### PR TITLE
Do not start failure monitoring for local endpoints in getReplyUnless…

### DIFF
--- a/fdbrpc/fdbrpc.h
+++ b/fdbrpc/fdbrpc.h
@@ -310,12 +310,18 @@ public:
 	//   See IFailureMonitor::onFailedFor() for an explanation of the duration and slope parameters.
 	template <class X>
 	Future<ErrorOr<REPLY_TYPE(X)>> getReplyUnlessFailedFor(const X& value, double sustainedFailureDuration, double sustainedFailureSlope, int taskID) const {
-		return waitValueOrSignal(getReply(value, taskID), makeDependent<T>(IFailureMonitor::failureMonitor()).onFailedFor(getEndpoint(taskID), sustainedFailureDuration, sustainedFailureSlope), getEndpoint(taskID));
+		// If it is local endpoint, no need for failure monitoring
+		return waitValueOrSignal(getReply(value, taskID),
+				getEndpoint(taskID).isLocal() ? Never() : makeDependent<T>(IFailureMonitor::failureMonitor()).onFailedFor(getEndpoint(taskID), sustainedFailureDuration, sustainedFailureSlope),
+				getEndpoint(taskID));
 	}
 
 	template <class X>
 	Future<ErrorOr<REPLY_TYPE(X)>> getReplyUnlessFailedFor(const X& value, double sustainedFailureDuration, double sustainedFailureSlope) const {
-		return waitValueOrSignal(getReply(value), makeDependent<T>(IFailureMonitor::failureMonitor()).onFailedFor(getEndpoint(), sustainedFailureDuration, sustainedFailureSlope), getEndpoint());
+		// If it is local endpoint, no need for failure monitoring
+		return waitValueOrSignal(getReply(value),
+				getEndpoint().isLocal() ? Never() : makeDependent<T>(IFailureMonitor::failureMonitor()).onFailedFor(getEndpoint(), sustainedFailureDuration, sustainedFailureSlope),
+				getEndpoint());
 	}
 
 	template <class X>


### PR DESCRIPTION
…FailedFor.