### PR TITLE
Fix a concurrency bug in Java queue example

### DIFF
--- a/documentation/sphinx/source/queues-java.rst
+++ b/documentation/sphinx/source/queues-java.rst
@@ -81,19 +81,18 @@ The following is a simple implementation of the basic pattern:
 
         // Remove the top element from the queue.
         public static Object dequeue(TransactionContext tcx){
-            final KeyValue item = firstItem(tcx);
-            if(item == null){
-                return null;
-            }
-
             // Remove from the top of the queue.
-            tcx.run((Transaction tr) -> {
+            return tcx.run((Transaction tr) -> {
+                final KeyValue item = firstItem(tr);
+                if(item == null){
+                    return null;
+                }
+
                 tr.clear(item.getKey());
-                return null;
+                // Return the old value.
+                return Tuple.fromBytes(item.getValue()).get(0);
             });
 
-            // Return the old value.
-            return Tuple.fromBytes(item.getValue()).get(0);
         }
 
         // Add an element to the queue.

--- a/recipes/java-recipes/MicroQueue.java
+++ b/recipes/java-recipes/MicroQueue.java
@@ -44,21 +44,20 @@ public class MicroQueue {
 
 	// Remove the top element from the queue.
 	public static Object dequeue(TransactionContext tcx){
-		final KeyValue item = firstItem(tcx);
-		if(item == null){
-			return null;
-		}
-
 		// Remove from the top of the queue.
-		tcx.run(new Function<Transaction,Void>(){
+		return tcx.run(new Function<Transaction,Void>(){
 			public Void apply(Transaction tr){
+                final KeyValue item = firstItem(tr);
+                if(item == null){
+                    return null;
+                }
+
 				tr.clear(item.getKey());
-				return null;
+                // Return the old value.
+                return Tuple.fromBytes(item.getValue()).get(0);
 			}
 		});
 
-		// Return the old value.
-		return Tuple.fromBytes(item.getValue()).get(0);
 	}
 
 	// Add an element to the queue.

--- a/recipes/java-recipes/MicroQueue.java
+++ b/recipes/java-recipes/MicroQueue.java
@@ -47,14 +47,14 @@ public class MicroQueue {
 		// Remove from the top of the queue.
 		return tcx.run(new Function<Transaction,Void>(){
 			public Void apply(Transaction tr){
-                final KeyValue item = firstItem(tr);
-                if(item == null){
-                    return null;
-                }
+				final KeyValue item = firstItem(tr);
+				if(item == null){
+					return null;
+				}
 
 				tr.clear(item.getKey());
-                // Return the old value.
-                return Tuple.fromBytes(item.getValue()).get(0);
+				// Return the old value.
+				return Tuple.fromBytes(item.getValue()).get(0);
 			}
 		});
 


### PR DESCRIPTION
`firstItem()` should be in the same transaction of `tr.clear()`. Otherwise two transactions can end up obtaining the same `item` from the queue. Try comparing the Python implementation below, which use the same transaction for both operations.

```
@fdb.transactional
def dequeue(tr):
    item = first_item(tr)
    if item is None: return None
    del tr[item.key]
    return item.value
```