### PR TITLE
document Begin and End members of KeyRange

### DIFF
--- a/bindings/go/src/fdb/range.go
+++ b/bindings/go/src/fdb/range.go
@@ -90,7 +90,10 @@ type ExactRange interface {
 // that the default zero-value of KeyRange specifies an empty range before all
 // keys in the database.
 type KeyRange struct {
-	Begin, End KeyConvertible
+	// the begin (inclusive)
+	Begin,
+	// the end (exclusive)
+	End KeyConvertible
 }
 
 // FDBRangeKeys allows KeyRange to satisfy the ExactRange interface.

--- a/bindings/go/src/fdb/range.go
+++ b/bindings/go/src/fdb/range.go
@@ -90,9 +90,9 @@ type ExactRange interface {
 // that the default zero-value of KeyRange specifies an empty range before all
 // keys in the database.
 type KeyRange struct {
-	// the begin (inclusive)
+	// The (inclusive) beginning of the range
 	Begin,
-	// the end (exclusive)
+	// The (exclusive) end of the range
 	End KeyConvertible
 }
 

--- a/bindings/go/src/fdb/range.go
+++ b/bindings/go/src/fdb/range.go
@@ -91,7 +91,8 @@ type ExactRange interface {
 // keys in the database.
 type KeyRange struct {
 	// The (inclusive) beginning of the range
-	Begin,
+	Begin KeyConvertible
+	
 	// The (exclusive) end of the range
 	End KeyConvertible
 }


### PR DESCRIPTION
This allows friendly hints by tools that have go doc integration or alike.