### PR TITLE
Spill-by-reference TLog Part 1: IDiskQueue::read()

### DIFF
--- a/fdbserver/DiskQueue.actor.cpp
+++ b/fdbserver/DiskQueue.actor.cpp
@@ -110,6 +110,7 @@ private:
 	}
 };
 
+// We use a Tracked instead of a Reference when the shutdown/destructor code would need to wait().
 template <typename T>
 class Tracked {
 protected:
@@ -951,6 +952,60 @@ private:
 			ASSERT(secondChunk.size() == (toPage + 1) * _PAGE_SIZE);
 			ASSERT( ((Page*)secondChunk.end() - 1)->seq == (end.lo - 1) / _PAGE_SIZE * _PAGE_SIZE );
 			return firstChunk.withSuffix(secondChunk);
+		}
+	}
+
+	ACTOR static Future<Standalone<StringRef>> read(DiskQueue *self, location start, location end) {
+		// This `state` is unnecessary, but works around pagedData wrongly becoming const
+		// due to the actor compiler.
+		state Standalone<StringRef> pagedData = wait(readPages(self, start, end));
+		ASSERT(start.lo % sizeof(Page) == 0 ||
+		       start.lo % sizeof(Page) >= sizeof(PageHeader));
+		int startingOffset = start.lo % sizeof(Page);
+		if (startingOffset > 0) startingOffset -= sizeof(PageHeader);
+		ASSERT(end.lo % sizeof(Page) == 0 ||
+		       end.lo % sizeof(Page) > sizeof(PageHeader));
+		int endingOffset = end.lo % sizeof(Page);
+		if (endingOffset == 0) endingOffset = sizeof(Page);
+		if (endingOffset > 0) endingOffset -= sizeof(PageHeader);
+
+		if ((end.lo-1)/sizeof(Page)*sizeof(Page) == start.lo/sizeof(Page)*sizeof(Page)) {
+			// start and end are on the same page
+			ASSERT(pagedData.size() == sizeof(Page));
+			pagedData.contents() = pagedData.substr(sizeof(PageHeader) + startingOffset, endingOffset - startingOffset);
+			return pagedData;
+		} else {
+			// FIXME: This allocation is excessive and unnecessary.  We know the overhead per page that
+			// we'll be stripping out (sizeof(PageHeader)), so we should be able to do a smaller
+			// allocation.  But we should be able to re-use the space allocated for pagedData, which
+			// would mean not having to allocate 2x the space for a read.
+			Standalone<StringRef> unpagedData = makeString(pagedData.size());
+			uint8_t *buf = mutateString(unpagedData);
+			memset(buf, 0, unpagedData.size());
+			const Page *data = reinterpret_cast<const Page*>(pagedData.begin());
+
+			// Only start copying from `start` in the first page.
+			if( data->payloadSize > startingOffset ) {
+				memcpy(buf, data->payload+startingOffset, data->payloadSize-startingOffset);
+				buf += data->payloadSize-startingOffset;
+			}
+			data++;
+
+			// Copy all the middle pages
+			while (data->seq != ((end.lo-1)/sizeof(Page)*sizeof(Page))) {
+				// These pages can have varying amounts of data, as pages with partial
+				// data will be zero-filled when commit is called.
+				memcpy(buf, data->payload, data->payloadSize);
+				buf += data->payloadSize;
+				data++;
+			}
+
+			// Copy only until `end` in the last page.
+			memcpy(buf, data->payload, std::min(endingOffset, data->payloadSize));
+			buf += std::min(endingOffset, data->payloadSize);
+
+			unpagedData.contents() = unpagedData.substr(0, buf - unpagedData.begin());
+			return unpagedData;
 		}
 	}
 

--- a/fdbserver/DiskQueue.actor.cpp
+++ b/fdbserver/DiskQueue.actor.cpp
@@ -713,6 +713,7 @@ public:
 		}
 		return endLocation();
 	}
+
 	virtual void pop( location upTo ) {
 		ASSERT( !upTo.hi );
 		ASSERT( !recovered || upTo.lo <= endLocation() );
@@ -731,6 +732,8 @@ public:
 			anyPopped = true;
 		}
 	}
