### PR TITLE
Improve comment consistency in Go tuple package

### DIFF
--- a/bindings/go/src/fdb/tuple/tuple.go
+++ b/bindings/go/src/fdb/tuple/tuple.go
@@ -33,7 +33,6 @@
 // floats, doubles, booleans, UUIDs, tuples, and NULL values. In Go these are
 // represented as []byte (or fdb.KeyConvertible), string, int64 (or int),
 // float32, float64, bool, UUID, Tuple, and nil.
-
 package tuple
 
 import (

--- a/bindings/go/src/fdb/tuple/tuple.go
+++ b/bindings/go/src/fdb/tuple/tuple.go
@@ -29,9 +29,11 @@
 // For general guidance on tuple usage, see the Tuple section of Data Modeling
 // (https://apple.github.io/foundationdb/data-modeling.html#tuples).
 //
-// FoundationDB tuples can currently encode byte and unicode strings, integers
-// and NULL values. In Go these are represented as []byte, string, int64 and
-// nil.
+// FoundationDB tuples can currently encode byte and unicode strings, integers,
+// floats, doubles, booleans, UUIDs, tuples, and NULL values. In Go these are
+// represented as []byte (or fdb.KeyConvertible), string, int64 (or int),
+// float32, float64, bool, UUID, Tuple, and nil.
+
 package tuple
 
 import (


### PR DESCRIPTION
This PR updates the first list of supported types, that can be encoded using a Tuple, to match the types that can be found in later comments within the tuple package.

This addresses a minor inconsistency found in the Go [tuple package documentation](https://godoc.org/github.com/apple/foundationdb/bindings/go/src/fdb/tuple) that was [mentioned on the forums](https://forums.foundationdb.org/t/data-modeling-efficient-encoding-for-wgs84-coordinate-key-ids/354).