### PR TITLE
Performant restore [14/XX Add-on]: Fix initialized field in VersionBatch struct

### DIFF
--- a/fdbclient/StorageServerInterface.h
+++ b/fdbclient/StorageServerInterface.h
@@ -267,7 +267,7 @@ struct GetShardStateRequest {
 		FETCHING = 1,
 		READABLE = 2
 	};
-	
+
 	KeyRange keys;
 	int32_t mode;
 	ReplyPromise<GetShardStateReply> reply;

--- a/fdbserver/RestoreMaster.actor.h
+++ b/fdbserver/RestoreMaster.actor.h
@@ -50,7 +50,7 @@ struct VersionBatch {
 	std::vector<RestoreFileFR> rangeFiles;
 	double size; // size of data in range and log files
 
-	VersionBatch() = default;
+	VersionBatch() : beginVersion(0), endVersion(0), size(0){};
 
 	bool isEmpty() { return logFiles.empty() && rangeFiles.empty(); }
 	void reset() {
@@ -240,7 +240,7 @@ struct RestoreMasterData : RestoreRoleData, public ReferenceCounted<RestoreMaste
 			if (vb.size + nextVersionSize <= opConfig.batchSizeThreshold) {
 				// nextVersion should be included in this batch
 				vb.size += nextVersionSize;
-				while (rangeIdx < nextRangeIdx) {
+				while (rangeIdx < nextRangeIdx && rangeIdx < rangeFiles.size()) {
 					ASSERT(rangeFiles[rangeIdx].fileSize > 0);
 					vb.rangeFiles.push_back(rangeFiles[rangeIdx]);
 					++rangeIdx;


### PR DESCRIPTION
Built-in variable may not be zero initialized by compiler provided default constructor, which fails valgrind tests.

This add-on PR fixes the error.