### PR TITLE
Convert bindings spec files to markdown

### DIFF
--- a/bindings/bindingtester/spec/bindingApiTester.md
+++ b/bindings/bindingtester/spec/bindingApiTester.md
@@ -5,9 +5,9 @@ Your API test program must implement a simple stack machine that exercises the
 FoundationDB API. The program is invoked with two or three arguments. The first
 argument is a prefix that is the first element of a tuple, the second is the
 API version, and the third argument is the path to a cluster file. If the
-third argument is not specified, your program may assume that fdb.open() will 
-succeed with no arguments (an fdb.cluster file will exist in the current 
-directory). Otherwise, your program should connect to the cluster specified 
+third argument is not specified, your program may assume that `fdb.open()` will
+succeed with no arguments (an fdb.cluster file will exist in the current
+directory). Otherwise, your program should connect to the cluster specified
 by the given cluster file.
 
 Your stack machine should begin reading the range returned by the tuple range
@@ -38,7 +38,7 @@ instructions:
     and a peek operation. The stack is initialized to be empty.
 
   - A current FDB transaction name (stored as a byte string). The transaction
-    name should be initialized to the prefix that instructions are being read 
+    name should be initialized to the prefix that instructions are being read
     from.
 
   - A last seen FDB version, which is a 64-bit integer.
@@ -47,44 +47,44 @@ instructions:
 Data Operations
 ---------------
 
-PUSH <item>
+#### PUSH &lt;item&gt;
 
     Pushes the provided item onto the stack.
 
-DUP
+#### DUP
 
     Duplicates the top item on the stack. The instruction number for the
     duplicate item should be the same as the original.
 
-EMPTY_STACK
+#### EMPTY_STACK
 
     Discards all items in the stack.
 
-SWAP
+#### SWAP
 
     Pops the top item off of the stack as INDEX. Swaps the items in the stack at
     depth 0 and depth INDEX. Does not modify the instruction numbers of the
     swapped items.
 
-POP
+#### POP
 
     Pops and discards the top item on the stack.
 
-SUB
+#### SUB
 
     Pops the top two items off of the stack as A and B and then pushes the
     difference (A-B) onto the stack. A and B may be assumed to be integers.
 
-CONCAT
+#### CONCAT
 
-    Pops the top two items off the stack as A and B and then pushes the 
+    Pops the top two items off the stack as A and B and then pushes the
     concatenation of A and B onto the stack. A and B can be assumed to
     be of the same type and will be either byte strings or unicode strings.
 
-LOG_STACK
+#### LOG_STACK
 
     Pops the top item off the stack as PREFIX. Using a new transaction with normal
-    retry logic, inserts a key-value pair into the database for each item in the 
+    retry logic, inserts a key-value pair into the database for each item in the
     stack of the form:
 
         PREFIX + tuple.pack((stackIndex, instructionNumber)) = tuple.pack((item,))
@@ -96,8 +96,8 @@ LOG_STACK
     then the value should be truncated to the first 40000 bytes of the packed
     tuple.
 
