### PR TITLE
Fix Python3 directory layer bug where str() was used instead of bytes()…

### DIFF
--- a/bindings/bindingtester/tests/directory.py
+++ b/bindings/bindingtester/tests/directory.py
@@ -340,9 +340,9 @@ class DirectoryTest(Test):
         # errors += directory_util.check_for_duplicate_prefixes(db, self.prefix_log)
         return errors
 
-    def get_result_specfications(self):
+    def get_result_specifications(self):
         return [
-            ResultSpecification(self.stack, key_start_index=1, ordering_index=1),
+            ResultSpecification(self.stack_subspace, key_start_index=1, ordering_index=1),
             ResultSpecification(self.directory_log, ordering_index=0),
             ResultSpecification(self.subspace_log, ordering_index=0)
         ]

--- a/bindings/python/fdb/directory_impl.py
+++ b/bindings/python/fdb/directory_impl.py
@@ -75,7 +75,7 @@ class HighContentionAllocator (object):
                     count = tr.snapshot[self.counters[start]]
 
                 if count != None:
-                    count = struct.unpack("<q", str(count))[0]
+                    count = struct.unpack("<q", bytes(count))[0]
                 else:
                     count = 0
 


### PR DESCRIPTION
… Fix bug in binding tester that caused directory tests to not compare results, which resulted in the directory layer bug going undetected.