### PR TITLE
Avoid null check to get rid of build error on Mac

### DIFF
--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -154,7 +154,7 @@ public:
 	std::string getMachineIDsStr() {
 		std::stringstream ss;
 
-		if (this == NULL || machineIDs.empty()) return "[unset]";
+		if (machineIDs.empty()) return "[unset]";
 
 		for (auto& id : machineIDs) {
 			ss << id.contents().toString() << " ";
@@ -211,7 +211,7 @@ public:
 	virtual std::string getServerIDsStr() {
 		std::stringstream ss;
 
-		if (this == NULL || serverIDs.empty()) return "[unset]";
+		if (serverIDs.empty()) return "[unset]";
 
 		for (auto& id : serverIDs) {
 			ss << id.toString() << " ";


### PR DESCRIPTION
It seems to me that `this == NULL` can only happen when the object is not initialized.