-    When finished, the stack should be empty. Note that because the stack may be 
-    large, it may be necessary to commit the transaction every so often (e.g. 
+    When finished, the stack should be empty. Note that because the stack may be
+    large, it may be necessary to commit the transaction every so often (e.g.
     after every 100 sets) to avoid past_version errors.
 
 FoundationDB Operations
@@ -117,7 +117,7 @@ should simulate it using an anonymous transaction. Remember that set and clear
 operations must immediately commit (with appropriate retry behavior!).
 
 Any error that bubbles out of these operations must be caught. In the event of
-an error, you must push the packed tuple of the string "ERROR" and the error
+an error, you must push the packed tuple of the string `"ERROR"` and the error
 code (as a string, not an integer).
 
 Some operations may allow you to push future values onto the stack. When popping
@@ -132,25 +132,25 @@ futures must apply the following rules to the result:
 
   - If the result is void (i.e. the future was just a signal of
     completion), then its value should be the byte string
-    "RESULT_NOT_PRESENT"
+    `"RESULT_NOT_PRESENT"`
 
   - If the result is from a GET operation in which no result was
     returned, then its value is to be converted to the byte string
-    "RESULT_NOT_PRESENT"
+    `"RESULT_NOT_PRESENT"`
 
-NEW_TRANSACTION
+#### NEW_TRANSACTION
 
     Creates a new transaction and stores it in the global transaction map
     under the currently used transaction name.
 
-USE_TRANSACTION
+#### USE_TRANSACTION
 
     Pop the top item off of the stack as TRANSACTION_NAME. Begin using the
     transaction stored at TRANSACTION_NAME in the transaction map for future
     operations. If no entry exists in the map for the given name, a new
     transaction should be inserted.
 
-ON_ERROR
+#### ON_ERROR
 
     Pops the top item off of the stack as ERROR_CODE. Passes ERROR_CODE in a
     language-appropriate way to the on_error method of current transaction
@@ -158,22 +158,22 @@ ON_ERROR
     the error out as indicated above. May optionally push a future onto the
     stack.
 
-GET (_SNAPSHOT, _DATABASE)
+#### GET (_SNAPSHOT, _DATABASE)
 
     Pops the top item off of the stack as KEY and then looks up KEY in the
     database using the get() method. May optionally push a future onto the
     stack.
 
-GET_KEY (_SNAPSHOT, _DATABASE)
+#### GET_KEY (_SNAPSHOT, _DATABASE)
 
     Pops the top four items off of the stack as KEY, OR_EQUAL, OFFSET, PREFIX
-    and then constructs a key selector. This key selector is then resolved 
-    using the get_key() method to yield RESULT. If RESULT starts with PREFIX, 
-    then RESULT is pushed onto the stack. Otherwise, if RESULT < PREFIX, PREFIX 
+    and then constructs a key selector. This key selector is then resolved
+    using the get_key() method to yield RESULT. If RESULT starts with PREFIX,
+    then RESULT is pushed onto the stack. Otherwise, if RESULT < PREFIX, PREFIX
     is pushed onto the stack. If RESULT > PREFIX, then strinc(PREFIX) is pushed
     onto the stack. May optionally push a future onto the stack.
 
-GET_RANGE (_SNAPSHOT, _DATABASE)
+#### GET_RANGE (_SNAPSHOT, _DATABASE)
 
     Pops the top five items off of the stack as BEGIN_KEY, END_KEY, LIMIT,
     REVERSE and STREAMING_MODE. Performs a range read in a language-appropriate
@@ -181,103 +181,103 @@ GET_RANGE (_SNAPSHOT, _DATABASE)
     packed into a tuple as [k1,v1,k2,v2,...,kn,vn], and this single packed value
     is pushed onto the stack.
 
-GET_RANGE_STARTS_WITH (_SNAPSHOT, _DATABASE)
+#### GET_RANGE_STARTS_WITH (_SNAPSHOT, _DATABASE)
 
     Pops the top four items off of the stack as PREFIX, LIMIT, REVERSE and
     STREAMING_MODE. Performs a prefix range read in a language-appropriate way
     using these parameters. Output is pushed onto the stack as with GET_RANGE.
 
-GET_RANGE_SELECTOR (_SNAPSHOT, _DATABASE)
+#### GET_RANGE_SELECTOR (_SNAPSHOT, _DATABASE)
 
     Pops the top ten items off of the stack as BEGIN_KEY, BEGIN_OR_EQUAL,
     BEGIN_OFFSET, END_KEY, END_OR_EQUAL, END_OFFSET, LIMIT, REVERSE,
-    STREAMING_MODE, and PREFIX. Constructs key selectors BEGIN and END from 
+    STREAMING_MODE, and PREFIX. Constructs key selectors BEGIN and END from
     the first six parameters, and then performs a range read in a language-
-    appropriate way using BEGIN, END, LIMIT, REVERSE and STREAMING_MODE. Output 
-    is pushed onto the stack as with GET_RANGE, excluding any keys that do not 
+    appropriate way using BEGIN, END, LIMIT, REVERSE and STREAMING_MODE. Output
+    is pushed onto the stack as with GET_RANGE, excluding any keys that do not
     begin with PREFIX.
 
-GET_READ_VERSION (_SNAPSHOT)
+#### GET_READ_VERSION (_SNAPSHOT)
 
     Gets the current read version and stores it in the internal stack machine
     state as the last seen version. Pushed the string "GOT_READ_VERSION" onto
     the stack.
 
-GET_VERSIONSTAMP
+#### GET_VERSIONSTAMP
 
     Calls get_versionstamp and pushes the resulting future onto the stack.
 
-SET (_DATABASE)
+#### SET (_DATABASE)
 
     Pops the top two items off of the stack as KEY and VALUE. Sets KEY to have
     the value VALUE. A SET_DATABASE call may optionally push a future onto the
     stack.
 
-SET_READ_VERSION
+#### SET_READ_VERSION
 
     Sets the current transaction read version to the internal state machine last
     seen version.
 
-CLEAR (_DATABASE)
+#### CLEAR (_DATABASE)
 
     Pops the top item off of the stack as KEY and then clears KEY from the
     database. A CLEAR_DATABASE call may optionally push a future onto the stack.
 
-CLEAR_RANGE (_DATABASE)
+#### CLEAR_RANGE (_DATABASE)
 
     Pops the top two items off of the stack as BEGIN_KEY and END_KEY. Clears the
     range of keys from BEGIN_KEY to END_KEY in the database. A
     CLEAR_RANGE_DATABASE call may optionally push a future onto the stack.
 
-CLEAR_RANGE_STARTS_WITH (_DATABASE)
+#### CLEAR_RANGE_STARTS_WITH (_DATABASE)
 
     Pops the top item off of the stack as PREFIX and then clears all keys from
     the database that begin with PREFIX. A CLEAR_RANGE_STARTS_WITH_DATABASE call
     may optionally push a future onto the stack.
 
-ATOMIC_OP (_DATABASE)
+#### ATOMIC_OP (_DATABASE)
 
     Pops the top three items off of the stack as OPTYPE, KEY, and VALUE.
     Performs the atomic operation described by OPTYPE upon KEY with VALUE. An
     ATOMIC_OP_DATABASE call may optionally push a future onto the stack.
 
-READ_CONFLICT_RANGE and WRITE_CONFLICT_RANGE
+#### READ_CONFLICT_RANGE and WRITE_CONFLICT_RANGE
 
     Pops the top two items off of the stack as BEGIN_KEY and END_KEY. Adds a
     read conflict range or write conflict range from BEGIN_KEY to END_KEY.
     Pushes the byte string "SET_CONFLICT_RANGE" onto the stack.
 
-READ_CONFLICT_KEY and WRITE_CONFLICT_KEY
+#### READ_CONFLICT_KEY and WRITE_CONFLICT_KEY
 
     Pops the top item off of the stack as KEY. Adds KEY as a read conflict key
     or write conflict key. Pushes the byte string "SET_CONFLICT_KEY" onto the
     stack.
 
-DISABLE_WRITE_CONFLICT
+#### DISABLE_WRITE_CONFLICT
 
     Sets the NEXT_WRITE_NO_WRITE_CONFLICT_RANGE transaction option on the
     current transaction. Does not modify the stack.
 
-COMMIT
+#### COMMIT
 
     Commits the current transaction (with no retry behavior). May optionally
     push a future onto the stack.
 
-RESET
+#### RESET
 
     Resets the current transaction.
 
-CANCEL
+#### CANCEL
 
     Cancels the current transaction.
 
-GET_COMMITTED_VERSION
+#### GET_COMMITTED_VERSION
 
     Gets the committed version from the current transaction and stores it in the
     internal stack machine state as the last seen version. Pushes the byte
     string "GOT_COMMITTED_VERSION" onto the stack.
 
-WAIT_FUTURE
+#### WAIT_FUTURE
 
     Pops the top item off the stack and pushes it back on. If the top item on
     the stack is a future, this will have the side effect of waiting on the
@@ -287,13 +287,13 @@ WAIT_FUTURE
 Tuple Operations
 ----------------
 
-TUPLE_PACK
+#### TUPLE_PACK
 
     Pops the top item off of the stack as N. Pops the next N items off of the
     stack and packs them as the tuple [item0,item1,...,itemN], and then pushes
     this single packed value onto the stack.
 
-TUPLE_PACK_WITH_VERSIONSTAMP
+#### TUPLE_PACK_WITH_VERSIONSTAMP
 
     Pops the top item off of the stack as a byte string prefix. Pops the next item
     off of the stack as N. Pops the next N items off of the stack and packs them
@@ -307,20 +307,20 @@ TUPLE_PACK_WITH_VERSIONSTAMP
     do not contain a 'Versionstamp' tuple-type do not have to implement this
     operation.)
 
