### PR TITLE
Improve Python KeySelector representation (cherry-picked from master)

### DIFF
--- a/bindings/python/fdb/impl.py
+++ b/bindings/python/fdb/impl.py
@@ -1159,8 +1159,8 @@ class KeySelector(object):
     def first_greater_or_equal(cls, key):
         return cls(key, False, 1)
 
-    def __str__(self):
-        return 'KeySelector(%s, %r, %d)' % (self.key, self.or_equal, self.offset)
+    def __repr__(self):
+        return 'KeySelector(%r, %r, %r)' % (self.key, self.or_equal, self.offset)
 
 
 class KVIter(object):


### PR DESCRIPTION
Python 2 resolves escape characters when printing byte strings,
which doesn't seem useful in this context.

I replaced __str__ since it defaults to __repr__ and the change
should be suitable for both cases.