### PR TITLE
Choose LogRouter tag to match an existing tag to save a copy.

### DIFF
--- a/fdbserver/LogSystem.h
+++ b/fdbserver/LogSystem.h
@@ -704,6 +704,8 @@ struct ILogSystem {
 
 	virtual bool hasRemoteLogs() = 0;
 
+	virtual int getLogRouterTags() = 0;
+
 	virtual Tag getRandomRouterTag() = 0;
 
 	virtual void stopRejoins() = 0;
@@ -766,11 +768,15 @@ struct LogPushData : NonCopyable {
 	void addMessage( StringRef rawMessageWithoutLength, bool usePreviousLocations = false ) {
 		if( !usePreviousLocations ) {
 			prev_tags.clear();
-			if(logSystem->hasRemoteLogs()) {
-				prev_tags.push_back( logSystem->getRandomRouterTag() );
-			}
 			for(auto& tag : next_message_tags) {
 				prev_tags.push_back(tag);
+			}
+			if(logSystem->hasRemoteLogs()) {
+				int primaryLogs = logSystem->getLogSystemConfig().tLogs[0].tLogs.size();
+				int logRouterTags = logSystem->getLogRouterTags();
+				int nWays = logRouterTags / primaryLogs;
+				int newId = (deterministicRandom()->randomChoice(prev_tags).id % primaryLogs) * deterministicRandom()->randomInt(1, nWays+1);
+				prev_tags.push_back( Tag(tagLocalityLogRouter, newId) );
 			}
 			msg_locations.clear();
 			logSystem->getPushLocations( prev_tags, msg_locations );
@@ -788,11 +794,15 @@ struct LogPushData : NonCopyable {
 	template <class T>
 	void addTypedMessage(T const& item, bool allLocations = false) {
 		prev_tags.clear();
-		if(logSystem->hasRemoteLogs()) {
-			prev_tags.push_back( logSystem->getRandomRouterTag() );
-		}
 		for(auto& tag : next_message_tags) {
 			prev_tags.push_back(tag);
+		}
+		if(logSystem->hasRemoteLogs()) {
+			int primaryLogs = logSystem->getLogSystemConfig().tLogs[0].tLogs.size();
+			int logRouterTags = logSystem->getLogRouterTags();
+			int nWays = logRouterTags / primaryLogs;
+			int newId = (deterministicRandom()->randomChoice(prev_tags).id % primaryLogs) * deterministicRandom()->randomInt(1, nWays+1);
+			prev_tags.push_back( Tag(tagLocalityLogRouter, newId) );
 		}
 		msg_locations.clear();
 		logSystem->getPushLocations(prev_tags, msg_locations, allLocations);

--- a/fdbserver/TagPartitionedLogSystem.actor.cpp
+++ b/fdbserver/TagPartitionedLogSystem.actor.cpp
@@ -1122,6 +1122,10 @@ struct TagPartitionedLogSystem : ILogSystem, ReferenceCounted<TagPartitionedLogS
 		return logRouterTags > 0 || pseudoLocalities.size() > 0;
 	}
 
+	virtual int getLogRouterTags() {
+		return logRouterTags;
+	}
+
 	virtual Tag getRandomRouterTag() {
 		return Tag(tagLocalityLogRouter, deterministicRandom()->randomInt(0, logRouterTags));
 	}


### PR DESCRIPTION
Let us suppose we have:
* five TLogs in the primary
* five log routers
* a mutation with tags {1,2,3}

Every tag has a preferred location (that is the id `mod` number of
logs).  For every tag on a mutation, the mutation *must* be stored at
the preferred location for that tag.

Previously, we would choose log router tags randomly, to ensure an even
distribution of mutations over log routers.  Suppose we happen to choose
-2:4 as the log router tag.  We already need to send the mutation to
TLogs 1, 2, and 3.  -2:4 has a preferred location of TLog 4, so now we
need to send out a fourth copy.

This commit changes the assignment to only choose from log router tags
that match an existing place where the mutation would already need to be
stored, to avoid the situation where a fourth copy would need to be
sent.  Within this example, we would only randomly choose over the
restricted subset of {-2:1, -2:2, -2:3} as the log router tags.

This potentially has the downside of being less efficient if one runs
one log router per primary TLog.  However, this is not generally the
recommended deployment, and Log Routers are stateless roles, which makes
running many of them very cheap and easy to do.