### PR TITLE
Added Missing Binaries To Runtime Image

### DIFF
--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -37,8 +37,8 @@ RUN ls -l /mnt/website
 RUN curl $FDB_WEBSITE/downloads/$FDB_VERSION/linux/fdb_$FDB_VERSION.tar.gz -o fdb_$FDB_VERSION.tar.gz && \
 	tar -xzf fdb_$FDB_VERSION.tar.gz --strip-components=1 && \
 	rm fdb_$FDB_VERSION.tar.gz && \
-	chmod u+x fdb* && \
-	mv fdb* /usr/bin && \
+	chmod u+x fdbbackup fdbcli fdbdr fdbmonitor fdbrestore fdbserver backup_agent dr_agent && \
+	mv fdbbackup fdbcli fdbdr fdbmonitor fdbrestore fdbserver backup_agent dr_agent /usr/bin && \
 	rm -r /var/fdb/tmp
 
 WORKDIR /var/fdb
@@ -50,7 +50,8 @@ ARG FDB_ADDITIONAL_VERSIONS="5.1.7"
 COPY download_multiversion_libraries.bash scripts/
 
 RUN curl $FDB_WEBSITE/downloads/$FDB_VERSION/linux/libfdb_c_$FDB_VERSION.so -o /usr/lib/libfdb_c.so && \
-	bash scripts/download_multiversion_libraries.bash $FDB_WEBSITE $FDB_ADDITIONAL_VERSIONS
+	bash scripts/download_multiversion_libraries.bash $FDB_WEBSITE $FDB_ADDITIONAL_VERSIONS && \
+	rm -rf /mnt/website
 
 # Set Up Runtime Scripts and Directories
 


### PR DESCRIPTION
Added backup_agent and dr_agent to runtime docker image
Removed mounted website directory from image
Explicitly listed runtimes being copied to runtime image