### PR TITLE
Improvements to fdb-go-install.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,11 @@ ifeq ($(MONO),)
   MONO := /usr/bin/mono
 endif
 
-MCS := $(shell which dmcs)
+DMCS := $(shell which dmcs)
+MCS := $(shell which mcs)
+ifneq ($(DMCS),)
+  MCS := $(DMCS)
+endif
 ifeq ($(MCS),)
   MCS := /usr/bin/dmcs
 endif

--- a/bindings/go/fdb-go-install.sh
+++ b/bindings/go/fdb-go-install.sh
@@ -221,7 +221,7 @@ else
                 fi
             else
                 echo "Downloading foundation repository into ${destdir}:"
-                cmd=( 'git' '-C' "${destdir}" 'clone' '--branch' "release-${FDBVER}" "git@${REMOTE}:${FDBREPO}.git" )
+                cmd=( 'git' '-C' "${destdir}" 'clone' '--branch' "release-${FDBVER}" "https://${REMOTE}/${FDBREPO}.git" )
 
                 echo "${cmd[*]}"
                 if ! "${cmd[@]}" ; then

--- a/bindings/go/fdb-go-install.sh
+++ b/bindings/go/fdb-go-install.sh
@@ -23,8 +23,32 @@ if [[ "${platform}" == "Darwin" ]] ; then
     FDBLIBDIR="${FDBLIBDIR:-/usr/local/lib}"
     libfdbc="libfdb_c.dylib"
 elif [[ "${platform}" == "Linux" ]] ; then
-    FDBLIBDIR="${FDBLIBDIR:-/usr/lib}"
     libfdbc="libfdb_c.so"
+    custom_libdir="${FDBLIBDIR:-}"
+    FDBLIBDIR=""
+
+    if [[ -z "${custom_libdir}" ]]; then
+	search_libdirs=( '/usr/lib' '/usr/lib64' )
+    else
+	search_libdirs=( "${custom_libdir}" )
+    fi
+
+    for libdir in "${search_libdirs[@]}" ; do
+        if [[ -e "${libdir}/${libfdbc}" ]]; then
+            FDBLIBDIR="${libdir}"
+            break
+        fi
+    done
+
+    if [[ -z "${FDBLIBDIR}" ]]; then
+        echo "The FoundationDB C library could not be found in any of:"
+        for libdir in "${search_libdirs[@]}" ; do
+            echo "   ${libdir}"
+        done
+        echo "Your installation may be incomplete, or you need to set a custom FDBLIBDIR."
+        let status="${status} + 1"
+    fi
+
 else
     echo "Unsupported platform ${platform}".
     echo "At the moment, only macOS and Linux are supported by this script."
@@ -277,13 +301,7 @@ else
             cgo_ldflags="-L${FDBLIBDIR}"
             fdb_go_path="${REMOTE}/${FDBREPO}/bindings/go/src"
 
-            if [[ ! -e "${FDBLIBDIR}/${libfdbc}" ]] ; then
-                # Just a warning. Don't fail script.
-                echo
-                echo "WARNING: The FoundationDB C library was not found within ${FDBLIBDIR}."
-                echo "Your installation may be incomplete."
-                echo
-            elif ! CGO_CPPFLAGS="${cgo_cppflags}" CGO_CFLAGS="${cgo_cflags}" CGO_LDFLAGS="${cgo_ldflags}" go install "${fdb_go_path}/fdb" "${fdb_go_path}/fdb/tuple" "${fdb_go_path}/fdb/subspace" "${fdb_go_path}/fdb/directory" ; then
+            if ! CGO_CPPFLAGS="${cgo_cppflags}" CGO_CFLAGS="${cgo_cflags}" CGO_LDFLAGS="${cgo_ldflags}" go install "${fdb_go_path}/fdb" "${fdb_go_path}/fdb/tuple" "${fdb_go_path}/fdb/subspace" "${fdb_go_path}/fdb/directory" ; then
                 let status="${status} + 1"
                 echo "Could not build FoundationDB go libraries."
             fi

--- a/bindings/go/fdb-go-install.sh
+++ b/bindings/go/fdb-go-install.sh
@@ -272,8 +272,9 @@ else
             # Do not install if only downloading
             :
         elif [[ "${status}" -eq 0 ]] ; then
-            cgo_cflags="-g -O2 -I${linkpath}/bindings/c"
-            cgo_ldflags="-g -O2 -L${FDBLIBDIR}"
+            cgo_cppflags="-I${linkpath}/bindings/c"
+            cgo_cflags="-g -O2"
+            cgo_ldflags="-L${FDBLIBDIR}"
             fdb_go_path="${REMOTE}/${FDBREPO}/bindings/go/src"
 
             if [[ ! -e "${FDBLIBDIR}/${libfdbc}" ]] ; then
@@ -282,7 +283,7 @@ else
                 echo "WARNING: The FoundationDB C library was not found within ${FDBLIBDIR}."
                 echo "Your installation may be incomplete."
                 echo
-            elif ! CGO_CFLAGS="${cgo_cflags}" CGO_LDFLAGS="${cgo_ldflags}" go install "${fdb_go_path}/fdb" "${fdb_go_path}/fdb/tuple" "${fdb_go_path}/fdb/subspace" "${fdb_go_path}/fdb/directory" ; then
+            elif ! CGO_CPPFLAGS="${cgo_cppflags}" CGO_CFLAGS="${cgo_cflags}" CGO_LDFLAGS="${cgo_ldflags}" go install "${fdb_go_path}/fdb" "${fdb_go_path}/fdb/tuple" "${fdb_go_path}/fdb/subspace" "${fdb_go_path}/fdb/directory" ; then
                 let status="${status} + 1"
                 echo "Could not build FoundationDB go libraries."
             fi
@@ -295,6 +296,7 @@ else
             echo "The FoundationDB go bindings were successfully installed."
             echo "To build packages which use the go bindings, you will need to"
             echo "set the following environment variables:"
+            echo "   CGO_CPPFLAGS=\"${cgo_cppflags}\""
             echo "   CGO_CFLAGS=\"${cgo_cflags}\""
             echo "   CGO_LDFLAGS=\"${cgo_ldflags}\""
         fi


### PR DESCRIPTION
Installing the Go bindings on CentOS 7 was a bumpy ride, so here's a few improvements to the install script that should smooth things out:
- Mono 4.x on CentOS 7 doesn't ship dmcs, or so it seems. mcs replaces all previous compiler versions, so let's use it if dmcs isn't available
- the FDB C library is installed under /usr/lib64, not /usr/lib, and that will generally be the case in many cases. There is more to do in this area to support multiarch paths on Debian
- check for the FDB C library first thing; the silent failure (exit 0) with the warning does not make it obvious what happened and didn't
- use HTTPS URL instead of git to clone the repository

Also noticed the CGO_*FLAGS variables could use some love:
- use CGO_CPPFLAGS for include path
- remove non-ld options from CGO_LDFLAGS

Tested on CentOS 7, successfully installs, sample Go project builds and runs (Go 1.10.x).