### PR TITLE
Fix: status was trying to read a metric under the wrong name, leading…

### DIFF
--- a/documentation/sphinx/source/release-notes.rst
+++ b/documentation/sphinx/source/release-notes.rst
@@ -69,7 +69,7 @@ Fixes only impacting 6.0.0+
 * The transaction logs would leak memory when serving peek requests to log routers. [6.0.12] `(PR #801) <https://github.com/apple/foundationdb/pull/801>`_
 * The transaction logs were doing a lot of unnecessary disk writes. [6.0.12] `(PR #784) <https://github.com/apple/foundationdb/pull/784>`_
 * The master will recover the transaction state store from local transaction logs if possible. [6.0.12] `(PR #801) <https://github.com/apple/foundationdb/pull/801>`_
-* A bug in status collection led to various workload metrics being missing and the cluster reporting unhealthy. [6.0.13] `(PR #X) <>`_
+* A bug in status collection led to various workload metrics being missing and the cluster reporting unhealthy. [6.0.13] `(PR #834) <https://github.com/apple/foundationdb/pull/834>`_
 
 Status
 ------

--- a/documentation/sphinx/source/release-notes.rst
+++ b/documentation/sphinx/source/release-notes.rst
@@ -5,14 +5,6 @@ Release Notes
 6.0.13
 ======
 
-Fixes
------
-
-* Python bindings didn't work with Python 3.7 because of new `async` keyword. `(Issue #830) <https://github.com/apple/foundationdb/issues/830>`_
-
-6.0.12
-======
-
 Features
 --------
 
@@ -77,6 +69,7 @@ Fixes only impacting 6.0.0+
 * The transaction logs would leak memory when serving peek requests to log routers. [6.0.12] `(PR #801) <https://github.com/apple/foundationdb/pull/801>`_
 * The transaction logs were doing a lot of unnecessary disk writes. [6.0.12] `(PR #784) <https://github.com/apple/foundationdb/pull/784>`_
 * The master will recover the transaction state store from local transaction logs if possible. [6.0.12] `(PR #801) <https://github.com/apple/foundationdb/pull/801>`_
+* A bug in status collection led to various workload metrics being missing and the cluster reporting unhealthy. [6.0.13] `(PR #X) <>`_
 
 Status
 ------
@@ -94,6 +87,8 @@ Bindings
 * C API calls made on the network thread could be reordered with calls made from other threads. [6.0.2] `(Issue #518) <https://github.com/apple/foundationdb/issues/518>`_
 * The TLS_PLUGIN option is now a no-op and has been deprecated. [6.0.10] `(PR #710) <https://github.com/apple/foundationdb/pull/710>`_
 * Java: the `Versionstamp::getUserVersion() </javadoc/com/apple/foundationdb/tuple/Versionstamp.html#getUserVersion-->`_ method did not handle user versions greater than ``0x00FF`` due to operator precedence errors. [6.0.11] `(Issue #761) <https://github.com/apple/foundationdb/issues/761>`_
+* Python bindings didn't work with Python 3.7 because of the new `async` keyword. [6.0.13] `(Issue #830) <https://github.com/apple/foundationdb/issues/830>`_
+
 
 Other Changes
 -------------

--- a/fdbserver/Status.actor.cpp
+++ b/fdbserver/Status.actor.cpp
@@ -414,7 +414,7 @@ struct RolesInfo {
 			obj["input_bytes"] = StatusCounter(metrics.getValue("BytesInput")).getStatus();
 			obj["durable_bytes"] = StatusCounter(metrics.getValue("BytesDurable")).getStatus();
 			obj.setKeyRawNumber("query_queue_max", metrics.getValue("QueryQueueMax"));
-			obj["total_queries"] = StatusCounter(metrics.getValue("AllQueries")).getStatus();
+			obj["total_queries"] = StatusCounter(metrics.getValue("QueryQueue")).getStatus();
 			obj["finished_queries"] = StatusCounter(metrics.getValue("FinishedQueries")).getStatus();
 			obj["bytes_queried"] = StatusCounter(metrics.getValue("BytesQueried")).getStatus();
 			obj["keys_queried"] = StatusCounter(metrics.getValue("RowsQueried")).getStatus();
@@ -1398,7 +1398,7 @@ ACTOR static Future<JsonBuilderObject> workloadStatusFetcher(Reference<AsyncVar<
 		StatusCounter readBytes;
 
 		for(auto &ss : storageServers.get()) {
-			readRequests.updateValues( StatusCounter(ss.second.getValue("AllQueries")));
+			readRequests.updateValues( StatusCounter(ss.second.getValue("QueryQueue")));
 			reads.updateValues( StatusCounter(ss.second.getValue("FinishedQueries")));
 			readKeys.updateValues( StatusCounter(ss.second.getValue("RowsQueried")));
 			readBytes.updateValues( StatusCounter(ss.second.getValue("BytesQueried")));


### PR DESCRIPTION
… to an error that caused the cluster to report itself unhealthy and some metrics to be missing.