### PR TITLE
Performance improvements to the transaction profiling analyzer

### DIFF
--- a/contrib/transaction_profiling_analyzer/transaction_profiling_analyzer.py
+++ b/contrib/transaction_profiling_analyzer/transaction_profiling_analyzer.py
@@ -524,18 +524,25 @@ class RangeCounter(object):
 
     def _insert_range(self, start_key, end_key):
         keys = self.ranges.keys()
-        start_pos = bisect_right(keys, start_key)-1
-        end_pos = bisect_right(keys, end_key)-1
+        start_pos = self.ranges.bisect_right(start_key)-1
+        end_pos = self.ranges.bisect_right(end_key)-1
 
-        start_count = self.ranges[keys[start_pos]]
-        end_count = self.ranges[keys[end_pos]]
+        exact_end = end_key == keys[end_pos]
+        if not exact_end:
+            end_count = self.ranges[keys[end_pos]]
+            end_pos += 1
 
-        end_pos = bisect_left(keys, end_key)
         for k in self.ranges.islice(start_pos+1, end_pos):
             self.ranges[k] += 1
 
-        self.ranges[start_key] = start_count+1
-        self.ranges[end_key] = end_count
+        if keys[start_pos] == start_key:
+            self.ranges[start_key] += 1
+        else:
+            self.ranges[start_key] = self.ranges[keys[start_pos]] + 1
+
+        if not exact_end:
+            self.ranges[end_key] = end_count
+
 
     def get_count_for_key(self, key):
         if key in self.ranges:

--- a/contrib/transaction_profiling_analyzer/transaction_profiling_analyzer.py
+++ b/contrib/transaction_profiling_analyzer/transaction_profiling_analyzer.py
@@ -411,7 +411,7 @@ class TransactionInfoLoader(object):
         else:
             end_key = self.client_latency_end_key_selector
 
-        valid_transaction_infos = 0
+        transaction_infos = 0
         invalid_transaction_infos = 0
 
         def build_client_transaction_info(v):
@@ -443,11 +443,12 @@ class TransactionInfoLoader(object):
                             info = build_client_transaction_info(v)
                             if info.has_types():
                                 buffer.append(info)
-                            valid_transaction_infos += 1
                         except UnsupportedProtocolVersionError as e:
                             invalid_transaction_infos += 1
                         except ValueError:
                             invalid_transaction_infos += 1
+
+                        transaction_infos += 1
                     else:
                         if chunk_num == 1:
                             # first chunk
@@ -473,14 +474,15 @@ class TransactionInfoLoader(object):
                                     info = build_client_transaction_info(b''.join([chunk.value for chunk in c_list]))
                                     if info.has_types():
                                         buffer.append(info)
-                                    valid_transaction_infos += 1
                                 except UnsupportedProtocolVersionError as e:
                                     invalid_transaction_infos += 1
                                 except ValueError:
                                     invalid_transaction_infos += 1
+
+                                transaction_infos += 1
                             self._check_and_adjust_chunk_cache_size()
-                    if (valid_transaction_infos + invalid_transaction_infos) % 1000 == 0:
-                        print("Processed valid: %d, invalid: %d" % (valid_transaction_infos, invalid_transaction_infos))
+                    if transaction_infos % 1000 == 0:
+                        print("Processed %d transactions, %d invalid" % (transaction_infos, invalid_transaction_infos))
                 if found == 0:
                     more = False
             except fdb.FDBError as e:
@@ -492,13 +494,15 @@ class TransactionInfoLoader(object):
             for item in buffer:
                 yield item
 
+        print("Processed %d transactions, %d invalid\n" % (transaction_infos, invalid_transaction_infos))
+
 
 def has_sortedcontainers():
     try:
         import sortedcontainers
         return True
     except ImportError:
-        logger.warn("Can't find sortedcontainers so disabling RangeCounter")
+        logger.warn("Can't find sortedcontainers so disabling ReadCounter")
         return False
 
 
@@ -510,107 +514,125 @@ def has_dateparser():
         logger.warn("Can't find dateparser so disabling human date parsing")
         return False
 
