### PR TITLE
Ignore -fsanitize=alignment for UBSAN

### DIFF
--- a/cmake/ConfigureCompiler.cmake
+++ b/cmake/ConfigureCompiler.cmake
@@ -157,6 +157,7 @@ else()
   if(USE_UBSAN)
     add_compile_options(
       -fsanitize=undefined
+      -fno-sanitize=alignment
       -DUSE_SANITIZER)
     set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -fsanitize=undefined")
     set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -fsanitize=undefined")


### PR DESCRIPTION
There seems to be an overwhelming amount of misaligned memory access, and it seems to be a large effort to fix them (see #1434 e.g.) Other types of undefined behavior seem to be more manageable, so I propose we fix those first, and suppress misaligned access for now. Hopefully this will help us resolve #965