### PR TITLE
Better handling for large packets

### DIFF
--- a/fdbrpc/FlowTransport.actor.cpp
+++ b/fdbrpc/FlowTransport.actor.cpp
@@ -18,22 +18,25 @@
  * limitations under the License.
  */
 
-#include "flow/flow.h"
 #include "fdbrpc/FlowTransport.h"
-#include "fdbrpc/genericactors.actor.h"
-#include "fdbrpc/fdbrpc.h"
-#include "flow/Net2Packet.h"
-#include "flow/ActorCollection.h"
-#include "flow/TDMetric.actor.h"
-#include "flow/ObjectSerializer.h"
-#include "fdbrpc/FailureMonitor.h"
-#include "fdbrpc/crc32c.h"
-#include "fdbrpc/simulator.h"
-#include <unordered_map>
 
+#include <unordered_map>
 #if VALGRIND
 #include <memcheck.h>
 #endif
+
+#include "fdbrpc/crc32c.h"
+#include "fdbrpc/fdbrpc.h"
+#include "fdbrpc/FailureMonitor.h"
+#include "fdbrpc/genericactors.actor.h"
+#include "fdbrpc/simulator.h"
+#include "flow/ActorCollection.h"
+#include "flow/Error.h"
+#include "flow/flow.h"
+#include "flow/Net2Packet.h"
+#include "flow/TDMetric.actor.h"
+#include "flow/ObjectSerializer.h"
+#include "flow/ProtocolVersion.h"
 #include "flow/actorcompiler.h"  // This must be the last #include.
 
 static NetworkAddressList g_currentDeliveryPeerAddress = NetworkAddressList();

--- a/fdbrpc/FlowTransport.actor.cpp
+++ b/fdbrpc/FlowTransport.actor.cpp
@@ -732,7 +732,7 @@ static void scanPackets(TransportData* transport, uint8_t*& unprocessed_begin, c
 
 // Given unprocessed buffer [begin, end), check if next packet size is known and return
 // enough size for the next packet, whose format is: {size, optional_checksum, data}.
-static int getNewBufferSize(uint8_t* begin, uint8_t* end, const NetworkAddress& peerAddress) {
+static int getNewBufferSize(const uint8_t* begin, const uint8_t* end, const NetworkAddress& peerAddress) {
 	const int len = end - begin;
 	if (len < sizeof(uint32_t)) {
 		return std::max(FLOW_KNOBS->DEFAULT_PACKET_BUFFER_BYTES, len * 2);

--- a/fdbrpc/FlowTransport.actor.cpp
+++ b/fdbrpc/FlowTransport.actor.cpp
@@ -735,7 +735,7 @@ static void scanPackets(TransportData* transport, uint8_t*& unprocessed_begin, c
 static int getNewBufferSize(const uint8_t* begin, const uint8_t* end, const NetworkAddress& peerAddress) {
 	const int len = end - begin;
 	if (len < sizeof(uint32_t)) {
-		return std::max(FLOW_KNOBS->DEFAULT_PACKET_BUFFER_BYTES, len * 2);
+		return FLOW_KNOBS->MIN_PACKET_BUFFER_BYTES;
 	}
 	const uint32_t packetLen = *(uint32_t*)begin;
 	if (packetLen > FLOW_KNOBS->PACKET_LIMIT) {

--- a/fdbrpc/FlowTransport.h
+++ b/fdbrpc/FlowTransport.h
@@ -23,6 +23,7 @@
 #pragma once
 
 #include <algorithm>
+#include "flow/genericactors.actor.h"
 #include "flow/network.h"
 #include "flow/FileIdentifier.h"
 

--- a/flow/Knobs.cpp
+++ b/flow/Knobs.cpp
@@ -109,6 +109,9 @@ FlowKnobs::FlowKnobs(bool randomize, bool isSimulated) {
 	init( PACKET_LIMIT,                                  100LL<<20 );
 	init( PACKET_WARNING,                                  2LL<<20 );  // 2MB packet warning quietly allows for 1MB system messages
 	init( TIME_OFFSET_LOGGING_INTERVAL,                       60.0 );
+	init( MAX_PACKET_SEND_BYTES,                        256 * 1024 );
+	init( DEFAULT_PACKET_BUFFER_BYTES,                   64 * 1024 );
+	init( MIN_PACKET_BUFFER_BYTES,                        4 * 1024 );
 
 	//Sim2
 	init( MIN_OPEN_TIME,                                    0.0002 );

--- a/flow/Knobs.cpp
+++ b/flow/Knobs.cpp
@@ -111,6 +111,7 @@ FlowKnobs::FlowKnobs(bool randomize, bool isSimulated) {
 	init( TIME_OFFSET_LOGGING_INTERVAL,                       60.0 );
 	init( MAX_PACKET_SEND_BYTES,                        256 * 1024 );
 	init( MIN_PACKET_BUFFER_BYTES,                        4 * 1024 );
+	init( MIN_PACKET_BUFFER_FREE_BYTES,                        256 );
 
 	//Sim2
 	init( MIN_OPEN_TIME,                                    0.0002 );

--- a/flow/Knobs.cpp
+++ b/flow/Knobs.cpp
@@ -110,7 +110,6 @@ FlowKnobs::FlowKnobs(bool randomize, bool isSimulated) {
 	init( PACKET_WARNING,                                  2LL<<20 );  // 2MB packet warning quietly allows for 1MB system messages
 	init( TIME_OFFSET_LOGGING_INTERVAL,                       60.0 );
 	init( MAX_PACKET_SEND_BYTES,                        256 * 1024 );
-	init( DEFAULT_PACKET_BUFFER_BYTES,                   64 * 1024 );
 	init( MIN_PACKET_BUFFER_BYTES,                        4 * 1024 );
 
 	//Sim2

--- a/flow/Knobs.h
+++ b/flow/Knobs.h
@@ -129,7 +129,6 @@ public:
 	int64_t PACKET_WARNING;  // 2MB packet warning quietly allows for 1MB system messages
 	double TIME_OFFSET_LOGGING_INTERVAL;
 	int MAX_PACKET_SEND_BYTES;
-	int DEFAULT_PACKET_BUFFER_BYTES;
 	int MIN_PACKET_BUFFER_BYTES;
 
 	//Sim2

--- a/flow/Knobs.h
+++ b/flow/Knobs.h
@@ -130,6 +130,7 @@ public:
 	double TIME_OFFSET_LOGGING_INTERVAL;
 	int MAX_PACKET_SEND_BYTES;
 	int MIN_PACKET_BUFFER_BYTES;
+	int MIN_PACKET_BUFFER_FREE_BYTES;
 
 	//Sim2
 	//FIMXE: more parameters could be factored out

--- a/flow/Knobs.h
+++ b/flow/Knobs.h
@@ -128,6 +128,9 @@ public:
 	int64_t PACKET_LIMIT;
 	int64_t PACKET_WARNING;  // 2MB packet warning quietly allows for 1MB system messages
 	double TIME_OFFSET_LOGGING_INTERVAL;
+	int MAX_PACKET_SEND_BYTES;
+	int DEFAULT_PACKET_BUFFER_BYTES;
+	int MIN_PACKET_BUFFER_BYTES;
 
 	//Sim2
 	//FIMXE: more parameters could be factored out


### PR DESCRIPTION
On the sending side, a large packet is split into smaller pieces. On the
receiving side, use packet length to allocate buffer to avoid multiple memcpy
and allocations.

This fixes #1466 and #1680 .