### PR TITLE
Add documentation of get_approximate_size for Python, Ruby, and Go

### DIFF
--- a/bindings/go/src/fdb/transaction.go
+++ b/bindings/go/src/fdb/transaction.go
@@ -406,6 +406,9 @@ func (t *transaction) getApproximateSize() FutureInt64 {
 	}
 }
 
+// Returns a future that is the approximate transaction size so far in this
+// transaction, which is the summation of the estimated size of mutations,
+// read conflict ranges, and write conflict ranges.
 func (t Transaction) GetApproximateSize() FutureInt64 {
 	return t.getApproximateSize()
 }

--- a/documentation/sphinx/source/api-common.rst.inc
+++ b/documentation/sphinx/source/api-common.rst.inc
@@ -176,6 +176,9 @@
 .. |transaction-get-committed-version-blurb| replace::
     Gets the version number at which a successful commit modified the database. This must be called only after the successful (non-error) completion of a call to |commit-func| on this Transaction, or the behavior is undefined. Read-only transactions do not modify the database when committed and will have a committed version of -1. Keep in mind that a transaction which reads keys and then sets them to their current values may be optimized to a read-only transaction.
 
+.. |transaction-get-approximate-size-blurb| replace::
+    Gets the the approximate transaction size so far, which is the summation of the estimated size of mutations, read conflict ranges, and write conflict ranges.
+
 .. |transaction-get-versionstamp-blurb| replace::
     Returns a future which will contain the versionstamp which was used by any versionstamp operations in this transaction. This function must be called before a call to |commit-func| on this Transaction. The future will be ready only after the successful completion of a call to |commit-func| on this Transaction. Read-only transactions do not modify the database when committed and will result in the future completing with an error. Keep in mind that a transaction which reads keys and then sets them to their current values may be optimized to a read-only transaction.
 

--- a/documentation/sphinx/source/api-python.rst
+++ b/documentation/sphinx/source/api-python.rst
@@ -792,6 +792,10 @@ Most applications should use the read version that FoundationDB determines autom
 
     |infrequent| |transaction-get-committed-version-blurb|
 
+.. method :: Transaction.get_approximate_size()
+
+    |infrequent| |transaction-get-approximate-size-blurb|
+
 .. method :: Transaction.get_versionstamp()
 
     |infrequent| |transaction-get-versionstamp-blurb|

--- a/documentation/sphinx/source/api-python.rst
+++ b/documentation/sphinx/source/api-python.rst
@@ -792,10 +792,6 @@ Most applications should use the read version that FoundationDB determines autom
 
     |infrequent| |transaction-get-committed-version-blurb|
 
-.. method :: Transaction.get_approximate_size()
-
-    |infrequent| |transaction-get-approximate-size-blurb|
-
 .. method :: Transaction.get_versionstamp()
 
     |infrequent| |transaction-get-versionstamp-blurb|
@@ -806,6 +802,10 @@ Transaction misc functions
 .. method:: Transaction.get_estimated_range_size_bytes(begin_key, end_key)
 
     Get the estimated byte size of the given key range. Returns a :class:`FutureInt64`.
+
+.. method:: Transaction.get_approximate_size()
+
+    |transaction-get-approximate-size-blurb|. Returns a :class:`FutureInt64`.
 
 .. _api-python-transaction-options:
 

--- a/documentation/sphinx/source/api-ruby.rst
+++ b/documentation/sphinx/source/api-ruby.rst
@@ -736,10 +736,6 @@ Most applications should use the read version that FoundationDB determines autom
 
     |infrequent| |transaction-get-committed-version-blurb|
 
-.. method:: Transaction.get_approximate_size() -> Int64Future
-
-    |infrequent| |transaction-get-approximate-size-blurb|
-
 .. method:: Transaction.get_verionstamp() -> String
 
     |infrequent| |transaction-get-versionstamp-blurb|
@@ -750,6 +746,10 @@ Transaction misc functions
 .. method:: Transaction.get_estimated_range_size_bytes(begin_key, end_key)
 
     Get the estimated byte size of the given key range. Returns a :class:`Int64Future`.
+
+.. method:: Transaction.get_approximate_size() -> Int64Future
+
+    |transaction-get-approximate-size-blurb|. Returns a :class:`Int64Future`.
 
 Transaction options
 -------------------

--- a/documentation/sphinx/source/api-ruby.rst
+++ b/documentation/sphinx/source/api-ruby.rst
@@ -736,6 +736,10 @@ Most applications should use the read version that FoundationDB determines autom
 
     |infrequent| |transaction-get-committed-version-blurb|
 
+.. method:: Transaction.get_approximate_size() -> Int64Future
+
+    |infrequent| |transaction-get-approximate-size-blurb|
+
 .. method:: Transaction.get_verionstamp() -> String
 
     |infrequent| |transaction-get-versionstamp-blurb|


### PR DESCRIPTION
This was missed from original PR #1756, where only C API was documented.

Java API was documented [inline](https://github.com/apple/foundationdb/blob/241b24b358cebcd3a1574ff79b918c8220617cb4/bindings/java/src/main/com/apple/foundationdb/Transaction.java#L276).

This will fix #2856.