### PR TITLE
Fix compiler warning about unreferenced exception variables

### DIFF
--- a/fdbbackup/backup.actor.cpp
+++ b/fdbbackup/backup.actor.cpp
@@ -3033,7 +3033,7 @@ int main(int argc, char* argv[]) {
 					try {
 						addKeyRange(args->File(argLoop), backupKeys);
 					}
-					catch (Error& e) {
+					catch (Error& ) {
 						printHelpTeaser(argv[0]);
 						return FDB_EXIT_ERROR;
 					}
@@ -3064,7 +3064,7 @@ int main(int argc, char* argv[]) {
 					try {
 						addKeyRange(args->File(argLoop), backupKeys);
 					}
-					catch (Error& e) {
+					catch (Error& ) {
 						printHelpTeaser(argv[0]);
 						return FDB_EXIT_ERROR;
 					}

--- a/fdbcli/fdbcli.actor.cpp
+++ b/fdbcli/fdbcli.actor.cpp
@@ -578,7 +578,7 @@ std::string getCoordinatorsInfoString(StatusObjectReader statusObj) {
 		for (StatusObjectReader coor : coordinatorsArr)
 			outputString += format("\n  %s  (%s)", coor["address"].get_str().c_str(), coor["reachable"].get_bool() ? "reachable" : "unreachable");
 	}
-	catch (std::runtime_error& e){
+	catch (std::runtime_error& ){
 		outputString = "\n  Unable to retrieve list of coordination servers";
 	}
 
@@ -609,7 +609,7 @@ std::string getProcessAddressByServerID(StatusObjectReader processesMap, std::st
 				}
 			}
 		}
-		catch (std::exception &e) {
+		catch (std::exception& ) {
 			// If an entry in the process map is badly formed then something will throw. Since we are
 			// looking for a positive match, just ignore any read execeptions and move on to the next proc
 		}
@@ -811,7 +811,7 @@ void printStatus(StatusObjectReader statusObj, StatusClient::StatusLevel level, 
 					}
 				}
 			}
-			catch (std::runtime_error& e){ }
+			catch (std::runtime_error& ){ }
 
 
 			// Check if cluster controllable is reachable
@@ -882,7 +882,7 @@ void printStatus(StatusObjectReader statusObj, StatusClient::StatusLevel level, 
 					}
 				}
 			}
