### PR TITLE
Python: _CBFUNC should be defined outside init_c_api

### DIFF
--- a/bindings/python/fdb/impl.py
+++ b/bindings/python/fdb/impl.py
@@ -1284,6 +1284,7 @@ def optionalParamToBytes(v):
 
 
 _FDBBase.capi = _capi
+_CBFUNC = ctypes.CFUNCTYPE(None, ctypes.c_void_p)
 
 def init_c_api():
     _capi.fdb_select_api_version_impl.argtypes = [ctypes.c_int, ctypes.c_int]
@@ -1326,8 +1327,6 @@ def init_c_api():
 
     _capi.fdb_future_is_ready.argtypes = [ctypes.c_void_p]
     _capi.fdb_future_is_ready.restype = ctypes.c_int
-
-    _CBFUNC = ctypes.CFUNCTYPE(None, ctypes.c_void_p)
 
     _capi.fdb_future_set_callback.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p]
     _capi.fdb_future_set_callback.restype = int


### PR DESCRIPTION
This is both because it doesn't depend on the C API and because it is used elsewhere and wasn't available globally as previously written.

I haven't run this through the binding tester, but we should once we are able. We can defer the merge until then, but since this is pretty simple we can go ahead and get the review out of the way.