### PR TITLE
rename opaque types in c binding to avoid conflicts with the standard library

### DIFF
--- a/bindings/c/foundationdb/fdb_c.h
+++ b/bindings/c/foundationdb/fdb_c.h
@@ -61,10 +61,10 @@ extern "C" {
 #endif
 
     /* Pointers to these opaque types represent objects in the FDB API */
-    typedef struct future FDBFuture;
-    typedef struct cluster FDBCluster;
-    typedef struct database FDBDatabase;
-    typedef struct transaction FDBTransaction;
+    typedef struct FDB_future FDBFuture;
+    typedef struct FDB_cluster FDBCluster;
+    typedef struct FDB_database FDBDatabase;
+    typedef struct FDB_transaction FDBTransaction;
 
     typedef int fdb_error_t;
     typedef int fdb_bool_t;


### PR DESCRIPTION
hi, I'm trying to use fdb in other project called Ceph. I got a compile error when I included fdb c binding. as following:
```
/usr/include/foundationdb/fdb_c.h:64:20: error: template argument required for ‘struct future’
     typedef struct future FDBFuture;
                    ^~~~~~
```

unfortunately, Ceph imports std namespace in its header file. `std::future<T>` conflicts with above `struct future`. I manage to remove std namespace from ceph header files, but there are almost million lines need to be updated.

Maybe we should not use `future` as a opaque type name. `future` is widely used in a lot of libraries. renaming it to `__fdb__future` is safer.

I'm not sure whether we could have a better solution. comments are appreciated! thanks

Signed-off-by: Chang Liu <liuchang0812@gmail.com>