### PR TITLE
Package testing

### DIFF
--- a/build/cmake/build.sh
+++ b/build/cmake/build.sh
@@ -13,7 +13,7 @@ EOF
 
 arguments_parse() {
     local __res=0
-    while getopts ":ho:" opt
+    while getopts ":h" opt
     do
         case ${opt} in
             h )

--- a/build/cmake/build.sh
+++ b/build/cmake/build.sh
@@ -168,6 +168,40 @@ deb() {
     return ${__res}
 }
 
+test-fast() {
+    local __res=0
+    for _ in 1
+    do
+        ctest -j`nproc`
+        __res=$?
+        if [ ${__res} -ne 0 ]
+        then
+            break
+        fi
+    done
+    return ${__res}
+}
+
+test() {
+    local __res=0
+    for _ in 1
+    do
+        build
+        __res=$?
+        if [ ${__res} -ne 0 ]
+        then
+            break
+        fi
+        test-fast
+        __res=$?
+        if [ ${__res} -ne 0 ]
+        then
+            break
+        fi
+    done
+    return ${__res}
+}
+
 main() {
     local __res=0
     for _ in 1
@@ -218,6 +252,12 @@ main() {
                 linux-pkgs)
                     rpm
                     deb
+                    ;;
+                test-fast)
+                    test-fast
+                    ;;
+                test)
+                    test
                     ;;
                 * )
                     echo "ERROR: Command not found ($command)"

--- a/build/cmake/docker-compose.yml
+++ b/build/cmake/docker-compose.yml
@@ -51,6 +51,15 @@ services:
     <<: *build-setup
     command: scl enable devtoolset-7 rh-ruby24 rh-python36 python27 -- bash ../src/build/cmake/build.sh package/fast
 
+  test-fast: &test-fast
+    <<: *build-setup
+    command: scl enable devtoolset-7 rh-ruby24 rh-python36 python27 -- bash ../src/build/cmake/build.sh test-fast
+
+  test: &test
+    <<: *build-setup
+    command: scl enable devtoolset-7 rh-ruby24 rh-python36 python27 -- bash ../src/build/cmake/build.sh test
+
   shell:
     <<: *build-setup
     command: scl enable devtoolset-7 rh-ruby24 rh-python36 python27 -- bash
+

--- a/build/cmake/docker-compose.yml
+++ b/build/cmake/docker-compose.yml
@@ -53,5 +53,4 @@ services:
 
   shell:
     <<: *build-setup
-    volumes:
-      - ..:/foundationdb
+    command: scl enable devtoolset-7 rh-ruby24 rh-python36 python27 -- bash

--- a/build/cmake/docker-compose.yml
+++ b/build/cmake/docker-compose.yml
@@ -15,49 +15,49 @@ services:
     #the path where debuginfo sources are places. Crazy, yes,
     #see the manual for CPACK_RPM_BUILD_SOURCE_DIRS_PREFIX.
     volumes:
-      - ../..:/foundationdb/deep/directory/as/debuginfo/doesnt/work/otherwise/src
+      - ../..:/foundationdb/deep/directory/as/debuginfo/doesnt/work/otherwise/foundationdb
       - ${BUILDDIR}:/foundationdb/deep/directory/as/debuginfo/doesnt/work/otherwise/build
     working_dir: /foundationdb/deep/directory/as/debuginfo/doesnt/work/otherwise/build
 
   configure: &configure
     <<: *build-setup
-    command: scl enable devtoolset-7 rh-ruby24 rh-python36 python27 -- bash ../src/build/cmake/build.sh configure
+    command: scl enable devtoolset-7 rh-ruby24 rh-python36 python27 -- bash ../foundationdb/build/cmake/build.sh configure
 
   build: &build
     <<: *build-setup
-    command: scl enable devtoolset-7 rh-ruby24 rh-python36 python27 -- bash ../src/build/cmake/build.sh build
+    command: scl enable devtoolset-7 rh-ruby24 rh-python36 python27 -- bash ../foundationdb/build/cmake/build.sh build
 
   build-fast: &build-fast
     <<: *build-setup
-    command: scl enable devtoolset-7 rh-ruby24 rh-python36 python27 -- bash ../src/build/cmake/build.sh build/fast
+    command: scl enable devtoolset-7 rh-ruby24 rh-python36 python27 -- bash ../foundationdb/build/cmake/build.sh build/fast
 
   rpm: &rpm
     <<: *build-setup
-    command: scl enable devtoolset-7 rh-ruby24 rh-python36 python27 -- bash ../src/build/cmake/build.sh rpm
+    command: scl enable devtoolset-7 rh-ruby24 rh-python36 python27 -- bash ../foundationdb/build/cmake/build.sh rpm
 
   deb: &deb
     <<: *build-setup
-    command: scl enable devtoolset-7 rh-ruby24 rh-python36 python27 -- bash ../src/build/cmake/build.sh deb
+    command: scl enable devtoolset-7 rh-ruby24 rh-python36 python27 -- bash ../foundationdb/build/cmake/build.sh deb
 
   linux-pkgs:
     <<: *build-setup
-    command: scl enable devtoolset-7 rh-ruby24 rh-python36 python27 -- bash ../src/build/cmake/build.sh linux-pkgs
+    command: scl enable devtoolset-7 rh-ruby24 rh-python36 python27 -- bash ../foundationdb/build/cmake/build.sh linux-pkgs
 
   package: &package
     <<: *build-setup
-    command: scl enable devtoolset-7 rh-ruby24 rh-python36 python27 -- bash ../src/build/cmake/build.sh package
+    command: scl enable devtoolset-7 rh-ruby24 rh-python36 python27 -- bash ../foundationdb/build/cmake/build.sh package
 
   package-fast: &package-fast
     <<: *build-setup
-    command: scl enable devtoolset-7 rh-ruby24 rh-python36 python27 -- bash ../src/build/cmake/build.sh package/fast
+    command: scl enable devtoolset-7 rh-ruby24 rh-python36 python27 -- bash ../foundationdb/build/cmake/build.sh package/fast
 
   test-fast: &test-fast
     <<: *build-setup
-    command: scl enable devtoolset-7 rh-ruby24 rh-python36 python27 -- bash ../src/build/cmake/build.sh test-fast
+    command: scl enable devtoolset-7 rh-ruby24 rh-python36 python27 -- bash ../foundationdb/build/cmake/build.sh test-fast
 
   test: &test
     <<: *build-setup
