### PR TITLE
Make cmake build fail if old build system was used

### DIFF
--- a/cmake/AssertFileDoesntExist.cmake
+++ b/cmake/AssertFileDoesntExist.cmake
@@ -1,0 +1,11 @@
+set(error_msg
+  ${CMAKE_SOURCE_DIR}/versions.h exists. This usually means that
+  you did run `make` "(the old build system)" in this directory before.
+  This can result in unexpected behavior. run `make clean` in the
+  source directory to continue)
+if(EXISTS "${FILE}")
+  list(JOIN error_msg " " err)
+  message(FATAL_ERROR "${err}")
+else()
+  message(STATUS "${FILE} does not exist")
+endif()

--- a/fdbmonitor/CMakeLists.txt
+++ b/fdbmonitor/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(FDBMONITOR_SRCS ConvertUTF.h SimpleIni.h fdbmonitor.cpp)
 
 add_executable(fdbmonitor ${FDBMONITOR_SRCS})
+assert_no_version_h(fdbmonitor)
 if(UNIX AND NOT APPLE)
     target_link_libraries(fdbmonitor rt)
 endif()


### PR DESCRIPTION
This changes makes a cmake build check for an existing
versions.h file in the source directory before it builds
anything else. If it finds it it will fail the build.

This is to prevent confusion when someone tries to use cmake
on a source directory where the old build system was used
before (as this is not supported).