### PR TITLE
Treat backup file parsing error as failure

### DIFF
--- a/fdbserver/RestoreCommon.actor.cpp
+++ b/fdbserver/RestoreCommon.actor.cpp
@@ -343,7 +343,7 @@ ACTOR Future<Standalone<VectorRef<KeyValueRef>>> decodeRangeFileBlock(Reference<
 		return results;
 
 	} catch (Error& e) {
-		TraceEvent(SevWarn, "FileRestoreCorruptRangeFileBlock")
+		TraceEvent(SevError, "FileRestoreCorruptRangeFileBlock")
 		    .error(e)
 		    .detail("Filename", file->getFilename())
 		    .detail("BlockOffset", offset)
@@ -388,7 +388,7 @@ ACTOR Future<Standalone<VectorRef<KeyValueRef>>> decodeLogFileBlock(Reference<IA
 		return results;
 
 	} catch (Error& e) {
-		TraceEvent(SevWarn, "FileRestoreCorruptLogFileBlock")
+		TraceEvent(SevError, "FileRestoreCorruptLogFileBlock")
 		    .error(e)
 		    .detail("Filename", file->getFilename())
 		    .detail("BlockOffset", offset)


### PR DESCRIPTION
Whenever a backup file (range or log) throws error in parsing, treat it as failure.