### PR TITLE
disable DD with a in-memory flag and use it for snap v2

### DIFF
--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -3355,11 +3355,14 @@ ACTOR Future<Void> snapshotDatabase(Reference<DatabaseContext> cx, StringRef sna
 			g_traceBatch.addEvent("TransactionDebug", debugID.get().first(), "NativeAPI.snapshotDatabase.Before");
 		}
 
-		ProxySnapRequest req(snapPayload, snapUID, debugID);
-		wait(loadBalance(cx->getMasterProxies(false), &MasterProxyInterface::proxySnapReq, req, cx->taskID, true /*atmostOnce*/ ));
-		if (debugID.present())
-			g_traceBatch.addEvent("TransactionDebug", debugID.get().first(),
-									"NativeAPI.SnapshotDatabase.After");
+		choose {
+			when(wait(cx->onMasterProxiesChanged())) { throw operation_failed(); }
+			when(wait(loadBalance(cx->getMasterProxies(false), &MasterProxyInterface::proxySnapReq, ProxySnapRequest(snapPayload, snapUID, debugID), cx->taskID, true /*atmostOnce*/ ))) {
+				if (debugID.present())
+					g_traceBatch.addEvent("TransactionDebug", debugID.get().first(),
+											"NativeAPI.SnapshotDatabase.After");
+			}
+		}
 	} catch (Error& e) {
 		TraceEvent("NativeAPI.SnapshotDatabaseError")
 			.detail("SnapPayload", snapPayload)
@@ -3370,11 +3373,11 @@ ACTOR Future<Void> snapshotDatabase(Reference<DatabaseContext> cx, StringRef sna
 	return Void();
 }
 
-ACTOR Future<Void> snapCreateCore(Database cx, StringRef snapCmd, UID snapUID) {
+ACTOR Future<Void> snapCreate(Database cx, StringRef snapCmd, UID snapUID) {
 	// remember the client ID before the snap operation
 	state UID preSnapClientUID = cx->clientInfo->get().id;
 
-	TraceEvent("SnapCreateCoreEnter")
+	TraceEvent("SnapCreateEnter")
 	    .detail("SnapCmd", snapCmd.toString())
 	    .detail("UID", snapUID)
 	    .detail("PreSnapClientUID", preSnapClientUID);
@@ -3392,7 +3395,7 @@ ACTOR Future<Void> snapCreateCore(Database cx, StringRef snapCmd, UID snapUID) {
 		Future<Void> exec = snapshotDatabase(Reference<DatabaseContext>::addRef(cx.getPtr()), snapPayloadRef, snapUID, snapUID);
 		wait(exec);
 	} catch (Error& e) {
-		TraceEvent("SnapCreateCoreError")
+		TraceEvent("SnapCreateError")
 			.detail("SnapCmd", snapCmd.toString())
 			.detail("UID", snapUID)
 			.error(e);
@@ -3402,28 +3405,15 @@ ACTOR Future<Void> snapCreateCore(Database cx, StringRef snapCmd, UID snapUID) {
 	UID postSnapClientUID = cx->clientInfo->get().id;
 	if (preSnapClientUID != postSnapClientUID) {
 		// if the client IDs changed then we fail the snapshot
-		TraceEvent("SnapCreateCoreUIDMismatch")
+		TraceEvent("SnapCreateUIDMismatch")
 		    .detail("SnapPreSnapClientUID", preSnapClientUID)
 		    .detail("SnapPostSnapClientUID", postSnapClientUID);
 		throw coordinators_changed();
 	}
 
-	TraceEvent("SnapCreateCoreExit")
+	TraceEvent("SnapCreateExit")
 	    .detail("SnapCmd", snapCmd.toString())
 	    .detail("UID", snapUID)
 	    .detail("PreSnapClientUID", preSnapClientUID);
-	return Void();
-}
-
-ACTOR Future<Void> snapCreate(Database cx, StringRef snapCmd, UID snapUID) {
-	state int oldMode = wait( setDDMode( cx, 0 ) );
-	try {
-		wait(snapCreateCore(cx, snapCmd, snapUID));
-	} catch (Error& e) {
-		state Error err = e;
-		wait(success( setDDMode( cx, oldMode ) ));
-		throw err;
-	}
-	wait(success( setDDMode( cx, oldMode ) ));
 	return Void();
 }

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -4157,12 +4157,14 @@ ACTOR Future<Void> ddSnapCreate(DistributorSnapRequest snapReq, Reference<AsyncV
 			snapReq.reply.sendError(e);
 		} else {
 			// enable DD should always succeed
-			ASSERT(setDDEnabled(true, snapReq.snapUID));
+			bool success = setDDEnabled(true, snapReq.snapUID);
+			ASSERT(success);
 			throw e;
 		}
 	}
 	// enable DD should always succeed
-	ASSERT(setDDEnabled(true, snapReq.snapUID));
+	bool success = setDDEnabled(true, snapReq.snapUID);
+	ASSERT(success);
 	return Void();
 }
 

--- a/fdbserver/DataDistributionQueue.actor.cpp
+++ b/fdbserver/DataDistributionQueue.actor.cpp
@@ -1089,8 +1089,11 @@ ACTOR Future<Void> dataDistributionRelocator( DDQueueData *self, RelocateData rd
 
 		relocationComplete.send( rd );
 
-		if( e.code() != error_code_actor_cancelled )
-			errorOut.sendError(e);
+		if( e.code() != error_code_actor_cancelled ) {
+			if (errorOut.canBeSet()) {
+				errorOut.sendError(e);
+			}
+		}
 		throw;
 	}
 }

--- a/fdbserver/MasterProxyServer.actor.cpp
+++ b/fdbserver/MasterProxyServer.actor.cpp
@@ -1668,6 +1668,7 @@ ACTOR Future<Void> masterProxyServerCore(
 			req.reply.send(rep);
 		}
 		when(ProxySnapRequest snapReq = waitNext(proxy.proxySnapReq.getFuture())) {
+			TraceEvent(SevDebug, "SnapMasterEnqueue");
 			addActor.send(proxySnapCreate(snapReq, &commitData));
 		}
 		when(TxnStateRequest req = waitNext(proxy.txnState.getFuture())) {

--- a/fdbserver/MoveKeys.actor.h
+++ b/fdbserver/MoveKeys.actor.h
@@ -47,6 +47,12 @@ Future<Void> checkMoveKeysLockReadOnly( Transaction* tr, MoveKeysLock lock );
 // Checks that the a moveKeysLock has not changed since having taken it
 // This does not modify the moveKeysLock
 
+bool isDDEnabled();
+// checks if the in-memory DDEnabled flag is set
+
+bool setDDEnabled(bool status, UID snapUID);
+// sets the in-memory DDEnabled flag
+
 void seedShardServers(
 	Arena& trArena,
 	CommitTransactionRef &tr,


### PR DESCRIPTION
Currently, the mechanism available to disable DD is by setting a persistent state on the database.  This mechanism is mostly used by operators to stall DD. But, to disable and enable DD after a certain time interval or other event, across process restarts - needs additional logic.

To help such cases, a mechanism to disable DD and enable DD by setting an in-memory state is added. If there is a process re-start then the disable DD will be forgotten. In all other cases, it is the responsibility of the caller to disable and enable DD.  Additionally, changes to use this mechanism in snapshot v2 is also part of this change.

Please note commit `731e996` is in a separate PR, some changes are dependent on it hence this PR is made on top of it, review only commits other than `731e996`.