### PR TITLE
Change the default boost to 1.67.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,13 +56,13 @@ else ifeq ($(PLATFORM),Darwin)
   .LIBPATTERNS := lib%.dylib lib%.a
 
   BOOSTDIR ?= $(HOME)/boost_1_67_0
-  $(info Boost dir: ${BOOSTDIR})
   TLS_LIBDIR ?= /usr/local/lib
   DLEXT := dylib
   java_DLEXT := jnilib
 else
   $(error Not prepared to compile on platform $(PLATFORM))
 endif
+$(info Boost dir: ${BOOSTDIR})
 
 CCACHE := $(shell which ccache)
 ifneq ($(CCACHE),)

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ else ifeq ($(PLATFORM),Darwin)
   .LIBPATTERNS := lib%.dylib lib%.a
 
   BOOSTDIR ?= $(HOME)/boost_1_67_0
-	$(info Boost dir: ${BOOSTDIR})
+  $(info Boost dir: ${BOOSTDIR})
   TLS_LIBDIR ?= /usr/local/lib
   DLEXT := dylib
   java_DLEXT := jnilib

--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,7 @@ else ifeq ($(PLATFORM),Darwin)
   .LIBPATTERNS := lib%.dylib lib%.a
 
   BOOSTDIR ?= $(HOME)/boost_1_67_0
+	$(info Boost dir: ${BOOSTDIR})
   TLS_LIBDIR ?= /usr/local/lib
   DLEXT := dylib
   java_DLEXT := jnilib

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ ifeq ($(PLATFORM),Linux)
 
   CXXFLAGS += -std=c++0x
 
-  BOOSTDIR ?= /opt/boost_1_52_0
+  BOOSTDIR ?= /opt/boost_1_67_0
   TLS_LIBDIR ?= /usr/local/lib
   DLEXT := so
   java_DLEXT := so
@@ -55,7 +55,7 @@ else ifeq ($(PLATFORM),Darwin)
 
   .LIBPATTERNS := lib%.dylib lib%.a
 
-  BOOSTDIR ?= $(HOME)/boost_1_52_0
+  BOOSTDIR ?= $(HOME)/boost_1_67_0
   TLS_LIBDIR ?= /usr/local/lib
   DLEXT := dylib
   java_DLEXT := jnilib

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:15.04
-LABEL version=0.0.2
+LABEL version=0.0.3
 
 RUN sed -i -e 's/archive.ubuntu.com\|security.ubuntu.com/old-releases.ubuntu.com/g' -e 's/us\.old/old/g' /etc/apt/sources.list && apt-get clean
 

--- a/build/docker-compose.yaml
+++ b/build/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   common: &common
-    image: foundationdb-build:0.0.2
+    image: foundationdb-build:0.0.3
     build:
       context: .
       dockerfile: Dockerfile


### PR DESCRIPTION
This changes the boost directory name to be boost_1_67_0, which is expected to be a copy of boost 1.67.0.

(I'm currently posting this for testing on the builders.)