### PR TITLE
Prevent main thread from destroying flatbuffers globals

### DIFF
--- a/flow/flat_buffers.cpp
+++ b/flow/flat_buffers.cpp
@@ -31,10 +31,12 @@
 namespace detail {
 
 namespace {
-std::vector<int> mWriteToOffsetsMemoy;
+thread_local std::vector<int> gWriteToOffsetsMemory;
 }
 
-std::vector<int>* writeToOffsetsMemory = &mWriteToOffsetsMemoy;
+void swapWithThreadLocalGlobal(std::vector<int>& writeToOffsets) {
+	gWriteToOffsetsMemory.swap(writeToOffsets);
+}
 
 VTable generate_vtable(size_t numMembers, const std::vector<unsigned>& sizesAlignments) {
 	if (numMembers == 0) {


### PR DESCRIPTION
We recently witnessed (using tsan) that if the main thread exits without first
joining the network thread, we can see data races and
heap-use-after-free's in flatbuffers globals.

Now the lifetime of these globals will be tied to the network thread
itself (and I guess every thread, but the one that actually uses memory
will be owned by the network thread.)

Fixes #2463