### PR TITLE
Performant restore [23/xx]: Enable Rollback test workload and abortAndRestartAfter option for restore tests

### DIFF
--- a/tests/slow/ParallelRestoreCorrectnessAtomicOpTinyData.txt
+++ b/tests/slow/ParallelRestoreCorrectnessAtomicOpTinyData.txt
@@ -29,9 +29,9 @@ testTitle=BackupAndParallelRestoreWithAtomicOp
     testName=RandomClogging
     testDuration=90.0
 
-;    testName=Rollback
-;    meanDelay=90.0
-;    testDuration=90.0
+    testName=Rollback
+    meanDelay=90.0
+    testDuration=90.0
 
 ; Do NOT kill restore worker process yet
 ; Kill other process to ensure restore works when FDB cluster has faults

--- a/tests/slow/ParallelRestoreCorrectnessCycle.txt
+++ b/tests/slow/ParallelRestoreCorrectnessCycle.txt
@@ -9,30 +9,6 @@ testTitle=BackupAndRestore
      clearAfterTest=false
  ;	keyPrefix=!
 
- ;    testName=Cycle
- ;;    nodeCount=1000
- ;    transactionsPerSecond=2500.0
- ;    testDuration=30.0
- ;    expectedRate=0
- ;    clearAfterTest=false
- ;	keyPrefix=z
- ;
- ;    testName=Cycle
- ;;    nodeCount=1000
- ;    transactionsPerSecond=2500.0
- ;    testDuration=30.0
- ;    expectedRate=0
- ;    clearAfterTest=false
- ;	keyPrefix=A
- ;
- ;    testName=Cycle
- ;;    nodeCount=1000
- ;    transactionsPerSecond=2500.0
- ;    testDuration=30.0
- ;    expectedRate=0
- ;    clearAfterTest=false
- ;	keyPrefix=Z
-
  ; Each testName=RunRestoreWorkerWorkload creates a restore worker
  ; We need at least 3 restore workers: master, loader, and applier
      testName=RunRestoreWorkerWorkload
@@ -45,8 +21,6 @@ testTitle=BackupAndRestore
      simBackupAgents=BackupToFile
  ; backupRangesCount<0 means backup the entire normal keyspace
      backupRangesCount=-1
- ; TODO: Support abortAndRestartAfter test by commenting it out
-     abortAndRestartAfter=0
 
      testName=RandomClogging
      testDuration=90.0

--- a/tests/slow/ParallelRestoreCorrectnessCycle.txt
+++ b/tests/slow/ParallelRestoreCorrectnessCycle.txt
@@ -25,9 +25,9 @@ testTitle=BackupAndRestore
      testName=RandomClogging
      testDuration=90.0
 
- ;    testName=Rollback
- ;    meanDelay=90.0
- ;    testDuration=90.0
+     testName=Rollback
+     meanDelay=90.0
+     testDuration=90.0
 
  ; Do NOT kill restore worker process yet
  ; Kill other process to ensure restore works when FDB cluster has faults

--- a/tests/slow/ParallelRestoreCorrectnessMultiCycles.txt
+++ b/tests/slow/ParallelRestoreCorrectnessMultiCycles.txt
@@ -44,15 +44,13 @@ testTitle=BackupAndRestore
      simBackupAgents=BackupToFile
  ; backupRangesCount<0 means backup the entire normal keyspace
      backupRangesCount=-1
- ; TODO: Support abortAndRestartAfter test by commenting it out
-     abortAndRestartAfter=0
 
      testName=RandomClogging
      testDuration=90.0
 
- ;    testName=Rollback
- ;    meanDelay=90.0
- ;    testDuration=90.0
+     testName=Rollback
+     meanDelay=90.0
+     testDuration=90.0
 
  ; Do NOT kill restore worker process yet
  ; Kill other process to ensure restore works when FDB cluster has faults


### PR DESCRIPTION
For each parallel restore tests, enable Rollback test workload and abortAndRestartAfter option in BackupAndParallelRestoreCorrectness. 

This is an effort to improve test coverage for the new restore system.