### PR TITLE
Prefer re-creating a DiskQueue file rather than performing a large truncate

### DIFF
--- a/documentation/sphinx/source/release-notes.rst
+++ b/documentation/sphinx/source/release-notes.rst
@@ -125,6 +125,7 @@ Fixes only impacting 6.1.0+
 * The background actor which removes redundant teams could leave data unbalanced. [6.1.3] `(PR #1479) <https://github.com/apple/foundationdb/pull/1479>`_
 * The transaction log spill-by-reference policy could read too much data from disk. [6.1.5] `(PR #1527) <https://github.com/apple/foundationdb/pull/1527>`_
 * Memory tracking trace events could cause the program to crash when called from inside a trace event. [6.1.5] `(PR #1541) <https://github.com/apple/foundationdb/pull/1541>`_
+* TLogs will replace a large file with an empty file rather than doing a large truncate operation. [6.1.5] `(PR #1545) <https://github.com/apple/foundationdb/pull/1545>`_
 
 Earlier release notes
 ---------------------

--- a/fdbserver/DiskQueue.actor.cpp
+++ b/fdbserver/DiskQueue.actor.cpp
@@ -270,68 +270,73 @@ public:
 
 	Future<Void> truncateFile(int file, int64_t pos) { return truncateFile(this, file, pos); }
 
