### PR TITLE
Fix assertion failure in SQLite thread pools on io_error

### DIFF
--- a/fdbserver/KeyValueStoreSQLite.actor.cpp
+++ b/fdbserver/KeyValueStoreSQLite.actor.cpp
@@ -1858,13 +1858,15 @@ private:
 	ACTOR static Future<Void> stopOnError( KeyValueStoreSQLite* self ) {
 		try {
 			wait( self->readThreads->getError() || self->writeThread->getError() );
+			ASSERT(false);
 		} catch (Error& e) {
 			if (e.code() == error_code_actor_cancelled)
 				throw;
+
+			self->readThreads->stop(e);
+			self->writeThread->stop(e);
 		}
 
-		self->readThreads->stop();
-		self->writeThread->stop();
 		return Void();
 	}
 

--- a/flow/IThreadPool.cpp
+++ b/flow/IThreadPool.cpp
@@ -78,7 +78,7 @@ class ThreadPool : public IThreadPool, public ReferenceCounted<ThreadPool> {
 public:
 	ThreadPool() : dontstop(ios), mode(Run) {}
 	~ThreadPool() {}
-	Future<Void> stop() {
+	Future<Void> stop(Error const& e = success()) {
 		if (mode == Shutdown) return Void();
 		ReferenceCounted<ThreadPool>::addref();
 		ios.stop(); // doesn't work?

--- a/flow/IThreadPool.h
+++ b/flow/IThreadPool.h
@@ -60,7 +60,7 @@ public:
 	virtual Future<Void> getError() = 0;  // asynchronously throws an error if there is an internal error
 	virtual void addThread( IThreadPoolReceiver* userData ) = 0;
 	virtual void post( PThreadAction action ) = 0;
-	virtual Future<Void> stop() = 0;
+	virtual Future<Void> stop(Error const& e = success()) = 0;
 	virtual bool isCoro() const { return false; }
 	virtual void addref() = 0;
 	virtual void delref() = 0;

--- a/flow/Trace.cpp
+++ b/flow/Trace.cpp
@@ -65,7 +65,7 @@ public:
 			errors.sendError( unknown_error() );
 		}
 	}
-	Future<Void> stop() {
+	Future<Void> stop(Error const& e) {
 		return Void();
 	}
 	void addref() {


### PR DESCRIPTION
When one of the reader or writer thread pools fails, the other is now failed with the same error.