### PR TITLE
Lower the priority of spilled peeks to below spilling

### DIFF
--- a/flow/network.h
+++ b/flow/network.h
@@ -51,7 +51,6 @@ enum {
 	TaskTLogPeek = 8590,
 	TaskTLogCommitReply = 8580,
 	TaskTLogCommit = 8570,
-	TaskTLogSpilledPeekReply = 8567,
 	TaskProxyGetRawCommittedVersion = 8565,
 	TaskProxyResolverReply = 8560,
 	TaskProxyCommitBatcher = 8550,
@@ -73,6 +72,7 @@ enum {
 	TaskDataDistribution = 3500,
 	TaskDiskWrite = 3010,
 	TaskUpdateStorage = 3000,
+	TaskTLogSpilledPeekReply = 2800,
 	TaskLowPriority = 2000,
 
 	TaskMinPriority = 1000


### PR DESCRIPTION
This prevents peeking from starving the TLog of CPU time to spill, and
thus impacting write throughput at prolonged saturation.