### PR TITLE
Configure Cirrus CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,6 @@
+build_task:
+  container:
+    dockerfile: build/Dockerfile
+    cpu: 8
+    memory: 20G
+  make_script: make


### PR DESCRIPTION
I saw that there is no CI configured and decided to fix it. 

Cirrus CI seems to be a perfect fit since it can take a Dockerfile as an environment for CI builds. And there is already `build/Dockerfile` for that purpose. Cirrus CI will build and **cache** a container based on contents of `build/Dockerfile`.

Here is a link to corresponding Cirrus CI build: https://cirrus-ci.com/build/5633821126950912

![image](https://user-images.githubusercontent.com/989066/39020913-97229d88-43fc-11e8-920e-5301a8bf2b94.png)

I've tried to use 4 and 8 CPUs and saw 52-55 minutes vs 43-45 minutes respectively. Seems FoundationDB's build is not parallelized well enough but I still kept 8 cores configuration. Hopefully someone will work on making builds more efficient on setups with many cores.

Cirrus CI can be [installed from GitHub's Marketplace](https://github.com/apps/cirrus-ci) by organization admins. Installation is pretty straight forward, but in case of any issues please ping me or check documentation: https://cirrus-ci.org/guide/quick-start/