### PR TITLE
Fixes #1186: Tuples: Malformed UTF-16 treated differently in Java and Python

### DIFF
--- a/bindings/java/src/main/com/apple/foundationdb/tuple/StringUtil.java
+++ b/bindings/java/src/main/com/apple/foundationdb/tuple/StringUtil.java
@@ -23,6 +23,8 @@ package com.apple.foundationdb.tuple;
 final class StringUtil {
 	private static final char SURROGATE_COUNT = Character.MAX_LOW_SURROGATE - Character.MIN_HIGH_SURROGATE + 1;
 	private static final char ABOVE_SURROGATES = Character.MAX_VALUE - Character.MAX_LOW_SURROGATE;
+	private static final String HIGH_WITHOUT_LOW_ERR_MSG = "malformed UTF-16 string contains high surrogate that is not followed by low surrogate";
+	private static final String LOW_WITHOUT_HIGH_ERR_MSG = "malformed UTF-16 string contains low surrogate without prior high surrogate";
 
 	static char adjustForSurrogates(char c, String s, int pos) {
 		if(c > Character.MAX_LOW_SURROGATE) {
@@ -30,12 +32,35 @@ final class StringUtil {
 		}
 		else {
 			// Validate the UTF-16 string as this can do weird things on invalid strings
-			if((Character.isHighSurrogate(c) && (pos + 1 >= s.length() || !Character.isLowSurrogate(s.charAt(pos + 1)))) ||
-					(Character.isLowSurrogate(c) && (pos == 0 || !Character.isHighSurrogate(s.charAt(pos - 1))))) {
-				throw new IllegalArgumentException("malformed UTF-16 string does not follow high surrogate with low surrogate");
+			if(Character.isHighSurrogate(c) && (pos + 1 >= s.length() || !Character.isLowSurrogate(s.charAt(pos + 1)))) {
+				throw new IllegalArgumentException(HIGH_WITHOUT_LOW_ERR_MSG);
+			}
+			else if(Character.isLowSurrogate(c) && (pos == 0 || !Character.isHighSurrogate(s.charAt(pos - 1)))) {
+				throw new IllegalArgumentException(LOW_WITHOUT_HIGH_ERR_MSG);
 			}
 			return (char)(c + ABOVE_SURROGATES);
 
+		}
+	}
+
+	// Validates that the string is well-formed UTF-16 by making sure every high surrogate is followed by a low-surrogate
+	static void validate(String s) {
+		final int strLength = s.length();
+		int i = 0;
+		while(i < strLength) {
+			char c = s.charAt(i);
+			if(Character.isHighSurrogate(c)) {
+				if(i + 1 >= strLength || !Character.isLowSurrogate(s.charAt(i + 1))) {
+					throw new IllegalArgumentException(HIGH_WITHOUT_LOW_ERR_MSG);
+				}
+				i += 2;
+			}
+			else if(Character.isLowSurrogate(c)) {
+				throw new IllegalArgumentException(LOW_WITHOUT_HIGH_ERR_MSG);
+			}
+			else {
+				i++;
+			}
 		}
 	}
 
@@ -50,13 +75,15 @@ final class StringUtil {
 	// See: https://ssl.icu-project.org/docs/papers/utf16_code_point_order.html
 	static int compareUtf8(String s1, String s2) {
 		// Ignore common prefix at the beginning which will compare equal regardless of encoding
+		final int s1Length = s1.length();
+		final int s2Length = s2.length();
 		int pos = 0;
-		while(pos < s1.length() && pos < s2.length() && s1.charAt(pos) == s2.charAt(pos)) {
+		while(pos < s1Length && pos < s2Length && s1.charAt(pos) == s2.charAt(pos)) {
 			pos++;
 		}
-		if(pos >= s1.length() || pos >= s2.length()) {
+		if(pos >= s1Length || pos >= s2Length) {
 			// One string is the prefix of another, so return based on length.
-			return Integer.compare(s1.length(), s2.length());
+			return Integer.compare(s1Length, s2Length);
 		}
 		// Compare first different character
 		char c1 = s1.charAt(pos);
@@ -98,11 +125,11 @@ final class StringUtil {
 					pos += 1;
 				}
 				else {
-					throw new IllegalArgumentException("malformed UTF-16 has high surrogate not followed by low surrogate");
+					throw new IllegalArgumentException(HIGH_WITHOUT_LOW_ERR_MSG);
 				}
 			}
 			else if(Character.isLowSurrogate(c)) {
-				throw new IllegalArgumentException("malformed UTF-16 has low surrogate without prior high surrogate");
+				throw new IllegalArgumentException(LOW_WITHOUT_HIGH_ERR_MSG);
 			}
 			else {
 				// 3 byte code point

--- a/bindings/java/src/test/com/apple/foundationdb/test/TuplePerformanceTest.java
+++ b/bindings/java/src/test/com/apple/foundationdb/test/TuplePerformanceTest.java
@@ -173,13 +173,7 @@ public class TuplePerformanceTest {
 		System.out.println("Warming up test...");
 		for(int i = 0; i < ignoreIterations; i++) {
 			int length = r.nextInt(20);
-			Tuple t = createTuple(length);
-			try {
-				t.pack();
-			}
-			catch(IllegalArgumentException e) {
-				System.out.println("ah!");
-			}
+			createTuple(length).pack();
 		}
 
 		System.gc();
@@ -302,7 +296,7 @@ public class TuplePerformanceTest {
 	}
 
 	public static void main(String[] args) {
-		TuplePerformanceTest tester = new TuplePerformanceTest(new Random(), 100_000, 10_000_000, GeneratedTypes.STRING_LIKE);
+		TuplePerformanceTest tester = new TuplePerformanceTest(new Random(), 100_000, 10_000_000, GeneratedTypes.ALL);
 		tester.run();
 	}
 }

--- a/bindings/java/src/test/com/apple/foundationdb/test/TuplePerformanceTest.java
+++ b/bindings/java/src/test/com/apple/foundationdb/test/TuplePerformanceTest.java
@@ -142,7 +142,11 @@ public class TuplePerformanceTest {
 				// Random Unicode codepoints
 				int[] codepoints = new int[r.nextInt(20)];
 				for(int x = 0; x < codepoints.length; x++) {
-					codepoints[x] = r.nextInt(0x10FFFF);
+					int codepoint = r.nextInt(0x10FFFF);
+					while(Character.isSurrogate((char)codepoint)) {
+						codepoint = r.nextInt(0x10FFFF);
+					}
+					codepoints[x] = codepoint;
 				}
 				values.add(new String(codepoints, 0, codepoints.length));
 			}
@@ -169,7 +173,13 @@ public class TuplePerformanceTest {
 		System.out.println("Warming up test...");
 		for(int i = 0; i < ignoreIterations; i++) {
 			int length = r.nextInt(20);
-			createTuple(length).pack();
+			Tuple t = createTuple(length);
+			try {
+				t.pack();
+			}
+			catch(IllegalArgumentException e) {
+				System.out.println("ah!");
+			}
 		}
 
 		System.gc();
@@ -292,7 +302,7 @@ public class TuplePerformanceTest {
 	}
 
 	public static void main(String[] args) {
-		TuplePerformanceTest tester = new TuplePerformanceTest(new Random(), 100_000, 10_000_000, GeneratedTypes.ALL);
+		TuplePerformanceTest tester = new TuplePerformanceTest(new Random(), 100_000, 10_000_000, GeneratedTypes.STRING_LIKE);
 		tester.run();
 	}
 }


### PR DESCRIPTION
Technically, they are still treated differently in Java and Python, but now, Java throws an exception if it encounters malformed UTF-16 to avoid serializing things in ways that it cannot deserialize. It also now throws an error when reading malformed UTF-8, which I think is safer as it stops it from accidentally doing something like reading bytes and then writing it back but accidentally writing to the wrong spot, but that might be a mistake.

I want to run a performance test to get some understanding of the performance impact (on well-formed strings), but this is I think what the code will look like.