### PR TITLE
HTTP RequestID/ResponseID mismatch event changed to warning...

### DIFF
--- a/fdbclient/HTTP.actor.cpp
+++ b/fdbclient/HTTP.actor.cpp
@@ -389,8 +389,15 @@ namespace HTTP {
 				event.detail("RequestIDReceived", responseID);
 				if(requestID != responseID) {
 					err = http_bad_request_id();
+
 					// Log a non-debug a error
-					TraceEvent(SevError, "HTTPRequestFailedIDMismatch")
+					Severity sev = SevError;
+					// If the response code is 5xx (server error) and the responseID is empty then just warn
+					if(responseID.empty() && r->code >= 500 && r->code < 600) {
+						sev = SevWarnAlways;
+					}
+
+					TraceEvent(sev, "HTTPRequestFailedIDMismatch")
 						.detail("DebugID", conn->getDebugID())
 						.detail("RemoteAddress", conn->getPeerAddress())
 						.detail("Verb", verb)


### PR DESCRIPTION
…the response code is 5xx and the responseID is empty.