### PR TITLE
AtomicOps Test: Add more detailed debug information when test fails with opType = AddValue

### DIFF
--- a/fdbclient/BackupContainer.h
+++ b/fdbclient/BackupContainer.h
@@ -173,7 +173,7 @@ struct RestorableFileSet {
 	Version targetVersion;
 	std::vector<LogFile> logs;
 	std::vector<RangeFile> ranges;
-	KeyspaceSnapshotFile snapshot;
+	KeyspaceSnapshotFile snapshot; // Info. for debug purposes
 };
 
 /* IBackupContainer is an interface to a set of backup data, which contains

--- a/fdbclient/RestoreWorkerInterface.actor.h
+++ b/fdbclient/RestoreWorkerInterface.actor.h
@@ -360,7 +360,7 @@ struct RestoreSendMutationVectorVersionedRequest : TimedRequest {
 
 	std::string toString() {
 		std::stringstream ss;
-		ss << "fileIndex" << fileIndex << "prevVersion:" << prevVersion << " version:" << version
+		ss << "fileIndex" << fileIndex << " prevVersion:" << prevVersion << " version:" << version
 		   << " isRangeFile:" << isRangeFile << " mutations.size:" << mutations.size();
 		return ss.str();
 	}

--- a/fdbclient/RestoreWorkerInterface.actor.h
+++ b/fdbclient/RestoreWorkerInterface.actor.h
@@ -360,7 +360,7 @@ struct RestoreSendMutationVectorVersionedRequest : TimedRequest {
 
 	std::string toString() {
 		std::stringstream ss;
-		ss << "fileIndex" << fileIndex << " prevVersion:" << prevVersion << " version:" << version
+		ss << "fileIndex:" << fileIndex << " prevVersion:" << prevVersion << " version:" << version
 		   << " isRangeFile:" << isRangeFile << " mutations.size:" << mutations.size();
 		return ss.str();
 	}

--- a/fdbserver/RestoreApplier.actor.cpp
+++ b/fdbserver/RestoreApplier.actor.cpp
@@ -123,6 +123,7 @@ ACTOR static Future<Void> handleSendMutationVectorRequest(RestoreSendMutationVec
 			    .detail("Index", mIndex)
 			    .detail("MutationReceived", mutation.toString());
 			self->kvOps[commitVersion].push_back_deep(self->kvOps[commitVersion].arena(), mutation);
+			// TODO: What if log file's mutations are delivered out-of-order (behind) the range file's mutations?!
 		}
 		curFilePos.set(req.version);
 	}

--- a/fdbserver/RestoreCommon.actor.h
+++ b/fdbserver/RestoreCommon.actor.h
@@ -236,7 +236,7 @@ struct RestoreFileFR {
 		ss << "version:" << std::to_string(version) << " fileName:" << fileName
 		   << " isRange:" << std::to_string(isRange) << " blockSize:" << std::to_string(blockSize)
 		   << " fileSize:" << std::to_string(fileSize) << " endVersion:" << std::to_string(endVersion)
-		   << std::to_string(beginVersion) << " cursor:" << std::to_string(cursor)
+		   << " beginVersion:" << std::to_string(beginVersion) << " cursor:" << std::to_string(cursor)
 		   << " fileIndex:" << std::to_string(fileIndex);
 		return ss.str();
 	}

--- a/fdbserver/RestoreLoader.actor.cpp
+++ b/fdbserver/RestoreLoader.actor.cpp
@@ -134,7 +134,7 @@ void handleSetApplierKeyRangeVectorRequest(const RestoreSetApplierKeyRangeVector
 	if (self->rangeToApplier.empty()) {
 		self->rangeToApplier = req.rangeToApplier;
 	} else {
-		ASSERT_WE_THINK(self->rangeToApplier == req.rangeToApplier);
+		ASSERT(self->rangeToApplier == req.rangeToApplier);
 	}
 	req.reply.send(RestoreCommonReply(self->id()));
 }

--- a/fdbserver/RestoreLoader.actor.cpp
+++ b/fdbserver/RestoreLoader.actor.cpp
@@ -127,9 +127,14 @@ void handleRestoreSysInfoRequest(const RestoreSysInfoRequest& req, Reference<Res
 
 void handleSetApplierKeyRangeVectorRequest(const RestoreSetApplierKeyRangeVectorRequest& req,
                                            Reference<RestoreLoaderData> self) {
+	TraceEvent("FastRestore")
+	    .detail("Loader", self->id())
+	    .detail("SetApplierKeyRangeVector", req.rangeToApplier.size());
 	// Idempodent operation. OK to re-execute the duplicate cmd
 	if (self->rangeToApplier.empty()) {
 		self->rangeToApplier = req.rangeToApplier;
+	} else {
+		ASSERT_WE_THINK(self->rangeToApplier == req.rangeToApplier);
 	}
 	req.reply.send(RestoreCommonReply(self->id()));
 }
@@ -185,6 +190,8 @@ ACTOR Future<Void> handleLoadFileRequest(RestoreLoadFileRequest req, Reference<R
 		TraceEvent("FastRestore").detail("Loader", self->id()).detail("ProcessLoadParam", req.param.toString());
 		self->processedFileParams[req.param] = Never();
 		self->processedFileParams[req.param] = _processLoadingParam(req.param, self);
+	} else {
+		TraceEvent("FastRestore").detail("Loader", self->id()).detail("WaitOnProcessLoadParam", req.param.toString());
 	}
 	ASSERT(self->processedFileParams.find(req.param) != self->processedFileParams.end());
 	wait(self->processedFileParams[req.param]); // wait on the processing of the req.param.

--- a/fdbserver/RestoreMaster.actor.cpp
+++ b/fdbserver/RestoreMaster.actor.cpp
@@ -412,11 +412,13 @@ ACTOR static Future<Void> collectBackupFiles(Reference<IBackupContainer> bc, std
 	for (const RangeFile& f : restorable.get().ranges) {
 		TraceEvent("FastRestore").detail("RangeFile", f.toString());
 		RestoreFileFR file(f.version, f.fileName, true, f.blockSize, f.fileSize, f.version, f.version);
+		TraceEvent("FastRestore").detail("RangeFileFR", file.toString());
 		files->push_back(file);
 	}
 	for (const LogFile& f : restorable.get().logs) {
 		TraceEvent("FastRestore").detail("LogFile", f.toString());
 		RestoreFileFR file(f.beginVersion, f.fileName, false, f.blockSize, f.fileSize, f.endVersion, f.beginVersion);
+		TraceEvent("FastRestore").detail("LogFileFR", file.toString());
 		files->push_back(file);
 	}
 

--- a/fdbserver/workloads/AtomicOps.actor.cpp
+++ b/fdbserver/workloads/AtomicOps.actor.cpp
@@ -33,6 +33,7 @@ struct AtomicOpsWorkload : TestWorkload {
 
 	double testDuration, transactionsPerSecond;
 	vector<Future<Void>> clients;
+	uint64_t lbsum, ubsum; // Tell if setup txn fails when opType = AddValue
 
 	AtomicOpsWorkload(WorkloadContext const& wcx)
 		: TestWorkload(wcx), opNum(0)
@@ -47,7 +48,10 @@ struct AtomicOpsWorkload : TestWorkload {
 		apiVersion500 = ((sharedRandomNumber % 10) == 0);
 		TraceEvent("AtomicOpsApiVersion500").detail("ApiVersion500", apiVersion500);
 
-		int64_t randNum = sharedRandomNumber / 10;
+		lbsum = 0;
+		ubsum = 0;
+
+		    int64_t randNum = sharedRandomNumber / 10;
 		if(opType == -1)
 			opType = randNum % 8;
 
@@ -119,7 +123,13 @@ struct AtomicOpsWorkload : TestWorkload {
 	virtual void getMetrics( vector<PerfMetric>& m ) {
 	}
 
-	Key logKey( int group ) { return StringRef(format("log%08x%08x%08x",group,clientId,opNum++));}
+	// Key logKey( int group ) { return StringRef(format("log%08x%08x%08x",group,clientId,opNum++));}
+	std::pair<Key, Key> logDebugKey(int group) {
+		Key logKey(format("log%08x%08x%08x", group, clientId, opNum));
+		Key debugKey(format("debug%08x%08x%08x", group, clientId, opNum));
+		opNum++;
+		return std::make_pair(logKey, debugKey);
+	}
 
 	ACTOR Future<Void> _setup( Database cx, AtomicOpsWorkload* self ) {
 		// Sanity check if log keyspace has elements
@@ -172,27 +182,136 @@ struct AtomicOpsWorkload : TestWorkload {
 			loop {
 				try {
 					int group = deterministicRandom()->randomInt(0,100);
-					uint64_t intValue = deterministicRandom()->randomInt( 0, 10000000 );
+					state uint64_t intValue = deterministicRandom()->randomInt(0, 10000000);
 					Key val = StringRef((const uint8_t*) &intValue, sizeof(intValue));
-					tr.set(self->logKey(group), val);
+					std::pair<Key, Key> logDebugKey = self->logDebugKey(group);
 					int nodeIndex = deterministicRandom()->randomInt(0, self->nodeCount / 100);
-					tr.atomicOp(StringRef(format("ops%08x%08x", group, nodeIndex)), val, self->opType);
-					// TraceEvent(SevDebug, "AtomicOpWorker")
-					//     .detail("LogKey", self->logKey(group))
-					//     .detail("Value", val)
-					//     .detail("ValueInt", intValue);
-					// TraceEvent(SevDebug, "AtomicOpWorker")
-					//     .detail("OpKey", format("ops%08x%08x", group, nodeIndex))
-					//     .detail("Value", val)
-					//     .detail("ValueInt", intValue)
-					//     .detail("AtomicOp", self->opType);
+					Key opsKey(format("ops%08x%08x", group, nodeIndex));
+					tr.set(logDebugKey.first, val); // set log key
+					tr.set(logDebugKey.second, opsKey); // set debug key; one opsKey can have multiple logs key
+					tr.atomicOp(opsKey, val, self->opType);
 					wait( tr.commit() );
+					if (self->opType == MutationRef::AddValue) {
+						self->lbsum += intValue;
+						self->ubsum += intValue;
+					}
 					break;
 				} catch( Error &e ) {
 					wait( tr.onError(e) );
+					if (self->opType == MutationRef::AddValue) {
+						self->ubsum += intValue;
+					}
 				}
 			}
 		}
+	}
+
+	ACTOR Future<Void> dumpLogKV(Database cx, int g) {
+		ReadYourWritesTransaction tr(cx);
+		Key begin(format("log%08x", g));
+		Standalone<RangeResultRef> log = wait(tr.getRange(KeyRangeRef(begin, strinc(begin)), CLIENT_KNOBS->TOO_MANY));
+		uint64_t sum = 0;
+		for (auto& kv : log) {
+			uint64_t intValue = 0;
+			memcpy(&intValue, kv.value.begin(), kv.value.size());
+			sum += intValue;
+			TraceEvent("AtomicOpLog")
+			    .detail("Key", kv.key)
+			    .detail("Val", kv.value)
+			    .detail("IntValue", intValue)
+			    .detail("CurSum", sum);
+		}
+		return Void();
+	}
+
+	ACTOR Future<Void> dumpDebugKV(Database cx, int g) {
+		ReadYourWritesTransaction tr(cx);
+		Key begin(format("debug%08x", g));
+		Standalone<RangeResultRef> log = wait(tr.getRange(KeyRangeRef(begin, strinc(begin)), CLIENT_KNOBS->TOO_MANY));
+		for (auto& kv : log) {
+			TraceEvent("AtomicOpDebug").detail("Key", kv.key).detail("Val", kv.value);
+		}
+		return Void();
+	}
+
+	ACTOR Future<Void> dumpOpsKV(Database cx, int g) {
+		ReadYourWritesTransaction tr(cx);
+		Key begin(format("ops%08x", g));
+		Standalone<RangeResultRef> ops = wait(tr.getRange(KeyRangeRef(begin, strinc(begin)), CLIENT_KNOBS->TOO_MANY));
+		uint64_t sum = 0;
+		for (auto& kv : ops) {
+			uint64_t intValue = 0;
+			memcpy(&intValue, kv.value.begin(), kv.value.size());
+			sum += intValue;
+			TraceEvent("AtomicOpOps")
+			    .detail("Key", kv.key)
+			    .detail("Val", kv.value)
+			    .detail("IntVal", intValue)
+			    .detail("CurSum", sum);
+		}
+		return Void();
+	}
+
+	ACTOR Future<Void> validateOpsKey(Database cx, AtomicOpsWorkload* self, int g) {
+		// Get mapping between opsKeys and debugKeys
+		state ReadYourWritesTransaction tr1(cx);
+		state std::map<Key, Key> records; // <ops, debugKey>
+		Key begin(format("debug%08x", g));
+		Standalone<RangeResultRef> debuglog =
+		    wait(tr1.getRange(KeyRangeRef(begin, strinc(begin)), CLIENT_KNOBS->TOO_MANY));
+		for (auto& kv : debuglog) {
+			records[kv.value] = kv.key;
+		}
+
+		// Get log key's value and assign it to the associated debugKey
+		state ReadYourWritesTransaction tr2(cx);
+		state std::map<Key, int64_t> logVal; // debugKey, log's value
+		Key begin(format("log%08x", g));
+		Standalone<RangeResultRef> log = wait(tr2.getRange(KeyRangeRef(begin, strinc(begin)), CLIENT_KNOBS->TOO_MANY));
+		for (auto& kv : log) {
+			uint64_t intValue = 0;
+			memcpy(&intValue, kv.value.begin(), kv.value.size());
+			logVal[kv.key.removePrefix(LiteralStringRef("log")).withPrefix(LiteralStringRef("debug"))] = intValue;
+		}
+
+		// Get opsKeys and validate if it has correct value
+		state ReadYourWritesTransaction tr3(cx);
+		state std::map<Key, int64_t> opsVal; // ops key, ops value
+		Key begin(format("ops%08x", g));
+		Standalone<RangeResultRef> ops = wait(tr3.getRange(KeyRangeRef(begin, strinc(begin)), CLIENT_KNOBS->TOO_MANY));
+		// Validate if ops' key value is consistent with logs' key value
+		for (auto& kv : ops) {
+			bool inRecord = records.find(kv.key) != records.end();
+			uint64_t intValue = 0;
+			memcpy(&intValue, kv.value.begin(), kv.value.size());
+			opsVal[kv.key] = intValue;
+			if (!inRecord) {
+				TraceEvent(SevError, "MissingLogKey").detail("OpsKey", kv.key);
+			}
+			if (inRecord && intValue == 0) {
+				TraceEvent(SevError, "MissingOpsKey1").detail("OpsKey", kv.key).detail("DebugKey", records[kv.key]);
+			}
+			if (inRecord && (self->actorCount == 1 && intValue != logVal[records[kv.key]])) {
+				// When multiple actors exist, 1 opsKey can have multiple log keys
+				TraceEvent(SevError, "InconsistentOpsKeyValue")
+				    .detail("OpsKey", kv.key)
+				    .detail("DebugKey", records[kv.key])
+				    .detail("LogValue", logVal[records[kv.key]])
+				    .detail("OpValue", intValue);
+			}
+		}
+
+		// Validate if there is any ops key missing
+		for (auto& kv : records) {
+			uint64_t intValue = opsVal[kv.first];
+			if (intValue <= 0) {
+				TraceEvent(SevError, "MissingOpsKey2")
+				    .detail("OpsKey", kv.first)
+				    .detail("OpsVal", intValue)
+				    .detail("DebugKey", kv.second);
+			}
+		}
+		return Void();
 	}
 
 	ACTOR Future<bool> _check( Database cx, AtomicOpsWorkload* self ) {
@@ -251,7 +370,17 @@ struct AtomicOpsWorkload : TestWorkload {
 								logResult += intValue;
 							}
 							if(logResult != opsResult) {
-								TraceEvent(SevError, "LogAddMismatch").detail("LogResult", logResult).detail("OpResult", opsResult).detail("OpsResultStr", printable(opsResultStr)).detail("Size", opsResultStr.size());
+								TraceEvent(SevError, "LogAddMismatch")
+								    .detail("LogResult", logResult)
+								    .detail("OpResult", opsResult)
+								    .detail("OpsResultStr", printable(opsResultStr))
+								    .detail("Size", opsResultStr.size())
+								    .detail("LowerBoundSum", self->lbsum)
+								    .detail("UperBoundSum", self->ubsum);
+								wait(self->dumpLogKV(cx, g));
+								wait(self->dumpDebugKV(cx, g));
+								wait(self->dumpOpsKV(cx, g));
+								wait(self->validateOpsKey(cx, self, g));
 							}
 						}
 						break;


### PR DESCRIPTION
The current AtomicOps test checks if two key spaces (`ops` and `logs`)  produces the same results and reports an error if they don't match.

This PR adds more detailed trace information for AddValue opType when inconsistent error is detected:
(1) It tells which `ops` key is missing; and 
(2) It tells which `ops` key does not match the value of which `logs` key when the `actorCount` is set to 1 per test client.

The detailed trace information is very useful in debugging: Knowing a specific key is inconsistent with another can help narrow down the debug surface.