### PR TITLE
Fix consistency check shard estimate validation

### DIFF
--- a/documentation/sphinx/source/release-notes.rst
+++ b/documentation/sphinx/source/release-notes.rst
@@ -2,6 +2,14 @@
 Release Notes
 #############
 
+6.1.2
+=====
+
+Fixes
+-----
+
+* Consistency check could report inaccurate shard size estimates if there were enough keys with large values and a small number of keys with small values. `(PR #1468) <https://github.com/apple/foundationdb/pull/1468>`_.
+
 6.1.0
 =====
 


### PR DESCRIPTION
The consistency check tries to validate that our shard size estimate is sufficiently close to the actual size. It does this by computing a variance based on the sampling properties and checking for large differences relative to the standard deviation.

It attempts to avoid performing this check when there are not enough samples by requiring at least 30 keys in the sample. However, it is possible that almost all of your samples could come from keys with large values, which are included unconditionally. That means that they have no effect on this computed variance or the difference between the estimated and actual size of the shard.

Therefore, this check hinges on the properties of the keys that are included conditionally, but there was no check to make sure we had enough of them. This PR changes the check to require 30 keys in the sample that are not unconditional inclusions.