### PR TITLE
Establish a convention with ratekeeper being one word

### DIFF
--- a/documentation/sphinx/source/engineering.rst
+++ b/documentation/sphinx/source/engineering.rst
@@ -14,10 +14,10 @@ Simulation
 
 We wanted FoundationDB to survive failures of machines, networks, disks, clocks, racks, data centers, file systems, etc., so we created a simulation framework closely tied to Flow. By replacing physical interfaces with shims, replacing the main epoll-based run loop with a time-based simulation, and running multiple logical processes as concurrent Flow Actors, Simulation is able to conduct a deterministic simulation of an entire FoundationDB cluster within a single-thread! Even better, we are able to execute this simulation in a deterministic way, enabling us to reproduce problems and add instrumentation ex post facto. This incredible capability enabled us to build FoundationDB exclusively in simulation for the first 18 months and ensure exceptional fault tolerance long before it sent its first real network packet. For a database with as strong a contract as the FoundationDB, testing is crucial, and over the years we have run the equivalent of *a trillion CPU-hours* of simulated stress testing. Read more about our :doc:`Simulation and Testing <testing>`.
 
-RateKeeper
+Ratekeeper
 ==========
 
-FoundationDB uses an intelligent control algorithm called RateKeeper to queue client transactions during heavy loads. Using principles from operational research and control theory, FoundationDB prevents system oscillation and reduces internal queue sizes by intelligently applying global backpressure. By handing out tickets and serving clients in order and at a controlled pace, latency is shifted from the read and commit operations to the transaction-creation line. This ensures continuous low-latency operation under all conditions and also allows transactions of different priorities to be queued separately, allowing concurrent batch and low-latency workloads.
+FoundationDB uses an intelligent control algorithm called Ratekeeper to queue client transactions during heavy loads. Using principles from operational research and control theory, FoundationDB prevents system oscillation and reduces internal queue sizes by intelligently applying global backpressure. By handing out tickets and serving clients in order and at a controlled pace, latency is shifted from the read and commit operations to the transaction-creation line. This ensures continuous low-latency operation under all conditions and also allows transactions of different priorities to be queued separately, allowing concurrent batch and low-latency workloads.
 
 Prioritization
 ==============

--- a/fdbrpc/Locality.cpp
+++ b/fdbrpc/Locality.cpp
@@ -176,9 +176,9 @@ ProcessClass::Fitness ProcessClass::machineClassFitness( ClusterRole role ) cons
 		default:
 			return ProcessClass::WorstFit;
 		}
