### PR TITLE
Don't simulate a TTY if clangd is invoked by IDE

### DIFF
--- a/build/gen_dev_docker.sh
+++ b/build/gen_dev_docker.sh
@@ -64,9 +64,14 @@ then
         ccache_args=\$args
 fi
 
+if [ -t 1 ] ; then
+    TERMINAL_ARGS=-it `# Run in interactive mode and simulate a TTY`
+else
+    TERMINAL_ARGS=-i `# Run in interactive mode`
+fi
 
 sudo docker run --rm `# delete (temporary) image after return` \\
-                -it `# Run in interactive mode and simulate a TTY` \\
+                \${TERMINAL_ARGS}  \\
                 --privileged=true `# Run in privileged mode ` \\
                 --cap-add=SYS_PTRACE \\
                 --security-opt seccomp=unconfined \\
@@ -87,6 +92,7 @@ then
         echo -e "\tThis can cause problems with some scripts (like fdb-clangd)"
 fi
 chmod +x $HOME/bin/fdb-dev
+chmod +x $HOME/bin/clangd
 echo "To start the dev docker image run $HOME/bin/fdb-dev"
 echo "$HOME/bin/clangd can be used for IDE integration"
 echo "You can edit these files but be aware that this script will overwrite your changes if you rerun it"


### PR DESCRIPTION
Without this, vscode complains that clangd just crashes.

Also make ~/bin/clangd executable