### PR TITLE
[Release 6.1 Patch] Ensure new added machines are used to build teams

### DIFF
--- a/documentation/sphinx/source/release-notes.rst
+++ b/documentation/sphinx/source/release-notes.rst
@@ -14,6 +14,7 @@ Fixes
 -----
 
 * The ``fdbrestore`` commands ``abort``, ``wait``, and ``status`` would use a default cluster file instead of the destination cluster file argument.  `(PR #1701) <https://github.com/apple/foundationdb/pull/1701>`_
+* Ensure new added machines are used to build teams and host data from existing machines when a cluster is expanded. `(PR #1764) <https://github.com/apple/foundationdb/pull/1764>`_
 
 6.1.9
 =====

--- a/documentation/sphinx/source/release-notes.rst
+++ b/documentation/sphinx/source/release-notes.rst
@@ -2,6 +2,14 @@
 Release Notes
 #############
 
+6.1.11
+======
+
+Fixes
+-----
+
+* Ensure new added machines are used to build teams and host data from existing machines when a cluster is expanded. `(PR #1764) <https://github.com/apple/foundationdb/pull/1764>`_
+
 6.1.10
 ======
 

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -1507,7 +1507,12 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 			// Only pick healthy server, which is not failed or excluded.
 			if (server_status.get(server.first).isUnhealthy()) continue;
 
