### PR TITLE
cmake: use mcs over dmcs

### DIFF
--- a/cmake/EnableCsharp.cmake
+++ b/cmake/EnableCsharp.cmake
@@ -4,24 +4,14 @@ if(WIN32)
   enable_language(CSharp)
 else()
   # for other platforms we currently use mono
+
   find_program(MONO_EXECUTABLE mono)
-  find_program(MCS_EXECUTABLE dmcs)
+  if (NOT MONO_EXECUTABLE)
+    message(FATAL_ERROR "Could not find 'mono' executable!")
+  endif()
 
+  find_program(MCS_EXECUTABLE mcs)
   if (NOT MCS_EXECUTABLE)
-    find_program(MCS_EXECUTABLE mcs)
-  endif()
-
-  set(MONO_FOUND FALSE CACHE INTERNAL "")
-
-  if (NOT MCS_EXECUTABLE)
-    find_program(MCS_EXECUTABLE mcs)
-  endif()
-
-  if (MONO_EXECUTABLE AND MCS_EXECUTABLE)
-    set(MONO_FOUND True CACHE INTERNAL "")
-  endif()
-
-  if (NOT MONO_FOUND)
-    message(FATAL_ERROR "Could not find mono")
+    message(FATAL_ERROR "Could not find 'mcs' executable, which is part of Mono!")
   endif()
 endif()


### PR DESCRIPTION
This is essentially a port of #993 to the new CMake build system. It also simplifies the code a little. This fixes several warnings that pop up when building.