### PR TITLE
Monitor leader only when proxies are unknown or any dies

### DIFF
--- a/fdbclient/NativeAPI.actor.h
+++ b/fdbclient/NativeAPI.actor.h
@@ -132,7 +132,6 @@ private:
 	Reference<AsyncVar<Optional<struct ClusterInterface>>> clusterInterface;
 	Reference<ClusterConnectionFile> connectionFile;
 
-	Future<Void> leaderMon;
 	Future<Void> failMon;
 	Future<Void> connected;
 };


### PR DESCRIPTION
FDB clients talk to coordinators to monitor the leader, and then ask
them for proxies. Once proxies are known, the clients still keep
talking to coordinators. This patch, stops this monitoring and
reconnects to coordinators only if one of the proxy is no longer
available.