### PR TITLE
Add comment explaining synchronization behavior in high contention allocator

### DIFF
--- a/bindings/java/src/main/com/apple/foundationdb/directory/DirectoryLayer.java
+++ b/bindings/java/src/main/com/apple/foundationdb/directory/DirectoryLayer.java
@@ -1037,7 +1037,8 @@ public class DirectoryLayer implements Directory {
 				CompletableFuture<byte[]> newCountRead;
 				// SOMEDAY: this code would work as written if synchronized on something transaction local.
 				// The reason we don't synchronize on the Transaction tr itself is that the user could also be using it 
-				// for synchronization.
+				// for synchronization. If they did, then synchronizing on tr here could lead to performance issues or 
+				// deadlocks.
 				synchronized(HighContentionAllocator.class) {
 					if(windowStart > initialWindowStart) {
 						tr.clear(oldCounters);
@@ -1077,7 +1078,8 @@ public class DirectoryLayer implements Directory {
 				CompletableFuture<byte[]> allocationTemp;
 				// SOMEDAY: this code would work as written if synchronized on something transaction local.
 				// The reason we don't synchronize on the Transaction tr itself is that the user could also be using it 
-				// for synchronization.
+				// for synchronization. If they did, then synchronizing on tr here could lead to performance issues or 
+				// deadlocks.
 				synchronized(HighContentionAllocator.class) {
 					counterRange = tr.snapshot().getRange(countersRange, 1, true);
 					allocationTemp = tr.get(allocationKey);

--- a/bindings/java/src/main/com/apple/foundationdb/directory/DirectoryLayer.java
+++ b/bindings/java/src/main/com/apple/foundationdb/directory/DirectoryLayer.java
@@ -1035,7 +1035,9 @@ public class DirectoryLayer implements Directory {
 				Range oldAllocations = new Range(allocator.recent.getKey(), allocator.recent.get(windowStart).getKey());
 
 				CompletableFuture<byte[]> newCountRead;
-				// SOMEDAY: synchronize on something transaction local
+				// SOMEDAY: this code would work as written if synchronized on something transaction local.
+				// The reason we don't synchronize on the Transaction tr itself is that the user could also be using it 
+				// for synchronization.
 				synchronized(HighContentionAllocator.class) {
 					if(windowStart > initialWindowStart) {
 						tr.clear(oldCounters);
@@ -1073,7 +1075,9 @@ public class DirectoryLayer implements Directory {
 
 				AsyncIterable<KeyValue> counterRange;
 				CompletableFuture<byte[]> allocationTemp;
-				// SOMEDAY: synchronize on something transaction local
+				// SOMEDAY: this code would work as written if synchronized on something transaction local.
+				// The reason we don't synchronize on the Transaction tr itself is that the user could also be using it 
+				// for synchronization.
 				synchronized(HighContentionAllocator.class) {
 					counterRange = tr.snapshot().getRange(countersRange, 1, true);
 					allocationTemp = tr.get(allocationKey);


### PR DESCRIPTION
Add a note about why the high-contention allocator synchronizes on HighContentionAllocator.class rather than Transaction.