-TUPLE_UNPACK
+#### TUPLE_UNPACK
 
     Pops the top item off of the stack as PACKED, and then unpacks PACKED into a
     tuple. For each element of the tuple, packs it as a new tuple and pushes it
     onto the stack.
 
-TUPLE_RANGE
+#### TUPLE_RANGE
 
     Pops the top item off of the stack as N. Pops the next N items off of the
     stack, and passes these items as a tuple (or array, or language-appropriate
     structure) to the tuple range method. Pushes the begin and end elements of
     the returned range onto the stack.
 
-TUPLE_SORT
+#### TUPLE_SORT
 
     Pops the top item off of the stack as N. Pops the next N items off of the
     stack as packed tuples (i.e., byte strings), unpacks them, sorts the tuples,
@@ -330,25 +330,25 @@ TUPLE_SORT
     use that to sort. Otherwise, it should sort them lexicographically by
     their byte representation. The choice of function should not affect final sort order.
 
-ENCODE_FLOAT
+#### ENCODE_FLOAT
 
     Pops the top item off of the stack. This will be a byte-string of length 4
     containing the IEEE 754 encoding of a float in big-endian order.
     This is then converted into a float and pushed onto the stack.
 
-ENCODE_DOUBLE
+#### ENCODE_DOUBLE
 
     Pops the top item off of the stack. This will be a byte-string of length 8
     containing the IEEE 754 encoding of a double in big-endian order.
     This is then converted into a double and pushed onto the stack.
 
