### PR TITLE
Revert to memcmp comparison in SkipList

### DIFF
--- a/fdbserver/SkipList.cpp
+++ b/fdbserver/SkipList.cpp
@@ -379,16 +379,9 @@ private:
 	};
 
 	static force_inline bool less( const uint8_t* a, int aLen, const uint8_t* b, int bLen ) {
-		int len = min(aLen, bLen);
-		for(int i=0; i<len; i++)
-			if (a[i] < b[i])
-				return true;
-			else if (a[i] > b[i])
-				return false;
-
-		/*int c = memcmp(a,b,min(aLen,bLen));
+		int c = memcmp(a,b,min(aLen,bLen));
 		if (c<0) return true;
-		if (c>0) return false;*/
+		if (c>0) return false;
 		return aLen < bLen;
 	}
 


### PR DESCRIPTION
This showed a ~25% reduction in the SkipListTest runtime.

A rebased version of https://github.com/apple/foundationdb/pull/2669