### PR TITLE
Use python3 in docpreview make target

### DIFF
--- a/documentation/Makefile
+++ b/documentation/Makefile
@@ -7,7 +7,7 @@ docprereqs:
 	ln -s . sphinx/.out/html/documentation
 
 docpreview: docprereqs
-	@( cd sphinx/.out/html && ! grep FIXME * && python -m SimpleHTTPServer $$((0x$$(echo ${USER} | $(MD5SUM) | awk '{print $$1}' | cut -c1-8)%8000+8000)) )
+	@( cd sphinx/.out/html && ! grep FIXME * && python3 -m http.server $$((0x$$(echo ${USER} | $(MD5SUM) | awk '{print $$1}' | cut -c1-8)%8000+8000)) )
 
 docpreview_clean:
 	$(MAKE) -C sphinx clean


### PR DESCRIPTION
The SimpleHTTPServer module is called http.server in python3, so if we don't explicitly choose a version it won't work if our python alias isn't the expected version.

A recent change to the docker image seems to have made python3 the default, so this fix is needed to work with it.