### PR TITLE
Cleaned up a variety of things about interfaces (collections of RequestStreams)

### DIFF
--- a/fdbclient/ClientWorkerInterface.h
+++ b/fdbclient/ClientWorkerInterface.h
@@ -38,9 +38,17 @@ struct ClientWorkerInterface {
 	UID id() const { return reboot.getEndpoint().token; }
 	NetworkAddress address() const { return reboot.getEndpoint().getPrimaryAddress(); }
 
+	void initEndpoints() {
+		Endpoint base = reboot.initEndpoint();
+		profiler.initEndpoint(&base);
+		TraceEvent("DumpToken", id()).detail("Name", "ClientWorkerInterface").detail("Token", base.token);
+	}
+
 	template <class Ar>
 	void serialize( Ar& ar ) {
-		serializer(ar, reboot, profiler);
+		serializer(ar, reboot);
+		auto holder = FlowTransport::transport().setBaseEndpoint(reboot.getEndpoint());
+		serializer(ar, profiler);
 	}
 };
 

--- a/fdbrpc/FlowTests.actor.cpp
+++ b/fdbrpc/FlowTests.actor.cpp
@@ -291,6 +291,7 @@ TEST_CASE("/flow/flow/nonserializable futures")
 
 	{
 		RequestStream<int> rsInt;
+		rsInt.initEndpoint();
 		FutureStream<int> f = rsInt.getFuture();
 		rsInt.send(1);
 		rsInt.send(2);
@@ -306,6 +307,7 @@ TEST_CASE("/flow/flow/networked futures")
 	// RequestStream can be serialized
 	{
 		RequestStream<int> locInt;
+		locInt.initEndpoint();
 		BinaryWriter wr(IncludeVersion());
 		wr << locInt;
 
@@ -313,6 +315,7 @@ TEST_CASE("/flow/flow/networked futures")
 
 		BinaryReader rd(wr.toStringRef(), IncludeVersion());
 		RequestStream<int> remoteInt;
+		remoteInt.initEndpoint();
 		rd >> remoteInt;
 
 		ASSERT(remoteInt.getEndpoint() == locInt.getEndpoint());

--- a/fdbserver/ClusterRecruitmentInterface.h
+++ b/fdbserver/ClusterRecruitmentInterface.h
@@ -50,19 +50,22 @@ struct ClusterControllerFullInterface {
 
 	void initEndpoints() {
 		clientInterface.initEndpoints();
-		recruitFromConfiguration.getEndpoint( TaskClusterController );
-		recruitRemoteFromConfiguration.getEndpoint( TaskClusterController );
-		recruitStorage.getEndpoint( TaskClusterController );
-		registerWorker.getEndpoint( TaskClusterController );
-		getWorkers.getEndpoint( TaskClusterController );
-		registerMaster.getEndpoint( TaskClusterController );
-		getServerDBInfo.getEndpoint( TaskClusterController );
+		Endpoint base = recruitFromConfiguration.initEndpoint(nullptr, TaskClusterController);
+		recruitRemoteFromConfiguration.initEndpoint(&base, TaskClusterController);
+		recruitStorage.initEndpoint(&base, TaskClusterController);
+		registerWorker.initEndpoint(&base, TaskClusterController);
+		getWorkers.initEndpoint(&base, TaskClusterController);
+		registerMaster.initEndpoint(&base, TaskClusterController);
+		getServerDBInfo.initEndpoint(&base, TaskClusterController);
+		TraceEvent("DumpToken", id()).detail("Name", "ClusterControllerFullInterface").detail("Token", base.token.toString());
 	}
 
 	template <class Ar>
 	void serialize( Ar& ar ) {
 		ASSERT( ar.protocolVersion() >= 0x0FDB00A200040001LL );
-		serializer(ar, clientInterface, recruitFromConfiguration, recruitRemoteFromConfiguration, recruitStorage, registerWorker, getWorkers, registerMaster, getServerDBInfo);
+		serializer(ar, clientInterface, recruitFromConfiguration);
+		auto holder = FlowTransport::transport().setBaseEndpoint(recruitFromConfiguration.getEndpoint());
+		serializer(ar, recruitRemoteFromConfiguration, recruitStorage, registerWorker, getWorkers, registerMaster, getServerDBInfo);
 	}
 };
 

--- a/fdbserver/Coordination.actor.cpp
+++ b/fdbserver/Coordination.actor.cpp
@@ -165,6 +165,8 @@ TEST_CASE("/fdbserver/Coordination/localGenerationReg/simple") {
 	state GenerationRegInterface reg;
 	state OnDemandStore store("simfdb/unittests/", //< FIXME
 		g_random->randomUniqueID());
+	reg.read.initEndpoint();
+	reg.write.initEndpoint();
 	state Future<Void> actor = localGenerationReg(reg, &store);
 	state Key the_key(g_random->randomAlphaNumeric( g_random->randomInt(0, 10)));
 

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -3729,6 +3729,7 @@ DDTeamCollection* testTeamCollection(int teamSize, IRepPolicyRef policy, int pro
 		UID uid(id, 0);
 		StorageServerInterface interface;
 		interface.uniqueID = uid;
+		interface.initEndpoints();
 	 	interface.locality.set(LiteralStringRef("machineid"), Standalone<StringRef>(std::to_string(id)));
 		interface.locality.set(LiteralStringRef("zoneid"), Standalone<StringRef>(std::to_string(id % 5)));
 		interface.locality.set(LiteralStringRef("data_hall"), Standalone<StringRef>(std::to_string(id % 3)));
@@ -3759,6 +3760,7 @@ DDTeamCollection* testMachineTeamCollection(int teamSize, IRepPolicyRef policy, 
 		UID uid(id, 0);
 		StorageServerInterface interface;
 		interface.uniqueID = uid;
+		interface.initEndpoints();
 		int process_id = id;
 		int dc_id = process_id / 1000;
 		int data_hall_id = process_id / 100;

--- a/fdbserver/DataDistributorInterface.h
+++ b/fdbserver/DataDistributorInterface.h
@@ -25,13 +25,16 @@
 #include "fdbrpc/Locality.h"
 
 struct DataDistributorInterface {
-	RequestStream<ReplyPromise<Void>> waitFailure;
 	struct LocalityData locality;
+	RequestStream<ReplyPromise<Void>> waitFailure;
 
 	DataDistributorInterface() {}
 	explicit DataDistributorInterface(const struct LocalityData& l) : locality(l) {}
 
-	void initEndpoints() {}
+	void initEndpoints() {
+		Endpoint base = waitFailure.initEndpoint();
+		TraceEvent("DumpToken", id()).detail("Name", "DataDistributorInterface").detail("Token", base.token);
+	}
 	UID id() const { return waitFailure.getEndpoint().token; }
 	NetworkAddress address() const { return waitFailure.getEndpoint().getPrimaryAddress(); }
 	bool operator== (const DataDistributorInterface& r) const {
@@ -43,7 +46,7 @@ struct DataDistributorInterface {
 
 	template <class Archive>
 	void serialize(Archive& ar) {
-		serializer(ar, waitFailure, locality);
+		serializer(ar, locality, waitFailure);
 	}
 };
 

--- a/fdbserver/OldTLogServer_4_6.actor.cpp
+++ b/fdbserver/OldTLogServer_4_6.actor.cpp
@@ -1083,15 +1083,15 @@ namespace oldTLog_4_6 {
 			}
 
 			if( registerWithMaster.isReady() ) {
-				if ( self->dbInfo->get().master.id() != lastMasterID) {
+				if ( self->dbInfo->get().master.present() && self->dbInfo->get().master.get().id() != lastMasterID) {
 					// The TLogRejoinRequest is needed to establish communications with a new master, which doesn't have our TLogInterface
 					TLogRejoinRequest req;
 					req.myInterface = tli;
-					TraceEvent("TLogRejoining", self->dbgid).detail("Master", self->dbInfo->get().master.id());
+					TraceEvent("TLogRejoining", self->dbgid).detail("Master", self->dbInfo->get().master.get().id());
 					choose {
-						when ( bool success = wait( brokenPromiseToNever( self->dbInfo->get().master.tlogRejoin.getReply( req ) ) ) ) {
+						when ( bool success = wait( brokenPromiseToNever( self->dbInfo->get().master.get().tlogRejoin.getReply( req ) ) ) ) {
 							if (success)
-								lastMasterID = self->dbInfo->get().master.id();
+								lastMasterID = self->dbInfo->get().master.get().id();
 						}
 						when ( wait( self->dbInfo->onChange() ) ) { }
 					}
@@ -1275,13 +1275,6 @@ namespace oldTLog_4_6 {
 
 			TLogInterface recruited(id1, self->dbgid, locality);
 			recruited.initEndpoints();
-
-			DUMPTOKEN( recruited.peekMessages );
-			DUMPTOKEN( recruited.popMessages );
-			DUMPTOKEN( recruited.commit );
-			DUMPTOKEN( recruited.lock );
-			DUMPTOKEN( recruited.getQueuingMetrics );
-			DUMPTOKEN( recruited.confirmRunning );
 
 			logData = Reference<LogData>( new LogData(self, recruited) );
 			logData->stopped = true;

--- a/fdbserver/OldTLogServer_6_0.actor.cpp
+++ b/fdbserver/OldTLogServer_6_0.actor.cpp
@@ -1335,14 +1335,14 @@ ACTOR Future<Void> rejoinMasters( TLogData* self, TLogInterface tli, DBRecoveryC
 		}
 
 		if( registerWithMaster.isReady() ) {
-			if ( self->dbInfo->get().master.id() != lastMasterID) {
+			if ( self->dbInfo->get().master.present() && self->dbInfo->get().master.get().id() != lastMasterID) {
 				// The TLogRejoinRequest is needed to establish communications with a new master, which doesn't have our TLogInterface
 				TLogRejoinRequest req(tli);
-				TraceEvent("TLogRejoining", self->dbgid).detail("Master", self->dbInfo->get().master.id());
+				TraceEvent("TLogRejoining", self->dbgid).detail("Master", self->dbInfo->get().master.get().id());
 				choose {
-					when ( bool success = wait( brokenPromiseToNever( self->dbInfo->get().master.tlogRejoin.getReply( req ) ) ) ) {
+					when ( bool success = wait( brokenPromiseToNever( self->dbInfo->get().master.get().tlogRejoin.getReply( req ) ) ) ) {
 						if (success)
-							lastMasterID = self->dbInfo->get().master.id();
+							lastMasterID = self->dbInfo->get().master.get().id();
 					}
 					when ( wait( self->dbInfo->onChange() ) ) { }
 				}
@@ -1769,13 +1769,6 @@ ACTOR Future<Void> restorePersistentState( TLogData* self, LocalityData locality
 		TLogInterface recruited(id1, self->dbgid, locality);
 		recruited.initEndpoints();
 
-		DUMPTOKEN( recruited.peekMessages );
-		DUMPTOKEN( recruited.popMessages );
-		DUMPTOKEN( recruited.commit );
-		DUMPTOKEN( recruited.lock );
-		DUMPTOKEN( recruited.getQueuingMetrics );
-		DUMPTOKEN( recruited.confirmRunning );
-
 		//We do not need the remoteTag, because we will not be loading any additional data
 		logData = Reference<LogData>( new LogData(self, recruited, Tag(), true, id_logRouterTags[id1], UID(), std::vector<Tag>()) );
 		logData->locality = id_locality[id1];
@@ -1935,13 +1928,6 @@ ACTOR Future<Void> updateLogSystem(TLogData* self, Reference<LogData> logData, L
 ACTOR Future<Void> tLogStart( TLogData* self, InitializeTLogRequest req, LocalityData locality ) {
 	state TLogInterface recruited(self->dbgid, locality);
 	recruited.initEndpoints();
-
-	DUMPTOKEN( recruited.peekMessages );
-	DUMPTOKEN( recruited.popMessages );
-	DUMPTOKEN( recruited.commit );
-	DUMPTOKEN( recruited.lock );
-	DUMPTOKEN( recruited.getQueuingMetrics );
-	DUMPTOKEN( recruited.confirmRunning );
 
 	for(auto it : self->id_data) {
 		if( !it.second->stopped ) {

--- a/fdbserver/RestoreInterface.h
+++ b/fdbserver/RestoreInterface.h
@@ -36,7 +36,8 @@ struct RestoreInterface {
 	NetworkAddress address() const { return test.getEndpoint().getPrimaryAddress(); }
 
 	void initEndpoints() {
-		test.getEndpoint( TaskClusterController );
+		Endpoint base = test.initEndpoint(nullptr, TaskClusterController);
+		TraceEvent("DumpToken", id()).detail("Name", "RestoreInterface").detail("Token", base.token);
 	}
 
 	template <class Ar>

--- a/fdbserver/ServerDBInfo.h
+++ b/fdbserver/ServerDBInfo.h
@@ -39,7 +39,7 @@ struct ServerDBInfo {
 	ClusterControllerFullInterface clusterInterface;
 	ClientDBInfo client;           // After a successful recovery, eventually proxies that communicate with it
 	Optional<DataDistributorInterface> distributor;  // The best guess of current data distributor.
-	MasterInterface master;        // The best guess as to the most recent master, which might still be recovering
+	Optional<MasterInterface> master;        // The best guess as to the most recent master, which might still be recovering
 	Optional<RatekeeperInterface> ratekeeper;
 	vector<ResolverInterface> resolvers;
 	DBRecoveryCount recoveryCount; // A recovery count from DBCoreState.  A successful master recovery increments it twice; unsuccessful recoveries may increment it once. Depending on where the current master is in its recovery process, this might not have been written by the current master.

--- a/fdbserver/TesterInterface.actor.h
+++ b/fdbserver/TesterInterface.actor.h
@@ -39,11 +39,22 @@ struct WorkloadInterface {
 	RequestStream<ReplyPromise< std::vector<PerfMetric> > > metrics;
 	RequestStream<ReplyPromise<Void>> stop;
 
+	void initEndpoints() {
+		Endpoint base = setup.initEndpoint();
+		start.initEndpoint(&base);
+		check.initEndpoint(&base);
+		metrics.initEndpoint(&base);
+		stop.initEndpoint(&base);
+		TraceEvent("DumpToken", id()).detail("Name", "WorkloadInterface").detail("Token", base.token);
+	}
+
 	UID id() const { return setup.getEndpoint().token; }
 
 	template <class Ar>
 	void serialize( Ar& ar ) {
-		serializer(ar, setup, start, check, metrics, stop);
+		serializer(ar, setup);
+		auto holder = FlowTransport::transport().setBaseEndpoint(setup.getEndpoint());
+		serializer(ar, start, check, metrics, stop);
 	}
 };
 
@@ -80,6 +91,11 @@ struct WorkloadRequest {
 
 struct TesterInterface {
 	RequestStream<WorkloadRequest> recruitments;
+
+	void initEndpoints() {
+		Endpoint base = recruitments.initEndpoint();
+		TraceEvent("DumpToken", id()).detail("Name", "TesterInterface").detail("Token", base.token);
+	}
 
 	UID id() const { return recruitments.getEndpoint().token; }
 

--- a/fdbserver/tester.actor.cpp
+++ b/fdbserver/tester.actor.cpp
@@ -496,6 +496,7 @@ ACTOR Future<Void> testerServerWorkload( WorkloadRequest work, Reference<Cluster
 	state bool replied = false;
 	state Database cx;
 	try {
+		workIface.initEndpoints();
 		std::map<std::string, std::string> details;
 		details["WorkloadTitle"] = printable(work.title);
 		details["ClientId"] = format("%d", work.clientId);

--- a/fdbserver/workloads/ConsistencyCheck.actor.cpp
+++ b/fdbserver/workloads/ConsistencyCheck.actor.cpp
@@ -1310,17 +1310,21 @@ struct ConsistencyCheckWorkload : TestWorkload
 			dcToNonExcludedClassTypes[dc].push_back(worker.processClass.classType());
 		}
 
+		if(!db.master.present()) {
+			TraceEvent("ConsistencyCheck_MasterNotDBInfo");
+			return false;
+		}
 		if (!allWorkerProcessMap.count(db.clusterInterface.clientInterface.address())) {
 			TraceEvent("ConsistencyCheck_CCNotInWorkerList").detail("CCAddress", db.clusterInterface.clientInterface.address().toString());
 			return false;
 		}
-		if (!allWorkerProcessMap.count(db.master.address())) {
-			TraceEvent("ConsistencyCheck_MasterNotInWorkerList").detail("MasterAddress", db.master.address().toString());
+		if (!allWorkerProcessMap.count(db.master.get().address())) {
+			TraceEvent("ConsistencyCheck_MasterNotInWorkerList").detail("MasterAddress", db.master.get().address().toString());
 			return false;
 		}
 
 		Optional<Key> ccDcId = allWorkerProcessMap[db.clusterInterface.clientInterface.address()].interf.locality._data[LocalityData::keyDcId];
-		Optional<Key> masterDcId = allWorkerProcessMap[db.master.address()].interf.locality._data[LocalityData::keyDcId];
+		Optional<Key> masterDcId = allWorkerProcessMap[db.master.get().address()].interf.locality._data[LocalityData::keyDcId];
 
 		if (ccDcId != masterDcId) {
 			TraceEvent("ConsistencyCheck_CCAndMasterNotInSameDC").detail("ClusterControllerDcId", getOptionalString(ccDcId)).detail("MasterDcId", getOptionalString(masterDcId));
@@ -1364,8 +1368,8 @@ struct ConsistencyCheckWorkload : TestWorkload
 			}
 		}
 
-		if ((!nonExcludedWorkerProcessMap.count(db.master.address()) && bestMasterFitness != ProcessClass::ExcludeFit) || nonExcludedWorkerProcessMap[db.master.address()].processClass.machineClassFitness(ProcessClass::Master) != bestMasterFitness) {
-			TraceEvent("ConsistencyCheck_MasterNotBest").detail("BestMasterFitness", bestMasterFitness).detail("ExistingMasterFit", nonExcludedWorkerProcessMap.count(db.master.address()) ? nonExcludedWorkerProcessMap[db.master.address()].processClass.machineClassFitness(ProcessClass::Master) : -1);
+		if ((!nonExcludedWorkerProcessMap.count(db.master.get().address()) && bestMasterFitness != ProcessClass::ExcludeFit) || nonExcludedWorkerProcessMap[db.master.get().address()].processClass.machineClassFitness(ProcessClass::Master) != bestMasterFitness) {
+			TraceEvent("ConsistencyCheck_MasterNotBest").detail("BestMasterFitness", bestMasterFitness).detail("ExistingMasterFit", nonExcludedWorkerProcessMap.count(db.master.get().address()) ? nonExcludedWorkerProcessMap[db.master.get().address()].processClass.machineClassFitness(ProcessClass::Master) : -1);
 			return false;
 		}
 

--- a/fdbserver/workloads/Ping.actor.cpp
+++ b/fdbserver/workloads/Ping.actor.cpp
@@ -32,6 +32,11 @@ struct PingWorkloadInterface {
 
 	UID id() const { return payloadPing.getEndpoint().token; }
 
+	void initEndpoints() {
+		Endpoint base = payloadPing.initEndpoint();
+		TraceEvent("DumpToken", id()).detail("Name", "PingWorkloadInterface").detail("Token", base.token);
+	}
+
 	template <class Ar>
 	void serialize( Ar& ar ) {
 		serializer(ar, payloadPing);
@@ -68,6 +73,7 @@ struct PingWorkload : TestWorkload {
 		payloadSize = getOption( options, LiteralStringRef("payloadSizeBack"), 1024 );
 		payloadBack = std::string( payloadSize, '.' );
 		actorCount = getOption( options, LiteralStringRef("actorCount"), 1 );
+		interf.initEndpoints();
 	}
 
 	virtual std::string description() { return "PingWorkload"; }

--- a/fdbserver/workloads/RandomMoveKeys.actor.cpp
+++ b/fdbserver/workloads/RandomMoveKeys.actor.cpp
@@ -137,7 +137,7 @@ struct MoveKeysWorkload : TestWorkload {
 			TraceEvent(relocateShardInterval.end()).detail("Result","Success");
 			return Void();
 		} catch (Error& e) {
-			TraceEvent(relocateShardInterval.end(), self->dbInfo->get().master.id()).error(e, true);
+			TraceEvent(relocateShardInterval.end()).error(e, true);
 			throw;
 		}
 	}
@@ -159,7 +159,7 @@ struct MoveKeysWorkload : TestWorkload {
 	ACTOR Future<Void> forceMasterFailure( Database cx, MoveKeysWorkload *self ) {
 		ASSERT( g_network->isSimulated() );
 		loop {
-			if( g_simulator.killZone( self->dbInfo->get().master.locality.zoneId(), ISimulator::Reboot, true ) )
+			if( self->dbInfo->get().master.present() && g_simulator.killZone( self->dbInfo->get().master.get().locality.zoneId(), ISimulator::Reboot, true ) )
 				return Void();
 			wait( delay(1.0) );
 		}

--- a/fdbserver/workloads/Sideband.actor.cpp
+++ b/fdbserver/workloads/Sideband.actor.cpp
@@ -41,6 +41,11 @@ struct SidebandInterface {
 
 	UID id() const { return updates.getEndpoint().token; }
 
+	void initEndpoints() {
+		Endpoint base = updates.initEndpoint();
+		TraceEvent("DumpToken", id()).detail("Name", "SidebandInterface").detail("Token", base.token);
+	}
+
 	template <class Ar>
 	void serialize( Ar& ar ) {
 		serializer(ar, updates);
@@ -61,6 +66,7 @@ struct SidebandWorkload : TestWorkload {
 	{
 		testDuration = getOption( options, LiteralStringRef("testDuration"), 10.0 );
 		operationsPerSecond = getOption( options, LiteralStringRef("operationsPerSecond"), 50.0 );
+		interf.initEndpoints();
 	}
 
 	virtual std::string description() { return "SidebandWorkload"; }

--- a/fdbserver/workloads/TargetedKill.actor.cpp
+++ b/fdbserver/workloads/TargetedKill.actor.cpp
@@ -86,7 +86,7 @@ struct TargetedKillWorkload : TestWorkload {
 
 		NetworkAddress machine;
 		if( self->machineToKill == "master" ) {
-			machine = self->dbInfo->get().master.address();
+			machine = self->dbInfo->get().master.get().address();
 		}
 		else if( self->machineToKill == "masterproxy" ) {
 			auto proxies = cx->getMasterProxies();

--- a/flow/flow.h
+++ b/flow/flow.h
@@ -872,12 +872,6 @@ public:
 	Future<X> getReply() const {
 		return getReply(Promise<X>());
 	}
-	template <class X>
-	Future<X> getReplyWithTaskID(int taskID) const {
-		Promise<X> reply;
-		reply.getEndpoint(taskID);
-		return getReply(reply);
-	}
 
 	FutureStream<T> getFuture() const { queue->addFutureRef(); return FutureStream<T>(queue); }
 	PromiseStream() : queue(new NotifiedQueue<T>(0, 1)) {}


### PR DESCRIPTION
Now you must call initEndpoint on a request stream before data can be sent to it.
Fixed a number of instances where data was sent to default constructed interfaces.
Reduced the serialized size of interfaces by reusing the NetworkAddress and 3/4 of the UID from the first Endpoint when serializing subsequent RequestStreams.
Moved DumpToken trace events into initEndpoints.