### PR TITLE
Make protocol version a type

### DIFF
--- a/fdbbackup/backup.actor.cpp
+++ b/fdbbackup/backup.actor.cpp
@@ -797,7 +797,7 @@ void parentWatcher(void *parentHandle) {
 static void printVersion() {
 	printf("FoundationDB " FDB_VT_PACKAGE_NAME " (v" FDB_VT_VERSION ")\n");
 	printf("source version %s\n", getHGVersion());
-	printf("protocol %llx\n", (long long) currentProtocolVersion);
+	printf("protocol %llx\n", (long long) currentProtocolVersion.version());
 }
 
 const char *BlobCredentialInfo =

--- a/fdbclient/ClientDBInfo.h
+++ b/fdbclient/ClientDBInfo.h
@@ -40,7 +40,7 @@ struct ClientDBInfo {
 	template <class Archive>
 	void serialize(Archive& ar) {
 		if constexpr (!is_fb_function<Archive>) {
-			ASSERT(ar.protocolVersion() >= 0x0FDB00A200040001LL);
+			ASSERT(ar.protocolVersion().isValid());
 		}
 		serializer(ar, proxies, id, clientTxnInfoSampleRate, clientTxnInfoSizeLimit);
 	}

--- a/fdbclient/ClusterInterface.h
+++ b/fdbclient/ClusterInterface.h
@@ -155,7 +155,7 @@ struct OpenDatabaseRequest {
 	template <class Ar>
 	void serialize(Ar& ar) {
 		if constexpr (!is_fb_function<Ar>) {
-			ASSERT(ar.protocolVersion() >= 0x0FDB00A400040001LL);
+			ASSERT(ar.protocolVersion().hasOpenDatabase());
 		}
 		serializer(ar, issues, supportedVersions, connectedCoordinatorsNum, traceLogGroup, knownClientInfoID, reply,
 				   arena);

--- a/fdbclient/MultiVersionTransaction.actor.cpp
+++ b/fdbclient/MultiVersionTransaction.actor.cpp
@@ -736,7 +736,7 @@ void MultiVersionDatabase::DatabaseState::stateChanged() {
 	for(int i = 0; i < clients.size(); ++i) {
 		if(i != currentClientIndex && connectionAttempts[i]->connected) {
 			if(currentClientIndex >= 0 && !clients[i]->canReplace(clients[currentClientIndex])) {
-				TraceEvent(SevWarn, "DuplicateClientVersion").detail("Keeping", clients[currentClientIndex]->libPath).detail("KeptClientProtocolVersion", clients[currentClientIndex]->protocolVersion).detail("Disabling", clients[i]->libPath).detail("DisabledClientProtocolVersion", clients[i]->protocolVersion);
+				TraceEvent(SevWarn, "DuplicateClientVersion").detail("Keeping", clients[currentClientIndex]->libPath).detail("KeptClientProtocolVersion", clients[currentClientIndex]->protocolVersion.version()).detail("Disabling", clients[i]->libPath).detail("DisabledClientProtocolVersion", clients[i]->protocolVersion.version());
 				connectionAttempts[i]->connected = false; // Permanently disable this client in favor of the current one
 				clients[i]->failed = true;
 				MultiVersionApi::api->updateSupportedVersions();
@@ -1277,15 +1277,15 @@ MultiVersionApi* MultiVersionApi::api = new MultiVersionApi();
 void ClientInfo::loadProtocolVersion() {
 	std::string version = api->getClientVersion();
 	if(version == "unknown") {
-		protocolVersion = 0;
+		protocolVersion = ProtocolVersion(0);
 		return;
 	}
 
 	char *next;
 	std::string protocolVersionStr = ClientVersionRef(version).protocolVersion.toString();
-	protocolVersion = strtoull(protocolVersionStr.c_str(), &next, 16);
+	protocolVersion = ProtocolVersion(strtoull(protocolVersionStr.c_str(), &next, 16));
 
-	ASSERT(protocolVersion != 0 && protocolVersion != ULLONG_MAX);
+	ASSERT(protocolVersion.version() != 0 && protocolVersion.version() != ULLONG_MAX);
 	ASSERT(next == &protocolVersionStr[protocolVersionStr.length()]);
 }
 
@@ -1298,7 +1298,7 @@ bool ClientInfo::canReplace(Reference<ClientInfo> other) const {
 		return true;
 	}
 
-	return (protocolVersion & compatibleProtocolVersionMask) != (other->protocolVersion & compatibleProtocolVersionMask);
+	return !protocolVersion.isCompatible(other->protocolVersion);
 }
 
 // UNIT TESTS

--- a/fdbclient/MultiVersionTransaction.h
+++ b/fdbclient/MultiVersionTransaction.h
@@ -264,7 +264,7 @@ private:
 };
 
 struct ClientInfo : ThreadSafeReferenceCounted<ClientInfo> {
-	uint64_t protocolVersion;
+	ProtocolVersion protocolVersion;
 	IClientApi *api;
 	std::string libPath;
 	bool external;

--- a/fdbclient/Status.h
+++ b/fdbclient/Status.h
@@ -47,7 +47,7 @@ void load(Ar& ar, StatusObject& statusObj) {
 	json_spirit::read_string( value, mv );
 	statusObj = StatusObject(mv.get_obj());
 
-	ASSERT( ar.protocolVersion() != 0 );
+	ASSERT( ar.protocolVersion().isValid() );
 }
 
 template <class Ar>
@@ -55,7 +55,7 @@ void save(Ar& ar, StatusObject const& statusObj) {
 	std::string value = json_spirit::write_string(json_spirit::mValue(statusObj));
 	ar << (int32_t)value.length();
 	ar.serializeBytes( (void*)&value[0], (int)value.length() );
-	ASSERT( ar.protocolVersion() != 0 );
+	ASSERT( ar.protocolVersion().isValid() );
 }
 
 struct StatusArray : json_spirit::mArray {

--- a/fdbclient/StorageServerInterface.h
+++ b/fdbclient/StorageServerInterface.h
@@ -70,7 +70,7 @@ struct StorageServerInterface {
 		if constexpr (!is_fb_function<Ar>) {
 			serializer(ar, uniqueID, locality, getVersion, getValue, getKey, getKeyValues, getShardState, waitMetrics,
 			           splitMetrics, getPhysicalMetrics, waitFailure, getQueuingMetrics, getKeyValueStoreType);
-			if (ar.protocolVersion() >= 0x0FDB00A200090001LL) serializer(ar, watchValue);
+			if (ar.protocolVersion().hasWatches()) serializer(ar, watchValue);
 		} else {
 			serializer(ar, uniqueID, locality, getVersion, getValue, getKey, getKeyValues, getShardState, waitMetrics,
 			           splitMetrics, getPhysicalMetrics, waitFailure, getQueuingMetrics, getKeyValueStoreType,

--- a/fdbclient/SystemData.cpp
+++ b/fdbclient/SystemData.cpp
@@ -181,7 +181,7 @@ Version decodeServerTagHistoryKey( KeyRef const& key ) {
 Tag decodeServerTagValue( ValueRef const& value ) {
 	Tag s;
 	BinaryReader reader( value, IncludeVersion() );
-	if( reader.protocolVersion() < 0x0FDB00A560010001LL ) {
+	if(!reader.protocolVersion().hasTagLocality()) {
 		int16_t id;
 		reader >> id;
 		if(id == invalidTagOld) {

--- a/fdbrpc/FlowTransport.actor.cpp
+++ b/fdbrpc/FlowTransport.actor.cpp
@@ -218,7 +218,7 @@ struct ConnectPacket {
 	// The value does not inclueds the size of `connectPacketLength` itself,
 	// but only the other fields of this structure.
 	uint32_t connectPacketLength;
-	uint64_t protocolVersion;      // Expect currentProtocolVersion
+	ProtocolVersion protocolVersion;      // Expect currentProtocolVersion
 
 	uint16_t canonicalRemotePort;  // Port number to reconnect to the originating process
 	uint64_t connectionId;         // Multi-version clients will use the same Id for both connections, other connections will set this to zero. Added at protocol Version 0x0FDB00A444020001.
@@ -326,13 +326,16 @@ struct Peer : NonCopyable {
 			pkt.canonicalRemotePort = transport->localAddresses.secondaryAddress.get().port;
 			pkt.setCanonicalRemoteIp(transport->localAddresses.secondaryAddress.get().ip);
 		} else {
-			pkt.canonicalRemotePort = 0;   // a "mixed" TLS/non-TLS connection is like a client/server connection - there's no way to reverse it
+			// a "mixed" TLS/non-TLS connection is like a client/server connection - there's no way to reverse it
+			pkt.canonicalRemotePort = 0;
 			pkt.setCanonicalRemoteIp(IPAddress(0));
 		}
 
 		pkt.connectPacketLength = sizeof(pkt) - sizeof(pkt.connectPacketLength);
-		pkt.protocolVersion =
-		    g_network->useObjectSerializer() ? addObjectSerializerFlag(currentProtocolVersion) : currentProtocolVersion;
+		pkt.protocolVersion = currentProtocolVersion;
+		if (g_network->useObjectSerializer()) {
+			pkt.protocolVersion.addObjectSerializerFlag();
+		}
 		pkt.connectionId = transport->transportId;
 
 		PacketBuffer* pb_first = new PacketBuffer;
@@ -784,14 +787,14 @@ ACTOR static Future<Void> connectionReader(
 					// At the beginning of a connection, we expect to receive a packet containing the protocol version and the listening port of the remote process
 					int32_t connectPacketSize = ((ConnectPacket*)unprocessed_begin)->totalPacketSize();
 					if ( unprocessed_end-unprocessed_begin >= connectPacketSize ) {
-						uint64_t protocolVersion = ((ConnectPacket*)unprocessed_begin)->protocolVersion;
+						auto protocolVersion = ((ConnectPacket*)unprocessed_begin)->protocolVersion;
 						BinaryReader pktReader(unprocessed_begin, connectPacketSize, AssumeVersion(protocolVersion));
 						ConnectPacket pkt;
 						serializer(pktReader, pkt);
 
 						uint64_t connectionId = pkt.connectionId;
-						if(g_network->useObjectSerializer() != hasObjectSerializerFlag(pkt.protocolVersion) ||
-						   (removeFlags(pkt.protocolVersion) & compatibleProtocolVersionMask) != (currentProtocolVersion & compatibleProtocolVersionMask)) {
+						if(g_network->useObjectSerializer() != pkt.protocolVersion.hasObjectSerializerFlag() ||
+						   !pkt.protocolVersion.isCompatible(currentProtocolVersion)) {
 							incompatibleProtocolVersionNewer = pkt.protocolVersion > currentProtocolVersion;
 							NetworkAddress addr = pkt.canonicalRemotePort
 							                          ? NetworkAddress(pkt.canonicalRemoteIp(), pkt.canonicalRemotePort)
@@ -802,9 +805,9 @@ ACTOR static Future<Void> connectionReader(
 								if(now() - transport->lastIncompatibleMessage > FLOW_KNOBS->CONNECTION_REJECTED_MESSAGE_DELAY) {
 									TraceEvent(SevWarn, "ConnectionRejected", conn->getDebugID())
 									    .detail("Reason", "IncompatibleProtocolVersion")
-									    .detail("LocalVersion", currentProtocolVersion)
-									    .detail("RejectedVersion", pkt.protocolVersion)
-									    .detail("VersionMask", compatibleProtocolVersionMask)
+									    .detail("LocalVersion", currentProtocolVersion.version())
+									    .detail("RejectedVersion", pkt.protocolVersion.version())
+									    .detail("VersionMask", ProtocolVersion::compatibleProtocolVersionMask)
 									    .detail("Peer", pkt.canonicalRemotePort ? NetworkAddress(pkt.canonicalRemoteIp(), pkt.canonicalRemotePort)
 									                                            : conn->getPeerAddress())
 									    .detail("ConnectionId", connectionId);
@@ -818,7 +821,7 @@ ACTOR static Future<Void> connectionReader(
 							}
 
 							compatible = false;
-							if(protocolVersion < 0x0FDB00A551000000LL) {
+							if(!protocolVersion.hasMultiVersionClient()) {
 								// Older versions expected us to hang up. It may work even if we don't hang up here, but it's safer to keep the old behavior.
 								throw incompatible_protocol_version();
 							}

--- a/fdbrpc/FlowTransport.actor.cpp
+++ b/fdbrpc/FlowTransport.actor.cpp
@@ -269,7 +269,7 @@ struct ConnectPacket {
 		}
 
 		serializer(ar, protocolVersion, canonicalRemotePort, connectionId, canonicalRemoteIp4);
-		if (ar.isDeserializing && ar.protocolVersion() < 0x0FDB00B061030001LL) {
+		if (ar.isDeserializing && !ar.protocolVersion().hasIPv6()) {
 			flags = 0;
 		} else {
 			// We can send everything in serialized packet, since the current version of ConnectPacket
@@ -638,7 +638,7 @@ ACTOR static void deliver(TransportData* self, Endpoint destination, ArenaReader
 }
 
 static void scanPackets(TransportData* transport, uint8_t*& unprocessed_begin, uint8_t* e, Arena& arena,
-                        NetworkAddress const& peerAddress, uint64_t peerProtocolVersion) {
+                        NetworkAddress const& peerAddress, ProtocolVersion peerProtocolVersion) {
 	// Find each complete packet in the given byte range and queue a ready task to deliver it.
 	// Remove the complete packets from the range by increasing unprocessed_begin.
 	// There won't be more than 64K of data plus one packet, so this shouldn't take a long time.
@@ -752,7 +752,7 @@ ACTOR static Future<Void> connectionReader(
 	state bool incompatiblePeerCounted = false;
 	state bool incompatibleProtocolVersionNewer = false;
 	state NetworkAddress peerAddress;
-	state uint64_t peerProtocolVersion;
+	state ProtocolVersion peerProtocolVersion;
 
 	peerAddress = conn->getPeerAddress();
 	if (peer == nullptr) {

--- a/fdbrpc/FlowTransport.h
+++ b/fdbrpc/FlowTransport.h
@@ -80,7 +80,7 @@ public:
 				choosePrimaryAddress();
 			}
 		} else {
-			if (ar.isDeserializing && ar.protocolVersion() < 0x0FDB00B061020001LL) {
+			if (ar.isDeserializing && !ar.protocolVersion().hasEndpointAddrList()) {
 				addresses.secondaryAddress = Optional<NetworkAddress>();
 				serializer(ar, addresses.address, token);
 			} else {

--- a/fdbrpc/Locality.h
+++ b/fdbrpc/Locality.h
@@ -197,7 +197,7 @@ public:
 		if constexpr (is_fb_function<Ar>) {
 			serializer(ar, _data);
 		} else {
-			if (ar.protocolVersion() >= 0x0FDB00A446020001LL) {
+			if (ar.protocolVersion().hasLocality()) {
 				Standalone<StringRef> key;
 				Optional<Standalone<StringRef>> value;
 				uint64_t mapSize = (uint64_t)_data.size();
@@ -221,7 +221,7 @@ public:
 				set(keyZoneId, Standalone<StringRef>(zoneId.toString()));
 				set(keyDcId, Standalone<StringRef>(dcId.toString()));
 
-				if (ar.protocolVersion() >= 0x0FDB00A340000001LL) {
+				if (ar.protocolVersion().hasProcessID()) {
 					serializer(ar, processId);
 					set(keyProcessId, Standalone<StringRef>(processId.toString()));
 				} else {

--- a/fdbserver/ClusterRecruitmentInterface.h
+++ b/fdbserver/ClusterRecruitmentInterface.h
@@ -75,7 +75,7 @@ struct ClusterControllerFullInterface {
 	template <class Ar>
 	void serialize(Ar& ar) {
 		if constexpr (!is_fb_function<Ar>) {
-			ASSERT(ar.protocolVersion() >= 0x0FDB00A200040001LL);
+			ASSERT(ar.protocolVersion().isValid());
 		}
 		serializer(ar, clientInterface, recruitFromConfiguration, recruitRemoteFromConfiguration, recruitStorage,
 		           registerWorker, getWorkers, registerMaster, getServerDBInfo);
@@ -244,7 +244,7 @@ struct RegisterMasterRequest {
 	template <class Ar>
 	void serialize(Ar& ar) {
 		if constexpr (!is_fb_function<Ar>) {
-			ASSERT(ar.protocolVersion() >= 0x0FDB00A200040001LL);
+			ASSERT(ar.protocolVersion().isValid());
 		}
 		serializer(ar, id, mi, logSystemConfig, proxies, resolvers, recoveryCount, registrationCount, configuration,
 		           priorCommittedLogServers, recoveryState, recoveryStalled, reply);

--- a/fdbserver/CoordinatedState.actor.cpp
+++ b/fdbserver/CoordinatedState.actor.cpp
@@ -212,7 +212,7 @@ struct MovableValue {
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		ASSERT( ar.protocolVersion() >= 0x0FDB00A2000D0001LL );
+		ASSERT( ar.protocolVersion().hasMovableCoordinatedState() );
 		serializer(ar, value, mode, other);
 	}
 };
@@ -230,7 +230,7 @@ struct MovableCoordinatedStateImpl {
 		Value rawValue = wait( self->cs.read() );
 		if( rawValue.size() ) {
 			BinaryReader r( rawValue, IncludeVersion() );
-			if (r.protocolVersion() < 0x0FDB00A2000D0001LL) {
+			if (!r.protocolVersion().hasMovableCoordinatedState()) {
 				// Old coordinated state, not a MovableValue
 				moveState.value = rawValue;
 			} else

--- a/fdbserver/LogSystem.h
+++ b/fdbserver/LogSystem.h
@@ -301,7 +301,7 @@ struct ILogSystem {
 		//clones the peek cursor, however you cannot call getMore() on the cloned cursor.
 		virtual Reference<IPeekCursor> cloneNoMore() = 0;
 
-		virtual void setProtocolVersion( uint64_t version ) = 0;
+		virtual void setProtocolVersion( ProtocolVersion version ) = 0;
 
 		//if hasMessage() returns true, getMessage(), getMessageWithTags(), or reader() can be called.
 		//does not modify the cursor
@@ -397,7 +397,7 @@ struct ILogSystem {
 		ServerPeekCursor( TLogPeekReply const& results, LogMessageVersion const& messageVersion, LogMessageVersion const& end, int32_t messageLength, int32_t rawLength, bool hasMsg, Version poppedVersion, Tag tag );
 
 		virtual Reference<IPeekCursor> cloneNoMore();
-		virtual void setProtocolVersion( uint64_t version );
+		virtual void setProtocolVersion( ProtocolVersion version );
 		virtual Arena& arena();
 		virtual ArenaReader* reader();
 		virtual bool hasMessage();
@@ -443,7 +443,7 @@ struct ILogSystem {
 		MergedPeekCursor( std::vector< Reference<IPeekCursor> > const& serverCursors, LogMessageVersion const& messageVersion, int bestServer, int readQuorum, Optional<LogMessageVersion> nextVersion, Reference<LogSet> logSet, int tLogReplicationFactor );
 
 		virtual Reference<IPeekCursor> cloneNoMore();
-		virtual void setProtocolVersion( uint64_t version );
+		virtual void setProtocolVersion( ProtocolVersion version );
 		virtual Arena& arena();
 		virtual ArenaReader* reader();
 		void calcHasMessage();
@@ -488,7 +488,7 @@ struct ILogSystem {
 		SetPeekCursor( std::vector<Reference<LogSet>> const& logSets, std::vector< std::vector< Reference<IPeekCursor> > > const& serverCursors, LogMessageVersion const& messageVersion, int bestSet, int bestServer, Optional<LogMessageVersion> nextVersion, bool useBestSet );
 
 		virtual Reference<IPeekCursor> cloneNoMore();
-		virtual void setProtocolVersion( uint64_t version );
+		virtual void setProtocolVersion( ProtocolVersion version );
 		virtual Arena& arena();
 		virtual ArenaReader* reader();
 		void calcHasMessage();
@@ -524,7 +524,7 @@ struct ILogSystem {
 		MultiCursor( std::vector<Reference<IPeekCursor>> cursors, std::vector<LogMessageVersion> epochEnds );
 
 		virtual Reference<IPeekCursor> cloneNoMore();
-		virtual void setProtocolVersion( uint64_t version );
+		virtual void setProtocolVersion( ProtocolVersion version );
 		virtual Arena& arena();
 		virtual ArenaReader* reader();
 		virtual bool hasMessage();
@@ -584,7 +584,7 @@ struct ILogSystem {
 		BufferedCursor( std::vector<Reference<IPeekCursor>> cursors, Version begin, Version end, bool collectTags );
 
 		virtual Reference<IPeekCursor> cloneNoMore();
-		virtual void setProtocolVersion( uint64_t version );
+		virtual void setProtocolVersion( ProtocolVersion version );
 		virtual Arena& arena();
 		virtual ArenaReader* reader();
 		virtual bool hasMessage();

--- a/fdbserver/LogSystemConfig.h
+++ b/fdbserver/LogSystemConfig.h
@@ -142,7 +142,7 @@ struct TLogSet {
 			           isLocal, locality, startVersion, satelliteTagLocations, tLogVersion);
 		} else {
 			serializer(ar, tLogs, logRouters, tLogWriteAntiQuorum, tLogReplicationFactor, tLogPolicy, tLogLocalities, isLocal, locality, startVersion, satelliteTagLocations);
-			if (ar.isDeserializing && ar.protocolVersion() < 0x0FDB00B061030001LL) {
+			if (ar.isDeserializing && !ar.protocolVersion().hasTLogVersion()) {
 				tLogVersion = TLogVersion::V2;
 			} else {
 				serializer(ar, tLogVersion);

--- a/fdbserver/LogSystemPeekCursor.actor.cpp
+++ b/fdbserver/LogSystemPeekCursor.actor.cpp
@@ -47,7 +47,7 @@ Reference<ILogSystem::IPeekCursor> ILogSystem::ServerPeekCursor::cloneNoMore() {
 	return Reference<ILogSystem::ServerPeekCursor>( new ILogSystem::ServerPeekCursor( results, messageVersion, end, messageLength, rawLength, hasMsg, poppedVersion, tag ) );
 }
 
-void ILogSystem::ServerPeekCursor::setProtocolVersion( uint64_t version ) {
+void ILogSystem::ServerPeekCursor::setProtocolVersion( ProtocolVersion version ) {
 	rd.setProtocolVersion(version);
 }
 
@@ -306,7 +306,7 @@ Reference<ILogSystem::IPeekCursor> ILogSystem::MergedPeekCursor::cloneNoMore() {
 	return Reference<ILogSystem::MergedPeekCursor>( new ILogSystem::MergedPeekCursor( cursors, messageVersion, bestServer, readQuorum, nextVersion, logSet, tLogReplicationFactor ) );
 }
 
-void ILogSystem::MergedPeekCursor::setProtocolVersion( uint64_t version ) {
+void ILogSystem::MergedPeekCursor::setProtocolVersion( ProtocolVersion version ) {
 	for( auto it : serverCursors )
 		if( it->hasMessage() )
 			it->setProtocolVersion( version );
@@ -532,7 +532,7 @@ Reference<ILogSystem::IPeekCursor> ILogSystem::SetPeekCursor::cloneNoMore() {
 	return Reference<ILogSystem::SetPeekCursor>( new ILogSystem::SetPeekCursor( logSets, cursors, messageVersion, bestSet, bestServer, nextVersion, useBestSet ) );
 }
 
-void ILogSystem::SetPeekCursor::setProtocolVersion( uint64_t version ) {
+void ILogSystem::SetPeekCursor::setProtocolVersion( ProtocolVersion version ) {
 	for( auto& cursors : serverCursors ) {
 		for( auto& it : cursors ) {
 			if( it->hasMessage() ) {
@@ -807,7 +807,7 @@ Reference<ILogSystem::IPeekCursor> ILogSystem::MultiCursor::cloneNoMore() {
 	return cursors.back()->cloneNoMore();
 }
 
-void ILogSystem::MultiCursor::setProtocolVersion( uint64_t version ) {
+void ILogSystem::MultiCursor::setProtocolVersion( ProtocolVersion version ) {
 	cursors.back()->setProtocolVersion(version);
 }
 
@@ -918,7 +918,7 @@ Reference<ILogSystem::IPeekCursor> ILogSystem::BufferedCursor::cloneNoMore() {
 	return Reference<ILogSystem::IPeekCursor>();
 }
 
-void ILogSystem::BufferedCursor::setProtocolVersion( uint64_t version ) {
+void ILogSystem::BufferedCursor::setProtocolVersion( ProtocolVersion version ) {
 	for(auto& c : cursors) {
 		c->setProtocolVersion(version);
 	}

--- a/fdbserver/MasterInterface.h
+++ b/fdbserver/MasterInterface.h
@@ -44,7 +44,7 @@ struct MasterInterface {
 	template <class Archive>
 	void serialize(Archive& ar) {
 		if constexpr (!is_fb_function<Archive>) {
-                ASSERT( ar.protocolVersion() >= 0x0FDB00A200040001LL );
+                ASSERT( ar.protocolVersion().isValid() );
         }
 		serializer(ar, locality, waitFailure, tlogRejoin, changeCoordinators, getCommitVersion);
 	}

--- a/fdbserver/OldTLogServer_4_6.actor.cpp
+++ b/fdbserver/OldTLogServer_4_6.actor.cpp
@@ -92,7 +92,7 @@ namespace oldTLog_4_6 {
 
 		template <class Ar>
 		void serialize(Ar& ar) {
-			if( ar.protocolVersion() >= 0x0FDB00A460010001) {
+			if (ar.protocolVersion().hasMultiGenerationTLog()) {
 				serializer(ar, version, messages, tags, knownCommittedVersion, id);
 			} else if(ar.isDeserializing) {
 				serializer(ar, version, messages, tags);

--- a/fdbserver/TLogServer.actor.cpp
+++ b/fdbserver/TLogServer.actor.cpp
@@ -492,7 +492,7 @@ struct LogData : NonCopyable, public ReferenceCounted<LogData> {
 	FlowLock execOpLock;
 	bool execOpCommitInProgress;
 
-	explicit LogData(TLogData* tLogData, TLogInterface interf, Tag remoteTag, bool isPrimary, int logRouterTags, UID recruitmentID, uint64_t protocolVersion, std::vector<Tag> tags) : tLogData(tLogData), knownCommittedVersion(0), logId(interf.id()),
+	explicit LogData(TLogData* tLogData, TLogInterface interf, Tag remoteTag, bool isPrimary, int logRouterTags, UID recruitmentID, ProtocolVersion protocolVersion, std::vector<Tag> tags) : tLogData(tLogData), knownCommittedVersion(0), logId(interf.id()),
 			cc("TLog", interf.id().toString()), bytesInput("BytesInput", cc), bytesDurable("BytesDurable", cc), remoteTag(remoteTag), isPrimary(isPrimary), logRouterTags(logRouterTags), recruitmentID(recruitmentID), protocolVersion(protocolVersion),
 			logSystem(new AsyncVar<Reference<ILogSystem>>()), logRouterPoppedVersion(0), durableKnownCommittedVersion(0), minKnownCommittedVersion(0), queuePoppedVersion(0), allTags(tags.begin(), tags.end()), terminated(tLogData->terminated.getFuture()),
 			// These are initialized differently on init() or recovery
@@ -1897,7 +1897,7 @@ ACTOR Future<Void> tLogCommit(
 	}
 
 	state Version execVersion = invalidVersion;
-	state ExecCmdValueString execArg();
+	state ExecCmdValueString execArg;
 	state TLogQueueEntryRef qe;
 	state StringRef execCmd;
 	state Standalone<VectorRef<Tag>> execTags;
@@ -2495,7 +2495,7 @@ ACTOR Future<Void> restorePersistentState( TLogData* self, LocalityData locality
 		DUMPTOKEN( recruited.getQueuingMetrics );
 		DUMPTOKEN( recruited.confirmRunning );
 
-		uint64_t protocolVersion = BinaryReader::fromStringRef<uint64_t>( fProtocolVersions.get()[idx].value, Unversioned() );
+		ProtocolVersion protocolVersion = BinaryReader::fromStringRef<ProtocolVersion>( fProtocolVersions.get()[idx].value, Unversioned() );
 
 		//We do not need the remoteTag, because we will not be loading any additional data
 		logData = Reference<LogData>( new LogData(self, recruited, Tag(), true, id_logRouterTags[id1], UID(), protocolVersion, std::vector<Tag>()) );

--- a/fdbserver/TLogServer.actor.cpp
+++ b/fdbserver/TLogServer.actor.cpp
@@ -472,7 +472,7 @@ struct LogData : NonCopyable, public ReferenceCounted<LogData> {
 	Counter bytesDurable;
 
 	UID logId;
-	uint64_t protocolVersion;
+	ProtocolVersion protocolVersion;
 	Version newPersistentDataVersion;
 	Future<Void> removed;
 	PromiseStream<Future<Void>> addActor;

--- a/fdbserver/WorkerInterface.actor.h
+++ b/fdbserver/WorkerInterface.actor.h
@@ -146,7 +146,7 @@ struct RecruitMasterRequest {
 	template <class Ar>
 	void serialize(Ar& ar) {
 		if constexpr (!is_fb_function<Ar>) {
-			ASSERT(ar.protocolVersion() >= 0x0FDB00A200040001LL);
+			ASSERT(ar.protocolVersion().isValid());
 		}
 		serializer(ar, lifetime, forceRecovery, reply, arena);
 	}

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -409,7 +409,7 @@ public:
 	Deque<std::pair<Version,Version>> recoveryVersionSkips;
 	int64_t versionLag; // An estimate for how many versions it takes for the data to move from the logs to this storage server
 
-	uint64_t logProtocol;
+	ProtocolVersion logProtocol;
 
 	Reference<ILogSystem> logSystem;
 	Reference<ILogSystem::IPeekCursor> logCursor;
@@ -3163,7 +3163,7 @@ ACTOR Future<bool> restoreDurableState( StorageServer* data, IKeyValueStore* sto
 	data->sk = serverKeysPrefixFor( data->thisServerID ).withPrefix(systemKeys.begin);  // FFFF/serverKeys/[this server]/
 
 	if (fLogProtocol.get().present())
-		data->logProtocol = BinaryReader::fromStringRef<uint64_t>(fLogProtocol.get().get(), Unversioned());
+		data->logProtocol = BinaryReader::fromStringRef<ProtocolVersion>(fLogProtocol.get().get(), Unversioned());
 
 	if (fPrimaryLocality.get().present())
 		data->primaryLocality = BinaryReader::fromStringRef<int8_t>(fPrimaryLocality.get().get(), Unversioned());

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -169,7 +169,7 @@ struct StorageServerDisk {
 	void makeVersionDurable( Version version );
 	Future<bool> restoreDurableState();
 
-	void changeLogProtocol(Version version, uint64_t protocol);
+	void changeLogProtocol(Version version, ProtocolVersion protocol);
 
 	void writeMutation( MutationRef mutation );
 	void writeKeyValue( KeyValueRef kv );
@@ -3043,7 +3043,7 @@ void StorageServerDisk::makeVersionDurable( Version version ) {
 	//TraceEvent("MakeDurable", data->thisServerID).detail("FromVersion", prevStorageVersion).detail("ToVersion", version);
 }
 
-void StorageServerDisk::changeLogProtocol(Version version, uint64_t protocol) {
+void StorageServerDisk::changeLogProtocol(Version version, ProtocolVersion protocol) {
 	data->addMutationToMutationLogOrStorage(version, MutationRef(MutationRef::SetValue, persistLogProtocol, BinaryWriter::toValue(protocol, Unversioned())));
 }
 

--- a/fdbserver/workloads/ClientTransactionProfileCorrectness.actor.cpp
+++ b/fdbserver/workloads/ClientTransactionProfileCorrectness.actor.cpp
@@ -27,7 +27,7 @@ static const int trIdFormatSize = 16;
 // Checks TransactionInfo format
 bool checkTxInfoEntryFormat(BinaryReader &reader) {
 	// Check protocol version
-	uint64_t protocolVersion;
+	ProtocolVersion protocolVersion;
 	reader >> protocolVersion;
 	reader.setProtocolVersion(protocolVersion);
 

--- a/flow/Net2.actor.cpp
+++ b/flow/Net2.actor.cpp
@@ -36,6 +36,7 @@
 #include "flow/TDMetric.actor.h"
 #include "flow/AsioReactor.h"
 #include "flow/Profiler.h"
+#include "flow/ProtocolVersion.h"
 
 #ifdef WIN32
 #include <mmsystem.h>
@@ -48,31 +49,6 @@ intptr_t g_stackYieldLimit = 0;
 
 using namespace boost::asio::ip;
 
-// These impact both communications and the deserialization of certain database and IKeyValueStore keys.
-//
-// The convention is that 'x' and 'y' should match the major and minor version of the software, and 'z' should be 0.
-// To make a change without a corresponding increase to the x.y version, increment the 'dev' digit.
-//
-//                                                       xyzdev
-//                                                       vvvv
-const uint64_t currentProtocolVersion        = 0x0FDB00B061070001LL;
-const uint64_t compatibleProtocolVersionMask = 0xffffffffffff0000LL;
-const uint64_t minValidProtocolVersion       = 0x0FDB00A200060001LL;
-const uint64_t objectSerializerFlag          = 0x1000000000000000LL;
-const uint64_t versionFlagMask               = 0x0FFFFFFFFFFFFFFFLL;
-
-uint64_t removeFlags(uint64_t version) {
-	return version & versionFlagMask;
-}
-uint64_t addObjectSerializerFlag(uint64_t version) {
-	return version | objectSerializerFlag;
-}
-bool hasObjectSerializerFlag(uint64_t version) {
-	return (version & objectSerializerFlag) > 0;
-}
-
-// This assert is intended to help prevent incrementing the leftmost digits accidentally. It will probably need to change when we reach version 10.
-static_assert(currentProtocolVersion < 0x0FDB00B100000000LL, "Unexpected protocol version");
 
 #if defined(__linux__)
 #include <execinfo.h>

--- a/flow/ProtocolVersion.h
+++ b/flow/ProtocolVersion.h
@@ -1,0 +1,92 @@
+/*
+ * ProtocolVersion.h
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2019 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include <cstdint>
+
+#define PROTOCOL_VERSION_FEATURE(v, x)                                                                                \
+	struct x {                                                                                                         \
+		static constexpr uint64_t protocolVersion = v;                                                                 \
+	};                                                                                                                 \
+	constexpr bool has##x() const { return this->version() >= x ::protocolVersion; }                                   \
+	static constexpr ProtocolVersion with##x() { return ProtocolVersion(x ::protocolVersion); }
+
+// ProtocolVersion wraps a uint64_t to make it type safe. It will know about the current versions.
+// The default constuctor will initialize the version to 0 (which is an invalid
+// version). ProtocolVersion objects should never be compared to version numbers
+// directly. Instead one should always use the type-safe version types from which
+// this class inherits all.
+class ProtocolVersion {
+	uint64_t _version;
+
+public: // constants
+	static constexpr uint64_t versionFlagMask = 0x0FFFFFFFFFFFFFFFLL;
+	static constexpr uint64_t objectSerializerFlag = 0x1000000000000000LL;
+	static constexpr uint64_t compatibleProtocolVersionMask = 0xffffffffffff0000LL;
+	static constexpr uint64_t minValidProtocolVersion = 0x0FDB00A200060001LL;
+
+public:
+	constexpr explicit ProtocolVersion(uint64_t version) : _version(version) {}
+	constexpr ProtocolVersion() : _version(0) {}
+
+	constexpr bool isCompatible(ProtocolVersion other) const {
+		return (other.version() & compatibleProtocolVersionMask) == (version() & compatibleProtocolVersionMask);
+	}
+	constexpr bool isValid() const { return version() >= minValidProtocolVersion; }
+
+	constexpr uint64_t version() const { return _version & versionFlagMask; }
+	constexpr uint64_t versionWithFlags() const { return _version; }
+
+	constexpr bool hasObjectSerializerFlag() const { return (_version & objectSerializerFlag) > 0; }
+	constexpr void addObjectSerializerFlag() { _version = _version | objectSerializerFlag; }
+	constexpr void removeObjectSerializerFlag() {
+		_version = hasObjectSerializerFlag() ? _version ^ objectSerializerFlag : _version;
+	}
+	constexpr void removeAllFlags() { _version = version(); }
+
+	constexpr operator bool() const { return _version != 0; }
+	// comparison operators
+	// Comparison operators ignore the flags - this is because the version flags are stored in the
+	// most significant byte which can make comparison confusing. Also, generally, when one wants to
+	// compare versions, we are usually not interested in the flags.
+	constexpr bool operator==(const ProtocolVersion other) const { return version() == other.version(); }
+	constexpr bool operator!=(const ProtocolVersion other) const { return version() != other.version(); }
+	constexpr bool operator<=(const ProtocolVersion other) const { return version() <= other.version(); }
+	constexpr bool operator>=(const ProtocolVersion other) const { return version() >= other.version(); }
+	constexpr bool operator<(const ProtocolVersion other) const { return version() < other.version(); }
+	constexpr bool operator>(const ProtocolVersion other) const { return version() > other.version(); }
+
+public: // introduced features
+	PROTOCOL_VERSION_FEATURE(0x0FDB00A560010001LL, TagLocality);
+	PROTOCOL_VERSION_FEATURE(0x0FDB00B060000001LL, Fearless);
+	PROTOCOL_VERSION_FEATURE(0x0FDB00A551000000LL, MultiVersionClient);
+};
+
+// These impact both communications and the deserialization of certain database and IKeyValueStore keys.
+//
+// The convention is that 'x' and 'y' should match the major and minor version of the software, and 'z' should be 0.
+// To make a change without a corresponding increase to the x.y version, increment the 'dev' digit.
+//
+//                                                         xyzdev
+//                                                         vvvv
+constexpr ProtocolVersion currentProtocolVersion(0x0FDB00B061070001LL);
+// This assert is intended to help prevent incrementing the leftmost digits accidentally. It will probably need to
+// change when we reach version 10.
+static_assert(currentProtocolVersion.version() < 0x0FDB00B100000000LL, "Unexpected protocol version");

--- a/flow/ProtocolVersion.h
+++ b/flow/ProtocolVersion.h
@@ -21,11 +21,11 @@
 #pragma once
 #include <cstdint>
 
-#define PROTOCOL_VERSION_FEATURE(v, x)                                                                                \
+#define PROTOCOL_VERSION_FEATURE(v, x)                                                                                 \
 	struct x {                                                                                                         \
 		static constexpr uint64_t protocolVersion = v;                                                                 \
 	};                                                                                                                 \
-	constexpr bool has##x() const { return this->version() >= x ::protocolVersion; }                                   \
+	constexpr bool has##x() const { return this->version() > x ::protocolVersion; }                                   \
 	static constexpr ProtocolVersion with##x() { return ProtocolVersion(x ::protocolVersion); }
 
 // ProtocolVersion wraps a uint64_t to make it type safe. It will know about the current versions.
@@ -61,7 +61,6 @@ public:
 	}
 	constexpr void removeAllFlags() { _version = version(); }
 
-	constexpr operator bool() const { return _version != 0; }
 	// comparison operators
 	// Comparison operators ignore the flags - this is because the version flags are stored in the
 	// most significant byte which can make comparison confusing. Also, generally, when one wants to
@@ -74,9 +73,19 @@ public:
 	constexpr bool operator>(const ProtocolVersion other) const { return version() > other.version(); }
 
 public: // introduced features
-	PROTOCOL_VERSION_FEATURE(0x0FDB00A560010001LL, TagLocality);
-	PROTOCOL_VERSION_FEATURE(0x0FDB00B060000001LL, Fearless);
+	PROTOCOL_VERSION_FEATURE(0x0FDB00A200090000LL, Watches);
+	PROTOCOL_VERSION_FEATURE(0x0FDB00A2000D0000LL, MovableCoordinatedState);
+	PROTOCOL_VERSION_FEATURE(0x0FDB00A340000000LL, ProcessID);
+	PROTOCOL_VERSION_FEATURE(0x0FDB00A400040000LL, OpenDatabase);
+	PROTOCOL_VERSION_FEATURE(0x0FDB00A446020000LL, Locality);
+	PROTOCOL_VERSION_FEATURE(0x0FDB00A460010000LL, MultiGenerationTLog);
 	PROTOCOL_VERSION_FEATURE(0x0FDB00A551000000LL, MultiVersionClient);
+	PROTOCOL_VERSION_FEATURE(0x0FDB00A560010000LL, TagLocality);
+	PROTOCOL_VERSION_FEATURE(0x0FDB00B060000000LL, Fearless);
+	PROTOCOL_VERSION_FEATURE(0x0FDB00B061020000LL, EndpointAddrList);
+	PROTOCOL_VERSION_FEATURE(0x0FDB00B061030000LL, IPv6);
+	PROTOCOL_VERSION_FEATURE(0x0FDB00B061030000LL, TLogVersion);
+	PROTOCOL_VERSION_FEATURE(0x0FDB00B061060000LL, PseudoLocalities);
 };
 
 // These impact both communications and the deserialization of certain database and IKeyValueStore keys.

--- a/flow/network.h
+++ b/flow/network.h
@@ -196,7 +196,7 @@ struct NetworkAddress {
 		if constexpr (is_fb_function<Ar>) {
 			serializer(ar, ip, port, flags);
 		} else {
-			if (ar.isDeserializing && ar.protocolVersion() < 0x0FDB00B061030001LL) {
+			if (ar.isDeserializing && !ar.protocolVersion().hasIPv6()) {
 				uint32_t ipV4;
 				serializer(ar, ipV4, port, flags);
 				ip = IPAddress(ipV4);

--- a/flow/serialize.cpp
+++ b/flow/serialize.cpp
@@ -21,8 +21,8 @@
 #include "flow/serialize.h"
 #include "flow/network.h"
 
-_AssumeVersion::_AssumeVersion( uint64_t version ) : v(version) {
-	if( version < minValidProtocolVersion ) {
+_AssumeVersion::_AssumeVersion( ProtocolVersion version ) : v(version) {
+	if(!version.isValid()) {
 		ASSERT(!g_network->isSimulated());
 		throw serialization_failed();
 	}

--- a/flow/serialize.h
+++ b/flow/serialize.h
@@ -104,7 +104,7 @@ class Serializer {
 public:
 	static void serialize( Archive& ar, T& t ) {
 		t.serialize(ar);
-		ASSERT( ar.protocolVersion() );
+		ASSERT( ar.protocolVersion().isValid() );
 	}
 };
 
@@ -129,14 +129,14 @@ inline void load( Archive& ar, std::string& value ) {
 	ar >> length;
 	value.resize(length);
 	ar.serializeBytes( &value[0], (int)value.length() );
-	ASSERT( ar.protocolVersion() != 0 );
+	ASSERT( ar.protocolVersion().isValid() );
 }
 
 template <class Archive>
 inline void save( Archive& ar, const std::string& value ) {
 	ar << (int32_t)value.length();
 	ar.serializeBytes( (void*)&value[0], (int)value.length() );
-	ASSERT( ar.protocolVersion() != 0 );
+	ASSERT( ar.protocolVersion().isValid() );
 }
 
 template <class Archive, class T>
@@ -177,7 +177,7 @@ inline void save( Archive& ar, const std::vector<T>& value ) {
 	ar << (int)value.size();
 	for(auto it = value.begin(); it != value.end(); ++it)
 		ar << *it;
-	ASSERT( ar.protocolVersion() != 0 );
+	ASSERT( ar.protocolVersion().isValid() );
 }
 template <class Archive, class T>
 inline void load( Archive& ar, std::vector<T>& value ) {
@@ -189,21 +189,21 @@ inline void load( Archive& ar, std::vector<T>& value ) {
 		value.push_back(T());
 		ar >> value[i];
 	}
-	ASSERT( ar.protocolVersion() != 0 );
+	ASSERT( ar.protocolVersion().isValid() );
 }
 
 template <class Archive, class T, size_t N>
 inline void save( Archive& ar, const std::array<T, N>& value ) {
 	for(int ii = 0; ii < N; ++ii)
 		ar << value[ii];
-	ASSERT( ar.protocolVersion() != 0 );
+	ASSERT( ar.protocolVersion().isValid() );
 }
 template <class Archive, class T, size_t N>
 inline void load( Archive& ar, std::array<T, N>& value ) {
 	for (int ii = 0; ii < N; ii++) {
 		ar >> value[ii];
 	}
-	ASSERT( ar.protocolVersion() != 0 );
+	ASSERT( ar.protocolVersion().isValid() );
 }
 
 template <class Archive, class T>
@@ -211,7 +211,7 @@ inline void save( Archive& ar, const std::set<T>& value ) {
 	ar << (int)value.size();
 	for(auto it = value.begin(); it != value.end(); ++it)
 		ar << *it;
-	ASSERT( ar.protocolVersion() != 0 );
+	ASSERT( ar.protocolVersion().isValid() );
 }
 template <class Archive, class T>
 inline void load( Archive& ar, std::set<T>& value ) {
@@ -223,7 +223,7 @@ inline void load( Archive& ar, std::set<T>& value ) {
 		ar >> currentValue;
 		value.insert(currentValue);
 	}
-	ASSERT( ar.protocolVersion() != 0 );
+	ASSERT( ar.protocolVersion().isValid() );
 }
 
 template <class Archive, class K, class V>
@@ -232,7 +232,7 @@ inline void save( Archive& ar, const std::map<K, V>& value ) {
 	for (const auto &it : value) {
 		ar << it.first << it.second;
 	}
-	ASSERT( ar.protocolVersion() != 0 );
+	ASSERT( ar.protocolVersion().isValid() );
 }
 template <class Archive, class K, class V>
 inline void load( Archive& ar, std::map<K, V>& value ) {
@@ -244,7 +244,7 @@ inline void load( Archive& ar, std::map<K, V>& value ) {
 		ar >> p.first >> p.second;
 		value.emplace(p);
 	}
-	ASSERT( ar.protocolVersion() != 0 );
+	ASSERT( ar.protocolVersion().isValid() );
 }
 
 #pragma intrinsic (memcpy)

--- a/flow/serialize.h
+++ b/flow/serialize.h
@@ -25,6 +25,7 @@
 #include <stdint.h>
 #include <array>
 #include <set>
+#include "flow/ProtocolVersion.h"
 #include "flow/Error.h"
 #include "flow/Arena.h"
 #include "flow/FileIdentifier.h"
@@ -52,6 +53,22 @@ BINARY_SERIALIZABLE( int64_t );
 BINARY_SERIALIZABLE( uint64_t );
 BINARY_SERIALIZABLE( bool );
 BINARY_SERIALIZABLE( double );
+BINARY_SERIALIZABLE( ProtocolVersion );
+
+template<>
+struct scalar_traits<ProtocolVersion> : std::true_type {
+	constexpr static size_t size = sizeof(uint64_t);
+
+	static void save(uint8_t* out, const ProtocolVersion& v) {
+		*reinterpret_cast<uint64_t*>(out) = v.versionWithFlags();
+	}
+
+	template <class Context>
+	static void load(const uint8_t* i, ProtocolVersion& out, Context& context) {
+		const uint64_t* in = reinterpret_cast<const uint64_t*>(i);
+		out = ProtocolVersion(*in);
+	}
+};
 
 template <class Archive, class Item>
 inline typename Archive::WRITER& operator << (Archive& ar, const Item& item ) {
@@ -87,7 +104,7 @@ class Serializer {
 public:
 	static void serialize( Archive& ar, T& t ) {
 		t.serialize(ar);
-		ASSERT( ar.protocolVersion() != 0 );
+		ASSERT( ar.protocolVersion() );
 	}
 };
 
@@ -250,19 +267,10 @@ static bool valgrindCheck( const void* data, int bytes, const char* context ) {
 static inline bool valgrindCheck( const void* data, int bytes, const char* context ) { return true; }
 #endif
 
-extern const uint64_t currentProtocolVersion;
-extern const uint64_t minValidProtocolVersion;
-extern const uint64_t compatibleProtocolVersionMask;
-extern const uint64_t objectSerializerFlag;
-
-extern uint64_t removeFlags(uint64_t version);
-extern uint64_t addObjectSerializerFlag(uint64_t version);
-extern bool hasObjectSerializerFlag(uint64_t version);
-
 struct _IncludeVersion {
-	uint64_t v;
-	explicit _IncludeVersion( uint64_t defaultVersion ) : v(defaultVersion) {
-		ASSERT( defaultVersion >= minValidProtocolVersion );
+	ProtocolVersion v;
+	explicit _IncludeVersion( ProtocolVersion defaultVersion ) : v(defaultVersion) {
+		ASSERT( defaultVersion.isValid() );
 	}
 	template <class Ar>
 	void write( Ar& ar ) {
@@ -272,7 +280,7 @@ struct _IncludeVersion {
 	template <class Ar>
 	void read( Ar& ar ) {
 		ar >> v;
-		if (v < minValidProtocolVersion) {
+		if (!v.isValid()) {
 			auto err = incompatible_protocol_version();
 			TraceEvent(SevError, "InvalidSerializationVersion").error(err).detailf("Version", "%llx", v);
 			throw err;
@@ -289,19 +297,19 @@ struct _IncludeVersion {
 	}
 };
 struct _AssumeVersion {
-	uint64_t v;
-	explicit _AssumeVersion( uint64_t version );
+	ProtocolVersion v;
+	explicit _AssumeVersion( ProtocolVersion version );
 	template <class Ar> void write( Ar& ar ) { ar.setProtocolVersion(v); }
 	template <class Ar> void read( Ar& ar ) { ar.setProtocolVersion(v); }
 };
 struct _Unversioned {
-	template <class Ar> void write( Ar& ar ) { ar.setProtocolVersion(0); }
-	template <class Ar> void read( Ar& ar ) { ar.setProtocolVersion(0); }
+	template <class Ar> void write( Ar& ar ) {}
+	template <class Ar> void read( Ar& ar ) {}
 };
 
 // These functions return valid options to the VersionOptions parameter of the constructor of each archive type
-inline _IncludeVersion IncludeVersion( uint64_t defaultVersion = currentProtocolVersion ) { return _IncludeVersion(defaultVersion); }
-inline _AssumeVersion AssumeVersion( uint64_t version ) { return _AssumeVersion(version); }
+inline _IncludeVersion IncludeVersion( ProtocolVersion defaultVersion = currentProtocolVersion ) { return _IncludeVersion(defaultVersion); }
+inline _AssumeVersion AssumeVersion( ProtocolVersion version ) { return _AssumeVersion(version); }
 inline _Unversioned Unversioned() { return _Unversioned(); }
 
 //static uint64_t size_limits[] = { 0ULL, 255ULL, 65535ULL, 16777215ULL, 4294967295ULL, 1099511627775ULL, 281474976710655ULL, 72057594037927935ULL, 18446744073709551615ULL };
@@ -426,13 +434,13 @@ public:
 		}
 	}
 
-	uint64_t protocolVersion() const { return m_protocolVersion; }
-	void setProtocolVersion(uint64_t pv) { m_protocolVersion = pv; }
+	ProtocolVersion protocolVersion() const { return m_protocolVersion; }
+	void setProtocolVersion(ProtocolVersion pv) { m_protocolVersion = pv; }
 private:
 	Arena arena;
 	uint8_t* data;
 	int size, allocated;
-	uint64_t m_protocolVersion;
+	ProtocolVersion m_protocolVersion;
 
 	void* writeBytes(int s) {
 		int p = size;
@@ -491,13 +499,13 @@ public:
 		writeBytes(&t, sizeof(T));
 	}
 
-	uint64_t protocolVersion() const { return m_protocolVersion; }
-	void setProtocolVersion(uint64_t pv) { m_protocolVersion = pv; }
+	ProtocolVersion protocolVersion() const { return m_protocolVersion; }
+	void setProtocolVersion(ProtocolVersion pv) { m_protocolVersion = pv; }
 
 private:
 	int len;
 	SplitBuffer buf;
-	uint64_t m_protocolVersion;
+	ProtocolVersion m_protocolVersion;
 
 	void writeBytes(const void *data, int wlen) {
 		ASSERT(wlen <= len);
@@ -551,8 +559,8 @@ public:
 
 	Arena& arena() { return m_pool; }
 
-	uint64_t protocolVersion() const { return m_protocolVersion; }
-	void setProtocolVersion(uint64_t pv) { m_protocolVersion = pv; }
+	ProtocolVersion protocolVersion() const { return m_protocolVersion; }
+	void setProtocolVersion(ProtocolVersion pv) { m_protocolVersion = pv; }
 
 	bool empty() const { return begin == end; }
 
@@ -569,7 +577,7 @@ public:
 private:
 	const char *begin, *end, *check;
 	Arena m_pool;
-	uint64_t m_protocolVersion;
+	ProtocolVersion m_protocolVersion;
 };
 
 class BinaryReader {
@@ -625,8 +633,8 @@ public:
 		return t;
 	}
 
-	uint64_t protocolVersion() const { return m_protocolVersion; }
-	void setProtocolVersion(uint64_t pv) { m_protocolVersion = pv; }
+	ProtocolVersion protocolVersion() const { return m_protocolVersion; }
+	void setProtocolVersion(ProtocolVersion pv) { m_protocolVersion = pv; }
 
 	void assertEnd() { ASSERT( begin == end ); }
 
@@ -646,7 +654,7 @@ public:
 private:
 	const char *begin, *end, *check;
 	Arena m_pool;
-	uint64_t m_protocolVersion;
+	ProtocolVersion m_protocolVersion;
 };
 
 struct SendBuffer {
@@ -679,7 +687,7 @@ struct PacketWriter {
 	PacketBuffer* buffer;
 	struct ReliablePacket *reliable;  // NULL if this is unreliable; otherwise the last entry in the ReliablePacket::cont chain
 	int length;
-	uint64_t m_protocolVersion;
+	ProtocolVersion m_protocolVersion;
 
 	// reliable is NULL if this is an unreliable packet, or points to a ReliablePacket.  PacketWriter is responsible
 	//   for filling in reliable->buffer, ->cont, ->begin, and ->end, but not ->prev or ->next.
@@ -712,8 +720,8 @@ struct PacketWriter {
 			serializeBytesAcrossBoundary(&t, sizeof(T));
 		}
 	}
-	uint64_t protocolVersion() const { return m_protocolVersion; }
-	void setProtocolVersion(uint64_t pv) { m_protocolVersion = pv; }
+	ProtocolVersion protocolVersion() const { return m_protocolVersion; }
+	void setProtocolVersion(ProtocolVersion pv) { m_protocolVersion = pv; }
 private:
 	void init( PacketBuffer* buf, ReliablePacket* reliable );
 };


### PR DESCRIPTION
This is the second try and should fix the issues of the previous PR. The main problem was that `operator bool() const`  was implemented before, so the compiler would accept comparisons with a number-type (but compare it to a bool - which is not meaningful).

Fixes #1214