### PR TITLE
Fix multi-version API infinite recursion when creating database

### DIFF
--- a/bindings/c/fdb_c.cpp
+++ b/bindings/c/fdb_c.cpp
@@ -107,12 +107,10 @@ fdb_error_t fdb_network_set_option( FDBNetworkOption option,
 		API->setNetworkOption( (FDBNetworkOptions::Option)option, value ? StringRef( value, value_length ) : Optional<StringRef>() ); );
 }
 
-extern "C"
 fdb_error_t fdb_setup_network_impl() {
 	CATCH_AND_RETURN( API->setupNetwork(); );
 }
 
-extern "C"
 fdb_error_t fdb_setup_network_v13( const char* localAddress ) {
 	fdb_error_t errorCode = fdb_network_set_option( FDB_NET_OPTION_LOCAL_ADDRESS, (uint8_t const*)localAddress, strlen(localAddress) );
 	if(errorCode != 0)
@@ -159,7 +157,6 @@ fdb_error_t fdb_future_block_until_ready( FDBFuture* f ) {
 	CATCH_AND_RETURN( TSAVB(f)->blockUntilReady(); );
 }
 
-extern "C" DLLEXPORT
 fdb_bool_t fdb_future_is_error_v22( FDBFuture* f ) {
 	return TSAVB(f)->isError();
 }
@@ -200,12 +197,10 @@ fdb_error_t fdb_future_set_callback( FDBFuture* f,
 	CATCH_AND_RETURN( TSAVB(f)->callOrSetAsCallback( cb, ignore, 0 ); );
 }
 
-extern "C" DLLEXPORT
 fdb_error_t fdb_future_get_error_impl( FDBFuture* f ) {
 	return TSAVB(f)->getErrorCode();
 }
 
-extern "C" DLLEXPORT
 fdb_error_t fdb_future_get_error_v22( FDBFuture* f, const char** description ) {
 	if ( !( TSAVB(f)->isError() ) )
 		return error_code_future_not_error;
@@ -228,14 +223,12 @@ fdb_error_t fdb_future_get_key( FDBFuture* f, uint8_t const** out_key,
 		*out_key_length = key.size(); );
 }
 
-extern "C" DLLEXPORT
 fdb_error_t fdb_future_get_cluster_v609( FDBFuture* f, FDBCluster** out_cluster ) {
 	CATCH_AND_RETURN(
 		*out_cluster = (FDBCluster*)
 		( (TSAV( char*, f )->get() ) ); );
 }
 
-extern "C" DLLEXPORT
 fdb_error_t fdb_future_get_database_v609( FDBFuture* f, FDBDatabase** out_database ) {
 	CATCH_AND_RETURN(
 		*out_database = (FDBDatabase*)
@@ -254,7 +247,6 @@ fdb_error_t fdb_future_get_value( FDBFuture* f, fdb_bool_t* out_present,
 		} );
 }
 
-extern "C"
 fdb_error_t fdb_future_get_keyvalue_array_impl(
 	FDBFuture* f, FDBKeyValue const** out_kv,
 	int* out_count, fdb_bool_t* out_more )
@@ -266,7 +258,6 @@ fdb_error_t fdb_future_get_keyvalue_array_impl(
 		*out_more = rrr.more; );
 }
 
-extern "C"
 fdb_error_t fdb_future_get_keyvalue_array_v13(
 	FDBFuture* f, FDBKeyValue const** out_kv, int* out_count)
 {
@@ -276,7 +267,7 @@ fdb_error_t fdb_future_get_keyvalue_array_v13(
 		*out_count = rrr.size(); );
 }
 
-extern "C"
+extern "C" DLLEXPORT
 fdb_error_t fdb_future_get_string_array(
 	FDBFuture* f, const char*** out_strings, int* out_count)
 {
@@ -287,7 +278,6 @@ fdb_error_t fdb_future_get_string_array(
 	);
 }
 
