### PR TITLE
the master checks the popped version of the txsTag before recovering the txnStateStore

### DIFF
--- a/fdbserver/LogSystem.h
+++ b/fdbserver/LogSystem.h
@@ -662,6 +662,8 @@ struct ILogSystem {
 	virtual Reference<IPeekCursor> peekTxs( UID dbgid, Version begin, int8_t peekLocality, Version localEnd, bool canDiscardPopped ) = 0;
 		// Same contract as peek(), but only for peeking the txsLocality. It allows specifying a preferred peek locality.
 
+	virtual Future<Version> getTxsPoppedVersion() = 0;
+
 	virtual Version getKnownCommittedVersion() = 0;
 
 	virtual Future<Void> onKnownCommittedVersionChange() = 0;

--- a/fdbserver/LogSystemDiskQueueAdapter.actor.cpp
+++ b/fdbserver/LogSystemDiskQueueAdapter.actor.cpp
@@ -194,6 +194,6 @@ Future<LogSystemDiskQueueAdapter::CommitMessage> LogSystemDiskQueueAdapter::getC
 	return pcm.getFuture();
 }
 
-LogSystemDiskQueueAdapter* openDiskQueueAdapter( Reference<ILogSystem> logSystem, Reference<AsyncVar<PeekTxsInfo>> peekLocality ) {
-	return new LogSystemDiskQueueAdapter( logSystem, peekLocality );
+LogSystemDiskQueueAdapter* openDiskQueueAdapter( Reference<ILogSystem> logSystem, Reference<AsyncVar<PeekTxsInfo>> peekLocality, Version txsPoppedVersion ) {
+	return new LogSystemDiskQueueAdapter( logSystem, peekLocality, txsPoppedVersion, true );
 }

--- a/fdbserver/LogSystemDiskQueueAdapter.h
+++ b/fdbserver/LogSystemDiskQueueAdapter.h
@@ -52,10 +52,10 @@ public:
 
 	// It does, however, peek the specified tag directly at recovery time.
 
-	LogSystemDiskQueueAdapter( Reference<ILogSystem> logSystem, Reference<AsyncVar<PeekTxsInfo>> peekLocality, bool recover=true ) : logSystem(logSystem), peekLocality(peekLocality), enableRecovery(recover), recoveryLoc(1), recoveryQueueLoc(1), poppedUpTo(0), nextCommit(1), recoveryQueueDataSize(0), peekTypeSwitches(0), hasDiscardedData(false), totalRecoveredBytes(0) {
+	LogSystemDiskQueueAdapter( Reference<ILogSystem> logSystem, Reference<AsyncVar<PeekTxsInfo>> peekLocality, Version txsPoppedVersion, bool recover ) : logSystem(logSystem), peekLocality(peekLocality), enableRecovery(recover), recoveryLoc(txsPoppedVersion), recoveryQueueLoc(txsPoppedVersion), poppedUpTo(0), nextCommit(1), recoveryQueueDataSize(0), peekTypeSwitches(0), hasDiscardedData(false), totalRecoveredBytes(0) {
 		if (enableRecovery) {
 			localityChanged = peekLocality ? peekLocality->onChange() : Never();
-			cursor = logSystem->peekTxs( UID(), 1, peekLocality ? peekLocality->get().primaryLocality : tagLocalityInvalid, peekLocality ? peekLocality->get().knownCommittedVersion : invalidVersion, true );
+			cursor = logSystem->peekTxs( UID(), txsPoppedVersion, peekLocality ? peekLocality->get().primaryLocality : tagLocalityInvalid, peekLocality ? peekLocality->get().knownCommittedVersion : invalidVersion, true );
 		}
 	}
 
@@ -115,6 +115,6 @@ private:
 	friend class LogSystemDiskQueueAdapterImpl;
 };
 
-LogSystemDiskQueueAdapter* openDiskQueueAdapter( Reference<ILogSystem> logSystem, Reference<AsyncVar<PeekTxsInfo>> peekLocality );
+LogSystemDiskQueueAdapter* openDiskQueueAdapter( Reference<ILogSystem> logSystem, Reference<AsyncVar<PeekTxsInfo>> peekLocality, Version txsPoppedVersion );
 
 #endif

--- a/fdbserver/MasterProxyServer.actor.cpp
+++ b/fdbserver/MasterProxyServer.actor.cpp
@@ -1576,7 +1576,7 @@ ACTOR Future<Void> masterProxyServerCore(
 		r->value().emplace_back(0,0);
 
 	commitData.logSystem = ILogSystem::fromServerDBInfo(proxy.id(), commitData.db->get(), false, addActor);
-	commitData.logAdapter = new LogSystemDiskQueueAdapter(commitData.logSystem, Reference<AsyncVar<PeekTxsInfo>>(), false);
+	commitData.logAdapter = new LogSystemDiskQueueAdapter(commitData.logSystem, Reference<AsyncVar<PeekTxsInfo>>(), 1, false);
 	commitData.txnStateStore = keyValueStoreLogSystem(commitData.logAdapter, proxy.id(), 2e9, true, true, true);
 	createWhitelistBinPathVec(whitelistBinPaths, commitData.whitelistedBinPathVec);
 

--- a/fdbserver/OldTLogServer_4_6.actor.cpp
+++ b/fdbserver/OldTLogServer_4_6.actor.cpp
@@ -906,6 +906,41 @@ namespace oldTLog_4_6 {
 
 		state Version endVersion = logData->version.get() + 1;
 
+		Version poppedVer = poppedVersion(logData, oldTag);
+		if(poppedVer > req.begin) {
+			TLogPeekReply rep;
+			rep.maxKnownVersion = logData->version.get();
+			rep.minKnownCommittedVersion = 0;
+			rep.popped = poppedVer;
+			rep.end = poppedVer;
+			rep.onlySpilled = false;
+
+			if(req.sequence.present()) {
+				auto& trackerData = self->peekTracker[peekId];
+				auto& sequenceData = trackerData.sequence_version[sequence+1];
+				trackerData.lastUpdate = now();
+				if(trackerData.sequence_version.size() && sequence+1 < trackerData.sequence_version.begin()->first) {
+					req.reply.sendError(timed_out());
+					if (!sequenceData.isSet())
+						sequenceData.sendError(timed_out());
+					return Void();
+				}
+				if(sequenceData.isSet()) {
+					if(sequenceData.getFuture().get() != rep.end) {
+						TEST(true); //tlog peek second attempt ended at a different version
+						req.reply.sendError(timed_out());
+						return Void();
+					}
+				} else {
+					sequenceData.send(rep.end);
+				}
+				rep.begin = req.begin;
+			}
+
+			req.reply.send( rep );
+			return Void();
+		}
+
 		//grab messages from disk
 		//TraceEvent("TLogPeekMessages", self->dbgid).detail("ReqBeginEpoch", req.begin.epoch).detail("ReqBeginSeq", req.begin.sequence).detail("Epoch", self->epoch()).detail("PersistentDataSeq", self->persistentDataSequence).detail("Tag1", req.tag1).detail("Tag2", req.tag2);
 		if( req.begin <= logData->persistentDataDurableVersion ) {
@@ -948,19 +983,13 @@ namespace oldTLog_4_6 {
 			//TraceEvent("TLogPeekResults", self->dbgid).detail("ForAddress", req.reply.getEndpoint().getPrimaryAddress()).detail("MessageBytes", messages.getLength()).detail("NextEpoch", next_pos.epoch).detail("NextSeq", next_pos.sequence).detail("NowSeq", self->sequence.getNextSequence());
 		}
 
-		Version poppedVer = poppedVersion(logData, oldTag);
-
 		TLogPeekReply reply;
 		reply.maxKnownVersion = logData->version.get();
 		reply.minKnownCommittedVersion = 0;
 		reply.onlySpilled = false;
-		if(poppedVer > req.begin) {
-			reply.popped = poppedVer;
-			reply.end = poppedVer;
-		} else {
-			reply.messages = messages.toValue();
-			reply.end = endVersion;
-		}
+		reply.messages = messages.toValue();
+		reply.end = endVersion;
+
 		//TraceEvent("TlogPeek", self->dbgid).detail("LogId", logData->logId).detail("EndVer", reply.end).detail("MsgBytes", reply.messages.expectedSize()).detail("ForAddress", req.reply.getEndpoint().getPrimaryAddress());
 
 		if(req.sequence.present()) {

--- a/fdbserver/TagPartitionedLogSystem.actor.cpp
+++ b/fdbserver/TagPartitionedLogSystem.actor.cpp
@@ -1056,6 +1056,60 @@ struct TagPartitionedLogSystem : ILogSystem, ReferenceCounted<TagPartitionedLogS
 		}
 	}
 
+	ACTOR static Future<Version> getPoppedFromTLog( Reference<AsyncVar<OptionalInterface<TLogInterface>>> log, Tag tag ) {
+		loop {
+			choose {
+				when( TLogPeekReply rep = wait( log->get().present() ? brokenPromiseToNever(log->get().interf().peekMessages.getReply(TLogPeekRequest(-1, tag, false, false))) : Never() ) ) {
+					ASSERT(rep.popped.present());
+					return rep.popped.get();
+				}
+				when( wait( log->onChange() ) ) {}
+			}
+		}
+	}
+
+	ACTOR static Future<Version> getPoppedTxs(TagPartitionedLogSystem* self) {
+		state std::vector<std::vector<Future<Version>>> poppedFutures;
+		state std::vector<Future<Void>> poppedReady;
+		if(self->tLogs.size()) {
+			poppedFutures.push_back( std::vector<Future<Version>>() );
+			for(auto& it : self->tLogs) {
+				for(auto& log : it->logServers) {
+					poppedFutures.back().push_back(getPoppedFromTLog(log, self->tLogs[0]->tLogVersion < TLogVersion::V4 ? txsTag : Tag(tagLocalityTxs, 0)));
+				}
+			}
+			poppedReady.push_back(waitForAny(poppedFutures.back()));
+		}
+
+		for(auto& old : self->oldLogData) {
+			if(old.tLogs.size()) {
+				poppedFutures.push_back( std::vector<Future<Version>>() );
+				for(auto& it : old.tLogs) {
+					for(auto& log : it->logServers) {
+						poppedFutures.back().push_back(getPoppedFromTLog(log, old.tLogs[0]->tLogVersion < TLogVersion::V4 ? txsTag : Tag(tagLocalityTxs, 0)));
+					}
+				}
+				poppedReady.push_back(waitForAny(poppedFutures.back()));
+			}
+		}
+
+		wait( waitForAll(poppedReady) );
+		
+		Version maxPopped = 1;
+		for(auto &it : poppedFutures) {
+			for(auto &v : it) {
+				if(v.isReady()) {
+					maxPopped = std::max(maxPopped, v.get());
+				}
+			}
+		}
+		return maxPopped;
+	}
+
+	virtual Future<Version> getTxsPoppedVersion() {
+		return getPoppedTxs(this);
+	}
+
 	ACTOR static Future<Void> confirmEpochLive_internal(Reference<LogSet> logSet, Optional<UID> debugID) {
 		state vector<Future<Void>> alive;
 		int numPresent = 0;


### PR DESCRIPTION
… to avoid restoring data that is later found to be popped