### PR TITLE
Trace format fixes

### DIFF
--- a/flow/Trace.cpp
+++ b/flow/Trace.cpp
@@ -1218,3 +1218,8 @@ void TraceEventFields::validateFormat() const {
 		}
 	}
 }
+
+std::string traceableStringToString(const char* value, size_t S) {
+	ASSERT_WE_THINK(value[S - 1] == '\0');
+	return std::string(value, S - 1); // Exclude trailing \0 byte
+}

--- a/flow/Trace.h
+++ b/flow/Trace.h
@@ -294,7 +294,7 @@ struct TraceableString<char*> {
 
 template<class T>
 struct TraceableStringImpl : std::true_type {
-	static constexpr bool isPrintable(char c) { return c > 32 && c < 127; }
+	static constexpr bool isPrintable(char c) { return 32 <= c && c <= 126; }
 
 	template<class Str>
 	static std::string toString(Str&& value) {

--- a/flow/Trace.h
+++ b/flow/Trace.h
@@ -262,6 +262,8 @@ struct TraceableString<const char*> {
 	}
 };
 
+std::string traceableStringToString(const char* value, size_t S);
+
 template<size_t S>
 struct TraceableString<char[S]> {
 	static const char* begin(const char* value) {
@@ -272,9 +274,7 @@ struct TraceableString<char[S]> {
 		return iter - value == S - 1; // Exclude trailing \0 byte
 	}
 
-	static std::string toString(const char* value) {
-		return std::string(value, S - 1); // Exclude trailing \0 byte
-	}
+	static std::string toString(const char* value) { return traceableStringToString(value, S); }
 };
 
 template<>

--- a/flow/Trace.h
+++ b/flow/Trace.h
@@ -269,11 +269,11 @@ struct TraceableString<char[S]> {
 	}
 
 	static bool atEnd(const char* value, const char* iter) {
-		return iter - value == S;
+		return iter - value == S - 1; // Exclude trailing \0 byte
 	}
 
 	static std::string toString(const char* value) {
-		return std::string(value, S);
+		return std::string(value, S - 1); // Exclude trailing \0 byte
 	}
 };
 


### PR DESCRIPTION
This fixes two recently-introduced bugs:
1. space was previously not counted as a printable character
2. detailing string literals previously included the trailing `\0` byte

This introduces some weirdness for detailing char arrays of known size but I doubt anyone will notice. That said if you have some way to detect if something is a string literal at compile time please suggest it.