### PR TITLE
Performant restore [28/xx]: Improve bandwidth of sending mutations from loaders to appliers

### DIFF
--- a/fdbclient/FDBTypes.h
+++ b/fdbclient/FDBTypes.h
@@ -820,6 +820,11 @@ struct LogMessageVersion {
 	explicit LogMessageVersion(Version version) : version(version), sub(0) {}
 	LogMessageVersion() : version(0), sub(0) {}
 	bool empty() const { return (version == 0) && (sub == 0); }
+
+	template <class Ar>
+	void serialize(Ar& ar) {
+		serializer(ar, version, sub);
+	}
 };
 
 struct AddressExclusion {

--- a/fdbclient/RestoreWorkerInterface.actor.h
+++ b/fdbclient/RestoreWorkerInterface.actor.h
@@ -460,31 +460,31 @@ struct RestoreSendVersionedMutationsRequest : TimedRequest {
 	int batchIndex; // version batch index
 	RestoreAsset asset; // Unique identifier for the current restore asset
 
-	Version prevVersion, version; // version is the commitVersion of the mutation vector.
+	Version msgIndex; // Monitonically increasing index of mutation messages
 	bool isRangeFile;
-	MutationsVec mutations; // All mutations at the same version parsed by one loader
-	SubSequenceVec subs; // Sub-sequence number for mutations
+	MutationsVec mutations; // Mutations that may be at different versions parsed by one loader
+	LogMessageVersionVec mVersions; // (version, subversion) of each mutation in mutations field
 
 	ReplyPromise<RestoreCommonReply> reply;
 
 	RestoreSendVersionedMutationsRequest() = default;
-	explicit RestoreSendVersionedMutationsRequest(int batchIndex, const RestoreAsset& asset, Version prevVersion,
-	                                              Version version, bool isRangeFile, MutationsVec mutations,
-	                                              SubSequenceVec subs)
-	  : batchIndex(batchIndex), asset(asset), prevVersion(prevVersion), version(version), isRangeFile(isRangeFile),
-	    mutations(mutations), subs(subs) {}
+	explicit RestoreSendVersionedMutationsRequest(int batchIndex, const RestoreAsset& asset, Version msgIndex,
+	                                              bool isRangeFile, MutationsVec mutations,
+	                                              LogMessageVersionVec mVersions)
+	  : batchIndex(batchIndex), asset(asset), msgIndex(msgIndex), isRangeFile(isRangeFile), mutations(mutations),
+	    mVersions(mVersions) {}
 
 	std::string toString() {
 		std::stringstream ss;
-		ss << "VersionBatchIndex:" << batchIndex << "RestoreAsset:" << asset.toString()
-		   << " prevVersion:" << prevVersion << " version:" << version << " isRangeFile:" << isRangeFile
-		   << " mutations.size:" << mutations.size() << " subs.size:" << subs.size();
+		ss << "VersionBatchIndex:" << batchIndex << "RestoreAsset:" << asset.toString() << " msgIndex:" << msgIndex
+		   << " isRangeFile:" << isRangeFile << " mutations.size:" << mutations.size()
+		   << " mVersions.size:" << mVersions.size();
 		return ss.str();
 	}
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, batchIndex, asset, prevVersion, version, isRangeFile, mutations, subs, reply);
+		serializer(ar, batchIndex, asset, msgIndex, isRangeFile, mutations, mVersions, reply);
 	}
 };
 

