### PR TITLE
Move TLS libs into STATIC_LIBS to avoid having a make dependency on them.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,7 @@ ifeq ($(PLATFORM),Linux)
   CXXFLAGS += -std=c++0x
 
   BOOSTDIR ?= /opt/boost_1_52_0
+  TLS_LIBDIR ?= /usr/local/lib
   DLEXT := so
   java_DLEXT := so
   TARGET_LIBC_VERSION ?= 2.11
@@ -56,6 +57,7 @@ else ifeq ($(PLATFORM),Darwin)
   .LIBPATTERNS := lib%.dylib lib%.a
 
   BOOSTDIR ?= $(HOME)/boost_1_52_0
+  TLS_LIBDIR ?= /usr/local/lib
   DLEXT := dylib
   java_DLEXT := jnilib
 else
@@ -90,14 +92,11 @@ CFLAGS += -g
 # Define the TLS compilation and link variables
 ifdef TLS_DISABLED
 CFLAGS += -DTLS_DISABLED
+FDB_TLS_LIB :=
 TLS_LIBS :=
 else
-TLS_LIBS := lib/libFDBLibTLS.a
-ifdef TLS_LIBDIR
+FDB_TLS_LIB := lib/libFDBLibTLS.a
 TLS_LIBS += $(addprefix $(TLS_LIBDIR)/,libtls.a libssl.a libcrypto.a)
-else
-TLS_LIBS += libtls.a libssl.a libcrypto.a
-endif
 endif
 
 CXXFLAGS += -Wno-deprecated

--- a/bindings/c/local.mk
+++ b/bindings/c/local.mk
@@ -22,8 +22,8 @@
 
 fdb_c_CFLAGS := $(fdbclient_CFLAGS)
 fdb_c_LDFLAGS := $(fdbrpc_LDFLAGS)
-fdb_c_LIBS := lib/libfdbclient.a lib/libfdbrpc.a lib/libflow.a $(TLS_LIBS)
-fdb_c_STATIC_LIBS :=
+fdb_c_LIBS := lib/libfdbclient.a lib/libfdbrpc.a lib/libflow.a
+fdb_c_STATIC_LIBS := $(TLS_LIBS)
 fdb_c_tests_LIBS := -Llib -lfdb_c
 fdb_c_tests_HEADERS := -Ibindings/c
 

--- a/bindings/c/local.mk
+++ b/bindings/c/local.mk
@@ -22,7 +22,7 @@
 
 fdb_c_CFLAGS := $(fdbclient_CFLAGS)
 fdb_c_LDFLAGS := $(fdbrpc_LDFLAGS)
-fdb_c_LIBS := lib/libfdbclient.a lib/libfdbrpc.a lib/libflow.a
+fdb_c_LIBS := lib/libfdbclient.a lib/libfdbrpc.a lib/libflow.a $(FDB_TLS_LIB)
 fdb_c_STATIC_LIBS := $(TLS_LIBS)
 fdb_c_tests_LIBS := -Llib -lfdb_c
 fdb_c_tests_HEADERS := -Ibindings/c

--- a/build/vcxproj.mk
+++ b/build/vcxproj.mk
@@ -40,7 +40,9 @@ GENNAME()_CFLAGS := -I GENDIR -I ${OBJDIR}/GENDIR ${GENNAME()_CFLAGS}
 ifeq ($(GENNAME()_STATIC_LIBS),)
   GENNAME()_STATIC_LIBS_REAL :=
 else
-  GENNAME()_STATIC_LIBS_REAL := -Wl,-Bstatic $(GENNAME()_STATIC_LIBS) -Wl,-Bdynamic
+# MacOS doesn't recognize -Wl,-Bstatic, but is happy with -Bstatic
+# gcc will handle both, so we prefer the non -Wl version
+  GENNAME()_STATIC_LIBS_REAL := -Bstatic $(GENNAME()_STATIC_LIBS) -Bdynamic
 endif
 
 # If we have any -L directives in our LDFLAGS, we need to add those
@@ -126,6 +128,6 @@ GENNAME()_clean:
 	@rm -rf $(DEPSDIR)/GENDIR
 	@rm -rf $(OBJDIR)/GENDIR
 
-GENTARGET: $(GENNAME()_OBJECTS) $(GENNAME()_LIBS) $(GENNAME()_STATIC_LIBS) $(ALL_MAKEFILES) build/link-wrapper.sh build/link-validate.sh
+GENTARGET: $(GENNAME()_OBJECTS) $(GENNAME()_LIBS) $(ALL_MAKEFILES) build/link-wrapper.sh build/link-validate.sh
 	@mkdir -p GENOUTDIR
 	@./build/link-wrapper.sh GENCONFIGTYPE GENNAME $@ $(TARGET_LIBC_VERSION)