-DECODE_FLOAT
+#### DECODE_FLOAT
 
     Pops the top item off of the stack. This will be a single-precision float.
     This is converted into a (4 byte) byte-string of its IEEE 754 representation
     in big-endian order, and pushed onto the stack.
 
-DECODE_DOUBLE
+#### DECODE_DOUBLE
 
     Pops the top item off of the stack. This will be a double-precision float.
     This is converted into a (8 byte) byte-string its IEEE 754 representation
@@ -358,7 +358,7 @@ DECODE_DOUBLE
 Thread Operations
 -----------------
 
-START_THREAD
+#### START_THREAD
 
     Pops the top item off of the stack as PREFIX. Creates a new stack machine
     instance operating on the same database as the current stack machine, but
@@ -366,7 +366,7 @@ START_THREAD
     state. The new stack machine should begin executing instructions concurrent
     with the current stack machine through a language-appropriate mechanism.
 
-WAIT_EMPTY
+#### WAIT_EMPTY
 
     Pops the top item off of the stack as PREFIX. Blocks execution until the
     range with prefix PREFIX is not present in the database. This should be
@@ -378,7 +378,7 @@ WAIT_EMPTY
 Miscellaneous
 -------------
 
-UNIT_TESTS
+#### UNIT_TESTS
 
     This is called during the scripted test to allow bindings to test features
     which aren't supported by the stack tester. Things currently tested in the

--- a/bindings/bindingtester/spec/directoryLayerTester.md
+++ b/bindings/bindingtester/spec/directoryLayerTester.md
@@ -8,19 +8,19 @@ directory testing state.
 Additional State and Initialization
 -----------------------------------
 
-Your tester should store three additional pieces of state. 
+Your tester should store three additional pieces of state.
 
-directory list - The items in this list should be accessible by index. The list
-should support an append operation.  It will be required to store Subspaces, 
+* directory list - The items in this list should be accessible by index. The list
+should support an append operation.  It will be required to store Subspaces,
 DirectorySubspaces, and DirectoryLayers.
 
