### PR TITLE
Mako benchmark:  Add variable throttling

### DIFF
--- a/bindings/c/test/mako/mako.h
+++ b/bindings/c/test/mako/mako.h
@@ -34,36 +34,50 @@
  */
 
 /* transaction specification */
-#define OP_GETREADVERSION 0
-#define OP_GET 1
-#define OP_GETRANGE 2
-#define OP_SGET 3
-#define OP_SGETRANGE 4
-#define OP_UPDATE 5
-#define OP_INSERT 6
-#define OP_INSERTRANGE 7
-#define OP_CLEAR 8
-#define OP_SETCLEAR 9
-#define OP_CLEARRANGE 10
-#define OP_SETCLEARRANGE 11
-#define OP_COMMIT 12
-#define MAX_OP 13 /* update this when adding a new operation */
+enum Operations {
+  OP_GETREADVERSION,
+  OP_GET,
+  OP_GETRANGE,
+  OP_SGET,
+  OP_SGETRANGE,
+  OP_UPDATE,
+  OP_INSERT,
+  OP_INSERTRANGE,
+  OP_CLEAR,
+  OP_SETCLEAR,
+  OP_CLEARRANGE,
+  OP_SETCLEARRANGE,
+  OP_COMMIT,
+  MAX_OP /* must be the last item */
+};
 
 #define OP_COUNT 0
 #define OP_RANGE 1
 #define OP_REVERSE 2
 
 /* for arguments */
-#define ARG_KEYLEN 1
-#define ARG_VALLEN 2
-#define ARG_TPS 3
-#define ARG_COMMITGET 4
-#define ARG_SAMPLING 5
-#define ARG_VERSION 6
-#define ARG_KNOBS 7
-#define ARG_FLATBUFFERS 8
-#define ARG_TRACE 9
-#define ARG_TRACEPATH 10
+enum Arguments {
+  ARG_KEYLEN,
+  ARG_VALLEN,
+  ARG_TPS,
+  ARG_COMMITGET,
+  ARG_SAMPLING,
+  ARG_VERSION,
+  ARG_KNOBS,
+  ARG_FLATBUFFERS,
+  ARG_TRACE,
+  ARG_TRACEPATH,
+  ARG_TPSMAX,
+  ARG_TPSMIN,
+  ARG_TPSINTERVAL,
+  ARG_TPSCHANGE
+};
+
+enum TPSChangeTypes {
+  TPS_SIN,
+  TPS_SQUARE,
+  TPS_PULSE
+};
 
 #define KEYPREFIX "mako"
 #define KEYPREFIXLEN 4
@@ -84,7 +98,10 @@ typedef struct {
   int rows; /* is 2 billion enough? */
   int seconds;
   int iteration;
-  int tps;
+  int tpsmax;
+  int tpsmin;
+  int tpsinterval;
+  int tpschange;
   int sampling;
   int key_length;
   int value_length;
@@ -107,6 +124,7 @@ typedef struct {
 typedef struct {
   int signal;
   int readycount;
+  double throttle_factor;
 } mako_shmhdr_t;
 
 typedef struct {


### PR DESCRIPTION
Add a capability to change the throttling rate between "--tpsmin" and "--tpsmax" in the interval of "--tpsinterval".
Three types of changes are added in this PR:
- Sin: TPS oscillates in the shape of sine curve
- Square: TPS changes from "min" to "max" periodically
- Pulse: TPS goes "max" for 1 second then stays at "min"
