### PR TITLE
Fix the build on -O0.

### DIFF
--- a/fdbserver/workloads/Throttling.actor.cpp
+++ b/fdbserver/workloads/Throttling.actor.cpp
@@ -62,6 +62,9 @@ struct TokenBucket {
 	}
 };
 
+constexpr const double TokenBucket::addTokensInterval;
+constexpr const double TokenBucket::maxSleepTime;
+
 struct ThrottlingWorkload : KVWorkload {
 
 	double testDuration;


### PR DESCRIPTION
C++ < 17 requires definitions of declared static constexpr variables.