### PR TITLE
fix: cache databases by cluster file and DB name in golang bindings.

### DIFF
--- a/bindings/go/src/fdb/fdb.go
+++ b/bindings/go/src/fdb/fdb.go
@@ -193,12 +193,17 @@ var apiVersion int
 var networkStarted bool
 var networkMutex sync.Mutex
 
+type DatabaseId struct {
+	clusterFile string
+	dbName      string
+}
+
 var openClusters map[string]Cluster
-var openDatabases map[string]Database
+var openDatabases map[DatabaseId]Database
 
 func init() {
 	openClusters = make(map[string]Cluster)
-	openDatabases = make(map[string]Database)
+	openDatabases = make(map[DatabaseId]Database)
 }
 
 func startNetwork() error {
@@ -288,13 +293,13 @@ func Open(clusterFile string, dbName []byte) (Database, error) {
 		openClusters[clusterFile] = cluster
 	}
 
-	db, ok := openDatabases[string(dbName)]
+	db, ok := openDatabases[DatabaseId{clusterFile, string(dbName)}]
 	if !ok {
 		db, e = cluster.OpenDatabase(dbName)
 		if e != nil {
 			return Database{}, e
 		}
-		openDatabases[string(dbName)] = db
+		openDatabases[DatabaseId{clusterFile, string(dbName)}] = db
 	}
 
 	return db, nil

--- a/documentation/sphinx/source/release-notes.rst
+++ b/documentation/sphinx/source/release-notes.rst
@@ -2,6 +2,14 @@
 Release Notes
 #############
 
+5.2.7
+=====
+
+Bindings
+--------
+
+* The go bindings now caches database connections on a per-cluster basis. `(Issue #607) <https://github.com/apple/foundationdb/issues/607>`_
+
 5.2.6
 =====
 


### PR DESCRIPTION
This cherry picks #625 onto release-5.2. This is part of fixing #607, but this time on release-5.2.