### PR TITLE
fdb_future_get_version cleanup

### DIFF
--- a/bindings/c/fdb_c.cpp
+++ b/bindings/c/fdb_c.cpp
@@ -214,7 +214,6 @@ fdb_error_t fdb_future_get_error_v22( FDBFuture* f, const char** description ) {
 	return TSAVB(f)->error.code();
 }
 
-extern "C" DLLEXPORT
 fdb_error_t fdb_future_get_version_v619( FDBFuture* f, int64_t* out_version ) {
 	CATCH_AND_RETURN( *out_version = TSAV(Version, f)->get(); );
 }

--- a/bindings/c/foundationdb/fdb_c.h
+++ b/bindings/c/foundationdb/fdb_c.h
@@ -120,11 +120,6 @@ extern "C" {
     fdb_future_get_error( FDBFuture* f );
 #endif
 
-#if FDB_API_VERSION < 620
-    DLLEXPORT WARN_UNUSED_RESULT fdb_error_t
-    fdb_future_get_version( FDBFuture* f, int64_t* out_version );
-#endif
-
     DLLEXPORT WARN_UNUSED_RESULT fdb_error_t
     fdb_future_get_int64( FDBFuture* f, int64_t* out );
 
@@ -264,6 +259,13 @@ extern "C" {
     DLLEXPORT const char* fdb_get_client_version();
 
     /* LEGACY API VERSIONS */
+
+#if FDB_API_VERSION < 620
+    DLLEXPORT WARN_UNUSED_RESULT fdb_error_t
+    fdb_future_get_version( FDBFuture* f, int64_t* out_version );
+#else
+    #define fdb_future_get_version(f, ov) FDB_REMOVED_FUNCTION
+#endif
 
 #if FDB_API_VERSION < 610 || defined FDB_INCLUDE_LEGACY_TYPES
     typedef struct FDB_cluster FDBCluster;


### PR DESCRIPTION
Don't export the `fdb_future_get_version_v619` symbol. Mark `fdb_future_get_version` as a removed function.