### PR TITLE
Resolves #1027: Adding interfaces to Flow bindings

### DIFF
--- a/bindings/flow/fdb_flow.actor.cpp
+++ b/bindings/flow/fdb_flow.actor.cpp
@@ -35,7 +35,7 @@ THREAD_FUNC networkThread(void* fdb) {
 ACTOR Future<Void> _test() {
 	API *fdb = FDB::API::selectAPIVersion(610);
 	auto db = fdb->createDatabase();
-	state Reference<Transaction> tr( new Transaction(db) );
+	state Reference<Transaction> tr = db->createTransaction();
 
 	// tr->setVersion(1);
 
@@ -98,8 +98,83 @@ void fdb_flow_test() {
 }
 
 namespace FDB {
+class DatabaseImpl : public Database, NonCopyable {
+public:
+	virtual ~DatabaseImpl() { fdb_database_destroy(db); }
 
-	static inline void throw_on_error( fdb_error_t e ) {
+	Reference<Transaction> createTransaction() override;
+	void setDatabaseOption(FDBDatabaseOption option, Optional<StringRef> value = Optional<StringRef>()) override;
+
+private:
+	FDBDatabase* db;
+	explicit DatabaseImpl(FDBDatabase* db) : db(db) {}
+
+	friend class API;
+};
+
+class TransactionImpl : public Transaction, private NonCopyable, public FastAllocated<TransactionImpl> {
+	friend class DatabaseImpl;
+
+public:
+	virtual ~TransactionImpl() {
+		if (tr) {
+			fdb_transaction_destroy(tr);
+		}
+	}
+
+	void setReadVersion(Version v) override;
+	Future<Version> getReadVersion() override;
+
+	Future<Optional<FDBStandalone<ValueRef>>> get(const Key& key, bool snapshot = false) override;
+	Future<FDBStandalone<KeyRef>> getKey(const KeySelector& key, bool snapshot = false) override;
+
+	Future<Void> watch(const Key& key) override;
+
+	using Transaction::getRange;
+	Future<FDBStandalone<RangeResultRef>> getRange(const KeySelector& begin, const KeySelector& end,
+	                                               GetRangeLimits limits = GetRangeLimits(), bool snapshot = false,
+	                                               bool reverse = false,
+	                                               FDBStreamingMode streamingMode = FDB_STREAMING_MODE_SERIAL) override;
+
+	void addReadConflictRange(KeyRangeRef const& keys) override;
+	void addReadConflictKey(KeyRef const& key) override;
+	void addWriteConflictRange(KeyRangeRef const& keys) override;
+	void addWriteConflictKey(KeyRef const& key) override;
+
+	void atomicOp(const KeyRef& key, const ValueRef& operand, FDBMutationType operationType) override;
+	void set(const KeyRef& key, const ValueRef& value) override;
+	void clear(const KeyRangeRef& range) override;
+	void clear(const KeyRef& key) override;
+
+	Future<Void> commit() override;
+	Version getCommittedVersion() override;
+	Future<FDBStandalone<StringRef>> getVersionstamp() override;
+
+	void setOption(FDBTransactionOption option, Optional<StringRef> value = Optional<StringRef>()) override;
+
+	Future<Void> onError(Error const& e) override;
+
+	void cancel() override;
+	void reset() override;
+
+	TransactionImpl() : tr(NULL) {}
+	TransactionImpl(TransactionImpl&& r) noexcept(true) {
+		tr = r.tr;
+		r.tr = NULL;
+	}
+	TransactionImpl& operator=(TransactionImpl&& r) noexcept(true) {
+		tr = r.tr;
+		r.tr = NULL;
+		return *this;
+	}
+
+private:
+	FDBTransaction* tr;
+
+	explicit TransactionImpl(FDBDatabase* db);
+};
+
+    static inline void throw_on_error( fdb_error_t e ) {
 		if (e)
 			throw Error(e);
 	}
@@ -187,51 +262,47 @@ namespace FDB {
 		return fdb_error_predicate( pred, e.code() );
 	}
 
-	Reference<Cluster> API::createCluster( std::string const& connFilename ) {
-		return Reference<Cluster>(new Cluster(connFilename));
-	}
-
-	Reference<DatabaseContext> API::createDatabase(std::string const& connFilename) {
-		FDBDatabase *db;
+    Reference<Database> API::createDatabase(std::string const& connFilename) {
+	    FDBDatabase *db;
 		throw_on_error(fdb_create_database(connFilename.c_str(), &db));
-		return Reference<DatabaseContext>(new DatabaseContext(db));
-	}
+	    return Reference<Database>(new DatabaseImpl(db));
+    }
 
-	int API::getAPIVersion() const {
+    int API::getAPIVersion() const {
 		return version;
 	}
 
-	Reference<DatabaseContext> Cluster::createDatabase() {
-		return API::getInstance()->createDatabase(connFilename.c_str());
-	}
+    Reference<Transaction> DatabaseImpl::createTransaction() {
+	    return Reference<Transaction>(new TransactionImpl(db));
+    }
 
-	void DatabaseContext::setDatabaseOption(FDBDatabaseOption option, Optional<StringRef> value) {
-		if (value.present())
+    void DatabaseImpl::setDatabaseOption(FDBDatabaseOption option, Optional<StringRef> value) {
+	    if (value.present())
 			throw_on_error(fdb_database_set_option(db, option, value.get().begin(), value.get().size()));
 		else
 			throw_on_error(fdb_database_set_option(db, option, NULL, 0));
-	}
+    }
 
-	Transaction::Transaction( Reference<DatabaseContext> const& db ) {
-		throw_on_error( fdb_database_create_transaction( db->db, &tr ) );
-	}
+    TransactionImpl::TransactionImpl(FDBDatabase* db) {
+	    throw_on_error(fdb_database_create_transaction(db, &tr));
+    }
 
-	void Transaction::setVersion( Version v ) {
-		fdb_transaction_set_read_version( tr, v );
-	}
+    void TransactionImpl::setReadVersion(Version v) {
+	    fdb_transaction_set_read_version( tr, v );
+    }
 
-	Future<Version> Transaction::getReadVersion() {
-		return backToFuture<Version>( fdb_transaction_get_read_version( tr ), [](Reference<CFuture> f){
+    Future<Version> TransactionImpl::getReadVersion() {
+	    return backToFuture<Version>( fdb_transaction_get_read_version( tr ), [](Reference<CFuture> f){
 				Version value;
 
 				throw_on_error( fdb_future_get_version( f->f, &value ) );
 
 				return value;
 			} );
-	}
+    }
 
-	Future< Optional<FDBStandalone<ValueRef>> > Transaction::get( const Key& key, bool snapshot ) {
-		return backToFuture< Optional<FDBStandalone<ValueRef>> >( fdb_transaction_get( tr, key.begin(), key.size(), snapshot ), [](Reference<CFuture> f) {
+    Future<Optional<FDBStandalone<ValueRef>>> TransactionImpl::get(const Key& key, bool snapshot) {
+	    return backToFuture< Optional<FDBStandalone<ValueRef>> >( fdb_transaction_get( tr, key.begin(), key.size(), snapshot ), [](Reference<CFuture> f) {
 				fdb_bool_t present;
 				uint8_t const* value;
 				int value_length;
@@ -244,17 +315,17 @@ namespace FDB {
 					return Optional<FDBStandalone<ValueRef>>();
 				}
 			} );
-	}
+    }
 
-	Future< Void > Transaction::watch( const Key& key ) {
-		return backToFuture< Void >( fdb_transaction_watch( tr, key.begin(), key.size() ), [](Reference<CFuture> f) {
+    Future<Void> TransactionImpl::watch(const Key& key) {
+	    return backToFuture< Void >( fdb_transaction_watch( tr, key.begin(), key.size() ), [](Reference<CFuture> f) {
 				throw_on_error( fdb_future_get_error( f->f ) );
 				return Void();
 			} );
-	}
+    }
 
-	Future< FDBStandalone<KeyRef> > Transaction::getKey( const KeySelector& key, bool snapshot ) {
-		return backToFuture< FDBStandalone<KeyRef> >( fdb_transaction_get_key( tr, key.key.begin(), key.key.size(), key.orEqual, key.offset, snapshot ), [](Reference<CFuture> f) {
+    Future<FDBStandalone<KeyRef>> TransactionImpl::getKey(const KeySelector& key, bool snapshot) {
+	    return backToFuture< FDBStandalone<KeyRef> >( fdb_transaction_get_key( tr, key.key.begin(), key.key.size(), key.orEqual, key.offset, snapshot ), [](Reference<CFuture> f) {
 				uint8_t const* key;
 				int key_length;
 
@@ -262,10 +333,12 @@ namespace FDB {
 
 				return FDBStandalone<KeyRef>( f, KeyRef( key, key_length ) );
 			} );
-	}
+    }
 
-	Future< FDBStandalone<RangeResultRef> > Transaction::getRange( const KeySelector& begin, const KeySelector& end, GetRangeLimits limits, bool snapshot, bool reverse, FDBStreamingMode streamingMode ) {
-		// FIXME: iteration
+    Future<FDBStandalone<RangeResultRef>> TransactionImpl::getRange(const KeySelector& begin, const KeySelector& end,
+                                                                    GetRangeLimits limits, bool snapshot, bool reverse,
+                                                                    FDBStreamingMode streamingMode) {
+	    // FIXME: iteration
 		return backToFuture< FDBStandalone<RangeResultRef> >( fdb_transaction_get_range( tr, begin.key.begin(), begin.key.size(), begin.orEqual, begin.offset, end.key.begin(), end.key.size(), end.orEqual, end.offset, limits.rows, limits.bytes, streamingMode, 1, snapshot, reverse ), [](Reference<CFuture> f) {
 				FDBKeyValue const* kv;
 				int count;
@@ -275,89 +348,89 @@ namespace FDB {
 
 				return FDBStandalone<RangeResultRef>( f, RangeResultRef( VectorRef<KeyValueRef>( (KeyValueRef*)kv, count ), more ) );
 			} );
-	}
+    }
 
-	void Transaction::addReadConflictRange( KeyRangeRef const& keys ) {
-		throw_on_error( fdb_transaction_add_conflict_range( tr, keys.begin.begin(), keys.begin.size(), keys.end.begin(), keys.end.size(), FDB_CONFLICT_RANGE_TYPE_READ ) );
-	}
+    void TransactionImpl::addReadConflictRange(KeyRangeRef const& keys) {
+	    throw_on_error( fdb_transaction_add_conflict_range( tr, keys.begin.begin(), keys.begin.size(), keys.end.begin(), keys.end.size(), FDB_CONFLICT_RANGE_TYPE_READ ) );
+    }
 
-	void Transaction::addReadConflictKey( KeyRef const& key ) {
-		return addReadConflictRange(KeyRange(KeyRangeRef(key, keyAfter(key))));
-	}
+    void TransactionImpl::addReadConflictKey(KeyRef const& key) {
+	    return addReadConflictRange(KeyRange(KeyRangeRef(key, keyAfter(key))));
+    }
 
-	void Transaction::addWriteConflictRange( KeyRangeRef const& keys ) {
-		throw_on_error( fdb_transaction_add_conflict_range( tr, keys.begin.begin(), keys.begin.size(), keys.end.begin(), keys.end.size(), FDB_CONFLICT_RANGE_TYPE_WRITE ) );
-	}
+    void TransactionImpl::addWriteConflictRange(KeyRangeRef const& keys) {
+	    throw_on_error( fdb_transaction_add_conflict_range( tr, keys.begin.begin(), keys.begin.size(), keys.end.begin(), keys.end.size(), FDB_CONFLICT_RANGE_TYPE_WRITE ) );
+    }
 
-	void Transaction::addWriteConflictKey( KeyRef const& key ) {
-		return addWriteConflictRange(KeyRange(KeyRangeRef(key, keyAfter(key))));
-	}
+    void TransactionImpl::addWriteConflictKey(KeyRef const& key) {
+	    return addWriteConflictRange(KeyRange(KeyRangeRef(key, keyAfter(key))));
+    }
 
-	void Transaction::atomicOp( const KeyRef& key, const ValueRef& operand, FDBMutationType operationType ) {
-		fdb_transaction_atomic_op( tr, key.begin(), key.size(), operand.begin(), operand.size(), operationType );
-	}
+    void TransactionImpl::atomicOp(const KeyRef& key, const ValueRef& operand, FDBMutationType operationType) {
+	    fdb_transaction_atomic_op( tr, key.begin(), key.size(), operand.begin(), operand.size(), operationType );
+    }
 
-	void Transaction::set( const KeyRef& key, const ValueRef& value ) {
-		fdb_transaction_set( tr, key.begin(), key.size(), value.begin(), value.size() );
-	}
+    void TransactionImpl::set(const KeyRef& key, const ValueRef& value) {
+	    fdb_transaction_set( tr, key.begin(), key.size(), value.begin(), value.size() );
+    }
 
-	void Transaction::clear( const KeyRangeRef& range ) {
-		fdb_transaction_clear_range( tr, range.begin.begin(), range.begin.size(), range.end.begin(), range.end.size() );
-	}
+    void TransactionImpl::clear(const KeyRangeRef& range) {
+	    fdb_transaction_clear_range( tr, range.begin.begin(), range.begin.size(), range.end.begin(), range.end.size() );
+    }
 
-	void Transaction::clear( const KeyRef& key ) {
-		fdb_transaction_clear( tr, key.begin(), key.size() );
-	}
+    void TransactionImpl::clear(const KeyRef& key) {
+	    fdb_transaction_clear( tr, key.begin(), key.size() );
+    }
 
-	Future<Void> Transaction::commit() {
-		return backToFuture< Void >( fdb_transaction_commit( tr ), [](Reference<CFuture> f) {
+    Future<Void> TransactionImpl::commit() {
+	    return backToFuture< Void >( fdb_transaction_commit( tr ), [](Reference<CFuture> f) {
 				throw_on_error( fdb_future_get_error( f->f ) );
 				return Void();
 			} );
-	}
+    }
 
-	Version Transaction::getCommittedVersion() {
-		Version v;
+    Version TransactionImpl::getCommittedVersion() {
+	    Version v;
 
 		throw_on_error( fdb_transaction_get_committed_version( tr, &v ) );
 		return v;
-	}
+    }
 
-	Future<FDBStandalone<StringRef>> Transaction::getVersionstamp() {
-			return backToFuture< FDBStandalone<KeyRef> >( fdb_transaction_get_versionstamp( tr ), [](Reference<CFuture> f) {
+    Future<FDBStandalone<StringRef>> TransactionImpl::getVersionstamp() {
+	    return backToFuture<FDBStandalone<KeyRef>>(fdb_transaction_get_versionstamp(tr), [](Reference<CFuture> f) {
 			uint8_t const* key;
 			int key_length;
 
 			throw_on_error( fdb_future_get_key( f->f, &key, &key_length ) );
 
 			return FDBStandalone<StringRef>( f, StringRef( key, key_length ) );
-		} );
-	}
+	    });
+    }
 
-	void Transaction::setOption( FDBTransactionOption option, Optional<StringRef> value ) {
-		if ( value.present() ) {
+    void TransactionImpl::setOption(FDBTransactionOption option, Optional<StringRef> value) {
+	    if ( value.present() ) {
 			throw_on_error( fdb_transaction_set_option( tr, option, value.get().begin(), value.get().size() ) );
 		} else {
 			throw_on_error( fdb_transaction_set_option( tr, option, NULL, 0 ) );
 		}
-	}
+    }
 
-	Future<Void> Transaction::onError( Error const& e ) {
-		return backToFuture< Void >( fdb_transaction_on_error( tr, e.code() ), [](Reference<CFuture> f) {
+    Future<Void> TransactionImpl::onError(Error const& e) {
+	    return backToFuture< Void >( fdb_transaction_on_error( tr, e.code() ), [](Reference<CFuture> f) {
 				throw_on_error( fdb_future_get_error( f->f ) );
 				return Void();
 			} );
-	}
+    }
 
-	void Transaction::cancel() {
-		fdb_transaction_cancel( tr );
-	}
+    void TransactionImpl::cancel() {
+	    fdb_transaction_cancel( tr );
+    }
 
-	void Transaction::reset() {
-		fdb_transaction_reset( tr );
-	}
+    void TransactionImpl::reset() {
+	    fdb_transaction_reset( tr );
+    }
 
-	std::string printable( const StringRef& val ) {
+    std::string printable( const StringRef& val ) {
 		std::string s;
 		for(int i=0; i<val.size(); i++) {
 			uint8_t b = val[i];

--- a/bindings/flow/fdb_flow.actor.cpp
+++ b/bindings/flow/fdb_flow.actor.cpp
@@ -335,9 +335,7 @@ namespace FDB {
 			} );
 	}
 
-	Future<FDBStandalone<RangeResultRef>> TransactionImpl::getRange(const KeySelector& begin, const KeySelector& end,
-																	GetRangeLimits limits, bool snapshot, bool reverse,
-																	FDBStreamingMode streamingMode) {
+	Future<FDBStandalone<RangeResultRef>> TransactionImpl::getRange(const KeySelector& begin, const KeySelector& end, GetRangeLimits limits, bool snapshot, bool reverse, FDBStreamingMode streamingMode) {
 		// FIXME: iteration
 		return backToFuture< FDBStandalone<RangeResultRef> >( fdb_transaction_get_range( tr, begin.key.begin(), begin.key.size(), begin.orEqual, begin.offset, end.key.begin(), end.key.size(), end.orEqual, end.offset, limits.rows, limits.bytes, streamingMode, 1, snapshot, reverse ), [](Reference<CFuture> f) {
 				FDBKeyValue const* kv;

--- a/bindings/flow/fdb_flow.actor.cpp
+++ b/bindings/flow/fdb_flow.actor.cpp
@@ -98,83 +98,83 @@ void fdb_flow_test() {
 }
 
 namespace FDB {
-class DatabaseImpl : public Database, NonCopyable {
-public:
-	virtual ~DatabaseImpl() { fdb_database_destroy(db); }
+	class DatabaseImpl : public Database, NonCopyable {
+	public:
+		virtual ~DatabaseImpl() { fdb_database_destroy(db); }
 
-	Reference<Transaction> createTransaction() override;
-	void setDatabaseOption(FDBDatabaseOption option, Optional<StringRef> value = Optional<StringRef>()) override;
+		Reference<Transaction> createTransaction() override;
+		void setDatabaseOption(FDBDatabaseOption option, Optional<StringRef> value = Optional<StringRef>()) override;
 
-private:
-	FDBDatabase* db;
-	explicit DatabaseImpl(FDBDatabase* db) : db(db) {}
+	private:
+		FDBDatabase* db;
+		explicit DatabaseImpl(FDBDatabase* db) : db(db) {}
 
-	friend class API;
-};
+		friend class API;
+	};
 
-class TransactionImpl : public Transaction, private NonCopyable, public FastAllocated<TransactionImpl> {
-	friend class DatabaseImpl;
+	class TransactionImpl : public Transaction, private NonCopyable, public FastAllocated<TransactionImpl> {
+		friend class DatabaseImpl;
 
-public:
-	virtual ~TransactionImpl() {
-		if (tr) {
-			fdb_transaction_destroy(tr);
+	public:
+		virtual ~TransactionImpl() {
+			if (tr) {
+				fdb_transaction_destroy(tr);
+			}
 		}
-	}
 
-	void setReadVersion(Version v) override;
-	Future<Version> getReadVersion() override;
+		void setReadVersion(Version v) override;
+		Future<Version> getReadVersion() override;
 
-	Future<Optional<FDBStandalone<ValueRef>>> get(const Key& key, bool snapshot = false) override;
-	Future<FDBStandalone<KeyRef>> getKey(const KeySelector& key, bool snapshot = false) override;
+		Future<Optional<FDBStandalone<ValueRef>>> get(const Key& key, bool snapshot = false) override;
+		Future<FDBStandalone<KeyRef>> getKey(const KeySelector& key, bool snapshot = false) override;
 
-	Future<Void> watch(const Key& key) override;
+		Future<Void> watch(const Key& key) override;
 
-	using Transaction::getRange;
-	Future<FDBStandalone<RangeResultRef>> getRange(const KeySelector& begin, const KeySelector& end,
-	                                               GetRangeLimits limits = GetRangeLimits(), bool snapshot = false,
-	                                               bool reverse = false,
-	                                               FDBStreamingMode streamingMode = FDB_STREAMING_MODE_SERIAL) override;
+		using Transaction::getRange;
+		Future<FDBStandalone<RangeResultRef>> getRange(const KeySelector& begin, const KeySelector& end,
+													   GetRangeLimits limits = GetRangeLimits(), bool snapshot = false,
+													   bool reverse = false,
+													   FDBStreamingMode streamingMode = FDB_STREAMING_MODE_SERIAL) override;
 
-	void addReadConflictRange(KeyRangeRef const& keys) override;
-	void addReadConflictKey(KeyRef const& key) override;
-	void addWriteConflictRange(KeyRangeRef const& keys) override;
-	void addWriteConflictKey(KeyRef const& key) override;
+		void addReadConflictRange(KeyRangeRef const& keys) override;
+		void addReadConflictKey(KeyRef const& key) override;
+		void addWriteConflictRange(KeyRangeRef const& keys) override;
+		void addWriteConflictKey(KeyRef const& key) override;
 
-	void atomicOp(const KeyRef& key, const ValueRef& operand, FDBMutationType operationType) override;
-	void set(const KeyRef& key, const ValueRef& value) override;
-	void clear(const KeyRangeRef& range) override;
-	void clear(const KeyRef& key) override;
+		void atomicOp(const KeyRef& key, const ValueRef& operand, FDBMutationType operationType) override;
+		void set(const KeyRef& key, const ValueRef& value) override;
+		void clear(const KeyRangeRef& range) override;
+		void clear(const KeyRef& key) override;
 
-	Future<Void> commit() override;
-	Version getCommittedVersion() override;
-	Future<FDBStandalone<StringRef>> getVersionstamp() override;
+		Future<Void> commit() override;
+		Version getCommittedVersion() override;
+		Future<FDBStandalone<StringRef>> getVersionstamp() override;
 
-	void setOption(FDBTransactionOption option, Optional<StringRef> value = Optional<StringRef>()) override;
+		void setOption(FDBTransactionOption option, Optional<StringRef> value = Optional<StringRef>()) override;
 
-	Future<Void> onError(Error const& e) override;
+		Future<Void> onError(Error const& e) override;
 
-	void cancel() override;
-	void reset() override;
+		void cancel() override;
+		void reset() override;
 
-	TransactionImpl() : tr(NULL) {}
-	TransactionImpl(TransactionImpl&& r) noexcept(true) {
-		tr = r.tr;
-		r.tr = NULL;
-	}
-	TransactionImpl& operator=(TransactionImpl&& r) noexcept(true) {
-		tr = r.tr;
-		r.tr = NULL;
-		return *this;
-	}
+		TransactionImpl() : tr(NULL) {}
+		TransactionImpl(TransactionImpl&& r) noexcept(true) {
+			tr = r.tr;
+			r.tr = NULL;
+		}
+		TransactionImpl& operator=(TransactionImpl&& r) noexcept(true) {
+			tr = r.tr;
+			r.tr = NULL;
+			return *this;
+		}
 
-private:
-	FDBTransaction* tr;
+	private:
+		FDBTransaction* tr;
 
-	explicit TransactionImpl(FDBDatabase* db);
-};
+		explicit TransactionImpl(FDBDatabase* db);
+	};
 
-    static inline void throw_on_error( fdb_error_t e ) {
+	static inline void throw_on_error( fdb_error_t e ) {
 		if (e)
 			throw Error(e);
 	}
@@ -262,47 +262,47 @@ private:
 		return fdb_error_predicate( pred, e.code() );
 	}
 
-    Reference<Database> API::createDatabase(std::string const& connFilename) {
-	    FDBDatabase *db;
+	Reference<Database> API::createDatabase(std::string const& connFilename) {
+		FDBDatabase *db;
 		throw_on_error(fdb_create_database(connFilename.c_str(), &db));
-	    return Reference<Database>(new DatabaseImpl(db));
-    }
+		return Reference<Database>(new DatabaseImpl(db));
+	}
 
-    int API::getAPIVersion() const {
+	int API::getAPIVersion() const {
 		return version;
 	}
 
-    Reference<Transaction> DatabaseImpl::createTransaction() {
-	    return Reference<Transaction>(new TransactionImpl(db));
-    }
+	Reference<Transaction> DatabaseImpl::createTransaction() {
+		return Reference<Transaction>(new TransactionImpl(db));
+	}
 
-    void DatabaseImpl::setDatabaseOption(FDBDatabaseOption option, Optional<StringRef> value) {
-	    if (value.present())
+	void DatabaseImpl::setDatabaseOption(FDBDatabaseOption option, Optional<StringRef> value) {
+		if (value.present())
 			throw_on_error(fdb_database_set_option(db, option, value.get().begin(), value.get().size()));
 		else
 			throw_on_error(fdb_database_set_option(db, option, NULL, 0));
-    }
+	}
 
-    TransactionImpl::TransactionImpl(FDBDatabase* db) {
-	    throw_on_error(fdb_database_create_transaction(db, &tr));
-    }
+	TransactionImpl::TransactionImpl(FDBDatabase* db) {
+		throw_on_error(fdb_database_create_transaction(db, &tr));
+	}
 
-    void TransactionImpl::setReadVersion(Version v) {
-	    fdb_transaction_set_read_version( tr, v );
-    }
+	void TransactionImpl::setReadVersion(Version v) {
+		fdb_transaction_set_read_version( tr, v );
+	}
 
-    Future<Version> TransactionImpl::getReadVersion() {
-	    return backToFuture<Version>( fdb_transaction_get_read_version( tr ), [](Reference<CFuture> f){
+	Future<Version> TransactionImpl::getReadVersion() {
+		return backToFuture<Version>( fdb_transaction_get_read_version( tr ), [](Reference<CFuture> f){
 				Version value;
 
 				throw_on_error( fdb_future_get_version( f->f, &value ) );
 
 				return value;
 			} );
-    }
+	}
 
-    Future<Optional<FDBStandalone<ValueRef>>> TransactionImpl::get(const Key& key, bool snapshot) {
-	    return backToFuture< Optional<FDBStandalone<ValueRef>> >( fdb_transaction_get( tr, key.begin(), key.size(), snapshot ), [](Reference<CFuture> f) {
+	Future<Optional<FDBStandalone<ValueRef>>> TransactionImpl::get(const Key& key, bool snapshot) {
+		return backToFuture< Optional<FDBStandalone<ValueRef>> >( fdb_transaction_get( tr, key.begin(), key.size(), snapshot ), [](Reference<CFuture> f) {
 				fdb_bool_t present;
 				uint8_t const* value;
 				int value_length;
@@ -315,17 +315,17 @@ private:
 					return Optional<FDBStandalone<ValueRef>>();
 				}
 			} );
-    }
+	}
 
-    Future<Void> TransactionImpl::watch(const Key& key) {
-	    return backToFuture< Void >( fdb_transaction_watch( tr, key.begin(), key.size() ), [](Reference<CFuture> f) {
+	Future<Void> TransactionImpl::watch(const Key& key) {
+		return backToFuture< Void >( fdb_transaction_watch( tr, key.begin(), key.size() ), [](Reference<CFuture> f) {
 				throw_on_error( fdb_future_get_error( f->f ) );
 				return Void();
 			} );
-    }
+	}
 
-    Future<FDBStandalone<KeyRef>> TransactionImpl::getKey(const KeySelector& key, bool snapshot) {
-	    return backToFuture< FDBStandalone<KeyRef> >( fdb_transaction_get_key( tr, key.key.begin(), key.key.size(), key.orEqual, key.offset, snapshot ), [](Reference<CFuture> f) {
+	Future<FDBStandalone<KeyRef>> TransactionImpl::getKey(const KeySelector& key, bool snapshot) {
+		return backToFuture< FDBStandalone<KeyRef> >( fdb_transaction_get_key( tr, key.key.begin(), key.key.size(), key.orEqual, key.offset, snapshot ), [](Reference<CFuture> f) {
 				uint8_t const* key;
 				int key_length;
 
@@ -333,12 +333,12 @@ private:
 
 				return FDBStandalone<KeyRef>( f, KeyRef( key, key_length ) );
 			} );
-    }
+	}
 
-    Future<FDBStandalone<RangeResultRef>> TransactionImpl::getRange(const KeySelector& begin, const KeySelector& end,
-                                                                    GetRangeLimits limits, bool snapshot, bool reverse,
-                                                                    FDBStreamingMode streamingMode) {
-	    // FIXME: iteration
+	Future<FDBStandalone<RangeResultRef>> TransactionImpl::getRange(const KeySelector& begin, const KeySelector& end,
+																	GetRangeLimits limits, bool snapshot, bool reverse,
+																	FDBStreamingMode streamingMode) {
+		// FIXME: iteration
 		return backToFuture< FDBStandalone<RangeResultRef> >( fdb_transaction_get_range( tr, begin.key.begin(), begin.key.size(), begin.orEqual, begin.offset, end.key.begin(), end.key.size(), end.orEqual, end.offset, limits.rows, limits.bytes, streamingMode, 1, snapshot, reverse ), [](Reference<CFuture> f) {
 				FDBKeyValue const* kv;
 				int count;
@@ -348,89 +348,89 @@ private:
 
 				return FDBStandalone<RangeResultRef>( f, RangeResultRef( VectorRef<KeyValueRef>( (KeyValueRef*)kv, count ), more ) );
 			} );
-    }
+	}
 
-    void TransactionImpl::addReadConflictRange(KeyRangeRef const& keys) {
-	    throw_on_error( fdb_transaction_add_conflict_range( tr, keys.begin.begin(), keys.begin.size(), keys.end.begin(), keys.end.size(), FDB_CONFLICT_RANGE_TYPE_READ ) );
-    }
+	void TransactionImpl::addReadConflictRange(KeyRangeRef const& keys) {
+		throw_on_error( fdb_transaction_add_conflict_range( tr, keys.begin.begin(), keys.begin.size(), keys.end.begin(), keys.end.size(), FDB_CONFLICT_RANGE_TYPE_READ ) );
+	}
 
-    void TransactionImpl::addReadConflictKey(KeyRef const& key) {
-	    return addReadConflictRange(KeyRange(KeyRangeRef(key, keyAfter(key))));
-    }
+	void TransactionImpl::addReadConflictKey(KeyRef const& key) {
+		return addReadConflictRange(KeyRange(KeyRangeRef(key, keyAfter(key))));
+	}
 
-    void TransactionImpl::addWriteConflictRange(KeyRangeRef const& keys) {
-	    throw_on_error( fdb_transaction_add_conflict_range( tr, keys.begin.begin(), keys.begin.size(), keys.end.begin(), keys.end.size(), FDB_CONFLICT_RANGE_TYPE_WRITE ) );
-    }
+	void TransactionImpl::addWriteConflictRange(KeyRangeRef const& keys) {
+		throw_on_error( fdb_transaction_add_conflict_range( tr, keys.begin.begin(), keys.begin.size(), keys.end.begin(), keys.end.size(), FDB_CONFLICT_RANGE_TYPE_WRITE ) );
+	}
 
-    void TransactionImpl::addWriteConflictKey(KeyRef const& key) {
-	    return addWriteConflictRange(KeyRange(KeyRangeRef(key, keyAfter(key))));
-    }
+	void TransactionImpl::addWriteConflictKey(KeyRef const& key) {
+		return addWriteConflictRange(KeyRange(KeyRangeRef(key, keyAfter(key))));
+	}
 
-    void TransactionImpl::atomicOp(const KeyRef& key, const ValueRef& operand, FDBMutationType operationType) {
-	    fdb_transaction_atomic_op( tr, key.begin(), key.size(), operand.begin(), operand.size(), operationType );
-    }
+	void TransactionImpl::atomicOp(const KeyRef& key, const ValueRef& operand, FDBMutationType operationType) {
+		fdb_transaction_atomic_op( tr, key.begin(), key.size(), operand.begin(), operand.size(), operationType );
+	}
 
-    void TransactionImpl::set(const KeyRef& key, const ValueRef& value) {
-	    fdb_transaction_set( tr, key.begin(), key.size(), value.begin(), value.size() );
-    }
+	void TransactionImpl::set(const KeyRef& key, const ValueRef& value) {
+		fdb_transaction_set( tr, key.begin(), key.size(), value.begin(), value.size() );
+	}
 
-    void TransactionImpl::clear(const KeyRangeRef& range) {
-	    fdb_transaction_clear_range( tr, range.begin.begin(), range.begin.size(), range.end.begin(), range.end.size() );
-    }
+	void TransactionImpl::clear(const KeyRangeRef& range) {
+		fdb_transaction_clear_range( tr, range.begin.begin(), range.begin.size(), range.end.begin(), range.end.size() );
+	}
 
-    void TransactionImpl::clear(const KeyRef& key) {
-	    fdb_transaction_clear( tr, key.begin(), key.size() );
-    }
+	void TransactionImpl::clear(const KeyRef& key) {
+		fdb_transaction_clear( tr, key.begin(), key.size() );
+	}
 
-    Future<Void> TransactionImpl::commit() {
-	    return backToFuture< Void >( fdb_transaction_commit( tr ), [](Reference<CFuture> f) {
+	Future<Void> TransactionImpl::commit() {
+		return backToFuture< Void >( fdb_transaction_commit( tr ), [](Reference<CFuture> f) {
 				throw_on_error( fdb_future_get_error( f->f ) );
 				return Void();
 			} );
-    }
+	}
 
-    Version TransactionImpl::getCommittedVersion() {
-	    Version v;
+	Version TransactionImpl::getCommittedVersion() {
+		Version v;
 
 		throw_on_error( fdb_transaction_get_committed_version( tr, &v ) );
 		return v;
-    }
+	}
 
-    Future<FDBStandalone<StringRef>> TransactionImpl::getVersionstamp() {
-	    return backToFuture<FDBStandalone<KeyRef>>(fdb_transaction_get_versionstamp(tr), [](Reference<CFuture> f) {
+	Future<FDBStandalone<StringRef>> TransactionImpl::getVersionstamp() {
+		return backToFuture<FDBStandalone<KeyRef>>(fdb_transaction_get_versionstamp(tr), [](Reference<CFuture> f) {
 			uint8_t const* key;
 			int key_length;
 
 			throw_on_error( fdb_future_get_key( f->f, &key, &key_length ) );
 
 			return FDBStandalone<StringRef>( f, StringRef( key, key_length ) );
-	    });
-    }
+		});
+	}
 
-    void TransactionImpl::setOption(FDBTransactionOption option, Optional<StringRef> value) {
-	    if ( value.present() ) {
+	void TransactionImpl::setOption(FDBTransactionOption option, Optional<StringRef> value) {
+		if ( value.present() ) {
 			throw_on_error( fdb_transaction_set_option( tr, option, value.get().begin(), value.get().size() ) );
 		} else {
 			throw_on_error( fdb_transaction_set_option( tr, option, NULL, 0 ) );
 		}
-    }
+	}
 
-    Future<Void> TransactionImpl::onError(Error const& e) {
-	    return backToFuture< Void >( fdb_transaction_on_error( tr, e.code() ), [](Reference<CFuture> f) {
+	Future<Void> TransactionImpl::onError(Error const& e) {
+		return backToFuture< Void >( fdb_transaction_on_error( tr, e.code() ), [](Reference<CFuture> f) {
 				throw_on_error( fdb_future_get_error( f->f ) );
 				return Void();
 			} );
-    }
+	}
 
-    void TransactionImpl::cancel() {
-	    fdb_transaction_cancel( tr );
-    }
+	void TransactionImpl::cancel() {
+		fdb_transaction_cancel( tr );
+	}
 
-    void TransactionImpl::reset() {
-	    fdb_transaction_reset( tr );
-    }
+	void TransactionImpl::reset() {
+		fdb_transaction_reset( tr );
+	}
 
-    std::string printable( const StringRef& val ) {
+	std::string printable( const StringRef& val ) {
 		std::string s;
 		for(int i=0; i<val.size(); i++) {
 			uint8_t b = val[i];

--- a/bindings/flow/fdb_flow.h
+++ b/bindings/flow/fdb_flow.h
@@ -30,69 +30,10 @@
 #include "FDBLoanerTypes.h"
 
 namespace FDB {
-
-	class DatabaseContext : public ReferenceCounted<DatabaseContext>, NonCopyable {
-		friend class Cluster;
-		friend class Transaction;
-	public:
-		~DatabaseContext() {
-			fdb_database_destroy( db );
-		}
-
-		void setDatabaseOption(FDBDatabaseOption option, Optional<StringRef> value = Optional<StringRef>());
-
-	private:
-		FDBDatabase* db;
-		explicit DatabaseContext( FDBDatabase* db ) : db(db) {}
-
-		friend class API;
-	};
-
-	// Deprecated: Use createDatabase instead.
-	class Cluster : public ReferenceCounted<Cluster>, NonCopyable {
-	public:
-		~Cluster() {}
-
-		Reference<DatabaseContext> createDatabase();
-
-	private:
-		explicit Cluster( std::string connFilename ) : connFilename(connFilename) {}
-
-		std::string connFilename;
-		friend class API;
-	};
-
-	class API {
-	public:
-		static API* selectAPIVersion(int apiVersion);
-		static API* getInstance();
-		static bool isAPIVersionSelected();
-
-		void setNetworkOption(FDBNetworkOption option, Optional<StringRef> value = Optional<StringRef>());
-
-		void setupNetwork();
-		void runNetwork();
-		void stopNetwork();
-
-		// Deprecated: Use createDatabase instead.
-		Reference<Cluster> createCluster( std::string const& connFilename );
-
-		Reference<DatabaseContext> createDatabase( std::string const& connFilename="" );
-
-		bool evaluatePredicate(FDBErrorPredicate pred, Error const& e);
-		int getAPIVersion() const;
-
-	private:
-		static API* instance;
-
-		API(int version);
-		int version;
-	};
-
 	struct CFuture : NonCopyable, ReferenceCounted<CFuture>, FastAllocated<CFuture> {
 		CFuture() : f(NULL) {}
-		explicit CFuture( FDBFuture* f ) : f(f) {}
-		~CFuture() {
+	    explicit CFuture(FDBFuture* f) : f(f) {}
+	    ~CFuture() {
 			if (f) {
 				fdb_future_destroy(f);
 			}
@@ -106,84 +47,103 @@ namespace FDB {
 	template <class T>
 	class FDBStandalone : public T {
 	public:
-		FDBStandalone() {}
-		FDBStandalone( Reference<CFuture> f, T const& t ) : T(t), f(f) {}
-		FDBStandalone( FDBStandalone const& o ) : T((T const&)o), f(o.f) {}
+	    FDBStandalone() {}
+	    FDBStandalone(Reference<CFuture> f, T const& t) : T(t), f(f) {}
+	    FDBStandalone(FDBStandalone const& o) : T((T const&)o), f(o.f) {}
+
 	private:
-		Reference<CFuture> f;
+	    Reference<CFuture> f;
 	};
 
-	class Transaction : public ReferenceCounted<Transaction>, private NonCopyable, public FastAllocated<Transaction> {
+    class ReadTransaction : public ReferenceCounted<ReadTransaction> {
 	public:
-		explicit Transaction( Reference<DatabaseContext> const& db );
-		~Transaction() {
-			if (tr) {
-				fdb_transaction_destroy(tr);
-			}
-		}
+	    virtual ~ReadTransaction(){};
+	    virtual void setReadVersion(Version v) = 0;
+	    virtual Future<Version> getReadVersion() = 0;
 
-		void setVersion( Version v );
-		Future<Version> getReadVersion();
+	    virtual Future<Optional<FDBStandalone<ValueRef>>> get(const Key& key, bool snapshot = false) = 0;
+	    virtual Future<FDBStandalone<KeyRef>> getKey(const KeySelector& key, bool snapshot = false) = 0;
+	    virtual Future<Void> watch(const Key& key) = 0;
 
-		Future< Optional<FDBStandalone<ValueRef>> > get( const Key& key, bool snapshot = false );
-		Future< Void > watch( const Key& key );
-		Future< FDBStandalone<KeyRef> > getKey( const KeySelector& key, bool snapshot = false );
-		Future< FDBStandalone<RangeResultRef> > getRange( const KeySelector& begin, const KeySelector& end, GetRangeLimits limits = GetRangeLimits(), bool snapshot = false, bool reverse = false, FDBStreamingMode streamingMode = FDB_STREAMING_MODE_SERIAL);
-		Future< FDBStandalone<RangeResultRef> > getRange( const KeySelector& begin, const KeySelector& end, int limit, bool snapshot = false, bool reverse = false, FDBStreamingMode streamingMode = FDB_STREAMING_MODE_SERIAL ) {
-			return getRange( begin, end, GetRangeLimits(limit), snapshot, reverse, streamingMode );
-		}
-		Future< FDBStandalone<RangeResultRef> > getRange( const KeyRange& keys, int limit, bool snapshot = false, bool reverse = false, FDBStreamingMode streamingMode = FDB_STREAMING_MODE_SERIAL ) {
-			return getRange( KeySelector( firstGreaterOrEqual(keys.begin), keys.arena() ),
-							 KeySelector( firstGreaterOrEqual(keys.end), keys.arena() ),
-							 limit, snapshot, reverse, streamingMode );
-		}
-		Future< FDBStandalone<RangeResultRef> > getRange( const KeyRange& keys, GetRangeLimits limits = GetRangeLimits(), bool snapshot = false, bool reverse = false, FDBStreamingMode streamingMode = FDB_STREAMING_MODE_SERIAL ) {
-			return getRange( KeySelector( firstGreaterOrEqual(keys.begin), keys.arena() ),
-							 KeySelector( firstGreaterOrEqual(keys.end), keys.arena() ),
-							 limits, snapshot, reverse, streamingMode );
-		}
+	    virtual Future<FDBStandalone<RangeResultRef>> getRange(
+	        const KeySelector& begin, const KeySelector& end, GetRangeLimits limits = GetRangeLimits(),
+	        bool snapshot = false, bool reverse = false,
+	        FDBStreamingMode streamingMode = FDB_STREAMING_MODE_SERIAL) = 0;
+	    virtual Future<FDBStandalone<RangeResultRef>> getRange(
+	        const KeySelector& begin, const KeySelector& end, int limit, bool snapshot = false, bool reverse = false,
+	        FDBStreamingMode streamingMode = FDB_STREAMING_MODE_SERIAL) {
+		    return getRange(begin, end, GetRangeLimits(limit), snapshot, reverse, streamingMode);
+	    }
+	    virtual Future<FDBStandalone<RangeResultRef>> getRange(
+	        const KeyRange& keys, int limit, bool snapshot = false, bool reverse = false,
+	        FDBStreamingMode streamingMode = FDB_STREAMING_MODE_SERIAL) {
+		    return getRange(KeySelector(firstGreaterOrEqual(keys.begin), keys.arena()),
+		                    KeySelector(firstGreaterOrEqual(keys.end), keys.arena()), limit, snapshot, reverse,
+		                    streamingMode);
+	    }
+	    virtual Future<FDBStandalone<RangeResultRef>> getRange(
+	        const KeyRange& keys, GetRangeLimits limits = GetRangeLimits(), bool snapshot = false, bool reverse = false,
+	        FDBStreamingMode streamingMode = FDB_STREAMING_MODE_SERIAL) {
+		    return getRange(KeySelector(firstGreaterOrEqual(keys.begin), keys.arena()),
+		                    KeySelector(firstGreaterOrEqual(keys.end), keys.arena()), limits, snapshot, reverse,
+		                    streamingMode);
+	    }
 
-		// Future< Standalone<VectorRef<const char*>> > getAddressesForKey(const Key& key);
+	    virtual void addReadConflictRange(KeyRangeRef const& keys) = 0;
+	    virtual void addReadConflictKey(KeyRef const& key) = 0;
 
-		void addReadConflictRange( KeyRangeRef const& keys );
-		void addReadConflictKey( KeyRef const& key );
-		void addWriteConflictRange( KeyRangeRef const& keys );
-		void addWriteConflictKey( KeyRef const& key );
-		// void makeSelfConflicting() { tr.makeSelfConflicting(); }
+	    virtual void setOption(FDBTransactionOption option, Optional<StringRef> value = Optional<StringRef>()) = 0;
 
-		void atomicOp( const KeyRef& key, const ValueRef& operand, FDBMutationType operationType );
-		void set( const KeyRef& key, const ValueRef& value );
-		void clear( const KeyRangeRef& range );
-		void clear( const KeyRef& key );
+	    virtual Future<Void> onError(Error const& e) = 0;
 
-		Future<Void> commit();
-		Version getCommittedVersion();
-		Future<FDBStandalone<StringRef>> getVersionstamp();
+	    virtual void cancel() = 0;
+	    virtual void reset() = 0;
+    };
 
-		void setOption( FDBTransactionOption option, Optional<StringRef> value = Optional<StringRef>() );
+    class Transaction : public ReadTransaction {
+	public:
+	    virtual void addWriteConflictRange(KeyRangeRef const& keys) = 0;
+	    virtual void addWriteConflictKey(KeyRef const& key) = 0;
 
-		Future<Void> onError( Error const& e );
+	    virtual void atomicOp(const KeyRef& key, const ValueRef& operand, FDBMutationType operationType) = 0;
+	    virtual void set(const KeyRef& key, const ValueRef& value) = 0;
+	    virtual void clear(const KeyRangeRef& range) = 0;
+	    virtual void clear(const KeyRef& key) = 0;
 
-		void cancel();
-		void reset();
-		// double getBackoff() { return tr.getBackoff(); }
-		// void debugTransaction(UID dID) { tr.debugTransaction(dID); }
+	    virtual Future<Void> commit() = 0;
+	    virtual Version getCommittedVersion() = 0;
+	    virtual Future<FDBStandalone<StringRef>> getVersionstamp() = 0;
+    };
 
-		Transaction() : tr(NULL) {}
-		Transaction( Transaction&& r ) noexcept(true) {
-			tr = r.tr;
-			r.tr = NULL;
-		}
-		Transaction& operator=( Transaction&& r ) noexcept(true) {
-			tr = r.tr;
-			r.tr = NULL;
-			return *this;
-		}
+    class Database : public ReferenceCounted<Database> {
+	public:
+	    virtual ~Database(){};
+	    virtual Reference<Transaction> createTransaction() = 0;
+	    virtual void setDatabaseOption(FDBDatabaseOption option, Optional<StringRef> value = Optional<StringRef>()) = 0;
+    };
+
+    class API {
+	public:
+	    static API* selectAPIVersion(int apiVersion);
+	    static API* getInstance();
+	    static bool isAPIVersionSelected();
+
+	    void setNetworkOption(FDBNetworkOption option, Optional<StringRef> value = Optional<StringRef>());
+
+	    void setupNetwork();
+	    void runNetwork();
+	    void stopNetwork();
+
+	    Reference<Database> createDatabase(std::string const& connFilename = "");
+
+	    bool evaluatePredicate(FDBErrorPredicate pred, Error const& e);
+	    int getAPIVersion() const;
 
 	private:
-		FDBTransaction* tr;
-	};
+	    static API* instance;
 
-}
-
-#endif
+	    API(int version);
+	    int version;
+    };
+    } // namespace FDB
+#endif // FDB_FLOW_FDB_FLOW_API_H

--- a/bindings/flow/fdb_flow.h
+++ b/bindings/flow/fdb_flow.h
@@ -146,4 +146,4 @@ namespace FDB {
 		int version;
 	};
 	} // namespace FDB
-#endif // FDB_FLOW_FDB_FLOW_API_H
+#endif // FDB_FLOW_FDB_FLOW_H

--- a/bindings/flow/fdb_flow.h
+++ b/bindings/flow/fdb_flow.h
@@ -32,8 +32,8 @@
 namespace FDB {
 	struct CFuture : NonCopyable, ReferenceCounted<CFuture>, FastAllocated<CFuture> {
 		CFuture() : f(NULL) {}
-	    explicit CFuture(FDBFuture* f) : f(f) {}
-	    ~CFuture() {
+		explicit CFuture(FDBFuture* f) : f(f) {}
+		~CFuture() {
 			if (f) {
 				fdb_future_destroy(f);
 			}
@@ -47,103 +47,103 @@ namespace FDB {
 	template <class T>
 	class FDBStandalone : public T {
 	public:
-	    FDBStandalone() {}
-	    FDBStandalone(Reference<CFuture> f, T const& t) : T(t), f(f) {}
-	    FDBStandalone(FDBStandalone const& o) : T((T const&)o), f(o.f) {}
+		FDBStandalone() {}
+		FDBStandalone(Reference<CFuture> f, T const& t) : T(t), f(f) {}
+		FDBStandalone(FDBStandalone const& o) : T((T const&)o), f(o.f) {}
 
 	private:
-	    Reference<CFuture> f;
+		Reference<CFuture> f;
 	};
 
-    class ReadTransaction : public ReferenceCounted<ReadTransaction> {
+	class ReadTransaction : public ReferenceCounted<ReadTransaction> {
 	public:
-	    virtual ~ReadTransaction(){};
-	    virtual void setReadVersion(Version v) = 0;
-	    virtual Future<Version> getReadVersion() = 0;
+		virtual ~ReadTransaction(){};
+		virtual void setReadVersion(Version v) = 0;
+		virtual Future<Version> getReadVersion() = 0;
 
-	    virtual Future<Optional<FDBStandalone<ValueRef>>> get(const Key& key, bool snapshot = false) = 0;
-	    virtual Future<FDBStandalone<KeyRef>> getKey(const KeySelector& key, bool snapshot = false) = 0;
-	    virtual Future<Void> watch(const Key& key) = 0;
+		virtual Future<Optional<FDBStandalone<ValueRef>>> get(const Key& key, bool snapshot = false) = 0;
+		virtual Future<FDBStandalone<KeyRef>> getKey(const KeySelector& key, bool snapshot = false) = 0;
+		virtual Future<Void> watch(const Key& key) = 0;
 
-	    virtual Future<FDBStandalone<RangeResultRef>> getRange(
-	        const KeySelector& begin, const KeySelector& end, GetRangeLimits limits = GetRangeLimits(),
-	        bool snapshot = false, bool reverse = false,
-	        FDBStreamingMode streamingMode = FDB_STREAMING_MODE_SERIAL) = 0;
-	    virtual Future<FDBStandalone<RangeResultRef>> getRange(
-	        const KeySelector& begin, const KeySelector& end, int limit, bool snapshot = false, bool reverse = false,
-	        FDBStreamingMode streamingMode = FDB_STREAMING_MODE_SERIAL) {
-		    return getRange(begin, end, GetRangeLimits(limit), snapshot, reverse, streamingMode);
-	    }
-	    virtual Future<FDBStandalone<RangeResultRef>> getRange(
-	        const KeyRange& keys, int limit, bool snapshot = false, bool reverse = false,
-	        FDBStreamingMode streamingMode = FDB_STREAMING_MODE_SERIAL) {
-		    return getRange(KeySelector(firstGreaterOrEqual(keys.begin), keys.arena()),
-		                    KeySelector(firstGreaterOrEqual(keys.end), keys.arena()), limit, snapshot, reverse,
-		                    streamingMode);
-	    }
-	    virtual Future<FDBStandalone<RangeResultRef>> getRange(
-	        const KeyRange& keys, GetRangeLimits limits = GetRangeLimits(), bool snapshot = false, bool reverse = false,
-	        FDBStreamingMode streamingMode = FDB_STREAMING_MODE_SERIAL) {
-		    return getRange(KeySelector(firstGreaterOrEqual(keys.begin), keys.arena()),
-		                    KeySelector(firstGreaterOrEqual(keys.end), keys.arena()), limits, snapshot, reverse,
-		                    streamingMode);
-	    }
+		virtual Future<FDBStandalone<RangeResultRef>> getRange(
+			const KeySelector& begin, const KeySelector& end, GetRangeLimits limits = GetRangeLimits(),
+			bool snapshot = false, bool reverse = false,
+			FDBStreamingMode streamingMode = FDB_STREAMING_MODE_SERIAL) = 0;
+		virtual Future<FDBStandalone<RangeResultRef>> getRange(
+			const KeySelector& begin, const KeySelector& end, int limit, bool snapshot = false, bool reverse = false,
+			FDBStreamingMode streamingMode = FDB_STREAMING_MODE_SERIAL) {
+			return getRange(begin, end, GetRangeLimits(limit), snapshot, reverse, streamingMode);
+		}
+		virtual Future<FDBStandalone<RangeResultRef>> getRange(
+			const KeyRange& keys, int limit, bool snapshot = false, bool reverse = false,
+			FDBStreamingMode streamingMode = FDB_STREAMING_MODE_SERIAL) {
+			return getRange(KeySelector(firstGreaterOrEqual(keys.begin), keys.arena()),
+							KeySelector(firstGreaterOrEqual(keys.end), keys.arena()), limit, snapshot, reverse,
+							streamingMode);
+		}
+		virtual Future<FDBStandalone<RangeResultRef>> getRange(
+			const KeyRange& keys, GetRangeLimits limits = GetRangeLimits(), bool snapshot = false, bool reverse = false,
+			FDBStreamingMode streamingMode = FDB_STREAMING_MODE_SERIAL) {
+			return getRange(KeySelector(firstGreaterOrEqual(keys.begin), keys.arena()),
+							KeySelector(firstGreaterOrEqual(keys.end), keys.arena()), limits, snapshot, reverse,
+							streamingMode);
+		}
 
-	    virtual void addReadConflictRange(KeyRangeRef const& keys) = 0;
-	    virtual void addReadConflictKey(KeyRef const& key) = 0;
+		virtual void addReadConflictRange(KeyRangeRef const& keys) = 0;
+		virtual void addReadConflictKey(KeyRef const& key) = 0;
 
-	    virtual void setOption(FDBTransactionOption option, Optional<StringRef> value = Optional<StringRef>()) = 0;
+		virtual void setOption(FDBTransactionOption option, Optional<StringRef> value = Optional<StringRef>()) = 0;
 
-	    virtual Future<Void> onError(Error const& e) = 0;
+		virtual Future<Void> onError(Error const& e) = 0;
 
-	    virtual void cancel() = 0;
-	    virtual void reset() = 0;
-    };
+		virtual void cancel() = 0;
+		virtual void reset() = 0;
+	};
 
-    class Transaction : public ReadTransaction {
+	class Transaction : public ReadTransaction {
 	public:
-	    virtual void addWriteConflictRange(KeyRangeRef const& keys) = 0;
-	    virtual void addWriteConflictKey(KeyRef const& key) = 0;
+		virtual void addWriteConflictRange(KeyRangeRef const& keys) = 0;
+		virtual void addWriteConflictKey(KeyRef const& key) = 0;
 
-	    virtual void atomicOp(const KeyRef& key, const ValueRef& operand, FDBMutationType operationType) = 0;
-	    virtual void set(const KeyRef& key, const ValueRef& value) = 0;
-	    virtual void clear(const KeyRangeRef& range) = 0;
-	    virtual void clear(const KeyRef& key) = 0;
+		virtual void atomicOp(const KeyRef& key, const ValueRef& operand, FDBMutationType operationType) = 0;
+		virtual void set(const KeyRef& key, const ValueRef& value) = 0;
+		virtual void clear(const KeyRangeRef& range) = 0;
+		virtual void clear(const KeyRef& key) = 0;
 
-	    virtual Future<Void> commit() = 0;
-	    virtual Version getCommittedVersion() = 0;
-	    virtual Future<FDBStandalone<StringRef>> getVersionstamp() = 0;
-    };
+		virtual Future<Void> commit() = 0;
+		virtual Version getCommittedVersion() = 0;
+		virtual Future<FDBStandalone<StringRef>> getVersionstamp() = 0;
+	};
 
-    class Database : public ReferenceCounted<Database> {
+	class Database : public ReferenceCounted<Database> {
 	public:
-	    virtual ~Database(){};
-	    virtual Reference<Transaction> createTransaction() = 0;
-	    virtual void setDatabaseOption(FDBDatabaseOption option, Optional<StringRef> value = Optional<StringRef>()) = 0;
-    };
+		virtual ~Database(){};
+		virtual Reference<Transaction> createTransaction() = 0;
+		virtual void setDatabaseOption(FDBDatabaseOption option, Optional<StringRef> value = Optional<StringRef>()) = 0;
+	};
 
-    class API {
+	class API {
 	public:
-	    static API* selectAPIVersion(int apiVersion);
-	    static API* getInstance();
-	    static bool isAPIVersionSelected();
+		static API* selectAPIVersion(int apiVersion);
+		static API* getInstance();
+		static bool isAPIVersionSelected();
 
-	    void setNetworkOption(FDBNetworkOption option, Optional<StringRef> value = Optional<StringRef>());
+		void setNetworkOption(FDBNetworkOption option, Optional<StringRef> value = Optional<StringRef>());
 
-	    void setupNetwork();
-	    void runNetwork();
-	    void stopNetwork();
+		void setupNetwork();
+		void runNetwork();
+		void stopNetwork();
 
-	    Reference<Database> createDatabase(std::string const& connFilename = "");
+		Reference<Database> createDatabase(std::string const& connFilename = "");
 
-	    bool evaluatePredicate(FDBErrorPredicate pred, Error const& e);
-	    int getAPIVersion() const;
+		bool evaluatePredicate(FDBErrorPredicate pred, Error const& e);
+		int getAPIVersion() const;
 
 	private:
-	    static API* instance;
+		static API* instance;
 
-	    API(int version);
-	    int version;
-    };
-    } // namespace FDB
+		API(int version);
+		int version;
+	};
+	} // namespace FDB
 #endif // FDB_FLOW_FDB_FLOW_API_H

--- a/bindings/flow/tester/Tester.actor.h
+++ b/bindings/flow/tester/Tester.actor.h
@@ -199,7 +199,7 @@ struct DirectoryTesterData {
 
 struct FlowTesterData : public ReferenceCounted<FlowTesterData> {
 	FDB::API *api;
-	Reference<FDB::DatabaseContext> db;
+	Reference<FDB::Database> db;
 	Standalone<FDB::RangeResultRef> instructions;
 	Standalone<StringRef> trName;
 	FlowTesterStack stack;


### PR DESCRIPTION
Mail goal of this PR is to make `Transaction` and `Database` interfaces. It allows clients to extend these interfaces. One interesting use case would be to implement a simulated client and test the app with simulated failures. Another nice thing that comes out of this refactoring is `ReadTransaction` interface.

Mostly the interfaces are made to look like Java bindings interfaces. Made the following changes part of this PR.

* Added interfaces `Transaction`, `ReadTransaction` and `Database`.
* Moved implementations into `DatabaseImpl` and `TransactionImpl`.
* Also removed deprecated class `Cluster`.

As we changed the interfaces, especially how we create a transaction, it's going to break the compilation of any app upgrades to this version of flow bindings. It doesn't change any of the fdb_c APIs. So, backward compatibility with old servers is preserved through the multi-version client.