### PR TITLE
Fix: fast allocator would not cleanup memory for a thread if...

### DIFF
--- a/documentation/sphinx/source/release-notes.rst
+++ b/documentation/sphinx/source/release-notes.rst
@@ -12,6 +12,7 @@ Fixes
 * Blobstore request failures could cause backup expire and delete operations to skip some files. `(PR #1007) <https://github.com/apple/foundationdb/pull/1007>`_
 * Blobstore request failures could cause restore to fail to apply some files. `(PR #1007) <https://github.com/apple/foundationdb/pull/1007>`_
 * Storage servers with large amounts of data would pause for a short period of time after rebooting. `(PR #1001) <https://github.com/apple/foundationdb/pull/1001>`_
+* The client library could leak memory when a thread died.
 
 Features
 --------

--- a/documentation/sphinx/source/release-notes.rst
+++ b/documentation/sphinx/source/release-notes.rst
@@ -12,7 +12,7 @@ Fixes
 * Blobstore request failures could cause backup expire and delete operations to skip some files. `(PR #1007) <https://github.com/apple/foundationdb/pull/1007>`_
 * Blobstore request failures could cause restore to fail to apply some files. `(PR #1007) <https://github.com/apple/foundationdb/pull/1007>`_
 * Storage servers with large amounts of data would pause for a short period of time after rebooting. `(PR #1001) <https://github.com/apple/foundationdb/pull/1001>`_
-* The client library could leak memory when a thread died.
+* The client library could leak memory when a thread died. `(PR #1011) <https://github.com/apple/foundationdb/pull/1011>`_
 
 Features
 --------

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -3562,7 +3562,7 @@ void versionedMapTest() {
 	const int NSIZE = sizeof(VersionedMap<int,int>::PTreeT);
 	const int ASIZE = NSIZE<=64 ? 64 : NextPowerOfTwo<NSIZE>::Result;
 
-	auto before = FastAllocator< ASIZE >::getMemoryUsed();
+	auto before = FastAllocator< ASIZE >::getTotalMemory();
 
 	for(int v=1; v<=1000; ++v) {
 		vm.createNewVersion(v);
@@ -3576,7 +3576,7 @@ void versionedMapTest() {
 		}
 	}
 
-	auto after = FastAllocator< ASIZE >::getMemoryUsed();
+	auto after = FastAllocator< ASIZE >::getTotalMemory();
 
 	int count = 0;
 	for(auto i = vm.atLatest().begin(); i != vm.atLatest().end(); ++i)

--- a/flow/Error.cpp
+++ b/flow/Error.cpp
@@ -115,5 +115,5 @@ void ErrorCodeTable::addCode(int code, const char *name, const char *description
 }
 
 bool isAssertDisabled(int line) {
-	return FLOW_KNOBS->DISABLE_ASSERTS == -1 || FLOW_KNOBS->DISABLE_ASSERTS == line;
+	return FLOW_KNOBS && (FLOW_KNOBS->DISABLE_ASSERTS == -1 || FLOW_KNOBS->DISABLE_ASSERTS == line);
 }

--- a/flow/FastAlloc.h
+++ b/flow/FastAlloc.h
@@ -106,8 +106,9 @@ public:
 	static void release(void* ptr);
 	static void check( void* ptr, bool alloc );
 
-	static long long getMemoryUsed();
-	static long long getMemoryUnused();
+	static long long getTotalMemory();
+	static long long getApproximateMemoryUnused();
+	static long long getActiveThreads();
 
 	static void releaseThreadMagazines();
 
@@ -129,6 +130,7 @@ private:
 		void* alternate;  // alternate is either a full magazine, or an empty one
 	};
 	static thread_local ThreadData threadData;
+	static thread_local bool threadInitialized;
 	static GlobalData* globalData() {
 #ifdef VALGRIND
 		ANNOTATE_RWLOCK_ACQUIRED(vLock, 1);
@@ -144,7 +146,8 @@ private:
 	static void* freelist;
 
 	FastAllocator();  // not implemented
-	static void getMagazine();   // sets threadData.freelist and threadData.count
+	static void initThread();
+	static void getMagazine();   
 	static void releaseMagazine(void*);
 };
 

