### PR TITLE
docpreview_clean, which is part of our normal clean target, no longer…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -192,13 +192,16 @@ lib/libstdc++.a: $(shell $(CC) -print-file-name=libstdc++_pic.a)
 	@rm -r .libstdc++
 
 docpreview: javadoc
-	TARGETS= $(MAKE) -C documentation docpreview
+	@echo "Generating     docpreview"
+	@TARGETS= $(MAKE) -C documentation docpreview
 
 docpreview_clean:
-	CLEAN_TARGETS= $(MAKE) -C documentation docpreview_clean
+	@echo "Cleaning       docpreview"
+	@CLEAN_TARGETS= $(MAKE) -C documentation -s --no-print-directory docpreview_clean
 
 packages/foundationdb-docs-$(VERSION).tar.gz: FORCE javadoc
-	TARGETS= $(MAKE) -C documentation docpackage
+	@echo "Packaging      documentation"
+	@TARGETS= $(MAKE) -C documentation docpackage
 	@mkdir -p packages
 	@rm -f packages/foundationdb-docs-$(VERSION).tar.gz
 	@cp documentation/sphinx/.dist/foundationdb-docs-$(VERSION).tar.gz packages/foundationdb-docs-$(VERSION).tar.gz


### PR DESCRIPTION
… prints extra messages. Tried to make a couple other documentation related targets nicer as well.