### PR TITLE
Improve FDB reliability from misconfigured localities - Part 1

### DIFF
--- a/documentation/sphinx/source/release-notes.rst
+++ b/documentation/sphinx/source/release-notes.rst
@@ -46,7 +46,7 @@ Fixes
 * The ``fileconfigure`` command in ``fdbcli`` could fail with an unknown error if the file did not contain a valid JSON object. `(PR #2017) <https://github.com/apple/foundationdb/pull/2017>`_.
 * Configuring regions would fail with an internal error if the cluster contained storage servers that didn't set a datacenter ID. `(PR #2017) <https://github.com/apple/foundationdb/pull/2017>`_.
 * Clients no longer prefer reading from servers with the same zone ID, because it could create hot shards. [6.2.3] `(PR #2019) <https://github.com/apple/foundationdb/pull/2019>`_.
-* Data distribution no longer gets stuck when storage servers' localities are misconfigured and later corrected. [6.2.5] `(PR #2110) <https://github.com/apple/foundationdb/pull/2110>`_.
+* Data distribution could fail to start if any storage servers had misconfigured locality information. This problem could persist even after the offending storage servers were removed or fixed. [6.2.5] `(PR #2110) <https://github.com/apple/foundationdb/pull/2110>`_.
 
 Status
 ------

--- a/documentation/sphinx/source/release-notes.rst
+++ b/documentation/sphinx/source/release-notes.rst
@@ -2,7 +2,7 @@
 Release Notes
 #############
 
-6.2.4
+6.2.5
 =====
 
 Performance
@@ -46,6 +46,7 @@ Fixes
 * The ``fileconfigure`` command in ``fdbcli`` could fail with an unknown error if the file did not contain a valid JSON object. `(PR #2017) <https://github.com/apple/foundationdb/pull/2017>`_.
 * Configuring regions would fail with an internal error if the cluster contained storage servers that didn't set a datacenter ID. `(PR #2017) <https://github.com/apple/foundationdb/pull/2017>`_.
 * Clients no longer prefer reading from servers with the same zone ID, because it could create hot shards. [6.2.3] `(PR #2019) <https://github.com/apple/foundationdb/pull/2019>`_.
+* Data distribution no longer gets stuck when storage servers' localities are misconfigured and later corrected. [6.2.5] `(PR #2110) <https://github.com/apple/foundationdb/pull/2110>`_.
 
 Status
 ------

--- a/fdbrpc/Locality.h
+++ b/fdbrpc/Locality.h
@@ -185,6 +185,9 @@ public:
 	bool isValidMachineId() const { return machineId().present(); }
 	bool isValidDcId() const { return dcId().present(); }
 	bool isValidDataHallId() const { return dataHallId().present(); }
