### PR TITLE
Removes the logo from our sphinx template.

### DIFF
--- a/documentation/sphinx/conf.py
+++ b/documentation/sphinx/conf.py
@@ -134,7 +134,6 @@ html_title = 'FoundationDB ' + version
 
 # The name of an image file (relative to this directory) to place at the top
 # of the sidebar.
-html_logo = sys.prefix + '/_static/logo.svg'
 
 # The name of an image file (within the static path) to use as favicon of the
 # docs.  This file should be a Windows icon file (.ico) being 16x16 or 32x32


### PR DESCRIPTION
This seems to be a dead link.