### PR TITLE
Fix backup progress calculation

### DIFF
--- a/fdbclient/BackupContainer.actor.cpp
+++ b/fdbclient/BackupContainer.actor.cpp
@@ -1193,7 +1193,10 @@ public:
 		std::vector<LogFile> filtered;
 		int i = 0;
 		for (int j = 1; j < logs.size(); j++) {
-			if (logs[j].isSubset(logs[i])) continue;
+			if (logs[j].isSubset(logs[i])) {
+				ASSERT(logs[j].fileSize <= logs[i].fileSize);
+				continue;
+			}
 
 			if (!logs[i].isSubset(logs[j])) {
 				filtered.push_back(logs[i]);
@@ -1249,6 +1252,7 @@ public:
 			// filter out if indices.back() is subset of files[i] or vice versa
 			if (!indices.empty()) {
 				if (logs[indices.back()].isSubset(logs[i])) {
+					ASSERT(logs[indices.back()].fileSize <= logs[i].fileSize);
 					indices.back() = i;
 				} else if (!logs[i].isSubset(logs[indices.back()])) {
 					indices.push_back(i);

--- a/fdbserver/BackupProgress.actor.cpp
+++ b/fdbserver/BackupProgress.actor.cpp
@@ -83,6 +83,15 @@ std::map<std::tuple<LogEpoch, Version, int>, std::map<Tag, Version>> BackupProgr
 
 		auto progressIt = progress.lower_bound(epoch);
 		if (progressIt != progress.end() && progressIt->first == epoch) {
+			if (progressIt != progress.begin() && info.epochBegin == 1) {
+				// Previous epoch is gone, consolidate the progress.
+				auto prev = std::prev(progressIt);
+				for (auto [tag, version] : prev->second) {
+					if (tags.count(tag) > 0) {
+						progressIt->second[tag] = std::max(version, progressIt->second[tag]);
+					}
+				}
+			}
 			updateTagVersions(&tagVersions, &tags, progressIt->second, info.epochEnd, adjustedBeginVersion, epoch);
 		} else {
 			auto rit = std::find_if(

--- a/fdbserver/BackupProgress.actor.cpp
+++ b/fdbserver/BackupProgress.actor.cpp
@@ -83,7 +83,7 @@ std::map<std::tuple<LogEpoch, Version, int>, std::map<Tag, Version>> BackupProgr
 
 		auto progressIt = progress.lower_bound(epoch);
 		if (progressIt != progress.end() && progressIt->first == epoch) {
-			if (progressIt != progress.begin() && info.epochBegin == 1) {
+			if (progressIt != progress.begin()) {
 				// Previous epoch is gone, consolidate the progress.
 				auto prev = std::prev(progressIt);
 				for (auto [tag, version] : prev->second) {

--- a/fdbserver/BackupWorker.actor.cpp
+++ b/fdbserver/BackupWorker.actor.cpp
@@ -68,7 +68,8 @@ struct BackupData {
 	const UID myId;
 	const Tag tag; // LogRouter tag for this worker, i.e., (-2, i)
 	const int totalTags; // Total log router tags
-	const Version startVersion;
+	// Backup request's commit version. Mutations are logged at some version after this.
+	const Version startVersion; // This worker's start version
 	const Optional<Version> endVersion; // old epoch's end version (inclusive), or empty for current epoch
 	const LogEpoch recruitedEpoch; // current epoch whose tLogs are receiving mutations
 	const LogEpoch backupEpoch; // the epoch workers should pull mutations
@@ -292,7 +293,7 @@ struct BackupData {
 		}
 		ASSERT_WE_THINK(backupEpoch == oldestBackupEpoch);
 		const Tag popTag = logSystem.get()->getPseudoPopTag(tag, ProcessClass::BackupClass);
-		logSystem.get()->pop(popVersion, popTag);
+		logSystem.get()->pop(std::max(popVersion, savedVersion), popTag);
 	}
 
 	void stop() {

--- a/fdbserver/BackupWorker.actor.cpp
+++ b/fdbserver/BackupWorker.actor.cpp
@@ -327,6 +327,7 @@ struct BackupData {
 		}
 
 		bool modified = false;
+		bool minVersionChanged = false;
 		Version minVersion = std::numeric_limits<Version>::max();
 		for (const auto [uid, version] : uidVersions) {
 			auto it = backups.find(uid);
@@ -334,6 +335,7 @@ struct BackupData {
 				modified = true;
 				backups.emplace(uid, BackupData::PerBackupInfo(this, uid, version));
 				minVersion = std::min(minVersion, version);
+				minVersionChanged = true;
 			} else {
 				stopList.erase(uid);
 			}
@@ -345,7 +347,7 @@ struct BackupData {
 			it->second.stop();
 			modified = true;
 		}
-		if (backupEpoch < recruitedEpoch && savedVersion + 1 == startVersion) {
+		if (minVersionChanged && backupEpoch < recruitedEpoch && savedVersion + 1 == startVersion) {
 			// Advance savedVersion to minimize version ranges in case backupEpoch's
 			// progress is not saved. Master may set a very low startVersion that
 			// is already popped. Advance the version is safe because these

--- a/fdbserver/TagPartitionedLogSystem.actor.cpp
+++ b/fdbserver/TagPartitionedLogSystem.actor.cpp
@@ -188,6 +188,7 @@ struct TagPartitionedLogSystem : ILogSystem, ReferenceCounted<TagPartitionedLogS
 	bool remoteLogsWrittenToCoreState;
 	bool hasRemoteServers;
 	AsyncTrigger backupWorkerChanged;
+	std::set<UID> removedBackupWorkers; // Workers that are removed before setting them.
 
 	Optional<Version> recoverAt;
 	Optional<Version> recoveredAt;
@@ -1399,6 +1400,10 @@ struct TagPartitionedLogSystem : ILogSystem, ReferenceCounted<TagPartitionedLogS
 		LogEpoch logsetEpoch = this->epoch;
 		oldestBackupEpoch = this->epoch;
 		for (const auto& reply : replies) {
+			if (removedBackupWorkers.count(reply.interf.id()) > 0) {
+				removedBackupWorkers.erase(reply.interf.id());
+				continue;
+			}
 			Reference<AsyncVar<OptionalInterface<BackupInterface>>> worker(new AsyncVar<OptionalInterface<BackupInterface>>(OptionalInterface<BackupInterface>(reply.interf)));
 			if (reply.backupEpoch != logsetEpoch) {
 				// find the logset from oldLogData
@@ -1408,6 +1413,9 @@ struct TagPartitionedLogSystem : ILogSystem, ReferenceCounted<TagPartitionedLogS
 				ASSERT(logset.isValid());
 			}
 			logset->backupWorkers.push_back(worker);
+			TraceEvent("AddBackupWorker", dbgid)
+			    .detail("Epoch", logsetEpoch)
+			    .detail("BackupWorkerID", reply.interf.id());
 		}
 		TraceEvent("SetOldestBackupEpoch", dbgid).detail("Epoch", oldestBackupEpoch);
 		backupWorkerChanged.trigger();
@@ -1434,6 +1442,8 @@ struct TagPartitionedLogSystem : ILogSystem, ReferenceCounted<TagPartitionedLogS
 				}
 			}
 			backupWorkerChanged.trigger();
+		} else {
+			removedBackupWorkers.insert(req.workerUID);
 		}
 
 		TraceEvent("RemoveBackupWorker", dbgid)


### PR DESCRIPTION
The oldest epoch the master gets can assume its begin version is some lower number (e.g., 1), which can be wrong. In this case, we use the saved backup progress to "true-up" the real begin version.

Another true-up is done for a backup's begin version to the exact version of the first mutation. This is needed to ensure the strict less than relationship between two mutation logs, if one's version range is within the other.
    
A problematic scenario is as follows:
    Epoch 1: a mutation log A [200, 900] is saved, but its progress is NOT saved.
    Epoch 2: master recruits a worker for [1, 1000], 1000 is epoch 1's end version.
             New worker saves a mutation log B [100, 1000]
A's range is strict within B's range, but A's size is larger than B.
    
This happens because B's start version is true-up to the backup's begin version, which is not the actual version of the first mutation. After B's begin version is true-up to 300, we won't have this issue.

This is a part of #2858