### PR TITLE
Remove `-isystem flow/-lpthread` from INCLUDES/CXXFLAGS

### DIFF
--- a/flow/CMakeLists.txt
+++ b/flow/CMakeLists.txt
@@ -87,7 +87,6 @@ set(FLOW_SRCS
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/SourceVersion.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/SourceVersion.h)
 
 add_flow_target(STATIC_LIBRARY NAME flow SRCS ${FLOW_SRCS})
-target_include_directories(flow SYSTEM PUBLIC ${CMAKE_THREAD_LIBS_INIT})
 target_include_directories(flow PUBLIC ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
 if (NOT APPLE AND NOT WIN32)
   set (FLOW_LIBS ${FLOW_LIBS} rt)


### PR DESCRIPTION
This cmake line generated a bogus and nonsensical include path, so as
the entire line isn't necessary, just remove it.

Thus finally answering where this strange line came from in my compile_commands.json.