### PR TITLE
Remove `operator , (vector<T>, T)` as an append operator.

### DIFF
--- a/fdbserver/OldTLogServer_4_6.actor.cpp
+++ b/fdbserver/OldTLogServer_4_6.actor.cpp
@@ -1240,8 +1240,8 @@ namespace oldTLog_4_6 {
 
 		// FIXME: metadata in queue?
 
-		wait( waitForAll( (vector<Future<Optional<Value>>>(), fFormat ) ) );
-		wait( waitForAll( (vector<Future<Standalone<VectorRef<KeyValueRef>>>>(), fVers, fRecoverCounts) ) );
+		wait( waitForAll( std::vector{fFormat} ) );
+		wait( waitForAll( std::vector{fVers, fRecoverCounts} ) );
 
 		if (fFormat.get().present() && !persistFormatReadableRange.contains( fFormat.get().get() )) {
 			TraceEvent(SevError, "UnsupportedDBFormat", self->dbgid).detail("Format", fFormat.get().get()).detail("Expected", persistFormat.value.toString());

--- a/fdbserver/OldTLogServer_6_0.actor.cpp
+++ b/fdbserver/OldTLogServer_6_0.actor.cpp
@@ -2061,8 +2061,8 @@ ACTOR Future<Void> restorePersistentState( TLogData* self, LocalityData locality
 
 	// FIXME: metadata in queue?
 
-	wait( waitForAll( (vector<Future<Optional<Value>>>(), fFormat ) ) );
-	wait( waitForAll( (vector<Future<Standalone<VectorRef<KeyValueRef>>>>(), fVers, fKnownCommitted, fLocality, fLogRouterTags, fTxsTags, fRecoverCounts) ) );
+	wait( waitForAll( std::vector{fFormat} ) );
+	wait( waitForAll( std::vector{fVers, fKnownCommitted, fLocality, fLogRouterTags, fTxsTags, fRecoverCounts} ) );
 
 	if (fFormat.get().present() && !persistFormatReadableRange.contains( fFormat.get().get() )) {
 		//FIXME: remove when we no longer need to test upgrades from 4.X releases

--- a/fdbserver/TLogServer.actor.cpp
+++ b/fdbserver/TLogServer.actor.cpp
@@ -2451,8 +2451,8 @@ ACTOR Future<Void> restorePersistentState( TLogData* self, LocalityData locality
 
 	// FIXME: metadata in queue?
 
-	wait( waitForAll( (vector<Future<Optional<Value>>>(), fFormat, fRecoveryLocation ) ) );
-	wait( waitForAll( (vector<Future<Standalone<VectorRef<KeyValueRef>>>>(), fVers, fKnownCommitted, fLocality, fLogRouterTags, fTxsTags, fRecoverCounts, fProtocolVersions ) ) );
+	wait( waitForAll( std::vector{fFormat, fRecoveryLocation} ) );
+	wait( waitForAll( std::vector{fVers, fKnownCommitted, fLocality, fLogRouterTags, fTxsTags, fRecoverCounts, fProtocolVersions} ) );
 
 	if (fFormat.get().present() && !persistFormatReadableRange.contains( fFormat.get().get() )) {
 		//FIXME: remove when we no longer need to test upgrades from 4.X releases

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -3149,8 +3149,8 @@ ACTOR Future<bool> restoreDurableState( StorageServer* data, IKeyValueStore* sto
 	data->byteSampleRecovery = restoreByteSample(data, storage, byteSampleSampleRecovered, startByteSampleRestore.getFuture());
 
 	TraceEvent("ReadingDurableState", data->thisServerID);
-	wait( waitForAll( (vector<Future<Optional<Value>>>(), fFormat, fID, fVersion, fLogProtocol, fPrimaryLocality) ) );
-	wait( waitForAll( (vector<Future<Standalone<VectorRef<KeyValueRef>>>>(), fShardAssigned, fShardAvailable) ) );
+	wait( waitForAll( std::vector{ fFormat, fID, fVersion, fLogProtocol, fPrimaryLocality } ) );
+	wait( waitForAll( std::vector{ fShardAssigned, fShardAvailable } ) );
 	wait( byteSampleSampleRecovered.getFuture() );
 	TraceEvent("RestoringDurableState", data->thisServerID);
 

--- a/flow/genericactors.actor.h
+++ b/flow/genericactors.actor.h
@@ -90,17 +90,6 @@ T sorted(T range) {
 }
 
 template <class T>
-inline std::vector<T>& operator , (std::vector<T>& v, T a) {
-	v.push_back(a);
-	return v;
-}
-
-template <class T>
-inline std::vector<T>& operator , (std::vector<T> && v, T a) {
-	return (const_cast<std::vector<T>&>(v), a);
-}
-
-template <class T>
 ErrorOr<T> errorOr( T t ) {
 	return ErrorOr<T>(t);
 }


### PR DESCRIPTION
Because no one expects the comma overload.


Now, this is a slightly trickier change than it looks.  Before this change, one could write:

```
std::vector<int> z;
z , 1;
doSomethingWith(z);
```

And after this change, this is still valid, compile-able C++.  It just does something different, and `doSomethingWith(z)` will get an empty vector instead of a one element vector.

So I added `ASSERT(false)` to these, ran simulation on that, and then removed them.  Nothing in simulation crashed, so it looks like these are unused, thankfully.