### PR TITLE
Fix Go bindings possible nested comment warnings

### DIFF
--- a/bindings/go/src/fdb/database.go
+++ b/bindings/go/src/fdb/database.go
@@ -86,7 +86,7 @@ func retryable(wrapped func() (interface{}, error), onError func(Error) FutureNi
 	for {
 		ret, e = wrapped()
 
-		/* No error means success! */
+		// No error means success!
 		if e == nil {
 			return
 		}
@@ -96,8 +96,8 @@ func retryable(wrapped func() (interface{}, error), onError func(Error) FutureNi
 			e = onError(ep).Get()
 		}
 
-		/* If OnError returns an error, then it's not
-		/* retryable; otherwise take another pass at things */
+		// If OnError returns an error, then it's not
+		// retryable; otherwise take another pass at things
 		if e != nil {
 			return
 		}
@@ -125,7 +125,7 @@ func retryable(wrapped func() (interface{}, error), onError func(Error) FutureNi
 // Transaction and Database objects.
 func (d Database) Transact(f func(Transaction) (interface{}, error)) (interface{}, error) {
 	tr, e := d.CreateTransaction()
-	/* Any error here is non-retryable */
+	// Any error here is non-retryable
 	if e != nil {
 		return nil, e
 	}
@@ -165,7 +165,7 @@ func (d Database) Transact(f func(Transaction) (interface{}, error)) (interface{
 // Transaction, Snapshot and Database objects.
 func (d Database) ReadTransact(f func(ReadTransaction) (interface{}, error)) (interface{}, error) {
 	tr, e := d.CreateTransaction()
-	/* Any error here is non-retryable */
+	// Any error here is non-retryable
 	if e != nil {
 		return nil, e
 	}

--- a/bindings/go/src/fdb/fdb.go
+++ b/bindings/go/src/fdb/fdb.go
@@ -37,9 +37,9 @@ import (
 	"unsafe"
 )
 
-/* Would put this in futures.go but for the documented issue with
-/* exports and functions in preamble
-/* (https://code.google.com/p/go-wiki/wiki/cgo#Global_functions) */
+// Would put this in futures.go but for the documented issue with
+// exports and functions in preamble
+// (https://code.google.com/p/go-wiki/wiki/cgo#Global_functions)
 //export unlockMutex
 func unlockMutex(p unsafe.Pointer) {
 	m := (*sync.Mutex)(p)


### PR DESCRIPTION
When using the Go bindings in a project, you can get compilation warnings for the `/*` in the comment blocks. These warnings seem unnecessary.

Warning is:

```
# github.com/apple/foundationdb/bindings/go/src/fdb
In file included from _cgo_export.c:4:
cgo-gcc-export-header-prolog:43:1: warning: '/*' within block comment [-Wcomment]
cgo-gcc-export-header-prolog:44:1: warning: '/*' within block comment [-Wcomment]
```

I wasn't too sure on the correct code style to fix these errors so if there's a different one, feel free to change or suggest differently.

These warnings can cause noise in IDEs that try to parse the error/warning messages during a build.