### PR TITLE
Refactor NextFastAllocatedSize to be constexpr function

### DIFF
--- a/fdbclient/VersionedMap.h
+++ b/fdbclient/VersionedMap.h
@@ -484,7 +484,7 @@ public:
 	}
 
 	// For each item in the versioned map, 4 PTree nodes are potentially allocated:
-	static const int overheadPerItem = NextFastAllocatedSize<sizeof(PTreeT)>::Result*4;
+	static const int overheadPerItem = nextFastAllocatedSize(sizeof(PTreeT)) * 4;
 	struct iterator;
 
 	VersionedMap() : oldestVersion(0), latestVersion(0) {

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -3756,7 +3756,7 @@ void versionedMapTest() {
 	printf("SS Ptree node is %zu bytes\n", sizeof( StorageServer::VersionedData::PTreeT ) );
 
 	const int NSIZE = sizeof(VersionedMap<int,int>::PTreeT);
-	const int ASIZE = NSIZE<=64 ? 64 : NextFastAllocatedSize<NSIZE>::Result;
+	const int ASIZE = NSIZE <= 64 ? 64 : nextFastAllocatedSize(NSIZE);
 
 	auto before = FastAllocator< ASIZE >::getTotalMemory();
 

--- a/flow/FastAlloc.h
+++ b/flow/FastAlloc.h
@@ -39,6 +39,7 @@
 
 #include "flow/Hash3.h"
 
+#include <assert.h>
 #include <vector>
 #include <cstdlib>
 #include <cstdio>
@@ -157,17 +158,31 @@ void releaseAllThreadMagazines();
 int64_t getTotalUnusedAllocatedMemory();
 void setFastAllocatorThreadInitFunction( void (*)() );  // The given function will be called at least once in each thread that allocates from a FastAllocator.  Currently just one such function is tracked.
 
-template<int X>
-class NextFastAllocatedSize {
-	static const int A = X-1;
-	static const int B = A | (A>>1);
-	static const int C = B | (B>>2);
-	static const int D = C | (C>>4);
-	static const int E = D | (D>>8);
-	static const int F = E | (E>>16);
-public:
-	static const int Result = (X > 64 && X <= 96) ? 96 : F+1;
-};
+inline constexpr int nextFastAllocatedSize(int x) {
+	assert(x > 0 && x <= 8192);
+	if (x <= 16)
+		return 16;
+	else if (x <= 32)
+		return 32;
+	else if (x <= 64)
+		return 64;
+	else if (x <= 96)
+		return 96;
+	else if (x <= 128)
+		return 128;
+	else if (x <= 256)
+		return 256;
+	else if (x <= 512)
+		return 512;
+	else if (x <= 1024)
+		return 1024;
+	else if (x <= 2048)
+		return 2048;
+	else if (x <= 4096)
+		return 4096;
+	else
+		return 8192;
+}
 
 template <class Object>
 class FastAllocated {
@@ -175,13 +190,13 @@ public:
 	static void* operator new(size_t s) {
 		if (s != sizeof(Object)) abort();
 		INSTRUMENT_ALLOCATE(typeid(Object).name());
-		void* p = FastAllocator<sizeof(Object)<=64 ? 64 : NextFastAllocatedSize<sizeof(Object)>::Result>::allocate();
+		void* p = FastAllocator < sizeof(Object) <= 64 ? 64 : nextFastAllocatedSize(sizeof(Object)) > ::allocate();
 		return p;
 	}
 
 	static void operator delete(void* s) {
 		INSTRUMENT_RELEASE(typeid(Object).name());
-		FastAllocator<sizeof(Object)<=64 ? 64 : NextFastAllocatedSize<sizeof(Object)>::Result>::release(s);
+		FastAllocator<sizeof(Object) <= 64 ? 64 : nextFastAllocatedSize(sizeof(Object))>::release(s);
 	}
 	// Redefine placement new so you can still use it
 	static void* operator new( size_t, void* p ) { return p; }


### PR DESCRIPTION
With C++17, nextFastAllocatedSize can be made much more readable.