-			int numTeams = server.second->teams.size();
+			int numTeams = 0;
+			for (auto& t : server.second->teams) {
+				 if (!t->isWrongConfiguration() && t->isHealthy()) {
+					 ++numTeams;
+				 }
+			}
 			if (numTeams < minTeamNumber) {
 				minTeamNumber = numTeams;
 				leastUsedServers.clear();
@@ -3056,7 +3061,7 @@ ACTOR Future<Void> storageServerTracker(
 
 			if ( lastIsUnhealthy && !status.isUnhealthy() && server->teams.size() < SERVER_KNOBS->DESIRED_TEAMS_PER_SERVER ) {
 				self->doBuildTeams = true;
-				self->restartTeamBuilder.trigger();
+				self->restartTeamBuilder.trigger(); // This does not trigger building teams if there exist healthy teams
 			}
 			lastIsUnhealthy = status.isUnhealthy();
 

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -1342,7 +1342,12 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 				// Invariant: We only create correct size machine teams.
 				// When configuration (e.g., team size) is changed, the DDTeamCollection will be destroyed and rebuilt
 				// so that the invariant will not be violated.
-				int teamCount = machine.second->machineTeams.size();
+				int teamCount = 0;
+				for (auto& mt : machine.second->machineTeams) {
+					if ( isMachineTeamHealthy(mt) ) {
+						++teamCount;
+					}
+				}
 
 				if (teamCount < minTeamCount) {
 					leastUsedMachines.clear();

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -1610,6 +1610,9 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 		uint32_t minTeamNumber = std::numeric_limits<uint32_t>::max();
 		uint32_t maxTeamNumber = std::numeric_limits<uint32_t>::min();
 		for (auto& server : server_info) {
+			if ( server_status.get(server.first).isUnhealthy() ) {
+				continue;
+			}
 			if (server.second->teams.size() < minTeamNumber) {
 				minTeamNumber = server.second->teams.size();
 			}
@@ -1624,6 +1627,9 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 		uint32_t minTeamNumber = std::numeric_limits<uint32_t>::max();
 		uint32_t maxTeamNumber = std::numeric_limits<uint32_t>::min();
 		for (auto& machine : machine_info) {
+			if ( !isMachineHealthy(machine.second) ) {
+				continue;
+			}
 			if (machine.second->machineTeams.size() < minTeamNumber) {
 				minTeamNumber = machine.second->machineTeams.size();
 			}

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -3190,7 +3190,7 @@ ACTOR Future<Void> storageServerTracker(
 							self->badTeamRemover = removeBadTeams(self);
 							self->addActor.send(self->badTeamRemover);
 							// The team number changes, so we need to update the team number info
-							//self->traceTeamCollectionInfo();
+							self->traceTeamCollectionInfo();
 						}
 					}
 
@@ -3458,6 +3458,7 @@ ACTOR Future<Void> dataDistributionTeamCollection(
 			self->redundantTeamRemover = teamRemover(self);
 			self->addActor.send(self->redundantTeamRemover);
 		}
+		self->traceTeamCollectionInfo();
 
 		if(self->includedDCs.size()) {
 			//start this actor before any potential recruitments can happen
@@ -3470,8 +3471,6 @@ ACTOR Future<Void> dataDistributionTeamCollection(
 		self->addActor.send(trackExcludedServers( self ));
 		self->addActor.send(monitorHealthyTeams( self ));
 		self->addActor.send(waitHealthyZoneChange( self ));
-
-		self->traceTeamCollectionInfo();
 
 		// SOMEDAY: Monitor FF/serverList for (new) servers that aren't in allServers and add or remove them
 

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -1591,6 +1591,34 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 		return totalHealthyMachineCount;
 	}
 
+	std::pair<int, int> calculateMinMaxServerTeamNumOnServer() {
+		int minTeamNumber = std::numeric_limits<int>::max();
+		int maxTeamNumber = std::numeric_limits<int>::min();
+		for (auto& server : server_info ) {
+			if ( server.second->teams.size() < minTeamNumber ) {
+				minTeamNumber = server.second->teams.size();
+			}
+			if ( server.second->teams.size() > maxTeamNumber ) {
+				maxTeamNumber = server.second->teams.size();
+			}
+		}
+		return std::make_pair(minTeamNumber, maxTeamNumber);
+	}
+
+	std::pair<int, int> calculateMinMaxMachineTeamNumOnMachine() {
+		int minTeamNumber = std::numeric_limits<int>::max();
+		int maxTeamNumber = std::numeric_limits<int>::min();
+		for (auto& machine : machine_info) {
+			if ( machine.second->machineTeams.size() < minTeamNumber ) {
+				minTeamNumber = machine.second->machineTeams.size();
+			}
+			if ( machine.second->machineTeams.size() > maxTeamNumber ) {
+				maxTeamNumber = machine.second->machineTeams.size();
+			}
+		}
+		return std::make_pair(minTeamNumber, maxTeamNumber);
+	}
+
 	// Sanity check
 	bool isServerTeamNumberCorrect(Reference<TCMachineTeamInfo>& mt) {
 		int num = 0;
@@ -1762,6 +1790,9 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 
 		healthyMachineTeamCount = getHealthyMachineTeamCount();
 
+		std::pair<int, int>  minMaxTeamNumberOnServer = calculateMinMaxServerTeamNumOnServer();
+		std::pair<int, int>  minMaxMachineTeamNumberOnMachine = calculateMinMaxMachineTeamNumOnMachine();
+
 		TraceEvent("TeamCollectionInfo", distributorId)
 		    .detail("Primary", primary)
 		    .detail("AddedTeamNumber", addedTeams)
@@ -1775,6 +1806,10 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 		    .detail("DesiredMachineTeams", desiredMachineTeams)
 		    .detail("MaxMachineTeams", maxMachineTeams)
 		    .detail("TotalHealthyMachine", totalHealthyMachineCount)
+			.detail("MinTeamNumberOnServer", minMaxTeamNumberOnServer.first)
+			.detail("MaxTeamNumberOnServer", minMaxTeamNumberOnServer.second)
+			.detail("MinMachineTeamNumberOnMachine", minMaxMachineTeamNumberOnMachine.first)
+			.detail("MaxMachineTeamNumberOnMachine", minMaxMachineTeamNumberOnMachine.second)
 		    .trackLatest("TeamCollectionInfo");
 
 		return addedTeams;
@@ -1791,6 +1826,9 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 		int maxMachineTeams = SERVER_KNOBS->MAX_TEAMS_PER_SERVER * totalHealthyMachineCount;
 		int healthyMachineTeamCount = getHealthyMachineTeamCount();
 
+		std::pair<int, int>  minMaxTeamNumberOnServer = calculateMinMaxServerTeamNumOnServer();
+		std::pair<int, int>  minMaxMachineTeamNumberOnMachine = calculateMinMaxMachineTeamNumOnMachine();
+
 		TraceEvent("TeamCollectionInfo", distributorId)
 		    .detail("Primary", primary)
 		    .detail("AddedTeamNumber", 0)
@@ -1804,6 +1842,10 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 		    .detail("DesiredMachineTeams", desiredMachineTeams)
 		    .detail("MaxMachineTeams", maxMachineTeams)
 		    .detail("TotalHealthyMachine", totalHealthyMachineCount)
+			.detail("MinTeamNumberOnServer", minMaxTeamNumberOnServer.first)
+			.detail("MaxTeamNumberOnServer", minMaxTeamNumberOnServer.second)
+			.detail("MinMachineTeamNumberOnMachine", minMaxMachineTeamNumberOnMachine.first)
+			.detail("MaxMachineTeamNumberOnMachine", minMaxMachineTeamNumberOnMachine.second)
 		    .trackLatest("TeamCollectionInfo");
 
 		// Debug purpose
@@ -1901,6 +1943,9 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 				int maxMachineTeams = SERVER_KNOBS->MAX_TEAMS_PER_SERVER * totalHealthyMachineCount;
 				int healthyMachineTeamCount = self->getHealthyMachineTeamCount();
 
+				std::pair<int, int>  minMaxTeamNumberOnServer = self->calculateMinMaxServerTeamNumOnServer();
+				std::pair<int, int>  minMaxMachineTeamNumberOnMachine = self->calculateMinMaxMachineTeamNumOnMachine();
+
 				TraceEvent("TeamCollectionInfo", self->distributorId)
 				    .detail("Primary", self->primary)
 				    .detail("AddedTeamNumber", 0)
@@ -1914,6 +1959,10 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 				    .detail("DesiredMachineTeams", desiredMachineTeams)
 				    .detail("MaxMachineTeams", maxMachineTeams)
 				    .detail("TotalHealthyMachine", totalHealthyMachineCount)
+					.detail("MinTeamNumberOnServer", minMaxTeamNumberOnServer.first)
+					.detail("MaxTeamNumberOnServer", minMaxTeamNumberOnServer.second)
+					.detail("MinMachineTeamNumberOnMachine", minMaxMachineTeamNumberOnMachine.first)
+					.detail("MaxMachineTeamNumberOnMachine", minMaxMachineTeamNumberOnMachine.second)
 				    .trackLatest("TeamCollectionInfo");
 			}
 		}

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -959,7 +959,7 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 		}
 
 		// Trace and record the current number of teams for correctness test
-		wait( self->traceTeamCollectionInfo(self) );
+		wait(self->traceTeamCollectionInfo(self));
 
 		return Void();
 	}
@@ -1381,7 +1381,7 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 				team.clear();
 				auto success = machineLocalityMap.selectReplicas(configuration.storagePolicy, forcedAttributes, team);
 				// NOTE: selectReplicas() should always return success when storageTeamSize = 1
-				ASSERT_WE_THINK ( configuration.storageTeamSize > 1 || (configuration.storageTeamSize == 1 && success) );
+				ASSERT_WE_THINK(configuration.storageTeamSize > 1 || (configuration.storageTeamSize == 1 && success));
 				if (!success && configuration.storageTeamSize > 1) {
 					break;
 				}
@@ -1601,7 +1601,7 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 		uint32_t minTeamNumber = std::numeric_limits<uint32_t>::max();
 		uint32_t maxTeamNumber = std::numeric_limits<uint32_t>::min();
 		for (auto& server : server_info) {
-			if ( server_status.get(server.first).isUnhealthy() ) {
+			if (server_status.get(server.first).isUnhealthy()) {
 				continue;
 			}
 			if (server.second->teams.size() < minTeamNumber) {
@@ -1618,7 +1618,7 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 		int minTeamNumber = std::numeric_limits<int>::max();
 		int maxTeamNumber = 0;
 		for (auto& machine : machine_info) {
-			if ( !isMachineHealthy(machine.second) ) {
+			if (!isMachineHealthy(machine.second)) {
 				continue;
 			}
 			if (machine.second->machineTeams.size() < minTeamNumber) {
@@ -1840,7 +1840,7 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 		    .detail("Primary", primary)
 		    .detail("AddedTeamNumber", addedTeams)
 		    .detail("AimToBuildTeamNumber", teamsToBuild)
-			.detail("RemainingTeamBudget", remainingTeamBudget)
+		    .detail("RemainingTeamBudget", remainingTeamBudget)
 		    .detail("CurrentTeamNumber", teams.size())
 		    .detail("DesiredTeamNumber", desiredTeamNumber)
 		    .detail("MaxTeamNumber", maxTeamNumber)
@@ -1878,7 +1878,7 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 		    .detail("Primary", self->primary)
 		    .detail("AddedTeamNumber", 0)
 		    .detail("AimToBuildTeamNumber", 0)
-			.detail("RemainingTeamBudget", 0)
+		    .detail("RemainingTeamBudget", 0)
 		    .detail("CurrentTeamNumber", self->teams.size())
 		    .detail("DesiredTeamNumber", desiredServerTeams)
 		    .detail("MaxTeamNumber", maxServerTeams)
@@ -1897,7 +1897,7 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 
 		// Advance time so that we will not have multiple TeamCollectionInfo at the same time, otherwise
 		// simulation test will randomly pick one TeamCollectionInfo trace, which could be the one before build teams
-		wait( delay(0.01) );
+		wait(delay(0.01));
 
 		// Debug purpose
 //		if (healthyMachineTeamCount > desiredMachineTeams || machineTeams.size() > maxMachineTeams) {
@@ -2006,7 +2006,7 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 				    .detail("Primary", self->primary)
 				    .detail("AddedTeamNumber", 0)
 				    .detail("AimToBuildTeamNumber", teamsToBuild)
-					.detail("RemainingTeamBudget", remainingTeamBudget)
+				    .detail("RemainingTeamBudget", remainingTeamBudget)
 				    .detail("CurrentTeamNumber", self->teams.size())
 				    .detail("DesiredTeamNumber", desiredTeams)
 				    .detail("MaxTeamNumber", maxTeams)
@@ -2467,7 +2467,7 @@ ACTOR Future<Void> teamRemover(DDTeamCollection* self) {
 				    .detail("CurrentMachineTeamNumber", self->machineTeams.size())
 				    .detail("DesiredMachineTeam", desiredMachineTeams)
 				    .detail("NumMachineTeamRemoved", numMachineTeamRemoved);
-				wait( self->traceTeamCollectionInfo(self) );
+				wait(self->traceTeamCollectionInfo(self));
 			}
 		}
 	}
@@ -3222,8 +3222,8 @@ ACTOR Future<Void> storageServerTracker(
 				}
 			}
 
-			if ( recordTeamCollectionInfo ) {
-				wait( self->traceTeamCollectionInfo(self) );
+			if (recordTeamCollectionInfo) {
+				wait(self->traceTeamCollectionInfo(self));
 			}
 		}
 	} catch( Error &e ) {
@@ -3459,7 +3459,7 @@ ACTOR Future<Void> dataDistributionTeamCollection(
 			self->redundantTeamRemover = teamRemover(self);
 			self->addActor.send(self->redundantTeamRemover);
 		}
-		wait( self->traceTeamCollectionInfo(self) );
+		wait(self->traceTeamCollectionInfo(self));
 
 		if(self->includedDCs.size()) {
 			//start this actor before any potential recruitments can happen

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -1510,12 +1510,7 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 			// Only pick healthy server, which is not failed or excluded.
 			if (server_status.get(server.first).isUnhealthy()) continue;
 
-			int numTeams = 0;
-			for (auto& t : server.second->teams) {
-				if (!t->isWrongConfiguration() && t->isHealthy()) {
-					++numTeams;
-				}
-			}
+			int numTeams = server.second->teams.size();
 			if (numTeams < minTeamNumber) {
 				minTeamNumber = numTeams;
 				leastUsedServers.clear();
@@ -1610,9 +1605,9 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 		uint32_t minTeamNumber = std::numeric_limits<uint32_t>::max();
 		uint32_t maxTeamNumber = std::numeric_limits<uint32_t>::min();
 		for (auto& server : server_info) {
-			if ( server_status.get(server.first).isUnhealthy() ) {
-				continue;
-			}
+			// if ( server_status.get(server.first).isUnhealthy() ) {
+			// 	continue;
+			// }
 			if (server.second->teams.size() < minTeamNumber) {
 				minTeamNumber = server.second->teams.size();
 			}
@@ -1623,13 +1618,13 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 		return std::make_pair(minTeamNumber, maxTeamNumber);
 	}
 
-	std::pair<uint32_t, uint32_t> calculateMinMaxMachineTeamNumOnMachine() {
-		uint32_t minTeamNumber = std::numeric_limits<uint32_t>::max();
-		uint32_t maxTeamNumber = std::numeric_limits<uint32_t>::min();
+	std::pair<int, int> calculateMinMaxMachineTeamNumOnMachine() {
+		int minTeamNumber = std::numeric_limits<int>::max();
+		int maxTeamNumber = 0;
 		for (auto& machine : machine_info) {
-			if ( !isMachineHealthy(machine.second) ) {
-				continue;
-			}
+			// if ( !isMachineHealthy(machine.second) ) {
+			// 	continue;
+			// }
 			if (machine.second->machineTeams.size() < minTeamNumber) {
 				minTeamNumber = machine.second->machineTeams.size();
 			}

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -1682,7 +1682,7 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 	}
 
 	// Each machine is expected to have SERVER_KNOBS->DESIRED_TEAMS_PER_SERVER,
-    // remainingMachineTeamBudget is the number of machine teams needed to ensure every machine has  SERVER_KNOBS->DESIRED_TEAMS_PER_SERVER teams
+	// remainingMachineTeamBudget is the number of machine teams needed to ensure every machine has  SERVER_KNOBS->DESIRED_TEAMS_PER_SERVER teams
 	int getRemainingMachineTeamBudget() {
 		 int remainingMachineTeamBudget = 0;
 		for ( auto& m : machine_info ) {

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -1897,7 +1897,7 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 
 		// Advance time so that we will not have multiple TeamCollectionInfo at the same time, otherwise
 		// simulation test will randomly pick one TeamCollectionInfo trace, which could be the one before build teams
-		wait(delay(0.01));
+		//wait(delay(0.01));
 
 		// Debug purpose
 //		if (healthyMachineTeamCount > desiredMachineTeams || machineTeams.size() > maxMachineTeams) {

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -1732,8 +1732,8 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 		int desiredMachineTeams = SERVER_KNOBS->DESIRED_TEAMS_PER_SERVER * totalHealthyMachineCount;
 		int maxMachineTeams = SERVER_KNOBS->MAX_TEAMS_PER_SERVER * totalHealthyMachineCount;
 		// machineTeamsToBuild mimics how the teamsToBuild is calculated in buildTeams()
-		int machineTeamsToBuild =
-		    std::min(desiredMachineTeams - healthyMachineTeamCount, maxMachineTeams - totalMachineTeamCount);
+		int machineTeamsToBuild = std::max(
+		    0, std::min(desiredMachineTeams - healthyMachineTeamCount, maxMachineTeams - totalMachineTeamCount));
 
 		TraceEvent("BuildMachineTeams")
 		    .detail("TotalHealthyMachine", totalHealthyMachineCount)
@@ -1897,7 +1897,7 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 
 		// Advance time so that we will not have multiple TeamCollectionInfo at the same time, otherwise
 		// simulation test will randomly pick one TeamCollectionInfo trace, which could be the one before build teams
-		//wait(delay(0.01));
+		// wait(delay(0.01));
 
 		// Debug purpose
 //		if (healthyMachineTeamCount > desiredMachineTeams || machineTeams.size() > maxMachineTeams) {

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -1591,9 +1591,9 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 		return totalHealthyMachineCount;
 	}
 
-	std::pair<int, int> calculateMinMaxServerTeamNumOnServer() {
-		int minTeamNumber = std::numeric_limits<int>::max();
-		int maxTeamNumber = std::numeric_limits<int>::min();
+	std::pair<uint32_t, uint32_t> calculateMinMaxServerTeamNumOnServer() {
+		uint32_t minTeamNumber = std::numeric_limits<uint32_t>::max();
+		uint32_t maxTeamNumber = std::numeric_limits<uint32_t>::min();
 		for (auto& server : server_info ) {
 			if ( server.second->teams.size() < minTeamNumber ) {
 				minTeamNumber = server.second->teams.size();
@@ -1605,9 +1605,9 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 		return std::make_pair(minTeamNumber, maxTeamNumber);
 	}
 
-	std::pair<int, int> calculateMinMaxMachineTeamNumOnMachine() {
-		int minTeamNumber = std::numeric_limits<int>::max();
-		int maxTeamNumber = std::numeric_limits<int>::min();
+	std::pair<uint32_t, uint32_t> calculateMinMaxMachineTeamNumOnMachine() {
+		uint32_t minTeamNumber = std::numeric_limits<uint32_t>::max();
+		uint32_t maxTeamNumber = std::numeric_limits<uint32_t>::min();
 		for (auto& machine : machine_info) {
 			if ( machine.second->machineTeams.size() < minTeamNumber ) {
 				minTeamNumber = machine.second->machineTeams.size();

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -1596,28 +1596,28 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 		return totalHealthyMachineCount;
 	}
 
-	std::pair<uint64_t, uint64_t> calculateMinMaxServerTeamNumOnServer() {
-		uint64_t minTeamNumber = std::numeric_limits<uint64_t>::max();
-		uint64_t maxTeamNumber = 0;
+	std::pair<int64_t, int64_t> calculateMinMaxServerTeamNumOnServer() {
+		int64_t minTeamNumber = std::numeric_limits<int64_t>::max();
+		int64_t maxTeamNumber = 0;
 		for (auto& server : server_info) {
 			if (server_status.get(server.first).isUnhealthy()) {
 				continue;
 			}
-			minTeamNumber = std::min(server.second->teams.size(), minTeamNumber);
-			maxTeamNumber = std::max(server.second->teams.size(), maxTeamNumber);
+			minTeamNumber = std::min((int64_t) server.second->teams.size(), minTeamNumber);
+			maxTeamNumber = std::max((int64_t) server.second->teams.size(), maxTeamNumber);
 		}
 		return std::make_pair(minTeamNumber, maxTeamNumber);
 	}
 
-	std::pair<uint64_t, uint64_t> calculateMinMaxMachineTeamNumOnMachine() {
-		uint64_t minTeamNumber = std::numeric_limits<uint64_t>::max();
-		uint64_t maxTeamNumber = 0;
+	std::pair<int64_t, int64_t> calculateMinMaxMachineTeamNumOnMachine() {
+		int64_t minTeamNumber = std::numeric_limits<int64_t>::max();
+		int64_t maxTeamNumber = 0;
 		for (auto& machine : machine_info) {
 			if (!isMachineHealthy(machine.second)) {
 				continue;
 			}
-			minTeamNumber = std::min<uint64_t>(machine.second->machineTeams.size(), minTeamNumber);
-			maxTeamNumber = std::max<uint64_t>(machine.second->machineTeams.size(), maxTeamNumber);
+			minTeamNumber = std::min<int64_t>((int64_t) machine.second->machineTeams.size(), minTeamNumber);
+			maxTeamNumber = std::max<int64_t>((int64_t) machine.second->machineTeams.size(), maxTeamNumber);
 		}
 		return std::make_pair(minTeamNumber, maxTeamNumber);
 	}

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -4019,7 +4019,7 @@ TEST_CASE("/DataDistribution/AddAllTeams/withLimit") {
 
 	delete(collection);
 
-	ASSERT(result == 10);
+	ASSERT(result >= 10);
 
 	return Void();
 }
@@ -4037,7 +4037,7 @@ TEST_CASE("/DataDistribution/AddTeamsBestOf/SkippingBusyServers") {
 
 	int result = collection->addTeamsBestOf(8, desiredTeams, maxTeams, 8);
 
-	ASSERT(result == 8);
+	ASSERT(result >= 8);
 
 	for(auto process = collection->server_info.begin(); process != collection->server_info.end(); process++) {
 		auto teamCount = process->second->teams.size();

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -1344,7 +1344,7 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 				// so that the invariant will not be violated.
 				int teamCount = 0;
 				for (auto& mt : machine.second->machineTeams) {
-					if ( isMachineTeamHealthy(mt) ) {
+					if (isMachineTeamHealthy(mt)) {
 						++teamCount;
 					}
 				}
@@ -1437,7 +1437,8 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 
 				addMachineTeam(machines);
 				addedMachineTeams++;
-				// Update the remaining machine team budget because the budget may decrease by any value between 1 and storageTeamSize
+				// Update the remaining machine team budget because the budget may decrease by any value between 1 and
+				// storageTeamSize
 				remainingMachineTeamBudget = getRemainingMachineTeamBudget();
 			} else {
 				TraceEvent(SevWarn, "DataDistributionBuildTeams", distributorId)
@@ -1509,9 +1510,9 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 
 			int numTeams = 0;
 			for (auto& t : server.second->teams) {
-				 if (!t->isWrongConfiguration() && t->isHealthy()) {
-					 ++numTeams;
-				 }
+				if (!t->isWrongConfiguration() && t->isHealthy()) {
+					++numTeams;
+				}
 			}
 			if (numTeams < minTeamNumber) {
 				minTeamNumber = numTeams;
@@ -1606,11 +1607,11 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 	std::pair<uint32_t, uint32_t> calculateMinMaxServerTeamNumOnServer() {
 		uint32_t minTeamNumber = std::numeric_limits<uint32_t>::max();
 		uint32_t maxTeamNumber = std::numeric_limits<uint32_t>::min();
-		for (auto& server : server_info ) {
-			if ( server.second->teams.size() < minTeamNumber ) {
+		for (auto& server : server_info) {
+			if (server.second->teams.size() < minTeamNumber) {
 				minTeamNumber = server.second->teams.size();
 			}
-			if ( server.second->teams.size() > maxTeamNumber ) {
+			if (server.second->teams.size() > maxTeamNumber) {
 				maxTeamNumber = server.second->teams.size();
 			}
 		}
@@ -1621,10 +1622,10 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 		uint32_t minTeamNumber = std::numeric_limits<uint32_t>::max();
 		uint32_t maxTeamNumber = std::numeric_limits<uint32_t>::min();
 		for (auto& machine : machine_info) {
-			if ( machine.second->machineTeams.size() < minTeamNumber ) {
+			if (machine.second->machineTeams.size() < minTeamNumber) {
 				minTeamNumber = machine.second->machineTeams.size();
 			}
-			if ( machine.second->machineTeams.size() > maxTeamNumber ) {
+			if (machine.second->machineTeams.size() > maxTeamNumber) {
 				maxTeamNumber = machine.second->machineTeams.size();
 			}
 		}
@@ -1682,41 +1683,43 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 	}
 
 	// Each machine is expected to have SERVER_KNOBS->DESIRED_TEAMS_PER_SERVER,
-	// remainingMachineTeamBudget is the number of machine teams needed to ensure every machine has  SERVER_KNOBS->DESIRED_TEAMS_PER_SERVER teams
+	// remainingMachineTeamBudget is the number of machine teams needed to ensure every machine has
+	// SERVER_KNOBS->DESIRED_TEAMS_PER_SERVER teams
 	int getRemainingMachineTeamBudget() {
-		 int remainingMachineTeamBudget = 0;
-		for ( auto& m : machine_info ) {
+		int remainingMachineTeamBudget = 0;
+		for (auto& m : machine_info) {
 			int healthyMTCount = 0;
-			for ( auto& mt : m.second->machineTeams ) {
-				if ( isMachineTeamHealthy(mt) ) {
+			for (auto& mt : m.second->machineTeams) {
+				if (isMachineTeamHealthy(mt)) {
 					++healthyMTCount;
 				}
 			}
-			remainingMachineTeamBudget += std::max(0, (int) (SERVER_KNOBS->DESIRED_TEAMS_PER_SERVER - healthyMTCount));
+			remainingMachineTeamBudget += std::max(0, (int)(SERVER_KNOBS->DESIRED_TEAMS_PER_SERVER - healthyMTCount));
 		}
 
-		// We over-provision the remainingMachineTeamBudget because we do not know when a new machine team is built, how many times it can be counted into the budget
-		// For example, when a new machine is added, a new machine team only consume 1 such budget
+		// We over-provision the remainingMachineTeamBudget because we do not know, when a new machine team is built,
+		// how many times it can be counted into the budget. For example, when a new machine is added,
+		// a new machine team only consume 1 such budget
 		return remainingMachineTeamBudget;
 	}
 
 	// Each server is expected to have SERVER_KNOBS->DESIRED_TEAMS_PER_SERVER,
 	int getRemainingServerTeamBudget() {
-		// remainingTeamBudget is the number of teams needed to ensure every server has  SERVER_KNOBS->DESIRED_TEAMS_PER_SERVER teams
+		// remainingTeamBudget is the number of teams needed to ensure every server has
+		// SERVER_KNOBS->DESIRED_TEAMS_PER_SERVER teams
 		int remainingTeamBudget = 0;
-		for ( auto& s : server_info ) {
+		for (auto& s : server_info) {
 			int numValidTeams = 0;
-			for ( auto& team : s.second->teams ) {
-				if ( !team->isWrongConfiguration() && team->isHealthy() ) {
+			for (auto& team : s.second->teams) {
+				if (!team->isWrongConfiguration() && team->isHealthy()) {
 					++numValidTeams;
 				}
 			}
-			remainingTeamBudget += std::max(0, (int) (SERVER_KNOBS->DESIRED_TEAMS_PER_SERVER - numValidTeams));
+			remainingTeamBudget += std::max(0, (int)(SERVER_KNOBS->DESIRED_TEAMS_PER_SERVER - numValidTeams));
 		}
 
 		return remainingTeamBudget;
 	}
-		
 
 	// Create server teams based on machine teams
 	// Before the number of machine teams reaches the threshold, build a machine team for each server team
@@ -1749,7 +1752,7 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 		    .detail("DesiredMachineTeams", desiredMachineTeams)
 		    .detail("MaxMachineTeams", maxMachineTeams)
 		    .detail("MachineTeamsToBuild", machineTeamsToBuild)
-			.detail("RemainingMachineTeamBudget", remainingMachineTeamBudget);
+		    .detail("RemainingMachineTeamBudget", remainingMachineTeamBudget);
 		// Pre-build all machine teams until we have the desired number of machine teams
 		if (machineTeamsToBuild > 0) {
 			addedMachineTeams = addBestMachineTeams(machineTeamsToBuild, remainingMachineTeamBudget);
@@ -1841,8 +1844,8 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 
 		healthyMachineTeamCount = getHealthyMachineTeamCount();
 
-		std::pair<int, int>  minMaxTeamNumberOnServer = calculateMinMaxServerTeamNumOnServer();
-		std::pair<int, int>  minMaxMachineTeamNumberOnMachine = calculateMinMaxMachineTeamNumOnMachine();
+		std::pair<int, int> minMaxTeamNumberOnServer = calculateMinMaxServerTeamNumOnServer();
+		std::pair<int, int> minMaxMachineTeamNumberOnMachine = calculateMinMaxMachineTeamNumOnMachine();
 
 		TraceEvent("TeamCollectionInfo", distributorId)
 		    .detail("Primary", primary)
@@ -1857,10 +1860,10 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 		    .detail("DesiredMachineTeams", desiredMachineTeams)
 		    .detail("MaxMachineTeams", maxMachineTeams)
 		    .detail("TotalHealthyMachine", totalHealthyMachineCount)
-			.detail("MinTeamNumberOnServer", minMaxTeamNumberOnServer.first)
-			.detail("MaxTeamNumberOnServer", minMaxTeamNumberOnServer.second)
-			.detail("MinMachineTeamNumberOnMachine", minMaxMachineTeamNumberOnMachine.first)
-			.detail("MaxMachineTeamNumberOnMachine", minMaxMachineTeamNumberOnMachine.second)
+		    .detail("MinTeamNumberOnServer", minMaxTeamNumberOnServer.first)
+		    .detail("MaxTeamNumberOnServer", minMaxTeamNumberOnServer.second)
+		    .detail("MinMachineTeamNumberOnMachine", minMaxMachineTeamNumberOnMachine.first)
+		    .detail("MaxMachineTeamNumberOnMachine", minMaxMachineTeamNumberOnMachine.second)
 		    .trackLatest("TeamCollectionInfo");
 
 		return addedTeams;
@@ -1877,8 +1880,8 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 		int maxMachineTeams = SERVER_KNOBS->MAX_TEAMS_PER_SERVER * totalHealthyMachineCount;
 		int healthyMachineTeamCount = getHealthyMachineTeamCount();
 
-		std::pair<int, int>  minMaxTeamNumberOnServer = calculateMinMaxServerTeamNumOnServer();
-		std::pair<int, int>  minMaxMachineTeamNumberOnMachine = calculateMinMaxMachineTeamNumOnMachine();
+		std::pair<int, int> minMaxTeamNumberOnServer = calculateMinMaxServerTeamNumOnServer();
+		std::pair<int, int> minMaxMachineTeamNumberOnMachine = calculateMinMaxMachineTeamNumOnMachine();
 
 		TraceEvent("TeamCollectionInfo", distributorId)
 		    .detail("Primary", primary)
@@ -1893,10 +1896,10 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 		    .detail("DesiredMachineTeams", desiredMachineTeams)
 		    .detail("MaxMachineTeams", maxMachineTeams)
 		    .detail("TotalHealthyMachine", totalHealthyMachineCount)
-			.detail("MinTeamNumberOnServer", minMaxTeamNumberOnServer.first)
-			.detail("MaxTeamNumberOnServer", minMaxTeamNumberOnServer.second)
-			.detail("MinMachineTeamNumberOnMachine", minMaxMachineTeamNumberOnMachine.first)
-			.detail("MaxMachineTeamNumberOnMachine", minMaxMachineTeamNumberOnMachine.second)
+		    .detail("MinTeamNumberOnServer", minMaxTeamNumberOnServer.first)
+		    .detail("MaxTeamNumberOnServer", minMaxTeamNumberOnServer.second)
+		    .detail("MinMachineTeamNumberOnMachine", minMaxMachineTeamNumberOnMachine.first)
+		    .detail("MaxMachineTeamNumberOnMachine", minMaxMachineTeamNumberOnMachine.second)
 		    .trackLatest("TeamCollectionInfo");
 
 		// Debug purpose
@@ -1953,7 +1956,8 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 				}
 			}
 			// Each server is expected to have SERVER_KNOBS->DESIRED_TEAMS_PER_SERVER,
-			// remainingTeamBudget is the number of teams needed to ensure every server has  SERVER_KNOBS->DESIRED_TEAMS_PER_SERVER teams
+			// remainingTeamBudget is the number of teams needed to ensure every server has
+			// SERVER_KNOBS->DESIRED_TEAMS_PER_SERVER teams
 			int remainingTeamBudget = self->getRemainingServerTeamBudget();
 
 			// teamsToBuild is calculated such that we will not build too many teams in the situation
@@ -1997,8 +2001,8 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 				int maxMachineTeams = SERVER_KNOBS->MAX_TEAMS_PER_SERVER * totalHealthyMachineCount;
 				int healthyMachineTeamCount = self->getHealthyMachineTeamCount();
 
-				std::pair<int, int>  minMaxTeamNumberOnServer = self->calculateMinMaxServerTeamNumOnServer();
-				std::pair<int, int>  minMaxMachineTeamNumberOnMachine = self->calculateMinMaxMachineTeamNumOnMachine();
+				std::pair<int, int> minMaxTeamNumberOnServer = self->calculateMinMaxServerTeamNumOnServer();
+				std::pair<int, int> minMaxMachineTeamNumberOnMachine = self->calculateMinMaxMachineTeamNumOnMachine();
 
 				TraceEvent("TeamCollectionInfo", self->distributorId)
 				    .detail("Primary", self->primary)
@@ -2013,10 +2017,10 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 				    .detail("DesiredMachineTeams", desiredMachineTeams)
 				    .detail("MaxMachineTeams", maxMachineTeams)
 				    .detail("TotalHealthyMachine", totalHealthyMachineCount)
-					.detail("MinTeamNumberOnServer", minMaxTeamNumberOnServer.first)
-					.detail("MaxTeamNumberOnServer", minMaxTeamNumberOnServer.second)
-					.detail("MinMachineTeamNumberOnMachine", minMaxMachineTeamNumberOnMachine.first)
-					.detail("MaxMachineTeamNumberOnMachine", minMaxMachineTeamNumberOnMachine.second)
+				    .detail("MinTeamNumberOnServer", minMaxTeamNumberOnServer.first)
+				    .detail("MaxTeamNumberOnServer", minMaxTeamNumberOnServer.second)
+				    .detail("MinMachineTeamNumberOnMachine", minMaxMachineTeamNumberOnMachine.first)
+				    .detail("MaxMachineTeamNumberOnMachine", minMaxMachineTeamNumberOnMachine.second)
 				    .trackLatest("TeamCollectionInfo");
 			}
 		}
@@ -3059,7 +3063,8 @@ ACTOR Future<Void> storageServerTracker(
 			if(hasWrongStoreTypeOrDC)
 				self->restartRecruiting.trigger();
 
-			if ( lastIsUnhealthy && !status.isUnhealthy() && server->teams.size() < SERVER_KNOBS->DESIRED_TEAMS_PER_SERVER ) {
+			if (lastIsUnhealthy && !status.isUnhealthy() &&
+			    server->teams.size() < SERVER_KNOBS->DESIRED_TEAMS_PER_SERVER) {
 				self->doBuildTeams = true;
 				self->restartTeamBuilder.trigger(); // This does not trigger building teams if there exist healthy teams
 			}

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -3190,7 +3190,7 @@ ACTOR Future<Void> storageServerTracker(
 							self->badTeamRemover = removeBadTeams(self);
 							self->addActor.send(self->badTeamRemover);
 							// The team number changes, so we need to update the team number info
-							self->traceTeamCollectionInfo();
+							//self->traceTeamCollectionInfo();
 						}
 					}
 
@@ -3458,7 +3458,6 @@ ACTOR Future<Void> dataDistributionTeamCollection(
 			self->redundantTeamRemover = teamRemover(self);
 			self->addActor.send(self->redundantTeamRemover);
 		}
-		self->traceTeamCollectionInfo();
 
 		if(self->includedDCs.size()) {
 			//start this actor before any potential recruitments can happen
@@ -3471,6 +3470,8 @@ ACTOR Future<Void> dataDistributionTeamCollection(
 		self->addActor.send(trackExcludedServers( self ));
 		self->addActor.send(monitorHealthyTeams( self ));
 		self->addActor.send(waitHealthyZoneChange( self ));
+
+		self->traceTeamCollectionInfo();
 
 		// SOMEDAY: Monitor FF/serverList for (new) servers that aren't in allServers and add or remove them
 

--- a/fdbserver/QuietDatabase.actor.cpp
+++ b/fdbserver/QuietDatabase.actor.cpp
@@ -289,11 +289,15 @@ ACTOR Future<bool> getTeamCollectionValid(Database cx, WorkerInterface dataDistr
 			int64_t healthyMachineTeamCount = boost::lexical_cast<int64_t>(teamCollectionInfoMessage.getValue("CurrentHealthyMachineTeamNumber"));
 			int64_t desiredMachineTeamNumber = boost::lexical_cast<int64_t>(teamCollectionInfoMessage.getValue("DesiredMachineTeams"));
 			int64_t maxMachineTeamNumber = boost::lexical_cast<int64_t>(teamCollectionInfoMessage.getValue("MaxMachineTeams"));
-			
-			int64_t minServerTeamOnServer = boost::lexical_cast<int64_t>(teamCollectionInfoMessage.getValue("MinTeamNumberOnServer"));
-			int64_t maxServerTeamOnServer = boost::lexical_cast<int64_t>(teamCollectionInfoMessage.getValue("MaxTeamNumberOnServer"));
-			int64_t minMachineTeamOnMachine = boost::lexical_cast<int64_t>(teamCollectionInfoMessage.getValue("MinMachineTeamNumberOnMachine"));
-			int64_t maxMachineTeamOnMachine = boost::lexical_cast<int64_t>(teamCollectionInfoMessage.getValue("MaxMachineTeamNumberOnMachine"));
+
+			int64_t minServerTeamOnServer =
+			    boost::lexical_cast<int64_t>(teamCollectionInfoMessage.getValue("MinTeamNumberOnServer"));
+			int64_t maxServerTeamOnServer =
+			    boost::lexical_cast<int64_t>(teamCollectionInfoMessage.getValue("MaxTeamNumberOnServer"));
+			int64_t minMachineTeamOnMachine =
+			    boost::lexical_cast<int64_t>(teamCollectionInfoMessage.getValue("MinMachineTeamNumberOnMachine"));
+			int64_t maxMachineTeamOnMachine =
+			    boost::lexical_cast<int64_t>(teamCollectionInfoMessage.getValue("MaxMachineTeamNumberOnMachine"));
 
 			// Team number is always valid when we disable teamRemover. This avoids false positive in simulation test
 			if (SERVER_KNOBS->TR_FLAG_DISABLE_TEAM_REMOVER) {
@@ -304,8 +308,7 @@ ACTOR Future<bool> getTeamCollectionValid(Database cx, WorkerInterface dataDistr
 
 			// The if condition should be consistent with the condition in teamRemover() that decides
 			// if redundant teams exist.
-			if (healthyMachineTeamCount > desiredMachineTeamNumber ||
-				minMachineTeamOnMachine <= 0 ) {
+			if (healthyMachineTeamCount > desiredMachineTeamNumber || minMachineTeamOnMachine <= 0) {
 				TraceEvent("GetTeamCollectionValid")
 				    .detail("CurrentTeamNumber", currentTeamNumber)
 				    .detail("DesiredTeamNumber", desiredTeamNumber)
@@ -314,12 +317,12 @@ ACTOR Future<bool> getTeamCollectionValid(Database cx, WorkerInterface dataDistr
 				    .detail("DesiredMachineTeams", desiredMachineTeamNumber)
 				    .detail("CurrentMachineTeamNumber", currentMachineTeamNumber)
 				    .detail("MaxMachineTeams", maxMachineTeamNumber)
-					.detail("MinTeamNumberOnServer", minServerTeamOnServer)
-					.detail("MaxTeamNumberOnServer", maxServerTeamOnServer)
-					.detail("MinMachineTeamNumberOnMachine", minMachineTeamOnMachine)
-					.detail("MaxMachineTeamNumberOnMachine", maxMachineTeamOnMachine)
-					.detail("DesiredTeamsPerServer", SERVER_KNOBS->DESIRED_TEAMS_PER_SERVER)
-					.detail("MaxTeamsPerServer", SERVER_KNOBS->MAX_TEAMS_PER_SERVER);
+				    .detail("MinTeamNumberOnServer", minServerTeamOnServer)
+				    .detail("MaxTeamNumberOnServer", maxServerTeamOnServer)
+				    .detail("MinMachineTeamNumberOnMachine", minMachineTeamOnMachine)
+				    .detail("MaxMachineTeamNumberOnMachine", maxMachineTeamOnMachine)
+				    .detail("DesiredTeamsPerServer", SERVER_KNOBS->DESIRED_TEAMS_PER_SERVER)
+				    .detail("MaxTeamsPerServer", SERVER_KNOBS->MAX_TEAMS_PER_SERVER);
 				return false;
 			} else {
 				return true;

--- a/fdbserver/QuietDatabase.actor.cpp
+++ b/fdbserver/QuietDatabase.actor.cpp
@@ -305,10 +305,10 @@ ACTOR Future<bool> getTeamCollectionValid(Database cx, WorkerInterface dataDistr
 			// The if condition should be consistent with the condition in teamRemover() that decides
 			// if redundant teams exist.
 			if (healthyMachineTeamCount > desiredMachineTeamNumber ||
-				minServerTeamOnServer < SERVER_KNOBS->DESIRED_TEAMS_PER_SERVER ||
-				minMachineTeamOnMachine < SERVER_KNOBS->DESIRED_TEAMS_PER_SERVER ||
-				maxServerTeamOnServer > SERVER_KNOBS->MAX_TEAMS_PER_SERVER ||
-				maxMachineTeamOnMachine > SERVER_KNOBS->MAX_TEAMS_PER_SERVER) {
+				minServerTeamOnServer <= 0 ||
+				minMachineTeamOnMachine <= 0 ||
+				( maxServerTeamOnServer > SERVER_KNOBS->DESIRED_TEAMS_PER_SERVER && minServerTeamOnServer < SERVER_KNOBS->DESIRED_TEAMS_PER_SERVER ) ||
+				( maxMachineTeamOnMachine > SERVER_KNOBS->DESIRED_TEAMS_PER_SERVER && minMachineTeamOnMachine < SERVER_KNOBS->DESIRED_TEAMS_PER_SERVER ) ) {
 				TraceEvent("GetTeamCollectionValid")
 				    .detail("CurrentTeamNumber", currentTeamNumber)
 				    .detail("DesiredTeamNumber", desiredTeamNumber)

--- a/fdbserver/QuietDatabase.actor.cpp
+++ b/fdbserver/QuietDatabase.actor.cpp
@@ -306,9 +306,7 @@ ACTOR Future<bool> getTeamCollectionValid(Database cx, WorkerInterface dataDistr
 			// if redundant teams exist.
 			if (healthyMachineTeamCount > desiredMachineTeamNumber ||
 				minServerTeamOnServer <= 0 ||
-				minMachineTeamOnMachine <= 0 ||
-				( maxServerTeamOnServer > SERVER_KNOBS->DESIRED_TEAMS_PER_SERVER && minServerTeamOnServer < SERVER_KNOBS->DESIRED_TEAMS_PER_SERVER ) ||
-				( maxMachineTeamOnMachine > SERVER_KNOBS->DESIRED_TEAMS_PER_SERVER && minMachineTeamOnMachine < SERVER_KNOBS->DESIRED_TEAMS_PER_SERVER ) ) {
+				minMachineTeamOnMachine <= 0 ) {
 				TraceEvent("GetTeamCollectionValid")
 				    .detail("CurrentTeamNumber", currentTeamNumber)
 				    .detail("DesiredTeamNumber", desiredTeamNumber)

--- a/fdbserver/QuietDatabase.actor.cpp
+++ b/fdbserver/QuietDatabase.actor.cpp
@@ -308,7 +308,7 @@ ACTOR Future<bool> getTeamCollectionValid(Database cx, WorkerInterface dataDistr
 
 			// The if condition should be consistent with the condition in teamRemover() that decides
 			// if redundant teams exist.
-			if (healthyMachineTeamCount > desiredMachineTeamNumber || minMachineTeamOnMachine <= 0) {
+			if (healthyMachineTeamCount > desiredMachineTeamNumber || minMachineTeamOnMachine <= 0 || minServerTeamOnServer <= 0 ) {
 				TraceEvent("GetTeamCollectionValid")
 				    .detail("CurrentTeamNumber", currentTeamNumber)
 				    .detail("DesiredTeamNumber", desiredTeamNumber)

--- a/fdbserver/QuietDatabase.actor.cpp
+++ b/fdbserver/QuietDatabase.actor.cpp
@@ -308,9 +308,10 @@ ACTOR Future<bool> getTeamCollectionValid(Database cx, WorkerInterface dataDistr
 
 			// The if condition should be consistent with the condition in teamRemover() that decides
 			// if redundant teams exist.
-			if (healthyMachineTeamCount > desiredMachineTeamNumber || (minMachineTeamOnMachine <= 0 && SERVER_KNOBS->DESIRED_TEAMS_PER_SERVER == 3)) {
-				// When DESIRED_TEAMS_PER_SERVER == 1, we see minMachineTeamOnMachine can be 0 in one out of 30k test cases.
-				// Only check DESIRED_TEAMS_PER_SERVER == 3 for now since it is mostly used configuration.
+			if (healthyMachineTeamCount > desiredMachineTeamNumber ||
+			    (minMachineTeamOnMachine <= 0 && SERVER_KNOBS->DESIRED_TEAMS_PER_SERVER == 3)) {
+				// When DESIRED_TEAMS_PER_SERVER == 1, we see minMachineTeamOnMachine can be 0 in one out of 30k test
+				// cases. Only check DESIRED_TEAMS_PER_SERVER == 3 for now since it is mostly used configuration.
 				TraceEvent("GetTeamCollectionValid")
 				    .detail("CurrentTeamNumber", currentTeamNumber)
 				    .detail("DesiredTeamNumber", desiredTeamNumber)

--- a/fdbserver/QuietDatabase.actor.cpp
+++ b/fdbserver/QuietDatabase.actor.cpp
@@ -323,7 +323,7 @@ ACTOR Future<bool> getTeamCollectionValid(Database cx, WorkerInterface dataDistr
 				    .detail("MaxMachineTeamNumberOnMachine", maxMachineTeamOnMachine)
 				    .detail("DesiredTeamsPerServer", SERVER_KNOBS->DESIRED_TEAMS_PER_SERVER)
 				    .detail("MaxTeamsPerServer", SERVER_KNOBS->MAX_TEAMS_PER_SERVER);
-				wait(delay(5.0));
+				return false;
 			} else {
 				return true;
 			}

--- a/fdbserver/QuietDatabase.actor.cpp
+++ b/fdbserver/QuietDatabase.actor.cpp
@@ -289,6 +289,11 @@ ACTOR Future<bool> getTeamCollectionValid(Database cx, WorkerInterface dataDistr
 			int64_t healthyMachineTeamCount = boost::lexical_cast<int64_t>(teamCollectionInfoMessage.getValue("CurrentHealthyMachineTeamNumber"));
 			int64_t desiredMachineTeamNumber = boost::lexical_cast<int64_t>(teamCollectionInfoMessage.getValue("DesiredMachineTeams"));
 			int64_t maxMachineTeamNumber = boost::lexical_cast<int64_t>(teamCollectionInfoMessage.getValue("MaxMachineTeams"));
+			
+			int64_t minServerTeamOnServer = boost::lexical_cast<int64_t>(teamCollectionInfoMessage.getValue("MinTeamNumberOnServer"));
+			int64_t maxServerTeamOnServer = boost::lexical_cast<int64_t>(teamCollectionInfoMessage.getValue("MaxTeamNumberOnServer"));
+			int64_t minMachineTeamOnMachine = boost::lexical_cast<int64_t>(teamCollectionInfoMessage.getValue("MinMachineTeamNumberOnMachine"));
+			int64_t maxMachineTeamOnMachine = boost::lexical_cast<int64_t>(teamCollectionInfoMessage.getValue("MaxMachineTeamNumberOnMachine"));
 
 			// Team number is always valid when we disable teamRemover. This avoids false positive in simulation test
 			if (SERVER_KNOBS->TR_FLAG_DISABLE_TEAM_REMOVER) {
@@ -299,7 +304,11 @@ ACTOR Future<bool> getTeamCollectionValid(Database cx, WorkerInterface dataDistr
 
 			// The if condition should be consistent with the condition in teamRemover() that decides
 			// if redundant teams exist.
-			if (healthyMachineTeamCount > desiredMachineTeamNumber) {
+			if (healthyMachineTeamCount > desiredMachineTeamNumber ||
+				minServerTeamOnServer < SERVER_KNOBS->DESIRED_TEAMS_PER_SERVER ||
+				minMachineTeamOnMachine < SERVER_KNOBS->DESIRED_TEAMS_PER_SERVER ||
+				maxServerTeamOnServer > SERVER_KNOBS->MAX_TEAMS_PER_SERVER ||
+				maxMachineTeamOnMachine > SERVER_KNOBS->MAX_TEAMS_PER_SERVER) {
 				TraceEvent("GetTeamCollectionValid")
 				    .detail("CurrentTeamNumber", currentTeamNumber)
 				    .detail("DesiredTeamNumber", desiredTeamNumber)
@@ -307,7 +316,13 @@ ACTOR Future<bool> getTeamCollectionValid(Database cx, WorkerInterface dataDistr
 				    .detail("CurrentHealthyMachineTeamNumber", healthyMachineTeamCount)
 				    .detail("DesiredMachineTeams", desiredMachineTeamNumber)
 				    .detail("CurrentMachineTeamNumber", currentMachineTeamNumber)
-				    .detail("MaxMachineTeams", maxMachineTeamNumber);
+				    .detail("MaxMachineTeams", maxMachineTeamNumber)
+					.detail("MinTeamNumberOnServer", minServerTeamOnServer)
+					.detail("MaxTeamNumberOnServer", maxServerTeamOnServer)
+					.detail("MinMachineTeamNumberOnMachine", minMachineTeamOnMachine)
+					.detail("MaxMachineTeamNumberOnMachine", maxMachineTeamOnMachine)
+					.detail("DesiredTeamsPerServer", SERVER_KNOBS->DESIRED_TEAMS_PER_SERVER)
+					.detail("MaxTeamsPerServer", SERVER_KNOBS->MAX_TEAMS_PER_SERVER);
 				return false;
 			} else {
 				return true;

--- a/fdbserver/QuietDatabase.actor.cpp
+++ b/fdbserver/QuietDatabase.actor.cpp
@@ -323,7 +323,7 @@ ACTOR Future<bool> getTeamCollectionValid(Database cx, WorkerInterface dataDistr
 				    .detail("MaxMachineTeamNumberOnMachine", maxMachineTeamOnMachine)
 				    .detail("DesiredTeamsPerServer", SERVER_KNOBS->DESIRED_TEAMS_PER_SERVER)
 				    .detail("MaxTeamsPerServer", SERVER_KNOBS->MAX_TEAMS_PER_SERVER);
-				return false;
+				wait(delay(10.0));
 			} else {
 				return true;
 			}

--- a/fdbserver/QuietDatabase.actor.cpp
+++ b/fdbserver/QuietDatabase.actor.cpp
@@ -323,7 +323,7 @@ ACTOR Future<bool> getTeamCollectionValid(Database cx, WorkerInterface dataDistr
 				    .detail("MaxMachineTeamNumberOnMachine", maxMachineTeamOnMachine)
 				    .detail("DesiredTeamsPerServer", SERVER_KNOBS->DESIRED_TEAMS_PER_SERVER)
 				    .detail("MaxTeamsPerServer", SERVER_KNOBS->MAX_TEAMS_PER_SERVER);
-				wait(delay(10.0));
+				wait(delay(5.0));
 			} else {
 				return true;
 			}

--- a/fdbserver/QuietDatabase.actor.cpp
+++ b/fdbserver/QuietDatabase.actor.cpp
@@ -308,7 +308,9 @@ ACTOR Future<bool> getTeamCollectionValid(Database cx, WorkerInterface dataDistr
 
 			// The if condition should be consistent with the condition in teamRemover() that decides
 			// if redundant teams exist.
-			if (healthyMachineTeamCount > desiredMachineTeamNumber || minMachineTeamOnMachine <= 0 ) {
+			if (healthyMachineTeamCount > desiredMachineTeamNumber || (minMachineTeamOnMachine <= 0 && SERVER_KNOBS->DESIRED_TEAMS_PER_SERVER == 3)) {
+				// When DESIRED_TEAMS_PER_SERVER == 1, we see minMachineTeamOnMachine can be 0 in one out of 30k test cases.
+				// Only check DESIRED_TEAMS_PER_SERVER == 3 for now since it is mostly used configuration.
 				TraceEvent("GetTeamCollectionValid")
 				    .detail("CurrentTeamNumber", currentTeamNumber)
 				    .detail("DesiredTeamNumber", desiredTeamNumber)

--- a/fdbserver/QuietDatabase.actor.cpp
+++ b/fdbserver/QuietDatabase.actor.cpp
@@ -305,7 +305,6 @@ ACTOR Future<bool> getTeamCollectionValid(Database cx, WorkerInterface dataDistr
 			// The if condition should be consistent with the condition in teamRemover() that decides
 			// if redundant teams exist.
 			if (healthyMachineTeamCount > desiredMachineTeamNumber ||
-				minServerTeamOnServer <= 0 ||
 				minMachineTeamOnMachine <= 0 ) {
 				TraceEvent("GetTeamCollectionValid")
 				    .detail("CurrentTeamNumber", currentTeamNumber)

--- a/fdbserver/QuietDatabase.actor.cpp
+++ b/fdbserver/QuietDatabase.actor.cpp
@@ -308,7 +308,7 @@ ACTOR Future<bool> getTeamCollectionValid(Database cx, WorkerInterface dataDistr
 
 			// The if condition should be consistent with the condition in teamRemover() that decides
 			// if redundant teams exist.
-			if (healthyMachineTeamCount > desiredMachineTeamNumber || minMachineTeamOnMachine <= 0 || minServerTeamOnServer <= 0 ) {
+			if (healthyMachineTeamCount > desiredMachineTeamNumber || minMachineTeamOnMachine <= 0 ) {
 				TraceEvent("GetTeamCollectionValid")
 				    .detail("CurrentTeamNumber", currentTeamNumber)
 				    .detail("DesiredTeamNumber", desiredTeamNumber)


### PR DESCRIPTION
This PR solves issue #1754.

When team collection computes the number of servers (and machine) teams, it also considers the number of teams each server (and team) needs to reach the DESIRED_TEAMS_PER_SERVER.

When new machine is added to the cluster, no matter how many machine teams the cluster already has, the new logic will re-kick the logic of building teams.

Simulation test is ongoing...