### PR TITLE
Mark the storage servers that are continually lagging as unhealthy

### DIFF
--- a/fdbclient/StorageServerInterface.h
+++ b/fdbclient/StorageServerInterface.h
@@ -394,6 +394,7 @@ struct GetStorageMetricsReply {
 	StorageMetrics available;
 	StorageMetrics capacity;
 	double bytesInputRate;
+	Version version; // current storage server version
 
 	GetStorageMetricsReply() : bytesInputRate(0) {}
 

--- a/fdbclient/StorageServerInterface.h
+++ b/fdbclient/StorageServerInterface.h
@@ -400,7 +400,7 @@ struct GetStorageMetricsReply {
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, load, available, capacity, bytesInputRate);
+		serializer(ar, load, available, capacity, bytesInputRate, version);
 	}
 };
 

--- a/fdbclient/StorageServerInterface.h
+++ b/fdbclient/StorageServerInterface.h
@@ -394,13 +394,14 @@ struct GetStorageMetricsReply {
 	StorageMetrics available;
 	StorageMetrics capacity;
 	double bytesInputRate;
-	Version version; // current storage server version
+	int64_t versionLag;
+	double lastUpdate;
 
 	GetStorageMetricsReply() : bytesInputRate(0) {}
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, load, available, capacity, bytesInputRate, version);
+		serializer(ar, load, available, capacity, bytesInputRate, versionLag, lastUpdate);
 	}
 };
 

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -3810,7 +3810,7 @@ ACTOR Future<Void> storageServerTracker(
 				}
 				when(wait(storeTypeTracker)) {}
 				when(wait(server->ssVersionTooFarBehind.onChange())) { }
-				when(wait(self->disableFailingLaggingServers.onChange())) {	}
+				when(wait(self->disableFailingLaggingServers.onChange())) { }
 			}
 
 			if (recordTeamCollectionInfo) {

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -156,7 +156,7 @@ ACTOR Future<Void> updateServerMetrics( TCServerInfo *server, Database cx ) {
 								tr->setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
 								return tr->getReadVersion(); }));
 		Version versionDiff = versionNow - server->serverMetrics.get().version;
