### PR TITLE
Fix missing read workload metrics

### DIFF
--- a/documentation/sphinx/source/release-notes.rst
+++ b/documentation/sphinx/source/release-notes.rst
@@ -39,6 +39,7 @@ Fixes
 * Python: Creating a ``SingleFloat`` for the tuple layer didn't work with integers. `(PR #1216) <https://github.com/apple/foundationdb/pull/1216>`_
 * In some cases, calling ``OnError`` with a non-retryable error would partially reset a transaction. As of API version 610, the transaction will no longer be reset in these cases and will instead put the transaction into an error state. `(PR #1298) <https://github.com/apple/foundationdb/pull/1298>`_
 * Standardized datetime string format across all backup and restore command options and outputs. `(PR #1248) <https://github.com/apple/foundationdb/pull/1248>`_
+* Read workload status metrics would disappear when a storage server was missing. `(PR #) <https://github.com/apple/foundationdb/pull/>`_
 
 Status
 ------

--- a/documentation/sphinx/source/release-notes.rst
+++ b/documentation/sphinx/source/release-notes.rst
@@ -39,7 +39,7 @@ Fixes
 * Python: Creating a ``SingleFloat`` for the tuple layer didn't work with integers. `(PR #1216) <https://github.com/apple/foundationdb/pull/1216>`_
 * In some cases, calling ``OnError`` with a non-retryable error would partially reset a transaction. As of API version 610, the transaction will no longer be reset in these cases and will instead put the transaction into an error state. `(PR #1298) <https://github.com/apple/foundationdb/pull/1298>`_
 * Standardized datetime string format across all backup and restore command options and outputs. `(PR #1248) <https://github.com/apple/foundationdb/pull/1248>`_
-* Read workload status metrics would disappear when a storage server was missing. `(PR #) <https://github.com/apple/foundationdb/pull/>`_
+* Read workload status metrics would disappear when a storage server was missing. `(PR #1348) <https://github.com/apple/foundationdb/pull/1348>`_
 
 Status
 ------

--- a/fdbserver/Status.actor.cpp
+++ b/fdbserver/Status.actor.cpp
@@ -1505,10 +1505,12 @@ ACTOR static Future<JsonBuilderObject> workloadStatusFetcher(Reference<AsyncVar<
 		for(auto &ss : storageServers.get()) {
 			TraceEventFields const& storageMetrics = ss.second.at("StorageMetrics");
 
-			readRequests.updateValues( StatusCounter(storageMetrics.getValue("QueryQueue")));
-			reads.updateValues( StatusCounter(storageMetrics.getValue("FinishedQueries")));
-			readKeys.updateValues( StatusCounter(storageMetrics.getValue("RowsQueried")));
-			readBytes.updateValues( StatusCounter(storageMetrics.getValue("BytesQueried")));
+			if (storageMetrics.size() > 0) {
+				readRequests.updateValues(StatusCounter(storageMetrics.getValue("QueryQueue")));
+				reads.updateValues(StatusCounter(storageMetrics.getValue("FinishedQueries")));
+				readKeys.updateValues(StatusCounter(storageMetrics.getValue("RowsQueried")));
+				readBytes.updateValues(StatusCounter(storageMetrics.getValue("BytesQueried")));
+			}
 		}
 
 		operationsObj["read_requests"] = readRequests.getStatus();


### PR DESCRIPTION
Some read workload metrics would disappear when a storage server was missing. With this change, we now ignore any missing storage server when tabulating read metrics.