### PR TITLE
Enough concurrent readers could bring the cluster down when the cluster is rebooted

### DIFF
--- a/documentation/sphinx/source/release-notes.rst
+++ b/documentation/sphinx/source/release-notes.rst
@@ -10,6 +10,11 @@ Bindings
 
 * Java: ``FDBDatabase::run`` and ``FDBDatabase::read`` now use the ``Executor`` provided for executing asynchronous callbacks instead of the default one for the database. `(Issue #640) <https://github.com/apple/foundationdb/issues/640>`_
 
+Fixes
+-----
+
+* A large number of concurrent read attempts could bring the database down after a cluster reboot. `(PR #650) <https://github.com/apple/foundationdb/pull/650>`_
+
 5.2.7
 =====
 

--- a/fdbclient/MasterProxyInterface.h
+++ b/fdbclient/MasterProxyInterface.h
@@ -56,7 +56,7 @@ struct MasterProxyInterface {
 		getConsistentReadVersion.getEndpoint(TaskProxyGetConsistentReadVersion);
 		getRawCommittedVersion.getEndpoint(TaskProxyGetRawCommittedVersion);
 		commit.getEndpoint(TaskProxyCommit);
-		getKeyServersLocations.getEndpoint(TaskProxyGetKeyServersLocations);
+		//getKeyServersLocations.getEndpoint(TaskProxyGetKeyServersLocations); //do not increase the priority of these requests, because clients cans bring down the cluster with too many of these messages.
 	}
 };
 

--- a/flow/network.h
+++ b/flow/network.h
@@ -53,7 +53,6 @@ enum {
 	TaskProxyCommit = 8540,
 	TaskTLogConfirmRunningReply = 8530,
 	TaskTLogConfirmRunning = 8520,
-	TaskProxyGetKeyServersLocations = 8515,
 	TaskProxyGRVTimer = 8510,
 	TaskProxyGetConsistentReadVersion = 8500,
 	TaskDefaultPromiseEndpoint = 8000,


### PR DESCRIPTION
Clients which cannot talk to storage servers poll the proxy for new storage server interfaces. If there are too many clients polling, we saturate the proxies with these requests, prevents the storage servers from updating their interfaces.