### PR TITLE
Update RPM spec with Apache 2.0 licence

### DIFF
--- a/packaging/rpm/foundationdb.spec.in
+++ b/packaging/rpm/foundationdb.spec.in
@@ -2,7 +2,7 @@ Name: foundationdb
 Version: FDBVERSION
 Release: FDBRELEASE
 Group: Applications/Databases
-License: FoundationDB Community License Agreement (https://www.foundationdb.org/license)
+License: Apache Software License 2.0
 URL: https://www.foundationdb.org
 Packager: FoundationDB <fdb-dist@apple.com>
 BuildArch: x86_64


### PR DESCRIPTION
The RPM packages were still being listed as "FoundationDB Community
Licence Agreement" with a broken link to the old license.

No functional changes to the code.