### PR TITLE
Build java fat-jar and make java-dependency optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ project(fdb
   VERSION 6.1.0
   DESCRIPTION "FoundationDB is a scalable, fault-tolerant, ordered key-value store with full ACID transactions."
   HOMEPAGE_URL "http://www.foundationdb.org/"
-  LANGUAGES ASM C CXX Java)
+  LANGUAGES ASM C CXX)
 
 if(WIN32)
   # C# is currently only supported on Windows.
@@ -57,29 +57,16 @@ find_package(PythonLibs 3.4 REQUIRED)
 
 
 ################################################################################
-# LibreSSL
+# Compiler configuration
 ################################################################################
 
-set(DISABLE_TLS OFF CACHE BOOL "Don't try to find LibreSSL and always build without TLS support")
-if(DISABLE_TLS)
-  set(WITH_TLS FALSE)
-else()
-  set(LIBRESSL_USE_STATIC_LIBS TRUE)
-  find_package(LibreSSL)
-  if(LibreSSL_FOUND)
-    set(WITH_TLS TRUE)
-  else()
-    message(STATUS "LibreSSL NOT Found - Will compile without TLS Support")
-    message(STATUS "You can set LibreSSL_ROOT to the LibreSSL install directory to help cmake find it")
-    set(WITH_TLS FALSE)
-  endif()
-endif()
+include(ConfigureCompiler)
 
 ################################################################################
 # Compiler configuration
 ################################################################################
 
-include(ConfigureCompiler)
+include(FDBComponents)
 
 ################################################################################
 # Get repository information