-	case ProcessClass::RateKeeper:
+	case ProcessClass::Ratekeeper:
 		switch( _class ) {
-		case ProcessClass::RateKeeperClass:
+		case ProcessClass::RatekeeperClass:
 			return ProcessClass::BestFit;
 		case ProcessClass::StatelessClass:
 			return ProcessClass::GoodFit;

--- a/fdbrpc/Locality.h
+++ b/fdbrpc/Locality.h
@@ -26,9 +26,9 @@
 
 struct ProcessClass {
 	// This enum is stored in restartInfo.ini for upgrade tests, so be very careful about changing the existing items!
-	enum ClassType { UnsetClass, StorageClass, TransactionClass, ResolutionClass, TesterClass, ProxyClass, MasterClass, StatelessClass, LogClass, ClusterControllerClass, LogRouterClass, DataDistributorClass, CoordinatorClass, RateKeeperClass, InvalidClass = -1 };
+	enum ClassType { UnsetClass, StorageClass, TransactionClass, ResolutionClass, TesterClass, ProxyClass, MasterClass, StatelessClass, LogClass, ClusterControllerClass, LogRouterClass, DataDistributorClass, CoordinatorClass, RatekeeperClass, InvalidClass = -1 };
 	enum Fitness { BestFit, GoodFit, UnsetFit, OkayFit, WorstFit, ExcludeFit, NeverAssign }; //cannot be larger than 7 because of leader election mask
-	enum ClusterRole { Storage, TLog, Proxy, Master, Resolver, LogRouter, ClusterController, DataDistributor, RateKeeper, NoRole };
+	enum ClusterRole { Storage, TLog, Proxy, Master, Resolver, LogRouter, ClusterController, DataDistributor, Ratekeeper, NoRole };
 	enum ClassSource { CommandLineSource, AutoSource, DBSource, InvalidSource = -1 };
 	int16_t _class;
 	int16_t _source;
@@ -50,7 +50,7 @@ public:
 		else if (s=="cluster_controller") _class = ClusterControllerClass;
 		else if (s=="data_distributor") _class = DataDistributorClass;
 		else if (s=="coordinator") _class = CoordinatorClass;
-		else if (s=="ratekeeper") _class = RateKeeperClass;
+		else if (s=="ratekeeper") _class = RatekeeperClass;
 		else _class = InvalidClass;
 	}
 
@@ -68,7 +68,7 @@ public:
 		else if (classStr=="cluster_controller") _class = ClusterControllerClass;
 		else if (classStr=="data_distributor") _class = DataDistributorClass;
 		else if (classStr=="coordinator") _class = CoordinatorClass;
-		else if (classStr=="ratekeeper") _class = RateKeeperClass;
+		else if (classStr=="ratekeeper") _class = RatekeeperClass;
 		else _class = InvalidClass;
 
 		if (sourceStr=="command_line") _source = CommandLineSource;
@@ -101,7 +101,7 @@ public:
 			case ClusterControllerClass: return "cluster_controller";
 			case DataDistributorClass: return "data_distributor";
 			case CoordinatorClass: return "coordinator";
-			case RateKeeperClass: return "ratekeeper";
+			case RatekeeperClass: return "ratekeeper";
 			default: return "invalid";
 		}
 	}

--- a/fdbrpc/simulator.h
+++ b/fdbrpc/simulator.h
@@ -96,7 +96,7 @@ public:
 				case ProcessClass::LogRouterClass: return false;
 				case ProcessClass::ClusterControllerClass: return false;
 				case ProcessClass::DataDistributorClass: return false;
-				case ProcessClass::RateKeeperClass: return false;
+				case ProcessClass::RatekeeperClass: return false;
 				default: return false;
 			}
 		}

