### PR TITLE
sev40 if knownCommittedVersion > recoveryVersion

### DIFF
--- a/fdbserver/TagPartitionedLogSystem.actor.cpp
+++ b/fdbserver/TagPartitionedLogSystem.actor.cpp
@@ -1477,7 +1477,16 @@ struct TagPartitionedLogSystem : ILogSystem, ReferenceCounted<TagPartitionedLogS
 				logSystem->rejoins = rejoins;
 				logSystem->lockResults = lockResults;
 				logSystem->recoverAt = minEnd;
-				logSystem->knownCommittedVersion = knownCommittedVersion;
+				if (knownCommittedVersion > minEnd) {
+					// FIXME: Remove the Sev40 once disk snapshot v2 feature is enabled, in all other
+					// code paths we should never be here.
+					TraceEvent(SevError, "KCVIsInvalid")
+						.detail("KnownCommittedVersion", knownCommittedVersion)
+						.detail("MinEnd", minEnd);
+					logSystem->knownCommittedVersion = minEnd;
+				} else {
+					logSystem->knownCommittedVersion = knownCommittedVersion;
+				}
 				logSystem->remoteLogsWrittenToCoreState = true;
 				logSystem->stopped = true;
 				logSystem->pseudoLocalities = prevState.pseudoLocalities;


### PR DESCRIPTION
It is implied that knownCommittedVersion (KCV) <= recoveryVersion. This change explicitly does a Sev40 if KCV > recoveryVersion. KCV is determined as the max of all the KCVs of the TLogs.

Once snapshot v2 code is enabled, this Sev40 will be removed, because we can recover with KCV > recoveryVersion, because the tlogs and snapshots can get snapshotted at different versions with many seconds or minutes apart.