### PR TITLE
Bug fix, after upgrade to 6.0.16 backup snapshot progress will halt

### DIFF
--- a/fdbclient/FileBackupAgent.actor.cpp
+++ b/fdbclient/FileBackupAgent.actor.cpp
@@ -1143,7 +1143,7 @@ namespace fileBackup {
 
 							Void _ = wait(taskBucket->keepRunning(tr, task)
 								&& storeOrThrow(backup.snapshotBeginVersion().get(tr), snapshotBeginVersion)
-								&& storeOrThrow(backup.snapshotRangeFileCount().get(tr), snapshotRangeFileCount)
+								&& store(backup.snapshotRangeFileCount().getD(tr), snapshotRangeFileCount)
 							);
 
 							break;


### PR DESCRIPTION
Backups started with version <= 6.0.15 will stop making snapshot progress and log key_not_found errors after upgrade to 6.0.16. Mutation log backup is not affected. Snapshot progress will resume after this fix.