### PR TITLE
Don't require /usr/bin/python in RPMs.

### DIFF
--- a/packaging/rpm/foundationdb.spec.in
+++ b/packaging/rpm/foundationdb.spec.in
@@ -19,6 +19,10 @@ Requires: foundationdb-clients = %{version}-%{release}
 Conflicts: foundationdb < 0.1.4
 ifdef(`RHEL6', `Requires(post): chkconfig >= 0.9, /sbin/service')
 Requires(pre): /usr/sbin/useradd, /usr/sbin/groupadd, /usr/bin/getent
+# This is a heavy hammer, to remove /usr/bin/python as a dependency,
+# as it also removes dependencies like glibc. However, none of the
+# other strategies (__requires_exclude) seem to work.
+AutoReq: 0
 
 %package clients
 Summary: FoundationDB clients and library


### PR DESCRIPTION
This was being "helpfully" automatically added for us by rpmbuild as it
saw that we listed a python file (make_public.py) in %files.  As that
isn't a vital thing for running FDB, it's better to not make it a hard
requirement.