### PR TITLE
Fix Windows build caused by incorrect definition check

### DIFF
--- a/flow/Platform.cpp
+++ b/flow/Platform.cpp
@@ -2721,7 +2721,7 @@ std::string exePath() {
 			return std::string(buf.get());
 		}
 	}
-#elif defined(__WIN32__)
+#elif defined(_WIN32)
 	DWORD bufSize = 1024;
 	std::unique_ptr<char[]> buf(new char[bufSize]);
 	while (true) {


### PR DESCRIPTION
Our Windows build broke as one line in a recent PR was changed to use the wrong definition for determining the Windows platform. This switches to the same definition used elsewhere on the file.

There's another line, that is kind of weird, as it also uses the wrong definition:

https://github.com/apple/foundationdb/blob/b92e6b09ad67fa382e17500536fd13b10bb23ede/flow/Platform.cpp#L2746

That line hasn't been changed since the original OSS release two years ago, so under the "don't fix what's not broke" idea, I've left it the same, but I could be convinced to change it as well.