### PR TITLE
Fix a potential UB instance

### DIFF
--- a/flow/flat_buffers.h
+++ b/flow/flat_buffers.h
@@ -1040,10 +1040,10 @@ struct LoadSaveHelper<std::vector<bool, Alloc>, Context> : Context {
 		current += sizeof(uint32_t);
 		member.clear();
 		member.resize(length);
-		bool m;
+		uint8_t m;
 		for (uint32_t i = 0; i < length; ++i) {
 			load_helper(m, current, *this);
-			member[i] = m;
+			member[i] = m != 0;
 			current += fb_size<bool>;
 		}
 	}


### PR DESCRIPTION
Writing a value which is not 0 or 1 to the underlying memory of a bool
is undefined behavior. Conformant flatbuffers implementations must
accept bytes that are not 0 or 1 as booleans [1]. (Conformant
implementations are only allowed to write the byte 0 or 1 as a boolean
[1])

So this protects us from undefined behavior if we ever read a
flatbuffers message written by an almost-conformant implementation.

[1]: https://github.com/dvidelabs/flatcc/blob/master/doc/binary-format.md#boolean