### PR TITLE
Gperftools Profiling fix.

### DIFF
--- a/cmake/ConfigureCompiler.cmake
+++ b/cmake/ConfigureCompiler.cmake
@@ -126,6 +126,13 @@ else()
     -Wreturn-type
     -fdiagnostics-color=always
     -fPIC)
+  if (GPERFTOOLS_FOUND AND GCC)
+    add_compile_options(
+      -fno-builtin-malloc
+      -fno-builtin-calloc
+      -fno-builtin-realloc
+      -fno-builtin-free)
+  endif()
 
   if(CMAKE_COMPILER_IS_GNUCXX)
     set(USE_LTO OFF CACHE BOOL "Do link time optimization")

--- a/cmake/ConfigureCompiler.cmake
+++ b/cmake/ConfigureCompiler.cmake
@@ -6,6 +6,10 @@ set(ALLOC_INSTRUMENTATION OFF CACHE BOOL "Instrument alloc")
 set(WITH_UNDODB OFF CACHE BOOL "Use rr or undodb")
 set(FDB_RELEASE OFF CACHE BOOL "This is a building of a final release")
 
+if(USE_GPERFTOOLS)
+  find_package(Gperftools REQUIRED)
+endif()
+
 add_compile_options(-DCMAKE_BUILD)
 add_compile_definitions(BOOST_ERROR_CODE_HEADER_ONLY BOOST_SYSTEM_NO_DEPRECATED)
 

--- a/cmake/FindGperftools.cmake
+++ b/cmake/FindGperftools.cmake
@@ -51,11 +51,6 @@ mark_as_advanced(
   GPERFTOOLS_INCLUDE_DIR)
 
 if (GPERFTOOLS_FOUND)
-  add_compile_options(
-    -fno-builtin-malloc
-    -fno-builtin-calloc
-    -fno-builtin-realloc
-    -fno-builtin-free)
   add_library(gperftools UNKNOWN IMPORTED)
   set_target_properties(gperftools PROPERTIES
     IMPORTED_LOCATION ${GPERFTOOLS_TCMALLOC_AND_PROFILER}

--- a/cmake/FindGperftools.cmake
+++ b/cmake/FindGperftools.cmake
@@ -49,3 +49,15 @@ mark_as_advanced(
   GPERFTOOLS_TCMALLOC_AND_PROFILER
   GPERFTOOLS_LIBRARIES
   GPERFTOOLS_INCLUDE_DIR)
+
+if (GPERFTOOLS_FOUND)
+  add_compile_options(
+    -fno-builtin-malloc
+    -fno-builtin-calloc
+    -fno-builtin-realloc
+    -fno-builtin-free)
+  add_library(gperftools UNKNOWN IMPORTED)
+  set_target_properties(gperftools PROPERTIES
+    IMPORTED_LOCATION ${GPERFTOOLS_TCMALLOC_AND_PROFILER}
+    INTERFACE_INCLUDE_DIRECTORIES "${GPERFTOOLS_INCLUDE_DIR}")
+endif()

--- a/fdbbackup/CMakeLists.txt
+++ b/fdbbackup/CMakeLists.txt
@@ -31,3 +31,8 @@ if(NOT OPEN_FOR_IDE)
     FILE_NAME fdbbackup
     LINK_NAME fdbdr)
 endif()
+
+if (GPERFTOOLS_FOUND)
+  add_compile_definitions(USE_GPERFTOOLS)
+  target_link_libraries(fdbbackup PRIVATE gperftools)
+endif()

--- a/fdbbackup/local.mk
+++ b/fdbbackup/local.mk
@@ -29,7 +29,7 @@ ifeq ($(PLATFORM),linux)
   fdbbackup_LDFLAGS += -static-libstdc++ -static-libgcc -ldl -lpthread -lrt
 
   # GPerfTools profiler (uncomment to use)
-  # fdbbackup_CFLAGS += -I/opt/gperftools/include -DUSE_GPERFTOOLS=1
+  # fdbbackup_CFLAGS += -I/opt/gperftools/include -DUSE_GPERFTOOLS=1 -fno-builtin-malloc -fno-builtin-calloc -fno-builtin-realloc -fno-builtin-free
   # fdbbackup_LDFLAGS += -L/opt/gperftools/lib
   # fdbbackup_STATIC_LIBS += -ltcmalloc -lunwind -lprofiler
 else ifeq ($(PLATFORM),osx)

--- a/fdbserver/CMakeLists.txt
+++ b/fdbserver/CMakeLists.txt
@@ -184,5 +184,9 @@ target_include_directories(fdbserver PRIVATE
   ${CMAKE_CURRENT_BINARY_DIR}/workloads
   ${CMAKE_CURRENT_SOURCE_DIR}/workloads)
 target_link_libraries(fdbserver PRIVATE fdbclient)
+if (GPERFTOOLS_FOUND)
+  add_compile_definitions(USE_GPERFTOOLS)
+  target_link_libraries(fdbserver PRIVATE gperftools)
+endif()
 
 fdb_install(TARGETS fdbserver DESTINATION sbin COMPONENT server)

--- a/fdbserver/local.mk
+++ b/fdbserver/local.mk
@@ -29,7 +29,7 @@ ifeq ($(PLATFORM),linux)
   fdbserver_LDFLAGS += -ldl -lpthread -lrt -static-libstdc++ -static-libgcc
 
   # GPerfTools profiler (uncomment to use)
-  # fdbserver_CFLAGS += -I/opt/gperftools/include -DUSE_GPERFTOOLS=1
+  # fdbserver_CFLAGS += -I/opt/gperftools/include -DUSE_GPERFTOOLS=1 -fno-builtin-malloc -fno-builtin-calloc -fno-builtin-realloc -fno-builtin-free
   # fdbserver_LDFLAGS += -L/opt/gperftools/lib
   # fdbserver_STATIC_LIBS += -ltcmalloc -lunwind -lprofiler
 else ifeq ($(PLATFORM),osx)

--- a/fdbserver/worker.actor.cpp
+++ b/fdbserver/worker.actor.cpp
@@ -407,7 +407,6 @@ void updateCpuProfiler(ProfilerRequest req) {
 			options->filter_in_thread = &filter_in_thread;
 			options->filter_in_thread_arg = NULL;
 			ProfilerStartWithOptions(path, options);
-			free(workingDir);
 			break;
 		}
 		case ProfilerRequest::Action::DISABLE:


### PR DESCRIPTION
Fix a bug and update gperftools compiling flags

The added flags are recommended by gperftools here:
https://github.com/gperftools/gperftools

Verified that heap profiles are saved with the following command:
HEAPPROFILE=/tmp/fdbserver fdbserver [args...]