### PR TITLE
Raise MIN_TRACE_SEVERITY from 0 to 1 to allow customized tunable trace severity

### DIFF
--- a/fdbserver/RestoreLoader.actor.cpp
+++ b/fdbserver/RestoreLoader.actor.cpp
@@ -453,7 +453,9 @@ void _parseSerializedMutation(VersionedMutationsMap* pkvOps, SerializedMutationL
 			const uint8_t* v = vReader.consume(vLen);
 
 			MutationRef mutation((MutationRef::Type)type, KeyRef(k, kLen), KeyRef(v, vLen));
-			//TraceEvent(SevDebug, "FastRestore_VerboseDebug").detail("CommitVersion", commitVersion).detail("ParsedMutation", mutation.toString());
+			TraceEvent(SevFRMutationInfo, "FastRestore_VerboseDebug")
+			    .detail("CommitVersion", commitVersion)
+			    .detail("ParsedMutation", mutation.toString());
 			kvOps[commitVersion].push_back_deep(kvOps[commitVersion].arena(), mutation);
 			ASSERT_WE_THINK(kLen >= 0 && kLen < val.size());
 			ASSERT_WE_THINK(vLen >= 0 && vLen < val.size());
@@ -515,7 +517,9 @@ ACTOR static Future<Void> _parseRangeFileToMutationsOnLoader(VersionedMutationsM
 
 		// We cache all kv operations into kvOps, and apply all kv operations later in one place
 		kvOps.insert(std::make_pair(version, VectorRef<MutationRef>()));
-		//TraceEvent(SevDebug, "FastRestore_VerboseDebug").detail("CommitVersion", version).detail("ParsedMutationKV", m.toString());
+		TraceEvent(SevFRMutationInfo, "FastRestore_VerboseDebug")
+		    .detail("CommitVersion", version)
+		    .detail("ParsedMutationKV", m.toString());
 
 		ASSERT_WE_THINK(kvOps.find(version) != kvOps.end());
 		kvOps[version].push_back_deep(kvOps[version].arena(), m);

--- a/fdbserver/RestoreUtil.h
+++ b/fdbserver/RestoreUtil.h
@@ -34,8 +34,8 @@
 #include <cstdint>
 #include <cstdarg>
 
-// #define SevFRMutationInfo  SevNoInfo
-#define SevFRMutationInfo SevInfo
+#define SevFRMutationInfo SevVerbose
+//#define SevFRMutationInfo SevInfo
 
 enum class RestoreRole { Invalid = 0, Master = 1, Loader, Applier };
 BINARY_SERIALIZABLE(RestoreRole);

--- a/fdbserver/RestoreUtil.h
+++ b/fdbserver/RestoreUtil.h
@@ -34,6 +34,9 @@
 #include <cstdint>
 #include <cstdarg>
 
+// #define SevFRMutationInfo  SevNoInfo
+#define SevFRMutationInfo SevInfo
+
 enum class RestoreRole { Invalid = 0, Master = 1, Loader, Applier };
 BINARY_SERIALIZABLE(RestoreRole);
 std::string getRoleStr(RestoreRole role);

--- a/flow/Knobs.cpp
+++ b/flow/Knobs.cpp
@@ -27,6 +27,7 @@ FlowKnobs const* FLOW_KNOBS = new FlowKnobs();
 
 #define init( knob, value ) initKnob( knob, value, #knob )
 
+// clang-format off
 FlowKnobs::FlowKnobs(bool randomize, bool isSimulated) {
 	init( AUTOMATIC_TRACE_DUMP,                                  1 );
 	init( PREVENT_FAST_SPIN_DELAY,                             .01 );
@@ -140,7 +141,7 @@ FlowKnobs::FlowKnobs(bool randomize, bool isSimulated) {
 	init( ZERO_LENGTH_FILE_PAD,                                  1 );
 	init( TRACE_FLUSH_INTERVAL,                               0.25 );
 	init( TRACE_RETRY_OPEN_INTERVAL,						  1.00 );
-	init( MIN_TRACE_SEVERITY,                 isSimulated ? 0 : 10 ); // Related to the trace severity in Trace.h
+	init( MIN_TRACE_SEVERITY,                 isSimulated ? 1 : 10 ); // Related to the trace severity in Trace.h
 	init( MAX_TRACE_SUPPRESSIONS,                              1e4 );
 	init( TRACE_SYNC_ENABLED,                                    0 );
 	init( TRACE_EVENT_METRIC_UNITS_PER_SAMPLE,                 500 );
@@ -183,6 +184,7 @@ FlowKnobs::FlowKnobs(bool randomize, bool isSimulated) {
 	init( LOAD_BALANCE_MAX_BAD_OPTIONS,                          1 ); //should be the same as MAX_MACHINES_FALLING_BEHIND
 	init( LOAD_BALANCE_PENALTY_IS_BAD,                        true );
 }
+// clang-format on
 
 static std::string toLower( std::string const& name ) {
 	std::string lower_name;

--- a/flow/Trace.h
+++ b/flow/Trace.h
@@ -45,14 +45,15 @@ inline static bool TRACE_SAMPLE() { return false; }
 extern thread_local int g_trace_depth;
 
 enum Severity {
-	SevSample=1,
-	SevDebug=5,
-	SevInfo=10,
-	SevWarn=20,
-	SevWarnAlways=30,
-	SevError=40,
-	SevMaxUsed=SevError,
-	SevMax=1000000
+	SevNoInfo = 0,
+	SevSample = 1,
+	SevDebug = 5,
+	SevInfo = 10,
+	SevWarn = 20,
+	SevWarnAlways = 30,
+	SevError = 40,
+	SevMaxUsed = SevError,
+	SevMax = 1000000
 };
 
 class TraceEventFields {

--- a/flow/Trace.h
+++ b/flow/Trace.h
@@ -45,7 +45,7 @@ inline static bool TRACE_SAMPLE() { return false; }
 extern thread_local int g_trace_depth;
 
 enum Severity {
-	SevNoInfo = 0,
+	SevVerbose = 0,
 	SevSample = 1,
 	SevDebug = 5,
 	SevInfo = 10,


### PR DESCRIPTION
We toggle the value of the macro `SevFRMutationInfo` to turn on and off the trace events that tracks mutations in the new performance restore systems

If we want to toggle a specific trace events, we can define a macro like `SevFRMutationInfo ` and toggle it to turn it on and off.

This is an updated PR for PR. https://github.com/apple/foundationdb/pull/2232