### PR TITLE
DD:fix:getTeam may fail to get a team when it can

### DIFF
--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -833,6 +833,25 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 					else
 						nTries++;
 				}
+				// In case we are very unlucky and didn't choose a feasible random team
+				if (randomTeams.size() == 0 && !self->zeroHealthyTeams->get()) {
+					for (auto& dest : self->teams) {
+						bool ok = dest->isHealthy() && (!req.preferLowerUtilization || dest->hasHealthyFreeSpace());
+						for(int i=0; ok && i<randomTeams.size(); i++) {
+							if (randomTeams[i].second->getServerIDs() == dest->getServerIDs()) {
+								ok = false;
+							}
+						}
+							
+						if (ok) {
+							randomTeams.push_back( std::make_pair( NONE_SHARED, dest ) );
+						}
+
+						if (randomTeams.size() >= SERVER_KNOBS->BEST_TEAM_OPTION_COUNT) {
+							break;
+						}
+					}
+				}
 
 				for( int i = 0; i < randomTeams.size(); i++ ) {
 					int64_t loadBytes = randomTeams[i].first * randomTeams[i].second->getLoadBytes(true, req.inflightPenalty);

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -820,7 +820,6 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 				int nTries = 0;
 				while( randomTeams.size() < SERVER_KNOBS->BEST_TEAM_OPTION_COUNT && nTries < SERVER_KNOBS->BEST_TEAM_MAX_TEAM_TRIES ) {
 					// If unhealthy team is majority, we may not find an ok desk in this while loop
-					// TODO: We may want to create the qualified team and choose among those.
 					Reference<IDataDistributionTeam> dest = deterministicRandom()->randomChoice(self->teams);
 
 					bool ok = dest->isHealthy() && (!req.preferLowerUtilization || dest->hasHealthyFreeSpace());
@@ -832,25 +831,6 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 						randomTeams.push_back( std::make_pair( NONE_SHARED, dest ) );
 					else
 						nTries++;
-				}
-				// In case we are very unlucky and didn't choose a feasible random team
-				if (randomTeams.size() == 0 && !self->zeroHealthyTeams->get()) {
-					for (auto& dest : self->teams) {
-						bool ok = dest->isHealthy() && (!req.preferLowerUtilization || dest->hasHealthyFreeSpace());
-						for(int i=0; ok && i<randomTeams.size(); i++) {
-							if (randomTeams[i].second->getServerIDs() == dest->getServerIDs()) {
-								ok = false;
-							}
-						}
-							
-						if (ok) {
-							randomTeams.push_back( std::make_pair( NONE_SHARED, dest ) );
-						}
-
-						if (randomTeams.size() >= SERVER_KNOBS->BEST_TEAM_OPTION_COUNT) {
-							break;
-						}
-					}
 				}
 
 				for( int i = 0; i < randomTeams.size(); i++ ) {
@@ -893,10 +873,10 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 					}
 				}
 			}
-			if (!bestOption.present()) {
-				TraceEvent("GetTeamRequest").detail("Request", req.getDesc());
-				self->traceAllInfo(true);
-			}
+			// if (!bestOption.present()) {
+			// 	TraceEvent("GetTeamRequest").detail("Request", req.getDesc());
+			// 	self->traceAllInfo(true);
+			// }
 
 			req.reply.send( bestOption );
 

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -833,6 +833,11 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 						nTries++;
 				}
 
+				// Log BestTeamStuck reason when we have healthy teams but they do not have healthy free space
+				if (g_network->isSimulated() && randomTeams.empty() && !self->zeroHealthyTeams->get()) {
+					TraceEvent(SevWarn, "GetTeamReturnEmpty").detail("HealthyTeams", self->healthyTeamCount);
+				}
+
 				for( int i = 0; i < randomTeams.size(); i++ ) {
 					int64_t loadBytes = randomTeams[i].first * randomTeams[i].second->getLoadBytes(true, req.inflightPenalty);
 					if( !bestOption.present() || ( req.preferLowerUtilization && loadBytes < bestLoadBytes ) || ( !req.preferLowerUtilization && loadBytes > bestLoadBytes ) ) {

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -1285,7 +1285,7 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 			TraceEvent("ServerTeamInfo")
 			    .detail("TeamIndex", i++)
 			    .detail("Healthy", team->isHealthy())
-				.detail("HasHealthyFreeSpace", team->hasHealthyFreeSpace())
+			    .detail("HasHealthyFreeSpace", team->hasHealthyFreeSpace())
 			    .detail("TeamSize", team->size())
 			    .detail("MemberIDs", team->getServerIDsStr());
 		}

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -819,7 +819,7 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 			else {
 				int nTries = 0;
 				while( randomTeams.size() < SERVER_KNOBS->BEST_TEAM_OPTION_COUNT && nTries < SERVER_KNOBS->BEST_TEAM_MAX_TEAM_TRIES ) {
-					// If unhealthy team is majority, we may not find an ok desk in this while loop
+					// If unhealthy team is majority, we may not find an ok dest in this while loop
 					Reference<IDataDistributionTeam> dest = deterministicRandom()->randomChoice(self->teams);
 
 					bool ok = dest->isHealthy() && (!req.preferLowerUtilization || dest->hasHealthyFreeSpace());

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -893,10 +893,10 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 					}
 				}
 			}
