### PR TITLE
Bump the default log_version to 3 and log_spill to 2

### DIFF
--- a/fdbclient/FDBTypes.h
+++ b/fdbclient/FDBTypes.h
@@ -604,7 +604,7 @@ struct TLogVersion {
 		MIN_SUPPORTED = V2,
 		MAX_SUPPORTED = V3,
 		MIN_RECRUITABLE = V2,
-		DEFAULT = V2,
+		DEFAULT = V3,
 	} version;
 
 	TLogVersion() : version(UNSET) {}
@@ -639,7 +639,7 @@ struct TLogSpillType {
 	// These enumerated values are stored in the database configuration, so can NEVER be changed.  Only add new ones just before END.
 	enum SpillType {
 		UNSET = 0,
-		DEFAULT = 1,
+		DEFAULT = 2,
 		VALUE = 1,
 		REFERENCE = 2,
 		END = 3,


### PR DESCRIPTION
Thus making spill-by-reference and crc32c disk queue checksums the default.