### PR TITLE
RFC: Initial stab of AddWithClear atomic mutation

### DIFF
--- a/fdbclient/CommitTransaction.h
+++ b/fdbclient/CommitTransaction.h
@@ -24,11 +24,11 @@
 
 #include "FDBTypes.h"
 
-static const char * typeString[] = { "SetValue", "ClearRange", "AddValue", "DebugKeyRange", "DebugKey", "NoOp", "And", "Or", "Xor", "AppendIfFits", "AvailableForReuse", "Reserved_For_LogProtocolMessage", "Max", "Min", "SetVersionstampedKey", "SetVersionstampedValue", "ByteMin", "ByteMax", "MinV2", "AndV2" };
+static const char * typeString[] = { "SetValue", "ClearRange", "AddValue", "DebugKeyRange", "DebugKey", "NoOp", "And", "Or", "Xor", "AppendIfFits", "AvailableForReuse", "Reserved_For_LogProtocolMessage", "Max", "Min", "SetVersionstampedKey", "SetVersionstampedValue", "ByteMin", "ByteMax", "MinV2", "AndV2", "AddWithClear" };
 
 struct MutationRef { 
 	static const int OVERHEAD_BYTES = 12; //12 is the size of Header in MutationList entries
-	enum Type : uint8_t { SetValue=0, ClearRange, AddValue, DebugKeyRange, DebugKey, NoOp, And, Or, Xor, AppendIfFits, AvailableForReuse, Reserved_For_LogProtocolMessage /* See fdbserver/LogProtocolMessage.h */, Max, Min, SetVersionstampedKey, SetVersionstampedValue, ByteMin, ByteMax, MinV2, AndV2, MAX_ATOMIC_OP };
+	enum Type : uint8_t { SetValue=0, ClearRange, AddValue, DebugKeyRange, DebugKey, NoOp, And, Or, Xor, AppendIfFits, AvailableForReuse, Reserved_For_LogProtocolMessage /* See fdbserver/LogProtocolMessage.h */, Max, Min, SetVersionstampedKey, SetVersionstampedValue, ByteMin, ByteMax, MinV2, AndV2, AddWithClear, MAX_ATOMIC_OP };
 	// This is stored this way for serialization purposes.
 	uint8_t type;
 	StringRef param1, param2;
@@ -55,9 +55,9 @@ struct MutationRef {
 
 	// These masks define which mutation types have particular properties (they are used to implement isSingleKeyMutation() etc)
 	enum { 
-		ATOMIC_MASK = (1 << AddValue) | (1 << And) | (1 << Or) | (1 << Xor) | (1 << AppendIfFits) | (1 << Max) | (1 << Min) | (1 << SetVersionstampedKey) | (1 << SetVersionstampedValue) | (1 << ByteMin) | (1 << ByteMax) | (1 << MinV2) | (1 << AndV2),
+		ATOMIC_MASK = (1 << AddValue) | (1 << And) | (1 << Or) | (1 << Xor) | (1 << AppendIfFits) | (1 << Max) | (1 << Min) | (1 << SetVersionstampedKey) | (1 << SetVersionstampedValue) | (1 << ByteMin) | (1 << ByteMax) | (1 << MinV2) | (1 << AndV2) | (1 << AddWithClear),
 		SINGLE_KEY_MASK = ATOMIC_MASK | (1<<SetValue),
-		NON_ASSOCIATIVE_MASK = (1 << AddValue) | (1 << Or) | (1 << Xor) | (1 << Max) | (1 << Min) | (1 << SetVersionstampedKey) | (1 << SetVersionstampedValue) | (1 << MinV2)
+		NON_ASSOCIATIVE_MASK = (1 << AddValue) | (1 << Or) | (1 << Xor) | (1 << Max) | (1 << Min) | (1 << SetVersionstampedKey) | (1 << SetVersionstampedValue) | (1 << MinV2) | (1 << AddWithClear)
 	};
 };
 

--- a/fdbclient/ReadYourWrites.actor.cpp
+++ b/fdbclient/ReadYourWrites.actor.cpp
@@ -1427,6 +1427,7 @@ void ReadYourWritesTransaction::writeRangeToNativeTransaction( KeyRangeRef const
 					case MutationRef::ByteMax:
 					case MutationRef::MinV2:
 					case MutationRef::AndV2:
+					case MutationRef::AddWithClear:
 						tr.atomicOp( it.beginKey().assertRef(), op[i].value.get(), op[i].type, false );
 						break;
 					default:

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -1539,6 +1539,19 @@ bool expandMutation( MutationRef& m, StorageServer::VersionedData const& data, U
 			case MutationRef::AndV2:
 				m.param2 = doAndV2(oldVal, m.param2, ar);
 				break;
+			case MutationRef::AddWithClear:
+				if(!oldVal.present() && m.param2.isZero())
+					return false;
+				m.param2 = doLittleEndianAdd(oldVal, m.param2, ar);
+				if (m.param2.isZero()) {
+					m.type = MutationRef::ClearRange;
+					KeyRange range = singleKeyRange(m.param1);
+					m.param1 = range.begin;
+					m.param2 = range.end;
+				} else {
+					m.type = MutationRef::SetValue;
+				}
+				return true;
 		}
 		m.type = MutationRef::SetValue;
 	}

--- a/flow/Arena.h
+++ b/flow/Arena.h
@@ -421,6 +421,7 @@ public:
 	StringRef substr(int start, int size) const { return StringRef( data + start, size ); }
 	bool startsWith( const StringRef& s ) const { return size() >= s.size() && !memcmp(begin(), s.begin(), s.size()); }
 	bool endsWith( const StringRef& s ) const { return size() >= s.size() && !memcmp(end()-s.size(), s.begin(), s.size()); }
+	bool isZero() const { for ( size_t i = 0; i < length; i++) { if (data[i]) return false; } return true; }
 
 	StringRef withPrefix( const StringRef& prefix, Arena& arena ) const {
 		uint8_t* s = new (arena) uint8_t[ prefix.size() + size() ];


### PR DESCRIPTION
Hi

This is an attempt to deal with the "leak" of keys (mentioned in issue #218)
It adds a new atomic add operation that in addition to the normal add semantics also clears the key if the value are all zeroes.

There are no workload tests, etc written yet, but running various manual tests it seems to do the right thing.

Just wanted to check if I'm on the right track before going further.
