### PR TITLE
Add KillRegion.actor.cpp workload to cmake

### DIFF
--- a/fdbserver/CMakeLists.txt
+++ b/fdbserver/CMakeLists.txt
@@ -130,6 +130,7 @@ set(FDBSERVER_SRCS
   workloads/IndexScan.actor.cpp
   workloads/Inventory.actor.cpp
   workloads/KVStoreTest.actor.cpp
+  workloads/KillRegion.actor.cpp
   workloads/LockDatabase.actor.cpp
   workloads/LogMetrics.actor.cpp
   workloads/LowLatency.actor.cpp


### PR DESCRIPTION
WIthout this, `ctest -R KillRegion` fails because the KillRegion workload is not linked in to fdbserver.