### PR TITLE
Extend Subspace interface with a PrefixRange method.

### DIFF
--- a/bindings/go/src/fdb/directory/directoryPartition.go
+++ b/bindings/go/src/fdb/directory/directoryPartition.go
@@ -65,6 +65,10 @@ func (dp directoryPartition) FDBRangeKeySelectors() (fdb.Selectable, fdb.Selecta
 	panic("cannot get range for the root of a directory partition")
 }
 
+func (dp directoryPartition) PrefixRange(t tuple.Tuple) (fdb.KeyRange, error) {
+	panic("cannot get range for the root of a directory partition")
+}
+
 func (dp directoryPartition) GetLayer() []byte {
 	return []byte("partition")
 }

--- a/bindings/go/src/fdb/range.go
+++ b/bindings/go/src/fdb/range.go
@@ -311,7 +311,7 @@ func PrefixRange(prefix []byte) (KeyRange, error) {
 	copy(begin, prefix)
 	end, e := Strinc(begin)
 	if e != nil {
-		return KeyRange{}, nil
+		return KeyRange{}, e
 	}
 	return KeyRange{Key(begin), Key(end)}, nil
 }


### PR DESCRIPTION
This makes it possible to do a simple prefix search  using a subspace:

```go
    courseSS = schedulingDir.Sub("class")
    r, e := courseSS.PrefixRange(tuple.Tuple{[]byte("101-")})
    iterator := tr.GetRange(r, fdb.RangeOptions{}).Iterator()
```