### PR TITLE
Identify processes with host:port regardless of if TLS is enabled or not

### DIFF
--- a/fdbcli/fdbcli.actor.cpp
+++ b/fdbcli/fdbcli.actor.cpp
@@ -2582,7 +2582,8 @@ ACTOR Future<int> cli(CLIOptions opt, LineNoise* plinenoise) {
 					if (tokens.size() == 1) {
 						Standalone<RangeResultRef> kvs = wait( makeInterruptable( tr->getRange(KeyRangeRef(LiteralStringRef("\xff\xff/worker_interfaces"), LiteralStringRef("\xff\xff\xff")), 1) ) );
 						for( auto it : kvs ) {
-							address_interface[it.key] = it.value;
+							auto ip_port = it.key.endsWith(LiteralStringRef(":tls")) ? it.key.removeSuffix(LiteralStringRef(":tls")) : it.key;
+							address_interface[ip_port] = it.value;
 						}
 					}
 					if (tokens.size() == 1 || tokencmp(tokens[1], "list")) {
@@ -2718,7 +2719,8 @@ ACTOR Future<int> cli(CLIOptions opt, LineNoise* plinenoise) {
 						                             LiteralStringRef("\xff\xff\xff")),
 						                 1)));
 						for (const auto& pair : kvs) {
-							printf("%s\n", printable(pair.key).c_str());
+							auto ip_port = pair.key.endsWith(LiteralStringRef(":tls")) ? pair.key.removeSuffix(LiteralStringRef(":tls")) : pair.key;
+							printf("%s\n", printable(ip_port).c_str());
 						}
 						continue;
 					}
@@ -2750,7 +2752,8 @@ ACTOR Future<int> cli(CLIOptions opt, LineNoise* plinenoise) {
 							state std::vector<Key> all_profiler_addresses;
 							state std::vector<Future<ErrorOr<Void>>> all_profiler_responses;
 							for (const auto& pair : kvs) {
-								interfaces.emplace(pair.key, BinaryReader::fromStringRef<ClientWorkerInterface>(pair.value, IncludeVersion()));
+								auto ip_port = pair.key.endsWith(LiteralStringRef(":tls")) ? pair.key.removeSuffix(LiteralStringRef(":tls")) : pair.key;
+								interfaces.emplace(ip_port, BinaryReader::fromStringRef<ClientWorkerInterface>(pair.value, IncludeVersion()));
 							}
 							if (tokens.size() == 6 && tokencmp(tokens[5], "all")) {
 								for (const auto& pair : interfaces) {


### PR DESCRIPTION
This makes `kill` and `profile` behave like how `exclude` functions, and means
commands don't have to change depending on TLS status.

Verified via starting a TLS cluster and killing a process before and after this change.