### PR TITLE
Fix compiler warnings

### DIFF
--- a/fdbcli/fdbcli.actor.cpp
+++ b/fdbcli/fdbcli.actor.cpp
@@ -568,7 +568,7 @@ void initHelp() {
 void printVersion() {
 	printf("FoundationDB CLI " FDB_VT_PACKAGE_NAME " (v" FDB_VT_VERSION ")\n");
 	printf("source version %s\n", getHGVersion());
-	printf("protocol %" PRIx64 "\n", currentProtocolVersion);
+	printf("protocol %" PRIx64 "\n", currentProtocolVersion.version());
 }
 
 void printHelpOverview() {

--- a/fdbserver/LogSystemConfig.h
+++ b/fdbserver/LogSystemConfig.h
@@ -28,7 +28,7 @@
 
 template <class Interface>
 struct OptionalInterface {
-	friend class serializable_traits<OptionalInterface<Interface>>;
+	friend struct serializable_traits<OptionalInterface<Interface>>;
 	// Represents an interface with a known id() and possibly known actual endpoints.
 	// For example, an OptionalInterface<TLogInterface> represents a particular tlog by id, which you might or might not presently know how to communicate with
 

--- a/fdbserver/Status.actor.cpp
+++ b/fdbserver/Status.actor.cpp
@@ -2145,7 +2145,7 @@ ACTOR Future<StatusReply> clusterGetStatus(
 		state JsonBuilderObject qos;
 		state JsonBuilderObject data_overlay;
 
-		statusObj["protocol_version"] = format("%llx", currentProtocolVersion);
+		statusObj["protocol_version"] = format("%" PRIx64, currentProtocolVersion.version());
 		statusObj["connection_string"] = coordinators.ccf->getConnectionString().toString();
 
 		state Optional<DatabaseConfiguration> configuration;

--- a/fdbserver/fdbserver.actor.cpp
+++ b/fdbserver/fdbserver.actor.cpp
@@ -528,7 +528,7 @@ void* parentWatcher(void *arg) {
 static void printVersion() {
 	printf("FoundationDB " FDB_VT_PACKAGE_NAME " (v" FDB_VT_VERSION ")\n");
 	printf("source version %s\n", getHGVersion());
-	printf("protocol %" PRIx64 "\n", currentProtocolVersion);
+	printf("protocol %" PRIx64 "\n", currentProtocolVersion.version());
 }
 
 static void printHelpTeaser( const char *name ) {

--- a/flow/Arena.h
+++ b/flow/Arena.h
@@ -1161,7 +1161,7 @@ struct dynamic_size_traits<VectorRef<V, VecSerStrategy::String>> : std::true_typ
 		memcpy(&num_elements, data, sizeof(num_elements));
 		data += sizeof(num_elements);
 		t.resize(context.arena(), num_elements);
-		for (int i = 0; i < num_elements; ++i) {
+		for (unsigned i = 0; i < num_elements; ++i) {
 			data += traits.load(data, t[i], context);
 		}
 		ASSERT(data - p == size);

--- a/flow/ObjectSerializer.h
+++ b/flow/ObjectSerializer.h
@@ -89,7 +89,7 @@ public:
 };
 
 class ObjectReader : public _ObjectReader<ObjectReader> {
-	friend class _IncludeVersion;
+	friend struct _IncludeVersion;
 	ObjectReader& operator>> (ProtocolVersion& version) {
 		uint64_t result;
 		memcpy(&result, _data, sizeof(result));
@@ -115,7 +115,7 @@ private:
 };
 
 class ArenaObjectReader : public _ObjectReader<ArenaObjectReader> {
-	friend class _IncludeVersion;
+	friend struct _IncludeVersion;
 	ArenaObjectReader& operator>> (ProtocolVersion& version) {
 		uint64_t result;
 		memcpy(&result, _data, sizeof(result));
@@ -142,7 +142,7 @@ private:
 };
 
 class ObjectWriter {
-	friend class _IncludeVersion;
+	friend struct _IncludeVersion;
 	bool writeProtocolVersion = false;
 	ObjectWriter& operator<< (const ProtocolVersion& version) {
 		writeProtocolVersion = true;

--- a/flow/genericactors.actor.h
+++ b/flow/genericactors.actor.h
@@ -311,7 +311,7 @@ Future<U> mapAsync(Future<T> what, F actorFunc)
 template<class T, class F>
 std::vector<Future<decltype(actorFunc(T()).getValue())>> mapAsync(std::vector<Future<T>> const& what, F const& actorFunc)
 {
-	std::vector<typename std::result_of<F(T)>::type> ret;
+	std::vector<typename std::invoke_result<F(T)>::type> ret;
 	for(auto f : what)
 		ret.push_back(mapAsync( f, actorFunc ));
 	return ret;
@@ -360,7 +360,7 @@ Future<Void> mapAsync( FutureStream<T> input, F actorFunc, PromiseStream<U> outp
 
 //Waits for a future to be ready, and then applies a function to it.
 ACTOR template<class T, class F>
-Future<typename std::result_of<F(T)>::type> map(Future<T> what, F func)
+Future<typename std::invoke_result<F, T>> map(Future<T> what, F func)
 {
 	T val = wait(what);
 	return func(val);
@@ -368,9 +368,9 @@ Future<typename std::result_of<F(T)>::type> map(Future<T> what, F func)
 
 //maps a vector of futures
 template<class T, class F>
-std::vector<Future<typename std::result_of<F(T)>>> map(std::vector<Future<T>> const& what, F const& func)
+std::vector<Future<typename std::invoke_result<F, T>>> map(std::vector<Future<T>> const& what, F const& func)
 {
-	std::vector<Future<typename std::result_of<F(T)>>> ret;
+	std::vector<Future<typename std::invoke_result<F, T>>> ret;
 	for(auto f : what)
 		ret.push_back(map( f, func ));
 	return ret;
@@ -378,7 +378,7 @@ std::vector<Future<typename std::result_of<F(T)>>> map(std::vector<Future<T>> co
 
 //maps a stream
 ACTOR template<class T, class F>
-Future<Void> map( FutureStream<T> input, F func, PromiseStream<typename std::result_of<F(T)>> output )
+Future<Void> map( FutureStream<T> input, F func, PromiseStream<typename std::invoke_result<F, T>> output )
 {
 	loop {
 		try {

--- a/flow/genericactors.actor.h
+++ b/flow/genericactors.actor.h
@@ -368,9 +368,9 @@ Future<std::invoke_result_t<F, T>> map(Future<T> what, F func)
 
 //maps a vector of futures
 template<class T, class F>
-std::vector<Future<std::invoke_result<F, T>>> map(std::vector<Future<T>> const& what, F const& func)
+std::vector<Future<std::invoke_result_t<F, T>>> map(std::vector<Future<T>> const& what, F const& func)
 {
-	std::vector<Future<std::invoke_result<F, T>>> ret;
+	std::vector<Future<std::invoke_result_t<F, T>>> ret;
 	for(auto f : what)
 		ret.push_back(map( f, func ));
 	return ret;
@@ -378,7 +378,7 @@ std::vector<Future<std::invoke_result<F, T>>> map(std::vector<Future<T>> const& 
 
 //maps a stream
 ACTOR template<class T, class F>
-Future<Void> map( FutureStream<T> input, F func, PromiseStream<std::invoke_result<F, T>> output )
+Future<Void> map( FutureStream<T> input, F func, PromiseStream<std::invoke_result_t<F, T>> output )
 {
 	loop {
 		try {

--- a/flow/genericactors.actor.h
+++ b/flow/genericactors.actor.h
@@ -309,9 +309,9 @@ Future<U> mapAsync(Future<T> what, F actorFunc)
 
 //maps a vector of futures with an asynchronous function
 template<class T, class F>
-std::vector<Future<decltype(actorFunc(T()).getValue())>> mapAsync(std::vector<Future<T>> const& what, F const& actorFunc)
+std::vector<Future<std::invoke_result_t<F, T>>> mapAsync(std::vector<Future<T>> const& what, F const& actorFunc)
 {
-	std::vector<typename std::invoke_result<F(T)>::type> ret;
+	std::vector<std::invoke_result_t<F, T>> ret;
 	for(auto f : what)
 		ret.push_back(mapAsync( f, actorFunc ));
 	return ret;
@@ -360,7 +360,7 @@ Future<Void> mapAsync( FutureStream<T> input, F actorFunc, PromiseStream<U> outp
 
 //Waits for a future to be ready, and then applies a function to it.
 ACTOR template<class T, class F>
-Future<typename std::invoke_result<F, T>> map(Future<T> what, F func)
+Future<std::invoke_result_t<F, T>> map(Future<T> what, F func)
 {
 	T val = wait(what);
 	return func(val);
@@ -368,9 +368,9 @@ Future<typename std::invoke_result<F, T>> map(Future<T> what, F func)
 
 //maps a vector of futures
 template<class T, class F>
-std::vector<Future<typename std::invoke_result<F, T>>> map(std::vector<Future<T>> const& what, F const& func)
+std::vector<Future<std::invoke_result<F, T>>> map(std::vector<Future<T>> const& what, F const& func)
 {
-	std::vector<Future<typename std::invoke_result<F, T>>> ret;
+	std::vector<Future<std::invoke_result<F, T>>> ret;
 	for(auto f : what)
 		ret.push_back(map( f, func ));
 	return ret;
@@ -378,7 +378,7 @@ std::vector<Future<typename std::invoke_result<F, T>>> map(std::vector<Future<T>
 
 //maps a stream
 ACTOR template<class T, class F>
-Future<Void> map( FutureStream<T> input, F func, PromiseStream<typename std::invoke_result<F, T>> output )
+Future<Void> map( FutureStream<T> input, F func, PromiseStream<std::invoke_result<F, T>> output )
 {
 	loop {
 		try {


### PR DESCRIPTION
std::result_of is deprecated in C++17. And some other improvements.

This is for #1255 

