### PR TITLE
Stop background eio threads on Net2::stop()

### DIFF
--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -995,6 +995,7 @@ void setupNetwork(uint64_t transportId, bool useMetrics) {
 		networkOptions.logClientInfo = true;
 
 	g_network = newNet2(tlsConfig, false, useMetrics || networkOptions.traceDirectory.present());
+	g_network->addStopCallback( Net2FileSystem::stop );
 	FlowTransport::createInstance(true, transportId);
 	Net2FileSystem::newFileSystem();
 }

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -997,6 +997,7 @@ void setupNetwork(uint64_t transportId, bool useMetrics) {
 	TLS::DisableOpenSSLAtExitHandler();
 	g_network = newNet2(tlsConfig, false, useMetrics || networkOptions.traceDirectory.present());
 	g_network->addStopCallback( Net2FileSystem::stop );
+	g_network->addStopCallback( TLS::DestroyOpenSSLGlobalState );
 	FlowTransport::createInstance(true, transportId);
 	Net2FileSystem::newFileSystem();
 }
@@ -1021,7 +1022,6 @@ void stopNetwork() {
 
 	g_network->stop();
 	closeTraceFile();
-	TLS::DestroyOpenSSLGlobalState();
 }
 
 Reference<ProxyInfo> DatabaseContext::getMasterProxies(bool useProvisionalProxies) {

--- a/fdbrpc/AsyncFileEIO.actor.h
+++ b/fdbrpc/AsyncFileEIO.actor.h
@@ -52,6 +52,10 @@ public:
 		}
 	}
 
+	static void stop() {
+		eio_set_max_parallel(0);
+	}
+
 	static bool should_poll() { return want_poll; }
 
 	static bool lock_fd( int fd ) {

--- a/fdbrpc/AsyncFileWinASIO.actor.h
+++ b/fdbrpc/AsyncFileWinASIO.actor.h
@@ -39,6 +39,8 @@ class AsyncFileWinASIO : public IAsyncFile, public ReferenceCounted<AsyncFileWin
 public:
 	static void init() {}
 
+	static void stop() {}
+
 	static bool should_poll() { return false; }
 	// FIXME: This implementation isn't actually asynchronous - it just does operations synchronously!
 

--- a/fdbrpc/FlowTests.actor.cpp
+++ b/fdbrpc/FlowTests.actor.cpp
@@ -194,6 +194,7 @@ struct YieldMockNetwork : INetwork, ReferenceCounted<YieldMockNetwork> {
 	virtual double now() { return baseNetwork->now(); }
 	virtual double timer() { return baseNetwork->timer(); }
 	virtual void stop() { return baseNetwork->stop(); }
+	virtual void addStopCallback( std::function<void()> fn ) { ASSERT(false); return; }
 	virtual bool isSimulated() const { return baseNetwork->isSimulated(); }
 	virtual void onMainThread(Promise<Void>&& signal, TaskPriority taskID) { return baseNetwork->onMainThread(std::move(signal), taskID); }
 	bool isOnMainThread() const override { return baseNetwork->isOnMainThread(); }

--- a/fdbrpc/Net2FileSystem.cpp
+++ b/fdbrpc/Net2FileSystem.cpp
@@ -114,3 +114,7 @@ Net2FileSystem::Net2FileSystem(double ioTimeout, std::string fileSystemPath)
 	}
 #endif
 }
+
+void Net2FileSystem::stop() {
+	Net2AsyncFile::stop();
+}

--- a/fdbrpc/Net2FileSystem.h
+++ b/fdbrpc/Net2FileSystem.h
@@ -36,6 +36,7 @@ public:
 	virtual Future< std::time_t > lastWriteTime( std::string filename );
 
 	//void init();
+	static void stop();
 
 	Net2FileSystem(double ioTimeout=0.0, std::string fileSystemPath = "");
 

--- a/fdbrpc/sim2.actor.cpp
+++ b/fdbrpc/sim2.actor.cpp
@@ -870,7 +870,15 @@ public:
 		return emptyConfig;
 	}
 
-	virtual void stop() { isStopped = true; }
+	virtual void stop() {
+		isStopped = true;
+		for ( auto& fn : stopCallbacks ) {
+			fn();
+		}
+	}
+	virtual void addStopCallback( std::function<void()> fn ) {
+		stopCallbacks.emplace_back(std::move(fn));
+	}
 	virtual bool isSimulated() const { return true; }
 
 	struct SimThreadArgs {
@@ -1605,6 +1613,7 @@ public:
 		// Not letting currentProcess be NULL eliminates some annoying special cases
 		currentProcess = new ProcessInfo("NoMachine", LocalityData(Optional<Standalone<StringRef>>(), StringRef(), StringRef(), StringRef()), ProcessClass(), {NetworkAddress()}, this, "", "");
 		g_network = net2 = newNet2(TLSConfig(), false, true);
+		g_network->addStopCallback( Net2FileSystem::stop );
 		Net2FileSystem::newFileSystem();
 		check_yield(TaskPriority::Zero);
 	}
