### PR TITLE
Reduce CPU cost of suppressed trace events

### DIFF
--- a/FDBLibTLS/FDBLibTLSSession.cpp
+++ b/FDBLibTLS/FDBLibTLSSession.cpp
@@ -369,7 +369,7 @@ int FDBLibTLSSession::handshake() {
 	case TLS_WANT_POLLOUT:
 		return WANT_WRITE;
 	default:
-		TraceEvent("FDBLibTLSHandshakeError", uid).detail("LibTLSErrorMessage", tls_error(tls_ctx)).suppressFor(1.0, true);
+		TraceEvent("FDBLibTLSHandshakeError", uid).suppressFor(1.0).detail("LibTLSErrorMessage", tls_error(tls_ctx));
 		return FAILED;
 	}
 }
@@ -389,7 +389,7 @@ int FDBLibTLSSession::read(uint8_t* data, int length) {
 		return (int)n;
 	}
 	if (n == 0) {
-		TraceEvent("FDBLibTLSReadEOF").suppressFor(1.0, true);
+		TraceEvent("FDBLibTLSReadEOF").suppressFor(1.0);
 		return FAILED;
 	}
 	if (n == TLS_WANT_POLLIN)
@@ -397,7 +397,7 @@ int FDBLibTLSSession::read(uint8_t* data, int length) {
 	if (n == TLS_WANT_POLLOUT)
 		return WANT_WRITE;
 
-	TraceEvent("FDBLibTLSReadError", uid).detail("LibTLSErrorMessage", tls_error(tls_ctx)).suppressFor(1.0, true);
+	TraceEvent("FDBLibTLSReadError", uid).suppressFor(1.0).detail("LibTLSErrorMessage", tls_error(tls_ctx));
 	return FAILED;
 }
 
@@ -416,7 +416,7 @@ int FDBLibTLSSession::write(const uint8_t* data, int length) {
 		return (int)n;
 	}
 	if (n == 0) {
-		TraceEvent("FDBLibTLSWriteEOF", uid).suppressFor(1.0, true);
+		TraceEvent("FDBLibTLSWriteEOF", uid).suppressFor(1.0);
 		return FAILED;
 	}
 	if (n == TLS_WANT_POLLIN)
@@ -424,6 +424,6 @@ int FDBLibTLSSession::write(const uint8_t* data, int length) {
 	if (n == TLS_WANT_POLLOUT)
 		return WANT_WRITE;
 
-	TraceEvent("FDBLibTLSWriteError", uid).detail("LibTLSErrorMessage", tls_error(tls_ctx)).suppressFor(1.0, true);
+	TraceEvent("FDBLibTLSWriteError", uid).suppressFor(1.0).detail("LibTLSErrorMessage", tls_error(tls_ctx));
 	return FAILED;
 }

--- a/fdbcli/fdbcli.actor.cpp
+++ b/fdbcli/fdbcli.actor.cpp
@@ -3087,7 +3087,7 @@ ACTOR Future<int> cli(CLIOptions opt, LineNoise* plinenoise) {
 						}
 						catch(Error &e) {
 							//options->setOption() prints error message
-							TraceEvent(SevWarn, "CLISetOptionError").detail("Option", printable(tokens[2])).error(e);
+							TraceEvent(SevWarn, "CLISetOptionError").error(e).detail("Option", printable(tokens[2]));
 							is_error = true;
 						}
 					}
@@ -3138,7 +3138,7 @@ ACTOR Future<int> runCli(CLIOptions opt) {
 		linenoise.historyLoad(historyFilename);
 	}
 	catch(Error &e) {
-		TraceEvent(SevWarnAlways, "ErrorLoadingCliHistory").detail("Filename", historyFilename.empty() ? "<unknown>" : historyFilename).error(e).GetLastError();
+		TraceEvent(SevWarnAlways, "ErrorLoadingCliHistory").error(e).detail("Filename", historyFilename.empty() ? "<unknown>" : historyFilename).GetLastError();
 	}
 
 	state int result = wait(cli(opt, &linenoise));
@@ -3148,7 +3148,7 @@ ACTOR Future<int> runCli(CLIOptions opt) {
 			linenoise.historySave(historyFilename);
 		}
 		catch(Error &e) {
-			TraceEvent(SevWarnAlways, "ErrorSavingCliHistory").detail("Filename", historyFilename).error(e).GetLastError();
+			TraceEvent(SevWarnAlways, "ErrorSavingCliHistory").error(e).detail("Filename", historyFilename).GetLastError();
 		}
 	}
 

--- a/fdbclient/BackupContainer.actor.cpp
+++ b/fdbclient/BackupContainer.actor.cpp
@@ -793,8 +793,7 @@ public:
 			Void _ = wait(f->finish());
 			return Void();
 		} catch(Error &e) {
-			if(e.code() != error_code_actor_cancelled)
-				TraceEvent(SevWarn, "BackupContainerWritePropertyFailed").detail("Path", path).error(e);
+			TraceEvent(SevWarn, "BackupContainerWritePropertyFailed").error(e).detail("Path", path);
 			throw;
 		}
 	}
@@ -816,8 +815,7 @@ public:
 		} catch(Error &e) {
 			if(e.code() == error_code_file_not_found)
 				return Optional<Version>();
-			if(e.code() != error_code_actor_cancelled)
-				TraceEvent(SevWarn, "BackupContainerReadPropertyFailed").detail("Path", path).error(e);
+			TraceEvent(SevWarn, "BackupContainerReadPropertyFailed").error(e).detail("Path", path);
 			throw;
 		}
 	}

--- a/fdbclient/MonitorLeader.actor.cpp
+++ b/fdbclient/MonitorLeader.actor.cpp
@@ -99,7 +99,7 @@ bool ClusterConnectionFile::fileContentsUpToDate(ClusterConnectionString &fileCo
 		return fileConnectionString.toString() == cs.toString();
 	}
 	catch (Error& e) {
-		TraceEvent(SevWarnAlways, "ClusterFileError").detail("Filename", filename).error(e);
+		TraceEvent(SevWarnAlways, "ClusterFileError").error(e).detail("Filename", filename);
 		return false; // Swallow the error and report that the file is out of date
 	}
 }
@@ -118,7 +118,7 @@ bool ClusterConnectionFile::writeFile() {
 
 			return true;
 		} catch( Error &e ) {
-			TraceEvent(SevWarnAlways, "UnableToChangeConnectionFile").detail("Filename", filename).detail("ConnStr", cs.toString()).error(e);
+			TraceEvent(SevWarnAlways, "UnableToChangeConnectionFile").error(e).detail("Filename", filename).detail("ConnStr", cs.toString());
 		}
 	}
 

--- a/fdbclient/MultiVersionTransaction.actor.cpp
+++ b/fdbclient/MultiVersionTransaction.actor.cpp
@@ -615,7 +615,7 @@ void MultiVersionDatabase::DatabaseState::fire(const Void &unused, int& userPara
 					}
 					catch(Error &e) {
 						optionFailed = true;
-						TraceEvent(SevError, "DatabaseVersionChangeOptionError").detail("Option", option.first).detail("OptionValue", printable(option.second)).error(e);
+						TraceEvent(SevError, "DatabaseVersionChangeOptionError").error(e).detail("Option", option.first).detail("OptionValue", printable(option.second));
 					}
 				}
 
@@ -811,7 +811,7 @@ void MultiVersionCluster::Connector::error(const Error& e, int& userParam) {
 		// TODO: is it right to abandon this connection attempt?
 		client->failed = true;
 		MultiVersionApi::api->updateSupportedVersions();
-		TraceEvent(SevError, "ClusterConnectionError").detail("ClientLibrary", this->client->libPath).error(e);
+		TraceEvent(SevError, "ClusterConnectionError").error(e).detail("ClientLibrary", this->client->libPath);
 	}
 
 	delref();
@@ -850,7 +850,7 @@ void MultiVersionCluster::ClusterState::stateChanged() {
 		}
 		catch(Error &e) {
 			optionLock.leave();
-			TraceEvent(SevError, "ClusterVersionChangeOptionError").detail("Option", option.first).detail("OptionValue", printable(option.second)).detail("LibPath", clients[newIndex]->libPath).error(e);
+			TraceEvent(SevError, "ClusterVersionChangeOptionError").error(e).detail("Option", option.first).detail("OptionValue", printable(option.second)).detail("LibPath", clients[newIndex]->libPath);
 			connectionAttempts[newIndex]->connected = false;
 			clients[newIndex]->failed = true;
 			MultiVersionApi::api->updateSupportedVersions();
@@ -910,7 +910,7 @@ void MultiVersionApi::runOnExternalClients(std::function<void(Reference<ClientIn
 			}
 		}
 		catch(Error &e) {
-			TraceEvent(SevWarnAlways, "ExternalClientFailure").detail("LibPath", c->second->libPath).error(e);
+			TraceEvent(SevWarnAlways, "ExternalClientFailure").error(e).detail("LibPath", c->second->libPath);
 			if(e.code() == error_code_external_client_already_loaded) {
 				c = externalClients.erase(c);
 				continue;
@@ -1342,7 +1342,7 @@ void MultiVersionApi::loadEnvironmentVariableNetworkOptions() {
 				}
 			}
 			catch(Error &e) {
-				TraceEvent(SevError, "EnvironmentVariableNetworkOptionFailed").detail("Option", option.second.name).detail("Value", valueStr).error(e);
+				TraceEvent(SevError, "EnvironmentVariableNetworkOptionFailed").error(e).detail("Option", option.second.name).detail("Value", valueStr);
 				throw environment_variable_network_option_failed();
 			}
 		}

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -522,10 +522,10 @@ ACTOR static Future<Void> monitorClientInfo( Reference<AsyncVar<Optional<Cluster
 		}
 	} catch( Error& e ) {
 		TraceEvent(SevError, "MonitorClientInfoError")
+			.error(e)
 			.detail("DBName", printable(dbName))
 			.detail("ConnectionFile", ccf && ccf->canGetFilename() ? ccf->getFilename() : "")
-			.detail("ConnectionString", ccf ? ccf->getConnectionString().toString() : "")
-			.error(e);
+			.detail("ConnectionString", ccf ? ccf->getConnectionString().toString() : "");
 
 		throw;
 	}
@@ -817,8 +817,8 @@ void setNetworkOption(FDBNetworkOptions::Option option, Optional<StringRef> valu
 				tlsOptions->set_verify_peers({ value.get().toString() });
 			} catch( Error& e ) {
 				TraceEvent(SevWarnAlways, "TLSValidationSetError")
-					.detail("Input", value.get().toString() )
-					.error( e );
+					.error( e )
+					.detail("Input", value.get().toString() );
 				throw invalid_option_value();
 			}
 			break;
@@ -1269,12 +1269,10 @@ ACTOR Future<Key> getKey( Database cx, KeySelector k, Future<Version> version, T
 
 				Void _ = wait(delay(CLIENT_KNOBS->WRONG_SHARD_SERVER_DELAY, info.taskID));
 			} else {
-				if(e.code() != error_code_actor_cancelled) {
-					TraceEvent(SevInfo, "GetKeyError")
-						.error(e)
-						.detail("AtKey", printable(k.getKey()))
-						.detail("Offset", k.offset);
-				}
+				TraceEvent(SevInfo, "GetKeyError")
+					.error(e)
+					.detail("AtKey", printable(k.getKey()))
+					.detail("Offset", k.offset);
 				throw e;
 			}
 		}
@@ -2483,11 +2481,11 @@ Future<Void> Transaction::commitMutations() {
 		size_t transactionSize = tr.transaction.mutations.expectedSize() + tr.transaction.read_conflict_ranges.expectedSize() + tr.transaction.write_conflict_ranges.expectedSize();
 		if (transactionSize > (uint64_t)FLOW_KNOBS->PACKET_WARNING) {
 			TraceEvent(!g_network->isSimulated() ? SevWarnAlways : SevWarn, "LargeTransaction")
+				.suppressFor(1.0)
 				.detail("Size", transactionSize)
 				.detail("NumMutations", tr.transaction.mutations.size())
 				.detail("ReadConflictSize", tr.transaction.read_conflict_ranges.expectedSize())
-				.detail("WriteConflictSize", tr.transaction.write_conflict_ranges.expectedSize())
-				.suppressFor(1.0);
+				.detail("WriteConflictSize", tr.transaction.write_conflict_ranges.expectedSize());
 		}
 
 		if(!apiVersionAtLeast(300)) {
@@ -2693,7 +2691,7 @@ ACTOR Future<GetReadVersionReply> getConsistentReadVersion( DatabaseContext *cx,
 			}
 		}
 	} catch (Error& e) {
-		if( e.code() != error_code_broken_promise && e.code() != error_code_actor_cancelled )
+		if( e.code() != error_code_broken_promise )
 			TraceEvent(SevError, "GetConsistentReadVersionError").error(e);
 		throw;
 	}

