### PR TITLE
Overall framework and first buggify entries

### DIFF
--- a/documentation/sphinx/source/client-testing.rst
+++ b/documentation/sphinx/source/client-testing.rst
@@ -2,6 +2,48 @@
 Client Testing
 ###############
 
+###################################
+Testing Error Handling with Buggify
+###################################
+
+FoundationDB clients need to handle errors correctly. Wrong error handling can lead to many bugs - in the worst case it can
+lead to a corrupted database. Because of this it is important that a application or layer author tests properly their
+application during failure scenarios. But this is non-trivial. In a developement environment cluster failures are very
+unlikely and it is therefore possible that certain types of exceptions are never tester in a controlled environment.
+
+The simplest way of testing for these kind of errors is a simple mechanism called ``Buggify``. If this option is enabled
+in the client, the client will randomly throw errors that an application might see in a production environment. Enable this
+option in testing will greatly improve the probabiliyty that error handling is tested properly.
+
+Options to Control Buggify
+==========================
+
+There are four network options to control the buggify behavior. By default, buggify is disabled (as it will behave in a way
+that is not desireable in a production environment). The options to control buggify are:
+
+- ``buggify_enable``
+  This option takes no argument and will enable buggify.
+- ``buggify_disable``
+  This can be used to disable buggify again.
+- ``client_buggify_section_activated_probability`` (default ``25``)
+  A number between 0 and 100.
+- ``client_buggify_section_fired_probability`` (default ``25``)
+  A number between 0 and 100.
+
+The way buggify works is by enabling sections in the code first that get only executed with a certain probability. Generally
+these code sections will simply introduce a synthetic error.
+
+When a section is passed for the first time, the client library will decide randomly whether that code section will be enabled
+or not. It will be enabled with a probability of ``client_buggify_section_activated_probability``.
+
+Whenever the client executes a buggify-enabled code-block, it will randomly execute it. This is to make sure that a certain
+exception doesn't always fire. The probably for executing such a section is ``client_buggify_section_fired_probability``.
+
+################################
+Simulation and Cluster Workloads
+################################
+
+
 FoundationDB comes with its own testing framework. Tests are implemented as workloads. A workload is nothing more than a class
 that gets called by server processes running the ``tester`` role. Additionally, a ``fdbserver`` process can run a simulator that
 simulates a full fdb cluster with several machines and different configurations in one process. This simulator can run the same

--- a/documentation/sphinx/source/client-testing.rst
+++ b/documentation/sphinx/source/client-testing.rst
@@ -7,7 +7,7 @@ Testing Error Handling with Buggify
 ###################################
 
 FoundationDB clients need to handle errors correctly. Wrong error handling can lead to many bugs - in the worst case it can
-lead to a corrupted database. Because of this it is important that a application or layer author tests properly their
+lead to a corrupted database. Because of this it is important that an application or layer author tests properly their
 application during failure scenarios. But this is non-trivial. In a developement environment cluster failures are very
 unlikely and it is therefore possible that certain types of exceptions are never tester in a controlled environment.
 

--- a/documentation/sphinx/source/client-testing.rst
+++ b/documentation/sphinx/source/client-testing.rst
@@ -9,7 +9,7 @@ Testing Error Handling with Buggify
 FoundationDB clients need to handle errors correctly. Wrong error handling can lead to many bugs - in the worst case it can
 lead to a corrupted database. Because of this it is important that an application or layer author tests properly their
 application during failure scenarios. But this is non-trivial. In a developement environment cluster failures are very
-unlikely and it is therefore possible that certain types of exceptions are never tester in a controlled environment.
+unlikely and it is therefore possible that certain types of exceptions are never tested in a controlled environment.
 
 The simplest way of testing for these kind of errors is a simple mechanism called ``Buggify``. If this option is enabled
 in the client, the client will randomly throw errors that an application might see in a production environment. Enable this

