### PR TITLE
Build for NodeJS now allows setting distribution and repo URLs

### DIFF
--- a/bindings/nodejs/include.mk
+++ b/bindings/nodejs/include.mk
@@ -25,6 +25,9 @@ CLEAN_TARGETS += fdb_node_clean fdb_node_npm_clean
 
 NODE_VERSIONS := 0.8.22 0.10.0
 
+NODE_DIST_URL ?= https://nodejs.org/dist
+NODE_REGISTRY_URL ?= https://registry.npmjs.org/
+
 ifeq ($(RELEASE),true)
   NPMVER = $(VERSION)
 else
@@ -46,7 +49,7 @@ bindings/nodejs/fdb_node.stamp: bindings/nodejs/src/FdbOptions.g.cpp bindings/no
 	for ver in $(NODE_VERSIONS); do \
 		MMVER=`echo $$ver | sed -e 's,\., ,g' | awk '{print $$1 "." $$2}'` && \
 		mkdir modules/$$MMVER && \
-		node-gyp configure --dist-url=https://nodejs.org/dist --target=$$ver && \
+		node-gyp configure --dist-url=$(NODE_DIST_URL) --target=$$ver && \
 		node-gyp -v build && \
 		cp build/Release/fdblib.node modules/$${MMVER} ; \
 	done
@@ -67,7 +70,7 @@ bindings/nodejs/package.json: bindings/nodejs/package.json.in $(ALL_MAKEFILES) v
 	@m4 -DVERSION=$(NPMVER) $< > $@
 	@echo "Updating       Node dependencies"
 	@cd bindings/nodejs && \
-	npm config set registry "https://registry.npmjs.org/" && \
+	npm config set registry "$(NODE_REGISTRY_URL)" && \
 	npm update
 
 fdb_node_npm: fdb_node versions.target bindings/nodejs/README.md bindings/nodejs/lib/*.js bindings/nodejs/src/* bindings/nodejs/binding.gyp LICENSE


### PR DESCRIPTION
In theory, these could be used by someone who wanted to pull the needed distributions for NodeJS from somewhere other than the public repo or if someone wanted to use something other than the default NPM registry, they could set the appropriate make variables and the build will use those instead. It still uses the public ones by default for those who don't so desire.

I am requesting that this get pulled to release-5.1 so that if someone wanted to start using these on builds off of that branch (which seems like a reasonable thing to me), they can do so. We should then merge it to master as well.