### PR TITLE
Fix valgrind error on backup workers

### DIFF
--- a/fdbserver/BackupWorker.actor.cpp
+++ b/fdbserver/BackupWorker.actor.cpp
@@ -54,13 +54,12 @@ struct VersionedMessage {
 			}
 		}
 
-		BinaryReader reader(message.begin(), message.size(), AssumeVersion(currentProtocolVersion));
+		ArenaReader reader(arena, message, AssumeVersion(currentProtocolVersion));
 
 		// Return false for LogProtocolMessage.
 		if (LogProtocolMessage::isNextIn(reader)) return false;
 
 		reader >> *m;
-TraceEvent("KeyDebug").detail("M", m->toString());
 		return normalKeys.contains(m->param1) || m->param1 == metadataVersionKey;
 	}
 };


### PR DESCRIPTION
The deserialization of mutation from a `StringRef` was done by a `BinaryReader`, which actually creates a copy of the data and returns the copy. As a result, when the reader is out of scope, the memory is no longer valid. Changing to `ArenaReader` solves the problem.

This PR also includes some code refactoring, including dead code removal.

The Valgrind Errors are:

```
    <ValgrindError Severity="40" What="Conditional jump or move depends on uninitialised value(s)"/>
    <ValgrindError Severity="40" What="Use of uninitialised value of size 8"/>
    <ValgrindError Severity="40" What="Invalid read of size 1"/>
```

These are found at: 
commit: 2d4f24ac
seed: -f fast/BackupCorrectness.txt -s 183149587 -b off
unseed: 81917

To reproduce the error, the first step is to create the binary with `VALGRIND := 1` flag, defined in `build/valgrind.mk` file.

The valgrind test uses `--xml` and `--xml-file` flags to generate log files that are processed by TestHarness. For example,

`valgrind --xml=yes --xml-file=valgrind.xml ./foundationdb/bin/fdbserver -r simulation -f ./foundationdb/tests/fast/BackupCorrectness.txt -s 183149587 -b off`

For human readable format, use
`valgrind --log-file=valgrind.log ./foundationdb/bin/fdbserver -r simulation -f ./foundationdb/tests/fast/BackupCorrectness.txt -s 183149587 -b off --crash`

