### PR TITLE
Add a test that's intended to test tuple encoding. Currently, it only…

### DIFF
--- a/bindings/bindingtester/__init__.py
+++ b/bindings/bindingtester/__init__.py
@@ -58,14 +58,17 @@ class Result:
         self.key_tuple = subspace.unpack(key)
         self.values = values
 
-    def matches(self, rhs, specification):
+    def matches_key(self, rhs, specification):
         if not isinstance(rhs, Result):
             return False
 
         left_key = self.key_tuple[specification.key_start_index:]
-        right_key = self.key_tuple[specification.key_start_index:]
+        right_key = rhs.key_tuple[specification.key_start_index:]
 
-        if len(left_key) != len(right_key) or left_key != right_key:
+        return left_key == right_key
+
+    def matches(self, rhs, specification):
+        if not self.matches_key(rhs, specification):
             return False
 
         for value in self.values:

--- a/bindings/bindingtester/bindingtester.py
+++ b/bindings/bindingtester/bindingtester.py
@@ -90,7 +90,7 @@ class ResultSet(object):
             if any([s is not None for s in sequence_nums]):
                 results = {i: r for i, r in results.items() if r.sequence_num(self.specification) == min(sequence_nums)}
             else:
-                results = {i: r for i, r in results.items() if r.matches(min(results.values()), self.specification)}
+                results = {i: r for i, r in results.items() if r.matches_key(min(results.values()), self.specification)}
 
             for i in results.keys():
                 indices[i] += 1

--- a/bindings/bindingtester/tests/__init__.py
+++ b/bindings/bindingtester/tests/__init__.py
@@ -181,8 +181,8 @@ class InstructionSet(TestInstructions, list):
             tr[subspace.pack((start + i,))] = instruction.to_value()
 
     def insert_operations(self, db, subspace):
-        for i in range(0, int(math.ceil(len(self) / 1000.0))):
-            self._insert_operations_transactional(db, subspace, i * 1000, 1000)
+        for i in range(0, int(math.ceil(len(self) / 5000.0))):
+            self._insert_operations_transactional(db, subspace, i * 5000, 5000)
 
 
 class ThreadedInstructionSet(TestInstructions):

--- a/bindings/bindingtester/tests/tuple.py
+++ b/bindings/bindingtester/tests/tuple.py
@@ -1,0 +1,91 @@
+#
+# tuple.py
+#
+# This source file is part of the FoundationDB open source project
+#
+# Copyright 2013-2018 Apple Inc. and the FoundationDB project authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import random
+import struct
+
+import fdb
+import fdb.tuple
+
+from bindingtester import FDB_API_VERSION
+from bindingtester import util
+from bindingtester.tests import Test, Instruction, InstructionSet, ResultSpecification
+from bindingtester.tests import test_util
+
+fdb.api_version(FDB_API_VERSION)
+
+class TupleTest(Test):
+    def __init__(self, subspace):
+        super(TupleTest, self).__init__(subspace)
+        self.workspace = self.subspace['workspace']  # The keys and values here must match between subsequent runs of the same test
+        self.stack_subspace = self.subspace['stack']
+
+    def setup(self, args):
+        self.max_int_bits = args.max_int_bits
+        self.api_version = args.api_version
+
+    def generate(self, args, thread_number):
+        instructions = InstructionSet()
+
+        min_value = -2**self.max_int_bits+1
+        max_value = 2**self.max_int_bits-1
+
+        instructions.append('NEW_TRANSACTION')
+
+        # Test integer encoding
+        mutations = 0
+        for i in range(0, self.max_int_bits+1):
+            for sign in [-1, 1]:
+                sign_str = '' if sign == 1 else '-'
+                for offset in range(-10, 11):
+                    val = (2**i) * sign + offset
+                    if val >= min_value and val <= max_value:
+                        if offset == 0:
+                            add_str = ''
+                        elif offset > 0:
+                            add_str = '+%d' % offset
+                        else:
+                            add_str = '%d' % offset
+
+                        instructions.push_args(1, val)
+                        instructions.append('TUPLE_PACK')
+                        instructions.push_args(self.workspace.pack(('%s2^%d%s' % (sign_str, i, add_str),)))
+                        instructions.append('SET')
+                        mutations += 1
+
+            if mutations >= 5000:
+                test_util.blocking_commit(instructions)
+                mutations = 0
+
+        instructions.begin_finalization()
+
+        test_util.blocking_commit(instructions)
+        instructions.push_args(self.stack_subspace.key())
+        instructions.append('LOG_STACK')
+
+        test_util.blocking_commit(instructions)
+
+        return instructions
+
+    def get_result_specifications(self):
+        return [
+            ResultSpecification(self.workspace, global_error_filter=[1007, 1021]),
+            ResultSpecification(self.stack_subspace, key_start_index=1, ordering_index=1, global_error_filter=[1007, 1021]),
+        ]


### PR DESCRIPTION
… checks the encoding of integers at and near the boundaries of every extra bit (i.e. 2^1, 2^2, 2^3, ...). Fixed some bugs in the binding tester results checking that made it hard to interpret results. Commit more instructions in a batch.