### PR TITLE
Flatbuffers part2

### DIFF
--- a/fdbcli/fdbcli.actor.cpp
+++ b/fdbcli/fdbcli.actor.cpp
@@ -3522,6 +3522,8 @@ int main(int argc, char **argv) {
 		}
 		setNetworkOption(FDBNetworkOptions::ENABLE_SLOW_TASK_PROFILING);
 	}
+	// The USE_OBJECT_SERIALIZER network option expects an 8 byte little endian integer which is interpreted as zero =
+	// false, non-zero = true.
 	setNetworkOption(FDBNetworkOptions::USE_OBJECT_SERIALIZER,
 	                 opt.useObjectSerializer ? LiteralStringRef("\x01\x00\x00\x00\x00\x00\x00\x00")
 	                                         : LiteralStringRef("\x00\x00\x00\x00\x00\x00\x00\x00"));

--- a/fdbrpc/ReplicationPolicy.h
+++ b/fdbrpc/ReplicationPolicy.h
@@ -317,4 +317,6 @@ struct dynamic_size_traits<Reference<IReplicationPolicy>> : std::true_type {
 	}
 };
 
+static_assert(detail::has_serialization_done<dynamic_size_traits<Reference<IReplicationPolicy>>>::value);
+
 #endif

--- a/fdbrpc/ReplicationPolicy.h
+++ b/fdbrpc/ReplicationPolicy.h
@@ -292,8 +292,8 @@ struct dynamic_size_traits<Reference<IReplicationPolicy>> : std::true_type {
 			                  writer.getLength());
 		}
 		if (!value->alreadyWritten) {
-			value->alreadyWritten = true;
 			serializeReplicationPolicy(value->writer, const_cast<Reference<IReplicationPolicy>&>(value));
+			value->alreadyWritten = true;
 		}
 		return unownedPtr(const_cast<const uint8_t*>(reinterpret_cast<uint8_t*>(value->writer.getData())),
 		                  value->writer.getLength());

--- a/fdbrpc/ReplicationPolicy.h
+++ b/fdbrpc/ReplicationPolicy.h
@@ -70,6 +70,13 @@ struct IReplicationPolicy : public ReferenceCounted<IReplicationPolicy> {
 		return keys;
 	}
 	virtual void attributeKeys(std::set<std::string>*) const = 0;
+
+	// For flatbuffers, IReplicationPolicy is just encoded as a string using
+	// |serializeReplicationPolicy|. |writer| is a member of IReplicationPolicy
+	// so that this string outlives all calls to
+	// dynamic_size_traits<Reference<IReplicationPolicy>>::save
+	mutable BinaryWriter writer{ IncludeVersion() };
+	mutable bool alreadyWritten = false;
 };
 
 template <class Archive>
@@ -276,12 +283,28 @@ void serializeReplicationPolicy(Ar& ar, Reference<IReplicationPolicy>& policy) {
 
 template <>
 struct dynamic_size_traits<Reference<IReplicationPolicy>> : std::true_type {
-	static WriteRawMemory save(const Reference<IReplicationPolicy>& value) {
-		BinaryWriter writer(IncludeVersion());
-		serializeReplicationPolicy(writer, const_cast<Reference<IReplicationPolicy>&>(value));
-		std::unique_ptr<uint8_t[]> memory(new uint8_t[writer.getLength()]);
-		memcpy(memory.get(), writer.getData(), writer.getLength());
-		return std::make_pair<OwnershipErasedPtr<const uint8_t>, size_t>(ownedPtr(const_cast<const uint8_t*>(memory.release())), writer.getLength());
+	static Block save(const Reference<IReplicationPolicy>& value) {
+		if (value.getPtr() == nullptr) {
+			static BinaryWriter writer{ IncludeVersion() };
+			writer = BinaryWriter{ IncludeVersion() };
+			serializeReplicationPolicy(writer, const_cast<Reference<IReplicationPolicy>&>(value));
+			return unownedPtr(const_cast<const uint8_t*>(reinterpret_cast<uint8_t*>(writer.getData())),
+			                  writer.getLength());
+		}
+		if (!value->alreadyWritten) {
+			value->alreadyWritten = true;
+			serializeReplicationPolicy(value->writer, const_cast<Reference<IReplicationPolicy>&>(value));
+		}
+		return unownedPtr(const_cast<const uint8_t*>(reinterpret_cast<uint8_t*>(value->writer.getData())),
+		                  value->writer.getLength());
+	}
+
+	static void serialization_done(const Reference<IReplicationPolicy>& value) {
+		if (value.getPtr() == nullptr) {
+			return;
+		}
+		value->alreadyWritten = false;
+		value->writer = BinaryWriter{ IncludeVersion() };
 	}
 
 	// Context is an arbitrary type that is plumbed by reference throughout the
@@ -293,6 +316,5 @@ struct dynamic_size_traits<Reference<IReplicationPolicy>> : std::true_type {
 		serializeReplicationPolicy(reader, value);
 	}
 };
-
 
 #endif

--- a/fdbrpc/fdbrpc.h
+++ b/fdbrpc/fdbrpc.h
@@ -425,7 +425,10 @@ struct serializable_traits<RequestStream<T>> : std::true_type {
 		} else {
 			const auto& ep = stream.getEndpoint();
 			serializer(ar, ep);
-			UNSTOPPABLE_ASSERT(ep.getPrimaryAddress().isValid());  // No serializing PromiseStreams on a client with no public address
+			if constexpr (Archiver::isSerializing) { // Don't assert this when collecting vtable for flatbuffers
+				UNSTOPPABLE_ASSERT(ep.getPrimaryAddress()
+				                       .isValid()); // No serializing PromiseStreams on a client with no public address
+			}
 		}
 	}
 };

