### PR TITLE
Add TLS Policy Failure count to ProcessMetrics and status json

### DIFF
--- a/documentation/sphinx/source/mr-status-json-schemas.rst.inc
+++ b/documentation/sphinx/source/mr-status-json-schemas.rst.inc
@@ -188,6 +188,9 @@
                },
                "megabits_received":{
                   "hz":0.0
+               },
+               "tls_policy_failures":{
+                  "hz":0.0
                }
             },
             "run_loop_busy":0.2 // fraction of time the run loop was busy

--- a/fdbclient/Schemas.cpp
+++ b/fdbclient/Schemas.cpp
@@ -209,9 +209,9 @@ const KeyRef JSONSchemas::statusSchema = LiteralStringRef(R"statusSchema(
                "megabits_received":{
                   "hz":0.0
                },
-							 "tls_policy_failures":{
-								 "hz":0.0
-							 },
+               "tls_policy_failures":{
+                 "hz":0.0
+               }
             },
             "run_loop_busy":0.2
          }

--- a/fdbclient/Schemas.cpp
+++ b/fdbclient/Schemas.cpp
@@ -208,7 +208,10 @@ const KeyRef JSONSchemas::statusSchema = LiteralStringRef(R"statusSchema(
                },
                "megabits_received":{
                   "hz":0.0
-               }
+               },
+							 "tls_policy_failures":{
+								 "hz":0
+							 },
             },
             "run_loop_busy":0.2
          }

--- a/fdbclient/Schemas.cpp
+++ b/fdbclient/Schemas.cpp
@@ -210,7 +210,7 @@ const KeyRef JSONSchemas::statusSchema = LiteralStringRef(R"statusSchema(
                   "hz":0.0
                },
 							 "tls_policy_failures":{
-								 "hz":0
+								 "hz":0.0
 							 },
             },
             "run_loop_busy":0.2

--- a/fdbserver/Status.actor.cpp
+++ b/fdbserver/Status.actor.cpp
@@ -773,6 +773,10 @@ ACTOR static Future<JsonBuilderObject> processStatusFetcher(
 				megabits_received.setKeyRawNumber("hz", processMetrics.getValue("MbpsReceived"));
 				networkObj["megabits_received"] = megabits_received;
 
+				JsonBuilderObject tls_policy_failures;
+				tls_policy_failures.setKeyRawNumber("hz", processMetrics.getValue("TLSPolicyFailures"));
+				networkObj["tls_policy_failures"] = tls_policy_failures;
+
 				statusObj["network"] = networkObj;
 
 				memoryObj.setKeyRawNumber("used_bytes", processMetrics.getValue("Memory"));

--- a/flow/SystemMonitor.cpp
+++ b/flow/SystemMonitor.cpp
@@ -101,7 +101,7 @@ SystemStatistics customSystemMonitor(std::string eventName, StatisticsState *sta
 				.detail("ConnectionsEstablished", (double) (netData.countConnEstablished - statState->networkState.countConnEstablished) / currentStats.elapsed)
 				.detail("ConnectionsClosed", ((netData.countConnClosedWithError - statState->networkState.countConnClosedWithError) + (netData.countConnClosedWithoutError - statState->networkState.countConnClosedWithoutError)) / currentStats.elapsed)
 				.detail("ConnectionErrors", (netData.countConnClosedWithError - statState->networkState.countConnClosedWithError) / currentStats.elapsed)
-				.detail("TLSPolicyFailures", (netData.countTLSPolicyFailures - statState->networkState.countTLSPolicyFailures))
+				.detail("TLSPolicyFailures", (netData.countTLSPolicyFailures - statState->networkState.countTLSPolicyFailures) / currentStats.elapsed)
 				.trackLatest(eventName);
 
 			TraceEvent("MemoryMetrics")

--- a/flow/SystemMonitor.cpp
+++ b/flow/SystemMonitor.cpp
@@ -101,6 +101,7 @@ SystemStatistics customSystemMonitor(std::string eventName, StatisticsState *sta
 				.detail("ConnectionsEstablished", (double) (netData.countConnEstablished - statState->networkState.countConnEstablished) / currentStats.elapsed)
 				.detail("ConnectionsClosed", ((netData.countConnClosedWithError - statState->networkState.countConnClosedWithError) + (netData.countConnClosedWithoutError - statState->networkState.countConnClosedWithoutError)) / currentStats.elapsed)
 				.detail("ConnectionErrors", (netData.countConnClosedWithError - statState->networkState.countConnClosedWithError) / currentStats.elapsed)
+				.detail("TLSPolicyFailures", (netData.countTLSPolicyFailures - statState->networkState.countTLSPolicyFailures))
 				.trackLatest(eventName);
 
 			TraceEvent("MemoryMetrics")

--- a/flow/SystemMonitor.h
+++ b/flow/SystemMonitor.h
@@ -80,6 +80,7 @@ struct NetworkData {
 	int64_t countConnEstablished;
 	int64_t countConnClosedWithError;
 	int64_t countConnClosedWithoutError;
+	int64_t countTLSPolicyFailures;
 	double countLaunchTime;
 	double countReactTime;
 
@@ -107,6 +108,7 @@ struct NetworkData {
 		countConnEstablished = Int64Metric::getValueOrDefault(LiteralStringRef("Net2.CountConnEstablished"));
 		countConnClosedWithError = Int64Metric::getValueOrDefault(LiteralStringRef("Net2.CountConnClosedWithError"));
 		countConnClosedWithoutError = Int64Metric::getValueOrDefault(LiteralStringRef("Net2.CountConnClosedWithoutError"));
+		countTLSPolicyFailures = Int64Metric::getValueOrDefault(LiteralStringRef("Net2.CountTLSPolicyFailures"));
 		countLaunchTime = DoubleMetric::getValueOrDefault(LiteralStringRef("Net2.CountLaunchTime"));
 		countReactTime = DoubleMetric::getValueOrDefault(LiteralStringRef("Net2.CountReactTime"));
 		countFileLogicalWrites = Int64Metric::getValueOrDefault(LiteralStringRef("AsyncFile.CountLogicalWrites"));


### PR DESCRIPTION
I didn't realize that status works via collecting traceevents from workers, so I'm trimming my plans down to just "hz", and the playbooks can link to a dashboard that aggregates TLSPolicyFailure trace events itself.

A trimmed status json from a failing process now looks like:
```
{
    "cluster" : {
        "processes" : {
            "bd91289b650802668e2217cc68f0463b" : {
                "address" : "127.0.0.1:5000:tls",
                "network" : {
                    "tls_errors" : {
                        "hz" : 0.4
                    }
                }
            }
        }
    }
}
```