### PR TITLE
Assert that version in versions.target and cmake are in sync

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@
 # limitations under the License.
 cmake_minimum_required(VERSION 3.12)
 project(foundationdb
-  VERSION 6.2.0
+  VERSION 6.2.4
   DESCRIPTION "FoundationDB is a scalable, fault-tolerant, ordered key-value store with full ACID transactions."
   HOMEPAGE_URL "http://www.foundationdb.org/"
   LANGUAGES C CXX ASM)
@@ -75,8 +75,7 @@ message(STATUS "Current git version ${CURRENT_GIT_VERSION}")
 # Version information
 ################################################################################
 
-set(USE_VERSIONS_TARGET OFF CACHE BOOL "Use the deprecated versions.target file")
-if(USE_VERSIONS_TARGET)
+if(NOT WIN32)
   add_custom_target(version_file ALL DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/versions.target)
   execute_process(
     COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/build/get_version.sh ${CMAKE_CURRENT_SOURCE_DIR}/versions.target
@@ -84,8 +83,17 @@ if(USE_VERSIONS_TARGET)
   execute_process(
     COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/build/get_package_name.sh ${CMAKE_CURRENT_SOURCE_DIR}/versions.target
     OUTPUT_VARIABLE FDB_PACKAGE_NAME_WNL)
-  string(STRIP "${FDB_VERSION_WNL}" FDB_VERSION)
-  string(STRIP "${FDB_PACKAGE_NAME_WNL}" FDB_PACKAGE_NAME)
+  string(STRIP "${FDB_VERSION_WNL}" FDB_VERSION_TARGET_FILE)
+  string(STRIP "${FDB_PACKAGE_NAME_WNL}" FDB_PACKAGE_NAME_TARGET_FILE)
+endif()
+
+set(USE_VERSIONS_TARGET OFF CACHE BOOL "Use the deprecated versions.target file")
+if(USE_VERSIONS_TARGET)
+  if (WIN32)
+    message(FATAL_ERROR "USE_VERSION_TARGET us not supported on Windows")
+  endif()
+  set(FDB_VERSION ${FDB_VERION_TARGET_FILE})
+  set(FDB_PACKAGE_NAME ${FDB_PACKAGE_NAME_TARGET_FILE})
   set(FDB_VERSION_PLAIN ${FDB_VERSION})
   if(NOT FDB_RELEASE)
     set(FDB_VERSION "${FDB_VERSION}-PRERELEASE")
@@ -94,6 +102,17 @@ else()
   set(FDB_PACKAGE_NAME "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}")
   set(FDB_VERSION ${PROJECT_VERSION})
   set(FDB_VERSION_PLAIN ${FDB_VERSION})
+  if(NOT WIN32)
+    # we need to assert that the cmake version is in sync with the target version
+    if(NOT (FDB_VERSION STREQUAL FDB_VERSION_TARGET_FILE))
+      message(SEND_ERROR "The project version in cmake is set to ${FDB_VERSION},\
+ but versions.target has it at ${FDB_VERSION_TARGET_FILE}")
+    endif()
+    if(NOT (FDB_PACKAGE_NAME STREQUAL FDB_PACKAGE_NAME_TARGET_FILE))
+      message(SEND_ERROR "The package name in cmake is set to ${FDB_PACKAGE_NAME},\
+ but versions.target has it set to ${FDB_PACKAGE_NAME_TARGET_FILE}")
+    endif()
+  endif()
 endif()
 
 message(STATUS "FDB version is ${FDB_VERSION}")


### PR DESCRIPTION
Currently we maintain the current fdb version in cmake and in the `versions.target` file. Because of that they are now out of sync.

This PR sync them and also adds a check in CMake to make sure that they are synced. This check only works on MacOS and Linux but not on Windows (but that should be fine for our purpose).

In the future I would like to remove the `versions.target` file from the source tree to make this easier to maintain.