### PR TITLE
Performant restore [12/XX add-on]: Rename StringRefReaderMX to BackupStringRefReader

### DIFF
--- a/fdbserver/RestoreLoader.actor.cpp
+++ b/fdbserver/RestoreLoader.actor.cpp
@@ -369,7 +369,7 @@ bool concatenateBackupMutationForLogFile(std::map<Standalone<StringRef>, Standal
 	std::stringstream ss;
 	const int key_prefix_len = sizeof(uint8_t) + sizeof(Version) + sizeof(uint32_t);
 
-	StringRefReaderMX readerKey(key_input, restore_corrupted_data()); // read key_input!
+	BackupStringRefReader readerKey(key_input, restore_corrupted_data()); // read key_input!
 	int logRangeMutationFirstLength = key_input.size() - key_prefix_len;
 	bool concatenated = false;
 
@@ -443,11 +443,11 @@ void _parseSerializedMutation(std::map<LoadingParam, VersionedMutationsMap>::ite
 		StringRef k = m.first.contents();
 		StringRef val = m.second.contents();
 
-		StringRefReaderMX kReader(k, restore_corrupted_data());
+		BackupStringRefReader kReader(k, restore_corrupted_data());
 		uint64_t commitVersion = kReader.consume<uint64_t>(); // Consume little Endian data
 		kvOps.insert(std::make_pair(commitVersion, MutationsVec()));
 
-		StringRefReaderMX vReader(val, restore_corrupted_data());
+		BackupStringRefReader vReader(val, restore_corrupted_data());
 		vReader.consume<uint64_t>(); // Consume the includeVersion
 		// TODO(xumengpanda): verify the protocol version is compatible and raise error if needed
 

--- a/fdbserver/RestoreRoleCommon.actor.h
+++ b/fdbserver/RestoreRoleCommon.actor.h
@@ -60,9 +60,9 @@ void handleFinishRestoreRequest(const RestoreVersionBatchRequest& req, Reference
 
 // Helper class for reading restore data from a buffer and throwing the right errors.
 // This struct is mostly copied from StringRefReader. We add a sanity check in this struct.
-// TODO: Merge this struct with StringRefReader.
-struct StringRefReaderMX {
-	StringRefReaderMX(StringRef s = StringRef(), Error e = Error())
+// We want to decouple code between fast restore and old restore. So we keep this duplicate struct
+struct BackupStringRefReader {
+	BackupStringRefReader(StringRef s = StringRef(), Error e = Error())
 	  : rptr(s.begin()), end(s.end()), failure_error(e), str_size(s.size()) {}
 
 	// Return remainder of data as a StringRef
@@ -75,7 +75,7 @@ struct StringRefReaderMX {
 		const uint8_t* p = rptr;
 		rptr += len;
 		if (rptr > end) {
-			printf("[ERROR] StringRefReaderMX throw error! string length:%d\n", str_size);
+			printf("[ERROR] BackupStringRefReader throw error! string length:%d\n", str_size);
 			printf("!!!!!!!!!!!![ERROR]!!!!!!!!!!!!!! Worker may die due to the error. Master will stuck when a worker "
 			       "die\n");
 			throw failure_error;


### PR DESCRIPTION
Remove the suffix `MX` from the structure name. 

No functional change.