### PR TITLE
configure memory now selects the ssd engine for transaction log spilling

### DIFF
--- a/fdbcli/fdbcli.actor.cpp
+++ b/fdbcli/fdbcli.actor.cpp
@@ -915,7 +915,7 @@ void printStatus(StatusObjectReader statusObj, StatusClient::StatusLevel level, 
 
 				outputString += "\n  Storage engine         - ";
 				if (statusObjConfig.get("storage_engine", strVal)){
-					if(strVal == "old_memory") {
+					if(strVal == "memory-1") {
 						isOldMemory = true;
 					}
 					outputString += strVal;
@@ -2214,7 +2214,7 @@ void onoff_generator(const char* text, const char *line, std::vector<std::string
 }
 
 void configure_generator(const char* text, const char *line, std::vector<std::string>& lc) {
-	const char* opts[] = {"new", "single", "double", "triple", "three_data_hall", "three_datacenter", "ssd", "ssd-1", "ssd-2", "memory", "proxies=", "logs=", "resolvers=", NULL};
+	const char* opts[] = {"new", "single", "double", "triple", "three_data_hall", "three_datacenter", "ssd", "ssd-1", "ssd-2", "memory", "memory-1", "memory-2", "proxies=", "logs=", "resolvers=", NULL};
 	array_generator(text, line, opts, lc);
 }
 

--- a/fdbcli/fdbcli.actor.cpp
+++ b/fdbcli/fdbcli.actor.cpp
@@ -900,6 +900,7 @@ void printStatus(StatusObjectReader statusObj, StatusClient::StatusLevel level, 
 			// If there is a configuration message then there is no configuration information to display
 			outputString += "\nConfiguration:";
 			std::string outputStringCache = outputString;
+			bool isOldMemory = false;
 			try {
 				// Configuration section
 				// FIXME: Should we suppress this if there are cluster messages implying that the database has no configuration?
@@ -914,6 +915,9 @@ void printStatus(StatusObjectReader statusObj, StatusClient::StatusLevel level, 
 
 				outputString += "\n  Storage engine         - ";
 				if (statusObjConfig.get("storage_engine", strVal)){
+					if(strVal == "old_memory") {
+						isOldMemory = true;
+					}
 					outputString += strVal;
 				} else
 					outputString += "unknown";
@@ -1173,6 +1177,7 @@ void printStatus(StatusObjectReader statusObj, StatusClient::StatusLevel level, 
 			// Workload section
 			outputString += "\n\nWorkload:";
 			outputStringCache = outputString;
+			bool foundLogAndStorage = false;
 			try {
 				// Determine which rates are unknown
 				StatusObjectReader statusObjWorkload;
@@ -1225,6 +1230,22 @@ void printStatus(StatusObjectReader statusObj, StatusClient::StatusLevel level, 
 				std::vector<std::string> messagesAddrs;
 				for (auto proc : processesMap.obj()){
 					StatusObjectReader process(proc.second);
+					if(process.has("roles")) {
+						StatusArray rolesArray = proc.second.get_obj()["roles"].get_array();
+						bool storageRole = false;
+						bool logRole = false;
+						for (StatusObjectReader role : rolesArray) {
+							if (role["role"].get_str() == "storage") {
+								storageRole = true;
+							}
+							else if (role["role"].get_str() == "log") {
+								logRole = true;
+							}
+						}
+						if(storageRole && logRole) {
+							foundLogAndStorage = true;
+						}
+					}
 					if (process.has("messages")) {
 						StatusArray processMessagesArr = process.last().get_array();
 						if (processMessagesArr.size()){
@@ -1408,6 +1429,14 @@ void printStatus(StatusObjectReader statusObj, StatusClient::StatusLevel level, 
 			if (clientTime != ""){
 				outputString += "\n\nClient time: " + clientTime;
 			}
+
+			if(processesMap.obj().size() > 1 && isOldMemory) {
+				outputString += "\n\nWARNING: type `configure memory' to switch to a safer method of persisting data on the transaction logs.";
+			}
+			if(processesMap.obj().size() > 9 && foundLogAndStorage) {
+				outputString += "\n\nWARNING: A single process is both a transaction log and a storage server.\n  For best performance use dedicated disks for the transaction logs by setting process classes.";
+			}
+
 			printf("%s\n", outputString.c_str());
 		}
 

--- a/fdbclient/DatabaseConfiguration.cpp
+++ b/fdbclient/DatabaseConfiguration.cpp
@@ -262,6 +262,8 @@ StatusObject DatabaseConfiguration::toJSON(bool noPolicies) const {
 		} else if( tLogDataStoreType == KeyValueStoreType::SSD_BTREE_V2 && storageServerStoreType == KeyValueStoreType::SSD_REDWOOD_V1 ) {
 			result["storage_engine"] = "ssd-redwood-experimental";
 		} else if( tLogDataStoreType == KeyValueStoreType::MEMORY && storageServerStoreType == KeyValueStoreType::MEMORY ) {
+			result["storage_engine"] = "old_memory";
+		} else if( tLogDataStoreType == KeyValueStoreType::SSD_BTREE_V2 && storageServerStoreType == KeyValueStoreType::MEMORY ) {
 			result["storage_engine"] = "memory";
 		} else {
 			result["storage_engine"] = "custom";

--- a/fdbclient/DatabaseConfiguration.cpp
+++ b/fdbclient/DatabaseConfiguration.cpp
@@ -262,9 +262,9 @@ StatusObject DatabaseConfiguration::toJSON(bool noPolicies) const {
 		} else if( tLogDataStoreType == KeyValueStoreType::SSD_BTREE_V2 && storageServerStoreType == KeyValueStoreType::SSD_REDWOOD_V1 ) {
 			result["storage_engine"] = "ssd-redwood-experimental";
 		} else if( tLogDataStoreType == KeyValueStoreType::MEMORY && storageServerStoreType == KeyValueStoreType::MEMORY ) {
-			result["storage_engine"] = "old_memory";
+			result["storage_engine"] = "memory-1";
 		} else if( tLogDataStoreType == KeyValueStoreType::SSD_BTREE_V2 && storageServerStoreType == KeyValueStoreType::MEMORY ) {
-			result["storage_engine"] = "memory";
+			result["storage_engine"] = "memory-2";
 		} else {
 			result["storage_engine"] = "custom";
 		}

--- a/fdbclient/ManagementAPI.actor.cpp
+++ b/fdbclient/ManagementAPI.actor.cpp
@@ -81,20 +81,28 @@ std::map<std::string, std::string> configForToken( std::string const& mode ) {
 		return out;
 	}
 
+	Optional<KeyValueStoreType> logType;
 	Optional<KeyValueStoreType> storeType;
 	if (mode == "ssd-1") {
-		storeType= KeyValueStoreType::SSD_BTREE_V1;
+		logType = KeyValueStoreType::SSD_BTREE_V1;
+		storeType = KeyValueStoreType::SSD_BTREE_V1;
 	} else if (mode == "ssd" || mode == "ssd-2") {
+		logType = KeyValueStoreType::SSD_BTREE_V2;
 		storeType = KeyValueStoreType::SSD_BTREE_V2;
 	} else if (mode == "ssd-redwood-experimental") {
+		logType = KeyValueStoreType::SSD_BTREE_V2;
 		storeType = KeyValueStoreType::SSD_REDWOOD_V1;
-	} else if (mode == "memory") {
+	} else if (mode == "memory" || mode == "memory-2") {
+		logType = KeyValueStoreType::SSD_BTREE_V2;
+		storeType= KeyValueStoreType::MEMORY;
+	} else if (mode == "memory-1") {
+		logType = KeyValueStoreType::MEMORY;
 		storeType= KeyValueStoreType::MEMORY;
 	}
 	// Add any new store types to fdbserver/workloads/ConfigureDatabase, too
 
 	if (storeType.present()) {
-		out[p+"log_engine"] = format("%d", KeyValueStoreType::SSD_BTREE_V2);
+		out[p+"log_engine"] = format("%d", logType.get());
 		out[p+"storage_engine"] = format("%d", storeType.get());
 		return out;
 	}

--- a/fdbclient/ManagementAPI.actor.cpp
+++ b/fdbclient/ManagementAPI.actor.cpp
@@ -94,7 +94,8 @@ std::map<std::string, std::string> configForToken( std::string const& mode ) {
 	// Add any new store types to fdbserver/workloads/ConfigureDatabase, too
 
 	if (storeType.present()) {
-		out[p+"log_engine"] = out[p+"storage_engine"] = format("%d", storeType.get());
+		out[p+"log_engine"] = format("%d", KeyValueStoreType::SSD_BTREE_V2);
+		out[p+"storage_engine"] = format("%d", storeType.get());
 		return out;
 	}
 

--- a/fdbclient/Schemas.cpp
+++ b/fdbclient/Schemas.cpp
@@ -501,7 +501,8 @@ const KeyRef JSONSchemas::statusSchema = LiteralStringRef(R"statusSchema(
              "ssd-1",
              "ssd-2",
              "ssd-redwood-experimental",
-             "memory"
+             "memory",
+             "old_memory"
          ]},
          "coordinators_count":1,
          "excluded_servers":[

--- a/fdbclient/Schemas.cpp
+++ b/fdbclient/Schemas.cpp
@@ -502,7 +502,8 @@ const KeyRef JSONSchemas::statusSchema = LiteralStringRef(R"statusSchema(
              "ssd-2",
              "ssd-redwood-experimental",
              "memory",
-             "old_memory"
+             "memory-1",
+             "memory-2"
          ]},
          "coordinators_count":1,
          "excluded_servers":[

--- a/fdbserver/KeyValueStoreMemory.actor.cpp
+++ b/fdbserver/KeyValueStoreMemory.actor.cpp
@@ -139,13 +139,6 @@ public:
 
 	virtual Future<Void> commit(bool sequential) {
 		if(getAvailableSize() <= 0) {
-			if(g_network->isSimulated()) { //FIXME: known bug in simulation we are supressing
-				int unseed = noUnseed ? 0 : g_random->randomInt(0, 100001);
-				TraceEvent(SevWarnAlways, "KeyValueStoreMemory_OutOfSpace", id);
-				TraceEvent("ElapsedTime").detail("SimTime", now()).detail("RealTime", 0)
-					.detail("RandomUnseed", unseed);
-				flushAndExit(0);
-			}
 			TraceEvent(SevError, "KeyValueStoreMemory_OutOfSpace", id);
 			return Never();
 		}

--- a/fdbserver/workloads/ConfigureDatabase.actor.cpp
+++ b/fdbserver/workloads/ConfigureDatabase.actor.cpp
@@ -26,7 +26,7 @@
 #include "flow/actorcompiler.h"  // This must be the last #include.
 
 // "ssd" is an alias to the preferred type which skews the random distribution toward it but that's okay.
-static const char* storeTypes[] = { "ssd", "ssd-1", "ssd-2", "memory" };
+static const char* storeTypes[] = { "ssd", "ssd-1", "ssd-2", "memory", "memory-1", "memory-2" };
 static const char* logTypes[] = { "log_engine:=1", "log_engine:=2", "log_spill:=1", "log_spill:=2", "log_version:=2", "log_version:=3" };
 static const char* redundancies[] = { "single", "double", "triple" };
 


### PR DESCRIPTION
Transaction log spilling is only used when the transaction logs cannot keep all of the unpopped mutations it has in memory. If we are only using this data structure because we do not have enough memory, it is much less safe to use the memory storage engine for this purpose.