### PR TITLE
Fix #2119:remove checkOnly parameter for cycleTest

### DIFF
--- a/fdbserver/workloads/Cycle.actor.cpp
+++ b/fdbserver/workloads/Cycle.actor.cpp
@@ -28,7 +28,6 @@ struct CycleWorkload : TestWorkload {
 	int actorCount, nodeCount;
 	double testDuration, transactionsPerSecond, minExpectedTransactionsPerSecond;
 	Key		keyPrefix;
-	bool checkOnly;
 
 	vector<Future<Void>> clients;
 	PerfIntCounter transactions, retries, tooOldRetries, commitFailedRetries;
@@ -45,7 +44,6 @@ struct CycleWorkload : TestWorkload {
 		nodeCount = getOption(options, LiteralStringRef("nodeCount"), transactionsPerSecond * clientCount);
 		keyPrefix = unprintable( getOption(options, LiteralStringRef("keyPrefix"), LiteralStringRef("")).toString() );
 		minExpectedTransactionsPerSecond = transactionsPerSecond * getOption(options, LiteralStringRef("expectedRate"), 0.7);
-		checkOnly = getOption(options, LiteralStringRef("checkOnly"), false);
 	}
 
 	virtual std::string description() { return "CycleWorkload"; }
@@ -53,7 +51,6 @@ struct CycleWorkload : TestWorkload {
 		return bulkSetup( cx, this, nodeCount, Promise<double>() );
 	}
 	virtual Future<Void> start( Database const& cx ) {
-		if (checkOnly) return Void();
 		for(int c=0; c<actorCount; c++)
 			clients.push_back(
 				timeout(


### PR DESCRIPTION
`checkOnly` param added for cycleTest verification actually fails the test.
`runSetup=false` is sufficient for cycleTest verification in real world or in the simulator.