### PR TITLE
Add pause/resume for new backups

### DIFF
--- a/fdbbackup/backup.actor.cpp
+++ b/fdbbackup/backup.actor.cpp
@@ -2051,8 +2051,8 @@ ACTOR Future<Void> discontinueBackup(Database db, std::string tagName, bool wait
 
 ACTOR Future<Void> changeBackupResumed(Database db, bool pause) {
 	try {
-		state FileBackupAgent backupAgent;
-		wait(backupAgent.taskBucket->changePause(db, pause));
+		FileBackupAgent backupAgent;
+		wait(backupAgent.changePause(db, pause));
 		printf("All backup agents have been %s.\n", pause ? "paused" : "resumed");
 	}
 	catch (Error& e) {

--- a/fdbclient/BackupAgent.actor.h
+++ b/fdbclient/BackupAgent.actor.h
@@ -362,6 +362,9 @@ public:
 
 	Future<bool> checkActive(Database cx) { return taskBucket->checkActive(cx); }
 
+	// If "pause" is true, pause all backups; otherwise, resume all.
+	Future<Void> changePause(Database db, bool pause);
+
 	friend class FileBackupAgentImpl;
 	static const int dataFooterSize;
 

--- a/fdbclient/FileBackupAgent.actor.cpp
+++ b/fdbclient/FileBackupAgent.actor.cpp
@@ -4059,7 +4059,7 @@ public:
 			tr->setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
 
 			try {
-				tr->set(backupPausedKey, encodeBackupPausedValue(pause));
+				tr->set(backupPausedKey, pause ? LiteralStringRef("1") : LiteralStringRef("0"));
 				wait(tr->commit());
 				break;
 			} catch (Error& e) {
@@ -4067,7 +4067,7 @@ public:
 			}
 		}
 		wait(change);
-		TraceEvent("FBA_ChangePaused").detail("Action", pause ? "Paused" : "Resumed");
+		TraceEvent("FileBackupAgentChangePaused").detail("Action", pause ? "Paused" : "Resumed");
 		return Void();
 	}
 

--- a/fdbclient/FileBackupAgent.actor.cpp
+++ b/fdbclient/FileBackupAgent.actor.cpp
@@ -4049,6 +4049,28 @@ public:
 		return Void();
 	}
 
