### PR TITLE
Defer formatting in traces to make them cheaper

### DIFF
--- a/fdbbackup/backup.actor.cpp
+++ b/fdbbackup/backup.actor.cpp
@@ -1387,7 +1387,7 @@ ACTOR Future<Void> cleanupStatus(Reference<ReadYourWritesTransaction> tr, std::s
 				readMore = true;
 		} catch(Error &e) {
 			// If doc can't be parsed or isn't alive, delete it.
-			TraceEvent(SevWarn, "RemovedDeadBackupLayerStatus").detail("Key", printable(docs[i].key));
+			TraceEvent(SevWarn, "RemovedDeadBackupLayerStatus").detail("Key", docs[i].key);
 			tr->clear(docs[i].key);
 			// If limit is 1 then read more.
 			if(limit == 1)

--- a/fdbcli/fdbcli.actor.cpp
+++ b/fdbcli/fdbcli.actor.cpp
@@ -3357,7 +3357,7 @@ ACTOR Future<int> cli(CLIOptions opt, LineNoise* plinenoise) {
 				is_error = true;
 			}
 
-			TraceEvent(SevInfo, "CLICommandLog", randomID).detail("Command", StringRef(line)).detail("IsError", is_error);
+			TraceEvent(SevInfo, "CLICommandLog", randomID).detail("Command", line).detail("IsError", is_error);
 
 		} catch (Error& e) {
 			if(e.code() != error_code_actor_cancelled)

--- a/fdbcli/fdbcli.actor.cpp
+++ b/fdbcli/fdbcli.actor.cpp
@@ -2292,7 +2292,7 @@ void fdbcli_comp_cmd(std::string const& text, std::vector<std::string>& lc) {
 
 void LogCommand(std::string line, UID randomID, std::string errMsg) {
 	printf("%s\n", errMsg.c_str());
-	TraceEvent(SevInfo, "CLICommandLog", randomID).detail("Command", printable(StringRef(line))).detail("Error", printable(StringRef(errMsg)));
+	TraceEvent(SevInfo, "CLICommandLog", randomID).detail("Command", StringRef(line)).detail("Error", StringRef(errMsg));
 }
 
 struct CLIOptions {
@@ -2523,7 +2523,7 @@ ACTOR Future<int> cli(CLIOptions opt, LineNoise* plinenoise) {
 
 		try {
 			state UID randomID = g_random->randomUniqueID();
-			TraceEvent(SevInfo, "CLICommandLog", randomID).detail("Command", printable(StringRef(line)));
+			TraceEvent(SevInfo, "CLICommandLog", randomID).detail("Command", StringRef(line));
 
 			bool malformed, partial;
 			state std::vector<std::vector<StringRef>> parsed = parseLine(line, malformed, partial);
@@ -3345,7 +3345,7 @@ ACTOR Future<int> cli(CLIOptions opt, LineNoise* plinenoise) {
 						}
 						catch(Error &e) {
 							//options->setOption() prints error message
-							TraceEvent(SevWarn, "CLISetOptionError").error(e).detail("Option", printable(tokens[2]));
+							TraceEvent(SevWarn, "CLISetOptionError").error(e).detail("Option", tokens[2]);
 							is_error = true;
 						}
 					}
@@ -3357,7 +3357,7 @@ ACTOR Future<int> cli(CLIOptions opt, LineNoise* plinenoise) {
 				is_error = true;
 			}
 
-			TraceEvent(SevInfo, "CLICommandLog", randomID).detail("Command", printable(StringRef(line))).detail("IsError", is_error);
+			TraceEvent(SevInfo, "CLICommandLog", randomID).detail("Command", StringRef(line)).detail("IsError", is_error);
 
 		} catch (Error& e) {
 			if(e.code() != error_code_actor_cancelled)

--- a/fdbcli/fdbcli.actor.cpp
+++ b/fdbcli/fdbcli.actor.cpp
@@ -2292,7 +2292,7 @@ void fdbcli_comp_cmd(std::string const& text, std::vector<std::string>& lc) {
 
 void LogCommand(std::string line, UID randomID, std::string errMsg) {
 	printf("%s\n", errMsg.c_str());
-	TraceEvent(SevInfo, "CLICommandLog", randomID).detail("Command", StringRef(line)).detail("Error", StringRef(errMsg));
+	TraceEvent(SevInfo, "CLICommandLog", randomID).detail("Command", line).detail("Error", errMsg);
 }
 
 struct CLIOptions {

--- a/fdbcli/fdbcli.actor.cpp
+++ b/fdbcli/fdbcli.actor.cpp
@@ -2523,7 +2523,7 @@ ACTOR Future<int> cli(CLIOptions opt, LineNoise* plinenoise) {
 
 		try {
 			state UID randomID = g_random->randomUniqueID();
-			TraceEvent(SevInfo, "CLICommandLog", randomID).detail("Command", StringRef(line));
+			TraceEvent(SevInfo, "CLICommandLog", randomID).detail("Command", line);
 
 			bool malformed, partial;
 			state std::vector<std::vector<StringRef>> parsed = parseLine(line, malformed, partial);

--- a/fdbclient/BackupAgentBase.actor.cpp
+++ b/fdbclient/BackupAgentBase.actor.cpp
@@ -149,7 +149,7 @@ Standalone<VectorRef<KeyRangeRef>> getLogRanges(Version beginVersion, Version en
 
 	Key baLogRangePrefix = destUidValue.withPrefix(backupLogKeys.begin);
 
-	//TraceEvent("GetLogRanges").detail("DestUidValue", destUidValue).detail("Prefix", printable(StringRef(baLogRangePrefix)));
+	//TraceEvent("GetLogRanges").detail("DestUidValue", destUidValue).detail("Prefix", StringRef(baLogRangePrefix));
 
 	for (int64_t vblock = beginVersion / blockSize; vblock < (endVersion + blockSize - 1) / blockSize; ++vblock) {
 		int64_t tb = vblock * blockSize / CLIENT_KNOBS->LOG_RANGE_BLOCK_SIZE;
@@ -172,7 +172,7 @@ Standalone<VectorRef<KeyRangeRef>> getApplyRanges(Version beginVersion, Version 
 
 	Key baLogRangePrefix = backupUid.withPrefix(applyLogKeys.begin);
 
-	//TraceEvent("GetLogRanges").detail("BackupUid", backupUid).detail("Prefix", printable(StringRef(baLogRangePrefix)));
+	//TraceEvent("GetLogRanges").detail("BackupUid", backupUid).detail("Prefix", StringRef(baLogRangePrefix));
 
 	for (int64_t vblock = beginVersion / CLIENT_KNOBS->APPLY_BLOCK_SIZE; vblock < (endVersion + CLIENT_KNOBS->APPLY_BLOCK_SIZE - 1) / CLIENT_KNOBS->APPLY_BLOCK_SIZE; ++vblock) {
 		int64_t tb = vblock * CLIENT_KNOBS->APPLY_BLOCK_SIZE / CLIENT_KNOBS->LOG_RANGE_BLOCK_SIZE;
@@ -221,7 +221,7 @@ Standalone<VectorRef<MutationRef>> decodeBackupLogValue(StringRef value) {
 		offset += sizeof(uint64_t);
 		if (protocolVersion <= 0x0FDB00A200090001){
 			TraceEvent(SevError, "DecodeBackupLogValue").detail("IncompatibleProtocolVersion", protocolVersion)
-				.detail("ValueSize", value.size()).detail("Value", printable(value));
+				.detail("ValueSize", value.size()).detail("Value", value);
 			throw incompatible_protocol_version();
 		}
 
@@ -267,7 +267,7 @@ Standalone<VectorRef<MutationRef>> decodeBackupLogValue(StringRef value) {
 		return result;
 	}
 	catch (Error& e) {
-		TraceEvent(e.code() == error_code_restore_missing_data ? SevWarn : SevError, "BA_DecodeBackupLogValue").error(e).GetLastError().detail("ValueSize", value.size()).detail("Value", printable(value));
+		TraceEvent(e.code() == error_code_restore_missing_data ? SevWarn : SevError, "BA_DecodeBackupLogValue").error(e).GetLastError().detail("ValueSize", value.size()).detail("Value", value);
 		throw;
 	}
 }
@@ -280,7 +280,7 @@ void decodeBackupLogValue(Arena& arena, VectorRef<MutationRef>& result, int& mut
 		offset += sizeof(uint64_t);
 		if (protocolVersion <= 0x0FDB00A200090001){
 			TraceEvent(SevError, "DecodeBackupLogValue").detail("IncompatibleProtocolVersion", protocolVersion)
-				.detail("ValueSize", value.size()).detail("Value", printable(value));
+				.detail("ValueSize", value.size()).detail("Value", value);
 			throw incompatible_protocol_version();
 		}
 
@@ -375,7 +375,7 @@ void decodeBackupLogValue(Arena& arena, VectorRef<MutationRef>& result, int& mut
 		}
 	}
 	catch (Error& e) {
-		TraceEvent(e.code() == error_code_restore_missing_data ? SevWarn : SevError, "BA_DecodeBackupLogValue").error(e).GetLastError().detail("ValueSize", value.size()).detail("Value", printable(value));
+		TraceEvent(e.code() == error_code_restore_missing_data ? SevWarn : SevError, "BA_DecodeBackupLogValue").error(e).GetLastError().detail("ValueSize", value.size()).detail("Value", value);
 		throw;
 	}
 }
@@ -384,7 +384,7 @@ void logErrorWorker(Reference<ReadYourWritesTransaction> tr, Key keyErrors, std:
 	tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
 	tr->setOption(FDBTransactionOptions::LOCK_AWARE);
 	if(now() - lastErrorTime > CLIENT_KNOBS->BACKUP_ERROR_DELAY) {
-		TraceEvent("BA_LogError").detail("Key", printable(keyErrors)).detail("Message", message);
+		TraceEvent("BA_LogError").detail("Key", keyErrors).detail("Message", message);
 		lastErrorTime = now();
 	}
 	tr->set(keyErrors, message);
@@ -496,7 +496,7 @@ ACTOR Future<Void> readCommitted(Database cx, PromiseStream<RCGroup> results, Fu
 			int index(0);
 			for (auto & s : rangevalue){
 				uint64_t groupKey = groupBy(s.key).first;
-				//TraceEvent("Log_ReadCommitted").detail("GroupKey", groupKey).detail("SkipGroup", skipGroup).detail("NextKey", printable(nextKey.key)).detail("End", printable(end.key)).detail("Valuesize", value.size()).detail("Index",index++).detail("Size",s.value.size());
+				//TraceEvent("Log_ReadCommitted").detail("GroupKey", groupKey).detail("SkipGroup", skipGroup).detail("NextKey", nextKey.key).detail("End", end.key).detail("Valuesize", value.size()).detail("Index",index++).detail("Size",s.value.size());
 				if (groupKey != skipGroup){
 					if (rcGroup.version == -1){
 						rcGroup.version = tr.getReadVersion().get();

--- a/fdbclient/BackupAgentBase.actor.cpp
+++ b/fdbclient/BackupAgentBase.actor.cpp
@@ -149,7 +149,7 @@ Standalone<VectorRef<KeyRangeRef>> getLogRanges(Version beginVersion, Version en
 
 	Key baLogRangePrefix = destUidValue.withPrefix(backupLogKeys.begin);
 
-	//TraceEvent("GetLogRanges").detail("DestUidValue", destUidValue).detail("Prefix", StringRef(baLogRangePrefix));
+	//TraceEvent("GetLogRanges").detail("DestUidValue", destUidValue).detail("Prefix", baLogRangePrefix);
 
 	for (int64_t vblock = beginVersion / blockSize; vblock < (endVersion + blockSize - 1) / blockSize; ++vblock) {
 		int64_t tb = vblock * blockSize / CLIENT_KNOBS->LOG_RANGE_BLOCK_SIZE;

--- a/fdbclient/BackupAgentBase.actor.cpp
+++ b/fdbclient/BackupAgentBase.actor.cpp
@@ -172,7 +172,7 @@ Standalone<VectorRef<KeyRangeRef>> getApplyRanges(Version beginVersion, Version 
 
 	Key baLogRangePrefix = backupUid.withPrefix(applyLogKeys.begin);
 
-	//TraceEvent("GetLogRanges").detail("BackupUid", backupUid).detail("Prefix", StringRef(baLogRangePrefix));
+	//TraceEvent("GetLogRanges").detail("BackupUid", backupUid).detail("Prefix", baLogRangePrefix);
 
 	for (int64_t vblock = beginVersion / CLIENT_KNOBS->APPLY_BLOCK_SIZE; vblock < (endVersion + CLIENT_KNOBS->APPLY_BLOCK_SIZE - 1) / CLIENT_KNOBS->APPLY_BLOCK_SIZE; ++vblock) {
 		int64_t tb = vblock * CLIENT_KNOBS->APPLY_BLOCK_SIZE / CLIENT_KNOBS->LOG_RANGE_BLOCK_SIZE;

--- a/fdbclient/BackupContainer.actor.cpp
+++ b/fdbclient/BackupContainer.actor.cpp
@@ -1380,7 +1380,7 @@ public:
 				m_bucket = kv.second;
 				continue;
 			}
-			TraceEvent(SevWarn, "BackupContainerBlobStoreInvalidParameter").detail("Name", printable(kv.first)).detail("Value", printable(kv.second));
+			TraceEvent(SevWarn, "BackupContainerBlobStoreInvalidParameter").detail("Name", kv.first).detail("Value", kv.second);
 			IBackupContainer::lastOpenError = format("Unknown URL parameter: '%s'", kv.first.c_str());
 			throw backup_invalid_url();
 		}

--- a/fdbclient/ClientLogEvents.h
+++ b/fdbclient/ClientLogEvents.h
@@ -81,7 +81,7 @@ namespace FdbClientLogEvents {
 		Key key;
 
 		void logEvent(std::string id) const {
-			TraceEvent("TransactionTrace_Get").detail("TransactionID", id).detail("Latency", latency).detail("ValueSizeBytes", valueSize).detail("Key", printable(key));
+			TraceEvent("TransactionTrace_Get").detail("TransactionID", id).detail("Latency", latency).detail("ValueSizeBytes", valueSize).detail("Key", key);
 		}
 	};
 
@@ -102,7 +102,7 @@ namespace FdbClientLogEvents {
 		Key endKey;
 
 		void logEvent(std::string id) const {
-			TraceEvent("TransactionTrace_GetRange").detail("TransactionID", id).detail("Latency", latency).detail("RangeSizeBytes", rangeSize).detail("StartKey", printable(startKey)).detail("EndKey", printable(endKey));
+			TraceEvent("TransactionTrace_GetRange").detail("TransactionID", id).detail("Latency", latency).detail("RangeSizeBytes", rangeSize).detail("StartKey", startKey).detail("EndKey", endKey);
 		}
 	};
 
@@ -124,11 +124,11 @@ namespace FdbClientLogEvents {
 
 		void logEvent(std::string id) const {
 			for (auto &read_range : req.transaction.read_conflict_ranges) {
-				TraceEvent("TransactionTrace_Commit_ReadConflictRange").detail("TransactionID", id).detail("Begin", printable(read_range.begin)).detail("End", printable(read_range.end));
+				TraceEvent("TransactionTrace_Commit_ReadConflictRange").detail("TransactionID", id).detail("Begin", read_range.begin).detail("End", read_range.end);
 			}
 
 			for (auto &write_range : req.transaction.write_conflict_ranges) {
-				TraceEvent("TransactionTrace_Commit_WriteConflictRange").detail("TransactionID", id).detail("Begin", printable(write_range.begin)).detail("End", printable(write_range.end));
+				TraceEvent("TransactionTrace_Commit_WriteConflictRange").detail("TransactionID", id).detail("Begin", write_range.begin).detail("End", write_range.end);
 			}
 
 			for (auto &mutation : req.transaction.mutations) {
@@ -154,7 +154,7 @@ namespace FdbClientLogEvents {
 		Key key;
 
 		void logEvent(std::string id) const {
-			TraceEvent("TransactionTrace_GetError").detail("TransactionID", id).detail("ErrCode", errCode).detail("Key", printable(key));
+			TraceEvent("TransactionTrace_GetError").detail("TransactionID", id).detail("ErrCode", errCode).detail("Key", key);
 		}
 	};
 
@@ -174,7 +174,7 @@ namespace FdbClientLogEvents {
 		Key endKey;
 
 		void logEvent(std::string id) const {
-			TraceEvent("TransactionTrace_GetRangeError").detail("TransactionID", id).detail("ErrCode", errCode).detail("StartKey", printable(startKey)).detail("EndKey", printable(endKey));
+			TraceEvent("TransactionTrace_GetRangeError").detail("TransactionID", id).detail("ErrCode", errCode).detail("StartKey", startKey).detail("EndKey", endKey);
 		}
 	};
 
@@ -194,11 +194,11 @@ namespace FdbClientLogEvents {
 
 		void logEvent(std::string id) const {
 			for (auto &read_range : req.transaction.read_conflict_ranges) {
-				TraceEvent("TransactionTrace_CommitError_ReadConflictRange").detail("TransactionID", id).detail("Begin", printable(read_range.begin)).detail("End", printable(read_range.end));
+				TraceEvent("TransactionTrace_CommitError_ReadConflictRange").detail("TransactionID", id).detail("Begin", read_range.begin).detail("End", read_range.end);
 			}
 
 			for (auto &write_range : req.transaction.write_conflict_ranges) {
-				TraceEvent("TransactionTrace_CommitError_WriteConflictRange").detail("TransactionID", id).detail("Begin", printable(write_range.begin)).detail("End", printable(write_range.end));
+				TraceEvent("TransactionTrace_CommitError_WriteConflictRange").detail("TransactionID", id).detail("Begin", write_range.begin).detail("End", write_range.end);
 			}
 
 			for (auto &mutation : req.transaction.mutations) {

--- a/fdbclient/FDBTypes.h
+++ b/fdbclient/FDBTypes.h
@@ -513,6 +513,13 @@ private:
 	uint32_t type;
 };
 
+template<>
+struct Traceable<KeyValueStoreType> : std::true_type {
+	static std::string toString(KeyValueStoreType const& value) {
+		return value.toString();
+	}
+};
+
 struct TLogVersion {
 	enum Version {
 		UNSET = 0,
@@ -545,6 +552,13 @@ struct TLogVersion {
 		if (s == LiteralStringRef("2")) return V2;
 		if (s == LiteralStringRef("3")) return V3;
 		return default_error_or();
+	}
+};
+
+template<>
+struct Traceable<TLogVersion> : std::true_type {
+	static std::string toString(TLogVersion const& value) {
+		return Traceable<Version>::toString(value.version);
 	}
 };
 

--- a/fdbclient/FDBTypes.h
+++ b/fdbclient/FDBTypes.h
@@ -213,6 +213,23 @@ struct KeyRangeRef {
 	};
 };
 
+template<>
+struct Traceable<KeyRangeRef> : std::true_type {
+	static std::string toString(const KeyRangeRef& value) {
+		auto begin = Traceable<StringRef>::toString(value.begin);
+		auto end = Traceable<StringRef>::toString(value.end);
+		std::string result;
+		result.reserve(begin.size() + end.size() + 3);
+		std::copy(begin.begin(), begin.end(), std::back_inserter(result));
+		result.push_back(' ');
+		result.push_back('-');
+		result.push_back(' ');
+		std::copy(end.begin(), end.end(), std::back_inserter(result));
+		return result;
+	}
+};
+
+
 inline KeyRangeRef operator & (const KeyRangeRef& lhs, const KeyRangeRef& rhs) {
 	KeyRef b = std::max(lhs.begin, rhs.begin), e = std::min(lhs.end, rhs.end);
 	if (e < b)
@@ -261,6 +278,13 @@ struct KeyValueRef {
 			return a.key > b;
 		}
 	};
+};
+
+template<>
+struct Traceable<KeyValueRef> : std::true_type {
+	static std::string toString(const KeyValueRef& value) {
+		return Traceable<KeyRef>::toString(value.key) + format(":%d", value.value.size());
+	}
 };
 
 typedef Standalone<KeyRef> Key;

--- a/fdbclient/FDBTypes.h
+++ b/fdbclient/FDBTypes.h
@@ -503,6 +503,13 @@ struct RangeResultRef : VectorRef<KeyValueRef> {
 	}
 };
 
+template<>
+struct Traceable<RangeResultRef> : std::true_type {
+	static std::string toString(const RangeResultRef& value) {
+		return Traceable<VectorRef<KeyValueRef>>::toString(value);
+	}
+};
+
 struct KeyValueStoreType {
 	// These enumerated values are stored in the database configuration, so can NEVER be changed.  Only add new ones just before END.
 	enum StoreType {

--- a/fdbclient/FileBackupAgent.actor.cpp
+++ b/fdbclient/FileBackupAgent.actor.cpp
@@ -741,7 +741,7 @@ namespace fileBackup {
 		if (taskVersion > version) {
 			state Error err = task_invalid_version();
 
-			TraceEvent(SevWarn, "BA_BackupRangeTaskFuncExecute").detail("TaskVersion", taskVersion).detail("Name", printable(name)).detail("Version", version);
+			TraceEvent(SevWarn, "BA_BackupRangeTaskFuncExecute").detail("TaskVersion", taskVersion).detail("Name", name).detail("Version", version);
 			if (KeyBackedConfig::TaskParams.uid().exists(task)) {
 				std::string msg = format("%s task version `%lu' is greater than supported version `%lu'", task->params[Task::reservedTaskParamKeyType].toString().c_str(), (unsigned long)taskVersion, (unsigned long)version);
 				wait(BackupConfig(task).logError(cx, err, msg));
@@ -806,7 +806,7 @@ namespace fileBackup {
 			TEST(true);  // Canceling old backup task
 
 			TraceEvent(SevInfo, "FileBackupCancelOldTask")
-					.detail("Task", printable(task->params[Task::reservedTaskParamKeyType]))
+				.detail("Task", task->params[Task::reservedTaskParamKeyType])
 					.detail("TagName", tagName);
 			wait(abortFiveZeroBackup(&backupAgent, tr, tagName));
 
@@ -876,7 +876,7 @@ namespace fileBackup {
 			TEST(true);  // Canceling 5.1 backup task
 
 			TraceEvent(SevInfo, "FileBackupCancelFiveOneTask")
-					.detail("Task", printable(task->params[Task::reservedTaskParamKeyType]))
+				.detail("Task", task->params[Task::reservedTaskParamKeyType])
 					.detail("TagName", tagName);
 			wait(abortFiveOneBackup(&backupAgent, tr, tagName));
 
@@ -2688,13 +2688,13 @@ namespace fileBackup {
 							.detail("ReadOffset", readOffset)
 							.detail("ReadLen", readLen)
 							.detail("CommitVersion", tr->getCommittedVersion())
-							.detail("BeginRange", printable(trRange.begin))
-							.detail("EndRange", printable(trRange.end))
+							.detail("BeginRange", trRange.begin)
+							.detail("EndRange", trRange.end)
 							.detail("StartIndex", start)
 							.detail("EndIndex", i)
 							.detail("DataSize", data.size())
 							.detail("Bytes", txBytes)
-							.detail("OriginalFileRange", printable(originalFileRange))
+							.detail("OriginalFileRange", originalFileRange)
 							.detail("TaskInstance", THIS_ADDR);
 
 						// Commit succeeded, so advance starting point
@@ -3005,7 +3005,7 @@ namespace fileBackup {
 					TraceEvent("FileRestoreDispatch")
 						.detail("RestoreUID", restore.getUid())
 						.detail("BeginVersion", beginVersion)
-						.detail("BeginFile", printable(Params.beginFile().get(task)))
+						.detail("BeginFile", Params.beginFile().get(task))
 						.detail("BeginBlock", Params.beginBlock().get(task))
 						.detail("RestoreVersion", restoreVersion)
 						.detail("ApplyLag", applyLag)
@@ -3019,7 +3019,7 @@ namespace fileBackup {
 					TraceEvent("FileRestoreDispatch")
 						.detail("RestoreUID", restore.getUid())
 						.detail("BeginVersion", beginVersion)
-						.detail("BeginFile", printable(Params.beginFile().get(task)))
+						.detail("BeginFile", Params.beginFile().get(task))
 						.detail("BeginBlock", Params.beginBlock().get(task))
 						.detail("RestoreVersion", restoreVersion)
 						.detail("ApplyLag", applyLag)
@@ -3033,7 +3033,7 @@ namespace fileBackup {
 					TraceEvent("FileRestoreDispatch")
 						.detail("RestoreUID", restore.getUid())
 						.detail("BeginVersion", beginVersion)
-						.detail("BeginFile", printable(Params.beginFile().get(task)))
+						.detail("BeginFile", Params.beginFile().get(task))
 						.detail("BeginBlock", Params.beginBlock().get(task))
 						.detail("ApplyLag", applyLag)
 						.detail("Decision", "restore_complete")
@@ -3141,7 +3141,7 @@ namespace fileBackup {
 				TraceEvent("FileRestoreDispatch")
 					.detail("RestoreUID", restore.getUid())
 					.detail("BeginVersion", beginVersion)
-					.detail("BeginFile", printable(Params.beginFile().get(task)))
+					.detail("BeginFile", Params.beginFile().get(task))
 					.detail("BeginBlock", Params.beginBlock().get(task))
 					.detail("EndVersion", endVersion)
 					.detail("ApplyLag", applyLag)
@@ -3187,7 +3187,7 @@ namespace fileBackup {
 			TraceEvent("FileRestoreDispatch")
 				.detail("RestoreUID", restore.getUid())
 				.detail("BeginVersion", beginVersion)
-				.detail("BeginFile", printable(Params.beginFile().get(task)))
+				.detail("BeginFile", Params.beginFile().get(task))
 				.detail("BeginBlock", Params.beginBlock().get(task))
 				.detail("EndVersion", endVersion)
 				.detail("ApplyLag", applyLag)

--- a/fdbclient/KeyBackedTypes.h
+++ b/fdbclient/KeyBackedTypes.h
@@ -124,9 +124,9 @@ public:
 		return map(get(tr, snapshot), [=](Optional<T> val) -> T {
 			if (!val.present()) {
 				TraceEvent(SevInfo, "KeyBackedProperty_KeyNotFound")
-						.detail("Key", printable(keyCopy))
-						.detail("Err", err.code())
-						.detail("ParentTrace", backtrace.c_str());
+					.detail("Key", keyCopy)
+					.detail("Err", err.code())
+					.detail("ParentTrace", backtrace.c_str());
 				throw err;
 			}
 

--- a/fdbclient/ManagementAPI.actor.cpp
+++ b/fdbclient/ManagementAPI.actor.cpp
@@ -212,7 +212,7 @@ ConfigurationResult::Type buildConfiguration( std::vector<StringRef> const& mode
 
 		for( auto t = m.begin(); t != m.end(); ++t ) {
 			if( outConf.count( t->first ) ) {
-				TraceEvent(SevWarnAlways, "ConflictingOption").detail("Option", printable(StringRef(t->first)));
+				TraceEvent(SevWarnAlways, "ConflictingOption").detail("Option", t->first);
 				return ConfigurationResult::CONFLICTING_OPTIONS;
 			}
 			outConf[t->first] = t->second;

--- a/fdbclient/MultiVersionTransaction.actor.cpp
+++ b/fdbclient/MultiVersionTransaction.actor.cpp
@@ -763,7 +763,7 @@ void MultiVersionDatabase::DatabaseState::stateChanged() {
 		}
 		catch(Error &e) {
 			optionLock.leave();
-			TraceEvent(SevError, "ClusterVersionChangeOptionError").error(e).detail("Option", option.first).detail("OptionValue", printable(option.second)).detail("LibPath", clients[newIndex]->libPath);
+			TraceEvent(SevError, "ClusterVersionChangeOptionError").error(e).detail("Option", option.first).detail("OptionValue", option.second).detail("LibPath", clients[newIndex]->libPath);
 			connectionAttempts[newIndex]->connected = false;
 			clients[newIndex]->failed = true;
 			MultiVersionApi::api->updateSupportedVersions();

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -2484,19 +2484,21 @@ ACTOR void checkWrites( Database cx, Future<Void> committed, Promise<Void> outCo
 					Standalone<RangeResultRef> shouldBeEmpty = wait(
 						tr.getRange( it->range(), 1 ) );
 					if( shouldBeEmpty.size() ) {
-						TraceEvent(SevError, "CheckWritesFailed").detail("Class", "Clear").detail("KeyBegin", it->range().begin.c_str())
-							.detail("KeyEnd", it->range().end.c_str());
+						TraceEvent(SevError, "CheckWritesFailed").detail("Class", "Clear").detail("KeyBegin", it->range().begin)
+							.detail("KeyEnd", it->range().end);
 						return;
 					}
 				} else {
 					Optional<Value> val = wait( tr.get( it->range().begin ) );
 					if( !val.present() || val.get() != m.setValue ) {
-						TraceEvent evt = TraceEvent(SevError, "CheckWritesFailed").detail("Class", "Set").detail("Key", it->range().begin.c_str())
-							.detail("Expected", m.setValue.c_str());
+						TraceEvent evt = TraceEvent(SevError, "CheckWritesFailed")
+							.detail("Class", "Set")
+							.detail("Key", it->range().begin)
+							.detail("Expected", m.setValue);
 						if( !val.present() )
 							evt.detail("Actual", "_Value Missing_");
 						else
-							evt.detail("Actual", val.get().c_str());
+							evt.detail("Actual", val.get());
 						return;
 					}
 				}

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -1126,13 +1126,13 @@ AddressExclusion AddressExclusion::parse( StringRef const& key ) {
 		auto addr = NetworkAddress::parse(key.toString());
 		if (addr.isTLS()) {
 			TraceEvent(SevWarnAlways, "AddressExclusionParseError")
-				.detail("String", printable(key))
+				.detail("String", key)
 				.detail("Description", "Address inclusion string should not include `:tls' suffix.");
 			return AddressExclusion();
 		}
 		return AddressExclusion(addr.ip, addr.port);
 	} catch (Error& ) {
-		TraceEvent(SevWarnAlways, "AddressExclusionParseError").detail("String", printable(key));
+		TraceEvent(SevWarnAlways, "AddressExclusionParseError").detail("String", key);
 		return AddressExclusion();
 	}
 }
@@ -1334,7 +1334,7 @@ ACTOR Future<Optional<Value>> getValue( Future<Version> version, Key key, Databa
 				g_traceBatch.addAttach("GetValueAttachID", info.debugID.get().first(), getValueID.get().first());
 				g_traceBatch.addEvent("GetValueDebug", getValueID.get().first(), "NativeAPI.getValue.Before"); //.detail("TaskID", g_network->getCurrentTask());
 				/*TraceEvent("TransactionDebugGetValueInfo", getValueID.get())
-					.detail("Key", printable(key))
+				  .detail("Key", key)
 					.detail("ReqVersion", ver)
 					.detail("Servers", describe(ssi.second->get()));*/
 			}
@@ -1356,7 +1356,7 @@ ACTOR Future<Optional<Value>> getValue( Future<Version> version, Key key, Databa
 			if( info.debugID.present() ) {
 				g_traceBatch.addEvent("GetValueDebug", getValueID.get().first(), "NativeAPI.getValue.After"); //.detail("TaskID", g_network->getCurrentTask());
 				/*TraceEvent("TransactionDebugGetValueDone", getValueID.get())
-					.detail("Key", printable(key))
+				  .detail("Key", key)
 					.detail("ReqVersion", ver)
 					.detail("ReplySize", reply.value.present() ? reply.value.get().size() : -1);*/
 			}
@@ -1367,7 +1367,7 @@ ACTOR Future<Optional<Value>> getValue( Future<Version> version, Key key, Databa
 			if( info.debugID.present() ) {
 				g_traceBatch.addEvent("GetValueDebug", getValueID.get().first(), "NativeAPI.getValue.Error"); //.detail("TaskID", g_network->getCurrentTask());
 				/*TraceEvent("TransactionDebugGetValueDone", getValueID.get())
-					.detail("Key", printable(key))
+				  .detail("Key", key)
 					.detail("ReqVersion", ver)
 					.detail("ReplySize", reply.value.present() ? reply.value.get().size() : -1);*/
 			}
@@ -1404,11 +1404,11 @@ ACTOR Future<Key> getKey( Database cx, KeySelector k, Future<Version> version, T
 
 		try {
 			if( info.debugID.present() )
-				g_traceBatch.addEvent("TransactionDebug", info.debugID.get().first(), "NativeAPI.getKey.Before"); //.detail("StartKey", printable(k.getKey())).detail("Offset",k.offset).detail("OrEqual",k.orEqual);
+				g_traceBatch.addEvent("TransactionDebug", info.debugID.get().first(), "NativeAPI.getKey.Before"); //.detail("StartKey", k.getKey()).detail("Offset",k.offset).detail("OrEqual",k.orEqual);
 			++cx->transactionPhysicalReads;
 			GetKeyReply reply = wait( loadBalance( ssi.second, &StorageServerInterface::getKey, GetKeyRequest(k, version.get()), TaskDefaultPromiseEndpoint, false, cx->enableLocalityLoadBalance ? &cx->queueModel : NULL ) );
 			if( info.debugID.present() )
-				g_traceBatch.addEvent("TransactionDebug", info.debugID.get().first(), "NativeAPI.getKey.After"); //.detail("NextKey",printable(reply.sel.key)).detail("Offset", reply.sel.offset).detail("OrEqual", k.orEqual);
+				g_traceBatch.addEvent("TransactionDebug", info.debugID.get().first(), "NativeAPI.getKey.After"); //.detail("NextKey",reply.sel.key).detail("Offset", reply.sel.offset).detail("OrEqual", k.orEqual);
 			k = reply.sel;
 			if (!k.offset && k.orEqual) {
 				return k.getKey();
@@ -1421,7 +1421,7 @@ ACTOR Future<Key> getKey( Database cx, KeySelector k, Future<Version> version, T
 			} else {
 				TraceEvent(SevInfo, "GetKeyError")
 					.error(e)
-					.detail("AtKey", printable(k.getKey()))
+					.detail("AtKey", k.getKey())
 					.detail("Offset", k.offset);
 				throw e;
 			}
@@ -1478,7 +1478,7 @@ ACTOR Future< Void > watchValue( Future<Version> version, Key key, Optional<Valu
 			//cannot do this until the storage server is notified on knownCommittedVersion changes from tlog (faster than the current update loop)
 			Version v = wait( waitForCommittedVersion( cx, resp ) );
 
-			//TraceEvent("WatcherCommitted").detail("CommittedVersion", v).detail("WatchVersion", resp).detail("Key", printable( key )).detail("Value", printable(value));
+			//TraceEvent("WatcherCommitted").detail("CommittedVersion", v).detail("WatchVersion", resp).detail("Key",  key ).detail("Value", value);
 
 			if( v - resp < 50000000 ) // False if there is a master failure between getting the response and getting the committed version, Dependent on SERVER_KNOBS->MAX_VERSIONS_IN_FLIGHT
 				return Void();
@@ -1551,8 +1551,8 @@ ACTOR Future<Standalone<RangeResultRef>> getExactRange( Database cx, Version ver
 				if( info.debugID.present() ) {
 					g_traceBatch.addEvent("TransactionDebug", info.debugID.get().first(), "NativeAPI.getExactRange.Before");
 					/*TraceEvent("TransactionDebugGetExactRangeInfo", info.debugID.get())
-					.detail("ReqBeginKey", printable(req.begin.getKey()))
-					.detail("ReqEndKey", printable(req.end.getKey()))
+					  .detail("ReqBeginKey", req.begin.getKey())
+					  .detail("ReqEndKey", req.end.getKey())
 					.detail("ReqLimit", req.limit)
 					.detail("ReqLimitBytes", req.limitBytes)
 					.detail("ReqVersion", req.version)
@@ -1641,8 +1641,8 @@ ACTOR Future<Standalone<RangeResultRef>> getExactRange( Database cx, Version ver
 				} else {
 					TraceEvent(SevInfo, "GetExactRangeError")
 						.error(e)
-						.detail("ShardBegin", printable(locations[shard].first.begin))
-						.detail("ShardEnd", printable(locations[shard].first.end));
+						.detail("ShardBegin", locations[shard].first.begin)
+						.detail("ShardEnd", locations[shard].first.end);
 					throw;
 				}
 			}
@@ -1816,13 +1816,13 @@ ACTOR Future<Standalone<RangeResultRef>> getRange( Database cx, Reference<Transa
 				if( info.debugID.present() ) {
 					g_traceBatch.addEvent("TransactionDebug", info.debugID.get().first(), "NativeAPI.getRange.Before");
 					/*TraceEvent("TransactionDebugGetRangeInfo", info.debugID.get())
-						.detail("ReqBeginKey", printable(req.begin.getKey()))
-						.detail("ReqEndKey", printable(req.end.getKey()))
+					  .detail("ReqBeginKey", req.begin.getKey())
+					  .detail("ReqEndKey", req.end.getKey())
 						.detail("OriginalBegin", originalBegin.toString())
 						.detail("OriginalEnd", originalEnd.toString())
 						.detail("Begin", begin.toString())
 						.detail("End", end.toString())
-						.detail("Shard", printable(shard))
+						.detail("Shard", shard)
 						.detail("ReqLimit", req.limit)
 						.detail("ReqLimitBytes", req.limitBytes)
 						.detail("ReqVersion", req.version)
@@ -1837,8 +1837,8 @@ ACTOR Future<Standalone<RangeResultRef>> getRange( Database cx, Reference<Transa
 				if( info.debugID.present() ) {
 					g_traceBatch.addEvent("TransactionDebug", info.debugID.get().first(), "NativeAPI.getRange.After");//.detail("SizeOf", rep.data.size());
 					/*TraceEvent("TransactionDebugGetRangeDone", info.debugID.get())
-						.detail("ReqBeginKey", printable(req.begin.getKey()))
-						.detail("ReqEndKey", printable(req.end.getKey()))
+					  .detail("ReqBeginKey", req.begin.getKey())
+					  .detail("ReqEndKey", req.end.getKey())
 						.detail("RepIsMore", rep.more)
 						.detail("VersionReturned", rep.version)
 						.detail("RowsReturned", rep.data.size());*/
@@ -2484,19 +2484,19 @@ ACTOR void checkWrites( Database cx, Future<Void> committed, Promise<Void> outCo
 					Standalone<RangeResultRef> shouldBeEmpty = wait(
 						tr.getRange( it->range(), 1 ) );
 					if( shouldBeEmpty.size() ) {
-						TraceEvent(SevError, "CheckWritesFailed").detail("Class", "Clear").detail("KeyBegin", printable(it->range().begin).c_str())
-							.detail("KeyEnd", printable(it->range().end).c_str());
+						TraceEvent(SevError, "CheckWritesFailed").detail("Class", "Clear").detail("KeyBegin", it->range().begin.c_str())
+							.detail("KeyEnd", it->range().end.c_str());
 						return;
 					}
 				} else {
 					Optional<Value> val = wait( tr.get( it->range().begin ) );
 					if( !val.present() || val.get() != m.setValue ) {
-						TraceEvent evt = TraceEvent(SevError, "CheckWritesFailed").detail("Class", "Set").detail("Key", printable(it->range().begin).c_str())
-							.detail("Expected", printable(m.setValue).c_str());
+						TraceEvent evt = TraceEvent(SevError, "CheckWritesFailed").detail("Class", "Set").detail("Key", it->range().begin.c_str())
+							.detail("Expected", m.setValue.c_str());
 						if( !val.present() )
 							evt.detail("Actual", "_Value Missing_");
 						else
-							evt.detail("Actual", printable(val.get()).c_str());
+							evt.detail("Actual", val.get().c_str());
 						return;
 					}
 				}
@@ -2515,7 +2515,7 @@ ACTOR static Future<Void> commitDummyTransaction( Database cx, KeyRange range, T
 	state int retries = 0;
 	loop {
 		try {
-			TraceEvent("CommitDummyTransaction").detail("Key", printable(range.begin)).detail("Retries", retries);
+			TraceEvent("CommitDummyTransaction").detail("Key", range.begin).detail("Retries", retries);
 			tr.options = options;
 			tr.info.taskID = info.taskID;
 			tr.setOption( FDBTransactionOptions::ACCESS_SYSTEM_KEYS );
@@ -2526,7 +2526,7 @@ ACTOR static Future<Void> commitDummyTransaction( Database cx, KeyRange range, T
 			wait( tr.commit() );
 			return Void();
 		} catch (Error& e) {
-			TraceEvent("CommitDummyTransactionError").error(e,true).detail("Key", printable(range.begin)).detail("Retries", retries);
+			TraceEvent("CommitDummyTransactionError").error(e,true).detail("Key", range.begin).detail("Retries", retries);
 			wait( tr.onError(e) );
 		}
 		++retries;
@@ -2715,7 +2715,7 @@ Future<Void> Transaction::commitMutations() {
 			UID u = g_nondeterministic_random->randomUniqueID();
 			TraceEvent("TransactionDump", u);
 			for(auto i=tr.transaction.mutations.begin(); i!=tr.transaction.mutations.end(); ++i)
-				TraceEvent("TransactionMutation", u).detail("T", i->type).detail("P1", printable(i->param1)).detail("P2", printable(i->param2));
+				TraceEvent("TransactionMutation", u).detail("T", i->type).detail("P1", i->param1).detail("P2", i->param2);
 		}
 
 		if(options.lockAware) {
@@ -2840,7 +2840,7 @@ void Transaction::setOption( FDBTransactionOptions::Option option, Optional<Stri
 					trLogInfo->identifier = printable(value.get());
 				}
 				else if (trLogInfo->identifier != printable(value.get())) {
-					TraceEvent(SevWarn, "CannotChangeDebugTransactionIdentifier").detail("PreviousIdentifier", trLogInfo->identifier).detail("NewIdentifier", printable(value.get()));
+					TraceEvent(SevWarn, "CannotChangeDebugTransactionIdentifier").detail("PreviousIdentifier", trLogInfo->identifier).detail("NewIdentifier", value.get());
 					throw client_invalid_operation();
 				}
 			}
@@ -3154,7 +3154,7 @@ ACTOR Future< StorageMetrics > waitStorageMetrics(
 			}
 		} else {
 			TraceEvent(SevWarn, "WaitStorageMetricsPenalty")
-				.detail("Keys", printable(keys))
+				.detail("Keys", keys)
 				.detail("Limit", CLIENT_KNOBS->STORAGE_METRICS_SHARD_LIMIT)
 				.detail("JitteredSecondsOfPenitence", CLIENT_KNOBS->STORAGE_METRICS_TOO_MANY_SHARDS_DELAY);
 			wait(delayJittered(CLIENT_KNOBS->STORAGE_METRICS_TOO_MANY_SHARDS_DELAY, TaskDataDistribution));

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -1334,7 +1334,7 @@ ACTOR Future<Optional<Value>> getValue( Future<Version> version, Key key, Databa
 				g_traceBatch.addAttach("GetValueAttachID", info.debugID.get().first(), getValueID.get().first());
 				g_traceBatch.addEvent("GetValueDebug", getValueID.get().first(), "NativeAPI.getValue.Before"); //.detail("TaskID", g_network->getCurrentTask());
 				/*TraceEvent("TransactionDebugGetValueInfo", getValueID.get())
-				  .detail("Key", key)
+					.detail("Key", key)
 					.detail("ReqVersion", ver)
 					.detail("Servers", describe(ssi.second->get()));*/
 			}
@@ -1356,7 +1356,7 @@ ACTOR Future<Optional<Value>> getValue( Future<Version> version, Key key, Databa
 			if( info.debugID.present() ) {
 				g_traceBatch.addEvent("GetValueDebug", getValueID.get().first(), "NativeAPI.getValue.After"); //.detail("TaskID", g_network->getCurrentTask());
 				/*TraceEvent("TransactionDebugGetValueDone", getValueID.get())
-				  .detail("Key", key)
+					.detail("Key", key)
 					.detail("ReqVersion", ver)
 					.detail("ReplySize", reply.value.present() ? reply.value.get().size() : -1);*/
 			}
@@ -1367,7 +1367,7 @@ ACTOR Future<Optional<Value>> getValue( Future<Version> version, Key key, Databa
 			if( info.debugID.present() ) {
 				g_traceBatch.addEvent("GetValueDebug", getValueID.get().first(), "NativeAPI.getValue.Error"); //.detail("TaskID", g_network->getCurrentTask());
 				/*TraceEvent("TransactionDebugGetValueDone", getValueID.get())
-				  .detail("Key", key)
+					.detail("Key", key)
 					.detail("ReqVersion", ver)
 					.detail("ReplySize", reply.value.present() ? reply.value.get().size() : -1);*/
 			}
@@ -1551,13 +1551,13 @@ ACTOR Future<Standalone<RangeResultRef>> getExactRange( Database cx, Version ver
 				if( info.debugID.present() ) {
 					g_traceBatch.addEvent("TransactionDebug", info.debugID.get().first(), "NativeAPI.getExactRange.Before");
 					/*TraceEvent("TransactionDebugGetExactRangeInfo", info.debugID.get())
-					  .detail("ReqBeginKey", req.begin.getKey())
-					  .detail("ReqEndKey", req.end.getKey())
-					.detail("ReqLimit", req.limit)
-					.detail("ReqLimitBytes", req.limitBytes)
-					.detail("ReqVersion", req.version)
-					.detail("Reverse", reverse)
-					.detail("Servers", locations[shard].second->description());*/
+						.detail("ReqBeginKey", req.begin.getKey())
+						.detail("ReqEndKey", req.end.getKey())
+						.detail("ReqLimit", req.limit)
+						.detail("ReqLimitBytes", req.limitBytes)
+						.detail("ReqVersion", req.version)
+						.detail("Reverse", reverse)
+						.detail("Servers", locations[shard].second->description());*/
 				}
 				++cx->transactionPhysicalReads;
 				GetKeyValuesReply rep = wait( loadBalance( locations[shard].second, &StorageServerInterface::getKeyValues, req, TaskDefaultPromiseEndpoint, false, cx->enableLocalityLoadBalance ? &cx->queueModel : NULL ) );
@@ -1816,8 +1816,8 @@ ACTOR Future<Standalone<RangeResultRef>> getRange( Database cx, Reference<Transa
 				if( info.debugID.present() ) {
 					g_traceBatch.addEvent("TransactionDebug", info.debugID.get().first(), "NativeAPI.getRange.Before");
 					/*TraceEvent("TransactionDebugGetRangeInfo", info.debugID.get())
-					  .detail("ReqBeginKey", req.begin.getKey())
-					  .detail("ReqEndKey", req.end.getKey())
+						.detail("ReqBeginKey", req.begin.getKey())
+						.detail("ReqEndKey", req.end.getKey())
 						.detail("OriginalBegin", originalBegin.toString())
 						.detail("OriginalEnd", originalEnd.toString())
 						.detail("Begin", begin.toString())
@@ -1837,8 +1837,8 @@ ACTOR Future<Standalone<RangeResultRef>> getRange( Database cx, Reference<Transa
 				if( info.debugID.present() ) {
 					g_traceBatch.addEvent("TransactionDebug", info.debugID.get().first(), "NativeAPI.getRange.After");//.detail("SizeOf", rep.data.size());
 					/*TraceEvent("TransactionDebugGetRangeDone", info.debugID.get())
-					  .detail("ReqBeginKey", req.begin.getKey())
-					  .detail("ReqEndKey", req.end.getKey())
+						.detail("ReqBeginKey", req.begin.getKey())
+						.detail("ReqEndKey", req.end.getKey())
 						.detail("RepIsMore", rep.more)
 						.detail("VersionReturned", rep.version)
 						.detail("RowsReturned", rep.data.size());*/

--- a/fdbclient/RYWIterator.cpp
+++ b/fdbclient/RYWIterator.cpp
@@ -574,7 +574,7 @@ TEST_CASE("/fdbclient/WriteMap/random") {
 			KeyRangeRef range = RandomTestImpl::getRandomRange(arena);
 			writes.addConflictRange(range);
 			conflictMap.insert(range, true);
-			TraceEvent("RWMT_AddConflictRange").detail("Range", printable(range));
+			TraceEvent("RWMT_AddConflictRange").detail("Range", range);
 		}
 		else if(r == 1) {
 			KeyRangeRef range = RandomTestImpl::getRandomRange(arena);
@@ -583,7 +583,7 @@ TEST_CASE("/fdbclient/WriteMap/random") {
 			conflictMap.insert(range, false);
 			clearMap.insert(range, false);
 			unreadableMap.insert(range, true);
-			TraceEvent("RWMT_AddUnmodifiedAndUnreadableRange").detail("Range", printable(range));
+			TraceEvent("RWMT_AddUnmodifiedAndUnreadableRange").detail("Range", range);
 		}
 		else if (r == 2) {
 			bool addConflict = g_random->random01() < 0.5;
@@ -594,7 +594,7 @@ TEST_CASE("/fdbclient/WriteMap/random") {
 				conflictMap.insert(range, true);
 			clearMap.insert(range, true);
 			unreadableMap.insert(range, false);
-			TraceEvent("RWMT_Clear").detail("Range", printable(range)).detail("AddConflict", addConflict);
+			TraceEvent("RWMT_Clear").detail("Range", range).detail("AddConflict", addConflict);
 		}
 		else if (r == 3) {
 			bool addConflict = g_random->random01() < 0.5;
@@ -606,7 +606,7 @@ TEST_CASE("/fdbclient/WriteMap/random") {
 				conflictMap.insert(key, true);
 			clearMap.insert(key, false);
 			unreadableMap.insert(key, true);
-			TraceEvent("RWMT_SetVersionstampedValue").detail("Key", printable(key)).detail("Value", value.size()).detail("AddConflict", addConflict);
+			TraceEvent("RWMT_SetVersionstampedValue").detail("Key", key).detail("Value", value.size()).detail("AddConflict", addConflict);
 		}
 		else if (r == 4) {
 			bool addConflict = g_random->random01() < 0.5;
@@ -618,7 +618,7 @@ TEST_CASE("/fdbclient/WriteMap/random") {
 				conflictMap.insert(key, true);
 			clearMap.insert(key, false);
 			unreadableMap.insert(key, true);
-			TraceEvent("RWMT_SetVersionstampedKey").detail("Key", printable(key)).detail("Value", value.size()).detail("AddConflict", addConflict);
+			TraceEvent("RWMT_SetVersionstampedKey").detail("Key", key).detail("Value", value.size()).detail("AddConflict", addConflict);
 		}
 		else if (r == 5) {
 			bool addConflict = g_random->random01() < 0.5;
@@ -638,7 +638,7 @@ TEST_CASE("/fdbclient/WriteMap/random") {
 			if (addConflict)
 				conflictMap.insert(key, true);
 			clearMap.insert(key, false);
-			TraceEvent("RWMT_And").detail("Key", printable(key)).detail("Value", value.size()).detail("AddConflict", addConflict);
+			TraceEvent("RWMT_And").detail("Key", key).detail("Value", value.size()).detail("AddConflict", addConflict);
 		}
 		else {
 			bool addConflict = g_random->random01() < 0.5;
@@ -652,7 +652,7 @@ TEST_CASE("/fdbclient/WriteMap/random") {
 			if (addConflict)
 				conflictMap.insert(key, true);
 			clearMap.insert(key, false);
-			TraceEvent("RWMT_Set").detail("Key", printable(key)).detail("Value", value.size()).detail("AddConflict", addConflict);
+			TraceEvent("RWMT_Set").detail("Key", key).detail("Value", value.size()).detail("AddConflict", addConflict);
 		}
 	}
 
@@ -665,11 +665,11 @@ TEST_CASE("/fdbclient/WriteMap/random") {
 		if (it.is_operation()) {
 			ASSERT(setIter != setEnd);
 			TraceEvent("RWMT_CheckOperation")
-				.detail("WmKey", printable(it.beginKey().toStandaloneStringRef()))
+				.detail("WmKey", it.beginKey().toStandaloneStringRef())
 				.detail("WmSize", it.op().size())
 				.detail("WmValue", it.op().top().value.present() ? std::to_string(it.op().top().value.get().size()) : "Not Found")
 				.detail("WmType", (int)it.op().top().type)
-				.detail("SmKey", printable(setIter->first))
+				.detail("SmKey", setIter->first)
 				.detail("SmSize", setIter->second.size())
 				.detail("SmValue", setIter->second.top().value.present() ? std::to_string(setIter->second.top().value.get().size()) : "Not Found")
 				.detail("SmType", (int)setIter->second.top().type);
@@ -679,7 +679,7 @@ TEST_CASE("/fdbclient/WriteMap/random") {
 	}
 
 	TraceEvent("RWMT_CheckOperationFinal")
-		.detail("WmKey", printable(it.beginKey().toStandaloneStringRef()))
+		.detail("WmKey", it.beginKey().toStandaloneStringRef())
 		.detail("SmIter", setIter == setEnd);
 
 	ASSERT(it.beginKey() >= allKeys.end && setIter == setEnd);
@@ -728,8 +728,8 @@ TEST_CASE("/fdbclient/WriteMap/random") {
 
 	while (it.beginKey() < allKeys.end && unreadableIter != unreadableEnd) {
 		TraceEvent("RWMT_CheckUnreadable")
-			.detail("WriteMapRange", printable(KeyRangeRef(it.beginKey().toStandaloneStringRef(), it.endKey().toStandaloneStringRef())))
-			.detail("UnreadableMapRange", printable(unreadableIter.range()))
+			.detail("WriteMapRange", KeyRangeRef(it.beginKey().toStandaloneStringRef(), it.endKey().toStandaloneStringRef()))
+			.detail("UnreadableMapRange", unreadableIter.range())
 			.detail("WriteMapValue", it.is_unreadable())
 			.detail("UnreadableMapValue", unreadableIter.value());
 		ASSERT(unreadableIter.value() == it.is_unreadable());

--- a/fdbclient/RYWIterator.cpp
+++ b/fdbclient/RYWIterator.cpp
@@ -665,7 +665,7 @@ TEST_CASE("/fdbclient/WriteMap/random") {
 		if (it.is_operation()) {
 			ASSERT(setIter != setEnd);
 			TraceEvent("RWMT_CheckOperation")
-				.detail("WmKey", it.beginKey().toStandaloneStringRef())
+				.detail("WmKey", it.beginKey())
 				.detail("WmSize", it.op().size())
 				.detail("WmValue", it.op().top().value.present() ? std::to_string(it.op().top().value.get().size()) : "Not Found")
 				.detail("WmType", (int)it.op().top().type)
@@ -679,7 +679,7 @@ TEST_CASE("/fdbclient/WriteMap/random") {
 	}
 
 	TraceEvent("RWMT_CheckOperationFinal")
-		.detail("WmKey", it.beginKey().toStandaloneStringRef())
+		.detail("WmKey", it.beginKey())
 		.detail("SmIter", setIter == setEnd);
 
 	ASSERT(it.beginKey() >= allKeys.end && setIter == setEnd);

--- a/fdbclient/ReadYourWrites.actor.cpp
+++ b/fdbclient/ReadYourWrites.actor.cpp
@@ -38,12 +38,12 @@ public:
 				if (kv) key = kv->key;
 			}
 			TraceEvent("RYWDump")
-			    .detail("Begin", printable(it.beginKey().toStandaloneStringRef()))
-			    .detail("End", printable(it.endKey().toStandaloneStringRef()))
+			    .detail("Begin", it.beginKey().toStandaloneStringRef())
+			    .detail("End", it.endKey().toStandaloneStringRef())
 			    .detail("Unknown", it.is_unknown_range())
 			    .detail("Empty", it.is_empty_range())
 			    .detail("KV", it.is_kv())
-			    .detail("Key", printable(key.get()));
+			    .detail("Key", key.get());
 			if( it.endKey() == allKeys.end )
 				break;
 			++it;
@@ -512,8 +512,8 @@ public:
 				.detail("Reached", limits.isReached())
 				.detail("ItemsPastEnd", itemsPastEnd)
 				.detail("EndOffset", -end.offset)
-				.detail("ItBegin", printable(it.beginKey().toStandaloneStringRef()))
-				.detail("ItEnd", printable(itEnd.beginKey().toStandaloneStringRef()))
+				.detail("ItBegin", it.beginKey().toStandaloneStringRef())
+				.detail("ItEnd", itEnd.beginKey().toStandaloneStringRef())
 				.detail("Unknown", it.is_unknown_range())
 				.detail("Requests", requestCount);*/
 
@@ -606,13 +606,13 @@ public:
 				ASSERT( !requestLimit.hasRowLimit() || requestLimit.rows > 0 );
 				ASSERT( requestLimit.hasRowLimit() || requestLimit.hasByteLimit() );
 				
-				//TraceEvent("RYWIssuing", randomID).detail("Begin", read_begin.toString()).detail("End", read_end.toString()).detail("Bytes", requestLimit.bytes).detail("Rows", requestLimit.rows).detail("Limits", limits.bytes).detail("Reached", limits.isReached()).detail("RequestCount", requestCount).detail("SingleClears", singleClears).detail("UcEnd", printable(ucEnd.beginKey().toStandaloneStringRef())).detail("MinRows", requestLimit.minRows);
+				//TraceEvent("RYWIssuing", randomID).detail("Begin", read_begin.toString()).detail("End", read_end.toString()).detail("Bytes", requestLimit.bytes).detail("Rows", requestLimit.rows).detail("Limits", limits.bytes).detail("Reached", limits.isReached()).detail("RequestCount", requestCount).detail("SingleClears", singleClears).detail("UcEnd", ucEnd.beginKey().toStandaloneStringRef()).detail("MinRows", requestLimit.minRows);
 
 				additionalRows = 0;
 				Standalone<RangeResultRef> snapshot_read = wait( ryw->tr.getRange( read_begin, read_end, requestLimit, true, false ) );
 				KeyRangeRef range = getKnownKeyRange( snapshot_read, read_begin, read_end, ryw->arena );
 				
-				//TraceEvent("RYWCacheInsert", randomID).detail("Range", printable(range)).detail("ExpectedSize", snapshot_read.expectedSize()).detail("Rows", snapshot_read.size()).detail("Results", printable(snapshot_read)).detail("More", snapshot_read.more).detail("ReadToBegin", snapshot_read.readToBegin).detail("ReadThroughEnd", snapshot_read.readThroughEnd).detail("ReadThrough", printable(snapshot_read.readThrough));
+				//TraceEvent("RYWCacheInsert", randomID).detail("Range", range).detail("ExpectedSize", snapshot_read.expectedSize()).detail("Rows", snapshot_read.size()).detail("Results", snapshot_read).detail("More", snapshot_read.more).detail("ReadToBegin", snapshot_read.readToBegin).detail("ReadThroughEnd", snapshot_read.readThroughEnd).detail("ReadThrough", snapshot_read.readThrough);
 
 				if( ryw->cache.insert( range, snapshot_read ) )
 					ryw->arena.dependsOn(snapshot_read.arena());
@@ -636,7 +636,7 @@ public:
 
 				itemsPastEnd += maxCount - count;
 				
-				//TraceEvent("RYWaddKV", randomID).detail("Key", printable(it.beginKey().toStandaloneStringRef())).detail("Count", count).detail("MaxCount", maxCount).detail("ItemsPastEnd", itemsPastEnd);
+				//TraceEvent("RYWaddKV", randomID).detail("Key", it.beginKey().toStandaloneStringRef()).detail("Count", count).detail("MaxCount", maxCount).detail("ItemsPastEnd", itemsPastEnd);
 				if( count ) result.append( result.arena(), start, count );
 				++it;
 			} else
@@ -785,8 +785,8 @@ public:
 				.detail("Reached", limits.isReached())
 				.detail("ItemsPastBegin", itemsPastBegin)
 				.detail("EndOffset", end.offset)
-				.detail("ItBegin", printable(it.beginKey().toStandaloneStringRef()))
-				.detail("ItEnd", printable(itEnd.beginKey().toStandaloneStringRef()))
+				.detail("ItBegin", it.beginKey().toStandaloneStringRef())
+				.detail("ItEnd", itEnd.beginKey().toStandaloneStringRef())
 				.detail("Unknown", it.is_unknown_range())
 				.detail("Kv", it.is_kv())
 				.detail("Requests", requestCount);*/
@@ -883,13 +883,13 @@ public:
 				ASSERT( !requestLimit.hasRowLimit() || requestLimit.rows > 0 );
 				ASSERT( requestLimit.hasRowLimit() || requestLimit.hasByteLimit() );
 
-				//TraceEvent("RYWIssuing", randomID).detail("Begin", read_begin.toString()).detail("End", read_end.toString()).detail("Bytes", requestLimit.bytes).detail("Rows", requestLimit.rows).detail("Limits", limits.bytes).detail("Reached", limits.isReached()).detail("RequestCount", requestCount).detail("SingleClears", singleClears).detail("UcEnd", printable(ucEnd.beginKey().toStandaloneStringRef())).detail("MinRows", requestLimit.minRows);
+				//TraceEvent("RYWIssuing", randomID).detail("Begin", read_begin.toString()).detail("End", read_end.toString()).detail("Bytes", requestLimit.bytes).detail("Rows", requestLimit.rows).detail("Limits", limits.bytes).detail("Reached", limits.isReached()).detail("RequestCount", requestCount).detail("SingleClears", singleClears).detail("UcEnd", ucEnd.beginKey().toStandaloneStringRef()).detail("MinRows", requestLimit.minRows);
 
 				additionalRows = 0;
 				Standalone<RangeResultRef> snapshot_read = wait( ryw->tr.getRange( read_begin, read_end, requestLimit, true, true ) );
 				KeyRangeRef range = getKnownKeyRangeBack( snapshot_read, read_begin, read_end, ryw->arena );
 
-				//TraceEvent("RYWCacheInsert", randomID).detail("Range", printable(range)).detail("ExpectedSize", snapshot_read.expectedSize()).detail("Rows", snapshot_read.size()).detail("Results", printable(snapshot_read)).detail("More", snapshot_read.more).detail("ReadToBegin", snapshot_read.readToBegin).detail("ReadThroughEnd", snapshot_read.readThroughEnd).detail("ReadThrough", printable(snapshot_read.readThrough));
+				//TraceEvent("RYWCacheInsert", randomID).detail("Range", range).detail("ExpectedSize", snapshot_read.expectedSize()).detail("Rows", snapshot_read.size()).detail("Results", snapshot_read).detail("More", snapshot_read.more).detail("ReadToBegin", snapshot_read.readToBegin).detail("ReadThroughEnd", snapshot_read.readThroughEnd).detail("ReadThrough", snapshot_read.readThrough);
 				
 				RangeResultRef reversed;
 				reversed.resize(ryw->arena, snapshot_read.size());
@@ -917,7 +917,7 @@ public:
 					}
 
 					itemsPastBegin += maxCount - count;
-					//TraceEvent("RYWaddKV", randomID).detail("Key", printable(it.beginKey().toStandaloneStringRef())).detail("Count", count).detail("MaxCount", maxCount).detail("ItemsPastBegin", itemsPastBegin);
+					//TraceEvent("RYWaddKV", randomID).detail("Key", it.beginKey().toStandaloneStringRef()).detail("Count", count).detail("MaxCount", maxCount).detail("ItemsPastBegin", itemsPastBegin);
 					if( count ) {
 						int size = result.size();
 						result.resize(result.arena(),size+count);
@@ -1982,7 +1982,7 @@ void ReadYourWritesTransaction::debugLogRetries(Optional<Error> error) {
 				if(error.present())
 					trace.error(error.get(), true);
 				if(!transactionDebugInfo->transactionName.empty())
-					trace.detail("TransactionName", printable(StringRef(transactionDebugInfo->transactionName)));
+					trace.detail("TransactionName", StringRef(transactionDebugInfo->transactionName));
 				trace.detail("Elapsed", elapsed).detail("Retries", retries).detail("Committed", committed);
 			}
 			transactionDebugInfo->lastRetryLogTime = now();

--- a/fdbclient/ReadYourWrites.actor.cpp
+++ b/fdbclient/ReadYourWrites.actor.cpp
@@ -38,8 +38,8 @@ public:
 				if (kv) key = kv->key;
 			}
 			TraceEvent("RYWDump")
-			    .detail("Begin", it.beginKey().toStandaloneStringRef())
-			    .detail("End", it.endKey().toStandaloneStringRef())
+			    .detail("Begin", it.beginKey())
+			    .detail("End", it.endKey())
 			    .detail("Unknown", it.is_unknown_range())
 			    .detail("Empty", it.is_empty_range())
 			    .detail("KV", it.is_kv())
@@ -512,8 +512,8 @@ public:
 				.detail("Reached", limits.isReached())
 				.detail("ItemsPastEnd", itemsPastEnd)
 				.detail("EndOffset", -end.offset)
-				.detail("ItBegin", it.beginKey().toStandaloneStringRef())
-				.detail("ItEnd", itEnd.beginKey().toStandaloneStringRef())
+				.detail("ItBegin", it.beginKey())
+				.detail("ItEnd", itEnd.beginKey())
 				.detail("Unknown", it.is_unknown_range())
 				.detail("Requests", requestCount);*/
 
@@ -606,7 +606,7 @@ public:
 				ASSERT( !requestLimit.hasRowLimit() || requestLimit.rows > 0 );
 				ASSERT( requestLimit.hasRowLimit() || requestLimit.hasByteLimit() );
 				
-				//TraceEvent("RYWIssuing", randomID).detail("Begin", read_begin.toString()).detail("End", read_end.toString()).detail("Bytes", requestLimit.bytes).detail("Rows", requestLimit.rows).detail("Limits", limits.bytes).detail("Reached", limits.isReached()).detail("RequestCount", requestCount).detail("SingleClears", singleClears).detail("UcEnd", ucEnd.beginKey().toStandaloneStringRef()).detail("MinRows", requestLimit.minRows);
+				//TraceEvent("RYWIssuing", randomID).detail("Begin", read_begin.toString()).detail("End", read_end.toString()).detail("Bytes", requestLimit.bytes).detail("Rows", requestLimit.rows).detail("Limits", limits.bytes).detail("Reached", limits.isReached()).detail("RequestCount", requestCount).detail("SingleClears", singleClears).detail("UcEnd", ucEnd.beginKey()).detail("MinRows", requestLimit.minRows);
 
 				additionalRows = 0;
 				Standalone<RangeResultRef> snapshot_read = wait( ryw->tr.getRange( read_begin, read_end, requestLimit, true, false ) );
@@ -636,7 +636,7 @@ public:
 
 				itemsPastEnd += maxCount - count;
 				
-				//TraceEvent("RYWaddKV", randomID).detail("Key", it.beginKey().toStandaloneStringRef()).detail("Count", count).detail("MaxCount", maxCount).detail("ItemsPastEnd", itemsPastEnd);
+				//TraceEvent("RYWaddKV", randomID).detail("Key", it.beginKey()).detail("Count", count).detail("MaxCount", maxCount).detail("ItemsPastEnd", itemsPastEnd);
 				if( count ) result.append( result.arena(), start, count );
 				++it;
 			} else
@@ -785,8 +785,8 @@ public:
 				.detail("Reached", limits.isReached())
 				.detail("ItemsPastBegin", itemsPastBegin)
 				.detail("EndOffset", end.offset)
-				.detail("ItBegin", it.beginKey().toStandaloneStringRef())
-				.detail("ItEnd", itEnd.beginKey().toStandaloneStringRef())
+				.detail("ItBegin", it.beginKey())
+				.detail("ItEnd", itEnd.beginKey())
 				.detail("Unknown", it.is_unknown_range())
 				.detail("Kv", it.is_kv())
 				.detail("Requests", requestCount);*/
@@ -883,7 +883,7 @@ public:
 				ASSERT( !requestLimit.hasRowLimit() || requestLimit.rows > 0 );
 				ASSERT( requestLimit.hasRowLimit() || requestLimit.hasByteLimit() );
 
-				//TraceEvent("RYWIssuing", randomID).detail("Begin", read_begin.toString()).detail("End", read_end.toString()).detail("Bytes", requestLimit.bytes).detail("Rows", requestLimit.rows).detail("Limits", limits.bytes).detail("Reached", limits.isReached()).detail("RequestCount", requestCount).detail("SingleClears", singleClears).detail("UcEnd", ucEnd.beginKey().toStandaloneStringRef()).detail("MinRows", requestLimit.minRows);
+				//TraceEvent("RYWIssuing", randomID).detail("Begin", read_begin.toString()).detail("End", read_end.toString()).detail("Bytes", requestLimit.bytes).detail("Rows", requestLimit.rows).detail("Limits", limits.bytes).detail("Reached", limits.isReached()).detail("RequestCount", requestCount).detail("SingleClears", singleClears).detail("UcEnd", ucEnd.beginKey()).detail("MinRows", requestLimit.minRows);
 
 				additionalRows = 0;
 				Standalone<RangeResultRef> snapshot_read = wait( ryw->tr.getRange( read_begin, read_end, requestLimit, true, true ) );
@@ -917,7 +917,7 @@ public:
 					}
 
 					itemsPastBegin += maxCount - count;
-					//TraceEvent("RYWaddKV", randomID).detail("Key", it.beginKey().toStandaloneStringRef()).detail("Count", count).detail("MaxCount", maxCount).detail("ItemsPastBegin", itemsPastBegin);
+					//TraceEvent("RYWaddKV", randomID).detail("Key", it.beginKey()).detail("Count", count).detail("MaxCount", maxCount).detail("ItemsPastBegin", itemsPastBegin);
 					if( count ) {
 						int size = result.size();
 						result.resize(result.arena(),size+count);
@@ -1982,7 +1982,7 @@ void ReadYourWritesTransaction::debugLogRetries(Optional<Error> error) {
 				if(error.present())
 					trace.error(error.get(), true);
 				if(!transactionDebugInfo->transactionName.empty())
-					trace.detail("TransactionName", StringRef(transactionDebugInfo->transactionName));
+					trace.detail("TransactionName", transactionDebugInfo->transactionName);
 				trace.detail("Elapsed", elapsed).detail("Retries", retries).detail("Committed", committed);
 			}
 			transactionDebugInfo->lastRetryLogTime = now();

--- a/fdbclient/SnapshotCache.h
+++ b/fdbclient/SnapshotCache.h
@@ -343,7 +343,7 @@ public:
 
 	void dump() {
 		for( auto it = entries.begin(); it != entries.end(); ++it ) {
-			TraceEvent("CacheDump").detail("Begin", printable(it->beginKey)).detail("End", printable(it->endKey.toStandaloneStringRef())).detail("Values", printable(it->values));
+			TraceEvent("CacheDump").detail("Begin", it->beginKey).detail("End", it->endKey.toStandaloneStringRef()).detail("Values", it->values);
 		}
 	}
 

--- a/fdbclient/SnapshotCache.h
+++ b/fdbclient/SnapshotCache.h
@@ -101,6 +101,7 @@ struct ExtStringRef {
 	}
 
 private:
+	friend struct Traceable<ExtStringRef>;
 	StringRef base;
 	int extra_zero_bytes;
 };
@@ -112,6 +113,19 @@ inline bool operator < ( const ExtStringRef& lhs, const ExtStringRef& rhs ) { re
 inline bool operator > ( const ExtStringRef& lhs, const ExtStringRef& rhs ) { return lhs.cmp(rhs)>0; }
 inline bool operator <= ( const ExtStringRef& lhs, const ExtStringRef& rhs ) { return lhs.cmp(rhs)<=0; }
 inline bool operator >= ( const ExtStringRef& lhs, const ExtStringRef& rhs ) { return lhs.cmp(rhs)>=0; }
+
+template<>
+struct Traceable<ExtStringRef> : std::true_type {
+	static std::string toString(const ExtStringRef str) {
+		std::string result;
+		result.reserve(str.size());
+		std::copy(str.base.begin(), str.base.end(), std::back_inserter(result));
+		for (int i = 0; i < str.extra_zero_bytes; ++i) {
+			result.push_back('\0');
+		}
+		return Traceable<std::string>::toString(result);
+	}
+};
 
 class SnapshotCache {
 private:

--- a/fdbclient/SystemData.cpp
+++ b/fdbclient/SystemData.cpp
@@ -483,7 +483,7 @@ Key logRangesEncodeKey(KeyRef keyBegin, UID logUid) {
 // Returns the start key and optionally the logRange Uid
 KeyRef logRangesDecodeKey(KeyRef key, UID* logUid) {
 	if (key.size() < logRangesRange.begin.size() + sizeof(UID)) {
-		TraceEvent(SevError, "InvalidDecodeKey").detail("Key", printable(key));
+		TraceEvent(SevError, "InvalidDecodeKey").detail("Key", key);
 		ASSERT(false);
 	}
 

--- a/fdbclient/TaskBucket.actor.cpp
+++ b/fdbclient/TaskBucket.actor.cpp
@@ -235,15 +235,15 @@ public:
 
 		if (task->params.find(Task::reservedTaskParamValidKey) == task->params.end()) {
 			TraceEvent("TB_TaskVerifyInvalidTask")
-				.detail("Task", printable(task->params[Task::reservedTaskParamKeyType]))
+				.detail("Task", task->params[Task::reservedTaskParamKeyType])
 				.detail("ReservedTaskParamValidKey", "missing");
 			return false;
 		}
 
 		if (task->params.find(Task::reservedTaskParamValidValue) == task->params.end()) {
 			TraceEvent("TB_TaskVerifyInvalidTask")
-				.detail("Task", printable(task->params[Task::reservedTaskParamKeyType]))
-				.detail("ReservedTaskParamValidKey", printable(task->params[Task::reservedTaskParamValidKey]))
+				.detail("Task", task->params[Task::reservedTaskParamKeyType])
+				.detail("ReservedTaskParamValidKey", task->params[Task::reservedTaskParamValidKey])
 				.detail("ReservedTaskParamValidValue", "missing");
 			return false;
 		}
@@ -254,19 +254,19 @@ public:
 
 		if (!keyValue.present()) {
 			TraceEvent("TB_TaskVerifyInvalidTask")
-				.detail("Task", printable(task->params[Task::reservedTaskParamKeyType]))
-				.detail("ReservedTaskParamValidKey", printable(task->params[Task::reservedTaskParamValidKey]))
-				.detail("ReservedTaskParamValidValue", printable(task->params[Task::reservedTaskParamValidValue]))
+				.detail("Task", task->params[Task::reservedTaskParamKeyType])
+				.detail("ReservedTaskParamValidKey", task->params[Task::reservedTaskParamValidKey])
+				.detail("ReservedTaskParamValidValue", task->params[Task::reservedTaskParamValidValue])
 				.detail("KeyValue", "missing");
 			return false;
 		}
 
 		if (keyValue.get().compare(StringRef(task->params[Task::reservedTaskParamValidValue]))) {
 			TraceEvent("TB_TaskVerifyAbortedTask")
-				.detail("Task", printable(task->params[Task::reservedTaskParamKeyType]))
-				.detail("ReservedTaskParamValidKey", printable(task->params[Task::reservedTaskParamValidKey]))
-				.detail("ReservedTaskParamValidValue", printable(task->params[Task::reservedTaskParamValidValue]))
-				.detail("KeyValue", printable(keyValue.get()));
+				.detail("Task", task->params[Task::reservedTaskParamKeyType])
+				.detail("ReservedTaskParamValidKey", task->params[Task::reservedTaskParamValidKey])
+				.detail("ReservedTaskParamValidValue", task->params[Task::reservedTaskParamValidValue])
+				.detail("KeyValue", keyValue.get());
 			return false;
 		}
 
@@ -396,7 +396,7 @@ public:
 		} catch(Error &e) {
 			TraceEvent(SevWarn, "TB_ExecuteFailure")
 				.error(e)
-				.detail("TaskUID", task->key.printable())
+				.detail("TaskUID", task->key.)
 				.detail("TaskType", task->params[Task::reservedTaskParamKeyType].printable())
 				.detail("Priority", task->getPriority());
 			try {
@@ -709,14 +709,14 @@ public:
 		tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
 		tr->setOption(FDBTransactionOptions::LOCK_AWARE);
 		Standalone<RangeResultRef> values = wait(tr->getRange(subspace.range(), CLIENT_KNOBS->TOO_MANY));
-		TraceEvent("TaskBucket").detail("DebugPrintRange", "Print DB Range").detail("Key", printable(subspace.key())).detail("Count", values.size()).detail("Msg", printable(msg));
+		TraceEvent("TaskBucket").detail("DebugPrintRange", "Print DB Range").detail("Key", subspace.key()).detail("Count", values.size()).detail("Msg", msg);
 		/*
 		printf("debugPrintRange  key: (%d) %s\n", values.size(), printable(subspace.key()).c_str());
 		for (auto & s : values) {
-			printf("   key: %-40s   value: %s\n", printable(s.key).c_str(), printable(s.value).c_str());
-			TraceEvent("TaskBucket").detail("DebugPrintRange", printable(msg))
-				.detail("Key", printable(s.key))
-				.detail("Value", printable(s.value));
+		printf("   key: %-40s   value: %s\n", printable(s.key).c_str(), s.value.c_str());
+		TraceEvent("TaskBucket").detail("DebugPrintRange", msg)
+			.detail("Key", s.key)
+			.detail("Value", s.value);
 		}*/
 
 		return Void();
@@ -846,8 +846,8 @@ ACTOR static Future<Key> actorAddTask(TaskBucket* tb, Reference<ReadYourWritesTr
 
 	if (!validationValue.present()) {
 		TraceEvent(SevError, "TB_AddTaskInvalidKey")
-			.detail("Task", printable(task->params[Task::reservedTaskParamKeyType]))
-			.detail("ValidationKey", printable(validationKey));
+			.detail("Task", task->params[Task::reservedTaskParamKeyType])
+			.detail("ValidationKey", validationKey);
 		throw invalid_option_value();
 	}
 
@@ -1114,8 +1114,8 @@ public:
 
 		if (!validationValue.present()) {
 			TraceEvent(SevError, "TB_OnSetAddTaskInvalidKey")
-				.detail("Task", printable(task->params[Task::reservedTaskParamKeyType]))
-				.detail("ValidationKey", printable(validationKey));
+				.detail("Task", task->params[Task::reservedTaskParamKeyType])
+				.detail("ValidationKey", validationKey);
 			throw invalid_option_value();
 		}
 

--- a/fdbclient/TaskBucket.actor.cpp
+++ b/fdbclient/TaskBucket.actor.cpp
@@ -396,7 +396,7 @@ public:
 		} catch(Error &e) {
 			TraceEvent(SevWarn, "TB_ExecuteFailure")
 				.error(e)
-				.detail("TaskUID", task->key.)
+				.detail("TaskUID", task->key)
 				.detail("TaskType", task->params[Task::reservedTaskParamKeyType].printable())
 				.detail("Priority", task->getPriority());
 			try {

--- a/fdbclient/TaskBucket.actor.cpp
+++ b/fdbclient/TaskBucket.actor.cpp
@@ -710,13 +710,13 @@ public:
 		tr->setOption(FDBTransactionOptions::LOCK_AWARE);
 		Standalone<RangeResultRef> values = wait(tr->getRange(subspace.range(), CLIENT_KNOBS->TOO_MANY));
 		TraceEvent("TaskBucket").detail("DebugPrintRange", "Print DB Range").detail("Key", subspace.key()).detail("Count", values.size()).detail("Msg", msg);
-		/*
-		printf("debugPrintRange  key: (%d) %s\n", values.size(), printable(subspace.key()).c_str());
+		
+		/*printf("debugPrintRange  key: (%d) %s\n", values.size(), printable(subspace.key()).c_str());
 		for (auto & s : values) {
-		printf("   key: %-40s   value: %s\n", printable(s.key).c_str(), s.value.c_str());
-		TraceEvent("TaskBucket").detail("DebugPrintRange", msg)
-			.detail("Key", s.key)
-			.detail("Value", s.value);
+			printf("   key: %-40s   value: %s\n", printable(s.key).c_str(), s.value.c_str());
+			TraceEvent("TaskBucket").detail("DebugPrintRange", msg)
+				.detail("Key", s.key)
+				.detail("Value", s.value);
 		}*/
 
 		return Void();

--- a/fdbclient/WriteMap.h
+++ b/fdbclient/WriteMap.h
@@ -544,7 +544,7 @@ private:
 		it.skip(allKeys.begin);
 		while( it.beginKey() < allKeys.end ) {
 			TraceEvent("WriteMapDump").detail("Begin", it.beginKey().toStandaloneStringRef())
-				.detail("End", it.endKey().toStandaloneStringRef())
+				.detail("End", it.endKey())
 				.detail("Cleared", it.is_cleared_range())
 				.detail("Conflicted", it.is_conflict_range())
 				.detail("Operation", it.is_operation())

--- a/fdbclient/WriteMap.h
+++ b/fdbclient/WriteMap.h
@@ -543,8 +543,8 @@ private:
 		iterator it( this );
 		it.skip(allKeys.begin);
 		while( it.beginKey() < allKeys.end ) {
-			TraceEvent("WriteMapDump").detail("Begin", printable(it.beginKey().toStandaloneStringRef()))
-				.detail("End", printable(it.endKey().toStandaloneStringRef()))
+			TraceEvent("WriteMapDump").detail("Begin", it.beginKey().toStandaloneStringRef())
+				.detail("End", it.endKey().toStandaloneStringRef())
 				.detail("Cleared", it.is_cleared_range())
 				.detail("Conflicted", it.is_conflict_range())
 				.detail("Operation", it.is_operation())

--- a/fdbrpc/ReplicationPolicy.h
+++ b/fdbrpc/ReplicationPolicy.h
@@ -255,7 +255,7 @@ void serializeReplicationPolicy(Ar& ar, Reference<IReplicationPolicy>& policy) {
 		}
 		else {
 			TraceEvent(SevError, "SerializingInvalidPolicyType")
-				.detailext("PolicyName", name);
+				.detail("PolicyName", name);
 		}
 	}
 	else {

--- a/fdbrpc/sim2.actor.cpp
+++ b/fdbrpc/sim2.actor.cpp
@@ -986,9 +986,9 @@ public:
 			if( machine.processes[i]->locality.machineId() != locality.machineId() ) { // SOMEDAY: compute ip from locality to avoid this check
 				TraceEvent("Sim2Mismatch")
 				    .detail("IP", format("%s", ip.toString().c_str()))
-				    .detailext("MachineId", locality.machineId())
+				    .detail("MachineId", locality.machineId())
 				    .detail("NewName", name)
-				    .detailext("ExistingMachineId", machine.processes[i]->locality.machineId())
+				    .detail("ExistingMachineId", machine.processes[i]->locality.machineId())
 				    .detail("ExistingName", machine.processes[i]->name);
 				ASSERT( false );
 			}
@@ -1025,7 +1025,7 @@ public:
 		m->setGlobal(enNetworkConnections, (flowGlobalType) m->network);
 		m->setGlobal(enASIOTimedOut, (flowGlobalType) false);
 
-		TraceEvent("NewMachine").detail("Name", name).detail("Address", m->address).detailext("MachineId", m->locality.machineId()).detail("Excluded", m->excluded).detail("Cleared", m->cleared);
+		TraceEvent("NewMachine").detail("Name", name).detail("Address", m->address).detail("MachineId", m->locality.machineId()).detail("Excluded", m->excluded).detail("Cleared", m->cleared);
 
 		// FIXME: Sometimes, connections to/from this process will explicitly close
 
@@ -1210,7 +1210,7 @@ public:
 	}
 
 	virtual void destroyProcess( ISimulator::ProcessInfo *p ) {
-		TraceEvent("ProcessDestroyed").detail("Name", p->name).detail("Address", p->address).detailext("MachineId", p->locality.machineId());
+		TraceEvent("ProcessDestroyed").detail("Name", p->name).detail("Address", p->address).detail("MachineId", p->locality.machineId());
 		currentlyRebootingProcesses.insert(std::pair<NetworkAddress, ProcessInfo*>(p->address, p));
 		std::vector<ProcessInfo*>& processes = machines[ p->locality.machineId().get() ].processes;
 		if( p != processes.back() ) {
@@ -1226,12 +1226,12 @@ public:
 		TEST( kt == InjectFaults ); // Simulated machine was killed with faults
 
 		if (kt == KillInstantly) {
-			TraceEvent(SevWarn, "FailMachine").detail("Name", machine->name).detail("Address", machine->address).detailext("ZoneId", machine->locality.zoneId()).detail("Process", machine->toString()).detail("Rebooting", machine->rebooting).detail("Protected", protectedAddresses.count(machine->address)).backtrace();
+			TraceEvent(SevWarn, "FailMachine").detail("Name", machine->name).detail("Address", machine->address).detail("ZoneId", machine->locality.zoneId()).detail("Process", machine->toString()).detail("Rebooting", machine->rebooting).detail("Protected", protectedAddresses.count(machine->address)).backtrace();
 			// This will remove all the "tracked" messages that came from the machine being killed
 			latestEventCache.clear();
 			machine->failed = true;
 		} else if (kt == InjectFaults) {
-			TraceEvent(SevWarn, "FaultMachine").detail("Name", machine->name).detail("Address", machine->address).detailext("ZoneId", machine->locality.zoneId()).detail("Process", machine->toString()).detail("Rebooting", machine->rebooting).detail("Protected", protectedAddresses.count(machine->address)).backtrace();
+			TraceEvent(SevWarn, "FaultMachine").detail("Name", machine->name).detail("Address", machine->address).detail("ZoneId", machine->locality.zoneId()).detail("Process", machine->toString()).detail("Rebooting", machine->rebooting).detail("Protected", protectedAddresses.count(machine->address)).backtrace();
 			should_inject_fault = simulator_should_inject_fault;
 			machine->fault_injection_r = g_random->randomUniqueID().first();
 			machine->fault_injection_p1 = 0.1;
@@ -1302,7 +1302,7 @@ public:
 		TEST(kt == InjectFaults);  // Trying to kill by injecting faults
 
 		if(speedUpSimulation && !forceKill) {
-			TraceEvent(SevWarn, "AbortedKill").detailext("MachineId", machineId).detail("Reason", "Unforced kill within speedy simulation.").backtrace();
+			TraceEvent(SevWarn, "AbortedKill").detail("MachineId", machineId).detail("Reason", "Unforced kill within speedy simulation.").backtrace();
 			if (ktFinal) *ktFinal = None;
 			return false;
 		}
@@ -1320,7 +1320,7 @@ public:
 
 		// Do nothing, if no processes to kill
 		if (processesOnMachine == 0) {
-			TraceEvent(SevWarn, "AbortedKill").detailext("MachineId", machineId).detail("Reason", "The target had no processes running.").detail("Processes", processesOnMachine).detail("ProcessesPerMachine", processesPerMachine).backtrace();
+			TraceEvent(SevWarn, "AbortedKill").detail("MachineId", machineId).detail("Reason", "The target had no processes running.").detail("Processes", processesOnMachine).detail("ProcessesPerMachine", processesPerMachine).backtrace();
 			if (ktFinal) *ktFinal = None;
 			return false;
 		}
@@ -1357,24 +1357,24 @@ public:
 				}
 			}
 			if (!canKillProcesses(processesLeft, processesDead, kt, &kt)) {
-				TraceEvent("ChangedKillMachine").detailext("MachineId", machineId).detail("KillType", kt).detail("OrigKillType", ktOrig).detail("ProcessesLeft", processesLeft.size()).detail("ProcessesDead", processesDead.size()).detail("TotalProcesses", machines.size()).detail("ProcessesPerMachine", processesPerMachine).detail("Protected", protectedWorker).detail("Unavailable", unavailable).detail("Excluded", excluded).detail("Cleared", cleared).detail("ProtectedTotal", protectedAddresses.size()).detail("TLogPolicy", tLogPolicy->info()).detail("StoragePolicy", storagePolicy->info());
+				TraceEvent("ChangedKillMachine").detail("MachineId", machineId).detail("KillType", kt).detail("OrigKillType", ktOrig).detail("ProcessesLeft", processesLeft.size()).detail("ProcessesDead", processesDead.size()).detail("TotalProcesses", machines.size()).detail("ProcessesPerMachine", processesPerMachine).detail("Protected", protectedWorker).detail("Unavailable", unavailable).detail("Excluded", excluded).detail("Cleared", cleared).detail("ProtectedTotal", protectedAddresses.size()).detail("TLogPolicy", tLogPolicy->info()).detail("StoragePolicy", storagePolicy->info());
 			}
 			else if ((kt == KillInstantly) || (kt == InjectFaults)) {
-				TraceEvent("DeadMachine").detailext("MachineId", machineId).detail("KillType", kt).detail("ProcessesLeft", processesLeft.size()).detail("ProcessesDead", processesDead.size()).detail("TotalProcesses", machines.size()).detail("ProcessesPerMachine", processesPerMachine).detail("TLogPolicy", tLogPolicy->info()).detail("StoragePolicy", storagePolicy->info());
+				TraceEvent("DeadMachine").detail("MachineId", machineId).detail("KillType", kt).detail("ProcessesLeft", processesLeft.size()).detail("ProcessesDead", processesDead.size()).detail("TotalProcesses", machines.size()).detail("ProcessesPerMachine", processesPerMachine).detail("TLogPolicy", tLogPolicy->info()).detail("StoragePolicy", storagePolicy->info());
 				for (auto process : processesLeft) {
-					TraceEvent("DeadMachineSurvivors").detailext("MachineId", machineId).detail("KillType", kt).detail("ProcessesLeft", processesLeft.size()).detail("ProcessesDead", processesDead.size()).detail("SurvivingProcess", process->toString());
+					TraceEvent("DeadMachineSurvivors").detail("MachineId", machineId).detail("KillType", kt).detail("ProcessesLeft", processesLeft.size()).detail("ProcessesDead", processesDead.size()).detail("SurvivingProcess", process->toString());
 				}
 				for (auto process : processesDead) {
-					TraceEvent("DeadMachineVictims").detailext("MachineId", machineId).detail("KillType", kt).detail("ProcessesLeft", processesLeft.size()).detail("ProcessesDead", processesDead.size()).detail("VictimProcess", process->toString());
+					TraceEvent("DeadMachineVictims").detail("MachineId", machineId).detail("KillType", kt).detail("ProcessesLeft", processesLeft.size()).detail("ProcessesDead", processesDead.size()).detail("VictimProcess", process->toString());
 				}
 			}
 			else {
-				TraceEvent("ClearMachine").detailext("MachineId", machineId).detail("KillType", kt).detail("ProcessesLeft", processesLeft.size()).detail("ProcessesDead", processesDead.size()).detail("TotalProcesses", machines.size()).detail("ProcessesPerMachine", processesPerMachine).detail("TLogPolicy", tLogPolicy->info()).detail("StoragePolicy", storagePolicy->info());
+				TraceEvent("ClearMachine").detail("MachineId", machineId).detail("KillType", kt).detail("ProcessesLeft", processesLeft.size()).detail("ProcessesDead", processesDead.size()).detail("TotalProcesses", machines.size()).detail("ProcessesPerMachine", processesPerMachine).detail("TLogPolicy", tLogPolicy->info()).detail("StoragePolicy", storagePolicy->info());
 				for (auto process : processesLeft) {
-					TraceEvent("ClearMachineSurvivors").detailext("MachineId", machineId).detail("KillType", kt).detail("ProcessesLeft", processesLeft.size()).detail("ProcessesDead", processesDead.size()).detail("SurvivingProcess", process->toString());
+					TraceEvent("ClearMachineSurvivors").detail("MachineId", machineId).detail("KillType", kt).detail("ProcessesLeft", processesLeft.size()).detail("ProcessesDead", processesDead.size()).detail("SurvivingProcess", process->toString());
 				}
 				for (auto process : processesDead) {
-					TraceEvent("ClearMachineVictims").detailext("MachineId", machineId).detail("KillType", kt).detail("ProcessesLeft", processesLeft.size()).detail("ProcessesDead", processesDead.size()).detail("VictimProcess", process->toString());
+					TraceEvent("ClearMachineVictims").detail("MachineId", machineId).detail("KillType", kt).detail("ProcessesLeft", processesLeft.size()).detail("ProcessesDead", processesDead.size()).detail("VictimProcess", process->toString());
 				}
 			}
 		}
@@ -1384,7 +1384,7 @@ public:
 		// Check if any processes on machine are rebooting
 		if( processesOnMachine != processesPerMachine && kt >= RebootAndDelete ) {
 			TEST(true); //Attempted reboot, but the target did not have all of its processes running
-			TraceEvent(SevWarn, "AbortedKill").detail("KillType", kt).detailext("MachineId", machineId).detail("Reason", "Machine processes does not match number of processes per machine").detail("Processes", processesOnMachine).detail("ProcessesPerMachine", processesPerMachine).backtrace();
+			TraceEvent(SevWarn, "AbortedKill").detail("KillType", kt).detail("MachineId", machineId).detail("Reason", "Machine processes does not match number of processes per machine").detail("Processes", processesOnMachine).detail("ProcessesPerMachine", processesPerMachine).backtrace();
 			if (ktFinal) *ktFinal = None;
 			return false;
 		}
@@ -1392,12 +1392,12 @@ public:
 		// Check if any processes on machine are rebooting
 		if ( processesOnMachine != processesPerMachine ) {
 			TEST(true); //Attempted reboot, but the target did not have all of its processes running
-			TraceEvent(SevWarn, "AbortedKill").detail("KillType", kt).detailext("MachineId", machineId).detail("Reason", "Machine processes does not match number of processes per machine").detail("Processes", processesOnMachine).detail("ProcessesPerMachine", processesPerMachine).backtrace();
+			TraceEvent(SevWarn, "AbortedKill").detail("KillType", kt).detail("MachineId", machineId).detail("Reason", "Machine processes does not match number of processes per machine").detail("Processes", processesOnMachine).detail("ProcessesPerMachine", processesPerMachine).backtrace();
 			if (ktFinal) *ktFinal = None;
 			return false;
 		}
 
-		TraceEvent("KillMachine").detailext("MachineId", machineId).detail("Kt", kt).detail("KtOrig", ktOrig).detail("KillableMachines", processesOnMachine).detail("ProcessPerMachine", processesPerMachine).detail("KillChanged", kt!=ktOrig);
+		TraceEvent("KillMachine").detail("MachineId", machineId).detail("Kt", kt).detail("KtOrig", ktOrig).detail("KillableMachines", processesOnMachine).detail("ProcessPerMachine", processesPerMachine).detail("KillChanged", kt!=ktOrig);
 		if ( kt < RebootAndDelete ) {
 			if(kt == InjectFaults && machines[machineId].machineProcess != nullptr)
 				killProcess_internal( machines[machineId].machineProcess, kt );
@@ -1438,7 +1438,7 @@ public:
 			if (processDcId.present() && (processDcId == dcId)) {
 				if ((kt != Reboot) && (protectedAddresses.count(procRecord->address))) {
 					kt = Reboot;
-					TraceEvent(SevWarn, "DcKillChanged").detailext("DataCenter", dcId).detail("KillType", kt).detail("OrigKillType", ktOrig)
+					TraceEvent(SevWarn, "DcKillChanged").detail("DataCenter", dcId).detail("KillType", kt).detail("OrigKillType", ktOrig)
 						.detail("Reason", "Datacenter has protected process").detail("ProcessAddress", procRecord->address).detail("Failed", procRecord->failed).detail("Rebooting", procRecord->rebooting).detail("Excluded", procRecord->excluded).detail("Cleared", procRecord->cleared).detail("Process", procRecord->toString());
 				}
 				datacenterMachines[processMachineId.get()] ++;
@@ -1463,15 +1463,15 @@ public:
 			}
 
 			if (!canKillProcesses(processesLeft, processesDead, kt, &kt)) {
-				TraceEvent(SevWarn, "DcKillChanged").detailext("DataCenter", dcId).detail("KillType", kt).detail("OrigKillType", ktOrig);
+				TraceEvent(SevWarn, "DcKillChanged").detail("DataCenter", dcId).detail("KillType", kt).detail("OrigKillType", ktOrig);
 			}
 			else {
-				TraceEvent("DeadDataCenter").detailext("DataCenter", dcId).detail("KillType", kt).detail("DcZones", datacenterMachines.size()).detail("DcProcesses", dcProcesses).detail("ProcessesDead", processesDead.size()).detail("ProcessesLeft", processesLeft.size()).detail("TLogPolicy", tLogPolicy->info()).detail("StoragePolicy", storagePolicy->info());
+				TraceEvent("DeadDataCenter").detail("DataCenter", dcId).detail("KillType", kt).detail("DcZones", datacenterMachines.size()).detail("DcProcesses", dcProcesses).detail("ProcessesDead", processesDead.size()).detail("ProcessesLeft", processesLeft.size()).detail("TLogPolicy", tLogPolicy->info()).detail("StoragePolicy", storagePolicy->info());
 				for (auto process : processesLeft) {
-					TraceEvent("DeadDcSurvivors").detailext("MachineId", process->locality.machineId()).detail("KillType", kt).detail("ProcessesLeft", processesLeft.size()).detail("ProcessesDead", processesDead.size()).detail("SurvivingProcess", process->toString());
+					TraceEvent("DeadDcSurvivors").detail("MachineId", process->locality.machineId()).detail("KillType", kt).detail("ProcessesLeft", processesLeft.size()).detail("ProcessesDead", processesDead.size()).detail("SurvivingProcess", process->toString());
 				}
 				for (auto process : processesDead) {
-					TraceEvent("DeadDcVictims").detailext("MachineId", process->locality.machineId()).detail("KillType", kt).detail("ProcessesLeft", processesLeft.size()).detail("ProcessesDead", processesDead.size()).detail("VictimProcess", process->toString());
+					TraceEvent("DeadDcVictims").detail("MachineId", process->locality.machineId()).detail("KillType", kt).detail("ProcessesLeft", processesLeft.size()).detail("ProcessesDead", processesDead.size()).detail("VictimProcess", process->toString());
 				}
 			}
 		}
@@ -1482,7 +1482,7 @@ public:
 				killMachine(datacenterMachine.first, kt, true, &ktResult);
 				if (ktResult != kt) {
 					TraceEvent(SevWarn, "KillDCFail")
-						.detailext("Zone", datacenterMachine.first)
+						.detail("Zone", datacenterMachine.first)
 						.detail("KillType", kt)
 						.detail("KillTypeResult", ktResult)
 						.detail("KillTypeOrig", ktOrig);
@@ -1495,7 +1495,7 @@ public:
 		TraceEvent("KillDataCenter")
 			.detail("DcZones", datacenterMachines.size())
 			.detail("DcProcesses", dcProcesses)
-			.detailext("DCID", dcId)
+			.detail("DCID", dcId)
 			.detail("KillType", kt)
 			.detail("KillTypeOrig", ktOrig)
 			.detail("KillTypeMin", ktMin)
@@ -1694,7 +1694,7 @@ static double networkLatency() {
 }
 
 ACTOR void doReboot( ISimulator::ProcessInfo *p, ISimulator::KillType kt ) {
-	TraceEvent("RebootingProcessAttempt").detailext("ZoneId", p->locality.zoneId()).detail("KillType", kt).detail("Process", p->toString()).detail("StartingClass", p->startingClass.toString()).detail("Failed", p->failed).detail("Excluded", p->excluded).detail("Cleared", p->cleared).detail("Rebooting", p->rebooting).detail("TaskDefaultDelay", TaskDefaultDelay);
+	TraceEvent("RebootingProcessAttempt").detail("ZoneId", p->locality.zoneId()).detail("KillType", kt).detail("Process", p->toString()).detail("StartingClass", p->startingClass.toString()).detail("Failed", p->failed).detail("Excluded", p->excluded).detail("Cleared", p->cleared).detail("Rebooting", p->rebooting).detail("TaskDefaultDelay", TaskDefaultDelay);
 
 	wait( g_sim2.delay( 0, TaskDefaultDelay, p ) ); // Switch to the machine in question
 
@@ -1708,7 +1708,7 @@ ACTOR void doReboot( ISimulator::ProcessInfo *p, ISimulator::KillType kt ) {
 
 		if( p->rebooting )
 			return;
-		TraceEvent("RebootingProcess").detail("KillType", kt).detail("Address", p->address).detailext("ZoneId", p->locality.zoneId()).detailext("DataHall", p->locality.dataHallId()).detail("Locality", p->locality.toString()).detail("Failed", p->failed).detail("Excluded", p->excluded).detail("Cleared", p->cleared).backtrace();
+		TraceEvent("RebootingProcess").detail("KillType", kt).detail("Address", p->address).detail("ZoneId", p->locality.zoneId()).detail("DataHall", p->locality.dataHallId()).detail("Locality", p->locality.toString()).detail("Failed", p->failed).detail("Excluded", p->excluded).detail("Cleared", p->cleared).backtrace();
 		p->rebooting = true;
 		if ((kt == ISimulator::RebootAndDelete) || (kt == ISimulator::RebootProcessAndDelete)) {
 			p->cleared = true;

--- a/fdbserver/ApplyMetadataMutation.h
+++ b/fdbserver/ApplyMetadataMutation.h
@@ -151,7 +151,10 @@ static void applyMetadataMutations(UID const& dbgid, Arena &arena, VectorRef<Mut
 				if(Optional<StringRef>(m.param2) != txnStateStore->readValue(m.param1).get().castTo<StringRef>()) { // FIXME: Make this check more specific, here or by reading configuration whenever there is a change
 					if(!m.param1.startsWith( excludedServersPrefix ) && m.param1 != excludedServersVersionKey) {
 						auto t = txnStateStore->readValue(m.param1).get();
-						TraceEvent("MutationRequiresRestart", dbgid).detail("M", m.toString()).detail("PrevValue", t.present() ? t.get() : "(none)").detail("ToCommit", toCommit!=NULL);
+						TraceEvent("MutationRequiresRestart", dbgid)
+							.detail("M", m.toString())
+							.detail("PrevValue", t.present() ? t.get() : LiteralStringRef("(none)"))
+							.detail("ToCommit", toCommit!=NULL);
 						if(confChange) *confChange = true;
 					}
 				}

--- a/fdbserver/ApplyMetadataMutation.h
+++ b/fdbserver/ApplyMetadataMutation.h
@@ -106,7 +106,7 @@ static void applyMetadataMutations(UID const& dbgid, Arena &arena, VectorRef<Mut
 					MutationRef privatized = m;
 					privatized.param1 = m.param1.withPrefix(systemKeys.begin, arena);
 					TraceEvent(SevDebug, "SendingPrivateMutation", dbgid).detail("Original", m.toString()).detail("Privatized", privatized.toString()).detail("Server", serverKeysDecodeServer(m.param1))
-						.detail("TagKey", printable(serverTagKeyFor( serverKeysDecodeServer(m.param1) ))).detail("Tag", decodeServerTagValue( txnStateStore->readValue( serverTagKeyFor( serverKeysDecodeServer(m.param1) ) ).get().get() ).toString());
+						.detail("TagKey", serverTagKeyFor( serverKeysDecodeServer(m.param1) )).detail("Tag", decodeServerTagValue( txnStateStore->readValue( serverTagKeyFor( serverKeysDecodeServer(m.param1) ) ).get().get() ).toString());
 
 					toCommit->addTag( decodeServerTagValue( txnStateStore->readValue( serverTagKeyFor( serverKeysDecodeServer(m.param1) ) ).get().get() ) );
 					toCommit->addTypedMessage(privatized);
@@ -151,7 +151,7 @@ static void applyMetadataMutations(UID const& dbgid, Arena &arena, VectorRef<Mut
 				if(Optional<StringRef>(m.param2) != txnStateStore->readValue(m.param1).get().castTo<StringRef>()) { // FIXME: Make this check more specific, here or by reading configuration whenever there is a change
 					if(!m.param1.startsWith( excludedServersPrefix ) && m.param1 != excludedServersVersionKey) {
 						auto t = txnStateStore->readValue(m.param1).get();
-						TraceEvent("MutationRequiresRestart", dbgid).detail("M", m.toString()).detail("PrevValue", t.present() ? printable(t.get()) : "(none)").detail("ToCommit", toCommit!=NULL);
+						TraceEvent("MutationRequiresRestart", dbgid).detail("M", m.toString()).detail("PrevValue", t.present() ? t.get() : "(none)").detail("ToCommit", toCommit!=NULL);
 						if(confChange) *confChange = true;
 					}
 				}
@@ -230,8 +230,8 @@ static void applyMetadataMutations(UID const& dbgid, Arena &arena, VectorRef<Mut
 					}
 
 					// Log the modification
-					TraceEvent("LogRangeAdd").detail("LogRanges", vecBackupKeys->size()).detail("MutationKey", printable(m.param1))
-						.detail("LogRangeBegin", printable(logRangeBegin)).detail("LogRangeEnd", printable(logRangeEnd));
+					TraceEvent("LogRangeAdd").detail("LogRanges", vecBackupKeys->size()).detail("MutationKey", m.param1)
+						.detail("LogRangeBegin", logRangeBegin).detail("LogRangeEnd", logRangeEnd);
 				}
 			}
 			else if (m.param1.startsWith(globalKeysPrefix)) {
@@ -383,8 +383,8 @@ static void applyMetadataMutations(UID const& dbgid, Arena &arena, VectorRef<Mut
 				KeyRangeRef commonLogRange(range & logRangesRange);
 
 				TraceEvent("LogRangeClear")
-					.detail("RangeBegin", printable(range.begin)).detail("RangeEnd", printable(range.end))
-					.detail("IntersectBegin", printable(commonLogRange.begin)).detail("IntersectEnd", printable(commonLogRange.end));
+					.detail("RangeBegin", range.begin).detail("RangeEnd", range.end)
+					.detail("IntersectBegin", commonLogRange.begin).detail("IntersectEnd", commonLogRange.end);
 
 				// Remove the key range from the vector, if defined
 				if (vecBackupKeys) {
@@ -406,9 +406,9 @@ static void applyMetadataMutations(UID const& dbgid, Arena &arena, VectorRef<Mut
 						// Decode the log destination and key value
 						logKeyEnd = logRangesDecodeValue(logRangeAffected.value, &logDestination);
 
-						TraceEvent("LogRangeErase").detail("AffectedKey", printable(logRangeAffected.key)).detail("AffectedValue", printable(logRangeAffected.value))
-							.detail("LogKeyBegin", printable(logKeyBegin)).detail("LogKeyEnd", printable(logKeyEnd))
-							.detail("LogDestination", printable(logDestination));
+						TraceEvent("LogRangeErase").detail("AffectedKey", logRangeAffected.key).detail("AffectedValue", logRangeAffected.value)
+							.detail("LogKeyBegin", logKeyBegin).detail("LogKeyEnd", logKeyEnd)
+							.detail("LogDestination", logDestination);
 
 						// Identify the locations to place the backup key
 						auto logRanges = vecBackupKeys->modify(KeyRangeRef(logKeyBegin, logKeyEnd));

--- a/fdbserver/CMakeLists.txt
+++ b/fdbserver/CMakeLists.txt
@@ -66,13 +66,6 @@ set(FDBSERVER_SRCS
   SimulatedCluster.actor.cpp
   SimulatedCluster.h
   SkipList.cpp
-  sqlite/btree.h
-  sqlite/hash.h
-  sqlite/sqlite3.h
-  sqlite/sqlite3ext.h
-  sqlite/sqliteInt.h
-  sqlite/sqliteLimit.h
-  sqlite/sqlite3.amalgamation.c
   Status.actor.cpp
   Status.h
   StorageMetrics.actor.h

--- a/fdbserver/CMakeLists.txt
+++ b/fdbserver/CMakeLists.txt
@@ -170,6 +170,18 @@ set(FDBSERVER_SRCS
   workloads/WriteBandwidth.actor.cpp
   workloads/WriteDuringRead.actor.cpp)
 
+set(SQLITE_SRCS
+  sqlite/btree.h
+  sqlite/hash.h
+  sqlite/sqlite3.h
+  sqlite/sqlite3ext.h
+  sqlite/sqliteInt.h
+  sqlite/sqliteLimit.h
+  sqlite/sqlite3.amalgamation.c)
+
+add_library(sqlite ${SQLITE_SRCS})
+target_compile_definitions(sqlite PRIVATE $<$<CONFIG:Debug>:NDEBUG>)
+
 set(java_workload_docstring "Build the Java workloads (makes fdbserver link against JNI)")
 if(FDB_RELEASE)
   set(WITH_JAVA_WORKLOAD OFF CACHE BOOL "${java_workload_docstring}")
@@ -188,7 +200,7 @@ add_flow_target(EXECUTABLE NAME fdbserver SRCS ${FDBSERVER_SRCS})
 target_include_directories(fdbserver PRIVATE
   ${CMAKE_CURRENT_BINARY_DIR}/workloads
   ${CMAKE_CURRENT_SOURCE_DIR}/workloads)
-target_link_libraries(fdbserver PRIVATE fdbclient)
+target_link_libraries(fdbserver PRIVATE fdbclient sqlite)
 if(WITH_JAVA_WORKLOAD)
   if(NOT JNI_FOUND)
     message(SEND_ERROR "Trying to build Java workload but couldn't find JNI")

--- a/fdbserver/ClusterController.actor.cpp
+++ b/fdbserver/ClusterController.actor.cpp
@@ -2449,7 +2449,7 @@ ACTOR Future<Void> doEmptyCommit(Database cx) {
 ACTOR Future<Void> handleForcedRecoveries( ClusterControllerData *self, ClusterControllerFullInterface interf ) {
 	loop {
 		state ForceRecoveryRequest req = waitNext( interf.clientInterface.forceRecovery.getFuture() );
-		TraceEvent("ForcedRecoveryStart", self->id).detail("ClusterControllerDcId", printable(self->clusterControllerDcId)).detail("DcId", req.dcId.printable());
+		TraceEvent("ForcedRecoveryStart", self->id).detail("ClusterControllerDcId", self->clusterControllerDcId).detail("DcId", req.dcId.printable());
 		state Future<Void> fCommit = doEmptyCommit(self->cx);
 		wait(fCommit || delay(SERVER_KNOBS->FORCE_RECOVERY_CHECK_DELAY));
 		if(!fCommit.isReady() || fCommit.isError()) {

--- a/fdbserver/ClusterController.actor.cpp
+++ b/fdbserver/ClusterController.actor.cpp
@@ -1843,9 +1843,9 @@ void registerWorker( RegisterWorkerRequest req, ClusterControllerData *self ) {
 	newPriorityInfo.processClassFitness = newProcessClass.machineClassFitness(ProcessClass::ClusterController);
 
 	if(info == self->id_worker.end()) {
-		TraceEvent("ClusterControllerActualWorkers", self->id).detail("WorkerId",w.id()).detailext("ProcessId", w.locality.processId()).detailext("ZoneId", w.locality.zoneId()).detailext("DataHall", w.locality.dataHallId()).detail("PClass", req.processClass.toString()).detail("Workers", self->id_worker.size());
+		TraceEvent("ClusterControllerActualWorkers", self->id).detail("WorkerId",w.id()).detail("ProcessId", w.locality.processId()).detail("ZoneId", w.locality.zoneId()).detail("DataHall", w.locality.dataHallId()).detail("PClass", req.processClass.toString()).detail("Workers", self->id_worker.size());
 	} else {
-		TraceEvent("ClusterControllerWorkerAlreadyRegistered", self->id).suppressFor(1.0).detail("WorkerId",w.id()).detailext("ProcessId", w.locality.processId()).detailext("ZoneId", w.locality.zoneId()).detailext("DataHall", w.locality.dataHallId()).detail("PClass", req.processClass.toString()).detail("Workers", self->id_worker.size());
+		TraceEvent("ClusterControllerWorkerAlreadyRegistered", self->id).suppressFor(1.0).detail("WorkerId",w.id()).detail("ProcessId", w.locality.processId()).detail("ZoneId", w.locality.zoneId()).detail("DataHall", w.locality.dataHallId()).detail("PClass", req.processClass.toString()).detail("Workers", self->id_worker.size());
 	}
 	if ( w.address() == g_network->getLocalAddress() ) {
 		if(self->changingDcIds.get().first) {

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -2561,8 +2561,8 @@ ACTOR Future<Void> teamTracker(DDTeamCollection* self, Reference<TCTeamInfo> tea
 						if(g_random->random01() < 0.01) {
 							TraceEvent("SendRelocateToDDQx100", self->distributorId)
 								.detail("Team", team->getDesc())
-								.detail("KeyBegin", printable(rs.keys.begin))
-								.detail("KeyEnd", printable(rs.keys.end))
+								.detail("KeyBegin", rs.keys.begin)
+								.detail("KeyEnd", rs.keys.end)
 								.detail("Priority", rs.priority)
 								.detail("TeamFailedMachines", team->size() - serversLeft)
 								.detail("TeamOKMachines", serversLeft);
@@ -3259,14 +3259,14 @@ ACTOR Future<Void> updateReplicasKey(DDTeamCollection* self, Optional<Key> dcId)
 
 	wait(self->initialFailureReactionDelay && waitForAll(serverUpdates));
 	wait(waitUntilHealthy(self));
-	TraceEvent("DDUpdatingReplicas", self->distributorId).detail("DcId", printable(dcId)).detail("Replicas", self->configuration.storageTeamSize);
+	TraceEvent("DDUpdatingReplicas", self->distributorId).detail("DcId", dcId).detail("Replicas", self->configuration.storageTeamSize);
 	state Transaction tr(self->cx);
 	loop {
 		try {
 			Optional<Value> val = wait( tr.get(datacenterReplicasKeyFor(dcId)) );
 			state int oldReplicas = val.present() ? decodeDatacenterReplicasValue(val.get()) : 0;
 			if(oldReplicas == self->configuration.storageTeamSize) {
-				TraceEvent("DDUpdatedAlready", self->distributorId).detail("DcId", printable(dcId)).detail("Replicas", self->configuration.storageTeamSize);
+				TraceEvent("DDUpdatedAlready", self->distributorId).detail("DcId", dcId).detail("Replicas", self->configuration.storageTeamSize);
 				return Void();
 			}
 			if(oldReplicas < self->configuration.storageTeamSize) {
@@ -3274,7 +3274,7 @@ ACTOR Future<Void> updateReplicasKey(DDTeamCollection* self, Optional<Key> dcId)
 			}
 			tr.set(datacenterReplicasKeyFor(dcId), datacenterReplicasValue(self->configuration.storageTeamSize));
 			wait( tr.commit() );
-			TraceEvent("DDUpdatedReplicas", self->distributorId).detail("DcId", printable(dcId)).detail("Replicas", self->configuration.storageTeamSize).detail("OldReplicas", oldReplicas);
+			TraceEvent("DDUpdatedReplicas", self->distributorId).detail("DcId", dcId).detail("Replicas", self->configuration.storageTeamSize).detail("OldReplicas", oldReplicas);
 			return Void();
 		} catch( Error &e ) {
 			wait( tr.onError(e) );
@@ -3459,7 +3459,7 @@ ACTOR Future<Void> debugCheckCoalescing(Database cx) {
 
 				for(int j = 0; j < ranges.size() - 2; j++)
 					if(ranges[j].value == ranges[j + 1].value)
-						TraceEvent(SevError, "UncoalescedValues", id).detail("Key1", printable(ranges[j].key)).detail("Key2", printable(ranges[j + 1].key)).detail("Value", printable(ranges[j].value));
+						TraceEvent(SevError, "UncoalescedValues", id).detail("Key1", ranges[j].key).detail("Key2", ranges[j + 1].key).detail("Value", ranges[j].value);
 			}
 
 			TraceEvent("DoneCheckingCoalescing");
@@ -3594,8 +3594,8 @@ ACTOR Future<Void> dataDistribution(Reference<DataDistributorData> self)
 				initData = initData_;
 				if(initData->shards.size() > 1) {
 					TraceEvent("DDInitGotInitialDD", self->ddId)
-					    .detail("B", printable(initData->shards.end()[-2].key))
-					    .detail("E", printable(initData->shards.end()[-1].key))
+					    .detail("B", initData->shards.end()[-2].key)
+					    .detail("E", initData->shards.end()[-1].key)
 					    .detail("Src", describe(initData->shards.end()[-2].primarySrc))
 					    .detail("Dest", describe(initData->shards.end()[-2].primaryDest))
 					    .trackLatest("InitialDD");
@@ -3643,7 +3643,7 @@ ACTOR Future<Void> dataDistribution(Reference<DataDistributorData> self)
 					teams.push_back(ShardsAffectedByTeamFailure::Team(initData->shards[shard].remoteSrc, false));
 				}
 				if(g_network->isSimulated()) {
-					TraceEvent("DDInitShard").detail("Keys", printable(keys)).detail("PrimarySrc", describe(initData->shards[shard].primarySrc)).detail("RemoteSrc", describe(initData->shards[shard].remoteSrc))
+					TraceEvent("DDInitShard").detail("Keys", keys).detail("PrimarySrc", describe(initData->shards[shard].primarySrc)).detail("RemoteSrc", describe(initData->shards[shard].remoteSrc))
 					.detail("PrimaryDest", describe(initData->shards[shard].primaryDest)).detail("RemoteDest", describe(initData->shards[shard].remoteDest));
 				}
 

--- a/fdbserver/DataDistributionQueue.actor.cpp
+++ b/fdbserver/DataDistributionQueue.actor.cpp
@@ -426,10 +426,10 @@ struct DDQueueData {
 					auto range = queueMap.rangeContaining( rdit->keys.begin );
 					if( range.value() != *rdit || range.range() != rdit->keys )
 						TraceEvent(SevError, "DDQueueValidateError4").detail("Problem", "relocates in the queue are in the queueMap exactly")
-						.detail("RangeBegin", printable(range.range().begin))
-						.detail("RangeEnd", printable(range.range().end))
-						.detail("RelocateBegin2", printable(range.value().keys.begin))
-						.detail("RelocateEnd2", printable(range.value().keys.end))
+						.detail("RangeBegin", range.range().begin)
+						.detail("RangeEnd", range.range().end)
+						.detail("RelocateBegin2", range.value().keys.begin)
+						.detail("RelocateEnd2", range.value().keys.end)
 						.detail("RelocateStart", range.value().startTime)
 						.detail("MapStart", rdit->startTime)
 						.detail("RelocateWork", range.value().workFactor)
@@ -570,7 +570,7 @@ struct DDQueueData {
 
 	//This function cannot handle relocation requests which split a shard into three pieces
 	void queueRelocation( RelocateData rd, std::set<UID> &serversToLaunchFrom ) {
-		//TraceEvent("QueueRelocationBegin").detail("Begin", printable(rd.keys.begin)).detail("End", printable(rd.keys.end));
+		//TraceEvent("QueueRelocationBegin").detail("Begin", rd.keys.begin).detail("End", rd.keys.end);
 
 		// remove all items from both queues that are fully contained in the new relocation (i.e. will be overwritten)
 		auto ranges = queueMap.intersectingRanges( rd.keys );
@@ -637,7 +637,7 @@ struct DDQueueData {
 
 				rrs.interval = TraceInterval("QueuedRelocation");
 				/*TraceEvent(rrs.interval.begin(), distributorId);
-					.detail("KeyBegin", printable(rrs.keys.begin)).detail("KeyEnd", printable(rrs.keys.end))
+				  .detail("KeyBegin", rrs.keys.begin).detail("KeyEnd", rrs.keys.end)
 					.detail("Priority", rrs.priority).detail("WantsNewServers", rrs.wantsNewServers);*/
 				queuedRelocations++;
 				startRelocation(rrs.priority);
@@ -657,7 +657,7 @@ struct DDQueueData {
 						if( !foundActiveRelocation ) {
 							newData.interval = TraceInterval("QueuedRelocation");
 							/*TraceEvent(newData.interval.begin(), distributorId);
-								.detail("KeyBegin", printable(newData.keys.begin)).detail("KeyEnd", printable(newData.keys.end))
+							  .detail("KeyBegin", newData.keys.begin).detail("KeyEnd", newData.keys.end)
 								.detail("Priority", newData.priority).detail("WantsNewServers", newData.wantsNewServers);*/
 							queuedRelocations++;
 							startRelocation(newData.priority);
@@ -677,8 +677,8 @@ struct DDQueueData {
 		}
 
 		/*TraceEvent("ReceivedRelocateShard", distributorId)
-			.detail("KeyBegin", printable(rd.keys.begin))
-			.detail("KeyEnd", printable(rd.keys.end))
+		  .detail("KeyBegin", rd.keys.begin)
+		  .detail("KeyEnd", rd.keys.end)
 			.detail("Priority", rd.priority)
 			.detail("AffectedRanges", affectedQueuedItems.size()); */
 	}
@@ -701,8 +701,8 @@ struct DDQueueData {
 			busyString += describe(rd.src[i]) + " - (" + busymap[ rd.src[i] ].toString() + "); ";
 
 		TraceEvent(title, distributorId)
-			.detail("KeyBegin", printable(rd.keys.begin))
-			.detail("KeyEnd", printable(rd.keys.end))
+						   .detail("KeyBegin", rd.keys.begin)
+						   .detail("KeyEnd", rd.keys.end)
 			.detail("Priority", rd.priority)
 			.detail("WorkFactor", rd.workFactor)
 			.detail("SourceServerCount", rd.src.size())
@@ -759,8 +759,8 @@ struct DDQueueData {
 						it->value().priority >= rd.priority &&
 						rd.priority < PRIORITY_TEAM_REDUNDANT ) {
 					/*TraceEvent("OverlappingInFlight", distributorId)
-						.detail("KeyBegin", printable(it->value().keys.begin))
-						.detail("KeyEnd", printable(it->value().keys.end))
+					  .detail("KeyBegin", it->value().keys.begin)
+					  .detail("KeyEnd", it->value().keys.end)
 						.detail("Priority", it->value().priority); */
 					overlappingInFlight = true;
 					break;
@@ -867,7 +867,7 @@ ACTOR Future<Void> dataDistributionRelocator( DDQueueData *self, RelocateData rd
 		}
 
 		TraceEvent(relocateShardInterval.begin(), distributorId)
-			.detail("KeyBegin", printable(rd.keys.begin)).detail("KeyEnd", printable(rd.keys.end))
+			.detail("KeyBegin", rd.keys.begin).detail("KeyEnd", rd.keys.end)
 			.detail("Priority", rd.priority).detail("RelocationID", relocateShardInterval.pairID).detail("SuppressedEventCount", self->suppressIntervals);
 
 		if(relocateShardInterval.severity != SevDebug) {

--- a/fdbserver/DataDistributionQueue.actor.cpp
+++ b/fdbserver/DataDistributionQueue.actor.cpp
@@ -701,8 +701,8 @@ struct DDQueueData {
 			busyString += describe(rd.src[i]) + " - (" + busymap[ rd.src[i] ].toString() + "); ";
 
 		TraceEvent(title, distributorId)
-						   .detail("KeyBegin", rd.keys.begin)
-						   .detail("KeyEnd", rd.keys.end)
+			.detail("KeyBegin", rd.keys.begin)
+			.detail("KeyEnd", rd.keys.end)
 			.detail("Priority", rd.priority)
 			.detail("WorkFactor", rd.workFactor)
 			.detail("SourceServerCount", rd.src.size())
@@ -759,9 +759,9 @@ struct DDQueueData {
 						it->value().priority >= rd.priority &&
 						rd.priority < PRIORITY_TEAM_REDUNDANT ) {
 					/*TraceEvent("OverlappingInFlight", distributorId)
-					  .detail("KeyBegin", it->value().keys.begin)
-					  .detail("KeyEnd", it->value().keys.end)
-						.detail("Priority", it->value().priority); */
+						.detail("KeyBegin", it->value().keys.begin)
+						.detail("KeyEnd", it->value().keys.end)
+						.detail("Priority", it->value().priority);*/
 					overlappingInFlight = true;
 					break;
 				}

--- a/fdbserver/DataDistributionTracker.actor.cpp
+++ b/fdbserver/DataDistributionTracker.actor.cpp
@@ -190,7 +190,7 @@ ACTOR Future<Void> trackShardBytes(
 			StorageMetrics metrics = wait( tr.waitStorageMetrics( keys, bounds.min, bounds.max, bounds.permittedError, CLIENT_KNOBS->STORAGE_METRICS_SHARD_LIMIT ) );
 
 			/*TraceEvent("ShardSizeUpdate")
-			  .detail("Keys", keys)
+				.detail("Keys", keys)
 				.detail("UpdatedSize", metrics.metrics.bytes)
 				.detail("Bandwidth", metrics.metrics.bytesPerKSecond)
 				.detail("BandwithStatus", getBandwidthStatus(metrics))
@@ -199,7 +199,7 @@ ACTOR Future<Void> trackShardBytes(
 				.detail("BandwidthLower", bounds.min.bytesPerKSecond)
 				.detail("BandwidthUpper", bounds.max.bytesPerKSecond)
 				.detail("ShardSizePresent", shardSize->get().present())
-				.detail("OldShardSize", shardSize->get().present() ? shardSize->get().get().metrics.bytes : 0 )
+				.detail("OldShardSize", shardSize->get().present() ? shardSize->get().get().metrics.bytes : 0)
 				.detail("TrackerID", trackerID);*/
 
 			if( shardSize->get().present() && addToSizeEstimate )
@@ -532,8 +532,8 @@ ACTOR Future<Void> shardTracker(
 	wait( delay( 0, TaskDataDistribution ) );
 
 	/*TraceEvent("ShardTracker", self->distributorId)
-	  .detail("Begin", keys.begin)
-	  .detail("End", keys.end)
+		.detail("Begin", keys.begin)
+		.detail("End", keys.end)
 		.detail("TrackerID", trackerID)
 		.detail("MaxBytes", self->maxShardSize->get().get())
 		.detail("ShardSize", shardSize->get().get().bytes)
@@ -572,7 +572,7 @@ void restartShardTrackers( DataDistributionTracker* self, KeyRangeRef keys, Opti
 		if( startingSize.present() ) {
 			ASSERT( ranges.size() == 1 );
 			/*TraceEvent("ShardTrackerSizePreset", self->distributorId)
-			  .detail("Keys", keys)
+				.detail("Keys", keys)
 				.detail("Size", startingSize.get().metrics.bytes)
 				.detail("Merges", startingSize.get().merges);*/
 			TEST( true ); // shardTracker started with trackedBytes already set
@@ -736,9 +736,9 @@ void ShardsAffectedByTeamFailure::defineShard( KeyRangeRef keys ) {
 	uniquify(prevTeams);
 
 	/*TraceEvent("ShardsAffectedByTeamFailureDefine")
-	  .detail("KeyBegin", keys.begin)
-	  .detail("KeyEnd", keys.end)
-		.detail("TeamCount", teams.size()); */
+		.detail("KeyBegin", keys.begin)
+		.detail("KeyEnd", keys.end)
+		.detail("TeamCount", teams.size());*/
 
 	auto affectedRanges = shard_teams.getAffectedRangesAfterInsertion(keys);
 	shard_teams.insert( keys, std::make_pair(teams, prevTeams) );
@@ -754,8 +754,8 @@ void ShardsAffectedByTeamFailure::defineShard( KeyRangeRef keys ) {
 
 void ShardsAffectedByTeamFailure::moveShard( KeyRangeRef keys, std::vector<Team> destinationTeams ) {
 	/*TraceEvent("ShardsAffectedByTeamFailureMove")
-	  .detail("KeyBegin", keys.begin)
-	  .detail("KeyEnd", keys.end)
+		.detail("KeyBegin", keys.begin)
+		.detail("KeyEnd", keys.end)
 		.detail("NewTeamSize", destinationTeam.size())
 		.detail("NewTeam", describe(destinationTeam));*/
 

--- a/fdbserver/DataDistributionTracker.actor.cpp
+++ b/fdbserver/DataDistributionTracker.actor.cpp
@@ -144,7 +144,7 @@ ACTOR Future<Void> trackShardBytes(
 
 	/*TraceEvent("TrackShardBytesStarting")
 		.detail("TrackerID", trackerID)
-		.detail("Keys", printable(keys))
+		.detail("Keys", keys)
 		.detail("TrackedBytesInitiallyPresent", shardSize->get().present())
 		.detail("StartingSize", shardSize->get().present() ? shardSize->get().get().metrics.bytes : 0)
 		.detail("StartingMerges", shardSize->get().present() ? shardSize->get().get().merges : 0);*/
@@ -190,7 +190,7 @@ ACTOR Future<Void> trackShardBytes(
 			StorageMetrics metrics = wait( tr.waitStorageMetrics( keys, bounds.min, bounds.max, bounds.permittedError, CLIENT_KNOBS->STORAGE_METRICS_SHARD_LIMIT ) );
 
 			/*TraceEvent("ShardSizeUpdate")
-				.detail("Keys", printable(keys))
+			  .detail("Keys", keys)
 				.detail("UpdatedSize", metrics.metrics.bytes)
 				.detail("Bandwidth", metrics.metrics.bytesPerKSecond)
 				.detail("BandwithStatus", getBandwidthStatus(metrics))
@@ -329,8 +329,8 @@ ACTOR Future<Void> shardSplitter(
 
 	if( g_random->random01() < 0.01 ) {
 		TraceEvent("RelocateShardStartSplitx100", self->distributorId)
-			.detail("Begin", printable(keys.begin))
-			.detail("End", printable(keys.end))
+			.detail("Begin", keys.begin)
+			.detail("End", keys.end)
 			.detail("MaxBytes", shardBounds.max.bytes)
 			.detail("MetricsBytes", metrics.bytes)
 			.detail("Bandwidth", bandwidthStatus == BandwidthStatusHigh ? "High" : bandwidthStatus == BandwidthStatusNormal ? "Normal" : "Low")
@@ -450,8 +450,8 @@ Future<Void> shardMerger(
 	KeyRange mergeRange = merged;
 
 	TraceEvent("RelocateShardMergeMetrics", self->distributorId)
-		.detail("OldKeys", printable(keys))
-		.detail("NewKeys", printable(mergeRange))
+		.detail("OldKeys", keys)
+		.detail("NewKeys", mergeRange)
 		.detail("EndingSize", endingStats.bytes)
 		.detail("BatchedMerges", shardsMerged);
 
@@ -532,8 +532,8 @@ ACTOR Future<Void> shardTracker(
 	wait( delay( 0, TaskDataDistribution ) );
 
 	/*TraceEvent("ShardTracker", self->distributorId)
-		.detail("Begin", printable(keys.begin))
-		.detail("End", printable(keys.end))
+	  .detail("Begin", keys.begin)
+	  .detail("End", keys.end)
 		.detail("TrackerID", trackerID)
 		.detail("MaxBytes", self->maxShardSize->get().get())
 		.detail("ShardSize", shardSize->get().get().bytes)
@@ -572,7 +572,7 @@ void restartShardTrackers( DataDistributionTracker* self, KeyRangeRef keys, Opti
 		if( startingSize.present() ) {
 			ASSERT( ranges.size() == 1 );
 			/*TraceEvent("ShardTrackerSizePreset", self->distributorId)
-				.detail("Keys", printable(keys))
+			  .detail("Keys", keys)
 				.detail("Size", startingSize.get().metrics.bytes)
 				.detail("Merges", startingSize.get().merges);*/
 			TEST( true ); // shardTracker started with trackedBytes already set
@@ -736,8 +736,8 @@ void ShardsAffectedByTeamFailure::defineShard( KeyRangeRef keys ) {
 	uniquify(prevTeams);
 
 	/*TraceEvent("ShardsAffectedByTeamFailureDefine")
-		.detail("KeyBegin", printable(keys.begin))
-		.detail("KeyEnd", printable(keys.end))
+	  .detail("KeyBegin", keys.begin)
+	  .detail("KeyEnd", keys.end)
 		.detail("TeamCount", teams.size()); */
 
 	auto affectedRanges = shard_teams.getAffectedRangesAfterInsertion(keys);
@@ -754,8 +754,8 @@ void ShardsAffectedByTeamFailure::defineShard( KeyRangeRef keys ) {
 
 void ShardsAffectedByTeamFailure::moveShard( KeyRangeRef keys, std::vector<Team> destinationTeams ) {
 	/*TraceEvent("ShardsAffectedByTeamFailureMove")
-		.detail("KeyBegin", printable(keys.begin))
-		.detail("KeyEnd", printable(keys.end))
+	  .detail("KeyBegin", keys.begin)
+	  .detail("KeyEnd", keys.end)
 		.detail("NewTeamSize", destinationTeam.size())
 		.detail("NewTeam", describe(destinationTeam));*/
 
@@ -828,8 +828,8 @@ void ShardsAffectedByTeamFailure::check() {
 					for(auto x = team_shards.lower_bound( std::make_pair( *t, KeyRangeRef() ) ); x != team_shards.end() && x->first == *t; ++x)
 						shards += printable(x->second.begin) + "-" + printable(x->second.end) + ",";
 					TraceEvent(SevError,"SATFInvariantError2")
-						.detail("KB", printable(i->begin()))
-						.detail("KE", printable(i->end()))
+						.detail("KB", i->begin())
+						.detail("KE", i->end())
 						.detail("Team", teamDesc)
 						.detail("Shards", shards);
 					ASSERT(false);

--- a/fdbserver/IDiskQueue.h
+++ b/fdbserver/IDiskQueue.h
@@ -37,7 +37,7 @@ public:
 		location() : hi(0), lo(0) {}
 		location(int64_t lo) : hi(0), lo(lo) {}
 		location(int64_t hi, int64_t lo) : hi(hi), lo(lo) {}
-		operator std::string() { return format("%lld.%lld", hi, lo); }  // FIXME: Return a 'HumanReadableDescription' instead of std::string, make TraceEvent::detail accept that (for safety)
+		operator std::string() const { return format("%lld.%lld", hi, lo); }  // FIXME: Return a 'HumanReadableDescription' instead of std::string, make TraceEvent::detail accept that (for safety)
 
 		template<class Ar>
 		void serialize_unversioned(Ar& ar) {
@@ -79,6 +79,13 @@ public:
 	virtual int getCommitOverhead() = 0; // returns the amount of unused space that would be written by a commit that immediately followed this call
 
 	virtual StorageBytes getStorageBytes() = 0;
+};
+
+template<>
+struct Traceable<IDiskQueue::location> : std::true_type {
+	static std::string toString(const IDiskQueue::location& value) {
+		return value;
+	}
 };
 
 // FIXME: One should be able to use SFINAE to choose between serialize and serialize_unversioned.

--- a/fdbserver/KeyValueStoreMemory.actor.cpp
+++ b/fdbserver/KeyValueStoreMemory.actor.cpp
@@ -485,8 +485,8 @@ private:
 					if (h.op == OpSnapshotItem) { // snapshot data item
 						/*if (p1 < uncommittedNextKey) {
 							TraceEvent(SevError, "RecSnapshotBack", self->id)
-							.detail("NextKey", uncommittedNextKey)
-							.detail("P1", p1)
+								.detail("NextKey", uncommittedNextKey)
+								.detail("P1", p1)
 								.detail("Nextlocation", self->log->getNextReadLocation());
 						}
 						ASSERT( p1 >= uncommittedNextKey );*/

--- a/fdbserver/KeyValueStoreMemory.actor.cpp
+++ b/fdbserver/KeyValueStoreMemory.actor.cpp
@@ -485,8 +485,8 @@ private:
 					if (h.op == OpSnapshotItem) { // snapshot data item
 						/*if (p1 < uncommittedNextKey) {
 							TraceEvent(SevError, "RecSnapshotBack", self->id)
-								.detail("NextKey", printable(uncommittedNextKey))
-								.detail("P1", printable(p1))
+							.detail("NextKey", uncommittedNextKey)
+							.detail("P1", p1)
 								.detail("Nextlocation", self->log->getNextReadLocation());
 						}
 						ASSERT( p1 >= uncommittedNextKey );*/
@@ -497,7 +497,7 @@ private:
 						++dbgSnapshotItemCount;
 					} else if (h.op == OpSnapshotEnd || h.op == OpSnapshotAbort) { // snapshot complete
 						TraceEvent("RecSnapshotEnd", self->id)
-							.detail("NextKey", printable(uncommittedNextKey))
+							.detail("NextKey", uncommittedNextKey)
 							.detail("Nextlocation", self->log->getNextReadLocation())
 							.detail("IsSnapshotEnd", h.op == OpSnapshotEnd);
 
@@ -526,7 +526,7 @@ private:
 					} else if (h.op == OpRollback) { // rollback previous transaction
 						recoveryQueue.rollback();
 						TraceEvent("KVSMemRecSnapshotRollback", self->id)
-							.detail("NextKey", printable(uncommittedNextKey));
+							.detail("NextKey", uncommittedNextKey);
 						uncommittedNextKey = self->recoveredSnapshotKey;
 						uncommittedPrevSnapshotEnd = self->previousSnapshotEnd;
 						uncommittedSnapshotEnd = self->currentSnapshotEnd;
@@ -620,7 +620,7 @@ private:
 		state int snapItems = 0;
 		state uint64_t snapshotBytes = 0;
 
-		TraceEvent("KVSMemStartingSnapshot", self->id).detail("StartKey", printable(nextKey));
+		TraceEvent("KVSMemStartingSnapshot", self->id).detail("StartKey", nextKey);
 
 		loop {
 			wait( self->notifiedCommittedWriteBytes.whenAtLeast( snapshotTotalWrittenBytes + 1 ) );
@@ -646,7 +646,7 @@ private:
 			if (next == self->data.end()) {
 				auto thisSnapshotEnd = self->log_op( OpSnapshotEnd, StringRef(), StringRef() );
 				//TraceEvent("SnapshotEnd", self->id)
-				//	.detail("LastKey", printable(lastKey.present() ? lastKey.get() : LiteralStringRef("<none>")))
+				//	.detail("LastKey", lastKey.present() ? lastKey.get() : LiteralStringRef("<none>"))
 				//	.detail("CurrentSnapshotEndLoc", self->currentSnapshotEnd)
 				//	.detail("PreviousSnapshotEndLoc", self->previousSnapshotEnd)
 				//	.detail("ThisSnapshotEnd", thisSnapshotEnd)

--- a/fdbserver/KeyValueStoreSQLite.actor.cpp
+++ b/fdbserver/KeyValueStoreSQLite.actor.cpp
@@ -39,6 +39,10 @@ u32 sqlite3VdbeSerialGet(const unsigned char*, u32, Mem*);
 	#define sqlite3_mutex_leave(x)
 #endif
 
+FORMAT_TRACEABLE(volatile long long, "%lld");
+FORMAT_TRACEABLE(volatile unsigned long long, "%llu");
+FORMAT_TRACEABLE(volatile double, "%g");
+
 void hexdump(FILE *fout, StringRef val);
 
 /*#undef state

--- a/fdbserver/KeyValueStoreSQLite.actor.cpp
+++ b/fdbserver/KeyValueStoreSQLite.actor.cpp
@@ -1211,7 +1211,7 @@ int SQLiteDB::checkAllPageChecksums() {
 	Statement *jm = new Statement(*this, "PRAGMA journal_mode");
 	ASSERT( jm->nextRow() );
 	if (jm->column(0) != LiteralStringRef("wal")){
-		TraceEvent(SevError, "JournalModeError").detail("Filename", filename).detail("Mode", printable(jm->column(0)));
+		TraceEvent(SevError, "JournalModeError").detail("Filename", filename).detail("Mode", jm->column(0));
 		ASSERT( false );
 	}
 	delete jm;
@@ -1337,7 +1337,7 @@ void SQLiteDB::open(bool writable) {
 	Statement jm(*this, "PRAGMA journal_mode");
 	ASSERT( jm.nextRow() );
 	if (jm.column(0) != LiteralStringRef("wal")){
-		TraceEvent(SevError, "JournalModeError").detail("Filename", filename).detail("Mode", printable(jm.column(0)));
+		TraceEvent(SevError, "JournalModeError").detail("Filename", filename).detail("Mode", jm.column(0));
 		ASSERT( false );
 	}
 

--- a/fdbserver/KeyValueStoreSQLite.actor.cpp
+++ b/fdbserver/KeyValueStoreSQLite.actor.cpp
@@ -39,10 +39,6 @@ u32 sqlite3VdbeSerialGet(const unsigned char*, u32, Mem*);
 	#define sqlite3_mutex_leave(x)
 #endif
 
-FORMAT_TRACEABLE(volatile long long, "%lld");
-FORMAT_TRACEABLE(volatile unsigned long long, "%llu");
-FORMAT_TRACEABLE(volatile double, "%g");
-
 void hexdump(FILE *fout, StringRef val);
 
 /*#undef state

--- a/fdbserver/LatencyBandConfig.cpp
+++ b/fdbserver/LatencyBandConfig.cpp
@@ -83,7 +83,7 @@ Optional<LatencyBandConfig> LatencyBandConfig::parse(ValueRef configurationStrin
 
 	json_spirit::mValue parsedConfig;
 	if(!json_spirit::read_string(configurationString.toString(), parsedConfig)) {
-		TraceEvent(SevWarnAlways, "InvalidLatencyBandConfiguration").detail("Reason", "InvalidJSON").detail("Configuration", printable(configurationString));
+		TraceEvent(SevWarnAlways, "InvalidLatencyBandConfiguration").detail("Reason", "InvalidJSON").detail("Configuration", configurationString);
 		return config;
 	}
 
@@ -96,7 +96,7 @@ Optional<LatencyBandConfig> LatencyBandConfig::parse(ValueRef configurationStrin
 
 	std::string errorStr;
 	if(!schemaMatch(schema.get_obj(), configJson, errorStr)) {
-		TraceEvent(SevWarnAlways, "InvalidLatencyBandConfiguration").detail("Reason", "SchemaMismatch").detail("Configuration", printable(configurationString)).detail("Error", errorStr);
+		TraceEvent(SevWarnAlways, "InvalidLatencyBandConfiguration").detail("Reason", "SchemaMismatch").detail("Configuration", configurationString).detail("Error", errorStr);
 		return config;
 	}
 

--- a/fdbserver/LogRouter.actor.cpp
+++ b/fdbserver/LogRouter.actor.cpp
@@ -285,7 +285,7 @@ void peekMessagesFromMemory( LogRouterData* self, TLogPeekRequest const& req, Bi
 	ASSERT( !messages.getLength() );
 
 	auto& deque = get_version_messages(self, req.tag);
-	//TraceEvent("TLogPeekMem", self->dbgid).detail("Tag", printable(req.tag1)).detail("PDS", self->persistentDataSequence).detail("PDDS", self->persistentDataDurableSequence).detail("Oldest", map1.empty() ? 0 : map1.begin()->key ).detail("OldestMsgCount", map1.empty() ? 0 : map1.begin()->value.size());
+	//TraceEvent("TLogPeekMem", self->dbgid).detail("Tag", req.tag1).detail("PDS", self->persistentDataSequence).detail("PDDS", self->persistentDataDurableSequence).detail("Oldest", map1.empty() ? 0 : map1.begin()->key ).detail("OldestMsgCount", map1.empty() ? 0 : map1.begin()->value.size());
 
 	auto it = std::lower_bound(deque.begin(), deque.end(), std::make_pair(req.begin, LengthPrefixedStringRef()), CompareFirst<std::pair<Version, LengthPrefixedStringRef>>());
 

--- a/fdbserver/MasterProxyServer.actor.cpp
+++ b/fdbserver/MasterProxyServer.actor.cpp
@@ -842,8 +842,8 @@ ACTOR Future<Void> commitBatch(
 
 //				if (debugMutation("BackupProxyCommit", commitVersion, backupMutation)) {
 //					TraceEvent("BackupProxyCommitTo", self->dbgid).detail("To", describe(tags)).detail("BackupMutation", backupMutation.toString())
-//						.detail("BackupMutationSize", val.size()).detail("Version", commitVersion).detail("DestPath", printable(logRangeMutation.first))
-//						.detail("PartIndex", part).detail("PartIndexEndian", bigEndian32(part)).detail("PartData", printable(backupMutation.param1));
+//						.detail("BackupMutationSize", val.size()).detail("Version", commitVersion).detail("DestPath", logRangeMutation.first)
+//						.detail("PartIndex", part).detail("PartIndexEndian", bigEndian32(part)).detail("PartData", backupMutation.param1);
 //				}
 			}
 		}

--- a/fdbserver/MoveKeys.actor.cpp
+++ b/fdbserver/MoveKeys.actor.cpp
@@ -301,8 +301,8 @@ ACTOR Future<Void> startMoveKeys( Database occ, KeyRange keys, vector<UID> serve
 						decodeKeyServersValue( old[i].value, src, dest );
 
 						/*TraceEvent("StartMoveKeysOldRange", relocationIntervalId)
-						  .detail("KeyBegin", rangeIntersectKeys.begin.c_str())
-						  .detail("KeyEnd", rangeIntersectKeys.end.c_str())
+							.detail("KeyBegin", rangeIntersectKeys.begin.c_str())
+							.detail("KeyEnd", rangeIntersectKeys.end.c_str())
 							.detail("OldSrc", describe(src))
 							.detail("OldDest", describe(dest))
 							.detail("ReadVersion", tr.getReadVersion().get());*/

--- a/fdbserver/MoveKeys.actor.cpp
+++ b/fdbserver/MoveKeys.actor.cpp
@@ -283,8 +283,8 @@ ACTOR Future<Void> startMoveKeys( Database occ, KeyRange keys, vector<UID> serve
 					currentKeys = KeyRangeRef(currentKeys.begin, endKey);
 
 					/*TraceEvent("StartMoveKeysBatch", relocationIntervalId)
-						.detail("KeyBegin", printable(currentKeys.begin).c_str())
-						.detail("KeyEnd", printable(currentKeys.end).c_str());*/
+					  .detail("KeyBegin", currentKeys.begin.c_str())
+					  .detail("KeyEnd", currentKeys.end.c_str());*/
 
 					//printf("Moving '%s'-'%s' (%d) to %d servers\n", keys.begin.toString().c_str(), keys.end.toString().c_str(), old.size(), servers.size());
 					//for(int i=0; i<old.size(); i++)
@@ -301,8 +301,8 @@ ACTOR Future<Void> startMoveKeys( Database occ, KeyRange keys, vector<UID> serve
 						decodeKeyServersValue( old[i].value, src, dest );
 
 						/*TraceEvent("StartMoveKeysOldRange", relocationIntervalId)
-							.detail("KeyBegin", printable(rangeIntersectKeys.begin).c_str())
-							.detail("KeyEnd", printable(rangeIntersectKeys.end).c_str())
+						  .detail("KeyBegin", rangeIntersectKeys.begin.c_str())
+						  .detail("KeyEnd", rangeIntersectKeys.end.c_str())
 							.detail("OldSrc", describe(src))
 							.detail("OldDest", describe(dest))
 							.detail("ReadVersion", tr.getReadVersion().get());*/
@@ -366,8 +366,8 @@ ACTOR Future<Void> startMoveKeys( Database occ, KeyRange keys, vector<UID> serve
 					if(retries%10 == 0) {
 						TraceEvent(retries == 50 ? SevWarnAlways : SevWarn, "StartMoveKeysRetrying", relocationIntervalId)
 							.error(err)
-							.detail("Keys", printable(keys))
-							.detail("BeginKey", printable(begin))
+							.detail("Keys", keys)
+							.detail("BeginKey", begin)
 							.detail("NumTries", retries);
 					}
 				}
@@ -468,7 +468,7 @@ ACTOR Future<Void> finishMoveKeys( Database occ, KeyRange keys, vector<UID> dest
 	ASSERT (!destinationTeam.empty());
 
 	try {
-		TraceEvent(SevDebug, interval.begin(), relocationIntervalId).detail("KeyBegin", printable(keys.begin)).detail("KeyEnd", printable(keys.end));
+		TraceEvent(SevDebug, interval.begin(), relocationIntervalId).detail("KeyBegin", keys.begin).detail("KeyEnd", keys.end);
 
 		//This process can be split up into multiple transactions if there are too many existing overlapping shards
 		//In that case, each iteration of this loop will have begin set to the end of the last processed shard
@@ -538,13 +538,13 @@ ACTOR Future<Void> finishMoveKeys( Database occ, KeyRange keys, vector<UID> dest
 						alreadyMoved = destSet.empty() && srcSet == intendedTeam;
 						if(destSet != intendedTeam && !alreadyMoved) {
 							TraceEvent(SevWarn, "MoveKeysDestTeamNotIntended", relocationIntervalId)
-								.detail("KeyBegin", printable(keys.begin))
-								.detail("KeyEnd", printable(keys.end))
-								.detail("IterationBegin", printable(begin))
-								.detail("IterationEnd", printable(endKey))
+								.detail("KeyBegin", keys.begin)
+								.detail("KeyEnd", keys.end)
+								.detail("IterationBegin", begin)
+								.detail("IterationEnd", endKey)
 								.detail("DestSet", describe(destSet))
 								.detail("IntendedTeam", describe(intendedTeam))
-								.detail("KeyServers", printable(keyServers));
+								.detail("KeyServers", keyServers);
 							//ASSERT( false );
 
 							ASSERT(!dest.empty()); //The range has already been moved, but to a different dest (or maybe dest was cleared)
@@ -589,18 +589,18 @@ ACTOR Future<Void> finishMoveKeys( Database occ, KeyRange keys, vector<UID> dest
 					if (!dest.size()) {
 						TEST(true); // A previous finishMoveKeys for this range committed just as it was cancelled to start this one?
 						TraceEvent("FinishMoveKeysNothingToDo", relocationIntervalId)
-							.detail("KeyBegin", printable(keys.begin))
-							.detail("KeyEnd", printable(keys.end))
-							.detail("IterationBegin", printable(begin))
-							.detail("IterationEnd", printable(endKey));
+							.detail("KeyBegin", keys.begin)
+							.detail("KeyEnd", keys.end)
+							.detail("IterationBegin", begin)
+							.detail("IterationEnd", endKey);
 						begin = keyServers.end()[-1].key;
 						break;
 					}
 
 					waitInterval = TraceInterval("RelocateShard_FinishMoveKeysWaitDurable");
 					TraceEvent(SevDebug, waitInterval.begin(), relocationIntervalId)
-						.detail("KeyBegin", printable(keys.begin))
-						.detail("KeyEnd", printable(keys.end));
+						.detail("KeyBegin", keys.begin)
+						.detail("KeyEnd", keys.end);
 
 					// Wait for a durable quorum of servers in destServers to have keys available (readWrite)
 					// They must also have at least the transaction read version so they can't "forget" the shard between
@@ -668,10 +668,10 @@ ACTOR Future<Void> finishMoveKeys( Database occ, KeyRange keys, vector<UID> dest
 					if(retries%10 == 0) {
 						TraceEvent(retries == 20 ? SevWarnAlways : SevWarn, "RelocateShard_FinishMoveKeysRetrying", relocationIntervalId)
 							.error(err)
-							.detail("KeyBegin", printable(keys.begin))
-							.detail("KeyEnd", printable(keys.end))
-							.detail("IterationBegin", printable(begin))
-							.detail("IterationEnd", printable(endKey));
+							.detail("KeyBegin", keys.begin)
+							.detail("KeyEnd", keys.end)
+							.detail("IterationBegin", begin)
+							.detail("IterationEnd", endKey);
 					}
 				}
 			}
@@ -785,7 +785,7 @@ ACTOR Future<bool> canRemoveStorageServer( Transaction* tr, UID serverID ) {
 	ASSERT(keys.size() >= 2);
 
 	if(keys[0].value == keys[1].value && keys[1].key != allKeys.end) {
-		TraceEvent("ServerKeysCoalescingError", serverID).detail("Key1", printable(keys[0].key)).detail("Key2", printable(keys[1].key)).detail("Value", printable(keys[0].value));
+		TraceEvent("ServerKeysCoalescingError", serverID).detail("Key1", keys[0].key).detail("Key2", keys[1].key).detail("Value", keys[0].value);
 		ASSERT(false);
 	}
 

--- a/fdbserver/OldTLogServer_4_6.actor.cpp
+++ b/fdbserver/OldTLogServer_4_6.actor.cpp
@@ -897,7 +897,7 @@ namespace oldTLog_4_6 {
 			return Void();
 		}
 
-		//TraceEvent("TLogPeekMessages0", self->dbgid).detail("ReqBeginEpoch", req.begin.epoch).detail("ReqBeginSeq", req.begin.sequence).detail("Epoch", self->epoch()).detail("PersistentDataSeq", self->persistentDataSequence).detail("Tag1", printable(req.tag1)).detail("Tag2", printable(req.tag2));
+		//TraceEvent("TLogPeekMessages0", self->dbgid).detail("ReqBeginEpoch", req.begin.epoch).detail("ReqBeginSeq", req.begin.sequence).detail("Epoch", self->epoch()).detail("PersistentDataSeq", self->persistentDataSequence).detail("Tag1", req.tag1).detail("Tag2", req.tag2);
 		// Wait until we have something to return that the caller doesn't already have
 		if( logData->version.get() < req.begin ) {
 			wait( logData->version.whenAtLeast( req.begin ) );
@@ -907,7 +907,7 @@ namespace oldTLog_4_6 {
 		state Version endVersion = logData->version.get() + 1;
 
 		//grab messages from disk
-		//TraceEvent("TLogPeekMessages", self->dbgid).detail("ReqBeginEpoch", req.begin.epoch).detail("ReqBeginSeq", req.begin.sequence).detail("Epoch", self->epoch()).detail("PersistentDataSeq", self->persistentDataSequence).detail("Tag1", printable(req.tag1)).detail("Tag2", printable(req.tag2));
+		//TraceEvent("TLogPeekMessages", self->dbgid).detail("ReqBeginEpoch", req.begin.epoch).detail("ReqBeginSeq", req.begin.sequence).detail("Epoch", self->epoch()).detail("PersistentDataSeq", self->persistentDataSequence).detail("Tag1", req.tag1).detail("Tag2", req.tag2);
 		if( req.begin <= logData->persistentDataDurableVersion ) {
 			// Just in case the durable version changes while we are waiting for the read, we grab this data from memory.  We may or may not actually send it depending on
 			// whether we get enough data from disk.
@@ -921,7 +921,7 @@ namespace oldTLog_4_6 {
 					persistTagMessagesKey(logData->logId, oldTag, req.begin),
 					persistTagMessagesKey(logData->logId, oldTag, logData->persistentDataDurableVersion + 1)), SERVER_KNOBS->DESIRED_TOTAL_BYTES, SERVER_KNOBS->DESIRED_TOTAL_BYTES));
 
-			//TraceEvent("TLogPeekResults", self->dbgid).detail("ForAddress", req.reply.getEndpoint().getPrimaryAddress()).detail("Tag1Results", s1).detail("Tag2Results", s2).detail("Tag1ResultsLim", kv1.size()).detail("Tag2ResultsLim", kv2.size()).detail("Tag1ResultsLast", kv1.size() ? printable(kv1[0].key) : "").detail("Tag2ResultsLast", kv2.size() ? printable(kv2[0].key) : "").detail("Limited", limited).detail("NextEpoch", next_pos.epoch).detail("NextSeq", next_pos.sequence).detail("NowEpoch", self->epoch()).detail("NowSeq", self->sequence.getNextSequence());
+			//TraceEvent("TLogPeekResults", self->dbgid).detail("ForAddress", req.reply.getEndpoint().getPrimaryAddress()).detail("Tag1Results", s1).detail("Tag2Results", s2).detail("Tag1ResultsLim", kv1.size()).detail("Tag2ResultsLim", kv2.size()).detail("Tag1ResultsLast", kv1.size() ? kv1[0].key : "").detail("Tag2ResultsLast", kv2.size() ? kv2[0].key : "").detail("Limited", limited).detail("NextEpoch", next_pos.epoch).detail("NextSeq", next_pos.sequence).detail("NowEpoch", self->epoch()).detail("NowSeq", self->sequence.getNextSequence());
 
 			for (auto &kv : kvs) {
 				auto ver = decodeTagMessagesKey(kv.key);
@@ -1244,7 +1244,7 @@ namespace oldTLog_4_6 {
 		wait( waitForAll( (vector<Future<Standalone<VectorRef<KeyValueRef>>>>(), fVers, fRecoverCounts) ) );
 
 		if (fFormat.get().present() && !persistFormatReadableRange.contains( fFormat.get().get() )) {
-			TraceEvent(SevError, "UnsupportedDBFormat", self->dbgid).detail("Format", printable(fFormat.get().get())).detail("Expected", persistFormat.value.toString());
+			TraceEvent(SevError, "UnsupportedDBFormat", self->dbgid).detail("Format", fFormat.get().get()).detail("Expected", persistFormat.value.toString());
 			throw worker_recovery_failed();
 		}
 
@@ -1255,7 +1255,7 @@ namespace oldTLog_4_6 {
 				throw worker_removed();
 			} else {
 				// This should never happen
-				TraceEvent(SevError, "NoDBFormatKey", self->dbgid).detail("FirstKey", printable(v[0].key));
+				TraceEvent(SevError, "NoDBFormatKey", self->dbgid).detail("FirstKey", v[0].key);
 				ASSERT( false );
 				throw worker_recovery_failed();
 			}

--- a/fdbserver/OldTLogServer_6_0.actor.cpp
+++ b/fdbserver/OldTLogServer_6_0.actor.cpp
@@ -912,7 +912,7 @@ void peekMessagesFromMemory( Reference<LogData> self, TLogPeekRequest const& req
 	ASSERT( !messages.getLength() );
 
 	auto& deque = getVersionMessages(self, req.tag);
-	//TraceEvent("TLogPeekMem", self->dbgid).detail("Tag", printable(req.tag1)).detail("PDS", self->persistentDataSequence).detail("PDDS", self->persistentDataDurableSequence).detail("Oldest", map1.empty() ? 0 : map1.begin()->key ).detail("OldestMsgCount", map1.empty() ? 0 : map1.begin()->value.size());
+	//TraceEvent("TLogPeekMem", self->dbgid).detail("Tag", req.tag1).detail("PDS", self->persistentDataSequence).detail("PDDS", self->persistentDataDurableSequence).detail("Oldest", map1.empty() ? 0 : map1.begin()->key ).detail("OldestMsgCount", map1.empty() ? 0 : map1.begin()->value.size());
 
 	Version begin = std::max( req.begin, self->persistentDataDurableVersion+1 );
 	auto it = std::lower_bound(deque.begin(), deque.end(), std::make_pair(begin, LengthPrefixedStringRef()), CompareFirst<std::pair<Version, LengthPrefixedStringRef>>());
@@ -979,7 +979,7 @@ ACTOR Future<Void> tLogPeekMessages( TLogData* self, TLogPeekRequest req, Refere
 		return Void();
 	}
 
-	//TraceEvent("TLogPeekMessages0", self->dbgid).detail("ReqBeginEpoch", req.begin.epoch).detail("ReqBeginSeq", req.begin.sequence).detail("Epoch", self->epoch()).detail("PersistentDataSeq", self->persistentDataSequence).detail("Tag1", printable(req.tag1)).detail("Tag2", printable(req.tag2));
+	//TraceEvent("TLogPeekMessages0", self->dbgid).detail("ReqBeginEpoch", req.begin.epoch).detail("ReqBeginSeq", req.begin.sequence).detail("Epoch", self->epoch()).detail("PersistentDataSeq", self->persistentDataSequence).detail("Tag1", req.tag1).detail("Tag2", req.tag2);
 	// Wait until we have something to return that the caller doesn't already have
 	if( logData->version.get() < req.begin ) {
 		wait( logData->version.whenAtLeast( req.begin ) );
@@ -1027,7 +1027,7 @@ ACTOR Future<Void> tLogPeekMessages( TLogData* self, TLogPeekRequest req, Refere
 	state Version endVersion = logData->version.get() + 1;
 
 	//grab messages from disk
-	//TraceEvent("TLogPeekMessages", self->dbgid).detail("ReqBeginEpoch", req.begin.epoch).detail("ReqBeginSeq", req.begin.sequence).detail("Epoch", self->epoch()).detail("PersistentDataSeq", self->persistentDataSequence).detail("Tag1", printable(req.tag1)).detail("Tag2", printable(req.tag2));
+	//TraceEvent("TLogPeekMessages", self->dbgid).detail("ReqBeginEpoch", req.begin.epoch).detail("ReqBeginSeq", req.begin.sequence).detail("Epoch", self->epoch()).detail("PersistentDataSeq", self->persistentDataSequence).detail("Tag1", req.tag1).detail("Tag2", req.tag2);
 	if( req.begin <= logData->persistentDataDurableVersion ) {
 		// Just in case the durable version changes while we are waiting for the read, we grab this data from memory.  We may or may not actually send it depending on
 		// whether we get enough data from disk.
@@ -1041,7 +1041,7 @@ ACTOR Future<Void> tLogPeekMessages( TLogData* self, TLogPeekRequest req, Refere
 				persistTagMessagesKey(logData->logId, req.tag, req.begin),
 				persistTagMessagesKey(logData->logId, req.tag, logData->persistentDataDurableVersion + 1)), SERVER_KNOBS->DESIRED_TOTAL_BYTES, SERVER_KNOBS->DESIRED_TOTAL_BYTES));
 
-		//TraceEvent("TLogPeekResults", self->dbgid).detail("ForAddress", req.reply.getEndpoint().address).detail("Tag1Results", s1).detail("Tag2Results", s2).detail("Tag1ResultsLim", kv1.size()).detail("Tag2ResultsLim", kv2.size()).detail("Tag1ResultsLast", kv1.size() ? printable(kv1[0].key) : "").detail("Tag2ResultsLast", kv2.size() ? printable(kv2[0].key) : "").detail("Limited", limited).detail("NextEpoch", next_pos.epoch).detail("NextSeq", next_pos.sequence).detail("NowEpoch", self->epoch()).detail("NowSeq", self->sequence.getNextSequence());
+		//TraceEvent("TLogPeekResults", self->dbgid).detail("ForAddress", req.reply.getEndpoint().address).detail("Tag1Results", s1).detail("Tag2Results", s2).detail("Tag1ResultsLim", kv1.size()).detail("Tag2ResultsLim", kv2.size()).detail("Tag1ResultsLast", kv1.size() ? kv1[0].key : "").detail("Tag2ResultsLast", kv2.size() ? kv2[0].key : "").detail("Limited", limited).detail("NextEpoch", next_pos.epoch).detail("NextSeq", next_pos.sequence).detail("NowEpoch", self->epoch()).detail("NowSeq", self->sequence.getNextSequence());
 
 		for (auto &kv : kvs) {
 			auto ver = decodeTagMessagesKey(kv.key);
@@ -1714,7 +1714,7 @@ ACTOR Future<Void> restorePersistentState( TLogData* self, LocalityData locality
 			flushAndExit(0);
 		}
 
-		TraceEvent(SevError, "UnsupportedDBFormat", self->dbgid).detail("Format", printable(fFormat.get().get())).detail("Expected", persistFormat.value.toString());
+		TraceEvent(SevError, "UnsupportedDBFormat", self->dbgid).detail("Format", fFormat.get().get()).detail("Expected", persistFormat.value.toString());
 		throw worker_recovery_failed();
 	}
 
@@ -1725,7 +1725,7 @@ ACTOR Future<Void> restorePersistentState( TLogData* self, LocalityData locality
 			throw worker_removed();
 		} else {
 			// This should never happen
-			TraceEvent(SevError, "NoDBFormatKey", self->dbgid).detail("FirstKey", printable(v[0].key));
+			TraceEvent(SevError, "NoDBFormatKey", self->dbgid).detail("FirstKey", v[0].key);
 			ASSERT( false );
 			throw worker_recovery_failed();
 		}

--- a/fdbserver/SimulatedCluster.actor.cpp
+++ b/fdbserver/SimulatedCluster.actor.cpp
@@ -207,7 +207,7 @@ ACTOR Future<ISimulator::KillType> simulatedFDBDRebooter(Reference<ClusterConnec
 		cycles ++;
 		TraceEvent("SimulatedFDBDPreWait").detail("Cycles", cycles).detail("RandomId", randomId)
 			.detail("Address", NetworkAddress(ip, port, true, false))
-			.detailext("ZoneId", localities.zoneId())
+			.detail("ZoneId", localities.zoneId())
 			.detail("WaitTime", waitTime).detail("Port", port);
 
 		wait( delay( waitTime ) );
@@ -218,8 +218,8 @@ ACTOR Future<ISimulator::KillType> simulatedFDBDRebooter(Reference<ClusterConnec
 
 		try {
 			TraceEvent("SimulatedRebooterStarting").detail("Cycles", cycles).detail("RandomId", randomId)
-				.detailext("ZoneId", localities.zoneId())
-				.detailext("DataHall", localities.dataHallId())
+				.detail("ZoneId", localities.zoneId())
+				.detail("DataHall", localities.dataHallId())
 				.detail("Address", process->address.toString())
 				.detail("Excluded", process->excluded)
 				.detail("UsingSSL", sslEnabled);
@@ -266,19 +266,19 @@ ACTOR Future<ISimulator::KillType> simulatedFDBDRebooter(Reference<ClusterConnec
 				if(e.code() != error_code_actor_cancelled)
 					printf("SimulatedFDBDTerminated: %s\n", e.what());
 				ASSERT( destructed || g_simulator.getCurrentProcess() == process ); // simulatedFDBD catch called on different process
-				TraceEvent(e.code() == error_code_actor_cancelled || e.code() == error_code_file_not_found || destructed ? SevInfo : SevError, "SimulatedFDBDTerminated").error(e, true).detailext("ZoneId", localities.zoneId());
+				TraceEvent(e.code() == error_code_actor_cancelled || e.code() == error_code_file_not_found || destructed ? SevInfo : SevError, "SimulatedFDBDTerminated").error(e, true).detail("ZoneId", localities.zoneId());
 			}
 
 			TraceEvent("SimulatedFDBDDone").detail("Cycles", cycles).detail("RandomId", randomId)
 				.detail("Address", process->address)
 				.detail("Excluded", process->excluded)
-				.detailext("ZoneId", localities.zoneId())
+				.detail("ZoneId", localities.zoneId())
 				.detail("KillType", onShutdown.isReady() ? onShutdown.get() : ISimulator::None);
 
 			if (!onShutdown.isReady())
 				onShutdown = ISimulator::InjectFaults;
 		} catch (Error& e) {
-			TraceEvent(destructed ? SevInfo : SevError, "SimulatedFDBDRebooterError").error(e, true).detailext("ZoneId", localities.zoneId()).detail("RandomId", randomId);
+			TraceEvent(destructed ? SevInfo : SevError, "SimulatedFDBDRebooterError").error(e, true).detail("ZoneId", localities.zoneId()).detail("RandomId", randomId);
 			onShutdown = e;
 		}
 
@@ -292,7 +292,7 @@ ACTOR Future<ISimulator::KillType> simulatedFDBDRebooter(Reference<ClusterConnec
 			.detail("Address", process->address)
 			.detail("Excluded", process->excluded)
 			.detail("Rebooting", process->rebooting)
-			.detailext("ZoneId", localities.zoneId());
+			.detail("ZoneId", localities.zoneId());
 		wait( g_simulator.onProcess( simProcess ) );
 
 		wait(delay(0.00001 + FLOW_KNOBS->MAX_BUGGIFIED_DELAY));  // One last chance for the process to clean up?
@@ -303,14 +303,14 @@ ACTOR Future<ISimulator::KillType> simulatedFDBDRebooter(Reference<ClusterConnec
 		TraceEvent("SimulatedFDBDShutdown").detail("Cycles", cycles).detail("RandomId", randomId)
 			.detail("Address", process->address)
 			.detail("Excluded", process->excluded)
-			.detailext("ZoneId", localities.zoneId())
+			.detail("ZoneId", localities.zoneId())
 			.detail("KillType", shutdownResult);
 
 		if( shutdownResult < ISimulator::RebootProcessAndDelete ) {
 			TraceEvent("SimulatedFDBDLowerReboot").detail("Cycles", cycles).detail("RandomId", randomId)
 				.detail("Address", process->address)
 				.detail("Excluded", process->excluded)
-				.detailext("ZoneId", localities.zoneId())
+				.detail("ZoneId", localities.zoneId())
 				.detail("KillType", shutdownResult);
 			return onShutdown.get();
 		}
@@ -318,7 +318,7 @@ ACTOR Future<ISimulator::KillType> simulatedFDBDRebooter(Reference<ClusterConnec
 		if( onShutdown.get() == ISimulator::RebootProcessAndDelete ) {
 			TraceEvent("SimulatedFDBDRebootAndDelete").detail("Cycles", cycles).detail("RandomId", randomId)
 				.detail("Address", process->address)
-				.detailext("ZoneId", localities.zoneId())
+				.detail("ZoneId", localities.zoneId())
 				.detail("KillType", shutdownResult);
 			*coordFolder = joinPath(baseFolder, g_random->randomUniqueID().toString());
 			*dataFolder = joinPath(baseFolder, g_random->randomUniqueID().toString());
@@ -335,7 +335,7 @@ ACTOR Future<ISimulator::KillType> simulatedFDBDRebooter(Reference<ClusterConnec
 		else {
 			TraceEvent("SimulatedFDBDJustRepeat").detail("Cycles", cycles).detail("RandomId", randomId)
 				.detail("Address", process->address)
-				.detailext("ZoneId", localities.zoneId())
+				.detail("ZoneId", localities.zoneId())
 				.detail("KillType", shutdownResult);
 		}
 	}
@@ -400,7 +400,7 @@ ACTOR Future<Void> simulatedMachine(ClusterConnectionString connStr, std::vector
 				Reference<ClusterConnectionFile> clusterFile(useSeedFile ? new ClusterConnectionFile(path, connStr.toString()) : new ClusterConnectionFile(path));
 				const int listenPort = i*listenPerProcess + 1;
 				processes.push_back(simulatedFDBDRebooter(clusterFile, ips[i], sslEnabled, tlsOptions, listenPort, listenPerProcess, localities, processClass, &myFolders[i], &coordFolders[i], baseFolder, connStr, useSeedFile, runBackupAgents));
-				TraceEvent("SimulatedMachineProcess", randomId).detail("Address", NetworkAddress(ips[i], listenPort, true, false)).detailext("ZoneId", localities.zoneId()).detailext("DataHall", localities.dataHallId()).detail("Folder", myFolders[i]);
+				TraceEvent("SimulatedMachineProcess", randomId).detail("Address", NetworkAddress(ips[i], listenPort, true, false)).detail("ZoneId", localities.zoneId()).detail("DataHall", localities.dataHallId()).detail("Folder", myFolders[i]);
 			}
 
 			TEST( bootCount >= 1 ); // Simulated machine rebooted
@@ -418,8 +418,8 @@ ACTOR Future<Void> simulatedMachine(ClusterConnectionString connStr, std::vector
 				.detail("ProcessClass", processClass.toString())
 				.detail("Restarting", restarting)
 				.detail("UseSeedFile", useSeedFile)
-				.detailext("ZoneId", localities.zoneId())
-				.detailext("DataHall", localities.dataHallId())
+				.detail("ZoneId", localities.zoneId())
+				.detail("DataHall", localities.dataHallId())
 				.detail("Locality", localities.toString());
 
 			wait( waitForAll( processes ) );
@@ -428,8 +428,8 @@ ACTOR Future<Void> simulatedMachine(ClusterConnectionString connStr, std::vector
 				.detail("Folder0", myFolders[0])
 				.detail("CFolder0", coordFolders[0])
 				.detail("MachineIPs", toIPVectorString(ips))
-				.detailext("ZoneId", localities.zoneId())
-				.detailext("DataHall", localities.dataHallId());
+				.detail("ZoneId", localities.zoneId())
+				.detail("DataHall", localities.dataHallId());
 
 			{
 				//Kill all open files, which may cause them to write invalid data.
@@ -468,8 +468,8 @@ ACTOR Future<Void> simulatedMachine(ClusterConnectionString connStr, std::vector
 				.detail("CFolder0", coordFolders[0])
 				.detail("MachineIPs", toIPVectorString(ips))
 				.detail("Closing", closingStr)
-				.detailext("ZoneId", localities.zoneId())
-				.detailext("DataHall", localities.dataHallId());
+				.detail("ZoneId", localities.zoneId())
+				.detail("DataHall", localities.dataHallId());
 
 			ISimulator::MachineInfo* machine = g_simulator.getMachineById(localities.machineId());
 			machine->closingFiles = filenames;
@@ -499,8 +499,8 @@ ACTOR Future<Void> simulatedMachine(ClusterConnectionString connStr, std::vector
 				if( shutdownDelayCount++ >= 50 ) {  // Worker doesn't shut down instantly on reboot
 					TraceEvent(SevError, "SimulatedFDBDFilesCheck", randomId)
 						.detail("PAddrs", toIPVectorString(ips))
-						.detailext("ZoneId", localities.zoneId())
-						.detailext("DataHall", localities.dataHallId());
+						.detail("ZoneId", localities.zoneId())
+						.detail("DataHall", localities.dataHallId());
 					ASSERT( false );
 				}
 
@@ -510,8 +510,8 @@ ACTOR Future<Void> simulatedMachine(ClusterConnectionString connStr, std::vector
 
 			TraceEvent("SimulatedFDBDFilesClosed", randomId)
 				.detail("Address", toIPVectorString(ips))
-				.detailext("ZoneId", localities.zoneId())
-				.detailext("DataHall", localities.dataHallId());
+				.detail("ZoneId", localities.zoneId())
+				.detail("DataHall", localities.dataHallId());
 
 			g_simulator.destroyMachine(localities.machineId());
 
@@ -535,8 +535,8 @@ ACTOR Future<Void> simulatedMachine(ClusterConnectionString connStr, std::vector
 				.detail("Swap", swap)
 				.detail("KillType", killType)
 				.detail("RebootTime", rebootTime)
-				.detailext("ZoneId", localities.zoneId())
-				.detailext("DataHall", localities.dataHallId())
+				.detail("ZoneId", localities.zoneId())
+				.detail("DataHall", localities.dataHallId())
 				.detail("MachineIPs", toIPVectorString(ips));
 
 			wait( delay( rebootTime ) );

--- a/fdbserver/SimulatedCluster.actor.cpp
+++ b/fdbserver/SimulatedCluster.actor.cpp
@@ -1141,7 +1141,7 @@ void setupSimulatedSystem(vector<Future<Void>>* systemActors, std::string baseFo
 
 	ASSERT(g_simulator.storagePolicy && g_simulator.tLogPolicy);
 	ASSERT(!g_simulator.hasSatelliteReplication || g_simulator.satelliteTLogPolicy);
-	TraceEvent("SimulatorConfig").detail("ConfigString", printable(StringRef(startingConfigString)));
+	TraceEvent("SimulatorConfig").detail("ConfigString", StringRef(startingConfigString));
 
 	const int dataCenters = simconfig.datacenters;
 	const int machineCount = simconfig.machine_count;
@@ -1235,7 +1235,7 @@ void setupSimulatedSystem(vector<Future<Void>>* systemActors, std::string baseFo
 
 	*pConnString = conn;
 
-	TraceEvent("SimulatedConnectionString").detail("String", conn.toString()).detail("ConfigString", printable(StringRef(startingConfigString)));
+	TraceEvent("SimulatedConnectionString").detail("String", conn.toString()).detail("ConfigString", StringRef(startingConfigString));
 
 	int assignedMachines = 0, nonVersatileMachines = 0;
 	for( int dc = 0; dc < dataCenters; dc++ ) {

--- a/fdbserver/SimulatedCluster.actor.cpp
+++ b/fdbserver/SimulatedCluster.actor.cpp
@@ -1235,7 +1235,7 @@ void setupSimulatedSystem(vector<Future<Void>>* systemActors, std::string baseFo
 
 	*pConnString = conn;
 
-	TraceEvent("SimulatedConnectionString").detail("String", conn.toString()).detail("ConfigString", StringRef(startingConfigString));
+	TraceEvent("SimulatedConnectionString").detail("String", conn.toString()).detail("ConfigString", startingConfigString);
 
 	int assignedMachines = 0, nonVersatileMachines = 0;
 	for( int dc = 0; dc < dataCenters; dc++ ) {

--- a/fdbserver/Status.actor.cpp
+++ b/fdbserver/Status.actor.cpp
@@ -1751,7 +1751,7 @@ ACTOR Future<JsonBuilderObject> layerStatusFetcher(Database cx, JsonBuilderArray
 							json.absorb(doc.get_obj());
 							wait(yield());
 						} catch(Error &e) {
-							TraceEvent(SevWarn, "LayerStatusBadJSON").detail("Key", printable(docs[j].key));
+							TraceEvent(SevWarn, "LayerStatusBadJSON").detail("Key", docs[j].key);
 						}
 					}
 				}

--- a/fdbserver/StorageMetrics.actor.h
+++ b/fdbserver/StorageMetrics.actor.h
@@ -73,7 +73,7 @@ struct StorageMetricSample {
 		}
 
 		// If we didn't return above, we didn't find anything.
-		TraceEvent(SevWarn, "CannotSplitLastSampleKey").detail("Range", printable(range)).detail("Offset", offset);
+		TraceEvent(SevWarn, "CannotSplitLastSampleKey").detail("Range", range).detail("Offset", offset);
 		return front ? range.end : range.begin;
 	}
 };
@@ -307,7 +307,7 @@ struct StorageServerMetrics {
 			StorageMetrics estimated = req.estimated;
 			StorageMetrics remaining = getMetrics( req.keys ) + used;
 
-			//TraceEvent("SplitMetrics").detail("Begin", printable(req.keys.begin)).detail("End", printable(req.keys.end)).detail("Remaining", remaining.bytes).detail("Used", used.bytes);
+			//TraceEvent("SplitMetrics").detail("Begin", req.keys.begin).detail("End", req.keys.end).detail("Remaining", remaining.bytes).detail("Used", used.bytes);
 			
 			while( true ) {
 				if( remaining.bytes < 2*SERVER_KNOBS->MIN_SHARD_BYTES )

--- a/fdbserver/TLogServer.actor.cpp
+++ b/fdbserver/TLogServer.actor.cpp
@@ -1157,7 +1157,7 @@ void peekMessagesFromMemory( Reference<LogData> self, TLogPeekRequest const& req
 	ASSERT( !messages.getLength() );
 
 	auto& deque = getVersionMessages(self, req.tag);
-	//TraceEvent("TLogPeekMem", self->dbgid).detail("Tag", printable(req.tag1)).detail("PDS", self->persistentDataSequence).detail("PDDS", self->persistentDataDurableSequence).detail("Oldest", map1.empty() ? 0 : map1.begin()->key ).detail("OldestMsgCount", map1.empty() ? 0 : map1.begin()->value.size());
+	//TraceEvent("TLogPeekMem", self->dbgid).detail("Tag", req.tag1).detail("PDS", self->persistentDataSequence).detail("PDDS", self->persistentDataDurableSequence).detail("Oldest", map1.empty() ? 0 : map1.begin()->key ).detail("OldestMsgCount", map1.empty() ? 0 : map1.begin()->value.size());
 
 	Version begin = std::max( req.begin, self->persistentDataDurableVersion+1 );
 	auto it = std::lower_bound(deque.begin(), deque.end(), std::make_pair(begin, LengthPrefixedStringRef()), CompareFirst<std::pair<Version, LengthPrefixedStringRef>>());
@@ -1260,7 +1260,7 @@ ACTOR Future<Void> tLogPeekMessages( TLogData* self, TLogPeekRequest req, Refere
 		return Void();
 	}
 
-	//TraceEvent("TLogPeekMessages0", self->dbgid).detail("ReqBeginEpoch", req.begin.epoch).detail("ReqBeginSeq", req.begin.sequence).detail("Epoch", self->epoch()).detail("PersistentDataSeq", self->persistentDataSequence).detail("Tag1", printable(req.tag1)).detail("Tag2", printable(req.tag2));
+	//TraceEvent("TLogPeekMessages0", self->dbgid).detail("ReqBeginEpoch", req.begin.epoch).detail("ReqBeginSeq", req.begin.sequence).detail("Epoch", self->epoch()).detail("PersistentDataSeq", self->persistentDataSequence).detail("Tag1", req.tag1).detail("Tag2", req.tag2);
 	// Wait until we have something to return that the caller doesn't already have
 	if( logData->version.get() < req.begin ) {
 		wait( logData->version.whenAtLeast( req.begin ) );
@@ -1308,7 +1308,7 @@ ACTOR Future<Void> tLogPeekMessages( TLogData* self, TLogPeekRequest req, Refere
 	state Version endVersion = logData->version.get() + 1;
 
 	//grab messages from disk
-	//TraceEvent("TLogPeekMessages", self->dbgid).detail("ReqBeginEpoch", req.begin.epoch).detail("ReqBeginSeq", req.begin.sequence).detail("Epoch", self->epoch()).detail("PersistentDataSeq", self->persistentDataSequence).detail("Tag1", printable(req.tag1)).detail("Tag2", printable(req.tag2));
+	//TraceEvent("TLogPeekMessages", self->dbgid).detail("ReqBeginEpoch", req.begin.epoch).detail("ReqBeginSeq", req.begin.sequence).detail("Epoch", self->epoch()).detail("PersistentDataSeq", self->persistentDataSequence).detail("Tag1", req.tag1).detail("Tag2", req.tag2);
 	if( req.begin <= logData->persistentDataDurableVersion ) {
 		// Just in case the durable version changes while we are waiting for the read, we grab this data from memory.  We may or may not actually send it depending on
 		// whether we get enough data from disk.
@@ -1345,7 +1345,7 @@ ACTOR Future<Void> tLogPeekMessages( TLogData* self, TLogPeekRequest req, Refere
 							persistTagMessageRefsKey(logData->logId, req.tag, req.begin),
 							persistTagMessageRefsKey(logData->logId, req.tag, logData->persistentDataDurableVersion + 1))));
 
-			//TraceEvent("TLogPeekResults", self->dbgid).detail("ForAddress", req.reply.getEndpoint().getPrimaryAddress()).detail("Tag1Results", s1).detail("Tag2Results", s2).detail("Tag1ResultsLim", kv1.size()).detail("Tag2ResultsLim", kv2.size()).detail("Tag1ResultsLast", kv1.size() ? printable(kv1[0].key) : "").detail("Tag2ResultsLast", kv2.size() ? printable(kv2[0].key) : "").detail("Limited", limited).detail("NextEpoch", next_pos.epoch).detail("NextSeq", next_pos.sequence).detail("NowEpoch", self->epoch()).detail("NowSeq", self->sequence.getNextSequence());
+			//TraceEvent("TLogPeekResults", self->dbgid).detail("ForAddress", req.reply.getEndpoint().getPrimaryAddress()).detail("Tag1Results", s1).detail("Tag2Results", s2).detail("Tag1ResultsLim", kv1.size()).detail("Tag2ResultsLim", kv2.size()).detail("Tag1ResultsLast", kv1.size() ? kv1[0].key : "").detail("Tag2ResultsLast", kv2.size() ? kv2[0].key : "").detail("Limited", limited).detail("NextEpoch", next_pos.epoch).detail("NextSeq", next_pos.sequence).detail("NowEpoch", self->epoch()).detail("NowSeq", self->sequence.getNextSequence());
 
 			state std::vector<std::pair<IDiskQueue::location, IDiskQueue::location>> commitLocations;
 			state bool earlyEnd = false;
@@ -2087,7 +2087,7 @@ ACTOR Future<Void> restorePersistentState( TLogData* self, LocalityData locality
 			flushAndExit(0);
 		}
 
-		TraceEvent(SevError, "UnsupportedDBFormat", self->dbgid).detail("Format", printable(fFormat.get().get())).detail("Expected", persistFormat.value.toString());
+		TraceEvent(SevError, "UnsupportedDBFormat", self->dbgid).detail("Format", fFormat.get().get()).detail("Expected", persistFormat.value.toString());
 		throw worker_recovery_failed();
 	}
 
@@ -2098,7 +2098,7 @@ ACTOR Future<Void> restorePersistentState( TLogData* self, LocalityData locality
 			throw worker_removed();
 		} else {
 			// This should never happen
-			TraceEvent(SevError, "NoDBFormatKey", self->dbgid).detail("FirstKey", printable(v[0].key));
+			TraceEvent(SevError, "NoDBFormatKey", self->dbgid).detail("FirstKey", v[0].key);
 			ASSERT( false );
 			throw worker_recovery_failed();
 		}

--- a/fdbserver/fdbserver.actor.cpp
+++ b/fdbserver/fdbserver.actor.cpp
@@ -203,9 +203,9 @@ StringRef debugKey2 = LiteralStringRef( "\xff\xff\xff\xff" );
 
 bool debugMutation( const char* context, Version version, MutationRef const& mutation ) {
 	if ((mutation.type == mutation.SetValue || mutation.type == mutation.AddValue || mutation.type==mutation.DebugKey) && (mutation.param1 == debugKey || mutation.param1 == debugKey2))
-		;//TraceEvent("MutationTracking").detail("At", context).detail("Version", version).detail("MutationType", "SetValue").detail("Key", printable(mutation.param1)).detail("Value", printable(mutation.param2));
+		;//TraceEvent("MutationTracking").detail("At", context).detail("Version", version).detail("MutationType", "SetValue").detail("Key", mutation.param1).detail("Value", mutation.param2);
 	else if ((mutation.type == mutation.ClearRange || mutation.type == mutation.DebugKeyRange) && ((mutation.param1<=debugKey && mutation.param2>debugKey) || (mutation.param1<=debugKey2 && mutation.param2>debugKey2)))
-		;//TraceEvent("MutationTracking").detail("At", context).detail("Version", version).detail("MutationType", "ClearRange").detail("KeyBegin", printable(mutation.param1)).detail("KeyEnd", printable(mutation.param2));
+		;//TraceEvent("MutationTracking").detail("At", context).detail("Version", version).detail("MutationType", "ClearRange").detail("KeyBegin", mutation.param1).detail("KeyEnd", mutation.param2);
 	else
 		return false;
 	const char* type =
@@ -223,7 +223,7 @@ bool debugMutation( const char* context, Version version, MutationRef const& mut
 bool debugKeyRange( const char* context, Version version, KeyRangeRef const& keys ) {
 	if (keys.contains(debugKey) || keys.contains(debugKey2)) {
 		debugMutation(context, version, MutationRef(MutationRef::DebugKeyRange, keys.begin, keys.end) );
-		//TraceEvent("MutationTracking").detail("At", context).detail("Version", version).detail("KeyBegin", printable(keys.begin)).detail("KeyEnd", printable(keys.end));
+		//TraceEvent("MutationTracking").detail("At", context).detail("Version", version).detail("KeyBegin", keys.begin).detail("KeyEnd", keys.end);
 		return true;
 	} else
 		return false;

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -535,7 +535,7 @@ public:
 	void addShard( ShardInfo* newShard ) {
 		ASSERT( !newShard->keys.empty() );
 		newShard->changeCounter = ++shardChangeCounter;
-		//TraceEvent("AddShard", this->thisServerID).detail("KeyBegin", printable(newShard->keys.begin)).detail("KeyEnd", printable(newShard->keys.end)).detail("State", newShard->isReadable() ? "Readable" : newShard->notAssigned() ? "NotAssigned" : "Adding").detail("Version", this->version.get());
+		//TraceEvent("AddShard", this->thisServerID).detail("KeyBegin", newShard->keys.begin).detail("KeyEnd", newShard->keys.end).detail("State", newShard->isReadable() ? "Readable" : newShard->notAssigned() ? "NotAssigned" : "Adding").detail("Version", this->version.get());
 		/*auto affected = shards.getAffectedRangesAfterInsertion( newShard->keys, Reference<ShardInfo>() );
 		for(auto i = affected.begin(); i != affected.end(); ++i)
 			shards.insert( *i, Reference<ShardInfo>() );*/
@@ -619,7 +619,7 @@ bool validateRange( StorageServer::VersionedData::ViewAtVersion const& view, Key
 	// * Nonoverlapping: No clear overlaps a set or another clear, or adjoins another clear.
 	// * Old mutations are erased: All items in versionedData.atLatest() have insertVersion() > durableVersion()
 
-	TraceEvent("ValidateRange", id).detail("KeyBegin", printable(range.begin)).detail("KeyEnd", printable(range.end)).detail("Version", version);
+	TraceEvent("ValidateRange", id).detail("KeyBegin", range.begin).detail("KeyEnd", range.end).detail("Version", version);
 	KeyRef k;
 	bool ok = true;
 	bool kIsClear = false;
@@ -628,7 +628,7 @@ bool validateRange( StorageServer::VersionedData::ViewAtVersion const& view, Key
 	for(; i != view.end() && i.key() < range.end; ++i) {
 		ASSERT( i.insertVersion() > minInsertVersion );
 		if (kIsClear && i->isClearTo() ? i.key() <= k : i.key() < k) {
-			TraceEvent(SevError,"InvalidRange",id).detail("Key1", printable(k)).detail("Key2", printable(i.key())).detail("Version", version);
+			TraceEvent(SevError,"InvalidRange",id).detail("Key1", k).detail("Key2", i.key()).detail("Version", version);
 			ok = false;
 		}
 		//ASSERT( i.key() >= k );
@@ -668,8 +668,8 @@ void validate(StorageServer* data, bool force = false) {
 				ShardInfo* shard = s->value().getPtr();
 				if (!shard->isInVersionedData()) {
 					if (latest.lower_bound(s->begin()) != latest.lower_bound(s->end())) {
-						TraceEvent(SevError, "VF", data->thisServerID).detail("LastValidTime", data->debug_lastValidateTime).detail("KeyBegin", printable(s->begin())).detail("KeyEnd", printable(s->end()))
-							.detail("FirstKey", printable(latest.lower_bound(s->begin()).key())).detail("FirstInsertV", latest.lower_bound(s->begin()).insertVersion());
+						TraceEvent(SevError, "VF", data->thisServerID).detail("LastValidTime", data->debug_lastValidateTime).detail("KeyBegin", s->begin()).detail("KeyEnd", s->end())
+							.detail("FirstKey", latest.lower_bound(s->begin()).key()).detail("FirstInsertV", latest.lower_bound(s->begin()).insertVersion());
 					}
 					ASSERT( latest.lower_bound(s->begin()) == latest.lower_bound(s->end()) );
 				}
@@ -784,7 +784,7 @@ ACTOR Future<Void> getValueQ( StorageServer* data, GetValueRequest req ) {
 		state uint64_t changeCounter = data->shardChangeCounter;
 
 		if (!data->shards[req.key]->isReadable()) {
-			//TraceEvent("WrongShardServer", data->thisServerID).detail("Key", printable(req.key)).detail("Version", version).detail("In", "getValueQ");
+			//TraceEvent("WrongShardServer", data->thisServerID).detail("Key", req.key).detail("Version", version).detail("In", "getValueQ");
 			throw wrong_shard_server();
 		}
 
@@ -861,7 +861,7 @@ ACTOR Future<Void> watchValue_impl( StorageServer* data, WatchValueRequest req )
 				GetValueRequest getReq( req.key, latest, req.debugID );
 				state Future<Void> getValue = getValueQ( data, getReq ); //we are relying on the delay zero at the top of getValueQ, if removed we need one here
 				GetValueReply reply = wait( getReq.reply.getFuture() );
-				//TraceEvent("WatcherCheckValue").detail("Key", printable( req.key ) ).detail("Value", printable( req.value ) ).detail("CurrentValue", printable( v ) ).detail("Ver", latest);
+				//TraceEvent("WatcherCheckValue").detail("Key",  req.key  ).detail("Value",  req.value  ).detail("CurrentValue",  v  ).detail("Ver", latest);
 
 				debugMutation("ShardWatchValue", latest, MutationRef(MutationRef::DebugKey, req.key, reply.value.present() ? StringRef( reply.value.get() ) : LiteralStringRef("<null>") ) );
 
@@ -1091,9 +1091,9 @@ ACTOR Future<GetKeyValuesReply> readRange( StorageServer* data, Version version,
 			if (more) { // if there might be more data, begin reading right after what we already found to find out
 				//if (track) printf("more\n");
 				if (!(limit<=0 || *pLimitBytes<=0 || result.data.end()[-1].key == atStorageVersion.end()[-1].key))
-					TraceEvent(SevError, "ReadRangeIssue", data->thisServerID).detail("ReadBegin", printable(readBegin)).detail("ReadEnd", printable(readEnd))
-						.detail("VStart", vStart ? printable(vStart.key()) : "nil").detail("VEnd", vEnd ? printable(vEnd.key()) : "nil")
-						.detail("AtStorageVersionBack", printable(atStorageVersion.end()[-1].key)).detail("ResultBack", printable(result.data.end()[-1].key))
+					TraceEvent(SevError, "ReadRangeIssue", data->thisServerID).detail("ReadBegin", readBegin).detail("ReadEnd", readEnd)
+						.detail("VStart", vStart ? vStart.key() : LiteralStringRef("nil")).detail("VEnd", vEnd ? vEnd.key() : LiteralStringRef("nil"))
+						.detail("AtStorageVersionBack", atStorageVersion.end()[-1].key).detail("ResultBack", result.data.end()[-1].key)
 						.detail("Limit", limit).detail("LimitBytes", *pLimitBytes).detail("ResultSize", result.data.size()).detail("PrevSize", prevSize);
 				readBegin = readBeginTemp = keyAfter( result.data.end()[-1].key );
 				ASSERT( limit<=0 || *pLimitBytes<=0 || result.data.end()[-1].key == atStorageVersion.end()[-1].key );
@@ -1111,8 +1111,8 @@ ACTOR Future<GetKeyValuesReply> readRange( StorageServer* data, Version version,
 		/*if (*pLimitBytes <= 0)
 			TraceEvent(SevWarn, "ReadRangeLimitExceeded")
 				.detail("Version", version)
-				.detail("Begin", printable(range.begin) )
-				.detail("End", printable(range.end) )
+				.detail("Begin", range.begin )
+				.detail("End", range.end )
 				.detail("LimitReamin", limit)
 				.detail("LimitBytesRemain", *pLimitBytes); */
 
@@ -1135,9 +1135,9 @@ ACTOR Future<GetKeyValuesReply> readRange( StorageServer* data, Version version,
 		if ( !(totalsize>originalLimitBytes ? prefix_equal : result.data==correct.data) || correct.more != result.more ) {
 			TraceEvent(SevError, "IncorrectResult", rrid).detail("Server", data->thisServerID).detail("CorrectRows", correct.data.size())
 				.detail("FirstDifference", first_difference).detail("OriginalLimit", originalLimit)
-				.detail("ResultRows", result.data.size()).detail("Result0", printable(result.data[0].key)).detail("Correct0", printable(correct.data[0].key))
-				.detail("ResultN", result.data.size() ? printable(result.data[std::min(correct.data.size(),result.data.size())-1].key) : "nil")
-				.detail("CorrectN", correct.data.size() ? printable(correct.data[std::min(correct.data.size(),result.data.size())-1].key) : "nil");
+				.detail("ResultRows", result.data.size()).detail("Result0", result.data[0].key).detail("Correct0", correct.data[0].key)
+				.detail("ResultN", result.data.size() ? result.data[std::min(correct.data.size(),result.data.size())-1].key : "nil")
+				.detail("CorrectN", correct.data.size() ? correct.data[std::min(correct.data.size(),result.data.size())-1].key : "nil");
 		}*/
 	} else {
 		// Reverse read - abandon hope alle ye who enter here
@@ -1297,11 +1297,11 @@ ACTOR Future<Void> getKeyValues( StorageServer* data, GetKeyValuesRequest req )
 
 		if( req.debugID.present() )
 			g_traceBatch.addEvent("TransactionDebug", req.debugID.get().first(), "storageserver.getKeyValues.AfterVersion");
-			//.detail("ShardBegin", printable(shard.begin)).detail("ShardEnd", printable(shard.end));
+		//.detail("ShardBegin", shard.begin).detail("ShardEnd", shard.end);
 		//} catch (Error& e) { TraceEvent("WrongShardServer", data->thisServerID).detail("Begin", req.begin.toString()).detail("End", req.end.toString()).detail("Version", version).detail("Shard", "None").detail("In", "getKeyValues>getShardKeyRange"); throw e; }
 
 		if ( !selectorInRange(req.end, shard) && !(req.end.isFirstGreaterOrEqual() && req.end.getKey() == shard.end) ) {
-//			TraceEvent("WrongShardServer1", data->thisServerID).detail("Begin", req.begin.toString()).detail("End", req.end.toString()).detail("Version", version).detail("ShardBegin", printable(shard.begin)).detail("ShardEnd", printable(shard.end)).detail("In", "getKeyValues>checkShardExtents");
+//			TraceEvent("WrongShardServer1", data->thisServerID).detail("Begin", req.begin.toString()).detail("End", req.end.toString()).detail("Version", version).detail("ShardBegin", shard.begin).detail("ShardEnd", shard.end).detail("In", "getKeyValues>checkShardExtents");
 			throw wrong_shard_server();
 		}
 
@@ -1313,7 +1313,7 @@ ACTOR Future<Void> getKeyValues( StorageServer* data, GetKeyValuesRequest req )
 		state Key end = wait(fEnd);
 		if( req.debugID.present() )
 			g_traceBatch.addEvent("TransactionDebug", req.debugID.get().first(), "storageserver.getKeyValues.AfterKeys");
-			//.detail("Off1",offset1).detail("Off2",offset2).detail("ReqBegin",printable(req.begin.getKey())).detail("ReqEnd",printable(req.end.getKey()));
+		//.detail("Off1",offset1).detail("Off2",offset2).detail("ReqBegin",req.begin.getKey()).detail("ReqEnd",req.end.getKey());
 
 		// Offsets of zero indicate begin/end keys in this shard, which obviously means we can answer the query
 		// An end offset of 1 is also OK because the end key is exclusive, so if the first key of the next shard is the end the last actual key returned must be from this shard.
@@ -1323,14 +1323,14 @@ ACTOR Future<Void> getKeyValues( StorageServer* data, GetKeyValuesRequest req )
 			// We could detect when offset1 takes us off the beginning of the database or offset2 takes us off the end, and return a clipped range rather
 			// than an error (since that is what the NativeAPI.getRange will do anyway via its "slow path"), but we would have to add some flags to the response
 			// to encode whether we went off the beginning and the end, since it needs that information.
-			//TraceEvent("WrongShardServer2", data->thisServerID).detail("Begin", req.begin.toString()).detail("End", req.end.toString()).detail("Version", version).detail("ShardBegin", printable(shard.begin)).detail("ShardEnd", printable(shard.end)).detail("In", "getKeyValues>checkOffsets").detail("BeginKey", printable(begin)).detail("EndKey", printable(end)).detail("BeginOffset", offset1).detail("EndOffset", offset2);
+			//TraceEvent("WrongShardServer2", data->thisServerID).detail("Begin", req.begin.toString()).detail("End", req.end.toString()).detail("Version", version).detail("ShardBegin", shard.begin).detail("ShardEnd", shard.end).detail("In", "getKeyValues>checkOffsets").detail("BeginKey", begin).detail("EndKey", end).detail("BeginOffset", offset1).detail("EndOffset", offset2);
 			throw wrong_shard_server();
 		}
 
 		if (begin >= end) {
 			if( req.debugID.present() )
 				g_traceBatch.addEvent("TransactionDebug", req.debugID.get().first(), "storageserver.getKeyValues.Send");
-				//.detail("Begin",printable(begin)).detail("End",printable(end));
+			//.detail("Begin",begin).detail("End",end);
 
 			GetKeyValuesReply none;
 			none.version = version;
@@ -1347,7 +1347,7 @@ ACTOR Future<Void> getKeyValues( StorageServer* data, GetKeyValuesRequest req )
 
 			if( req.debugID.present() )
 				g_traceBatch.addEvent("TransactionDebug", req.debugID.get().first(), "storageserver.getKeyValues.AfterReadRange");
-				//.detail("Begin",printable(begin)).detail("End",printable(end)).detail("SizeOf",r.data.size());
+			//.detail("Begin",begin).detail("End",end).detail("SizeOf",r.data.size());
 			data->checkChangeCounter( changeCounter, KeyRangeRef( std::min<KeyRef>(begin, std::min<KeyRef>(req.begin.getKey(), req.end.getKey())), std::max<KeyRef>(end, std::max<KeyRef>(req.begin.getKey(), req.end.getKey())) ) );
 			if (EXPENSIVE_VALIDATION) {
 				for (int i = 0; i < r.data.size(); i++)
@@ -1873,8 +1873,8 @@ ACTOR Future<Void> fetchKeys( StorageServer *data, AddingShard* shard ) {
 		debugKeyRange("fetchKeysBegin", data->version.get(), shard->keys);
 
 		TraceEvent(SevDebug, interval.begin(), data->thisServerID)
-			.detail("KeyBegin", printable(shard->keys.begin))
-			.detail("KeyEnd",printable(shard->keys.end));
+			.detail("KeyBegin", shard->keys.begin)
+			.detail("KeyEnd",shard->keys.end);
 
 		validate(data);
 
@@ -1935,8 +1935,8 @@ ACTOR Future<Void> fetchKeys( StorageServer *data, AddingShard* shard ) {
 
 				TraceEvent(SevDebug, "FetchKeysBlock", data->thisServerID).detail("FKID", interval.pairID)
 					.detail("BlockRows", this_block.size()).detail("BlockBytes", expectedSize)
-					.detail("KeyBegin", printable(keys.begin)).detail("KeyEnd", printable(keys.end))
-					.detail("Last", this_block.size() ? printable(this_block.end()[-1].key) : std::string())
+					.detail("KeyBegin", keys.begin).detail("KeyEnd", keys.end)
+					.detail("Last", this_block.size() ? this_block.end()[-1].key : std::string())
 					.detail("Version", fetchVersion).detail("More", this_block.more);
 				debugKeyRange("fetchRange", fetchVersion, keys);
 				for(auto k = this_block.begin(); k != this_block.end(); ++k) debugMutation("fetch", fetchVersion, MutationRef(MutationRef::SetValue, k->key, k->value));
@@ -2124,8 +2124,8 @@ ACTOR Future<Void> fetchKeys( StorageServer *data, AddingShard* shard ) {
 		TraceEvent(SevError, "FetchKeysError", data->thisServerID)
 			.error(e)
 			.detail("Elapsed", now()-startt)
-			.detail("KeyBegin", printable(keys.begin))
-			.detail("KeyEnd",printable(keys.end));
+			.detail("KeyBegin", keys.begin)
+			.detail("KeyEnd",keys.end);
 		if (e.code() != error_code_actor_cancelled)
 			data->otherError.sendError(e);  // Kill the storage server.  Are there any recoverable errors?
 		throw; // goes nowhere
@@ -2185,8 +2185,8 @@ void changeServerKeys( StorageServer* data, const KeyRangeRef& keys, bool nowAss
 	ASSERT( !keys.empty() );
 
 	//TraceEvent("ChangeServerKeys", data->thisServerID)
-	//	.detail("KeyBegin", printable(keys.begin))
-	//	.detail("KeyEnd", printable(keys.end))
+	//	.detail("KeyBegin", keys.begin)
+	//	.detail("KeyEnd", keys.end)
 	//	.detail("NowAssigned", nowAssigned)
 	//	.detail("Version", version)
 	//	.detail("Context", changeServerKeysContextName[(int)context]);
@@ -2200,15 +2200,15 @@ void changeServerKeys( StorageServer* data, const KeyRangeRef& keys, bool nowAss
 		if( nowAssigned != it->value()->assigned() ) {
 			isDifferent = true;
 			/*TraceEvent("CSKRangeDifferent", data->thisServerID)
-				.detail("KeyBegin", printable(it->range().begin))
-				.detail("KeyEnd", printable(it->range().end));*/
+			  .detail("KeyBegin", it->range().begin)
+			  .detail("KeyEnd", it->range().end);*/
 			break;
 		}
 	}
 	if( !isDifferent ) {
 		//TraceEvent("CSKShortCircuit", data->thisServerID)
-		//	.detail("KeyBegin", printable(keys.begin))
-		//	.detail("KeyEnd", printable(keys.end));
+		//	.detail("KeyBegin", keys.begin)
+		//	.detail("KeyEnd", keys.end);
 		return;
 	}
 
@@ -2245,8 +2245,8 @@ void changeServerKeys( StorageServer* data, const KeyRangeRef& keys, bool nowAss
 		KeyRangeRef range = keys & r->range();
 		bool dataAvailable = r->value()==latestVersion || r->value() >= version;
 		/*TraceEvent("CSKRange", data->thisServerID)
-			.detail("KeyBegin", printable(range.begin))
-			.detail("KeyEnd", printable(range.end))
+		  .detail("KeyBegin", range.begin)
+		  .detail("KeyEnd", range.end)
 			.detail("Available", dataAvailable)
 			.detail("NowAssigned", nowAssigned)
 			.detail("NewestAvailable", r->value())
@@ -2832,7 +2832,7 @@ void setAvailableStatus( StorageServer* self, KeyRangeRef keys, bool available )
 	auto& mLV = self->addVersionToMutationLog( self->data().getLatestVersion() );
 
 	KeyRange availableKeys = KeyRangeRef( persistShardAvailableKeys.begin.toString() + keys.begin.toString(), persistShardAvailableKeys.begin.toString() + keys.end.toString() );
-	//TraceEvent("SetAvailableStatus", self->thisServerID).detail("Version", mLV.version).detail("RangeBegin", printable(availableKeys.begin)).detail("RangeEnd", printable(availableKeys.end));
+	//TraceEvent("SetAvailableStatus", self->thisServerID).detail("Version", mLV.version).detail("RangeBegin", availableKeys.begin).detail("RangeEnd", availableKeys.end);
 
 	self->addMutationToMutationLog( mLV, MutationRef( MutationRef::ClearRange, availableKeys.begin, availableKeys.end ) );
 	self->addMutationToMutationLog( mLV, MutationRef( MutationRef::SetValue, availableKeys.begin, available ? LiteralStringRef("1") : LiteralStringRef("0") ) );
@@ -2849,7 +2849,7 @@ void setAssignedStatus( StorageServer* self, KeyRangeRef keys, bool nowAssigned 
 	KeyRange assignedKeys = KeyRangeRef(
 		persistShardAssignedKeys.begin.toString() + keys.begin.toString(),
 		persistShardAssignedKeys.begin.toString() + keys.end.toString() );
-	//TraceEvent("SetAssignedStatus", self->thisServerID).detail("Version", mLV.version).detail("RangeBegin", printable(assignedKeys.begin)).detail("RangeEnd", printable(assignedKeys.end));
+	//TraceEvent("SetAssignedStatus", self->thisServerID).detail("Version", mLV.version).detail("RangeBegin", assignedKeys.begin).detail("RangeEnd", assignedKeys.end);
 	self->addMutationToMutationLog( mLV, MutationRef( MutationRef::ClearRange, assignedKeys.begin, assignedKeys.end ) );
 	self->addMutationToMutationLog( mLV, MutationRef( MutationRef::SetValue, assignedKeys.begin,
 			nowAssigned ? LiteralStringRef("1") : LiteralStringRef("0") ) );
@@ -2954,7 +2954,7 @@ ACTOR Future<Void> applyByteSampleResult( StorageServer* data, IKeyValueStore* s
 			wait(delay(SERVER_KNOBS->BYTE_SAMPLE_LOAD_DELAY));
 		}
 	}
-	TraceEvent("RecoveredByteSampleRange", data->thisServerID).detail("Begin", printable(begin)).detail("End", printable(end)).detail("Fetches", totalFetches).detail("Keys", totalKeys).detail("ReadBytes", totalBytes);
+	TraceEvent("RecoveredByteSampleRange", data->thisServerID).detail("Begin", begin).detail("End", end).detail("Fetches", totalFetches).detail("Keys", totalKeys).detail("ReadBytes", totalBytes);
 	return Void();
 }
 
@@ -3051,7 +3051,7 @@ ACTOR Future<bool> restoreDurableState( StorageServer* data, IKeyValueStore* sto
 		ASSERT( !keys.empty() );
 		bool nowAvailable = available[availableLoc].value!=LiteralStringRef("0");
 		/*if(nowAvailable)
-			TraceEvent("AvailableShard", data->thisServerID).detail("RangeBegin", printable(keys.begin)).detail("RangeEnd", printable(keys.end));*/
+		  TraceEvent("AvailableShard", data->thisServerID).detail("RangeBegin", keys.begin).detail("RangeEnd", keys.end);*/
 		data->newestAvailableVersion.insert( keys, nowAvailable ? latestVersion : invalidVersion );
 		wait(yield());
 	}
@@ -3065,7 +3065,7 @@ ACTOR Future<bool> restoreDurableState( StorageServer* data, IKeyValueStore* sto
 		ASSERT( !keys.empty() );
 		bool nowAssigned = assigned[assignedLoc].value!=LiteralStringRef("0");
 		/*if(nowAssigned)
-			TraceEvent("AssignedShard", data->thisServerID).detail("RangeBegin", printable(keys.begin)).detail("RangeEnd", printable(keys.end));*/
+		  TraceEvent("AssignedShard", data->thisServerID).detail("RangeBegin", keys.begin).detail("RangeEnd", keys.end);*/
 		changeServerKeys(data, keys, nowAssigned, version, CSK_RESTORE);
 
 		if (!nowAssigned) ASSERT( data->newestAvailableVersion.allEqual(keys, invalidVersion) );

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -2245,8 +2245,8 @@ void changeServerKeys( StorageServer* data, const KeyRangeRef& keys, bool nowAss
 		KeyRangeRef range = keys & r->range();
 		bool dataAvailable = r->value()==latestVersion || r->value() >= version;
 		/*TraceEvent("CSKRange", data->thisServerID)
-		  .detail("KeyBegin", range.begin)
-		  .detail("KeyEnd", range.end)
+			.detail("KeyBegin", range.begin)
+			.detail("KeyEnd", range.end)
 			.detail("Available", dataAvailable)
 			.detail("NowAssigned", nowAssigned)
 			.detail("NewestAvailable", r->value())

--- a/fdbserver/tester.actor.cpp
+++ b/fdbserver/tester.actor.cpp
@@ -151,7 +151,7 @@ int getOption( VectorRef<KeyValueRef> options, Key key, int defaultValue) {
 				options[i].value = LiteralStringRef("");
 				return r;
 			} else {
-				TraceEvent(SevError, "InvalidTestOption").detail("OptionName", printable(key));
+				TraceEvent(SevError, "InvalidTestOption").detail("OptionName", key);
 				throw test_specification_invalid();
 			}
 		}
@@ -167,7 +167,7 @@ uint64_t getOption( VectorRef<KeyValueRef> options, Key key, uint64_t defaultVal
 				options[i].value = LiteralStringRef("");
 				return r;
 			} else {
-				TraceEvent(SevError, "InvalidTestOption").detail("OptionName", printable(key));
+				TraceEvent(SevError, "InvalidTestOption").detail("OptionName", key);
 				throw test_specification_invalid();
 			}
 		}
@@ -183,7 +183,7 @@ int64_t getOption( VectorRef<KeyValueRef> options, Key key, int64_t defaultValue
 				options[i].value = LiteralStringRef("");
 				return r;
 			} else {
-				TraceEvent(SevError, "InvalidTestOption").detail("OptionName", printable(key));
+				TraceEvent(SevError, "InvalidTestOption").detail("OptionName", key);
 				throw test_specification_invalid();
 			}
 		}
@@ -304,7 +304,7 @@ TestWorkload *getWorkloadIface( WorkloadRequest work, VectorRef<KeyValueRef> opt
 	auto unconsumedOptions = checkAllOptionsConsumed( workload ? workload->options : VectorRef<KeyValueRef>() );
 	if( !workload || unconsumedOptions.size() ) {
 		TraceEvent evt(SevError,"TestCreationError");
-		evt.detail("TestName", printable(testName));
+		evt.detail("TestName", testName);
 		if( !workload ) {
 			evt.detail("Reason", "Null workload");
 			fprintf(stderr, "ERROR: Workload could not be created, perhaps testName (%s) is not a valid workload\n", printable(testName).c_str());
@@ -509,7 +509,7 @@ ACTOR Future<Void> testerServerWorkload( WorkloadRequest work, Reference<Cluster
 		}
 
 		// add test for "done" ?
-		TraceEvent("WorkloadReceived", workIface.id()).detail("Title", printable(work.title) );
+		TraceEvent("WorkloadReceived", workIface.id()).detail("Title", work.title );
 		TestWorkload *workload = getWorkloadIface( work, dbInfo );
 		if(!workload) {
 			TraceEvent("TestCreationError").detail("Reason", "Workload could not be created");
@@ -635,7 +635,7 @@ void throwIfError(const std::vector<Future<ErrorOr<T>>> &futures, std::string er
 
 ACTOR Future<DistributedTestResults> runWorkload( Database cx, std::vector< TesterInterface > testers, 
 	TestSpec spec ) {
-	TraceEvent("TestRunning").detail( "WorkloadTitle", printable(spec.title) )
+	TraceEvent("TestRunning").detail( "WorkloadTitle", spec.title )
 		.detail("TesterCount", testers.size()).detail("Phases", spec.phases)
 		.detail("TestTimeout", spec.timeout);
 
@@ -667,16 +667,16 @@ ACTOR Future<DistributedTestResults> runWorkload( Database cx, std::vector< Test
 	if( spec.phases & TestWorkload::SETUP ) {
 		state std::vector< Future<ErrorOr<Void>> > setups;
 		printf("setting up test (%s)...\n", printable(spec.title).c_str());
-		TraceEvent("TestSetupStart").detail("WorkloadTitle", printable(spec.title));
+		TraceEvent("TestSetupStart").detail("WorkloadTitle", spec.title);
 		for(int i= 0; i < workloads.size(); i++)
 			setups.push_back( workloads[i].setup.template getReplyUnlessFailedFor<Void>( waitForFailureTime, 0) );
 		wait( waitForAll( setups ) );
 		throwIfError(setups, "SetupFailedForWorkload" + printable(spec.title));
-		TraceEvent("TestSetupComplete").detail("WorkloadTitle", printable(spec.title));
+		TraceEvent("TestSetupComplete").detail("WorkloadTitle", spec.title);
 	}
 
 	if( spec.phases & TestWorkload::EXECUTION ) {
-		TraceEvent("TestStarting").detail("WorkloadTitle", printable(spec.title));
+		TraceEvent("TestStarting").detail("WorkloadTitle", spec.title);
 		printf("running test (%s)...\n", printable(spec.title).c_str());
 		state std::vector< Future<ErrorOr<Void>> > starts;
 		for(int i= 0; i < workloads.size(); i++)
@@ -684,7 +684,7 @@ ACTOR Future<DistributedTestResults> runWorkload( Database cx, std::vector< Test
 		wait( waitForAll( starts ) );
 		throwIfError(starts, "StartFailedForWorkload" + printable(spec.title));
 		printf("%s complete\n", printable(spec.title).c_str());
-		TraceEvent("TestComplete").detail("WorkloadTitle", printable(spec.title));
+		TraceEvent("TestComplete").detail("WorkloadTitle", spec.title);
 	}
 
 	if( spec.phases & TestWorkload::CHECK ) {
@@ -711,7 +711,7 @@ ACTOR Future<DistributedTestResults> runWorkload( Database cx, std::vector< Test
 	if( spec.phases & TestWorkload::METRICS ) {
 		state std::vector< Future<ErrorOr<vector<PerfMetric>>> > metricTasks;
 		printf("fetching metrics (%s)...\n", printable(spec.title).c_str());
-		TraceEvent("TestFetchingMetrics").detail("WorkloadTitle", printable(spec.title));
+		TraceEvent("TestFetchingMetrics").detail("WorkloadTitle", spec.title);
 		for(int i= 0; i < workloads.size(); i++)
 			metricTasks.push_back( workloads[i].metrics.template getReplyUnlessFailedFor<vector<PerfMetric>>(waitForFailureTime, 0) );
 		wait( waitForAll( metricTasks ) );
@@ -834,7 +834,7 @@ ACTOR Future<bool> runTest( Database cx, std::vector< TesterInterface > testers,
 	}
 
 	TraceEvent(ok ? SevInfo : SevWarnAlways, "TestResults")
-		.detail("Workload", printable(spec.title))
+		.detail("Workload", spec.title)
 		.detail("Passed", (int)ok);
 		//.detail("Metrics", metricSummary);
 
@@ -888,7 +888,7 @@ vector<TestSpec> readTests( ifstream& ifs ) {
 			}
 
 			spec.title = StringRef( value );
-			TraceEvent("TestParserTest").detail("ParsedTest", printable( spec.title ));
+			TraceEvent("TestParserTest").detail("ParsedTest",  spec.title );
 		} else if( attrib == "timeout" ) {
 			sscanf( value.c_str(), "%d", &(spec.timeout) );
 			ASSERT( spec.timeout > 0 );

--- a/fdbserver/worker.actor.cpp
+++ b/fdbserver/worker.actor.cpp
@@ -1261,7 +1261,7 @@ ACTOR Future<Void> fdbd(
 	try {
 
 		ServerCoordinators coordinators( connFile );
-		TraceEvent("StartingFDBD").detailext("ZoneID", localities.zoneId()).detailext("MachineId", localities.machineId()).detail("DiskPath", dataFolder).detail("CoordPath", coordFolder);
+		TraceEvent("StartingFDBD").detail("ZoneID", localities.zoneId()).detail("MachineId", localities.machineId()).detail("DiskPath", dataFolder).detail("CoordPath", coordFolder);
 
 		// SOMEDAY: start the services on the machine in a staggered fashion in simulation?
 		state vector<Future<Void>> v;

--- a/fdbserver/worker.actor.cpp
+++ b/fdbserver/worker.actor.cpp
@@ -307,18 +307,18 @@ std::vector< DiskStore > getDiskStores( std::string folder, std::string suffix, 
 			// Use the option string that's in the file rather than tLogOptions.toPrefix(),
 			// because they might be different if a new option was introduced in this version.
 			StringRef optionsString = filename.removePrefix(fileVersionedLogDataPrefix).eat("-");
-			TraceEvent("DiskStoreVersioned").detail("Filename", printable(filename));
+			TraceEvent("DiskStoreVersioned").detail("Filename", filename);
 			ErrorOr<TLogOptions> tLogOptions = TLogOptions::FromStringRef(optionsString);
 			if (tLogOptions.isError()) {
-				TraceEvent(SevWarn, "DiskStoreMalformedFilename").detail("Filename", printable(filename));
+				TraceEvent(SevWarn, "DiskStoreMalformedFilename").detail("Filename", filename);
 				continue;
 			}
-			TraceEvent("DiskStoreVersionedSuccess").detail("Filename", printable(filename));
+			TraceEvent("DiskStoreVersionedSuccess").detail("Filename", filename);
 			store.tLogOptions = tLogOptions.get();
 			prefix = filename.substr(0, fileVersionedLogDataPrefix.size() + optionsString.size() + 1);
 		}
 		else if( filename.startsWith( fileLogDataPrefix ) ) {
-			TraceEvent("DiskStoreUnversioned").detail("Filename", printable(filename));
+			TraceEvent("DiskStoreUnversioned").detail("Filename", filename);
 			store.storedComponent = DiskStore::TLogData;
 			store.tLogOptions.version = TLogVersion::V2;
 			store.tLogOptions.spillType = TLogSpillType::VALUE;

--- a/fdbserver/workloads/JavaWorkload.actor.cpp
+++ b/fdbserver/workloads/JavaWorkload.actor.cpp
@@ -47,7 +47,7 @@ void printTrace(JNIEnv* env, jobject self, jint severity, jstring message, jobje
 	auto f = onMainThread([severity, &detailsMap, msg]() -> Future<Void> {
 		TraceEvent evt(Severity(severity), msg);
 		for (const auto& p : detailsMap) {
-			evt.detail(p.first, p.second);
+			evt.detail(p.first.c_str(), p.second);
 		}
 		return Void();
 	});

--- a/fdbserver/workloads/MachineAttrition.actor.cpp
+++ b/fdbserver/workloads/MachineAttrition.actor.cpp
@@ -140,7 +140,7 @@ struct MachineAttritionWorkload : TestWorkload {
 				else
 					kt = ISimulator::RebootAndDelete;
 			}
-			TraceEvent("Assassination").detailext("TargetDatacenter", target).detail("Reboot", self->reboot).detail("KillType", kt);
+			TraceEvent("Assassination").detail("TargetDatacenter", target).detail("Reboot", self->reboot).detail("KillType", kt);
 
 			g_simulator.killDataCenter( target, kt );
 		} else {
@@ -176,7 +176,7 @@ struct MachineAttritionWorkload : TestWorkload {
 				}
 
 				TraceEvent("Assassination").detail("TargetMachine", targetMachine.toString())
-					.detailext("ZoneId", targetMachine.zoneId())
+					.detail("ZoneId", targetMachine.zoneId())
 					.detail("Reboot", self->reboot).detail("KilledMachines", killedMachines)
 					.detail("MachinesToKill", self->machinesToKill).detail("MachinesToLeave", self->machinesToLeave)
 					.detail("Machines", self->machines.size()).detail("Replace", self->replacement);

--- a/fdbserver/workloads/RemoveServersSafely.actor.cpp
+++ b/fdbserver/workloads/RemoveServersSafely.actor.cpp
@@ -379,7 +379,7 @@ struct RemoveServersSafelyWorkload : TestWorkload {
 			TraceEvent("RemoveAndKill", functionId).detail("Step", removeViaClear ? "ClearMachines" : "KillMachines").detail("Addresses", describe(killAddrs)).detail("Processes", killProcArray.size()).detail("Zones", zoneIds.size()).detail("ClusterAvailable", g_simulator.isAvailable());
 			for (auto& zoneId : zoneIds) {
 				killedMachine = g_simulator.killZone( zoneId, removeViaClear ? ISimulator::RebootAndDelete : ISimulator::KillInstantly );
-				TraceEvent(killedMachine ? SevInfo : SevWarn, "RemoveAndKill").detail("Step", removeViaClear ? "Clear Machine" : "Kill Machine").detailext("ZoneId", zoneId).detail(removeViaClear ? "Cleared" : "Killed", killedMachine).detail("ClusterAvailable", g_simulator.isAvailable());
+				TraceEvent(killedMachine ? SevInfo : SevWarn, "RemoveAndKill").detail("Step", removeViaClear ? "Clear Machine" : "Kill Machine").detail("ZoneId", zoneId).detail(removeViaClear ? "Cleared" : "Killed", killedMachine).detail("ClusterAvailable", g_simulator.isAvailable());
 			}
 		}
 

--- a/fdbserver/workloads/TaskBucketCorrectness.actor.cpp
+++ b/fdbserver/workloads/TaskBucketCorrectness.actor.cpp
@@ -33,7 +33,7 @@
 
 struct SayHelloTaskFunc : TaskFuncBase {
 	static StringRef name;
-	static const uint32_t version = 1;
+	static constexpr uint32_t version = 1;
 
 	StringRef getName() const { return name; };
 	Future<Void> execute(Database cx, Reference<TaskBucket> tb, Reference<FutureBucket> fb, Reference<Task> task) { return Void(); };
@@ -43,7 +43,11 @@ struct SayHelloTaskFunc : TaskFuncBase {
 		// check task version
 		uint32_t taskVersion = task->getVersion();
 		if (taskVersion > SayHelloTaskFunc::version) {
-			TraceEvent("TaskBucketCorrectnessSayHello").detail("CheckTaskVersion", "taskVersion is larger than the funcVersion").detail("TaskVersion", taskVersion).detail("FuncVersion", SayHelloTaskFunc::version);
+			uint32_t v = SayHelloTaskFunc::version;
+			TraceEvent("TaskBucketCorrectnessSayHello")
+				.detail("CheckTaskVersion", "taskVersion is larger than the funcVersion")
+				.detail("TaskVersion", taskVersion)
+				.detail("FuncVersion", v);
 		}
 
 		state Reference<TaskFuture> done = futureBucket->unpack(task->params[Task::reservedTaskParamKeyDone]);

--- a/flow/ActorCollection.actor.cpp
+++ b/flow/ActorCollection.actor.cpp
@@ -143,7 +143,7 @@ TEST_CASE("/flow/TraceEvent") {
 	}
 	TraceEvent("TraceDuration")
 		.detail("Time", g_network->now() - startTime);
-	printf("benchmark done\n", getpid());
+	printf("benchmark done\n");
 	wait(delay(10));
 	return Void();
 }

--- a/flow/ActorCollection.actor.cpp
+++ b/flow/ActorCollection.actor.cpp
@@ -62,14 +62,22 @@ ACTOR Future<Void> actorCollection( FutureStream<Future<Void>> addActor, int* pC
 
 TEST_CASE("/flow/TraceEvent") {
 	state unsigned i;
-	state double startTime = g_network->now();
-	state std::string str = "hello";
+	state double startTime;
+	state std::vector<std::string> strings;
+	strings.reserve(1000);
+	for (i = 0; i < 100; ++i) {
+		for (int j = 0; j < 100; ++j) {
+			strings.emplace_back(g_random->randomAlphaNumeric(g_random->randomInt(1, 30)));
+		}
+	}
+	wait(delay(0));
+	startTime = g_network->now();
 	for (i = 0; i < 100000; ++i) {
 		for (unsigned j = 0; j < 100; ++j) {
 			TraceEvent("TestTraceLineNoDebug")
 				.detail("Num", g_random->randomInt(0, 1000))
 				.detail("Double", g_random->random01())
-				.detail("hello", str);
+				.detail("hello", strings[g_random->randomInt(0, strings.size())]);
 		}
 		wait(delay(0));
 	}
@@ -81,7 +89,7 @@ TEST_CASE("/flow/TraceEvent") {
 			TraceEvent(SevDebug, "TestTraceLineNoDebug")
 				.detail("Num", g_random->randomInt(0, 1000))
 				.detail("Double", g_random->random01())
-				.detail("hello", str);
+				.detail("hello", strings[g_random->randomInt(0, strings.size())]);
 		}
 		wait(delay(0));
 	}

--- a/flow/ActorCollection.actor.cpp
+++ b/flow/ActorCollection.actor.cpp
@@ -60,14 +60,6 @@ ACTOR Future<Void> actorCollection( FutureStream<Future<Void>> addActor, int* pC
 	}
 }
 
-template<>
-struct Traceable<std::string> : std::true_type {
-	template<class Str>
-	static std::string toString(Str&& s) {
-		return std::forward<Str>(s);
-	}
-};
-
 template<class T, class U>
 struct Traceable<std::pair<T, U>> {
 	static constexpr bool value = Traceable<T>::value && Traceable<U>::value;
@@ -90,24 +82,45 @@ TEST_CASE("/flow/TraceEvent") {
 	state unsigned i;
 	state double startTime;
 	state std::vector<std::string> strings;
+	state std::vector<int> keyIdx;
+	state std::vector<int> pairRnd;
+	state std::vector<int> num;
+	state std::vector<double> doub;
+	state std::vector<int> strIdx;
 	strings.reserve(10000);
+	keyIdx.reserve(1e6);
+	pairRnd.reserve(1e6);
+	num.reserve(1e6);
+	doub.reserve(1e6);
+	strIdx.reserve(1e6);
 	for (i = 0; i < 100; ++i) {
 		for (int j = 0; j < 100; ++j) {
 			strings.emplace_back(g_random->randomAlphaNumeric(g_random->randomInt(1, 30)));
 		}
 		wait(delay(0));
 	}
+	for (i = 0; i < 1e6; ++i) {
+		keyIdx.emplace_back(g_random->randomInt(0, strings.size()));
+		pairRnd.emplace_back(g_random->randomInt(-1000, 1000));
+		num.emplace_back(g_random->randomInt(0, 1000));
+		doub.emplace_back(g_random->random01());
+		strIdx.emplace_back(g_random->randomInt(0, strings.size()));
+	}
 	TraceEvent("pairsfilled")
 		.detail("MemoryUsage", getMemoryUsage());
+	printf("Sleeping for 20 seconds - attach perf now to PID %d\n", getpid());
+	wait(delay(20));
+	printf("Done sleeping\n");
 	startTime = g_network->now();
 	for (i = 0; i < 100000; ++i) {
 		for (unsigned j = 0; j < 100; ++j) {
-			StringRef key(strings[g_random->randomInt(0, strings.size())]);
-			auto p = std::make_pair(key, g_random->randomInt(-1000, 1000));
+			int idx = (i+1)*j % keyIdx.size();
+			StringRef key(strings[keyIdx[idx]]);
+			auto p = std::make_pair(key, pairRnd[idx]);
 			TraceEvent("TestTraceLineNoDebug")
-				.detail("Num", g_random->randomInt(0, 1000))
-				.detail("Double", g_random->random01())
-				.detail("str", strings[g_random->randomInt(0, strings.size())])
+				.detail("Num", num[idx])
+				.detail("Double", doub[idx])
+				.detail("str", strings[strIdx[idx]])
 				.detail("pair", p);
 		}
 		wait(delay(0));
@@ -117,17 +130,20 @@ TEST_CASE("/flow/TraceEvent") {
 	startTime = g_network->now();
 	for (i = 0; i < 1000000; ++i) {
 		for (unsigned j = 0; j < 100; ++j) {
-			StringRef key(strings[g_random->randomInt(0, strings.size())]);
-			auto p = std::make_pair(key, g_random->randomInt(-1000, 1000));
+			int idx = (i+1)*j % keyIdx.size();
+			StringRef key(strings[keyIdx[idx]]);
+			auto p = std::make_pair(key, pairRnd[idx]);
 			TraceEvent(SevDebug, "TestTraceLineDebug")
-				.detail("Num", g_random->randomInt(0, 1000))
-				.detail("Double", g_random->random01())
-				.detail("str", strings[g_random->randomInt(0, strings.size())])
+				.detail("Num", num[idx])
+				.detail("Double", doub[idx])
+				.detail("str", strings[strIdx[idx]])
 				.detail("pair", p);
 		}
 		wait(delay(0));
 	}
 	TraceEvent("TraceDuration")
 		.detail("Time", g_network->now() - startTime);
+	printf("benchmark done\n", getpid());
+	wait(delay(10));
 	return Void();
 }

--- a/flow/ActorCollection.actor.cpp
+++ b/flow/ActorCollection.actor.cpp
@@ -20,6 +20,7 @@
 
 #include "flow/ActorCollection.h"
 #include "flow/IndexedSet.h"
+#include "flow/UnitTest.h"
 #include "flow/actorcompiler.h"  // This must be the last #include.
 
 ACTOR Future<Void> actorCollection( FutureStream<Future<Void>> addActor, int* pCount, double *lastChangeTime, double *idleTime, double *allTime, bool returnWhenEmptied )
@@ -57,4 +58,34 @@ ACTOR Future<Void> actorCollection( FutureStream<Future<Void>> addActor, int* pC
 		}
 		when (Error e = waitNext(errors.getFuture())) { throw e; }
 	}
+}
+
+TEST_CASE("/flow/TraceEvent") {
+	state unsigned i;
+	state double startTime = g_network->now();
+	state std::string str = "hello";
+	for (i = 0; i < 10000; ++i) {
+		for (unsigned j = 0; j < 100; ++j) {
+			TraceEvent("TestTraceLineNoDebug")
+				.detail("Num", g_random->randomInt(0, 1000))
+				.detail("Double", g_random->random01())
+				.detail("hello", str);
+		}
+		wait(delay(0));
+	}
+	TraceEvent("TraceDuration")
+		.detail("Time", g_network->now() - startTime);
+	startTime = g_network->now();
+	for (i = 0; i < 10000; ++i) {
+		for (unsigned j = 0; j < 100; ++j) {
+			TraceEvent(SevDebug, "TestTraceLineNoDebug")
+				.detail("Num", g_random->randomInt(0, 1000))
+				.detail("Double", g_random->random01())
+				.detail("hello", str);
+		}
+		wait(delay(0));
+	}
+	TraceEvent("TraceDuration")
+		.detail("Time", g_network->now() - startTime);
+	return Void();
 }

--- a/flow/ActorCollection.actor.cpp
+++ b/flow/ActorCollection.actor.cpp
@@ -60,24 +60,55 @@ ACTOR Future<Void> actorCollection( FutureStream<Future<Void>> addActor, int* pC
 	}
 }
 
+template<>
+struct Traceable<std::string> : std::true_type {
+	template<class Str>
+	static std::string toString(Str&& s) {
+		return std::forward<Str>(s);
+	}
+};
+
+template<class T, class U>
+struct Traceable<std::pair<T, U>> {
+	static constexpr bool value = Traceable<T>::value && Traceable<U>::value;
+	static std::string toString(const std::pair<T, U>& p) {
+		auto tStr = Traceable<T>::toString(p.first);
+		auto uStr = Traceable<U>::toString(p.second);
+		std::string result(tStr.size() + uStr.size() + 3, 'x');
+		std::copy(tStr.begin(), tStr.end(), result.begin());
+		auto iter = result.begin() + tStr.size();
+		*(iter++) = ' ';
+		*(iter++) = '-';
+		*(iter++) = ' ';
+		std::copy(uStr.begin(), uStr.end(), iter);
+		return result;
+	}
+};
+
+
 TEST_CASE("/flow/TraceEvent") {
 	state unsigned i;
 	state double startTime;
 	state std::vector<std::string> strings;
-	strings.reserve(1000);
+	strings.reserve(10000);
 	for (i = 0; i < 100; ++i) {
 		for (int j = 0; j < 100; ++j) {
 			strings.emplace_back(g_random->randomAlphaNumeric(g_random->randomInt(1, 30)));
 		}
+		wait(delay(0));
 	}
-	wait(delay(0));
+	TraceEvent("pairsfilled")
+		.detail("MemoryUsage", getMemoryUsage());
 	startTime = g_network->now();
 	for (i = 0; i < 100000; ++i) {
 		for (unsigned j = 0; j < 100; ++j) {
+			StringRef key(strings[g_random->randomInt(0, strings.size())]);
+			auto p = std::make_pair(key, g_random->randomInt(-1000, 1000));
 			TraceEvent("TestTraceLineNoDebug")
 				.detail("Num", g_random->randomInt(0, 1000))
 				.detail("Double", g_random->random01())
-				.detail("hello", strings[g_random->randomInt(0, strings.size())]);
+				.detail("str", strings[g_random->randomInt(0, strings.size())])
+				.detail("pair", p);
 		}
 		wait(delay(0));
 	}
@@ -86,10 +117,13 @@ TEST_CASE("/flow/TraceEvent") {
 	startTime = g_network->now();
 	for (i = 0; i < 1000000; ++i) {
 		for (unsigned j = 0; j < 100; ++j) {
-			TraceEvent(SevDebug, "TestTraceLineNoDebug")
+			StringRef key(strings[g_random->randomInt(0, strings.size())]);
+			auto p = std::make_pair(key, g_random->randomInt(-1000, 1000));
+			TraceEvent(SevDebug, "TestTraceLineDebug")
 				.detail("Num", g_random->randomInt(0, 1000))
 				.detail("Double", g_random->random01())
-				.detail("hello", strings[g_random->randomInt(0, strings.size())]);
+				.detail("str", strings[g_random->randomInt(0, strings.size())])
+				.detail("pair", p);
 		}
 		wait(delay(0));
 	}

--- a/flow/ActorCollection.actor.cpp
+++ b/flow/ActorCollection.actor.cpp
@@ -64,7 +64,7 @@ TEST_CASE("/flow/TraceEvent") {
 	state unsigned i;
 	state double startTime = g_network->now();
 	state std::string str = "hello";
-	for (i = 0; i < 10000; ++i) {
+	for (i = 0; i < 100000; ++i) {
 		for (unsigned j = 0; j < 100; ++j) {
 			TraceEvent("TestTraceLineNoDebug")
 				.detail("Num", g_random->randomInt(0, 1000))
@@ -76,7 +76,7 @@ TEST_CASE("/flow/TraceEvent") {
 	TraceEvent("TraceDuration")
 		.detail("Time", g_network->now() - startTime);
 	startTime = g_network->now();
-	for (i = 0; i < 10000; ++i) {
+	for (i = 0; i < 1000000; ++i) {
 		for (unsigned j = 0; j < 100; ++j) {
 			TraceEvent(SevDebug, "TestTraceLineNoDebug")
 				.detail("Num", g_random->randomInt(0, 1000))

--- a/flow/Arena.h
+++ b/flow/Arena.h
@@ -652,6 +652,20 @@ private:
 };
 #pragma pack( pop )
 
+template<>
+struct Traceable<StringRef> : std::true_type {
+	static std::string toString(const StringRef& value) {
+		return value.toString();
+	}
+};
+
+template<class T>
+struct Traceable<Standalone<T>> : std::conditional<Traceable<T>::value, std::true_type, std::false_type>::type {
+	static std::string toString(const Standalone<T>& value) {
+		return Traceable<T>::toString(value);
+	}
+};
+
 #define LiteralStringRef( str ) StringRef( (const uint8_t*)(str), sizeof((str))-1 )
 
 // makeString is used to allocate a Standalone<StringRef> of a known length for later

--- a/flow/Arena.h
+++ b/flow/Arena.h
@@ -422,6 +422,13 @@ private:
 	bool valid;
 };
 
+template<class T>
+struct Traceable<Optional<T>> : std::conditional<Traceable<T>::value, std::true_type, std::false_type>::type {
+	static std::string toString(const Optional<T>& value) {
+		return value.present() ? Traceable<T>::toString(value.get()) : "[not set]";
+	}
+};
+
 //#define STANDALONE_ALWAYS_COPY
 
 template <class T>

--- a/flow/SystemMonitor.cpp
+++ b/flow/SystemMonitor.cpp
@@ -89,8 +89,8 @@ SystemStatistics customSystemMonitor(std::string eventName, StatisticsState *sta
 				.detail("CachePageReadsMerged", netData.countFileCachePageReadsMerged - statState->networkState.countFileCachePageReadsMerged)
 				.detail("CacheWrites", netData.countFileCacheWrites - statState->networkState.countFileCacheWrites)
 				.detail("CacheReads", netData.countFileCacheReads - statState->networkState.countFileCacheReads)
-				.detailext("ZoneID", machineState.zoneId)
-				.detailext("MachineID", machineState.machineId)
+				.detail("ZoneID", machineState.zoneId)
+				.detail("MachineID", machineState.machineId)
 				.detail("AIOSubmitCount", netData.countAIOSubmit - statState->networkState.countAIOSubmit)
 				.detail("AIOCollectCount", netData.countAIOCollect - statState->networkState.countAIOCollect)
 				.detail("AIOSubmitLag", (g_network->networkMetrics.secSquaredSubmit - statState->networkMetricsState.secSquaredSubmit) / currentStats.elapsed)
@@ -153,8 +153,8 @@ SystemStatistics customSystemMonitor(std::string eventName, StatisticsState *sta
 				.detail("TotalMemory", currentStats.machineTotalRAM)
 				.detail("CommittedMemory", currentStats.machineCommittedRAM)
 				.detail("AvailableMemory", currentStats.machineAvailableRAM)
-				.detailext("ZoneID", machineState.zoneId)
-				.detailext("MachineID", machineState.machineId)
+				.detail("ZoneID", machineState.zoneId)
+				.detail("MachineID", machineState.machineId)
 				.trackLatest("MachineMetrics");
 		}
 	}

--- a/flow/TDMetric.actor.h
+++ b/flow/TDMetric.actor.h
@@ -1381,6 +1381,21 @@ struct MetricHandle {
 	Reference<T> ref;
 };
 
+template<class T>
+struct Traceable<MetricHandle<T>> : Traceable<typename T::ValueType> {
+	static std::string toString(const MetricHandle<T>& value) {
+		return Traceable<typename T::ValueType>::toString(value.getValue());
+	}
+};
+
+template<class T>
+struct SpecialTraceMetricType<MetricHandle<T>> : SpecialTraceMetricType<typename T::ValueType> {
+	using parent = SpecialTraceMetricType<typename T::ValueType>;
+	static auto getValue(const MetricHandle<T>& value) -> decltype(parent::getValue(value.getValue())) {
+		return parent::getValue(value.getValue());
+	}
+};
+
 typedef MetricHandle<Int64Metric> Int64MetricHandle;
 typedef MetricHandle<VersionMetric> VersionMetricHandle;
 typedef MetricHandle<BoolMetric> BoolMetricHandle;

--- a/flow/Trace.cpp
+++ b/flow/Trace.cpp
@@ -654,11 +654,17 @@ void removeTraceRole(std::string role) {
 }
 
 TraceEvent::TraceEvent( const char* type, UID id ) : id(id), type(type), severity(SevInfo), initialized(false), enabled(true) {}
-TraceEvent::TraceEvent( Severity severity, const char* type, UID id ) : id(id), type(type), severity(severity), initialized(false), enabled(true) {}
+TraceEvent::TraceEvent( Severity severity, const char* type, UID id )
+	: id(id), type(type), severity(severity), initialized(false),
+	  enabled(g_network == nullptr || FLOW_KNOBS->MIN_TRACE_SEVERITY >= severity) {}
 TraceEvent::TraceEvent( TraceInterval& interval, UID id ) : id(id), type(interval.type), severity(interval.severity), initialized(false), enabled(true) {
 	init(interval);
 }
-TraceEvent::TraceEvent( Severity severity, TraceInterval& interval, UID id ) : id(id), type(interval.type), severity(severity), initialized(false), enabled(true) {
+TraceEvent::TraceEvent( Severity severity, TraceInterval& interval, UID id )
+	: id(id), type(interval.type),
+	  severity(severity),
+	  initialized(false),
+	  enabled(g_network == nullptr || FLOW_KNOBS->MIN_TRACE_SEVERITY >= severity) {
 	init(interval);
 }
 
@@ -713,7 +719,7 @@ bool TraceEvent::init() {
 			severity = SevWarnAlways;
 		}
 
-		detail("Severity", severity);
+		detail("Severity", int(severity));
 		detailf("Time", "%.6f", time);
 		detail("Type", type);
 		if(g_network && g_network->isSimulated()) {
@@ -736,25 +742,23 @@ bool TraceEvent::init() {
 	return enabled;
 }
 
-TraceEvent& TraceEvent::error(class Error const& error, bool includeCancelled) {
-	if(enabled) {
-		if (error.code() != error_code_actor_cancelled || includeCancelled) {
-			err = error;
-			if (initialized) {
-				if (error.isInjectedFault()) {
-					detail("ErrorIsInjectedFault", true);
-					if(severity == SevError) severity = SevWarnAlways;
-				}
-				detail("Error", error.name());
-				detail("ErrorDescription", error.what());
-				detail("ErrorCode", error.code());
+TraceEvent& TraceEvent::errorImpl(class Error const& error, bool includeCancelled) {
+	if (error.code() != error_code_actor_cancelled || includeCancelled) {
+		err = error;
+		if (initialized) {
+			if (error.isInjectedFault()) {
+				detail("ErrorIsInjectedFault", true);
+				if(severity == SevError) severity = SevWarnAlways;
 			}
+			detail("Error", error.name());
+			detail("ErrorDescription", error.what());
+			detail("ErrorCode", error.code());
+		}
+	} else {
+		if (initialized) {
+			TraceEvent(g_network && g_network->isSimulated() ? SevError : SevWarnAlways, std::string(TRACE_EVENT_INVALID_SUPPRESSION).append(type).c_str()).suppressFor(5);
 		} else {
-			if (initialized) {
-				TraceEvent(g_network && g_network->isSimulated() ? SevError : SevWarnAlways, std::string(TRACE_EVENT_INVALID_SUPPRESSION).append(type).c_str()).suppressFor(5);
-			} else {
-				enabled = false;
-			}
+			enabled = false;
 		}
 	}
 	return *this;
@@ -781,66 +785,18 @@ TraceEvent& TraceEvent::detailImpl( std::string&& key, std::string&& value, bool
 	return *this;
 }
 
-TraceEvent& TraceEvent::detail( std::string key, std::string value ) {
-	return detailImpl(std::move(key), std::move(value));
+void TraceEvent::setField(const char* key, int64_t value) {
+	tmpEventMetric->setField(key, value);
 }
-TraceEvent& TraceEvent::detail( std::string key, double value ) {
-	init();
-	if(enabled)
-		tmpEventMetric->setField(key.c_str(), value);
-	return detailfNoMetric( std::move(key), "%g", value );
+
+void TraceEvent::setField(const char* key, double value) {
+	tmpEventMetric->setField(key, value);
 }
-TraceEvent& TraceEvent::detail( std::string key, int value ) {
-	init();
-	if(enabled)
-		tmpEventMetric->setField(key.c_str(), (int64_t)value);
-	return detailfNoMetric( std::move(key), "%d", value );
+
+void TraceEvent::setField(const char* key, const std::string& value) {
+	tmpEventMetric->setField(key, Standalone<StringRef>(value));
 }
-TraceEvent& TraceEvent::detail( std::string key, unsigned value ) {
-	init();
-	if(enabled)
-		tmpEventMetric->setField(key.c_str(), (int64_t)value);
-	return detailfNoMetric( std::move(key), "%u", value );
-}
-TraceEvent& TraceEvent::detail( std::string key, long int value ) {
-	init();
-	if(enabled)
-		tmpEventMetric->setField(key.c_str(), (int64_t)value);
-	return detailfNoMetric( std::move(key), "%ld", value );
-}
-TraceEvent& TraceEvent::detail( std::string key, long unsigned int value ) {
-	init();
-	if(enabled)
-		tmpEventMetric->setField(key.c_str(), (int64_t)value);
-	return detailfNoMetric( std::move(key), "%lu", value );
-}
-TraceEvent& TraceEvent::detail( std::string key, long long int value ) {
-	init();
-	if(enabled)
-		tmpEventMetric->setField(key.c_str(), (int64_t)value);
-	return detailfNoMetric( std::move(key), "%lld", value );
-}
-TraceEvent& TraceEvent::detail( std::string key, long long unsigned int value ) {
-	init();
-	if(enabled)
-		tmpEventMetric->setField(key.c_str(), (int64_t)value);
-	return detailfNoMetric( std::move(key), "%llu", value );
-}
-TraceEvent& TraceEvent::detail( std::string key, const NetworkAddress& value ) {
-	return detailImpl( std::move(key), value.toString() );
-}
-TraceEvent& TraceEvent::detail( std::string key, const IPAddress& value ) {
-	return detailImpl( std::move(key), value.toString() );
-}
-TraceEvent& TraceEvent::detail( std::string key, const UID& value ) {
-	return detailf( std::move(key), "%016llx", value.first() );  // SOMEDAY: Log entire value?  We also do this explicitly in some "lists" in various individual TraceEvent calls
-}
-TraceEvent& TraceEvent::detailext( std::string key, StringRef const& value ) {
-	return detailImpl(std::move(key), value.printable());
-}
-TraceEvent& TraceEvent::detailext( std::string key, const Optional<Standalone<StringRef>>& value ) {
-	return detailImpl(std::move(key), (value.present()) ? value.get().printable() : "[not set]");
-}
+
 TraceEvent& TraceEvent::detailf( std::string key, const char* valueFormat, ... ) {
 	if (enabled) {
 		va_list args;

--- a/flow/Trace.cpp
+++ b/flow/Trace.cpp
@@ -656,7 +656,7 @@ void removeTraceRole(std::string role) {
 TraceEvent::TraceEvent( const char* type, UID id ) : id(id), type(type), severity(SevInfo), initialized(false), enabled(true) {}
 TraceEvent::TraceEvent( Severity severity, const char* type, UID id )
 	: id(id), type(type), severity(severity), initialized(false),
-	  enabled(g_network == nullptr || FLOW_KNOBS->MIN_TRACE_SEVERITY >= severity) {}
+	  enabled(g_network == nullptr || FLOW_KNOBS->MIN_TRACE_SEVERITY <= severity) {}
 TraceEvent::TraceEvent( TraceInterval& interval, UID id ) : id(id), type(interval.type), severity(interval.severity), initialized(false), enabled(true) {
 	init(interval);
 }
@@ -664,7 +664,7 @@ TraceEvent::TraceEvent( Severity severity, TraceInterval& interval, UID id )
 	: id(id), type(interval.type),
 	  severity(severity),
 	  initialized(false),
-	  enabled(g_network == nullptr || FLOW_KNOBS->MIN_TRACE_SEVERITY >= severity) {
+	  enabled(g_network == nullptr || FLOW_KNOBS->MIN_TRACE_SEVERITY <= severity) {
 	init(interval);
 }
 

--- a/flow/Trace.cpp
+++ b/flow/Trace.cpp
@@ -657,7 +657,11 @@ TraceEvent::TraceEvent( const char* type, UID id ) : id(id), type(type), severit
 TraceEvent::TraceEvent( Severity severity, const char* type, UID id )
 	: id(id), type(type), severity(severity), initialized(false),
 	  enabled(g_network == nullptr || FLOW_KNOBS->MIN_TRACE_SEVERITY <= severity) {}
-TraceEvent::TraceEvent( TraceInterval& interval, UID id ) : id(id), type(interval.type), severity(interval.severity), initialized(false), enabled(true) {
+TraceEvent::TraceEvent( TraceInterval& interval, UID id )
+	: id(id), type(interval.type)
+	, severity(interval.severity)
+	, initialized(false)
+	, enabled(g_network == nullptr || FLOW_KNOBS->MIN_TRACE_SEVERITY <= interval.severity) {
 	init(interval);
 }
 TraceEvent::TraceEvent( Severity severity, TraceInterval& interval, UID id )

--- a/flow/Trace.h
+++ b/flow/Trace.h
@@ -271,13 +271,14 @@ struct Traceable<char*> : std::true_type {
 
 template<>
 struct Traceable<std::string> : std::true_type {
+	static bool isPrintable(char c) { return c >= 32 && c < 127; }
 	template<class Str>
 	static std::string toString(Str&& value) {
 		// if all characters are printable ascii, we simply return the string
 		int nonPrintables = 0;
 		int numBackslashes = 0;
 		for (auto c : value) {
-			if (!Traceable<const char*>::isPrintable(c)) {
+			if (!isPrintable(c)) {
 				++nonPrintables;
 			} else if (c == '\\') {
 				++numBackslashes;
@@ -289,7 +290,7 @@ struct Traceable<std::string> : std::true_type {
 		std::string result;
 		result.reserve(value.size() - nonPrintables + (nonPrintables * 4) + numBackslashes);
 		for (auto c : value) {
-			if (Traceable<const char*>::isPrintable(c)) {
+			if (isPrintable(c)) {
 				result.push_back(c);
 			} else if (c == '\\') {
 				result.push_back('\\');

--- a/flow/Trace.h
+++ b/flow/Trace.h
@@ -162,6 +162,12 @@ FORMAT_TRACEABLE(unsigned long int, "%lu");
 FORMAT_TRACEABLE(long long int, "%lld");
 FORMAT_TRACEABLE(unsigned long long int, "%llu");
 FORMAT_TRACEABLE(double, "%g");
+FORMAT_TRACEABLE(volatile long, "%ld");
+FORMAT_TRACEABLE(volatile unsigned long, "%lu");
+FORMAT_TRACEABLE(volatile long long, "%lld");
+FORMAT_TRACEABLE(volatile unsigned long long, "%llu");
+FORMAT_TRACEABLE(volatile double, "%g");
+
 
 template<>
 struct Traceable<UID> : std::true_type {

--- a/flow/Trace.h
+++ b/flow/Trace.h
@@ -216,15 +216,6 @@ struct Traceable<UID> : std::true_type {
 	}
 };
 
-template<class S>
-struct IsTraceableString : std::false_type {};
-
-template<>
-struct IsTraceableString<std::string> : std::false_type {};
-
-template<>
-struct IsTraceableString<const char*> : std::false_type {};
-
 template<class Str>
 struct TraceableString {
 	static auto begin(const Str& value) -> decltype(value.begin()) {

--- a/flow/Trace.h
+++ b/flow/Trace.h
@@ -211,8 +211,7 @@ struct TraceEvent {
 	template<class T>
 	typename std::enable_if<Traceable<T>::value, TraceEvent&>::type
 	detail( std::string&& key, const T& value ) {
-		if (enabled) {
-			init();
+		if (enabled && init()) {
 			auto s = Traceable<T>::toString(value);
 			addMetric(key.c_str(), value, s);
 			return detailImpl(std::move(key), std::move(s));
@@ -223,8 +222,7 @@ struct TraceEvent {
 	template<class T>
 	typename std::enable_if<Traceable<T>::value, TraceEvent&>::type
 	detail( const char* key, const T& value ) {
-		if (enabled) {
-			init();
+		if (enabled && init()) {
 			auto s = Traceable<T>::toString(value);
 			addMetric(key, value, s);
 			return detailImpl(std::string(key), std::move(s), false);
@@ -234,15 +232,14 @@ struct TraceEvent {
 	template<class T>
 	typename std::enable_if<std::is_enum<T>::value, TraceEvent&>::type
 	detail(const char* key, T value) {
-		if (enabled) {
-			init();
+		if (enabled && init()) {
 			setField(key, int64_t(value));
 			return detailImpl(std::string(key), format("%d", value), false);
 		}
 		return *this;
 	}
 	TraceEvent& detail(std::string key, std::string value) {
-		if (enabled) {
+		if (enabled && init()) {
 			init();
 			addMetric(key.c_str(), value, value);
 			return detailImpl(std::string(key), std::move(value), false);
@@ -250,8 +247,7 @@ struct TraceEvent {
 		return *this;
 	}
 	TraceEvent& detail(const char* key, std::string value) {
-		if (enabled) {
-			init();
+		if (enabled && init()) {
 			addMetric(key, value, value);
 			return detailImpl(std::string(key), std::move(value), false);
 		}

--- a/flow/Trace.h
+++ b/flow/Trace.h
@@ -347,7 +347,7 @@ struct TraceEvent {
 		if (enabled && init()) {
 			auto s = Traceable<T>::toString(value);
 			addMetric(key.c_str(), value, s);
-			return detailImpl(std::move(key), std::move(s));
+			return detailImpl(std::move(key), std::move(s), false);
 		}
 		return *this;
 	}

--- a/flow/network.h
+++ b/flow/network.h
@@ -80,6 +80,8 @@ enum {
 
 class Void;
 
+template<class T> class Optional;
+
 struct IPAddress {
 	// Represents both IPv4 and IPv6 address. For IPv4 addresses,
 	// only the first 32bits are relevant and rest are initialized to
@@ -144,6 +146,13 @@ private:
 	} addr;
 };
 
+template<>
+struct Traceable<IPAddress> : std::true_type {
+	static std::string toString(const IPAddress& value) {
+		return value.toString();
+	}
+};
+
 struct NetworkAddress {
 	// A NetworkAddress identifies a particular running server (i.e. a TCP endpoint).
 	IPAddress ip;
@@ -189,6 +198,13 @@ struct NetworkAddress {
 		} else {
 			serializer(ar, ip, port, flags);
 		}
+	}
+};
+
+template<>
+struct Traceable<NetworkAddress> : std::true_type {
+	static std::string toString(const NetworkAddress& value) {
+		return value.toString();
 	}
 };
 


### PR DESCRIPTION
This is the first part of making `TraceEvent` cheaper. The main idea is
to defer calls to any code that formats string. These are the main
changes:

- TraceEvent::detail now takes a c-string instead of std::string for
  literals. This prevents unnecessary allocations if the trace is not
  going to be printed in the first place (for example for SevDebug).
  Before that `detail` expected a `std::string` as key, which mean that
  any string literal would be copied on each call.
- Templates Traceable and SpecialTraceMetricType. These templates can be
  specialized for any type that needs to be printed. The actual
  formatting will be deferred to after the `enabled` check. This
  provides two benefits: (1) if a TraceEvent is disabled, we don't pay
  for the formatting and (2) TraceEvent can trace types that it doesn't
  know about.
- TraceEvent::enabled will be set in the constructor if the Severity is
  passed. This will make sure that `TraceEvent::init` is not called.
- `TraceEvent::detail` will be inlined. So for disabled TraceEvent
  calls, a call to detail will only introduce a if-branch which is much
  cheaper than a function call.

The main thing missing now is `printable`: there are many calls to `TraceEvent::detail`
where printable is called. This is very expensive and these calls should be deffered for
later through the templates mentioned above.