### PR TITLE
Add .cland to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,11 @@ compile_commands.json
 flow/actorcompiler/obj
 flow/coveragetool/obj
 
+# IDE indexing (commonly used tools)
+/compile_commands.json
+/.ccls-cache
+/.clangd
+
 # Temporary and user configuration files
 *~
 *.orig
@@ -89,5 +94,3 @@ flow/coveragetool/obj
 .envrc
 .DS_Store
 temp/
-/compile_commands.json
-/.ccls-cache


### PR DESCRIPTION
clangd is the default language server for Visual Studio Code and generally seems to gain popularity.