### PR TITLE
Fix heap buffer overflow in mako

### DIFF
--- a/bindings/c/test/mako/mako.c
+++ b/bindings/c/test/mako/mako.c
@@ -1711,7 +1711,7 @@ int main(int argc, char *argv[]) {
   shm->readycount = 0;
 
   /* fork worker processes */
-  worker_pids = (pid_t *)calloc(sizeof(pid_t), args.num_processes);
+  worker_pids = (pid_t*)calloc(sizeof(pid_t), args.num_processes + 1);
   if (!worker_pids) {
     fprintf(stderr, "ERROR: cannot allocate worker_pids (%d processes)\n",
             args.num_processes);


### PR DESCRIPTION
I'm not sure this is the right fix, but I thought I'd let you know @kaomakino 