-directory list index - an index into the directory list of the currently active 
+* directory list index - an index into the directory list of the currently active
 directory.
 
-error index - the index to use when the directory at directory list index is not
+* error index - the index to use when the directory at directory list index is not
 present
 
-At the beginning of the test, the list should contain just the default directory 
+At the beginning of the test, the list should contain just the default directory
 layer. The directory index and error index should both be set to 0.
 
 Popping Tuples
@@ -29,14 +29,14 @@ Popping Tuples
 Some instructions will require you to pop N tuples. To do this, repeat the
 following procedure N times:
 
-Pop 1 item off the stack as M. Pop M items off the stack as 
+Pop 1 item off the stack as M. Pop M items off the stack as
 tuple = [item1, ..., itemM].
 
 Errors
 ------
 
 In the even that you encounter an error when performing a directory layer
-operation, you should push the byte string: "DIRECTORY_ERROR" onto the stack. If
+operation, you should push the byte string: `"DIRECTORY_ERROR"` onto the stack. If
 the operation being performed was supposed to append an item to the directory
 list, then a null entry should be appended instead.
 
@@ -46,65 +46,65 @@ New Instructions
 Below are the new instructions that must be implemented to test the directory
 layer. Some instructions specify that the current directory should be used
 for the operation. In that case, use the object in the directory list specified
-by the current directory list index. Operations that are not defined for a 
+by the current directory list index. Operations that are not defined for a
 particular object will not be called (e.g. a DirectoryLayer will never be asked
 to pack a key).
 
 Directory/Subspace/Layer Creation
 ---------------------------------
 
-DIRECTORY_CREATE_SUBSPACE
+#### DIRECTORY_CREATE_SUBSPACE
 
 	Pop 1 tuple off the stack as [path]. Pop 1 additional item as [raw_prefix].  
-	Create a subspace with path as the prefix tuple and the specified 
+	Create a subspace with path as the prefix tuple and the specified
 	raw_prefix. Append it to the directory list.
 
-DIRECTORY_CREATE_LAYER
+#### DIRECTORY_CREATE_LAYER
 
-	Pop 3 items off the stack as [index1, index2, allow_manual_prefixes]. Let 
-	node_subspace be the object in the directory list at index1 and 
-	content_subspace be the object in the directory list at index2. Create a new 
-	directory layer with the specified node_subspace and content_subspace. If 
+	Pop 3 items off the stack as [index1, index2, allow_manual_prefixes]. Let
+	node_subspace be the object in the directory list at index1 and
+	content_subspace be the object in the directory list at index2. Create a new
+	directory layer with the specified node_subspace and content_subspace. If
 	allow_manual_prefixes is 1, then enable manual prefixes on the directory
 	layer. Append the resulting directory layer to the directory list.
 
-	If either of the two specified subspaces are null, then do not create a 
+	If either of the two specified subspaces are null, then do not create a
 	directory layer and instead push null onto the directory list.
 
-DIRECTORY_CREATE_OR_OPEN[_DATABASE]
+#### DIRECTORY_CREATE_OR_OPEN[_DATABASE]
 
 	Use the current directory for this operation.
 
-	Pop 1 tuple off the stack as [path]. Pop 1 additional item as [layer]. 
-	create_or_open a directory with the specified path and layer. If layer is 
+	Pop 1 tuple off the stack as [path]. Pop 1 additional item as [layer].
+	create_or_open a directory with the specified path and layer. If layer is
 	null, use the default value for that parameter.
 
-DIRECTORY_CREATE[_DATABASE]
+#### DIRECTORY_CREATE[_DATABASE]
 
-	Pop 1 tuple off the stack as [path]. Pop 2 additional items as 
-	[layer, prefix]. create a directory with the specified path, layer, 
-	and prefix. If either of layer or prefix is null, use the default value for 
+	Pop 1 tuple off the stack as [path]. Pop 2 additional items as
+	[layer, prefix]. create a directory with the specified path, layer,
+	and prefix. If either of layer or prefix is null, use the default value for
 	that parameter (layer='', prefix=null).
 
