### PR TITLE
Fixed Compiler Error in GCC 4.8.5

### DIFF
--- a/fdbserver/DiskQueue.actor.cpp
+++ b/fdbserver/DiskQueue.actor.cpp
@@ -151,7 +151,7 @@ protected:
 
 private:
 	int actorCount = 0;
-	AsyncVar<bool> actorCountIsZero = true;
+	AsyncVar<bool> actorCountIsZero = AsyncVar<bool>(true);
 };
 
 class RawDiskQueue_TwoFiles : public Tracked<RawDiskQueue_TwoFiles> {


### PR DESCRIPTION
Initialized AsyncVar member variable using class constructor.
This resolves issue #2122