### PR TITLE
Fix the printStatus redundancy mode output

### DIFF
--- a/fdbcli/fdbcli.actor.cpp
+++ b/fdbcli/fdbcli.actor.cpp
@@ -854,7 +854,7 @@ void printStatus(StatusObjectReader statusObj, StatusClient::StatusLevel level, 
 				outputString += "\n  Redundancy mode        - ";
 				std::string strVal;
 
-				if (statusObjConfig.get("redundancy.factor", strVal)){
+				if (statusObjConfig.get("redundancy_mode", strVal)){
 					outputString += strVal;
 				} else
 					outputString += "unknown";


### PR DESCRIPTION
The key used to get the redundancy mode should match what's in JSON. Otherwise we have
`
fdb> status

Using cluster file `/usr/local/etc/foundationdb/fdb.cluster’.

Configuration:
Redundancy mode - unknown
Storage engine - ssd-2
Coordinators - 3
`