### PR TITLE
Removed typo in go binding `fdb-go-install.sh` file

### DIFF
--- a/bindings/go/fdb-go-install.sh
+++ b/bindings/go/fdb-go-install.sh
@@ -63,7 +63,7 @@ function printUsage() {
     echo
     echo "cmd: One of the commands to run. The options are:"
     echo "     install         Download the FDB go bindings and install them"
-    echo "     localinstall    Install a into the go path a local copy of the repo"
+    echo "     localinstall    Install into the go path a local copy of the repo"
     echo "     download        Download but do not prepare the FoundationDB bindings"
     echo "     help            Print this help message and then quit"
     echo


### PR DESCRIPTION
When I run `sh ./foundationdb/bindings/go/fdb-go-install.sh` I noticed what appeared to be an extra word (`a`) in the `localinstall` command description.

**Changes**
* Extra word removed from help description of `localinstall` command [a1a88b2](https://github.com/apple/foundationdb/commit/a1a88b2f474ec268b5e7947cff2dbdb61fb03a78)