### PR TITLE
Improve backup error types

### DIFF
--- a/fdbrpc/BlobStore.actor.cpp
+++ b/fdbrpc/BlobStore.actor.cpp
@@ -575,6 +575,12 @@ ACTOR Future<Reference<HTTP::Response>> doRequest_impl(Reference<BlobStoreEndpoi
 			if(r && r->code == 401)
 				throw http_auth_failed();
 
+			if(err.present()) {
+				int code = err.get().code();
+				if(code == error_code_timed_out || code == error_code_connection_failed)
+					throw err.get();
+			}
+
 			throw http_request_failed();
 		}
 	}

--- a/flow/error_definitions.h
+++ b/flow/error_definitions.h
@@ -98,7 +98,7 @@ ERROR( http_not_accepted, 1519, "HTTP request not accepted" )
 ERROR( checksum_failed, 1520, "A data checksum failed" )
 ERROR( io_timeout, 1521, "A disk IO operation failed to complete in a timely manner" )
 ERROR( file_corrupt, 1522, "A structurally corrupt data file was detected" )
-ERROR( http_request_failed, 1523, "HTTP response code indicated failure" )
+ERROR( http_request_failed, 1523, "HTTP response code not received or indicated failure" )
 ERROR( http_auth_failed, 1524, "HTTP request failed due to bad credentials" )
 
 


### PR DESCRIPTION
If an HTTP request fails due to a connection failure or a timeout, do not convert the error to the more generic http_request_failed.