### PR TITLE
Features/protocol version flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ ifeq ($(PLATFORM),Linux)
   CC ?= gcc
   CXX ?= g++
 
-  CXXFLAGS += -std=c++0x
+  CXXFLAGS += -std=c++17
 
   BOOST_BASEDIR ?= /opt
   TLS_LIBDIR ?= /usr/local/lib

--- a/cmake/ConfigureCompiler.cmake
+++ b/cmake/ConfigureCompiler.cmake
@@ -95,7 +95,7 @@ else()
     -mmmx
     -mavx
     -msse4.2)
-  add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-std=c++11>)
+  add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-std=c++17>)
   if (USE_VALGRIND)
     add_compile_options(-DVALGRIND -DUSE_VALGRIND)
   endif()

--- a/cmake/ConfigureCompiler.cmake
+++ b/cmake/ConfigureCompiler.cmake
@@ -52,7 +52,7 @@ if(WIN32)
   # see: https://docs.microsoft.com/en-us/windows/desktop/WinProg/using-the-windows-headers
   # this sets the windows target version to Windows 7
   set(WINDOWS_TARGET 0x0601)
-  add_compile_options(/W3 /EHsc /std:c++14 /bigobj $<$<CONFIG:Release>:/Zi> /MP)
+  add_compile_options(/W3 /EHsc /std:c++17 /bigobj $<$<CONFIG:Release>:/Zi> /MP)
   add_compile_definitions(_WIN32_WINNT=${WINDOWS_TARGET} BOOST_ALL_NO_LIB)
 else()
   if(USE_GOLD_LINKER)

