### PR TITLE
Fix correctness failure on master branch

### DIFF
--- a/fdbclient/ManagementAPI.actor.cpp
+++ b/fdbclient/ManagementAPI.actor.cpp
@@ -1206,6 +1206,11 @@ struct AutoQuorumChange : IQuorumChange {
 				if(addressExcluded(excluded, worker->address)) {
 					continue;
 				}
+				// Exclude faulty node due to machine assassination
+				if (g_network->isSimulated() && g_simulator.protectedAddresses.count(worker->address) && !g_simulator.getProcessByAddress(worker->address)->isReliable()) {
+					TraceEvent("AutoSelectCoordinators").detail("SkipUnreliableWorker", worker->address.toString());
+					continue;
+				}
 				bool valid = true;
 				for(auto field = fields.begin(); field != fields.end(); field++) {
 					if(maxCounts[*field] == 0) {

--- a/fdbclient/ManagementAPI.actor.cpp
+++ b/fdbclient/ManagementAPI.actor.cpp
@@ -986,7 +986,7 @@ ACTOR Future<CoordinatorsResult::Type> changeQuorum( Database cx, Reference<IQuo
 			if(g_network->isSimulated()) {
 				for(int i = 0; i < (desiredCoordinators.size()/2)+1; i++) {
 					auto addresses = g_simulator.getProcessByAddress(desiredCoordinators[i])->addresses;
-					
+
 					g_simulator.protectedAddresses.insert(addresses.address);
 					if(addresses.secondaryAddress.present()) {
 						g_simulator.protectedAddresses.insert(addresses.secondaryAddress.get());

--- a/fdbclient/StorageServerInterface.h
+++ b/fdbclient/StorageServerInterface.h
@@ -74,11 +74,11 @@ struct StorageServerInterface {
 	explicit StorageServerInterface(UID uid) : uniqueID( uid ) {}
 	StorageServerInterface() : uniqueID( deterministicRandom()->randomUniqueID() ) {}
 	NetworkAddress address() const { return getValue.getEndpoint().getPrimaryAddress(); }
-	Optional<NetworkAddress> secondaryAddress() const {return getValue.getEndpoint().addresses.secondaryAddress;}
+	Optional<NetworkAddress> secondaryAddress() const { return getValue.getEndpoint().addresses.secondaryAddress; }
 	UID id() const { return uniqueID; }
 	std::string toString() const { return id().shortString(); }
 	template <class Ar>
-	void serialize( Ar& ar ) {
+	void serialize(Ar& ar) {
 		// StorageServerInterface is persisted in the database and in the tLog's data structures, so changes here have to be
 		// versioned carefully!
 

--- a/fdbclient/StorageServerInterface.h
+++ b/fdbclient/StorageServerInterface.h
@@ -74,9 +74,10 @@ struct StorageServerInterface {
 	explicit StorageServerInterface(UID uid) : uniqueID( uid ) {}
 	StorageServerInterface() : uniqueID( deterministicRandom()->randomUniqueID() ) {}
 	NetworkAddress address() const { return getValue.getEndpoint().getPrimaryAddress(); }
+	Optional<NetworkAddress> secondaryAddress() const {return getValue.getEndpoint().addresses.secondaryAddress;}
 	UID id() const { return uniqueID; }
 	std::string toString() const { return id().shortString(); }
-	template <class Ar> 
+	template <class Ar>
 	void serialize( Ar& ar ) {
 		// StorageServerInterface is persisted in the database and in the tLog's data structures, so changes here have to be
 		// versioned carefully!

--- a/fdbrpc/FlowTransport.h
+++ b/fdbrpc/FlowTransport.h
@@ -46,7 +46,8 @@ public:
 	void choosePrimaryAddress() {
 		if(addresses.secondaryAddress.present() && !g_network->getLocalAddresses().secondaryAddress.present() && (addresses.address.isTLS() != g_network->getLocalAddresses().address.isTLS())) {
 			// if (addresses.address.isTLS()) {
-			// 	TraceEvent(SevWarn, "MXDEBUGChoosePrimaryAddressSwap").detail("PrimaryAddressWillBeTLS", addresses.secondaryAddress.get().isTLS()).backtrace();
+			// 	TraceEvent(SevWarn, "MXDEBUGChoosePrimaryAddressSwap").detail("PrimaryAddressWillBeTLS",
+			// addresses.secondaryAddress.get().isTLS()).backtrace();
 			// }
 			std::swap(addresses.address, addresses.secondaryAddress.get());
 		}

--- a/fdbrpc/FlowTransport.h
+++ b/fdbrpc/FlowTransport.h
@@ -45,9 +45,9 @@ public:
 
 	void choosePrimaryAddress() {
 		if(addresses.secondaryAddress.present() && !g_network->getLocalAddresses().secondaryAddress.present() && (addresses.address.isTLS() != g_network->getLocalAddresses().address.isTLS())) {
-			if (addresses.address.isTLS()) {
-				TraceEvent(SevWarn, "MXDEBUGChoosePrimaryAddressSwap").detail("PrimaryAddressWillBeTLS", addresses.secondaryAddress.get().isTLS()).backtrace();
-			}
+			// if (addresses.address.isTLS()) {
+			// 	TraceEvent(SevWarn, "MXDEBUGChoosePrimaryAddressSwap").detail("PrimaryAddressWillBeTLS", addresses.secondaryAddress.get().isTLS()).backtrace();
+			// }
 			std::swap(addresses.address, addresses.secondaryAddress.get());
 		}
 	}

--- a/fdbrpc/FlowTransport.h
+++ b/fdbrpc/FlowTransport.h
@@ -45,8 +45,11 @@ public:
 
 	void choosePrimaryAddress() {
 		if(addresses.secondaryAddress.present() && !g_network->getLocalAddresses().secondaryAddress.present() && (addresses.address.isTLS() != g_network->getLocalAddresses().address.isTLS())) {
+			if (addresses.address.isTLS()) {
+				TraceEvent(SevWarn, "MXDEBUGChoosePrimaryAddressSwap").detail("PrimaryAddressWillBeTLS", addresses.secondaryAddress.get().isTLS()).backtrace();
+			}
 			std::swap(addresses.address, addresses.secondaryAddress.get());
-		}	
+		}
 	}
 
 	bool isValid() const { return token.isValid(); }

--- a/fdbrpc/FlowTransport.h
+++ b/fdbrpc/FlowTransport.h
@@ -45,10 +45,6 @@ public:
 
 	void choosePrimaryAddress() {
 		if(addresses.secondaryAddress.present() && !g_network->getLocalAddresses().secondaryAddress.present() && (addresses.address.isTLS() != g_network->getLocalAddresses().address.isTLS())) {
-			// if (addresses.address.isTLS()) {
-			// 	TraceEvent(SevWarn, "MXDEBUGChoosePrimaryAddressSwap").detail("PrimaryAddressWillBeTLS",
-			// addresses.secondaryAddress.get().isTLS()).backtrace();
-			// }
 			std::swap(addresses.address, addresses.secondaryAddress.get());
 		}
 	}

--- a/fdbrpc/sim2.actor.cpp
+++ b/fdbrpc/sim2.actor.cpp
@@ -1029,7 +1029,7 @@ public:
 
 		NetworkAddressList addresses;
 		addresses.address = NetworkAddress(ip, port, true, sslEnabled);
-		if(listenPerProcess == 2) {
+		if(listenPerProcess == 2) { // listenPerProcess is only 1 or 2
 			addresses.secondaryAddress = NetworkAddress(ip, port+1, true, false);
 		}
 
@@ -1250,12 +1250,26 @@ public:
 		TEST( kt == InjectFaults ); // Simulated machine was killed with faults
 
 		if (kt == KillInstantly) {
-			TraceEvent(SevWarn, "FailMachine").detail("Name", machine->name).detail("Address", machine->address).detail("ZoneId", machine->locality.zoneId()).detail("Process", machine->toString()).detail("Rebooting", machine->rebooting).detail("Protected", protectedAddresses.count(machine->address)).backtrace();
+			TraceEvent(SevWarn, "FailMachine")
+			    .detail("Name", machine->name)
+			    .detail("Address", machine->address)
+			    .detail("ZoneId", machine->locality.zoneId())
+			    .detail("Process", machine->toString())
+			    .detail("Rebooting", machine->rebooting)
+			    .detail("Protected", protectedAddresses.count(machine->address))
+			    .backtrace();
 			// This will remove all the "tracked" messages that came from the machine being killed
 			latestEventCache.clear();
 			machine->failed = true;
 		} else if (kt == InjectFaults) {
-			TraceEvent(SevWarn, "FaultMachine").detail("Name", machine->name).detail("Address", machine->address).detail("ZoneId", machine->locality.zoneId()).detail("Process", machine->toString()).detail("Rebooting", machine->rebooting).detail("Protected", protectedAddresses.count(machine->address)).backtrace();
+			TraceEvent(SevWarn, "FaultMachine")
+			    .detail("Name", machine->name)
+			    .detail("Address", machine->address)
+			    .detail("ZoneId", machine->locality.zoneId())
+			    .detail("Process", machine->toString())
+			    .detail("Rebooting", machine->rebooting)
+			    .detail("Protected", protectedAddresses.count(machine->address))
+			    .backtrace();
 			should_inject_fault = simulator_should_inject_fault;
 			machine->fault_injection_r = deterministicRandom()->randomUniqueID().first();
 			machine->fault_injection_p1 = 0.1;
@@ -1290,7 +1304,7 @@ public:
 		}
 	}
 	virtual void killProcess( ProcessInfo* machine, KillType kt ) {
-		TraceEvent("AttemptingKillProcess");
+		TraceEvent("AttemptingKillProcess").detail("ProcessInfo", machine->toString());
 		if (kt < RebootAndDelete ) {
 			killProcess_internal( machine, kt );
 		}

--- a/fdbrpc/sim2.actor.cpp
+++ b/fdbrpc/sim2.actor.cpp
@@ -1029,7 +1029,7 @@ public:
 
 		NetworkAddressList addresses;
 		addresses.address = NetworkAddress(ip, port, true, sslEnabled);
-		if(listenPerProcess == 2) { // listenPerProcess is only 1 or 2
+		if (listenPerProcess == 2) { // listenPerProcess is only 1 or 2
 			addresses.secondaryAddress = NetworkAddress(ip, port+1, true, false);
 		}
 

--- a/fdbrpc/sim2.actor.cpp
+++ b/fdbrpc/sim2.actor.cpp
@@ -1584,7 +1584,9 @@ public:
 	virtual ProcessInfo* getProcessByAddress( NetworkAddress const& address ) {
 		NetworkAddress normalizedAddress(address.ip, address.port, true, address.isTLS());
 		ASSERT( addressMap.count( normalizedAddress ) );
-		return addressMap[ normalizedAddress ];
+		// NOTE: addressMap[normalizedAddress]->address may not equal to normalizedAddress
+		// ASSERT_WE_THINK( addressMap[normalizedAddress]->address == normalizedAddress );
+		return addressMap[normalizedAddress];
 	}
 
 	virtual MachineInfo* getMachineByNetworkAddress(NetworkAddress const& address) {

--- a/fdbrpc/sim2.actor.cpp
+++ b/fdbrpc/sim2.actor.cpp
@@ -1585,7 +1585,6 @@ public:
 		NetworkAddress normalizedAddress(address.ip, address.port, true, address.isTLS());
 		ASSERT( addressMap.count( normalizedAddress ) );
 		// NOTE: addressMap[normalizedAddress]->address may not equal to normalizedAddress
-		// ASSERT_WE_THINK( addressMap[normalizedAddress]->address == normalizedAddress );
 		return addressMap[normalizedAddress];
 	}
 

--- a/fdbrpc/simulator.h
+++ b/fdbrpc/simulator.h
@@ -81,6 +81,12 @@ public:
 		bool isAvailable() const { return !isExcluded() && isReliable(); }
 		bool isExcluded() const { return excluded; }
 		bool isCleared() const { return cleared; }
+		std::string getReliableInfo() {
+			std::stringstream ss;
+			ss << "failed:" << failed << " fault_injection_p1:" << fault_injection_p1
+			   << " fault_injection_p2:" << fault_injection_p2;
+			return ss.str();
+		}
 
 		// Returns true if the class represents an acceptable worker
 		bool isAvailableClass() const {

--- a/fdbserver/LogSystemDiskQueueAdapter.actor.cpp
+++ b/fdbserver/LogSystemDiskQueueAdapter.actor.cpp
@@ -60,8 +60,14 @@ public:
 						}
 					}
 				}
-				TraceEvent("PeekNextGetMore").detail("Total", self->totalRecoveredBytes).detail("Queue", self->recoveryQueue.size()).detail("Bytes", bytes).detail("Loc", self->recoveryLoc)
-					.detail("End", self->logSystem->getEnd()).detail("HasMessage", self->cursor->hasMessage()).detail("Version", self->cursor->version().version);
+				TraceEvent("PeekNextGetMore")
+				    .detail("Total", self->totalRecoveredBytes)
+				    .detail("Queue", self->recoveryQueue.size())
+				    .detail("Bytes", bytes)
+				    .detail("Loc", self->recoveryLoc)
+				    .detail("End", self->logSystem->getEnd())
+				    .detail("HasMessage", self->cursor->hasMessage())
+				    .detail("Version", self->cursor->version().version);
 
 				if(self->cursor->popped() != 0 || (!self->hasDiscardedData && BUGGIFY_WITH_PROB(0.01))) {
 					TEST(true); //disk adapter reset

--- a/fdbserver/LogSystemDiskQueueAdapter.actor.cpp
+++ b/fdbserver/LogSystemDiskQueueAdapter.actor.cpp
@@ -61,8 +61,8 @@ public:
 					}
 				}
 				TraceEvent("PeekNextGetMore").detail("Total", self->totalRecoveredBytes).detail("Queue", self->recoveryQueue.size()).detail("Bytes", bytes).detail("Loc", self->recoveryLoc)
-					.detail("End", self->logSystem->getEnd()).detail("HasMessage", self->cursor->hasMessage()).detail("Version", self->cursor->version().version); 
-				
+					.detail("End", self->logSystem->getEnd()).detail("HasMessage", self->cursor->hasMessage()).detail("Version", self->cursor->version().version);
+
 				if(self->cursor->popped() != 0 || (!self->hasDiscardedData && BUGGIFY_WITH_PROB(0.01))) {
 					TEST(true); //disk adapter reset
 					TraceEvent(SevWarnAlways, "DiskQueueAdapterReset").detail("Version", self->cursor->popped());

--- a/fdbserver/LogSystemPeekCursor.actor.cpp
+++ b/fdbserver/LogSystemPeekCursor.actor.cpp
@@ -195,6 +195,7 @@ ACTOR Future<Void> serverPeekParallelGetMore( ILogSystem::ServerPeekCursor* self
 				TraceEvent("PeekCursorTimedOut", self->randomID).error(e);
 				// We *should* never get timed_out(), as it means the TLog got stuck while handling a parallel peek,
 				// and thus we've likely just wasted 10min.
+				// timed_out() is sent by cleanupPeekTrackers as value PEEK_TRACKER_EXPIRATION_TIME
 				ASSERT_WE_THINK(e.code() == error_code_operation_obsolete || SERVER_KNOBS->PEEK_TRACKER_EXPIRATION_TIME < 10);
 				self->interfaceChanged = self->interf->onChange();
 				self->randomID = deterministicRandom()->randomUniqueID();

--- a/fdbserver/OldTLogServer_6_0.actor.cpp
+++ b/fdbserver/OldTLogServer_6_0.actor.cpp
@@ -381,6 +381,7 @@ struct LogData : NonCopyable, public ReferenceCounted<LogData> {
 	Version queueCommittingVersion;
 	Version knownCommittedVersion, durableKnownCommittedVersion, minKnownCommittedVersion;
 
+	// Track lastUpdate time for parallel peek and detect stall on tLogs
 	struct PeekTrackerData {
 		std::map<int, Promise<std::pair<Version, bool>>> sequence_version;
 		double lastUpdate;
@@ -500,7 +501,7 @@ struct LogData : NonCopyable, public ReferenceCounted<LogData> {
 		for ( auto it = peekTracker.begin(); it != peekTracker.end(); ++it ) {
 			for(auto seq : it->second.sequence_version) {
 				if(!seq.second.isSet()) {
-					seq.second.sendError(timed_out());
+					seq.second.sendError(operation_obsolete());
 				}
 			}
 		}

--- a/fdbserver/TLogInterface.h
+++ b/fdbserver/TLogInterface.h
@@ -49,7 +49,6 @@ struct TLogInterface {
 	RequestStream< struct TLogEnablePopRequest> enablePopRequest;
 	RequestStream< struct TLogSnapRequest> snapRequest;
 
-	
 	TLogInterface() {}
 	explicit TLogInterface(const LocalityData& locality) : uniqueID( deterministicRandom()->randomUniqueID() ), locality(locality) { sharedTLogID = uniqueID; }
 	TLogInterface(UID sharedTLogID, const LocalityData& locality) : uniqueID( deterministicRandom()->randomUniqueID() ), sharedTLogID(sharedTLogID), locality(locality) {}
@@ -59,6 +58,7 @@ struct TLogInterface {
 	std::string toString() const { return id().shortString(); }
 	bool operator == ( TLogInterface const& r ) const { return id() == r.id(); }
 	NetworkAddress address() const { return peekMessages.getEndpoint().getPrimaryAddress(); }
+	Optional<NetworkAddress> secondaryAddress() const {return peekMessages.getEndpoint().addresses.secondaryAddress;}
 	void initEndpoints() {
 		getQueuingMetrics.getEndpoint( TaskPriority::TLogQueuingMetrics );
 		popMessages.getEndpoint( TaskPriority::TLogPop );

--- a/fdbserver/TLogInterface.h
+++ b/fdbserver/TLogInterface.h
@@ -58,7 +58,7 @@ struct TLogInterface {
 	std::string toString() const { return id().shortString(); }
 	bool operator == ( TLogInterface const& r ) const { return id() == r.id(); }
 	NetworkAddress address() const { return peekMessages.getEndpoint().getPrimaryAddress(); }
-	Optional<NetworkAddress> secondaryAddress() const {return peekMessages.getEndpoint().addresses.secondaryAddress;}
+	Optional<NetworkAddress> secondaryAddress() const { return peekMessages.getEndpoint().addresses.secondaryAddress; }
 	void initEndpoints() {
 		getQueuingMetrics.getEndpoint( TaskPriority::TLogQueuingMetrics );
 		popMessages.getEndpoint( TaskPriority::TLogPop );

--- a/fdbserver/WorkerInterface.actor.h
+++ b/fdbserver/WorkerInterface.actor.h
@@ -67,6 +67,7 @@ struct WorkerInterface {
 
 	UID id() const { return tLog.getEndpoint().token; }
 	NetworkAddress address() const { return tLog.getEndpoint().getPrimaryAddress(); }
+	Optional<NetworkAddress> secondaryAddress() const { return tLog.getEndpoint().addresses.secondaryAddress; }
 
 	WorkerInterface() {}
 	WorkerInterface( const LocalityData& locality ) : locality( locality ) {}

--- a/fdbserver/workloads/ConsistencyCheck.actor.cpp
+++ b/fdbserver/workloads/ConsistencyCheck.actor.cpp
@@ -1350,7 +1350,8 @@ struct ConsistencyCheckWorkload : TestWorkload
 						TraceEvent("ConsistencyCheck_RebootProcess")
 						    .detail("Address",
 						            itr->interf.address()) // worker's primary address (i.e., the first address)
-						    .detail("ProcessAddress", p->address)
+						    .detail("ProcessPrimaryAddress", p->address)
+							.detail("ProcessAddresses", p->addresses.toString())
 						    .detail("DataStoreID", id)
 						    .detail("Protected", g_simulator.protectedAddresses.count(itr->interf.address()))
 						    .detail("Reliable", p->isReliable())

--- a/fdbserver/workloads/ConsistencyCheck.actor.cpp
+++ b/fdbserver/workloads/ConsistencyCheck.actor.cpp
@@ -1170,9 +1170,9 @@ struct ConsistencyCheckWorkload : TestWorkload
 	ACTOR Future<bool> checkForExtraDataStores(Database cx, ConsistencyCheckWorkload *self) {
 		state vector<WorkerDetails> workers = wait( getWorkers( self->dbInfo ) );
 		state vector<StorageServerInterface> storageServers = wait( getStorageServers( cx ) );
+		state std::vector<WorkerInterface> coordWorkers = wait(getCoordWorkers(cx, self->dbInfo));
 		auto& db = self->dbInfo->get();
 		state std::vector<TLogInterface> logs = db.logSystemConfig.allPresentLogs();
-		state std::vector<WorkerInterface> coordWorkers = wait(getCoordWorkers(cx, self->dbInfo));
 
 		state std::vector<WorkerDetails>::iterator itr;
 		state bool foundExtraDataStore = false;

--- a/fdbserver/workloads/ConsistencyCheck.actor.cpp
+++ b/fdbserver/workloads/ConsistencyCheck.actor.cpp
@@ -295,7 +295,6 @@ struct ConsistencyCheckWorkload : TestWorkload
 					}
 
 					wait(::success(self->checkForStorage(cx, configuration, self)));
-					// wait(::success(self->waitForUnreliableExtraStoreReboot(cx, self)));
 					wait(::success(self->checkForExtraDataStores(cx, self)));
 
 					//Check that each machine is operating as its desired class
@@ -1171,108 +1170,6 @@ struct ConsistencyCheckWorkload : TestWorkload
 		return true;
 	}
 
-	ACTOR Future<bool> waitForUnreliableExtraStoreReboot(Database cx, ConsistencyCheckWorkload* self) {
-		state int waitCount = 0;
-		loop {
-			state std::vector<WorkerDetails> workers = wait(getWorkers(self->dbInfo));
-			state std::vector<StorageServerInterface> storageServers = wait(getStorageServers(cx));
-			state std::vector<WorkerInterface> coordWorkers = wait(getCoordWorkers(cx, self->dbInfo));
-			auto& db = self->dbInfo->get();
-			state std::vector<TLogInterface> logs = db.logSystemConfig.allPresentLogs();
-
-			state std::vector<WorkerDetails>::iterator itr;
-			state bool foundExtraDataStore = false;
-			state std::vector<struct ProcessInfo*> protectedProcessesToKill;
-
-			state std::map<NetworkAddress, std::set<UID>> statefulProcesses;
-			for (const auto& ss : storageServers) {
-				statefulProcesses[ss.address()].insert(ss.id());
-				// Add both addresses so that we will not mistakenly trigger ConsistencyCheck_ExtraDataStore
-				if (ss.secondaryAddress().present()) {
-					statefulProcesses[ss.secondaryAddress().get()].insert(ss.id());
-				}
-				TraceEvent(SevCCheckInfo, "StatefulProcess")
-				    .detail("StorageServer", ss.id())
-				    .detail("PrimaryAddress", ss.address().toString())
-				    .detail("SecondaryAddress",
-				            ss.secondaryAddress().present() ? ss.secondaryAddress().get().toString() : "Unset");
-			}
-			for (const auto& log : logs) {
-				statefulProcesses[log.address()].insert(log.id());
-				if (log.secondaryAddress().present()) {
-					statefulProcesses[log.secondaryAddress().get()].insert(log.id());
-				}
-				TraceEvent(SevCCheckInfo, "StatefulProcess")
-				    .detail("Log", log.id())
-				    .detail("PrimaryAddress", log.address().toString())
-				    .detail("SecondaryAddress",
-				            log.secondaryAddress().present() ? log.secondaryAddress().get().toString() : "Unset");
-			}
-			// Coordinators are also stateful processes
-			for (const auto& cWorker : coordWorkers) {
-				statefulProcesses[cWorker.address()].insert(cWorker.id());
-				if (cWorker.secondaryAddress().present()) {
-					statefulProcesses[cWorker.secondaryAddress().get()].insert(cWorker.id());
-				}
-				TraceEvent(SevCCheckInfo, "StatefulProcess")
-				    .detail("Coordinator", cWorker.id())
-				    .detail("PrimaryAddress", cWorker.address().toString())
-				    .detail("SecondaryAddress", cWorker.secondaryAddress().present()
-				                                    ? cWorker.secondaryAddress().get().toString()
-				                                    : "Unset");
-			}
-
-			// Wait for extra store process that is unreliable (i.e., in the process of rebooting) to finish; Otherwise,
-			// the test will try to kill the extra store process which may be protected. This causes failure.
-			state bool protectedExtraStoreUnreliable = false;
-
-			for (itr = workers.begin(); itr != workers.end(); ++itr) {
-				ErrorOr<Standalone<VectorRef<UID>>> stores =
-				    wait(itr->interf.diskStoreRequest.getReplyUnlessFailedFor(DiskStoreRequest(false), 2, 0));
-				if (stores.isError()) {
-					TraceEvent("ConsistencyCheck_GetDataStoreFailure")
-					    .error(stores.getError())
-					    .detail("Address", itr->interf.address());
-					self->testFailure("Failed to get data stores");
-					return false;
-				}
-
-				TraceEvent(SevCCheckInfo, "CheckProtectedExtraStoreRebootProgress")
-				    .detail("Worker", itr->interf.id().toString())
-				    .detail("PrimaryAddress", itr->interf.address().toString())
-				    .detail("SecondaryAddress", itr->interf.secondaryAddress().present()
-				                                    ? itr->interf.secondaryAddress().get().toString()
-				                                    : "Unset");
-				for (const auto& id : stores.get()) {
-					if (statefulProcesses[itr->interf.address()].count(id)) {
-						continue;
-					} else {
-						if (g_network->isSimulated()) {
-							auto p = g_simulator.getProcessByAddress(itr->interf.address());
-							if (g_simulator.protectedAddresses.count(p->address) && !p->isReliable()) {
-								protectedExtraStoreUnreliable = true;
-								break;
-							}
-						}
-					}
-				}
-				if (protectedExtraStoreUnreliable) {
-					break;
-				}
-			}
-			if (protectedExtraStoreUnreliable) {
-				wait(delay(10.0));
-				waitCount++;
-			}
-			if (waitCount > 20) {
-				TraceEvent(SevError, "ProtectedExtraStoreUnreliableStuck")
-				    .detail("ExpectedBehavior", "Extra store should be cleaned up after process reboot");
-				break;
-			}
-		}
-		return waitCount <= 20;
-	}
-
 	ACTOR Future<bool> checkForExtraDataStores(Database cx, ConsistencyCheckWorkload *self) {
 		state std::vector<WorkerDetails> workers = wait(getWorkers(self->dbInfo));
 		state std::vector<StorageServerInterface> storageServers = wait(getStorageServers(cx));
@@ -1287,7 +1184,7 @@ struct ConsistencyCheckWorkload : TestWorkload
 		state std::map<NetworkAddress, std::set<UID>> statefulProcesses;
 		for (const auto& ss : storageServers) {
 			statefulProcesses[ss.address()].insert(ss.id());
-			// Add both addresses so that we will not mistakenly trigger ConsistencyCheck_ExtraDataStore
+			// A process may have two addresses (same ip, different ports)
 			if (ss.secondaryAddress().present()) {
 				statefulProcesses[ss.secondaryAddress().get()].insert(ss.id());
 			}
@@ -1336,49 +1233,40 @@ struct ConsistencyCheckWorkload : TestWorkload
 			                                    ? itr->interf.secondaryAddress().get().toString()
 			                                    : "Unset");
 			for (const auto& id : stores.get()) {
-				// if (statefulProcesses[itr->interf.address()].count(id)) {
-				// 	continue;
-				// }
-				if(!statefulProcesses[itr->interf.address()].count(id)) {
-					TraceEvent("ConsistencyCheck_ExtraDataStore").detail("Address", itr->interf.address()).detail("DataStoreID", id);
-					if(g_network->isSimulated()) {
-						//FIXME: this is hiding the fact that we can recruit a new storage server on a location the has files left behind by a previous failure
-						// this means that the process is wasting disk space until the process is rebooting
-						ISimulator::ProcessInfo* p = g_simulator.getProcessByAddress(itr->interf.address());
-						ISimulator::ProcessInfo* p2 = nullptr;
-						if (itr->interf.secondaryAddress().present()) {
-							p2 = g_simulator.getProcessByAddress(itr->interf.secondaryAddress().get());
-						}
-						// Note: itr->interf.address() may not equal to p->address() because role's endpoint's primary
-						// addr can be swapped by choosePrimaryAddress() based on its peer's tls config.
-						TraceEvent("ConsistencyCheck_RebootProcess")
-						    .detail("Address",
-						            itr->interf.address()) // worker's primary address (i.e., the first address)
-						    .detail("ProcessPrimaryAddress", p->address)
-							.detail("ProcessAddresses", p->addresses.toString())
-							.detail("ProcessAtPrimaryAddressIsReliable", p->isReliable())
-							.detail("ProcessAtSecondaryAddressIsReliable", p2 != nullptr ? (p2->isReliable() ? "True" : "False") : "unset")
-						    .detail("DataStoreID", id)
-						    .detail("Protected", g_simulator.protectedAddresses.count(itr->interf.address()))
-						    .detail("Reliable", p->isReliable())
-						    .detail("ReliableInfo", p->getReliableInfo())
-						    .detail("KillOrRebootProcess", p->address);
-						if(p->isReliable()) {
-							g_simulator.rebootProcess(p, ISimulator::RebootProcess);
-						} else {
-							g_simulator.killProcess(p, ISimulator::KillInstantly);
-						}
-					}
-
-					foundExtraDataStore = true;
+				if (statefulProcesses[itr->interf.address()].count(id)) {
+					continue;
 				}
+				// For extra data store
+				TraceEvent("ConsistencyCheck_ExtraDataStore")
+				    .detail("Address", itr->interf.address())
+				    .detail("DataStoreID", id);
+				if (g_network->isSimulated()) {
+					// FIXME: this is hiding the fact that we can recruit a new storage server on a location the has
+					// files left behind by a previous failure
+					// this means that the process is wasting disk space until the process is rebooting
+					ISimulator::ProcessInfo* p = g_simulator.getProcessByAddress(itr->interf.address());
+					// Note: itr->interf.address() may not equal to p->address() because role's endpoint's primary
+					// addr can be swapped by choosePrimaryAddress() based on its peer's tls config.
+					TraceEvent("ConsistencyCheck_RebootProcess")
+					    .detail("Address",
+					            itr->interf.address()) // worker's primary address (i.e., the first address)
+					    .detail("ProcessPrimaryAddress", p->address)
+					    .detail("ProcessAddresses", p->addresses.toString())
+					    .detail("DataStoreID", id)
+					    .detail("Protected", g_simulator.protectedAddresses.count(itr->interf.address()))
+					    .detail("Reliable", p->isReliable())
+					    .detail("ReliableInfo", p->getReliableInfo())
+					    .detail("KillOrRebootProcess", p->address);
+					if (p->isReliable()) {
+						g_simulator.rebootProcess(p, ISimulator::RebootProcess);
+					} else {
+						g_simulator.killProcess(p, ISimulator::KillInstantly);
+					}
+				}
+
+				foundExtraDataStore = true;
 			}
 		}
-
-		// kill or reboot protected process
-		// for () {
-
-		// }
 
 		if(foundExtraDataStore) {
 			self->testFailure("Extra data stores present on workers");

--- a/fdbserver/workloads/RemoveServersSafely.actor.cpp
+++ b/fdbserver/workloads/RemoveServersSafely.actor.cpp
@@ -113,14 +113,14 @@ struct RemoveServersSafelyWorkload : TestWorkload {
 			toKill2.insert(processSet.begin(), processSet.end());
 		}
 
-		std::vector<NetworkAddress> disableAddrs1;
+		// std::vector<NetworkAddress> disableAddrs1;
 		for( AddressExclusion ex : toKill1 ) {
 			AddressExclusion machineIp(ex.ip);
 			ASSERT(machine_ids.count(machineIp));
 			g_simulator.disableSwapToMachine(machine_ids[machineIp]);
 		}
 
-		std::vector<NetworkAddress> disableAddrs2;
+		// std::vector<NetworkAddress> disableAddrs2;
 		for( AddressExclusion ex : toKill2 ) {
 			AddressExclusion machineIp(ex.ip);
 			ASSERT(machine_ids.count(machineIp));
@@ -224,6 +224,8 @@ struct RemoveServersSafelyWorkload : TestWorkload {
 		return procArray;
 	}
 
+	// Return processes that are intersection of killAddrs and allServers and that are safe to kill together;
+	// killAddrs does not guarantee the addresses are safe to kill simultaneously.
 	virtual std::vector<ISimulator::ProcessInfo*> protectServers(std::set<AddressExclusion> const& killAddrs)
 	{
 		std::vector<ISimulator::ProcessInfo*>	processes;
@@ -309,7 +311,7 @@ struct RemoveServersSafelyWorkload : TestWorkload {
 			TraceEvent("RemoveAndKill").detail("Step", "include all first").detail("KillTotal", toKill1.size()).detail("ToKill", describe(toKill1)).detail("ClusterAvailable", g_simulator.isAvailable());
 			wait( includeServers( cx, vector<AddressExclusion>(1) ) );
 			self->includeAddresses(toKill1);
-			TraceEvent("RemoveAndKill").detail("Step", "included all first").detail("KillTotal", toKill1.size()).detail("ToKill", describe(toKill1)).detail("ClusterAvailable", g_simulator.isAvailable());
+			//TraceEvent("RemoveAndKill").detail("Step", "included all first").detail("KillTotal", toKill1.size()).detail("ToKill", describe(toKill1)).detail("ClusterAvailable", g_simulator.isAvailable());
 		}
 
 		// Get the list of protected servers
@@ -335,7 +337,7 @@ struct RemoveServersSafelyWorkload : TestWorkload {
 			TraceEvent("RemoveAndKill").detail("Step", "include all second").detail("KillTotal", toKill2.size()).detail("ToKill", describe(toKill2)).detail("ClusterAvailable", g_simulator.isAvailable());
 			wait( includeServers( cx, vector<AddressExclusion>(1) ) );
 			self->includeAddresses(toKill2);
-			TraceEvent("RemoveAndKill").detail("Step", "included all second").detail("KillTotal", toKill2.size()).detail("ToKill", describe(toKill2)).detail("ClusterAvailable", g_simulator.isAvailable());
+			//TraceEvent("RemoveAndKill").detail("Step", "included all second").detail("KillTotal", toKill2.size()).detail("ToKill", describe(toKill2)).detail("ClusterAvailable", g_simulator.isAvailable());
 		}
 
 		return Void();

--- a/fdbserver/workloads/RemoveServersSafely.actor.cpp
+++ b/fdbserver/workloads/RemoveServersSafely.actor.cpp
@@ -113,14 +113,12 @@ struct RemoveServersSafelyWorkload : TestWorkload {
 			toKill2.insert(processSet.begin(), processSet.end());
 		}
 
-		// std::vector<NetworkAddress> disableAddrs1;
 		for( AddressExclusion ex : toKill1 ) {
 			AddressExclusion machineIp(ex.ip);
 			ASSERT(machine_ids.count(machineIp));
 			g_simulator.disableSwapToMachine(machine_ids[machineIp]);
 		}
 
-		// std::vector<NetworkAddress> disableAddrs2;
 		for( AddressExclusion ex : toKill2 ) {
 			AddressExclusion machineIp(ex.ip);
 			ASSERT(machine_ids.count(machineIp));
@@ -311,7 +309,6 @@ struct RemoveServersSafelyWorkload : TestWorkload {
 			TraceEvent("RemoveAndKill").detail("Step", "include all first").detail("KillTotal", toKill1.size()).detail("ToKill", describe(toKill1)).detail("ClusterAvailable", g_simulator.isAvailable());
 			wait( includeServers( cx, vector<AddressExclusion>(1) ) );
 			self->includeAddresses(toKill1);
-			//TraceEvent("RemoveAndKill").detail("Step", "included all first").detail("KillTotal", toKill1.size()).detail("ToKill", describe(toKill1)).detail("ClusterAvailable", g_simulator.isAvailable());
 		}
 
 		// Get the list of protected servers
@@ -337,7 +334,6 @@ struct RemoveServersSafelyWorkload : TestWorkload {
 			TraceEvent("RemoveAndKill").detail("Step", "include all second").detail("KillTotal", toKill2.size()).detail("ToKill", describe(toKill2)).detail("ClusterAvailable", g_simulator.isAvailable());
 			wait( includeServers( cx, vector<AddressExclusion>(1) ) );
 			self->includeAddresses(toKill2);
-			//TraceEvent("RemoveAndKill").detail("Step", "included all second").detail("KillTotal", toKill2.size()).detail("ToKill", describe(toKill2)).detail("ClusterAvailable", g_simulator.isAvailable());
 		}
 
 		return Void();
@@ -495,8 +491,6 @@ struct RemoveServersSafelyWorkload : TestWorkload {
 			// Wait for removal to be safe
 			TraceEvent("RemoveAndKill", functionId).detail("Step", "Wait For Server Exclusion").detail("Addresses", describe(toKill)).detail("ClusterAvailable", g_simulator.isAvailable());
 			wait(success(checkForExcludingServers(cx, toKillArray, true /* wait for exclusion */)));
-			// TODO: We have to wait for faulty machine to die or reborn; otherwise,
-			// machine that is in failing due to injected fault may be chosen as coordinator.
 
 			TraceEvent("RemoveAndKill", functionId).detail("Step", "coordinators auto").detail("DesiredCoordinators", g_simulator.desiredCoordinators).detail("ClusterAvailable", g_simulator.isAvailable());
 

--- a/fdbserver/workloads/RemoveServersSafely.actor.cpp
+++ b/fdbserver/workloads/RemoveServersSafely.actor.cpp
@@ -500,8 +500,6 @@ struct RemoveServersSafelyWorkload : TestWorkload {
 
 			TraceEvent("RemoveAndKill", functionId).detail("Step", "coordinators auto").detail("DesiredCoordinators", g_simulator.desiredCoordinators).detail("ClusterAvailable", g_simulator.isAvailable());
 
-			// Ensure coordinators do not use faulty node
-			
 			// Setup the coordinators BEFORE the exclusion
 			// Otherwise, we may end up with NotEnoughMachinesForCoordinators
 			state int cycle=0;

--- a/fdbserver/workloads/RemoveServersSafely.actor.cpp
+++ b/fdbserver/workloads/RemoveServersSafely.actor.cpp
@@ -495,9 +495,13 @@ struct RemoveServersSafelyWorkload : TestWorkload {
 			// Wait for removal to be safe
 			TraceEvent("RemoveAndKill", functionId).detail("Step", "Wait For Server Exclusion").detail("Addresses", describe(toKill)).detail("ClusterAvailable", g_simulator.isAvailable());
 			wait(success(checkForExcludingServers(cx, toKillArray, true /* wait for exclusion */)));
+			// TODO: We have to wait for faulty machine to die or reborn; otherwise,
+			// machine that is in failing due to injected fault may be chosen as coordinator.
 
 			TraceEvent("RemoveAndKill", functionId).detail("Step", "coordinators auto").detail("DesiredCoordinators", g_simulator.desiredCoordinators).detail("ClusterAvailable", g_simulator.isAvailable());
 
+			// Ensure coordinators do not use faulty node
+			
 			// Setup the coordinators BEFORE the exclusion
 			// Otherwise, we may end up with NotEnoughMachinesForCoordinators
 			state int cycle=0;


### PR DESCRIPTION
Nightly correctness test found multiple failures on master commit `0e6ac08f268e0e6e51bb471d59c58b98423542c2`.

This is an attempt to fix the error on `DDBalanceAndRemove.txt ` test workload.

Command to reproduce the error `-r simulation --logsize 1024MiB -f foundationdb/tests/slow/DDBalanceAndRemove.txt -b on -s 948610707`

Failure diagnosis: Simulation test's consistency check reboots or kills worker that has extra data file left on disk (ConsistencyCheck_ExtraStore). If worker is reliable, it reboots the worker; otherwise, it kills the worker. In the test case, the worker with extra store was a SS, is in the process of being kill but has not been killed. Before consistency check identifies the worker and reboots it, another workload changes coordinators using AutoQuorum. The same worker was unfortunately picked as the only desired coordinator and put into `protected` state. When consistency check later identifies the worker and kills it, it triggers the assertion failure: cannot kill a process that is in `protected` state.

Fix: When ManagementAPI changes coordinator, it needs to filter out the unreliable workers in simulation mode. 