### PR TITLE
Fix: Java directory layer was unpacking little endian numbers without properly handling signs

### DIFF
--- a/bindings/java/src/main/com/apple/foundationdb/directory/DirectoryLayer.java
+++ b/bindings/java/src/main/com/apple/foundationdb/directory/DirectoryLayer.java
@@ -819,7 +819,7 @@ public class DirectoryLayer implements Directory {
 		assert bytes.length == 8;
 		long value = 0;
 		for(int i = 0; i < 8; ++i) {
-			value += ((long)bytes[i]&0xFF << (i * 8));
+			value += (Byte.toUnsignedLong(bytes[i]) << (i * 8));
 		}
 		return value;
 	}

--- a/bindings/java/src/main/com/apple/foundationdb/directory/DirectoryLayer.java
+++ b/bindings/java/src/main/com/apple/foundationdb/directory/DirectoryLayer.java
@@ -817,9 +817,9 @@ public class DirectoryLayer implements Directory {
 
 	private static long unpackLittleEndian(byte[] bytes) {
 		assert bytes.length == 8;
-		int value = 0;
+		long value = 0;
 		for(int i = 0; i < 8; ++i) {
-			value += (bytes[i] << (i * 8));
+			value += ((long)bytes[i]&0xFF << (i * 8));
 		}
 		return value;
 	}


### PR DESCRIPTION
Resolves #2720.