### PR TITLE
Move .actor.g.cpp files to .obj/

### DIFF
--- a/build/vcxproj.mk
+++ b/build/vcxproj.mk
@@ -26,10 +26,14 @@ CLEAN_TARGETS += GENNAME()_clean
 GENNAME()_ALL_SOURCES := $(addprefix GENDIR/,GENSOURCES)
 
 GENNAME()_BUILD_SOURCES := $(patsubst %.actor.cpp,%.actor.g.cpp,$(filter-out %.h %.hpp,$(GENNAME()_ALL_SOURCES)))
-GENNAME()_GENERATED_SOURCES := $(patsubst %.actor.h,%.actor.g.h,$(patsubst %.actor.cpp,%.actor.g.cpp,$(filter %.actor.h %.actor.cpp,$(GENNAME()_ALL_SOURCES))))
+GENNAME()_GENERATED_SOURCES := $(patsubst %.actor.h,%.actor.g.h,$(patsubst %.actor.cpp,${OBJDIR}/%.actor.g.cpp,$(filter %.actor.h %.actor.cpp,$(GENNAME()_ALL_SOURCES))))
 GENERATED_SOURCES += $(GENNAME()_GENERATED_SOURCES)
 
 -include GENDIR/local.mk
+
+# We need to include the current directory for .g.actor.cpp files emitted into
+# .objs that use includes not based at the root of fdb.
+GENNAME()_CFLAGS := -I GENDIR -I ${OBJDIR}/GENDIR ${GENNAME()_CFLAGS}
 
 # If we have any static libs, we have to wrap them in the appropriate
 # compiler flag magic
@@ -54,30 +58,34 @@ GENNAME: GENTARGET
 
 -include $(GENNAME()_DEPS)
 
-GENDIR/%.actor.g.cpp: GENDIR/%.actor.cpp $(ACTORCOMPILER)
+$(OBJDIR)/GENDIR/%.actor.g.cpp: GENDIR/%.actor.cpp $(ACTORCOMPILER)
 	@echo "Actorcompiling $<"
+	@mkdir -p $(OBJDIR)/$(<D)
 	@$(MONO) $(ACTORCOMPILER) $< $@ >/dev/null
 
 GENDIR/%.actor.g.h: GENDIR/%.actor.h $(ACTORCOMPILER)
 	@if [ -e $< ]; then echo "Actorcompiling $<" ; $(MONO) $(ACTORCOMPILER) $< $@ >/dev/null ; fi
-.PRECIOUS: GENDIR/%.actor.g.cpp GENDIR/%.actor.g.h
+.PRECIOUS: $(OBJDIR)/GENDIR/%.actor.g.cpp GENDIR/%.actor.g.h
 
 # The order-only dependency on the generated .h files is to force make
 # to actor compile all headers before attempting compilation of any .c
 # or .cpp files. We have no mechanism to detect dependencies on
 # generated headers before compilation.
 
+define run-gplusplus-GENNAME() =
+@mkdir -p $(DEPSDIR)/$(<D) && \
+mkdir -p $(OBJDIR)/$(<D) && \
+$(CCACHE_CXX) $(CFLAGS) $(CXXFLAGS) $(GENNAME()_CFLAGS) $(GENNAME()_CXXFLAGS) -MMD -MT $@ -MF $(DEPSDIR)/$<.d.tmp -c $< -o $@ && \
+cp $(DEPSDIR)/$<.d.tmp $(DEPSDIR)/$<.d && \
+sed -e 's/#.*//' -e 's/^[^:]*: *//' -e 's/ *\\$$//' -e '/^$$/ d' -e 's/$$/ :/' < $(DEPSDIR)/$<.d.tmp >> $(DEPSDIR)/$<.d && \
+rm $(DEPSDIR)/$<.d.tmp
+endef
+
 $(OBJDIR)/GENDIR/%.cpp.o: GENDIR/%.cpp $(ALL_MAKEFILES) | $(filter %.h,$(GENERATED_SOURCES))
-	@echo "Compiling      $<"
-ifeq ($(VERBOSE),1)
-	@echo "$(CCACHE_CXX) $(CFLAGS) $(CXXFLAGS) $(GENNAME()_CFLAGS) $(GENNAME()_CXXFLAGS) -MMD -MT $@ -MF $(DEPSDIR)/$<.d.tmp -c $< -o $@"
-endif
-	@mkdir -p $(DEPSDIR)/$(<D) && \
-	mkdir -p $(OBJDIR)/$(<D) && \
-	$(CCACHE_CXX) $(CFLAGS) $(CXXFLAGS) $(GENNAME()_CFLAGS) $(GENNAME()_CXXFLAGS) -MMD -MT $@ -MF $(DEPSDIR)/$<.d.tmp -c $< -o $@ && \
-	cp $(DEPSDIR)/$<.d.tmp $(DEPSDIR)/$<.d && \
-	sed -e 's/#.*//' -e 's/^[^:]*: *//' -e 's/ *\\$$//' -e '/^$$/ d' -e 's/$$/ :/' < $(DEPSDIR)/$<.d.tmp >> $(DEPSDIR)/$<.d && \
-	rm $(DEPSDIR)/$<.d.tmp
+	${run-gplusplus-GENNAME()}
+
+$(OBJDIR)/GENDIR/%.cpp.o: $(OBJDIR)/GENDIR/%.cpp $(ALL_MAKEFILES) | $(filter %.h,$(GENERATED_SOURCES))
+	${run-gplusplus-GENNAME()}
 
 $(OBJDIR)/GENDIR/%.c.o: GENDIR/%.c $(ALL_MAKEFILES) | $(filter %.h,$(GENERATED_SOURCES))
 	@echo "Compiling      $<"

--- a/fdbserver/local.mk
+++ b/fdbserver/local.mk
@@ -20,7 +20,7 @@
 
 # -*- mode: makefile; -*-
 
-fdbserver_CFLAGS := $(fdbclient_CFLAGS)
+fdbserver_CFLAGS := $(fdbclient_CFLAGS) -I fdbserver/workloads
 fdbserver_LDFLAGS := $(fdbrpc_LDFLAGS)
 fdbserver_LIBS := lib/libfdbclient.a lib/libfdbrpc.a lib/libflow.a
 


### PR DESCRIPTION
This means that grep over our source tree doesn't return 2x the results.