### PR TITLE
Write range files' begin & end keys to backup's manifest file

### DIFF
--- a/fdbclient/BackupAgent.actor.h
+++ b/fdbclient/BackupAgent.actor.h
@@ -934,5 +934,10 @@ struct StringRefReader {
 	Error failure_error;
 };
 
+namespace fileBackup {
+ACTOR Future<Standalone<VectorRef<KeyValueRef>>> decodeRangeFileBlock(Reference<IAsyncFile> file, int64_t offset,
+                                                                      int len);
+}
+
 #include "flow/unactorcompiler.h"
 #endif

--- a/fdbclient/BackupContainer.actor.cpp
+++ b/fdbclient/BackupContainer.actor.cpp
@@ -1353,6 +1353,7 @@ public:
 			// No logs needed if there is a complete key space snapshot at the target version.
 			if (snapshot.get().beginVersion == snapshot.get().endVersion &&
 			    snapshot.get().endVersion == targetVersion) {
+				restorable.continuousBeginVersion = restorable.continuousEndVersion = invalidVersion;
 				return Optional<RestorableFileSet>(restorable);
 			}
 

--- a/fdbclient/BackupContainer.h
+++ b/fdbclient/BackupContainer.h
@@ -231,7 +231,9 @@ public:
 
 	// Write a KeyspaceSnapshotFile of range file names representing a full non overlapping
 	// snapshot of the key ranges this backup is targeting.
-	virtual Future<Void> writeKeyspaceSnapshotFile(std::vector<std::string> fileNames, int64_t totalBytes) = 0;
+	virtual Future<Void> writeKeyspaceSnapshotFile(const std::vector<std::string>& fileNames,
+	                                               const std::vector<std::pair<Key, Key>>& beginEndKeys,
+	                                               int64_t totalBytes) = 0;
 
 	// Open a file for read by name
 	virtual Future<Reference<IAsyncFile>> readFile(std::string name) = 0;

