### PR TITLE
Fix the other half of simulation requiring a TLS Plugin.

### DIFF
--- a/fdbrpc/TLSConnection.actor.cpp
+++ b/fdbrpc/TLSConnection.actor.cpp
@@ -250,6 +250,8 @@ void TLSOptions::set_verify_peers( std::string const& verify_peers ) {
 }
 
 void TLSOptions::register_network() {
+	// Simulation relies upon being able to call this multiple times, and have it override g_network
+	// each time it's called.
 	new TLSNetworkConnections( Reference<TLSOptions>::addRef( this ) );
 }
 

--- a/fdbrpc/TLSConnection.h
+++ b/fdbrpc/TLSConnection.h
@@ -124,7 +124,7 @@ private:
 #define TLS_VERIFY_PEERS_FLAG "--tls_verify_peers"
 
 #define TLS_OPTION_FLAGS \
-	{ TLSOptions::OPT_TLS_PLUGIN,       TLS_PLUGIN_FLAG,           SO_REQ_SEP }, \
+	{ TLSOptions::OPT_TLS_PLUGIN,       TLS_PLUGIN_FLAG,           SO_OPT }, \
 	{ TLSOptions::OPT_TLS_CERTIFICATES, TLS_CERTIFICATE_FILE_FLAG, SO_REQ_SEP }, \
 	{ TLSOptions::OPT_TLS_KEY,          TLS_KEY_FILE_FLAG,         SO_REQ_SEP }, \
 	{ TLSOptions::OPT_TLS_VERIFY_PEERS, TLS_VERIFY_PEERS_FLAG,     SO_REQ_SEP },

--- a/fdbserver/SimulatedCluster.h
+++ b/fdbserver/SimulatedCluster.h
@@ -18,10 +18,12 @@
  * limitations under the License.
  */
 
+#include "fdbrpc/TLSConnection.h"
+
 #ifndef FDBSERVER_SIMULATEDCLUSTER_H
 #define FDBSERVER_SIMULATEDCLUSTER_H
 #pragma once
 
-void setupAndRun(std::string const& dataFolder, const char* const& testFile, bool const& rebooting, bool const& useSSL);
+void setupAndRun(std::string const& dataFolder, const char* const& testFile, bool const& rebooting, Reference<TLSOptions> const& useSSL);
 
 #endif

--- a/fdbserver/fdbserver.actor.cpp
+++ b/fdbserver/fdbserver.actor.cpp
@@ -1192,7 +1192,8 @@ int main(int argc, char* argv[]) {
 					break;
 				case TLSOptions::OPT_TLS_PLUGIN:
 					try {
-						tlsOptions->set_plugin_name_or_path( args.OptionArg() );
+						const char* plugin_path = args.OptionArg();
+						tlsOptions->set_plugin_name_or_path( plugin_path ? plugin_path : "" );
 					} catch (Error& e) {
 						fprintf(stderr, "ERROR: cannot load TLS plugin `%s' (%s)\n", args.OptionArg(), e.what());
 						printHelpTeaser(argv[0]);
@@ -1471,8 +1472,7 @@ int main(int argc, char* argv[]) {
 			if ( tlsVerifyPeers.size() )
 				tlsOptions->set_verify_peers( tlsVerifyPeers );
 
-			if (tlsOptions->get_policy())
-				tlsOptions->register_network();
+			tlsOptions->register_network();
 
 			if (role == FDBD || role == NetworkTestServer) {
 				try {
@@ -1586,7 +1586,7 @@ int main(int argc, char* argv[]) {
 				platform::createDirectory( dataFolder );
 			}
 
-			setupAndRun( dataFolder, testFile, restarting, tlsOptions->enabled() );
+			setupAndRun( dataFolder, testFile, restarting, tlsOptions );
 			g_simulator.run();
 		} else if (role == FDBD) {
 			ASSERT( connectionFile );


### PR DESCRIPTION
This commit:
1. Restores --tls_plugin as a way to provide the path to the TLS plugin when running in simulation.
2. Removes the TLS Plugin as being required for 5% of tests.
3. Standardizes on 'sslEnabled' as a variable name.

And is a fix/improvement upon commit f7733d1b.

(1) previously didn't work, because we would create multiple new TLSOptions
instances and run init_plugin multiple times.  Only the first call would use
the argument specified on the command line.  To fix this, the TLSOptions
derived from the command line is threaded through all the simulation code that
needs it.

(2) was an oversight in f7733d1b, which didn't actually make "should we be TLS"
dependant on if the TLS plugin was available or not.

(3) is just nice for trying to grep around in the codebase.