--- a/fdbserver/Knobs.cpp
+++ b/fdbserver/Knobs.cpp
@@ -201,7 +201,7 @@ void ServerKnobs::initialize(bool randomize, ClientKnobs* clientKnobs, bool isSi
 	init( STORAGE_METRICS_POLLING_DELAY,                         2.0 ); if( randomize && BUGGIFY ) STORAGE_METRICS_POLLING_DELAY = 15.0;
 	init( STORAGE_METRICS_RANDOM_DELAY,                          0.2 );
 	init( AVAILABLE_SPACE_RATIO_CUTOFF,                         0.05 );
-	init( DESIRED_TEAMS_PER_SERVER,                                5 ); if( randomize && BUGGIFY ) DESIRED_TEAMS_PER_SERVER = deterministicRandom()->randomInt(1, 10);
+	init( DESIRED_TEAMS_PER_SERVER,                                5 ); DESIRED_TEAMS_PER_SERVER = deterministicRandom()->randomInt(1, 10);
 	init( MAX_TEAMS_PER_SERVER,           5*DESIRED_TEAMS_PER_SERVER );
 	init( DD_SHARD_SIZE_GRANULARITY,                         5000000 );
 	init( DD_SHARD_SIZE_GRANULARITY_SIM,                      500000 ); if( randomize && BUGGIFY ) DD_SHARD_SIZE_GRANULARITY_SIM = 0;
@@ -581,6 +581,7 @@ void ServerKnobs::initialize(bool randomize, ClientKnobs* clientKnobs, bool isSi
 	init( FASTRESTORE_HEARTBEAT_DELAY,                            10 ); if( randomize && BUGGIFY ) { FASTRESTORE_HEARTBEAT_DELAY = deterministicRandom()->random01() * 120 + 2; }
 	init( FASTRESTORE_HEARTBEAT_MAX_DELAY,                        10 ); if( randomize && BUGGIFY ) { FASTRESTORE_HEARTBEAT_MAX_DELAY = FASTRESTORE_HEARTBEAT_DELAY * 10; }
 	init( FASTRESTORE_APPLIER_FETCH_KEYS_SIZE,                   100 ); if( randomize && BUGGIFY ) { FASTRESTORE_APPLIER_FETCH_KEYS_SIZE =  deterministicRandom()->random01() * 10240 + 1; }
+	init( FASTRESTORE_LOADER_SEND_MUTATION_MSG_BYTES, 1.0 * 1024.0 * 1024.0 ); if( randomize && BUGGIFY ) { FASTRESTORE_LOADER_SEND_MUTATION_MSG_BYTES =  deterministicRandom()->random01() * 10.0 * 1024.0 * 1024.0 + 1; }
 
 	// clang-format on
 

--- a/fdbserver/Knobs.h
+++ b/fdbserver/Knobs.h
@@ -519,6 +519,7 @@ public:
 	int64_t FASTRESTORE_HEARTBEAT_DELAY; // interval for master to ping loaders and appliers
 	int64_t FASTRESTORE_HEARTBEAT_MAX_DELAY; // master claim a node is down if no heart beat from the node for this delay
 	int64_t FASTRESTORE_APPLIER_FETCH_KEYS_SIZE; // number of keys to fetch in a txn on applier
+	int64_t FASTRESTORE_LOADER_SEND_MUTATION_MSG_BYTES; // desired size of mutation message sent from loader to appliers
 
 	ServerKnobs();
 	void initialize(bool randomize = false, ClientKnobs* clientKnobs = NULL, bool isSimulated = false);

--- a/fdbserver/RestoreApplier.actor.cpp
+++ b/fdbserver/RestoreApplier.actor.cpp
@@ -110,35 +110,29 @@ ACTOR static Future<Void> handleSendMutationVectorRequest(RestoreSendVersionedMu
 	state Reference<ApplierBatchData> batchData = self->batch[req.batchIndex];
 	// Assume: processedFileState[req.asset] will not be erased while the actor is active.
 	// Note: Insert new items into processedFileState will not invalidate the reference.
-	state NotifiedVersion& curFilePos = batchData->processedFileState[req.asset];
+	state NotifiedVersion& curMsgIndex = batchData->processedFileState[req.asset];
 
 	TraceEvent(SevDebug, "FastRestoreApplierPhaseReceiveMutations", self->id())
 	    .detail("BatchIndex", req.batchIndex)
 	    .detail("RestoreAsset", req.asset.toString())
-	    .detail("ProcessedFileVersion", curFilePos.get())
+	    .detail("RestoreAssetMesssageIndex", curMsgIndex.get())
 	    .detail("Request", req.toString())
 	    .detail("CurrentMemory", getSystemStatistics().processMemory)
 	    .detail("PreviousVersionBatchState", batchData->vbState.get());
 
 	wait(isSchedulable(self, req.batchIndex, __FUNCTION__));
 
-	wait(curFilePos.whenAtLeast(req.prevVersion));
+	wait(curMsgIndex.whenAtLeast(req.msgIndex - 1));
 	batchData->vbState = ApplierVersionBatchState::RECEIVE_MUTATIONS;
 
 	state bool isDuplicated = true;
-	if (curFilePos.get() == req.prevVersion) {
+	if (curMsgIndex.get() == req.msgIndex - 1) {
 		isDuplicated = false;
-		const Version commitVersion = req.version;
-		// Sanity check: mutations in range file is in [beginVersion, endVersion);
-		// mutations in log file is in [beginVersion, endVersion], both inclusive.
-		ASSERT(commitVersion >= req.asset.beginVersion);
-		// Loader sends the endVersion to ensure all useful versions are sent
-		ASSERT(commitVersion <= req.asset.endVersion);
-		ASSERT(req.mutations.size() == req.subs.size());
+		ASSERT(req.mutations.size() == req.mVersions.size());
 
 		for (int mIndex = 0; mIndex < req.mutations.size(); mIndex++) {
 			const MutationRef& mutation = req.mutations[mIndex];
-			const LogMessageVersion mutationVersion(commitVersion, req.subs[mIndex]);
+			const LogMessageVersion mutationVersion(req.mVersions[mIndex]);
 			TraceEvent(SevFRMutationInfo, "FastRestoreApplierPhaseReceiveMutations", self->id())
 			    .detail("RestoreAsset", req.asset.toString())
 			    .detail("Version", mutationVersion.toString())
@@ -149,6 +143,7 @@ ACTOR static Future<Void> handleSendMutationVectorRequest(RestoreSendVersionedMu
 			batchData->counters.receivedMutations += 1;
 			batchData->counters.receivedAtomicOps += isAtomicOp((MutationRef::Type)mutation.type) ? 1 : 0;
 			// Sanity check
+			ASSERT_WE_THINK(req.asset.isInVersionRange(mutationVersion.version));
 			ASSERT_WE_THINK(req.asset.isInKeyRange(mutation));
 
 			// Note: Log and range mutations may be delivered out of order. Can we handle it?
@@ -157,14 +152,14 @@ ACTOR static Future<Void> handleSendMutationVectorRequest(RestoreSendVersionedMu
 			ASSERT(mutation.type != MutationRef::SetVersionstampedKey &&
 			       mutation.type != MutationRef::SetVersionstampedValue);
 		}
-		curFilePos.set(req.version);
+		curMsgIndex.set(req.msgIndex);
 	}
 
 	req.reply.send(RestoreCommonReply(self->id(), isDuplicated));
 	TraceEvent(SevDebug, "FastRestoreApplierPhaseReceiveMutationsDone", self->id())
 	    .detail("BatchIndex", req.batchIndex)
 	    .detail("RestoreAsset", req.asset.toString())
-	    .detail("ProcessedFileVersion", curFilePos.get())
+	    .detail("ProcessedMessageIndex", curMsgIndex.get())
 	    .detail("Request", req.toString());
 	return Void();
 }

--- a/fdbserver/RestoreApplier.actor.h
+++ b/fdbserver/RestoreApplier.actor.h
@@ -107,8 +107,9 @@ struct StagingKey {
 				// TODO: Add SevError here
 				TraceEvent("SameVersion")
 				    .detail("Version", version.toString())
-				    .detail("Mutation", m.toString())
-				    .detail("NewVersion", newVersion.toString());
+				    .detail("NewVersion", newVersion.toString())
+				    .detail("OldMutation", it->second.toString())
+				    .detail("NewMutation", m.toString());
 				ASSERT(it->second.type == m.type && it->second.param1 == m.param1 && it->second.param2 == m.param2);
 			}
 		}

--- a/fdbserver/RestoreUtil.h
+++ b/fdbserver/RestoreUtil.h
@@ -39,7 +39,7 @@
 #define SevFRMutationInfo SevInfo
 
 using MutationsVec = Standalone<VectorRef<MutationRef>>;
-using SubSequenceVec = Standalone<VectorRef<uint32_t>>;
+using LogMessageVersionVec = Standalone<VectorRef<LogMessageVersion>>;
 
 enum class RestoreRole { Invalid = 0, Master = 1, Loader, Applier };
 BINARY_SERIALIZABLE(RestoreRole);


### PR DESCRIPTION
With this PR, loaders no longer has the constraint: mutations in a message sent to applier must belong to the same version.

The size of mutation message is tunable.