### PR TITLE
Buggify upload delay when backup worker upload data to blob

### DIFF
--- a/fdbserver/BackupWorker.actor.cpp
+++ b/fdbserver/BackupWorker.actor.cpp
@@ -153,7 +153,8 @@ struct BackupData {
 			    .detail("Version", savedVersion);
 			return;
 		}
-		ASSERT_WE_THINK(backupEpoch == oldest);
+		// ASSERT will be fixed in PR#2642
+		// ASSERT_WE_THINK(backupEpoch == oldest);
 		const Tag popTag = logSystem.get()->getPseudoPopTag(tag, ProcessClass::BackupClass);
 		logSystem.get()->pop(savedVersion, popTag);
 	}

--- a/fdbserver/BackupWorker.actor.cpp
+++ b/fdbserver/BackupWorker.actor.cpp
@@ -153,7 +153,7 @@ struct BackupData {
 			    .detail("Version", savedVersion);
 			return;
 		}
-		// Q: Can backupEpoch < oldest ? If cannot, add an Assertion here
+		ASSERT_WE_THINK(backupEpoch == oldest);
 		const Tag popTag = logSystem.get()->getPseudoPopTag(tag, ProcessClass::BackupClass);
 		logSystem.get()->pop(savedVersion, popTag);
 	}
@@ -381,7 +381,7 @@ ACTOR Future<Void> addMutation(Reference<IBackupFile> logFile, VersionedMessage 
 }
 
 // Saves messages in the range of [0, numMsg) to a file and then remove these
-// messages. The file (name?) format is a sequence of (Version, sub#, msgSize, message).
+// messages. The file content format is a sequence of (Version, sub#, msgSize, message).
 // Note only ready backups are saved.
 ACTOR Future<Void> saveMutationsToFile(BackupData* self, Version popVersion, int numMsg) {
 	state int blockSize = SERVER_KNOBS->BACKUP_FILE_BLOCK_BYTES;
@@ -497,9 +497,7 @@ ACTOR Future<Void> uploadData(BackupData* self) {
 			return Void();
 		}
 
-		// Q: what lag Tlog has in the below comment? Will shorter delay pass consistency check?
-		// FIXME: knobify the delay of 10s. This delay is sensitive, as it is the
-		// lag TLog might have. Changing to 20s may fail consistency check.
+		// Too large uploadDelay will delay popping tLog data for too long.
 		state Future<Void> uploadDelay = delay(SERVER_KNOBS->BACKUP_UPLOAD_DELAY);
 
 		const Version maxPopVersion =
@@ -510,7 +508,7 @@ ACTOR Future<Void> uploadData(BackupData* self) {
 		} else {
 			state int numMsg = 0;
 			for (const auto& message : self->messages) {
-				// Q: Why would message.getVersion() > maxPopVersion?
+				// message may be prefetched in peek; uncommitted message should not be uploaded.
 				if (message.getVersion() > maxPopVersion) break;
 				popVersion = std::max(popVersion, message.getVersion());
 				numMsg++;

--- a/fdbserver/Knobs.cpp
+++ b/fdbserver/Knobs.cpp
@@ -367,6 +367,7 @@ ServerKnobs::ServerKnobs(bool randomize, ClientKnobs* clientKnobs, bool isSimula
 	init( BACKUP_TIMEOUT,                                        0.4 );
 	init( BACKUP_NOOP_POP_DELAY,                                 5.0 );
 	init( BACKUP_FILE_BLOCK_BYTES,                       1024 * 1024 );
+	init( BACKUP_UPLOAD_DELAY,                                  10.0 ); if( randomize && BUGGIFY ) BACKUP_UPLOAD_DELAY = deterministicRandom()->random01() * 20; // TODO: Increase delay range
 
 	//Cluster Controller
 	init( CLUSTER_CONTROLLER_LOGGING_DELAY,                      5.0 );

--- a/fdbserver/Knobs.h
+++ b/fdbserver/Knobs.h
@@ -304,6 +304,7 @@ public:
 	double BACKUP_TIMEOUT;  // master's reaction time for backup failure
 	double BACKUP_NOOP_POP_DELAY;
 	int BACKUP_FILE_BLOCK_BYTES;
+	double BACKUP_UPLOAD_DELAY;
 
 	//Cluster Controller
 	double CLUSTER_CONTROLLER_LOGGING_DELAY;

--- a/fdbserver/TagPartitionedLogSystem.actor.cpp
+++ b/fdbserver/TagPartitionedLogSystem.actor.cpp
@@ -260,6 +260,7 @@ struct TagPartitionedLogSystem : ILogSystem, ReferenceCounted<TagPartitionedLogS
 
 	bool hasPseudoLocality(int8_t locality) override { return pseudoLocalities.count(locality) > 0; }
 
+	// Return the min version of all pseudoLocalities, i.e., logRouter and backupTag
 	Version popPseudoLocalityTag(Tag tag, Version upTo) override {
 		ASSERT(isPseudoLocality(tag.locality) && hasPseudoLocality(tag.locality));
 


### PR DESCRIPTION
Right now, the upload delay is hard coded as 10 and comes with the comment that Buggify the delay will cause consistency check failure. 

This draft PR is to investigate why we cannot buggify it and then buggify it.