--- a/fdbclient/BackupContainer.h
+++ b/fdbclient/BackupContainer.h
@@ -197,7 +197,8 @@ struct RestorableFileSet {
 	// Range file's key ranges. Can be empty for backups generated before 6.3.
 	std::map<std::string, KeyRange> keyRanges;
 
-	// Mutation logs continuous range [begin, end)
+	// Mutation logs continuous range [begin, end). Both can be invalidVersion
+	// when the entire key space snapshot is at the target version.
 	Version continuousBeginVersion, continuousEndVersion;
 
 	KeyspaceSnapshotFile snapshot; // Info. for debug purposes

--- a/fdbclient/BackupContainer.h
+++ b/fdbclient/BackupContainer.h
@@ -193,6 +193,13 @@ struct RestorableFileSet {
 	Version targetVersion;
 	std::vector<LogFile> logs;
 	std::vector<RangeFile> ranges;
+
+	// Range file's key ranges. Can be empty for backups generated before 6.3.
+	std::map<std::string, KeyRange> keyRanges;
+
+	// Mutation logs continuous range [begin, end)
+	Version continuousBeginVersion, continuousEndVersion;
+
 	KeyspaceSnapshotFile snapshot; // Info. for debug purposes
 };
 

--- a/fdbclient/BackupContainer.h
+++ b/fdbclient/BackupContainer.h
@@ -108,6 +108,12 @@ struct RangeFile {
 	std::string fileName;
 	int64_t fileSize;
 
+	RangeFile() {}
+	RangeFile(Version v, uint32_t bSize, std::string name, int64_t size)
+	  : version(v), blockSize(bSize), fileName(name), fileSize(size) {}
+	RangeFile(const RangeFile& f)
+	  : version(f.version), blockSize(f.blockSize), fileName(f.fileName), fileSize(f.fileSize) {}
+
 	// Order by version, break ties with name
 	bool operator< (const RangeFile &rhs) const {
 		return version == rhs.version ? fileName < rhs.fileName : version < rhs.version;
@@ -245,6 +251,10 @@ public:
 
 	// Open a file for read by name
 	virtual Future<Reference<IAsyncFile>> readFile(std::string name) = 0;
+
+	// Returns the key ranges in the snapshot file. This is an expensive function
+	// and should only be used in simulation for sanity check.
+	virtual Future<KeyRange> getSnapshotFileKeyRange(const RangeFile& file) = 0;
 
 	struct ExpireProgress {
 		std::string step;

--- a/fdbclient/FileBackupAgent.actor.cpp
+++ b/fdbclient/FileBackupAgent.actor.cpp
@@ -2257,6 +2257,7 @@ namespace fileBackup {
 			}
 
 			std::vector<std::string> files;
+			std::vector<std::pair<Key, Key>> beginEndKeys;
 			state Version maxVer = 0;
 			state Version minVer = std::numeric_limits<Version>::max();
 			state int64_t totalBytes = 0;
@@ -2271,6 +2272,9 @@ namespace fileBackup {
 
 					// Add file to final file list
 					files.push_back(r.fileName);
+
+					// Add (beginKey, endKey) pairs to the list
+					beginEndKeys.emplace_back(i->second.begin, i->first);
 
 					// Update version range seen
 					if(r.version < minVer)
@@ -2293,7 +2297,7 @@ namespace fileBackup {
 			}
 
 			Params.endVersion().set(task, maxVer);
-			wait(bc->writeKeyspaceSnapshotFile(files, totalBytes));
+			wait(bc->writeKeyspaceSnapshotFile(files, beginEndKeys, totalBytes));
 
 			TraceEvent(SevInfo, "FileBackupWroteSnapshotManifest")
 				.detail("BackupUID", config.getUid())

--- a/fdbclient/JSONDoc.h
+++ b/fdbclient/JSONDoc.h
@@ -193,7 +193,7 @@ struct JSONDoc {
 		return v.get_value<T>();
 	}
 
-	// Ensures that a an Object exists at path and returns a JSONDoc that writes to it.
+	// Ensures that an Object exists at path and returns a JSONDoc that writes to it.
 	JSONDoc subDoc(std::string path, bool split=true) {
 		json_spirit::mValue &v = create(path, split);
 		if(v.type() != json_spirit::obj_type)

--- a/fdbserver/RestoreCommon.actor.h
+++ b/fdbserver/RestoreCommon.actor.h
@@ -248,8 +248,6 @@ struct RestoreFileFR {
 };
 
 namespace parallelFileRestore {
-ACTOR Future<Standalone<VectorRef<KeyValueRef>>> decodeRangeFileBlock(Reference<IAsyncFile> file, int64_t offset,
-                                                                      int len);
 ACTOR Future<Standalone<VectorRef<KeyValueRef>>> decodeLogFileBlock(Reference<IAsyncFile> file, int64_t offset,
                                                                     int len);
 } // namespace parallelFileRestore

--- a/fdbserver/RestoreLoader.actor.cpp
+++ b/fdbserver/RestoreLoader.actor.cpp
@@ -23,6 +23,7 @@
 
 #include "flow/UnitTest.h"
 #include "fdbclient/BackupContainer.h"
+#include "fdbclient/BackupAgent.actor.h"
 #include "fdbserver/RestoreLoader.actor.h"
 #include "fdbserver/RestoreRoleCommon.actor.h"
 
@@ -816,11 +817,18 @@ ACTOR static Future<Void> _parseRangeFileToMutationsOnLoader(
 
 	// The set of key value version is rangeFile.version. the key-value set in the same range file has the same version
 	Reference<IAsyncFile> inFile = wait(bc->readFile(asset.filename));
-	Standalone<VectorRef<KeyValueRef>> blockData =
-	    wait(parallelFileRestore::decodeRangeFileBlock(inFile, asset.offset, asset.len));
-	TraceEvent("FastRestore")
-	    .detail("DecodedRangeFile", asset.filename)
-	    .detail("DataSize", blockData.contents().size());
+	state VectorRef<KeyValueRef> blockData;
+	try {
+		Standalone<VectorRef<KeyValueRef>> kvs =
+		    wait(fileBackup::decodeRangeFileBlock(inFile, asset.offset, asset.len));
+		TraceEvent("FastRestore")
+		    .detail("DecodedRangeFile", asset.filename)
+		    .detail("DataSize", kvs.contents().size());
+		blockData = kvs;
+	} catch (Error& e) {
+		TraceEvent(SevError, "FileRestoreCorruptRangeFileBlock").error(e);
+		throw;
+	}
 
 	// First and last key are the range for this file
 	KeyRange fileRange = KeyRangeRef(blockData.front().key, blockData.back().key);

--- a/fdbserver/workloads/BackupAndParallelRestoreCorrectness.actor.cpp
+++ b/fdbserver/workloads/BackupAndParallelRestoreCorrectness.actor.cpp
@@ -450,7 +450,8 @@ struct BackupAndParallelRestoreCorrectnessWorkload : TestWorkload {
 						targetVersion = desc.minRestorableVersion.get();
 					} else if (deterministicRandom()->random01() < 0.1) {
 						targetVersion = desc.maxRestorableVersion.get();
-					} else if (deterministicRandom()->random01() < 0.5) {
+					} else if (deterministicRandom()->random01() < 0.5 &&
+					           desc.minRestorableVersion.get() < desc.contiguousLogEnd.get()) {
 						// The assertion may fail because minRestorableVersion may be decided by snapshot version.
 						// ASSERT_WE_THINK(desc.minRestorableVersion.get() <= desc.contiguousLogEnd.get());
 						// This assertion can fail when contiguousLogEnd < maxRestorableVersion and


### PR DESCRIPTION
This information can be very useful in knowing the content in these files, especially for restores.

The `RestorableFileSet` has been changed to provide range file's key ranges read from the manifest, as well as providing the continuous logs' version range.

Now the manifest looks like:
```
{
  "beginVersion": 503220272,
  "endVersion": 782301777,
  "files": [
    "kvranges/snapshot.000000000498286936/0/range,782301777,9dfec472659756f8d2547ffca4b00570,1048576",
    "kvranges/snapshot.000000000498286936/0/range,775960292,d6e5f43d28f6c6abb286d1f5513e50d2,1048576",
    "ranges/0000000/0007/range,769914768,8363975cad03a74170d519014ab2a286,868778",
    "kvranges/snapshot.000000000498286936/0/range,764039809,e45e003119bd2ac558c29fe9210d9bb1,342769",
    "ranges/0000000/0007/range,752129017,91d5ea777b3b80c7c920a80965c939f7,1048576",
    "ranges/0000000/0007/range,745804047,e02ad7d97079ad7ff0fde6896e227bfe,2926678",
    "ranges/0000000/0005/range,509338820,d862ac6be31a721dca54c4fbbdb6ec61,1048576",
    "kvranges/snapshot.000000000498286936/0/range,503220272,b47b048de505264957b7a995cf537242,1048576"
  ],
  "keyRanges": {
    "kvranges/snapshot.000000000498286936/0/range,503220272,b47b048de505264957b7a995cf537242,1048576": {
      "beginKey": "",
      "endKey": "debug000000050000000100000db4\u0000"
    },
    "kvranges/snapshot.000000000498286936/0/range,764039809,e45e003119bd2ac558c29fe9210d9bb1,342769": {
      "beginKey": "log0000002e0000000300000c8f\u0000",
      "endKey": "log0000005c0000000400000a2c\u0000"
    },
    "kvranges/snapshot.000000000498286936/0/range,775960292,d6e5f43d28f6c6abb286d1f5513e50d2,1048576": {
      "beginKey": "log00000060000000000000098c\u0000",
      "endKey": "ops0000001900000114\u0000"
    },
    "kvranges/snapshot.000000000498286936/0/range,782301777,9dfec472659756f8d2547ffca4b00570,1048576": {
      "beginKey": "ops0000001900000114\u0000",
      "endKey": "ÿ"
    },
    "ranges/0000000/0005/range,509338820,d862ac6be31a721dca54c4fbbdb6ec61,1048576": {
      "beginKey": "debug000000050000000100000db4\u0000",
      "endKey": "debug00000038000000050000060f\u0000"
    },
    "ranges/0000000/0007/range,745804047,e02ad7d97079ad7ff0fde6896e227bfe,2926678": {
      "beginKey": "debug00000038000000050000060f\u0000",
      "endKey": "debug0000003e0000000000000d4f\u0000"
    },
    "ranges/0000000/0007/range,752129017,91d5ea777b3b80c7c920a80965c939f7,1048576": {
      "beginKey": "debug0000003e0000000000000d4f\u0000",
      "endKey": "log0000002e0000000300000c8f\u0000"
    },
    "ranges/0000000/0007/range,769914768,8363975cad03a74170d519014ab2a286,868778": {
      "beginKey": "log0000005c0000000400000a2c\u0000",
      "endKey": "log00000060000000000000098c\u0000"
    }
  },
  "totalBytes": 3079492
}
```

This is part of #2858