### PR TITLE
Fix Windows compilation error

### DIFF
--- a/fdbclient/BackupAgent.actor.h
+++ b/fdbclient/BackupAgent.actor.h
@@ -39,25 +39,11 @@
 class BackupAgentBase : NonCopyable {
 public:
 	// Time formatter for anything backup or restore related
-	static std::string formatTime(int64_t epochs) {
-		time_t curTime = (time_t)epochs;
-		char buffer[128];
-		struct tm timeinfo;
-		getLocalTime(&curTime, &timeinfo);
-		strftime(buffer, 128, "%Y/%m/%d.%H:%M:%S%z", &timeinfo);
-		return buffer;
-	}
+	static std::string formatTime(int64_t epochs);
+	static int64_t parseTime(std::string timestamp);
 
 	static std::string timeFormat() {
 		return "YYYY/MM/DD.HH:MI:SS[+/-]HHMM";
-	}
-
-	static int64_t parseTime(std::string timestamp) {
-		struct tm out;
-		if (strptime(timestamp.c_str(), "%Y/%m/%d.%H:%M:%S%z", &out) == nullptr) {
-			return -1;
-		}
-		return (int64_t) mktime(&out);
 	}
 
 	// Type of program being executed

--- a/fdbclient/BackupAgentBase.actor.cpp
+++ b/fdbclient/BackupAgentBase.actor.cpp
@@ -18,6 +18,8 @@
  * limitations under the License.
  */
 
+#include <iomanip>
+
 #include "fdbclient/BackupAgent.actor.h"
 #include "fdbrpc/simulator.h"
 #include "flow/ActorCollection.h"

--- a/fdbclient/BackupAgentBase.actor.cpp
+++ b/fdbclient/BackupAgentBase.actor.cpp
@@ -20,7 +20,7 @@
 
 #ifdef _WIN32
 	// Need struct tm member tm_gmtoff
-	#define_GNU_SOURCE
+	#define _GNU_SOURCE
 #endif
 
 #include <iomanip>

--- a/fdbclient/BackupAgentBase.actor.cpp
+++ b/fdbclient/BackupAgentBase.actor.cpp
@@ -18,6 +18,11 @@
  * limitations under the License.
  */
 
+#ifdef _WIN32
+	// Need struct tm member tm_gmtoff
+	#define_GNU_SOURCE
+#endif
+
 #include <iomanip>
 
 #include "fdbclient/BackupAgent.actor.h"

--- a/fdbclient/BackupContainer.actor.cpp
+++ b/fdbclient/BackupContainer.actor.cpp
@@ -1913,3 +1913,16 @@ TEST_CASE("/backup/containers_list") {
 	}
 	return Void();
 };
+
+TEST_CASE("/backup/time") {
+	ASSERT(BackupAgentBase::formatTime(BackupAgentBase::parseTime("2019/03/18.17:51:11-0600")) == "2019/03/18.16:51:11-0700");
+	ASSERT(BackupAgentBase::formatTime(BackupAgentBase::parseTime("2019/03/18.16:51:11-0700")) == "2019/03/18.16:51:11-0700");
+
+	ASSERT(BackupAgentBase::parseTime("2019/03/18.17:51:11-0600") == BackupAgentBase::parseTime("2019/03/18.16:51:11-0700"));
+	ASSERT(BackupAgentBase::parseTime("2019/03/31.22:45:07-0700") == BackupAgentBase::parseTime("2019/04/01.03:45:07-0200"));
+	ASSERT(BackupAgentBase::parseTime("2019/03/31.22:45:07+0000") == BackupAgentBase::parseTime("2019/04/01.03:45:07+0500"));
+	ASSERT(BackupAgentBase::parseTime("2019/03/31.22:45:07+0030") == BackupAgentBase::parseTime("2019/04/01.03:45:07+0530"));
+	ASSERT(BackupAgentBase::parseTime("2019/03/31.22:45:07+0030") == BackupAgentBase::parseTime("2019/04/01.04:00:07+0545"));
+
+	return Void();
+}


### PR DESCRIPTION
Implemented BackupAgentBase::parseTime() using std::get_time() on Windows.  Added unit test for parseTime() and formatTime().