### PR TITLE
Convert ActorCompiler project to new style csproj and target netcoreapp2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ packaging/msi/FDBInstaller.wix*
 .ccache
 .deps/
 .objs/
+obj/
 bindings/c/fdb_c.symbols
 bindings/go/build
 bindings/go/godoc

--- a/flow/actorcompiler/ActorCompiler.targets
+++ b/flow/actorcompiler/ActorCompiler.targets
@@ -16,7 +16,7 @@
       <Targets>_ActorCompiler</Targets>
     </AvailableItemName>
     <!-- This item is used to reference the actorcompiler .exe; possibly a property would be better? -->
-    <ActorCompilerExe Include="$(SolutionDir)bin\$(Configuration)\actorcompiler.exe"/>
+    <ActorCompilerExe Include="$(SolutionDir)bin\$(Configuration)\netcoreapp2.0\actorcompiler.dll"/>
   </ItemGroup>
   <PropertyGroup>
     <!-- The "fast up to date check" done by the IDE (not MSBuild!) doesn't notice when the compiler .exe has changed,
@@ -49,6 +49,6 @@
     Inputs="@(ActorCompilerExe);@(ActorCompiler)"
     Outputs="@(ActorCompiler->'%(RelativeDir)%(Filename).g%(Extension)')"
     >
-    <Exec Command="&quot;@(ActorCompilerExe)&quot; %(ActorCompiler.Identity) %(ActorCompiler.RelativeDir)%(ActorCompiler.Filename).g%(ActorCompiler.Extension) %(ActorCompiler.ActorCompilerOptions)"/>
+    <Exec Command="dotnet &quot;@(ActorCompilerExe)&quot; %(ActorCompiler.Identity) %(ActorCompiler.RelativeDir)%(ActorCompiler.Filename).g%(ActorCompiler.Extension) %(ActorCompiler.ActorCompilerOptions)"/>
   </Target>
 </Project>

--- a/flow/actorcompiler/Properties/AssemblyInfo.cs
+++ b/flow/actorcompiler/Properties/AssemblyInfo.cs
@@ -18,39 +18,8 @@
  * limitations under the License.
  */
 
