### PR TITLE
Don't link flow into fdbmonitor for cmake

### DIFF
--- a/fdbmonitor/CMakeLists.txt
+++ b/fdbmonitor/CMakeLists.txt
@@ -4,6 +4,5 @@ add_executable(fdbmonitor ${FDBMONITOR_SRCS})
 # FIXME: This include directory is an ugly hack. We probably want to fix this
 # as soon as we get rid of the old build system
 target_include_directories(fdbmonitor PRIVATE ${CMAKE_BINARY_DIR}/fdbclient)
-target_link_libraries(fdbmonitor flow)
 
 install(TARGETS fdbmonitor DESTINATION "${FDB_LIB_DIR}/foundationdb" COMPONENT server)


### PR DESCRIPTION
It seems that fdbmonitor is not meant to depend on flow, since it
redefines symbols such as `joinPath`

@alexmiller-apple PTAL