### PR TITLE
Make takeMoveKeysLock() update move key owner lock

### DIFF
--- a/fdbserver/MoveKeys.actor.cpp
+++ b/fdbserver/MoveKeys.actor.cpp
@@ -28,7 +28,7 @@
 using std::min;
 using std::max;
 
-ACTOR Future<MoveKeysLock> takeMoveKeysLock( Database cx, UID masterId ) {
+ACTOR Future<MoveKeysLock> takeMoveKeysLock(Database cx, UID ddId) {
 	state Transaction tr(cx);
 	loop {
 		try {
@@ -36,7 +36,7 @@ ACTOR Future<MoveKeysLock> takeMoveKeysLock( Database cx, UID masterId ) {
 			tr.setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
 			if( !g_network->isSimulated() ) {
 				UID id(deterministicRandom()->randomUniqueID());
-				TraceEvent("TakeMoveKeysLockTransaction", masterId)
+				TraceEvent("TakeMoveKeysLockTransaction", ddId)
 					.detail("TransactionUID", id);
 				tr.debugTransaction( id );
 			}
@@ -49,6 +49,8 @@ ACTOR Future<MoveKeysLock> takeMoveKeysLock( Database cx, UID masterId ) {
 				lock.prevWrite = readVal.present() ? BinaryReader::fromStringRef<UID>(readVal.get(), Unversioned()) : UID();
 			}
 			lock.myOwner = deterministicRandom()->randomUniqueID();
+			tr.set(moveKeysLockOwnerKey, BinaryWriter::toValue(lock.myOwner, Unversioned()));
+			wait(tr.commit());
 			return lock;
 		} catch (Error &e){
 			wait(tr.onError(e));

--- a/fdbserver/MoveKeys.actor.h
+++ b/fdbserver/MoveKeys.actor.h
@@ -37,15 +37,14 @@ struct MoveKeysLock {
 	void serialize(Ar& ar) { serializer(ar, prevOwner, myOwner, prevWrite); }
 };
 
-ACTOR Future<MoveKeysLock> takeMoveKeysLock(Database cx, UID masterId);
 // Calling moveKeys, etc with the return value of this actor ensures that no movekeys, etc
-// has been executed by a different locker since takeMoveKeysLock().
-// takeMoveKeysLock itself is a read-only operation - it does not conflict with other
-// attempts to take the lock.
+// has been executed by a different locker since takeMoveKeysLock(), as calling
+// takeMoveKeysLock() updates "moveKeysLockOwnerKey" to a random UID.
+ACTOR Future<MoveKeysLock> takeMoveKeysLock(Database cx, UID ddId);
 
-Future<Void> checkMoveKeysLockReadOnly( Transaction* tr, MoveKeysLock lock );
 // Checks that the a moveKeysLock has not changed since having taken it
 // This does not modify the moveKeysLock
+Future<Void> checkMoveKeysLockReadOnly(Transaction* tr, MoveKeysLock lock);
 
 void seedShardServers(
 	Arena& trArena,


### PR DESCRIPTION
This allows a new data distributor to update the owner lock so that older
data distributor can't hang on to the lock. This fixes #1821