### PR TITLE
Fix the Power-of-Two-Choices implementation to make better load balancing decision in data distribution

### DIFF
--- a/fdbserver/DataDistribution.actor.h
+++ b/fdbserver/DataDistribution.actor.h
@@ -74,7 +74,7 @@ struct IDataDistributionTeam {
 struct GetTeamRequest {
 	bool wantsNewServers;
 	bool wantsTrueBest;
-	bool preferLowerUtilization;
+	bool preferLowerUtilization; // true for lowest utilization, false for highest utilization
 	double inflightPenalty;
 	std::vector<UID> completeSources;
 	Promise< Optional< Reference<IDataDistributionTeam> > > reply;


### PR DESCRIPTION
This is related to Issue https://github.com/apple/foundationdb/issues/2593

The `GetTeam` request does implement the power-of-two-choice, aiming to provide a good team candidate for DD's load balancers, i.e., `MountainChopper` and `ValleyFiller`. Unfortunately, the condition used to select a team in `GetTeam` is slightly different from that in the load balancers. The difference may spoil the intention and makes the load balancers unable to effiencetly or effectively balance data in corner cases.

This PR wants to confirms the above theory and provide fix to that.