### PR TITLE
Initialize memory for Optional and ErrorOr

### DIFF
--- a/flow/Arena.h
+++ b/flow/Arena.h
@@ -350,7 +350,7 @@ inline void save( Archive& ar, const Arena& p ) {
 template <class T>
 class Optional : public ComposedIdentifier<T, 0x10> {
 public:
-	Optional() : valid(false) {}
+	Optional() : valid(false) { memset(&value, 0, sizeof(value)); }
 	Optional(const Optional<T>& o) : valid(o.valid) {
 		if (valid) new (&value) T(o.get());
 	}

--- a/flow/flow.h
+++ b/flow/flow.h
@@ -133,8 +133,8 @@ class Never {};
 template <class T>
 class ErrorOr : public ComposedIdentifier<T, 0x1> {
 public:
-	ErrorOr() : error(default_error_or()) {}
-	ErrorOr(Error const& error) : error(error) {}
+	ErrorOr() : ErrorOr(default_error_or()) {}
+	ErrorOr(Error const& error) : error(error) { memset(&value, 0, sizeof(value)); }
 	ErrorOr(const ErrorOr<T>& o) : error(o.error) {
 		if (present()) new (&value) T(o.get());
 	}


### PR DESCRIPTION
This does _not_ fix any potential uses of uninitialized memory, but without
this change, gcc issues false-positive -Wuninitialized warnings.

I'm hoping this does not have a noticeable impact on performance