### PR TITLE
Overall framework and first buggify entries

### DIFF
--- a/fdbclient/NativeAPI.actor.h
+++ b/fdbclient/NativeAPI.actor.h
@@ -36,6 +36,9 @@
 #include "fdbclient/ClientLogEvents.h"
 #include "flow/actorcompiler.h" // has to be last include
 
+#define CLIENT_BUGGIFY_WITH_PROB(x) (getSBVar(__FILE__, __LINE__, BuggifyType::Client) && g_random->random01() < (x))
+#define CLIENT_BUGGIFY CLIENT_BUGGIFY_WITH_PROB(P_BUGGIFIED_SECTION_FIRES[int(BuggifyType::Client)])
+
 // Incomplete types that are reference counted
 class DatabaseContext;
 template <> void addref( DatabaseContext* ptr );

--- a/fdbclient/vexillographer/fdb.options
+++ b/fdbclient/vexillographer/fdb.options
@@ -107,6 +107,16 @@ description is not currently required but encouraged.
             description="Disables logging of client statistics, such as sampled transaction activity." />
     <Option name="enable_slow_task_profiling" code="71"
             description="Enables debugging feature to perform slow task profiling. Requires trace logging to be enabled. WARNING: this feature is not recommended for use in production." />
+    <Option name="ClientBuggify_enable" code="80"
+            description="" />
+    <Option name="ClientBuggify_disable" code="81"
+            description="" />
+    <Option name="ClientBuggify_section_activated_probability" code="82"
+            paramType="Int" paramDescription="probability expressed as a percentage between 0 and 100"
+            description="Set the probability of a CLIENT_BUGGIFY section being active for the current execution.  Only applies to code paths first traversed AFTER this option is changed." />
+    <Option name="ClientBuggify_section_fired_probability" code="83"
+            paramType="Int" paramDescription="probability expressed as a percentage between 0 and 100"
+            description="Set the probability of an active CLIENT_BUGGIFY section being fired" />
     <Option name="supported_client_versions" code="1000"
             paramType="String" paramDescription="[release version],[source version],[protocol version];..."
             description="This option is set automatically to communicate the list of supported clients to the active client."

--- a/fdbserver/SimulatedCluster.actor.cpp
+++ b/fdbserver/SimulatedCluster.actor.cpp
@@ -42,7 +42,6 @@
 #undef max
 #undef min
 
-extern bool buggifyActivated;
 extern "C" int g_expect_full_pointermap;
 extern const char* getHGVersion();
 
@@ -231,7 +230,7 @@ ACTOR Future<ISimulator::KillType> simulatedFDBDRebooter(Reference<ClusterConnec
 				.detail("ConnectionString", connFile ? connFile->getConnectionString().toString() : "")
 				.detailf("ActualTime", "%lld", DEBUG_DETERMINISM ? 0 : time(NULL))
 				.detail("CommandLine", "fdbserver -r simulation")
-				.detail("BuggifyEnabled", buggifyActivated)
+				.detail("BuggifyEnabled", isBuggifyEnabled(BuggifyType::General))
 				.detail("Simulated", true)
 				.trackLatest("ProgramStart");
 
@@ -1416,7 +1415,10 @@ ACTOR void setupAndRun(std::string dataFolder, const char *testFile, bool reboot
 		std::string clusterFileDir = joinPath( dataFolder, g_random->randomUniqueID().toString() );
 		platform::createDirectory( clusterFileDir );
 		writeFile(joinPath(clusterFileDir, "fdb.cluster"), connFile.get().toString());
-		wait(timeoutError(runTests(Reference<ClusterConnectionFile>(new ClusterConnectionFile(joinPath(clusterFileDir, "fdb.cluster"))), TEST_TYPE_FROM_FILE, TEST_ON_TESTERS, testerCount, testFile, startingConfiguration), buggifyActivated ? 36000.0 : 5400.0));
+		wait(timeoutError(runTests(Reference<ClusterConnectionFile>(
+									   new ClusterConnectionFile(joinPath(clusterFileDir, "fdb.cluster"))),
+								   TEST_TYPE_FROM_FILE, TEST_ON_TESTERS, testerCount, testFile, startingConfiguration),
+						  isBuggifyEnabled(BuggifyType::General) ? 36000.0 : 5400.0));
 	} catch (Error& e) {
 		TraceEvent(SevError, "SetupAndRunError").error(e);
 	}

--- a/fdbserver/fdbserver.actor.cpp
+++ b/fdbserver/fdbserver.actor.cpp
@@ -1372,7 +1372,7 @@ int main(int argc, char* argv[]) {
 			if(buggifyOverride.present())
 				buggifyEnabled = buggifyOverride.get();
 		}
-		enableBuggify( buggifyEnabled );
+		enableBuggify(buggifyEnabled, BuggifyType::General);
 
 		delete FLOW_KNOBS;
 		delete SERVER_KNOBS;

--- a/flow/flow.h
+++ b/flow/flow.h
@@ -59,14 +59,19 @@ if (BUGGIFY) (
 )
 */
 
-extern double P_BUGGIFIED_SECTION_ACTIVATED, P_BUGGIFIED_SECTION_FIRES, P_EXPENSIVE_VALIDATION;
-int getSBVar(std::string file, int line);
-void enableBuggify(bool enabled);   // Currently controls buggification and (randomized) expensive validation
-bool validationIsEnabled();
+extern std::vector<double> P_BUGGIFIED_SECTION_ACTIVATED, P_BUGGIFIED_SECTION_FIRES;
+extern double P_EXPENSIVE_VALIDATION;
+enum class BuggifyType : uint8_t {
+	General=0, Client
+};
+bool isBuggifyEnabled(BuggifyType type);
+int getSBVar(std::string file, int line, BuggifyType);
+void enableBuggify(bool enabled, BuggifyType type);   // Currently controls buggification and (randomized) expensive validation
+bool validationIsEnabled(BuggifyType type);
 
-#define BUGGIFY_WITH_PROB(x) (getSBVar(__FILE__, __LINE__) && g_random->random01() < (x))
-#define BUGGIFY BUGGIFY_WITH_PROB(P_BUGGIFIED_SECTION_FIRES)
-#define EXPENSIVE_VALIDATION (validationIsEnabled() && g_random->random01() < P_EXPENSIVE_VALIDATION)
+#define BUGGIFY_WITH_PROB(x) (getSBVar(__FILE__, __LINE__, BuggifyType::General) && g_random->random01() < (x))
+#define BUGGIFY BUGGIFY_WITH_PROB(P_BUGGIFIED_SECTION_FIRES[int(BuggifyType::General)])
+#define EXPENSIVE_VALIDATION (validationIsEnabled(BuggifyType::General) && g_random->random01() < P_EXPENSIVE_VALIDATION)
 
 extern Optional<uint64_t> parse_with_suffix(std::string toparse, std::string default_unit = "");
 extern std::string format(const char* form, ...);


### PR DESCRIPTION
This PR will add a special client side buggify. The overall idea is that a user can enable this client-side buggify to test client libraries and layers.

If enabled, the client will start throwing errors with a configurable probability. This way an application or layer implementer can test that her exception handling works correctly.