### PR TITLE
Test watch outliving transaction

### DIFF
--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -2146,13 +2146,9 @@ void Watch::setWatch(Future<Void> watchFuture) {
 }
 
 //FIXME: This seems pretty horrible. Now a Database can't die until all of its watches do...
-ACTOR Future<Void> watch( Reference<Watch> watch, Database cx, Transaction *self ) {
-	state TransactionInfo info = self->info;
+ACTOR Future<Void> watch(Reference<Watch> watch, Database cx, TransactionInfo info) {
 	cx->addWatch();
 	try {
-		self->watches.push_back(watch);
-		self = nullptr; // This actor may outlive *self
-
 		choose {
 			// RYOW write to value that is being watched (if applicable)
 			// Errors
@@ -2191,7 +2187,9 @@ Future<Version> Transaction::getRawReadVersion() {
 
 Future< Void > Transaction::watch( Reference<Watch> watch ) {
 	++cx->transactionWatchRequests;
-	return ::watch(watch, cx, this);
+	cx->addWatch();
+	watches.push_back(watch);
+	return ::watch(watch, cx, info);
 }
 
 ACTOR Future<Standalone<VectorRef<const char*>>> getAddressesForKeyActor(Key key, Future<Version> ver, Database cx,

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -2151,6 +2151,7 @@ ACTOR Future<Void> watch( Reference<Watch> watch, Database cx, Transaction *self
 	cx->addWatch();
 	try {
 		self->watches.push_back(watch);
+		self = nullptr; // This actor may outlive *self
 
 		choose {
 			// RYOW write to value that is being watched (if applicable)

--- a/fdbserver/workloads/Watches.actor.cpp
+++ b/fdbserver/workloads/Watches.actor.cpp
@@ -129,38 +129,49 @@ struct WatchesWorkload : TestWorkload {
 		state Optional<Optional<Value>> lastValue;
 
 		loop {
-			state Transaction tr( cx );
 			loop {
+				state std::unique_ptr<Transaction> tr = std::make_unique<Transaction>(cx);
 				try {
-					state Future<Optional<Value>> setValueFuture = tr.get( setKey );
-					state Optional<Value> watchValue = wait( tr.get( watchKey ) );
+					state Future<Optional<Value>> setValueFuture = tr->get(setKey);
+					state Optional<Value> watchValue = wait(tr->get(watchKey));
 					Optional<Value> setValue = wait( setValueFuture );
 					
 					if( lastValue.present() && lastValue.get() == watchValue) {
-						TraceEvent(SevError, "WatcherTriggeredWithoutChanging").detail("WatchKey", printable( watchKey )).detail("SetKey", printable( setKey )).detail("WatchValue", printable( watchValue )).detail("SetValue", printable( setValue )).detail("ReadVersion", tr.getReadVersion().get());
+						TraceEvent(SevError, "WatcherTriggeredWithoutChanging")
+						    .detail("WatchKey", printable(watchKey))
+						    .detail("SetKey", printable(setKey))
+						    .detail("WatchValue", printable(watchValue))
+						    .detail("SetValue", printable(setValue))
+						    .detail("ReadVersion", tr->getReadVersion().get());
 					}
 
 					lastValue = Optional<Optional<Value>>();
 
 					if( watchValue != setValue ) {
 						if( watchValue.present() )
-							tr.set( setKey, watchValue.get() );
+							tr->set(setKey, watchValue.get());
 						else
-							tr.clear( setKey );
+							tr->clear(setKey);
 						//TraceEvent("WatcherSetStart").detail("Watch", printable(watchKey)).detail("Set", printable(setKey)).detail("Value", printable( watchValue ) );
-						wait( tr.commit() );
-						//TraceEvent("WatcherSetFinish").detail("Watch", printable(watchKey)).detail("Set", printable(setKey)).detail("Value", printable( watchValue ) ).detail("Ver", tr.getCommittedVersion());
+						wait(tr->commit());
+						//TraceEvent("WatcherSetFinish").detail("Watch", printable(watchKey)).detail("Set", printable(setKey)).detail("Value", printable( watchValue ) ).detail("Ver", tr->getCommittedVersion());
 					} else {
 						//TraceEvent("WatcherWatch").detail("Watch", printable(watchKey));
-						state Future<Void> watchFuture = tr.watch( Reference<Watch>( new Watch(watchKey, watchValue) ) );
-						wait( tr.commit() );
+						state Future<Void> watchFuture = tr->watch(Reference<Watch>(new Watch(watchKey, watchValue)));
+						wait(tr->commit());
+						if (BUGGIFY) {
+							// Make watch future outlive transaction
+							tr.reset();
+						}
 						wait( watchFuture );
 						if( watchValue.present() )
 							lastValue = watchValue;
 					}
 					break;
 				} catch( Error &e ) {
-					wait( tr.onError(e) );
+					if (tr != nullptr) {
+						wait(tr->onError(e));
+					}
 				}
 			}
 		}


### PR DESCRIPTION
The `self` pointer may point to invalid memory after a wait in `watch`, so try to prevent a potential heap-use-after-free