### PR TITLE
Force Make to push $CC into the environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,12 @@ else
   CCACHE_CXX := $(CXX)
 endif
 
+# Default variables don't get pushed into the environment, but scripts in build/
+# rely on the existence of CC in the environment.
+ifeq ($(origin CC), default)
+  CC := $(CC)
+endif
+
 ACTORCOMPILER := bin/actorcompiler.exe
 
 # UNSTRIPPED := 1

--- a/build/link-wrapper.sh
+++ b/build/link-wrapper.sh
@@ -2,11 +2,6 @@
 
 set -e
 
-if [ -z ${CC+x} ]
-then
-    CC=gcc
-fi
-
 case $1 in
     Application | DynamicLibrary)
 	echo "Linking        $3"


### PR DESCRIPTION
This fixes a long standing weird issue of doing non-docker builds of FDB
can hit problems of $CC not being defined in link-wrapper.sh.  It turns
out that this is because the official docker image defines CC in the
environment, and no one else does that.

Instead, we can just force Make to propagate its setting of CC into the
environment, thus requiring no extra configuration to be able to do a
build.

I've manually tested that building from within a build/cmake/Dockerfile based image still works.

cc: @wolfspider, because I think this was the source of your $CC troubles on FreeBSD