+	ACTOR static Future<Void> changePause(FileBackupAgent* backupAgent, Database db, bool pause) {
+		state Reference<ReadYourWritesTransaction> tr(new ReadYourWritesTransaction(db));
+		state Future<Void> change = backupAgent->taskBucket->changePause(db, pause);
+
+		loop {
+			tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
+			tr->setOption(FDBTransactionOptions::LOCK_AWARE);
+			tr->setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
+
+			try {
+				tr->set(backupPausedKey, encodeBackupPausedValue(pause));
+				wait(tr->commit());
+				break;
+			} catch (Error& e) {
+				wait(tr->onError(e));
+			}
+		}
+		wait(change);
+		TraceEvent("FBA_ChangePaused").detail("Action", pause ? "Paused" : "Resumed");
+		return Void();
+	}
+
 	struct TimestampedVersion {
 		Optional<Version> version;
 		Optional<int64_t> epochs;
@@ -4651,4 +4673,8 @@ void FileBackupAgent::setLastRestorable(Reference<ReadYourWritesTransaction> tr,
 
 Future<int> FileBackupAgent::waitBackup(Database cx, std::string tagName, bool stopWhenDone, Reference<IBackupContainer> *pContainer, UID *pUID) {
 	return FileBackupAgentImpl::waitBackup(this, cx, tagName, stopWhenDone, pContainer, pUID);
+}
+
+Future<Void> FileBackupAgent::changePause(Database db, bool pause) {
+	return FileBackupAgentImpl::changePause(this, db, pause);
 }

--- a/fdbclient/SystemData.cpp
+++ b/fdbclient/SystemData.cpp
@@ -523,19 +523,6 @@ UID decodeBackupProgressKey(const KeyRef& key) {
 	return serverID;
 }
 
-Value encodeBackupPausedValue(bool pause) {
-	BinaryWriter wr(Unversioned());
-	wr << pause;
-	return wr.toValue();
-}
-
-bool decodeBackupPausedValue(const ValueRef& value) {
-	bool pause;
-	BinaryReader rd(value, Unversioned());
-	rd >> pause;
-	return pause;
-}
-
 WorkerBackupStatus decodeBackupProgressValue(const ValueRef& value) {
 	WorkerBackupStatus status;
 	BinaryReader reader(value, IncludeVersion());

--- a/fdbclient/SystemData.cpp
+++ b/fdbclient/SystemData.cpp
@@ -501,6 +501,7 @@ const KeyRangeRef backupProgressKeys(LiteralStringRef("\xff\x02/backupProgress/"
                                      LiteralStringRef("\xff\x02/backupProgress0"));
 const KeyRef backupProgressPrefix = backupProgressKeys.begin;
 const KeyRef backupStartedKey = LiteralStringRef("\xff\x02/backupStarted");
+extern const KeyRef backupPausedKey = LiteralStringRef("\xff\x02/backupPaused");
 
 const Key backupProgressKeyFor(UID workerID) {
 	BinaryWriter wr(Unversioned());
@@ -520,6 +521,19 @@ UID decodeBackupProgressKey(const KeyRef& key) {
 	BinaryReader rd(key.removePrefix(backupProgressPrefix), Unversioned());
 	rd >> serverID;
 	return serverID;
+}
+
+Value encodeBackupPausedValue(bool pause) {
+	BinaryWriter wr(Unversioned());
+	wr << pause;
+	return wr.toValue();
+}
+
+bool decodeBackupPausedValue(const ValueRef& value) {
+	bool pause;
+	BinaryReader rd(value, Unversioned());
+	rd >> pause;
+	return pause;
 }
 
 WorkerBackupStatus decodeBackupProgressValue(const ValueRef& value) {

--- a/fdbclient/SystemData.h
+++ b/fdbclient/SystemData.h
@@ -196,8 +196,6 @@ std::vector<std::pair<UID, Version>> decodeBackupStartedValue(const ValueRef& va
 // The key to signal backup workers that they should pause or resume.
 //    "\xff\x02/backupPaused" := "[[0|1]]"
 extern const KeyRef backupPausedKey;
-Value encodeBackupPausedValue(bool pause);
-bool decodeBackupPausedValue(const ValueRef& value);
 
 extern const KeyRef coordinatorsKey;
 extern const KeyRef logsKey;

--- a/fdbclient/SystemData.h
+++ b/fdbclient/SystemData.h
@@ -179,7 +179,7 @@ const Value workerListValue( ProcessData const& );
 Key decodeWorkerListKey( KeyRef const& );
 ProcessData decodeWorkerListValue( ValueRef const& );
 
-//    "\xff/backupProgress/[[workerID]]" := "[[WorkerBackupStatus]]"
+//    "\xff\x02/backupProgress/[[workerID]]" := "[[WorkerBackupStatus]]"
 extern const KeyRangeRef backupProgressKeys;
 extern const KeyRef backupProgressPrefix;
 const Key backupProgressKeyFor(UID workerID);
@@ -187,10 +187,17 @@ const Value backupProgressValue(const WorkerBackupStatus& status);
 UID decodeBackupProgressKey(const KeyRef& key);
 WorkerBackupStatus decodeBackupProgressValue(const ValueRef& value);
 
-//    "\xff/backupStarted" := "[[vector<UID,Version1>]]"
+// The key to signal backup workers a new backup job is submitted.
+//    "\xff\x02/backupStarted" := "[[vector<UID,Version1>]]"
 extern const KeyRef backupStartedKey;
 Value encodeBackupStartedValue(const std::vector<std::pair<UID, Version>>& ids);
 std::vector<std::pair<UID, Version>> decodeBackupStartedValue(const ValueRef& value);
+
+// The key to signal backup workers that they should pause or resume.
+//    "\xff\x02/backupPaused" := "[[0|1]]"
+extern const KeyRef backupPausedKey;
+Value encodeBackupPausedValue(bool pause);
+bool decodeBackupPausedValue(const ValueRef& value);
 
 extern const KeyRef coordinatorsKey;
 extern const KeyRef logsKey;

--- a/fdbserver/BackupWorker.actor.cpp
+++ b/fdbserver/BackupWorker.actor.cpp
@@ -915,7 +915,7 @@ ACTOR static Future<Void> monitorWorkerPause(BackupData* self) {
 			tr->setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
 
 			Optional<Value> value = wait(tr->get(backupPausedKey));
-			bool paused = value.present() && decodeBackupPausedValue(value.get());
+			bool paused = value.present() && value.get() == LiteralStringRef("1");
 			if (self->paused.get() != paused) {
 				TraceEvent(paused ? "BackupWorkerPaused" : "BackupWorkerResumed", self->myId);
 				self->paused.set(paused);

--- a/fdbserver/workloads/BackupAndParallelRestoreCorrectness.actor.cpp
+++ b/fdbserver/workloads/BackupAndParallelRestoreCorrectness.actor.cpp
@@ -136,9 +136,9 @@ struct BackupAndParallelRestoreCorrectnessWorkload : TestWorkload {
 
 	ACTOR static Future<Void> changePaused(Database cx, FileBackupAgent* backupAgent) {
 		loop {
-			wait(backupAgent->taskBucket->changePause(cx, true));
+			wait(backupAgent->changePause(cx, true));
 			wait(delay(30 * deterministicRandom()->random01()));
-			wait(backupAgent->taskBucket->changePause(cx, false));
+			wait(backupAgent->changePause(cx, false));
 			wait(delay(120 * deterministicRandom()->random01()));
 		}
 	}

--- a/fdbserver/workloads/BackupCorrectness.actor.cpp
+++ b/fdbserver/workloads/BackupCorrectness.actor.cpp
@@ -180,10 +180,10 @@ struct BackupAndRestoreCorrectnessWorkload : TestWorkload {
 
 	ACTOR static Future<Void> changePaused(Database cx, FileBackupAgent* backupAgent) {
 		loop {
-			wait( backupAgent->taskBucket->changePause(cx, true) );
-			wait( delay(30*deterministicRandom()->random01()) );
-			wait( backupAgent->taskBucket->changePause(cx, false) );
-			wait( delay(120*deterministicRandom()->random01()) );
+			wait(backupAgent->changePause(cx, true));
+			wait(delay(30 * deterministicRandom()->random01()));
+			wait(backupAgent->changePause(cx, false));
+			wait(delay(120 * deterministicRandom()->random01()));
 		}
 	}
 


### PR DESCRIPTION
To pause/resume the backup workers, the fdbbackup command will write to the
backupPausedKey. Then backup workers noticed the value of the key has been
changed and stops/resumes pulling from TLog.

This is part of #1003.