### PR TITLE
Suppressed trace event speedup

### DIFF
--- a/FDBLibTLS/FDBLibTLSSession.cpp
+++ b/FDBLibTLS/FDBLibTLSSession.cpp
@@ -369,7 +369,7 @@ int FDBLibTLSSession::handshake() {
 	case TLS_WANT_POLLOUT:
 		return WANT_WRITE;
 	default:
-		TraceEvent("FDBLibTLSHandshakeError", uid).detail("LibTLSErrorMessage", tls_error(tls_ctx)).suppressFor(1.0, true);
+		TraceEvent("FDBLibTLSHandshakeError", uid, 1.0).detail("LibTLSErrorMessage", tls_error(tls_ctx));
 		return FAILED;
 	}
 }
@@ -389,7 +389,7 @@ int FDBLibTLSSession::read(uint8_t* data, int length) {
 		return (int)n;
 	}
 	if (n == 0) {
-		TraceEvent("FDBLibTLSReadEOF").suppressFor(1.0, true);
+		TraceEvent("FDBLibTLSReadEOF", 1.0);
 		return FAILED;
 	}
 	if (n == TLS_WANT_POLLIN)
@@ -397,7 +397,7 @@ int FDBLibTLSSession::read(uint8_t* data, int length) {
 	if (n == TLS_WANT_POLLOUT)
 		return WANT_WRITE;
 
-	TraceEvent("FDBLibTLSReadError", uid).detail("LibTLSErrorMessage", tls_error(tls_ctx)).suppressFor(1.0, true);
+	TraceEvent("FDBLibTLSReadError", uid, 1.0).detail("LibTLSErrorMessage", tls_error(tls_ctx));
 	return FAILED;
 }
 
@@ -416,7 +416,7 @@ int FDBLibTLSSession::write(const uint8_t* data, int length) {
 		return (int)n;
 	}
 	if (n == 0) {
-		TraceEvent("FDBLibTLSWriteEOF", uid).suppressFor(1.0, true);
+		TraceEvent("FDBLibTLSWriteEOF", uid, 1.0);
 		return FAILED;
 	}
 	if (n == TLS_WANT_POLLIN)
@@ -424,6 +424,6 @@ int FDBLibTLSSession::write(const uint8_t* data, int length) {
 	if (n == TLS_WANT_POLLOUT)
 		return WANT_WRITE;
 
-	TraceEvent("FDBLibTLSWriteError", uid).detail("LibTLSErrorMessage", tls_error(tls_ctx)).suppressFor(1.0, true);
+	TraceEvent("FDBLibTLSWriteError", uid, 1.0).detail("LibTLSErrorMessage", tls_error(tls_ctx));
 	return FAILED;
 }

--- a/bindings/flow/tester/Tester.actor.cpp
+++ b/bindings/flow/tester/Tester.actor.cpp
@@ -1653,7 +1653,7 @@ ACTOR static Future<Void> runTest(Reference<FlowTesterData> data, Reference<Data
 		Void _ = wait(waitForAll(data->subThreads));
 	}
 	catch (Error& e) {
-		TraceEvent(SevError, "FlowTesterDataRunError").error(e);
+		TraceEvent(SevError, "FlowTesterDataRunError", e);
 	}
 
 	return Void();
@@ -1725,7 +1725,7 @@ ACTOR void startTest(std::string clusterFilename, StringRef prefix, int apiVersi
 		g_network->stop();
 	}
 	catch(Error &e) {
-		TraceEvent("ErrorRunningTest").error(e);
+		TraceEvent("ErrorRunningTest", e);
 		if(LOG_ERRORS) {
 			printf("Flow tester encountered error: %s\n", e.name());
 			fflush(stdout);
@@ -1767,7 +1767,7 @@ ACTOR void _test_versionstamp() {
 		g_network->stop();
 	}
 	catch (Error &e) {
-		TraceEvent("ErrorRunningTest").error(e);
+		TraceEvent("ErrorRunningTest", e);
 		if (LOG_ERRORS) {
 			printf("Flow tester encountered error: %s\n", e.name());
 			fflush(stdout);
@@ -1811,12 +1811,12 @@ int main( int argc, char** argv ) {
 	}
 	catch (Error& e) {
 		fprintf(stderr, "Error: %s\n", e.name());
-		TraceEvent(SevError, "MainError").error(e);
+		TraceEvent(SevError, "MainError", e);
 		flushAndExit(FDB_EXIT_MAIN_ERROR);
 	}
 	catch (std::exception& e) {
 		fprintf(stderr, "std::exception: %s\n", e.what());
-		TraceEvent(SevError, "MainError").error(unknown_error()).detail("RootException", e.what());
+		TraceEvent(SevError, "MainError", unknown_error()).detail("RootException", e.what());
 		flushAndExit(FDB_EXIT_MAIN_EXCEPTION);
 	}
 }

--- a/fdbbackup/backup.actor.cpp
+++ b/fdbbackup/backup.actor.cpp
@@ -1251,7 +1251,7 @@ ACTOR Future<Void> updateAgentPollRate(Database src, std::string rootKey, std::s
 				*pollDelay = (double)processes / CLIENT_KNOBS->BACKUP_AGGREGATE_POLL_RATE;
 			}
 		} catch(Error &e) {
-			TraceEvent(SevWarn, "BackupAgentPollRateUpdateError").error(e);
+			TraceEvent(SevWarn, "BackupAgentPollRateUpdateError", e);
 		}
 		Void _ = wait(delay(CLIENT_KNOBS->BACKUP_AGGREGATE_POLL_RATE_UPDATE_INTERVAL));
 	}
@@ -1306,7 +1306,7 @@ ACTOR Future<Void> statusUpdateActor(Database statusUpdateDest, std::string name
 				pollRateUpdater = updateAgentPollRate(statusUpdateDest, rootKey, name, pollDelay);
 		}
 		catch (Error& e) {
-			TraceEvent(SevWarnAlways, "UnableToWriteStatus").error(e);
+			TraceEvent(SevWarnAlways, "UnableToWriteStatus", e);
 			Void _ = wait(delay(10.0));
 		}
 	}
@@ -1328,7 +1328,7 @@ ACTOR Future<Void> runDBAgent(Database src, Database dest) {
 			if (e.code() == error_code_operation_cancelled)
 				throw;
 
-			TraceEvent(SevError, "DA_runAgent").error(e);
+			TraceEvent(SevError, "DA_runAgent", e);
 			fprintf(stderr, "ERROR: DR agent encountered fatal error `%s'\n", e.what());
 
 			Void _ = wait( delay(FLOW_KNOBS->PREVENT_FAST_SPIN_DELAY) );
@@ -1353,7 +1353,7 @@ ACTOR Future<Void> runAgent(Database db) {
 			if (e.code() == error_code_operation_cancelled)
 				throw;
 
-			TraceEvent(SevError, "BA_runAgent").error(e);
+			TraceEvent(SevError, "BA_runAgent", e);
 			fprintf(stderr, "ERROR: backup agent encountered fatal error `%s'\n", e.what());
 
 			Void _ = wait( delay(FLOW_KNOBS->PREVENT_FAST_SPIN_DELAY) );
@@ -2996,10 +2996,10 @@ int main(int argc, char* argv[]) {
 		}
 		#endif
 	} catch (Error& e) {
-		TraceEvent(SevError, "MainError").error(e);
+		TraceEvent(SevError, "MainError", e);
 		status = FDB_EXIT_MAIN_ERROR;
 	} catch (std::exception& e) {
-		TraceEvent(SevError, "MainError").error(unknown_error()).detail("RootException", e.what());
+		TraceEvent(SevError, "MainError", unknown_error()).detail("RootException", e.what());
 		status = FDB_EXIT_MAIN_EXCEPTION;
 	}
 

--- a/fdbcli/fdbcli.actor.cpp
+++ b/fdbcli/fdbcli.actor.cpp
@@ -3087,7 +3087,7 @@ ACTOR Future<int> cli(CLIOptions opt, LineNoise* plinenoise) {
 						}
 						catch(Error &e) {
 							//options->setOption() prints error message
-							TraceEvent(SevWarn, "CLISetOptionError").detail("Option", printable(tokens[2])).error(e);
+							TraceEvent(SevWarn, "CLISetOptionError", e).detail("Option", printable(tokens[2]));
 							is_error = true;
 						}
 					}
@@ -3138,7 +3138,7 @@ ACTOR Future<int> runCli(CLIOptions opt) {
 		linenoise.historyLoad(historyFilename);
 	}
 	catch(Error &e) {
-		TraceEvent(SevWarnAlways, "ErrorLoadingCliHistory").detail("Filename", historyFilename.empty() ? "<unknown>" : historyFilename).error(e).GetLastError();
+		TraceEvent(SevWarnAlways, "ErrorLoadingCliHistory", e).detail("Filename", historyFilename.empty() ? "<unknown>" : historyFilename).GetLastError();
 	}
 
 	state int result = wait(cli(opt, &linenoise));
@@ -3148,7 +3148,7 @@ ACTOR Future<int> runCli(CLIOptions opt) {
 			linenoise.historySave(historyFilename);
 		}
 		catch(Error &e) {
-			TraceEvent(SevWarnAlways, "ErrorSavingCliHistory").detail("Filename", historyFilename).error(e).GetLastError();
+			TraceEvent(SevWarnAlways, "ErrorSavingCliHistory", e).detail("Filename", historyFilename).GetLastError();
 		}
 	}
 

--- a/fdbclient/BackupAgent.h
+++ b/fdbclient/BackupAgent.h
@@ -748,11 +748,11 @@ public:
 
 	Future<Void> logError(Database cx, Error e, std::string details, void *taskInstance = nullptr) {
 		if(!uid.isValid()) {
-			TraceEvent(SevError, "FileBackupErrorNoUID").error(e).detail("Description", details);
+			TraceEvent(SevError, "FileBackupErrorNoUID", e).detail("Description", details);
 			return Void();
 		}
-		TraceEvent t(SevWarn, "FileBackupError");
-		t.error(e).detail("BackupUID", uid).detail("Description", details).detail("TaskInstance", (uint64_t)taskInstance);
+		TraceEvent t(SevWarn, "FileBackupError", e);
+		t.detail("BackupUID", uid).detail("Description", details).detail("TaskInstance", (uint64_t)taskInstance);
 		// These should not happen
 		if(e.code() == error_code_key_not_found)
 			t.backtrace();

--- a/fdbclient/BackupAgentBase.actor.cpp
+++ b/fdbclient/BackupAgentBase.actor.cpp
@@ -195,7 +195,7 @@ Standalone<VectorRef<MutationRef>> decodeBackupLogValue(StringRef value) {
 		return result;
 	}
 	catch (Error& e) {
-		TraceEvent(e.code() == error_code_restore_missing_data ? SevWarn : SevError, "BA_DecodeBackupLogValue").error(e).GetLastError().detail("ValueSize", value.size()).detail("Value", printable(value));
+		TraceEvent(e.code() == error_code_restore_missing_data ? SevWarn : SevError, "BA_DecodeBackupLogValue", e).GetLastError().detail("ValueSize", value.size()).detail("Value", printable(value));
 		throw;
 	}
 }
@@ -303,7 +303,7 @@ void decodeBackupLogValue(Arena& arena, VectorRef<MutationRef>& result, int& mut
 		}
 	}
 	catch (Error& e) {
-		TraceEvent(e.code() == error_code_restore_missing_data ? SevWarn : SevError, "BA_DecodeBackupLogValue").error(e).GetLastError().detail("ValueSize", value.size()).detail("Value", printable(value));
+		TraceEvent(e.code() == error_code_restore_missing_data ? SevWarn : SevError, "BA_DecodeBackupLogValue", e).GetLastError().detail("ValueSize", value.size()).detail("Value", printable(value));
 		throw;
 	}
 }
@@ -619,7 +619,7 @@ ACTOR Future<Void> applyMutations(Database cx, Key uid, Key addPrefix, Key remov
 			beginVersion = newEndVersion;
 		}
 	} catch( Error &e ) {
-		TraceEvent(e.code() == error_code_restore_missing_data ? SevWarnAlways : SevError, "ApplyMutationsError").error(e);
+		TraceEvent(e.code() == error_code_restore_missing_data ? SevWarnAlways : SevError, "ApplyMutationsError", e);
 		throw;	
 	}
 }

--- a/fdbclient/BackupContainer.actor.cpp
+++ b/fdbclient/BackupContainer.actor.cpp
@@ -793,8 +793,7 @@ public:
 			Void _ = wait(f->finish());
 			return Void();
 		} catch(Error &e) {
-			if(e.code() != error_code_actor_cancelled)
-				TraceEvent(SevWarn, "BackupContainerWritePropertyFailed").detail("Path", path).error(e);
+			TraceEvent(SevWarn, "BackupContainerWritePropertyFailed", e).detail("Path", path);
 			throw;
 		}
 	}
@@ -816,8 +815,7 @@ public:
 		} catch(Error &e) {
 			if(e.code() == error_code_file_not_found)
 				return Optional<Version>();
-			if(e.code() != error_code_actor_cancelled)
-				TraceEvent(SevWarn, "BackupContainerReadPropertyFailed").detail("Path", path).error(e);
+			TraceEvent(SevWarn, "BackupContainerReadPropertyFailed", e).detail("Path", path);
 			throw;
 		}
 	}

--- a/fdbclient/FailureMonitorClient.actor.cpp
+++ b/fdbclient/FailureMonitorClient.actor.cpp
@@ -126,7 +126,7 @@ ACTOR Future<Void> failureMonitorClientLoop(
 	} catch (Error& e) {
 		if (e.code() == error_code_broken_promise)  // broken promise from clustercontroller means it has died (and hopefully will be replaced)
 			return Void();
-		TraceEvent(SevError, "FailureMonitorClientError").error(e);
+		TraceEvent(SevError, "FailureMonitorClientError", e);
 		throw;  // goes nowhere
 	}
 }

--- a/fdbclient/ManagementAPI.actor.cpp
+++ b/fdbclient/ManagementAPI.actor.cpp
@@ -1018,7 +1018,7 @@ ACTOR Future<Void> includeServers( Database cx, vector<AddressExclusion> servers
 			Void _ = wait( tr.commit() );
 			return Void();
 		} catch (Error& e) {
-			TraceEvent("IncludeServersError").error(e);
+			TraceEvent("IncludeServersError").errorUnconditional(e);
 			Void _ = wait( tr.onError(e) );
 		}
 	}

--- a/fdbclient/ManagementAPI.actor.cpp
+++ b/fdbclient/ManagementAPI.actor.cpp
@@ -748,7 +748,7 @@ ACTOR Future<CoordinatorsResult::Type> changeQuorum( Database cx, Reference<IQuo
 			Void _ = wait( tr.commit() );
 			ASSERT( false ); //commit should fail, but the value has changed
 		} catch (Error& e) {
-			TraceEvent("RetryQuorumChange").error(e).detail("Retries", retries);
+			TraceEvent("RetryQuorumChange", e).detail("Retries", retries);
 			Void _ = wait( tr.onError(e) );
 			++retries;
 		}
@@ -1018,7 +1018,7 @@ ACTOR Future<Void> includeServers( Database cx, vector<AddressExclusion> servers
 			Void _ = wait( tr.commit() );
 			return Void();
 		} catch (Error& e) {
-			TraceEvent("IncludeServersError").error(e, true);
+			TraceEvent("IncludeServersError").error(e);
 			Void _ = wait( tr.onError(e) );
 		}
 	}
@@ -1112,7 +1112,7 @@ ACTOR Future<int> setDDMode( Database cx, int mode ) {
 			Void _ = wait( tr.commit() );
 			return oldMode;
 		} catch (Error& e) {
-			TraceEvent("SetDDModeRetrying").error(e);
+			TraceEvent("SetDDModeRetrying", e);
 			Void _ = wait (tr.onError(e));
 		}
 	}

--- a/fdbclient/MetricLogger.actor.cpp
+++ b/fdbclient/MetricLogger.actor.cpp
@@ -392,7 +392,7 @@ ACTOR Future<Void> runMetrics( Future<Database> fcx, Key prefix ) {
 				it.value->setConfig(false);
 		}
 		
-		TraceEvent(SevWarnAlways, "TDMetricsStopped").error(e);
+		TraceEvent(SevWarnAlways, "TDMetricsStopped", e);
 		throw e;
 	}
 	return Void();

--- a/fdbclient/MonitorLeader.actor.cpp
+++ b/fdbclient/MonitorLeader.actor.cpp
@@ -99,7 +99,7 @@ bool ClusterConnectionFile::fileContentsUpToDate(ClusterConnectionString &fileCo
 		return fileConnectionString.toString() == cs.toString();
 	}
 	catch (Error& e) {
-		TraceEvent(SevWarnAlways, "ClusterFileError").detail("Filename", filename).error(e);
+		TraceEvent(SevWarnAlways, "ClusterFileError", e).detail("Filename", filename);
 		return false; // Swallow the error and report that the file is out of date
 	}
 }
@@ -118,7 +118,7 @@ bool ClusterConnectionFile::writeFile() {
 
 			return true;
 		} catch( Error &e ) {
-			TraceEvent(SevWarnAlways, "UnableToChangeConnectionFile").detail("Filename", filename).detail("ConnStr", cs.toString()).error(e);
+			TraceEvent(SevWarnAlways, "UnableToChangeConnectionFile", e).detail("Filename", filename).detail("ConnStr", cs.toString());
 		}
 	}
 

--- a/fdbclient/MultiVersionTransaction.actor.cpp
+++ b/fdbclient/MultiVersionTransaction.actor.cpp
@@ -343,10 +343,10 @@ void DLApi::runNetwork() {
 			hook.first(hook.second);
 		}
 		catch(Error &e) {
-			TraceEvent(SevError, "NetworkShutdownHookError").error(e);
+			TraceEvent(SevError, "NetworkShutdownHookError", e);
 		}
 		catch(...) {
-			TraceEvent(SevError, "NetworkShutdownHookError").error(unknown_error());
+			TraceEvent(SevError, "NetworkShutdownHookError", unknown_error());
 		}
 	}
 
@@ -615,7 +615,7 @@ void MultiVersionDatabase::DatabaseState::fire(const Void &unused, int& userPara
 					}
 					catch(Error &e) {
 						optionFailed = true;
-						TraceEvent(SevError, "DatabaseVersionChangeOptionError").detail("Option", option.first).detail("OptionValue", printable(option.second)).error(e);
+						TraceEvent(SevError, "DatabaseVersionChangeOptionError", e).detail("Option", option.first).detail("OptionValue", printable(option.second));
 					}
 				}
 
@@ -644,7 +644,7 @@ void MultiVersionDatabase::DatabaseState::error(const Error& e, int& userParam) 
 	}
 
 	// TODO: retry?
-	TraceEvent(SevWarnAlways, "DatabaseCreationFailed").error(e);
+	TraceEvent(SevWarnAlways, "DatabaseCreationFailed", e);
 	onMainThreadVoid([this]() {
 		updateDatabase();
 		delref();
@@ -811,7 +811,7 @@ void MultiVersionCluster::Connector::error(const Error& e, int& userParam) {
 		// TODO: is it right to abandon this connection attempt?
 		client->failed = true;
 		MultiVersionApi::api->updateSupportedVersions();
-		TraceEvent(SevError, "ClusterConnectionError").detail("ClientLibrary", this->client->libPath).error(e);
+		TraceEvent(SevError, "ClusterConnectionError", e).detail("ClientLibrary", this->client->libPath);
 	}
 
 	delref();
@@ -850,7 +850,7 @@ void MultiVersionCluster::ClusterState::stateChanged() {
 		}
 		catch(Error &e) {
 			optionLock.leave();
-			TraceEvent(SevError, "ClusterVersionChangeOptionError").detail("Option", option.first).detail("OptionValue", printable(option.second)).detail("LibPath", clients[newIndex]->libPath).error(e);
+			TraceEvent(SevError, "ClusterVersionChangeOptionError", e).detail("Option", option.first).detail("OptionValue", printable(option.second)).detail("LibPath", clients[newIndex]->libPath);
 			connectionAttempts[newIndex]->connected = false;
 			clients[newIndex]->failed = true;
 			MultiVersionApi::api->updateSupportedVersions();
@@ -910,7 +910,7 @@ void MultiVersionApi::runOnExternalClients(std::function<void(Reference<ClientIn
 			}
 		}
 		catch(Error &e) {
-			TraceEvent(SevWarnAlways, "ExternalClientFailure").detail("LibPath", c->second->libPath).error(e);
+			TraceEvent(SevWarnAlways, "ExternalClientFailure", e).detail("LibPath", c->second->libPath);
 			if(e.code() == error_code_external_client_already_loaded) {
 				c = externalClients.erase(c);
 				continue;
@@ -1156,7 +1156,7 @@ THREAD_FUNC_RETURN runNetworkThread(void *param) {
 		((ClientInfo*)param)->api->runNetwork();
 	}
 	catch(Error &e) {
-		TraceEvent(SevError, "RunNetworkError").error(e);
+		TraceEvent(SevError, "RunNetworkError", e);
 	}
 
 	THREAD_RETURN;
@@ -1342,7 +1342,7 @@ void MultiVersionApi::loadEnvironmentVariableNetworkOptions() {
 				}
 			}
 			catch(Error &e) {
-				TraceEvent(SevError, "EnvironmentVariableNetworkOptionFailed").detail("Option", option.second.name).detail("Value", valueStr).error(e);
+				TraceEvent(SevError, "EnvironmentVariableNetworkOptionFailed", e).detail("Option", option.second.name).detail("Value", valueStr);
 				throw environment_variable_network_option_failed();
 			}
 		}

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -2318,7 +2318,7 @@ ACTOR static Future<Void> commitDummyTransaction( Database cx, KeyRange range, T
 			Void _ = wait( tr.commit() );
 			return Void();
 		} catch (Error& e) {
-			TraceEvent("CommitDummyTransactionError").error(e).detail("Key", printable(range.begin)).detail("Retries", retries);
+			TraceEvent("CommitDummyTransactionError").errorUnconditional(e).detail("Key", printable(range.begin)).detail("Retries", retries);
 			Void _ = wait( tr.onError(e) );
 		}
 		++retries;

--- a/fdbclient/ReadYourWrites.actor.cpp
+++ b/fdbclient/ReadYourWrites.actor.cpp
@@ -1910,7 +1910,7 @@ void ReadYourWritesTransaction::debugLogRetries(Optional<Error> error) {
 				
 				trace.detail("Elapsed", elapsed).detail("Retries", retries).detail("Committed", committed);
 				if(error.present())
-					trace.error(error.get(), true);
+					trace.error(error.get());
 			}
 			transactionDebugInfo->lastRetryLogTime = now();
 		}

--- a/fdbclient/ReadYourWrites.actor.cpp
+++ b/fdbclient/ReadYourWrites.actor.cpp
@@ -1910,7 +1910,7 @@ void ReadYourWritesTransaction::debugLogRetries(Optional<Error> error) {
 				
 				trace.detail("Elapsed", elapsed).detail("Retries", retries).detail("Committed", committed);
 				if(error.present())
-					trace.error(error.get());
+					trace.errorUnconditional(error.get());
 			}
 			transactionDebugInfo->lastRetryLogTime = now();
 		}

--- a/fdbclient/StatusClient.actor.cpp
+++ b/fdbclient/StatusClient.actor.cpp
@@ -449,7 +449,7 @@ ACTOR Future<StatusObject> statusFetcherImpl( Reference<ClusterConnectionFile> f
 	catch (Error& e) {
 		if (e.code() == error_code_actor_cancelled)
 			throw;
-		TraceEvent(SevError, "ClientStatusFetchError").error(e);
+		TraceEvent(SevError, "ClientStatusFetchError", e);
 		clientMessages.push_back(makeMessage("status_incomplete_client", "Could not retrieve client status information."));
 
 		// quorum_reachable will be false because clientStatusFetcher won't throw and it's the only thing would change it.
@@ -495,7 +495,7 @@ ACTOR Future<StatusObject> statusFetcherImpl( Reference<ClusterConnectionFile> f
 			statusObj["cluster"] = statusObjCluster;
 		}
 		catch (Error &e){
-			TraceEvent(e.code() == error_code_all_alternatives_failed ? SevInfo : SevError, "ClusterStatusFetchError").error(e);
+			TraceEvent(e.code() == error_code_all_alternatives_failed ? SevInfo : SevError, "ClusterStatusFetchError", e);
 			// Set client.messages to an array of one message
 			clientMessages.push_back(makeMessage("status_incomplete_cluster", "Could not retrieve cluster status information."));
 		}

--- a/fdbclient/TaskBucket.actor.cpp
+++ b/fdbclient/TaskBucket.actor.cpp
@@ -389,19 +389,17 @@ public:
 				}));
 			}
 		} catch(Error &e) {
-			TraceEvent(SevWarn, "TB_ExecuteFailure")
+			TraceEvent(SevWarn, "TB_ExecuteFailure", e)
 				.detail("TaskUID", task->key.printable())
 				.detail("TaskType", task->params[Task::reservedTaskParamKeyType].printable())
-				.detail("Priority", task->getPriority())
-				.error(e);
+				.detail("Priority", task->getPriority());
 			try {
 				Void _ = wait(taskFunc->handleError(cx, task, e));
 			} catch(Error &e) {
-				TraceEvent(SevWarn, "TB_ExecuteFailureLogErrorFailed")
+				TraceEvent(SevWarn, "TB_ExecuteFailureLogErrorFailed", e) // output handleError() error instead of original task error
 					.detail("TaskUID", task->key.printable())
 					.detail("TaskType", task->params[Task::reservedTaskParamKeyType].printable())
-					.detail("Priority", task->getPriority())
-					.error(e);  // output handleError() error instead of original task error
+					.detail("Priority", task->getPriority());
 			}
 		}
 

