### PR TITLE
bindings/go: explicit CFLAGS and LDFLAGS for macOS and windows

### DIFF
--- a/bindings/go/src/fdb/fdb_darwin.go
+++ b/bindings/go/src/fdb/fdb_darwin.go
@@ -1,0 +1,5 @@
+package fdb
+
+//#cgo CFLAGS: -I/usr/local/include/
+//#cgo LDFLAGS: -L/usr/local/lib/
+import "C"

--- a/bindings/go/src/fdb/fdb_windows.go
+++ b/bindings/go/src/fdb/fdb_windows.go
@@ -1,0 +1,5 @@
+package fdb
+
+//#cgo CFLAGS: -I"C:/Program Files/foundationdb/include"
+//#cgo LDFLAGS: -L"C:/Program Files/foundationdb/bin" -lfdb_c
+import "C"


### PR DESCRIPTION
When applied these changes will tell the CGO toolchain on macOS
the default installation location for the headers and libs.

I've recently started playing around with FDB go bindings on my mac.
I've followed the tutorial to set everything up but whilst doing so
I've started getting some error messages like so:

     /Users/sevki/go/pkg/mod/github.com/apple/foundationdb/bindings/go@v0.0.0-20200125010749-6945a6ea0141/src/fdb/cluster.go:26:11: fatal error: 'foundationdb/fdb_c.h' file not found
      #include <foundationdb/fdb_c.h>
                ^~~~~~~~~~~~~~~~~~~~~~

These errors are most probably caused by me unsetting LDFLAGS, CFLAGS
globally as the installer installs the header files and the libraries
to sane default locations.

However, I believe explicitly telling the CGO toolchain here is a
better experience for using this library. While unsetting LDFLAGS
and CFLAGS is not a very smart thing to do, some IDEs and other build
tools make it very hard to pass environment variables to set in this
context.