### PR TITLE
Thread safety fixes

### DIFF
--- a/flow/Platform.cpp
+++ b/flow/Platform.cpp
@@ -2594,13 +2594,13 @@ extern volatile size_t net2backtraces_max;
 extern volatile bool net2backtraces_overflow;
 extern volatile int net2backtraces_count;
 extern volatile double net2liveness;
-extern volatile int profilingEnabled;
+extern volatile thread_local int profilingEnabled;
 extern void initProfiling();
 
 volatile thread_local bool profileThread = false;
 #endif
 
-volatile int profilingEnabled = 1;
+volatile thread_local int profilingEnabled = 1;
 
 void setProfilingEnabled(int enabled) { 
 	profilingEnabled = enabled; 

--- a/flow/Profiler.actor.cpp
+++ b/flow/Profiler.actor.cpp
@@ -33,7 +33,7 @@
 
 #include "flow/Platform.h"
 
-extern volatile int profilingEnabled;
+extern volatile thread_local int profilingEnabled;
 
 static uint64_t gettid() { return syscall(__NR_gettid); }
 


### PR DESCRIPTION
This does not include any changes to ThreadSafeQueue, which will potentially come in a later PR. Included changes are:

1. profilingEnabled is made thread_local to avoid a race
2. dl_iterate_phdr is only loaded once to avoid potentially concurrent overwrites.