### PR TITLE
implement Stringer interface on Tuple and Subspace

### DIFF
--- a/bindings/go/src/fdb/subspace/subspace.go
+++ b/bindings/go/src/fdb/subspace/subspace.go
@@ -35,6 +35,8 @@ package subspace
 import (
 	"bytes"
 	"errors"
+	"fmt"
+
 	"github.com/apple/foundationdb/bindings/go/src/fdb"
 	"github.com/apple/foundationdb/bindings/go/src/fdb/tuple"
 )
@@ -42,6 +44,8 @@ import (
 // Subspace represents a well-defined region of keyspace in a FoundationDB
 // database.
 type Subspace interface {
+	fmt.Stringer
+
 	// Sub returns a new Subspace whose prefix extends this Subspace with the
 	// encoding of the provided element(s). If any of the elements are not a
 	// valid tuple.TupleElement, Sub will panic.
@@ -94,6 +98,12 @@ func FromBytes(b []byte) Subspace {
 	s := make([]byte, len(b))
 	copy(s, b)
 	return subspace{s}
+}
+
+// String implements the fmt.Stringer interface and return the subspace
+// as a human readable byte string provided by fdb.Printable.
+func (s subspace) String() string {
+	return fdb.Printable(s.b)
 }
 
 func (s subspace) Sub(el ...tuple.TupleElement) Subspace {

--- a/bindings/go/src/fdb/subspace/subspace_test.go
+++ b/bindings/go/src/fdb/subspace/subspace_test.go
@@ -1,0 +1,15 @@
+package subspace
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestSubspaceString(t *testing.T) {
+	printed := fmt.Sprint(Sub([]byte("hello"), "world", 42, 0x99))
+	expected := "\\x01hello\\x00\\x02world\\x00\\x15*\\x15\\x99"
+
+	if printed != expected {
+		t.Fatalf("printed subspace result differs, expected %v, got %v", expected, printed)
+	}
+}

--- a/bindings/go/src/fdb/tuple/tuple.go
+++ b/bindings/go/src/fdb/tuple/tuple.go
@@ -66,6 +66,12 @@ type TupleElement interface{}
 // packing T (modulo type normalization to []byte, uint64, and int64).
 type Tuple []TupleElement
 
+// String implements the fmt.Stringer interface and return the tuple
+// as a human readable byte string provided by fdb.Printable.
+func (t Tuple) String() string {
+	return fdb.Printable(t.Pack())
+}
+
 // UUID wraps a basic byte array as a UUID. We do not provide any special
 // methods for accessing or generating the UUID, but as Go does not provide
 // a built-in UUID type, this simple wrapper allows for other libraries

--- a/bindings/go/src/fdb/tuple/tuple_test.go
+++ b/bindings/go/src/fdb/tuple/tuple_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/gob"
 	"flag"
+	"fmt"
 	"math/rand"
 	"os"
 	"testing"
@@ -116,5 +117,14 @@ func BenchmarkTuplePacking(b *testing.B) {
 				_ = tuple.Pack()
 			}
 		})
+	}
+}
+
+func TestTupleString(t *testing.T) {
+	printed := fmt.Sprint(Tuple{[]byte("hello"), "world", 42, 0x99})
+	expected := "\\x01hello\\x00\\x02world\\x00\\x15*\\x15\\x99"
+
+	if printed != expected {
+		t.Fatalf("printed tuple result differs, expected %v, got %v", expected, printed)
 	}
 }


### PR DESCRIPTION
This pull request implements the [fmt.Stringer](\x01hello\x00\x02world\x00\x15*\x15\x99) interface on the Tuple and Subspace of the Go bindings.

This allows easy printing of tuples and spaces with the default string interpolation. The String method is used to print values passed as an operand to any format that accepts a string or to an unformatted printer such as Print.

Example:

```go
// create tuple
t :=tuple.Tuple{[]byte("hello", "world", 42, 0x99})

// print tuple (or use your fav logging framework)
fmt.Printf("tuple at %v", t)
```

Output:

```
\x01hello\x00\x02world\x00\x15*\x15\x99
```