### PR TITLE
Performant restore [21/xx]: Enable assassination workload in restore test

### DIFF
--- a/fdbserver/RestoreWorker.actor.cpp
+++ b/fdbserver/RestoreWorker.actor.cpp
@@ -32,6 +32,7 @@
 #include "fdbclient/MutationList.h"
 #include "fdbclient/BackupContainer.h"
 #include "fdbrpc/IAsyncFile.h"
+#include "fdbrpc/simulator.h"
 #include "flow/genericactors.actor.h"
 #include "flow/Hash3.h"
 #include "flow/ActorCollection.h"

--- a/fdbserver/RestoreWorker.actor.cpp
+++ b/fdbserver/RestoreWorker.actor.cpp
@@ -312,7 +312,13 @@ ACTOR Future<Void> _restoreWorker(Database cx, LocalityData locality) {
 		if (addresses.secondaryAddress.present()) {
 			g_simulator.protectedAddresses.insert(addresses.secondaryAddress.get());
 		}
-		TraceEvent("ProtectRestoreWorker").detail("Address", addresses.toString()).backtrace();
+		ISimulator::ProcessInfo* p = g_simulator.getProcessByAddress(myWorkerInterf.address());
+		TraceEvent("ProtectRestoreWorker")
+		    .detail("Address", addresses.toString())
+		    .detail("IsReliable", p->isReliable())
+		    .detail("ReliableInfo", p->getReliableInfo())
+		    .backtrace();
+		ASSERT(p->isReliable());
 	}
 
 	TraceEvent("FastRestoreWorkerKnobs", myWorkerInterf.id())

--- a/tests/slow/ParallelRestoreCorrectnessAtomicOpTinyData.txt
+++ b/tests/slow/ParallelRestoreCorrectnessAtomicOpTinyData.txt
@@ -33,18 +33,19 @@ testTitle=BackupAndParallelRestoreWithAtomicOp
 ;    meanDelay=90.0
 ;    testDuration=90.0
 
-; Do NOT consider machine crash yet
-;    testName=Attrition
-;    machinesToKill=10
-;    machinesToLeave=3
-;    reboot=true
-;    testDuration=90.0
+; Do NOT kill restore worker process yet
+; Kill other process to ensure restore works when FDB cluster has faults
+    testName=Attrition
+    machinesToKill=10
+    machinesToLeave=3
+    reboot=true
+    testDuration=90.0
 
-;    testName=Attrition
-;    machinesToKill=10
-;    machinesToLeave=3
-;    reboot=true
-;    testDuration=90.0
+    testName=Attrition
+    machinesToKill=10
+    machinesToLeave=3
+    reboot=true
+    testDuration=90.0
 
 ; Disable buggify for parallel restore
 ;buggify=on

--- a/tests/slow/ParallelRestoreCorrectnessCycle.txt
+++ b/tests/slow/ParallelRestoreCorrectnessCycle.txt
@@ -55,18 +55,19 @@ testTitle=BackupAndRestore
  ;    meanDelay=90.0
  ;    testDuration=90.0
 
- ; Do NOT consider machine crash yet
- ;    testName=Attrition
- ;    machinesToKill=10
- ;    machinesToLeave=3
- ;    reboot=true
- ;    testDuration=90.0
+ ; Do NOT kill restore worker process yet
+ ; Kill other process to ensure restore works when FDB cluster has faults
+     testName=Attrition
+     machinesToKill=10
+     machinesToLeave=3
+     reboot=true
+     testDuration=90.0
 
- ;    testName=Attrition
- ;    machinesToKill=10
- ;    machinesToLeave=3
- ;    reboot=true
- ;    testDuration=90.0
+     testName=Attrition
+     machinesToKill=10
+     machinesToLeave=3
+     reboot=true
+     testDuration=90.0
 
  ; Disable buggify for parallel restore
  ;buggify=off


### PR DESCRIPTION
We want to test if the new restore works well when the destination FDB cluster has failures.

We adds restore workers into protected address list to prevent them from being killed, since the current restore assumes its process does not crash.

This allows us to enable assassination workload to kill other processes in simulation.
