### PR TITLE
Default initialize absent flatbuffers members

### DIFF
--- a/fdbclient/FDBTypes.h
+++ b/fdbclient/FDBTypes.h
@@ -829,7 +829,9 @@ struct ClusterControllerPriorityInfo {
 	uint8_t dcFitness;
 
 	bool operator== (ClusterControllerPriorityInfo const& r) const { return processClassFitness == r.processClassFitness && isExcluded == r.isExcluded && dcFitness == r.dcFitness; }
-
+	ClusterControllerPriorityInfo()
+	  : ClusterControllerPriorityInfo(/*ProcessClass::UnsetFit*/ 2, false,
+	                                  ClusterControllerPriorityInfo::FitnessUnknown) {}
 	ClusterControllerPriorityInfo(uint8_t processClassFitness, bool isExcluded, uint8_t dcFitness) : processClassFitness(processClassFitness), isExcluded(isExcluded), dcFitness(dcFitness) {}
 
 	template <class Ar>

--- a/flow/flat_buffers.h
+++ b/flow/flat_buffers.h
@@ -699,6 +699,8 @@ private:
 			} else {
 				load_<Alternative + 1>(type_tag, member);
 			}
+		} else {
+			member = std::decay_t<decltype(member)>{};
 		}
 	}
 };
@@ -809,6 +811,7 @@ struct LoadMember {
 		if constexpr (is_vector_of_union_like<Member>) {
 			if (!field_present()) {
 				i += 2;
+				member = std::decay_t<decltype(member)>{};
 				return;
 			}
 			const uint8_t* types_current = &message[vtable[i++]];
@@ -829,6 +832,8 @@ struct LoadMember {
 				if (types_current[i] > 0) {
 					uint8_t type_tag = types_current[i] - 1; // Flatbuffers indexes from 1.
 					(LoadAlternative<Context, union_like_traits<T>>{ context, current }).load(type_tag, value);
+				} else {
+					value = std::decay_t<decltype(value)>{};
 				}
 				*inserter = std::move(value);
 				++inserter;
@@ -837,6 +842,7 @@ struct LoadMember {
 		} else if constexpr (is_union_like<Member>) {
 			if (!field_present()) {
 				i += 2;
+				member = std::decay_t<decltype(member)>{};
 				return;
 			}
 			uint8_t fb_type_tag;
@@ -846,6 +852,8 @@ struct LoadMember {
 			if (field_present() && fb_type_tag > 0) {
 				(LoadAlternative<Context, union_like_traits<Member>>{ context, &message[vtable[i]] })
 				    .load(type_tag, member);
+			} else {
+				member = std::decay_t<decltype(member)>{};
 			}
 			++i;
 		} else if constexpr (_SizeOf<Member>::size == 0) {
@@ -853,6 +861,8 @@ struct LoadMember {
 		} else {
 			if (field_present()) {
 				load_helper(member, &message[vtable[i]], context);
+			} else {
+				member = std::decay_t<decltype(member)>{};
 			}
 			++i;
 		}
@@ -1158,7 +1168,7 @@ struct NoFileIdentifier {};
 template <class T>
 struct EnsureTable
   : std::conditional_t<HasFileIdentifier<T>::value, detail::YesFileIdentifier<T>, detail::NoFileIdentifier> {
-	EnsureTable() = default;
+	EnsureTable() : t() {}
 	EnsureTable(const T& t) : t(t) {}
 	template <class Archive>
 	void serialize(Archive& ar) {


### PR DESCRIPTION
These were found via enabling `-Wuninitialized` with gcc. It might be a good idea to merge this into release-6.2, as otherwise if we do a protocol-compatible deprecation of a field (or introduction of a new alternative in a union), fdbserver processes running without this change may start using uninitialized memory.

A binary which introduces a field (and has this change) can safely interact with a binary without this change.