### PR TITLE
Fix some CMake build issues

### DIFF
--- a/fdbmonitor/CMakeLists.txt
+++ b/fdbmonitor/CMakeLists.txt
@@ -4,11 +4,12 @@ add_executable(fdbmonitor ${FDBMONITOR_SRCS})
 strip_debug_symbols(fdbmonitor)
 assert_no_version_h(fdbmonitor)
 if(UNIX AND NOT APPLE)
-    target_link_libraries(fdbmonitor rt)
+    target_link_libraries(fdbmonitor PUBLIC rt)
 endif()
 # FIXME: This include directory is an ugly hack. We probably want to fix this
 # as soon as we get rid of the old build system
 target_include_directories(fdbmonitor PRIVATE ${CMAKE_BINARY_DIR}/fdbclient)
+target_link_libraries(fdbmonitor PUBLIC Threads::Threads)
 
 fdb_install(TARGETS fdbmonitor DESTINATION fdbmonitor COMPONENT server)
 

--- a/fdbmonitor/CMakeLists.txt
+++ b/fdbmonitor/CMakeLists.txt
@@ -4,7 +4,7 @@ add_executable(fdbmonitor ${FDBMONITOR_SRCS})
 strip_debug_symbols(fdbmonitor)
 assert_no_version_h(fdbmonitor)
 if(UNIX AND NOT APPLE)
-    target_link_libraries(fdbmonitor PUBLIC rt)
+    target_link_libraries(fdbmonitor PRIVATE rt)
 endif()
 # FIXME: This include directory is an ugly hack. We probably want to fix this
 # as soon as we get rid of the old build system

--- a/flow/CMakeLists.txt
+++ b/flow/CMakeLists.txt
@@ -80,7 +80,6 @@ set(FLOW_SRCS
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/hgVersion.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/hgVersion.h)
 
 add_flow_target(STATIC_LIBRARY NAME flow SRCS ${FLOW_SRCS})
-target_include_directories(flow SYSTEM PUBLIC ${CMAKE_THREAD_LIBS_INIT})
 target_include_directories(flow PUBLIC ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
 if (NOT APPLE AND NOT WIN32)
   set (FLOW_LIBS ${FLOW_LIBS} rt)


### PR DESCRIPTION
1. `-isystem ../flow/-lpthreads` was appearing as an include flag

    Due to an apparent mistake of specifying CMAKE_THREAD_LIBS_INIT
    as a system include.  The correct way to do this is to link
    against Threads::Threads, which was already done below.

2. fdbmonitor wouldn't link due to missing pthread_once

    So it also needs to link against Threads::Threads