### PR TITLE
Add simulation test for misconfigured locality scenario

### DIFF
--- a/fdbrpc/Locality.h
+++ b/fdbrpc/Locality.h
@@ -157,6 +157,16 @@ public:
 		_data[key] = value;
 	}
 
+	int size() const { return _data.size(); }
+	std::pair<Standalone<StringRef>, Optional<Standalone<StringRef>>> getItem(int i) {
+		ASSERT(i < _data.size());
+		std::map<Standalone<StringRef>, Optional<Standalone<StringRef>>>::iterator iter = _data.begin();
+		while (i-- > 0) {
+			iter++;
+		}
+		return *iter;
+	}
+
 	bool	isPresent(StringRef key) const { return (_data.find(key) != _data.end()); }
 	bool	isPresent(StringRef key, Optional<Standalone<StringRef>> value) const {
 		auto pos = _data.find(key);

--- a/fdbserver/SimulatedCluster.actor.cpp
+++ b/fdbserver/SimulatedCluster.actor.cpp
@@ -366,8 +366,12 @@ ACTOR Future<ISimulator::KillType> simulatedInvalidLocalityFDBDRebooter(Referenc
 			ISimulator::KillType ret = wait(simulatedFDBDRebooter(connFile, ip, sslEnabled, tlsOptions, port, listenPerProcess, localities, processClass, dataFolder, coordFolder, baseFolder, connStr, useSeedFile, runBackupAgents, whitelistBinPaths));
 			return ret;
 		} else if (curReboot < numReboots) {
+			// Simulate the case when operators try to misconfig localities multiple times
 			// ProcessId is unset on purpose because it will be set based on data filename
 			state LocalityData misConfLocalities(Optional<Standalone<StringRef>>(), Optional<Standalone<StringRef>>(), Optional<Standalone<StringRef>>(), Optional<Standalone<StringRef>>());
+			// Must set keyProcessId and machineId
+			misConfLocalities.set(LocalityData::keyProcessId, localities.get(LocalityData::keyProcessId));
+			misConfLocalities.set(LocalityData::keyMachineId, localities.get(LocalityData::keyMachineId));
 			for (int i = 0; i < localities.size(); i++) {
 				if (deterministicRandom()->random01() < 0.2) {
 					std::pair<Standalone<StringRef>, Optional<Standalone<StringRef>>> entry = localities.getItem(i);


### PR DESCRIPTION
This is the companion PR for PR#2110.

This PR adds the simulation test that misconfigures localities for a restarted machine on purpose. The randomly chosen restarted machine (whose class is storage server) will be later reconfigured to the correct locality.

This allows us to test the impact of misconfigured locality scenario without creating an invalid simulated configuration.

This PR is for review purpose and should not be merged without PR#2110 because it breaks correctness tests as expected.