### PR TITLE
FDBExceptions are no longer created upon successful operation completion

### DIFF
--- a/bindings/java/fdbJNI.cpp
+++ b/bindings/java/fdbJNI.cpp
@@ -206,7 +206,11 @@ JNIEXPORT jthrowable JNICALL Java_com_apple_foundationdb_NativeFuture_Future_1ge
 		return JNI_NULL;
 	}
 	FDBFuture *sav = (FDBFuture *)future;
-	return getThrowable( jenv, fdb_future_get_error( sav ) );
+	fdb_error_t err = fdb_future_get_error( sav );
+	if( err )
+		return getThrowable( jenv, err );
+	else
+		return JNI_NULL;
 }
 
 JNIEXPORT jboolean JNICALL Java_com_apple_foundationdb_NativeFuture_Future_1isReady(JNIEnv *jenv, jobject, jlong future) {

--- a/bindings/java/src/main/com/apple/foundationdb/FutureResults.java
+++ b/bindings/java/src/main/com/apple/foundationdb/FutureResults.java
@@ -37,7 +37,7 @@ class FutureResults extends NativeFuture<RangeResultInfo> {
 	protected RangeResultInfo getIfDone_internal(long cPtr) throws FDBException {
 		FDBException err = Future_getError(cPtr);
 
-		if(!err.isSuccess()) {
+		if(err != null && !err.isSuccess()) {
 			throw err;
 		}
 

--- a/bindings/java/src/main/com/apple/foundationdb/FutureVoid.java
+++ b/bindings/java/src/main/com/apple/foundationdb/FutureVoid.java
@@ -34,7 +34,7 @@ class FutureVoid extends NativeFuture<Void> {
 		//  with a get on the error and throw if the error is not success.
 		FDBException err = Future_getError(cPtr);
 
-		if(!err.isSuccess()) {
+		if(err != null && !err.isSuccess()) {
 			throw err;
 		}
 		return null;

--- a/documentation/sphinx/source/release-notes.rst
+++ b/documentation/sphinx/source/release-notes.rst
@@ -18,6 +18,8 @@ Improved replication mechanism, a new hierarchical replication technique that fu
 Performance
 -----------
 
+* Java: Succesful commits and range reads no longer create ``FDBException`` objects to reduce memory pressure. `(Issue #1235) <https://github.com/apple/foundationdb/issues/1235>`_
+
 Fixes
 -----
 


### PR DESCRIPTION
The native function `NativeFuture::Future_getError` now returns `null` when the error code is 0 instead of an `FDBException` with a "Success" message and an error code of 0. This was only used in two places within the codebase; those two places now check for `null` errors and treats them like successes.

This resolves #1235.