### PR TITLE
fix fdbcli --exec 'snapshot create.sh' failure

### DIFF
--- a/fdbcli/fdbcli.actor.cpp
+++ b/fdbcli/fdbcli.actor.cpp
@@ -2199,7 +2199,14 @@ ACTOR Future<bool> exclude( Database db, std::vector<StringRef> tokens, Referenc
 	}
 }
 
-ACTOR Future<bool> createSnapshot(Database db, StringRef snapCmd) {
+ACTOR Future<bool> createSnapshot(Database db, std::vector<StringRef> tokens ) {
+	state Standalone<StringRef> snapCmd;
+	for ( int i = 1; i < tokens.size(); i++) {
+		snapCmd = snapCmd.withSuffix(tokens[i]);
+		if (i != tokens.size() - 1) {
+			snapCmd = snapCmd.withSuffix(LiteralStringRef(" "));
+		}
+	}
 	try {
 		UID snapUID = wait(makeInterruptable(mgmtSnapCreate(db, snapCmd)));
 		printf("Snapshot command succeeded with UID %s\n", snapUID.toString().c_str());
@@ -2815,11 +2822,11 @@ ACTOR Future<int> cli(CLIOptions opt, LineNoise* plinenoise) {
 				}
 
 				if (tokencmp(tokens[0], "snapshot")) {
-					if (tokens.size() != 2) {
+					if (tokens.size() < 2) {
 						printUsage(tokens[0]);
 						is_error = true;
 					} else {
-						bool err = wait(createSnapshot(db, tokens[1]));
+						bool err = wait(createSnapshot(db, tokens));
 						if (err) is_error = true;
 					}
 					continue;

--- a/fdbclient/ManagementAPI.actor.cpp
+++ b/fdbclient/ManagementAPI.actor.cpp
@@ -1576,7 +1576,7 @@ ACTOR Future<std::set<NetworkAddress>> checkForExcludingServers(Database cx, vec
 	return inProgressExclusion;
 }
 
-ACTOR Future<UID> mgmtSnapCreate(Database cx, StringRef snapCmd) {
+ACTOR Future<UID> mgmtSnapCreate(Database cx, Standalone<StringRef> snapCmd) {
 	state UID snapUID = deterministicRandom()->randomUniqueID();
 	try {
 		wait(snapCreate(cx, snapCmd, snapUID));

--- a/fdbclient/ManagementAPI.actor.h
+++ b/fdbclient/ManagementAPI.actor.h
@@ -197,7 +197,7 @@ bool schemaMatch( json_spirit::mValue const& schema, json_spirit::mValue const& 
 
 // execute payload in 'snapCmd' on all the coordinators, TLogs and
 // storage nodes
-ACTOR Future<UID> mgmtSnapCreate(Database cx, StringRef snapCmd);
+ACTOR Future<UID> mgmtSnapCreate(Database cx, Standalone<StringRef> snapCmd);
 
 #include "flow/unactorcompiler.h"
 #endif

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -3348,54 +3348,32 @@ void enableClientInfoLogging() {
 	TraceEvent(SevInfo, "ClientInfoLoggingEnabled");
 }
 
-ACTOR Future<Void> snapshotDatabase(Reference<DatabaseContext> cx, StringRef snapPayload, UID snapUID, Optional<UID> debugID) {
-	TraceEvent("SnapshotDatabaseEnter")
-		.detail("SnapPayload", snapPayload)
-		.detail("SnapUID", snapUID);
-	try {
-		if (debugID.present()) {
-			g_traceBatch.addEvent("TransactionDebug", debugID.get().first(), "NativeAPI.snapshotDatabase.Before");
-		}
-
-		choose {
-			when(wait(cx->onMasterProxiesChanged())) { throw operation_failed(); }
-			when(wait(loadBalance(cx->getMasterProxies(false), &MasterProxyInterface::proxySnapReq, ProxySnapRequest(snapPayload, snapUID, debugID), cx->taskID, true /*atmostOnce*/ ))) {
-				if (debugID.present())
-					g_traceBatch.addEvent("TransactionDebug", debugID.get().first(),
-											"NativeAPI.SnapshotDatabase.After");
-			}
-		}
-	} catch (Error& e) {
-		TraceEvent("SnapshotDatabaseError")
-			.error(e)
-			.detail("SnapPayload", snapPayload)
-			.detail("SnapUID", snapUID);
-		throw;
-	}
-	return Void();
-}
-
 ACTOR Future<Void> snapCreate(Database cx, StringRef snapCmd, UID snapUID) {
-	// remember the client ID before the snap operation
-	state UID preSnapClientUID = cx->clientInfo->get().id;
-
 	TraceEvent("SnapCreateEnter")
 	    .detail("SnapCmd", snapCmd.toString())
-	    .detail("UID", snapUID)
-	    .detail("PreSnapClientUID", preSnapClientUID);
+	    .detail("UID", snapUID);
 
 	StringRef snapCmdArgs = snapCmd;
 	StringRef snapCmdPart = snapCmdArgs.eat(":");
 	Standalone<StringRef> snapUIDRef(snapUID.toString());
-	Standalone<StringRef> snapPayloadRef = snapCmdPart
+	state Standalone<StringRef> snapPayloadRef = snapCmdPart
 		.withSuffix(LiteralStringRef(":uid="))
 		.withSuffix(snapUIDRef)
 		.withSuffix(LiteralStringRef(","))
 		.withSuffix(snapCmdArgs);
 
 	try {
-		Future<Void> exec = snapshotDatabase(Reference<DatabaseContext>::addRef(cx.getPtr()), snapPayloadRef, snapUID, snapUID);
-		wait(exec);
+		loop {
+			choose {
+				when(wait(cx->onMasterProxiesChanged())) {}
+				when(wait(loadBalance(cx->getMasterProxies(false), &MasterProxyInterface::proxySnapReq, ProxySnapRequest(snapPayloadRef, snapUID, snapUID), cx->taskID, true /*atmostOnce*/ ))) {
+					TraceEvent("SnapCreateExit")
+						.detail("SnapCmd", snapCmd.toString())
+						.detail("UID", snapUID);
+					return Void();
+				}
+			}
+		}
 	} catch (Error& e) {
 		TraceEvent("SnapCreateError")
 			.detail("SnapCmd", snapCmd.toString())
@@ -3403,19 +3381,4 @@ ACTOR Future<Void> snapCreate(Database cx, StringRef snapCmd, UID snapUID) {
 			.error(e);
 		throw;
 	}
-
-	UID postSnapClientUID = cx->clientInfo->get().id;
-	if (preSnapClientUID != postSnapClientUID) {
-		// if the client IDs changed then we fail the snapshot
-		TraceEvent("SnapCreateUIDMismatch")
-		    .detail("SnapPreSnapClientUID", preSnapClientUID)
-		    .detail("SnapPostSnapClientUID", postSnapClientUID);
-		throw coordinators_changed();
-	}
-
-	TraceEvent("SnapCreateExit")
-	    .detail("SnapCmd", snapCmd.toString())
-	    .detail("UID", snapUID)
-	    .detail("PreSnapClientUID", preSnapClientUID);
-	return Void();
 }

--- a/fdbclient/NativeAPI.actor.h
+++ b/fdbclient/NativeAPI.actor.h
@@ -310,7 +310,7 @@ int64_t extractIntOption( Optional<StringRef> value, int64_t minValue = std::num
 
 // Takes a snapshot of the cluster, specifically the following persistent
 // states: coordinator, TLog and storage state
-ACTOR Future<Void> snapCreate(Database cx, StringRef snapCmd, UID snapUID);
+ACTOR Future<Void> snapCreate(Database cx, Standalone<StringRef> snapCmd, UID snapUID);
 
 #include "flow/unactorcompiler.h"
 #endif

--- a/fdbserver/FDBExecHelper.actor.cpp
+++ b/fdbserver/FDBExecHelper.actor.cpp
@@ -21,7 +21,6 @@ ExecCmdValueString::ExecCmdValueString(StringRef pCmdValueString) {
 void ExecCmdValueString::setCmdValueString(StringRef pCmdValueString) {
 	// reset everything
 	binaryPath = StringRef();
-	keyValueMap.clear();
 
 	// set the new cmdValueString
 	cmdValueString = pCmdValueString;
@@ -42,18 +41,10 @@ VectorRef<StringRef> ExecCmdValueString::getBinaryArgs() {
 	return binaryArgs;
 }
 
-StringRef ExecCmdValueString::getBinaryArgValue(StringRef key) {
-	StringRef res;
-	if (keyValueMap.find(key) != keyValueMap.end()) {
-		res = keyValueMap[key];
-	}
-	return res;
-}
-
 void ExecCmdValueString::parseCmdValue() {
 	StringRef param = this->cmdValueString;
 	// get the binary path
-	this->binaryPath = param.eat(LiteralStringRef(":"));
+	this->binaryPath = param.eat(LiteralStringRef(" "));
 
 	// no arguments provided
 	if (param == StringRef()) {
@@ -62,11 +53,8 @@ void ExecCmdValueString::parseCmdValue() {
 
 	// extract the arguments
 	while (param != StringRef()) {
-		StringRef token = param.eat(LiteralStringRef(","));
+		StringRef token = param.eat(LiteralStringRef(" "));
 		this->binaryArgs.push_back(this->binaryArgs.arena(), token);
-
-		StringRef key = token.eat(LiteralStringRef("="));
-		keyValueMap.insert(std::make_pair(key, token));
 	}
 	return;
 }
@@ -153,15 +141,14 @@ ACTOR Future<int> spawnProcess(std::string binPath, std::vector<std::string> par
 }
 #endif
 
-ACTOR Future<int> execHelper(ExecCmdValueString* execArg, std::string folder, std::string role) {
-	state StringRef uidStr = execArg->getBinaryArgValue(LiteralStringRef("uid"));
+ACTOR Future<int> execHelper(ExecCmdValueString* execArg, UID snapUID, std::string folder, std::string role) {
+	state Standalone<StringRef> uidStr = snapUID.toString();
 	state int err = 0;
 	state Future<int> cmdErr;
 	state double maxWaitTime = SERVER_KNOBS->SNAP_CREATE_MAX_TIMEOUT;
 	if (!g_network->isSimulated()) {
 		// get bin path
 		auto snapBin = execArg->getBinaryPath();
-		auto dataFolder = "path=" + folder;
 		std::vector<std::string> paramList;
 		paramList.push_back(snapBin.toString());
 		// get user passed arguments
@@ -170,12 +157,15 @@ ACTOR Future<int> execHelper(ExecCmdValueString* execArg, std::string folder, st
 			paramList.push_back(elem.toString());
 		}
 		// get additional arguments
-		paramList.push_back(dataFolder);
+		paramList.push_back("--path");
+		paramList.push_back(folder);
 		const char* version = FDB_VT_VERSION;
-		std::string versionString = "version=";
-		versionString += version;
-		paramList.push_back(versionString);
+		paramList.push_back("--version");
+		paramList.push_back(version);
+		paramList.push_back("--role");
 		paramList.push_back(role);
+		paramList.push_back("--uid");
+		paramList.push_back(uidStr.toString());
 		cmdErr = spawnProcess(snapBin.toString(), paramList, maxWaitTime, false /*isSync*/, 0);
 		wait(success(cmdErr));
 		err = cmdErr.get();

--- a/fdbserver/FDBExecHelper.actor.h
+++ b/fdbserver/FDBExecHelper.actor.h
@@ -27,7 +27,6 @@ public: // ctor & dtor
 public: // interfaces
 	StringRef getBinaryPath();
 	VectorRef<StringRef> getBinaryArgs();
-	StringRef getBinaryArgValue(StringRef key);
 	void setCmdValueString(StringRef cmdValueString);
 	StringRef getCmdValueString(void);
 
@@ -41,7 +40,6 @@ private: // data
 	Standalone<StringRef> cmdValueString;
 	Standalone<VectorRef<StringRef>> binaryArgs;
 	StringRef binaryPath;
-	std::map<StringRef, StringRef> keyValueMap;
 };
 
 // FIXME: move this function to a common location
@@ -52,7 +50,7 @@ private: // data
 ACTOR Future<int> spawnProcess(std::string binPath, std::vector<std::string> paramList, double maxWaitTime, bool isSync, double maxSimDelayTime);
 
 // helper to run all the work related to running the exec command
-ACTOR Future<int> execHelper(ExecCmdValueString* execArg, std::string folder, std::string role);
+ACTOR Future<int> execHelper(ExecCmdValueString* execArg, UID snapUID, std::string folder, std::string role);
 
 // returns true if the execUID op is in progress
 bool isExecOpInProgress(UID execUID);

--- a/fdbserver/OldTLogServer_6_0.actor.cpp
+++ b/fdbserver/OldTLogServer_6_0.actor.cpp
@@ -1556,8 +1556,7 @@ tLogSnapCreate(TLogSnapRequest snapReq, TLogData* self, Reference<LogData> logDa
 	}
 	ExecCmdValueString snapArg(snapReq.snapPayload);
 	try {
-		Standalone<StringRef> role = LiteralStringRef("role=").withSuffix(snapReq.role);
-		int err = wait(execHelper(&snapArg, self->dataFolder, role.toString()));
+		int err = wait(execHelper(&snapArg, snapReq.snapUID, self->dataFolder, snapReq.role.toString()));
 
 		std::string uidStr = snapReq.snapUID.toString();
 		TraceEvent("ExecTraceTLog")

--- a/fdbserver/TLogServer.actor.cpp
+++ b/fdbserver/TLogServer.actor.cpp
@@ -1933,8 +1933,7 @@ tLogSnapCreate(TLogSnapRequest snapReq, TLogData* self, Reference<LogData> logDa
 	}
 	ExecCmdValueString snapArg(snapReq.snapPayload);
 	try {
-		Standalone<StringRef> role = LiteralStringRef("role=").withSuffix(snapReq.role);
-		int err = wait(execHelper(&snapArg, self->dataFolder, role.toString()));
+		int err = wait(execHelper(&snapArg, snapReq.snapUID, self->dataFolder, snapReq.role.toString()));
 
 		std::string uidStr = snapReq.snapUID.toString();
 		TraceEvent("ExecTraceTLog")

--- a/fdbserver/worker.actor.cpp
+++ b/fdbserver/worker.actor.cpp
@@ -658,8 +658,7 @@ void endRole(const Role &role, UID id, std::string reason, bool ok, Error e) {
 ACTOR Future<Void> workerSnapCreate(WorkerSnapRequest snapReq, StringRef snapFolder) {
 	state ExecCmdValueString snapArg(snapReq.snapPayload);
 	try {
-		Standalone<StringRef> role = LiteralStringRef("role=").withSuffix(snapReq.role);
-		int err = wait(execHelper(&snapArg, snapFolder.toString(), role.toString()));
+		int err = wait(execHelper(&snapArg, snapReq.snapUID, snapFolder.toString(), snapReq.role.toString()));
 		std::string uidStr = snapReq.snapUID.toString();
 		TraceEvent("ExecTraceWorker")
 			.detail("Uid", uidStr)


### PR DESCRIPTION
snapshot command when invoked from command line like : fdbcli --exec 'snapshot create.sh' fails, because the client db info gets populated after snapshot is invoked. snapshot command monitors for change in client db info and uses that as a proxy for cluster recovery happening and fails the request. So, when invoked with --exec - snapshot command fails, because it assumes it detected a recovery.
This PR allows the snapshot commands to succeed when run via --exec or from inside the cli shell.

Additionally, snapshot binary script will take posix compliant arguments and not custom style arguments.