--- a/fdbclient/ThreadSafeTransaction.actor.cpp
+++ b/fdbclient/ThreadSafeTransaction.actor.cpp
@@ -370,10 +370,10 @@ void ThreadSafeApi::runNetwork() {
 			hook.first(hook.second);
 		}
 		catch(Error &e) {
-			TraceEvent(SevError, "NetworkShutdownHookError").error(e);
+			TraceEvent(SevError, "NetworkShutdownHookError", e);
 		}
 		catch(...) {
-			TraceEvent(SevError, "NetworkShutdownHookError").error(unknown_error());
+			TraceEvent(SevError, "NetworkShutdownHookError", unknown_error());
 		}
 	}
 

--- a/fdbrpc/AsyncFileCached.actor.h
+++ b/fdbrpc/AsyncFileCached.actor.h
@@ -358,7 +358,7 @@ struct AFCPage : public EvictablePage, public FastAllocated<AFCPage> {
 					TraceEvent("ReadThroughShortRead").detail("ReadAmount", _).detail("PageSize", self->pageCache->pageSize).detail("PageOffset", self->pageOffset);
 			} catch (Error& e) {
 				self->zeroCopyRefCount = 0;
-				TraceEvent("ReadThroughFailed").error(e);
+				TraceEvent("ReadThroughFailed", e);
 				throw;
 			}
 		}

--- a/fdbrpc/AsyncFileEIO.actor.h
+++ b/fdbrpc/AsyncFileEIO.actor.h
@@ -80,10 +80,10 @@ public:
 			errno = r->errorno;
 			bool notFound = errno == ENOENT;
 			Error e = notFound ? file_not_found() : io_error();
-			TraceEvent(notFound ? SevWarn : SevWarnAlways, "FileOpenError").error(e).GetLastError().detail("File", filename).detail("Flags", flags).detail("Mode", mode);
+			TraceEvent(notFound ? SevWarn : SevWarnAlways, "FileOpenError", e).GetLastError().detail("File", filename).detail("Flags", flags).detail("Mode", mode);
 			throw e;
 		}
-		TraceEvent("AsyncFileOpened").detail("Filename", filename).detail("Fd", r->result).detail("Flags", flags).suppressFor(1.0);
+		TraceEvent("AsyncFileOpened", 1.0).detail("Filename", filename).detail("Fd", r->result).detail("Flags", flags);
 
 		if ((flags & OPEN_LOCK) && !lock_fd(r->result)) {
 			TraceEvent(SevError, "UnableToLockFile").detail("Filename", filename).GetLastError();
@@ -254,7 +254,7 @@ private:
 	static void error( const char* context, int fd, eio_req* r, Reference<ErrorInfo> const& err = Reference<ErrorInfo>() ) {
 		Error e = io_error();
 		errno = r->errorno;
-		TraceEvent(context).detail("Fd", fd).detail("Result", r->result).GetLastError().error(e);
+		TraceEvent(context, e).detail("Fd", fd).detail("Result", r->result).GetLastError();
 		if (err) err->set(e);
 		else throw e;
 	}
@@ -264,7 +264,7 @@ private:
 		state eio_req* r = eio_close(fd, 0, eio_callback, &p);
 		Void _ = wait( p.getFuture() );
 		if (r->result) error( "CloseError", fd, r );
-		TraceEvent("AsyncFileClosed").detail("Fd", fd).suppressFor(1.0);
+		TraceEvent("AsyncFileClosed", 1.0).detail("Fd", fd);
 	}
 
 	ACTOR static Future<int> read_impl( int fd, void* data, int length, int64_t offset ) {

--- a/fdbrpc/AsyncFileKAIO.actor.h
+++ b/fdbrpc/AsyncFileKAIO.actor.h
@@ -111,9 +111,9 @@ public:
 		if (fd<0) {
 			Error e = errno==ENOENT ? file_not_found() : io_error();
 			int ecode = errno;  // Save errno in case it is modified before it is used below
-			TraceEvent ev("AsyncFileKAIOOpenFailed");
+			TraceEvent ev("AsyncFileKAIOOpenFailed", e);
 			ev.detail("Filename", filename).detailf("Flags", "%x", flags)
-			  .detailf("OSFlags", "%x", openFlags(flags) | O_DIRECT).detailf("Mode", "0%o", mode).error(e).GetLastError();
+			  .detailf("OSFlags", "%x", openFlags(flags) | O_DIRECT).detailf("Mode", "0%o", mode).GetLastError();
 			if(ecode == EINVAL)
 				ev.detail("Description", "Invalid argument - Does the target filesystem support KAIO?");
 			return e;
@@ -604,7 +604,7 @@ private:
 							.detail("ErrorDesc", strerror(errno));
 					}
 				} catch(Error &e) {
-					TraceEvent(SevError, "KAIOLogOpenFailure").error(e);
+					TraceEvent(SevError, "KAIOLogOpenFailure", e);
 				}
 			}
 		}

--- a/fdbrpc/AsyncFileNonDurable.actor.h
+++ b/fdbrpc/AsyncFileNonDurable.actor.h
@@ -238,7 +238,7 @@ public:
 			state Error err = e;
 			std::string currentFilename = ( wrappedFile.isReady() && !wrappedFile.isError() ) ? wrappedFile.get()->getFilename() : actualFilename;
 			currentProcess->machine->openFiles.erase( currentFilename );
-			//TraceEvent("AsyncFileNonDurableOpenError").detail("Filename", filename).detail("Address", currentProcess->address).error(e).detail("Addr", g_simulator.getCurrentProcess()->address);
+			//TraceEvent("AsyncFileNonDurableOpenError").detail("Filename", filename).detail("Address", currentProcess->address).errorUnconditional(e).detail("Addr", g_simulator.getCurrentProcess()->address);
 			Void _ = wait( g_simulator.onProcess( currentProcess, currentTaskID ) );
 			throw err;
 		}

--- a/fdbrpc/AsyncFileNonDurable.actor.h
+++ b/fdbrpc/AsyncFileNonDurable.actor.h
@@ -238,7 +238,7 @@ public:
 			state Error err = e;
 			std::string currentFilename = ( wrappedFile.isReady() && !wrappedFile.isError() ) ? wrappedFile.get()->getFilename() : actualFilename;
 			currentProcess->machine->openFiles.erase( currentFilename );
-			//TraceEvent("AsyncFileNonDurableOpenError").detail("Filename", filename).detail("Address", currentProcess->address).error(e, true).detail("Addr", g_simulator.getCurrentProcess()->address);
+			//TraceEvent("AsyncFileNonDurableOpenError").detail("Filename", filename).detail("Address", currentProcess->address).error(e).detail("Addr", g_simulator.getCurrentProcess()->address);
 			Void _ = wait( g_simulator.onProcess( currentProcess, currentTaskID ) );
 			throw err;
 		}

--- a/fdbrpc/AsyncFileWinASIO.actor.h
+++ b/fdbrpc/AsyncFileWinASIO.actor.h
@@ -65,7 +65,7 @@ public:
 		if (h == INVALID_HANDLE_VALUE) {
 			bool notFound = GetLastError() == ERROR_FILE_NOT_FOUND;
 			Error e = notFound ? file_not_found() : io_error();
-			TraceEvent(notFound ? SevWarn : SevWarnAlways, "FileOpenError").error(e).GetLastError()
+			TraceEvent(notFound ? SevWarn : SevWarnAlways, "FileOpenError", e).GetLastError()
 				.detail("File", filename).detail("Flags", flags).detail("Mode", mode);
 			return e;
 		}
@@ -85,7 +85,7 @@ public:
 	static void onReadReady( Promise<int> onReady, const boost::system::error_code& error, size_t bytesRead ) {
 		if (error) {
 			Error e = io_error();
-			TraceEvent("AsyncReadError").GetLastError().error(e)
+			TraceEvent("AsyncReadError", e).GetLastError()
 				.detail("ASIOCode", error.value())
 				.detail("ASIOMessage", error.message());
 			onReady.sendError(e);
@@ -96,7 +96,7 @@ public:
 	static void onWriteReady( Promise<Void> onReady, size_t bytesExpected, const boost::system::error_code& error, size_t bytesWritten ) {
 		if (error) {
 			Error e = io_error();
-			TraceEvent("AsyncWriteError").GetLastError().error(e)
+			TraceEvent("AsyncWriteError", e).GetLastError()
 				.detail("ASIOCode", error.value())
 				.detail("ASIOMessage", error.message());
 			onReady.sendError(e);

--- a/fdbrpc/AsyncFileWriteChecker.h
+++ b/fdbrpc/AsyncFileWriteChecker.h
@@ -133,13 +133,12 @@ private:
 			else {
 				if(history.checksum != 0 && history.checksum != checksum) {
 					// For reads, verify the stored sum if it is not 0.  If it fails, clear it.
-					TraceEvent (SevError, "AsyncFileLostWriteDetected")
+					TraceEvent (SevError, "AsyncFileLostWriteDetected", checksum_failed())
 						.detail("Filename", m_f->getFilename())
 						.detail("PageNumber", page)
 						.detail("ChecksumOfPage", checksum)
 						.detail("ChecksumHistory", history.checksum)
-						.detail("LastWriteTime", history.timestamp)
-						.error(checksum_failed());
+						.detail("LastWriteTime", history.timestamp);
 					history.checksum = 0;
 				}
 			}

--- a/fdbrpc/BlobStore.actor.cpp
+++ b/fdbrpc/BlobStore.actor.cpp
@@ -182,7 +182,7 @@ Reference<BlobStoreEndpoint> BlobStoreEndpoint::fromString(std::string const &ur
 	} catch(std::string &err) {
 		if(error != nullptr)
 			*error = err;
-		TraceEvent(SevWarnAlways, "BlobStoreEndpointBadURL").detail("Description", err).detail("Format", getURLFormat()).detail("URL", url).suppressFor(60, true);
+		TraceEvent(SevWarnAlways, "BlobStoreEndpointBadURL", 60).detail("Description", err).detail("Format", getURLFormat()).detail("URL", url);
 		throw backup_invalid_url();
 	}
 }
@@ -341,11 +341,11 @@ ACTOR Future<Optional<json_spirit::mObject>> tryReadJSONFile(std::string path) {
 		if(json.type() == json_spirit::obj_type)
 			return json.get_obj();
 		else
-			TraceEvent(SevWarn, "BlobCredentialFileNotJSONObject").detail("File", path).suppressFor(60, true);
+			TraceEvent(SevWarn, "BlobCredentialFileNotJSONObject", 60).detail("File", path);
 
 	} catch(Error &e) {
 		if(e.code() != error_code_actor_cancelled)
-			TraceEvent(SevWarn, errorEventType).detail("File", path).error(e).suppressFor(60, true);
+			TraceEvent(SevWarn, errorEventType, e, 60).detail("File", path);
 	}
 
 	return Optional<json_spirit::mObject>();
@@ -408,10 +408,9 @@ ACTOR Future<BlobStoreEndpoint::ReusableConnection> connect_impl(Reference<BlobS
 
 		// If the connection expires in the future then return it
 		if(rconn.expirationTime > now()) {
-		TraceEvent("BlobStoreEndpointReusingConnected")
+		TraceEvent("BlobStoreEndpointReusingConnected", 60)
 			.detail("RemoteEndpoint", rconn.conn->getPeerAddress())
-			.detail("ExpiresIn", rconn.expirationTime - now())
-			.suppressFor(60, true);
+			.detail("ExpiresIn", rconn.expirationTime - now());
 			return rconn;
 		}
 	}
@@ -420,10 +419,9 @@ ACTOR Future<BlobStoreEndpoint::ReusableConnection> connect_impl(Reference<BlobS
 		service = b->knobs.secure_connection ? "https" : "http";
 	state Reference<IConnection> conn = wait(INetworkConnections::net()->connect(b->host, service, b->knobs.secure_connection ? true : false));
 
-	TraceEvent("BlobStoreEndpointNewConnection")
+	TraceEvent("BlobStoreEndpointNewConnection", 60)
 		.detail("RemoteEndpoint", conn->getPeerAddress())
-		.detail("ExpiresIn", b->knobs.max_connection_life)
-		.suppressFor(60, true);
+		.detail("ExpiresIn", b->knobs.max_connection_life);
 
 	if(b->lookupSecret)
 		Void _ = wait(b->updateSecret());
@@ -520,7 +518,7 @@ ACTOR Future<Reference<HTTP::Response>> doRequest_impl(Reference<BlobStoreEndpoi
 		// But only if our previous attempt was not the last allowable try.
 		retryable = retryable && (thisTry < maxTries);
 
-		TraceEvent event(SevWarn, retryable ? "BlobStoreEndpointRequestFailedRetryable" : "BlobStoreEndpointRequestFailed");
+		TraceEvent event(SevWarn, retryable ? "BlobStoreEndpointRequestFailedRetryable" : "BlobStoreEndpointRequestFailed", err.present() ? err.get() : Error(), 60);
 		event.detail("ConnectionEstablished", connectionEstablished);
 
 		if(remoteAddress.present())
@@ -530,8 +528,7 @@ ACTOR Future<Reference<HTTP::Response>> doRequest_impl(Reference<BlobStoreEndpoi
 
 		event.detail("Verb", verb)
 			 .detail("Resource", resource)
-			 .detail("ThisTry", thisTry)
-			 .suppressFor(60, true);
+			 .detail("ThisTry", thisTry);
 
 		// If r is not valid or not code 429 then increment the try count.  429's will not count against the attempt limit.
 		if(!r || r->code != 429)
@@ -543,9 +540,7 @@ ACTOR Future<Reference<HTTP::Response>> doRequest_impl(Reference<BlobStoreEndpoi
 		nextRetryDelay = std::min(nextRetryDelay * 2, 60.0);
 
 		// Attach err to trace event if present, otherwise extract some stuff from the response
-		if(err.present())
-			event.error(err.get());
-		else {
+		if(!err.present()) {
 			event.detail("ResponseCode", r->code);
 		}
 
@@ -702,13 +697,13 @@ ACTOR Future<Void> listBucketStream_impl(Reference<BlobStoreEndpoint> bstore, st
 					lastFile = result.commonPrefixes.back();
 
 				if(lastFile.empty()) {
-					TraceEvent(SevWarn, "BlobStoreEndpointListNoNextMarker").detail("Resource", fullResource).suppressFor(60, true);
+					TraceEvent(SevWarn, "BlobStoreEndpointListNoNextMarker", 60).detail("Resource", fullResource);
 					throw backup_error();
 				}
 			}
 		} catch(Error &e) {
 			if(e.code() != error_code_actor_cancelled)
-				TraceEvent(SevWarn, "BlobStoreEndpointListResultParseError").detail("Resource", fullResource).error(e).suppressFor(60, true);
+				TraceEvent(SevWarn, "BlobStoreEndpointListResultParseError", e, 60).detail("Resource", fullResource);
 			throw http_bad_response();
 		}
 	}

--- a/fdbrpc/FailureMonitor.actor.cpp
+++ b/fdbrpc/FailureMonitor.actor.cpp
@@ -92,7 +92,7 @@ void SimpleFailureMonitor::setStatus( NetworkAddress const& address, FailureStat
 
 void SimpleFailureMonitor::endpointNotFound( Endpoint const& endpoint ) {
 	// SOMEDAY: Expiration (this "leaks" memory)
-	TraceEvent("EndpointNotFound").detail("Address", endpoint.address).detail("Token", endpoint.token).suppressFor(1.0);
+	TraceEvent("EndpointNotFound", 1.0).detail("Address", endpoint.address).detail("Token", endpoint.token);
 	endpointKnownFailed.set( endpoint, true );
 }
 

--- a/fdbrpc/FlowTransport.actor.cpp
+++ b/fdbrpc/FlowTransport.actor.cpp
@@ -415,10 +415,10 @@ struct Peer : NonCopyable {
 				bool ok = e.code() == error_code_connection_failed || e.code() == error_code_actor_cancelled || ( g_network->isSimulated() && e.code() == error_code_checksum_failed );
 
 				if(self->compatible) {
-					TraceEvent(ok ? SevInfo : SevWarnAlways, "ConnectionClosed", conn ? conn->getDebugID() : UID(), 1.0).detail("PeerAddr", self->destination).error(e);
+					TraceEvent(ok ? SevInfo : SevWarnAlways, "ConnectionClosed", conn ? conn->getDebugID() : UID(), 1.0).detail("PeerAddr", self->destination).errorUnconditional(e);
 				}
 				else {
-					TraceEvent(ok ? SevInfo : SevWarnAlways, "IncompatibleConnectionClosed", conn ? conn->getDebugID() : UID()).detail("PeerAddr", self->destination).error(e);
+					TraceEvent(ok ? SevInfo : SevWarnAlways, "IncompatibleConnectionClosed", conn ? conn->getDebugID() : UID()).detail("PeerAddr", self->destination).errorUnconditional(e);
 				}
 
 				if (conn) {

--- a/fdbrpc/TLSConnection.actor.cpp
+++ b/fdbrpc/TLSConnection.actor.cpp
@@ -45,10 +45,10 @@ static int send_func(void* ctx, const uint8_t* buf, int len) {
 		int w = conn->conn->write( &sb );
 		return w;
 	} catch ( Error& e ) {
-		TraceEvent("TLSConnectionSendError", conn->getDebugID()).error(e);
+		TraceEvent("TLSConnectionSendError", conn->getDebugID(), e);
 		return -1;
 	} catch ( ... ) {
-		TraceEvent("TLSConnectionSendError", conn->getDebugID()).error( unknown_error() );
+		TraceEvent("TLSConnectionSendError", conn->getDebugID(), unknown_error());
 		return -1;
 	}
 }
@@ -61,10 +61,10 @@ static int recv_func(void* ctx, uint8_t* buf, int len) {
 		int r = conn->conn->read( buf, buf + len );
 		return r;
 	} catch ( Error& e ) {
-		TraceEvent("TLSConnectionRecvError", conn->getDebugID()).error(e);
+		TraceEvent("TLSConnectionRecvError", conn->getDebugID(), e);
 		return -1;
 	} catch ( ... ) {
-		TraceEvent("TLSConnectionRecvError", conn->getDebugID()).error( unknown_error() );
+		TraceEvent("TLSConnectionRecvError", conn->getDebugID(), unknown_error());
 		return -1;
 	}
 }

--- a/fdbrpc/batcher.actor.h
+++ b/fdbrpc/batcher.actor.h
@@ -72,7 +72,7 @@ Future<Void> batcher(PromiseStream<std::pair<std::vector<X>, int> > out, FutureS
 					// Drop requests if memory is under severe pressure
 					if (*commitBatchesMemBytesCount + bytes > commitBatchesMemBytesLimit) {
 						x.reply.sendError(proxy_memory_limit_exceeded());
-						TraceEvent(SevWarnAlways, "ProxyCommitBatchMemoryThresholdExceeded").detail("CommitBatchesMemBytesCount", *commitBatchesMemBytesCount).detail("CommitBatchesMemLimit", commitBatchesMemBytesLimit).suppressFor(60, true);
+						TraceEvent(SevWarnAlways, "ProxyCommitBatchMemoryThresholdExceeded", 60).detail("CommitBatchesMemBytesCount", *commitBatchesMemBytesCount).detail("CommitBatchesMemLimit", commitBatchesMemBytesLimit);
 						continue;
 					}
 

--- a/fdbrpc/genericactors.actor.h
+++ b/fdbrpc/genericactors.actor.h
@@ -160,7 +160,7 @@ Future<ErrorOr<X>> waitValueOrSignal( Future<X> value, Future<Void> signal, Endp
 			}
 		} catch (Error& e) {
 			if (signal.isError()) {
-				TraceEvent(SevError, "WaitValueOrSignalError").error(signal.getError());
+				TraceEvent(SevError, "WaitValueOrSignalError", signal.getError());
 				return ErrorOr<X>(internal_error());
 			}
 

--- a/fdbrpc/sim2.actor.cpp
+++ b/fdbrpc/sim2.actor.cpp
@@ -1569,7 +1569,7 @@ public:
 					currentProcess->cpuTicks = 0;
 				}*/
 			} catch (Error& e) {
-				TraceEvent(SevError, "UnhandledSimulationEventError").error(e);
+				TraceEvent(SevError, "UnhandledSimulationEventError").errorUnconditional(e);
 				killProcess(t.machine, KillInstantly);
 			}
 

--- a/fdbrpc/sim2.actor.cpp
+++ b/fdbrpc/sim2.actor.cpp
@@ -382,7 +382,7 @@ private:
 		Void _ = wait( g_simulator.onProcess( self->process ) );
 		// SOMEDAY: Make this value variable? Dependent on buggification status?
 		Void _ = wait( delay( 20.0 ) );
-		TraceEvent(SevError, "LeakedConnection", self->dbgid).error(connection_leaked()).detail("MyAddr", self->process->address).detail("PeerAddr", self->peerEndpoint).detail("PeerId", self->peerId).detail("Opened", self->opened);
+		TraceEvent(SevError, "LeakedConnection", self->dbgid, connection_leaked()).detail("MyAddr", self->process->address).detail("PeerAddr", self->peerEndpoint).detail("PeerId", self->peerId).detail("Opened", self->opened);
 		return Void();
 	}
 };
@@ -449,7 +449,7 @@ public:
 			if( h == -1 ) {
 				bool notFound = errno == ENOENT;
 				Error e = notFound ? file_not_found() : io_error();
-				TraceEvent(notFound ? SevWarn : SevWarnAlways, "FileOpenError").error(e).GetLastError().detail("File", filename).detail("Flags", flags);
+				TraceEvent(notFound ? SevWarn : SevWarnAlways, "FileOpenError", e).GetLastError().detail("File", filename).detail("Flags", flags);
 				throw e;
 			}
 
@@ -1569,7 +1569,7 @@ public:
 					currentProcess->cpuTicks = 0;
 				}*/
 			} catch (Error& e) {
-				TraceEvent(SevError, "UnhandledSimulationEventError").error(e, true);
+				TraceEvent(SevError, "UnhandledSimulationEventError").error(e);
 				killProcess(t.machine, KillInstantly);
 			}
 
@@ -1668,7 +1668,7 @@ ACTOR void doReboot( ISimulator::ProcessInfo *p, ISimulator::KillType kt ) {
 		}
 		p->shutdownSignal.send( kt );
 	} catch (Error& e) {
-		TraceEvent(SevError, "RebootError").error(e);
+		TraceEvent(SevError, "RebootError", e);
 		p->shutdownSignal.sendError(e);  // ?
 		throw; // goes nowhere!
 	}

--- a/fdbrpc/simulator.h
+++ b/fdbrpc/simulator.h
@@ -129,10 +129,10 @@ public:
 		try {
 			func();
 		} catch (Error& e) {
-			TraceEvent(SevError, "NewMachineError").error(e);
+			TraceEvent(SevError, "NewMachineError", e);
 			killProcess(currentProcess, KillInstantly);
 		} catch (...) {
-			TraceEvent(SevError, "NewMachineError").error(unknown_error());
+			TraceEvent(SevError, "NewMachineError", unknown_error());
 			killProcess(currentProcess, KillInstantly);
 		}
 		std::swap(m, currentProcess);

--- a/fdbserver/ClusterController.actor.cpp
+++ b/fdbserver/ClusterController.actor.cpp
@@ -1104,7 +1104,7 @@ ACTOR Future<Void> clusterWatchDatabase( ClusterControllerData* cluster, Cluster
 				Void _ = wait( delay(SERVER_KNOBS->MASTER_SPIN_DELAY) );
 			}
 		} catch (Error& e) {
-			TraceEvent("CCWDB", cluster->id).error(e).detail("Master", iMaster.id());
+			TraceEvent("CCWDB", cluster->id).errorUnconditional(e).detail("Master", iMaster.id());
 			if (e.code() == error_code_actor_cancelled) throw;
 
 			bool ok = e.code() == error_code_no_more_servers;

--- a/fdbserver/Coordination.actor.cpp
+++ b/fdbserver/Coordination.actor.cpp
@@ -437,7 +437,7 @@ ACTOR Future<Void> coordinationServer(std::string dataFolder) {
 		Void _ = wait( localGenerationReg(myInterface, &store) || leaderServer(myLeaderInterface, &store) || store.getError() );
 		throw internal_error();
 	} catch (Error& e) {
-		TraceEvent("CoordinationServerError", myID).error(e);
+		TraceEvent("CoordinationServerError", myID).errorUnconditional(e);
 		throw;
 	}
 }

