### PR TITLE
Add simulated disk interface

### DIFF
--- a/fdbclient/StorageServerInterface.h
+++ b/fdbclient/StorageServerInterface.h
@@ -57,7 +57,6 @@ struct StorageServerInterface {
 	RequestStream<struct GetPhysicalMetricsRequest> getPhysicalMetrics;
 	RequestStream<ReplyPromise<Void>> waitFailure;
 	RequestStream<struct StorageQueuingMetricsRequest> getQueuingMetrics;
-	RequestStream<struct ChangeDiskRequest> changeDisk;
 
 	RequestStream<ReplyPromise<KeyValueStoreType>> getKeyValueStoreType;
 	RequestStream<struct WatchValueRequest> watchValue;
@@ -72,7 +71,7 @@ struct StorageServerInterface {
 		// StorageServerInterface is persisted in the database and in the tLog's data structures, so changes here have to be
 		// versioned carefully!
 		serializer(ar, uniqueID, locality, getVersion, getValue, getKey, getKeyValues, getShardState, waitMetrics,
-			splitMetrics, getPhysicalMetrics, waitFailure, getQueuingMetrics, changeDisk, getKeyValueStoreType);
+			splitMetrics, getPhysicalMetrics, waitFailure, getQueuingMetrics, getKeyValueStoreType);
 
 		if( ar.protocolVersion() >= 0x0FDB00A200090001LL )
 			serializer(ar, watchValue);
@@ -356,29 +355,6 @@ struct StorageQueuingMetricsReply {
 	template <class Ar>
 	void serialize(Ar& ar) {
 		serializer(ar, localTime, instanceID, bytesDurable, bytesInput, version, storageBytes, durableVersion, cpuUsage, diskUsage);
-	}
-};
-
-struct ChangeDiskRequest {
-	DiskType diskType;
-	ReplyPromise<struct ChangeDiskReply> reply;
-
-	ChangeDiskRequest(DiskType diskType = DiskType::Normal) : diskType(diskType) {}
-
-	template <class Ar>
-	void serialize(Ar& ar) {
-		serializer(ar, reply);
-	}
-};
-
-struct ChangeDiskReply {
-	bool success;
-
-	ChangeDiskReply(bool success = false) : success(success) {}
-
-	template <class Ar>
-	void serialize(Ar& ar) {
-		serializer(ar, success);
 	}
 };
 

--- a/fdbrpc/CMakeLists.txt
+++ b/fdbrpc/CMakeLists.txt
@@ -15,6 +15,7 @@ set(FDBRPC_SRCS
   genericactors.actor.h
   genericactors.actor.cpp
   IAsyncFile.actor.cpp
+  IDisk.cpp
   LoadBalance.actor.h
   Locality.cpp
   Net2FileSystem.cpp

--- a/fdbrpc/IDisk.cpp
+++ b/fdbrpc/IDisk.cpp
@@ -111,7 +111,7 @@ Reference<IDisk> createSimulatedDisk(DiskType diskType) {
         case DiskType::Normal:
             return Reference<IDisk>(new NormalDisk(FLOW_KNOBS->SIM_DISK_IOPS, FLOW_KNOBS->SIM_DISK_BANDWIDTH));
         case DiskType::Slow:
-            return Reference<IDisk>(new NormalDisk(FLOW_KNOBS->SIM_DISK_IOPS / 2, FLOW_KNOBS->SIM_DISK_BANDWIDTH / 2));
+            return Reference<IDisk>(new NormalDisk(FLOW_KNOBS->SIM_DISK_IOPS / 1e3, FLOW_KNOBS->SIM_DISK_BANDWIDTH / 1e3));
         case DiskType::Dead:
             return Reference<IDisk>(new NeverDisk());
         case DiskType::EBS:

--- a/fdbrpc/IDisk.cpp
+++ b/fdbrpc/IDisk.cpp
@@ -115,7 +115,7 @@ Reference<IDisk> createSimulatedDisk(DiskType diskType) {
             return Reference<IDisk>(new NormalDisk(FLOW_KNOBS->SIM_DISK_IOPS, FLOW_KNOBS->SIM_DISK_BANDWIDTH));
         case DiskType::Slow:
             return Reference<IDisk>(new NormalDisk(FLOW_KNOBS->SIM_DISK_IOPS / 1e3, FLOW_KNOBS->SIM_DISK_BANDWIDTH / 1e3));
-        case DiskType::Dead:
+        case DiskType::Never:
             return Reference<IDisk>(new NeverDisk());
         case DiskType::Empty:
             return Reference<IDisk>(new EmptyDisk(FLOW_KNOBS->SIM_DISK_IOPS, FLOW_KNOBS->SIM_DISK_BANDWIDTH));

--- a/fdbrpc/IDisk.cpp
+++ b/fdbrpc/IDisk.cpp
@@ -85,6 +85,9 @@ struct NeverDisk : public IDisk, public ReferenceCounted<NeverDisk> {
 struct EmptyDisk : public NormalDisk, public ReferenceCounted<EmptyDisk> {
     void addref() override { ReferenceCounted<EmptyDisk>::addref(); };
     void delref() override { ReferenceCounted<EmptyDisk>::delref(); }
+
+    EmptyDisk(int64_t iops, int64_t bandwidth) : NormalDisk(iops, bandwidth) {}
+
     Future<int> override read(int h, void* data, int length) {
         memset(data, 0, length);
         return length;
@@ -114,6 +117,8 @@ Reference<IDisk> createSimulatedDisk(DiskType diskType) {
             return Reference<IDisk>(new NormalDisk(FLOW_KNOBS->SIM_DISK_IOPS / 1e3, FLOW_KNOBS->SIM_DISK_BANDWIDTH / 1e3));
         case DiskType::Dead:
             return Reference<IDisk>(new NeverDisk());
+        case DiskType::Empty:
+            return Reference<IDisk>(new EmptyDisk(FLOW_KNOBS->SIM_DISK_IOPS, FLOW_KNOBS->SIM_DISK_BANDWIDTH));
         case DiskType::EBS:
             return Reference<IDisk>(new EBSDisk(FLOW_KNOBS->SIM_DISK_IOPS, FLOW_KNOBS->SIM_DISK_BANDWIDTH));
         default:

--- a/fdbrpc/IDisk.cpp
+++ b/fdbrpc/IDisk.cpp
@@ -1,0 +1,80 @@
+/*
+ * IDisk.cpp
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2018 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "IDisk.h"
+#include "fdbrpc/simulator.h"
+#include "flow/FastRef.h"
+#include "flow/Knobs.h"
+//#include "flow/actorcompiler.h" // This must be the last #include.
+
+struct SimSSD : public IDisk, public ReferenceCounted<SimSSD> {
+	SimSSD(int64_t iops, int64_t bandwidth) :
+        nextOperation(0),
+        iops(iops),
+        bandwidth(bandwidth) {}
+	void addref() override { ReferenceCounted<SimSSD>::addref(); }
+	void delref() override { ReferenceCounted<SimSSD>::delref(); }
+    Future<Void> override waitUntilDiskReady(int64_t size, bool sync) {
+        if (g_simulator.connectionFailuresDisableDuration > 1e4)
+            return delay(0.0001);
+        if (nextOperation < now()) nextOperation = now();
+        nextOperation += (1.0 / iops) + (size / bandwidth);
+
+        double randomLatency;
+        if (sync) {
+            randomLatency = .005 + g_random->random01() * (BUGGIFY ? 1.0 : 0.010);
+        } else
+            randomLatency = 10 * g_random->random01() / iops;
+
+        return delayUntil(nextOperation + randomLatency);
+    }
+    Future<int> override read(int h, void* data, int length) {
+        return ::read(h, data, static_cast<unsigned int>(length));
+    }
+    Future<int> override write(int h, StringRef data) {
+        return ::write(h, static_cast<const void*>(data.begin()), data.size());
+    }
+
+private:
+    double nextOperation;
+    int64_t iops;
+    int64_t bandwidth;
+};
+
+struct NeverDisk : public IDisk, public ReferenceCounted<NeverDisk> {
+    void addref() override { ReferenceCounted<NeverDisk>::addref(); }
+    void delref() override { ReferenceCounted<NeverDisk>::delref(); }
+    Future<Void> override waitUntilDiskReady(int64_t size, bool sync) {
+        return Never();
+    }
+    Future<int> override read(int h, void* data, int length) {
+        return ::read(h, data, static_cast<unsigned int>(length));
+    }
+    Future<int> override write(int h, StringRef data) {
+        return ::write(h, static_cast<const void*>(data.begin()), data.size());
+    }
+};
+
+Reference<IDisk> createSimSSD() {
+    return Reference<IDisk>(new SimSSD(FLOW_KNOBS->SIM_DISK_IOPS, FLOW_KNOBS->SIM_DISK_BANDWIDTH));
+}
+Reference<IDisk> createNeverDisk() {
+    return Reference<IDisk>(new NeverDisk());
+}

--- a/fdbrpc/IDisk.cpp
+++ b/fdbrpc/IDisk.cpp
@@ -22,7 +22,13 @@
 #include "fdbrpc/simulator.h"
 #include "flow/FastRef.h"
 #include "flow/Knobs.h"
-//#include "flow/actorcompiler.h" // This must be the last #include.
+
+#if defined(_WIN32)
+#include <io.h>
+#elif defined(__unixish__)
+#define _read ::read
+#define _write ::write
+#endif
 
 struct NormalDisk : public IDisk, public ReferenceCounted<NormalDisk> {
 	NormalDisk(int64_t iops, int64_t bandwidth) :
@@ -35,10 +41,10 @@ struct NormalDisk : public IDisk, public ReferenceCounted<NormalDisk> {
         return waitUntilDiskReady(size, sync, 1);
     }
     Future<int> override read(int h, void* data, int length) {
-        return ::read(h, data, static_cast<unsigned int>(length));
+        return _read(h, data, static_cast<unsigned int>(length));
     }
     Future<int> override write(int h, StringRef data) {
-        return ::write(h, static_cast<const void*>(data.begin()), data.size());
+        return _write(h, static_cast<const void*>(data.begin()), data.size());
     }
 
 protected:

--- a/fdbrpc/IDisk.cpp
+++ b/fdbrpc/IDisk.cpp
@@ -96,7 +96,7 @@ struct EBSDisk : public NormalDisk, public ReferenceCounted<EBSDisk> {
     static const double constexpr epochLength = 1.0;
 
     EBSDisk(int64_t iops, int64_t bandwidth) : NormalDisk(iops, bandwidth) {}
-    
+
     void addref() override { ReferenceCounted<EBSDisk>::addref(); }
     void delref() override { ReferenceCounted<EBSDisk>::delref(); }
 

--- a/fdbrpc/IDisk.h
+++ b/fdbrpc/IDisk.h
@@ -39,7 +39,7 @@ struct IDisk {
 enum class DiskType {
 	Normal,
 	Slow,
-	Dead,
+	Never,
 	Empty,
 	EBS
 };

--- a/fdbrpc/IDisk.h
+++ b/fdbrpc/IDisk.h
@@ -45,4 +45,5 @@ enum class DiskType {
 
 Reference<IDisk> createSimulatedDisk(DiskType diskType);
 
+#include "flow/unactorcompiler.h"
 #endif

--- a/fdbrpc/IDisk.h
+++ b/fdbrpc/IDisk.h
@@ -1,0 +1,42 @@
+/*
+ * IDisk.h
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2018 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FDBRPC_IDISK_H
+#define FDBRPC_IDISK_H
+#pragma once
+
+#include "flow/flow.h"
+#include "flow/FastRef.h"
+#include "flow/Knobs.h"
+#include "flow/actorcompiler.h"  // This must be the last #include.
+
+struct IDisk {
+	virtual ~IDisk() = default;
+	virtual void addref() = 0;
+	virtual void delref() = 0;
+	virtual Future<Void> waitUntilDiskReady(int64_t size, bool sync) = 0;
+	virtual Future<int> read(int h, void* data, int length) = 0;
+	virtual Future<int> write(int h, StringRef data) = 0;
+};
+
+Reference<IDisk> createSimSSD();
+Reference<IDisk> createNeverDisk();
+
+#endif

--- a/fdbrpc/IDisk.h
+++ b/fdbrpc/IDisk.h
@@ -31,12 +31,19 @@ struct IDisk {
 	virtual ~IDisk() = default;
 	virtual void addref() = 0;
 	virtual void delref() = 0;
-	virtual Future<Void> waitUntilDiskReady(int64_t size, bool sync) = 0;
+	virtual Future<Void> waitUntilDiskReady(int64_t size, bool sync = false) = 0;
 	virtual Future<int> read(int h, void* data, int length) = 0;
 	virtual Future<int> write(int h, StringRef data) = 0;
 };
 
-Reference<IDisk> createSimSSD();
-Reference<IDisk> createNeverDisk();
+enum class DiskType {
+	Normal,
+	Slow,
+	Dead,
+	Empty,
+	EBS
+};
+
+Reference<IDisk> createSimulatedDisk(DiskType diskType);
 
 #endif

--- a/fdbrpc/IDisk.h
+++ b/fdbrpc/IDisk.h
@@ -40,8 +40,7 @@ enum class DiskType {
 	Normal,
 	Slow,
 	Never,
-	Empty,
-	EBS
+	Empty
 };
 
 Reference<IDisk> createSimulatedDisk(DiskType diskType);

--- a/fdbrpc/fdbrpc.vcxproj
+++ b/fdbrpc/fdbrpc.vcxproj
@@ -24,6 +24,7 @@
     <ClCompile Include="generated-constants.cpp" />
     <ClCompile Include="Platform.cpp" />
     <ClCompile Include="AsyncFileWriteChecker.cpp" />
+    <ClCompile Include="IDisk.cpp" />
     <ClCompile Include="libcoroutine\Common.c" />
     <ClCompile Include="libcoroutine\Coro.c" />
     <ClCompile Include="Locality.cpp" />
@@ -87,6 +88,7 @@
       <EnableCompile>false</EnableCompile>
     </ActorCompiler>
     <ClInclude Include="IAsyncFile.h" />
+    <ClInclude Include="IDisk.h" />
     <ClInclude Include="IRateControl.h" />
     <ClInclude Include="Platform.h" />
     <ClInclude Include="fdbrpc.h" />

--- a/fdbrpc/fdbrpc.vcxproj.filters
+++ b/fdbrpc/fdbrpc.vcxproj.filters
@@ -23,6 +23,7 @@
     <ActorCompiler Include="networksender.actor.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="IDisk.h" />
     <ClCompile Include="Locality.cpp" />
     <ClCompile Include="libcoroutine\Common.c">
       <Filter>libcoroutine</Filter>
@@ -83,6 +84,7 @@
     <ClCompile Include="ReplicationUtils.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="IDisk.h" />
     <ClInclude Include="LoadBalance.h" />
     <ClInclude Include="Locality.h" />
     <ClInclude Include="simulator.h" />

--- a/fdbrpc/sim2.actor.cpp
+++ b/fdbrpc/sim2.actor.cpp
@@ -540,8 +540,8 @@ private:
 			throw io_error();
 		}
 
-		unsigned int read_bytes = 0;
-		if( ( read_bytes = _read( self->h, data, (unsigned int) length ) ) == -1 ) {
+		int read_bytes = wait(g_simulator.getCurrentProcess()->machine->disk->read(self->h, data, (unsigned int) length));
+		if( read_bytes == -1 ) {
 			TraceEvent(SevWarn, "SimpleFileIOError").detail("Location", 2);
 			throw io_error();
 		}
@@ -576,8 +576,8 @@ private:
 			throw io_error();
 		}
 
-		unsigned int write_bytes = 0;
-		if ( ( write_bytes = _write( self->h, (void*)data.begin(), data.size() ) ) == -1 ) {
+		int write_bytes = wait(g_simulator.getCurrentProcess()->machine->disk->write(self->h, data));
+		if ( write_bytes == -1 ) {
 			TraceEvent(SevWarn, "SimpleFileIOError").detail("Location", 4);
 			throw io_error();
 		}

--- a/fdbrpc/sim2.actor.cpp
+++ b/fdbrpc/sim2.actor.cpp
@@ -1513,6 +1513,8 @@ public:
 
 		return (kt == ktMin);
 	}
+	virtual void override changeDisk(std::string desc, DiskType dt) { diskTypes[desc] = dt; }
+	virtual DiskType override getDiskType(std::string desc) { return diskTypes[desc]; }
 	virtual void clogInterface(const IPAddress& ip, double seconds, ClogMode mode = ClogDefault) {
 		if (mode == ClogDefault) {
 			double a = g_random->random01();
@@ -1674,6 +1676,9 @@ public:
 	//Whether or not yield has returned true during the current iteration of the run loop
 	bool yielded;
 	int yield_limit;  // how many more times yield may return false before next returning true
+
+private:
+	std::map<std::string, DiskType> diskTypes;
 };
 
 void startNewSimulator() {

--- a/fdbrpc/sim2.actor.cpp
+++ b/fdbrpc/sim2.actor.cpp
@@ -533,7 +533,7 @@ private:
 		if (randLog)
 			fprintf( randLog, "SFR1 %s %s %s %d %lld\n", self->dbgId.shortString().c_str(), self->filename.c_str(), opId.shortString().c_str(), length, offset );
 
-		wait( waitUntilDiskReady( self->diskParameters, length ) );
+		wait(g_simulator.getCurrentProcess()->machine->disk->waitUntilDiskReady(length));
 
 		if( _lseeki64( self->h, offset, SEEK_SET ) == -1 ) {
 			TraceEvent(SevWarn, "SimpleFileIOError").detail("Location", 1);
@@ -569,7 +569,7 @@ private:
 		}
 
 		if(self->delayOnWrite)
-			wait( waitUntilDiskReady( self->diskParameters, data.size() ) );
+			wait(g_simulator.getCurrentProcess()->machine->disk->waitUntilDiskReady(data.size()));;
 
 		if( _lseeki64( self->h, offset, SEEK_SET ) == -1 ) {
 			TraceEvent(SevWarn, "SimpleFileIOError").detail("Location", 3);
@@ -605,7 +605,7 @@ private:
 			fprintf( randLog, "SFT1 %s %s %s %lld\n", self->dbgId.shortString().c_str(), self->filename.c_str(), opId.shortString().c_str(), size );
 
 		if(self->delayOnWrite)
-			wait( waitUntilDiskReady( self->diskParameters, 0 ) );
+			wait(g_simulator.getCurrentProcess()->machine->disk->waitUntilDiskReady(0));
 
 		if( _chsize( self->h, (long) size ) == -1 ) {
 			TraceEvent(SevWarn, "SimpleFileIOError").detail("Location", 6);
@@ -627,7 +627,7 @@ private:
 			fprintf( randLog, "SFC1 %s %s %s\n", self->dbgId.shortString().c_str(), self->filename.c_str(), opId.shortString().c_str());
 
 		if(self->delayOnWrite)
-			wait( waitUntilDiskReady( self->diskParameters, 0, true ) );
+			wait(g_simulator.getCurrentProcess()->machine->disk->waitUntilDiskReady(0, true));
 
 		if (self->flags & OPEN_ATOMIC_WRITE_AND_CREATE) {
 			self->flags &= ~OPEN_ATOMIC_WRITE_AND_CREATE;
@@ -659,7 +659,7 @@ private:
 		if (randLog)
 			fprintf(randLog, "SFS1 %s %s %s\n", self->dbgId.shortString().c_str(), self->filename.c_str(), opId.shortString().c_str());
 
-		wait( waitUntilDiskReady( self->diskParameters, 0 ) );
+		wait(g_simulator.getCurrentProcess()->machine->disk->waitUntilDiskReady(0));
 
 		int64_t pos = _lseeki64( self->h, 0L, SEEK_END );
 		if( pos == -1 ) {

--- a/fdbrpc/simulator.h
+++ b/fdbrpc/simulator.h
@@ -133,10 +133,10 @@ public:
 		Optional<Standalone<StringRef>>	machineId;
 		Reference<IDisk> disk;
 
-		MachineInfo() : machineProcess(0), disk(Reference<IDisk>(createSimSSD())) {}
+		MachineInfo() : machineProcess(0), disk(createSimulatedDisk(DiskType::Normal)) {}
 
-		void killDisk() {
-			disk = Reference<IDisk>(createNeverDisk());
+		void changeDisk(DiskType diskType) {
+			disk = createSimulatedDisk(diskType);
 		}
 	};
 

--- a/fdbrpc/simulator.h
+++ b/fdbrpc/simulator.h
@@ -26,6 +26,7 @@
 #include "fdbrpc/FailureMonitor.h"
 #include "fdbrpc/Locality.h"
 #include "fdbrpc/IAsyncFile.h"
+#include "fdbrpc/IDisk.h"
 #include "flow/TDMetric.actor.h"
 #include <random>
 #include "fdbrpc/ReplicationPolicy.h"
@@ -130,8 +131,13 @@ public:
 		std::set<std::string> deletingFiles;
 		std::set<std::string> closingFiles;
 		Optional<Standalone<StringRef>>	machineId;
+		Reference<IDisk> disk;
 
-		MachineInfo() : machineProcess(0) {}
+		MachineInfo() : machineProcess(0), disk(Reference<IDisk>(createSimSSD())) {}
+
+		void killDisk() {
+			disk = Reference<IDisk>(createNeverDisk());
+		}
 	};
 
 	ProcessInfo* getProcess( Endpoint const& endpoint ) { return getProcessByAddress(endpoint.getPrimaryAddress()); }

--- a/fdbrpc/simulator.h
+++ b/fdbrpc/simulator.h
@@ -155,6 +155,8 @@ public:
 	virtual bool killMachine(Optional<Standalone<StringRef>> machineId, KillType kt, bool forceKill = false, KillType* ktFinal = NULL) = 0;
 	virtual bool killZone(Optional<Standalone<StringRef>> zoneId, KillType kt, bool forceKill = false, KillType* ktFinal = NULL) = 0;
 	virtual bool killDataCenter(Optional<Standalone<StringRef>> dcId, KillType kt, bool forceKill = false, KillType* ktFinal = NULL) = 0;
+	virtual void changeDisk(std::string desc, DiskType dt) = 0;
+	virtual DiskType getDiskType(std::string desc) = 0;
 	//virtual KillType getMachineKillState( UID zoneID ) = 0;
 	virtual bool canKillProcesses(std::vector<ProcessInfo*> const& availableProcesses, std::vector<ProcessInfo*> const& deadProcesses, KillType kt, KillType* newKillType) const = 0;
 	virtual bool isAvailable() const = 0;

--- a/fdbrpc/simulator.h
+++ b/fdbrpc/simulator.h
@@ -335,17 +335,8 @@ extern ISimulator* g_pSimulator;
 
 void startNewSimulator();
 
-//Parameters used to simulate disk performance
-struct DiskParameters : ReferenceCounted<DiskParameters> {
-	double nextOperation;
-	int64_t iops;
-	int64_t bandwidth;
-
-	DiskParameters(int64_t iops, int64_t bandwidth) : nextOperation(0), iops(iops), bandwidth(bandwidth) { }
-};
-
 //Simulates delays for performing operations on disk
-extern Future<Void> waitUntilDiskReady(Reference<DiskParameters> parameters, int64_t size, bool sync = false);
+extern Future<Void> waitUntilDiskReady(int64_t size, bool sync = false);
 
 
 class Sim2FileSystem : public IAsyncFileSystem {

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -3441,6 +3441,11 @@ ACTOR Future<Void> storageServerCore( StorageServer* self, StorageServerInterfac
 			when (StorageQueuingMetricsRequest req = waitNext(ssi.getQueuingMetrics.getFuture())) {
 				getQueuingMetrics(self, req);
 			}
+			when (ChangeDiskRequest req = waitNext(ssi.changeDisk.getFuture())) {
+				ASSERT(g_network->isSimulated());
+				g_simulator.getCurrentProcess()->machine->changeDisk(req.diskType);
+				req.reply.send(ChangeDiskReply(true));
+			}
 			when( ReplyPromise<Version> reply = waitNext(ssi.getVersion.getFuture()) ) {
 				reply.send( self->version.get() );
 			}

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -2743,6 +2743,13 @@ ACTOR Future<Void> updateStorage(StorageServer* data) {
 		wait( data->desiredOldestVersion.whenAtLeast( data->storageVersion()+1 ) );
 		wait( delay(0, TaskUpdateStorage) );
 
+		if (g_network->isSimulated()) {
+			auto dt = g_pSimulator->getDiskType(data->thisServerID.toString().substr(0,16));
+			if (dt != DiskType::Normal) {
+				g_pSimulator->getCurrentProcess()->machine->changeDisk(dt);
+			}
+		}
+
 		state Promise<Void> durableInProgress;
 		data->durableInProgress = durableInProgress.getFuture();
 

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -3441,11 +3441,6 @@ ACTOR Future<Void> storageServerCore( StorageServer* self, StorageServerInterfac
 			when (StorageQueuingMetricsRequest req = waitNext(ssi.getQueuingMetrics.getFuture())) {
 				getQueuingMetrics(self, req);
 			}
-			when (ChangeDiskRequest req = waitNext(ssi.changeDisk.getFuture())) {
-				ASSERT(g_network->isSimulated());
-				g_simulator.getCurrentProcess()->machine->changeDisk(req.diskType);
-				req.reply.send(ChangeDiskReply(true));
-			}
 			when( ReplyPromise<Version> reply = waitNext(ssi.getVersion.getFuture()) ) {
 				reply.send( self->version.get() );
 			}


### PR DESCRIPTION
This addresses issue #1181.

This pull request creates an interface for a simulated disk, which can be used to test FDB's response to various disk failures in the simulator. For example, randomly slowing a single storage server's disk has been used to simulate the scenario where a single storage server's number of non-durable versions gradually grows over time. This is a scenario we at Snowflake hope to fix with a local ratekeeper.