### PR TITLE
Increment Build Docker Version

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:15.04
-LABEL version=0.0.2
+LABEL version=0.0.3
 
 RUN sed -i -e 's/archive.ubuntu.com\|security.ubuntu.com/old-releases.ubuntu.com/g' -e 's/us\.old/old/g' /etc/apt/sources.list && apt-get clean
 

--- a/build/docker-compose.yaml
+++ b/build/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   common: &common
-    image: foundationdb-build:0.0.2
+    image: foundationdb-build:0.0.3
     build:
       context: .
       dockerfile: Dockerfile


### PR DESCRIPTION
Incrementing version of build docker due to changes made in earlier commit that added boost version 1.67