### PR TITLE
Offer a knob to disable the use of O_DIRECT

### DIFF
--- a/flow/Knobs.cpp
+++ b/flow/Knobs.cpp
@@ -76,6 +76,8 @@ FlowKnobs::FlowKnobs(bool randomize, bool isSimulated) {
 	//AsyncFileKAIO
 	init( MAX_OUTSTANDING,                                      64 );
 	init( MIN_SUBMIT,                                           10 );
+	init( USE_O_DIRECT,                                          1 );
+
 
 	init( PAGE_WRITE_CHECKSUM_HISTORY,                           0 ); if( randomize && BUGGIFY ) PAGE_WRITE_CHECKSUM_HISTORY = 10000000;
 

--- a/flow/Knobs.h
+++ b/flow/Knobs.h
@@ -96,6 +96,7 @@ public:
 	//AsyncFileKAIO
 	int MAX_OUTSTANDING;
 	int MIN_SUBMIT;
+	int USE_O_DIRECT;
 
 	int PAGE_WRITE_CHECKSUM_HISTORY;
 


### PR DESCRIPTION
This allows FDB to run on systems that don't support O_DIRECT, but at a potentially large performance and 2x memory penalty.

This "fixes" #842.