### PR TITLE
Make old build system work on CentOS container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,11 @@
 export
 PLATFORM := $(shell uname)
 ARCH := $(shell uname -m)
+ifeq ("$(wildcard /etc/centos-release)", "")
+	LIBSTDCPP_HACK = 1
+else
+	LIBSTDCPP_HACK = 0
+endif
 
 TOPDIR := $(shell pwd)
 
@@ -180,6 +185,25 @@ targets:
 	@echo "Available targets:"
 	@for i in $(sort $(TARGETS)); do echo "  $$i" ; done
 	@echo "Append _clean to clean specific target."
+
+lib/libstdc++.a: $(shell $(CC) -print-file-name=libstdc++_pic.a)
+	@echo "Frobnicating   $@"
+	@mkdir -p lib
+	@rm -rf .libstdc++
+	@mkdir .libstdc++
+	@(cd .libstdc++ && ar x $<)
+	@for i in .libstdc++/*.o ; do \
+		nm $$i | grep -q \@ || continue ; \
+		nm $$i | awk '$$3 ~ /@@/ { COPY = $$3; sub(/@@.*/, "", COPY); print $$3, COPY; }' > .libstdc++/replacements ; \
+		objcopy --redefine-syms=.libstdc++/replacements $$i $$i.new && mv $$i.new $$i ; \
+		rm .libstdc++/replacements ; \
+		nm $$i | awk '$$3 ~ /@/ { print $$3; }' > .libstdc++/deletes ; \
+		objcopy --strip-symbols=.libstdc++/deletes $$i $$i.new && mv $$i.new $$i ; \
+		rm .libstdc++/deletes ; \
+	done
+	@ar rcs $@ .libstdc++/*.o
+	@rm -r .libstdc++
+
 
 docpreview: javadoc
 	@echo "Generating     docpreview"

--- a/Makefile
+++ b/Makefile
@@ -181,24 +181,6 @@ targets:
 	@for i in $(sort $(TARGETS)); do echo "  $$i" ; done
 	@echo "Append _clean to clean specific target."
 
-lib/libstdc++.a: $(shell $(CC) -print-file-name=libstdc++_pic.a)
-	@echo "Frobnicating   $@"
-	@mkdir -p lib
-	@rm -rf .libstdc++
-	@mkdir .libstdc++
-	@(cd .libstdc++ && ar x $<)
-	@for i in .libstdc++/*.o ; do \
-		nm $$i | grep -q \@ || continue ; \
-		nm $$i | awk '$$3 ~ /@@/ { COPY = $$3; sub(/@@.*/, "", COPY); print $$3, COPY; }' > .libstdc++/replacements ; \
-		objcopy --redefine-syms=.libstdc++/replacements $$i $$i.new && mv $$i.new $$i ; \
-		rm .libstdc++/replacements ; \
-		nm $$i | awk '$$3 ~ /@/ { print $$3; }' > .libstdc++/deletes ; \
-		objcopy --strip-symbols=.libstdc++/deletes $$i $$i.new && mv $$i.new $$i ; \
-		rm .libstdc++/deletes ; \
-	done
-	@ar rcs $@ .libstdc++/*.o
-	@rm -r .libstdc++
-
 docpreview: javadoc
 	@echo "Generating     docpreview"
 	@TARGETS= $(MAKE) -C documentation docpreview

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ become the only build system available.
 1. Run the docker image interactively [Docker Run](https://docs.docker.com/engine/reference/run/#general-form) with the directory containing the foundationdb repo mounted [Docker Mounts](https://docs.docker.com/storage/volumes/).
 
     ```shell
-    docker run -it -v '/local/dir/path/foundationdb:/docker/dir/path/foundationdb' foundationdb/foundationdb-build:latest /bin/bash
+    docker run -it -v '/local/dir/path/foundationdb:/docker/dir/path/foundationdb' foundationdb/foundationdb-build:latest
     ```
 
 1. Navigate to the container's mounted directory which contains the foundationdb repo.

--- a/bindings/c/local.mk
+++ b/bindings/c/local.mk
@@ -30,8 +30,7 @@ fdb_c_tests_HEADERS := -Ibindings/c
 CLEAN_TARGETS += fdb_c_tests_clean
 
 ifeq ($(PLATFORM),linux)
-  fdb_c_LIBS += lib/libstdc++.a -lm -lpthread -lrt -ldl
-  fdb_c_LDFLAGS += -Wl,--version-script=bindings/c/fdb_c.map -static-libgcc -Wl,-z,nodelete
+  fdb_c_LDFLAGS += -Wl,--version-script=bindings/c/fdb_c.map -static-libgcc -Wl,-z,nodelete -lm -lpthread -lrt -ldl
   fdb_c_tests_LIBS += -lpthread
 endif
 

--- a/bindings/c/local.mk
+++ b/bindings/c/local.mk
@@ -31,6 +31,9 @@ CLEAN_TARGETS += fdb_c_tests_clean
 
 ifeq ($(PLATFORM),linux)
   fdb_c_LDFLAGS += -Wl,--version-script=bindings/c/fdb_c.map -static-libgcc -Wl,-z,nodelete -lm -lpthread -lrt -ldl
+  ifeq ($(LIBSTDCPP_HACK),1)
+    fdb_c_LIBS += lib/libstdc++.a
+  endif
   fdb_c_tests_LIBS += -lpthread
 endif
 

--- a/build/link-wrapper.sh
+++ b/build/link-wrapper.sh
@@ -23,7 +23,7 @@ case $1 in
 	    OPTIONS=
 	fi
 
-	OPTIONS=$( eval echo "$OPTIONS $LDFLAGS \$$2_LDFLAGS \$$2_OBJECTS \$$2_LIBS \$$2_STATIC_LIBS_REAL -o $3" )
+	OPTIONS=$( eval echo "$OPTIONS $LDFLAGS \$$2_OBJECTS \$$2_LIBS \$$2_STATIC_LIBS_REAL \$$2_LDFLAGS -o $3" )
 
 	if echo $OPTIONS | grep -q -- -static-libstdc\+\+ ; then
 	    OPTIONS=$( echo $OPTIONS | sed -e s,-static-libstdc\+\+,, -e s,\$,\ `$CC -print-file-name=libstdc++.a`\ -lm, )

--- a/build/link-wrapper.sh
+++ b/build/link-wrapper.sh
@@ -2,6 +2,11 @@
 
 set -e
 
+if [ -z ${CC+x} ]
+then
+    CC=gcc
+fi
+
 case $1 in
     Application | DynamicLibrary)
 	echo "Linking        $3"

--- a/fdbbackup/local.mk
+++ b/fdbbackup/local.mk
@@ -26,8 +26,7 @@ fdbbackup_LIBS := lib/libfdbclient.a lib/libfdbrpc.a lib/libflow.a $(FDB_TLS_LIB
 fdbbackup_STATIC_LIBS := $(TLS_LIBS)
 
 ifeq ($(PLATFORM),linux)
-  fdbbackup_LIBS += -ldl -lpthread -lrt
-  fdbbackup_LDFLAGS += -static-libstdc++ -static-libgcc
+  fdbbackup_LDFLAGS += -static-libstdc++ -static-libgcc -ldl -lpthread -lrt
 
   # GPerfTools profiler (uncomment to use)
   # fdbbackup_CFLAGS += -I/opt/gperftools/include -DUSE_GPERFTOOLS=1

--- a/fdbcli/local.mk
+++ b/fdbcli/local.mk
@@ -22,14 +22,13 @@
 
 fdbcli_CFLAGS := $(fdbclient_CFLAGS)
 fdbcli_LDFLAGS := $(fdbrpc_LDFLAGS)
-fdbcli_LIBS := lib/libfdbclient.a lib/libfdbrpc.a lib/libflow.a -ldl $(FDB_TLS_LIB)
+fdbcli_LIBS := lib/libfdbclient.a lib/libfdbrpc.a lib/libflow.a $(FDB_TLS_LIB)
 fdbcli_STATIC_LIBS := $(TLS_LIBS)
 
 fdbcli_GENERATED_SOURCES += versions.h
 
 ifeq ($(PLATFORM),linux)
-  fdbcli_LDFLAGS += -static-libstdc++ -static-libgcc
-  fdbcli_LIBS += -lpthread -lrt
+  fdbcli_LDFLAGS += -static-libstdc++ -static-libgcc -lpthread -lrt -ldl
 else ifeq ($(PLATFORM),osx)
   fdbcli_LDFLAGS += -lc++
 endif

--- a/fdbserver/local.mk
+++ b/fdbserver/local.mk
@@ -26,8 +26,7 @@ fdbserver_LIBS := lib/libfdbclient.a lib/libfdbrpc.a lib/libflow.a $(FDB_TLS_LIB
 fdbserver_STATIC_LIBS := $(TLS_LIBS)
 
 ifeq ($(PLATFORM),linux)
-  fdbserver_LIBS += -ldl -lpthread -lrt
-  fdbserver_LDFLAGS += -static-libstdc++ -static-libgcc
+  fdbserver_LDFLAGS += -static-libstdc++ -static-libgcc -ldl -lpthread -lrt
 
   # GPerfTools profiler (uncomment to use)
   # fdbserver_CFLAGS += -I/opt/gperftools/include -DUSE_GPERFTOOLS=1

--- a/fdbserver/local.mk
+++ b/fdbserver/local.mk
@@ -26,7 +26,7 @@ fdbserver_LIBS := lib/libfdbclient.a lib/libfdbrpc.a lib/libflow.a $(FDB_TLS_LIB
 fdbserver_STATIC_LIBS := $(TLS_LIBS)
 
 ifeq ($(PLATFORM),linux)
-  fdbserver_LDFLAGS += -static-libstdc++ -static-libgcc -ldl -lpthread -lrt
+  fdbserver_LDFLAGS += -ldl -lpthread -lrt -static-libstdc++ -static-libgcc
 
   # GPerfTools profiler (uncomment to use)
   # fdbserver_CFLAGS += -I/opt/gperftools/include -DUSE_GPERFTOOLS=1


### PR DESCRIPTION
This commit replaces the ubuntu-based docker-container with a CentOS one. This
image was before in `build/cmake` and this uses it as a default. The work here
is still not finished, so please don't merge yet (this change will make the
ubuntu-image break which still needs to be fixed).

The main motivation for this is that it will give us a newer version of gcc
(7.0). This also makes the old libstdc++-static-linking-hack obsolete (as CentOS
does something similar).

The changes mostly include:

1. Default CC to gcc in linker-script (as not all make versions set this
   environment variables)
1. Move linker-flag dependencies to ld-flags. This was, as far as I can tell with
   my limited make knowledge, a bug in the build system.
1. Remove the libstdc++.a target. This doesn't work under CentOS (and is not
   necessary). With a later commit I will guard this code with some
   if-statements so that it works on the ubuntu-container as well.