@@ -256,3 +243,9 @@ if (CMAKE_EXPORT_COMPILE_COMMANDS)
 	)
   add_custom_target(procossed_compile_commands ALL DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/compile_commands.json ${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json)
 endif()
+
+################################################################################
+# Inform user which components we are going to build
+################################################################################
+
+print_components()

--- a/README.md
+++ b/README.md
@@ -104,6 +104,16 @@ cmake -DLibreSSL_ROOT=/usr/local/libressl-2.8.3/ ../foundationdb
 FoundationDB will build just fine without LibreSSL, however, the resulting
 binaries won't support TLS connections.
 
+### Language Bindings
+
+The language bindings that are supported by cmake will have a corresponding
+`README.md` file in the corresponding `bindings/lang` directory.
+
+Generally, cmake will build all language bindings for which it can find all
+necessary dependencies. After each successful cmake run, cmake will tell you
+which language bindings it is going to build.
+
+
 ### Generating compile_commands.json
 
 CMake can build a compilation database for you. However, the default generatd

--- a/bindings/CMakeLists.txt
+++ b/bindings/CMakeLists.txt
@@ -1,3 +1,5 @@
 add_subdirectory(c)
 add_subdirectory(python)
-add_subdirectory(java)
+if(BUILD_JAVA)
+  add_subdirectory(java)
+endif()

--- a/bindings/java/CMakeLists.txt
+++ b/bindings/java/CMakeLists.txt
@@ -1,7 +1,3 @@
-include(UseJava)
-find_package(JNI 1.8 REQUIRED)
-find_package(Java 1.8 COMPONENTS Development REQUIRED)
-
 set(JAVA_BINDING_SRCS
   src/main/com/apple/foundationdb/async/AsyncIterable.java
   src/main/com/apple/foundationdb/async/AsyncIterator.java

--- a/bindings/java/CMakeLists.txt
+++ b/bindings/java/CMakeLists.txt
@@ -125,11 +125,65 @@ set_target_properties(fdb_java PROPERTIES
 set(CMAKE_JAVA_COMPILE_FLAGS "-source" "1.8" "-target" "1.8")
 set(CMAKE_JNI_TARGET TRUE)
 set(JAR_VERSION "${FDB_MAJOR}.${FDB_MINOR}.${FDB_REVISION}")
-add_jar(fdb-java ${JAVA_BINDING_SRCS} ${GENERATED_JAVA_FILES}
-  OUTPUT_DIR ${PROJECT_BINARY_DIR}/lib)
+add_jar(fdb-java ${JAVA_BINDING_SRCS} ${GENERATED_JAVA_FILES} ${CMAKE_SOURCE_DIR}/LICENSE
+  OUTPUT_DIR ${PROJECT_BINARY_DIR}/lib VERSION ${CMAKE_PROJECT_VERSION})
 add_dependencies(fdb-java fdb_java_options fdb_java)
 add_jar(foundationdb-tests SOURCES ${JAVA_TESTS_SRCS} INCLUDE_JARS fdb-java)
 add_dependencies(foundationdb-tests fdb_java_options)
 
-install_jar(fdb-java DESTINATION ${FDB_SHARE_DIR}/java COMPONENT clients)
-install(TARGETS fdb_java DESTINATION ${FDB_LIB_DIR} COMPONENT clients)
+install_jar(fdb-java DESTINATION ${FDB_SHARE_DIR}/java COMPONENT java)
+install(TARGETS fdb_java DESTINATION ${FDB_LIB_DIR} COMPONENT java)
+
+set(BUILD_FAT_JAR OFF CACHE BOOL "Build a Jar that includes the jni libraries")
+set(FAT_JAR_BINARIES "NOTFOUND" CACHE STRING
+  "Path of a directory structure with libraries to include in fat jar (a lib directory)")
+
+if(BUILD_FAT_JAR)
+  set(jar_destination ${CMAKE_BINARY_DIR}/fat_jar)
+  set(unpack_dir ${CMAKE_CURRENT_BINARY_DIR}/fat_jar)
+  file(MAKE_DIRECTORY ${jar_destination})
+  file(MAKE_DIRECTORY ${unpack_dir})
+  message(STATUS "Building fat jar to ${jar_destination}")
+  get_property(jar_path TARGET fdb-java PROPERTY JAR_FILE)
+  add_custom_command(OUTPUT ${unpack_dir}/META-INF/MANIFEST.MF
+    COMMAND ${Java_JAR_EXECUTABLE} xf ${jar_path}
+    WORKING_DIRECTORY ${unpack_dir}
+    COMMENT "Unpack jar-file")
+  add_custom_target(unpack_jar DEPENDS ${unpack_dir}/META-INF/MANIFEST.MF)
+  add_dependencies(unpack_jar fdb_java)
+  add_custom_command(OUTPUT ${unpack_dir}/LICENSE
+    COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_SOURCE_DIR}/LICENSE ${unpack_dir}
+    COMMENT "copy license")
+  add_custom_target(copy_license DEPENDS ${unpack_dir}/LICENSE)
+  add_dependencies(unpack_jar copy_license)
+  if(FAT_JAR_BINARIES)
+    add_custom_command(OUTPUT ${unpack_dir}/lib
+      COMMAND ${CMAKE_COMMAND} -E copy_directory ${FAT_JAR_BINARIES} ${unpack_dir}
+      COMMENT "copy additional libraries"
+      DEPENDS ${unpack_dir}/META-INF/MANIFEST.MF)
+    add_custom_target(copy_libs DEPENDS ${unpack_dir}/lib)
+    add_dependencies(unpack_jar copy_libs)
+  endif()
+  if(WIN32)
+    set(lib_destination "windows/amd64")
+  elseif(APPLE)
+    set(lib_destination "osx/x86_64")
+  else()
+    set(lib_destination "linux/amd64")
+  endif()
+  set(lib_destination "${unpack_dir}/lib/${lib_destination}")
+  file(MAKE_DIRECTORY ${lib_destination})
+  add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/lib_copied
+    COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:fdb_java> ${lib_destination} &&
+            ${CMAKE_COMMAND} -E touch ${CMAKE_CURRENT_BINARY_DIR}/lib_copied
+    COMMENT "Copy library")
+  add_custom_target(copy_lib DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/lib_copied)
+  add_dependencies(copy_lib unpack_jar)
+  set(target_jar ${jar_destination}/fdb-java-${CMAKE_PROJECT_VERSION}.jar)
+  add_custom_command(OUTPUT ${target_jar}
+    COMMAND ${Java_JAR_EXECUTABLE} cf ${target_jar} .
+    WORKING_DIRECTORY ${unpack_dir}
+    COMMENT "Build ${jar_destination}/fdb-java-${CMAKE_PROJECT_VERSION}.jar")
+  add_custom_target(fat-jar ALL DEPENDS ${target_jar})
+  add_dependencies(fat-jar copy_lib)
+endif()

--- a/bindings/java/README.md
+++ b/bindings/java/README.md
@@ -1,0 +1,54 @@
+<img alt="FoundationDB logo" src="documentation/FDB_logo.png?raw=true" width="400">
+
+FoundationDB is a distributed database designed to handle large volumes of structured data across clusters of commodity servers. It organizes data as an ordered key-value store and employs ACID transactions for all operations. It is especially well-suited for read/write workloads but also has excellent performance for write-intensive workloads. Users interact with the database using API language binding.
+
+To learn more about FoundationDB, visit [foundationdb.org](https://www.foundationdb.org/)
+
+## FoundationDB Java Bindings
+
+In order to build the java bindings,
+[JDK](http://www.oracle.com/technetwork/java/javase/downloads/index.html) >= 8
+has to be installed. CMake will try to find a JDK installation, if it can find
+one it will automatically build the java bindings.
+
+If you have Java installed but cmake fails to find them, set the
+`JAVA_HOME`environment variable.
+
+### Fat Jar
+
+By default, the generated jar file will depend on an installed libfdb_java
+(provided with the generated RPM/DEB file on Linux). However, users usually find
+a Jar-file that contains this library more convenient. This is also what you
+will get if you download the jar file from Maven.
+
+If you want to build a jar file that contains the library enable the cmake
+variable `BUILD_FAT_JAR`. You can do this with the following command:
+
+```
+cmake -DBUILD_FAT_JAR <PATH_TO_FDB_SOURCE>
+```
+
+This will add the jni library of for the current architecture to the jar file.
+
+#### Multi-Platform Jar-File
+
+If you want to create a jar file that can run on more than one supported
+architecture (the offical one supports MacOS, Linux, and Windows), you can do
+that by executing the following steps:
+
+1. Create a directory called `lib` somewhere on your file system.
+1. Create a subdirectory for each *additional* platform you want to support
+   (`windows` for windows, `osx` for MacOS, and `linux` for Linux).
+1. Under each of those create a subdirectory with the name of the architecture
+   (currently only `amd64` is supported - on MacOS this has to be called
+   `x86_64` - `amd64` on all others).
+1. Set the cmake variable `FAT_JAR_BINARIES` to this `lib` directory. For
+   example, if you created this directory structure under `/foo/bar`, the
+   corresponding cmake command would be:
+
+```
+cmake -DFAT_JAR_BINARIES=/foo/bar/lib <PATH_TO_FDB_SOURCE>
+```
+
+After executing building (with `make` or `Visual Studio`) you will find a
+jar-file in the `fat-jar` directory in your build directory.

--- a/cmake/FDBComponents.cmake
+++ b/cmake/FDBComponents.cmake
@@ -1,0 +1,42 @@
+################################################################################
+# Java Bindings
+################################################################################
+
+set(BUILD_JAVA OFF)
+find_package(JNI 1.8 REQUIRED)
+find_package(Java 1.8 COMPONENTS Development)
+if(JNI_FOUND AND Java_FOUND AND Java_Development_FOUND)
+  set(BUILD_JAVA ON)
+  include(UseJava)
+  enable_language(Java)
+endif()
+
+################################################################################
+# LibreSSL
+################################################################################
+
+set(DISABLE_TLS OFF CACHE BOOL "Don't try to find LibreSSL and always build without TLS support")
+if(DISABLE_TLS)
+  set(WITH_TLS OFF)
+else()
+  set(LIBRESSL_USE_STATIC_LIBS TRUE)
+  find_package(LibreSSL)
+  if(LibreSSL_FOUND)
+    set(WITH_TLS ON)
+  else()
+    message(STATUS "LibreSSL NOT Found - Will compile without TLS Support")
+    message(STATUS "You can set LibreSSL_ROOT to the LibreSSL install directory to help cmake find it")
+    set(WITH_TLS OFF)
+  endif()
+endif()
+
+
+function(print_components)
+  message(STATUS "=============================")
+  message(STATUS "   Components Build Overview ")
+  message(STATUS "=============================")
+  message(STATUS "Build Python Bindings:    ON")
+  message(STATUS "Build Java Bindings:      ${BUILD_JAVA}")
+  message(STATUS "Build with TLS support:   ${WITH_TLS}")
+  message(STATUS "=============================")
+endfunction()


### PR DESCRIPTION
This addresses the Java-part of #1035 

This patch contains mostly two changes:

1. There is no good reason why cmake should enforce java to be installed in order to build fdb. Instead, it will build the Java-bindings only if it can find a recent enough JDK.
2. Added two more cmake variables. One will instruct cmake to build a jar-file that contains the jni library. The other will tell cmake where it can find additional  jni libraries (for other platforms).

All of this is described in bindings/java/README.md