### PR TITLE
fdb_c test fixes

### DIFF
--- a/bindings/c/test/performance_test.c
+++ b/bindings/c/test/performance_test.c
@@ -44,7 +44,6 @@ fdb_error_t waitError(FDBFuture *f) {
 
 struct RunResult run(struct ResultSet *rs, FDBDatabase *db, struct RunResult (*func)(struct ResultSet*, FDBTransaction*)) {
 	FDBTransaction *tr = NULL;
-	checkError(fdb_database_create_transaction(db, &tr), "create transaction", rs);
 	fdb_error_t e = fdb_database_create_transaction(db, &tr);
 	checkError(e, "create transaction", rs);
 
@@ -62,9 +61,11 @@ struct RunResult run(struct ResultSet *rs, FDBDatabase *db, struct RunResult (*f
 			fdb_error_t retryE = waitError(f);
 			fdb_future_destroy(f);
 			if (retryE) {
+				fdb_transaction_destroy(tr);
 				return (struct RunResult) {0, retryE};
 			}
 		} else {
+			fdb_transaction_destroy(tr);
 			return r;
 		}
 	}

--- a/bindings/c/test/ryw_benchmark.c
+++ b/bindings/c/test/ryw_benchmark.c
@@ -236,6 +236,7 @@ void runTests(struct ResultSet *rs) {
 	runTest(&clearRangeGetRange, tr, rs, "C: get range cached values with clear ranges throughput");
 	runTest(&interleavedSetsGets, tr, rs, "C: interleaved sets and gets on a single key throughput");
 
+	fdb_transaction_destroy(tr);
 	fdb_database_destroy(db);
 	fdb_stop_network();
 }


### PR DESCRIPTION
Remove extra call to create transaction. Cleanup created transactions.