### PR TITLE
Add comment to explain why server ping incompatible clients

### DIFF
--- a/fdbrpc/FlowTransport.actor.cpp
+++ b/fdbrpc/FlowTransport.actor.cpp
@@ -296,6 +296,8 @@ ACTOR Future<Void> connectionMonitor( Reference<Peer> peer ) {
 	loop {
 		if (!FlowTransport::transport().isClient() && !peer->destination.isPublic() && peer->compatible) {
 			// Don't send ping messages to clients unless necessary. Instead monitor incoming client pings.
+			// We ignore this block for incompatible clients because pings from server would trigger the
+			// peer->resetPing and prevent 'connection_failed' due to ping timeout.
 			state double lastRefreshed = now();
 			state int64_t lastBytesReceived = peer->bytesReceived;
 			loop {


### PR DESCRIPTION
If client is incompatible, connectionMonitor relies on peer->resetPing
to be triggered whenever data is received to prevent ping timeout.
The server stopped sending pings since 6.2 which meant resetPing
doesn't get triggered.