### PR TITLE
Remove default version from fdb-go-install script

### DIFF
--- a/bindings/go/fdb-go-install.sh
+++ b/bindings/go/fdb-go-install.sh
@@ -129,7 +129,7 @@ function parseArgs() {
 
     if [[ -z "${FDBVER}" ]] ; then
         echo "No FoundationDB version specified!"
-        echo "Please provide a value to the --fdbver or set the FDBVER environment variable."
+        echo "Please supply a version by setting the --fdbver flag or the FDBVER environment variable."
         let status="${status} + 1"
     fi
 

--- a/bindings/go/fdb-go-install.sh
+++ b/bindings/go/fdb-go-install.sh
@@ -12,7 +12,7 @@
 #
 
 DESTDIR="${DESTDIR:-}"
-FDBVER="${FDBVER:-5.1.0}"
+FDBVER="${FDBVER:-}"
 REMOTE="${REMOTE:-github.com}"
 FDBREPO="${FDBREPO:-apple/foundationdb}"
 
@@ -68,10 +68,11 @@ function printUsage() {
     echo "     help            Print this help message and then quit"
     echo
     echo "Command Line Options:"
-    echo "     --fdbver <version>    FoundationDB semantic version (default is ${FDBVER})"
+    echo "     --fdbver <version>    FoundationDB semantic version to install or download (required if FDBVER environment variable is not set)"
     echo "     -d/--dest-dir <dest>  Local location for the repo (default is to place in go path)"
     echo
     echo "Environment Variable Options:"
+    echo "     FDBVER          Default FoundationDB semantic version to use if --fdbver flag is not set"
     echo "     REMOTE          Remote repository to download from (currently ${REMOTE})"
     echo "     FDBREPO         Repository of FoundationDB library to download (currently ${FDBREPO})"
     echo "     FDBLIBDIR       Directory within which should be the FoundationDB c library (currently ${FDBLIBDIR})"
@@ -125,6 +126,12 @@ function parseArgs() {
         esac
         shift
     done
+
+    if [[ -z "${FDBVER}" ]] ; then
+        echo "No FoundationDB version specified!"
+        echo "Please provide a value to the --fdbver or set the FDBVER environment variable."
+        let status="${status} + 1"
+    fi
 
     return "${status}"
 }


### PR DESCRIPTION
This requires the user to (somehow) specify the FoundationDB version to download. They can do it by either specifying the FDBVER environment variable or by passing an argument through the `--fdbver` command line flag. If they do both, then the command line flag is chosen.

Resolves: #732