### PR TITLE
New backup folder scheme which results in far fewer kv range folders

### DIFF
--- a/fdbclient/BackupAgent.h
+++ b/fdbclient/BackupAgent.h
@@ -615,6 +615,15 @@ public:
 		return configSpace.pack(LiteralStringRef(__FUNCTION__));
 	}
 
+	// Number of kv range files that were both committed to persistent storage AND inserted into
+	// the snapshotRangeFileMap.  Note that since insertions could replace 1 or more existing
+	// map entries this is not necessarily the number of entries currently in the map.
+	// This value exists to help with sizing of kv range folders for BackupContainers that 
+	// require it.
+	KeyBackedBinaryValue<int64_t> snapshotRangeFileCount() {
+		return configSpace.pack(LiteralStringRef(__FUNCTION__));
+	}
+
 	// Coalesced set of ranges already dispatched for writing.
 	typedef KeyBackedMap<Key, bool> RangeDispatchMapT;
 	RangeDispatchMapT snapshotRangeDispatchMap() {
@@ -671,6 +680,7 @@ public:
 			
 			copy.snapshotBeginVersion().set(tr, beginVersion.get());
 			copy.snapshotTargetEndVersion().set(tr, endVersion);
+			copy.snapshotRangeFileCount().set(tr, 0);
 
 			return Void();
 		});

--- a/fdbclient/BackupContainer.actor.cpp
+++ b/fdbclient/BackupContainer.actor.cpp
@@ -454,7 +454,7 @@ public:
 		});
 	}
 
-	// List range files which contain data at or between beginVersion and endVersion
+	// List range files, sorted in version order, which contain data at or between beginVersion and endVersion
 	// Note: The contents of each top level snapshot.N folder do not necessarily constitute a valid snapshot
 	// and therefore listing files is not how RestoreSets are obtained.
 	// Note: Snapshots partially written using FDB versions prior to 6.0.16 will have some range files stored
@@ -466,7 +466,7 @@ public:
 		// Define filter function (for listFiles() implementations that use it) to reject any folder
 		// starting after endVersion
 		std::function<bool(std::string const &)> pathFilter = [=](std::string const &path) {
-			return extractSnapshotBeginVersion(path) > endVersion;
+			return extractSnapshotBeginVersion(path) <= endVersion;
 		};
 
 		Future<std::vector<RangeFile>> newFiles = map(listFiles("kvranges/", pathFilter), [=](const FilesAndSizesT &files) {

--- a/fdbclient/BackupContainer.actor.cpp
+++ b/fdbclient/BackupContainer.actor.cpp
@@ -481,7 +481,8 @@ public:
 
 		return map(success(oldFiles) && success(newFiles), [=](Void _) {
 			std::vector<RangeFile> results = std::move(newFiles.get());
-			results.insert(results.end(), std::make_move_iterator(oldFiles.get().begin()), std::make_move_iterator(oldFiles.get().end()));
+			std::vector<RangeFile> oldResults = std::move(oldFiles.get());
+			results.insert(results.end(), std::make_move_iterator(oldResults.begin()), std::make_move_iterator(oldResults.end()));
 			std::sort(results.begin(), results.end());
 			return results;
 		});

--- a/fdbclient/BackupContainer.h
+++ b/fdbclient/BackupContainer.h
@@ -156,7 +156,7 @@ public:
 
 	// Open a log file or range file for writing
 	virtual Future<Reference<IBackupFile>> writeLogFile(Version beginVersion, Version endVersion, int blockSize) = 0;
-	virtual Future<Reference<IBackupFile>> writeRangeFile(Version version, int blockSize) = 0;
+	virtual Future<Reference<IBackupFile>> writeRangeFile(Version snapshotBeginVersion, int snapshotFileCount, Version fileVersion, int blockSize) = 0;
 
 	// Write a KeyspaceSnapshotFile of range file names representing a full non overlapping
 	// snapshot of the key ranges this backup is targeting.

--- a/flow/genericactors.actor.h
+++ b/flow/genericactors.actor.h
@@ -296,6 +296,16 @@ Future<Void> store(Future<T> what, T &out) {
 	return map(what, [&out](T const &v) { out = v; return Void(); });
 }
 
+template<class T>
+Future<Void> storeOrThrow(Future<Optional<T>> what, T &out, Error e = key_not_found()) {
+	return map(what, [&out,e](Optional<T> const &o) {
+		if(!o.present())
+			throw e;
+		out = o.get();
+		return Void();
+	});
+}
+
 //Waits for a future to be ready, and then applies an asynchronous function to it.
 ACTOR template<class T, class F, class U = decltype( fake<F>()(fake<T>()).getValue() )>
 Future<U> mapAsync(Future<T> what, F actorFunc)


### PR DESCRIPTION
BackupContainerFileSystem (used for local dir and blobstore bucket locations) was spreading kv range files across multiple folders based only on the read version of the data they contained.  For rapid snapshots, this results in at most thousands of files per folder, but for slow snapshots (the norm with continuous backup) it results in many folders which contain only a few files or even just 1. 

The new scheme organizes kv range files into a folder based on the start version of the snapshot they were created for and then a bin number which starts with 0 and increases approximately every 5,000 files.  This results in folders with about 5,000 files each, so recursive parallel list operations such as those required by expire operations are now much faster as they have much less request overhead per file found.

This change is backward compatible for reading backups.  In simulation, kv range files are generated using both the old and the new folder schemes in order to test backward compatibility.