### PR TITLE
Set the address in consistency check processes…

### DIFF
--- a/fdbserver/fdbserver.actor.cpp
+++ b/fdbserver/fdbserver.actor.cpp
@@ -1314,6 +1314,16 @@ int main(int argc, char* argv[]) {
 			flushAndExit(FDB_EXIT_ERROR);
 		}
 
+		if(role == ConsistencyCheck) {
+			if(publicAddressStr != "") {
+				fprintf(stderr, "ERROR: Public address cannot be specified for consistency check processes\n");
+				printHelpTeaser(argv[0]);
+				flushAndExit(FDB_EXIT_ERROR);
+			}
+			auto publicIP = determinePublicIPAutomatically(connectionFile->getConnectionString());
+			publicAddress = NetworkAddress(publicIP, ::getpid());
+		}
+
 		if (listenAddressStr == "public")
 			listenAddress = publicAddress;
 		else {


### PR DESCRIPTION
...in the same way we set it for clients so that it shows up in trace logs. Disallow specifying a public address for consistency check processes.