--- a/fdbserver/Coordination.actor.cpp
+++ b/fdbserver/Coordination.actor.cpp
@@ -437,7 +437,7 @@ ACTOR Future<Void> coordinationServer(std::string dataFolder) {
 		Void _ = wait( localGenerationReg(myInterface, &store) || leaderServer(myLeaderInterface, &store) || store.getError() );
 		throw internal_error();
 	} catch (Error& e) {
-		TraceEvent("CoordinationServerError", myID).error(e, true);
+		TraceEvent("CoordinationServerError", myID).error(e);
 		throw;
 	}
 }

--- a/fdbserver/CoroFlow.actor.cpp
+++ b/fdbserver/CoroFlow.actor.cpp
@@ -156,7 +156,7 @@ class WorkPool : public IThreadPool, public ReferenceCounted<WorkPool<Threadlike
 				stopped.send(Void());
 				return;
 			} catch (Error& e) {
-				TraceEvent("WorkPoolError").error(e, true);
+				TraceEvent("WorkPoolError").error(e);
 				error.sendError(e);
 			} catch (...) {
 				TraceEvent("WorkPoolError");

--- a/fdbserver/CoroFlow.actor.cpp
+++ b/fdbserver/CoroFlow.actor.cpp
@@ -156,7 +156,7 @@ class WorkPool : public IThreadPool, public ReferenceCounted<WorkPool<Threadlike
 				stopped.send(Void());
 				return;
 			} catch (Error& e) {
-				TraceEvent("WorkPoolError").error(e);
+				TraceEvent("WorkPoolError").errorUnconditional(e);
 				error.sendError(e);
 			} catch (...) {
 				TraceEvent("WorkPoolError");

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -1818,7 +1818,7 @@ ACTOR Future<Void> initializeStorage( DDTeamCollection *self, RecruitStorageRepl
 		.detail("WorkerLocality", candidateWorker.worker.locality.toString()).detail("Interf", interfaceId).detail("Addr", candidateWorker.worker.address());
 
 	if( newServer.isError() ) {
-		TraceEvent(SevWarn, "DDRecruitmentError").error(newServer.getError());
+		TraceEvent(SevWarn, "DDRecruitmentError", newServer.getError());
 		if( !newServer.isError( error_code_recruitment_failed ) && !newServer.isError( error_code_request_maybe_delivered ) )
 			throw newServer.getError();
 		Void _ = wait( delay(SERVER_KNOBS->STORAGE_RECRUITMENT_DELAY, TaskDataDistribution) );
@@ -2005,7 +2005,7 @@ ACTOR Future<Void> dataDistributionTeamCollection(
 		}
 	} catch (Error& e) {
 		if (e.code() != error_code_movekeys_conflict)
-			TraceEvent(SevError, "DataDistributionTeamCollectionError", masterId).error(e);
+			TraceEvent(SevError, "DataDistributionTeamCollectionError", masterId, e);
 		throw e;
 	}
 }

--- a/fdbserver/DataDistributionQueue.actor.cpp
+++ b/fdbserver/DataDistributionQueue.actor.cpp
@@ -1045,7 +1045,7 @@ ACTOR Future<Void> dataDistributionRelocator( DDQueueData *self, RelocateData rd
 			}
 		}
 	} catch (Error& e) {
-		TraceEvent(relocateShardInterval.end(), masterId).error(e);
+		TraceEvent(relocateShardInterval.end(), masterId).errorUnconditional(e);
 		if( !signalledTransferComplete )
 			dataTransferComplete.send( rd );
 

--- a/fdbserver/DataDistributionQueue.actor.cpp
+++ b/fdbserver/DataDistributionQueue.actor.cpp
@@ -926,7 +926,7 @@ ACTOR Future<Void> dataDistributionRelocator( DDQueueData *self, RelocateData rd
 				}
 				TEST(true); //did not find a healthy destination team on the first attempt
 				stuckCount++;
-				TraceEvent(stuckCount > 50 ? SevWarnAlways : SevWarn, "BestTeamStuck", masterId).detail("Count", stuckCount).suppressFor(1.0);
+				TraceEvent(stuckCount > 50 ? SevWarnAlways : SevWarn, "BestTeamStuck", masterId, 1.0).detail("Count", stuckCount);
 				Void _ = wait( delay( SERVER_KNOBS->BEST_TEAM_STUCK_DELAY, TaskDataDistributionLaunch ) );
 			}
 
@@ -1045,7 +1045,7 @@ ACTOR Future<Void> dataDistributionRelocator( DDQueueData *self, RelocateData rd
 			}
 		}
 	} catch (Error& e) {
-		TraceEvent(relocateShardInterval.end(), masterId).error(e, true);
+		TraceEvent(relocateShardInterval.end(), masterId).error(e);
 		if( !signalledTransferComplete )
 			dataTransferComplete.send( rd );
 
@@ -1281,7 +1281,7 @@ ACTOR Future<Void> dataDistributionQueue(
 	} catch (Error& e) {
 		if (e.code() != error_code_broken_promise && // FIXME: Get rid of these broken_promise errors every time we are killed by the master dying
 			e.code() != error_code_movekeys_conflict)
-			TraceEvent(SevError, "DataDistributionQueueError", mi.id()).error(e);
+			TraceEvent(SevError, "DataDistributionQueueError", mi.id(), e);
 		throw e;
 	}
 }

--- a/fdbserver/DataDistributionTracker.actor.cpp
+++ b/fdbserver/DataDistributionTracker.actor.cpp
@@ -209,7 +209,7 @@ ACTOR Future<Void> trackShardBytes(
 
 				shardSize->set( metrics );
 			} catch( Error &e ) {
-				//TraceEvent("ShardSizeUpdateError").detail("Begin", printable(keys.begin)).detail("End", printable(keys.end)).detail("TrackerID", trackerID).error(e, true);
+				//TraceEvent("ShardSizeUpdateError").detail("Begin", printable(keys.begin)).detail("End", printable(keys.end)).detail("TrackerID", trackerID).error(e);
 				Void _ = wait( tr.onError(e) );
 			}
 		}
@@ -691,7 +691,7 @@ ACTOR Future<Void> dataDistributionTracker(
 			when( Void _ = wait( self.sizeChanges.getResult() ) ) {}
 		}
 	} catch (Error& e) {
-		TraceEvent(SevError, "DataDistributionTrackerError", self.masterId).error(e);
+		TraceEvent(SevError, "DataDistributionTrackerError", self.masterId, e);
 		throw e;
 	}
 }

--- a/fdbserver/DataDistributionTracker.actor.cpp
+++ b/fdbserver/DataDistributionTracker.actor.cpp
@@ -209,7 +209,7 @@ ACTOR Future<Void> trackShardBytes(
 
 				shardSize->set( metrics );
 			} catch( Error &e ) {
-				//TraceEvent("ShardSizeUpdateError").detail("Begin", printable(keys.begin)).detail("End", printable(keys.end)).detail("TrackerID", trackerID).error(e);
+				//TraceEvent("ShardSizeUpdateError").detail("Begin", printable(keys.begin)).detail("End", printable(keys.end)).detail("TrackerID", trackerID).errorUnconditional(e);
 				Void _ = wait( tr.onError(e) );
 			}
 		}

--- a/fdbserver/DiskQueue.actor.cpp
+++ b/fdbserver/DiskQueue.actor.cpp
@@ -253,7 +253,7 @@ public:
 				waitfor.push_back( files[1].f->truncate( files[1].size ) );
 
 				if(fileSizeWarningLimit > 0 && files[1].size > fileSizeWarningLimit) {
-					TraceEvent(SevWarnAlways, "DiskQueueFileTooLarge", dbgid).detail("Filename", filename(1)).detail("Size", files[1].size).suppressFor(1.0);
+					TraceEvent(SevWarnAlways, "DiskQueueFileTooLarge", dbgid, 1.0).detail("Filename", filename(1)).detail("Size", files[1].size);
 				}
 			}
 		}
@@ -322,7 +322,7 @@ public:
 			delete pageMem;
 			TEST(true);  // push error
 			TEST(2==syncFiles.size());  // push spanning both files error
-			TraceEvent(SevError, "RDQPushAndCommitError", dbgid).detail("InitialFilename0", filename).error(e, true);
+			TraceEvent(SevError, "RDQPushAndCommitError", dbgid).detail("InitialFilename0", filename).error(e);
 
 			if (errorPromise.canBeSet()) errorPromise.sendError(e);
 			if (pushing.canBeSet()) pushing.sendError(e);
@@ -429,7 +429,7 @@ public:
 		} catch( Error &e ) {
 			TraceEvent(SevError, "DiskQueueShutdownError", self->dbgid)
 				.detail("Reason", e.code() == error_code_platform_error ? "could not delete database" : "unknown")
-				.error(e,true);
+				.error(e);
 			error = e;
 		}
 
@@ -533,7 +533,7 @@ public:
 			return result.str;
 		} catch (Error& e) {
 			bool ok = e.code() == error_code_file_not_found;
-			TraceEvent(ok ? SevInfo : SevError, "RDQReadFirstAndLastPagesError", self->dbgid).detail("File0Name", self->files[0].dbgFilename).error(e, true);
+			TraceEvent(ok ? SevInfo : SevError, "RDQReadFirstAndLastPagesError", self->dbgid).detail("File0Name", self->files[0].dbgFilename).error(e);
 			if (!self->error.isSet()) self->error.sendError(e);
 			throw;
 		}
@@ -588,7 +588,7 @@ public:
 			return result;
 		} catch (Error& e) {
 			TEST(true);  // Read next page error
-			TraceEvent(SevError, "RDQReadNextPageError", self->dbgid).detail("File0Name", self->files[0].dbgFilename).error(e, true);
+			TraceEvent(SevError, "RDQReadNextPageError", self->dbgid).detail("File0Name", self->files[0].dbgFilename).error(e);
 			if (!self->error.isSet()) self->error.sendError(e);
 			throw;
 		}
@@ -633,7 +633,7 @@ public:
 
 			return Void();
 		} catch (Error& e) {
-			TraceEvent(SevError, "RDQTruncateBeforeLastReadPageError", self->dbgid).detail("File0Name", self->files[0].dbgFilename).error(e);
+			TraceEvent(SevError, "RDQTruncateBeforeLastReadPageError", self->dbgid, e).detail("File0Name", self->files[0].dbgFilename);
 			if (!self->error.isSet()) self->error.sendError(e);
 			throw;
 		}
@@ -711,12 +711,11 @@ public:
 		backPage().updateHash();
 
 		if( pushedPageCount() >= 8000 ) {
-			TraceEvent( warnAlwaysForMemory ? SevWarnAlways : SevWarn, "DiskQueueMemoryWarning", dbgid)
+			TraceEvent( warnAlwaysForMemory ? SevWarnAlways : SevWarn, "DiskQueueMemoryWarning", dbgid, 1.0)
 				.detail("PushedPages", pushedPageCount())
 				.detail("NextPageSeq", nextPageSeq)
 				.detail("Details", format("%d pages", pushedPageCount()))
-				.detail("File0Name", rawQueue->files[0].dbgFilename)
-				.suppressFor(1.0);
+				.detail("File0Name", rawQueue->files[0].dbgFilename);
 			if(g_network->isSimulated())
 				warnAlwaysForMemory = false;
 		}

--- a/fdbserver/DiskQueue.actor.cpp
+++ b/fdbserver/DiskQueue.actor.cpp
@@ -322,7 +322,7 @@ public:
 			delete pageMem;
 			TEST(true);  // push error
 			TEST(2==syncFiles.size());  // push spanning both files error
-			TraceEvent(SevError, "RDQPushAndCommitError", dbgid).detail("InitialFilename0", filename).error(e);
+			TraceEvent(SevError, "RDQPushAndCommitError", dbgid).detail("InitialFilename0", filename).errorUnconditional(e);
 
 			if (errorPromise.canBeSet()) errorPromise.sendError(e);
 			if (pushing.canBeSet()) pushing.sendError(e);
@@ -429,7 +429,7 @@ public:
 		} catch( Error &e ) {
 			TraceEvent(SevError, "DiskQueueShutdownError", self->dbgid)
 				.detail("Reason", e.code() == error_code_platform_error ? "could not delete database" : "unknown")
-				.error(e);
+				.errorUnconditional(e);
 			error = e;
 		}
 
@@ -533,7 +533,7 @@ public:
 			return result.str;
 		} catch (Error& e) {
 			bool ok = e.code() == error_code_file_not_found;
-			TraceEvent(ok ? SevInfo : SevError, "RDQReadFirstAndLastPagesError", self->dbgid).detail("File0Name", self->files[0].dbgFilename).error(e);
+			TraceEvent(ok ? SevInfo : SevError, "RDQReadFirstAndLastPagesError", self->dbgid).detail("File0Name", self->files[0].dbgFilename).errorUnconditional(e);
 			if (!self->error.isSet()) self->error.sendError(e);
 			throw;
 		}
@@ -588,7 +588,7 @@ public:
 			return result;
 		} catch (Error& e) {
 			TEST(true);  // Read next page error
-			TraceEvent(SevError, "RDQReadNextPageError", self->dbgid).detail("File0Name", self->files[0].dbgFilename).error(e);
+			TraceEvent(SevError, "RDQReadNextPageError", self->dbgid).detail("File0Name", self->files[0].dbgFilename).errorUnconditional(e);
 			if (!self->error.isSet()) self->error.sendError(e);
 			throw;
 		}

--- a/fdbserver/KeyValueStoreMemory.actor.cpp
+++ b/fdbserver/KeyValueStoreMemory.actor.cpp
@@ -581,7 +581,7 @@ private:
 			return Void();
 		} catch( Error &e ) {
 			bool ok = e.code() == error_code_operation_cancelled || e.code() == error_code_file_not_found;
-			TraceEvent(ok ? SevInfo : SevError, "ErrorDuringRecovery", dbgid).error(e, true);
+			TraceEvent(ok ? SevInfo : SevError, "ErrorDuringRecovery", dbgid).error(e);
 			throw e;
 		}
 	}

--- a/fdbserver/KeyValueStoreMemory.actor.cpp
+++ b/fdbserver/KeyValueStoreMemory.actor.cpp
@@ -581,7 +581,7 @@ private:
 			return Void();
 		} catch( Error &e ) {
 			bool ok = e.code() == error_code_operation_cancelled || e.code() == error_code_file_not_found;
-			TraceEvent(ok ? SevInfo : SevError, "ErrorDuringRecovery", dbgid).error(e);
+			TraceEvent(ok ? SevInfo : SevError, "ErrorDuringRecovery", dbgid).errorUnconditional(e);
 			throw e;
 		}
 	}

--- a/fdbserver/KeyValueStoreSQLite.actor.cpp
+++ b/fdbserver/KeyValueStoreSQLite.actor.cpp
@@ -1832,7 +1832,7 @@ private:
 		} catch (Error& e) {
 			TraceEvent(SevError, "KVDoCloseError", self->logID)
 				.detail("Reason", e.code() == error_code_platform_error ? "could not delete database" : "unknown")
-				.error(e);
+				.errorUnconditional(e);
 			error = e;
 		}
 

--- a/fdbserver/KeyValueStoreSQLite.actor.cpp
+++ b/fdbserver/KeyValueStoreSQLite.actor.cpp
@@ -102,15 +102,14 @@ struct PageChecksumCodec {
 		// Verify if not in write mode
 		if(!write && sum != *pSumInPage) {
 			if(!silent)
-				TraceEvent (SevError, "SQLitePageChecksumFailure")
+				TraceEvent (SevError, "SQLitePageChecksumFailure", checksum_failed())
 					.detail("CodecPageSize", pageSize)
 					.detail("CodecReserveSize", reserveSize)
 					.detail("Filename", filename)
 					.detail("PageNumber", pageNumber)
 					.detail("PageSize", pageLen)
 					.detail("ChecksumInPage", pSumInPage->toString())
-					.detail("ChecksumCalculated", sum.toString())
-					.error(checksum_failed());
+					.detail("ChecksumCalculated", sum.toString());
 
 			return false;
 		}
@@ -234,7 +233,7 @@ struct SQLiteDB : NonCopyable {
 				db->errCode = rc;
 			if (rc == SQLITE_NOMEM) platform::outOfMemory(); // SOMEDAY: Trap out of memory errors at allocation time; check out different allocation options in sqlite
 
-			TraceEvent(SevError, "DiskError").error(err).detail("In", context).detail("File", filename).detail("SQLiteError", sqlite3ErrStr(rc)).detail("SQLiteErrorCode", rc).GetLastError();
+			TraceEvent(SevError, "DiskError", err).detail("In", context).detail("File", filename).detail("SQLiteError", sqlite3ErrStr(rc)).detail("SQLiteErrorCode", rc).GetLastError();
 			throw err;
 		}
 	}
@@ -1833,7 +1832,7 @@ private:
 		} catch (Error& e) {
 			TraceEvent(SevError, "KVDoCloseError", self->logID)
 				.detail("Reason", e.code() == error_code_platform_error ? "could not delete database" : "unknown")
-				.error(e,true);
+				.error(e);
 			error = e;
 		}
 

