### PR TITLE
Allow forward declarations to be actors

### DIFF
--- a/flow/actorcompiler/ActorCompiler.cs
+++ b/flow/actorcompiler/ActorCompiler.cs
@@ -300,6 +300,13 @@ namespace actorcompiler
         }
         public void Write(TextWriter writer)
         {
+            string fullReturnType =
+                actor.returnType != null ? string.Format("Future<{0}>", actor.returnType)
+                : "void";
+            if (actor.isForwardDeclaration) {
+                writer.WriteLine("{0} {3}{1}( {2} );", fullReturnType, actor.name, string.Join(", ", ParameterList()), actor.nameSpace==null ? "" : actor.nameSpace + "::");
+                return;
+            }
             for (int i = 0; ; i++)
             {
                 className = string.Format("{0}{1}Actor{2}",
@@ -391,9 +398,6 @@ namespace actorcompiler
             if (isTopLevel) writer.WriteLine("}");  // namespace
             WriteTemplate(writer);
             LineNumber(writer, actor.SourceLine);
-            string fullReturnType =
-                actor.returnType != null ? string.Format("Future<{0}>", actor.returnType)
-                : "void";
             if (actor.isStatic) writer.Write("static ");
             writer.WriteLine("{0} {3}{1}( {2} ) {{", fullReturnType, actor.name, string.Join(", ", ParameterList()), actor.nameSpace==null ? "" : actor.nameSpace + "::");
             LineNumber(writer, actor.SourceLine);

--- a/flow/actorcompiler/ParseTree.cs
+++ b/flow/actorcompiler/ParseTree.cs
@@ -233,6 +233,7 @@ namespace actorcompiler
         public bool isUncancellable = false;
         public string testCaseParameters = null;
         public string nameSpace = null;
+        public bool isForwardDeclaration = false;
     };
 
     class Descr


### PR DESCRIPTION
If an actor is forward declared it is kind of
awkward as the signatures don't fit. For example:

Future<Void> foo(int const& bar);

is the correct forward declaration for this actor:

ACTOR Future<Void> foo(int bar);

This also means that a lot of tooling (like rtags/cquery etc)
doesn't work correctly. It will show errors that the function
calls are ambiguous and "find references"-features typically
don't work.

Allowing to do this in the actor compiler is the first step. The
next will be to refactor all forward declarations.