-    command: scl enable devtoolset-7 rh-ruby24 rh-python36 python27 -- bash ../src/build/cmake/build.sh test
+    command: scl enable devtoolset-7 rh-ruby24 rh-python36 python27 -- bash ../foundationdb/build/cmake/build.sh test
 
   shell:
     <<: *build-setup

--- a/build/cmake/docker.ini
+++ b/build/cmake/docker.ini
@@ -1,0 +1,7 @@
+[RPM_1]
+name = fdb-centos
+location = centos-test
+
+[DEB_1]
+name = fdb-debian
+location = debian-test

--- a/build/cmake/package_tester/deb_tests.sh
+++ b/build/cmake/package_tester/deb_tests.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+source_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+
+source ${source_dir}/modules/util.sh
+source ${source_dir}/modules/deb.sh
+source ${source_dir}/modules/tests.sh
+
+main() {
+    local __res=0
+    enterfun
+    for _ in 1
+    do
+        package_files=( "$@" )
+        if [ "${__res}" -ne 0 ]
+        then
+            break
+        fi
+        tests_main
+    done
+    exitfun
+    return ${__res}
+}
+
+main "$@"

--- a/build/cmake/package_tester/deb_tests.sh
+++ b/build/cmake/package_tester/deb_tests.sh
@@ -5,14 +5,20 @@ source_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 source ${source_dir}/modules/util.sh
 source ${source_dir}/modules/deb.sh
 source ${source_dir}/modules/tests.sh
+source ${source_dir}/modules/test_args.sh
 
 main() {
     local __res=0
     enterfun
     for _ in 1
     do
-        package_files=( "$@" )
-        if [ "${__res}" -ne 0 ]
+        test_args_parse "$@"
+        __res=$?
+        if [ ${__res} -eq 2 ]
+        then
+            __res=0
+            break
+        elif [ ${__res} -ne 0 ]
         then
             break
         fi

--- a/build/cmake/package_tester/modules/arguments.sh
+++ b/build/cmake/package_tester/modules/arguments.sh
@@ -1,0 +1,80 @@
+#!env bash
+
+if [ -z ${arguments_sh_included+x} ]
+then
+    arguments_sh_included=1
+
+    source ${source_dir}/modules/util.sh
+
+    arguments_usage() {
+        cat <<EOF
+usage: test_packages.sh [-h] [commands]
+       -h:      print this help message and
+                abort execution
+       -b DIR:  point set the fdb build directory
+                (this is a required argument).
+       -s DIR:  Path to fdb source directory.
+       -p STR:  Colon-separated list of package
+                file names (without path) to
+                test.
+       -c PATH: Path to a ini-file with the docker
+                configuration
+       -t TEST: One of DEB, RPM, ALL
+
+       Will execute the passed commands
+       in the order they were passed
+EOF
+    }
+
+    arguments_parse() {
+        local __res=0
+        run_deb_tests=1
+        run_rpm_tests=1
+        while getopts ":hb:s:t:" opt
+        do
+            case ${opt} in
+                h )
+                    arguments_usage
+                    __res=2
+                    break
+                    ;;
+                b )
+                    fdb_build="${OPTARG}"
+                    ;;
+                s )
+                    fdb_source="${OPTARG}"
+                    ;;
+                p )
+                    fdb_packages="${OPTARG}"
+                    ;;
+                c )
+                    docker_ini="${OPTARG}"
+                    ;;
+                t )
+                    if [ "${OPTARG}" = "DEB" ]
+                    then
+                        run_rpm_tests=0
+                    elif [ "${OPTARG}" = "RPM" ]
+                    then
+                        run_deb_tests=0
+                    elif [ "${OPTARG}" != "ALL" ]
+                    then
+                        echo -e "${RED}No such test: ${OPTARG}${NC}"
+                        echo "Note: Currently known tests are: RPM, DEB, and ALL"
+                        exit 1
+                    fi
+                    ;;
+                \? )
+                    curr_index="$((OPTIND-1))"
+                    echo "Unknown option ${@:${curr_index}:1}"
+                    arguments_usage
+                    __res=1
+                    break
+                    ;;
+            esac
+        done
+        shift $((OPTIND -1))
+        commands=("$@")
+        return ${__res}
+    }
+fi

--- a/build/cmake/package_tester/modules/arguments.sh
+++ b/build/cmake/package_tester/modules/arguments.sh
@@ -1,4 +1,4 @@
-#!env bash
+#!/usr/bin/env bash
 
 if [ -z ${arguments_sh_included+x} ]
 then

--- a/build/cmake/package_tester/modules/arguments.sh
+++ b/build/cmake/package_tester/modules/arguments.sh
@@ -9,17 +9,20 @@ then
     arguments_usage() {
         cat <<EOF
 usage: test_packages.sh [-h] [commands]
-       -h:      print this help message and
-                abort execution
-       -b DIR:  point set the fdb build directory
-                (this is a required argument).
-       -s DIR:  Path to fdb source directory.
-       -p STR:  Colon-separated list of package
-                file names (without path) to
-                test.
-       -c PATH: Path to a ini-file with the docker
-                configuration
-       -t TEST: One of DEB, RPM, ALL
+       -h:       print this help message and
+                 abort execution
+       -b DIR:   point set the fdb build directory
+                 (this is a required argument).
+       -s DIR:   Path to fdb source directory.
+       -p STR:   Colon-separated list of package
+                 file names (without path) to
+                 test.
+       -c PATH:  Path to a ini-file with the docker
+                 configuration
+       -t TEST:  One of DEB, RPM, ALL
+       -n TESTS: Colon separated list of test names
+                 to run (will run all if this option
+                 is not set)
 
        Will execute the passed commands
        in the order they were passed
@@ -63,6 +66,9 @@ EOF
                         echo "Note: Currently known tests are: RPM, DEB, and ALL"
                         exit 1
                     fi
+                    ;;
+                n )
+                    tests_to_run="${OPTARG}"
                     ;;
                 \? )
                     curr_index="$((OPTIND-1))"