--- a/fdbserver/LogRouter.actor.cpp
+++ b/fdbserver/LogRouter.actor.cpp
@@ -423,7 +423,7 @@ ACTOR Future<Void> logRouter(
 	catch (Error& e) {
 		if (e.code() == error_code_actor_cancelled || e.code() == error_code_worker_removed)
 		{
-			TraceEvent("LogRouterTerminated", interf.id()).error(e);
+			TraceEvent("LogRouterTerminated", interf.id()).errorUnconditional(e);
 			return Void();
 		}
 		throw;

--- a/fdbserver/LogRouter.actor.cpp
+++ b/fdbserver/LogRouter.actor.cpp
@@ -423,7 +423,7 @@ ACTOR Future<Void> logRouter(
 	catch (Error& e) {
 		if (e.code() == error_code_actor_cancelled || e.code() == error_code_worker_removed)
 		{
-			TraceEvent("LogRouterTerminated", interf.id()).error(e, true);
+			TraceEvent("LogRouterTerminated", interf.id()).error(e);
 			return Void();
 		}
 		throw;

--- a/fdbserver/MasterProxyServer.actor.cpp
+++ b/fdbserver/MasterProxyServer.actor.cpp
@@ -97,14 +97,14 @@ ACTOR Future<Void> getRate(UID myID, MasterInterface master, int64_t* inTransact
 		when(GetRateInfoReply rep = wait(reply)) {
 			reply = Never();
 			*outTransactionRate = rep.transactionRate;
-			TraceEvent("MasterProxyRate", myID).detail("Rate", rep.transactionRate).detail("Lease", rep.leaseDuration).detail("ReleasedTransactions", *inTransactionCount - lastTC);
+			//TraceEvent("MasterProxyRate", myID).detail("Rate", rep.transactionRate).detail("Lease", rep.leaseDuration).detail("ReleasedTransactions", *inTransactionCount - lastTC);
 			lastTC = *inTransactionCount;
 			leaseTimeout = delay(rep.leaseDuration);
 			nextRequestTimer = delayJittered(rep.leaseDuration / 2);
 		}
 		when(Void _ = wait(leaseTimeout)) {
 			*outTransactionRate = 0;
-			TraceEvent("MasterProxyRate", myID).detail("Rate", 0).detail("Lease", "Expired");
+			//TraceEvent("MasterProxyRate", myID).detail("Rate", 0).detail("Lease", "Expired");
 			leaseTimeout = Never();
 		}
 	}
@@ -1379,7 +1379,7 @@ ACTOR Future<Void> masterProxyServer(
 			e.code() == error_code_master_tlog_failed || e.code() == error_code_coordinators_changed || e.code() == error_code_coordinated_state_conflict ||
 			e.code() == error_code_new_coordinators_timed_out)
 		{
-			TraceEvent("MasterProxyTerminated", proxy.id()).error(e, true);
+			TraceEvent("MasterProxyTerminated", proxy.id()).error(e);
 			return Void();
 		}
 		throw;

--- a/fdbserver/MasterProxyServer.actor.cpp
+++ b/fdbserver/MasterProxyServer.actor.cpp
@@ -1379,7 +1379,7 @@ ACTOR Future<Void> masterProxyServer(
 			e.code() == error_code_master_tlog_failed || e.code() == error_code_coordinators_changed || e.code() == error_code_coordinated_state_conflict ||
 			e.code() == error_code_new_coordinators_timed_out)
 		{
-			TraceEvent("MasterProxyTerminated", proxy.id()).error(e);
+			TraceEvent("MasterProxyTerminated", proxy.id()).errorUnconditional(e);
 			return Void();
 		}
 		throw;

--- a/fdbserver/MoveKeys.actor.cpp
+++ b/fdbserver/MoveKeys.actor.cpp
@@ -313,11 +313,10 @@ ACTOR Future<Void> startMoveKeys( Database occ, KeyRange keys, vector<UID> serve
 					Void _ = wait( tr.onError(e) );
 
 					if(retries%10 == 0) {
-						TraceEvent(retries == 50 ? SevWarnAlways : SevWarn, "StartMoveKeysRetrying", relocationIntervalId)
+						TraceEvent(retries == 50 ? SevWarnAlways : SevWarn, "StartMoveKeysRetrying", relocationIntervalId, err)
 							.detail("Keys", printable(keys))
 							.detail("BeginKey", printable(begin))
-							.detail("NumTries", retries)
-							.error(err);
+							.detail("NumTries", retries);
 					}
 				}
 			}
@@ -333,7 +332,7 @@ ACTOR Future<Void> startMoveKeys( Database occ, KeyRange keys, vector<UID> serve
 			.detail("Shards", shards)
 			.detail("MaxRetries", maxRetries);
 	} catch( Error& e ) {
-		TraceEvent(SevDebug, interval.end(), relocationIntervalId).error(e, true);
+		TraceEvent(SevDebug, interval.end(), relocationIntervalId).error(e);
 		throw;
 	}
 
@@ -616,8 +615,7 @@ ACTOR Future<Void> finishMoveKeys( Database occ, KeyRange keys, vector<UID> dest
 					Void _ = wait( tr.onError(error) );
 					retries++;
 					if(retries%10 == 0) {
-						TraceEvent(retries == 20 ? SevWarnAlways : SevWarn, "RelocateShard_FinishMoveKeysRetrying", relocationIntervalId)
-							.error(err)
+						TraceEvent(retries == 20 ? SevWarnAlways : SevWarn, "RelocateShard_FinishMoveKeysRetrying", relocationIntervalId, err)
 							.detail("KeyBegin", printable(keys.begin))
 							.detail("KeyEnd", printable(keys.end))
 							.detail("IterationBegin", printable(begin))
@@ -629,7 +627,7 @@ ACTOR Future<Void> finishMoveKeys( Database occ, KeyRange keys, vector<UID> dest
 
 		TraceEvent(SevDebug, interval.end(), relocationIntervalId);
 	} catch(Error &e) {
-		TraceEvent(SevDebug, interval.end(), relocationIntervalId).error(e, true);
+		TraceEvent(SevDebug, interval.end(), relocationIntervalId).error(e);
 		throw;
 	}
 	return Void();
@@ -813,7 +811,7 @@ ACTOR Future<Void> removeStorageServer( Database cx, UID serverID, MoveKeysLock 
 		} catch (Error& e) {
 			state Error err = e;
 			Void _ = wait( tr.onError(e) );
-			TraceEvent("RemoveStorageServerRetrying").error(err);
+			TraceEvent("RemoveStorageServerRetrying", err);
 		}
 	}
 }

--- a/fdbserver/MoveKeys.actor.cpp
+++ b/fdbserver/MoveKeys.actor.cpp
@@ -332,7 +332,7 @@ ACTOR Future<Void> startMoveKeys( Database occ, KeyRange keys, vector<UID> serve
 			.detail("Shards", shards)
 			.detail("MaxRetries", maxRetries);
 	} catch( Error& e ) {
-		TraceEvent(SevDebug, interval.end(), relocationIntervalId).error(e);
+		TraceEvent(SevDebug, interval.end(), relocationIntervalId).errorUnconditional(e);
 		throw;
 	}
 
@@ -627,7 +627,7 @@ ACTOR Future<Void> finishMoveKeys( Database occ, KeyRange keys, vector<UID> dest
 
 		TraceEvent(SevDebug, interval.end(), relocationIntervalId);
 	} catch(Error &e) {
-		TraceEvent(SevDebug, interval.end(), relocationIntervalId).error(e);
+		TraceEvent(SevDebug, interval.end(), relocationIntervalId).errorUnconditional(e);
 		throw;
 	}
 	return Void();

--- a/fdbserver/OldTLogServer.actor.cpp
+++ b/fdbserver/OldTLogServer.actor.cpp
@@ -1005,7 +1005,7 @@ namespace oldTLog {
 		logData->queueCommittedVersion.set(ver);
 		self->queueCommitEnd.set(commitNumber);
 
-		TraceEvent("TLogCommitDurable", self->dbgid).detail("Version", ver);
+		//TraceEvent("TLogCommitDurable", self->dbgid).detail("Version", ver);
 
 		return Void();
 	}
@@ -1405,7 +1405,7 @@ namespace oldTLog {
 			Void _ = wait( error );
 			throw internal_error();
 		} catch (Error& e) {
-			TraceEvent("TLogError", tlogId).error(e, true);
+			TraceEvent("TLogError", tlogId).error(e);
 
 			for( auto& it : self.id_data ) {
 				if(it.second->recoverySuccessful.canBeSet()) {

--- a/fdbserver/OldTLogServer.actor.cpp
+++ b/fdbserver/OldTLogServer.actor.cpp
@@ -1405,7 +1405,7 @@ namespace oldTLog {
 			Void _ = wait( error );
 			throw internal_error();
 		} catch (Error& e) {
-			TraceEvent("TLogError", tlogId).error(e);
+			TraceEvent("TLogError", tlogId).errorUnconditional(e);
 
 			for( auto& it : self.id_data ) {
 				if(it.second->recoverySuccessful.canBeSet()) {

--- a/fdbserver/QuietDatabase.actor.cpp
+++ b/fdbserver/QuietDatabase.actor.cpp
@@ -74,7 +74,7 @@ ACTOR Future<int64_t> getDataInFlight( Database cx, WorkerInterface masterWorker
 		sscanf(md.getValue("TotalBytes").c_str(), "%lld", &dataInFlight);
 		return dataInFlight;
 	} catch( Error &e ) {
-		TraceEvent("QuietDatabaseFailure", masterWorker.id()).detail("Reason", "Failed to extract DataInFlight").error(e);
+		TraceEvent("QuietDatabaseFailure", masterWorker.id(), e).detail("Reason", "Failed to extract DataInFlight");
 		throw;
 	}
 
@@ -358,13 +358,13 @@ ACTOR Future<Void> waitForQuietDatabase( Database cx, Reference<AsyncVar<ServerD
 			}
 		} catch (Error& e) {
 			if( e.code() != error_code_actor_cancelled && e.code() != error_code_attribute_not_found && e.code() != error_code_timed_out)
-				TraceEvent(("QuietDatabase" + phase + "Error").c_str()).error(e);
+				TraceEvent(("QuietDatabase" + phase + "Error").c_str(), e);
 
 			//Client invalid operation occurs if we don't get back a message from one of the servers, often corrected by retrying
 			if(e.code() != error_code_attribute_not_found && e.code() != error_code_timed_out)
 				throw;
 
-			TraceEvent(("QuietDatabase" + phase + "Retry").c_str()).error(e);
+			TraceEvent(("QuietDatabase" + phase + "Retry").c_str(), e);
 			Void _ = wait(delay(1.0));
 			numSuccesses = 0;
 		}

--- a/fdbserver/Resolver.actor.cpp
+++ b/fdbserver/Resolver.actor.cpp
@@ -311,7 +311,7 @@ ACTOR Future<Void> resolver(
 		}
 	} catch (Error& e) {
 		if (e.code() == error_code_actor_cancelled || e.code() == error_code_worker_removed) {
-			TraceEvent("ResolverTerminated", resolver.id()).error(e,true);
+			TraceEvent("ResolverTerminated", resolver.id()).error(e);
 			return Void();
 		}
 		throw;

--- a/fdbserver/Resolver.actor.cpp
+++ b/fdbserver/Resolver.actor.cpp
@@ -311,7 +311,7 @@ ACTOR Future<Void> resolver(
 		}
 	} catch (Error& e) {
 		if (e.code() == error_code_actor_cancelled || e.code() == error_code_worker_removed) {
-			TraceEvent("ResolverTerminated", resolver.id()).error(e);
+			TraceEvent("ResolverTerminated", resolver.id()).errorUnconditional(e);
 			return Void();
 		}
 		throw;

--- a/fdbserver/SimulatedCluster.actor.cpp
+++ b/fdbserver/SimulatedCluster.actor.cpp
@@ -270,7 +270,7 @@ ACTOR Future<ISimulator::KillType> simulatedFDBDRebooter(
 				if(e.code() != error_code_actor_cancelled)
 					printf("SimulatedFDBDTerminated: %s\n", e.what());
 				ASSERT( destructed || g_simulator.getCurrentProcess() == process ); // simulatedFDBD catch called on different process
-				TraceEvent(e.code() == error_code_actor_cancelled || e.code() == error_code_file_not_found || destructed ? SevInfo : SevError, "SimulatedFDBDTerminated", localities.zoneId()).error(e, true);
+				TraceEvent(e.code() == error_code_actor_cancelled || e.code() == error_code_file_not_found || destructed ? SevInfo : SevError, "SimulatedFDBDTerminated", localities.zoneId()).error(e);
 			}
 
 			TraceEvent("SimulatedFDBDDone", localities.zoneId()).detail("Cycles", cycles).detail("RandomId", randomId)
@@ -282,7 +282,7 @@ ACTOR Future<ISimulator::KillType> simulatedFDBDRebooter(
 			if (!onShutdown.isReady())
 				onShutdown = ISimulator::InjectFaults;
 		} catch (Error& e) {
-			TraceEvent(destructed ? SevInfo : SevError, "SimulatedFDBDRebooterError", localities.zoneId()).detail("RandomId", randomId).error(e, true);
+			TraceEvent(destructed ? SevInfo : SevError, "SimulatedFDBDRebooterError", localities.zoneId()).detail("RandomId", randomId).error(e);
 			onShutdown = e;
 		}
 
@@ -658,7 +658,7 @@ ACTOR Future<Void> restartSimulatedSystem(
 		g_simulator.processesPerMachine = processesPerMachine;
 	}
 	catch (Error& e) {
-		TraceEvent(SevError, "RestartSimulationError").error(e);
+		TraceEvent(SevError, "RestartSimulationError", e);
 	}
 
 	TraceEvent("RestartSimulatorSettings")
@@ -1251,7 +1251,7 @@ ACTOR void setupAndRun(std::string dataFolder, const char *testFile, bool reboot
 		writeFile(joinPath(clusterFileDir, "fdb.cluster"), connFile.get().toString());
 		Void _ = wait(timeoutError(runTests(Reference<ClusterConnectionFile>(new ClusterConnectionFile(joinPath(clusterFileDir, "fdb.cluster"))), TEST_TYPE_FROM_FILE, TEST_ON_TESTERS, testerCount, testFile, startingConfiguration), buggifyActivated ? 36000.0 : 5400.0));
 	} catch (Error& e) {
-		TraceEvent(SevError, "SetupAndRunError").error(e);
+		TraceEvent(SevError, "SetupAndRunError", e);
 	}
 
 	TraceEvent("SimulatedSystemDestruct");

--- a/fdbserver/SimulatedCluster.actor.cpp
+++ b/fdbserver/SimulatedCluster.actor.cpp
@@ -270,7 +270,7 @@ ACTOR Future<ISimulator::KillType> simulatedFDBDRebooter(
 				if(e.code() != error_code_actor_cancelled)
 					printf("SimulatedFDBDTerminated: %s\n", e.what());
 				ASSERT( destructed || g_simulator.getCurrentProcess() == process ); // simulatedFDBD catch called on different process
-				TraceEvent(e.code() == error_code_actor_cancelled || e.code() == error_code_file_not_found || destructed ? SevInfo : SevError, "SimulatedFDBDTerminated", localities.zoneId()).error(e);
+				TraceEvent(e.code() == error_code_actor_cancelled || e.code() == error_code_file_not_found || destructed ? SevInfo : SevError, "SimulatedFDBDTerminated", localities.zoneId()).errorUnconditional(e);
 			}
 
 			TraceEvent("SimulatedFDBDDone", localities.zoneId()).detail("Cycles", cycles).detail("RandomId", randomId)
@@ -282,7 +282,7 @@ ACTOR Future<ISimulator::KillType> simulatedFDBDRebooter(
 			if (!onShutdown.isReady())
 				onShutdown = ISimulator::InjectFaults;
 		} catch (Error& e) {
-			TraceEvent(destructed ? SevInfo : SevError, "SimulatedFDBDRebooterError", localities.zoneId()).detail("RandomId", randomId).error(e);
+			TraceEvent(destructed ? SevInfo : SevError, "SimulatedFDBDRebooterError", localities.zoneId()).detail("RandomId", randomId).errorUnconditional(e);
 			onShutdown = e;
 		}
 

--- a/fdbserver/Status.actor.cpp
+++ b/fdbserver/Status.actor.cpp
@@ -269,7 +269,7 @@ static StatusObject getError(const TraceEventFields& errorFields) {
 		}
 	}
 	catch (Error &e){
-		TraceEvent(SevError, "StatusGetErrorError").error(e).detail("RawError", errorFields.toString());
+		TraceEvent(SevError, "StatusGetErrorError", e).detail("RawError", errorFields.toString());
 	}
 	return statusObj;
 }
@@ -1517,7 +1517,7 @@ static std::map<std::string, StatusObject> getProcessIssuesAsMessages( ProcessIs
 		}
 	}
 	catch (Error &e) {
-		TraceEvent(SevError, "ErrorParsingProcessIssues").error(e);
+		TraceEvent(SevError, "ErrorParsingProcessIssues", e);
 		// swallow
 	}
 
@@ -1547,7 +1547,7 @@ static StatusArray getClientIssuesAsMessages( ProcessIssuesMap const& _issues) {
 		}
 	}
 	catch (Error &e) {
-		TraceEvent(SevError, "ErrorParsingClientIssues").error(e);
+		TraceEvent(SevError, "ErrorParsingClientIssues", e);
 		// swallow
 	}
 
@@ -1600,7 +1600,7 @@ ACTOR Future<StatusObject> layerStatusFetcher(Database cx, StatusArray *messages
 			}
 		}
 	} catch(Error &e) {
-		TraceEvent(SevWarn, "LayerStatusError").error(e);
+		TraceEvent(SevWarn, "LayerStatusError", e);
 		incomplete_reasons->insert(format("Unable to retrieve layer status (%s).", e.what()));
 		json.create("_error") = format("Unable to retrieve layer status (%s).", e.what());
 		json.create("_valid") = false;
@@ -1887,7 +1887,7 @@ ACTOR Future<StatusReply> clusterGetStatus(
 
 		return statusObj;
 	} catch( Error&e ) {
-		TraceEvent(SevError, "StatusError").error(e);
+		TraceEvent(SevError, "StatusError", e);
 		throw;
 	}
 }

--- a/fdbserver/TLogServer.actor.cpp
+++ b/fdbserver/TLogServer.actor.cpp
@@ -1107,7 +1107,7 @@ ACTOR Future<Void> doQueueCommit( TLogData* self, Reference<LogData> logData ) {
 		logData->recoveryComplete.send(Void());
 	}
 
-	TraceEvent("TLogCommitDurable", self->dbgid).detail("Version", ver);
+	//TraceEvent("TLogCommitDurable", self->dbgid).detail("Version", ver);
 	if(logData->logSystem->get() && (!logData->isPrimary || logData->logRouterPoppedVersion < logData->logRouterPopToVersion)) {
 		logData->logRouterPoppedVersion = ver;
 		logData->logSystem->get()->pop(ver, logData->remoteTag, knownCommittedVersion, logData->locality);
@@ -1204,7 +1204,7 @@ ACTOR Future<Void> tLogCommit(
 		if(req.debugID.present())
 			g_traceBatch.addEvent("CommitDebug", tlogDebugID.get().first(), "TLog.tLogCommit.Before");
 
-		TraceEvent("TLogCommit", logData->logId).detail("Version", req.version);
+		//TraceEvent("TLogCommit", logData->logId).detail("Version", req.version);
 		commitMessages(logData, req.version, req.arena, req.messages, self->bytesInput);
 
 		logData->knownCommittedVersion = std::max(logData->knownCommittedVersion, req.knownCommittedVersion);
@@ -1865,7 +1865,7 @@ bool tlogTerminated( TLogData* self, IKeyValueStore* persistentData, TLogQueue* 
 		 e.code() == error_code_recruitment_failed ||
 		 e.code() == error_code_file_not_found )
 	{
-		TraceEvent("TLogTerminated", self->dbgid).error(e, true);
+		TraceEvent("TLogTerminated", self->dbgid).error(e);
 		return true;
 	} else
 		return false;
@@ -2078,7 +2078,7 @@ ACTOR Future<Void> tLog( IKeyValueStore* persistentData, IDiskQueue* persistentQ
 		}
 	} catch (Error& e) {
 		self.terminated = true;
-		TraceEvent("TLogError", tlogId).error(e, true);
+		TraceEvent("TLogError", tlogId).error(e);
 		endRole(tlogId, "SharedTLog", "Error", true);
 		if(recovered.canBeSet()) recovered.send(Void());
 

--- a/fdbserver/TLogServer.actor.cpp
+++ b/fdbserver/TLogServer.actor.cpp
@@ -1865,7 +1865,7 @@ bool tlogTerminated( TLogData* self, IKeyValueStore* persistentData, TLogQueue* 
 		 e.code() == error_code_recruitment_failed ||
 		 e.code() == error_code_file_not_found )
 	{
-		TraceEvent("TLogTerminated", self->dbgid).error(e);
+		TraceEvent("TLogTerminated", self->dbgid).errorUnconditional(e);
 		return true;
 	} else
 		return false;
@@ -2078,7 +2078,7 @@ ACTOR Future<Void> tLog( IKeyValueStore* persistentData, IDiskQueue* persistentQ
 		}
 	} catch (Error& e) {
 		self.terminated = true;
-		TraceEvent("TLogError", tlogId).error(e);
+		TraceEvent("TLogError", tlogId).errorUnconditional(e);
 		endRole(tlogId, "SharedTLog", "Error", true);
 		if(recovered.canBeSet()) recovered.send(Void());
 

--- a/fdbserver/TagPartitionedLogSystem.actor.cpp
+++ b/fdbserver/TagPartitionedLogSystem.actor.cpp
@@ -843,7 +843,7 @@ struct TagPartitionedLogSystem : ILogSystem, ReferenceCounted<TagPartitionedLogS
 				last = to.first;
 			} catch (Error& e) {
 				if (e.code() == error_code_actor_cancelled) throw;
-				TraceEvent( (e.code() == error_code_broken_promise) ? SevInfo : SevError, "LogPopError", self->dbgid ).detail("Log", log->get().id()).error(e);
+				TraceEvent( (e.code() == error_code_broken_promise) ? SevInfo : SevError, "LogPopError", self->dbgid, e ).detail("Log", log->get().id());
 				return Void();  // Leaving outstandingPops filled in means no further pop requests to this tlog from this logSystem
 			}
 		}

--- a/fdbserver/VFSAsync.cpp
+++ b/fdbserver/VFSAsync.cpp
@@ -199,12 +199,11 @@ static int asyncSync(sqlite3_file *pFile, int flags){
 		waitFor( p->file->sync() );
 		return SQLITE_OK;
 	} catch (Error& e) {
-		TraceEvent("VFSSyncError")
+		TraceEvent("VFSSyncError", e)
 			.detail("Filename", p->filename)
 			.detail("Sqlite3File", (int64_t)pFile)
-			.detail("IAsyncFile", (int64_t)p->file.getPtr())
-			.error(e);
-		
+			.detail("IAsyncFile", (int64_t)p->file.getPtr());
+
 		return SQLITE_IOERR_FSYNC;
 	}
 }
@@ -528,7 +527,7 @@ static int asyncOpen(
 			.detail("Sqlite3File", DEBUG_DETERMINISM ? 0 : (int64_t)pFile)
 			.detail("IAsyncFile", DEBUG_DETERMINISM ? 0 : (int64_t)p->file.getPtr());*/
 	} catch (Error& e) {
-		TraceEvent("SQLiteOpenFail").detail("Filename", p->filename).error(e);
+		TraceEvent("SQLiteOpenFail", e).detail("Filename", p->filename);
 		p->~VFSAsyncFile();
 		return SQLITE_CANTOPEN;
 	}
@@ -632,10 +631,10 @@ static int asyncFullPathname(
 		memcpy(zPathOut, s.c_str(), s.size()+1);
 		return SQLITE_OK;
 	} catch (Error& e) {
-		TraceEvent(SevError,"VFSAsyncFullPathnameError").detail("PathIn", (std::string)zPath).error(e);
+		TraceEvent(SevError,"VFSAsyncFullPathnameError", e).detail("PathIn", (std::string)zPath);
 		return SQLITE_IOERR;
 	} catch(...) {
-		TraceEvent(SevError,"VFSAsyncFullPathnameError").detail("PathIn", (std::string)zPath).error(unknown_error());
+		TraceEvent(SevError,"VFSAsyncFullPathnameError", unknown_error()).detail("PathIn", (std::string)zPath);
 		return SQLITE_IOERR;
 	}
 }
