### PR TITLE
Add a checkOnly parameter to Cycle workload.

### DIFF
--- a/fdbserver/workloads/Cycle.actor.cpp
+++ b/fdbserver/workloads/Cycle.actor.cpp
@@ -28,6 +28,7 @@ struct CycleWorkload : TestWorkload {
 	int actorCount, nodeCount;
 	double testDuration, transactionsPerSecond, minExpectedTransactionsPerSecond;
 	Key		keyPrefix;
+	bool checkOnly;
 
 	vector<Future<Void>> clients;
 	PerfIntCounter transactions, retries, tooOldRetries, commitFailedRetries;
@@ -44,6 +45,7 @@ struct CycleWorkload : TestWorkload {
 		nodeCount = getOption(options, LiteralStringRef("nodeCount"), transactionsPerSecond * clientCount);
 		keyPrefix = getOption(options, LiteralStringRef("keyPrefix"), LiteralStringRef(""));
 		minExpectedTransactionsPerSecond = transactionsPerSecond * getOption(options, LiteralStringRef("expectedRate"), 0.7);
+		checkOnly = getOption(options, LiteralStringRef("checkOnly"), false);
 	}
 
 	virtual std::string description() { return "CycleWorkload"; }
@@ -51,6 +53,7 @@ struct CycleWorkload : TestWorkload {
 		return bulkSetup( cx, this, nodeCount, Promise<double>() );
 	}
 	virtual Future<Void> start( Database const& cx ) {
+		if (checkOnly) return Void();
 		for(int c=0; c<actorCount; c++)
 			clients.push_back(
 				timeout(


### PR DESCRIPTION
So that it can be used in the real world for consistency checking of backup and DR.

See https://forums.foundationdb.org/t/test-backup-and-restore-on-fdb-6-1-8-cluster/1504