### PR TITLE
Cherrypick docs and formatting fixes

### DIFF
--- a/bindings/go/src/fdb/directory/directoryLayer.go
+++ b/bindings/go/src/fdb/directory/directoryLayer.go
@@ -27,6 +27,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+
 	"github.com/apple/foundationdb/bindings/go/src/fdb"
 	"github.com/apple/foundationdb/bindings/go/src/fdb/subspace"
 	"github.com/apple/foundationdb/bindings/go/src/fdb/tuple"
@@ -78,9 +79,8 @@ func (dl directoryLayer) createOrOpen(rtr fdb.ReadTransaction, tr *fdb.Transacti
 	if prefix != nil && !dl.allowManualPrefixes {
 		if len(dl.path) == 0 {
 			return nil, errors.New("cannot specify a prefix unless manual prefixes are enabled")
-		} else {
-			return nil, errors.New("cannot specify a prefix in a partition")
 		}
+		return nil, errors.New("cannot specify a prefix in a partition")
 	}
 
 	if len(path) == 0 {
@@ -562,9 +562,8 @@ func (dl directoryLayer) contentsOfNode(node subspace.Subspace, path []string, l
 		ndl := NewDirectoryLayer(subspace.FromBytes(nssb), ss, false).(directoryLayer)
 		ndl.path = newPath
 		return directoryPartition{ndl, dl}, nil
-	} else {
-		return directorySubspace{ss, dl, newPath, layer}, nil
 	}
+	return directorySubspace{ss, dl, newPath, layer}, nil
 }
 
 func (dl directoryLayer) nodeWithPrefix(prefix []byte) subspace.Subspace {

--- a/bindings/go/src/fdb/directory/directoryPartition.go
+++ b/bindings/go/src/fdb/directory/directoryPartition.go
@@ -72,9 +72,8 @@ func (dp directoryPartition) GetLayer() []byte {
 func (dp directoryPartition) getLayerForPath(path []string) directoryLayer {
 	if len(path) == 0 {
 		return dp.parentDirectoryLayer
-	} else {
-		return dp.directoryLayer
 	}
+	return dp.directoryLayer
 }
 
 func (dp directoryPartition) MoveTo(t fdb.Transactor, newAbsolutePath []string) (DirectorySubspace, error) {

--- a/bindings/go/src/fdb/fdb.go
+++ b/bindings/go/src/fdb/fdb.go
@@ -139,9 +139,8 @@ func APIVersion(version int) error {
 				maxSupportedVersion := C.fdb_get_max_api_version()
 				if headerVersion > int(maxSupportedVersion) {
 					return fmt.Errorf("This version of the FoundationDB Go binding is not supported by the installed FoundationDB C library. The binding requires a library that supports API version %d, but the installed library supports a maximum version of %d.", version, maxSupportedVersion)
-				} else {
-					return fmt.Errorf("API version %d is not supported by the installed FoundationDB C library.", version)
 				}
+				return fmt.Errorf("API version %d is not supported by the installed FoundationDB C library.", version)
 			}
 			return Error{int(e)}
 		}
@@ -326,9 +325,8 @@ func CreateCluster(clusterFile string) (Cluster, error) {
 func byteSliceToPtr(b []byte) *C.uint8_t {
 	if len(b) > 0 {
 		return (*C.uint8_t)(unsafe.Pointer(&b[0]))
-	} else {
-		return nil
 	}
+	return nil
 }
 
 // A KeyConvertible can be converted to a FoundationDB Key. All functions in the

--- a/bindings/go/src/fdb/range.go
+++ b/bindings/go/src/fdb/range.go
@@ -247,7 +247,7 @@ func (ri *RangeIterator) fetchNextBatch() {
 		ri.sr.Begin = FirstGreaterThan(ri.kvs[ri.index-1].Key)
 	}
 
-	ri.iteration += 1
+	ri.iteration++
 
 	f := ri.t.doGetRange(ri.sr, ri.options, ri.snapshot, ri.iteration)
 	ri.f = &f
@@ -265,7 +265,7 @@ func (ri *RangeIterator) Get() (kv KeyValue, e error) {
 
 	kv = ri.kvs[ri.index]
 
-	ri.index += 1
+	ri.index++
 
 	if ri.index == len(ri.kvs) {
 		ri.fetchNextBatch()
@@ -291,7 +291,7 @@ func Strinc(prefix []byte) ([]byte, error) {
 		if prefix[i] != 0xFF {
 			ret := make([]byte, i+1)
 			copy(ret, prefix[:i+1])
-			ret[i] += 1
+			ret[i]++
 			return ret, nil
 		}
 	}

--- a/bindings/go/src/fdb/transaction.go
+++ b/bindings/go/src/fdb/transaction.go
@@ -352,9 +352,8 @@ func (t Transaction) Reset() {
 func boolToInt(b bool) int {
 	if b {
 		return 1
-	} else {
-		return 0
 	}
+	return 0
 }
 
 func (t *transaction) getKey(sel KeySelector, snapshot int) FutureKey {

--- a/bindings/go/src/fdb/tuple/tuple.go
+++ b/bindings/go/src/fdb/tuple/tuple.go
@@ -38,6 +38,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
+
 	"github.com/apple/foundationdb/bindings/go/src/fdb"
 )
 
@@ -114,7 +115,7 @@ func encodeBytes(buf *bytes.Buffer, code byte, b []byte) {
 func bisectLeft(u uint64) int {
 	var n int
 	for sizeLimits[n] < u {
-		n += 1
+		n++
 	}
 	return n
 }
@@ -356,7 +357,7 @@ func decodeTuple(b []byte, nested bool) (Tuple, int, error) {
 			if err != nil {
 				return nil, i, err
 			}
-			off += 1
+			off++
 		default:
 			return nil, i, fmt.Errorf("unable to decode tuple element with unknown typecode %02x", b[i])
 		}

--- a/documentation/sphinx/source/queues-java.rst
+++ b/documentation/sphinx/source/queues-java.rst
@@ -110,7 +110,7 @@ The following is a simple implementation of the basic pattern:
 
         // Get the top element of the queue.
         private static KeyValue firstItem(TransactionContext tcx){
-            return tcx.run((Transaction tr) ->
+            return tcx.run((Transaction tr) -> {
                 for(KeyValue kv : tr.getRange(queue.range(), 1)){
                     return kv;
                 }
@@ -121,7 +121,7 @@ The following is a simple implementation of the basic pattern:
 
         // Get the last index in the queue.
         private static long lastIndex(TransactionContext tcx){
-            return tcx.run((Transaction tr) ->
+            return tcx.run((Transaction tr) -> {
                 for(KeyValue kv : tr.snapshot().getRange(queue.range(), 1, true)){
                     return (long)queue.unpack(kv.getKey()).get(0);
                 }

--- a/documentation/sphinx/source/queues-java.rst
+++ b/documentation/sphinx/source/queues-java.rst
@@ -87,7 +87,7 @@ The following is a simple implementation of the basic pattern:
             }
 
             // Remove from the top of the queue.
-            tcx.run((Transaction tr) ->
+            tcx.run((Transaction tr) -> {
                 tr.clear(item.getKey());
                 return null;
             });


### PR DESCRIPTION
These are some fixes to our Java examples and also some go linting fixes that have been merged into master that I think should be pulled into release-5.1.