### PR TITLE
cmake: add support for choosing the linker using -DUSE_LD

### DIFF
--- a/cmake/ConfigureCompiler.cmake
+++ b/cmake/ConfigureCompiler.cmake
@@ -1,10 +1,11 @@
 set(USE_GPERFTOOLS OFF CACHE BOOL "Use gperfools for profiling")
 set(PORTABLE_BINARY OFF CACHE BOOL "Create a binary that runs on older OS versions")
 set(USE_VALGRIND OFF CACHE BOOL "Compile for valgrind usage")
-set(USE_GOLD_LINKER OFF CACHE BOOL "Use gold linker")
 set(ALLOC_INSTRUMENTATION OFF CACHE BOOL "Instrument alloc")
 set(WITH_UNDODB OFF CACHE BOOL "Use rr or undodb")
+set(USE_ASAN OFF CACHE BOOL "Compile with address sanitizer")
 set(FDB_RELEASE OFF CACHE BOOL "This is a building of a final release")
+set(USE_LD "LD" CACHE STRING "The linker to use for building: can be LD (system default, default choice), GOLD, or LLD")
 
 if(USE_GPERFTOOLS)
   find_package(Gperftools REQUIRED)
@@ -47,7 +48,6 @@ include(CheckFunctionExists)
 set(CMAKE_REQUIRED_INCLUDES stdlib.h malloc.h)
 set(CMAKE_REQUIRED_LIBRARIES c)
 
-
 if(WIN32)
   # see: https://docs.microsoft.com/en-us/windows/desktop/WinProg/using-the-windows-headers
   # this sets the windows target version to Windows 7
@@ -55,10 +55,6 @@ if(WIN32)
   add_compile_options(/W3 /EHsc /std:c++14 /bigobj $<$<CONFIG:Release>:/Zi> /MP)
   add_compile_definitions(_WIN32_WINNT=${WINDOWS_TARGET} BOOST_ALL_NO_LIB)
 else()
-  if(USE_GOLD_LINKER)
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fuse-ld=gold -Wl,--disable-new-dtags")
-    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fuse-ld=gold -Wl,--disable-new-dtags")
-  endif()
 
   set(GCC NO)
   set(CLANG NO)
@@ -70,10 +66,29 @@ else()
     set(GCC YES)
   endif()
 
+  # check linker flags.
+  if ((NOT (USE_LD STREQUAL "LD")) AND (NOT (USE_LD STREQUAL "GOLD")) AND (NOT (USE_LD STREQUAL "LLD")))
+    message (FATAL_ERROR "USE_LD must be set to LD, GOLD, or LLD!")
+  endif()
+
+  # if USE_LD=LD, then we don't do anything, defaulting to whatever system
+  # linker is available (e.g. binutils doesn't normally exist on macOS, so this
+  # implies the default xcode linker, and other distros may choose others by
+  # default).
+
+  if(USE_LD STREQUAL "GOLD")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fuse-ld=gold -Wl,--disable-new-dtags")
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fuse-ld=gold -Wl,--disable-new-dtags")
+  endif()
+
+  if(USE_LD STREQUAL "LLD")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fuse-ld=lld -Wl,--disable-new-dtags")
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fuse-ld=lld -Wl,--disable-new-dtags")
+  endif()
+
   # we always compile with debug symbols. CPack will strip them out
   # and create a debuginfo rpm
   add_compile_options(-ggdb)
-  set(USE_ASAN OFF CACHE BOOL "Compile with address sanitizer")
   if(USE_ASAN)
     add_compile_options(
       -fno-omit-frame-pointer -fsanitize=address


### PR DESCRIPTION
As noted in #1533, LTO gives a nice reduction in binary sizes, which would be useful for NixOS users (after thorough testing, of course).

This also enables the use of LLD as the linker: binutils takes quite a lot of memory still, and when using clang with libcxx, lld is a nice and obvious choice.