### PR TITLE
Force setuptools to be upgraded during sphinx build

### DIFF
--- a/documentation/sphinx/requirements.txt
+++ b/documentation/sphinx/requirements.txt
@@ -1,4 +1,5 @@
 --index-url https://pypi.python.org/simple
+setuptools>=45.0.0
 sphinx==1.5.6
 sphinx-bootstrap-theme==0.4.8
 pygments-style-solarized


### PR DESCRIPTION
So that setuptools understands PEP 508, which is now required for a
transitive watchdog dependency.