### PR TITLE
setDDMode should set moveKeysLockWriteKey

### DIFF
--- a/fdbclient/ManagementAPI.actor.cpp
+++ b/fdbclient/ManagementAPI.actor.cpp
@@ -1403,11 +1403,12 @@ ACTOR Future<int> setDDMode( Database cx, int mode ) {
 					rd >> oldMode;
 				}
 			}
-			if (!mode) {
-				BinaryWriter wrMyOwner(Unversioned());
-				wrMyOwner << dataDistributionModeLock;
-				tr.set( moveKeysLockOwnerKey, wrMyOwner.toValue() );
-			}
+			BinaryWriter wrMyOwner(Unversioned());
+			wrMyOwner << dataDistributionModeLock;
+			tr.set( moveKeysLockOwnerKey, wrMyOwner.toValue() );
+			BinaryWriter wrLastWrite(Unversioned());
+			wrLastWrite << deterministicRandom()->randomUniqueID();
+			tr.set( moveKeysLockWriteKey, wrLastWrite.toValue() );
 
 			tr.set( dataDistributionModeKey, wr.toValue() );
 


### PR DESCRIPTION
setDDMode disable enable disable - would not disable DD sometimes. setDDMode does not set the moveKeysLockWriteKey which can cause the above.

After takeMoveKeysLock notes down the moveKeysLockOwnerKey and the moveKeysLockWriteKey value, it monitors the above two in pollMoveKeysLock and checks if anything is changed, but setDDMode was not setting the moveKeysLockWriteKey and so a sequence like disable, enable and disable would not really disable DD unless the intermediate enable had a change in the moveKeysLockOwnerKey.

This will fix the issue #1865 .