### PR TITLE
Add retry loop to Java binding tester instruction reader

### DIFF
--- a/bindings/java/src/test/com/apple/foundationdb/test/AsyncStackTester.java
+++ b/bindings/java/src/test/com/apple/foundationdb/test/AsyncStackTester.java
@@ -667,10 +667,7 @@ public class AsyncStackTester {
 			};
 
 			if(operations == null || ++currentOp == operations.size()) {
-				Transaction tr = db.createTransaction();
-
-				return tr.getRange(nextKey, endKey, 1000).asList()
-				.whenComplete((x, t) -> tr.close())
+				return db.readAsync(readTr -> readTr.getRange(nextKey, endKey, 1000).asList())
 				.thenComposeAsync(next -> {
 					if(next.size() < 1) {
 						//System.out.println("No key found after: " + ByteArrayUtil.printable(nextKey.getKey()));

--- a/bindings/java/src/test/com/apple/foundationdb/test/StackTester.java
+++ b/bindings/java/src/test/com/apple/foundationdb/test/StackTester.java
@@ -547,18 +547,15 @@ public class StackTester {
 
 		@Override
 		void executeOperations() {
-			KeySelector begin = nextKey;
 			while(true) {
-				Transaction t = db.createTransaction();
-				List<KeyValue> keyValues = t.getRange(begin, endKey/*, 1000*/).asList().join();
-				t.close();
+				List<KeyValue> keyValues = db.read(readTr -> readTr.getRange(nextKey, endKey/*, 1000*/).asList().join());
 				if(keyValues.size() == 0) {
 					break;
 				}
 				//System.out.println(" * Got " + keyValues.size() + " instructions");
 
 				for(KeyValue next : keyValues) {
-					begin = KeySelector.firstGreaterThan(next.getKey());
+					nextKey = KeySelector.firstGreaterThan(next.getKey());
 					processOp(next.getValue());
 					instructionIndex++;
 				}


### PR DESCRIPTION
We weren't using a retry loop, so in the rare cases where we got errors in this transaction the test would fail.