### PR TITLE
Make sharded txsTag upgradeable and downgradeable

### DIFF
--- a/fdbserver/LogSystem.h
+++ b/fdbserver/LogSystem.h
@@ -712,6 +712,10 @@ struct ILogSystem {
 
 	virtual Tag getRandomTxsTag() const = 0;
 
+	// Returns the TLogVersion of the current generation of TLogs.
+	// (This only exists because getLogSystemConfig is a significantly more expensive call.)
+	virtual TLogVersion getTLogVersion() const = 0;
+
 	virtual void stopRejoins() = 0;
 
 	// Returns the pseudo tag to be popped for the given process class. If the
@@ -760,7 +764,11 @@ struct LogPushData : NonCopyable {
 	}
 
 	void addTxsTag() {
-		next_message_tags.push_back( logSystem->getRandomTxsTag() );
+		if ( logSystem->getTLogVersion() >= TLogVersion::V4 ) {
+			next_message_tags.push_back( logSystem->getRandomTxsTag() );
+		} else {
+			next_message_tags.push_back( txsTag );
+		}
 	}
 
 	// addTag() adds a tag for the *next* message to be added

--- a/fdbserver/LogSystem.h
+++ b/fdbserver/LogSystem.h
@@ -706,11 +706,11 @@ struct ILogSystem {
 
 	virtual void getPushLocations(std::vector<Tag> const& tags, std::vector<int>& locations, bool allLocations = false) = 0;
 
-	virtual bool hasRemoteLogs() = 0;
+	virtual bool hasRemoteLogs() const = 0;
 
-	virtual Tag getRandomRouterTag() = 0;
+	virtual Tag getRandomRouterTag() const = 0;
 
-	virtual Tag getRandomTxsTag() = 0;
+	virtual Tag getRandomTxsTag() const = 0;
 
 	virtual void stopRejoins() = 0;
 

--- a/fdbserver/OldTLogServer_6_0.actor.cpp
+++ b/fdbserver/OldTLogServer_6_0.actor.cpp
@@ -831,7 +831,11 @@ void commitMessages( TLogData* self, Reference<LogData> logData, Version version
 				tag.id = tag.id % logData->logRouterTags;
 			}
 			if(tag.locality == tagLocalityTxs) {
-				tag.id = tag.id % logData->txsTags;
+				if (logData->txsTags > 0) {
+					tag.id = tag.id % logData->txsTags;
+				} else {
+					tag = txsTag;
+				}
 			}
 			Reference<LogData::TagData> tagData = logData->getTagData(tag);
 			if(!tagData) {

--- a/fdbserver/TLogServer.actor.cpp
+++ b/fdbserver/TLogServer.actor.cpp
@@ -1081,7 +1081,13 @@ void commitMessages( TLogData* self, Reference<LogData> logData, Version version
 				tag.id = tag.id % logData->logRouterTags;
 			}
 			if(tag.locality == tagLocalityTxs) {
-				tag.id = tag.id % logData->txsTags;
+				// TODO: When TLogVersion is threaded into the TLog, this should be replaced with a >V4 check,
+				// as txsTag is improperly correspondingly overridden in TLog recruitment requests.
+				if (logData->txsTags > 0) {
+					tag.id = tag.id % logData->txsTags;
+				} else {
+					tag = txsTag;
+				}
 			}
 			Reference<LogData::TagData> tagData = logData->getTagData(tag);
 			if(!tagData) {

--- a/fdbserver/TLogServer.actor.cpp
+++ b/fdbserver/TLogServer.actor.cpp
@@ -1081,8 +1081,6 @@ void commitMessages( TLogData* self, Reference<LogData> logData, Version version
 				tag.id = tag.id % logData->logRouterTags;
 			}
 			if(tag.locality == tagLocalityTxs) {
-				// TODO: When TLogVersion is threaded into the TLog, this should be replaced with a >V4 check,
-				// as txsTag is improperly correspondingly overridden in TLog recruitment requests.
 				if (logData->txsTags > 0) {
 					tag.id = tag.id % logData->txsTags;
 				} else {

--- a/fdbserver/TagPartitionedLogSystem.actor.cpp
+++ b/fdbserver/TagPartitionedLogSystem.actor.cpp
@@ -1236,6 +1236,10 @@ struct TagPartitionedLogSystem : ILogSystem, ReferenceCounted<TagPartitionedLogS
 		return Tag(tagLocalityTxs, deterministicRandom()->randomInt(0, txsTags));
 	}
 
+	virtual TLogVersion getTLogVersion() const {
+		return tLogs[0]->tLogVersion;
+	}
+
 	ACTOR static Future<Void> monitorLog(Reference<AsyncVar<OptionalInterface<TLogInterface>>> logServer, Reference<AsyncVar<bool>> failed) {
 		state Future<Void> waitFailure;
 		loop {

--- a/fdbserver/TagPartitionedLogSystem.actor.cpp
+++ b/fdbserver/TagPartitionedLogSystem.actor.cpp
@@ -1221,15 +1221,15 @@ struct TagPartitionedLogSystem : ILogSystem, ReferenceCounted<TagPartitionedLogS
 		}
 	}
 
-	virtual bool hasRemoteLogs() {
+	virtual bool hasRemoteLogs() const {
 		return logRouterTags > 0 || pseudoLocalities.size() > 0;
 	}
 
-	virtual Tag getRandomRouterTag() {
+	virtual Tag getRandomRouterTag() const {
 		return Tag(tagLocalityLogRouter, deterministicRandom()->randomInt(0, logRouterTags));
 	}
 
-	virtual Tag getRandomTxsTag() {
+	virtual Tag getRandomTxsTag() const {
 		if(txsTags==0) {
 			return txsTag;
 		}

--- a/fdbserver/TagPartitionedLogSystem.actor.cpp
+++ b/fdbserver/TagPartitionedLogSystem.actor.cpp
@@ -267,7 +267,6 @@ struct TagPartitionedLogSystem : ILogSystem, ReferenceCounted<TagPartitionedLogS
 		logSystem->expectedLogSets = lsConf.expectedLogSets;
 		logSystem->logRouterTags = lsConf.logRouterTags;
 		logSystem->txsTags = lsConf.txsTags;
-		ASSERT( !(lsConf.txsTags > 0 && lsConf.tLogs[0].tLogVersion < TLogVersion::V4) );
 		logSystem->recruitmentID = lsConf.recruitmentID;
 		logSystem->stopped = lsConf.stopped;
 		if(useRecoveredAt) {


### PR DESCRIPTION
I'm getting really good at these 1 line changes that spiral out of control...

There's part of this that is a decently mechanical transformation of changing `txsTags==0` to `tLogVersion < V4`.

The other part of this is handling copying txnStateStore mutations between the Known Committed Version and the Recovery Version when configuring from V4 to V3.  This is code that didn't need to exist previously, because it wasn't possible to do.  We now force all sharded txsLocality tags to be copied to the preferred location for the txsTag.

I have this baking in correctness, so I'll updraft it in the morning if it's safe.