### PR TITLE
Fix Versionstamp encoding issue for Value objects

### DIFF
--- a/bindings/python/fdb/tuple.py
+++ b/bindings/python/fdb/tuple.py
@@ -180,8 +180,11 @@ class Versionstamp(object):
         return "Versionstamp(" + repr(self.tr_version) + ", " + str(self.user_version) + ")"
 
     def to_bytes(self):
+        tr_version = self.tr_version
+        if isinstance(tr_version, fdb.impl.Value):
+            tr_version = tr_version.value
         return struct.pack(self._STRUCT_FORMAT_STRING,
-                           self.tr_version if self.is_complete() else self._UNSET_TR_VERSION,
+                           tr_version if self.is_complete() else self._UNSET_TR_VERSION,
                            self.user_version)
 
     def completed(self, new_tr_version):


### PR DESCRIPTION
Python's struct.pack does not accept Value objects.

The issue is reproducible in master with
```
>>> val = tr[<key_pointing_to_versionstamp>].wait()
>>> fdb.tuple.Versionstamp(val).to_bytes()
struct.error: argument for 's' must be a bytes object
```