### PR TITLE
Prefetch B-Tree cells in sqlite3BtreeMovetoUnpacked() to reduce cache misses

### DIFF
--- a/fdbserver/sqlite/btree.c
+++ b/fdbserver/sqlite/btree.c
@@ -4570,6 +4570,13 @@ SQLITE_PRIVATE int sqlite3BtreeMovetoUnpacked(
 
       pCur->info.nSize = 0;
       pCell = findCell(pPage, idx) + pPage->childPtrSize;
+
+#if defined(__GNUC__) && defined(__linux__)
+      /* prefetch the next possible cells */
+      __builtin_prefetch(findCell(pPage, (u16)(((idx+1)+upr)/2)) + pPage->childPtrSize); /* c < 0 */
+      __builtin_prefetch(findCell(pPage, (u16)((lwr+(idx-1))/2)) + pPage->childPtrSize); /* c > 0 */
+#endif
+
       if( pPage->intKey ){
         i64 nCellKey;
         if( pPage->hasData ){


### PR DESCRIPTION
Our internal benchmark showed that the storage server spends 12.4% of its time in sqlite3BtreeMovetoUnpacked() for GET only workload.
Out of 12.4%, significant time is spent to load the pCell from memory.

```
  Overhead  Command    Shared Object       Symbol
+   12.41%  fdbserver  fdbserver           [.] sqlite3BtreeMovetoUnpacked
+    7.39%  fdbserver  libc-2.12.so        [.] __swapcontext
+    7.22%  fdbserver  fdbserver           [.] std::_Hashtable<long, std::pair<long const, AFCPage*>, std::allocator<std::pair<long const, AFCPage*> >, std::__detail::_Select1st, std::equal_to<long>, std::hash<long>, std::__detail::_Mod_range_hashing, std::__de
+    5.59%  fdbserver  fdbserver           [.] AsyncFileCached::readZeroCopy
+    4.92%  fdbserver  fdbserver           [.] btreeInitPage.part.265
```
This PR enables prefetching the next possible cells into the CPU cache in advance in order to reduce the cache-miss overhead.

Here's the perf diff with the change for the same internal benchmark.
```
# Baseline  Delta Abs  Shared Object       Symbol
# ........  .........  ..................  ..........................................................................................................................................................................................................................
#
    12.41%     -5.52%  fdbserver           [.] sqlite3BtreeMovetoUnpacked
     2.22%     +1.12%  libc-2.12.so        [.] __memcmp_sse4_1
     7.22%     +0.49%  fdbserver           [.] std::_Hashtable<long, std::pair<long const, AFCPage*>, std::allocator<std::pair<long const, AFCPage*> >, std::__detail::_Select1st, std::equal_to<long>, std::hash<long>, std::__detail::_Mod_range_hashing, std::__de
     7.39%     +0.45%  libc-2.12.so        [.] __swapcontext
     4.92%     +0.38%  fdbserver           [.] btreeInitPage.part.265
```

Using Mako workload (g16), we verified that this change reduces the storage server CPU by 5%.  In other words, it increases the peak throughput of each storage server by 5%.

Mako Workload g16 |   |   |  
-- | -- | -- | --
Iterations | 7d7cd5e | 7d7cd5e + Prefetch |  
1 | 275218.0 | 289767.0 |  
2 | 274203.0 | 286268.0 |  
3 | 273132.0 | 288103.0 |  
Average | 274184.3 | 288046.0 | 5.06%

Mako test specification used for this:
```
testTitle=MakoTest
testName=Mako
testDuration=60.0
rows=10000000
sampleSize=1000
keyBytes=32
valueBytes=16
operations=g16
actorCountPerClient=256
enableLogging=false
commitGet=false
populateData=false
runBenchmark=true
preserveData=true
```