### PR TITLE
Fix a couple places where variables were being unsafely accessed from multiple threads

### DIFF
--- a/flow/Net2.actor.cpp
+++ b/flow/Net2.actor.cpp
@@ -65,7 +65,7 @@ static_assert(currentProtocolVersion < 0x0FDB00B100000000LL, "Unexpected protoco
 #if defined(__linux__)
 #include <execinfo.h>
 
-volatile double net2liveness = 0;
+std::atomic<int64_t> net2liveness(0);
 
 volatile size_t net2backtraces_max = 10000;
 volatile void** volatile net2backtraces = NULL;
@@ -689,7 +689,7 @@ void Net2::run() {
 			}
 
 			// to keep the thread liveness check happy
-			net2liveness = g_nondeterministic_random->random01();
+			net2liveness.fetch_add(1);
 		}
 #endif
 

--- a/flow/Platform.cpp
+++ b/flow/Platform.cpp
@@ -2742,7 +2742,7 @@ extern volatile size_t net2backtraces_offset;
 extern volatile size_t net2backtraces_max;
 extern volatile bool net2backtraces_overflow;
 extern volatile int net2backtraces_count;
-extern volatile double net2liveness;
+extern std::atomic<int64_t> net2liveness;
 extern volatile thread_local int profilingEnabled;
 extern void initProfiling();
 
@@ -2789,12 +2789,13 @@ void* checkThread(void *arg) {
 	pthread_t mainThread = *(pthread_t*)arg;
 	free(arg);
 
-	double lastValue = net2liveness;
+	int64_t lastValue = net2liveness.load();
 	double lastSignal = 0;
 	double logInterval = FLOW_KNOBS->SLOWTASK_PROFILING_INTERVAL;
 	while(true) {
 		threadSleep(FLOW_KNOBS->SLOWTASK_PROFILING_INTERVAL);
-		if(lastValue == net2liveness) {
+		int64_t currentLiveness = net2liveness.load();
+		if(lastValue == currentLiveness) {
 			double t = timer();
 			if(lastSignal == 0 || t - lastSignal >= logInterval) {
 				if(lastSignal > 0) {
@@ -2806,10 +2807,10 @@ void* checkThread(void *arg) {
 			}
 		}
 		else {
+			lastValue = currentLiveness;
 			lastSignal = 0;
 			logInterval = FLOW_KNOBS->SLOWTASK_PROFILING_INTERVAL;
 		}
-		lastValue = net2liveness;
 	}
 	return NULL;
 #else

--- a/flow/Trace.cpp
+++ b/flow/Trace.cpp
@@ -921,7 +921,10 @@ TraceEvent::~TraceEvent() {
 				severity = SevError;
 			}
 
-			TraceEvent::eventCounts[severity/10]++;
+			if(isNetworkThread()) {
+				TraceEvent::eventCounts[severity/10]++;
+			}
+
 			g_traceLog.writeEvent( fields, trackingKey, severity > SevWarnAlways );
 
 			if (g_traceLog.isOpen()) {


### PR DESCRIPTION
Don't modify TraceEvent::eventCounts except on the main thread. Make net2liveness an atomic counter.