-DIRECTORY_OPEN[_DATABASE|_SNAPSHOT]
+#### DIRECTORY_OPEN[_DATABASE|_SNAPSHOT]
 
 	Use the current directory for this operation.
 
-	Pop 1 tuple off the stack as [path]. Pop 1 additional item as [layer]. Open 
-	a directory with the specified path and layer. If layer is null, use the 
+	Pop 1 tuple off the stack as [path]. Pop 1 additional item as [layer]. Open
+	a directory with the specified path and layer. If layer is null, use the
 	default value (layer='').
 
 Directory Management
 --------------------
 
-DIRECTORY_CHANGE
+#### DIRECTORY_CHANGE
 
 	Pop the top item off the stack as [index]. Set the current directory list
 	index to index. In the event that the directory at this new index is null
-	(as the result of a previous error), set the directory list index to the 
+	(as the result of a previous error), set the directory list index to the
 	error index.
 
-DIRECTORY_SET_ERROR_INDEX
+#### DIRECTORY_SET_ERROR_INDEX
 
 	Pop the top item off the stack as [error_index]. Set the current error index
 	to error_index.
@@ -112,130 +112,130 @@ DIRECTORY_SET_ERROR_INDEX
 Directory Operations
 --------------------
 
-DIRECTORY_MOVE[_DATABASE]
+#### DIRECTORY_MOVE[_DATABASE]
 
 	Use the current directory for this operation.
 
-	Pop 2 tuples off the stack as [old_path, new_path]. Call move with the 
+	Pop 2 tuples off the stack as [old_path, new_path]. Call move with the
 	specified old_path and new_path. Append the result onto the directory list.
 
-DIRECTORY_MOVE_TO[_DATABASE]
+#### DIRECTORY_MOVE_TO[_DATABASE]
 
 	Use the current directory for this operation.
 
-	Pop 1 tuple off the stack as [new_absolute_path]. Call moveTo with the 
+	Pop 1 tuple off the stack as [new_absolute_path]. Call moveTo with the
 	specified new_absolute_path. Append the result onto the directory list.
 
-DIRECTORY_REMOVE[_DATABASE]
+#### DIRECTORY_REMOVE[_DATABASE]
 
 	Use the current directory for this operation.
 
 	Pop 1 item off the stack as [count] (either 0 or 1). If count is 1, pop 1
-	tuple off the stack as [path]. Call remove, passing it path if one was 
+	tuple off the stack as [path]. Call remove, passing it path if one was
 	popped.
 
-DIRECTORY_REMOVE_IF_EXISTS[_DATABASE]
+#### DIRECTORY_REMOVE_IF_EXISTS[_DATABASE]
 
 	Use the current directory for this operation.
 
 	Pop 1 item off the stack as [count] (either 0 or 1). If count is 1, pop 1
-	tuple off the stack as [path]. Call remove_if_exits, passing it path if one 
+	tuple off the stack as [path]. Call remove_if_exits, passing it path if one
 	was popped.
 
-DIRECTORY_LIST[_DATABASE|_SNAPSHOT]
+#### DIRECTORY_LIST[_DATABASE|_SNAPSHOT]
 
 	Use the current directory for this operation.
 
 	Pop 1 item off the stack as [count] (either 0 or 1). If count is 1, pop 1
-	tuple off the stack as [path]. Call list, passing it path if one was popped. 
-	Pack the resulting list of directories using the tuple layer and push the 
+	tuple off the stack as [path]. Call list, passing it path if one was popped.
+	Pack the resulting list of directories using the tuple layer and push the
 	packed string onto the stack.
 
-DIRECTORY_EXISTS[_DATABASE|_SNAPSHOT]
+#### DIRECTORY_EXISTS[_DATABASE|_SNAPSHOT]
 
 	Use the current directory for this operation.
 
 	Pop 1 item off the stack as [count] (either 0 or 1). If count is 1, pop 1
-	tuple off the stack as [path]. Call exists, passing it path if one 
+	tuple off the stack as [path]. Call exists, passing it path if one
 	was popped. Push 1 onto the stack if the path exists and 0 if it does not.
 
 Subspace Operations
 -------------------
 
