### PR TITLE
Fix OPEN_FOR_IDE build errors

### DIFF
--- a/fdbrpc/AsyncFileKAIO.actor.h
+++ b/fdbrpc/AsyncFileKAIO.actor.h
@@ -794,8 +794,8 @@ ACTOR Future<Void> runTestOps(Reference<IAsyncFile> f, int numIterations, int fi
 }
 
 TEST_CASE("/fdbrpc/AsyncFileKAIO/RequestList") {
-	if (!g_network
-	         ->isSimulated()) { // This test does nothing in simulation because simulation doesn't support AsyncFileKAIO
+	// This test does nothing in simulation because simulation doesn't support AsyncFileKAIO
+	if (!g_network->isSimulated()) {
 		state Reference<IAsyncFile> f;
 		try {
 			Reference<IAsyncFile> f_ = wait(AsyncFileKAIO::open(

--- a/fdbrpc/AsyncFileKAIO.actor.h
+++ b/fdbrpc/AsyncFileKAIO.actor.h
@@ -795,8 +795,11 @@ ACTOR Future<Void> runTestOps(Reference<IAsyncFile> f, int numIterations, int fi
 
 TEST_CASE("/fdbrpc/AsyncFileKAIO/RequestList") {
 	if(!g_network->isSimulated()) { // This test does nothing in simulation because simulation doesn't support AsyncFileKAIO
+		state Reference<IAsyncFile> f;
 		try {
-			state Reference<IAsyncFile> f = wait(AsyncFileKAIO::open("/tmp/__KAIO_TEST_FILE__", IAsyncFile::OPEN_UNBUFFERED | IAsyncFile::OPEN_READWRITE | IAsyncFile::OPEN_CREATE, 0666, nullptr));
+			f = wait(AsyncFileKAIO::open(
+			    "/tmp/__KAIO_TEST_FILE__",
+			    IAsyncFile::OPEN_UNBUFFERED | IAsyncFile::OPEN_READWRITE | IAsyncFile::OPEN_CREATE, 0666, nullptr));
 			state int fileSize = 2<<27; // ~100MB
 			wait(f->truncate(fileSize));
 

--- a/fdbserver/DataDistribution.actor.h
+++ b/fdbserver/DataDistribution.actor.h
@@ -255,4 +255,5 @@ ACTOR Future<Void> teamRemover(DDTeamCollection* self);
 ACTOR Future<Void> teamRemoverPeriodic(DDTeamCollection* self);
 ACTOR Future<vector<std::pair<StorageServerInterface, ProcessClass>>> getServerListAndProcessClasses(Transaction* tr);
 
+#include "flow/unactorcompiler.h"
 #endif

--- a/fdbserver/workloads/KillRegion.actor.cpp
+++ b/fdbserver/workloads/KillRegion.actor.cpp
@@ -18,7 +18,6 @@
  * limitations under the License.
  */
 
-#include "flow/actorcompiler.h"
 #include "fdbclient/NativeAPI.actor.h"
 #include "fdbserver/TesterInterface.actor.h"
 #include "fdbserver/WorkerInterface.actor.h"
@@ -27,6 +26,7 @@
 #include "fdbserver/ServerDBInfo.h"
 #include "fdbrpc/simulator.h"
 #include "fdbclient/ManagementAPI.actor.h"
+#include "flow/actorcompiler.h" // This must be the last include.
 
 struct KillRegionWorkload : TestWorkload {
 	bool enabled;

--- a/flow/Profiler.actor.cpp
+++ b/flow/Profiler.actor.cpp
@@ -32,6 +32,7 @@
 #include <link.h>
 
 #include "flow/Platform.h"
+#include "flow/actorcompiler.h" // This must be the last include.
 
 extern volatile thread_local int profilingEnabled;
 


### PR DESCRIPTION
Make IDEs happy again.

This also counts as more evidence that we should build cmake with -DOPEN_FOR_IDE=1 before merging PRs