### PR TITLE
Fix compilation with clang from Apple LLVM 9.1.0

### DIFF
--- a/fdbrpc/ITLSPlugin.h
+++ b/fdbrpc/ITLSPlugin.h
@@ -131,7 +131,7 @@ struct ITLSPolicy {
 // remaining arguments must be pairs of (const char*); the first of
 // each pair must be a valid XML attribute name, and the second a
 // valid XML attribute value. The final parameter must be NULL.
-typedef void(*ITLSLogFunc)(const char* event, void* uid, bool is_error, ...);
+typedef void(*ITLSLogFunc)(const char* event, void* uid, int is_error, ...);
 
 struct ITLSPlugin {
 	virtual void addref() = 0;

--- a/fdbrpc/TLSConnection.actor.cpp
+++ b/fdbrpc/TLSConnection.actor.cpp
@@ -347,7 +347,7 @@ Reference<ITLSPolicy> TLSOptions::get_policy(PolicyType type) {
 	return policy;
 }
 
-static void TLSConnectionLogFunc( const char* event, void* uid_ptr, bool is_error, ... ) {
+static void TLSConnectionLogFunc( const char* event, void* uid_ptr, int is_error, ... ) {
 	UID uid;
 
 	if ( uid_ptr )


### PR DESCRIPTION
The version of clang included in Apple LLVM 9.1.0 complains about
passing `TLSConnectionLogFunc`'s bool parameter `is_error` to va_start, which causes make
to fail:

```
fdbrpc/TLSConnection.actor.cpp:370:16: error: passing an object that undergoes
      default argument promotion to 'va_start' has undefined behavior
      [-Werror,-Wvarargs]
        va_start( ap, is_error );
                      ^
```

I think is_error was changed from int to bool in [this commit](https://github.com/apple/foundationdb/commit/d3b5cfb93c83a264eebd1f133114b20f0d4cd7b6) which was merged a day or two ago. [It looks like this technically may cause undefined behavior](https://wiki.sei.cmu.edu/confluence/display/cplusplus/EXP58-CPP.+Pass+an+object+of+the+correct+type+to+va_start) which is only noticed by recent versions of clang. I'm sure every compiler would do something sane here anyway, but this just switches `is_error` back to the type it would get promoted to (int).

The specific clang version in question:
```
$ clang --version
Apple LLVM version 9.1.0 (clang-902.0.39.1)
Target: x86_64-apple-darwin17.5.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
```