### PR TITLE
Allows cluster string to contain coordinators with different TLS states

### DIFF
--- a/fdbcli/fdbcli.actor.cpp
+++ b/fdbcli/fdbcli.actor.cpp
@@ -1817,10 +1817,6 @@ ACTOR Future<bool> coordinators( Database db, std::vector<StringRef> tokens, boo
 			try {
 				// SOMEDAY: Check for keywords
 				auto const& addr = NetworkAddress::parse( t->toString() );
-				if (addresses.size() > 0 && addr.isTLS() != addresses.begin()->isTLS()) {
-					printf("ERROR: cannot use coordinators with different TLS states: `%s'\n", t->toString().c_str());
-					return true;
-				}
 				if (addresses.count(addr)){
 					printf("ERROR: passed redundant coordinators: `%s'\n", addr.toString().c_str());
 					return true;

--- a/fdbclient/MonitorLeader.actor.cpp
+++ b/fdbclient/MonitorLeader.actor.cpp
@@ -176,12 +176,6 @@ ClusterConnectionString::ClusterConnectionString( std::string const& connectionS
 	coord = NetworkAddress::parseList(addrs);
 	ASSERT( coord.size() > 0 );  // parseList() always returns at least one address if it doesn't throw
 
-	bool isTLS = coord[0].isTLS();
-	for( auto const& server : coord ) {
-		if( server.isTLS() != isTLS )
-			throw connection_string_invalid();
-	}
-
 	std::sort( coord.begin(), coord.end() );
 	// Check that there are no duplicate addresses
 	if ( std::unique( coord.begin(), coord.end() ) != coord.end() )

--- a/fdbserver/fdbserver.actor.cpp
+++ b/fdbserver/fdbserver.actor.cpp
@@ -759,13 +759,6 @@ std::pair<NetworkAddressList, NetworkAddressList> buildNetworkAddresses(const Cl
 
 	const NetworkAddressList& coordinators = connectionFile.getConnectionString().coordinators();
 	ASSERT(coordinators.size() > 0);
-	bool clusterIsTLS = coordinators[0].isTLS();
-	for (int ii = 1; ii < coordinators.size(); ++ii) {
-		if (coordinators[ii].isTLS() != clusterIsTLS) {
-			fprintf(stderr, "ERROR: coordinators cannot have mixed TLS state.\n");
-			flushAndExit(FDB_EXIT_ERROR);
-		}
-	}
 
 	int numTLSAddress = 0;
 


### PR DESCRIPTION
During live TLS upgrades, we can hence switch one coordinator at a time
to TLS than all of them together.