### PR TITLE
Fix reference binding to nullptr

### DIFF
--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -1156,7 +1156,7 @@ ACTOR Future<GetKeyValuesReply> readRange( StorageServer* data, Version version,
 			merge( result.arena, result.data, atStorageVersion, vStart, vEnd, vCount, limit, more, *pLimitBytes );
 			limit -= result.data.size() - prevSize;
 
-			for (auto i = &result.data[prevSize]; i != result.data.end(); i++)
+			for (auto i = result.data.begin() + prevSize; i != result.data.end(); i++)
 				*pLimitBytes -= sizeof(KeyValueRef) + i->expectedSize();
 
 			// Setup for the next iteration


### PR DESCRIPTION
UBSAN has this to say:

flow/Arena.h:982:10: runtime error: reference binding to null pointer of type 'KeyValueRef'

After this change UBSAN no longer complains about this occurrence