### PR TITLE
Remove version stamp ops from RestoreApplier

### DIFF
--- a/fdbserver/RestoreApplier.actor.h
+++ b/fdbserver/RestoreApplier.actor.h
@@ -282,26 +282,6 @@ struct ApplierBatchData : public ReferenceCounted<ApplierBatchData> {
 		}
 	}
 
-	void addVersionStampedKV(MutationRef m, LogMessageVersion ver, uint16_t numVersionStampedKV) {
-		if (m.type == MutationRef::SetVersionstampedKey) {
-			// Assume transactionNumber = 0 does not affect result
-			TraceEvent(SevDebug, "FastRestoreApplierAddMutation")
-			    .detail("MutationType", typeString[m.type])
-			    .detail("FakedTransactionNumber", numVersionStampedKV);
-			transformVersionstampMutation(m, &MutationRef::param1, ver.version, numVersionStampedKV);
-			addMutation(m, ver);
-		} else if (m.type == MutationRef::SetVersionstampedValue) {
-			// Assume transactionNumber = 0 does not affect result
-			TraceEvent(SevDebug, "FastRestoreApplierAddMutation")
-			    .detail("MutationType", typeString[m.type])
-			    .detail("FakedTransactionNumber", numVersionStampedKV);
-			transformVersionstampMutation(m, &MutationRef::param2, ver.version, numVersionStampedKV);
-			addMutation(m, ver);
-		} else {
-			ASSERT(false);
-		}
-	}
-
 	// Return true if all staging keys have been precomputed
 	bool allKeysPrecomputed() {
 		for (auto& stagingKey : stagingKeys) {


### PR DESCRIPTION
Version stamp ops are converted into SET at the proxy, so the backup files will never have them.

This is a part of #2858