### PR TITLE
Port documentation to build via Python3

### DIFF
--- a/documentation/sphinx/Makefile
+++ b/documentation/sphinx/Makefile
@@ -68,9 +68,7 @@ buildsphinx:
 	if [ ! -e $(SPHINXBUILD) ]; then \
 		mkdir $(BUILDDIR); \
 		cd $(BUILDDIR); \
-		curl -OL $(VENV_URL); \
-		tar zxvf $(VENV_VERSION).tar.gz; \
-		python2 ./$(VENV_VERSION)/virtualenv.py venv; \
+		python3 -m venv venv; \
 	fi
 	. $(VENVDIR)/bin/activate && \
 	cp .pip.conf $(VENVDIR)/pip.conf && \

--- a/documentation/sphinx/Makefile
+++ b/documentation/sphinx/Makefile
@@ -18,11 +18,6 @@ SPHINXBUILD	= $(VENVDIR)/bin/sphinx-build
 SPHINXAUTOBUILD	= $(VENVDIR)/bin/sphinx-autobuild
 TEMPLATEDIR	= $(ROOTDIR)/_templates
 
-# virtualenv for sphinx-build
-VENV_VERSION	?= virtualenv-13.0.1
-VENV_URL_BASE	?= https://pypi.python.org
-VENV_URL	?= $(VENV_URL_BASE)/packages/source/v/virtualenv/$(VENV_VERSION).tar.gz
-
 # Internal variables.
 PAPEROPT_a4	= -D latex_paper_size=a4
 PAPEROPT_letter	= -D latex_paper_size=letter

--- a/documentation/sphinx/extensions/rubydomain.py
+++ b/documentation/sphinx/extensions/rubydomain.py
@@ -502,7 +502,7 @@ class RubyModuleIndex(Index):
         ignores = self.domain.env.config['modindex_common_prefix']
         ignores = sorted(ignores, key=len, reverse=True)
         # list of all modules, sorted by module name
-        modules = sorted(self.domain.data['modules'].iteritems(),
+        modules = sorted(iter(self.domain.data['modules'].items()),
                          key=lambda x: x[0].lower())
         # sort out collapsable modules
         prev_modname = ''
@@ -551,7 +551,7 @@ class RubyModuleIndex(Index):
         collapse = len(modules) - num_toplevels < num_toplevels
 
         # sort by first letter
-        content = sorted(content.iteritems())
+        content = sorted(content.items())
 
         return content, collapse
 
@@ -609,10 +609,10 @@ class RubyDomain(Domain):
     ]
 
     def clear_doc(self, docname):
-        for fullname, (fn, _) in self.data['objects'].items():
+        for fullname, (fn, _) in list(self.data['objects'].items()):
             if fn == docname:
                 del self.data['objects'][fullname]
-        for modname, (fn, _, _, _) in self.data['modules'].items():
+        for modname, (fn, _, _, _) in list(self.data['modules'].items()):
             if fn == docname:
                 del self.data['modules'][modname]
 
@@ -704,9 +704,9 @@ class RubyDomain(Domain):
                                     contnode, name)
 
     def get_objects(self):
-        for modname, info in self.data['modules'].iteritems():
+        for modname, info in self.data['modules'].items():
             yield (modname, modname, 'module', info[0], 'module-' + modname, 0)
-        for refname, (docname, type) in self.data['objects'].iteritems():
+        for refname, (docname, type) in self.data['objects'].items():
             yield (refname, refname, type, docname, refname, 1)
 
 


### PR DESCRIPTION
Fixes #2581 

In addition to creating the `virtual environment` with Python3 itself, another change I had to do was to port `documentation/sphinx/extensions/rubydomain.py` to Python3 for the documentation to build successfully.