+
+	virtual Future<Standalone<StringRef>> read(location from, location to) { return read(this, from, to); }
 
 	int getMaxPayload() {
 		return Page::maxPayload;
@@ -1240,6 +1243,8 @@ public:
 	Future<Standalone<StringRef>> readNext( int bytes ) { return readNext(this, bytes); }
 
 	virtual location getNextReadLocation() { return queue->getNextReadLocation(); }
+
+	virtual Future<Standalone<StringRef>> read( location start, location end ) { return queue->read( start, end ); }
 
 	virtual location push( StringRef contents ) {
 		pushed = queue->push(contents);

--- a/fdbserver/DiskQueue.actor.cpp
+++ b/fdbserver/DiskQueue.actor.cpp
@@ -923,8 +923,9 @@ private:
 		self->findPhysicalLocation(end.lo-1, &toFile, &toPage, nullptr);
 		if (fromFile == 0) { ASSERT( fromPage < file0size / _PAGE_SIZE ); }
 		if (toFile == 0) { ASSERT( toPage < file0size / _PAGE_SIZE ); }
-		if (fromFile == 1) { ASSERT( fromPage < self->rawQueue->writingPos / _PAGE_SIZE ); }
-		if (toFile == 1) { ASSERT( toPage < self->rawQueue->writingPos / _PAGE_SIZE ); }
+		// FIXME I think there's something with nextReadLocation we can do here when initialized && !recovered.
+		if (fromFile == 1 && self->recovered) { ASSERT( fromPage < self->rawQueue->writingPos / _PAGE_SIZE ); }
+		if (toFile == 1 && self->recovered) { ASSERT( toPage < self->rawQueue->writingPos / _PAGE_SIZE ); }
 		if (fromFile == toFile) {
 			ASSERT(toPage >= fromPage);
 			Standalone<StringRef> pagedData = wait( self->rawQueue->read( fromFile, fromPage, toPage - fromPage + 1 ) );

--- a/fdbserver/IDiskQueue.h
+++ b/fdbserver/IDiskQueue.h
@@ -41,6 +41,14 @@ public:
 		}
 	};
 
+	//! Find the first and last pages in the disk queue, and initialize invariants.
+	//!
+	//! Most importantly, most invariants only hold after this function returns, and
+	//! some functions assert that the IDiskQueue has been initialized.
+	//!
+	//! \returns True, if DiskQueue is now considered in a recovered state.
+	//!          False, if the caller should call readNext until recovered is true.
+	virtual Future<bool> initializeRecovery() = 0;
 	// Before calling push or commit, the caller *must* perform recovery by calling readNext() until it returns less than the requested number of bytes.
 	// Thereafter it may not be called again.
 	virtual Future<Standalone<StringRef>> readNext( int bytes ) = 0;  // Return the next bytes in the queue (beginning, the first time called, with the first unpopped byte)

--- a/fdbserver/IDiskQueue.h
+++ b/fdbserver/IDiskQueue.h
@@ -54,6 +54,7 @@ public:
 	virtual Future<Standalone<StringRef>> readNext( int bytes ) = 0;  // Return the next bytes in the queue (beginning, the first time called, with the first unpopped byte)
 	virtual location getNextReadLocation() = 0;    // Returns a location >= the location of all bytes previously returned by readNext(), and <= the location of all bytes subsequently returned
 
+	virtual Future<Standalone<StringRef>> read( location start, location end ) = 0;
 	virtual location push( StringRef contents ) = 0;  // Appends the given bytes to the byte stream.  Returns a location token representing the *end* of the contents.
 	virtual void pop( location upTo ) = 0;            // Removes all bytes before the given location token from the byte stream.
 	virtual Future<Void> commit() = 0;  // returns when all prior pushes and pops are durable.  If commit does not return (due to close or a crash), any prefix of the pushed bytes and any prefix of the popped bytes may be durable.

--- a/fdbserver/LogSystemDiskQueueAdapter.h
+++ b/fdbserver/LogSystemDiskQueueAdapter.h
@@ -67,6 +67,7 @@ public:
 	virtual void close();
 
 	// IDiskQueue interface
+	virtual Future<bool> initializeRecovery() { return false; }
 	virtual Future<Standalone<StringRef>> readNext( int bytes );
 	virtual IDiskQueue::location getNextReadLocation();
 	virtual IDiskQueue::location push( StringRef contents );

--- a/fdbserver/LogSystemDiskQueueAdapter.h
+++ b/fdbserver/LogSystemDiskQueueAdapter.h
@@ -70,6 +70,7 @@ public:
 	virtual Future<bool> initializeRecovery() { return false; }
 	virtual Future<Standalone<StringRef>> readNext( int bytes );
 	virtual IDiskQueue::location getNextReadLocation();
+	virtual Future<Standalone<StringRef>> read( location start, location end ) { ASSERT(false); throw internal_error(); }
 	virtual IDiskQueue::location push( StringRef contents );
 	virtual void pop( IDiskQueue::location upTo );
 	virtual Future<Void> commit();

--- a/flow/Arena.h
+++ b/flow/Arena.h
@@ -547,6 +547,14 @@ inline static Standalone<StringRef> makeString( int length ) {
 	return returnString;
 }
 
+inline static Standalone<StringRef> makeAlignedString( int alignment, int length ) {
+	Standalone<StringRef> returnString;
+	uint8_t *outData = new (returnString.arena()) uint8_t[alignment + length];
+	outData = (uint8_t*)((((uintptr_t)outData + (alignment - 1)) / alignment) * alignment);
+	((StringRef&)returnString) = StringRef(outData, length);
+	return returnString;
+}
+
 inline static StringRef makeString( int length, Arena& arena ) {
 	uint8_t *outData = new (arena) uint8_t[length];
 	return StringRef(outData, length);

--- a/flow/Error.cpp
+++ b/flow/Error.cpp
@@ -117,3 +117,7 @@ void ErrorCodeTable::addCode(int code, const char *name, const char *description
 bool isAssertDisabled(int line) {
 	return FLOW_KNOBS && (FLOW_KNOBS->DISABLE_ASSERTS == -1 || FLOW_KNOBS->DISABLE_ASSERTS == line);
 }
+
+void breakpoint_me() {
+	return;
+}

--- a/flow/Error.h
+++ b/flow/Error.h
@@ -98,6 +98,8 @@ extern bool isAssertDisabled( int line );
 	catch(Error &e) { criticalError(FDB_EXIT_ABORT, "AbortOnError", e.what()); } \
 	catch(...) { criticalError(FDB_EXIT_ABORT, "AbortOnError", "Aborted due to unknown error"); }
 
+EXTERNC void breakpoint_me();
+
 #ifdef FDB_CLEAN_BUILD
 #  define NOT_IN_CLEAN BOOST_STATIC_ASSERT_MSG(0, "This code can not be enabled in a clean build.");
 #else


### PR DESCRIPTION
The only time we've ever read from a DiskQueue before is when doing recovery.  Now, we're going to be looking to read arbitrary sections of the DiskQueue.

This PR builds up to introducing a fully implemented IDiskQueue::read(), that will then be used in a later PR to read commits out of the Disk Queue.

Part 1/? of #1048 