### PR TITLE
Add cmake targets to execute local dev instance

### DIFF
--- a/cmake/Sandbox.conf.cmake
+++ b/cmake/Sandbox.conf.cmake
@@ -1,0 +1,38 @@
+## foundationdb.conf
+##
+## Configuration file for FoundationDB server processes
+## Full documentation is available at
+## https://apple.github.io/foundationdb/configuration.html#the-configuration-file
+
+[fdbmonitor]
+
+[general]
+restart_delay = 10
+## by default, restart_backoff = restart_delay_reset_interval = restart_delay
+# initial_restart_delay = 0
+# restart_backoff = 60
+# restart_delay_reset_interval = 60
+cluster_file = ${CMAKE_BINARY_DIR}/fdb.cluster
+# delete_envvars =
+# kill_on_configuration_change = true
+
+## Default parameters for individual fdbserver processes
+[fdbserver]
+command = ${CMAKE_BINARY_DIR}/bin/fdbserver
+public_address = auto:$ID
+listen_address = public
+datadir = ${CMAKE_BINARY_DIR}/sandbox/data/$ID
+logdir = ${CMAKE_BINARY_DIR}/sandbox/logs
+# logsize = 10MiB
+# maxlogssize = 100MiB
+# machine_id =
+# datacenter_id =
+# class =
+# memory = 8GiB
+# storage_memory = 1GiB
+# metrics_cluster =
+# metrics_prefix =
+
+## An individual fdbserver process with id 4500
+## Parameters set here override defaults from the [fdbserver] section
+[fdbserver.4500]

--- a/cmake/Sandbox.conf.cmake
+++ b/cmake/Sandbox.conf.cmake
@@ -35,4 +35,4 @@ logdir = ${CMAKE_BINARY_DIR}/sandbox/logs
 
 ## An individual fdbserver process with id 4500
 ## Parameters set here override defaults from the [fdbserver] section
-[fdbserver.4500]
+[fdbserver.4000]

--- a/fdbmonitor/CMakeLists.txt
+++ b/fdbmonitor/CMakeLists.txt
@@ -11,7 +11,7 @@ target_include_directories(fdbmonitor PRIVATE ${CMAKE_BINARY_DIR}/fdbclient)
 
 fdb_install(TARGETS fdbmonitor DESTINATION fdbmonitor COMPONENT server)
 
-# Create a local sanbox for quick manual testing without simulator
+# Create a local sandbox for quick manual testing without simulator
 file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/sandbox/data)
 file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/sandbox/logs)
 configure_file(${CMAKE_SOURCE_DIR}/cmake/Sandbox.conf.cmake

--- a/fdbmonitor/CMakeLists.txt
+++ b/fdbmonitor/CMakeLists.txt
@@ -10,3 +10,20 @@ endif()
 target_include_directories(fdbmonitor PRIVATE ${CMAKE_BINARY_DIR}/fdbclient)
 
 fdb_install(TARGETS fdbmonitor DESTINATION fdbmonitor COMPONENT server)
+
+# Create a local sanbox for quick manual testing without simulator
+file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/sandbox/data)
+file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/sandbox/logs)
+configure_file(${CMAKE_SOURCE_DIR}/cmake/Sandbox.conf.cmake
+  ${CMAKE_BINARY_DIR}/sandbox/foundationdb.conf)
+
+# this is not portable on Windows - but fdbmonitor isn't built there anyways...
+add_custom_target(clean_sandbox
+  COMMAND rm -rf ${CMAKE_BINARY_DIR}/sandbox/data/* && rm -rf ${CMAKE_BINARY_DIR}/sandbox/logs/*
+  COMMENT "Cleaning existing sandbox")
+
+add_custom_target(start_sandbox
+  COMMAND ${CMAKE_BINARY_DIR}/bin/fdbmonitor --conffile ${CMAKE_BINARY_DIR}/sandbox/foundationdb.conf
+                                             --lockfile ${CMAKE_BINARY_DIR}/sandbox/fdbmonitor.lock)
+
+add_dependencies(start_sandbox fdbmonitor fdbserver)


### PR DESCRIPTION
This PR adds two new targets through cmake: `start_sandbox` and `clean_sandbox`.

When cmake runs it will generate a `sandbox`-folder in the build directory and a configuration file for fdbmonitor. A developer can then run `make start_sandbox` to start a properly configured fdbmonitor (which will start fdbserver from the build directory and it will build it if it is outdated or has not been built before). One can also run `make clean_sandbox` to delete the data.

This is useful for quick and dirty testing of stuff that can't be tested properly in the simulator.