### PR TITLE
Bump Docker build to use CentOS 7

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,6 +1,6 @@
 FROM centos:7
-LABEL version=0.1.9
-ENV DOCKER_IMAGEVER=0.1.9
+LABEL version=0.2.0
+ENV DOCKER_IMAGEVER=0.2.0
 
 # Install dependencies for developer tools, bindings,\
 # documentation, actorcompiler, and packaging tools\

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:6
+FROM centos:7
 LABEL version=0.1.9
 ENV DOCKER_IMAGEVER=0.1.9
 
@@ -8,6 +8,7 @@ RUN yum install -y yum-utils &&\
 	yum-config-manager --enable rhel-server-rhscl-7-rpms &&\
 	yum -y install centos-release-scl epel-release &&\
 		yum -y install devtoolset-8-8.1-1.el6 java-1.8.0-openjdk-devel \
+		devtoolset-8-gcc devtoolset-8-gcc-c++ \
 		rh-python36-python-devel devtoolset-8-valgrind-devel \
 		mono-core rh-ruby24 golang python27 rpm-build debbuild \
 		python-pip npm dos2unix valgrind-devel ccache distcc devtoolset-8-libubsan-devel libubsan-devel &&\

--- a/build/docker-compose.yaml
+++ b/build/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   common: &common
-    image: foundationdb/foundationdb-build:0.1.9
+    image: foundationdb/foundationdb-build:0.2.0
 
   build-setup: &build-setup
     <<: *common


### PR DESCRIPTION
CentOS 6 (the previous base for docker build image) stops receiving maintenance updates at the end of the year, so at some point it would be a good idea to change the build to CentOS 7.

This pull request bumps the base to CentOS 7. It also adds a couple of required packages that were included in the base package of devtoolset-8 in CentOS 6 but are no longer in CentOS 7.