### PR TITLE
Use JAVA_HOME to find location of JVM for headers for JNI build

### DIFF
--- a/bindings/java/local.mk
+++ b/bindings/java/local.mk
@@ -44,7 +44,7 @@ ifeq ($(PLATFORM),linux)
 
   java_ARCH := amd64
 else ifeq ($(PLATFORM),osx)
-  JAVA_HOME ?= $(shell /usr/libexec/java_home || /Library/Java/JavaVirtualMachines/jdk1.8.0_112.jdk/Contents/Home)
+  JAVA_HOME ?= $(shell /usr/libexec/java_home)
   fdb_java_CFLAGS += -I$(JAVA_HOME)/include -I$(JAVA_HOME)/include/darwin
 
   java_ARCH := x86_64


### PR DESCRIPTION
This uses JAVA_HOME within the build script to find the location of the JVM and, from there, the Java header files (on Linux and macOS). In Linux, I just used the same path, but I brought up the path to a variable that will be overridden with the JAVA_HOME location should it already be defined. This is a little tacky, but I don't know enough about the right way to do this. On macOS, this will again use the preset value if one is there, but it otherwise shells out to `/usr/libexec/java_home` to find the Java home, and if that fails, it defaults to a specific build, which is somewhat tacky, but strictly better than the previous setup, IMHO.