### PR TITLE
Make the (cmake) build system more succinct unless VERBOSE=1 is set

### DIFF
--- a/cmake/FlowCommands.cmake
+++ b/cmake/FlowCommands.cmake
@@ -77,13 +77,22 @@ function(assert_no_version_h target)
 
   message(STATUS "Check versions.h on ${target}")
   set(target_name "${target}_versions_h_check")
-  add_custom_target("${target_name}"
-    COMMAND "${CMAKE_COMMAND}" -DFILE="${CMAKE_SOURCE_DIR}/versions.h"
+
+  if (DEFINED ENV{VERBOSE})
+    add_custom_target("${target_name}"
+      COMMAND "${CMAKE_COMMAND}" -DFILE="${CMAKE_SOURCE_DIR}/versions.h"
                                -P "${CMAKE_SOURCE_DIR}/cmake/AssertFileDoesntExist.cmake"
-    COMMAND echo
-    "${CMAKE_COMMAND}" -P "${CMAKE_SOURCE_DIR}/cmake/AssertFileDoesntExist.cmake"
-                               -DFILE="${CMAKE_SOURCE_DIR}/versions.h"
-    COMMENT "Check old build system wasn't used in source dir")
+      COMMAND echo
+      "${CMAKE_COMMAND}" -P "${CMAKE_SOURCE_DIR}/cmake/AssertFileDoesntExist.cmake"
+                                 -DFILE="${CMAKE_SOURCE_DIR}/versions.h"
+      COMMENT "Check old build system wasn't used in source dir")
+  else()
+    add_custom_target("${target_name}"
+      COMMAND "${CMAKE_COMMAND}" -DFILE="${CMAKE_SOURCE_DIR}/versions.h"
+                               -P "${CMAKE_SOURCE_DIR}/cmake/AssertFileDoesntExist.cmake"
+      COMMENT "Check old build system wasn't used in source dir")
+  endif()
+
   add_dependencies(${target} ${target_name})
 endfunction()
 

--- a/flow/coveragetool/Program.cs
+++ b/flow/coveragetool/Program.cs
@@ -18,7 +18,7 @@
  * limitations under the License.
  */
 
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -46,7 +46,15 @@ namespace coveragetool
                 Console.WriteLine("  coveragetool [coveragefile] [inputpath]*");
                 return 100;
             }
-            Console.WriteLine("coveragetool {0}", string.Join(" ", args));
+
+            bool quiet = true;
+            if (Environment.GetEnvironmentVariable("VERBOSE") != null) {
+                quiet = false;
+            }
+
+            if (!quiet) {
+                Console.WriteLine("coveragetool {0}", string.Join(" ", args));
+            }
 
             string output = args[0];
             string[] inputPaths = args.Skip(1).Where(p=>!p.Contains(".g.") && !p.Contains(".amalgamation.")).ToArray();
@@ -79,8 +87,10 @@ namespace coveragetool
                 .Concat( changedFiles.SelectMany( f => ParseSource( f.Key ) ) )
                 .ToArray();
 
-            Console.WriteLine("  {0}/{1} files scanned", changedFiles.Count, inputPaths.Length);
-            Console.WriteLine("  {0} coverage cases found", cases.Length);
+            if (!quiet) {
+                Console.WriteLine("  {0}/{1} files scanned", changedFiles.Count, inputPaths.Length);
+                Console.WriteLine("  {0} coverage cases found", cases.Length);
+            }
 
             WriteOutput(output, cases, inputPaths);
 


### PR DESCRIPTION
When using the CMake build system with tools such as Ninja (instead of Make), they have very concise output, and the general "UX flow" involves only outputting warnings that should be fixed or errors that should stop the build. Furthermore, when building things in CI systems and looking at build logs, etc, it's often vastly easier to to hunt down errors when only relevant stuff is output.

If the environment variable `VERBOSE=1` is set, then both `coveragetool.exe` and `cmake` are made verbose and output diagnostic information, but otherwise, by default, do not output anything in their respective build phases.

With these changes (and others), I can get very concise build output from the build system when using CMake and Ninja with absolutely zero warnings, making it much easier to keep track of other changes and fix things that are introduced (you don't *really* want to mess it up when it's all clean, do you?)

---

Two nits:

  1) I'm not sure how valuable people feel coveragetool's output is by default
  2) I don't know if this is the "best" way to make the cmake change for `FlowCommands`. Input appreciated.

Also:

  - We could switch into an opt-out rather than opt-in, depending on feedback on the above.