### PR TITLE
Default to -O3 for an optimized build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,9 @@ ACTORCOMPILER := bin/actorcompiler.exe
 # UNSTRIPPED := 1
 
 # Normal optimization level
-CFLAGS += -O2
+# ipa-cp-clone causes incorrect generated code for serializing LocalityData.
+# See https://github.com/apple/foundationdb/issues/657
+CFLAGS += -O3 -fno-ipa-cp-clone
 
 # Or turn off optimization entirely
 # CFLAGS += -O0


### PR DESCRIPTION
I ran a couple performance tests (a bandwidth test and a latency test) and didn't see any change.

I've been running with this patch in correctness for quite some time now, and haven't found anything else that looks like a crash, so I'm under the belief that it's safe to land.

Related issue: #657