### PR TITLE
fix: tlogs must send a recruitment reply even when actor cancelled 

### DIFF
--- a/fdbserver/OldTLogServer_6_0.actor.cpp
+++ b/fdbserver/OldTLogServer_6_0.actor.cpp
@@ -2292,9 +2292,7 @@ ACTOR Future<Void> tLogStart( TLogData* self, InitializeTLogRequest req, Localit
 		}
 		wait(logData->committingQueue.getFuture() || logData->removed );
 	} catch( Error &e ) {
-		if(e.code() != error_code_actor_cancelled) {
-			req.reply.sendError(e);
-		}
+		req.reply.sendError(recruitment_failed());
 
 		if( e.code() != error_code_worker_removed ) {
 			throw;

--- a/fdbserver/TLogServer.actor.cpp
+++ b/fdbserver/TLogServer.actor.cpp
@@ -2723,9 +2723,7 @@ ACTOR Future<Void> tLogStart( TLogData* self, InitializeTLogRequest req, Localit
 		}
 		wait(logData->committingQueue.getFuture() || logData->removed );
 	} catch( Error &e ) {
-		if(e.code() != error_code_actor_cancelled) {
-			req.reply.sendError(e);
-		}
+		req.reply.sendError(recruitment_failed());
 
 		if( e.code() != error_code_worker_removed ) {
 			throw;


### PR DESCRIPTION
...or the recruitment endpoint will be marked as permanently failed.

This fixes a very rare simulation problem where a worker can be healthy, but its InitializeTLogRequest endpoint can be marked as failed, so the master repeatedly tries and fails to recruit the same process.