@@ -700,7 +699,7 @@ static int asyncSleep(sqlite3_vfs *pVfs, int microseconds){
 		waitFor( g_network->delay( microseconds*1e-6, TaskDefaultDelay ) || simCancel );
 		return microseconds;
 	} catch( Error &e ) {
-		TraceEvent(SevError, "AsyncSleepError").error(e,true);
+		TraceEvent(SevError, "AsyncSleepError").error(e);
 		return 0;
 	}
 }

--- a/fdbserver/VFSAsync.cpp
+++ b/fdbserver/VFSAsync.cpp
@@ -699,7 +699,7 @@ static int asyncSleep(sqlite3_vfs *pVfs, int microseconds){
 		waitFor( g_network->delay( microseconds*1e-6, TaskDefaultDelay ) || simCancel );
 		return microseconds;
 	} catch( Error &e ) {
-		TraceEvent(SevError, "AsyncSleepError").error(e);
+		TraceEvent(SevError, "AsyncSleepError").errorUnconditional(e);
 		return 0;
 	}
 }

--- a/fdbserver/WaitFailure.actor.cpp
+++ b/fdbserver/WaitFailure.actor.cpp
@@ -50,7 +50,7 @@ ACTOR Future<Void> waitFailureClient(RequestStream<ReplyPromise<Void>> waitFailu
 		} catch (Error &e){
 			if (e.code() == error_code_actor_cancelled)
 				throw;
-			TraceEvent(SevError, "WaitFailureClientError").error(e);
+			TraceEvent(SevError, "WaitFailureClientError", e);
 			ASSERT(false); // unknown error from waitFailureServer
 		}
 	}
@@ -74,7 +74,7 @@ ACTOR Future<Void> waitFailureTracker(RequestStream<ReplyPromise<Void>> waitFail
 		} catch (Error &e){
 			if (e.code() == error_code_actor_cancelled)
 				throw;
-			TraceEvent(SevError, "WaitFailureClientError").error(e);
+			TraceEvent(SevError, "WaitFailureClientError", e);
 			ASSERT(false); // unknown error from waitFailureServer
 		}
 	}

--- a/fdbserver/fdbserver.actor.cpp
+++ b/fdbserver/fdbserver.actor.cpp
@@ -540,7 +540,7 @@ ACTOR Future<Void> dumpDatabase( Database cx, std::string outputFilename, KeyRan
 			}
 		}
 	} catch (Error& e) {
-		TraceEvent(SevError,"DumpDatabaseError").error(e).detail("Filename", outputFilename);
+		TraceEvent(SevError,"DumpDatabaseError", e).detail("Filename", outputFilename);
 		throw;
 	}
 }
@@ -1495,7 +1495,7 @@ int main(int argc, char* argv[]) {
 					listenError = FlowTransport::transport().bind(publicAddress, listenAddress);
 					if (listenError.isReady()) listenError.get();
 				} catch (Error& e) {
-					TraceEvent("BindError").error(e);
+					TraceEvent("BindError", e);
 					fprintf(stderr, "Error initializing networking with public address %s and listen address %s (%s)\n", publicAddress.toString().c_str(), listenAddress.toString().c_str(), e.what());
 					printHelpTeaser(argv[0]);
 					flushAndExit(FDB_EXIT_ERROR);
@@ -1773,12 +1773,12 @@ int main(int argc, char* argv[]) {
 		flushAndExit(rc);
 	} catch (Error& e) {
 		fprintf(stderr, "Error: %s\n", e.what());
-		TraceEvent(SevError, "MainError").error(e);
+		TraceEvent(SevError, "MainError", e);
 		//printf("\n%d tests passed; %d tests failed\n", passCount, failCount);
 		flushAndExit(FDB_EXIT_MAIN_ERROR);
 	} catch (std::exception& e) {
 		fprintf(stderr, "std::exception: %s\n", e.what());
-		TraceEvent(SevError, "MainError").error(unknown_error()).detail("RootException", e.what());
+		TraceEvent(SevError, "MainError", unknown_error()).detail("RootException", e.what());
 		//printf("\n%d tests passed; %d tests failed\n", passCount, failCount);
 		flushAndExit(FDB_EXIT_MAIN_EXCEPTION);
 	}

--- a/fdbserver/masterserver.actor.cpp
+++ b/fdbserver/masterserver.actor.cpp
@@ -1362,7 +1362,7 @@ ACTOR Future<Void> masterServer( MasterInterface mi, Reference<AsyncVar<ServerDB
 
 		if (normalMasterErrors().count(err.code()))
 		{
-			TraceEvent("MasterTerminated", mi.id()).error(err);
+			TraceEvent("MasterTerminated", mi.id(), err);
 			return Void();
 		}
 		throw err;

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -1898,7 +1898,7 @@ ACTOR Future<Void> fetchKeys( StorageServer *data, AddingShard* shard ) {
 
 				break;
 			} catch (Error& e) {
-				TraceEvent("FKBlockFail", data->thisServerID, 1.0).detail("FKID", interval.pairID).error(e);
+				TraceEvent("FKBlockFail", data->thisServerID, 1.0).detail("FKID", interval.pairID).errorUnconditional(e);
 				if (e.code() == error_code_transaction_too_old){
 					TEST(true); // A storage server has forgotten the history data we are fetching
 					Version lastFV = fetchVersion;
@@ -2007,7 +2007,7 @@ ACTOR Future<Void> fetchKeys( StorageServer *data, AddingShard* shard ) {
 
 		TraceEvent(SevDebug, interval.end(), data->thisServerID);
 	} catch (Error &e){
-		TraceEvent(SevDebug, interval.end(), data->thisServerID).error(e).detail("Version", data->version.get());
+		TraceEvent(SevDebug, interval.end(), data->thisServerID).errorUnconditional(e).detail("Version", data->version.get());
 
 		if (e.code() == error_code_actor_cancelled && !data->shuttingDown && shard->phase >= AddingShard::Fetching) {
 			if (shard->phase < AddingShard::Waiting) {
@@ -3274,7 +3274,7 @@ bool storageServerTerminated(StorageServer& self, IKeyValueStore* persistentData
 		 e.code() == error_code_file_not_found ||
 		 e.code() == error_code_actor_cancelled )
 	{
-		TraceEvent("StorageServerTerminated", self.thisServerID).error(e);
+		TraceEvent("StorageServerTerminated", self.thisServerID).errorUnconditional(e);
 		return true;
 	} else
 		return false;

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -1455,7 +1455,7 @@ bool changeDurableVersion( StorageServer* data, Version desiredDurableVersion ) 
 	data->durableVersion.set( nextDurableVersion );
 	if (checkFatalError.isReady()) checkFatalError.get();
 
-	TraceEvent("ForgotVersionsBefore", data->thisServerID).detail("Version", nextDurableVersion);
+	//TraceEvent("ForgotVersionsBefore", data->thisServerID).detail("Version", nextDurableVersion);
 	validate(data);
 
 	return nextDurableVersion == desiredDurableVersion;
@@ -1898,7 +1898,7 @@ ACTOR Future<Void> fetchKeys( StorageServer *data, AddingShard* shard ) {
 
 				break;
 			} catch (Error& e) {
-				TraceEvent("FKBlockFail", data->thisServerID).detail("FKID", interval.pairID).error(e,true).suppressFor(1.0);
+				TraceEvent("FKBlockFail", data->thisServerID, 1.0).detail("FKID", interval.pairID).error(e);
 				if (e.code() == error_code_transaction_too_old){
 					TEST(true); // A storage server has forgotten the history data we are fetching
 					Version lastFV = fetchVersion;
@@ -2007,7 +2007,7 @@ ACTOR Future<Void> fetchKeys( StorageServer *data, AddingShard* shard ) {
 
 		TraceEvent(SevDebug, interval.end(), data->thisServerID);
 	} catch (Error &e){
-		TraceEvent(SevDebug, interval.end(), data->thisServerID).error(e, true).detail("Version", data->version.get());
+		TraceEvent(SevDebug, interval.end(), data->thisServerID).error(e).detail("Version", data->version.get());
 
 		if (e.code() == error_code_actor_cancelled && !data->shuttingDown && shard->phase >= AddingShard::Fetching) {
 			if (shard->phase < AddingShard::Waiting) {
@@ -2022,8 +2022,7 @@ ACTOR Future<Void> fetchKeys( StorageServer *data, AddingShard* shard ) {
 			}
 		}
 
-		TraceEvent(SevError, "FetchKeysError", data->thisServerID)
-			.error(e)
+		TraceEvent(SevError, "FetchKeysError", data->thisServerID, e)
 			.detail("Elapsed", now()-startt)
 			.detail("KeyBegin", printable(keys.begin))
 			.detail("KeyEnd",printable(keys.end));
@@ -2585,7 +2584,7 @@ ACTOR Future<Void> update( StorageServer* data, bool* pReceivedUpdate )
 		return Void();  // update will get called again ASAP
 	} catch (Error& e) {
 		if (e.code() != error_code_worker_removed && e.code() != error_code_please_reboot)
-			TraceEvent(SevError, "SSUpdateError", data->thisServerID).error(e).backtrace();
+			TraceEvent(SevError, "SSUpdateError", data->thisServerID, e).backtrace();
 		throw;
 	}
 }
@@ -2638,7 +2637,7 @@ ACTOR Future<Void> updateStorage(StorageServer* data) {
 			Void _ = wait( yield(TaskUpdateStorage) );
 		}
 
-		TraceEvent("StorageServerDurable", data->thisServerID).detail("Version", newOldestVersion);
+		//TraceEvent("StorageServerDurable", data->thisServerID).detail("Version", newOldestVersion);
 
 		Void _ = wait( durableDelay );
 	}
@@ -3275,7 +3274,7 @@ bool storageServerTerminated(StorageServer& self, IKeyValueStore* persistentData
 		 e.code() == error_code_file_not_found ||
 		 e.code() == error_code_actor_cancelled )
 	{
-		TraceEvent("StorageServerTerminated", self.thisServerID).error(e, true);
+		TraceEvent("StorageServerTerminated", self.thisServerID).error(e);
 		return true;
 	} else
 		return false;

--- a/fdbserver/tester.actor.cpp
+++ b/fdbserver/tester.actor.cpp
@@ -433,7 +433,7 @@ ACTOR Future<Void> runWorkloadAsync( Database cx, WorkloadInterface workIface, T
 					startResult = operation_failed();
 					if( e.code() == error_code_please_reboot || e.code() == error_code_please_reboot_delete) throw;
 					TraceEvent(SevError,"TestFailure", workIface.id())
-						.error(e)
+						.errorUnconditional(e)
 						.detail("Reason", "Error starting workload")
 						.detail("Workload", workload->description());
 					//ok = false;

--- a/fdbserver/tester.actor.cpp
+++ b/fdbserver/tester.actor.cpp
@@ -358,7 +358,7 @@ ACTOR Future<Void> pingDatabase( Database cx ) {
 			Void _ = wait( tr.commit() );
 			return Void();
 		} catch( Error& e ) {
-			TraceEvent("PingingDatabaseTransactionError").error(e);
+			TraceEvent("PingingDatabaseTransactionError", e);
 			Void _ = wait( tr.onError( e ) );
 		}
 	}
@@ -376,9 +376,7 @@ ACTOR Future<Void> testDatabaseLiveness( Database cx, double databasePingDelay, 
 			TraceEvent(("PingingDatabaseLivenessDone_" + context).c_str()).detail("TimeTaken", pingTime);
 			Void _ = wait( delay( databasePingDelay - pingTime ) );
 		} catch( Error& e ) {
-			if( e.code() != error_code_actor_cancelled )
-				TraceEvent(SevError, ("PingingDatabaseLivenessError_" + context).c_str()).error(e)
-					.detail("Database", printable(cx->dbName)).detail("PingDelay", databasePingDelay);
+			TraceEvent(SevError, ("PingingDatabaseLivenessError_" + context).c_str(), e).detail("Database", printable(cx->dbName)).detail("PingDelay", databasePingDelay);
 			throw;
 		}
 	}
@@ -418,7 +416,7 @@ ACTOR Future<Void> runWorkloadAsync( Database cx, WorkloadInterface workIface, T
 					setupResult = Void();
 				} catch (Error& e) {
 					setupResult = operation_failed();
-					TraceEvent(SevError, "TestSetupError", workIface.id()).detail("Workload", workload->description()).error(e);
+					TraceEvent(SevError, "TestSetupError", workIface.id(), e).detail("Workload", workload->description());
 					if( e.code() == error_code_please_reboot || e.code() == error_code_please_reboot_delete) throw;
 				}
 			}
@@ -435,7 +433,7 @@ ACTOR Future<Void> runWorkloadAsync( Database cx, WorkloadInterface workIface, T
 					startResult = operation_failed();
 					if( e.code() == error_code_please_reboot || e.code() == error_code_please_reboot_delete) throw;
 					TraceEvent(SevError,"TestFailure", workIface.id())
-						.error(e, true)
+						.error(e)
 						.detail("Reason", "Error starting workload")
 						.detail("Workload", workload->description());
 					//ok = false;
@@ -454,8 +452,7 @@ ACTOR Future<Void> runWorkloadAsync( Database cx, WorkloadInterface workIface, T
 				} catch (Error& e) {
 					checkResult = operation_failed();  // was: checkResult = false;
 					if( e.code() == error_code_please_reboot || e.code() == error_code_please_reboot_delete) throw;
-					TraceEvent(SevError,"TestFailure", workIface.id())
-						.error(e)
+					TraceEvent(SevError,"TestFailure", workIface.id(), e)
 						.detail("Reason", "Error checking workload")
 						.detail("Workload", workload->description());
 					//ok = false;
@@ -473,7 +470,7 @@ ACTOR Future<Void> runWorkloadAsync( Database cx, WorkloadInterface workIface, T
 				req.send( m );
 			} catch (Error& e) {
 				if( e.code() == error_code_please_reboot || e.code() == error_code_please_reboot_delete) throw;
-				TraceEvent(SevError, "WorkloadSendMetrics", workIface.id()).error(e);
+				TraceEvent(SevError, "WorkloadSendMetrics", workIface.id(), e);
 				s_req.sendError( operation_failed() );
 			}
 		}
@@ -571,7 +568,7 @@ ACTOR Future<Void> clearData( Database cx ) {
 			TraceEvent("TesterClearingDatabase").detail("AtVersion", tr.getCommittedVersion());
 			break;
 		} catch (Error& e) {
-			TraceEvent(SevWarn, "TesterClearingDatabaseError").error(e);
+			TraceEvent(SevWarn, "TesterClearingDatabaseError", e);
 			Void _ = wait( tr.onError(e) );
 		}
 	}
@@ -708,9 +705,8 @@ ACTOR Future<DistributedTestResults> runWorkload( Database cx, std::vector< Test
 			if(!metricTasks[i].isError())
 				metricsResults.push_back( metricTasks[i].get() );
 			else
-				TraceEvent(SevError, "TestFailure")
+				TraceEvent(SevError, "TestFailure", metricTasks[i].getError())
 					.detail("Reason", "Metrics not retrieved")
-					.error(metricTasks[i].getError())
 					.detail("From", workloads[i].metrics.getEndpoint().address);
 		}
 	}
@@ -790,7 +786,7 @@ ACTOR Future<bool> runTest( Database cx, std::vector< TesterInterface > testers,
 		logMetrics( testResults.metrics );
 	} catch(Error& e) {
 		if( e.code() == error_code_timed_out ) {
-			TraceEvent(SevError, "TestFailure").detail("Reason", "Test timed out").detail("Timeout", spec.timeout).error(e);
+			TraceEvent(SevError, "TestFailure", e).detail("Reason", "Test timed out").detail("Timeout", spec.timeout);
 			fprintf(stderr, "ERROR: Test timed out after %d seconds.\n", spec.timeout);
 			testResults.failures = testers.size();
 			testResults.successes = 0;
@@ -805,7 +801,7 @@ ACTOR Future<bool> runTest( Database cx, std::vector< TesterInterface > testers,
 			try {
 				Void _ = wait( timeoutError( dumpDatabase( cx, "dump after " + printable(spec.title) + ".html", allKeys ), 30.0 ) );
 			} catch (Error& e) {
-				TraceEvent(SevError, "TestFailure").detail("Reason", "Unable to dump database").error(e);
+				TraceEvent(SevError, "TestFailure", e).detail("Reason", "Unable to dump database");
 				ok = false;
 			}
 
@@ -819,7 +815,7 @@ ACTOR Future<bool> runTest( Database cx, std::vector< TesterInterface > testers,
 				Void _ = wait(timeoutError(checkConsistency(cx, testers, database, quiescent, 10000.0, 18000, spec.databasePingDelay, dbInfo), 20000.0));
 			}
 			catch(Error& e) {
-				TraceEvent(SevError, "TestFailure").detail("Reason", "Unable to perform consistency check").error(e);
+				TraceEvent(SevError, "TestFailure", e).detail("Reason", "Unable to perform consistency check");
 				ok = false;
 			}
 		}
@@ -840,7 +836,7 @@ ACTOR Future<bool> runTest( Database cx, std::vector< TesterInterface > testers,
 			TraceEvent("TesterClearingDatabase");
 			Void _ = wait( timeoutError(clearData(cx), 1000.0) );
 		} catch (Error& e) {
-			TraceEvent(SevError, "ErrorClearingDatabaseAfterTest").error(e);
+			TraceEvent(SevError, "ErrorClearingDatabaseAfterTest", e);
 			throw;   // If we didn't do this, we don't want any later tests to run on this DB
 		}
 
@@ -1047,7 +1043,7 @@ ACTOR Future<Void> runTests( Reference<AsyncVar<Optional<struct ClusterControlle
 			Void _ = wait(timeoutError(changeConfiguration(cx, testers, database, startingConfiguration), 2000.0));
 		}
 		catch(Error& e) {
-			TraceEvent(SevError, "TestFailure").detail("Reason", "Unable to set starting configuration").error(e);
+			TraceEvent(SevError, "TestFailure", e).detail("Reason", "Unable to set starting configuration");
 		}
 	}
 
@@ -1057,8 +1053,7 @@ ACTOR Future<Void> runTests( Reference<AsyncVar<Optional<struct ClusterControlle
 			Void _ = wait( quietDatabase( cx, dbInfo, "Start") || 
 				( databasePingDelay == 0.0 ? Never() : testDatabaseLiveness( cx, databasePingDelay, "QuietDatabaseStart", startDelay ) ) );
 		} catch( Error& e ) {
-			if( e.code() != error_code_actor_cancelled )
-				TraceEvent("QuietDatabaseStartExternalError").error(e);
+			TraceEvent("QuietDatabaseStartExternalError", e);
 			throw;
 		}
 	}
@@ -1079,8 +1074,7 @@ ACTOR Future<Void> runTests( Reference<AsyncVar<Optional<struct ClusterControlle
 				Void _ = wait( quietDatabase( cx, dbInfo, "End", 0, 2e6, 2e6 ) || 
 					( databasePingDelay == 0.0 ? Never() : testDatabaseLiveness( cx, databasePingDelay, "QuietDatabaseEnd" ) ) );
 			} catch( Error& e ) {
-				if( e.code() != error_code_actor_cancelled )
-					TraceEvent("QuietDatabaseEndExternalError").error(e);
+				TraceEvent("QuietDatabaseEndExternalError", e);
 				throw;
 			}
 		}

--- a/fdbserver/worker.actor.cpp
+++ b/fdbserver/worker.actor.cpp
@@ -119,7 +119,7 @@ ACTOR Future<Void> handleIOErrors( Future<Void> actor, IClosable* store, UID id,
 			if (e.isError()) throw e.getError(); else return e.get();
 		}
 		when (ErrorOr<Void> e = wait( storeError )) {
-			TraceEvent("WorkerTerminatingByIOError", id).error(e.getError());
+			TraceEvent("WorkerTerminatingByIOError", id).errorUnconditional(e.getError());
 			actor.cancel();
 			// file_not_found can occur due to attempting to open a partially deleted DiskQueue, which should not be reported SevError.
 			if (e.getError().code() == error_code_file_not_found) {
@@ -410,7 +410,7 @@ void endRole(UID id, std::string as, std::string reason, bool ok, Error e) {
 			.detail("As", as)
 			.detail("Reason", reason);
 		if(e.code() != invalid_error_code)
-			ev.error(e);
+			ev.errorUnconditional(e);
 
 		ev.trackLatest( (id.shortString() + ".Role").c_str() );
 	}
@@ -422,7 +422,7 @@ void endRole(UID id, std::string as, std::string reason, bool ok, Error e) {
 		err.detail("Reason", reason);
 
 		if(e.code() != invalid_error_code) {
-			err.error(e);
+			err.errorUnconditional(e);
 		}
 	}
 

--- a/fdbserver/workloads/BackupCorrectness.actor.cpp
+++ b/fdbserver/workloads/BackupCorrectness.actor.cpp
@@ -156,7 +156,7 @@ struct BackupAndRestoreCorrectnessWorkload : TestWorkload {
 				Void _ = wait(backupAgent->abortBackup(cx, tag.toString()));
 			}
 			catch (Error& e) {
-				TraceEvent("BARW_DoBackupAbortBackupException", randomID).detail("Tag", printable(tag)).error(e);
+				TraceEvent("BARW_DoBackupAbortBackupException", randomID, e).detail("Tag", printable(tag));
 				if (e.code() != error_code_backup_unneeded)
 					throw;
 			}
@@ -171,7 +171,7 @@ struct BackupAndRestoreCorrectnessWorkload : TestWorkload {
 			Void _ = wait(backupAgent->submitBackup(cx, StringRef(backupContainer), g_random->randomInt(0, 100), tag.toString(), backupRanges, stopDifferentialDelay ? false : true));
 		}
 		catch (Error& e) {
-			TraceEvent("BARW_DoBackupSubmitBackupException", randomID).detail("Tag", printable(tag)).error(e);
+			TraceEvent("BARW_DoBackupSubmitBackupException", randomID, e).detail("Tag", printable(tag));
 			if (e.code() != error_code_backup_unneeded && e.code() != error_code_backup_duplicate)
 				throw;
 		}
@@ -244,7 +244,7 @@ struct BackupAndRestoreCorrectnessWorkload : TestWorkload {
 				}
 			}
 			catch (Error& e) {
-				TraceEvent("BARW_DoBackupDiscontinueBackupException", randomID).detail("Tag", printable(tag)).error(e);
+				TraceEvent("BARW_DoBackupDiscontinueBackupException", randomID, e).detail("Tag", printable(tag));
 				if (e.code() != error_code_backup_unneeded && e.code() != error_code_backup_duplicate)
 					throw;
 			}
@@ -359,7 +359,7 @@ struct BackupAndRestoreCorrectnessWorkload : TestWorkload {
 					extraBackup = backupAgent.submitBackup(cx, LiteralStringRef("file://simfdb/backups/"), g_random->randomInt(0, 100), self->backupTag.toString(), self->backupRanges, true);
 				}
 				catch (Error& e) {
-					TraceEvent("BARW_SubmitBackup2Exception", randomID).detail("BackupTag", printable(self->backupTag)).error(e);
+					TraceEvent("BARW_SubmitBackup2Exception", randomID, e).detail("BackupTag", printable(self->backupTag));
 					if (e.code() != error_code_backup_unneeded && e.code() != error_code_backup_duplicate)
 						throw;
 				}
@@ -423,7 +423,7 @@ struct BackupAndRestoreCorrectnessWorkload : TestWorkload {
 					Void _ = wait(extraBackup);
 				}
 				catch (Error& e) {
-					TraceEvent("BARW_ExtraBackupException", randomID).detail("BackupTag", printable(self->backupTag)).error(e);
+					TraceEvent("BARW_ExtraBackupException", randomID, e).detail("BackupTag", printable(self->backupTag));
 					if (e.code() != error_code_backup_unneeded && e.code() != error_code_backup_duplicate)
 						throw;
 				}
@@ -433,7 +433,7 @@ struct BackupAndRestoreCorrectnessWorkload : TestWorkload {
 					Void _ = wait(backupAgent.abortBackup(cx, self->backupTag.toString()));
 				}
 				catch (Error& e) {
-					TraceEvent("BARW_AbortBackupExtraException", randomID).error(e);
+					TraceEvent("BARW_AbortBackupExtraException", randomID, e);
 					if (e.code() != error_code_backup_unneeded)
 						throw;
 				}
@@ -537,7 +537,7 @@ struct BackupAndRestoreCorrectnessWorkload : TestWorkload {
 					break;
 				}
 				catch (Error &e) {
-					TraceEvent("BARW_CheckException", randomID).error(e);
+					TraceEvent("BARW_CheckException", randomID, e);
 					Void _ = wait(tr->onError(e));
 				}
 			}
@@ -559,7 +559,7 @@ struct BackupAndRestoreCorrectnessWorkload : TestWorkload {
 			}
 		}
 		catch (Error& e) {
-			TraceEvent(SevError, "BackupAndRestoreCorrectness").error(e).GetLastError();
+			TraceEvent(SevError, "BackupAndRestoreCorrectness", e).GetLastError();
 			throw;
 		}
 		return Void();

--- a/fdbserver/workloads/BackupToDBCorrectness.actor.cpp
+++ b/fdbserver/workloads/BackupToDBCorrectness.actor.cpp
@@ -215,7 +215,7 @@ struct BackupToDBCorrectnessWorkload : TestWorkload {
 				Void _ = wait(backupAgent->abortBackup(cx, tag));
 			}
 			catch (Error& e) {
-				TraceEvent("BARW_DoBackupAbortBackupException", randomID).detail("Tag", printable(tag)).error(e);
+				TraceEvent("BARW_DoBackupAbortBackupException", randomID, e).detail("Tag", printable(tag));
 				if (e.code() != error_code_backup_unneeded)
 					throw;
 			}
@@ -250,7 +250,7 @@ struct BackupToDBCorrectnessWorkload : TestWorkload {
 			}
 		}
 		catch (Error &e) {
-			TraceEvent("BARW_DoBackupSubmitBackupException", randomID).detail("Tag", printable(tag)).error(e);
+			TraceEvent("BARW_DoBackupSubmitBackupException", randomID, e).detail("Tag", printable(tag));
 			if (e.code() != error_code_backup_unneeded && e.code() != error_code_backup_duplicate) {
 				throw e;
 			}
@@ -294,7 +294,7 @@ struct BackupToDBCorrectnessWorkload : TestWorkload {
 				}
 			}
 			catch (Error& e) {
-				TraceEvent("BARW_DoBackupDiscontinueBackupException", randomID).detail("Tag", printable(tag)).error(e);
+				TraceEvent("BARW_DoBackupDiscontinueBackupException", randomID, e).detail("Tag", printable(tag));
 				if (e.code() != error_code_backup_unneeded && e.code() != error_code_backup_duplicate)
 					throw;
 			}
@@ -424,7 +424,7 @@ struct BackupToDBCorrectnessWorkload : TestWorkload {
 				break;
 			}
 			catch (Error &e) {
-				TraceEvent("BARW_CheckException", randomID).error(e);
+				TraceEvent("BARW_CheckException", randomID, e);
 				Void _ = wait(tr->onError(e));
 			}
 		}
@@ -480,7 +480,7 @@ struct BackupToDBCorrectnessWorkload : TestWorkload {
 					extraBackup = backupAgent.submitBackup(self->extraDB, self->backupTag, self->backupRanges, true, self->extraPrefix, StringRef(), self->locked);
 				}
 				catch (Error& e) {
-					TraceEvent("BARW_SubmitBackup2Exception", randomID).detail("BackupTag", printable(self->backupTag)).error(e);
+					TraceEvent("BARW_SubmitBackup2Exception", randomID, e).detail("BackupTag", printable(self->backupTag));
 					if (e.code() != error_code_backup_unneeded && e.code() != error_code_backup_duplicate)
 						throw;
 				}
@@ -520,7 +520,7 @@ struct BackupToDBCorrectnessWorkload : TestWorkload {
 					Void _ = wait(restoreAgent.submitBackup(cx, self->restoreTag, restoreRange, true, StringRef(), self->backupPrefix, self->locked));
 				}
 				catch (Error& e) {
-					TraceEvent("BARW_DoBackupSubmitBackupException", randomID).detail("Tag", printable(self->restoreTag)).error(e);
+					TraceEvent("BARW_DoBackupSubmitBackupException", randomID, e).detail("Tag", printable(self->restoreTag));
 					if (e.code() != error_code_backup_unneeded && e.code() != error_code_backup_duplicate)
 						throw;
 				}
@@ -536,7 +536,7 @@ struct BackupToDBCorrectnessWorkload : TestWorkload {
 					Void _ = wait(extraBackup);
 				}
 				catch (Error& e) {
-					TraceEvent("BARW_ExtraBackupException", randomID).detail("BackupTag", printable(self->backupTag)).error(e);
+					TraceEvent("BARW_ExtraBackupException", randomID, e).detail("BackupTag", printable(self->backupTag));
 					if (e.code() != error_code_backup_unneeded && e.code() != error_code_backup_duplicate)
 						throw;
 				}
@@ -546,7 +546,7 @@ struct BackupToDBCorrectnessWorkload : TestWorkload {
 					Void _ = wait(backupAgent.abortBackup(self->extraDB, self->backupTag));
 				}
 				catch (Error& e) {
-					TraceEvent("BARW_AbortBackupExtraException", randomID).error(e);
+					TraceEvent("BARW_AbortBackupExtraException", randomID, e);
 					if (e.code() != error_code_backup_unneeded)
 						throw;
 				}
@@ -572,7 +572,7 @@ struct BackupToDBCorrectnessWorkload : TestWorkload {
 			}
 		}
 		catch (Error& e) {
-			TraceEvent(SevError, "BackupAndRestoreCorrectness").error(e);
+			TraceEvent(SevError, "BackupAndRestoreCorrectness", e);
 			throw;
 		}
 

