### PR TITLE
In our binding testers, stop using the TRANSACTION_LOGGING_ENABLE option

### DIFF
--- a/bindings/go/src/_stacktester/stacktester.go
+++ b/bindings/go/src/_stacktester/stacktester.go
@@ -831,7 +831,8 @@ func (sm *StackMachine) processInst(idx int, inst tuple.Tuple) {
 			tr.Options().SetRetryLimit(50)
 			tr.Options().SetMaxRetryDelay(100)
 			tr.Options().SetUsedDuringCommitProtectionDisable()
-			tr.Options().SetTransactionLoggingEnable("my_transaction")
+			tr.Options().SetDebugTransactionIdentifier("my_transaction")
+			tr.Options().SetLogTransaction()
 			tr.Options().SetReadLockAware()
 			tr.Options().SetLockAware()
 

--- a/bindings/java/src/test/com/apple/foundationdb/test/AsyncStackTester.java
+++ b/bindings/java/src/test/com/apple/foundationdb/test/AsyncStackTester.java
@@ -482,7 +482,8 @@ public class AsyncStackTester {
 				tr.options().setRetryLimit(50);
 				tr.options().setMaxRetryDelay(100);
 				tr.options().setUsedDuringCommitProtectionDisable();
-				tr.options().setTransactionLoggingEnable("my_transaction");
+				tr.options().setDebugTransactionIdentifier("my_transaction");
+				tr.options().setLogTransaction();
 				tr.options().setReadLockAware();
 				tr.options().setLockAware();
 

--- a/bindings/java/src/test/com/apple/foundationdb/test/StackTester.java
+++ b/bindings/java/src/test/com/apple/foundationdb/test/StackTester.java
@@ -436,7 +436,8 @@ public class StackTester {
 						tr.options().setRetryLimit(50);
 						tr.options().setMaxRetryDelay(100);
 						tr.options().setUsedDuringCommitProtectionDisable();
-						tr.options().setTransactionLoggingEnable("my_transaction");
+						tr.options().setDebugTransactionIdentifier("my_transaction");
+						tr.options().setLogTransaction();
 						tr.options().setReadLockAware();
 						tr.options().setLockAware();
 

--- a/bindings/python/tests/tester.py
+++ b/bindings/python/tests/tester.py
@@ -136,7 +136,8 @@ def test_options(tr):
     tr.options.set_retry_limit(50)
     tr.options.set_max_retry_delay(100)
     tr.options.set_used_during_commit_protection_disable()
-    tr.options.set_transaction_logging_enable('my_transaction')
+    tr.options.set_debug_transaction_identifier('my_transaction')
+    tr.options.set_log_transaction()
     tr.options.set_read_lock_aware()
     tr.options.set_lock_aware()
 

--- a/bindings/ruby/tests/tester.rb
+++ b/bindings/ruby/tests/tester.rb
@@ -466,7 +466,8 @@ class Tester
               tr.options.set_retry_limit(50)
               tr.options.set_max_retry_delay(100)
               tr.options.set_used_during_commit_protection_disable
-              tr.options.set_transaction_logging_enable('my_transaction')
+              tr.options.set_debug_transaction_identifier('my_transaction')
+              tr.options.set_log_transaction()
               tr.options.set_read_lock_aware()
               tr.options.set_lock_aware()
 


### PR DESCRIPTION
... and switch to the DEBUG_TRANSACTION_IDENTIFIER and LOG_TRANSACTION options