### PR TITLE
Backup fixes

### DIFF
--- a/fdbserver/BackupWorker.actor.cpp
+++ b/fdbserver/BackupWorker.actor.cpp
@@ -68,7 +68,6 @@ struct BackupData {
 	const UID myId;
 	const Tag tag; // LogRouter tag for this worker, i.e., (-2, i)
 	const int totalTags; // Total log router tags
-	// Backup request's commit version. Mutations are logged at some version after this.
 	const Version startVersion; // This worker's start version
 	const Optional<Version> endVersion; // old epoch's end version (inclusive), or empty for current epoch
 	const LogEpoch recruitedEpoch; // current epoch whose tLogs are receiving mutations
@@ -209,8 +208,12 @@ struct BackupData {
 		}
 
 		BackupData* self = nullptr;
+
+		// Backup request's commit version. Mutations are logged at some version after this.
 		Version startVersion = invalidVersion;
+		// The last mutation log's saved version (not inclusive), i.e., next log's begin version.
 		Version lastSavedVersion = invalidVersion;
+
 		Future<Optional<Reference<IBackupContainer>>> container;
 		Future<Optional<std::vector<KeyRange>>> ranges; // Key ranges of this backup
 		Future<Void> updateWorker;

--- a/fdbserver/BackupWorker.actor.cpp
+++ b/fdbserver/BackupWorker.actor.cpp
@@ -765,6 +765,10 @@ ACTOR Future<Void> uploadData(BackupData* self) {
 
 		state int numMsg = 0;
 		Version lastPopVersion = popVersion;
+		// index of last version's end position in self->messages
+		int lastVersionIndex = 0;
+		Version lastVersion = invalidVersion;
+
 		if (self->messages.empty()) {
 			// Even though messages is empty, we still want to advance popVersion.
 			if (!self->endVersion.present()) {
@@ -773,18 +777,30 @@ ACTOR Future<Void> uploadData(BackupData* self) {
 		} else {
 			for (const auto& message : self->messages) {
 				// message may be prefetched in peek; uncommitted message should not be uploaded.
-				if (message.getVersion() > self->maxPopVersion()) break;
-				popVersion = std::max(popVersion, message.getVersion());
+				const Version version = message.getVersion();
+				if (version > self->maxPopVersion()) break;
+				if (version > popVersion) {
+					lastVersionIndex = numMsg;
+					lastVersion = popVersion;
+					popVersion = version;
+				}
 				numMsg++;
 			}
 		}
 		if (self->pullFinished()) {
 			popVersion = self->endVersion.get();
+		} else {
+			// make sure file is saved on version boundary
+			popVersion = lastVersion;
+			numMsg = lastVersionIndex;
 		}
 		if (((numMsg > 0 || popVersion > lastPopVersion) && self->pulling) || self->pullFinished()) {
 			TraceEvent("BackupWorkerSave", self->myId)
 			    .detail("Version", popVersion)
+			    .detail("LastPopVersion", lastPopVersion)
+			    .detail("Pulling", self->pulling)
 			    .detail("SavedVersion", self->savedVersion)
+			    .detail("NumMsg", numMsg)
 			    .detail("MsgQ", self->messages.size());
 			// save an empty file for old epochs so that log file versions are continuous
 			wait(saveMutationsToFile(self, popVersion, numMsg));


### PR DESCRIPTION
Fixed:

- Backup worker saves the same version's mutations in multiple log files, which violates the contract with restore;
- Backup container may contain empty minRestorableVersion

This is part of #2858