### PR TITLE
blobstore: case insensitive ETag header

### DIFF
--- a/fdbrpc/BlobStore.actor.cpp
+++ b/fdbrpc/BlobStore.actor.cpp
@@ -26,6 +26,7 @@
 #include <time.h>
 #include <boost/algorithm/string/split.hpp>
 #include <boost/algorithm/string/classification.hpp>
+#include <boost/algorithm/string/predicate.hpp>
 #include "fdbrpc/IAsyncFile.h"
 
 json_spirit::mObject BlobStoreEndpoint::Stats::getJSON() {
@@ -956,7 +957,7 @@ ACTOR Future<std::string> uploadPart_impl(Reference<BlobStoreEndpoint> bstore, s
 	std::string etag;
 
 	for (const auto &h : r->headers) {
-		if(0 == strcasecmp(h.first.c_str(), "etag")) {
+		if(boost::iequals(h.first, "etag")) {
 			etag = h.second;
 			break;
 		}

--- a/fdbrpc/BlobStore.actor.cpp
+++ b/fdbrpc/BlobStore.actor.cpp
@@ -953,7 +953,14 @@ ACTOR Future<std::string> uploadPart_impl(Reference<BlobStoreEndpoint> bstore, s
 		throw checksum_failed();
 
 	// No etag -> bad response.
-	std::string etag = r->headers["ETag"];
+	std::string etag;
+
+	for (const auto &h : r->headers) {
+		if(0 == strcasecmp(h.first.c_str(), "etag")) {
+			etag = h.second;
+			break;
+		}
+	}
 	if(etag.empty())
 		throw http_bad_response();
 


### PR DESCRIPTION
https://github.com/minio/minio returns "Etag" header instead of "ETag". HTTP protocol it allows