### PR TITLE
Use abspath when dealing with the simulator file-cache

### DIFF
--- a/fdbrpc/sim2.actor.cpp
+++ b/fdbrpc/sim2.actor.cpp
@@ -1706,7 +1706,7 @@ Future< Reference<class IAsyncFile> > Sim2FileSystem::open( std::string filename
 
 	if (flags & IAsyncFile::OPEN_UNCACHED) {
 		auto& machineCache = g_simulator.getCurrentProcess()->machine->openFiles;
-		std::string actualFilename = filename;
+		std::string actualFilename = abspath(filename);
 		if ( machineCache.find(filename) == machineCache.end() ) {
 			if(flags & IAsyncFile::OPEN_ATOMIC_WRITE_AND_CREATE) {
 				actualFilename = filename + ".part";
@@ -1734,7 +1734,7 @@ Future< Reference<class IAsyncFile> > Sim2FileSystem::open( std::string filename
 // Deletes the given file.  If mustBeDurable, returns only when the file is guaranteed to be deleted even after a power failure.
 Future< Void > Sim2FileSystem::deleteFile( std::string filename, bool mustBeDurable )
 {
-	return Sim2::deleteFileImpl(&g_sim2, filename, mustBeDurable);
+	return Sim2::deleteFileImpl(&g_sim2, abspath(filename), mustBeDurable);
 }
 
 void Sim2FileSystem::newFileSystem()


### PR DESCRIPTION
The simulator uses a hash table to cache all open files to make sure
that several simulated processes don't open the file more than once.
This currently doesn't work properly and deleted files are often kept
open forever. As a result, we often ran out of file descriptors.

The problem is luckily quite simple: files are often opened with an
absolute path but later a relativ path is passed for deletion. This
is not working because the map that is used to store the file
descriptors is not aware of paths - so deleted files are often not
removed from this map. The fix that works for us is to just always
work with absolute paths when adding and removing files from this map.