### PR TITLE
Staying consistent with Pointer syntax

### DIFF
--- a/bindings/c/foundationdb/fdb_c.h
+++ b/bindings/c/foundationdb/fdb_c.h
@@ -99,7 +99,7 @@ extern "C" {
     } FDBKeyValue;
 #pragma pack(pop)
 
-    DLLEXPORT void fdb_future_cancel( FDBFuture *f );
+    DLLEXPORT void fdb_future_cancel( FDBFuture* f );
 
     DLLEXPORT void fdb_future_release_memory( FDBFuture* f );
 


### PR DESCRIPTION
Space after '*' instead of before it