### PR TITLE
Bump supported python version to 3.6

### DIFF
--- a/documentation/sphinx/source/api-python.rst
+++ b/documentation/sphinx/source/api-python.rst
@@ -54,7 +54,7 @@ Python API
 Installation
 ============
 
-The FoundationDB Python API is compatible with Python 2.7 - 3.4. You will need to have a Python version within this range on your system before the FoundationDB Python API can be installed.
+The FoundationDB Python API is compatible with Python 2.7 - 3.6. You will need to have a Python version within this range on your system before the FoundationDB Python API can be installed.
 
 On macOS, the FoundationDB Python API is installed as part of the FoundationDB installation (see :ref:`installing-client-binaries`). On Ubuntu or RHEL/CentOS, you will need to install the FoundationDB Python API manually.
 

--- a/documentation/sphinx/source/downloads.rst
+++ b/documentation/sphinx/source/downloads.rst
@@ -51,7 +51,7 @@ C
 
 FoundationDB's C bindings are installed with the FoundationDB client binaries. You can find more details in the :doc:`C API Documentation <api-c>`.
 
-Python 2.7 - 3.4
+Python 2.7 - 3.5
 ----------------
 
 On macOS and Windows, the FoundationDB Python API bindings are installed as part of your FoundationDB installation.


### PR DESCRIPTION
There was a question as to what it would take to support versions of Python greater than 3.4 (which was our advertised maximum supported versions). Testing has shown that we were actually already compatible with 3.6 (as far as our tests can tell), so I'm suggesting we just bump the maximum supported Python version.

This closes issue: #379