### PR TITLE
Avoid calls that can panic when handling errors

### DIFF
--- a/bindings/go/src/fdb/directory/node.go
+++ b/bindings/go/src/fdb/directory/node.go
@@ -67,5 +67,9 @@ func (n *node) getPartitionSubpath() []string {
 }
 
 func (n *node) getContents(dl directoryLayer, tr *fdb.Transaction) (DirectorySubspace, error) {
-	return dl.contentsOfNode(n.subspace, n.path, n._layer.MustGet())
+	l, err := n._layer.Get()
+	if err != nil {
+		return nil, err
+	}
+	return dl.contentsOfNode(n.subspace, n.path, l)
 }


### PR DESCRIPTION
In the cases where `error` is being handled, prefer to use the methods that return an `error` instead of the version that panic.