### PR TITLE
Split BOOSTDIR into BOOSTDIR_BASEDIR and BOOSTDIR_BASENAME

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ ifeq ($(NIGHTLY),true)
 	CFLAGS += -DFDB_CLEAN_BUILD
 endif
 
-BOOST_BASENAME ?= boost_1_52_0
+BOOST_BASENAME ?= boost_1_67_0
 ifeq ($(PLATFORM),Linux)
   PLATFORM := linux
 

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ ifeq ($(NIGHTLY),true)
 	CFLAGS += -DFDB_CLEAN_BUILD
 endif
 
+BOOST_BASENAME ?= boost_1_52_0
 ifeq ($(PLATFORM),Linux)
   PLATFORM := linux
 
@@ -39,7 +40,7 @@ ifeq ($(PLATFORM),Linux)
 
   CXXFLAGS += -std=c++0x
 
-  BOOSTDIR ?= /opt/boost_1_52_0
+  BOOST_BASEDIR ?= /opt
   TLS_LIBDIR ?= /usr/local/lib
   DLEXT := so
   java_DLEXT := so
@@ -55,13 +56,14 @@ else ifeq ($(PLATFORM),Darwin)
 
   .LIBPATTERNS := lib%.dylib lib%.a
 
-  BOOSTDIR ?= $(HOME)/boost_1_52_0
+  BOOST_BASEDIR ?= ${HOME}
   TLS_LIBDIR ?= /usr/local/lib
   DLEXT := dylib
   java_DLEXT := jnilib
 else
   $(error Not prepared to compile on platform $(PLATFORM))
 endif
+BOOSTDIR ?= ${BOOST_BASEDIR}/${BOOST_BASENAME}
 
 CCACHE := $(shell which ccache)
 ifneq ($(CCACHE),)

--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,7 @@ else
   $(error Not prepared to compile on platform $(PLATFORM))
 endif
 BOOSTDIR ?= ${BOOST_BASEDIR}/${BOOST_BASENAME}
+$(info BOOSTDIR is ${BOOSTDIR})
 
 CCACHE := $(shell which ccache)
 ifneq ($(CCACHE),)

--- a/bindings/c/fdb_c.vcxproj
+++ b/bindings/c/fdb_c.vcxproj
@@ -67,14 +67,14 @@ FOR /F "tokens=1" %%i in ('hg.exe id') do copy /Y "$(TargetPath)" "$(TargetPath)
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <IncludePath>..\..\;C:\Program Files\boost_1_52_0;$(IncludePath)</IncludePath>
+    <IncludePath>..\..\;C:\Program Files\boost_1_67_0;$(IncludePath)</IncludePath>
     <OutDir>$(SolutionDir)bin\$(Configuration)\</OutDir>
     <IntDir>$(SystemDrive)\temp\msvcfdb\$(Platform)$(Configuration)\$(MSBuildProjectName)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <OutDir>$(SolutionDir)bin\$(Configuration)\</OutDir>
     <IntDir>$(SystemDrive)\temp\msvcfdb\$(Platform)$(Configuration)\$(MSBuildProjectName)\</IntDir>
-    <IncludePath>..\..\;C:\Program Files\boost_1_52_0;$(IncludePath)</IncludePath>
+    <IncludePath>..\..\;C:\Program Files\boost_1_67_0;$(IncludePath)</IncludePath>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>

