### PR TITLE
Add trace_format network option

### DIFF
--- a/bindings/go/src/fdb/generated.go
+++ b/bindings/go/src/fdb/generated.go
@@ -92,6 +92,13 @@ func (o NetworkOptions) SetTraceLogGroup(param string) error {
 	return o.setOpt(33, []byte(param))
 }
 
+// Selects trace output format for this client. xml (the default) and json are supported.
+//
+// Parameter: trace format
+func (o NetworkOptions) SetTraceFormat(param string) error {
+	return o.setOpt(34, []byte(param))
+}
+
 // Set internal tuning or debugging knobs
 //
 // Parameter: knob_name=knob_value

--- a/documentation/sphinx/source/api-common.rst.inc
+++ b/documentation/sphinx/source/api-common.rst.inc
@@ -232,6 +232,9 @@
 .. |option-trace-roll-size-blurb| replace::
     Sets the maximum size in bytes of a single trace output file for this FoundationDB client.
 
+.. |option-trace-format-blurb| replace::
+    Select the format of the trace files for this FoundationDB client. xml (the default) and json are supported.
+
 .. |network-options-warning| replace::
 
     It is an error to set these options after the first call to |open-func| anywhere in your application.

--- a/documentation/sphinx/source/api-python.rst
+++ b/documentation/sphinx/source/api-python.rst
@@ -117,6 +117,10 @@ After importing the ``fdb`` module and selecting an API version, you probably wa
 
        |option-trace-roll-size-blurb|
 
+    .. method :: fdb.options.set_trace_format(format)
+
+       |option-trace-format-blurb|
+
     .. method :: fdb.options.set_disable_multi_version_client_api()
 
        |option-disable-multi-version-client-api|

--- a/documentation/sphinx/source/api-ruby.rst
+++ b/documentation/sphinx/source/api-ruby.rst
@@ -104,6 +104,10 @@ After requiring the ``FDB`` gem and selecting an API version, you probably want 
 
         |option-trace-roll-size-blurb|
 
+    .. method:: FDB.options.set_trace_format(format) -> nil
+
+        |option-trace-format-blurb|
+
        |option-disable-multi-version-client-api|
 
     .. method :: FDB.options.set_callbacks_on_external_threads() -> nil

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -799,6 +799,10 @@ void setNetworkOption(FDBNetworkOptions::Option option, Optional<StringRef> valu
 		case FDBNetworkOptions::TRACE_FORMAT:
 			validateOptionValue(value, true);
 			networkOptions.traceFormat = value.get().toString();
+			if (!validateTraceFormat(networkOptions.traceFormat)) {
+				fprintf(stderr, "Unrecognized trace format: `%s'\n", networkOptions.traceFormat.c_str());
+				throw invalid_option_value();
+			}
 			break;
 		case FDBNetworkOptions::KNOB: {
 			validateOptionValue(value, true);

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -743,6 +743,7 @@ void Cluster::init( Reference<ClusterConnectionFile> connFile, bool startClientI
 			initTraceEventMetrics();
 
 			auto publicIP = determinePublicIPAutomatically( connFile->getConnectionString() );
+			selectTraceFormatter(networkOptions.traceFormat);
 			openTraceFile(NetworkAddress(publicIP, ::getpid()), networkOptions.traceRollSize, networkOptions.traceMaxLogsSize, networkOptions.traceDirectory.get(), "trace", networkOptions.traceLogGroup);
 
 			TraceEvent("ClientStart")
@@ -794,6 +795,10 @@ void setNetworkOption(FDBNetworkOptions::Option option, Optional<StringRef> valu
 		case FDBNetworkOptions::TRACE_LOG_GROUP:
 			if(value.present())
 				networkOptions.traceLogGroup = value.get().toString();
+			break;
+		case FDBNetworkOptions::TRACE_FORMAT:
+			validateOptionValue(value, true);
+			networkOptions.traceFormat = value.get().toString();
 			break;
 		case FDBNetworkOptions::KNOB: {
 			validateOptionValue(value, true);

--- a/fdbclient/NativeAPI.h
+++ b/fdbclient/NativeAPI.h
@@ -47,14 +47,16 @@ struct NetworkOptions {
 	uint64_t traceRollSize;
 	uint64_t traceMaxLogsSize;	
 	std::string traceLogGroup;
+	std::string traceFormat;
 	Optional<bool> logClientInfo;
 	Standalone<VectorRef<ClientVersionRef>> supportedVersions;
 	bool slowTaskProfilingEnabled;
 
 	// The default values, TRACE_DEFAULT_ROLL_SIZE and TRACE_DEFAULT_MAX_LOGS_SIZE are located in Trace.h.
-	NetworkOptions() : localAddress(""), clusterFile(""), traceDirectory(Optional<std::string>()), traceRollSize(TRACE_DEFAULT_ROLL_SIZE), traceMaxLogsSize(TRACE_DEFAULT_MAX_LOGS_SIZE), traceLogGroup("default"),
-	                   slowTaskProfilingEnabled(false)
-	{ }
+	NetworkOptions()
+	  : localAddress(""), clusterFile(""), traceDirectory(Optional<std::string>()),
+	    traceRollSize(TRACE_DEFAULT_ROLL_SIZE), traceMaxLogsSize(TRACE_DEFAULT_MAX_LOGS_SIZE), traceLogGroup("default"),
+	    traceFormat("xml"), slowTaskProfilingEnabled(false) {}
 };
 
 class Database {

--- a/fdbclient/vexillographer/fdb.options
+++ b/fdbclient/vexillographer/fdb.options
@@ -48,6 +48,9 @@ description is not currently required but encouraged.
     <Option name="trace_log_group" code="33"
             paramType="String" paramDescription="value of the LogGroup attribute"
             description="Sets the 'LogGroup' attribute with the specified value for all events in the trace output files. The default log group is 'default'."/>
+    <Option name="trace_format" code="34"
+            paramType="String" paramDescription="Format of trace files"
+            description="Select the format of the log files. xml (the default) and json are supported."/>
     <Option name="knob" code="40"
             paramType="String" paramDescription="knob_name=knob_value"
             description="Set internal tuning or debugging knobs"/>

--- a/flow/Trace.h
+++ b/flow/Trace.h
@@ -265,6 +265,8 @@ bool traceFileIsOpen();
 // Changes the format of trace files. Returns false if the format is unrecognized. No longer safe to call after a call
 // to openTraceFile.
 bool selectTraceFormatter(std::string format);
+// Returns true iff format is recognized.
+bool validateTraceFormat(std::string format);
 
 void addTraceRole(std::string role);
 void removeTraceRole(std::string role);


### PR DESCRIPTION
Resolves #997. I tested that I could select the trace formatter for the client from the python bindings.