### PR TITLE
StorageServerTracker:Do not always set doBuildTeams

### DIFF
--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -3187,7 +3187,6 @@ ACTOR Future<Void> storageServerTracker(
 					//Restart the storeTracker for the new interface
 					storeTracker = keyValueStoreTypeTracker(self, server);
 					hasWrongStoreTypeOrDC = false;
-					self->doBuildTeams = true;
 					self->restartTeamBuilder.trigger();
 
 					if(restartRecruiting)


### PR DESCRIPTION
When interface changes, we set doBuildTeams to true only when
the interface location changes.