### PR TITLE
DD:Defend DD from misconfigured locality of servers -- Part 2

### DIFF
--- a/documentation/sphinx/source/release-notes.rst
+++ b/documentation/sphinx/source/release-notes.rst
@@ -2,7 +2,7 @@
 Release Notes
 #############
 
-6.2.4
+6.2.5
 =====
 
 Performance
@@ -46,6 +46,7 @@ Fixes
 * The ``fileconfigure`` command in ``fdbcli`` could fail with an unknown error if the file did not contain a valid JSON object. `(PR #2017) <https://github.com/apple/foundationdb/pull/2017>`_.
 * Configuring regions would fail with an internal error if the cluster contained storage servers that didn't set a datacenter ID. `(PR #2017) <https://github.com/apple/foundationdb/pull/2017>`_.
 * Clients no longer prefer reading from servers with the same zone ID, because it could create hot shards. [6.2.3] `(PR #2019) <https://github.com/apple/foundationdb/pull/2019>`_.
+* Data distribution no longer gets stuck when storage servers' localities are misconfigured and later corrected. [6.2.5] `(PR #2110) <https://github.com/apple/foundationdb/pull/2110>`_.
 
 Status
 ------

--- a/fdbclient/Knobs.cpp
+++ b/fdbclient/Knobs.cpp
@@ -197,4 +197,6 @@ ClientKnobs::ClientKnobs(bool randomize) {
 
 	init( CONSISTENCY_CHECK_RATE_LIMIT_MAX,		  50e6 ); // Limit in per sec
 	init( CONSISTENCY_CHECK_ONE_ROUND_TARGET_COMPLETION_TIME,	7 * 24 * 60 * 60 ); // 7 days
+
+	init( VALIDATE_LOCALITY,						1 ); if( randomize && BUGGIFY ) VALIDATE_LOCALITY = 0;
 }

--- a/fdbclient/Knobs.h
+++ b/fdbclient/Knobs.h
@@ -188,6 +188,8 @@ public:
 	int CONSISTENCY_CHECK_RATE_LIMIT_MAX;
 	int CONSISTENCY_CHECK_ONE_ROUND_TARGET_COMPLETION_TIME;
 
+	int VALIDATE_LOCALITY;
+
 	ClientKnobs(bool randomize = false);
 };
 

--- a/fdbrpc/Locality.h
+++ b/fdbrpc/Locality.h
@@ -185,6 +185,9 @@ public:
 	bool isValidMachineId() const { return machineId().present(); }
 	bool isValidDcId() const { return dcId().present(); }
 	bool isValidDataHallId() const { return dataHallId().present(); }
