### PR TITLE
 Use abspath when dealing with the simulator file-cache

### DIFF
--- a/fdbrpc/sim2.actor.cpp
+++ b/fdbrpc/sim2.actor.cpp
@@ -1718,7 +1718,7 @@ Future< Reference<class IAsyncFile> > Sim2FileSystem::open( std::string filename
 	if (flags & IAsyncFile::OPEN_UNCACHED) {
 		auto& machineCache = g_simulator.getCurrentProcess()->machine->openFiles;
 		std::string actualFilename = abspath(filename);
-		if ( machineCache.find(filename) == machineCache.end() ) {
+		if ( machineCache.find(actualFilename) == machineCache.end() ) {
 			if(flags & IAsyncFile::OPEN_ATOMIC_WRITE_AND_CREATE) {
 				actualFilename = filename + ".part";
 				auto partFile = machineCache.find(actualFilename);

--- a/fdbrpc/sim2.actor.cpp
+++ b/fdbrpc/sim2.actor.cpp
@@ -1717,7 +1717,7 @@ Future< Reference<class IAsyncFile> > Sim2FileSystem::open( std::string filename
 
 	if (flags & IAsyncFile::OPEN_UNCACHED) {
 		auto& machineCache = g_simulator.getCurrentProcess()->machine->openFiles;
-		std::string actualFilename = filename;
+		std::string actualFilename = abspath(filename);
 		if ( machineCache.find(filename) == machineCache.end() ) {
 			if(flags & IAsyncFile::OPEN_ATOMIC_WRITE_AND_CREATE) {
 				actualFilename = filename + ".part";
@@ -1745,7 +1745,7 @@ Future< Reference<class IAsyncFile> > Sim2FileSystem::open( std::string filename
 // Deletes the given file.  If mustBeDurable, returns only when the file is guaranteed to be deleted even after a power failure.
 Future< Void > Sim2FileSystem::deleteFile( std::string filename, bool mustBeDurable )
 {
-	return Sim2::deleteFileImpl(&g_sim2, filename, mustBeDurable);
+	return Sim2::deleteFileImpl(&g_sim2, abspath(filename), mustBeDurable);
 }
 
 Future< std::time_t > Sim2FileSystem::lastWriteTime( std::string filename ) {


### PR DESCRIPTION
+cc @mpilman

These are cherry picked commits from #974, with integration into the vcxproj-based build system instead of CMake. I'm trying to split up the review work, and have only checked that this PR compiles.

There was a bit of previous discussion about this change on #974:

> > alexmiller-apple:
> > This is something I had talked over with @satherton before, who seemed of the opinion that not closing files was an intentional feature, due to it then properly emulating that one can open a file, do changes, close the file, open the file again, and get a copy of the file that's different from what's persisted on disk.
> >
> mpilman:
> I think you misunderstand this fix. The problem with the current code is that deleted files will not be closed. I did not remove the file cache (so if a file is opened several times - they will still share a file descriptor). Also files can still be opened and closed again. Without this change, the simulator will leak file descriptors. This was very problematic for us when we introduced a simulator feature (which we will port later) that runs more than one FDB cluster in the simulator - as the number of simulated machines will go up by a constant factor we quickly ran out of file descriptors when running tests.
