### PR TITLE
Suppress warnings for clang on Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,10 @@ ifeq ($(PLATFORM),Linux)
   CC ?= gcc
   CXX ?= g++
 
+  ifneq '' '$(findstring clang++,$(CXX))'
+    CXXFLAGS += -Wno-undefined-var-template -Wno-unknown-warning-option -Wno-unused-command-line-argument
+  endif
+
   CXXFLAGS += -std=c++17
 
   BOOST_BASEDIR ?= /opt


### PR DESCRIPTION
Add `-Wno-undefined-var-template` and `-Wno-unknown-warning-option` flags to be consistent with `cmake` and Darwin `clang` flags. Otherwise, Linux clang can generate spurious errors.