### PR TITLE
Memory storage engine to use crc32c DiskQueue by default (in 6.2).

### DIFF
--- a/fdbserver/KeyValueStoreMemory.actor.cpp
+++ b/fdbserver/KeyValueStoreMemory.actor.cpp
@@ -715,7 +715,7 @@ KeyValueStoreMemory::KeyValueStoreMemory( IDiskQueue* log, UID id, int64_t memor
 
 IKeyValueStore* keyValueStoreMemory( std::string const& basename, UID logID, int64_t memoryLimit, std::string ext ) {
 	TraceEvent("KVSMemOpening", logID).detail("Basename", basename).detail("MemoryLimit", memoryLimit);
-	IDiskQueue *log = openDiskQueue( basename, ext, logID, DiskQueueVersion::V0 );
+	IDiskQueue *log = openDiskQueue( basename, ext, logID, DiskQueueVersion::V1 );
 	return new KeyValueStoreMemory( log, logID, memoryLimit, false, false, false );
 }
 


### PR DESCRIPTION
This should result in some speedup.  I haven't measured how much for memory storage engine, but CPU usage should decrease at least.