### PR TITLE
fix the bug 'fdbserver/fdbserver.actor.cpp:761:16: error: aggregate ‘std::ifstream ifs’ has incomplete type and cannot be defined'

### DIFF
--- a/fdbserver/fdbserver.actor.cpp
+++ b/fdbserver/fdbserver.actor.cpp
@@ -38,6 +38,7 @@
 #include "IKeyValueStore.h"
 #include <stdarg.h>
 #include <stdio.h>
+#include <fstream>
 #include "pubsub.h"
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN


### PR DESCRIPTION
fix the bug 'fdbserver/fdbserver.actor.cpp:761:16: error: aggregate ‘std::ifstream ifs’ has incomplete type and cannot be defined'
