### PR TITLE
Fix scripted bindingtester test

### DIFF
--- a/bindings/python/tests/cancellation_timeout_tests.py
+++ b/bindings/python/tests/cancellation_timeout_tests.py
@@ -414,28 +414,7 @@ def test_timeouts(db):
 
 
 def test_combinations(db):
-    # (1) Hitting retry limit cancels transaction
-    @retry_with_timeout(default_timeout)
-    def txn1(tr):
-        tr.options.set_retry_limit(0)
-        tr.options.set_timeout(100)
-        try:
-            tr.on_error(fdb.FDBError(1007)).wait()  # should throw
-            raise TestError("Retry limit was ignored.")
-        except fdb.FDBError as e:
-            if e.code != 1007:
-                raise
-        time.sleep(1)
-        try:
-            tr.commit().wait()  # should throw
-            raise TestError("Hitting retry limit did not cancel the transaction.")
-        except fdb.FDBError as e:
-            if e.code != 1025:
-                raise
-
-    txn1(db)
-
-    # (2) Cancellation does survive on_error() even when retry limit is hit
+    # (1) Cancellation does survive on_error() even when retry limit is hit
     @retry_with_timeout(default_timeout)
     def txn2(tr):
         tr.options.set_retry_limit(0)
@@ -453,4 +432,4 @@ def test_combinations(db):
             if e.code != 1025:
                 raise
 
-    txn2(db)
+    txn1(db)

--- a/bindings/python/tests/cancellation_timeout_tests.py
+++ b/bindings/python/tests/cancellation_timeout_tests.py
@@ -238,7 +238,7 @@ def test_retry_limits(db):
                 raise
         try:
             tr[b'foo'] = b'bar'
-            tr.on_error(err).wait()  # should not throw
+            tr.on_error(err).wait()  # should throw
             raise TestError('(5) Transaction not cancelled after error.')
         except fdb.FDBError as e:
             if e.code != 1025:
@@ -427,7 +427,7 @@ def test_combinations(db):
                 raise
         time.sleep(1)
         try:
-            tr.commit().wait()  # should not throw
+            tr.commit().wait()  # should throw
             raise TestError("Hitting retry limit did not cancel the transaction.")
         except fdb.FDBError as e:
             if e.code != 1025:

--- a/bindings/python/tests/cancellation_timeout_tests.py
+++ b/bindings/python/tests/cancellation_timeout_tests.py
@@ -416,7 +416,7 @@ def test_timeouts(db):
 def test_combinations(db):
     # (1) Cancellation does survive on_error() even when retry limit is hit
     @retry_with_timeout(default_timeout)
-    def txn2(tr):
+    def txn1(tr):
         tr.options.set_retry_limit(0)
         tr.cancel()
         try:

--- a/bindings/python/tests/cancellation_timeout_tests.py
+++ b/bindings/python/tests/cancellation_timeout_tests.py
@@ -126,124 +126,125 @@ def test_retry_limits(db):
             tr.on_error(err).wait()  # should throw
             raise TestError('(1) Retry limit was ignored.')
         except fdb.FDBError as e:
-            if e.code != 1007:
+            if e.code != err.code:
                 raise
         tr[b'foo'] = b'bar'
         tr.options.set_retry_limit(1)
         try:
             tr.on_error(err).wait()  # should throw
-            raise TestError('(1) Retry limit was ignored.')
+            raise TestError('(1) Transaction not cancelled after error.')
         except fdb.FDBError as e:
-            if e.code != 1007:
+            if e.code != 1025:
                 raise
 
     txn1(db)
 
-    # (2) Number of retries accumulates even when limit is being hit
+    # (2) Retry limits don't survive resets
     @retry_with_timeout(default_timeout)
     def txn2(tr):
-        tr.options.set_retry_limit(0)
-        tr[b'foo'] = b'bar'
-        try:
-            tr.on_error(err).wait()  # should throw
-            raise TestError('(2) Retry limit was ignored.')
-        except fdb.FDBError as e:
-            if e.code != 1007:
-                raise
-        tr.options.set_retry_limit(1)
-        tr[b'foo'] = b'bar'
-        try:
-            tr.on_error(err).wait()  # should throw
-            raise TestError('(2) Retry limit was ignored.')
-        except fdb.FDBError as e:
-            if e.code != 1007:
-                raise
-
-    txn2(db)
-
-    # (3) Retry limits don't survive resets
-    @retry_with_timeout(default_timeout)
-    def txn3(tr):
         tr.options.set_retry_limit(1)
         tr[b'foo'] = b'bar'
         tr.on_error(err).wait()  # should not throw
         tr.options.set_retry_limit(1)
+        tr[b'foo'] = b'bar'
+        try:
+            tr.on_error(err).wait()  # should throw
+            raise TestError('(2) Retry limit was ignored.')
+        except fdb.FDBError as e:
+            if e.code != err.code:
+                raise
+        tr.reset()
+        tr[b'foo'] = b'bar'
+        tr.on_error(err).wait()  # should not throw
+
+    txn2(db)
+
+    # (3) Number of retries does not survive resets
+    @retry_with_timeout(default_timeout)
+    def txn3(tr):
+        tr.options.set_retry_limit(0)
         tr[b'foo'] = b'bar'
         try:
             tr.on_error(err).wait()  # should throw
             raise TestError('(3) Retry limit was ignored.')
         except fdb.FDBError as e:
