### PR TITLE
Allow sqlite pages to be checked for CRC32 checksum

### DIFF
--- a/fdbserver/KeyValueStoreSQLite.actor.cpp
+++ b/fdbserver/KeyValueStoreSQLite.actor.cpp
@@ -118,16 +118,18 @@ struct PageChecksumCodec {
 		hashlittle2(pData, dataLen, &hashLittle2Sum.part1, &hashLittle2Sum.part2);
 		if (hashLittle2Sum == *pSumInPage) return true;
 
-		TraceEvent tr(SevError, "SQLitePageChecksumFailure");
-		tr.error(checksum_failed())
-		    .detail("CodecPageSize", pageSize)
-		    .detail("CodecReserveSize", reserveSize)
-		    .detail("Filename", filename)
-		    .detail("PageNumber", pageNumber)
-		    .detail("PageSize", pageLen)
-		    .detail("ChecksumInPage", pSumInPage->toString())
-		    .detail("ChecksumCalculatedHL2", hashLittle2Sum.toString());
-		if (pSumInPage->part1 == 0) tr.detail("ChecksumCalculatedCRC", sum.toString());
+		if (!silent) {
+			TraceEvent trEvent(SevError, "SQLitePageChecksumFailure");
+			trEvent.error(checksum_failed())
+			    .detail("CodecPageSize", pageSize)
+			    .detail("CodecReserveSize", reserveSize)
+			    .detail("Filename", filename)
+			    .detail("PageNumber", pageNumber)
+			    .detail("PageSize", pageLen)
+			    .detail("ChecksumInPage", pSumInPage->toString())
+			    .detail("ChecksumCalculatedHL2", hashLittle2Sum.toString());
+			if (pSumInPage->part1 == 0) trEvent.detail("ChecksumCalculatedCRC", sum.toString());
+		}
 		return false;
 	}
 


### PR DESCRIPTION
Future versions of FDB will write sqlite pages with CRC32 checksums. In order to roll back to this version from a version that writes CRC32 checksums, this version must be able to verify those checksums.

This is a solution to the rollback issue pointed out in the discussion of #1582.