--- a/documentation/sphinx/source/client-testing.rst
+++ b/documentation/sphinx/source/client-testing.rst
@@ -13,7 +13,7 @@ unlikely and it is therefore possible that certain types of exceptions are never
 
 The simplest way of testing for these kind of errors is a simple mechanism called ``Buggify``. If this option is enabled
 in the client, the client will randomly throw errors that an application might see in a production environment. Enable this
-option in testing will greatly improve the probabiliyty that error handling is tested properly.
+option in testing will greatly improve the probability that error handling is tested properly.
 
 Options to Control Buggify
 ==========================

--- a/documentation/sphinx/source/client-testing.rst
+++ b/documentation/sphinx/source/client-testing.rst
@@ -19,7 +19,7 @@ Options to Control Buggify
 ==========================
 
 There are four network options to control the buggify behavior. By default, buggify is disabled (as it will behave in a way
-that is not desireable in a production environment). The options to control buggify are:
+that is not desirable in a production environment). The options to control buggify are:
 
 - ``buggify_enable``
   This option takes no argument and will enable buggify.

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -1005,11 +1005,11 @@ void setNetworkOption(FDBNetworkOptions::Option option, Optional<StringRef> valu
 		case FDBNetworkOptions::CLIENT_BUGGIFY_SECTION_ACTIVATED_PROBABILITY:
 			validateOptionValue(value, true);
 			clearBuggifySections(BuggifyType::Client);
-			P_BUGGIFIED_SECTION_ACTIVATED[int(BuggifyType::Client)] = 100.0/double(extractIntOption(value, 0, 100));
+			P_BUGGIFIED_SECTION_ACTIVATED[int(BuggifyType::Client)] = double(extractIntOption(value, 0, 100))/100.0;
 			break;
 		case FDBNetworkOptions::CLIENT_BUGGIFY_SECTION_FIRED_PROBABILITY:
 			validateOptionValue(value, true);
-			P_BUGGIFIED_SECTION_FIRES[int(BuggifyType::Client)] = 100.0/double(extractIntOption(value, 0, 100));
+			P_BUGGIFIED_SECTION_FIRES[int(BuggifyType::Client)] = double(extractIntOption(value, 0, 100))/100.0;
 			break;
 		case FDBNetworkOptions::DISABLE_CLIENT_STATISTICS_LOGGING:
 			validateOptionValue(value, false);

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -1387,7 +1387,13 @@ ACTOR Future<Optional<Value>> getValue( Future<Version> version, Key key, Databa
 			startTime = timer_int();
 			startTimeD = now();
 			++cx->transactionPhysicalReads;
-			state GetValueReply reply = wait( loadBalance( ssi.second, &StorageServerInterface::getValue, GetValueRequest(key, ver, getValueID), TaskDefaultPromiseEndpoint, false, cx->enableLocalityLoadBalance ? &cx->queueModel : NULL ) );
+			if (CLIENT_BUGGIFY) {
+				throw deterministicRandom()->randomChoice(
+					std::vector<Error>{ transaction_too_old(), future_version() });
+			}
+			state GetValueReply reply = wait(
+			    loadBalance(ssi.second, &StorageServerInterface::getValue, GetValueRequest(key, ver, getValueID),
+			                TaskDefaultPromiseEndpoint, false, cx->enableLocalityLoadBalance ? &cx->queueModel : NULL));
 			double latency = now() - startTimeD;
 			cx->readLatencies.addSample(latency);
 			if (trLogInfo) {

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -2670,6 +2670,7 @@ ACTOR static Future<Void> tryCommit( Database cx, Reference<TransactionLogInfo> 
 		throw deterministicRandom()->randomChoice(std::vector<Error>{
 				not_committed(),
 				transaction_too_old(),
+				proxy_memory_limit_exceeded(),
 				commit_unknown_result()});
 	}
 

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -996,6 +996,20 @@ void setNetworkOption(FDBNetworkOptions::Option option, Optional<StringRef> valu
 				throw invalid_option_value();
 			}
 			break;
+		case FDBNetworkOptions::CLIENTBUGGIFY_ENABLE:
+			enableBuggify(true, BuggifyType::Client);
+			break;
+		case FDBNetworkOptions::CLIENTBUGGIFY_DISABLE:
+			enableBuggify(false, BuggifyType::Client);
+			break;
+		case FDBNetworkOptions::CLIENTBUGGIFY_SECTION_ACTIVATED_PROBABILITY:
+			validateOptionValue(value, true);
+			P_BUGGIFIED_SECTION_ACTIVATED[int(BuggifyType::Client)] = 100.0/double(extractIntOption(value, 0, 100));
+			break;
+		case FDBNetworkOptions::CLIENTBUGGIFY_SECTION_FIRED_PROBABILITY:
+			validateOptionValue(value, true);
+			P_BUGGIFIED_SECTION_FIRES[int(BuggifyType::Client)] = 100.0/double(extractIntOption(value, 0, 100));
+			break;
 		case FDBNetworkOptions::DISABLE_CLIENT_STATISTICS_LOGGING:
 			validateOptionValue(value, false);
 			networkOptions.logClientInfo = false;
@@ -1862,6 +1876,11 @@ ACTOR Future<Standalone<RangeResultRef>> getRange( Database cx, Reference<Transa
 				}
 
 				++cx->transactionPhysicalReads;
+				if (CLIENT_BUGGIFY) {
+					throw deterministicRandom()->randomChoice(std::vector<Error>{
+							transaction_too_old(), future_version()
+								});
+				}
 				GetKeyValuesReply rep = wait( loadBalance(beginServer.second, &StorageServerInterface::getKeyValues, req, TaskDefaultPromiseEndpoint, false, cx->enableLocalityLoadBalance ? &cx->queueModel : NULL ) );
 
 				if( info.debugID.present() ) {
@@ -2646,6 +2665,13 @@ ACTOR static Future<Void> tryCommit( Database cx, Reference<TransactionLogInfo> 
 	if (info.debugID.present())
 		TraceEvent(interval.begin()).detail( "Parent", info.debugID.get() );
 
+	if(CLIENT_BUGGIFY) {
+		throw deterministicRandom()->randomChoice(std::vector<Error>{
+				not_committed(),
+				transaction_too_old(),
+				commit_unknown_result()});
+	}
+
 	try {
 		Version v = wait( readVersion );
 		req.transaction.read_snapshot = v;
@@ -3096,6 +3122,9 @@ Future<Version> Transaction::getReadVersion(uint32_t flags) {
 		batcher.actor = readVersionBatcher( cx.getPtr(), batcher.stream.getFuture(), flags );
 	}
 	if (!readVersion.isValid()) {
+		if (CLIENT_BUGGIFY) {
+			throw database_locked();
+		}
 		Promise<GetReadVersionReply> p;
 		batcher.stream.send( std::make_pair( p, info.debugID ) );
 		startTime = now();

--- a/fdbclient/NativeAPI.actor.h
+++ b/fdbclient/NativeAPI.actor.h
@@ -36,6 +36,8 @@
 #include "fdbclient/ClientLogEvents.h"
 #include "flow/actorcompiler.h" // has to be last include
 
+// CLIENT_BUGGIFY should be used to randomly introduce failures at run time (like BUGGIFY but for client side testing)
+// Unlike BUGGIFY, CLIENT_BUGGIFY can be enabled and disabled at runtime.
 #define CLIENT_BUGGIFY_WITH_PROB(x) (getSBVar(__FILE__, __LINE__, BuggifyType::Client) && deterministicRandom()->random01() < (x))
 #define CLIENT_BUGGIFY CLIENT_BUGGIFY_WITH_PROB(P_BUGGIFIED_SECTION_FIRES[int(BuggifyType::Client)])
 

--- a/fdbclient/NativeAPI.actor.h
+++ b/fdbclient/NativeAPI.actor.h
@@ -36,6 +36,9 @@
 #include "fdbclient/ClientLogEvents.h"
 #include "flow/actorcompiler.h" // has to be last include
 
+#define CLIENT_BUGGIFY_WITH_PROB(x) (getSBVar(__FILE__, __LINE__, BuggifyType::Client) && deterministicRandom()->random01() < (x))
+#define CLIENT_BUGGIFY CLIENT_BUGGIFY_WITH_PROB(P_BUGGIFIED_SECTION_FIRES[int(BuggifyType::Client)])
+
 // Incomplete types that are reference counted
 class DatabaseContext;
 template <> void addref( DatabaseContext* ptr );

--- a/fdbclient/vexillographer/fdb.options
+++ b/fdbclient/vexillographer/fdb.options
@@ -111,7 +111,7 @@ description is not currently required but encouraged.
     <Option name="enable_slow_task_profiling" code="71"
             description="Enables debugging feature to perform slow task profiling. Requires trace logging to be enabled. WARNING: this feature is not recommended for use in production." />
     <Option name="client_buggify_enable" code="80"
-            description="Enable client buggify - will make requests randomly fail (intendet for client testing)" />
+            description="Enable client buggify - will make requests randomly fail (intended for client testing)" />
     <Option name="client_buggify_disable" code="81"
             description="Disable client buggify" />
     <Option name="client_buggify_section_activated_probability" code="82"

--- a/fdbclient/vexillographer/fdb.options
+++ b/fdbclient/vexillographer/fdb.options
@@ -110,16 +110,16 @@ description is not currently required but encouraged.
             description="Disables logging of client statistics, such as sampled transaction activity." />
     <Option name="enable_slow_task_profiling" code="71"
             description="Enables debugging feature to perform slow task profiling. Requires trace logging to be enabled. WARNING: this feature is not recommended for use in production." />
-    <Option name="ClientBuggify_enable" code="80"
+    <Option name="client_buggify_enable" code="80"
             description="" />
-    <Option name="ClientBuggify_disable" code="81"
+    <Option name="client_buggify_disable" code="81"
             description="" />
-    <Option name="ClientBuggify_section_activated_probability" code="82"
+    <Option name="client_buggify_section_activated_probability" code="82"
             paramType="Int" paramDescription="probability expressed as a percentage between 0 and 100"
             description="Set the probability of a CLIENT_BUGGIFY section being active for the current execution.  Only applies to code paths first traversed AFTER this option is changed." />
-    <Option name="ClientBuggify_section_fired_probability" code="83"
+    <Option name="client_buggify_section_fired_probability" code="83"
             paramType="Int" paramDescription="probability expressed as a percentage between 0 and 100"
-            description="Set the probability of an active CLIENT_BUGGIFY section being fired" />
+            description="Set the probability of an active CLIENT_BUGGIFY section being fired. A section will only fire if it was activated" />
     <Option name="supported_client_versions" code="1000"
             paramType="String" paramDescription="[release version],[source version],[protocol version];..."
             description="This option is set automatically to communicate the list of supported clients to the active client."

--- a/fdbclient/vexillographer/fdb.options
+++ b/fdbclient/vexillographer/fdb.options
@@ -110,6 +110,16 @@ description is not currently required but encouraged.
             description="Disables logging of client statistics, such as sampled transaction activity." />
     <Option name="enable_slow_task_profiling" code="71"
             description="Enables debugging feature to perform slow task profiling. Requires trace logging to be enabled. WARNING: this feature is not recommended for use in production." />
+    <Option name="ClientBuggify_enable" code="80"
+            description="" />
+    <Option name="ClientBuggify_disable" code="81"
+            description="" />
+    <Option name="ClientBuggify_section_activated_probability" code="82"
+            paramType="Int" paramDescription="probability expressed as a percentage between 0 and 100"
+            description="Set the probability of a CLIENT_BUGGIFY section being active for the current execution.  Only applies to code paths first traversed AFTER this option is changed." />
+    <Option name="ClientBuggify_section_fired_probability" code="83"
+            paramType="Int" paramDescription="probability expressed as a percentage between 0 and 100"
+            description="Set the probability of an active CLIENT_BUGGIFY section being fired" />
     <Option name="supported_client_versions" code="1000"
             paramType="String" paramDescription="[release version],[source version],[protocol version];..."
             description="This option is set automatically to communicate the list of supported clients to the active client."

--- a/fdbclient/vexillographer/fdb.options
+++ b/fdbclient/vexillographer/fdb.options
@@ -111,12 +111,12 @@ description is not currently required but encouraged.
     <Option name="enable_slow_task_profiling" code="71"
             description="Enables debugging feature to perform slow task profiling. Requires trace logging to be enabled. WARNING: this feature is not recommended for use in production." />
     <Option name="client_buggify_enable" code="80"
-            description="" />
+            description="Enable client buggify - will make requests randomly fail (intendet for client testing)" />
     <Option name="client_buggify_disable" code="81"
-            description="" />
+            description="Disable client buggify" />
     <Option name="client_buggify_section_activated_probability" code="82"
             paramType="Int" paramDescription="probability expressed as a percentage between 0 and 100"
-            description="Set the probability of a CLIENT_BUGGIFY section being active for the current execution.  Only applies to code paths first traversed AFTER this option is changed." />
+            description="Set the probability of a CLIENT_BUGGIFY section being active for the current execution." />
     <Option name="client_buggify_section_fired_probability" code="83"
             paramType="Int" paramDescription="probability expressed as a percentage between 0 and 100"
             description="Set the probability of an active CLIENT_BUGGIFY section being fired. A section will only fire if it was activated" />

--- a/fdbserver/fdbserver.actor.cpp
+++ b/fdbserver/fdbserver.actor.cpp
@@ -1425,7 +1425,7 @@ int main(int argc, char* argv[]) {
 			if(buggifyOverride.present())
 				buggifyEnabled = buggifyOverride.get();
 		}
-		enableBuggify( buggifyEnabled );
+		enableBuggify(buggifyEnabled, BuggifyType::General);
 
 		delete FLOW_KNOBS;
 		delete SERVER_KNOBS;

--- a/flow/flow.cpp
+++ b/flow/flow.cpp
@@ -207,19 +207,25 @@ Standalone<StringRef> addVersionStampAtEnd(StringRef const& str) {
 	return r;
 }
 
-bool buggifyActivated = false;
-std::map<std::pair<std::string,int>, int> SBVars;
+namespace {
 
-double P_BUGGIFIED_SECTION_ACTIVATED = .25,
-	P_BUGGIFIED_SECTION_FIRES = .25,
-	P_EXPENSIVE_VALIDATION = .05;
+std::vector<bool> buggifyActivated{false, false};
+std::map<BuggifyType, std::map<std::pair<std::string,int>, int>> typedSBVars;
 
-int getSBVar(std::string file, int line){
-	if (!buggifyActivated) return 0;
+}
+
+std::vector<double> P_BUGGIFIED_SECTION_ACTIVATED{.25, .25};
+std::vector<double> P_BUGGIFIED_SECTION_FIRES{.25, .25};
+
+double P_EXPENSIVE_VALIDATION = .05;
+
+int getSBVar(std::string file, int line, BuggifyType type){
+	if (!buggifyActivated[int(type)]) return 0;
 
 	const auto &flPair = std::make_pair(file, line);
+	auto& SBVars = typedSBVars[type];
 	if (!SBVars.count(flPair)){
-		SBVars[flPair] = deterministicRandom()->random01() < P_BUGGIFIED_SECTION_ACTIVATED;
+		SBVars[flPair] = deterministicRandom()->random01() < P_BUGGIFIED_SECTION_ACTIVATED[int(type)];
 		g_traceBatch.addBuggify( SBVars[flPair], line, file );
 		if( g_network ) g_traceBatch.dump();
 	}
@@ -227,12 +233,16 @@ int getSBVar(std::string file, int line){
 	return SBVars[flPair];
 }
 
-bool validationIsEnabled() {
-	return buggifyActivated;
+bool validationIsEnabled(BuggifyType type) {
+	return buggifyActivated[int(type)];
 }
 
-void enableBuggify( bool enabled ) {
-	buggifyActivated = enabled;
+bool isBuggifyEnabled(BuggifyType type) {
+	return buggifyActivated[int(type)];
+}
+
+void enableBuggify(bool enabled, BuggifyType type) {
+	buggifyActivated[int(type)] = enabled;
 }
 
 TEST_CASE("/flow/FlatBuffers/ErrorOr") {

--- a/flow/flow.cpp
+++ b/flow/flow.cpp
@@ -233,6 +233,10 @@ int getSBVar(std::string file, int line, BuggifyType type){
 	return SBVars[flPair];
 }
 
+void clearBuggifySections(BuggifyType type) {
+	typedSBVars[type].clear();
+}
+
 bool validationIsEnabled(BuggifyType type) {
 	return buggifyActivated[int(type)];
 }

--- a/flow/flow.h
+++ b/flow/flow.h
@@ -68,14 +68,19 @@ if (BUGGIFY) (
 )
 */
 
-extern double P_BUGGIFIED_SECTION_ACTIVATED, P_BUGGIFIED_SECTION_FIRES, P_EXPENSIVE_VALIDATION;
-int getSBVar(std::string file, int line);
-void enableBuggify(bool enabled);   // Currently controls buggification and (randomized) expensive validation
-bool validationIsEnabled();
+extern std::vector<double> P_BUGGIFIED_SECTION_ACTIVATED, P_BUGGIFIED_SECTION_FIRES;
+extern double P_EXPENSIVE_VALIDATION;
+enum class BuggifyType : uint8_t {
+	General=0, Client
+};
+bool isBuggifyEnabled(BuggifyType type);
+int getSBVar(std::string file, int line, BuggifyType);
+void enableBuggify(bool enabled, BuggifyType type);   // Currently controls buggification and (randomized) expensive validation
+bool validationIsEnabled(BuggifyType type);
 
-#define BUGGIFY_WITH_PROB(x) (getSBVar(__FILE__, __LINE__) && deterministicRandom()->random01() < (x))
-#define BUGGIFY BUGGIFY_WITH_PROB(P_BUGGIFIED_SECTION_FIRES)
-#define EXPENSIVE_VALIDATION (validationIsEnabled() && deterministicRandom()->random01() < P_EXPENSIVE_VALIDATION)
+#define BUGGIFY_WITH_PROB(x) (getSBVar(__FILE__, __LINE__, BuggifyType::General) && deterministicRandom()->random01() < (x))
+#define BUGGIFY BUGGIFY_WITH_PROB(P_BUGGIFIED_SECTION_FIRES[int(BuggifyType::General)])
+#define EXPENSIVE_VALIDATION (validationIsEnabled(BuggifyType::General) && deterministicRandom()->random01() < P_EXPENSIVE_VALIDATION)
 
 extern Optional<uint64_t> parse_with_suffix(std::string toparse, std::string default_unit = "");
 extern std::string format(const char* form, ...);

--- a/flow/flow.h
+++ b/flow/flow.h
@@ -74,6 +74,7 @@ enum class BuggifyType : uint8_t {
 	General=0, Client
 };
 bool isBuggifyEnabled(BuggifyType type);
+void clearBuggifySections(BuggifyType type);
 int getSBVar(std::string file, int line, BuggifyType);
 void enableBuggify(bool enabled, BuggifyType type);   // Currently controls buggification and (randomized) expensive validation
 bool validationIsEnabled(BuggifyType type);


### PR DESCRIPTION
This PR will add a special client side buggify. The overall idea is that a user can enable this client-side buggify to test client libraries and layers.

If enabled, the client will start throwing errors with a configurable probability. This way an application or layer implementer can test that her exception handling works correctly.