+def wait_for_shard_addresses(ranges, shard_finder, key_idx, addr_idx):
+    for index in range(len(ranges)):
+        item = ranges[index]
+        if item[addr_idx] is not None:
+            while True:
+                try:
+                    ranges[index] = item[0:addr_idx] + ([a.decode('ascii') for a in item[addr_idx].wait()],) + item[addr_idx+1:]
+                    break
+                except fdb.FDBError as e:
+                    ranges[index] = item[0:addr_idx] + (shard_finder.get_addresses_for_key(item[key_idx]),) + item[addr_idx+1:]
 
-class RangeCounter(object):
-    def __init__(self, k):
-        self.k = k
+class ReadCounter(object):
+    def __init__(self):
         from sortedcontainers import SortedDict
-        self.ranges = SortedDict()
-        self.ranges[b''] = 0
+        self.reads = SortedDict()
+        self.reads[b''] = [0, 0]
+
+        self.read_counts = {}
+        self.hit_count=0
 
     def process(self, transaction_info):
+        for get in transaction_info.gets:
+            self._insert_read(get.key, None)
         for get_range in transaction_info.get_ranges:
-            self._insert_range(get_range.key_range.start_key, get_range.key_range.end_key)
+            self._insert_read(get_range.key_range.start_key, get_range.key_range.end_key)
 
-    def _insert_range(self, start_key, end_key):
-        keys = self.ranges.keys()
-        start_pos = self.ranges.bisect_right(start_key)-1
-        end_pos = self.ranges.bisect_right(end_key)-1
+    def _insert_read(self, start_key, end_key):
+        self.read_counts.setdefault((start_key, end_key), 0)
+        self.read_counts[(start_key, end_key)] += 1
 
-        exact_end = end_key == keys[end_pos]
-        if not exact_end:
-            end_count = self.ranges[keys[end_pos]]
-            end_pos += 1
-
-        for k in self.ranges.islice(start_pos+1, end_pos):
-            self.ranges[k] += 1
-
-        if keys[start_pos] == start_key:
-            self.ranges[start_key] += 1
+        self.reads.setdefault(start_key, [0, 0])[0] += 1
+        if end_key is not None:
+            self.reads.setdefault(end_key, [0, 0])[1] += 1
         else:
-            self.ranges[start_key] = self.ranges[keys[start_pos]] + 1
+            self.reads.setdefault(start_key+b'\x00', [0, 0])[1] += 1
 
-        if not exact_end:
-            self.ranges[end_key] = end_count
+    def get_total_reads(self):
+        return sum([v for v in self.read_counts.values()])
+    
+    def matches_filter(addresses, required_addresses):
+        for addr in required_addresses:
+            if addr not in addresses:
+                return False
+        return True
 
+    def get_top_k_reads(self, num, filter_addresses, shard_finder=None):
+        count_pairs = sorted([(v, k) for (k, v) in self.read_counts.items()], reverse=True)
+        if not filter_addresses:
+            count_pairs = count_pairs[0:num]
 
-    def get_count_for_key(self, key):
-        if key in self.ranges:
-            return self.ranges[key][1]
+        if shard_finder:
+            results = []
+            for (count, (start, end)) in count_pairs:
+                results.append((start, end, count, shard_finder.get_addresses_for_key(start)))
 
-        keys = self.ranges.keys()
-        index = bisect_left(keys, key)
+            wait_for_shard_addresses(results, shard_finder, 0, 3)
 
-        index_key = keys[index-1]
-        return self.ranges[keys[index_key]]
+            if filter_addresses:
+                filter_addresses = set(filter_addresses)
+                results = [r for r in results if filter_addresses.issubset(set(r[3]))][0:num]
+        else:
+            results = [(start, end, count) for (count, (start, end)) in count_pairs[0:num]]
 
-    def get_range_boundaries(self, shard_finder=None):
-        total = sum([count for count in self.ranges.values()])
-        range_size = total // self.k
+        return results
+
+    def get_range_boundaries(self, num_buckets, shard_finder=None):
+        total = sum([start_count for (start_count, end_count) in self.reads.values()])
+        range_size = total // num_buckets
         output_range_counts = []
 
-        def add_boundary(start, end, count):
+        def add_boundary(start, end, started_count, total_count):
             if shard_finder:
                 shard_count = shard_finder.get_shard_count(start, end)
                 if shard_count == 1:
                     addresses = shard_finder.get_addresses_for_key(start)
                 else:
                     addresses = None
-                output_range_counts.append((start, end, count, shard_count, addresses))
+                output_range_counts.append((start, end, started_count, total_count, shard_count, addresses))
             else:
