### PR TITLE
Make FDBLibTLS and thirdparty static libraries.

### DIFF
--- a/FDBLibTLS/CMakeLists.txt
+++ b/FDBLibTLS/CMakeLists.txt
@@ -8,5 +8,5 @@ set(SRCS
   FDBLibTLSVerify.cpp
   FDBLibTLSVerify.h)
 
-add_library(FDBLibTLS ${SRCS})
+add_library(FDBLibTLS STATIC ${SRCS})
 target_link_libraries(FDBLibTLS PUBLIC LibreSSL boost_target PRIVATE flow)

--- a/fdbrpc/CMakeLists.txt
+++ b/fdbrpc/CMakeLists.txt
@@ -54,7 +54,7 @@ if(NOT WIN32)
   list(APPEND FDBRPC_THIRD_PARTY_SRCS libcoroutine/context.c libeio/eio.c)
 endif()
 
-add_library(thirdparty ${FDBRPC_THIRD_PARTY_SRCS})
+add_library(thirdparty STATIC ${FDBRPC_THIRD_PARTY_SRCS})
 if(NOT WIN32)
   target_compile_options(thirdparty BEFORE PRIVATE -w) # disable warnings for third party
 endif()


### PR DESCRIPTION
They're statically linked anyway, and this fixes an issue with CMake
complaining that there are cyclic dependencies that are non-static.

No idea why I'm hitting this and our CMake builder isn't though?