### PR TITLE
Merge release 5.2 into master

### DIFF
--- a/bindings/c/foundationdb/fdb_c.h
+++ b/bindings/c/foundationdb/fdb_c.h
@@ -241,7 +241,7 @@ extern "C" {
     fdb_transaction_get_committed_version( FDBTransaction* tr,
                                            int64_t* out_version );
 
-	DLLEXPORT WARN_UNUSED_RESULT FDBFuture* fdb_transaction_get_versionstamp( FDBTransaction* tr );
+    DLLEXPORT WARN_UNUSED_RESULT FDBFuture* fdb_transaction_get_versionstamp( FDBTransaction* tr );
 
     DLLEXPORT WARN_UNUSED_RESULT FDBFuture*
     fdb_transaction_on_error( FDBTransaction* tr, fdb_error_t error );
@@ -276,7 +276,7 @@ extern "C" {
 
     DLLEXPORT fdb_bool_t fdb_future_is_error( FDBFuture* f );
 #else
-	#define fdb_future_is_error(x) FDB_REMOVED_FUNCTION
+    #define fdb_future_is_error(x) FDB_REMOVED_FUNCTION
 #endif
 
 #if FDB_API_VERSION < 14
@@ -307,7 +307,7 @@ extern "C" {
         int end_key_name_length, fdb_bool_t end_or_equal, int end_offset,
         int limit );
 #else
-	#define fdb_transaction_get_range_selector(tr,bkn,bknl,boe,bo,ekn,eknl,eoe,eo,lim) FDB_REMOVED_FUNCTION
+    #define fdb_transaction_get_range_selector(tr,bkn,bknl,boe,bo,ekn,eknl,eoe,eo,lim) FDB_REMOVED_FUNCTION
 #endif
 
 #ifdef __cplusplus

--- a/bindings/flow/tester/Tester.actor.cpp
+++ b/bindings/flow/tester/Tester.actor.cpp
@@ -1538,7 +1538,6 @@ struct UnitTestsFunc : InstructionFunc {
 		tr->setOption(FDBTransactionOption::FDB_TR_OPTION_READ_YOUR_WRITES_DISABLE);
 		tr->setOption(FDBTransactionOption::FDB_TR_OPTION_READ_SYSTEM_KEYS);
 		tr->setOption(FDBTransactionOption::FDB_TR_OPTION_ACCESS_SYSTEM_KEYS);
-		tr->setOption(FDBTransactionOption::FDB_TR_OPTION_DURABILITY_DEV_NULL_IS_WEB_SCALE);
 		const uint64_t timeout = 60*1000;
 		tr->setOption(FDBTransactionOption::FDB_TR_OPTION_TIMEOUT, Optional<StringRef>(StringRef((const uint8_t*)&timeout, 8)));
 		const uint64_t retryLimit = 50;

--- a/bindings/go/src/_stacktester/stacktester.go
+++ b/bindings/go/src/_stacktester/stacktester.go
@@ -787,7 +787,6 @@ func (sm *StackMachine) processInst(idx int, inst tuple.Tuple) {
 			tr.Options().SetReadYourWritesDisable()
 			tr.Options().SetReadSystemKeys()
 			tr.Options().SetAccessSystemKeys()
-			tr.Options().SetDurabilityDevNullIsWebScale()
 			tr.Options().SetTimeout(60 * 1000)
 			tr.Options().SetRetryLimit(50)
 			tr.Options().SetMaxRetryDelay(100)

--- a/bindings/go/src/fdb/generated.go
+++ b/bindings/go/src/fdb/generated.go
@@ -254,24 +254,9 @@ func (o TransactionOptions) SetNextWriteNoWriteConflictRange() error {
 	return o.setOpt(30, nil)
 }
 
-// Committing this transaction will bypass the normal load balancing across proxies and go directly to the specifically nominated 'first proxy'.
-func (o TransactionOptions) SetCommitOnFirstProxy() error {
-	return o.setOpt(40, nil)
-}
-
-// Not yet implemented.
-func (o TransactionOptions) SetCheckWritesEnable() error {
-	return o.setOpt(50, nil)
-}
-
 // Reads performed by a transaction will not see any prior mutations that occured in that transaction, instead seeing the value which was in the database at the transaction's read version. This option may provide a small performance benefit for the client, but also disables a number of client-side optimizations which are beneficial for transactions which tend to read and write the same keys within a single transaction.
 func (o TransactionOptions) SetReadYourWritesDisable() error {
 	return o.setOpt(51, nil)
-}
-
-// Disables read-ahead caching for range reads. Under normal operation, a transaction will read extra rows from the database into cache if range reads are used to page through a series of data one row at a time (i.e. if a range read with a one row limit is followed by another one row range read starting immediately after the result of the first).
-func (o TransactionOptions) SetReadAheadDisable() error {
-	return o.setOpt(52, nil)
 }
 
 // Not yet implemented.
@@ -282,11 +267,6 @@ func (o TransactionOptions) SetDurabilityDatacenter() error {
 // Not yet implemented.
 func (o TransactionOptions) SetDurabilityRisky() error {
 	return o.setOpt(120, nil)
-}
-
-// Not yet implemented.
-func (o TransactionOptions) SetDurabilityDevNullIsWebScale() error {
-	return o.setOpt(130, nil)
 }
 
 // Specifies that this transaction should be treated as highest priority and that lower priority transactions should block behind this one. Use is discouraged outside of low-level tools
@@ -312,11 +292,6 @@ func (o TransactionOptions) SetAccessSystemKeys() error {
 // Allows this transaction to read system keys (those that start with the byte 0xFF)
 func (o TransactionOptions) SetReadSystemKeys() error {
 	return o.setOpt(302, nil)
-}
-
-// Not yet implemented.
-func (o TransactionOptions) SetDebugDump() error {
-	return o.setOpt(400, nil)
 }
 
 // Not yet implemented.
@@ -453,6 +428,11 @@ func (t Transaction) BitOr(key KeyConvertible, param []byte) {
 // BitXor performs a bitwise ``xor`` operation.  If the existing value in the database is not present or shorter than ``param``, it is first extended to the length of ``param`` with zero bytes.  If ``param`` is shorter than the existing value in the database, the existing value is truncated to match the length of ``param``.
 func (t Transaction) BitXor(key KeyConvertible, param []byte) {
 	t.atomicOp(key.FDBKey(), param, 8)
+}
+
+// AppendIfFits appends ``param`` to the end of the existing value already in the database at the given key (or creates the key and sets the value to ``param`` if the key is empty). This will only append the value if the final concatenated value size is less than or equal to the maximum value size (i.e., if it fits). WARNING: No error is surfaced back to the user if the final value is too large because the mutation will not be applied until after the transaction has been committed. Therefore, it is only safe to use this mutation type if one can guarantee that one will keep the total value size under the maximum size.
+func (t Transaction) AppendIfFits(key KeyConvertible, param []byte) {
+	t.atomicOp(key.FDBKey(), param, 9)
 }
 
 // Max performs a little-endian comparison of byte strings. If the existing value in the database is not present or shorter than ``param``, it is first extended to the length of ``param`` with zero bytes.  If ``param`` is shorter than the existing value in the database, the existing value is truncated to match the length of ``param``. The larger of the two values is then stored in the database.

--- a/bindings/go/src/fdb/generated.go
+++ b/bindings/go/src/fdb/generated.go
@@ -364,6 +364,11 @@ func (o TransactionOptions) SetReadLockAware() error {
 	return o.setOpt(702, nil)
 }
 
+// No other transactions will be applied before this transaction within the same commit version.
+func (o TransactionOptions) SetFirstInBatch() error {
+	return o.setOpt(710, nil)
+}
+
 type StreamingMode int
 
 const (

--- a/bindings/java/src/test/com/apple/foundationdb/test/AsyncStackTester.java
+++ b/bindings/java/src/test/com/apple/foundationdb/test/AsyncStackTester.java
@@ -479,7 +479,6 @@ public class AsyncStackTester {
 				tr.options().setReadYourWritesDisable();
 				tr.options().setReadSystemKeys();
 				tr.options().setAccessSystemKeys();
-				tr.options().setDurabilityDevNullIsWebScale();
 				tr.options().setTimeout(60*1000);
 				tr.options().setRetryLimit(50);
 				tr.options().setMaxRetryDelay(100);

--- a/bindings/java/src/test/com/apple/foundationdb/test/StackTester.java
+++ b/bindings/java/src/test/com/apple/foundationdb/test/StackTester.java
@@ -429,7 +429,6 @@ public class StackTester {
 						tr.options().setReadYourWritesDisable();
 						tr.options().setReadSystemKeys();
 						tr.options().setAccessSystemKeys();
-						tr.options().setDurabilityDevNullIsWebScale();
 						tr.options().setTimeout(60*1000);
 						tr.options().setRetryLimit(50);
 						tr.options().setMaxRetryDelay(100);

--- a/bindings/python/tests/tester.py
+++ b/bindings/python/tests/tester.py
@@ -138,7 +138,6 @@ def test_options(tr):
     tr.options.set_read_your_writes_disable()
     tr.options.set_read_system_keys()
     tr.options.set_access_system_keys()
-    tr.options.set_durability_dev_null_is_web_scale()
     tr.options.set_timeout(60 * 1000)
     tr.options.set_retry_limit(50)
     tr.options.set_max_retry_delay(100)

--- a/bindings/ruby/tests/tester.rb
+++ b/bindings/ruby/tests/tester.rb
@@ -462,7 +462,6 @@ class Tester
               tr.options.set_read_your_writes_disable
               tr.options.set_read_system_keys
               tr.options.set_access_system_keys
-              tr.options.set_durability_dev_null_is_web_scale
               tr.options.set_timeout(60*1000)
               tr.options.set_retry_limit(50)
               tr.options.set_max_retry_delay(100)

--- a/documentation/sphinx/source/administration.rst
+++ b/documentation/sphinx/source/administration.rst
@@ -482,7 +482,7 @@ To make configuring, starting, stopping, and restarting ``fdbserver`` processes 
 
 During normal operation, ``fdbmonitor`` is transparent, and you interact with it only by modifying the configuration in :ref:`foundationdb.conf <foundationdb-conf>` and perhaps occasionally by :ref:`starting and stopping <administration-running-foundationdb>` it manually. If some problem prevents an ``fdbserver`` or ``backup-agent`` process from starting or causes it to stop unexpectedly, ``fdbmonitor`` will log errors to the system log.
 
-If kill_on_configuration_change parameter is unset or set to `true` in foundationdb.conf then fdbmonitor will restart on changes automatically. If this parameter is set to `false` it will not restart on changes.
+If ``kill_on_configuration_change`` parameter is unset or set to ``true`` in foundationdb.conf then fdbmonitor will restart on changes automatically. If this parameter is set to ``false`` it will not restart on changes.
 
 .. _administration-managing-trace-files:
 

--- a/documentation/sphinx/source/api-common.rst.inc
+++ b/documentation/sphinx/source/api-common.rst.inc
@@ -357,10 +357,6 @@
 .. |option-read-system-keys-warning| replace::
 
     The format of data in the system keys may change from version to version in FoundationDB.
-
-.. |option-durability-dev-null-is-web-scale-blurb| replace::
-
-    This option has no effect yet, but may make users migrating from MongoDB more comfortable.
     
 ..  |option-set-retry-limit-blurb1| replace::
     

--- a/documentation/sphinx/source/api-python.rst
+++ b/documentation/sphinx/source/api-python.rst
@@ -840,10 +840,6 @@ Transaction options
 
     |option-set-timeout-blurb3|
 
-.. method:: Transaction.options.set_durability_dev_null_is_web_scale
-
-    |option-durability-dev-null-is-web-scale-blurb|
-
 .. _api-python-future:
 
 Future objects

--- a/documentation/sphinx/source/api-ruby.rst
+++ b/documentation/sphinx/source/api-ruby.rst
@@ -775,10 +775,6 @@ Transaction options
 
     |option-set-timeout-blurb3|
 
-.. method:: Transaction.options.set_durability_dev_null_is_web_scale() -> nil
-
-    |option-durability-dev-null-is-web-scale-blurb|
-
 .. _transact:
 
 The transact method

--- a/fdbclient/BackupAgent.h
+++ b/fdbclient/BackupAgent.h
@@ -56,6 +56,7 @@ public:
 	static const Key keyLastUid;
 	static const Key keyBeginKey;
 	static const Key keyEndKey;
+	static const Key keyDrVersion;
 	static const Key destUid;
 	static const Key backupStartVersion;
 
@@ -347,7 +348,7 @@ public:
 		return runRYWTransaction(cx, [=](Reference<ReadYourWritesTransaction> tr){ return discontinueBackup(tr, tagName); });
 	}
 
-	Future<Void> abortBackup(Database cx, Key tagName, bool partial = false);
+	Future<Void> abortBackup(Database cx, Key tagName, bool partial = false, bool abortOldBackup = false);
 
 	Future<std::string> getStatus(Database cx, int errorLimit, Key tagName);
 
@@ -373,12 +374,14 @@ public:
 	// will return when the backup directory is restorable.
 	Future<int> waitBackup(Database cx, Key tagName, bool stopWhenDone = true);
 	Future<int> waitSubmitted(Database cx, Key tagName);
+	Future<Void> waitUpgradeToLatestDrVersion(Database cx, Key tagName);
 
 	static const Key keyAddPrefix;
 	static const Key keyRemovePrefix;
 	static const Key keyRangeVersions;
 	static const Key keyCopyStop;
 	static const Key keyDatabasesInSync;
+	static const int LATEST_DR_VERSION;
 
 	Future<int64_t> getTaskCount(Reference<ReadYourWritesTransaction> tr) { return taskBucket->getTaskCount(tr); }
 	Future<int64_t> getTaskCount(Database cx) { return taskBucket->getTaskCount(cx); }

--- a/fdbclient/BackupAgentBase.actor.cpp
+++ b/fdbclient/BackupAgentBase.actor.cpp
@@ -35,6 +35,7 @@ const Key BackupAgentBase::keyStateStatus = LiteralStringRef("state_status");
 const Key BackupAgentBase::keyLastUid = LiteralStringRef("last_uid");
 const Key BackupAgentBase::keyBeginKey = LiteralStringRef("beginKey");
 const Key BackupAgentBase::keyEndKey = LiteralStringRef("endKey");
+const Key BackupAgentBase::keyDrVersion = LiteralStringRef("drVersion");
 const Key BackupAgentBase::destUid = LiteralStringRef("destUid");
 const Key BackupAgentBase::backupStartVersion = LiteralStringRef("backupStartVersion");
 
@@ -628,7 +629,7 @@ ACTOR Future<Void> _clearLogRanges(Reference<ReadYourWritesTransaction> tr, bool
 	state Key backupLatestVersionsKey = logUidValue.withPrefix(backupLatestVersionsPath);
 	tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
 	tr->setOption(FDBTransactionOptions::LOCK_AWARE);
-	
+
 	state Standalone<RangeResultRef> backupVersions = wait(tr->getRange(KeyRangeRef(backupLatestVersionsPath, strinc(backupLatestVersionsPath)), CLIENT_KNOBS->TOO_MANY));
 
 	// Make sure version history key does exist and lower the beginVersion if needed

--- a/fdbclient/DatabaseBackupAgent.actor.cpp
+++ b/fdbclient/DatabaseBackupAgent.actor.cpp
@@ -33,6 +33,7 @@ const Key DatabaseBackupAgent::keyRemovePrefix = LiteralStringRef("remove_prefix
 const Key DatabaseBackupAgent::keyRangeVersions = LiteralStringRef("range_versions");
 const Key DatabaseBackupAgent::keyCopyStop = LiteralStringRef("copy_stop");
 const Key DatabaseBackupAgent::keyDatabasesInSync = LiteralStringRef("databases_in_sync");
+const int DatabaseBackupAgent::LATEST_DR_VERSION = 1;
 
 DatabaseBackupAgent::DatabaseBackupAgent()
 	: subspace(Subspace(databaseBackupPrefixRange.begin))
@@ -411,7 +412,7 @@ namespace dbBackup {
 		}
 
 	};
-	StringRef BackupRangeTaskFunc::name = LiteralStringRef("db_backup_range");
+	StringRef BackupRangeTaskFunc::name = LiteralStringRef("dr_backup_range");
 	const uint32_t BackupRangeTaskFunc::version = 1;
 	const Key BackupRangeTaskFunc::keyAddBackupRangeTasks = LiteralStringRef("addBackupRangeTasks");
 	const Key BackupRangeTaskFunc::keyBackupRangeBeginKey = LiteralStringRef("backupRangeBeginKey");
@@ -457,7 +458,7 @@ namespace dbBackup {
 		Future<Void> finish(Reference<ReadYourWritesTransaction> tr, Reference<TaskBucket> tb, Reference<FutureBucket> fb, Reference<Task> task) { return _finish(tr, tb, fb, task); };
 
 	};
-	StringRef FinishFullBackupTaskFunc::name = LiteralStringRef("db_finish_full_backup");
+	StringRef FinishFullBackupTaskFunc::name = LiteralStringRef("dr_finish_full_backup");
 	const uint32_t FinishFullBackupTaskFunc::version = 1;
 	REGISTER_TASKFUNC(FinishFullBackupTaskFunc);
 
@@ -508,7 +509,7 @@ namespace dbBackup {
 			return Void();
 		}
 	};
-	StringRef EraseLogRangeTaskFunc::name = LiteralStringRef("db_erase_log_range");
+	StringRef EraseLogRangeTaskFunc::name = LiteralStringRef("dr_erase_log_range");
 	const uint32_t EraseLogRangeTaskFunc::version = 1;
 	REGISTER_TASKFUNC(EraseLogRangeTaskFunc);
 
@@ -685,7 +686,7 @@ namespace dbBackup {
 			return Void();
 		}
 	};
-	StringRef CopyLogRangeTaskFunc::name = LiteralStringRef("db_copy_log_range");
+	StringRef CopyLogRangeTaskFunc::name = LiteralStringRef("dr_copy_log_range");
 	const uint32_t CopyLogRangeTaskFunc::version = 1;
 	const Key CopyLogRangeTaskFunc::keyNextBeginVersion = LiteralStringRef("nextBeginVersion");
 	REGISTER_TASKFUNC(CopyLogRangeTaskFunc);
@@ -788,7 +789,7 @@ namespace dbBackup {
 		Future<Void> execute(Database cx, Reference<TaskBucket> tb, Reference<FutureBucket> fb, Reference<Task> task) { return Void(); };
 		Future<Void> finish(Reference<ReadYourWritesTransaction> tr, Reference<TaskBucket> tb, Reference<FutureBucket> fb, Reference<Task> task) { return _finish(tr, tb, fb, task); };
 	};
-	StringRef CopyLogsTaskFunc::name = LiteralStringRef("db_copy_logs");
+	StringRef CopyLogsTaskFunc::name = LiteralStringRef("dr_copy_logs");
 	const uint32_t CopyLogsTaskFunc::version = 1;
 	REGISTER_TASKFUNC(CopyLogsTaskFunc);
 
@@ -900,7 +901,7 @@ namespace dbBackup {
 		Future<Void> execute(Database cx, Reference<TaskBucket> tb, Reference<FutureBucket> fb, Reference<Task> task) { return _execute(cx, tb, fb, task); };
 		Future<Void> finish(Reference<ReadYourWritesTransaction> tr, Reference<TaskBucket> tb, Reference<FutureBucket> fb, Reference<Task> task) { return _finish(tr, tb, fb, task); };
 	};
-	StringRef FinishedFullBackupTaskFunc::name = LiteralStringRef("db_finished_full_backup");
+	StringRef FinishedFullBackupTaskFunc::name = LiteralStringRef("dr_finished_full_backup");
 	const uint32_t FinishedFullBackupTaskFunc::version = 1;
 	const Key FinishedFullBackupTaskFunc::keyInsertTask = LiteralStringRef("insertTask");
 	REGISTER_TASKFUNC(FinishedFullBackupTaskFunc);
@@ -983,9 +984,380 @@ namespace dbBackup {
 		Future<Void> execute(Database cx, Reference<TaskBucket> tb, Reference<FutureBucket> fb, Reference<Task> task) { return Void(); };
 		Future<Void> finish(Reference<ReadYourWritesTransaction> tr, Reference<TaskBucket> tb, Reference<FutureBucket> fb, Reference<Task> task) { return _finish(tr, tb, fb, task); };
 	};
-	StringRef CopyDiffLogsTaskFunc::name = LiteralStringRef("db_copy_diff_logs");
+	StringRef CopyDiffLogsTaskFunc::name = LiteralStringRef("dr_copy_diff_logs");
 	const uint32_t CopyDiffLogsTaskFunc::version = 1;
 	REGISTER_TASKFUNC(CopyDiffLogsTaskFunc);
+
+	// Skip unneeded EraseLogRangeTaskFunc in 5.1
+	struct SkipOldEraseLogRangeTaskFunc : TaskFuncBase {
+		static StringRef name;
+		static const uint32_t version;
+
+		ACTOR static Future<Void> _finish(Reference<ReadYourWritesTransaction> tr, Reference<TaskBucket> taskBucket, Reference<FutureBucket> futureBucket, Reference<Task> task) {
+			state Reference<TaskFuture> taskFuture = futureBucket->unpack(task->params[Task::reservedTaskParamKeyDone]);
+			Void _ = wait(taskFuture->set(tr, taskBucket) && taskBucket->finish(tr, task));
+			return Void();
+		}
+
+		StringRef getName() const { return name; };
+
+		Future<Void> execute(Database cx, Reference<TaskBucket> tb, Reference<FutureBucket> fb, Reference<Task> task) { return Void(); };
+		Future<Void> finish(Reference<ReadYourWritesTransaction> tr, Reference<TaskBucket> tb, Reference<FutureBucket> fb, Reference<Task> task) { return _finish(tr, tb, fb, task); };
+	};
+	StringRef SkipOldEraseLogRangeTaskFunc::name = LiteralStringRef("dr_skip_legacy_task");
+	const uint32_t SkipOldEraseLogRangeTaskFunc::version = 1;
+	REGISTER_TASKFUNC(SkipOldEraseLogRangeTaskFunc);
+	REGISTER_TASKFUNC_ALIAS(SkipOldEraseLogRangeTaskFunc, db_erase_log_range);
+
+	// This is almost the same as CopyLogRangeTaskFunc in 5.1. The only purpose is to support DR upgrade
+	struct OldCopyLogRangeTaskFunc : TaskFuncBase {
+		static StringRef name;
+		static const uint32_t version;
+
+		static struct {
+			static TaskParam<int64_t> bytesWritten() { return LiteralStringRef(__FUNCTION__); }
+		} Params;
+
+		static const Key keyNextBeginVersion;
+
+		StringRef getName() const { return name; };
+
+		Future<Void> execute(Database cx, Reference<TaskBucket> tb, Reference<FutureBucket> fb, Reference<Task> task) { return _execute(cx, tb, fb, task); };
+		Future<Void> finish(Reference<ReadYourWritesTransaction> tr, Reference<TaskBucket> tb, Reference<FutureBucket> fb, Reference<Task> task) { return _finish(tr, tb, fb, task); };
+
+		ACTOR static Future<Void> dumpData(Database cx, Reference<Task> task, PromiseStream<RCGroup> results, FlowLock* lock, Reference<TaskBucket> tb) {
+			state bool endOfStream = false;
+			state Subspace conf = Subspace(databaseBackupPrefixRange.begin).get(BackupAgentBase::keyConfig).get(task->params[BackupAgentBase::keyConfigLogUid]);
+
+			state std::vector<Standalone<RangeResultRef>> nextMutations;
+			state int64_t nextMutationSize = 0;
+			loop{
+				try {
+					if (endOfStream && !nextMutationSize) {
+						return Void();
+					}
+
+					state std::vector<Standalone<RangeResultRef>> mutations = std::move(nextMutations);
+					state int64_t mutationSize = nextMutationSize;
+					nextMutations = std::vector<Standalone<RangeResultRef>>();
+					nextMutationSize = 0;
+
+					if (!endOfStream) {
+						loop{
+							try {
+								RCGroup group = waitNext(results.getFuture());
+								lock->release(group.items.expectedSize());
+
+								int vecSize = group.items.expectedSize();
+								if (mutationSize + vecSize >= CLIENT_KNOBS->BACKUP_LOG_WRITE_BATCH_MAX_SIZE) {
+
+									nextMutations.push_back(group.items);
+									nextMutationSize = vecSize;
+									break;
+								}
+
+								mutations.push_back(group.items);
+								mutationSize += vecSize;
+							}
+							catch (Error &e) {
+								state Error error = e;
+								if (e.code() == error_code_end_of_stream) {
+									endOfStream = true;
+									break;
+								}
+
+								throw error;
+							}
+						}
+					}
+
+					state Transaction tr(cx);
+
+					loop{
+						try {
+							tr.setOption(FDBTransactionOptions::LOCK_AWARE);
+							tr.options.customTransactionSizeLimit = 2 * CLIENT_KNOBS->TRANSACTION_SIZE_LIMIT;
+							Void _ = wait(checkDatabaseLock(&tr, BinaryReader::fromStringRef<UID>(task->params[BackupAgentBase::keyConfigLogUid], Unversioned())));
+							state int64_t bytesSet = 0;
+
+							bool first = true;
+							for(auto m : mutations) {
+								for(auto kv : m) {
+									if(first) {
+										tr.addReadConflictRange(singleKeyRange(kv.key));
+										first = false;
+									}
+									tr.set(kv.key.removePrefix(backupLogKeys.begin).withPrefix(applyLogKeys.begin), kv.value);
+									bytesSet += kv.expectedSize() - backupLogKeys.begin.expectedSize() + applyLogKeys.begin.expectedSize();
+								}
+							}
+
+							Void _ = wait(tr.commit());
+							Params.bytesWritten().set(task, Params.bytesWritten().getOrDefault(task) + bytesSet);
+							break;
+						}
+						catch (Error &e) {
+							Void _ = wait(tr.onError(e));
+						}
+					}
+				}
+				catch (Error &e) {
+					if (e.code() == error_code_actor_cancelled || e.code() == error_code_backup_error)
+						throw e;
+
+					state Error err = e;
+					Void _ = wait(logError(cx, Subspace(databaseBackupPrefixRange.begin).get(BackupAgentBase::keyErrors).pack(task->params[BackupAgentBase::keyConfigLogUid]), format("ERROR: Failed to dump mutations because of error %s", err.what())));
+
+					throw err;
+				}
+			}
+		}
+
+		ACTOR static Future<Void> _execute(Database cx, Reference<TaskBucket> taskBucket, Reference<FutureBucket> futureBucket, Reference<Task> task) {
+			state Reference<FlowLock> lock(new FlowLock(CLIENT_KNOBS->BACKUP_LOCK_BYTES));
+
+			Void _ = wait(checkTaskVersion(cx, task, OldCopyLogRangeTaskFunc::name, OldCopyLogRangeTaskFunc::version));
+
+			state Version beginVersion = BinaryReader::fromStringRef<Version>(task->params[DatabaseBackupAgent::keyBeginVersion], Unversioned());
+			state Version endVersion = BinaryReader::fromStringRef<Version>(task->params[DatabaseBackupAgent::keyEndVersion], Unversioned());
+			state Version newEndVersion = std::min(endVersion, (((beginVersion-1) / CLIENT_KNOBS->BACKUP_BLOCK_SIZE) + 2 + (g_network->isSimulated() ? CLIENT_KNOBS->BACKUP_SIM_COPY_LOG_RANGES : 0)) * CLIENT_KNOBS->BACKUP_BLOCK_SIZE);
+
+			state Standalone<VectorRef<KeyRangeRef>> ranges = getLogRanges(beginVersion, newEndVersion, task->params[BackupAgentBase::keyConfigLogUid], CLIENT_KNOBS->BACKUP_BLOCK_SIZE);
+			state std::vector<PromiseStream<RCGroup>> results;
+			state std::vector<Future<Void>> rc;
+			state std::vector<Future<Void>> dump;
+
+			for (int i = 0; i < ranges.size(); ++i) {
+				results.push_back(PromiseStream<RCGroup>());
+				rc.push_back(readCommitted(taskBucket->src, results[i], Future<Void>(Void()), lock, ranges[i], decodeBKMutationLogKey, true, true, true));
+				dump.push_back(dumpData(cx, task, results[i], lock.getPtr(), taskBucket));
+			}
+
+			Void _ = wait(waitForAll(dump));
+
+			if (newEndVersion < endVersion) {
+				task->params[OldCopyLogRangeTaskFunc::keyNextBeginVersion] = BinaryWriter::toValue(newEndVersion, Unversioned());
+			}
+
+			return Void();
+		}
+
+		ACTOR static Future<Key> addTask(Reference<ReadYourWritesTransaction> tr, Reference<TaskBucket> taskBucket, Reference<Task> parentTask, Version beginVersion, Version endVersion, TaskCompletionKey completionKey, Reference<TaskFuture> waitFor = Reference<TaskFuture>()) {
+			Key doneKey = wait(completionKey.get(tr, taskBucket));
+			Reference<Task> task(new Task(OldCopyLogRangeTaskFunc::name, OldCopyLogRangeTaskFunc::version, doneKey, 1));
+
+			copyDefaultParameters(parentTask, task);
+
+			task->params[DatabaseBackupAgent::keyBeginVersion] = BinaryWriter::toValue(beginVersion, Unversioned());
+			task->params[DatabaseBackupAgent::keyEndVersion] = BinaryWriter::toValue(endVersion, Unversioned());
+
+			if (!waitFor) {
+				return taskBucket->addTask(tr, task, parentTask->params[Task::reservedTaskParamValidKey], task->params[BackupAgentBase::keyFolderId]);
+			}
+
+			Void _ = wait(waitFor->onSetAddTask(tr, taskBucket, task, parentTask->params[Task::reservedTaskParamValidKey], task->params[BackupAgentBase::keyFolderId]));
+			return LiteralStringRef("OnSetAddTask");
+		}
+
+		ACTOR static Future<Void> _finish(Reference<ReadYourWritesTransaction> tr, Reference<TaskBucket> taskBucket, Reference<FutureBucket> futureBucket, Reference<Task> task) {
+
+			state Version beginVersion = BinaryReader::fromStringRef<Version>(task->params[DatabaseBackupAgent::keyBeginVersion], Unversioned());
+			state Version endVersion = BinaryReader::fromStringRef<Version>(task->params[DatabaseBackupAgent::keyEndVersion], Unversioned());
+			state Reference<TaskFuture> taskFuture = futureBucket->unpack(task->params[Task::reservedTaskParamKeyDone]);
+
+			// Get the bytesWritten parameter from task and atomically add it to the logBytesWritten() property of the DR config.
+			DRConfig config(task);
+			int64_t bytesWritten = Params.bytesWritten().getOrDefault(task);
+			config.logBytesWritten().atomicOp(tr, bytesWritten, MutationRef::AddValue);
+
+			if (task->params.find(OldCopyLogRangeTaskFunc::keyNextBeginVersion) != task->params.end()) {
+				state Version nextVersion = BinaryReader::fromStringRef<Version>(task->params[OldCopyLogRangeTaskFunc::keyNextBeginVersion], Unversioned());
+				Void _ = wait(success(OldCopyLogRangeTaskFunc::addTask(tr, taskBucket, task, nextVersion, endVersion, TaskCompletionKey::signal(taskFuture->key))) && taskBucket->finish(tr, task));
+			}
+			else {
+				Void _ = wait(taskFuture->set(tr, taskBucket) && taskBucket->finish(tr, task));
+			}
+
+			return Void();
+		}
+	};
+	StringRef OldCopyLogRangeTaskFunc::name = LiteralStringRef("db_copy_log_range");
+	const uint32_t OldCopyLogRangeTaskFunc::version = 1;
+	const Key OldCopyLogRangeTaskFunc::keyNextBeginVersion = LiteralStringRef("nextBeginVersion");
+	REGISTER_TASKFUNC(OldCopyLogRangeTaskFunc);
+
+	struct AbortOldBackupTaskFunc : TaskFuncBase {
+		static StringRef name;
+		static const uint32_t version;
+
+		ACTOR static Future<Void> _execute(Database cx, Reference<TaskBucket> taskBucket, Reference<FutureBucket> futureBucket, Reference<Task> task) {
+			state DatabaseBackupAgent srcDrAgent(taskBucket->src);
+			state Reference<ReadYourWritesTransaction> tr(new ReadYourWritesTransaction(cx));
+			state Key tagNameKey;
+
+			loop {
+				try {
+					tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
+ 					tr->setOption(FDBTransactionOptions::LOCK_AWARE);
+					Key tagPath = srcDrAgent.states.get(task->params[DatabaseBackupAgent::keyConfigLogUid]).pack(BackupAgentBase::keyConfigBackupTag);
+					Optional<Key> tagName = wait(tr->get(tagPath));
+					if (!tagName.present()) {
+						return Void();
+					}
+
+					tagNameKey = tagName.get();
+					break;
+				} catch (Error &e) {
+					Void _ = wait(tr->onError(e));
+				}
+			}
+			
+			TraceEvent("DBA_abort_old_backup").detail("tagName", tagNameKey.printable());
+			Void _ = wait(srcDrAgent.abortBackup(cx, tagNameKey, false, true));
+
+			return Void();
+		}
+
+		ACTOR static Future<Void> _finish(Reference<ReadYourWritesTransaction> tr, Reference<TaskBucket> taskBucket, Reference<FutureBucket> futureBucket, Reference<Task> task) {
+			Void _ = wait(taskBucket->finish(tr, task));
+			return Void();
+		}
+
+		ACTOR static Future<Key> addTask(Reference<ReadYourWritesTransaction> tr, Reference<TaskBucket> taskBucket, Reference<Task> parentTask, TaskCompletionKey completionKey, Reference<TaskFuture> waitFor = Reference<TaskFuture>()) {
+			Key doneKey = wait(completionKey.get(tr, taskBucket));
+			Reference<Task> task(new Task(AbortOldBackupTaskFunc::name, AbortOldBackupTaskFunc::version, doneKey, 1));
+
+			copyDefaultParameters(parentTask, task);
+
+			if (!waitFor) {
+				return taskBucket->addTask(tr, task, parentTask->params[Task::reservedTaskParamValidKey], task->params[BackupAgentBase::keyFolderId]);
+			}
+
+			Void _ = wait(waitFor->onSetAddTask(tr, taskBucket, task, parentTask->params[Task::reservedTaskParamValidKey], task->params[BackupAgentBase::keyFolderId]));
+			return LiteralStringRef("OnSetAddTask");
+		}
+
+		StringRef getName() const { return name; };
+
+		Future<Void> execute(Database cx, Reference<TaskBucket> tb, Reference<FutureBucket> fb, Reference<Task> task) { return _execute(cx, tb, fb, task); };
+		Future<Void> finish(Reference<ReadYourWritesTransaction> tr, Reference<TaskBucket> tb, Reference<FutureBucket> fb, Reference<Task> task) { return _finish(tr, tb, fb, task); };
+	};
+	StringRef AbortOldBackupTaskFunc::name = LiteralStringRef("dr_abort_legacy_backup");
+	const uint32_t AbortOldBackupTaskFunc::version = 1;
+	REGISTER_TASKFUNC(AbortOldBackupTaskFunc);
+	REGISTER_TASKFUNC_ALIAS(AbortOldBackupTaskFunc, db_backup_range);
+	REGISTER_TASKFUNC_ALIAS(AbortOldBackupTaskFunc, db_finish_full_backup);
+	REGISTER_TASKFUNC_ALIAS(AbortOldBackupTaskFunc, db_copy_logs);
+	REGISTER_TASKFUNC_ALIAS(AbortOldBackupTaskFunc, db_finished_full_backup);
+	REGISTER_TASKFUNC_ALIAS(AbortOldBackupTaskFunc, db_backup_restorable);
+	REGISTER_TASKFUNC_ALIAS(AbortOldBackupTaskFunc, db_start_full_backup);
+
+	//Upgrade DR from 5.1
+	struct CopyDiffLogsUpgradeTaskFunc : TaskFuncBase {
+		static StringRef name;
+		static const uint32_t version;
+
+		ACTOR static Future<Void> _execute(Database cx, Reference<TaskBucket> taskBucket, Reference<FutureBucket> futureBucket, Reference<Task> task) {
+			state Key logUidValue = task->params[DatabaseBackupAgent::keyConfigLogUid];
+			state Subspace sourceStates = Subspace(databaseBackupPrefixRange.begin).get(BackupAgentBase::keySourceStates).get(logUidValue);
+			state Subspace config = Subspace(databaseBackupPrefixRange.begin).get(BackupAgentBase::keyConfig).get(logUidValue);
+			Void _ = wait(checkTaskVersion(cx, task, CopyDiffLogsUpgradeTaskFunc::name, CopyDiffLogsUpgradeTaskFunc::version));
+
+			// Retrieve backupRanges
+			state Standalone<VectorRef<KeyRangeRef>> backupRanges;
+			state Reference<ReadYourWritesTransaction> tr(new ReadYourWritesTransaction(cx));
+			loop {
+				try {
+					tr->setOption(FDBTransactionOptions::LOCK_AWARE);
+					tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
+					Future<Void> verified = taskBucket->keepRunning(tr, task);
+					Void _ = wait(verified);
+
+					Optional<Key> backupKeysPacked = wait(tr->get(config.pack(BackupAgentBase::keyConfigBackupRanges)));
+					if (!backupKeysPacked.present()) {
+						return Void();
+					}
+
+					BinaryReader br(backupKeysPacked.get(), IncludeVersion());
+					br >> backupRanges;
+					break;
+				} catch(Error &e) {
+					Void _ = wait(tr->onError(e));
+				}
+			}
+
+			// Set destUidValue and versionKey on src side
+			state Key destUidValue(logUidValue);
+			state Reference<ReadYourWritesTransaction> srcTr(new ReadYourWritesTransaction(taskBucket->src));
+			loop {
+				try {
+					srcTr->setOption(FDBTransactionOptions::LOCK_AWARE);
+					srcTr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
+
+					state Optional<Value> v = wait( srcTr->get( sourceStates.pack(DatabaseBackupAgent::keyFolderId) ) );
+					if(v.present() && BinaryReader::fromStringRef<Version>(v.get(), Unversioned()) > BinaryReader::fromStringRef<Version>(task->params[DatabaseBackupAgent::keyFolderId], Unversioned())) {
+						return Void();
+					}
+
+					if (backupRanges.size() == 1) {
+						state Key destUidLookupPath = BinaryWriter::toValue(backupRanges[0], IncludeVersion()).withPrefix(destUidLookupPrefix);
+						Optional<Key> existingDestUidValue = wait(srcTr->get(destUidLookupPath));
+						if (existingDestUidValue.present()) {
+							if (destUidValue == existingDestUidValue.get()) {
+								// due to unknown commit result
+								break;
+							} else {
+								// existing backup/DR is running
+								return Void();
+							}
+						}
+						
+						srcTr->set(destUidLookupPath, destUidValue);
+					}
+
+					Key versionKey = logUidValue.withPrefix(destUidValue).withPrefix(backupLatestVersionsPrefix);
+					srcTr->set(versionKey, task->params[DatabaseBackupAgent::keyBeginVersion]);
+					Void _ = wait(srcTr->commit());
+					break;
+				} catch(Error &e) {
+					Void _ = wait(srcTr->onError(e));
+				}
+			}
+
+			task->params[BackupAgentBase::destUid] = destUidValue;
+			ASSERT(destUidValue == logUidValue);
+
+			return Void();
+		}
+
+
+		ACTOR static Future<Void> _finish(Reference<ReadYourWritesTransaction> tr, Reference<TaskBucket> taskBucket, Reference<FutureBucket> futureBucket, Reference<Task> task) {
+			Void _ = wait(checkTaskVersion(tr, task, CopyDiffLogsUpgradeTaskFunc::name, CopyDiffLogsUpgradeTaskFunc::version));
+			state Reference<TaskFuture> onDone = futureBucket->unpack(task->params[Task::reservedTaskParamKeyDone]);
+
+			if (task->params[BackupAgentBase::destUid].size() == 0) {
+				TraceEvent("DBA_CopyDiffLogsUpgradeTaskFunc_abort_in_upgrade");
+				Key _ = wait(AbortOldBackupTaskFunc::addTask(tr, taskBucket, task, TaskCompletionKey::signal(onDone)));
+			} else {
+				Version beginVersion = BinaryReader::fromStringRef<Version>(task->params[DatabaseBackupAgent::keyBeginVersion], Unversioned());
+				Subspace config = Subspace(databaseBackupPrefixRange.begin).get(BackupAgentBase::keyConfig).get(task->params[DatabaseBackupAgent::keyConfigLogUid]);
+				tr->set(config.pack(BackupAgentBase::destUid), task->params[BackupAgentBase::destUid]);
+				tr->set(config.pack(BackupAgentBase::keyDrVersion), BinaryWriter::toValue(DatabaseBackupAgent::LATEST_DR_VERSION, Unversioned()));
+				Key _ = wait(CopyDiffLogsTaskFunc::addTask(tr, taskBucket, task, 0, beginVersion, TaskCompletionKey::signal(onDone)));
+			}
+
+			Void _ = wait(taskBucket->finish(tr, task));
+			return Void();
+		}
+
+		StringRef getName() const { return name; };
+
+		Future<Void> execute(Database cx, Reference<TaskBucket> tb, Reference<FutureBucket> fb, Reference<Task> task) { return _execute(cx, tb, fb, task); };
+		Future<Void> finish(Reference<ReadYourWritesTransaction> tr, Reference<TaskBucket> tb, Reference<FutureBucket> fb, Reference<Task> task) { return _finish(tr, tb, fb, task); };
+	};
+	StringRef CopyDiffLogsUpgradeTaskFunc::name = LiteralStringRef("db_copy_diff_logs");
+	const uint32_t CopyDiffLogsUpgradeTaskFunc::version = 1;
+	REGISTER_TASKFUNC(CopyDiffLogsUpgradeTaskFunc);
 
 	struct BackupRestorableTaskFunc : TaskFuncBase {
 		static StringRef name;
@@ -1075,7 +1447,7 @@ namespace dbBackup {
 		Future<Void> execute(Database cx, Reference<TaskBucket> tb, Reference<FutureBucket> fb, Reference<Task> task) { return _execute(cx, tb, fb, task); };
 		Future<Void> finish(Reference<ReadYourWritesTransaction> tr, Reference<TaskBucket> tb, Reference<FutureBucket> fb, Reference<Task> task) { return _finish(tr, tb, fb, task); };
 	};
-	StringRef BackupRestorableTaskFunc::name = LiteralStringRef("db_backup_restorable");
+	StringRef BackupRestorableTaskFunc::name = LiteralStringRef("dr_backup_restorable");
 	const uint32_t BackupRestorableTaskFunc::version = 1;
 	REGISTER_TASKFUNC(BackupRestorableTaskFunc);
 
@@ -1087,16 +1459,14 @@ namespace dbBackup {
 			state Key logUidValue = task->params[DatabaseBackupAgent::keyConfigLogUid];
 			state Subspace sourceStates = Subspace(databaseBackupPrefixRange.begin).get(BackupAgentBase::keySourceStates).get(logUidValue);
 			Void _ = wait(checkTaskVersion(cx, task, StartFullBackupTaskFunc::name, StartFullBackupTaskFunc::version));
-
 			state Key destUidValue(logUidValue);
-			state UID logUid = BinaryReader::fromStringRef<UID>(logUidValue, Unversioned());
 
 			state Standalone<VectorRef<KeyRangeRef>> backupRanges = BinaryReader::fromStringRef<Standalone<VectorRef<KeyRangeRef>>>(task->params[DatabaseBackupAgent::keyConfigBackupRanges], IncludeVersion());
 			state Key beginVersionKey;
 
 			state Reference<ReadYourWritesTransaction> srcTr(new ReadYourWritesTransaction(taskBucket->src));
 			loop {
-				try {					
+				try {
 					srcTr->setOption(FDBTransactionOptions::LOCK_AWARE);
 					srcTr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
 
@@ -1251,15 +1621,44 @@ namespace dbBackup {
 		Future<Void> execute(Database cx, Reference<TaskBucket> tb, Reference<FutureBucket> fb, Reference<Task> task) { return _execute(cx, tb, fb, task); };
 		Future<Void> finish(Reference<ReadYourWritesTransaction> tr, Reference<TaskBucket> tb, Reference<FutureBucket> fb, Reference<Task> task) { return _finish(tr, tb, fb, task); };
 	};
-	StringRef StartFullBackupTaskFunc::name = LiteralStringRef("db_start_full_backup");
+	StringRef StartFullBackupTaskFunc::name = LiteralStringRef("dr_start_full_backup");
 	const uint32_t StartFullBackupTaskFunc::version = 1;
 	REGISTER_TASKFUNC(StartFullBackupTaskFunc);
-
 }
 
 class DatabaseBackupAgentImpl {
 public:
 	static const int MAX_RESTORABLE_FILE_METASECTION_BYTES = 1024 * 8;
+
+	ACTOR static Future<Void> waitUpgradeToLatestDrVersion(DatabaseBackupAgent* backupAgent, Database cx, Key tagName) {
+		state UID logUid = wait(backupAgent->getLogUid(cx, tagName));
+		state Key drVersionKey = backupAgent->config.get(BinaryWriter::toValue(logUid, Unversioned())).pack(DatabaseBackupAgent::keyDrVersion);
+
+		TraceEvent("DRU_watchLatestDrVersion").detail("drVersionKey", drVersionKey.printable()).detail("logUid", BinaryWriter::toValue(logUid, Unversioned()).printable());
+
+		loop {
+			state Reference<ReadYourWritesTransaction> tr(new ReadYourWritesTransaction(cx));
+
+			loop {
+				try {
+					tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
+					tr->setOption(FDBTransactionOptions::LOCK_AWARE);
+					Optional<Value> drVersion = wait(tr->get(drVersionKey));
+
+					if (drVersion.present() && BinaryReader::fromStringRef<int>(drVersion.get(), Unversioned()) == DatabaseBackupAgent::LATEST_DR_VERSION) {
+						return Void();
+					}
+
+					state Future<Void> watchDrVersionFuture = tr->watch(drVersionKey);
+					Void _ = wait(tr->commit());
+					Void _ = wait(watchDrVersionFuture);
+					break;
+				} catch (Error &e) {
+					Void _ = wait(tr->onError(e));
+				}
+			}
+		}
+	}
 
 	// This method will return the final status of the backup
 	ACTOR static Future<int> waitBackup(DatabaseBackupAgent* backupAgent, Database cx, Key tagName, bool stopWhenDone) {
@@ -1387,6 +1786,7 @@ public:
 
 		// Clear DRConfig for this UID, which unfortunately only contains some newer vars and not the stuff below.
 		DRConfig(logUid).clear(tr);
+		tr->set(backupAgent->config.get(logUidValue).pack(DatabaseBackupAgent::keyDrVersion), BinaryWriter::toValue(DatabaseBackupAgent::LATEST_DR_VERSION, Unversioned()));
 		tr->set(backupAgent->config.get(logUidValue).pack(DatabaseBackupAgent::keyAddPrefix), addPrefix);
 		tr->set(backupAgent->config.get(logUidValue).pack(DatabaseBackupAgent::keyRemovePrefix), removePrefix);
 		tr->set(backupAgent->states.get(logUidValue).pack(DatabaseBackupAgent::keyConfigBackupTag), tagName);
@@ -1574,7 +1974,7 @@ public:
 		return Void();
 	}
 
-	ACTOR static Future<Void> abortBackup(DatabaseBackupAgent* backupAgent, Database cx, Key tagName, bool partial) {
+	ACTOR static Future<Void> abortBackup(DatabaseBackupAgent* backupAgent, Database cx, Key tagName, bool partial, bool abortOldBackup) {
 		state Reference<ReadYourWritesTransaction> tr(new ReadYourWritesTransaction(cx));
 		state Key logUidValue, destUidValue;
 		state UID logUid, destUid;
@@ -1685,6 +2085,14 @@ public:
 					break;
 				}
 
+				if (abortOldBackup) {
+					srcTr->set( backupAgent->sourceStates.pack(DatabaseBackupAgent::keyStateStatus), StringRef(BackupAgentBase::getStateText(BackupAgentBase::STATE_ABORTED) ));
+					srcTr->set( backupAgent->sourceStates.get(logUidValue).pack(DatabaseBackupAgent::keyFolderId), backupUid );
+					srcTr->clear(prefixRange(logUidValue.withPrefix(backupLogKeys.begin)));
+					srcTr->clear(prefixRange(logUidValue.withPrefix(logRangesRange.begin)));
+					break;
+				}
+
 				Key latestVersionKey = logUidValue.withPrefix(destUidValue.withPrefix(backupLatestVersionsPrefix));
 
 				Optional<Key> bVersion = wait(srcTr->get(latestVersionKey));
@@ -1700,7 +2108,7 @@ public:
 
 				Void _ = wait(srcTr->commit());
 				endVersion = srcTr->getCommittedVersion() + 1;
-				
+
 				break;
 			}
 			catch (Error &e) {
@@ -1708,7 +2116,7 @@ public:
 			}
 		}
 
-		if (clearSrcDb) {
+		if (clearSrcDb && !abortOldBackup) {
 			Void _ = wait(eraseLogData(backupAgent->taskBucket->src, logUidValue, destUidValue));
 		}
 
@@ -1899,8 +2307,8 @@ Future<Void> DatabaseBackupAgent::discontinueBackup(Reference<ReadYourWritesTran
 	return DatabaseBackupAgentImpl::discontinueBackup(this, tr, tagName);
 }
 
-Future<Void> DatabaseBackupAgent::abortBackup(Database cx, Key tagName, bool partial){
-	return DatabaseBackupAgentImpl::abortBackup(this, cx, tagName, partial);
+Future<Void> DatabaseBackupAgent::abortBackup(Database cx, Key tagName, bool partial, bool abortOldBackup){
+	return DatabaseBackupAgentImpl::abortBackup(this, cx, tagName, partial, abortOldBackup);
 }
 
 Future<std::string> DatabaseBackupAgent::getStatus(Database cx, int errorLimit, Key tagName) {
@@ -1917,6 +2325,10 @@ Future<UID> DatabaseBackupAgent::getDestUid(Reference<ReadYourWritesTransaction>
 
 Future<UID> DatabaseBackupAgent::getLogUid(Reference<ReadYourWritesTransaction> tr, Key tagName) {
 	return DatabaseBackupAgentImpl::getLogUid(this, tr, tagName);
+}
+
+Future<Void> DatabaseBackupAgent::waitUpgradeToLatestDrVersion(Database cx, Key tagName) {
+	return DatabaseBackupAgentImpl::waitUpgradeToLatestDrVersion(this, cx, tagName);
 }
 
 Future<int> DatabaseBackupAgent::waitBackup(Database cx, Key tagName, bool stopWhenDone) {

--- a/fdbclient/vexillographer/fdb.options
+++ b/fdbclient/vexillographer/fdb.options
@@ -142,7 +142,6 @@ description is not currently required but encouraged.
             description="Deprecated" />
     <Option name="durability_datacenter" code="110" />
     <Option name="durability_risky" code="120" />
-    <Option name="durability_dev_null_is_web_scale" code="130" />
     <Option name="priority_system_immediate" code="200"
             description="Specifies that this transaction should be treated as highest priority and that lower priority transactions should block behind this one. Use is discouraged outside of low-level tools" />
     <Option name="priority_batch" code="201"

--- a/fdbserver/SimulatedCluster.actor.cpp
+++ b/fdbserver/SimulatedCluster.actor.cpp
@@ -594,7 +594,7 @@ ACTOR Future<Void> simulatedMachine(
 #include "fdbclient/MonitorLeader.h"
 
 ACTOR Future<Void> restartSimulatedSystem(vector<Future<Void>> *systemActors, std::string baseFolder,
-										  int* pTesterCount, Optional<ClusterConnectionString> *pConnString) {
+										  int* pTesterCount, Optional<ClusterConnectionString> *pConnString, int extraDB) {
 	CSimpleIni ini;
 	ini.SetUnicode();
 	ini.LoadFile(joinPath(baseFolder, "restartInfo.ini").c_str());
@@ -607,7 +607,11 @@ ACTOR Future<Void> restartSimulatedSystem(vector<Future<Void>> *systemActors, st
 		int processesPerMachine = atoi(ini.GetValue("META", "processesPerMachine"));
 		int desiredCoordinators = atoi(ini.GetValue("META", "desiredCoordinators"));
 		int testerCount = atoi(ini.GetValue("META", "testerCount"));
+		bool enableExtraDB = (extraDB == 3);
 		ClusterConnectionString conn(ini.GetValue("META", "connectionString"));
+		if (enableExtraDB) {
+			g_simulator.extraDB = new ClusterConnectionString(ini.GetValue("META", "connectionString"));
+		}
 		*pConnString = conn;
 		*pTesterCount = testerCount;
 		bool usingSSL = conn.toString().find(":tls") != std::string::npos;
@@ -641,8 +645,9 @@ ACTOR Future<Void> restartSimulatedSystem(vector<Future<Void>> *systemActors, st
 			LocalityData	localities(Optional<Standalone<StringRef>>(), zoneId, zoneId, dcUID);
 			localities.set(LiteralStringRef("data_hall"), dcUID);
 
+			// SOMEDAY: parse backup agent from test file
 			systemActors->push_back( reportErrors( simulatedMachine(
-				conn, ipAddrs, usingSSL, localities, processClass, baseFolder, true, i == useSeedForMachine, false ),
+				conn, ipAddrs, usingSSL, localities, processClass, baseFolder, true, i == useSeedForMachine, enableExtraDB ),
 				processClass == ProcessClass::TesterClass ? "SimulatedTesterMachine" : "SimulatedMachine") );
 		}
 
@@ -978,7 +983,7 @@ void setupSimulatedSystem( vector<Future<Void>> *systemActors, std::string baseF
 
 	ASSERT( coordinatorAddresses.size() == coordinatorCount );
 	ClusterConnectionString conn(coordinatorAddresses, LiteralStringRef("TestCluster:0"));
-	
+
 	// If extraDB==0, leave g_simulator.extraDB as null because the test does not use DR.
 	if(extraDB==1) {
 		// The DR database can be either a new database or itself
@@ -990,7 +995,7 @@ void setupSimulatedSystem( vector<Future<Void>> *systemActors, std::string baseF
 		// The DR database is the same database
 		g_simulator.extraDB = new ClusterConnectionString(coordinatorAddresses, LiteralStringRef("TestCluster:0"));
 	}
-	
+
 	*pConnString = conn;
 
 	TraceEvent("SimulatedConnectionString").detail("String", conn.toString()).detail("ConfigString", printable(StringRef(startingConfigString)));
@@ -1159,7 +1164,7 @@ ACTOR void setupAndRun(std::string dataFolder, const char *testFile, bool reboot
 	try {
 		//systemActors.push_back( startSystemMonitor(dataFolder) );
 		if (rebooting) {
-			Void _ = wait( timeoutError( restartSimulatedSystem( &systemActors, dataFolder, &testerCount, &connFile), 100.0 ) );
+			Void _ = wait( timeoutError( restartSimulatedSystem( &systemActors, dataFolder, &testerCount, &connFile, extraDB), 100.0 ) );
 		}
 		else {
 			g_expect_full_pointermap = 1;

--- a/flow/Platform.cpp
+++ b/flow/Platform.cpp
@@ -2645,6 +2645,28 @@ void setupSlowTaskProfiler() {
 #endif
 }
 
+#ifdef __linux__
+// There's no good place to put this, so it's here.
+// Ubuntu's packaging of libstdc++_pic offers different symbols than libstdc++.  Go figure.
+// Notably, it's missing a definition of std::istream::ignore(long), which causes compilation errors
+// in the bindings.  Thus, we provide weak versions of their definitions, so that if the
+// linked-against libstdc++ is missing their definitions, we'll be able to use the provided
+// ignore(long, int) version.
+#include <istream>
+namespace std {
+typedef basic_istream<char, std::char_traits<char>> char_basic_istream;
+template <>
+char_basic_istream& __attribute__((weak)) char_basic_istream::ignore(streamsize count) {
+  return ignore(count, std::char_traits<char>::eof());
+}
+typedef basic_istream<wchar_t, std::char_traits<wchar_t>> wchar_basic_istream;
+template <>
+wchar_basic_istream& __attribute__((weak)) wchar_basic_istream::ignore(streamsize count) {
+  return ignore(count, std::char_traits<wchar_t>::eof());
+}
+}
+#endif
+
 // UnitTest for getMemoryInfo
 #ifdef __linux__
 TEST_CASE("flow/Platform/getMemoryInfo") {

--- a/packaging/msi/FDBInstaller.wxs
+++ b/packaging/msi/FDBInstaller.wxs
@@ -99,9 +99,6 @@
             <CreateFolder />
                   <Environment Action='set' Name='FOUNDATIONDB_INSTALL_PATH' Value='[INSTALLDIR]' Part='all' Id='InstallPathSetEnvVar' System='yes' Permanent='no' />
           </Component>
-          <Component Id='LicenseFiles' Guid='{071FFA9B-EDE5-42E3-A8EC-B9AFA6B260D2}' Win64='yes'>
-            <File Id='README' Name='README.txt' DiskId='1' Source='$(var.SolutionRoot)README.md'/>
-          </Component>
           <Directory Id='IncludeDir' Name='include'>
             <Directory Id='IncludeFDBDir' Name='foundationdb'>
               <Component Id='FDBCLibraryHeader' Guid='{32D846FA-3BA8-4CF6-8777-51DFA1011198}' Win64='yes'>
@@ -301,7 +298,6 @@
         <ComponentRef Id='CreateClusterFileDir'/>  <!-- In a client only install, we don't make any files here, but want it to be easy to drop fdb.cluster here -->
         <ComponentRef Id='PathAddition'/>
         <ComponentRef Id='InstallPathEnvVar'/>
-        <ComponentRef Id='LicenseFiles'/>
         <ComponentRef Id='FDBCLibraryPFiles' />
         <ComponentRef Id='FDBCLibraryHeader'/>
         <ComponentRef Id='FDBCLibraryLib' />
@@ -393,7 +389,20 @@
               Value="Thank you for installing FoundationDB. For documentation, please visit https://apple.github.io/foundationdb/index.html#documentation.
 
 To allow path variables to update, please restart your IDE and any open terminal sessions." />
+
     <UIRef Id='WixUI_FeatureTree' />
+    <UI>
+      <Publish Dialog="WelcomeDlg"
+            Control="Next"
+            Event="NewDialog"
+            Value="FeaturesDlg"
+            Order="2">1</Publish>
+      <Publish Dialog="FeaturesDlg"
+            Control="Back"
+            Event="NewDialog"
+            Value="WelcomeDlg"
+            Order="2">1</Publish>
+    </UI>
     <UIRef Id='WixUI_ErrorProgressText' />
 
     <WixVariable Id="WixUIDialogBmp" Value="$(var.ProjectRoot)\art\dialog.jpg" />

--- a/tests/restarting/from_5.1.7/DrUpgradeRestart-1.txt
+++ b/tests/restarting/from_5.1.7/DrUpgradeRestart-1.txt
@@ -1,0 +1,19 @@
+testTitle=DrUpgrade
+    testName=Cycle
+    nodeCount=30000
+    transactionsPerSecond=2500.0
+    testDuration=30.0
+    expectedRate=0
+    clearAfterTest=false
+
+    testName=BackupToDBUpgrade
+    backupAfter=10.0
+    stopDifferentialAfter=50.0
+    clearAfterTest=false
+    simBackupAgents=BackupToDB
+    backupRangesCount=-1
+    extraDB=3
+    
+    testName=SaveAndKill
+    restartInfoLocation=simfdb/restartInfo.ini
+    testDuration=40.0

--- a/tests/restarting/from_5.1.7/DrUpgradeRestart-2.txt
+++ b/tests/restarting/from_5.1.7/DrUpgradeRestart-2.txt
@@ -1,0 +1,18 @@
+testTitle=DrUpgrade
+    testName=Cycle
+    runSetup=false
+    nodeCount=30000
+    transactionsPerSecond=2500.0
+    testDuration=30.0
+    expectedRate=0
+    clearAfterTest=false
+
+    testName=BackupToDBUpgrade
+    runSetup=false
+    backupAfter=10.0
+    clearAfterTest=false
+    simBackupAgents=BackupToDB
+    backupRangesCount=-1
+    stopDifferentialAfter=70.0
+    extraDB=3
+    waitForQuiescenceBegin=false


### PR DESCRIPTION
This merges in the changes from release-5.2 into master. Some of these are changes that were merged in from release-5.1. The majority of those were actually already on master and then had been cherry picked back, so they shouldn't actually do anything to this PR.

This PR also updates the generated.go file for master to match its fdb.options file. I think we ran into problems where they were out of sync earlier, so I figured getting them in sync was a worthy goal. I think we had discussed that maybe the "first_in_batch" option, which is the option that was missing, is one that we might want to be hidden, so maybe the correct thing to do is to update fdb.options instead. In any case, they should be consistent.