### PR TITLE
Fix more UBSAN reports

### DIFF
--- a/cmake/ConfigureCompiler.cmake
+++ b/cmake/ConfigureCompiler.cmake
@@ -3,6 +3,7 @@ set(USE_VALGRIND OFF CACHE BOOL "Compile for valgrind usage")
 set(ALLOC_INSTRUMENTATION OFF CACHE BOOL "Instrument alloc")
 set(WITH_UNDODB OFF CACHE BOOL "Use rr or undodb")
 set(USE_ASAN OFF CACHE BOOL "Compile with address sanitizer")
+set(USE_UBSAN OFF CACHE BOOL "Compile with undefined behavior sanitizer")
 set(FDB_RELEASE OFF CACHE BOOL "This is a building of a final release")
 set(USE_LD "DEFAULT" CACHE STRING "The linker to use for building: can be LD (system default, default choice), BFD, GOLD, or LLD")
 set(USE_LIBCXX OFF CACHE BOOL "Use libc++")
@@ -146,10 +147,19 @@ else()
   if(USE_ASAN)
     add_compile_options(
       -fsanitize=address
-      -DUSE_ASAN)
+      -DUSE_SANITIZER)
     set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -fsanitize=address")
     set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -fsanitize=address")
     set(CMAKE_EXE_LINKER_FLAGS    "${CMAKE_EXE_LINKER_FLAGS}    -fsanitize=address ${CMAKE_THREAD_LIBS_INIT}")
+  endif()
+
+  if(USE_UBSAN)
+    add_compile_options(
+      -fsanitize=undefined
+      -DUSE_SANITIZER)
+    set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -fsanitize=undefined")
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -fsanitize=undefined")
+    set(CMAKE_EXE_LINKER_FLAGS    "${CMAKE_EXE_LINKER_FLAGS}    -fsanitize=undefined ${CMAKE_THREAD_LIBS_INIT}")
   endif()
 
   if(PORTABLE_BINARY)

--- a/cmake/ConfigureCompiler.cmake
+++ b/cmake/ConfigureCompiler.cmake
@@ -156,6 +156,7 @@ else()
   if(USE_UBSAN)
     add_compile_options(
       -fsanitize=undefined
+      -fno-sanitize=alignment
       -DUSE_SANITIZER)
     set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -fsanitize=undefined")
     set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -fsanitize=undefined")

