### PR TITLE
Crash fix on MacOS with aligned memory allocation of small types.

### DIFF
--- a/flow/Platform.cpp
+++ b/flow/Platform.cpp
@@ -38,6 +38,7 @@
 #include <sstream>
 #include <cstring>
 #include <algorithm>
+#include <stdexcept>
 
 #include <sys/types.h>
 #include <time.h>
@@ -2427,6 +2428,21 @@ std::string get_backtrace() { return std::string(); }
 std::string format_backtrace(void **addresses, int numAddresses) { return std::string(); }
 void* getImageOffset() { return NULL; }
 }; // namespace platform
+#endif
+
+#ifdef __APPLE__
+void* aligned_alloc(size_t alignment, size_t size) {
+	// posix_memalign requires alignment to be an integer multiple of sizeof(void *)
+	if(alignment < sizeof(void *)) {
+		alignment = sizeof(void *);
+	}
+	void* ptr = nullptr;
+	// Check for failure in case of out of memory or size is not a multiple of sizeof(void *)
+	if(posix_memalign(&ptr, alignment, size) != 0) {
+		throw std::bad_alloc();
+	}
+	return ptr;
+}
 #endif
 
 bool isLibraryLoaded(const char* lib_path) {

--- a/flow/Platform.cpp
+++ b/flow/Platform.cpp
@@ -38,7 +38,6 @@
 #include <sstream>
 #include <cstring>
 #include <algorithm>
-#include <stdexcept>
 
 #include <sys/types.h>
 #include <time.h>
@@ -2428,21 +2427,6 @@ std::string get_backtrace() { return std::string(); }
 std::string format_backtrace(void **addresses, int numAddresses) { return std::string(); }
 void* getImageOffset() { return NULL; }
 }; // namespace platform
-#endif
-
-#ifdef __APPLE__
-void* aligned_alloc(size_t alignment, size_t size) {
-	// posix_memalign requires alignment to be an integer multiple of sizeof(void *)
-	if(alignment < sizeof(void *)) {
-		alignment = sizeof(void *);
-	}
-	void* ptr = nullptr;
-	// Check for failure in case of out of memory or size is not a multiple of sizeof(void *)
-	if(posix_memalign(&ptr, alignment, size) != 0) {
-		throw std::bad_alloc();
-	}
-	return ptr;
-}
 #endif
 
 bool isLibraryLoaded(const char* lib_path) {

--- a/flow/Platform.h
+++ b/flow/Platform.h
@@ -494,11 +494,7 @@ inline static void* aligned_alloc(size_t alignment, size_t size) { return memali
 #endif
 #elif defined(__APPLE__)
 #include <cstdlib>
-inline static void* aligned_alloc(size_t alignment, size_t size) {
-	void* ptr = nullptr;
-	posix_memalign(&ptr, alignment, size);
-	return ptr;
-}
+void * aligned_alloc(size_t alignment, size_t size);
 inline static void aligned_free(void* ptr) { free(ptr); }
 #endif
 


### PR DESCRIPTION
Aligned_alloc() would silently fail for alignments less than 8, which happen in Deque<T> for small T's such as Void or Error.

This occurs because on MacOS Platform.h uses posix_memalign which requires alignment to be at least sizeof(void *).  The fix is to force alignment to be at least sizeof(void *) on MacOS.