### PR TITLE
ignore ccls-cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,4 @@ flow/coveragetool/obj
 .DS_Store
 temp/
 /compile_commands.json
+/.ccls-cache


### PR DESCRIPTION
[ccls](https://github.com/MaskRay/ccls) is a popular language server for C/C++
that I use to work with Foundationdb. Sadly, it doesn't seem to provide an
option to put the cache index into another directory.

I would like to add the ccl-cache to the `.gitignore` file.