--- a/fdbclient/SnapshotCache.h
+++ b/fdbclient/SnapshotCache.h
@@ -65,10 +65,12 @@ struct ExtStringRef {
 
 	int size() const { return base.size() + extra_zero_bytes; }
 
-	int cmp( ExtStringRef const& rhs ) const {
+	int cmp(ExtStringRef const& rhs) const {
 		int cbl = std::min(base.size(), rhs.base.size());
-		int c = memcmp( base.begin(), rhs.base.begin(), cbl );
-		if (c!=0) return c;
+		if (cbl > 0) {
+			int c = memcmp(base.begin(), rhs.base.begin(), cbl);
+			if (c != 0) return c;
+		}
 
 		for(int i=cbl; i<base.size(); i++)
 			if (base[i]) return 1;

--- a/fdbclient/SnapshotCache.h
+++ b/fdbclient/SnapshotCache.h
@@ -41,7 +41,9 @@ struct ExtStringRef {
 	StringRef toArenaOrRef( Arena& a ) {
 		if (extra_zero_bytes) {
 			StringRef dest = StringRef( new(a) uint8_t[ size() ], size() );
-			memcpy( mutateString(dest), base.begin(), base.size() );
+			if (base.size()) {
+				memcpy(mutateString(dest), base.begin(), base.size());
+			}
 			memset( mutateString(dest)+base.size(), 0, extra_zero_bytes );
 			return dest;
 		} else

--- a/fdbclient/SnapshotCache.h
+++ b/fdbclient/SnapshotCache.h
@@ -33,7 +33,9 @@ struct ExtStringRef {
 
 	Standalone<StringRef> toStandaloneStringRef() {
 		auto s = makeString( size() );
-		memcpy( mutateString( s ), base.begin(), base.size() );
+		if (base.size() > 0) {
+			memcpy(mutateString(s), base.begin(), base.size());
+		}
 		memset( mutateString( s ) + base.size(), 0, extra_zero_bytes );
 		return s;
 	};
@@ -58,7 +60,9 @@ struct ExtStringRef {
 	StringRef toArena( Arena& a ) {
 		if (extra_zero_bytes) {
 			StringRef dest = StringRef( new(a) uint8_t[ size() ], size() );
-			memcpy( mutateString(dest), base.begin(), base.size() );
+			if (base.size() > 0) {
+				memcpy(mutateString(dest), base.begin(), base.size());
+			}
 			memset( mutateString(dest)+base.size(), 0, extra_zero_bytes );
 			return dest;
 		} else

--- a/fdbclient/vexillographer/cpp.cs
+++ b/fdbclient/vexillographer/cpp.cs
@@ -33,7 +33,7 @@ namespace vexillographer
             outFile.WriteLine("struct FDB{0}s {{", scope.ToString());
             outFile.WriteLine("\tfriend class FDBOptionInfoMap<FDB{0}s>;",scope.ToString());
             outFile.WriteLine();
-            outFile.WriteLine("\tenum Option {");
+            outFile.WriteLine("\tenum Option : int {");
             outFile.WriteLine(string.Join(",\n\n", options.Select(f => c.getCLine(f, "\t\t", "")).ToArray()));
             outFile.WriteLine("\t};");
             outFile.WriteLine();

--- a/fdbrpc/FlowTransport.actor.cpp
+++ b/fdbrpc/FlowTransport.actor.cpp
@@ -818,7 +818,9 @@ ACTOR static Future<Void> connectionReader(
 					const int unproc_len = unprocessed_end - unprocessed_begin;
 					const int len = getNewBufferSize(unprocessed_begin, unprocessed_end, peerAddress);
 					uint8_t* const newBuffer = new (newArena) uint8_t[ len ];
-					memcpy( newBuffer, unprocessed_begin, unproc_len );
+					if (unproc_len > 0) {
+						memcpy(newBuffer, unprocessed_begin, unproc_len);
+					}
 					arena = newArena;
 					unprocessed_begin = newBuffer;
 					unprocessed_end = newBuffer + unproc_len;

--- a/fdbserver/DiskQueue.actor.cpp
+++ b/fdbserver/DiskQueue.actor.cpp
@@ -92,7 +92,9 @@ struct StringBuffer {
 			uint8_t* p = (uint8_t*)(int64_t(b+alignment-1) & ~(alignment-1));  // first multiple of alignment greater than or equal to b
 			ASSERT( p>=b && p+reserved<=e && int64_t(p)%alignment == 0 );
 
-			memcpy(p, str.begin(), str.size());
+			if (str.size() > 0) {
+				memcpy(p, str.begin(), str.size());
+			}
 			ref() = StringRef( p, str.size() );
 		}
 	}

--- a/fdbserver/KeyValueStoreSQLite.actor.cpp
+++ b/fdbserver/KeyValueStoreSQLite.actor.cpp
@@ -435,8 +435,7 @@ Value encodeKVFragment( KeyValueRef kv, uint32_t index) {
 	}
 	// An increment is required if the high bit of the N-byte index value is set, since it is
 	// positive number but SQLite only stores signed values and would interpret it as negative.
-	if(index >> (8 * indexCode - 1))
-		++indexCode;
+	if (indexCode > 0 && index >> (8 * indexCode - 1)) ++indexCode;
 
 	int header_size = sqlite3VarintLen(keyCode) + sizeof(indexCode) + sqlite3VarintLen(valCode);
 	int hh = sqlite3VarintLen(header_size);

--- a/fdbserver/KeyValueStoreSQLite.actor.cpp
+++ b/fdbserver/KeyValueStoreSQLite.actor.cpp
@@ -428,14 +428,16 @@ Value encodeKVFragment( KeyValueRef kv, uint32_t index) {
 	// a signed representation of the index value.  The type code for 0 is 0 (which is
 	// actually the null type in SQLite).
 	int8_t indexCode = 0;
-	uint32_t tmp = index;
-	while(tmp != 0) {
-		++indexCode;
-		tmp >>= 8;
+	if (index != 0) {
+		uint32_t tmp = index;
+		while (tmp != 0) {
+			++indexCode;
+			tmp >>= 8;
+		}
+		// An increment is required if the high bit of the N-byte index value is set, since it is
+		// positive number but SQLite only stores signed values and would interpret it as negative.
+		if (index >> (8 * indexCode - 1)) ++indexCode;
 	}
-	// An increment is required if the high bit of the N-byte index value is set, since it is
-	// positive number but SQLite only stores signed values and would interpret it as negative.
-	if (indexCode > 0 && index >> (8 * indexCode - 1)) ++indexCode;
 
 	int header_size = sqlite3VarintLen(keyCode) + sizeof(indexCode) + sqlite3VarintLen(valCode);
 	int hh = sqlite3VarintLen(header_size);

--- a/fdbserver/Ratekeeper.actor.cpp
+++ b/fdbserver/Ratekeeper.actor.cpp
@@ -553,10 +553,13 @@ void updateRate(RatekeeperData* self, RatekeeperLimits* limits) {
 			maxTLVer = std::max(maxTLVer, tl.lastReply.v);
 		}
 
-		// writeToReadLatencyLimit: 0 = infinte speed; 1 = TL durable speed ; 2 = half TL durable speed
-		writeToReadLatencyLimit = ((maxTLVer - minLimitingSSVer) - limits->maxVersionDifference/2) / (limits->maxVersionDifference/4);
-		worstVersionLag = std::max((Version)0, maxTLVer - minSSVer);
-		limitingVersionLag = std::max((Version)0, maxTLVer - minLimitingSSVer);
+		if (minSSVer != std::numeric_limits<Version>::max() && maxTLVer != std::numeric_limits<Version>::min()) {
+			// writeToReadLatencyLimit: 0 = infinte speed; 1 = TL durable speed ; 2 = half TL durable speed
+			writeToReadLatencyLimit =
+			    ((maxTLVer - minLimitingSSVer) - limits->maxVersionDifference / 2) / (limits->maxVersionDifference / 4);
+			worstVersionLag = std::max((Version)0, maxTLVer - minSSVer);
+			limitingVersionLag = std::max((Version)0, maxTLVer - minLimitingSSVer);
+		}
 	}
 
 	int64_t worstFreeSpaceTLog = std::numeric_limits<int64_t>::max();

--- a/fdbserver/Ratekeeper.actor.cpp
+++ b/fdbserver/Ratekeeper.actor.cpp
@@ -94,11 +94,12 @@ struct StorageQueueInfo {
 	Smoother smoothFreeSpace;
 	Smoother smoothTotalSpace;
 	limitReason_t limitReason;
-	StorageQueueInfo(UID id, LocalityData locality) : valid(false), id(id), locality(locality), smoothDurableBytes(SERVER_KNOBS->SMOOTHING_AMOUNT),
-		smoothInputBytes(SERVER_KNOBS->SMOOTHING_AMOUNT), verySmoothDurableBytes(SERVER_KNOBS->SLOW_SMOOTHING_AMOUNT),
-		verySmoothDurableVersion(SERVER_KNOBS->SLOW_SMOOTHING_AMOUNT), smoothLatestVersion(SERVER_KNOBS->SMOOTHING_AMOUNT), smoothFreeSpace(SERVER_KNOBS->SMOOTHING_AMOUNT),
-		smoothTotalSpace(SERVER_KNOBS->SMOOTHING_AMOUNT)
-	{
+	StorageQueueInfo(UID id, LocalityData locality)
+	  : valid(false), id(id), locality(locality), smoothDurableBytes(SERVER_KNOBS->SMOOTHING_AMOUNT),
+	    smoothInputBytes(SERVER_KNOBS->SMOOTHING_AMOUNT), verySmoothDurableBytes(SERVER_KNOBS->SLOW_SMOOTHING_AMOUNT),
+	    verySmoothDurableVersion(SERVER_KNOBS->SLOW_SMOOTHING_AMOUNT),
+	    smoothLatestVersion(SERVER_KNOBS->SMOOTHING_AMOUNT), smoothFreeSpace(SERVER_KNOBS->SMOOTHING_AMOUNT),
+	    smoothTotalSpace(SERVER_KNOBS->SMOOTHING_AMOUNT), limitReason(limitReason_t::unlimited) {
 		// FIXME: this is a tacky workaround for a potential uninitialized use in trackStorageServerQueueInfo
 		lastReply.instanceID = -1;
 	}

--- a/fdbserver/SkipList.cpp
+++ b/fdbserver/SkipList.cpp
@@ -343,7 +343,9 @@ private:
 			n->nPointers = level+1;
 
 			n->valueLength = value.size();
-			memcpy(n->value(), value.begin(), value.size());
+			if (value.size() > 0) {
+				memcpy(n->value(), value.begin(), value.size());
+			}
 			return n;
 		}
 

--- a/fdbserver/TLogInterface.h
+++ b/fdbserver/TLogInterface.h
@@ -155,7 +155,7 @@ struct TLogPeekReply {
 	Version maxKnownVersion;
 	Version minKnownCommittedVersion;
 	Optional<Version> begin;
-	bool onlySpilled;
+	bool onlySpilled = false;
 
 	template <class Ar>
 	void serialize(Ar& ar) {

--- a/fdbserver/VersionedBTree.actor.cpp
+++ b/fdbserver/VersionedBTree.actor.cpp
@@ -1603,7 +1603,9 @@ private:
 		void setMetaKey(StringRef key) {
 			ASSERT(key.size() < (smallestPhysicalBlock - sizeof(Header)));
 			metaKeySize = key.size();
-			memcpy(this + 1, key.begin(), key.size());
+			if (key.size() > 0) {
+				memcpy(this + 1, key.begin(), key.size());
+			}
 		}
 
 		int size() const {

--- a/fdbserver/sqlite/sqlite3.amalgamation.c
+++ b/fdbserver/sqlite/sqlite3.amalgamation.c
@@ -14706,7 +14706,7 @@ SQLITE_PRIVATE int sqlite3VarintLen(u64 v){
 ** Read or write a four-byte big-endian integer value.
 */
 SQLITE_PRIVATE u32 sqlite3Get4byte(const u8 *p){
-  return (p[0]<<24) | (p[1]<<16) | (p[2]<<8) | p[3];
+  return ((u32)p[0]<<24) | ((u32)p[1]<<16) | ((u32)p[2]<<8) | (u32)p[3];
 }
 SQLITE_PRIVATE void sqlite3Put4byte(unsigned char *p, u32 v){
   p[0] = (u8)(v>>24);

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -1244,7 +1244,7 @@ ACTOR Future<GetKeyValuesReply> readRange( StorageServer* data, Version version,
 			merge( result.arena, result.data, atStorageVersion, vStart, vEnd, vCount, limit, false, *pLimitBytes );
 			limit += result.data.size() - prevSize;
 
-			for (auto i = result.data.begin(); i != result.data.end(); i++)
+			for (auto i = result.data.begin() + prevSize; i != result.data.end(); i++)
 				*pLimitBytes -= sizeof(KeyValueRef) + i->expectedSize();
 
 			vStart = vEnd;

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -1244,7 +1244,7 @@ ACTOR Future<GetKeyValuesReply> readRange( StorageServer* data, Version version,
 			merge( result.arena, result.data, atStorageVersion, vStart, vEnd, vCount, limit, false, *pLimitBytes );
 			limit += result.data.size() - prevSize;
 
-			for (auto i = &result.data[prevSize]; i != result.data.end(); i++)
+			for (auto i = result.data.begin(); i != result.data.end(); i++)
 				*pLimitBytes -= sizeof(KeyValueRef) + i->expectedSize();
 
 			vStart = vEnd;

--- a/fdbserver/workloads/FuzzApiCorrectness.actor.cpp
+++ b/fdbserver/workloads/FuzzApiCorrectness.actor.cpp
@@ -383,8 +383,8 @@ struct FuzzApiCorrectnessWorkload : TestWorkload {
 		ExceptionContract contract;
 		std::vector<ThreadFuture<Void> > pre_steps;
 
-		BaseTest(unsigned int id_, FuzzApiCorrectnessWorkload *wl, const char *func)
-			: id(id_), workload(wl), contract(func, std::bind(&Subclass::augmentTrace, static_cast<Subclass *>(this), ph::_1)) {}
+		BaseTest(unsigned int id_, FuzzApiCorrectnessWorkload* wl, const char* func)
+		  : id(id_), workload(wl), contract(func, std::bind(&BaseTest::augmentTrace, this, ph::_1)) {}
 
 		static Key makeKey() {
 			double ksrv = deterministicRandom()->random01();

--- a/fdbserver/workloads/RyowCorrectness.actor.cpp
+++ b/fdbserver/workloads/RyowCorrectness.actor.cpp
@@ -57,7 +57,7 @@ struct Operation {
 	Value value;
 
 	int limit;
-	bool reverse;
+	bool reverse = false;
 };
 
 //A workload which executes random sequences of operations on RYOW transactions and confirms the results

--- a/flow/Arena.h
+++ b/flow/Arena.h
@@ -546,7 +546,9 @@ public:
 	constexpr static FileIdentifier file_identifier = 13300811;
 	StringRef() : data(0), length(0) {}
 	StringRef( Arena& p, const StringRef& toCopy ) : data( new (p) uint8_t[toCopy.size()] ), length( toCopy.size() ) {
-		memcpy( (void*)data, toCopy.data, length );
+		if (length > 0) {
+			memcpy((void*)data, toCopy.data, length);
+		}
 	}
 	StringRef( Arena& p, const std::string& toCopy ) : length( (int)toCopy.size() ) {
 		UNSTOPPABLE_ASSERT( toCopy.size() <= std::numeric_limits<int>::max());
@@ -554,7 +556,9 @@ public:
 		if (length) memcpy( (void*)data, &toCopy[0], length );
 	}
 	StringRef( Arena& p, const uint8_t* toCopy, int length ) : data( new (p) uint8_t[length] ), length(length) {
-		memcpy( (void*)data, toCopy, length );
+		if (length > 0) {
+			memcpy((void*)data, toCopy, length);
+		}
 	}
 	StringRef( const uint8_t* data, int length ) : data(data), length(length) {}
 	StringRef( const std::string& s ) : data((const uint8_t*)s.c_str()), length((int)s.size()) {
@@ -573,17 +577,25 @@ public:
 	bool startsWith( const StringRef& s ) const { return size() >= s.size() && !memcmp(begin(), s.begin(), s.size()); }
 	bool endsWith( const StringRef& s ) const { return size() >= s.size() && !memcmp(end()-s.size(), s.begin(), s.size()); }
 
-	StringRef withPrefix( const StringRef& prefix, Arena& arena ) const {
-		uint8_t* s = new (arena) uint8_t[ prefix.size() + size() ];
-		memcpy(s, prefix.begin(), prefix.size());
-		memcpy(s+prefix.size(), begin(), size());
-		return StringRef(s,prefix.size() + size());
+	StringRef withPrefix(const StringRef& prefix, Arena& arena) const {
+		uint8_t* s = new (arena) uint8_t[prefix.size() + size()];
+		if (prefix.size() > 0) {
+			memcpy(s, prefix.begin(), prefix.size());
+		}
+		if (size() > 0) {
+			memcpy(s + prefix.size(), begin(), size());
+		}
+		return StringRef(s, prefix.size() + size());
 	}
 
 	StringRef withSuffix( const StringRef& suffix, Arena& arena ) const {
 		uint8_t* s = new (arena) uint8_t[ suffix.size() + size() ];
-		memcpy(s, begin(), size());
-		memcpy(s+size(), suffix.begin(), suffix.size());
+		if (size() > 0) {
+			memcpy(s, begin(), size());
+		}
+		if (suffix.size() > 0) {
+			memcpy(s + size(), suffix.begin(), suffix.size());
+		}
 		return StringRef(s,suffix.size() + size());
 	}
 
@@ -644,9 +656,11 @@ public:
 
 	int expectedSize() const { return size(); }
 
-	int compare( StringRef const& other ) const {
-		int c = memcmp( begin(), other.begin(), std::min( size(), other.size() ) );
-		if (c!=0) return c;
+	int compare(StringRef const& other) const {
+		if (std::min(size(), other.size()) > 0) {
+			int c = memcmp(begin(), other.begin(), std::min(size(), other.size()));
+			if (c != 0) return c;
+		}
 		return size() - other.size();
 	}
 
@@ -782,17 +796,24 @@ struct dynamic_size_traits<StringRef> : std::true_type {
 	}
 };
 
-inline bool operator == (const StringRef& lhs, const StringRef& rhs ) {
+inline bool operator==(const StringRef& lhs, const StringRef& rhs) {
+	if (lhs.size() == 0 && rhs.size() == 0) {
+		return true;
+	}
 	return lhs.size() == rhs.size() && !memcmp(lhs.begin(), rhs.begin(), lhs.size());
 }
-inline bool operator < ( const StringRef& lhs, const StringRef& rhs ) {
-	int c = memcmp( lhs.begin(), rhs.begin(), std::min(lhs.size(), rhs.size()) );
-	if (c!=0) return c<0;
+inline bool operator<(const StringRef& lhs, const StringRef& rhs) {
+	if (std::min(lhs.size(), rhs.size()) > 0) {
+		int c = memcmp(lhs.begin(), rhs.begin(), std::min(lhs.size(), rhs.size()));
+		if (c != 0) return c < 0;
+	}
 	return lhs.size() < rhs.size();
 }
-inline bool operator > ( const StringRef& lhs, const StringRef& rhs ) {
-	int c = memcmp( lhs.begin(), rhs.begin(), std::min(lhs.size(), rhs.size()) );
-	if (c!=0) return c>0;
+inline bool operator>(const StringRef& lhs, const StringRef& rhs) {
+	if (std::min(lhs.size(), rhs.size()) > 0) {
+		int c = memcmp(lhs.begin(), rhs.begin(), std::min(lhs.size(), rhs.size()));
+		if (c != 0) return c > 0;
+	}
 	return lhs.size() > rhs.size();
 }
 inline bool operator != (const StringRef& lhs, const StringRef& rhs ) { return !(lhs==rhs); }
@@ -903,7 +924,9 @@ public:
 	VectorRef(Arena& p, const VectorRef<T, S>& toCopy, typename std::enable_if<memcpy_able<T2>::value, int>::type = 0)
 	  : VPS(toCopy), data((T*)new (p) uint8_t[sizeof(T) * toCopy.size()]), m_size(toCopy.size()),
 	    m_capacity(toCopy.size()) {
-		memcpy(data, toCopy.data, m_size * sizeof(T));
+		if (m_size > 0) {
+			memcpy(data, toCopy.data, m_size * sizeof(T));
+		}
 	}
 
 	// Arena constructor for Ref types, which must have an Arena constructor
@@ -997,7 +1020,9 @@ public:
 	void append(Arena& p, const T* begin, int count) {
 		if (m_size + count > m_capacity) reallocate(p, m_size + count);
 		VPS::invalidate();
-		memcpy(data + m_size, begin, sizeof(T) * count);
+		if (count > 0) {
+			memcpy(data + m_size, begin, sizeof(T) * count);
+		}
 		m_size += count;
 	}
 	template <class It>
@@ -1062,7 +1087,9 @@ private:
 		requiredCapacity = std::max(m_capacity * 2, requiredCapacity);
 		// SOMEDAY: Maybe we are right at the end of the arena and can expand cheaply
 		T* newData = (T*)new (p) uint8_t[requiredCapacity * sizeof(T)];
-		memcpy(newData, data, m_size * sizeof(T));
+		if (m_size > 0) {
+			memcpy(newData, data, m_size * sizeof(T));
+		}
 		data = newData;
 		m_capacity = requiredCapacity;
 	}

--- a/flow/Deque.h
+++ b/flow/Deque.h
@@ -42,8 +42,10 @@ public:
 
 	// TODO: iterator construction, other constructors
 	Deque(Deque const& r) : arr(0), begin(0), end(r.size()), mask(r.mask) {
-		if(r.capacity() > 0)
-			arr = (T*)aligned_alloc(__alignof(T), capacity()*sizeof(T));
+		if (r.capacity() > 0) {
+			arr = (T*)aligned_alloc(std::max(__alignof(T), sizeof(void*)), capacity() * sizeof(T));
+			ASSERT(arr != nullptr);
+		}
 		ASSERT(capacity() >= end || end == 0);
 		for (uint32_t i=0; i<end; i++)
 			new (&arr[i]) T(r[i]);
@@ -57,8 +59,10 @@ public:
 		begin = 0;
 		end = r.size();
 		mask = r.mask;
-		if(r.capacity() > 0)
-			arr = (T*)aligned_alloc(__alignof(T), capacity()*sizeof(T));
+		if (r.capacity() > 0) {
+			arr = (T*)aligned_alloc(std::max(__alignof(T), sizeof(void*)), capacity() * sizeof(T));
+			ASSERT(arr != nullptr);
+		}
 		ASSERT(capacity() >= end || end == 0);
 		for (uint32_t i=0; i<end; i++)
 			new (&arr[i]) T(r[i]);
@@ -163,7 +167,9 @@ private:
 		size_t newSize = mp1 * 2;
 		if (newSize > max_size()) throw std::bad_alloc();
 		//printf("Growing to %lld (%u-%u mask %u)\n", (long long)newSize, begin, end, mask);
-		T *newArr = (T*)aligned_alloc(__alignof(T), newSize*sizeof(T));   // SOMEDAY: FastAllocator, exception safety
+		T* newArr = (T*)aligned_alloc(std::max(__alignof(T), sizeof(void*)),
+		                              newSize * sizeof(T)); // SOMEDAY: FastAllocator, exception safety
+		ASSERT(newArr != nullptr);
 		for (int i = begin; i != end; i++) {
 			new (&newArr[i - begin]) T(std::move(arr[i&mask]));
 			arr[i&mask].~T();

--- a/flow/Platform.cpp
+++ b/flow/Platform.cpp
@@ -1391,7 +1391,7 @@ void getLocalTime(const time_t *timep, struct tm *result) {
 }
 
 void setMemoryQuota( size_t limit ) {
-#if defined(USE_ASAN)
+#if defined(USE_SANITIZER)
 	// ASAN doesn't work with memory quotas: https://github.com/google/sanitizers/wiki/AddressSanitizer#ulimit--v
 	return;
 #endif

--- a/flow/Platform.h
+++ b/flow/Platform.h
@@ -527,16 +527,6 @@ inline static void* aligned_alloc(size_t alignment, size_t size) { return memali
 #if !defined(HAS_ALIGNED_ALLOC)
 #include <cstdlib>
 inline static void* aligned_alloc(size_t alignment, size_t size) {
-	// Linux's aligned_alloc() requires alignment to be a power of 2.  While posix_memalign()
-	// also requires this, in addition it requires alignment to be a multiple of sizeof(void *).
-	// Rather than add this requirement to the platform::aligned_alloc() interface we will simply
-	// upgrade powers of 2 which are less than sizeof(void *) to be exactly sizeof(void *).  Non
-	// powers of 2 of any size will fail as they would on other platforms.  This change does not
-	// break the platform::aligned_alloc() contract as all addresses which are aligned to
-	// sizeof(void *) are also aligned to any power of 2 less than sizeof(void *).
-	if(alignment != 0 && alignment < sizeof(void *) && (alignment & (alignment - 1)) == 0) {
-		alignment = sizeof(void *);
-	}
 	void* ptr = nullptr;
 	posix_memalign(&ptr, alignment, size);
 	return ptr;

--- a/flow/serialize.h
+++ b/flow/serialize.h
@@ -324,9 +324,11 @@ public:
 		serializeBytes(bytes.begin(), bytes.size());
 	}
 	void serializeBytes(const void* data, int bytes) {
-		valgrindCheck( data, bytes, "serializeBytes" );
-		void* p = writeBytes(bytes);
-		memcpy(p, data, bytes);
+		if (bytes > 0) {
+			valgrindCheck(data, bytes, "serializeBytes");
+			void* p = writeBytes(bytes);
+			memcpy(p, data, bytes);
+		}
 	}
 	template <class T>
 	void serializeBinaryItem( const T& t ) {
@@ -456,7 +458,9 @@ private:
 			}
 			Arena newArena;
 			uint8_t* newData = new ( newArena ) uint8_t[ allocated ];
-			memcpy(newData, data, p);
+			if (p > 0) {
+				memcpy(newData, data, p);
+			}
 			arena = newArena;
 			data = newData;
 		}


### PR DESCRIPTION
This fixes ~~all the errors~~ some of the errors I'm seeing with `-fsanitize=undefined -fno-sanitize=alignment`

PTAL at the KeyValueStoreSQLite and Ratekeeper changes, as it's not 100% clear to me I've preserved the original author's intent.