### PR TITLE
improved error msgs for snapshot cmd

### DIFF
--- a/fdbclient/DatabaseContext.h
+++ b/fdbclient/DatabaseContext.h
@@ -172,7 +172,6 @@ public:
 	Counter transactionsMaybeCommitted;
 	Counter transactionsResourceConstrained;
 	Counter transactionsProcessBehind;
-	Counter transactionWaitsForFullRecovery;
 
 	ContinuousSample<double> latencies, readLatencies, commitLatencies, GRVLatencies, mutationsPerCommit, bytesPerCommit;
 

--- a/fdbserver/MasterProxyServer.actor.cpp
+++ b/fdbserver/MasterProxyServer.actor.cpp
@@ -1466,7 +1466,7 @@ ACTOR Future<Void> proxySnapCreate(ProxySnapRequest snapReq, ProxyCommitData* co
 			TraceEvent("SnapMasterProxy_WhiteListCheckFailed")
 				.detail("SnapPayload", snapReq.snapPayload)
 				.detail("SnapUID", snapReq.snapUID);
-			throw transaction_not_permitted();
+			throw snap_path_not_whitelisted();
 		}
 		// db fully recovered check
 		if (commitData->db->get().recoveryState != RecoveryState::FULLY_RECOVERED)  {
@@ -1478,7 +1478,7 @@ ACTOR Future<Void> proxySnapCreate(ProxySnapRequest snapReq, ProxyCommitData* co
 			TraceEvent("SnapMasterProxy_ClusterNotFullyRecovered")
 				.detail("SnapPayload", snapReq.snapPayload)
 				.detail("SnapUID", snapReq.snapUID);
-			throw cluster_not_fully_recovered();
+			throw snap_not_fully_recovered_unsupported();
 		}
 
 		auto result =
@@ -1493,7 +1493,7 @@ ACTOR Future<Void> proxySnapCreate(ProxySnapRequest snapReq, ProxyCommitData* co
 			TraceEvent("SnapMasterProxy_LogAnitQuorumNotSupported")
 				.detail("SnapPayload", snapReq.snapPayload)
 				.detail("SnapUID", snapReq.snapUID);
-			throw txn_exec_log_anti_quorum();
+			throw snap_log_anti_quorum_unsupported();
 		}
 
 		// send a snap request to DD

--- a/fdbserver/workloads/SnapTest.actor.cpp
+++ b/fdbserver/workloads/SnapTest.actor.cpp
@@ -211,7 +211,7 @@ public: // workload functions
 					wait(status);
 					break;
 				} catch (Error& e) {
-					if (e.code() == error_code_txn_exec_log_anti_quorum) {
+					if (e.code() == error_code_snap_log_anti_quorum_unsupported) {
 						snapFailed = true;
 						break;
 					}
@@ -298,12 +298,12 @@ public: // workload functions
 					wait(status);
 					break;
 				} catch (Error& e) {
-					if (e.code() == error_code_cluster_not_fully_recovered ||
-						e.code() == error_code_txn_exec_log_anti_quorum) {
+					if (e.code() == error_code_snap_not_fully_recovered_unsupported ||
+						e.code() == error_code_snap_log_anti_quorum_unsupported) {
 						snapFailed = true;
 						break;
 					}
-					if (e.code() == error_code_transaction_not_permitted) {
+					if (e.code() == error_code_snap_path_not_whitelisted) {
 						testedFailure = true;
 						break;
 					}

--- a/flow/error_definitions.h
+++ b/flow/error_definitions.h
@@ -65,9 +65,6 @@ ERROR( lookup_failed, 1041, "DNS lookup failed" )
 ERROR( proxy_memory_limit_exceeded, 1042, "Proxy commit memory limit exceeded" )
 ERROR( shutdown_in_progress, 1043, "Operation no longer supported due to shutdown" )
 ERROR( serialization_failed, 1044, "Failed to deserialize an object" )
-ERROR( transaction_not_permitted, 1045, "Operation not permitted")
-ERROR( cluster_not_fully_recovered, 1046, "Cluster not fully recovered")
-ERROR( txn_exec_log_anti_quorum, 1047, "Execute Transaction not supported when log anti quorum is configured")
 ERROR( connection_unreferenced, 1048, "No peer references for connection" )
 ERROR( connection_idle, 1049, "Connection closed after idle timeout" )
 ERROR( disk_adapter_reset, 1050, "The disk queue adpater reset" )
@@ -205,6 +202,17 @@ ERROR( task_interrupted, 2382, "Task execution stopped due to timeout, abort, or
 ERROR( key_not_found, 2400, "Expected key is missing")
 ERROR( json_malformed, 2401, "JSON string was malformed")
 ERROR( json_eof_expected, 2402, "JSON string did not terminate where expected")
+
+// 2500 - disk snapshot based backup errors
+ERROR( snap_disable_tlog_pop_failed,  2500, "Snapshot error")
+ERROR( snap_storage_failed,  2501, "Failed to snapshot storage nodes")
+ERROR( snap_tlog_failed,  2502, "Failed to snapshot TLog nodes")
+ERROR( snap_coord_failed,  2503, "Failed to snapshot coordinator nodes")
+ERROR( snap_enable_tlog_pop_failed,  2504, "Snapshot error")
+ERROR( snap_path_not_whitelisted, 2505, "Snapshot create binary path not whitelisted")
+ERROR( snap_not_fully_recovered_unsupported, 2506, "Unsupported when the cluster is not fully recovered")
+ERROR( snap_log_anti_quorum_unsupported, 2507, "Unsupported when log anti quorum is configured")
+ERROR( snap_with_recovery_unsupported, 2508, "Cluster recovery during snapshot operation not supported")
 
 // 4xxx Internal errors (those that should be generated only by bugs) are decimal 4xxx
 ERROR( unknown_error, 4000, "An unknown error occurred" )  // C++ exception not of type Error

--- a/flow/error_definitions.h
+++ b/flow/error_definitions.h
@@ -204,11 +204,11 @@ ERROR( json_malformed, 2401, "JSON string was malformed")
 ERROR( json_eof_expected, 2402, "JSON string did not terminate where expected")
 
 // 2500 - disk snapshot based backup errors
-ERROR( snap_disable_tlog_pop_failed,  2500, "Snapshot error")
+ERROR( snap_disable_tlog_pop_failed,  2500, "Disk Snapshot error")
 ERROR( snap_storage_failed,  2501, "Failed to snapshot storage nodes")
 ERROR( snap_tlog_failed,  2502, "Failed to snapshot TLog nodes")
 ERROR( snap_coord_failed,  2503, "Failed to snapshot coordinator nodes")
-ERROR( snap_enable_tlog_pop_failed,  2504, "Snapshot error")
+ERROR( snap_enable_tlog_pop_failed,  2504, "Disk Snapshot error")
 ERROR( snap_path_not_whitelisted, 2505, "Snapshot create binary path not whitelisted")
 ERROR( snap_not_fully_recovered_unsupported, 2506, "Unsupported when the cluster is not fully recovered")
 ERROR( snap_log_anti_quorum_unsupported, 2507, "Unsupported when log anti quorum is configured")


### PR DESCRIPTION
Many snapshot failures are marked with the same error code of operation_failed() which gives very little information about where the command really failed.

In this PR:
- introduced specific error codes that reflects where the snapshot command failed
- reworded error codes to remove the snap v1 history
- enable tlog pop in snapshot failure cases so that the subsequent snapshot command need not wait for the timeout to enable popping of the tlogs