-	Future<Void> push(StringRef pageData, vector<Reference<SyncQueue>>& toSync) {
+	Future<Void> push(StringRef pageData, vector<Reference<SyncQueue>>* toSync) {
+		return push( this, pageData, toSync );
+	}
+
+	ACTOR static Future<Void> push(RawDiskQueue_TwoFiles* self, StringRef pageData, vector<Reference<SyncQueue>>* toSync) {
 		// Write the given data to the queue files, swapping or extending them if necessary.
 		// Don't do any syncs, but push the modified file(s) onto toSync.
-		ASSERT( readingFile == 2 );
+		ASSERT( self->readingFile == 2 );
 		ASSERT( pageData.size() % _PAGE_SIZE == 0 );
 		ASSERT( int64_t(pageData.begin()) % _PAGE_SIZE == 0 );
-		ASSERT( writingPos % _PAGE_SIZE == 0 );
-		ASSERT( files[0].size % _PAGE_SIZE == 0 && files[1].size % _PAGE_SIZE == 0 );
+		ASSERT( self->writingPos % _PAGE_SIZE == 0 );
+		ASSERT( self->files[0].size % _PAGE_SIZE == 0 && self->files[1].size % _PAGE_SIZE == 0 );
 
 		vector<Future<Void>> waitfor;
 
-		if (pageData.size() + writingPos > files[1].size) {
-			if ( files[0].popped == files[0].size ) {
-				// Finish files[1] and swap
-				int p = files[1].size - writingPos;
+		if (pageData.size() + self->writingPos > self->files[1].size) {
+			if ( self->files[0].popped == self->files[0].size ) {
+				// Finish self->files[1] and swap
+				int p = self->files[1].size - self->writingPos;
 				if(p > 0) {
-					toSync.push_back( files[1].syncQueue );
-					/*TraceEvent("RDQWriteAndSwap", this->dbgid).detail("File1name", files[1].dbgFilename).detail("File1size", files[1].size)
-						.detail("WritingPos", writingPos).detail("WritingBytes", p);*/
-					waitfor.push_back( files[1].f->write( pageData.begin(), p, writingPos ) );
+					toSync->push_back( self->files[1].syncQueue );
+					/*TraceEvent("RDQWriteAndSwap", this->dbgid).detail("File1name", self->files[1].dbgFilename).detail("File1size", self->files[1].size)
+						.detail("WritingPos", self->writingPos).detail("WritingBytes", p);*/
+					waitfor.push_back( self->files[1].f->write( pageData.begin(), p, self->writingPos ) );
 					pageData = pageData.substr( p );
 				}
 
-				dbg_file0BeginSeq += files[0].size;
-				std::swap(files[0], files[1]);
-				std::swap(firstPages[0], firstPages[1]);
-				files[1].popped = 0;
-				writingPos = 0;
+				self->dbg_file0BeginSeq += self->files[0].size;
+				std::swap(self->files[0], self->files[1]);
+				std::swap(self->firstPages[0], self->firstPages[1]);
+				self->files[1].popped = 0;
+				self->writingPos = 0;
 
-				const int64_t activeDataVolume = pageCeiling(files[0].size - files[0].popped + fileExtensionBytes + fileShrinkBytes);
-				if (files[1].size > activeDataVolume) {
-					// Either shrink files[1] to the size of files[0], or chop off fileShrinkBytes
-					int64_t maxShrink = std::max( pageFloor(files[1].size - activeDataVolume), fileShrinkBytes );
-					files[1].size -= maxShrink;
-					waitfor.push_back( files[1].f->truncate( files[1].size ) );
+				const int64_t activeDataVolume = pageCeiling(self->files[0].size - self->files[0].popped + self->fileExtensionBytes + self->fileShrinkBytes);
+				if (self->files[1].size > activeDataVolume) {
+					// Either shrink self->files[1] to the size of self->files[0], or chop off fileShrinkBytes
+					int64_t maxShrink = std::max( pageFloor(self->files[1].size - activeDataVolume), self->fileShrinkBytes );
+					self->files[1].size -= maxShrink;
+					waitfor.push_back( self->files[1].f->truncate( self->files[1].size ) );
 				}
 			} else {
-				// Extend files[1] to accomodate the new write and about 10MB or 2x current size for future writes.
-				/*TraceEvent("RDQExtend", this->dbgid).detail("File1name", files[1].dbgFilename).detail("File1size", files[1].size)
+				// Extend self->files[1] to accomodate the new write and about 10MB or 2x current size for future writes.
+				/*TraceEvent("RDQExtend", this->dbgid).detail("File1name", self->files[1].dbgFilename).detail("File1size", self->files[1].size)
 					.detail("ExtensionBytes", fileExtensionBytes);*/
-				int64_t minExtension = pageData.size() + writingPos - files[1].size;
-				files[1].size += std::min(std::max(fileExtensionBytes, minExtension), files[0].size+files[1].size+minExtension);
-				waitfor.push_back( files[1].f->truncate( files[1].size ) );
+				int64_t minExtension = pageData.size() + self->writingPos - self->files[1].size;
+				self->files[1].size += std::min(std::max(self->fileExtensionBytes, minExtension), self->files[0].size+self->files[1].size+minExtension);
+				waitfor.push_back( self->files[1].f->truncate( self->files[1].size ) );
 
-				if(fileSizeWarningLimit > 0 && files[1].size > fileSizeWarningLimit) {
-					TraceEvent(SevWarnAlways, "DiskQueueFileTooLarge", dbgid).suppressFor(1.0).detail("Filename", filename(1)).detail("Size", files[1].size);
+				if(self->fileSizeWarningLimit > 0 && self->files[1].size > self->fileSizeWarningLimit) {
+					TraceEvent(SevWarnAlways, "DiskQueueFileTooLarge", self->dbgid).suppressFor(1.0).detail("Filename", self->filename(1)).detail("Size", self->files[1].size);
 				}
 			}
 		}
 
-		if (writingPos == 0) {
-			*firstPages[1] = *(const Page*)pageData.begin();
+		if (self->writingPos == 0) {
+			*self->firstPages[1] = *(const Page*)pageData.begin();
 		}
 
-		/*TraceEvent("RDQWrite", this->dbgid).detail("File1name", files[1].dbgFilename).detail("File1size", files[1].size)
-			.detail("WritingPos", writingPos).detail("WritingBytes", pageData.size());*/
-		files[1].size = std::max( files[1].size, writingPos + pageData.size() );
-		toSync.push_back( files[1].syncQueue );
-		waitfor.push_back( files[1].f->write( pageData.begin(), pageData.size(), writingPos ) );
-		writingPos += pageData.size();
+		/*TraceEvent("RDQWrite", this->dbgid).detail("File1name", self->files[1].dbgFilename).detail("File1size", self->files[1].size)
+			.detail("WritingPos", self->writingPos).detail("WritingBytes", pageData.size());*/
+		self->files[1].size = std::max( self->files[1].size, self->writingPos + pageData.size() );
+		toSync->push_back( self->files[1].syncQueue );
+		waitfor.push_back( self->files[1].f->write( pageData.begin(), pageData.size(), self->writingPos ) );
+		self->writingPos += pageData.size();
 
-		return waitForAll(waitfor);
+		wait( waitForAll(waitfor) );
+		return Void();
 	}
 
 	ACTOR static UNCANCELLABLE Future<Void> pushAndCommit(RawDiskQueue_TwoFiles* self, StringRef pageData, StringBuffer* pageMem, uint64_t poppedPages) {
@@ -358,7 +363,7 @@ public:
 
 			TEST( pageData.size() > sizeof(Page) ); // push more than one page of data
 
-			Future<Void> pushed = self->push( pageData, syncFiles );
+			Future<Void> pushed = self->push( pageData, &syncFiles );
 			pushing.send(Void());
 			ASSERT( syncFiles.size() >= 1 && syncFiles.size() <= 2 );
 			TEST(2==syncFiles.size());  // push spans both files

--- a/fdbserver/DiskQueue.actor.cpp
+++ b/fdbserver/DiskQueue.actor.cpp
@@ -304,9 +304,10 @@ public:
 				self->writingPos = 0;
 
 				const int64_t activeDataVolume = pageCeiling(self->files[0].size - self->files[0].popped + self->fileExtensionBytes + self->fileShrinkBytes);
-				if (self->files[1].size > activeDataVolume) {
+				const int64_t desiredMaxFileSize = std::max( activeDataVolume, SERVER_KNOBS->TLOG_HARD_LIMIT_BYTES * 2 );
+				if (self->files[1].size > desiredMaxFileSize) {
 					// Either shrink self->files[1] to the size of self->files[0], or chop off fileShrinkBytes
-					int64_t maxShrink = std::max( pageFloor(self->files[1].size - activeDataVolume), self->fileShrinkBytes );
+					int64_t maxShrink = std::max( pageFloor(self->files[1].size - desiredMaxFileSize), self->fileShrinkBytes );
 					self->files[1].size -= maxShrink;
 					waitfor.push_back( self->files[1].f->truncate( self->files[1].size ) );
 				}

--- a/fdbserver/DiskQueue.actor.cpp
+++ b/fdbserver/DiskQueue.actor.cpp
@@ -279,6 +279,8 @@ public:
 			wait(file->sync());
 			wait(delay(FLOW_KNOBS->INCREMENTAL_DELETE_INTERVAL));
 		}
+
+		TraceEvent("DiskQueueReplaceTruncateEnded").detail("Filename", file->getFilename());
 	}
 
 	ACTOR static Future<Reference<IAsyncFile>> replaceFile(Reference<IAsyncFile> toReplace) {

--- a/fdbserver/DiskQueue.actor.cpp
+++ b/fdbserver/DiskQueue.actor.cpp
@@ -332,6 +332,7 @@ public:
 					if (maxShrink / SERVER_KNOBS->DISK_QUEUE_FILE_EXTENSION_BYTES >
 							SERVER_KNOBS->DISK_QUEUE_MAX_TRUNCATE_EXTENTS) {
 						TEST(true);  // Replacing DiskQueue file
+						TraceEvent("DiskQueueReplaceFile", self->dbgid).detail("Filename", self->files[1].f->getFilename()).detail("OldFileSize", self->files[1].size).detail("ElidedTruncateSize", maxShrink);
 						Reference<IAsyncFile> newFile = wait( replaceFile(self->files[1].f) );
 						self->files[1].setFile(newFile);
 						self->files[1].size = 0;

--- a/fdbserver/Knobs.cpp
+++ b/fdbserver/Knobs.cpp
@@ -75,6 +75,7 @@ ServerKnobs::ServerKnobs(bool randomize, ClientKnobs* clientKnobs) {
 	init( TLOG_SPILL_REFERENCE_MAX_BYTES_PER_BATCH,           16<<10 ); if ( randomize && BUGGIFY ) TLOG_SPILL_REFERENCE_MAX_BYTES_PER_BATCH = 500;
 	init( DISK_QUEUE_FILE_EXTENSION_BYTES,                    10<<20 ); // BUGGIFYd per file within the DiskQueue
 	init( DISK_QUEUE_FILE_SHRINK_BYTES,                      100<<20 ); // BUGGIFYd per file within the DiskQueue
+	init( DISK_QUEUE_MAX_TRUNCATE_EXTENTS,                     1<<10 ); if ( randomize && BUGGIFY ) DISK_QUEUE_MAX_TRUNCATE_EXTENTS = 0;
 	init( TLOG_DEGRADED_DELAY_COUNT,                               5 );
 	init( TLOG_DEGRADED_DURATION,                                5.0 );
 

--- a/fdbserver/Knobs.h
+++ b/fdbserver/Knobs.h
@@ -79,6 +79,7 @@ public:
 	int64_t TLOG_SPILL_REFERENCE_MAX_BYTES_PER_BATCH;
 	int64_t DISK_QUEUE_FILE_EXTENSION_BYTES; // When we grow the disk queue, by how many bytes should it grow?
 	int64_t DISK_QUEUE_FILE_SHRINK_BYTES; // When we shrink the disk queue, by how many bytes should it shrink?
+	int DISK_QUEUE_MAX_TRUNCATE_EXTENTS;
 	int TLOG_DEGRADED_DELAY_COUNT;
 	double TLOG_DEGRADED_DURATION;
 


### PR DESCRIPTION
Large truncates strike again!

When a remote datacenter or storage server is down for a long time, a single DiskQueue file will grow continuously.  When the spilled data is popped, this will lead to a large truncate, since I considered this possibility and wrote code to "rubber band" snap the extremely large disk queue file back to a reasonable size.  Otherwise, the code only understands how to shrink a file after rewriting it entirely, so shrinking a 1TB file to 4GB would take O(1TB^2) rewrites, and probably seriously burn through SSD lifetime.

We always extend DiskQueue files by 10MB at a time, rather than the 4-8KB of SQLite, so I thought this wouldn't be as terrible.  It turns out it is as terrible, so now we need to stop doing that.

This PR introduces a mechanism in the DiskQueue so that instead of performing a large truncate (where large is >10GB = ~1000 extents), it simply replaces the file with an empty one, and incrementally truncates the old file down in the background.

@satherton, Do you have any better intuition as to the correct default setting for the number of extents knob?

@etschannen, I think this PR is correctness good, as I already had to fix a few stupid mistakes, but if you're working before I am, then check 20190507-205706-alexmiller-3fe18b04228f8148.  I tweaked the values in this to be extra abusive towards triggering the added code.