-extern "C" DLLEXPORT
 FDBFuture* fdb_create_cluster_v609( const char* cluster_file_path ) {
 	char *path;
 	if(cluster_file_path) {
@@ -301,7 +291,6 @@ FDBFuture* fdb_create_cluster_v609( const char* cluster_file_path ) {
 	return (FDBFuture*)ThreadFuture<char*>(path).extractPtr();
 }
 
-extern "C" DLLEXPORT
 fdb_error_t fdb_cluster_set_option_v609( FDBCluster* c,
 							 FDBClusterOption option,
 							 uint8_t const* value,
@@ -311,12 +300,19 @@ fdb_error_t fdb_cluster_set_option_v609( FDBCluster* c,
 	return error_code_success;
 }
 
-extern "C" DLLEXPORT
 void fdb_cluster_destroy_v609( FDBCluster* c ) {
 	CATCH_AND_DIE( delete[] CLUSTER(c); );
 }
 
-extern "C" DLLEXPORT
+// This exists so that fdb_cluster_create_database doesn't need to call the public symbol fdb_create_database.
+// If it does and this is an external client loaded though the multi-version API, then it may inadvertently call
+// the version of the function in the primary library if it was loaded into the global symbols.
+fdb_error_t fdb_create_database_impl( const char* cluster_file_path, FDBDatabase** out_database ) {
+	CATCH_AND_RETURN(
+		*out_database = (FDBDatabase*)API->createDatabase( cluster_file_path ? cluster_file_path : "" ).extractPtr();
+	);
+}
+
 FDBFuture* fdb_cluster_create_database_v609( FDBCluster* c, uint8_t const* db_name,
 											int db_name_length ) 
 {
@@ -325,7 +321,7 @@ FDBFuture* fdb_cluster_create_database_v609( FDBCluster* c, uint8_t const* db_na
 	}
 
 	FDBDatabase *db;
-	fdb_error_t err = fdb_create_database(CLUSTER(c), &db);
+	fdb_error_t err = fdb_create_database_impl(CLUSTER(c), &db);
 	if(err) {
 		return (FDBFuture*)ThreadFuture<Reference<IDatabase>>(Error(err)).extractPtr();
 	}
@@ -335,9 +331,7 @@ FDBFuture* fdb_cluster_create_database_v609( FDBCluster* c, uint8_t const* db_na
 
 extern "C" DLLEXPORT
 fdb_error_t fdb_create_database( const char* cluster_file_path, FDBDatabase** out_database ) {
-	CATCH_AND_RETURN(
-		*out_database = (FDBDatabase*)API->createDatabase( cluster_file_path ? cluster_file_path : "" ).extractPtr();
-	);
+	return fdb_create_database_impl( cluster_file_path, out_database );
 }
 
 extern "C" DLLEXPORT
@@ -389,21 +383,18 @@ FDBFuture* fdb_transaction_get_read_version( FDBTransaction* tr ) {
 	return (FDBFuture*)( TXN(tr)->getReadVersion().extractPtr() );
 }
 
-extern "C"
 FDBFuture* fdb_transaction_get_impl( FDBTransaction* tr, uint8_t const* key_name,
 									 int key_name_length, fdb_bool_t snapshot ) {
 	return (FDBFuture*)
 		( TXN(tr)->get( KeyRef( key_name, key_name_length ), snapshot ).extractPtr() );
 }
 
-extern "C"
 FDBFuture* fdb_transaction_get_v13( FDBTransaction* tr, uint8_t const* key_name,
 									int key_name_length )
 {
 	return fdb_transaction_get_impl( tr, key_name, key_name_length, 0 );
 }
 
-extern "C"
 FDBFuture* fdb_transaction_get_key_impl( FDBTransaction* tr, uint8_t const* key_name,
 										 int key_name_length, fdb_bool_t or_equal,
 										 int offset, fdb_bool_t snapshot ) {
@@ -414,7 +405,6 @@ FDBFuture* fdb_transaction_get_key_impl( FDBTransaction* tr, uint8_t const* key_
 										  snapshot ).extractPtr() );
 }
 
-extern "C"
 FDBFuture* fdb_transaction_get_key_v13( FDBTransaction* tr, uint8_t const* key_name,
 										int key_name_length, fdb_bool_t or_equal,
 										int offset ) {
@@ -422,14 +412,13 @@ FDBFuture* fdb_transaction_get_key_v13( FDBTransaction* tr, uint8_t const* key_n
 										 or_equal, offset, false );
 }
 
-extern "C"
+extern "C" DLLEXPORT
 FDBFuture* fdb_transaction_get_addresses_for_key( FDBTransaction* tr, uint8_t const* key_name,
 									int key_name_length ){
 	return (FDBFuture*)( TXN(tr)->getAddressesForKey( KeyRef(key_name, key_name_length) ).extractPtr() );
 
 }
 
-extern "C"
 FDBFuture* fdb_transaction_get_range_impl(
 		FDBTransaction* tr, uint8_t const* begin_key_name,
 		int begin_key_name_length, fdb_bool_t begin_or_equal, int begin_offset,
@@ -500,7 +489,6 @@ FDBFuture* fdb_transaction_get_range_impl(
 							 snapshot, reverse ).extractPtr() );
 }
 
-extern "C"
 FDBFuture* fdb_transaction_get_range_selector_v13(
 	FDBTransaction* tr, uint8_t const* begin_key_name, int begin_key_name_length,
 	fdb_bool_t begin_or_equal, int begin_offset, uint8_t const* end_key_name,
@@ -512,7 +500,6 @@ FDBFuture* fdb_transaction_get_range_selector_v13(
 		limit, 0, FDB_STREAMING_MODE_EXACT, 0, false, false);
 }
 
-extern "C"
 FDBFuture* fdb_transaction_get_range_v13(
 	FDBTransaction* tr, uint8_t const* begin_key_name, int begin_key_name_length,
 	uint8_t const* end_key_name, int end_key_name_length, int limit )
@@ -590,7 +577,6 @@ FDBFuture* fdb_transaction_get_versionstamp( FDBTransaction* tr )
 	return (FDBFuture*)(TXN(tr)->getVersionstamp().extractPtr());
 }
 
-extern "C"
 fdb_error_t fdb_transaction_set_option_impl( FDBTransaction* tr,
 								 FDBTransactionOption option,
 								 uint8_t const* value,
@@ -600,7 +586,6 @@ fdb_error_t fdb_transaction_set_option_impl( FDBTransaction* tr,
 		TXN(tr)->setOption( (FDBTransactionOptions::Option)option, value ? StringRef( value, value_length ) : Optional<StringRef>() ); );
 }
 
-extern "C"
 void fdb_transaction_set_option_v13( FDBTransaction* tr,
 									 FDBTransactionOption option )
 {
@@ -670,6 +655,10 @@ fdb_error_t fdb_select_api_version_impl( int runtime_version, int header_version
 	// Versioned API changes -- descending order by version (new changes at top)
 	// FDB_API_CHANGED( function, ver ) means there is a new implementation as of ver, and a function function_(ver-1) is the old implementation
 	// FDB_API_REMOVED( function, ver ) means the function was removed as of ver, and function_(ver-1) is the old implementation
+	//
+	// WARNING: use caution when implementing removed functions by calling public API functions. This can lead to undesired behavior when
+	// using the multi-version API. Instead, it is better to have both the removed and public functions call an internal implementation function.
+	// See fdb_create_database_impl for an example.
 	FDB_API_REMOVED( fdb_create_cluster, 610 );
 	FDB_API_REMOVED( fdb_cluster_create_database, 610 );
 	FDB_API_REMOVED( fdb_cluster_set_option, 610 );

--- a/bindings/c/foundationdb/fdb_c.h
+++ b/bindings/c/foundationdb/fdb_c.h
@@ -280,6 +280,13 @@ extern "C" {
     DLLEXPORT WARN_UNUSED_RESULT FDBFuture*
     fdb_cluster_create_database( FDBCluster* c, uint8_t const* db_name,
                                  int db_name_length );
+#else
+    #define fdb_future_get_cluster(f, oc) FDB_REMOVED_FUNCTION
+    #define fdb_future_get_database(f, od) FDB_REMOVED_FUNCTION
+    #define fdb_create_cluster(cfp) FDB_REMOVED_FUNCTION
+    #define fdb_cluster_destroy(c) FDB_REMOVED_FUNCTION
+    #define fdb_cluster_set_option(c, o, v, vl) FDB_REMOVED_FUNCTION
+    #define fdb_cluster_create_database(c, dn, dnl) FDB_REMOVED_FUNCTION
 #endif
 
 #if FDB_API_VERSION < 23

--- a/documentation/sphinx/source/release-notes.rst
+++ b/documentation/sphinx/source/release-notes.rst
@@ -9,7 +9,7 @@ Fixes
 -----
 
 * Loading a 6.1 or newer ``fdb_c`` library as a secondary client using the multi-version client could lead to an infinite recursion when run with API versions older than 610. `(PR #2169) <https://github.com/apple/foundationdb/pull/2169>`_
-* Using functions that were removed in API version 610 now results in a compilation error. `(PR #2169) <https://github.com/apple/foundationdb/pull/2169>`_
+* Using C API functions that were removed in 6.1 when using API version 610 or above now results in a compilation error. `(PR #2169) <https://github.com/apple/foundationdb/pull/2169>`_
 
 6.1.12
 ======

--- a/documentation/sphinx/source/release-notes.rst
+++ b/documentation/sphinx/source/release-notes.rst
@@ -10,6 +10,7 @@ Fixes
 
 * Loading a 6.1 or newer ``fdb_c`` library as a secondary client using the multi-version client could lead to an infinite recursion when run with API versions older than 610. `(PR #2169) <https://github.com/apple/foundationdb/pull/2169>`_
 * Using C API functions that were removed in 6.1 when using API version 610 or above now results in a compilation error. `(PR #2169) <https://github.com/apple/foundationdb/pull/2169>`_
+* ``fdbrestore`` commands other than ``start`` required a default cluster file to be found but did not actually use it. `(PR #1912) <https://github.com/apple/foundationdb/pull/1912>`_.
 
 6.1.12
 ======

--- a/documentation/sphinx/source/release-notes.rst
+++ b/documentation/sphinx/source/release-notes.rst
@@ -2,6 +2,15 @@
 Release Notes
 #############
 
+6.1.13
+======
+
+Fixes
+-----
+
+* Loading a 6.1 or newer ``fdb_c`` library as a secondary client using the multi-version client could lead to an infinite recursion when run with API versions older than 610. `(PR #2169) <https://github.com/apple/foundationdb/pull/2169>`_
+* Using functions that were removed in API version 610 now results in a compilation error. `(PR #2169) <https://github.com/apple/foundationdb/pull/2169>`_
+
 6.1.12
 ======
 


### PR DESCRIPTION
When creating a database with API version <610 and client libraries 6.1 or newer, the `fdb_cluster_create_database` function was implemented by calling `fdb_create_database`. When using the multi-version API with a program that was explicitly linked against `fdb_c`, this could result in an infinite recursion where an external library calls `fdb_create_database` on the primary library, who then calls back into the external, etc.

This is known to affect programs written using the Go and Flow bindings as well as some written using the C bindings.

The solution implemented here removes `DLLEXPORT` from a variety of functions that don't need to be public and avoids calling `fdb_create_database` by adding a private implementation function.

I've opened this PR against release-6.1, as it is necessary to backport this if we want to use 6.1 as an external client version. I'll update release notes on relevant branches once we've decided how we intend to release this.

This doesn't really address the issue of preventing this in the future (outside of a couple comments), and which ideas or other potential solutions to the problem are considered I'm leaving this as a draft PR.