### PR TITLE
Compile on High Sierra (10.13.4)

### DIFF
--- a/fdbclient/MultiVersionAssignmentVars.h
+++ b/fdbclient/MultiVersionAssignmentVars.h
@@ -135,7 +135,7 @@ public:
 	~DLThreadSingleAssignmentVar() {
 		lock.assertNotEntered();
 		if(f) {
-			ASSERT(futureRefCount == 1);
+			ASSERT_ABORT(futureRefCount == 1);
 			api->futureDestroy(f);
 		}
 	}

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -93,7 +93,7 @@ LocationInfo::~LocationInfo() {
 		for( auto const& alternative : getAlternatives() )
 			handles.push_back( alternative.v.getVersion.getEndpoint().token ); // must match above choice of UID
 		std::sort( handles.begin(), handles.end() );
-		ASSERT( handles.size() );
+		ASSERT_ABORT( handles.size() );
 
 		auto it = cx->ssid_locationInfo.find( handles );
 		if( it != cx->ssid_locationInfo.end() )
@@ -540,7 +540,7 @@ DatabaseContext::~DatabaseContext() {
 	monitorMasterProxiesInfoChange.cancel();
 	for(auto it = ssid_locationInfo.begin(); it != ssid_locationInfo.end(); it = ssid_locationInfo.erase(it))
 		it->second->notifyContextDestroyed();
-	ASSERT( ssid_locationInfo.empty() );
+	ASSERT_ABORT( ssid_locationInfo.empty() );
 	locationCache.insert( allKeys, Reference<LocationInfo>() );
 }
 

--- a/fdbrpc/AsyncFileCached.actor.cpp
+++ b/fdbrpc/AsyncFileCached.actor.cpp
@@ -233,7 +233,7 @@ Future<Void> AsyncFileCached::quiesce() {
 AsyncFileCached::~AsyncFileCached() {
 	while ( !pages.empty() ) {
 		auto ok = pages.begin()->second->evict();
-		ASSERT( ok );
+		ASSERT_ABORT( ok );
 	}
 	openFiles.erase( filename );
 }

--- a/fdbrpc/AsyncFileCached.actor.h
+++ b/fdbrpc/AsyncFileCached.actor.h
@@ -450,7 +450,7 @@ struct AFCPage : public EvictablePage, public FastAllocated<AFCPage> {
 
 	virtual ~AFCPage() {
 		clearDirty();
-		ASSERT( flushableIndex == -1 );
+		ASSERT_ABORT( flushableIndex == -1 );
 	}
 
 	void setDirty() {

--- a/fdbserver/TLogServer.actor.cpp
+++ b/fdbserver/TLogServer.actor.cpp
@@ -425,7 +425,7 @@ struct LogData : NonCopyable, public ReferenceCounted<LogData> {
 		tLogData->bytesDurable += bytesInput.getValue() - bytesDurable.getValue();
 		TraceEvent("TLogBytesWhenRemoved", tli.id()).detail("sharedBytesInput", tLogData->bytesInput).detail("sharedBytesDurable", tLogData->bytesDurable).detail("localBytesInput", bytesInput.getValue()).detail("localBytesDurable", bytesDurable.getValue());
 
-		ASSERT(tLogData->bytesDurable <= tLogData->bytesInput);
+		ASSERT_ABORT(tLogData->bytesDurable <= tLogData->bytesInput);
 		endRole(tli.id(), "TLog", "Error", true);
 
 		if(!tLogData->terminated) {

--- a/fdbserver/VFSAsync.cpp
+++ b/fdbserver/VFSAsync.cpp
@@ -460,7 +460,7 @@ static int asyncDeviceCharacteristics(sqlite3_file *pFile){ return 0; }
 			//resulting in a locking error
 			auto itr = SharedMemoryInfo::table.find(filename);
 			if(itr != SharedMemoryInfo::table.end()) {
-				ASSERT(itr->second.refcount == 0);
+				ASSERT_ABORT(itr->second.refcount == 0);
 				itr->second.cleanup();
 			}
 		}

--- a/fdbserver/fdbserver.actor.cpp
+++ b/fdbserver/fdbserver.actor.cpp
@@ -38,6 +38,7 @@
 #include "IKeyValueStore.h"
 #include <stdarg.h>
 #include <stdio.h>
+#include <fstream>
 #include "pubsub.h"
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN

--- a/flow/IThreadPool.cpp
+++ b/flow/IThreadPool.cpp
@@ -35,7 +35,7 @@ class ThreadPool : public IThreadPool, public ReferenceCounted<ThreadPool> {
 		Event stopped;
 		static thread_local IThreadPoolReceiver* threadUserObject;
 		explicit Thread(ThreadPool *pool, IThreadPoolReceiver *userObject) : pool(pool), userObject(userObject) {}
-		~Thread() { ASSERT(!userObject); }
+		~Thread() { ASSERT_ABORT(!userObject); }
 
 		void run() {
 			deprioritizeThread();

--- a/flow/Net2.actor.cpp
+++ b/flow/Net2.actor.cpp
@@ -403,8 +403,7 @@ private:
 
 	void init() {
 		// Socket settings that have to be set after connect or accept succeeds
-		boost::asio::socket_base::non_blocking_io nbio(true);
-		socket.io_control(nbio);
+		socket.non_blocking(true);
 		socket.set_option(boost::asio::ip::tcp::no_delay(true));
 	}
 

--- a/flow/libs/system/src/error_code.cpp
+++ b/flow/libs/system/src/error_code.cpp
@@ -35,6 +35,11 @@ using namespace boost::system::errc;
 #   endif
 # endif
 
+#if BOOST_VERSION > 105200
+#define FOUNDATIONDB_NOEXCEPT BOOST_SYSTEM_NOEXCEPT
+#else
+#define FOUNDATIONDB_NOEXCEPT
+#endif
 //----------------------------------------------------------------------------//
 
 namespace
@@ -48,7 +53,7 @@ namespace
   {
   public:
     generic_error_category(){}
-    const char *   name() const;
+    const char *   name() const FOUNDATIONDB_NOEXCEPT ; 
     std::string    message( int ev ) const;
   };
 
@@ -56,14 +61,14 @@ namespace
   {
   public:
     system_error_category(){}
-    const char *        name() const;
+    const char *        name() const FOUNDATIONDB_NOEXCEPT;
     std::string         message( int ev ) const;
     error_condition     default_error_condition( int ev ) const;
   };
 
   //  generic_error_category implementation  ---------------------------------//
 
-  const char * generic_error_category::name() const
+  const char * generic_error_category::name() const FOUNDATIONDB_NOEXCEPT
   {
     return "generic";
   }
@@ -154,7 +159,7 @@ namespace
   }
   //  system_error_category implementation  --------------------------------// 
 
-  const char * system_error_category::name() const
+  const char * system_error_category::name() const FOUNDATIONDB_NOEXCEPT
   {
     return "system";
   }


### PR DESCRIPTION
In order to compile on High Sierra with latest clang I needed to change the following:

- Using ASSERT_ABORT in destructors. (Lastest) clang does not allows exceptions without correct definition
- include fstream before usage of ifstream in fdbserver.actor.cpp