### PR TITLE
TeamCollection: Fix build in osX

### DIFF
--- a/fdbrpc/ReplicationTypes.h
+++ b/fdbrpc/ReplicationTypes.h
@@ -22,6 +22,7 @@
 #define FLOW_REPLICATION_TYPES_H
 #pragma once
 
+#include <sstream>
 #include "flow/flow.h"
 #include "fdbrpc/Locality.h"
 
@@ -142,14 +143,15 @@ struct LocalityRecord : public ReferenceCounted<LocalityRecord> {
 	}
 
 	std::string toString() {
-		std::string str = "KeyValueArraySize:" + _dataMap->_keyvaluearray.size();
+		std::stringstream ss;
+		ss << "KeyValueArraySize:" << _dataMap->_keyvaluearray.size();
 		for (int i = 0; i < _dataMap->size(); ++i) {
 			AttribRecord attribRecord = _dataMap->_keyvaluearray[i]; // first is key, second is value
-			str += " KeyValueArrayIndex:" + std::to_string(i) + " Key:" + std::to_string(attribRecord.first._id) +
-			       " Value:" + std::to_string(attribRecord.second._id);
+			ss << " KeyValueArrayIndex:" << i << " Key:" << attribRecord.first._id <<
+			       " Value:" << attribRecord.second._id;
 		}
 
-		return str;
+		return ss.str();
 	}
 };
 

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -25,6 +25,7 @@
 #include "fdbserver/MoveKeys.h"
 #include "fdbserver/Knobs.h"
 #include <set>
+#include <sstream>
 #include "fdbserver/WaitFailure.h"
 #include "fdbserver/ServerDBInfo.h"
 #include "fdbserver/IKeyValueStore.h"
@@ -74,15 +75,14 @@ struct TCMachineInfo : public ReferenceCounted<TCMachineInfo> {
 	}
 
 	std::string getServersIDStr() {
-		std::string str;
+		std::stringstream ss;
 		if (serversOnMachine.empty()) return "[unset]";
 
 		for (auto& server : serversOnMachine) {
-			str += server->id.toString() + " ";
+			ss << server->id.toString() << " ";
 		}
-		str.pop_back();
 
-		return str;
+		return ss.str();
 	}
 };
 
@@ -152,16 +152,15 @@ public:
 	}
 
 	std::string getMachineIDsStr() {
-		std::string str;
+		std::stringstream ss;
 
 		if (this == NULL || machineIDs.empty()) return "[unset]";
 
 		for (auto& id : machineIDs) {
-			str += id.contents().toString() + " ";
+			ss << id.contents().toString() << " ";
 		}
-		str.pop_back();
 
-		return str;
+		return ss.str();
 	}
 
 	int getTotalMachineTeamNumber() {
@@ -210,15 +209,15 @@ public:
 	virtual vector<UID> const& getServerIDs() { return serverIDs; }
 
 	virtual std::string getServerIDsStr() {
-		std::string str;
+		std::stringstream ss;
+
 		if (this == NULL || serverIDs.empty()) return "[unset]";
 
 		for (auto& id : serverIDs) {
-			str += id.toString() + " ";
+			ss << id.toString() << " ";
 		}
-		str.pop_back();
 
-		return str;
+		return ss.str();
 	}
 
 	virtual void addDataInFlightToTeam( int64_t delta ) {


### PR DESCRIPTION
In osX, we cannot adding unsigned long to a string to append to the string.

In this PR, I changed the std::string in any toString() added in PR#964  to std::stringstream to concatenate the information. 

This fixes the build in osX and also has a little performance benefit by avoiding copying the strings around.

This PR has no functionality change and is ready to be merged.
I have run it in the automatically build and it succeeds. 