### PR TITLE
Include hgVersion.h in FLOW_SRCS

### DIFF
--- a/flow/CMakeLists.txt
+++ b/flow/CMakeLists.txt
@@ -63,6 +63,7 @@ set(FLOW_SRCS
   XmlTraceLogFormatter.cpp
   actorcompiler.h
   error_definitions.h
+  ${CMAKE_CURRENT_BINARY_DIR}/hgVersion.h
   flat_buffers.h
   flat_buffers.cpp
   flow.cpp


### PR DESCRIPTION
This way if we rebuild after reconfiguring, the binaries will pick up
the new hgVersion.h