### PR TITLE
Add snowflake ci commands to docker-compose

### DIFF
--- a/build/cmake/build.sh
+++ b/build/cmake/build.sh
@@ -38,7 +38,7 @@ configure() {
     local __res=0
     for _ in 1
     do
-        cmake ../foundationdb
+        cmake ../foundationdb ${CMAKE_EXTRA_ARGS}
         __res=$?
         if [ ${__res} -ne 0 ]
         then
@@ -122,7 +122,7 @@ rpm() {
     local __res=0
     for _ in 1
     do
-        cmake ../foundationdb
+        configure
         __res=$?
         if [ ${__res} -ne 0 ]
         then
@@ -149,7 +149,7 @@ deb() {
     local __res=0
     for _ in 1
     do
-        cmake ../foundationdb
+        configure
         __res=$?
         if [ ${__res} -ne 0 ]
         then
@@ -175,7 +175,7 @@ test-fast() {
     local __res=0
     for _ in 1
     do
-        ctest -j`nproc`
+        ctest -j`nproc` ${CTEST_EXTRA_ARGS}
         __res=$?
         if [ ${__res} -ne 0 ]
         then

--- a/build/cmake/docker-compose.yml
+++ b/build/cmake/docker-compose.yml
@@ -59,6 +59,10 @@ services:
     <<: *build-setup
     command: scl enable devtoolset-7 rh-ruby24 rh-python36 python27 -- bash ../foundationdb/build/cmake/build.sh test
 
+  snowflake-ci: &snowflake-ci
+    <<: *build-setup
+    command: scl enable devtoolset-7 rh-ruby24 rh-python36 python27 -- bash ../foundationdb/build/cmake/build.sh package test-fast
+
   shell:
     <<: *build-setup
     command: scl enable devtoolset-7 rh-ruby24 rh-python36 python27 -- bash

--- a/tests/TestRunner/TestRunner.py
+++ b/tests/TestRunner/TestRunner.py
@@ -242,7 +242,7 @@ def get_traces(d, log_format):
     return traces
 
 
-def process_traces(basedir, testname, path, out, aggregationPolicy, log_format, return_codes):
+def process_traces(basedir, testname, path, out, aggregationPolicy, log_format, return_codes, cmake_seed):
     res = True
     backtraces = []
     parser = None
@@ -261,6 +261,7 @@ def process_traces(basedir, testname, path, out, aggregationPolicy, log_format, 
             parser.fail()
         parser.processTraces()
         res = res and parser.result
+    parser.writeObject({'CMakeSEED': str(cmake_seed)})
     return res
 
 def run_simulation_test(basedir, options):
@@ -314,14 +315,14 @@ def run_simulation_test(basedir, options):
     if options.aggregate_traces == 'NONE':
         res = process_traces(basedir, options.name,
                              wd, None, 'NONE',
-                             options.log_format, return_codes)
+                             options.log_format, return_codes, options.seed)
     else:
         with open(outfile, 'a') as f:
             os.lockf(f.fileno(), os.F_LOCK, 0)
             pos = f.tell()
             res = process_traces(basedir, options.name,
                                  wd, f, options.aggregate_traces,
-                                 options.log_format, return_codes)
+                                 options.log_format, return_codes, options.seed)
             f.seek(pos)
             os.lockf(f.fileno(), os.F_ULOCK, 0)
     if options.keep_logs == 'NONE' or options.keep_logs == 'FAILED' and res:


### PR DESCRIPTION
This is based on #1204, so review only the last two commits please.

We at Snowflake are planning to run a CI job for each PR. Initially we're thinking

- Verify packages build
- Run some correctness tests using ctest

We could add more to the `snowflake-ci` docker compose command later though.

We plan to report instructions to reproduce the results. Example:
`sudo BUILDDIR=<builddir> docker-compose -f path/to/foundationdb/build/cmake/docker-compose.yml run -u $(id -u) -e 'CMAKE_EXTRA_ARGS=-DSEED=<seed>' snowflake-ci`

CC @mpilman 