### PR TITLE
Fix operator problems like those mentioned in GitHub issue #606

### DIFF
--- a/flow/flow.h
+++ b/flow/flow.h
@@ -177,12 +177,6 @@ public:
 		}
 	}
 
-	bool operator == (Optional const& o) const {
-		return present() == o.present() && (!present() || get() == o.get());
-	}
-	bool operator != (Optional const& o) const {
-		return !(*this == o);
-	}
 	// Ordering: If T is ordered, then Optional() < Optional(t) and (Optional(u)<Optional(v))==(u<v)
 	bool operator < (Optional const& o) const {
 		if (present() != o.present()) return o.present();
@@ -193,6 +187,16 @@ private:
 	typename std::aligned_storage< sizeof(T), __alignof(T) >::type value;
 	bool valid;
 };
+
+template <class T>
+bool operator == (Optional<T> const& lhs, Optional<T> const& rhs) {
+	return lhs.present() == rhs.present() && (!lhs.present() || lhs.get() == rhs.get());
+}
+
+template <class T>
+bool operator != (Optional<T> const& lhs, Optional<T> const& rhs) {
+	return !(lhs == rhs);
+}
 
 template <class T>
 class ErrorOr {
@@ -254,19 +258,6 @@ public:
 		}
 	}
 
-	bool operator == (ErrorOr const& o) const {
-		return error == o.error && (!present() || get() == o.get());
-	}
-	bool operator != (ErrorOr const& o) const {
-		return !(*this == o);
-	}
-
-	bool operator < (ErrorOr const& o) const {
-		if (error != o.error) return error < o.error;
-		if (!present()) return false;
-		return get() < o.get();
-	}
-
 	bool isError() const { return error.code() != invalid_error_code; }
 	bool isError(int code) const { return error.code() == code; }
 	Error getError() const { ASSERT(isError()); return error; }
@@ -275,6 +266,23 @@ private:
 	typename std::aligned_storage< sizeof(T), __alignof(T) >::type value;
 	Error error;
 };
+
+
+template <typename T>
+bool operator == (ErrorOr<T> const& lhs, ErrorOr<T> const& rhs) {
+	return lhs.error == rhs.error && (!lhs.present() || lhs.get() == rhs.get());
+}
+template <typename T>
+bool operator != (ErrorOr<T> const& lhs, ErrorOr<T> const& rhs) {
+	return !(lhs == rhs);
+}
+
+template <typename T>
+bool operator < (ErrorOr<T> const& lhs, ErrorOr<T> const& rhs) {
+	if (lhs.error != rhs.error) return lhs.error < rhs.error;
+	if (!lhs.present()) return false;
+	return lhs.get() < rhs.get();
+}
 
 template <class T>
 struct Callback {


### PR DESCRIPTION
So the code as written works well on older gcc, but does not like newer gcc.  I
don't fully know why member operators seem to be more in conflict with different
compiler versions, but experience has taught me to always use non-member
operators for maximum portability across compilers.

Make a small change to that effect here.

Signed-off-by: Robert Escriva <rescriva@dropbox.com>