### PR TITLE
Exclude .vs folder from the repository (Visual Studio 2017)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,7 @@ trace.*.xml
 .project
 .pydevproject
 .vscode
+.vs/
 FoundationDB.xcodeproj
 foundationdb.VC.db
 foundationdb.VC.VC.opendb


### PR DESCRIPTION
Exclude temporary files created by Visual Studio 2017 from the repository