### PR TITLE
Performant restore [22/xx]: Introduce multiple cycle tests for the restore

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -209,6 +209,7 @@ if(WITH_PYTHON)
   add_fdb_test(TEST_FILES slow/ddbalance.txt)
   add_fdb_test(TEST_FILES slow/ParallelRestoreCorrectnessAtomicOpTinyData.txt)
   add_fdb_test(TEST_FILES slow/ParallelRestoreCorrectnessCycle.txt)
+  add_fdb_test(TEST_FILES slow/ParallelRestoreCorrectnessMultiCycles.txt)
   # Note that status tests are not deterministic.
   add_fdb_test(TEST_FILES status/invalid_proc_addresses.txt)
   add_fdb_test(TEST_FILES status/local_6_machine_no_replicas_remain.txt)

--- a/tests/slow/ParallelRestoreCorrectnessMultiCycles.txt
+++ b/tests/slow/ParallelRestoreCorrectnessMultiCycles.txt
@@ -54,18 +54,19 @@ testTitle=BackupAndRestore
  ;    meanDelay=90.0
  ;    testDuration=90.0
 
- ; Do NOT consider machine crash yet
- ;    testName=Attrition
- ;    machinesToKill=10
- ;    machinesToLeave=3
- ;    reboot=true
- ;    testDuration=90.0
+ ; Do NOT kill restore worker process yet
+ ; Kill other process to ensure restore works when FDB cluster has faults
+     testName=Attrition
+     machinesToKill=10
+     machinesToLeave=3
+     reboot=true
+     testDuration=90.0
 
- ;    testName=Attrition
- ;    machinesToKill=10
- ;    machinesToLeave=3
- ;    reboot=true
- ;    testDuration=90.0
+     testName=Attrition
+     machinesToKill=10
+     machinesToLeave=3
+     reboot=true
+     testDuration=90.0
 
  ; Disable buggify for parallel restore
  ;buggify=off

--- a/tests/slow/ParallelRestoreCorrectnessMultiCycles.txt
+++ b/tests/slow/ParallelRestoreCorrectnessMultiCycles.txt
@@ -1,0 +1,75 @@
+testTitle=BackupAndRestore
+     testName=Cycle
+ ;    nodeCount=30000
+     nodeCount=1000
+     transactionsPerSecond=2500.0
+     testDuration=30.0
+     expectedRate=0
+     clearAfterTest=false
+ 	 keyPrefix=!
+
+     testName=Cycle
+     nodeCount=1000
+     transactionsPerSecond=2500.0
+     testDuration=30.0
+     expectedRate=0
+     clearAfterTest=false
+ 	 keyPrefix=z
+
+     testName=Cycle
+     nodeCount=1000
+     transactionsPerSecond=2500.0
+     testDuration=30.0
+     expectedRate=0
+     clearAfterTest=false
+ 	 keyPrefix=A
+
+     testName=Cycle
+     nodeCount=1000
+     transactionsPerSecond=2500.0
+     testDuration=30.0
+     expectedRate=0
+     clearAfterTest=false
+  	 keyPrefix=Z
+
+ ; Each testName=RunRestoreWorkerWorkload creates a restore worker
+ ; We need at least 3 restore workers: master, loader, and applier
+     testName=RunRestoreWorkerWorkload
+
+ ; Test case for parallel restore
+     testName=BackupAndParallelRestoreCorrectness
+     backupAfter=10.0
+     restoreAfter=60.0
+     clearAfterTest=false
+     simBackupAgents=BackupToFile
+ ; backupRangesCount<0 means backup the entire normal keyspace
+     backupRangesCount=-1
+ ; TODO: Support abortAndRestartAfter test by commenting it out
+     abortAndRestartAfter=0
+
+     testName=RandomClogging
+     testDuration=90.0
+
+ ;    testName=Rollback
+ ;    meanDelay=90.0
+ ;    testDuration=90.0
+
+ ; Do NOT consider machine crash yet
+ ;    testName=Attrition
+ ;    machinesToKill=10
+ ;    machinesToLeave=3
+ ;    reboot=true
+ ;    testDuration=90.0
+
+ ;    testName=Attrition
+ ;    machinesToKill=10
+ ;    machinesToLeave=3
+ ;    reboot=true
+ ;    testDuration=90.0
+
+ ; Disable buggify for parallel restore
+ ;buggify=off
+ ;testDuration=360000 ;not work
+ ;timeout is in seconds
+ timeout=360000
+

--- a/tests/slow/ParallelRestoreCorrectnessMultiCycles.txt
+++ b/tests/slow/ParallelRestoreCorrectnessMultiCycles.txt
@@ -6,7 +6,7 @@ testTitle=BackupAndRestore
      testDuration=30.0
      expectedRate=0
      clearAfterTest=false
- 	 keyPrefix=!
+     keyPrefix=!
 
      testName=Cycle
      nodeCount=1000
@@ -14,7 +14,7 @@ testTitle=BackupAndRestore
      testDuration=30.0
      expectedRate=0
      clearAfterTest=false
- 	 keyPrefix=z
+     keyPrefix=z
 
      testName=Cycle
      nodeCount=1000
@@ -22,7 +22,7 @@ testTitle=BackupAndRestore
      testDuration=30.0
      expectedRate=0
      clearAfterTest=false
- 	 keyPrefix=A
+     keyPrefix=A
 
      testName=Cycle
      nodeCount=1000
@@ -30,7 +30,7 @@ testTitle=BackupAndRestore
      testDuration=30.0
      expectedRate=0
      clearAfterTest=false
-  	 keyPrefix=Z
+     keyPrefix=Z
 
  ; Each testName=RunRestoreWorkerWorkload creates a restore worker
  ; We need at least 3 restore workers: master, loader, and applier


### PR DESCRIPTION
This aims to increase the test pressure on the new performance restore system.

- [x] Once this PR passes the test without attrition workload, we should enable the attrition workload before merging it.