### PR TITLE
Make build instruction header levels for macOS and Linux aligned

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Developers on a OS for which there is no binary package, or who would like to st
 1. Navigate to the directory where you checked out the foundationdb repo.
 1. Run `make`.
 
-## Linux
+#### Linux
 
 1. Install [Docker] (https://www.docker.com/).
 1. Build Linux docker image using the file `Dockerfile` located in the `build` source directory.


### PR DESCRIPTION
We were writing the linux build instructions with &lt;h2&gt; header level and macOS with &lt;h4&gt; header level. This aligns them so that they both use &lt;h4&gt;.