### PR TITLE
Fix print/scan format warnings from version size mismatches.

### DIFF
--- a/bindings/c/test/test.h
+++ b/bindings/c/test/test.h
@@ -26,6 +26,8 @@
 #include <string.h>
 #include <pthread.h>
 
+#include <inttypes.h>
+
 #ifndef FDB_API_VERSION
 #define FDB_API_VERSION 610
 #endif
@@ -125,7 +127,7 @@ void addError(struct ResultSet *rs, const char *message) {
 void writeResultSet(struct ResultSet *rs) {
 	uint64_t id = ((uint64_t)rand() << 32) + rand();
 	char name[100];
-	sprintf(name, "fdb-c_result-%llu.json", id);
+	sprintf(name, "fdb-c_result-%" SCNu64 ".json", id);
 	FILE *fp = fopen(name, "w");
 	if(!fp) {
 		fprintf(stderr, "Could not open results file %s\n", name);

--- a/bindings/flow/fdb_flow.actor.cpp
+++ b/bindings/flow/fdb_flow.actor.cpp
@@ -24,6 +24,7 @@
 #include "flow/SystemMonitor.h"
 
 #include <stdio.h>
+#include <cinttypes>
 
 using namespace FDB;
 
@@ -40,7 +41,7 @@ ACTOR Future<Void> _test() {
 	// tr->setVersion(1);
 
 	Version ver = wait( tr->getReadVersion() );
-	printf("%lld\n", ver);
+	printf("%" PRId64 "\n", ver);
 
 	state std::vector< Future<Version> > versions;
 

--- a/fdbbackup/backup.actor.cpp
+++ b/fdbbackup/backup.actor.cpp
@@ -42,6 +42,7 @@
 
 #include <stdarg.h>
 #include <stdio.h>
+#include <cinttypes>
 #include <algorithm>	// std::transform
 #include <string>
 #include <iostream>
@@ -1982,7 +1983,7 @@ ACTOR Future<Void> runRestore(std::string destClusterFile, std::string originalC
 
 		origDb = Database::createDatabase(originalClusterFile, Database::API_VERSION_LATEST);
 		Version v = wait(timeKeeperVersionFromDatetime(targetTimestamp, origDb.get()));
-		printf("Timestamp '%s' resolves to version %lld\n", targetTimestamp.c_str(), v);
+		printf("Timestamp '%s' resolves to version %" PRId64 "\n", targetTimestamp.c_str(), v);
 		targetVersion = v;
 	}
 
@@ -2007,7 +2008,7 @@ ACTOR Future<Void> runRestore(std::string destClusterFile, std::string originalC
 			targetVersion = desc.maxRestorableVersion.get();
 
 			if(verbose)
-				printf("Using target restore version %lld\n", targetVersion);
+				printf("Using target restore version %" PRId64 "\n", targetVersion);
 		}
 
 		if (performRestore) {
@@ -2015,18 +2016,18 @@ ACTOR Future<Void> runRestore(std::string destClusterFile, std::string originalC
 
 			if(waitForDone && verbose) {
 				// If restore is now complete then report version restored
-				printf("Restored to version %lld\n", restoredVersion);
+				printf("Restored to version %" PRId64 "\n", restoredVersion);
 			}
 		}
 		else {
 			state Optional<RestorableFileSet> rset = wait(bc->getRestoreSet(targetVersion));
 
 			if(!rset.present()) {
-				fprintf(stderr, "Insufficient data to restore to version %lld.  Describe backup for more information.\n", targetVersion);
+				fprintf(stderr, "Insufficient data to restore to version %" PRId64 ".  Describe backup for more information.\n", targetVersion);
 				throw restore_invalid_version();
 			}
 
-			printf("Backup can be used to restore to version %lld\n", targetVersion);
+			printf("Backup can be used to restore to version %" PRId64 "\n", targetVersion);
 		}
 
 	}
@@ -2060,7 +2061,7 @@ ACTOR Future<Void> dumpBackupData(const char *name, std::string destinationConta
 		}
 	}
 
-	printf("Scanning version range %lld to %lld\n", beginVersion, endVersion);
+	printf("Scanning version range %" PRId64 " to %" PRId64 "\n", beginVersion, endVersion);
 	BackupFileList files = wait(c->dumpFileList(beginVersion, endVersion));
 	files.toStream(stdout);
 
@@ -2112,9 +2113,9 @@ ACTOR Future<Void> expireBackupData(const char *name, std::string destinationCon
 		printf("\r%s%s\n", p.c_str(), (spaces > 0 ? std::string(spaces, ' ').c_str() : "") );
 
 		if(endVersion < 0)
-			printf("All data before %lld versions (%lld days) prior to latest backup log has been deleted.\n", -endVersion, -endVersion / ((int64_t)24 * 3600 * CLIENT_KNOBS->CORE_VERSIONSPERSECOND));
+			printf("All data before %" PRId64 " versions (%" PRId64 " days) prior to latest backup log has been deleted.\n", -endVersion, -endVersion / ((int64_t)24 * 3600 * CLIENT_KNOBS->CORE_VERSIONSPERSECOND));
 		else
-			printf("All data before version %lld has been deleted.\n", endVersion);
+			printf("All data before version %" PRId64 " has been deleted.\n", endVersion);
 	}
 	catch (Error& e) {
 		if(e.code() == error_code_actor_cancelled)
@@ -2452,7 +2453,7 @@ Version parseVersion(const char *str) {
 	}
 
 	Version ver;
-	if(sscanf(str, "%lld", &ver) != 1) {
+	if(sscanf(str, "%" SCNd64, &ver) != 1) {
 		fprintf(stderr, "Could not parse version: %s\n", str);
 		flushAndExit(FDB_EXIT_ERROR);
 	}

--- a/fdbcli/fdbcli.actor.cpp
+++ b/fdbcli/fdbcli.actor.cpp
@@ -40,6 +40,7 @@
 
 #include "fdbcli/FlowLineNoise.h"
 
+#include <cinttypes>
 #include <type_traits>
 #include <signal.h>
 
@@ -540,7 +541,7 @@ void initHelp() {
 void printVersion() {
 	printf("FoundationDB CLI " FDB_VT_PACKAGE_NAME " (v" FDB_VT_VERSION ")\n");
 	printf("source version %s\n", getHGVersion());
-	printf("protocol %llx\n", currentProtocolVersion);
+	printf("protocol %" PRIx64 "\n", currentProtocolVersion);
 }
 
 void printHelpOverview() {

--- a/fdbclient/FileBackupAgent.actor.cpp
+++ b/fdbclient/FileBackupAgent.actor.cpp
@@ -26,6 +26,7 @@
 #include "fdbclient/KeyBackedTypes.h"
 #include "fdbclient/JsonBuilder.h"
 
+#include <cinttypes>
 #include <ctime>
 #include <climits>
 #include "fdbrpc/IAsyncFile.h"
@@ -345,7 +346,7 @@ ACTOR Future<std::string> RestoreConfig::getProgress_impl(RestoreConfig restore,
 
 	std::string errstr = "None";
 	if(lastError.get().second != 0)
-		errstr = format("'%s' %llds ago.\n", lastError.get().first.c_str(), (tr->getReadVersion().get() - lastError.get().second) / CLIENT_KNOBS->CORE_VERSIONSPERSECOND );
+		errstr = format("'%s' %" PRId64 "s ago.\n", lastError.get().first.c_str(), (tr->getReadVersion().get() - lastError.get().second) / CLIENT_KNOBS->CORE_VERSIONSPERSECOND );
 
 	TraceEvent("FileRestoreProgress")
 		.detail("RestoreUID", uid)
@@ -4227,7 +4228,7 @@ public:
 			TraceEvent(SevWarn, "FileBackupAgentRestoreNotPossible")
 				.detail("BackupContainer", bc->getURL())
 				.detail("TargetVersion", targetVersion);
-			fprintf(stderr, "ERROR: Restore version %lld is not possible from %s\n", targetVersion, bc->getURL().c_str());
+			fprintf(stderr, "ERROR: Restore version %" PRId64 " is not possible from %s\n", targetVersion, bc->getURL().c_str());
 			throw restore_invalid_version();
 		}
 

--- a/fdbclient/ManagementAPI.actor.cpp
+++ b/fdbclient/ManagementAPI.actor.cpp
@@ -18,6 +18,8 @@
  * limitations under the License.
  */
 
+#include <cinttypes>
+
 #include "fdbclient/ManagementAPI.actor.h"
 
 #include "fdbclient/SystemData.h"
@@ -1347,7 +1349,7 @@ ACTOR Future<Void> printHealthyZone( Database cx ) {
 				printf("No ongoing maintenance.\n");
 			} else {
 				auto healthyZone = decodeHealthyZoneValue(val.get());
-				printf("Maintenance for zone %s will continue for %d seconds.\n", healthyZone.first.toString().c_str(), (healthyZone.second-tr.getReadVersion().get())/CLIENT_KNOBS->CORE_VERSIONSPERSECOND);
+				printf("Maintenance for zone %s will continue for %" PRId64 " seconds.\n", healthyZone.first.toString().c_str(), (healthyZone.second-tr.getReadVersion().get())/CLIENT_KNOBS->CORE_VERSIONSPERSECOND);
 			}
 			return Void();
 		} catch( Error &e ) {

--- a/fdbmonitor/fdbmonitor.cpp
+++ b/fdbmonitor/fdbmonitor.cpp
@@ -46,6 +46,7 @@
 #include <sys/time.h>
 #include <stdlib.h>
 
+#include <cinttypes>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
@@ -377,7 +378,7 @@ public:
 	Command() : argv(NULL) { }
 	Command(const CSimpleIni& ini, std::string _section, uint64_t id, fdb_fd_set fds, int* maxfd) : section(_section), argv(NULL), fork_retry_time(-1), quiet(false), delete_envvars(NULL), fds(fds), deconfigured(false), kill_on_configuration_change(true) {
 		char _ssection[strlen(section.c_str()) + 22];
-		snprintf(_ssection, strlen(section.c_str()) + 22, "%s.%llu", section.c_str(), id);
+		snprintf(_ssection, strlen(section.c_str()) + 22, "%s.%" PRIu64, section.c_str(), id);
 		ssection = _ssection;
 
 		for ( auto p : pipes ) {

--- a/fdbrpc/sim2.actor.cpp
+++ b/fdbrpc/sim2.actor.cpp
@@ -18,6 +18,8 @@
  * limitations under the License.
  */
 
+#include <cinttypes>
+
 #include "fdbrpc/simulator.h"
 #include "flow/IThreadPool.h"
 #include "flow/Util.h"
@@ -528,7 +530,7 @@ private:
 		        ( (uintptr_t)data % 4096 == 0 && length % 4096 == 0 && offset % 4096 == 0 ) );  // Required by KAIO.
 		state UID opId = g_random->randomUniqueID();
 		if (randLog)
-			fprintf( randLog, "SFR1 %s %s %s %d %lld\n", self->dbgId.shortString().c_str(), self->filename.c_str(), opId.shortString().c_str(), length, offset );
+			fprintf( randLog, "SFR1 %s %s %s %d %" PRId64 "\n", self->dbgId.shortString().c_str(), self->filename.c_str(), opId.shortString().c_str(), length, offset );
 
 		wait( waitUntilDiskReady( self->diskParameters, length ) );
 
@@ -562,7 +564,7 @@ private:
 		if (randLog) {
 			uint32_t a=0, b=0;
 			hashlittle2( data.begin(), data.size(), &a, &b );
-			fprintf( randLog, "SFW1 %s %s %s %d %d %lld\n", self->dbgId.shortString().c_str(), self->filename.c_str(), opId.shortString().c_str(), a, data.size(), offset );
+			fprintf( randLog, "SFW1 %s %s %s %d %d %" PRId64 "\n", self->dbgId.shortString().c_str(), self->filename.c_str(), opId.shortString().c_str(), a, data.size(), offset );
 		}
 
 		if(self->delayOnWrite)
@@ -599,7 +601,7 @@ private:
 	ACTOR static Future<Void> truncate_impl( SimpleFile* self, int64_t size ) {
 		state UID opId = g_random->randomUniqueID();
 		if (randLog)
-			fprintf( randLog, "SFT1 %s %s %s %lld\n", self->dbgId.shortString().c_str(), self->filename.c_str(), opId.shortString().c_str(), size );
+			fprintf( randLog, "SFT1 %s %s %s %" PRId64 "\n", self->dbgId.shortString().c_str(), self->filename.c_str(), opId.shortString().c_str(), size );
 
 		if(self->delayOnWrite)
 			wait( waitUntilDiskReady( self->diskParameters, 0 ) );
@@ -665,7 +667,7 @@ private:
 		}
 
 		if (randLog)
-			fprintf(randLog, "SFS2 %s %s %s %lld\n", self->dbgId.shortString().c_str(), self->filename.c_str(), opId.shortString().c_str(), pos);
+			fprintf(randLog, "SFS2 %s %s %s %" PRId64 "\n", self->dbgId.shortString().c_str(), self->filename.c_str(), opId.shortString().c_str(), pos);
 		INJECT_FAULT( io_error, "SimpleFile::size" );
 
 		return pos;
@@ -1622,7 +1624,7 @@ public:
 			//}
 
 			if (randLog)
-				fprintf( randLog, "T %f %d %s %lld\n", this->time, int(g_random->peek() % 10000), t.machine ? t.machine->name : "none", t.stable);
+				fprintf( randLog, "T %f %d %s %" PRId64 "\n", this->time, int(g_random->peek() % 10000), t.machine ? t.machine->name : "none", t.stable);
 		}
 	}
 

--- a/fdbserver/MemoryPager.actor.cpp
+++ b/fdbserver/MemoryPager.actor.cpp
@@ -18,6 +18,7 @@
  * limitations under the License.
  */
 
+#include <cinttypes>
 #include "fdbserver/MemoryPager.h"
 #include "fdbserver/Knobs.h"
 
@@ -339,7 +340,7 @@ bool validatePage(Reference<const IPage> page, LogicalPageID pageID, Version ver
 
 	Version readVersion = *(Version*)(page->begin()+sizeof(LogicalPageID));
 	if(readVersion != version) {
-		fprintf(stderr, "Invalid Version detected on page %u: %lld (expected %lld)\n", pageID, readVersion, version);
+		fprintf(stderr, "Invalid Version detected on page %u: %" PRId64 "(expected %" PRId64 ")\n", pageID, readVersion, version);
 		valid = false;
 	}
 

--- a/fdbserver/QuietDatabase.actor.cpp
+++ b/fdbserver/QuietDatabase.actor.cpp
@@ -18,6 +18,7 @@
  * limitations under the License.
  */
 
+#include <cinttypes>
 #include "flow/ActorCollection.h"
 #include "fdbrpc/simulator.h"
 #include "flow/Trace.h"
@@ -96,7 +97,7 @@ ACTOR Future<int64_t> getDataInFlight( Database cx, WorkerInterface distributorW
 		TraceEventFields md = wait( timeoutError(distributorWorker.eventLogRequest.getReply(
 			EventLogRequest( LiteralStringRef("TotalDataInFlight") ) ), 1.0 ) );
 		int64_t dataInFlight;
-		sscanf(md.getValue("TotalBytes").c_str(), "%lld", &dataInFlight);
+		sscanf(md.getValue("TotalBytes").c_str(), "%" SCNd64, &dataInFlight);
 		return dataInFlight;
 	} catch( Error &e ) {
 		TraceEvent("QuietDatabaseFailure", distributorWorker.id()).error(e).detail("Reason", "Failed to extract DataInFlight");
@@ -118,8 +119,8 @@ int64_t getQueueSize( const TraceEventFields& md ) {
 	double inputRoughness, durableRoughness;
 	int64_t inputBytes, durableBytes;
 
-	sscanf(md.getValue("BytesInput").c_str(), "%lf %lf %lld", &inputRate, &inputRoughness, &inputBytes);
-	sscanf(md.getValue("BytesDurable").c_str(), "%lf %lf %lld", &durableRate, &durableRoughness, &durableBytes);
+	sscanf(md.getValue("BytesInput").c_str(), "%lf %lf %" SCNd64, &inputRate, &inputRoughness, &inputBytes);
+	sscanf(md.getValue("BytesDurable").c_str(), "%lf %lf %" SCNd64, &durableRate, &durableRoughness, &durableBytes);
 
 	return inputBytes - durableBytes;
 }
@@ -239,11 +240,11 @@ ACTOR Future<int64_t> getDataDistributionQueueSize( Database cx, WorkerInterface
 		TraceEvent("DataDistributionQueueSize").detail("Stage", "GotString");
 
 		int64_t inQueue;
-		sscanf(movingDataMessage.getValue("InQueue").c_str(), "%lld", &inQueue);
+		sscanf(movingDataMessage.getValue("InQueue").c_str(), "%" SCNd64, &inQueue);
 
 		if(reportInFlight) {
 			int64_t inFlight;
-			sscanf(movingDataMessage.getValue("InFlight").c_str(), "%lld", &inFlight);
+			sscanf(movingDataMessage.getValue("InFlight").c_str(), "%" SCNd64, &inFlight);
 			inQueue += inFlight;
 		}
 
@@ -281,16 +282,16 @@ ACTOR Future<bool> getTeamCollectionValid(Database cx, WorkerInterface dataDistr
 			int64_t healthyMachineTeamCount;
 			int64_t desiredMachineTeamNumber;
 			int64_t maxMachineTeamNumber;
-			sscanf(teamCollectionInfoMessage.getValue("CurrentTeamNumber").c_str(), "%lld", &currentTeamNumber);
-			sscanf(teamCollectionInfoMessage.getValue("DesiredTeamNumber").c_str(), "%lld", &desiredTeamNumber);
-			sscanf(teamCollectionInfoMessage.getValue("MaxTeamNumber").c_str(), "%lld", &maxTeamNumber);
-			sscanf(teamCollectionInfoMessage.getValue("CurrentMachineTeamNumber").c_str(), "%lld",
+			sscanf(teamCollectionInfoMessage.getValue("CurrentTeamNumber").c_str(), "%" SCNd64, &currentTeamNumber);
+			sscanf(teamCollectionInfoMessage.getValue("DesiredTeamNumber").c_str(), "%" SCNd64, &desiredTeamNumber);
+			sscanf(teamCollectionInfoMessage.getValue("MaxTeamNumber").c_str(), "%" SCNd64, &maxTeamNumber);
+			sscanf(teamCollectionInfoMessage.getValue("CurrentMachineTeamNumber").c_str(), "%" SCNd64,
 			       &currentMachineTeamNumber);
-			sscanf(teamCollectionInfoMessage.getValue("CurrentHealthyMachineTeamNumber").c_str(), "%lld",
+			sscanf(teamCollectionInfoMessage.getValue("CurrentHealthyMachineTeamNumber").c_str(), "%" SCNd64,
 			       &healthyMachineTeamCount);
-			sscanf(teamCollectionInfoMessage.getValue("DesiredMachineTeams").c_str(), "%lld",
+			sscanf(teamCollectionInfoMessage.getValue("DesiredMachineTeams").c_str(), "%" SCNd64,
 			       &desiredMachineTeamNumber);
-			sscanf(teamCollectionInfoMessage.getValue("MaxMachineTeams").c_str(), "%lld", &maxMachineTeamNumber);
+			sscanf(teamCollectionInfoMessage.getValue("MaxMachineTeams").c_str(), "%" SCNd64, &maxMachineTeamNumber);
 
 			// Team number is always valid when we disable teamRemover. This avoids false positive in simulation test
 			if (SERVER_KNOBS->TR_FLAG_DISABLE_TEAM_REMOVER) {

--- a/fdbserver/Status.actor.cpp
+++ b/fdbserver/Status.actor.cpp
@@ -18,6 +18,7 @@
  * limitations under the License.
  */
 
+#include <cinttypes>
 #include "fdbserver/Status.h"
 #include "flow/Trace.h"
 #include "fdbclient/NativeAPI.actor.h"
@@ -169,7 +170,7 @@ public:
 	}
 
 	StatusCounter& parseText(const std::string& parsableText) {
-		sscanf(parsableText.c_str(), "%lf %lf %lld", &hz, &roughness, &counter);
+		sscanf(parsableText.c_str(), "%lf %lf %" SCNd64 "", &hz, &roughness, &counter);
 		return *this;
 	}
 
@@ -2351,7 +2352,7 @@ TEST_CASE("/status/json/builderPerf") {
 	}
 
 	double elapsed = generated + serialized;
-	printf("RESULT: %lld bytes  %d elements  %d levels  %f seconds (%f gen, %f serialize)  %f MB/s  %f items/s\n",
+	printf("RESULT: %" PRId64 " bytes  %d elements  %d levels  %f seconds (%f gen, %f serialize)  %f MB/s  %f items/s\n",
 		bytes, iterations*elements, level, elapsed, generated, elapsed - generated, bytes / elapsed / 1e6, iterations*elements / elapsed);
 
 	return Void();

--- a/fdbserver/VersionedBTree.actor.cpp
+++ b/fdbserver/VersionedBTree.actor.cpp
@@ -34,6 +34,7 @@
 #include "fdbserver/PrefixTree.h"
 #include <string.h>
 #include "flow/actorcompiler.h"
+#include <cinttypes>
 
 // Convenience method for converting a Standalone to a Ref while adding its arena to another arena.
 template<typename T> inline const Standalone<T> & dependsOn(Arena &arena, const Standalone<T> &s) {
@@ -2019,18 +2020,18 @@ ACTOR Future<int> verifyRandomRange(VersionedBTree *btree, Version v, std::map<s
 
 		if(iLast == iEnd) {
 			errors += 1;
-			printf("VerifyRange(@%lld, %s, %s) ERROR: Tree key '%s' vs nothing in written map.\n", v, start.toString().c_str(), end.toString().c_str(), cur->getKey().toString().c_str());
+			printf("VerifyRange(@%" PRId64 ", %s, %s) ERROR: Tree key '%s' vs nothing in written map.\n", v, start.toString().c_str(), end.toString().c_str(), cur->getKey().toString().c_str());
 			break;
 		}
 
 		if(cur->getKey() != iLast->first.first) {
 			errors += 1;
-			printf("VerifyRange(@%lld, %s, %s) ERROR: Tree key '%s' vs written '%s'\n", v, start.toString().c_str(), end.toString().c_str(), cur->getKey().toString().c_str(), iLast->first.first.c_str());
+			printf("VerifyRange(@%" PRId64 ", %s, %s) ERROR: Tree key '%s' vs written '%s'\n", v, start.toString().c_str(), end.toString().c_str(), cur->getKey().toString().c_str(), iLast->first.first.c_str());
 			break;
 		}
 		if(cur->getValue() != iLast->second.get()) {
 			errors += 1;
-			printf("VerifyRange(@%lld, %s, %s) ERROR: Tree key '%s' has tree value '%s' vs written '%s'\n", v, start.toString().c_str(), end.toString().c_str(), cur->getKey().toString().c_str(), cur->getValue().toString().c_str(), iLast->second.get().c_str());
+			printf("VerifyRange(@%" PRId64 ", %s, %s) ERROR: Tree key '%s' has tree value '%s' vs written '%s'\n", v, start.toString().c_str(), end.toString().c_str(), cur->getKey().toString().c_str(), cur->getValue().toString().c_str(), iLast->second.get().c_str());
 			break;
 		}
 
@@ -2057,10 +2058,10 @@ ACTOR Future<int> verifyRandomRange(VersionedBTree *btree, Version v, std::map<s
 
 	if(iLast != iEnd) {
 		errors += 1;
-		printf("VerifyRange(@%lld, %s, %s) ERROR: Tree range ended but written has @%lld '%s'\n", v, start.toString().c_str(), end.toString().c_str(), iLast->first.second, iLast->first.first.c_str());
+		printf("VerifyRange(@%" PRId64 ", %s, %s) ERROR: Tree range ended but written has @%" PRId64 " '%s'\n", v, start.toString().c_str(), end.toString().c_str(), iLast->first.second, iLast->first.first.c_str());
 	}
 
-	debug_printf("VerifyRangeReverse '%s' to '%s' @%lld\n", printable(start).c_str(), printable(end).c_str(), v);
+	debug_printf("VerifyRangeReverse '%s' to '%s' @%" PRId64 "\n", printable(start).c_str(), printable(end).c_str(), v);
 	// Randomly use a new cursor for the revere range read
 	if(g_random->coinflip()) {
 		cur = btree->readAtVersion(v);
@@ -2076,18 +2077,18 @@ ACTOR Future<int> verifyRandomRange(VersionedBTree *btree, Version v, std::map<s
 	while(cur->isValid() && cur->getKey() >= start) {
 		if(r == results.rend()) {
 			errors += 1;
-			printf("VerifyRangeReverse(@%lld, %s, %s) ERROR: Tree key '%s' vs nothing in written map.\n", v, start.toString().c_str(), end.toString().c_str(), cur->getKey().toString().c_str());
+			printf("VerifyRangeReverse(@%" PRId64 ", %s, %s) ERROR: Tree key '%s' vs nothing in written map.\n", v, start.toString().c_str(), end.toString().c_str(), cur->getKey().toString().c_str());
 			break;
 		}
 
 		if(cur->getKey() != r->key) {
 			errors += 1;
-			printf("VerifyRangeReverse(@%lld, %s, %s) ERROR: Tree key '%s' vs written '%s'\n", v, start.toString().c_str(), end.toString().c_str(), cur->getKey().toString().c_str(), r->key.toString().c_str());
+			printf("VerifyRangeReverse(@%" PRId64 ", %s, %s) ERROR: Tree key '%s' vs written '%s'\n", v, start.toString().c_str(), end.toString().c_str(), cur->getKey().toString().c_str(), r->key.toString().c_str());
 			break;
 		}
 		if(cur->getValue() != r->value) {
 			errors += 1;
-			printf("VerifyRangeReverse(@%lld, %s, %s) ERROR: Tree key '%s' has tree value '%s' vs written '%s'\n", v, start.toString().c_str(), end.toString().c_str(), cur->getKey().toString().c_str(), cur->getValue().toString().c_str(), r->value.toString().c_str());
+			printf("VerifyRangeReverse(@%" PRId64 ", %s, %s) ERROR: Tree key '%s' has tree value '%s' vs written '%s'\n", v, start.toString().c_str(), end.toString().c_str(), cur->getKey().toString().c_str(), cur->getValue().toString().c_str(), r->value.toString().c_str());
 			break;
 		}
 
@@ -2097,7 +2098,7 @@ ACTOR Future<int> verifyRandomRange(VersionedBTree *btree, Version v, std::map<s
 
 	if(r != results.rend()) {
 		errors += 1;
-		printf("VerifyRangeReverse(@%lld, %s, %s) ERROR: Tree range ended but written has '%s'\n", v, start.toString().c_str(), end.toString().c_str(), r->key.toString().c_str());
+		printf("VerifyRangeReverse(@%" PRId64 ", %s, %s) ERROR: Tree range ended but written has '%s'\n", v, start.toString().c_str(), end.toString().c_str(), r->key.toString().c_str());
 	}
 
 	return errors;
@@ -2124,16 +2125,16 @@ ACTOR Future<int> verifyAll(VersionedBTree *btree, Version maxCommittedVersion, 
 				if(!(cur->isValid() && cur->getKey() == key && cur->getValue() == val.get())) {
 					++errors;
 					if(!cur->isValid())
-						printf("Verify ERROR: key_not_found: '%s' -> '%s' @%lld\n", key.c_str(), val.get().c_str(), ver);
+						printf("Verify ERROR: key_not_found: '%s' -> '%s' @%" PRId64 "\n", key.c_str(), val.get().c_str(), ver);
 					else if(cur->getKey() != key)
-						printf("Verify ERROR: key_incorrect: found '%s' expected '%s' @%lld\n", cur->getKey().toString().c_str(), key.c_str(), ver);
+						printf("Verify ERROR: key_incorrect: found '%s' expected '%s' @%" PRId64 "\n", cur->getKey().toString().c_str(), key.c_str(), ver);
 					else if(cur->getValue() != val.get())
-						printf("Verify ERROR: value_incorrect: for '%s' found '%s' expected '%s' @%lld\n", cur->getKey().toString().c_str(), cur->getValue().toString().c_str(), val.get().c_str(), ver);
+						printf("Verify ERROR: value_incorrect: for '%s' found '%s' expected '%s' @%" PRId64 "\n", cur->getKey().toString().c_str(), cur->getValue().toString().c_str(), val.get().c_str(), ver);
 				}
 			} else {
 				if(cur->isValid() && cur->getKey() == key) {
 					++errors;
-					printf("Verify ERROR: cleared_key_found: '%s' -> '%s' @%lld\n", key.c_str(), cur->getValue().toString().c_str(), ver);
+					printf("Verify ERROR: cleared_key_found: '%s' -> '%s' @%" PRId64 "\n", key.c_str(), cur->getValue().toString().c_str(), ver);
 				}
 			}
 		}
@@ -2221,7 +2222,7 @@ TEST_CASE("!/redwood/correctness") {
 	state std::set<Key> keys;
 
 	state Version lastVer = wait(btree->getLatestVersion());
-	printf("Starting from version: %lld\n", lastVer);
+	printf("Starting from version: %" PRId64 "\n", lastVer);
 
 	state Version version = lastVer + 1;
 	state int mutationBytes = 0;
@@ -2324,7 +2325,7 @@ TEST_CASE("!/redwood/correctness") {
 				return Void();
 			});
 
-			printf("Cumulative: %d total mutation bytes, %lu key changes, %lld key bytes, %lld value bytes\n", mutationBytes, written.size(), keyBytesInserted, ValueBytesInserted);
+			printf("Cumulative: %d total mutation bytes, %lu key changes, %" PRId64 " key bytes, %" PRId64 " value bytes\n", mutationBytes, written.size(), keyBytesInserted, ValueBytesInserted);
 
 			// Recover from disk at random
 			if(useDisk && g_random->random01() < .1) {
@@ -2350,7 +2351,7 @@ TEST_CASE("!/redwood/correctness") {
 
 				Version v = wait(btree->getLatestVersion());
 				ASSERT(v == version);
-				printf("Recovered from disk.  Latest version %lld\n", v);
+				printf("Recovered from disk.  Latest version %" PRId64 "\n", v);
 
 				// Create new promise stream and start the verifier again
 				committedVersions = PromiseStream<Version>();
@@ -2422,7 +2423,7 @@ TEST_CASE("!/redwood/performance/set") {
 			wait(commit);
 			commit = btree->commit();
 			double elapsed = now() - startTime;
-			printf("Committed (cumulative) %lld bytes in %d records in %f seconds, %.2f MB/s\n", kvBytes, records, elapsed, kvBytes / elapsed / 1e6);
+			printf("Committed (cumulative) %" PRId64 " bytes in %d records in %f seconds, %.2f MB/s\n", kvBytes, records, elapsed, kvBytes / elapsed / 1e6);
 		}
 	}
 
@@ -2433,7 +2434,7 @@ TEST_CASE("!/redwood/performance/set") {
 	wait(closedFuture);
 
 	double elapsed = now() - startTime;
-	printf("Wrote (final) %lld bytes in %d records in %f seconds, %.2f MB/s\n", kvBytes, records, elapsed, kvBytes / elapsed / 1e6);
+	printf("Wrote (final) %" PRId64 " bytes in %d records in %f seconds, %.2f MB/s\n", kvBytes, records, elapsed, kvBytes / elapsed / 1e6);
 
 	return Void();
 }

--- a/fdbserver/fdbserver.actor.cpp
+++ b/fdbserver/fdbserver.actor.cpp
@@ -454,7 +454,7 @@ ACTOR Future<Void> dumpDatabase( Database cx, std::string outputFilename, KeyRan
 				state Arena arena;
 				fprintf(output, "<html><head><style type=\"text/css\">.binary {color:red}</style></head><body>\n");
 				Version ver = wait( tr.getReadVersion() );
-				fprintf(output, "<h3>Database version: %lld</h3>", ver);
+				fprintf(output, "<h3>Database version: %" PRId64 "</h3>", ver);
 
 				loop {
 					Standalone<RangeResultRef> results = wait(
@@ -507,7 +507,7 @@ void parentWatcher(void *parentHandle) {
 static void printVersion() {
 	printf("FoundationDB " FDB_VT_PACKAGE_NAME " (v" FDB_VT_VERSION ")\n");
 	printf("source version %s\n", getHGVersion());
-	printf("protocol %llx\n", currentProtocolVersion);
+	printf("protocol %" PRIx64 "\n", currentProtocolVersion);
 }
 
 static void printHelpTeaser( const char *name ) {

--- a/fdbserver/pubsub.actor.cpp
+++ b/fdbserver/pubsub.actor.cpp
@@ -18,6 +18,7 @@
  * limitations under the License.
  */
 
+#include <cinttypes>
 #include "fdbclient/NativeAPI.actor.h"
 #include "fdbserver/pubsub.h"
 #include "flow/actorcompiler.h"  // This must be the last #include.
@@ -27,7 +28,7 @@ Value uInt64ToValue( uint64_t v ) {
 }
 uint64_t valueToUInt64( const StringRef& v ) {
 	uint64_t x = 0;
-	sscanf( v.toString().c_str(), "%llx", &x );
+	sscanf( v.toString().c_str(), "%" SCNx64, &x );
 	return x;
 }
 

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -18,7 +18,7 @@
  * limitations under the License.
  */
 
-
+#include <cinttypes>
 #include "fdbrpc/fdbrpc.h"
 #include "fdbrpc/LoadBalance.h"
 #include "flow/IndexedSet.h"
@@ -2325,7 +2325,7 @@ void StorageServer::addMutation(Version version, MutationRef const& mutation, Ke
 			mutation.type == MutationRef::DebugKeyRange ? "DebugKeyRange" :
 			mutation.type == MutationRef::DebugKey ? "DebugKey" :
 			"UnknownMutation";
-		printf("DEBUGMUTATION:\t%.6f\t%s\t%s\t%lld\t%s\t%s\t%s\n", now(), g_network->getLocalAddress().toString().c_str(), "originalMutation", version, type, printable(mutation.param1).c_str(), printable(mutation.param2).c_str());
+		printf("DEBUGMUTATION:\t%.6f\t%s\t%s\t%" PRId64 "\t%s\t%s\t%s\n", now(), g_network->getLocalAddress().toString().c_str(), "originalMutation", version, type, printable(mutation.param1).c_str(), printable(mutation.param2).c_str());
 		printf("  shard: %s - %s\n", printable(shard.begin).c_str(), printable(shard.end).c_str());
 		if (mutation.type == MutationRef::ClearRange && mutation.param2 != shard.end)
 			printf("  eager: %s\n", printable( eagerReads->getKeyEnd( mutation.param2 ) ).c_str() );

--- a/fdbserver/tester.actor.cpp
+++ b/fdbserver/tester.actor.cpp
@@ -18,6 +18,7 @@
  * limitations under the License.
  */
 
+#include <cinttypes>
 #include <fstream>
 #include "flow/ActorCollection.h"
 #include "fdbrpc/sim_validation.h"
@@ -65,7 +66,7 @@ Key doubleToTestKey( double p ) {
 
 double testKeyToDouble( const KeyRef& p ) {
 	uint64_t x = 0;
-	sscanf( p.toString().c_str(), "%llx", &x );
+	sscanf( p.toString().c_str(), "%" SCNx64, &x );
 	return *(double*)&x;
 }
 
@@ -163,7 +164,7 @@ uint64_t getOption( VectorRef<KeyValueRef> options, Key key, uint64_t defaultVal
 	for(int i = 0; i < options.size(); i++)
 		if( options[i].key == key ) {
 			uint64_t r;
-			if( sscanf(options[i].value.toString().c_str(), "%lld", &r) ) {
+			if( sscanf(options[i].value.toString().c_str(), "%" SCNd64, &r) ) {
 				options[i].value = LiteralStringRef("");
 				return r;
 			} else {
@@ -179,7 +180,7 @@ int64_t getOption( VectorRef<KeyValueRef> options, Key key, int64_t defaultValue
 	for(int i = 0; i < options.size(); i++)
 		if( options[i].key == key ) {
 			int64_t r;
-			if( sscanf(options[i].value.toString().c_str(), "%lld", &r) ) {
+			if( sscanf(options[i].value.toString().c_str(), "%" SCNd64, &r) ) {
 				options[i].value = LiteralStringRef("");
 				return r;
 			} else {

--- a/fdbserver/workloads/ApiWorkload.actor.cpp
+++ b/fdbserver/workloads/ApiWorkload.actor.cpp
@@ -18,6 +18,7 @@
  * limitations under the License.
  */
 
+#include <cinttypes>
 #include "fdbserver/workloads/ApiWorkload.h"
 #include "fdbclient/MultiVersionTransaction.h"
 #include "flow/actorcompiler.h"  // This must be the last #include.
@@ -114,7 +115,7 @@ bool ApiWorkload::compareResults(VectorRef<KeyValueRef> dbResults, VectorRef<Key
 		for(int j = 0; j < storeResults.size(); j++)
 			printf("%d: %s %d\n", j, storeResults[j].key.toString().c_str(), storeResults[j].value.size());
 
-		printf("Read Version: %lld\n", readVersion);
+		printf("Read Version: %" PRId64 "\n", readVersion);
 
 		TraceEvent(SevError, format("%s_CompareSizeMismatch", description().c_str()).c_str()).detail("ReadVer", readVersion).detail("ResultSize", dbResults.size()).detail("StoreResultSize", storeResults.size());
 
@@ -134,7 +135,7 @@ bool ApiWorkload::compareResults(VectorRef<KeyValueRef> dbResults, VectorRef<Key
 			for(int j = 0; j < storeResults.size(); j++)
 				printf("%d: %s %d\n", j, storeResults[j].key.toString().c_str(), storeResults[j].value.size());
 
-			printf("Read Version: %lld\n", readVersion);
+			printf("Read Version: %" PRId64 "\n", readVersion);
 
 			TraceEvent(SevError, format("%s_CompareValueMismatch", description().c_str()).c_str()).detail("ReadVer", readVersion).detail("ResultSize", dbResults.size()).detail("DifferAt", i);
 

--- a/fdbserver/workloads/AsyncFileCorrectness.actor.cpp
+++ b/fdbserver/workloads/AsyncFileCorrectness.actor.cpp
@@ -18,6 +18,8 @@
  * limitations under the License.
  */
 
+#include <cinttypes>
+
 #include "fdbserver/workloads/workloads.actor.h"
 #include "flow/ActorCollection.h"
 #include "flow/SystemMonitor.h"
@@ -89,7 +91,7 @@ struct AsyncFileCorrectnessWorkload : public AsyncFileWorkload
 		if(maxOperationSize * numSimultaneousOperations > targetFileSize * 0.25)
 		{
 			targetFileSize *= (int)ceil((maxOperationSize * numSimultaneousOperations * 4.0) / targetFileSize);
-			printf("Target file size is insufficient to support %d simultaneous operations of size %d; changing to %lld\n", numSimultaneousOperations, maxOperationSize, targetFileSize);
+			printf("Target file size is insufficient to support %d simultaneous operations of size %d; changing to %" PRId64 "\n", numSimultaneousOperations, maxOperationSize, targetFileSize);
 		}
 	}
 
@@ -206,7 +208,7 @@ struct AsyncFileCorrectnessWorkload : public AsyncFileWorkload
 						//If we know what data should be in a particular range, then compare the result with what we know
 						if(isValid && memcmp(&self->fileValidityMask[info.offset + start], &info.data->buffer[start], i - start))
 						{
-							printf("Read returned incorrect results at %llu of length %llu\n", info.offset, info.length);
+							printf("Read returned incorrect results at %" PRIu64 " of length %" PRIu64 "\n", info.offset, info.length);
 
 							self->success = false;
 							return Void();
@@ -415,7 +417,7 @@ struct AsyncFileCorrectnessWorkload : public AsyncFileWorkload
 
 			if(numRead != std::min(info.length, self->fileSize - info.offset))
 			{
-				printf("Read reported incorrect number of bytes at %llu of length %llu\n", info.offset, info.length);
+				printf("Read reported incorrect number of bytes at %" PRIu64 " of length %" PRIu64 "\n", info.offset, info.length);
 				self->success = false;
 			}
 		}
@@ -456,12 +458,12 @@ struct AsyncFileCorrectnessWorkload : public AsyncFileWorkload
 			int64_t fileSizeChange = fileSize - self->fileSize;
 			if(fileSizeChange >= _PAGE_SIZE)
 			{
-				printf("Reopened file increased in size by %lld bytes (at most %d allowed)\n", fileSizeChange, _PAGE_SIZE - 1);
+				printf("Reopened file increased in size by %" PRId64 " bytes (at most %d allowed)\n", fileSizeChange, _PAGE_SIZE - 1);
 				self->success = false;
 			}
 			else if(fileSizeChange < 0)
 			{
-				printf("Reopened file decreased in size by %lld bytes\n", -fileSizeChange);
+				printf("Reopened file decreased in size by %" PRId64 " bytes\n", -fileSizeChange);
 				self->success = false;
 			}
 

--- a/fdbserver/workloads/DiskDurabilityTest.actor.cpp
+++ b/fdbserver/workloads/DiskDurabilityTest.actor.cpp
@@ -18,6 +18,7 @@
  * limitations under the License.
  */
 
+#include <cinttypes>
 #include "fdbserver/workloads/workloads.actor.h"
 #include "fdbrpc/IAsyncFile.h"
 #include "fdbclient/FDBTypes.h"
@@ -107,7 +108,7 @@ struct DiskDurabilityTest : TestWorkload {
 
 		if (failed) throw operation_failed();
 
-		printf("Verified %d/%lld pages\n", verifyPages, size/4096);
+		printf("Verified %d/%" PRId64 " pages\n", verifyPages, size/4096);
 		TraceEvent(SevInfo, "Verified").detail("Pages", verifyPages).detail("Of", size/4096);
 
 		// Run

--- a/fdbserver/workloads/KVStoreTest.actor.cpp
+++ b/fdbserver/workloads/KVStoreTest.actor.cpp
@@ -19,6 +19,7 @@
  */
 
 #include <ctime>
+#include <cinttypes>
 #include "fdbserver/workloads/workloads.actor.h"
 #include "fdbserver/IKeyValueStore.h"
 #include "flow/ActorCollection.h"
@@ -276,7 +277,7 @@ ACTOR Future<Void> testKVStoreMain( KVStoreTestWorkload* workload, KVTest* ptest
 		}
 		double elapsed = timer()-cst;
 		TraceEvent("KVStoreCount").detail("Count", count).detail("Took", elapsed);
-		printf("Counted: %lld in %0.1fs\n", count, elapsed);
+		printf("Counted: %" PRId64 " in %0.1fs\n", count, elapsed);
 	}
 
 	if (workload->doSetup) {

--- a/fdbserver/workloads/SlowTaskWorkload.actor.cpp
+++ b/fdbserver/workloads/SlowTaskWorkload.actor.cpp
@@ -18,6 +18,8 @@
  * limitations under the License.
  */
 
+#include <cinttypes>
+
 #include "fdbserver/workloads/workloads.actor.h"
 #include "flow/SignalSafeUnwind.h"
 #include "flow/actorcompiler.h"  // This must be the last #include.
@@ -56,7 +58,7 @@ struct SlowTaskWorkload : TestWorkload {
 				do_slow_exception_thing(&exc);
 			}
 		}
-		fprintf(stderr, "Slow task complete: %lld exceptions; %lld calls to dl_iterate_phdr\n", exc, dl_iterate_phdr_calls - phc);
+		fprintf(stderr, "Slow task complete: %" PRId64 " exceptions; %" PRId64 " calls to dl_iterate_phdr\n", exc, dl_iterate_phdr_calls - phc);
 		return Void();
 	}
 

--- a/flow/IndexedSet.cpp
+++ b/flow/IndexedSet.cpp
@@ -24,6 +24,7 @@
 #include "flow/IndexedSet.h"
 #include "flow/IRandom.h"
 #include "flow/ThreadPrimitives.h"
+#include <cinttypes>
 #include <algorithm>
 #include <set>
 #include <string>
@@ -401,7 +402,7 @@ TEST_CASE("/flow/IndexedSet/all numbers") {
 		int ib = ii != is.end() ? *ii : 1000000;
 		ASSERT(ib == b);
 		if (ib != b)
-			printf("%s %lld %d %d %lld\n", ib == b ? "OK" : "ERROR", n, b, ib, is.sumTo(ii));
+			printf("%s %" PRId64 " %d %d %" PRId64 "\n", ib == b ? "OK" : "ERROR", n, b, ib, is.sumTo(ii));
 	}
 
 	for (int i = 0; i<100000; i++) {
@@ -414,7 +415,7 @@ TEST_CASE("/flow/IndexedSet/all numbers") {
 		int64_t ntotal = int64_t(b - a)*(a + b - 1) / 2;
 		ASSERT(itotal == ntotal);
 		if (itotal != ntotal)
-			printf("%s %lld %lld\n", itotal == ntotal ? "OK" : "ERROR", ntotal, itotal);
+			printf("%s %" PRId64 " %" PRId64 "\n", itotal == ntotal ? "OK" : "ERROR", ntotal, itotal);
 	}
 
 	//double a = timer();

--- a/flow/Knobs.cpp
+++ b/flow/Knobs.cpp
@@ -21,6 +21,7 @@
 #include "flow/Knobs.h"
 #include "flow/flow.h"
 #include <cmath>
+#include <cinttypes>
 
 FlowKnobs const* FLOW_KNOBS = new FlowKnobs();
 
@@ -172,10 +173,10 @@ bool Knobs::setKnob( std::string const& knob, std::string const& value ) {
 		int64_t v;
 		int n=0;
 		if (StringRef(value).startsWith(LiteralStringRef("0x"))) {
-			if (sscanf(value.c_str(), "0x%llx%n", &v, &n) != 1 || n != value.size())
+			if (sscanf(value.c_str(), "0x%" SCNx64 "%n", &v, &n) != 1 || n != value.size())
 				throw invalid_option_value();
 		} else {
-			if (sscanf(value.c_str(), "%lld%n", &v, &n) != 1 || n != value.size())
+			if (sscanf(value.c_str(), "%" SCNd64 "%n", &v, &n) != 1 || n != value.size())
 				throw invalid_option_value();
 		}
 		if (int64_knobs.count(knob))

--- a/flow/flow.cpp
+++ b/flow/flow.cpp
@@ -20,6 +20,7 @@
 
 #include "flow/flow.h"
 #include <stdarg.h>
+#include <cinttypes>
 
 INetwork *g_network = 0;
 IRandom *g_random = 0;
@@ -36,7 +37,7 @@ std::string UID::toString() const {
 UID UID::fromString( std::string const& s ) {
 	ASSERT( s.size() == 32 );
 	uint64_t a=0, b=0;
-	int r = sscanf( s.c_str(), "%16llx%16llx", &a, &b );
+	int r = sscanf( s.c_str(), "%16" SCNx64 "%16" SCNx64, &a, &b );
 	ASSERT( r == 2 );
 	return UID(a, b);
 }


### PR DESCRIPTION
While building FoundationDB for Linux (because I want to try and add something), there were a number of compile-time warnings that popped up, entirely related to `scanf`/`printf` size mismatches.

The basic problem is that uses of format specifiers like `%lld` or `%llu` were given `long int` (resp. `unsigned long)` instead of their appropriate `long long` variants, etc.

It's problematic to get format specifiers correct due to LP64/LLP64 differences in platforms like Darwin/Unix vs Windows. Luckily, the `cinttypes` (from `inttypes.h`) header can alleviate this by giving us portable format specifiers for different sized values. This should be supported since `C++11` at least, which I believe has quite good support on all supported compilers. But I could be wrong, here.

With this, FoundationDB `master` builds cleanly with no warnings on NixOS Linux. I have yet to test this on macOS (which I do not have access to), and have not tested this on Windows (where I do), but eventually I would like to see FDB warning free here on all platforms if possible once this is achievable, barring any compiler problems.