### PR TITLE
Fixing the Tutorials Link

### DIFF
--- a/bindings/go/README.md
+++ b/bindings/go/README.md
@@ -30,7 +30,7 @@ Documentation
 -------------
 
 * [API documentation](https://godoc.org/github.com/apple/foundationdb/bindings/go/src/fdb)
-* [Tutorial](https://apple.github.io/foundationdb/class-scheduling.html)
+* [Tutorial](https://apple.github.io/foundationdb/class-scheduling-go.html)
 
 Modules
 -------


### PR DESCRIPTION
Fixing the Tutorials link to point to GO version of the tutorials