### PR TITLE
Make trace files lexicographically ordered

### DIFF
--- a/documentation/sphinx/source/release-notes.rst
+++ b/documentation/sphinx/source/release-notes.rst
@@ -37,6 +37,8 @@ Bindings
 Other Changes
 -------------
 
+* Trace files are now ordered lexicographically ``(PR #1828) <https://github.com/apple/foundationdb/pull/1828>``. This means that the filename format for traces did change.
+
 Earlier release notes
 ---------------------
 * :doc:`6.1 (API Version 610) </old-release-notes/release-notes-610>`

--- a/flow/FileTraceLogWriter.cpp
+++ b/flow/FileTraceLogWriter.cpp
@@ -87,7 +87,18 @@ void FileTraceLogWriter::write(const std::string& str) {
 void FileTraceLogWriter::open() {
 	cleanupTraceFiles();
 
-	auto finalname = format("%s.%d.%s", basename.c_str(), ++index, extension.c_str());
+	++index;
+	int indexWidth = -1;
+	while (index > 0) {
+		index /= 10;
+		++indexWidth;
+	}
+
+	// this allows one process to write 10 billion log files
+	// this should be enough - if not we could make the base larger...
+	ASSERT(index >= 0 && index < 10);
+
+	auto finalname = format("%s.%d.%d.%s", basename.c_str(), indexWidth, ++index, extension.c_str());
 	while ( (traceFileFD = __open( finalname.c_str(), TRACEFILE_FLAGS, TRACEFILE_MODE )) == -1 ) {
 		lastError(errno);
 		if (errno == EEXIST)

--- a/flow/FileTraceLogWriter.cpp
+++ b/flow/FileTraceLogWriter.cpp
@@ -107,7 +107,7 @@ void FileTraceLogWriter::open() {
 			indexWidth = unsigned(::floor(log10f(float(index))));
 
 			UNSTOPPABLE_ASSERT(indexWidth < 10);
-			finalname = format("%s.%c.%d.%s", basename.c_str(), indexWidth, index, extension.c_str());
+			finalname = format("%s.%d.%d.%s", basename.c_str(), indexWidth, index, extension.c_str());
 		}
 		else {
 			fprintf(stderr, "ERROR: could not create trace log file `%s' (%d: %s)\n", finalname.c_str(), errno, strerror(errno));

--- a/flow/FileTraceLogWriter.h
+++ b/flow/FileTraceLogWriter.h
@@ -56,8 +56,6 @@ public:
 	void sync();
 
 	static void extractTraceFileNameInfo(std::string const& filename, std::string &root, int &index);
-	static bool compareTraceFileName (std::string const& f1, std::string const& f2);
-	static bool reverseCompareTraceFileName(std::string f1, std::string f2);
 
 	void cleanupTraceFiles();
 };

--- a/flow/FileTraceLogWriter.h
+++ b/flow/FileTraceLogWriter.h
@@ -37,7 +37,7 @@ private:
 
 	uint64_t maxLogsSize;
 	int traceFileFD;
-	unsigned index;
+	uint32_t index;
 
 	std::function<void()> onError;
 
@@ -54,8 +54,6 @@ public:
 	void close();
 	void roll();
 	void sync();
-
-	static void extractTraceFileNameInfo(std::string const& filename, std::string &root, int &index);
 
 	void cleanupTraceFiles();
 };

--- a/flow/FileTraceLogWriter.h
+++ b/flow/FileTraceLogWriter.h
@@ -37,7 +37,7 @@ private:
 
 	uint64_t maxLogsSize;
 	int traceFileFD;
-	int index;
+	unsigned index;
 
 	std::function<void()> onError;
 


### PR DESCRIPTION
This resolves #1825

The basic idea is that we prefix every sequence number with its with,
separated by a dot. That way the filename length isn't increased
drastically (unlike using a fixed whidth number with 0-padding)
and the file names will be lexicographically ordered.

The main motivation for this case is to make it easier to investigate issues
in traces through the command-line. Without this change a command like this:

```
grep ProcessMetrics *.xml | tail -1
```

won't necessary work as one would expect as the last trace-file in the list might not be the newest one.