### PR TITLE
Fix printable() being incorrect for bytes >127.

### DIFF
--- a/flow/Trace.h
+++ b/flow/Trace.h
@@ -331,10 +331,11 @@ struct TraceableStringImpl : std::true_type {
 				result.push_back('\\');
 				result.push_back('\\');
 			} else {
+				const uint8_t byte = *iter;
 				result.push_back('\\');
 				result.push_back('x');
-				result.push_back(base16Char(*iter / 16));
-				result.push_back(base16Char(*iter));
+				result.push_back(base16Char(byte / 16));
+				result.push_back(base16Char(byte));
 			}
 		}
 		return result;


### PR DESCRIPTION
The use of `auto` hid that TraceableString<T>::begin(value) was a signed
char, and therefore `*iter` was -1, and -1/16 is 0.

Thus, a 0xFF byte was printed as \x0f.  Forcing it to an unsigned type
makes it correctly become \xff.