--- a/build/cmake/package_tester/modules/config.sh
+++ b/build/cmake/package_tester/modules/config.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+
+if [ -z ${config_sh_included+x} ]
+then
+    config_sh_included=1
+
+    source ${source_dir}/modules/util.sh
+
+    config_load_vms() {
+        local __res=0
+        enterfun
+        for _ in 1
+        do
+            if [ -z "${docker_ini+x}"]
+            then
+                docker_file="${source_dir}/../docker.ini"
+            fi
+            # parse the ini file and read it into an
+            # associative array
+            declare -gA ini_name
+            declare -gA ini_location
+
+            eval "$(awk -F ' *= *' '{ if ($1 ~ /^\[/) section=$1; else if ($1 !~ /^$/) print "ini_" $1 section "=" "\"" $2 "\"" }' ${docker_file})"
+            if [ $? -ne 0 ]
+            then
+                echo "ERROR: Could not parse config-file ${docker_file}"
+                __res=1
+                break
+            fi
+        done
+        exitfun
+        return ${__res}
+    }
+
+    config_find_packages() {
+        local __res=0
+        enterfun
+        for _ in 1
+        do
+            cd ${fdb_build}
+            while read f
+            do
+                if [[ "${f}" =~ .*"clients".* || "${f}" =~ .*"server".* ]]
+                then
+                    if [ -z ${fdb_packages+x} ]
+                    then
+                        fdb_packages="${f}"
+                    else
+                        fdb_packages="${fdb_packages}:${f}"
+                    fi
+                fi
+            done <<< "$(ls *.deb *.rpm)"
+            if [ $? -ne 0 ]
+            then
+                __res=1
+                break
+            fi
+        done
+        exitfun
+        return ${__res}
+    }
+
+    get_fdb_source() {
+        local __res=0
+        enterfun
+        cd ${source_dir}
+        while true
+        do
+            if [ -d .git ]
+            then
+                # we found the root
+                pwd
+                break
+            fi
+            if [ `pwd` = "/" ]
+            then
+                __res=1
+                break
+            fi
+            cd ..
+        done
+        exitfun
+        return ${__res}
+    }
+
+    fdb_build=0
+
+    config_verify() {
+        local __res=0
+        enterfun
+        for _ in 1
+        do
+            if [ -z ${fdb_source+x} ]
+            then
+                fdb_source=`get_fdb_source`
+            fi
+            if [ ! -d "${fdb_build}" ]
+            then
+                __res=1
+                echo "ERROR: Could not find fdb build dir: ${fdb_build}"
+                echo "        Either set the environment variable fdb_build or"
+                echo "        pass it with -b <PATH_TO_BUILD>"
+            fi
+            if [ ! -f "${fdb_source}/flow/Net2.actor.cpp" ]
+            then
+                __res=1
+                echo "ERROR: ${fdb_source} does not appear to be a fdb source"
+                echo "       directory. Either pass it with -s or set"
+                echo "       the environment variable fdb_source."
+            fi
+            if [ ${__res} -ne 0 ]
+            then
+                break
+            fi
+            if [ -z ${fdb_packages+x} ]
+            then
+                config_find_packages
+                if [ $? -ne 0 ]
+                then
+                    __res=1
+                    break
+                fi
+            fi
+            config_load_vms
+            __res=$?
+            if [ ${__res} -ne 0 ]
+            then
+                break
+            fi
+        done
+        exitfun
+        return ${__res}
+    }
+fi