--- a/fdbserver/Knobs.cpp
+++ b/fdbserver/Knobs.cpp
@@ -349,10 +349,10 @@ ServerKnobs::ServerKnobs(bool randomize, ClientKnobs* clientKnobs) {
 	init(SERVER_MEM_LIMIT, 8LL << 30);
 
 	//Ratekeeper
-	bool slowRateKeeper = randomize && BUGGIFY;
-	init( SMOOTHING_AMOUNT,                                      1.0 ); if( slowRateKeeper ) SMOOTHING_AMOUNT = 5.0;
-	init( SLOW_SMOOTHING_AMOUNT,                                10.0 ); if( slowRateKeeper ) SLOW_SMOOTHING_AMOUNT = 50.0;
-	init( METRIC_UPDATE_RATE,                                     .1 ); if( slowRateKeeper ) METRIC_UPDATE_RATE = 0.5;
+	bool slowRatekeeper = randomize && BUGGIFY;
+	init( SMOOTHING_AMOUNT,                                      1.0 ); if( slowRatekeeper ) SMOOTHING_AMOUNT = 5.0;
+	init( SLOW_SMOOTHING_AMOUNT,                                10.0 ); if( slowRatekeeper ) SLOW_SMOOTHING_AMOUNT = 50.0;
+	init( METRIC_UPDATE_RATE,                                     .1 ); if( slowRatekeeper ) METRIC_UPDATE_RATE = 0.5;
 	init( DETAILED_METRIC_UPDATE_RATE,                           5.0 );
 
 	bool smallStorageTarget = randomize && BUGGIFY;

--- a/fdbserver/Ratekeeper.actor.cpp
+++ b/fdbserver/Ratekeeper.actor.cpp
@@ -294,7 +294,7 @@ ACTOR Future<Void> trackEachStorageServer(
 ACTOR Future<Void> monitorServerListChange(
 		Reference<AsyncVar<ServerDBInfo>> dbInfo,
 		PromiseStream< std::pair<UID, Optional<StorageServerInterface>> > serverChanges) {
-	state Database db = openDBOnServer(dbInfo, TaskRateKeeper, true, true);
+	state Database db = openDBOnServer(dbInfo, TaskRatekeeper, true, true);
 	state std::map<UID, StorageServerInterface> oldServers;
 	state Transaction tr(db);
 
@@ -394,7 +394,7 @@ void updateRate(RatekeeperData* self, RatekeeperLimits* limits) {
 		//inputRate = std::max( inputRate, actualTps / SERVER_KNOBS->MAX_TRANSACTIONS_PER_BYTE );
 
 		/*if( g_random->random01() < 0.1 ) {
-			std::string name = "RateKeeperUpdateRate" + limits.context;
+			std::string name = "RatekeeperUpdateRate" + limits.context;
 			TraceEvent(name, ss.id)
 				.detail("MinFreeSpace", minFreeSpace)
 				.detail("SpringBytes", springBytes)
@@ -633,7 +633,7 @@ ACTOR Future<Void> configurationMonitor(Reference<AsyncVar<ServerDBInfo>> dbInfo
 	}
 }
 
-ACTOR Future<Void> rateKeeper(RatekeeperInterface rkInterf, Reference<AsyncVar<ServerDBInfo>> dbInfo) {
+ACTOR Future<Void> ratekeeper(RatekeeperInterface rkInterf, Reference<AsyncVar<ServerDBInfo>> dbInfo) {
 	state RatekeeperData self;
 	state Future<Void> timeout = Void();
 	state std::vector<Future<Void>> tlogTrackers;

--- a/fdbserver/Status.actor.cpp
+++ b/fdbserver/Status.actor.cpp
@@ -605,7 +605,7 @@ ACTOR static Future<JsonBuilderObject> processStatusFetcher(
 	}
 
 	if (db->get().ratekeeper.present()) {
-		roles.addRole("rate_keeper", db->get().ratekeeper.get());
+		roles.addRole("ratekeeper", db->get().ratekeeper.get());
 	}
 
 	state std::vector<std::pair<MasterProxyInterface, EventMap>>::iterator proxy;

--- a/fdbserver/Status.actor.cpp
+++ b/fdbserver/Status.actor.cpp
@@ -1831,7 +1831,7 @@ ACTOR Future<StatusReply> clusterGetStatus(
 	state std::set<std::string> status_incomplete_reasons;
 	state WorkerDetails mWorker;
 	state WorkerDetails ddWorker; // DataDistributor worker
-	state WorkerDetails rkWorker; // RateKeeper worker
+	state WorkerDetails rkWorker; // Ratekeeper worker
 
 	try {
 		// Get the master Worker interface
@@ -1853,7 +1853,7 @@ ACTOR Future<StatusReply> clusterGetStatus(
 			ddWorker = _ddWorker.get();
 		}
 
-		// Get the RateKeeper worker interface
+		// Get the Ratekeeper worker interface
 		Optional<WorkerDetails> _rkWorker;
 		if (db->get().ratekeeper.present()) {
 			_rkWorker = getWorker( workers, db->get().ratekeeper.get().address() );

--- a/fdbserver/WorkerInterface.actor.h
+++ b/fdbserver/WorkerInterface.actor.h
@@ -392,7 +392,7 @@ ACTOR Future<Void> resolver(ResolverInterface proxy, InitializeResolverRequest i
 ACTOR Future<Void> logRouter(TLogInterface interf, InitializeLogRouterRequest req,
                              Reference<AsyncVar<ServerDBInfo>> db);
 ACTOR Future<Void> dataDistributor(DataDistributorInterface ddi, Reference<AsyncVar<ServerDBInfo>> db);
-ACTOR Future<Void> rateKeeper(RatekeeperInterface rki, Reference<AsyncVar<ServerDBInfo>> db);
+ACTOR Future<Void> ratekeeper(RatekeeperInterface rki, Reference<AsyncVar<ServerDBInfo>> db);
 
 void registerThreadForProfiling();
 void updateCpuProfiler(ProfilerRequest req);

--- a/fdbserver/WorkerInterface.actor.h
+++ b/fdbserver/WorkerInterface.actor.h
@@ -330,7 +330,7 @@ struct Role {
 	static const Role TESTER;
 	static const Role LOG_ROUTER;
 	static const Role DATA_DISTRIBUTOR;
-	static const Role RATE_KEEPER;
+	static const Role RATEKEEPER;
 
 	std::string roleName;
 	std::string abbreviation;

--- a/fdbserver/worker.actor.cpp
+++ b/fdbserver/worker.actor.cpp
@@ -858,13 +858,15 @@ ACTOR Future<Void> workerServer( Reference<ClusterConnectionFile> connFile, Refe
 					recruited = rkInterf->get().get();
 					TEST(true);  // Recruited while already a ratekeeper.
 				} else {
-					startRole(Role::RATE_KEEPER, recruited.id(), interf.id());
+					startRole(Role::RATEKEEPER, recruited.id(), interf.id());
 					DUMPTOKEN( recruited.waitFailure );
 					DUMPTOKEN( recruited.getRateInfo );
 					DUMPTOKEN( recruited.haltRatekeeper );
 
 					Future<Void> ratekeeper = rateKeeper( recruited, dbInfo );
-					errorForwarders.add( forwardError( errors, Role::RATE_KEEPER, recruited.id(), setWhenDoneOrError( ratekeeper, rkInterf, Optional<RatekeeperInterface>() ) ) );
+					errorForwarders.add(
+					    forwardError(errors, Role::RATEKEEPER, recruited.id(),
+					                 setWhenDoneOrError(ratekeeper, rkInterf, Optional<RatekeeperInterface>())));
 					rkInterf->set(Optional<RatekeeperInterface>(recruited));
 				}
 				TraceEvent("Ratekeeper_InitRequest", req.reqId).detail("RatekeeperId", recruited.id());
@@ -1279,4 +1281,4 @@ const Role Role::CLUSTER_CONTROLLER("ClusterController", "CC");
 const Role Role::TESTER("Tester", "TS");
 const Role Role::LOG_ROUTER("LogRouter", "LR");
 const Role Role::DATA_DISTRIBUTOR("DataDistributor", "DD");
-const Role Role::RATE_KEEPER("RateKeeper", "RK");
+const Role Role::RATEKEEPER("Ratekeeper", "RK");

--- a/fdbserver/worker.actor.cpp
+++ b/fdbserver/worker.actor.cpp
@@ -863,7 +863,7 @@ ACTOR Future<Void> workerServer( Reference<ClusterConnectionFile> connFile, Refe
 					DUMPTOKEN( recruited.getRateInfo );
 					DUMPTOKEN( recruited.haltRatekeeper );
 
-					Future<Void> ratekeeper = rateKeeper( recruited, dbInfo );
+					Future<Void> ratekeeper = ratekeeper( recruited, dbInfo );
 					errorForwarders.add(
 					    forwardError(errors, Role::RATEKEEPER, recruited.id(),
 					                 setWhenDoneOrError(ratekeeper, rkInterf, Optional<RatekeeperInterface>())));

--- a/fdbserver/worker.actor.cpp
+++ b/fdbserver/worker.actor.cpp
@@ -863,10 +863,10 @@ ACTOR Future<Void> workerServer( Reference<ClusterConnectionFile> connFile, Refe
 					DUMPTOKEN( recruited.getRateInfo );
 					DUMPTOKEN( recruited.haltRatekeeper );
 
-					Future<Void> ratekeeper = ratekeeper( recruited, dbInfo );
+					Future<Void> ratekeeperProcess = ratekeeper(recruited, dbInfo);
 					errorForwarders.add(
 					    forwardError(errors, Role::RATEKEEPER, recruited.id(),
-					                 setWhenDoneOrError(ratekeeper, rkInterf, Optional<RatekeeperInterface>())));
+					                 setWhenDoneOrError(ratekeeperProcess, rkInterf, Optional<RatekeeperInterface>())));
 					rkInterf->set(Optional<RatekeeperInterface>(recruited));
 				}
 				TraceEvent("Ratekeeper_InitRequest", req.reqId).detail("RatekeeperId", recruited.id());

--- a/fdbserver/workloads/ConsistencyCheck.actor.cpp
+++ b/fdbserver/workloads/ConsistencyCheck.actor.cpp
@@ -1377,11 +1377,11 @@ struct ConsistencyCheckWorkload : TestWorkload
 			return false;
 		}
 
-		// Check RateKeeper
-		ProcessClass::Fitness bestRateKeeperFitness = getBestAvailableFitness(dcToNonExcludedClassTypes[masterDcId], ProcessClass::RateKeeper);
-		if (db.ratekeeper.present() && (!nonExcludedWorkerProcessMap.count(db.ratekeeper.get().address()) || nonExcludedWorkerProcessMap[db.ratekeeper.get().address()].processClass.machineClassFitness(ProcessClass::RateKeeper) != bestRateKeeperFitness)) {
-			TraceEvent("ConsistencyCheck_RateKeeperNotBest").detail("BestRateKeeperFitness", bestRateKeeperFitness)
-			.detail("ExistingRateKeeperFitness", nonExcludedWorkerProcessMap.count(db.ratekeeper.get().address()) ? nonExcludedWorkerProcessMap[db.ratekeeper.get().address()].processClass.machineClassFitness(ProcessClass::RateKeeper) : -1);
+		// Check Ratekeeper
+		ProcessClass::Fitness bestRatekeeperFitness = getBestAvailableFitness(dcToNonExcludedClassTypes[masterDcId], ProcessClass::Ratekeeper);
+		if (db.ratekeeper.present() && (!nonExcludedWorkerProcessMap.count(db.ratekeeper.get().address()) || nonExcludedWorkerProcessMap[db.ratekeeper.get().address()].processClass.machineClassFitness(ProcessClass::Ratekeeper) != bestRatekeeperFitness)) {
+			TraceEvent("ConsistencyCheck_RatekeeperNotBest").detail("BestRatekeeperFitness", bestRatekeeperFitness)
+			.detail("ExistingRatekeeperFitness", nonExcludedWorkerProcessMap.count(db.ratekeeper.get().address()) ? nonExcludedWorkerProcessMap[db.ratekeeper.get().address()].processClass.machineClassFitness(ProcessClass::Ratekeeper) : -1);
 			return false;
 		}
 

--- a/flow/network.h
+++ b/flow/network.h
@@ -68,7 +68,7 @@ enum {
 	TaskUnknownEndpoint = 4000,
 	TaskMoveKeys = 3550,
 	TaskDataDistributionLaunch = 3530,
-	TaskRateKeeper = 3510,
+	TaskRatekeeper = 3510,
 	TaskDataDistribution = 3500,
 	TaskDiskWrite = 3010,
 	TaskUpdateStorage = 3000,


### PR DESCRIPTION
I think we mostly had used ratekeeper as one word, but there were various places in old and new code that treated it as two words. Because this word is going to be exposed through status, I wanted to pick a convention and use it consistently. This PR changes them all to be one word.