### PR TITLE
fdb.Key implements fmt.Stringer interface

### DIFF
--- a/bindings/go/src/fdb/fdb.go
+++ b/bindings/go/src/fdb/fdb.go
@@ -34,6 +34,7 @@ import (
 	"fmt"
 	"log"
 	"runtime"
+	"strings"
 	"sync"
 	"unsafe"
 )
@@ -382,6 +383,23 @@ func (k Key) String() string {
 // FDBKey allows Key to (trivially) satisfy the KeyConvertible interface.
 func (k Key) FDBKey() Key {
 	return k
+}
+
+// String describes the key as a hexadecimal encoded string.
+func (k Key) String() string {
+	var sb strings.Builder
+	for _, b := range k {
+		if b >= 32 && b < 127 && b != '\\' {
+			sb.WriteByte(b)
+			continue
+		}
+		if b == '\\' {
+			sb.WriteString("\\\\")
+			continue
+		}
+		sb.WriteString(fmt.Sprintf("\\x%x", b))
+	}
+	return sb.String()
 }
 
 func panicToError(e *error) {

--- a/bindings/go/src/fdb/fdb.go
+++ b/bindings/go/src/fdb/fdb.go
@@ -30,6 +30,7 @@ package fdb
 import "C"
 
 import (
+	"encoding/hex"
 	"fmt"
 	"log"
 	"runtime"
@@ -371,6 +372,12 @@ type KeyConvertible interface {
 // Key represents a FoundationDB key, a lexicographically-ordered sequence of
 // bytes. Key implements the KeyConvertible interface.
 type Key []byte
+
+// String returns human readable hexadecimal encoding of the key.
+func (k Key) String() string {
+	return hex.EncodeToString(k)
+}
+
 
 // FDBKey allows Key to (trivially) satisfy the KeyConvertible interface.
 func (k Key) FDBKey() Key {

--- a/bindings/go/src/fdb/fdb.go
+++ b/bindings/go/src/fdb/fdb.go
@@ -30,10 +30,10 @@ package fdb
 import "C"
 
 import (
+	"bytes"
 	"fmt"
 	"log"
 	"runtime"
-	"strings"
 	"sync"
 	"unsafe"
 )
@@ -387,19 +387,19 @@ func (k Key) String() string {
 // ASCII printable characters [32-127) are passed through. Other bytes are
 // replaced with \x followed by a two character zero-padded hex code for byte.
 func Printable(d []byte) string {
-	var sb strings.Builder
+	buf := new(bytes.Buffer)
 	for _, b := range d {
 		if b >= 32 && b < 127 && b != '\\' {
-			sb.WriteByte(b)
+			buf.WriteByte(b)
 			continue
 		}
 		if b == '\\' {
-			sb.WriteString("\\\\")
+			buf.WriteString("\\\\")
 			continue
 		}
-		sb.WriteString(fmt.Sprintf("\\x%02x", b))
+		buf.WriteString(fmt.Sprintf("\\x%02x", b))
 	}
-	return sb.String()
+	return buf.String()
 }
 
 func panicToError(e *error) {

--- a/bindings/go/src/fdb/fdb.go
+++ b/bindings/go/src/fdb/fdb.go
@@ -380,8 +380,15 @@ func (k Key) FDBKey() Key {
 
 // String describes the key as a hexadecimal encoded string.
 func (k Key) String() string {
+	return Printable(k)
+}
+
+// Printable returns a human readable version of a byte array. The bytes that correspond with
+// ASCII printable characters [32-127) are passed through. Other bytes are
+// replaced with \x followed by a two character zero-padded hex code for byte.
+func Printable(d []byte) string {
 	var sb strings.Builder
-	for _, b := range k {
+	for _, b := range d {
 		if b >= 32 && b < 127 && b != '\\' {
 			sb.WriteByte(b)
 			continue

--- a/bindings/go/src/fdb/fdb.go
+++ b/bindings/go/src/fdb/fdb.go
@@ -30,7 +30,6 @@ package fdb
 import "C"
 
 import (
-	"encoding/hex"
 	"fmt"
 	"log"
 	"runtime"
@@ -373,12 +372,6 @@ type KeyConvertible interface {
 // Key represents a FoundationDB key, a lexicographically-ordered sequence of
 // bytes. Key implements the KeyConvertible interface.
 type Key []byte
-
-// String returns human readable hexadecimal encoding of the key.
-func (k Key) String() string {
-	return hex.EncodeToString(k)
-}
-
 
 // FDBKey allows Key to (trivially) satisfy the KeyConvertible interface.
 func (k Key) FDBKey() Key {

--- a/bindings/go/src/fdb/fdb.go
+++ b/bindings/go/src/fdb/fdb.go
@@ -390,7 +390,7 @@ func (k Key) String() string {
 			sb.WriteString("\\\\")
 			continue
 		}
-		sb.WriteString(fmt.Sprintf("\\x%x", b))
+		sb.WriteString(fmt.Sprintf("\\x%02x", b))
 	}
 	return sb.String()
 }

--- a/bindings/go/src/fdb/fdb_test.go
+++ b/bindings/go/src/fdb/fdb_test.go
@@ -268,8 +268,8 @@ func TestKeyToString(t *testing.T) {
 		key    fdb.Key
 		expect string
 	}{
-		{fdb.Key("plain-text"), "plain-text"},
 		{fdb.Key([]byte{0}), "\\x00"},
+		{fdb.Key("plain-text"), "plain-text"},
 		{fdb.Key("\xbdascii☻☺"), "\\xbdascii\\xe2\\x98\\xbb\\xe2\\x98\\xba"},
 	}
 
@@ -278,4 +278,9 @@ func TestKeyToString(t *testing.T) {
 			t.Errorf("got '%v', want '%v' at case %v", s, c.expect, i)
 		}
 	}
+}
+
+func ExamplePrintable() {
+	fmt.Println(fdb.Printable([]byte{0, 1, 2, 'a', 'b', 'c', '1', '2', '3', '!', '?', 255}))
+	// Output: \x00\x01\x02abc123!?\xff
 }

--- a/bindings/go/src/fdb/fdb_test.go
+++ b/bindings/go/src/fdb/fdb_test.go
@@ -24,8 +24,9 @@ package fdb_test
 
 import (
 	"fmt"
-	"github.com/apple/foundationdb/bindings/go/src/fdb"
 	"testing"
+
+	"github.com/apple/foundationdb/bindings/go/src/fdb"
 )
 
 func ExampleOpenDefault() {
@@ -260,4 +261,20 @@ func ExampleRangeIterator() {
 	// apple is foo
 	// banana is bar
 	// cherry is baz
+}
+
+func TestKeyToString(t *testing.T) {
+	cases := []struct {
+		key    fdb.Key
+		expect string
+	}{
+		{fdb.Key("plain-text"), "plain-text"},
+		{fdb.Key("\xbdascii☻☺"), "\\xbdascii\\xe2\\x98\\xbb\\xe2\\x98\\xba"},
+	}
+
+	for i, c := range cases {
+		if s := c.key.String(); s != c.expect {
+			t.Errorf("got '%v', want '%v' at case %v", s, c.expect, i)
+		}
+	}
 }

--- a/bindings/go/src/fdb/fdb_test.go
+++ b/bindings/go/src/fdb/fdb_test.go
@@ -269,6 +269,7 @@ func TestKeyToString(t *testing.T) {
 		expect string
 	}{
 		{fdb.Key("plain-text"), "plain-text"},
+		{fdb.Key([]byte{0}), "\\x00"},
 		{fdb.Key("\xbdascii☻☺"), "\\xbdascii\\xe2\\x98\\xbb\\xe2\\x98\\xba"},
 	}
 


### PR DESCRIPTION
Add the ability to get a human readable string representation of a fdb.Key by satisfying the fmt.Stringer interface. This allows keys to be used with the fmt package.