### PR TITLE
Remove a broken ASSERT.

### DIFF
--- a/flow/genericactors.actor.h
+++ b/flow/genericactors.actor.h
@@ -1218,7 +1218,6 @@ struct FlowLock : NonCopyable, public ReferenceCounted<FlowLock> {
 	explicit FlowLock(int64_t permits) : permits(permits), active(0) {}
 
 	Future<Void> take(int taskID = TaskDefaultYield, int64_t amount = 1) {
-		ASSERT(amount <= permits || active == 0);
 		if (active + amount <= permits || active == 0) {
 			active += amount;
 			return safeYieldActor(this, taskID, amount);


### PR DESCRIPTION
It's now totally valid to have:
permits=3
take(1)
take(2)
take(72)

and the take(72) will only be granted once the first two finish.