### PR TITLE
Add keyAfter method to Java bindings

### DIFF
--- a/bindings/java/src/main/com/apple/foundationdb/tuple/ByteArrayUtil.java
+++ b/bindings/java/src/main/com/apple/foundationdb/tuple/ByteArrayUtil.java
@@ -360,6 +360,21 @@ public class ByteArrayUtil {
 	}
 
 	/**
+	 * Computes the key that would sort immediately after {@code key}.
+	 *  {@code key} must be non-null.
+	 *
+	 * @param key byte array for which next key is to be computed
+	 *
+	 * @return a newly created byte array that would sort immediately after {@code key}
+	*/
+	public static byte[] keyAfter(byte[] key) {
+		byte[] copy = new byte[key.length + 1];
+		System.arraycopy(key, 0, copy, 0, key.length);
+		copy[key.length] = 0x0;
+		return copy;
+	}
+
+	/**
 	 * Get a copy of an array, with all matching characters stripped from trailing edge.
 	 * @param input array to copy. Must not be null.
 	 * @param target byte to exclude from copy.

--- a/documentation/sphinx/source/release-notes.rst
+++ b/documentation/sphinx/source/release-notes.rst
@@ -17,6 +17,7 @@ Status
 
 Bindings
 --------
+* Java: Introduced ``keyAfter`` utility API, that can be used to create immediate next key for a given byte array. `(PR #2458) <https://github.com/apple/foundationdb/pull/2458>`_
 
 Other Changes
 -------------

--- a/documentation/sphinx/source/release-notes.rst
+++ b/documentation/sphinx/source/release-notes.rst
@@ -17,7 +17,7 @@ Status
 
 Bindings
 --------
-* Java: Introduced ``keyAfter`` utility API, that can be used to create immediate next key for a given byte array. `(PR #2458) <https://github.com/apple/foundationdb/pull/2458>`_
+* Java: Introduced ``keyAfter`` utility function that can be used to create the immediate next key for a given byte array. `(PR #2458) <https://github.com/apple/foundationdb/pull/2458>`_
 
 Other Changes
 -------------


### PR DESCRIPTION
Copied from https://github.com/apple/foundationdb/blob/master/fdbclient/FDBTypes.h#L416
Not sure if I should add a check against [0xFF 0xFF] here.

@alecgrieser Could you please review this?