### PR TITLE
Assert that a request hasn't already gotten a reply

### DIFF
--- a/fdbrpc/fdbrpc.h
+++ b/fdbrpc/fdbrpc.h
@@ -282,6 +282,7 @@ public:
 	//   If cancelled, request was or will be delivered zero or more times.
 	template <class X>
 	Future< REPLY_TYPE(X) > getReply(const X& value) const {
+		ASSERT(!getReplyPromise(value).getFuture().isReady());
 		if (queue->isRemoteEndpoint()) {
 			return sendCanceler(getReplyPromise(value), FlowTransport::transport().sendReliable(SerializeSource<T>(value), getEndpoint()), getEndpoint());
 		}


### PR DESCRIPTION
This catches a potential bug where a request object is unintentionally reused, and gives a much nicer diagnostic than say a timeout.

I ran 10 ctest suites on it.