### PR TITLE
Add router to help text for storage class of fdbserver

### DIFF
--- a/fdbserver/fdbserver.actor.cpp
+++ b/fdbserver/fdbserver.actor.cpp
@@ -623,8 +623,9 @@ static void printUsage( const char *name, bool devhelp ) {
 	printf("  -a ID, --datacenter_id ID\n"
 		   "                 Data center identifier key (up to 16 hex characters).\n");
 	printf("  -c CLASS, --class CLASS\n"
-		   "                 Machine class (valid options are storage, transaction,\n");
-	printf("                 resolution, proxy, master, test, unset, stateless, log, cluster_controller).\n");
+		   "                 Machine class (valid options are storage, transaction,\n"
+		   "                 resolution, proxy, master, test, unset, stateless, log, router,\n"
+		   "                 and cluster_controller).\n");
 	printf(TLS_HELP);
 	printf("  -v, --version  Print version information and exit.\n");
 	printf("  -h, -?, --help Display this help and exit.\n");


### PR DESCRIPTION
The "router" class used for fearless was missing from the help text for `--class` on fdbserver. I have just added it to the list and switched the formatting to look more like the other ones.