### PR TITLE
Remove debug message in cmake

### DIFF
--- a/cmake/AssertFileDoesntExist.cmake
+++ b/cmake/AssertFileDoesntExist.cmake
@@ -6,6 +6,4 @@ set(error_msg
 if(EXISTS "${FILE}")
   list(JOIN error_msg " " err)
   message(FATAL_ERROR "${err}")
-else()
-  message(STATUS "${FILE} does not exist")
 endif()


### PR DESCRIPTION
When compiling with cmake users will currently see a message that says that
`versions.h` doesn't exist. This might be confusing as this looks a bit like a
warning. This line was originally printed for debug purposes and should never
have made it into master.