### PR TITLE
Consolidate backup container APIs

### DIFF
--- a/fdbclient/BackupContainer.actor.cpp
+++ b/fdbclient/BackupContainer.actor.cpp
@@ -657,18 +657,6 @@ public:
 		return dumpFileList_impl(Reference<BackupContainerFileSystem>::addRef(this), begin, end);
 	}
 
-	ACTOR static Future<bool> isPartitionedBackup_impl(Reference<BackupContainerFileSystem> bc) {
-		BackupFileList list = wait(bc->dumpFileList(0, std::numeric_limits<Version>::max()));
-		for (const auto& file : list.logs) {
-			if (file.isPartitionedLog()) return true;
-		}
-		return false;
-	}
-
-	Future<bool> isPartitionedBackup() final {
-		return isPartitionedBackup_impl(Reference<BackupContainerFileSystem>::addRef(this));
-	}
-
 	static Version resolveRelativeVersion(Optional<Version> max, Version v, const char *name, Error e) {
 		if(v == invalidVersion) {
 			TraceEvent(SevError, "BackupExpireInvalidVersion").detail(name, v);

--- a/fdbclient/BackupContainer.h
+++ b/fdbclient/BackupContainer.h
@@ -263,9 +263,6 @@ public:
 
 	virtual Future<BackupFileList> dumpFileList(Version begin = 0, Version end = std::numeric_limits<Version>::max()) = 0;
 
-	// If there are partitioned log files, then returns true; otherwise, returns false.
-	virtual Future<bool> isPartitionedBackup() = 0;
-
 	// Get exactly the files necessary to restore to targetVersion.  Returns non-present if
 	// restore to given version is not possible.
 	virtual Future<Optional<RestorableFileSet>> getRestoreSet(Version targetVersion) = 0;

--- a/fdbclient/BackupContainer.h
+++ b/fdbclient/BackupContainer.h
@@ -267,11 +267,6 @@ public:
 	// restore to given version is not possible.
 	virtual Future<Optional<RestorableFileSet>> getRestoreSet(Version targetVersion) = 0;
 
-	// Get exactly the files necessary to restore to targetVersion. Returns non-present if
-	// restore to given version is not possible. This is intended for parallel
-	// restore in FDB 7.0, which reads partitioned mutation logs.
-	virtual Future<Optional<RestorableFileSet>> getPartitionedRestoreSet(Version targetVersion) = 0;
-
 	// Get an IBackupContainer based on a container spec string
 	static Reference<IBackupContainer> openContainer(std::string url);
 	static std::vector<std::string> getURLFormats();

--- a/fdbclient/BackupContainer.h
+++ b/fdbclient/BackupContainer.h
@@ -178,6 +178,7 @@ struct BackupDescription {
 	// The minimum version which this backup can be used to restore to
 	Optional<Version> minRestorableVersion;
 	std::string extendedDetail;  // Freeform container-specific info.
+	bool partitioned; // If this backup contains partitioned mutation logs.
 
 	// Resolves the versions above to timestamps using a given database's TimeKeeper data.
 	// toString will use this information if present.
@@ -259,9 +260,6 @@ public:
 	// of this describe operation.  This can be used to calculate what the restorability of a backup would
 	// be after deleting all data prior to logStartVersionOverride.
 	virtual Future<BackupDescription> describeBackup(bool deepScan = false, Version logStartVersionOverride = invalidVersion) = 0;
-
-	// The same as above, except using partitioned mutation logs.
-	virtual Future<BackupDescription> describePartitionedBackup(bool deepScan = false, Version logStartVersionOverride = invalidVersion) = 0;
 
 	virtual Future<BackupFileList> dumpFileList(Version begin = 0, Version end = std::numeric_limits<Version>::max()) = 0;
 

--- a/fdbserver/BackupProgress.actor.cpp
+++ b/fdbserver/BackupProgress.actor.cpp
@@ -45,17 +45,21 @@ void BackupProgress::addBackupStatus(const WorkerBackupStatus& status) {
 }
 
 void BackupProgress::updateTagVersions(std::map<Tag, Version>* tagVersions, std::set<Tag>* tags,
-                                       const std::map<Tag, Version>& progress, Version endVersion, LogEpoch epoch) {
+                                       const std::map<Tag, Version>& progress, Version endVersion,
+                                       Version adjustedBeginVersion, LogEpoch epoch) {
 	for (const auto& [tag, savedVersion] : progress) {
 		// If tag is not in "tags", it means the old epoch has more tags than
 		// new epoch's tags. Just ignore the tag here.
 		auto n = tags->erase(tag);
 		if (n > 0 && savedVersion < endVersion - 1) {
-			tagVersions->insert({ tag, savedVersion + 1 });
+			const Version beginVersion =
+			    (savedVersion + 1 > adjustedBeginVersion) ? (savedVersion + 1) : adjustedBeginVersion;
+			tagVersions->insert({ tag, beginVersion });
 			TraceEvent("BackupVersionRange", dbgid)
 			    .detail("OldEpoch", epoch)
 			    .detail("Tag", tag.toString())
 			    .detail("BeginVersion", savedVersion + 1)
+			    .detail("AdjustedBeginVersion", beginVersion)
 			    .detail("EndVersion", endVersion);
 		}
 	}
@@ -66,12 +70,20 @@ std::map<std::tuple<LogEpoch, Version, int>, std::map<Tag, Version>> BackupProgr
 
 	if (!backupStartedValue.present()) return toRecruit; // No active backups
 
+	Version lastEnd = invalidVersion;
 	for (const auto& [epoch, info] : epochInfos) {
 		std::set<Tag> tags = enumerateLogRouterTags(info.logRouterTags);
 		std::map<Tag, Version> tagVersions;
+
+		// Sometimes, an epoch's begin version is lower than the previous epoch's
+		// end version. In this case, adjust the epoch's begin version to be the
+		// same as previous end version.
+		Version adjustedBeginVersion = lastEnd > info.epochBegin ? lastEnd : info.epochBegin;
+		lastEnd = info.epochEnd;
+
 		auto progressIt = progress.lower_bound(epoch);
 		if (progressIt != progress.end() && progressIt->first == epoch) {
-			updateTagVersions(&tagVersions, &tags, progressIt->second, info.epochEnd, epoch);
+			updateTagVersions(&tagVersions, &tags, progressIt->second, info.epochEnd, adjustedBeginVersion, epoch);
 		} else {
 			auto rit = std::find_if(
 			    progress.rbegin(), progress.rend(),
@@ -90,17 +102,18 @@ std::map<std::tuple<LogEpoch, Version, int>, std::map<Tag, Version>> BackupProgr
 					// The logRouterTags are the same
 					// ASSERT(info.logRouterTags == epochTags[rit->first]);
 
-					updateTagVersions(&tagVersions, &tags, rit->second, info.epochEnd, epoch);
+					updateTagVersions(&tagVersions, &tags, rit->second, info.epochEnd, adjustedBeginVersion, epoch);
 				}
 			}
 		}
 
 		for (const Tag tag : tags) { // tags without progress data
-			tagVersions.insert({ tag, info.epochBegin });
+			tagVersions.insert({ tag, adjustedBeginVersion });
 			TraceEvent("BackupVersionRange", dbgid)
 			    .detail("OldEpoch", epoch)
 			    .detail("Tag", tag.toString())
 			    .detail("BeginVersion", info.epochBegin)
+			    .detail("AdjustedBeginVersion", adjustedBeginVersion)
 			    .detail("EndVersion", info.epochEnd);
 		}
 		if (!tagVersions.empty()) {

--- a/fdbserver/BackupProgress.actor.h
+++ b/fdbserver/BackupProgress.actor.h
@@ -81,7 +81,8 @@ private:
 	// For each tag in progress, the saved version is smaller than endVersion - 1,
 	// add {tag, savedVersion+1} to tagVersions and remove the tag from "tags".
 	void updateTagVersions(std::map<Tag, Version>* tagVersions, std::set<Tag>* tags,
-	                       const std::map<Tag, Version>& progress, Version endVersion, LogEpoch epoch);
+	                       const std::map<Tag, Version>& progress, Version endVersion, Version adjustedBeginVersion,
+	                       LogEpoch epoch);
 
 	const UID dbgid;
 

--- a/fdbserver/BackupWorker.actor.cpp
+++ b/fdbserver/BackupWorker.actor.cpp
@@ -179,7 +179,9 @@ struct BackupData {
 							config.startedBackupWorkers().set(tr, workers.get());
 						}
 						for (auto p : workers.get()) {
-							TraceEvent("BackupWorkerDebug", self->myId).detail("Epoch", p.first).detail("TagID", p.second);
+							TraceEvent("BackupWorkerDebugTag", self->myId)
+							    .detail("Epoch", p.first)
+							    .detail("TagID", p.second);
 						}
 						wait(tr->commit());
 

--- a/fdbserver/RestoreMaster.actor.cpp
+++ b/fdbserver/RestoreMaster.actor.cpp
@@ -633,8 +633,7 @@ ACTOR static Future<Version> collectBackupFiles(Reference<IBackupContainer> bc, 
 		std::cout << "Restore to version: " << request.targetVersion << "\nBackupDesc: \n" << desc.toString() << "\n\n";
 	}
 
-	Optional<RestorableFileSet> restorable = wait(desc.partitioned ? bc->getPartitionedRestoreSet(request.targetVersion)
-	                                                               : bc->getRestoreSet(request.targetVersion));
+	Optional<RestorableFileSet> restorable = wait(bc->getRestoreSet(request.targetVersion));
 
 	if (!restorable.present()) {
 		TraceEvent(SevWarn, "FastRestoreMasterPhaseCollectBackupFiles").detail("NotRestorable", request.targetVersion);

--- a/fdbserver/RestoreMaster.actor.cpp
+++ b/fdbserver/RestoreMaster.actor.cpp
@@ -617,8 +617,7 @@ ACTOR static Future<Standalone<VectorRef<RestoreRequest>>> collectRestoreRequest
 ACTOR static Future<Version> collectBackupFiles(Reference<IBackupContainer> bc, std::vector<RestoreFileFR>* rangeFiles,
                                                 std::vector<RestoreFileFR>* logFiles, Database cx,
                                                 RestoreRequest request) {
-	state bool partitioned = wait(bc->isPartitionedBackup());
-	state BackupDescription desc = wait(partitioned ? bc->describePartitionedBackup() : bc->describeBackup());
+	state BackupDescription desc = wait(bc->describeBackup());
 
 	// Convert version to real time for operators to read the BackupDescription desc.
 	wait(desc.resolveVersionTimes(cx));
@@ -634,8 +633,8 @@ ACTOR static Future<Version> collectBackupFiles(Reference<IBackupContainer> bc, 
 		std::cout << "Restore to version: " << request.targetVersion << "\nBackupDesc: \n" << desc.toString() << "\n\n";
 	}
 
-	Optional<RestorableFileSet> restorable = wait(partitioned ? bc->getPartitionedRestoreSet(request.targetVersion)
-	                                                          : bc->getRestoreSet(request.targetVersion));
+	Optional<RestorableFileSet> restorable = wait(desc.partitioned ? bc->getPartitionedRestoreSet(request.targetVersion)
+	                                                               : bc->getRestoreSet(request.targetVersion));
 
 	if (!restorable.present()) {
 		TraceEvent(SevWarn, "FastRestoreMasterPhaseCollectBackupFiles").detail("NotRestorable", request.targetVersion);

--- a/fdbserver/workloads/BackupAndParallelRestoreCorrectness.actor.cpp
+++ b/fdbserver/workloads/BackupAndParallelRestoreCorrectness.actor.cpp
@@ -21,6 +21,7 @@
 #include "fdbrpc/simulator.h"
 #include "fdbclient/BackupAgent.actor.h"
 #include "fdbclient/BackupContainer.h"
+#include "fdbclient/ManagementAPI.actor.h"
 #include "fdbserver/workloads/workloads.actor.h"
 #include "fdbserver/workloads/BulkSetup.actor.h"
 #include "fdbclient/RestoreWorkerInterface.actor.h"
@@ -421,6 +422,11 @@ struct BackupAndParallelRestoreCorrectnessWorkload : TestWorkload {
 					// wait(attemptDirtyRestore(self, cx, &backupAgent, StringRef(lastBackupContainer->getURL()),
 					// randomID));
 				}
+
+				// We must ensure no backup workers are running, otherwise the clear DB
+				// below can be picked up by backup workers and applied during restore.
+				wait(success(changeConfig(cx, "backup_worker_enabled:=0", true)));
+
 				// Clear DB before restore
 				wait(runRYWTransaction(cx, [=](Reference<ReadYourWritesTransaction> tr) -> Future<Void> {
 					for (auto& kvrange : self->backupRanges) tr->clear(kvrange);
@@ -436,12 +442,6 @@ struct BackupAndParallelRestoreCorrectnessWorkload : TestWorkload {
 				auto container = IBackupContainer::openContainer(lastBackupContainer->getURL());
 				BackupDescription desc = wait(container->describeBackup());
 				ASSERT(self->usePartitionedLogs == desc.partitioned);
-
-				TraceEvent("BAFRW_Restore", randomID)
-				    .detail("LastBackupContainer", lastBackupContainer->getURL())
-				    .detail("MinRestorableVersion", desc.minRestorableVersion.get())
-				    .detail("MaxRestorableVersion", desc.maxRestorableVersion.get())
-				    .detail("ContiguousLogEnd", desc.contiguousLogEnd.get());
 
 				state Version targetVersion = -1;
 				if (desc.maxRestorableVersion.present()) {
@@ -460,6 +460,13 @@ struct BackupAndParallelRestoreCorrectnessWorkload : TestWorkload {
 						                                                   desc.contiguousLogEnd.get());
 					}
 				}
+
+				TraceEvent("BAFRW_Restore", randomID)
+				    .detail("LastBackupContainer", lastBackupContainer->getURL())
+				    .detail("MinRestorableVersion", desc.minRestorableVersion.get())
+				    .detail("MaxRestorableVersion", desc.maxRestorableVersion.get())
+				    .detail("ContiguousLogEnd", desc.contiguousLogEnd.get())
+				    .detail("TargetVersion", targetVersion);
 
 				state std::vector<Future<Version>> restores;
 				state std::vector<Standalone<StringRef>> restoreTags;

--- a/fdbserver/workloads/BackupAndParallelRestoreCorrectness.actor.cpp
+++ b/fdbserver/workloads/BackupAndParallelRestoreCorrectness.actor.cpp
@@ -218,7 +218,6 @@ struct BackupAndParallelRestoreCorrectnessWorkload : TestWorkload {
 
 						if(!fdesc.isError()) {
 							state BackupDescription desc = fdesc.get();
-							ASSERT(self->usePartitionedLogs == desc.partitioned);
 							wait(desc.resolveVersionTimes(cx));
 							printf("BackupDescription:\n%s\n", desc.toString().c_str());
 							restorable = desc.maxRestorableVersion.present();


### PR DESCRIPTION
 Consolidate `describePartitionedBackup()` into `describeBackup()` and remove `isPartitionedBackup()`, `getPartitionedRestoreSet()`.

This is a part of #2858