### PR TITLE
Fixed Object Stripping Command

### DIFF
--- a/cmake/FlowCommands.cmake
+++ b/cmake/FlowCommands.cmake
@@ -134,8 +134,8 @@ function(strip_debug_symbols target)
   set(out_files "${out_file}")
   if(is_exec AND NOT APPLE)
   add_custom_command(OUTPUT "${out_file}.debug"
-    COMMAND objcopy --verbose --only-keep-debug $<TARGET_FILE:${target}> "${out_file}.debug" &> "${out_file}.objcopy1"
-    COMMAND objcopy --verbose --add-gnu-debuglink="${out_file}.debug" "${out_file}" &> "${out_file}.objcopy2"
+    COMMAND objcopy --verbose --only-keep-debug $<TARGET_FILE:${target}> "${out_file}.debug"
+    COMMAND objcopy --verbose --add-gnu-debuglink="${out_file}.debug" "${out_file}"
     COMMENT "Copy debug symbols to ${out_name}.debug")
     list(APPEND out_files "${out_file}.debug")
   endif()

--- a/cmake/FlowCommands.cmake
+++ b/cmake/FlowCommands.cmake
@@ -133,11 +133,9 @@ function(strip_debug_symbols target)
     COMMENT "Stripping symbols from ${target}")
   set(out_files "${out_file}")
   if(is_exec AND NOT APPLE)
-    add_custom_command(OUTPUT "${out_file}.debug"
-      COMMAND objcopy --only-keep-debug $<TARGET_FILE:${target}> "${out_file}.debug" &&
-      objcopy --add-gnu-debuglink="${out_file}.debug" ${out_file}
-      DEPENDS "${out_file}"
-      COMMENT "Copy debug symbols to ${out_name}.debug")
+  add_custom_command(OUTPUT "${out_file}.debug"
+    COMMAND objcopy --verbose --only-keep-debug $<TARGET_FILE:${target}> "${out_file}.debug" &> "${out_file}.objcopy1" && if [ -f "${out_file}" ]; then objcopy --verbose --add-gnu-debuglink="${out_file}.debug" "${out_file}" &> "${out_file}.objcopy2"; fi
+    COMMENT "Copy debug symbols to ${out_name}.debug")
     list(APPEND out_files "${out_file}.debug")
   endif()
   add_custom_target(strip_${target} DEPENDS ${out_files})

--- a/cmake/FlowCommands.cmake
+++ b/cmake/FlowCommands.cmake
@@ -134,7 +134,8 @@ function(strip_debug_symbols target)
   set(out_files "${out_file}")
   if(is_exec AND NOT APPLE)
   add_custom_command(OUTPUT "${out_file}.debug"
-    COMMAND objcopy --verbose --only-keep-debug $<TARGET_FILE:${target}> "${out_file}.debug" &> "${out_file}.objcopy1" && if [ -f "${out_file}" ]; then objcopy --verbose --add-gnu-debuglink="${out_file}.debug" "${out_file}" &> "${out_file}.objcopy2"; fi
+    COMMAND objcopy --verbose --only-keep-debug $<TARGET_FILE:${target}> "${out_file}.debug" &> "${out_file}.objcopy1"
+    COMMAND objcopy --verbose --add-gnu-debuglink="${out_file}.debug" "${out_file}" &> "${out_file}.objcopy2"
     COMMENT "Copy debug symbols to ${out_name}.debug")
     list(APPEND out_files "${out_file}.debug")
   endif()


### PR DESCRIPTION
Moved object stripping command to multiple commands in order to prevent strange error of file non-existence from occurring