### PR TITLE
Add flag to disable directory snapshot ops in the binding tester

### DIFF
--- a/bindings/bindingtester/bindingtester.py
+++ b/bindings/bindingtester/bindingtester.py
@@ -185,6 +185,8 @@ class TestRunner(object):
         # Test types should be intersection of all tester supported types
         self.args.types = reduce(lambda t1, t2: filter(t1.__contains__, t2), map(lambda tester: tester.types, self.testers))
 
+        self.args.no_directory_snapshot_ops = self.args.no_directory_snapshot_ops or any([not tester.directory_snapshot_ops_enabled for tester in self.testers])
+
     def print_test(self):
         test_instructions = self._generate_test()
 
@@ -424,6 +426,8 @@ def parse_args(argv):
     # SOMEDAY: this applies only to the scripted test. Should we invoke test files specifically (as in circus),
     # or invoke them here and allow tests to add arguments?
     parser.add_argument('--no-threads', action='store_true', help='Disables the START_THREAD instruction in the scripted test.')
+    
+    parser.add_argument('--no-directory-snapshot-ops', action='store_true', help='Disables snapshot operations for directory instructions.')
 
     return parser.parse_args(argv)
 

--- a/bindings/bindingtester/known_testers.py
+++ b/bindings/bindingtester/known_testers.py
@@ -26,7 +26,7 @@ ALL_TYPES = COMMON_TYPES + ['versionstamp']
 
 
 class Tester:
-    def __init__(self, name, cmd, max_int_bits=64, min_api_version=0, max_api_version=MAX_API_VERSION, threads_enabled=True, types=COMMON_TYPES):
+    def __init__(self, name, cmd, max_int_bits=64, min_api_version=0, max_api_version=MAX_API_VERSION, threads_enabled=True, types=COMMON_TYPES, directory_snapshot_ops_enabled=True):
         self.name = name
         self.cmd = cmd
         self.max_int_bits = max_int_bits
@@ -34,6 +34,7 @@ class Tester:
         self.max_api_version = max_api_version
         self.threads_enabled = threads_enabled
         self.types = types
+        self.directory_snapshot_ops_enabled = directory_snapshot_ops_enabled
 
     def supports_api_version(self, api_version):
         return api_version >= self.min_api_version and api_version <= self.max_api_version
@@ -62,5 +63,5 @@ testers = {
     'java': Tester('java', _java_cmd + 'StackTester', 2040, 510, MAX_API_VERSION, types=ALL_TYPES),
     'java_async': Tester('java', _java_cmd + 'AsyncStackTester', 2040, 510, MAX_API_VERSION, types=ALL_TYPES),
     'go': Tester('go', _absolute_path('go/build/bin/_stacktester'), 63, 200, MAX_API_VERSION),
-    'flow': Tester('flow', _absolute_path('flow/bin/fdb_flow_tester'), 63, 500, MAX_API_VERSION),
+    'flow': Tester('flow', _absolute_path('flow/bin/fdb_flow_tester'), 63, 500, MAX_API_VERSION, directory_snapshot_ops_enabled=False),
 }

--- a/bindings/bindingtester/tests/directory.py
+++ b/bindings/bindingtester/tests/directory.py
@@ -92,7 +92,7 @@ class DirectoryTest(Test):
         directory += directory_db_reads
 
         if not args.no_directory_snapshot_ops:
-        directory += directory_snapshot_reads
+            directory += directory_snapshot_reads
 
         subspace = ['DIRECTORY_PACK_KEY', 'DIRECTORY_UNPACK_KEY', 'DIRECTORY_RANGE', 'DIRECTORY_CONTAINS', 'DIRECTORY_OPEN_SUBSPACE']
 

--- a/bindings/bindingtester/tests/directory.py
+++ b/bindings/bindingtester/tests/directory.py
@@ -90,6 +90,8 @@ class DirectoryTest(Test):
         directory += directory_reads
         directory += directory_db_mutations
         directory += directory_db_reads
+
+        if not args.no_directory_snapshot_ops:
         directory += directory_snapshot_reads
 
         subspace = ['DIRECTORY_PACK_KEY', 'DIRECTORY_UNPACK_KEY', 'DIRECTORY_RANGE', 'DIRECTORY_CONTAINS', 'DIRECTORY_OPEN_SUBSPACE']

--- a/bindings/flow/tester/Tester.actor.cpp
+++ b/bindings/flow/tester/Tester.actor.cpp
@@ -1618,11 +1618,7 @@ ACTOR static Future<Void> doInstructions(Reference<FlowTesterData> data) {
 			}
 
 			// Flow directory operations don't support snapshot reads
-			if (isDirectory && isSnapshot) {
-				Version readVersion = wait(instruction->tr->getReadVersion());
-				instruction->tr = Reference<Transaction>(new Transaction(data->db));
-				instruction->tr->setVersion(readVersion);
-			}
+			ASSERT(!isDirectory || !isSnapshot);
 
 			data->stack.index = idx;
 			Void _ = wait(InstructionFunc::call(op.toString(), data, instruction));


### PR DESCRIPTION
and use it in the flow bindings. Addresses https://github.com/apple/foundationdb/issues/157