### PR TITLE
Use std::atomics in thread-safe queue

### DIFF
--- a/flow/ThreadSafeQueue.h
+++ b/flow/ThreadSafeQueue.h
@@ -27,63 +27,88 @@ THIS SOFTWARE IS PROVIDED BY DMITRY VYUKOV "AS IS" AND ANY EXPRESS OR IMPLIED WA
 
 The views and conclusions contained in the software and documentation are those of the authors and should not be interpreted as representing official policies, either expressed or implied, of Dmitry Vyukov.*/
 
+#include <atomic>
+
 template <class T>
 class ThreadSafeQueue : NonCopyable {
 	struct BaseNode {
-		BaseNode* volatile  next;
+		std::atomic<BaseNode*> next;
+		BaseNode() : next(nullptr) {}
 	};
 
-	struct Node : BaseNode, FastAllocated<Node>
-	{
+	struct Node : BaseNode, FastAllocated<Node> {
 		T data;
 		Node( T const& data ) : data(data) {}
 	};
-	BaseNode* volatile  head;
-	BaseNode*           tail;
+	std::atomic<BaseNode*> head;
+	BaseNode* tail;
 	BaseNode stub, sleeping;
 	bool sleepy;
 
 	BaseNode* popNode() {
 		BaseNode* tail = this->tail;
-		BaseNode* next = tail->next;
+		BaseNode* next = tail->next.load();
+#ifdef VALGRIND
+		ANNOTATE_HAPPENS_BEFORE(&tail->next);
+#endif
 		if (tail == &this->stub) {
-			if (0 == next)
-				return 0;
+			if (!next) {
+				return nullptr;
+			}
 			this->tail = next;
 			tail = next;
-			next = next->next;
+			next = next->next.load();
+#ifdef VALGRIND
+			ANNOTATE_HAPPENS_BEFORE(&next->next);
+#endif
 		}
-		if (next)
-		{
+		if (next) {
 			this->tail = next;
 			return tail;
 		}
-		BaseNode* head = this->head;
-		if (tail != head)
-			return 0;
-		pushNode( &this->stub );
-		next = tail->next;
-		if (next)
-		{
+		BaseNode* head = this->head.load();
+#ifdef VALGRIND
+		ANNOTATE_HAPPENS_BEFORE(&this->head);
+#endif
+		if (tail != head) {
+			return nullptr;
+		}
+#ifdef VALGRIND
+		ANNOTATE_HAPPENS_AFTER(&this->stub.next);
+#endif
+		this->stub.next.store(nullptr);
+		pushNode(&this->stub);
+		next = tail->next.load();
+#ifdef VALGRIND
+		ANNOTATE_HAPPENS_BEFORE(&tail->next);
+#endif
+		if (next) {
 			this->tail = next;
 			return tail;
 		}
-		return 0;
+		return nullptr;
 	}
 
 	// Pushes n at the end of the queue and returns the node immediately before it
 	BaseNode* pushNode( BaseNode* n ) {
-		n->next = 0;
-		BaseNode* prev = interlockedExchangePtr( &head, n );
-		prev->next = n;
+#ifdef VALGRIND
+		ANNOTATE_HAPPENS_AFTER(&head);
+#endif
+		BaseNode* prev = head.exchange(n);
+#ifdef VALGRIND
+		ANNOTATE_HAPPENS_BEFORE(&head);
+		ANNOTATE_HAPPENS_AFTER(&prev->next);
+#endif
+		prev->next.store(n);
 		return prev;
 	}
 public:
 	ThreadSafeQueue() {
-		this->head = &this->stub;
+#ifdef VALGRIND
+		ANNOTATE_HAPPENS_AFTER(&this->head);
+#endif
+		this->head.store(&this->stub);
 		this->tail = &this->stub;
-		this->stub.next = 0;
-		this->sleeping.next = 0;
 		this->sleepy = false;
 	}
 	~ThreadSafeQueue() {
@@ -101,10 +126,21 @@ public:
 
 	// If canSleep returns true, then the queue is empty and the next push() will return true
 	bool canSleep() {
-		if (sleepy) return false;  // We already have sleeping in the queue from a previous call to canSleep.  Pop it and then maybe you can sleep!
-		if (this->tail != &stub || this->tail->next != 0) return false;  // There is definitely something in the queue.  This is a rejection test not needed for correctness, but avoids calls to pushNode
+		if (sleepy) {
+			return false;  // We already have sleeping in the queue from a previous call to canSleep.  Pop it and then maybe you can sleep!
+		}
+		if (this->tail != &stub || this->tail->next.load()) {
+#ifdef VALGRIND
+			ANNOTATE_HAPPENS_BEFORE(&this->tail->next);
+#endif
+			return false;  // There is definitely something in the queue.  This is a rejection test not needed for correctness, but avoids calls to pushNode
+		}
+#ifdef VALGRIND
+		ANNOTATE_HAPPENS_BEFORE(&this->tail->next);
+#endif
 		// sleeping is definitely not in the queue, so we can safely try...
-		bool ok = pushNode( &sleeping ) == &stub;
+		sleeping.next.store(nullptr);
+		bool ok = pushNode(&sleeping) == &stub;
 		sleepy = true; // sleeping is in the queue, regardless of whether it's the first thing; we need to pop it before sleeping again
 		return ok;
 	}
@@ -112,8 +148,8 @@ public:
 	Optional<T> pop() {
 		BaseNode* b = popNode();
 		if (b == &sleeping) { sleepy = false; b = popNode(); }
-		if ( b == &sleeping ) ASSERT(false);
-		if ( b == &stub ) ASSERT(false);
+		if (b == &sleeping) ASSERT(false);
+		if (b == &stub) ASSERT(false);
 		if (!b) return Optional<T>();
 
 		Node* n = (Node*)b;

--- a/flow/ThreadSafeQueue.h
+++ b/flow/ThreadSafeQueue.h
@@ -48,7 +48,7 @@ class ThreadSafeQueue : NonCopyable {
 	BaseNode* popNode() {
 		BaseNode* tail = this->tail;
 		BaseNode* next = tail->next.load();
-#ifdef VALGRIND
+#if VALGRIND
 		ANNOTATE_HAPPENS_BEFORE(&tail->next);
 #endif
 		if (tail == &this->stub) {
@@ -58,7 +58,7 @@ class ThreadSafeQueue : NonCopyable {
 			this->tail = next;
 			tail = next;
 			next = next->next.load();
-#ifdef VALGRIND
+#if VALGRIND
 			ANNOTATE_HAPPENS_BEFORE(&next->next);
 #endif
 		}
@@ -67,19 +67,19 @@ class ThreadSafeQueue : NonCopyable {
 			return tail;
 		}
 		BaseNode* head = this->head.load();
-#ifdef VALGRIND
+#if VALGRIND
 		ANNOTATE_HAPPENS_BEFORE(&this->head);
 #endif
 		if (tail != head) {
 			return nullptr;
 		}
-#ifdef VALGRIND
+#if VALGRIND
 		ANNOTATE_HAPPENS_AFTER(&this->stub.next);
 #endif
 		this->stub.next.store(nullptr);
 		pushNode(&this->stub);
 		next = tail->next.load();
-#ifdef VALGRIND
+#if VALGRIND
 		ANNOTATE_HAPPENS_BEFORE(&tail->next);
 #endif
 		if (next) {
@@ -91,11 +91,11 @@ class ThreadSafeQueue : NonCopyable {
 
 	// Pushes n at the end of the queue and returns the node immediately before it
 	BaseNode* pushNode( BaseNode* n ) {
-#ifdef VALGRIND
+#if VALGRIND
 		ANNOTATE_HAPPENS_AFTER(&head);
 #endif
 		BaseNode* prev = head.exchange(n);
-#ifdef VALGRIND
+#if VALGRIND
 		ANNOTATE_HAPPENS_BEFORE(&head);
 		ANNOTATE_HAPPENS_AFTER(&prev->next);
 #endif
@@ -104,7 +104,7 @@ class ThreadSafeQueue : NonCopyable {
 	}
 public:
 	ThreadSafeQueue() {
-#ifdef VALGRIND
+#if VALGRIND
 		ANNOTATE_HAPPENS_AFTER(&this->head);
 #endif
 		this->head.store(&this->stub);
@@ -130,12 +130,12 @@ public:
 			return false;  // We already have sleeping in the queue from a previous call to canSleep.  Pop it and then maybe you can sleep!
 		}
 		if (this->tail != &stub || this->tail->next.load()) {
-#ifdef VALGRIND
+#if VALGRIND
 			ANNOTATE_HAPPENS_BEFORE(&this->tail->next);
 #endif
 			return false;  // There is definitely something in the queue.  This is a rejection test not needed for correctness, but avoids calls to pushNode
 		}
-#ifdef VALGRIND
+#if VALGRIND
 		ANNOTATE_HAPPENS_BEFORE(&this->tail->next);
 #endif
 		// sleeping is definitely not in the queue, so we can safely try...


### PR DESCRIPTION
It appears to me that thread-safe queue is relying on some properties of accessing variables from multiple threads that aren't guaranteed (although perhaps they are in practice with our compilers/processers/etc?). On that assumption, I've updated the thread-safe queue to use atomics for variables that are shared between threads.

I've done no performance testing of this yet, but I'm hoping to at least get an idea whether the code below seems reasonable.