### PR TITLE
Ensure new added machines are used to build teams

### DIFF
--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -1680,7 +1680,7 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 	}
 
 	// Each machine is expected to have SERVER_KNOBS->DESIRED_TEAMS_PER_SERVER,
-    // remainingMachineTeamBudget is the number of machine teams needed to ensure every machine has  SERVER_KNOBS->DESIRED_TEAMS_PER_SERVER teams
+	// remainingMachineTeamBudget is the number of machine teams needed to ensure every machine has  SERVER_KNOBS->DESIRED_TEAMS_PER_SERVER teams
 	int getRemainingMachineTeamBudget() {
 		 int remainingMachineTeamBudget = 0;
 		for ( auto& m : machine_info ) {

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -1342,7 +1342,7 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 				// so that the invariant will not be violated.
 				int teamCount = 0;
 				for (auto& mt : machine.second->machineTeams) {
-					if ( isMachineTeamHealthy(mt) ) {
+					if (isMachineTeamHealthy(mt)) {
 						++teamCount;
 					}
 				}
@@ -1435,7 +1435,8 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 
 				addMachineTeam(machines);
 				addedMachineTeams++;
-				// Update the remaining machine team budget because the budget may decrease by any value between 1 and storageTeamSize
+				// Update the remaining machine team budget because the budget may decrease by any value between 1 and
+				// storageTeamSize
 				remainingMachineTeamBudget = getRemainingMachineTeamBudget();
 			} else {
 				TraceEvent(SevWarn, "DataDistributionBuildTeams", distributorId)
@@ -1507,9 +1508,9 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 
 			int numTeams = 0;
 			for (auto& t : server.second->teams) {
-				 if (!t->isWrongConfiguration() && t->isHealthy()) {
-					 ++numTeams;
-				 }
+				if (!t->isWrongConfiguration() && t->isHealthy()) {
+					++numTeams;
+				}
 			}
 			if (numTeams < minTeamNumber) {
 				minTeamNumber = numTeams;
@@ -1604,11 +1605,11 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 	std::pair<uint32_t, uint32_t> calculateMinMaxServerTeamNumOnServer() {
 		uint32_t minTeamNumber = std::numeric_limits<uint32_t>::max();
 		uint32_t maxTeamNumber = std::numeric_limits<uint32_t>::min();
-		for (auto& server : server_info ) {
-			if ( server.second->teams.size() < minTeamNumber ) {
+		for (auto& server : server_info) {
+			if (server.second->teams.size() < minTeamNumber) {
 				minTeamNumber = server.second->teams.size();
 			}
-			if ( server.second->teams.size() > maxTeamNumber ) {
+			if (server.second->teams.size() > maxTeamNumber) {
 				maxTeamNumber = server.second->teams.size();
 			}
 		}
@@ -1619,10 +1620,10 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 		uint32_t minTeamNumber = std::numeric_limits<uint32_t>::max();
 		uint32_t maxTeamNumber = std::numeric_limits<uint32_t>::min();
 		for (auto& machine : machine_info) {
-			if ( machine.second->machineTeams.size() < minTeamNumber ) {
+			if (machine.second->machineTeams.size() < minTeamNumber) {
 				minTeamNumber = machine.second->machineTeams.size();
 			}
-			if ( machine.second->machineTeams.size() > maxTeamNumber ) {
+			if (machine.second->machineTeams.size() > maxTeamNumber) {
 				maxTeamNumber = machine.second->machineTeams.size();
 			}
 		}
@@ -1680,41 +1681,43 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 	}
 
 	// Each machine is expected to have SERVER_KNOBS->DESIRED_TEAMS_PER_SERVER,
-	// remainingMachineTeamBudget is the number of machine teams needed to ensure every machine has  SERVER_KNOBS->DESIRED_TEAMS_PER_SERVER teams
+	// remainingMachineTeamBudget is the number of machine teams needed to ensure every machine has
+	// SERVER_KNOBS->DESIRED_TEAMS_PER_SERVER teams
 	int getRemainingMachineTeamBudget() {
-		 int remainingMachineTeamBudget = 0;
-		for ( auto& m : machine_info ) {
+		int remainingMachineTeamBudget = 0;
+		for (auto& m : machine_info) {
 			int healthyMTCount = 0;
-			for ( auto& mt : m.second->machineTeams ) {
-				if ( isMachineTeamHealthy(mt) ) {
+			for (auto& mt : m.second->machineTeams) {
+				if (isMachineTeamHealthy(mt)) {
 					++healthyMTCount;
 				}
 			}
-			remainingMachineTeamBudget += std::max(0, (int) (SERVER_KNOBS->DESIRED_TEAMS_PER_SERVER - healthyMTCount));
+			remainingMachineTeamBudget += std::max(0, (int)(SERVER_KNOBS->DESIRED_TEAMS_PER_SERVER - healthyMTCount));
 		}
 
-		// We over-provision the remainingMachineTeamBudget because we do not know when a new machine team is built, how many times it can be counted into the budget
-		// For example, when a new machine is added, a new machine team only consume 1 such budget
+		// We over-provision the remainingMachineTeamBudget because we do not know, when a new machine team is built,
+		// how many times it can be counted into the budget. For example, when a new machine is added,
+		// a new machine team only consume 1 such budget
 		return remainingMachineTeamBudget;
 	}
 
 	// Each server is expected to have SERVER_KNOBS->DESIRED_TEAMS_PER_SERVER,
 	int getRemainingServerTeamBudget() {
-		// remainingTeamBudget is the number of teams needed to ensure every server has  SERVER_KNOBS->DESIRED_TEAMS_PER_SERVER teams
+		// remainingTeamBudget is the number of teams needed to ensure every server has
+		// SERVER_KNOBS->DESIRED_TEAMS_PER_SERVER teams
 		int remainingTeamBudget = 0;
-		for ( auto& s : server_info ) {
+		for (auto& s : server_info) {
 			int numValidTeams = 0;
-			for ( auto& team : s.second->teams ) {
-				if ( !team->isWrongConfiguration() && team->isHealthy() ) {
+			for (auto& team : s.second->teams) {
+				if (!team->isWrongConfiguration() && team->isHealthy()) {
 					++numValidTeams;
 				}
 			}
-			remainingTeamBudget += std::max(0, (int) (SERVER_KNOBS->DESIRED_TEAMS_PER_SERVER - numValidTeams));
+			remainingTeamBudget += std::max(0, (int)(SERVER_KNOBS->DESIRED_TEAMS_PER_SERVER - numValidTeams));
 		}
 
 		return remainingTeamBudget;
 	}
-		
 
 	// Create server teams based on machine teams
 	// Before the number of machine teams reaches the threshold, build a machine team for each server team
@@ -1747,7 +1750,7 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 		    .detail("DesiredMachineTeams", desiredMachineTeams)
 		    .detail("MaxMachineTeams", maxMachineTeams)
 		    .detail("MachineTeamsToBuild", machineTeamsToBuild)
-			.detail("RemainingMachineTeamBudget", remainingMachineTeamBudget);
+		    .detail("RemainingMachineTeamBudget", remainingMachineTeamBudget);
 		// Pre-build all machine teams until we have the desired number of machine teams
 		if (machineTeamsToBuild > 0) {
 			addedMachineTeams = addBestMachineTeams(machineTeamsToBuild, remainingMachineTeamBudget);
@@ -1839,8 +1842,8 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 
 		healthyMachineTeamCount = getHealthyMachineTeamCount();
 
-		std::pair<int, int>  minMaxTeamNumberOnServer = calculateMinMaxServerTeamNumOnServer();
-		std::pair<int, int>  minMaxMachineTeamNumberOnMachine = calculateMinMaxMachineTeamNumOnMachine();
+		std::pair<int, int> minMaxTeamNumberOnServer = calculateMinMaxServerTeamNumOnServer();
+		std::pair<int, int> minMaxMachineTeamNumberOnMachine = calculateMinMaxMachineTeamNumOnMachine();
 
 		TraceEvent("TeamCollectionInfo", distributorId)
 		    .detail("Primary", primary)
@@ -1855,10 +1858,10 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 		    .detail("DesiredMachineTeams", desiredMachineTeams)
 		    .detail("MaxMachineTeams", maxMachineTeams)
 		    .detail("TotalHealthyMachine", totalHealthyMachineCount)
-			.detail("MinTeamNumberOnServer", minMaxTeamNumberOnServer.first)
-			.detail("MaxTeamNumberOnServer", minMaxTeamNumberOnServer.second)
-			.detail("MinMachineTeamNumberOnMachine", minMaxMachineTeamNumberOnMachine.first)
-			.detail("MaxMachineTeamNumberOnMachine", minMaxMachineTeamNumberOnMachine.second)
+		    .detail("MinTeamNumberOnServer", minMaxTeamNumberOnServer.first)
+		    .detail("MaxTeamNumberOnServer", minMaxTeamNumberOnServer.second)
+		    .detail("MinMachineTeamNumberOnMachine", minMaxMachineTeamNumberOnMachine.first)
+		    .detail("MaxMachineTeamNumberOnMachine", minMaxMachineTeamNumberOnMachine.second)
 		    .trackLatest("TeamCollectionInfo");
 
 		return addedTeams;
@@ -1875,8 +1878,8 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 		int maxMachineTeams = SERVER_KNOBS->MAX_TEAMS_PER_SERVER * totalHealthyMachineCount;
 		int healthyMachineTeamCount = getHealthyMachineTeamCount();
 
-		std::pair<int, int>  minMaxTeamNumberOnServer = calculateMinMaxServerTeamNumOnServer();
-		std::pair<int, int>  minMaxMachineTeamNumberOnMachine = calculateMinMaxMachineTeamNumOnMachine();
+		std::pair<int, int> minMaxTeamNumberOnServer = calculateMinMaxServerTeamNumOnServer();
+		std::pair<int, int> minMaxMachineTeamNumberOnMachine = calculateMinMaxMachineTeamNumOnMachine();
 
 		TraceEvent("TeamCollectionInfo", distributorId)
 		    .detail("Primary", primary)
@@ -1891,10 +1894,10 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 		    .detail("DesiredMachineTeams", desiredMachineTeams)
 		    .detail("MaxMachineTeams", maxMachineTeams)
 		    .detail("TotalHealthyMachine", totalHealthyMachineCount)
-			.detail("MinTeamNumberOnServer", minMaxTeamNumberOnServer.first)
-			.detail("MaxTeamNumberOnServer", minMaxTeamNumberOnServer.second)
-			.detail("MinMachineTeamNumberOnMachine", minMaxMachineTeamNumberOnMachine.first)
-			.detail("MaxMachineTeamNumberOnMachine", minMaxMachineTeamNumberOnMachine.second)
+		    .detail("MinTeamNumberOnServer", minMaxTeamNumberOnServer.first)
+		    .detail("MaxTeamNumberOnServer", minMaxTeamNumberOnServer.second)
+		    .detail("MinMachineTeamNumberOnMachine", minMaxMachineTeamNumberOnMachine.first)
+		    .detail("MaxMachineTeamNumberOnMachine", minMaxMachineTeamNumberOnMachine.second)
 		    .trackLatest("TeamCollectionInfo");
 
 		// Debug purpose
@@ -1950,7 +1953,8 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 				}
 			}
 			// Each server is expected to have SERVER_KNOBS->DESIRED_TEAMS_PER_SERVER,
-			// remainingTeamBudget is the number of teams needed to ensure every server has  SERVER_KNOBS->DESIRED_TEAMS_PER_SERVER teams
+			// remainingTeamBudget is the number of teams needed to ensure every server has
+			// SERVER_KNOBS->DESIRED_TEAMS_PER_SERVER teams
 			int remainingTeamBudget = self->getRemainingServerTeamBudget();
 
 			// teamsToBuild is calculated such that we will not build too many teams in the situation
@@ -1994,8 +1998,8 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 				int maxMachineTeams = SERVER_KNOBS->MAX_TEAMS_PER_SERVER * totalHealthyMachineCount;
 				int healthyMachineTeamCount = self->getHealthyMachineTeamCount();
 
-				std::pair<int, int>  minMaxTeamNumberOnServer = self->calculateMinMaxServerTeamNumOnServer();
-				std::pair<int, int>  minMaxMachineTeamNumberOnMachine = self->calculateMinMaxMachineTeamNumOnMachine();
+				std::pair<int, int> minMaxTeamNumberOnServer = self->calculateMinMaxServerTeamNumOnServer();
+				std::pair<int, int> minMaxMachineTeamNumberOnMachine = self->calculateMinMaxMachineTeamNumOnMachine();
 
 				TraceEvent("TeamCollectionInfo", self->distributorId)
 				    .detail("Primary", self->primary)
@@ -2010,10 +2014,10 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 				    .detail("DesiredMachineTeams", desiredMachineTeams)
 				    .detail("MaxMachineTeams", maxMachineTeams)
 				    .detail("TotalHealthyMachine", totalHealthyMachineCount)
-					.detail("MinTeamNumberOnServer", minMaxTeamNumberOnServer.first)
-					.detail("MaxTeamNumberOnServer", minMaxTeamNumberOnServer.second)
-					.detail("MinMachineTeamNumberOnMachine", minMaxMachineTeamNumberOnMachine.first)
-					.detail("MaxMachineTeamNumberOnMachine", minMaxMachineTeamNumberOnMachine.second)
+				    .detail("MinTeamNumberOnServer", minMaxTeamNumberOnServer.first)
+				    .detail("MaxTeamNumberOnServer", minMaxTeamNumberOnServer.second)
+				    .detail("MinMachineTeamNumberOnMachine", minMaxMachineTeamNumberOnMachine.first)
+				    .detail("MaxMachineTeamNumberOnMachine", minMaxMachineTeamNumberOnMachine.second)
 				    .trackLatest("TeamCollectionInfo");
 			}
 		}
@@ -3056,7 +3060,8 @@ ACTOR Future<Void> storageServerTracker(
 			if(hasWrongStoreTypeOrDC)
 				self->restartRecruiting.trigger();
 
-			if ( lastIsUnhealthy && !status.isUnhealthy() && server->teams.size() < SERVER_KNOBS->DESIRED_TEAMS_PER_SERVER ) {
+			if (lastIsUnhealthy && !status.isUnhealthy() &&
+			    server->teams.size() < SERVER_KNOBS->DESIRED_TEAMS_PER_SERVER) {
 				self->doBuildTeams = true;
 				self->restartTeamBuilder.trigger(); // This does not trigger building teams if there exist healthy teams
 			}

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -1589,9 +1589,9 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 		return totalHealthyMachineCount;
 	}
 
-	std::pair<int, int> calculateMinMaxServerTeamNumOnServer() {
-		int minTeamNumber = std::numeric_limits<int>::max();
-		int maxTeamNumber = std::numeric_limits<int>::min();
+	std::pair<uint32_t, uint32_t> calculateMinMaxServerTeamNumOnServer() {
+		uint32_t minTeamNumber = std::numeric_limits<uint32_t>::max();
+		uint32_t maxTeamNumber = std::numeric_limits<uint32_t>::min();
 		for (auto& server : server_info ) {
 			if ( server.second->teams.size() < minTeamNumber ) {
 				minTeamNumber = server.second->teams.size();
@@ -1603,9 +1603,9 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 		return std::make_pair(minTeamNumber, maxTeamNumber);
 	}
 
-	std::pair<int, int> calculateMinMaxMachineTeamNumOnMachine() {
-		int minTeamNumber = std::numeric_limits<int>::max();
-		int maxTeamNumber = std::numeric_limits<int>::min();
+	std::pair<uint32_t, uint32_t> calculateMinMaxMachineTeamNumOnMachine() {
+		uint32_t minTeamNumber = std::numeric_limits<uint32_t>::max();
+		uint32_t maxTeamNumber = std::numeric_limits<uint32_t>::min();
 		for (auto& machine : machine_info) {
 			if ( machine.second->machineTeams.size() < minTeamNumber ) {
 				minTeamNumber = machine.second->machineTeams.size();

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -1505,7 +1505,12 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 			// Only pick healthy server, which is not failed or excluded.
 			if (server_status.get(server.first).isUnhealthy()) continue;
 
-			int numTeams = server.second->teams.size();
+			int numTeams = 0;
+			for (auto& t : server.second->teams) {
+				 if (!t->isWrongConfiguration() && t->isHealthy()) {
+					 ++numTeams;
+				 }
+			}
 			if (numTeams < minTeamNumber) {
 				minTeamNumber = numTeams;
 				leastUsedServers.clear();
@@ -3053,7 +3058,7 @@ ACTOR Future<Void> storageServerTracker(
 
 			if ( lastIsUnhealthy && !status.isUnhealthy() && server->teams.size() < SERVER_KNOBS->DESIRED_TEAMS_PER_SERVER ) {
 				self->doBuildTeams = true;
-				self->restartTeamBuilder.trigger();
+				self->restartTeamBuilder.trigger(); // This does not trigger building teams if there exist healthy teams
 			}
 			lastIsUnhealthy = status.isUnhealthy();
 

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -4016,7 +4016,7 @@ TEST_CASE("/DataDistribution/AddAllTeams/withLimit") {
 
 	delete(collection);
 
-	ASSERT(result == 10);
+	ASSERT(result >= 10);
 
 	return Void();
 }
@@ -4034,7 +4034,7 @@ TEST_CASE("/DataDistribution/AddTeamsBestOf/SkippingBusyServers") {
 
 	int result = collection->addTeamsBestOf(8, desiredTeams, maxTeams, 8);
 
-	ASSERT(result == 8);
+	ASSERT(result >= 8);
 
 	for(auto process = collection->server_info.begin(); process != collection->server_info.end(); process++) {
 		auto teamCount = process->second->teams.size();

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -1589,6 +1589,34 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 		return totalHealthyMachineCount;
 	}
 
+	std::pair<int, int> calculateMinMaxServerTeamNumOnServer() {
+		int minTeamNumber = std::numeric_limits<int>::max();
+		int maxTeamNumber = std::numeric_limits<int>::min();
+		for (auto& server : server_info ) {
+			if ( server.second->teams.size() < minTeamNumber ) {
+				minTeamNumber = server.second->teams.size();
+			}
+			if ( server.second->teams.size() > maxTeamNumber ) {
+				maxTeamNumber = server.second->teams.size();
+			}
+		}
+		return std::make_pair(minTeamNumber, maxTeamNumber);
+	}
+
+	std::pair<int, int> calculateMinMaxMachineTeamNumOnMachine() {
+		int minTeamNumber = std::numeric_limits<int>::max();
+		int maxTeamNumber = std::numeric_limits<int>::min();
+		for (auto& machine : machine_info) {
+			if ( machine.second->machineTeams.size() < minTeamNumber ) {
+				minTeamNumber = machine.second->machineTeams.size();
+			}
+			if ( machine.second->machineTeams.size() > maxTeamNumber ) {
+				maxTeamNumber = machine.second->machineTeams.size();
+			}
+		}
+		return std::make_pair(minTeamNumber, maxTeamNumber);
+	}
+
 	// Sanity check
 	bool isServerTeamNumberCorrect(Reference<TCMachineTeamInfo>& mt) {
 		int num = 0;
@@ -1760,6 +1788,9 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 
 		healthyMachineTeamCount = getHealthyMachineTeamCount();
 
+		std::pair<int, int>  minMaxTeamNumberOnServer = calculateMinMaxServerTeamNumOnServer();
+		std::pair<int, int>  minMaxMachineTeamNumberOnMachine = calculateMinMaxMachineTeamNumOnMachine();
+
 		TraceEvent("TeamCollectionInfo", distributorId)
 		    .detail("Primary", primary)
 		    .detail("AddedTeamNumber", addedTeams)
@@ -1773,6 +1804,10 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 		    .detail("DesiredMachineTeams", desiredMachineTeams)
 		    .detail("MaxMachineTeams", maxMachineTeams)
 		    .detail("TotalHealthyMachine", totalHealthyMachineCount)
+			.detail("MinTeamNumberOnServer", minMaxTeamNumberOnServer.first)
+			.detail("MaxTeamNumberOnServer", minMaxTeamNumberOnServer.second)
+			.detail("MinMachineTeamNumberOnMachine", minMaxMachineTeamNumberOnMachine.first)
+			.detail("MaxMachineTeamNumberOnMachine", minMaxMachineTeamNumberOnMachine.second)
 		    .trackLatest("TeamCollectionInfo");
 
 		return addedTeams;
@@ -1789,6 +1824,9 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 		int maxMachineTeams = SERVER_KNOBS->MAX_TEAMS_PER_SERVER * totalHealthyMachineCount;
 		int healthyMachineTeamCount = getHealthyMachineTeamCount();
 
+		std::pair<int, int>  minMaxTeamNumberOnServer = calculateMinMaxServerTeamNumOnServer();
+		std::pair<int, int>  minMaxMachineTeamNumberOnMachine = calculateMinMaxMachineTeamNumOnMachine();
+
 		TraceEvent("TeamCollectionInfo", distributorId)
 		    .detail("Primary", primary)
 		    .detail("AddedTeamNumber", 0)
@@ -1802,6 +1840,10 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 		    .detail("DesiredMachineTeams", desiredMachineTeams)
 		    .detail("MaxMachineTeams", maxMachineTeams)
 		    .detail("TotalHealthyMachine", totalHealthyMachineCount)
+			.detail("MinTeamNumberOnServer", minMaxTeamNumberOnServer.first)
+			.detail("MaxTeamNumberOnServer", minMaxTeamNumberOnServer.second)
+			.detail("MinMachineTeamNumberOnMachine", minMaxMachineTeamNumberOnMachine.first)
+			.detail("MaxMachineTeamNumberOnMachine", minMaxMachineTeamNumberOnMachine.second)
 		    .trackLatest("TeamCollectionInfo");
 
 		// Debug purpose
@@ -1898,6 +1940,9 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 				int maxMachineTeams = SERVER_KNOBS->MAX_TEAMS_PER_SERVER * totalHealthyMachineCount;
 				int healthyMachineTeamCount = self->getHealthyMachineTeamCount();
 
+				std::pair<int, int>  minMaxTeamNumberOnServer = self->calculateMinMaxServerTeamNumOnServer();
+				std::pair<int, int>  minMaxMachineTeamNumberOnMachine = self->calculateMinMaxMachineTeamNumOnMachine();
+
 				TraceEvent("TeamCollectionInfo", self->distributorId)
 				    .detail("Primary", self->primary)
 				    .detail("AddedTeamNumber", 0)
@@ -1911,6 +1956,10 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 				    .detail("DesiredMachineTeams", desiredMachineTeams)
 				    .detail("MaxMachineTeams", maxMachineTeams)
 				    .detail("TotalHealthyMachine", totalHealthyMachineCount)
+					.detail("MinTeamNumberOnServer", minMaxTeamNumberOnServer.first)
+					.detail("MaxTeamNumberOnServer", minMaxTeamNumberOnServer.second)
+					.detail("MinMachineTeamNumberOnMachine", minMaxMachineTeamNumberOnMachine.first)
+					.detail("MaxMachineTeamNumberOnMachine", minMaxMachineTeamNumberOnMachine.second)
 				    .trackLatest("TeamCollectionInfo");
 			}
 		}

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -1340,7 +1340,12 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 				// Invariant: We only create correct size machine teams.
 				// When configuration (e.g., team size) is changed, the DDTeamCollection will be destroyed and rebuilt
 				// so that the invariant will not be violated.
-				int teamCount = machine.second->machineTeams.size();
+				int teamCount = 0;
+				for (auto& mt : machine.second->machineTeams) {
+					if ( isMachineTeamHealthy(mt) ) {
+						++teamCount;
+					}
+				}
 
 				if (teamCount < minTeamCount) {
 					leastUsedMachines.clear();

--- a/fdbserver/QuietDatabase.actor.cpp
+++ b/fdbserver/QuietDatabase.actor.cpp
@@ -306,7 +306,6 @@ ACTOR Future<bool> getTeamCollectionValid(Database cx, WorkerInterface dataDistr
 			// The if condition should be consistent with the condition in teamRemover() that decides
 			// if redundant teams exist.
 			if (healthyMachineTeamCount > desiredMachineTeamNumber ||
-				minServerTeamOnServer <= 0 ||
 				minMachineTeamOnMachine <= 0 ) {
 				TraceEvent("GetTeamCollectionValid")
 				    .detail("CurrentTeamNumber", currentTeamNumber)

--- a/fdbserver/QuietDatabase.actor.cpp
+++ b/fdbserver/QuietDatabase.actor.cpp
@@ -290,6 +290,11 @@ ACTOR Future<bool> getTeamCollectionValid(Database cx, WorkerInterface dataDistr
 			int64_t healthyMachineTeamCount = boost::lexical_cast<int64_t>(teamCollectionInfoMessage.getValue("CurrentHealthyMachineTeamNumber"));
 			int64_t desiredMachineTeamNumber = boost::lexical_cast<int64_t>(teamCollectionInfoMessage.getValue("DesiredMachineTeams"));
 			int64_t maxMachineTeamNumber = boost::lexical_cast<int64_t>(teamCollectionInfoMessage.getValue("MaxMachineTeams"));
+			
+			int64_t minServerTeamOnServer = boost::lexical_cast<int64_t>(teamCollectionInfoMessage.getValue("MinTeamNumberOnServer"));
+			int64_t maxServerTeamOnServer = boost::lexical_cast<int64_t>(teamCollectionInfoMessage.getValue("MaxTeamNumberOnServer"));
+			int64_t minMachineTeamOnMachine = boost::lexical_cast<int64_t>(teamCollectionInfoMessage.getValue("MinMachineTeamNumberOnMachine"));
+			int64_t maxMachineTeamOnMachine = boost::lexical_cast<int64_t>(teamCollectionInfoMessage.getValue("MaxMachineTeamNumberOnMachine"));
 
 			// Team number is always valid when we disable teamRemover. This avoids false positive in simulation test
 			if (SERVER_KNOBS->TR_FLAG_DISABLE_TEAM_REMOVER) {
@@ -300,7 +305,11 @@ ACTOR Future<bool> getTeamCollectionValid(Database cx, WorkerInterface dataDistr
 
 			// The if condition should be consistent with the condition in teamRemover() that decides
 			// if redundant teams exist.
-			if (healthyMachineTeamCount > desiredMachineTeamNumber) {
+			if (healthyMachineTeamCount > desiredMachineTeamNumber ||
+				minServerTeamOnServer < SERVER_KNOBS->DESIRED_TEAMS_PER_SERVER ||
+				minMachineTeamOnMachine < SERVER_KNOBS->DESIRED_TEAMS_PER_SERVER ||
+				maxServerTeamOnServer > SERVER_KNOBS->MAX_TEAMS_PER_SERVER ||
+				maxMachineTeamOnMachine > SERVER_KNOBS->MAX_TEAMS_PER_SERVER) {
 				TraceEvent("GetTeamCollectionValid")
 				    .detail("CurrentTeamNumber", currentTeamNumber)
 				    .detail("DesiredTeamNumber", desiredTeamNumber)
@@ -308,7 +317,13 @@ ACTOR Future<bool> getTeamCollectionValid(Database cx, WorkerInterface dataDistr
 				    .detail("CurrentHealthyMachineTeamNumber", healthyMachineTeamCount)
 				    .detail("DesiredMachineTeams", desiredMachineTeamNumber)
 				    .detail("CurrentMachineTeamNumber", currentMachineTeamNumber)
-				    .detail("MaxMachineTeams", maxMachineTeamNumber);
+				    .detail("MaxMachineTeams", maxMachineTeamNumber)
+					.detail("MinTeamNumberOnServer", minServerTeamOnServer)
+					.detail("MaxTeamNumberOnServer", maxServerTeamOnServer)
+					.detail("MinMachineTeamNumberOnMachine", minMachineTeamOnMachine)
+					.detail("MaxMachineTeamNumberOnMachine", maxMachineTeamOnMachine)
+					.detail("DesiredTeamsPerServer", SERVER_KNOBS->DESIRED_TEAMS_PER_SERVER)
+					.detail("MaxTeamsPerServer", SERVER_KNOBS->MAX_TEAMS_PER_SERVER);
 				return false;
 			} else {
 				return true;

--- a/fdbserver/QuietDatabase.actor.cpp
+++ b/fdbserver/QuietDatabase.actor.cpp
@@ -306,10 +306,10 @@ ACTOR Future<bool> getTeamCollectionValid(Database cx, WorkerInterface dataDistr
 			// The if condition should be consistent with the condition in teamRemover() that decides
 			// if redundant teams exist.
 			if (healthyMachineTeamCount > desiredMachineTeamNumber ||
-				minServerTeamOnServer < SERVER_KNOBS->DESIRED_TEAMS_PER_SERVER ||
-				minMachineTeamOnMachine < SERVER_KNOBS->DESIRED_TEAMS_PER_SERVER ||
-				maxServerTeamOnServer > SERVER_KNOBS->MAX_TEAMS_PER_SERVER ||
-				maxMachineTeamOnMachine > SERVER_KNOBS->MAX_TEAMS_PER_SERVER) {
+				minServerTeamOnServer <= 0 ||
+				minMachineTeamOnMachine <= 0 ||
+				( maxServerTeamOnServer > SERVER_KNOBS->DESIRED_TEAMS_PER_SERVER && minServerTeamOnServer < SERVER_KNOBS->DESIRED_TEAMS_PER_SERVER ) ||
+				( maxMachineTeamOnMachine > SERVER_KNOBS->DESIRED_TEAMS_PER_SERVER && minMachineTeamOnMachine < SERVER_KNOBS->DESIRED_TEAMS_PER_SERVER ) ) {
 				TraceEvent("GetTeamCollectionValid")
 				    .detail("CurrentTeamNumber", currentTeamNumber)
 				    .detail("DesiredTeamNumber", desiredTeamNumber)

--- a/fdbserver/QuietDatabase.actor.cpp
+++ b/fdbserver/QuietDatabase.actor.cpp
@@ -307,9 +307,7 @@ ACTOR Future<bool> getTeamCollectionValid(Database cx, WorkerInterface dataDistr
 			// if redundant teams exist.
 			if (healthyMachineTeamCount > desiredMachineTeamNumber ||
 				minServerTeamOnServer <= 0 ||
-				minMachineTeamOnMachine <= 0 ||
-				( maxServerTeamOnServer > SERVER_KNOBS->DESIRED_TEAMS_PER_SERVER && minServerTeamOnServer < SERVER_KNOBS->DESIRED_TEAMS_PER_SERVER ) ||
-				( maxMachineTeamOnMachine > SERVER_KNOBS->DESIRED_TEAMS_PER_SERVER && minMachineTeamOnMachine < SERVER_KNOBS->DESIRED_TEAMS_PER_SERVER ) ) {
+				minMachineTeamOnMachine <= 0 ) {
 				TraceEvent("GetTeamCollectionValid")
 				    .detail("CurrentTeamNumber", currentTeamNumber)
 				    .detail("DesiredTeamNumber", desiredTeamNumber)

--- a/fdbserver/QuietDatabase.actor.cpp
+++ b/fdbserver/QuietDatabase.actor.cpp
@@ -290,11 +290,15 @@ ACTOR Future<bool> getTeamCollectionValid(Database cx, WorkerInterface dataDistr
 			int64_t healthyMachineTeamCount = boost::lexical_cast<int64_t>(teamCollectionInfoMessage.getValue("CurrentHealthyMachineTeamNumber"));
 			int64_t desiredMachineTeamNumber = boost::lexical_cast<int64_t>(teamCollectionInfoMessage.getValue("DesiredMachineTeams"));
 			int64_t maxMachineTeamNumber = boost::lexical_cast<int64_t>(teamCollectionInfoMessage.getValue("MaxMachineTeams"));
-			
-			int64_t minServerTeamOnServer = boost::lexical_cast<int64_t>(teamCollectionInfoMessage.getValue("MinTeamNumberOnServer"));
-			int64_t maxServerTeamOnServer = boost::lexical_cast<int64_t>(teamCollectionInfoMessage.getValue("MaxTeamNumberOnServer"));
-			int64_t minMachineTeamOnMachine = boost::lexical_cast<int64_t>(teamCollectionInfoMessage.getValue("MinMachineTeamNumberOnMachine"));
-			int64_t maxMachineTeamOnMachine = boost::lexical_cast<int64_t>(teamCollectionInfoMessage.getValue("MaxMachineTeamNumberOnMachine"));
+
+			int64_t minServerTeamOnServer =
+			    boost::lexical_cast<int64_t>(teamCollectionInfoMessage.getValue("MinTeamNumberOnServer"));
+			int64_t maxServerTeamOnServer =
+			    boost::lexical_cast<int64_t>(teamCollectionInfoMessage.getValue("MaxTeamNumberOnServer"));
+			int64_t minMachineTeamOnMachine =
+			    boost::lexical_cast<int64_t>(teamCollectionInfoMessage.getValue("MinMachineTeamNumberOnMachine"));
+			int64_t maxMachineTeamOnMachine =
+			    boost::lexical_cast<int64_t>(teamCollectionInfoMessage.getValue("MaxMachineTeamNumberOnMachine"));
 
 			// Team number is always valid when we disable teamRemover. This avoids false positive in simulation test
 			if (SERVER_KNOBS->TR_FLAG_DISABLE_TEAM_REMOVER) {
@@ -305,8 +309,7 @@ ACTOR Future<bool> getTeamCollectionValid(Database cx, WorkerInterface dataDistr
 
 			// The if condition should be consistent with the condition in teamRemover() that decides
 			// if redundant teams exist.
-			if (healthyMachineTeamCount > desiredMachineTeamNumber ||
-				minMachineTeamOnMachine <= 0 ) {
+			if (healthyMachineTeamCount > desiredMachineTeamNumber || minMachineTeamOnMachine <= 0) {
 				TraceEvent("GetTeamCollectionValid")
 				    .detail("CurrentTeamNumber", currentTeamNumber)
 				    .detail("DesiredTeamNumber", desiredTeamNumber)
@@ -315,12 +318,12 @@ ACTOR Future<bool> getTeamCollectionValid(Database cx, WorkerInterface dataDistr
 				    .detail("DesiredMachineTeams", desiredMachineTeamNumber)
 				    .detail("CurrentMachineTeamNumber", currentMachineTeamNumber)
 				    .detail("MaxMachineTeams", maxMachineTeamNumber)
-					.detail("MinTeamNumberOnServer", minServerTeamOnServer)
-					.detail("MaxTeamNumberOnServer", maxServerTeamOnServer)
-					.detail("MinMachineTeamNumberOnMachine", minMachineTeamOnMachine)
-					.detail("MaxMachineTeamNumberOnMachine", maxMachineTeamOnMachine)
-					.detail("DesiredTeamsPerServer", SERVER_KNOBS->DESIRED_TEAMS_PER_SERVER)
-					.detail("MaxTeamsPerServer", SERVER_KNOBS->MAX_TEAMS_PER_SERVER);
+				    .detail("MinTeamNumberOnServer", minServerTeamOnServer)
+				    .detail("MaxTeamNumberOnServer", maxServerTeamOnServer)
+				    .detail("MinMachineTeamNumberOnMachine", minMachineTeamOnMachine)
+				    .detail("MaxMachineTeamNumberOnMachine", maxMachineTeamOnMachine)
+				    .detail("DesiredTeamsPerServer", SERVER_KNOBS->DESIRED_TEAMS_PER_SERVER)
+				    .detail("MaxTeamsPerServer", SERVER_KNOBS->MAX_TEAMS_PER_SERVER);
 				return false;
 			} else {
 				return true;


### PR DESCRIPTION
This PR solves issue  #1754.

When team collection computes the number of servers (and machine) teams, it also considers the number of teams each server (and team) needs to reach the DESIRED_TEAMS_PER_SERVER.

When new machine is added to the cluster, no matter how many machine teams the cluster already has, the new logic will re-kick the logic of building teams. 

Simulation test in ongoing and will be done by tomorrow.