### PR TITLE
Add TEST_LOG_FORMAT to cmake

### DIFF
--- a/cmake/AddFdbTest.cmake
+++ b/cmake/AddFdbTest.cmake
@@ -107,6 +107,7 @@ function(add_fdb_test)
     -t ${test_type}
     -O ${OLD_FDBSERVER_BINARY}
     --aggregate-traces ${TEST_AGGREGATE_TRACES}
+    --log-format ${TEST_LOG_FORMAT}
     --keep-logs ${TEST_KEEP_LOGS}
     --keep-simdirs ${TEST_KEEP_SIMDIR}
     --seed ${SEED}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,6 +6,7 @@ set(RUN_IGNORED_TESTS OFF CACHE BOOL "Run tests that are marked for ignore")
 set(TEST_KEEP_LOGS "FAILED" CACHE STRING "Which locks to keep (NONE, FAILED, ALL)")
 set(TEST_KEEP_SIMDIR "NONE" CACHE STRING "Which simfdb directories to keep (NONE, FAILED, ALL)")
 set(TEST_AGGREGATE_TRACES "NONE" CACHE STRING "Create aggregated trace files (NONE, FAILED, ALL)")
+set(TEST_LOG_FORMAT "xml" CACHE STRING "Format for test trace files (xml, json)")
 
 # for the restart test we optimally want to use the last stable fdbserver
 # to test upgrades

--- a/tests/TestRunner/TestRunner.py
+++ b/tests/TestRunner/TestRunner.py
@@ -273,9 +273,8 @@ def run_simulation_test(basedir, options):
     if options.buggify:
         pargs.append('-b')
         pargs.append('on')
-    # FIXME: include these lines as soon as json support is added
-    #pargs.append('--trace_format')
-    #pargs.append(log_format)
+    pargs.append('--trace_format')
+    pargs.append(options.log_format)
     test_dir = td.get_current_test_dir()
     if options.seed is not None:
         pargs.append('-s')


### PR DESCRIPTION
This adds support for generating json logs from ctest instead of xml

cc @mpilman 