### PR TITLE
Fix build with glibc 2.30

### DIFF
--- a/flow/Profiler.actor.cpp
+++ b/flow/Profiler.actor.cpp
@@ -36,7 +36,7 @@
 
 extern volatile thread_local int profilingEnabled;
 
-static uint64_t gettid() { return syscall(__NR_gettid); }
+static uint64_t sys_gettid() { return syscall(__NR_gettid); }
 
 struct SignalClosure {
 	void (* func)(int, siginfo_t*, void*, void*);
@@ -230,7 +230,7 @@ struct Profiler {
 		sev.sigev_notify = SIGEV_THREAD_ID;
 		sev.sigev_signo = SIGPROF;
 		sev.sigev_value.sival_ptr = &(self->signalClosure);
-		sev._sigev_un._tid = gettid();
+		sev._sigev_un._tid = sys_gettid();
 		if(timer_create( CLOCK_THREAD_CPUTIME_ID, &sev, &self->periodicTimer ) != 0) {
 			TraceEvent(SevWarn, "FailedToCreateProfilingTimer").GetLastError();
 			return Void();
@@ -284,7 +284,7 @@ void startProfiling(INetwork* network, Optional<int> maybePeriod /*= {}*/, Optio
 		const char* outfn = getenv("FLOW_PROFILER_OUTPUT");
 		outputFile = (outfn ? outfn : "profile.bin");
 	}
-	outputFile = findAndReplace(findAndReplace(findAndReplace(outputFile, "%ADDRESS%", findAndReplace(network->getLocalAddress().toString(), ":", ".")), "%PID%", format("%d", getpid())), "%TID%", format("%llx", (long long)gettid()));
+	outputFile = findAndReplace(findAndReplace(findAndReplace(outputFile, "%ADDRESS%", findAndReplace(network->getLocalAddress().toString(), ":", ".")), "%PID%", format("%d", getpid())), "%TID%", format("%llx", (long long)sys_gettid()));
 
 	if (!Profiler::active_profiler)
 		Profiler::active_profiler = new Profiler( period, outputFile, network );


### PR DESCRIPTION
The `gettid()` function is part of glibc 2.30[1]. I decided to keep the
`gettid` implementation here under a different name to remain compatible
to older glibc versions.

[1] https://sourceware.org/ml/libc-alpha/2019-08/msg00029.html