### PR TITLE
Correctly calculate new version position in nested versions things in Python

### DIFF
--- a/bindings/python/fdb/tuple.py
+++ b/bindings/python/fdb/tuple.py
@@ -363,7 +363,7 @@ def _encode(value, nested=False):
     elif isinstance(value, tuple) or isinstance(value, list):
         child_bytes, version_pos = _reduce_children(map(lambda x: _encode(x, True), value))
         new_version_pos = -1 if version_pos < 0 else version_pos + 1
-        return b''.join([six.int2byte(NESTED_CODE)] + child_bytes + [six.int2byte(0x00)]), version_pos
+        return b''.join([six.int2byte(NESTED_CODE)] + child_bytes + [six.int2byte(0x00)]), new_version_pos
     else:
         raise ValueError("Unsupported data type: " + str(type(value)))
 


### PR DESCRIPTION
The Python code calculated the new version position, but it did not pass it along correctly (for whatever reason). The Java bindings were already doing this correctly: https://github.com/apple/foundationdb/blob/a799d2a08c9b3d9227f67adfd74a210cc4176c89/bindings/java/src/main/com/apple/foundationdb/tuple/TupleUtil.java#L344

We definitely test versionstamps in nested tuples in the binding tester, so I'm not sure why this wasn't caught by the tests.

This closes #356.