### PR TITLE
fixed a very rare bug would could cause files sizes to grow on TLogs

### DIFF
--- a/fdbserver/TLogServer.actor.cpp
+++ b/fdbserver/TLogServer.actor.cpp
@@ -648,7 +648,7 @@ ACTOR Future<Void> updatePoppedLocation( TLogData* self, Reference<LogData> logD
 	if (!data->requiresPoppedLocationUpdate) return Void();
 	data->requiresPoppedLocationUpdate = false;
 
-	if (data->popped < logData->persistentDataVersion) {
+	if (data->popped <= logData->persistentDataVersion) {
 		// Recover the next needed location in the Disk Queue from the index.
 		Standalone<VectorRef<KeyValueRef>> kvrefs = wait(
 				self->persistentData->readRange(KeyRangeRef(


### PR DESCRIPTION
If a removed storage server was popped to exactly the persistDataVersion on a TLog; its disk queue file would grow indefinitely