### PR TITLE
Go bindings: Use single line comments in CGO

### DIFF
--- a/bindings/go/src/fdb/cluster.go
+++ b/bindings/go/src/fdb/cluster.go
@@ -22,10 +22,8 @@
 
 package fdb
 
-/*
- #define FDB_API_VERSION 610
- #include <foundationdb/fdb_c.h>
-*/
+// #define FDB_API_VERSION 610
+// #include <foundationdb/fdb_c.h>
 import "C"
 
 // Deprecated: Use OpenDatabase or OpenDefault to obtain a database handle directly

--- a/bindings/go/src/fdb/database.go
+++ b/bindings/go/src/fdb/database.go
@@ -22,10 +22,8 @@
 
 package fdb
 
-/*
- #define FDB_API_VERSION 610
- #include <foundationdb/fdb_c.h>
-*/
+// #define FDB_API_VERSION 610
+// #include <foundationdb/fdb_c.h>
 import "C"
 
 import (

--- a/bindings/go/src/fdb/errors.go
+++ b/bindings/go/src/fdb/errors.go
@@ -22,10 +22,8 @@
 
 package fdb
 
-/*
- #define FDB_API_VERSION 610
- #include <foundationdb/fdb_c.h>
-*/
+// #define FDB_API_VERSION 610
+// #include <foundationdb/fdb_c.h>
 import "C"
 
 import (

--- a/bindings/go/src/fdb/fdb.go
+++ b/bindings/go/src/fdb/fdb.go
@@ -22,11 +22,9 @@
 
 package fdb
 
-/*
- #define FDB_API_VERSION 610
- #include <foundationdb/fdb_c.h>
- #include <stdlib.h>
-*/
+// #define FDB_API_VERSION 610
+// #include <foundationdb/fdb_c.h>
+// #include <stdlib.h>
 import "C"
 
 import (

--- a/bindings/go/src/fdb/futures.go
+++ b/bindings/go/src/fdb/futures.go
@@ -22,22 +22,20 @@
 
 package fdb
 
-/*
- #cgo LDFLAGS: -lfdb_c -lm
- #define FDB_API_VERSION 610
- #include <foundationdb/fdb_c.h>
- #include <string.h>
-
- extern void unlockMutex(void*);
-
- void go_callback(FDBFuture* f, void* m) {
-     unlockMutex(m);
- }
-
- void go_set_callback(void* f, void* m) {
-     fdb_future_set_callback(f, (FDBCallback)&go_callback, m);
- }
-*/
+//  #cgo LDFLAGS: -lfdb_c -lm
+//  #define FDB_API_VERSION 610
+//  #include <foundationdb/fdb_c.h>
+//  #include <string.h>
+//
+//  extern void unlockMutex(void*);
+//
+//  void go_callback(FDBFuture* f, void* m) {
+//      unlockMutex(m);
+//  }
+//
+//  void go_set_callback(void* f, void* m) {
+//      fdb_future_set_callback(f, (FDBCallback)&go_callback, m);
+//  }
 import "C"
 
 import (

--- a/bindings/go/src/fdb/generated.go
+++ b/bindings/go/src/fdb/generated.go
@@ -46,6 +46,13 @@ func (o NetworkOptions) SetLocalAddress(param string) error {
 	return o.setOpt(10, []byte(param))
 }
 
+// enable the object serializer for network communication
+//
+// Parameter: 0 is false, every other value is true
+func (o NetworkOptions) SetUseObjectSerializer(param int64) error {
+	return o.setOpt(11, int64ToBytes(param))
+}
+
 // Deprecated
 //
 // Parameter: path to cluster file
@@ -444,7 +451,7 @@ const (
 	// Infrequently used. The client has passed a specific row limit and wants
 	// that many rows delivered in a single batch. Because of iterator operation
 	// in client drivers make request batches transparent to the user, consider
-	// ``WANT_ALL`` StreamingMode instead. A row limit must be specified if this
+	// “WANT_ALL“ StreamingMode instead. A row limit must be specified if this
 	// mode is used.
 	StreamingModeExact StreamingMode = 1
 
@@ -561,15 +568,15 @@ type ErrorPredicate int
 
 const (
 
-	// Returns ``true`` if the error indicates the operations in the
-	// transactions should be retried because of transient error.
+	// Returns “true“ if the error indicates the operations in the transactions
+	// should be retried because of transient error.
 	ErrorPredicateRetryable ErrorPredicate = 50000
 
-	// Returns ``true`` if the error indicates the transaction may have
-	// succeeded, though not in a way the system can verify.
+	// Returns “true“ if the error indicates the transaction may have succeeded,
+	// though not in a way the system can verify.
 	ErrorPredicateMaybeCommitted ErrorPredicate = 50001
 
-	// Returns ``true`` if the error indicates the transaction has not
-	// committed, though in a way that can be retried.
+	// Returns “true“ if the error indicates the transaction has not committed,
+	// though in a way that can be retried.
 	ErrorPredicateRetryableNotCommitted ErrorPredicate = 50002
 )

--- a/bindings/go/src/fdb/range.go
+++ b/bindings/go/src/fdb/range.go
@@ -22,10 +22,8 @@
 
 package fdb
 
-/*
- #define FDB_API_VERSION 610
- #include <foundationdb/fdb_c.h>
-*/
+// #define FDB_API_VERSION 610
+// #include <foundationdb/fdb_c.h>
 import "C"
 
 import (

--- a/bindings/go/src/fdb/transaction.go
+++ b/bindings/go/src/fdb/transaction.go
@@ -22,10 +22,8 @@
 
 package fdb
 
-/*
- #define FDB_API_VERSION 610
- #include <foundationdb/fdb_c.h>
-*/
+// #define FDB_API_VERSION 610
+// #include <foundationdb/fdb_c.h>
 import "C"
 
 // A ReadTransaction can asynchronously read from a FoundationDB


### PR DESCRIPTION
This converts the multi-line comments for C imports to single line comments, which at the least is more idiomatic.

This also updates `generated.go` to reflect some recent `fdb.options` changes. These are unrelated, but it happens automatically when building our go bindings.

This resolves #1612.