### PR TITLE
Fix ub in MiniConflictSet (Skiplist.cpp)

### DIFF
--- a/fdbserver/SkipList.cpp
+++ b/fdbserver/SkipList.cpp
@@ -1052,7 +1052,7 @@ class MiniConflictSet : NonCopyable {
 	}
 	wordType highBits(int b){ // bits (b&bucketMask) and higher are 1
 		#pragma warning(disable: 4146)
-		return -(wordType(1) << (b & bucketMask));
+		return -bitMask(b);
 		#pragma warning(default: 4146)
 	}
 	wordType lowBits(int b) { // bits lower than (b&bucketMask) are 1

--- a/fdbserver/SkipList.cpp
+++ b/fdbserver/SkipList.cpp
@@ -1036,7 +1036,7 @@ class MiniConflictSet : NonCopyable {
 	MiniConflictSet2 debug;		// SOMEDAY: Test on big ranges, eliminate this
 
 	uint64_t bitMask(unsigned int bit){ // computes results for bit%word
-		return (((wordType)1) << ( bit & bucketMask )); // '&' unnecesary?
+		return (((wordType)1) << (bit & bucketMask));
 	}
 	void setNthBit(std::vector<wordType>& v, const unsigned int bit){
 		v[bit>>bucketShift] |= bitMask(bit);
@@ -1055,8 +1055,8 @@ class MiniConflictSet : NonCopyable {
 		return -(wordType(1) << (b & bucketMask));
 		#pragma warning(default: 4146)
 	}
-	wordType lowBits(int b){ // bits lower than b are 1
-		return (wordType(1)<<b)-1;
+	wordType lowBits(int b) { // bits lower than (b&bucketMask) are 1
+		return (wordType(1) << (b & bucketMask)) - 1;
 	}
 	wordType lowBits2(int b) {
 		return (b&bucketMask) ? lowBits(b) : -1;

--- a/fdbserver/SkipList.cpp
+++ b/fdbserver/SkipList.cpp
@@ -1092,6 +1092,15 @@ class MiniConflictSet : NonCopyable {
 		}
 	}
 
+	bool orImpl(int begin, int end) {
+		if (begin == end) return false;
+		int beginWord = begin >> bucketShift;
+		int lastWord = ((end + bucketMask) >> bucketShift) - 1;
+
+		return orBits(orValues, beginWord + 1, lastWord, true) || getNthBit(andValues, beginWord) ||
+		       getNthBit(andValues, lastWord) || orBits(values, begin, end, false);
+	}
+
 public:
 	explicit MiniConflictSet( int size ) : debug(size) {
 		static_assert((1<<bucketShift) == sizeof(wordType)*8, "BucketShift incorrect");
@@ -1118,16 +1127,6 @@ public:
 		bool b = debug.any(begin,end);
 		ASSERT( a == b );
 		return b;
-	}
-
-	bool orImpl( int begin, int end ) {
-		if (begin == end) return false;
-		int beginWord = begin>>bucketShift;
-		int lastWord = ((end+bucketMask) >> bucketShift) - 1;
-
-		return orBits( orValues, beginWord+1, lastWord, true ) ||
-			getNthBit( andValues, beginWord ) || getNthBit( andValues, lastWord ) ||
-			orBits( values, begin, end, false );
 	}
 };
 

--- a/fdbserver/SkipList.cpp
+++ b/fdbserver/SkipList.cpp
@@ -1056,7 +1056,7 @@ class MiniConflictSet : NonCopyable {
 		#pragma warning(default: 4146)
 	}
 	wordType lowBits(int b) { // bits lower than (b&bucketMask) are 1
-		return (wordType(1) << (b & bucketMask)) - 1;
+		return bitMask(b) - 1;
 	}
 	wordType lowBits2(int b) {
 		return (b&bucketMask) ? lowBits(b) : -1;

--- a/fdbserver/SkipList.cpp
+++ b/fdbserver/SkipList.cpp
@@ -1035,7 +1035,7 @@ class MiniConflictSet : NonCopyable {
 	std::vector<wordType> andValues;
 	MiniConflictSet2 debug;		// SOMEDAY: Test on big ranges, eliminate this
 
-	uint64_t bitMask(unsigned int bit){ // computes results for bit%word
+	wordType bitMask(unsigned int bit) { // computes results for bit%word
 		return (((wordType)1) << (bit & bucketMask));
 	}
 	void setNthBit(std::vector<wordType>& v, const unsigned int bit){

--- a/fdbserver/SkipList.cpp
+++ b/fdbserver/SkipList.cpp
@@ -1052,7 +1052,7 @@ class MiniConflictSet : NonCopyable {
 	}
 	wordType highBits(int b){ // bits (b&bucketMask) and higher are 1
 		#pragma warning(disable: 4146)
-		return -(wordType(1) << b);
+		return -(wordType(1) << (b & bucketMask));
 		#pragma warning(default: 4146)
 	}
 	wordType lowBits(int b){ // bits lower than b are 1


### PR DESCRIPTION
It seems to me that the original author was under the impression that `x << y` is semantically equivalent to `x << (y % (sizeof(x) * 8))`. This is the behavior we were getting and seem to rely on, so let's keep the behavior but make it not UB

Resolves #2398