### PR TITLE
Fix upgrade reconnect failure

### DIFF
--- a/fdbrpc/FlowTransport.actor.cpp
+++ b/fdbrpc/FlowTransport.actor.cpp
@@ -148,6 +148,8 @@ public:
 		numIncompatibleConnections(0)
 	{}
 
+	~TransportData();
+
 	void initMetrics() {
 		bytesSent.init(LiteralStringRef("Net2.BytesSent"));
 		countPacketsReceived.init(LiteralStringRef("Net2.CountPacketsReceived"));
@@ -433,6 +435,13 @@ struct Peer : NonCopyable {
 		}
 	}
 };
+
+TransportData::~TransportData() {
+	for(auto &p : peers) {
+		p.second->connect.cancel();
+		delete p.second;
+	}
+}
 
 ACTOR static void deliver( TransportData* self, Endpoint destination, ArenaReader reader, bool inReadSocket ) {
 	int priority = self->endpoints.getPriority(destination.token);

--- a/fdbrpc/FlowTransport.actor.cpp
+++ b/fdbrpc/FlowTransport.actor.cpp
@@ -425,7 +425,7 @@ struct Peer : NonCopyable {
 				// Try to recover, even from serious errors, by retrying
 
 				if(self->reliable.empty() && self->unsent.empty()) {
-					TraceEvent("PeerDestroy").detail("PeerAddr", self->destination).error(e, true);
+					TraceEvent("PeerDestroy").detail("PeerAddr", self->destination).error(e).suppressFor(1.0);
 					self->connect.cancel();
 					self->transport->peers.erase(self->destination);
 					delete self;

--- a/fdbrpc/FlowTransport.actor.cpp
+++ b/fdbrpc/FlowTransport.actor.cpp
@@ -585,6 +585,7 @@ ACTOR static Future<Void> connectionReader(
 	state bool expectConnectPacket = true;
 	state bool compatible = false;
 	state bool incompatibleProtocolVersionNewer = false;
+	state bool initiallyCompatible = (peer == nullptr) || peer->compatible;
 	state NetworkAddress peerAddress;
 	state uint64_t peerProtocolVersion = 0;
 
@@ -709,7 +710,7 @@ ACTOR static Future<Void> connectionReader(
 		}
 	}
 	catch (Error& e) {
-		if (peer && !peer->compatible) {
+		if (initiallyCompatible && peer && !peer->compatible) {
 			ASSERT(peer->transport->numIncompatibleConnections > 0);
 			peer->transport->numIncompatibleConnections--;
 		}


### PR DESCRIPTION
There are three flow connection related fixes here, the most important is that reliable packet send attempts to an already-connected peer which has been determined to be incompatible would be silently dropped.  This could, in certain rare sequences of events, cause the multi version client to never connect to a cluster after an upgrade.  The fix is to only silently drop reliable packets to peers which are *newer* than the current process because the current process will never communicate with such a peer in its lifetime.  Older peers, however, may be upgraded.

The other fixes were a memory leak and a rare failed assertion regarding incompatible connection count which could occur if a cluster was rapidly cycled between versions (in a very abusive and unsupported way).