### PR TITLE
Fix Make build.

### DIFF
--- a/fdbmonitor/fdbmonitor.cpp
+++ b/fdbmonitor/fdbmonitor.cpp
@@ -68,7 +68,7 @@
 #include "flow/SimpleOpt.h"
 #include "SimpleIni.h"
 
-#include "fdbclient/versions.h"
+#include "versions.h"
 
 #ifdef __linux__
 typedef fd_set* fdb_fd_set;


### PR DESCRIPTION
With Makefile build `versions.h` comes from the root directory, not from `fdbclient/versions.h`.

This patch fixes Makefile build but breaks the CMake build. For now, all intentions and purposes, Makefile build is the primary build. We have to find a way to fix CMake build without breaking the current build.