### PR TITLE
atomicReplace to preserve owner & permission info

### DIFF
--- a/flow/Platform.cpp
+++ b/flow/Platform.cpp
@@ -1667,6 +1667,8 @@ void atomicReplace( std::string const& path, std::string const& content, bool te
 		if(!f)
 			throw io_error();
 	#ifdef _WIN32
+		// In Windows case, ReplaceFile API is used which preserves the ownership,
+		// ACLs and other attributes of the original file
 	#elif defined(__unixish__)
 		// get the uid/gid/mode bits of old file and set it on new file, else fail
 		struct stat info;

--- a/flow/Platform.cpp
+++ b/flow/Platform.cpp
@@ -1671,17 +1671,24 @@ void atomicReplace( std::string const& path, std::string const& content, bool te
 		// get the uid/gid/mode bits of old file and set it on new file, else fail
 		struct stat info;
 		if (stat(path.c_str(), &info) < 0) {
-			TraceEvent("StatFailed").detail("path", path);
+			TraceEvent("StatFailed").detail("Path", path);
 			throw io_error();
 		}
 		if (chown(tempfilename.c_str(), info.st_uid, info.st_gid) < 0) {
+			TraceEvent("ChownFailed")
+				.detail("TempFilename", tempfilename)
+				.detail("OriginalFile", path)
+				.detail("Uid", info.st_uid)
+				.detail("Gid", info.st_gid);
 			deleteFile(tempfilename);
-			TraceEvent("ChownFailed").detail("tempfilename", tempfilename).detail("uid", info.st_uid).detail("gid", info.st_gid);
 			throw io_error();
 		}
 		if (chmod(tempfilename.c_str(), info.st_mode) < 0) {
+			TraceEvent("ChmodFailed")
+				.detail("TempFilename", tempfilename)
+				.detail("OriginalFile", path)
+				.detail("Mode", info.st_mode);
 			deleteFile(tempfilename);
-			TraceEvent("ChmodFailed").detail("tempfilename", tempfilename).detail("mode", info.st_mode);
 			throw io_error();
 		}
 	#else


### PR DESCRIPTION
atomicReplace call currently does not preserve the ownership and permission info, this fix will preserves the ownership and permission info - it fails the call if it is not able to do so.