### PR TITLE
Clean up and add comments to Roughness calculation

### DIFF
--- a/flow/Stats.actor.cpp
+++ b/flow/Stats.actor.cpp
@@ -22,7 +22,7 @@
 #include "flow/actorcompiler.h" // has to be last include
 
 Counter::Counter(std::string const& name, CounterCollection& collection)
-: name(name), interval_start(0), last_event(0), interval_sq_time(0), interval_start_value(0), interval_delta(0)
+: name(name), interval_start(0), last_event(0), interval_sq_time(0), interval_start_value(0), interval_delta(0), roughness_interval_start(0)
 {
 	metric.init(collection.name + "." + (char)toupper(name.at(0)) + name.substr(1), collection.id);
 	collection.counters.push_back(this);
@@ -45,13 +45,21 @@ double Counter::getRate() const {
 }
 
 double Counter::getRoughness() const {
-	double elapsed = now() - interval_start;
+	double elapsed = now() - roughness_interval_start;
 	if(elapsed == 0) {
 		return 0;
 	}
 
+	// If we have time samples t in T, and let:
+	// n = size(T) = interval_delta
+	// m = mean(T) = elapsed / interval_delta
+	// v = sum(t^2) for t in T = interval_sq_time
+	// 
+	// The formula below is: (v/(m*n)) / m - 1
+	// This is equivalent to (v/n - m^2) / m^2 = Variance(T)/m^2
+	// Variance(T)/m^2 is equal to Variance(t/m) for t in T
 	double delay = interval_sq_time / elapsed;
-	return delay * getRate() * 2;
+	return delay * interval_delta / elapsed - 1;
 }
 
 void Counter::resetInterval() {
@@ -59,7 +67,10 @@ void Counter::resetInterval() {
 	interval_delta = 0;
 	interval_sq_time = 0;
 	interval_start = now();
-	last_event = interval_start;  // <FIXME: Is this right?
+	if(last_event == 0) {
+		last_event = interval_start;
+	}
+	roughness_interval_start = last_event;
 }
 
 void Counter::clear() {

--- a/flow/Stats.actor.cpp
+++ b/flow/Stats.actor.cpp
@@ -47,10 +47,10 @@ double Counter::getRate() const {
 double Counter::getRoughness() const {
 	double elapsed = now() - roughness_interval_start;
 	if(elapsed == 0) {
-		return 0;
+		return -1;
 	}
 
-	// If we have time samples t in T, and let:
+	// If we have time interval samples t in T, and let:
 	// n = size(T) = interval_delta
 	// m = mean(T) = elapsed / interval_delta
 	// v = sum(t^2) for t in T = interval_sq_time

--- a/flow/Stats.h
+++ b/flow/Stats.h
@@ -100,11 +100,11 @@ public:
 	// A delta of N is treated as N distinct increments, with N-1 increments having time span 0.
 	// Normalization is performed by dividing each time sample by the mean time before taking variance.
 	//
-	// roughness = Variance(t/mean(T)) for time samples t in T
+	// roughness = Variance(t/mean(T)) for time interval samples t in T
 	//
 	// A uniformly periodic counter will have roughness of 0
 	// A uniformly periodic counter that increases in clumps of N will have roughness of N-1
-	// A poisson distributed counter will have roughness of 1
+	// A counter with exponentially distributed incrementations will have roughness of 1
 	double getRoughness() const;
 
 	bool hasRate() const { return true; }

--- a/flow/Stats.h
+++ b/flow/Stats.h
@@ -91,14 +91,28 @@ public:
 
 	Value getIntervalDelta() const { return interval_delta; }
 	Value getValue() const { return interval_start_value + interval_delta; }
-	double getRate() const;				// dValue / dt
-	double getRoughness() const;			// value deltas come in "clumps" of this many ( 1 = periodic, 2 = poisson, 10 = periodic clumps of 10 (nearly) simultaneous delta )
+
+	// dValue / dt
+	double getRate() const;
+
+	// Measures the clumpiness or dispersion of the counter.
+	// Computed as a normalized variance of the time between each incrementation of the value.
+	// A delta of N is treated as N distinct increments, with N-1 increments having time span 0.
+	// Normalization is performed by dividing each time sample by the mean time before taking variance.
+	//
+	// roughness = Variance(t/mean(T)) for time samples t in T
+	//
+	// A uniformly periodic counter will have roughness of 0
+	// A uniformly periodic counter that increases in clumps of N will have roughness of N-1
+	// A poisson distributed counter will have roughness of 1
+	double getRoughness() const;
+
 	bool hasRate() const { return true; }
 	bool hasRoughness() const { return true; }
 
 private:
 	std::string name;
-	double interval_start, last_event, interval_sq_time;
+	double interval_start, last_event, interval_sq_time, roughness_interval_start;
 	Value interval_delta, interval_start_value;
 	Int64MetricHandle metric;
 };


### PR DESCRIPTION
This documents the derivation for roughness, which has also been modified slightly:

* An unexplained factor of 2 was removed
* Window edges are handled differently. Now, roughness is calculated considering all the way back to the previous event rather than the beginning of the window. The time at the end of window after the last event is ignored.
* Subtract 1 from the previous value. This is intended to make the value a more standard variance.