--- a/fdbclient/ClientDBInfo.h
+++ b/fdbclient/ClientDBInfo.h
@@ -27,6 +27,7 @@
 // ClientDBInfo is all the information needed by a database client to access the database
 // It is returned (and kept up to date) by the OpenDatabaseRequest interface of ClusterInterface
 struct ClientDBInfo {
+	constexpr static FileIdentifier file_identifier = 5355080;
 	UID id;  // Changes each time anything else changes
 	vector< MasterProxyInterface > proxies;
 	double clientTxnInfoSampleRate;

--- a/fdbclient/ClientDBInfo.h
+++ b/fdbclient/ClientDBInfo.h
@@ -38,7 +38,9 @@ struct ClientDBInfo {
 
 	template <class Archive>
 	void serialize(Archive& ar) {
-		ASSERT( ar.protocolVersion() >= 0x0FDB00A200040001LL );
+		if constexpr (!is_fb_function<Archive>) {
+			ASSERT(ar.protocolVersion() >= 0x0FDB00A200040001LL);
+		}
 		serializer(ar, proxies, id, clientTxnInfoSampleRate, clientTxnInfoSizeLimit);
 	}
 };

--- a/fdbclient/ClientWorkerInterface.h
+++ b/fdbclient/ClientWorkerInterface.h
@@ -30,6 +30,7 @@
 // Streams from WorkerInterface that are safe and useful to call from a client.
 // A ClientWorkerInterface is embedded as the first element of a WorkerInterface.
 struct ClientWorkerInterface {
+	constexpr static FileIdentifier file_identifier = 12418152;
 	RequestStream< struct RebootRequest > reboot;
 	RequestStream< struct ProfilerRequest > profiler;
 
@@ -45,6 +46,7 @@ struct ClientWorkerInterface {
 };
 
 struct RebootRequest {
+	constexpr static FileIdentifier file_identifier = 11913957;
 	bool deleteData;
 	bool checkData;
 
@@ -57,6 +59,7 @@ struct RebootRequest {
 };
 
 struct ProfilerRequest {
+	constexpr static FileIdentifier file_identifier = 15437862;
 	ReplyPromise<Void> reply;
 
 	enum class Type : std::int8_t {

--- a/fdbclient/ClusterInterface.h
+++ b/fdbclient/ClusterInterface.h
@@ -29,6 +29,7 @@
 #include "fdbclient/ClientWorkerInterface.h"
 
 struct ClusterInterface {
+    constexpr static FileIdentifier file_identifier = 15888863;
 	RequestStream< struct OpenDatabaseRequest > openDatabase;
 	RequestStream< struct FailureMonitoringRequest > failureMonitoring;
 	RequestStream< struct StatusRequest > databaseStatus;
@@ -53,6 +54,23 @@ struct ClusterInterface {
 	template <class Ar>
 	void serialize( Ar& ar ) {
 		serializer(ar, openDatabase, failureMonitoring, databaseStatus, ping, getClientWorkers, forceRecovery);
+	}
+};
+
+struct ClusterControllerClientInterface {
+	constexpr static FileIdentifier file_identifier = 14997695;
+	ClusterInterface clientInterface;
+
+	bool operator==(ClusterControllerClientInterface const& r) const {
+		return clientInterface.id() == r.clientInterface.id();
+	}
+	bool operator!=(ClusterControllerClientInterface const& r) const {
+		return clientInterface.id() != r.clientInterface.id();
+	}
+
+	template <class Ar>
+	void serialize(Ar& ar) {
+		serializer(ar, clientInterface);
 	}
 };
 

--- a/fdbclient/ClusterInterface.h
+++ b/fdbclient/ClusterInterface.h
@@ -146,9 +146,10 @@ struct OpenDatabaseRequest {
 	template <class Ar>
 	void serialize(Ar& ar) {
 		if constexpr (!is_fb_function<Ar>) {
-                ASSERT( ar.protocolVersion() >= 0x0FDB00A400040001LL );
+			ASSERT(ar.protocolVersion() >= 0x0FDB00A400040001LL);
 		}
-        serializer(ar, issues, supportedVersions, connectedCoordinatorsNum, traceLogGroup, knownClientInfoID, reply, arena);
+		serializer(ar, issues, supportedVersions, connectedCoordinatorsNum, traceLogGroup, knownClientInfoID, reply,
+				   arena);
 	}
 };
 

--- a/fdbclient/ClusterInterface.h
+++ b/fdbclient/ClusterInterface.h
@@ -166,6 +166,21 @@ struct SystemFailureStatus {
 	}
 };
 
+struct FailureMonitoringReply {
+	constexpr static FileIdentifier file_identifier = 6820325;
+	VectorRef< SystemFailureStatus > changes;
+	Version failureInformationVersion;
+	bool allOthersFailed;							// If true, changes are relative to all servers being failed, otherwise to the version given in the request
+	int clientRequestIntervalMS,        // after this many milliseconds, send another request
+		considerServerFailedTimeoutMS;  // after this many additional milliseconds, consider the ClusterController itself to be failed
+	Arena arena;
+
+	template <class Ar>
+	void serialize(Ar& ar) {
+		serializer(ar, changes, failureInformationVersion, allOthersFailed, clientRequestIntervalMS, considerServerFailedTimeoutMS, arena);
+	}
+};
+
 struct FailureMonitoringRequest {
 	// Sent by all participants to the cluster controller reply.clientRequestIntervalMS
 	//   ms after receiving the previous reply.
@@ -186,31 +201,6 @@ struct FailureMonitoringRequest {
 	template <class Ar>
 	void serialize(Ar& ar) {
 		serializer(ar, senderStatus, failureInformationVersion, addresses, reply);
-	}
-};
-
-struct FailureMonitoringReply {
-	constexpr static FileIdentifier file_identifier = 6820325;
-	VectorRef< SystemFailureStatus > changes;
-	Version failureInformationVersion;
-	bool allOthersFailed;							// If true, changes are relative to all servers being failed, otherwise to the version given in the request
-	int clientRequestIntervalMS,        // after this many milliseconds, send another request
-		considerServerFailedTimeoutMS;  // after this many additional milliseconds, consider the ClusterController itself to be failed
-	Arena arena;
-
-	template <class Ar>
-	void serialize(Ar& ar) {
-		serializer(ar, changes, failureInformationVersion, allOthersFailed, clientRequestIntervalMS, considerServerFailedTimeoutMS, arena);
-	}
-};
-
-struct StatusRequest {
-	constexpr static FileIdentifier file_identifier = 14419140;
-	ReplyPromise< struct StatusReply > reply;
-
-	template <class Ar>
-	void serialize(Ar& ar) {
-		serializer(ar, reply);
 	}
 };
 
@@ -237,6 +227,16 @@ struct StatusReply {
 			}
 			statusObj = std::move(mv.get_obj());
 		}
+	}
+};
+
+struct StatusRequest {
+	constexpr static FileIdentifier file_identifier = 14419140;
+	ReplyPromise< struct StatusReply > reply;
+
+	template <class Ar>
+	void serialize(Ar& ar) {
+		serializer(ar, reply);
 	}
 };
 

--- a/fdbclient/ClusterInterface.h
+++ b/fdbclient/ClusterInterface.h
@@ -126,8 +126,10 @@ struct OpenDatabaseRequest {
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		ASSERT( ar.protocolVersion() >= 0x0FDB00A400040001LL );
-		serializer(ar, issues, supportedVersions, connectedCoordinatorsNum, traceLogGroup, knownClientInfoID, reply, arena);
+		if constexpr (!is_fb_function<Ar>) {
+                ASSERT( ar.protocolVersion() >= 0x0FDB00A400040001LL );
+		}
+        serializer(ar, issues, supportedVersions, connectedCoordinatorsNum, traceLogGroup, knownClientInfoID, reply, arena);
 	}
 };
 

--- a/fdbclient/ClusterInterface.h
+++ b/fdbclient/ClusterInterface.h
@@ -131,6 +131,7 @@ struct ClientVersionRef {
 };
 
 struct OpenDatabaseRequest {
+	constexpr static FileIdentifier file_identifier = 2799502;
 	// Sent by the native API to the cluster controller to open a database and track client
 	//   info changes.  Returns immediately if the current client info id is different from
 	//   knownClientInfoID; otherwise returns when it next changes (or perhaps after a long interval)
@@ -152,6 +153,7 @@ struct OpenDatabaseRequest {
 };
 
 struct SystemFailureStatus {
+	constexpr static FileIdentifier file_identifier = 3194108;
 	NetworkAddressList addresses;
 	FailureStatus status;
 
@@ -175,6 +177,7 @@ struct FailureMonitoringRequest {
 	// The failureInformationVersion returned in reply should be passed back to the
 	//   next request to facilitate delta compression of the failure information.
 
+	constexpr static FileIdentifier file_identifier = 5867851;
 	Optional<FailureStatus> senderStatus;
 	Version failureInformationVersion;
 	NetworkAddressList addresses;
@@ -187,6 +190,7 @@ struct FailureMonitoringRequest {
 };
 
 struct FailureMonitoringReply {
+	constexpr static FileIdentifier file_identifier = 6820325;
 	VectorRef< SystemFailureStatus > changes;
 	Version failureInformationVersion;
 	bool allOthersFailed;							// If true, changes are relative to all servers being failed, otherwise to the version given in the request
@@ -201,6 +205,7 @@ struct FailureMonitoringReply {
 };
 
 struct StatusRequest {
+	constexpr static FileIdentifier file_identifier = 14419140;
 	ReplyPromise< struct StatusReply > reply;
 
 	template <class Ar>
@@ -210,6 +215,7 @@ struct StatusRequest {
 };
 
 struct StatusReply {
+	constexpr static FileIdentifier file_identifier = 9980504;
 	StatusObject statusObj;
 	std::string statusStr;
 
@@ -235,6 +241,7 @@ struct StatusReply {
 };
 
 struct GetClientWorkersRequest {
+	constexpr static FileIdentifier file_identifier = 10771791;
 	ReplyPromise<vector<ClientWorkerInterface>> reply;
 
 	GetClientWorkersRequest() {}
@@ -246,6 +253,7 @@ struct GetClientWorkersRequest {
 };
 
 struct ForceRecoveryRequest {
+	constexpr static FileIdentifier file_identifier = 14821350;
 	Key dcId;
 	ReplyPromise<Void> reply;
 

--- a/fdbclient/CoordinationInterface.h
+++ b/fdbclient/CoordinationInterface.h
@@ -91,6 +91,7 @@ private:
 };
 
 struct LeaderInfo {
+	constexpr static FileIdentifier file_identifier = 8338794;
 	UID changeID;
 	static const uint64_t mask = ~(127ll << 57);
 	Value serializedInfo;
@@ -126,6 +127,7 @@ struct LeaderInfo {
 };
 
 struct GetLeaderRequest {
+	constexpr static FileIdentifier file_identifier = 214727;
 	Key key;
 	UID knownLeader;
 	ReplyPromise< Optional<LeaderInfo> > reply;

--- a/fdbclient/FDBTypes.h
+++ b/fdbclient/FDBTypes.h
@@ -540,6 +540,7 @@ struct Traceable<RangeResultRef> : std::true_type {
 };
 
 struct KeyValueStoreType {
+	constexpr static FileIdentifier file_identifier = 6560359;
 	// These enumerated values are stored in the database configuration, so can NEVER be changed.  Only add new ones just before END.
 	enum StoreType {
 		SSD_BTREE_V1,

--- a/fdbclient/FDBTypes.h
+++ b/fdbclient/FDBTypes.h
@@ -745,25 +745,6 @@ struct AddressExclusion {
 	}
 };
 
-template <>
-struct scalar_traits<AddressExclusion> : std::true_type {
-	using ip_traits = scalar_traits<uint32_t>;
-	using port_traits = scalar_traits<int>;
-	constexpr static size_t size = ip_traits::size + port_traits::size;
-	static void save(uint8_t* buf, const AddressExclusion& value) {
-		ip_traits::save(buf, value.ip);
-		port_traits::save(buf + ip_traits::size, value.port);
-	}
-
-	// Context is an arbitrary type that is plumbed by reference throughout the
-	// load call tree.
-	template <class Context>
-	static void load(const uint8_t* buf, AddressExclusion& value, Context& context) {
-		ip_traits::load<Context>(buf, value.ip, context);
-		port_traits::load<Context>(buf + ip_traits::size, value.port, context);
-	}
-};
-
 static bool addressExcluded( std::set<AddressExclusion> const& exclusions, NetworkAddress const& addr ) {
 	return exclusions.count( AddressExclusion(addr.ip, addr.port) ) || exclusions.count( AddressExclusion(addr.ip) );
 }

--- a/fdbclient/MasterProxyInterface.h
+++ b/fdbclient/MasterProxyInterface.h
@@ -30,6 +30,7 @@
 #include "flow/Stats.h"
 
 struct MasterProxyInterface {
+	constexpr static FileIdentifier file_identifier = 8954922;
 	enum { LocationAwareLoadBalance = 1 };
 	enum { AlwaysFresh = 1 };
 
@@ -71,6 +72,7 @@ struct MasterProxyInterface {
 };
 
 struct CommitID {
+	constexpr static FileIdentifier file_identifier = 14254927;
 	Version version; 			// returns invalidVersion if transaction conflicts
 	uint16_t txnBatchId;
 	Optional<Value> metadataVersion;
@@ -85,6 +87,7 @@ struct CommitID {
 };
 
 struct CommitTransactionRequest : TimedRequest {
+	constexpr static FileIdentifier file_identifier = 93948;
 	enum { 
 		FLAG_IS_LOCK_AWARE = 0x1,
 		FLAG_FIRST_IN_BATCH = 0x2
@@ -121,6 +124,7 @@ static inline int getBytes( CommitTransactionRequest const& r ) {
 }
 
 struct GetReadVersionReply {
+	constexpr static FileIdentifier file_identifier = 15709388;
 	Version version;
 	bool locked;
 	Optional<Value> metadataVersion;
@@ -132,6 +136,7 @@ struct GetReadVersionReply {
 };
 
 struct GetReadVersionRequest : TimedRequest {
+	constexpr static FileIdentifier file_identifier = 838566;
 	enum { 
 		PRIORITY_SYSTEM_IMMEDIATE = 15 << 24,  // Highest possible priority, always executed even if writes are otherwise blocked
 		PRIORITY_DEFAULT = 8 << 24,
@@ -161,6 +166,7 @@ struct GetReadVersionRequest : TimedRequest {
 };
 
 struct GetKeyServerLocationsReply {
+	constexpr static FileIdentifier file_identifier = 10636023;
 	Arena arena;
 	vector<pair<KeyRangeRef, vector<StorageServerInterface>>> results;
 
@@ -171,6 +177,7 @@ struct GetKeyServerLocationsReply {
 };
 
 struct GetKeyServerLocationsRequest {
+	constexpr static FileIdentifier file_identifier = 9144680;
 	Arena arena;
 	KeyRef begin;
 	Optional<KeyRef> end;
@@ -188,6 +195,7 @@ struct GetKeyServerLocationsRequest {
 };
 
 struct GetRawCommittedVersionRequest {
+	constexpr static FileIdentifier file_identifier = 12954034;
 	Optional<UID> debugID;
 	ReplyPromise<GetReadVersionReply> reply;
 
@@ -200,6 +208,7 @@ struct GetRawCommittedVersionRequest {
 };
 
 struct GetStorageServerRejoinInfoReply {
+	constexpr static FileIdentifier file_identifier = 9469225;
 	Version version;
 	Tag tag;
 	Optional<Tag> newTag;
@@ -213,6 +222,7 @@ struct GetStorageServerRejoinInfoReply {
 };
 
 struct GetStorageServerRejoinInfoRequest {
+	constexpr static FileIdentifier file_identifier = 994279;
 	UID id;
 	Optional<Value> dcId;
 	ReplyPromise< GetStorageServerRejoinInfoReply > reply;
@@ -227,6 +237,7 @@ struct GetStorageServerRejoinInfoRequest {
 };
 
 struct TxnStateRequest {
+	constexpr static FileIdentifier file_identifier = 15250781;
 	Arena arena;
 	VectorRef<KeyValueRef> data;
 	Sequence sequence;

--- a/fdbclient/MasterProxyInterface.h
+++ b/fdbclient/MasterProxyInterface.h
@@ -252,6 +252,7 @@ struct TxnStateRequest {
 
 struct GetHealthMetricsRequest
 {
+	constexpr static FileIdentifier file_identifier = 11403900;
 	ReplyPromise<struct GetHealthMetricsReply> reply;
 	bool detailed;
 
@@ -266,6 +267,7 @@ struct GetHealthMetricsRequest
 
 struct GetHealthMetricsReply
 {
+	constexpr static FileIdentifier file_identifier = 11544290;
 	Standalone<StringRef> serialized;
 	HealthMetrics healthMetrics;
 

--- a/fdbclient/MasterProxyInterface.h
+++ b/fdbclient/MasterProxyInterface.h
@@ -250,21 +250,6 @@ struct TxnStateRequest {
 	}
 };
 
-struct GetHealthMetricsRequest
-{
-	constexpr static FileIdentifier file_identifier = 11403900;
-	ReplyPromise<struct GetHealthMetricsReply> reply;
-	bool detailed;
-
-	explicit GetHealthMetricsRequest(bool detailed = false) : detailed(detailed) {}
-
-	template <class Ar>
-	void serialize(Ar& ar)
-	{
-		serializer(ar, reply, detailed);
-	}
-};
-
 struct GetHealthMetricsReply
 {
 	constexpr static FileIdentifier file_identifier = 11544290;
@@ -292,6 +277,21 @@ struct GetHealthMetricsReply
 			BinaryReader br(serialized, IncludeVersion());
 			br >> healthMetrics;
 		}
+	}
+};
+
+struct GetHealthMetricsRequest
+{
+	constexpr static FileIdentifier file_identifier = 11403900;
+	ReplyPromise<struct GetHealthMetricsReply> reply;
+	bool detailed;
+
+	explicit GetHealthMetricsRequest(bool detailed = false) : detailed(detailed) {}
+
+	template <class Ar>
+	void serialize(Ar& ar)
+	{
+		serializer(ar, reply, detailed);
 	}
 };
 

--- a/fdbclient/MonitorLeader.actor.cpp
+++ b/fdbclient/MonitorLeader.actor.cpp
@@ -234,6 +234,27 @@ TEST_CASE("/fdbclient/MonitorLeader/parseConnectionString/basic") {
 }
 
 TEST_CASE("/flow/FlatBuffers/LeaderInfo") {
+	{
+		LeaderInfo in;
+		LeaderInfo out;
+		in.forward = g_random->coinflip();
+		in.changeID = g_random->randomUniqueID();
+		{
+			std::string rndString(g_random->randomInt(10, 400), 'x');
+			for (auto& c : rndString) {
+				c = g_random->randomAlphaNumeric();
+			}
+			in.serializedInfo = rndString;
+		}
+		ObjectWriter writer;
+		writer.serialize(in);
+		Standalone<StringRef> copy = writer.toStringRef();
+		ArenaObjectReader reader(copy.arena(), copy);
+		reader.deserialize(out);
+		ASSERT(in.forward == out.forward);
+		ASSERT(in.changeID == out.changeID);
+		ASSERT(in.serializedInfo == out.serializedInfo);
+	}
 	LeaderInfo leaderInfo;
 	leaderInfo.forward = g_random->coinflip();
 	leaderInfo.changeID = g_random->randomUniqueID();
@@ -247,11 +268,9 @@ TEST_CASE("/flow/FlatBuffers/LeaderInfo") {
 	ErrorOr<Optional<LeaderInfo>> objIn{ Optional<LeaderInfo>{leaderInfo} };
 	ErrorOr<Optional<LeaderInfo>> objOut;
 	Standalone<StringRef> copy;
-	{
-		ObjectWriter writer;
-		writer.serialize(objIn);
-		copy = writer.toStringRef();
-	}
+	ObjectWriter writer;
+	writer.serialize(objIn);
+	copy = writer.toStringRef();
 	ArenaObjectReader reader(copy.arena(), copy);
 	reader.deserialize(objOut);
 

--- a/fdbclient/MonitorLeader.actor.cpp
+++ b/fdbclient/MonitorLeader.actor.cpp
@@ -265,8 +265,8 @@ TEST_CASE("/flow/FlatBuffers/LeaderInfo") {
 		}
 		leaderInfo.serializedInfo = rndString;
 	}
-	ErrorOr<Optional<LeaderInfo>> objIn{ Optional<LeaderInfo>{leaderInfo} };
-	ErrorOr<Optional<LeaderInfo>> objOut;
+	ErrorOr<EnsureTable<Optional<LeaderInfo>>> objIn(leaderInfo);
+	ErrorOr<EnsureTable<Optional<LeaderInfo>>> objOut;
 	Standalone<StringRef> copy;
 	ObjectWriter writer;
 	writer.serialize(objIn);
@@ -275,8 +275,8 @@ TEST_CASE("/flow/FlatBuffers/LeaderInfo") {
 	reader.deserialize(objOut);
 
 	ASSERT(!objOut.isError());
-	ASSERT(objOut.get().present());
-	LeaderInfo outLeader = objOut.get().get();
+	ASSERT(objOut.get().asUnderlyingType().present());
+	LeaderInfo outLeader = objOut.get().asUnderlyingType().get();
 	ASSERT(outLeader.changeID == leaderInfo.changeID);
 	ASSERT(outLeader.forward == leaderInfo.forward);
 	ASSERT(outLeader.serializedInfo == leaderInfo.serializedInfo);

--- a/fdbclient/MonitorLeader.actor.cpp
+++ b/fdbclient/MonitorLeader.actor.cpp
@@ -515,10 +515,10 @@ ACTOR Future<Void> monitorLeaderInternal( Reference<ClusterConnectionFile> connF
 }
 
 ACTOR Future<Void> asyncDeserializeClusterInterface(Reference<AsyncVar<Value>> serializedInfo,
-                                                    Reference<AsyncVar<Optional<ClusterInterface>>> outKnownLeader) {
+													Reference<AsyncVar<Optional<ClusterInterface>>> outKnownLeader) {
 	state Reference<AsyncVar<Optional<ClusterControllerClientInterface>>> knownLeader(
-	    new AsyncVar<Optional<ClusterControllerClientInterface>>{});
-	state Future<Void> deserializer = asyncDeserialize(serializedInfo, knownLeader);
+		new AsyncVar<Optional<ClusterControllerClientInterface>>{});
+	state Future<Void> deserializer = asyncDeserialize(serializedInfo, knownLeader, g_network->useObjectSerializer());
 	loop {
 		choose {
 			when(wait(deserializer)) { UNSTOPPABLE_ASSERT(false); }

--- a/fdbclient/MonitorLeader.h
+++ b/fdbclient/MonitorLeader.h
@@ -43,24 +43,26 @@ Future<Void> monitorLeaderInternal( Reference<ClusterConnectionFile> const& conn
 template <class LeaderInterface>
 struct LeaderDeserializer {
 	Future<Void> operator()(const Reference<AsyncVar<Value>>& serializedInfo,
-	                        const Reference<AsyncVar<Optional<LeaderInterface>>>& outKnownLeader) {
-		return asyncDeserialize(serializedInfo, outKnownLeader);
+							const Reference<AsyncVar<Optional<LeaderInterface>>>& outKnownLeader) {
+		return asyncDeserialize(serializedInfo, outKnownLeader, g_network->useObjectSerializer());
 	}
 };
 
 Future<Void> asyncDeserializeClusterInterface(const Reference<AsyncVar<Value>>& serializedInfo,
-                                              const Reference<AsyncVar<Optional<ClusterInterface>>>& outKnownLeader);
+											  const Reference<AsyncVar<Optional<ClusterInterface>>>& outKnownLeader);
 
 template <>
 struct LeaderDeserializer<ClusterInterface> {
 	Future<Void> operator()(const Reference<AsyncVar<Value>>& serializedInfo,
-	                        const Reference<AsyncVar<Optional<ClusterInterface>>>& outKnownLeader) {
+							const Reference<AsyncVar<Optional<ClusterInterface>>>& outKnownLeader) {
 		return asyncDeserializeClusterInterface(serializedInfo, outKnownLeader);
 	}
 };
 
 template <class LeaderInterface>
-Future<Void> monitorLeader( Reference<ClusterConnectionFile> const& connFile, Reference<AsyncVar<Optional<LeaderInterface>>> const& outKnownLeader, Reference<AsyncVar<int>> connectedCoordinatorsNum ) {
+Future<Void> monitorLeader(Reference<ClusterConnectionFile> const& connFile,
+						   Reference<AsyncVar<Optional<LeaderInterface>>> const& outKnownLeader,
+						   Reference<AsyncVar<int>> connectedCoordinatorsNum) {
 	LeaderDeserializer<LeaderInterface> deserializer;
 	Reference<AsyncVar<Value>> serializedInfo( new AsyncVar<Value> );
 	Future<Void> m = monitorLeaderInternal( connFile, serializedInfo, connectedCoordinatorsNum );

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -869,6 +869,9 @@ Future<Void> Cluster::onConnected() {
 void setNetworkOption(FDBNetworkOptions::Option option, Optional<StringRef> value) {
 	switch(option) {
 		// SOMEDAY: If the network is already started, should these three throw an error?
+		case FDBNetworkOptions::USE_OBJECT_SERIALIZER:
+			networkOptions.useObjectSerializer = extractIntOption(value) != 0;
+			break;
 		case FDBNetworkOptions::TRACE_ENABLE:
 			networkOptions.traceDirectory = value.present() ? value.get().toString() : "";
 			break;
@@ -1008,7 +1011,7 @@ void setupNetwork(uint64_t transportId, bool useMetrics) {
 	if (!networkOptions.logClientInfo.present())
 		networkOptions.logClientInfo = true;
 
-	g_network = newNet2(false, useMetrics || networkOptions.traceDirectory.present());
+	g_network = newNet2(false, useMetrics || networkOptions.traceDirectory.present(), networkOptions.useObjectSerializer);
 	FlowTransport::createInstance(transportId);
 	Net2FileSystem::newFileSystem();
 

--- a/fdbclient/NativeAPI.actor.h
+++ b/fdbclient/NativeAPI.actor.h
@@ -56,12 +56,13 @@ struct NetworkOptions {
 	Optional<bool> logClientInfo;
 	Standalone<VectorRef<ClientVersionRef>> supportedVersions;
 	bool slowTaskProfilingEnabled;
+	bool useObjectSerializer;
 
 	// The default values, TRACE_DEFAULT_ROLL_SIZE and TRACE_DEFAULT_MAX_LOGS_SIZE are located in Trace.h.
 	NetworkOptions()
 	  : localAddress(""), clusterFile(""), traceDirectory(Optional<std::string>()),
 	    traceRollSize(TRACE_DEFAULT_ROLL_SIZE), traceMaxLogsSize(TRACE_DEFAULT_MAX_LOGS_SIZE), traceLogGroup("default"),
-	    traceFormat("xml"), slowTaskProfilingEnabled(false) {}
+	    traceFormat("xml"), slowTaskProfilingEnabled(false), useObjectSerializer(false) {}
 };
 
 class Database {

--- a/fdbclient/StorageServerInterface.h
+++ b/fdbclient/StorageServerInterface.h
@@ -69,11 +69,16 @@ struct StorageServerInterface {
 	void serialize( Ar& ar ) {
 		// StorageServerInterface is persisted in the database and in the tLog's data structures, so changes here have to be
 		// versioned carefully!
-		serializer(ar, uniqueID, locality, getVersion, getValue, getKey, getKeyValues, getShardState, waitMetrics,
-			splitMetrics, getPhysicalMetrics, waitFailure, getQueuingMetrics, getKeyValueStoreType);
 
-		if( ar.protocolVersion() >= 0x0FDB00A200090001LL )
-			serializer(ar, watchValue);
+		if constexpr (!is_fb_function<Ar>) {
+			serializer(ar, uniqueID, locality, getVersion, getValue, getKey, getKeyValues, getShardState, waitMetrics,
+			           splitMetrics, getPhysicalMetrics, waitFailure, getQueuingMetrics, getKeyValueStoreType);
+			if (ar.protocolVersion() >= 0x0FDB00A200090001LL) serializer(ar, watchValue);
+		} else {
+			serializer(ar, uniqueID, locality, getVersion, getValue, getKey, getKeyValues, getShardState, waitMetrics,
+			           splitMetrics, getPhysicalMetrics, waitFailure, getQueuingMetrics, getKeyValueStoreType,
+			           watchValue);
+		}
 	}
 	bool operator == (StorageServerInterface const& s) const { return uniqueID == s.uniqueID; }
 	bool operator < (StorageServerInterface const& s) const { return uniqueID < s.uniqueID; }

--- a/fdbclient/StorageServerInterface.h
+++ b/fdbclient/StorageServerInterface.h
@@ -30,11 +30,8 @@
 #include "flow/Stats.h"
 
 struct StorageServerInterface {
-	enum { 
-		BUSY_ALLOWED = 0,
-		BUSY_FORCE = 1,
-		BUSY_LOCAL = 2
-	};
+	constexpr static FileIdentifier file_identifier = 15302073;
+	enum { BUSY_ALLOWED = 0, BUSY_FORCE = 1, BUSY_LOCAL = 2 };
 
 	enum { LocationAwareLoadBalance = 1 };
 	enum { AlwaysFresh = 0 };
@@ -114,6 +111,7 @@ struct ServerCacheInfo {
 };
 
 struct GetValueReply : public LoadBalancedReply {
+	constexpr static FileIdentifier file_identifier = 1378929;
 	Optional<Value> value;
 
 	GetValueReply() {}
@@ -126,6 +124,7 @@ struct GetValueReply : public LoadBalancedReply {
 };
 
 struct GetValueRequest : TimedRequest {
+	constexpr static FileIdentifier file_identifier = 8454530;
 	Key key;
 	Version version;
 	Optional<UID> debugID;
@@ -141,6 +140,7 @@ struct GetValueRequest : TimedRequest {
 };
 
 struct WatchValueRequest {
+	constexpr static FileIdentifier file_identifier = 14747733;
 	Key key;
 	Optional<Value> value;
 	Version version;
@@ -157,6 +157,7 @@ struct WatchValueRequest {
 };
 
 struct GetKeyValuesReply : public LoadBalancedReply {
+	constexpr static FileIdentifier file_identifier = 1783066;
 	Arena arena;
 	VectorRef<KeyValueRef> data;
 	Version version; // useful when latestVersion was requested
@@ -169,6 +170,7 @@ struct GetKeyValuesReply : public LoadBalancedReply {
 };
 
 struct GetKeyValuesRequest : TimedRequest {
+	constexpr static FileIdentifier file_identifier = 6795746;
 	Arena arena;
 	KeySelectorRef begin, end;
 	Version version;		// or latestVersion
@@ -185,6 +187,7 @@ struct GetKeyValuesRequest : TimedRequest {
 };
 
 struct GetKeyReply : public LoadBalancedReply {
+	constexpr static FileIdentifier file_identifier = 11226513;
 	KeySelector sel;
 
 	GetKeyReply() {}
@@ -197,6 +200,7 @@ struct GetKeyReply : public LoadBalancedReply {
 };
 
 struct GetKeyRequest : TimedRequest {
+	constexpr static FileIdentifier file_identifier = 10457870;
 	Arena arena;
 	KeySelectorRef sel;
 	Version version;		// or latestVersion
@@ -212,6 +216,7 @@ struct GetKeyRequest : TimedRequest {
 };
 
 struct GetShardStateRequest {
+	constexpr static FileIdentifier file_identifier = 15860168;
 	enum waitMode {
 		NO_WAIT = 0,
 		FETCHING = 1,
@@ -231,6 +236,7 @@ struct GetShardStateRequest {
 };
 
 struct StorageMetrics {
+	constexpr static FileIdentifier file_identifier = 13622226;
 	int64_t bytes;				// total storage
 	int64_t bytesPerKSecond;	// network bandwidth (average over 10s)
 	int64_t iosPerKSecond;
@@ -283,6 +289,7 @@ struct StorageMetrics {
 struct WaitMetricsRequest {
 	// Waits for any of the given minimum or maximum metrics to be exceeded, and then returns the current values
 	// Send a reversed range for min, max to receive an immediate report
+	constexpr static FileIdentifier file_identifier = 1795961;
 	Arena arena;
 	KeyRangeRef keys;
 	StorageMetrics min, max;
@@ -301,6 +308,7 @@ struct WaitMetricsRequest {
 };
 
 struct SplitMetricsReply {
+	constexpr static FileIdentifier file_identifier = 11530792;
 	Standalone<VectorRef<KeyRef>> splits;
 	StorageMetrics used;
 
@@ -311,6 +319,7 @@ struct SplitMetricsReply {
 };
 
 struct SplitMetricsRequest {
+	constexpr static FileIdentifier file_identifier = 10463876;
 	Arena arena;
 	KeyRangeRef keys;
 	StorageMetrics limits;
@@ -329,6 +338,7 @@ struct SplitMetricsRequest {
 };
 
 struct GetPhysicalMetricsReply {
+	constexpr static FileIdentifier file_identifier = 15491478;
 	StorageMetrics load;
 	StorageMetrics free;
 	StorageMetrics capacity;
@@ -340,6 +350,7 @@ struct GetPhysicalMetricsReply {
 };
 
 struct GetPhysicalMetricsRequest {
+	constexpr static FileIdentifier file_identifier = 13290999;
 	ReplyPromise<GetPhysicalMetricsReply> reply;
 
 	template <class Ar>
@@ -350,6 +361,7 @@ struct GetPhysicalMetricsRequest {
 
 struct StorageQueuingMetricsRequest {
 	// SOMEDAY: Send threshold value to avoid polling faster than the information changes?
+	constexpr static FileIdentifier file_identifier = 3978640;
 	ReplyPromise<struct StorageQueuingMetricsReply> reply;
 
 	template <class Ar>
@@ -359,6 +371,7 @@ struct StorageQueuingMetricsRequest {
 };
 
 struct StorageQueuingMetricsReply {
+	constexpr static FileIdentifier file_identifier = 7633366;
 	double localTime;
 	int64_t instanceID;  // changes if bytesDurable and bytesInput reset
 	int64_t bytesDurable, bytesInput;

--- a/fdbclient/StorageServerInterface.h
+++ b/fdbclient/StorageServerInterface.h
@@ -359,17 +359,6 @@ struct GetPhysicalMetricsRequest {
 	}
 };
 
-struct StorageQueuingMetricsRequest {
-	// SOMEDAY: Send threshold value to avoid polling faster than the information changes?
-	constexpr static FileIdentifier file_identifier = 3978640;
-	ReplyPromise<struct StorageQueuingMetricsReply> reply;
-
-	template <class Ar>
-	void serialize(Ar& ar) {
-		serializer(ar, reply);
-	}
-};
-
 struct StorageQueuingMetricsReply {
 	constexpr static FileIdentifier file_identifier = 7633366;
 	double localTime;
@@ -384,6 +373,17 @@ struct StorageQueuingMetricsReply {
 	template <class Ar>
 	void serialize(Ar& ar) {
 		serializer(ar, localTime, instanceID, bytesDurable, bytesInput, version, storageBytes, durableVersion, cpuUsage, diskUsage);
+	}
+};
+
+struct StorageQueuingMetricsRequest {
+	// SOMEDAY: Send threshold value to avoid polling faster than the information changes?
+	constexpr static FileIdentifier file_identifier = 3978640;
+	ReplyPromise<struct StorageQueuingMetricsReply> reply;
+
+	template <class Ar>
+	void serialize(Ar& ar) {
+		serializer(ar, reply);
 	}
 };
 

--- a/fdbclient/vexillographer/fdb.options
+++ b/fdbclient/vexillographer/fdb.options
@@ -33,6 +33,9 @@ description is not currently required but encouraged.
     <Option name="local_address"  code="10" 
             paramType="String" paramDescription="IP:PORT" 
             description="Deprecated"/>
+    <Option name="use_object_serializer" code="11"
+            paramType="Int" paramDescription="0 is false, every other value is true"
+            description="enable the object serializer for network communication"/>
     <Option name="cluster_file" code="20"
             paramType="String" paramDescription="path to cluster file"
             description="Deprecated"/>

--- a/fdbmonitor/SimpleIni.h
+++ b/fdbmonitor/SimpleIni.h
@@ -324,7 +324,7 @@ public:
 #endif
 
         /** Strict less ordering by name of key only */
-        struct KeyOrder : std::binary_function<Entry, Entry, bool> {
+        struct KeyOrder {
             bool operator()(const Entry & lhs, const Entry & rhs) const {
                 const static SI_STRLESS isLess = SI_STRLESS();
                 return isLess(lhs.pItem, rhs.pItem);
@@ -332,7 +332,7 @@ public:
         };
 
         /** Strict less ordering by order, and then name of key */
-        struct LoadOrder : std::binary_function<Entry, Entry, bool> {
+        struct LoadOrder {
             bool operator()(const Entry & lhs, const Entry & rhs) const {
                 if (lhs.nOrder != rhs.nOrder) {
                     return lhs.nOrder < rhs.nOrder;

--- a/fdbrpc/FlowTests.actor.cpp
+++ b/fdbrpc/FlowTests.actor.cpp
@@ -200,6 +200,7 @@ struct YieldMockNetwork : INetwork, ReferenceCounted<YieldMockNetwork> {
 	virtual void run() { return baseNetwork->run(); }
 	virtual void getDiskBytes(std::string const& directory, int64_t& free, int64_t& total)  { return baseNetwork->getDiskBytes(directory,free,total); }
 	virtual bool isAddressOnThisHost(NetworkAddress const& addr) { return baseNetwork->isAddressOnThisHost(addr); }
+	virtual bool useObjectSerializer() const { return baseNetwork->useObjectSerializer(); }
 };
 
 struct NonserializableThing {};

--- a/fdbrpc/FlowTransport.actor.cpp
+++ b/fdbrpc/FlowTransport.actor.cpp
@@ -127,6 +127,12 @@ struct EndpointNotFoundReceiver : NetworkMessageReceiver {
 		Endpoint e; reader >> e;
 		IFailureMonitor::failureMonitor().endpointNotFound(e);
 	}
+
+	virtual void receive(ArenaObjectReader& reader) {
+		Endpoint e;
+		reader.deserialize(e);
+		IFailureMonitor::failureMonitor().endpointNotFound(e);
+	}
 };
 
 struct PingReceiver : NetworkMessageReceiver {
@@ -137,6 +143,11 @@ struct PingReceiver : NetworkMessageReceiver {
 	}
 	virtual void receive( ArenaReader& reader ) {
 		ReplyPromise<Void> reply; reader >> reply;
+		reply.send(Void());
+	}
+	virtual void receive(ArenaObjectReader& reader) {
+		ReplyPromise<Void> reply;
+		reader.deserialize(reply);
 		reply.send(Void());
 	}
 };

--- a/fdbrpc/FlowTransport.actor.cpp
+++ b/fdbrpc/FlowTransport.actor.cpp
@@ -1022,7 +1022,7 @@ static PacketID sendPacket( TransportData* self, ISerializeSource const& what, c
 		Standalone<StringRef> copy;
 		if (g_network->useObjectSerializer()) {
 			ObjectWriter wr;
-			what.serializeBinaryWriter(wr);
+			what.serializeObjectWriter(wr);
 			copy = wr.toStringRef();
 		} else {
 			BinaryWriter wr( AssumeVersion(currentProtocolVersion) );

--- a/fdbrpc/FlowTransport.actor.cpp
+++ b/fdbrpc/FlowTransport.actor.cpp
@@ -1026,10 +1026,6 @@ static PacketID sendPacket( TransportData* self, ISerializeSource const& what, c
 			copy = wr.toStringRef();
 		} else {
 			BinaryWriter wr( AssumeVersion(currentProtocolVersion) );
-			// we don't need to send using an object writer here. This is a loopback delivery
-			// and therefore it is guaranteed that both versions will have exactly the
-			// same structures - so the backwards compatability capabilities are never needed
-			// here.
 			what.serializeBinaryWriter(wr);
 			copy = wr.toValue();
 		}

--- a/fdbrpc/FlowTransport.actor.cpp
+++ b/fdbrpc/FlowTransport.actor.cpp
@@ -553,7 +553,7 @@ ACTOR static void deliver(TransportData* self, Endpoint destination, ArenaReader
 	auto receiver = self->endpoints.get(destination.token);
 	if (receiver) {
 		try {
-			g_currentDeliveryPeerAddress = destination.address;
+			g_currentDeliveryPeerAddress = destination.addresses;
 			if (useFlatbuffers) {
 				ArenaObjectReader objReader(reader.arena(), reader.arenaReadAll());
 				receiver->receive(objReader);

--- a/fdbrpc/FlowTransport.actor.cpp
+++ b/fdbrpc/FlowTransport.actor.cpp
@@ -558,9 +558,9 @@ ACTOR static void deliver(TransportData* self, Endpoint destination, ArenaReader
 				ArenaObjectReader objReader(reader.arena(), reader.arenaReadAll());
 				receiver->receive(objReader);
 			} else {
-                receiver->receive( reader );
-            }
-			g_currentDeliveryPeerAddress = {NetworkAddress()};
+				receiver->receive(reader);
+			}
+			g_currentDeliveryPeerAddress = { NetworkAddress() };
 		} catch (Error& e) {
 			g_currentDeliveryPeerAddress = {NetworkAddress()};
 			TraceEvent(SevError, "ReceiverError").error(e).detail("Token", destination.token.toString()).detail("Peer", destination.getPrimaryAddress());

--- a/fdbrpc/FlowTransport.actor.cpp
+++ b/fdbrpc/FlowTransport.actor.cpp
@@ -25,6 +25,7 @@
 #include "flow/Net2Packet.h"
 #include "flow/ActorCollection.h"
 #include "flow/TDMetric.actor.h"
+#include "flow/ObjectSerializer.h"
 #include "fdbrpc/FailureMonitor.h"
 #include "fdbrpc/crc32c.h"
 #include "fdbrpc/simulator.h"
@@ -371,7 +372,6 @@ struct Peer : NonCopyable {
 
 			// Send an (ignored) packet to make sure that, if our outgoing connection died before the peer made this connection attempt,
 			// we eventually find out that our connection is dead, close it, and then respond to the next connection reattempt from peer.
-			//sendPacket( self, SerializeSourceRaw(StringRef()), Endpoint(peer->address(), TOKEN_IGNORE_PACKET), false );
 		}
 	}
 
@@ -529,7 +529,8 @@ TransportData::~TransportData() {
 	}
 }
 
-ACTOR static void deliver( TransportData* self, Endpoint destination, ArenaReader reader, bool inReadSocket ) {
+ACTOR static void deliver(TransportData* self, Endpoint destination, ArenaReader reader, bool inReadSocket,
+                          bool useFlatbuffers) {
 	int priority = self->endpoints.getPriority(destination.token);
 	if (priority < TaskReadSocket || !inReadSocket) {
 		wait( delay(0, priority) );
@@ -540,8 +541,13 @@ ACTOR static void deliver( TransportData* self, Endpoint destination, ArenaReade
 	auto receiver = self->endpoints.get(destination.token);
 	if (receiver) {
 		try {
-			g_currentDeliveryPeerAddress = destination.addresses;
-			receiver->receive( reader );
+			g_currentDeliveryPeerAddress = destination.address;
+			if (useFlatbuffers) {
+				ArenaObjectReader objReader(reader.arena(), reader.arenaReadAll());
+				receiver->receive(objReader);
+			} else {
+                receiver->receive( reader );
+            }
 			g_currentDeliveryPeerAddress = {NetworkAddress()};
 		} catch (Error& e) {
 			g_currentDeliveryPeerAddress = {NetworkAddress()};
@@ -561,7 +567,8 @@ ACTOR static void deliver( TransportData* self, Endpoint destination, ArenaReade
 		g_network->setCurrentTask( TaskReadSocket );
 }
 
-static void scanPackets( TransportData* transport, uint8_t*& unprocessed_begin, uint8_t* e, Arena& arena, NetworkAddress const& peerAddress, uint64_t peerProtocolVersion ) {
+static void scanPackets(TransportData* transport, uint8_t*& unprocessed_begin, uint8_t* e, Arena& arena,
+                        NetworkAddress const& peerAddress, uint64_t peerProtocolVersion) {
 	// Find each complete packet in the given byte range and queue a ready task to deliver it.
 	// Remove the complete packets from the range by increasing unprocessed_begin.
 	// There won't be more than 64K of data plus one packet, so this shouldn't take a long time.
@@ -633,8 +640,9 @@ static void scanPackets( TransportData* transport, uint8_t*& unprocessed_begin, 
 #if VALGRIND
 		VALGRIND_CHECK_MEM_IS_DEFINED(p, packetLen);
 #endif
-		ArenaReader reader( arena, StringRef(p, packetLen), AssumeVersion(peerProtocolVersion) );
-		UID token; reader >> token;
+		ArenaReader reader(arena, StringRef(p, packetLen), AssumeVersion(removeFlags(peerProtocolVersion)));
+		UID token;
+		reader >> token;
 
 		++transport->countPacketsReceived;
 
@@ -649,7 +657,7 @@ static void scanPackets( TransportData* transport, uint8_t*& unprocessed_begin, 
 				transport->warnAlwaysForLargePacket = false;
 		}
 
-		deliver( transport, Endpoint( {peerAddress}, token ), std::move(reader), true );
+		deliver(transport, Endpoint({ peerAddress }, token), std::move(reader), true, hasObjectSerializerFlag(peerProtocolVersion));
 
 		unprocessed_begin = p = p + packetLen;
 	}
@@ -748,7 +756,8 @@ ACTOR static Future<Void> connectionReader(
 							TraceEvent("ConnectionEstablished", conn->getDebugID())
 								.suppressFor(1.0)
 								.detail("Peer", conn->getPeerAddress())
-								.detail("ConnectionId", connectionId);
+								.detail("ConnectionId", connectionId)
+								.detail("UseObjectSerializer", false);
 						}
 
 						if(connectionId > 1) {
@@ -994,13 +1003,18 @@ static PacketID sendPacket( TransportData* self, ISerializeSource const& what, c
 		// SOMEDAY: Would it be better to avoid (de)serialization by doing this check in flow?
 
 		BinaryWriter wr( AssumeVersion(currentProtocolVersion) );
+		// we don't need to send using an object writer here. This is a loopback delivery
+		// and therefore it is guaranteed that both versions will have exactly the
+		// same structures - so the backwards compatability capabilities are never needed
+		// here.
 		what.serializeBinaryWriter(wr);
 		Standalone<StringRef> copy = wr.toValue();
 #if VALGRIND
 		VALGRIND_CHECK_MEM_IS_DEFINED(copy.begin(), copy.size());
 #endif
 
-		deliver( self, destination, ArenaReader(copy.arena(), copy, AssumeVersion(currentProtocolVersion)), false );
+		deliver(self, destination, ArenaReader(copy.arena(), copy, AssumeVersion(currentProtocolVersion)), false,
+		        false);
 
 		return (PacketID)NULL;
 	} else {
@@ -1039,7 +1053,7 @@ static PacketID sendPacket( TransportData* self, ISerializeSource const& what, c
 
 		wr.writeAhead(packetInfoSize , &packetInfoBuffer);
 		wr << destination.token;
-		what.serializePacketWriter(wr);
+		what.serializePacketWriter(wr, g_network->useObjectSerializer());
 		pb = wr.finish();
 		len = wr.size() - packetInfoSize;
 

--- a/fdbrpc/FlowTransport.actor.cpp
+++ b/fdbrpc/FlowTransport.actor.cpp
@@ -1020,13 +1020,13 @@ static PacketID sendPacket( TransportData* self, ISerializeSource const& what, c
 			what.serializeBinaryWriter(wr);
 			copy = wr.toStringRef();
 		} else {
-		BinaryWriter wr( AssumeVersion(currentProtocolVersion) );
-		// we don't need to send using an object writer here. This is a loopback delivery
-		// and therefore it is guaranteed that both versions will have exactly the
-		// same structures - so the backwards compatability capabilities are never needed
-		// here.
-		what.serializeBinaryWriter(wr);
-			copy = wr.toStringRef();
+			BinaryWriter wr( AssumeVersion(currentProtocolVersion) );
+			// we don't need to send using an object writer here. This is a loopback delivery
+			// and therefore it is guaranteed that both versions will have exactly the
+			// same structures - so the backwards compatability capabilities are never needed
+			// here.
+			what.serializeBinaryWriter(wr);
+			copy = wr.toValue();
 		}
 #if VALGRIND
 		VALGRIND_CHECK_MEM_IS_DEFINED(copy.begin(), copy.size());

--- a/fdbrpc/FlowTransport.h
+++ b/fdbrpc/FlowTransport.h
@@ -24,12 +24,14 @@
 
 #include <algorithm>
 #include "flow/network.h"
+#include "flow/FileIdentifier.h"
 
 #pragma pack(push, 4)
 class Endpoint {
 public:
 	// Endpoint represents a particular service (e.g. a serialized Promise<T> or PromiseStream<T>)
 	// An endpoint is either "local" (used for receiving data) or "remote" (used for sending data)
+	constexpr static FileIdentifier file_identifier = 10618805;
 	typedef UID Token;
 	NetworkAddressList addresses;
 	Token token;

--- a/fdbrpc/FlowTransport.h
+++ b/fdbrpc/FlowTransport.h
@@ -85,9 +85,13 @@ public:
 };
 #pragma pack(pop)
 
+
+
+class ArenaObjectReader;
 class NetworkMessageReceiver {
 public:
 	virtual void receive( ArenaReader& ) = 0;
+	virtual void receive(ArenaObjectReader&) = 0;
 	virtual bool isStream() const { return false; }
 };
 

--- a/fdbrpc/FlowTransport.h
+++ b/fdbrpc/FlowTransport.h
@@ -86,6 +86,26 @@ public:
 #pragma pack(pop)
 
 
+template <>
+struct scalar_traits<Endpoint> : std::true_type {
+	using networkAddress = scalar_traits<NetworkAddress>;
+	using token = scalar_traits<UID>;
+
+	static constexpr size_t size = networkAddress::size + token::size;
+
+	static void save(uint8_t* out, const Endpoint& endpoint) {
+		networkAddress::save(out, endpoint.address);
+		out += networkAddress::size;
+		token::save(out, endpoint.token);
+	}
+
+	template <class C>
+	static void load(const uint8_t* in, Endpoint& endpoint, C& c) {
+		networkAddress::load(in, endpoint.address, c);
+		in += networkAddress::size;
+		token::load(in, endpoint.token, c);
+	}
+};
 
 class ArenaObjectReader;
 class NetworkMessageReceiver {
@@ -162,6 +182,8 @@ public:
 	static NetworkAddressList getGlobalLocalAddresses() { return transport().getLocalAddresses(); }
 
 	Endpoint loadedEndpoint(const UID& token);
+
+	void loadedEndpoint(Endpoint&);
 
 private:
 	class TransportData* self;

--- a/fdbrpc/FlowTransport.h
+++ b/fdbrpc/FlowTransport.h
@@ -81,8 +81,8 @@ public:
 			}
 		} else {
 			if (ar.isDeserializing && ar.protocolVersion() < 0x0FDB00B061020001LL) {
-				addresses.resize(1);
-				serializer(ar, addresses[0], token);
+				addresses.secondaryAddress = Optional<NetworkAddress>();
+				serializer(ar, addresses.address, token);
 			} else {
 				serializer(ar, addresses, token);
 				if (ar.isDeserializing) {
@@ -169,8 +169,6 @@ public:
 	static NetworkAddressList getGlobalLocalAddresses() { return transport().getLocalAddresses(); }
 
 	Endpoint loadedEndpoint(const UID& token);
-
-	void loadedEndpoint(Endpoint&);
 
 private:
 	class TransportData* self;

--- a/fdbrpc/Locality.h
+++ b/fdbrpc/Locality.h
@@ -25,6 +25,7 @@
 #include "flow/flow.h"
 
 struct ProcessClass {
+	constexpr static FileIdentifier file_identifier = 6697257;
 	// This enum is stored in restartInfo.ini for upgrade tests, so be very careful about changing the existing items!
 	enum ClassType { UnsetClass, StorageClass, TransactionClass, ResolutionClass, TesterClass, ProxyClass, MasterClass, StatelessClass, LogClass, ClusterControllerClass, LogRouterClass, DataDistributorClass, CoordinatorClass, RatekeeperClass, InvalidClass = -1 };
 	enum Fitness { BestFit, GoodFit, UnsetFit, OkayFit, WorstFit, ExcludeFit, NeverAssign }; //cannot be larger than 7 because of leader election mask

--- a/fdbrpc/Locality.h
+++ b/fdbrpc/Locality.h
@@ -193,39 +193,40 @@ public:
 	void serialize(Ar& ar) {
 		// Locality is persisted in the database inside StorageServerInterface, so changes here have to be
 		// versioned carefully!
-		if (ar.protocolVersion() >= 0x0FDB00A446020001LL) {
-			Standalone<StringRef> key;
-			Optional<Standalone<StringRef>> value;
-			uint64_t mapSize = (uint64_t)_data.size();
-			serializer(ar, mapSize);
-			if (ar.isDeserializing) {
-				for (size_t i = 0; i < mapSize; i++) {
-					serializer(ar, key, value);
-					_data[key] = value;
+		if constexpr (is_fb_function<Ar>) {
+			serializer(ar, _data);
+		} else {
+			if (ar.protocolVersion() >= 0x0FDB00A446020001LL) {
+				Standalone<StringRef> key;
+				Optional<Standalone<StringRef>> value;
+				uint64_t mapSize = (uint64_t)_data.size();
+				serializer(ar, mapSize);
+				if (ar.isDeserializing) {
+					for (size_t i = 0; i < mapSize; i++) {
+						serializer(ar, key, value);
+						_data[key] = value;
+					}
+				} else {
+					for (auto it = _data.begin(); it != _data.end(); it++) {
+						key = it->first;
+						value = it->second;
+						serializer(ar, key, value);
+					}
 				}
-			}
-			else {
-				for (auto it = _data.begin(); it != _data.end(); it++) {
-					key = it->first;
-					value = it->second;
-					serializer(ar, key, value);
-				}
-			}
-		}
-		else {
-			ASSERT(ar.isDeserializing);
-			UID	zoneId, dcId, processId;
-			serializer(ar, zoneId, dcId);
-			set(keyZoneId, Standalone<StringRef>(zoneId.toString()));
-			set(keyDcId, Standalone<StringRef>(dcId.toString()));
+			} else {
+				ASSERT(ar.isDeserializing);
+				UID zoneId, dcId, processId;
+				serializer(ar, zoneId, dcId);
+				set(keyZoneId, Standalone<StringRef>(zoneId.toString()));
+				set(keyDcId, Standalone<StringRef>(dcId.toString()));
 
-			if (ar.protocolVersion() >= 0x0FDB00A340000001LL) {
-				serializer(ar, processId);
-				set(keyProcessId, Standalone<StringRef>(processId.toString()));
-			}
-			else {
-				int _machineClass = ProcessClass::UnsetClass;
-				serializer(ar, _machineClass);
+				if (ar.protocolVersion() >= 0x0FDB00A340000001LL) {
+					serializer(ar, processId);
+					set(keyProcessId, Standalone<StringRef>(processId.toString()));
+				} else {
+					int _machineClass = ProcessClass::UnsetClass;
+					serializer(ar, _machineClass);
+				}
 			}
 		}
 	}

--- a/fdbrpc/PerfMetric.h
+++ b/fdbrpc/PerfMetric.h
@@ -29,6 +29,7 @@
 using std::vector;
 
 struct PerfMetric {
+	constexpr static FileIdentifier file_identifier = 5980618;
 	PerfMetric() : m_name(""), m_value(0), m_averaged(false), m_format_code( "%.3g" ) {}
 	PerfMetric( std::string name, double value, bool averaged ) : m_name(name), m_value(value), m_averaged(averaged), m_format_code( "%.3g" ) {}
 	PerfMetric( std::string name, double value, bool averaged, std::string format_code ) : m_name(name), m_value(value), m_averaged(averaged), m_format_code(format_code) {}

--- a/fdbrpc/ReplicationPolicy.cpp
+++ b/fdbrpc/ReplicationPolicy.cpp
@@ -142,6 +142,8 @@ PolicyAcross::PolicyAcross(int count, std::string const& attribKey, Reference<IR
 	return;
 }
 
+PolicyAcross::PolicyAcross() : _policy(new PolicyOne()) {}
+
 PolicyAcross::~PolicyAcross()
 {
 	return;

--- a/fdbrpc/ReplicationPolicy.h
+++ b/fdbrpc/ReplicationPolicy.h
@@ -58,6 +58,7 @@ struct IReplicationPolicy : public ReferenceCounted<IReplicationPolicy> {
 			serializeReplicationPolicy(ar, refThis);
 			refThis->delref_no_destroy();
 		}
+		virtual void deserializationDone() = 0;
 
 		// Utility functions
 		bool selectReplicas(
@@ -100,6 +101,7 @@ inline void save( Archive& ar, const Reference<IReplicationPolicy>& value ) {
 
 struct PolicyOne : IReplicationPolicy, public ReferenceCounted<PolicyOne> {
 	PolicyOne() {};
+	explicit PolicyOne(const PolicyOne& o) {}
 	virtual ~PolicyOne() {};
 	virtual std::string name() const { return "One"; }
 	virtual std::string info() const { return "1"; }
@@ -115,23 +117,22 @@ struct PolicyOne : IReplicationPolicy, public ReferenceCounted<PolicyOne> {
 	template <class Ar>
 	void serialize(Ar& ar) {
 	}
+	virtual void deserializationDone() {}
 	virtual void attributeKeys(std::set<std::string>* set) const override { return; }
 };
 
 struct PolicyAcross : IReplicationPolicy, public ReferenceCounted<PolicyAcross> {
-	PolicyAcross(int count, std::string const& attribKey, Reference<IReplicationPolicy> const policy);
+	friend struct serializable_traits<PolicyAcross*>;
+	PolicyAcross(int count, std::string const& attribKey, IRepPolicyRef const policy);
+	explicit PolicyAcross();
+	explicit PolicyAcross(const PolicyAcross& other) : PolicyAcross(other._count, other._attribKey, other._policy) {}
 	virtual ~PolicyAcross();
 	virtual std::string name() const { return "Across"; }
-	virtual std::string info() const
-	{ return format("%s^%d x ", _attribKey.c_str(), _count) + _policy->info(); }
+	virtual std::string info() const { return format("%s^%d x ", _attribKey.c_str(), _count) + _policy->info(); }
 	virtual int maxResults() const { return _count * _policy->maxResults(); }
 	virtual int depth() const  { return 1 + _policy->depth(); }
-	virtual bool validate(
-		std::vector<LocalityEntry>	const&	solutionSet,
-		Reference<LocalitySet> const&				fromServers ) const;
-	virtual bool selectReplicas(
-		Reference<LocalitySet>	&						fromServers,
-		std::vector<LocalityEntry> const&		alsoServers,
+	virtual bool validate(std::vector<LocalityEntry> const& solutionSet, LocalitySetRef const& fromServers) const;
+	virtual bool selectReplicas(LocalitySetRef& fromServers, std::vector<LocalityEntry> const& alsoServers,
 		std::vector<LocalityEntry>	&				results );
 
 	template <class Ar>
@@ -140,31 +141,39 @@ struct PolicyAcross : IReplicationPolicy, public ReferenceCounted<PolicyAcross> 
 		serializeReplicationPolicy(ar, _policy);
 	}
 
-	static bool compareAddedResults(const std::pair<int, int>& rhs, const std::pair<int, int>& lhs)
-	{ return (rhs.first < lhs.first) || (!(lhs.first < rhs.first) && (rhs.second < lhs.second)); }
+	virtual void deserializationDone() {}
 
-	virtual void attributeKeys(std::set<std::string> *set) const override
-	{ set->insert(_attribKey); _policy->attributeKeys(set); }
+	static bool compareAddedResults(const std::pair<int, int>& rhs, const std::pair<int, int>& lhs) {
+		return (rhs.first < lhs.first) || (!(lhs.first < rhs.first) && (rhs.second < lhs.second));
+	}
+
+	virtual void attributeKeys(std::set<std::string>* set) const override {
+		set->insert(_attribKey);
+		_policy->attributeKeys(set);
+	}
 
 protected:
 	int																_count;
 	std::string												_attribKey;
-	Reference<IReplicationPolicy>								_policy;
+	IRepPolicyRef _policy;
 
 	// Cache temporary members
 	std::vector<AttribValue>					_usedValues;
 	std::vector<LocalityEntry>				_newResults;
-	Reference<LocalitySet>										_selected;
+	LocalitySetRef _selected;
 	VectorRef<std::pair<int,int>>			_addedResults;
 	Arena															_arena;
 };
 
 struct PolicyAnd : IReplicationPolicy, public ReferenceCounted<PolicyAnd> {
-	PolicyAnd(std::vector<Reference<IReplicationPolicy>> policies): _policies(policies), _sortedPolicies(policies)
+	friend struct serializable_traits<PolicyAnd*>;
+	PolicyAnd(std::vector<IRepPolicyRef> policies): _policies(policies), _sortedPolicies(policies)
 	{
 		// Sort the policy array
 		std::sort(_sortedPolicies.begin(), _sortedPolicies.end(), PolicyAnd::comparePolicy);
 	}
+	explicit PolicyAnd(const PolicyAnd& other) : _policies(other._policies), _sortedPolicies(other._sortedPolicies) {}
+	explicit PolicyAnd() {}
 	virtual ~PolicyAnd() {}
 	virtual std::string name() const { return "And"; }
 	virtual std::string info() const {
@@ -218,6 +227,11 @@ struct PolicyAnd : IReplicationPolicy, public ReferenceCounted<PolicyAnd> {
 		}
 	}
 
+	virtual void deserializationDone() {
+		_sortedPolicies = _policies;
+		std::sort(_sortedPolicies.begin(), _sortedPolicies.end(), PolicyAnd::comparePolicy);
+	}
+
 	virtual void attributeKeys(std::set<std::string> *set) const override
 	{ for (const Reference<IReplicationPolicy>& r : _policies) { r->attributeKeys(set); } }
 
@@ -227,6 +241,138 @@ protected:
 };
 
 extern int testReplication();
+
+#define POLICY_CONSTRUCTION_WRAPPER(t)                                                                                 \
+	template <>                                                                                                        \
+	struct object_construction<t*> {                                                                                   \
+		using type = t*;                                                                                               \
+		type obj;                                                                                                      \
+                                                                                                                       \
+		object_construction() : obj(new t()) {}                                                                        \
+		object_construction(object_construction&& other) : obj(other.obj) { other.obj = nullptr; }                     \
+		object_construction(const object_construction& other) : obj() {}                                               \
+                                                                                                                       \
+		object_construction& operator=(object_construction&& other) {                                                  \
+			if (obj != nullptr) {                                                                                      \
+				delete obj;                                                                                            \
+			}                                                                                                          \
+			obj = other.obj;                                                                                           \
+			other.obj = nullptr;                                                                                       \
+			return *this;                                                                                              \
+		}                                                                                                              \
+                                                                                                                       \
+		object_construction& operator=(const object_construction& other) {                                             \
+			if (obj != nullptr) {                                                                                      \
+				delete obj;                                                                                            \
+			}                                                                                                          \
+			obj = new t(*other.obj);                                                                                   \
+			return *this;                                                                                              \
+		}                                                                                                              \
+                                                                                                                       \
+		type& get() { return obj; }                                                                                    \
+		const type& get() const { return obj; }                                                                        \
+		type move() {                                                                                                  \
+			auto res = obj;                                                                                            \
+			obj = nullptr;                                                                                             \
+			return res;                                                                                                \
+		}                                                                                                              \
+	};
+
+template <>
+struct object_construction<IRepPolicyRef> {
+	using type = IRepPolicyRef;
+	type _impl;
+
+	object_construction() : _impl(new PolicyOne()){};
+
+	type& get() { return _impl; }
+	const type& get() const { return _impl; }
+
+	type move() { return std::move(_impl); }
+};
+
+POLICY_CONSTRUCTION_WRAPPER(PolicyOne);
+POLICY_CONSTRUCTION_WRAPPER(PolicyAcross);
+POLICY_CONSTRUCTION_WRAPPER(PolicyAnd);
+
+template <>
+struct FileIdentifierFor<IRepPolicyRef> {
+	static constexpr FileIdentifier value = 14695621;
+};
+
+template <>
+struct serializable_traits<PolicyOne*> : std::true_type {
+	template <class Archiver>
+	static void serialize(Archiver& ar, PolicyOne*& p) {}
+};
+
+template <>
+struct serializable_traits<PolicyAcross*> : std::true_type {
+	template <class Archiver>
+	static void serialize(Archiver& ar, PolicyAcross*& p) {
+		::serializer(ar, p->_count, p->_attribKey, p->_policy);
+	}
+};
+
+template <>
+struct serializable_traits<PolicyAnd*> : std::true_type {
+	template <class Archiver>
+	static void serialize(Archiver& ar, PolicyAnd*& p) {
+		::serializer(ar, p->_policies);
+	}
+};
+
+template <>
+struct serializable_traits<IRepPolicyRef> : std::true_type {
+	template <class Archiver>
+	static void serialize(Archiver& ar, IRepPolicyRef& policy) {
+		::serializer(ar, policy.changePtrUnsafe());
+	}
+};
+
+template <>
+struct union_like_traits<IReplicationPolicy*> : std::true_type {
+	using Member = IReplicationPolicy*;
+	using alternatives = pack<PolicyOne*, PolicyAcross*, PolicyAnd*>;
+
+	static uint8_t index(const Member& policy) {
+		if (policy->name() == "One") {
+			return 0;
+		} else if (policy->name() == "And") {
+			return 2;
+		} else {
+			return 1;
+		}
+	}
+
+	static bool empty(const Member& policy) { return policy == nullptr; }
+
+	template <int i>
+	static const index_t<i, alternatives>& get(IReplicationPolicy* const& member) {
+		if constexpr (i == 0) {
+			return reinterpret_cast<PolicyOne* const&>(member);
+		} else if constexpr (i == 1) {
+			return reinterpret_cast<PolicyAcross* const&>(member);
+		} else {
+			return reinterpret_cast<PolicyAnd* const&>(member);
+		}
+	}
+
+	template <int i, class Alternative>
+	static const void assign(Member& policy, const Alternative& impl) {
+		if (policy != nullptr) {
+			policy->delref();
+		}
+		policy = impl;
+	}
+
+	template <class Context>
+	static void done(Member& policy, Context&) {
+		if (policy != nullptr) {
+			policy->deserializationDone();
+		}
+	}
+};
 
 
 template <class Ar>

--- a/fdbrpc/ReplicationPolicy.h
+++ b/fdbrpc/ReplicationPolicy.h
@@ -392,7 +392,7 @@ void serializeReplicationPolicy(Ar& ar, Reference<IReplicationPolicy>& policy) {
 			policy = Reference<IReplicationPolicy>(pointer);
 		}
 		else if(name == LiteralStringRef("And")) {
-			PolicyAnd* pointer = new PolicyAnd({});
+			PolicyAnd* pointer = new PolicyAnd{};
 			pointer->serialize(ar);
 			policy = Reference<IReplicationPolicy>(pointer);
 		}

--- a/fdbrpc/ReplicationPolicy.h
+++ b/fdbrpc/ReplicationPolicy.h
@@ -255,7 +255,7 @@ void serializeReplicationPolicy(Ar& ar, Reference<IReplicationPolicy>& policy) {
 		} else if (name == LiteralStringRef("None")) {
 			policy = Reference<IReplicationPolicy>();
 		} else {
-			TraceEvent(SevError, "SerializingInvalidPolicyType").detailext("PolicyName", name);
+			TraceEvent(SevError, "SerializingInvalidPolicyType").detail("PolicyName", name);
 		}
 	} else {
 		std::string name = policy ? policy->name() : "None";

--- a/fdbrpc/ReplicationPolicy.h
+++ b/fdbrpc/ReplicationPolicy.h
@@ -29,111 +29,99 @@ template <class Ar>
 void serializeReplicationPolicy(Ar& ar, Reference<IReplicationPolicy>& policy);
 extern void testReplicationPolicy(int nTests);
 
-
 struct IReplicationPolicy : public ReferenceCounted<IReplicationPolicy> {
-		IReplicationPolicy() {}
-		virtual ~IReplicationPolicy() {}
-		virtual std::string name() const = 0;
-		virtual std::string info() const = 0;
-		virtual void addref() { ReferenceCounted<IReplicationPolicy>::addref(); }
-		virtual void delref() { ReferenceCounted<IReplicationPolicy>::delref(); }
-		virtual int maxResults() const = 0;
-		virtual int depth() const = 0;
-		virtual bool selectReplicas(
-			Reference<LocalitySet> &										fromServers,
-			std::vector<LocalityEntry> const&		alsoServers,
-			std::vector<LocalityEntry>	&				results ) = 0;
-	    virtual void traceLocalityRecords(Reference<LocalitySet> const& fromServers);
-	    virtual void traceOneLocalityRecord(Reference<LocalityRecord> record, Reference<LocalitySet> const& fromServers);
-	    virtual bool validate(
-			std::vector<LocalityEntry>	const&	solutionSet,
-			Reference<LocalitySet> const&								fromServers ) const = 0;
+	IReplicationPolicy() {}
+	virtual ~IReplicationPolicy() {}
+	virtual std::string name() const = 0;
+	virtual std::string info() const = 0;
+	virtual void addref() { ReferenceCounted<IReplicationPolicy>::addref(); }
+	virtual void delref() { ReferenceCounted<IReplicationPolicy>::delref(); }
+	virtual int maxResults() const = 0;
+	virtual int depth() const = 0;
+	virtual bool selectReplicas(Reference<LocalitySet>& fromServers, std::vector<LocalityEntry> const& alsoServers,
+	                            std::vector<LocalityEntry>& results) = 0;
+	virtual void traceLocalityRecords(Reference<LocalitySet> const& fromServers);
+	virtual void traceOneLocalityRecord(Reference<LocalityRecord> record, Reference<LocalitySet> const& fromServers);
+	virtual bool validate(std::vector<LocalityEntry> const& solutionSet,
+	                      Reference<LocalitySet> const& fromServers) const = 0;
 
-		bool operator == ( const IReplicationPolicy& r ) const { return info() == r.info(); }
-		bool operator != ( const IReplicationPolicy& r ) const { return info() != r.info(); }
+	bool operator==(const IReplicationPolicy& r) const { return info() == r.info(); }
+	bool operator!=(const IReplicationPolicy& r) const { return info() != r.info(); }
 
-		template <class Ar>
-		void serialize(Ar& ar) {
-			Reference<IReplicationPolicy>	refThis(this);
-			serializeReplicationPolicy(ar, refThis);
-			refThis->delref_no_destroy();
-		}
-		virtual void deserializationDone() = 0;
+	template <class Ar>
+	void serialize(Ar& ar) {
+		Reference<IReplicationPolicy> refThis(this);
+		serializeReplicationPolicy(ar, refThis);
+		refThis->delref_no_destroy();
+	}
+	virtual void deserializationDone() = 0;
 
-		// Utility functions
-		bool selectReplicas(
-			Reference<LocalitySet> &										fromServers,
-			std::vector<LocalityEntry>	&				results );
-		bool validate(
-			Reference<LocalitySet> const&								solutionSet ) const;
-		bool validateFull(
-			bool																solved,
-			std::vector<LocalityEntry>	const&	solutionSet,
-			std::vector<LocalityEntry> const&		alsoServers,
-			Reference<LocalitySet> const&								fromServers );
+	// Utility functions
+	bool selectReplicas(Reference<LocalitySet>& fromServers, std::vector<LocalityEntry>& results);
+	bool validate(Reference<LocalitySet> const& solutionSet) const;
+	bool validateFull(bool solved, std::vector<LocalityEntry> const& solutionSet,
+	                  std::vector<LocalityEntry> const& alsoServers, Reference<LocalitySet> const& fromServers);
 
-		// Returns a set of the attributes that this policy uses in selection and validation.
-		std::set<std::string> attributeKeys() const
-		{ std::set<std::string> keys; this->attributeKeys(&keys); return keys; }
-		virtual void attributeKeys(std::set<std::string>*) const = 0;
+	// Returns a set of the attributes that this policy uses in selection and validation.
+	std::set<std::string> attributeKeys() const {
+		std::set<std::string> keys;
+		this->attributeKeys(&keys);
+		return keys;
+	}
+	virtual void attributeKeys(std::set<std::string>*) const = 0;
 };
 
 template <class Archive>
-inline void load( Archive& ar, Reference<IReplicationPolicy>& value ) {
+inline void load(Archive& ar, Reference<IReplicationPolicy>& value) {
 	bool present;
 	ar >> present;
 	if (present) {
 		serializeReplicationPolicy(ar, value);
-	}
-	else {
+	} else {
 		value.clear();
 	}
 }
 
 template <class Archive>
-inline void save( Archive& ar, const Reference<IReplicationPolicy>& value ) {
+inline void save(Archive& ar, const Reference<IReplicationPolicy>& value) {
 	bool present = (value.getPtr() != nullptr);
 	ar << present;
 	if (present) {
-		serializeReplicationPolicy(ar, (Reference<IReplicationPolicy>&) value);
+		serializeReplicationPolicy(ar, (Reference<IReplicationPolicy>&)value);
 	}
 }
 
 struct PolicyOne : IReplicationPolicy, public ReferenceCounted<PolicyOne> {
-	PolicyOne() {};
+	PolicyOne(){};
 	explicit PolicyOne(const PolicyOne& o) {}
-	virtual ~PolicyOne() {};
+	virtual ~PolicyOne(){};
 	virtual std::string name() const { return "One"; }
 	virtual std::string info() const { return "1"; }
 	virtual int maxResults() const { return 1; }
 	virtual int depth() const { return 1; }
-	virtual bool validate(
-		std::vector<LocalityEntry>	const&	solutionSet,
-		Reference<LocalitySet> const&				fromServers ) const;
-	virtual bool selectReplicas(
-		Reference<LocalitySet>	&						fromServers,
-		std::vector<LocalityEntry> const&		alsoServers,
-		std::vector<LocalityEntry>	&				results );
+	virtual bool validate(std::vector<LocalityEntry> const& solutionSet,
+	                      Reference<LocalitySet> const& fromServers) const;
+	virtual bool selectReplicas(Reference<LocalitySet>& fromServers, std::vector<LocalityEntry> const& alsoServers,
+	                            std::vector<LocalityEntry>& results);
 	template <class Ar>
-	void serialize(Ar& ar) {
-	}
+	void serialize(Ar& ar) {}
 	virtual void deserializationDone() {}
 	virtual void attributeKeys(std::set<std::string>* set) const override { return; }
 };
 
 struct PolicyAcross : IReplicationPolicy, public ReferenceCounted<PolicyAcross> {
 	friend struct serializable_traits<PolicyAcross*>;
-	PolicyAcross(int count, std::string const& attribKey, IRepPolicyRef const policy);
+	PolicyAcross(int count, std::string const& attribKey, Reference<IReplicationPolicy> const policy);
 	explicit PolicyAcross();
 	explicit PolicyAcross(const PolicyAcross& other) : PolicyAcross(other._count, other._attribKey, other._policy) {}
 	virtual ~PolicyAcross();
 	virtual std::string name() const { return "Across"; }
 	virtual std::string info() const { return format("%s^%d x ", _attribKey.c_str(), _count) + _policy->info(); }
 	virtual int maxResults() const { return _count * _policy->maxResults(); }
-	virtual int depth() const  { return 1 + _policy->depth(); }
-	virtual bool validate(std::vector<LocalityEntry> const& solutionSet, LocalitySetRef const& fromServers) const;
-	virtual bool selectReplicas(LocalitySetRef& fromServers, std::vector<LocalityEntry> const& alsoServers,
-		std::vector<LocalityEntry>	&				results );
+	virtual int depth() const { return 1 + _policy->depth(); }
+	virtual bool validate(std::vector<LocalityEntry> const& solutionSet, Reference<LocalitySet> const& fromServers) const;
+	virtual bool selectReplicas(Reference<LocalitySet>& fromServers, std::vector<LocalityEntry> const& alsoServers,
+	                            std::vector<LocalityEntry>& results);
 
 	template <class Ar>
 	void serialize(Ar& ar) {
@@ -153,22 +141,21 @@ struct PolicyAcross : IReplicationPolicy, public ReferenceCounted<PolicyAcross> 
 	}
 
 protected:
-	int																_count;
-	std::string												_attribKey;
-	IRepPolicyRef _policy;
+	int _count;
+	std::string _attribKey;
+	Reference<IReplicationPolicy> _policy;
 
 	// Cache temporary members
-	std::vector<AttribValue>					_usedValues;
-	std::vector<LocalityEntry>				_newResults;
-	LocalitySetRef _selected;
-	VectorRef<std::pair<int,int>>			_addedResults;
-	Arena															_arena;
+	std::vector<AttribValue> _usedValues;
+	std::vector<LocalityEntry> _newResults;
+	Reference<LocalitySet> _selected;
+	VectorRef<std::pair<int, int>> _addedResults;
+	Arena _arena;
 };
 
 struct PolicyAnd : IReplicationPolicy, public ReferenceCounted<PolicyAnd> {
 	friend struct serializable_traits<PolicyAnd*>;
-	PolicyAnd(std::vector<IRepPolicyRef> policies): _policies(policies), _sortedPolicies(policies)
-	{
+	PolicyAnd(std::vector<Reference<IReplicationPolicy>> policies) : _policies(policies), _sortedPolicies(policies) {
 		// Sort the policy array
 		std::sort(_sortedPolicies.begin(), _sortedPolicies.end(), PolicyAnd::comparePolicy);
 	}
@@ -177,9 +164,9 @@ struct PolicyAnd : IReplicationPolicy, public ReferenceCounted<PolicyAnd> {
 	virtual ~PolicyAnd() {}
 	virtual std::string name() const { return "And"; }
 	virtual std::string info() const {
-		std::string	infoText;
+		std::string infoText;
 		for (auto& policy : _policies) {
-			infoText += ((infoText.length()) ? " & ("  : "(") + policy->info() + ")";
+			infoText += ((infoText.length()) ? " & (" : "(") + policy->info() + ")";
 		}
 		if (_policies.size()) infoText = "(" + infoText + ")";
 		return infoText;
@@ -201,27 +188,26 @@ struct PolicyAnd : IReplicationPolicy, public ReferenceCounted<PolicyAnd> {
 		}
 		return depthMax;
 	}
-	virtual bool validate(
-		std::vector<LocalityEntry>	const&	solutionSet,
-		Reference<LocalitySet> const&				fromServers ) const;
+	virtual bool validate(std::vector<LocalityEntry> const& solutionSet,
+	                      Reference<LocalitySet> const& fromServers) const;
 
-	virtual bool selectReplicas(
-		Reference<LocalitySet>	&						fromServers,
-		std::vector<LocalityEntry> const&		alsoServers,
-		std::vector<LocalityEntry>	&				results );
+	virtual bool selectReplicas(Reference<LocalitySet>& fromServers, std::vector<LocalityEntry> const& alsoServers,
+	                            std::vector<LocalityEntry>& results);
 
-	static bool comparePolicy(const Reference<IReplicationPolicy>& rhs, const Reference<IReplicationPolicy>& lhs)
-	{ return (lhs->maxResults() < rhs->maxResults()) || (!(rhs->maxResults() < lhs->maxResults()) && (lhs->depth() < rhs->depth())); }
+	static bool comparePolicy(const Reference<IReplicationPolicy>& rhs, const Reference<IReplicationPolicy>& lhs) {
+		return (lhs->maxResults() < rhs->maxResults()) ||
+		       (!(rhs->maxResults() < lhs->maxResults()) && (lhs->depth() < rhs->depth()));
+	}
 
 	template <class Ar>
 	void serialize(Ar& ar) {
 		int count = _policies.size();
 		serializer(ar, count);
 		_policies.resize(count);
-		for(int i = 0; i < count; i++) {
+		for (int i = 0; i < count; i++) {
 			serializeReplicationPolicy(ar, _policies[i]);
 		}
-		if(Ar::isDeserializing) {
+		if (Ar::isDeserializing) {
 			_sortedPolicies = _policies;
 			std::sort(_sortedPolicies.begin(), _sortedPolicies.end(), PolicyAnd::comparePolicy);
 		}
@@ -232,12 +218,15 @@ struct PolicyAnd : IReplicationPolicy, public ReferenceCounted<PolicyAnd> {
 		std::sort(_sortedPolicies.begin(), _sortedPolicies.end(), PolicyAnd::comparePolicy);
 	}
 
-	virtual void attributeKeys(std::set<std::string> *set) const override
-	{ for (const Reference<IReplicationPolicy>& r : _policies) { r->attributeKeys(set); } }
+	virtual void attributeKeys(std::set<std::string>* set) const override {
+		for (const Reference<IReplicationPolicy>& r : _policies) {
+			r->attributeKeys(set);
+		}
+	}
 
 protected:
-	std::vector<Reference<IReplicationPolicy>>			_policies;
-	std::vector<Reference<IReplicationPolicy>>			_sortedPolicies;
+	std::vector<Reference<IReplicationPolicy>> _policies;
+	std::vector<Reference<IReplicationPolicy>> _sortedPolicies;
 };
 
 extern int testReplication();
@@ -279,8 +268,8 @@ extern int testReplication();
 	};
 
 template <>
-struct object_construction<IRepPolicyRef> {
-	using type = IRepPolicyRef;
+struct object_construction<Reference<IReplicationPolicy>> {
+	using type = Reference<IReplicationPolicy>;
 	type _impl;
 
 	object_construction() : _impl(new PolicyOne()){};
@@ -296,7 +285,7 @@ POLICY_CONSTRUCTION_WRAPPER(PolicyAcross);
 POLICY_CONSTRUCTION_WRAPPER(PolicyAnd);
 
 template <>
-struct FileIdentifierFor<IRepPolicyRef> {
+struct FileIdentifierFor<Reference<IReplicationPolicy>> {
 	static constexpr FileIdentifier value = 14695621;
 };
 
@@ -323,9 +312,9 @@ struct serializable_traits<PolicyAnd*> : std::true_type {
 };
 
 template <>
-struct serializable_traits<IRepPolicyRef> : std::true_type {
+struct serializable_traits<Reference<IReplicationPolicy>> : std::true_type {
 	template <class Archiver>
-	static void serialize(Archiver& ar, IRepPolicyRef& policy) {
+	static void serialize(Archiver& ar, Reference<IReplicationPolicy>& policy) {
 		::serializer(ar, policy.changePtrUnsafe());
 	}
 };
@@ -374,53 +363,42 @@ struct union_like_traits<IReplicationPolicy*> : std::true_type {
 	}
 };
 
-
 template <class Ar>
 void serializeReplicationPolicy(Ar& ar, Reference<IReplicationPolicy>& policy) {
-	if(Ar::isDeserializing) {
+	if (Ar::isDeserializing) {
 		StringRef name;
 		serializer(ar, name);
 
-		if(name == LiteralStringRef("One")) {
+		if (name == LiteralStringRef("One")) {
 			PolicyOne* pointer = new PolicyOne();
 			pointer->serialize(ar);
 			policy = Reference<IReplicationPolicy>(pointer);
-		}
-		else if(name == LiteralStringRef("Across")) {
+		} else if (name == LiteralStringRef("Across")) {
 			PolicyAcross* pointer = new PolicyAcross(0, "", Reference<IReplicationPolicy>());
 			pointer->serialize(ar);
 			policy = Reference<IReplicationPolicy>(pointer);
-		}
-		else if(name == LiteralStringRef("And")) {
+		} else if (name == LiteralStringRef("And")) {
 			PolicyAnd* pointer = new PolicyAnd{};
 			pointer->serialize(ar);
 			policy = Reference<IReplicationPolicy>(pointer);
-		}
-		else if(name == LiteralStringRef("None")) {
+		} else if (name == LiteralStringRef("None")) {
 			policy = Reference<IReplicationPolicy>();
+		} else {
+			TraceEvent(SevError, "SerializingInvalidPolicyType").detailext("PolicyName", name);
 		}
-		else {
-			TraceEvent(SevError, "SerializingInvalidPolicyType")
-				.detail("PolicyName", name);
-		}
-	}
-	else {
+	} else {
 		std::string name = policy ? policy->name() : "None";
 		Standalone<StringRef> nameRef = StringRef(name);
 		serializer(ar, nameRef);
-		if(name == "One") {
+		if (name == "One") {
 			((PolicyOne*)policy.getPtr())->serialize(ar);
-		}
-		else if(name == "Across") {
+		} else if (name == "Across") {
 			((PolicyAcross*)policy.getPtr())->serialize(ar);
-		}
-		else if(name == "And") {
+		} else if (name == "And") {
 			((PolicyAnd*)policy.getPtr())->serialize(ar);
-		}
-		else if(name == "None") {}
-		else {
-			TraceEvent(SevError, "SerializingInvalidPolicyType")
-				.detail("PolicyName", name);
+		} else if (name == "None") {
+		} else {
+			TraceEvent(SevError, "SerializingInvalidPolicyType").detail("PolicyName", name);
 		}
 	}
 }

--- a/fdbrpc/fdbrpc.h
+++ b/fdbrpc/fdbrpc.h
@@ -112,8 +112,9 @@ template <class T>
 class ReplyPromise sealed
 {
 public:
+	constexpr static FileIdentifier file_identifier = (0x2 << 24) | FileIdentifierFor<T>::value;
 	template <class U>
-	void send(U && value) const {
+	void send(U&& value) const {
 		sav->send(std::forward<U>(value));
 	}
 	template <class E>

--- a/fdbrpc/fdbrpc.h
+++ b/fdbrpc/fdbrpc.h
@@ -96,12 +96,12 @@ struct NetSAV : SAV<T>, FlowReceiver, FastAllocated<NetSAV<T>> {
 	virtual void receive(ArenaObjectReader& reader) {
 		if (!SAV<T>::canBeSet()) return;
 		this->addPromiseRef();
-		ErrorOr<T> message;
+		ErrorOr<EnsureTable<T>> message;
 		reader.deserialize(message);
 		if (message.isError()) {
 			SAV<T>::sendErrorAndDelPromiseRef(message.getError());
 		} else {
-			SAV<T>::sendAndDelPromiseRef(message.get());
+			SAV<T>::sendAndDelPromiseRef(message.get().asUnderlyingType());
 		}
 	}
 };

--- a/fdbrpc/fdbrpc.h
+++ b/fdbrpc/fdbrpc.h
@@ -92,6 +92,17 @@ struct NetSAV : SAV<T>, FlowReceiver, FastAllocated<NetSAV<T>> {
 			SAV<T>::sendErrorAndDelPromiseRef(error);
 		}
 	}
+	virtual void receive(ArenaObjectReader& reader) {
+		if (!SAV<T>::canBeSet()) return;
+		this->addPromiseRef();
+		ErrorOr<T> message;
+		reader.deserialize(message);
+		if (message.isError()) {
+			SAV<T>::sendErrorAndDelPromiseRef(message.getError());
+		} else {
+			SAV<T>::sendAndDelPromiseRef(message.get());
+		}
+	}
 };
 
 

--- a/fdbrpc/fdbrpc.h
+++ b/fdbrpc/fdbrpc.h
@@ -109,10 +109,9 @@ struct NetSAV : SAV<T>, FlowReceiver, FastAllocated<NetSAV<T>> {
 
 
 template <class T>
-class ReplyPromise sealed
+class ReplyPromise sealed : public ComposedIdentifier<T, 0x2>
 {
 public:
-	constexpr static FileIdentifier file_identifier = (0x2 << 24) | FileIdentifierFor<T>::value;
 	template <class U>
 	void send(U&& value) const {
 		sav->send(std::forward<U>(value));

--- a/fdbrpc/genericactors.actor.cpp
+++ b/fdbrpc/genericactors.actor.cpp
@@ -24,11 +24,6 @@
 #include "fdbrpc/simulator.h"
 #include "flow/actorcompiler.h"
 
-ACTOR void simDeliverDuplicate( Standalone<StringRef> data, Endpoint destination ) {
-	wait( delay( g_random->random01() * FLOW_KNOBS->MAX_DELIVER_DUPLICATE_DELAY ) );
-	FlowTransport::transport().sendUnreliable( SerializeSourceRaw(data), destination );
-}
-
 ACTOR Future<Void> disableConnectionFailuresAfter( double time, std::string context ) {
 	wait( delay(time) );
 

--- a/fdbrpc/networksender.actor.h
+++ b/fdbrpc/networksender.actor.h
@@ -31,14 +31,22 @@
 #include "flow/actorcompiler.h"  // This must be the last #include.
 
 ACTOR template <class T>
-void networkSender( Future<T> input, Endpoint endpoint ) {
+void networkSender(Future<T> input, Endpoint endpoint) {
 	try {
-		T value = wait( input );
-		FlowTransport::transport().sendUnreliable( SerializeBoolAnd<T>(true, value), endpoint, false );
+		T value = wait(input);
+		if (g_network->useObjectSerializer()) {
+			FlowTransport::transport().sendUnreliable(SerializeSource<ErrorOr<T>>(ErrorOr<T>(value)), endpoint);
+		} else {
+			FlowTransport::transport().sendUnreliable(SerializeBoolAnd<T>(true, value), endpoint, false);
+		}
 	} catch (Error& err) {
-		//if (err.code() == error_code_broken_promise) return;
-		ASSERT( err.code() != error_code_actor_cancelled );
-		FlowTransport::transport().sendUnreliable( SerializeBoolAnd<Error>(false, err), endpoint, false );
+		// if (err.code() == error_code_broken_promise) return;
+		ASSERT(err.code() != error_code_actor_cancelled);
+		if (g_network->useObjectSerializer()) {
+			FlowTransport::transport().sendUnreliable(SerializeSource<ErrorOr<T>>(ErrorOr<T>(err)), endpoint);
+		} else {
+			FlowTransport::transport().sendUnreliable(SerializeBoolAnd<Error>(false, err), endpoint, false);
+		}
 	}
 }
 #include "flow/unactorcompiler.h"

--- a/fdbrpc/networksender.actor.h
+++ b/fdbrpc/networksender.actor.h
@@ -35,7 +35,7 @@ void networkSender(Future<T> input, Endpoint endpoint) {
 	try {
 		T value = wait(input);
 		if (g_network->useObjectSerializer()) {
-			FlowTransport::transport().sendUnreliable(SerializeSource<ErrorOr<T>>(ErrorOr<T>(value)), endpoint);
+			FlowTransport::transport().sendUnreliable(SerializeSource<ErrorOr<EnsureTable<T>>>(value), endpoint);
 		} else {
 			FlowTransport::transport().sendUnreliable(SerializeBoolAnd<T>(true, value), endpoint, false);
 		}
@@ -43,7 +43,7 @@ void networkSender(Future<T> input, Endpoint endpoint) {
 		// if (err.code() == error_code_broken_promise) return;
 		ASSERT(err.code() != error_code_actor_cancelled);
 		if (g_network->useObjectSerializer()) {
-			FlowTransport::transport().sendUnreliable(SerializeSource<ErrorOr<T>>(ErrorOr<T>(err)), endpoint);
+			FlowTransport::transport().sendUnreliable(SerializeSource<ErrorOr<EnsureTable<T>>>(err), endpoint);
 		} else {
 			FlowTransport::transport().sendUnreliable(SerializeBoolAnd<Error>(false, err), endpoint, false);
 		}

--- a/fdbrpc/sim2.actor.cpp
+++ b/fdbrpc/sim2.actor.cpp
@@ -979,7 +979,7 @@ public:
 	}
 	virtual ProcessInfo* newProcess(const char* name, IPAddress ip, uint16_t port, uint16_t listenPerProcess,
 	                                LocalityData locality, ProcessClass startingClass, const char* dataFolder,
-	                                const char* coordinationFolder) {
+	                                const char* coordinationFolder, bool ObjSerializer) {
 		ASSERT( locality.machineId().present() );
 		MachineInfo& machine = machines[ locality.machineId().get() ];
 		if (!machine.machineId.present())
@@ -1001,7 +1001,7 @@ public:
 		// These files must live on after process kills for sim purposes.
 		if( machine.machineProcess == 0 ) {
 			NetworkAddress machineAddress(ip, 0, false, false);
-			machine.machineProcess = new ProcessInfo("Machine", locality, startingClass, {machineAddress}, this, "", "");
+			machine.machineProcess = new ProcessInfo("Machine", locality, startingClass, {machineAddress}, this, "", "", objSerializer);
 			machine.machineProcess->machine = &machine;
 		}
 
@@ -1011,7 +1011,7 @@ public:
 			addresses.secondaryAddress = NetworkAddress(ip, port+1, true, false);
 		}
 
-		ProcessInfo* m = new ProcessInfo(name, locality, startingClass, addresses, this, dataFolder, coordinationFolder);
+		ProcessInfo* m = new ProcessInfo(name, locality, startingClass, addresses, this, dataFolder, coordinationFolder, objSerializer);
 		for (int processPort = port; processPort < port + listenPerProcess; ++processPort) {
 			NetworkAddress address(ip, processPort, true, false); // SOMEDAY see above about becoming SSL!
 			m->listenerMap[address] = Reference<IListener>( new Sim2Listener(m, address) );
@@ -1572,7 +1572,7 @@ public:
 
 	Sim2() : time(0.0), taskCount(0), yielded(false), yield_limit(0), currentTaskID(-1) {
 		// Not letting currentProcess be NULL eliminates some annoying special cases
-		currentProcess = new ProcessInfo( "NoMachine", LocalityData(Optional<Standalone<StringRef>>(), StringRef(), StringRef(), StringRef()), ProcessClass(), {NetworkAddress()}, this, "", "" );
+		currentProcess = new ProcessInfo("NoMachine", LocalityData(Optional<Standalone<StringRef>>(), StringRef(), StringRef(), StringRef()), ProcessClass(), {NetworkAddress()}, this, "", "", false);
 		g_network = net2 = newNet2(false, true);
 		Net2FileSystem::newFileSystem();
 		check_yield(0);

--- a/fdbrpc/sim2.actor.cpp
+++ b/fdbrpc/sim2.actor.cpp
@@ -979,7 +979,7 @@ public:
 	}
 	virtual ProcessInfo* newProcess(const char* name, IPAddress ip, uint16_t port, uint16_t listenPerProcess,
 	                                LocalityData locality, ProcessClass startingClass, const char* dataFolder,
-	                                const char* coordinationFolder, bool ObjSerializer) {
+	                                const char* coordinationFolder, bool objSerializer) {
 		ASSERT( locality.machineId().present() );
 		MachineInfo& machine = machines[ locality.machineId().get() ];
 		if (!machine.machineId.present())

--- a/fdbrpc/simulator.h
+++ b/fdbrpc/simulator.h
@@ -53,7 +53,6 @@ public:
 		NetworkAddress address;
 		LocalityData	locality;
 		ProcessClass startingClass;
-		bool useObjectSerializer;
 		TDMetricCollection tdmetrics;
 		std::map<NetworkAddress, Reference<IListener>> listenerMap;
 		bool failed;
@@ -69,8 +68,8 @@ public:
 		double fault_injection_p1, fault_injection_p2;
 
 		ProcessInfo(const char* name, LocalityData locality, ProcessClass startingClass, NetworkAddressList addresses,
-					INetworkConnections *net, const char* dataFolder, const char* coordinationFolder, bool useObjectSerializer )
-			: name(name), locality(locality), startingClass(startingClass), useObjectSerializer(useObjectSerializer),
+					INetworkConnections *net, const char* dataFolder, const char* coordinationFolder )
+			: name(name), locality(locality), startingClass(startingClass),
 			  addresses(addresses), address(addresses.address), dataFolder(dataFolder),
 			  network(net), coordinationFolder(coordinationFolder), failed(false), excluded(false), cpuTicks(0),
 			  rebooting(false), fault_injection_p1(0), fault_injection_p2(0),
@@ -143,7 +142,7 @@ public:
 
 	virtual ProcessInfo* newProcess(const char* name, IPAddress ip, uint16_t port, uint16_t listenPerProcess,
 	                                LocalityData locality, ProcessClass startingClass, const char* dataFolder,
-	                                const char* coordinationFolder, bool useObjectSerializer) = 0;
+	                                const char* coordinationFolder) = 0;
 	virtual void killProcess( ProcessInfo* machine, KillType ) = 0;
 	virtual void rebootProcess(Optional<Standalone<StringRef>> zoneId, bool allProcesses ) = 0;
 	virtual void rebootProcess( ProcessInfo* process, KillType kt ) = 0;
@@ -156,7 +155,7 @@ public:
 	virtual bool isAvailable() const = 0;
 	virtual bool datacenterDead(Optional<Standalone<StringRef>> dcId) const = 0;
 	virtual void displayWorkers() const;
-	virtual bool useObjectSerializer() const { return currentProcess->useObjectSerializer; }
+	virtual bool useObjectSerializer() const = 0;
 
 	virtual void addRole(NetworkAddress const& address, std::string const& role) {
 		roleAddresses[address][role] ++;
@@ -328,7 +327,7 @@ private:
 extern ISimulator* g_pSimulator;
 #define g_simulator (*g_pSimulator)
 
-void startNewSimulator();
+void startNewSimulator(bool useObjectSerializer);
 
 //Parameters used to simulate disk performance
 struct DiskParameters : ReferenceCounted<DiskParameters> {

--- a/fdbrpc/simulator.h
+++ b/fdbrpc/simulator.h
@@ -53,6 +53,7 @@ public:
 		NetworkAddress address;
 		LocalityData	locality;
 		ProcessClass startingClass;
+		bool useObjectSerializer;
 		TDMetricCollection tdmetrics;
 		std::map<NetworkAddress, Reference<IListener>> listenerMap;
 		bool failed;
@@ -69,10 +70,11 @@ public:
 
 		ProcessInfo(const char* name, LocalityData locality, ProcessClass startingClass, NetworkAddressList addresses,
 					INetworkConnections *net, const char* dataFolder, const char* coordinationFolder )
-			: name(name), locality(locality), startingClass(startingClass), addresses(addresses), address(addresses.address), dataFolder(dataFolder),
-				network(net), coordinationFolder(coordinationFolder), failed(false), excluded(false), cpuTicks(0),
-				rebooting(false), fault_injection_p1(0), fault_injection_p2(0),
-				fault_injection_r(0), machine(0), cleared(false) {}
+            : name(name), locality(locality), startingClass(startingClass), useObjectSerializer(useObjectSerializer),
+              addresses(addresses), address(addresses.address), dataFolder(dataFolder),
+              network(net), coordinationFolder(coordinationFolder), failed(false), excluded(false), cpuTicks(0),
+              rebooting(false), fault_injection_p1(0), fault_injection_p2(0),
+              fault_injection_r(0), machine(0), cleared(false) {}
 
 		Future<KillType> onShutdown() { return shutdownSignal.getFuture(); }
 
@@ -141,7 +143,7 @@ public:
 
 	virtual ProcessInfo* newProcess(const char* name, IPAddress ip, uint16_t port, uint16_t listenPerProcess,
 	                                LocalityData locality, ProcessClass startingClass, const char* dataFolder,
-	                                const char* coordinationFolder) = 0;
+	                                const char* coordinationFolder, bool useObjectSerializer) = 0;
 	virtual void killProcess( ProcessInfo* machine, KillType ) = 0;
 	virtual void rebootProcess(Optional<Standalone<StringRef>> zoneId, bool allProcesses ) = 0;
 	virtual void rebootProcess( ProcessInfo* process, KillType kt ) = 0;
@@ -154,6 +156,7 @@ public:
 	virtual bool isAvailable() const = 0;
 	virtual bool datacenterDead(Optional<Standalone<StringRef>> dcId) const = 0;
 	virtual void displayWorkers() const;
+	virtual bool useObjectSerializer() const { return currentProcess->useObjectSerializer; }
 
 	virtual void addRole(NetworkAddress const& address, std::string const& role) {
 		roleAddresses[address][role] ++;

--- a/fdbrpc/simulator.h
+++ b/fdbrpc/simulator.h
@@ -69,12 +69,12 @@ public:
 		double fault_injection_p1, fault_injection_p2;
 
 		ProcessInfo(const char* name, LocalityData locality, ProcessClass startingClass, NetworkAddressList addresses,
-					INetworkConnections *net, const char* dataFolder, const char* coordinationFolder )
-            : name(name), locality(locality), startingClass(startingClass), useObjectSerializer(useObjectSerializer),
-              addresses(addresses), address(addresses.address), dataFolder(dataFolder),
-              network(net), coordinationFolder(coordinationFolder), failed(false), excluded(false), cpuTicks(0),
-              rebooting(false), fault_injection_p1(0), fault_injection_p2(0),
-              fault_injection_r(0), machine(0), cleared(false) {}
+					INetworkConnections *net, const char* dataFolder, const char* coordinationFolder, bool useObjectSerializer )
+			: name(name), locality(locality), startingClass(startingClass), useObjectSerializer(useObjectSerializer),
+			  addresses(addresses), address(addresses.address), dataFolder(dataFolder),
+			  network(net), coordinationFolder(coordinationFolder), failed(false), excluded(false), cpuTicks(0),
+			  rebooting(false), fault_injection_p1(0), fault_injection_p2(0),
+			  fault_injection_r(0), machine(0), cleared(false) {}
 
 		Future<KillType> onShutdown() { return shutdownSignal.getFuture(); }
 

--- a/fdbserver/CMakeLists.txt
+++ b/fdbserver/CMakeLists.txt
@@ -171,7 +171,7 @@ set(FDBSERVER_SRCS
   workloads/WriteBandwidth.actor.cpp
   workloads/WriteDuringRead.actor.cpp)
 
-set(SQLITE_SRCS
+add_library(fdb_sqlite STATIC
   sqlite/btree.h
   sqlite/hash.h
   sqlite/sqlite3.h
@@ -179,9 +179,7 @@ set(SQLITE_SRCS
   sqlite/sqliteInt.h
   sqlite/sqliteLimit.h
   sqlite/sqlite3.amalgamation.c)
-
-add_library(sqlite ${SQLITE_SRCS})
-target_compile_definitions(sqlite PRIVATE $<$<CONFIG:Debug>:NDEBUG>)
+target_compile_definitions(fdb_sqlite PRIVATE $<$<CONFIG:Debug>:NDEBUG>)
 
 # Suppress warnings in sqlite since it's third party
 if(NOT WIN32)
@@ -200,7 +198,7 @@ add_flow_target(EXECUTABLE NAME fdbserver SRCS ${FDBSERVER_SRCS})
 target_include_directories(fdbserver PRIVATE
   ${CMAKE_CURRENT_BINARY_DIR}/workloads
   ${CMAKE_CURRENT_SOURCE_DIR}/workloads)
-target_link_libraries(fdbserver PRIVATE fdbclient sqlite)
+target_link_libraries(fdbserver PRIVATE fdbclient fdb_sqlite)
 if(WITH_JAVA_WORKLOAD)
   if(NOT JNI_FOUND)
     message(SEND_ERROR "Trying to build Java workload but couldn't find JNI")

--- a/fdbserver/CMakeLists.txt
+++ b/fdbserver/CMakeLists.txt
@@ -179,11 +179,11 @@ add_library(fdb_sqlite STATIC
   sqlite/sqliteInt.h
   sqlite/sqliteLimit.h
   sqlite/sqlite3.amalgamation.c)
-target_compile_definitions(fdb_sqlite PRIVATE $<$<CONFIG:Debug>:NDEBUG>)
 
 # Suppress warnings in sqlite since it's third party
 if(NOT WIN32)
-  target_compile_options(sqlite BEFORE PRIVATE -w) # disable warnings for third party
+  target_compile_definitions(fdb_sqlite PRIVATE $<$<CONFIG:Debug>:NDEBUG>)
+  target_compile_options(fdb_sqlite BEFORE PRIVATE -w) # disable warnings for third party
 endif()
 
 set(java_workload_docstring "Build the Java workloads (makes fdbserver link against JNI)")

--- a/fdbserver/ClusterRecruitmentInterface.h
+++ b/fdbserver/ClusterRecruitmentInterface.h
@@ -35,6 +35,8 @@
 
 // This interface and its serialization depend on slicing, since the client will deserialize only the first part of this structure
 struct ClusterControllerFullInterface {
+    constexpr static FileIdentifier file_identifier =
+        ClusterControllerClientInterface::file_identifier;
 	ClusterInterface clientInterface;
 	RequestStream< struct RecruitFromConfigurationRequest > recruitFromConfiguration;
 	RequestStream< struct RecruitRemoteFromConfigurationRequest > recruitRemoteFromConfiguration;

--- a/fdbserver/ClusterRecruitmentInterface.h
+++ b/fdbserver/ClusterRecruitmentInterface.h
@@ -72,6 +72,7 @@ struct ClusterControllerFullInterface {
 };
 
 struct RecruitFromConfigurationRequest {
+	constexpr static FileIdentifier file_identifier = 2023046;
 	DatabaseConfiguration configuration;
 	bool recruitSeedServers;
 	int maxOldLogRouters;
@@ -88,6 +89,7 @@ struct RecruitFromConfigurationRequest {
 };
 
 struct RecruitFromConfigurationReply {
+	constexpr static FileIdentifier file_identifier = 2224085;
 	vector<WorkerInterface> tLogs;
 	vector<WorkerInterface> satelliteTLogs;
 	vector<WorkerInterface> proxies;
@@ -106,6 +108,7 @@ struct RecruitFromConfigurationReply {
 };
 
 struct RecruitRemoteFromConfigurationRequest {
+	constexpr static FileIdentifier file_identifier = 3235995;
 	DatabaseConfiguration configuration;
 	Optional<Key> dcId;
 	int logRouterCount;
@@ -122,6 +125,7 @@ struct RecruitRemoteFromConfigurationRequest {
 };
 
 struct RecruitRemoteFromConfigurationReply {
+	constexpr static FileIdentifier file_identifier = 9091392;
 	vector<WorkerInterface> remoteTLogs;
 	vector<WorkerInterface> logRouters;
 
@@ -132,6 +136,7 @@ struct RecruitRemoteFromConfigurationReply {
 };
 
 struct RecruitStorageReply {
+	constexpr static FileIdentifier file_identifier = 15877089;
 	WorkerInterface worker;
 	ProcessClass processClass;
 
@@ -142,6 +147,7 @@ struct RecruitStorageReply {
 };
 
 struct RecruitStorageRequest {
+	constexpr static FileIdentifier file_identifier = 905920;
 	std::vector<Optional<Standalone<StringRef>>> excludeMachines;	//< Don't recruit any of these machines
 	std::vector<AddressExclusion> excludeAddresses;		//< Don't recruit any of these addresses
 	std::vector<Optional<Standalone<StringRef>>> includeDCs;
@@ -155,6 +161,7 @@ struct RecruitStorageRequest {
 };
 
 struct RegisterWorkerReply {
+	constexpr static FileIdentifier file_identifier = 16475696;
 	ProcessClass processClass;
 	ClusterControllerPriorityInfo priorityInfo;
 
@@ -168,6 +175,7 @@ struct RegisterWorkerReply {
 };
 
 struct RegisterWorkerRequest {
+	constexpr static FileIdentifier file_identifier = 14332605;
 	WorkerInterface wi;
 	ProcessClass initialClass;
 	ProcessClass processClass;
@@ -189,6 +197,7 @@ struct RegisterWorkerRequest {
 };
 
 struct GetWorkersRequest {
+	constexpr static FileIdentifier file_identifier = 1254174;
 	enum { TESTER_CLASS_ONLY = 0x1, NON_EXCLUDED_PROCESSES_ONLY = 0x2 };
 
 	int flags;
@@ -204,6 +213,7 @@ struct GetWorkersRequest {
 };
 
 struct RegisterMasterRequest {
+	constexpr static FileIdentifier file_identifier = 10773445;
 	UID id;
 	LocalityData mi;
 	LogSystemConfig logSystemConfig;
@@ -231,6 +241,7 @@ struct RegisterMasterRequest {
 };
 
 struct GetServerDBInfoRequest {
+	constexpr static FileIdentifier file_identifier = 9467438;
 	UID knownServerInfoID;
 	Standalone<VectorRef<StringRef>> issues;
 	std::vector<NetworkAddress> incompatiblePeers;

--- a/fdbserver/ClusterRecruitmentInterface.h
+++ b/fdbserver/ClusterRecruitmentInterface.h
@@ -60,9 +60,12 @@ struct ClusterControllerFullInterface {
 	}
 
 	template <class Ar>
-	void serialize( Ar& ar ) {
-		ASSERT( ar.protocolVersion() >= 0x0FDB00A200040001LL );
-		serializer(ar, clientInterface, recruitFromConfiguration, recruitRemoteFromConfiguration, recruitStorage, registerWorker, getWorkers, registerMaster, getServerDBInfo);
+	void serialize(Ar& ar) {
+		if constexpr (!is_fb_function<Ar>) {
+			ASSERT(ar.protocolVersion() >= 0x0FDB00A200040001LL);
+		}
+		serializer(ar, clientInterface, recruitFromConfiguration, recruitRemoteFromConfiguration, recruitStorage,
+		           registerWorker, getWorkers, registerMaster, getServerDBInfo);
 	}
 };
 
@@ -216,9 +219,12 @@ struct RegisterMasterRequest {
 	RegisterMasterRequest() {}
 
 	template <class Ar>
-	void serialize( Ar& ar ) {
-		ASSERT( ar.protocolVersion() >= 0x0FDB00A200040001LL );
-		serializer(ar, id, mi, logSystemConfig, proxies, resolvers, recoveryCount, registrationCount, configuration, priorCommittedLogServers, recoveryState, recoveryStalled, reply);
+	void serialize(Ar& ar) {
+		if constexpr (!is_fb_function<Ar>) {
+			ASSERT(ar.protocolVersion() >= 0x0FDB00A200040001LL);
+		}
+		serializer(ar, id, mi, logSystemConfig, proxies, resolvers, recoveryCount, registrationCount, configuration,
+		           priorCommittedLogServers, recoveryState, recoveryStalled, reply);
 	}
 };
 

--- a/fdbserver/ClusterRecruitmentInterface.h
+++ b/fdbserver/ClusterRecruitmentInterface.h
@@ -71,23 +71,6 @@ struct ClusterControllerFullInterface {
 	}
 };
 
-struct RecruitFromConfigurationRequest {
-	constexpr static FileIdentifier file_identifier = 2023046;
-	DatabaseConfiguration configuration;
-	bool recruitSeedServers;
-	int maxOldLogRouters;
-	ReplyPromise< struct RecruitFromConfigurationReply > reply;
-
-	RecruitFromConfigurationRequest() {}
-	explicit RecruitFromConfigurationRequest(DatabaseConfiguration const& configuration, bool recruitSeedServers, int maxOldLogRouters)
-		: configuration(configuration), recruitSeedServers(recruitSeedServers), maxOldLogRouters(maxOldLogRouters) {}
-
-	template <class Ar>
-	void serialize( Ar& ar ) {
-		serializer(ar, configuration, recruitSeedServers, maxOldLogRouters, reply);
-	}
-};
-
 struct RecruitFromConfigurationReply {
 	constexpr static FileIdentifier file_identifier = 2224085;
 	vector<WorkerInterface> tLogs;
@@ -107,6 +90,34 @@ struct RecruitFromConfigurationReply {
 	}
 };
 
+struct RecruitFromConfigurationRequest {
+	constexpr static FileIdentifier file_identifier = 2023046;
+	DatabaseConfiguration configuration;
+	bool recruitSeedServers;
+	int maxOldLogRouters;
+	ReplyPromise< struct RecruitFromConfigurationReply > reply;
+
+	RecruitFromConfigurationRequest() {}
+	explicit RecruitFromConfigurationRequest(DatabaseConfiguration const& configuration, bool recruitSeedServers, int maxOldLogRouters)
+		: configuration(configuration), recruitSeedServers(recruitSeedServers), maxOldLogRouters(maxOldLogRouters) {}
+
+	template <class Ar>
+	void serialize( Ar& ar ) {
+		serializer(ar, configuration, recruitSeedServers, maxOldLogRouters, reply);
+	}
+};
+
+struct RecruitRemoteFromConfigurationReply {
+	constexpr static FileIdentifier file_identifier = 9091392;
+	vector<WorkerInterface> remoteTLogs;
+	vector<WorkerInterface> logRouters;
+
+	template <class Ar>
+	void serialize( Ar& ar ) {
+		serializer(ar, remoteTLogs, logRouters);
+	}
+};
+
 struct RecruitRemoteFromConfigurationRequest {
 	constexpr static FileIdentifier file_identifier = 3235995;
 	DatabaseConfiguration configuration;
@@ -121,17 +132,6 @@ struct RecruitRemoteFromConfigurationRequest {
 	template <class Ar>
 	void serialize( Ar& ar ) {
 		serializer(ar, configuration, dcId, logRouterCount, exclusionWorkerIds, reply);
-	}
-};
-
-struct RecruitRemoteFromConfigurationReply {
-	constexpr static FileIdentifier file_identifier = 9091392;
-	vector<WorkerInterface> remoteTLogs;
-	vector<WorkerInterface> logRouters;
-
-	template <class Ar>
-	void serialize( Ar& ar ) {
-		serializer(ar, remoteTLogs, logRouters);
 	}
 };
 
@@ -237,19 +237,6 @@ struct RegisterMasterRequest {
 		}
 		serializer(ar, id, mi, logSystemConfig, proxies, resolvers, recoveryCount, registrationCount, configuration,
 		           priorCommittedLogServers, recoveryState, recoveryStalled, reply);
-	}
-};
-
-struct GetServerDBInfoRequest {
-	constexpr static FileIdentifier file_identifier = 9467438;
-	UID knownServerInfoID;
-	Standalone<VectorRef<StringRef>> issues;
-	std::vector<NetworkAddress> incompatiblePeers;
-	ReplyPromise< struct ServerDBInfo > reply;
-
-	template <class Ar>
-	void serialize(Ar& ar) {
-		serializer(ar, knownServerInfoID, issues, incompatiblePeers, reply);
 	}
 };
 

--- a/fdbserver/CoordinationInterface.h
+++ b/fdbserver/CoordinationInterface.h
@@ -25,6 +25,7 @@
 #include "fdbclient/CoordinationInterface.h"
 
 struct GenerationRegInterface {
+	constexpr static FileIdentifier file_identifier = 16726744;
 	RequestStream< struct GenerationRegReadRequest > read;
 	RequestStream< struct GenerationRegWriteRequest > write;
 
@@ -52,6 +53,7 @@ struct GenerationRegInterface {
 };
 
 struct UniqueGeneration {
+	constexpr static FileIdentifier file_identifier = 16684234;
 	uint64_t generation;
 	UID uid;
 	UniqueGeneration() : generation(0) {}
@@ -71,6 +73,7 @@ struct UniqueGeneration {
 };
 
 struct GenerationRegReadRequest {
+	constexpr static FileIdentifier file_identifier = 8975311;
 	Key key;
 	UniqueGeneration gen;
 	ReplyPromise<struct GenerationRegReadReply> reply;
@@ -83,6 +86,7 @@ struct GenerationRegReadRequest {
 };
 
 struct GenerationRegReadReply {
+	constexpr static FileIdentifier file_identifier = 12623609;
 	Optional<Value> value;
 	UniqueGeneration gen, rgen;
 	GenerationRegReadReply() {}
@@ -94,6 +98,7 @@ struct GenerationRegReadReply {
 };
 
 struct GenerationRegWriteRequest {
+	constexpr static FileIdentifier file_identifier = 3521510;
 	KeyValue kv;
 	UniqueGeneration gen;
 	ReplyPromise< UniqueGeneration > reply;
@@ -116,6 +121,7 @@ struct LeaderElectionRegInterface : ClientLeaderRegInterface {
 };
 
 struct CandidacyRequest {
+	constexpr static FileIdentifier file_identifier = 14473958;
 	Key key;
 	LeaderInfo myInfo;
 	UID knownLeader, prevChangeID;
@@ -131,6 +137,7 @@ struct CandidacyRequest {
 };
 
 struct LeaderHeartbeatRequest {
+	constexpr static FileIdentifier file_identifier = 9495992;
 	Key key;
 	LeaderInfo myInfo;
 	UID prevChangeID;
@@ -146,6 +153,7 @@ struct LeaderHeartbeatRequest {
 };
 
 struct ForwardRequest {
+	constexpr static FileIdentifier file_identifier = 13570359;
 	Key key;
 	Value conn;  // a cluster connection string
 	ReplyPromise<Void> reply;

--- a/fdbserver/CoordinationInterface.h
+++ b/fdbserver/CoordinationInterface.h
@@ -72,6 +72,18 @@ struct UniqueGeneration {
 	}
 };
 
+struct GenerationRegReadReply {
+	constexpr static FileIdentifier file_identifier = 12623609;
+	Optional<Value> value;
+	UniqueGeneration gen, rgen;
+	GenerationRegReadReply() {}
+	GenerationRegReadReply( Optional<Value> value, UniqueGeneration gen, UniqueGeneration rgen ) : value(value), gen(gen), rgen(rgen) {}
+	template <class Ar>
+	void serialize(Ar& ar) {
+		serializer(ar, value, gen, rgen);
+	}
+};
+
 struct GenerationRegReadRequest {
 	constexpr static FileIdentifier file_identifier = 8975311;
 	Key key;
@@ -82,18 +94,6 @@ struct GenerationRegReadRequest {
 	template <class Ar>
 	void serialize(Ar& ar) {
 		serializer(ar, key, gen, reply);
-	}
-};
-
-struct GenerationRegReadReply {
-	constexpr static FileIdentifier file_identifier = 12623609;
-	Optional<Value> value;
-	UniqueGeneration gen, rgen;
-	GenerationRegReadReply() {}
-	GenerationRegReadReply( Optional<Value> value, UniqueGeneration gen, UniqueGeneration rgen ) : value(value), gen(gen), rgen(rgen) {}
-	template <class Ar>
-	void serialize(Ar& ar) {
-		serializer(ar, value, gen, rgen);
 	}
 };
 

--- a/fdbserver/DataDistributorInterface.h
+++ b/fdbserver/DataDistributorInterface.h
@@ -25,6 +25,7 @@
 #include "fdbrpc/Locality.h"
 
 struct DataDistributorInterface {
+	constexpr static FileIdentifier file_identifier = 12383874;
 	RequestStream<ReplyPromise<Void>> waitFailure;
 	RequestStream<struct HaltDataDistributorRequest> haltDataDistributor;
 	struct LocalityData locality;
@@ -49,6 +50,7 @@ struct DataDistributorInterface {
 };
 
 struct HaltDataDistributorRequest {
+	constexpr static FileIdentifier file_identifier = 1904127;
 	UID requesterID;
 	ReplyPromise<Void> reply;
 

--- a/fdbserver/LeaderElection.actor.cpp
+++ b/fdbserver/LeaderElection.actor.cpp
@@ -75,8 +75,10 @@ ACTOR Future<Void> changeLeaderCoordinators( ServerCoordinators coordinators, Va
 	return Void();
 }
 
-ACTOR Future<Void> tryBecomeLeaderInternal( ServerCoordinators coordinators, Value proposedSerializedInterface, Reference<AsyncVar<Value>> outSerializedLeader, bool hasConnected, Reference<AsyncVar<ClusterControllerPriorityInfo>> asyncPriorityInfo ) {
-	state Reference<AsyncVar<vector<Optional<LeaderInfo>>>> nominees( new AsyncVar<vector<Optional<LeaderInfo>>>() );
+ACTOR Future<Void> tryBecomeLeaderInternal(ServerCoordinators coordinators, Value proposedSerializedInterface,
+                                           Reference<AsyncVar<Value>> outSerializedLeader, bool hasConnected,
+                                           Reference<AsyncVar<ClusterControllerPriorityInfo>> asyncPriorityInfo) {
+	state Reference<AsyncVar<vector<Optional<LeaderInfo>>>> nominees(new AsyncVar<vector<Optional<LeaderInfo>>>());
 	state LeaderInfo myInfo;
 	state Future<Void> candidacies;
 	state bool iAmLeader = false;

--- a/fdbserver/LeaderElection.h
+++ b/fdbserver/LeaderElection.h
@@ -24,6 +24,7 @@
 
 #include "fdbrpc/fdbrpc.h"
 #include "fdbrpc/Locality.h"
+#include "fdbclient/FDBTypes.h"
 
 class ServerCoordinators;
 
@@ -57,9 +58,12 @@ Future<Void> tryBecomeLeader( ServerCoordinators const& coordinators,
 							  bool hasConnected,
 							  Reference<AsyncVar<ClusterControllerPriorityInfo>> const& asyncPriorityInfo)
 {
-	Reference<AsyncVar<Value>> serializedInfo( new AsyncVar<Value> );
-	Future<Void> m = tryBecomeLeaderInternal( coordinators, BinaryWriter::toValue(proposedInterface, IncludeVersion()), serializedInfo, hasConnected, asyncPriorityInfo );
-	return m || asyncDeserialize( serializedInfo, outKnownLeader );
+	Reference<AsyncVar<Value>> serializedInfo(new AsyncVar<Value>);
+	Future<Void> m = tryBecomeLeaderInternal(
+		coordinators,
+		g_network->useObjectSerializer() ? ObjectWriter::toValue(proposedInterface) : BinaryWriter::toValue(proposedInterface, IncludeVersion()),
+		serializedInfo, hasConnected, asyncPriorityInfo);
+	return m || asyncDeserialize(serializedInfo, outKnownLeader, g_network->useObjectSerializer());
 }
 
 #pragma endregion

--- a/fdbserver/LogSystemConfig.h
+++ b/fdbserver/LogSystemConfig.h
@@ -28,6 +28,7 @@
 
 template <class Interface>
 struct OptionalInterface {
+	friend class serializable_traits<OptionalInterface<Interface>>;
 	// Represents an interface with a known id() and possibly known actual endpoints.
 	// For example, an OptionalInterface<TLogInterface> represents a particular tlog by id, which you might or might not presently know how to communicate with
 
@@ -57,6 +58,25 @@ protected:
 
 class LogSet;
 struct OldLogData;
+
+template <class Interface>
+struct serializable_traits<OptionalInterface<Interface>> : std::true_type {
+	template <class Archiver>
+	static void serialize(Archiver& ar, OptionalInterface<Interface>& m) {
+		if constexpr (!Archiver::isDeserializing) {
+			if (m.iface.present()) {
+				m.ident = m.iface.get().id();
+			}
+		}
+		::serializer(ar, m.iface, m.ident);
+		if constexpr (Archiver::isDeserializing) {
+			if (m.iface.present()) {
+				m.ident = m.iface.get().id();
+			}
+		}
+	}
+};
+
 
 struct TLogSet {
 	std::vector<OptionalInterface<TLogInterface>> tLogs;
@@ -136,7 +156,7 @@ struct OldTLogConf {
 	explicit OldTLogConf(const OldLogData&);
 
 	std::string toString() const {
-		return format("end: %d tags: %d %s", epochEnd, logRouterTags, describe(tLogs).c_str()); 
+		return format("end: %d tags: %d %s", epochEnd, logRouterTags, describe(tLogs).c_str());
 	}
 
 	bool operator == ( const OldTLogConf& rhs ) const {

--- a/fdbserver/LogSystemConfig.h
+++ b/fdbserver/LogSystemConfig.h
@@ -79,6 +79,7 @@ struct serializable_traits<OptionalInterface<Interface>> : std::true_type {
 
 
 struct TLogSet {
+	constexpr static FileIdentifier file_identifier = 6302317;
 	std::vector<OptionalInterface<TLogInterface>> tLogs;
 	std::vector<OptionalInterface<TLogInterface>> logRouters;
 	int32_t tLogWriteAntiQuorum, tLogReplicationFactor;
@@ -136,17 +137,23 @@ struct TLogSet {
 
 	template <class Ar>
 	void serialize( Ar& ar ) {
-		serializer(ar, tLogs, logRouters, tLogWriteAntiQuorum, tLogReplicationFactor, tLogPolicy, tLogLocalities, isLocal, locality, startVersion, satelliteTagLocations);
-		if (ar.isDeserializing && ar.protocolVersion() < 0x0FDB00B061030001LL) {
-			tLogVersion = TLogVersion::V2;
+		if constexpr (is_fb_function<Ar>) {
+			serializer(ar, tLogs, logRouters, tLogWriteAntiQuorum, tLogReplicationFactor, tLogPolicy, tLogLocalities,
+			           isLocal, locality, startVersion, satelliteTagLocations, tLogVersion);
 		} else {
-			serializer(ar, tLogVersion);
+			serializer(ar, tLogs, logRouters, tLogWriteAntiQuorum, tLogReplicationFactor, tLogPolicy, tLogLocalities, isLocal, locality, startVersion, satelliteTagLocations);
+			if (ar.isDeserializing && ar.protocolVersion() < 0x0FDB00B061030001LL) {
+				tLogVersion = TLogVersion::V2;
+			} else {
+				serializer(ar, tLogVersion);
+			}
+			ASSERT(tLogPolicy.getPtr() == nullptr || tLogVersion != TLogVersion::UNSET);
 		}
-		ASSERT(tLogPolicy.getPtr() == nullptr || tLogVersion != TLogVersion::UNSET);
 	}
 };
 
 struct OldTLogConf {
+	constexpr static FileIdentifier file_identifier = 16233772;
 	std::vector<TLogSet> tLogs;
 	Version epochEnd;
 	int32_t logRouterTags;
@@ -188,6 +195,7 @@ enum class LogSystemType {
 BINARY_SERIALIZABLE(LogSystemType);
 
 struct LogSystemConfig {
+	constexpr static FileIdentifier file_identifier = 16360847;
 	LogSystemType logSystemType;
 	std::vector<TLogSet> tLogs;
 	int32_t logRouterTags;

--- a/fdbserver/MasterInterface.h
+++ b/fdbserver/MasterInterface.h
@@ -31,6 +31,7 @@
 typedef uint64_t DBRecoveryCount;
 
 struct MasterInterface {
+	constexpr static FileIdentifier file_identifier = 5979145;
 	LocalityData locality;
 	RequestStream< ReplyPromise<Void> > waitFailure;
 	RequestStream< struct TLogRejoinRequest > tlogRejoin; // sent by tlog (whether or not rebooted) to communicate with a new master
@@ -54,6 +55,7 @@ struct MasterInterface {
 };
 
 struct TLogRejoinRequest {
+	constexpr static FileIdentifier file_identifier = 15692200;
 	TLogInterface myInterface;
 	ReplyPromise<bool> reply;   // false means someone else registered, so we should re-register.  true means this master is recovered, so don't send again to the same master.
 
@@ -66,6 +68,7 @@ struct TLogRejoinRequest {
 };
 
 struct ChangeCoordinatorsRequest {
+	constexpr static FileIdentifier file_identifier = 13605416;
 	Standalone<StringRef> newConnectionString;
 	ReplyPromise<Void> reply;  // normally throws even on success!
 
@@ -79,6 +82,7 @@ struct ChangeCoordinatorsRequest {
 };
 
 struct ResolverMoveRef {
+	constexpr static FileIdentifier file_identifier = 11945475;
 	KeyRangeRef range;
 	int dest;
 
@@ -104,6 +108,7 @@ struct ResolverMoveRef {
 };
 
 struct GetCommitVersionReply {
+	constexpr static FileIdentifier file_identifier = 3568822;
 	Standalone<VectorRef<ResolverMoveRef>> resolverChanges;
 	Version resolverChangesVersion;
 	Version version;
@@ -120,6 +125,7 @@ struct GetCommitVersionReply {
 };
 
 struct GetCommitVersionRequest {
+	constexpr static FileIdentifier file_identifier = 16683181;
 	uint64_t requestNum;
 	uint64_t mostRecentProcessedRequestNum;
 	UID requestingProxy;

--- a/fdbserver/MasterInterface.h
+++ b/fdbserver/MasterInterface.h
@@ -42,7 +42,9 @@ struct MasterInterface {
 	UID id() const { return changeCoordinators.getEndpoint().token; }
 	template <class Archive>
 	void serialize(Archive& ar) {
-		ASSERT( ar.protocolVersion() >= 0x0FDB00A200040001LL );
+		if constexpr (!is_fb_function<Archive>) {
+                ASSERT( ar.protocolVersion() >= 0x0FDB00A200040001LL );
+        }
 		serializer(ar, locality, waitFailure, tlogRejoin, changeCoordinators, getCommitVersion);
 	}
 

--- a/fdbserver/NetworkTest.h
+++ b/fdbserver/NetworkTest.h
@@ -24,6 +24,7 @@
 
 #include "fdbclient/FDBTypes.h"
 #include "fdbrpc/fdbrpc.h"
+#include "flow/FileIdentifier.h"
 
 struct NetworkTestInterface {
 	RequestStream< struct NetworkTestRequest > test;
@@ -33,6 +34,7 @@ struct NetworkTestInterface {
 };
 
 struct NetworkTestRequest {
+	constexpr static FileIdentifier file_identifier = 4146513;
 	Key key;
 	uint32_t replySize;
 	ReplyPromise<struct NetworkTestReply> reply;
@@ -45,6 +47,7 @@ struct NetworkTestRequest {
 };
 
 struct NetworkTestReply {
+	constexpr static FileIdentifier file_identifier = 14465374;
 	Value value;
 	NetworkTestReply() {}
 	NetworkTestReply( Value value ) : value(value) {}

--- a/fdbserver/NetworkTest.h
+++ b/fdbserver/NetworkTest.h
@@ -33,6 +33,17 @@ struct NetworkTestInterface {
 	NetworkTestInterface( INetwork* local );
 };
 
+struct NetworkTestReply {
+	constexpr static FileIdentifier file_identifier = 14465374;
+	Value value;
+	NetworkTestReply() {}
+	NetworkTestReply( Value value ) : value(value) {}
+	template <class Ar>
+	void serialize(Ar& ar) {
+		serializer(ar, value);
+	}
+};
+
 struct NetworkTestRequest {
 	constexpr static FileIdentifier file_identifier = 4146513;
 	Key key;
@@ -43,17 +54,6 @@ struct NetworkTestRequest {
 	template <class Ar>
 	void serialize(Ar& ar) {
 		serializer(ar, key, replySize, reply);
-	}
-};
-
-struct NetworkTestReply {
-	constexpr static FileIdentifier file_identifier = 14465374;
-	Value value;
-	NetworkTestReply() {}
-	NetworkTestReply( Value value ) : value(value) {}
-	template <class Ar>
-	void serialize(Ar& ar) {
-		serializer(ar, value);
 	}
 };
 

--- a/fdbserver/RatekeeperInterface.h
+++ b/fdbserver/RatekeeperInterface.h
@@ -26,6 +26,7 @@
 #include "fdbrpc/Locality.h"
 
 struct RatekeeperInterface {
+	constexpr static FileIdentifier file_identifier = 5983305;
 	RequestStream<ReplyPromise<Void>> waitFailure;
 	RequestStream<struct GetRateInfoRequest> getRateInfo;
 	RequestStream<struct HaltRatekeeperRequest> haltRatekeeper;
@@ -52,6 +53,7 @@ struct RatekeeperInterface {
 };
 
 struct GetRateInfoRequest {
+	constexpr static FileIdentifier file_identifier = 9068521;
 	UID requesterID;
 	int64_t totalReleasedTransactions;
 	int64_t batchReleasedTransactions;
@@ -69,6 +71,7 @@ struct GetRateInfoRequest {
 };
 
 struct GetRateInfoReply {
+	constexpr static FileIdentifier file_identifier = 7845006;
 	double transactionRate;
 	double batchTransactionRate;
 	double leaseDuration;
@@ -81,6 +84,7 @@ struct GetRateInfoReply {
 };
 
 struct HaltRatekeeperRequest {
+	constexpr static FileIdentifier file_identifier = 6997218;
 	UID requesterID;
 	ReplyPromise<Void> reply;
 

--- a/fdbserver/RatekeeperInterface.h
+++ b/fdbserver/RatekeeperInterface.h
@@ -52,6 +52,19 @@ struct RatekeeperInterface {
 	}
 };
 
+struct GetRateInfoReply {
+	constexpr static FileIdentifier file_identifier = 7845006;
+	double transactionRate;
+	double batchTransactionRate;
+	double leaseDuration;
+	HealthMetrics healthMetrics;
+
+	template <class Ar>
+	void serialize(Ar& ar) {
+		serializer(ar, transactionRate, batchTransactionRate, leaseDuration, healthMetrics);
+	}
+};
+
 struct GetRateInfoRequest {
 	constexpr static FileIdentifier file_identifier = 9068521;
 	UID requesterID;
@@ -67,19 +80,6 @@ struct GetRateInfoRequest {
 	template <class Ar>
 	void serialize(Ar& ar) {
 		serializer(ar, requesterID, totalReleasedTransactions, batchReleasedTransactions, detailed, reply);
-	}
-};
-
-struct GetRateInfoReply {
-	constexpr static FileIdentifier file_identifier = 7845006;
-	double transactionRate;
-	double batchTransactionRate;
-	double leaseDuration;
-	HealthMetrics healthMetrics;
-
-	template <class Ar>
-	void serialize(Ar& ar) {
-		serializer(ar, transactionRate, batchTransactionRate, leaseDuration, healthMetrics);
 	}
 };
 

--- a/fdbserver/ResolverInterface.h
+++ b/fdbserver/ResolverInterface.h
@@ -25,6 +25,7 @@
 #include "fdbclient/FDBTypes.h"
 
 struct ResolverInterface {
+	constexpr static FileIdentifier file_identifier = 1755944;
 	enum { LocationAwareLoadBalance = 1 };
 	enum { AlwaysFresh = 1 };
 
@@ -54,6 +55,7 @@ struct ResolverInterface {
 };
 
 struct StateTransactionRef {
+	constexpr static FileIdentifier file_identifier = 6150271;
 	StateTransactionRef() {}
 	StateTransactionRef(const bool committed, VectorRef<MutationRef> const& mutations) : committed(committed), mutations(mutations) {}
 	StateTransactionRef(Arena &p, const StateTransactionRef &toCopy) : committed(toCopy.committed), mutations(p, toCopy.mutations) {}
@@ -70,6 +72,7 @@ struct StateTransactionRef {
 };
 
 struct ResolveTransactionBatchReply {
+	constexpr static FileIdentifier file_identifier = 15472264;
 	Arena arena;
 	VectorRef<uint8_t> committed;
 	Optional<UID> debugID;
@@ -83,6 +86,7 @@ struct ResolveTransactionBatchReply {
 };
 
 struct ResolveTransactionBatchRequest {
+	constexpr static FileIdentifier file_identifier = 16462858;
 	Arena arena;
 
 	Version prevVersion;
@@ -100,6 +104,7 @@ struct ResolveTransactionBatchRequest {
 };
 
 struct ResolutionMetricsRequest {
+	constexpr static FileIdentifier file_identifier = 11663527;
 	ReplyPromise<int64_t> reply;
 
 	template <class Archive>
@@ -109,6 +114,7 @@ struct ResolutionMetricsRequest {
 };
 
 struct ResolutionSplitReply {
+	constexpr static FileIdentifier file_identifier = 12137765;
 	Key key;
 	int64_t used;
 	template <class Archive>
@@ -119,6 +125,7 @@ struct ResolutionSplitReply {
 };
 
 struct ResolutionSplitRequest {
+	constexpr static FileIdentifier file_identifier = 167535;
 	KeyRange range;
 	int64_t offset;
 	bool front;

--- a/fdbserver/RestoreInterface.h
+++ b/fdbserver/RestoreInterface.h
@@ -28,6 +28,7 @@
 #include "fdbrpc/Locality.h"
 
 struct RestoreInterface {
+	constexpr static FileIdentifier file_identifier = 13398189;
 	RequestStream< struct TestRequest > test;
 
 	bool operator == (RestoreInterface const& r) const { return id() == r.id(); }
@@ -46,6 +47,7 @@ struct RestoreInterface {
 };
 
 struct TestRequest {
+	constexpr static FileIdentifier file_identifier = 14404487;
 	int testData;
 	ReplyPromise< struct TestReply > reply;
 
@@ -59,6 +61,7 @@ struct TestRequest {
 };
 
 struct TestReply {
+	constexpr static FileIdentifier file_identifier = 12075719;
 	int replyData;
 
 	TestReply() : replyData(0) {}

--- a/fdbserver/RestoreInterface.h
+++ b/fdbserver/RestoreInterface.h
@@ -46,6 +46,19 @@ struct RestoreInterface {
 	}
 };
 
+struct TestReply {
+	constexpr static FileIdentifier file_identifier = 12075719;
+	int replyData;
+
+	TestReply() : replyData(0) {}
+	explicit TestReply(int replyData) : replyData(replyData) {}
+
+	template <class Ar>
+	void serialize(Ar& ar) {
+		serializer(ar, replyData);
+	}
+};
+
 struct TestRequest {
 	constexpr static FileIdentifier file_identifier = 14404487;
 	int testData;
@@ -57,19 +70,6 @@ struct TestRequest {
 	template <class Ar>
 	void serialize(Ar& ar) {
 		serializer(ar, testData, reply);
-	}
-};
-
-struct TestReply {
-	constexpr static FileIdentifier file_identifier = 12075719;
-	int replyData;
-
-	TestReply() : replyData(0) {}
-	explicit TestReply(int replyData) : replyData(replyData) {}
-
-	template <class Ar>
-	void serialize(Ar& ar) {
-		serializer(ar, replyData);
 	}
 };
 

--- a/fdbserver/ServerDBInfo.h
+++ b/fdbserver/ServerDBInfo.h
@@ -31,6 +31,7 @@
 #include "fdbserver/LatencyBandConfig.h"
 
 struct ServerDBInfo {
+	constexpr static FileIdentifier file_identifier = 13838807;
 	// This structure contains transient information which is broadcast to all workers for a database,
 	// permitting them to communicate with each other.  It is not available to the client.  This mechanism
 	// (see GetServerDBInfoRequest) is closely parallel to OpenDatabaseRequest for the client.

--- a/fdbserver/ServerDBInfo.h
+++ b/fdbserver/ServerDBInfo.h
@@ -62,4 +62,17 @@ struct ServerDBInfo {
 	}
 };
 
+struct GetServerDBInfoRequest {
+	constexpr static FileIdentifier file_identifier = 9467438;
+	UID knownServerInfoID;
+	Standalone<VectorRef<StringRef>> issues;
+	std::vector<NetworkAddress> incompatiblePeers;
+	ReplyPromise< struct ServerDBInfo > reply;
+
+	template <class Ar>
+	void serialize(Ar& ar) {
+		serializer(ar, knownServerInfoID, issues, incompatiblePeers, reply);
+	}
+};
+
 #endif

--- a/fdbserver/SimulatedCluster.actor.cpp
+++ b/fdbserver/SimulatedCluster.actor.cpp
@@ -411,7 +411,7 @@ ACTOR Future<Void> simulatedMachine(ClusterConnectionString connStr, std::vector
 				std::string path = joinPath(myFolders[i], "fdb.cluster");
 				Reference<ClusterConnectionFile> clusterFile(useSeedFile ? new ClusterConnectionFile(path, connStr.toString()) : new ClusterConnectionFile(path));
 				const int listenPort = i*listenPerProcess + 1;
-				processes.push_back(simulatedFDBDRebooter(clusterFile, ips[i], sslEnabled, tlsOptions, listenPort, listenPerProcess, localities, processClass, &myFolders[i], &coordFolders[i], baseFolder, connStr, useSeedFile, runBackupAgents, useObjectSerializer));
+				processes.push_back(simulatedFDBDRebooter(clusterFile, ips[i], sslEnabled, tlsOptions, listenPort, listenPerProcess, localities, processClass, &myFolders[i], &coordFolders[i], baseFolder, connStr, useSeedFile, runBackupAgents, objSerializer));
 				TraceEvent("SimulatedMachineProcess", randomId).detail("Address", NetworkAddress(ips[i], listenPort, true, false)).detail("ZoneId", localities.zoneId()).detail("DataHall", localities.dataHallId()).detail("Folder", myFolders[i]);
 			}
 

--- a/fdbserver/SimulatedCluster.h
+++ b/fdbserver/SimulatedCluster.h
@@ -24,6 +24,6 @@
 #define FDBSERVER_SIMULATEDCLUSTER_H
 #pragma once
 
-void setupAndRun(std::string const& dataFolder, const char* const& testFile, bool const& rebooting, Reference<TLSOptions> const& useSSL);
+void setupAndRun(std::string const& dataFolder, const char* const& testFile, bool const& rebooting, Reference<TLSOptions> const& useSSL, int const& useObjectSerializer);
 
 #endif

--- a/fdbserver/SimulatedCluster.h
+++ b/fdbserver/SimulatedCluster.h
@@ -24,6 +24,6 @@
 #define FDBSERVER_SIMULATEDCLUSTER_H
 #pragma once
 
-void setupAndRun(std::string const& dataFolder, const char* const& testFile, bool const& rebooting, Reference<TLSOptions> const& useSSL, int const& useObjectSerializer);
+void setupAndRun(std::string const& dataFolder, const char* const& testFile, bool const& rebooting, Reference<TLSOptions> const& useSSL);
 
 #endif

--- a/fdbserver/TLogInterface.h
+++ b/fdbserver/TLogInterface.h
@@ -29,6 +29,7 @@
 #include <iterator>
 
 struct TLogInterface {
+	constexpr static FileIdentifier file_identifier = 16308510;
 	enum { LocationAwareLoadBalance = 1 };
 	enum { AlwaysFresh = 1 };
 
@@ -71,6 +72,7 @@ struct TLogInterface {
 };
 
 struct TLogRecoveryFinishedRequest {
+	constexpr static FileIdentifier file_identifier = 8818668;
 	ReplyPromise<Void> reply;
 
 	TLogRecoveryFinishedRequest() {}
@@ -82,6 +84,7 @@ struct TLogRecoveryFinishedRequest {
 };
 
 struct TLogLockResult {
+	constexpr static FileIdentifier file_identifier = 11822027;
 	Version end;
 	Version knownCommittedVersion;
 
@@ -92,6 +95,7 @@ struct TLogLockResult {
 };
 
 struct TLogConfirmRunningRequest {
+	constexpr static FileIdentifier file_identifier = 10929130;
 	Optional<UID> debugID;
 	ReplyPromise<Void> reply;
 
@@ -136,6 +140,7 @@ struct VerUpdateRef {
 };
 
 struct TLogPeekReply {
+	constexpr static FileIdentifier file_identifier = 11365689;
 	Arena arena;
 	StringRef messages;
 	Version end;
@@ -151,6 +156,7 @@ struct TLogPeekReply {
 };
 
 struct TLogPeekRequest {
+	constexpr static FileIdentifier file_identifier = 11001131;
 	Arena arena;
 	Version begin;
 	Tag tag;
@@ -168,6 +174,7 @@ struct TLogPeekRequest {
 };
 
 struct TLogPopRequest {
+	constexpr static FileIdentifier file_identifier = 5556423;
 	Arena arena;
 	Version to;
 	Version durableKnownCommittedVersion;
@@ -201,6 +208,7 @@ struct TagMessagesRef {
 };
 
 struct TLogCommitRequest {
+	constexpr static FileIdentifier file_identifier = 4022206;
 	Arena arena;
 	Version prevVersion, version, knownCommittedVersion, minKnownCommittedVersion;
 
@@ -219,6 +227,7 @@ struct TLogCommitRequest {
 };
 
 struct TLogQueuingMetricsRequest {
+	constexpr static FileIdentifier file_identifier = 7798476;
 	ReplyPromise<struct TLogQueuingMetricsReply> reply;
 
 	template <class Ar>
@@ -228,6 +237,7 @@ struct TLogQueuingMetricsRequest {
 };
 
 struct TLogQueuingMetricsReply {
+	constexpr static FileIdentifier file_identifier = 12206626;
 	double localTime;
 	int64_t instanceID;  // changes if bytesDurable and bytesInput reset
 	int64_t bytesDurable, bytesInput;

--- a/fdbserver/TLogInterface.h
+++ b/fdbserver/TLogInterface.h
@@ -65,7 +65,9 @@ struct TLogInterface {
 
 	template <class Ar> 
 	void serialize( Ar& ar ) {
-		ASSERT(ar.isDeserializing || uniqueID != UID());
+		if constexpr (!is_fb_function<Ar>) {
+			ASSERT(ar.isDeserializing || uniqueID != UID());
+		}
 		serializer(ar, uniqueID, sharedTLogID, locality, peekMessages, popMessages
 		  , commit, lock, getQueuingMetrics, confirmRunning, waitFailure, recoveryFinished);
 	}

--- a/fdbserver/TLogInterface.h
+++ b/fdbserver/TLogInterface.h
@@ -228,16 +228,6 @@ struct TLogCommitRequest {
 	}
 };
 
-struct TLogQueuingMetricsRequest {
-	constexpr static FileIdentifier file_identifier = 7798476;
-	ReplyPromise<struct TLogQueuingMetricsReply> reply;
-
-	template <class Ar>
-	void serialize(Ar& ar) {
-		serializer(ar, reply);
-	}
-};
-
 struct TLogQueuingMetricsReply {
 	constexpr static FileIdentifier file_identifier = 12206626;
 	double localTime;
@@ -249,6 +239,16 @@ struct TLogQueuingMetricsReply {
 	template <class Ar>
 	void serialize(Ar& ar) {
 		serializer(ar, localTime, instanceID, bytesDurable, bytesInput, storageBytes, v);
+	}
+};
+
+struct TLogQueuingMetricsRequest {
+	constexpr static FileIdentifier file_identifier = 7798476;
+	ReplyPromise<struct TLogQueuingMetricsReply> reply;
+
+	template <class Ar>
+	void serialize(Ar& ar) {
+		serializer(ar, reply);
 	}
 };
 

--- a/fdbserver/TesterInterface.actor.h
+++ b/fdbserver/TesterInterface.actor.h
@@ -33,6 +33,7 @@
 #include "flow/actorcompiler.h" // has to be last include
 
 struct WorkloadInterface {
+	constexpr static FileIdentifier file_identifier = 4454551;
 	RequestStream<ReplyPromise<Void>> setup;
 	RequestStream<ReplyPromise<Void>> start;
 	RequestStream<ReplyPromise<bool>> check;
@@ -48,6 +49,7 @@ struct WorkloadInterface {
 };
 
 struct WorkloadRequest {
+	constexpr static FileIdentifier file_identifier = 8121024;
 	Arena arena;
 	StringRef title;
 	int timeout;
@@ -79,6 +81,7 @@ struct WorkloadRequest {
 };
 
 struct TesterInterface {
+	constexpr static FileIdentifier file_identifier = 4465210;
 	RequestStream<WorkloadRequest> recruitments;
 
 	UID id() const { return recruitments.getEndpoint().token; }

--- a/fdbserver/WorkerInterface.actor.h
+++ b/fdbserver/WorkerInterface.actor.h
@@ -41,6 +41,7 @@
 #define DUMPTOKEN( name ) TraceEvent("DumpToken", recruited.id()).detail("Name", #name).detail("Token", name.getEndpoint().token)
 
 struct WorkerInterface {
+	constexpr static FileIdentifier file_identifier = 14712718;
 	ClientWorkerInterface clientInterface;
 	LocalityData locality;
 	RequestStream< struct InitializeTLogRequest > tLog;
@@ -89,6 +90,7 @@ struct WorkerDetails {
 };
 
 struct InitializeTLogRequest {
+	constexpr static FileIdentifier file_identifier = 15604392;
 	UID recruitmentID;
 	LogSystemConfig recoverFrom;
 	Version recoverAt;
@@ -116,6 +118,7 @@ struct InitializeTLogRequest {
 };
 
 struct InitializeLogRouterRequest {
+	constexpr static FileIdentifier file_identifier = 2976228;
 	uint64_t recoveryCount;
 	Tag routerTag;
 	Version startVersion;
@@ -132,6 +135,7 @@ struct InitializeLogRouterRequest {
 
 // FIXME: Rename to InitializeMasterRequest, etc
 struct RecruitMasterRequest {
+	constexpr static FileIdentifier file_identifier = 12684574;
 	Arena arena;
 	LifetimeToken lifetime;
 	bool forceRecovery;
@@ -147,6 +151,7 @@ struct RecruitMasterRequest {
 };
 
 struct InitializeMasterProxyRequest {
+	constexpr static FileIdentifier file_identifier = 10344153;
 	MasterInterface master;
 	uint64_t recoveryCount;
 	Version recoveryTransactionVersion;
@@ -184,6 +189,7 @@ struct InitializeRatekeeperRequest {
 };
 
 struct InitializeResolverRequest {
+	constexpr static FileIdentifier file_identifier = 7413317;
 	uint64_t recoveryCount;
 	int proxyCount;
 	int resolverCount;
@@ -196,6 +202,7 @@ struct InitializeResolverRequest {
 };
 
 struct InitializeStorageReply {
+	constexpr static FileIdentifier file_identifier = 10390645;
 	StorageServerInterface interf;
 	Version addedVersion;
 
@@ -206,6 +213,7 @@ struct InitializeStorageReply {
 };
 
 struct InitializeStorageRequest {
+	constexpr static FileIdentifier file_identifier = 16665642;
 	Tag seedTag;									//< If this server will be passed to seedShardServers, this will be a tag, otherwise it is invalidTag
 	UID reqId;
 	UID interfaceId;
@@ -219,6 +227,7 @@ struct InitializeStorageRequest {
 };
 
 struct TraceBatchDumpRequest {
+	constexpr static FileIdentifier file_identifier = 8184121;
 	ReplyPromise<Void> reply;
 
 	template <class Ar>
@@ -228,6 +237,7 @@ struct TraceBatchDumpRequest {
 };
 
 struct LoadedReply {
+	constexpr static FileIdentifier file_identifier = 9956350;
 	Standalone<StringRef> payload;
 	UID id;
 
@@ -238,6 +248,7 @@ struct LoadedReply {
 };
 
 struct LoadedPingRequest {
+	constexpr static FileIdentifier file_identifier = 4590979;
 	UID id;
 	bool loadReply;
 	Standalone<StringRef> payload;
@@ -250,6 +261,7 @@ struct LoadedPingRequest {
 };
 
 struct CoordinationPingMessage {
+	constexpr static FileIdentifier file_identifier = 9982747;
 	UID clusterControllerId;
 	int64_t timeStep;
 
@@ -263,6 +275,7 @@ struct CoordinationPingMessage {
 };
 
 struct SetMetricsLogRateRequest {
+	constexpr static FileIdentifier file_identifier = 4245995;
 	uint32_t metricsLogsPerSecond;
 
 	SetMetricsLogRateRequest() : metricsLogsPerSecond( 1 ) {}
@@ -275,6 +288,7 @@ struct SetMetricsLogRateRequest {
 };
 
 struct EventLogRequest {
+	constexpr static FileIdentifier file_identifier = 122319;
 	bool getLastError;
 	Standalone<StringRef> eventName;
 	ReplyPromise< TraceEventFields > reply;
@@ -309,6 +323,7 @@ struct DebugEntryRef {
 };
 
 struct DiskStoreRequest {
+	constexpr static FileIdentifier file_identifier = 1986262;
 	bool includePartialStores;
 	ReplyPromise<Standalone<VectorRef<UID>>> reply;
 

--- a/fdbserver/WorkerInterface.actor.h
+++ b/fdbserver/WorkerInterface.actor.h
@@ -139,7 +139,9 @@ struct RecruitMasterRequest {
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		ASSERT( ar.protocolVersion() >= 0x0FDB00A200040001LL );
+		if constexpr (!is_fb_function<Ar>) {
+			ASSERT(ar.protocolVersion() >= 0x0FDB00A200040001LL);
+		}
 		serializer(ar, lifetime, forceRecovery, reply, arena);
 	}
 };

--- a/fdbserver/WorkerInterface.actor.h
+++ b/fdbserver/WorkerInterface.actor.h
@@ -76,6 +76,7 @@ struct WorkerInterface {
 };
 
 struct WorkerDetails {
+	constexpr static FileIdentifier file_identifier = 9973980;
 	WorkerInterface interf;
 	ProcessClass processClass;
 	bool degraded;
@@ -178,6 +179,7 @@ struct InitializeDataDistributorRequest {
 };
 
 struct InitializeRatekeeperRequest {
+	constexpr static FileIdentifier file_identifier = 6416816;
 	UID reqId;
 	ReplyPromise<RatekeeperInterface> reply;
 

--- a/fdbserver/WorkerInterface.actor.h
+++ b/fdbserver/WorkerInterface.actor.h
@@ -165,6 +165,7 @@ struct InitializeMasterProxyRequest {
 };
 
 struct InitializeDataDistributorRequest {
+	constexpr static FileIdentifier file_identifier = 8858952;
 	UID reqId;
 	ReplyPromise<DataDistributorInterface> reply;
 

--- a/fdbserver/fdbserver.actor.cpp
+++ b/fdbserver/fdbserver.actor.cpp
@@ -79,82 +79,84 @@
 
 enum {
 	OPT_CONNFILE, OPT_SEEDCONNFILE, OPT_SEEDCONNSTRING, OPT_ROLE, OPT_LISTEN, OPT_PUBLICADDR, OPT_DATAFOLDER, OPT_LOGFOLDER, OPT_PARENTPID, OPT_NEWCONSOLE, OPT_NOBOX, OPT_TESTFILE, OPT_RESTARTING, OPT_RANDOMSEED, OPT_KEY, OPT_MEMLIMIT, OPT_STORAGEMEMLIMIT, OPT_MACHINEID, OPT_DCID, OPT_MACHINE_CLASS, OPT_BUGGIFY, OPT_VERSION, OPT_CRASHONERROR, OPT_HELP, OPT_NETWORKIMPL, OPT_NOBUFSTDOUT, OPT_BUFSTDOUTERR, OPT_TRACECLOCK, OPT_NUMTESTERS, OPT_DEVHELP, OPT_ROLLSIZE, OPT_MAXLOGS, OPT_MAXLOGSSIZE, OPT_KNOB, OPT_TESTSERVERS, OPT_TEST_ON_SERVERS, OPT_METRICSCONNFILE, OPT_METRICSPREFIX,
-	OPT_LOGGROUP, OPT_LOCALITY, OPT_IO_TRUST_SECONDS, OPT_IO_TRUST_WARN_ONLY, OPT_FILESYSTEM, OPT_PROFILER_RSS_SIZE, OPT_KVFILE, OPT_TRACE_FORMAT };
+	OPT_LOGGROUP, OPT_LOCALITY, OPT_IO_TRUST_SECONDS, OPT_IO_TRUST_WARN_ONLY, OPT_FILESYSTEM, OPT_PROFILER_RSS_SIZE, OPT_KVFILE, OPT_TRACE_FORMAT, OPT_USE_OBJECT_SERIALIZER };
 
 CSimpleOpt::SOption g_rgOptions[] = {
-	{ OPT_CONNFILE,             "-C",                          SO_REQ_SEP },
-	{ OPT_CONNFILE,             "--cluster_file",              SO_REQ_SEP },
-	{ OPT_SEEDCONNFILE,         "--seed_cluster_file",         SO_REQ_SEP },
-	{ OPT_SEEDCONNSTRING,       "--seed_connection_string",    SO_REQ_SEP },
-	{ OPT_ROLE,                 "-r",                          SO_REQ_SEP },
-	{ OPT_ROLE,                 "--role",                      SO_REQ_SEP },
-	{ OPT_PUBLICADDR,           "-p",                          SO_REQ_SEP },
-	{ OPT_PUBLICADDR,           "--public_address",            SO_REQ_SEP },
-	{ OPT_LISTEN,               "-l",                          SO_REQ_SEP },
-	{ OPT_LISTEN,               "--listen_address",            SO_REQ_SEP },
+	{ OPT_CONNFILE,              "-C",                          SO_REQ_SEP },
+	{ OPT_CONNFILE,              "--cluster_file",              SO_REQ_SEP },
+	{ OPT_SEEDCONNFILE,          "--seed_cluster_file",         SO_REQ_SEP },
+	{ OPT_SEEDCONNSTRING,        "--seed_connection_string",    SO_REQ_SEP },
+	{ OPT_ROLE,                  "-r",                          SO_REQ_SEP },
+	{ OPT_ROLE,                  "--role",                      SO_REQ_SEP },
+	{ OPT_PUBLICADDR,            "-p",                          SO_REQ_SEP },
+	{ OPT_PUBLICADDR,            "--public_address",            SO_REQ_SEP },
+	{ OPT_LISTEN,                "-l",                          SO_REQ_SEP },
+	{ OPT_LISTEN,                "--listen_address",            SO_REQ_SEP },
 #ifdef __linux__
 	{ OPT_FILESYSTEM,           "--data_filesystem",           SO_REQ_SEP },
 	{ OPT_PROFILER_RSS_SIZE,    "--rsssize",                   SO_REQ_SEP },
 #endif
-	{ OPT_DATAFOLDER,           "-d",                          SO_REQ_SEP },
-	{ OPT_DATAFOLDER,           "--datadir",                   SO_REQ_SEP },
-	{ OPT_LOGFOLDER,            "-L",                          SO_REQ_SEP },
-	{ OPT_LOGFOLDER,            "--logdir",                    SO_REQ_SEP },
-	{ OPT_ROLLSIZE,             "-Rs",                         SO_REQ_SEP },
-	{ OPT_ROLLSIZE,             "--logsize",                   SO_REQ_SEP },
-	{ OPT_MAXLOGS,              "--maxlogs",                   SO_REQ_SEP },
-	{ OPT_MAXLOGSSIZE,          "--maxlogssize",               SO_REQ_SEP },
-	{ OPT_LOGGROUP,             "--loggroup",                  SO_REQ_SEP },
+	{ OPT_DATAFOLDER,            "-d",                          SO_REQ_SEP },
+	{ OPT_DATAFOLDER,            "--datadir",                   SO_REQ_SEP },
+	{ OPT_LOGFOLDER,             "-L",                          SO_REQ_SEP },
+	{ OPT_LOGFOLDER,             "--logdir",                    SO_REQ_SEP },
+	{ OPT_ROLLSIZE,              "-Rs",                         SO_REQ_SEP },
+	{ OPT_ROLLSIZE,              "--logsize",                   SO_REQ_SEP },
+	{ OPT_MAXLOGS,               "--maxlogs",                   SO_REQ_SEP },
+	{ OPT_MAXLOGSSIZE,           "--maxlogssize",               SO_REQ_SEP },
+	{ OPT_LOGGROUP,              "--loggroup",                  SO_REQ_SEP },
 #ifdef _WIN32
-	{ OPT_PARENTPID,            "--parentpid",                 SO_REQ_SEP },
-	{ OPT_NEWCONSOLE,           "-n",                          SO_NONE },
-	{ OPT_NEWCONSOLE,           "--newconsole",                SO_NONE },
-	{ OPT_NOBOX,                "-q",                          SO_NONE },
-	{ OPT_NOBOX,                "--no_dialog",                 SO_NONE },
+	{ OPT_PARENTPID,             "--parentpid",                 SO_REQ_SEP },
+	{ OPT_NEWCONSOLE,            "-n",                          SO_NONE },
+	{ OPT_NEWCONSOLE,            "--newconsole",                SO_NONE },
+	{ OPT_NOBOX,                 "-q",                          SO_NONE },
+	{ OPT_NOBOX,                 "--no_dialog",                 SO_NONE },
 #endif
-	{ OPT_KVFILE,               "--kvfile",                    SO_REQ_SEP },
-	{ OPT_TESTFILE,             "-f",                          SO_REQ_SEP },
-	{ OPT_TESTFILE,             "--testfile",                  SO_REQ_SEP },
-	{ OPT_RESTARTING,           "-R",                          SO_NONE },
-	{ OPT_RESTARTING,           "--restarting",                SO_NONE },
-	{ OPT_RANDOMSEED,           "-s",                          SO_REQ_SEP },
-	{ OPT_RANDOMSEED,           "--seed",                      SO_REQ_SEP },
-	{ OPT_KEY,                  "-k",                          SO_REQ_SEP },
-	{ OPT_KEY,                  "--key",                       SO_REQ_SEP },
-	{ OPT_MEMLIMIT,             "-m",                          SO_REQ_SEP },
-	{ OPT_MEMLIMIT,             "--memory",                    SO_REQ_SEP },
-	{ OPT_STORAGEMEMLIMIT,      "-M",                          SO_REQ_SEP },
-	{ OPT_STORAGEMEMLIMIT,      "--storage_memory",            SO_REQ_SEP },
-	{ OPT_MACHINEID,            "-i",                          SO_REQ_SEP },
-	{ OPT_MACHINEID,            "--machine_id",                SO_REQ_SEP },
-	{ OPT_DCID,                 "-a",                          SO_REQ_SEP },
-	{ OPT_DCID,                 "--datacenter_id",             SO_REQ_SEP },
-	{ OPT_MACHINE_CLASS,        "-c",                          SO_REQ_SEP },
-	{ OPT_MACHINE_CLASS,        "--class",                     SO_REQ_SEP },
-	{ OPT_BUGGIFY,              "-b",                          SO_REQ_SEP },
-	{ OPT_BUGGIFY,              "--buggify",                   SO_REQ_SEP },
-	{ OPT_VERSION,              "-v",                          SO_NONE },
-	{ OPT_VERSION,              "--version",                   SO_NONE },
-	{ OPT_CRASHONERROR,         "--crash",                     SO_NONE },
-	{ OPT_NETWORKIMPL,          "-N",                          SO_REQ_SEP },
-	{ OPT_NETWORKIMPL,          "--network",                   SO_REQ_SEP },
-	{ OPT_NOBUFSTDOUT,          "--unbufferedout",             SO_NONE },
-	{ OPT_BUFSTDOUTERR,         "--bufferedout",               SO_NONE },
-	{ OPT_TRACECLOCK,           "--traceclock",                SO_REQ_SEP },
-	{ OPT_NUMTESTERS,           "--num_testers",               SO_REQ_SEP },
-	{ OPT_HELP,                 "-?",                          SO_NONE },
-	{ OPT_HELP,                 "-h",                          SO_NONE },
-	{ OPT_HELP,                 "--help",                      SO_NONE },
-	{ OPT_DEVHELP,              "--dev-help",                  SO_NONE },
-	{ OPT_KNOB,                 "--knob_",                     SO_REQ_SEP },
-	{ OPT_LOCALITY,             "--locality_",                 SO_REQ_SEP },
-	{ OPT_TESTSERVERS,          "--testservers",               SO_REQ_SEP },
-	{ OPT_TEST_ON_SERVERS,      "--testonservers",             SO_NONE },
-	{ OPT_METRICSCONNFILE,      "--metrics_cluster",           SO_REQ_SEP },
-	{ OPT_METRICSPREFIX,        "--metrics_prefix",            SO_REQ_SEP },
-	{ OPT_IO_TRUST_SECONDS,     "--io_trust_seconds",          SO_REQ_SEP },
-	{ OPT_IO_TRUST_WARN_ONLY,   "--io_trust_warn_only",        SO_NONE },
-	{ OPT_TRACE_FORMAT      ,   "--trace_format",              SO_REQ_SEP },
+	{ OPT_KVFILE,                "--kvfile",                    SO_REQ_SEP },
+	{ OPT_TESTFILE,              "-f",                          SO_REQ_SEP },
+	{ OPT_TESTFILE,              "--testfile",                  SO_REQ_SEP },
+	{ OPT_RESTARTING,            "-R",                          SO_NONE },
+	{ OPT_RESTARTING,            "--restarting",                SO_NONE },
+	{ OPT_RANDOMSEED,            "-s",                          SO_REQ_SEP },
+	{ OPT_RANDOMSEED,            "--seed",                      SO_REQ_SEP },
+	{ OPT_KEY,                   "-k",                          SO_REQ_SEP },
+	{ OPT_KEY,                   "--key",                       SO_REQ_SEP },
+	{ OPT_MEMLIMIT,              "-m",                          SO_REQ_SEP },
+	{ OPT_MEMLIMIT,              "--memory",                    SO_REQ_SEP },
+	{ OPT_STORAGEMEMLIMIT,       "-M",                          SO_REQ_SEP },
+	{ OPT_STORAGEMEMLIMIT,       "--storage_memory",            SO_REQ_SEP },
+	{ OPT_MACHINEID,             "-i",                          SO_REQ_SEP },
+	{ OPT_MACHINEID,             "--machine_id",                SO_REQ_SEP },
+	{ OPT_DCID,                  "-a",                          SO_REQ_SEP },
+	{ OPT_DCID,                  "--datacenter_id",             SO_REQ_SEP },
+	{ OPT_MACHINE_CLASS,         "-c",                          SO_REQ_SEP },
+	{ OPT_MACHINE_CLASS,         "--class",                     SO_REQ_SEP },
+	{ OPT_BUGGIFY,               "-b",                          SO_REQ_SEP },
+	{ OPT_BUGGIFY,               "--buggify",                   SO_REQ_SEP },
+	{ OPT_VERSION,               "-v",                          SO_NONE },
+	{ OPT_VERSION,               "--version",                   SO_NONE },
+	{ OPT_CRASHONERROR,          "--crash",                     SO_NONE },
+	{ OPT_NETWORKIMPL,           "-N",                          SO_REQ_SEP },
+	{ OPT_NETWORKIMPL,           "--network",                   SO_REQ_SEP },
+	{ OPT_NOBUFSTDOUT,           "--unbufferedout",             SO_NONE },
+	{ OPT_BUFSTDOUTERR,          "--bufferedout",               SO_NONE },
+	{ OPT_TRACECLOCK,            "--traceclock",                SO_REQ_SEP },
+	{ OPT_NUMTESTERS,            "--num_testers",               SO_REQ_SEP },
+	{ OPT_HELP,                  "-?",                          SO_NONE },
+	{ OPT_HELP,                  "-h",                          SO_NONE },
+	{ OPT_HELP,                  "--help",                      SO_NONE },
+	{ OPT_DEVHELP,               "--dev-help",                  SO_NONE },
+	{ OPT_KNOB,                  "--knob_",                     SO_REQ_SEP },
+	{ OPT_LOCALITY,              "--locality_",                 SO_REQ_SEP },
+	{ OPT_TESTSERVERS,           "--testservers",               SO_REQ_SEP },
+	{ OPT_TEST_ON_SERVERS,       "--testonservers",             SO_NONE },
+	{ OPT_METRICSCONNFILE,       "--metrics_cluster",           SO_REQ_SEP },
+	{ OPT_METRICSPREFIX,         "--metrics_prefix",            SO_REQ_SEP },
+	{ OPT_IO_TRUST_SECONDS,      "--io_trust_seconds",          SO_REQ_SEP },
+	{ OPT_IO_TRUST_WARN_ONLY,    "--io_trust_warn_only",        SO_NONE },
+	{ OPT_TRACE_FORMAT      ,    "--trace_format",              SO_REQ_SEP },
+	{ OPT_USE_OBJECT_SERIALIZER, "-S",                          SO_REQ_SEP },
+	{ OPT_USE_OBJECT_SERIALIZER, "--object-serializer",         SO_REQ_SEP },
 
 #ifndef TLS_DISABLED
 	TLS_OPTION_FLAGS
@@ -567,6 +569,11 @@ static void printUsage( const char *name, bool devhelp ) {
 		   "                 Machine class (valid options are storage, transaction,\n"
 		   "                 resolution, proxy, master, test, unset, stateless, log, router,\n"
 		   "                 and cluster_controller).\n");
+	printf("  -S %s, --object-serializer %s\n"
+		   "                 Use object serializer for sending messages. The object serializer\n"
+		   "                 is currently a beta feature and it allows fdb processes to talk to\n"
+		   "                 each other even if they don't have the same version\n",
+		   devhelp ? "ON|OFF|RANDOM" : "ON|OFF", devhelp ? "ON|OFF|RANDOM" : "ON|OFF");
 #ifndef TLS_DISABLED
 	printf(TLS_HELP);
 #endif
@@ -924,6 +931,7 @@ int main(int argc, char* argv[]) {
 		double fileIoTimeout = 0.0;
 		bool fileIoWarnOnly = false;
 		uint64_t rsssize = -1;
+		int useObjectSerializer = 0;
 
 		if( argc == 1 ) {
 			printUsage(argv[0], false);
@@ -1260,6 +1268,23 @@ int main(int argc, char* argv[]) {
 						fprintf(stderr, "WARNING: Unrecognized trace format `%s'\n", args.OptionArg());
 					}
 					break;
+				case OPT_USE_OBJECT_SERIALIZER:
+				{
+					std::string s = args.OptionArg();
+					std::transform(s.begin(), s.end(), s.begin(), ::tolower);
+					if (s == "on" || s == "true" || s == "1") {
+						useObjectSerializer = 1;
+					} else if (s == "off" || s == "false" || s == "0") {
+						useObjectSerializer = 0;
+					} else if (s == "random") {
+						useObjectSerializer = 2;
+					} else {
+						fprintf(stderr, "ERROR: Could not parse object serializer option: `%s'\n", s.c_str());
+						printHelpTeaser(argv[0]);
+						flushAndExit(FDB_EXIT_ERROR);
+					}
+					break;
+				}
 #ifndef TLS_DISABLED
 				case TLSOptions::OPT_TLS_PLUGIN:
 					args.OptionArg();
@@ -1485,7 +1510,11 @@ int main(int argc, char* argv[]) {
 			startNewSimulator();
 			openTraceFile(NetworkAddress(), rollsize, maxLogsSize, logFolder, "trace", logGroup);
 		} else {
-			g_network = newNet2(useThreadPool, true);
+			if (useObjectSerializer == 2) {
+				fprintf(stderr, "ERROR: 'random' for object serializer is only supported for simulation");
+				flushAndExit(FDB_EXIT_ERROR);
+			}
+			g_network = newNet2(useThreadPool, true, useObjectSerializer == 1);
 			FlowTransport::createInstance(1);
 
 			const bool expectsPublicAddress = (role == FDBD || role == NetworkTestServer || role == Restore);
@@ -1633,7 +1662,7 @@ int main(int argc, char* argv[]) {
 				platform::createDirectory( dataFolder );
 			}
 
-			setupAndRun( dataFolder, testFile, restarting, tlsOptions );
+			setupAndRun( dataFolder, testFile, restarting, tlsOptions, useObjectSerializer );
 			g_simulator.run();
 		} else if (role == FDBD) {
 			ASSERT( connectionFile );

--- a/fdbserver/sqlite/btree.h
+++ b/fdbserver/sqlite/btree.h
@@ -15,6 +15,9 @@
 */
 #ifndef _BTREE_H_
 #define _BTREE_H_
+#ifndef NDEBUG
+#define NDEBUG
+#endif
 
 /* TODO: This definition is just included so other modules compile. It
 ** needs to be revisited.

--- a/fdbserver/sqlite/sqlite3.amalgamation.c
+++ b/fdbserver/sqlite/sqlite3.amalgamation.c
@@ -1,4 +1,7 @@
 #ifndef NDEBUG
+#define NDEBUG
+#endif
+#ifndef NDEBUG
     #define SQLITE_DEBUG 1
 #endif
 #define SQLITE_THREADSAFE 0

--- a/fdbserver/tester.actor.cpp
+++ b/fdbserver/tester.actor.cpp
@@ -757,12 +757,16 @@ ACTOR Future<Void> checkConsistency(Database cx, std::vector< TesterInterface > 
 	}
 	
 	Standalone<VectorRef<KeyValueRef>> options;
+	StringRef performQuiescent = LiteralStringRef("false");
+	if (doQuiescentCheck) {
+		performQuiescent = LiteralStringRef("true");
+	}
 	spec.title = LiteralStringRef("ConsistencyCheck");
 	spec.databasePingDelay = databasePingDelay;
 	spec.timeout = 32000;
 	options.push_back_deep(options.arena(), KeyValueRef(LiteralStringRef("testName"), LiteralStringRef("ConsistencyCheck")));
-	options.push_back_deep(options.arena(), KeyValueRef(LiteralStringRef("performQuiescentChecks"), ValueRef(format("%s", LiteralStringRef(doQuiescentCheck ? "true" : "false").toString().c_str()))));
-	options.push_back_deep(options.arena(), KeyValueRef(LiteralStringRef("quiescentWaitTimeout"), ValueRef(format("%f", quiescentWaitTimeout))));
+	options.push_back_deep(options.arena(), KeyValueRef(LiteralStringRef("performQuiescentChecks"), performQuiescent));
+	options.push_back_deep(options.arena(), KeyValueRef(LiteralStringRef("quiescentWaitTimeout"), ValueRef(options.arena(), format("%f", quiescentWaitTimeout))));
 	options.push_back_deep(options.arena(), KeyValueRef(LiteralStringRef("distributed"), LiteralStringRef("false")));
 	spec.options.push_back_deep(spec.options.arena(), options);
 

--- a/fdbserver/workloads/JavaWorkload.actor.cpp
+++ b/fdbserver/workloads/JavaWorkload.actor.cpp
@@ -203,6 +203,7 @@ struct JVMContext {
 	bool checkException() {
 		auto flag = env->ExceptionCheck();
 		if (flag) {
+			env->ExceptionOccurred();
 			TraceEvent(SevError, "JavaException");
 			env->ExceptionDescribe();
 			env->ExceptionClear();

--- a/fdbserver/workloads/Sideband.actor.cpp
+++ b/fdbserver/workloads/Sideband.actor.cpp
@@ -24,6 +24,7 @@
 #include "flow/actorcompiler.h"  // This must be the last #include.
 
 struct SidebandMessage {
+	constexpr static FileIdentifier file_identifier = 11862046;
 	uint64_t key;
 	Version commitVersion;
 
@@ -37,6 +38,7 @@ struct SidebandMessage {
 };
 
 struct SidebandInterface {
+	constexpr static FileIdentifier file_identifier = 15950544;
 	RequestStream<SidebandMessage> updates;
 
 	UID id() const { return updates.getEndpoint().token; }

--- a/flow/Arena.h
+++ b/flow/Arena.h
@@ -514,6 +514,7 @@ public:
 		//T tmp;
 		//ar >> tmp;
 		//*this = tmp;
+		static_assert(!is_fb_function<Archive>);
 		serializer(ar, (*(T*)this), arena());
 	}
 

--- a/flow/Arena.h
+++ b/flow/Arena.h
@@ -514,7 +514,6 @@ public:
 		//T tmp;
 		//ar >> tmp;
 		//*this = tmp;
-		static_assert(!is_fb_function<Archive>);
 		serializer(ar, (*(T*)this), arena());
 	}
 

--- a/flow/Arena.h
+++ b/flow/Arena.h
@@ -27,6 +27,7 @@
 #include "flow/Error.h"
 #include "flow/Trace.h"
 #include "flow/ObjectSerializerTraits.h"
+#include "flow/FileIdentifier.h"
 #include <algorithm>
 #include <stdint.h>
 #include <string>
@@ -512,6 +513,7 @@ extern std::string format(const char* form, ...);
 #pragma pack( push, 4 )
 class StringRef {
 public:
+	constexpr static FileIdentifier file_identifier = 13300811;
 	StringRef() : data(0), length(0) {}
 	StringRef( Arena& p, const StringRef& toCopy ) : data( new (p) uint8_t[toCopy.size()] ), length( toCopy.size() ) {
 		memcpy( (void*)data, toCopy.data, length );
@@ -778,6 +780,7 @@ template <class T>
 class VectorRef {
 public:
 	using value_type = T;
+	static constexpr FileIdentifier file_identifier = (0x8 << 24) | FileIdentifierFor<T>::value;
 
 	// T must be trivially destructible (and copyable)!
 	VectorRef() : data(0), m_size(0), m_capacity(0) {}

--- a/flow/Arena.h
+++ b/flow/Arena.h
@@ -441,9 +441,10 @@ template<class T>
 struct Traceable<Optional<T>> : std::conditional<Traceable<T>::value, std::true_type, std::false_type>::type {
 	static std::string toString(const Optional<T>& value) {
 		return value.present() ? Traceable<T>::toString(value.get()) : "[not set]";
-    }
+	}
 };
 
+template<class T>
 struct union_like_traits<Optional<T>> : std::true_type {
 	using Member = Optional<T>;
 	using alternatives = pack<T>;

--- a/flow/Arena.h
+++ b/flow/Arena.h
@@ -347,9 +347,8 @@ inline void save( Archive& ar, const Arena& p ) {
 }
 
 template <class T>
-class Optional {
+class Optional : public ComposedIdentifier<T, 0x10> {
 public:
-	static constexpr FileIdentifier file_identifier = (0x10 << 24) | FileIdentifierFor<T>::value;
 	Optional() : valid(false) {}
 	Optional(const Optional<T>& o) : valid(o.valid) {
 		if (valid) new (&value) T(o.get());
@@ -797,10 +796,9 @@ template <>
 struct memcpy_able<UID> : std::integral_constant<bool, true> {};
 
 template <class T>
-class VectorRef {
+class VectorRef : public ComposedIdentifier<T, 0x8> {
 public:
 	using value_type = T;
-	static constexpr FileIdentifier file_identifier = (0x8 << 24) | FileIdentifierFor<T>::value;
 
 	// T must be trivially destructible (and copyable)!
 	VectorRef() : data(0), m_size(0), m_capacity(0) {}

--- a/flow/CMakeLists.txt
+++ b/flow/CMakeLists.txt
@@ -63,6 +63,8 @@ set(FLOW_SRCS
   XmlTraceLogFormatter.cpp
   actorcompiler.h
   error_definitions.h
+  flat_buffers.h
+  flat_buffers.cpp
   flow.cpp
   flow.h
   genericactors.actor.cpp

--- a/flow/Error.h
+++ b/flow/Error.h
@@ -29,6 +29,7 @@
 #include <boost/preprocessor/control/if.hpp>
 #include "flow/Platform.h"
 #include "flow/Knobs.h"
+#include "flow/ObjectSerializerTraits.h"
 
 enum { invalid_error_code = 0xffff };
 

--- a/flow/Error.h
+++ b/flow/Error.h
@@ -29,6 +29,7 @@
 #include <boost/preprocessor/control/if.hpp>
 #include "flow/Platform.h"
 #include "flow/Knobs.h"
+#include "flow/FileIdentifier.h"
 #include "flow/ObjectSerializerTraits.h"
 
 enum { invalid_error_code = 0xffff };
@@ -41,6 +42,7 @@ public:
 
 class Error {
 public:
+	constexpr static FileIdentifier file_identifier = 14065384;
 	int code() const { return error_code; }
 	const char* name() const;
 	const char* what() const;

--- a/flow/FastRef.h
+++ b/flow/FastRef.h
@@ -156,6 +156,7 @@ public:
 
 	bool isValid() const { return ptr != NULL; }
 	explicit operator bool() const { return ptr != NULL; }
+	P*& changePtrUnsafe() { return ptr; }
 
 private:
 	P *ptr;

--- a/flow/FastRef.h
+++ b/flow/FastRef.h
@@ -156,7 +156,6 @@ public:
 
 	bool isValid() const { return ptr != NULL; }
 	explicit operator bool() const { return ptr != NULL; }
-	P*& changePtrUnsafe() { return ptr; }
 
 private:
 	P *ptr;

--- a/flow/FileIdentifier.h
+++ b/flow/FileIdentifier.h
@@ -1,0 +1,97 @@
+/*
+ * FileIdentifier.h
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2018 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include <cstdint>
+
+using FileIdentifier = uint32_t;
+
+template <class T>
+struct FileIdentifierFor {
+	//constexpr static FileIdentifier value = T::file_identifier;
+	// TODO: use file identifiers for different types
+	constexpr static FileIdentifier value = 0xffffff;
+};
+
+template <>
+struct FileIdentifierFor<int> {
+	constexpr static FileIdentifier value = 1;
+};
+
+template <>
+struct FileIdentifierFor<unsigned> {
+	constexpr static FileIdentifier value = 2;
+};
+
+template <>
+struct FileIdentifierFor<long> {
+	constexpr static FileIdentifier value = 3;
+};
+
+template <>
+struct FileIdentifierFor<unsigned long> {
+	constexpr static FileIdentifier value = 4;
+};
+
+template <>
+struct FileIdentifierFor<long long> {
+	constexpr static FileIdentifier value = 5;
+};
+
+template <>
+struct FileIdentifierFor<unsigned long long> {
+	constexpr static FileIdentifier value = 6;
+};
+
+template <>
+struct FileIdentifierFor<short> {
+	constexpr static FileIdentifier value = 7;
+};
+
+template <>
+struct FileIdentifierFor<unsigned short> {
+	constexpr static FileIdentifier value = 8;
+};
+
+template <>
+struct FileIdentifierFor<signed char> {
+	constexpr static FileIdentifier value = 9;
+};
+
+template <>
+struct FileIdentifierFor<unsigned char> {
+	constexpr static FileIdentifier value = 10;
+};
+
+template <>
+struct FileIdentifierFor<bool> {
+	constexpr static FileIdentifier value = 11;
+};
+
+template <>
+struct FileIdentifierFor<float> {
+	constexpr static FileIdentifier value = 7266212;
+};
+
+template <>
+struct FileIdentifierFor<double> {
+	constexpr static FileIdentifier value = 9348150;
+};
+

--- a/flow/FileIdentifier.h
+++ b/flow/FileIdentifier.h
@@ -25,9 +25,7 @@ using FileIdentifier = uint32_t;
 
 template <class T>
 struct FileIdentifierFor {
-	//constexpr static FileIdentifier value = T::file_identifier;
-	// TODO: use file identifiers for different types
-	constexpr static FileIdentifier value = 0xffffff;
+	constexpr static FileIdentifier value = T::file_identifier;
 };
 
 template <>

--- a/flow/FileIdentifier.h
+++ b/flow/FileIdentifier.h
@@ -24,11 +24,6 @@
 
 using FileIdentifier = uint32_t;
 
-template <class T>
-struct FileIdentifierOf {
-	constexpr static FileIdentifier value = T::file_identifier;
-};
-
 struct Empty {};
 
 template <typename T, typename = int>
@@ -142,4 +137,3 @@ template <>
 struct FileIdentifierFor<double> {
 	constexpr static FileIdentifier value = 9348150;
 };
-

--- a/flow/IRandom.h
+++ b/flow/IRandom.h
@@ -23,6 +23,7 @@
 #pragma once
 
 #include "flow/Platform.h"
+#include "flow/ObjectSerializerTraits.h"
 #include <stdint.h>
 #if (defined(__APPLE__))
 #include <ext/hash_map>
@@ -58,6 +59,22 @@ public:
 
 template <class Ar> void load( Ar& ar, UID& uid ) { uid.serialize_unversioned(ar); }
 template <class Ar> void save( Ar& ar, UID const& uid ) { const_cast<UID&>(uid).serialize_unversioned(ar); }
+
+template <>
+struct scalar_traits<UID> : std::true_type {
+	constexpr static size_t size = sizeof(uint64_t[2]);
+	static void save(uint8_t* out, const UID& uid) {
+		uint64_t* outI = reinterpret_cast<uint64_t*>(out);
+		outI[0] = uid.first();
+		outI[1] = uid.second();
+	}
+
+	template <class Context>
+	static void load(const uint8_t* i, UID& out, Context& context) {
+		const uint64_t* in = reinterpret_cast<const uint64_t*>(i);
+		out = UID(in[0], in[1]);
+	}
+};
 
 namespace std {
 	template <>

--- a/flow/IRandom.h
+++ b/flow/IRandom.h
@@ -23,6 +23,7 @@
 #pragma once
 
 #include "flow/Platform.h"
+#include "flow/FileIdentifier.h"
 #include "flow/ObjectSerializerTraits.h"
 #include <stdint.h>
 #if (defined(__APPLE__))
@@ -35,6 +36,7 @@
 class UID {
 	uint64_t part[2];
 public:
+	constexpr static FileIdentifier file_identifier = 15597147;
 	UID() { part[0] = part[1] = 0; }
 	UID( uint64_t a, uint64_t b ) { part[0]=a; part[1]=b; }
 	std::string toString() const;

--- a/flow/Knobs.cpp
+++ b/flow/Knobs.cpp
@@ -91,7 +91,6 @@ FlowKnobs::FlowKnobs(bool randomize, bool isSimulated) {
 	init( MAX_PRIOR_MODIFICATION_DELAY,                        1.0 ); if( randomize && BUGGIFY ) MAX_PRIOR_MODIFICATION_DELAY = 10.0;
 
 	//GenericActors
-	init( MAX_DELIVER_DUPLICATE_DELAY,                         1.0 ); if( randomize && BUGGIFY ) MAX_DELIVER_DUPLICATE_DELAY = 10.0;
 	init( BUGGIFY_FLOW_LOCK_RELEASE_DELAY,                     1.0 );
 
 	//IAsyncFile

--- a/flow/Knobs.h
+++ b/flow/Knobs.h
@@ -109,7 +109,6 @@ public:
 	double MAX_PRIOR_MODIFICATION_DELAY;
 
 	//GenericActors
-	double MAX_DELIVER_DUPLICATE_DELAY;
 	double BUGGIFY_FLOW_LOCK_RELEASE_DELAY;
 
 	//IAsyncFile

--- a/flow/Net2.actor.cpp
+++ b/flow/Net2.actor.cpp
@@ -58,6 +58,18 @@ using namespace boost::asio::ip;
 const uint64_t currentProtocolVersion        = 0x0FDB00B061070001LL;
 const uint64_t compatibleProtocolVersionMask = 0xffffffffffff0000LL;
 const uint64_t minValidProtocolVersion       = 0x0FDB00A200060001LL;
+const uint64_t objectSerializerFlag          = 0x1000000000000000LL;
+const uint64_t versionFlagMask               = 0x0FFFFFFFFFFFFFFFLL;
+
+uint64_t removeFlags(uint64_t version) {
+	return version & versionFlagMask;
+}
+uint64_t addObjectSerializerFlag(uint64_t version) {
+	return version | versionFlagMask;
+}
+bool hasObjectSerializerFlag(uint64_t version) {
+	return (version & objectSerializerFlag) > 0;
+}
 
 // This assert is intended to help prevent incrementing the leftmost digits accidentally. It will probably need to change when we reach version 10.
 static_assert(currentProtocolVersion < 0x0FDB00B100000000LL, "Unexpected protocol version");

--- a/flow/Net2.actor.cpp
+++ b/flow/Net2.actor.cpp
@@ -65,7 +65,7 @@ uint64_t removeFlags(uint64_t version) {
 	return version & versionFlagMask;
 }
 uint64_t addObjectSerializerFlag(uint64_t version) {
-	return version | versionFlagMask;
+	return version | objectSerializerFlag;
 }
 bool hasObjectSerializerFlag(uint64_t version) {
 	return (version & objectSerializerFlag) > 0;

--- a/flow/ObjectSerializer.h
+++ b/flow/ObjectSerializer.h
@@ -1,0 +1,128 @@
+/*
+ * serialize.h
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2018 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "flow/Error.h"
+#include "flow/Arena.h"
+#include "flow/flat_buffers.h"
+
+template <class Ar>
+struct LoadContext {
+	Ar& ar;
+	std::vector<std::function<void()>> doAfter;
+	LoadContext(Ar& ar) : ar(ar) {}
+	Arena& arena() { return ar.arena(); }
+
+	const uint8_t* tryReadZeroCopy(const uint8_t* ptr, unsigned len) {
+		if constexpr (Ar::ownsUnderlyingMemory) {
+			return ptr;
+		} else {
+			if (len == 0) return nullptr;
+			uint8_t* dat = new (arena()) uint8_t[len];
+			std::copy(ptr, ptr + len, dat);
+			return dat;
+		}
+	}
+
+	void done() const {
+		for (auto& f : doAfter) {
+			f();
+		}
+	}
+	void addArena(Arena& arena) { arena = ar.arena(); }
+};
+
+template <class ReaderImpl>
+class _ObjectReader {
+public:
+	template <class... Items>
+	void deserialize(flat_buffers::FileIdentifier file_identifier, Items&... items) {
+		const uint8_t* data = static_cast<ReaderImpl*>(this)->data();
+		LoadContext<ReaderImpl> context(*static_cast<ReaderImpl*>(this));
+		ASSERT(flat_buffers::read_file_identifier(data) == file_identifier);
+		flat_buffers::load_members(data, context, items...);
+		context.done();
+	}
+
+	template <class Item>
+	void deserialize(Item& item) {
+		deserialize(flat_buffers::FileIdentifierFor<Item>::value, item);
+	}
+};
+
+class ObjectReader : _ObjectReader<ObjectReader> {
+public:
+	static constexpr bool ownsUnderlyingMemory = false;
+
+	ObjectReader(const uint8_t* data) : _data(data) {}
+
+	const uint8_t* data() { return _data; }
+
+	Arena& arena() { return _arena; }
+
+private:
+	const uint8_t* _data;
+	Arena _arena;
+};
+
+class ArenaObjectReader : _ObjectReader<ArenaObjectReader> {
+public:
+	static constexpr bool ownsUnderlyingMemory = true;
+
+	ArenaObjectReader(Arena const& arena, const StringRef& input) : _data(input.begin()), _arena(arena) {}
+
+	const uint8_t* data() { return _data; }
+
+	Arena& arena() { return _arena; }
+
+private:
+	const uint8_t* _data;
+	Arena _arena;
+};
+
+class ObjectWriter {
+public:
+	template <class... Items>
+	void serialize(flat_buffers::FileIdentifier file_identifier, Items const&... items) {
+		ASSERT(data = nullptr); // object serializer can only serialize one object
+		int allocations = 0;
+		auto allocator = [this, &allocations](size_t size_) {
+			++allocations;
+			size = size_;
+			data = new uint8_t[size];
+			return data;
+		};
+		auto res = flat_buffers::save_members(allocator, file_identifier, items...);
+		ASSERT(allocations == 1);
+	}
+
+	template <class Item>
+	void serialize(Item const& item) {
+		serialize(flat_buffers::FileIdentifierFor<Item>::value, item);
+	}
+
+private:
+	uint8_t* data = nullptr;
+	int size = 0;
+};
+
+template <class Visitor, class... Items>
+std::enable_if<Visitor::is_object_serializer> serializer(Visitor& visitor, Items&... items) {
+	visitor(items...);
+}

--- a/flow/ObjectSerializer.h
+++ b/flow/ObjectSerializer.h
@@ -101,7 +101,7 @@ class ObjectWriter {
 public:
 	template <class... Items>
 	void serialize(FileIdentifier file_identifier, Items const&... items) {
-		ASSERT(data = nullptr); // object serializer can only serialize one object
+		ASSERT(data == nullptr); // object serializer can only serialize one object
 		int allocations = 0;
 		auto allocator = [this, &allocations](size_t size_) {
 			++allocations;

--- a/flow/ObjectSerializer.h
+++ b/flow/ObjectSerializer.h
@@ -126,3 +126,26 @@ private:
 	uint8_t* data = nullptr;
 	int size = 0;
 };
+
+// this special case is needed - the code expects
+// Standalone<T> and T to be equivalent for serialization
+namespace detail {
+
+template <class T>
+struct LoadSaveHelper<Standalone<T>> {
+	template <class Context>
+	void load(Standalone<T>& member, const uint8_t* current, Context& context) {
+		helper.load(member.contents(), current, context);
+		context.addArena(member.arena());
+	}
+
+	template <class Writer>
+	RelativeOffset save(const Standalone<T>& member, Writer& writer, const VTableSet* vtables) {
+		return helper.save(member.contents(), writer, vtables);
+	}
+
+private:
+	LoadSaveHelper<T> helper;
+};
+
+} // namespace detail

--- a/flow/ObjectSerializer.h
+++ b/flow/ObjectSerializer.h
@@ -106,7 +106,7 @@ public:
 		auto allocator = [this, &allocations](size_t size_) {
 			++allocations;
 			size = size_;
-			data = new uint8_t[size];
+			data = new (arena) uint8_t[size];
 			return data;
 		};
 		auto res = save_members(allocator, file_identifier, items...);
@@ -122,7 +122,19 @@ public:
 		return StringRef(data, size);
 	}
 
+	Standalone<StringRef> toString() const {
+		return Standalone<StringRef>(toStringRef(), arena);
+	}
+
+	template <class Item>
+	static Standalone<StringRef> toValue(Item const& item) {
+		ObjectWriter writer;
+		writer.serialize(item);
+		return writer.toString();
+	}
+
 private:
+	Arena arena;
 	uint8_t* data = nullptr;
 	int size = 0;
 };

--- a/flow/ObjectSerializer.h
+++ b/flow/ObjectSerializer.h
@@ -109,7 +109,7 @@ public:
 			data = new (arena) uint8_t[size];
 			return data;
 		};
-		auto res = save_members(allocator, file_identifier, items...);
+		save_members(allocator, file_identifier, items...);
 		ASSERT(allocations == 1);
 	}
 

--- a/flow/ObjectSerializerTraits.h
+++ b/flow/ObjectSerializerTraits.h
@@ -27,6 +27,21 @@
 #include <functional>
 #include <vector>
 
+template <class T, typename = void>
+struct is_fb_function_t : std::false_type {};
+
+template<class T>
+struct is_fb_function_t<T, typename std::enable_if<T::is_fb_visitor>::type> : std::true_type {};
+
+template <class T>
+constexpr bool is_fb_function = is_fb_function_t<T>::value;
+
+template <class Visitor, class... Items>
+typename std::enable_if<is_fb_function<Visitor>, void>::type serializer(Visitor& visitor, Items&... items) {
+	visitor(items...);
+}
+
+
 template <class... Ts>
 struct pack {};
 

--- a/flow/ObjectSerializerTraits.h
+++ b/flow/ObjectSerializerTraits.h
@@ -1,0 +1,164 @@
+/*
+ * ObjectSerializerTraits.h
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2018 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <type_traits>
+#include <cstdint>
+#include <cstddef>
+#include <memory>
+#include <functional>
+#include <vector>
+
+template <class... Ts>
+struct pack {};
+
+template <int i, class... Ts>
+struct index_impl;
+
+template <int i, class T, class... Ts>
+struct index_impl<i, pack<T, Ts...>> {
+	using type = typename index_impl<i - 1, pack<Ts...>>::type;
+};
+
+template <class T, class... Ts>
+struct index_impl<0, pack<T, Ts...>> {
+	using type = T;
+};
+
+template <int i, class Pack>
+using index_t = typename index_impl<i, Pack>::type;
+
+//  A smart pointer that knows whether or not to delete itself.
+template <class T>
+using OwnershipErasedPtr = std::unique_ptr<T, std::function<void(T*)>>;
+
+// Creates an OwnershipErasedPtr<T> that will delete itself.
+template <class T, class Deleter = std::default_delete<T>>
+OwnershipErasedPtr<T> ownedPtr(T* t, Deleter&& d = Deleter{}) {
+	return OwnershipErasedPtr<T>{ t, std::forward<Deleter>(d) };
+}
+
+// Creates an OwnershipErasedPtr<T> that will not delete itself.
+template <class T>
+OwnershipErasedPtr<T> unownedPtr(T* t) {
+	return OwnershipErasedPtr<T>{ t, [](T*) {} };
+}
+
+struct WriteRawMemory {
+	using Block = std::pair<OwnershipErasedPtr<const uint8_t>, size_t>;
+	std::vector<Block> blocks;
+
+	WriteRawMemory() {}
+	WriteRawMemory(Block&& b) { blocks.emplace_back(std::move(b.first), b.second); }
+	WriteRawMemory(std::vector<Block>&& v) : blocks(std::move(v)) {}
+
+	WriteRawMemory(WriteRawMemory&&) = default;
+	WriteRawMemory& operator=(WriteRawMemory&&) = default;
+
+	size_t size() const {
+		size_t result = 0;
+		for (const auto& b : blocks) {
+			result += b.second;
+		}
+		return result;
+	}
+};
+
+
+template <class T, typename = void>
+struct scalar_traits : std::false_type {
+	constexpr static size_t size = 0;
+	static void save(uint8_t*, const T&);
+
+	// Context is an arbitrary type that is plumbed by reference throughout the
+	// load call tree.
+	template <class Context>
+	static void load(const uint8_t*, T&, Context&);
+};
+
+
+template <class T>
+struct dynamic_size_traits : std::false_type {
+	static WriteRawMemory save(const T&);
+
+	// Context is an arbitrary type that is plumbed by reference throughout the
+	// load call tree.
+	template <class Context>
+	static void load(const uint8_t*, size_t, T&, Context&);
+};
+
+template <class T>
+struct serializable_traits : std::false_type {
+	template <class Archiver>
+	static void serialize(Archiver& ar, T& v);
+};
+
+template <class VectorLike>
+struct vector_like_traits : std::false_type {
+	// Write this at the beginning of the buffer
+	using value_type = uint8_t;
+	using iterator = void;
+	using insert_iterator = void;
+
+	static size_t num_entries(VectorLike&);
+	template <class Context>
+	static void reserve(VectorLike&, size_t, Context&);
+
+	static insert_iterator insert(VectorLike&);
+	static iterator begin(const VectorLike&);
+	static void deserialization_done(VectorLike&); // Optional
+};
+
+template <class UnionLike>
+struct union_like_traits : std::false_type {
+	using Member = UnionLike;
+	using alternatives = pack<>;
+	static uint8_t index(const Member&);
+	static bool empty(const Member& variant);
+
+	template <int i>
+	static const index_t<i, alternatives>& get(const Member&);
+
+	template <int i, class Alternative>
+	static const void assign(Member&, const Alternative&);
+
+	template <class Context>
+	static void done(Member&, Context&);
+};
+
+// TODO(anoyes): Implement things that are currently using scalar traits with
+// struct-like traits.
+template <class StructLike>
+struct struct_like_traits : std::false_type {
+	using Member = StructLike;
+	using types = pack<>;
+
+	template <int i>
+	static const index_t<i, types>& get(const Member&);
+
+	template <int i>
+	static const void assign(Member&, const index_t<i, types>&);
+
+	template <class Context>
+	static void done(Member&, Context&);
+};
+
+

--- a/flow/ObjectSerializerTraits.h
+++ b/flow/ObjectSerializerTraits.h
@@ -26,6 +26,7 @@
 #include <memory>
 #include <functional>
 #include <vector>
+#include <variant>
 
 template <class T, typename = void>
 struct is_fb_function_t : std::false_type {};
@@ -174,6 +175,25 @@ struct struct_like_traits : std::false_type {
 
 	template <class Context>
 	static void done(Member&, Context&);
+};
+
+template <class... Alternatives>
+struct union_like_traits<std::variant<Alternatives...>> : std::true_type {
+	using Member = std::variant<Alternatives...>;
+	using alternatives = pack<Alternatives...>;
+	static uint8_t index(const Member& variant) { return variant.index(); }
+	static bool empty(const Member& variant) { return false; }
+
+	template <int i>
+	static const index_t<i, alternatives>& get(const Member& variant) {
+		return std::get<index_t<i, alternatives>>(variant);
+	}
+
+	template <size_t i, class Alternative>
+	static const void assign(Member& member, const Alternative& a) {
+		static_assert(std::is_same_v<index_t<i, alternatives>, Alternative>);
+		member = a;
+	}
 };
 
 

--- a/flow/Platform.cpp
+++ b/flow/Platform.cpp
@@ -1410,7 +1410,7 @@ void setMemoryQuota( size_t limit ) {
 	}
 	if (!AssignProcessToJobObject( job, GetCurrentProcess() ))
 		TraceEvent(SevWarn, "FailedToSetMemoryLimit").GetLastError();
-#elif defined(__linux__)
+#elif defined(__linux__) && !defined(USE_ASAN)
 	struct rlimit rlim;
 	if (getrlimit(RLIMIT_AS, &rlim)) {
 		TraceEvent(SevError, "GetMemoryLimit").GetLastError();

--- a/flow/Platform.cpp
+++ b/flow/Platform.cpp
@@ -1410,7 +1410,7 @@ void setMemoryQuota( size_t limit ) {
 	}
 	if (!AssignProcessToJobObject( job, GetCurrentProcess() ))
 		TraceEvent(SevWarn, "FailedToSetMemoryLimit").GetLastError();
-#elif defined(__linux__) && !defined(USE_ASAN)
+#elif defined(__linux__)
 	struct rlimit rlim;
 	if (getrlimit(RLIMIT_AS, &rlim)) {
 		TraceEvent(SevError, "GetMemoryLimit").GetLastError();

--- a/flow/Trace.h
+++ b/flow/Trace.h
@@ -80,6 +80,11 @@ public:
 
 	std::string toString() const;
 	void validateFormat() const;
+	template<class Archiver>
+	void serialize(Archiver& ar) {
+		static_assert(is_fb_function<Archiver>, "Streaming serializer has to use load/save");
+		serializer(ar, fields);
+	}
 
 private:
 	FieldContainer fields;

--- a/flow/Trace.h
+++ b/flow/Trace.h
@@ -57,6 +57,7 @@ enum Severity {
 
 class TraceEventFields {
 public:
+	constexpr static FileIdentifier file_identifier = 11262274;
 	typedef std::pair<std::string, std::string> Field;
 	typedef std::vector<Field> FieldContainer;
 	typedef FieldContainer::const_iterator FieldIterator;

--- a/flow/flat_buffers.cpp
+++ b/flow/flat_buffers.cpp
@@ -1,0 +1,513 @@
+/*
+ * serialize.h
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2018 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "flat_buffers.h"
+#include "UnitTest.h"
+#include "Arena.h"
+#include "serialize.h"
+
+#include <algorithm>
+#include <iomanip>
+#include <boost/variant.hpp>
+
+namespace flat_buffers {
+
+namespace detail {
+
+bool TraverseMessageTypes::vtableGeneratedBefore(const std::type_index& idx) {
+	return !f.known_types.insert(idx).second;
+}
+
+VTable generate_vtable(size_t numMembers, const std::vector<unsigned>& members,
+                       const std::vector<unsigned>& alignments) {
+	if (numMembers == 0) {
+		return VTable{ 4, 4 };
+	}
+	// first is index, second is size
+	std::vector<std::pair<unsigned, unsigned>> indexed;
+	indexed.reserve(members.size());
+	for (unsigned i = 0; i < members.size(); ++i) {
+		if (members[i] > 0) {
+			indexed.emplace_back(i, members[i]);
+		}
+	}
+	std::stable_sort(indexed.begin(), indexed.end(),
+	                 [](const std::pair<unsigned, unsigned>& lhs, const std::pair<unsigned, unsigned>& rhs) {
+		                 return lhs.second > rhs.second;
+	                 });
+	VTable result;
+	result.resize(members.size() + 2);
+	// size of the vtable is
+	// - 2 bytes per member +
+	// - 2 bytes for the size entry +
+	// - 2 bytes for the size of the object
+	result[0] = 2 * members.size() + 4;
+	int offset = 0;
+	for (auto p : indexed) {
+		auto align = alignments[p.first];
+		auto& res = result[p.first + 2];
+		res = offset % align == 0 ? offset : ((offset / align) + 1) * align;
+		offset = res + p.second;
+		res += 4;
+	}
+	result[1] = offset + 4;
+	return result;
+}
+
+} // namespace detail
+
+namespace unit_tests {
+
+TEST_CASE("flow/FlatBuffers/test") {
+	auto* vtable1 = detail::get_vtable<int>();
+	auto* vtable2 = detail::get_vtable<uint8_t, uint8_t, int, int64_t, int>();
+	auto* vtable3 = detail::get_vtable<uint8_t, uint8_t, int, int64_t, int>();
+	ASSERT(vtable1 != vtable2);
+	ASSERT(vtable2 == vtable3);
+	ASSERT(vtable1->size() == 3);
+	ASSERT(vtable2->size() == 7);
+	ASSERT((*vtable2)[0] == 14);
+	ASSERT((*vtable2)[1] == 22);
+	ASSERT(((*vtable2)[4] - 4) % 4 == 0);
+	ASSERT(((*vtable2)[5] - 4) % 8 == 0);
+	ASSERT(((*vtable2)[6] - 4) % 4 == 0);
+	return Void();
+}
+
+TEST_CASE("flow/FlatBuffers/emptyVtable") {
+	auto* vtable = detail::get_vtable<>();
+	ASSERT((*vtable)[0] == 4);
+	ASSERT((*vtable)[1] == 4);
+	return Void();
+}
+
+struct Table2 {
+	std::string m_p = {};
+	bool m_ujrnpumbfvc = {};
+	int64_t m_iwgxxt = {};
+	int64_t m_tjkuqo = {};
+	int16_t m_ed = {};
+	template <class Archiver>
+	void serialize(Archiver& ar) {
+		return flat_buffers::serializer(ar, m_p, m_ujrnpumbfvc, m_iwgxxt, m_tjkuqo, m_ed);
+	}
+};
+
+struct Table3 {
+	uint16_t m_asbehdlquj = {};
+	uint16_t m_k = {};
+	uint16_t m_jib = {};
+	int64_t m_n = {};
+	template <class Archiver>
+	void serialize(Archiver& ar) {
+		return flat_buffers::serializer(ar, m_asbehdlquj, m_k, m_jib, m_n);
+	}
+};
+
+TEST_CASE("flow/FlatBuffers/vtable2") {
+	const auto& vtable =
+	    *detail::get_vtable<uint64_t, bool, std::string, int64_t, std::vector<uint16_t>, Table2, Table3>();
+	ASSERT(!(vtable[2] <= vtable[4] && vtable[4] < vtable[2] + 8));
+	return Void();
+}
+
+struct Nested2 {
+	uint8_t a;
+	std::vector<std::string> b;
+	int c;
+	template <class Archiver>
+	void serialize(Archiver& ar) {
+		return flat_buffers::serializer(ar, a, b, c);
+	}
+
+	friend bool operator==(const Nested2& lhs, const Nested2& rhs) {
+		return lhs.a == rhs.a && lhs.b == rhs.b && lhs.c == rhs.c;
+	}
+};
+
+struct Nested {
+	uint8_t a;
+	std::string b;
+	Nested2 nested;
+	std::vector<uint64_t> c;
+	template <class Archiver>
+	void serialize(Archiver& ar) {
+		return flat_buffers::serializer(ar, a, b, nested, c);
+	}
+};
+
+struct Root {
+	uint8_t a;
+	std::vector<Nested2> b;
+	Nested c;
+	template <class Archiver>
+	void serialize(Archiver& ar) {
+		return flat_buffers::serializer(ar, a, b, c);
+	}
+};
+
+TEST_CASE("flow/FlatBuffers/collectVTables") {
+	Root root;
+	const auto* vtables = detail::get_vtableset(root);
+	ASSERT(vtables == detail::get_vtableset(root));
+	ASSERT(vtables->offsets.size() == 3);
+	const auto& root_vtable = *detail::get_vtable<uint8_t, std::vector<Nested2>, Nested>();
+	const auto& nested_vtable = *detail::get_vtable<uint8_t, std::vector<std::string>, int>();
+	int root_offset = vtables->offsets.at(&root_vtable);
+	int nested_offset = vtables->offsets.at(&nested_vtable);
+	ASSERT(!memcmp((uint8_t*)&root_vtable[0], &vtables->packed_tables[root_offset], root_vtable.size()));
+	ASSERT(!memcmp((uint8_t*)&nested_vtable[0], &vtables->packed_tables[nested_offset], nested_vtable.size()));
+	return Void();
+}
+
+void print_buffer(const uint8_t* out, int len) {
+	std::cout << std::hex << std::setfill('0');
+	for (int i = 0; i < len; ++i) {
+		if (i % 8 == 0) {
+			std::cout << std::endl;
+			std::cout << std::setw(4) << i << ": ";
+		}
+		std::cout << std::setw(2) << (int)out[i] << " ";
+	}
+	std::cout << std::endl << std::dec;
+}
+
+struct Arena {
+	std::vector<std::pair<uint8_t*, size_t>> allocated;
+	~Arena() {
+		for (auto b : allocated) {
+			delete[] b.first;
+		}
+	}
+
+	uint8_t* operator()(size_t sz) {
+		auto res = new uint8_t[sz];
+		allocated.emplace_back(res, sz);
+		return res;
+	}
+
+	size_t get_size(const uint8_t* ptr) const {
+		for (auto& p : allocated) {
+			if (p.first == ptr) {
+				return p.second;
+			}
+		}
+		return -1;
+	}
+};
+
+struct DummyContext {
+	Arena a;
+	Arena& arena() { return a; }
+};
+
+TEST_CASE("flow/FlatBuffers/serializeDeserializeRoot") {
+	Root root{ 1,
+		       { { 13, { "ghi", "jkl" }, 15 }, { 16, { "mnop", "qrstuv" }, 18 } },
+		       { 3, "hello", { 6, { "abc", "def" }, 8 }, { 10, 11, 12 } } };
+	Root root2 = root;
+	Arena arena;
+	auto out = flat_buffers::detail::save(arena, root, flat_buffers::FileIdentifier{});
+
+	ASSERT(root.a == root2.a);
+	ASSERT(root.b == root2.b);
+	ASSERT(root.c.a == root2.c.a);
+	ASSERT(root.c.b == root2.c.b);
+	ASSERT(root.c.nested.a == root2.c.nested.a);
+	ASSERT(root.c.nested.b == root2.c.nested.b);
+	ASSERT(root.c.nested.c == root2.c.nested.c);
+	ASSERT(root.c.c == root2.c.c);
+
+	root2 = {};
+	DummyContext context;
+	flat_buffers::detail::load(root2, out, context);
+
+	ASSERT(root.a == root2.a);
+	ASSERT(root.b == root2.b);
+	ASSERT(root.c.a == root2.c.a);
+	ASSERT(root.c.b == root2.c.b);
+	ASSERT(root.c.nested.a == root2.c.nested.a);
+	ASSERT(root.c.nested.b == root2.c.nested.b);
+	ASSERT(root.c.nested.c == root2.c.nested.c);
+	ASSERT(root.c.c == root2.c.c);
+	return Void();
+}
+
+TEST_CASE("flow/FlatBuffers/serializeDeserializeMembers") {
+	Root root{ 1,
+		       { { 13, { "ghi", "jkl" }, 15 }, { 16, { "mnop", "qrstuv" }, 18 } },
+		       { 3, "hello", { 6, { "abc", "def" }, 8 }, { 10, 11, 12 } } };
+	Root root2 = root;
+	Arena arena;
+	const auto* out = save_members(arena, FileIdentifier{}, root.a, root.b, root.c);
+
+	ASSERT(root.a == root2.a);
+	ASSERT(root.b == root2.b);
+	ASSERT(root.c.a == root2.c.a);
+	ASSERT(root.c.b == root2.c.b);
+	ASSERT(root.c.nested.a == root2.c.nested.a);
+	ASSERT(root.c.nested.b == root2.c.nested.b);
+	ASSERT(root.c.nested.c == root2.c.nested.c);
+	ASSERT(root.c.c == root2.c.c);
+
+	root2 = {};
+	DummyContext context;
+	load_members(out, context, root2.a, root2.b, root2.c);
+
+	ASSERT(root.a == root2.a);
+	ASSERT(root.b == root2.b);
+	ASSERT(root.c.a == root2.c.a);
+	ASSERT(root.c.b == root2.c.b);
+	ASSERT(root.c.nested.a == root2.c.nested.a);
+	ASSERT(root.c.nested.b == root2.c.nested.b);
+	ASSERT(root.c.nested.c == root2.c.nested.c);
+	ASSERT(root.c.c == root2.c.c);
+	return Void();
+}
+
+} // namespace unit_tests
+
+template <class... Alternatives>
+struct union_like_traits<boost::variant<Alternatives...>> : std::true_type {
+	using Member = boost::variant<Alternatives...>;
+	using alternatives = pack<Alternatives...>;
+	static uint8_t index(const Member& variant) { return variant.which(); }
+	static bool empty(const Member& variant) { return false; }
+
+	template <int i>
+	static const index_t<i, alternatives>& get(const Member& variant) {
+		return boost::get<index_t<i, alternatives>>(variant);
+	}
+
+	template <size_t i, class Alternative>
+	static const void assign(Member& member, const Alternative& a) {
+		static_assert(std::is_same_v<index_t<i, alternatives>, Alternative>);
+		member = a;
+	}
+};
+
+namespace unit_tests {
+
+TEST_CASE("flow/FlatBuffers/variant") {
+	using V = boost::variant<int, double, Nested2>;
+	V v1;
+	V v2;
+	Arena arena;
+	DummyContext context;
+	const uint8_t* out;
+
+	v1 = 1;
+	out = save_members(arena, FileIdentifier{}, v1);
+	// print_buffer(out, arena.get_size(out));
+	load_members(out, context, v2);
+	ASSERT(boost::get<int>(v1) == boost::get<int>(v2));
+
+	v1 = 1.0;
+	out = save_members(arena, FileIdentifier{}, v1);
+	// print_buffer(out, arena.get_size(out));
+	load_members(out, context, v2);
+	ASSERT(boost::get<double>(v1) == boost::get<double>(v2));
+
+	v1 = Nested2{ 1, { "abc", "def" }, 2 };
+	out = save_members(arena, FileIdentifier{}, v1);
+	// print_buffer(out, arena.get_size(out));
+	load_members(out, context, v2);
+	ASSERT(boost::get<Nested2>(v1).a == boost::get<Nested2>(v2).a);
+	ASSERT(boost::get<Nested2>(v1).b == boost::get<Nested2>(v2).b);
+	ASSERT(boost::get<Nested2>(v1).c == boost::get<Nested2>(v2).c);
+	return Void();
+}
+
+TEST_CASE("flow/FlatBuffers/vectorBool") {
+	std::vector<bool> x1 = { true, false, true, false, true };
+	std::vector<bool> x2;
+	Arena arena;
+	DummyContext context;
+	const uint8_t* out;
+
+	out = save_members(arena, FileIdentifier{}, x1);
+	// print_buffer(out, arena.get_size(out));
+	load_members(out, context, x2);
+	ASSERT(x1 == x2);
+	return Void();
+}
+
+struct DynamicSizeThingy {
+	std::string x;
+	mutable int saves = 0;
+};
+
+} // namespace unit_tests
+
+template <>
+struct dynamic_size_traits<unit_tests::DynamicSizeThingy> : std::true_type {
+private:
+	using T = unit_tests::DynamicSizeThingy;
+
+public:
+	static WriteRawMemory save(const T& t) {
+		++t.saves;
+		T* t2 = new T(t);
+		return { { ownedPtr(reinterpret_cast<const uint8_t*>(t2->x.data()), [t2](auto*) { delete t2; }),
+			       t2->x.size() } };
+	}
+
+	// Context is an arbitrary type that is plumbed by reference throughout the
+	// load call tree.
+	template <class Context>
+	static void load(const uint8_t* p, size_t n, T& t, Context&) {
+		t.x.assign(reinterpret_cast<const char*>(p), n);
+	}
+};
+
+namespace unit_tests {
+
+TEST_CASE("flow/FlatBuffers/dynamic_size_owned") {
+	DynamicSizeThingy x1 = { "abcdefg" };
+	DynamicSizeThingy x2;
+	Arena arena;
+	DummyContext context;
+	const uint8_t* out;
+
+	out = save_members(arena, FileIdentifier{}, x1);
+	ASSERT(x1.saves == 1);
+	// print_buffer(out, arena.get_size(out));
+	load_members(out, context, x2);
+	ASSERT(x1.x == x2.x);
+	return Void();
+}
+
+struct Y1 {
+	int a;
+
+	template <class Archiver>
+	void serialize(Archiver& ar) {
+		return flat_buffers::serializer(ar, a);
+	}
+};
+
+struct Y2 {
+	int a;
+	boost::variant<int> b;
+
+	template <class Archiver>
+	void serialize(Archiver& ar) {
+		return flat_buffers::serializer(ar, a, b);
+	}
+};
+
+template <class Y>
+struct X {
+	int a;
+	Y b;
+	int c;
+
+	template <class Archiver>
+	void serialize(Archiver& ar) {
+		return flat_buffers::serializer(ar, a, b, c);
+	}
+};
+
+TEST_CASE("flow/FlatBuffers/nestedCompat") {
+	X<Y1> x1 = { 1, { 2 }, 3 };
+	X<Y2> x2;
+	Arena arena;
+	DummyContext context;
+	const uint8_t* out;
+
+	out = save_members(arena, FileIdentifier{}, x1);
+	load_members(out, context, x2);
+	ASSERT(x1.a == x2.a);
+	ASSERT(x1.b.a == x2.b.a);
+	ASSERT(x1.c == x2.c);
+
+	x1 = {};
+	x2.b.b = 4;
+
+	out = save_members(arena, FileIdentifier{}, x2);
+	load_members(out, context, x1);
+	ASSERT(x1.a == x2.a);
+	ASSERT(x1.b.a == x2.b.a);
+	ASSERT(x1.c == x2.c);
+	return Void();
+}
+
+TEST_CASE("flow/FlatBuffers/struct") {
+	std::vector<std::tuple<int16_t, bool, int64_t>> x1 = { { 1, true, 2 }, { 3, false, 4 } };
+	decltype(x1) x2;
+	Arena arena;
+	DummyContext context;
+	const uint8_t* out;
+
+	out = save_members(arena, FileIdentifier{}, x1);
+	// print_buffer(out, arena.get_size(out));
+	load_members(out, context, x2);
+	ASSERT(x1 == x2);
+	return Void();
+}
+
+TEST_CASE("flow/FlatBuffers/file_identifier") {
+	Arena arena;
+	const uint8_t* out;
+	constexpr FileIdentifier file_identifier{ 1234 };
+	out = save_members(arena, file_identifier);
+	// print_buffer(out, arena.get_size(out));
+	ASSERT(read_file_identifier(out) == file_identifier);
+	return Void();
+}
+
+TEST_CASE("flow/FlatBuffers/VectorRef") {
+	// this test tests a few weird memory properties of
+	// serialized arenas. This is why it uses weird scoping
+
+	// first we construct the data to serialize/deserialize
+	// so we can compare it afterwards
+	std::vector<std::string> src;
+	src.push_back("Foo");
+	src.push_back("Bar");
+	::Arena vecArena;
+	VectorRef<StringRef> outVec;
+	{
+		::Arena readerArena;
+		StringRef serializedVector;
+		{
+			::Arena arena;
+			VectorRef<StringRef> vec;
+			for (const auto& str : src) {
+				vec.push_back(arena, str);
+			}
+			BinaryWriter writer(IncludeVersion());
+			::serialize_fake_root(writer, FileIdentifierFor<decltype(vec)>::value, arena, vec);
+			serializedVector = StringRef(readerArena, writer.toStringRef());
+		}
+		ArenaReader reader(readerArena, serializedVector, IncludeVersion());
+		::serialize_fake_root(reader, FileIdentifierFor<decltype(outVec)>::value, vecArena, outVec);
+	}
+	ASSERT(src.size() == outVec.size());
+	for (int i = 0; i < src.size(); ++i) {
+		auto str = outVec[i].toString();
+		ASSERT(str == src[i]);
+	}
+	return Void();
+}
+
+} // namespace unit_tests
+
+} // namespace flat_buffers

--- a/flow/flat_buffers.cpp
+++ b/flow/flat_buffers.cpp
@@ -18,16 +18,15 @@
  * limitations under the License.
  */
 
-#include "flat_buffers.h"
-#include "UnitTest.h"
-#include "Arena.h"
-#include "serialize.h"
+#include "flow/flat_buffers.h"
+#include "flow/UnitTest.h"
+#include "flow/Arena.h"
+#include "flow/serialize.h"
+#include "flow/ObjectSerializer.h"
 
 #include <algorithm>
 #include <iomanip>
 #include <boost/variant.hpp>
-
-namespace flat_buffers {
 
 namespace detail {
 
@@ -106,7 +105,7 @@ struct Table2 {
 	int16_t m_ed = {};
 	template <class Archiver>
 	void serialize(Archiver& ar) {
-		return flat_buffers::serializer(ar, m_p, m_ujrnpumbfvc, m_iwgxxt, m_tjkuqo, m_ed);
+		serializer(ar, m_p, m_ujrnpumbfvc, m_iwgxxt, m_tjkuqo, m_ed);
 	}
 };
 
@@ -117,7 +116,7 @@ struct Table3 {
 	int64_t m_n = {};
 	template <class Archiver>
 	void serialize(Archiver& ar) {
-		return flat_buffers::serializer(ar, m_asbehdlquj, m_k, m_jib, m_n);
+		serializer(ar, m_asbehdlquj, m_k, m_jib, m_n);
 	}
 };
 
@@ -134,7 +133,7 @@ struct Nested2 {
 	int c;
 	template <class Archiver>
 	void serialize(Archiver& ar) {
-		return flat_buffers::serializer(ar, a, b, c);
+		serializer(ar, a, b, c);
 	}
 
 	friend bool operator==(const Nested2& lhs, const Nested2& rhs) {
@@ -149,7 +148,7 @@ struct Nested {
 	std::vector<uint64_t> c;
 	template <class Archiver>
 	void serialize(Archiver& ar) {
-		return flat_buffers::serializer(ar, a, b, nested, c);
+		serializer(ar, a, b, nested, c);
 	}
 };
 
@@ -159,7 +158,7 @@ struct Root {
 	Nested c;
 	template <class Archiver>
 	void serialize(Archiver& ar) {
-		return flat_buffers::serializer(ar, a, b, c);
+		serializer(ar, a, b, c);
 	}
 };
 
@@ -224,7 +223,7 @@ TEST_CASE("flow/FlatBuffers/serializeDeserializeRoot") {
 		       { 3, "hello", { 6, { "abc", "def" }, 8 }, { 10, 11, 12 } } };
 	Root root2 = root;
 	Arena arena;
-	auto out = flat_buffers::detail::save(arena, root, flat_buffers::FileIdentifier{});
+	auto out = detail::save(arena, root, FileIdentifier{});
 
 	ASSERT(root.a == root2.a);
 	ASSERT(root.b == root2.b);
@@ -237,7 +236,7 @@ TEST_CASE("flow/FlatBuffers/serializeDeserializeRoot") {
 
 	root2 = {};
 	DummyContext context;
-	flat_buffers::detail::load(root2, out, context);
+	detail::load(root2, out, context);
 
 	ASSERT(root.a == root2.a);
 	ASSERT(root.b == root2.b);
@@ -399,7 +398,7 @@ struct Y1 {
 
 	template <class Archiver>
 	void serialize(Archiver& ar) {
-		return flat_buffers::serializer(ar, a);
+		serializer(ar, a);
 	}
 };
 
@@ -409,7 +408,7 @@ struct Y2 {
 
 	template <class Archiver>
 	void serialize(Archiver& ar) {
-		return flat_buffers::serializer(ar, a, b);
+		serializer(ar, a, b);
 	}
 };
 
@@ -421,7 +420,7 @@ struct X {
 
 	template <class Archiver>
 	void serialize(Archiver& ar) {
-		return flat_buffers::serializer(ar, a, b, c);
+		serializer(ar, a, b, c);
 	}
 };
 
@@ -493,12 +492,12 @@ TEST_CASE("flow/FlatBuffers/VectorRef") {
 			for (const auto& str : src) {
 				vec.push_back(arena, str);
 			}
-			BinaryWriter writer(IncludeVersion());
-			::serialize_fake_root(writer, FileIdentifierFor<decltype(vec)>::value, arena, vec);
+			ObjectWriter writer;
+			writer.serialize(FileIdentifierFor<decltype(vec)>::value, arena, vec);
 			serializedVector = StringRef(readerArena, writer.toStringRef());
 		}
-		ArenaReader reader(readerArena, serializedVector, IncludeVersion());
-		::serialize_fake_root(reader, FileIdentifierFor<decltype(outVec)>::value, vecArena, outVec);
+		ArenaObjectReader reader(readerArena, serializedVector);
+		reader.deserialize(FileIdentifierFor<decltype(outVec)>::value, vecArena, outVec);
 	}
 	ASSERT(src.size() == outVec.size());
 	for (int i = 0; i < src.size(); ++i) {
@@ -509,5 +508,3 @@ TEST_CASE("flow/FlatBuffers/VectorRef") {
 }
 
 } // namespace unit_tests
-
-} // namespace flat_buffers

--- a/flow/flat_buffers.cpp
+++ b/flow/flat_buffers.cpp
@@ -424,7 +424,7 @@ struct X {
 	}
 };
 
-TEST_CASE("flow/FlatBuffers/nestedCompat") {
+TEST_CASE("/flow/FlatBuffers/nestedCompat") {
 	X<Y1> x1 = { 1, { 2 }, 3 };
 	X<Y2> x2;
 	Arena arena;
@@ -448,7 +448,7 @@ TEST_CASE("flow/FlatBuffers/nestedCompat") {
 	return Void();
 }
 
-TEST_CASE("flow/FlatBuffers/struct") {
+TEST_CASE("/flow/FlatBuffers/struct") {
 	std::vector<std::tuple<int16_t, bool, int64_t>> x1 = { { 1, true, 2 }, { 3, false, 4 } };
 	decltype(x1) x2;
 	Arena arena;
@@ -462,7 +462,7 @@ TEST_CASE("flow/FlatBuffers/struct") {
 	return Void();
 }
 
-TEST_CASE("flow/FlatBuffers/file_identifier") {
+TEST_CASE("/flow/FlatBuffers/file_identifier") {
 	Arena arena;
 	const uint8_t* out;
 	constexpr FileIdentifier file_identifier{ 1234 };
@@ -472,7 +472,7 @@ TEST_CASE("flow/FlatBuffers/file_identifier") {
 	return Void();
 }
 
-TEST_CASE("flow/FlatBuffers/VectorRef") {
+TEST_CASE("/flow/FlatBuffers/VectorRef") {
 	// this test tests a few weird memory properties of
 	// serialized arenas. This is why it uses weird scoping
 

--- a/flow/flat_buffers.cpp
+++ b/flow/flat_buffers.cpp
@@ -507,4 +507,22 @@ TEST_CASE("/flow/FlatBuffers/VectorRef") {
 	return Void();
 }
 
+TEST_CASE("/flow/FlatBuffers/Standalone") {
+	Standalone<VectorRef<StringRef>> vecIn;
+	auto numElements = g_random->randomInt(1, 20);
+	for (int i = 0; i < numElements; ++i) {
+		auto str = g_random->randomAlphaNumeric(g_random->randomInt(0, 30));
+		vecIn.push_back(vecIn.arena(), StringRef(vecIn.arena(), str));
+	}
+	Standalone<StringRef> value = ObjectWriter::toValue(vecIn);
+	ArenaObjectReader reader(value.arena(), value);
+	VectorRef<Standalone<StringRef>> vecOut;
+	reader.deserialize(vecOut);
+	ASSERT(vecOut.size() == vecIn.size());
+	for (int i = 0; i < vecOut.size(); ++i) {
+		ASSERT(vecOut[i] == vecIn[i]);
+	}
+	return Void();
+}
+
 } // namespace unit_tests

--- a/flow/flat_buffers.h
+++ b/flow/flat_buffers.h
@@ -56,20 +56,6 @@ constexpr int RightAlign(int offset, int alignment) {
 	return offset % alignment == 0 ? offset : ((offset / alignment) + 1) * alignment;
 }
 
-template <class T, typename = void>
-struct is_fb_function_t : std::false_type {};
-
-template<class T>
-struct is_fb_function_t<T, typename std::enable_if<T::is_fb_visitor>::type> : std::true_type {};
-
-template <class T>
-constexpr bool is_fb_function = is_fb_function_t<T>::value;
-
-template <class Visitor, class... Items>
-typename std::enable_if<is_fb_function<Visitor>, void>::type serializer(Visitor& visitor, Items&... items) {
-	visitor(items...);
-}
-
 template <class T>
 struct object_construction {
 	T obj;
@@ -100,7 +86,8 @@ struct struct_like_traits<std::tuple<Ts...>> : std::true_type {
 };
 
 template <class T>
-struct scalar_traits<T, std::enable_if_t<std::is_integral<T>::value || std::is_floating_point<T>::value>>
+struct scalar_traits<
+    T, std::enable_if_t<std::is_integral<T>::value || std::is_floating_point<T>::value || std::is_enum<T>::value>>
   : std::true_type {
 	constexpr static size_t size = sizeof(T);
 	static void save(uint8_t* out, const T& t) { memcpy(out, &t, size); }

--- a/flow/flat_buffers.h
+++ b/flow/flat_buffers.h
@@ -1,0 +1,1241 @@
+/*
+ * flat_buffers.h
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2018 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <cstring>
+#include <functional>
+#include <map>
+#include <memory>
+#include <set>
+#include <stdint.h>
+#include <string>
+#include <tuple>
+#include <type_traits>
+#include <vector>
+#include <cstring>
+#include <array>
+#include <typeinfo>
+#include <typeindex>
+
+namespace flat_buffers {
+
+template <class... Ts>
+struct pack {};
+
+template <class T = pack<>, class...>
+struct concat {
+	using type = T;
+};
+template <class... T1, class... T2, class... Ts>
+struct concat<pack<T1...>, pack<T2...>, Ts...> : concat<pack<T1..., T2...>, Ts...> {};
+template <class... Ts>
+using concat_t = typename concat<Ts...>::type;
+
+template <class... Ts>
+constexpr auto pack_size(pack<Ts...>) {
+	return sizeof...(Ts);
+}
+
+template <int i, class... Ts>
+struct index;
+
+template <int i, class T, class... Ts>
+struct index<i, pack<T, Ts...>> {
+	using type = typename index<i - 1, pack<Ts...>>::type;
+};
+
+template <class T, class... Ts>
+struct index<0, pack<T, Ts...>> {
+	using type = T;
+};
+
+template <int i, class Pack>
+using index_t = typename index<i, Pack>::type;
+
+constexpr int RightAlign(int offset, int alignment) {
+	return offset % alignment == 0 ? offset : ((offset / alignment) + 1) * alignment;
+}
+
+using FileIdentifier = uint32_t;
+
+template <class T>
+struct FileIdentifierFor {
+	constexpr static FileIdentifier value = T::file_identifier;
+};
+
+template <>
+struct FileIdentifierFor<int> {
+	constexpr static FileIdentifier value = 1;
+};
+
+template <>
+struct FileIdentifierFor<unsigned> {
+	constexpr static FileIdentifier value = 2;
+};
+
+template <>
+struct FileIdentifierFor<long> {
+	constexpr static FileIdentifier value = 3;
+};
+
+template <>
+struct FileIdentifierFor<unsigned long> {
+	constexpr static FileIdentifier value = 4;
+};
+
+template <>
+struct FileIdentifierFor<long long> {
+	constexpr static FileIdentifier value = 5;
+};
+
+template <>
+struct FileIdentifierFor<unsigned long long> {
+	constexpr static FileIdentifier value = 6;
+};
+
+template <>
+struct FileIdentifierFor<short> {
+	constexpr static FileIdentifier value = 7;
+};
+
+template <>
+struct FileIdentifierFor<unsigned short> {
+	constexpr static FileIdentifier value = 8;
+};
+
+template <>
+struct FileIdentifierFor<signed char> {
+	constexpr static FileIdentifier value = 9;
+};
+
+template <>
+struct FileIdentifierFor<unsigned char> {
+	constexpr static FileIdentifier value = 10;
+};
+
+template <>
+struct FileIdentifierFor<bool> {
+	constexpr static FileIdentifier value = 11;
+};
+
+template <>
+struct FileIdentifierFor<float> {
+	constexpr static flat_buffers::FileIdentifier value = 7266212;
+};
+
+template <>
+struct FileIdentifierFor<double> {
+	constexpr static flat_buffers::FileIdentifier value = 9348150;
+};
+
+template <class K, class V, class Compare, class Allocator>
+struct FileIdentifierFor<std::map<K, V, Compare, Allocator>> {
+	constexpr static FileIdentifier value = FileIdentifierFor<std::pair<K, V>>::value;
+};
+
+template <class F, class S>
+struct FileIdentifierFor<std::pair<F, S>> {
+	constexpr static FileIdentifier value = FileIdentifierFor<F>::value ^ FileIdentifierFor<S>::value;
+};
+
+template <class T, class Allocator>
+struct FileIdentifierFor<std::vector<T, Allocator>> {
+	constexpr static FileIdentifier value = (0x10 << 24) | FileIdentifierFor<T>::value;
+};
+
+template <class CharT, class Traits, class Allocator>
+struct FileIdentifierFor<std::basic_string<CharT, Traits, Allocator>> {
+	constexpr static FileIdentifier value = 15694229;
+};
+
+template <class T>
+struct object_construction {
+	T obj;
+
+	object_construction() : obj() {}
+	object_construction(const T& o) : obj(o) {}
+	object_construction(T&& o) : obj(std::move(o)) {}
+
+	T& get() { return obj; }
+	const T& get() const { return obj; }
+	T move() { return std::move(obj); }
+};
+
+// A smart pointer that knows whether or not to delete itself.
+template <class T>
+using OwnershipErasedPtr = std::unique_ptr<T, std::function<void(T*)>>;
+
+// Creates an OwnershipErasedPtr<T> that will delete itself.
+template <class T, class Deleter = std::default_delete<T>>
+OwnershipErasedPtr<T> ownedPtr(T* t, Deleter&& d = Deleter{}) {
+	return OwnershipErasedPtr<T>{ t, std::forward<Deleter>(d) };
+}
+
+// Creates an OwnershipErasedPtr<T> that will not delete itself.
+template <class T>
+OwnershipErasedPtr<T> unownedPtr(T* t) {
+	return OwnershipErasedPtr<T>{ t, [](T*) {} };
+}
+
+template <class T, typename = void>
+struct scalar_traits : std::false_type {
+	constexpr static size_t size = 0;
+	static void save(uint8_t*, const T&);
+
+	// Context is an arbitrary type that is plumbed by reference throughout the
+	// load call tree.
+	template <class Context>
+	static void load(const uint8_t*, T&, Context&);
+};
+
+struct WriteRawMemory {
+	using Block = std::pair<OwnershipErasedPtr<const uint8_t>, size_t>;
+	std::vector<Block> blocks;
+
+	WriteRawMemory() {}
+	WriteRawMemory(Block&& b) { blocks.emplace_back(std::move(b.first), b.second); }
+	WriteRawMemory(std::vector<Block>&& v) : blocks(std::move(v)) {}
+
+	WriteRawMemory(WriteRawMemory&&) = default;
+	WriteRawMemory& operator=(WriteRawMemory&&) = default;
+
+	size_t size() const {
+		size_t result = 0;
+		for (const auto& b : blocks) {
+			result += b.second;
+		}
+		return result;
+	}
+};
+
+template <class T>
+struct dynamic_size_traits : std::false_type {
+	static WriteRawMemory save(const T&);
+
+	// Context is an arbitrary type that is plumbed by reference throughout the
+	// load call tree.
+	template <class Context>
+	static void load(const uint8_t*, size_t, T&, Context&);
+};
+
+template <class T>
+struct serializable_traits : std::false_type {
+	template <class Archiver>
+	static void serialize(Archiver& ar, T& v);
+};
+
+template <class VectorLike>
+struct vector_like_traits : std::false_type {
+	// Write this at the beginning of the buffer
+	using value_type = uint8_t;
+	using iterator = void;
+	using insert_iterator = void;
+
+	static size_t num_entries(VectorLike&);
+	template <class Context>
+	static void reserve(VectorLike&, size_t, Context&);
+
+	static insert_iterator insert(VectorLike&);
+	static iterator begin(const VectorLike&);
+	static void deserialization_done(VectorLike&); // Optional
+};
+
+template <class UnionLike>
+struct union_like_traits : std::false_type {
+	using Member = UnionLike;
+	using alternatives = pack<>;
+	static uint8_t index(const Member&);
+	static bool empty(const Member& variant);
+
+	template <int i>
+	static const index_t<i, alternatives>& get(const Member&);
+
+	template <int i, class Alternative>
+	static const void assign(Member&, const Alternative&);
+
+	template <class Context>
+	static void done(Member&, Context&);
+};
+
+// TODO(anoyes): Implement things that are currently using scalar traits with
+// struct-like traits.
+template <class StructLike>
+struct struct_like_traits : std::false_type {
+	using Member = StructLike;
+	using types = pack<>;
+
+	template <int i>
+	static const index_t<i, types>& get(const Member&);
+
+	template <int i>
+	static const void assign(Member&, const index_t<i, types>&);
+
+	template <class Context>
+	static void done(Member&, Context&);
+};
+
+template <class... Ts>
+struct struct_like_traits<std::tuple<Ts...>> : std::true_type {
+	using Member = std::tuple<Ts...>;
+	using types = pack<Ts...>;
+
+	template <int i>
+	static const index_t<i, types>& get(const Member& m) {
+		return std::get<i>(m);
+	}
+
+	template <int i, class Type>
+	static const void assign(Member& m, const Type& t) {
+		std::get<i>(m) = t;
+	}
+};
+
+template <class T>
+struct scalar_traits<T, std::enable_if_t<std::is_integral<T>::value || std::is_floating_point<T>::value>>
+  : std::true_type {
+	constexpr static size_t size = sizeof(T);
+	static void save(uint8_t* out, const T& t) { memcpy(out, &t, size); }
+	template <class Context>
+	static void load(const uint8_t* in, T& t, Context&) {
+		memcpy(&t, in, size);
+	}
+};
+
+template <class F, class... Items>
+void serializer(F& fun, Items&... items);
+
+template <class F, class S>
+struct serializable_traits<std::pair<F, S>> : std::true_type {
+	template <class Archiver>
+	static void serialize(Archiver& ar, std::pair<F, S>& p) {
+		flat_buffers::serializer(ar, p.first, p.second);
+	}
+};
+
+template <class T, class Alloc>
+struct vector_like_traits<std::vector<T, Alloc>> : std::true_type {
+	using Vec = std::vector<T, Alloc>;
+	using value_type = typename Vec::value_type;
+	using iterator = typename Vec::const_iterator;
+	using insert_iterator = std::back_insert_iterator<Vec>;
+
+	static size_t num_entries(const Vec& v) { return v.size(); }
+	template <class Context>
+	static void reserve(Vec& v, size_t size, Context&) {
+		v.clear();
+		v.reserve(size);
+	}
+
+	static insert_iterator insert(Vec& v) { return std::back_inserter(v); }
+	static iterator begin(const Vec& v) { return v.begin(); }
+};
+
+template <class Key, class T, class Compare, class Allocator>
+struct vector_like_traits<std::map<Key, T, Compare, Allocator>> : std::true_type {
+	using Vec = std::map<Key, T, Compare, Allocator>;
+	using value_type = std::pair<Key, T>;
+	using iterator = typename Vec::const_iterator;
+	using insert_iterator = std::insert_iterator<Vec>;
+
+	static size_t num_entries(const Vec& v) { return v.size(); }
+	template <class Context>
+	static void reserve(Vec& v, size_t size, Context&) {}
+
+	static insert_iterator insert(Vec& v) { return std::inserter(v, v.end()); }
+	static iterator begin(const Vec& v) { return v.begin(); }
+};
+
+template <>
+struct dynamic_size_traits<std::string> : std::true_type {
+private:
+	using T = std::string;
+
+public:
+	static WriteRawMemory save(const T& t) {
+		return { { unownedPtr(reinterpret_cast<const uint8_t*>(t.data())), t.size() } };
+	};
+
+	// Context is an arbitrary type that is plumbed by reference throughout the
+	// load call tree.
+	template <class Context>
+	static void load(const uint8_t* p, size_t n, T& t, Context&) {
+		t.assign(reinterpret_cast<const char*>(p), n);
+	}
+};
+
+namespace detail {
+
+template <class T>
+T interpret_as(const uint8_t* current) {
+	T t;
+	memcpy(&t, current, sizeof(t));
+	return t;
+}
+
+// Used to select an overload for |MessageWriter::write| that fixes relative
+// offsets.
+struct RelativeOffset {
+	int value;
+};
+static_assert(sizeof(RelativeOffset) == 4, "");
+
+template <class T>
+constexpr bool is_scalar = scalar_traits<T>::value;
+
+template <class T>
+constexpr bool is_dynamic_size = dynamic_size_traits<T>::value;
+
+template <class T>
+constexpr bool is_union_like = union_like_traits<T>::value;
+
+template <class T>
+constexpr bool is_vector_like = vector_like_traits<T>::value;
+
+template <class T>
+constexpr bool is_struct_like = struct_like_traits<T>::value;
+
+template <class T>
+constexpr bool expect_serialize_member =
+    !is_scalar<T> && !is_vector_like<T> && !is_union_like<T> && !is_dynamic_size<T> && !is_struct_like<T>;
+
+template <class T>
+constexpr bool use_indirection = !(is_scalar<T> || is_struct_like<T>);
+
+using VTable = std::vector<uint16_t>;
+
+template <class T>
+struct sfinae_true : std::true_type {};
+
+template <class T>
+auto test_deserialization_done(int) -> sfinae_true<decltype(T::deserialization_done)>;
+
+template <class T>
+auto test_deserialization_done(long) -> std::false_type;
+
+template <class T>
+struct has_deserialization_done : decltype(test_deserialization_done<T>(0)) {};
+
+template <class T>
+constexpr int fb_scalar_size = is_scalar<T> ? scalar_traits<T>::size : sizeof(RelativeOffset);
+
+template <size_t offset, size_t index, class... Ts>
+struct struct_offset_impl;
+
+template <size_t o, size_t index>
+struct struct_offset_impl<o, index> {
+	static_assert(index == 0);
+	static constexpr auto offset = o;
+};
+
+template <size_t o, size_t index, class T, class... Ts>
+struct struct_offset_impl<o, index, T, Ts...> {
+private:
+	static constexpr size_t offset_() {
+		if constexpr (index == 0) {
+			return RightAlign(o, fb_scalar_size<T>);
+		} else {
+			return struct_offset_impl<RightAlign(o, fb_scalar_size<T>) + fb_scalar_size<T>, index - 1, Ts...>::offset;
+		}
+	}
+
+public:
+	static_assert(!is_struct_like<T>, "Nested structs not supported yet");
+	static constexpr auto offset = offset_();
+};
+
+constexpr size_t AlignToPowerOfTwo(size_t s) {
+	if (s > 4) {
+		return 8;
+	} else if (s > 2) {
+		return 4;
+	} else if (s > 1) {
+		return 2;
+	} else {
+		return 1;
+	}
+}
+
+template <class... Ts>
+constexpr auto align_helper(pack<Ts...>) {
+	return std::max({ size_t{ 1 }, AlignToPowerOfTwo(fb_scalar_size<Ts>)... });
+}
+
+template <class... T>
+constexpr auto struct_size(pack<T...>) {
+	return std::max(1, RightAlign(struct_offset_impl<0, sizeof...(T), T...>::offset, align_helper(pack<T...>{})));
+}
+
+template <int i, class... T>
+constexpr auto struct_offset(pack<T...>) {
+	static_assert(i < sizeof...(T));
+	return struct_offset_impl<0, i, T...>::offset;
+}
+
+static_assert(struct_offset<0>(pack<int>{}) == 0);
+static_assert(struct_offset<1>(pack<int, bool>{}) == 4);
+static_assert(struct_offset<2>(pack<int, bool, double>{}) == 8);
+
+static_assert(struct_size(pack<>{}) == 1);
+static_assert(struct_size(pack<int>{}) == 4);
+static_assert(struct_size(pack<int, bool>{}) == 8);
+static_assert(struct_size(pack<int, bool, double>{}) == 16);
+
+template <class T>
+constexpr int fb_size = is_struct_like<T> ? struct_size(typename struct_like_traits<T>::types{}) : fb_scalar_size<T>;
+
+template <class T>
+constexpr int fb_align = is_struct_like<T> ? align_helper(typename struct_like_traits<T>::types{})
+                                           : AlignToPowerOfTwo(fb_scalar_size<T>);
+
+template <class T>
+struct _SizeOf {
+	static constexpr int size = fb_size<T>;
+	static constexpr int align = fb_align<T>;
+};
+
+struct PrecomputeSize {
+	// |offset| is measured from the end of the buffer. Precondition: len <=
+	// offset.
+	void write(const void*, int offset, int len) { current_buffer_size = std::max(current_buffer_size, offset); }
+
+	template <class ToRawMemory>
+	void writeRawMemory(ToRawMemory&& to_raw_memory) {
+		auto w = std::forward<ToRawMemory>(to_raw_memory)();
+		int start = RightAlign(current_buffer_size + w.size() + 4, 4);
+		write(nullptr, start, 4);
+		start -= 4;
+		for (auto& block : w.blocks) {
+			write(nullptr, start, block.second);
+			start -= block.second;
+		}
+		writeRawMemories.emplace_back(std::move(w));
+	}
+
+	struct Noop {
+		void write(const void* src, int offset, int len) {}
+		void writeTo(PrecomputeSize& writer, int offset) {
+
+			writer.write(nullptr, offset, size);
+			writer.writeToOffsets[writeToIndex] = offset;
+		}
+		void writeTo(PrecomputeSize& writer) { writeTo(writer, writer.current_buffer_size + size); }
+		int size;
+		int writeToIndex;
+	};
+
+	Noop getMessageWriter(int size) {
+		int writeToIndex = writeToOffsets.size();
+		writeToOffsets.push_back({});
+		return Noop{ size, writeToIndex };
+	}
+
+	int current_buffer_size = 0;
+
+	const int buffer_length = -1; // Dummy, the value of this should not affect anything.
+	const int vtable_start = -1; // Dummy, the value of this should not affect anything.
+	std::vector<int> writeToOffsets;
+	std::vector<WriteRawMemory> writeRawMemories;
+};
+
+template <class Member, class Context>
+void load_helper(Member&, const uint8_t*, Context&);
+
+class VTableSet;
+
+template <class T>
+struct is_array : std::false_type {};
+
+template <class T, size_t size>
+struct is_array<std::array<T, size>> : std::true_type {};
+
+struct WriteToBuffer {
+	// |offset| is measured from the end of the buffer. Precondition: len <=
+	// offset.
+	void write(const void* src, int offset, int len) {
+		copy_memory(src, offset, len);
+		current_buffer_size = std::max(current_buffer_size, offset);
+	}
+
+	template <class ToRawMemory>
+	void writeRawMemory(ToRawMemory&&) {
+		auto& w = *write_raw_memories_iter;
+		uint32_t size = w.size();
+		int start = RightAlign(current_buffer_size + size + 4, 4);
+		write(&size, start, 4);
+		start -= 4;
+		for (auto& p : w.blocks) {
+			if (p.second > 0) {
+				write(reinterpret_cast<const void*>(p.first.get()), start, p.second);
+			}
+			start -= p.second;
+		}
+		++write_raw_memories_iter;
+	}
+
+	WriteToBuffer(int buffer_length, int vtable_start, uint8_t* buffer, std::vector<int> writeToOffsets,
+	              std::vector<WriteRawMemory>::iterator write_raw_memories_iter)
+	  : buffer_length(buffer_length), vtable_start(vtable_start), buffer(buffer),
+	    writeToOffsets(std::move(writeToOffsets)), write_raw_memories_iter(write_raw_memories_iter) {}
+
+	struct MessageWriter {
+		template <class T>
+		void write(const T* src, int offset, size_t len) {
+			if constexpr (std::is_same_v<T, RelativeOffset>) {
+				uint32_t fixed_offset = finalLocation - offset - src->value;
+				writer.copy_memory(&fixed_offset, finalLocation - offset, len);
+			} else if constexpr (is_array<T>::value) {
+				writer.copy_memory(src, finalLocation - offset, std::min(src->size(), len));
+			} else {
+				writer.copy_memory(src, finalLocation - offset, len);
+			}
+		}
+		void writeTo(WriteToBuffer&) { writer.current_buffer_size += size; }
+		void writeTo(WriteToBuffer&, int offset) {
+			writer.current_buffer_size = std::max(writer.current_buffer_size, offset);
+		}
+		WriteToBuffer& writer;
+		int finalLocation;
+		int size;
+	};
+
+	MessageWriter getMessageWriter(int size) {
+		MessageWriter m{ *this, writeToOffsets[writeToIndex++], size };
+		return m;
+	}
+
+	const int buffer_length;
+	const int vtable_start;
+	int current_buffer_size = 0;
+
+private:
+	void copy_memory(const void* src, int offset, int len) {
+		memcpy(static_cast<void*>(&buffer[buffer_length - offset]), src, len);
+	}
+	std::vector<int> writeToOffsets;
+	std::vector<WriteRawMemory>::iterator write_raw_memories_iter;
+	int writeToIndex = 0;
+	uint8_t* buffer;
+};
+
+template <class Member>
+constexpr auto fields_helper() {
+	if constexpr (_SizeOf<Member>::size == 0) {
+		return pack<>{};
+	} else if constexpr (is_union_like<Member>) {
+		return pack<uint8_t, uint32_t>{};
+	} else {
+		return pack<Member>{};
+	}
+}
+
+template <class Member>
+using Fields = decltype(fields_helper<Member>());
+
+// TODO(anoyes): Make this `template <int... offsets>` so we can re-use
+// identical vtables even if they have different types.
+// Also, it's important that get_vtable always returns the same VTable pointer
+// so that we can decide equality by comparing the pointers.
+
+extern VTable generate_vtable(size_t numMembers, const std::vector<unsigned>& members,
+                              const std::vector<unsigned>& alignments);
+
+template <class... Members>
+VTable gen_vtable(pack<Members...> p) {
+	return generate_vtable(sizeof...(Members), std::vector<unsigned>{ { _SizeOf<Members>::size... } },
+	                       std::vector<unsigned>{ { _SizeOf<Members>::align... } });
+}
+
+template <class... Members>
+const VTable* get_vtable() {
+	static VTable table = gen_vtable(concat_t<Fields<Members>...>{});
+	return &table;
+}
+
+template <class F, class... Members>
+void for_each(F&& f, Members&&... members) {
+	(std::forward<F>(f)(std::forward<Members>(members)), ...);
+}
+
+struct VTableSet {
+	std::map<const VTable*, int> offsets;
+	std::vector<uint8_t> packed_tables;
+};
+
+struct InsertVTableLambda;
+
+struct TraverseMessageTypes {
+	InsertVTableLambda& f;
+
+	bool vtableGeneratedBefore(const std::type_index&);
+
+	template <class Member>
+	std::enable_if_t<expect_serialize_member<Member>> operator()(const Member& member) {
+		if (vtableGeneratedBefore(typeid(Member))) {
+			return;
+		}
+		if constexpr (serializable_traits<Member>::value) {
+			serializable_traits<Member>::serialize(f, const_cast<Member&>(member));
+		} else {
+			const_cast<Member&>(member).serialize(f);
+		}
+	};
+
+	template <class T>
+	std::enable_if_t<!expect_serialize_member<T> && !is_vector_like<T> && !is_union_like<T>> operator()(const T&) {}
+
+	template <class VectorLike>
+	std::enable_if_t<is_vector_like<VectorLike>> operator()(const VectorLike& members) {
+		using VectorTraits = vector_like_traits<VectorLike>;
+		using T = typename VectorTraits::value_type;
+		static_assert(!is_union_like<T>, "vector<union> not yet supported");
+		// we don't need to check for recursion here because the next call
+		// to operator() will do that and we don't generate a vtable for the
+		// vector-like type itself
+		object_construction<T> t;
+		(*this)(t.get());
+	}
+
+	template <class UnionLike>
+	std::enable_if_t<is_union_like<UnionLike>> operator()(const UnionLike& members) {
+		using UnionTraits = union_like_traits<UnionLike>;
+		static_assert(pack_size(typename UnionTraits::alternatives{}) <= 254,
+		              "Up to 254 alternatives are supported for unions");
+		union_helper(typename UnionTraits::alternatives{});
+	}
+
+private:
+	template <class T, class... Ts>
+	void union_helper(pack<T, Ts...>) {
+		object_construction<T> t;
+		(*this)(t.get());
+		union_helper(pack<Ts...>{});
+	}
+	void union_helper(pack<>) {}
+};
+
+struct InsertVTableLambda {
+	static constexpr bool isDeserializing = true;
+	std::set<const VTable*>& vtables;
+	std::set<std::type_index>& known_types;
+
+	template <class... Members>
+	void operator()(const Members&... members) {
+		vtables.insert(get_vtable<Members...>());
+		for_each(TraverseMessageTypes{ *this }, members...);
+	}
+};
+
+template <class T>
+int vec_bytes(const T& begin, const T& end) {
+	return sizeof(typename T::value_type) * (end - begin);
+}
+
+template <class Root>
+VTableSet get_vtableset_impl(const Root& root) {
+	std::set<const VTable*> vtables;
+	std::set<std::type_index> known_types;
+	InsertVTableLambda vlambda{ vtables, known_types };
+	if constexpr (serializable_traits<Root>::value) {
+		serializable_traits<Root>::serialize(vlambda, const_cast<Root&>(root));
+	} else {
+		const_cast<Root&>(root).serialize(vlambda);
+	}
+	size_t size = 0;
+	for (const auto* vtable : vtables) {
+		size += vec_bytes(vtable->begin(), vtable->end());
+	}
+	std::vector<uint8_t> packed_tables(size);
+	int i = 0;
+	std::map<const VTable*, int> offsets;
+	for (const auto* vtable : vtables) {
+		memcpy(&packed_tables[i], reinterpret_cast<const uint8_t*>(&(*vtable)[0]),
+		       vec_bytes(vtable->begin(), vtable->end()));
+		offsets[vtable] = i;
+		i += vec_bytes(vtable->begin(), vtable->end());
+	}
+	return VTableSet{ offsets, packed_tables };
+}
+
+template <class Root>
+const VTableSet* get_vtableset(const Root& root) {
+	static VTableSet result = get_vtableset_impl(root);
+	return &result;
+}
+
+template <class Root, class Writer>
+void save_with_vtables(const Root& root, const VTableSet* vtableset, Writer& writer, int* vtable_start,
+                       FileIdentifier file_identifier) {
+	auto vtable_writer = writer.getMessageWriter(vtableset->packed_tables.size());
+	vtable_writer.write(&vtableset->packed_tables[0], 0, vtableset->packed_tables.size());
+	RelativeOffset offset = save_helper(const_cast<Root&>(root), writer, vtableset);
+	vtable_writer.writeTo(writer);
+	*vtable_start = writer.current_buffer_size;
+	int root_writer_size = sizeof(uint32_t) + sizeof(file_identifier);
+	auto root_writer = writer.getMessageWriter(root_writer_size);
+	root_writer.write(&offset, 0, sizeof(offset));
+	root_writer.write(&file_identifier, sizeof(offset), sizeof(file_identifier));
+	root_writer.writeTo(writer, RightAlign(writer.current_buffer_size + root_writer_size, 8));
+}
+
+template <class Writer, class UnionTraits>
+struct SaveAlternative {
+	Writer& writer;
+	const VTableSet* vtables;
+
+	RelativeOffset save(uint8_t type_tag, const typename UnionTraits::Member& member) {
+		return save_<0>(type_tag, member);
+	}
+
+private:
+	template <uint8_t Alternative>
+	RelativeOffset save_(uint8_t type_tag, const typename UnionTraits::Member& member) {
+		if constexpr (Alternative < pack_size(typename UnionTraits::alternatives{})) {
+			if (type_tag == Alternative) {
+				auto result = save_helper(UnionTraits::template get<Alternative>(member), writer, vtables);
+				if constexpr (use_indirection<index_t<Alternative, typename UnionTraits::alternatives>>) {
+					return result;
+				}
+				writer.write(&result, writer.current_buffer_size + sizeof(result), sizeof(result));
+				return RelativeOffset{ writer.current_buffer_size };
+			} else {
+				return save_<Alternative + 1>(type_tag, member);
+			}
+		}
+		throw std::runtime_error("type_tag out of range. This should never happen.");
+	}
+};
+
+template <class Context, class UnionTraits>
+struct LoadAlternative {
+	Context& context;
+	const uint8_t* current;
+
+	void load(uint8_t type_tag, typename UnionTraits::Member& member) { return load_<0>(type_tag, member); }
+
+private:
+	template <uint8_t Alternative>
+	void load_(uint8_t type_tag, typename UnionTraits::Member& member) {
+		if constexpr (Alternative < pack_size(typename UnionTraits::alternatives{})) {
+			if (type_tag == Alternative) {
+				using AlternativeT = index_t<Alternative, typename UnionTraits::alternatives>;
+				object_construction<AlternativeT> alternative;
+				if constexpr (use_indirection<AlternativeT>) {
+					load_helper(alternative.get(), current, context);
+				} else {
+					uint32_t current_offset = interpret_as<uint32_t>(current);
+					current += current_offset;
+					load_helper(alternative.get(), current, context);
+				}
+				UnionTraits::template assign<Alternative>(member, std::move(alternative.move()));
+			} else {
+				load_<Alternative + 1>(type_tag, member);
+			}
+		}
+	}
+};
+
+template <class Writer>
+struct SaveVisitorLambda {
+	static constexpr bool isDeserializing = false;
+	const VTableSet* vtableset;
+	Writer& writer;
+
+	template <class... Members>
+	void operator()(const Members&... members) {
+		const auto& vtable = *get_vtable<Members...>();
+		auto self = writer.getMessageWriter(vtable[1] /* length */);
+		int i = 2;
+		for_each(
+		    [&](const auto& member) {
+			    using Member = std::decay_t<decltype(member)>;
+			    if constexpr (is_union_like<Member>) {
+				    using UnionTraits = union_like_traits<Member>;
+				    uint8_t type_tag = UnionTraits::index(member);
+				    uint8_t fb_type_tag = UnionTraits::empty(member) ? 0 : type_tag + 1; // Flatbuffers indexes from 1.
+				    self.write(&fb_type_tag, vtable[i++], sizeof(fb_type_tag));
+				    if (!UnionTraits::empty(member)) {
+					    RelativeOffset offset =
+					        (SaveAlternative<Writer, UnionTraits>{ writer, vtableset }).save(type_tag, member);
+					    self.write(&offset, vtable[i++], sizeof(offset));
+				    } else {
+					    ++i;
+				    }
+			    } else if constexpr (_SizeOf<Member>::size == 0) {
+				    save_helper(member, writer, vtableset);
+			    } else {
+				    auto result = save_helper(member, writer, vtableset);
+				    self.write(&result, vtable[i++], sizeof(result));
+			    }
+		    },
+		    members...);
+		int vtable_offset = writer.vtable_start - vtableset->offsets.at(&vtable);
+		int start = RightAlign(writer.current_buffer_size + vtable[1] - 4, std::max({ 1, fb_align<Members>... })) + 4;
+		int32_t relative = vtable_offset - start;
+		self.write(&relative, 0, sizeof(relative));
+		self.writeTo(writer, start);
+	}
+};
+
+template <class Context>
+struct LoadMember {
+	static constexpr bool isDeserializing = true;
+	const uint16_t* const vtable;
+	const uint8_t* const message;
+	const uint16_t vtable_length;
+	const uint16_t table_length;
+	int& i;
+	Context& context;
+	template <class Member>
+	void operator()(Member& member) {
+		if constexpr (is_union_like<Member>) {
+			if (!field_present()) {
+				i += 2;
+				return;
+			}
+			uint8_t fb_type_tag;
+			load_helper(fb_type_tag, &message[vtable[i]], context);
+			uint8_t type_tag = fb_type_tag - 1; // Flatbuffers indexes from 1.
+			++i;
+			if (field_present() && fb_type_tag > 0) {
+				(LoadAlternative<Context, union_like_traits<Member>>{ context, &message[vtable[i]] })
+				    .load(type_tag, member);
+			}
+			++i;
+		} else if constexpr (_SizeOf<Member>::size == 0) {
+			load_helper(member, nullptr, context);
+		} else {
+			if (field_present()) {
+				load_helper(member, &message[vtable[i]], context);
+			}
+			++i;
+		}
+	}
+
+private:
+	bool field_present() { return i < vtable_length && vtable[i] >= 4; }
+};
+
+template <size_t i>
+struct int_type {
+	static constexpr int value = i;
+};
+
+template <class F, size_t... I>
+void for_each_i_impl(F&& f, std::index_sequence<I...>) {
+	for_each(std::forward<F>(f), int_type<I>{}...);
+}
+
+template <size_t I, class F>
+void for_each_i(F&& f) {
+	for_each_i_impl(std::forward<F>(f), std::make_index_sequence<I>{});
+}
+
+template <class>
+struct LoadSaveHelper {
+	template <class U, class Context>
+	std::enable_if_t<is_scalar<U>> load(U& member, const uint8_t* current, Context& context) {
+		scalar_traits<U>::load(current, member, context);
+	}
+
+	template <class U, class Context>
+	std::enable_if_t<is_struct_like<U>> load(U& member, const uint8_t* current, Context& context) {
+		using StructTraits = struct_like_traits<U>;
+		using types = typename StructTraits::types;
+		constexpr auto size = struct_size(types{});
+		for_each_i<pack_size(types{})>([&](auto i_type) {
+			constexpr int i = decltype(i_type)::value;
+			using type = index_t<i, types>;
+			object_construction<type> t;
+			load_helper(t.get(), current + struct_offset<i>(types{}), context);
+			StructTraits::template assign<i>(member, t.move());
+		});
+	}
+
+	template <class U, class Context>
+	std::enable_if_t<is_dynamic_size<U>> load(U& member, const uint8_t* current, Context& context) {
+		uint32_t current_offset = interpret_as<uint32_t>(current);
+		current += current_offset;
+		uint32_t size = interpret_as<uint32_t>(current);
+		current += sizeof(size);
+		dynamic_size_traits<U>::load(current, size, member, context);
+	}
+
+	template <class Context>
+	struct SerializeFun {
+		static constexpr bool isDeserializing = true;
+
+		const uint16_t* vtable;
+		const uint8_t* current;
+		Context& context;
+
+		SerializeFun(const uint16_t* vtable, const uint8_t* current, Context& context)
+		  : vtable(vtable), current(current), context(context) {}
+
+		template <class... Args>
+		void operator()(Args&... members) {
+			int i = 0;
+			uint16_t vtable_length = vtable[i++] / sizeof(uint16_t);
+			uint16_t table_length = vtable[i++];
+			for_each(LoadMember<Context>{ vtable, current, vtable_length, table_length, i, context }, members...);
+		}
+	};
+
+	template <class Member, class Context>
+	std::enable_if_t<expect_serialize_member<Member>> load(Member& member, const uint8_t* current, Context& context) {
+		uint32_t current_offset = interpret_as<uint32_t>(current);
+		current += current_offset;
+		int32_t vtable_offset = interpret_as<int32_t>(current);
+		const uint16_t* vtable = reinterpret_cast<const uint16_t*>(current - vtable_offset);
+		SerializeFun<Context> fun(vtable, current, context);
+		if constexpr (serializable_traits<Member>::value) {
+			serializable_traits<Member>::serialize(fun, member);
+		} else {
+			member.serialize(fun);
+		}
+	}
+
+	template <class VectorLike, class Context>
+	std::enable_if_t<is_vector_like<VectorLike>> load(VectorLike& member, const uint8_t* current, Context& context) {
+		using VectorTraits = vector_like_traits<VectorLike>;
+		using T = typename VectorTraits::value_type;
+		uint32_t current_offset = interpret_as<uint32_t>(current);
+		current += current_offset;
+		uint32_t numEntries = interpret_as<uint32_t>(current);
+		current += sizeof(uint32_t);
+		VectorTraits::reserve(member, numEntries, context);
+		auto inserter = VectorTraits::insert(member);
+		for (int i = 0; i < numEntries; ++i) {
+			T value;
+			load_helper(value, current, context);
+			*inserter = std::move(value);
+			++inserter;
+			current += fb_size<T>;
+		}
+		if constexpr (has_deserialization_done<VectorTraits>::value) {
+			VectorTraits::deserialization_done(member);
+		}
+	}
+
+	template <class U, class Writer, typename = std::enable_if_t<is_scalar<U>>>
+	auto save(const U& message, Writer& writer, const VTableSet*) {
+		constexpr auto size = scalar_traits<U>::size;
+		std::array<uint8_t, size> result = {};
+		scalar_traits<U>::save(&result[0], message);
+		return result;
+	}
+
+	template <class U, class Writer>
+	auto save(const U& message, Writer& writer, const VTableSet* vtables,
+	          std::enable_if_t<is_struct_like<U>, int> _ = 0) {
+		using StructTraits = struct_like_traits<U>;
+		using types = typename StructTraits::types;
+		constexpr auto size = struct_size(types{});
+		std::array<uint8_t, size> struct_bytes = {};
+		for_each_i<pack_size(types{})>([&](auto i_type) {
+			constexpr int i = decltype(i_type)::value;
+			auto result = save_helper(StructTraits::template get<i>(message), writer, vtables);
+			memcpy(&struct_bytes[struct_offset<i>(types{})], &result, sizeof(result));
+		});
+		return struct_bytes;
+	}
+
+	template <class U, class Writer, typename = std::enable_if_t<is_dynamic_size<U>>>
+	RelativeOffset save(const U& message, Writer& writer, const VTableSet*,
+	                    std::enable_if_t<is_dynamic_size<U>, int> _ = 0) {
+		writer.writeRawMemory([&]() { return dynamic_size_traits<U>::save(message); });
+		return RelativeOffset{ writer.current_buffer_size };
+	}
+
+	template <class Member, class Writer>
+	RelativeOffset save(const Member& member, Writer& writer, const VTableSet* vtables,
+	                    std::enable_if_t<expect_serialize_member<Member>, int> _ = 0) {
+		SaveVisitorLambda<Writer> l{ vtables, writer };
+		if constexpr (serializable_traits<Member>::value) {
+			serializable_traits<Member>::serialize(l, const_cast<Member&>(member));
+		} else {
+			const_cast<Member&>(member).serialize(l);
+		}
+		return RelativeOffset{ writer.current_buffer_size };
+	}
+
+	template <class VectorLike, class Writer, typename = std::enable_if_t<is_vector_like<VectorLike>>>
+	RelativeOffset save(const VectorLike& members, Writer& writer, const VTableSet* vtables) {
+		using VectorTraits = vector_like_traits<VectorLike>;
+		using T = typename VectorTraits::value_type;
+		constexpr auto size = fb_size<T>;
+		uint32_t num_entries = VectorTraits::num_entries(members);
+		uint32_t len = num_entries * size;
+		auto self = writer.getMessageWriter(len);
+		auto iter = VectorTraits::begin(members);
+		for (int i = 0; i < num_entries; ++i) {
+			auto result = save_helper(*iter, writer, vtables);
+			self.write(&result, i * size, size);
+			++iter;
+		}
+		int start = RightAlign(writer.current_buffer_size + len, std::min(4, fb_align<T>)) + 4;
+		writer.write(&num_entries, start, sizeof(uint32_t));
+		self.writeTo(writer, start - sizeof(uint32_t));
+		return RelativeOffset{ writer.current_buffer_size };
+	}
+};
+
+template <class Alloc>
+struct LoadSaveHelper<std::vector<bool, Alloc>> {
+	template <class Context>
+	void load(std::vector<bool, Alloc>& member, const uint8_t* current, Context& context) {
+		uint32_t current_offset = interpret_as<uint32_t>(current);
+		current += current_offset;
+		uint32_t length = interpret_as<uint32_t>(current);
+		current += sizeof(uint32_t);
+		member.clear();
+		member.resize(length);
+		bool m;
+		for (int i = 0; i < length; ++i) {
+			load_helper(m, current, context);
+			member[i] = m;
+			current += fb_size<bool>;
+		}
+	}
+
+	template <class Writer>
+	RelativeOffset save(const std::vector<bool, Alloc>& members, Writer& writer, const VTableSet* vtables) {
+		uint32_t len = members.size();
+		int start = RightAlign(writer.current_buffer_size + sizeof(uint32_t) + len, sizeof(uint32_t));
+		writer.write(&len, start, sizeof(uint32_t));
+		int i = 0;
+		for (bool b : members) {
+			writer.write(&b, start - sizeof(uint32_t) - i++, 1);
+		}
+		return RelativeOffset{ writer.current_buffer_size };
+	}
+};
+
+template <class Member, class Context>
+void load_helper(Member& member, const uint8_t* current, Context& context) {
+	LoadSaveHelper<Member> helper;
+	helper.load(member, current, context);
+}
+
+template <class Member, class Writer>
+auto save_helper(const Member& member, Writer& writer, const VTableSet* vtables) {
+	LoadSaveHelper<Member> helper;
+	return helper.save(member, writer, vtables);
+}
+
+} // namespace detail
+
+template <class F, class... Items>
+void serializer(F& fun, Items&... items) {
+	fun(items...);
+}
+
+namespace detail {
+
+template <class... Members>
+struct FakeRoot {
+	std::tuple<Members&...> members;
+
+	FakeRoot(Members&... members) : members(members...) {}
+
+	template <class Archive>
+	void serialize(Archive& archive) {
+		serialize_impl(archive, std::index_sequence_for<Members...>{});
+	}
+
+private:
+	template <class Archive, size_t... is>
+	void serialize_impl(Archive& archive, std::index_sequence<is...>) {
+		flat_buffers::serializer(archive, std::get<is>(members)...);
+	}
+};
+
+template <class... Members>
+auto fake_root(Members&... members) {
+	return FakeRoot<Members...>(members...);
+}
+
+template <class Allocator, class Root>
+uint8_t* save(Allocator& allocator, const Root& root, FileIdentifier file_identifier) {
+	const auto* vtableset = get_vtableset(root);
+	PrecomputeSize precompute_size;
+	int vtable_start;
+	save_with_vtables(root, vtableset, precompute_size, &vtable_start, file_identifier);
+	uint8_t* out = allocator(precompute_size.current_buffer_size);
+	memset(out, 0, precompute_size.current_buffer_size);
+	WriteToBuffer writeToBuffer{ precompute_size.current_buffer_size, vtable_start, out,
+		                         std::move(precompute_size.writeToOffsets), precompute_size.writeRawMemories.begin() };
+	save_with_vtables(root, vtableset, writeToBuffer, &vtable_start, file_identifier);
+	return out;
+}
+
+template <class Root, class Context>
+void load(Root& root, const uint8_t* in, Context& context) {
+	flat_buffers::detail::load_helper(root, in, context);
+}
+
+} // namespace detail
+
+template <class Allocator, class... Members>
+uint8_t* save_members(Allocator& allocator, FileIdentifier file_identifier, Members&... members) {
+	const auto& root = flat_buffers::detail::fake_root(members...);
+	return detail::save(allocator, root, file_identifier);
+}
+
+template <class Context, class... Members>
+void load_members(const uint8_t* in, Context& context, Members&... members) {
+	auto root = flat_buffers::detail::fake_root(members...);
+	detail::load(root, in, context);
+}
+
+inline FileIdentifier read_file_identifier(const uint8_t* in) {
+	FileIdentifier result;
+	memcpy(&result, in + sizeof(result), sizeof(result));
+	return result;
+}
+
+// members of unions must be tables in flatbuffers, so you can use this to
+// introduce the indirection only when necessary.
+template <class T>
+struct EnsureTable {
+	constexpr static flat_buffers::FileIdentifier file_identifier = FileIdentifierFor<T>::value;
+	EnsureTable() = default;
+	EnsureTable(const object_construction<T>& t) : t(t) {}
+	EnsureTable(const T& t) : t(t) {}
+	template <class Archive>
+	void serialize(Archive& ar) {
+		if constexpr (detail::expect_serialize_member<T>) {
+			if constexpr (serializable_traits<T>::value) {
+				serializable_traits<T>::serialize(ar, t.get());
+			} else {
+				t.get().serialize(ar);
+			}
+		} else {
+			flat_buffers::serializer(ar, t.get());
+		}
+	}
+	T& asUnderlyingType() { return t.get(); }
+
+private:
+	object_construction<T> t;
+};
+
+} // namespace flat_buffers

--- a/flow/flat_buffers.h
+++ b/flow/flat_buffers.h
@@ -881,7 +881,9 @@ struct LoadSaveHelper {
 	auto save(const U& message, Writer& writer, const VTableSet*) {
 		constexpr auto size = scalar_traits<U>::size;
 		std::array<uint8_t, size> result = {};
-		scalar_traits<U>::save(&result[0], message);
+		if constexpr (size > 0) {
+			scalar_traits<U>::save(&result[0], message);
+		}
 		return result;
 	}
 

--- a/flow/flat_buffers.h
+++ b/flow/flat_buffers.h
@@ -1070,6 +1070,7 @@ inline FileIdentifier read_file_identifier(const uint8_t* in) {
 // introduce the indirection only when necessary.
 template <class T>
 struct EnsureTable {
+	static_assert(HasFileIdentifier<T>::value);
 	constexpr static FileIdentifier file_identifier = FileIdentifierFor<T>::value;
 	EnsureTable() = default;
 	EnsureTable(const object_construction<T>& t) : t(t) {}

--- a/flow/flat_buffers.h
+++ b/flow/flat_buffers.h
@@ -123,6 +123,21 @@ struct vector_like_traits<std::vector<T, Alloc>> : std::true_type {
 	static iterator begin(const Vec& v) { return v.begin(); }
 };
 
+template<class T, size_t N>
+struct vector_like_traits<std::array<T, N>> : std::true_type {
+	using Vec = std::array<T, N>;
+	using value_type = typename Vec::value_type;
+	using iterator = typename Vec::const_iterator;
+	using insert_iterator = typename Vec::iterator;
+
+	static size_t num_entries(const Vec& v) { return N; }
+	template <class Context>
+	static void reserve(Vec& v, size_t size, Context&) {
+	}
+	static insert_iterator insert(Vec& v) { return v.begin(); }
+	static iterator begin(const Vec& v) { return v.begin(); }
+};
+
 template <class Key, class T, class Compare, class Allocator>
 struct vector_like_traits<std::map<Key, T, Compare, Allocator>> : std::true_type {
 	using Vec = std::map<Key, T, Compare, Allocator>;

--- a/flow/flat_buffers.h
+++ b/flow/flat_buffers.h
@@ -1059,11 +1059,15 @@ struct EnsureTable {
 	EnsureTable(const T& t) : t(t) {}
 	template <class Archive>
 	void serialize(Archive& ar) {
-		if constexpr (detail::expect_serialize_member<T>) {
-			if constexpr (serializable_traits<T>::value) {
-				serializable_traits<T>::serialize(ar, t.get());
+		if constexpr (is_fb_function<Archive>) {
+			if constexpr (detail::expect_serialize_member<T>) {
+				if constexpr (serializable_traits<T>::value) {
+					serializable_traits<T>::serialize(ar, t.get());
+				} else {
+					t.get().serialize(ar);
+				}
 			} else {
-				t.get().serialize(ar);
+				serializer(ar, t.get());
 			}
 		} else {
 			serializer(ar, t.get());

--- a/flow/flat_buffers.h
+++ b/flow/flat_buffers.h
@@ -507,7 +507,7 @@ private:
 };
 
 struct InsertVTableLambda {
-	static constexpr bool isDeserializing = true;
+	static constexpr bool isDeserializing = false;
 	static constexpr bool is_fb_visitor = true;
 	std::set<const VTable*>& vtables;
 	std::set<std::type_index>& known_types;

--- a/flow/flat_buffers.h
+++ b/flow/flat_buffers.h
@@ -153,6 +153,21 @@ struct vector_like_traits<std::map<Key, T, Compare, Allocator>> : std::true_type
 	static iterator begin(const Vec& v) { return v.begin(); }
 };
 
+template<class Key, class Compare, class Allocator>
+struct vector_like_traits<std::set<Key, Compare, Allocator>> : std::true_type {
+	using Vec = std::set<Key, Compare, Allocator>;
+	using value_type = Key;
+	using iterator = typename Vec::const_iterator;
+	using insert_iterator = std::insert_iterator<Vec>;
+
+	static size_t num_entries(const Vec& v) { return v.size(); }
+	template <class Context>
+	static void reserve(Vec&, size_t, Context&) {}
+
+	static insert_iterator insert(Vec& v) { return std::inserter(v, v.end()); }
+	static iterator begin(const Vec& v) { return v.begin(); }
+};
+
 template <>
 struct dynamic_size_traits<std::string> : std::true_type {
 private:

--- a/flow/flat_buffers.h
+++ b/flow/flat_buffers.h
@@ -816,7 +816,6 @@ struct LoadSaveHelper {
 	std::enable_if_t<is_struct_like<U>> load(U& member, const uint8_t* current, Context& context) {
 		using StructTraits = struct_like_traits<U>;
 		using types = typename StructTraits::types;
-		constexpr auto size = struct_size(types{});
 		for_each_i<pack_size(types{})>([&](auto i_type) {
 			constexpr int i = decltype(i_type)::value;
 			using type = index_t<i, types>;

--- a/flow/flat_buffers.h
+++ b/flow/flat_buffers.h
@@ -300,8 +300,8 @@ constexpr int fb_align = is_struct_like<T> ? align_helper(typename struct_like_t
 
 template <class T>
 struct _SizeOf {
-	static constexpr int size = fb_size<T>;
-	static constexpr int align = fb_align<T>;
+	static constexpr unsigned int size = fb_size<T>;
+	static constexpr unsigned int align = fb_align<T>;
 };
 
 struct PrecomputeSize {
@@ -351,7 +351,7 @@ struct PrecomputeSize {
 template <class Member, class Context>
 void load_helper(Member&, const uint8_t*, Context&);
 
-class VTableSet;
+struct VTableSet;
 
 template <class T>
 struct is_array : std::false_type {};
@@ -880,7 +880,7 @@ struct LoadSaveHelper {
 		current += sizeof(uint32_t);
 		VectorTraits::reserve(member, numEntries, context);
 		auto inserter = VectorTraits::insert(member);
-		for (int i = 0; i < numEntries; ++i) {
+		for (uint32_t i = 0; i < numEntries; ++i) {
 			T value;
 			load_helper(value, current, context);
 			*inserter = std::move(value);
@@ -945,7 +945,7 @@ struct LoadSaveHelper {
 		uint32_t len = num_entries * size;
 		auto self = writer.getMessageWriter(len);
 		auto iter = VectorTraits::begin(members);
-		for (int i = 0; i < num_entries; ++i) {
+		for (uint32_t i = 0; i < num_entries; ++i) {
 			auto result = save_helper(*iter, writer, vtables);
 			self.write(&result, i * size, size);
 			++iter;
@@ -968,7 +968,7 @@ struct LoadSaveHelper<std::vector<bool, Alloc>> {
 		member.clear();
 		member.resize(length);
 		bool m;
-		for (int i = 0; i < length; ++i) {
+		for (uint32_t i = 0; i < length; ++i) {
 			load_helper(m, current, context);
 			member[i] = m;
 			current += fb_size<bool>;

--- a/flow/flow.h
+++ b/flow/flow.h
@@ -123,9 +123,8 @@ public:
 class Never {};
 
 template <class T>
-class ErrorOr {
+class ErrorOr : public ComposedIdentifier<T, 0x1> {
 public:
-	constexpr static FileIdentifier file_identifier = (0x1 << 24) | FileIdentifierFor<T>::value;
 	ErrorOr() : error(default_error_or()) {}
 	ErrorOr(Error const& error) : error(error) {}
 	ErrorOr(const ErrorOr<T>& o) : error(o.error) {

--- a/flow/flow.h
+++ b/flow/flow.h
@@ -44,6 +44,7 @@
 #include "flow/Deque.h"
 #include "flow/ThreadPrimitives.h"
 #include "flow/network.h"
+#include "flow/FileIdentifier.h"
 
 #include <boost/version.hpp>
 
@@ -114,6 +115,7 @@ Standalone<StringRef> concatenate( Iter b, Iter const& e ) {
 
 class Void {
 public:
+	constexpr static FileIdentifier file_identifier = 2010442;
 	template <class Ar>
 	void serialize(Ar&) {}
 };
@@ -123,6 +125,7 @@ class Never {};
 template <class T>
 class ErrorOr {
 public:
+	constexpr static FileIdentifier file_identifier = (0x1 << 24) | FileIdentifierFor<T>::value;
 	ErrorOr() : error(default_error_or()) {}
 	ErrorOr(Error const& error) : error(error) {}
 	ErrorOr(const ErrorOr<T>& o) : error(o.error) {

--- a/flow/network.cpp
+++ b/flow/network.cpp
@@ -24,20 +24,8 @@
 #include "flow/flow.h"
 #include "flow/UnitTest.h"
 
-IPAddress::IPAddress() : isV6addr(false) {
-	addr.v4 = 0;
-}
-
-IPAddress::IPAddress(const IPAddressStore& v6addr) : isV6addr(true) {
-	addr.v6 = v6addr;
-}
-
-IPAddress::IPAddress(uint32_t v4addr) : isV6addr(false) {
-	addr.v4 = v4addr;
-}
-
 bool IPAddress::operator==(const IPAddress& rhs) const {
-	return isV6addr == rhs.isV6addr && (isV6addr ? addr.v6 == rhs.addr.v6 : addr.v4 == rhs.addr.v4);
+	return addr == rhs.addr;
 }
 
 bool IPAddress::operator!=(const IPAddress& addr) const {
@@ -45,20 +33,15 @@ bool IPAddress::operator!=(const IPAddress& addr) const {
 }
 
 bool IPAddress::operator<(const IPAddress& rhs) const {
-	if(isV6addr != rhs.isV6addr) {
-		return isV6addr < rhs.isV6addr;
-	}
-	if(isV6addr) {
-		return addr.v6 < rhs.addr.v6;
-	}
-	return addr.v4 < rhs.addr.v4;
+	return addr < rhs.addr;
 }
 
 std::string IPAddress::toString() const {
-	if (isV6addr) {
-		return boost::asio::ip::address_v6(addr.v6).to_string();
+	if (isV6()) {
+		return boost::asio::ip::address_v6(std::get<IPAddressStore>(addr)).to_string();
 	} else {
-		return format("%d.%d.%d.%d", (addr.v4 >> 24) & 0xff, (addr.v4 >> 16) & 0xff, (addr.v4 >> 8) & 0xff, addr.v4 & 0xff);
+		auto ip = std::get<uint32_t>(addr);
+		return format("%d.%d.%d.%d", (ip >> 24) & 0xff, (ip >> 16) & 0xff, (ip >> 8) & 0xff, ip & 0xff);
 	}
 }
 
@@ -72,10 +55,11 @@ Optional<IPAddress> IPAddress::parse(std::string str) {
 }
 
 bool IPAddress::isValid() const {
-	if (isV6addr) {
-		return std::any_of(addr.v6.begin(), addr.v6.end(), [](uint8_t part) { return part != 0; });
+	if (isV6()) {
+		const auto& ip = std::get<IPAddressStore>(addr);
+		return std::any_of(ip.begin(), ip.end(), [](uint8_t part) { return part != 0; });
 	}
-	return addr.v4 != 0;
+	return std::get<uint32_t>(addr) != 0;
 }
 
 NetworkAddress NetworkAddress::parse( std::string const& s ) {

--- a/flow/network.h
+++ b/flow/network.h
@@ -120,9 +120,13 @@ struct IPAddress {
 			bool v6 = isV6();
 			serializer(ar, v6);
 			if (v6) {
-				serializer(ar, std::get<IPAddressStore>(addr));
+				IPAddressStore store;
+				serializer(ar, store);
+				addr = store;
 			} else {
-				serializer(ar, std::get<uint32_t>(addr));
+				uint32_t res;
+				serializer(ar, res);
+				addr = res;
 			}
 		}
 	}

--- a/flow/network.h
+++ b/flow/network.h
@@ -399,6 +399,9 @@ public:
 	virtual bool isAddressOnThisHost( NetworkAddress const& addr ) = 0;
 	// Returns true if it is reasonably certain that a connection to the given address would be a fast loopback connection
 
+	virtual bool useObjectSerializer() { return false; }
+	// Whether or not the object serializer should be used when sending packets
+
 	// Shorthand for transport().getLocalAddress()
 	static NetworkAddress getLocalAddress()
 	{

--- a/flow/network.h
+++ b/flow/network.h
@@ -337,7 +337,7 @@ typedef NetworkAddressList (*NetworkAddressesFuncPtr)();
 
 class INetwork;
 extern INetwork* g_network;
-extern INetwork* newNet2(bool useThreadPool = false, bool useMetrics = false);
+extern INetwork* newNet2(bool useThreadPool = false, bool useMetrics = false, bool useObjectSerializer = false);
 
 class INetwork {
 public:
@@ -399,7 +399,7 @@ public:
 	virtual bool isAddressOnThisHost( NetworkAddress const& addr ) = 0;
 	// Returns true if it is reasonably certain that a connection to the given address would be a fast loopback connection
 
-	virtual bool useObjectSerializer() { return false; }
+	virtual bool useObjectSerializer() const = 0;
 	// Whether or not the object serializer should be used when sending packets
 
 	// Shorthand for transport().getLocalAddress()

--- a/flow/serialize.h
+++ b/flow/serialize.h
@@ -130,11 +130,19 @@ public:
 	}
 };
 
+template <class F, class S, bool = HasFileIdentifier<F>::value&& HasFileIdentifier<S>::value>
+struct PairFileIdentifier;
+
 template <class F, class S>
-struct FileIdentifierFor<std::pair<F, S>> {
+struct PairFileIdentifier<F, S, false> {};
+
+template <class F, class S>
+struct PairFileIdentifier<F, S, true> {
 	constexpr static FileIdentifier value = FileIdentifierFor<F>::value ^ FileIdentifierFor<S>::value;
 };
 
+template <class F, class S>
+struct FileIdentifierFor<std::pair<F, S>> : PairFileIdentifier<F, S> {};
 
 template <class Archive, class T1, class T2>
 class Serializer< Archive, std::pair<T1,T2>, void > {
@@ -145,9 +153,7 @@ public:
 };
 
 template <class T, class Allocator>
-struct FileIdentifierFor<std::vector<T, Allocator>> {
-	constexpr static FileIdentifier value = (0x10 << 24) | FileIdentifierFor<T>::value;
-};
+struct FileIdentifierFor<std::vector<T, Allocator>> : ComposedIdentifierExternal<T, 0x10> {};
 
 template <class Archive, class T>
 inline void save( Archive& ar, const std::vector<T>& value ) {

--- a/flow/serialize.h
+++ b/flow/serialize.h
@@ -725,6 +725,7 @@ struct MakeSerializeSource : ISerializeSource {
 		if (useObjectSerializer) {
 			ObjectWriter writer;
 			writer.serialize(get());
+			w.serializeBytes(writer.toStringRef());
 		} else {
 			static_cast<T const*>(this)->serialize(w);
 		}

--- a/flow/serialize.h
+++ b/flow/serialize.h
@@ -715,6 +715,7 @@ private:
 struct ISerializeSource {
 	virtual void serializePacketWriter(PacketWriter&, bool useObjectSerializer) const = 0;
 	virtual void serializeBinaryWriter(BinaryWriter&) const = 0;
+	virtual void serializeBinaryWriter(ObjectWriter&) const = 0;
 };
 
 template <class T, class V>
@@ -737,7 +738,12 @@ struct SerializeSource : MakeSerializeSource<SerializeSource<T>, T> {
 	using value_type = T;
 	T const& value;
 	SerializeSource(T const& value) : value(value) {}
-	template <class Ar> void serialize(Ar& ar) const { ar << value; }
+	virtual void serializeBinaryWriter(ObjectWriter& w) const {
+		w.serialize(value);
+	}
+	template <class Ar> void serialize(Ar& ar) const {
+		ar << value;
+	}
 	virtual T const& get() const { return value; }
 };
 
@@ -748,6 +754,9 @@ struct SerializeBoolAnd : MakeSerializeSource<SerializeBoolAnd<T>, T> {
 	T const& value;
 	SerializeBoolAnd( bool b, T const& value ) : b(b), value(value) {}
 	template <class Ar> void serialize(Ar& ar) const { ar << b << value; }
+	virtual void serializeBinaryWriter(ObjectWriter& w) const {
+		ASSERT(false);
+	}
 	virtual T const& get() const {
 		// This is only used for the streaming serializer
 		ASSERT(false);

--- a/flow/serialize.h
+++ b/flow/serialize.h
@@ -731,7 +731,7 @@ struct MakeSerializeSource : ISerializeSource {
 		if (useObjectSerializer) {
 			ObjectWriter writer;
 			writer.serialize(get());
-			w.serializeBytes(writer.toStringRef());
+			w.serializeBytes(writer.toStringRef()); // TODO(atn34) Eliminate unnecessary memcpy
 		} else {
 			static_cast<T const*>(this)->serialize(w);
 		}

--- a/flow/serialize.h
+++ b/flow/serialize.h
@@ -721,7 +721,7 @@ private:
 struct ISerializeSource {
 	virtual void serializePacketWriter(PacketWriter&, bool useObjectSerializer) const = 0;
 	virtual void serializeBinaryWriter(BinaryWriter&) const = 0;
-	virtual void serializeBinaryWriter(ObjectWriter&) const = 0;
+	virtual void serializeObjectWriter(ObjectWriter&) const = 0;
 };
 
 template <class T, class V>
@@ -745,7 +745,7 @@ struct SerializeSource : MakeSerializeSource<SerializeSource<T>, T> {
 	using value_type = T;
 	T const& value;
 	SerializeSource(T const& value) : value(value) {}
-	virtual void serializeBinaryWriter(ObjectWriter& w) const {
+	virtual void serializeObjectWriter(ObjectWriter& w) const {
 		w.serialize(value);
 	}
 	template <class Ar> void serialize(Ar& ar) const {
@@ -761,7 +761,7 @@ struct SerializeBoolAnd : MakeSerializeSource<SerializeBoolAnd<T>, T> {
 	T const& value;
 	SerializeBoolAnd( bool b, T const& value ) : b(b), value(value) {}
 	template <class Ar> void serialize(Ar& ar) const { ar << b << value; }
-	virtual void serializeBinaryWriter(ObjectWriter& w) const {
+	virtual void serializeObjectWriter(ObjectWriter& w) const {
 		ASSERT(false);
 	}
 	virtual T const& get() const {

--- a/tests/TestRunner/TestRunner.py
+++ b/tests/TestRunner/TestRunner.py
@@ -271,6 +271,9 @@ def run_simulation_test(basedir, options):
     if options.testtype == 'test':
         pargs.append('-C')
         pargs.append(os.path.join(args.builddir, 'fdb.cluster'))
+    else:
+        pargs.append('-S')
+        pargs.append('random')
     td = TestDirectory(basedir)
     if options.buggify:
         pargs.append('-b')


### PR DESCRIPTION
In order to make the code review process for flatbuffers less painful (as this will be a quite large change), I am going to make a code review early in the process so that people can take a look. The main ideas here are:

1. There are now object serializers that use flatbuffers to serialize and deserialize data. They are called object serializers as they do not support streaming (one can only serialize a root object). This serializer does not need the versioning and is fully upwards and downwards compatible if used correctly.
2. The version number includes a flag that will be set whenever a connecting process sends data that was serialized using this object serializer.
3. The idea will be to use a flag to instruct processes whether they should send data using this serializer. They can read objects serialized with either serializer (and decide which one to use by looking at the version number flag). This allows us to set this flag one process at a time. The reason this is done this way is because processes don't exchange versions both ways. The network code for this is mostly complete (though untested).
4. All data that is written to disk (for example to the system key-space) will still use the current serializer (which supports streaming and is order-preserving if it is unversioned). For newly introduced data, the user can chose which one to use.