### PR TITLE
Spill-By-Reference TLog Part 3: Reference Spilling

### DIFF
--- a/fdbserver/DiskQueue.actor.cpp
+++ b/fdbserver/DiskQueue.actor.cpp
@@ -796,6 +796,8 @@ public:
 	// FIXME: getNextReadLocation should ASSERT( initialized ), but the memory storage engine needs
 	// to be changed to understand the new intiailizeRecovery protocol.
 	virtual location getNextReadLocation() { return nextReadLocation; }
+	virtual location getNextCommitLocation() { ASSERT( initialized ); return lastCommittedSeq + sizeof(Page); }
+	virtual location getNextPushLocation() { ASSERT( initialized ); return endLocation(); }
 
 	virtual Future<Void> getError() { return rawQueue->getError(); }
 	virtual Future<Void> onClosed() { return rawQueue->onClosed(); }
@@ -1247,6 +1249,9 @@ public:
 	virtual location getNextReadLocation() { return queue->getNextReadLocation(); }
 
 	virtual Future<Standalone<StringRef>> read( location start, location end ) { return queue->read( start, end ); }
+	virtual location getNextCommitLocation() { return queue->getNextCommitLocation(); }
+	virtual location getNextPushLocation() { return queue->getNextPushLocation(); }
+
 
 	virtual location push( StringRef contents ) {
 		pushed = queue->push(contents);

--- a/fdbserver/IDiskQueue.h
+++ b/fdbserver/IDiskQueue.h
@@ -53,6 +53,8 @@ public:
 	// Thereafter it may not be called again.
 	virtual Future<Standalone<StringRef>> readNext( int bytes ) = 0;  // Return the next bytes in the queue (beginning, the first time called, with the first unpopped byte)
 	virtual location getNextReadLocation() = 0;    // Returns a location >= the location of all bytes previously returned by readNext(), and <= the location of all bytes subsequently returned
+	virtual location getNextCommitLocation() = 0;  // If commit() were to be called, all buffered writes would be written starting at `location`.
+	virtual location getNextPushLocation() = 0;  // If push() were to be called, the pushed data would be written starting at `location`.
 
 	virtual Future<Standalone<StringRef>> read( location start, location end ) = 0;
 	virtual location push( StringRef contents ) = 0;  // Appends the given bytes to the byte stream.  Returns a location token representing the *end* of the contents.

--- a/fdbserver/IDiskQueue.h
+++ b/fdbserver/IDiskQueue.h
@@ -34,6 +34,11 @@ public:
 		location(int64_t hi, int64_t lo) : hi(hi), lo(lo) {}
 		operator std::string() { return format("%lld.%lld", hi, lo); }  // FIXME: Return a 'HumanReadableDescription' instead of std::string, make TraceEvent::detail accept that (for safety)
 
+		template<class Ar>
+		void serialize_unversioned(Ar& ar) {
+			serializer(ar, hi, lo);
+		}
+
 		bool operator < (location const& r) const {
 			if (hi<r.hi) return true;
 			if (hi>r.hi) return false;
@@ -65,6 +70,10 @@ public:
 
 	virtual StorageBytes getStorageBytes() = 0;
 };
+
+// FIXME: One should be able to use SFINAE to choose between serialize and serialize_unversioned.
+template <class Ar> void load( Ar& ar, IDiskQueue::location& loc ) { loc.serialize_unversioned(ar); }
+template <class Ar> void save( Ar& ar, const IDiskQueue::location& loc ) { const_cast<IDiskQueue::location&>(loc).serialize_unversioned(ar); }
 
 IDiskQueue* openDiskQueue( std::string basename, std::string ext, UID dbgid, int64_t fileSizeWarningLimit = -1);  // opens basename+"0."+ext and basename+"1."+ext
 

--- a/fdbserver/LogSystemDiskQueueAdapter.h
+++ b/fdbserver/LogSystemDiskQueueAdapter.h
@@ -82,6 +82,8 @@ public:
 	virtual Future<bool> initializeRecovery() { return false; }
 	virtual Future<Standalone<StringRef>> readNext( int bytes );
 	virtual IDiskQueue::location getNextReadLocation();
+	virtual IDiskQueue::location getNextCommitLocation() { ASSERT(false); throw internal_error(); }
+	virtual IDiskQueue::location getNextPushLocation() { ASSERT(false); throw internal_error(); }
 	virtual Future<Standalone<StringRef>> read( location start, location end ) { ASSERT(false); throw internal_error(); }
 	virtual IDiskQueue::location push( StringRef contents );
 	virtual void pop( IDiskQueue::location upTo );

--- a/fdbserver/TLogServer.actor.cpp
+++ b/fdbserver/TLogServer.actor.cpp
@@ -648,8 +648,10 @@ ACTOR Future<Void> updatePersistentData( TLogData* self, Reference<LogData> logD
 					tagData->nothingPersistent = false;
 					BinaryWriter wr( Unversioned() );
 
-					for(; msg != tagData->versionMessages.end() && msg->first == currentVersion; ++msg)
+					for(; msg != tagData->versionMessages.end() && msg->first == currentVersion; ++msg) {
+						// .toStringRef() strips off the length prefix, but << adds it back when serializing a StringRef.
 						wr << msg->second.toStringRef();
+					}
 
 					self->persistentData->set( KeyValueRef( persistTagMessagesKey( logData->logId, tagData->tag, currentVersion ), wr.toStringRef() ) );
 

--- a/flow/serialize.h
+++ b/flow/serialize.h
@@ -511,6 +511,11 @@ public:
 		return b;
 	}
 
+	const void* peekBytes( int bytes ) {
+		ASSERT( begin + bytes <= end );
+		return begin;
+	}
+
 	void serializeBytes(void* data, int bytes) {
 		memcpy(data, readBytes(bytes), bytes);
 	}
@@ -534,6 +539,7 @@ public:
 	BinaryReader( const void* data, int length, VersionOptions vo ) {
 		begin = (const char*)data;
 		end = begin + length;
+		check = nullptr;
 		vo.read(*this);
 	}
 	template <class VersionOptions>
@@ -558,8 +564,19 @@ public:
 
 	bool empty() const { return begin == end; }
 
+	void checkpoint() {
+		check = begin;
+	}
+
+	void rewind() {
+		ASSERT(check != nullptr);
+		begin = check;
+		check = nullptr;
+	}
+
+
 private:
-	const char *begin, *end;
+	const char *begin, *end, *check;
 	Arena m_pool;
 	uint64_t m_protocolVersion;
 };


### PR DESCRIPTION
Part 3 of probably 4 or 5 for #1048

This actually implements the new spill type in the "new" TLogServer.

This code is not something that you would actually wish to use.  Performance testing it will probably cause OOMs, and other sad things.  However, it makes a convenient stepping stone for all the improvements that need to be done to bring this up to a productionized state. 