### PR TITLE
[go] Fix ${fdbdir} path definition in fdb-go-install.sh

### DIFF
--- a/bindings/go/fdb-go-install.sh
+++ b/bindings/go/fdb-go-install.sh
@@ -167,7 +167,7 @@ else
 
         if [[ "${status}" -eq 0 ]] ; then
             destdir=$( cd "${destdir}" && pwd ) # Get absolute path of destination dir.
-            fdbdir="${destdir}/foundation"
+            fdbdir="${destdir}/foundationdb"
 
             if [[ ! -d "${destdir}" ]] ; then
                 cmd=("mkdir" "-p" "${destdir}")


### PR DESCRIPTION
When trying to install the go bindings I encountered an error:
```
$ ./fdb-go-install.sh install
...
make: *** /Users/seshadri/go/src/github.com/apple/foundation: No such file or directory.  Stop.
```

With this change the install proceeds smoothly.