### PR TITLE
Performant restore [1/XX]: Add debug TraceEvent type to make adding debug trace easier

### DIFF
--- a/fdbserver/FDBExecHelper.actor.h
+++ b/fdbserver/FDBExecHelper.actor.h
@@ -59,7 +59,6 @@ void setExecOpInProgress(UID execUID);
 // clears the execUID op from the list of ops in progress
 void clearExecOpInProgress(UID execUID);
 
-
 // registers a non-stopped TLog instance
 void registerTLog(UID uid);
 // unregisters a stopped TLog instance

--- a/fdbserver/FDBExecHelper.actor.h
+++ b/fdbserver/FDBExecHelper.actor.h
@@ -59,6 +59,7 @@ void setExecOpInProgress(UID execUID);
 // clears the execUID op from the list of ops in progress
 void clearExecOpInProgress(UID execUID);
 
+
 // registers a non-stopped TLog instance
 void registerTLog(UID uid);
 // unregisters a stopped TLog instance

--- a/fdbserver/RestoreMaster.actor.cpp
+++ b/fdbserver/RestoreMaster.actor.cpp
@@ -131,7 +131,9 @@ ACTOR Future<Void> distributeRestoreSysInfo(Reference<RestoreWorkerData> masterW
 	ASSERT(!masterData->loadersInterf.empty());
 	RestoreSysInfo sysInfo(masterData->appliersInterf);
 	std::vector<std::pair<UID, RestoreSysInfoRequest>> requests;
+	FRTraceEvent().detail("DistributeRestoreSysInfo", masterData->loadersInterf.size());
 	for (auto& loader : masterData->loadersInterf) {
+		FRTraceEvent().detail("Loader", loader.first);
 		requests.push_back(std::make_pair(loader.first, RestoreSysInfoRequest(sysInfo)));
 	}
 

--- a/fdbserver/RestoreUtil.h
+++ b/fdbserver/RestoreUtil.h
@@ -39,18 +39,17 @@
 
 #ifndef FR_DEBUG
 #define FR_DEBUG
-#define FRTraceEvent(...)	TraceEvent(SevDebug, "FastRestore", UID(), true)
+#define FRTraceEvent(...) TraceEvent(SevDebug, "FastRestore", UID(), true)
 #else
-#define FRTraceEvent(...)	TraceEvent(SevDebug, "FastRestore", UID(), false)
+#define FRTraceEvent(...) TraceEvent(SevDebug, "FastRestore", UID(), false)
 #endif
 
 #ifndef FR_VERBOSE_DEBUG
 #define FR_VERBOSE_DEBUG
-#define FRVBTraceEvent	TraceEvent(SevDebug, "FastRestoreVerbose", UID(), true);
+#define FRVBTraceEvent TraceEvent(SevDebug, "FastRestoreVerbose", UID(), true);
 #else
-#define FRVBTraceEvent	TraceEvent(SevDebug, "FastRestore", UID(), false);
+#define FRVBTraceEvent TraceEvent(SevDebug, "FastRestore", UID(), false);
 #endif
-
 
 enum class RestoreRole { Invalid = 0, Master = 1, Loader, Applier };
 BINARY_SERIALIZABLE(RestoreRole);

--- a/fdbserver/RestoreUtil.h
+++ b/fdbserver/RestoreUtil.h
@@ -34,6 +34,24 @@
 #include <cstdint>
 #include <cstdarg>
 
+#define FR_DEBUG
+#define FR_VERBOSE_DEBUG
+
+#ifndef FR_DEBUG
+#define FR_DEBUG
+#define FRTraceEvent(...)	TraceEvent(SevDebug, "FastRestore", UID(), true)
+#else
+#define FRTraceEvent(...)	TraceEvent(SevDebug, "FastRestore", UID(), false)
+#endif
+
+#ifndef FR_VERBOSE_DEBUG
+#define FR_VERBOSE_DEBUG
+#define FRVBTraceEvent	TraceEvent(SevDebug, "FastRestoreVerbose", UID(), true);
+#else
+#define FRVBTraceEvent	TraceEvent(SevDebug, "FastRestore", UID(), false);
+#endif
+
+
 enum class RestoreRole { Invalid = 0, Master = 1, Loader, Applier };
 BINARY_SERIALIZABLE(RestoreRole);
 std::string getRoleStr(RestoreRole role);

--- a/fdbserver/RestoreUtil.h
+++ b/fdbserver/RestoreUtil.h
@@ -38,14 +38,16 @@
 #define FR_VERBOSE_DEBUG
 
 #ifndef FR_DEBUG
-#define FR_DEBUG
+#ifdef FR_DEBUG
+
 #define FRTraceEvent(...) TraceEvent(SevDebug, "FastRestore", UID(), true)
 #else
 #define FRTraceEvent(...) TraceEvent(SevDebug, "FastRestore", UID(), false)
 #endif
 
 #ifndef FR_VERBOSE_DEBUG
-#define FR_VERBOSE_DEBUG
+#ifdef FR_VERBOSE_DEBUG
+
 #define FRVBTraceEvent TraceEvent(SevDebug, "FastRestoreVerbose", UID(), true);
 #else
 #define FRVBTraceEvent TraceEvent(SevDebug, "FastRestore", UID(), false);

--- a/flow/Trace.cpp
+++ b/flow/Trace.cpp
@@ -653,23 +653,22 @@ void removeTraceRole(std::string role) {
 	g_traceLog.removeRole(role);
 }
 
-TraceEvent::TraceEvent( const char* type, UID id, bool enabled ) : id(id), type(type), severity(SevInfo), initialized(false), enabled(enabled) {
+TraceEvent::TraceEvent(const char* type, UID id, bool enabled)
+  : id(id), type(type), severity(SevInfo), initialized(false), enabled(enabled) {
 	g_trace_depth++;
 	setMaxFieldLength(0);
 	setMaxEventLength(0);
 }
-TraceEvent::TraceEvent( Severity severity, const char* type, UID id, bool enabled )
-	: id(id), type(type), severity(severity), initialized(false),
-	  enabled(enabled && (g_network == nullptr || FLOW_KNOBS->MIN_TRACE_SEVERITY <= severity)) {
+TraceEvent::TraceEvent(Severity severity, const char* type, UID id, bool enabled)
+  : id(id), type(type), severity(severity), initialized(false),
+    enabled(enabled && (g_network == nullptr || FLOW_KNOBS->MIN_TRACE_SEVERITY <= severity)) {
 	g_trace_depth++;
 	setMaxFieldLength(0);
 	setMaxEventLength(0);
 }
-TraceEvent::TraceEvent( TraceInterval& interval, UID id, bool enabled )
-	: id(id), type(interval.type),
-	  severity(interval.severity),
-	  initialized(false),
-	  enabled(enabled && (g_network == nullptr || FLOW_KNOBS->MIN_TRACE_SEVERITY <= interval.severity)) {
+TraceEvent::TraceEvent(TraceInterval& interval, UID id, bool enabled)
+  : id(id), type(interval.type), severity(interval.severity), initialized(false),
+    enabled(enabled && (g_network == nullptr || FLOW_KNOBS->MIN_TRACE_SEVERITY <= interval.severity)) {
 
 	g_trace_depth++;
 	setMaxFieldLength(0);
@@ -677,11 +676,9 @@ TraceEvent::TraceEvent( TraceInterval& interval, UID id, bool enabled )
 
 	init(interval);
 }
-TraceEvent::TraceEvent( Severity severity, TraceInterval& interval, UID id, bool enabled )
-	: id(id), type(interval.type),
-	  severity(severity),
-	  initialized(false),
-	  enabled(enabled && (g_network == nullptr || FLOW_KNOBS->MIN_TRACE_SEVERITY <= severity)) {
+TraceEvent::TraceEvent(Severity severity, TraceInterval& interval, UID id, bool enabled)
+  : id(id), type(interval.type), severity(severity), initialized(false),
+    enabled(enabled && (g_network == nullptr || FLOW_KNOBS->MIN_TRACE_SEVERITY <= severity)) {
 
 	g_trace_depth++;
 	setMaxFieldLength(0);

--- a/flow/Trace.cpp
+++ b/flow/Trace.cpp
@@ -653,23 +653,23 @@ void removeTraceRole(std::string role) {
 	g_traceLog.removeRole(role);
 }
 
-TraceEvent::TraceEvent( const char* type, UID id ) : id(id), type(type), severity(SevInfo), initialized(false), enabled(true) {
+TraceEvent::TraceEvent( const char* type, UID id, bool enabled ) : id(id), type(type), severity(SevInfo), initialized(false), enabled(enabled) {
 	g_trace_depth++;
 	setMaxFieldLength(0);
 	setMaxEventLength(0);
 }
-TraceEvent::TraceEvent( Severity severity, const char* type, UID id )
+TraceEvent::TraceEvent( Severity severity, const char* type, UID id, bool enabled )
 	: id(id), type(type), severity(severity), initialized(false),
-	  enabled(g_network == nullptr || FLOW_KNOBS->MIN_TRACE_SEVERITY <= severity) {
+	  enabled(enabled && (g_network == nullptr || FLOW_KNOBS->MIN_TRACE_SEVERITY <= severity)) {
 	g_trace_depth++;
 	setMaxFieldLength(0);
 	setMaxEventLength(0);
 }
-TraceEvent::TraceEvent( TraceInterval& interval, UID id )
+TraceEvent::TraceEvent( TraceInterval& interval, UID id, bool enabled )
 	: id(id), type(interval.type),
 	  severity(interval.severity),
 	  initialized(false),
-	  enabled(g_network == nullptr || FLOW_KNOBS->MIN_TRACE_SEVERITY <= interval.severity) {
+	  enabled(enabled && (g_network == nullptr || FLOW_KNOBS->MIN_TRACE_SEVERITY <= interval.severity)) {
 
 	g_trace_depth++;
 	setMaxFieldLength(0);
@@ -677,11 +677,11 @@ TraceEvent::TraceEvent( TraceInterval& interval, UID id )
 
 	init(interval);
 }
-TraceEvent::TraceEvent( Severity severity, TraceInterval& interval, UID id )
+TraceEvent::TraceEvent( Severity severity, TraceInterval& interval, UID id, bool enabled )
 	: id(id), type(interval.type),
 	  severity(severity),
 	  initialized(false),
-	  enabled(g_network == nullptr || FLOW_KNOBS->MIN_TRACE_SEVERITY <= severity) {
+	  enabled(enabled && (g_network == nullptr || FLOW_KNOBS->MIN_TRACE_SEVERITY <= severity)) {
 
 	g_trace_depth++;
 	setMaxFieldLength(0);

--- a/flow/Trace.h
+++ b/flow/Trace.h
@@ -372,10 +372,11 @@ struct SpecialTraceMetricType
 TRACE_METRIC_TYPE(double, double);
 
 struct TraceEvent {
-	TraceEvent( const char* type, UID id = UID() );   // Assumes SevInfo severity
-	TraceEvent( Severity, const char* type, UID id = UID() );
-	TraceEvent( struct TraceInterval&, UID id = UID() );
-	TraceEvent( Severity severity, struct TraceInterval& interval, UID id = UID() );
+	TraceEvent( const char* type, UID id = UID(), bool enabled = true );   // Assumes SevInfo severity
+	TraceEvent( Severity, const char* type, UID id = UID(), bool enabled = true );
+	TraceEvent( struct TraceInterval&, UID id = UID(), bool enabled = true );
+	TraceEvent( Severity severity, struct TraceInterval& interval, UID id = UID(), bool enabled = true );
+	// For defining debug TraceEvent
 
 	static void setNetworkThread();
 	static bool isNetworkThread();

--- a/flow/Trace.h
+++ b/flow/Trace.h
@@ -372,10 +372,10 @@ struct SpecialTraceMetricType
 TRACE_METRIC_TYPE(double, double);
 
 struct TraceEvent {
-	TraceEvent( const char* type, UID id = UID(), bool enabled = true );   // Assumes SevInfo severity
-	TraceEvent( Severity, const char* type, UID id = UID(), bool enabled = true );
-	TraceEvent( struct TraceInterval&, UID id = UID(), bool enabled = true );
-	TraceEvent( Severity severity, struct TraceInterval& interval, UID id = UID(), bool enabled = true );
+	TraceEvent(const char* type, UID id = UID(), bool enabled = true); // Assumes SevInfo severity
+	TraceEvent(Severity, const char* type, UID id = UID(), bool enabled = true);
+	TraceEvent(struct TraceInterval&, UID id = UID(), bool enabled = true);
+	TraceEvent(Severity severity, struct TraceInterval& interval, UID id = UID(), bool enabled = true);
 	// For defining debug TraceEvent
 
 	static void setNetworkThread();


### PR DESCRIPTION
I found extra trace events are useful in development. However, too many trace events are bad for productional environment and even for simulation environment.

Instead of removing the extra trace event before committing and adding them back for debugging, we can use the preprocessing macro to define debug TraceEvent type based on TraceEvent.

This PR first adding the `enable` parameter to TraceEvent constructor and then create a `FRTraceEvent` macro for Fast Restore