@@ -1702,6 +1711,8 @@ public:
 
 	//tasks is guarded by ISimulator::mutex
 	std::priority_queue<Task, std::vector<Task>> tasks;
+
+	std::vector<std::function<void()>> stopCallbacks;
 
 	//Sim2Net network;
 	INetwork *net2;

--- a/fdbrpc/sim2.actor.cpp
+++ b/fdbrpc/sim2.actor.cpp
@@ -872,9 +872,6 @@ public:
 
 	virtual void stop() {
 		isStopped = true;
-		for ( auto& fn : stopCallbacks ) {
-			fn();
-		}
 	}
 	virtual void addStopCallback( std::function<void()> fn ) {
 		stopCallbacks.emplace_back(std::move(fn));
@@ -1002,6 +999,9 @@ public:
 		}
 		self->currentProcess = callingMachine;
 		self->net2->stop();
+		for ( auto& fn : self->stopCallbacks ) {
+			fn();
+		}
 		return Void();
 	}
 

--- a/fdbserver/fdbserver.actor.cpp
+++ b/fdbserver/fdbserver.actor.cpp
@@ -1551,6 +1551,7 @@ int main(int argc, char* argv[]) {
 			openTraceFile(NetworkAddress(), rollsize, maxLogsSize, logFolder, "trace", logGroup);
 		} else {
 			g_network = newNet2(tlsConfig, useThreadPool, true);
+			g_network->addStopCallback( Net2FileSystem::stop );
 			FlowTransport::createInstance(false, 1);
 
 			const bool expectsPublicAddress = (role == FDBD || role == NetworkTestServer || role == Restore);

--- a/flow/Net2.actor.cpp
+++ b/flow/Net2.actor.cpp
@@ -42,6 +42,7 @@
 
 // See the comment in TLSConfig.actor.h for the explanation of why this module breaking include was done.
 #include "fdbrpc/IAsyncFile.h"
+#include "fdbrpc/Net2FileSystem.h"
 
 #ifdef WIN32
 #include <mmsystem.h>
@@ -200,6 +201,7 @@ public:
 	void trackMinPriority( TaskPriority minTaskID, double now );
 	void stopImmediately() {
 		stopped=true; decltype(ready) _1; ready.swap(_1); decltype(timers) _2; timers.swap(_2);
+		Net2FileSystem::stop();
 	}
 
 	Future<Void> timeOffsetLogger;

--- a/flow/Net2.actor.cpp
+++ b/flow/Net2.actor.cpp
@@ -207,9 +207,6 @@ public:
 	void trackMinPriority( TaskPriority minTaskID, double now );
 	void stopImmediately() {
 		stopped=true; decltype(ready) _1; ready.swap(_1); decltype(timers) _2; timers.swap(_2);
-		for ( auto& fn : stopCallbacks ) {
-			fn();
-		}
 	}
 
 	Future<Void> timeOffsetLogger;
@@ -1187,6 +1184,10 @@ void Net2::run() {
 
 		if ((nnow-now) > FLOW_KNOBS->SLOW_LOOP_CUTOFF && nondeterministicRandom()->random01() < (nnow-now)*FLOW_KNOBS->SLOW_LOOP_SAMPLING_RATE)
 			TraceEvent("SomewhatSlowRunLoopBottom").detail("Elapsed", nnow - now); // This includes the time spent running tasks
+	}
+
+	for ( auto& fn : stopCallbacks ) {
+		fn();
 	}
 
 	#ifdef WIN32

--- a/flow/Net2.actor.cpp
+++ b/flow/Net2.actor.cpp
@@ -141,14 +141,12 @@ public:
 		if ( thread_network == this )
 			stopImmediately();
 		else
-			// SOMEDAY: NULL for deferred error, no analysis of correctness (itp)
 			onMainThreadVoid( [this] { this->stopImmediately(); }, NULL );
 	}
 	virtual void addStopCallback( std::function<void()> fn ) {
 		if ( thread_network == this )
 			stopCallbacks.emplace_back(std::move(fn));
 		else
-			// SOMEDAY: NULL for deferred error, no analysis of correctness (itp)
 			onMainThreadVoid( [this, fn] { this->stopCallbacks.emplace_back(std::move(fn)); }, NULL );
 	}
 

--- a/flow/network.h
+++ b/flow/network.h
@@ -463,6 +463,10 @@ public:
 	virtual void stop() = 0;
 	// Terminate the program
 
+	virtual void addStopCallback( std::function<void()> fn ) = 0;
+	// Calls `fn` when stop() is called.
+	// addStopCallback can be called more than once, and each added `fn` will be run once.
+
 	virtual bool isSimulated() const = 0;
 	// Returns true if this network is a local simulation
 