+	bool isValidLocalityValueUnderPolicy(std::string policy) {
+		return get(policy).present();
+	}
 
 	std::string toString() const {
 		std::string	infoString;

--- a/fdbrpc/Locality.h
+++ b/fdbrpc/Locality.h
@@ -180,8 +180,6 @@ public:
 	Optional<Standalone<StringRef>> dcId() const { return get(keyDcId); }
 	Optional<Standalone<StringRef>> dataHallId() const { return get(keyDataHallId); }
 
-	bool isValidLocalityValueUnderPolicy(std::string policy) { return get(policy).present(); }
-
 	std::string toString() const {
 		std::string	infoString;
 		for (auto it = _data.rbegin(); !(it == _data.rend()); ++it) {

--- a/fdbrpc/Locality.h
+++ b/fdbrpc/Locality.h
@@ -181,19 +181,19 @@ public:
 	Optional<Standalone<StringRef>> dataHallId() const { return get(keyDataHallId); }
 
 	bool isValidProcesId() const {
-		return processId().present() && processId().get().size() > 0;
+		return processId().present();
 	}
 	bool isValidZoneId() const {
-		return zoneId().present() && zoneId().get().size() > 0;
+		return zoneId().present();
 	}
 	bool isValidMachineId() const {
-		return machineId().present() && machineId().get().size() > 0;
+		return machineId().present();
 	}
 	bool isValidDcId() const {
-		return dcId().present() && dcId().get().size() > 0;
+		return dcId().present();
 	}
 	bool isValidDataHallId() const {
-		return dataHallId().present() && dataHallId().get().size() > 0;
+		return dataHallId().present();
 	}
 
 	std::string toString() const {

--- a/fdbrpc/Locality.h
+++ b/fdbrpc/Locality.h
@@ -180,14 +180,7 @@ public:
 	Optional<Standalone<StringRef>> dcId() const { return get(keyDcId); }
 	Optional<Standalone<StringRef>> dataHallId() const { return get(keyDataHallId); }
 
-	bool isValidProcesId() const { return processId().present(); }
-	bool isValidZoneId() const { return zoneId().present(); }
-	bool isValidMachineId() const { return machineId().present(); }
-	bool isValidDcId() const { return dcId().present(); }
-	bool isValidDataHallId() const { return dataHallId().present(); }
-	bool isValidLocalityValueUnderPolicy(std::string policy) {
-		return get(policy).present();
-	}
+	bool isValidLocalityValueUnderPolicy(std::string policy) { return get(policy).present(); }
 
 	std::string toString() const {
 		std::string	infoString;

--- a/fdbrpc/Locality.h
+++ b/fdbrpc/Locality.h
@@ -180,21 +180,11 @@ public:
 	Optional<Standalone<StringRef>> dcId() const { return get(keyDcId); }
 	Optional<Standalone<StringRef>> dataHallId() const { return get(keyDataHallId); }
 
-	bool isValidProcesId() const {
-		return processId().present();
-	}
-	bool isValidZoneId() const {
-		return zoneId().present();
-	}
-	bool isValidMachineId() const {
-		return machineId().present();
-	}
-	bool isValidDcId() const {
-		return dcId().present();
-	}
-	bool isValidDataHallId() const {
-		return dataHallId().present();
-	}
+	bool isValidProcesId() const { return processId().present(); }
+	bool isValidZoneId() const { return zoneId().present(); }
+	bool isValidMachineId() const { return machineId().present(); }
+	bool isValidDcId() const { return dcId().present(); }
+	bool isValidDataHallId() const { return dataHallId().present(); }
 
 	std::string toString() const {
 		std::string	infoString;

--- a/fdbrpc/Locality.h
+++ b/fdbrpc/Locality.h
@@ -180,6 +180,22 @@ public:
 	Optional<Standalone<StringRef>> dcId() const { return get(keyDcId); }
 	Optional<Standalone<StringRef>> dataHallId() const { return get(keyDataHallId); }
 
+	bool isValidProcesId() const {
+		return processId().present() && processId().get().size() > 0;
+	}
+	bool isValidZoneId() const {
+		return zoneId().present() && zoneId().get().size() > 0;
+	}
+	bool isValidMachineId() const {
+		return machineId().present() && machineId().get().size() > 0;
+	}
+	bool isValidDcId() const {
+		return dcId().present() && dcId().get().size() > 0;
+	}
+	bool isValidDataHallId() const {
+		return dataHallId().present() && dataHallId().get().size() > 0;
+	}
+
 	std::string toString() const {
 		std::string	infoString;
 		for (auto it = _data.rbegin(); !(it == _data.rend()); ++it) {

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -1002,6 +1002,10 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 
 	// Check if server or machine has a valid locality based on configured replication policy
 	bool isValidLocality(Reference<IReplicationPolicy> storagePolicy, LocalityData &locality) {
+		if (!SERVER_KNOBS->DD_VALIDATE_LOCALITY) {
+			// Disable the checking if locality is valid
+			return true;
+		}
 		if (!locality.isValidZoneId()) {
 			// zoneId is used for machine_id. Must have no matter what policy  is used
 			return false;

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -3617,7 +3617,7 @@ ACTOR Future<Void> checkAndRemoveInvalidLocalityAddr(DDTeamCollection* self) {
 			for (auto addr = self->invalidLocalityAddr.begin(); addr != self->invalidLocalityAddr.end();) {
 				if (!existingAddrs.count(*addr)) {
 					// The address no longer has a worker
-					self->invalidLocalityAddr.erase(addr++);
+					addr = self->invalidLocalityAddr.erase(addr);
 				} else {
 					++addr;
 				}

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -3615,7 +3615,7 @@ ACTOR Future<Void> checkAndRemoveInvalidLocalityAddr(DDTeamCollection* self) {
 				if (!existingAddrs.count(*addr)) {
 					// The address no longer has a worker
 					addr = self->invalidLocalityAddr.erase(addr);
-					TraceEvent("InvalidLocalityNoLongerExisted").detail("Addr", addr->toString());
+					TraceEvent("InvalidLocalityNoLongerExists").detail("Addr", addr->toString());
 				} else {
 					++addr;
 				}

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -1007,6 +1007,8 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 
 	// Check if server or machine has a valid locality based on configured replication policy
 	bool isValidLocality(Reference<IReplicationPolicy> storagePolicy, LocalityData& locality) {
+		// Future: Once we add simulation test that misconfigure a cluster, such as not setting some locality entries,
+		// DD_VALIDATE_LOCALITY should always be true. Otherwise, simulation test may fail.
 		if (!SERVER_KNOBS->DD_VALIDATE_LOCALITY) {
 			// Disable the checking if locality is valid
 			return true;

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -74,7 +74,14 @@ struct TCMachineInfo : public ReferenceCounted<TCMachineInfo> {
 	explicit TCMachineInfo(Reference<TCServerInfo> server, const LocalityEntry& entry) : localityEntry(entry) {
 		ASSERT(serversOnMachine.empty());
 		serversOnMachine.push_back(server);
-		machineID = server->lastKnownInterface.locality.zoneId().get();
+		LocalityData &locality = server->lastKnownInterface.locality;
+		if (locality.zoneId().present()) {
+			machineID = locality.zoneId().get();
+		} else {
+			// If locality is not set, the machine has only one server.
+			machineID = locality.processId().present() ? locality.processId().get() : "";
+		}
+
 	}
 
 	std::string getServersIDStr() {

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -80,7 +80,7 @@ struct TCMachineInfo : public ReferenceCounted<TCMachineInfo> {
 			machineID = locality.zoneId().get();
 		} else {
 			// If locality is not set, the machine has only one server.
-			machineID = locality.processId().present() ? locality.processId().get() : StringRef("");
+			machineID = locality.processId().present() ? locality.processId().get() : StringRef(std::string(""));
 		}
 	}
 
@@ -1016,30 +1016,13 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 			return true;
 		}
 
-		// Assume processId is always configured
-		ASSERT(locality.isValidProcesId());
-
 		std::set<std::string> replicationPolicyKeys = storagePolicy->attributeKeys();
 		for (auto& policy : replicationPolicyKeys) {
 			if (!locality.isValidLocalityValueUnderPolicy(policy)) {
 				return false;
 			}
 		}
-		// if (replicationPolicyKeys.count("zoneid") && !locality.isValidZoneId()) {
-		// 	// zoneId is used for machine_id.
-		// 	return false;
-		// }
-		// if ((replicationPolicyKeys.count("dcid") || replicationPolicyKeys.count("data_center")) && !locality.isValidDcId()) {
-		// 	return false;
-		// }
-		// if (replicationPolicyKeys.count("data_hall") && !locality.isValidDataHallId()) {
-		// 	return false;
-		// }
-		// if (replicationPolicyKeys.count("machineid") && !locality.isValidMachineId()) {
-		// 	return false;
-		// }
-		// ASSERT(replicationPolicyKeys.count("rack") == 0); // Replication policy does not consider this yet.
-		
+
 		return true;
 	}
 

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -80,7 +80,7 @@ struct TCMachineInfo : public ReferenceCounted<TCMachineInfo> {
 			machineID = locality.zoneId().get();
 		} else {
 			// If locality is not set, the machine has only one server.
-			machineID = locality.processId().present() ? locality.processId().get() : "";
+			machineID = locality.processId().present() ? locality.processId().get() : StringRef("");
 		}
 	}
 
@@ -1020,16 +1020,26 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 		ASSERT(locality.isValidProcesId());
 
 		std::set<std::string> replicationPolicyKeys = storagePolicy->attributeKeys();
-		if (replicationPolicyKeys.count("zoneid") && !locality.isValidZoneId()) {
-			// zoneId is used for machine_id.
-			return false;
+		for (auto& policy : replicationPolicyKeys) {
+			if (!locality.isValidLocalityValueUnderPolicy(policy)) {
+				return false;
+			}
 		}
-		if (replicationPolicyKeys.count("dcid") && !locality.isValidDcId()) {
-			return false;
-		}
-		if (replicationPolicyKeys.count("data_hall") && !locality.isValidDataHallId()) {
-			return false;
-		}
+		// if (replicationPolicyKeys.count("zoneid") && !locality.isValidZoneId()) {
+		// 	// zoneId is used for machine_id.
+		// 	return false;
+		// }
+		// if ((replicationPolicyKeys.count("dcid") || replicationPolicyKeys.count("data_center")) && !locality.isValidDcId()) {
+		// 	return false;
+		// }
+		// if (replicationPolicyKeys.count("data_hall") && !locality.isValidDataHallId()) {
+		// 	return false;
+		// }
+		// if (replicationPolicyKeys.count("machineid") && !locality.isValidMachineId()) {
+		// 	return false;
+		// }
+		// ASSERT(replicationPolicyKeys.count("rack") == 0); // Replication policy does not consider this yet.
+		
 		return true;
 	}
 

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -74,6 +74,7 @@ struct TCMachineInfo : public ReferenceCounted<TCMachineInfo> {
 	explicit TCMachineInfo(Reference<TCServerInfo> server, const LocalityEntry& entry) : localityEntry(entry) {
 		ASSERT(serversOnMachine.empty());
 		serversOnMachine.push_back(server);
+
 		LocalityData &locality = server->lastKnownInterface.locality;
 		if (locality.zoneId().present()) {
 			machineID = locality.zoneId().get();
@@ -1013,11 +1014,15 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 			// Disable the checking if locality is valid
 			return true;
 		}
-		if (!locality.isValidZoneId()) {
-			// zoneId is used for machine_id. Must have no matter what policy  is used
+
+		// Assume processId is always configured
+		ASSERT(locality.isValidProcesId());
+
+		std::set<std::string> replicationPolicyKeys = storagePolicy->attributeKeys();
+		if (replicationPolicyKeys.count("zoneid") && !locality.isValidZoneId()) {
+			// zoneId is used for machine_id.
 			return false;
 		}
-		std::set<std::string> replicationPolicyKeys = storagePolicy->attributeKeys();
 		if (replicationPolicyKeys.count("dcid") && !locality.isValidDcId()) {
 			return false;
 		}

--- a/fdbserver/Knobs.cpp
+++ b/fdbserver/Knobs.cpp
@@ -187,6 +187,7 @@ ServerKnobs::ServerKnobs(bool randomize, ClientKnobs* clientKnobs) {
 	init( DD_ZERO_HEALTHY_TEAM_DELAY,                            1.0 );
 	init( REBALANCE_MAX_RETRIES,                                 100 );
 	init( DD_OVERLAP_PENALTY,                                  10000 );
+	init( DD_VALIDATE_LOCALITY,                                 true ); if( randomize && BUGGIFY ) DD_VALIDATE_LOCALITY = deterministicRandom()->random01() < 0.6 ? true : false;
 
 	// TeamRemover
 	TR_FLAG_DISABLE_MACHINE_TEAM_REMOVER =                       false; if( randomize && BUGGIFY ) TR_FLAG_DISABLE_MACHINE_TEAM_REMOVER = deterministicRandom()->random01() < 0.1 ? true : false; // false by default. disable the consistency check when it's true

--- a/fdbserver/Knobs.cpp
+++ b/fdbserver/Knobs.cpp
@@ -188,7 +188,7 @@ ServerKnobs::ServerKnobs(bool randomize, ClientKnobs* clientKnobs) {
 	init( REBALANCE_MAX_RETRIES,                                 100 );
 	init( DD_OVERLAP_PENALTY,                                  10000 );
 	init( DD_VALIDATE_LOCALITY,                                 true ); if( randomize && BUGGIFY ) DD_VALIDATE_LOCALITY = false;
-	init( DD_CHECK_INVALID_LOCALITY_DELAY,                       60  ); if( randomize && BUGGIFY ) DD_CHECK_INVALID_LOCALITY_DELAY = 10 + deterministicRandom()->random01() * 600;
+	init( DD_CHECK_INVALID_LOCALITY_DELAY,                       60  ); if( randomize && BUGGIFY ) DD_CHECK_INVALID_LOCALITY_DELAY = 1 + deterministicRandom()->random01() * 600;
 
 	// TeamRemover
 	TR_FLAG_DISABLE_MACHINE_TEAM_REMOVER =                       false; if( randomize && BUGGIFY ) TR_FLAG_DISABLE_MACHINE_TEAM_REMOVER = deterministicRandom()->random01() < 0.1 ? true : false; // false by default. disable the consistency check when it's true

--- a/fdbserver/Knobs.cpp
+++ b/fdbserver/Knobs.cpp
@@ -188,6 +188,7 @@ ServerKnobs::ServerKnobs(bool randomize, ClientKnobs* clientKnobs) {
 	init( REBALANCE_MAX_RETRIES,                                 100 );
 	init( DD_OVERLAP_PENALTY,                                  10000 );
 	init( DD_VALIDATE_LOCALITY,                                 true ); if( randomize && BUGGIFY ) DD_VALIDATE_LOCALITY = false;
+	init( DD_CHECK_INVALID_LOCALITY_DELAY,                       60  ); if( randomize && BUGGIFY ) DD_CHECK_INVALID_LOCALITY_DELAY = 10 + deterministicRandom()->random01() * 600;
 
 	// TeamRemover
 	TR_FLAG_DISABLE_MACHINE_TEAM_REMOVER =                       false; if( randomize && BUGGIFY ) TR_FLAG_DISABLE_MACHINE_TEAM_REMOVER = deterministicRandom()->random01() < 0.1 ? true : false; // false by default. disable the consistency check when it's true

--- a/fdbserver/Knobs.cpp
+++ b/fdbserver/Knobs.cpp
@@ -187,7 +187,7 @@ ServerKnobs::ServerKnobs(bool randomize, ClientKnobs* clientKnobs) {
 	init( DD_ZERO_HEALTHY_TEAM_DELAY,                            1.0 );
 	init( REBALANCE_MAX_RETRIES,                                 100 );
 	init( DD_OVERLAP_PENALTY,                                  10000 );
-	init( DD_VALIDATE_LOCALITY,                                 true ); if( randomize && BUGGIFY ) DD_VALIDATE_LOCALITY = deterministicRandom()->random01() < 0.6 ? true : false;
+	init( DD_VALIDATE_LOCALITY,                                 true ); if( randomize && BUGGIFY ) DD_VALIDATE_LOCALITY = false;
 
 	// TeamRemover
 	TR_FLAG_DISABLE_MACHINE_TEAM_REMOVER =                       false; if( randomize && BUGGIFY ) TR_FLAG_DISABLE_MACHINE_TEAM_REMOVER = deterministicRandom()->random01() < 0.1 ? true : false; // false by default. disable the consistency check when it's true

--- a/fdbserver/Knobs.h
+++ b/fdbserver/Knobs.h
@@ -145,6 +145,7 @@ public:
 	double DEBOUNCE_RECRUITING_DELAY;
 	int REBALANCE_MAX_RETRIES;
 	int DD_OVERLAP_PENALTY;
+	bool DD_VALIDATE_LOCALITY;
 
 	// TeamRemover to remove redundant teams
 	bool TR_FLAG_DISABLE_MACHINE_TEAM_REMOVER; // disable the machineTeamRemover actor

--- a/fdbserver/Knobs.h
+++ b/fdbserver/Knobs.h
@@ -146,6 +146,7 @@ public:
 	int REBALANCE_MAX_RETRIES;
 	int DD_OVERLAP_PENALTY;
 	bool DD_VALIDATE_LOCALITY;
+	int DD_CHECK_INVALID_LOCALITY_DELAY;
 
 	// TeamRemover to remove redundant teams
 	bool TR_FLAG_DISABLE_MACHINE_TEAM_REMOVER; // disable the machineTeamRemover actor


### PR DESCRIPTION
This is the part 1 of a PR set for Issue#2100

When a storage server has misconfigured locality information, e.g., missing data_hall or zone_id entry, the current data distribution algorithm may get stuck and cannot recover by itself. This may leave a cluster to an unrecoverable situation.

This change aims to make DD resilient to such misconfiguration.