### PR TITLE
Match 6.2.15's behavior in how invalid/unreadable/non-existent certs are handled.

### DIFF
--- a/flow/Net2.actor.cpp
+++ b/flow/Net2.actor.cpp
@@ -148,7 +148,7 @@ public:
 		if ( thread_network == this )
 			stopCallbacks.emplace_back(std::move(fn));
 		else
-			onMainThreadVoid( [this, fn] { this->stopCallbacks.emplace_back(std::move(fn)); }, NULL );
+			onMainThreadVoid( [this, fn] { this->stopCallbacks.emplace_back(std::move(fn)); }, nullptr );
 	}
 
 	virtual bool isSimulated() const { return false; }

--- a/flow/Net2.actor.cpp
+++ b/flow/Net2.actor.cpp
@@ -907,13 +907,19 @@ ACTOR static Future<Void> watchFileForChanges( std::string filename, AsyncTrigge
 	if (filename == "") {
 		return Never();
 	}
-	state std::time_t lastModTime = wait(IAsyncFileSystem::filesystem()->lastWriteTime(filename));
+	state bool firstRun = true;
+	state bool statError = false;
+	state std::time_t lastModTime = 0;
 	loop {
-		wait(delay(FLOW_KNOBS->TLS_CERT_REFRESH_DELAY_SECONDS));
 		try {
 			std::time_t modtime = wait(IAsyncFileSystem::filesystem()->lastWriteTime(filename));
-			if (lastModTime != modtime) {
+			if (firstRun) {
 				lastModTime = modtime;
+				firstRun = false;
+			}
+			if (lastModTime != modtime || statError) {
+				lastModTime = modtime;
+				statError = false;
 				fileChanged->trigger();
 			}
 		} catch (Error& e) {
@@ -923,10 +929,12 @@ ACTOR static Future<Void> watchFileForChanges( std::string filename, AsyncTrigge
 				// certificates, then there's no point in crashing, but we should complain
 				// loudly.  IAsyncFile will log the error, but not necessarily as a warning.
 				TraceEvent(SevWarnAlways, "TLSCertificateRefreshStatError").detail("File", filename);
+				statError = true;
 			} else {
 				throw;
 			}
 		}
+		wait(delay(FLOW_KNOBS->TLS_CERT_REFRESH_DELAY_SECONDS));
 	}
 }
 
@@ -975,9 +983,9 @@ void Net2::initTLS() {
 		return;
 	}
 #ifndef TLS_DISABLED
+	auto onPolicyFailure = [this]() { this->countTLSPolicyFailures++; };
 	try {
 		boost::asio::ssl::context newContext(boost::asio::ssl::context::tls);
-		auto onPolicyFailure = [this]() { this->countTLSPolicyFailures++; };
 		const LoadedTLSConfig& loaded = tlsConfig.loadSync();
 		TraceEvent("Net2TLSConfig")
 			.detail("CAPath", tlsConfig.getCAPathSync())
@@ -987,11 +995,10 @@ void Net2::initTLS() {
 			.detail("VerifyPeers", boost::algorithm::join(loaded.getVerifyPeers(), "|"));
 		ConfigureSSLContext( tlsConfig.loadSync(), &newContext, onPolicyFailure );
 		sslContextVar.set(ReferencedObject<boost::asio::ssl::context>::from(std::move(newContext)));
-		backgroundCertRefresh = reloadCertificatesOnChange( tlsConfig, onPolicyFailure, &sslContextVar );
 	} catch (Error& e) {
 		TraceEvent("Net2TLSInitError").error(e);
-		throw tls_error();
 	}
+	backgroundCertRefresh = reloadCertificatesOnChange( tlsConfig, onPolicyFailure, &sslContextVar );
 #endif
 	tlsInitialized = true;
 }


### PR DESCRIPTION
Which is to proceed past Net2 creation, and allow certificate refresh to
try and eventually load valid certs.  Additionally, fix certificate
refeshing dieing if the certificate is not readable when first called.

In testing, I also found and fixed an issue where if a cert went from
unreadable to readable, we wouldn't reload the TLS context, due to not
considering it as a file change.

---

This PR builds on top #2980, which should be merged first, and then all but one of the commits here will drop out.

Fixes #2992 

---

```
FDBLibTLS/testdata $ mv test-client-1.pem test-client-1.pem.bak
```

```
$ FDB_TLS_CA_FILE=FDBLibTLS/testdata/test-ca-1.pem FDB_TLS_CERTIFICATE_FILE=FDBLibTLS/testdata/test-client-1.pem FDB_TLS_KEY_FILE=FDBLibTLS/testdata/test-client-1.pem ./bin/fdbcli  -C ../local.cluster --log --log-dir=. --knob_tls_cert_refresh_delay_seconds=1
Using cluster file `../local.cluster'.

The database is unavailable; type `status' for more information.

Welcome to the fdbcli. For help, type `help'.
fdb> status

Using cluster file `../local.cluster'.

Could not communicate with a quorum of coordination servers:
  127.0.0.1:5000:tls  (unreachable)
```

```
FDBLibTLS/testdata $ mv test-client-1.pem.bak test-client-1.pem
```

```
fdb> status

Using cluster file `../local.cluster'.

Configuration:
  Redundancy mode        - single
  Storage engine         - ssd-2
  Coordinators           - 1
```