### PR TITLE
Raise the priority of TLogRejoin above TLogPeekReply

### DIFF
--- a/fdbserver/MasterInterface.h
+++ b/fdbserver/MasterInterface.h
@@ -51,6 +51,7 @@ struct MasterInterface {
 
 	void initEndpoints() {
 		getCommitVersion.getEndpoint( TaskPriority::ProxyGetConsistentReadVersion );
+		tlogRejoin.getEndpoint( TaskPriority::MasterTLogRejoin );
 	}
 };
 

--- a/flow/network.h
+++ b/flow/network.h
@@ -44,6 +44,7 @@ enum class TaskPriority {
 	FailureMonitor = 8700,
 	ResolutionMetrics = 8700,
 	ClusterController = 8650,
+	MasterTLogRejoin = 8646,
 	ProxyStorageRejoin = 8645,
 	ProxyCommitDispatcher = 8640,
 	TLogQueuingMetrics = 8620,


### PR DESCRIPTION
With sharded txs tags, the master now receives data from transaction logs at an order of magnitude higher rate.  This is the intentional desires result of sharding the txs tag.  With a sufficient number of TLogs, the master will saturate its CPU time handling the peek responses.

Performance tests revealed some unstable oddities in how long a recovery would take, which was eventually root caused to a priority inversion between TLogRejoin requests (happening at TaskPriority::Default) and processing TLog peek replies (happening at TaskPriority::TLogPeekReply).

Once peek replies saturate the CPU, the master would proceed to ignore further TLogRejoin messages.  TLogRejoin is what marks a TLog as available to the failure monitor, which is also what decides between a ServerPeekCursor and a MergePeekCursor for a SetPeekCursor.  Ignoring TLogRejoins meant that the sharded txs locality tags for those servers would be merge peeked over all TLogs.  This is much less efficient than just peeking one copy of data from the one preferred server.

Depending on the race between TLogPeek replies saturating the CPU and TLogRejoin requests being submitted, a variable number of tags would be affected, and thus the performance test would have some variance in its results.