### PR TITLE
Fix fdbcli and fdbbackup --trace_format option

### DIFF
--- a/fdbbackup/backup.actor.cpp
+++ b/fdbbackup/backup.actor.cpp
@@ -2673,6 +2673,7 @@ int main(int argc, char* argv[]) {
 		bool quietDisplay = false;
 		bool dryRun = false;
 		std::string traceDir = "";
+		std::string traceFormat = "";
 		std::string traceLogGroup;
 		uint64_t traceRollSize = TRACE_DEFAULT_ROLL_SIZE;
 		uint64_t traceMaxLogsSize = TRACE_DEFAULT_MAX_LOGS_SIZE;
@@ -2778,9 +2779,10 @@ int main(int argc, char* argv[]) {
 					traceDir = args->OptionArg();
 					break;
 				case OPT_TRACE_FORMAT:
-					if (!selectTraceFormatter(args->OptionArg())) {
+					if (!validateTraceFormat(args->OptionArg())) {
 						fprintf(stderr, "WARNING: Unrecognized trace format `%s'\n", args->OptionArg());
 					}
+					traceFormat = args->OptionArg();
 					break;
 				case OPT_TRACE_LOG_GROUP:
 					traceLogGroup = args->OptionArg();
@@ -3121,6 +3123,9 @@ int main(int argc, char* argv[]) {
 				setNetworkOption(FDBNetworkOptions::TRACE_ENABLE);
 			else
 				setNetworkOption(FDBNetworkOptions::TRACE_ENABLE, StringRef(traceDir));
+			if (!traceFormat.empty()) {
+				setNetworkOption(FDBNetworkOptions::TRACE_FORMAT, StringRef(traceFormat));
+			}
 
 			setNetworkOption(FDBNetworkOptions::ENABLE_SLOW_TASK_PROFILING);
 		}

--- a/fdbcli/fdbcli.actor.cpp
+++ b/fdbcli/fdbcli.actor.cpp
@@ -2302,6 +2302,7 @@ struct CLIOptions {
 	std::string clusterFile;
 	bool trace;
 	std::string traceDir;
+	std::string traceFormat;
 	int exit_timeout;
 	Optional<std::string> exec;
 	bool initialStatusCheck;
@@ -2398,9 +2399,10 @@ struct CLIOptions {
 			case OPT_STATUS_FROM_JSON:
 				return printStatusFromJSON(args.OptionArg());
 			case OPT_TRACE_FORMAT:
-				if (!selectTraceFormatter(args.OptionArg())) {
+				if (!validateTraceFormat(args.OptionArg())) {
 					fprintf(stderr, "WARNING: Unrecognized trace format `%s'\n", args.OptionArg());
 				}
+				traceFormat = args.OptionArg();
 				break;
 			case OPT_VERSION:
 				printVersion();
@@ -3395,6 +3397,9 @@ int main(int argc, char **argv) {
 		else
 			setNetworkOption(FDBNetworkOptions::TRACE_ENABLE, StringRef(opt.traceDir));
 
+		if (!opt.traceFormat.empty()) {
+			setNetworkOption(FDBNetworkOptions::TRACE_FORMAT, StringRef(opt.traceFormat));
+		}
 		setNetworkOption(FDBNetworkOptions::ENABLE_SLOW_TASK_PROFILING);
 	}
 


### PR DESCRIPTION
The network option has the finally say on the what trace format to use, so set the network option.