-			// if (!bestOption.present()) {
-			// 	TraceEvent("GetTeamRequest").detail("Request", req.getDesc());
-			// 	self->traceAllInfo(true);
-			// }
+			if (!bestOption.present()) {
+				TraceEvent("GetTeamRequest").detail("Request", req.getDesc());
+				self->traceAllInfo(true);
+			}
 
 			req.reply.send( bestOption );
 
@@ -1305,6 +1305,7 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 			TraceEvent("ServerTeamInfo")
 			    .detail("TeamIndex", i++)
 			    .detail("Healthy", team->isHealthy())
+				.detail("HasHealthyFreeSpace", team->hasHealthyFreeSpace())
 			    .detail("TeamSize", team->size())
 			    .detail("MemberIDs", team->getServerIDsStr());
 		}

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -819,6 +819,8 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 			else {
 				int nTries = 0;
 				while( randomTeams.size() < SERVER_KNOBS->BEST_TEAM_OPTION_COUNT && nTries < SERVER_KNOBS->BEST_TEAM_MAX_TEAM_TRIES ) {
+					// If unhealthy team is majority, we may not find an ok desk in this while loop
+					// TODO: We may want to create the qualified team and choose among those.
 					Reference<IDataDistributionTeam> dest = deterministicRandom()->randomChoice(self->teams);
 
 					bool ok = dest->isHealthy() && (!req.preferLowerUtilization || dest->hasHealthyFreeSpace());
@@ -872,6 +874,10 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 					}
 				}
 			}
+			// if (!bestOption.present()) {
+			// 	TraceEvent("GetTeamRequest").detail("Request", req.getDesc());
+			// 	self->traceAllInfo(true);
+			// }
 
 			req.reply.send( bestOption );
 