--- a/bindings/flow/fdb_flow.h
+++ b/bindings/flow/fdb_flow.h
@@ -170,11 +170,11 @@ namespace FDB {
 		// void debugTransaction(UID dID) { tr.debugTransaction(dID); }
 
 		Transaction() : tr(NULL) {}
-		Transaction( Transaction&& r ) noexcept(true) {
+		Transaction( Transaction&& r ) BOOST_NOEXCEPT {
 			tr = r.tr;
 			r.tr = NULL;
 		}
-		Transaction& operator=( Transaction&& r ) noexcept(true) {
+		Transaction& operator=( Transaction&& r ) BOOST_NOEXCEPT {
 			tr = r.tr;
 			r.tr = NULL;
 			return *this;

--- a/bindings/flow/fdb_flow.vcxproj
+++ b/bindings/flow/fdb_flow.vcxproj
@@ -79,11 +79,11 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|X64'">
     <LinkIncremental>true</LinkIncremental>
-    <IncludePath>..\..\;C:\Program Files\boost_1_52_0;$(IncludePath)</IncludePath>
+    <IncludePath>..\..\;C:\Program Files\boost_1_67_0;$(IncludePath)</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|X64'">
     <LinkIncremental>false</LinkIncremental>
-    <IncludePath>..\..\;C:\Program Files\boost_1_52_0;$(IncludePath)</IncludePath>
+    <IncludePath>..\..\;C:\Program Files\boost_1_67_0;$(IncludePath)</IncludePath>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|X64'">
     <ClCompile>

--- a/bindings/flow/tester/fdb_flow_tester.vcxproj
+++ b/bindings/flow/tester/fdb_flow_tester.vcxproj
@@ -58,13 +58,13 @@
     <LinkIncremental>true</LinkIncremental>
     <OutDir>$(SolutionDir)bin\$(Configuration)\</OutDir>
     <IntDir>$(SystemDrive)\temp\msvcfdb\$(Platform)$(Configuration)\$(MSBuildProjectName)\</IntDir>
-    <IncludePath>$(IncludePath);../../../;C:\Program Files\boost_1_52_0</IncludePath>
+    <IncludePath>$(IncludePath);../../../;C:\Program Files\boost_1_67_0</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|X64'">
     <LinkIncremental>false</LinkIncremental>
     <OutDir>$(SolutionDir)bin\$(Configuration)\</OutDir>
     <IntDir>$(SystemDrive)\temp\msvcfdb\$(Platform)$(Configuration)\$(MSBuildProjectName)\</IntDir>
-    <IncludePath>$(IncludePath);../;C:\Program Files\boost_1_52_0</IncludePath>
+    <IncludePath>$(IncludePath);../;C:\Program Files\boost_1_67_0</IncludePath>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>

--- a/bindings/java/fdb_java.vcxproj
+++ b/bindings/java/fdb_java.vcxproj
@@ -45,7 +45,7 @@
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
-    <IncludePath>..\..\;C:\Program Files\Java\jdk6\include\win32;C:\Program Files\Java\jdk6\include;C:\Program Files\boost_1_52_0;$(IncludePath)</IncludePath>
+    <IncludePath>..\..\;C:\Program Files\Java\jdk6\include\win32;C:\Program Files\Java\jdk6\include;C:\Program Files\boost_1_67_0;$(IncludePath)</IncludePath>
     <OutDir>$(SolutionDir)bin\$(Configuration)\</OutDir>
     <IntDir>$(SystemDrive)\temp\msvcfdb\$(Platform)$(Configuration)\$(MSBuildProjectName)\</IntDir>
   </PropertyGroup>

--- a/fdbbackup/fdbbackup.vcxproj
+++ b/fdbbackup/fdbbackup.vcxproj
@@ -53,11 +53,11 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|X64'">
     <LinkIncremental>true</LinkIncremental>
-    <IncludePath>$(IncludePath);../;C:\Program Files\boost_1_52_0</IncludePath>
+    <IncludePath>$(IncludePath);../;C:\Program Files\boost_1_67_0</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|X64'">
     <LinkIncremental>false</LinkIncremental>
-    <IncludePath>$(IncludePath);../;C:\Program Files\boost_1_52_0</IncludePath>
+    <IncludePath>$(IncludePath);../;C:\Program Files\boost_1_67_0</IncludePath>
     <CustomBuildBeforeTargets>PreBuildEvent</CustomBuildBeforeTargets>
   </PropertyGroup>
   <ItemDefinitionGroup>

--- a/fdbcli/fdbcli.vcxproj
+++ b/fdbcli/fdbcli.vcxproj
@@ -62,13 +62,13 @@
     <LinkIncremental>true</LinkIncremental>
     <OutDir>$(SolutionDir)bin\$(Configuration)\</OutDir>
     <IntDir>$(SystemDrive)\temp\msvcfdb\$(Platform)$(Configuration)\$(MSBuildProjectName)\</IntDir>
-    <IncludePath>$(IncludePath);../;C:\Program Files\boost_1_52_0</IncludePath>
+    <IncludePath>$(IncludePath);../;C:\Program Files\boost_1_67_0</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|X64'">
     <LinkIncremental>false</LinkIncremental>
     <OutDir>$(SolutionDir)bin\$(Configuration)\</OutDir>
     <IntDir>$(SystemDrive)\temp\msvcfdb\$(Platform)$(Configuration)\$(MSBuildProjectName)\</IntDir>
-    <IncludePath>$(IncludePath);../;C:\Program Files\boost_1_52_0</IncludePath>
+    <IncludePath>$(IncludePath);../;C:\Program Files\boost_1_67_0</IncludePath>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>

--- a/fdbclient/BackupAgent.h
+++ b/fdbclient/BackupAgent.h
@@ -195,14 +195,14 @@ class FileBackupAgent : public BackupAgentBase {
 public:
 	FileBackupAgent();
 
-	FileBackupAgent( FileBackupAgent&& r ) noexcept(true) :
+	FileBackupAgent( FileBackupAgent&& r ) BOOST_NOEXCEPT :
 		subspace( std::move(r.subspace) ),
 		config( std::move(r.config) ),
 		lastRestorable( std::move(r.lastRestorable) ),
 		taskBucket( std::move(r.taskBucket) ),
 		futureBucket( std::move(r.futureBucket) ) {}
 
-	void operator=( FileBackupAgent&& r ) noexcept(true) {
+	void operator=( FileBackupAgent&& r ) BOOST_NOEXCEPT {
 		subspace = std::move(r.subspace);
 		config = std::move(r.config);
 		lastRestorable = std::move(r.lastRestorable),
@@ -302,7 +302,7 @@ public:
 	DatabaseBackupAgent();
 	explicit DatabaseBackupAgent(Database src);
 
-	DatabaseBackupAgent( DatabaseBackupAgent&& r ) noexcept(true) :
+	DatabaseBackupAgent( DatabaseBackupAgent&& r ) BOOST_NOEXCEPT :
 		subspace( std::move(r.subspace) ),
 		states( std::move(r.states) ),
 		config( std::move(r.config) ),
@@ -314,7 +314,7 @@ public:
 		sourceStates( std::move(r.sourceStates) ),
 		sourceTagNames( std::move(r.sourceTagNames) ) {}
 
-	void operator=( DatabaseBackupAgent&& r ) noexcept(true) {
+	void operator=( DatabaseBackupAgent&& r ) BOOST_NOEXCEPT {
 		subspace = std::move(r.subspace);
 		states = std::move(r.states);
 		config = std::move(r.config);

--- a/fdbclient/KeyRangeMap.h
+++ b/fdbclient/KeyRangeMap.h
@@ -36,7 +36,7 @@ template <class Val, class Metric=int, class MetricFunc = ConstantMetric<Metric>
 class KeyRangeMap : public RangeMap<Key,Val,KeyRangeRef,Metric,MetricFunc>, NonCopyable, public ReferenceCounted<KeyRangeMap<Val>> {
 public:
 	explicit KeyRangeMap(Val v=Val(), Key endKey = allKeys.end) : RangeMap<Key,Val,KeyRangeRef,Metric,MetricFunc>(endKey, v), mapEnd(endKey) {}
-	void operator=(KeyRangeMap&& r) noexcept(true) { mapEnd = std::move(r.mapEnd); RangeMap<Key,Val,KeyRangeRef,Metric,MetricFunc>::operator=(std::move(r)); }
+	void operator=(KeyRangeMap&& r) BOOST_NOEXCEPT { mapEnd = std::move(r.mapEnd); RangeMap<Key,Val,KeyRangeRef,Metric,MetricFunc>::operator=(std::move(r)); }
 	void insert( const KeyRangeRef& keys, const Val& value ) { RangeMap<Key,Val,KeyRangeRef,Metric,MetricFunc>::insert(keys, value); }
 	void insert( const KeyRef& key, const Val& value ) { RangeMap<Key,Val,KeyRangeRef,Metric,MetricFunc>::insert( singleKeyRange(key), value); }
 	std::vector<KeyRangeWith<Val>> getAffectedRangesAfterInsertion( const KeyRangeRef& keys, const Val &insertionValue = Val());
@@ -67,7 +67,7 @@ template <class Val, class Metric=int, class MetricFunc = ConstantMetric<Metric>
 class CoalescedKeyRefRangeMap : public RangeMap<KeyRef,Val,KeyRangeRef,Metric,MetricFunc>, NonCopyable {
 public:
 	explicit CoalescedKeyRefRangeMap(Val v=Val(), Key endKey = allKeys.end) : RangeMap<KeyRef,Val,KeyRangeRef,Metric,MetricFunc>(endKey, v), mapEnd(endKey) {}
-	void operator=(CoalescedKeyRefRangeMap&& r) noexcept(true) { mapEnd = std::move(r.mapEnd); RangeMap<KeyRef, Val, KeyRangeRef,Metric,MetricFunc>::operator=(std::move(r)); }
+	void operator=(CoalescedKeyRefRangeMap&& r) BOOST_NOEXCEPT { mapEnd = std::move(r.mapEnd); RangeMap<KeyRef, Val, KeyRangeRef,Metric,MetricFunc>::operator=(std::move(r)); }
 	void insert( const KeyRangeRef& keys, const Val& value );
 	void insert( const KeyRef& key, const Val& value, Arena& arena );
 	Key mapEnd;
@@ -77,7 +77,7 @@ template <class Val, class Metric=int, class MetricFunc = ConstantMetric<Metric>
 class CoalescedKeyRangeMap : public RangeMap<Key,Val,KeyRangeRef,Metric,MetricFunc>, NonCopyable {
 public:
 	explicit CoalescedKeyRangeMap(Val v=Val(), Key endKey = allKeys.end) : RangeMap<Key,Val,KeyRangeRef,Metric,MetricFunc>(endKey, v), mapEnd(endKey) {}
-	void operator=(CoalescedKeyRangeMap&& r) noexcept(true) { mapEnd = std::move(r.mapEnd); RangeMap<Key,Val,KeyRangeRef,Metric,MetricFunc>::operator=(std::move(r)); }
+	void operator=(CoalescedKeyRangeMap&& r) BOOST_NOEXCEPT { mapEnd = std::move(r.mapEnd); RangeMap<Key,Val,KeyRangeRef,Metric,MetricFunc>::operator=(std::move(r)); }
 	void insert( const KeyRangeRef& keys, const Val& value );
 	void insert( const KeyRef& key, const Val& value );
 	Key mapEnd;

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -1867,7 +1867,7 @@ Transaction::~Transaction() {
 	cancelWatches();
 }
 
-void Transaction::operator=(Transaction&& r) noexcept(true) {
+void Transaction::operator=(Transaction&& r) BOOST_NOEXCEPT {
 	flushTrLogsIfEnabled();
 	cx = std::move(r.cx);
 	tr = std::move(r.tr);

--- a/fdbclient/NativeAPI.h
+++ b/fdbclient/NativeAPI.h
@@ -67,8 +67,8 @@ public:
 	Database() {}  // an uninitialized database can be destructed or reassigned safely; that's it
 	void operator= ( Database const& rhs ) { db = rhs.db; }
 	Database( Database const& rhs ) : db(rhs.db) {}
-	Database(Database&& r) noexcept(true) : db(std::move(r.db)) {}
-	void operator= (Database&& r) noexcept(true) { db = std::move(r.db); }
+	Database(Database&& r) BOOST_NOEXCEPT : db(std::move(r.db)) {}
+	void operator= (Database&& r) BOOST_NOEXCEPT { db = std::move(r.db); }
 
 	// For internal use by the native client:
 	explicit Database(Reference<DatabaseContext> cx) : db(cx) {}
@@ -270,7 +270,7 @@ public:
 
 	// These are to permit use as state variables in actors:
 	Transaction() : info( TaskDefaultEndpoint ) {}
-	void operator=(Transaction&& r) noexcept(true);
+	void operator=(Transaction&& r) BOOST_NOEXCEPT;
 
 	void reset();
 	void fullReset();

--- a/fdbclient/Notified.h
+++ b/fdbclient/Notified.h
@@ -66,8 +66,8 @@ struct NotifiedVersion {
 		set( v );
 	}
 
-	NotifiedVersion(NotifiedVersion&& r) noexcept(true) : waiting(std::move(r.waiting)), val(std::move(r.val)) {}
-	void operator=(NotifiedVersion&& r) noexcept(true) { waiting = std::move(r.waiting); val = std::move(r.val); }
+	NotifiedVersion(NotifiedVersion&& r) BOOST_NOEXCEPT : waiting(std::move(r.waiting)), val(std::move(r.val)) {}
+	void operator=(NotifiedVersion&& r) BOOST_NOEXCEPT { waiting = std::move(r.waiting); val = std::move(r.val); }
 
 private:
 	typedef std::pair<Version,Promise<Void>> Item;

--- a/fdbclient/ReadYourWrites.actor.cpp
+++ b/fdbclient/ReadYourWrites.actor.cpp
@@ -1779,7 +1779,7 @@ void ReadYourWritesTransaction::setOption( FDBTransactionOptions::Option option,
 	tr.setOption( option, value );
 }
 
-void ReadYourWritesTransaction::operator=(ReadYourWritesTransaction&& r) noexcept(true) {
+void ReadYourWritesTransaction::operator=(ReadYourWritesTransaction&& r) BOOST_NOEXCEPT {
 	cache = std::move( r.cache );
 	writes = std::move( r.writes );
 	arena = std::move( r.arena );
@@ -1800,7 +1800,7 @@ void ReadYourWritesTransaction::operator=(ReadYourWritesTransaction&& r) noexcep
 	writes.arena = &arena;
 }
 
-ReadYourWritesTransaction::ReadYourWritesTransaction(ReadYourWritesTransaction&& r) noexcept(true) :
+ReadYourWritesTransaction::ReadYourWritesTransaction(ReadYourWritesTransaction&& r) BOOST_NOEXCEPT :
 	cache( std::move(r.cache) ),
 	writes( std::move(r.writes) ), 
 	arena( std::move(r.arena) ), 

--- a/fdbclient/ReadYourWrites.h
+++ b/fdbclient/ReadYourWrites.h
@@ -111,8 +111,8 @@ public:
 
 	// These are to permit use as state variables in actors:
 	ReadYourWritesTransaction() : cache(&arena), writes(&arena) {}
-	void operator=(ReadYourWritesTransaction&& r) noexcept(true);
-	ReadYourWritesTransaction(ReadYourWritesTransaction&& r) noexcept(true);
+	void operator=(ReadYourWritesTransaction&& r) BOOST_NOEXCEPT;
+	ReadYourWritesTransaction(ReadYourWritesTransaction&& r) BOOST_NOEXCEPT;
 
 	virtual void addref() { ReferenceCounted<ReadYourWritesTransaction>::addref(); }
 	virtual void delref() { ReferenceCounted<ReadYourWritesTransaction>::delref(); }

--- a/fdbclient/SnapshotCache.h
+++ b/fdbclient/SnapshotCache.h
@@ -265,8 +265,8 @@ public:
 		entries.insert( Entry( allKeys.end, afterAllKeys, VectorRef<KeyValueRef>() ), NoMetric(), true );
 	}
 	// Visual Studio refuses to generate these, apparently despite the standard
-	SnapshotCache(SnapshotCache&& r) noexcept(true) : entries(std::move(r.entries)), arena(r.arena) {}
-	SnapshotCache& operator=(SnapshotCache&& r) noexcept(true) { entries = std::move(r.entries); arena = r.arena; return *this; }
+	SnapshotCache(SnapshotCache&& r) BOOST_NOEXCEPT : entries(std::move(r.entries)), arena(r.arena) {}
+	SnapshotCache& operator=(SnapshotCache&& r) BOOST_NOEXCEPT { entries = std::move(r.entries); arena = r.arena; return *this; }
 
 	bool empty() const {
 		// Returns true iff anything is known about the contents of the snapshot

--- a/fdbclient/ThreadSafeTransaction.actor.cpp
+++ b/fdbclient/ThreadSafeTransaction.actor.cpp
@@ -287,12 +287,12 @@ ThreadFuture<Void> ThreadSafeTransaction::onError( Error const& e ) {
 	return onMainThread( [tr, e](){ return tr->onError(e); } );
 }
 
-void ThreadSafeTransaction::operator=(ThreadSafeTransaction&& r) noexcept(true) {
+void ThreadSafeTransaction::operator=(ThreadSafeTransaction&& r) BOOST_NOEXCEPT {
 	tr = r.tr;
 	r.tr = NULL;
 }
 
-ThreadSafeTransaction::ThreadSafeTransaction(ThreadSafeTransaction&& r) noexcept(true) {
+ThreadSafeTransaction::ThreadSafeTransaction(ThreadSafeTransaction&& r) BOOST_NOEXCEPT {
 	tr = r.tr;
 	r.tr = NULL;
 }

--- a/fdbclient/ThreadSafeTransaction.h
+++ b/fdbclient/ThreadSafeTransaction.h
@@ -96,8 +96,8 @@ public:
 
 	// These are to permit use as state variables in actors:
 	ThreadSafeTransaction() : tr(NULL) {}
-	void operator=(ThreadSafeTransaction&& r) noexcept(true);
-	ThreadSafeTransaction(ThreadSafeTransaction&& r) noexcept(true);
+	void operator=(ThreadSafeTransaction&& r) BOOST_NOEXCEPT;
+	ThreadSafeTransaction(ThreadSafeTransaction&& r) BOOST_NOEXCEPT;
 
 	void reset();
 

--- a/fdbclient/VersionedMap.h
+++ b/fdbclient/VersionedMap.h
@@ -489,10 +489,10 @@ public:
 	VersionedMap() : oldestVersion(0), latestVersion(0) {
 		latestRoot = &roots[0];
 	}
-	VersionedMap( VersionedMap&& v ) noexcept(true) : oldestVersion(v.oldestVersion), latestVersion(v.latestVersion), roots(std::move(v.roots)) {
+	VersionedMap( VersionedMap&& v ) BOOST_NOEXCEPT : oldestVersion(v.oldestVersion), latestVersion(v.latestVersion), roots(std::move(v.roots)) {
 		latestRoot = &roots[latestVersion];
 	}
-	void operator = (VersionedMap && v) noexcept(true) {
+	void operator = (VersionedMap && v) BOOST_NOEXCEPT {
 		oldestVersion = v.oldestVersion;
 		latestVersion = v.latestVersion;
 		roots = std::move(v.roots);

--- a/fdbclient/WriteMap.h
+++ b/fdbclient/WriteMap.h
@@ -128,8 +128,8 @@ public:
 		PTreeImpl::insert( writes, ver, WriteMapEntry( afterAllKeys, OperationStack(), false, false, false, false, false ) );
 	}
 
-	WriteMap(WriteMap&& r) noexcept(true) : writeMapEmpty(r.writeMapEmpty), writes(std::move(r.writes)), ver(r.ver), scratch_iterator(std::move(r.scratch_iterator)), arena(r.arena) {}
-	WriteMap& operator=(WriteMap&& r) noexcept(true) { writeMapEmpty = r.writeMapEmpty; writes = std::move(r.writes); ver = r.ver; scratch_iterator = std::move(r.scratch_iterator); arena = r.arena; return *this; }
+	WriteMap(WriteMap&& r) BOOST_NOEXCEPT : writeMapEmpty(r.writeMapEmpty), writes(std::move(r.writes)), ver(r.ver), scratch_iterator(std::move(r.scratch_iterator)), arena(r.arena) {}
+	WriteMap& operator=(WriteMap&& r) BOOST_NOEXCEPT { writeMapEmpty = r.writeMapEmpty; writes = std::move(r.writes); ver = r.ver; scratch_iterator = std::move(r.scratch_iterator); arena = r.arena; return *this; }
 
 	//a write with addConflict false on top of an existing write with a conflict range will not remove the conflict
 	void mutate( KeyRef key, MutationRef::Type operation, ValueRef param, bool addConflict ) {

--- a/fdbclient/fdbclient.vcxproj
+++ b/fdbclient/fdbclient.vcxproj
@@ -156,11 +156,11 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|X64'">
     <LinkIncremental>true</LinkIncremental>
-    <IncludePath>$(IncludePath);../;C:\Program Files\boost_1_52_0</IncludePath>
+    <IncludePath>$(IncludePath);../;C:\Program Files\boost_1_67_0</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|X64'">
     <LinkIncremental>false</LinkIncremental>
-    <IncludePath>$(IncludePath);../;C:\Program Files\boost_1_52_0</IncludePath>
+    <IncludePath>$(IncludePath);../;C:\Program Files\boost_1_67_0</IncludePath>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>

--- a/fdbrpc/AsyncFileCached.actor.h
+++ b/fdbrpc/AsyncFileCached.actor.h
@@ -77,7 +77,7 @@ struct OpenFileInfo : NonCopyable {
 	Future<Reference<IAsyncFile>> opened; // Only valid until the file is fully opened
 
 	OpenFileInfo() : f(0) {}
-	OpenFileInfo(OpenFileInfo && r) noexcept(true) : f(r.f), opened(std::move(r.opened)) { r.f = 0; }
+	OpenFileInfo(OpenFileInfo && r) BOOST_NOEXCEPT : f(r.f), opened(std::move(r.opened)) { r.f = 0; }
 
 	Future<Reference<IAsyncFile>> get() {
 		if (f) return Reference<IAsyncFile>::addRef(f);

--- a/fdbrpc/RangeMap.h
+++ b/fdbrpc/RangeMap.h
@@ -149,7 +149,7 @@ public:
 	void coalesce( const Range& k );
 	void validateCoalesced();
 
-	void operator=(RangeMap&& r) noexcept(true) { map = std::move(r.map); }
+	void operator=(RangeMap&& r) BOOST_NOEXCEPT { map = std::move(r.map); }
 	//void clear( const Val& value ) { ranges.clear(); ranges.insert(std::make_pair(Key(),value)); }
 
 	void insert( const Range& keys, const Val& value );

--- a/fdbrpc/fdbrpc.h
+++ b/fdbrpc/fdbrpc.h
@@ -111,7 +111,7 @@ public:
 	bool isValid() const { return sav != NULL; }
 	ReplyPromise() : sav(new NetSAV<T>(0, 1)) {}
 	ReplyPromise(const ReplyPromise& rhs) : sav(rhs.sav) { sav->addPromiseRef(); }
-	ReplyPromise(ReplyPromise&& rhs) noexcept(true) : sav(rhs.sav) { rhs.sav = 0; }
+	ReplyPromise(ReplyPromise&& rhs) BOOST_NOEXCEPT : sav(rhs.sav) { rhs.sav = 0; }
 	~ReplyPromise() { if (sav) sav->delPromiseRef(); }
 
 	ReplyPromise(const Endpoint& endpoint) : sav(new NetSAV<T>(0, 1, endpoint)) {}
@@ -122,7 +122,7 @@ public:
 		if (sav) sav->delPromiseRef();
 		sav = rhs.sav;
 	}
-	void operator=(ReplyPromise && rhs) noexcept(true) {
+	void operator=(ReplyPromise && rhs) BOOST_NOEXCEPT {
 		if (sav != rhs.sav) {
 			if (sav) sav->delPromiseRef();
 			sav = rhs.sav;
@@ -322,13 +322,13 @@ public:
 	FutureStream<T> getFuture() const { queue->addFutureRef(); return FutureStream<T>(queue); }
 	RequestStream() : queue(new NetNotifiedQueue<T>(0, 1)) {}
 	RequestStream(const RequestStream& rhs) : queue(rhs.queue) { queue->addPromiseRef(); }
-	RequestStream(RequestStream&& rhs) noexcept(true) : queue(rhs.queue) { rhs.queue = 0; }
+	RequestStream(RequestStream&& rhs) BOOST_NOEXCEPT : queue(rhs.queue) { rhs.queue = 0; }
 	void operator=(const RequestStream& rhs) {
 		rhs.queue->addPromiseRef();
 		if (queue) queue->delPromiseRef();
 		queue = rhs.queue;
 	}
-	void operator=(RequestStream&& rhs) noexcept(true) {
+	void operator=(RequestStream&& rhs) BOOST_NOEXCEPT {
 		if (queue != rhs.queue) {
 			if (queue) queue->delPromiseRef();
 			queue = rhs.queue;

--- a/fdbrpc/fdbrpc.vcxproj
+++ b/fdbrpc/fdbrpc.vcxproj
@@ -154,11 +154,11 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|X64'">
     <LinkIncremental>true</LinkIncremental>
-    <IncludePath>$(IncludePath);../;C:\Program Files\boost_1_52_0</IncludePath>
+    <IncludePath>$(IncludePath);../;C:\Program Files\boost_1_67_0</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|X64'">
     <LinkIncremental>false</LinkIncremental>
-    <IncludePath>$(IncludePath);../;C:\Program Files\boost_1_52_0</IncludePath>
+    <IncludePath>$(IncludePath);../;C:\Program Files\boost_1_67_0</IncludePath>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <CustomBuildStep>

--- a/fdbrpc/sim2.actor.cpp
+++ b/fdbrpc/sim2.actor.cpp
@@ -1529,10 +1529,10 @@ public:
 		Promise<Void> action;
 		Task( double time, int taskID, uint64_t stable, ProcessInfo* machine, Promise<Void>&& action ) : time(time), taskID(taskID), stable(stable), machine(machine), action(std::move(action)) {}
 		Task( double time, int taskID, uint64_t stable, ProcessInfo* machine, Future<Void>& future ) : time(time), taskID(taskID), stable(stable), machine(machine) { future = action.getFuture(); }
-		Task(Task&& rhs) noexcept(true) : time(rhs.time), taskID(rhs.taskID), stable(rhs.stable), machine(rhs.machine), action(std::move(rhs.action)) {}
+		Task(Task&& rhs) BOOST_NOEXCEPT : time(rhs.time), taskID(rhs.taskID), stable(rhs.stable), machine(rhs.machine), action(std::move(rhs.action)) {}
 		void operator= ( Task const& rhs ) { taskID = rhs.taskID; time = rhs.time; stable = rhs.stable; machine = rhs.machine; action = rhs.action; }
 		Task( Task const& rhs ) : taskID(rhs.taskID), time(rhs.time), stable(rhs.stable), machine(rhs.machine), action(rhs.action) {}
-		void operator= (Task&& rhs) noexcept(true) { time = rhs.time; taskID = rhs.taskID; stable = rhs.stable; machine = rhs.machine; action = std::move(rhs.action); }
+		void operator= (Task&& rhs) BOOST_NOEXCEPT { time = rhs.time; taskID = rhs.taskID; stable = rhs.stable; machine = rhs.machine; action = std::move(rhs.action); }
 
 		bool operator < (Task const& rhs) const {
 			// Ordering is reversed for priority_queue

--- a/fdbserver/ClusterController.actor.cpp
+++ b/fdbserver/ClusterController.actor.cpp
@@ -57,9 +57,9 @@ struct WorkerInfo : NonCopyable {
 	WorkerInfo( Future<Void> watcher, ReplyPromise<RegisterWorkerReply> reply, Generation gen, WorkerInterface interf, ProcessClass initialClass, ProcessClass processClass, ClusterControllerPriorityInfo priorityInfo ) :
 		watcher(watcher), reply(reply), gen(gen), reboots(0), lastAvailableTime(now()), interf(interf), initialClass(initialClass), processClass(processClass), priorityInfo(priorityInfo) {}
 
-	WorkerInfo( WorkerInfo&& r ) noexcept(true) : watcher(std::move(r.watcher)), reply(std::move(r.reply)), gen(r.gen),
+	WorkerInfo( WorkerInfo&& r ) BOOST_NOEXCEPT : watcher(std::move(r.watcher)), reply(std::move(r.reply)), gen(r.gen),
 		reboots(r.reboots), lastAvailableTime(r.lastAvailableTime), interf(std::move(r.interf)), initialClass(r.initialClass), processClass(r.processClass), priorityInfo(r.priorityInfo) {}
-	void operator=( WorkerInfo&& r ) noexcept(true) {
+	void operator=( WorkerInfo&& r ) BOOST_NOEXCEPT {
 		watcher = std::move(r.watcher);
 		reply = std::move(r.reply);
 		gen = r.gen;

--- a/fdbserver/LogRouter.actor.cpp
+++ b/fdbserver/LogRouter.actor.cpp
@@ -42,8 +42,8 @@ struct LogRouterData {
 
 		TagData( Tag tag, Version popped, Version durableKnownCommittedVersion ) : tag(tag), popped(popped), durableKnownCommittedVersion(durableKnownCommittedVersion) {}
 
-		TagData(TagData&& r) noexcept(true) : version_messages(std::move(r.version_messages)), tag(r.tag), popped(r.popped), durableKnownCommittedVersion(r.durableKnownCommittedVersion) {}
-		void operator= (TagData&& r) noexcept(true) {
+		TagData(TagData&& r) BOOST_NOEXCEPT : version_messages(std::move(r.version_messages)), tag(r.tag), popped(r.popped), durableKnownCommittedVersion(r.durableKnownCommittedVersion) {}
+		void operator= (TagData&& r) BOOST_NOEXCEPT {
 			version_messages = std::move(r.version_messages);
 			tag = r.tag;
 			popped = r.popped;

--- a/fdbserver/OldTLogServer.actor.cpp
+++ b/fdbserver/OldTLogServer.actor.cpp
@@ -323,8 +323,8 @@ namespace oldTLog {
 
 			TagData( Version popped, bool nothing_persistent, bool popped_recently, OldTag tag ) : nothing_persistent(nothing_persistent), popped(popped), popped_recently(popped_recently), update_version_sizes(tag != txsTagOld) {}
 
-			TagData(TagData&& r) noexcept(true) : version_messages(std::move(r.version_messages)), nothing_persistent(r.nothing_persistent), popped_recently(r.popped_recently), popped(r.popped), update_version_sizes(r.update_version_sizes) {}
-			void operator= (TagData&& r) noexcept(true) {
+			TagData(TagData&& r) BOOST_NOEXCEPT : version_messages(std::move(r.version_messages)), nothing_persistent(r.nothing_persistent), popped_recently(r.popped_recently), popped(r.popped), update_version_sizes(r.update_version_sizes) {}
+			void operator= (TagData&& r) BOOST_NOEXCEPT {
 				version_messages = std::move(r.version_messages);
 				nothing_persistent = r.nothing_persistent;
 				popped_recently = r.popped_recently;

--- a/fdbserver/SkipList.cpp
+++ b/fdbserver/SkipList.cpp
@@ -494,12 +494,12 @@ public:
 	~SkipList() {
 		destroy();
 	}
-	SkipList(SkipList&& other) noexcept(true)
+	SkipList(SkipList&& other) BOOST_NOEXCEPT
 		: header(other.header)
 	{
 		other.header = NULL;
 	}
-	void operator=(SkipList&& other) noexcept(true) {
+	void operator=(SkipList&& other) BOOST_NOEXCEPT {
 		destroy();
 		header = other.header;
 		other.header = NULL;

--- a/fdbserver/TLogServer.actor.cpp
+++ b/fdbserver/TLogServer.actor.cpp
@@ -292,8 +292,8 @@ struct LogData : NonCopyable, public ReferenceCounted<LogData> {
 
 		TagData( Tag tag, Version popped, bool nothingPersistent, bool poppedRecently, bool unpoppedRecovered ) : tag(tag), nothingPersistent(nothingPersistent), popped(popped), poppedRecently(poppedRecently), unpoppedRecovered(unpoppedRecovered) {}
 
-		TagData(TagData&& r) noexcept(true) : versionMessages(std::move(r.versionMessages)), nothingPersistent(r.nothingPersistent), poppedRecently(r.poppedRecently), popped(r.popped), tag(r.tag), unpoppedRecovered(r.unpoppedRecovered) {}
-		void operator= (TagData&& r) noexcept(true) {
+		TagData(TagData&& r) BOOST_NOEXCEPT : versionMessages(std::move(r.versionMessages)), nothingPersistent(r.nothingPersistent), poppedRecently(r.poppedRecently), popped(r.popped), tag(r.tag), unpoppedRecovered(r.unpoppedRecovered) {}
+		void operator= (TagData&& r) BOOST_NOEXCEPT {
 			versionMessages = std::move(r.versionMessages);
 			nothingPersistent = r.nothingPersistent;
 			poppedRecently = r.poppedRecently;

--- a/fdbserver/fdbserver.vcxproj
+++ b/fdbserver/fdbserver.vcxproj
@@ -239,11 +239,11 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|X64'">
     <LinkIncremental>true</LinkIncremental>
-    <IncludePath>$(IncludePath);../;C:\Program Files\boost_1_52_0</IncludePath>
+    <IncludePath>$(IncludePath);../;C:\Program Files\boost_1_67_0</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|X64'">
     <LinkIncremental>false</LinkIncremental>
-    <IncludePath>$(IncludePath);../;C:\Program Files\boost_1_52_0</IncludePath>
+    <IncludePath>$(IncludePath);../;C:\Program Files\boost_1_67_0</IncludePath>
     <CustomBuildBeforeTargets>PreBuildEvent</CustomBuildBeforeTargets>
   </PropertyGroup>
   <ItemDefinitionGroup>

--- a/fdbserver/masterserver.actor.cpp
+++ b/fdbserver/masterserver.actor.cpp
@@ -53,8 +53,8 @@ struct ProxyVersionReplies {
 	std::map<uint64_t, GetCommitVersionReply> replies;
 	NotifiedVersion latestRequestNum;
 
-	ProxyVersionReplies(ProxyVersionReplies&& r) noexcept(true)  : replies(std::move(r.replies)), latestRequestNum(std::move(r.latestRequestNum)) {}
-	void operator=(ProxyVersionReplies&& r) noexcept(true) { replies = std::move(r.replies); latestRequestNum = std::move(r.latestRequestNum); }
+	ProxyVersionReplies(ProxyVersionReplies&& r) BOOST_NOEXCEPT  : replies(std::move(r.replies)), latestRequestNum(std::move(r.latestRequestNum)) {}
+	void operator=(ProxyVersionReplies&& r) BOOST_NOEXCEPT { replies = std::move(r.replies); latestRequestNum = std::move(r.latestRequestNum); }
 
 	ProxyVersionReplies() : latestRequestNum(0) {}
 };

--- a/flow/Arena.h
+++ b/flow/Arena.h
@@ -92,9 +92,9 @@ public:
 	inline explicit Arena( size_t reservedSize );
 	//~Arena();
 	Arena(const Arena&);
-	Arena(Arena && r) noexcept(true);
+	Arena(Arena && r) BOOST_NOEXCEPT;
 	Arena& operator=(const Arena&);
-	Arena& operator=(Arena&&) noexcept(true);
+	Arena& operator=(Arena&&) BOOST_NOEXCEPT;
 
 	inline void dependsOn( const Arena& p );
 	inline size_t getSize() const;
@@ -288,12 +288,12 @@ inline Arena::Arena(size_t reservedSize) : impl( 0 ) {
 		ArenaBlock::create((int)reservedSize,impl);
 }
 inline Arena::Arena( const Arena& r ) : impl( r.impl ) {}
-inline Arena::Arena(Arena && r) noexcept(true) : impl(std::move(r.impl)) {}
+inline Arena::Arena(Arena && r) BOOST_NOEXCEPT : impl(std::move(r.impl)) {}
 inline Arena& Arena::operator=(const Arena& r) {
 	impl = r.impl;
 	return *this;
 }
-inline Arena& Arena::operator=(Arena&& r) noexcept(true) {
+inline Arena& Arena::operator=(Arena&& r) BOOST_NOEXCEPT {
 	impl = std::move(r.impl);
 	return *this;
 }

--- a/flow/Deque.h
+++ b/flow/Deque.h
@@ -65,13 +65,13 @@ public:
 		// FIXME: Specialization for POD types using memcpy?
 	}
 
-	Deque(Deque&& r) noexcept(true) : begin(r.begin), end(r.end), mask(r.mask), arr(r.arr) {
+	Deque(Deque&& r) BOOST_NOEXCEPT : begin(r.begin), end(r.end), mask(r.mask), arr(r.arr) {
 		r.arr = 0;
 		r.begin = r.end = 0;
 		r.mask = -1;
 	}
 
-	void operator=(Deque&& r) noexcept(true) {
+	void operator=(Deque&& r) BOOST_NOEXCEPT {
 		cleanup();
 
 		begin = r.begin;

--- a/flow/FastRef.h
+++ b/flow/FastRef.h
@@ -104,7 +104,7 @@ public:
 	static Reference<P> addRef( P* ptr ) { ptr->addref(); return Reference(ptr); }
 
 	Reference(const Reference& r) : ptr(r.getPtr()) { if (ptr) addref(ptr); }
-	Reference(Reference && r) noexcept(true) : ptr(r.getPtr()) { r.ptr = NULL; }
+	Reference(Reference && r) BOOST_NOEXCEPT : ptr(r.getPtr()) { r.ptr = NULL; }
 
 	template <class Q>
 	Reference(const Reference<Q>& r) : ptr(r.getPtr()) { if (ptr) addref(ptr); }
@@ -122,7 +122,7 @@ public:
 		}
 		return *this;
 	}
-	Reference& operator=(Reference&& r) noexcept(true) {
+	Reference& operator=(Reference&& r) BOOST_NOEXCEPT {
 		P* oldPtr = ptr;
 		P* newPtr = r.ptr;
 		if (oldPtr != newPtr) {

--- a/flow/IndexedSet.h
+++ b/flow/IndexedSet.h
@@ -96,8 +96,8 @@ public:
 
 	IndexedSet() : root(NULL) {};
 	~IndexedSet() { delete root; }
-	IndexedSet(IndexedSet&& r) noexcept(true) : root(r.root) { r.root = NULL; }
-	IndexedSet& operator=(IndexedSet&& r) noexcept(true) { delete root; root = r.root; r.root = 0; return *this; }
+	IndexedSet(IndexedSet&& r) BOOST_NOEXCEPT : root(r.root) { r.root = NULL; }
+	IndexedSet& operator=(IndexedSet&& r) BOOST_NOEXCEPT { delete root; root = r.root; r.root = 0; return *this; }
 
 	iterator begin() const;
 	iterator end() const { return iterator(); }
@@ -243,8 +243,8 @@ public:
 	void operator= ( MapPair const& rhs ) { key = rhs.key; value = rhs.value; }
 	MapPair( MapPair const& rhs ) : key(rhs.key), value(rhs.value) {}
 
-	MapPair(MapPair&& r) noexcept(true)  : key(std::move(r.key)), value(std::move(r.value)) {}
-	void operator=(MapPair&& r) noexcept(true) { key = std::move(r.key); value = std::move(r.value); }
+	MapPair(MapPair&& r) BOOST_NOEXCEPT  : key(std::move(r.key)), value(std::move(r.value)) {}
+	void operator=(MapPair&& r) BOOST_NOEXCEPT { key = std::move(r.key); value = std::move(r.value); }
 
 	bool operator<(MapPair<Key,Value> const& r) const { return key < r.key; }
 	bool operator==(MapPair<Key,Value> const& r) const { return key == r.key; }
@@ -316,8 +316,8 @@ public:
 
 	static int getElementBytes() { return IndexedSet< Pair, Metric >::getElementBytes(); }
 
-	Map(Map&& r) noexcept(true) : set(std::move(r.set)) {}
-	void operator=(Map&& r) noexcept(true) { set = std::move(r.set); }
+	Map(Map&& r) BOOST_NOEXCEPT : set(std::move(r.set)) {}
+	void operator=(Map&& r) BOOST_NOEXCEPT { set = std::move(r.set); }
 
 private:
 	Map( Map<Key,Value,Pair> const& ); // unimplemented

--- a/flow/Net2.actor.cpp
+++ b/flow/Net2.actor.cpp
@@ -237,7 +237,7 @@ class BindPromise {
 public:
 	BindPromise( const char* errContext, UID errID ) : errContext(errContext), errID(errID) {}
 	BindPromise( BindPromise const& r ) : p(r.p), errContext(r.errContext), errID(r.errID) {}
-	BindPromise(BindPromise&& r) noexcept(true) : p(std::move(r.p)), errContext(r.errContext), errID(r.errID) {}
+	BindPromise(BindPromise&& r) BOOST_NOEXCEPT : p(std::move(r.p)), errContext(r.errContext), errID(r.errID) {}
 
 	Future<Void> getFuture() { return p.getFuture(); }
 
@@ -471,7 +471,7 @@ private:
 struct PromiseTask : public Task, public FastAllocated<PromiseTask> {
 	Promise<Void> promise;
 	PromiseTask() {}
-	explicit PromiseTask( Promise<Void>&& promise ) noexcept(true) : promise(std::move(promise)) {}
+	explicit PromiseTask( Promise<Void>&& promise ) BOOST_NOEXCEPT : promise(std::move(promise)) {}
 
 	virtual void operator()() {
 		promise.send(Void());

--- a/flow/Platform.h
+++ b/flow/Platform.h
@@ -542,12 +542,8 @@ inline static int ctzll( uint64_t value ) {
 #define ctzll __builtin_ctzll
 #endif
 
-// MSVC not support noexcept yet
-#ifndef __GNUG__
-#ifndef VS14
-#define noexcept(enabled)
-#endif
-#endif
+#include <boost/config.hpp>
+// The formerly existing BOOST_NOEXCEPT is now BOOST_NOEXCEPT
 
 #else
 #define EXTERNC

--- a/flow/TDMetric.actor.h
+++ b/flow/TDMetric.actor.h
@@ -217,14 +217,14 @@ struct MetricData {
 		appendStart(appendStart) {
 	}
 
-	MetricData( MetricData&& r ) noexcept(true) :
+	MetricData( MetricData&& r ) BOOST_NOEXCEPT :
 		start(r.start),
 		rollTime(r.rollTime),
 		appendStart(r.appendStart),
 		writer(std::move(r.writer)) {
 	}
 
-	void operator=( MetricData&& r ) noexcept(true) {
+	void operator=( MetricData&& r ) BOOST_NOEXCEPT {
 		start = r.start; rollTime = r.rollTime; appendStart = r.appendStart; writer = std::move(r.writer);
 	}
 
@@ -620,9 +620,9 @@ template <class T, class Descriptor = NullDescriptor, class FieldLevelType = Fie
 struct EventField : public Descriptor {
 	std::vector<FieldLevelType> levels;
 
-	EventField( EventField&& r ) noexcept(true) : Descriptor(r), levels(std::move(r.levels)) {}
+	EventField( EventField&& r ) BOOST_NOEXCEPT : Descriptor(r), levels(std::move(r.levels)) {}
 
-	void operator=( EventField&& r ) noexcept(true) {
+	void operator=( EventField&& r ) BOOST_NOEXCEPT {
 		levels = std::move(r.levels);
 	}
 

--- a/flow/ThreadHelper.actor.h
+++ b/flow/ThreadHelper.actor.h
@@ -462,7 +462,7 @@ public:
 	ThreadFuture( const ThreadFuture<T>& rhs ) : sav(rhs.sav) {
 		if (sav) sav->addref();
 	}
-	ThreadFuture(ThreadFuture<T>&& rhs) noexcept(true) : sav(rhs.sav) {
+	ThreadFuture(ThreadFuture<T>&& rhs) BOOST_NOEXCEPT : sav(rhs.sav) {
 		rhs.sav = 0;
 	}
 	ThreadFuture( const T& presentValue ) 
@@ -487,7 +487,7 @@ public:
 		if (sav) sav->delref();
 		sav = rhs.sav;
 	}
-	void operator=(ThreadFuture<T>&& rhs) noexcept(true) {
+	void operator=(ThreadFuture<T>&& rhs) BOOST_NOEXCEPT {
 		if (sav != rhs.sav) {
 			if (sav) sav->delref();
 			sav = rhs.sav;

--- a/flow/flow.h
+++ b/flow/flow.h
@@ -624,7 +624,7 @@ public:
 		if (sav) sav->addFutureRef();
 		//if (sav->endpoint.isValid()) cout << "Future copied for " << sav->endpoint.key << endl;
 	}
-	Future(Future<T>&& rhs) noexcept(true) : sav(rhs.sav) {
+	Future(Future<T>&& rhs) BOOST_NOEXCEPT : sav(rhs.sav) {
 		rhs.sav = 0;
 		//if (sav->endpoint.isValid()) cout << "Future moved for " << sav->endpoint.key << endl;
 	}
@@ -653,7 +653,7 @@ public:
 		if (sav) sav->delFutureRef();
 		sav = rhs.sav;
 	}
-	void operator=(Future<T>&& rhs) noexcept(true) {
+	void operator=(Future<T>&& rhs) BOOST_NOEXCEPT {
 		if (sav != rhs.sav) {
 			if (sav) sav->delFutureRef();
 			sav = rhs.sav;
@@ -729,7 +729,7 @@ public:
 	bool isValid() const { return sav != NULL; }
 	Promise() : sav(new SAV<T>(0, 1)) {}
 	Promise(const Promise& rhs) : sav(rhs.sav) { sav->addPromiseRef(); }
-	Promise(Promise&& rhs) noexcept(true) : sav(rhs.sav) { rhs.sav = 0; }
+	Promise(Promise&& rhs) BOOST_NOEXCEPT : sav(rhs.sav) { rhs.sav = 0; }
 	~Promise() { if (sav) sav->delPromiseRef(); }
 
 	void operator=(const Promise& rhs) {
@@ -737,7 +737,7 @@ public:
 		if (sav) sav->delPromiseRef();
 		sav = rhs.sav;
 	}
-	void operator=(Promise && rhs) noexcept(true) {
+	void operator=(Promise && rhs) BOOST_NOEXCEPT {
 		if (sav != rhs.sav) {
 			if (sav) sav->delPromiseRef();
 			sav = rhs.sav;
@@ -782,14 +782,14 @@ public:
 	}
 	FutureStream() : queue(NULL) {}
 	FutureStream(const FutureStream& rhs) : queue(rhs.queue) { queue->addFutureRef(); }
-	FutureStream(FutureStream&& rhs) noexcept(true) : queue(rhs.queue) { rhs.queue = 0; }
+	FutureStream(FutureStream&& rhs) BOOST_NOEXCEPT : queue(rhs.queue) { rhs.queue = 0; }
 	~FutureStream() { if (queue) queue->delFutureRef(); }
 	void operator=(const FutureStream& rhs) {
 		rhs.queue->addFutureRef();
 		if (queue) queue->delFutureRef();
 		queue = rhs.queue;
 	}
-	void operator=(FutureStream&& rhs) noexcept(true) {
+	void operator=(FutureStream&& rhs) BOOST_NOEXCEPT {
 		if (rhs.queue != queue) {
 			if (queue) queue->delFutureRef();
 			queue = rhs.queue;
@@ -883,13 +883,13 @@ public:
 	FutureStream<T> getFuture() const { queue->addFutureRef(); return FutureStream<T>(queue); }
 	PromiseStream() : queue(new NotifiedQueue<T>(0, 1)) {}
 	PromiseStream(const PromiseStream& rhs) : queue(rhs.queue) { queue->addPromiseRef(); }
-	PromiseStream(PromiseStream&& rhs) noexcept(true) : queue(rhs.queue) { rhs.queue = 0; }
+	PromiseStream(PromiseStream&& rhs) BOOST_NOEXCEPT : queue(rhs.queue) { rhs.queue = 0; }
 	void operator=(const PromiseStream& rhs) {
 		rhs.queue->addPromiseRef();
 		if (queue) queue->delPromiseRef();
 		queue = rhs.queue;
 	}
-	void operator=(PromiseStream&& rhs) noexcept(true) {
+	void operator=(PromiseStream&& rhs) BOOST_NOEXCEPT {
 		if (queue != rhs.queue) {
 			if (queue) queue->delPromiseRef();
 			queue = rhs.queue;

--- a/flow/flow.h
+++ b/flow/flow.h
@@ -45,6 +45,14 @@
 #include "flow/ThreadPrimitives.h"
 #include "flow/network.h"
 
+#include <boost/version.hpp>
+
+#if BOOST_VERSION == 105200
+#error Boost is still 1.52.0
+#elif BOOST_VERSION != 106700
+#error Boost is not 1.67.0
+#endif
+
 using namespace std::rel_ops;
 
 #define TEST( condition ) if (!(condition)); else { static TraceEvent* __test = &(TraceEvent("CodeCoverage").detail("File", __FILE__).detail("Line",__LINE__).detail("Condition", #condition)); }

--- a/flow/flow.vcxproj
+++ b/flow/flow.vcxproj
@@ -132,11 +132,11 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|X64'">
     <LinkIncremental>true</LinkIncremental>
-    <IncludePath>$(IncludePath);../;C:\Program Files\boost_1_52_0</IncludePath>
+    <IncludePath>$(IncludePath);../;C:\Program Files\boost_1_67_0</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|X64'">
     <LinkIncremental>false</LinkIncremental>
-    <IncludePath>$(IncludePath);../;C:\Program Files\boost_1_52_0</IncludePath>
+    <IncludePath>$(IncludePath);../;C:\Program Files\boost_1_67_0</IncludePath>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <PreBuildEvent>

--- a/flow/genericactors.actor.h
+++ b/flow/genericactors.actor.h
@@ -1187,7 +1187,7 @@ struct FlowLock : NonCopyable, public ReferenceCounted<FlowLock> {
 		int remaining;
 		Releaser() : lock(0), remaining(0) {}
 		Releaser( FlowLock& lock, int amount = 1 ) : lock(&lock), remaining(amount) {}
-		Releaser(Releaser&& r) noexcept(true) : lock(r.lock), remaining(r.remaining) { r.remaining = 0; }
+		Releaser(Releaser&& r) BOOST_NOEXCEPT : lock(r.lock), remaining(r.remaining) { r.remaining = 0; }
 		void operator=(Releaser&& r) { if (remaining) lock->release(remaining); lock = r.lock; remaining = r.remaining; r.remaining = 0; }
 
 		void release( int amount = -1 ) {
@@ -1425,7 +1425,7 @@ public:
 		futures = f.futures;
 	}
 
-	AndFuture(AndFuture&& f) noexcept(true) {
+	AndFuture(AndFuture&& f) BOOST_NOEXCEPT {
 		futures = std::move(f.futures);
 	}
 
@@ -1445,7 +1445,7 @@ public:
 		futures = f.futures;
 	}
 
-	void operator=(AndFuture&& f) noexcept(true) {
+	void operator=(AndFuture&& f) BOOST_NOEXCEPT {
 		futures = std::move(f.futures);
 	}
 


### PR DESCRIPTION
This is to give us a way to let which boost to use toggleable in the
source code as BOOSTDIR_BASENAME, and let build enviornments configure
where to find appropriately named boost folders via BOOSTDIR_BASEDIR.

This isn't pretty, and CMake's FindBoost is a far better way to do this,
but it'll work for now.