--- a/fdbbackup/local.mk
+++ b/fdbbackup/local.mk
@@ -22,8 +22,8 @@
 
 fdbbackup_CFLAGS := $(fdbclient_CFLAGS)
 fdbbackup_LDFLAGS := $(fdbrpc_LDFLAGS)
-fdbbackup_LIBS := lib/libfdbclient.a lib/libfdbrpc.a lib/libflow.a $(TLS_LIBS)
-fdbbackup_STATIC_LIBS :=
+fdbbackup_LIBS := lib/libfdbclient.a lib/libfdbrpc.a lib/libflow.a
+fdbbackup_STATIC_LIBS := $(TLS_LIBS)
 
 ifeq ($(PLATFORM),linux)
   fdbbackup_LIBS += -ldl -lpthread -lrt

--- a/fdbbackup/local.mk
+++ b/fdbbackup/local.mk
@@ -22,7 +22,7 @@
 
 fdbbackup_CFLAGS := $(fdbclient_CFLAGS)
 fdbbackup_LDFLAGS := $(fdbrpc_LDFLAGS)
-fdbbackup_LIBS := lib/libfdbclient.a lib/libfdbrpc.a lib/libflow.a
+fdbbackup_LIBS := lib/libfdbclient.a lib/libfdbrpc.a lib/libflow.a $(FDB_TLS_LIB)
 fdbbackup_STATIC_LIBS := $(TLS_LIBS)
 
 ifeq ($(PLATFORM),linux)

--- a/fdbcli/local.mk
+++ b/fdbcli/local.mk
@@ -22,8 +22,8 @@
 
 fdbcli_CFLAGS := $(fdbclient_CFLAGS)
 fdbcli_LDFLAGS := $(fdbrpc_LDFLAGS)
-fdbcli_LIBS := lib/libfdbclient.a lib/libfdbrpc.a lib/libflow.a -ldl $(TLS_LIBS)
-fdbcli_STATIC_LIBS :=
+fdbcli_LIBS := lib/libfdbclient.a lib/libfdbrpc.a lib/libflow.a -ldl
+fdbcli_STATIC_LIBS := $(TLS_LIBS)
 
 fdbcli_GENERATED_SOURCES += versions.h
 

--- a/fdbcli/local.mk
+++ b/fdbcli/local.mk
@@ -22,7 +22,7 @@
 
 fdbcli_CFLAGS := $(fdbclient_CFLAGS)
 fdbcli_LDFLAGS := $(fdbrpc_LDFLAGS)
-fdbcli_LIBS := lib/libfdbclient.a lib/libfdbrpc.a lib/libflow.a -ldl
+fdbcli_LIBS := lib/libfdbclient.a lib/libfdbrpc.a lib/libflow.a -ldl $(FDB_TLS_LIB)
 fdbcli_STATIC_LIBS := $(TLS_LIBS)
 
 fdbcli_GENERATED_SOURCES += versions.h

--- a/fdbserver/local.mk
+++ b/fdbserver/local.mk
@@ -22,8 +22,8 @@
 
 fdbserver_CFLAGS := $(fdbclient_CFLAGS) -I fdbserver/workloads
 fdbserver_LDFLAGS := $(fdbrpc_LDFLAGS)
-fdbserver_LIBS := lib/libfdbclient.a lib/libfdbrpc.a lib/libflow.a $(TLS_LIBS)
-fdbserver_STATIC_LIBS :=
+fdbserver_LIBS := lib/libfdbclient.a lib/libfdbrpc.a lib/libflow.a
+fdbserver_STATIC_LIBS := $(TLS_LIBS)
 
 ifeq ($(PLATFORM),linux)
   fdbserver_LIBS += -ldl -lpthread -lrt

--- a/fdbserver/local.mk
+++ b/fdbserver/local.mk
@@ -22,7 +22,7 @@
 
 fdbserver_CFLAGS := $(fdbclient_CFLAGS) -I fdbserver/workloads
 fdbserver_LDFLAGS := $(fdbrpc_LDFLAGS)
-fdbserver_LIBS := lib/libfdbclient.a lib/libfdbrpc.a lib/libflow.a
+fdbserver_LIBS := lib/libfdbclient.a lib/libfdbrpc.a lib/libflow.a $(FDB_TLS_LIB)
 fdbserver_STATIC_LIBS := $(TLS_LIBS)
 
 ifeq ($(PLATFORM),linux)


### PR DESCRIPTION
And fix STATIC_LIBS to be cross platform.