### PR TITLE
change common directory errors for easy comparison

### DIFF
--- a/bindings/go/src/fdb/directory/directory.go
+++ b/bindings/go/src/fdb/directory/directory.go
@@ -59,7 +59,7 @@ var (
 	// ErrDirAlreadyExists is returned when trying to create a directory while it already exists.
 	ErrDirAlreadyExists = errors.New("the directory already exists")
 
-	// ErrDirNotExists is returned when opening or listing a directory that does not exists.
+	// ErrDirNotExists is returned when opening or listing a directory that does not exist.
 	ErrDirNotExists = errors.New("the directory does not exist")
 
 	// ErrParentDirDoesNotExist is returned when opening a directory and one or more

--- a/bindings/go/src/fdb/directory/directory.go
+++ b/bindings/go/src/fdb/directory/directory.go
@@ -41,6 +41,7 @@ package directory
 
 import (
 	"errors"
+
 	"github.com/apple/foundationdb/bindings/go/src/fdb"
 	"github.com/apple/foundationdb/bindings/go/src/fdb/subspace"
 )
@@ -52,6 +53,12 @@ const (
 	_MAJORVERSION int32 = 1
 	_MINORVERSION int32 = 0
 	_MICROVERSION int32 = 0
+)
+
+var (
+	ErrDirAlreadyExists      = errors.New("the directory already exists")
+	ErrDirNotExists          = errors.New("the directory does not exist")
+	ErrParentDirDoesNotExist = errors.New("the parent directory does not exist")
 )
 
 // Directory represents a subspace of keys in a FoundationDB database,

--- a/bindings/go/src/fdb/directory/directory.go
+++ b/bindings/go/src/fdb/directory/directory.go
@@ -56,8 +56,14 @@ const (
 )
 
 var (
-	ErrDirAlreadyExists      = errors.New("the directory already exists")
-	ErrDirNotExists          = errors.New("the directory does not exist")
+	// ErrDirAlreadyExists is returned when trying to create a directory while it already exists.
+	ErrDirAlreadyExists = errors.New("the directory already exists")
+
+	// ErrDirNotExists is returned when opening or listing a directory that does not exists.
+	ErrDirNotExists = errors.New("the directory does not exist")
+
+	// ErrParentDirDoesNotExist is returned when opening a directory and one or more
+	// parent directories in the path do not exist.
 	ErrParentDirDoesNotExist = errors.New("the parent directory does not exist")
 )
 
@@ -76,8 +82,9 @@ type Directory interface {
 	CreateOrOpen(t fdb.Transactor, path []string, layer []byte) (DirectorySubspace, error)
 
 	// Open opens the directory specified by path (relative to this Directory),
-	// and returns the directory and its contents as a DirectorySubspace (or an
-	// error if the directory does not exist).
+	// and returns the directory and its contents as a DirectorySubspace (or ErrDirNotExists
+	// error if the directory does not exist, or ErrParentDirDoesNotExist if one of the parent
+	// directories in the path does not exist).
 	//
 	// If the byte slice layer is specified, it is compared against the layer
 	// specified when the directory was created, and an error is returned if
@@ -86,7 +93,7 @@ type Directory interface {
 
 	// Create creates a directory specified by path (relative to this
 	// Directory), and returns the directory and its contents as a
-	// DirectorySubspace (or an error if the directory already exists).
+	// DirectorySubspace (or ErrDirAlreadyExists if the directory already exists).
 	//
 	// If the byte slice layer is specified, it is recorded as the layer and
 	// will be checked when opening the directory in the future.

--- a/bindings/go/src/fdb/directory/directoryLayer.go
+++ b/bindings/go/src/fdb/directory/directoryLayer.go
@@ -99,7 +99,7 @@ func (dl directoryLayer) createOrOpen(rtr fdb.ReadTransaction, tr *fdb.Transacti
 		}
 
 		if !allowOpen {
-			return nil, errors.New("the directory already exists")
+			return nil, ErrDirAlreadyExists
 		}
 
 		if layer != nil {
@@ -112,7 +112,7 @@ func (dl directoryLayer) createOrOpen(rtr fdb.ReadTransaction, tr *fdb.Transacti
 	}
 
 	if !allowCreate {
-		return nil, errors.New("the directory does not exist")
+		return nil, ErrDirNotExists
 	}
 
 	if e := dl.checkVersion(rtr, tr); e != nil {
@@ -161,7 +161,7 @@ func (dl directoryLayer) createOrOpen(rtr fdb.ReadTransaction, tr *fdb.Transacti
 	}
 
 	if parentNode == nil {
-		return nil, errors.New("the parent directory does not exist")
+		return nil, ErrParentDirDoesNotExist
 	}
 
 	node := dl.nodeWithPrefix(prefix)
@@ -254,7 +254,7 @@ func (dl directoryLayer) List(rt fdb.ReadTransactor, path []string) ([]string, e
 
 		node := dl.find(rtr, path).prefetchMetadata(rtr)
 		if !node.exists() {
-			return nil, errors.New("the directory does not exist")
+			return nil, ErrDirNotExists
 		}
 
 		if node.isInPartition(nil, true) {


### PR DESCRIPTION
This pull requests changes common directory errors to public package level variables for easy comparison. This allows user code to check for obvious error, like an directory that does not exist when opening:

```
d, err := directory.Open(tx, []{"table"}, l)
if err != nil {
   if err == directory.ErrDirNotExists {
      return nil, errors.New("table not found")
   }

   // ...
}
```