--- a/fdbserver/workloads/BackupToDBUpgrade.actor.cpp
+++ b/fdbserver/workloads/BackupToDBUpgrade.actor.cpp
@@ -425,7 +425,7 @@ struct BackupToDBUpgradeWorkload : TestWorkload {
 					Void _ = wait( tr2->commit() );
 					break;
 				} catch( Error &e ) {
-					TraceEvent("DRU_RestoreSetupError").error(e);
+					TraceEvent("DRU_RestoreSetupError").errorUnconditional(e);
 					Void _ = wait( tr2->onError(e) );
 				}
 			}

--- a/fdbserver/workloads/BackupToDBUpgrade.actor.cpp
+++ b/fdbserver/workloads/BackupToDBUpgrade.actor.cpp
@@ -121,7 +121,7 @@ struct BackupToDBUpgradeWorkload : TestWorkload {
 
 			TraceEvent("DRU_DoBackupInDifferentialMode").detail("Tag", printable(tag));
 		} catch (Error &e) {
-			TraceEvent("DRU_DoBackupSubmitBackupError").detail("Tag", printable(tag)).error(e);
+			TraceEvent("DRU_DoBackupSubmitBackupError", e).detail("Tag", printable(tag));
 			if (e.code() != error_code_backup_unneeded && e.code() != error_code_backup_duplicate) {
 				throw e;
 			}
@@ -233,7 +233,7 @@ struct BackupToDBUpgradeWorkload : TestWorkload {
 				break;
 			}
 			catch (Error &e) {
-				TraceEvent("DRU_CheckError").error(e);
+				TraceEvent("DRU_CheckError", e);
 				Void _ = wait(tr->onError(e));
 			}
 		}
@@ -259,7 +259,7 @@ struct BackupToDBUpgradeWorkload : TestWorkload {
 			TraceEvent("DRU_DoBackupWaitEnd").detail("BackupTag", printable(self->backupTag));
 		}
 		catch (Error& e) {
-			TraceEvent(SevError, "BackupToDBUpgradeSetuEerror").error(e);
+			TraceEvent(SevError, "BackupToDBUpgradeSetuEerror", e);
 			throw;
 		}
 
@@ -425,7 +425,7 @@ struct BackupToDBUpgradeWorkload : TestWorkload {
 					Void _ = wait( tr2->commit() );
 					break;
 				} catch( Error &e ) {
-					TraceEvent("DRU_RestoreSetupError").error(e, true);
+					TraceEvent("DRU_RestoreSetupError").error(e);
 					Void _ = wait( tr2->onError(e) );
 				}
 			}
@@ -441,7 +441,7 @@ struct BackupToDBUpgradeWorkload : TestWorkload {
 				Void _ = wait(restoreAgent.submitBackup(cx, self->restoreTag, restoreRanges, true, StringRef(), self->backupPrefix));
 			}
 			catch (Error& e) {
-				TraceEvent("DRU_RestoreSubmitBackupError").detail("Tag", printable(self->restoreTag)).error(e);
+				TraceEvent("DRU_RestoreSubmitBackupError", e).detail("Tag", printable(self->restoreTag));
 				if (e.code() != error_code_backup_unneeded && e.code() != error_code_backup_duplicate)
 					throw;
 			}
@@ -459,7 +459,7 @@ struct BackupToDBUpgradeWorkload : TestWorkload {
 				g_simulator.drAgents = ISimulator::NoBackupAgents;
 			}
 		} catch (Error& e) {
-			TraceEvent(SevError, "BackupAndRestoreCorrectnessError").error(e);
+			TraceEvent(SevError, "BackupAndRestoreCorrectnessError", e);
 			throw;
 		}
 

--- a/fdbserver/workloads/BulkSetup.actor.h
+++ b/fdbserver/workloads/BulkSetup.actor.h
@@ -49,7 +49,7 @@ Future<bool> checkRangeSimpleValueSize( Database cx, T* workload, uint64_t begin
 			Void _ = wait( success( first ) && success( last ) );
 			return first.get().present() && last.get().present();
 		} catch (Error& e) {
-			TraceEvent("CheckRangeError").detail("Begin", begin).detail("End", end).error(e);
+			TraceEvent("CheckRangeError", e).detail("Begin", begin).detail("End", end);
 			Void _ = wait( tr.onError(e) );
 		}
 	}
@@ -289,7 +289,7 @@ Future<Void> bulkSetup( Database cx, T* workload, uint64_t nodeCount, Promise<do
 		Void _ = wait( success(insertionTimes) && waitForAll(fs) );
 	} catch(Error& e) {
 		if( e.code() == error_code_operation_failed ) {
-			TraceEvent(SevError, "BulkSetupFailed").error(e);
+			TraceEvent(SevError, "BulkSetupFailed", e);
 		}
 		throw;
 	}
@@ -325,7 +325,7 @@ Future<Void> bulkSetup( Database cx, T* workload, uint64_t nodeCount, Promise<do
 		} catch (Error& e) {
 			if( e.code() == error_code_actor_cancelled )
 				throw;
-			TraceEvent("DynamicWarmingError").error(e);
+			TraceEvent("DynamicWarmingError", e);
 			if( postSetupWarming > 0 )
 				Void _ = wait( timeout( databaseWarmer( cx ), postSetupWarming, Void() ) );
 		}

--- a/fdbserver/workloads/CommitBugCheck.actor.cpp
+++ b/fdbserver/workloads/CommitBugCheck.actor.cpp
@@ -63,7 +63,7 @@ struct CommitBugWorkload : TestWorkload
 					break;
 				}
 				catch(Error &e) {
-					TraceEvent("CommitBugSetVal1Error").error(e);
+					TraceEvent("CommitBugSetVal1Error", e);
 					TEST(e.code() == error_code_commit_unknown_result); //Commit unknown result
 					Void _ = wait(tr.onError(e));
 				}
@@ -76,7 +76,7 @@ struct CommitBugWorkload : TestWorkload
 					break;
 				}
 				catch(Error &e) {
-					TraceEvent("CommitBugSetVal2Error").error(e);
+					TraceEvent("CommitBugSetVal2Error", e);
 					Void _ = wait(tr.onError(e));
 				}
 			}
@@ -93,7 +93,7 @@ struct CommitBugWorkload : TestWorkload
 					break;
 				}
 				catch(Error &e) {
-					TraceEvent("CommitBugGetValError").error(e);
+					TraceEvent("CommitBugGetValError", e);
 					Void _ = wait(tr.onError(e));
 				}
 			}
@@ -105,7 +105,7 @@ struct CommitBugWorkload : TestWorkload
 					break;
 				}
 				catch(Error &e) {
-					TraceEvent("CommitBugClearValError").error(e);
+					TraceEvent("CommitBugClearValError", e);
 					Void _ = wait(tr.onError(e));
 				}
 			}
@@ -160,7 +160,7 @@ struct CommitBugWorkload : TestWorkload
 					else {
 						TEST(true); //Commit conflict
 
-						TraceEvent("CommitBug2Error").detail("AttemptedNum", i+1).error(e);
+						TraceEvent("CommitBug2Error", e).detail("AttemptedNum", i+1);
 						Void _ = wait(tr.onError(e));
 					}
 				}

--- a/fdbserver/workloads/ConsistencyCheck.actor.cpp
+++ b/fdbserver/workloads/ConsistencyCheck.actor.cpp
@@ -114,7 +114,7 @@ struct ConsistencyCheckWorkload : TestWorkload
 			}
 			catch(Error& e)
 			{
-				TraceEvent("ConsistencyCheck_QuietDatabaseError").error(e);
+				TraceEvent("ConsistencyCheck_QuietDatabaseError", e);
 				self->testFailure("Unable to achieve a quiet database");
 				self->performQuiescentChecks = false;
 			}
@@ -228,7 +228,7 @@ struct ConsistencyCheckWorkload : TestWorkload
 					{
 						if(e.code() == error_code_attribute_not_found)
 						{
-							TraceEvent("ConsistencyCheck_StorageQueueSizeError").detail("Reason", "Could not read queue size").error(e);
+							TraceEvent("ConsistencyCheck_StorageQueueSizeError", e).detail("Reason", "Could not read queue size");
 
 							//This error occurs if we have undesirable servers; in that case just report the undesirable servers error
 							if(!hasUndesirableServers)
@@ -274,7 +274,7 @@ struct ConsistencyCheckWorkload : TestWorkload
 			catch(Error &e)
 			{
 				if(e.code() == error_code_transaction_too_old || e.code() == error_code_future_version || e.code() == error_code_wrong_shard_server || e.code() == error_code_all_alternatives_failed || e.code() == error_code_server_request_queue_full)
-					TraceEvent("ConsistencyCheck_Retry").error(e); // FIXME: consistency check does not retry in this case
+					TraceEvent("ConsistencyCheck_Retry", e); // FIXME: consistency check does not retry in this case
 				else
 					self->testFailure(format("Error %d - %s", e.code(), e.name()));
 			}
@@ -462,7 +462,7 @@ struct ConsistencyCheckWorkload : TestWorkload
 				{
 					//If we failed because of a version problem, then retry
 					if(e.code() == error_code_transaction_too_old || e.code() == error_code_future_version || e.code() == error_code_transaction_too_old)
-						TraceEvent("ConsistencyCheck_RetryGetKeyLocations").error(e);
+						TraceEvent("ConsistencyCheck_RetryGetKeyLocations", e);
 					else
 						throw;
 				}
@@ -532,7 +532,7 @@ struct ConsistencyCheckWorkload : TestWorkload
 		}
 		catch(Error& e)
 		{
-			TraceEvent("ConsistencyCheck_ErrorFetchingMetrics").detail("Begin", printable(shard.begin)).detail("End", printable(shard.end)).error(e);
+			TraceEvent("ConsistencyCheck_ErrorFetchingMetrics", e).detail("Begin", printable(shard.begin)).detail("End", printable(shard.end));
 			estimatedBytes.clear();
 		}
 
@@ -843,8 +843,8 @@ struct ConsistencyCheckWorkload : TestWorkload
 							//If the data is not available and we aren't relocating this shard
 							else if(!isRelocating)
 							{
-								TraceEvent("ConsistencyCheck_StorageServerUnavailable").detail("StorageServer", storageServers[j]).detail("ShardBegin", printable(range.begin)).detail("ShardEnd", printable(range.end))
-									.detail("Address", storageServerInterfaces[j].address()).detail("GetKeyValuesToken", storageServerInterfaces[j].getKeyValues.getEndpoint().token).suppressFor(1.0);
+								TraceEvent("ConsistencyCheck_StorageServerUnavailable", 1.0).detail("StorageServer", storageServers[j]).detail("ShardBegin", printable(range.begin)).detail("ShardEnd", printable(range.end))
+									.detail("Address", storageServerInterfaces[j].address()).detail("GetKeyValuesToken", storageServerInterfaces[j].getKeyValues.getEndpoint().token);
 
 								//All shards should be available in quiscence
 								if(self->performQuiescentChecks)
@@ -912,7 +912,7 @@ struct ConsistencyCheckWorkload : TestWorkload
 					{
 						//If we failed because of a version problem, then retry
 						if(e.code() == error_code_transaction_too_old || e.code() == error_code_future_version || e.code() == error_code_transaction_too_old)
-							TraceEvent("ConsistencyCheck_RetryDataConsistency").error(e);
+							TraceEvent("ConsistencyCheck_RetryDataConsistency", e);
 						else
 							throw;
 					}
@@ -1107,7 +1107,7 @@ struct ConsistencyCheckWorkload : TestWorkload
 		for(itr = workers.begin(); itr != workers.end(); ++itr) {
 			ErrorOr<Standalone<VectorRef<UID>>> stores = wait(itr->first.diskStoreRequest.getReplyUnlessFailedFor(DiskStoreRequest(false), 2, 0));
 			if(stores.isError()) {
-				TraceEvent("ConsistencyCheck_GetDataStoreFailure").detail("Address", itr->first.address()).error(stores.getError());
+				TraceEvent("ConsistencyCheck_GetDataStoreFailure", stores.getError()).detail("Address", itr->first.address());
 				self->testFailure("Failed to get data stores");
 				return false;
 			}

--- a/fdbserver/workloads/Cycle.actor.cpp
+++ b/fdbserver/workloads/Cycle.actor.cpp
@@ -130,8 +130,7 @@ struct CycleWorkload : TestWorkload {
 				self->totalLatency += now() - tstart;
 			}
 		} catch (Error& e) {
-			if (e.code() != error_code_actor_cancelled)
-				TraceEvent(SevError, "CycleClient").error(e);
+			TraceEvent(SevError, "CycleClient", e);
 			throw;
 		}
 	}
@@ -183,7 +182,7 @@ struct CycleWorkload : TestWorkload {
 					break;
 				} catch (Error& e) {
 					retryCount++;
-					TraceEvent(retryCount > 20 ? SevWarnAlways : SevWarn, "CycleCheckError").error(e);
+					TraceEvent(retryCount > 20 ? SevWarnAlways : SevWarn, "CycleCheckError", e);
 					Void _ = wait(tr.onError(e));
 				}
 			}