-            if e.code != 1007:
+            if e.code != err.code:
                 raise
         tr.reset()
+        tr.options.set_retry_limit(1)
         tr[b'foo'] = b'bar'
         tr.on_error(err).wait()  # should not throw
 
     txn3(db)
 
-    # (4) Number of retries does not survive resets
+    # (4) Retries accumulate when limits are turned off, and are respected retroactively
     @retry_with_timeout(default_timeout)
     def txn4(tr):
-        tr.options.set_retry_limit(0)
         tr[b'foo'] = b'bar'
+        tr.on_error(err).wait()  # should not throw
+        tr[b'foo'] = b'bar'
+        tr.on_error(err).wait()  # should not throw
+        tr.options.set_retry_limit(1)
         try:
             tr.on_error(err).wait()  # should throw
             raise TestError('(4) Retry limit was ignored.')
         except fdb.FDBError as e:
-            if e.code != 1007:
+            if e.code != err.code:
                 raise
         tr.reset()
+        tr[b'foo'] = b'bar'
         tr.options.set_retry_limit(1)
-        tr[b'foo'] = b'bar'
-        tr.on_error(err).wait()  # should not throw
-
-    txn4(db)
-
-    # (5) Retries accumulate when limits are turned off, and are respected retroactively
-    @retry_with_timeout(default_timeout)
-    def txn5(tr):
-        tr[b'foo'] = b'bar'
         tr.on_error(err).wait()  # should not throw
         tr[b'foo'] = b'bar'
+        tr.options.set_retry_limit(2)
         tr.on_error(err).wait()  # should not throw
-        tr.options.set_retry_limit(1)
-        try:
-            tr.on_error(err).wait()  # should throw
-            raise TestError('(5) Retry limit was ignored.')
-        except fdb.FDBError as e:
-            if e.code != 1007:
-                raise
         tr[b'foo'] = b'bar'
-        tr.options.set_retry_limit(-1)
+        tr.options.set_retry_limit(3)
+        tr.on_error(err).wait()  # should not throw
+        tr[b'foo'] = b'bar'
+        tr.options.set_retry_limit(4)
         tr.on_error(err).wait()  # should not throw
         tr.options.set_retry_limit(4)
         try:
             tr.on_error(err).wait()  # should throw
+            raise TestError('(4) Retry limit was ignored.')
+        except fdb.FDBError as e:
+            if e.code != err.code:
+                raise
+        tr.options.set_retry_limit(4)
+        try:
+            tr.on_error(err).wait()  # should throw
+            raise TestError('(4) Transaction not cancelled after error.')
+        except fdb.FDBError as e:
+            if e.code != 1025:
+                raise
+
+    txn4(db)
+
+    # (5) Retry limits don't survive on_error()
+    @retry_with_timeout(default_timeout)
+    def txn5(tr):
+        tr.options.set_retry_limit(1)
+        tr[b'foo'] = b'bar'
+        tr.on_error(err).wait()  # should not throw
+        tr[b'foo'] = b'bar'
+        tr.on_error(err).wait()  # should not throw
+        tr.options.set_retry_limit(2)
+        try:
+            tr.on_error(err).wait()  # should throw
             raise TestError('(5) Retry limit was ignored.')
         except fdb.FDBError as e:
-            if e.code != 1007:
+            if e.code != err.code:
+                raise
+        try:
+            tr[b'foo'] = b'bar'
+            tr.on_error(err).wait()  # should not throw
+            raise TestError('(5) Transaction not cancelled after error.')
+        except fdb.FDBError as e:
+            if e.code != 1025:
                 raise
 
     txn5(db)
-
-    # (6) Retry limits don't survive on_error()
-    @retry_with_timeout(default_timeout)
-    def txn6(tr):
-        tr.options.set_retry_limit(1)
-        tr[b'foo'] = b'bar'
-        tr.on_error(err).wait()  # should not throw
-        tr[b'foo'] = b'bar'
-        tr.options.set_retry_limit(1)
-        try:
-            tr.on_error(err).wait()  # should throw
-            raise TestError('(6) Retry limit was ignored.')
-        except fdb.FDBError as e:
-            if e.code != 1007:
-                raise
-        tr[b'foo'] = b'bar'
-        tr.on_error(err).wait()  # should not throw
-
-    txn6(db)
 
 
 def test_timeouts(db):
@@ -413,7 +414,7 @@ def test_timeouts(db):
 
 
 def test_combinations(db):
-    # (1) Hitting retry limit still clears timeouts
+    # (1) Hitting retry limit cancels transaction
     @retry_with_timeout(default_timeout)
     def txn1(tr):
         tr.options.set_retry_limit(0)
@@ -425,7 +426,12 @@ def test_combinations(db):
             if e.code != 1007:
                 raise
         time.sleep(1)
-        tr.commit().wait()  # should not throw
+        try:
+            tr.commit().wait()  # should not throw
+            raise TestError("Hitting retry limit did not cancel the transaction.")
+        except fdb.FDBError as e:
+            if e.code != 1025:
+                raise
 
     txn1(db)
 


### PR DESCRIPTION
There were some unit tests for timeouts and retries that did not handle the fact that `on_error` now puts a transaction in a cancelled state if the error is not retried (either because it is not retryable or if the retry limit is hit). This fixes those tests so that the scripted bindingtester test now works.