--- a/flow/Net2.actor.cpp
+++ b/flow/Net2.actor.cpp
@@ -1097,7 +1097,7 @@ void net2_test() {
 
 	Endpoint destination;
 
-	printf("  Used: %lld\n", FastAllocator<4096>::getMemoryUsed());
+	printf("  Used: %lld\n", FastAllocator<4096>::getTotalMemory());
 
 	char junk[100];
 
@@ -1147,6 +1147,6 @@ void net2_test() {
 
 	printf("SimSend x 1Kx10K: %0.2f sec\n", timer()-before);
 	printf("  Bytes: %d\n", totalBytes);
-	printf("  Used: %lld\n", FastAllocator<4096>::getMemoryUsed());
+	printf("  Used: %lld\n", FastAllocator<4096>::getTotalMemory());
 	*/
 };

--- a/flow/Platform.cpp
+++ b/flow/Platform.cpp
@@ -2232,7 +2232,7 @@ std::string getDefaultPluginPath( const char* plugin_name ) {
 }; // namespace platform
 
 #ifdef ALLOC_INSTRUMENTATION
-#define TRACEALLOCATOR( size ) TraceEvent("MemSample").detail("Count", FastAllocator<size>::getMemoryUnused()/size).detail("TotalSize", FastAllocator<size>::getMemoryUnused()).detail("SampleCount", 1).detail("Hash", "FastAllocatedUnused" #size ).detail("Bt", "na")
+#define TRACEALLOCATOR( size ) TraceEvent("MemSample").detail("Count", FastAllocator<size>::getApproximateMemoryUnused()/size).detail("TotalSize", FastAllocator<size>::getApproximateMemoryUnused()).detail("SampleCount", 1).detail("Hash", "FastAllocatedUnused" #size ).detail("Bt", "na")
 #ifdef __linux__
 #include <cxxabi.h>
 #endif

--- a/flow/SystemMonitor.cpp
+++ b/flow/SystemMonitor.cpp
@@ -41,8 +41,8 @@ void systemMonitor() {
 	customSystemMonitor("ProcessMetrics", &statState, true );
 }
 
-#define TRACEALLOCATOR( size ) TraceEvent("MemSample").detail("Count", FastAllocator<size>::getMemoryUnused()/size).detail("TotalSize", FastAllocator<size>::getMemoryUnused()).detail("SampleCount", 1).detail("Hash", "FastAllocatedUnused" #size ).detail("Bt", "na")
-#define DETAILALLOCATORMEMUSAGE( size ) detail("AllocatedMemory"#size, FastAllocator<size>::getMemoryUsed()).detail("ApproximateUnusedMemory"#size, FastAllocator<size>::getMemoryUnused())
+#define TRACEALLOCATOR( size ) TraceEvent("MemSample").detail("Count", FastAllocator<size>::getApproximateMemoryUnused()/size).detail("TotalSize", FastAllocator<size>::getApproximateMemoryUnused()).detail("SampleCount", 1).detail("Hash", "FastAllocatedUnused" #size ).detail("Bt", "na")
+#define DETAILALLOCATORMEMUSAGE( size ) detail("TotalMemory"#size, FastAllocator<size>::getTotalMemory()).detail("ApproximateUnusedMemory"#size, FastAllocator<size>::getApproximateMemoryUnused()).detail("ActiveThreads"#size, FastAllocator<size>::getActiveThreads())
 
 SystemStatistics customSystemMonitor(std::string eventName, StatisticsState *statState, bool machineMetrics) {
 	SystemStatistics currentStats = getSystemStatistics(machineState.folder.present() ? machineState.folder.get() : "", 


### PR DESCRIPTION
…that thread never called getMagazine. This could happen if the first thing the thread did was to release memory.

Added a new metric for the number of threads that hold memory for each size and improve some existing metrics.

Fix: a failed ASSERT would crash if done early in the program lifetime.