### PR TITLE
tuple.Tuple needs to be deconstructed into TupleElement items

### DIFF
--- a/recipes/go-recipes/doc.go
+++ b/recipes/go-recipes/doc.go
@@ -210,7 +210,7 @@ func (doc Doc) GetDoc(trtr fdb.Transactor, doc_id int) interface{} {
 			if err != nil {
 				panic(err)
 			}
-			tuples = append(tuples, append(tup[1:len(tup)], _unpack(v.Value)))
+			tuples = append(tuples, append(tup[1:len(tup)], _unpack(v.Value)...))
 		}
 		return nil, nil
 	})


### PR DESCRIPTION
Constructing a Tuple for later decoding requires an array of TupleElement. The `_unpack` function returns a Tuple, requiring the result of that function to be deconstructed into the key Tuple.