### PR TITLE
Update go.mod module directive to segmentio

### DIFF
--- a/bindings/go/go.mod
+++ b/bindings/go/go.mod
@@ -1,4 +1,4 @@
-module github.com/apple/foundationdb/bindings/go
+module github.com/segmentio/foundationdb/bindings/go
 
 // The FoundationDB go bindings currently have no external golang dependencies outside of
 // the go standard library.


### PR DESCRIPTION
This PR updates the `module` directive in `go.mod` to be github.com/segmentio instead of github.com/apple -- otherwise, any attempt to `go get` this module causes:

```
	github.com/segmentio/foundationdb/bindings/go/src/fdb: github.com/segmentio/foundationdb/bindings/go@v0.0.0-20190405054838-7b0e8c692095: parsing go.mod:
	module declares its path as: github.com/apple/foundationdb/bindings/go
	        but was required as: github.com/segmentio/foundationdb/bindings/go
```

If we were doing things the `go mod` way from day one, we would have used this repo as a `replace` directive. But that's not the approach we took: code in github.com/segmentio/record imports code in this repo with the path "github.com/segmentio/foundationdb", and so code in github.com/segmentio/record can't be used from `go mod` code because of the mistmatch between what this module is used as (segmentio) versus what it declares itself to be (apple).