### PR TITLE
Fix certificate reloading issues

### DIFF
--- a/fdbrpc/TLSConnection.actor.cpp
+++ b/fdbrpc/TLSConnection.actor.cpp
@@ -309,7 +309,7 @@ void TLSOptions::register_network() {
 }
 
 ACTOR static Future<ErrorOr<Standalone<StringRef>>> readEntireFile( std::string filename ) {
-	state Reference<IAsyncFile> file = wait(IAsyncFileSystem::filesystem()->open(filename, IAsyncFile::OPEN_READONLY, 0));
+	state Reference<IAsyncFile> file = wait(IAsyncFileSystem::filesystem()->open(filename, IAsyncFile::OPEN_READONLY | IAsyncFile::OPEN_UNCACHED, 0));
 	state int64_t filesize = wait(file->size());
 	state Standalone<StringRef> buf = makeString(filesize);
 	int rc = wait(file->read(mutateString(buf), filesize, 0));

--- a/fdbrpc/TLSConnection.actor.cpp
+++ b/fdbrpc/TLSConnection.actor.cpp
@@ -349,6 +349,7 @@ ACTOR static Future<Void> reloadConfigurationOnChange( TLSOptions::PolicyInfo *p
 		}
 		wait(delay(1.0));
 	}
+	state int mismatches = 0;
 	state AsyncVar<Standalone<StringRef>> ca_var;
 	state AsyncVar<Standalone<StringRef>> key_var;
 	state AsyncVar<Standalone<StringRef>> cert_var;
@@ -405,11 +406,14 @@ ACTOR static Future<Void> reloadConfigurationOnChange( TLSOptions::PolicyInfo *p
 		}
 
 		if (rc) {
+			TraceEvent(SevInfo, "TLSCertificateRefreshSucceeded");
 			realVerifyPeersPolicy->set(verifypeers);
 			realNoVerifyPeersPolicy->set(noverifypeers);
+			mismatches = 0;
 		} else {
 			// Some files didn't match up, they should in the future, and we'll retry then.
-			TraceEvent(SevWarn, "TLSCertificateRefresh");
+			mismatches++;
+			TraceEvent(SevWarn, "TLSCertificateRefreshMismatch").detail("mismatches", mismatches);
 		}
 	}
 }


### PR DESCRIPTION
Of which two were raised:  certificates were required to be read-write, and there were FDBLibTLSOutOfMemory errors when certificates were actually reloaded.

The former is an easy fix of adding OPEN_UNCACHED.

The latter is an easy fix of actually initializing the cached copy of certificate data, which I had assumed were initialized anyway.  Oops.