### PR TITLE
Add 8192 bit fast allocator

### DIFF
--- a/fdbbackup/backup.actor.cpp
+++ b/fdbbackup/backup.actor.cpp
@@ -3318,7 +3318,8 @@ int main(int argc, char* argv[]) {
 				<< FastAllocator<512>::pageCount << " "
 				<< FastAllocator<1024>::pageCount << " "
 				<< FastAllocator<2048>::pageCount << " "
-				<< FastAllocator<4096>::pageCount << endl;
+				<< FastAllocator<4096>::pageCount << " "
+				<< FastAllocator<8192>::pageCount << endl;
 
 			vector< std::pair<std::string, const char*> > typeNames;
 			for( auto i = allocInstr.begin(); i != allocInstr.end(); ++i ) {

--- a/fdbserver/fdbserver.actor.cpp
+++ b/fdbserver/fdbserver.actor.cpp
@@ -1749,7 +1749,8 @@ int main(int argc, char* argv[]) {
 				<< FastAllocator<512>::pageCount << " "
 				<< FastAllocator<1024>::pageCount << " "
 				<< FastAllocator<2048>::pageCount << " "
-				<< FastAllocator<4096>::pageCount << std::endl;
+				<< FastAllocator<4096>::pageCount << " "
+				<< FastAllocator<8192>::pageCount << std::endl;
 
 			vector< std::pair<std::string, const char*> > typeNames;
 			for( auto i = allocInstr.begin(); i != allocInstr.end(); ++i ) {

--- a/flow/Arena.h
+++ b/flow/Arena.h
@@ -227,7 +227,8 @@ struct ArenaBlock : NonCopyable, ThreadSafeReferenceCounted<ArenaBlock>
 				else if (reqSize <= 512) { b = (ArenaBlock*)FastAllocator<512>::allocate(); b->bigSize = 512; INSTRUMENT_ALLOCATE("Arena512"); }
 				else if (reqSize <= 1024) { b = (ArenaBlock*)FastAllocator<1024>::allocate(); b->bigSize = 1024; INSTRUMENT_ALLOCATE("Arena1024"); }
 				else if (reqSize <= 2048) { b = (ArenaBlock*)FastAllocator<2048>::allocate(); b->bigSize = 2048; INSTRUMENT_ALLOCATE("Arena2048"); }
-				else { b = (ArenaBlock*)FastAllocator<4096>::allocate(); b->bigSize = 4096; INSTRUMENT_ALLOCATE("Arena4096"); }
+				else if (reqSize <= 4096) { b = (ArenaBlock*)FastAllocator<4096>::allocate(); b->bigSize = 4096; INSTRUMENT_ALLOCATE("Arena4096"); }
+				else { b = (ArenaBlock*)FastAllocator<8192>::allocate(); b->bigSize = 8192; INSTRUMENT_ALLOCATE("Arena8192"); }
 				b->tinySize = b->tinyUsed = NOT_TINY;
 				b->bigUsed = sizeof(ArenaBlock);
 			} else {
@@ -269,6 +270,7 @@ struct ArenaBlock : NonCopyable, ThreadSafeReferenceCounted<ArenaBlock>
 			else if (bigSize <= 1024) { FastAllocator<1024>::release(this); INSTRUMENT_RELEASE("Arena1024"); }
 			else if (bigSize <= 2048) { FastAllocator<2048>::release(this); INSTRUMENT_RELEASE("Arena2048"); }
 			else if (bigSize <= 4096) { FastAllocator<4096>::release(this); INSTRUMENT_RELEASE("Arena4096"); }
+			else if (bigSize <= 8192) { FastAllocator<8192>::release(this); INSTRUMENT_RELEASE("Arena8192"); }
 			else {
 				#ifdef ALLOC_INSTRUMENTATION
 					allocInstr[ "ArenaHugeKB" ].dealloc( (bigSize+1023)>>10 );

--- a/flow/FastAlloc.cpp
+++ b/flow/FastAlloc.cpp
@@ -224,7 +224,8 @@ static int64_t getSizeCode(int i) {
 		case 1024: return 7;
 		case 2048: return 8;
 		case 4096: return 9;
-		default: return 10;
+		case 8192: return 10;
+		default: return 11;
 	}
 }
 
@@ -476,6 +477,7 @@ void releaseAllThreadMagazines() {
 	FastAllocator<1024>::releaseThreadMagazines();
 	FastAllocator<2048>::releaseThreadMagazines();
 	FastAllocator<4096>::releaseThreadMagazines();
+	FastAllocator<8192>::releaseThreadMagazines();
 }
 
 int64_t getTotalUnusedAllocatedMemory() {
@@ -490,6 +492,7 @@ int64_t getTotalUnusedAllocatedMemory() {
 	unusedMemory += FastAllocator<1024>::getApproximateMemoryUnused();
 	unusedMemory += FastAllocator<2048>::getApproximateMemoryUnused();
 	unusedMemory += FastAllocator<4096>::getApproximateMemoryUnused();
+	unusedMemory += FastAllocator<8192>::getApproximateMemoryUnused();
 
 	return unusedMemory;
 }
@@ -503,4 +506,5 @@ template class FastAllocator<512>;
 template class FastAllocator<1024>;
 template class FastAllocator<2048>;
 template class FastAllocator<4096>;
+template class FastAllocator<8192>;
 


### PR DESCRIPTION
StorageServer is getting close to 4KB on older gccs. However,
on some systems (for example Fedora) the storageServer actor
is already larger than 4KB. This results in a linker error.