### PR TITLE
Add administration and TLS sections to the site map.

### DIFF
--- a/documentation/sphinx/source/administration.rst
+++ b/documentation/sphinx/source/administration.rst
@@ -10,6 +10,7 @@ Administration
    :titlesonly:
 
    moving-a-cluster
+   tls
    
 This document covers the administration of an existing FoundationDB cluster. We recommend you read this document before setting up a cluster for performance testing or production use.
 

--- a/documentation/sphinx/source/index.rst
+++ b/documentation/sphinx/source/index.rst
@@ -50,4 +50,5 @@ The latest changes are detailed in :doc:`release-notes`. The documentation has t
    design-recipes
    api-reference
    tutorials
+   administration
    earlier-release-notes


### PR DESCRIPTION
#264 

Probably should have filed this against release-5.2 the first time, but pobody's nerfect. I don't think we need this on release-5.1, since I doubt we're going to cut another docs release off of that branch.