### PR TITLE
use inspect.getfullargspec when available

### DIFF
--- a/bindings/python/fdb/impl.py
+++ b/bindings/python/fdb/impl.py
@@ -227,7 +227,10 @@ def transactional(*tr_args, **tr_kwargs):
         wfunc = func
         while getattr(wfunc, '__wrapped__', None):
             wfunc = wfunc.__wrapped__
-        index = inspect.getargspec(wfunc).args.index(parameter)
+        if hasattr(inspect, 'getfullargspec'):
+            index = inspect.getfullargspec(wfunc).args.index(parameter)
+        else:
+            index = inspect.getargspec(wfunc).args.index(parameter)
 
         if getattr(func, '_is_coroutine', False):
             @functools.wraps(func)


### PR DESCRIPTION
`getargspec` was deprecated in python3, this should use `getfullargspec` when available, and degrade gracefully otherwise.

Besides avoiding the use of a deprecated function, this is useful because `getargspec` chokes on functions using the new type annotation syntax, but `getfullargspec` handles it. So with this change, you can type annotate functions decorated with `@fdb.transactional`.