-		if(versionDiff > SERVER_KNOBS->DD_SS_FAILURE_VERSIONLAG) { // TODO: Knobbify
+		if(versionDiff > SERVER_KNOBS->DD_SS_FAILURE_VERSIONLAG) {
 			if(server->ssVersionTooFarBehind.get() == false) {
 				TraceEvent(SevInfo, "SSVersionDiffLarge").detail("ServerId", server->id.toString()).detail("VersionNow", versionNow).detail("SSVersion", server->serverMetrics.get().version).detail("Diff", versionDiff);
 				server->ssVersionTooFarBehind.set(true);
@@ -3642,7 +3642,7 @@ ACTOR Future<Void> storageServerTracker(
 					if(server->updated.canBeSet()) {
 						server->updated.send(Void());
 					}
-					
+
 					// Remove server from FF/serverList
 					wait( removeStorageServer( cx, server->id, self->lock ) );
 

--- a/fdbserver/Knobs.cpp
+++ b/fdbserver/Knobs.cpp
@@ -215,6 +215,9 @@ ServerKnobs::ServerKnobs(bool randomize, ClientKnobs* clientKnobs, bool isSimula
 	init( DD_VALIDATE_LOCALITY,                                 true ); if( randomize && BUGGIFY ) DD_VALIDATE_LOCALITY = false;
 	init( DD_CHECK_INVALID_LOCALITY_DELAY,                       60  ); if( randomize && BUGGIFY ) DD_CHECK_INVALID_LOCALITY_DELAY = 1 + deterministicRandom()->random01() * 600;
 	init( DD_ENABLE_VERBOSE_TRACING,                           false ); if( randomize && BUGGIFY ) DD_ENABLE_VERBOSE_TRACING = true;
+	init( DD_SS_FAILURE_VERSIONLAG,                        250000000 ); 
+	init( DD_SS_ALLOWED_VERSIONLAG,                        200000000 ); if( randomize && BUGGIFY ) { DD_SS_FAILURE_VERSIONLAG = deterministicRandom()->randomInt(15000000, 500000000); DD_SS_ALLOWED_VERSIONLAG = 0.75 * DD_SS_FAILURE_VERSIONLAG; }
+	
 
 	// TeamRemover
 	init( TR_FLAG_DISABLE_MACHINE_TEAM_REMOVER,                false ); if( randomize && BUGGIFY ) TR_FLAG_DISABLE_MACHINE_TEAM_REMOVER = deterministicRandom()->random01() < 0.1 ? true : false; // false by default. disable the consistency check when it's true

--- a/fdbserver/Knobs.cpp
+++ b/fdbserver/Knobs.cpp
@@ -217,7 +217,7 @@ ServerKnobs::ServerKnobs(bool randomize, ClientKnobs* clientKnobs, bool isSimula
 	init( DD_ENABLE_VERBOSE_TRACING,                           false ); if( randomize && BUGGIFY ) DD_ENABLE_VERBOSE_TRACING = true;
 	init( DD_SS_FAILURE_VERSIONLAG,                        250000000 ); 
 	init( DD_SS_ALLOWED_VERSIONLAG,                        200000000 ); if( randomize && BUGGIFY ) { DD_SS_FAILURE_VERSIONLAG = deterministicRandom()->randomInt(15000000, 500000000); DD_SS_ALLOWED_VERSIONLAG = 0.75 * DD_SS_FAILURE_VERSIONLAG; }
-	init( DD_SS_STUCK_TIME_LIMIT,                              120.0 ); if( randomize && BUGGIFY ) { DD_SS_STUCK_TIME_LIMIT = 60.0 + deterministicRandom()->random01() * 60.0; }
+	init( DD_SS_STUCK_TIME_LIMIT,                              300.0 ); if( randomize && BUGGIFY ) { DD_SS_STUCK_TIME_LIMIT = 200.0 + deterministicRandom()->random01() * 100.0; }
 
 	// TeamRemover
 	init( TR_FLAG_DISABLE_MACHINE_TEAM_REMOVER,                false ); if( randomize && BUGGIFY ) TR_FLAG_DISABLE_MACHINE_TEAM_REMOVER = deterministicRandom()->random01() < 0.1 ? true : false; // false by default. disable the consistency check when it's true

--- a/fdbserver/Knobs.cpp
+++ b/fdbserver/Knobs.cpp
@@ -217,7 +217,7 @@ ServerKnobs::ServerKnobs(bool randomize, ClientKnobs* clientKnobs, bool isSimula
 	init( DD_ENABLE_VERBOSE_TRACING,                           false ); if( randomize && BUGGIFY ) DD_ENABLE_VERBOSE_TRACING = true;
 	init( DD_SS_FAILURE_VERSIONLAG,                        250000000 ); 
 	init( DD_SS_ALLOWED_VERSIONLAG,                        200000000 ); if( randomize && BUGGIFY ) { DD_SS_FAILURE_VERSIONLAG = deterministicRandom()->randomInt(15000000, 500000000); DD_SS_ALLOWED_VERSIONLAG = 0.75 * DD_SS_FAILURE_VERSIONLAG; }
-	
+	init( DD_SS_STUCK_TIME_LIMIT,                              120.0 ); if( randomize && BUGGIFY ) { DD_SS_STUCK_TIME_LIMIT = 60.0 + deterministicRandom()->random01() * 60.0; }
 
 	// TeamRemover
 	init( TR_FLAG_DISABLE_MACHINE_TEAM_REMOVER,                false ); if( randomize && BUGGIFY ) TR_FLAG_DISABLE_MACHINE_TEAM_REMOVER = deterministicRandom()->random01() < 0.1 ? true : false; // false by default. disable the consistency check when it's true

--- a/fdbserver/Knobs.h
+++ b/fdbserver/Knobs.h
@@ -173,8 +173,8 @@ public:
 	bool DD_VALIDATE_LOCALITY;
 	int DD_CHECK_INVALID_LOCALITY_DELAY;
 	bool DD_ENABLE_VERBOSE_TRACING;
-	int64_t DD_SS_FAILURE_VERSIONLAG;
-	int64_t DD_SS_ALLOWED_VERSIONLAG;
+	int64_t DD_SS_FAILURE_VERSIONLAG; // Allowed SS version lag from the current read version before marking it as failed.
+	int64_t DD_SS_ALLOWED_VERSIONLAG; // SS will be marked as healthy if it's version lag goes below this value. 
 	
 	// TeamRemover to remove redundant teams
 	bool TR_FLAG_DISABLE_MACHINE_TEAM_REMOVER; // disable the machineTeamRemover actor

--- a/fdbserver/Knobs.h
+++ b/fdbserver/Knobs.h
@@ -174,7 +174,8 @@ public:
 	int DD_CHECK_INVALID_LOCALITY_DELAY;
 	bool DD_ENABLE_VERBOSE_TRACING;
 	int64_t DD_SS_FAILURE_VERSIONLAG; // Allowed SS version lag from the current read version before marking it as failed.
-	int64_t DD_SS_ALLOWED_VERSIONLAG; // SS will be marked as healthy if it's version lag goes below this value. 
+	int64_t DD_SS_ALLOWED_VERSIONLAG; // SS will be marked as healthy if it's version lag goes below this value.
+	double DD_SS_STUCK_TIME_LIMIT; // If a storage server is not getting new versions for this amount of time, then it becomes undesired.
 	
 	// TeamRemover to remove redundant teams
 	bool TR_FLAG_DISABLE_MACHINE_TEAM_REMOVER; // disable the machineTeamRemover actor

--- a/fdbserver/Knobs.h
+++ b/fdbserver/Knobs.h
@@ -173,7 +173,9 @@ public:
 	bool DD_VALIDATE_LOCALITY;
 	int DD_CHECK_INVALID_LOCALITY_DELAY;
 	bool DD_ENABLE_VERBOSE_TRACING;
-
+	int64_t DD_SS_FAILURE_VERSIONLAG;
+	int64_t DD_SS_ALLOWED_VERSIONLAG;
+	
 	// TeamRemover to remove redundant teams
 	bool TR_FLAG_DISABLE_MACHINE_TEAM_REMOVER; // disable the machineTeamRemover actor
 	double TR_REMOVE_MACHINE_TEAM_DELAY; // wait for the specified time before try to remove next machine team

--- a/fdbserver/StorageMetrics.actor.h
+++ b/fdbserver/StorageMetrics.actor.h
@@ -378,7 +378,7 @@ struct StorageServerMetrics {
 		}
 	}
 
-	void getStorageMetrics( GetStorageMetricsRequest req, StorageBytes sb, double bytesInputRate, Version version ){
+	void getStorageMetrics( GetStorageMetricsRequest req, StorageBytes sb, double bytesInputRate, int64_t versionLag, double lastUpdate ){
 		GetStorageMetricsReply rep;
 
 		// SOMEDAY: make bytes dynamic with hard disk space
@@ -405,7 +405,8 @@ struct StorageServerMetrics {
 
 		rep.bytesInputRate = bytesInputRate;
 
-		rep.version = version;
+		rep.versionLag = versionLag;
+		rep.lastUpdate = lastUpdate;
 
 		req.reply.send(rep);
 	}

--- a/fdbserver/StorageMetrics.actor.h
+++ b/fdbserver/StorageMetrics.actor.h
@@ -378,7 +378,7 @@ struct StorageServerMetrics {
 		}
 	}
 
-	void getStorageMetrics( GetStorageMetricsRequest req, StorageBytes sb, double bytesInputRate ){
+	void getStorageMetrics( GetStorageMetricsRequest req, StorageBytes sb, double bytesInputRate, Version version ){
 		GetStorageMetricsReply rep;
 
 		// SOMEDAY: make bytes dynamic with hard disk space
@@ -404,6 +404,8 @@ struct StorageServerMetrics {
 		rep.capacity.bytesReadPerKSecond = 100e9;
 
 		rep.bytesInputRate = bytesInputRate;
+
+		rep.version = version;
 
 		req.reply.send(rep);
 	}

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -3484,7 +3484,7 @@ ACTOR Future<Void> metricsCore( StorageServer* self, StorageServerInterface ssi 
 			}
 			when (GetStorageMetricsRequest req = waitNext(ssi.getStorageMetrics.getFuture())) {
 				StorageBytes sb = self->storage.getStorageBytes();
-				self->metrics.getStorageMetrics( req, sb, self->counters.bytesInput.getRate() );
+				self->metrics.getStorageMetrics( req, sb, self->counters.bytesInput.getRate(), self->version.get() );
 			}
 			when (wait(doPollMetrics) ) {
 				self->metrics.poll();

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -3484,7 +3484,7 @@ ACTOR Future<Void> metricsCore( StorageServer* self, StorageServerInterface ssi 
 			}
 			when (GetStorageMetricsRequest req = waitNext(ssi.getStorageMetrics.getFuture())) {
 				StorageBytes sb = self->storage.getStorageBytes();
-				self->metrics.getStorageMetrics( req, sb, self->counters.bytesInput.getRate(), self->version.get() );
+				self->metrics.getStorageMetrics( req, sb, self->counters.bytesInput.getRate(), self->versionLag, self->lastUpdate );
 			}
 			when (wait(doPollMetrics) ) {
 				self->metrics.poll();

--- a/fdbserver/workloads/KillRegion.actor.cpp
+++ b/fdbserver/workloads/KillRegion.actor.cpp
@@ -68,7 +68,7 @@ struct KillRegionWorkload : TestWorkload {
 
 	ACTOR static Future<Void> waitForStorageRecovered( KillRegionWorkload *self ) {
 		while( self->dbInfo->get().recoveryState < RecoveryState::STORAGE_RECOVERED ) {
-				wait( self->dbInfo->onChange() );
+			wait( self->dbInfo->onChange() );
 		}
 		return Void();
 	}

--- a/fdbserver/workloads/KillRegion.actor.cpp
+++ b/fdbserver/workloads/KillRegion.actor.cpp
@@ -66,6 +66,13 @@ struct KillRegionWorkload : TestWorkload {
 		return Void();
 	}
 
+	ACTOR static Future<Void> waitForStorageRecovered( KillRegionWorkload *self ) {
+		while( self->dbInfo->get().recoveryState < RecoveryState::STORAGE_RECOVERED ) {
+				wait( self->dbInfo->onChange() );
+		}
+		return Void();
+	}
+
 	ACTOR static Future<Void> killRegion( KillRegionWorkload *self, Database cx ) {
 		ASSERT( g_network->isSimulated() );
 		if(deterministicRandom()->random01() < 0.5) {
@@ -94,10 +101,13 @@ struct KillRegionWorkload : TestWorkload {
 		TraceEvent("ForceRecovery_GotConfig").detail("Conf", conf.toString());
 
 		if(conf.usableRegions>1) {
-			//only needed if force recovery was unnecessary and we killed the secondary
-			wait( success( changeConfig( cx, g_simulator.disablePrimary + " repopulate_anti_quorum=1", true ) ) );
-			while( self->dbInfo->get().recoveryState < RecoveryState::STORAGE_RECOVERED ) {
-				wait( self->dbInfo->onChange() );
+			loop {
+				//only needed if force recovery was unnecessary and we killed the secondary
+				wait( success( changeConfig( cx, g_simulator.disablePrimary + " repopulate_anti_quorum=1", true ) ) );
+				choose {
+					when( wait( waitForStorageRecovered(self) ) ) { break; }
+					when( wait( delay(300.0) ) ) { }
+				}
 			}
 			wait( success( changeConfig( cx, "usable_regions=1", true ) ) );
 		}


### PR DESCRIPTION
Mark lagging storage servers as undesired. Fixes #1510.
Mark storage servers which are not progressing as undesired. Fixes #1184.
Have a backstop mechanism from not marking too many storage servers as undesired.