### PR TITLE
Add instruction to install Python for CMake/Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ that Visual Studio is used to compile.
 1. Install a [JDK](http://www.oracle.com/technetwork/java/javase/downloads/index.html). FoundationDB currently builds with Java 8.
 1. Set `JAVA_HOME` to the unpacked location and JAVA_COMPILE to
    `$JAVA_HOME/bin/javac`.
+1. Install [Python](https://www.python.org/downloads/). Required to build the Python binding.
 1. (Optional) Install [WIX](http://wixtoolset.org/). Without it Visual Studio
    won't build the Windows installer.
 1. Create a build directory (you can have the build directory anywhere you

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ that Visual Studio is used to compile.
 1. Install a [JDK](http://www.oracle.com/technetwork/java/javase/downloads/index.html). FoundationDB currently builds with Java 8.
 1. Set `JAVA_HOME` to the unpacked location and JAVA_COMPILE to
    `$JAVA_HOME/bin/javac`.
-1. Install [Python](https://www.python.org/downloads/). Required to build the Python binding.
+1. Install [Python](https://www.python.org/downloads/) if it is not already installed by Visual Studio.
 1. (Optional) Install [WIX](http://wixtoolset.org/). Without it Visual Studio
    won't build the Windows installer.
 1. Create a build directory (you can have the build directory anywhere you


### PR DESCRIPTION
I followed the instructions to build with CMake on Windows, but cmake complains about missing Python interpreter.

Installing Python 2.7.x solved the issue.

```
C:\Data\Git\GitHub\foundationdb\build>cmake -G "Visual Studio 15 2017 Win64" -DBOOST_ROOT=C:\Users\chevalier\Downloads\boost_1_67_0\boost_1_67_0 c:\data\git\github\foundationdb
-- C:/Data/Git/GitHub/foundationdb C:/Data/Git/GitHub/foundationdb/build
-- Could NOT find LibreSSL, try to set the path to LibreSSL root folder in the system variable LibreSSL_ROOT (missing: LIBRESSL_CRYPTO_LIBRARY LIBRESSL_SSL_LIBRARY LIBRESSL_TLS_LIBRARY LIBRESSL_INCLUDE_DIR)
-- LibreSSL NOT Found - Will compile without TLS Support
-- You can set LibreSSL_ROOT to the LibreSSL install directory to help cmake find it
-- Found JNI: C:/Program Files/Java/jdk-11.0.2/lib/jawt.lib (Required is at least version "1.8")
-- Found Java: C:/Program Files/Java/jdk-11.0.2/bin/java.exe (found suitable version "11.0.2", minimum required is "1.8") found components:  Development
-- Could NOT find Python (missing: Python_EXECUTABLE Interpreter)
CMake Error at cmake/FDBComponents.cmake:46 (message):
  Could not found a suitable python interpreter
Call Stack (most recent call first):
  CMakeLists.txt:60 (include)


-- Configuring incomplete, errors occurred!
See also "C:/Data/Git/GitHub/foundationdb/build/CMakeFiles/CMakeOutput.log".
See also "C:/Data/Git/GitHub/foundationdb/build/CMakeFiles/CMakeError.log".
```

After installing python
```
...
-- Found Python: C:/Python27/python.exe (found version "2.7.16") found components:  Interpreter
...
-- =========================================
--    Components Build Overview
-- =========================================
-- Build Java Bindings:                  ON
-- Build with TLS support:               OFF
-- Build Go bindings:                    OFF
-- Build Ruby bindings:                  OFF
-- Build Python sdist (make package):    ON
-- Build Documentation (make html):      OFF
-- =========================================
-- CPACK_COMPONENTS_ALL
-- Configuring done
-- Generating done
-- Build files have been written to: C:/Data/Git/GitHub/foundationdb/build
```