### PR TITLE
Fix slow task profiler crash

### DIFF
--- a/documentation/sphinx/source/release-notes.rst
+++ b/documentation/sphinx/source/release-notes.rst
@@ -10,6 +10,7 @@ Fixes
 
 * Clients could throw an internal error during ``commit`` if client buggification was enabled. `(PR #2427) <https://github.com/apple/foundationdb/pull/2427>`_.
 * Backup and DR agent transactions which update and clean up status had an unnecessarily high conflict rate. `(PR #2483) <https://github.com/apple/foundationdb/pull/2483>`_.
+* The slow task profiler used an unsafe call to get a timestamp in its signal handler that could lead to rare crashes. `(PR #2515) <https://github.com/apple/foundationdb/pull/2515>`_.
 
 6.2.11
 ======

--- a/flow/Net2.actor.cpp
+++ b/flow/Net2.actor.cpp
@@ -54,6 +54,7 @@ using namespace boost::asio::ip;
 #include <execinfo.h>
 
 std::atomic<int64_t> net2liveness(0);
+std::atomic<double> checkThreadTime(0);
 
 volatile size_t net2backtraces_max = 10000;
 volatile void** volatile net2backtraces = NULL;

--- a/flow/Net2.actor.cpp
+++ b/flow/Net2.actor.cpp
@@ -54,7 +54,6 @@ using namespace boost::asio::ip;
 #include <execinfo.h>
 
 std::atomic<int64_t> net2liveness(0);
-std::atomic<double> checkThreadTime(0);
 
 volatile size_t net2backtraces_max = 10000;
 volatile void** volatile net2backtraces = NULL;

--- a/flow/Platform.cpp
+++ b/flow/Platform.cpp
@@ -133,12 +133,12 @@ std::string removeWhitespace(const std::string &t)
 	if (found != std::string::npos)
 		str.erase(found + 1);
 	else
-		str.clear();			// str is all whitespace
+		str.clear(); // str is all whitespace
 	found = str.find_first_not_of(ws);
 	if (found != std::string::npos)
 		str.erase(0, found);
 	else
-		str.clear();			// str is all whitespace
+		str.clear(); // str is all whitespace
 
 	return str;
 }

--- a/flow/Platform.cpp
+++ b/flow/Platform.cpp
@@ -2804,10 +2804,10 @@ extern volatile size_t net2backtraces_max;
 extern volatile bool net2backtraces_overflow;
 extern volatile int net2backtraces_count;
 extern std::atomic<int64_t> net2liveness;
-extern std::atomic<double> checkThreadTime;
 extern volatile thread_local int profilingEnabled;
 extern void initProfiling();
 
+std::atomic<double> checkThreadTime;
 volatile thread_local bool profileThread = false;
 #endif
 


### PR DESCRIPTION
The slow task profiler includes a call to `timer()` to get the time that the backtrace was captured. This seems to be unsafe if the signal is raised in the middle of a call to `time()`, among possibly other things.

This PR removes the call to `timer()` in the signal handler and instead relies on the check thread to capture a time and propagate it to the signal handler using an atomic variable. In the event that atomic variables on the platform are not lock-free, this mechanism will not be used and instead the logs will not report the time that the backtrace was taken.

Resolves #2364 (hopefully)