### PR TITLE
Revert "Merge pull request #977 from alexmiller-apple/abspath"

### DIFF
--- a/fdbrpc/sim2.actor.cpp
+++ b/fdbrpc/sim2.actor.cpp
@@ -1717,8 +1717,8 @@ Future< Reference<class IAsyncFile> > Sim2FileSystem::open( std::string filename
 
 	if (flags & IAsyncFile::OPEN_UNCACHED) {
 		auto& machineCache = g_simulator.getCurrentProcess()->machine->openFiles;
-		std::string actualFilename = abspath(filename);
-		if ( machineCache.find(actualFilename) == machineCache.end() ) {
+		std::string actualFilename = filename;
+		if ( machineCache.find(filename) == machineCache.end() ) {
 			if(flags & IAsyncFile::OPEN_ATOMIC_WRITE_AND_CREATE) {
 				actualFilename = filename + ".part";
 				auto partFile = machineCache.find(actualFilename);
@@ -1745,7 +1745,7 @@ Future< Reference<class IAsyncFile> > Sim2FileSystem::open( std::string filename
 // Deletes the given file.  If mustBeDurable, returns only when the file is guaranteed to be deleted even after a power failure.
 Future< Void > Sim2FileSystem::deleteFile( std::string filename, bool mustBeDurable )
 {
-	return Sim2::deleteFileImpl(&g_sim2, abspath(filename), mustBeDurable);
+	return Sim2::deleteFileImpl(&g_sim2, filename, mustBeDurable);
 }
 
 Future< std::time_t > Sim2FileSystem::lastWriteTime( std::string filename ) {


### PR DESCRIPTION
Apparently this broke correctness, but we didn't realize it until now because our nightly correctness tests weren't running for the past month and no one noticed. :(

I apologize for reverting before even taking a look at why it's failing, but I'd like nightly runs to start burning cycles on finding what else has broken in the past month.

From a build of a9b1770e87208e9c8256981d7d4dcc0363978dbb

    Tests causing errors:
    Test                                          | Seed                 | Buggify              | Determinism Check    | Error                | Unseed               | Reason          
    ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
    fast/CycleTest.txt                            | 442185656            | True                 | False                | internal_error       | -                    | -               
    fast/InventoryTestAlmostReadOnly.txt          | 489383657            | False                | False                | internal_error       | -                    | -               
    fast/SidebandWithStatus.txt                   | 48106731             | True                 | False                | internal_error       | -                    | -               
    fast/MoveKeysCycle.txt                        | 674060685            | True                 | False                | internal_error       | -                    | -               
    fast/SidebandWithStatus.txt                   | 483749761            | True                 | False                | internal_error       | -                    | -               
    fast/AtomicOps.txt                            | 554287248            | True                 | False                | internal_error       | -                    | -               
    fast/InventoryTestAlmostReadOnly.txt          | 549178168            | True                 | False                | internal_error       | -                    | -               
    fast/WriteDuringRead.txt                      | 67071643             | True                 | False                | internal_error       | -                    | -               
    slow/WriteDuringReadAtomicRestore.txt         | 746572802            | True                 | False                | internal_error       | -                    | -               
    fast/Sideband.txt                             | 240359868            | True                 | False                | internal_error       | -                    | -               
    fast/Sideband.txt                             | 240359868            | True                 | False                | internal_error       | -                    | -               

cc: @mpilman 