--- a/fdbclient/ReadYourWrites.actor.cpp
+++ b/fdbclient/ReadYourWrites.actor.cpp
@@ -1905,12 +1905,11 @@ void ReadYourWritesTransaction::debugLogRetries(Optional<Error> error) {
 				fprintf(stderr, "fdb WARNING: long transaction (%.2fs elapsed%s, %d retries, %s)\n", elapsed, transactionNameStr.c_str(), retries, committed ? "committed" : error.get().what());
 			{
 				TraceEvent trace = TraceEvent("LongTransaction");
-				if(!transactionDebugInfo->transactionName.empty())
-					trace.detail("TransactionName", printable(StringRef(transactionDebugInfo->transactionName)));
-				
-				trace.detail("Elapsed", elapsed).detail("Retries", retries).detail("Committed", committed);
 				if(error.present())
 					trace.error(error.get(), true);
+				if(!transactionDebugInfo->transactionName.empty())
+					trace.detail("TransactionName", printable(StringRef(transactionDebugInfo->transactionName)));
+				trace.detail("Elapsed", elapsed).detail("Retries", retries).detail("Committed", committed);
 			}
 			transactionDebugInfo->lastRetryLogTime = now();
 		}

--- a/fdbclient/TaskBucket.actor.cpp
+++ b/fdbclient/TaskBucket.actor.cpp
@@ -390,18 +390,18 @@ public:
 			}
 		} catch(Error &e) {
 			TraceEvent(SevWarn, "TB_ExecuteFailure")
+				.error(e)
 				.detail("TaskUID", task->key.printable())
 				.detail("TaskType", task->params[Task::reservedTaskParamKeyType].printable())
-				.detail("Priority", task->getPriority())
-				.error(e);
+				.detail("Priority", task->getPriority());
 			try {
 				Void _ = wait(taskFunc->handleError(cx, task, e));
 			} catch(Error &e) {
 				TraceEvent(SevWarn, "TB_ExecuteFailureLogErrorFailed")
+					.error(e) // output handleError() error instead of original task error
 					.detail("TaskUID", task->key.printable())
 					.detail("TaskType", task->params[Task::reservedTaskParamKeyType].printable())
-					.detail("Priority", task->getPriority())
-					.error(e);  // output handleError() error instead of original task error
+					.detail("Priority", task->getPriority());
 			}
 		}
 

--- a/fdbrpc/AsyncFileEIO.actor.h
+++ b/fdbrpc/AsyncFileEIO.actor.h
@@ -83,7 +83,7 @@ public:
 			TraceEvent(notFound ? SevWarn : SevWarnAlways, "FileOpenError").error(e).GetLastError().detail("File", filename).detail("Flags", flags).detail("Mode", mode);
 			throw e;
 		}
-		TraceEvent("AsyncFileOpened").detail("Filename", filename).detail("Fd", r->result).detail("Flags", flags).suppressFor(1.0);
+		TraceEvent("AsyncFileOpened").suppressFor(1.0).detail("Filename", filename).detail("Fd", r->result).detail("Flags", flags);
 
 		if ((flags & OPEN_LOCK) && !lock_fd(r->result)) {
 			TraceEvent(SevError, "UnableToLockFile").detail("Filename", filename).GetLastError();
@@ -254,7 +254,7 @@ private:
 	static void error( const char* context, int fd, eio_req* r, Reference<ErrorInfo> const& err = Reference<ErrorInfo>() ) {
 		Error e = io_error();
 		errno = r->errorno;
-		TraceEvent(context).detail("Fd", fd).detail("Result", r->result).GetLastError().error(e);
+		TraceEvent(context).error(e).detail("Fd", fd).detail("Result", r->result).GetLastError();
 		if (err) err->set(e);
 		else throw e;
 	}
@@ -264,7 +264,7 @@ private:
 		state eio_req* r = eio_close(fd, 0, eio_callback, &p);
 		Void _ = wait( p.getFuture() );
 		if (r->result) error( "CloseError", fd, r );
-		TraceEvent("AsyncFileClosed").detail("Fd", fd).suppressFor(1.0);
+		TraceEvent("AsyncFileClosed").suppressFor(1.0).detail("Fd", fd);
 	}
 
 	ACTOR static Future<int> read_impl( int fd, void* data, int length, int64_t offset ) {

--- a/fdbrpc/AsyncFileKAIO.actor.h
+++ b/fdbrpc/AsyncFileKAIO.actor.h
@@ -112,8 +112,8 @@ public:
 			Error e = errno==ENOENT ? file_not_found() : io_error();
 			int ecode = errno;  // Save errno in case it is modified before it is used below
 			TraceEvent ev("AsyncFileKAIOOpenFailed");
-			ev.detail("Filename", filename).detailf("Flags", "%x", flags)
-			  .detailf("OSFlags", "%x", openFlags(flags) | O_DIRECT).detailf("Mode", "0%o", mode).error(e).GetLastError();
+			ev.error(e).detail("Filename", filename).detailf("Flags", "%x", flags)
+			  .detailf("OSFlags", "%x", openFlags(flags) | O_DIRECT).detailf("Mode", "0%o", mode).GetLastError();
 			if(ecode == EINVAL)
 				ev.detail("Description", "Invalid argument - Does the target filesystem support KAIO?");
 			return e;

--- a/fdbrpc/AsyncFileNonDurable.actor.h
+++ b/fdbrpc/AsyncFileNonDurable.actor.h
@@ -238,7 +238,7 @@ public:
 			state Error err = e;
 			std::string currentFilename = ( wrappedFile.isReady() && !wrappedFile.isError() ) ? wrappedFile.get()->getFilename() : actualFilename;
 			currentProcess->machine->openFiles.erase( currentFilename );
-			//TraceEvent("AsyncFileNonDurableOpenError").detail("Filename", filename).detail("Address", currentProcess->address).error(e, true).detail("Addr", g_simulator.getCurrentProcess()->address);
+			//TraceEvent("AsyncFileNonDurableOpenError").error(e, true).detail("Filename", filename).detail("Address", currentProcess->address).detail("Addr", g_simulator.getCurrentProcess()->address);
 			Void _ = wait( g_simulator.onProcess( currentProcess, currentTaskID ) );
 			throw err;
 		}

