### PR TITLE
Recovery Optimization

### DIFF
--- a/fdbserver/WorkerInterface.actor.h
+++ b/fdbserver/WorkerInterface.actor.h
@@ -416,7 +416,7 @@ ACTOR Future<Void> storageServer(IKeyValueStore* persistentData, StorageServerIn
 ACTOR Future<Void> storageServer(IKeyValueStore* persistentData, StorageServerInterface ssi,
                                  Reference<AsyncVar<ServerDBInfo>> db, std::string folder,
                                  Promise<Void> recovered,
-                                 Reference<ClusterConnectionFile> const& connFile );  // changes pssi->id() to be the recovered ID); // changes pssi->id() to be the recovered ID
+                                 Reference<ClusterConnectionFile> connFile );  // changes pssi->id() to be the recovered ID); // changes pssi->id() to be the recovered ID
 ACTOR Future<Void> masterServer(MasterInterface mi, Reference<AsyncVar<ServerDBInfo>> db,
                                 ServerCoordinators serverCoordinators, LifetimeToken lifetime, bool forceRecovery);
 ACTOR Future<Void> masterProxyServer(MasterProxyInterface proxy, InitializeMasterProxyRequest req,

--- a/fdbserver/WorkerInterface.actor.h
+++ b/fdbserver/WorkerInterface.actor.h
@@ -415,7 +415,8 @@ ACTOR Future<Void> storageServer(IKeyValueStore* persistentData, StorageServerIn
                                  Reference<AsyncVar<ServerDBInfo>> db, std::string folder);
 ACTOR Future<Void> storageServer(IKeyValueStore* persistentData, StorageServerInterface ssi,
                                  Reference<AsyncVar<ServerDBInfo>> db, std::string folder,
-                                 Promise<Void> recovered); // changes pssi->id() to be the recovered ID
+                                 Promise<Void> recovered,
+                                 Reference<ClusterConnectionFile> const& connFile );  // changes pssi->id() to be the recovered ID); // changes pssi->id() to be the recovered ID
 ACTOR Future<Void> masterServer(MasterInterface mi, Reference<AsyncVar<ServerDBInfo>> db,
                                 ServerCoordinators serverCoordinators, LifetimeToken lifetime, bool forceRecovery);
 ACTOR Future<Void> masterProxyServer(MasterProxyInterface proxy, InitializeMasterProxyRequest req,

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -3642,16 +3642,11 @@ ACTOR Future<Void> memoryStoreRecover(IKeyValueStore* store, Reference<ClusterCo
 				tr.reset();
 				TraceEvent("RemoveStorageServerRetrying").detail("Count", noCanRemoveCount++).detail("ServerID", id).detail("CanRemove", canRemove);
 			} else {
-				wait(tr.commit());
 				return Void();
 			}
 		} catch (Error& e) {
 			state Error err = e;
-			try {
-			    wait( tr.onError(e));
-			} catch (Error& e2) {
-			    return Never();
-			}
+			wait(tr.onError(e));
 			TraceEvent("RemoveStorageServerRetrying").error(err);
 		}
 	}

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -3790,9 +3790,9 @@ ACTOR Future<Void> storageServer( IKeyValueStore* persistentData, StorageServerI
 		choose {
 			//after a rollback there might be uncommitted changes.
 			//for memory storage engine type, wait until recovery is done before commit
-			wait(self.storage.commit()) {}
+			when( wait(self.storage.commit()))  {}
 
-			wait(memoryStoreRecover (persistentData, connFile, self.thisServerID)) {
+			when( wait(memoryStoreRecover (persistentData, connFile, self.thisServerID))) {
 				TraceEvent("DisposeStorageServer", self.thisServerID);
 				throw worker_removed();
 			}

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -31,6 +31,7 @@
 #include "fdbclient/SystemData.h"
 #include "fdbclient/NativeAPI.actor.h"
 #include "fdbclient/Notified.h"
+#include "fdbclient/StatusClient.h"
 #include "fdbclient/MasterProxyInterface.h"
 #include "fdbclient/DatabaseContext.h"
 #include "fdbserver/WorkerInterface.actor.h"
@@ -3620,6 +3621,39 @@ bool storageServerTerminated(StorageServer& self, IKeyValueStore* persistentData
 		return false;
 }
 
+ACTOR Future<bool> memoryStoreRecover(IKeyValueStore* store, Reference<ClusterConnectionFile> connFile, UID id)
+{
+    if(store->getType() != KeyValueStoreType::MEMORY || connFile.getPtr() == nullptr) {
+        return false;
+    }
+
+	// create a temp client connect to DB
+	Database cx = Database::createDatabase(connFile, Database::API_VERSION_LATEST);
+
+	state Transaction tr( cx );
+	state int noCanRemoveCount = 0;
+	loop {
+		try {
+			tr.setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
+
+			state bool canRemove = wait( canRemoveStorageServer( &tr, id ) );
+			if (!canRemove) {
+				TEST(true); // it's possible that the caller had a transaction in flight that assigned keys to the server. Wait for it to reverse its mistake.
+				Void _ = wait( delayJittered(SERVER_KNOBS->REMOVE_RETRY_DELAY, TaskUpdateStorage) );
+				tr.reset();
+				TraceEvent("RemoveStorageServerRetrying").detail("Count", noCanRemoveCount++).detail("ServerID", id).detail("CanRemove", canRemove);
+			} else {
+				Void _ = wait(tr.commit());
+				return true;
+			}
+		} catch (Error& e) {
+			state Error err = e;
+			Void _ = wait( tr.onError(e) );
+			TraceEvent("RemoveStorageServerRetrying").error(err);
+		}
+	}
+}
+
 ACTOR Future<Void> storageServer( IKeyValueStore* persistentData, StorageServerInterface ssi, Tag seedTag, ReplyPromise<InitializeStorageReply> recruitReply,
 	Reference<AsyncVar<ServerDBInfo>> db, std::string folder )
 {
@@ -3739,7 +3773,7 @@ ACTOR Future<Void> replaceInterface( StorageServer* self, StorageServerInterface
 	return Void();
 }
 
-ACTOR Future<Void> storageServer( IKeyValueStore* persistentData, StorageServerInterface ssi, Reference<AsyncVar<ServerDBInfo>> db, std::string folder, Promise<Void> recovered )
+ACTOR Future<Void> storageServer( IKeyValueStore* persistentData, StorageServerInterface ssi, Reference<AsyncVar<ServerDBInfo>> db, std::string folder, Promise<Void> recovered, Reference<ClusterConnectionFile> connFile)
 {
 	state StorageServer self(persistentData, db, ssi);
 	self.folder = folder;
@@ -3747,8 +3781,21 @@ ACTOR Future<Void> storageServer( IKeyValueStore* persistentData, StorageServerI
 	try {
 		state double start = now();
 		TraceEvent("StorageServerRebootStart", self.thisServerID);
-		wait(self.storage.init());
-		wait(self.storage.commit()); //after a rollback there might be uncommitted changes.
+
+		state Future<bool> dispose = memoryStoreRecover (persistentData, connFile, self.thisServerID);
+        wait(self.storage.init());
+		//after a rollback there might be uncommitted changes.
+		//for memory storage engine type, wait until recovery is done before commit
+		state Future<bool> committed = self.storage.commit();
+		wait(success(dispose) || success(committed))
+		if (committed.isReady()) {
+			// recovery finished before dispose
+			dispose.cancel();
+		} else if (dispose.isReady() && dispose.get()){
+			TraceEvent("DisposeStorageServer", self.thisServerID);
+			throw worker_removed();
+		}
+
 		bool ok = wait( self.storage.restoreDurableState() );
 		if (!ok) {
 			if(recovered.canBeSet()) recovered.send(Void());

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -1318,8 +1318,7 @@ ACTOR Future<Key> findKey( StorageServer* data, KeySelectorRef sel, Version vers
 			ASSERT(returnKey != sel.getKey());
 
 			return returnKey;
-		}
-		else
+		} else
 			return forward ? range.end : range.begin;
 	}
 }
@@ -3623,9 +3622,9 @@ bool storageServerTerminated(StorageServer& self, IKeyValueStore* persistentData
 
 ACTOR Future<Void> memoryStoreRecover(IKeyValueStore* store, Reference<ClusterConnectionFile> connFile, UID id)
 {
-    if(store->getType() != KeyValueStoreType::MEMORY || connFile.getPtr() == nullptr) {
-        return Never();
-    }
+	if (store->getType() != KeyValueStoreType::MEMORY || connFile.getPtr() == nullptr) {
+		return Never();
+	}
 
 	// create a temp client connect to DB
 	Database cx = Database::createDatabase(connFile, Database::API_VERSION_LATEST);
@@ -3786,7 +3785,7 @@ ACTOR Future<Void> storageServer( IKeyValueStore* persistentData, StorageServerI
 		state double start = now();
 		TraceEvent("StorageServerRebootStart", self.thisServerID);
 
-        wait(self.storage.init());
+		wait(self.storage.init());
 		choose {
 			//after a rollback there might be uncommitted changes.
 			//for memory storage engine type, wait until recovery is done before commit

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -3652,8 +3652,8 @@ ACTOR Future<bool> memoryStoreRecover(IKeyValueStore* store, Reference<ClusterCo
 			    wait( tr.onError(e));
 			} catch (Error& e2) {
 			    return Never();
-            }
-            TraceEvent("RemoveStorageServerRetrying").error(err);
+			}
+			TraceEvent("RemoveStorageServerRetrying").error(err);
 		}
 	}
 }

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -3648,8 +3648,12 @@ ACTOR Future<bool> memoryStoreRecover(IKeyValueStore* store, Reference<ClusterCo
 			}
 		} catch (Error& e) {
 			state Error err = e;
-			wait( tr.onError(e) );
-			TraceEvent("RemoveStorageServerRetrying").error(err);
+			try {
+			    wait( tr.onError(e));
+			} catch (Error& e2) {
+			    return Never();
+            }
+            TraceEvent("RemoveStorageServerRetrying").error(err);
 		}
 	}
 }

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -3621,10 +3621,10 @@ bool storageServerTerminated(StorageServer& self, IKeyValueStore* persistentData
 		return false;
 }
 
-ACTOR Future<bool> memoryStoreRecover(IKeyValueStore* store, Reference<ClusterConnectionFile> connFile, UID id)
+ACTOR Future<Void> memoryStoreRecover(IKeyValueStore* store, Reference<ClusterConnectionFile> connFile, UID id)
 {
     if(store->getType() != KeyValueStoreType::MEMORY || connFile.getPtr() == nullptr) {
-        return false;
+        return Never();
     }
 
 	// create a temp client connect to DB
@@ -3644,7 +3644,7 @@ ACTOR Future<bool> memoryStoreRecover(IKeyValueStore* store, Reference<ClusterCo
 				TraceEvent("RemoveStorageServerRetrying").detail("Count", noCanRemoveCount++).detail("ServerID", id).detail("CanRemove", canRemove);
 			} else {
 				wait(tr.commit());
-				return true;
+				return Void();
 			}
 		} catch (Error& e) {
 			state Error err = e;
@@ -3786,18 +3786,16 @@ ACTOR Future<Void> storageServer( IKeyValueStore* persistentData, StorageServerI
 		state double start = now();
 		TraceEvent("StorageServerRebootStart", self.thisServerID);
 
-		state Future<bool> dispose = memoryStoreRecover (persistentData, connFile, self.thisServerID);
         wait(self.storage.init());
-		//after a rollback there might be uncommitted changes.
-		//for memory storage engine type, wait until recovery is done before commit
-		state Future<Void> committed = self.storage.commit();
-		wait(success(dispose) || success(committed));
-		if (committed.isReady()) {
-			// recovery finished before dispose
-			dispose.cancel();
-		} else if (dispose.isReady() && dispose.get()){
-			TraceEvent("DisposeStorageServer", self.thisServerID);
-			throw worker_removed();
+		choose {
+			//after a rollback there might be uncommitted changes.
+			//for memory storage engine type, wait until recovery is done before commit
+			wait(self.storage.commit()) {}
+
+			wait(memoryStoreRecover (persistentData, connFile, self.thisServerID)) {
+				TraceEvent("DisposeStorageServer", self.thisServerID);
+				throw worker_removed();
+			}
 		}
 
 		bool ok = wait( self.storage.restoreDurableState() );

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -3639,16 +3639,16 @@ ACTOR Future<bool> memoryStoreRecover(IKeyValueStore* store, Reference<ClusterCo
 			state bool canRemove = wait( canRemoveStorageServer( &tr, id ) );
 			if (!canRemove) {
 				TEST(true); // it's possible that the caller had a transaction in flight that assigned keys to the server. Wait for it to reverse its mistake.
-				Void _ = wait( delayJittered(SERVER_KNOBS->REMOVE_RETRY_DELAY, TaskUpdateStorage) );
+				wait( delayJittered(SERVER_KNOBS->REMOVE_RETRY_DELAY, TaskUpdateStorage) );
 				tr.reset();
 				TraceEvent("RemoveStorageServerRetrying").detail("Count", noCanRemoveCount++).detail("ServerID", id).detail("CanRemove", canRemove);
 			} else {
-				Void _ = wait(tr.commit());
+				wait(tr.commit());
 				return true;
 			}
 		} catch (Error& e) {
 			state Error err = e;
-			Void _ = wait( tr.onError(e) );
+			wait( tr.onError(e) );
 			TraceEvent("RemoveStorageServerRetrying").error(err);
 		}
 	}
@@ -3786,8 +3786,8 @@ ACTOR Future<Void> storageServer( IKeyValueStore* persistentData, StorageServerI
         wait(self.storage.init());
 		//after a rollback there might be uncommitted changes.
 		//for memory storage engine type, wait until recovery is done before commit
-		state Future<bool> committed = self.storage.commit();
-		wait(success(dispose) || success(committed))
+		state Future<Void> committed = self.storage.commit();
+		wait(success(dispose) || success(committed));
 		if (committed.isReady()) {
 			// recovery finished before dispose
 			dispose.cancel();

--- a/fdbserver/worker.actor.cpp
+++ b/fdbserver/worker.actor.cpp
@@ -556,7 +556,7 @@ ACTOR Future<Void> storageServerRollbackRebooter( Future<Void> prevStorageServer
 		DUMPTOKEN(recruited.getKeyValueStoreType);
 		DUMPTOKEN(recruited.watchValue);
 
-		prevStorageServer = storageServer( store, recruited, db, folder, Promise<Void>() );
+		prevStorageServer = storageServer( store, recruited, db, folder, Promise<Void>(), Reference<ClusterConnectionFile> (nullptr) );
 		prevStorageServer = handleIOErrors(prevStorageServer, store, id, store->onClosed());
 	}
 }
@@ -804,7 +804,7 @@ ACTOR Future<Void> workerServer(
 				DUMPTOKEN(recruited.watchValue);
 
 				Promise<Void> recovery;
-				Future<Void> f = storageServer( kv, recruited, dbInfo, folder, recovery );
+				Future<Void> f = storageServer( kv, recruited, dbInfo, folder, recovery, connFile);
 				recoveries.push_back(recovery.getFuture());
 				f = handleIOErrors( f, kv, s.storeID, kvClosed );
 				f = storageServerRollbackRebooter( f, s.storeType, s.filename, recruited.id(), recruited.locality, dbInfo, folder, &filesClosed, memoryLimit, kv);


### PR DESCRIPTION
Sorry, had to open a new PR on this issue
Issue we(Wavefront) have:
#53 

Solution:
Based on branch **[mater](https://github.com/apple/foundationdb)**
During recovery process for memory storage engine, we’ll check periodically whether we can safely remove this storage engine (by calling canRemoveStorageServer() method). If the cluster is healthy then abort recovery and join in as an empty node. Otherwise, keep going until it’s done.