### PR TITLE
Bump API version from 520 to 600

### DIFF
--- a/bindings/bindingtester/__init__.py
+++ b/bindings/bindingtester/__init__.py
@@ -25,7 +25,7 @@ sys.path[:0] = [os.path.join(os.path.dirname(__file__), '..', '..', 'bindings', 
 
 import util
 
-FDB_API_VERSION = 520
+FDB_API_VERSION = 600
 
 LOGGING = {
     'version': 1,

--- a/bindings/bindingtester/bindingtester.py
+++ b/bindings/bindingtester/bindingtester.py
@@ -141,7 +141,7 @@ def choose_api_version(selected_api_version, tester_min_version, tester_max_vers
             api_version = min_version
         elif random.random() < 0.9:
             api_version = random.choice([v for v in [13, 14, 16, 21, 22, 23, 100, 200, 300, 400, 410, 420, 430,
-                                                     440, 450, 460, 500, 510, 520] if v >= min_version and v <= max_version])
+                                                     440, 450, 460, 500, 510, 520, 600] if v >= min_version and v <= max_version])
         else:
             api_version = random.randint(min_version, max_version)
 

--- a/bindings/bindingtester/known_testers.py
+++ b/bindings/bindingtester/known_testers.py
@@ -20,7 +20,7 @@
 
 import os
 
-MAX_API_VERSION = 520
+MAX_API_VERSION = 600
 COMMON_TYPES = ['null', 'bytes', 'string', 'int', 'uuid', 'bool', 'float', 'double', 'tuple']
 ALL_TYPES = COMMON_TYPES + ['versionstamp']
 

--- a/bindings/bindingtester/tests/scripted.py
+++ b/bindings/bindingtester/tests/scripted.py
@@ -34,7 +34,7 @@ fdb.api_version(FDB_API_VERSION)
 
 
 class ScriptedTest(Test):
-    TEST_API_VERSION = 520
+    TEST_API_VERSION = 600
 
     def __init__(self, subspace):
         super(ScriptedTest, self).__init__(subspace, ScriptedTest.TEST_API_VERSION, ScriptedTest.TEST_API_VERSION)

--- a/bindings/c/fdb_c.cpp
+++ b/bindings/c/fdb_c.cpp
@@ -18,7 +18,7 @@
  * limitations under the License.
  */
 
-#define FDB_API_VERSION 520
+#define FDB_API_VERSION 600
 
 #include "fdbclient/MultiVersionTransaction.h"
 #include "foundationdb/fdb_c.h"

--- a/bindings/c/foundationdb/fdb_c.h
+++ b/bindings/c/foundationdb/fdb_c.h
@@ -28,10 +28,10 @@
 #endif
 
 #if !defined(FDB_API_VERSION)
-#error You must #define FDB_API_VERSION prior to including fdb_c.h (current version is 520)
+#error You must #define FDB_API_VERSION prior to including fdb_c.h (current version is 600)
 #elif FDB_API_VERSION < 13
 #error API version no longer supported (upgrade to 13)
-#elif FDB_API_VERSION > 520
+#elif FDB_API_VERSION > 600
 #error Requested API version requires a newer version of this header
 #endif
 

--- a/bindings/c/test/performance_test.c
+++ b/bindings/c/test/performance_test.c
@@ -603,7 +603,7 @@ void runTests(struct ResultSet *rs) {
 int main(int argc, char **argv) {
 	srand(time(NULL));
 	struct ResultSet *rs = newResultSet();
-	checkError(fdb_select_api_version(520), "select API version", rs);
+	checkError(fdb_select_api_version(600), "select API version", rs);
 	printf("Running performance test at client version: %s\n", fdb_get_client_version());
 
 	valueStr = (uint8_t*)malloc((sizeof(uint8_t))*valueSize);

--- a/bindings/c/test/ryw_benchmark.c
+++ b/bindings/c/test/ryw_benchmark.c
@@ -244,7 +244,7 @@ void runTests(struct ResultSet *rs) {
 int main(int argc, char **argv) {
 	srand(time(NULL));
 	struct ResultSet *rs = newResultSet();
-	checkError(fdb_select_api_version(520), "select API version", rs);
+	checkError(fdb_select_api_version(600), "select API version", rs);
 	printf("Running RYW Benchmark test at client version: %s\n", fdb_get_client_version());
 
 	keys = generateKeys(numKeys, keySize);

--- a/bindings/c/test/test.h
+++ b/bindings/c/test/test.h
@@ -27,7 +27,7 @@
 #include <pthread.h>
 
 #ifndef FDB_API_VERSION
-#define FDB_API_VERSION 520
+#define FDB_API_VERSION 600
 #endif
 
 #include <foundationdb/fdb_c.h>

--- a/bindings/flow/fdb_flow.actor.cpp
+++ b/bindings/flow/fdb_flow.actor.cpp
@@ -33,7 +33,7 @@ THREAD_FUNC networkThread(void* fdb) {
 }
 
 ACTOR Future<Void> _test() {
-	API *fdb = FDB::API::selectAPIVersion(520);
+	API *fdb = FDB::API::selectAPIVersion(600);
 	auto c = fdb->createCluster( std::string() );
 	auto db = c->createDatabase();
 	state Reference<Transaction> tr( new Transaction(db) );
@@ -77,7 +77,7 @@ ACTOR Future<Void> _test() {
 }
 
 void fdb_flow_test() {
-	API *fdb = FDB::API::selectAPIVersion(520);
+	API *fdb = FDB::API::selectAPIVersion(600);
 	fdb->setupNetwork();
 	startThread(networkThread, fdb);
 

--- a/bindings/flow/fdb_flow.h
+++ b/bindings/flow/fdb_flow.h
@@ -23,7 +23,7 @@
 
 #include <flow/flow.h>
 
-#define FDB_API_VERSION 520
+#define FDB_API_VERSION 600
 #include <bindings/c/foundationdb/fdb_c.h>
 #undef DLLEXPORT
 

--- a/bindings/flow/tester/Tester.actor.cpp
+++ b/bindings/flow/tester/Tester.actor.cpp
@@ -1739,7 +1739,7 @@ ACTOR void _test_versionstamp() {
 	try {
 		g_network = newNet2(NetworkAddress(), false);
 
-		API *fdb = FDB::API::selectAPIVersion(520);
+		API *fdb = FDB::API::selectAPIVersion(600);
 
 		fdb->setupNetwork();
 		startThread(networkThread, fdb);

--- a/bindings/go/README.md
+++ b/bindings/go/README.md
@@ -9,7 +9,7 @@ This package requires:
 - [Mono](http://www.mono-project.com/) (macOS or Windows) or [Visual Studio](https://www.visualstudio.com/) (Windows)  (build-time only)
 - FoundationDB C API 2.0.x, 3.0.x, or 4.x.y (part of the [FoundationDB clients package](https://apple.github.io/foundationdb/downloads.html#c))
 
-Use of this package requires the selection of a FoundationDB API version at runtime. This package currently supports FoundationDB API versions 200-520.
+Use of this package requires the selection of a FoundationDB API version at runtime. This package currently supports FoundationDB API versions 200-600.
 
 To build this package, in the top level of this repository run:
 

--- a/bindings/go/src/fdb/cluster.go
+++ b/bindings/go/src/fdb/cluster.go
@@ -23,7 +23,7 @@
 package fdb
 
 /*
- #define FDB_API_VERSION 520
+ #define FDB_API_VERSION 600
  #include <foundationdb/fdb_c.h>
 */
 import "C"

--- a/bindings/go/src/fdb/database.go
+++ b/bindings/go/src/fdb/database.go
@@ -23,7 +23,7 @@
 package fdb
 
 /*
- #define FDB_API_VERSION 520
+ #define FDB_API_VERSION 600
  #include <foundationdb/fdb_c.h>
 */
 import "C"

--- a/bindings/go/src/fdb/errors.go
+++ b/bindings/go/src/fdb/errors.go
@@ -23,7 +23,7 @@
 package fdb
 
 /*
- #define FDB_API_VERSION 520
+ #define FDB_API_VERSION 600
  #include <foundationdb/fdb_c.h>
 */
 import "C"

--- a/bindings/go/src/fdb/fdb.go
+++ b/bindings/go/src/fdb/fdb.go
@@ -23,7 +23,7 @@
 package fdb
 
 /*
- #define FDB_API_VERSION 520
+ #define FDB_API_VERSION 600
  #include <foundationdb/fdb_c.h>
  #include <stdlib.h>
 */
@@ -109,7 +109,7 @@ func (opt NetworkOptions) setOpt(code int, param []byte) error {
 // library, an error will be returned. APIVersion must be called prior to any
 // other functions in the fdb package.
 //
-// Currently, this package supports API versions 200 through 520.
+// Currently, this package supports API versions 200 through 600.
 //
 // Warning: When using the multi-version client API, setting an API version that
 // is not supported by a particular client library will prevent that client from
@@ -117,7 +117,7 @@ func (opt NetworkOptions) setOpt(code int, param []byte) error {
 // the API version of your application after upgrading your client until the
 // cluster has also been upgraded.
 func APIVersion(version int) error {
-	headerVersion := 520
+	headerVersion := 600
 
 	networkMutex.Lock()
 	defer networkMutex.Unlock()
@@ -129,7 +129,7 @@ func APIVersion(version int) error {
 		return errAPIVersionAlreadySet
 	}
 
-	if version < 200 || version > 520 {
+	if version < 200 || version > 600 {
 		return errAPIVersionNotSupported
 	}
 

--- a/bindings/go/src/fdb/futures.go
+++ b/bindings/go/src/fdb/futures.go
@@ -24,7 +24,7 @@ package fdb
 
 /*
  #cgo LDFLAGS: -lfdb_c -lm
- #define FDB_API_VERSION 520
+ #define FDB_API_VERSION 600
  #include <foundationdb/fdb_c.h>
  #include <string.h>
 

--- a/bindings/go/src/fdb/generated.go
+++ b/bindings/go/src/fdb/generated.go
@@ -71,9 +71,9 @@ func (o NetworkOptions) SetTraceMaxLogsSize(param int64) error {
 	return o.setOpt(32, b)
 }
 
-// Sets the 'logGroup' attribute with the specified value for all events in the trace output files. The default log group is 'default'.
+// Sets the 'LogGroup' attribute with the specified value for all events in the trace output files. The default log group is 'default'.
 //
-// Parameter: value of the logGroup attribute
+// Parameter: value of the LogGroup attribute
 func (o NetworkOptions) SetTraceLogGroup(param string) error {
 	return o.setOpt(33, []byte(param))
 }
@@ -383,11 +383,6 @@ func (o TransactionOptions) SetUsedDuringCommitProtectionDisable() error {
 // The transaction can read from locked databases.
 func (o TransactionOptions) SetReadLockAware() error {
 	return o.setOpt(702, nil)
-}
-
-// No other transactions will be applied before this transaction within the same commit version.
-func (o TransactionOptions) SetFirstInBatch() error {
-	return o.setOpt(710, nil)
 }
 
 type StreamingMode int

--- a/bindings/go/src/fdb/range.go
+++ b/bindings/go/src/fdb/range.go
@@ -23,7 +23,7 @@
 package fdb
 
 /*
- #define FDB_API_VERSION 520
+ #define FDB_API_VERSION 600
  #include <foundationdb/fdb_c.h>
 */
 import "C"

--- a/bindings/go/src/fdb/transaction.go
+++ b/bindings/go/src/fdb/transaction.go
@@ -23,7 +23,7 @@
 package fdb
 
 /*
- #define FDB_API_VERSION 520
+ #define FDB_API_VERSION 600
  #include <foundationdb/fdb_c.h>
 */
 import "C"

--- a/bindings/java/fdbJNI.cpp
+++ b/bindings/java/fdbJNI.cpp
@@ -21,7 +21,7 @@
 #include <jni.h>
 #include <string.h>
 
-#define FDB_API_VERSION 520
+#define FDB_API_VERSION 600
 
 #include <foundationdb/fdb_c.h>
 

--- a/bindings/java/src/main/com/apple/foundationdb/FDB.java
+++ b/bindings/java/src/main/com/apple/foundationdb/FDB.java
@@ -35,7 +35,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  *   This call is required before using any other part of the API. The call allows
  *   an error to be thrown at this point to prevent client code from accessing a later library
  *   with incorrect assumptions from the current version. The API version documented here is version
- *   {@code 520}.<br><br>
+ *   {@code 600}.<br><br>
  *  FoundationDB encapsulates multiple versions of its interface by requiring
  *   the client to explicitly specify the version of the API it uses. The purpose
  *   of this design is to allow you to upgrade the server, client libraries, or
@@ -181,8 +181,8 @@ public class FDB {
 		}
 		if(version < 510)
 			throw new IllegalArgumentException("API version not supported (minimum 510)");
-		if(version > 520)
-			throw new IllegalArgumentException("API version not supported (maximum 520)");
+		if(version > 600)
+			throw new IllegalArgumentException("API version not supported (maximum 600)");
 
 		Select_API_version(version);
 		FDB fdb = new FDB(version);

--- a/bindings/java/src/main/overview.html.in
+++ b/bindings/java/src/main/overview.html.in
@@ -13,7 +13,7 @@ and then added to your classpath.<br>
 <h3>Getting started</h3>
 To start using FoundationDB from Java, create an instance of the 
 {@link com.apple.foundationdb.FDB FoundationDB API interface} with the version of the
-API that you want to use (this release of the FoundationDB Java API supports versions between {@code 510} and {@code 520}).
+API that you want to use (this release of the FoundationDB Java API supports versions between {@code 510} and {@code 600}).
 With this API object you can then open {@link com.apple.foundationdb.Cluster Cluster}s and
 {@link com.apple.foundationdb.Database Database}s and start using
 {@link com.apple.foundationdb.Transaction Transaction}s.
@@ -29,7 +29,7 @@ import com.apple.foundationdb.tuple.Tuple;
 
 public class Example {
   public static void main(String[] args) {
-    FDB fdb = FDB.selectAPIVersion(520);
+    FDB fdb = FDB.selectAPIVersion(600);
 
     try(Database db = fdb.open()) {
       // Run an operation on the database

--- a/bindings/java/src/test/com/apple/foundationdb/test/AbstractTester.java
+++ b/bindings/java/src/test/com/apple/foundationdb/test/AbstractTester.java
@@ -27,7 +27,7 @@ import com.apple.foundationdb.Database;
 import com.apple.foundationdb.FDB;
 
 public abstract class AbstractTester {
-	public static final int API_VERSION = 520;
+	public static final int API_VERSION = 600;
 	protected static final int NUM_RUNS = 25;
 	protected static final Charset ASCII = Charset.forName("ASCII");
 

--- a/bindings/java/src/test/com/apple/foundationdb/test/BlockingBenchmark.java
+++ b/bindings/java/src/test/com/apple/foundationdb/test/BlockingBenchmark.java
@@ -33,7 +33,7 @@ public class BlockingBenchmark {
 	private static final int PARALLEL = 100;
 
 	public static void main(String[] args) throws InterruptedException {
-		FDB fdb = FDB.selectAPIVersion(520);
+		FDB fdb = FDB.selectAPIVersion(600);
 
 		// The cluster file DOES NOT need to be valid, although it must exist.
 		//  This is because the database is never really contacted in this test.

--- a/bindings/java/src/test/com/apple/foundationdb/test/ConcurrentGetSetGet.java
+++ b/bindings/java/src/test/com/apple/foundationdb/test/ConcurrentGetSetGet.java
@@ -48,7 +48,7 @@ public class ConcurrentGetSetGet {
 	}
 
 	public static void main(String[] args) {
-		try(Database database = FDB.selectAPIVersion(520).open()) {
+		try(Database database = FDB.selectAPIVersion(600).open()) {
 			new ConcurrentGetSetGet().apply(database);
 		}
 	}

--- a/bindings/java/src/test/com/apple/foundationdb/test/DirectoryTest.java
+++ b/bindings/java/src/test/com/apple/foundationdb/test/DirectoryTest.java
@@ -33,7 +33,7 @@ import com.apple.foundationdb.directory.DirectorySubspace;
 public class DirectoryTest {
 	public static void main(String[] args) throws Exception {
 		try {
-			FDB fdb = FDB.selectAPIVersion(520);
+			FDB fdb = FDB.selectAPIVersion(600);
 			try(Database db = fdb.open()) {
 				runTests(db);
 			}

--- a/bindings/java/src/test/com/apple/foundationdb/test/Example.java
+++ b/bindings/java/src/test/com/apple/foundationdb/test/Example.java
@@ -26,7 +26,7 @@ import com.apple.foundationdb.tuple.Tuple;
 
 public class Example {
 	public static void main(String[] args) {
-		FDB fdb = FDB.selectAPIVersion(520);
+		FDB fdb = FDB.selectAPIVersion(600);
 
 		try(Database db = fdb.open()) {
 			// Run an operation on the database

--- a/bindings/java/src/test/com/apple/foundationdb/test/IterableTest.java
+++ b/bindings/java/src/test/com/apple/foundationdb/test/IterableTest.java
@@ -31,7 +31,7 @@ public class IterableTest {
 	public static void main(String[] args) throws InterruptedException {
 		final int reps = 1000;
 		try {
-			FDB fdb = FDB.selectAPIVersion(520);
+			FDB fdb = FDB.selectAPIVersion(600);
 			try(Database db = fdb.open()) {
 				runTests(reps, db);
 			}

--- a/bindings/java/src/test/com/apple/foundationdb/test/LocalityTests.java
+++ b/bindings/java/src/test/com/apple/foundationdb/test/LocalityTests.java
@@ -34,7 +34,7 @@ import com.apple.foundationdb.tuple.ByteArrayUtil;
 public class LocalityTests {
 
 	public static void main(String[] args) {
-		FDB fdb = FDB.selectAPIVersion(520);
+		FDB fdb = FDB.selectAPIVersion(600);
 		try(Database database = fdb.open(args[0])) {
 			try(Transaction tr = database.createTransaction()) {
 				String[] keyAddresses = LocalityUtil.getAddressesForKey(tr, "a".getBytes()).join();

--- a/bindings/java/src/test/com/apple/foundationdb/test/ParallelRandomScan.java
+++ b/bindings/java/src/test/com/apple/foundationdb/test/ParallelRandomScan.java
@@ -43,7 +43,7 @@ public class ParallelRandomScan {
 	private static final int PARALLELISM_STEP = 5;
 
 	public static void main(String[] args) throws InterruptedException {
-		FDB api = FDB.selectAPIVersion(520);
+		FDB api = FDB.selectAPIVersion(600);
 		try(Database database = api.open(args[0])) {
 			for(int i = PARALLELISM_MIN; i <= PARALLELISM_MAX; i += PARALLELISM_STEP) {
 				runTest(database, i, ROWS, DURATION_MS);

--- a/bindings/java/src/test/com/apple/foundationdb/test/RangeTest.java
+++ b/bindings/java/src/test/com/apple/foundationdb/test/RangeTest.java
@@ -34,7 +34,7 @@ import com.apple.foundationdb.Transaction;
 import com.apple.foundationdb.async.AsyncIterable;
 
 public class RangeTest {
-	private static final int API_VERSION = 520;
+	private static final int API_VERSION = 600;
 
 	public static void main(String[] args) {
 		System.out.println("About to use version " + API_VERSION);

--- a/bindings/java/src/test/com/apple/foundationdb/test/SerialInsertion.java
+++ b/bindings/java/src/test/com/apple/foundationdb/test/SerialInsertion.java
@@ -34,7 +34,7 @@ public class SerialInsertion {
 	private static final int NODES = 1000000;
 
 	public static void main(String[] args) {
-		FDB api = FDB.selectAPIVersion(520);
+		FDB api = FDB.selectAPIVersion(600);
 		try(Database database = api.open()) {
 			long start = System.currentTimeMillis();
 

--- a/bindings/java/src/test/com/apple/foundationdb/test/SerialIteration.java
+++ b/bindings/java/src/test/com/apple/foundationdb/test/SerialIteration.java
@@ -39,7 +39,7 @@ public class SerialIteration {
 	private static final int THREAD_COUNT = 1;
 
 	public static void main(String[] args) throws InterruptedException {
-		FDB api = FDB.selectAPIVersion(520);
+		FDB api = FDB.selectAPIVersion(600);
 		try(Database database = api.open(args[0])) {
 			for(int i = 1; i <= THREAD_COUNT; i++) {
 				runThreadedTest(database, i);

--- a/bindings/java/src/test/com/apple/foundationdb/test/SerialTest.java
+++ b/bindings/java/src/test/com/apple/foundationdb/test/SerialTest.java
@@ -30,7 +30,7 @@ public class SerialTest {
 	public static void main(String[] args) throws InterruptedException {
 		final int reps = 1000;
 		try {
-			FDB fdb = FDB.selectAPIVersion(520);
+			FDB fdb = FDB.selectAPIVersion(600);
 			try(Database db = fdb.open()) {
 				runTests(reps, db);
 			}

--- a/bindings/java/src/test/com/apple/foundationdb/test/TupleTest.java
+++ b/bindings/java/src/test/com/apple/foundationdb/test/TupleTest.java
@@ -29,7 +29,7 @@ public class TupleTest {
 	public static void main(String[] args) throws InterruptedException {
 		final int reps = 1000;
 		try {
-			FDB fdb = FDB.selectAPIVersion(520);
+			FDB fdb = FDB.selectAPIVersion(600);
 			try(Database db = fdb.open()) {
 				runTests(reps, db);
 			}

--- a/bindings/java/src/test/com/apple/foundationdb/test/VersionstampSmokeTest.java
+++ b/bindings/java/src/test/com/apple/foundationdb/test/VersionstampSmokeTest.java
@@ -32,7 +32,7 @@ import com.apple.foundationdb.tuple.Versionstamp;
 
 public class VersionstampSmokeTest {
 	public static void main(String[] args) {
-		FDB fdb = FDB.selectAPIVersion(520);
+		FDB fdb = FDB.selectAPIVersion(600);
 		try(Database db = fdb.open()) {
 			db.run(tr -> {
 				tr.clear(Tuple.from("prefix").range());

--- a/bindings/java/src/test/com/apple/foundationdb/test/WatchTest.java
+++ b/bindings/java/src/test/com/apple/foundationdb/test/WatchTest.java
@@ -34,7 +34,7 @@ import com.apple.foundationdb.Transaction;
 public class WatchTest {
 
 	public static void main(String[] args) {
-		FDB fdb = FDB.selectAPIVersion(520);
+		FDB fdb = FDB.selectAPIVersion(600);
 		try(Database database = fdb.open(args[0])) {
 			database.options().setLocationCacheSize(42);
 			try(Transaction tr = database.createTransaction()) {

--- a/bindings/python/fdb/__init__.py
+++ b/bindings/python/fdb/__init__.py
@@ -52,7 +52,7 @@ def get_api_version():
 
 
 def api_version(ver):
-    header_version = 520
+    header_version = 600
 
     if '_version' in globals():
         if globals()['_version'] != ver:

--- a/bindings/ruby/lib/fdb.rb
+++ b/bindings/ruby/lib/fdb.rb
@@ -36,7 +36,7 @@ module FDB
     end
   end
   def self.api_version(version)
-    header_version = 520
+    header_version = 600
     if self.is_api_version_selected?()
       if @@chosen_version != version
         raise "FDB API already loaded at version #{@@chosen_version}."

--- a/documentation/sphinx/source/api-c.rst
+++ b/documentation/sphinx/source/api-c.rst
@@ -118,7 +118,7 @@ API versioning
 
 Prior to including ``fdb_c.h``, you must define the :macro:`FDB_API_VERSION` macro. This, together with the :func:`fdb_select_api_version()` function, allows programs written against an older version of the API to compile and run with newer versions of the C library. The current version of the FoundationDB C API is |api-version|. ::
 
-  #define FDB_API_VERSION 520
+  #define FDB_API_VERSION 600
   #include <foundationdb/fdb_c.h>
 
 .. function:: fdb_error_t fdb_select_api_version(int version)

--- a/documentation/sphinx/source/api-common.rst.inc
+++ b/documentation/sphinx/source/api-common.rst.inc
@@ -147,7 +147,7 @@
 .. |atomic-versionstamps-tuple-warning-value| replace::
     At this time, versionstamped values are not compatible with the Tuple layer.
 
-.. |api-version| replace:: 520
+.. |api-version| replace:: 600
 
 .. |streaming-mode-blurb1| replace::
     When using |get-range-func| and similar interfaces, API clients can request large ranges of the database to iterate over.  Making such a request doesn't necessarily mean that the client will consume all of the data in the range - sometimes the client doesn't know how far it intends to iterate in advance.  FoundationDB tries to balance latency and bandwidth by requesting data for iteration in batches.

--- a/documentation/sphinx/source/api-python.rst
+++ b/documentation/sphinx/source/api-python.rst
@@ -89,7 +89,7 @@ Opening a database
 After importing the ``fdb`` module and selecting an API version, you probably want to open a :class:`Database`. The simplest way of doing this is using :func:`open`::
 
     import fdb
-    fdb.api_version(520)
+    fdb.api_version(600)
     db = fdb.open()
 
 .. function:: open( cluster_file=None, db_name="DB", event_model=None )

--- a/documentation/sphinx/source/api-ruby.rst
+++ b/documentation/sphinx/source/api-ruby.rst
@@ -78,7 +78,7 @@ Opening a database
 After requiring the ``FDB`` gem and selecting an API version, you probably want to open a :class:`Database`. The simplest way of doing this is using :func:`open`::
 
     require 'fdb'
-    FDB.api_version 520
+    FDB.api_version 600
     db = FDB.open
 
 .. function:: open( cluster_file=nil, db_name="DB" ) -> Database

--- a/documentation/sphinx/source/class-scheduling-go.rst
+++ b/documentation/sphinx/source/class-scheduling-go.rst
@@ -29,7 +29,7 @@ Before using the API, we need to specify the API version. This allows programs t
 
 .. code-block:: go
 
-  fdb.MustAPIVersion(520)
+  fdb.MustAPIVersion(600)
 
 Next, we open a FoundationDB database.  The API will connect to the FoundationDB cluster indicated by the :ref:`default cluster file <default-cluster-file>`.
 
@@ -78,7 +78,7 @@ If this is all working, it looks like we are ready to start building a real appl
 
   func main() {
       // Different API versions may expose different runtime behaviors.
-      fdb.MustAPIVersion(520)
+      fdb.MustAPIVersion(600)
 
       // Open the default database from the system cluster
       db := fdb.MustOpenDefault()
@@ -661,7 +661,7 @@ Here's the code for the scheduling tutorial:
   }
 
   func main() {
-    fdb.MustAPIVersion(520)
+    fdb.MustAPIVersion(600)
     db := fdb.MustOpenDefault()
 
     schedulingDir, err := directory.CreateOrOpen(db, []string{"scheduling"}, nil)

--- a/documentation/sphinx/source/class-scheduling-java.rst
+++ b/documentation/sphinx/source/class-scheduling-java.rst
@@ -30,7 +30,7 @@ Before using the API, we need to specify the API version. This allows programs t
   private static final Database db;
 
   static {
-    fdb = FDB.selectAPIVersion(520);
+    fdb = FDB.selectAPIVersion(600);
     db = fdb.open();
   }
 
@@ -66,7 +66,7 @@ If this is all working, it looks like we are ready to start building a real appl
     private static final Database db;
 
     static {
-      fdb = FDB.selectAPIVersion(520);
+      fdb = FDB.selectAPIVersion(600);
       db = fdb.open();
     }
 
@@ -436,7 +436,7 @@ Here's the code for the scheduling tutorial:
     private static final Database db;
 
     static {
-      fdb = FDB.selectAPIVersion(520);
+      fdb = FDB.selectAPIVersion(600);
       db = fdb.open();
     }
 

--- a/documentation/sphinx/source/class-scheduling-ruby.rst
+++ b/documentation/sphinx/source/class-scheduling-ruby.rst
@@ -23,7 +23,7 @@ Open a Ruby interactive interpreter and import the FoundationDB API module::
 
 Before using the API, we need to specify the API version. This allows programs to maintain compatibility even if the API is modified in future versions::
 
-    > FDB.api_version 520
+    > FDB.api_version 600
     => nil
 
 Next, we open a FoundationDB database.  The API will connect to the FoundationDB cluster indicated by the :ref:`default cluster file <default-cluster-file>`. ::
@@ -46,7 +46,7 @@ If this is all working, it looks like we are ready to start building a real appl
 .. code-block:: ruby
 
     require 'fdb'
-    FDB.api_version 520
+    FDB.api_version 600
     @db = FDB.open
     @db['hello'] = 'world'
     print 'hello ', @db['hello']
@@ -368,7 +368,7 @@ Here's the code for the scheduling tutorial:
 
     require 'fdb'
 
-    FDB.api_version 520
+    FDB.api_version 600
 
     ####################################
     ##        Initialization          ##

--- a/documentation/sphinx/source/class-scheduling.rst
+++ b/documentation/sphinx/source/class-scheduling.rst
@@ -30,7 +30,7 @@ Open a Python interactive interpreter and import the FoundationDB API module::
 
 Before using the API, we need to specify the API version. This allows programs to maintain compatibility even if the API is modified in future versions::
 
-    >>> fdb.api_version(520)
+    >>> fdb.api_version(600)
 
 Next, we open a FoundationDB database.  The API will connect to the FoundationDB cluster indicated by the :ref:`default cluster file <default-cluster-file>`. ::
 
@@ -48,7 +48,7 @@ When this command returns without exception, the modification is durably stored 
 If this is all working, it looks like we are ready to start building a real application. For reference, here's the full code for "hello world"::
 
     import fdb
-    fdb.api_version(520)
+    fdb.api_version(600)
     db = fdb.open()
     db[b'hello'] = b'world'
     print 'hello', db[b'hello']
@@ -91,7 +91,7 @@ FoundationDB includes a few tools that make it easy to model data using this app
 opening a :ref:`directory <developer-guide-directories>` in the database::
 
     import fdb
-    fdb.api_version(520)
+    fdb.api_version(600)
 
     db = fdb.open()
     scheduling = fdb.directory.create_or_open(db, ('scheduling',))
@@ -332,7 +332,7 @@ Here's the code for the scheduling tutorial::
     import fdb
     import fdb.tuple
 
-    fdb.api_version(520)
+    fdb.api_version(600)
 
 
     ####################################

--- a/documentation/sphinx/source/hierarchical-documents-java.rst
+++ b/documentation/sphinx/source/hierarchical-documents-java.rst
@@ -69,7 +69,7 @@ Here’s a basic implementation of the recipe.
         private static final long EMPTY_ARRAY = -1;
 
         static {
-            fdb = FDB.selectAPIVersion(520);
+            fdb = FDB.selectAPIVersion(600);
             db = fdb.open();
             docSpace = new Subspace(Tuple.from("D"));
         }

--- a/documentation/sphinx/source/multimaps-java.rst
+++ b/documentation/sphinx/source/multimaps-java.rst
@@ -74,7 +74,7 @@ Here’s a simple implementation of multimaps with multisets as described:
         private static final int N = 100;
 
         static {
-            fdb = FDB.selectAPIVersion(520);
+            fdb = FDB.selectAPIVersion(600);
             db = fdb.open();
             multi = new Subspace(Tuple.from("M"));
         }

--- a/documentation/sphinx/source/priority-queues-java.rst
+++ b/documentation/sphinx/source/priority-queues-java.rst
@@ -74,7 +74,7 @@ Here's a basic implementation of the model:
         private static final Random randno;
 
         static{
-            fdb = FDB.selectAPIVersion(520);
+            fdb = FDB.selectAPIVersion(600);
             db = fdb.open();
             pq = new Subspace(Tuple.from("P"));
 

--- a/documentation/sphinx/source/queues-java.rst
+++ b/documentation/sphinx/source/queues-java.rst
@@ -73,7 +73,7 @@ The following is a simple implementation of the basic pattern:
         private static final Random randno;
 
         static{
-            fdb = FDB.selectAPIVersion(520);
+            fdb = FDB.selectAPIVersion(600);
             db = fdb.open();
             queue = new Subspace(Tuple.from("Q"));
             randno = new Random();

--- a/documentation/sphinx/source/release-notes.rst
+++ b/documentation/sphinx/source/release-notes.rst
@@ -30,6 +30,12 @@ Status
 
 * The replication factor in status JSON is stored under "redundancy_mode" instead of "redundancy":"factor". `(PR #492) <https://github.com/apple/foundationdb/pull/492>`_
 
+Bindings
+--------
+
+* API version updated to 600. There are no changes since API version 520.
+* Several cases where functions in go might previously cause a panic now return a non-``nil`` error. `(PR #532) <https://github.com/apple/foundationdb/pull/532>`_
+
 Other Changes
 -------------
 

--- a/documentation/sphinx/source/simple-indexes-java.rst
+++ b/documentation/sphinx/source/simple-indexes-java.rst
@@ -87,7 +87,7 @@ In this example, we’re storing user data based on user ID but sometimes need t
         private static final Subspace index;
 
         static {
-            fdb = FDB.selectAPIVersion(520);
+            fdb = FDB.selectAPIVersion(600);
             db = fdb.open();
             main = new Subspace(Tuple.from("user"));
             index = new Subspace(Tuple.from("zipcode_index"));

--- a/documentation/sphinx/source/tables-java.rst
+++ b/documentation/sphinx/source/tables-java.rst
@@ -62,7 +62,7 @@ Here’s a simple implementation of the basic table pattern:
         private static final Subspace colIndex;
 
         static {
-            fdb = FDB.selectAPIVersion(520);
+            fdb = FDB.selectAPIVersion(600);
             db = fdb.open();
             table = new Subspace(Tuple.from("T"));
             rowIndex = table.subspace(Tuple.from("R"));

--- a/documentation/sphinx/source/vector-java.rst
+++ b/documentation/sphinx/source/vector-java.rst
@@ -77,7 +77,7 @@ Here’s the basic pattern:
         private static final Subspace vector;
 
         static {
-            fdb = FDB.selectAPIVersion(520);
+            fdb = FDB.selectAPIVersion(600);
             db = fdb.open();
             vector = new Subspace(Tuple.from("V"));
         }

--- a/recipes/go-recipes/blob.go
+++ b/recipes/go-recipes/blob.go
@@ -78,7 +78,7 @@ func read_blob(t fdb.ReadTransactor, blob_subspace subspace.Subspace) ([]byte, e
 }
 
 func main() {
-	fdb.MustAPIVersion(520)
+	fdb.MustAPIVersion(600)
 
 	db := fdb.MustOpenDefault()
 

--- a/recipes/go-recipes/doc.go
+++ b/recipes/go-recipes/doc.go
@@ -219,7 +219,7 @@ func (doc Doc) GetDoc(trtr fdb.Transactor, doc_id int) interface{} {
 }
 
 func main() {
-	fdb.MustAPIVersion(520)
+	fdb.MustAPIVersion(600)
 
 	db := fdb.MustOpenDefault()
 

--- a/recipes/go-recipes/graph.go
+++ b/recipes/go-recipes/graph.go
@@ -124,7 +124,7 @@ func (graph *Graph) get_in_neighbors(trtr fdb.Transactor, node int) ([]int, erro
 }
 
 func main() {
-	fdb.MustAPIVersion(520)
+	fdb.MustAPIVersion(600)
 
 	db := fdb.MustOpenDefault()
 

--- a/recipes/go-recipes/indirect.go
+++ b/recipes/go-recipes/indirect.go
@@ -93,7 +93,7 @@ func (wrkspc Workspace) Session(foo func(directory.DirectorySubspace)) (err erro
 }
 
 func main() {
-	fdb.MustAPIVersion(520)
+	fdb.MustAPIVersion(600)
 
 	db := fdb.MustOpenDefault()
 

--- a/recipes/go-recipes/multi.go
+++ b/recipes/go-recipes/multi.go
@@ -132,7 +132,7 @@ func (multi MultiMap) MultiIsElement(trtr fdb.Transactor, index, value interface
 
 func main() {
 
-	fdb.MustAPIVersion(520)
+	fdb.MustAPIVersion(600)
 
 	db := fdb.MustOpenDefault()
 

--- a/recipes/go-recipes/priority.go
+++ b/recipes/go-recipes/priority.go
@@ -117,7 +117,7 @@ func (prty Priority) Peek(trtr fdb.Transactor, max bool) interface{} {
 }
 
 func main() {
-	fdb.MustAPIVersion(520)
+	fdb.MustAPIVersion(600)
 
 	db := fdb.MustOpenDefault()
 

--- a/recipes/go-recipes/queue.go
+++ b/recipes/go-recipes/queue.go
@@ -107,7 +107,7 @@ func (q *Queue) FirstItem(trtr fdb.Transactor) (interface{}, error) {
 func main() {
 	fmt.Println("Queue Example Program")
 
-	fdb.MustAPIVersion(520)
+	fdb.MustAPIVersion(600)
 
 	db := fdb.MustOpenDefault()
 

--- a/recipes/go-recipes/table.go
+++ b/recipes/go-recipes/table.go
@@ -144,7 +144,7 @@ func (tbl Table) TableGetCol(tr fdb.ReadTransactor, col int) ([]interface{}, err
 }
 
 func main() {
-	fdb.MustAPIVersion(520)
+	fdb.MustAPIVersion(600)
 
 	db := fdb.MustOpenDefault()
 


### PR DESCRIPTION
There weren't any actual changes between the two API versions, so this is simply bumping the version to the higher one.

I'm currently testing this to make sure that tests don't show that this misses some obvious places. There are a fair number of places that we reference API version 520 in our code but in such a way that we *don't* want to bump it (e.g., to indicate that the new versionstamp code shouldn't be used for API versions less than 520), but I tried to update all of the places that just used it to mean "the latest version".