### PR TITLE
Rename max_machine_failures_without_losing_X to max_zone_failures_without_losing_X in status.

### DIFF
--- a/documentation/sphinx/source/mr-status-json-schemas.rst.inc
+++ b/documentation/sphinx/source/mr-status-json-schemas.rst.inc
@@ -212,8 +212,8 @@
          }
       ],
       "fault_tolerance":{
-         "max_machine_failures_without_losing_availability":0,
-         "max_machine_failures_without_losing_data":0
+         "max_zone_failures_without_losing_availability":0,
+         "max_zone_failures_without_losing_data":0
       },
       "qos":{
          "worst_queue_bytes_log_server":460,

--- a/documentation/sphinx/source/release-notes.rst
+++ b/documentation/sphinx/source/release-notes.rst
@@ -36,6 +36,7 @@ Status
 * Added transaction start counts by priority to ``cluster.workload.transactions``. The new counters are named ``started_immediate_priority``, ``started_default_priority``, and ``started_batch_priority``. `(PR #1836) <https://github.com/apple/foundationdb/pull/1836>`_.
 * Remove ``cluster.datacenter_version_difference`` and replace it with ``cluster.datacenter_lag`` that has subfields ``versions`` and ``seconds``. `(PR #1800) <https://github.com/apple/foundationdb/pull/1800>`_.
 * Added ``local_rate`` to the ``roles`` section to record the throttling rate of the local ratekeeper `(PR #1712) <http://github.com/apple/foundationdb/pull/1712>`_.
+* Renamed ``cluster.fault_tolerance`` fields ``max_machines_without_losing_availability`` and ``max_machines_without_losing_data`` to ``max_zones_without_losing_availability`` and ``max_zones_without_losing_data`` `(PR #1925) <https://github.com/apple/foundationdb/pull/1925>`_.
 
 Bindings
 --------

--- a/fdbcli/fdbcli.actor.cpp
+++ b/fdbcli/fdbcli.actor.cpp
@@ -1068,7 +1068,7 @@ void printStatus(StatusObjectReader statusObj, StatusClient::StatusLevel level, 
 				if (statusObjCluster.get("fault_tolerance", faultTolerance)) {
 					int availLoss, dataLoss;
 
-					if (faultTolerance.get("max_machine_failures_without_losing_availability", availLoss) && faultTolerance.get("max_machine_failures_without_losing_data", dataLoss)) {
+					if (faultTolerance.get("max_zone_failures_without_losing_availability", availLoss) && faultTolerance.get("max_zone_failures_without_losing_data", dataLoss)) {
 
 						outputString += "\n  Fault Tolerance        - ";
 

--- a/fdbclient/DatabaseConfiguration.h
+++ b/fdbclient/DatabaseConfiguration.h
@@ -123,7 +123,7 @@ struct DatabaseConfiguration {
 		}
 		return minRequired;
 	}
-	int32_t minMachinesRequiredPerDatacenter() const {
+	int32_t minZonesRequiredPerDatacenter() const {
 		int minRequired = std::max( remoteTLogReplicationFactor, std::max(tLogReplicationFactor, storageTeamSize) );
 		for(auto& r : regions) {
 			minRequired = std::max( minRequired, r.satelliteTLogReplicationFactor/std::max(1, r.satelliteTLogUsableDcs) );
@@ -131,8 +131,8 @@ struct DatabaseConfiguration {
 		return minRequired;
 	}
 
-	//Killing an entire datacenter counts as killing one machine in modes that support it
-	int32_t maxMachineFailuresTolerated() const {
+	//Killing an entire datacenter counts as killing one zone in modes that support it
+	int32_t maxZoneFailuresTolerated() const {
 		int worstSatellite = regions.size() ? std::numeric_limits<int>::max() : 0;
 		for(auto& r : regions) {
 			worstSatellite = std::min(worstSatellite, r.satelliteTLogReplicationFactor - r.satelliteTLogWriteAntiQuorum);

--- a/fdbclient/Schemas.cpp
+++ b/fdbclient/Schemas.cpp
@@ -232,8 +232,8 @@ const KeyRef JSONSchemas::statusSchema = LiteralStringRef(R"statusSchema(
          }
       ],
       "fault_tolerance":{
-         "max_machine_failures_without_losing_availability":0,
-         "max_machine_failures_without_losing_data":0
+         "max_zone_failures_without_losing_availability":0,
+         "max_zone_failures_without_losing_data":0
       },
       "qos":{
          "worst_queue_bytes_log_server":460,
@@ -614,8 +614,7 @@ const KeyRef JSONSchemas::statusSchema = LiteralStringRef(R"statusSchema(
                 }
             }
          ],
-         "least_operating_space_bytes_storage_server":0,
-         "max_machine_failures_without_losing_data":0
+         "least_operating_space_bytes_storage_server":0
       },
       "machines":{
          "$map":{

--- a/fdbclient/StatusClient.actor.cpp
+++ b/fdbclient/StatusClient.actor.cpp
@@ -502,10 +502,10 @@ ACTOR Future<StatusObject> statusFetcherImpl( Reference<ClusterConnectionFile> f
 							StatusObject::Map &faultToleranceWriteable = statusObjCluster["fault_tolerance"].get_obj();
 							StatusObjectReader faultToleranceReader(faultToleranceWriteable);
 							int maxDataLoss, maxAvailLoss;
-							if (faultToleranceReader.get("max_machine_failures_without_losing_data", maxDataLoss) && faultToleranceReader.get("max_machine_failures_without_losing_availability", maxAvailLoss)) {
-								// max_machine_failures_without_losing_availability <= max_machine_failures_without_losing_data
-								faultToleranceWriteable["max_machine_failures_without_losing_data"] = std::min(maxDataLoss, coordinatorsFaultTolerance);
-								faultToleranceWriteable["max_machine_failures_without_losing_availability"] = std::min(maxAvailLoss, coordinatorsFaultTolerance);
+							if (faultToleranceReader.get("max_zone_failures_without_losing_data", maxDataLoss) && faultToleranceReader.get("max_zone_failures_without_losing_availability", maxAvailLoss)) {
+								// max_zone_failures_without_losing_availability <= max_zone_failures_without_losing_data
+								faultToleranceWriteable["max_zone_failures_without_losing_data"] = std::min(maxDataLoss, coordinatorsFaultTolerance);
+								faultToleranceWriteable["max_zone_failures_without_losing_availability"] = std::min(maxAvailLoss, coordinatorsFaultTolerance);
 							}
 						}
 					}

--- a/fdbserver/SimulatedCluster.actor.cpp
+++ b/fdbserver/SimulatedCluster.actor.cpp
@@ -1057,7 +1057,7 @@ void SimulationConfig::generateNormalConfig(int minimumReplication, int minimumR
 		machine_count = 9;
 	} else {
 		//datacenters+2 so that the configure database workload can configure into three_data_hall
-		machine_count = std::max(datacenters+2, ((db.minDatacentersRequired() > 0) ? datacenters : 1) * std::max(3, db.minMachinesRequiredPerDatacenter()));
+		machine_count = std::max(datacenters+2, ((db.minDatacentersRequired() > 0) ? datacenters : 1) * std::max(3, db.minZonesRequiredPerDatacenter()));
 		machine_count = deterministicRandom()->randomInt( machine_count, std::max(machine_count+1, extraDB ? 6 : 10) );
 		if (generateMachineTeamTestConfig) {
 			// When DESIRED_TEAMS_PER_SERVER is set to 1, the desired machine team number is 5

--- a/tests/status/local_6_machine_no_replicas_remain.json
+++ b/tests/status/local_6_machine_no_replicas_remain.json
@@ -51,8 +51,8 @@
             "total_kv_size_bytes" : 258839413
         },
         "fault_tolerance" : {
-            "max_machine_failures_without_losing_availability" : 0,
-            "max_machine_failures_without_losing_data" : 0
+            "max_zone_failures_without_losing_availability" : 0,
+            "max_zone_failures_without_losing_data" : 0
         },
         "latency_probe" : {
             "commit_seconds" : 0.036632299423217773,

--- a/tests/status/separate_2_of_3_coordinators_remain.json
+++ b/tests/status/separate_2_of_3_coordinators_remain.json
@@ -57,8 +57,8 @@
             "total_kv_size_bytes" : 0
         },
         "fault_tolerance" : {
-            "max_machine_failures_without_losing_availability" : 0,
-            "max_machine_failures_without_losing_data" : 0
+            "max_zone_failures_without_losing_availability" : 0,
+            "max_zone_failures_without_losing_data" : 0
         },
         "latency_probe" : {
             "commit_seconds" : 0.03298234939575196,

--- a/tests/status/separate_cannot_write_cluster_file.json
+++ b/tests/status/separate_cannot_write_cluster_file.json
@@ -61,8 +61,8 @@
             "total_kv_size_bytes" : 0
         },
         "fault_tolerance" : {
-            "max_machine_failures_without_losing_availability" : 0,
-            "max_machine_failures_without_losing_data" : 0
+            "max_zone_failures_without_losing_availability" : 0,
+            "max_zone_failures_without_losing_data" : 0
         },
         "latency_probe" : {
             "commit_seconds" : 0.022355079650878906,

--- a/tests/status/separate_no_database.json
+++ b/tests/status/separate_no_database.json
@@ -37,8 +37,8 @@
             ]
         },
         "fault_tolerance" : {
-            "max_machine_failures_without_losing_availability" : 0,
-            "max_machine_failures_without_losing_data" : 0
+            "max_zone_failures_without_losing_availability" : 0,
+            "max_zone_failures_without_losing_data" : 0
         },
         "machines" : {
             "6344abf1813eb05b" : {


### PR DESCRIPTION
This is the potentially more contentious change related to #1421. It renames the fields in status that report fault tolerance in terms of the number of machines that can be lost into the more accurate number of zones that can be lost (note the actual number stays the same, just the name has changed).