### PR TITLE
Java: Tuple serialization/deserialization uses fewer allocations

### DIFF
--- a/bindings/java/CMakeLists.txt
+++ b/bindings/java/CMakeLists.txt
@@ -56,6 +56,7 @@ set(JAVA_BINDING_SRCS
   src/main/com/apple/foundationdb/tuple/package-info.java
   src/main/com/apple/foundationdb/tuple/Tuple.java
   src/main/com/apple/foundationdb/tuple/TupleUtil.java
+  src/main/com/apple/foundationdb/tuple/StringUtil.java
   src/main/com/apple/foundationdb/tuple/Versionstamp.java)
 
 set(JAVA_TESTS_SRCS

--- a/bindings/java/CMakeLists.txt
+++ b/bindings/java/CMakeLists.txt
@@ -54,9 +54,9 @@ set(JAVA_BINDING_SRCS
   src/main/com/apple/foundationdb/tuple/ByteArrayUtil.java
   src/main/com/apple/foundationdb/tuple/IterableComparator.java
   src/main/com/apple/foundationdb/tuple/package-info.java
+  src/main/com/apple/foundationdb/tuple/StringUtil.java
   src/main/com/apple/foundationdb/tuple/Tuple.java
   src/main/com/apple/foundationdb/tuple/TupleUtil.java
-  src/main/com/apple/foundationdb/tuple/StringUtil.java
   src/main/com/apple/foundationdb/tuple/Versionstamp.java)
 
 set(JAVA_TESTS_SRCS
@@ -89,8 +89,8 @@ set(JAVA_TESTS_SRCS
   src/test/com/apple/foundationdb/test/StackUtils.java
   src/test/com/apple/foundationdb/test/TesterArgs.java
   src/test/com/apple/foundationdb/test/TestResult.java
-  src/test/com/apple/foundationdb/test/TupleTest.java
   src/test/com/apple/foundationdb/test/TuplePerformanceTest.java
+  src/test/com/apple/foundationdb/test/TupleTest.java
   src/test/com/apple/foundationdb/test/VersionstampSmokeTest.java
   src/test/com/apple/foundationdb/test/WatchTest.java
   src/test/com/apple/foundationdb/test/WhileTrueTest.java)

--- a/bindings/java/CMakeLists.txt
+++ b/bindings/java/CMakeLists.txt
@@ -89,6 +89,7 @@ set(JAVA_TESTS_SRCS
   src/test/com/apple/foundationdb/test/TesterArgs.java
   src/test/com/apple/foundationdb/test/TestResult.java
   src/test/com/apple/foundationdb/test/TupleTest.java
+  src/test/com/apple/foundationdb/test/TuplePerformanceTest.java
   src/test/com/apple/foundationdb/test/VersionstampSmokeTest.java
   src/test/com/apple/foundationdb/test/WatchTest.java
   src/test/com/apple/foundationdb/test/WhileTrueTest.java)

--- a/bindings/java/src/main/com/apple/foundationdb/subspace/Subspace.java
+++ b/bindings/java/src/main/com/apple/foundationdb/subspace/Subspace.java
@@ -46,8 +46,8 @@ import com.apple.foundationdb.tuple.Versionstamp;
  * </p>
  */
 public class Subspace {
-	static final Tuple EMPTY_TUPLE = Tuple.from();
-	static final byte[] EMPTY_BYTES = new byte[0];
+	private static final Tuple EMPTY_TUPLE = Tuple.from();
+	private static final byte[] EMPTY_BYTES = new byte[0];
 
 	private final byte[] rawPrefix;
 
@@ -248,8 +248,7 @@ public class Subspace {
 	 * @return the {@link Range} of keyspace corresponding to {@code tuple}
 	 */
 	public Range range(Tuple tuple) {
-		Range p = tuple.range();
-		return new Range(join(rawPrefix, p.begin), join(rawPrefix, p.end));
+		return tuple.range(rawPrefix);
 	}
 
 	/**

--- a/bindings/java/src/main/com/apple/foundationdb/tuple/ByteArrayUtil.java
+++ b/bindings/java/src/main/com/apple/foundationdb/tuple/ByteArrayUtil.java
@@ -229,8 +229,7 @@ public class ByteArrayUtil {
 		int n = Arrays.binarySearch(arr, i);
 		if(n >= 0)
 			return n;
-		int ip = (n + 1) * -1;
-		return ip;
+		return (n + 1) * -1;
 	}
 
 	/**

--- a/bindings/java/src/main/com/apple/foundationdb/tuple/ByteArrayUtil.java
+++ b/bindings/java/src/main/com/apple/foundationdb/tuple/ByteArrayUtil.java
@@ -187,10 +187,6 @@ public class ByteArrayUtil {
 			// Array might change size. This is the "tricky" case.
 			int newLength = replace(src, offset, length, pattern, replacement, null);
 			if(newLength != length) {
-				if(newLength < 0) {
-					System.out.println("oops");
-					newLength = replace(src, offset, length, pattern, replacement, null);
-				}
 				dest = ByteBuffer.allocate(newLength);
 			}
 			else {

--- a/bindings/java/src/main/com/apple/foundationdb/tuple/IterableComparator.java
+++ b/bindings/java/src/main/com/apple/foundationdb/tuple/IterableComparator.java
@@ -34,7 +34,7 @@ import java.util.Iterator;
  *    tuple1.compareTo(tuple2)
  *      == new IterableComparator().compare(tuple1, tuple2)
  *      == new IterableComparator().compare(tuple1.getItems(), tuple2.getItems()),
- *      == ByteArrayUtil.compareUnsigned(tuple1.pack(), tuple2.pack())}
+ *      == ByteArrayUtil.compareUnsigned(tuple1.packInternal(), tuple2.packInternal())}
  * </pre>
  *
  * <p>

--- a/bindings/java/src/main/com/apple/foundationdb/tuple/IterableComparator.java
+++ b/bindings/java/src/main/com/apple/foundationdb/tuple/IterableComparator.java
@@ -34,7 +34,7 @@ import java.util.Iterator;
  *    tuple1.compareTo(tuple2)
  *      == new IterableComparator().compare(tuple1, tuple2)
  *      == new IterableComparator().compare(tuple1.getItems(), tuple2.getItems()),
- *      == ByteArrayUtil.compareUnsigned(tuple1.packInternal(), tuple2.packInternal())}
+ *      == ByteArrayUtil.compareUnsigned(tuple1.pack(), tuple2.pack())}
  * </pre>
  *
  * <p>

--- a/bindings/java/src/main/com/apple/foundationdb/tuple/StringUtil.java
+++ b/bindings/java/src/main/com/apple/foundationdb/tuple/StringUtil.java
@@ -1,0 +1,75 @@
+/*
+ * StringUtil.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2018 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb.tuple;
+
+final class StringUtil {
+	private static final char SURROGATE_COUNT = Character.MAX_LOW_SURROGATE - Character.MIN_HIGH_SURROGATE + 1;
+	private static final char ABOVE_SURROGATES = Character.MAX_VALUE - Character.MAX_LOW_SURROGATE;
+
+	static char adjustForSurrogates(char c, String s, int pos) {
+		if(c > Character.MAX_LOW_SURROGATE) {
+			return (char)(c - SURROGATE_COUNT);
+		}
+		else {
+			// Validate the UTF-16 string as this can do weird things on invalid strings
+			if((Character.isHighSurrogate(c) && (pos + 1 >= s.length() || !Character.isLowSurrogate(s.charAt(pos + 1)))) ||
+					(Character.isLowSurrogate(c) && (pos == 0 || !Character.isHighSurrogate(s.charAt(pos - 1))))) {
+				throw new IllegalArgumentException("malformed UTF-16 string does not follow high surrogate with low surrogate");
+			}
+			return (char)(c + ABOVE_SURROGATES);
+
+		}
+	}
+
+	// Compare two strings based on their UTF-8 code point values. Note that Java stores strings
+	// using UTF-16. However, {@link Tuple}s are encoded using UTF-8. Using unsigned byte comparison,
+	// UTF-8 strings will sort based on their Unicode codepoints. However, UTF-16 strings <em>almost</em>,
+	// but not quite, sort that way. This can be addressed by fixing up surrogates. There are 0x800 surrogate
+	// values and about 0x2000 code points above the maximum surrogate value. For anything that is a surrogate,
+	// shift it up by 0x2000, and anything that is above the maximum surrogate value, shift it down by 0x800.
+	// This makes all surrogates sort after all non-surrogates.
+	//
+	// See: https://ssl.icu-project.org/docs/papers/utf16_code_point_order.html
+	static int compareUtf8(String s1, String s2) {
+		// Ignore common prefix at the beginning which will compare equal regardless of encoding
+		int pos = 0;
+		while(pos < s1.length() && pos < s2.length() && s1.charAt(pos) == s2.charAt(pos)) {
+			pos++;
+		}
+		if(pos >= s1.length() || pos >= s2.length()) {
+			// One string is the prefix of another, so return based on length.
+			return Integer.compare(s1.length(), s2.length());
+		}
+		// Compare first different character
+		char c1 = s1.charAt(pos);
+		char c2 = s2.charAt(pos);
+		// Apply "fix up" for surrogates
+		if(c1 >= Character.MIN_HIGH_SURROGATE) {
+			c1 = adjustForSurrogates(c1, s1, pos);
+		}
+		if(c2 >= Character.MIN_HIGH_SURROGATE) {
+			c2 = adjustForSurrogates(c2, s2, pos);
+		}
+		return Character.compare(c1, c2);
+	}
+
+	private StringUtil() {}
+}

--- a/bindings/java/src/main/com/apple/foundationdb/tuple/Tuple.java
+++ b/bindings/java/src/main/com/apple/foundationdb/tuple/Tuple.java
@@ -824,9 +824,12 @@ public class Tuple implements Comparable<Tuple>, Iterable<Object> {
 	}
 
 	/**
-	 * Get the number of bytes in the packed representation of this {@code Tuple}.
+	 * Get the number of bytes in the packed representation of this {@code Tuple}. Note that at the
+	 *  moment, this number is calculated by packing the {@code Tuple} and looking at its size. This method
+	 *  will memoize the result, however, so asking the same {@code Tuple} for its size multiple times
+	 *  is a fast operation.
 	 *
-	 * @return
+	 * @return the number of bytes in the packed representation of this {@code Tuple}
 	 */
 	public int getPackedSize() {
 		byte[] p = packMaybeVersionstamp(null);
@@ -847,7 +850,12 @@ public class Tuple implements Comparable<Tuple>, Iterable<Object> {
 	 */
 	@Override
 	public int compareTo(Tuple t) {
-		return comparator.compare(elements, t.elements);
+		if(packed != null && t.packed != null) {
+			return ByteArrayUtil.compareUnsigned(packed, t.packed);
+		}
+		else {
+			return comparator.compare(elements, t.elements);
+		}
 	}
 
 	/**

--- a/bindings/java/src/main/com/apple/foundationdb/tuple/TupleUtil.java
+++ b/bindings/java/src/main/com/apple/foundationdb/tuple/TupleUtil.java
@@ -546,7 +546,13 @@ class TupleUtil {
 			return ByteArrayUtil.compareUnsigned((byte[])item1, (byte[])item2);
 		}
 		if(code1 == STRING_CODE) {
-			return ByteArrayUtil.compareUnsigned(((String)item1).getBytes(UTF8), ((String)item2).getBytes(UTF8));
+			try {
+				return StringUtil.compareUtf8((String)item1, (String)item2);
+			}
+			catch(IllegalArgumentException e) {
+				// Encountered malformed unicode when comparing. Use byte comparison.
+				return ByteArrayUtil.compareUnsigned(((String)item1).getBytes(UTF8), ((String)item2).getBytes(UTF8));
+			}
 		}
 		if(code1 == INT_ZERO_CODE) {
 			if(item1 instanceof Long && item2 instanceof Long) {

--- a/bindings/java/src/main/com/apple/foundationdb/tuple/TupleUtil.java
+++ b/bindings/java/src/main/com/apple/foundationdb/tuple/TupleUtil.java
@@ -509,14 +509,14 @@ class TupleUtil {
 			if(positive && (n < Long.BYTES || rep[start] > 0)) {
 				long res = 0L;
 				for(int i = start; i < end; i++) {
-					res = (res << 8) + (rep[i] & 0xff);
+					res = (res << 8) | (rep[i] & 0xff);
 				}
 				state.add(res, end);
 			}
 			else if(!positive && (n < Long.BYTES || rep[start] < 0)) {
 				long res = ~0L;
 				for(int i = start; i < end; i++) {
-					res = (res << 8) + (rep[i] & 0xff);
+					res = (res << 8) | (rep[i] & 0xff);
 				}
 				state.add(res + 1, end);
 			}

--- a/bindings/java/src/main/com/apple/foundationdb/tuple/TupleUtil.java
+++ b/bindings/java/src/main/com/apple/foundationdb/tuple/TupleUtil.java
@@ -40,6 +40,7 @@ class TupleUtil {
 	private static final Charset UTF8 = Charset.forName("UTF-8");
 	private static final BigInteger LONG_MIN_VALUE = BigInteger.valueOf(Long.MIN_VALUE);
 	private static final BigInteger LONG_MAX_VALUE = BigInteger.valueOf(Long.MAX_VALUE);
+	private static final int UUID_BYTES = 2 * Long.BYTES;
 	private static final IterableComparator iterableComparator = new IterableComparator();
 
 	private static final byte BYTES_CODE            = 0x01;
@@ -475,10 +476,10 @@ class TupleUtil {
 			state.add(true, start);
 		}
 		else if(code == UUID_CODE) {
-			ByteBuffer bb = ByteBuffer.wrap(rep, start, 2 * Long.BYTES).order(ByteOrder.BIG_ENDIAN);
+			ByteBuffer bb = ByteBuffer.wrap(rep, start, UUID_BYTES).order(ByteOrder.BIG_ENDIAN);
 			long msb = bb.getLong();
 			long lsb = bb.getLong();
-			state.add(new UUID(msb, lsb), start + 16);
+			state.add(new UUID(msb, lsb), start + UUID_BYTES);
 		}
 		else if(code == POS_INT_END) {
 			int n = rep[start] & 0xff;
@@ -533,8 +534,8 @@ class TupleUtil {
 				if (val.compareTo(LONG_MIN_VALUE) >= 0 && val.compareTo(LONG_MAX_VALUE) <= 0) {
 					state.add(val.longValue(), end);
 				} else {
-					// This can occur if the thing can be represented with 8 bytes but not
-					// the right sign information.
+					// This can occur if the thing can be represented with 8 bytes but requires using
+					// the most-significant bit as a normal bit instead of the sign bit.
 					state.add(val, end);
 				}
 			}
@@ -745,7 +746,7 @@ class TupleUtil {
 			else if(item instanceof Boolean)
 				packedSize += 1;
 			else if(item instanceof UUID)
-				packedSize += 1 + 2 * Long.BYTES;
+				packedSize += 1 + UUID_BYTES;
 			else if(item instanceof BigInteger) {
 				BigInteger bigInt = (BigInteger)item;
 				int byteCount = minimalByteCount(bigInt);

--- a/bindings/java/src/main/com/apple/foundationdb/tuple/TupleUtil.java
+++ b/bindings/java/src/main/com/apple/foundationdb/tuple/TupleUtil.java
@@ -36,8 +36,10 @@ import com.apple.foundationdb.FDB;
 
 class TupleUtil {
 	private static final byte nil = 0x00;
-	private static final BigInteger[] size_limits;
+	private static final BigInteger[] BIG_INT_SIZE_LIMITS;
 	private static final Charset UTF8;
+	private static final BigInteger LONG_MIN_VALUE = BigInteger.valueOf(Long.MIN_VALUE);
+	private static final BigInteger LONG_MAX_VALUE = BigInteger.valueOf(Long.MAX_VALUE);
 	private static final IterableComparator iterableComparator;
 
 	private static final byte BYTES_CODE            = 0x01;
@@ -55,27 +57,28 @@ class TupleUtil {
 
 	private static final byte[] NULL_ARR           = new byte[] {nil};
 	private static final byte[] NULL_ESCAPED_ARR   = new byte[] {nil, (byte)0xFF};
-	private static final byte[] BYTES_ARR          = new byte[]{0x01};
-	private static final byte[] STRING_ARR         = new byte[]{0x02};
-	private static final byte[] NESTED_ARR         = new byte[]{0x05};
-	private static final byte[] FALSE_ARR          = new byte[]{0x26};
-	private static final byte[] TRUE_ARR           = new byte[]{0x27};
-	private static final byte[] VERSIONSTAMP_ARR   = new byte[]{0x33};
+	private static final byte[] BYTES_ARR          = new byte[]{BYTES_CODE};
+	private static final byte[] STRING_ARR         = new byte[]{STRING_CODE};
+	private static final byte[] NESTED_ARR         = new byte[]{NESTED_CODE};
+	private static final byte[] INT_ZERO_ARR       = new byte[]{INT_ZERO_CODE};
+	private static final byte[] FALSE_ARR          = new byte[]{FALSE_CODE};
+	private static final byte[] TRUE_ARR           = new byte[]{TRUE_CODE};
+	private static final byte[] VERSIONSTAMP_ARR   = new byte[]{VERSIONSTAMP_CODE};
 
 	static {
-		size_limits = new BigInteger[9];
-		for(int i = 0; i < 9; i++) {
-			size_limits[i] = (BigInteger.ONE).shiftLeft(i * 8).subtract(BigInteger.ONE);
+		BIG_INT_SIZE_LIMITS = new BigInteger[9];
+		for(int i = 0; i < BIG_INT_SIZE_LIMITS.length; i++) {
+			BIG_INT_SIZE_LIMITS[i] = (BigInteger.ONE).shiftLeft(i * 8).subtract(BigInteger.ONE);
 		}
 		UTF8 = Charset.forName("UTF-8");
 		iterableComparator = new IterableComparator();
 	}
 
-	static class DecodeResult {
+	static class DecodeState {
 		final List<Object> values;
 		int end;
 
-		DecodeResult() {
+		DecodeState() {
 			values = new ArrayList<>();
 			end = 0;
 		}
@@ -86,18 +89,18 @@ class TupleUtil {
 		}
 	}
 
-	static class EncodeResult {
+	static class EncodeState {
 		final List<byte[]> encodedValues;
 		int totalLength;
 		int versionPos;
 
-		EncodeResult(int capacity) {
+		EncodeState(int capacity) {
 			this.encodedValues = new ArrayList<>(capacity);
 			totalLength = 0;
 			versionPos = -1;
 		}
 
-		EncodeResult add(byte[] encoded, int versionPos) {
+		EncodeState add(byte[] encoded, int versionPos) {
 			if(versionPos >= 0 && this.versionPos >= 0) {
 				throw new IllegalArgumentException("Multiple incomplete Versionstamps included in Tuple");
 			}
@@ -107,7 +110,7 @@ class TupleUtil {
 			return this;
 		}
 
-		EncodeResult add(byte[] encoded) {
+		EncodeState add(byte[] encoded) {
 			encodedValues.add(encoded);
 			totalLength += encoded.length;
 			return this;
@@ -122,37 +125,37 @@ class TupleUtil {
 		return 0;
 	}
 
-	/**
-	 * Takes the Big-Endian byte representation of a floating point number and adjusts
-	 * it so that it sorts correctly. For encoding, if the sign bit is 1 (the number
-	 * is negative), then we need to flip all of the bits; otherwise, just flip the
-	 * sign bit. For decoding, if the sign bit is 0 (the number is negative), then
-	 * we also need to flip all of the bits; otherwise, just flip the sign bit.
-	 * This will mutate in place the given array.
-	 *
-	 * @param bytes Big-Endian IEEE encoding of a floating point number
-	 * @param start the (zero-indexed) first byte in the array to mutate
-	 * @param encode <code>true</code> if we encoding the float and <code>false</code> if we are decoding
-	 * @return the encoded {@code byte[]}
-	 */
-	static byte[] floatingPointCoding(byte[] bytes, int start, boolean encode) {
-		if(encode && (bytes[start] & (byte)0x80) != (byte)0x00) {
-			for(int i = start; i < bytes.length; i++) {
-				bytes[i] = (byte) (bytes[i] ^ 0xff);
-			}
-		} else if(!encode && (bytes[start] & (byte)0x80) != (byte)0x80) {
-			for(int i = start; i < bytes.length; i++) {
-				bytes[i] = (byte) (bytes[i] ^ 0xff);
-			}
-		} else {
-			bytes[start] = (byte) (0x80 ^ bytes[start]);
-		}
+	// These four functions are for adjusting the encoding of floating point numbers so
+	// that when their byte representation is written out in big-endian order, unsigned
+	// lexicographic byte comparison orders the values in the same way as the semantic
+	// ordering of the values. This means flipping all bits for negative values and flipping
+	// only the most-significant bit (i.e., the sign bit as all values in Java are signed)
+	// in the case that the number is positive. For these purposes, 0.0 is positive and -0.0
+	// is negative.
 
-		return bytes;
+	static int encodeFloatBits(float f) {
+		int intBits = Float.floatToRawIntBits(f);
+		return (intBits < 0) ? (~intBits) : (intBits ^ Integer.MIN_VALUE);
 	}
 
-	static byte[] join(List<byte[]> items) {
-		return ByteArrayUtil.join(null, items);
+	static long encodeDoubleBits(double d) {
+		long longBits = Double.doubleToRawLongBits(d);
+		return (longBits < 0L) ? (~longBits) : (longBits ^ Long.MIN_VALUE);
+	}
+
+	static float decodeFloatBits(int i) {
+		int origBits = (i >= 0) ? (~i) : (i ^ Integer.MIN_VALUE);
+		return Float.intBitsToFloat(origBits);
+	}
+
+	static double decodeDoubleBits(long l) {
+		long origBits = (l >= 0) ? (~l) : (l ^ Long.MIN_VALUE);
+		return Double.longBitsToDouble(origBits);
+	}
+
+	// Get the number of bytes in the representation of a long.
+	static int byteCount(long i) {
+		return (Long.SIZE + 7 - Long.numberOfLeadingZeros(i >= 0 ? i : -i)) / 8;
 	}
 
 	private static void adjustVersionPosition300(byte[] packed, int delta) {
@@ -215,64 +218,64 @@ class TupleUtil {
 		throw new IllegalArgumentException("Unsupported data type: " + o.getClass().getName());
 	}
 
-	static void encode(EncodeResult result, Object t, boolean nested) {
+	static void encode(EncodeState state, Object t, boolean nested) {
 		if(t == null) {
 			if(nested) {
-				result.add(NULL_ESCAPED_ARR);
+				state.add(NULL_ESCAPED_ARR);
 			}
 			else {
-				result.add(NULL_ARR);
+				state.add(NULL_ARR);
 			}
 		}
 		else if(t instanceof byte[])
-			encode(result, (byte[]) t);
+			encode(state, (byte[]) t);
 		else if(t instanceof String)
-			encode(result, (String)t);
-		else if(t instanceof BigInteger)
-			encode(result, (BigInteger)t);
+			encode(state, (String)t);
 		else if(t instanceof Float)
-			encode(result, (Float)t);
+			encode(state, (Float)t);
 		else if(t instanceof Double)
-			encode(result, (Double)t);
+			encode(state, (Double)t);
 		else if(t instanceof Boolean)
-			encode(result, (Boolean)t);
+			encode(state, (Boolean)t);
 		else if(t instanceof UUID)
-			encode(result, (UUID)t);
+			encode(state, (UUID)t);
+		else if(t instanceof BigInteger)
+			encode(state, (BigInteger)t);
 		else if(t instanceof Number)
-			encode(result, ((Number)t).longValue());
+			encode(state, ((Number)t).longValue());
 		else if(t instanceof Versionstamp)
-			encode(result, (Versionstamp)t);
+			encode(state, (Versionstamp)t);
 		else if(t instanceof List<?>)
-			encode(result, (List<?>)t);
+			encode(state, (List<?>)t);
 		else if(t instanceof Tuple)
-			encode(result, ((Tuple)t).getItems());
+			encode(state, ((Tuple)t).getItems());
 		else
 			throw new IllegalArgumentException("Unsupported data type: " + t.getClass().getName());
 	}
 
-	static void encode(EncodeResult result, Object t) {
-		encode(result, t, false);
+	static void encode(EncodeState state, Object t) {
+		encode(state, t, false);
 	}
 
-	static void encode(EncodeResult result, byte[] bytes) {
+	static void encode(EncodeState state, byte[] bytes) {
 		byte[] escaped = ByteArrayUtil.replace(bytes, NULL_ARR, NULL_ESCAPED_ARR);
-		result.add(BYTES_ARR).add(escaped).add(NULL_ARR);
+		state.add(BYTES_ARR).add(escaped).add(NULL_ARR);
 	}
 
-	static void encode(EncodeResult result, String s) {
+	static void encode(EncodeState state, String s) {
 		byte[] escaped = ByteArrayUtil.replace(s.getBytes(UTF8), NULL_ARR, NULL_ESCAPED_ARR);
-		result.add(STRING_ARR).add(escaped).add(NULL_ARR);
+		state.add(STRING_ARR).add(escaped).add(NULL_ARR);
 	}
 
-	static void encode(EncodeResult result, BigInteger i) {
+	static void encode(EncodeState state, BigInteger i) {
 		//System.out.println("Encoding integral " + i);
 		if(i.equals(BigInteger.ZERO)) {
-			result.add(new byte[]{INT_ZERO_CODE});
+			state.add(INT_ZERO_ARR);
 			return;
 		}
 		byte[] bytes = i.toByteArray();
 		if(i.compareTo(BigInteger.ZERO) > 0) {
-			if(i.compareTo(size_limits[size_limits.length-1]) > 0) {
+			if(i.compareTo(BIG_INT_SIZE_LIMITS[BIG_INT_SIZE_LIMITS.length-1]) > 0) {
 				int length = byteLength(bytes);
 				if(length > 0xff) {
 					throw new IllegalArgumentException("BigInteger magnitude is too large (more than 255 bytes)");
@@ -281,21 +284,20 @@ class TupleUtil {
 				intBytes[0] = POS_INT_END;
 				intBytes[1] = (byte)(length);
 				System.arraycopy(bytes, bytes.length - length, intBytes, 2, length);
-				result.add(intBytes);
+				state.add(intBytes);
 			}
 			else {
-				int n = ByteArrayUtil.bisectLeft(size_limits, i);
-				assert n <= size_limits.length;
-				//byte[] bytes = ByteBuffer.allocate(8).order(ByteOrder.BIG_ENDIAN).putLong(i).array();
+				int n = ByteArrayUtil.bisectLeft(BIG_INT_SIZE_LIMITS, i);
+				assert n <= BIG_INT_SIZE_LIMITS.length;
 				//System.out.println("  -- integral has 'n' of " + n + " and output bytes of " + bytes.length);
 				byte[] intBytes = new byte[n + 1];
 				intBytes[0] = (byte) (INT_ZERO_CODE + n);
 				System.arraycopy(bytes, bytes.length - n, intBytes, 1, n);
-				result.add(intBytes);
+				state.add(intBytes);
 			}
 		}
 		else {
-			if(i.negate().compareTo(size_limits[size_limits.length - 1]) > 0) {
+			if(i.negate().compareTo(BIG_INT_SIZE_LIMITS[BIG_INT_SIZE_LIMITS.length - 1]) > 0) {
 				int length = byteLength(i.negate().toByteArray());
 				if (length > 0xff) {
 					throw new IllegalArgumentException("BigInteger magnitude is too large (more than 255 bytes)");
@@ -311,92 +313,109 @@ class TupleUtil {
 					Arrays.fill(intBytes, 2, intBytes.length - adjusted.length, (byte) 0x00);
 					System.arraycopy(adjusted, 0, intBytes, intBytes.length - adjusted.length, adjusted.length);
 				}
-				result.add(intBytes);
+				state.add(intBytes);
 			}
 			else {
-				int n = ByteArrayUtil.bisectLeft(size_limits, i.negate());
+				int n = ByteArrayUtil.bisectLeft(BIG_INT_SIZE_LIMITS, i.negate());
 
-				assert n >= 0 && n < size_limits.length; // can we do this? it seems to be required for the following statement
+				assert n >= 0 && n < BIG_INT_SIZE_LIMITS.length; // can we do this? it seems to be required for the following statement
 
-				long maxv = size_limits[n].add(i).longValue();
+				long maxv = BIG_INT_SIZE_LIMITS[n].add(i).longValue();
 				byte[] adjustedBytes = ByteBuffer.allocate(8).order(ByteOrder.BIG_ENDIAN).putLong(maxv).array();
 				byte[] intBytes = new byte[n + 1];
-				intBytes[0] = (byte) (20 - n);
+				intBytes[0] = (byte) (INT_ZERO_CODE - n);
 				System.arraycopy(adjustedBytes, adjustedBytes.length - n, intBytes, 1, n);
-				result.add(intBytes);
+				state.add(intBytes);
 			}
 		}
 	}
 
-	static void encode(EncodeResult result, Integer i) {
-		encode(result, i.longValue());
+	static void encode(EncodeState state, long i) {
+		if(i == 0L) {
+			state.add(INT_ZERO_ARR);
+			return;
+		}
+		int n = byteCount(i);
+		byte[] intBytes = new byte[n + 1];
+		// First byte encodes number of bytes (as difference from INT_ZERO_CODE)
+		intBytes[0] = (byte)(INT_ZERO_CODE + (i >= 0 ? n : -n));
+		// For positive integers, copy the bytes in big-endian order excluding leading 0x00 bytes.
+		// For negative integers, copy the bytes of the one's complement representation excluding
+		// the leading 0xff bytes. As Java stores negative values in two's complement, we subtract 1
+		// from negative values.
+		long val = Long.reverseBytes((i >= 0) ? i : (i - 1)) >> (Long.SIZE - 8 * n);
+		for(int x = 1; x < intBytes.length; x++) {
+			intBytes[x] = (byte)(val & 0xff);
+			val >>= 8;
+		}
+		state.add(intBytes);
 	}
 
-	static void encode(EncodeResult result, long i) {
-		encode(result, BigInteger.valueOf(i));
+	static void encode(EncodeState state, Float f) {
+		byte[] floatBytes = ByteBuffer.allocate(1 + Float.BYTES).order(ByteOrder.BIG_ENDIAN)
+				.put(FLOAT_CODE)
+				.putInt(encodeFloatBits(f))
+				.array();
+		state.add(floatBytes);
 	}
 
-	static void encode(EncodeResult result, Float f) {
-		byte[] floatBytes = ByteBuffer.allocate(5).order(ByteOrder.BIG_ENDIAN).put(FLOAT_CODE).putFloat(f).array();
-		floatingPointCoding(floatBytes, 1, true);
-		result.add(floatBytes);
+	static void encode(EncodeState state, Double d) {
+		byte[] doubleBytes = ByteBuffer.allocate(1 + Double.BYTES).order(ByteOrder.BIG_ENDIAN)
+				.put(DOUBLE_CODE)
+				.putLong(encodeDoubleBits(d))
+				.array();
+		state.add(doubleBytes);
 	}
 
-	static void encode(EncodeResult result, Double d) {
-		byte[] doubleBytes = ByteBuffer.allocate(9).order(ByteOrder.BIG_ENDIAN).put(DOUBLE_CODE).putDouble(d).array();
-		floatingPointCoding(doubleBytes, 1, true);
-		result.add(doubleBytes);
-	}
-
-	static void encode(EncodeResult result, Boolean b) {
+	static void encode(EncodeState state, Boolean b) {
 		if(b) {
-			result.add(TRUE_ARR);
+			state.add(TRUE_ARR);
 		}
 		else {
-			result.add(FALSE_ARR);
+			state.add(FALSE_ARR);
 		}
 	}
 
-	static void encode(EncodeResult result, UUID uuid) {
+	static void encode(EncodeState state, UUID uuid) {
 		byte[] uuidBytes = ByteBuffer.allocate(17).put(UUID_CODE).order(ByteOrder.BIG_ENDIAN)
 				.putLong(uuid.getMostSignificantBits()).putLong(uuid.getLeastSignificantBits())
 				.array();
-		result.add(uuidBytes);
+		state.add(uuidBytes);
 	}
 
-	static void encode(EncodeResult result, Versionstamp v) {
-		result.add(VERSIONSTAMP_ARR);
+	static void encode(EncodeState state, Versionstamp v) {
+		state.add(VERSIONSTAMP_ARR);
 		if(v.isComplete()) {
-			result.add(v.getBytes());
+			state.add(v.getBytes());
 		}
 		else {
-			result.add(v.getBytes(), result.totalLength);
+			state.add(v.getBytes(), state.totalLength);
 		}
 	}
 
-	static void encode(EncodeResult result, List<?> value) {
-		result.add(NESTED_ARR);
+	static void encode(EncodeState state, List<?> value) {
+		state.add(NESTED_ARR);
 		for(Object t : value) {
-			encode(result, t, true);
+			encode(state, t, true);
 		}
-		result.add(NULL_ARR);
+		state.add(NULL_ARR);
 	}
 
-	static void decode(DecodeResult result, byte[] rep, int pos, int last) {
+	static void decode(DecodeState state, byte[] rep, int pos, int last) {
 		//System.out.println("Decoding '" + ArrayUtils.printable(rep) + "' at " + pos);
 
 		// SOMEDAY: codes over 127 will be a problem with the signed Java byte mess
 		int code = rep[pos];
 		int start = pos + 1;
 		if(code == nil) {
-			result.add(null, start);
+			state.add(null, start);
 		}
 		else if(code == BYTES_CODE) {
 			int end = ByteArrayUtil.findTerminator(rep, (byte)0x0, (byte)0xff, start, last);
 			//System.out.println("End of byte string: " + end);
 			byte[] range = ByteArrayUtil.replace(rep, start, end - start, NULL_ESCAPED_ARR, new byte[] { nil });
 			//System.out.println(" -> byte string contents: '" + ArrayUtils.printable(range) + "'");
-			result.add(range, end + 1);
+			state.add(range, end + 1);
 		}
 		else if(code == STRING_CODE) {
 			int end = ByteArrayUtil.findTerminator(rep, (byte)0x0, (byte)0xff, start, last);
@@ -404,78 +423,91 @@ class TupleUtil {
 			byte[] stringBytes = ByteArrayUtil.replace(rep, start, end - start, NULL_ESCAPED_ARR, new byte[] { nil });
 			String str = new String(stringBytes, UTF8);
 			//System.out.println(" -> UTF8 string contents: '" + str + "'");
-			result.add(str, end + 1);
+			state.add(str, end + 1);
 		}
 		else if(code == FLOAT_CODE) {
-			byte[] resBytes = Arrays.copyOfRange(rep, start, start+4);
-			floatingPointCoding(resBytes, 0, false);
-			float res = ByteBuffer.wrap(resBytes).order(ByteOrder.BIG_ENDIAN).getFloat();
-			result.add(res, start + Float.BYTES);
+			int rawFloatBits = ByteBuffer.wrap(rep, start, Float.BYTES).getInt();
+			float res = decodeFloatBits(rawFloatBits);
+			state.add(res, start + Float.BYTES);
 		}
 		else if(code == DOUBLE_CODE) {
-			byte[] resBytes = Arrays.copyOfRange(rep, start, start+8);
-			floatingPointCoding(resBytes, 0, false);
-			double res = ByteBuffer.wrap(resBytes).order(ByteOrder.BIG_ENDIAN).getDouble();
-			result.add(res, start + Double.BYTES);
+			long rawDoubleBits = ByteBuffer.wrap(rep, start, Double.BYTES).getLong();
+			double res = decodeDoubleBits(rawDoubleBits);
+			state.add(res, start + Double.BYTES);
 		}
 		else if(code == FALSE_CODE) {
-			result.add(false, start);
+			state.add(false, start);
 		}
 		else if(code == TRUE_CODE) {
-			result.add(true, start);
+			state.add(true, start);
 		}
 		else if(code == UUID_CODE) {
 			ByteBuffer bb = ByteBuffer.wrap(rep, start, 16).order(ByteOrder.BIG_ENDIAN);
 			long msb = bb.getLong();
 			long lsb = bb.getLong();
-			result.add(new UUID(msb, lsb), start + 16);
+			state.add(new UUID(msb, lsb), start + 16);
 		}
 		else if(code == POS_INT_END) {
 			int n = rep[start] & 0xff;
 			BigInteger res = new BigInteger(ByteArrayUtil.join(new byte[]{0x00}, Arrays.copyOfRange(rep, start+1, start+n+1)));
-			result.add(res, start + n + 1);
+			state.add(res, start + n + 1);
 		}
 		else if(code == NEG_INT_START) {
 			int n = (rep[start] ^ 0xff) & 0xff;
 			BigInteger origValue = new BigInteger(ByteArrayUtil.join(new byte[]{0x00}, Arrays.copyOfRange(rep, start+1, start+n+1)));
 			BigInteger offset = BigInteger.ONE.shiftLeft(n*8).subtract(BigInteger.ONE);
-			result.add(origValue.subtract(offset), start + n + 1);
+			state.add(origValue.subtract(offset), start + n + 1);
 		}
 		else if(code > NEG_INT_START && code < POS_INT_END) {
 			// decode a long
-			byte[] longBytes = new byte[9];
-			boolean upper = code >= INT_ZERO_CODE;
-			int n = upper ? code - 20 : 20 - code;
+			boolean positive = code >= INT_ZERO_CODE;
+			int n = positive ? code - INT_ZERO_CODE : INT_ZERO_CODE - code;
 			int end = start + n;
 
 			if(rep.length < end) {
 				throw new RuntimeException("Invalid tuple (possible truncation)");
 			}
 
-			System.arraycopy(rep, start, longBytes, longBytes.length-n, n);
-			if (!upper)
-				for(int i=longBytes.length-n; i<longBytes.length; i++)
-					longBytes[i] = (byte)(longBytes[i] ^ 0xff);
+			if(positive && (n < Long.BYTES || rep[start] > 0)) {
+				long res = 0L;
+				for(int i = start; i < end; i++) {
+					res = (res << 8) + (rep[i] & 0xff);
+				}
+				state.add(res, end);
+			}
+			else if(!positive && (n < Long.BYTES || rep[start] < 0)) {
+				long res = ~0L;
+				for(int i = start; i < end; i++) {
+					res = (res << 8) + (rep[i] & 0xff);
+				}
+				state.add(res + 1, end);
+			}
+			else {
+				byte[] longBytes = new byte[9];
+				System.arraycopy(rep, start, longBytes, longBytes.length-n, n);
+				if (!positive)
+					for(int i=longBytes.length-n; i<longBytes.length; i++)
+						longBytes[i] = (byte)(longBytes[i] ^ 0xff);
 
-			BigInteger val = new BigInteger(longBytes);
-			if (!upper) val = val.negate();
+				BigInteger val = new BigInteger(longBytes);
+				if (!positive) val = val.negate();
 
-			// Convert to long if in range -- otherwise, leave as BigInteger.
-			if (val.compareTo(BigInteger.valueOf(Long.MIN_VALUE))<0||
-				val.compareTo(BigInteger.valueOf(Long.MAX_VALUE))>0) {
-				// This can occur if the thing can be represented with 8 bytes but not
-				// the right sign information.
-				result.add(val, end);
-			} else {
-				result.add(val.longValue(), end);
+				// Convert to long if in range -- otherwise, leave as BigInteger.
+				if (val.compareTo(LONG_MIN_VALUE) >= 0 && val.compareTo(LONG_MAX_VALUE) <= 0) {
+					state.add(val.longValue(), end);
+				} else {
+					// This can occur if the thing can be represented with 8 bytes but not
+					// the right sign information.
+					state.add(val, end);
+				}
 			}
 		}
 		else if(code == VERSIONSTAMP_CODE) {
 			Versionstamp val = Versionstamp.fromBytes(Arrays.copyOfRange(rep, start, start + Versionstamp.LENGTH));
-			result.add(val, start + Versionstamp.LENGTH);
+			state.add(val, start + Versionstamp.LENGTH);
 		}
 		else if(code == NESTED_CODE) {
-			DecodeResult subResult = new DecodeResult();
+			DecodeState subResult = new DecodeState();
 			int endPos = start;
 			while(endPos < rep.length) {
 				if(rep[endPos] == nil) {
@@ -491,22 +523,10 @@ class TupleUtil {
 					endPos = subResult.end;
 				}
 			}
-			result.add(subResult.values, endPos);
+			state.add(subResult.values, endPos);
 		}
 		else {
 			throw new IllegalArgumentException("Unknown tuple data type " + code + " at index " + pos);
-		}
-	}
-
-	static int compareSignedBigEndian(byte[] arr1, byte[] arr2) {
-		if(arr1[0] < 0 && arr2[0] < 0) {
-			return -1 * ByteArrayUtil.compareUnsigned(arr1, arr2);
-		} else if(arr1[0] < 0) {
-			return -1;
-		} else if(arr2[0] < 0) {
-			return 1;
-		} else {
-			return ByteArrayUtil.compareUnsigned(arr1, arr2);
 		}
 	}
 
@@ -529,33 +549,39 @@ class TupleUtil {
 			return ByteArrayUtil.compareUnsigned(((String)item1).getBytes(UTF8), ((String)item2).getBytes(UTF8));
 		}
 		if(code1 == INT_ZERO_CODE) {
-			BigInteger bi1;
-			if(item1 instanceof BigInteger) {
-				bi1 = (BigInteger)item1;
-			} else {
-				bi1 = BigInteger.valueOf(((Number)item1).longValue());
+			if(item1 instanceof Long && item2 instanceof Long) {
+				// This should be the common case, so it's probably worth including as a way out.
+				return Long.compare((Long)item1, (Long)item2);
 			}
-			BigInteger bi2;
-			if(item2 instanceof BigInteger) {
-				bi2 = (BigInteger)item2;
-			} else {
-				bi2 = BigInteger.valueOf(((Number)item2).longValue());
+			else {
+				BigInteger bi1;
+				if (item1 instanceof BigInteger) {
+					bi1 = (BigInteger) item1;
+				} else {
+					bi1 = BigInteger.valueOf(((Number) item1).longValue());
+				}
+				BigInteger bi2;
+				if (item2 instanceof BigInteger) {
+					bi2 = (BigInteger) item2;
+				} else {
+					bi2 = BigInteger.valueOf(((Number) item2).longValue());
+				}
+				return bi1.compareTo(bi2);
 			}
-			return bi1.compareTo(bi2);
-		}
-		if(code1 == DOUBLE_CODE) {
-			// This is done over vanilla double comparison basically to handle NaN
-			// sorting correctly.
-			byte[] dBytes1 = ByteBuffer.allocate(8).putDouble((Double)item1).array();
-			byte[] dBytes2 = ByteBuffer.allocate(8).putDouble((Double)item2).array();
-			return compareSignedBigEndian(dBytes1, dBytes2);
 		}
 		if(code1 == FLOAT_CODE) {
 			// This is done for the same reason that double comparison is done
 			// that way.
-			byte[] fBytes1 = ByteBuffer.allocate(4).putFloat((Float)item1).array();
-			byte[] fBytes2 = ByteBuffer.allocate(4).putFloat((Float)item2).array();
-			return compareSignedBigEndian(fBytes1, fBytes2);
+			int fbits1 = encodeFloatBits((Float)item1);
+			int fbits2 = encodeFloatBits((Float)item2);
+			return Integer.compareUnsigned(fbits1, fbits2);
+		}
+		if(code1 == DOUBLE_CODE) {
+			// This is done over vanilla double comparison basically to handle NaN
+			// sorting correctly.
+			long dbits1 = encodeDoubleBits((Double)item1);
+			long dbits2 = encodeDoubleBits((Double)item2);
+			return Long.compareUnsigned(dbits1, dbits2);
 		}
 		if(code1 == FALSE_CODE) {
 			return Boolean.compare((Boolean)item1, (Boolean)item2);
@@ -579,51 +605,53 @@ class TupleUtil {
 	}
 
 	static List<Object> unpack(byte[] bytes, int start, int length) {
-		DecodeResult decodeResult = new DecodeResult();
+		DecodeState decodeState = new DecodeState();
 		int pos = start;
 		int end = start + length;
 		while(pos < end) {
-			decode(decodeResult, bytes, pos, end);
-			pos = decodeResult.end;
+			decode(decodeState, bytes, pos, end);
+			pos = decodeState.end;
 		}
-		return decodeResult.values;
+		return decodeState.values;
 	}
 
-	static void encodeAll(EncodeResult result, List<Object> items, byte[] prefix) {
+	static void encodeAll(EncodeState state, List<Object> items, byte[] prefix) {
 		if(prefix != null) {
-			result.add(prefix);
+			state.add(prefix);
 		}
 		for(Object t : items) {
-			encode(result, t);
+			encode(state, t);
 		}
 		//System.out.println("Joining whole tuple...");
 	}
 
 	static byte[] pack(List<Object> items, byte[] prefix) {
-		EncodeResult result = new EncodeResult(2 * items.size() + (prefix == null ? 0 : 1));
-		encodeAll(result, items, prefix);
-		if(result.versionPos >= 0) {
+		EncodeState state = new EncodeState(2 * items.size() + (prefix == null ? 0 : 1));
+		encodeAll(state, items, prefix);
+		if(state.versionPos >= 0) {
 			throw new IllegalArgumentException("Incomplete Versionstamp included in vanilla tuple packInternal");
-		} else {
-			return ByteArrayUtil.join(null, result.encodedValues);
+		}
+		else {
+			return ByteArrayUtil.join(null, state.encodedValues);
 		}
 	}
 
 	static byte[] packWithVersionstamp(List<Object> items, byte[] prefix) {
-		EncodeResult result = new EncodeResult(2 * items.size() + (prefix == null ? 1 : 2));
-		encodeAll(result, items, prefix);
-		if(result.versionPos < 0) {
+		EncodeState state = new EncodeState(2 * items.size() + (prefix == null ? 1 : 2));
+		encodeAll(state, items, prefix);
+		if(state.versionPos < 0) {
 			throw new IllegalArgumentException("No incomplete Versionstamp included in tuple packInternal with versionstamp");
-		} else {
-			if(result.versionPos > 0xffff) {
-				throw new IllegalArgumentException("Tuple has incomplete version at position " + result.versionPos + " which is greater than the maximum " + 0xffff);
+		}
+		else {
+			if(state.versionPos > 0xffff) {
+				throw new IllegalArgumentException("Tuple has incomplete version at position " + state.versionPos + " which is greater than the maximum " + 0xffff);
 			}
 			if (FDB.instance().getAPIVersion() < 520) {
-				result.add(ByteBuffer.allocate(Short.BYTES).order(ByteOrder.LITTLE_ENDIAN).putShort((short)result.versionPos).array());
+				state.add(ByteBuffer.allocate(Short.BYTES).order(ByteOrder.LITTLE_ENDIAN).putShort((short)state.versionPos).array());
 			} else {
-				result.add(ByteBuffer.allocate(Integer.BYTES).order(ByteOrder.LITTLE_ENDIAN).putInt(result.versionPos).array());
+				state.add(ByteBuffer.allocate(Integer.BYTES).order(ByteOrder.LITTLE_ENDIAN).putInt(state.versionPos).array());
 			}
-			return ByteArrayUtil.join(null, result.encodedValues);
+			return ByteArrayUtil.join(null, state.encodedValues);
 		}
 	}
 
@@ -631,13 +659,17 @@ class TupleUtil {
 		return items.anyMatch(item -> {
 			if(item == null) {
 				return false;
-			} else if(item instanceof Versionstamp) {
+			}
+			else if(item instanceof Versionstamp) {
 				return !((Versionstamp) item).isComplete();
-			} else if(item instanceof Tuple) {
+			}
+			else if(item instanceof Tuple) {
 				return hasIncompleteVersionstamp(((Tuple) item).stream());
-			} else if(item instanceof Collection<?>) {
+			}
+			else if(item instanceof Collection<?>) {
 				return hasIncompleteVersionstamp(((Collection) item).stream());
-			} else {
+			}
+			else {
 				return false;
 			}
 		});
@@ -646,23 +678,25 @@ class TupleUtil {
 	public static void main(String[] args) {
 		try {
 			byte[] bytes = pack(Collections.singletonList(4), null);
-			DecodeResult result = new DecodeResult();
+			DecodeState result = new DecodeState();
 			decode(result, bytes, 0, bytes.length);
 			int val = (int)result.values.get(0);
 			assert 4 == val;
-		} catch (Exception e) {
+		}
+		catch(Exception e) {
 			e.printStackTrace();
 			System.out.println("Error " + e.getMessage());
 		}
 
 		try {
 			byte[] bytes = pack(Collections.singletonList("\u021Aest \u0218tring"), null);
-			DecodeResult result = new DecodeResult();
+			DecodeState result = new DecodeState();
 			decode(result, bytes, 0, bytes.length);
 			String string = (String)result.values.get(0);
 			System.out.println("contents -> " + string);
 			assert "\u021Aest \u0218tring".equals(string);
-		} catch (Exception e) {
+		}
+		catch(Exception e) {
 			e.printStackTrace();
 			System.out.println("Error " + e.getMessage());
 		}

--- a/bindings/java/src/main/com/apple/foundationdb/tuple/Versionstamp.java
+++ b/bindings/java/src/main/com/apple/foundationdb/tuple/Versionstamp.java
@@ -94,8 +94,8 @@ public class Versionstamp implements Comparable<Versionstamp> {
 	private static final byte[] UNSET_TRANSACTION_VERSION = {(byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff,
 	                                                         (byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff};
 
-	private boolean complete;
-	private byte[] versionBytes;
+	private final boolean complete;
+	private final byte[] versionBytes;
 
 	/**
 	 * From a byte array, unpack the user version starting at the given position.

--- a/bindings/java/src/test/com/apple/foundationdb/test/AsyncStackTester.java
+++ b/bindings/java/src/test/com/apple/foundationdb/test/AsyncStackTester.java
@@ -412,7 +412,11 @@ public class AsyncStackTester {
 				return inst.popParams(listSize).thenAcceptAsync(rawElements -> {
 					List<Tuple> tuples = new ArrayList<>(listSize);
 					for(Object o : rawElements) {
-						tuples.add(Tuple.fromBytes((byte[])o));
+						// Unpacking a tuple keeps around the serialized representation and uses
+						// it for comparison if it's available. To test semantic comparison, recreate
+						// the tuple from the item list.
+						Tuple t = Tuple.fromBytes((byte[])o);
+						tuples.add(Tuple.fromList(t.getItems()));
 					}
 					Collections.sort(tuples);
 					for(Tuple t : tuples) {

--- a/bindings/java/src/test/com/apple/foundationdb/test/StackTester.java
+++ b/bindings/java/src/test/com/apple/foundationdb/test/StackTester.java
@@ -368,9 +368,13 @@ public class StackTester {
 			else if (op == StackOperation.TUPLE_SORT) {
 				int listSize = StackUtils.getInt(inst.popParam().join());
 				List<Object> rawElements = inst.popParams(listSize).join();
-				List<Tuple> tuples = new ArrayList<Tuple>(listSize);
+				List<Tuple> tuples = new ArrayList<>(listSize);
 				for(Object o : rawElements) {
-					tuples.add(Tuple.fromBytes((byte[])o));
+					// Unpacking a tuple keeps around the serialized representation and uses
+					// it for comparison if it's available. To test semantic comparison, recreate
+					// the tuple from the item list.
+					Tuple t = Tuple.fromBytes((byte[])o);
+					tuples.add(Tuple.fromList(t.getItems()));
 				}
 				Collections.sort(tuples);
 				for(Tuple t : tuples) {

--- a/bindings/java/src/test/com/apple/foundationdb/test/TuplePerformanceTest.java
+++ b/bindings/java/src/test/com/apple/foundationdb/test/TuplePerformanceTest.java
@@ -142,6 +142,7 @@ public class TuplePerformanceTest {
 		long packNanos = 0L;
 		long unpackNanos = 0L;
 		long equalsNanos = 0L;
+		long equalsArrayNanos = 0L;
 		long hashNanos = 0L;
 		long secondHashNanos = 0L;
 		long subspacePackNanos = 0L;
@@ -164,12 +165,22 @@ public class TuplePerformanceTest {
 			endNanos = System.nanoTime();
 			unpackNanos += endNanos - startNanos;
 
+			// Copy items over as if both are packed, their byte arrays are compared
+			Tuple tCopy = Tuple.fromList(t.getItems());
+			Tuple t2Copy = Tuple.fromList(t2.getItems());
+			startNanos = System.nanoTime();
+			if (!tCopy.equals(t2Copy)) {
+				throw new RuntimeException("deserialized did not match serialized: " + t + " -- " + t2);
+			}
+			endNanos = System.nanoTime();
+			equalsNanos += endNanos - startNanos;
+
 			startNanos = System.nanoTime();
 			if(!t.equals(t2)) {
 				throw new RuntimeException("deserialized did not match serialized: " + t + " -- " + t2);
 			}
 			endNanos = System.nanoTime();
-			equalsNanos += endNanos - startNanos;
+			equalsArrayNanos += endNanos - startNanos;
 
 			startNanos = System.nanoTime();
 			byte[] subspacePacked = subspace.pack(t);
@@ -182,7 +193,7 @@ public class TuplePerformanceTest {
 			startNanos = System.nanoTime();
 			Tuple t3 = subspace.unpack(subspacePacked);
 			endNanos = System.nanoTime();
-			if(!t.equals(t3)) {
+			if (!Tuple.fromList(t.getItems()).equals(Tuple.fromList(t3.getItems())) || !t.equals(t3)) {
 				throw new RuntimeException("does not unpack equally from subspace");
 			}
 			if(!Arrays.equals(t.pack(), t3.pack())) {
@@ -205,25 +216,27 @@ public class TuplePerformanceTest {
 		}
 
 		System.out.println("Test ended.");
-		System.out.printf("  Total elements:                  %d%n", totalLength);
-		System.out.printf("  Total bytes:                     %d kB%n", totalBytes / 1000);
-		System.out.printf("  Bytes per tuple:                 %f B%n", totalBytes * 1.0 / iterations);
-		System.out.printf("  Pack time:                       %f s%n", packNanos * 1e-9);
-		System.out.printf("  Pack time per tuple:             %f \u03BCs%n", packNanos * 1e-3 / iterations);
-		System.out.printf("  Pack time per kB:                %f \u03BCs%n", packNanos * 1.0 / totalBytes);
-		System.out.printf("  Serialization rate:              %f objects / \u03BCs%n", totalLength * 1000.0 / packNanos);
-		System.out.printf("  Unpack time:                     %f s%n", unpackNanos * 1e-9);
-		System.out.printf("  Unpack time per tuple:           %f \u03BCs%n", unpackNanos * 1e-3 / iterations);
-		System.out.printf("  Equals time:                     %f s%n", equalsNanos * 1e-9);
-		System.out.printf("  Equals time per tuple:           %f \u03BCs%n", equalsNanos * 1e-3 / iterations);
-		System.out.printf("  Subspace pack time:              %f s%n", subspacePackNanos * 1e-9);
-		System.out.printf("  Subspace pack time per tuple:    %f \u03BCs%n", subspacePackNanos * 1e-3 / iterations);
-		System.out.printf("  Subspace unpack time:            %f s%n", subspaceUnpackNanos * 1e-9);
-		System.out.printf("  Subspace unpack time per tuple:  %f \u03BCs%n", subspaceUnpackNanos * 1e-3 / iterations);
-		System.out.printf("  Hash time:                       %f s%n", hashNanos * 1e-9);
-		System.out.printf("  Hash time per tuple:             %f \u03BCs%n", hashNanos * 1e-3 / iterations);
-		System.out.printf("  Second hash time:                %f s%n", secondHashNanos * 1e-9);
-		System.out.printf("  Second hash time per tuple:      %f \u03BCs%n", secondHashNanos * 1e-3 / iterations);
+		System.out.printf("  Total elements:                        %d%n", totalLength);
+		System.out.printf("  Total bytes:                           %d kB%n", totalBytes / 1000);
+		System.out.printf("  Bytes per tuple:                       %f B%n", totalBytes * 1.0 / iterations);
+		System.out.printf("  Pack time:                             %f s%n", packNanos * 1e-9);
+		System.out.printf("  Pack time per tuple:                   %f \u03BCs%n", packNanos * 1e-3 / iterations);
+		System.out.printf("  Pack time per kB:                      %f \u03BCs%n", packNanos * 1.0 / totalBytes);
+		System.out.printf("  Serialization rate:                    %f objects / \u03BCs%n", totalLength * 1000.0 / packNanos);
+		System.out.printf("  Unpack time:                           %f s%n", unpackNanos * 1e-9);
+		System.out.printf("  Unpack time per tuple:                 %f \u03BCs%n", unpackNanos * 1e-3 / iterations);
+		System.out.printf("  Equals time:                           %f s%n", equalsNanos * 1e-9);
+		System.out.printf("  Equals time per tuple:                 %f \u03BCs%n", equalsNanos * 1e-3 / iterations);
+		System.out.printf("  Equals time (using packed):            %f s%n", equalsArrayNanos * 1e-9);
+		System.out.printf("  Equals time (using packed) per tuple:  %f \u03BCs%n", equalsArrayNanos * 1e-3 / iterations);
+		System.out.printf("  Subspace pack time:                    %f s%n", subspacePackNanos * 1e-9);
+		System.out.printf("  Subspace pack time per tuple:          %f \u03BCs%n", subspacePackNanos * 1e-3 / iterations);
+		System.out.printf("  Subspace unpack time:                  %f s%n", subspaceUnpackNanos * 1e-9);
+		System.out.printf("  Subspace unpack time per tuple:        %f \u03BCs%n", subspaceUnpackNanos * 1e-3 / iterations);
+		System.out.printf("  Hash time:                             %f s%n", hashNanos * 1e-9);
+		System.out.printf("  Hash time per tuple:                   %f \u03BCs%n", hashNanos * 1e-3 / iterations);
+		System.out.printf("  Second hash time:                      %f s%n", secondHashNanos * 1e-9);
+		System.out.printf("  Second hash time per tuple:            %f \u03BCs%n", secondHashNanos * 1e-3 / iterations);
 	}
 
 	public static void main(String[] args) {

--- a/bindings/java/src/test/com/apple/foundationdb/test/TuplePerformanceTest.java
+++ b/bindings/java/src/test/com/apple/foundationdb/test/TuplePerformanceTest.java
@@ -25,17 +25,15 @@ public class TuplePerformanceTest {
 
 	public Tuple createTuple(int length) {
 		List<Object> values = new ArrayList<>(length);
-		for(int i = 0; i < length; i++) {
+		for (int i = 0; i < length; i++) {
 			double choice = r.nextDouble();
-			if(choice < 0.1) {
+			if (choice < 0.1) {
 				values.add(null);
-			}
-			else if(choice < 0.2) {
+			} else if (choice < 0.2) {
 				byte[] bytes = new byte[r.nextInt(20)];
 				r.nextBytes(bytes);
 				values.add(bytes);
-			}
-			else if(choice < 0.3) {
+			} else if (choice < 0.3) {
 				char[] chars = new char[r.nextInt(20)];
 				for (int j = 0; j < chars.length; j++) {
 					chars[j] = (char)('a' + r.nextInt(26));
@@ -171,7 +169,7 @@ public class TuplePerformanceTest {
 	}
 
 	public static void main(String[] args) {
-		TuplePerformanceTest tester = new TuplePerformanceTest(new Random(), 100_000, 10_000);
+		TuplePerformanceTest tester = new TuplePerformanceTest(new Random(), 100_000, 10_000_000);
 		tester.run();
 	}
 }

--- a/bindings/java/src/test/com/apple/foundationdb/test/TupleTest.java
+++ b/bindings/java/src/test/com/apple/foundationdb/test/TupleTest.java
@@ -916,6 +916,42 @@ public class TupleTest {
 						" with " + ByteArrayUtil.printable(replacement) + " in " + ByteArrayUtil.printable(src));
 			}
 		}
+
+		try {
+			ByteArrayUtil.replace(null, 0, 1, new byte[]{0x00}, new byte[]{0x00, FF});
+			throw new RuntimeException("able to replace null bytes");
+		}
+		catch(NullPointerException e) {
+			// eat
+		}
+		try {
+			ByteArrayUtil.replace(new byte[]{0x00, 0x01}, -1, 2, new byte[]{0x00}, new byte[]{0x00, FF});
+			throw new RuntimeException("able to use negative offset");
+		}
+		catch(IllegalArgumentException e) {
+			// eat
+		}
+		try {
+			ByteArrayUtil.replace(new byte[]{0x00, 0x01}, 3, 2, new byte[]{0x00}, new byte[]{0x00, FF});
+			throw new RuntimeException("able to use offset after end of array");
+		}
+		catch(IllegalArgumentException e) {
+			// eat
+		}
+		try {
+			ByteArrayUtil.replace(new byte[]{0x00, 0x01}, 1, -1, new byte[]{0x00}, new byte[]{0x00, FF});
+			throw new RuntimeException("able to use negative length");
+		}
+		catch(IllegalArgumentException e) {
+			// eat
+		}
+		try {
+			ByteArrayUtil.replace(new byte[]{0x00, 0x01}, 1, 2, new byte[]{0x00}, new byte[]{0x00, FF});
+			throw new RuntimeException("able to give length that exceeds end of the array");
+		}
+		catch(IllegalArgumentException e) {
+			// eat
+		}
 	}
 
 	private static void runTests(final int reps, TransactionContext db) {

--- a/bindings/java/src/test/com/apple/foundationdb/test/TupleTest.java
+++ b/bindings/java/src/test/com/apple/foundationdb/test/TupleTest.java
@@ -20,22 +20,114 @@
 
 package com.apple.foundationdb.test;
 
-import com.apple.foundationdb.Database;
-import com.apple.foundationdb.FDB;
 import com.apple.foundationdb.TransactionContext;
+import com.apple.foundationdb.tuple.ByteArrayUtil;
 import com.apple.foundationdb.tuple.Tuple;
 
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
 public class TupleTest {
+	private static final byte FF = (byte)0xff;
+
 	public static void main(String[] args) throws InterruptedException {
 		final int reps = 1000;
 		try {
-			FDB fdb = FDB.selectAPIVersion(610);
+			// FDB fdb = FDB.selectAPIVersion(610);
+			serializedForms();
+			/*
 			try(Database db = fdb.open()) {
 				runTests(reps, db);
 			}
+			*/
 		} catch(Throwable t) {
 			t.printStackTrace();
 		}
+	}
+
+	private static class TupleSerialization {
+		private final Tuple tuple;
+		private final byte[] serialization;
+
+		TupleSerialization(Tuple tuple, byte[] serialization) {
+			this.tuple = tuple;
+			this.serialization = serialization;
+		}
+
+		static void addAll(List<TupleSerialization> list, Object... args) {
+			for(int i = 0; i < args.length; i += 2) {
+				TupleSerialization serialization = new TupleSerialization((Tuple)args[i], (byte[])args[i + 1]);
+				list.add(serialization);
+			}
+		}
+	}
+
+	private static void serializedForms() {
+		List<TupleSerialization> serializations = new ArrayList<>();
+		TupleSerialization.addAll(serializations,
+				Tuple.from(0L), new byte[]{0x14},
+				Tuple.from(BigInteger.ZERO), new byte[]{0x14},
+				Tuple.from(1L), new byte[]{0x15, 0x01},
+				Tuple.from(BigInteger.ONE), new byte[]{0x15, 0x01},
+				Tuple.from(-1L), new byte[]{0x13, FF - 1},
+				Tuple.from(BigInteger.ONE.negate()), new byte[]{0x13, FF - 1},
+				Tuple.from(255L), new byte[]{0x15, FF},
+				Tuple.from(BigInteger.valueOf(255)), new byte[]{0x15, FF},
+				Tuple.from(-255L), new byte[]{0x13, 0x00},
+				Tuple.from(BigInteger.valueOf(-255)), new byte[]{0x13, 0x00},
+				Tuple.from(256L), new byte[]{0x16, 0x01, 0x00},
+				Tuple.from(BigInteger.valueOf(256)), new byte[]{0x16, 0x01, 0x00},
+				Tuple.from(-256L), new byte[]{0x12, FF - 1, FF},
+				Tuple.from(BigInteger.valueOf(-256)), new byte[]{0x12, FF - 1, FF},
+				Tuple.from(65536), new byte[]{0x17, 0x01, 0x00, 0x00},
+				Tuple.from(-65536), new byte[]{0x11, FF - 1, FF, FF},
+				Tuple.from(Long.MAX_VALUE), new byte[]{0x1C, 0x7f, FF, FF, FF, FF, FF, FF, FF},
+				Tuple.from(BigInteger.valueOf(Long.MAX_VALUE)), new byte[]{0x1C, 0x7f, FF, FF, FF, FF, FF, FF, FF},
+				Tuple.from(BigInteger.valueOf(Long.MAX_VALUE).add(BigInteger.ONE)), new byte[]{0x1C, (byte)0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+				Tuple.from(BigInteger.ONE.shiftLeft(64).subtract(BigInteger.ONE)), new byte[]{0x1C, FF, FF, FF, FF, FF, FF, FF, FF},
+				Tuple.from(BigInteger.ONE.shiftLeft(64)), new byte[]{0x1D, 0x09, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+				Tuple.from(-((1L << 32) - 1)), new byte[]{0x10, 0x00, 0x00, 0x00, 0x00},
+				Tuple.from(BigInteger.ONE.shiftLeft(32).subtract(BigInteger.ONE).negate()), new byte[]{0x10, 0x00, 0x00, 0x00, 0x00},
+				Tuple.from(Long.MIN_VALUE + 2), new byte[]{0x0C, (byte)0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01},
+				Tuple.from(Long.MIN_VALUE + 1), new byte[]{0x0C, (byte)0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+				Tuple.from(BigInteger.valueOf(Long.MIN_VALUE).add(BigInteger.ONE)), new byte[]{0x0C, (byte)0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+				Tuple.from(Long.MIN_VALUE), new byte[]{0x0C, 0x7f, FF, FF, FF, FF, FF, FF, FF},
+				Tuple.from(BigInteger.valueOf(Long.MIN_VALUE)), new byte[]{0x0C, 0x7f, FF, FF, FF, FF, FF, FF, FF},
+				Tuple.from(BigInteger.valueOf(Long.MIN_VALUE).subtract(BigInteger.ONE)), new byte[]{0x0C, 0x7f, FF, FF, FF, FF, FF, FF, FF - 1},
+				Tuple.from(BigInteger.ONE.shiftLeft(64).subtract(BigInteger.ONE).negate()), new byte[]{0x0C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+				Tuple.from(3.14f), new byte[]{0x20, (byte)0xc0, 0x48, (byte)0xf5, (byte)0xc3},
+				Tuple.from(-3.14f), new byte[]{0x20, (byte)0x3f, (byte)0xb7, (byte)0x0a, (byte)0x3c},
+				Tuple.from(3.14), new byte[]{0x21, (byte)0xc0, (byte)0x09, (byte)0x1e, (byte)0xb8, (byte)0x51, (byte)0xeb, (byte)0x85, (byte)0x1f},
+				Tuple.from(-3.14), new byte[]{0x21, (byte)0x3f, (byte)0xf6, (byte)0xe1, (byte)0x47, (byte)0xae, (byte)0x14, (byte)0x7a, (byte)0xe0},
+				Tuple.from(0.0f), new byte[]{0x20, (byte)0x80, 0x00, 0x00, 0x00},
+				Tuple.from(-0.0f), new byte[]{0x20, 0x7f, FF, FF, FF},
+				Tuple.from(0.0), new byte[]{0x21, (byte)0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+				Tuple.from(-0.0), new byte[]{0x21, 0x7f, FF, FF, FF, FF, FF, FF, FF},
+				Tuple.from(Float.POSITIVE_INFINITY), new byte[]{0x20, FF, (byte)0x80, 0x00, 0x00},
+				Tuple.from(Float.NEGATIVE_INFINITY), new byte[]{0x20, 0x00, 0x7f, FF, FF},
+				Tuple.from(Double.POSITIVE_INFINITY), new byte[]{0x21, FF, (byte)0xf0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+				Tuple.from(Double.NEGATIVE_INFINITY), new byte[]{0x21, 0x00, 0x0f, FF, FF, FF, FF, FF, FF},
+				Tuple.from(Float.intBitsToFloat(Integer.MAX_VALUE)), new byte[]{0x20, FF, FF, FF, FF},
+				Tuple.from(Double.longBitsToDouble(Long.MAX_VALUE)), new byte[]{0x21, FF, FF, FF, FF, FF, FF, FF, FF},
+				Tuple.from(Float.intBitsToFloat(~0)), new byte[]{0x20, 0x00, 0x00, 0x00, 0x00},
+				Tuple.from(Double.longBitsToDouble(~0L)), new byte[]{0x21, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
+		);
+
+		for(TupleSerialization serialization : serializations) {
+			System.out.println("Packing " + serialization.tuple + " (expecting: " + ByteArrayUtil.printable(serialization.serialization) + ")");
+			if(!Arrays.equals(serialization.tuple.pack(), serialization.serialization)) {
+				throw new RuntimeException("Tuple " + serialization.tuple + " has serialization " + ByteArrayUtil.printable(serialization.tuple.pack()) +
+						" which does not match expected serialization " + ByteArrayUtil.printable(serialization.serialization));
+			}
+			if(!Objects.equals(serialization.tuple, Tuple.fromBytes(serialization.serialization))) {
+				throw new RuntimeException("Tuple " + serialization.tuple + " does not match deserialization " + Tuple.fromBytes(serialization.serialization) +
+						" which comes from serialization " + ByteArrayUtil.printable(serialization.serialization));
+			}
+		}
+		System.out.println("All tuples had matching serializations");
 	}
 
 	private static void runTests(final int reps, TransactionContext db) {

--- a/bindings/java/src/test/com/apple/foundationdb/test/TupleTest.java
+++ b/bindings/java/src/test/com/apple/foundationdb/test/TupleTest.java
@@ -21,13 +21,21 @@
 package com.apple.foundationdb.test;
 
 import java.math.BigInteger;
+import java.nio.BufferOverflowException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
+import java.util.stream.Stream;
 
+import com.apple.foundationdb.Database;
+import com.apple.foundationdb.FDB;
 import com.apple.foundationdb.TransactionContext;
+import com.apple.foundationdb.subspace.Subspace;
 import com.apple.foundationdb.tuple.ByteArrayUtil;
 import com.apple.foundationdb.tuple.Tuple;
 import com.apple.foundationdb.tuple.Versionstamp;
@@ -38,15 +46,19 @@ public class TupleTest {
 	public static void main(String[] args) throws InterruptedException {
 		final int reps = 1000;
 		try {
-			// FDB fdb = FDB.selectAPIVersion(610);
-			serializedForms();
+			FDB fdb = FDB.selectAPIVersion(610);
+			addMethods();
 			comparisons();
+			emptyTuple();
+			incompleteVersionstamps();
+			intoBuffer();
+			offsetsAndLengths();
+			malformedBytes();
 			replaceTests();
-			/*
+			serializedForms();
 			try(Database db = fdb.open()) {
 				runTests(reps, db);
 			}
-			*/
 		} catch(Throwable t) {
 			t.printStackTrace();
 		}
@@ -266,6 +278,606 @@ public class TupleTest {
 					throw new RuntimeException("Tuple t1 and t2 comparison mismatched: semantic = " + semanticComparison + " while implicit byte order = " + implicitByteComparison);
 				}
 			}
+		}
+	}
+
+	private static void emptyTuple() {
+		Tuple t = new Tuple();
+		if(!t.isEmpty()) {
+			throw new RuntimeException("empty tuple is not empty");
+		}
+		if(t.getPackedSize() != 0) {
+			throw new RuntimeException("empty tuple packed size is not 0");
+		}
+		if(t.pack().length != 0) {
+			throw new RuntimeException("empty tuple is not packed to the empty byte string");
+		}
+	}
+
+	private static void addMethods() {
+		List<Tuple> baseTuples = Arrays.asList(
+				new Tuple(),
+				Tuple.from(),
+				Tuple.from((Object)null),
+				Tuple.from("prefix"),
+				Tuple.from("prefix", null),
+				Tuple.from(new UUID(100, 1000)),
+				Tuple.from(Versionstamp.incomplete(1)),
+				Tuple.from(Tuple.from(Versionstamp.incomplete(2))),
+				Tuple.from(Collections.singletonList(Versionstamp.incomplete(3)))
+		);
+		List<Object> toAdd = Arrays.asList(
+				null,
+				1066L,
+				BigInteger.valueOf(1066),
+				-3.14f,
+				2.71828,
+				new byte[]{0x01, 0x02, 0x03},
+				new byte[]{0x01, 0x00, 0x02, 0x00, 0x03},
+				"hello there",
+				"hell\0 there",
+				"\ud83d\udd25",
+				"\ufb14",
+				false,
+				true,
+				Float.NaN,
+				Float.intBitsToFloat(Integer.MAX_VALUE),
+				Double.NaN,
+				Double.longBitsToDouble(Long.MAX_VALUE),
+				Versionstamp.complete(new byte[]{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09}, 100),
+				Versionstamp.incomplete(4),
+				new UUID(-1, 1),
+				Tuple.from((Object)null),
+				Tuple.from("suffix", "tuple"),
+				Tuple.from("s\0ffix", "tuple"),
+				Arrays.asList("suffix", "tuple"),
+				Arrays.asList("suffix", null, "tuple"),
+				Tuple.from("suffix", null, "tuple"),
+				Tuple.from("suffix", Versionstamp.incomplete(4), "tuple"),
+				Arrays.asList("suffix", Arrays.asList("inner", Versionstamp.incomplete(5), "tuple"), "tuple")
+		);
+
+		for(Tuple baseTuple : baseTuples) {
+			for(Object newItem : toAdd) {
+				int baseSize = baseTuple.size();
+				Tuple freshTuple = Tuple.fromStream(Stream.concat(baseTuple.stream(), Stream.of(newItem)));
+				if(freshTuple.size() != baseSize + 1) {
+					throw new RuntimeException("freshTuple size was not one larger than base size");
+				}
+				Tuple withObjectAdded = baseTuple.addObject(newItem);
+				if(withObjectAdded.size() != baseSize + 1) {
+					throw new RuntimeException("withObjectAdded size was not one larger than the base size");
+				}
+				// Use the appropriate "add" overload.
+				Tuple withValueAdded;
+				if(newItem == null) {
+					withValueAdded = baseTuple.addObject(null);
+				}
+				else if(newItem instanceof byte[]) {
+					withValueAdded = baseTuple.add((byte[])newItem);
+				}
+				else if(newItem instanceof String) {
+					withValueAdded = baseTuple.add((String)newItem);
+				}
+				else if(newItem instanceof Long) {
+					withValueAdded = baseTuple.add((Long)newItem);
+				}
+				else if(newItem instanceof BigInteger) {
+					withValueAdded = baseTuple.add((BigInteger)newItem);
+				}
+				else if(newItem instanceof Float) {
+					withValueAdded = baseTuple.add((Float)newItem);
+				}
+				else if(newItem instanceof Double) {
+					withValueAdded = baseTuple.add((Double)newItem);
+				}
+				else if(newItem instanceof Boolean) {
+					withValueAdded = baseTuple.add((Boolean)newItem);
+				}
+				else if(newItem instanceof UUID) {
+					withValueAdded = baseTuple.add((UUID)newItem);
+				}
+				else if(newItem instanceof Versionstamp) {
+					withValueAdded = baseTuple.add((Versionstamp)newItem);
+				}
+				else if(newItem instanceof List<?>) {
+					withValueAdded = baseTuple.add((List<?>)newItem);
+				}
+				else if(newItem instanceof Tuple) {
+					withValueAdded = baseTuple.add((Tuple)newItem);
+				}
+				else {
+					throw new RuntimeException("unknown type for tuple serialization " + newItem.getClass());
+				}
+				// Use Tuple.addAll, which has optimizations if both tuples have been packed already
+				// Getting their hash codes memoizes the packed representation.
+				Tuple newItemTuple = Tuple.from(newItem);
+				baseTuple.hashCode();
+				newItemTuple.hashCode();
+				Tuple withTupleAddedAll = baseTuple.addAll(newItemTuple);
+				Tuple withListAddedAll = baseTuple.addAll(Collections.singletonList(newItem));
+				List<Tuple> allTuples = Arrays.asList(freshTuple, withObjectAdded, withValueAdded, withTupleAddedAll, withListAddedAll);
+
+				int basePlusNewSize = baseTuple.getPackedSize() + Tuple.from(newItem).getPackedSize();
+				int freshTuplePackedSize = freshTuple.getPackedSize();
+				int withObjectAddedPackedSize = withObjectAdded.getPackedSize();
+				int withValueAddedPackedSize = withValueAdded.getPackedSize();
+				int withTupleAddedAllPackedSize = withTupleAddedAll.getPackedSize();
+				int withListAddAllPackedSize = withListAddedAll.getPackedSize();
+				if(basePlusNewSize != freshTuplePackedSize || basePlusNewSize != withObjectAddedPackedSize ||
+						basePlusNewSize != withValueAddedPackedSize || basePlusNewSize != withTupleAddedAllPackedSize ||
+						basePlusNewSize != withListAddAllPackedSize) {
+					throw new RuntimeException("packed sizes not equivalent");
+				}
+				byte[] concatPacked;
+				byte[] prefixPacked;
+				byte[] freshPacked;
+				byte[] objectAddedPacked;
+				byte[] valueAddedPacked;
+				byte[] tupleAddedAllPacked;
+				byte[] listAddedAllPacked;
+				if(!baseTuple.hasIncompleteVersionstamp() && !Tuple.from(newItem).hasIncompleteVersionstamp()) {
+					concatPacked = ByteArrayUtil.join(baseTuple.pack(), Tuple.from(newItem).pack());
+					prefixPacked = Tuple.from(newItem).pack(baseTuple.pack());
+					freshPacked = freshTuple.pack();
+					objectAddedPacked = withObjectAdded.pack();
+					valueAddedPacked = withValueAdded.pack();
+					tupleAddedAllPacked = withTupleAddedAll.pack();
+					listAddedAllPacked = withListAddedAll.pack();
+
+					for(Tuple t : allTuples) {
+						try {
+							t.packWithVersionstamp();
+							throw new RuntimeException("able to pack tuple without incomplete versionstamp using packWithVersionstamp");
+						}
+						catch(IllegalArgumentException e) {
+							// eat
+						}
+					}
+				}
+				else if(!baseTuple.hasIncompleteVersionstamp() && Tuple.from(newItem).hasIncompleteVersionstamp()) {
+					concatPacked = newItemTuple.packWithVersionstamp(baseTuple.pack());
+					try {
+						prefixPacked = Tuple.from(newItem).packWithVersionstamp(baseTuple.pack());
+					}
+					catch(NullPointerException e) {
+						prefixPacked = Tuple.from(newItem).packWithVersionstamp(baseTuple.pack());
+					}
+					freshPacked = freshTuple.packWithVersionstamp();
+					objectAddedPacked = withObjectAdded.packWithVersionstamp();
+					valueAddedPacked = withValueAdded.packWithVersionstamp();
+					tupleAddedAllPacked = withTupleAddedAll.packWithVersionstamp();
+					listAddedAllPacked = withListAddedAll.packWithVersionstamp();
+
+					for(Tuple t : allTuples) {
+						try {
+							t.pack();
+							throw new RuntimeException("able to pack tuple with incomplete versionstamp");
+						}
+						catch(IllegalArgumentException e) {
+							// eat
+						}
+					}
+				}
+				else if(baseTuple.hasIncompleteVersionstamp() && !Tuple.from(newItem).hasIncompleteVersionstamp()) {
+					concatPacked = baseTuple.addAll(Tuple.from(newItem)).packWithVersionstamp();
+					prefixPacked = baseTuple.addObject(newItem).packWithVersionstamp();
+					freshPacked = freshTuple.packWithVersionstamp();
+					objectAddedPacked = withObjectAdded.packWithVersionstamp();
+					valueAddedPacked = withValueAdded.packWithVersionstamp();
+					tupleAddedAllPacked = withTupleAddedAll.packWithVersionstamp();
+					listAddedAllPacked = withListAddedAll.packWithVersionstamp();
+
+					for(Tuple t : allTuples) {
+						try {
+							t.pack();
+							throw new RuntimeException("able to pack tuple with incomplete versionstamp");
+						}
+						catch(IllegalArgumentException e) {
+							// eat
+						}
+					}
+				}
+				else {
+					for(Tuple t : allTuples) {
+						try {
+							t.pack();
+							throw new RuntimeException("able to pack tuple with two versionstamps using pack");
+						}
+						catch(IllegalArgumentException e) {
+							// eat
+						}
+						try {
+							t.packWithVersionstamp();
+							throw new RuntimeException("able to pack tuple with two versionstamps using packWithVersionstamp");
+						}
+						catch(IllegalArgumentException e) {
+							// eat
+						}
+						try {
+							t.hashCode();
+							throw new RuntimeException("able to get hash code of tuple with two versionstamps");
+						}
+						catch(IllegalArgumentException e) {
+							// eat
+						}
+					}
+					concatPacked = null;
+					prefixPacked = null;
+					freshPacked = null;
+					objectAddedPacked = null;
+					valueAddedPacked = null;
+					tupleAddedAllPacked = null;
+					listAddedAllPacked = null;
+				}
+				if(!Arrays.equals(concatPacked, freshPacked) ||
+						!Arrays.equals(freshPacked, prefixPacked) ||
+						!Arrays.equals(freshPacked, objectAddedPacked) ||
+						!Arrays.equals(freshPacked, valueAddedPacked) ||
+						!Arrays.equals(freshPacked, tupleAddedAllPacked) ||
+						!Arrays.equals(freshPacked, listAddedAllPacked)) {
+					throw new RuntimeException("packed values are not concatenation of original packings");
+				}
+				if(freshPacked != null && freshPacked.length != basePlusNewSize) {
+					throw new RuntimeException("packed length did not match expectation");
+				}
+				if(freshPacked != null) {
+					if(freshTuple.hashCode() != Arrays.hashCode(freshPacked)) {
+						throw new IllegalArgumentException("hash code does not match fresh packed");
+					}
+					for(Tuple t : allTuples) {
+						if(t.hashCode() != freshTuple.hashCode()) {
+							throw new IllegalArgumentException("hash code mismatch");
+						}
+						if(Tuple.fromItems(t.getItems()).hashCode() != freshTuple.hashCode()) {
+							throw new IllegalArgumentException("hash code mismatch after re-compute");
+						}
+					}
+				}
+			}
+		}
+	}
+
+	private static void incompleteVersionstamps() {
+		if(FDB.instance().getAPIVersion() < 520) {
+			throw new IllegalStateException("cannot run test with API version " + FDB.instance().getAPIVersion());
+		}
+		// This is a tricky case where there are two tuples with identical representations but different semantics.
+		byte[] arr = new byte[0x0100fe];
+		Arrays.fill(arr, (byte)0x7f); // The actual value doesn't matter, but it can't be zero.
+		Tuple t1 = Tuple.from(arr, Versionstamp.complete(new byte[]{FF, FF, FF, FF, FF, FF, FF, FF, FF, FF}), new byte[]{0x01, 0x01});
+		Tuple t2 = Tuple.from(arr, Versionstamp.incomplete());
+		if(t1.equals(t2)) {
+			throw new RuntimeException("tuples " + t1 + " and " + t2 + " compared equal");
+		}
+		byte[] bytes1 = t1.pack();
+		byte[] bytes2 = t2.packWithVersionstamp();
+		if(!Arrays.equals(bytes1, bytes2)) {
+			throw new RuntimeException("tuples " + t1 + " and " + t2 + " did not have matching representations");
+		}
+		if(t1.equals(t2)) {
+			throw new RuntimeException("tuples " + t1 + " and " + t2 + " compared equal with memoized packed representations");
+		}
+
+		// Make sure position information adjustment works.
+		Tuple t3 = Tuple.from(Versionstamp.incomplete(1));
+		if(t3.getPackedSize() != 1 + Versionstamp.LENGTH + Integer.BYTES) {
+			throw new RuntimeException("incomplete versionstamp has incorrect packed size " + t3.getPackedSize());
+		}
+		byte[] bytes3 = t3.packWithVersionstamp();
+		if(ByteBuffer.wrap(bytes3, bytes3.length - Integer.BYTES, Integer.BYTES).order(ByteOrder.LITTLE_ENDIAN).getInt() != 1) {
+			throw new RuntimeException("incomplete versionstamp has incorrect position");
+		}
+		if(!Tuple.fromBytes(bytes3, 0, bytes3.length - Integer.BYTES).equals(Tuple.from(Versionstamp.incomplete(1)))) {
+			throw new RuntimeException("unpacked bytes did not match");
+		}
+		Subspace subspace = new Subspace(Tuple.from("prefix"));
+		byte[] bytes4 = subspace.packWithVersionstamp(t3);
+		if(ByteBuffer.wrap(bytes4, bytes4.length - Integer.BYTES, Integer.BYTES).order(ByteOrder.LITTLE_ENDIAN).getInt() != 1 + subspace.getKey().length) {
+			throw new RuntimeException("incomplete versionstamp has incorrect position with prefix");
+		}
+		if(!Tuple.fromBytes(bytes4, 0, bytes4.length - Integer.BYTES).equals(Tuple.from("prefix", Versionstamp.incomplete(1)))) {
+			throw new RuntimeException("unpacked bytes with subspace did not match");
+		}
+		try {
+			// At this point, the representation is cached, so an easy bug would be to have it return the already serialized value
+			t3.pack();
+			throw new RuntimeException("was able to pack versionstamp with incomplete versionstamp");
+		} catch(IllegalArgumentException e) {
+			// eat
+		}
+
+		// Tuples with two incomplete versionstamps somewhere.
+		List<Tuple> twoIncompleteList = Arrays.asList(
+				Tuple.from(Versionstamp.incomplete(1), Versionstamp.incomplete(2)),
+				Tuple.from(Tuple.from(Versionstamp.incomplete(3)), Tuple.from(Versionstamp.incomplete(4))),
+				new Tuple().add(Versionstamp.incomplete()).add(Versionstamp.incomplete()),
+				new Tuple().add(Versionstamp.incomplete()).add(3L).add(Versionstamp.incomplete()),
+				Tuple.from(Tuple.from(Versionstamp.incomplete()), "dummy_string").add(Tuple.from(Versionstamp.incomplete())),
+				Tuple.from(Arrays.asList(Versionstamp.incomplete(), "dummy_string")).add(Tuple.from(Versionstamp.incomplete())),
+				Tuple.from(Tuple.from(Versionstamp.incomplete()), "dummy_string").add(Collections.singletonList(Versionstamp.incomplete()))
+		);
+		for(Tuple t : twoIncompleteList) {
+			if(!t.hasIncompleteVersionstamp()) {
+				throw new RuntimeException("tuple doesn't think it has incomplete versionstamp");
+			}
+			if(t.getPackedSize() < 2 * (1 + Versionstamp.LENGTH + Integer.BYTES)) {
+				throw new RuntimeException("tuple packed size " + t.getPackedSize() + " is smaller than expected");
+			}
+			try {
+				t.pack();
+				throw new RuntimeException("no error thrown when packing any incomplete versionstamps");
+			}
+			catch(IllegalArgumentException e) {
+				// eat
+			}
+			try {
+				t.packWithVersionstamp();
+				throw new RuntimeException("no error thrown when packing with versionstamp with two incompletes");
+			}
+			catch(IllegalArgumentException e) {
+				// eat
+			}
+		}
+	}
+
+	// Assumes API version < 520
+	private static void incompleteVersionstamps300() {
+		if(FDB.instance().getAPIVersion() >= 520) {
+			throw new IllegalStateException("cannot run test with API version " + FDB.instance().getAPIVersion());
+		}
+		Tuple t1 = Tuple.from(Versionstamp.complete(new byte[]{FF, FF, FF, FF, FF, FF, FF, FF, FF, FF}), new byte[]{});
+		Tuple t2 = Tuple.from(Versionstamp.incomplete());
+		if(t1.equals(t2)) {
+			throw new RuntimeException("tuples " + t1 + " and " + t2 + " compared equal");
+		}
+		byte[] bytes1 = t1.pack();
+		byte[] bytes2 = t2.packWithVersionstamp();
+		if(!Arrays.equals(bytes1, bytes2)) {
+			throw new RuntimeException("tuples " + t1 + " and " + t2 + " did not have matching representations");
+		}
+		if(t1.equals(t2)) {
+			throw new RuntimeException("tuples " + t1 + " and " + t2 + " compared equal with memoized packed representations");
+		}
+
+		// Make sure position information adjustment works.
+		Tuple t3 = Tuple.from(Versionstamp.incomplete(1));
+		if(t3.getPackedSize() != 1 + Versionstamp.LENGTH + Short.BYTES) {
+			throw new RuntimeException("incomplete versionstamp has incorrect packed size " + t3.getPackedSize());
+		}
+		byte[] bytes3 = t3.packWithVersionstamp();
+		if(ByteBuffer.wrap(bytes3, bytes3.length - Short.BYTES, Short.BYTES).order(ByteOrder.LITTLE_ENDIAN).getShort() != 1) {
+			throw new RuntimeException("incomplete versionstamp has incorrect position");
+		}
+		if(!Tuple.fromBytes(bytes3, 0, bytes3.length - Short.BYTES).equals(Tuple.from(Versionstamp.incomplete(1)))) {
+			throw new RuntimeException("unpacked bytes did not match");
+		}
+		Subspace subspace = new Subspace(Tuple.from("prefix"));
+		byte[] bytes4 = subspace.packWithVersionstamp(t3);
+		if(ByteBuffer.wrap(bytes4, bytes4.length - Short.BYTES, Short.BYTES).order(ByteOrder.LITTLE_ENDIAN).getShort() != 1 + subspace.getKey().length) {
+			throw new RuntimeException("incomplete versionstamp has incorrect position with prefix");
+		}
+		if(!Tuple.fromBytes(bytes4, 0, bytes4.length - Short.BYTES).equals(Tuple.from("prefix", Versionstamp.incomplete(1)))) {
+			throw new RuntimeException("unpacked bytes with subspace did not match");
+		}
+
+		// Make sure an offset > 0xFFFF throws an error.
+		Tuple t4 = Tuple.from(Versionstamp.incomplete(2));
+		byte[] bytes5 = t4.packWithVersionstamp(); // Get bytes memoized.
+		if(ByteBuffer.wrap(bytes5, bytes5.length - Short.BYTES, Short.BYTES).order(ByteOrder.LITTLE_ENDIAN).getShort() != 1) {
+			throw new RuntimeException("incomplete versionstamp has incorrect position with prefix");
+		}
+		byte[] bytes6 = t4.packWithVersionstamp(new byte[0xfffe]); // Offset is 0xffff
+		if(!Arrays.equals(Arrays.copyOfRange(bytes5, 0, 1 + Versionstamp.LENGTH), Arrays.copyOfRange(bytes6, 0xfffe, 0xffff + Versionstamp.LENGTH))) {
+			throw new RuntimeException("area before versionstamp offset did not match");
+		}
+		if((ByteBuffer.wrap(bytes6, bytes6.length - Short.BYTES, Short.BYTES).order(ByteOrder.LITTLE_ENDIAN).getShort() & 0xffff) != 0xffff) {
+			throw new RuntimeException("incomplete versionstamp has incorrect position with prefix");
+		}
+		try {
+			t4.packWithVersionstamp(new byte[0xffff]); // Offset is 0x10000
+			throw new RuntimeException("able to pack versionstamp with offset that is too large");
+		}
+		catch(IllegalArgumentException e) {
+			// eat
+		}
+		// Same as before, but packed representation is not memoized.
+		try {
+			Tuple.from(Versionstamp.incomplete(3)).packWithVersionstamp(new byte[0xffff]); // Offset is 0x10000
+			throw new RuntimeException("able to pack versionstamp with offset that is too large");
+		}
+		catch(IllegalArgumentException e) {
+			// eat
+		}
+	}
+
+	private static void malformedBytes() {
+		List<byte[]> malformedSequences = Arrays.asList(
+				new byte[]{0x01, (byte)0xde, (byte)0xad, (byte)0xc0, (byte)0xde}, // no termination character for byte array
+				new byte[]{0x01, (byte)0xde, (byte)0xad, 0x00, FF, (byte)0xc0, (byte)0xde}, // no termination character but null in middle
+				new byte[]{0x02, 'h', 'e', 'l', 'l', 'o'}, // no termination character for string
+				new byte[]{0x02, 'h', 'e', 'l', 0x00, FF, 'l', 'o'}, // no termination character but null in the middle
+				// Invalid UTF-8 decodes malformed as U+FFFD rather than throwing an error
+				// new byte[]{0x02, 'u', 't', 'f', 0x08, (byte)0x80, 0x00}, // invalid utf-8 code point start character
+				// new byte[]{0x02, 'u', 't', 'f', 0x08, (byte)0xc0, 0x01, 0x00}, // invalid utf-8 code point second character
+				new byte[]{0x05, 0x02, 'h', 'e', 'l', 'l', 'o', 0x00}, // no termination character for nested tuple
+				new byte[]{0x05, 0x02, 'h', 'e', 'l', 'l', 'o', 0x00, 0x00, FF, 0x02, 't', 'h', 'e', 'r', 'e', 0x00}, // no termination character for nested tuple but null in the middle
+				new byte[]{0x16, 0x01}, // integer truncation
+				new byte[]{0x12, 0x01}, // integer truncation
+				new byte[]{0x1d, 0x09, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}, // integer truncation
+				new byte[]{0x0b, 0x09 ^ FF, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}, // integer truncation
+				new byte[]{0x20, 0x01, 0x02, 0x03}, // float truncation
+				new byte[]{0x21, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07}, // double truncation
+				new byte[]{0x30, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e}, // UUID truncation
+				new byte[]{0x33, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b}, // versionstamp truncation
+				new byte[]{FF} // unknown start code
+		);
+		for(byte[] sequence : malformedSequences) {
+			try {
+				Tuple t = Tuple.fromBytes(sequence);
+				throw new RuntimeException("Able to unpack " + ByteArrayUtil.printable(sequence) + " into " + t);
+			}
+			catch(IllegalArgumentException e) {
+				System.out.println("Error for " + ByteArrayUtil.printable(sequence) + ": " + e.getMessage());
+			}
+		}
+
+		// Perfectly good byte sequences, but using the offset and length to remove terminal bytes
+		List<byte[]> wellFormedSequences = Arrays.asList(
+				Tuple.from((Object)new byte[]{0x01, 0x02}).pack(),
+				Tuple.from("hello").pack(),
+				Tuple.from("hell\0").pack(),
+				Tuple.from(1066L).pack(),
+				Tuple.from(-1066L).pack(),
+				Tuple.from(BigInteger.ONE.shiftLeft(Long.SIZE + 1)).pack(),
+				Tuple.from(BigInteger.ONE.shiftLeft(Long.SIZE + 1).negate()).pack(),
+				Tuple.from(-3.14f).pack(),
+				Tuple.from(2.71828).pack(),
+				Tuple.from(new UUID(1066L, 1415L)).pack(),
+				Tuple.from(Versionstamp.fromBytes(new byte[]{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c})).pack()
+		);
+		for(byte[] sequence : wellFormedSequences) {
+			try {
+				Tuple t = Tuple.fromBytes(sequence, 0, sequence.length - 1);
+				throw new RuntimeException("Able to unpack " + ByteArrayUtil.printable(sequence) + " into " + t + " without last character");
+			}
+			catch(IllegalArgumentException e) {
+				System.out.println("Error for " + ByteArrayUtil.printable(sequence) + ": " + e.getMessage());
+			}
+		}
+	}
+
+	private static void offsetsAndLengths() {
+		List<Tuple> tuples = Arrays.asList(
+				new Tuple(),
+				Tuple.from((Object)null),
+				Tuple.from(null, new byte[]{0x10, 0x66}),
+				Tuple.from("dummy_string"),
+				Tuple.from(1066L)
+		);
+		Tuple allTuples = tuples.stream().reduce(new Tuple(), Tuple::addAll);
+		byte[] allTupleBytes = allTuples.pack();
+
+		// Unpack each tuple individually using their lengths
+		int offset = 0;
+		for(Tuple t : tuples) {
+			int length = t.getPackedSize();
+			Tuple unpacked = Tuple.fromBytes(allTupleBytes, offset, length);
+			if(!unpacked.equals(t)) {
+				throw new RuntimeException("unpacked tuple " + unpacked + " does not match serialized tuple " + t);
+			}
+			offset += length;
+		}
+
+		// Unpack successive pairs of tuples.
+		offset = 0;
+		for(int i = 0; i < tuples.size() - 1; i++) {
+			Tuple combinedTuple = tuples.get(i).addAll(tuples.get(i + 1));
+			Tuple unpacked = Tuple.fromBytes(allTupleBytes, offset, combinedTuple.getPackedSize());
+			if(!unpacked.equals(combinedTuple)) {
+				throw new RuntimeException("unpacked tuple " + unpacked + " does not match combined tuple " + combinedTuple);
+			}
+			offset += tuples.get(i).getPackedSize();
+		}
+
+		// Allow an offset to equal the length of the array, but essentially only a zero-length is allowed there.
+		Tuple emptyAtEndTuple = Tuple.fromBytes(allTupleBytes, allTupleBytes.length, 0);
+		if(!emptyAtEndTuple.isEmpty()) {
+			throw new RuntimeException("tuple with no bytes is not empty");
+		}
+
+		try {
+			Tuple.fromBytes(allTupleBytes, -1, 4);
+			throw new RuntimeException("able to give negative offset to fromBytes");
+		}
+		catch(IllegalArgumentException e) {
+			// eat
+		}
+		try {
+			Tuple.fromBytes(allTupleBytes, allTupleBytes.length + 1, 4);
+			throw new RuntimeException("able to give offset larger than array to fromBytes");
+		}
+		catch(IllegalArgumentException e) {
+			// eat
+		}
+		try {
+			Tuple.fromBytes(allTupleBytes, 0, -1);
+			throw new RuntimeException("able to give negative length to fromBytes");
+		}
+		catch(IllegalArgumentException e) {
+			// eat
+		}
+		try {
+			Tuple.fromBytes(allTupleBytes, 0, allTupleBytes.length + 1);
+			throw new RuntimeException("able to give length larger than array to fromBytes");
+		}
+		catch(IllegalArgumentException e) {
+			// eat
+		}
+		try {
+			Tuple.fromBytes(allTupleBytes, allTupleBytes.length / 2, allTupleBytes.length / 2 + 2);
+			throw new RuntimeException("able to exceed array length in fromBytes");
+		}
+		catch(IllegalArgumentException e) {
+			// eat
+		}
+	}
+
+	private static void intoBuffer() {
+		Tuple t = Tuple.from("hello", 3.14f, "world");
+		ByteBuffer buffer = ByteBuffer.allocate("hello".length() + 2 + Float.BYTES + 1 + "world".length() + 2);
+		t.packInto(buffer);
+		if(!Arrays.equals(t.pack(), buffer.array())) {
+			throw new RuntimeException("buffer and tuple do not match");
+		}
+
+		buffer = ByteBuffer.allocate(t.getPackedSize() + 2);
+		buffer.order(ByteOrder.LITTLE_ENDIAN);
+		t.packInto(buffer);
+		if(!Arrays.equals(ByteArrayUtil.join(t.pack(), new byte[]{0x00, 0x00}), buffer.array())) {
+			throw new RuntimeException("buffer and tuple do not match");
+		}
+		if(!buffer.order().equals(ByteOrder.LITTLE_ENDIAN)) {
+			throw new RuntimeException("byte order changed");
+		}
+
+		buffer = ByteBuffer.allocate(t.getPackedSize() + 2);
+		buffer.put((byte)0x01).put((byte)0x02);
+		t.packInto(buffer);
+		if(!Arrays.equals(t.pack(new byte[]{0x01, 0x02}), buffer.array())) {
+			throw new RuntimeException("buffer and tuple do not match");
+		}
+
+		buffer = ByteBuffer.allocate(t.getPackedSize() - 1);
+		try {
+			t.packInto(buffer);
+			throw new RuntimeException("able to pack into buffer that was too small");
+		}
+		catch(BufferOverflowException e) {
+			// eat
+		}
+
+		Tuple tCopy = Tuple.fromItems(t.getItems()); // remove memoized stuff
+		buffer = ByteBuffer.allocate(t.getPackedSize() - 1);
+		try {
+			tCopy.packInto(buffer);
+			throw new RuntimeException("able to pack into buffer that was too small");
+		}
+		catch(BufferOverflowException e) {
+			// eat
+		}
+
+		Tuple tWithIncomplete = Tuple.from(Versionstamp.incomplete(3));
+		buffer = ByteBuffer.allocate(tWithIncomplete.getPackedSize());
+		try {
+			tWithIncomplete.packInto(buffer);
+			throw new RuntimeException("able to pack incomplete versionstamp into buffer");
+		}
+		catch(IllegalArgumentException e) {
+			// eat
+		}
+		if(buffer.arrayOffset() != 0) {
+			throw new RuntimeException("offset changed after unsuccessful pack with incomplete versionstamp");
 		}
 	}
 

--- a/documentation/sphinx/source/release-notes.rst
+++ b/documentation/sphinx/source/release-notes.rst
@@ -40,10 +40,15 @@ Bindings
 * Java: Deprecated ``FDB.createCluster`` and ``Cluster``. The preferred way to get a ``Database`` is by using ``FDB.open``, which should work in both new and old API versions. `(PR #942) <https://github.com/apple/foundationdb/pull/942>`_
 * Java: Removed ``Cluster(long cPtr, Executor executor)`` constructor. This is API breaking for any code that has subclassed the ``Cluster`` class and is not protected by API versioning. `(PR #942) <https://github.com/apple/foundationdb/pull/942>`_
 * Java: Several methods relevant to read-only transactions have been moved into the ``ReadTransaction`` interface.
+* Java: Tuples now cache previous hash codes and equality checking no longer requires packing the underlying Tuples. `(PR #1166) <https://github.com/apple/foundationdb/pull/1166>`_
+* Java: Tuple performance has been improved to use fewer allocations when packing and unpacking. `(Issue #1206) <https://github.com/apple/foundationdb/issues/1206>`_
+* Java: Unpacking a Tuple with a byte array or string that is missing the end-of-string character now throws an error. `(Issue #671) <https://github.com/apple/foundationdb/issues/671>`_
+* Java: Unpacking a Tuple constrained to a subset of the underlying array now throws an error when it encounters a truncated integer. `(Issue #672) <https://github.com/apple/foundationdb/issues/672>`_
 * Ruby: Removed ``FDB.init``, ``FDB.create_cluster``, and ``FDB.Cluster``. ``FDB.open`` no longer accepts a ``database_name`` parameter. `(PR #942) <https://github.com/apple/foundationdb/pull/942>`_
 * Golang: Deprecated ``fdb.StartNetwork``, ``fdb.Open``, ``fdb.MustOpen``, and ``fdb.CreateCluster`` and added ``fdb.OpenDatabase`` and ``fdb.MustOpenDatabase``. The preferred way to start the network and get a ``Database`` is by using ``FDB.OpenDatabase`` or ``FDB.OpenDefault``. `(PR #942) <https://github.com/apple/foundationdb/pull/942>`_
 * Flow: Deprecated ``API::createCluster`` and ``Cluster`` and added ``API::createDatabase``. The preferred way to get a ``Database`` is by using ``API::createDatabase``. `(PR #942) <https://github.com/apple/foundationdb/pull/942>`_
 * Golang: Added ``fdb.Printable`` to print a human-readable string for a given byte array. Add ``Key.String()``, which converts the ``Key`` to a ``string`` using the ``Printable`` function. `(PR #1010) <https://github.com/apple/foundationdb/pull/1010>`_
+* Golang: Tuples now support ``Versionstamp`` operations. `(PR #1187) <https://github.com/apple/foundationdb/pull/1187>`_
 * Python: Python signal handling didn't work when waiting on a future. In particular, pressing Ctrl-C would not successfully interrupt the program. `(PR #1138) <https://github.com/apple/foundationdb/pull/1138>`_
 
 Other Changes


### PR DESCRIPTION
This makes a few improvements to the Java Tuple packing and unpacking logic. The main thing is it now calculates the size of the tuple it is about to pack before allocating one array and then packing things into it.

This also:

* Uses `long`s instead of `BigInteger`s if possible
* Uses stack-allocated primitives for `float` and `double` serialization/deserialization
* Avoids copying byte array and string representations for comparison
* Memoizes the serialized form for fast reserialization
* Adds a method for the user to pack a tuple into a `ByteBuffer`
* Fixes two bugs related to malformed tuples (while I was here)

To give a feel for the improvement here, here's a table with the performance results packing random tuples:

|     | Master | With PR | Improvement |
|---|--------|----------| --------- |
| Bytes per Tuple | 141 B |  141 B |  N/A |
| Pack time | 2.52 µs | 1.39 µs | 1.81 x |
| Unpack time | 1.33 µs | 0.85 µs | 1.56 x |

Here are the numbers specifically for random tuples consisting only of `long`s to test no longer using `BigInteger`s:

|     | Master | With PR | Improvement |
|---|--------|----------| --------- |
| Bytes per Tuple | 47.5 B |  47.5 B |  N/A |
| Pack time | 1.17 µs | 0.424 µs | 2.76 x |
| Unpack time | 0.720 µs | 0.321 µs | 2.24 x |

Here are numbers for random tuples consisting only of floating-point numbers (both floats and doubles):

|     | Master | With PR | Improvement |
|---|--------|----------| --------- |
| Bytes per Tuple | 66.5 B |  66.5 B |  N/A |
| Pack time | 0.435 µs | 0.282 µs | 1.54 x |
| Unpack time | 0.299 µs | 0.244 µs | 1.23 x |

And here are numbers for random tuples consisting only of byte arrays and strings (or "string like") values:

|     | Master | With PR | Improvement |
|---|--------|----------| --------- |
| Bytes per Tuple | 145 B |  145 B |  N/A |
| Pack time | 3.21 µs | 1.37 µs | 2.34 x |
| Unpack time | 2.40 µs | 1.01 µs | 2.38 x |

I tried to add tests to cover what was changed. They mainly got placed in `TupleTest` with performance testing changes added to `TuplePerformanceTest`. I will attempt to run some randomized bindingtester tests as well.

This resolves #1206. It also fixes #671 and it fixes #672.