### PR TITLE
Add status documentation comments to 6.2

### DIFF
--- a/documentation/sphinx/source/mr-status-json-schemas.rst.inc
+++ b/documentation/sphinx/source/mr-status-json-schemas.rst.inc
@@ -628,7 +628,7 @@
             },
             "memory":{
                "free_bytes":0, // an estimate of how many bytes are free to allocate to fdbservers without swapping
-               "committed_bytes":0, // an estimate of the number of bytes of memory on the machine that are not available
+               "committed_bytes":0, // an estimate of the number of bytes of memory on the machine that are not free for allocation
                "total_bytes":0 // an estimate of total physical RAM
             },
             "contributing_workers":4,

--- a/documentation/sphinx/source/mr-status-json-schemas.rst.inc
+++ b/documentation/sphinx/source/mr-status-json-schemas.rst.inc
@@ -124,10 +124,10 @@
             ],
             "command_line":"-r simulation",
             "memory":{
-               "available_bytes":0, //an estimate of the process' fair share of the memory available to fdbservers
+               "available_bytes":0, // an estimate of the process' fair share of the memory available to fdbservers
                "limit_bytes":0, // memory limit per process
                "unused_allocated_memory":0,
-               "used_bytes":0
+               "used_bytes":0 // virtual memory size of the process
             },
             "messages":[
                {
@@ -408,18 +408,18 @@
                "counter":0,
                "roughness":0.0
             },
-            "reads":{
+            "reads":{ // measures number of completed read requests
                "hz":0.0,
                "counter":0,
                "roughness":0.0
             },
-            "read_requests":{
+            "read_requests":{ // measures number of incoming read requests
                "hz":0.0,
                "counter":0,
                "roughness":0.0
             }
          },
-         "bytes":{ // of operations (independent of hz). Perfectly spaced operations will have a roughness of 1.0 . Randomly spaced (Poisson-distributed) operations will have a roughness of 2.0, with increased bunching resulting in increased values. Higher roughness can result in increased latency due to increased queuing.
+         "bytes":{ // measures number of logical bytes read/written (ignoring replication factor and overhead on disk). Perfectly spaced operations will have a roughness of 1.0 . Randomly spaced (Poisson-distributed) operations will have a roughness of 2.0, with increased bunching resulting in increased values. Higher roughness can result in increased latency due to increased queuing.
             "written":{
                "hz":0.0,
                "counter":0,
@@ -628,7 +628,7 @@
             },
             "memory":{
                "free_bytes":0, // an estimate of how many bytes are free to allocate to fdbservers without swapping
-               "committed_bytes":0,
+               "committed_bytes":0, // an estimate of the number of bytes of memory on the machine that are not available
                "total_bytes":0 // an estimate of total physical RAM
             },
             "contributing_workers":4,

--- a/documentation/sphinx/source/mr-status-json-schemas.rst.inc
+++ b/documentation/sphinx/source/mr-status-json-schemas.rst.inc
@@ -419,7 +419,7 @@
                "roughness":0.0
             }
          },
-         "bytes":{ // measures number of logical bytes read/written (ignoring replication factor and overhead on disk). Perfectly spaced operations will have a roughness of 1.0 . Randomly spaced (Poisson-distributed) operations will have a roughness of 2.0, with increased bunching resulting in increased values. Higher roughness can result in increased latency due to increased queuing.
+         "bytes":{ // measures number of logical bytes read/written (ignoring replication factor and overhead on disk). Perfectly spaced operations will have a roughness of 1.0. Randomly spaced (Poisson-distributed) operations will have a roughness of 2.0, with increased bunching resulting in increased values. Higher roughness can result in increased latency due to increased queuing.
             "written":{
                "hz":0.0,
                "counter":0,

--- a/documentation/sphinx/source/mr-status-json-schemas.rst.inc
+++ b/documentation/sphinx/source/mr-status-json-schemas.rst.inc
@@ -582,8 +582,8 @@
          "partitions_count":2,
          "moving_data":{
             "total_written_bytes":0, // reset whenever data distributor is re-recruited
-            "in_flight_bytes":0,
-            "in_queue_bytes":0,
+            "in_flight_bytes":0, // number of bytes currently being moved between storage servers
+            "in_queue_bytes":0, // number of bytes in the data distributor queue that should be moved (but are not yet being transferred between storage servers)
             "highest_priority":0
          },
          "team_trackers":[

--- a/documentation/sphinx/source/mr-status-json-schemas.rst.inc
+++ b/documentation/sphinx/source/mr-status-json-schemas.rst.inc
@@ -581,7 +581,7 @@
          "system_kv_size_bytes":0, // estimated
          "partitions_count":2,
          "moving_data":{
-            "total_written_bytes":0,
+            "total_written_bytes":0, // reset whenever data distributor is re-recruited
             "in_flight_bytes":0,
             "in_queue_bytes":0,
             "highest_priority":0


### PR DESCRIPTION
This is the PR from https://github.com/apple/foundationdb/pull/2461, rebased against 6.2.