### PR TITLE
Change setting \xff/minRequiredCommitVersion to not always cause a recovery

### DIFF
--- a/fdbserver/ApplyMetadataMutation.h
+++ b/fdbserver/ApplyMetadataMutation.h
@@ -271,7 +271,7 @@ static void applyMetadataMutations(UID const& dbgid, Arena &arena, VectorRef<Mut
 				Version requested = BinaryReader::fromStringRef<Version>(m.param2, Unversioned());
 				TraceEvent("MinRequiredCommitVersion", dbgid).detail("Min", requested).detail("Current", popVersion).detail("HasConf", !!confChange);
 				if(!initialCommit) txnStateStore->set(KeyValueRef(m.param1, m.param2));
-				if (confChange) *confChange = true;
+				if (commitVersion && commitVersion->get() < requested && confChange) *confChange = true;
 				TEST(true);  // Recovering at a higher version.
 			}
 		}


### PR DESCRIPTION
The recovery is now skipped if `version <= current version`.

There's been a couple new inqueries into using this key, and it turns
outout that the expected simple transaction body of just setting this
key causes an infinite number of recoveries, as `commit_unknown_result`
is a retryable error, and setting minRequiredCommitVersion would
previously never result in anything but commit_unknown_result.

cc: @atn34 