### PR TITLE
Put rpm, deb, or msi into the packages folder

### DIFF
--- a/cmake/InstallLayout.cmake
+++ b/cmake/InstallLayout.cmake
@@ -3,17 +3,19 @@
 ################################################################################
 
 function(install_symlink)
-  set(options "")
-  set(one_value_options COMPONENT TO DESTINATION)
-  set(multi_value_options)
-  cmake_parse_arguments(SYM "${options}" "${one_value_options}" "${multi_value_options}" "${ARGN}")
+  if (NOT WIN32)
+    set(options "")
+    set(one_value_options COMPONENT TO DESTINATION)
+    set(multi_value_options)
+    cmake_parse_arguments(SYM "${options}" "${one_value_options}" "${multi_value_options}" "${ARGN}")
 
-  file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/symlinks)
-  get_filename_component(fname ${SYM_DESTINATION} NAME)
-  get_filename_component(dest_dir ${SYM_DESTINATION} DIRECTORY)
-  set(sl ${CMAKE_CURRENT_BINARY_DIR}/symlinks/${fname})
-  execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink ${SYM_TO} ${sl})
-  install(FILES ${sl} DESTINATION ${dest_dir} COMPONENT ${SYM_COMPONENT})
+    file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/symlinks)
+    get_filename_component(fname ${SYM_DESTINATION} NAME)
+    get_filename_component(dest_dir ${SYM_DESTINATION} DIRECTORY)
+    set(sl ${CMAKE_CURRENT_BINARY_DIR}/symlinks/${fname})
+    execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink ${SYM_TO} ${sl})
+    install(FILES ${sl} DESTINATION ${dest_dir} COMPONENT ${SYM_COMPONENT})
+  endif()
 endfunction()
 
 if(NOT INSTALL_LAYOUT)
@@ -121,6 +123,8 @@ set(CPACK_PACKAGE_VENDOR "FoundationDB <fdb-dist@apple.com>")
 set(CPACK_PACKAGE_VERSION_MAJOR ${FDB_MAJOR})
 set(CPACK_PACKAGE_VERSION_MINOR ${FDB_MINOR})
 set(CPACK_PACKAGE_VERSION_PATCH ${FDB_PATCH})
+set(CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_NAME}-${FDB_VERSION}-${CPACK_SYSTEM_NAME}")
+set(CPACK_OUTPUT_FILE_PREFIX "${CMAKE_BINARY_DIR}/packages")
 set(CPACK_PACKAGE_DESCRIPTION_FILE ${CMAKE_SOURCE_DIR}/packaging/description)
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY
   "FoundationDB is a scalable, fault-tolerant, ordered key-value store with full ACID transactions.")
@@ -138,9 +142,12 @@ else()
   set(CPACK_RESOURCE_FILE_LICENSE ${CMAKE_SOURCE_DIR}/LICENSE)
 endif()
 
+if(NOT WIN32)
+  add_dependencies(packages package)
+endif()
+
 ################################################################################
 # Configuration for RPM
-################################################################################
 ################################################################################
 
 if(UNIX AND NOT APPLE)

--- a/cmake/InstallLayout.cmake
+++ b/cmake/InstallLayout.cmake
@@ -142,10 +142,6 @@ else()
   set(CPACK_RESOURCE_FILE_LICENSE ${CMAKE_SOURCE_DIR}/LICENSE)
 endif()
 
-if(NOT WIN32)
-  add_dependencies(packages package)
-endif()
-
 ################################################################################
 # Configuration for RPM
 ################################################################################

--- a/packaging/msi/CMakeLists.txt
+++ b/packaging/msi/CMakeLists.txt
@@ -16,7 +16,7 @@ if(WIX_FOUND)
             -DVERSION=${CMAKE_PROJECT_VERSION}
             -DVERSION_NAME=${FDB_VERSION}
             -P ${CMAKE_CURRENT_SOURCE_DIR}/generate_wxs.cmake
-    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/FDBInstaller.wxs ${CMAKE_CURRENT_SOURCE_DIR}/generate_wsx.cmake fdbserver fdbcli fdbmonitor fdb_c fdbbackup
+    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/FDBInstaller.wxs ${CMAKE_CURRENT_SOURCE_DIR}/generate_wsx.cmake
     COMMENT "Generate WIX file")
   add_custom_target(wix_file DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/FDBInstaller.wxs)
   add_custom_command(
@@ -27,14 +27,17 @@ if(WIX_FOUND)
     COMMENT "Create WIX Object file"
     )
   add_custom_target(wixobj DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/FDBInstaller.wixobj)
+  add_dependencies(wixobj fdbserver fdbcli fdbmonitor fdb_c fdbbackup python_binding)
+  string(REPLACE "/" "\\" msi_out_file "${CMAKE_BINARY_DIR}/packages/FDBInstaller.msi")
   add_custom_command(
-    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/FDBInstaller.msi
-    COMMAND ${WIX_LIGHT} FDBInstaller.wixobj -ext WixUIExtension
+    OUTPUT ${CMAKE_BINARY_DIR}/packages/FDBInstaller.msi
+    COMMAND ${WIX_LIGHT} FDBInstaller.wixobj -ext WixUIExtension -out ${msi_out_file}
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-    DEPENDS wixobj
     COMMENT "Generate MSI installer"
     )
-  add_custom_target(installer ALL DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/FDBInstaller.msi)
+  add_custom_target(installer DEPENDS ${CMAKE_BINARY_DIR}/packages/FDBInstaller.msi)
+  add_dependencies(installer wixobj)
+  add_dependencies(packages installer)
   #add_dependencies(installer fdbserver fdbcli fdbmonitor fdbbackup)
 else()
   message(WARNING "Could NOT find WIX - will not build installer")


### PR DESCRIPTION
This additionally fixes a dependency bug on Windows.

Additionally, the target `packages`, will now create either the RPM, the DEB, or the MSI.

@AlvinMooreSr Can you please take a look at this PR. I think this covers one part of what we discussed on Friday