### PR TITLE
bindings/go: use PutUint64

### DIFF
--- a/bindings/go/bench/int64ToBytes_bench_test.go
+++ b/bindings/go/bench/int64ToBytes_bench_test.go
@@ -1,0 +1,41 @@
+package bench
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+)
+
+var result []byte
+
+func Benchmark_Int64ToBytesBuffer(b *testing.B) {
+	b.ReportAllocs()
+
+	var r []byte
+	for n := 0; n < b.N; n++ {
+		buf := new(bytes.Buffer)
+		if err := binary.Write(buf, binary.LittleEndian, int64(n)); err != nil {
+			b.Error("failed to write int64:", err)
+		}
+
+		b.SetBytes(int64(buf.Len()))
+		r = buf.Bytes()
+	}
+
+	result = r
+}
+
+func Benchmark_Int64ToBytesPut(b *testing.B) {
+	b.ReportAllocs()
+
+	var r []byte
+	for n := 0; n < b.N; n++ {
+		buf := make([]byte, 8)
+		binary.LittleEndian.PutUint64(buf, uint64(n))
+
+		b.SetBytes(int64(len(buf)))
+		r = buf
+	}
+
+	result = r
+}

--- a/bindings/go/src/_util/translate_fdb_options.go
+++ b/bindings/go/src/_util/translate_fdb_options.go
@@ -66,11 +66,7 @@ func writeOptBytes(w io.Writer, receiver string, function string, opt Option) {
 
 func writeOptInt(w io.Writer, receiver string, function string, opt Option) {
 	fmt.Fprintf(w, `func (o %s) %s(param int64) error {
-	b, e := int64ToBytes(param)
-	if e != nil {
-		return e
-	}
-	return o.setOpt(%d, b)
+	return o.setOpt(%d, int64ToBytes(param))
 }
 `, receiver, function, opt.Code)
 }
@@ -205,7 +201,6 @@ func main() {
 package fdb
 
 import (
-	"bytes"
 	"encoding/binary"
 )
 

--- a/bindings/go/src/_util/translate_fdb_options.go
+++ b/bindings/go/src/_util/translate_fdb_options.go
@@ -209,12 +209,10 @@ import (
 	"encoding/binary"
 )
 
-func int64ToBytes(i int64) ([]byte, error) {
-	buf := new(bytes.Buffer)
-	if e := binary.Write(buf, binary.LittleEndian, i); e != nil {
-		return nil, e
-	}
-	return buf.Bytes(), nil
+func int64ToBytes(i int64) []byte {
+	buf := make([]byte, 8)
+	binary.LittleEndian.PutUint64(buf, uint64(i))
+	return buf
 }
 `)
 

--- a/bindings/go/src/fdb/database.go
+++ b/bindings/go/src/fdb/database.go
@@ -216,7 +216,10 @@ func (d Database) LocalityGetBoundaryKeys(er ExactRange, limit int, readVersion 
 	tr.Options().SetLockAware()
 
 	bk, ek := er.FDBRangeKeys()
-	ffer := KeyRange{append(Key("\xFF/keyServers/"), bk.FDBKey()...), append(Key("\xFF/keyServers/"), ek.FDBKey()...)}
+	ffer := KeyRange{
+		append(Key("\xFF/keyServers/"), bk.FDBKey()...),
+		append(Key("\xFF/keyServers/"), ek.FDBKey()...),
+	}
 
 	kvs, e := tr.Snapshot().GetRange(ffer, RangeOptions{Limit: limit}).GetSliceWithError()
 	if e != nil {

--- a/bindings/go/src/fdb/fdb.go
+++ b/bindings/go/src/fdb/fdb.go
@@ -139,7 +139,10 @@ func APIVersion(version int) error {
 			if e == 2203 {
 				maxSupportedVersion := C.fdb_get_max_api_version()
 				if headerVersion > int(maxSupportedVersion) {
-					return fmt.Errorf("This version of the FoundationDB Go binding is not supported by the installed FoundationDB C library. The binding requires a library that supports API version %d, but the installed library supports a maximum version of %d.", headerVersion, maxSupportedVersion)
+					return fmt.Errorf("This version of the FoundationDB Go binding is "+
+						"not supported by the installed FoundationDB C library. "+
+						"The binding requires a library that supports API version %d, "+
+						"but the installed library supports a maximum version of %d.", headerVersion, maxSupportedVersion)
 				}
 				return fmt.Errorf("API version %d is not supported by the installed FoundationDB C library.", version)
 			}

--- a/bindings/go/src/fdb/generated.go
+++ b/bindings/go/src/fdb/generated.go
@@ -34,12 +34,10 @@ import (
 	"encoding/binary"
 )
 
-func int64ToBytes(i int64) ([]byte, error) {
-	buf := new(bytes.Buffer)
-	if e := binary.Write(buf, binary.LittleEndian, i); e != nil {
-		return nil, e
-	}
-	return buf.Bytes(), nil
+func int64ToBytes(i int64) []byte {
+	buf := make([]byte, 8)
+	binary.LittleEndian.PutUint64(buf, uint64(i))
+	return buf
 }
 
 // Deprecated
@@ -495,7 +493,7 @@ const (
 	// Infrequently used. The client has passed a specific row limit and wants
 	// that many rows delivered in a single batch. Because of iterator operation
 	// in client drivers make request batches transparent to the user, consider
-	// ``WANT_ALL`` StreamingMode instead. A row limit must be specified if this
+	// “WANT_ALL“ StreamingMode instead. A row limit must be specified if this
 	// mode is used.
 	StreamingModeExact StreamingMode = 1
 
@@ -612,15 +610,15 @@ type ErrorPredicate int
 
 const (
 
-	// Returns ``true`` if the error indicates the operations in the
-	// transactions should be retried because of transient error.
+	// Returns “true“ if the error indicates the operations in the transactions
+	// should be retried because of transient error.
 	ErrorPredicateRetryable ErrorPredicate = 50000
 
-	// Returns ``true`` if the error indicates the transaction may have
-	// succeeded, though not in a way the system can verify.
+	// Returns “true“ if the error indicates the transaction may have succeeded,
+	// though not in a way the system can verify.
 	ErrorPredicateMaybeCommitted ErrorPredicate = 50001
 
-	// Returns ``true`` if the error indicates the transaction has not
-	// committed, though in a way that can be retried.
+	// Returns “true“ if the error indicates the transaction has not committed,
+	// though in a way that can be retried.
 	ErrorPredicateRetryableNotCommitted ErrorPredicate = 50002
 )

--- a/bindings/go/src/fdb/generated.go
+++ b/bindings/go/src/fdb/generated.go
@@ -30,7 +30,6 @@
 package fdb
 
 import (
-	"bytes"
 	"encoding/binary"
 )
 
@@ -65,22 +64,14 @@ func (o NetworkOptions) SetTraceEnable(param string) error {
 //
 // Parameter: max size of a single trace output file
 func (o NetworkOptions) SetTraceRollSize(param int64) error {
-	b, e := int64ToBytes(param)
-	if e != nil {
-		return e
-	}
-	return o.setOpt(31, b)
+	return o.setOpt(31, int64ToBytes(param))
 }
 
 // Sets the maximum size of all the trace output files put together. This value should be in the range ``[0, INT64_MAX]``. If the value is set to 0, there is no limit on the total size of the files. The default is a maximum size of 104,857,600 bytes. If the default roll size is used, this means that a maximum of 10 trace files will be written at a time.
 //
 // Parameter: max total size of trace files
 func (o NetworkOptions) SetTraceMaxLogsSize(param int64) error {
-	b, e := int64ToBytes(param)
-	if e != nil {
-		return e
-	}
-	return o.setOpt(32, b)
+	return o.setOpt(32, int64ToBytes(param))
 }
 
 // Sets the 'LogGroup' attribute with the specified value for all events in the trace output files. The default log group is 'default'.
@@ -160,22 +151,14 @@ func (o NetworkOptions) SetBuggifyDisable() error {
 //
 // Parameter: probability expressed as a percentage between 0 and 100
 func (o NetworkOptions) SetBuggifySectionActivatedProbability(param int64) error {
-	b, e := int64ToBytes(param)
-	if e != nil {
-		return e
-	}
-	return o.setOpt(50, b)
+	return o.setOpt(50, int64ToBytes(param))
 }
 
 // Set the probability of an active BUGGIFY section being fired
 //
 // Parameter: probability expressed as a percentage between 0 and 100
 func (o NetworkOptions) SetBuggifySectionFiredProbability(param int64) error {
-	b, e := int64ToBytes(param)
-	if e != nil {
-		return e
-	}
-	return o.setOpt(51, b)
+	return o.setOpt(51, int64ToBytes(param))
 }
 
 // Set the ca bundle
@@ -242,22 +225,14 @@ func (o NetworkOptions) SetEnableSlowTaskProfiling() error {
 //
 // Parameter: Max location cache entries
 func (o DatabaseOptions) SetLocationCacheSize(param int64) error {
-	b, e := int64ToBytes(param)
-	if e != nil {
-		return e
-	}
-	return o.setOpt(10, b)
+	return o.setOpt(10, int64ToBytes(param))
 }
 
 // Set the maximum number of watches allowed to be outstanding on a database connection. Increasing this number could result in increased resource usage. Reducing this number will not cancel any outstanding watches. Defaults to 10000 and cannot be larger than 1000000.
 //
 // Parameter: Max outstanding watches
 func (o DatabaseOptions) SetMaxWatches(param int64) error {
-	b, e := int64ToBytes(param)
-	if e != nil {
-		return e
-	}
-	return o.setOpt(20, b)
+	return o.setOpt(20, int64ToBytes(param))
 }
 
 // Specify the machine ID that was passed to fdbserver processes running on the same machine as this client, for better location-aware load balancing.
@@ -278,33 +253,21 @@ func (o DatabaseOptions) SetDatacenterId(param string) error {
 //
 // Parameter: value in milliseconds of timeout
 func (o DatabaseOptions) SetTransactionTimeout(param int64) error {
-	b, e := int64ToBytes(param)
-	if e != nil {
-		return e
-	}
-	return o.setOpt(500, b)
+	return o.setOpt(500, int64ToBytes(param))
 }
 
 // Set a timeout in milliseconds which, when elapsed, will cause a transaction automatically to be cancelled. This sets the ``retry_limit`` option of each transaction created by this database. See the transaction option description for more information.
 //
 // Parameter: number of times to retry
 func (o DatabaseOptions) SetTransactionRetryLimit(param int64) error {
-	b, e := int64ToBytes(param)
-	if e != nil {
-		return e
-	}
-	return o.setOpt(501, b)
+	return o.setOpt(501, int64ToBytes(param))
 }
 
 // Set the maximum amount of backoff delay incurred in the call to ``onError`` if the error is retryable. This sets the ``max_retry_delay`` option of each transaction created by this database. See the transaction option description for more information.
 //
 // Parameter: value in milliseconds of maximum delay
 func (o DatabaseOptions) SetTransactionMaxRetryDelay(param int64) error {
-	b, e := int64ToBytes(param)
-	if e != nil {
-		return e
-	}
-	return o.setOpt(502, b)
+	return o.setOpt(502, int64ToBytes(param))
 }
 
 // Snapshot read operations will see the results of writes done in the same transaction. This is the default behavior.
@@ -415,33 +378,21 @@ func (o TransactionOptions) SetLogTransaction() error {
 //
 // Parameter: value in milliseconds of timeout
 func (o TransactionOptions) SetTimeout(param int64) error {
-	b, e := int64ToBytes(param)
-	if e != nil {
-		return e
-	}
-	return o.setOpt(500, b)
+	return o.setOpt(500, int64ToBytes(param))
 }
 
 // Set a maximum number of retries after which additional calls to ``onError`` will throw the most recently seen error code. Valid parameter values are ``[-1, INT_MAX]``. If set to -1, will disable the retry limit. Prior to API version 610, like all other transaction options, the retry limit must be reset after a call to ``onError``. If the API version is 610 or greater, the retry limit is not reset after an ``onError`` call. Note that at all API versions, it is safe and legal to set the retry limit each time the transaction begins, so most code written assuming the older behavior can be upgraded to the newer behavior without requiring any modification, and the caller is not required to implement special logic in retry loops to only conditionally set this option.
 //
 // Parameter: number of times to retry
 func (o TransactionOptions) SetRetryLimit(param int64) error {
-	b, e := int64ToBytes(param)
-	if e != nil {
-		return e
-	}
-	return o.setOpt(501, b)
+	return o.setOpt(501, int64ToBytes(param))
 }
 
 // Set the maximum amount of backoff delay incurred in the call to ``onError`` if the error is retryable. Defaults to 1000 ms. Valid parameter values are ``[0, INT_MAX]``. If the maximum retry delay is less than the current retry delay of the transaction, then the current retry delay will be clamped to the maximum retry delay. Prior to API version 610, like all other transaction options, the maximum retry delay must be reset after a call to ``onError``. If the API version is 610 or greater, the retry limit is not reset after an ``onError`` call. Note that at all API versions, it is safe and legal to set the maximum retry delay each time the transaction begins, so most code written assuming the older behavior can be upgraded to the newer behavior without requiring any modification, and the caller is not required to implement special logic in retry loops to only conditionally set this option.
 //
 // Parameter: value in milliseconds of maximum delay
 func (o TransactionOptions) SetMaxRetryDelay(param int64) error {
-	b, e := int64ToBytes(param)
-	if e != nil {
-		return e
-	}
-	return o.setOpt(502, b)
+	return o.setOpt(502, int64ToBytes(param))
 }
 
 // Snapshot read operations will see the results of writes done in the same transaction. This is the default behavior.
@@ -493,7 +444,7 @@ const (
 	// Infrequently used. The client has passed a specific row limit and wants
 	// that many rows delivered in a single batch. Because of iterator operation
 	// in client drivers make request batches transparent to the user, consider
-	// “WANT_ALL“ StreamingMode instead. A row limit must be specified if this
+	// ``WANT_ALL`` StreamingMode instead. A row limit must be specified if this
 	// mode is used.
 	StreamingModeExact StreamingMode = 1
 
@@ -610,15 +561,15 @@ type ErrorPredicate int
 
 const (
 
-	// Returns “true“ if the error indicates the operations in the transactions
-	// should be retried because of transient error.
+	// Returns ``true`` if the error indicates the operations in the
+	// transactions should be retried because of transient error.
 	ErrorPredicateRetryable ErrorPredicate = 50000
 
-	// Returns “true“ if the error indicates the transaction may have succeeded,
-	// though not in a way the system can verify.
+	// Returns ``true`` if the error indicates the transaction may have
+	// succeeded, though not in a way the system can verify.
 	ErrorPredicateMaybeCommitted ErrorPredicate = 50001
 
-	// Returns “true“ if the error indicates the transaction has not committed,
-	// though in a way that can be retried.
+	// Returns ``true`` if the error indicates the transaction has not
+	// committed, though in a way that can be retried.
 	ErrorPredicateRetryableNotCommitted ErrorPredicate = 50002
 )

--- a/bindings/go/src/fdb/transaction.go
+++ b/bindings/go/src/fdb/transaction.go
@@ -184,7 +184,9 @@ func (t Transaction) Snapshot() Snapshot {
 // Typical code will not use OnError directly. (Database).Transact uses
 // OnError internally to implement a correct retry loop.
 func (t Transaction) OnError(e Error) FutureNil {
-	return &futureNil{newFuture(C.fdb_transaction_on_error(t.ptr, C.fdb_error_t(e.Code)))}
+	return &futureNil{
+		future: newFuture(C.fdb_transaction_on_error(t.ptr, C.fdb_error_t(e.Code))),
+	}
 }
 
 // Commit attempts to commit the modifications made in the transaction to the
@@ -198,7 +200,9 @@ func (t Transaction) OnError(e Error) FutureNil {
 // see
 // https://apple.github.io/foundationdb/developer-guide.html#transactions-with-unknown-results.
 func (t Transaction) Commit() FutureNil {
-	return &futureNil{newFuture(C.fdb_transaction_commit(t.ptr))}
+	return &futureNil{
+		future: newFuture(C.fdb_transaction_commit(t.ptr)),
+	}
 }
 
 // Watch creates a watch and returns a FutureNil that will become ready when the
@@ -232,12 +236,14 @@ func (t Transaction) Commit() FutureNil {
 // cancelled by calling (FutureNil).Cancel on its returned future.
 func (t Transaction) Watch(key KeyConvertible) FutureNil {
 	kb := key.FDBKey()
-	return &futureNil{newFuture(C.fdb_transaction_watch(t.ptr, byteSliceToPtr(kb), C.int(len(kb))))}
+	return &futureNil{
+		future: newFuture(C.fdb_transaction_watch(t.ptr, byteSliceToPtr(kb), C.int(len(kb)))),
+	}
 }
 
 func (t *transaction) get(key []byte, snapshot int) FutureByteSlice {
 	return &futureByteSlice{
-		newFuture(C.fdb_transaction_get(
+		future: newFuture(C.fdb_transaction_get(
 			t.ptr,
 			byteSliceToPtr(key),
 			C.int(len(key)),
@@ -261,7 +267,7 @@ func (t *transaction) doGetRange(r Range, options RangeOptions, snapshot bool, i
 	ekey := esel.Key.FDBKey()
 
 	return futureKeyValueArray{
-		newFuture(C.fdb_transaction_get_range(
+		future: newFuture(C.fdb_transaction_get_range(
 			t.ptr,
 			byteSliceToPtr(bkey),
 			C.int(len(bkey)),
@@ -302,7 +308,9 @@ func (t Transaction) GetRange(r Range, options RangeOptions) RangeResult {
 }
 
 func (t *transaction) getReadVersion() FutureInt64 {
-	return &futureInt64{newFuture(C.fdb_transaction_get_read_version(t.ptr))}
+	return &futureInt64{
+		future: newFuture(C.fdb_transaction_get_read_version(t.ptr)),
+	}
 }
 
 // (Infrequently used) GetReadVersion returns the (future) transaction read version. The read is
@@ -383,7 +391,7 @@ func boolToInt(b bool) int {
 func (t *transaction) getKey(sel KeySelector, snapshot int) FutureKey {
 	key := sel.Key.FDBKey()
 	return &futureKey{
-		newFuture(C.fdb_transaction_get_key(
+		future: newFuture(C.fdb_transaction_get_key(
 			t.ptr,
 			byteSliceToPtr(key),
 			C.int(len(key)),
@@ -502,7 +510,7 @@ func (t Transaction) Options() TransactionOptions {
 func localityGetAddressesForKey(t *transaction, key KeyConvertible) FutureStringSlice {
 	kb := key.FDBKey()
 	return &futureStringSlice{
-		newFuture(C.fdb_transaction_get_addresses_for_key(
+		future: newFuture(C.fdb_transaction_get_addresses_for_key(
 			t.ptr,
 			byteSliceToPtr(kb),
 			C.int(len(kb)),


### PR DESCRIPTION
Speeds up marshaling around 10x and saves 120 bytes of garbage every call

This is the same function that `binary.Write` calls, we just bypass all of the buffer and type switching

```
goos: linux
goarch: amd64
pkg: github.com/apple/foundationdb/bindings/go/bench
Benchmark_Int64ToBytesBuffer-16    	20000000	       106 ns/op	  75.08 MB/s	     128 B/op	      4 allocs/op
Benchmark_Int64ToBytesPut-16       	100000000	        11.9 ns/op	 673.80 MB/s	       8 B/op	      1 allocs/op
```

Also contains some formatting for extremely long lines but I can get rid of that if necessary.