### PR TITLE
Add reporting for zone count

### DIFF
--- a/documentation/sphinx/source/release-notes.rst
+++ b/documentation/sphinx/source/release-notes.rst
@@ -36,6 +36,7 @@ Status
 * Added transaction start counts by priority to ``cluster.workload.transactions``. The new counters are named ``started_immediate_priority``, ``started_default_priority``, and ``started_batch_priority``. `(PR #1836) <https://github.com/apple/foundationdb/pull/1836>`_.
 * Remove ``cluster.datacenter_version_difference`` and replace it with ``cluster.datacenter_lag`` that has subfields ``versions`` and ``seconds``. `(PR #1800) <https://github.com/apple/foundationdb/pull/1800>`_.
 * Added ``local_rate`` to the ``roles`` section to record the throttling rate of the local ratekeeper `(PR #1712) <http://github.com/apple/foundationdb/pull/1712>`_.
+* ``fdbcli`` status now reports the configured zone count. The fault tolerance is now reported in terms of the number of zones unless machine IDs are being used as zone IDs. `(PR #1924) <https://github.com/apple/foundationdb/pull/1924>`_.
 
 Bindings
 --------

--- a/fdbcli/fdbcli.actor.cpp
+++ b/fdbcli/fdbcli.actor.cpp
@@ -995,6 +995,9 @@ void printStatus(StatusObjectReader statusObj, StatusClient::StatusLevel level, 
 			StatusObjectReader machinesMap;
 
 			outputStringCache = outputString;
+
+			bool machinesAreZones = true;
+			std::map<std::string, int> zones;
 			try {
 				outputString += "\n  FoundationDB processes - ";
 				if (statusObjCluster.get("processes", processesMap)) {
@@ -1005,10 +1008,24 @@ void printStatus(StatusObjectReader statusObj, StatusClient::StatusLevel level, 
 					int processExclusions = 0;
 					for (auto p : processesMap.obj()) {
 						StatusObjectReader process(p.second);
-						if (process.has("excluded") && process.last().get_bool())
+						bool excluded = process.has("excluded") && process.last().get_bool();
+						if (excluded) {
 							processExclusions++;
+						}
 						if (process.has("messages") && process.last().get_array().size()){
-							errors ++;
+							errors++;
+						}
+
+						std::string zoneId;
+						if (process.get("locality.zoneid", zoneId)) {
+							std::string machineId;
+							if (!process.get("locality.machineid", machineId) || machineId != zoneId) {
+								machinesAreZones = false;
+							}
+							int& nonExcluded = zones[zoneId];
+							if(!excluded) {
+								nonExcluded = 1;
+							}
 						}
 					}
 
@@ -1018,6 +1035,21 @@ void printStatus(StatusObjectReader statusObj, StatusClient::StatusLevel level, 
 
 				} else
 					outputString += "unknown";
+
+				if (zones.size() > 0) {
+					outputString += format("\n  Zones                  - %d", zones.size());
+					int zoneExclusions = 0;
+					for (auto itr : zones) {
+						if (itr.second == 0) {
+							++zoneExclusions;
+						}
+					}
+					if (zoneExclusions > 0) {
+						outputString += format(" (less %d excluded)", zoneExclusions);
+					}
+				} else {
+					outputString += "\n  Zones                  - unknown";
+				}
 
 				outputString += "\n  Machines               - ";
 				if (statusObjCluster.get("machines", machinesMap)) {
@@ -1073,15 +1105,15 @@ void printStatus(StatusObjectReader statusObj, StatusClient::StatusLevel level, 
 						outputString += "\n  Fault Tolerance        - ";
 
 						int minLoss = std::min(availLoss, dataLoss);
+						const char *faultDomain = machinesAreZones ? "machine" : "zone";
 						if (minLoss == 1)
-							outputString += "1 machine";
+							outputString += format("1 %s", faultDomain);
 						else
-							outputString += format("%d machines", minLoss);
+							outputString += format("%d %ss", minLoss, faultDomain);
 
 						if (dataLoss > availLoss){
 							outputString += format(" (%d without data loss)", dataLoss);
 						}
-
 					}
 				}
 


### PR DESCRIPTION
Fault tolerance reports in terms of zones unless machine ID matches zone ID. Resolves #1420, partially completes the items for #1421 (this doesn't change the status field names).