### PR TITLE
Typo fixes using aspell

### DIFF
--- a/documentation/sphinx/source/api-common.rst.inc
+++ b/documentation/sphinx/source/api-common.rst.inc
@@ -309,7 +309,7 @@
 
 .. |option-snapshot-ryw-disable-blurb| replace::
 
-    If this option is set more times in this transction than the enable option, snapshot reads will *not* see the effects of prior writes in the same transaction.
+    If this option is set more times in this transaction than the enable option, snapshot reads will *not* see the effects of prior writes in the same transaction.
 
 .. |option-priority-batch-blurb| replace::
     This transaction should be treated as low priority (other transactions should be processed first).  Useful for doing potentially saturating batch work without interfering with the latency of other operations.

--- a/documentation/sphinx/source/api-python.rst
+++ b/documentation/sphinx/source/api-python.rst
@@ -1110,7 +1110,7 @@ the most part, this also implies that ``T == fdb.tuple.unpack(fdb.tuple.pack(T))
    differ from the default sort when non-ASCII characters are included within the string), and UUIDs are sorted
    based on their big-endian byte representation. Single-precision floating point numbers are sorted before all
    double-precision floating point numbers, and for floating point numbers, -NaN is sorted before -Infinity which
-   is sorted before finite numbers which are sorted before Infinity which is sorted before NaN. Different represetations
+   is sorted before finite numbers which are sorted before Infinity which is sorted before NaN. Different representations
    of NaN are not treated as equal.
 
    Additionally, the tuple serialization contract is such that after they are serialized, the byte-string representations


### PR DESCRIPTION
Some typo fixes on running aspell on the source directory that contains the docs : 

Command : 

`ls -1 | xargs -I{} sh -c "aspell --master=en_US --extra-dicts=en_GB --ignore 3 list < {}" | sort | uniq | less`

Changes made : 

transction -> transaction
represetations -> representations

Master branch changes : 
responsiblity -> responsibility (Has to be fixed on master for 6.0 release notes)

Can be viewed using `git diff --color-words=.` locally

@ajbeamon  Supersedes #475 

Thanks