### PR TITLE
Fix an issue where a peek starting from version 1 could crash a TLog

### DIFF
--- a/fdbserver/OldTLogServer_6_2.actor.cpp
+++ b/fdbserver/OldTLogServer_6_2.actor.cpp
@@ -366,19 +366,21 @@ struct LogData : NonCopyable, public ReferenceCounted<LogData> {
 		bool nothingPersistent;				// true means tag is *known* to have no messages in persistentData.  false means nothing.
 		bool poppedRecently;					// `popped` has changed since last updatePersistentData
 		Version popped;				// see popped version tracking contract below
+		Version persistentPopped;  // The popped version recorded in the btree.
 		bool requiresPoppedLocationUpdate;					// `popped` has changed since last updatePoppedLocation
 		IDiskQueue::location poppedLocation;  // The location of the earliest commit with data for this tag.
 		bool unpoppedRecovered;
 		Tag tag;
 
-		TagData( Tag tag, Version popped, IDiskQueue::location poppedLocation, bool nothingPersistent, bool poppedRecently, bool unpoppedRecovered ) : tag(tag), nothingPersistent(nothingPersistent), poppedRecently(poppedRecently), popped(popped), requiresPoppedLocationUpdate(false), poppedLocation(poppedLocation), unpoppedRecovered(unpoppedRecovered) {}
+		TagData( Tag tag, Version popped, IDiskQueue::location poppedLocation, bool nothingPersistent, bool poppedRecently, bool unpoppedRecovered ) : tag(tag), nothingPersistent(nothingPersistent), poppedRecently(poppedRecently), popped(popped), persistentPopped(0), requiresPoppedLocationUpdate(false), poppedLocation(poppedLocation), unpoppedRecovered(unpoppedRecovered) {}
 
-		TagData(TagData&& r) BOOST_NOEXCEPT : versionMessages(std::move(r.versionMessages)), nothingPersistent(r.nothingPersistent), poppedRecently(r.poppedRecently), popped(r.popped), requiresPoppedLocationUpdate(r.requiresPoppedLocationUpdate), poppedLocation(r.poppedLocation), tag(r.tag), unpoppedRecovered(r.unpoppedRecovered) {}
+		TagData(TagData&& r) BOOST_NOEXCEPT : versionMessages(std::move(r.versionMessages)), nothingPersistent(r.nothingPersistent), poppedRecently(r.poppedRecently), popped(r.popped), persistentPopped(r.persistentPopped), requiresPoppedLocationUpdate(r.requiresPoppedLocationUpdate), poppedLocation(r.poppedLocation), tag(r.tag), unpoppedRecovered(r.unpoppedRecovered) {}
 		void operator= (TagData&& r) BOOST_NOEXCEPT {
 			versionMessages = std::move(r.versionMessages);
 			nothingPersistent = r.nothingPersistent;
 			poppedRecently = r.poppedRecently;
 			popped = r.popped;
+			persistentPopped = r.persistentPopped;
 			requiresPoppedLocationUpdate = r.requiresPoppedLocationUpdate;
 			poppedLocation = r.poppedLocation;
 			tag = r.tag;
@@ -663,6 +665,7 @@ void updatePersistentPopped( TLogData* self, Reference<LogData> logData, Referen
 	if (!data->poppedRecently) return;
 	self->persistentData->set(KeyValueRef( persistTagPoppedKey(logData->logId, data->tag), persistTagPoppedValue(data->popped) ));
 	data->poppedRecently = false;
+	data->persistentPopped = data->popped;
 
 	if (data->nothingPersistent) return;
 
@@ -690,11 +693,13 @@ ACTOR Future<Void> updatePoppedLocation( TLogData* self, Reference<LogData> logD
 	if (!data->requiresPoppedLocationUpdate) return Void();
 	data->requiresPoppedLocationUpdate = false;
 
-	if (data->popped <= logData->persistentDataVersion) {
+	// Use persistentPopped and not popped, so that a pop update received after spilling doesn't cause
+	// us to remove data that still is pointed to by SpilledData in the btree.
+	if (data->persistentPopped <= logData->persistentDataVersion) {
 		// Recover the next needed location in the Disk Queue from the index.
 		Standalone<VectorRef<KeyValueRef>> kvrefs = wait(
 				self->persistentData->readRange(KeyRangeRef(
-						persistTagMessageRefsKey(logData->logId, data->tag, data->popped),
+						persistTagMessageRefsKey(logData->logId, data->tag, data->persistentPopped),
 						persistTagMessageRefsKey(logData->logId, data->tag, logData->persistentDataVersion + 1)), 1));
 
 		if (kvrefs.empty()) {
@@ -706,7 +711,7 @@ ACTOR Future<Void> updatePoppedLocation( TLogData* self, Reference<LogData> logD
 			r >> spilledData;
 
 			for (const SpilledData& sd : spilledData) {
-				if (sd.version >= data->popped) {
+				if (sd.version >= data->persistentPopped) {
 					data->poppedLocation = sd.start;
 					break;
 				}
@@ -714,9 +719,9 @@ ACTOR Future<Void> updatePoppedLocation( TLogData* self, Reference<LogData> logD
 		}
 	}
 
-	if (data->popped >= logData->persistentDataVersion || data->nothingPersistent) {
+	if (data->persistentPopped >= logData->persistentDataVersion || data->nothingPersistent) {
 		// Then the location must be in memory.
-		auto locationIter = logData->versionLocation.lower_bound(data->popped);
+		auto locationIter = logData->versionLocation.lower_bound(data->persistentPopped);
 		if (locationIter != logData->versionLocation.end()) {
 			data->poppedLocation = locationIter->value.first;
 		} else {
@@ -2462,6 +2467,7 @@ ACTOR Future<Void> restorePersistentState( TLogData* self, LocalityData locality
 				auto tagData = logData->getTagData(tag);
 				ASSERT( !tagData );
 				logData->createTagData(tag, popped, false, false, false);
+				logData->getTagData(tag)->persistentPopped = popped;
 			}
 		}
 	}

--- a/fdbserver/OldTLogServer_6_2.actor.cpp
+++ b/fdbserver/OldTLogServer_6_2.actor.cpp
@@ -367,21 +367,21 @@ struct LogData : NonCopyable, public ReferenceCounted<LogData> {
 		bool poppedRecently;					// `popped` has changed since last updatePersistentData
 		Version popped;				// see popped version tracking contract below
 		Version persistentPopped;  // The popped version recorded in the btree.
-		Version poppedLocationForVersion;  // `poppedLocation` was calculated at this popped version
+		Version versionForPoppedLocation;  // `poppedLocation` was calculated at this popped version
 		IDiskQueue::location poppedLocation;  // The location of the earliest commit with data for this tag.
 		bool unpoppedRecovered;
 		Tag tag;
 
-		TagData( Tag tag, Version popped, IDiskQueue::location poppedLocation, bool nothingPersistent, bool poppedRecently, bool unpoppedRecovered ) : tag(tag), nothingPersistent(nothingPersistent), poppedRecently(poppedRecently), popped(popped), persistentPopped(0), poppedLocationForVersion(0), poppedLocation(poppedLocation), unpoppedRecovered(unpoppedRecovered) {}
+		TagData( Tag tag, Version popped, IDiskQueue::location poppedLocation, bool nothingPersistent, bool poppedRecently, bool unpoppedRecovered ) : tag(tag), nothingPersistent(nothingPersistent), poppedRecently(poppedRecently), popped(popped), persistentPopped(0), versionForPoppedLocation(0), poppedLocation(poppedLocation), unpoppedRecovered(unpoppedRecovered) {}
 
-		TagData(TagData&& r) BOOST_NOEXCEPT : versionMessages(std::move(r.versionMessages)), nothingPersistent(r.nothingPersistent), poppedRecently(r.poppedRecently), popped(r.popped), persistentPopped(r.persistentPopped), poppedLocationForVersion(r.poppedLocationForVersion), poppedLocation(r.poppedLocation), tag(r.tag), unpoppedRecovered(r.unpoppedRecovered) {}
+		TagData(TagData&& r) BOOST_NOEXCEPT : versionMessages(std::move(r.versionMessages)), nothingPersistent(r.nothingPersistent), poppedRecently(r.poppedRecently), popped(r.popped), persistentPopped(r.persistentPopped), versionForPoppedLocation(r.versionForPoppedLocation), poppedLocation(r.poppedLocation), tag(r.tag), unpoppedRecovered(r.unpoppedRecovered) {}
 		void operator= (TagData&& r) BOOST_NOEXCEPT {
 			versionMessages = std::move(r.versionMessages);
 			nothingPersistent = r.nothingPersistent;
 			poppedRecently = r.poppedRecently;
 			popped = r.popped;
 			persistentPopped = r.persistentPopped;
-			poppedLocationForVersion = r.poppedLocationForVersion;
+			versionForPoppedLocation = r.versionForPoppedLocation;
 			poppedLocation = r.poppedLocation;
 			tag = r.tag;
 			unpoppedRecovered = r.unpoppedRecovered;
@@ -690,8 +690,8 @@ ACTOR Future<Void> updatePoppedLocation( TLogData* self, Reference<LogData> logD
 		return Void();
 	}
 
-	if (data->poppedLocationForVersion >= data->persistentPopped) return Void();
-	data->poppedLocationForVersion = data->persistentPopped;
+	if (data->versionForPoppedLocation >= data->persistentPopped) return Void();
+	data->versionForPoppedLocation = data->persistentPopped;
 
 	// Use persistentPopped and not popped, so that a pop update received after spilling doesn't cause
 	// us to remove data that still is pointed to by SpilledData in the btree.
@@ -713,7 +713,7 @@ ACTOR Future<Void> updatePoppedLocation( TLogData* self, Reference<LogData> logD
 			for (const SpilledData& sd : spilledData) {
 				if (sd.version >= data->persistentPopped) {
 					data->poppedLocation = sd.start;
-					data->poppedLocationForVersion = sd.version;
+					data->versionForPoppedLocation = sd.version;
 					break;
 				}
 			}
@@ -725,7 +725,7 @@ ACTOR Future<Void> updatePoppedLocation( TLogData* self, Reference<LogData> logD
 		auto locationIter = logData->versionLocation.lower_bound(data->persistentPopped);
 		if (locationIter != logData->versionLocation.end()) {
 			data->poppedLocation = locationIter->value.first;
-			data->poppedLocationForVersion = locationIter->key;
+			data->versionForPoppedLocation = locationIter->key;
 		} else {
 			// No data on disk and no data in RAM.
 			// This TLog instance will be removed soon anyway, so we temporarily freeze our poppedLocation

--- a/fdbserver/OldTLogServer_6_2.actor.cpp
+++ b/fdbserver/OldTLogServer_6_2.actor.cpp
@@ -372,7 +372,7 @@ struct LogData : NonCopyable, public ReferenceCounted<LogData> {
 		bool unpoppedRecovered;
 		Tag tag;
 
-		TagData( Tag tag, Version popped, IDiskQueue::location poppedLocation, bool nothingPersistent, bool poppedRecently, bool unpoppedRecovered ) : tag(tag), nothingPersistent(nothingPersistent), poppedRecently(poppedRecently), popped(popped), persistentPopped(0), poppedLocationForVersion(false), poppedLocation(poppedLocation), unpoppedRecovered(unpoppedRecovered) {}
+		TagData( Tag tag, Version popped, IDiskQueue::location poppedLocation, bool nothingPersistent, bool poppedRecently, bool unpoppedRecovered ) : tag(tag), nothingPersistent(nothingPersistent), poppedRecently(poppedRecently), popped(popped), persistentPopped(0), poppedLocationForVersion(0), poppedLocation(poppedLocation), unpoppedRecovered(unpoppedRecovered) {}
 
 		TagData(TagData&& r) BOOST_NOEXCEPT : versionMessages(std::move(r.versionMessages)), nothingPersistent(r.nothingPersistent), poppedRecently(r.poppedRecently), popped(r.popped), persistentPopped(r.persistentPopped), poppedLocationForVersion(r.poppedLocationForVersion), poppedLocation(r.poppedLocation), tag(r.tag), unpoppedRecovered(r.unpoppedRecovered) {}
 		void operator= (TagData&& r) BOOST_NOEXCEPT {

--- a/fdbserver/TLogServer.actor.cpp
+++ b/fdbserver/TLogServer.actor.cpp
@@ -371,7 +371,7 @@ struct LogData : NonCopyable, public ReferenceCounted<LogData> {
 		bool unpoppedRecovered;
 		Tag tag;
 
-		TagData( Tag tag, Version popped, IDiskQueue::location poppedLocation, bool nothingPersistent, bool poppedRecently, bool unpoppedRecovered ) : tag(tag), nothingPersistent(nothingPersistent), poppedRecently(poppedRecently), popped(popped), persistentPopped(0), poppedLocationForVersion(false), poppedLocation(poppedLocation), unpoppedRecovered(unpoppedRecovered) {}
+		TagData( Tag tag, Version popped, IDiskQueue::location poppedLocation, bool nothingPersistent, bool poppedRecently, bool unpoppedRecovered ) : tag(tag), nothingPersistent(nothingPersistent), poppedRecently(poppedRecently), popped(popped), persistentPopped(0), poppedLocationForVersion(0), poppedLocation(poppedLocation), unpoppedRecovered(unpoppedRecovered) {}
 
 		TagData(TagData&& r) BOOST_NOEXCEPT : versionMessages(std::move(r.versionMessages)), nothingPersistent(r.nothingPersistent), poppedRecently(r.poppedRecently), popped(r.popped), persistentPopped(r.persistentPopped), poppedLocationForVersion(r.poppedLocationForVersion), poppedLocation(r.poppedLocation), tag(r.tag), unpoppedRecovered(r.unpoppedRecovered) {}
 		void operator= (TagData&& r) BOOST_NOEXCEPT {

--- a/fdbserver/TLogServer.actor.cpp
+++ b/fdbserver/TLogServer.actor.cpp
@@ -365,19 +365,21 @@ struct LogData : NonCopyable, public ReferenceCounted<LogData> {
 		bool nothingPersistent;				// true means tag is *known* to have no messages in persistentData.  false means nothing.
 		bool poppedRecently;					// `popped` has changed since last updatePersistentData
 		Version popped;				// see popped version tracking contract below
+		Version persistentPopped;  // The popped version recorded in the btree.
 		bool requiresPoppedLocationUpdate;					// `popped` has changed since last updatePoppedLocation
 		IDiskQueue::location poppedLocation;  // The location of the earliest commit with data for this tag.
 		bool unpoppedRecovered;
 		Tag tag;
 
-		TagData( Tag tag, Version popped, IDiskQueue::location poppedLocation, bool nothingPersistent, bool poppedRecently, bool unpoppedRecovered ) : tag(tag), nothingPersistent(nothingPersistent), poppedRecently(poppedRecently), popped(popped), requiresPoppedLocationUpdate(false), poppedLocation(poppedLocation), unpoppedRecovered(unpoppedRecovered) {}
+		TagData( Tag tag, Version popped, IDiskQueue::location poppedLocation, bool nothingPersistent, bool poppedRecently, bool unpoppedRecovered ) : tag(tag), nothingPersistent(nothingPersistent), poppedRecently(poppedRecently), popped(popped), persistentPopped(0), requiresPoppedLocationUpdate(false), poppedLocation(poppedLocation), unpoppedRecovered(unpoppedRecovered) {}
 
-		TagData(TagData&& r) BOOST_NOEXCEPT : versionMessages(std::move(r.versionMessages)), nothingPersistent(r.nothingPersistent), poppedRecently(r.poppedRecently), popped(r.popped), requiresPoppedLocationUpdate(r.requiresPoppedLocationUpdate), poppedLocation(r.poppedLocation), tag(r.tag), unpoppedRecovered(r.unpoppedRecovered) {}
+		TagData(TagData&& r) BOOST_NOEXCEPT : versionMessages(std::move(r.versionMessages)), nothingPersistent(r.nothingPersistent), poppedRecently(r.poppedRecently), popped(r.popped), persistentPopped(r.persistentPopped), requiresPoppedLocationUpdate(r.requiresPoppedLocationUpdate), poppedLocation(r.poppedLocation), tag(r.tag), unpoppedRecovered(r.unpoppedRecovered) {}
 		void operator= (TagData&& r) BOOST_NOEXCEPT {
 			versionMessages = std::move(r.versionMessages);
 			nothingPersistent = r.nothingPersistent;
 			poppedRecently = r.poppedRecently;
 			popped = r.popped;
+			persistentPopped = r.persistentPopped;
 			requiresPoppedLocationUpdate = r.requiresPoppedLocationUpdate;
 			poppedLocation = r.poppedLocation;
 			tag = r.tag;
@@ -680,6 +682,7 @@ void updatePersistentPopped( TLogData* self, Reference<LogData> logData, Referen
 	if (!data->poppedRecently) return;
 	self->persistentData->set(KeyValueRef( persistTagPoppedKey(logData->logId, data->tag), persistTagPoppedValue(data->popped) ));
 	data->poppedRecently = false;
+	data->persistentPopped = data->popped;
 
 	if (data->nothingPersistent) return;
 
@@ -707,11 +710,13 @@ ACTOR Future<Void> updatePoppedLocation( TLogData* self, Reference<LogData> logD
 	if (!data->requiresPoppedLocationUpdate) return Void();
 	data->requiresPoppedLocationUpdate = false;
 
-	if (data->popped <= logData->persistentDataVersion) {
+	// Use persistentPopped and not popped, so that a pop update received after spilling doesn't cause
+	// us to remove data that still is pointed to by SpilledData in the btree.
+	if (data->persistentPopped <= logData->persistentDataVersion) {
 		// Recover the next needed location in the Disk Queue from the index.
 		Standalone<VectorRef<KeyValueRef>> kvrefs = wait(
 				self->persistentData->readRange(KeyRangeRef(
-						persistTagMessageRefsKey(logData->logId, data->tag, data->popped),
+						persistTagMessageRefsKey(logData->logId, data->tag, data->persistentPopped),
 						persistTagMessageRefsKey(logData->logId, data->tag, logData->persistentDataVersion + 1)), 1));
 
 		if (kvrefs.empty()) {
@@ -723,7 +728,7 @@ ACTOR Future<Void> updatePoppedLocation( TLogData* self, Reference<LogData> logD
 			r >> spilledData;
 
 			for (const SpilledData& sd : spilledData) {
-				if (sd.version >= data->popped) {
+				if (sd.version >= data->persistentPopped) {
 					data->poppedLocation = sd.start;
 					break;
 				}
@@ -731,9 +736,9 @@ ACTOR Future<Void> updatePoppedLocation( TLogData* self, Reference<LogData> logD
 		}
 	}
 
-	if (data->popped >= logData->persistentDataVersion || data->nothingPersistent) {
+	if (data->persistentPopped >= logData->persistentDataVersion || data->nothingPersistent) {
 		// Then the location must be in memory.
-		auto locationIter = logData->versionLocation.lower_bound(data->popped);
+		auto locationIter = logData->versionLocation.lower_bound(data->persistentPopped);
 		if (locationIter != logData->versionLocation.end()) {
 			data->poppedLocation = locationIter->value.first;
 		} else {
@@ -2484,6 +2489,7 @@ ACTOR Future<Void> restorePersistentState( TLogData* self, LocalityData locality
 				auto tagData = logData->getTagData(tag);
 				ASSERT( !tagData );
 				logData->createTagData(tag, popped, false, false, false);
+				logData->getTagData(tag)->persistentPopped = popped;
 			}
 		}
 	}

--- a/fdbserver/TLogServer.actor.cpp
+++ b/fdbserver/TLogServer.actor.cpp
@@ -366,21 +366,21 @@ struct LogData : NonCopyable, public ReferenceCounted<LogData> {
 		bool poppedRecently;					// `popped` has changed since last updatePersistentData
 		Version popped;				// see popped version tracking contract below
 		Version persistentPopped;  // The popped version recorded in the btree.
-		bool requiresPoppedLocationUpdate;					// `popped` has changed since last updatePoppedLocation
+		Version poppedLocationForVersion;  // `poppedLocation` was calculated at this popped version
 		IDiskQueue::location poppedLocation;  // The location of the earliest commit with data for this tag.
 		bool unpoppedRecovered;
 		Tag tag;
 
-		TagData( Tag tag, Version popped, IDiskQueue::location poppedLocation, bool nothingPersistent, bool poppedRecently, bool unpoppedRecovered ) : tag(tag), nothingPersistent(nothingPersistent), poppedRecently(poppedRecently), popped(popped), persistentPopped(0), requiresPoppedLocationUpdate(false), poppedLocation(poppedLocation), unpoppedRecovered(unpoppedRecovered) {}
+		TagData( Tag tag, Version popped, IDiskQueue::location poppedLocation, bool nothingPersistent, bool poppedRecently, bool unpoppedRecovered ) : tag(tag), nothingPersistent(nothingPersistent), poppedRecently(poppedRecently), popped(popped), persistentPopped(0), poppedLocationForVersion(false), poppedLocation(poppedLocation), unpoppedRecovered(unpoppedRecovered) {}
 
-		TagData(TagData&& r) BOOST_NOEXCEPT : versionMessages(std::move(r.versionMessages)), nothingPersistent(r.nothingPersistent), poppedRecently(r.poppedRecently), popped(r.popped), persistentPopped(r.persistentPopped), requiresPoppedLocationUpdate(r.requiresPoppedLocationUpdate), poppedLocation(r.poppedLocation), tag(r.tag), unpoppedRecovered(r.unpoppedRecovered) {}
+		TagData(TagData&& r) BOOST_NOEXCEPT : versionMessages(std::move(r.versionMessages)), nothingPersistent(r.nothingPersistent), poppedRecently(r.poppedRecently), popped(r.popped), persistentPopped(r.persistentPopped), poppedLocationForVersion(r.poppedLocationForVersion), poppedLocation(r.poppedLocation), tag(r.tag), unpoppedRecovered(r.unpoppedRecovered) {}
 		void operator= (TagData&& r) BOOST_NOEXCEPT {
 			versionMessages = std::move(r.versionMessages);
 			nothingPersistent = r.nothingPersistent;
 			poppedRecently = r.poppedRecently;
 			popped = r.popped;
 			persistentPopped = r.persistentPopped;
-			requiresPoppedLocationUpdate = r.requiresPoppedLocationUpdate;
+			poppedLocationForVersion = r.poppedLocationForVersion;
 			poppedLocation = r.poppedLocation;
 			tag = r.tag;
 			unpoppedRecovered = r.unpoppedRecovered;
@@ -707,8 +707,8 @@ ACTOR Future<Void> updatePoppedLocation( TLogData* self, Reference<LogData> logD
 		return Void();
 	}
 
-	if (!data->requiresPoppedLocationUpdate) return Void();
-	data->requiresPoppedLocationUpdate = false;
+	if (data->poppedLocationForVersion >= data->persistentPopped) return Void();
+	data->poppedLocationForVersion = data->persistentPopped;
 
 	// Use persistentPopped and not popped, so that a pop update received after spilling doesn't cause
 	// us to remove data that still is pointed to by SpilledData in the btree.
@@ -730,6 +730,7 @@ ACTOR Future<Void> updatePoppedLocation( TLogData* self, Reference<LogData> logD
 			for (const SpilledData& sd : spilledData) {
 				if (sd.version >= data->persistentPopped) {
 					data->poppedLocation = sd.start;
+					data->poppedLocationForVersion = sd.version;
 					break;
 				}
 			}
@@ -741,6 +742,7 @@ ACTOR Future<Void> updatePoppedLocation( TLogData* self, Reference<LogData> logD
 		auto locationIter = logData->versionLocation.lower_bound(data->persistentPopped);
 		if (locationIter != logData->versionLocation.end()) {
 			data->poppedLocation = locationIter->value.first;
+			data->poppedLocationForVersion = locationIter->key;
 		} else {
 			// No data on disk and no data in RAM.
 			// This TLog instance will be removed soon anyway, so we temporarily freeze our poppedLocation
@@ -992,7 +994,6 @@ ACTOR Future<Void> tLogPopCore( TLogData* self, Tag inputTag, Version to, Refere
 	} else if (upTo > tagData->popped) {
 		tagData->popped = upTo;
 		tagData->poppedRecently = true;
-		tagData->requiresPoppedLocationUpdate = true;
 
 		if(tagData->unpoppedRecovered && upTo > logData->recoveredAt) {
 			tagData->unpoppedRecovered = false;


### PR DESCRIPTION
This wasn't detected by simulation until @jzhou77's new changes because nothing in our current codebase peeks below what was popped.  The bug exists because we will pop the disk queue based off a version that we haven't persisted to disk, so if the TLog crashes, the btree index and the disk queue disagree on what versions have been popped, and thus a peek can get through that tries to read data from the disk queue that no longer exists.