--- a/fdbrpc/AsyncFileWinASIO.actor.h
+++ b/fdbrpc/AsyncFileWinASIO.actor.h
@@ -85,7 +85,7 @@ public:
 	static void onReadReady( Promise<int> onReady, const boost::system::error_code& error, size_t bytesRead ) {
 		if (error) {
 			Error e = io_error();
-			TraceEvent("AsyncReadError").GetLastError().error(e)
+			TraceEvent("AsyncReadError").error(e).GetLastError()
 				.detail("ASIOCode", error.value())
 				.detail("ASIOMessage", error.message());
 			onReady.sendError(e);
@@ -96,7 +96,7 @@ public:
 	static void onWriteReady( Promise<Void> onReady, size_t bytesExpected, const boost::system::error_code& error, size_t bytesWritten ) {
 		if (error) {
 			Error e = io_error();
-			TraceEvent("AsyncWriteError").GetLastError().error(e)
+			TraceEvent("AsyncWriteError").error(e).GetLastError()
 				.detail("ASIOCode", error.value())
 				.detail("ASIOMessage", error.message());
 			onReady.sendError(e);

--- a/fdbrpc/AsyncFileWriteChecker.h
+++ b/fdbrpc/AsyncFileWriteChecker.h
@@ -134,12 +134,12 @@ private:
 				if(history.checksum != 0 && history.checksum != checksum) {
 					// For reads, verify the stored sum if it is not 0.  If it fails, clear it.
 					TraceEvent (SevError, "AsyncFileLostWriteDetected")
+						.error(checksum_failed())
 						.detail("Filename", m_f->getFilename())
 						.detail("PageNumber", page)
 						.detail("ChecksumOfPage", checksum)
 						.detail("ChecksumHistory", history.checksum)
-						.detail("LastWriteTime", history.timestamp)
-						.error(checksum_failed());
+						.detail("LastWriteTime", history.timestamp);
 					history.checksum = 0;
 				}
 			}

--- a/fdbrpc/BlobStore.actor.cpp
+++ b/fdbrpc/BlobStore.actor.cpp
@@ -182,7 +182,7 @@ Reference<BlobStoreEndpoint> BlobStoreEndpoint::fromString(std::string const &ur
 	} catch(std::string &err) {
 		if(error != nullptr)
 			*error = err;
-		TraceEvent(SevWarnAlways, "BlobStoreEndpointBadURL").detail("Description", err).detail("Format", getURLFormat()).detail("URL", url).suppressFor(60, true);
+		TraceEvent(SevWarnAlways, "BlobStoreEndpointBadURL").suppressFor(60).detail("Description", err).detail("Format", getURLFormat()).detail("URL", url);
 		throw backup_invalid_url();
 	}
 }
@@ -341,11 +341,11 @@ ACTOR Future<Optional<json_spirit::mObject>> tryReadJSONFile(std::string path) {
 		if(json.type() == json_spirit::obj_type)
 			return json.get_obj();
 		else
-			TraceEvent(SevWarn, "BlobCredentialFileNotJSONObject").detail("File", path).suppressFor(60, true);
+			TraceEvent(SevWarn, "BlobCredentialFileNotJSONObject").suppressFor(60).detail("File", path);
 
 	} catch(Error &e) {
 		if(e.code() != error_code_actor_cancelled)
-			TraceEvent(SevWarn, errorEventType).detail("File", path).error(e).suppressFor(60, true);
+			TraceEvent(SevWarn, errorEventType).error(e).suppressFor(60).detail("File", path);
 	}
 
 	return Optional<json_spirit::mObject>();
@@ -408,10 +408,9 @@ ACTOR Future<BlobStoreEndpoint::ReusableConnection> connect_impl(Reference<BlobS
 
 		// If the connection expires in the future then return it
 		if(rconn.expirationTime > now()) {
-		TraceEvent("BlobStoreEndpointReusingConnected")
+		TraceEvent("BlobStoreEndpointReusingConnected").suppressFor(60)
 			.detail("RemoteEndpoint", rconn.conn->getPeerAddress())
-			.detail("ExpiresIn", rconn.expirationTime - now())
-			.suppressFor(60, true);
+			.detail("ExpiresIn", rconn.expirationTime - now());
 			return rconn;
 		}
 	}
@@ -420,10 +419,9 @@ ACTOR Future<BlobStoreEndpoint::ReusableConnection> connect_impl(Reference<BlobS
 		service = b->knobs.secure_connection ? "https" : "http";
 	state Reference<IConnection> conn = wait(INetworkConnections::net()->connect(b->host, service, b->knobs.secure_connection ? true : false));
 
-	TraceEvent("BlobStoreEndpointNewConnection")
+	TraceEvent("BlobStoreEndpointNewConnection").suppressFor(60)
 		.detail("RemoteEndpoint", conn->getPeerAddress())
-		.detail("ExpiresIn", b->knobs.max_connection_life)
-		.suppressFor(60, true);
+		.detail("ExpiresIn", b->knobs.max_connection_life);
 
 	if(b->lookupSecret)
 		Void _ = wait(b->updateSecret());
@@ -521,6 +519,16 @@ ACTOR Future<Reference<HTTP::Response>> doRequest_impl(Reference<BlobStoreEndpoi
 		retryable = retryable && (thisTry < maxTries);
 
 		TraceEvent event(SevWarn, retryable ? "BlobStoreEndpointRequestFailedRetryable" : "BlobStoreEndpointRequestFailed");
+
+		// Attach err to trace event if present, otherwise extract some stuff from the response
+		if(err.present()) {
+			event.error(err.get());
+		}
+		event.suppressFor(60);
+		if(!err.present()) {
+			event.detail("ResponseCode", r->code);
+		}
+
 		event.detail("ConnectionEstablished", connectionEstablished);
 
 		if(remoteAddress.present())
@@ -530,8 +538,7 @@ ACTOR Future<Reference<HTTP::Response>> doRequest_impl(Reference<BlobStoreEndpoi
 
 		event.detail("Verb", verb)
 			 .detail("Resource", resource)
-			 .detail("ThisTry", thisTry)
-			 .suppressFor(60, true);
+			 .detail("ThisTry", thisTry);
 
 		// If r is not valid or not code 429 then increment the try count.  429's will not count against the attempt limit.
 		if(!r || r->code != 429)
@@ -541,13 +548,6 @@ ACTOR Future<Reference<HTTP::Response>> doRequest_impl(Reference<BlobStoreEndpoi
 		double delay = nextRetryDelay;
 		// Double but limit the *next* nextRetryDelay.
 		nextRetryDelay = std::min(nextRetryDelay * 2, 60.0);
-
-		// Attach err to trace event if present, otherwise extract some stuff from the response
-		if(err.present())
-			event.error(err.get());
-		else {
-			event.detail("ResponseCode", r->code);
-		}
 
 		if(retryable) {
 			// If r is valid then obey the Retry-After response header if present.
@@ -702,13 +702,13 @@ ACTOR Future<Void> listBucketStream_impl(Reference<BlobStoreEndpoint> bstore, st
 					lastFile = result.commonPrefixes.back();
 
 				if(lastFile.empty()) {
-					TraceEvent(SevWarn, "BlobStoreEndpointListNoNextMarker").detail("Resource", fullResource).suppressFor(60, true);
+					TraceEvent(SevWarn, "BlobStoreEndpointListNoNextMarker").suppressFor(60).detail("Resource", fullResource);
 					throw backup_error();
 				}
 			}
 		} catch(Error &e) {
 			if(e.code() != error_code_actor_cancelled)
-				TraceEvent(SevWarn, "BlobStoreEndpointListResultParseError").detail("Resource", fullResource).error(e).suppressFor(60, true);
+				TraceEvent(SevWarn, "BlobStoreEndpointListResultParseError").error(e).suppressFor(60).detail("Resource", fullResource);
 			throw http_bad_response();
 		}
 	}

--- a/fdbrpc/FailureMonitor.actor.cpp
+++ b/fdbrpc/FailureMonitor.actor.cpp
@@ -92,7 +92,7 @@ void SimpleFailureMonitor::setStatus( NetworkAddress const& address, FailureStat
 
 void SimpleFailureMonitor::endpointNotFound( Endpoint const& endpoint ) {
 	// SOMEDAY: Expiration (this "leaks" memory)
-	TraceEvent("EndpointNotFound").detail("Address", endpoint.address).detail("Token", endpoint.token).suppressFor(1.0);
+	TraceEvent("EndpointNotFound").suppressFor(1.0).detail("Address", endpoint.address).detail("Token", endpoint.token);
 	endpointKnownFailed.set( endpoint, true );
 }
 

--- a/fdbrpc/FlowTransport.actor.cpp
+++ b/fdbrpc/FlowTransport.actor.cpp
@@ -376,14 +376,14 @@ struct Peer : NonCopyable {
 					Void _ = wait( delayJittered( std::max(0.0, self->lastConnectTime+self->reconnectionDelay - now()) ) );  // Don't connect() to the same peer more than once per 2 sec
 					self->lastConnectTime = now();
 
-					TraceEvent("ConnectingTo", conn ? conn->getDebugID() : UID()).detail("PeerAddr", self->destination).suppressFor(1.0);
+					TraceEvent("ConnectingTo", conn ? conn->getDebugID() : UID()).suppressFor(1.0).detail("PeerAddr", self->destination);
 					Reference<IConnection> _conn = wait( timeout( INetworkConnections::net()->connect(self->destination), FLOW_KNOBS->CONNECTION_MONITOR_TIMEOUT, Reference<IConnection>() ) );
 					if (_conn) {
 						conn = _conn;
-						TraceEvent("ConnectionExchangingConnectPacket", conn->getDebugID()).detail("PeerAddr", self->destination).suppressFor(1.0);
+						TraceEvent("ConnectionExchangingConnectPacket", conn->getDebugID()).suppressFor(1.0).detail("PeerAddr", self->destination);
 						self->prependConnectPacket();
 					} else {
-						TraceEvent("ConnectionTimedOut", conn ? conn->getDebugID() : UID()).detail("PeerAddr", self->destination).suppressFor(1.0);
+						TraceEvent("ConnectionTimedOut", conn ? conn->getDebugID() : UID()).suppressFor(1.0).detail("PeerAddr", self->destination);
 						throw connection_failed();
 					}
 
@@ -415,10 +415,10 @@ struct Peer : NonCopyable {
 				bool ok = e.code() == error_code_connection_failed || e.code() == error_code_actor_cancelled || ( g_network->isSimulated() && e.code() == error_code_checksum_failed );
 
 				if(self->compatible) {
-					TraceEvent(ok ? SevInfo : SevWarnAlways, "ConnectionClosed", conn ? conn->getDebugID() : UID()).detail("PeerAddr", self->destination).error(e, true).suppressFor(1.0);
+					TraceEvent(ok ? SevInfo : SevWarnAlways, "ConnectionClosed", conn ? conn->getDebugID() : UID()).error(e, true).suppressFor(1.0).detail("PeerAddr", self->destination);
 				}
 				else {
-					TraceEvent(ok ? SevInfo : SevWarnAlways, "IncompatibleConnectionClosed", conn ? conn->getDebugID() : UID()).detail("PeerAddr", self->destination).error(e, true);
+					TraceEvent(ok ? SevInfo : SevWarnAlways, "IncompatibleConnectionClosed", conn ? conn->getDebugID() : UID()).error(e, true).detail("PeerAddr", self->destination);
 				}
 
 				if (conn) {
@@ -430,7 +430,7 @@ struct Peer : NonCopyable {
 				// Try to recover, even from serious errors, by retrying
 
 				if(self->peerReferences <= 0 && self->reliable.empty() && self->unsent.empty()) {
-					TraceEvent("PeerDestroy").detail("PeerAddr", self->destination).error(e).suppressFor(1.0);
+					TraceEvent("PeerDestroy").error(e).suppressFor(1.0).detail("PeerAddr", self->destination);
 					self->connect.cancel();
 					self->transport->peers.erase(self->destination);
 					delete self;
@@ -559,10 +559,10 @@ static void scanPackets( TransportData* transport, uint8_t*& unprocessed_begin, 
 
 		if (packetLen > FLOW_KNOBS->PACKET_WARNING) {
 			TraceEvent(transport->warnAlwaysForLargePacket ? SevWarnAlways : SevWarn, "Net2_LargePacket")
+				.suppressFor(1.0)
 				.detail("FromPeer", peerAddress.toString())
 				.detail("Length", (int)packetLen)
-				.detail("Token", token)
-				.suppressFor(1.0);
+				.detail("Token", token);
 
 			if(g_network->isSimulated())
 				transport->warnAlwaysForLargePacket = false;
@@ -663,8 +663,9 @@ ACTOR static Future<Void> connectionReader(
 						else {
 							compatible = true;
 							TraceEvent("ConnectionEstablished", conn->getDebugID())
+								.suppressFor(1.0)
 								.detail("Peer", conn->getPeerAddress())
-								.detail("ConnectionId", connectionId).suppressFor(1.0);
+								.detail("ConnectionId", connectionId);
 						}
 
 						if(connectionId > 1) {
@@ -676,7 +677,7 @@ ACTOR static Future<Void> connectionReader(
 						peerProtocolVersion = p->protocolVersion;
 						if (peer != nullptr) {
 							// Outgoing connection; port information should be what we expect
-							TraceEvent("ConnectedOutgoing").detail("PeerAddr", NetworkAddress( p->canonicalRemoteIp, p->canonicalRemotePort ) ).suppressFor(1.0);
+							TraceEvent("ConnectedOutgoing").suppressFor(1.0).detail("PeerAddr", NetworkAddress( p->canonicalRemoteIp, p->canonicalRemotePort ) );
 							peer->compatible = compatible;
 							peer->incompatibleProtocolVersionNewer = incompatibleProtocolVersionNewer;
 							if (!compatible) {
@@ -743,7 +744,7 @@ ACTOR static Future<Void> connectionIncoming( TransportData* self, Reference<ICo
 		}
 		return Void();
 	} catch (Error& e) {
-		TraceEvent("IncomingConnectionError", conn->getDebugID()).error(e).detail("FromAddress", conn->getPeerAddress()).suppressFor(1.0);
+		TraceEvent("IncomingConnectionError", conn->getDebugID()).error(e).suppressFor(1.0).detail("FromAddress", conn->getPeerAddress());
 		conn->close();
 		return Void();
 	}
@@ -755,7 +756,7 @@ ACTOR static Future<Void> listen( TransportData* self, NetworkAddress listenAddr
 	try {
 		loop {
 			Reference<IConnection> conn = wait( listener->accept() );
-			TraceEvent("ConnectionFrom", conn->getDebugID()).detail("FromAddress", conn->getPeerAddress()).suppressFor(1.0);
+			TraceEvent("ConnectionFrom", conn->getDebugID()).suppressFor(1.0).detail("FromAddress", conn->getPeerAddress());
 			incoming.add( connectionIncoming(self, conn) );
 		}
 	} catch (Error& e) {
@@ -969,11 +970,11 @@ static PacketID sendPacket( TransportData* self, ISerializeSource const& what, c
 		} 
 		else if (len > FLOW_KNOBS->PACKET_WARNING) {
 			TraceEvent(self->warnAlwaysForLargePacket ? SevWarnAlways : SevWarn, "Net2_LargePacket")
+				.suppressFor(1.0)
 				.detail("ToPeer", destination.address)
 				.detail("Length", (int)len)
 				.detail("Token", destination.token)
-				.backtrace()
-				.suppressFor(1.0);
+				.backtrace();
 
 			if(g_network->isSimulated())
 				self->warnAlwaysForLargePacket = false;

--- a/fdbrpc/batcher.actor.h
+++ b/fdbrpc/batcher.actor.h
@@ -72,7 +72,7 @@ Future<Void> batcher(PromiseStream<std::pair<std::vector<X>, int> > out, FutureS
 					// Drop requests if memory is under severe pressure
 					if (*commitBatchesMemBytesCount + bytes > commitBatchesMemBytesLimit) {
 						x.reply.sendError(proxy_memory_limit_exceeded());
-						TraceEvent(SevWarnAlways, "ProxyCommitBatchMemoryThresholdExceeded").detail("CommitBatchesMemBytesCount", *commitBatchesMemBytesCount).detail("CommitBatchesMemLimit", commitBatchesMemBytesLimit).suppressFor(60, true);
+						TraceEvent(SevWarnAlways, "ProxyCommitBatchMemoryThresholdExceeded").suppressFor(60).detail("CommitBatchesMemBytesCount", *commitBatchesMemBytesCount).detail("CommitBatchesMemLimit", commitBatchesMemBytesLimit);
 						continue;
 					}
 

--- a/fdbrpc/sim2.actor.cpp
+++ b/fdbrpc/sim2.actor.cpp
@@ -1194,12 +1194,12 @@ public:
 		TEST( kt == InjectFaults ); // Simulated machine was killed with faults
 
 		if (kt == KillInstantly) {
-			TraceEvent(SevWarn, "FailMachine", machine->locality.zoneId()).detail("Name", machine->name).detail("Address", machine->address).detailext("ZoneId", machine->locality.zoneId()).detail("Process", describe(*machine)).detail("Rebooting", machine->rebooting).detail("Protected", protectedAddresses.count(machine->address)).backtrace();
+			TraceEvent(SevWarn, "FailMachine").detail("Name", machine->name).detail("Address", machine->address).detailext("ZoneId", machine->locality.zoneId()).detail("Process", describe(*machine)).detail("Rebooting", machine->rebooting).detail("Protected", protectedAddresses.count(machine->address)).backtrace();
 			// This will remove all the "tracked" messages that came from the machine being killed
 			latestEventCache.clear();
 			machine->failed = true;
 		} else if (kt == InjectFaults) {
-			TraceEvent(SevWarn, "FaultMachine", machine->locality.zoneId()).detail("Name", machine->name).detail("Address", machine->address).detailext("ZoneId", machine->locality.zoneId()).detail("Process", describe(*machine)).detail("Rebooting", machine->rebooting).detail("Protected", protectedAddresses.count(machine->address)).backtrace();
+			TraceEvent(SevWarn, "FaultMachine").detail("Name", machine->name).detail("Address", machine->address).detailext("ZoneId", machine->locality.zoneId()).detail("Process", describe(*machine)).detail("Rebooting", machine->rebooting).detail("Protected", protectedAddresses.count(machine->address)).backtrace();
 			should_inject_fault = simulator_should_inject_fault;
 			machine->fault_injection_r = g_random->randomUniqueID().first();
 			machine->fault_injection_p1 = 0.1;
@@ -1255,7 +1255,7 @@ public:
 		TEST(kt == InjectFaults);  // Trying to kill by injecting faults
 
 		if(speedUpSimulation && !forceKill) {
-			TraceEvent(SevWarn, "AbortedKill", zoneId).detailext("ZoneId", zoneId).detail("Reason", "Unforced kill within speedy simulation.").backtrace();
+			TraceEvent(SevWarn, "AbortedKill").detailext("ZoneId", zoneId).detail("Reason", "Unforced kill within speedy simulation.").backtrace();
 			if (ktFinal) *ktFinal = None;
 			return false;
 		}
@@ -1273,7 +1273,7 @@ public:
 
 		// Do nothing, if no processes to kill
 		if (processesOnMachine == 0) {
-			TraceEvent(SevWarn, "AbortedKill", zoneId).detailext("ZoneId", zoneId).detail("Reason", "The target had no processes running.").detail("Processes", processesOnMachine).detail("ProcessesPerMachine", processesPerMachine).backtrace();
+			TraceEvent(SevWarn, "AbortedKill").detailext("ZoneId", zoneId).detail("Reason", "The target had no processes running.").detail("Processes", processesOnMachine).detail("ProcessesPerMachine", processesPerMachine).backtrace();
 			if (ktFinal) *ktFinal = None;
 			return false;
 		}
@@ -1310,24 +1310,24 @@ public:
 				}
 			}
 			if (!canKillProcesses(processesLeft, processesDead, kt, &kt)) {
-				TraceEvent("ChangedKillMachine", zoneId).detailext("ZoneId", zoneId).detail("KillType", kt).detail("OrigKillType", ktOrig).detail("ProcessesLeft", processesLeft.size()).detail("ProcessesDead", processesDead.size()).detail("TotalProcesses", machines.size()).detail("ProcessesPerMachine", processesPerMachine).detail("Protected", protectedWorker).detail("Unavailable", unavailable).detail("Excluded", excluded).detail("Cleared", cleared).detail("ProtectedTotal", protectedAddresses.size()).detail("TLogPolicy", tLogPolicy->info()).detail("StoragePolicy", storagePolicy->info());
+				TraceEvent("ChangedKillMachine").detailext("ZoneId", zoneId).detail("KillType", kt).detail("OrigKillType", ktOrig).detail("ProcessesLeft", processesLeft.size()).detail("ProcessesDead", processesDead.size()).detail("TotalProcesses", machines.size()).detail("ProcessesPerMachine", processesPerMachine).detail("Protected", protectedWorker).detail("Unavailable", unavailable).detail("Excluded", excluded).detail("Cleared", cleared).detail("ProtectedTotal", protectedAddresses.size()).detail("TLogPolicy", tLogPolicy->info()).detail("StoragePolicy", storagePolicy->info());
 			}
 			else if ((kt == KillInstantly) || (kt == InjectFaults)) {
-				TraceEvent("DeadMachine", zoneId).detailext("ZoneId", zoneId).detail("KillType", kt).detail("ProcessesLeft", processesLeft.size()).detail("ProcessesDead", processesDead.size()).detail("TotalProcesses", machines.size()).detail("ProcessesPerMachine", processesPerMachine).detail("TLogPolicy", tLogPolicy->info()).detail("StoragePolicy", storagePolicy->info());
+				TraceEvent("DeadMachine").detailext("ZoneId", zoneId).detail("KillType", kt).detail("ProcessesLeft", processesLeft.size()).detail("ProcessesDead", processesDead.size()).detail("TotalProcesses", machines.size()).detail("ProcessesPerMachine", processesPerMachine).detail("TLogPolicy", tLogPolicy->info()).detail("StoragePolicy", storagePolicy->info());
 				for (auto process : processesLeft) {
-					TraceEvent("DeadMachineSurvivors", zoneId).detailext("ZoneId", zoneId).detail("KillType", kt).detail("ProcessesLeft", processesLeft.size()).detail("ProcessesDead", processesDead.size()).detail("SurvivingProcess", describe(*process));
+					TraceEvent("DeadMachineSurvivors").detailext("ZoneId", zoneId).detail("KillType", kt).detail("ProcessesLeft", processesLeft.size()).detail("ProcessesDead", processesDead.size()).detail("SurvivingProcess", describe(*process));
 				}
 				for (auto process : processesDead) {
-					TraceEvent("DeadMachineVictims", zoneId).detailext("ZoneId", zoneId).detail("KillType", kt).detail("ProcessesLeft", processesLeft.size()).detail("ProcessesDead", processesDead.size()).detail("VictimProcess", describe(*process));
+					TraceEvent("DeadMachineVictims").detailext("ZoneId", zoneId).detail("KillType", kt).detail("ProcessesLeft", processesLeft.size()).detail("ProcessesDead", processesDead.size()).detail("VictimProcess", describe(*process));
 				}
 			}
 			else {
-				TraceEvent("ClearMachine", zoneId).detailext("ZoneId", zoneId).detail("KillType", kt).detail("ProcessesLeft", processesLeft.size()).detail("ProcessesDead", processesDead.size()).detail("TotalProcesses", machines.size()).detail("ProcessesPerMachine", processesPerMachine).detail("TLogPolicy", tLogPolicy->info()).detail("StoragePolicy", storagePolicy->info());
+				TraceEvent("ClearMachine").detailext("ZoneId", zoneId).detail("KillType", kt).detail("ProcessesLeft", processesLeft.size()).detail("ProcessesDead", processesDead.size()).detail("TotalProcesses", machines.size()).detail("ProcessesPerMachine", processesPerMachine).detail("TLogPolicy", tLogPolicy->info()).detail("StoragePolicy", storagePolicy->info());
 				for (auto process : processesLeft) {
-					TraceEvent("ClearMachineSurvivors", zoneId).detailext("ZoneId", zoneId).detail("KillType", kt).detail("ProcessesLeft", processesLeft.size()).detail("ProcessesDead", processesDead.size()).detail("SurvivingProcess", describe(*process));
+					TraceEvent("ClearMachineSurvivors").detailext("ZoneId", zoneId).detail("KillType", kt).detail("ProcessesLeft", processesLeft.size()).detail("ProcessesDead", processesDead.size()).detail("SurvivingProcess", describe(*process));
 				}
 				for (auto process : processesDead) {
-					TraceEvent("ClearMachineVictims", zoneId).detailext("ZoneId", zoneId).detail("KillType", kt).detail("ProcessesLeft", processesLeft.size()).detail("ProcessesDead", processesDead.size()).detail("VictimProcess", describe(*process));
+					TraceEvent("ClearMachineVictims").detailext("ZoneId", zoneId).detail("KillType", kt).detail("ProcessesLeft", processesLeft.size()).detail("ProcessesDead", processesDead.size()).detail("VictimProcess", describe(*process));
 				}
 			}
 		}
@@ -1337,7 +1337,7 @@ public:
 		// Check if any processes on machine are rebooting
 		if( processesOnMachine != processesPerMachine && kt >= RebootAndDelete ) {
 			TEST(true); //Attempted reboot, but the target did not have all of its processes running
-			TraceEvent(SevWarn, "AbortedKill", zoneId).detail("KillType", kt).detailext("ZoneId", zoneId).detail("Reason", "Machine processes does not match number of processes per machine").detail("Processes", processesOnMachine).detail("ProcessesPerMachine", processesPerMachine).backtrace();
+			TraceEvent(SevWarn, "AbortedKill").detail("KillType", kt).detailext("ZoneId", zoneId).detail("Reason", "Machine processes does not match number of processes per machine").detail("Processes", processesOnMachine).detail("ProcessesPerMachine", processesPerMachine).backtrace();
 			if (ktFinal) *ktFinal = None;
 			return false;
 		}
@@ -1345,24 +1345,24 @@ public:
 		// Check if any processes on machine are rebooting
 		if ( processesOnMachine != processesPerMachine ) {
 			TEST(true); //Attempted reboot, but the target did not have all of its processes running
-			TraceEvent(SevWarn, "AbortedKill", zoneId).detail("KillType", kt).detailext("ZoneId", zoneId).detail("Reason", "Machine processes does not match number of processes per machine").detail("Processes", processesOnMachine).detail("ProcessesPerMachine", processesPerMachine).backtrace();
+			TraceEvent(SevWarn, "AbortedKill").detail("KillType", kt).detailext("ZoneId", zoneId).detail("Reason", "Machine processes does not match number of processes per machine").detail("Processes", processesOnMachine).detail("ProcessesPerMachine", processesPerMachine).backtrace();
 			if (ktFinal) *ktFinal = None;
 			return false;
 		}
 
-		TraceEvent("KillMachine", zoneId).detailext("ZoneId", zoneId).detail("Kt", kt).detail("KtOrig", ktOrig).detail("KillableMachines", processesOnMachine).detail("ProcessPerMachine", processesPerMachine).detail("KillChanged", kt!=ktOrig);
+		TraceEvent("KillMachine").detailext("ZoneId", zoneId).detail("Kt", kt).detail("KtOrig", ktOrig).detail("KillableMachines", processesOnMachine).detail("ProcessPerMachine", processesPerMachine).detail("KillChanged", kt!=ktOrig);
 		if ( kt < RebootAndDelete ) {
 			if(kt == InjectFaults && machines[zoneId].machineProcess != nullptr)
 				killProcess_internal( machines[zoneId].machineProcess, kt );
 			for (auto& process : machines[zoneId].processes) {
-				TraceEvent("KillMachineProcess", zoneId).detail("KillType", kt).detail("Process", process->toString()).detail("StartingClass", process->startingClass.toString()).detail("Failed", process->failed).detail("Excluded", process->excluded).detail("Cleared", process->cleared).detail("Rebooting", process->rebooting);
+				TraceEvent("KillMachineProcess").detail("KillType", kt).detail("Process", process->toString()).detail("StartingClass", process->startingClass.toString()).detail("Failed", process->failed).detail("Excluded", process->excluded).detail("Cleared", process->cleared).detail("Rebooting", process->rebooting);
 				if (process->startingClass != ProcessClass::TesterClass)
 					killProcess_internal( process, kt );
 			}
 		}
 		else if ( kt == Reboot || kt == RebootAndDelete ) {
 			for (auto& process : machines[zoneId].processes) {
-				TraceEvent("KillMachineProcess", zoneId).detail("KillType", kt).detail("Process", process->toString()).detail("StartingClass", process->startingClass.toString()).detail("Failed", process->failed).detail("Excluded", process->excluded).detail("Cleared", process->cleared).detail("Rebooting", process->rebooting);
+				TraceEvent("KillMachineProcess").detail("KillType", kt).detail("Process", process->toString()).detail("StartingClass", process->startingClass.toString()).detail("Failed", process->failed).detail("Excluded", process->excluded).detail("Cleared", process->cleared).detail("Rebooting", process->rebooting);
 				if (process->startingClass != ProcessClass::TesterClass)
 					doReboot(process, kt );
 			}
@@ -1422,11 +1422,11 @@ public:
 				TraceEvent("DeadDataCenter").detailext("DataCenter", dcId).detail("KillType", kt).detail("DcZones", datacenterZones.size()).detail("DcProcesses", dcProcesses).detail("ProcessesDead", processesDead.size()).detail("ProcessesLeft", processesLeft.size()).detail("TLogPolicy", tLogPolicy->info()).detail("StoragePolicy", storagePolicy->info());
 				for (auto process : processesLeft) {
 					auto zoneId = process->locality.zoneId();
-					TraceEvent("DeadDcSurvivors", zoneId).detailext("ZoneId", zoneId).detail("KillType", kt).detail("ProcessesLeft", processesLeft.size()).detail("ProcessesDead", processesDead.size()).detail("SurvivingProcess", describe(*process));
+					TraceEvent("DeadDcSurvivors").detailext("ZoneId", zoneId).detail("KillType", kt).detail("ProcessesLeft", processesLeft.size()).detail("ProcessesDead", processesDead.size()).detail("SurvivingProcess", describe(*process));
 				}
 				for (auto process : processesDead) {
 					auto zoneId = process->locality.zoneId();
-					TraceEvent("DeadDcVictims", zoneId).detailext("ZoneId", zoneId).detail("KillType", kt).detail("ProcessesLeft", processesLeft.size()).detail("ProcessesDead", processesDead.size()).detail("VictimProcess", describe(*process));
+					TraceEvent("DeadDcVictims").detailext("ZoneId", zoneId).detail("KillType", kt).detail("ProcessesLeft", processesLeft.size()).detail("ProcessesDead", processesDead.size()).detail("VictimProcess", describe(*process));
 				}
 			}
 		}

--- a/fdbserver/ClusterController.actor.cpp
+++ b/fdbserver/ClusterController.actor.cpp
@@ -1430,7 +1430,7 @@ ACTOR Future<Void> failureDetectionServer( UID uniqueID, FutureStream< FailureMo
 			for(auto it=currentStatus.begin(); it!=currentStatus.end(); it++)
 				if (it->second.penultimateRequestTime) {
 					delays.push_back(it->second.latency(t));
-					TraceEvent("FDData", uniqueID).detail("S", it->first.toString()).detail("L", it->second.latency(t));
+					//TraceEvent("FDData", uniqueID).detail("S", it->first.toString()).detail("L", it->second.latency(t));
 				}
 			int pivot = std::max(0, (int)delays.size()-2);
 			double pivotDelay = 0;
@@ -1440,7 +1440,7 @@ ACTOR Future<Void> failureDetectionServer( UID uniqueID, FutureStream< FailureMo
 			}
 			pivotDelay = std::max(0.0, pivotDelay - FLOW_KNOBS->SERVER_REQUEST_INTERVAL);
 
-			TraceEvent("FailureDetectionPoll", uniqueID).detail("PivotDelay", pivotDelay).detail("Clients", currentStatus.size());
+			//TraceEvent("FailureDetectionPoll", uniqueID).detail("PivotDelay", pivotDelay).detail("Clients", currentStatus.size());
 			//TraceEvent("FailureDetectionAcceptableDelay").detail("Delay", acceptableDelay1000);
 
 			for(auto it = currentStatus.begin(); it != currentStatus.end(); ) {

--- a/fdbserver/DataDistributionQueue.actor.cpp
+++ b/fdbserver/DataDistributionQueue.actor.cpp
@@ -926,7 +926,7 @@ ACTOR Future<Void> dataDistributionRelocator( DDQueueData *self, RelocateData rd
 				}
 				TEST(true); //did not find a healthy destination team on the first attempt
 				stuckCount++;
-				TraceEvent(stuckCount > 50 ? SevWarnAlways : SevWarn, "BestTeamStuck", masterId).detail("Count", stuckCount).suppressFor(1.0);
+				TraceEvent(stuckCount > 50 ? SevWarnAlways : SevWarn, "BestTeamStuck", masterId).suppressFor(1.0).detail("Count", stuckCount);
 				Void _ = wait( delay( SERVER_KNOBS->BEST_TEAM_STUCK_DELAY, TaskDataDistributionLaunch ) );
 			}
 

--- a/fdbserver/DataDistributionTracker.actor.cpp
+++ b/fdbserver/DataDistributionTracker.actor.cpp
@@ -209,7 +209,7 @@ ACTOR Future<Void> trackShardBytes(
 
 				shardSize->set( metrics );
 			} catch( Error &e ) {
-				//TraceEvent("ShardSizeUpdateError").detail("Begin", printable(keys.begin)).detail("End", printable(keys.end)).detail("TrackerID", trackerID).error(e, true);
+				//TraceEvent("ShardSizeUpdateError").error(e, true).detail("Begin", printable(keys.begin)).detail("End", printable(keys.end)).detail("TrackerID", trackerID);
 				Void _ = wait( tr.onError(e) );
 			}
 		}

--- a/fdbserver/DiskQueue.actor.cpp
+++ b/fdbserver/DiskQueue.actor.cpp
@@ -253,7 +253,7 @@ public:
 				waitfor.push_back( files[1].f->truncate( files[1].size ) );
 
 				if(fileSizeWarningLimit > 0 && files[1].size > fileSizeWarningLimit) {
-					TraceEvent(SevWarnAlways, "DiskQueueFileTooLarge", dbgid).detail("Filename", filename(1)).detail("Size", files[1].size).suppressFor(1.0);
+					TraceEvent(SevWarnAlways, "DiskQueueFileTooLarge", dbgid).suppressFor(1.0).detail("Filename", filename(1)).detail("Size", files[1].size);
 				}
 			}
 		}
@@ -322,7 +322,7 @@ public:
 			delete pageMem;
 			TEST(true);  // push error
 			TEST(2==syncFiles.size());  // push spanning both files error
-			TraceEvent(SevError, "RDQPushAndCommitError", dbgid).detail("InitialFilename0", filename).error(e, true);
+			TraceEvent(SevError, "RDQPushAndCommitError", dbgid).error(e, true).detail("InitialFilename0", filename);
 
 			if (errorPromise.canBeSet()) errorPromise.sendError(e);
 			if (pushing.canBeSet()) pushing.sendError(e);
@@ -428,8 +428,8 @@ public:
 				.detail("File0", self->filename(0));
 		} catch( Error &e ) {
 			TraceEvent(SevError, "DiskQueueShutdownError", self->dbgid)
-				.detail("Reason", e.code() == error_code_platform_error ? "could not delete database" : "unknown")
-				.error(e,true);
+				.error(e,true)
+				.detail("Reason", e.code() == error_code_platform_error ? "could not delete database" : "unknown");
 			error = e;
 		}
 
@@ -533,7 +533,7 @@ public:
 			return result.str;
 		} catch (Error& e) {
 			bool ok = e.code() == error_code_file_not_found;
-			TraceEvent(ok ? SevInfo : SevError, "RDQReadFirstAndLastPagesError", self->dbgid).detail("File0Name", self->files[0].dbgFilename).error(e, true);
+			TraceEvent(ok ? SevInfo : SevError, "RDQReadFirstAndLastPagesError", self->dbgid).error(e, true).detail("File0Name", self->files[0].dbgFilename);
 			if (!self->error.isSet()) self->error.sendError(e);
 			throw;
 		}
@@ -588,7 +588,7 @@ public:
 			return result;
 		} catch (Error& e) {
 			TEST(true);  // Read next page error
-			TraceEvent(SevError, "RDQReadNextPageError", self->dbgid).detail("File0Name", self->files[0].dbgFilename).error(e, true);
+			TraceEvent(SevError, "RDQReadNextPageError", self->dbgid).error(e, true).detail("File0Name", self->files[0].dbgFilename);
 			if (!self->error.isSet()) self->error.sendError(e);
 			throw;
 		}
@@ -633,7 +633,7 @@ public:
 
 			return Void();
 		} catch (Error& e) {
-			TraceEvent(SevError, "RDQTruncateBeforeLastReadPageError", self->dbgid).detail("File0Name", self->files[0].dbgFilename).error(e);
+			TraceEvent(SevError, "RDQTruncateBeforeLastReadPageError", self->dbgid).error(e).detail("File0Name", self->files[0].dbgFilename);
 			if (!self->error.isSet()) self->error.sendError(e);
 			throw;
 		}
@@ -712,11 +712,11 @@ public:
 
 		if( pushedPageCount() >= 8000 ) {
 			TraceEvent( warnAlwaysForMemory ? SevWarnAlways : SevWarn, "DiskQueueMemoryWarning", dbgid)
+				.suppressFor(1.0)
 				.detail("PushedPages", pushedPageCount())
 				.detail("NextPageSeq", nextPageSeq)
 				.detail("Details", format("%d pages", pushedPageCount()))
-				.detail("File0Name", rawQueue->files[0].dbgFilename)
-				.suppressFor(1.0);
+				.detail("File0Name", rawQueue->files[0].dbgFilename);
 			if(g_network->isSimulated())
 				warnAlwaysForMemory = false;
 		}

--- a/fdbserver/KeyValueStoreSQLite.actor.cpp
+++ b/fdbserver/KeyValueStoreSQLite.actor.cpp
@@ -103,14 +103,14 @@ struct PageChecksumCodec {
 		if(!write && sum != *pSumInPage) {
 			if(!silent)
 				TraceEvent (SevError, "SQLitePageChecksumFailure")
+					.error(checksum_failed())
 					.detail("CodecPageSize", pageSize)
 					.detail("CodecReserveSize", reserveSize)
 					.detail("Filename", filename)
 					.detail("PageNumber", pageNumber)
 					.detail("PageSize", pageLen)
 					.detail("ChecksumInPage", pSumInPage->toString())
-					.detail("ChecksumCalculated", sum.toString())
-					.error(checksum_failed());
+					.detail("ChecksumCalculated", sum.toString());
 
 			return false;
 		}
@@ -1832,8 +1832,8 @@ private:
 			}
 		} catch (Error& e) {
 			TraceEvent(SevError, "KVDoCloseError", self->logID)
-				.detail("Reason", e.code() == error_code_platform_error ? "could not delete database" : "unknown")
-				.error(e,true);
+				.error(e,true)
+				.detail("Reason", e.code() == error_code_platform_error ? "could not delete database" : "unknown");
 			error = e;
 		}
 

--- a/fdbserver/MasterProxyServer.actor.cpp
+++ b/fdbserver/MasterProxyServer.actor.cpp
@@ -97,14 +97,14 @@ ACTOR Future<Void> getRate(UID myID, MasterInterface master, int64_t* inTransact
 		when(GetRateInfoReply rep = wait(reply)) {
 			reply = Never();
 			*outTransactionRate = rep.transactionRate;
-			TraceEvent("MasterProxyRate", myID).detail("Rate", rep.transactionRate).detail("Lease", rep.leaseDuration).detail("ReleasedTransactions", *inTransactionCount - lastTC);
+			//TraceEvent("MasterProxyRate", myID).detail("Rate", rep.transactionRate).detail("Lease", rep.leaseDuration).detail("ReleasedTransactions", *inTransactionCount - lastTC);
 			lastTC = *inTransactionCount;
 			leaseTimeout = delay(rep.leaseDuration);
 			nextRequestTimer = delayJittered(rep.leaseDuration / 2);
 		}
 		when(Void _ = wait(leaseTimeout)) {
 			*outTransactionRate = 0;
-			TraceEvent("MasterProxyRate", myID).detail("Rate", 0).detail("Lease", "Expired");
+			//TraceEvent("MasterProxyRate", myID).detail("Rate", 0).detail("Lease", "Expired");
 			leaseTimeout = Never();
 		}
 	}

--- a/fdbserver/MoveKeys.actor.cpp
+++ b/fdbserver/MoveKeys.actor.cpp
@@ -314,10 +314,10 @@ ACTOR Future<Void> startMoveKeys( Database occ, KeyRange keys, vector<UID> serve
 
 					if(retries%10 == 0) {
 						TraceEvent(retries == 50 ? SevWarnAlways : SevWarn, "StartMoveKeysRetrying", relocationIntervalId)
+							.error(err)
 							.detail("Keys", printable(keys))
 							.detail("BeginKey", printable(begin))
-							.detail("NumTries", retries)
-							.error(err);
+							.detail("NumTries", retries);
 					}
 				}
 			}

--- a/fdbserver/OldTLogServer.actor.cpp
+++ b/fdbserver/OldTLogServer.actor.cpp
@@ -1005,7 +1005,7 @@ namespace oldTLog {
 		logData->queueCommittedVersion.set(ver);
 		self->queueCommitEnd.set(commitNumber);
 
-		TraceEvent("TLogCommitDurable", self->dbgid).detail("Version", ver);
+		//TraceEvent("TLogCommitDurable", self->dbgid).detail("Version", ver);
 
 		return Void();
 	}

--- a/fdbserver/QuietDatabase.actor.cpp
+++ b/fdbserver/QuietDatabase.actor.cpp
@@ -74,7 +74,7 @@ ACTOR Future<int64_t> getDataInFlight( Database cx, WorkerInterface masterWorker
 		sscanf(md.getValue("TotalBytes").c_str(), "%lld", &dataInFlight);
 		return dataInFlight;
 	} catch( Error &e ) {
-		TraceEvent("QuietDatabaseFailure", masterWorker.id()).detail("Reason", "Failed to extract DataInFlight").error(e);
+		TraceEvent("QuietDatabaseFailure", masterWorker.id()).error(e).detail("Reason", "Failed to extract DataInFlight");
 		throw;
 	}
 

--- a/fdbserver/SimulatedCluster.actor.cpp
+++ b/fdbserver/SimulatedCluster.actor.cpp
@@ -229,7 +229,7 @@ ACTOR Future<ISimulator::KillType> simulatedFDBDRebooter(
 		state Future<ISimulator::KillType> onShutdown = process->onShutdown();
 
 		try {
-			TraceEvent("SimulatedRebooterStarting", localities.zoneId()).detail("Cycles", cycles).detail("RandomId", randomId)
+			TraceEvent("SimulatedRebooterStarting").detail("Cycles", cycles).detail("RandomId", randomId)
 				.detailext("ZoneId", localities.zoneId())
 				.detailext("DataHall", localities.dataHallId())
 				.detail("Address", process->address.toString())
@@ -270,10 +270,10 @@ ACTOR Future<ISimulator::KillType> simulatedFDBDRebooter(
 				if(e.code() != error_code_actor_cancelled)
 					printf("SimulatedFDBDTerminated: %s\n", e.what());
 				ASSERT( destructed || g_simulator.getCurrentProcess() == process ); // simulatedFDBD catch called on different process
-				TraceEvent(e.code() == error_code_actor_cancelled || e.code() == error_code_file_not_found || destructed ? SevInfo : SevError, "SimulatedFDBDTerminated", localities.zoneId()).error(e, true);
+				TraceEvent(e.code() == error_code_actor_cancelled || e.code() == error_code_file_not_found || destructed ? SevInfo : SevError, "SimulatedFDBDTerminated").error(e, true).detailext("ZoneId", localities.zoneId());
 			}
 
-			TraceEvent("SimulatedFDBDDone", localities.zoneId()).detail("Cycles", cycles).detail("RandomId", randomId)
+			TraceEvent("SimulatedFDBDDone").detail("Cycles", cycles).detail("RandomId", randomId)
 				.detail("Address", process->address)
 				.detail("Excluded", process->excluded)
 				.detailext("ZoneId", localities.zoneId())
@@ -282,7 +282,7 @@ ACTOR Future<ISimulator::KillType> simulatedFDBDRebooter(
 			if (!onShutdown.isReady())
 				onShutdown = ISimulator::InjectFaults;
 		} catch (Error& e) {
-			TraceEvent(destructed ? SevInfo : SevError, "SimulatedFDBDRebooterError", localities.zoneId()).detail("RandomId", randomId).error(e, true);
+			TraceEvent(destructed ? SevInfo : SevError, "SimulatedFDBDRebooterError").error(e, true).detailext("ZoneId", localities.zoneId()).detail("RandomId", randomId);
 			onShutdown = e;
 		}
 
@@ -292,7 +292,7 @@ ACTOR Future<ISimulator::KillType> simulatedFDBDRebooter(
 			process->rebooting = true;
 			process->shutdownSignal.send(ISimulator::None);
 		}
-		TraceEvent("SimulatedFDBDWait", localities.zoneId()).detail("Cycles", cycles).detail("RandomId", randomId)
+		TraceEvent("SimulatedFDBDWait").detail("Cycles", cycles).detail("RandomId", randomId)
 			.detail("Address", process->address)
 			.detail("Excluded", process->excluded)
 			.detail("Rebooting", process->rebooting)
@@ -304,14 +304,14 @@ ACTOR Future<ISimulator::KillType> simulatedFDBDRebooter(
 		g_simulator.destroyProcess( process );  // Leak memory here; the process may be used in other parts of the simulation
 
 		auto shutdownResult = onShutdown.get();
-		TraceEvent("SimulatedFDBDShutdown", localities.zoneId()).detail("Cycles", cycles).detail("RandomId", randomId)
+		TraceEvent("SimulatedFDBDShutdown").detail("Cycles", cycles).detail("RandomId", randomId)
 			.detail("Address", process->address)
 			.detail("Excluded", process->excluded)
 			.detailext("ZoneId", localities.zoneId())
 			.detail("KillType", shutdownResult);
 
 		if( shutdownResult < ISimulator::RebootProcessAndDelete ) {
-			TraceEvent("SimulatedFDBDLowerReboot", localities.zoneId()).detail("Cycles", cycles).detail("RandomId", randomId)
+			TraceEvent("SimulatedFDBDLowerReboot").detail("Cycles", cycles).detail("RandomId", randomId)
 				.detail("Address", process->address)
 				.detail("Excluded", process->excluded)
 				.detailext("ZoneId", localities.zoneId())
@@ -320,7 +320,7 @@ ACTOR Future<ISimulator::KillType> simulatedFDBDRebooter(
 		}
 
 		if( onShutdown.get() == ISimulator::RebootProcessAndDelete ) {
-			TraceEvent("SimulatedFDBDRebootAndDelete", localities.zoneId()).detail("Cycles", cycles).detail("RandomId", randomId)
+			TraceEvent("SimulatedFDBDRebootAndDelete").detail("Cycles", cycles).detail("RandomId", randomId)
 				.detail("Address", process->address)
 				.detailext("ZoneId", localities.zoneId())
 				.detail("KillType", shutdownResult);
@@ -337,7 +337,7 @@ ACTOR Future<ISimulator::KillType> simulatedFDBDRebooter(
 			}
 		}
 		else {
-			TraceEvent("SimulatedFDBDJustRepeat", localities.zoneId()).detail("Cycles", cycles).detail("RandomId", randomId)
+			TraceEvent("SimulatedFDBDJustRepeat").detail("Cycles", cycles).detail("RandomId", randomId)
 				.detail("Address", process->address)
 				.detailext("ZoneId", localities.zoneId())
 				.detail("KillType", shutdownResult);

--- a/fdbserver/TLogServer.actor.cpp
+++ b/fdbserver/TLogServer.actor.cpp
@@ -1107,7 +1107,7 @@ ACTOR Future<Void> doQueueCommit( TLogData* self, Reference<LogData> logData ) {
 		logData->recoveryComplete.send(Void());
 	}
 
-	TraceEvent("TLogCommitDurable", self->dbgid).detail("Version", ver);
+	//TraceEvent("TLogCommitDurable", self->dbgid).detail("Version", ver);
 	if(logData->logSystem->get() && (!logData->isPrimary || logData->logRouterPoppedVersion < logData->logRouterPopToVersion)) {
 		logData->logRouterPoppedVersion = ver;
 		logData->logSystem->get()->pop(ver, logData->remoteTag, knownCommittedVersion, logData->locality);
@@ -1204,7 +1204,7 @@ ACTOR Future<Void> tLogCommit(
 		if(req.debugID.present())
 			g_traceBatch.addEvent("CommitDebug", tlogDebugID.get().first(), "TLog.tLogCommit.Before");
 
-		TraceEvent("TLogCommit", logData->logId).detail("Version", req.version);
+		//TraceEvent("TLogCommit", logData->logId).detail("Version", req.version);
 		commitMessages(logData, req.version, req.arena, req.messages, self->bytesInput);
 
 		logData->knownCommittedVersion = std::max(logData->knownCommittedVersion, req.knownCommittedVersion);

--- a/fdbserver/TagPartitionedLogSystem.actor.cpp
+++ b/fdbserver/TagPartitionedLogSystem.actor.cpp
@@ -843,7 +843,7 @@ struct TagPartitionedLogSystem : ILogSystem, ReferenceCounted<TagPartitionedLogS
 				last = to.first;
 			} catch (Error& e) {
 				if (e.code() == error_code_actor_cancelled) throw;
-				TraceEvent( (e.code() == error_code_broken_promise) ? SevInfo : SevError, "LogPopError", self->dbgid ).detail("Log", log->get().id()).error(e);
+				TraceEvent( (e.code() == error_code_broken_promise) ? SevInfo : SevError, "LogPopError", self->dbgid ).error(e).detail("Log", log->get().id());
 				return Void();  // Leaving outstandingPops filled in means no further pop requests to this tlog from this logSystem
 			}
 		}

--- a/fdbserver/VFSAsync.cpp
+++ b/fdbserver/VFSAsync.cpp
@@ -200,10 +200,10 @@ static int asyncSync(sqlite3_file *pFile, int flags){
 		return SQLITE_OK;
 	} catch (Error& e) {
 		TraceEvent("VFSSyncError")
+			.error(e)
 			.detail("Filename", p->filename)
 			.detail("Sqlite3File", (int64_t)pFile)
-			.detail("IAsyncFile", (int64_t)p->file.getPtr())
-			.error(e);
+			.detail("IAsyncFile", (int64_t)p->file.getPtr());
 		
 		return SQLITE_IOERR_FSYNC;
 	}
@@ -528,7 +528,7 @@ static int asyncOpen(
 			.detail("Sqlite3File", DEBUG_DETERMINISM ? 0 : (int64_t)pFile)
 			.detail("IAsyncFile", DEBUG_DETERMINISM ? 0 : (int64_t)p->file.getPtr());*/
 	} catch (Error& e) {
-		TraceEvent("SQLiteOpenFail").detail("Filename", p->filename).error(e);
+		TraceEvent("SQLiteOpenFail").error(e).detail("Filename", p->filename);
 		p->~VFSAsyncFile();
 		return SQLITE_CANTOPEN;
 	}
@@ -632,10 +632,10 @@ static int asyncFullPathname(
 		memcpy(zPathOut, s.c_str(), s.size()+1);
 		return SQLITE_OK;
 	} catch (Error& e) {
-		TraceEvent(SevError,"VFSAsyncFullPathnameError").detail("PathIn", (std::string)zPath).error(e);
+		TraceEvent(SevError,"VFSAsyncFullPathnameError").error(e).detail("PathIn", (std::string)zPath);
 		return SQLITE_IOERR;
 	} catch(...) {
-		TraceEvent(SevError,"VFSAsyncFullPathnameError").detail("PathIn", (std::string)zPath).error(unknown_error());
+		TraceEvent(SevError,"VFSAsyncFullPathnameError").error(unknown_error()).detail("PathIn", (std::string)zPath);
 		return SQLITE_IOERR;
 	}
 }

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -1455,7 +1455,7 @@ bool changeDurableVersion( StorageServer* data, Version desiredDurableVersion ) 
 	data->durableVersion.set( nextDurableVersion );
 	if (checkFatalError.isReady()) checkFatalError.get();
 
-	TraceEvent("ForgotVersionsBefore", data->thisServerID).detail("Version", nextDurableVersion);
+	//TraceEvent("ForgotVersionsBefore", data->thisServerID).detail("Version", nextDurableVersion);
 	validate(data);
 
 	return nextDurableVersion == desiredDurableVersion;
@@ -1898,7 +1898,7 @@ ACTOR Future<Void> fetchKeys( StorageServer *data, AddingShard* shard ) {
 
 				break;
 			} catch (Error& e) {
-				TraceEvent("FKBlockFail", data->thisServerID).detail("FKID", interval.pairID).error(e,true).suppressFor(1.0);
+				TraceEvent("FKBlockFail", data->thisServerID).error(e,true).suppressFor(1.0).detail("FKID", interval.pairID);
 				if (e.code() == error_code_transaction_too_old){
 					TEST(true); // A storage server has forgotten the history data we are fetching
 					Version lastFV = fetchVersion;
@@ -2638,7 +2638,7 @@ ACTOR Future<Void> updateStorage(StorageServer* data) {
 			Void _ = wait( yield(TaskUpdateStorage) );
 		}
 
-		TraceEvent("StorageServerDurable", data->thisServerID).detail("Version", newOldestVersion);
+		//TraceEvent("StorageServerDurable", data->thisServerID).detail("Version", newOldestVersion);
 
 		Void _ = wait( durableDelay );
 	}

--- a/fdbserver/worker.actor.cpp
+++ b/fdbserver/worker.actor.cpp
@@ -406,11 +406,11 @@ void startRole(UID roleId, UID workerId, std::string as, std::map<std::string, s
 void endRole(UID id, std::string as, std::string reason, bool ok, Error e) {
 	{
 		TraceEvent ev("Role", id);
+		if(e.code() != invalid_error_code)
+			ev.error(e, true);
 		ev.detail("Transition", "End")
 			.detail("As", as)
 			.detail("Reason", reason);
-		if(e.code() != invalid_error_code)
-			ev.error(e, true);
 
 		ev.trackLatest( (id.shortString() + ".Role").c_str() );
 	}
@@ -419,11 +419,10 @@ void endRole(UID id, std::string as, std::string reason, bool ok, Error e) {
 		std::string type = as + "Failed";
 
 		TraceEvent err(SevError, type.c_str(), id);
-		err.detail("Reason", reason);
-
 		if(e.code() != invalid_error_code) {
 			err.error(e, true);
 		}
+		err.detail("Reason", reason);
 	}
 
 	latestEventCache.clear( id.shortString() );

--- a/fdbserver/workloads/BackupCorrectness.actor.cpp
+++ b/fdbserver/workloads/BackupCorrectness.actor.cpp
@@ -156,7 +156,7 @@ struct BackupAndRestoreCorrectnessWorkload : TestWorkload {
 				Void _ = wait(backupAgent->abortBackup(cx, tag.toString()));
 			}
 			catch (Error& e) {
-				TraceEvent("BARW_DoBackupAbortBackupException", randomID).detail("Tag", printable(tag)).error(e);
+				TraceEvent("BARW_DoBackupAbortBackupException", randomID).error(e).detail("Tag", printable(tag));
 				if (e.code() != error_code_backup_unneeded)
 					throw;
 			}
@@ -171,7 +171,7 @@ struct BackupAndRestoreCorrectnessWorkload : TestWorkload {
 			Void _ = wait(backupAgent->submitBackup(cx, StringRef(backupContainer), g_random->randomInt(0, 100), tag.toString(), backupRanges, stopDifferentialDelay ? false : true));
 		}
 		catch (Error& e) {
-			TraceEvent("BARW_DoBackupSubmitBackupException", randomID).detail("Tag", printable(tag)).error(e);
+			TraceEvent("BARW_DoBackupSubmitBackupException", randomID).error(e).detail("Tag", printable(tag));
 			if (e.code() != error_code_backup_unneeded && e.code() != error_code_backup_duplicate)
 				throw;
 		}
@@ -244,7 +244,7 @@ struct BackupAndRestoreCorrectnessWorkload : TestWorkload {
 				}
 			}
 			catch (Error& e) {
-				TraceEvent("BARW_DoBackupDiscontinueBackupException", randomID).detail("Tag", printable(tag)).error(e);
+				TraceEvent("BARW_DoBackupDiscontinueBackupException", randomID).error(e).detail("Tag", printable(tag));
 				if (e.code() != error_code_backup_unneeded && e.code() != error_code_backup_duplicate)
 					throw;
 			}
@@ -359,7 +359,7 @@ struct BackupAndRestoreCorrectnessWorkload : TestWorkload {
 					extraBackup = backupAgent.submitBackup(cx, LiteralStringRef("file://simfdb/backups/"), g_random->randomInt(0, 100), self->backupTag.toString(), self->backupRanges, true);
 				}
 				catch (Error& e) {
-					TraceEvent("BARW_SubmitBackup2Exception", randomID).detail("BackupTag", printable(self->backupTag)).error(e);
+					TraceEvent("BARW_SubmitBackup2Exception", randomID).error(e).detail("BackupTag", printable(self->backupTag));
 					if (e.code() != error_code_backup_unneeded && e.code() != error_code_backup_duplicate)
 						throw;
 				}
@@ -423,7 +423,7 @@ struct BackupAndRestoreCorrectnessWorkload : TestWorkload {
 					Void _ = wait(extraBackup);
 				}
 				catch (Error& e) {
-					TraceEvent("BARW_ExtraBackupException", randomID).detail("BackupTag", printable(self->backupTag)).error(e);
+					TraceEvent("BARW_ExtraBackupException", randomID).error(e).detail("BackupTag", printable(self->backupTag));
 					if (e.code() != error_code_backup_unneeded && e.code() != error_code_backup_duplicate)
 						throw;
 				}

--- a/fdbserver/workloads/BackupToDBCorrectness.actor.cpp
+++ b/fdbserver/workloads/BackupToDBCorrectness.actor.cpp
@@ -215,7 +215,7 @@ struct BackupToDBCorrectnessWorkload : TestWorkload {
 				Void _ = wait(backupAgent->abortBackup(cx, tag));
 			}
 			catch (Error& e) {
-				TraceEvent("BARW_DoBackupAbortBackupException", randomID).detail("Tag", printable(tag)).error(e);
+				TraceEvent("BARW_DoBackupAbortBackupException", randomID).error(e).detail("Tag", printable(tag));
 				if (e.code() != error_code_backup_unneeded)
 					throw;
 			}
@@ -250,7 +250,7 @@ struct BackupToDBCorrectnessWorkload : TestWorkload {
 			}
 		}
 		catch (Error &e) {
-			TraceEvent("BARW_DoBackupSubmitBackupException", randomID).detail("Tag", printable(tag)).error(e);
+			TraceEvent("BARW_DoBackupSubmitBackupException", randomID).error(e).detail("Tag", printable(tag));
 			if (e.code() != error_code_backup_unneeded && e.code() != error_code_backup_duplicate) {
 				throw e;
 			}
@@ -294,7 +294,7 @@ struct BackupToDBCorrectnessWorkload : TestWorkload {
 				}
 			}
 			catch (Error& e) {
-				TraceEvent("BARW_DoBackupDiscontinueBackupException", randomID).detail("Tag", printable(tag)).error(e);
+				TraceEvent("BARW_DoBackupDiscontinueBackupException", randomID).error(e).detail("Tag", printable(tag));
 				if (e.code() != error_code_backup_unneeded && e.code() != error_code_backup_duplicate)
 					throw;
 			}
@@ -480,7 +480,7 @@ struct BackupToDBCorrectnessWorkload : TestWorkload {
 					extraBackup = backupAgent.submitBackup(self->extraDB, self->backupTag, self->backupRanges, true, self->extraPrefix, StringRef(), self->locked);
 				}
 				catch (Error& e) {
-					TraceEvent("BARW_SubmitBackup2Exception", randomID).detail("BackupTag", printable(self->backupTag)).error(e);
+					TraceEvent("BARW_SubmitBackup2Exception", randomID).error(e).detail("BackupTag", printable(self->backupTag));
 					if (e.code() != error_code_backup_unneeded && e.code() != error_code_backup_duplicate)
 						throw;
 				}
@@ -520,7 +520,7 @@ struct BackupToDBCorrectnessWorkload : TestWorkload {
 					Void _ = wait(restoreAgent.submitBackup(cx, self->restoreTag, restoreRange, true, StringRef(), self->backupPrefix, self->locked));
 				}
 				catch (Error& e) {
-					TraceEvent("BARW_DoBackupSubmitBackupException", randomID).detail("Tag", printable(self->restoreTag)).error(e);
+					TraceEvent("BARW_DoBackupSubmitBackupException", randomID).error(e).detail("Tag", printable(self->restoreTag));
 					if (e.code() != error_code_backup_unneeded && e.code() != error_code_backup_duplicate)
 						throw;
 				}
@@ -536,7 +536,7 @@ struct BackupToDBCorrectnessWorkload : TestWorkload {
 					Void _ = wait(extraBackup);
 				}
 				catch (Error& e) {
-					TraceEvent("BARW_ExtraBackupException", randomID).detail("BackupTag", printable(self->backupTag)).error(e);
+					TraceEvent("BARW_ExtraBackupException", randomID).error(e).detail("BackupTag", printable(self->backupTag));
 					if (e.code() != error_code_backup_unneeded && e.code() != error_code_backup_duplicate)
 						throw;
 				}

--- a/fdbserver/workloads/BackupToDBUpgrade.actor.cpp
+++ b/fdbserver/workloads/BackupToDBUpgrade.actor.cpp
@@ -121,7 +121,7 @@ struct BackupToDBUpgradeWorkload : TestWorkload {
 
 			TraceEvent("DRU_DoBackupInDifferentialMode").detail("Tag", printable(tag));
 		} catch (Error &e) {
-			TraceEvent("DRU_DoBackupSubmitBackupError").detail("Tag", printable(tag)).error(e);
+			TraceEvent("DRU_DoBackupSubmitBackupError").error(e).detail("Tag", printable(tag));
 			if (e.code() != error_code_backup_unneeded && e.code() != error_code_backup_duplicate) {
 				throw e;
 			}
@@ -441,7 +441,7 @@ struct BackupToDBUpgradeWorkload : TestWorkload {
 				Void _ = wait(restoreAgent.submitBackup(cx, self->restoreTag, restoreRanges, true, StringRef(), self->backupPrefix));
 			}
 			catch (Error& e) {
-				TraceEvent("DRU_RestoreSubmitBackupError").detail("Tag", printable(self->restoreTag)).error(e);
+				TraceEvent("DRU_RestoreSubmitBackupError").error(e).detail("Tag", printable(self->restoreTag));
 				if (e.code() != error_code_backup_unneeded && e.code() != error_code_backup_duplicate)
 					throw;
 			}

--- a/fdbserver/workloads/BulkSetup.actor.h
+++ b/fdbserver/workloads/BulkSetup.actor.h
@@ -49,7 +49,7 @@ Future<bool> checkRangeSimpleValueSize( Database cx, T* workload, uint64_t begin
 			Void _ = wait( success( first ) && success( last ) );
 			return first.get().present() && last.get().present();
 		} catch (Error& e) {
-			TraceEvent("CheckRangeError").detail("Begin", begin).detail("End", end).error(e);
+			TraceEvent("CheckRangeError").error(e).detail("Begin", begin).detail("End", end);
 			Void _ = wait( tr.onError(e) );
 		}
 	}

--- a/fdbserver/workloads/CommitBugCheck.actor.cpp
+++ b/fdbserver/workloads/CommitBugCheck.actor.cpp
@@ -160,7 +160,7 @@ struct CommitBugWorkload : TestWorkload
 					else {
 						TEST(true); //Commit conflict
 
-						TraceEvent("CommitBug2Error").detail("AttemptedNum", i+1).error(e);
+						TraceEvent("CommitBug2Error").error(e).detail("AttemptedNum", i+1);
 						Void _ = wait(tr.onError(e));
 					}
 				}

--- a/fdbserver/workloads/ConsistencyCheck.actor.cpp
+++ b/fdbserver/workloads/ConsistencyCheck.actor.cpp
@@ -228,7 +228,7 @@ struct ConsistencyCheckWorkload : TestWorkload
 					{
 						if(e.code() == error_code_attribute_not_found)
 						{
-							TraceEvent("ConsistencyCheck_StorageQueueSizeError").detail("Reason", "Could not read queue size").error(e);
+							TraceEvent("ConsistencyCheck_StorageQueueSizeError").error(e).detail("Reason", "Could not read queue size");
 
 							//This error occurs if we have undesirable servers; in that case just report the undesirable servers error
 							if(!hasUndesirableServers)
@@ -532,7 +532,7 @@ struct ConsistencyCheckWorkload : TestWorkload
 		}
 		catch(Error& e)
 		{
-			TraceEvent("ConsistencyCheck_ErrorFetchingMetrics").detail("Begin", printable(shard.begin)).detail("End", printable(shard.end)).error(e);
+			TraceEvent("ConsistencyCheck_ErrorFetchingMetrics").error(e).detail("Begin", printable(shard.begin)).detail("End", printable(shard.end));
 			estimatedBytes.clear();
 		}
 
@@ -843,8 +843,8 @@ struct ConsistencyCheckWorkload : TestWorkload
 							//If the data is not available and we aren't relocating this shard
 							else if(!isRelocating)
 							{
-								TraceEvent("ConsistencyCheck_StorageServerUnavailable").detail("StorageServer", storageServers[j]).detail("ShardBegin", printable(range.begin)).detail("ShardEnd", printable(range.end))
-									.detail("Address", storageServerInterfaces[j].address()).detail("GetKeyValuesToken", storageServerInterfaces[j].getKeyValues.getEndpoint().token).suppressFor(1.0);
+								TraceEvent("ConsistencyCheck_StorageServerUnavailable").suppressFor(1.0).detail("StorageServer", storageServers[j]).detail("ShardBegin", printable(range.begin)).detail("ShardEnd", printable(range.end))
+									.detail("Address", storageServerInterfaces[j].address()).detail("GetKeyValuesToken", storageServerInterfaces[j].getKeyValues.getEndpoint().token);
 
 								//All shards should be available in quiscence
 								if(self->performQuiescentChecks)
@@ -1107,7 +1107,7 @@ struct ConsistencyCheckWorkload : TestWorkload
 		for(itr = workers.begin(); itr != workers.end(); ++itr) {
 			ErrorOr<Standalone<VectorRef<UID>>> stores = wait(itr->first.diskStoreRequest.getReplyUnlessFailedFor(DiskStoreRequest(false), 2, 0));
 			if(stores.isError()) {
-				TraceEvent("ConsistencyCheck_GetDataStoreFailure").detail("Address", itr->first.address()).error(stores.getError());
+				TraceEvent("ConsistencyCheck_GetDataStoreFailure").error(stores.getError()).detail("Address", itr->first.address());
 				self->testFailure("Failed to get data stores");
 				return false;
 			}

--- a/fdbserver/workloads/Cycle.actor.cpp
+++ b/fdbserver/workloads/Cycle.actor.cpp
@@ -130,8 +130,7 @@ struct CycleWorkload : TestWorkload {
 				self->totalLatency += now() - tstart;
 			}
 		} catch (Error& e) {
-			if (e.code() != error_code_actor_cancelled)
-				TraceEvent(SevError, "CycleClient").error(e);
+			TraceEvent(SevError, "CycleClient").error(e);
 			throw;
 		}
 	}

--- a/fdbserver/workloads/FastTriggeredWatches.actor.cpp
+++ b/fdbserver/workloads/FastTriggeredWatches.actor.cpp
@@ -87,7 +87,7 @@ struct FastTriggeredWatchesWorkload : TestWorkload {
 				//TraceEvent("FTWSetEnd").detail("Key", printable(key)).detail("Value", printable(value)).detail("Ver", tr.getCommittedVersion());
 				return tr.getCommittedVersion();
 			} catch( Error &e ) {
-				//TraceEvent("FTWSetError").detail("Key", printable(key)).detail("Value", printable(value)).error(e);
+				//TraceEvent("FTWSetError").error(e).detail("Key", printable(key)).detail("Value", printable(value));
 				Void _ = wait( tr.onError(e) );
 			}
 		}
@@ -128,7 +128,7 @@ struct FastTriggeredWatchesWorkload : TestWorkload {
 						watchEnd = now();
 						first = false;
 					} catch( Error &e ) {
-						//TraceEvent("FTWWatchError").detail("Key", printable(setKey)).error(e);
+						//TraceEvent("FTWWatchError").error(e).detail("Key", printable(setKey));
 						Void _ = wait( tr.onError(e) );
 					}
 				}

--- a/fdbserver/workloads/FuzzApiCorrectness.actor.cpp
+++ b/fdbserver/workloads/FuzzApiCorrectness.actor.cpp
@@ -87,7 +87,7 @@ struct ExceptionContract {
 		for (auto i : expected) {
 			if (i.second == Always) {
 				TraceEvent evt(SevError, func.c_str());
-				evt.detail("Thrown", false).detail("Expected", "always").error(Error::fromUnvalidatedCode(i.first)).backtrace();
+				evt.error(Error::fromUnvalidatedCode(i.first)).detail("Thrown", false).detail("Expected", "always").backtrace();
 				if (augment)
 					augment(evt);
 			}

--- a/fdbserver/workloads/Increment.actor.cpp
+++ b/fdbserver/workloads/Increment.actor.cpp
@@ -104,8 +104,7 @@ struct Increment : TestWorkload {
 				self->totalLatency += now() - tstart;
 			}
 		} catch (Error& e) {
-			if (e.code() != error_code_actor_cancelled)
-				TraceEvent(SevError, "IncrementClient").error(e);
+			TraceEvent(SevError, "IncrementClient").error(e);
 			throw;
 		}
 	}

--- a/fdbserver/workloads/Performance.actor.cpp
+++ b/fdbserver/workloads/Performance.actor.cpp
@@ -169,7 +169,7 @@ struct PerformanceWorkload : TestWorkload {
 				DistributedTestResults r = wait( runWorkload( cx, self->testers, self->dbName, spec ) );
 				results = r;
 			} catch(Error& e) {
-				TraceEvent("PerformanceRunError").detail("Workload", printable(self->probeWorkload)).error(e, true);
+				TraceEvent("PerformanceRunError").error(e, true).detail("Workload", printable(self->probeWorkload));
 				break;
 			}
 			PerfMetric tpsMetric = self->getNamedMetric( "Transactions/sec", results.metrics );

--- a/fdbserver/workloads/Storefront.actor.cpp
+++ b/fdbserver/workloads/Storefront.actor.cpp
@@ -75,7 +75,7 @@ struct StorefrontWorkload : TestWorkload {
 		for(int c=0; c<clients.size(); c++)
 			if( clients[c].isError() ) {
 				errors++;
-				TraceEvent(SevError, "TestFailure").detail("Reason", "ClientError").error(clients[c].getError());
+				TraceEvent(SevError, "TestFailure").error(clients[c].getError()).detail("Reason", "ClientError");
 			}
 		clients.clear();
 		return inventoryCheck( cx->clone(), this, !errors );
@@ -173,8 +173,7 @@ struct StorefrontWorkload : TestWorkload {
 				self->totalLatency += now() - tstart;
 			}
 		} catch (Error& e) {
-			if (e.code() != error_code_actor_cancelled)
-				TraceEvent(SevError, "OrderingClient").error(e);
+			TraceEvent(SevError, "OrderingClient").error(e);
 			throw;
 		}
 	}

--- a/fdbserver/workloads/UnitTests.actor.cpp
+++ b/fdbserver/workloads/UnitTests.actor.cpp
@@ -100,9 +100,9 @@ struct UnitTestWorkload : TestWorkload {
 
 			auto test = *t;
 			TraceEvent(result.code() != error_code_success ? SevError : SevInfo, "UnitTest")
+				.error(result, true)
 				.detail("Name", test->name)
 				.detail("File", test->file).detail("Line", test->line)
-				.error(result, true)
 				.detail("WallTime", wallTime)
 				.detail("FlowTime", simTime);
 		}

--- a/fdbserver/workloads/VersionStamp.actor.cpp
+++ b/fdbserver/workloads/VersionStamp.actor.cpp
@@ -290,7 +290,7 @@ struct VersionStampWorkload : TestWorkload {
 						tr = ReadYourWritesTransaction(cx_is_primary ? cx : extraDB);
 						break;
 					} else if (err.code() == error_code_commit_unknown_result) {
-						//TraceEvent("VST_CommitUnknownResult").detail("Key", printable(key)).detail("VsKey", printable(versionStampKey)).error(e);
+						//TraceEvent("VST_CommitUnknownResult").error(e).detail("Key", printable(key)).detail("VsKey", printable(versionStampKey));
 						loop {
 							state ReadYourWritesTransaction cur_tr(cx_is_primary ? cx : extraDB);
 							cur_tr.setOption(FDBTransactionOptions::LOCK_AWARE);
@@ -326,7 +326,7 @@ struct VersionStampWorkload : TestWorkload {
 				}
 
 				if (error) {
-					TraceEvent("VST_CommitFailed").detail("Key", printable(key)).detail("VsKey", printable(versionStampKey)).error(err);
+					TraceEvent("VST_CommitFailed").error(err).detail("Key", printable(key)).detail("VsKey", printable(versionStampKey));
 					Void _ = wait(tr.onError(err));
 					continue;
 				}

--- a/fdbserver/workloads/Watches.actor.cpp
+++ b/fdbserver/workloads/Watches.actor.cpp
@@ -118,7 +118,7 @@ struct WatchesWorkload : TestWorkload {
 				extraLoc += 1000;
 				//TraceEvent("WatcherInitialSetup").detail("Watch", printable(watchKey)).detail("Ver", tr.getCommittedVersion());
 			} catch( Error &e ) {
-				//TraceEvent("WatcherInitialSetupError").detail("ExtraLoc", extraLoc).error(e);
+				//TraceEvent("WatcherInitialSetupError").error(e).detail("ExtraLoc", extraLoc);
 				Void _ = wait( tr.onError(e) );
 			}
 		}

--- a/flow/Error.cpp
+++ b/flow/Error.cpp
@@ -40,7 +40,7 @@ extern void flushTraceFileVoid();
 Error Error::fromUnvalidatedCode(int code) {
 	if (code < 0 || code > 30000) {
 		Error e = Error::fromCode(error_code_unknown_error);
-		TraceEvent(SevWarn, "ConvertedUnvalidatedErrorCode").detail("OriginalCode", code).error(e);
+		TraceEvent(SevWarn, "ConvertedUnvalidatedErrorCode").error(e).detail("OriginalCode", code);
 		return e;
 	}
 	else

--- a/flow/Net2.actor.cpp
+++ b/flow/Net2.actor.cpp
@@ -240,7 +240,7 @@ public:
 		try {
 			if (error) {
 				// Log the error...
-				TraceEvent(SevWarn, errContext, errID).detail("Message", error.value()).suppressFor(1.0);
+				TraceEvent(SevWarn, errContext, errID).suppressFor(1.0).detail("Message", error.value());
 				p.sendError( connection_failed() );
 			} else
 				p.send( Void() );
@@ -411,15 +411,15 @@ private:
 		boost::system::error_code error;
 		socket.close(error);
 		if (error)
-			TraceEvent(SevWarn, "N2_CloseError", id).detail("Message", error.value()).suppressFor(1.0);
+			TraceEvent(SevWarn, "N2_CloseError", id).suppressFor(1.0).detail("Message", error.value());
 	}
 
 	void onReadError( const boost::system::error_code& error ) {
-		TraceEvent(SevWarn, "N2_ReadError", id).detail("Message", error.value()).suppressFor(1.0);
+		TraceEvent(SevWarn, "N2_ReadError", id).suppressFor(1.0).detail("Message", error.value());
 		closeSocket();
 	}
 	void onWriteError( const boost::system::error_code& error ) {
-		TraceEvent(SevWarn, "N2_WriteError", id).detail("Message", error.value()).suppressFor(1.0);
+		TraceEvent(SevWarn, "N2_WriteError", id).suppressFor(1.0).detail("Message", error.value());
 		closeSocket();
 	}
 };
@@ -900,11 +900,11 @@ Reference<IListener> Net2::listen( NetworkAddress localAddr ) {
 			x = invalid_local_address();
 		else
 			x = bind_failed();
-		TraceEvent("Net2ListenError").detail("Message", e.what()).error(x);
+		TraceEvent("Net2ListenError").error(x).detail("Message", e.what());
 		throw x;
 	} catch (std::exception const& e) {
 		Error x = unknown_error();
-		TraceEvent("Net2ListenError").detail("Message", e.what()).error(x);
+		TraceEvent("Net2ListenError").error(x).detail("Message", e.what());
 		throw x;
 	} catch (...) {
 		Error x = unknown_error();

--- a/flow/Platform.cpp
+++ b/flow/Platform.cpp
@@ -1683,7 +1683,7 @@ void atomicReplace( std::string const& path, std::string const& content, bool te
 		INJECT_FAULT( io_error, "atomicReplace" );
 	}
 	catch(Error &e) {
-		TraceEvent(SevWarn, "AtomicReplace").detail("Path", path).error(e).GetLastError();
+		TraceEvent(SevWarn, "AtomicReplace").error(e).detail("Path", path).GetLastError();
 		if (f) fclose(f);
 		throw;
 	}

--- a/flow/Trace.h
+++ b/flow/Trace.h
@@ -186,7 +186,6 @@ private:
 	bool enabled;
 	std::string trackingKey;
 	TraceEventFields fields;
-	int length;
 	Severity severity;
 	const char *type;
 	UID id;

--- a/flow/genericactors.actor.h
+++ b/flow/genericactors.actor.h
@@ -41,7 +41,7 @@ Future<T> traceAfter(Future<T> what, const char* type, const char* key, X value,
 		TraceEvent(type).detail(key, value);
 		return val;
 	} catch( Error &e ) {
-		if(traceErrors) TraceEvent(type).detail(key, value).error(e,true);
+		if(traceErrors) TraceEvent(type).error(e,true).detail(key, value);
 		throw;
 	}
 }

--- a/flow/serialize.h
+++ b/flow/serialize.h
@@ -204,7 +204,7 @@ struct _IncludeVersion {
 		ar >> v;
 		if (v < minValidProtocolVersion) {
 			auto err = incompatible_protocol_version();
-			TraceEvent(SevError, "InvalidSerializationVersion").detailf("Version", "%llx", v).error(err);
+			TraceEvent(SevError, "InvalidSerializationVersion").error(err).detailf("Version", "%llx", v);
 			throw err;
 		}
 		if (v > currentProtocolVersion) {
@@ -212,7 +212,7 @@ struct _IncludeVersion {
 			// particular data structures (e.g. to support mismatches between client and server versions when the client
 			// must deserialize zookeeper and database structures)
 			auto err = incompatible_protocol_version();
-			TraceEvent(SevError, "FutureProtocolVersion").detailf("Version", "%llx", v).error(err);
+			TraceEvent(SevError, "FutureProtocolVersion").error(err).detailf("Version", "%llx", v);
 			throw err;
 		}
 		ar.setProtocolVersion(v);


### PR DESCRIPTION
Call all methods which could disable a trace event before it is initialized. In practice this means calling .error first, then .suppressFor, then all your details.

Fixed a bug where the trace event suppress backstop was counting events which were later suppressed through other mechanisms.