### PR TITLE
Fix unused-variable warning in linux-only code

### DIFF
--- a/fdbrpc/AsyncFileKAIO.actor.h
+++ b/fdbrpc/AsyncFileKAIO.actor.h
@@ -639,7 +639,7 @@ private:
 
 	ACTOR static void poll( Reference<IEventFD> ev ) {
 		loop {
-			int64_t evfd_count = wait( ev->read() );
+			wait(success(ev->read()));
 
 			wait(delay(0, TaskDiskIOComplete));
 


### PR DESCRIPTION
I missed this one previously since I was compiling on osx.