### PR TITLE
Cherrypick docs and go install fixes

### DIFF
--- a/bindings/go/fdb-go-install.sh
+++ b/bindings/go/fdb-go-install.sh
@@ -167,7 +167,7 @@ else
 
         if [[ "${status}" -eq 0 ]] ; then
             destdir=$( cd "${destdir}" && pwd ) # Get absolute path of destination dir.
-            fdbdir="${destdir}/foundation"
+            fdbdir="${destdir}/foundationdb"
 
             if [[ ! -d "${destdir}" ]] ; then
                 cmd=("mkdir" "-p" "${destdir}")

--- a/documentation/sphinx/source/api-python.rst
+++ b/documentation/sphinx/source/api-python.rst
@@ -394,8 +394,8 @@ Transactional decoration
 
         @fdb.transactional
         def simple_function(tr, x, y):
-            tr['foo'] = x
-            tr['bar'] = y
+            tr[b'foo'] = x
+            tr[b'bar'] = y
 
     The ``@fdb.transactional`` decorator makes ``simple_function`` a transactional function.  All functions using this decorator must have an argument **named** ``tr``.  This specially named argument is passed a transaction that the function can use to do reads and writes.
 
@@ -897,7 +897,7 @@ Asynchronous methods return one of the following subclasses of :class:`Future`:
 
         @fdb.transactional
         def foo(tr):
-            val = tr['foo']
+            val = tr[b'foo']
             if val.present():
                 print 'Got value: %s' % val
             else:

--- a/documentation/sphinx/source/class-scheduling.rst
+++ b/documentation/sphinx/source/class-scheduling.rst
@@ -38,11 +38,11 @@ Next, we open a FoundationDB database.  The API will connect to the FoundationDB
 
 We are ready to use the database. In Python, using the ``[]`` operator on the db object is a convenient syntax for performing a read or write on the database. First, let's simply write a key-value pair:
 
-    >>> db['hello'] = 'world'
+    >>> db[b'hello'] = b'world'
 
 When this command returns without exception, the modification is durably stored in FoundationDB! Under the covers, this function creates a transaction with a single modification. We'll see later how to do multiple operations in a single transaction. For now, let's read back the data::
 
-    >>> print 'hello', db['hello']
+    >>> print 'hello', db[b'hello']
     hello world
 
 If this is all working, it looks like we are ready to start building a real application. For reference, here's the full code for "hello world"::
@@ -50,8 +50,8 @@ If this is all working, it looks like we are ready to start building a real appl
     import fdb
     fdb.api_version(510)
     db = fdb.open()
-    db['hello'] = 'world'
-    print 'hello', db['hello']
+    db[b'hello'] = b'world'
+    print 'hello', db[b'hello']
 
 Class scheduling application
 ============================


### PR DESCRIPTION
There were some changes to our python docs to make them work in both python2 and python3. There is also another commit fixing a directory within the go installer which was causing #246 when run from release-5.1