--- a/flow/Arena.h
+++ b/flow/Arena.h
@@ -767,7 +767,7 @@ inline void save( Archive& ar, const StringRef& value ) {
 
 template<>
 struct dynamic_size_traits<StringRef> : std::true_type {
-	static WriteRawMemory save(const StringRef& str) { return { { unownedPtr(str.begin()), str.size() } }; }
+	static Block save(const StringRef& str) { return unownedPtr(str.begin(), str.size()); }
 
 	template <class Context>
 	static void load(const uint8_t* ptr, size_t sz, StringRef& str, Context& context) {

--- a/flow/flat_buffers.cpp
+++ b/flow/flat_buffers.cpp
@@ -34,17 +34,16 @@ bool TraverseMessageTypes::vtableGeneratedBefore(const std::type_index& idx) {
 	return !f.known_types.insert(idx).second;
 }
 
-VTable generate_vtable(size_t numMembers, const std::vector<unsigned>& members,
-                       const std::vector<unsigned>& alignments) {
+VTable generate_vtable(size_t numMembers, const std::vector<unsigned>& sizesAlignments) {
 	if (numMembers == 0) {
 		return VTable{ 4, 4 };
 	}
 	// first is index, second is size
 	std::vector<std::pair<unsigned, unsigned>> indexed;
-	indexed.reserve(members.size());
-	for (unsigned i = 0; i < members.size(); ++i) {
-		if (members[i] > 0) {
-			indexed.emplace_back(i, members[i]);
+	indexed.reserve(numMembers);
+	for (unsigned i = 0; i < numMembers; ++i) {
+		if (sizesAlignments[i] > 0) {
+			indexed.emplace_back(i, sizesAlignments[i]);
 		}
 	}
 	std::stable_sort(indexed.begin(), indexed.end(),
@@ -52,15 +51,15 @@ VTable generate_vtable(size_t numMembers, const std::vector<unsigned>& members,
 		                 return lhs.second > rhs.second;
 	                 });
 	VTable result;
-	result.resize(members.size() + 2);
+	result.resize(numMembers + 2);
 	// size of the vtable is
 	// - 2 bytes per member +
 	// - 2 bytes for the size entry +
 	// - 2 bytes for the size of the object
-	result[0] = 2 * members.size() + 4;
+	result[0] = 2 * numMembers + 4;
 	int offset = 0;
 	for (auto p : indexed) {
-		auto align = alignments[p.first];
+		auto align = sizesAlignments[numMembers + p.first];
 		auto& res = result[p.first + 2];
 		res = offset % align == 0 ? offset : ((offset / align) + 1) * align;
 		offset = res + p.second;
@@ -78,8 +77,10 @@ TEST_CASE("flow/FlatBuffers/test") {
 	auto* vtable1 = detail::get_vtable<int>();
 	auto* vtable2 = detail::get_vtable<uint8_t, uint8_t, int, int64_t, int>();
 	auto* vtable3 = detail::get_vtable<uint8_t, uint8_t, int, int64_t, int>();
+	auto* vtable4 = detail::get_vtable<uint32_t>();
 	ASSERT(vtable1 != vtable2);
 	ASSERT(vtable2 == vtable3);
+	ASSERT(vtable1 == vtable4); // Different types, but same vtable! Saves space in encoded messages
 	ASSERT(vtable1->size() == 3);
 	ASSERT(vtable2->size() == 7);
 	ASSERT((*vtable2)[0] == 14);
@@ -166,7 +167,6 @@ TEST_CASE("flow/FlatBuffers/collectVTables") {
 	Root root;
 	const auto* vtables = detail::get_vtableset(root);
 	ASSERT(vtables == detail::get_vtableset(root));
-	ASSERT(vtables->offsets.size() == 3);
 	const auto& root_vtable = *detail::get_vtable<uint8_t, std::vector<Nested2>, Nested>();
 	const auto& nested_vtable = *detail::get_vtable<uint8_t, std::vector<std::string>, int>();
 	int root_offset = vtables->offsets.at(&root_vtable);

--- a/flow/flat_buffers.h
+++ b/flow/flat_buffers.h
@@ -542,6 +542,7 @@ private:
 
 struct InsertVTableLambda {
 	static constexpr bool isDeserializing = false;
+	static constexpr bool isSerializing = false;
 	static constexpr bool is_fb_visitor = true;
 	std::set<const VTable*>& vtables;
 	std::set<std::type_index>& known_types;
@@ -665,6 +666,7 @@ private:
 template <class Writer>
 struct SaveVisitorLambda {
 	static constexpr bool isDeserializing = false;
+	static constexpr bool isSerializing = true;
 	static constexpr bool is_fb_visitor = true;
 	const VTableSet* vtableset;
 	Writer& writer;
@@ -738,6 +740,7 @@ struct SaveVisitorLambda {
 template <class Context>
 struct LoadMember {
 	static constexpr bool isDeserializing = true;
+	static constexpr bool isSerializing = false;
 	const uint16_t* const vtable;
 	const uint8_t* const message;
 	const uint16_t vtable_length;
@@ -852,6 +855,7 @@ struct LoadSaveHelper {
 	template <class Context>
 	struct SerializeFun {
 		static constexpr bool isDeserializing = true;
+		static constexpr bool isSerializing = false;
 		static constexpr bool is_fb_visitor = true;
 
 		const uint16_t* vtable;

--- a/flow/flat_buffers.h
+++ b/flow/flat_buffers.h
@@ -236,6 +236,8 @@ auto test_serialization_done(int) -> sfinae_true<decltype(T::serialization_done)
 template <class T>
 auto test_serialization_done(long) -> std::false_type;
 
+// int is a better match for 0 than long. If substituting T::serialization_done succeeds the true_type overload is
+// selected.
 template <class T>
 struct has_serialization_done : decltype(test_serialization_done<T>(0)) {};
 

--- a/flow/serialize.h
+++ b/flow/serialize.h
@@ -317,6 +317,7 @@ inline _Unversioned Unversioned() { return _Unversioned(); }
 class BinaryWriter : NonCopyable {
 public:
 	static const int isDeserializing = 0;
+	static constexpr bool isSerializing = true;
 	typedef BinaryWriter WRITER;
 
 	void serializeBytes( StringRef bytes ) {
@@ -518,6 +519,7 @@ private:
 class ArenaReader {
 public:
 	static const int isDeserializing = 1;
+	static constexpr bool isSerializing = false;
 	typedef ArenaReader READER;
 
 	const void* readBytes( int bytes ) {
@@ -583,6 +585,7 @@ private:
 class BinaryReader {
 public:
 	static const int isDeserializing = 1;
+	static constexpr bool isSerializing = false;
 	typedef BinaryReader READER;
 
 	const void* readBytes( int bytes );
@@ -682,6 +685,7 @@ struct PacketBuffer : SendBuffer, FastAllocated<PacketBuffer> {
 
 struct PacketWriter {
 	static const int isDeserializing = 0;
+	static constexpr bool isSerializing = 1;
 	typedef PacketWriter WRITER;
 
 	PacketBuffer* buffer;

--- a/flow/serialize.h
+++ b/flow/serialize.h
@@ -685,7 +685,7 @@ struct PacketBuffer : SendBuffer, FastAllocated<PacketBuffer> {
 
 struct PacketWriter {
 	static const int isDeserializing = 0;
-	static constexpr bool isSerializing = 1;
+	static constexpr bool isSerializing = true;
 	typedef PacketWriter WRITER;
 
 	PacketBuffer* buffer;


### PR DESCRIPTION
This is part of #1676 . 

This PR introduces the `--object-serializer` flag to fdbcli for testing purposes, and the plan is to remove all occurrences of `--object-serializer`, when making it the default setting.

CC @mpilman