### PR TITLE
Performant restore [8/XX]: Fix bugs in applyToDB logic and add more tests

### DIFF
--- a/fdbclient/SystemData.cpp
+++ b/fdbclient/SystemData.cpp
@@ -641,6 +641,7 @@ const KeyRangeRef restoreApplierKeys(LiteralStringRef("\xff\x02/restoreApplier/"
 const KeyRef restoreApplierTxnValue = LiteralStringRef("1");
 
 // restoreApplierKeys: track atomic transaction progress to ensure applying atomicOp exactly once
+// Version integer must be BigEndian to maintain ordering in lexical order
 const Key restoreApplierKeyFor(UID const& applierID, Version version) {
 	BinaryWriter wr(Unversioned());
 	wr.serializeBytes(restoreApplierKeys.begin);

--- a/fdbclient/SystemData.cpp
+++ b/fdbclient/SystemData.cpp
@@ -643,9 +643,17 @@ const KeyRef restoreApplierTxnValue = LiteralStringRef("1");
 // restoreApplierKeys: track atomic transaction progress to ensure applying atomicOp exactly once
 const Key restoreApplierKeyFor(UID const& applierID, Version version) {
 	BinaryWriter wr(Unversioned());
-	wr.serializeBytes(restoreWorkersKeys.begin);
+	wr.serializeBytes(restoreApplierKeys.begin);
 	wr << applierID << version;
 	return wr.toValue();
+}
+
+std::pair<UID, Version> decodeRestoreApplierKey(ValueRef const& key) {
+	BinaryReader rd(key, Unversioned());
+	UID applierID;
+	Version version;
+	rd >> applierID >> version;
+	return std::make_pair(applierID, version);
 }
 
 // Encode restore worker key for workerID

--- a/fdbclient/SystemData.cpp
+++ b/fdbclient/SystemData.cpp
@@ -641,11 +641,11 @@ const KeyRangeRef restoreApplierKeys(LiteralStringRef("\xff\x02/restoreApplier/"
 const KeyRef restoreApplierTxnValue = LiteralStringRef("1");
 
 // restoreApplierKeys: track atomic transaction progress to ensure applying atomicOp exactly once
-// Version integer must be BigEndian to maintain ordering in lexical order
+// Version is passed in as LittleEndian, it must be converted to BigEndian to maintain ordering in lexical order
 const Key restoreApplierKeyFor(UID const& applierID, Version version) {
 	BinaryWriter wr(Unversioned());
 	wr.serializeBytes(restoreApplierKeys.begin);
-	wr << applierID << version;
+	wr << applierID << bigEndian64(version);
 	return wr.toValue();
 }
 
@@ -654,7 +654,7 @@ std::pair<UID, Version> decodeRestoreApplierKey(ValueRef const& key) {
 	UID applierID;
 	Version version;
 	rd >> applierID >> version;
-	return std::make_pair(applierID, version);
+	return std::make_pair(applierID, bigEndian64(version));
 }
 
 // Encode restore worker key for workerID

--- a/fdbclient/SystemData.h
+++ b/fdbclient/SystemData.h
@@ -298,6 +298,7 @@ extern const KeyRangeRef restoreApplierKeys;
 extern const KeyRef restoreApplierTxnValue;
 
 const Key restoreApplierKeyFor(UID const& applierID, Version version);
+std::pair<UID, Version> decodeRestoreApplierKey(ValueRef const& key);
 const Key restoreWorkerKeyFor(UID const& workerID);
 const Value restoreWorkerInterfaceValue(RestoreWorkerInterface const& server);
 RestoreWorkerInterface decodeRestoreWorkerInterfaceValue(ValueRef const& value);

--- a/fdbserver/RestoreApplier.actor.cpp
+++ b/fdbserver/RestoreApplier.actor.cpp
@@ -277,8 +277,8 @@ ACTOR Future<Void> applyToDB(Reference<RestoreApplierData> self, Database cx) {
 			tr->reset();
 			tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
 			tr->setOption(FDBTransactionOptions::LOCK_AWARE);
-			Key begin = restoreApplierKeyFor(
-			    self->id(), bigEndian64(0)); // Integer must be BigEndian to maintain ordering in lexical order
+			// Version integer must be BigEndian to maintain ordering in lexical order
+			Key begin = restoreApplierKeyFor(self->id(), bigEndian64(0));
 			Key end = restoreApplierKeyFor(self->id(), bigEndian64(std::numeric_limits<int64_t>::max()));
 			Standalone<RangeResultRef> txnIds = wait(tr->getRange(KeyRangeRef(begin, end), CLIENT_KNOBS->TOO_MANY));
 			if (txnIds.size() > 0) {

--- a/fdbserver/RestoreApplier.actor.cpp
+++ b/fdbserver/RestoreApplier.actor.cpp
@@ -287,7 +287,7 @@ ACTOR Future<Void> applyToDB(Reference<RestoreApplierData> self, Database cx) {
 					std::pair<UID, Version> applierInfo = decodeRestoreApplierKey(kv.key);
 					TraceEvent(SevError, "FastRestore_ApplyTxnStateNotClean")
 					    .detail("Applier", applierInfo.first)
-					    .detail("ResidueTxnID", applierInfo.second);
+					    .detail("ResidueTxnID", bigEndian64(applierInfo.second));
 				}
 			}
 			break;

--- a/fdbserver/RestoreLoader.actor.cpp
+++ b/fdbserver/RestoreLoader.actor.cpp
@@ -86,7 +86,7 @@ ACTOR Future<Void> restoreLoaderCore(RestoreLoaderInterface loaderInterf, int no
 				}
 				when(RestoreVersionBatchRequest req = waitNext(loaderInterf.initVersionBatch.getFuture())) {
 					requestTypeStr = "initVersionBatch";
-					handleInitVersionBatchRequest(req, self);
+					wait(handleInitVersionBatchRequest(req, self));
 				}
 				when(RestoreVersionBatchRequest req = waitNext(loaderInterf.finishRestore.getFuture())) {
 					requestTypeStr = "finishRestore";

--- a/fdbserver/RestoreMaster.actor.h
+++ b/fdbserver/RestoreMaster.actor.h
@@ -68,7 +68,8 @@ struct RestoreMasterData : RestoreRoleData, public ReferenceCounted<RestoreMaste
 	RestoreMasterData() {
 		role = RestoreRole::Master;
 		nodeID = UID();
-		batchIndex = 0;
+		batchIndex =
+		    1; // batchIndex must starts with 1 because NotifiedVersion batchId in loaders and appliers start with 0
 	}
 
 	~RestoreMasterData() = default;
@@ -128,15 +129,23 @@ struct RestoreMasterData : RestoreRoleData, public ReferenceCounted<RestoreMaste
 		// Assumption: fileIndex starts at 1. Each loader's initized fileIndex (NotifiedVersion type) starts at 0
 		int fileIndex = 0; // fileIndex must be unique; ideally it continuously increase across verstionBatches for
 		                   // easier progress tracking
+		int versionBatchId = 1;
 		for (auto versionBatch = versionBatches->begin(); versionBatch != versionBatches->end(); versionBatch++) {
 			std::sort(versionBatch->second.rangeFiles.begin(), versionBatch->second.rangeFiles.end());
 			std::sort(versionBatch->second.logFiles.begin(), versionBatch->second.logFiles.end());
 			for (auto& logFile : versionBatch->second.logFiles) {
 				logFile.fileIndex = ++fileIndex;
+				TraceEvent("FastRestore")
+				    .detail("VersionBatchId", versionBatchId)
+				    .detail("LogFile", logFile.toString());
 			}
 			for (auto& rangeFile : versionBatch->second.rangeFiles) {
 				rangeFile.fileIndex = ++fileIndex;
+				TraceEvent("FastRestore")
+				    .detail("VersionBatchId", versionBatchId)
+				    .detail("RangeFile", rangeFile.toString());
 			}
+			versionBatchId++;
 		}
 
 		TraceEvent("FastRestore").detail("VersionBatches", versionBatches->size());

--- a/fdbserver/RestoreMaster.actor.h
+++ b/fdbserver/RestoreMaster.actor.h
@@ -68,8 +68,7 @@ struct RestoreMasterData : RestoreRoleData, public ReferenceCounted<RestoreMaste
 	RestoreMasterData() {
 		role = RestoreRole::Master;
 		nodeID = UID();
-		batchIndex =
-		    1; // batchIndex must starts with 1 because NotifiedVersion batchId in loaders and appliers start with 0
+		batchIndex = 1; // starts with 1 because batchId (NotifiedVersion) in loaders and appliers start with 0
 	}
 
 	~RestoreMasterData() = default;

--- a/fdbserver/RestoreRoleCommon.actor.cpp
+++ b/fdbserver/RestoreRoleCommon.actor.cpp
@@ -55,9 +55,9 @@ void handleFinishRestoreRequest(const RestoreVersionBatchRequest& req, Reference
 	req.reply.send(RestoreCommonReply(self->id()));
 }
 
-void handleInitVersionBatchRequest(const RestoreVersionBatchRequest& req, Reference<RestoreRoleData> self) {
+ACTOR Future<Void> handleInitVersionBatchRequest(RestoreVersionBatchRequest req, Reference<RestoreRoleData> self) {
 	// batchId is continuous. (req.batchID-1) is the id of the just finished batch.
-	self->versionBatchId.whenAtLeast(req.batchID - 1);
+	wait(self->versionBatchId.whenAtLeast(req.batchID - 1));
 
 	if (self->versionBatchId.get() == req.batchID - 1) {
 		self->resetPerVersionBatch();
@@ -69,6 +69,7 @@ void handleInitVersionBatchRequest(const RestoreVersionBatchRequest& req, Refere
 	}
 
 	req.reply.send(RestoreCommonReply(self->id()));
+	return Void();
 }
 
 //-------Helper functions

--- a/fdbserver/RestoreRoleCommon.actor.h
+++ b/fdbserver/RestoreRoleCommon.actor.h
@@ -32,6 +32,7 @@
 #include "flow/Stats.h"
 #include "fdbclient/FDBTypes.h"
 #include "fdbclient/CommitTransaction.h"
+#include "fdbclient/Notified.h"
 #include "fdbrpc/fdbrpc.h"
 #include "fdbrpc/Locality.h"
 #include "fdbserver/CoordinationInterface.h"
@@ -113,6 +114,8 @@ public:
 	std::map<UID, RestoreLoaderInterface> loadersInterf;
 	std::map<UID, RestoreApplierInterface> appliersInterf;
 	RestoreApplierInterface masterApplierInterf;
+
+	NotifiedVersion versionBatchId; // Continuously increase for each versionBatch
 
 	bool versionBatchStart = false;
 

--- a/fdbserver/RestoreRoleCommon.actor.h
+++ b/fdbserver/RestoreRoleCommon.actor.h
@@ -55,7 +55,7 @@ struct RestoreSimpleRequest;
 typedef std::map<Version, Standalone<VectorRef<MutationRef>>> VersionedMutationsMap;
 
 ACTOR Future<Void> handleHeartbeat(RestoreSimpleRequest req, UID id);
-void handleInitVersionBatchRequest(const RestoreVersionBatchRequest& req, Reference<RestoreRoleData> self);
+ACTOR Future<Void> handleInitVersionBatchRequest(RestoreVersionBatchRequest req, Reference<RestoreRoleData> self);
 void handleFinishRestoreRequest(const RestoreVersionBatchRequest& req, Reference<RestoreRoleData> self);
 
 // Helper class for reading restore data from a buffer and throwing the right errors.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -199,6 +199,7 @@ add_fdb_test(TEST_FILES slow/WriteDuringReadAtomicRestore.txt)
 add_fdb_test(TEST_FILES slow/WriteDuringReadSwitchover.txt)
 add_fdb_test(TEST_FILES slow/ddbalance.txt)
 add_fdb_test(TEST_FILES slow/ParallelRestoreCorrectnessAtomicOpTinyData.txt)
+add_fdb_test(TEST_FILES slow/ParallelRestoreCorrectnessCycle.txt)
 # Note that status tests are not deterministic.
 add_fdb_test(TEST_FILES status/invalid_proc_addresses.txt)
 add_fdb_test(TEST_FILES status/local_6_machine_no_replicas_remain.txt)

--- a/tests/slow/ParallelRestoreCorrectnessAtomicOpTinyData.txt
+++ b/tests/slow/ParallelRestoreCorrectnessAtomicOpTinyData.txt
@@ -1,10 +1,10 @@
 testTitle=BackupAndParallelRestoreWithAtomicOp
     testName=AtomicOps
-;    nodeCount=30000
+    nodeCount=30000
 ; Make ops space only 1 key per group
-    nodeCount=100
-;    transactionsPerSecond=2500.0
-    transactionsPerSecond=500.0
+;    nodeCount=100
+    transactionsPerSecond=2500.0
+;    transactionsPerSecond=500.0
 ;    transactionsPerSecond=100.0
 ;    nodeCount=4
 ;    transactionsPerSecond=250.0

--- a/tests/slow/ParallelRestoreCorrectnessCycle.txt
+++ b/tests/slow/ParallelRestoreCorrectnessCycle.txt
@@ -1,0 +1,76 @@
+testTitle=BackupAndRestore
+     testName=Cycle
+ ;    nodeCount=30000
+     nodeCount=1000
+     transactionsPerSecond=500.0
+ ;    transactionsPerSecond=2500.0
+     testDuration=30.0
+     expectedRate=0
+     clearAfterTest=false
+ ;	keyPrefix=!
+
+ ;    testName=Cycle
+ ;;    nodeCount=1000
+ ;    transactionsPerSecond=2500.0
+ ;    testDuration=30.0
+ ;    expectedRate=0
+ ;    clearAfterTest=false
+ ;	keyPrefix=z
+ ;
+ ;    testName=Cycle
+ ;;    nodeCount=1000
+ ;    transactionsPerSecond=2500.0
+ ;    testDuration=30.0
+ ;    expectedRate=0
+ ;    clearAfterTest=false
+ ;	keyPrefix=A
+ ;
+ ;    testName=Cycle
+ ;;    nodeCount=1000
+ ;    transactionsPerSecond=2500.0
+ ;    testDuration=30.0
+ ;    expectedRate=0
+ ;    clearAfterTest=false
+ ;	keyPrefix=Z
+
+ ; Each testName=RunRestoreWorkerWorkload creates a restore worker
+ ; We need at least 3 restore workers: master, loader, and applier
+     testName=RunRestoreWorkerWorkload
+
+ ; Test case for parallel restore
+     testName=BackupAndParallelRestoreCorrectness
+     backupAfter=10.0
+     restoreAfter=60.0
+     clearAfterTest=false
+     simBackupAgents=BackupToFile
+ ; backupRangesCount<0 means backup the entire normal keyspace
+     backupRangesCount=-1
+ ; TODO: Support abortAndRestartAfter test by commenting it out
+     abortAndRestartAfter=0
+
+     testName=RandomClogging
+     testDuration=90.0
+
+ ;    testName=Rollback
+ ;    meanDelay=90.0
+ ;    testDuration=90.0
+
+ ; Do NOT consider machine crash yet
+ ;    testName=Attrition
+ ;    machinesToKill=10
+ ;    machinesToLeave=3
+ ;    reboot=true
+ ;    testDuration=90.0
+
+ ;    testName=Attrition
+ ;    machinesToKill=10
+ ;    machinesToLeave=3
+ ;    reboot=true
+ ;    testDuration=90.0
+
+ ; Disable buggify for parallel restore
+ buggify=off
+ ;testDuration=360000 ;not work
+ ;timeout is in seconds
+ timeout=360000
+


### PR DESCRIPTION
The applyToDB step writes mutations to the destination database. Atomic mutations must be applied exactly once for correctness. Other mutations should be applied exactly once for performance benefit.
The current code has a bug that neglects the serialized form (little endian) of the integer type of transaction id. This leads to the serialized transaction ids in the system keyspace are not ordered by the integer value. When transaction throws unknown error and the old transaction id is not properly cleared, we will lose some mutations.

This PR fixes the above bug.

This PR also enhance the tests:
(a) Increase the workload of the AtomicOps tests;
(b) Add the Cycle test for the fast restore.