### PR TITLE
Performant restore [3/XX]: Add fileIndex to RestoreFileFR struct and fix bugs for RestoreMaster

### DIFF
--- a/fdbserver/RestoreApplier.actor.h
+++ b/fdbserver/RestoreApplier.actor.h
@@ -82,8 +82,7 @@ struct RestoreApplierData : RestoreRoleData, public ReferenceCounted<RestoreAppl
 	}
 
 	void resetPerVersionBatch() {
-		RestoreRoleData::resetPerVersionBatch();
-
+		TraceEvent("FastRestore").detail("ResetPerVersionBatchOnApplier", nodeID);
 		inProgressApplyToDB = false;
 		kvOps.clear();
 		dbApplier = Optional<Future<Void>>();

--- a/fdbserver/RestoreCommon.actor.h
+++ b/fdbserver/RestoreCommon.actor.h
@@ -189,6 +189,7 @@ struct RestoreFileFR {
 	                      // [beginVersion, endVersion)
 	int64_t cursor; // The start block location to be restored. All blocks before cursor have been scheduled to load and
 	                // restore
+	int fileIndex; // index of backup file. Must be identical per file.
 
 	Tuple pack() const {
 		return Tuple()
@@ -199,7 +200,8 @@ struct RestoreFileFR {
 		    .append(blockSize)
 		    .append(endVersion)
 		    .append(beginVersion)
-		    .append(cursor);
+		    .append(cursor)
+		    .append(fileIndex);
 	}
 	static RestoreFileFR unpack(Tuple const& t) {
 		RestoreFileFR r;
@@ -212,26 +214,31 @@ struct RestoreFileFR {
 		r.endVersion = t.getInt(i++);
 		r.beginVersion = t.getInt(i++);
 		r.cursor = t.getInt(i++);
+		r.fileIndex = t.getInt(i++);
 		return r;
 	}
 
-	bool operator<(const RestoreFileFR& rhs) const { return beginVersion < rhs.beginVersion; }
+	bool operator<(const RestoreFileFR& rhs) const {
+		return beginVersion < rhs.beginVersion || (beginVersion == rhs.beginVersion && endVersion < rhs.endVersion) ||
+		       (beginVersion == rhs.beginVersion && endVersion == rhs.endVersion && fileIndex < rhs.fileIndex);
+	}
 
 	RestoreFileFR()
 	  : version(invalidVersion), isRange(false), blockSize(0), fileSize(0), endVersion(invalidVersion),
-	    beginVersion(invalidVersion), cursor(0) {}
+	    beginVersion(invalidVersion), cursor(0), fileIndex(0) {}
 
 	RestoreFileFR(Version version, std::string fileName, bool isRange, int64_t blockSize, int64_t fileSize,
 	              Version endVersion, Version beginVersion)
 	  : version(version), fileName(fileName), isRange(isRange), blockSize(blockSize), fileSize(fileSize),
-	    endVersion(endVersion), beginVersion(beginVersion), cursor(0) {}
+	    endVersion(endVersion), beginVersion(beginVersion), cursor(0), fileIndex(0) {}
 
 	std::string toString() const {
 		std::stringstream ss;
 		ss << "version:" << std::to_string(version) << " fileName:" << fileName
 		   << " isRange:" << std::to_string(isRange) << " blockSize:" << std::to_string(blockSize)
 		   << " fileSize:" << std::to_string(fileSize) << " endVersion:" << std::to_string(endVersion)
-		   << std::to_string(beginVersion) << " cursor:" << std::to_string(cursor);
+		   << std::to_string(beginVersion) << " cursor:" << std::to_string(cursor)
+		   << " fileIndex:" << std::to_string(fileIndex);
 		return ss.str();
 	}
 };

--- a/fdbserver/RestoreCommon.actor.h
+++ b/fdbserver/RestoreCommon.actor.h
@@ -219,8 +219,7 @@ struct RestoreFileFR {
 	}
 
 	bool operator<(const RestoreFileFR& rhs) const {
-		return beginVersion < rhs.beginVersion || (beginVersion == rhs.beginVersion && endVersion < rhs.endVersion) ||
-		       (beginVersion == rhs.beginVersion && endVersion == rhs.endVersion && fileIndex < rhs.fileIndex);
+		return std::tie(beginVersion, endVersion, fileIndex) < std::tie(rhs.beginVersion, rhs.endVersion, rhs.fileIndex);
 	}
 
 	RestoreFileFR()

--- a/fdbserver/RestoreLoader.actor.h
+++ b/fdbserver/RestoreLoader.actor.h
@@ -75,7 +75,6 @@ struct RestoreLoaderData : RestoreRoleData, public ReferenceCounted<RestoreLoade
 
 	void resetPerVersionBatch() {
 		TraceEvent("FastRestore").detail("ResetPerVersionBatchOnLoader", nodeID);
-		RestoreRoleData::resetPerVersionBatch();
 		rangeToApplier.clear();
 		keyOpsCount.clear();
 		numSampledMutations = 0;

--- a/fdbserver/RestoreMaster.actor.cpp
+++ b/fdbserver/RestoreMaster.actor.cpp
@@ -163,7 +163,6 @@ ACTOR Future<Void> startProcessRestoreRequests(Reference<RestoreMasterData> self
 	state Standalone<VectorRef<RestoreRequest>> restoreRequests = wait(collectRestoreRequests(cx));
 
 	// lock DB for restore
-	wait(lockDatabase(cx, randomUID));
 	state int numTries = 0;
 	loop {
 		try {

--- a/fdbserver/RestoreMaster.actor.cpp
+++ b/fdbserver/RestoreMaster.actor.cpp
@@ -60,12 +60,19 @@ void dummySampleWorkload(Reference<RestoreMasterData> self);
 ACTOR Future<Void> startRestoreMaster(Reference<RestoreWorkerData> masterWorker, Database cx) {
 	state Reference<RestoreMasterData> self = Reference<RestoreMasterData>(new RestoreMasterData());
 
-	// recruitRestoreRoles must come after masterWorker has finished collectWorkerInterface
-	wait(recruitRestoreRoles(masterWorker, self));
+	try {
+		// recruitRestoreRoles must come after masterWorker has finished collectWorkerInterface
+		wait(recruitRestoreRoles(masterWorker, self));
 
-	wait(distributeRestoreSysInfo(masterWorker, self));
+		wait(distributeRestoreSysInfo(masterWorker, self));
 
-	wait(startProcessRestoreRequests(self, cx));
+		wait(startProcessRestoreRequests(self, cx));
+	} catch (Error& e) {
+		TraceEvent(SevError, "FastRestore")
+		    .detail("StartRestoreMaster", "Unexpectedly unhandled error")
+		    .detail("Error", e.what())
+		    .detail("ErrorCode", e.code());
+	}
 
 	return Void();
 }
@@ -157,6 +164,28 @@ ACTOR Future<Void> startProcessRestoreRequests(Reference<RestoreMasterData> self
 
 	// lock DB for restore
 	wait(lockDatabase(cx, randomUID));
+	state int numTries = 0;
+	loop {
+		try {
+			wait(lockDatabase(cx, randomUID));
+			state Reference<ReadYourWritesTransaction> tr =
+			    Reference<ReadYourWritesTransaction>(new ReadYourWritesTransaction(cx));
+			tr->reset();
+			tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
+			tr->setOption(FDBTransactionOptions::LOCK_AWARE);
+			wait(checkDatabaseLock(tr, randomUID));
+			TraceEvent("FastRestore").detail("DBIsLocked", randomUID);
+			break;
+		} catch (Error& e) {
+			TraceEvent("FastRestore").detail("CheckLockError", e.what());
+			TraceEvent(numTries > 50 ? SevError : SevWarnAlways, "FastRestoreMayFail")
+			    .detail("Reason", "DB is not properly locked")
+			    .detail("ExpectedLockID", randomUID);
+			numTries++;
+			wait(delay(5.0));
+		}
+	}
+
 	wait(clearDB(cx));
 
 	// Step: Perform the restore requests
@@ -174,10 +203,15 @@ ACTOR Future<Void> startProcessRestoreRequests(Reference<RestoreMasterData> self
 	// Step: Notify all restore requests have been handled by cleaning up the restore keys
 	wait(notifyRestoreCompleted(self, cx));
 
-	try {
-		wait(unlockDatabase(cx, randomUID));
-	} catch (Error& e) {
-		TraceEvent(SevWarn, "UnlockDBFailed").detail("UID", randomUID.toString());
+	numTries = 0;
+	loop {
+		try {
+			wait(unlockDatabase(cx, randomUID));
+			break;
+		} catch (Error& e) {
+			TraceEvent(numTries > 50 ? SevError : SevWarn, "UnlockDBFailed").detail("UID", randomUID.toString());
+			numTries++;
+		}
 	}
 
 	TraceEvent("FastRestore").detail("RestoreMasterComplete", self->id());
@@ -200,6 +234,7 @@ ACTOR static Future<Version> processRestoreRequest(Reference<RestoreMasterData> 
 	for (versionBatch = self->versionBatches.begin(); versionBatch != self->versionBatches.end(); versionBatch++) {
 		wait(initializeVersionBatch(self));
 		wait(distributeWorkloadPerVersionBatch(self, cx, request, versionBatch->second));
+		self->batchIndex++;
 	}
 
 	TraceEvent("FastRestore").detail("RestoreToVersion", request.targetVersion);
@@ -223,11 +258,16 @@ ACTOR static Future<Void> loadFilesOnLoaders(Reference<RestoreMasterData> self, 
 		mutationLogPrefix = restoreConfig->mutationLogPrefix();
 	}
 
+	// sort files in increasing order of beginVersion
+	std::sort(files->begin(), files->end());
+
 	std::vector<std::pair<UID, RestoreLoadFileRequest>> requests;
 	std::map<UID, RestoreLoaderInterface>::iterator loader = self->loadersInterf.begin();
 
-	Version prevVersion = versionBatch.beginVersion;
+	// TODO: Remove files that are empty before proceed
+	// ASSERT(files->size() > 0); // files should not be empty
 
+	Version prevVersion = 0;
 	for (auto& file : *files) {
 		// NOTE: Cannot skip empty files because empty files, e.g., log file, still need to generate dummy mutation to
 		// drive applier's NotifiedVersion (e.g., logVersion and rangeVersion)
@@ -236,10 +276,12 @@ ACTOR static Future<Void> loadFilesOnLoaders(Reference<RestoreMasterData> self, 
 		}
 		// Prepare loading
 		LoadingParam param;
-		param.url = request.url;
-		param.prevVersion = prevVersion;
+
+		param.prevVersion = 0; // Each file's NotifiedVersion starts from 0
 		param.endVersion = file.isRange ? file.version : file.endVersion;
-		prevVersion = param.endVersion;
+		param.fileIndex = file.fileIndex;
+
+		param.url = request.url;
 		param.isRangeFile = file.isRange;
 		param.version = file.version;
 		param.filename = file.fileName;
@@ -250,14 +292,17 @@ ACTOR static Future<Void> loadFilesOnLoaders(Reference<RestoreMasterData> self, 
 		param.addPrefix = request.addPrefix;
 		param.removePrefix = request.removePrefix;
 		param.mutationLogPrefix = mutationLogPrefix;
+
+		prevVersion = param.endVersion;
+
+		// Log file to be loaded
+		TraceEvent("FastRestore").detail("LoadParam", param.toString()).detail("LoaderID", loader->first.toString());
 		ASSERT_WE_THINK(param.length >= 0); // we may load an empty file
 		ASSERT_WE_THINK(param.offset >= 0);
 		ASSERT_WE_THINK(param.offset <= file.fileSize);
 		ASSERT_WE_THINK(param.prevVersion <= param.endVersion);
 
 		requests.push_back(std::make_pair(loader->first, RestoreLoadFileRequest(param)));
-		// Log file to be loaded
-		TraceEvent("FastRestore").detail("LoadParam", param.toString()).detail("LoaderID", loader->first.toString());
 		loader++;
 	}
 

--- a/fdbserver/RestoreMaster.actor.h
+++ b/fdbserver/RestoreMaster.actor.h
@@ -132,10 +132,10 @@ struct RestoreMasterData : RestoreRoleData, public ReferenceCounted<RestoreMaste
 			std::sort(versionBatch->second.rangeFiles.begin(), versionBatch->second.rangeFiles.end());
 			std::sort(versionBatch->second.logFiles.begin(), versionBatch->second.logFiles.end());
 			for (auto& logFile : versionBatch->second.logFiles) {
-				logFile.fileIndex = (++fileIndex);
+				logFile.fileIndex = ++fileIndex;
 			}
 			for (auto& rangeFile : versionBatch->second.rangeFiles) {
-				rangeFile.fileIndex = (++fileIndex);
+				rangeFile.fileIndex = ++fileIndex;
 			}
 		}
 

--- a/fdbserver/RestoreRoleCommon.actor.h
+++ b/fdbserver/RestoreRoleCommon.actor.h
@@ -124,7 +124,7 @@ public:
 
 	UID id() const { return nodeID; }
 
-	void resetPerVersionBatch() { inProgressFlag = 0; }
+	virtual void resetPerVersionBatch() = 0;
 
 	void clearInterfaces() {
 		loadersInterf.clear();

--- a/fdbserver/RestoreWorkerInterface.h
+++ b/fdbserver/RestoreWorkerInterface.h
@@ -201,6 +201,7 @@ struct LoadingParam {
 	Key url;
 	Version prevVersion;
 	Version endVersion;
+	int fileIndex;
 	Version version;
 	std::string filename;
 	int64_t offset;
@@ -220,17 +221,16 @@ struct LoadingParam {
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, isRangeFile, url, prevVersion, endVersion, version, filename, offset, length, blockSize,
-		           restoreRange, addPrefix, removePrefix, mutationLogPrefix);
+		serializer(ar, isRangeFile, url, prevVersion, endVersion, fileIndex, version, filename, offset, length,
+		           blockSize, restoreRange, addPrefix, removePrefix, mutationLogPrefix);
 	}
 
 	std::string toString() {
 		std::stringstream str;
-		str << "isRangeFile:" << isRangeFile << "url:" << url.toString() << " prevVersion:" << prevVersion
-		    << " endVersion:" << endVersion << " version:" << version << " filename:" << filename
-		    << " offset:" << offset << " length:" << length << " blockSize:" << blockSize
-		    << " restoreRange:" << restoreRange.toString() << " addPrefix:" << addPrefix.toString()
-		    << " removePrefix:" << removePrefix.toString();
+		str << "isRangeFile:" << isRangeFile << " url:" << url.toString() << " prevVersion:" << prevVersion
+		    << " fileIndex:" << fileIndex << " endVersion:" << endVersion << " version:" << version
+		    << " filename:" << filename << " offset:" << offset << " length:" << length << " blockSize:" << blockSize
+		    << " restoreRange:" << restoreRange.toString() << " addPrefix:" << addPrefix.toString();
 		return str.str();
 	}
 };


### PR DESCRIPTION
The new coming backup system will create multiple backup files (one per log tag) that hold mutations at the same version. This raise new challenges for the performant restore to handle exact-once semantics.

This PR is a preparation for extending the performant restore to handle the above situation.

This PR makes two changes:
1) Add fileIndex to RestoreFileFR struct; fileIndex will be the unique identifier for backup files;
2) Fix some bugs in RestoreMaster: For example, ensure database is locked before starts restore.