-                output_range_counts.append((start, end, count, None, None))
+                output_range_counts.append((start, end, started_count, total_count, None, None))
 
         this_range_start_key = None
-        this_range_end_key = None
+        last_end = None
+        open_count = 0
+        opened_this_range = 0
         count_this_range = 0
-        prev_count = 0
-        for (start_key, count) in self.ranges.items():
-            if prev_count > 0:
-                this_range_end_key = start_key
 
-            if count_this_range >= range_size:
-                add_boundary(this_range_start_key, this_range_end_key, count_this_range)
-                count_this_range = 0
+        for (start_key, (start_count, end_count)) in self.reads.items():
+            open_count -= end_count
+
+            if opened_this_range >= range_size:
+                add_boundary(this_range_start_key, start_key, opened_this_range, count_this_range)
+                count_this_range = open_count
+                opened_this_range = 0
                 this_range_start_key = None
 
-            if count != 0 and not this_range_start_key:
+            count_this_range += start_count
+            opened_this_range += start_count
+            open_count += start_count
+
+            if count_this_range > 0 and this_range_start_key is None:
                 this_range_start_key = start_key
 
-            prev_count = count
-            count_this_range += count
+            if end_count > 0:
+                last_end = start_key
 
-        if this_range_end_key is None:
-            this_range_end_key = b'\xff'
+        if last_end is None:
+            last_end = b'\xff'
         if count_this_range > 0:
-            add_boundary(this_range_start_key, this_range_end_key, count_this_range)
+            add_boundary(this_range_start_key, last_end, opened_this_range, count_this_range)
 
-        for index in range(len(output_range_counts)):
-            item = output_range_counts[index]
-            if item[4] is not None:
-                while True:
-                    try:
-                        output_range_counts[index] = item[0:4] + ([a.decode('ascii') for a in item[4].wait()],)
-                        break
-                    except fdb.FDBError as e:
-                        output_range_counts[index] = item[0:4] + (shard_finder.get_addresses_for_key(item[0]),)
-
+        wait_for_shard_addresses(output_range_counts, shard_finder, 0, 5)
         return output_range_counts
 
 
 class ShardFinder(object):
-    def __init__(self, db, include_ports):
+    def __init__(self, db, exclude_ports):
         self.db = db
-        self.include_ports = include_ports
+        self.exclude_ports = exclude_ports
 
         self.tr = db.create_transaction()
         self.refresh_tr()
@@ -627,7 +649,7 @@ class ShardFinder(object):
 
     def refresh_tr(self):
         self.tr.options.set_read_lock_aware()
-        if self.include_ports:
+        if not self.exclude_ports:
             self.tr.options.set_include_port_in_address()
 
     @staticmethod
@@ -669,26 +691,22 @@ class ShardFinder(object):
         return self.shard_cache[shard]
 
 
-class TopKeysCounter(object):
+class WriteCounter(object):
     mutation_types_to_consider = frozenset([MutationType.SET_VALUE, MutationType.ADD_VALUE])
 
-    def __init__(self, k):
-        self.k = k
-        self.reads = defaultdict(lambda: 0)
+    def __init__(self):
         self.writes = defaultdict(lambda: 0)
 
     def process(self, transaction_info):
-        for get in transaction_info.gets:
-            self.reads[get.key] += 1
         if transaction_info.commit:
             for mutation in transaction_info.commit.mutations:
                 if mutation.code in self.mutation_types_to_consider:
                     self.writes[mutation.param_one] += 1
 
-    def _get_range_boundaries(self, counts, shard_finder=None):
-        total = sum([v for (k, v) in counts.items()])
-        range_size = total // self.k
-        key_counts_sorted = sorted(counts.items())
+    def get_range_boundaries(self, num_buckets, shard_finder=None):
+        total = sum([v for (k, v) in self.writes.items()])
+        range_size = total // num_buckets
+        key_counts_sorted = sorted(self.writes.items())
         output_range_counts = []
 
         def add_boundary(start, end, count):
@@ -698,9 +716,9 @@ class TopKeysCounter(object):
                     addresses = shard_finder.get_addresses_for_key(start)
                 else:
                     addresses = None
-                output_range_counts.append((start, end, count, shard_count, addresses))
+                output_range_counts.append((start, end, count, None, shard_count, addresses))
             else:
-                output_range_counts.append((start, end, count, None, None))
+                output_range_counts.append((start, end, count, None, None, None))
 
         start_key = None
         count_this_range = 0
