### PR TITLE
Updates documentation config copyright attribution / footer

### DIFF
--- a/documentation/sphinx/conf.py
+++ b/documentation/sphinx/conf.py
@@ -48,8 +48,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'FoundationDB'
-copyright = u'2015 Apple, Inc.  All Rights Reserved.'
-author = u"Stephen Pimentel"
+copyright = u'2013-2018 Apple, Inc and the FoundationDB project authors'
 
 # Load the version information from 'versions.target'
 import xml.etree.ElementTree as ET


### PR DESCRIPTION
This minor change updates the documentation copyright attribution to be the same as the project source code, and removes individual author attribution. Copyright info from this config file is displayed in the footer of the Sphinx docs once they're built.