### PR TITLE
More ide fixes

### DIFF
--- a/fdbrpc/dsltest.actor.cpp
+++ b/fdbrpc/dsltest.actor.cpp
@@ -868,7 +868,7 @@ template<> Future<int> chain<0>( Future<int> const& x ) {
 	return x;
 }
 
-Future<int> chain2( Future<int> const& x, int const& i );
+ACTOR Future<int> chain2(Future<int> x, int i);
 
 ACTOR Future<int> chain2( Future<int> x, int i ) {
 	if (i>1) {
@@ -1017,7 +1017,7 @@ ACTOR void cycle(FutureStream<Void> in, PromiseStream<Void> out, int* ptotal){
 	loop{
 		waitNext(in);
 		(*ptotal)++;
-		out.send(_);
+		out.send(Void());
 	}
 }
 

--- a/fdbserver/CMakeLists.txt
+++ b/fdbserver/CMakeLists.txt
@@ -10,7 +10,7 @@ set(FDBSERVER_SRCS
   CoroFlow.actor.cpp
   CoroFlow.h
   DataDistribution.actor.cpp
-  DataDistribution.h
+  DataDistribution.actor.h
   DataDistributionQueue.actor.cpp
   DataDistributionTracker.actor.cpp
   DataDistributorInterface.h

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -19,7 +19,7 @@
  */
 
 #include "flow/ActorCollection.h"
-#include "fdbserver/DataDistribution.h"
+#include "fdbserver/DataDistribution.actor.h"
 #include "fdbclient/SystemData.h"
 #include "fdbclient/DatabaseContext.h"
 #include "fdbserver/MoveKeys.actor.h"

--- a/fdbserver/DataDistribution.actor.h
+++ b/fdbserver/DataDistribution.actor.h
@@ -1,5 +1,5 @@
 /*
- * DataDistribution.h
+ * DataDistribution.actor.h
  *
  * This source file is part of the FoundationDB open source project
  *
@@ -18,10 +18,17 @@
  * limitations under the License.
  */
 
+#if defined(NO_INTELLISENSE) && !defined(FDBSERVER_DATA_DISTRIBUTION_ACTOR_G_H)
+#define FDBSERVER_DATA_DISTRIBUTION_ACTOR_G_H
+#include "fdbserver/DataDistribution.actor.g.h"
+#elif !defined(FDBSERVER_DATA_DISTRIBUTION_ACTOR_H)
+#define FDBSERVER_DATA_DISTRIBUTION_ACTOR_H
+
 #include "fdbclient/NativeAPI.actor.h"
 #include "fdbserver/ClusterRecruitmentInterface.h"
 #include "fdbserver/MoveKeys.actor.h"
 #include "fdbserver/LogSystem.h"
+#include "flow/actorcompiler.h" // This must be the last #include.
 
 struct RelocateShard {
 	KeyRange keys;
@@ -244,5 +251,7 @@ ShardSizeBounds getShardSizeBounds(KeyRangeRef shard, int64_t maxShardSize);
 int64_t getMaxShardSize( double dbSizeEstimate );
 
 class DDTeamCollection;
-Future<Void> teamRemover(DDTeamCollection* const& self);
-Future<Void> teamRemoverPeriodic(DDTeamCollection* const& self);
+ACTOR Future<Void> teamRemover(DDTeamCollection* self);
+ACTOR Future<Void> teamRemoverPeriodic(DDTeamCollection* self);
+
+#endif

--- a/fdbserver/DataDistributionQueue.actor.cpp
+++ b/fdbserver/DataDistributionQueue.actor.cpp
@@ -25,7 +25,7 @@
 #include "flow/Util.h"
 #include "fdbrpc/sim_validation.h"
 #include "fdbclient/SystemData.h"
-#include "fdbserver/DataDistribution.h"
+#include "fdbserver/DataDistribution.actor.h"
 #include "fdbclient/DatabaseContext.h"
 #include "fdbserver/MoveKeys.actor.h"
 #include "fdbserver/Knobs.h"

--- a/fdbserver/DataDistributionTracker.actor.cpp
+++ b/fdbserver/DataDistributionTracker.actor.cpp
@@ -20,7 +20,7 @@
 
 #include "fdbrpc/FailureMonitor.h"
 #include "fdbclient/SystemData.h"
-#include "fdbserver/DataDistribution.h"
+#include "fdbserver/DataDistribution.actor.h"
 #include "fdbserver/Knobs.h"
 #include "fdbclient/DatabaseContext.h"
 #include "flow/ActorCollection.h"

--- a/fdbserver/Status.actor.cpp
+++ b/fdbserver/Status.actor.cpp
@@ -27,7 +27,7 @@
 #include "fdbserver/ClusterRecruitmentInterface.h"
 #include <time.h>
 #include "fdbserver/CoordinationInterface.h"
-#include "fdbserver/DataDistribution.h"
+#include "fdbserver/DataDistribution.actor.h"
 #include "flow/UnitTest.h"
 #include "fdbserver/QuietDatabase.h"
 #include "fdbserver/RecoveryState.h"

--- a/fdbserver/fdbserver.actor.cpp
+++ b/fdbserver/fdbserver.actor.cpp
@@ -38,7 +38,7 @@
 #include "fdbserver/ServerDBInfo.h"
 #include "fdbserver/MoveKeys.actor.h"
 #include "fdbserver/ConflictSet.h"
-#include "fdbserver/DataDistribution.h"
+#include "fdbserver/DataDistribution.actor.h"
 #include "fdbserver/NetworkTest.h"
 #include "fdbserver/IKeyValueStore.h"
 #include <algorithm>

--- a/fdbserver/fdbserver.vcxproj
+++ b/fdbserver/fdbserver.vcxproj
@@ -159,7 +159,9 @@
     <ClInclude Include="CoordinatedState.h" />
     <ClInclude Include="CoordinationInterface.h" />
     <ClInclude Include="CoroFlow.h" />
-    <ClInclude Include="DataDistribution.actor.h" />
+    <ActorCompiler Include="DataDistribution.actor.h">
+          <EnableCompile>false</EnableCompile>
+    </ActorCompiler>
     <ClInclude Include="DataDistributorInterface.h" />
     <ClInclude Include="DBCoreState.h" />
     <ClInclude Include="IDiskQueue.h" />

--- a/fdbserver/fdbserver.vcxproj
+++ b/fdbserver/fdbserver.vcxproj
@@ -159,7 +159,7 @@
     <ClInclude Include="CoordinatedState.h" />
     <ClInclude Include="CoordinationInterface.h" />
     <ClInclude Include="CoroFlow.h" />
-    <ClInclude Include="DataDistribution.h" />
+    <ClInclude Include="DataDistribution.actor.h" />
     <ClInclude Include="DataDistributorInterface.h" />
     <ClInclude Include="DBCoreState.h" />
     <ClInclude Include="IDiskQueue.h" />

--- a/fdbserver/fdbserver.vcxproj.filters
+++ b/fdbserver/fdbserver.vcxproj.filters
@@ -309,7 +309,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="ConflictSet.h" />
-    <ClInclude Include="DataDistribution.h" />
+    <ClInclude Include="DataDistribution.actor.h" />
     <ClInclude Include="MoveKeys.actor.h" />
     <ClInclude Include="pubsub.h" />
     <ClInclude Include="Knobs.h" />

--- a/fdbserver/masterserver.actor.cpp
+++ b/fdbserver/masterserver.actor.cpp
@@ -26,7 +26,7 @@
 #include "fdbclient/Notified.h"
 #include "fdbclient/SystemData.h"
 #include "fdbserver/ConflictSet.h"
-#include "fdbserver/DataDistribution.h"
+#include "fdbserver/DataDistribution.actor.h"
 #include "fdbserver/Knobs.h"
 #include <iterator>
 #include "fdbserver/WaitFailure.h"

--- a/fdbserver/workloads/ConsistencyCheck.actor.cpp
+++ b/fdbserver/workloads/ConsistencyCheck.actor.cpp
@@ -28,7 +28,7 @@
 #include "fdbrpc/simulator.h"
 #include "fdbserver/Knobs.h"
 #include "fdbserver/StorageMetrics.h"
-#include "fdbserver/DataDistribution.h"
+#include "fdbserver/DataDistribution.actor.h"
 #include "fdbserver/QuietDatabase.h"
 #include "flow/DeterministicRandom.h"
 #include "fdbclient/ManagementAPI.actor.h"

--- a/fdbserver/workloads/Throttling.actor.cpp
+++ b/fdbserver/workloads/Throttling.actor.cpp
@@ -22,6 +22,7 @@
 
 #include "fdbclient/ReadYourWrites.h"
 #include "fdbserver/workloads/workloads.actor.h"
+#include "flow/actorcompiler.h" // This must be the last include
 
 struct TokenBucket {
 	static constexpr const double addTokensInterval = 0.1;


### PR DESCRIPTION
Looks like git clang-format gave fdbserver/DataDistribution.actor.h the full treatment. You can see the diff without the whitespace changes using `git diff -w -U0 '--word-diff-regex=[^[:space:]]' ea599ed9c~ ea599ed9c`