-DIRECTORY_PACK_KEY
+#### DIRECTORY_PACK_KEY
 
 	Use the current directory for this operation.
 
 	Pop 1 tuple off the stack as [key_tuple]. Pack key_tuple and push the result
 	onto the stack.
 
-DIRECTORY_UNPACK_KEY
+#### DIRECTORY_UNPACK_KEY
 
 	Use the current directory for this operation.
 
 	Pop 1 item off the stack as [key]. Unpack key and push the resulting tuple
 	onto the stack one item at a time.
 
-DIRECTORY_RANGE
+#### DIRECTORY_RANGE
 
 	Use the current directory for this operation.
 
-	Pop 1 tuple off the stack as [tuple]. Create a range using tuple and push 
+	Pop 1 tuple off the stack as [tuple]. Create a range using tuple and push
 	range.begin and range.end onto the stack.
 
-DIRECTORY_CONTAINS
+#### DIRECTORY_CONTAINS
 
 	Use the current directory for this operation.
 
 	Pop 1 item off the stack as [key]. Check if the current directory contains
 	the specified key. Push 1 if it does and 0 if it doesn't.
 
-DIRECTORY_OPEN_SUBSPACE
+#### DIRECTORY_OPEN_SUBSPACE
 
 	Use the current directory for this operation.
 
-	Pop 1 tuple off the stack as [tuple]. Open the subspace of the current 
+	Pop 1 tuple off the stack as [tuple]. Open the subspace of the current
 	directory specified by tuple and push it onto the directory list.
 
 Directory Logging
 --------------------
 
-DIRECTORY_LOG_SUBSPACE
+#### DIRECTORY_LOG_SUBSPACE
 
 	Use the current directory for this operation.
 
-	Pop 1 item off the stack as [prefix]. Let key equal 
+	Pop 1 item off the stack as [prefix]. Let key equal
 	prefix + tuple.pack([dir_index]). Set key to be the result of calling
-	directory.key() in the current transaction. 
+	directory.key() in the current transaction.
 
-DIRECTORY_LOG_DIRECTORY
+#### DIRECTORY_LOG_DIRECTORY
 
 	Use the current directory for this operation.
 
-	Pop 1 item off the stack as [raw_prefix]. Create a subspace log_subspace 
+	Pop 1 item off the stack as [raw_prefix]. Create a subspace log_subspace
 	with path (dir_index) and the specified raw_prefix. Set:
 
 	tr[log_subspace[u'path']] = the tuple packed path of the directory.
 
 	tr[log_subspace[u'layer']] = the tuple packed layer of the directory.
 
-	tr[log_subspace[u'exists']] = the packed tuple containing a 1 if the 
+	tr[log_subspace[u'exists']] = the packed tuple containing a 1 if the
 	directory exists and 0 if it doesn't.
 
-	tr[log_subspace[u'children']] the tuple packed list of children of the 
+	tr[log_subspace[u'children']] the tuple packed list of children of the
 	directory.
 
-	Where log_subspace[u<str>] is the subspace packed tuple containing only the 
+	Where log_subspace[u<str>] is the subspace packed tuple containing only the
 	single specified unicode string <str>.
 
 Other
 -----
 
-DIRECTORY_STRIP_PREFIX
+#### DIRECTORY_STRIP_PREFIX
 
 	Use the current directory for this operation.
 
-	Pop 1 item off the stack as [byte_array]. Call .key() on the current 
-	subspace and store the result as [prefix]. Throw an error if the popped 
-	array does not start with prefix. Otherwise, remove the prefix from the 
+	Pop 1 item off the stack as [byte_array]. Call .key() on the current
+	subspace and store the result as [prefix]. Throw an error if the popped
+	array does not start with prefix. Otherwise, remove the prefix from the
 	popped array and push the result onto the stack.


### PR DESCRIPTION
Converts `bindings/bindingtester/spec` files to markdown (#213). It's mostly an extension change, but I also changed the operation names to be small headings so they stand out better when rendered. Let me know if you have other preferences for formatting.