### PR TITLE
GCC 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Developers on a OS for which there is no binary package, or who would like to st
 1. Run the docker image interactively [Docker Run](https://docs.docker.com/engine/reference/run/#general-form) with the directory containing the foundationdb repo mounted [Docker Mounts](https://docs.docker.com/storage/volumes/).
 
     ```shell
-    docker run -it -v '/local/dir/path/foundationdb:/docker/dir/path/foundationdb' <image-tag-name> /bin/bash
+    docker run -it -v '/local/dir/path/foundationdb:/docker/dir/path/foundationdb' <image-tag-name>
     ```
 
 1. Navigate to the container's mounted directory which contains the foundationdb repo.

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,45 +1,30 @@
-FROM ubuntu:15.04
-LABEL version=0.0.3
+FROM centos:6
+LABEL version=0.1
 
-RUN sed -i -e 's/archive.ubuntu.com\|security.ubuntu.com/old-releases.ubuntu.com/g' -e 's/us\.old/old/g' /etc/apt/sources.list && apt-get clean
+RUN yum install -y yum-utils
+RUN yum-config-manager --enable rhel-server-rhscl-7-rpms
+RUN yum -y install centos-release-scl
+RUN yum install -y devtoolset-7
 
-RUN apt-get update && apt-get --no-install-recommends install -y --force-yes bzip2 ca-certificates=20141019 adduser apt base-files base-passwd bash binutils build-essential cpp cpp-4.9 dpkg dos2unix fakeroot findutils g++=4:4.9.2-2ubuntu2 g++-4.9=4.9.2-10ubuntu13 gawk=1:4.1.1+dfsg-1 gcc-5-base gcc=4:4.9.2-2ubuntu2 gcc-4.9=4.9.2-10ubuntu13 gcc-4.9-base:amd64=4.9.2-10ubuntu13 gcc-5-base:amd64=5.1~rc1-0ubuntu1 gdb git golang golang-go golang-go-linux-amd64 golang-src grep gzip hostname java-common libasan1 liblsan0 libtsan0 libubsan0 libcilkrts5 libgcc-4.9-dev libstdc++-4.9-dev libgl1-mesa-dri libgl1-mesa-glx libmono-system-xml-linq4.0-cil libmono-system-data-datasetextensions4.0-cil libstdc++-4.9-pic locales login m4 make makedev mawk mono-dmcs npm openjdk-8-jdk passwd python-distlib python-gevent python-greenlet python-html5lib python-minimal python-pip python-pkg-resources python-requests python-setuptools python-six python-urllib3 python-yaml python2.7 python2.7-minimal rpm rpm2cpio ruby ruby2.1 rubygems-integration sed tar texinfo tzdata-java udev unzip util-linux valgrind vim wget golang-go.tools curl sphinx-common gnupg python-dev
+# install cmake
+RUN curl -L https://github.com/Kitware/CMake/releases/download/v3.13.4/cmake-3.13.4-Linux-x86_64.tar.gz > /tmp/cmake.tar.gz &&\
+    echo "563a39e0a7c7368f81bfa1c3aff8b590a0617cdfe51177ddc808f66cc0866c76  /tmp/cmake.tar.gz" > /tmp/cmake-sha.txt &&\
+    sha256sum -c /tmp/cmake-sha.txt &&\
+    cd /tmp && tar xf cmake.tar.gz && cp -r cmake-3.13.4-Linux-x86_64/* /usr/local/
 
-RUN adduser --disabled-password --gecos '' fdb && chown -R fdb /opt && chmod -R 0777 /opt
+# install boost
+RUN curl -L https://dl.bintray.com/boostorg/release/1.67.0/source/boost_1_67_0.tar.bz2 > /tmp/boost.tar.bz2 &&\
+    cd /tmp && echo "2684c972994ee57fc5632e03bf044746f6eb45d4920c343937a465fd67a5adba  boost.tar.bz2" > boost-sha.txt &&\
+    sha256sum -c boost-sha.txt && tar xf boost.tar.bz2 && cp -r boost_1_67_0/boost /usr/local/include/
 
-USER fdb
+# install mono (for actorcompiler)
+RUN yum install -y epel-release
+RUN yum install -y mono-core
 
-# wget of bintray without forcing UTF-8 encoding results in 403 Forbidden
-RUN cd /opt/ && wget http://downloads.sourceforge.net/project/boost/boost/1.52.0/boost_1_52_0.tar.bz2 &&\
-    wget --local-encoding=UTF-8 https://dl.bintray.com/boostorg/release/1.67.0/source/boost_1_67_0.tar.bz2 &&\
-    echo '2684c972994ee57fc5632e03bf044746f6eb45d4920c343937a465fd67a5adba boost_1_67_0.tar.bz2' | sha256sum -c - &&\
-    tar -xjf boost_1_52_0.tar.bz2 &&\
-    tar -xjf boost_1_67_0.tar.bz2 &&\
-    rm boost_1_52_0.tar.bz2 boost_1_67_0.tar.bz2
+# install Java
+RUN yum install -y java-1.8.0-openjdk-devel
 
-USER root
+# install python
+RUN yum install -y rh-python36-python-devel
 
-RUN pip install boto3==1.1.1
-
-RUN ln -s /usr/bin/nodejs /usr/bin/node
-
-RUN cd /opt/ && wget https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-2.6.4.tar.gz &&\
-    wget https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-2.6.4.tar.gz.asc &&\
-    wget https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl.asc &&\
-    gpg --import libressl.asc && gpg --verify libressl-2.6.4.tar.gz.asc libressl-2.6.4.tar.gz &&\
-    tar -xzf libressl-2.6.4.tar.gz && cd libressl-2.6.4 &&\
-    ./configure CFLAGS="-fPIC -O3" && make -j4 && make install &&\
-    cd /opt/ && rm -r libressl-2.6.4/ libressl-2.6.4.tar.gz libressl-2.6.4.tar.gz.asc libressl.asc
-
-RUN LANGUAGE=en_US.UTF-8 LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 locale-gen en_US.UTF-8
-
-RUN dpkg-reconfigure locales
-
-ARG TARGET_LIBC_VERSION=2.17
-ENV TARGET_LIBC_VERSION=$TARGET_LIBC_VERSION
-
-ARG CC=/usr/bin/gcc
-ENV CC=$CC
-
-ARG LIBRARY_PATH=/usr/local/lib
-ENV LIBRARY_PATH=$LD_FLAGS
+CMD scl enable devtoolset-7 -- scl enable rh-python36 -- bash

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -27,4 +27,12 @@ RUN yum install -y java-1.8.0-openjdk-devel
 # install python
 RUN yum install -y rh-python36-python-devel
 
+# install LibreSSL
+RUN curl https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-2.8.2.tar.gz > /tmp/libressl.tar.gz &&\
+    cd /tmp && echo "b8cb31e59f1294557bfc80f2a662969bc064e83006ceef0574e2553a1c254fd5  libressl.tar.gz" > libressl-sha.txt &&\
+    sha256sum -c libressl-sha.txt && tar xf libressl.tar.gz &&\
+    cd libressl-2.8.2
+RUN cd /tmp/libressl-2.8.2 && scl enable devtoolset-7 -- ./configure --prefix=/usr/local/stow/libressl CFLAGS="-fPIC -O3" --prefix=/usr/local
+RUN cd /tmp/libressl-2.8.2 && scl enable devtoolset-7 -- make -j`nproc` install
+
 CMD scl enable devtoolset-7 -- scl enable rh-python36 -- bash

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,5 +1,5 @@
 FROM centos:6
-LABEL version=0.1
+LABEL version=0.0.4
 
 RUN yum install -y yum-utils
 RUN yum-config-manager --enable rhel-server-rhscl-7-rpms

--- a/build/docker-compose.yaml
+++ b/build/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   common: &common
-    image: foundationdb-build:0.0.3
+    image: foundationdb-build:0.0.4
     build:
       context: .
       dockerfile: Dockerfile


### PR DESCRIPTION
I rewrote the current Dockerfile so that it supports gcc 7. This file now uses CentOS 6 instead of Ubuntu 15.04 for the following reasons:

1. This is what Snowflake uses internally and we therefore are willing to keep this maintained.
2. It is relatively easy to get recent versions of gcc etc in CentOS.
3. As CentOS 6 is very old, it uses a very old glibc. This means that produced binaries will probably run on almost any Linux installation used today.

The main motivation for us is that some of the changes we try to get ported to open source depend on C++17