### PR TITLE
Two structs named ShardInfo in one namespace (but different scopes) results in incorrect linking

### DIFF
--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -404,7 +404,7 @@ ACTOR Future<Reference<InitialDataDistribution>> getInitialDataDistribution( Dat
 
 				// for each range
 				for(int i = 0; i < keyServers.size() - 1; i++) {
-					ShardInfo info( keyServers[i].key );
+					DDShardInfo info( keyServers[i].key );
 					decodeKeyServersValue( keyServers[i].value, src, dest );
 					if(remoteDcIds.size()) {
 						auto srcIter = team_cache.find(src);
@@ -471,7 +471,7 @@ ACTOR Future<Reference<InitialDataDistribution>> getInitialDataDistribution( Dat
 	}
 
 	// a dummy shard at the end with no keys or servers makes life easier for trackInitialShards()
-	result->shards.push_back( ShardInfo(allKeys.end) );
+	result->shards.push_back( DDShardInfo(allKeys.end) );
 
 	return result;
 }

--- a/fdbserver/DataDistribution.h
+++ b/fdbserver/DataDistribution.h
@@ -175,7 +175,8 @@ private:
 	void insert(Team team, KeyRange const& range);
 };
 
-struct ShardInfo {
+// DDShardInfo is so named to avoid link-time name collision with ShardInfo within the StorageServer
+struct DDShardInfo {
 	Key key;
 	vector<UID> primarySrc;
 	vector<UID> remoteSrc;
@@ -183,7 +184,7 @@ struct ShardInfo {
 	vector<UID> remoteDest;
 	bool hasDest;
 
-	explicit ShardInfo(Key key) : key(key), hasDest(false) {}
+	explicit DDShardInfo(Key key) : key(key), hasDest(false) {}
 };
 
 struct InitialDataDistribution : ReferenceCounted<InitialDataDistribution> {
@@ -191,7 +192,7 @@ struct InitialDataDistribution : ReferenceCounted<InitialDataDistribution> {
 	vector<std::pair<StorageServerInterface, ProcessClass>> allServers;
 	std::set<vector<UID>> primaryTeams;
 	std::set<vector<UID>> remoteTeams;
-	vector<ShardInfo> shards;
+	vector<DDShardInfo> shards;
 };
 
 Future<Void> dataDistribution(


### PR DESCRIPTION
This problem is confirmed on Linux and MacOS built with low optimizations, untested on Windows.  Sufficient optimization causes inlining which masks the issue.

The fix was to rename the newer ShardInfo, in DataDistribution.h, to avoid the name collision.

If the names are the same, a low optimization build will cause StorageServer's ShardInfo's parent's delref() to use DataDistribution's ShardInfo destructor instead of its own, despite the fact that DataDistribution's ShardInfo is obviously not in scope.