@@ -715,34 +733,31 @@ class TopKeysCounter(object):
         if count_this_range > 0:
             add_boundary(start_key, k, count_this_range)
 
-        for index in range(len(output_range_counts)):
-            item = output_range_counts[index]
-            if item[4] is not None:
-                while True:
-                    try:
-                        output_range_counts[index] = item[0:4] + ([a.decode('ascii') for a in item[4].wait()],)
-                        break
-                    except fdb.FDBError as e:
-                        output_range_counts[index] = item[0:4] + (shard_finder.get_addresses_for_key(item[0]),)
-
+        wait_for_shard_addresses(output_range_counts, shard_finder, 0, 5)
         return output_range_counts
 
-    def _get_top_k(self, counts):
-        count_key_pairs = sorted([(v, k) for (k, v) in counts.items()], reverse=True)
-        return count_key_pairs[0:self.k]
+    def get_total_writes(self):
+        return sum([v for v in self.writes.values()])
 
-    def get_top_k_reads(self):
-        return self._get_top_k(self.reads)
+    def get_top_k_writes(self, num, filter_addresses, shard_finder=None):
+        count_pairs = sorted([(v, k) for (k, v) in self.writes.items()], reverse=True)
+        if not filter_addresses:
+            count_pairs = count_pairs[0:num]
 
-    def get_top_k_writes(self):
-        return self._get_top_k(self.writes)
+        if shard_finder:
+            results = []
+            for (count, key) in count_pairs:
+                results.append((key, None, count, shard_finder.get_addresses_for_key(key)))
 
-    def get_k_read_range_boundaries(self, shard_finder=None):
-        return self._get_range_boundaries(self.reads, shard_finder)
+            wait_for_shard_addresses(results, shard_finder, 0, 3)
 
-    def get_k_write_range_boundaries(self, shard_finder=None):
-        return self._get_range_boundaries(self.writes, shard_finder)
+            if filter_addresses:
+                filter_addresses = set(filter_addresses)
+                results = [r for r in results if filter_addresses.issubset(set(r[3]))][0:num]
+        else:
+            results = [(key, end, count) for (count, key) in count_pairs[0:num]]
 
+        return results
 
 def connect(cluster_file=None):
     db = fdb.open(cluster_file=cluster_file)
@@ -759,6 +774,8 @@ def main():
                         help="Include get type. If no filter args are given all will be returned.")
     parser.add_argument("--filter-get-range", action="store_true",
                         help="Include get_range type. If no filter args are given all will be returned.")
