### PR TITLE
unwrap error for retry

### DIFF
--- a/bindings/go/go.mod
+++ b/bindings/go/go.mod
@@ -3,4 +3,4 @@ module github.com/apple/foundationdb/bindings/go
 // The FoundationDB go bindings currently have no external golang dependencies outside of
 // the go standard library.
 
-require golang.org/x/xerrors v0.0.0-20190513163551-3ee3066db522 // indirect
+require golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 // indirect

--- a/bindings/go/go.mod
+++ b/bindings/go/go.mod
@@ -2,3 +2,5 @@ module github.com/apple/foundationdb/bindings/go
 
 // The FoundationDB go bindings currently have no external golang dependencies outside of
 // the go standard library.
+
+require golang.org/x/xerrors v0.0.0-20190513163551-3ee3066db522 // indirect

--- a/bindings/go/src/fdb/database.go
+++ b/bindings/go/src/fdb/database.go
@@ -117,7 +117,7 @@ func retryable(wrapped func() (interface{}, error), onError func(Error) FutureNi
 // will recover a panicked Error and either retry the transaction or return the
 // error.
 //
-// The transaction is retried if the error is or wraps an retryable Error.
+// The transaction is retried if the error is or wraps a retryable Error.
 // The error is unwrapped with the xerrors.Wrapper. See https://godoc.org/golang.org/x/xerrors#Wrapper
 // for details.
 //

--- a/bindings/go/src/fdb/database.go
+++ b/bindings/go/src/fdb/database.go
@@ -161,7 +161,7 @@ func (d Database) Transact(f func(Transaction) (interface{}, error)) (interface{
 // MustGet. ReadTransact will recover a panicked Error and either retry the
 // transaction or return the error.
 //
-// The transaction is retried if the error is or wraps an retryable Error.
+// The transaction is retried if the error is or wraps a retryable Error.
 // The error is unwrapped with the xerrors.Wrapper. See https://godoc.org/golang.org/x/xerrors#Wrapper
 // for details.
 //

--- a/bindings/go/src/fdb/database.go
+++ b/bindings/go/src/fdb/database.go
@@ -162,7 +162,7 @@ func (d Database) Transact(f func(Transaction) (interface{}, error)) (interface{
 // transaction or return the error.
 //
 // The transaction is retried if the error is or wraps an retryable Error.
-// The error is unwrapped with the xerrors.Wrapper, see https://godoc.org/golang.org/x/xerrors#Wrapper
+// The error is unwrapped with the xerrors.Wrapper. See https://godoc.org/golang.org/x/xerrors#Wrapper
 // for details.
 //
 // Do not return Future objects from the function provided to ReadTransact. The

--- a/bindings/go/src/fdb/database.go
+++ b/bindings/go/src/fdb/database.go
@@ -118,7 +118,7 @@ func retryable(wrapped func() (interface{}, error), onError func(Error) FutureNi
 // error.
 //
 // The transaction is retried if the error is or wraps an retryable Error.
-// The error is unwrapped with the xerrors.Wrapper, see https://godoc.org/golang.org/x/xerrors#Wrapper
+// The error is unwrapped with the xerrors.Wrapper. See https://godoc.org/golang.org/x/xerrors#Wrapper
 // for details.
 //
 // Do not return Future objects from the function provided to Transact. The

--- a/bindings/go/src/fdb/database.go
+++ b/bindings/go/src/fdb/database.go
@@ -28,6 +28,8 @@ import "C"
 
 import (
 	"runtime"
+
+	"golang.org/x/xerrors"
 )
 
 // Database is a handle to a FoundationDB database. Database is a lightweight
@@ -89,8 +91,10 @@ func retryable(wrapped func() (interface{}, error), onError func(Error) FutureNi
 			return
 		}
 
-		ep, ok := e.(Error)
-		if ok {
+		// Check if the error chain contains an
+		// fdb.Error
+		var ep Error
+		if xerrors.As(e, &ep) {
 			e = onError(ep).Get()
 		}
 
@@ -112,6 +116,10 @@ func retryable(wrapped func() (interface{}, error), onError func(Error) FutureNi
 // explicitly check and return error values using Get, or call MustGet. Transact
 // will recover a panicked Error and either retry the transaction or return the
 // error.
+//
+// The transaction is retried if the error is or wraps an retryable Error.
+// The error is unwrapped with the xerrors.Wrapper, see https://godoc.org/golang.org/x/xerrors#Wrapper
+// for details.
 //
 // Do not return Future objects from the function provided to Transact. The
 // Transaction created by Transact may be finalized at any point after Transact
@@ -152,6 +160,10 @@ func (d Database) Transact(f func(Transaction) (interface{}, error)) (interface{
 // may either explicitly check and return error values using Get, or call
 // MustGet. ReadTransact will recover a panicked Error and either retry the
 // transaction or return the error.
+//
+// The transaction is retried if the error is or wraps an retryable Error.
+// The error is unwrapped with the xerrors.Wrapper, see https://godoc.org/golang.org/x/xerrors#Wrapper
+// for details.
 //
 // Do not return Future objects from the function provided to ReadTransact. The
 // Transaction created by ReadTransact may be finalized at any point after

--- a/bindings/go/src/fdb/retryable_test.go
+++ b/bindings/go/src/fdb/retryable_test.go
@@ -1,0 +1,67 @@
+package fdb
+
+import (
+	"errors"
+	"testing"
+
+	"golang.org/x/xerrors"
+)
+
+type futureNilValue struct {
+	err error
+}
+
+func (f futureNilValue) Get() error {
+	return f.err
+}
+
+func (f futureNilValue) MustGet() {
+	if f.err != nil {
+		panic(f.err)
+	}
+}
+
+func (f futureNilValue) BlockUntilReady() {}
+
+func (f futureNilValue) IsReady() bool { return true }
+
+func (f futureNilValue) Cancel() {}
+
+func TestRetryable(t *testing.T) {
+	retryableError := Error{1007}
+	wrapped := func() (interface{}, error) {
+		return nil, retryableError
+	}
+
+	var ep Error
+	onError := func(e Error) FutureNil {
+		ep = e
+		return futureNilValue{errors.New("stop")}
+	}
+
+	retryable(wrapped, onError)
+
+	if ep != retryableError {
+		t.Errorf("onError not called with fdb.Error")
+	}
+}
+
+func TestRetryableWrap(t *testing.T) {
+	retryableError := Error{1007}
+	wrappedError := xerrors.Errorf("failed to read key: %w", retryableError)
+	wrapped := func() (interface{}, error) {
+		return nil, wrappedError
+	}
+
+	var ep Error
+	onError := func(e Error) FutureNil {
+		ep = e
+		return futureNilValue{errors.New("stop")}
+	}
+
+	retryable(wrapped, onError)
+
+	if ep.Error() != retryableError.Error() {
+		t.Errorf("onError not called with fdb.Error, but %T: %v", ep, ep)
+	}
+}


### PR DESCRIPTION
The Go team released a new error package called [xerror](https://godoc.org/golang.org/x/xerrors) to supports transitioning to the Go 2 proposal for error values. According to the documentation of xerror, most of the functions and types of the xerrors package will be incorporated into the standard library's errors package in Go 1.13.

One of the concepts xerrors introduces is a strandard way errors can be chained. A bit like the inner exception concept of .NET and getCause of Java exception.

This pull requests adds support for wrapper fdb.Error's in transactions. The retry loop first unwraps the error chain to see if there is an fdb.Error, and if so, it will see if it is retryable. This is fully backwards compatible due the way how xerrors wrapping works.

The change allows users to wrap errors within transactions an provide extra context, here is an example:

``` go
db.Transact(func(tx fdb.Transaction) (interface{}, error) {
  for i := 0; i < 10; i++ {
    myObject, err := readMyObject(tx);
    if err != nil {
      return nil, xerrors.Errorf("my object read error at index %v: %w", i, err)
    }
    
    ...
  }
  
  ...
})
```

In this example, readMyObject might have failed due an retryable fdb.Error, or it might be an error that represents an deserialization problem. The later will now be available to the Transact caller and the extra added context will not interfere with fdb's retry logic.