### PR TITLE
Fix unit test failure due to trace event names

### DIFF
--- a/flow/ActorCollection.actor.cpp
+++ b/flow/ActorCollection.actor.cpp
@@ -106,7 +106,7 @@ TEST_CASE("/flow/TraceEvent") {
 		doub.emplace_back(g_random->random01());
 		strIdx.emplace_back(g_random->randomInt(0, strings.size()));
 	}
-	TraceEvent("pairsfilled")
+	TraceEvent("PairsFilled")
 		.detail("MemoryUsage", getMemoryUsage());
 	printf("Sleeping for 20 seconds - attach perf now to PID %d\n", getpid());
 	wait(delay(20));
@@ -120,8 +120,8 @@ TEST_CASE("/flow/TraceEvent") {
 			TraceEvent("TestTraceLineNoDebug")
 				.detail("Num", num[idx])
 				.detail("Double", doub[idx])
-				.detail("str", strings[strIdx[idx]])
-				.detail("pair", p);
+				.detail("Str", strings[strIdx[idx]])
+				.detail("Pair", p);
 		}
 		wait(delay(0));
 	}
@@ -136,8 +136,8 @@ TEST_CASE("/flow/TraceEvent") {
 			TraceEvent(SevDebug, "TestTraceLineDebug")
 				.detail("Num", num[idx])
 				.detail("Double", doub[idx])
-				.detail("str", strings[strIdx[idx]])
-				.detail("pair", p);
+				.detail("Str", strings[strIdx[idx]])
+				.detail("Pair", p);
 		}
 		wait(delay(0));
 	}


### PR DESCRIPTION
Capitalize the first letter.

Saw errors like:
```
    <StdErrOutput Output="Trace event detail Type `pairsfilled' is invalid" Severity="40"/>
    <StdErrOutput Output="Trace event detail name `str' is invalid in:" Severity="40"/>
    <StdErrOutput Output="	&quot;Severity&quot;=&quot;10&quot;, &quot;Time&quot;=&quot;26.743637&quot;, &quot;Type&quot;=&quot;TestTraceLineNoDebug&quot;, &quot;Machine&quot;=&quot;[abcd::3:4:3:3]:1&quot;, " Severity="40"/>
    <StdErrOutput Output="Trace event detail name `pair' is invalid in:" Severity="40"/>
    <StdErrOutput Output="	&quot;Severity&quot;=&quot;10&quot;, &quot;Time&quot;=&quot;26.743637&quot;, &quot;Type&quot;=&quot;TestTraceLineNoDebug&quot;, &quot;Machine&quot;=&quot;[abcd::3:4:3:3]:1&quot;, " Severity="40"/>
    <StdErrOutput Output="Trace event detail name `str' is invalid in:" Severity="40"/>
    <StdErrOutput Output="	&quot;Severity&quot;=&quot;10&quot;, &quot;Time&quot;=&quot;26.743637&quot;, &quot;Type&quot;=&quot;TestTraceLineNoDebug&quot;, &quot;Machine&quot;=&quot;[abcd::3:4:3:3]:1&quot;, " Severity="40"/>
    <StdErrOutput Output="Trace event detail name `pair' is invalid in:" Severity="40"/>
    <StdErrOutput Output="	&quot;Severity&quot;=&quot;10&quot;, &quot;Time&quot;=&quot;26.743637&quot;, &quot;Type&quot;=&quot;TestTraceLineNoDebug&quot;, &quot;Machine&quot;=&quot;[abcd::3:4:3:3]:1&quot;, " Severity="40"/>
    <StdErrOutput Output="Trace event detail name `str' is invalid in:" Severity="40"/>
    <ExitCode Code="139" Severity="40"/>

```