### PR TITLE
Fix Void flatbuffers serialization

### DIFF
--- a/flow/flow.h
+++ b/flow/flow.h
@@ -123,7 +123,9 @@ class Void {
 public:
 	constexpr static FileIdentifier file_identifier = 2010442;
 	template <class Ar>
-	void serialize(Ar&) {}
+	void serialize(Ar& ar) {
+		serializer(ar);
+	}
 };
 
 class Never {};


### PR DESCRIPTION
Before this fix, the encoding of Void happens to 'work' in that this
implementation can both read and write it, but it is not a flatbuffers
message since it contains a invalid offset (the implementation 'works'
because it does not dereference that offset).

CC @mpilman 