### PR TITLE
fix: Use getReply* instead of tryGetReply in `monitorProxies`

### DIFF
--- a/fdbclient/MonitorLeader.actor.cpp
+++ b/fdbclient/MonitorLeader.actor.cpp
@@ -709,7 +709,8 @@ ACTOR Future<MonitorLeaderInfo> monitorProxiesOneGeneration( Reference<ClusterCo
 			incorrectTime = Optional<double>();
 		}
 
-		state ErrorOr<ClientDBInfo> rep = wait( clientLeaderServer.openDatabase.tryGetReply( req, TaskPriority::CoordinationReply ) );
+		state ErrorOr<ClientDBInfo> rep =
+		    wait(clientLeaderServer.openDatabase.getReplyUnlessFailedFor(req, 0, 0, TaskPriority::CoordinationReply));
 		if (rep.present()) {
 			if( rep.get().forward.present() ) {
 				TraceEvent("MonitorProxiesForwarding").detail("NewConnStr", rep.get().forward.get().toString()).detail("OldConnStr", info.intermediateConnFile->getConnectionString().toString());


### PR DESCRIPTION
`tryGetReply` is unreliable, and since `monitorProxies` expects reply
after long period, the connection to coordinator gets closed due to
idle timeout, only to get reopened again in next loop to make
`openDatabase` request.

When using `getReply` our reliable message queue won't be empty and
connection will stay open.