### PR TITLE
Fix typos and formatting errors

### DIFF
--- a/fdbmonitor/fdbmonitor.cpp
+++ b/fdbmonitor/fdbmonitor.cpp
@@ -615,7 +615,7 @@ void print_usage(const char* name) {
 		"                 fdbmonitor. The default is `/var/run/fdbmonitor.pid'.\n"
 		"  --loggroup LOGGROUP\n"
 		"                 Sets the 'LogGroup' field with the specified value for all\n"
-		"                 entries in the log output. The default log group is 'default'."
+		"                 entries in the log output. The default log group is 'default'.\n"
 		"  --daemonize    Background the fdbmonitor process.\n"
 		"  -h, --help     Display this help and exit.\n", name);
 }

--- a/fdbserver/Ratekeeper.actor.cpp
+++ b/fdbserver/Ratekeeper.actor.cpp
@@ -91,7 +91,7 @@ struct StorageQueueInfo {
 		smoothDurableVersion(1.), smoothLatestVersion(1.), smoothFreeSpace(SERVER_KNOBS->SMOOTHING_AMOUNT),
 		smoothTotalSpace(SERVER_KNOBS->SMOOTHING_AMOUNT), readReplyRate(0.0), limitReason(limitReason_t::unlimited)
 	{
-		// FIXME: this is a tacky workaround for a potential unitialized use in trackStorageServerQueueInfo
+		// FIXME: this is a tacky workaround for a potential uninitialized use in trackStorageServerQueueInfo
 		lastReply.instanceID = -1;
 	}
 };
@@ -107,7 +107,7 @@ struct TLogQueueInfo {
 	TLogQueueInfo(UID id) : valid(false), id(id), smoothDurableBytes(SERVER_KNOBS->SMOOTHING_AMOUNT), smoothInputBytes(SERVER_KNOBS->SMOOTHING_AMOUNT),
 		verySmoothDurableBytes(SERVER_KNOBS->SLOW_SMOOTHING_AMOUNT), smoothFreeSpace(SERVER_KNOBS->SMOOTHING_AMOUNT),
 		smoothTotalSpace(SERVER_KNOBS->SMOOTHING_AMOUNT) {
-		// FIXME: this is a tacky workaround for a potential unitialized use in trackTLogQueueInfo (copied from storageQueueInfO)
+		// FIXME: this is a tacky workaround for a potential uninitialized use in trackTLogQueueInfo (copied from storageQueueInfO)
 		lastReply.instanceID = -1;
 	}
 };


### PR DESCRIPTION
Our help message for fdbmonitor was missing a newline, so it looked weird. This also addresses a spelling error in Ratekeeper.actor.cpp's comments.