### PR TITLE
Go bindings release tag update

### DIFF
--- a/bindings/go/README.md
+++ b/bindings/go/README.md
@@ -6,16 +6,10 @@ fdb-go
 This package requires:
 
 - Go 1.1+ with CGO enabled
-- [Mono](http://www.mono-project.com/) (macOS or Windows) or [Visual Studio](https://www.visualstudio.com/) (Windows)  (build-time only)
-- FoundationDB C API 2.0.x, 3.0.x, or 4.x.y (part of the [FoundationDB clients package](https://apple.github.io/foundationdb/downloads.html#c))
+- [Mono](http://www.mono-project.com/) (macOS or Linux) or [Visual Studio](https://www.visualstudio.com/) (Windows)  (build-time only)
+- FoundationDB C API 2.0.x, 3.0.x, or 4.x.y (part of the [FoundationDB client packages](https://apple.github.io/foundationdb/downloads.html#c))
 
 Use of this package requires the selection of a FoundationDB API version at runtime. This package currently supports FoundationDB API versions 200-600.
-
-To build this package, in the top level of this repository run:
-
-    make fdb_go
-
-This will create binary packages for the appropriate platform within the "build" subdirectory of this folder.
 
 To install this package, you can run the "fdb-go-install.sh" script:
 
@@ -24,6 +18,13 @@ To install this package, you can run the "fdb-go-install.sh" script:
 The "install" command of this script does not depend on the presence of the repo in general and will download the repository into
 your local go path. Running "localinstall" instead of "install" will use the local copy here (with a symlink) instead
 of downloading from the remote repository.
+
+You can also build this package, in the top level of this repository run:
+
+    make fdb_go
+
+This will create binary packages for the appropriate platform within the "build" subdirectory of this folder.
+
 
 Documentation
 -------------

--- a/bindings/go/fdb-go-install.sh
+++ b/bindings/go/fdb-go-install.sh
@@ -210,18 +210,18 @@ else
             if [[ -d "${fdbdir}" ]] ; then
                 echo "Directory ${fdbdir} already exists ; checking out appropriate tag"
                 cmd1=( 'git' '-C' "${fdbdir}" 'fetch' 'origin' )
-                cmd2=( 'git' '-C' "${fdbdir}" 'checkout' "release-${FDBVER}" )
+                cmd2=( 'git' '-C' "${fdbdir}" 'checkout' "${FDBVER}" )
 
                 if ! echo "${cmd1[*]}" || ! "${cmd1[@]}" ; then
                     let status="${status} + 1"
                     echo "Could not pull latest changes from origin"
                 elif ! echo "${cmd2[*]}" ||  ! "${cmd2[@]}" ; then
                     let status="${status} + 1"
-                    echo "Could not checkout tag release-${FDBVER}."
+                    echo "Could not checkout tag ${FDBVER}."
                 fi
             else
                 echo "Downloading foundation repository into ${destdir}:"
-                cmd=( 'git' '-C' "${destdir}" 'clone' '--branch' "release-${FDBVER}" "https://${REMOTE}/${FDBREPO}.git" )
+                cmd=( 'git' '-C' "${destdir}" 'clone' '--branch' "${FDBVER}" "https://${REMOTE}/${FDBREPO}.git" )
 
                 echo "${cmd[*]}"
                 if ! "${cmd[@]}" ; then


### PR DESCRIPTION
Within the fdb-go-install script, we were using the old tag convention to try and check out a specific version of the repo. This switches to using the newer convention.

This also tweaks the README, which incorrectly stated you needed mono for Windows development (and also Visual Studio, which...), and it re-orders the information on building the script, which had previously suggested users use the Makefile first. (It's possible we should just delete that, tbh.)

This closes #714.