### PR TITLE
Performant restore [5/XX]:RestoreApplier should cache mutations sent from RestoreLoader exactly once

### DIFF
--- a/fdbserver/RestoreApplier.actor.cpp
+++ b/fdbserver/RestoreApplier.actor.cpp
@@ -93,6 +93,8 @@ ACTOR Future<Void> restoreApplierCore(RestoreApplierInterface applierInterf, int
 // Only one actor can process mutations from the same file
 ACTOR static Future<Void> handleSendMutationVectorRequest(RestoreSendMutationVectorVersionedRequest req,
                                                           Reference<RestoreApplierData> self) {
+	// Assume: self->processedFileState[req.fileIndex] will not be erased while the actor is active.
+	// Note: Insert new items into processedFileState will not invalidate the reference.
 	state NotifiedVersion& curFilePos = self->processedFileState[req.fileIndex];
 
 	TraceEvent("FastRestore")

--- a/fdbserver/RestoreApplier.actor.h
+++ b/fdbserver/RestoreApplier.actor.h
@@ -41,8 +41,8 @@
 #include "flow/actorcompiler.h" // has to be last include
 
 struct RestoreApplierData : RestoreRoleData, public ReferenceCounted<RestoreApplierData> {
-	NotifiedVersion rangeVersion; // All requests of mutations in range file below this version has been processed
-	NotifiedVersion logVersion; // All requests of mutations in log file below this version has been processed
+	// processedFileState: key: file unique index; value: largest version of mutation received on the applier
+	std::map<uint32_t, NotifiedVersion> processedFileState;
 	Optional<Future<Void>> dbApplier;
 
 	// rangeToApplier is in master and loader. Loader uses it to determine which applier a mutation should be sent

--- a/fdbserver/RestoreMaster.actor.cpp
+++ b/fdbserver/RestoreMaster.actor.cpp
@@ -266,7 +266,7 @@ ACTOR static Future<Void> loadFilesOnLoaders(Reference<RestoreMasterData> self, 
 	Version prevVersion = 0;
 	for (auto& file : *files) {
 		// NOTE: Cannot skip empty files because empty files, e.g., log file, still need to generate dummy mutation to
-		// drive applier's NotifiedVersion (e.g., logVersion and rangeVersion)
+		// drive applier's NotifiedVersion.
 		if (loader == self->loadersInterf.end()) {
 			loader = self->loadersInterf.begin();
 		}


### PR DESCRIPTION
When RestoreLoader sends the parsed mutations to RestoreAppliers, the message can be resent.

RestoreApplier should only cache the parsed mutations exactly once, because those mutations may include atomic operations.

RestoreApplier keeps a NotifiedVersion for each parsed file to achieve the above exact-once requirement.