### PR TITLE
Replace /flow/delayOrdering with /flow/buggifiedDelay

### DIFF
--- a/fdbrpc/FlowTests.actor.cpp
+++ b/fdbrpc/FlowTests.actor.cpp
@@ -50,24 +50,27 @@ TEST_CASE("/flow/actorcompiler/lineNumbers") {
 	return Void();
 }
 
-TEST_CASE("/flow/delayOrdering") {
-	state double x = deterministicRandom()->random01();
-	state double y = deterministicRandom()->random01();
-	if (BUGGIFY) {
-		y = x;
+TEST_CASE("/flow/buggifiedDelay") {
+	if (FLOW_KNOBS->MAX_BUGGIFIED_DELAY == 0) {
+		return Void();
 	}
-	state int last = 0;
-	state Future<Void> f1 = map(delay(x), [last = &last](const Void&) {
-		*last = 1;
-		return Void();
-	});
-	state Future<Void> f2 = map(delay(y), [last = &last](const Void&) {
-		*last = 2;
-		return Void();
-	});
-	wait(f1 && f2);
-	ASSERT((x <= y) == (last == 2));
-	return Void();
+	loop {
+		state double x = deterministicRandom()->random01();
+		state int last = 0;
+		state Future<Void> f1 = map(delay(x), [last = &last](const Void&) {
+			*last = 1;
+			return Void();
+		});
+		state Future<Void> f2 = map(delay(x), [last = &last](const Void&) {
+			*last = 2;
+			return Void();
+		});
+		wait(f1 && f2);
+		if (last == 1) {
+			TEST(true); // Delays can become ready out of order
+			return Void();
+		}
+	}
 }
 
 template <class T, class Func, class ErrFunc, class CallbackType>


### PR DESCRIPTION
Seems that we don't want the property that delays become ready in order
to hold, so make sure it doesn't hold in the simulator.

CC #2148 