### PR TITLE
#2691 start foundationdb only after the public ip adress exists

### DIFF
--- a/packaging/rpm/foundationdb.service
+++ b/packaging/rpm/foundationdb.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=FoundationDB Key-Value Store
-After=syslog.target network.target
+After=syslog.target network-online.target
+Wants=network-online.target
 
 [Service]
 Type=forking


### PR DESCRIPTION
This change makes starting foundationdb.service only after a public ip adress apears