-			catch (std::runtime_error& e){}
+			catch (std::runtime_error& ){}
 
 			if (fatalRecoveryState){
 				printf("%s", outputString.c_str());
@@ -948,7 +948,7 @@ void printStatus(StatusObjectReader statusObj, StatusClient::StatusLevel level, 
 				if (statusObjConfig.get("log_routers", intVal))
 					outputString += format("\n  Desired Log Routers    - %d", intVal);
 			}
-			catch (std::runtime_error& e) {
+			catch (std::runtime_error& ) {
 				outputString = outputStringCache;
 				outputString += "\n  Unable to retrieve configuration status";
 			}
@@ -1057,7 +1057,7 @@ void printStatus(StatusObjectReader statusObj, StatusClient::StatusLevel level, 
 					outputString += "\n  Server time            - " + serverTime;
 				}
 			}
-			catch (std::runtime_error& e){
+			catch (std::runtime_error& ){
 				outputString = outputStringCache;
 				outputString += "\n  Unable to retrieve cluster status";
 			}
@@ -1148,7 +1148,7 @@ void printStatus(StatusObjectReader statusObj, StatusClient::StatusLevel level, 
 					outputString += "unknown";
 
 			}
-			catch (std::runtime_error& e) {
+			catch (std::runtime_error& ) {
 				outputString = outputStringCache;
 				outputString += "\n  Unable to retrieve data status";
 			}
@@ -1165,7 +1165,7 @@ void printStatus(StatusObjectReader statusObj, StatusClient::StatusLevel level, 
 					operatingSpaceString += format("\n  Log server             - %.1f GB free on most full server", std::max(val / 1e9, 0.0));
 
 			}
-			catch (std::runtime_error& e){
+			catch (std::runtime_error& ){
 				operatingSpaceString = "";
 			}
 
@@ -1202,7 +1202,7 @@ void printStatus(StatusObjectReader statusObj, StatusClient::StatusLevel level, 
 							performanceLimited += format("\n  Most limiting process: %s", procAddr.c_str());
 					}
 				}
-				catch (std::exception &e) {
+				catch (std::exception& ) {
 					// If anything here throws (such as for an incompatible type) ignore it.
 				}
 
@@ -1266,7 +1266,7 @@ void printStatus(StatusObjectReader statusObj, StatusClient::StatusLevel level, 
 					}
 				}
 			}
-			catch (std::runtime_error& e){
+			catch (std::runtime_error& ){
 				outputString = outputStringCache;
 				outputString += "\n  Unable to retrieve workload status";
 			}
@@ -1404,7 +1404,7 @@ void printStatus(StatusObjectReader statusObj, StatusClient::StatusLevel level, 
 							workerDetails[addrNum] = line;
 						}
 
-						catch (std::runtime_error& e) {
+						catch (std::runtime_error& ) {
 							std::string noMetrics = format("  %-22s (no metrics available)", address.c_str());
 							workerDetails[addrNum] = noMetrics;
 						}
@@ -1412,7 +1412,7 @@ void printStatus(StatusObjectReader statusObj, StatusClient::StatusLevel level, 
 					for (auto w : workerDetails)
 						outputString += "\n" + format("%s", w.second.c_str());
 				}
-				catch (std::runtime_error& e){
+				catch (std::runtime_error& ){
 					outputString = outputStringCache;
 					outputString += "\n  Unable to retrieve process performance details";
 				}
@@ -1469,7 +1469,7 @@ void printStatus(StatusObjectReader statusObj, StatusClient::StatusLevel level, 
 							printf("The database is available, but has issues (type 'status' for more information).\n");
 						}
 					}
-					catch (std::runtime_error& e){
+					catch (std::runtime_error& ){
 						printf("The database is available, but has issues (type 'status' for more information).\n");
 					}
 				}
@@ -1479,7 +1479,7 @@ void printStatus(StatusObjectReader statusObj, StatusClient::StatusLevel level, 
 					printf("WARNING: The cluster file is not up to date. Type 'status' for more information.\n");
 				}
 			}
-			catch (std::runtime_error& e){
+			catch (std::runtime_error& ){
 				printf("Unable to determine database state, type 'status' for more information.\n");
 			}
 
@@ -1490,7 +1490,7 @@ void printStatus(StatusObjectReader statusObj, StatusClient::StatusLevel level, 
 			printf("%s\n", json_spirit::write_string(json_spirit::mValue(statusObj.obj()), json_spirit::Output_options::pretty_print).c_str());
 		}
 	}
-	catch (Error &e){
+	catch (Error& ){
 		if (hideErrorMessages)
 			return;
 		if (level == StatusClient::MINIMAL) {

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -1131,7 +1131,7 @@ AddressExclusion AddressExclusion::parse( StringRef const& key ) {
 			return AddressExclusion();
 		}
 		return AddressExclusion(addr.ip, addr.port);
-	} catch (Error& e) {
+	} catch (Error& ) {
 		TraceEvent(SevWarnAlways, "AddressExclusionParseError").detail("String", printable(key));
 		return AddressExclusion();
 	}

--- a/fdbserver/Coordination.actor.cpp
+++ b/fdbserver/Coordination.actor.cpp
@@ -224,7 +224,7 @@ ACTOR Future<Void> leaderRegister(LeaderElectionRegInterface interf, Key key) {
 				notify.push_back( req.reply );
 				if(notify.size() > SERVER_KNOBS->MAX_NOTIFICATIONS) {
 					TraceEvent(SevWarnAlways, "TooManyNotifications").detail("Amount", notify.size());
-					for(int i=0; i<notify.size(); i++)
+					for (uint32_t i=0; i<notify.size(); i++)
 						notify[i].send( currentNominee.get() );
 					notify.clear();
 				}
@@ -240,7 +240,7 @@ ACTOR Future<Void> leaderRegister(LeaderElectionRegInterface interf, Key key) {
 				notify.push_back( req.reply );
 				if(notify.size() > SERVER_KNOBS->MAX_NOTIFICATIONS) {
 					TraceEvent(SevWarnAlways, "TooManyNotifications").detail("Amount", notify.size());
-					for(int i=0; i<notify.size(); i++)
+					for (uint32_t i=0; i<notify.size(); i++)
 						notify[i].send( currentNominee.get() );
 					notify.clear();
 				}

--- a/fdbserver/CoroFlow.actor.cpp
+++ b/fdbserver/CoroFlow.actor.cpp
@@ -237,7 +237,7 @@ public:
 		TraceEvent("WorkPool_Stop").detail("Workers", pool->workers.size()).detail("Idle", pool->idle.size())
 			.detail("Work", pool->work.size());
 
-		for(int i=0; i<pool->work.size(); i++)
+		for (uint32_t i=0; i<pool->work.size(); i++)
 			pool->work[i]->cancel();   // What if cancel() does something to this?
 		pool->work.clear();
 		for(int i=0; i<pool->workers.size(); i++)

--- a/fdbserver/DataDistribution.actor.h
+++ b/fdbserver/DataDistribution.actor.h
@@ -250,7 +250,7 @@ ShardSizeBounds getShardSizeBounds(KeyRangeRef shard, int64_t maxShardSize);
 //Determines the maximum shard size based on the size of the database
 int64_t getMaxShardSize( double dbSizeEstimate );
 
-class DDTeamCollection;
+struct DDTeamCollection;
 ACTOR Future<Void> teamRemover(DDTeamCollection* self);
 ACTOR Future<Void> teamRemoverPeriodic(DDTeamCollection* self);
 ACTOR Future<vector<std::pair<StorageServerInterface, ProcessClass>>> getServerListAndProcessClasses(Transaction* tr);

--- a/fdbserver/Status.actor.cpp
+++ b/fdbserver/Status.actor.cpp
@@ -146,7 +146,7 @@ static Optional<WorkerDetails> getWorker(std::vector<WorkerDetails> const& worke
 				return workers[c];
 		return Optional<WorkerDetails>();
 	}
-	catch (Error &e){
+	catch (Error& ){
 		return Optional<WorkerDetails>();
 	}
 }
@@ -345,7 +345,7 @@ static JsonBuilderObject machineStatusFetcher(WorkerEvents mMetrics, vector<Work
 				notExcludedMap[machineId] = false;
 			workerContribMap[machineId] ++;
 		}
-		catch (Error& e) {
+		catch (Error& ) {
 			++failed;
 		}
 	}
@@ -1091,7 +1091,7 @@ static JsonBuilderObject configurationFetcher(Optional<DatabaseConfiguration> co
 		int count = coordinatorLeaderServers.size();
 		statusObj["coordinators_count"] = count;
 	}
-	catch (Error &e){
+	catch (Error& ){
 		incomplete_reasons->insert("Could not retrieve all configuration status information.");
 	}
 	return statusObj;

--- a/fdbserver/VFSAsync.cpp
+++ b/fdbserver/VFSAsync.cpp
@@ -112,7 +112,7 @@ static int asyncRead(sqlite3_file *pFile, void *zBuf, int iAmt, sqlite_int64 iOf
 			return SQLITE_IOERR_SHORT_READ;
 		}
 		return SQLITE_OK;
-	} catch (Error& e) {
+	} catch (Error& ) {
 		return SQLITE_IOERR_READ;
 	}
 }
@@ -123,7 +123,7 @@ static int asyncReleaseZeroCopy(sqlite3_file* pFile, void* data, int iAmt, sqlit
 	try{
 		--p->debug_zcrefs;
 		p->file->releaseZeroCopy( data, iAmt, iOfst );
-	} catch (Error& e) {
+	} catch (Error& ) {
 		return SQLITE_IOERR;
 	}
 	return SQLITE_OK;
@@ -145,7 +145,7 @@ static int asyncReadZeroCopy(sqlite3_file *pFile, void **data, int iAmt, sqlite_
 		}
 		++p->debug_zcreads;
 		return SQLITE_OK;
-	} catch (Error& e) {
+	} catch (Error& ) {
 		return SQLITE_IOERR_READ;
 	}
 }
@@ -162,7 +162,7 @@ static int asyncReadZeroCopy(sqlite3_file *pFile, void **data, int iAmt, sqlite_
 			return SQLITE_IOERR_SHORT_READ;
 		}
 		return SQLITE_OK;
-	} catch (Error& e) {
+	} catch (Error& ) {
 		return SQLITE_IOERR_READ;
 	}
 }
@@ -178,7 +178,7 @@ static int asyncWrite(sqlite3_file *pFile, const void *zBuf, int iAmt, sqlite_in
 	try {
 		waitFor( p->file->write( zBuf, iAmt, iOfst ) );
 		return SQLITE_OK;
-	} catch(Error& e) {
+	} catch(Error& ) {
 		return SQLITE_IOERR_WRITE;
 	}
 }
@@ -188,7 +188,7 @@ static int asyncTruncate(sqlite3_file *pFile, sqlite_int64 size){
 	try {
 		waitFor( p->file->truncate( size ) );
 		return SQLITE_OK;
-	} catch(Error& e) {
+	} catch(Error& ) {
 		return SQLITE_IOERR_TRUNCATE;
 	}
 }
@@ -217,7 +217,7 @@ static int VFSAsyncFileSize(sqlite3_file *pFile, sqlite_int64 *pSize){
 	try {
 		*pSize = waitForAndGet( p->file->size() );
 		return SQLITE_OK;
-	} catch (Error& e) {
+	} catch (Error& ) {
 		return SQLITE_IOERR_FSTAT;
 	}
 }
@@ -645,7 +645,7 @@ static int asyncFullPathname(
 ** and false otherwise.
 */
 bool vfsAsyncIsOpen( std::string filename ) {
-	return SharedMemoryInfo::table.count( abspath(filename) );
+	return SharedMemoryInfo::table.count( abspath(filename) ) > 0;
 }
 
 /*

--- a/fdbserver/VersionedBTree.actor.cpp
+++ b/fdbserver/VersionedBTree.actor.cpp
@@ -88,7 +88,7 @@ struct BTreePage {
 							if(t.getType(i) == Tuple::ElementType::INT)
 								r += format("%lld", t.getInt(i, true));
 						}
-					} catch(Error &e) {
+					} catch(Error& ) {
 					}
 					r += format("['%s']", c.getKeyRef().toHexString(20).c_str());
 
@@ -100,7 +100,7 @@ struct BTreePage {
 
 				} while(c.moveNext());
 			}
-		} catch(Error &e) {
+		} catch(Error& ) {
 			debug_printf("BTreePage::toString ERROR: %s\n", e.what());
 			debug_printf("BTreePage::toString partial result: %s\n", r.c_str());
 			throw;

--- a/fdbserver/fdbserver.actor.cpp
+++ b/fdbserver/fdbserver.actor.cpp
@@ -331,7 +331,7 @@ UID getSharedMemoryMachineId() {
 				criticalError(FDB_EXIT_ERROR, "SharedMemoryError", "Could not locate or create shared memory - 'machineId'");
 			return *machineId;
 		}
-		catch (boost::interprocess::interprocess_exception &e) {
+		catch (boost::interprocess::interprocess_exception& ) {
 			try {
 				//If the shared memory already exists, open it read-only in case it was created by another user
 				boost::interprocess::managed_shared_memory segment(boost::interprocess::open_read_only, sharedMemoryIdentifier.c_str());

--- a/fdbserver/workloads/SlowTaskWorkload.actor.cpp
+++ b/fdbserver/workloads/SlowTaskWorkload.actor.cpp
@@ -65,7 +65,7 @@ struct SlowTaskWorkload : TestWorkload {
 		for(int j=0; j<1000; j++)
 			try {
 				throw success();
-			} catch (Error& e) {
+			} catch (Error& ) {
 				++*exc_count;
 			}
 	}

--- a/flow/Deque.h
+++ b/flow/Deque.h
@@ -45,7 +45,7 @@ public:
 		if(r.capacity() > 0)
 			arr = (T*)aligned_alloc(__alignof(T), capacity()*sizeof(T));
 		ASSERT(capacity() >= end || end == 0);
-		for(int i=0; i<end; i++)
+		for (uint32_t i=0; i<end; i++)
 			new (&arr[i]) T(r[i]);
 		// FIXME: Specialization for POD types using memcpy?
 	}
@@ -60,7 +60,7 @@ public:
 		if(r.capacity() > 0)
 			arr = (T*)aligned_alloc(__alignof(T), capacity()*sizeof(T));
 		ASSERT(capacity() >= end || end == 0);
-		for(int i=0; i<end; i++)
+		for (uint32_t i=0; i<end; i++)
 			new (&arr[i]) T(r[i]);
 		// FIXME: Specialization for POD types using memcpy?
 	}
@@ -87,7 +87,7 @@ public:
 	bool operator == (const Deque& r) const { 
 		if(size() != r.size())
 			return false;
-		for(int i=0; i<size(); i++)
+		for (uint32_t i=0; i<size(); i++)
 			if((*this)[i] != r[i])
 				return false;
 		return true;
@@ -130,7 +130,7 @@ public:
 	}
 
 	void clear() {
-		for (int i = begin; i != end; i++)
+		for (uint32_t i = begin; i != end; i++)
 			arr[i&mask].~T();
 		begin = end = 0;
 	}

--- a/flow/Trace.cpp
+++ b/flow/Trace.cpp
@@ -205,7 +205,7 @@ public:
 		}
 		void triggerAll() {
 			MutexHolder h(mutex);
-			for(int i=ntriggered; i<barriers.size(); i++)
+			for(uint32_t i=ntriggered; i<barriers.size(); i++)
 				unsafeTrigger(i);
 			ntriggered = barriers.size();
 		}


### PR DESCRIPTION
Remove variable name from exception catch statement.

A small, partial attempt for #1255.