### PR TITLE
Fix documentation build

### DIFF
--- a/documentation/sphinx/conf.py
+++ b/documentation/sphinx/conf.py
@@ -32,7 +32,7 @@ extensions = [
     'sphinx.ext.ifconfig',
     'brokenrole',
     'relativelink',
-    'rubydomain'
+    'sphinxcontrib.rubydomain'
 ]
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
The package name for the sphinx ruby domain was set incorrectly. This should fix that build by updating it to the correct one.