### PR TITLE
Undo the partial retry implementation in NativeAPI

### DIFF
--- a/fdbclient/NativeAPI.actor.h
+++ b/fdbclient/NativeAPI.actor.h
@@ -145,7 +145,6 @@ struct StorageMetrics;
 
 struct TransactionOptions {
 	double maxBackoff;
-	uint32_t maxRetries;
 	uint32_t getReadVersionFlags;
 	uint32_t sizeLimit;
 	bool checkWritesEnabled : 1;
@@ -291,7 +290,6 @@ public:
 	void operator=(Transaction&& r) BOOST_NOEXCEPT;
 
 	void reset();
-	void onErrorReset();
 	void fullReset();
 	double getBackoff(int errCode);
 	void debugTransaction(UID dID) { info.debugID = dID; }
@@ -302,7 +300,6 @@ public:
 
 	TransactionInfo info;
 	int numErrors;
-	int numRetries;
 
 	std::vector<Reference<Watch>> watches;
 


### PR DESCRIPTION
NativeAPI did not have a retry logic implemented and a partial implementation was done, this change was to revert the partial implementation.