### PR TITLE
Disable/Re-enable consistency check through a database key.

### DIFF
--- a/fdbclient/SystemData.cpp
+++ b/fdbclient/SystemData.cpp
@@ -442,6 +442,9 @@ const KeyRangeRef fdbClientInfoPrefixRange(LiteralStringRef("\xff\x02/fdbClientI
 const KeyRef fdbClientInfoTxnSampleRate = LiteralStringRef("\xff\x02/fdbClientInfo/client_txn_sample_rate/");
 const KeyRef fdbClientInfoTxnSizeLimit = LiteralStringRef("\xff\x02/fdbClientInfo/client_txn_size_limit/");
 
+// ConsistencyCheck settings
+const KeyRef fdbShouldConsistencyCheckBeSuspended = LiteralStringRef("\xff\x02/ConsistencyCheck/Suspend");
+
 // Request latency measurement key
 const KeyRef latencyBandConfigKey = LiteralStringRef("\xff\x02/latencyBandConfig");
 

--- a/fdbclient/SystemData.h
+++ b/fdbclient/SystemData.h
@@ -216,6 +216,9 @@ extern const KeyRangeRef fdbClientInfoPrefixRange;
 extern const KeyRef fdbClientInfoTxnSampleRate;
 extern const KeyRef fdbClientInfoTxnSizeLimit;
 
+// Consistency Check settings
+extern const KeyRef fdbShouldConsistencyCheckBeSuspended;
+
 // Request latency measurement key
 extern const KeyRef latencyBandConfigKey;
 

--- a/fdbserver/workloads/ConsistencyCheck.actor.cpp
+++ b/fdbserver/workloads/ConsistencyCheck.actor.cpp
@@ -75,6 +75,11 @@ struct ConsistencyCheckWorkload : TestWorkload
 	//Whether to continuously perfom the consistency check
 	bool indefinite;
 
+	// Whether to suspendConsistencyCheck
+	AsyncVar<bool> suspendConsistencyCheck;
+
+	Future<Void> monitorConsistencyCheckSettingsActor;
+
 	ConsistencyCheckWorkload(WorkloadContext const& wcx)
 		: TestWorkload(wcx)
 	{
@@ -86,6 +91,7 @@ struct ConsistencyCheckWorkload : TestWorkload
 		rateLimitMax = getOption(options, LiteralStringRef("rateLimitMax"), 0);
 		shuffleShards = getOption(options, LiteralStringRef("shuffleShards"), false);
 		indefinite = getOption(options, LiteralStringRef("indefinite"), false);
+		suspendConsistencyCheck.set(true);
 
 		success = true;
 
@@ -124,6 +130,7 @@ struct ConsistencyCheckWorkload : TestWorkload
 			}
 		}
 
+		self->monitorConsistencyCheckSettingsActor = self->monitorConsistencyCheckSettings(cx, self);
 		return Void();
 	}
 
@@ -156,14 +163,43 @@ struct ConsistencyCheckWorkload : TestWorkload
 		failEvent.detail("Reason", "Consistency check: " + message);
 	}
 
+	ACTOR Future<Void> monitorConsistencyCheckSettings(Database cx, ConsistencyCheckWorkload *self) {
+		loop {
+			state ReadYourWritesTransaction tr(cx);
+			try {
+				tr.setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
+				tr.setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
+				tr.setOption(FDBTransactionOptions::LOCK_AWARE);
+				state Optional<Value> ccSuspendVal = wait(tr.get(fdbShouldConsistencyCheckBeSuspended));
+				bool ccSuspend = ccSuspendVal.present() ? BinaryReader::fromStringRef<bool>(ccSuspendVal.get(), Unversioned()) : false;
+				self->suspendConsistencyCheck.set(ccSuspend);
+				state Future<Void> watchCCSuspendFuture = tr.watch(fdbShouldConsistencyCheckBeSuspended);
+				wait(tr.commit());
+				wait(watchCCSuspendFuture);
+			}
+			catch (Error &e) {
+				wait(tr.onError(e));
+			}
+		}
+	}
+
 	ACTOR Future<Void> _start(Database cx, ConsistencyCheckWorkload *self)
 	{
 		loop {
-			wait(self->runCheck(cx, self));
-			if(!self->indefinite)
-				break;
-			self->repetitions++;
-			wait(delay(5.0));
+			while(self->suspendConsistencyCheck.get()) {
+				TraceEvent("ConsistencyCheck_Suspended");
+				wait(self->suspendConsistencyCheck.onChange());
+			}
+			TraceEvent("ConsistencyCheck_StartingOrResuming");
+			choose {
+				when(wait(self->runCheck(cx, self))) { 
+					if(!self->indefinite)
+						break;
+					self->repetitions++;
+					wait(delay(5.0));
+				}
+				when(wait(self->suspendConsistencyCheck.onChange())) { }
+			}
 		}
 		return Void();
 	}


### PR DESCRIPTION
fdbcli has a new command 'consistencycheck' to disable/re-enable consistency check.
cluster_healthy metric in status becomes false if consistencycheck is disabled.