### PR TITLE
Use correct key and value values for validating versionstamp operations at old API versions

### DIFF
--- a/bindings/bindingtester/tests/scripted.py
+++ b/bindings/bindingtester/tests/scripted.py
@@ -34,10 +34,11 @@ fdb.api_version(FDB_API_VERSION)
 
 
 class ScriptedTest(Test):
+    MIN_API_VERSION = 500
     TEST_API_VERSION = 520
 
     def __init__(self, subspace):
-        super(ScriptedTest, self).__init__(subspace, ScriptedTest.TEST_API_VERSION, ScriptedTest.TEST_API_VERSION)
+        super(ScriptedTest, self).__init__(subspace, ScriptedTest.MIN_API_VERSION, ScriptedTest.TEST_API_VERSION)
         self.workspace = self.subspace['workspace']
         self.results_subspace = self.subspace['results']
         # self.thread_subspace = self.subspace['threads'] # TODO: update START_THREAD so that we can create threads in subspaces

--- a/bindings/bindingtester/tests/scripted.py
+++ b/bindings/bindingtester/tests/scripted.py
@@ -34,11 +34,10 @@ fdb.api_version(FDB_API_VERSION)
 
 
 class ScriptedTest(Test):
-    MIN_API_VERSION = 500
     TEST_API_VERSION = 520
 
     def __init__(self, subspace):
-        super(ScriptedTest, self).__init__(subspace, ScriptedTest.MIN_API_VERSION, ScriptedTest.TEST_API_VERSION)
+        super(ScriptedTest, self).__init__(subspace, ScriptedTest.TEST_API_VERSION, ScriptedTest.TEST_API_VERSION)
         self.workspace = self.subspace['workspace']
         self.results_subspace = self.subspace['results']
         # self.thread_subspace = self.subspace['threads'] # TODO: update START_THREAD so that we can create threads in subspaces

--- a/documentation/sphinx/source/release-notes.rst
+++ b/documentation/sphinx/source/release-notes.rst
@@ -2,6 +2,14 @@
 Release Notes
 #############
 
+5.2.1
+=====
+
+Fixes
+-----
+
+* Client input validation would handle inputs to versionstamp mutations incorrectly if the API version was less than 520. `(Issue #387) <https://github.com/apple/foundationdb/issues/387>`_
+
 5.2.0
 =====
 

--- a/fdbclient/NativeAPI.h
+++ b/fdbclient/NativeAPI.h
@@ -129,6 +129,7 @@ public:
 private: friend class ThreadSafeCluster;
 		 friend class AtomicOpsApiCorrectnessWorkload; // This is just for testing purposes. It needs to change apiVersion
 		 friend class AtomicOpsWorkload; // This is just for testing purposes. It needs to change apiVersion
+		 friend class VersionStampWorkload; // This is just for testing purposes. It needs to change apiVersion
 
 	Cluster( Reference<ClusterConnectionFile> connFile, int apiVersion = API_VERSION_LATEST );
 

--- a/fdbclient/ReadYourWrites.actor.cpp
+++ b/fdbclient/ReadYourWrites.actor.cpp
@@ -1508,7 +1508,7 @@ void ReadYourWritesTransaction::atomicOp( const KeyRef& key, const ValueRef& ope
 	}
 
 	if(operationType == MutationRef::SetVersionstampedKey) {
-		KeyRangeRef range = getVersionstampKeyRange(arena, key, getMaxReadKey()); // this does validation of the key and needs to be performed before the readYourWritesDisabled path
+		KeyRangeRef range = getVersionstampKeyRange(arena, k, getMaxReadKey()); // this does validation of the key and needs to be performed before the readYourWritesDisabled path
 		if(!options.readYourWritesDisabled) {
 			writeRangeToNativeTransaction(range);
 			writes.addUnmodifiedAndUnreadableRange(range);
@@ -1516,12 +1516,12 @@ void ReadYourWritesTransaction::atomicOp( const KeyRef& key, const ValueRef& ope
 	}
 
 	if(operationType == MutationRef::SetVersionstampedValue) {
-		if(operand.size() < 4)
+		if(v.size() < 4)
 			throw client_invalid_operation();
 		int32_t pos;
-		memcpy(&pos, operand.end() - sizeof(int32_t), sizeof(int32_t));
+		memcpy(&pos, v.end() - sizeof(int32_t), sizeof(int32_t));
 		pos = littleEndian32(pos);
-		if (pos < 0 || pos + 10 > operand.size() - 4)
+		if (pos < 0 || pos + 10 > v.size() - 4)
 			throw client_invalid_operation();
 	}
 
@@ -1530,7 +1530,7 @@ void ReadYourWritesTransaction::atomicOp( const KeyRef& key, const ValueRef& ope
 	}
 
 	writes.mutate(k, (MutationRef::Type) operationType, v, addWriteConflict);
-	RYWImpl::triggerWatches(this, key, Optional<ValueRef>(), false);
+	RYWImpl::triggerWatches(this, k, Optional<ValueRef>(), false);
 }
 
 void ReadYourWritesTransaction::set( const KeyRef& key, const ValueRef& value ) {

--- a/fdbserver/workloads/VersionStamp.actor.cpp
+++ b/fdbserver/workloads/VersionStamp.actor.cpp
@@ -71,7 +71,8 @@ struct VersionStampWorkload : TestWorkload {
 		}
 		else if (choice < 0.3) {
 			apiVersion = 520;
-		} else {
+		}
+		else {
 			apiVersion = Cluster::API_VERSION_LATEST;
 		}
 		TraceEvent("VersionStampApiVersion").detail("ApiVersion", apiVersion);
@@ -104,7 +105,8 @@ struct VersionStampWorkload : TestWorkload {
 		if (oldVSFormat) {
 			data[keySize - 2] = 24 + vsKeyPrefix.size();
 			data[keySize - 1] = 0;
-		} else {
+		}
+		else {
 			data[keySize - 4] = 24 + vsKeyPrefix.size();
 			data[keySize - 3] = 0;
 			data[keySize - 2] = 0;
@@ -259,7 +261,6 @@ struct VersionStampWorkload : TestWorkload {
 			state Standalone<StringRef> committedVersionStamp;
 			state Version committedVersion;
 
-			bool useVersionstampPos = (g_random->random01() < 0.5); // TODO: remove after tests pass
 			state Value versionStampValue;
 			if (oldVSFormat) {
 				versionStampValue = value;

--- a/versions.target
+++ b/versions.target
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <Version>5.2.0</Version>
+    <Version>5.2.1</Version>
     <PackageName>5.2</PackageName>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
This does two things. The first is it changes our scripted test from running only at a single version to running at a range of versions. I haven't looked into this too much, but I was able to run it a few times and not get errors. I know that for the differences between API versions 510 and 520, I wrote code to make it handle the compatibility correctly, but I don't know about between API versions 500 and 510. I think those are just the MIN and MAX atomic operations, and I don't see it in the test at all (which maybe is a thing to add).

The second is it changes ReadYourWrites.actor.cpp to actually thread through the correct values for the key and value. This wasn't caught by simulation as we only run simulation at the most recent API version, so those two values were always the same.

Closes #387.