### PR TITLE
Fixed Docker Package Requirements

### DIFF
--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -22,8 +22,8 @@ FROM ubuntu:18.04
 # Install dependencies
 
 RUN apt-get update && \
-	apt-get install -y curl=7.58.0-2ubuntu3.5 \
-	dnsutils=1:9.11.3+dfsg-1ubuntu1.3 && \
+	apt-get install -y curl>=7.58.0-2ubuntu3.6 \
+	dnsutils>=1:9.11.3+dfsg-1ubuntu1.7 && \
 	rm -r /var/lib/apt/lists/*
 
 # Install FoundationDB Binaries


### PR DESCRIPTION
Added support for allowing packages to be greater than current version to not require a Dockerfile update when current version is not included