### PR TITLE
Revert "Clean up some memory after network thread exits"

### DIFF
--- a/flow/IRandom.h
+++ b/flow/IRandom.h
@@ -90,7 +90,6 @@ namespace std {
 
 class IRandom {
 public:
-	virtual ~IRandom() = default;
 	virtual double random01() = 0; // return random value in [0, 1]
 	virtual int randomInt(int min, int maxPlusOne) = 0;
 	virtual int64_t randomInt64(int64_t min, int64_t maxPlusOne) = 0;

--- a/flow/Net2.actor.cpp
+++ b/flow/Net2.actor.cpp
@@ -732,10 +732,6 @@ void Net2::run() {
 	#ifdef WIN32
 	timeEndPeriod(1);
 	#endif
-
-	// clean up memory
-	delete this;
-	thread_network = nullptr;
 }
 
 void Net2::trackMinPriority( TaskPriority minTaskID, double now ) {


### PR DESCRIPTION
Reverts apple/foundationdb#2300

This seems to cause client segfault when existing. Presumably the client is still accessing the deleted `g_network`.