### PR TITLE
windows build fix : del sys/wait.h in Platform.cpp

### DIFF
--- a/flow/Platform.cpp
+++ b/flow/Platform.cpp
@@ -42,7 +42,6 @@
 #include <sys/types.h>
 #include <time.h>
 #include <sys/stat.h>
-#include <sys/wait.h>
 #include <fcntl.h>
 #include "flow/UnitTest.h"
 #include "flow/FaultInjection.h"


### PR DESCRIPTION
Remove the unwanted include of sys/wait.h in Platform.cpp.