### PR TITLE
Add network option for the trace clock source

### DIFF
--- a/bindings/go/src/fdb/generated.go
+++ b/bindings/go/src/fdb/generated.go
@@ -88,6 +88,13 @@ func (o NetworkOptions) SetTraceFormat(param string) error {
 	return o.setOpt(34, []byte(param))
 }
 
+// Select clock source for trace files. now (default) or realtime are supported.
+//
+// Parameter: Trace clock source
+func (o NetworkOptions) SetTraceClockSource(param string) error {
+	return o.setOpt(35, []byte(param))
+}
+
 // Set internal tuning or debugging knobs
 //
 // Parameter: knob_name=knob_value

--- a/documentation/sphinx/source/api-common.rst.inc
+++ b/documentation/sphinx/source/api-common.rst.inc
@@ -242,6 +242,9 @@
 .. |option-trace-format-blurb| replace::
     Select the format of the trace files for this FoundationDB client. xml (the default) and json are supported.
 
+.. |option-trace-clock-source-blurb| replace::
+    Select clock source for trace files. now (the default) or realtime are supported.
+
 .. |network-options-warning| replace::
 
     It is an error to set these options after the first call to |open-func| anywhere in your application.

--- a/documentation/sphinx/source/api-python.rst
+++ b/documentation/sphinx/source/api-python.rst
@@ -145,6 +145,10 @@ After importing the ``fdb`` module and selecting an API version, you probably wa
 
        |option-trace-format-blurb|
 
+    .. method :: fdb.options.set_trace_clock_source(source)
+
+       |option-trace-clock-source-blurb|
+
     .. method :: fdb.options.set_disable_multi_version_client_api()
 
        |option-disable-multi-version-client-api|

--- a/documentation/sphinx/source/api-ruby.rst
+++ b/documentation/sphinx/source/api-ruby.rst
@@ -128,6 +128,10 @@ After requiring the ``FDB`` gem and selecting an API version, you probably want 
 
        |option-trace-format-blurb|
 
