### PR TITLE
Backup and DR layer status document generation now uses snapshot reads…

### DIFF
--- a/documentation/sphinx/source/release-notes.rst
+++ b/documentation/sphinx/source/release-notes.rst
@@ -9,6 +9,7 @@ Fixes
 -----
 
 * Clients could throw an internal error during ``commit`` if client buggification was enabled. `(PR #2427) <https://github.com/apple/foundationdb/pull/2427>`_.
+* Backup and DR agent transactions which update and clean up status had an unnecessarily high conflict rate. `(PR #2483) <https://github.com/apple/foundationdb/pull/2483>`_.
 
 6.2.11
 ======


### PR DESCRIPTION
… for all keys read to avoid unnecessary conflicts when read during a status update/cleanup transaction.  Since many of the keys read use wrapper functions, all of the underlying functions in BackupAgentBase and its two implementations also required a snapshot mode argument.  All snapshot arguments default to false to match the underlying FDB API get/getRange methods.

The vast majority of unnecessary conflicts are due to reading the frequently-changing log and range byte counts, but I decided to eliminate the other unnecessary read conflict keys as well since they unnecessarily bloat the size of a frequently repeated transaction.