### PR TITLE
Avoid memcpy for small types

### DIFF
--- a/fdbclient/FDBTypes.h
+++ b/fdbclient/FDBTypes.h
@@ -331,12 +331,12 @@ struct string_serialized_traits<KeyValueRef> : std::true_type {
 	uint32_t save(uint8_t* out, const KeyValueRef& item) const {
 		auto begin = out;
 		uint32_t sz = item.key.size();
-		memcpy(out, &sz, sizeof(sz));
+		*reinterpret_cast<decltype(sz)*>(out) = sz;
 		out += sizeof(sz);
 		memcpy(out, item.key.begin(), sz);
 		out += sz;
 		sz = item.value.size();
-		memcpy(out, &sz, sizeof(sz));
+		*reinterpret_cast<decltype(sz)*>(out) = sz;
 		out += sizeof(sz);
 		memcpy(out, item.value.begin(), sz);
 		out += sz;

--- a/flow/Arena.h
+++ b/flow/Arena.h
@@ -1143,7 +1143,7 @@ struct dynamic_size_traits<VectorRef<V, VecSerStrategy::String>> : std::true_typ
 		string_serialized_traits<V> traits;
 		auto* p = out;
 		uint32_t length = t.size();
-		memcpy(out, &length, sizeof(length));
+		*reinterpret_cast<decltype(length)*>(out) = length;
 		out += sizeof(length);
 		for (const auto& item : t) {
 			out += traits.save(out, item);

--- a/flow/flat_buffers.cpp
+++ b/flow/flat_buffers.cpp
@@ -180,8 +180,8 @@ TEST_CASE("flow/FlatBuffers/collectVTables") {
 	ASSERT(vtables == detail::get_vtableset(root, context));
 	const auto& root_vtable = *detail::get_vtable<uint8_t, std::vector<Nested2>, Nested>();
 	const auto& nested_vtable = *detail::get_vtable<uint8_t, std::vector<std::string>, int>();
-	int root_offset = vtables->offsets.at(&root_vtable);
-	int nested_offset = vtables->offsets.at(&nested_vtable);
+	int root_offset = vtables->getOffset(&root_vtable);
+	int nested_offset = vtables->getOffset(&nested_vtable);
 	ASSERT(!memcmp((uint8_t*)&root_vtable[0], &vtables->packed_tables[root_offset], root_vtable.size()));
 	ASSERT(!memcmp((uint8_t*)&nested_vtable[0], &vtables->packed_tables[nested_offset], nested_vtable.size()));
 	return Void();


### PR DESCRIPTION
This is undefined behavior, since it's potentially a misaligned access.
But it's _probably_ not worse than the status quo