### PR TITLE
Fixed broken links to documentation

### DIFF
--- a/bindings/go/README.md
+++ b/bindings/go/README.md
@@ -1,7 +1,7 @@
 fdb-go
 ======
 
-[Go language](http://golang.org) bindings for [FoundationDB](https://www.foundationdb.org/documentation/), a distributed key-value store with ACID transactions.
+[Go language](http://golang.org) bindings for [FoundationDB](https://apple.github.io/foundationdb/index.html#documentation), a distributed key-value store with ACID transactions.
 
 This package requires:
 
@@ -28,4 +28,4 @@ Documentation
 -------------
 
 * [API documentation](https://godoc.org/github.com/apple/foundationdb/bindings/go/src/fdb)
-* [Tutorial](https://www.foundationdb.org/documentation/class-scheduling-go.html)
+* [Tutorial](https://apple.github.io/foundationdb/class-scheduling.html)

--- a/bindings/go/src/fdb/directory/directory.go
+++ b/bindings/go/src/fdb/directory/directory.go
@@ -26,7 +26,7 @@
 //
 // For general guidance on directory usage, see the Directories section of the
 // Developer Guide
-// (https://www.foundationdb.org/documentation/developer-guide.html#developer-guide-directories).
+// (https://apple.github.io/foundationdb/developer-guide.html#directories).
 //
 // Directories are identified by hierarchical paths analogous to the paths in a
 // Unix-like file system. A path is represented as a slice of strings. Each

--- a/bindings/go/src/fdb/errors.go
+++ b/bindings/go/src/fdb/errors.go
@@ -37,7 +37,7 @@ import (
 // as a panic from any FoundationDB API function whose name ends with OrPanic.
 //
 // You may compare the Code field of an Error against the list of FoundationDB
-// error codes at https://www.foundationdb.org/documentation/api-error-codes.html,
+// error codes at https://apple.github.io/foundationdb/api-error-codes.html,
 // but generally an Error should be passed to (Transaction).OnError. When using
 // (Database).Transact, non-fatal errors will be retried automatically.
 type Error struct {

--- a/bindings/go/src/fdb/keyselector.go
+++ b/bindings/go/src/fdb/keyselector.go
@@ -34,7 +34,7 @@ type Selectable interface {
 //
 // The most common key selectors are constructed with the functions documented
 // below. For details of how KeySelectors are specified and resolved, see
-// https://www.foundationdb.org/documentation/developer-guide.html#key-selectors.
+// https://apple.github.io/foundationdb/developer-guide.html#key-selectors.
 type KeySelector struct {
 	Key     KeyConvertible
 	OrEqual bool

--- a/bindings/go/src/fdb/subspace/subspace.go
+++ b/bindings/go/src/fdb/subspace/subspace.go
@@ -29,7 +29,7 @@
 // As a best practice, API clients should use at least one subspace for
 // application data. For general guidance on subspace usage, see the Subspaces
 // section of the Developer Guide
-// (https://www.foundationdb.org/documentation/developer-guide.html#developer-guide-sub-keyspaces).
+// (https://apple.github.io/foundationdb/developer-guide.html#subspaces).
 package subspace
 
 import (

--- a/bindings/go/src/fdb/transaction.go
+++ b/bindings/go/src/fdb/transaction.go
@@ -171,7 +171,7 @@ func (t Transaction) SetReadVersion(version int64) {
 // but making it harder to reason about concurrency.
 //
 // For more information on snapshot reads, see
-// https://www.foundationdb.org/documentation/developer-guide.html#using-snapshot-reads.
+// https://apple.github.io/foundationdb/developer-guide.html#snapshot-reads.
 func (t Transaction) Snapshot() Snapshot {
 	return Snapshot{t.transaction}
 }
@@ -196,7 +196,7 @@ func (t Transaction) OnError(e Error) FutureNil {
 // As with other client/server databases, in some failure scenarios a client may
 // be unable to determine whether a transaction succeeded. For more information,
 // see
-// https://www.foundationdb.org/documentation/developer-guide.html#developer-guide-unknown-results.
+// https://apple.github.io/foundationdb/developer-guide.html#transactions-with-unknown-results.
 func (t Transaction) Commit() FutureNil {
 	return &futureNil{newFuture(C.fdb_transaction_commit(t.ptr))}
 }
@@ -396,7 +396,7 @@ func addConflictRange(t *transaction, er ExactRange, crtype conflictRangeType) e
 // conflict.
 //
 // For more information on conflict ranges, see
-// https://www.foundationdb.org/documentation/developer-guide.html#conflict-ranges.
+// https://apple.github.io/foundationdb/developer-guide.html#conflict-ranges.
 func (t Transaction) AddReadConflictRange(er ExactRange) error {
 	return addConflictRange(t.transaction, er, conflictRangeTypeRead)
 }
@@ -413,7 +413,7 @@ func copyAndAppend(orig []byte, b byte) []byte {
 // this key could cause the transaction to fail with a conflict.
 //
 // For more information on conflict ranges, see
-// https://www.foundationdb.org/documentation/developer-guide.html#conflict-ranges.
+// https://apple.github.io/foundationdb/developer-guide.html#conflict-ranges.
 func (t Transaction) AddReadConflictKey(key KeyConvertible) error {
 	return addConflictRange(t.transaction, KeyRange{key, Key(copyAndAppend(key.FDBKey(), 0x00))}, conflictRangeTypeRead)
 }
@@ -424,7 +424,7 @@ func (t Transaction) AddReadConflictKey(key KeyConvertible) error {
 // conflict.
 //
 // For more information on conflict ranges, see
-// https://www.foundationdb.org/documentation/developer-guide.html#conflict-ranges.
+// https://apple.github.io/foundationdb/developer-guide.html#conflict-ranges.
 func (t Transaction) AddWriteConflictRange(er ExactRange) error {
 	return addConflictRange(t.transaction, er, conflictRangeTypeWrite)
 }
@@ -434,7 +434,7 @@ func (t Transaction) AddWriteConflictRange(er ExactRange) error {
 // read this key could fail with a conflict.
 //
 // For more information on conflict ranges, see
-// https://www.foundationdb.org/documentation/developer-guide.html#conflict-ranges.
+// https://apple.github.io/foundationdb/developer-guide.html#conflict-ranges.
 func (t Transaction) AddWriteConflictKey(key KeyConvertible) error {
 	return addConflictRange(t.transaction, KeyRange{key, Key(copyAndAppend(key.FDBKey(), 0x00))}, conflictRangeTypeWrite)
 }

--- a/bindings/go/src/fdb/tuple/tuple.go
+++ b/bindings/go/src/fdb/tuple/tuple.go
@@ -27,7 +27,7 @@
 // of higher-level data models.
 //
 // For general guidance on tuple usage, see the Tuple section of Data Modeling
-// (https://www.foundationdb.org/documentation/data-modeling.html#data-modeling-tuples).
+// (https://apple.github.io/foundationdb/data-modeling.html#tuples).
 //
 // FoundationDB tuples can currently encode byte and unicode strings, integers
 // and NULL values. In Go these are represented as []byte, string, int64 and

--- a/bindings/python/README.rst
+++ b/bindings/python/README.rst
@@ -1,3 +1,3 @@
-Complete documentation of the FoundationDB Python API can be found at https://www.foundationdb.org/documentation/api-python.html.
+Complete documentation of the FoundationDB Python API can be found at https://apple.github.io/foundationdb/api-python.html.
 
 These bindings require the FoundationDB client. The client can be obtained from https://www.foundationdb.org/downloads/fdb-c/.

--- a/bindings/python/fdb/__init__.py
+++ b/bindings/python/fdb/__init__.py
@@ -21,7 +21,7 @@
 # FoundationDB Python API
 
 """Documentation for this API can be found at
-https://www.foundationdb.org/documentation/api-python.html"""
+https://apple.github.io/foundationdb/api-python.html"""
 
 
 def open(*args, **kwargs):

--- a/bindings/python/fdb/locality.py
+++ b/bindings/python/fdb/locality.py
@@ -21,7 +21,7 @@
 # FoundationDB Python API
 
 """Documentation for this API can be found at
-https://www.foundationdb.org/documentation/api-python.html"""
+https://apple.github.io/foundationdb/api-python.html"""
 
 from fdb import impl as _impl
 

--- a/bindings/ruby/fdb.gemspec.in
+++ b/bindings/ruby/fdb.gemspec.in
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
 Ruby bindings for the FoundationDB database.
 
 Complete documentation of the FoundationDB Ruby API can be found at:
-https://www.foundationdb.org/documentation/api-ruby.html.
+https://apple.github.io/foundationdb/api-ruby.html.
 EOF
   s.authors = ["FoundationDB"]
   s.email = 'fdb-dist@apple.com'

--- a/bindings/ruby/lib/fdb.rb
+++ b/bindings/ruby/lib/fdb.rb
@@ -21,7 +21,7 @@
 # FoundationDB Ruby API
 
 # Documentation for this API can be found at
-# https://www.foundationdb.org/documentation/api-ruby.html
+# https://apple.github.io/foundationdb/api-ruby.html
 
 module FDB
   @@chosen_version = -1

--- a/bindings/ruby/lib/fdbdirectory.rb
+++ b/bindings/ruby/lib/fdbdirectory.rb
@@ -23,7 +23,7 @@
 # FoundationDB Ruby API
 
 # Documentation for this API can be found at
-# https://www.foundationdb.org/documentation/api-ruby.html
+# https://apple.github.io/foundationdb/api-ruby.html
 
 require 'thread'
 

--- a/bindings/ruby/lib/fdbimpl.rb
+++ b/bindings/ruby/lib/fdbimpl.rb
@@ -23,7 +23,7 @@
 # FoundationDB Ruby API
 
 # Documentation for this API can be found at
-# https://www.foundationdb.org/documentation/api-ruby.html
+# https://apple.github.io/foundationdb/api-ruby.html
 
 require 'ffi'
 

--- a/bindings/ruby/lib/fdblocality.rb
+++ b/bindings/ruby/lib/fdblocality.rb
@@ -23,7 +23,7 @@
 # FoundationDB Ruby API
 
 # Documentation for this API can be found at
-# https://www.foundationdb.org/documentation/api-ruby.html
+# https://apple.github.io/foundationdb/api-ruby.html
 
 module FDB
   module Locality

--- a/bindings/ruby/lib/fdbsubspace.rb
+++ b/bindings/ruby/lib/fdbsubspace.rb
@@ -23,7 +23,7 @@
 # FoundationDB Ruby API
 
 # Documentation for this API can be found at
-# https://www.foundationdb.org/documentation/api-ruby.html
+# https://apple.github.io/foundationdb/api-ruby.html
 
 require_relative 'fdbtuple'
 

--- a/bindings/ruby/lib/fdbtuple.rb
+++ b/bindings/ruby/lib/fdbtuple.rb
@@ -23,7 +23,7 @@
 # FoundationDB Ruby API
 
 # Documentation for this API can be found at
-# https://www.foundationdb.org/documentation/api-ruby.html
+# https://apple.github.io/foundationdb/api-ruby.html
 
 module FDB
   module Tuple

--- a/fdbclient/vexillographer/ruby.cs
+++ b/fdbclient/vexillographer/ruby.cs
@@ -79,7 +79,7 @@ namespace vexillographer
 # THE SOFTWARE.
 
 # Documentation for this API can be found at
-# https://www.foundationdb.org/documentation/api-ruby.html
+# https://apple.github.io/foundationdb/api-ruby.html
 
 module FDB");
                 foreach (Scope s in Enum.GetValues(typeof(Scope)))

--- a/packaging/foundationdb.conf
+++ b/packaging/foundationdb.conf
@@ -2,7 +2,7 @@
 ##
 ## Configuration file for FoundationDB server processes
 ## Full documentation is available at
-## https://www.foundationdb.org/documentation/configuration.html#foundationdb-conf
+## https://apple.github.io/foundationdb/configuration.html#the-configuration-file
 
 [fdbmonitor]
 user = foundationdb

--- a/packaging/msi/FDBInstaller.wxs
+++ b/packaging/msi/FDBInstaller.wxs
@@ -390,7 +390,7 @@
     </InstallExecuteSequence>
 
     <Property Id="WIXUI_EXITDIALOGOPTIONALTEXT"
-              Value="Thank you for installing FoundationDB. For documentation, please visit https://www.foundationdb.org/documentation.
+              Value="Thank you for installing FoundationDB. For documentation, please visit https://apple.github.io/foundationdb/index.html#documentation.
 
 To allow path variables to update, please restart your IDE and any open terminal sessions." />
     <UIRef Id='WixUI_FeatureTree' />

--- a/packaging/msi/skeleton.conf
+++ b/packaging/msi/skeleton.conf
@@ -2,7 +2,7 @@
 ##
 ## Configuration file for FoundationDB server processes
 ## Full documentation is available at
-## https://www.foundationdb.org/documentation/configuration.html#foundationdb-conf
+## https://apple.github.io/foundationdb/configuration.html#the-configuration-file
 
 [fdbmonitor]
 restart_delay = 20

--- a/packaging/osx/foundationdb.conf.new
+++ b/packaging/osx/foundationdb.conf.new
@@ -2,7 +2,7 @@
 ##
 ## Configuration file for FoundationDB server processes
 ## Full documentation is available at
-## https://www.foundationdb.org/documentation/configuration.html#foundationdb-conf
+## https://apple.github.io/foundationdb/configuration.html#the-configuration-file
 
 [general]
 restart_delay = 60


### PR DESCRIPTION
Fixes issue #178 and beyond

Changed references to `https://www.foundationdb.org/documentation` to the correct `https://apple.github.io/foundationdb` link.