--- a/build/cmake/package_tester/modules/deb.sh
+++ b/build/cmake/package_tester/modules/deb.sh
@@ -9,17 +9,17 @@ then
    install() {
        local __res=0
        enterfun
+       echo "Install FoundationDB"
        cd /build
-       declare -ga package_names
+       package_names=()
        for f in "${package_files[@]}"
        do
            package_name="$(dpkg -I ${f} | grep Package | sed 's/.*://')"
            package_names+=( "${package_name}" )
        done
        dpkg -i ${package_files[@]}
-       apt-get -yf install
+       apt-get -yf -o Dpkg::Options::="--force-confold" install
        __res=$?
-       # give the server some time to come up
        sleep 5
        exitfun
        return ${__res}

--- a/build/cmake/package_tester/modules/deb.sh
+++ b/build/cmake/package_tester/modules/deb.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+if [ -z "${deb_sh_included}" ]
+then
+   deb_sh_included=1
+
+   source ${source_dir}/modules/util.sh
+
+   install() {
+       local __res=0
+       enterfun
+       cd /build
+       declare -ga package_names
+       for f in "${package_files[@]}"
+       do
+           package_name="$(dpkg -I ${f} | grep Package | sed 's/.*://')"
+           package_names+=( "${package_name}" )
+       done
+       dpkg -i ${package_files[@]}
+       apt-get -yf install
+       __res=$?
+       # give the server some time to come up
+       sleep 5
+       exitfun
+       return ${__res}
+   }
+
+   uninstall() {
+       local __res=0
+       enterfun
+       apt-get -y remove ${package_names[@]}
+       __res=$?
+       exitfun
+       return ${__res}
+   }
+fi

--- a/build/cmake/package_tester/modules/docker.sh
+++ b/build/cmake/package_tester/modules/docker.sh
@@ -38,16 +38,18 @@ then
                     docker_ids=( "${docker_ids[@]:0:$i}" "${docker_ids[@]:$n}" )
                     docker_threads=( "${docker_threads[@]:0:$i}" "${docker_threads[@]:$n}" )
                     # prune
+                    set -x
                     if [ "${pruning_strategy}" = "ALL" ]
                     then
-                        docker rmi "${docker_id}" > /dev/null
-                    elif [ "${ret_code}" -eq 0 ] && [ "${pruning_strategt}" = "SUCCEEDED" ]
+                        docker container rm "${docker_id}" > /dev/null
+                    elif [ "${ret_code}" -eq 0 ] && [ "${pruning_strategy}" = "SUCCEEDED" ]
                     then
-                         docker rmi "${docker_id}" > /dev/null
-                    elif [ "${ret_code}" -ne 0 ] && [ "${pruning_strategt}" = "FAILED" ]
+                        docker container rm "${docker_id}" > /dev/null
+                    elif [ "${ret_code}" -ne 0 ] && [ "${pruning_strategy}" = "FAILED" ]
                     then
-                         docker rmi "${docker_id}" > /dev/null
+                        docker container rm "${docker_id}" > /dev/null
                     fi
+                    set +x
                 fi
             done
             sleep 1

--- a/build/cmake/package_tester/modules/docker.sh
+++ b/build/cmake/package_tester/modules/docker.sh
@@ -1,0 +1,166 @@
+if [ -z "${docker_sh_included+x}" ]
+then
+    docker_sh_included=1
+    source ${source_dir}/modules/util.sh
+    source ${source_dir}/modules/config.sh
+
+    docker_build_and_run() {
+        local __res=0
+        enterfun
+        for _ in 1
+        do
+            if [[ "$location" = /* ]]
+            then
+                cd "${location}"
+            else
+                cd ${source_dir}/../${location}
+            fi
+            docker build . -t ${name}
+            # we start docker in interactive mode, otherwise CTRL-C won't work
+            docker run -it -v "${fdb_source}:/foundationdb" -v "${fdb_build}:/build" ${name} bash /foundationdb/build/cmake/package_tester/${PKG,,}_tests.sh ${packages_to_test[@]}
+            __res=$?
+        done
+        exitfun
+        return ${__res}
+    }
+
+    docker_run_tests() {
+        local __res=0
+        enterfun
+        counter=1
+        while true
+        do
+            #if [ -z "${DEB_${}}" ]
+            if [ -z "${ini_name[${PKG}_${counter}]+x}" ]
+            then
+                # we are done
+                break
+            fi
+            name="${ini_name[${PKG}_${counter}]}"
+            location="${ini_location[${PKG}_${counter}]}"
+            docker_build_and_run
+            __res=$?
+            counter=$((counter+1))
+            if [ ${__res} -ne 0 ]
+            then
+                break
+            fi
+        done
+        if [ ${counter} -eq 1 ]
+        then
+            echo -e "${YELLOW}WARNING: No docker config found!${NC}"
+        fi
+        exitfun
+        return ${__res}
+    }
+
+    docker_debian_tests() {
+        local __res=0
+        enterfun
+        PKG=DEB
+        packages_to_test=("${deb_packages[@]}")
+        docker_run_tests
+        __res=$?
+        exitfun
+        return ${__res}
+    }
+
+    docker_rpm_tests() {
+        local __res=0
+        enterfun
+        PKG=RPM
+        packages_to_test=("${rpm_packages[@]}")
+        docker_run_tests
+        __res=$?
+        exitfun
+        return ${__res}
+    }
+
+    docker_run() {
+        local __res=0
+        enterfun
+        for _ in 1
+        do
+            # create list of package files to test
+            IFS=':' read -ra packages <<< "${fdb_packages}"
+            deb_packages=()
+            rpm_packages=()
+            for i in "${packages[@]}"
+            do
+                if [[ "${i}" =~ .*".deb" ]]
+                then
+                    if [ ${run_deb_tests} -ne 0 ]
+                    then
+                        deb_packages+=("${i}")
+                    fi
+                else
+                    if [ ${run_rpm_tests} -ne 0 ]
+                    then
+                        rpm_packages+=("${i}")
+                    fi
+                fi
+            done
+            do_deb_tests=0
+            do_rpm_tests=0
+            if [ "${#deb_packages[@]}" -gt 0 ]
+            then
+                do_deb_tests=1
+                echo "Will test the following debian packages:"
+                echo "========================================"
+                for i in "${deb_packages[@]}"
+                do
+                    echo " - ${i}"
+                done
+                echo -e "\n"
+            fi
+            if [ "${#rpm_packages[@]}" -gt 0 ]
+            then
+                do_rpm_tests=1
+                echo "Will test the following rpm packages"
+                echo "===================================="
+                for i in "${rpm_packages[@]}"
+                do
+                    echo " - ${i}"
+                done
+            fi
+            if [ "${do_deb_tests}" -eq 0 ] && [ "${do_rpm_tests}" -eq 0 ]
+            then
+                echo "nothing to do"
+            else
+                read -n 1 -s -r -p "Press any key to continue (or Ctrl-C to cancel)"
+                echo -e "\n"
+            fi
+            if [ "${do_deb_tests}" -ne 0 ]
+            then
+                docker_debian_tests
+                if [ $? -eq 0 ]
+                then
+                    echo -e "${GREEN}Debian tests succeeded${NC}"
+                else
+                    echo -e "${RED}Debian tests failed${NC}"
+                    __res=1
+                fi
+            fi
+            if [ "${do_rpm_tests}" -ne 0 ]
+            then
+                docker_rpm_tests
+                if [ $? -eq 0 ]
+                then
+                    echo -e "${GREEN}RPM tests succeeded${NC}"
+                else
+                    echo -e "${RED}Debian tests failed${NC}"
+                    __res=1
+                fi
+            fi
+            if [ "${__res}" -eq 0 ]
+            then
+                echo -e "${GREEN}SUCCESS${NC}"
+            else
+                echo -e "${RED}FAILURE${NC}"
+                __res=1
+            fi
+        done
+        exitfun
+        return ${__res}
+    }
+fi

--- a/build/cmake/package_tester/modules/docker.sh
+++ b/build/cmake/package_tester/modules/docker.sh
@@ -24,7 +24,7 @@ then
                 status="$(docker ps -a -f id=${docker_id} --format '{{.Status}}' | awk '{print $1;}')"
                 if [ "${status}" = "Exited" ]
                 then
-                    successOr=1
+                    success=1
                     ret_code="$(docker wait ${docker_id})"
                     if [ "${ret_code}" -ne 0 ]
                     then

--- a/build/cmake/package_tester/modules/docker.sh
+++ b/build/cmake/package_tester/modules/docker.sh
@@ -114,7 +114,6 @@ then
         counter=1
         while true
         do
-            #if [ -z "${DEB_${}}" ]
             if [ -z "${ini_name[${PKG}_${counter}]+x}" ]
             then
                 # we are done

--- a/build/cmake/package_tester/modules/docker.sh
+++ b/build/cmake/package_tester/modules/docker.sh
@@ -24,7 +24,7 @@ then
                 status="$(docker ps -a -f id=${docker_id} --format '{{.Status}}' | awk '{print $1;}')"
                 if [ "${status}" = "Exited" ]
                 then
-                    success=1
+                    successOr=1
                     ret_code="$(docker wait ${docker_id})"
                     if [ "${ret_code}" -ne 0 ]
                     then
@@ -82,7 +82,7 @@ then
             fi
             docker_logs="${log_dir}/docker_build_${name}"
             docker build . -t ${name} 1> "${docker_logs}.log" 2> "${docker_logs}.err"
-            success "Building Docker image ${name} failed - see ${docker_logs}.log and ${docker_logs}.err"
+            successOr "Building Docker image ${name} failed - see ${docker_logs}.log and ${docker_logs}.err"
             # we start docker in interactive mode, otherwise CTRL-C won't work
             if [ ! -z "${tests_to_run+x}"]
             then

--- a/build/cmake/package_tester/modules/rpm.sh
+++ b/build/cmake/package_tester/modules/rpm.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+if [ -z "${rpm_sh_included}" ]
+then
+   rpm_sh_included=1
+
+   source ${source_dir}/modules/util.sh
+
+   install() {
+       local __res=0
+       enterfun
+       cd /build
+       declare -ga package_names
+       for f in "${package_files[@]}"
+       do
+           package_names+=( "$(rpm -qp ${f})" )
+       done
+       yum install -y ${package_files[@]}
+       __res=$?
+       # give the server some time to come up
+       sleep 5
+       exitfun
+       return ${__res}
+   }
+
+   uninstall() {
+       local __res=0
+       enterfun
+       yum remove -y ${package_names[@]}
+       __res=$?
+       exitfun
+       return ${__res}
+   }
+fi

--- a/build/cmake/package_tester/modules/rpm.sh
+++ b/build/cmake/package_tester/modules/rpm.sh
@@ -26,7 +26,12 @@ then
    uninstall() {
        local __res=0
        enterfun
-       yum remove -y ${package_names[@]}
+       if [ "$1" == "purge" ]
+       then
+           yum remove --purge -y ${package_names[@]}
+       else
+           yum remove -y ${package_names[@]}
+       fi
        __res=$?
        exitfun
        return ${__res}

--- a/build/cmake/package_tester/modules/test_args.sh
+++ b/build/cmake/package_tester/modules/test_args.sh
@@ -1,4 +1,4 @@
-#!env bash
+#!/usr/bin/env bash
 
 if [ -z ${test_args_sh_included+x} ]
 then

--- a/build/cmake/package_tester/modules/test_args.sh
+++ b/build/cmake/package_tester/modules/test_args.sh
@@ -7,8 +7,9 @@ then
     source ${source_dir}/modules/util.sh
 
     test_args_usage() {
+        me=`basename "$0"`
+        echo "usage: ${me} [-h] files..."
         cat <<EOF
-usage: pkg_test.sh [-h] files...
        -n TEST: The name of the test to run
 
        Will execute the passed commands

--- a/build/cmake/package_tester/modules/test_args.sh
+++ b/build/cmake/package_tester/modules/test_args.sh
@@ -1,0 +1,47 @@
+#!env bash
+
+if [ -z ${test_args_sh_included+x} ]
+then
+    test_args_sh_included=1
+
+    source ${source_dir}/modules/util.sh
+
+    test_args_usage() {
+        cat <<EOF
+usage: pkg_test.sh [-h] files...
+       -n TEST: The name of the test to run
+
+       Will execute the passed commands
+       in the order they were passed
+EOF
+    }
+
+    test_args_parse() {
+        local __res=0
+        run_deb_tests=1
+        run_rpm_tests=1
+        while getopts ":hn:" opt
+        do
+            case ${opt} in
+                h )
+                    arguments_usage
+                    __res=2
+                    break
+                    ;;
+                n )
+                    test_name="${OPTARG}"
+                    ;;
+                \? )
+                    curr_index="$((OPTIND-1))"
+                    echo "Unknown option ${@:${curr_index}:1}"
+                    arguments_usage
+                    __res=1
+                    break
+                    ;;
+            esac
+        done
+        shift $((OPTIND -1))
+        package_files=("$@")
+        return ${__res}
+    }
+fi

--- a/build/cmake/package_tester/modules/testing.sh
+++ b/build/cmake/package_tester/modules/testing.sh
@@ -33,7 +33,7 @@ then
 
     tests_clean() {
         uninstall purge
-        success FoundationDB was not uninstalled correctly
+        successOr FoundationDB was not uninstalled correctly
         # systemd/initd are not running, so we have to kill manually here
         pidof fdbmonitor | xargs kill
         tests_clean_nouninstall
@@ -47,7 +47,7 @@ then
         echo "Setting desired state ${new_state} for ${test_name}"
         desired_state "${new_state}"
         ${test_name}
-        success ${test_name} Failed
+        successOr ${test_name} Failed
         echo  "======================================================================="
         echo  "Test $t successfully finished"
         echo  "======================================================================="

--- a/build/cmake/package_tester/modules/testing.sh
+++ b/build/cmake/package_tester/modules/testing.sh
@@ -48,9 +48,9 @@ then
         desired_state "${new_state}"
         ${test_name}
         success ${test_name} Failed
-        echo -e "${GREEN}======================================================================="
-        echo -e "Test $t successfully finished"
-        echo -e "=======================================================================${NC}"
+        echo  "======================================================================="
+        echo  "Test $t successfully finished"
+        echo  "======================================================================="
         current_state="${test_exit_state[${test_name}]}"
     }
 fi

--- a/build/cmake/package_tester/modules/testing.sh
+++ b/build/cmake/package_tester/modules/testing.sh
@@ -2,8 +2,9 @@
 
 if [ -z "${testing_sh_included}" ]
 then
-
     testing_sh_included=1
+
+    source ${source_dir}/modules/util.sh
 
     desired_state() {
         case $1 in
@@ -17,23 +18,30 @@ then
     }
 
     tests_healthy() {
-        cd /
-        fdbcli --exec status
-        if [ $? -ne 0 ]
-        then
-            return 1
-        fi
-        healthy="$(fdbcli --exec status | grep HEALTHY | wc -l)"
-        if [ -z "${healthy}" ]
-        then
-            __res=1
-            break
-        fi
+        enterfun
+        local __res=0
+        for _ in 1
+        do
+            cd /
+            fdbcli --exec status
+            if [ $? -ne 0 ]
+            then
+                return 1
+            fi
+            healthy="$(fdbcli --exec status | grep HEALTHY | wc -l)"
+            if [ -z "${healthy}" ]
+            then
+                __res=1
+                break
+            fi
+        done
+        exitfun
+        return ${__res}
     }
 
     tests_clean() {
         uninstall purge
-        successOr FoundationDB was not uninstalled correctly
+        successOr "FoundationDB was not uninstalled correctly"
         # systemd/initd are not running, so we have to kill manually here
         pidof fdbmonitor | xargs kill
         tests_clean_nouninstall
@@ -47,7 +55,7 @@ then
         echo "Setting desired state ${new_state} for ${test_name}"
         desired_state "${new_state}"
         ${test_name}
-        successOr ${test_name} Failed
+        successOr "${test_name} Failed"
         echo  "======================================================================="
         echo  "Test $t successfully finished"
         echo  "======================================================================="

--- a/build/cmake/package_tester/modules/tests.sh
+++ b/build/cmake/package_tester/modules/tests.sh
@@ -101,8 +101,7 @@ then
        differences="$(diff /tmp/foundationdb.conf /etc/foundationdb/foundationdb.conf)"
        if [ -n "${differences}" ]
        then
-          ?=1
-          successOr Install changed configuration files
+          fail Install changed configuration files
        fi
 
        uninstall

--- a/build/cmake/package_tester/modules/tests.sh
+++ b/build/cmake/package_tester/modules/tests.sh
@@ -44,21 +44,21 @@ then
 
    fresh_install() {
        tests_healthy
-       success Fresh installation is not clean
+       successOr Fresh installation is not clean
        # test that we can read from and write to fdb
        cd /
        fdbcli --exec 'writemode on ; set foo bar'
-       success Cannot write to database
+       successOr Cannot write to database
        getresult="$(fdbcli --exec 'get foo')"
-       success Get on database failed
+       successOr Get on database failed
        if [ "${getresult}" != "\`foo' is \`bar'" ]
        then
           fail "value was not set correctly"
        fi
        fdbcli --exec 'writemode on ; clear foo'
-       success Deleting value failed
+       successOr Deleting value failed
        getresult="$(fdbcli --exec 'get foo')"
-       success Get on database failed
+       successOr Get on database failed
        if [ "${getresult}" != "\`foo': not found" ]
        then
           fail "value was not cleared correctly"
@@ -69,23 +69,23 @@ then
        mkdir /etc/foundationdb
        description=$(LC_CTYPE=C tr -dc A-Za-z0-9 < /dev/urandom | head -c 8)
        random_str=$(LC_CTYPE=C tr -dc A-Za-z0-9 < /dev/urandom | head -c 8)
-       success Could not create secret
+       successOr Could not create secret
        echo $description:$random_str@127.0.0.1:4500 > /tmp/fdb.cluster
-       success Could not create fdb.cluster file
+       successOr Could not create fdb.cluster file
        sed '/\[fdbserver.4500\]/a \[fdbserver.4501\]' /foundationdb/packaging/foundationdb.conf > /tmp/foundationdb.conf
-       success Could not change foundationdb.conf file
+       successOr Could not change foundationdb.conf file
        # we need to keep these files around for testing that the install didn't change them
        cp /tmp/fdb.cluster /etc/foundationdb/fdb.cluster
        cp /tmp/foundationdb.conf /etc/foundationdb/foundationdb.conf
 
        install
-       success FoundationDB install failed
+       successOr FoundationDB install failed
        # make sure we are not in build directory as there is a fdbc.cluster file there
        echo "Configure new database - Install isn't supposed to do this for us"
        echo "as there was an existing configuration"
        cd /
        fdbcli --exec 'configure new single ssd'
-       success "Couldn't" configure new database
+       successOr "Couldn't" configure new database
        tests_healthy
        num_processes="$(fdbcli --exec 'status' | grep "FoundationDB processes" | sed -e 's/.*- //')"
        if [ "${num_processes}" -ne 2 ]
@@ -102,7 +102,7 @@ then
        if [ -n "${differences}" ]
        then
           ?=1
-          success Install changed configuration files
+          successOr Install changed configuration files
        fi
 
        uninstall

--- a/build/cmake/package_tester/modules/tests.sh
+++ b/build/cmake/package_tester/modules/tests.sh
@@ -1,5 +1,33 @@
 #!/usr/bin/env bash
 
+# In this file the tests are formulated which
+# should run in the docker container to test
+# whether the RPM and DEB packages work properly.
+#
+# In order to add a test, a user first has to
+# add the name of the test to the `tests` array
+# which is defined in this file.
+#
+# Then, she must define the state this test
+# expects the container to be in. To do that,
+# a value for the test has to be added to the
+# associative array `test_start_state`. Valid
+# values are:
+#
+#  - INSTALLED: In this case, the test will be
+#    started with a freshly installed FDB, but
+#    no other changes were made to the container.
+#  - CLEAN: This simply means that the container
+#    will run a minimal version of the OS (as defined
+#    in the corresponsing Dockerfile)
+#
+# A test is then simply a bash function with the
+# same name as the test. It can use the predefined
+# bash functions `install` and `uninstall` to either
+# install or uninstall FDB on the container. The FDB
+# build directory can be found in `/build`, the
+# source code will be located in `/foundationdb`
+
 declare -A test_start_state
 declare -A test_exit_state
 declare -a tests

--- a/build/cmake/package_tester/modules/tests.sh
+++ b/build/cmake/package_tester/modules/tests.sh
@@ -1,32 +1,93 @@
 #!/usr/bin/env bash
 
+declare -A test_start_state
+declare -A test_exit_state
+declare -a tests
+
 if [ -z "${tests_sh_included}" ]
 then
    tests_sh_included=1
 
-   sourcce ${source_dir}/modules/util.sh
+   source ${source_dir}/modules/util.sh
+   source ${source_dir}/modules/testing.sh
 
-   tests_healthy() {
+   tests=( "fresh_install" "keep_config" )
+   test_start_state=([fresh_install]=INSTALLED [keep_config]=CLEAN )
+
+   fresh_install() {
+       tests_healthy
+       success Fresh installation is not clean
+       # test that we can read from and write to fdb
        cd /
-       fdbcli --exec status
-        if [ $? -ne 0 ]
-        then
-            return 1
-        fi
-        healthy="$(fdbcli --exec status | grep HEALTHY | wc -l)"
-        if [ -z "${healthy}" ]
-        then
-            __res=1
-            break
-        fi
+       fdbcli --exec 'writemode on ; set foo bar'
+       success Cannot write to database
+       getresult="$(fdbcli --exec 'get foo')"
+       success Get on database failed
+       if [ "${getresult}" != "\`foo' is \`bar'" ]
+       then
+          fail "value was not set correctly"
+       fi
+       fdbcli --exec 'writemode on ; clear foo'
+       success Deleting value failed
+       getresult="$(fdbcli --exec 'get foo')"
+       success Get on database failed
+       if [ "${getresult}" != "\`foo': not found" ]
+       then
+          fail "value was not cleared correctly"
+       fi
    }
 
-   tests_main() {
+   keep_config() {
+       mkdir /etc/foundationdb
+       description=$(LC_CTYPE=C tr -dc A-Za-z0-9 < /dev/urandom | head -c 8)
+       random_str=$(LC_CTYPE=C tr -dc A-Za-z0-9 < /dev/urandom | head -c 8)
+       success Could not create secret
+       echo $description:$random_str@127.0.0.1:4500 > /tmp/fdb.cluster
+       success Could not create fdb.cluster file
+       sed '/\[fdbserver.4500\]/a \[fdbserver.4501\]' /foundationdb/packaging/foundationdb.conf > /tmp/foundationdb.conf
+       success Could not change foundationdb.conf file
+       # we need to keep these files around for testing that the install didn't change them
+       cp /tmp/fdb.cluster /etc/foundationdb/fdb.cluster
+       cp /tmp/foundationdb.conf /etc/foundationdb/foundationdb.conf
+
        install
-       success Installation failed
+       success FoundationDB install failed
+       # make sure we are not in build directory as there is a fdbc.cluster file there
+       echo "Configure new database - Install isn't supposed to do this for us"
+       echo "as there was an existing configuration"
+       cd /
+       fdbcli --exec 'configure new single ssd'
+       success "Couldn't" configure new database
        tests_healthy
-       success FoundationDB is not healthy or not running
+       num_processes="$(fdbcli --exec 'status' | grep "FoundationDB processes" | sed -e 's/.*- //')"
+       if [ "${num_processes}" -ne 2 ]
+       then
+          ?=2
+          success Number of processes incorrect after config change
+       fi
+
+       differences="$(diff /tmp/fdb.cluster /etc/foundationdb/fdb.cluster)"
+       if [ -n "${differences}" ]
+       then
+          ?=1
+          success Install changed configuration files
+       fi
+       differences="$(diff /tmp/foundationdb.conf /etc/foundationdb/foundationdb.conf)"
+       if [ -n "${differences}" ]
+       then
+          ?=1
+          success Install changed configuration files
+       fi
+
        uninstall
-       success FoundationDB could not be uninstalled
+       # make sure config didn't get deleted
+       if [ ! -f /etc/foundationdb/fdb.cluster ] || [ ! -f /etc/foundationdb/foundationdb.conf ]
+       then
+          fail "Uninstall removed configuration"
+       fi
+
+       rm /tmp/fdb.cluster
+       rm /tmp/foundationdb.conf
+       return 0
    }
 fi

--- a/build/cmake/package_tester/modules/tests.sh
+++ b/build/cmake/package_tester/modules/tests.sh
@@ -44,21 +44,21 @@ then
 
    fresh_install() {
        tests_healthy
-       successOr Fresh installation is not clean
+       successOr "Fresh installation is not clean"
        # test that we can read from and write to fdb
        cd /
        fdbcli --exec 'writemode on ; set foo bar'
-       successOr Cannot write to database
+       successOr "Cannot write to database"
        getresult="$(fdbcli --exec 'get foo')"
-       successOr Get on database failed
+       successOr "Get on database failed"
        if [ "${getresult}" != "\`foo' is \`bar'" ]
        then
           fail "value was not set correctly"
        fi
        fdbcli --exec 'writemode on ; clear foo'
-       successOr Deleting value failed
+       successOr "Deleting value failed"
        getresult="$(fdbcli --exec 'get foo')"
-       successOr Get on database failed
+       successOr "Get on database failed"
        if [ "${getresult}" != "\`foo': not found" ]
        then
           fail "value was not cleared correctly"
@@ -69,23 +69,23 @@ then
        mkdir /etc/foundationdb
        description=$(LC_CTYPE=C tr -dc A-Za-z0-9 < /dev/urandom | head -c 8)
        random_str=$(LC_CTYPE=C tr -dc A-Za-z0-9 < /dev/urandom | head -c 8)
-       successOr Could not create secret
+       successOr "Could not create secret"
        echo $description:$random_str@127.0.0.1:4500 > /tmp/fdb.cluster
-       successOr Could not create fdb.cluster file
+       successOr "Could not create fdb.cluster file"
        sed '/\[fdbserver.4500\]/a \[fdbserver.4501\]' /foundationdb/packaging/foundationdb.conf > /tmp/foundationdb.conf
-       successOr Could not change foundationdb.conf file
+       successOr "Could not change foundationdb.conf file"
        # we need to keep these files around for testing that the install didn't change them
        cp /tmp/fdb.cluster /etc/foundationdb/fdb.cluster
        cp /tmp/foundationdb.conf /etc/foundationdb/foundationdb.conf
 
        install
-       successOr FoundationDB install failed
+       successOr "FoundationDB install failed"
        # make sure we are not in build directory as there is a fdbc.cluster file there
        echo "Configure new database - Install isn't supposed to do this for us"
        echo "as there was an existing configuration"
        cd /
        fdbcli --exec 'configure new single ssd'
-       successOr "Couldn't" configure new database
+       successOr "Couldn't configure new database"
        tests_healthy
        num_processes="$(fdbcli --exec 'status' | grep "FoundationDB processes" | sed -e 's/.*- //')"
        if [ "${num_processes}" -ne 2 ]

--- a/build/cmake/package_tester/modules/tests.sh
+++ b/build/cmake/package_tester/modules/tests.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+if [ -z "${tests_sh_included}" ]
+then
+   tests_sh_included=1
+
+   sourcce ${source_dir}/modules/util.sh
+
+   tests_healthy() {
+       cd /
+       fdbcli --exec status
+        if [ $? -ne 0 ]
+        then
+            return 1
+        fi
+        healthy="$(fdbcli --exec status | grep HEALTHY | wc -l)"
+        if [ -z "${healthy}" ]
+        then
+            __res=1
+            break
+        fi
+   }
+
+   tests_main() {
+       install
+       success Installation failed
+       tests_healthy
+       success FoundationDB is not healthy or not running
+       uninstall
+       success FoundationDB could not be uninstalled
+   }
+fi

--- a/build/cmake/package_tester/modules/tests.sh
+++ b/build/cmake/package_tester/modules/tests.sh
@@ -62,15 +62,13 @@ then
        num_processes="$(fdbcli --exec 'status' | grep "FoundationDB processes" | sed -e 's/.*- //')"
        if [ "${num_processes}" -ne 2 ]
        then
-          ?=2
-          success Number of processes incorrect after config change
+          fail Number of processes incorrect after config change
        fi
 
        differences="$(diff /tmp/fdb.cluster /etc/foundationdb/fdb.cluster)"
        if [ -n "${differences}" ]
        then
-          ?=1
-          success Install changed configuration files
+          fail Install changed configuration files
        fi
        differences="$(diff /tmp/foundationdb.conf /etc/foundationdb/foundationdb.conf)"
        if [ -n "${differences}" ]

--- a/build/cmake/package_tester/modules/util.sh
+++ b/build/cmake/package_tester/modules/util.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+if [ -z ${util_sh_included+x} ]
+then
+    util_sh_included=1
+
+    # for colored output
+    RED='\033[0;31m'
+    GREEN='\033[0;32m'
+    YELLOW='\033[1;33m'
+    NC='\033[0m' # No Color
+
+    enterfun() {
+        pushd . > /dev/null
+    }
+
+    exitfun() {
+        popd > /dev/null
+    }
+
+    success() {
+        local __res=$?
+        if [ ${__res} -ne 0 ]
+        then
+            if [ "$#" -gt 1 ]
+            then
+                echo -e "${RED}${@:1}${NC}"
+            fi
+            exit ${__res}
+        fi
+        return 0
+    }
+
+fi

--- a/build/cmake/package_tester/modules/util.sh
+++ b/build/cmake/package_tester/modules/util.sh
@@ -18,6 +18,11 @@ then
         popd > /dev/null
     }
 
+    fail() {
+        false
+        success ${@:1}
+    }
+
     success() {
         local __res=$?
         if [ ${__res} -ne 0 ]

--- a/build/cmake/package_tester/modules/util.sh
+++ b/build/cmake/package_tester/modules/util.sh
@@ -21,10 +21,10 @@ then
 
     fail() {
         false
-        success ${@:1}
+        successOr ${@:1}
     }
 
-    success() {
+    successOrOr() {
         local __res=$?
         if [ ${__res} -ne 0 ]
         then

--- a/build/cmake/package_tester/modules/util.sh
+++ b/build/cmake/package_tester/modules/util.sh
@@ -10,6 +10,7 @@ then
     YELLOW='\033[1;33m'
     NC='\033[0m' # No Color
 
+
     enterfun() {
         pushd . > /dev/null
     }
@@ -29,7 +30,7 @@ then
         then
             if [ "$#" -gt 1 ]
             then
-                echo -e "${RED}${@:1}${NC}"
+                >&2 echo -e "${RED}${@:1} ${NC}"
             fi
             exit ${__res}
         fi

--- a/build/cmake/package_tester/rpm_tests.sh
+++ b/build/cmake/package_tester/rpm_tests.sh
@@ -5,14 +5,20 @@ source_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 source ${source_dir}/modules/util.sh
 source ${source_dir}/modules/rpm.sh
 source ${source_dir}/modules/tests.sh
+source ${source_dir}/modules/test_args.sh
 
 main() {
     local __res=0
     enterfun
     for _ in 1
     do
-        package_files=( "$@" )
-        if [ "${__res}" -ne 0 ]
+        test_args_parse "$@"
+        __res=$?
+        if [ ${__res} -eq 2 ]
+        then
+            __res=0
+            break
+        elif [ ${__res} -ne 0 ]
         then
             break
         fi

--- a/build/cmake/package_tester/rpm_tests.sh
+++ b/build/cmake/package_tester/rpm_tests.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+source_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+
+source ${source_dir}/modules/util.sh
+source ${source_dir}/modules/rpm.sh
+source ${source_dir}/modules/tests.sh
+
+main() {
+    local __res=0
+    enterfun
+    for _ in 1
+    do
+        package_files=( "$@" )
+        if [ "${__res}" -ne 0 ]
+        then
+            break
+        fi
+        tests_main
+    done
+    exitfun
+    return ${__res}
+}
+
+main "$@"

--- a/build/cmake/package_tester/test_packages.sh
+++ b/build/cmake/package_tester/test_packages.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+source_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+
+source ${source_dir}/modules/config.sh
+source ${source_dir}/modules/util.sh
+source ${source_dir}/modules/arguments.sh
+source ${source_dir}/modules/docker.sh
+
+main() {
+    local __res=0
+    enterfun
+    for _ in 1
+    do
+        arguments_parse "$@"
+        if [ $? -ne 0 ]
+        then
+            __res=1
+            break
+        fi
+        config_verify
+        if [ $? -ne 0 ]
+        then
+            __res=1
+            break
+        fi
+        docker_run
+        __res=$?
+    done
+    exitfun
+    return ${__res}
+}
+
+main "$@"

--- a/tests/TestRunner/TestRunner.py
+++ b/tests/TestRunner/TestRunner.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 from argparse import ArgumentParser
 from TestDirectory import TestDirectory


### PR DESCRIPTION
This PR depends on #1141 - so until that is merged it looks much larger than it is. But all the interesting stuff happens in build/cmake

This is a set of scripts that tests the generated deb and rpm files. Currently the tests are simple - probably too simple. But the idea is that writing new tests should be quite simple.

It currently tests for the following things:

- The deb/rpm files can be installed and have the correct dependencies
- After installation FoundationDB is running and the status is healthy
- The package can be uninstalled

The idea is, that new tests can be added in `build/cmake/package_tester/modules/tests.sh`

To use these scripts the following is required: `docker`, `docker-compose`, `bash`. As an example one can go to build/cmake/ and execute the following commands to build the packages

1. `mkdir $HOME/build`
1. `export BUILDDIR=$HOME/build`
1. `sudo --preserve-env=BUILDDIR docker-compose run linux-pkgs`

The deb and rpm files will be then in `$HOME/build`. Next, to test the packages, one can use the following command:

```
package_tester/test_packages.sh -b $BUILDDIR
```

By default this will use the docker containers defined in this directory. However, other containers (as many as one wishes) can be defined in `docker.ini`