--- a/fdbserver/DataDistribution.actor.h
+++ b/fdbserver/DataDistribution.actor.h
@@ -114,6 +114,22 @@ struct GetTeamRequest {
 
 	GetTeamRequest() {}
 	GetTeamRequest( bool wantsNewServers, bool wantsTrueBest, bool preferLowerUtilization, double inflightPenalty = 1.0 ) : wantsNewServers( wantsNewServers ), wantsTrueBest( wantsTrueBest ), preferLowerUtilization( preferLowerUtilization ), inflightPenalty( inflightPenalty ) {}
+
+	std::string getDesc() {
+		std::stringstream ss;
+
+		ss << "WantsNewServers:" << wantsNewServers << " WantsTrueBest:" << wantsTrueBest << " PreferLowerUtilization:" << preferLowerUtilization << " inflightPenalty:" << inflightPenalty << ";";
+		ss << "Sources:";
+		for (auto& s : sources) {
+			ss << s.toString() << ",";
+		}
+		ss << "CompleteSources:";
+		for (auto& cs : completeSources) {
+			ss << cs.toString() << ",";
+		}
+
+		return ss.str();
+	}
 };
 
 struct GetMetricsRequest {

--- a/fdbserver/DataDistribution.actor.h
+++ b/fdbserver/DataDistribution.actor.h
@@ -118,7 +118,8 @@ struct GetTeamRequest {
 	std::string getDesc() {
 		std::stringstream ss;
 
-		ss << "WantsNewServers:" << wantsNewServers << " WantsTrueBest:" << wantsTrueBest << " PreferLowerUtilization:" << preferLowerUtilization << " inflightPenalty:" << inflightPenalty << ";";
+		ss << "WantsNewServers:" << wantsNewServers << " WantsTrueBest:" << wantsTrueBest
+		   << " PreferLowerUtilization:" << preferLowerUtilization << " inflightPenalty:" << inflightPenalty << ";";
 		ss << "Sources:";
 		for (auto& s : sources) {
 			ss << s.toString() << ",";

--- a/fdbserver/DataDistributionQueue.actor.cpp
+++ b/fdbserver/DataDistributionQueue.actor.cpp
@@ -1204,7 +1204,7 @@ ACTOR Future<Void> BgDDMountainChopper( DDQueueData* self, int teamCollectionInd
 				if (randomTeam.present()) {
 					// Destination team must be healthy and have healthyFreeSpace, otherwise, BestTeamStuck may occur
 					if (randomTeam.get()->getMinFreeSpaceRatio() > SERVER_KNOBS->FREE_SPACE_RATIO_DD_CUTOFF &&
-						randomTeam.get()->hasHealthyFreeSpace()) {
+					    randomTeam.get()->hasHealthyFreeSpace()) {
 						state Optional<Reference<IDataDistributionTeam>> loadedTeam =
 						    wait(brokenPromiseToNever(self->teamCollections[teamCollectionIndex].getTeam.getReply(
 						        GetTeamRequest(true, true, false))));
@@ -1276,9 +1276,9 @@ ACTOR Future<Void> BgDDValleyFiller( DDQueueData* self, int teamCollectionIndex)
 					state Optional<Reference<IDataDistributionTeam>> unloadedTeam = wait(brokenPromiseToNever(
 					    self->teamCollections[teamCollectionIndex].getTeam.getReply(GetTeamRequest(true, true, true))));
 					if (unloadedTeam.present()) {
-						// Destination team must be healthy and have healthyFreeSpace, otherwise, BestTeamStuck may occur
+						// Destination team must be healthy and healthyFreeSpace, otherwise, BestTeamStuck may occur
 						if (unloadedTeam.get()->getMinFreeSpaceRatio() > SERVER_KNOBS->FREE_SPACE_RATIO_DD_CUTOFF &&
-							unloadedTeam.get()->hasHealthyFreeSpace()) {
+						    unloadedTeam.get()->hasHealthyFreeSpace()) {
 							bool moved =
 							    wait(rebalanceTeams(self, PRIORITY_REBALANCE_UNDERUTILIZED_TEAM, randomTeam.get(),
 							                        unloadedTeam.get(), teamCollectionIndex == 0));

--- a/fdbserver/DataDistributionQueue.actor.cpp
+++ b/fdbserver/DataDistributionQueue.actor.cpp
@@ -1202,7 +1202,9 @@ ACTOR Future<Void> BgDDMountainChopper( DDQueueData* self, int teamCollectionInd
 				state Optional<Reference<IDataDistributionTeam>> randomTeam = wait(brokenPromiseToNever(
 				    self->teamCollections[teamCollectionIndex].getTeam.getReply(GetTeamRequest(true, false, true))));
 				if (randomTeam.present()) {
-					if (randomTeam.get()->getMinFreeSpaceRatio() > SERVER_KNOBS->FREE_SPACE_RATIO_DD_CUTOFF) {
+					// Destination team must be healthy and have healthyFreeSpace, otherwise, BestTeamStuck may occur
+					if (randomTeam.get()->getMinFreeSpaceRatio() > SERVER_KNOBS->FREE_SPACE_RATIO_DD_CUTOFF &&
+						randomTeam.get()->hasHealthyFreeSpace()) {
 						state Optional<Reference<IDataDistributionTeam>> loadedTeam =
 						    wait(brokenPromiseToNever(self->teamCollections[teamCollectionIndex].getTeam.getReply(
 						        GetTeamRequest(true, true, false))));
@@ -1274,7 +1276,9 @@ ACTOR Future<Void> BgDDValleyFiller( DDQueueData* self, int teamCollectionIndex)
 					state Optional<Reference<IDataDistributionTeam>> unloadedTeam = wait(brokenPromiseToNever(
 					    self->teamCollections[teamCollectionIndex].getTeam.getReply(GetTeamRequest(true, true, true))));
 					if (unloadedTeam.present()) {
-						if (unloadedTeam.get()->getMinFreeSpaceRatio() > SERVER_KNOBS->FREE_SPACE_RATIO_DD_CUTOFF) {
+						// Destination team must be healthy and have healthyFreeSpace, otherwise, BestTeamStuck may occur
+						if (unloadedTeam.get()->getMinFreeSpaceRatio() > SERVER_KNOBS->FREE_SPACE_RATIO_DD_CUTOFF &&
+							unloadedTeam.get()->hasHealthyFreeSpace()) {
 							bool moved =
 							    wait(rebalanceTeams(self, PRIORITY_REBALANCE_UNDERUTILIZED_TEAM, randomTeam.get(),
 							                        unloadedTeam.get(), teamCollectionIndex == 0));

--- a/fdbserver/Knobs.cpp
+++ b/fdbserver/Knobs.cpp
@@ -159,7 +159,7 @@ ServerKnobs::ServerKnobs(bool randomize, ClientKnobs* clientKnobs) {
 	init( INITIAL_FAILURE_REACTION_DELAY,                       30.0 ); if( randomize && BUGGIFY ) INITIAL_FAILURE_REACTION_DELAY = 0.0;
 	init( CHECK_TEAM_DELAY,                                     30.0 );
 	init( LOG_ON_COMPLETION_DELAY,         DD_QUEUE_LOGGING_INTERVAL );
-	init( BEST_TEAM_MAX_TEAM_TRIES,                               10 );
+	init( BEST_TEAM_MAX_TEAM_TRIES,                               20 );
 	init( BEST_TEAM_OPTION_COUNT,                                  4 );
 	init( BEST_OF_AMT,                                             4 );
 	init( SERVER_LIST_DELAY,                                     1.0 );

--- a/fdbserver/Knobs.cpp
+++ b/fdbserver/Knobs.cpp
@@ -159,7 +159,7 @@ ServerKnobs::ServerKnobs(bool randomize, ClientKnobs* clientKnobs) {
 	init( INITIAL_FAILURE_REACTION_DELAY,                       30.0 ); if( randomize && BUGGIFY ) INITIAL_FAILURE_REACTION_DELAY = 0.0;
 	init( CHECK_TEAM_DELAY,                                     30.0 );
 	init( LOG_ON_COMPLETION_DELAY,         DD_QUEUE_LOGGING_INTERVAL );
-	init( BEST_TEAM_MAX_TEAM_TRIES,                               20 );
+	init( BEST_TEAM_MAX_TEAM_TRIES,                               10 );
 	init( BEST_TEAM_OPTION_COUNT,                                  4 );
 	init( BEST_OF_AMT,                                             4 );
 	init( SERVER_LIST_DELAY,                                     1.0 );

--- a/fdbserver/tester.actor.cpp
+++ b/fdbserver/tester.actor.cpp
@@ -702,8 +702,6 @@ ACTOR Future<DistributedTestResults> runWorkload( Database cx, std::vector< Test
 			checks.push_back(workloads[i].check.template getReplyUnlessFailedFor<CheckReply>(waitForFailureTime, 0));
 		wait( waitForAll( checks ) );
 
-		printf("checking tests DONE num_workloads:%d\n", workloads.size());
-
 		throwIfError(checks, "CheckFailedForWorkload" + printable(spec.title));
 
 		for(int i = 0; i < checks.size(); i++) {
@@ -801,7 +799,6 @@ ACTOR Future<bool> runTest( Database cx, std::vector< TesterInterface > testers,
 	try {
 		Future<DistributedTestResults> fTestResults = runWorkload( cx, testers, spec );
 		if( spec.timeout > 0 ) {
-			printf("[INFO] TestSpec, timeout:%d\n", spec.timeout);
 			fTestResults = timeoutError( fTestResults, spec.timeout );
 		}
 		DistributedTestResults _testResults = wait( fTestResults );

--- a/fdbserver/workloads/Cycle.actor.cpp
+++ b/fdbserver/workloads/Cycle.actor.cpp
@@ -142,7 +142,7 @@ struct CycleWorkload : TestWorkload {
 	}
 
 	void logTestData(const VectorRef<KeyValueRef>& data) {
-		TraceEvent("MXTestFailureDetail");
+		TraceEvent("TestFailureDetail");
 		int index = 0;
 		for (auto& entry : data) {
 			TraceEvent("CurrentDataEntry")


### PR DESCRIPTION
[This PR fixes bugs found in nightly correctness test on 09-06-2019]  

When mountainChopper and valleyFiller balances data across teams, it should only choose the team with healthy free space as the candidate.

Non-functional change: This commit removes unneeded printf introduced by
fast restore PR 1404.