### PR DESCRIPTION
This will stop eio threads for both the client (`fdb_stop_network()`)
and the server.  This change is being done more for the former, but I
don't see any harm in doing the latter as well.

Tested using an (AJ-provided) [reproduction test](https://gist.github.com/alexmiller-apple/0ac7c4cea6b0b2b746677e61af1def4b), where one attaches gdb and looks at the threads that exist after `fdb_stop_network()` is called.

Before:
```
0x00007f1c6469d728 in __GI___nanosleep (requested_time=requested_time@entry=0x7ffe00ae7310, remaining=remaining@entry=0x7ffe00ae7310)
    at ../sysdeps/unix/sysv/linux/nanosleep.c:28
28	  return SYSCALL_CANCEL (nanosleep, requested_time, remaining);
Missing separate debuginfos, use: dnf debuginfo-install libgcc-8.3.1-2.fc29.x86_64 libstdc++-8.3.1-2.fc29.x86_64
(gdb) thread apply all bt

Thread 3 (Thread 0x7f1c647c6700 (LWP 3541)):
#0  futex_wait_cancelable (private=0, expected=0, futex_word=0x7f1c653a7048 <reqwait+40>) at ../sysdeps/unix/sysv/linux/futex-internal.h:88
#1  __pthread_cond_wait_common (abstime=0x0, mutex=0x7f1c653a7060 <reqlock>, cond=0x7f1c653a7020 <reqwait>) at pthread_cond_wait.c:502
#2  __pthread_cond_wait (cond=cond@entry=0x7f1c653a7020 <reqwait>, mutex=mutex@entry=0x7f1c653a7060 <reqlock>) at pthread_cond_wait.c:655
#3  0x00007f1c6490e558 in etp_proc (thr_arg=0x7f1c5c00cbc0) at /home/alexmiller/foundationdb/fdbrpc/libeio/eio.c:2195
#4  0x00007f1c647a14aa in start_thread (arg=<optimized out>) at pthread_create.c:479
#5  0x00007f1c646d13f3 in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95

Thread 2 (Thread 0x7f1c647cf700 (LWP 3540)):
#0  futex_wait_cancelable (private=0, expected=0, futex_word=0x7f1c653a7048 <reqwait+40>) at ../sysdeps/unix/sysv/linux/futex-internal.h:88
#1  __pthread_cond_wait_common (abstime=0x0, mutex=0x7f1c653a7060 <reqlock>, cond=0x7f1c653a7020 <reqwait>) at pthread_cond_wait.c:502
#2  __pthread_cond_wait (cond=cond@entry=0x7f1c653a7020 <reqwait>, mutex=mutex@entry=0x7f1c653a7060 <reqlock>) at pthread_cond_wait.c:655
#3  0x00007f1c6490e558 in etp_proc (thr_arg=0x7f1c5c00aae0) at /home/alexmiller/foundationdb/fdbrpc/libeio/eio.c:2195
#4  0x00007f1c647a14aa in start_thread (arg=<optimized out>) at pthread_create.c:479
#5  0x00007f1c646d13f3 in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95

Thread 1 (Thread 0x7f1c64288dc0 (LWP 3538)):
#0  0x00007f1c6469d728 in __GI___nanosleep (requested_time=requested_time@entry=0x7ffe00ae7310, remaining=remaining@entry=0x7ffe00ae7310)
    at ../sysdeps/unix/sysv/linux/nanosleep.c:28
#1  0x00007f1c6469d62e in __sleep (seconds=0, seconds@entry=30) at ../sysdeps/posix/sleep.c:55
#2  0x00000000004011d6 in main (argc=<optimized out>, argv=0x7ffe00ae7458) at test.c:83
(gdb)
```

After:

```
0x00007fb2a1a60728 in __GI___nanosleep (requested_time=requested_time@entry=0x7ffd1cdf06a0, remaining=remaining@entry=0x7ffd1cdf06a0)
    at ../sysdeps/unix/sysv/linux/nanosleep.c:28
28	  return SYSCALL_CANCEL (nanosleep, requested_time, remaining);
Missing separate debuginfos, use: dnf debuginfo-install libgcc-8.3.1-2.fc29.x86_64 libstdc++-8.3.1-2.fc29.x86_64
(gdb) thread apply all bt

Thread 1 (Thread 0x7fb2a164bdc0 (LWP 32610)):
#0  0x00007fb2a1a60728 in __GI___nanosleep (requested_time=requested_time@entry=0x7ffd1cdf06a0, remaining=remaining@entry=0x7ffd1cdf06a0)
    at ../sysdeps/unix/sysv/linux/nanosleep.c:28
#1  0x00007fb2a1a6062e in __sleep (seconds=0, seconds@entry=30) at ../sysdeps/posix/sleep.c:55
#2  0x00000000004011d6 in main (argc=<optimized out>, argv=0x7ffd1cdf07e8) at test.c:83
```

Fixes #2842 