### PR TITLE
BlobStoreEndpoint enhancements

### DIFF
--- a/fdbclient/BackupContainer.actor.cpp
+++ b/fdbclient/BackupContainer.actor.cpp
@@ -1458,7 +1458,7 @@ public:
 			return pathFilter(folderPath.substr(prefixTrim));
 		};
 
-		state BlobStoreEndpoint::ListResult result = wait(bc->m_bstore->listBucket(bc->m_bucket, bc->dataPath(path), '/', std::numeric_limits<int>::max(), rawPathFilter));
+		state BlobStoreEndpoint::ListResult result = wait(bc->m_bstore->listObjects(bc->m_bucket, bc->dataPath(path), '/', std::numeric_limits<int>::max(), rawPathFilter));
 		FilesAndSizesT files;
 		for(auto &o : result.objects) {
 			ASSERT(o.name.size() >= prefixTrim);

--- a/fdbclient/BackupContainer.actor.cpp
+++ b/fdbclient/BackupContainer.actor.cpp
@@ -1412,7 +1412,7 @@ public:
 
 	ACTOR static Future<std::vector<std::string>> listURLs(Reference<BlobStoreEndpoint> bstore, std::string bucket) {
 		state std::string basePath = INDEXFOLDER + '/';
-		BlobStoreEndpoint::ListResult contents = wait(bstore->listBucket(bucket, basePath));
+		BlobStoreEndpoint::ListResult contents = wait(bstore->listObjects(bucket, basePath));
 		std::vector<std::string> results;
 		for(auto &f : contents.objects) {
 			results.push_back(bstore->getResourceURL(f.name.substr(basePath.size()), format("bucket=%s", bucket.c_str())));

--- a/fdbclient/BlobStore.h
+++ b/fdbclient/BlobStore.h
@@ -193,10 +193,13 @@ public:
 	// Get bucket contents via a stream, since listing large buckets will take many serial blob requests
 	// If a delimiter is passed then common prefixes will be read in parallel, recursively, depending on recurseFilter.
 	// Recursefilter is a must be a function that takes a string and returns true if it passes.  The default behavior is to assume true.
-	Future<Void> listBucketStream(std::string const &bucket, PromiseStream<ListResult> results, Optional<std::string> prefix = {}, Optional<char> delimiter = {}, int maxDepth = 0, std::function<bool(std::string const &)> recurseFilter = nullptr);
+	Future<Void> listObjectsStream(std::string const &bucket, PromiseStream<ListResult> results, Optional<std::string> prefix = {}, Optional<char> delimiter = {}, int maxDepth = 0, std::function<bool(std::string const &)> recurseFilter = nullptr);
 
-	// Get a list of the files in a bucket, see listBucketStream for more argument detail.
-	Future<ListResult> listBucket(std::string const &bucket, Optional<std::string> prefix = {}, Optional<char> delimiter = {}, int maxDepth = 0, std::function<bool(std::string const &)> recurseFilter = nullptr);
+	// Get a list of the files in a bucket, see listObjectsStream for more argument detail.
+	Future<ListResult> listObjects(std::string const &bucket, Optional<std::string> prefix = {}, Optional<char> delimiter = {}, int maxDepth = 0, std::function<bool(std::string const &)> recurseFilter = nullptr);
+
+	// Get a list of all buckets
+	Future<std::vector<std::string>> listBuckets();
 
 	// Check if a bucket exists
 	Future<bool> bucketExists(std::string const &bucket);
@@ -216,9 +219,9 @@ public:
 	// Delete all objects in a bucket under a prefix.  Note this is not atomic as blob store does not
 	// support this operation directly. This method is just a convenience method that lists and deletes
 	// all of the objects in the bucket under the given prefix.
-	// Since it can take a while, if a pNumDeleted is provided then it will be incremented every time
+	// Since it can take a while, if a pNumDeleted and/or pBytesDeleted are provided they will be incremented every time
 	// a deletion of an object completes.
-	Future<Void> deleteRecursively(std::string const &bucket, std::string prefix = "", int *pNumDeleted = NULL);
+	Future<Void> deleteRecursively(std::string const &bucket, std::string prefix = "", int *pNumDeleted = nullptr, int64_t *pBytesDeleted = nullptr);
 
 	// Create a bucket if it does not already exists.
 	Future<Void> createBucket(std::string const &bucket);


### PR DESCRIPTION
Added BlobStoreEndpoint::listBuckets(), renamed listBucket() and several related functions with similar names to listObjects() to avoid confusion and closer match what it actually does.

Added a bytesDeleted output statistic to BlobStoreEndpoint::deleteRecursively().

None of these API features are used yet on master, but they were tested/used by me in a one-off tool I wrote to clean up some very old (pre 5.0 I think) backup data. 

These new features could be used to enhance fdbbackup to be able to find buckets which contain backups or to report the amount of data deleted during backup expiration or deletion.