### PR TITLE
Optimize truncate calls

### DIFF
--- a/fdbrpc/AsyncFileCached.actor.cpp
+++ b/fdbrpc/AsyncFileCached.actor.cpp
@@ -20,11 +20,12 @@
 
 #include "AsyncFileCached.actor.h"
 
-//Page caches used in non-simulated environments
+// Page caches used in non-simulated environments
 Optional<Reference<EvictablePageCache>> pc4k, pc64k;
 
-//The simulator needs to store separate page caches for each machine
-static std::map<NetworkAddress, std::pair<Reference<EvictablePageCache>, Reference<EvictablePageCache>>> simulatorPageCaches;
+// The simulator needs to store separate page caches for each machine
+static std::map<NetworkAddress, std::pair<Reference<EvictablePageCache>, Reference<EvictablePageCache>>>
+    simulatorPageCaches;
 
 EvictablePage::~EvictablePage() {
 	if (data) {
@@ -40,34 +41,37 @@ EvictablePage::~EvictablePage() {
 	}
 }
 
-std::map< std::string, OpenFileInfo > AsyncFileCached::openFiles;
+std::map<std::string, OpenFileInfo> AsyncFileCached::openFiles;
 
-void AsyncFileCached::remove_page( AFCPage* page ) {
-	pages.erase( page->pageOffset );
+void AsyncFileCached::remove_page(AFCPage* page) {
+	pages.erase(page->pageOffset);
 }
 
-Future<Reference<IAsyncFile>> AsyncFileCached::open_impl( std::string filename, int flags, int mode ) {
+Future<Reference<IAsyncFile>> AsyncFileCached::open_impl(std::string filename, int flags, int mode) {
 	Reference<EvictablePageCache> pageCache;
 
-	//In a simulated environment, each machine needs its own caches
-	if(g_network->isSimulated()) {
+	// In a simulated environment, each machine needs its own caches
+	if (g_network->isSimulated()) {
 		auto cacheItr = simulatorPageCaches.find(g_network->getLocalAddress());
-		if(cacheItr == simulatorPageCaches.end()) {
+		if (cacheItr == simulatorPageCaches.end()) {
 			int64_t pageCacheSize4k = (BUGGIFY) ? FLOW_KNOBS->BUGGIFY_SIM_PAGE_CACHE_4K : FLOW_KNOBS->SIM_PAGE_CACHE_4K;
-			int64_t pageCacheSize64k = (BUGGIFY) ? FLOW_KNOBS->BUGGIFY_SIM_PAGE_CACHE_64K : FLOW_KNOBS->SIM_PAGE_CACHE_64K;
-			auto caches = std::make_pair(Reference<EvictablePageCache>(new EvictablePageCache(4096, pageCacheSize4k)), Reference<EvictablePageCache>(new EvictablePageCache(65536, pageCacheSize64k)));
+			int64_t pageCacheSize64k =
+			    (BUGGIFY) ? FLOW_KNOBS->BUGGIFY_SIM_PAGE_CACHE_64K : FLOW_KNOBS->SIM_PAGE_CACHE_64K;
+			auto caches =
+			    std::make_pair(Reference<EvictablePageCache>(new EvictablePageCache(4096, pageCacheSize4k)),
+			                   Reference<EvictablePageCache>(new EvictablePageCache(65536, pageCacheSize64k)));
 			simulatorPageCaches[g_network->getLocalAddress()] = caches;
 			pageCache = (flags & IAsyncFile::OPEN_LARGE_PAGES) ? caches.second : caches.first;
-		}
-		else
+		} else
 			pageCache = (flags & IAsyncFile::OPEN_LARGE_PAGES) ? cacheItr->second.second : cacheItr->second.first;
-	}
-	else {
-		if(flags & IAsyncFile::OPEN_LARGE_PAGES) {
-			if(!pc64k.present()) pc64k = Reference<EvictablePageCache>(new EvictablePageCache(65536, FLOW_KNOBS->PAGE_CACHE_64K));
+	} else {
+		if (flags & IAsyncFile::OPEN_LARGE_PAGES) {
+			if (!pc64k.present())
+				pc64k = Reference<EvictablePageCache>(new EvictablePageCache(65536, FLOW_KNOBS->PAGE_CACHE_64K));
 			pageCache = pc64k.get();
 		} else {
-			if(!pc4k.present()) pc4k = Reference<EvictablePageCache>(new EvictablePageCache(4096, FLOW_KNOBS->PAGE_CACHE_4K));
+			if (!pc4k.present())
+				pc4k = Reference<EvictablePageCache>(new EvictablePageCache(4096, FLOW_KNOBS->PAGE_CACHE_4K));
 			pageCache = pc4k.get();
 		}
 	}
@@ -75,10 +79,10 @@ Future<Reference<IAsyncFile>> AsyncFileCached::open_impl( std::string filename, 
 	return open_impl(filename, flags, mode, pageCache);
 }
 
-Future<Void> AsyncFileCached::read_write_impl( AsyncFileCached* self, void* data, int length, int64_t offset, bool writing ) {
+Future<Void> AsyncFileCached::read_write_impl(AsyncFileCached* self, void* data, int length, int64_t offset,
+                                              bool writing) {
 	if (writing) {
-		if (offset + length > self->length)
-			self->length = offset + length;
+		if (offset + length > self->length) self->length = offset + length;
 	}
 
 	std::vector<Future<Void>> actors;
@@ -93,19 +97,17 @@ Future<Void> AsyncFileCached::read_write_impl( AsyncFileCached* self, void* data
 	while (remaining) {
 		++self->countFileCacheFinds;
 		++self->countCacheFinds;
-		auto p = self->pages.find( pageOffset );
-		if ( p == self->pages.end() ) {
-			AFCPage* page = new AFCPage( self, pageOffset );
-			p = self->pages.insert( std::make_pair(pageOffset, page) ).first;
+		auto p = self->pages.find(pageOffset);
+		if (p == self->pages.end()) {
+			AFCPage* page = new AFCPage(self, pageOffset);
+			p = self->pages.insert(std::make_pair(pageOffset, page)).first;
 		}
 
 		int bytesInPage = std::min(self->pageCache->pageSize - offsetInPage, remaining);
 
-		auto w = writing
-			? p->second->write( cdata, bytesInPage, offsetInPage )
-			: p->second->read( cdata, bytesInPage, offsetInPage );
-		if (!w.isReady() || w.isError())
-			actors.push_back( w );
+		auto w = writing ? p->second->write(cdata, bytesInPage, offsetInPage)
+		                 : p->second->read(cdata, bytesInPage, offsetInPage);
+		if (!w.isReady() || w.isError()) actors.push_back(w);
 
 		cdata += bytesInPage;
 		pageOffset += self->pageCache->pageSize;
@@ -114,48 +116,49 @@ Future<Void> AsyncFileCached::read_write_impl( AsyncFileCached* self, void* data
 		remaining -= bytesInPage;
 	}
 
-	//This is susceptible to the introduction of waits on the read/write path: no wait can occur prior to AFCPage::readThrough
-	//or prevLength will be set prematurely
+	// This is susceptible to the introduction of waits on the read/write path: no wait can occur prior to
+	// AFCPage::readThrough or prevLength will be set prematurely
 	self->prevLength = self->length;
 
-	return waitForAll( actors );
+	return waitForAll(actors);
 }
 
-Future<Void> AsyncFileCached::readZeroCopy( void** data, int* length, int64_t offset ) {
+Future<Void> AsyncFileCached::readZeroCopy(void** data, int* length, int64_t offset) {
 	++countFileCacheReads;
 	++countCacheReads;
 
 	// Only aligned page reads are zero-copy
-	if (*length != pageCache->pageSize || (offset & (pageCache->pageSize-1)) || offset + *length > this->length)
+	if (*length != pageCache->pageSize || (offset & (pageCache->pageSize - 1)) || offset + *length > this->length)
 		return io_error();
 
-	auto p = pages.find( offset );
-	if ( p == pages.end() ) {
-		AFCPage* page = new AFCPage( this, offset );
-		p = pages.insert( std::make_pair(offset, page) ).first;
+	auto p = pages.find(offset);
+	if (p == pages.end()) {
+		AFCPage* page = new AFCPage(this, offset);
+		p = pages.insert(std::make_pair(offset, page)).first;
 	}
 
 	*data = p->second->data;
 
 	return p->second->readZeroCopy();
 }
-void AsyncFileCached::releaseZeroCopy( void* data, int length, int64_t offset ) {
-	ASSERT( length == pageCache->pageSize && !(offset & (pageCache->pageSize-1)) && offset + length <= this->length);
-	auto p = pages.find( offset );
-	ASSERT( p != pages.end() && p->second->data == data );
+void AsyncFileCached::releaseZeroCopy(void* data, int length, int64_t offset) {
+	ASSERT(length == pageCache->pageSize && !(offset & (pageCache->pageSize - 1)) && offset + length <= this->length);
+	auto p = pages.find(offset);
+	ASSERT(p != pages.end() && p->second->data == data);
 	p->second->releaseZeroCopy();
 }
 
-Future<Void> AsyncFileCached::truncate( int64_t size ) {
+Future<Void> AsyncFileCached::truncate(int64_t size) {
 	++countFileCacheWrites;
 	++countCacheWrites;
 
 	std::vector<Future<Void>> actors;
+	auto oldLength = length;
 
 	int offsetInPage = size % pageCache->pageSize;
 	int64_t pageOffset = size - offsetInPage;
 
-	if(offsetInPage == 0 && size == length) {
+	if (offsetInPage == 0 && size == length) {
 		return Void();
 	}
 
@@ -167,36 +170,49 @@ Future<Void> AsyncFileCached::truncate( int64_t size ) {
 		auto p = pages.find(pageOffset);
 		if (p != pages.end()) {
 			auto f = p->second->flush();
-			if (!f.isReady() || f.isError())
-				actors.push_back(f);
-		}
-		else {
+			if (!f.isReady() || f.isError()) actors.push_back(f);
+		} else {
 			TEST(true); // Truncating to the middle of a page that isn't in cache
 		}
 
 		pageOffset += pageCache->pageSize;
 	}
-	/*
-	for ( auto p = pages.lower_bound( pageOffset ); p != pages.end(); p = pages.erase(p) ) {
-		auto f = p->second->truncate();
-		if ( !f.isReady() || f.isError())
-			actors.push_back( f );
-	}
-	*/
 
-	for ( auto p = pages.begin(); p != pages.end(); ) {
-		if ( p->first >= pageOffset ) {
-			auto f = p->second->truncate();
-			if ( !f.isReady() || f.isError() )
-				actors.push_back( f );
-			auto last = p;
-			++p;
-			pages.erase(last);
-		} else
-			++p;
+	// if this call to truncate results in a larger file, there is no
+	// need to erase any pages
+	if (oldLength > pageOffset) {
+		// iterating through all pages results in better cache locality than
+		// looking up pages one by one in the hash table. However, if we only
+		// need to truncate a small portion of data, looking up pages one by one
+		// should be faster. So for now we do single key lookup for each page
+		// if it results in less than 10% of the unordered map being accessed.
+		unsigned numLookups = (oldLength - pageOffset) / pageCache->pageSize;
+		if (numLookups < pages.size() / 10) {
+			for (size_t offset = pageOffset; offset <= oldLength; offset += pageCache->pageSize) {
+				auto iter = pages.find(offset);
+				if (iter != pages.end()) {
+					auto f = iter->second->truncate();
+					if (!f.isReady() || f.isError()) {
+						actors.push_back(f);
+					}
+					pages.erase(iter);
+				}
+			}
+		} else {
+			for (auto p = pages.begin(); p != pages.end();) {
+				if (p->first >= pageOffset) {
+					auto f = p->second->truncate();
+					if (!f.isReady() || f.isError()) actors.push_back(f);
+					auto last = p;
+					++p;
+					pages.erase(last);
+				} else
+					++p;
+			}
+		}
 	}
 
-	return truncate_impl( this, size, waitForAll( actors ) );
+	return truncate_impl(this, size, waitForAll(actors));
 }
 
 Future<Void> AsyncFileCached::flush() {
@@ -206,14 +222,14 @@ Future<Void> AsyncFileCached::flush() {
 	std::vector<Future<Void>> unflushed;
 
 	int debug_count = flushable.size();
-	for(int i=0; i<flushable.size(); ) {
+	for (int i = 0; i < flushable.size();) {
 		auto p = flushable[i];
 		auto f = p->flush();
-		if (!f.isReady() || f.isError()) unflushed.push_back( f );
-		ASSERT( (i<flushable.size() && flushable[i] == p) != f.isReady() );
+		if (!f.isReady() || f.isError()) unflushed.push_back(f);
+		ASSERT((i < flushable.size() && flushable[i] == p) != f.isReady());
 		if (!f.isReady()) i++;
 	}
-	ASSERT( flushable.size() <= debug_count );
+	ASSERT(flushable.size() <= debug_count);
 
 	return waitForAll(unflushed);
 }
@@ -221,19 +237,19 @@ Future<Void> AsyncFileCached::flush() {
 Future<Void> AsyncFileCached::quiesce() {
 	std::vector<Future<Void>> unquiescent;
 
-	for( auto i = pages.begin(); i != pages.end(); ++i ) {
+	for (auto i = pages.begin(); i != pages.end(); ++i) {
 		auto f = i->second->quiesce();
-		if( !f.isReady() ) unquiescent.push_back( f );
+		if (!f.isReady()) unquiescent.push_back(f);
 	}
-	
-	//Errors are absorbed because we need everything to finish
+
+	// Errors are absorbed because we need everything to finish
 	return waitForAllReady(unquiescent);
 }
 
 AsyncFileCached::~AsyncFileCached() {
-	while ( !pages.empty() ) {
+	while (!pages.empty()) {
 		auto ok = pages.begin()->second->evict();
-		ASSERT_ABORT( ok );
+		ASSERT_ABORT(ok);
 	}
-	openFiles.erase( filename );
+	openFiles.erase(filename);
 }


### PR DESCRIPTION
A call to truncate currently iterates through the
whole page list. This is very inefficient, especially
if truncate only affects a small portion of the file.

This fix will take into account truncate calls that
make the file larger (in which case it simply skips
the cache invalidation part) or calls that make a file
smaller only by a few pages. In the later case, we
look up all affected pages in the hash table.