### PR TITLE
Update redundancy mode descriptions

### DIFF
--- a/documentation/sphinx/source/configuration.rst
+++ b/documentation/sphinx/source/configuration.rst
@@ -355,10 +355,7 @@ FoundationDB will never use processes on the same machine for the replication of
     FoundationDB replicates data to three machines, and at least three available machines are required to make progress. This is the recommended mode for a cluster of five or more machines in a single datacenter.
 
 ``three_data_hall`` mode
-    FoundationDB replicates data to three machines, and at least three available machines are required to make progress. Every piece of data that has been committed to storage servers
-    will be replicated onto three different data halls, and the cluster will
-    remain available after losing a single data hall and one machine in another
-    data hall.
+    FoundationDB stores data in triplicate, with one copy on a storage server in each of three data halls. The transaction logs are replicated four times, with two data halls containing two replicas apiece. Four available machines (two in each of two data halls) are therefore required to make progress. This configuration enables the cluster to remain available after losing a single data hall and one machine in another data hall.
 
 Datacenter-aware mode
 ---------------------
@@ -370,7 +367,7 @@ In addition to the more commonly used modes listed above, this version of Founda
 ``three_datacenter`` mode
     *(for 5+ machines in 3 datacenters)*
 
-    FoundationDB attempts to replicate data across three datacenters and will stay up with only two available. Data is replicated 6 times.  For maximum availability, you should use five coordination servers: two in two of the datacenters and one in the third datacenter.
+    FoundationDB attempts to replicate data across three datacenters and will stay up with only two available. Data is replicated 6 times. Transaction logs are stored in the same configuration as the ``three_data_hall`` mode, so commit latencies are tied to the latency between datacenters. For maximum availability, you should use five coordination servers: two in two of the datacenters and one in the third datacenter.
 
 .. warning:: ``three_datacenter`` mode is not compatible with region configuration.
 

--- a/documentation/sphinx/source/configuration.rst
+++ b/documentation/sphinx/source/configuration.rst
@@ -363,7 +363,7 @@ FoundationDB will never use processes on the same machine for the replication of
 Datacenter-aware mode
 ---------------------
 
-In addition to the more commonly used modes listed above, this version of FoundationDB has support for redundancy across multiple datacenters. Although data will always be triple replicated in this mode, it may not be replicated across all datacenters.
+In addition to the more commonly used modes listed above, this version of FoundationDB has support for redundancy across multiple datacenters.
 
     .. note:: When using the datacenter-aware mode, all ``fdbserver`` processes should be passed a valid datacenter identifier on the command line.
 


### PR DESCRIPTION
Hi, this PR does a couple of things:

1. Removes a description of datacenter-aware mode which is conflicting with the reality of `three_datacenter`'s current implementation. @alecgrieser suggested in [this forum post](https://forums.foundationdb.org/t/cross-datacenter-region/186/5) that perhaps it was referring to an older concept of the mode.

1. Adds a description of the transaction log replication topology for `three_data_hall` and `three_datacenter`, and briefly mentions the availability and latency implications.

1. Edits the description of `three_data_hall` to change the minimum number of machines required to make progress from three to four (and specifically 2x2). [This post](https://forums.foundationdb.org/t/redundancy-mode-three-data-hall/945) indicated some confusion on the topic.

As an aside, I kept the statement that "This configuration enables the cluster to remain available after losing a single data hall and one machine in another data hall"  but I'm not entirely certain I could back up that assertion. I understand how `three_data_hall` survives the loss of a data hall, but I'm not sure what the thinking is behind the loss of that additional machine. Seems like there must be some additional assumptions there (e.g. the use of 9 coordinators).

My first PR to this repo so happy to take any suggestions. I checked that the docs rendered locally but that's about it.