### PR TITLE
Added a specialized 'findBestPolicySet' for policies of shape 'Policy…

### DIFF
--- a/fdbrpc/ReplicationPolicy.cpp
+++ b/fdbrpc/ReplicationPolicy.cpp
@@ -176,11 +176,6 @@ void IReplicationPolicy::traceOneLocalityRecord(Reference<LocalityRecord> record
 	}
 }
 
-// Validate if the team satisfies the replication policy
-// LocalitySet is the base class about the locality information
-// solutionSet is the team to be validated
-// fromServers is the location information of all servers
-// return true if the team satisfies the policy; false otherwise
 bool PolicyAcross::validate(
 		std::vector<LocalityEntry>	const&	solutionSet,
 		Reference<LocalitySet> const&				fromServers ) const
@@ -255,22 +250,13 @@ bool PolicyAcross::validate(
 	return valid;
 }
 
-// Choose new servers from "least utilized" alsoServers and append the new servers to results
-// fromserverse are the servers that have already been chosen and
-// that should be excluded from being selected as replicas.
-// FIXME: Simplify this function, such as removing unnecessary printf
-// fromServers are the servers that must have;
-// alsoServers are the servers you can choose.
-bool PolicyAcross::selectReplicas(
-	Reference<LocalitySet>	&						fromServers,
-	std::vector<LocalityEntry> const&		alsoServers,
-	std::vector<LocalityEntry>	&				results )
-{
-	int					count = 0;
-	AttribKey		indexKey = fromServers->keyIndex(_attribKey);
-	auto				groupIndexKey = fromServers->getGroupKeyIndex(indexKey);
-	int					resultsSize, resultsAdded;
-	int					resultsInit = results.size();
+bool PolicyAcross::selectReplicas(Reference<LocalitySet>& fromServers, std::vector<LocalityEntry> const& alsoServers,
+                                  std::vector<LocalityEntry>& results) {
+	int count = 0;
+	AttribKey indexKey = fromServers->keyIndex(_attribKey);
+	auto groupIndexKey = fromServers->getGroupKeyIndex(indexKey);
+	int resultsSize, resultsAdded;
+	int resultsInit = results.size();
 
 	// Clear the member variables
 	_usedValues.clear();
@@ -317,9 +303,7 @@ bool PolicyAcross::selectReplicas(
 		}
 	}
 
-	// Process the remaining results, if present
 	if ((count < _count) && (_addedResults.size())) {
-		// Sort the added results array
 		std::sort(_addedResults.begin(), _addedResults.end(), PolicyAcross::compareAddedResults);
 
 		if (g_replicationdebug > 0) {
@@ -346,8 +330,6 @@ bool PolicyAcross::selectReplicas(
 		}
 	}
 
-	// Cannot find replica from the least used alsoServers, now try to find replicas from all servers
-	// Process the remaining values
 	if (count < _count) {
 		if (g_replicationdebug > 0) {
 			printf("Across items:%4d key: %-7s policy: %-10s => %s  count:%3d of%3d\n", fromServers->size(), _attribKey.c_str(), _policy->name().c_str(), _policy->info().c_str(), count, _count);

--- a/fdbrpc/ReplicationTypes.h
+++ b/fdbrpc/ReplicationTypes.h
@@ -154,8 +154,8 @@ struct LocalityRecord : public ReferenceCounted<LocalityRecord> {
 
 // This class stores the information for string to integer map for keys and values
 struct StringToIntMap : public ReferenceCounted<StringToIntMap> {
-	std::map<std::string, int>		_hashmap;
-	std::vector<std::string>			_lookuparray;
+	std::map<std::string, int> _hashmap;
+	std::vector<std::string> _lookuparray;
 	StringToIntMap() {}
 	StringToIntMap(StringToIntMap const& source):_hashmap(source._hashmap), _lookuparray(source._lookuparray){}
 	virtual ~StringToIntMap(){}
@@ -172,8 +172,9 @@ struct StringToIntMap : public ReferenceCounted<StringToIntMap> {
 		_hashmap = source._hashmap;
 		_lookuparray = source._lookuparray;
 	}
-	std::string lookupString(int hashValue) const
-	{	return (hashValue < _lookuparray.size()) ? _lookuparray[hashValue] : "<missing>";	}
+	std::string lookupString(int hashValue) const {
+		return (hashValue < _lookuparray.size()) ? _lookuparray[hashValue] : "<missing>";
+	}
 	int convertString( std::string const& value) {
 		int hashValue;
 		auto itValue = _hashmap.find(value);
@@ -187,12 +188,11 @@ struct StringToIntMap : public ReferenceCounted<StringToIntMap> {
 		}
 		return hashValue;
 	}
-	int convertString( char const* value)
-	{	return convertString(std::string(value));	}
-	int convertString( StringRef const& value)
-	{	return convertString(value.printable());	}
-	int convertString( Optional<Standalone<StringRef>> const& value)
-	{	return convertString((value.present()) ? value.get().printable() : "<undefined>");	}
+	int convertString(char const* value) { return convertString(std::string(value)); }
+	int convertString(StringRef const& value) { return convertString(value.printable()); }
+	int convertString(Optional<Standalone<StringRef>> const& value) {
+		return convertString((value.present()) ? value.get().printable() : "<undefined>");
+	}
 
 	int	getMemoryUsed() const {
 		int memSize = sizeof(_hashmap) + sizeof(_lookuparray);
@@ -208,6 +208,6 @@ struct StringToIntMap : public ReferenceCounted<StringToIntMap> {
 	virtual void delref() { ReferenceCounted<StringToIntMap>::delref(); }
 };
 
-extern const std::vector<LocalityEntry>		emptyEntryArray;
+extern const std::vector<LocalityEntry> emptyEntryArray;
 
 #endif

--- a/fdbrpc/ReplicationUtils.cpp
+++ b/fdbrpc/ReplicationUtils.cpp
@@ -122,7 +122,8 @@ bool findBestPolicySetSimple(std::vector<LocalityEntry>& bestResults, Reference<
 	// Then greedily choose LocalityEntries.
 	int perValue = nMinItems / pa->getCount();
 	int remainder = nMinItems % pa->getCount();
-	for (auto it = kvToEntryCounts.rbegin(); it != kvToEntryCounts.rend() && bestResults.size() < nMinItems; ++it) {
+	for (std::reverse_iterator<std::vector<std::pair<AttribRecord, int>>> it = kvToEntryCounts.rbegin();
+	     it != kvToEntryCounts.rend() && bestResults.size() < nMinItems; ++it) {
 		int _perValue = remainder > 0 ? perValue + 1 : perValue;
 		auto& entryList = kvToEntryMap[it->first];
 		if (it->second >= _perValue) {

--- a/fdbrpc/ReplicationUtils.cpp
+++ b/fdbrpc/ReplicationUtils.cpp
@@ -122,11 +122,10 @@ bool findBestPolicySetSimple(std::vector<LocalityEntry>& bestResults, Reference<
 	// Then greedily choose LocalityEntries.
 	int perValue = nMinItems / pa->getCount();
 	int remainder = nMinItems % pa->getCount();
-	for (std::reverse_iterator<std::vector<std::pair<AttribRecord, int>>> it = kvToEntryCounts.rbegin();
-	     it != kvToEntryCounts.rend() && bestResults.size() < nMinItems; ++it) {
+	for (int i = kvToEntryCounts.size() - 1; i >= 0; i--) {
 		int _perValue = remainder > 0 ? perValue + 1 : perValue;
-		auto& entryList = kvToEntryMap[it->first];
-		if (it->second >= _perValue) {
+		auto& entryList = kvToEntryMap[kvToEntryCounts[i].first];
+		if (kvToEntryCounts[i].second >= _perValue) {
 			bestResults.insert(bestResults.end(), entryList.begin(), entryList.begin() + _perValue);
 			remainder--;
 		} else {


### PR DESCRIPTION
This resolves #2663 

Added a specialized `findBestPolicySet` for policies of shape `PolicyAcross(,,PolicyOne())`, which is the most commonly used policy in FDB.

Basically instead of doing a heavily randomized algorithm, this specialized function relies on statistics collected by LocalitySat and implements a greedy even selection based on the specification of the PolicyAcross.