### PR TITLE
documentation: Update class-scheduling and class-scheduling-go to inc…

### DIFF
--- a/documentation/sphinx/source/class-scheduling.rst
+++ b/documentation/sphinx/source/class-scheduling.rst
@@ -133,6 +133,10 @@ is equivalent to something like::
 
 If instead you pass a :class:`Transaction` for the ``tr`` parameter, the transaction will be used directly, and it is assumed that the caller implements appropriate retry logic for errors. This permits transactionally decorated functions to be composed into larger transactions.
 
+It is important to note that transactions will not timeout by default. You should set a timeout (adjust from 3000ms to fit your needs) with::
+
+    tr.options.set_timeout(3000)
+
 Making some sample classes
 --------------------------
 


### PR DESCRIPTION
Added transaction timeouts in golang to the class scheduling examples as well as a quick message in the class scheduling introduction noting that timeouts are important.

documentation: include transaction timeouts in examples
fixes: #882

Perhaps someone wants to add the java and ruby equivalents here also.