### PR TITLE
TeamCollection: Use machine team to create server team

### DIFF
--- a/fdbrpc/Locality.h
+++ b/fdbrpc/Locality.h
@@ -160,10 +160,13 @@ public:
 
 	std::string describeZone() const { return describeValue(keyZoneId); }
 	std::string describeDataHall() const { return describeValue(keyDataHallId); }
+	std::string describeDcId() const { return describeValue(keyDcId); }
+	std::string describeMachineId() const { return describeValue(keyMachineId); }
+	std::string describeProcessId() const { return describeValue(keyProcessId); }
 
 	Optional<Standalone<StringRef>> processId() const { return get(keyProcessId); }
 	Optional<Standalone<StringRef>> zoneId() const { return get(keyZoneId); }
-	Optional<Standalone<StringRef>> machineId() const { return get(keyMachineId); }
+	Optional<Standalone<StringRef>> machineId() const { return get(keyMachineId); } //default is ""
 	Optional<Standalone<StringRef>> dcId() const { return get(keyDcId); }
 	Optional<Standalone<StringRef>> dataHallId() const { return get(keyDataHallId); }
 

--- a/fdbrpc/Locality.h
+++ b/fdbrpc/Locality.h
@@ -166,7 +166,7 @@ public:
 
 	Optional<Standalone<StringRef>> processId() const { return get(keyProcessId); }
 	Optional<Standalone<StringRef>> zoneId() const { return get(keyZoneId); }
-	Optional<Standalone<StringRef>> machineId() const { return get(keyMachineId); } //default is ""
+	Optional<Standalone<StringRef>> machineId() const { return get(keyMachineId); } // default is ""
 	Optional<Standalone<StringRef>> dcId() const { return get(keyDcId); }
 	Optional<Standalone<StringRef>> dataHallId() const { return get(keyDataHallId); }
 

--- a/fdbrpc/Replication.h
+++ b/fdbrpc/Replication.h
@@ -102,6 +102,11 @@ public:
 		return _localitygroup->getRecord(getEntry(localIndex)._id);
 	}
 
+	// Return record array to help debug the locality information for servers
+	virtual std::vector<Reference<LocalityRecord>> const& getRecordArray() const {
+		return _localitygroup->getRecordArray();
+	}
+
 	Reference<LocalityRecord> const& getRecordViaEntry(LocalityEntry localEntry) const {
 		return _localitygroup->getRecord(localEntry._id);
 	}
@@ -167,6 +172,8 @@ public:
 
 	// This function is used to create an subset containing all of the entries within
 	// the specified value for the given key
