### PR TITLE
Fix bug where accessing shared memory created by boost 1.52 leads to …

### DIFF
--- a/fdbserver/fdbserver.actor.cpp
+++ b/fdbserver/fdbserver.actor.cpp
@@ -325,7 +325,7 @@ UID getSharedMemoryMachineId() {
 	loop {
 		try {
 			// "0" is the default parameter "addr"
-			boost::interprocess::managed_shared_memory segment(boost::interprocess::open_or_create, "fdbserver", 1000, 0, p.permission);
+			boost::interprocess::managed_shared_memory segment(boost::interprocess::open_or_create, "fdbserver_boost_1_67", 1000, 0, p.permission);
 			machineId = segment.find_or_construct<UID>("machineId")(g_random->randomUniqueID());
 			if (!machineId)
 				criticalError(FDB_EXIT_ERROR, "SharedMemoryError", "Could not locate or create shared memory - 'machineId'");

--- a/fdbserver/fdbserver.actor.cpp
+++ b/fdbserver/fdbserver.actor.cpp
@@ -321,7 +321,7 @@ UID getSharedMemoryMachineId() {
 	// Permissions object defaults to 0644 on *nix, but on windows defaults to allowing access to only the creator.
 	// On windows, this means that we have to create an elaborate workaround for DACLs
 	WorldReadablePermissions p;
-	std::string sharedMemoryIdentifier = format("fdbserver_boost_%s", BOOST_LIB_VERSION);
+	std::string sharedMemoryIdentifier = "fdbserver_shared_memory_id";
 	loop {
 		try {
 			// "0" is the default parameter "addr"


### PR DESCRIPTION
…error when accessed by boost 1.67.