### PR TITLE
Fix unsafe usage of now() function from multiple threads in trace logging.

### DIFF
--- a/flow/Trace.cpp
+++ b/flow/Trace.cpp
@@ -113,7 +113,7 @@ struct SuppressionMap {
 };
 
 TraceBatch g_traceBatch;
-trace_clock_t g_trace_clock = TRACE_CLOCK_NOW;
+thread_local trace_clock_t g_trace_clock = TRACE_CLOCK_REALTIME;
 
 LatestEventCache latestEventCache;
 SuppressionMap suppressedEvents;
@@ -979,6 +979,7 @@ thread_local bool TraceEvent::networkThread = false;
 void TraceEvent::setNetworkThread() {
 	traceEventThrottlerCache = new TransientThresholdMetricSample<Standalone<StringRef>>(FLOW_KNOBS->TRACE_EVENT_METRIC_UNITS_PER_SAMPLE, FLOW_KNOBS->TRACE_EVENT_THROTTLER_MSG_LIMIT);
 	networkThread = true;
+	g_trace_clock = TRACE_CLOCK_NOW;
 }
 
 bool TraceEvent::isNetworkThread() {

--- a/flow/Trace.h
+++ b/flow/Trace.h
@@ -564,7 +564,7 @@ void addTraceRole(std::string role);
 void removeTraceRole(std::string role);
 
 enum trace_clock_t { TRACE_CLOCK_NOW, TRACE_CLOCK_REALTIME };
-extern trace_clock_t g_trace_clock;
+extern thread_local trace_clock_t g_trace_clock;
 extern TraceBatch g_traceBatch;
 
 #endif


### PR DESCRIPTION
This change fixes the problem of accessing the current time from multiple threads by having non-network threads use a real-time clock for trace events.

This will add cost to trace logging on non-network threads as well as on the network thread prior to the point when `setNetworkThread` is called. Because of that, we may want to consider whether this  approach is the best option.