### PR TITLE
Clients should seed the deterministic random number generator on the …

### DIFF
--- a/bindings/flow/fdb_flow.actor.cpp
+++ b/bindings/flow/fdb_flow.actor.cpp
@@ -81,10 +81,6 @@ void fdb_flow_test() {
 	fdb->setupNetwork();
 	startThread(networkThread, fdb);
 
-	int randomSeed = platform::getRandomSeed();
-
-	setThreadLocalDeterministicRandomSeed(randomSeed);
-
 	g_network = newNet2( false );
 
 	openTraceFile(NetworkAddress(), 1000000, 1000000, ".");

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -1004,8 +1004,6 @@ void setupNetwork(uint64_t transportId, bool useMetrics) {
 	if( g_network )
 		throw network_already_setup();
 
-	setThreadLocalDeterministicRandomSeed(platform::getRandomSeed());
-
 	if (!networkOptions.logClientInfo.present())
 		networkOptions.logClientInfo = true;
 
@@ -1027,6 +1025,8 @@ void runNetwork() {
 	if(networkOptions.traceDirectory.present() && networkOptions.slowTaskProfilingEnabled) {
 		setupSlowTaskProfiler();
 	}
+
+	setThreadLocalDeterministicRandomSeed(platform::getRandomSeed());
 
 	g_network->run();
 

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -1026,8 +1026,6 @@ void runNetwork() {
 		setupSlowTaskProfiler();
 	}
 
-	setThreadLocalDeterministicRandomSeed(platform::getRandomSeed());
-
 	g_network->run();
 
 	if(networkOptions.traceDirectory.present())

--- a/flow/IRandom.h
+++ b/flow/IRandom.h
@@ -127,6 +127,8 @@ void setThreadLocalDeterministicRandomSeed(uint32_t seed);
 
 // Returns the random number generator that can be seeded. This generator should only 
 // be used in contexts where the choice to call it is deterministic.
+//
+// This generator is only deterministic if given a seed using setThreadLocalDeterministicRandomSeed
 Reference<IRandom> deterministicRandom();
 
 // A random number generator that cannot be manually seeded and may be called in 

--- a/flow/flow.cpp
+++ b/flow/flow.cpp
@@ -37,7 +37,7 @@ void setThreadLocalDeterministicRandomSeed(uint32_t seed) {
 
 Reference<IRandom> deterministicRandom() {
 	if(!seededRandom) {
-		seededRandom = Reference<IRandom>(new DeterministicRandom(1, true));
+		seededRandom = Reference<IRandom>(new DeterministicRandom(platform::getRandomSeed(), true));
 	}
 	return seededRandom;
 }


### PR DESCRIPTION
…network thread.