-using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-[assembly: AssemblyTitle("actorcompiler")]
-[assembly: AssemblyDescription("Compile Flow code to C++")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("Apple Inc")]
-[assembly: AssemblyProduct("actorcompiler")]
-[assembly: AssemblyCopyright("Copyright (c) 2013-2017 Apple Inc.")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
-
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 
-// The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("fd8d34c8-46ca-43de-bfb3-b437e46943da")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/flow/actorcompiler/actorcompiler.csproj
+++ b/flow/actorcompiler/actorcompiler.csproj
@@ -1,109 +1,26 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <ProductVersion>10.0.20506</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
-    <ProjectGuid>{0ECC1314-3FC2-458D-8E41-B50B4EA24E51}</ProjectGuid>
     <OutputType>Exe</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>actorcompiler</RootNamespace>
-    <AssemblyName>actorcompiler</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <ProjectGuid>{0ECC1314-3FC2-458D-8E41-B50B4EA24E51}</ProjectGuid>
     <OutputPath>$(SolutionDir)bin\$(Configuration)\</OutputPath>
     <IntermediateOutputPath>$(SystemDrive)\temp\msvcfdb\$(Configuration)\actorcompiler\</IntermediateOutputPath>
-    <PublishUrl>publish\</PublishUrl>
-    <Install>true</Install>
-    <InstallFrom>Disk</InstallFrom>
-    <UpdateEnabled>false</UpdateEnabled>
-    <UpdateMode>Foreground</UpdateMode>
-    <UpdateInterval>7</UpdateInterval>
-    <UpdateIntervalUnits>Days</UpdateIntervalUnits>
-    <UpdatePeriodically>false</UpdatePeriodically>
-    <UpdateRequired>false</UpdateRequired>
-    <MapFileExtensions>true</MapFileExtensions>
-    <ApplicationRevision>0</ApplicationRevision>
-    <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
-    <IsWebBootstrapper>false</IsWebBootstrapper>
-    <UseApplicationTrust>false</UseApplicationTrust>
-    <BootstrapperEnabled>true</BootstrapperEnabled>
+	
+    <Description>Compile Flow code to C++</Description>
+    <Copyright>Copyright (c) 2013-2017 Apple Inc.</Copyright>
+    <Company>Apple Inc</Company>
+    <Product>actorcompiler</Product>
+    <Authors>c</Authors>
+    <PackageProjectUrl>https://www.foundationdb.org/</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/apple/foundationdb</RepositoryUrl>
+    <PackageLicenseUrl>http://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
-    <DebugSymbols>true</DebugSymbols>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <DebugType>full</DebugType>
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <LangVersion>default</LangVersion>
-    <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisIgnoreBuiltInRuleSets>false</CodeAnalysisIgnoreBuiltInRuleSets>
-    <CodeAnalysisFailOnMissingRules>false</CodeAnalysisFailOnMissingRules>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
-    <DefineConstants>TRACE</DefineConstants>
-    <Optimize>true</Optimize>
-    <DebugType>pdbonly</DebugType>
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <LangVersion>default</LangVersion>
-    <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisIgnoreBuiltInRuleSets>false</CodeAnalysisIgnoreBuiltInRuleSets>
-    <CodeAnalysisIgnoreBuiltInRules>false</CodeAnalysisIgnoreBuiltInRules>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
   </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Core">
-      <RequiredTargetFramework>3.5</RequiredTargetFramework>
-    </Reference>
-    <Reference Include="System.Xml.Linq">
-      <RequiredTargetFramework>3.5</RequiredTargetFramework>
-    </Reference>
-    <Reference Include="System.Data.DataSetExtensions">
-      <RequiredTargetFramework>3.5</RequiredTargetFramework>
-    </Reference>
-    <Reference Include="Microsoft.CSharp">
-      <RequiredTargetFramework>4.0</RequiredTargetFramework>
-    </Reference>
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="ActorCompiler.cs" />
-    <Compile Include="ActorParser.cs" />
-    <Compile Include="ParseTree.cs" />
-    <Compile Include="Program.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <BootstrapperPackage Include=".NETFramework,Version=v4.0">
-      <Visible>False</Visible>
-      <ProductName>Microsoft .NET Framework 4 %28x86 and x64%29</ProductName>
-      <Install>true</Install>
-    </BootstrapperPackage>
-    <BootstrapperPackage Include="Microsoft.Net.Client.3.5">
-      <Visible>False</Visible>
-      <ProductName>.NET Framework 3.5 SP1 Client Profile</ProductName>
-      <Install>false</Install>
-    </BootstrapperPackage>
-    <BootstrapperPackage Include="Microsoft.Net.Framework.3.5.SP1">
-      <Visible>False</Visible>
-      <ProductName>.NET Framework 3.5 SP1</ProductName>
-      <Install>false</Install>
-    </BootstrapperPackage>
-    <BootstrapperPackage Include="Microsoft.Windows.Installer.3.1">
-      <Visible>False</Visible>
-      <ProductName>Windows Installer 3.1</ProductName>
-      <Install>true</Install>
-    </BootstrapperPackage>
-  </ItemGroup>
-  <ItemGroup>
-    <Content Include="Actor checklist.txt" />
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
+
 </Project>


### PR DESCRIPTION
This is a proof of concept of converting the ActorCompiler project to target .NET Core 2.0, as potentially discussed in https://forums.foundationdb.org/t/is-there-a-plan-to-release-the-flow-language-and-sdk/231. Currently only works when building with Visual Studio, and is not ready to merge, also it would have some impact on the build dependencies (dropping Mono) which may have consequences I'm not aware of.

I converted the csproj to the new sdk-style, and targets netcoreapp2.0 (which is redistributed with the latest versions of Visual Studio).

Since by default, console app in .NET Core are now dll, the `actorcompiler.exe` now becomes `actorcompiler.dll` and must be run via `dotnet actorcompiler.dll`. Also, I was not able to make it build directory in `$(SolionDir)\bin\Debug\` and it insist on build in a subfolder `netcoreapp2.0`, which may not be a big problem.

To make it work on mac/linux, I would need to make similar changes to `Makefile` and especially `csproj.mk`, but I also see a `csprojtom4.py` that I'm not sure what it does. If this was there to work around some difficulties in making Mono work on these platforms, it may be obsolete when using the .NET Core SDK directlly?
