### PR TITLE
allow specification of public port

### DIFF
--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -64,6 +64,7 @@ CMD /var/fdb/scripts/fdb.bash
 # Runtime Configuration Options
 
 ENV FDB_PORT 4500
+ENV FDB_PUBLIC_PORT 4500
 ENV FDB_CLUSTER_FILE /var/fdb/fdb.cluster
 ENV FDB_NETWORKING_MODE container
 ENV FDB_COORDINATOR ""

--- a/packaging/docker/README.md
+++ b/packaging/docker/README.md
@@ -37,7 +37,42 @@ This image supports several environment variables for run-time configuration.
 
 ### FDB_PORT
 
-The port that FoundationDB should bind to. The default is 4500. 
+The port that FoundationDB should bind to. The default is 4500.
+
+### FDB_PORT
+
+The publicly visible port of the process. The default is 4500.
+
+This can be used to expose multiple fdb servers on the host ip:
+
+```
+version: '3'
+services:
+  fdb-coordinator:
+    image: foundationdb:5.2.5
+    environment:
+      FDB_COORDINATOR: fdb-coordinator
+      FDB_NETWORKING_MODE: host
+      FDB_PUBLIC_PORT: 4500
+    ports:
+      - 4500:4500
+  fdb-1:
+    image: foundationdb:5.2.5
+    environment:
+      FDB_COORDINATOR: fdb-coordinator
+      FDB_NETWORKING_MODE: host
+      FDB_PUBLIC_PORT: 4501
+    ports:
+      - 4501:4500
+  fdb-2:
+    image: foundationdb:5.2.5
+    environment:
+      FDB_COORDINATOR: fdb-coordinator
+      FDB_NETWORKING_MODE: host
+      FDB_PUBLIC_PORT: 4502
+    ports:
+      - 4502:4500
+```
 
 ### FDB_NETWORKING_MODE
 

--- a/packaging/docker/fdb.bash
+++ b/packaging/docker/fdb.bash
@@ -23,7 +23,7 @@
 source /var/fdb/scripts/create_server_environment.bash
 create_server_environment
 source /var/fdb/.fdbenv
-echo "Starting FDB server on $PUBLIC_IP:4500"
-fdbserver --listen_address 0.0.0.0:$FDB_PORT --public_address $PUBLIC_IP:4500 \
+echo "Starting FDB server on $PUBLIC_IP:${PUBLIC_PORT:-4500}"
+fdbserver --listen_address 0.0.0.0:$FDB_PORT --public_address $PUBLIC_IP:${PUBLIC_PORT:-4500} \
 	--datadir /var/fdb/data --logdir /var/fdb/logs \
 	--locality_zoneid=`hostname` --locality_machineid=`hostname` --class $FDB_PROCESS_CLASS


### PR DESCRIPTION
Allow the specification of a public port. For backwards compatibility and convenience I added a 4500 default value.

This allows to easily expose multiple fdb containers on the host ip on different ports, like you would normally do on a machine.