### PR TITLE
Fix doc building assumes 'foundationdb' top level dir

### DIFF
--- a/documentation/sphinx/conf.py
+++ b/documentation/sphinx/conf.py
@@ -53,7 +53,7 @@ copyright = u'2013-2018 Apple, Inc and the FoundationDB project authors'
 
 # Load the version information from 'versions.target'
 import xml.etree.ElementTree as ET
-version_path = os.path.join(os.path.dirname(__file__), '..', '..', '..', 'foundationdb', 'versions.target')
+version_path = os.path.join(os.path.dirname(__file__), '..', '..', 'versions.target')
 tree = ET.parse(version_path)
 root = tree.getroot()
 


### PR DESCRIPTION
When cloning repository without specifying the destination,
building documentation works fine. But it fail when the top
level directory is not 'foundatinodb'.

To reproduce:

```
git clone https://github.com/apple/foundationdb.git /tmp/apple-fdb
cd /tmp/apple-fdb/documentation/sphinx
make
```
will result in

```
Exception occurred:
File
"/Users/ssudakovich/.pyenv/versions/2.7.13/lib/python2.7/xml/etree/ElementTree.py", line 647, in parse
  source = open(source, "rb")
IOError: [Errno 2] No such file or directory: u'/private/tmp/apple_fdb/documentation/sphinx/../../../foundationdb/versions.target'
```