### PR TITLE
Merge Removal of  Project Name Requirement Into Release

### DIFF
--- a/documentation/sphinx/conf.py
+++ b/documentation/sphinx/conf.py
@@ -53,7 +53,7 @@ copyright = u'2013-2018 Apple, Inc and the FoundationDB project authors'
 
 # Load the version information from 'versions.target'
 import xml.etree.ElementTree as ET
-version_path = os.path.join(os.path.dirname(__file__), '..', '..', '..', 'foundationdb', 'versions.target')
+version_path = os.path.join(os.path.dirname(__file__), '..', '..', 'versions.target')
 tree = ET.parse(version_path)
 root = tree.getroot()
 


### PR DESCRIPTION
Updated documentation configuration logic that locates versions.target so that parent directory does not have to be named foundationdb