### PR TITLE
Performant restore [14/XX]: Ensure each version-batch not exceed a configured size

### DIFF
--- a/fdbclient/RestoreWorkerInterface.actor.h
+++ b/fdbclient/RestoreWorkerInterface.actor.h
@@ -246,16 +246,12 @@ struct RestoreAsset {
 	}
 };
 
-// TODO: It is probably better to specify the (beginVersion, endVersion] for each loadingParam.
-// beginVersion (endVersion) is the version the applier is before (after) it receives the request.
 struct LoadingParam {
 	constexpr static FileIdentifier file_identifier = 17023837;
 
 	bool isRangeFile;
 	Key url;
-	//Version prevVersion;
 	Version rangeVersion; // range file's version
-	// Version endVersion; // range file's mutations are all at the endVersion
 
 	int64_t blockSize;
 	RestoreAsset asset;
@@ -271,14 +267,11 @@ struct LoadingParam {
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		// serializer(ar, isRangeFile, url, prevVersion, endVersion, blockSize, asset);
 		serializer(ar, isRangeFile, url, rangeVersion, blockSize, asset);
 	}
 
 	std::string toString() {
 		std::stringstream str;
-		// str << "isRangeFile:" << isRangeFile << " url:" << url.toString() << " prevVersion:" << prevVersion
-		//     << " endVersion:" << endVersion << " blockSize:" << blockSize << " RestoreAsset:" << asset.toString();
 		str << "isRangeFile:" << isRangeFile << " url:" << url.toString()
 		    << " rangeVersion:" << rangeVersion << " blockSize:" << blockSize << " RestoreAsset:" << asset.toString();
 		return str.str();

--- a/fdbclient/RestoreWorkerInterface.actor.h
+++ b/fdbclient/RestoreWorkerInterface.actor.h
@@ -211,7 +211,7 @@ struct RestoreAsset {
 
 	UID uid;
 
-	RestoreAsset() { uid = deterministicRandom()->randomUniqueID(); }
+	RestoreAsset() = default;
 
 	bool operator==(const RestoreAsset& r) const {
 		return fileIndex == r.fileIndex && filename == r.filename && offset == r.offset && len == r.len &&
@@ -253,7 +253,7 @@ struct LoadingParam {
 
 	bool isRangeFile;
 	Key url;
-	Version prevVersion;
+	//Version prevVersion;
 	Version rangeVersion; // range file's version
 	// Version endVersion; // range file's mutations are all at the endVersion
 
@@ -272,14 +272,14 @@ struct LoadingParam {
 	template <class Ar>
 	void serialize(Ar& ar) {
 		// serializer(ar, isRangeFile, url, prevVersion, endVersion, blockSize, asset);
-		serializer(ar, isRangeFile, url, prevVersion, rangeVersion, blockSize, asset);
+		serializer(ar, isRangeFile, url, rangeVersion, blockSize, asset);
 	}
 
 	std::string toString() {
 		std::stringstream str;
 		// str << "isRangeFile:" << isRangeFile << " url:" << url.toString() << " prevVersion:" << prevVersion
 		//     << " endVersion:" << endVersion << " blockSize:" << blockSize << " RestoreAsset:" << asset.toString();
-		str << "isRangeFile:" << isRangeFile << " url:" << url.toString() << " prevVersion:" << prevVersion
+		str << "isRangeFile:" << isRangeFile << " url:" << url.toString()
 		    << " rangeVersion:" << rangeVersion << " blockSize:" << blockSize << " RestoreAsset:" << asset.toString();
 		return str.str();
 	}

--- a/fdbclient/RestoreWorkerInterface.actor.h
+++ b/fdbclient/RestoreWorkerInterface.actor.h
@@ -211,9 +211,7 @@ struct RestoreAsset {
 
 	UID uid;
 
-	RestoreAsset() {
-		uid = deterministicRandom()->randomUniqueID();
-	}
+	RestoreAsset() { uid = deterministicRandom()->randomUniqueID(); }
 
 	bool operator==(const RestoreAsset& r) const {
 		return fileIndex == r.fileIndex && filename == r.filename && offset == r.offset && len == r.len &&
@@ -236,8 +234,9 @@ struct RestoreAsset {
 
 	std::string toString() {
 		std::stringstream ss;
-		ss << "UID:" << uid.toString() << " begin:" << beginVersion << " end:" << endVersion << " range:" << range.toString()
-		   << " filename:" << filename << " fileIndex:" << fileIndex << " offset:" << offset << " len:" << len;
+		ss << "UID:" << uid.toString() << " begin:" << beginVersion << " end:" << endVersion
+		   << " range:" << range.toString() << " filename:" << filename << " fileIndex:" << fileIndex
+		   << " offset:" << offset << " len:" << len;
 		return ss.str();
 	}
 
@@ -256,7 +255,7 @@ struct LoadingParam {
 	Key url;
 	Version prevVersion;
 	Version rangeVersion; // range file's version
-	//Version endVersion; // range file's mutations are all at the endVersion
+	// Version endVersion; // range file's mutations are all at the endVersion
 
 	int64_t blockSize;
 	RestoreAsset asset;
@@ -272,7 +271,7 @@ struct LoadingParam {
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		//serializer(ar, isRangeFile, url, prevVersion, endVersion, blockSize, asset);
+		// serializer(ar, isRangeFile, url, prevVersion, endVersion, blockSize, asset);
 		serializer(ar, isRangeFile, url, prevVersion, rangeVersion, blockSize, asset);
 	}
 
@@ -281,7 +280,7 @@ struct LoadingParam {
 		// str << "isRangeFile:" << isRangeFile << " url:" << url.toString() << " prevVersion:" << prevVersion
 		//     << " endVersion:" << endVersion << " blockSize:" << blockSize << " RestoreAsset:" << asset.toString();
 		str << "isRangeFile:" << isRangeFile << " url:" << url.toString() << " prevVersion:" << prevVersion
-			<< " rangeVersion:" << rangeVersion << " blockSize:" << blockSize << " RestoreAsset:" << asset.toString();
+		    << " rangeVersion:" << rangeVersion << " blockSize:" << blockSize << " RestoreAsset:" << asset.toString();
 		return str.str();
 	}
 };

--- a/fdbclient/RestoreWorkerInterface.actor.h
+++ b/fdbclient/RestoreWorkerInterface.actor.h
@@ -236,7 +236,7 @@ struct RestoreAsset {
 
 	std::string toString() {
 		std::stringstream ss;
-		ss << "UID" << uid.toString() << "begin:" << beginVersion << " end:" << endVersion << " range:" << range.toString()
+		ss << "UID:" << uid.toString() << " begin:" << beginVersion << " end:" << endVersion << " range:" << range.toString()
 		   << " filename:" << filename << " fileIndex:" << fileIndex << " offset:" << offset << " len:" << len;
 		return ss.str();
 	}
@@ -255,7 +255,8 @@ struct LoadingParam {
 	bool isRangeFile;
 	Key url;
 	Version prevVersion;
-	Version endVersion; // range file's mutations are all at the endVersion
+	Version rangeVersion; // range file's version
+	//Version endVersion; // range file's mutations are all at the endVersion
 
 	int64_t blockSize;
 	RestoreAsset asset;
@@ -271,13 +272,16 @@ struct LoadingParam {
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, isRangeFile, url, prevVersion, endVersion, blockSize, asset);
+		//serializer(ar, isRangeFile, url, prevVersion, endVersion, blockSize, asset);
+		serializer(ar, isRangeFile, url, prevVersion, rangeVersion, blockSize, asset);
 	}
 
 	std::string toString() {
 		std::stringstream str;
+		// str << "isRangeFile:" << isRangeFile << " url:" << url.toString() << " prevVersion:" << prevVersion
+		//     << " endVersion:" << endVersion << " blockSize:" << blockSize << " RestoreAsset:" << asset.toString();
 		str << "isRangeFile:" << isRangeFile << " url:" << url.toString() << " prevVersion:" << prevVersion
-		    << " endVersion:" << endVersion << " blockSize:" << blockSize << " RestoreAsset:" << asset.toString();
+			<< " rangeVersion:" << rangeVersion << " blockSize:" << blockSize << " RestoreAsset:" << asset.toString();
 		return str.str();
 	}
 };

--- a/fdbclient/RestoreWorkerInterface.actor.h
+++ b/fdbclient/RestoreWorkerInterface.actor.h
@@ -251,7 +251,7 @@ struct LoadingParam {
 
 	bool isRangeFile;
 	Key url;
-	Version rangeVersion; // range file's version
+	Optional<Version> rangeVersion; // range file's version
 
 	int64_t blockSize;
 	RestoreAsset asset;
@@ -273,7 +273,8 @@ struct LoadingParam {
 	std::string toString() {
 		std::stringstream str;
 		str << "isRangeFile:" << isRangeFile << " url:" << url.toString()
-		    << " rangeVersion:" << rangeVersion << " blockSize:" << blockSize << " RestoreAsset:" << asset.toString();
+		    << " rangeVersion:" << (rangeVersion.present() ? rangeVersion.get() : -1) << " blockSize:" << blockSize
+		    << " RestoreAsset:" << asset.toString();
 		return str.str();
 	}
 };

--- a/fdbclient/RestoreWorkerInterface.actor.h
+++ b/fdbclient/RestoreWorkerInterface.actor.h
@@ -209,7 +209,11 @@ struct RestoreAsset {
 	int64_t offset;
 	int64_t len;
 
-	RestoreAsset() = default;
+	UID uid;
+
+	RestoreAsset() {
+		uid = deterministicRandom()->randomUniqueID();
+	}
 
 	bool operator==(const RestoreAsset& r) const {
 		return fileIndex == r.fileIndex && filename == r.filename && offset == r.offset && len == r.len &&
@@ -227,16 +231,17 @@ struct RestoreAsset {
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, beginVersion, endVersion, range, filename, fileIndex, offset, len);
+		serializer(ar, beginVersion, endVersion, range, filename, fileIndex, offset, len, uid);
 	}
 
 	std::string toString() {
 		std::stringstream ss;
-		ss << "begin:" << beginVersion << " end:" << endVersion << " range:" << range.toString()
+		ss << "UID" << uid.toString() << "begin:" << beginVersion << " end:" << endVersion << " range:" << range.toString()
 		   << " filename:" << filename << " fileIndex:" << fileIndex << " offset:" << offset << " len:" << len;
 		return ss.str();
 	}
 
+	// RestoreAsset and VersionBatch both use endVersion as exclusive in version range
 	bool isInVersionRange(Version commitVersion) const {
 		return commitVersion >= beginVersion && commitVersion < endVersion;
 	}

--- a/fdbserver/RestoreApplier.actor.cpp
+++ b/fdbserver/RestoreApplier.actor.cpp
@@ -112,7 +112,8 @@ ACTOR static Future<Void> handleSendMutationVectorRequest(RestoreSendVersionedMu
 		// Sanity check: mutations in range file is in [beginVersion, endVersion);
 		// mutations in log file is in [beginVersion, endVersion], both inclusive.
 		ASSERT_WE_THINK(commitVersion >= req.asset.beginVersion);
-		ASSERT_WE_THINK((req.isRangeFile && commitVersion < req.asset.endVersion) ||
+		// Loader sends the endVersion to ensure all useful versions are sent
+		ASSERT_WE_THINK((req.isRangeFile && commitVersion <= req.asset.endVersion) ||
 		                (!req.isRangeFile && commitVersion <= req.asset.endVersion));
 
 		if (self->kvOps.find(commitVersion) == self->kvOps.end()) {

--- a/fdbserver/RestoreLoader.actor.cpp
+++ b/fdbserver/RestoreLoader.actor.cpp
@@ -153,8 +153,8 @@ ACTOR Future<Void> _processLoadingParam(LoadingParam param, Reference<RestoreLoa
 		subAsset.offset = j;
 		subAsset.len = std::min<int64_t>(param.blockSize, param.asset.len - j);
 		if (param.isRangeFile) {
-			fileParserFutures.push_back(
-			    _parseRangeFileToMutationsOnLoader(kvOpsPerLPIter, samplesIter, self->bc, param.rangeVersion, subAsset));
+			fileParserFutures.push_back(_parseRangeFileToMutationsOnLoader(kvOpsPerLPIter, samplesIter, self->bc,
+			                                                               param.rangeVersion, subAsset));
 		} else {
 			// TODO: Sanity check the log file's range is overlapped with the restored version range
 			fileParserFutures.push_back(_parseLogFileToMutationsOnLoader(&processedFileOffset, &mutationMap,
@@ -246,7 +246,9 @@ ACTOR Future<Void> sendMutationsToApplier(Reference<RestoreLoaderData> self, Ver
 		}
 		Version commitVersion = kvOp->first;
 		if (!(commitVersion >= asset.beginVersion && commitVersion <= asset.endVersion)) { // Debug purpose
-			TraceEvent(SevError, "FastRestore_SendMutationsToApplier").detail("CommitVersion", commitVersion).detail("RestoreAsset", asset.toString());
+			TraceEvent(SevError, "FastRestore_SendMutationsToApplier")
+			    .detail("CommitVersion", commitVersion)
+			    .detail("RestoreAsset", asset.toString());
 		}
 		ASSERT(commitVersion >= asset.beginVersion);
 		ASSERT(commitVersion <= asset.endVersion); // endVersion is an empty commit to ensure progress

--- a/fdbserver/RestoreMaster.actor.cpp
+++ b/fdbserver/RestoreMaster.actor.cpp
@@ -288,9 +288,10 @@ ACTOR static Future<Void> loadFilesOnLoaders(Reference<RestoreMasterData> self, 
 		LoadingParam param;
 
 		param.prevVersion = 0; // Each file's NotifiedVersion starts from 0
-		param.endVersion = file.isRange ? file.version : file.endVersion;
+		//param.endVersion = file.isRange ? file.version : file.endVersion;
 		param.url = request.url;
 		param.isRangeFile = file.isRange;
+		param.rangeVersion = file.isRange ? file.version : -1;
 		param.blockSize = file.blockSize;
 
 		param.asset.filename = file.fileName;
@@ -301,14 +302,14 @@ ACTOR static Future<Void> loadFilesOnLoaders(Reference<RestoreMasterData> self, 
 		param.asset.beginVersion = versionBatch.beginVersion;
 		param.asset.endVersion = versionBatch.endVersion;
 
-		prevVersion = param.endVersion;
+		prevVersion = param.asset.endVersion;
 
 		// Log file to be loaded
 		TraceEvent("FastRestore").detail("LoadParam", param.toString()).detail("LoaderID", loader->first.toString());
 		ASSERT_WE_THINK(param.asset.len >= 0); // we may load an empty file
 		ASSERT_WE_THINK(param.asset.offset >= 0);
 		ASSERT_WE_THINK(param.asset.offset <= file.fileSize);
-		ASSERT_WE_THINK(param.prevVersion <= param.endVersion);
+		ASSERT_WE_THINK(param.prevVersion <= param.asset.endVersion);
 
 		requests.emplace_back(loader->first, RestoreLoadFileRequest(param));
 		loader++;

--- a/fdbserver/RestoreMaster.actor.cpp
+++ b/fdbserver/RestoreMaster.actor.cpp
@@ -273,9 +273,6 @@ ACTOR static Future<Void> loadFilesOnLoaders(Reference<RestoreMasterData> self, 
 	std::vector<std::pair<UID, RestoreLoadFileRequest>> requests;
 	std::map<UID, RestoreLoaderInterface>::iterator loader = self->loadersInterf.begin();
 
-	// TODO: Remove files that are empty before proceed
-	// ASSERT(files->size() > 0); // files should not be empty
-
 	Version prevVersion = 0;
 	for (auto& file : *files) {
 		// NOTE: Cannot skip empty files because empty files, e.g., log file, still need to generate dummy mutation to
@@ -285,9 +282,6 @@ ACTOR static Future<Void> loadFilesOnLoaders(Reference<RestoreMasterData> self, 
 		}
 		// Prepare loading
 		LoadingParam param;
-
-		//param.prevVersion = 0; // Each file's NotifiedVersion starts from 0
-		// param.endVersion = file.isRange ? file.version : file.endVersion;
 		param.url = request.url;
 		param.isRangeFile = file.isRange;
 		param.rangeVersion = file.isRange ? file.version : -1;
@@ -304,9 +298,8 @@ ACTOR static Future<Void> loadFilesOnLoaders(Reference<RestoreMasterData> self, 
 
 		prevVersion = param.asset.endVersion;
 
-		// Log file to be loaded
 		TraceEvent("FastRestore").detail("LoadParam", param.toString()).detail("LoaderID", loader->first.toString());
-		ASSERT_WE_THINK(param.asset.len >= 0); // we may load an empty file
+		ASSERT_WE_THINK(param.asset.len > 0); // TODO: ensure empty files are not included here
 		ASSERT_WE_THINK(param.asset.offset >= 0);
 		ASSERT_WE_THINK(param.asset.offset <= file.fileSize);
 		ASSERT_WE_THINK(param.asset.beginVersion <= param.asset.endVersion);

--- a/fdbserver/RestoreMaster.actor.cpp
+++ b/fdbserver/RestoreMaster.actor.cpp
@@ -37,8 +37,7 @@
 
 ACTOR static Future<Void> clearDB(Database cx);
 ACTOR static Future<Void> collectBackupFiles(Reference<IBackupContainer> bc, std::vector<RestoreFileFR>* rangeFiles,
-                                               std::vector<RestoreFileFR>* logFiles, Database cx,
-                                               RestoreRequest request);
+                                             std::vector<RestoreFileFR>* logFiles, Database cx, RestoreRequest request);
 
 ACTOR static Future<Version> processRestoreRequest(Reference<RestoreMasterData> self, Database cx, RestoreRequest request);
 ACTOR static Future<Void> startProcessRestoreRequests(Reference<RestoreMasterData> self, Database cx);
@@ -288,7 +287,7 @@ ACTOR static Future<Void> loadFilesOnLoaders(Reference<RestoreMasterData> self, 
 		LoadingParam param;
 
 		param.prevVersion = 0; // Each file's NotifiedVersion starts from 0
-		//param.endVersion = file.isRange ? file.version : file.endVersion;
+		// param.endVersion = file.isRange ? file.version : file.endVersion;
 		param.url = request.url;
 		param.isRangeFile = file.isRange;
 		param.rangeVersion = file.isRange ? file.version : -1;
@@ -453,8 +452,8 @@ ACTOR static Future<Standalone<VectorRef<RestoreRequest>>> collectRestoreRequest
 
 // Collect the backup files' description into output_files by reading the backupContainer bc.
 ACTOR static Future<Void> collectBackupFiles(Reference<IBackupContainer> bc, std::vector<RestoreFileFR>* rangeFiles,
-                                               std::vector<RestoreFileFR>* logFiles, Database cx,
-                                               RestoreRequest request) {
+                                             std::vector<RestoreFileFR>* logFiles, Database cx,
+                                             RestoreRequest request) {
 	state BackupDescription desc = wait(bc->describeBackup());
 
 	// Convert version to real time for operators to read the BackupDescription desc.

--- a/fdbserver/RestoreMaster.actor.cpp
+++ b/fdbserver/RestoreMaster.actor.cpp
@@ -286,13 +286,14 @@ ACTOR static Future<Void> loadFilesOnLoaders(Reference<RestoreMasterData> self, 
 		// Prepare loading
 		LoadingParam param;
 
-		param.prevVersion = 0; // Each file's NotifiedVersion starts from 0
+		//param.prevVersion = 0; // Each file's NotifiedVersion starts from 0
 		// param.endVersion = file.isRange ? file.version : file.endVersion;
 		param.url = request.url;
 		param.isRangeFile = file.isRange;
 		param.rangeVersion = file.isRange ? file.version : -1;
 		param.blockSize = file.blockSize;
 
+		param.asset.uid = deterministicRandom()->randomUniqueID();
 		param.asset.filename = file.fileName;
 		param.asset.fileIndex = file.fileIndex;
 		param.asset.offset = 0;
@@ -308,7 +309,7 @@ ACTOR static Future<Void> loadFilesOnLoaders(Reference<RestoreMasterData> self, 
 		ASSERT_WE_THINK(param.asset.len >= 0); // we may load an empty file
 		ASSERT_WE_THINK(param.asset.offset >= 0);
 		ASSERT_WE_THINK(param.asset.offset <= file.fileSize);
-		ASSERT_WE_THINK(param.prevVersion <= param.asset.endVersion);
+		ASSERT_WE_THINK(param.asset.beginVersion <= param.asset.endVersion);
 
 		requests.emplace_back(loader->first, RestoreLoadFileRequest(param));
 		loader++;

--- a/fdbserver/RestoreMaster.actor.cpp
+++ b/fdbserver/RestoreMaster.actor.cpp
@@ -299,7 +299,7 @@ ACTOR static Future<Void> loadFilesOnLoaders(Reference<RestoreMasterData> self, 
 		prevVersion = param.asset.endVersion;
 
 		TraceEvent("FastRestore").detail("LoadParam", param.toString()).detail("LoaderID", loader->first.toString());
-		ASSERT_WE_THINK(param.asset.len > 0); // TODO: ensure empty files are not included here
+		ASSERT_WE_THINK(param.asset.len > 0);
 		ASSERT_WE_THINK(param.asset.offset >= 0);
 		ASSERT_WE_THINK(param.asset.offset <= file.fileSize);
 		ASSERT_WE_THINK(param.asset.beginVersion <= param.asset.endVersion);
@@ -465,14 +465,8 @@ ACTOR static Future<Void> collectBackupFiles(Reference<IBackupContainer> bc, std
 		throw restore_missing_data();
 	}
 
-	if (!rangeFiles->empty()) {
-		TraceEvent(SevError, "FastRestore").detail("ClearOldRangeFiles", rangeFiles->size());
-		rangeFiles->clear();
-	}
-	if (!logFiles->empty()) {
-		TraceEvent(SevError, "FastRestore").detail("ClearOldRangeFiles", logFiles->size());
-		logFiles->clear();
-	}
+	ASSERT(rangeFiles->empty());
+	ASSERT(logFiles->empty());
 
 	for (const RangeFile& f : restorable.get().ranges) {
 		TraceEvent("FastRestore").detail("RangeFile", f.toString());

--- a/fdbserver/RestoreMaster.actor.h
+++ b/fdbserver/RestoreMaster.actor.h
@@ -127,7 +127,7 @@ struct RestoreMasterData : RestoreRoleData, public ReferenceCounted<RestoreMaste
 
 	// Input: Get the size of data in backup files in version range [prevVersion, nextVersion)
 	// Return: param1: the size of data at nextVersion, param2: the minimum range file index whose version >
-	// nextVersion, param3: log files with data in [prevVersion, nextVersion]
+	// nextVersion, param3: log files with data in [prevVersion, nextVersion)
 	std::tuple<double, int, std::vector<RestoreFileFR>> getVersionSize(Version prevVersion, Version nextVersion,
 	                                                                   const std::vector<RestoreFileFR>& rangeFiles,
 	                                                                   int rangeIdx,
@@ -170,9 +170,9 @@ struct RestoreMasterData : RestoreRoleData, public ReferenceCounted<RestoreMaste
 	// Split backup files into version batches, each of which has similar data size
 	// Input: sorted range files, sorted log files;
 	// Output: a set of version batches whose size is less than opConfig.batchSizeThreshold
-	//    and each mutation data in backup files is included in the version batches exactly once
-	// Assumption 1: input files has no empty files
-	// Assumption 2: range files at one version > batchSizeThreshold
+	//    	   and each mutation data in backup files is included in the version batches exactly once.
+	// Assumption 1: input files has no empty files;
+	// Assumption 2: range files at one version > batchSizeThreshold.
 	void buildVersionBatches(const std::vector<RestoreFileFR>& rangeFiles, const std::vector<RestoreFileFR>& logFiles,
 	                         std::map<Version, VersionBatch>* versionBatches) {
 		// Version batch range [beginVersion, endVersion)
@@ -204,9 +204,9 @@ struct RestoreMasterData : RestoreRoleData, public ReferenceCounted<RestoreMaste
 					}
 				} else {
 					TraceEvent(SevError, "FastRestoreBuildVersionBatch")
-					    .detail("RangeIdx", rangeIdx)
+					    .detail("RangeIndex", rangeIdx)
 					    .detail("RangeFiles", rangeFiles.size())
-					    .detail("LogIdx", logIdx)
+					    .detail("LogIndex", logIdx)
 					    .detail("LogFiles", logFiles.size());
 				}
 			} else {
@@ -257,8 +257,7 @@ struct RestoreMasterData : RestoreRoleData, public ReferenceCounted<RestoreMaste
 				if (batchSize < 1) {
 					// [vb.endVersion, nextVersion) > opConfig.batchSizeThreshold. We should split the version range
 					if (prevEndVersion >= nextVersion) {
-						// If range files at one version > batchSizeThreshold, DBA should increase the
-						// batchSizeThreshold
+						// If range files at one version > batchSizeThreshold, DBA should increase batchSizeThreshold
 						TraceEvent(SevError, "FastRestoreBuildVersionBatch")
 						    .detail("NextVersion", nextVersion)
 						    .detail("PrevEndVersion", prevEndVersion)
@@ -273,7 +272,6 @@ struct RestoreMasterData : RestoreRoleData, public ReferenceCounted<RestoreMaste
 					continue;
 				}
 				// Finalize the current version batch
-				// vb.endVersion = nextVersion;
 				vb.size = batchSize;
 				versionBatches->emplace(vb.beginVersion, vb); // copy vb to versionBatch
 				// start finding the next version batch

--- a/fdbserver/RestoreMaster.actor.h
+++ b/fdbserver/RestoreMaster.actor.h
@@ -58,9 +58,7 @@ struct VersionBatch {
 	}
 
 	// RestoreAsset and VersionBatch both use endVersion as exclusive in version range
-	bool isInVersionRange(Version version) const {
-		return version >= beginVersion && version < endVersion;
-	}
+	bool isInVersionRange(Version version) const { return version >= beginVersion && version < endVersion; }
 };
 
 struct RestoreMasterData : RestoreRoleData, public ReferenceCounted<RestoreMasterData> {
@@ -106,17 +104,22 @@ struct RestoreMasterData : RestoreRoleData, public ReferenceCounted<RestoreMaste
 		int i = 0;
 		for (auto& vb : versionBatches) {
 			TraceEvent("FastRestoreVersionBatches")
-				.detail("BatchIndex", i)
+			    .detail("BatchIndex", i)
 			    .detail("BeginVersion", vb.second.beginVersion)
 			    .detail("EndVersion", vb.second.endVersion)
 			    .detail("Size", vb.second.size);
 			for (auto& f : vb.second.rangeFiles) {
-				bool invalidVersion = (f.beginVersion != f.endVersion) || (f.beginVersion >= vb.second.endVersion || f.beginVersion < vb.second.beginVersion);
-				TraceEvent(invalidVersion ? SevError : SevInfo, "FastRestoreVersionBatches").detail("BatchIndex", i).detail("RangeFile", f.toString());
+				bool invalidVersion = (f.beginVersion != f.endVersion) || (f.beginVersion >= vb.second.endVersion ||
+				                                                           f.beginVersion < vb.second.beginVersion);
+				TraceEvent(invalidVersion ? SevError : SevInfo, "FastRestoreVersionBatches")
+				    .detail("BatchIndex", i)
+				    .detail("RangeFile", f.toString());
 			}
 			for (auto& f : vb.second.logFiles) {
 				bool outOfRange = (f.beginVersion >= vb.second.endVersion || f.endVersion <= vb.second.beginVersion);
-				TraceEvent(outOfRange ? SevError : SevInfo, "FastRestoreVersionBatches").detail("BatchIndex", i).detail("LogFile", f.toString());
+				TraceEvent(outOfRange ? SevError : SevInfo, "FastRestoreVersionBatches")
+				    .detail("BatchIndex", i)
+				    .detail("LogFile", f.toString());
 			}
 			++i;
 		}
@@ -171,7 +174,7 @@ struct RestoreMasterData : RestoreRoleData, public ReferenceCounted<RestoreMaste
 	// Assumption 1: input files has no empty files
 	// Assumption 2: range files at one version > batchSizeThreshold
 	void buildVersionBatches(const std::vector<RestoreFileFR>& rangeFiles, const std::vector<RestoreFileFR>& logFiles,
-	                           std::map<Version, VersionBatch>* versionBatches) {
+	                         std::map<Version, VersionBatch>* versionBatches) {
 		// Version batch range [beginVersion, endVersion)
 		Version beginVersion = 0;
 		Version endVersion = 0;
@@ -217,8 +220,8 @@ struct RestoreMasterData : RestoreRoleData, public ReferenceCounted<RestoreMaste
 			    getVersionSize(prevEndVersion, nextVersion, rangeFiles, rangeIdx, logFiles);
 
 			TraceEvent("FastRestoreBuildVersionBatch")
-				.detail("VersionBatchBeginVersion", vb.beginVersion)
-				.detail("PrevEndVersion", prevEndVersion)
+			    .detail("VersionBatchBeginVersion", vb.beginVersion)
+			    .detail("PrevEndVersion", prevEndVersion)
 			    .detail("NextVersion", nextVersion)
 			    .detail("RangeIndex", rangeIdx)
 			    .detail("RangeFiles", rangeFiles.size())
@@ -228,7 +231,7 @@ struct RestoreMasterData : RestoreRoleData, public ReferenceCounted<RestoreMaste
 			    .detail("BatchSize", batchSize)
 			    .detail("NextVersionSize", nextVersionSize)
 			    .detail("NextRangeIndex", nextRangeIdx)
-				.detail("UsedLogFiles", curLogFiles.size());
+			    .detail("UsedLogFiles", curLogFiles.size());
 
 			if (batchSize + nextVersionSize <= opConfig.batchSizeThreshold) {
 				// nextVersion should be included in this batch
@@ -270,7 +273,7 @@ struct RestoreMasterData : RestoreRoleData, public ReferenceCounted<RestoreMaste
 					continue;
 				}
 				// Finalize the current version batch
-				//vb.endVersion = nextVersion;
+				// vb.endVersion = nextVersion;
 				vb.size = batchSize;
 				versionBatches->emplace(vb.beginVersion, vb); // copy vb to versionBatch
 				// start finding the next version batch

--- a/fdbserver/RestoreMaster.actor.h
+++ b/fdbserver/RestoreMaster.actor.h
@@ -177,7 +177,7 @@ struct RestoreMasterData : RestoreRoleData, public ReferenceCounted<RestoreMaste
 	//    	   and each mutation in backup files is included in the version batches exactly once.
 	// Assumption 1: input files has no empty files;
 	// Assumption 2: range files at one version <= batchSizeThreshold.
-	// Note: We do not allow a versoinBatch size larger than the batchSizeThreshold because the range file size at
+	// Note: We do not allow a versionBatch size larger than the batchSizeThreshold because the range file size at
 	// a version depends on the number of backupAgents and its upper bound is hard to get.
 	void buildVersionBatches(const std::vector<RestoreFileFR>& rangeFiles, const std::vector<RestoreFileFR>& logFiles,
 	                         std::map<Version, VersionBatch>* versionBatches) {

--- a/fdbserver/RestoreMaster.actor.h
+++ b/fdbserver/RestoreMaster.actor.h
@@ -175,16 +175,13 @@ struct RestoreMasterData : RestoreRoleData, public ReferenceCounted<RestoreMaste
 	// Assumption 2: range files at one version > batchSizeThreshold.
 	void buildVersionBatches(const std::vector<RestoreFileFR>& rangeFiles, const std::vector<RestoreFileFR>& logFiles,
 	                         std::map<Version, VersionBatch>* versionBatches) {
-		// Version batch range [beginVersion, endVersion)
-		Version beginVersion = 0;
-		Version endVersion = 0;
 		Version prevEndVersion = 0;
 		double batchSize = 0; // TODO: Can be deleted
 		int rangeIdx = 0;
 		int logIdx = 0;
 		Version nextVersion = 0; // Used to calculate the batch's endVersion
 		VersionBatch vb;
-		vb.beginVersion = beginVersion;
+		vb.beginVersion = 0; // Version batch range [beginVersion, endVersion)
 		bool rewriteNextVersion = false;
 		while (rangeIdx < rangeFiles.size() || logIdx < logFiles.size()) {
 			if (!rewriteNextVersion) {

--- a/fdbserver/RestoreUtil.h
+++ b/fdbserver/RestoreUtil.h
@@ -56,7 +56,7 @@ struct FastRestoreOpConfig {
 	// transactionBatchSizeThreshold is used when applier applies multiple mutations in a transaction to DB
 	double transactionBatchSizeThreshold = 512; // 512 in Bytes
 	// batchSizeThreshold is the maximum data size in each version batch
-	double batchSizeThreshold = 10.0 * 1024.0 * 1024.0 * 1024.0; // 1 GB
+	double batchSizeThreshold = 10.0 * 1024.0 * 1024.0 * 1024.0; // 10 GB
 };
 extern FastRestoreOpConfig opConfig;
 

--- a/fdbserver/RestoreUtil.h
+++ b/fdbserver/RestoreUtil.h
@@ -56,7 +56,7 @@ struct FastRestoreOpConfig {
 	// transactionBatchSizeThreshold is used when applier applies multiple mutations in a transaction to DB
 	double transactionBatchSizeThreshold = 512; // 512 in Bytes
 	// batchSizeThreshold is the maximum data size in each version batch
-	double batchSizeThreshold = 1 * 1024 * 1024 * 1024; // 1 GB
+	double batchSizeThreshold = 10.0 * 1024.0 * 1024.0 * 1024.0; // 1 GB
 };
 extern FastRestoreOpConfig opConfig;
 

--- a/fdbserver/RestoreUtil.h
+++ b/fdbserver/RestoreUtil.h
@@ -55,6 +55,8 @@ struct FastRestoreOpConfig {
 	int num_appliers = 40;
 	// transactionBatchSizeThreshold is used when applier applies multiple mutations in a transaction to DB
 	double transactionBatchSizeThreshold = 512; // 512 in Bytes
+	// batchSizeThreshold is the maximum data size in each version batch
+	double batchSizeThreshold = 1 * 1024 * 1024 * 1024; // 1 GB
 };
 extern FastRestoreOpConfig opConfig;
 

--- a/fdbserver/RestoreWorker.actor.cpp
+++ b/fdbserver/RestoreWorker.actor.cpp
@@ -185,8 +185,10 @@ ACTOR Future<Void> monitorWorkerLiveness(Reference<RestoreWorkerData> self) {
 void initRestoreWorkerConfig() {
 	opConfig.num_loaders = g_network->isSimulated() ? 3 : opConfig.num_loaders;
 	opConfig.num_appliers = g_network->isSimulated() ? 3 : opConfig.num_appliers;
+	// TODO: Set the threshold to a random value in a range
 	opConfig.transactionBatchSizeThreshold =
 	    g_network->isSimulated() ? 512 : opConfig.transactionBatchSizeThreshold; // Byte
+	opConfig.batchSizeThreshold = g_network->isSimulated() ? 10 * 1024 * 1024 : opConfig.batchSizeThreshold; // Byte
 	TraceEvent("FastRestore")
 	    .detail("InitOpConfig", "Result")
 	    .detail("NumLoaders", opConfig.num_loaders)


### PR DESCRIPTION
A version batch is a set of backup files to be parsed and applied to the destination cluster. The new restore split backup files into multiple version batches and process each one by one.

The earlier version of implementation split backup files (based on the version range in log filename) into version batches such that a file is only processed exactly once for all of its data at various versions.  The size of version batch is not controlled.

When a version batch size is larger than the memory size of the restore systems' cluster, the cluster will experience out of memory (OOM) error. To prevent this, this PR limits the size of each version batch to be no larger than the preconfigured value. 

The challenge to achieve that is that each file will need to be processed multiple times, but the data in each file should be processed exactly once. This is done by using `RestoreAsset`, introduced in the previous PR, to identify which version range in a file should be processed. 