### PR TITLE
Backup improvements

### DIFF
--- a/fdbbackup/backup.actor.cpp
+++ b/fdbbackup/backup.actor.cpp
@@ -1463,7 +1463,7 @@ ACTOR Future<Void> submitBackup(Database db, std::string url, int snapshotInterv
 			// Wait for the backup to complete, if requested
 			if (waitForCompletion) {
 				printf("Submitted and now waiting for the backup on tag `%s' to complete.\n", printable(StringRef(tagName)).c_str());
-				int _ = wait(backupAgent.waitBackup(db, tagName));
+				wait(success(backupAgent.waitBackup(db, tagName)));
 			}
 			else {
 				// Check if a backup agent is running
@@ -1642,10 +1642,10 @@ ACTOR Future<Void> waitBackup(Database db, std::string tagName, bool stopWhenDon
 	{
 		state FileBackupAgent backupAgent;
 
-		int status = wait(backupAgent.waitBackup(db, tagName, stopWhenDone));
+		EBackupState status = wait(backupAgent.waitBackup(db, tagName, stopWhenDone));
 
 		printf("The backup on tag `%s' %s.\n", printable(StringRef(tagName)).c_str(),
-			BackupAgentBase::getStateText((BackupAgentBase::enumState) status));
+			BackupAgentBase::getStateText(status));
 	}
 	catch (Error& e) {
 		if(e.code() == error_code_actor_cancelled)
@@ -1667,7 +1667,7 @@ ACTOR Future<Void> discontinueBackup(Database db, std::string tagName, bool wait
 		// Wait for the backup to complete, if requested
 		if (waitForCompletion) {
 			printf("Discontinued and now waiting for the backup on tag `%s' to complete.\n", printable(StringRef(tagName)).c_str());
-			int _ = wait(backupAgent.waitBackup(db, tagName));
+			wait(success(backupAgent.waitBackup(db, tagName)));
 		}
 		else {
 			printf("The backup on tag `%s' was successfully discontinued.\n", printable(StringRef(tagName)).c_str());

--- a/fdbclient/BackupAgent.h
+++ b/fdbclient/BackupAgent.h
@@ -191,6 +191,8 @@ protected:
 	static const std::string defaultTagName;
 };
 
+typedef BackupAgentBase::enumState EBackupState;
+
 class FileBackupAgent : public BackupAgentBase {
 public:
 	FileBackupAgent();
@@ -276,7 +278,7 @@ public:
 
 	// stopWhenDone will return when the backup is stopped, if enabled. Otherwise, it
 	// will return when the backup directory is restorable.
-	Future<int> waitBackup(Database cx, std::string tagName, bool stopWhenDone = true);
+	Future<EBackupState> waitBackup(Database cx, std::string tagName, bool stopWhenDone = true);
 
 	static const Key keyLastRestorable;
 
@@ -435,7 +437,6 @@ Future<Void> readCommitted(Database const& cx, PromiseStream<RangeResultWithVers
 Future<Void> readCommitted(Database const& cx, PromiseStream<RCGroup> const& results, Future<Void> const& active, Reference<FlowLock> const& lock, KeyRangeRef const& range, std::function< std::pair<uint64_t, uint32_t>(Key key) > const& groupBy, bool const& terminator = true, bool const& systemAccess = false, bool const& lockAware = false);
 Future<Void> applyMutations(Database const& cx, Key const& uid, Key const& addPrefix, Key const& removePrefix, Version const& beginVersion, Version* const& endVersion, RequestStream<CommitTransactionRequest> const& commit, NotifiedVersion* const& committedVersion, Reference<KeyRangeMap<Version>> const& keyVersion);
 
-typedef BackupAgentBase::enumState EBackupState;
 template<> inline Tuple Codec<EBackupState>::pack(EBackupState const &val) { return Tuple().append(val); }
 template<> inline EBackupState Codec<EBackupState>::unpack(Tuple const &val) { return (EBackupState)val.getInt(0); }
 

--- a/fdbclient/TaskBucket.actor.cpp
+++ b/fdbclient/TaskBucket.actor.cpp
@@ -591,7 +591,7 @@ public:
 
 				bool is_busy = wait(isBusy(tr, taskBucket));
 				if (!is_busy) {
-					Key _ = wait(addIdle(tr, taskBucket));
+					wait(success(addIdle(tr, taskBucket)));
 				}
 
 				Optional<Value> val = wait(tr->get(taskBucket->active.key()));

--- a/fdbserver/workloads/AtomicRestore.actor.cpp
+++ b/fdbserver/workloads/AtomicRestore.actor.cpp
@@ -74,7 +74,7 @@ struct AtomicRestoreWorkload : TestWorkload {
 		}
 
 		TraceEvent("AtomicRestore_Wait");
-		int _ = wait( backupAgent.waitBackup(cx, BackupAgentBase::getDefaultTagName(), false) );
+		wait( success( backupAgent.waitBackup(cx, BackupAgentBase::getDefaultTagName(), false) ) );
 		TraceEvent("AtomicRestore_BackupStart");
 		wait( delay(self->restoreAfter * g_random->random01()) );
 		TraceEvent("AtomicRestore_RestoreStart");

--- a/fdbserver/workloads/BackupCorrectness.actor.cpp
+++ b/fdbserver/workloads/BackupCorrectness.actor.cpp
@@ -215,7 +215,7 @@ struct BackupAndRestoreCorrectnessWorkload : TestWorkload {
 								}
 								else {
 									// Update status code, break if no longer runnable
-									wait(store(statusCode, BackupConfig(logUid).stateEnum().getD(cx, false, EBackupState::STATE_ABORTED)));
+									wait(store(BackupConfig(logUid).stateEnum().getD(cx, false, EBackupState::STATE_ABORTED), statusCode));
 
 									if(!backupAgent->isRunnable(statusCode)) {
 										TEST(true);


### PR DESCRIPTION
Backup correctness tests will sometimes run until 3 snapshots are completed, some logging improvements, and cleaned up some wait statements using the new no-return syntax.