### PR TITLE
Cherrypick more typos and link fixes from master to release-5.1

### DIFF
--- a/bindings/go/README.md
+++ b/bindings/go/README.md
@@ -6,7 +6,7 @@ fdb-go
 This package requires:
 
 - Go 1.1+ with CGO enabled
-- FoundationDB C API 2.0.x, 3.0.x, or 4.x.y (part of the [FoundationDB clients package](https://www.foundationdb.org/downloads/fdb-c/))
+- FoundationDB C API 2.0.x, 3.0.x, or 4.x.y (part of the [FoundationDB clients package](https://apple.github.io/foundationdb/api-c.html))
 
 Use of this package requires the selection of a FoundationDB API version at runtime. This package currently supports FoundationDB API versions 200-510.
 

--- a/bindings/go/README.md
+++ b/bindings/go/README.md
@@ -6,7 +6,7 @@ fdb-go
 This package requires:
 
 - Go 1.1+ with CGO enabled
-- FoundationDB C API 2.0.x, 3.0.x, or 4.x.y (part of the [FoundationDB clients package](https://apple.github.io/foundationdb/api-c.html))
+- FoundationDB C API 2.0.x, 3.0.x, or 4.x.y (part of the [FoundationDB clients package](https://apple.github.io/foundationdb/downloads.html#c))
 
 Use of this package requires the selection of a FoundationDB API version at runtime. This package currently supports FoundationDB API versions 200-510.
 

--- a/bindings/go/src/fdb/doc.go
+++ b/bindings/go/src/fdb/doc.go
@@ -30,7 +30,7 @@ Windows and OS X at https://www.foundationdb.org/downloads/fdb-c/.
 This documentation specifically applies to the FoundationDB Go binding. For more
 extensive guidance to programming with FoundationDB, as well as API
 documentation for the other FoundationDB interfaces, please see
-https://www.foundationdb.org/documentation/index.html.
+https://apple.github.io/foundationdb/index.html.
 
 Basic Usage
 
@@ -198,7 +198,7 @@ operations perform different transformations. Like other database operations, an
 atomic operation is used within a transaction.
 
 For more information on atomic operations in FoundationDB, please see
-https://www.foundationdb.org/documentation/developer-guide.html#atomic-operations. The
+https://apple.github.io/foundationdb/developer-guide.html#atomic-operations. The
 operands to atomic operations in this API must be provided as appropriately
 encoded byte slices. To convert a Go type to a byte slice, see the binary
 package.

--- a/bindings/go/src/fdb/snapshot.go
+++ b/bindings/go/src/fdb/snapshot.go
@@ -28,7 +28,7 @@ package fdb
 // transaction conflicts but making it harder to reason about concurrency.
 //
 // For more information on snapshot reads, see
-// https://www.foundationdb.org/documentation/developer-guide.html#snapshot-reads.
+// https://apple.github.io/foundationdb/developer-guide.html#snapshot-reads.
 type Snapshot struct {
 	*transaction
 }

--- a/fdbservice/ServiceBase.cpp
+++ b/fdbservice/ServiceBase.cpp
@@ -218,7 +218,7 @@ void CServiceBase::Stop()
         // Log the error.
         WriteErrorLogEntry("Service Stop", dwError);
 
-        // Set the orginal service status.
+        // Set the original service status.
         SetServiceStatus(dwOriginalState);
     }
     catch (...)
@@ -226,7 +226,7 @@ void CServiceBase::Stop()
         // Log the error.
         WriteEventLogEntry("Service failed to stop.", EVENTLOG_ERROR_TYPE);
 
-        // Set the orginal service status.
+        // Set the original service status.
         SetServiceStatus(dwOriginalState);
     }
 }


### PR DESCRIPTION
These are some more community-submitted typos and fixes for links that were committed to master that should probably be cherry-picked back to release-5.1.