### PR TITLE
Bump CMake minimum required version to 3.13

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.13)
 project(foundationdb
   VERSION 6.1.0
   DESCRIPTION "FoundationDB is a scalable, fault-tolerant, ordered key-value store with full ACID transactions."

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ To build with CMake, generally the following is required (works on Linux and
 Mac OS - for Windows see below):
 
 1. Check out this repository.
-1. Install cmake Version 3.12 or higher [CMake](https://cmake.org/)
+1. Install cmake Version 3.13 or higher [CMake](https://cmake.org/)
 1. Download version 1.67 of [Boost](https://sourceforge.net/projects/boost/files/boost/1.67.0/). 
 1. Unpack boost (you don't need to compile it)
 1. Install [Mono](http://www.mono-project.com/download/stable/).


### PR DESCRIPTION
`add_link_options` is not available in CMake version 3.12, so we now need version 3.13.