### PR TITLE
Actually compile ManagementAPI.actor.cpp on windows.

### DIFF
--- a/fdbclient/fdbclient.vcxproj
+++ b/fdbclient/fdbclient.vcxproj
@@ -119,10 +119,7 @@
     <ClCompile Include="md5\md5.c" />
     <ActorCompiler Include="MetricLogger.actor.cpp" />
     <ActorCompiler Include="MonitorLeader.actor.cpp" />
-    <ActorCompiler Include="ManagementAPI.actor.cpp">
-      <EnableCompile Condition="'$(Configuration)|$(Platform)'=='Debug|X64'">false</EnableCompile>
-      <EnableCompile Condition="'$(Configuration)|$(Platform)'=='Release|X64'">false</EnableCompile>
-    </ActorCompiler>
+    <ActorCompiler Include="ManagementAPI.actor.cpp" />
     <ActorCompiler Include="MultiVersionTransaction.actor.cpp" />
     <ActorCompiler Include="NativeAPI.actor.cpp" />
     <ActorCompiler Include="ReadYourWrites.actor.cpp" />


### PR DESCRIPTION
<EnableCompile>false should only be applied to .actor.h files, so that
we don't try to compile the resulting .h file.

Apparently.