### PR TITLE
Add some conveniences for Optional and ErrorOr

### DIFF
--- a/fdbcli/fdbcli.actor.cpp
+++ b/fdbcli/fdbcli.actor.cpp
@@ -136,7 +136,7 @@ public:
 	//Applies all enabled transaction options to the given transaction
 	void apply(Reference<ReadYourWritesTransaction> tr) {
 		for(auto itr = transactionOptions.options.begin(); itr != transactionOptions.options.end(); ++itr)
-			tr->setOption(itr->first, itr->second.cast_to<StringRef>());
+			tr->setOption(itr->first, itr->second.castTo<StringRef>());
 	}
 
 	//Returns true if any options have been set
@@ -174,7 +174,7 @@ private:
 		if(intrans)
 			tr->setOption(option, arg);
 
-		transactionOptions.setOption(option, enabled, arg.cast_to<StringRef>());
+		transactionOptions.setOption(option, enabled, arg.castTo<StringRef>());
 	}
 
 	//A group of enabled options (of type T::Option) as well as a legal options map from string to T::Option
@@ -189,8 +189,8 @@ private:
 		//Enable or disable an option. Returns true if option value changed
 		bool setOption(typename T::Option option, bool enabled, Optional<StringRef> arg) {
 			auto optionItr = options.find(option);
-			if(enabled && (optionItr == options.end() || Optional<Standalone<StringRef>>(optionItr->second).cast_to< StringRef >() != arg)) {
-				options[option] = arg.cast_to<Standalone<StringRef>>();
+			if(enabled && (optionItr == options.end() || Optional<Standalone<StringRef>>(optionItr->second).castTo< StringRef >() != arg)) {
+				options[option] = arg.castTo<Standalone<StringRef>>();
 				return true;
 			}
 			else if(!enabled && optionItr != options.end()) {

--- a/fdbclient/DatabaseBackupAgent.actor.cpp
+++ b/fdbclient/DatabaseBackupAgent.actor.cpp
@@ -1197,7 +1197,7 @@ namespace dbBackup {
 			loop {
 				try {
 					tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
- 					tr->setOption(FDBTransactionOptions::LOCK_AWARE);
+					tr->setOption(FDBTransactionOptions::LOCK_AWARE);
 					Key tagPath = srcDrAgent.states.get(task->params[DatabaseBackupAgent::keyConfigLogUid]).pack(BackupAgentBase::keyConfigBackupTag);
 					Optional<Key> tagName = wait(tr->get(tagPath));
 					if (!tagName.present()) {

--- a/fdbclient/FDBTypes.h
+++ b/fdbclient/FDBTypes.h
@@ -145,12 +145,17 @@ static std::string describe( std::set<T> const& items, int max_items = -1 ) {
 
 std::string printable( const StringRef& val );
 std::string printable( const std::string& val );
-std::string printable( const Optional<StringRef>& val );
-std::string printable( const Optional<Standalone<StringRef>>& val );
 std::string printable( const KeyRangeRef& range );
 std::string printable( const VectorRef<StringRef>& val );
 std::string printable( const VectorRef<KeyValueRef>& val );
 std::string printable( const KeyValueRef& val );
+
+template <class T>
+std::string printable( const Optional<T>& val ) {
+	if( val.present() )
+		return printable( val.get() );
+	return "[not set]";
+}
 
 inline bool equalsKeyAfter( const KeyRef& key, const KeyRef& compareKey ) {
 	if( key.size()+1 != compareKey.size() || compareKey[compareKey.size()-1] != 0 )

--- a/fdbclient/MultiVersionTransaction.actor.cpp
+++ b/fdbclient/MultiVersionTransaction.actor.cpp
@@ -622,7 +622,7 @@ void MultiVersionDatabase::setOption(FDBDatabaseOptions::Option option, Optional
 		dbState->db->setOption(option, value);
 	}
 
-	dbState->options.push_back(std::make_pair(option, value.cast_to<Standalone<StringRef>>()));
+	dbState->options.push_back(std::make_pair(option, value.castTo<Standalone<StringRef>>()));
 }
 
 void MultiVersionDatabase::Connector::connect() {
@@ -727,7 +727,7 @@ void MultiVersionDatabase::DatabaseState::stateChanged() {
 	optionLock.enter();
 	for(auto option : options) {
 		try {
-			newDb->setOption(option.first, option.second.cast_to<StringRef>()); // In practice, this will set a deferred error instead of throwing. If that happens, the database will be unusable (attempts to use it will throw errors).
+			newDb->setOption(option.first, option.second.castTo<StringRef>()); // In practice, this will set a deferred error instead of throwing. If that happens, the database will be unusable (attempts to use it will throw errors).
 		}
 		catch(Error &e) {
 			optionLock.leave();
@@ -982,7 +982,7 @@ void MultiVersionApi::setNetworkOptionInternal(FDBNetworkOptions::Option option,
 				});
 			}
 			else {
-				options.push_back(std::make_pair(option, value.cast_to<Standalone<StringRef>>()));
+				options.push_back(std::make_pair(option, value.castTo<Standalone<StringRef>>()));
 			}
 		}
 	}
@@ -1026,7 +1026,7 @@ void MultiVersionApi::setupNetwork() {
 		MutexHolder holder(lock);
 		runOnExternalClients([this, transportId](Reference<ClientInfo> client) {
 			for(auto option : options) {
-				client->api->setNetworkOption(option.first, option.second.cast_to<StringRef>());
+				client->api->setNetworkOption(option.first, option.second.castTo<StringRef>());
 			}
 			client->api->setNetworkOption(FDBNetworkOptions::EXTERNAL_CLIENT_TRANSPORT_ID, std::to_string(transportId));
 

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -137,18 +137,6 @@ std::string printable( const std::string& str ) {
 	return StringRef(str).printable();
 }
 
-std::string printable( const Optional<StringRef>& val ) {
-	if( val.present() )
-		return printable( val.get() );
-	return "[not set]";
-}
-
-std::string printable( const Optional<Standalone<StringRef>>& val ) {
-	if( val.present() )
-		return printable( val.get() );
-	return "[not set]";
-}
-
 std::string printable( const KeyRangeRef& range ) {
 	return printable(range.begin) + " - " + printable(range.end);
 }

--- a/fdbclient/ReadYourWrites.actor.cpp
+++ b/fdbclient/ReadYourWrites.actor.cpp
@@ -945,7 +945,7 @@ public:
 					swapAndPop(&itCopy->value, i--);
 				} else {
 					itCopy->value[i]->setPresent = true;
-					itCopy->value[i]->setValue = val.cast_to<Value>();
+					itCopy->value[i]->setValue = val.castTo<Value>();
 				}
 			}
 

--- a/fdbserver/ApplyMetadataMutation.h
+++ b/fdbserver/ApplyMetadataMutation.h
@@ -148,7 +148,7 @@ static void applyMetadataMutations(UID const& dbgid, Arena &arena, VectorRef<Mut
 				}
 			}
 			else if (m.param1.startsWith(configKeysPrefix) || m.param1 == coordinatorsKey) {
-				if(Optional<StringRef>(m.param2) != txnStateStore->readValue(m.param1).get().cast_to<StringRef>()) { // FIXME: Make this check more specific, here or by reading configuration whenever there is a change
+				if(Optional<StringRef>(m.param2) != txnStateStore->readValue(m.param1).get().castTo<StringRef>()) { // FIXME: Make this check more specific, here or by reading configuration whenever there is a change
 					if(!m.param1.startsWith( excludedServersPrefix ) && m.param1 != excludedServersVersionKey) {
 						auto t = txnStateStore->readValue(m.param1).get();
 						TraceEvent("MutationRequiresRestart", dbgid).detail("M", m.toString()).detail("PrevValue", t.present() ? printable(t.get()) : "(none)").detail("ToCommit", toCommit!=NULL);

--- a/fdbserver/workloads/FuzzApiCorrectness.actor.cpp
+++ b/fdbserver/workloads/FuzzApiCorrectness.actor.cpp
@@ -1098,7 +1098,7 @@ struct FuzzApiCorrectnessWorkload : TestWorkload {
 		}
 
 		void callback(Reference<ITransaction> tr) {
-			tr->setOption((FDBTransactionOptions::Option) op, val.cast_to<StringRef>());
+			tr->setOption((FDBTransactionOptions::Option) op, val.castTo<StringRef>());
 		}
 
 		void augmentTrace(TraceEvent &e) const {

--- a/flow/flow.h
+++ b/flow/flow.h
@@ -123,7 +123,7 @@ public:
 
 	/* This conversion constructor was nice, but combined with the prior constructor it means that Optional<int> can be converted to Optional<Optional<int>> in the wrong way
 	(a non-present Optional<int> converts to a non-present Optional<Optional<int>>).
-	Use .cast_to<>() instead.
+	Use .castTo<>() instead.
 	template <class S> Optional(const Optional<S>& o) : valid(o.present()) { if (valid) new (&value) T(o.get()); } */
 
 	Optional(Arena& a, const Optional<T>& o) : valid(o.valid) {
@@ -131,11 +131,17 @@ public:
 	}
 	int expectedSize() const { return valid ? get().expectedSize() : 0; }
 
-	template <class R> Optional<R> cast_to() const {
-		if (present())
-			return Optional<R>(get());
-		else
+	template <class R> Optional<R> castTo() const {
+		return map<R>([](const T& v){ return (R)v; });
+	}
+
+	template <class R> Optional<R> map(std::function<R(T)> f) const {
+		if (present()) {
+			return Optional<R>(f(get()));
+		}
+		else {
 			return Optional<R>();
+		}
 	}
 
 	~Optional() {
@@ -211,11 +217,17 @@ public:
 	}
 	int expectedSize() const { return present() ? get().expectedSize() : 0; }
 
-	template <class R> ErrorOr<R> cast_to() const {
-		if (present())
-			return ErrorOr<R>(get());
-		else
-			return ErrorOr<R>();
+	template <class R> ErrorOr<R> castTo() const {
+		return map<R>([](const T& v){ return (R)v; });
+	}
+
+	template <class R> ErrorOr<R> map(std::function<R(T)> f) const {
+		if (present()) {
+			return ErrorOr<R>(f(get()));
+		}
+		else {
+			return ErrorOr<R>(error);
+		}
 	}
 
 	~ErrorOr() {


### PR DESCRIPTION
Changes:

* Add Optional.map and ErrorOr.map.
* Rename Optional/ErrorOr cast_to to castTo.
* Make printable(Optional<T>) templated rather than restricted to StringRef types.
* Fixes bug in (unused) ErrorOr.castTo where an ErrorOr that was not set would lose its error.
* One whitespace fix

I did use Optional.map when writing some code I used to test something, although there is nothing using it now. I figured it might be useful again later, so I decided to commit it rather than throw it away.
