### PR TITLE
Fixed bug in maintaining kill set size in RemoveServersSafely workload

### DIFF
--- a/fdbserver/workloads/RemoveServersSafely.actor.cpp
+++ b/fdbserver/workloads/RemoveServersSafely.actor.cpp
@@ -461,6 +461,7 @@ struct RemoveServersSafelyWorkload : TestWorkload {
 				    .detail("Removing", removeServer->toString());
 				toKillMarkFailedArray.erase(removeServer);
 			}
+			ASSERT(toKillMarkFailedArray.size() <= toKillArray.size());
 			auto removeServer = toKill.begin();
 			TraceEvent("RemoveAndKill", functionId)
 				.detail("Step", "ReplaceNonFailedKillSet")


### PR DESCRIPTION
Fixed test case scenario where having a larger failed set than non-failed set would break the db and cause the test to time out. Also re-arranged ordering of non-failed set replacement due to dependency on an iterator