### PR TITLE
Honor length in Tuple.fromBytes if provided

### DIFF
--- a/bindings/go/src/fdb/generated.go
+++ b/bindings/go/src/fdb/generated.go
@@ -159,6 +159,27 @@ func (o NetworkOptions) SetBuggifySectionFiredProbability(param int64) error {
 	return o.setOpt(51, b)
 }
 
+// Set the ca bundle
+//
+// Parameter: ca bundle
+func (o NetworkOptions) SetTLSCaBytes(param []byte) error {
+	return o.setOpt(52, param)
+}
+
+// Set the file from which to load the certificate authority bundle
+//
+// Parameter: file path
+func (o NetworkOptions) SetTLSCaPath(param string) error {
+	return o.setOpt(53, []byte(param))
+}
+
+// Set the passphrase for encrypted private key. Password should be set before setting the key for the password to be used.
+//
+// Parameter: key passphrase
+func (o NetworkOptions) SetTLSPassword(param string) error {
+	return o.setOpt(54, []byte(param))
+}
+
 // Disables the multi-version client API and instead uses the local client directly. Must be set before setting up the network.
 func (o NetworkOptions) SetDisableMultiVersionClientApi() error {
 	return o.setOpt(60, nil)

--- a/bindings/java/src/main/com/apple/foundationdb/tuple/Tuple.java
+++ b/bindings/java/src/main/com/apple/foundationdb/tuple/Tuple.java
@@ -962,6 +962,14 @@ public class Tuple implements Comparable<Tuple>, Iterable<Object> {
 		System.out.println("t2.getNestedTuple(17): " + t2.getNestedTuple(17));
 		System.out.println("t2.getVersionstamp(20): " + t2.getVersionstamp(20));
 
+		int currOffset = 0;
+		for (Object item : t) {
+			int length = Tuple.from(item).pack().length;
+			Tuple t3 = Tuple.fromBytes(bytes, currOffset, length);
+			System.out.println("item = " + t3);
+			currOffset += length;
+		}
+
 		System.out.println("(2*(Long.MAX_VALUE+1),) = " + ByteArrayUtil.printable(Tuple.from(
 				BigInteger.valueOf(Long.MAX_VALUE).add(BigInteger.ONE).shiftLeft(1)
 		).pack()));

--- a/bindings/java/src/main/com/apple/foundationdb/tuple/TupleUtil.java
+++ b/bindings/java/src/main/com/apple/foundationdb/tuple/TupleUtil.java
@@ -539,10 +539,10 @@ class TupleUtil {
 	}
 
 	static List<Object> unpack(byte[] bytes, int start, int length) {
-		List<Object> items = new LinkedList<Object>();
+		List<Object> items = new LinkedList<>();
 		int pos = start;
 		int end = start + length;
-		while(pos < bytes.length) {
+		while(pos < end) {
 			DecodeResult decoded = decode(bytes, pos, end);
 			items.add(decoded.o);
 			pos = decoded.end;


### PR DESCRIPTION
In Tuple unpack, we were looping until the end of the array rather than to the end of where the user specified. This fixes that. It now passes the little quick test I added within Tuple.java, but testing this more thoroughly would probably require more work in other places.

It also looks like the TLS related network options that were just added to fdb.options weren't added to the generated.go file, so I fixed that (in a separate commit).

This closes #362.