### PR TITLE
Remove whitespace to fix go fmt check

### DIFF
--- a/bindings/go/src/fdb/range.go
+++ b/bindings/go/src/fdb/range.go
@@ -92,7 +92,7 @@ type ExactRange interface {
 type KeyRange struct {
 	// The (inclusive) beginning of the range
 	Begin KeyConvertible
-	
+
 	// The (exclusive) end of the range
 	End KeyConvertible
 }


### PR DESCRIPTION
This currently causes builds of the go bindings to fail, as we enforce formatting rules before allowing the go bindings to build.