+    parser.add_argument("--filter-reads", action="store_true",
+                        help="Include get and get_range type. If no filter args are given all will be returned.")
     parser.add_argument("--filter-commit", action="store_true",
                         help="Include commit type. If no filter args are given all will be returned.")
     parser.add_argument("--filter-error-get", action="store_true",
@@ -774,22 +791,34 @@ def main():
     end_time_group = parser.add_mutually_exclusive_group()
     end_time_group.add_argument("--max-timestamp", type=int, help="Don't return events newer than this epoch time")
     end_time_group.add_argument("-e", "--end-time", type=str, help="Don't return events older than this parsed time")
-    parser.add_argument("--top-keys", type=int, help="If specified will output this many top keys for reads or writes", default=0)
-    parser.add_argument("--include-ports", type=bool, help="Print addresses with the port number. 6.2 clusters only", default=False)
+    parser.add_argument("--num-buckets", type=int, help="The number of buckets to partition the key-space into for operation counts", default=100)
+    parser.add_argument("--top-requests", type=int, help="If specified will output this many top keys for reads or writes", default=0)
+    parser.add_argument("--exclude-ports", action="store_true", help="Print addresses without the port number. Only works in versions older than 6.3, and is required in versions older than 6.2.")
+    parser.add_argument("--single-shard-ranges-only", action="store_true", help="Only print range boundaries that exist in a single shard")
+    parser.add_argument("-a", "--filter-address", action="append", help="Only print range boundaries that include the given address. This option can used multiple times to include more than one address in the filter, in which case all addresses must match.")
+
     args = parser.parse_args()
 
     type_filter = set()
     if args.filter_get_version: type_filter.add("get_version")
-    if args.filter_get: type_filter.add("get")
-    if args.filter_get_range: type_filter.add("get_range")
+    if args.filter_get or args.filter_reads: type_filter.add("get")
+    if args.filter_get_range or args.filter_reads: type_filter.add("get_range")
     if args.filter_commit: type_filter.add("commit")
     if args.filter_error_get: type_filter.add("error_get")
     if args.filter_error_get_range: type_filter.add("error_get_range")
     if args.filter_error_commit: type_filter.add("error_commit")
-    top_keys = args.top_keys
-    key_counter = TopKeysCounter(top_keys) if top_keys else None
-    range_counter = RangeCounter(top_keys) if (has_sortedcontainers() and top_keys) else None
-    full_output = args.full_output or (top_keys is not None)
+
+    if (not type_filter or "commit" in type_filter):
+        write_counter = WriteCounter() if args.num_buckets else None
+    else:
+        write_counter = None
+
+    if (not type_filter or "get" in type_filter or "get_range" in type_filter):
+        read_counter = ReadCounter() if (has_sortedcontainers() and args.num_buckets) else None
+    else:
+        read_counter = None
+
+    full_output = args.full_output or (args.num_buckets is not None)
 
     if args.min_timestamp:
         min_timestamp = args.min_timestamp
@@ -822,49 +851,128 @@ def main():
     db = connect(cluster_file=args.cluster_file)
     loader = TransactionInfoLoader(db, full_output=full_output, type_filter=type_filter,
                                    min_timestamp=min_timestamp, max_timestamp=max_timestamp)
+
     for info in loader.fetch_transaction_info():
         if info.has_types():
-            if not key_counter and not range_counter:
+            if not write_counter and not read_counter:
                 print(info.to_json())
             else:
-                if key_counter:
-                    key_counter.process(info)
-                if range_counter:
-                    range_counter.process(info)
+                if write_counter:
+                    write_counter.process(info)
+                if read_counter:
+                    read_counter.process(info)
 
-    if key_counter:
-        def print_top(top):
-            for (count, key) in top:
-                print("%s %d" % (key, count))
-
-        def print_range_boundaries(range_boundaries):
-            for (start, end, count, shard_count, addresses) in range_boundaries:
-                if not shard_count:
-                    print("[%s, %s] %d" % (start, end, count))
+    def print_top(top, total, context):
+        if top:
+            running_count = 0
+            for (idx, (start, end, count, addresses)) in enumerate(top):
+                running_count += count
+                if end is not None:
+                    op_str = 'Range %r - %r' % (start, end)
                 else:
-                    addresses_string = "addresses=%s" % ','.join(addresses) if addresses else ''
-                    print("[%s, %s] %d shards=%d %s" % (start, end, count, shard_count, addresses_string))
+                    op_str = 'Key %r' % start
 
-        shard_finder = ShardFinder(db, args.include_ports)
+                print(" %d. %s\n    %d sampled %s (%.2f%%, %.2f%% cumulative)" % (idx+1, op_str, count, context, 100*count/total, 100*running_count/total))
+                print("    shard addresses: %s\n" % ", ".join(addresses))
 
-        top_reads = key_counter.get_top_k_reads()
-        if top_reads:
-            print("Top %d reads:" % min(top_keys, len(top_reads)))
-            print_top(top_reads)
-            print("Approx equal sized gets range boundaries:")
-            print_range_boundaries(key_counter.get_k_read_range_boundaries(shard_finder=shard_finder))
-        top_writes = key_counter.get_top_k_writes()
-        if top_writes:
-            print("Top %d writes:" % min(top_keys, len(top_writes)))
-            print_top(top_writes)
-            print("Approx equal sized commits range boundaries:")
-            print_range_boundaries(key_counter.get_k_write_range_boundaries(shard_finder=shard_finder))
-    if range_counter:
-        range_boundaries = range_counter.get_range_boundaries(shard_finder=shard_finder)
+        else:
+            print(" No %s found" % context)
+
+    def print_range_boundaries(range_boundaries, context):
+        omit_start = None
+        for (idx, (start, end, start_count, total_count, shard_count, addresses)) in enumerate(range_boundaries):
+            omit = args.single_shard_ranges_only and shard_count is not None and shard_count > 1
+            if args.filter_address:
+                if not addresses:
+                    omit = True
+                else:
+                    for addr in args.filter_address:
+                        if addr not in addresses:
+                            omit = True
+                            break
+
+            if not omit:
+                if omit_start is not None:
+                    if omit_start == idx-1:
+                        print(" %d. Omitted\n" % (idx))
+                    else:
+                        print(" %d - %d. Omitted\n" % (omit_start+1, idx))
+                    omit_start = None
+
+                if total_count is None:
+                    count_str = '%d sampled %s' % (start_count, context)
+                else:
+                    count_str = '%d sampled %s (%d intersecting)' % (start_count, context, total_count)
+                if not shard_count:
+                    print(" %d. [%s, %s]\n     %d sampled %s\n" % (idx+1, start, end, count, context))
+                else:
+                    addresses_string = "; addresses=%s" % ', '.join(addresses) if addresses else ''
+                    print(" %d. [%s, %s]\n     %s spanning %d shard(s)%s\n" % (idx+1, start, end, count_str, shard_count, addresses_string))
+            elif omit_start is None:
+                omit_start = idx
+
+        if omit_start is not None:
+            if omit_start == len(range_boundaries)-1:
+                print(" %d. Omitted\n" % len(range_boundaries))
+            else:
+                print(" %d - %d. Omitted\n" % (omit_start+1, len(range_boundaries)))
+
+    shard_finder = ShardFinder(db, args.exclude_ports)
+
+    print("NOTE: shard locations are current and may not reflect where an operation was performed in the past\n")
+
+    if write_counter:
+        if args.top_requests:
+            top_writes = write_counter.get_top_k_writes(args.top_requests, args.filter_address, shard_finder=shard_finder)
+
+        range_boundaries = write_counter.get_range_boundaries(args.num_buckets, shard_finder=shard_finder)
+        num_writes = write_counter.get_total_writes()
+
+        if args.top_requests or range_boundaries:
+            print("WRITES")
+            print("------\n")
+            print("Processed %d total writes\n" % num_writes)
+
+        if args.top_requests:
+            suffix = ""
+            if args.filter_address:
+                suffix = " (%s)" % ", ".join(args.filter_address)
+            print("Top %d writes%s:\n" % (args.top_requests, suffix))
+
+            print_top(top_writes, write_counter.get_total_writes(), "writes")
+            print("")
+
         if range_boundaries:
-            print("Approx equal sized get_ranges boundaries:")
-            print_range_boundaries(range_boundaries)
+            print("Key-space boundaries with approximately equal mutation counts:\n")
+            print_range_boundaries(range_boundaries, "writes")
 
+        if args.top_requests or range_boundaries:
+            print("")
+
+    if read_counter:
+        if args.top_requests:
+            top_reads = read_counter.get_top_k_reads(args.top_requests, args.filter_address, shard_finder=shard_finder)
+
+        range_boundaries = read_counter.get_range_boundaries(args.num_buckets, shard_finder=shard_finder)
+        num_reads = read_counter.get_total_reads()
+
+        if args.top_requests or range_boundaries:
+            print("READS")
+            print("-----\n")
+            print("Processed %d total reads\n" % num_reads)
+
+        if args.top_requests:
+            suffix = ""
+            if args.filter_address:
+                suffix = " (%s)" % ", ".join(args.filter_address)
+            print("Top %d reads%s:\n" % (args.top_requests, suffix))
+
+            print_top(top_reads, num_reads, "reads")
+            print("")
+
+        if range_boundaries:
+            print("Key-space boundaries with approximately equal read counts:\n")
+            print_range_boundaries(range_boundaries, "reads")
 
 if __name__ == "__main__":
     main()

--- a/contrib/transaction_profiling_analyzer/transaction_profiling_analyzer.py
+++ b/contrib/transaction_profiling_analyzer/transaction_profiling_analyzer.py
@@ -560,7 +560,7 @@ class ReadCounter(object):
         return True
 
     def get_top_k_reads(self, num, filter_addresses, shard_finder=None):
-        count_pairs = sorted([(v, k) for (k, v) in self.read_counts.items()], reverse=True)
+        count_pairs = sorted([(v, k) for (k, v) in self.read_counts.items()], reverse=True, key=lambda item: item[0])
         if not filter_addresses:
             count_pairs = count_pairs[0:num]
 


### PR DESCRIPTION
* Fetch the boundary keys once and cache the results
* Try to get addresses for shards in the same transaction and in parallel
* Simplify the range count logic (this seems not to be a clear win performance-wise, I've seen this go twice as fast or take 50% longer)

Also added a flag to enable ports on addresses.