--- a/fdbserver/workloads/DDMetrics.actor.cpp
+++ b/fdbserver/workloads/DDMetrics.actor.cpp
@@ -64,7 +64,7 @@ struct DDMetricsWorkload : TestWorkload {
 				}
 			}
 		} catch( Error& e ) {
-			TraceEvent("DDMetricsError").error(e);
+			TraceEvent("DDMetricsError", e);
 		}
 		return Void();
 	}

--- a/fdbserver/workloads/FastTriggeredWatches.actor.cpp
+++ b/fdbserver/workloads/FastTriggeredWatches.actor.cpp
@@ -141,7 +141,7 @@ struct FastTriggeredWatchesWorkload : TestWorkload {
 			}
 			return Void();
 		} catch( Error &e ) {
-			TraceEvent(SevError, "FastWatchError").error(e);
+			TraceEvent(SevError, "FastWatchError").errorUnconditional(e);
 			throw;
 		}
 	}

--- a/fdbserver/workloads/FastTriggeredWatches.actor.cpp
+++ b/fdbserver/workloads/FastTriggeredWatches.actor.cpp
@@ -87,7 +87,7 @@ struct FastTriggeredWatchesWorkload : TestWorkload {
 				//TraceEvent("FTWSetEnd").detail("Key", printable(key)).detail("Value", printable(value)).detail("Ver", tr.getCommittedVersion());
 				return tr.getCommittedVersion();
 			} catch( Error &e ) {
-				//TraceEvent("FTWSetError").detail("Key", printable(key)).detail("Value", printable(value)).error(e);
+				//TraceEvent("FTWSetError", e).detail("Key", printable(key)).detail("Value", printable(value));
 				Void _ = wait( tr.onError(e) );
 			}
 		}
@@ -128,7 +128,7 @@ struct FastTriggeredWatchesWorkload : TestWorkload {
 						watchEnd = now();
 						first = false;
 					} catch( Error &e ) {
-						//TraceEvent("FTWWatchError").detail("Key", printable(setKey)).error(e);
+						//TraceEvent("FTWWatchError", e).detail("Key", printable(setKey));
 						Void _ = wait( tr.onError(e) );
 					}
 				}
@@ -141,7 +141,7 @@ struct FastTriggeredWatchesWorkload : TestWorkload {
 			}
 			return Void();
 		} catch( Error &e ) {
-			TraceEvent(SevError, "FastWatchError").error(e,true);
+			TraceEvent(SevError, "FastWatchError").error(e);
 			throw;
 		}
 	}

--- a/fdbserver/workloads/FuzzApiCorrectness.actor.cpp
+++ b/fdbserver/workloads/FuzzApiCorrectness.actor.cpp
@@ -67,16 +67,15 @@ struct ExceptionContract {
 		if (i != expected.end() && i->second != Never)
 		{
 			Severity s = (i->second == Possible) ? SevWarn : SevInfo;
-			TraceEvent evt(s, func.c_str());
-			evt.error(e).detail("Thrown", true)
-				.detail("Expected", i->second == Possible ? "possible" : "always").backtrace();
+			TraceEvent evt(s, func.c_str(), e);
+			evt.detail("Thrown", true).detail("Expected", i->second == Possible ? "possible" : "always").backtrace();
 			if (augment)
 				augment(evt);
 			return;
 		}
 
-		TraceEvent evt(SevError, func.c_str());
-		evt.error(e).detail("Thrown", true).detail("Expected", "never").backtrace();
+		TraceEvent evt(SevError, func.c_str(), e);
+		evt.detail("Thrown", true).detail("Expected", "never").backtrace();
 		if (augment)
 			augment(evt);
 		throw e;
@@ -86,8 +85,8 @@ struct ExceptionContract {
 	void handleNotThrown() const {
 		for (auto i : expected) {
 			if (i.second == Always) {
-				TraceEvent evt(SevError, func.c_str());
-				evt.detail("Thrown", false).detail("Expected", "always").error(Error::fromUnvalidatedCode(i.first)).backtrace();
+				TraceEvent evt(SevError, func.c_str(), Error::fromUnvalidatedCode(i.first));
+				evt.detail("Thrown", false).detail("Expected", "always").backtrace();
 				if (augment)
 					augment(evt);
 			}
@@ -248,7 +247,7 @@ struct FuzzApiCorrectnessWorkload : TestWorkload {
 			}
 		}
 		} catch (Error &e) {
-			TraceEvent("FuzzLoadAndRunError").error(e).backtrace();
+			TraceEvent("FuzzLoadAndRunError", e).backtrace();
 			throw e;
 		}
 	}
@@ -286,8 +285,7 @@ struct FuzzApiCorrectnessWorkload : TestWorkload {
 						try {
 							operations.push_back(testCases[operationType](++self->operationId, self, tr));
 						} catch( Error &e ) {
-							TraceEvent(SevWarn, "IgnoredOperation").error(e)
-								.detail("Operation", operationType).detail("Id", self->operationId);
+							TraceEvent(SevWarn, "IgnoredOperation", e).detail("Operation", operationType).detail("Id", self->operationId);
 						}
 					}
 

--- a/fdbserver/workloads/Increment.actor.cpp
+++ b/fdbserver/workloads/Increment.actor.cpp
@@ -104,8 +104,7 @@ struct Increment : TestWorkload {
 				self->totalLatency += now() - tstart;
 			}
 		} catch (Error& e) {
-			if (e.code() != error_code_actor_cancelled)
-				TraceEvent(SevError, "IncrementClient").error(e);
+			TraceEvent(SevError, "IncrementClient", e);
 			throw;
 		}
 	}
@@ -154,7 +153,7 @@ struct Increment : TestWorkload {
 					break;
 				} catch (Error& e) {
 					retryCount++;
-					TraceEvent(retryCount > 20 ? SevWarnAlways : SevWarn, "IncrementCheckError").error(e);
+					TraceEvent(retryCount > 20 ? SevWarnAlways : SevWarn, "IncrementCheckError", e);
 					Void _ = wait(tr.onError(e));
 				}
 			}

--- a/fdbserver/workloads/LowLatency.actor.cpp
+++ b/fdbserver/workloads/LowLatency.actor.cpp
@@ -81,7 +81,7 @@ struct LowLatencyWorkload : TestWorkload {
 			}
 			return Void();
 		} catch( Error &e ) {
-			TraceEvent(SevError, "LowLatencyError").error(e);
+			TraceEvent(SevError, "LowLatencyError").errorUnconditional(e);
 			throw;
 		}
 	}

--- a/fdbserver/workloads/LowLatency.actor.cpp
+++ b/fdbserver/workloads/LowLatency.actor.cpp
@@ -81,7 +81,7 @@ struct LowLatencyWorkload : TestWorkload {
 			}
 			return Void();
 		} catch( Error &e ) {
-			TraceEvent(SevError, "LowLatencyError").error(e,true);
+			TraceEvent(SevError, "LowLatencyError").error(e);
 			throw;
 		}
 	}

--- a/fdbserver/workloads/Performance.actor.cpp
+++ b/fdbserver/workloads/Performance.actor.cpp
@@ -169,7 +169,7 @@ struct PerformanceWorkload : TestWorkload {
 				DistributedTestResults r = wait( runWorkload( cx, self->testers, self->dbName, spec ) );
 				results = r;
 			} catch(Error& e) {
-				TraceEvent("PerformanceRunError").detail("Workload", printable(self->probeWorkload)).error(e, true);
+				TraceEvent("PerformanceRunError").detail("Workload", printable(self->probeWorkload)).error(e);
 				break;
 			}
 			PerfMetric tpsMetric = self->getNamedMetric( "Transactions/sec", results.metrics );

--- a/fdbserver/workloads/Performance.actor.cpp
+++ b/fdbserver/workloads/Performance.actor.cpp
@@ -169,7 +169,7 @@ struct PerformanceWorkload : TestWorkload {
 				DistributedTestResults r = wait( runWorkload( cx, self->testers, self->dbName, spec ) );
 				results = r;
 			} catch(Error& e) {
-				TraceEvent("PerformanceRunError").detail("Workload", printable(self->probeWorkload)).error(e);
+				TraceEvent("PerformanceRunError").detail("Workload", printable(self->probeWorkload)).errorUnconditional(e);
 				break;
 			}
 			PerfMetric tpsMetric = self->getNamedMetric( "Transactions/sec", results.metrics );

--- a/fdbserver/workloads/RandomMoveKeys.actor.cpp
+++ b/fdbserver/workloads/RandomMoveKeys.actor.cpp
@@ -138,7 +138,7 @@ struct MoveKeysWorkload : TestWorkload {
 			TraceEvent(relocateShardInterval.end()).detail("Result","Success");
 			return Void();
 		} catch (Error& e) {
-			TraceEvent(relocateShardInterval.end(), self->dbInfo->get().master.id()).error(e);
+			TraceEvent(relocateShardInterval.end(), self->dbInfo->get().master.id()).errorUnconditional(e);
 			throw;
 		}
 	}

--- a/fdbserver/workloads/RandomMoveKeys.actor.cpp
+++ b/fdbserver/workloads/RandomMoveKeys.actor.cpp
@@ -138,7 +138,7 @@ struct MoveKeysWorkload : TestWorkload {
 			TraceEvent(relocateShardInterval.end()).detail("Result","Success");
 			return Void();
 		} catch (Error& e) {
-			TraceEvent(relocateShardInterval.end(), self->dbInfo->get().master.id()).error(e, true);
+			TraceEvent(relocateShardInterval.end(), self->dbInfo->get().master.id()).error(e);
 			throw;
 		}
 	}

--- a/fdbserver/workloads/ReadWrite.actor.cpp
+++ b/fdbserver/workloads/ReadWrite.actor.cpp
@@ -231,7 +231,7 @@ struct ReadWriteWorkload : KVWorkload {
 				Void _ = wait( delay( 1.0 ) );
 			}
 		} catch( Error &e ) {
-			TraceEvent(SevError, "FailedToDumpWorkers").error(e);
+			TraceEvent(SevError, "FailedToDumpWorkers", e);
 			throw;
 		}
 	}

--- a/fdbserver/workloads/StatusWorkload.actor.cpp
+++ b/fdbserver/workloads/StatusWorkload.actor.cpp
@@ -257,7 +257,7 @@ struct StatusWorkload : TestWorkload {
 			}
 			catch (Error& e) {
 				if (e.code() != error_code_actor_cancelled) {
-					TraceEvent(SevError, "StatusWorkloadError").error(e);
+					TraceEvent(SevError, "StatusWorkloadError", e);
 					++self->errors;
 				}
 				throw;

--- a/fdbserver/workloads/Storefront.actor.cpp
+++ b/fdbserver/workloads/Storefront.actor.cpp
@@ -75,7 +75,7 @@ struct StorefrontWorkload : TestWorkload {
 		for(int c=0; c<clients.size(); c++)
 			if( clients[c].isError() ) {
 				errors++;
-				TraceEvent(SevError, "TestFailure").detail("Reason", "ClientError").error(clients[c].getError());
+				TraceEvent(SevError, "TestFailure", clients[c].getError()).detail("Reason", "ClientError");
 			}
 		clients.clear();
 		return inventoryCheck( cx->clone(), this, !errors );
@@ -173,8 +173,7 @@ struct StorefrontWorkload : TestWorkload {
 				self->totalLatency += now() - tstart;
 			}
 		} catch (Error& e) {
-			if (e.code() != error_code_actor_cancelled)
-				TraceEvent(SevError, "OrderingClient").error(e);
+			TraceEvent(SevError, "OrderingClient", e);
 			throw;
 		}
 	}

--- a/fdbserver/workloads/TaskBucketCorrectness.actor.cpp
+++ b/fdbserver/workloads/TaskBucketCorrectness.actor.cpp
@@ -239,7 +239,7 @@ struct TaskBucketCorrectnessWorkload : TestWorkload {
 				}
 				catch (Error &e) {
 					if (e.code() == error_code_timed_out)
-						TraceEvent(SevWarn, "TaskBucketCorrectness").error(e);
+						TraceEvent(SevWarn, "TaskBucketCorrectness", e);
 					else
 						Void _ = wait(tr->onError(e));
 				}
@@ -251,7 +251,7 @@ struct TaskBucketCorrectnessWorkload : TestWorkload {
 			}
 		}
 		catch (Error &e) {
-			TraceEvent(SevError, "TaskBucketCorrectness").error(e);
+			TraceEvent(SevError, "TaskBucketCorrectness", e);
 			Void _ = wait(tr->onError(e));
 		}
 

