### PR TITLE
Improvements to sample python docker app

### DIFF
--- a/packaging/docker/samples/python/README.md
+++ b/packaging/docker/samples/python/README.md
@@ -44,3 +44,7 @@ FDB_CLUSTER_FILE=./docker.cluster fdbcli
 ```
 docker-compose down
 ```
+
+## Use outside of docker-compose
+
+The client application is also available as a standalone image: `foundationdb/foundationdb-sample-python-app:latest`.

--- a/packaging/docker/samples/python/app/Dockerfile
+++ b/packaging/docker/samples/python/app/Dockerfile
@@ -31,6 +31,15 @@ COPY --from=fdb /usr/lib/libfdb_c.so /usr/lib
 COPY --from=fdb /usr/bin/fdbcli /usr/bin/
 COPY --from=fdb /var/fdb/scripts/create_cluster_file.bash /app
 
+ARG FDB_WEBSITE=https://foundationdb.org
+ARG FDB_OLDER_VERSIONS=""
+ENV FDB_NETWORK_OPTION_EXTERNAL_CLIENT_DIRECTORY=/usr/lib/fdb-multiversion
+RUN \
+	mkdir /usr/lib/fdb-multiversion; \
+	for version in ${FDB_OLDER_VERSIONS}; do \
+		wget ${FDB_WEBSITE}/downloads/$version/linux/libfdb_c_$version.so -O /usr/lib/fdb-multiversion/libfdb_c_$version.so; \
+	done
+
 COPY requirements.txt /app
 RUN pip install -r requirements.txt
 

--- a/packaging/docker/samples/python/app/requirements.txt
+++ b/packaging/docker/samples/python/app/requirements.txt
@@ -18,4 +18,4 @@
 #
 
 Flask==1.1.1
-foundationdb==6.2.10
+foundationdb==6.1.11

--- a/packaging/docker/samples/python/app/start.bash
+++ b/packaging/docker/samples/python/app/start.bash
@@ -21,15 +21,17 @@
 
 set -xe;
 
-/app/create_cluster_file.bash
-FDB_CLUSTER_FILE="${FDB_CLUSTER_FILE:-/etc/foundationdb/fdb.cluster}"
+if [[ ! -n "${FDB_CLUSTER_FILE:-}" || ! -s "${FDB_CLUSTER_FILE}" ]]; then
+    /app/create_cluster_file.bash
+    FDB_CLUSTER_FILE="${FDB_CLUSTER_FILE:-/etc/foundationdb/fdb.cluster}"
 
-# Attempt to connect. Configure the database if necessary.
-if ! /usr/bin/fdbcli -C $FDB_CLUSTER_FILE --exec status --timeout 3 ; then
-    echo "creating the database"
-    if ! fdbcli -C $FDB_CLUSTER_FILE --exec "configure new single memory ; status" --timeout 10 ; then 
-        echo "Unable to configure new FDB cluster."
-        exit 1
+    # Attempt to connect. Configure the database if necessary.
+    if ! /usr/bin/fdbcli -C $FDB_CLUSTER_FILE --exec status --timeout 3 ; then
+        echo "creating the database"
+        if ! fdbcli -C $FDB_CLUSTER_FILE --exec "configure new single memory ; status" --timeout 10 ; then 
+            echo "Unable to configure new FDB cluster."
+            exit 1
+        fi
     fi
 fi
 


### PR DESCRIPTION
Add additional client libraries to the sample python app to show how …to prepare for upgrades.
Skip the creating of the cluster file in the sample python app if it exists and is non-empty.
Document that we have published the sample python app image.

Resolves #2484