### PR TITLE
Highly prioritize storageServerRejoin messages on the proxy

### DIFF
--- a/documentation/sphinx/source/release-notes.rst
+++ b/documentation/sphinx/source/release-notes.rst
@@ -71,6 +71,7 @@ Fixes
 * Starting a restore on a tag already in-use would hang and the process would eventually run out of memory. `(PR #1394) <https://github.com/apple/foundationdb/pull/1394>`_
 * The ``proxy_memory_limit_exceeded`` error was treated as retryable, but ``fdb_error_predicate`` returned that it is not retryable. `(PR #1438) <https://github.com/apple/foundationdb/pull/1438>`_.
 * Consistency check could report inaccurate shard size estimates if there were enough keys with large values and a small number of keys with small values. [6.1.3] `(PR #1468) <https://github.com/apple/foundationdb/pull/1468>`_.
+* Storage servers could not rejoin the cluster when the proxies were saturated. [6.1.3] `(PR #1486) <https://github.com/apple/foundationdb/pull/1486>`_.
 
 Status
 ------

--- a/fdbclient/MasterProxyInterface.h
+++ b/fdbclient/MasterProxyInterface.h
@@ -65,6 +65,7 @@ struct MasterProxyInterface {
 		getConsistentReadVersion.getEndpoint(TaskProxyGetConsistentReadVersion);
 		getRawCommittedVersion.getEndpoint(TaskProxyGetRawCommittedVersion);
 		commit.getEndpoint(TaskProxyCommitDispatcher);
+		getStorageServerRejoinInfo.getEndpoint(TaskProxyStorageRejoin);
 		//getKeyServersLocations.getEndpoint(TaskProxyGetKeyServersLocations); //do not increase the priority of these requests, because clients cans bring down the cluster with too many of these messages.
 	}
 };

--- a/flow/network.h
+++ b/flow/network.h
@@ -44,6 +44,7 @@ enum {
 	TaskFailureMonitor = 8700,
 	TaskResolutionMetrics = 8700,
 	TaskClusterController = 8650,
+	TaskProxyStorageRejoin = 8645,
 	TaskProxyCommitDispatcher = 8640,
 	TaskTLogQueuingMetrics = 8620,
 	TaskTLogPop = 8610,


### PR DESCRIPTION
So that storage servers can rejoin the cluster even when a proxy is CPU saturated