### PR TITLE
Broken link (C API documentation page) fixed

### DIFF
--- a/bindings/go/README.md
+++ b/bindings/go/README.md
@@ -6,7 +6,7 @@ fdb-go
 This package requires:
 
 - Go 1.1+ with CGO enabled
-- FoundationDB C API 2.0.x, 3.0.x, or 4.x.y (part of the [FoundationDB clients package](https://apple.github.io/foundationdb/api-c.html))
+- FoundationDB C API 2.0.x, 3.0.x, or 4.x.y (part of the [FoundationDB clients package](https://apple.github.io/foundationdb/downloads.html#c))
 
 Use of this package requires the selection of a FoundationDB API version at runtime. This package currently supports FoundationDB API versions 200-520.
 


### PR DESCRIPTION
C API link doesn't work. Probably needs to redirect -> https://apple.github.io/foundationdb/downloads.html#c. Thanks.