### PR TITLE
AsynFileWinASIO: Make error checking consistent with Linux

### DIFF
--- a/fdbrpc/AsyncFileWinASIO.actor.h
+++ b/fdbrpc/AsyncFileWinASIO.actor.h
@@ -43,10 +43,7 @@ public:
 	// FIXME: This implementation isn't actually asynchronous - it just does operations synchronously!
 
 	static Future<Reference<IAsyncFile>> open( std::string filename, int flags, int mode, boost::asio::io_service* ios ) {
-		if (!(flags & OPEN_UNBUFFERED)) {
-			TraceEvent(SevError, "FileOpenError").detail("Reason", "Must be unbuffered").detail("Flags", flags).detail("File", filename);
-			return io_error();
-		}
+		ASSERT( flags & OPEN_UNBUFFERED );
 
 		std::string open_filename = filename;
 		if (flags & OPEN_ATOMIC_WRITE_AND_CREATE) {


### PR DESCRIPTION
In Linux, KAIO uses ASSERT to make sure open() flags have
OPEN_UNBUFFERED set.

In Windows, we uses if-condition and return io_errors() when the
flag is not set.

This PR makes Windoes implementation always use ASSERT to check the
flag.