+	// The returned LocalitySet contains the LocalityRecords that have the same value as
+	// the indexValue under the same indexKey (e.g., zoneid)
 	LocalitySetRef restrict(AttribKey indexKey, AttribValue indexValue ) {
 		LocalitySetRef	localitySet;
 		LocalityCacheRecord			searchRecord(AttribRecord(indexKey, indexValue), localitySet);
@@ -497,6 +504,7 @@ struct LocalityGroup : public LocalitySet {
 	virtual ~LocalityGroup() { }
 
 	LocalityEntry const& add(LocalityData const& data) {
+		// _recordArray.size() is the new entry index for the new data
 		Reference<LocalityRecord>	record(new LocalityRecord(convertToAttribMap(data), _recordArray.size()));
 		_recordArray.push_back(record);
 		return LocalitySet::add(record, *this);
@@ -525,6 +533,11 @@ struct LocalityGroup : public LocalitySet {
 	virtual Reference<LocalityRecord> const& getRecord(int recordIndex) const {
 		ASSERT((recordIndex >= 0) && (recordIndex < _recordArray.size()));
 		return _recordArray[recordIndex];
+	}
+
+	// Get the locality info for debug purpose
+	virtual std::vector<Reference<LocalityRecord>> const& getRecordArray() const {
+		return _recordArray;
 	}
 
 	virtual int	getMemoryUsed() const {

--- a/fdbrpc/Replication.h
+++ b/fdbrpc/Replication.h
@@ -536,9 +536,7 @@ struct LocalityGroup : public LocalitySet {
 	}
 
 	// Get the locality info for debug purpose
-	virtual std::vector<Reference<LocalityRecord>> const& getRecordArray() const {
-		return _recordArray;
-	}
+	virtual std::vector<Reference<LocalityRecord>> const& getRecordArray() const { return _recordArray; }
 
 	virtual int	getMemoryUsed() const {
 		int memorySize = sizeof(_recordArray) + _keymap->getMemoryUsed();

--- a/fdbrpc/ReplicationPolicy.cpp
+++ b/fdbrpc/ReplicationPolicy.cpp
@@ -147,15 +147,55 @@ PolicyAcross::~PolicyAcross()
 	return;
 }
 
+/**
+ * Debug purpose only
+ * Trace all record entries to help debug
+ * @param fromServers the servers' locality to be printed out.
+ */
+void IReplicationPolicy::traceLocalityRecords(LocalitySetRef const& fromServers)
+{
+	std::vector<Reference<LocalityRecord>> const& recordArray = fromServers->getRecordArray();
+	TraceEvent("LocalityRecordArray").detail("Size", recordArray.size());
+	for ( auto &record : recordArray ) {
+		traceOneLocalityRecord(record, fromServers);
+	}
+}
+
+void IReplicationPolicy::traceOneLocalityRecord(Reference<LocalityRecord> record, LocalitySetRef const& fromServers) {
+	int localityEntryIndex = record->_entryIndex._id;
+	Reference<KeyValueMap> const& dataMap = record->_dataMap;
+	std::vector<AttribRecord> const& keyValueArray = dataMap->_keyvaluearray;
+
+	TraceEvent("LocalityRecordInfo").detail("EntryIndex", localityEntryIndex)
+			.detail("KeyValueArraySize", keyValueArray.size());
+	for ( int i = 0; i < keyValueArray.size(); ++i ) {
+		AttribRecord attribRecord = keyValueArray[i]; //first is key, second is value
+		TraceEvent("LocalityRecordInfo").detail("EntryIndex", localityEntryIndex)
+				.detail("ArrayIndex", i)
+				.detail("Key", attribRecord.first._id)
+				.detail("Value", attribRecord.second._id)
+				.detail("KeyName", fromServers->keyText(attribRecord.first))
+				.detail("ValueName", fromServers->valueText(attribRecord.second));
+	}
+}
+
+/**
+ * Validate if the team satisfies the replication policy
+ * LocalitySet is the base class about the locality information
+ * @param solutionSet: the team to be validated
+ * @param fromServers: the location information of all servers
+ * @return true if the team satisfies the policy; false otherwise
+ */
 bool PolicyAcross::validate(
 		std::vector<LocalityEntry>	const&	solutionSet,
 		LocalitySetRef const&				fromServers ) const
 {
 	bool			valid = true;
 	int				count = 0;
-	AttribKey	indexKey = fromServers->keyIndex(_attribKey);
+	AttribKey	indexKey = fromServers->keyIndex(_attribKey); // The indexKey from the policy name (e.g., zoneid) in _attribKey
 	auto			groupIndexKey = fromServers->getGroupKeyIndex(indexKey);
 	std::map<AttribValue, std::vector<LocalityEntry>>	validMap;
+
 	for (auto& item : solutionSet) {
 		auto value = fromServers->getValueViaGroupKey(item, groupIndexKey);
 		if (value.present()) {
@@ -182,9 +222,11 @@ bool PolicyAcross::validate(
 			}
 		}
 		for (auto& itValid : validMap) {
-			if (_policy->validate(itValid.second, fromServers)) {
+			//MX: Q: why do we need to validate the itValid again? What is the logic behind this?
+			if (_policy->validate(itValid.second, fromServers)) { //itValid.second is the vector of LocalityEntries that belong to the same locality
 				if (g_replicationdebug > 4) {
-					printf("Across valid solution: %6lu key: %-7s count:%3d of%3d value: (%3d) %-10s policy: %-10s => %s\n", itValid.second.size(), _attribKey.c_str(), count+1, _count, itValid.first._id, fromServers->valueText(itValid.first).c_str(), _policy->name().c_str(), _policy->info().c_str());
+					printf("Across valid solution: %6lu key: %-7s count:%3d of%3d value: (%3d) %-10s policy: %-10s => %s\n",
+							itValid.second.size(), _attribKey.c_str(), count+1, _count, itValid.first._id, fromServers->valueText(itValid.first).c_str(), _policy->name().c_str(), _policy->info().c_str());
 					if (g_replicationdebug > 5) {
 						for (auto& entry : itValid.second) {
 							printf("   entry: %s\n", fromServers->getEntryInfo(entry).c_str());
@@ -215,6 +257,11 @@ bool PolicyAcross::validate(
 	return valid;
 }
 
+/*
+ * Choose new servers from "least utilized" alsoServers and append the new servers to results
+ * fromserverse are the servers that have already been chosen. fromServers is the set of servers that should be excluded from being selected as replicas.
+ * FIXME: Simplify this function, such as removing unnecessary printf
+ */
 bool PolicyAcross::selectReplicas(
 	LocalitySetRef	&						fromServers,
 	std::vector<LocalityEntry> const&		alsoServers,
@@ -239,11 +286,15 @@ bool PolicyAcross::selectReplicas(
 		if (value.present()) {
 			auto lowerBound = std::lower_bound(_usedValues.begin(), _usedValues.end(), value.get());
 			if ((lowerBound == _usedValues.end()) || (*lowerBound != value.get())) {
+				//_selected is a set of processes that have the same indexKey and indexValue (value)
 				_selected = fromServers->restrict(indexKey, value.get());
 				if (_selected->size()) {
 					// Pass only the also array item which are valid for the value
 					if (g_replicationdebug > 5) {
-						printf("Across !select    key: %-7s value: (%3d) %-10s entry: %s\n", _attribKey.c_str(), value.get()._id, fromServers->valueText(value.get()).c_str(), fromServers->getEntryInfo(alsoServer).c_str());
+						printf("Across !select    key: %-7s value: (%3d) %-10s entry: %s\n", _attribKey.c_str(),
+								value.get()._id, fromServers->valueText(value.get()).c_str(),
+								//Get the locality entry info (entryValue) from the to-be-selected team member alsoServer
+								fromServers->getEntryInfo(alsoServer).c_str());
 					}
 					resultsSize = _newResults.size();
 					if (_policy->selectReplicas(_selected, alsoServers, _newResults))
@@ -256,7 +307,10 @@ bool PolicyAcross::selectReplicas(
 							_addedResults.push_back(_arena, std::pair<int, int>(resultsAdded, resultsSize));
 						}
 						if (g_replicationdebug > 5) {
-							printf("Across !added:%3d key: %-7s count:%3d of%3d value: (%3d) %-10s entry: %s\n", resultsAdded, _attribKey.c_str(), count, _count, value.get()._id, fromServers->valueText(value.get()).c_str(), fromServers->getEntryInfo(alsoServer).c_str());
+							printf("Across !added:%3d key: %-7s count:%3d of%3d value: (%3d) %-10s entry: %s\n",
+									resultsAdded, _attribKey.c_str(), count, _count,
+									value.get()._id, fromServers->valueText(value.get()).c_str(),
+									fromServers->getEntryInfo(alsoServer).c_str());
 						}
 						if (count >= _count) break;
 						_usedValues.insert(lowerBound, value.get());
@@ -308,6 +362,7 @@ bool PolicyAcross::selectReplicas(
 		}
 	}
 
+	// Cannot find replica from the least used alsoServers, now try to find replicas from all servers
 	// Process the remaining values
 	if (count < _count) {
 		if (g_replicationdebug > 3) {
@@ -329,12 +384,17 @@ bool PolicyAcross::selectReplicas(
 					_selected = fromServers->restrict(indexKey, value.get());
 					if (_selected->size()) {
 						if (g_replicationdebug > 5) {
-							printf("Across select:%3d key: %-7s value: (%3d) %-10s entry: %s  index:%4d\n", fromServers->size()-checksLeft+1, _attribKey.c_str(), value.get()._id, fromServers->valueText(value.get()).c_str(), fromServers->getEntryInfo(entry).c_str(), recordIndex);
+							printf("Across select:%3d key: %-7s value: (%3d) %-10s entry: %s  index:%4d\n",
+									fromServers->size()-checksLeft+1, _attribKey.c_str(), value.get()._id,
+									fromServers->valueText(value.get()).c_str(), fromServers->getEntryInfo(entry).c_str(), recordIndex);
 						}
 						if (_policy->selectReplicas(_selected, emptyEntryArray, results))
 						{
 							if (g_replicationdebug > 5) {
-								printf("Across added:%4d key: %-7s value: (%3d) %-10s policy: %-10s => %s  needed:%3d\n", count+1, _attribKey.c_str(), value.get()._id, fromServers->valueText(value.get()).c_str(), _policy->name().c_str(), _policy->info().c_str(), _count);
+								printf("Across added:%4d key: %-7s value: (%3d) %-10s policy: %-10s => %s  needed:%3d\n",
+										count+1, _attribKey.c_str(),
+										value.get()._id, fromServers->valueText(value.get()).c_str(),
+										_policy->name().c_str(), _policy->info().c_str(), _count);
 							}
 							count ++;
 							if (count >= _count) break;

--- a/fdbrpc/ReplicationPolicy.cpp
+++ b/fdbrpc/ReplicationPolicy.cpp
@@ -222,6 +222,7 @@ bool PolicyAcross::validate(
 			}
 		}
 		for (auto& itValid : validMap) {
+			//MXX: remove this question.
 			//MX: Q: why do we need to validate the itValid again? What is the logic behind this?
 			if (_policy->validate(itValid.second, fromServers)) { //itValid.second is the vector of LocalityEntries that belong to the same locality
 				if (g_replicationdebug > 4) {
@@ -259,7 +260,7 @@ bool PolicyAcross::validate(
 
 /*
  * Choose new servers from "least utilized" alsoServers and append the new servers to results
- * fromserverse are the servers that have already been chosen. fromServers is the set of servers that should be excluded from being selected as replicas.
+ * fromserverse are the servers that have already been chosen and that should be excluded from being selected as replicas.
  * FIXME: Simplify this function, such as removing unnecessary printf
  */
 bool PolicyAcross::selectReplicas(

--- a/fdbrpc/ReplicationPolicy.cpp
+++ b/fdbrpc/ReplicationPolicy.cpp
@@ -147,11 +147,9 @@ PolicyAcross::~PolicyAcross()
 	return;
 }
 
-/**
- * Debug purpose only
- * Trace all record entries to help debug
- * @param fromServers the servers' locality to be printed out.
- */
+// Debug purpose only
+// Trace all record entries to help debug
+// fromServers is the servers locality to be printed out.
 void IReplicationPolicy::traceLocalityRecords(LocalitySetRef const& fromServers)
 {
 	std::vector<Reference<LocalityRecord>> const& recordArray = fromServers->getRecordArray();
@@ -179,13 +177,11 @@ void IReplicationPolicy::traceOneLocalityRecord(Reference<LocalityRecord> record
 	}
 }
 
-/**
- * Validate if the team satisfies the replication policy
- * LocalitySet is the base class about the locality information
- * @param solutionSet: the team to be validated
- * @param fromServers: the location information of all servers
- * @return true if the team satisfies the policy; false otherwise
- */
+// Validate if the team satisfies the replication policy
+// LocalitySet is the base class about the locality information
+// solutionSet is the team to be validated
+// fromServers is the location information of all servers
+// return true if the team satisfies the policy; false otherwise
 bool PolicyAcross::validate(
 		std::vector<LocalityEntry>	const&	solutionSet,
 		LocalitySetRef const&				fromServers ) const
@@ -222,8 +218,6 @@ bool PolicyAcross::validate(
 			}
 		}
 		for (auto& itValid : validMap) {
-			//MXX: remove this question.
-			//MX: Q: why do we need to validate the itValid again? What is the logic behind this?
 			if (_policy->validate(itValid.second, fromServers)) { //itValid.second is the vector of LocalityEntries that belong to the same locality
 				if (g_replicationdebug > 4) {
 					printf("Across valid solution: %6lu key: %-7s count:%3d of%3d value: (%3d) %-10s policy: %-10s => %s\n",
@@ -258,11 +252,10 @@ bool PolicyAcross::validate(
 	return valid;
 }
 
-/*
- * Choose new servers from "least utilized" alsoServers and append the new servers to results
- * fromserverse are the servers that have already been chosen and that should be excluded from being selected as replicas.
- * FIXME: Simplify this function, such as removing unnecessary printf
- */
+
+// Choose new servers from "least utilized" alsoServers and append the new servers to results
+// fromserverse are the servers that have already been chosen and that should be excluded from being selected as replicas.
+// FIXME: Simplify this function, such as removing unnecessary printf
 bool PolicyAcross::selectReplicas(
 	LocalitySetRef	&						fromServers,
 	std::vector<LocalityEntry> const&		alsoServers,

--- a/fdbrpc/ReplicationPolicy.cpp
+++ b/fdbrpc/ReplicationPolicy.cpp
@@ -150,11 +150,10 @@ PolicyAcross::~PolicyAcross()
 // Debug purpose only
 // Trace all record entries to help debug
 // fromServers is the servers locality to be printed out.
-void IReplicationPolicy::traceLocalityRecords(LocalitySetRef const& fromServers)
-{
+void IReplicationPolicy::traceLocalityRecords(LocalitySetRef const& fromServers) {
 	std::vector<Reference<LocalityRecord>> const& recordArray = fromServers->getRecordArray();
 	TraceEvent("LocalityRecordArray").detail("Size", recordArray.size());
-	for ( auto &record : recordArray ) {
+	for (auto& record : recordArray) {
 		traceOneLocalityRecord(record, fromServers);
 	}
 }
@@ -164,16 +163,18 @@ void IReplicationPolicy::traceOneLocalityRecord(Reference<LocalityRecord> record
 	Reference<KeyValueMap> const& dataMap = record->_dataMap;
 	std::vector<AttribRecord> const& keyValueArray = dataMap->_keyvaluearray;
 
-	TraceEvent("LocalityRecordInfo").detail("EntryIndex", localityEntryIndex)
-			.detail("KeyValueArraySize", keyValueArray.size());
-	for ( int i = 0; i < keyValueArray.size(); ++i ) {
-		AttribRecord attribRecord = keyValueArray[i]; //first is key, second is value
-		TraceEvent("LocalityRecordInfo").detail("EntryIndex", localityEntryIndex)
-				.detail("ArrayIndex", i)
-				.detail("Key", attribRecord.first._id)
-				.detail("Value", attribRecord.second._id)
-				.detail("KeyName", fromServers->keyText(attribRecord.first))
-				.detail("ValueName", fromServers->valueText(attribRecord.second));
+	TraceEvent("LocalityRecordInfo")
+	    .detail("EntryIndex", localityEntryIndex)
+	    .detail("KeyValueArraySize", keyValueArray.size());
+	for (int i = 0; i < keyValueArray.size(); ++i) {
+		AttribRecord attribRecord = keyValueArray[i]; // first is key, second is value
+		TraceEvent("LocalityRecordInfo")
+		    .detail("EntryIndex", localityEntryIndex)
+		    .detail("ArrayIndex", i)
+		    .detail("Key", attribRecord.first._id)
+		    .detail("Value", attribRecord.second._id)
+		    .detail("KeyName", fromServers->keyText(attribRecord.first))
+		    .detail("ValueName", fromServers->valueText(attribRecord.second));
 	}
 }
 
@@ -188,7 +189,8 @@ bool PolicyAcross::validate(
 {
 	bool			valid = true;
 	int				count = 0;
-	AttribKey	indexKey = fromServers->keyIndex(_attribKey); // The indexKey from the policy name (e.g., zoneid) in _attribKey
+	// Get the indexKey from the policy name (e.g., zoneid) in _attribKey
+	AttribKey indexKey = fromServers->keyIndex(_attribKey);
 	auto			groupIndexKey = fromServers->getGroupKeyIndex(indexKey);
 	std::map<AttribValue, std::vector<LocalityEntry>>	validMap;
 
@@ -218,10 +220,14 @@ bool PolicyAcross::validate(
 			}
 		}
 		for (auto& itValid : validMap) {
-			if (_policy->validate(itValid.second, fromServers)) { //itValid.second is the vector of LocalityEntries that belong to the same locality
+			// itValid.second is the vector of LocalityEntries that belong to the same locality
+			if (_policy->validate(itValid.second, fromServers)) {
 				if (g_replicationdebug > 4) {
-					printf("Across valid solution: %6lu key: %-7s count:%3d of%3d value: (%3d) %-10s policy: %-10s => %s\n",
-							itValid.second.size(), _attribKey.c_str(), count+1, _count, itValid.first._id, fromServers->valueText(itValid.first).c_str(), _policy->name().c_str(), _policy->info().c_str());
+					printf("Across valid solution: %6lu key: %-7s count:%3d of%3d value: (%3d) %-10s policy: %-10s => "
+					       "%s\n",
+					       itValid.second.size(), _attribKey.c_str(), count + 1, _count, itValid.first._id,
+					       fromServers->valueText(itValid.first).c_str(), _policy->name().c_str(),
+					       _policy->info().c_str());
 					if (g_replicationdebug > 5) {
 						for (auto& entry : itValid.second) {
 							printf("   entry: %s\n", fromServers->getEntryInfo(entry).c_str());
@@ -229,8 +235,7 @@ bool PolicyAcross::validate(
 					}
 				}
 				count ++;
-			}
-			else if (g_replicationdebug > 4) {
+			} else if (g_replicationdebug > 4) {
 				printf("Across invalid solution:%5lu key: %-7s value: (%3d) %-10s policy: %-10s => %s\n", itValid.second.size(), _attribKey.c_str(), itValid.first._id, fromServers->valueText(itValid.first).c_str(), _policy->name().c_str(), _policy->info().c_str());
 				if (g_replicationdebug > 5) {
 					for (auto& entry : itValid.second) {
@@ -252,9 +257,9 @@ bool PolicyAcross::validate(
 	return valid;
 }
 
-
 // Choose new servers from "least utilized" alsoServers and append the new servers to results
-// fromserverse are the servers that have already been chosen and that should be excluded from being selected as replicas.
+// fromserverse are the servers that have already been chosen and
+// that should be excluded from being selected as replicas.
 // FIXME: Simplify this function, such as removing unnecessary printf
 bool PolicyAcross::selectReplicas(
 	LocalitySetRef	&						fromServers,
@@ -285,9 +290,9 @@ bool PolicyAcross::selectReplicas(
 				if (_selected->size()) {
 					// Pass only the also array item which are valid for the value
 					if (g_replicationdebug > 5) {
-						printf("Across !select    key: %-7s value: (%3d) %-10s entry: %s\n", _attribKey.c_str(),
-								value.get()._id, fromServers->valueText(value.get()).c_str(),
-								//Get the locality entry info (entryValue) from the to-be-selected team member alsoServer
+						// entry is the locality entry info (entryValue) from the to-be-selected team member alsoServer
+						printf("Across !select    key: %-7s value: (%3d) %-10s entry: %s\n",
+								_attribKey.c_str(), value.get()._id, fromServers->valueText(value.get()).c_str(),
 								fromServers->getEntryInfo(alsoServer).c_str());
 					}
 					resultsSize = _newResults.size();
@@ -302,9 +307,9 @@ bool PolicyAcross::selectReplicas(
 						}
 						if (g_replicationdebug > 5) {
 							printf("Across !added:%3d key: %-7s count:%3d of%3d value: (%3d) %-10s entry: %s\n",
-									resultsAdded, _attribKey.c_str(), count, _count,
-									value.get()._id, fromServers->valueText(value.get()).c_str(),
-									fromServers->getEntryInfo(alsoServer).c_str());
+							       resultsAdded, _attribKey.c_str(), count, _count, value.get()._id,
+							       fromServers->valueText(value.get()).c_str(),
+							       fromServers->getEntryInfo(alsoServer).c_str());
 						}
 						if (count >= _count) break;
 						_usedValues.insert(lowerBound, value.get());
@@ -379,16 +384,17 @@ bool PolicyAcross::selectReplicas(
 					if (_selected->size()) {
 						if (g_replicationdebug > 5) {
 							printf("Across select:%3d key: %-7s value: (%3d) %-10s entry: %s  index:%4d\n",
-									fromServers->size()-checksLeft+1, _attribKey.c_str(), value.get()._id,
-									fromServers->valueText(value.get()).c_str(), fromServers->getEntryInfo(entry).c_str(), recordIndex);
+							       fromServers->size() - checksLeft + 1, _attribKey.c_str(), value.get()._id,
+							       fromServers->valueText(value.get()).c_str(),
+							       fromServers->getEntryInfo(entry).c_str(), recordIndex);
 						}
 						if (_policy->selectReplicas(_selected, emptyEntryArray, results))
 						{
 							if (g_replicationdebug > 5) {
-								printf("Across added:%4d key: %-7s value: (%3d) %-10s policy: %-10s => %s  needed:%3d\n",
-										count+1, _attribKey.c_str(),
-										value.get()._id, fromServers->valueText(value.get()).c_str(),
-										_policy->name().c_str(), _policy->info().c_str(), _count);
+								printf("Across added:%4d key: %-7s value: (%3d) %-10s policy: %-10s => %s needed:%3d\n",
+								    count + 1, _attribKey.c_str(), value.get()._id,
+								    fromServers->valueText(value.get()).c_str(), _policy->name().c_str(),
+								    _policy->info().c_str(), _count);
 							}
 							count ++;
 							if (count >= _count) break;

--- a/fdbrpc/ReplicationPolicy.h
+++ b/fdbrpc/ReplicationPolicy.h
@@ -43,6 +43,9 @@ struct IReplicationPolicy : public ReferenceCounted<IReplicationPolicy> {
 			LocalitySetRef &										fromServers,
 			std::vector<LocalityEntry> const&		alsoServers,
 			std::vector<LocalityEntry>	&				results ) = 0;
+		virtual void traceLocalityRecords(LocalitySetRef const& fromServers);
+		virtual void traceOneLocalityRecord(Reference<LocalityRecord> record,
+											LocalitySetRef const& fromServers);
 		virtual bool validate(
 			std::vector<LocalityEntry>	const&	solutionSet,
 			LocalitySetRef const&								fromServers ) const = 0;

--- a/fdbrpc/ReplicationPolicy.h
+++ b/fdbrpc/ReplicationPolicy.h
@@ -44,8 +44,7 @@ struct IReplicationPolicy : public ReferenceCounted<IReplicationPolicy> {
 			std::vector<LocalityEntry> const&		alsoServers,
 			std::vector<LocalityEntry>	&				results ) = 0;
 		virtual void traceLocalityRecords(LocalitySetRef const& fromServers);
-		virtual void traceOneLocalityRecord(Reference<LocalityRecord> record,
-											LocalitySetRef const& fromServers);
+		virtual void traceOneLocalityRecord(Reference<LocalityRecord> record, LocalitySetRef const& fromServers);
 		virtual bool validate(
 			std::vector<LocalityEntry>	const&	solutionSet,
 			LocalitySetRef const&								fromServers ) const = 0;

--- a/fdbrpc/ReplicationTypes.h
+++ b/fdbrpc/ReplicationTypes.h
@@ -140,6 +140,19 @@ struct LocalityRecord : public ReferenceCounted<LocalityRecord> {
 	int	getMemoryUsed() const {
 		return sizeof(_entryIndex) + sizeof(_dataMap) + _dataMap->getMemoryUsed();
 	}
+
+	std::string toString() {
+		std::string str = "KeyValueArraySize:" + _dataMap->_keyvaluearray.size();
+		for ( int i = 0; i < _dataMap->size(); ++i ) {
+			AttribRecord attribRecord = _dataMap->_keyvaluearray[i]; //first is key, second is value
+			str = str + " KeyValueArrayIndex:" + std::to_string(i)
+					+ " Key:" + std::to_string(attribRecord.first._id)
+					+ " Value:" + std::to_string(attribRecord.second._id);
+		}
+
+		return str;
+	}
+
 };
 
 // This class stores the information for string to integer map for keys and values

--- a/fdbrpc/ReplicationTypes.h
+++ b/fdbrpc/ReplicationTypes.h
@@ -145,7 +145,7 @@ struct LocalityRecord : public ReferenceCounted<LocalityRecord> {
 		std::string str = "KeyValueArraySize:" + _dataMap->_keyvaluearray.size();
 		for ( int i = 0; i < _dataMap->size(); ++i ) {
 			AttribRecord attribRecord = _dataMap->_keyvaluearray[i]; //first is key, second is value
-			str = str + " KeyValueArrayIndex:" + std::to_string(i)
+			str += " KeyValueArrayIndex:" + std::to_string(i)
 					+ " Key:" + std::to_string(attribRecord.first._id)
 					+ " Value:" + std::to_string(attribRecord.second._id);
 		}

--- a/fdbrpc/ReplicationTypes.h
+++ b/fdbrpc/ReplicationTypes.h
@@ -143,16 +143,14 @@ struct LocalityRecord : public ReferenceCounted<LocalityRecord> {
 
 	std::string toString() {
 		std::string str = "KeyValueArraySize:" + _dataMap->_keyvaluearray.size();
-		for ( int i = 0; i < _dataMap->size(); ++i ) {
-			AttribRecord attribRecord = _dataMap->_keyvaluearray[i]; //first is key, second is value
-			str += " KeyValueArrayIndex:" + std::to_string(i)
-					+ " Key:" + std::to_string(attribRecord.first._id)
-					+ " Value:" + std::to_string(attribRecord.second._id);
+		for (int i = 0; i < _dataMap->size(); ++i) {
+			AttribRecord attribRecord = _dataMap->_keyvaluearray[i]; // first is key, second is value
+			str += " KeyValueArrayIndex:" + std::to_string(i) + " Key:" + std::to_string(attribRecord.first._id) +
+			       " Value:" + std::to_string(attribRecord.second._id);
 		}
 
 		return str;
 	}
-
 };
 
 // This class stores the information for string to integer map for keys and values

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -1077,8 +1077,8 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 	// The empty team is used as the starting point to move data to the remote DB
 	// begin : the start of the team member ID
 	// end : end of the team member ID
-	// isIntialTeam : False when the team is added by addTeamsBestOf();
-	// 	              True otherwise, e.g., when the team added at init() when we recreate teams by looking up DB
+	// isIntialTeam : False when the team is added by addTeamsBestOf(); True otherwise, e.g.,
+	// when the team added at init() when we recreate teams by looking up DB
 	template <class InputIt>
 	void addTeam(InputIt begin, InputIt end, bool isInitialTeam) {
 		vector<Reference<TCServerInfo>> newTeamServers;
@@ -1388,14 +1388,8 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 
 		machineTeamsToBuild = targetMachineTeamsToBuild;
 
-		if (machine_info.size() < configuration.storageTeamSize) {
-			TraceEvent(SevWarn, "DataDistributionBuildMachineTeams", masterId)
-			    .suppressFor(10)
-			    .detail("Reason", "Not enough machines for a team. Machine number should be larger than Team size")
-			    .detail("MachineNumber", machine_info.size())
-			    .detail("TeamSize", configuration.storageTeamSize);
-			return addedMachineTeams;
-		}
+		// The number of machines is always no smaller than the storageTeamSize in a correct configuration
+		ASSERT(machine_info.size() >= configuration.storageTeamSize);
 
 		// Step 1: Create machineLocalityMap which will be used in building machine team
 		rebuildMachineLocalityMap();
@@ -1555,8 +1549,7 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 
 	bool isMachineHealthy(Reference<TCMachineInfo> const& machine) {
 		if (!machine.isValid() || machine_info.find(machine->machineID) == machine_info.end() ||
-		    machine_info[machine->machineID]->serversOnMachine.empty()) {
-
+		    machine->serversOnMachine.empty()) {
 			return false;
 		}
 
@@ -3488,7 +3481,7 @@ TEST_CASE("DataDistribution/AddTeamsBestOf/NotUseMachineID") {
 		return Void();
 	}
 
-	collection->addBestMachineTeams(30); // Creat machine teams to help debug
+	collection->addBestMachineTeams(30); // Create machine teams to help debug
 	int result = collection->addTeamsBestOf(30);
 	collection->sanityCheckTeams(); // Server team may happen to be on the same machine team, although unlikely
 

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -132,9 +132,7 @@ ACTOR Future<Void> updateServerMetrics( Reference<TCServerInfo> server ) {
 	return Void();
 }
 
-/**
- * Machine team information
- */
+// Machine team information
 class TCMachineTeamInfo : public ReferenceCounted<TCMachineTeamInfo> {
 public:
 	vector< Reference<TCMachineInfo> > machines;
@@ -760,19 +758,6 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 			// SOMEDAY: Account for capacity, load (when shardMetrics load is high)
 
 			ASSERT( self->teams.size() );
-			//MXX: If assert is never triggered, we can remove the /**/
-			/*
-			if( !self->teams.size() ) {
-				TEST(true);
-				//MX: Review: If this code is never triggered, change this to ASSERT!
-				TraceEvent(SevError, "NoTeamExist").detail("SourceUIDVectorSize", req.sources.size())
-					.detail("SourceUID[0]", req.sources.empty() ?  "[unset]" : req.sources[0].toString())
-					.detail("Debug", "CheckInfoBelow");
-				self->traceAllInfo(true);
-				req.reply.send( Optional<Reference<IDataDistributionTeam>>() );
-				return Void();
-			}
-			 */
 
 			int64_t bestLoadBytes = 0;
 			Optional<Reference<IDataDistributionTeam>> bestOption;
@@ -905,83 +890,6 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 				}
 			}
 
-			//MX: Review: Remove the commented code once we pass correctness test
-			/*
-			bool valid = true;
-			if ( bestOption.present() ) {
-				vector<UID> serverIDs = bestOption.get()->getServerIDs();
-				for ( int i = 0; i < serverIDs.size(); ++i ) {
-					if ( self->server_info.find(serverIDs[i]) == self->server_info.end() ) {
-						valid = false;
-						break;
-					}
-				}
-			} else {
-				valid = false;
-			}
-
-			//NOTE: We may have invalid bestOption when the DB is initialized when req.completeSources is empty? TODO: Check with Evan about this hypothesis
-			//If change SevInfo to SevError, will see error with the command -r simulation -f ./foundationdb/tests/fast/RandomSelector.txt -b on -s 600381032 --logsize 1024MiB
-			if ( !valid ) {
-				TraceEvent(SevInfo, "MXGetTeamInvalidTeam").detail("WantsNewServer", req.wantsNewServers)
-					.detail("WantsTrueBest", req.wantsTrueBest).detail("PreferLowestUtilization", req.preferLowerUtilization)
-					.detail("InflightPenalty", req.inflightPenalty)
-					.detail("BestOptionPresent", bestOption.present())
-					.detail("ReqSourceSize", req.sources.size());
-				TraceEvent(SevInfo, "MXReqCompleteSourceUID").detail("Debug", "CheckInfoBelow");
-				for( int i = 0; i < req.completeSources.size(); i++ )
-				{
-					TraceEvent(SevInfo, "MXComplementSourceUID").detail("Index", i).detail("UID", req.completeSources[i]);
-				}
-				if ( bestOption.present() ) {
-					vector<UID> serverIDs = bestOption.get()->getServerIDs();
-					TraceEvent("BestOption").detail("Size", serverIDs.size());
-					for ( int i = 0; i < serverIDs.size(); ++i ) {
-						TraceEvent("BestOption\t").detail("Index", i).detail("ServerUID", serverIDs[i]);
-					}
-				} else {
-					TraceEvent("BestOptionNotPresent");
-				}
-				self->traceAllInfo(true);
-			}
-			 */
-
-			//MX: Review: Remove the following commented code if we pass the correctness test
-			/*
-			// TODO: Check the team size: be sure team size is correct
-			// TODO: MX: Q: bestOption can be not present, should we record the information?
-			// TODO: MX: If we will record the info, the following trace code can be simplified
-			if ( bestOption.present() ) {
-				if (  bestOption.get()->size() != self->configuration.storageTeamSize ) {
-					TraceEvent(SevInfo, "IncorrectTeamSize").detail("Primary", self->primary)
-						.detail("GetTeamReturnIncorrectTeamSize", "CheckTeamInfoBelow");
-					TraceEvent(SevInfo, "ReturnedIncorrectBestTeamInfo").detail("TeamDesc", bestOption.get()->getDesc())
-							.detail("WantsNewServer", req.wantsNewServers)
-							.detail("WantsTrueBest", req.wantsTrueBest).detail("PreferLowestUtilization", req.preferLowerUtilization)
-							.detail("InflightPenalty", req.inflightPenalty).detail("ReqSourceSize", req.sources.size())
-							.detail("ZeroHealthyTeams", self->zeroHealthyTeams->get());
-					TraceEvent(SevInfo, "ReqCompleteSourceUID").detail("Debug", "CheckInfoBelow");
-					for( int i = 0; i < req.completeSources.size(); i++ )
-					{
-						TraceEvent(SevInfo, "ComplementSourceUID").detail("Index", i).detail("UID", req.completeSources[i]);
-					}
-					self->traceAllInfo(true);
-				}
-			} else {
-				TraceEvent(SevInfo, "GetTeamBestOptionIsNOTPresent")
-						.detail("WantsNewServer", req.wantsNewServers)
-						.detail("WantsTrueBest", req.wantsTrueBest).detail("PreferLowestUtilization", req.preferLowerUtilization)
-						.detail("InflightPenalty", req.inflightPenalty).detail("ReqSourceSize", req.sources.size())
-						.detail("ZeroHealthyTeams", self->zeroHealthyTeams->get());
-				TraceEvent(SevInfo, "ReqCompleteSourceUID").detail("Debug", "CheckInfoBelow");
-				for( int i = 0; i < req.completeSources.size(); i++ )
-				{
-					TraceEvent(SevInfo, "MXComplementSourceUID").detail("Index", i).detail("UID", req.completeSources[i]);
-				}
-				self->traceAllInfo(true);
-			}
-			 */
-
 			req.reply.send( bestOption );
 			return Void();
 		} catch( Error &e ) {
@@ -1100,7 +1008,7 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 
 		ASSERT( serverCount == server_info.size() );
 
-		int minTeams = std::numeric_limits<int>::max(); // MX: Q: Should we use unsigned int
+		int minTeams = std::numeric_limits<int>::max();
 		int maxTeams = std::numeric_limits<int>::min();
 		double varTeams = 0;
 
@@ -1168,15 +1076,13 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 		return machineTeams.size();
 	}
 
-	/*
-	 * Assume begin to end is sorted by std::sort
-	 * Assume InputIt is iterator to UID
-	 * Note: We must allow creating empty teams because empty team is created when a remote DB is initialized.
-	 * The empty team is used as the starting point to move data to the remote DB
-	 * begin: start of the team member ID
-	 * end: end of the team member ID
-	 * isIntialTeam: Is the team added at init() when we recreate teams by looking up DB
-	 */
+	// Assume begin to end is sorted by std::sort
+	// Assume InputIt is iterator to UID
+	// Note: We must allow creating empty teams because empty team is created when a remote DB is initialized.
+	// The empty team is used as the starting point to move data to the remote DB
+	// begin : the start of the team member ID
+	// end : end of the team member ID
+	// isIntialTeam : is the team added at init() when we recreate teams by looking up DB
 	template<class InputIt>
 	void addTeam( InputIt begin, InputIt end, bool isInitialTeam) {
 		vector< Reference<TCServerInfo> > newTeamServers;
@@ -1234,9 +1140,7 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 		addTeam(team.begin(), team.end(), isInitialTeam);
 	}
 
-	/*
-	 * Add a machine team specified by input machines
-	 */
+	// Add a machine team specified by input machines
 	Reference<TCMachineTeamInfo> addMachineTeam( vector< Reference<TCMachineInfo> > machines) {
 		Reference<TCMachineTeamInfo> machineTeamInfo( new TCMachineTeamInfo( machines ) );
 		machineTeams.push_back(machineTeamInfo);
@@ -1249,9 +1153,7 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 		return machineTeamInfo;
 	}
 
-	/*
-	 * Add a machine team by using the machineIDs from begin to end
-	 */
+	// Add a machine team by using the machineIDs from begin to end
 	Reference<TCMachineTeamInfo> addMachineTeam( vector<Standalone<StringRef>>::iterator begin, vector<Standalone<StringRef>>::iterator end) {
 		vector< Reference<TCMachineInfo> > machines;
 
@@ -1267,15 +1169,14 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 	}
 
 
-	//MX: Enumerate all possible teams by backtracing. Add a team, if it's valid, into the teamCollection
-	//MX: Q: this function could be very slow! It is exponential complexity. Q: Can we remove this function
+	// Enumerate all possible teams by backtracing. Add a team, if it's valid, into the teamCollection
+	// FIXME: Remove this function since it can be replaced by addTeamsBestOf()
 	ACTOR Future<Void> addAllTeams( DDTeamCollection *self, int location, vector<LocalityEntry>* history, Reference<LocalityMap<UID>> processes, vector<std::vector<UID>>* output, int teamLimit, int* addedTeams ) {
 		wait( yield( TaskDataDistributionLaunch ) );
 
 		// Add team, if valid
 		if(history->size() == self->configuration.storageTeamSize) {
-			//self->configuration.storagePolicy->traceLocalityRecords(processes);//MX: print out the locality records, which are used in validate the new team
-			auto valid = self->configuration.storagePolicy->validate(*history, processes); //MX: TODO: Maybe very slow!
+			auto valid = self->configuration.storagePolicy->validate(*history, processes); // Can be very slow!
 			if(!valid) {
 				return Void();
 			}
@@ -1319,17 +1220,6 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 		return addedTeams;
 	}
 
-	//TODO:ToRemove
-	/*
-	void getProcesses(Reference<LocalityMap<UID>> & processes) {
-
-		for ( auto it = this->server_info.begin(); it != this->server_info.end(); it++ ) {
-			processes->add(it->second->lastKnownInterface.locality, &it->first);
-		}
-		return;
-	}
-	 */
-
 	int constructMachineFor1Server(UID const &uid) {
 		ASSERT( server_info.find(uid) != server_info.end() );
 		auto &server = server_info[uid];
@@ -1351,11 +1241,10 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 		return 0;
 	}
 
-	/**
-	 * Group storage servers (process) based on their machineId in LocalityData
-	 * All created machines are healthy
-	 * @return The number of healthy servers we grouped into machines
-	 */
+
+	// Group storage servers (process) based on their machineId in LocalityData
+	// All created machines are healthy
+	// Return The number of healthy servers we grouped into machines
 	int constructMachinesFromServers() {
 		int totalServerIndex = 0;
 		for(auto i = server_info.begin(); i != server_info.end(); ++i) {
@@ -1497,16 +1386,7 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 
 		machineTeamsToBuild = targetMachineTeamsToBuild;
 
-		//Q: Is there a special TraceEvent that is enabled at debug build but disabled at release built
-		// Trace global information to help debug
-//		TraceEvent("AddMachineTeams").detail("Primary", primary)
-//				.detail("MachineTeamsToBuild", machineTeamsToBuild)
-//				.detail("CurrentMachineTeamNumber", machineTeams.size())
-//				.detail("CurrentTotalMachines", machine_info.size())
-//				.detail("DesiredTeamPerServer", SERVER_KNOBS->DESIRED_TEAMS_PER_SERVER);
-//		traceAllInfo();
-
-		if(machine_info.size() < configuration.storageTeamSize ) {
+		if ( machine_info.size() < configuration.storageTeamSize ) {
 			TraceEvent(SevWarn, "DataDistributionBuildMachineTeams", masterId)
 				.detail("Reason","Not enough machines for a team. Machine number should be larger than Team size")
 				.detail("MachineNumber",machine_info.size()).detail("TeamSize", configuration.storageTeamSize);
@@ -1574,7 +1454,7 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 
 				// selectReplicas() may return server not in server_info. Retry if it happens
 				// Reproduce the situation with -r simulation -f foundationdb/tests/fast/BackupToDBCorrectnessClean.txt  -b on -s 801184616
-				// MX: Q: Why should selectReplicas returne invalid server. Should not we avoid this in selectReplicas.
+				// MX: Q: Why should selectReplicas return invalid server. Should not we avoid this in selectReplicas.
 				int valid = true;
 				for ( auto &pUID : team ) {
 					if ( server_info.find(*pUID) == server_info.end() ) {
@@ -1595,18 +1475,13 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 				}
 
 				// MX:Q: why will this happen? If this happens, it means selectReplicas() did not choose a correct team in the first place!
-				if( team.size() != configuration.storageTeamSize) {
+				if ( team.size() != configuration.storageTeamSize) {
 					maxAttempts += 1;
 				}
 
 				int score = 0;
 				vector<Standalone<StringRef>> machineIDs;
 				for ( auto process = team.begin(); process != team.end(); process++ ) {
-//					TraceEvent("AddMachineTeamsBestOf").detail("Primary", primary).detail("AddedMachineTeams", addedMachineTeams)
-//						.detail("Attempt", i).detail("ServerInfoSize", server_info.size())
-//						.detail("TeamSize", team.size()).detail("UID", (**process).toString())
-//						.detail("ProcessIP", server_info.find(**process) != server_info.end()
-//								? server_info[**process]->lastKnownInterface.address().toString() : "[unset]");
 					score += server_info[**process]->teams.size();
 					Standalone<StringRef> machine_id  = server_info[**process]->lastKnownInterface.locality.zoneId().get();
 					machineIDs.push_back(machine_id);
@@ -1636,7 +1511,6 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 			}
 
 			//Step 5: Restore machine from its representative process team and get the machine team
-			//MXX: TODO: Remove // comment at the beginning of a line
 			if ( bestTeam.size() == configuration.storageTeamSize ) {
 				vector<Standalone<StringRef>> machineIDs; // Used to quickly check if the machineIDs belong to an existed team
 				vector<Reference<TCMachineInfo>> machines; // Keep machines reference for performance benefit by avoiding looking up machine by machineID
@@ -1649,7 +1523,7 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 				}
 
 				std::sort(machineIDs.begin(), machineIDs.end());
-				if( !machineTeamExists(machineIDs) ) {
+				if ( !machineTeamExists(machineIDs) ) {
 					addMachineTeam(machines);
 					addedMachineTeams++;
 				}
@@ -1680,10 +1554,7 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 				healthyNum++;
 			}
 		}
-		if ( healthyNum == machineIDs.size() )
-			return true;
-		else
-			return false;
+		return ( healthyNum == machineIDs.size() );
 	}
 
 	bool isMachineTeamHealthy( Reference<TCMachineTeamInfo> const &machineTeam ) {
@@ -1698,36 +1569,31 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 				healthyNum++;
 			}
 		}
-		if ( healthyNum == machineTeam->machines.size() )
-			return true;
-		else
-			return false;
+		return ( healthyNum == machineTeam->machines.size() );
 	}
 
 	bool isMachineHealthy( Reference<TCMachineInfo> const &machine ) {
 		if ( !machine.isValid() ||machine_info.find(machine->machineID) == machine_info.end()
 			 || machine_info[machine->machineID]->serversOnMachine.empty() ) {
 			//Debug trace
-			if ( !machine.isValid() )
-				TraceEvent(SevWarn, "InvalidMachineTeam").detail("IsValid", machine.isValid());
-			else
-				TraceEvent(SevWarn, "InvalidMachineTeam").detail("IsValid", machine.isValid())
-						.detail("InMachineInfo", machine_info.find(machine->machineID) != machine_info.end())
-						.detail("ServerNumber", machine_info[machine->machineID]->serversOnMachine.size());
+//			if ( !machine.isValid() )
+//				TraceEvent(SevWarn, "InvalidMachineTeam").detail("IsValid", machine.isValid());
+//			else
+//				TraceEvent(SevWarn, "InvalidMachineTeam").detail("IsValid", machine.isValid())
+//						.detail("InMachineInfo", machine_info.find(machine->machineID) != machine_info.end())
+//						.detail("ServerNumber", machine_info[machine->machineID]->serversOnMachine.size());
 
 			return false;
 		}
 
-		bool healthy = false;
 		// Healthy machine has at least one healthy server
 		for ( auto &server : machine->serversOnMachine ) {
 			if ( !server_status.get(server->id).isUnhealthy() ) {
-				healthy = true;
-				break;
+				return true;
 			}
 		}
 
-		return healthy;
+		return false;
 	}
 
 	bool isMachineIDValid( vector<Standalone<StringRef>> const &machineIDs ) {
@@ -1743,10 +1609,9 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 		return true;
 	}
 
-	/*
-	 * Set targetMachineTeam with a random machine team among those have the smallest machine-team-score
-	 * Return 0 if succeed; return 1 otherwise
-	 */
+
+	 // Set targetMachineTeam with a random machine team among those have the smallest machine-team-score
+	 // Return 0 if succeed; return 1 otherwise
 	int findOneLeastUsedMachineTeam( std::map<Reference<TCMachineTeamInfo>, int, CompareTCMachineTeamInfoRef> &machineTeamStats,
 									 std::map<Reference<TCMachineTeamInfo>, int, CompareTCMachineTeamInfoRef>  &machineTeamPenalties,
 									 Reference<TCMachineTeamInfo> &targetMachineTeam ) {
@@ -1785,9 +1650,7 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 
 	}
 
-	/*
-	 * A server's team may have incorrect size. We do NOT want to count those teams because they will be deleted any way
-	 */
+	 // A server's team may have incorrect size. We do NOT want to count those teams because they will be deleted any way
 	int countCorrectSizeTeam(Reference<TCServerInfo> &server, int expectedSize) {
 		int count = 0;
 		for ( auto &team : server->teams ) {
@@ -1821,11 +1684,9 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 		return g_random->randomChoice(leastUsedServers);
 	}
 
-	/*
-	 * A machine team score is the total number of server teams of servers on the machine team's machine plus machine score
-	 * Machine score is the max number of server teams of servers on the machine.
-	 * Adding machine core to penalize the machine that includes a server that owns a large number of teams
-	 */
+	// A machine team score is the total number of server teams of servers on the machine team's machine plus machine score
+	// Machine score is the max number of server teams of servers on the machine.
+	// Adding machine core to penalize the machine that includes a server that owns a large number of teams
 	int calculateMachineTeamScore( Reference<TCMachineTeamInfo> machineTeam ) {
 		int score = 0;
 		for ( auto &machine : machineTeam->machines ) {
@@ -1840,10 +1701,8 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 		return score;
 	}
 
-	/*
-	 * Check if machines on which server team is on belong to a machine team.
-	 * A server team should always come from servers on a machine team
-	 */
+	// Check if machines on which server team is on belong to a machine team.
+	// A server team should always come from servers on a machine team
 	bool isOnSameMachineTeam(Reference<TCTeamInfo> &team) {
 		std::vector< Standalone<StringRef> > machineIDs;
 		for ( auto &server: team->servers ) {
@@ -1863,16 +1722,11 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 				}
 			}
 		}
-		if ( numExistance == team->servers.size() )
-			return true;
-		else
-			return false;
+		return ( numExistance == team->servers.size() );
 	}
 
-	/*
-	 * Sanity check the property of teams in unit test
-	 * Return true if all server teams belong to machine teams
-	 */
+	// Sanity check the property of teams in unit test
+	// Return true if all server teams belong to machine teams
 	bool sanityCheckTeams() {
 		int teamIndex = 0;
 		int alwaysOnSameMachineTeam = true;
@@ -1891,12 +1745,10 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 		return alwaysOnSameMachineTeam;
 	}
 
-	/*
-	 * A machine may have some invalid machine teams, which will eventually be removed
-	 * We should only count valid machine teams for the machine so that the machine can be chosen into a new team
-	 * expectedSize is the expected team size
-	 * Return the number of machine teams that match the correct team size
-	 */
+	// A machine may have some invalid machine teams, which will eventually be removed
+	// We should only count valid machine teams for the machine so that the machine can be chosen into a new team
+	// expectedSize is the expected team size
+	// Return the number of machine teams that match the correct team size
 	int countCorrectSizedMachineTeam(Reference<TCMachineInfo> &machine, const int expectedSize) {
 		int count = 0;
 		for ( auto &machineTeam : machine->machineTeams ) {
@@ -1906,12 +1758,10 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 		return count;
 	}
 
-	/**
-	 * Create server teams based on machine teams
-	 * Before the number of machine teams reaches the threshold, build a machine team for each server team
-	 * When it reaches the threshold, first try to build a server team with existing machine teams; if failed,
-	 * build an extra machine team and record the event in trace
-	 */
+	// Create server teams based on machine teams
+	// Before the number of machine teams reaches the threshold, build a machine team for each server team
+	// When it reaches the threshold, first try to build a server team with existing machine teams; if failed,
+	// build an extra machine team and record the event in trace
 	int addTeamsBestOf( int teamsToBuild ) {
 		ASSERT(teamsToBuild > 0);
 		if ( machine_info.size() == 0 && server_info.size() != 0 ) {
@@ -1924,9 +1774,6 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 		int loopCount = 0;
 		int machineTeamThreshold = machine_info.size() * SERVER_KNOBS->MAX_TEAMS_PER_SERVER;
 		bool ignoreMachineTeamThreshhold = false;
-
-//		TraceEvent("AddTeamsBestOf").detail("Primary", primary).detail("TeamsToBuild", teamsToBuild).detail("CurrentTeamNum", teams.size())
-//			.detail("MachineTeamThreshold", machineTeamThreshold);
 
 		while( addedTeams < teamsToBuild ) {
 			int machineTeamsToBuild = 1;
@@ -1947,11 +1794,8 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 					.detail("StorageTeamSize", configuration.storageTeamSize)
 					.detail("TeamsToBuild", teamsToBuild).detail("CurrentTeamNumber", teams.size());
 			}
-			// build 1 machine team if machineTeamsToBuild is not zero
+			// Build 1 machine team if machineTeamsToBuild is not zero
 			addedMachineTeams = addBestMachineTeams(machineTeamsToBuild);
-
-			TraceEvent("AddTeamsBestOf").detail("Primary", primary).detail("TraceMachineServerLocalityInfo", 1).detail("TeamsToBuild", teamsToBuild);
-			traceAllInfo();
 
 			std::map<Reference<TCMachineTeamInfo>, int, CompareTCMachineTeamInfoRef> machineTeamStats;
 			std::map<Reference<TCMachineTeamInfo>, int, CompareTCMachineTeamInfoRef> machineTeamPenalties;
@@ -2037,29 +1881,6 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 				.detail("StorageTeamSize", configuration.storageTeamSize)
 				.detail("MachineTeamNum", machineTeams.size());
 
-
-		/* //DEBUG ONLY. Can safely remove
-		// Compute the maximum teams
-		int machineNum = 0;
-		for ( auto &machine : machine_info ) {
-			if ( isMachineHealthy(machine.second) )
-				++machineNum;
-		}
-		int maxMachineTeams = 1;
-		for ( int i = 0; i < configuration.storageTeamSize; ++i ) {
-			maxMachineTeams = maxMachineTeams * ( machineNum - i );
-		}
-		for ( int i = 1; i <= configuration.storageTeamSize; ++i ) {
-			maxMachineTeams = maxMachineTeams / i;
-		}
-		if (  addedTeams < teamsToBuild && teams.size() < maxMachineTeams ) {
-			TraceEvent(SevInfo, "MissValidTeams").detail("Debug","CheckSysInfoBelow")
-					.detail("AddedTeams", addedTeams).detail("TeamsToBuild", teamsToBuild)
-					.detail("TeamNum", teams.size()).detail("MaxMachineTeams", maxMachineTeams);
-			traceAllInfo(true);
-		}
-		 */
-
 		return addedTeams;
 	}
 
@@ -2117,9 +1938,6 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 				.detail("UniqueMachines", uniqueMachines).detail("TeamSize", self->configuration.storageTeamSize).detail("Servers", serverCount)
 				.detail("CurrentTrackedTeams", self->teams.size()).detail("HealthyTeamCount", teamCount).detail("TotalTeamCount", totalTeamCount);
 
-//			TraceEvent("BuildTeamsBegin", self->masterId).detail("TeamCount", teamCount)
-//				.detail("DesiredTeams", desiredTeams).detail("TotalTeamCount", totalTeamCount).detail("MaxTeams", maxTeams);
-
 			teamCount = std::max(teamCount, desiredTeams + totalTeamCount - maxTeams ); //Situation when unhealthy teams are a LOT.
 
 			if( desiredTeams > teamCount ) {
@@ -2134,41 +1952,11 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 
 				state vector<std::vector<UID>> builtTeams;
 
-				/* //ToRemove
-				int useMachineTeam = 1;
-				if ( useMachineTeam == 1 )
-				 */
-				{
-					int addedTeams = self->addTeamsBestOf(teamsToBuild);
-//					TraceEvent("AddTeamsBestOfInBuildTeam", self->masterId).detail("TeamsToBuild", teamsToBuild)
-//						.detail("CurrentTeams", self->teams.size()).detail("AddedTeams", addedTeams);
-					if ( addedTeams <= 0 && self->teams.size() == 0 ) {
-						TraceEvent(SevWarn, "NoTeamAfterBuildTeam").detail("TeamNum", self->teams.size()).detail("Debug", "Check information below");
-						self->traceAllInfo(true);
-					}
+				int addedTeams = self->addTeamsBestOf(teamsToBuild);
+				if ( addedTeams <= 0 && self->teams.size() == 0 ) {
+					TraceEvent(SevWarn, "NoTeamAfterBuildTeam").detail("TeamNum", self->teams.size()).detail("Debug", "Check information below");
+					self->traceAllInfo(true);
 				}
-				/* //ToRemove
-				else { //TODO: Remove the else content.
-					if ( self->configuration.storageTeamSize > 3) {
-						int addedTeams = self->addTeamsBestOf( teamsToBuild );
-						TraceEvent("AddTeamsBestOf", self->masterId).detail("CurrentTeams", self->teams.size()).detail("AddedTeams", addedTeams);
-					} else {
-						int addedTeams = wait( self->addAllTeams( self, desiredServerVector, &builtTeams, teamsToBuild ) );
-
-						if ( addedTeams < teamsToBuild ) {
-							for ( int i = 0; i < builtTeams.size(); i++ ) {
-								std::sort(builtTeams[i].begin(), builtTeams[i].end());
-								self->addTeam( builtTeams[i].begin(), builtTeams[i].end() );
-							}
-							TraceEvent("AddAllTeams", self->masterId).detail("CurrentTeams", self->teams.size()).detail("AddedTeams", builtTeams.size());
-						}
-						else {
-							int addedTeams = self->addTeamsBestOf( teamsToBuild );
-							TraceEvent("AddTeamsBestOf", self->masterId).detail("CurrentTeams", self->teams.size()).detail("AddedTeams", addedTeams);
-						}
-					}
-				}
-				 */
 			}
 		}
 
@@ -2479,7 +2267,7 @@ ACTOR Future<Void> teamTracker( DDTeamCollection* self, Reference<TCTeamInfo> te
 
 				if( lastHealthy != healthy ) {
 					lastHealthy = healthy;
-					self->healthyTeamCount += healthy ? 1 : -1;//MX: update healthy team count when the team's healthy changes
+					self->healthyTeamCount += healthy ? 1 : -1; // Update healthy team count when the team healthy changes
 
 					ASSERT( self->healthyTeamCount >= 0 );
 					self->zeroHealthyTeams->set(self->healthyTeamCount == 0);
@@ -3453,7 +3241,7 @@ ACTOR Future<Void> dataDistribution(
 					TraceEvent("DDInitGotInitialDD", mi.id()).detail("B","").detail("E", "").detail("Src", "[no items]").detail("Dest", "[no items]").trackLatest("InitialDD");
 				}
 
-				if (initData->mode) break;//MX:Q: when will initData->mode become true?
+				if (initData->mode) break; // mode may be set true by system operator using fdbcli
 				TraceEvent("DataDistributionDisabled", mi.id());
 
 				TraceEvent("MovingData", mi.id())

--- a/fdbserver/DataDistributionQueue.actor.cpp
+++ b/fdbserver/DataDistributionQueue.actor.cpp
@@ -881,6 +881,7 @@ ACTOR Future<Void> dataDistributionRelocator( DDQueueData *self, RelocateData rd
 		ASSERT( rd.src.size() );
 		loop {
 			state int stuckCount = 0;
+			state int bestTeamStuckThreshold = 50;
 			loop {
 				state int tciIndex = 0;
 				state bool foundTeams = true;
@@ -897,6 +898,7 @@ ACTOR Future<Void> dataDistributionRelocator( DDQueueData *self, RelocateData rd
 					req.sources = rd.src;
 					req.completeSources = rd.completeSources;
 					Optional<Reference<IDataDistributionTeam>> bestTeam = wait(brokenPromiseToNever(self->teamCollections[tciIndex].getTeam.getReply(req)));
+					// If a DC has no healthy team, we stop checking the other DCs until the unhealthy DC is healthy again or is excluded.
 					if(!bestTeam.present()) {
 						foundTeams = false;
 						break;
@@ -922,6 +924,28 @@ ACTOR Future<Void> dataDistributionRelocator( DDQueueData *self, RelocateData rd
 				if (foundTeams && anyHealthy) {
 					break;
 				}
+
+				TraceEvent(SevWarn, "BestTeamStuckOnce").detail("BestTeamsSize",bestTeams.size())
+					.detail("FoundTeams", foundTeams).detail("AnyHealthy", anyHealthy).detail("WantsNewServers", rd.wantsNewServers)
+					.detail("StuckCount", stuckCount);
+				int i = 0;
+				for ( auto &team : bestTeams ) {
+					TraceEvent(SevWarn, "BestTeam").detail("IsSource", team.second)
+						.detail("IsHealthy", team.first->isHealthy())
+						.detail("ServerUID", "CheckBelow");
+					for ( auto &uid : team.first->getServerIDs() ) {
+						TraceEvent("Server").detail("Index", i).detail("UID", uid);
+					}
+					i++;
+				}
+				if ( stuckCount > bestTeamStuckThreshold ) {
+					printf("[WARNING] BestTeamStuck for %d times!\n", stuckCount);
+					TraceEvent(SevWarn, "BestTeamStuckTooLong").detail("StuckCountEach50", stuckCount)
+							.detail("TeamCollectionIndex", tciIndex).detail("FoundTeams", foundTeams)
+							.detail("AnyWithSource", anyWithSource).detail("AllHealthy", allHealthy).detail("AnyHealthy", anyHealthy);
+					bestTeamStuckThreshold += 50; // Log each 50 bestTeamStuck
+				}
+
 				TEST(true); //did not find a healthy destination team on the first attempt
 				stuckCount++;
 				TraceEvent(stuckCount > 50 ? SevWarnAlways : SevWarn, "BestTeamStuck", masterId).suppressFor(1.0).detail("Count", stuckCount);
@@ -936,7 +960,7 @@ ACTOR Future<Void> dataDistributionRelocator( DDQueueData *self, RelocateData rd
 			for(int i = 0; i < bestTeams.size(); i++) {
 				auto& serverIds = bestTeams[i].first->getServerIDs();
 				destinationTeams.push_back(ShardsAffectedByTeamFailure::Team(serverIds, i == 0));
-				if(allHealthy && anyWithSource && !bestTeams[i].second) {
+				if(allHealthy && anyWithSource && !bestTeams[i].second) { //bestTeams[i] is not the source of the shard
 					int idx = g_random->randomInt(0, serverIds.size());
 					destIds.push_back(serverIds[idx]);
 					healthyIds.push_back(serverIds[idx]);
@@ -952,6 +976,23 @@ ACTOR Future<Void> dataDistributionRelocator( DDQueueData *self, RelocateData rd
 						healthyIds.insert(healthyIds.end(), serverIds.begin(), serverIds.end());
 						healthyDestinations.addTeam(bestTeams[i].first);
 					}
+				}
+			}
+
+			// Sanity check
+			state int totalIds = 0;
+			for (auto &destTeam : destinationTeams) {
+				totalIds += destTeam.servers.size();
+			}
+			if ( totalIds != self->teamSize ) {
+				TraceEvent(SevWarn, "IncorrectDestTeamSize").detail("ExpectedTeamSize", self->teamSize)
+						.detail("DestTeamSize", totalIds).detail("Debug", "CheckDestTeamUID");
+				int i = 0;
+				for (auto &destTeam : destinationTeams) {
+					for ( auto &id : destTeam.servers ) {
+						TraceEvent(SevWarn, "IncorrectDestTeamSize\t").detail("TeamID", i).detail("UID", id);
+					}
+					++i;
 				}
 			}
 
@@ -977,6 +1018,7 @@ ACTOR Future<Void> dataDistributionRelocator( DDQueueData *self, RelocateData rd
 								destIds.insert(destIds.end(), extraIds.begin(), extraIds.end());
 								healthyIds.insert(healthyIds.end(), extraIds.begin(), extraIds.end());
 								extraIds.clear();
+								ASSERT( totalIds == destIds.size() ); // Sanity check the destIDs before we move keys
 								doMoveKeys = moveKeys(self->cx, rd.keys, destIds, healthyIds, self->lock, Promise<Void>(), &self->startMoveKeysParallelismLock, &self->finishMoveKeysParallelismLock, self->recoveryVersion, self->teamCollections.size() > 1, relocateShardInterval.pairID );
 							} else {
 								self->fetchKeysComplete.insert( rd );

--- a/fdbserver/DataDistributionQueue.actor.cpp
+++ b/fdbserver/DataDistributionQueue.actor.cpp
@@ -925,30 +925,6 @@ ACTOR Future<Void> dataDistributionRelocator( DDQueueData *self, RelocateData rd
 					break;
 				}
 
-				//MXX: No need to print out so many information. Print out the tci and self->teamCollections.size(), we will know which data center got stuck.
-				/*
-				TraceEvent(SevWarn, "BestTeamStuckOnce").detail("BestTeamsSize",bestTeams.size())
-					.detail("FoundTeams", foundTeams).detail("AnyHealthy", anyHealthy).detail("WantsNewServers", rd.wantsNewServers)
-					.detail("StuckCount", stuckCount);
-				int i = 0;
-				for ( auto &team : bestTeams ) {
-					TraceEvent(SevWarn, "BestTeam").detail("IsSource", team.second)
-						.detail("IsHealthy", team.first->isHealthy())
-						.detail("ServerUID", "CheckBelow");
-					for ( auto &uid : team.first->getServerIDs() ) {
-						TraceEvent("Server").detail("Index", i).detail("UID", uid);
-					}
-					i++;
-				}
-				if ( stuckCount > bestTeamStuckThreshold ) {
-					printf("[WARNING] BestTeamStuck for %d times!\n", stuckCount);
-					TraceEvent(SevWarn, "BestTeamStuckTooLong").detail("StuckCountEach50", stuckCount)
-							.detail("TeamCollectionIndex", tciIndex).detail("FoundTeams", foundTeams)
-							.detail("AnyWithSource", anyWithSource).detail("AllHealthy", allHealthy).detail("AnyHealthy", anyHealthy);
-					bestTeamStuckThreshold += 50; // Log each 50 bestTeamStuck
-				}
-				*/
-
 				TEST(true); //did not find a healthy destination team on the first attempt
 				stuckCount++;
 				TraceEvent(stuckCount > 50 ? SevWarnAlways : SevWarn, "BestTeamStuck", masterId).suppressFor(1.0).detail("Count", stuckCount)

--- a/fdbserver/DataDistributionQueue.actor.cpp
+++ b/fdbserver/DataDistributionQueue.actor.cpp
@@ -881,7 +881,7 @@ ACTOR Future<Void> dataDistributionRelocator( DDQueueData *self, RelocateData rd
 		ASSERT( rd.src.size() );
 		loop {
 			state int stuckCount = 0;
-			//state int bestTeamStuckThreshold = 50;
+			// state int bestTeamStuckThreshold = 50;
 			loop {
 				state int tciIndex = 0;
 				state bool foundTeams = true;
@@ -898,7 +898,8 @@ ACTOR Future<Void> dataDistributionRelocator( DDQueueData *self, RelocateData rd
 					req.sources = rd.src;
 					req.completeSources = rd.completeSources;
 					Optional<Reference<IDataDistributionTeam>> bestTeam = wait(brokenPromiseToNever(self->teamCollections[tciIndex].getTeam.getReply(req)));
-					// If a DC has no healthy team, we stop checking the other DCs until the unhealthy DC is healthy again or is excluded.
+					// If a DC has no healthy team, we stop checking the other DCs until
+					// the unhealthy DC is healthy again or is excluded.
 					if(!bestTeam.present()) {
 						foundTeams = false;
 						break;
@@ -927,8 +928,11 @@ ACTOR Future<Void> dataDistributionRelocator( DDQueueData *self, RelocateData rd
 
 				TEST(true); //did not find a healthy destination team on the first attempt
 				stuckCount++;
-				TraceEvent(stuckCount > 50 ? SevWarnAlways : SevWarn, "BestTeamStuck", masterId).suppressFor(1.0).detail("Count", stuckCount)
-					.detail("TeamCollectionId", tciIndex).detail("NumOfTeamCollections", self->teamCollections.size());
+				TraceEvent(stuckCount > 50 ? SevWarnAlways : SevWarn, "BestTeamStuck", masterId)
+				    .suppressFor(1.0)
+				    .detail("Count", stuckCount)
+				    .detail("TeamCollectionId", tciIndex)
+				    .detail("NumOfTeamCollections", self->teamCollections.size());
 				wait( delay( SERVER_KNOBS->BEST_TEAM_STUCK_DELAY, TaskDataDistributionLaunch ) );
 			}
 
@@ -940,7 +944,8 @@ ACTOR Future<Void> dataDistributionRelocator( DDQueueData *self, RelocateData rd
 			for(int i = 0; i < bestTeams.size(); i++) {
 				auto& serverIds = bestTeams[i].first->getServerIDs();
 				destinationTeams.push_back(ShardsAffectedByTeamFailure::Team(serverIds, i == 0));
-				if(allHealthy && anyWithSource && !bestTeams[i].second) { //bestTeams[i] is not the source of the shard
+				if (allHealthy && anyWithSource && !bestTeams[i].second) { // bestTeams[i] is not the source of the
+					                                                       // shard
 					int idx = g_random->randomInt(0, serverIds.size());
 					destIds.push_back(serverIds[idx]);
 					healthyIds.push_back(serverIds[idx]);
@@ -961,12 +966,14 @@ ACTOR Future<Void> dataDistributionRelocator( DDQueueData *self, RelocateData rd
 
 			// Sanity check
 			state int totalIds = 0;
-			for (auto &destTeam : destinationTeams) {
+			for (auto& destTeam : destinationTeams) {
 				totalIds += destTeam.servers.size();
 			}
-			if ( totalIds != self->teamSize ) {
-				TraceEvent(SevWarn, "IncorrectDestTeamSize").suppressFor(1.0).detail("ExpectedTeamSize", self->teamSize)
-						.detail("DestTeamSize", totalIds);
+			if (totalIds != self->teamSize) {
+				TraceEvent(SevWarn, "IncorrectDestTeamSize")
+				    .suppressFor(1.0)
+				    .detail("ExpectedTeamSize", self->teamSize)
+				    .detail("DestTeamSize", totalIds);
 			}
 
 			self->shardsAffectedByTeamFailure->moveShard(rd.keys, destinationTeams);
@@ -991,7 +998,7 @@ ACTOR Future<Void> dataDistributionRelocator( DDQueueData *self, RelocateData rd
 								destIds.insert(destIds.end(), extraIds.begin(), extraIds.end());
 								healthyIds.insert(healthyIds.end(), extraIds.begin(), extraIds.end());
 								extraIds.clear();
-								ASSERT( totalIds == destIds.size() ); // Sanity check the destIDs before we move keys
+								ASSERT(totalIds == destIds.size()); // Sanity check the destIDs before we move keys
 								doMoveKeys = moveKeys(self->cx, rd.keys, destIds, healthyIds, self->lock, Promise<Void>(), &self->startMoveKeysParallelismLock, &self->finishMoveKeysParallelismLock, self->recoveryVersion, self->teamCollections.size() > 1, relocateShardInterval.pairID );
 							} else {
 								self->fetchKeysComplete.insert( rd );

--- a/fdbserver/TesterInterface.h
+++ b/fdbserver/TesterInterface.h
@@ -88,6 +88,9 @@ Future<Void> testerServerCore( TesterInterface const& interf, Reference<ClusterC
 enum test_location_t { TEST_HERE, TEST_ON_SERVERS, TEST_ON_TESTERS };
 enum test_type_t { TEST_TYPE_FROM_FILE, TEST_TYPE_CONSISTENCY_CHECK };
 
-Future<Void> runTests( Reference<ClusterConnectionFile> const& connFile, test_type_t const& whatToRun, test_location_t const& whereToRun, int const& minTestersExpected, std::string const& fileName = std::string(), StringRef const& startingConfiguration = StringRef(), LocalityData const& locality = LocalityData() );
+Future<Void> runTests( Reference<ClusterConnectionFile> const& connFile, test_type_t const& whatToRun,
+					test_location_t const& whereToRun, int const& minTestersExpected,
+					std::string const& fileName = std::string(), StringRef const& startingConfiguration = StringRef(),
+					LocalityData const& locality = LocalityData() );
 
 #endif

--- a/fdbserver/TesterInterface.h
+++ b/fdbserver/TesterInterface.h
@@ -88,9 +88,9 @@ Future<Void> testerServerCore( TesterInterface const& interf, Reference<ClusterC
 enum test_location_t { TEST_HERE, TEST_ON_SERVERS, TEST_ON_TESTERS };
 enum test_type_t { TEST_TYPE_FROM_FILE, TEST_TYPE_CONSISTENCY_CHECK };
 
-Future<Void> runTests( Reference<ClusterConnectionFile> const& connFile, test_type_t const& whatToRun,
-					test_location_t const& whereToRun, int const& minTestersExpected,
-					std::string const& fileName = std::string(), StringRef const& startingConfiguration = StringRef(),
-					LocalityData const& locality = LocalityData() );
+Future<Void> runTests(Reference<ClusterConnectionFile> const& connFile, test_type_t const& whatToRun,
+                      test_location_t const& whereToRun, int const& minTestersExpected,
+                      std::string const& fileName = std::string(), StringRef const& startingConfiguration = StringRef(),
+                      LocalityData const& locality = LocalityData());
 
 #endif

--- a/fdbserver/tester.actor.cpp
+++ b/fdbserver/tester.actor.cpp
@@ -1070,8 +1070,9 @@ ACTOR Future<Void> runTests( Reference<AsyncVar<Optional<struct ClusterControlle
 	if(tests.empty() || useDB) {
 		if(waitForQuiescenceEnd) {
 			try {
-				wait( quietDatabase( cx, dbInfo, "End", 0, 2e6, 2e6 ) ||
-					( databasePingDelay == 0.0 ? Never() : testDatabaseLiveness( cx, databasePingDelay, "QuietDatabaseEnd" ) ) );
+				wait(quietDatabase(cx, dbInfo, "End", 0, 2e6, 2e6) ||
+				     (databasePingDelay == 0.0 ? Never()
+				                               : testDatabaseLiveness(cx, databasePingDelay, "QuietDatabaseEnd")));
 			} catch( Error& e ) {
 				TraceEvent("QuietDatabaseEndExternalError").error(e);
 				throw;

--- a/fdbserver/tester.actor.cpp
+++ b/fdbserver/tester.actor.cpp
@@ -795,7 +795,6 @@ ACTOR Future<bool> runTest( Database cx, std::vector< TesterInterface > testers,
 
 	state bool ok = testResults.ok();
 
-	printf("Spec info: useDB:%d, dumpAfterTest:%d, runConsistencyCheck:%d\n", spec.useDB, spec.dumpAfterTest, spec.runConsistencyCheck);
 	if( spec.useDB ) {
 		if( spec.dumpAfterTest ) {
 			try {
@@ -1047,7 +1046,6 @@ ACTOR Future<Void> runTests( Reference<AsyncVar<Optional<struct ClusterControlle
 		}
 	}
 
-	printf("waitForQuiescenceBegin start\n");
 	if (useDB && waitForQuiescenceBegin) {
 		TraceEvent("TesterStartingPreTestChecks").detail("DatabasePingDelay", databasePingDelay).detail("StartDelay", startDelay);
 		try {
@@ -1061,7 +1059,6 @@ ACTOR Future<Void> runTests( Reference<AsyncVar<Optional<struct ClusterControlle
 
 	TraceEvent("TestsExpectedToPass").detail("Count", tests.size());
 	state int idx = 0;
-	printf("TestsExpectedToPass, count:%d\n", tests.size());
 	for(; idx < tests.size(); idx++ ) {
 		bool ok = wait( runTest( cx, testers, tests[idx], dbInfo ) );
 		// do we handle a failure here?

--- a/fdbserver/worker.actor.cpp
+++ b/fdbserver/worker.actor.cpp
@@ -145,8 +145,9 @@ ACTOR Future<Void> workerHandleErrors(FutureStream<ErrorInfo> errors) {
 				err.error.code() == error_code_coordinators_changed ||  // The worker server was cancelled
 				err.error.code() == error_code_shutdown_in_progress;
 
-			if(!ok)
+			if(!ok) {
 				err.error = checkIOTimeout(err.error);  // Possibly convert error to io_timeout
+			}
 
 			endRole(err.role, err.id, "Error", ok, err.error);
 

--- a/fdbserver/worker.actor.cpp
+++ b/fdbserver/worker.actor.cpp
@@ -145,7 +145,7 @@ ACTOR Future<Void> workerHandleErrors(FutureStream<ErrorInfo> errors) {
 				err.error.code() == error_code_coordinators_changed ||  // The worker server was cancelled
 				err.error.code() == error_code_shutdown_in_progress;
 
-			if(!ok) {
+			if (!ok) {
 				err.error = checkIOTimeout(err.error);  // Possibly convert error to io_timeout
 			}
 

--- a/fdbserver/workloads/ConsistencyCheck.actor.cpp
+++ b/fdbserver/workloads/ConsistencyCheck.actor.cpp
@@ -630,7 +630,17 @@ struct ConsistencyCheckWorkload : TestWorkload
 			//In a quiescent database, check that the team size is the same as the desired team size
 			if(self->firstClient && self->performQuiescentChecks && sourceStorageServers.size() != configuration.usableRegions*configuration.storageTeamSize)
 			{
-				TraceEvent("ConsistencyCheck_InvalidTeamSize").detail("ShardBegin", printable(range.begin)).detail("ShardEnd", printable(range.end)).detail("TeamSize", sourceStorageServers.size()).detail("DesiredTeamSize", configuration.storageTeamSize);
+				TraceEvent("ConsistencyCheck_InvalidTeamSize").detail("ShardBegin", printable(range.begin))
+					.detail("ShardEnd", printable(range.end)).detail("SourceTeamSize", sourceStorageServers.size())
+					.detail("DestServerSize", destStorageServers.size())
+					.detail("ConfigStorageTeamSize", configuration.storageTeamSize)
+					.detail("UsableRegions", configuration.usableRegions);
+				//MX: record the server reponsible for the problematic shards
+				int i = 0;
+				for ( auto& id : sourceStorageServers ) {
+					TraceEvent("IncorrectSizeTeamInfo").detail("ServerUID", id).detail("TeamIndex", i++);
+				}
+				//TraceEvent(SevError, "QuitCheck").detail("ErrorOnPurpose", *(int *) NULL);
 				self->testFailure("Invalid team size");
 				return false;
 			}
@@ -1070,7 +1080,8 @@ struct ConsistencyCheckWorkload : TestWorkload
 					}
 				}
 				if( !found ) {
-					TraceEvent("ConsistencyCheck_NoStorage").detail("Address", workers[i].first.address());
+					TraceEvent("ConsistencyCheck_NoStorage").detail("Address", workers[i].first.address())
+						.detail("ProcessClassEqualToStorageClass", (int) (workers[i].second == ProcessClass::StorageClass));
 					missingStorage.insert(workers[i].first.locality.dcId());
 				}
 			}

--- a/fdbserver/workloads/ConsistencyCheck.actor.cpp
+++ b/fdbserver/workloads/ConsistencyCheck.actor.cpp
@@ -635,12 +635,11 @@ struct ConsistencyCheckWorkload : TestWorkload
 					.detail("DestServerSize", destStorageServers.size())
 					.detail("ConfigStorageTeamSize", configuration.storageTeamSize)
 					.detail("UsableRegions", configuration.usableRegions);
-				//MX: record the server reponsible for the problematic shards
+				// Record the server reponsible for the problematic shards
 				int i = 0;
 				for ( auto& id : sourceStorageServers ) {
 					TraceEvent("IncorrectSizeTeamInfo").detail("ServerUID", id).detail("TeamIndex", i++);
 				}
-				//TraceEvent(SevError, "QuitCheck").detail("ErrorOnPurpose", *(int *) NULL);
 				self->testFailure("Invalid team size");
 				return false;
 			}

--- a/fdbserver/workloads/ConsistencyCheck.actor.cpp
+++ b/fdbserver/workloads/ConsistencyCheck.actor.cpp
@@ -630,14 +630,16 @@ struct ConsistencyCheckWorkload : TestWorkload
 			//In a quiescent database, check that the team size is the same as the desired team size
 			if(self->firstClient && self->performQuiescentChecks && sourceStorageServers.size() != configuration.usableRegions*configuration.storageTeamSize)
 			{
-				TraceEvent("ConsistencyCheck_InvalidTeamSize").detail("ShardBegin", printable(range.begin))
-					.detail("ShardEnd", printable(range.end)).detail("SourceTeamSize", sourceStorageServers.size())
-					.detail("DestServerSize", destStorageServers.size())
-					.detail("ConfigStorageTeamSize", configuration.storageTeamSize)
-					.detail("UsableRegions", configuration.usableRegions);
+				TraceEvent("ConsistencyCheck_InvalidTeamSize")
+				    .detail("ShardBegin", printable(range.begin))
+				    .detail("ShardEnd", printable(range.end))
+				    .detail("SourceTeamSize", sourceStorageServers.size())
+				    .detail("DestServerSize", destStorageServers.size())
+				    .detail("ConfigStorageTeamSize", configuration.storageTeamSize)
+				    .detail("UsableRegions", configuration.usableRegions);
 				// Record the server reponsible for the problematic shards
 				int i = 0;
-				for ( auto& id : sourceStorageServers ) {
+				for (auto& id : sourceStorageServers) {
 					TraceEvent("IncorrectSizeTeamInfo").detail("ServerUID", id).detail("TeamIndex", i++);
 				}
 				self->testFailure("Invalid team size");
@@ -1079,8 +1081,10 @@ struct ConsistencyCheckWorkload : TestWorkload
 					}
 				}
 				if( !found ) {
-					TraceEvent("ConsistencyCheck_NoStorage").detail("Address", workers[i].first.address())
-						.detail("ProcessClassEqualToStorageClass", (int) (workers[i].second == ProcessClass::StorageClass));
+					TraceEvent("ConsistencyCheck_NoStorage")
+					    .detail("Address", workers[i].first.address())
+					    .detail("ProcessClassEqualToStorageClass",
+					            (int)(workers[i].second == ProcessClass::StorageClass));
 					missingStorage.insert(workers[i].first.locality.dcId());
 				}
 			}

--- a/fdbserver/workloads/RemoveServersSafely.actor.cpp
+++ b/fdbserver/workloads/RemoveServersSafely.actor.cpp
@@ -247,6 +247,7 @@ struct RemoveServersSafelyWorkload : TestWorkload {
 		int	randomIndex;
 		bool bCanKillProcess;
 		ISimulator::ProcessInfo*	randomProcess;
+
 		for (int killsLeft = killProcArray.size(); killsLeft > 0; killsLeft --)
 		{
 			// Select a random kill process
@@ -268,7 +269,7 @@ struct RemoveServersSafelyWorkload : TestWorkload {
 				killableProcesses.push_back(randomProcess);
 				killableAddrs.push_back(AddressExclusion(randomProcess->address.ip, randomProcess->address.port));
 				TraceEvent("RemoveAndKill").detail("Step", "identifyVictim")
-					.detail("VictimCount", killableAddrs.size()).detail("Victim",randomProcess->toString())
+					.detail("VictimCount", killableAddrs.size()).detail("Victim", randomProcess->toString())
 					.detail("Victims", describe(killableAddrs));
 			}
 			// Move the process to the keep array

--- a/fdbserver/workloads/RemoveServersSafely.actor.cpp
+++ b/fdbserver/workloads/RemoveServersSafely.actor.cpp
@@ -268,9 +268,11 @@ struct RemoveServersSafelyWorkload : TestWorkload {
 			if (bCanKillProcess) {
 				killableProcesses.push_back(randomProcess);
 				killableAddrs.push_back(AddressExclusion(randomProcess->address.ip, randomProcess->address.port));
-				TraceEvent("RemoveAndKill").detail("Step", "identifyVictim")
-					.detail("VictimCount", killableAddrs.size()).detail("Victim", randomProcess->toString())
-					.detail("Victims", describe(killableAddrs));
+				TraceEvent("RemoveAndKill")
+				    .detail("Step", "identifyVictim")
+				    .detail("VictimCount", killableAddrs.size())
+				    .detail("Victim", randomProcess->toString())
+				    .detail("Victims", describe(killableAddrs));
 			}
 			// Move the process to the keep array
 			else {


### PR DESCRIPTION
Current server team collection logic does not consider
the fact that multipe storage servers can run on the same machine.
When multiple machines fail, all servers on the machines will fail, and
the possibility of having one process team fail and lose data is very high.

To reduce the possibility of losing data when multiple machine fails,
we first create machine teams which span across different fault zones;
we then create server teams based on machine teams by
first picking 1 machine team, and then
picking 1 server from each machine in the machine team.

---
This version is tested and need Evan review.
Not ready to merge into master before Evan review
---

Signed-off-by: Meng Xu <meng_xu@apple.com>