### PR TITLE
Make virtualenv download directories overridable

### DIFF
--- a/documentation/sphinx/Makefile
+++ b/documentation/sphinx/Makefile
@@ -19,8 +19,9 @@ SPHINXAUTOBUILD	= $(VENVDIR)/bin/sphinx-autobuild
 TEMPLATEDIR	= $(ROOTDIR)/_templates
 
 # virtualenv for sphinx-build
-VENV_VERSION	= virtualenv-13.0.1
-VENV_URL	= https://pypi.python.org/packages/source/v/virtualenv/$(VENV_VERSION).tar.gz
+VENV_VERSION	?= virtualenv-13.0.1
+VENV_URL_BASE	?= https://pypi.python.org
+VENV_URL	?= $(VENV_URL_BASE)/packages/source/v/virtualenv/$(VENV_VERSION).tar.gz
 
 # Internal variables.
 PAPEROPT_a4	= -D latex_paper_size=a4


### PR DESCRIPTION
This allows a user to set a different download URL for virtualenv within our docs build if they so choose. The user can set it through make or environment variables. If they don't do anything, it uses the old values (which are to pull them from pypi).