### PR TITLE
Debug Strip Failure Exploration

### DIFF
--- a/bindings/flow/CMakeLists.txt
+++ b/bindings/flow/CMakeLists.txt
@@ -16,7 +16,7 @@ set(SRCS
   fdb_flow.actor.cpp
   fdb_flow.h)
 
-add_flow_target(NAME fdb_flow SRCS ${SRCS} STATIC_LIBRARY)
+add_flow_target(STATIC_LIBRARY NAME fdb_flow SRCS ${SRCS})
 target_link_libraries(fdb_flow PUBLIC fdb_c)
 
 add_subdirectory(tester)

--- a/bindings/flow/tester/CMakeLists.txt
+++ b/bindings/flow/tester/CMakeLists.txt
@@ -2,5 +2,5 @@ set(TEST_SRCS
   DirectoryTester.actor.cpp
   Tester.actor.cpp
   Tester.actor.h)
-add_flow_target(NAME fdb_flow_tester EXECUTABLE SRCS ${TEST_SRCS})
+add_flow_target(EXECUTABLE NAME fdb_flow_tester SRCS ${TEST_SRCS})
 target_link_libraries(fdb_flow_tester fdb_flow)


### PR DESCRIPTION
Moved the STATIC_LIBRARY and EXECUTABLE keyword to the beginning of t…he function argument list