### PR TITLE
deprecate isTLogInSameNode used by snapshot V1

### DIFF
--- a/fdbserver/FDBExecHelper.actor.cpp
+++ b/fdbserver/FDBExecHelper.actor.cpp
@@ -194,44 +194,6 @@ ACTOR Future<int> execHelper(ExecCmdValueString* execArg, UID snapUID, std::stri
 	return err;
 }
 
-std::map<NetworkAddress, std::set<UID>> execOpsInProgress;
-
-bool isExecOpInProgress(UID execUID) {
-	NetworkAddress addr = g_network->getLocalAddress();
-	return (execOpsInProgress[addr].find(execUID) != execOpsInProgress[addr].end());
-}
-
-void setExecOpInProgress(UID execUID) {
-	NetworkAddress addr = g_network->getLocalAddress();
-	ASSERT(execOpsInProgress[addr].find(execUID) == execOpsInProgress[addr].end());
-	execOpsInProgress[addr].insert(execUID);
-	return;
-}
-
-void clearExecOpInProgress(UID execUID) {
-	NetworkAddress addr = g_network->getLocalAddress();
-	ASSERT(execOpsInProgress[addr].find(execUID) != execOpsInProgress[addr].end());
-	execOpsInProgress[addr].erase(execUID);
-	return;
-}
-
-std::map<NetworkAddress, std::set<UID>> tLogsAlive;
-
-void registerTLog(UID uid) {
-	NetworkAddress addr = g_network->getLocalAddress();
-	tLogsAlive[addr].insert(uid);
-}
-void unregisterTLog(UID uid) {
-	NetworkAddress addr = g_network->getLocalAddress();
-	if (tLogsAlive[addr].find(uid) != tLogsAlive[addr].end()) {
-		tLogsAlive[addr].erase(uid);
-	}
-}
-bool isTLogInSameNode() {
-	NetworkAddress addr = g_network->getLocalAddress();
-	return tLogsAlive[addr].size() >= 1;
-}
-
 struct StorageVersionInfo {
 	Version version;
 	Version durableVersion;

--- a/fdbserver/FDBExecHelper.actor.h
+++ b/fdbserver/FDBExecHelper.actor.h
@@ -52,21 +52,6 @@ ACTOR Future<int> spawnProcess(std::string binPath, std::vector<std::string> par
 // helper to run all the work related to running the exec command
 ACTOR Future<int> execHelper(ExecCmdValueString* execArg, UID snapUID, std::string folder, std::string role);
 
-// returns true if the execUID op is in progress
-bool isExecOpInProgress(UID execUID);
-// adds the execUID op to the list of ops in progress
-void setExecOpInProgress(UID execUID);
-// clears the execUID op from the list of ops in progress
-void clearExecOpInProgress(UID execUID);
-
-
-// registers a non-stopped TLog instance
-void registerTLog(UID uid);
-// unregisters a stopped TLog instance
-void unregisterTLog(UID uid);
-// checks if there is any non-stopped TLog instance
-bool isTLogInSameNode();
-
 // set the data version for the specified storage server UID
 void setDataVersion(UID uid, Version version);
 // set the data durable version for the specified storage server UID

--- a/fdbserver/OldTLogServer_6_0.actor.cpp
+++ b/fdbserver/OldTLogServer_6_0.actor.cpp
@@ -548,7 +548,6 @@ ACTOR Future<Void> tLogLock( TLogData* self, ReplyPromise< TLogLockResult > repl
 	TEST( !logData->stopped );
 
 	TraceEvent("TLogStop", logData->logId).detail("Ver", stopVersion).detail("IsStopped", logData->stopped).detail("QueueCommitted", logData->queueCommittedVersion.get());
-	unregisterTLog(logData->logId);
 
 	logData->stopped = true;
 	if(!logData->recoveryComplete.isSet()) {
@@ -1702,7 +1701,6 @@ ACTOR Future<Void> serveTLogInterface( TLogData* self, TLogInterface tli, Refere
 void removeLog( TLogData* self, Reference<LogData> logData ) {
 	TraceEvent("TLogRemoved", logData->logId).detail("Input", logData->bytesInput.getValue()).detail("Durable", logData->bytesDurable.getValue());
 	logData->stopped = true;
-	unregisterTLog(logData->logId);
 	if(!logData->recoveryComplete.isSet()) {
 		logData->recoveryComplete.sendError(end_of_stream());
 	}
@@ -2196,7 +2194,6 @@ ACTOR Future<Void> tLogStart( TLogData* self, InitializeTLogRequest req, Localit
 	self->queueOrder.push_back(recruited.id());
 
 	TraceEvent("TLogStart", logData->logId);
-	registerTLog(logData->logId);
 	state Future<Void> updater;
 	state bool pulledRecoveryVersions = false;
 	try {

--- a/fdbserver/OldTLogServer_6_2.actor.cpp
+++ b/fdbserver/OldTLogServer_6_2.actor.cpp
@@ -637,7 +637,6 @@ ACTOR Future<Void> tLogLock( TLogData* self, ReplyPromise< TLogLockResult > repl
 	TEST( !logData->stopped );
 
 	TraceEvent("TLogStop", logData->logId).detail("Ver", stopVersion).detail("IsStopped", logData->stopped).detail("QueueCommitted", logData->queueCommittedVersion.get());
-	unregisterTLog(logData->logId);
 
 	logData->stopped = true;
 	if(!logData->recoveryComplete.isSet()) {
@@ -2092,7 +2091,6 @@ ACTOR Future<Void> serveTLogInterface( TLogData* self, TLogInterface tli, Refere
 void removeLog( TLogData* self, Reference<LogData> logData ) {
 	TraceEvent("TLogRemoved", self->dbgid).detail("LogId", logData->logId).detail("Input", logData->bytesInput.getValue()).detail("Durable", logData->bytesDurable.getValue());
 	logData->stopped = true;
-	unregisterTLog(logData->logId);
 	if(!logData->recoveryComplete.isSet()) {
 		logData->recoveryComplete.sendError(end_of_stream());
 	}
@@ -2620,7 +2618,6 @@ ACTOR Future<Void> tLogStart( TLogData* self, InitializeTLogRequest req, Localit
 	self->spillOrder.push_back(recruited.id());
 
 	TraceEvent("TLogStart", logData->logId);
-	registerTLog(logData->logId);
 
 	state Future<Void> updater;
 	state bool pulledRecoveryVersions = false;

--- a/fdbserver/TLogServer.actor.cpp
+++ b/fdbserver/TLogServer.actor.cpp
@@ -653,7 +653,6 @@ ACTOR Future<Void> tLogLock( TLogData* self, ReplyPromise< TLogLockResult > repl
 	TEST( !logData->stopped );
 
 	TraceEvent("TLogStop", logData->logId).detail("Ver", stopVersion).detail("IsStopped", logData->stopped).detail("QueueCommitted", logData->queueCommittedVersion.get());
-	unregisterTLog(logData->logId);
 
 	logData->stopped = true;
 	if(!logData->recoveryComplete.isSet()) {
@@ -2108,7 +2107,6 @@ ACTOR Future<Void> serveTLogInterface( TLogData* self, TLogInterface tli, Refere
 void removeLog( TLogData* self, Reference<LogData> logData ) {
 	TraceEvent("TLogRemoved", self->dbgid).detail("LogId", logData->logId).detail("Input", logData->bytesInput.getValue()).detail("Durable", logData->bytesDurable.getValue());
 	logData->stopped = true;
-	unregisterTLog(logData->logId);
 	if(!logData->recoveryComplete.isSet()) {
 		logData->recoveryComplete.sendError(end_of_stream());
 	}
@@ -2638,7 +2636,6 @@ ACTOR Future<Void> tLogStart( TLogData* self, InitializeTLogRequest req, Localit
 	self->spillOrder.push_back(recruited.id());
 
 	TraceEvent("TLogStart", logData->logId);
-	registerTLog(logData->logId);
 
 	state Future<Void> updater;
 	state bool pulledRecoveryVersions = false;


### PR DESCRIPTION
`isTLogInSameNode` was a functionality used in snapshot V1 to detect if the storage and TLog are on the same process and use that to determine if the snap create needs to be done. With snapshot V2, we no long user this functionality, hence deprecating this and all the dependent functions.