### PR TITLE
Fix segmentation fault in logFetchKeysWarning actor

### DIFF
--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -1948,7 +1948,7 @@ void splitMutation(StorageServer* data, KeyRangeMap<T>& map, MutationRef const& 
 ACTOR Future<Void> logFetchKeysWarning(AddingShard* shard) {
 	state double startTime = now();
 	loop {
-		wait(delay(600));
+		wait(delay(g_network->isSimulated() ? 5 : 600));
 		TraceEvent(SevWarnAlways, "FetchKeysTooLong").detail("Duration", now() - startTime).detail("Phase", shard->phase).detail("Begin", shard->keys.begin.printable()).detail("End", shard->keys.end.printable());
 	}
 }


### PR DESCRIPTION
This fixes the Issue https://github.com/apple/foundationdb/issues/2123.

The input shard of the actor can be destroyed before the actor is cancelled.
Instead of passing in the shard pointer, we pass in the content.


