### PR TITLE
Small typos

### DIFF
--- a/documentation/sphinx/source/cap-theorem.rst
+++ b/documentation/sphinx/source/cap-theorem.rst
@@ -22,7 +22,7 @@ What does choosing Availability mean?
 
 Let's consider an **AP** database. In such a database, reads and writes would always succeed, even when network connectivity is unavailable between nodes. If possible, these would certainly seem like desirable properties!
 
-However, the downside is stark. Imagine a simple distributed database consisting of two nodes and a network partition making them unable communicate. To be Available, each of the two nodes must continue to accept writes from clients.
+However, the downside is stark. Imagine a simple distributed database consisting of two nodes and a network partition making them unable to communicate. To be Available, each of the two nodes must continue to accept writes from clients.
 
 .. figure:: /images/AP_Partition.png
 

--- a/documentation/sphinx/source/features.rst
+++ b/documentation/sphinx/source/features.rst
@@ -30,7 +30,7 @@ FoundationDB stores each piece of data on multiple servers. If a server containi
 Ordered Key-Value API
 ---------------------
 
-Simple can be powerful. FoundationDB uses an ordered key-value data model (and richer data models are exposed via :doc:`layers <layer-concept>`. Each "row" within the database consists of a key that is used to reference the row and a value which stores data associated with the key. No specific format for the keys or values is required; they are simply binary data. Because keys are kept in lexicographical (sorted) order, ranges of key-value pairs can be read efficiently.
+Simple can be powerful. FoundationDB uses an ordered key-value data model (and richer data models are exposed via :doc:`layers <layer-concept>`). Each "row" within the database consists of a key that is used to reference the row and a value which stores data associated with the key. No specific format for the keys or values is required; they are simply binary data. Because keys are kept in lexicographical (sorted) order, ranges of key-value pairs can be read efficiently.
 
 Watches
 -------


### PR DESCRIPTION
Fix a couple of small typos in the docs:

1. In CAP Theorem, [What does choosing Availability mean?](https://github.com/apple/foundationdb/blob/3b86576b69aba565d4c2b8ab509ae87d155c6c80/documentation/sphinx/source/cap-theorem.rst#what-does-choosing-availability-mean), second paragraph, I think "unable communicate" should be "unable *to* communicate"
2. In Features, [Ordered Key-Value API](https://github.com/apple/foundationdb/blob/3b86576b69aba565d4c2b8ab509ae87d155c6c80/documentation/sphinx/source/features.rst#ordered-key-value-api), first paragraph, I think there should be a closing bracket