### PR TITLE
Bug fix: fdbrestore commands other than "start" were using default cl…

### DIFF
--- a/documentation/sphinx/source/backups.rst
+++ b/documentation/sphinx/source/backups.rst
@@ -407,7 +407,7 @@ The following options apply to all commands:
   Use FILE as a :ref:`Blob Credential File<blob-credential-files>`.  Can be used multiple times.
 
 ``--dest_cluster_file <CONNFILE>``
-  Required.  Path to the cluster file that should be used to connect to the FoundationDB cluster you want to use.
+  Required.  Path to the cluster file that should be used to connect to the FoundationDB cluster you are restoring to.
 
 .. _restore-start:
 

--- a/documentation/sphinx/source/backups.rst
+++ b/documentation/sphinx/source/backups.rst
@@ -406,10 +406,8 @@ The following options apply to all commands:
 ``--blob_credentials <FILE>``
   Use FILE as a :ref:`Blob Credential File<blob-credential-files>`.  Can be used multiple times.
 
-The following options apply to all commands except ``start``:
-
-``-C <CLUSTER_FILE>``
-  Path to the cluster file that should be used to connect to the FoundationDB cluster you want to use.  If not specified, a :ref:`default cluster file <default-cluster-file>` will be used.
+``--dest_cluster_file <CONNFILE>``
+  Required.  Path to the cluster file that should be used to connect to the FoundationDB cluster you want to use.
 
 .. _restore-start:
 
@@ -423,10 +421,6 @@ The ``start`` command will start a new restore on the specified (or default) tag
 
 ``-r <BACKUP_URL>``
   Required.  Specifies the Backup URL for the source backup data to restore to the database.  The source data must be accessible by the ``backup_agent`` processes for the cluster.
-
-``--dest_cluster_file <CONNFILE>``
-  Required.  The backup data will be restored into this cluster.
-
 
 ``-w``
   Wait for the restore to reach a final state (such as complete) before exiting.  Prints a progress update every few seconds.  Behavior is identical to that of the wait command.

--- a/fdbbackup/backup.actor.cpp
+++ b/fdbbackup/backup.actor.cpp
@@ -903,7 +903,7 @@ static void printBackupUsage(bool devhelp) {
 	printf("  -e ERRORLIMIT  The maximum number of errors printed by status (default is 10).\n");
 	printf("  -k KEYS        List of key ranges to backup.\n"
 		   "                 If not specified, the entire database will be backed up.\n");
-	printf("  -n, --dryrun  For start or restore operations, performs a trial run with no actual changes made.\n");
+	printf("  -n, --dryrun   For backup start or restore start, performs a trial run with no actual changes made.\n");
 #ifndef TLS_DISABLED
 	printf(TLS_HELP);
 #endif
@@ -3386,12 +3386,8 @@ int main(int argc, char* argv[]) {
 
 			break;
 		case EXE_RESTORE:
-			if(dryRun) {
-				initTraceFile();
-			}
-			else if(restoreType != RESTORE_START && !initCluster()) {
-				return FDB_EXIT_ERROR;
-			}
+			// Must explicitly call trace file options handling because initCluster() is not being used
+			initTraceFile();
 
 			if(restoreClusterFileDest.empty()) {
 				fprintf(stderr, "Restore destination cluster file must be specified explicitly.\n");

--- a/fdbbackup/backup.actor.cpp
+++ b/fdbbackup/backup.actor.cpp
@@ -3386,24 +3386,32 @@ int main(int argc, char* argv[]) {
 
 			break;
 		case EXE_RESTORE:
-			// Must explicitly call trace file options handling because initCluster() is not being used
-			initTraceFile();
+			if(dryRun) {
+				if(restoreType != RESTORE_START) {
+					fprintf(stderr, "Restore dry run only works for 'start' command\n");
+					return FDB_EXIT_ERROR;
+				}
 
-			if(restoreClusterFileDest.empty()) {
-				fprintf(stderr, "Restore destination cluster file must be specified explicitly.\n");
-				return FDB_EXIT_ERROR;
+				// Must explicitly call trace file options handling if not calling Database::createDatabase()
+				initTraceFile();
 			}
+			else {
+				if(restoreClusterFileDest.empty()) {
+					fprintf(stderr, "Restore destination cluster file must be specified explicitly.\n");
+					return FDB_EXIT_ERROR;
+				}
 
-			if(!fileExists(restoreClusterFileDest)) {
-				fprintf(stderr, "Restore destination cluster file '%s' does not exist.\n", restoreClusterFileDest.c_str());
-				return FDB_EXIT_ERROR;
-			}
+				if(!fileExists(restoreClusterFileDest)) {
+					fprintf(stderr, "Restore destination cluster file '%s' does not exist.\n", restoreClusterFileDest.c_str());
+					return FDB_EXIT_ERROR;
+				}
 
-			try {
-				db = Database::createDatabase(restoreClusterFileDest, Database::API_VERSION_LATEST);
-			} catch(Error &e) {
-				fprintf(stderr, "Restore destination cluster file '%s' invalid: %s\n", restoreClusterFileDest.c_str(), e.what());
-				return FDB_EXIT_ERROR;
+				try {
+					db = Database::createDatabase(restoreClusterFileDest, Database::API_VERSION_LATEST);
+				} catch(Error &e) {
+					fprintf(stderr, "Restore destination cluster file '%s' invalid: %s\n", restoreClusterFileDest.c_str(), e.what());
+					return FDB_EXIT_ERROR;
+				}
 			}
 
 			switch(restoreType) {


### PR DESCRIPTION
argument handling (but without the -C flag) instead of using the --dest_cluster_file argument.

Also fixes bug where trace file initialization (based on arguments) is not done for `fdbrestore start` operations.

Also fixes bug where `fdbrestore start --dryrun` would still require a cluster file even though it would not be used.