### PR TITLE
Recovery optimization

### DIFF
--- a/fdbserver/IKeyValueStore.h
+++ b/fdbserver/IKeyValueStore.h
@@ -57,6 +57,7 @@ public:
 	virtual void resyncLog() {}
 
 	virtual void enableSnapshot() {}
+
 	/*
 	Concurrency contract
 		Causal consistency:

--- a/fdbserver/KeyValueStoreMemory.actor.cpp
+++ b/fdbserver/KeyValueStoreMemory.actor.cpp
@@ -552,7 +552,7 @@ private:
 						.detail("Mutations", dbgMutationCount)
 						.detail("Commits", dbgCommitCount)
 						.detail("EndsAt", self->log->getNextReadLocation());
-					loggingDelay = delay(1.0);
+						loggingDelay = delay(1.0);
 				}
 
 				Void _ = wait( yield() );

--- a/fdbserver/WorkerInterface.h
+++ b/fdbserver/WorkerInterface.h
@@ -334,7 +334,8 @@ Future<Void> storageServer(
 				StorageServerInterface const& ssi,
 				Reference<AsyncVar<ServerDBInfo>> const& db,
 				std::string const& folder,
-				Promise<Void> const& recovered);  // changes pssi->id() to be the recovered ID
+				Promise<Void> const& recovered,
+				Reference<ClusterConnectionFile> const& connFile );  // changes pssi->id() to be the recovered ID
 Future<Void> masterServer( MasterInterface const& mi, Reference<AsyncVar<ServerDBInfo>> const& db, class ServerCoordinators const&, LifetimeToken const& lifetime, bool const& forceRecovery );
 Future<Void> masterProxyServer(MasterProxyInterface const& proxy, InitializeMasterProxyRequest const& req, Reference<AsyncVar<ServerDBInfo>> const& db);
 Future<Void> tLog( class IKeyValueStore* const& persistentData, class IDiskQueue* const& persistentQueue, Reference<AsyncVar<ServerDBInfo>> const& db, LocalityData const& locality, PromiseStream<InitializeTLogRequest> const& tlogRequests, UID const& tlogId, bool const& restoreFromDisk, Promise<Void> const& oldLog, Promise<Void> const& recovered );  // changes tli->id() to be the recovered ID

--- a/fdbserver/worker.actor.cpp
+++ b/fdbserver/worker.actor.cpp
@@ -374,7 +374,7 @@ ACTOR Future<Void> storageServerRollbackRebooter( Future<Void> prevStorageServer
 		DUMPTOKEN(recruited.getKeyValueStoreType);
 		DUMPTOKEN(recruited.watchValue);
 
-		prevStorageServer = storageServer( store, recruited, db, folder, Promise<Void>() );
+		prevStorageServer = storageServer( store, recruited, db, folder, Promise<Void>(), Reference<ClusterConnectionFile> (nullptr) );
 		prevStorageServer = handleIOErrors(prevStorageServer, store, id, store->onClosed());
 	}
 }
@@ -598,7 +598,7 @@ ACTOR Future<Void> workerServer( Reference<ClusterConnectionFile> connFile, Refe
 				DUMPTOKEN(recruited.watchValue);
 
 				Promise<Void> recovery;
-				Future<Void> f = storageServer( kv, recruited, dbInfo, folder, recovery );
+				Future<Void> f = storageServer( kv, recruited, dbInfo, folder, recovery, connFile);
 				recoveries.push_back(recovery.getFuture());
 				f = handleIOErrors( f, kv, s.storeID, kvClosed );
 				f = storageServerRollbackRebooter( f, s.storeType, s.filename, recruited.id(), recruited.locality, dbInfo, folder, &filesClosed, memoryLimit, kv);


### PR DESCRIPTION
**Issue we(Wavefront) have:**
https://github.com/apple/foundationdb/issues/53
@panghy 

**Current solution:**
Based on branch [release-6.0](https://github.com/apple/foundationdb/tree/release-6.0) 
During recovery process for memory storage engine, we’ll check periodically whether the cluster is healthy or not (by calling StatusClient::statusFetcher(<file>)). If it’s healthy then abort recovery and join in as an empty node. Otherwise, keep going until it’s done. 