### PR TITLE
Make one case in ConfigureDatabase wait for >3s.

### DIFF
--- a/fdbserver/workloads/ConfigureDatabase.actor.cpp
+++ b/fdbserver/workloads/ConfigureDatabase.actor.cpp
@@ -21,6 +21,7 @@
 #include "fdbclient/NativeAPI.actor.h"
 #include "fdbserver/TesterInterface.actor.h"
 #include "fdbclient/ManagementAPI.actor.h"
+#include "fdbclient/RunTransaction.actor.h"
 #include "fdbserver/workloads/workloads.actor.h"
 #include "fdbrpc/simulator.h"
 #include "flow/actorcompiler.h"  // This must be the last #include.
@@ -271,7 +272,15 @@ struct ConfigureDatabaseWorkload : TestWorkload {
 				return Void();
 			}
 			state int randomChoice = deterministicRandom()->randomInt(0, 7);
-			if( randomChoice < 3 ) {
+			if( randomChoice == 0 ) {
+				wait( success(
+						runRYWTransaction(cx, [=](Reference<ReadYourWritesTransaction> tr) -> Future<Optional<Value>>
+							{
+								return tr->get(LiteralStringRef("This read is only to ensure that the database recovered"));
+							})));
+				wait( delay( 20 + 10 * deterministicRandom()->random01() ) );
+			}
+			else if( randomChoice < 3 ) {
 				double waitDuration = 3.0 * deterministicRandom()->random01();
 				//TraceEvent("ConfigureTestWaitAfter").detail("WaitDuration",waitDuration);
 				wait( delay( waitDuration ) );


### PR DESCRIPTION
[This is @alexmiller-apple's PR#2140. We merge it to master for nightly test.]

It turns out that in rare situations, simulation can run into a case
where recovering to the point that tlog generations can be dropped takes
longer than 3s, and thus tests fail with an OOM as an ever increasing
number of tlogs are recruited and never removed.