--- a/fdbserver/workloads/ThreadSafety.actor.cpp
+++ b/fdbserver/workloads/ThreadSafety.actor.cpp
@@ -181,7 +181,7 @@ struct ThreadSafetyWorkload : TestWorkload {
 			catch(Error &e) {
 				self->success = false;
 				printf("Thread %d.%d failed: %s\n", self->clientId, i, e.name());
-				TraceEvent(SevError, "ThreadSafety_ThreadFailed").error(e);
+				TraceEvent(SevError, "ThreadSafety_ThreadFailed", e);
 			}
 
 			delete threadInfo[i];

--- a/fdbserver/workloads/UnitTests.actor.cpp
+++ b/fdbserver/workloads/UnitTests.actor.cpp
@@ -102,7 +102,7 @@ struct UnitTestWorkload : TestWorkload {
 			TraceEvent(result.code() != error_code_success ? SevError : SevInfo, "UnitTest")
 				.detail("Name", test->name)
 				.detail("File", test->file).detail("Line", test->line)
-				.error(result, true)
+				.error(result)
 				.detail("WallTime", wallTime)
 				.detail("FlowTime", simTime);
 		}

--- a/fdbserver/workloads/UnitTests.actor.cpp
+++ b/fdbserver/workloads/UnitTests.actor.cpp
@@ -102,7 +102,7 @@ struct UnitTestWorkload : TestWorkload {
 			TraceEvent(result.code() != error_code_success ? SevError : SevInfo, "UnitTest")
 				.detail("Name", test->name)
 				.detail("File", test->file).detail("Line", test->line)
-				.error(result)
+				.errorUnconditional(result)
 				.detail("WallTime", wallTime)
 				.detail("FlowTime", simTime);
 		}

--- a/fdbserver/workloads/Unreadable.actor.cpp
+++ b/fdbserver/workloads/Unreadable.actor.cpp
@@ -368,7 +368,7 @@ struct UnreadableWorkload : TestWorkload {
 							ASSERT(containsUnreadable(unreadableMap, range, true).present() == value.isError());
 					}
 					else {
-						//TraceEvent("RYWT_Reset1").error(value.getError());
+						//TraceEvent("RYWT_Reset1").errorUnconditional(value.getError());
 						setMap = std::map<KeyRef, ValueRef>();
 						unreadableMap = KeyRangeMap<bool>();
 						tr = ReadYourWritesTransaction(cx);

--- a/fdbserver/workloads/Unreadable.actor.cpp
+++ b/fdbserver/workloads/Unreadable.actor.cpp
@@ -368,7 +368,7 @@ struct UnreadableWorkload : TestWorkload {
 							ASSERT(containsUnreadable(unreadableMap, range, true).present() == value.isError());
 					}
 					else {
-						//TraceEvent("RYWT_Reset1").error(value.getError(), true);
+						//TraceEvent("RYWT_Reset1").error(value.getError());
 						setMap = std::map<KeyRef, ValueRef>();
 						unreadableMap = KeyRangeMap<bool>();
 						tr = ReadYourWritesTransaction(cx);

--- a/fdbserver/workloads/VersionStamp.actor.cpp
+++ b/fdbserver/workloads/VersionStamp.actor.cpp
@@ -290,7 +290,7 @@ struct VersionStampWorkload : TestWorkload {
 						tr = ReadYourWritesTransaction(cx_is_primary ? cx : extraDB);
 						break;
 					} else if (err.code() == error_code_commit_unknown_result) {
-						//TraceEvent("VST_CommitUnknownResult").detail("Key", printable(key)).detail("VsKey", printable(versionStampKey)).error(e);
+						//TraceEvent("VST_CommitUnknownResult", e).detail("Key", printable(key)).detail("VsKey", printable(versionStampKey));
 						loop {
 							state ReadYourWritesTransaction cur_tr(cx_is_primary ? cx : extraDB);
 							cur_tr.setOption(FDBTransactionOptions::LOCK_AWARE);
@@ -326,7 +326,7 @@ struct VersionStampWorkload : TestWorkload {
 				}
 
 				if (error) {
-					TraceEvent("VST_CommitFailed").detail("Key", printable(key)).detail("VsKey", printable(versionStampKey)).error(err);
+					TraceEvent("VST_CommitFailed", err).detail("Key", printable(key)).detail("VsKey", printable(versionStampKey));
 					Void _ = wait(tr.onError(err));
 					continue;
 				}

--- a/fdbserver/workloads/WatchAndWait.actor.cpp
+++ b/fdbserver/workloads/WatchAndWait.actor.cpp
@@ -125,7 +125,7 @@ struct WatchAndWaitWorkload : TestWorkload {
 				}
 			}
 		} catch( Error &e ) {
-			TraceEvent(SevError, "WatchAndWaitError").error(e);
+			TraceEvent(SevError, "WatchAndWaitError", e);
 			throw e;
 		}
 	}

--- a/fdbserver/workloads/Watches.actor.cpp
+++ b/fdbserver/workloads/Watches.actor.cpp
@@ -118,7 +118,7 @@ struct WatchesWorkload : TestWorkload {
 				extraLoc += 1000;
 				//TraceEvent("WatcherInitialSetup").detail("Watch", printable(watchKey)).detail("Ver", tr.getCommittedVersion());
 			} catch( Error &e ) {
-				//TraceEvent("WatcherInitialSetupError").detail("ExtraLoc", extraLoc).error(e);
+				//TraceEvent("WatcherInitialSetupError", e).detail("ExtraLoc", extraLoc);
 				Void _ = wait( tr.onError(e) );
 			}
 		}

--- a/fdbserver/workloads/WriteDuringRead.actor.cpp
+++ b/fdbserver/workloads/WriteDuringRead.actor.cpp
@@ -155,7 +155,7 @@ struct WriteDuringReadWorkload : TestWorkload {
 			}
 			return Void();
 		} catch( Error &e ) {
-			//TraceEvent("WDRGetKeyError", randomID).error(e);
+			//TraceEvent("WDRGetKeyError", randomID).errorUnconditional(e);
 			if( e.code() == error_code_used_during_commit ) {
 				ASSERT( *doingCommit );
 				return Void();
@@ -277,7 +277,7 @@ struct WriteDuringReadWorkload : TestWorkload {
 			}
 			return Void();
 		} catch( Error &e ) {
-			//TraceEvent("WDRGetRangeError", randomID).error(e);
+			//TraceEvent("WDRGetRangeError", randomID).errorUnconditional(e);
 			if( e.code() == error_code_used_during_commit ) {
 				ASSERT( *doingCommit );
 				return Void();
@@ -309,7 +309,7 @@ struct WriteDuringReadWorkload : TestWorkload {
 			}
 			return Void();
 		} catch( Error &e ) {
-			//TraceEvent("WDRGetError", randomID).error(e);
+			//TraceEvent("WDRGetError", randomID).errorUnconditional(e);
 			if( e.code() == error_code_used_during_commit ) {
 				ASSERT( *doingCommit );
 				return Void();
@@ -348,7 +348,7 @@ struct WriteDuringReadWorkload : TestWorkload {
 			return Void();
 		} catch( Error &e ) {
 			//check for transaction cancelled if the watch was not committed
-			//TraceEvent("WDRWatchError", randomID).error(e);
+			//TraceEvent("WDRWatchError", randomID).errorUnconditional(e);
 			if( e.code() == error_code_used_during_commit ) {
 				ASSERT( *doingCommit );
 				return Void();
@@ -421,7 +421,7 @@ struct WriteDuringReadWorkload : TestWorkload {
 			
 			return Void();
 		} catch( Error &e ) {
-			//TraceEvent("WDRCommitCancelled", randomID).error(e);
+			//TraceEvent("WDRCommitCancelled", randomID).errorUnconditional(e);
 			if( e.code() == error_code_actor_cancelled || e.code() == error_code_transaction_cancelled || e.code() == error_code_used_during_commit )
 				*cancelled = true;
 			if( e.code() == error_code_actor_cancelled || e.code() == error_code_transaction_cancelled )
@@ -816,7 +816,7 @@ struct WriteDuringReadWorkload : TestWorkload {
 				watches.clear();
 				self->changeCount.insert( allKeys, 0 );
 				doingCommit = false;
-				//TraceEvent("WDRError").error(e);
+				//TraceEvent("WDRError").errorUnconditional(e);
 				if(e.code() == error_code_database_locked) {
 					self->memoryDatabase = self->lastCommittedDatabase;
 					self->addedConflicts.insert(allKeys, false);

--- a/fdbserver/workloads/WriteDuringRead.actor.cpp
+++ b/fdbserver/workloads/WriteDuringRead.actor.cpp
@@ -155,7 +155,7 @@ struct WriteDuringReadWorkload : TestWorkload {
 			}
 			return Void();
 		} catch( Error &e ) {
-			//TraceEvent("WDRGetKeyError", randomID).error(e,true);
+			//TraceEvent("WDRGetKeyError", randomID).error(e);
 			if( e.code() == error_code_used_during_commit ) {
 				ASSERT( *doingCommit );
 				return Void();
@@ -277,7 +277,7 @@ struct WriteDuringReadWorkload : TestWorkload {
 			}
 			return Void();
 		} catch( Error &e ) {
-			//TraceEvent("WDRGetRangeError", randomID).error(e,true);
+			//TraceEvent("WDRGetRangeError", randomID).error(e);
 			if( e.code() == error_code_used_during_commit ) {
 				ASSERT( *doingCommit );
 				return Void();
@@ -309,7 +309,7 @@ struct WriteDuringReadWorkload : TestWorkload {
 			}
 			return Void();
 		} catch( Error &e ) {
-			//TraceEvent("WDRGetError", randomID).error(e,true);
+			//TraceEvent("WDRGetError", randomID).error(e);
 			if( e.code() == error_code_used_during_commit ) {
 				ASSERT( *doingCommit );
 				return Void();
@@ -348,7 +348,7 @@ struct WriteDuringReadWorkload : TestWorkload {
 			return Void();
 		} catch( Error &e ) {
 			//check for transaction cancelled if the watch was not committed
-			//TraceEvent("WDRWatchError", randomID).error(e,true);
+			//TraceEvent("WDRWatchError", randomID).error(e);
 			if( e.code() == error_code_used_during_commit ) {
 				ASSERT( *doingCommit );
 				return Void();
@@ -421,7 +421,7 @@ struct WriteDuringReadWorkload : TestWorkload {
 			
 			return Void();
 		} catch( Error &e ) {
-			//TraceEvent("WDRCommitCancelled", randomID).error(e,true);
+			//TraceEvent("WDRCommitCancelled", randomID).error(e);
 			if( e.code() == error_code_actor_cancelled || e.code() == error_code_transaction_cancelled || e.code() == error_code_used_during_commit )
 				*cancelled = true;
 			if( e.code() == error_code_actor_cancelled || e.code() == error_code_transaction_cancelled )
@@ -816,7 +816,7 @@ struct WriteDuringReadWorkload : TestWorkload {
 				watches.clear();
 				self->changeCount.insert( allKeys, 0 );
 				doingCommit = false;
-				//TraceEvent("WDRError").error(e, true);
+				//TraceEvent("WDRError").error(e);
 				if(e.code() == error_code_database_locked) {
 					self->memoryDatabase = self->lastCommittedDatabase;
 					self->addedConflicts.insert(allKeys, false);

--- a/flow/Error.cpp
+++ b/flow/Error.cpp
@@ -40,7 +40,7 @@ extern void flushTraceFileVoid();
 Error Error::fromUnvalidatedCode(int code) {
 	if (code < 0 || code > 30000) {
 		Error e = Error::fromCode(error_code_unknown_error);
-		TraceEvent(SevWarn, "ConvertedUnvalidatedErrorCode").detail("OriginalCode", code).error(e);
+		TraceEvent(SevWarn, "ConvertedUnvalidatedErrorCode", e).detail("OriginalCode", code);
 		return e;
 	}
 	else
@@ -50,8 +50,7 @@ Error Error::fromUnvalidatedCode(int code) {
 Error internal_error_impl( const char* file, int line ) {
 	fprintf(stderr, "Internal Error @ %s %d:\n  %s\n", file, line, platform::get_backtrace().c_str());
 
-	TraceEvent(SevError, "InternalError")
-		.error(Error::fromCode(error_code_internal_error))
+	TraceEvent(SevError, "InternalError", Error::fromCode(error_code_internal_error))
 		.detail("File", file)
 		.detail("Line", line)
 		.backtrace();
@@ -65,7 +64,7 @@ Error::Error(int error_code)
 	if (TRACE_SAMPLE()) TraceEvent(SevSample, "ErrorCreated").detail("ErrorCode", error_code);
 	//std::cout << "Error: " << error_code << std::endl;
 	if (error_code >= 3000 && error_code < 6000) {
-		TraceEvent(SevError, "SystemError").error(*this).backtrace();
+		TraceEvent(SevError, "SystemError", *this).backtrace();
 		if (g_crashOnError) {
 			flushOutputStreams();
 			flushTraceFileVoid();

--- a/flow/IThreadPool.cpp
+++ b/flow/IThreadPool.cpp
@@ -45,7 +45,7 @@ class ThreadPool : public IThreadPool, public ReferenceCounted<ThreadPool> {
 				userObject->init();
 				while (pool->ios.run_one() && !pool->mode);
 			} catch (Error& e) {
-				TraceEvent(SevError, "ThreadPoolError").error(e);
+				TraceEvent(SevError, "ThreadPoolError", e);
 			}
 			delete userObject; userObject = 0;
 			stopped.set();

--- a/flow/Net2.actor.cpp
+++ b/flow/Net2.actor.cpp
@@ -240,7 +240,7 @@ public:
 		try {
 			if (error) {
 				// Log the error...
-				TraceEvent(SevWarn, errContext, errID).detail("Message", error.value()).suppressFor(1.0);
+				TraceEvent(SevWarn, errContext, errID, 1.0).detail("Message", error.value());
 				p.sendError( connection_failed() );
 			} else
 				p.send( Void() );
@@ -411,15 +411,15 @@ private:
 		boost::system::error_code error;
 		socket.close(error);
 		if (error)
-			TraceEvent(SevWarn, "N2_CloseError", id).detail("Message", error.value()).suppressFor(1.0);
+			TraceEvent(SevWarn, "N2_CloseError", id, 1.0).detail("Message", error.value());
 	}
 
 	void onReadError( const boost::system::error_code& error ) {
-		TraceEvent(SevWarn, "N2_ReadError", id).detail("Message", error.value()).suppressFor(1.0);
+		TraceEvent(SevWarn, "N2_ReadError", id, 1.0).detail("Message", error.value());
 		closeSocket();
 	}
 	void onWriteError( const boost::system::error_code& error ) {
-		TraceEvent(SevWarn, "N2_WriteError", id).detail("Message", error.value()).suppressFor(1.0);
+		TraceEvent(SevWarn, "N2_WriteError", id, 1.0).detail("Message", error.value());
 		closeSocket();
 	}
 };
@@ -626,9 +626,9 @@ void Net2::run() {
 			try {
 				(*task)();
 			} catch (Error& e) {
-				TraceEvent(SevError, "TaskError").error(e);
+				TraceEvent(SevError, "TaskError", e);
 			} catch (...) {
-				TraceEvent(SevError, "TaskError").error(unknown_error());
+				TraceEvent(SevError, "TaskError", unknown_error());
 			}
 
 			if (check_yield(TaskMaxPriority, true)) { ++countYields; break; }
@@ -900,15 +900,15 @@ Reference<IListener> Net2::listen( NetworkAddress localAddr ) {
 			x = invalid_local_address();
 		else
 			x = bind_failed();
-		TraceEvent("Net2ListenError").detail("Message", e.what()).error(x);
+		TraceEvent("Net2ListenError", x).detail("Message", e.what());
 		throw x;
 	} catch (std::exception const& e) {
 		Error x = unknown_error();
-		TraceEvent("Net2ListenError").detail("Message", e.what()).error(x);
+		TraceEvent("Net2ListenError", x).detail("Message", e.what());
 		throw x;
 	} catch (...) {
 		Error x = unknown_error();
-		TraceEvent("Net2ListenError").error(x);
+		TraceEvent("Net2ListenError", x);
 		throw x;
 	}
 }

--- a/flow/Platform.cpp
+++ b/flow/Platform.cpp
@@ -1408,7 +1408,7 @@ static int ModifyPrivilege( const char* szPrivilege, bool fEnable )
 						   TOKEN_ADJUST_PRIVILEGES | TOKEN_QUERY,
 						   &hToken ))
 	{
-		TraceEvent( SevWarn, "OpenProcessTokenError" ).error(large_alloc_failed()).GetLastError();
+		TraceEvent( SevWarn, "OpenProcessTokenError", large_alloc_failed() ).GetLastError();
 		return ERROR_FUNCTION_FAILED;
 	}
 
@@ -1418,7 +1418,7 @@ static int ModifyPrivilege( const char* szPrivilege, bool fEnable )
 								&luid ))
 	{
 		CloseHandle( hToken );
-		TraceEvent( SevWarn, "LookupPrivilegeValue" ).error(large_alloc_failed()).GetLastError();
+		TraceEvent( SevWarn, "LookupPrivilegeValue", large_alloc_failed() ).GetLastError();
 		return ERROR_FUNCTION_FAILED;
 	}
 
@@ -1438,7 +1438,7 @@ static int ModifyPrivilege( const char* szPrivilege, bool fEnable )
 							   NULL,
 							   NULL))
 	{
-		TraceEvent( SevWarn, "AdjustTokenPrivileges" ).error(large_alloc_failed()).GetLastError();
+		TraceEvent( SevWarn, "AdjustTokenPrivileges", large_alloc_failed() ).GetLastError();
 		hr = ERROR_FUNCTION_FAILED;
 	}
 
@@ -1683,7 +1683,7 @@ void atomicReplace( std::string const& path, std::string const& content, bool te
 		INJECT_FAULT( io_error, "atomicReplace" );
 	}
 	catch(Error &e) {
-		TraceEvent(SevWarn, "AtomicReplace").detail("Path", path).error(e).GetLastError();
+		TraceEvent(SevWarn, "AtomicReplace", e).detail("Path", path).GetLastError();
 		if (f) fclose(f);
 		throw;
 	}

--- a/flow/ThreadHelper.actor.h
+++ b/flow/ThreadHelper.actor.h
@@ -557,7 +557,7 @@ ACTOR template <class R, class F> Future<Void> doOnMainThread( Future<Void> sign
 		result->send(r);
 	} catch (Error& e) {
 		if(!result->canBeSet()) {
-			TraceEvent(SevError, "OnMainThreadSetTwice").error(e);
+			TraceEvent(SevError, "OnMainThreadSetTwice").errorUnconditional(e);
 		}
 		result->sendError(e);
 	}

--- a/flow/ThreadHelper.actor.h
+++ b/flow/ThreadHelper.actor.h
@@ -557,7 +557,7 @@ ACTOR template <class R, class F> Future<Void> doOnMainThread( Future<Void> sign
 		result->send(r);
 	} catch (Error& e) {
 		if(!result->canBeSet()) {
-			TraceEvent(SevError, "OnMainThreadSetTwice").error(e,true);
+			TraceEvent(SevError, "OnMainThreadSetTwice").error(e);
 		}
 		result->sendError(e);
 	}

--- a/flow/Trace.cpp
+++ b/flow/Trace.cpp
@@ -572,27 +572,27 @@ TraceEvent::TraceEvent( const char* type, const Optional<Standalone<StringRef>>&
 
 TraceEvent::TraceEvent( const char* type, const class Error& e, double suppressFor ) {
 	init(SevInfo, type, e, suppressFor);
-	error(e);
+	errorUnconditional(e);
 }
 
 TraceEvent::TraceEvent( const char* type, UID id, const class Error& e, double suppressFor ) : id(id) {
 	init(SevInfo, type, e, suppressFor);
 	detail("ID", id);
-	error(e);
+	errorUnconditional(e);
 }
 
 TraceEvent::TraceEvent( const char* type, const StringRef& zoneId, const class Error& e, double suppressFor ) {
 	id = UID(hashlittle(zoneId.begin(), zoneId.size(), 0), 0);
 	init(SevInfo, type, e, suppressFor);
 	detailext("ID", zoneId);
-	error(e);
+	errorUnconditional(e);
 }
 
 TraceEvent::TraceEvent( const char* type, const Optional<Standalone<StringRef>>& zoneId, const class Error& e, double suppressFor ) {
 	id = zoneId.present() ? UID(hashlittle(zoneId.get().begin(), zoneId.get().size(), 0), 0) : UID(-1LL,0);
 	init(SevInfo, type, e, suppressFor);
 	detailext("ID", zoneId);
-	error(e);
+	errorUnconditional(e);
 }
 
 TraceEvent::TraceEvent( Severity severity, const char* type, UID id, double suppressFor ) : id(id) {
@@ -618,27 +618,27 @@ TraceEvent::TraceEvent( Severity severity, const char* type, const Optional<Stan
 
 TraceEvent::TraceEvent( Severity severity, const char* type, const class Error& e, double suppressFor ) {
 	init(severity, type, e, suppressFor);
-	error(e);
+	errorUnconditional(e);
 }
 
 TraceEvent::TraceEvent( Severity severity, const char* type, UID id, const class Error& e, double suppressFor ) : id(id) {
 	init(severity, type, e, suppressFor);
 	detail("ID", id);
-	error(e);
+	errorUnconditional(e);
 }
 
 TraceEvent::TraceEvent( Severity severity, const char* type, const StringRef& zoneId, const class Error& e, double suppressFor ) {
 	id = UID(hashlittle(zoneId.begin(), zoneId.size(), 0), 0);
 	init(severity, type, e, suppressFor);
 	detailext("ID", zoneId);
-	error(e);
+	errorUnconditional(e);
 }
 
 TraceEvent::TraceEvent( Severity severity, const char* type, const Optional<Standalone<StringRef>>& zoneId, const class Error& e, double suppressFor ) {
 	id = zoneId.present() ? UID(hashlittle(zoneId.get().begin(), zoneId.get().size(), 0), 0) : UID(-1LL,0);
 	init(severity, type, e, suppressFor);
 	detailext("ID", zoneId);
-	error(e);
+	errorUnconditional(e);
 }
 
 TraceEvent::TraceEvent( TraceInterval& interval, UID id ) : id(id) {
@@ -724,7 +724,7 @@ bool TraceEvent::init( Severity severity, const char* type, const Error& e, doub
 	return enabled;
 }
 
-TraceEvent& TraceEvent::error(class Error const& error) {
+TraceEvent& TraceEvent::errorUnconditional(class Error const& error) {
 	if (enabled && error.isValid()) {
 		if (error.isInjectedFault()) {
 			detail("ErrorIsInjectedFault", true);

--- a/flow/Trace.h
+++ b/flow/Trace.h
@@ -160,7 +160,7 @@ struct TraceEvent {
 	static void setNetworkThread();
 	static bool isNetworkThread();
 
-	TraceEvent& error(const class Error& e);
+	TraceEvent& errorUnconditional(const class Error& e);
 
 	TraceEvent& detail( std::string key, std::string value );
 	TraceEvent& detail( std::string key, double value );

--- a/flow/Trace.h
+++ b/flow/Trace.h
@@ -205,7 +205,7 @@ private:
 	static unsigned long eventCounts[5];
 	static thread_local bool networkThread;
 
-	bool init( Severity, const char* type, const class Error& e, double suppressFor = 0.0 );
+	bool init( Severity, const char* type, bool isEnabled, double suppressFor = 0.0 );
 	bool init( Severity, struct TraceInterval& );
 };
 

--- a/flow/Trace.h
+++ b/flow/Trace.h
@@ -135,20 +135,32 @@ template <class T> class Standalone;
 template <class T> class Optional;
 
 struct TraceEvent {
-	TraceEvent( const char* type, UID id = UID() );   // Assumes SevInfo severity
-	TraceEvent( Severity, const char* type, UID id = UID() );
+	// Assumes SevInfo severity
+	TraceEvent( const char* type, UID id = UID(), double suppressFor = 0.0 );
+	TraceEvent( const char* type, double suppressFor );
+	TraceEvent( const char* type, const StringRef& id);
+	TraceEvent( const char* type, const Optional<Standalone<StringRef>>& id);
+	TraceEvent( const char* type, const class Error& e, double suppressFor = 0.0 );
+	TraceEvent( const char* type, UID id, const class Error& e, double suppressFor = 0.0 );
+	TraceEvent( const char* type, const StringRef& id, const class Error& e, double suppressFor = 0.0 );
+	TraceEvent( const char* type, const Optional<Standalone<StringRef>>& id, const class Error& e, double suppressFor = 0.0 );
+
+	TraceEvent( Severity, const char* type, UID id = UID(), double suppressFor = 0.0 );
+	TraceEvent( Severity, const char* type, double suppressFor );
+	TraceEvent( Severity, const char* type, const StringRef& id);
+	TraceEvent( Severity, const char* type, const Optional<Standalone<StringRef>>& id);
+	TraceEvent( Severity, const char* type, const class Error& e, double suppressFor = 0.0 );
+	TraceEvent( Severity, const char* type, UID id, const class Error& e, double suppressFor = 0.0 );
+	TraceEvent( Severity, const char* type, const StringRef& id, const class Error& e, double suppressFor = 0.0 );
+	TraceEvent( Severity, const char* type, const Optional<Standalone<StringRef>>& id, const class Error& e, double suppressFor = 0.0 );
+
 	TraceEvent( struct TraceInterval&, UID id = UID() );
 	TraceEvent( Severity severity, struct TraceInterval& interval, UID id = UID() );
-	TraceEvent(const char* type, const StringRef& id);   // Assumes SevInfo severity
-	TraceEvent(Severity, const char* type, const StringRef& id);
-	TraceEvent(const char* type, const Optional<Standalone<StringRef>>& id);   // Assumes SevInfo severity
-	TraceEvent(Severity, const char* type, const Optional<Standalone<StringRef>>& id);
 
-	static bool isEnabled( const char* type, Severity = SevMax );
 	static void setNetworkThread();
 	static bool isNetworkThread();
 
-	TraceEvent& error(const class Error& e, bool includeCancelled=false);
+	TraceEvent& error(const class Error& e);
 
 	TraceEvent& detail( std::string key, std::string value );
 	TraceEvent& detail( std::string key, double value );
@@ -171,8 +183,6 @@ public:
 	TraceEvent& detail( std::string key, const UID& value );
 	TraceEvent& backtrace(const std::string& prefix = "");
 	TraceEvent& trackLatest( const char* trackingKey );
-	TraceEvent& sample( double sampleRate, bool logSampleRate=true );
-	TraceEvent& suppressFor( double duration, bool logSuppressedEventCount=true );
 
 	TraceEvent& GetLastError();
 
@@ -195,7 +205,7 @@ private:
 	static unsigned long eventCounts[5];
 	static thread_local bool networkThread;
 
-	bool init( Severity, const char* type );
+	bool init( Severity, const char* type, const class Error& e, double suppressFor = 0.0 );
 	bool init( Severity, struct TraceInterval& );
 };
 
@@ -251,11 +261,6 @@ private:
 };
 
 extern LatestEventCache latestEventCache;
-
-// Evil but potentially useful for verbose messages:
-#if CENABLED(0, NOT_IN_CLEAN)
-#define TRACE( t, m ) if (TraceEvent::isEnabled(t)) TraceEvent(t,m)
-#endif
 
 struct NetworkAddress;
 void openTraceFile(const NetworkAddress& na, uint64_t rollsize, uint64_t maxLogsSize, std::string directory = ".", std::string baseOfBase = "trace", std::string logGroup = "default");

--- a/flow/genericactors.actor.h
+++ b/flow/genericactors.actor.h
@@ -41,7 +41,7 @@ Future<T> traceAfter(Future<T> what, const char* type, const char* key, X value,
 		TraceEvent(type).detail(key, value);
 		return val;
 	} catch( Error &e ) {
-		if(traceErrors) TraceEvent(type).detail(key, value).error(e);
+		if(traceErrors) TraceEvent(type).detail(key, value).errorUnconditional(e);
 		throw;
 	}
 }
@@ -58,7 +58,7 @@ Future<T> traceAfterCall(Future<T> what, const char* type, const char* key, X fu
 		}
 		return val;
 	} catch( Error &e ) {
-		if(traceErrors) TraceEvent(type).error(e);
+		if(traceErrors) TraceEvent(type).errorUnconditional(e);
 		throw;
 	}
 }

--- a/flow/genericactors.actor.h
+++ b/flow/genericactors.actor.h
@@ -41,7 +41,7 @@ Future<T> traceAfter(Future<T> what, const char* type, const char* key, X value,
 		TraceEvent(type).detail(key, value);
 		return val;
 	} catch( Error &e ) {
-		if(traceErrors) TraceEvent(type).detail(key, value).error(e,true);
+		if(traceErrors) TraceEvent(type).detail(key, value).error(e);
 		throw;
 	}
 }
@@ -54,11 +54,11 @@ Future<T> traceAfterCall(Future<T> what, const char* type, const char* key, X fu
 		try {
 			TraceEvent(type).detail(key, func(val));
 		} catch( Error &e ) {
-			TraceEvent(SevError, "TraceAfterCallError").error(e);
+			TraceEvent(SevError, "TraceAfterCallError", e);
 		}
 		return val;
 	} catch( Error &e ) {
-		if(traceErrors) TraceEvent(type).error(e,true);
+		if(traceErrors) TraceEvent(type).error(e);
 		throw;
 	}
 }
@@ -71,7 +71,7 @@ Future<Optional<T>> stopAfter( Future<T> what ) {
 		ret = Optional<T>(_);
 	} catch (Error& e) {
 		bool ok = e.code() == error_code_please_reboot || e.code() == error_code_please_reboot_delete || e.code() == error_code_actor_cancelled;
-		TraceEvent(ok ? SevInfo : SevError, "StopAfterError").error(e);
+		TraceEvent(ok ? SevInfo : SevError, "StopAfterError", e);
 		if(!ok) {
 			fprintf(stderr, "Fatal Error: %s\n", e.what());
 			ret = Optional<T>();
@@ -991,7 +991,7 @@ Future<T> reportErrorsExcept( Future<T> in, const char* context, UID id, std::se
 		return t;
 	} catch (Error& e) {
 		if (e.code() != error_code_actor_cancelled && (!pExceptErrors || !pExceptErrors->count(e.code())))
-			TraceEvent(SevError, context, id).error(e);
+			TraceEvent(SevError, context, id, e);
 		throw;
 	}
 }

--- a/flow/serialize.h
+++ b/flow/serialize.h
@@ -204,7 +204,7 @@ struct _IncludeVersion {
 		ar >> v;
 		if (v < minValidProtocolVersion) {
 			auto err = incompatible_protocol_version();
-			TraceEvent(SevError, "InvalidSerializationVersion").detailf("Version", "%llx", v).error(err);
+			TraceEvent(SevError, "InvalidSerializationVersion", err).detailf("Version", "%llx", v);
 			throw err;
 		}
 		if (v > currentProtocolVersion) {
@@ -212,7 +212,7 @@ struct _IncludeVersion {
 			// particular data structures (e.g. to support mismatches between client and server versions when the client
 			// must deserialize zookeeper and database structures)
 			auto err = incompatible_protocol_version();
-			TraceEvent(SevError, "FutureProtocolVersion").detailf("Version", "%llx", v).error(err);
+			TraceEvent(SevError, "FutureProtocolVersion", err).detailf("Version", "%llx", v);
 			throw err;
 		}
 		ar.setProtocolVersion(v);


### PR DESCRIPTION
Moved all trace event suppression into the construction, to save work manipulating trace events which are later suppressed. Most .error calls, which want to suppress actor_cancelled errors were moved to the constructor. Also, the suppressFor method was moved to a parameter of the constructor. This also fixes a bug where the spammy trace event backstop was triggering incorrectly because it was counting suppressed messages.