### PR TITLE
Fix docs for three_datacenter mode

### DIFF
--- a/documentation/sphinx/source/configuration.rst
+++ b/documentation/sphinx/source/configuration.rst
@@ -369,7 +369,7 @@ In addition to the more commonly used modes listed above, this version of Founda
 ``three_datacenter`` mode
     *(for 5+ machines in 3 datacenters)*
 
-    FoundationDB attempts to replicate data across two datacenters and will stay up with only two available. Data is triple replicated.  For maximum availability, you should use five coordination servers: two in two of the datacenters and one in the third datacenter.
+    FoundationDB attempts to replicate data across three datacenters and will stay up with only two available. Data is replicated 6 times.  For maximum availability, you should use five coordination servers: two in two of the datacenters and one in the third datacenter.
 
 Changing redundancy mode
 ------------------------


### PR DESCRIPTION
According to fdbclient/ManagementAPI.actor.cpp, the three_datacenter mode has a redundancy/replication factor of 6, and distributes the replicas across 3 datacenters and 2 zones within each datacenter.