+    .. method:: FDB.options.set_trace_clock_source(source) -> nil
+
+       |option-trace-clock-source-blurb|
+
     .. method:: FDB.options.set_disable_multi_version_client_api() -> nil
 
        |option-disable-multi-version-client-api|

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -788,6 +788,7 @@ Database Database::createDatabase( Reference<ClusterConnectionFile> connFile, in
 
 			auto publicIP = determinePublicIPAutomatically( connFile->getConnectionString() );
 			selectTraceFormatter(networkOptions.traceFormat);
+			selectTraceClockSource(networkOptions.traceClockSource);
 			openTraceFile(NetworkAddress(publicIP, ::getpid()), networkOptions.traceRollSize, networkOptions.traceMaxLogsSize, networkOptions.traceDirectory.get(), "trace", networkOptions.traceLogGroup);
 
 			TraceEvent("ClientStart")
@@ -857,6 +858,14 @@ void setNetworkOption(FDBNetworkOptions::Option option, Optional<StringRef> valu
 			networkOptions.traceFormat = value.get().toString();
 			if (!validateTraceFormat(networkOptions.traceFormat)) {
 				fprintf(stderr, "Unrecognized trace format: `%s'\n", networkOptions.traceFormat.c_str());
+				throw invalid_option_value();
+			}
+			break;
+		case FDBNetworkOptions::TRACE_CLOCK_SOURCE:
+			validateOptionValue(value, true);
+			networkOptions.traceClockSource = value.get().toString();
+			if (!validateTraceClockSource(networkOptions.traceClockSource)) {
+				fprintf(stderr, "Unrecognized trace clock source: `%s'\n", networkOptions.traceClockSource.c_str());
 				throw invalid_option_value();
 			}
 			break;

--- a/fdbclient/NativeAPI.actor.h
+++ b/fdbclient/NativeAPI.actor.h
@@ -58,6 +58,7 @@ struct NetworkOptions {
 	uint64_t traceMaxLogsSize;	
 	std::string traceLogGroup;
 	std::string traceFormat;
+	std::string traceClockSource;
 	Optional<bool> logClientInfo;
 	Standalone<VectorRef<ClientVersionRef>> supportedVersions;
 	bool slowTaskProfilingEnabled;
@@ -66,7 +67,7 @@ struct NetworkOptions {
 	NetworkOptions()
 	  : localAddress(""), clusterFile(""), traceDirectory(Optional<std::string>()),
 	    traceRollSize(TRACE_DEFAULT_ROLL_SIZE), traceMaxLogsSize(TRACE_DEFAULT_MAX_LOGS_SIZE), traceLogGroup("default"),
-	    traceFormat("xml"), slowTaskProfilingEnabled(false) {}
+	    traceFormat("xml"), traceClockSource("now"), slowTaskProfilingEnabled(false) {}
 };
 
 class Database {

--- a/fdbclient/vexillographer/fdb.options
+++ b/fdbclient/vexillographer/fdb.options
@@ -51,6 +51,9 @@ description is not currently required but encouraged.
     <Option name="trace_format" code="34"
             paramType="String" paramDescription="Format of trace files"
             description="Select the format of the log files. xml (the default) and json are supported."/>
+    <Option name="trace_clock_source" code="35"
+            paramType="String" paramDescription="Trace clock source"
+            description="Select clock source for trace files. now (the default) or realtime are supported." />
     <Option name="knob" code="40"
             paramType="String" paramDescription="knob_name=knob_value"
             description="Set internal tuning or debugging knobs"/>

--- a/flow/Trace.cpp
+++ b/flow/Trace.cpp
@@ -585,6 +585,24 @@ bool traceFormatImpl(std::string& format) {
 		return false;
 	}
 }
+
+template <bool validate>
+bool traceClockSource(std::string& source) {
+	std::transform(source.begin(), source.end(), source.begin(), ::tolower);
+	if (source == "now") {
+		if (!validate) {
+			g_trace_clock.store(TRACE_CLOCK_NOW);
+		}
+		return true;
+	} else if (source == "realtime") {
+		if (!validate) {
+			g_trace_clock.store(TRACE_CLOCK_REALTIME);
+		}
+		return true;
+	} else {
+		return false;
+	}
+}
 } // namespace
 
 bool selectTraceFormatter(std::string format) {
@@ -598,6 +616,19 @@ bool selectTraceFormatter(std::string format) {
 
 bool validateTraceFormat(std::string format) {
 	return traceFormatImpl</*validate*/ true>(format);
+}
+
+bool selectTraceClockSource(std::string source) {
+	ASSERT(!g_traceLog.isOpen());
+	bool recognized = traceClockSource</*validate*/ false>(source);
+	if (!recognized) {
+		TraceEvent(SevWarnAlways, "UnrecognizedTraceClockSource").detail("source", source);
+	}
+	return recognized;
+}
+
+bool validateTraceClockSource(std::string source) {
+	return traceClockSource</*validate*/ true>(source);
 }
 
 ThreadFuture<Void> flushTraceFile() {

--- a/flow/Trace.h
+++ b/flow/Trace.h
@@ -571,6 +571,12 @@ bool selectTraceFormatter(std::string format);
 // Returns true iff format is recognized.
 bool validateTraceFormat(std::string format);
 
+// Select the clock source for trace files. Returns false if the format is unrecognized. No longer safe to call after a call
+// to openTraceFile.
+bool selectTraceClockSource(std::string source);
+// Returns true iff source is recognized.
+bool validateTraceClockSource(std::string source);
+
 void addTraceRole(std::string role);
 void removeTraceRole(std::string role);
 


### PR DESCRIPTION
This option allows clients to select the clock source for trace events
similar to the `--traceclock` command line parameter for `fdbserver`.
Using the `realtime` clock sources makes loading event data into
OpenTracing systems like Jaeger more useful.

This is heavily cribbed from #1092 so hopefully it covers all the bases. I wasn't 100% certain on the `selectTraceClockSource`/`validateTraceClockSource` differences but rather than be creative I just followed the pre-existing pattern.