### PR TITLE
Add manually triggered heap profiling

### DIFF
--- a/fdbclient/ClientWorkerInterface.h
+++ b/fdbclient/ClientWorkerInterface.h
@@ -76,7 +76,7 @@ struct ProfilerRequest {
 	int duration;
 	Standalone<StringRef> outputFile;
 
-	ProfilerRequest() {}
+	ProfilerRequest() = default;
 	explicit ProfilerRequest(Type t, Action a, int d) : type(t), action(a), duration(d) {}
 
 	template<class Ar>

--- a/fdbclient/ClientWorkerInterface.h
+++ b/fdbclient/ClientWorkerInterface.h
@@ -61,7 +61,8 @@ struct ProfilerRequest {
 
 	enum class Type : std::int8_t {
 		GPROF = 1,
-		FLOW = 2
+		FLOW = 2,
+		GPROF_HEAP = 3,
 	};
 
 	enum class Action : std::int8_t {
@@ -74,6 +75,9 @@ struct ProfilerRequest {
 	Action action;
 	int duration;
 	Standalone<StringRef> outputFile;
+
+	ProfilerRequest() {}
+	explicit ProfilerRequest(Type t, Action a, int d) : type(t), action(a), duration(d) {}
 
 	template<class Ar>
 	void serialize( Ar& ar ) {

--- a/fdbserver/worker.actor.cpp
+++ b/fdbserver/worker.actor.cpp
@@ -457,7 +457,7 @@ void runHeapProfiler() {
 	if (IsHeapProfilerRunning()) {
 		HeapProfilerDump("User triggered heap dump");
 	} else {
-		TraceEvent("ProfilerError").detail("Message", "HeapProfiler Unsupported");
+		TraceEvent("ProfilerError").detail("Message", "HeapProfiler not running");
 	}
 #else
 	TraceEvent("ProfilerError").detail("Message", "HeapProfiler Unsupported");

--- a/fdbserver/worker.actor.cpp
+++ b/fdbserver/worker.actor.cpp
@@ -432,7 +432,8 @@ void updateCpuProfiler(ProfilerRequest req) {
 			break;
 		}
 		break;
-	case ProfilerRequest::Type::GPROF_HEAP:
+	default:
+		ASSERT(false);
 		break;
 	}
 }


### PR DESCRIPTION
At client side:
fdb> profile
ERROR: Usage: profile <client|list|flow|heap>
fdb> profile heap 127.0.0.1:4500

On the server side:
$ HEAPPROFILE=/tmp/fdbserver bin/fdbserver -C ../test.cluster -p 127.0.0.1:4500
Starting tracking the heap
FDBD joined cluster.
Dumping heap profile to /tmp/fdbserver.0001.heap (1024 MB allocated cumulatively, 13 MB currently in use)
Dumping heap profile to /tmp/fdbserver.0002.heap (User triggered heap dump)

This is for #1411