+	bool isValidLocalityValueUnderPolicy(std::string policy) {
+		return get(policy).present();
+	}
 
 	std::string toString() const {
 		std::string	infoString;

--- a/fdbrpc/Locality.h
+++ b/fdbrpc/Locality.h
@@ -180,8 +180,6 @@ public:
 	Optional<Standalone<StringRef>> dcId() const { return get(keyDcId); }
 	Optional<Standalone<StringRef>> dataHallId() const { return get(keyDataHallId); }
 
-	bool isValidLocalityValueUnderPolicy(std::string policy) { return get(policy).present(); }
-
 	std::string toString() const {
 		std::string	infoString;
 		for (auto it = _data.rbegin(); !(it == _data.rend()); ++it) {

--- a/fdbrpc/Locality.h
+++ b/fdbrpc/Locality.h
@@ -181,19 +181,19 @@ public:
 	Optional<Standalone<StringRef>> dataHallId() const { return get(keyDataHallId); }
 
 	bool isValidProcesId() const {
-		return processId().present() && processId().get().size() > 0;
+		return processId().present();
 	}
 	bool isValidZoneId() const {
-		return zoneId().present() && zoneId().get().size() > 0;
+		return zoneId().present();
 	}
 	bool isValidMachineId() const {
-		return machineId().present() && machineId().get().size() > 0;
+		return machineId().present();
 	}
 	bool isValidDcId() const {
-		return dcId().present() && dcId().get().size() > 0;
+		return dcId().present();
 	}
 	bool isValidDataHallId() const {
-		return dataHallId().present() && dataHallId().get().size() > 0;
+		return dataHallId().present();
 	}
 
 	std::string toString() const {

--- a/fdbrpc/Locality.h
+++ b/fdbrpc/Locality.h
@@ -180,14 +180,7 @@ public:
 	Optional<Standalone<StringRef>> dcId() const { return get(keyDcId); }
 	Optional<Standalone<StringRef>> dataHallId() const { return get(keyDataHallId); }
 
-	bool isValidProcesId() const { return processId().present(); }
-	bool isValidZoneId() const { return zoneId().present(); }
-	bool isValidMachineId() const { return machineId().present(); }
-	bool isValidDcId() const { return dcId().present(); }
-	bool isValidDataHallId() const { return dataHallId().present(); }
-	bool isValidLocalityValueUnderPolicy(std::string policy) {
-		return get(policy).present();
-	}
+	bool isValidLocalityValueUnderPolicy(std::string policy) { return get(policy).present(); }
 
 	std::string toString() const {
 		std::string	infoString;

--- a/fdbrpc/Locality.h
+++ b/fdbrpc/Locality.h
@@ -180,21 +180,11 @@ public:
 	Optional<Standalone<StringRef>> dcId() const { return get(keyDcId); }
 	Optional<Standalone<StringRef>> dataHallId() const { return get(keyDataHallId); }
 
-	bool isValidProcesId() const {
-		return processId().present();
-	}
-	bool isValidZoneId() const {
-		return zoneId().present();
-	}
-	bool isValidMachineId() const {
-		return machineId().present();
-	}
-	bool isValidDcId() const {
-		return dcId().present();
-	}
-	bool isValidDataHallId() const {
-		return dataHallId().present();
-	}
+	bool isValidProcesId() const { return processId().present(); }
+	bool isValidZoneId() const { return zoneId().present(); }
+	bool isValidMachineId() const { return machineId().present(); }
+	bool isValidDcId() const { return dcId().present(); }
+	bool isValidDataHallId() const { return dataHallId().present(); }
 
 	std::string toString() const {
 		std::string	infoString;

--- a/fdbrpc/Locality.h
+++ b/fdbrpc/Locality.h
@@ -180,6 +180,22 @@ public:
 	Optional<Standalone<StringRef>> dcId() const { return get(keyDcId); }
 	Optional<Standalone<StringRef>> dataHallId() const { return get(keyDataHallId); }
 
+	bool isValidProcesId() const {
+		return processId().present() && processId().get().size() > 0;
+	}
+	bool isValidZoneId() const {
+		return zoneId().present() && zoneId().get().size() > 0;
+	}
+	bool isValidMachineId() const {
+		return machineId().present() && machineId().get().size() > 0;
+	}
+	bool isValidDcId() const {
+		return dcId().present() && dcId().get().size() > 0;
+	}
+	bool isValidDataHallId() const {
+		return dataHallId().present() && dataHallId().get().size() > 0;
+	}
+
 	std::string toString() const {
 		std::string	infoString;
 		for (auto it = _data.rbegin(); !(it == _data.rend()); ++it) {

--- a/fdbrpc/Locality.h
+++ b/fdbrpc/Locality.h
@@ -166,6 +166,22 @@ public:
 		}
 		return *iter;
 	}
+	bool isValidLocality(std::set<std::string> replicationPolicyKeys) {
+		// Future: Once we add simulation test that misconfigure a cluster, such as not setting some locality entries,
+		// VALIDATE_LOCALITY should always be true. Otherwise, simulation test may fail.
+		// if (!CLIENT_KNOBS->VALIDATE_LOCALITY) {
+		// 	// Disable the checking if locality is valid
+		// 	return true;
+		// }
+
+		for (auto& policy : replicationPolicyKeys) {
+			if (!isPresent(policy)) {
+				return false;
+			}
+		}
+
+		return true;
+	}
 
 	bool	isPresent(StringRef key) const { return (_data.find(key) != _data.end()); }
 	bool	isPresent(StringRef key, Optional<Standalone<StringRef>> value) const {

--- a/fdbserver/ClusterController.actor.cpp
+++ b/fdbserver/ClusterController.actor.cpp
@@ -254,7 +254,10 @@ public:
 
 		for( auto& it : fitness_workers ) {
 			for (auto& worker : it.second ) {
-				logServerMap->add(worker.interf.locality, &worker);
+				if (worker.interf.locality.isValidLocality(conf.tLogPolicy->attributeKeys())) {
+					// In case worker locality is misconfigured
+					logServerMap->add(worker.interf.locality, &worker);
+				}
 			}
 
 			std::vector<LocalityEntry> bestSet;

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -1002,6 +1002,10 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 
 	// Check if server or machine has a valid locality based on configured replication policy
 	bool isValidLocality(Reference<IReplicationPolicy> storagePolicy, LocalityData &locality) {
+		if (!SERVER_KNOBS->DD_VALIDATE_LOCALITY) {
+			// Disable the checking if locality is valid
+			return true;
+		}
 		if (!locality.isValidZoneId()) {
 			// zoneId is used for machine_id. Must have no matter what policy  is used
 			return false;

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -553,6 +553,7 @@ Future<Void> teamTracker(struct DDTeamCollection* const& self, Reference<TCTeamI
 struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 	enum { REQUESTING_WORKER = 0, GETTING_WORKER = 1, GETTING_STORAGE = 2 };
 
+	// clang-format off
 	// addActor: add to actorCollection so that when an actor has error, the ActorCollection can catch the error.
 	// addActor is used to create the actorCollection when the dataDistributionTeamCollection is created
 	PromiseStream<Future<Void>> addActor;
@@ -617,6 +618,7 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 	std::vector<DDTeamCollection*> teamCollections;
 	AsyncVar<Optional<Key>> healthyZone;
 	Future<bool> clearHealthyZoneFuture;
+	// clang-format on
 
 	void resetLocalitySet() {
 		storageServerSet = Reference<LocalitySet>(new LocalityMap<UID>());
@@ -3635,7 +3637,8 @@ ACTOR Future<Void> checkAndRemoveInvalidLocalityAddr(DDTeamCollection* self) {
 			}
 		} catch (Error& e) {
 			wait(tr.onError(e));
-			TraceEvent("CheckAndRemoveInvalidLocalityAddrRetry", self->distributorId).detail("InvalidAddrs", self->invalidLocalityAddr.size());
+			TraceEvent("CheckAndRemoveInvalidLocalityAddrRetry", self->distributorId)
+			    .detail("InvalidAddrs", self->invalidLocalityAddr.size());
 		}
 	}
 
@@ -3645,7 +3648,7 @@ ACTOR Future<Void> checkAndRemoveInvalidLocalityAddr(DDTeamCollection* self) {
 ACTOR Future<Void> initializeStorage( DDTeamCollection* self, RecruitStorageReply candidateWorker ) {
 	// Exclude the worker that has invalid locality
 	if (SERVER_KNOBS->DD_VALIDATE_LOCALITY &&
-		!self->isValidLocality(self->configuration.storagePolicy, candidateWorker.worker.locality)) {
+	    !self->isValidLocality(self->configuration.storagePolicy, candidateWorker.worker.locality)) {
 		TraceEvent(SevWarn, "DDRecruiting")
 		    .detail("ExcludeWorkWithInvalidLocality", candidateWorker.worker.id())
 		    .detail("WorkerLocality", candidateWorker.worker.locality.toString())
@@ -3739,7 +3742,6 @@ ACTOR Future<Void> storageRecruiter( DDTeamCollection* self, Reference<AsyncVar<
 					exclusions.insert(addr);
 				}
 			}
-			
 
 			rsr.criticalRecruitment = self->healthyTeamCount == 0;
 			for(auto it : exclusions) {

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -3591,6 +3591,7 @@ ACTOR Future<Void> checkAndRemoveInvalidLocalityAddr(DDTeamCollection* self) {
 			// Because worker's processId can be changed when its locality is changed, we cannot watch on the old
 			// processId; This actor is inactive most time, so iterating all workers incurs little performance overhead.
 			Future<vector<ProcessData>> workers = getWorkers(&tr);
+			wait(success(workers));
 			std::set<AddressExclusion> existingAddrs;
 			for (int i = 0; i < workers.get().size(); i++) {
 				const ProcessData& workerData = workers.get()[i];

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -1007,6 +1007,8 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 
 	// Check if server or machine has a valid locality based on configured replication policy
 	bool isValidLocality(Reference<IReplicationPolicy> storagePolicy, LocalityData& locality) {
+		// Future: Once we add simulation test that misconfigure a cluster, such as not setting some locality entries,
+		// DD_VALIDATE_LOCALITY should always be true. Otherwise, simulation test may fail.
 		if (!SERVER_KNOBS->DD_VALIDATE_LOCALITY) {
 			// Disable the checking if locality is valid
 			return true;

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -74,7 +74,14 @@ struct TCMachineInfo : public ReferenceCounted<TCMachineInfo> {
 	explicit TCMachineInfo(Reference<TCServerInfo> server, const LocalityEntry& entry) : localityEntry(entry) {
 		ASSERT(serversOnMachine.empty());
 		serversOnMachine.push_back(server);
-		machineID = server->lastKnownInterface.locality.zoneId().get();
+		LocalityData &locality = server->lastKnownInterface.locality;
+		if (locality.zoneId().present()) {
+			machineID = locality.zoneId().get();
+		} else {
+			// If locality is not set, the machine has only one server.
+			machineID = locality.processId().present() ? locality.processId().get() : "";
+		}
+
 	}
 
 	std::string getServersIDStr() {

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -80,7 +80,7 @@ struct TCMachineInfo : public ReferenceCounted<TCMachineInfo> {
 			machineID = locality.zoneId().get();
 		} else {
 			// If locality is not set, the machine has only one server.
-			machineID = locality.processId().present() ? locality.processId().get() : StringRef("");
+			machineID = locality.processId().present() ? locality.processId().get() : StringRef(std::string(""));
 		}
 	}
 
@@ -1016,30 +1016,13 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 			return true;
 		}
 
-		// Assume processId is always configured
-		ASSERT(locality.isValidProcesId());
-
 		std::set<std::string> replicationPolicyKeys = storagePolicy->attributeKeys();
 		for (auto& policy : replicationPolicyKeys) {
 			if (!locality.isValidLocalityValueUnderPolicy(policy)) {
 				return false;
 			}
 		}
-		// if (replicationPolicyKeys.count("zoneid") && !locality.isValidZoneId()) {
-		// 	// zoneId is used for machine_id.
-		// 	return false;
-		// }
-		// if ((replicationPolicyKeys.count("dcid") || replicationPolicyKeys.count("data_center")) && !locality.isValidDcId()) {
-		// 	return false;
-		// }
-		// if (replicationPolicyKeys.count("data_hall") && !locality.isValidDataHallId()) {
-		// 	return false;
-		// }
-		// if (replicationPolicyKeys.count("machineid") && !locality.isValidMachineId()) {
-		// 	return false;
-		// }
-		// ASSERT(replicationPolicyKeys.count("rack") == 0); // Replication policy does not consider this yet.
-		
+
 		return true;
 	}
 

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -80,7 +80,7 @@ struct TCMachineInfo : public ReferenceCounted<TCMachineInfo> {
 			machineID = locality.zoneId().get();
 		} else {
 			// If locality is not set, the machine has only one server.
-			machineID = locality.processId().present() ? locality.processId().get() : "";
+			machineID = locality.processId().present() ? locality.processId().get() : StringRef("");
 		}
 	}
 
@@ -1020,16 +1020,26 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 		ASSERT(locality.isValidProcesId());
 
 		std::set<std::string> replicationPolicyKeys = storagePolicy->attributeKeys();
-		if (replicationPolicyKeys.count("zoneid") && !locality.isValidZoneId()) {
-			// zoneId is used for machine_id.
-			return false;
+		for (auto& policy : replicationPolicyKeys) {
+			if (!locality.isValidLocalityValueUnderPolicy(policy)) {
+				return false;
+			}
 		}
-		if (replicationPolicyKeys.count("dcid") && !locality.isValidDcId()) {
-			return false;
-		}
-		if (replicationPolicyKeys.count("data_hall") && !locality.isValidDataHallId()) {
-			return false;
-		}
+		// if (replicationPolicyKeys.count("zoneid") && !locality.isValidZoneId()) {
+		// 	// zoneId is used for machine_id.
+		// 	return false;
+		// }
+		// if ((replicationPolicyKeys.count("dcid") || replicationPolicyKeys.count("data_center")) && !locality.isValidDcId()) {
+		// 	return false;
+		// }
+		// if (replicationPolicyKeys.count("data_hall") && !locality.isValidDataHallId()) {
+		// 	return false;
+		// }
+		// if (replicationPolicyKeys.count("machineid") && !locality.isValidMachineId()) {
+		// 	return false;
+		// }
+		// ASSERT(replicationPolicyKeys.count("rack") == 0); // Replication policy does not consider this yet.
+		
 		return true;
 	}
 

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -74,6 +74,7 @@ struct TCMachineInfo : public ReferenceCounted<TCMachineInfo> {
 	explicit TCMachineInfo(Reference<TCServerInfo> server, const LocalityEntry& entry) : localityEntry(entry) {
 		ASSERT(serversOnMachine.empty());
 		serversOnMachine.push_back(server);
+
 		LocalityData &locality = server->lastKnownInterface.locality;
 		if (locality.zoneId().present()) {
 			machineID = locality.zoneId().get();
@@ -1013,11 +1014,15 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 			// Disable the checking if locality is valid
 			return true;
 		}
-		if (!locality.isValidZoneId()) {
-			// zoneId is used for machine_id. Must have no matter what policy  is used
+
+		// Assume processId is always configured
+		ASSERT(locality.isValidProcesId());
+
+		std::set<std::string> replicationPolicyKeys = storagePolicy->attributeKeys();
+		if (replicationPolicyKeys.count("zoneid") && !locality.isValidZoneId()) {
+			// zoneId is used for machine_id.
 			return false;
 		}
-		std::set<std::string> replicationPolicyKeys = storagePolicy->attributeKeys();
 		if (replicationPolicyKeys.count("dcid") && !locality.isValidDcId()) {
 			return false;
 		}

--- a/fdbserver/Knobs.cpp
+++ b/fdbserver/Knobs.cpp
@@ -187,6 +187,7 @@ ServerKnobs::ServerKnobs(bool randomize, ClientKnobs* clientKnobs) {
 	init( DD_ZERO_HEALTHY_TEAM_DELAY,                            1.0 );
 	init( REBALANCE_MAX_RETRIES,                                 100 );
 	init( DD_OVERLAP_PENALTY,                                  10000 );
+	init( DD_VALIDATE_LOCALITY,                                 true ); if( randomize && BUGGIFY ) DD_VALIDATE_LOCALITY = deterministicRandom()->random01() < 0.6 ? true : false;
 
 	// TeamRemover
 	TR_FLAG_DISABLE_MACHINE_TEAM_REMOVER =                       false; if( randomize && BUGGIFY ) TR_FLAG_DISABLE_MACHINE_TEAM_REMOVER = deterministicRandom()->random01() < 0.1 ? true : false; // false by default. disable the consistency check when it's true

--- a/fdbserver/Knobs.cpp
+++ b/fdbserver/Knobs.cpp
@@ -188,6 +188,7 @@ ServerKnobs::ServerKnobs(bool randomize, ClientKnobs* clientKnobs) {
 	init( REBALANCE_MAX_RETRIES,                                 100 );
 	init( DD_OVERLAP_PENALTY,                                  10000 );
 	init( DD_VALIDATE_LOCALITY,                                 true ); if( randomize && BUGGIFY ) DD_VALIDATE_LOCALITY = false;
+	init( DD_CHECK_INVALID_LOCALITY_DELAY,                       60  ); if( randomize && BUGGIFY ) DD_CHECK_INVALID_LOCALITY_DELAY = 10 + deterministicRandom()->random01() * 600;
 
 	// TeamRemover
 	TR_FLAG_DISABLE_MACHINE_TEAM_REMOVER =                       false; if( randomize && BUGGIFY ) TR_FLAG_DISABLE_MACHINE_TEAM_REMOVER = deterministicRandom()->random01() < 0.1 ? true : false; // false by default. disable the consistency check when it's true

--- a/fdbserver/Knobs.cpp
+++ b/fdbserver/Knobs.cpp
@@ -187,7 +187,7 @@ ServerKnobs::ServerKnobs(bool randomize, ClientKnobs* clientKnobs) {
 	init( DD_ZERO_HEALTHY_TEAM_DELAY,                            1.0 );
 	init( REBALANCE_MAX_RETRIES,                                 100 );
 	init( DD_OVERLAP_PENALTY,                                  10000 );
-	init( DD_VALIDATE_LOCALITY,                                 true ); if( randomize && BUGGIFY ) DD_VALIDATE_LOCALITY = deterministicRandom()->random01() < 0.6 ? true : false;
+	init( DD_VALIDATE_LOCALITY,                                 true ); if( randomize && BUGGIFY ) DD_VALIDATE_LOCALITY = false;
 
 	// TeamRemover
 	TR_FLAG_DISABLE_MACHINE_TEAM_REMOVER =                       false; if( randomize && BUGGIFY ) TR_FLAG_DISABLE_MACHINE_TEAM_REMOVER = deterministicRandom()->random01() < 0.1 ? true : false; // false by default. disable the consistency check when it's true

--- a/fdbserver/Knobs.cpp
+++ b/fdbserver/Knobs.cpp
@@ -187,8 +187,8 @@ ServerKnobs::ServerKnobs(bool randomize, ClientKnobs* clientKnobs) {
 	init( DD_ZERO_HEALTHY_TEAM_DELAY,                            1.0 );
 	init( REBALANCE_MAX_RETRIES,                                 100 );
 	init( DD_OVERLAP_PENALTY,                                  10000 );
-	init( DD_VALIDATE_LOCALITY,                                 true ); if( randomize && BUGGIFY ) DD_VALIDATE_LOCALITY = false;
-	init( DD_CHECK_INVALID_LOCALITY_DELAY,                       60  ); if( randomize && BUGGIFY ) DD_CHECK_INVALID_LOCALITY_DELAY = 10 + deterministicRandom()->random01() * 600;
+	init( DD_VALIDATE_LOCALITY,                                false ); if( randomize && BUGGIFY ) DD_VALIDATE_LOCALITY = false;
+	init( DD_CHECK_INVALID_LOCALITY_DELAY,                       10  ); if( randomize && BUGGIFY ) DD_CHECK_INVALID_LOCALITY_DELAY = 1 + deterministicRandom()->random01() * 600;
 
 	// TeamRemover
 	TR_FLAG_DISABLE_MACHINE_TEAM_REMOVER =                       false; if( randomize && BUGGIFY ) TR_FLAG_DISABLE_MACHINE_TEAM_REMOVER = deterministicRandom()->random01() < 0.1 ? true : false; // false by default. disable the consistency check when it's true

--- a/fdbserver/Knobs.h
+++ b/fdbserver/Knobs.h
@@ -145,6 +145,7 @@ public:
 	double DEBOUNCE_RECRUITING_DELAY;
 	int REBALANCE_MAX_RETRIES;
 	int DD_OVERLAP_PENALTY;
+	bool DD_VALIDATE_LOCALITY;
 
 	// TeamRemover to remove redundant teams
 	bool TR_FLAG_DISABLE_MACHINE_TEAM_REMOVER; // disable the machineTeamRemover actor

--- a/fdbserver/Knobs.h
+++ b/fdbserver/Knobs.h
@@ -146,6 +146,7 @@ public:
 	int REBALANCE_MAX_RETRIES;
 	int DD_OVERLAP_PENALTY;
 	bool DD_VALIDATE_LOCALITY;
+	int DD_CHECK_INVALID_LOCALITY_DELAY;
 
 	// TeamRemover to remove redundant teams
 	bool TR_FLAG_DISABLE_MACHINE_TEAM_REMOVER; // disable the machineTeamRemover actor

--- a/fdbserver/SimulatedCluster.actor.cpp
+++ b/fdbserver/SimulatedCluster.actor.cpp
@@ -369,9 +369,10 @@ ACTOR Future<ISimulator::KillType> simulatedInvalidLocalityFDBDRebooter(
 			// ProcessId is unset on purpose because it will be set based on data filename
 			state LocalityData misConfLocalities(Optional<Standalone<StringRef>>(), Optional<Standalone<StringRef>>(),
 			                                     Optional<Standalone<StringRef>>(), Optional<Standalone<StringRef>>());
-			// Must set keyProcessId and machineId
+			// Must set keyProcessId, machineId, and zoneId which have assert() in code base already
 			misConfLocalities.set(LocalityData::keyProcessId, localities.get(LocalityData::keyProcessId));
 			misConfLocalities.set(LocalityData::keyMachineId, localities.get(LocalityData::keyMachineId));
+			misConfLocalities.set(LocalityData::keyZoneId, localities.get(LocalityData::keyZoneId));
 			for (int i = 0; i < localities.size(); i++) {
 				if (deterministicRandom()->random01() < 0.2) {
 					std::pair<Standalone<StringRef>, Optional<Standalone<StringRef>>> entry = localities.getItem(i);


### PR DESCRIPTION
When a storage server has misconfigured locality information, e.g., missing `data_hall` or `zone_id` entry, the current data distribution algorithm may get stuck and cannot recover by itself. This may leave a cluster to an unrecoverable situation.

This change aims to make DD resilient to such misconfiguration.
