### PR TITLE
Several small compilation fixes for new versions of gcc

### DIFF
--- a/fdbrpc/ContinuousSample.h
+++ b/fdbrpc/ContinuousSample.h
@@ -26,6 +26,7 @@
 #include "flow/IRandom.h"
 #include <vector>
 #include <algorithm>
+#include <cmath>
 
 template <class T>
 class ContinuousSample {

--- a/fdbrpc/Smoother.h
+++ b/fdbrpc/Smoother.h
@@ -23,6 +23,7 @@
 #pragma once
 
 #include "flow/flow.h"
+#include <cmath>
 
 struct Smoother {
 	// Times (t) are expected to be nondecreasing

--- a/fdbrpc/libcoroutine/Coro.c
+++ b/fdbrpc/libcoroutine/Coro.c
@@ -66,6 +66,8 @@ VALGRIND_STACK_DEREGISTER((coro)->valgrindStackId)
 #define STACK_DEREGISTER(coro)
 #endif
 
+#pragma GCC diagnostic ignored "-Wreturn-local-addr"
+
 // Define outside
 extern intptr_t g_stackYieldLimit;
 

--- a/fdbserver/Knobs.cpp
+++ b/fdbserver/Knobs.cpp
@@ -20,6 +20,7 @@
 
 #include "Knobs.h"
 #include "fdbrpc/Locality.h"
+#include <cmath>
 
 ServerKnobs const* SERVER_KNOBS = new ServerKnobs();
 

--- a/flow/Knobs.cpp
+++ b/flow/Knobs.cpp
@@ -20,6 +20,7 @@
 
 #include "Knobs.h"
 #include "flow/flow.h"
+#include <cmath>
 
 FlowKnobs const* FLOW_KNOBS = new FlowKnobs();
 

--- a/flow/Platform.cpp
+++ b/flow/Platform.cpp
@@ -623,7 +623,7 @@ void getDiskStatistics(std::string const& directory, uint64_t& currentIOs, uint6
 		unsigned int minorId;
 		disk_stream >> majorId;
 		disk_stream >> minorId;
-		if(majorId == (unsigned int) major(buf.st_dev) && minorId == (unsigned int) minor(buf.st_dev)) {
+		if(majorId == (unsigned int) gnu_dev_major(buf.st_dev) && minorId == (unsigned int) gnu_dev_minor(buf.st_dev)) {
 			std::string ignore;
 			uint64_t rd_ios;	/* # of reads completed */
 			//	    This is the total number of reads completed successfully.

--- a/flow/TDMetric.actor.h
+++ b/flow/TDMetric.actor.h
@@ -36,6 +36,7 @@
 #include "CompressedInt.h"
 #include <algorithm>
 #include <functional>
+#include <cmath>
 
 struct MetricNameRef {
 	MetricNameRef() {}

--- a/flow/Trace.cpp
+++ b/flow/Trace.cpp
@@ -931,7 +931,9 @@ TraceEvent::~TraceEvent() {
 	} catch( Error &e ) {
 		TraceEvent(SevError, "TraceEventDestructorError").error(e,true);
 		delete tmpEventMetric;
-		throw;
+		// TODO: it is illegal in C++11 to throw an exception in a destructor
+		// so we need to figure out what to do here
+		//throw;
 	}
 	delete tmpEventMetric;
 }

--- a/flow/flow.h
+++ b/flow/flow.h
@@ -250,19 +250,6 @@ public:
 		}
 	}
 
-	bool operator == (ErrorOr const& o) const {
-		return error == o.error && (!present() || get() == o.get());
-	}
-	bool operator != (ErrorOr const& o) const {
-		return !(*this == o);
-	}
-
-	bool operator < (ErrorOr const& o) const {
-		if (error != o.error) return error < o.error;
-		if (!present()) return false;
-		return get() < o.get();
-	}
-
 	bool isError() const { return error.code() != invalid_error_code; }
 	bool isError(int code) const { return error.code() == code; }
 	Error getError() const { ASSERT(isError()); return error; }


### PR DESCRIPTION
There are several missing includes for cmath in the code, I added those.

Next, Coro returns a reference to a stack variable and this causes a
warning. As this is probably ok for Coro, I disabled the warning in
that file for GCC. I want to have this warning in the build system as
it is generally a very useful warning to have.

Another change is that major and minor are deprecated for a while now.
I replaced those with gnu_dev_major and gnu_dev_minor.

ErrorOr currently implements operators ==, !=, and <. These do not
compile because Error does not implement ==. This compiles on older
versions of gcc and clang because ErrorOr<T>::operator== is not used
anywhere. It is still wrong though and newer gcc versions complain.
I simply removed these methods.

The most interesting fix is that TraceEvent::~TraceEvent is currently
throwing exceptions. This is illegal behavior in C++11 and a idea in
older versions of C++. For now I simply removed the throw, but this
might need some more thought.