### PR TITLE
Fix backup rangefile count init

### DIFF
--- a/fdbclient/FileBackupAgent.actor.cpp
+++ b/fdbclient/FileBackupAgent.actor.cpp
@@ -1143,7 +1143,7 @@ namespace fileBackup {
 
 							Void _ = wait(taskBucket->keepRunning(tr, task)
 								&& storeOrThrow(backup.snapshotBeginVersion().get(tr), snapshotBeginVersion)
-								&& storeOrThrow(backup.snapshotRangeFileCount().get(tr), snapshotRangeFileCount)
+								&& store(backup.snapshotRangeFileCount().getD(tr), snapshotRangeFileCount)
 							);
 
 							break;

--- a/flow/Platform.cpp
+++ b/flow/Platform.cpp
@@ -463,7 +463,7 @@ void getDiskBytes(std::string const& directory, int64_t& free, int64_t& total) {
 #elif defined(__APPLE__)
 	struct statfs buf;
 	if (statfs(directory.c_str(), &buf)) {
-		Error e = systemErrorCodeToError() 
+		Error e = systemErrorCodeToError();
 		TraceEvent(SevError, "GetDiskBytesStatfsError").detail("Directory", directory).GetLastError().error(e);
 		throw e;
 	}


### PR DESCRIPTION
Bug fix for issue where backups started with version <= 6.0.15 will stop making snapshot progress and log key_not_found errors after upgrade to 6.0.16.  Mutation log backup is not affected.  Snapshot progress will resume after this fix.