### PR TITLE
Fix internal error when client buggify fails successful transaction with commit_unknown_result

### DIFF
--- a/documentation/sphinx/source/release-notes.rst
+++ b/documentation/sphinx/source/release-notes.rst
@@ -2,6 +2,14 @@
 Release Notes
 #############
 
+6.2.12
+======
+
+Fixes
+-----
+
+* Clients could throw an internal error during ``commit`` if client buggification was enabled. `(PR #2427) <https://github.com/apple/foundationdb/pull/2427>`_.
+
 6.2.11
 ======
 


### PR DESCRIPTION
Resolves #2424 

Also:

Move some buggify errors into a try catch block so that the normal error handling path can run.
Initialize `startTime` so that it's valid in the case of errors thrown early.