### PR TITLE
Fix: storage server version could fail to advance in response to empty commits

### DIFF
--- a/documentation/sphinx/source/release-notes.rst
+++ b/documentation/sphinx/source/release-notes.rst
@@ -2,6 +2,14 @@
 Release Notes
 #############
 
+6.2.16
+======
+
+Fixes
+-----
+
+* Storage servers could fail to advance their version correctly in response to empty commits. `(PR #) <https://github.com/apple/foundationdb/pull/>`_.
+
 6.2.15
 ======
 

--- a/documentation/sphinx/source/release-notes.rst
+++ b/documentation/sphinx/source/release-notes.rst
@@ -8,7 +8,7 @@ Release Notes
 Fixes
 -----
 
-* Storage servers could fail to advance their version correctly in response to empty commits. `(PR #) <https://github.com/apple/foundationdb/pull/>`_.
+* Storage servers could fail to advance their version correctly in response to empty commits. `(PR #2617) <https://github.com/apple/foundationdb/pull/2617>`_.
 
 6.2.15
 ======

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -2768,9 +2768,9 @@ ACTOR Future<Void> update( StorageServer* data, bool* pReceivedUpdate )
 
 		if(ver != invalidVersion) {
 			data->lastVersionWithData = ver;
-		} else {
-			ver = cloneCursor2->version().version - 1;
-		}
+		} 
+		ver = cloneCursor2->version().version - 1;
+
 		if(injectedChanges) data->lastVersionWithData = ver;
 
 		data->updateEagerReads = NULL;


### PR DESCRIPTION
The storage server could fail to update its version to the latest processed if the peeked data contained a non-empty commit and ended with an empty commit.