### PR TITLE
Avoiding holding references to ThreadSafeDatabase on the main thread.

### DIFF
--- a/fdbclient/ThreadSafeTransaction.h
+++ b/fdbclient/ThreadSafeTransaction.h
@@ -52,7 +52,7 @@ public:  // Internal use only
 
 class ThreadSafeTransaction : public ITransaction, ThreadSafeReferenceCounted<ThreadSafeTransaction>, NonCopyable {
 public:
-	explicit ThreadSafeTransaction( Reference<ThreadSafeDatabase> db );
+	explicit ThreadSafeTransaction(DatabaseContext* cx);
 	~ThreadSafeTransaction();
 
 	void cancel();


### PR DESCRIPTION
Holding references to `ThreadSafeDatabase` on the main thread can cause a race with `fdb_stop_network` when it comes time to destroy the database. If the stop call is queued up on the network thread task queue before the `delref` of `ThreadSafeDatabase`, then the memory for the `ThreadSafeDatabase` will never be reclaimed.

I also stopped passing the reference into the `ThreadSafeTransaction` constructor at all because it seemed unnecessary.

The reason why I believe this new code to be safe is that all accesses to the `DatabaseContext cx` are from the main thread. So long as you don't make any calls using a database concurrently with or after destroying it using `fdb_database_destroy`, you should be fine.