### PR TITLE
Fix some Windows issues

### DIFF
--- a/cmake/ConfigureCompiler.cmake
+++ b/cmake/ConfigureCompiler.cmake
@@ -44,7 +44,11 @@ set(CMAKE_REQUIRED_LIBRARIES c)
 
 
 if(WIN32)
+  # see: https://docs.microsoft.com/en-us/windows/desktop/WinProg/using-the-windows-headers
+  # this sets the windows target version to Windows 7
+  set(WINDOWS_TARGET 0x0601)
   add_compile_options(/W3 /EHsc /std:c++14 /bigobj $<$<CONFIG:Release>:/Zi>)
+  add_compile_definitions(_WIN32_WINNT=${WINDOWS_TARGET} BOOST_ALL_NO_LIB)
 else()
   if(USE_GOLD_LINKER)
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fuse-ld=gold -Wl,--disable-new-dtags")

--- a/flow/Platform.cpp
+++ b/flow/Platform.cpp
@@ -47,6 +47,7 @@
 #include "flow/FaultInjection.h"
 
 #ifdef _WIN32
+#include <winioctl.h>
 #define NOMINMAX
 #include <windows.h>
 #include <winioctl.h>

--- a/flow/Platform.cpp
+++ b/flow/Platform.cpp
@@ -47,7 +47,6 @@
 #include "flow/FaultInjection.h"
 
 #ifdef _WIN32
-#include <winioctl.h>
 #define NOMINMAX
 #include <windows.h>
 #include <winioctl.h>


### PR DESCRIPTION
1. We need to set a Windows target to get rid of warnings when compiling
   files that include windows.h
2. By default Boost will try to automatically link against boost_system.
   In order to prevent this, we define BOOST_ALL_NO_LIB
3. Somehow, I had to include winioctl.h in Platform.cpp. According to
   the documentation from MS, this shouldn't be necessary as windows.h
   includes this as well. However, for me it didn't compile otherwise.

Fixed #1273