### PR TITLE
Update API version in godocs example from 200 to 520.

### DIFF
--- a/bindings/go/src/fdb/doc.go
+++ b/bindings/go/src/fdb/doc.go
@@ -46,7 +46,7 @@ A basic interaction with the FoundationDB API is demonstrated below:
 
     func main() {
         // Different API versions may expose different runtime behaviors.
-        fdb.MustAPIVersion(200)
+        fdb.MustAPIVersion(520)
 
         // Open the default database from the system cluster
         db := fdb.MustOpenDefault()


### PR DESCRIPTION
I don't think any code changes are required to the example to support the new version.