### PR TITLE
Add a monitorServerInfoConfig() call back

### DIFF
--- a/fdbserver/ClusterController.actor.cpp
+++ b/fdbserver/ClusterController.actor.cpp
@@ -2619,6 +2619,7 @@ ACTOR Future<Void> clusterControllerCore( ClusterControllerFullInterface interf,
 	self.addActor.send( statusServer( interf.clientInterface.databaseStatus.getFuture(), &self, coordinators));
 	self.addActor.send( timeKeeper(&self) );
 	self.addActor.send( monitorProcessClasses(&self) );
+	self.addActor.send( monitorServerInfoConfig(&self.db) );
 	self.addActor.send( monitorClientTxnInfoConfigs(&self.db) );
 	self.addActor.send( updatedChangingDatacenters(&self) );
 	self.addActor.send( updatedChangedDatacenters(&self) );


### PR DESCRIPTION
This was deleted during a code refactor in ef868f5. Because no tests were complaining, we didn't find this until now.