### PR TITLE
Depend on actorcompiler.exe

### DIFF
--- a/cmake/FlowCommands.cmake
+++ b/cmake/FlowCommands.cmake
@@ -185,12 +185,12 @@ function(add_flow_target)
         if(WIN32)
           add_custom_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${generated}"
             COMMAND $<TARGET_FILE:actorcompiler> "${CMAKE_CURRENT_SOURCE_DIR}/${src}" "${CMAKE_CURRENT_BINARY_DIR}/${generated}" ${actor_compiler_flags}
-            DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/${src}"
+            DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/${src}" ${actor_exe}
             COMMENT "Compile actor: ${src}")
         else()
           add_custom_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${generated}"
             COMMAND ${MONO_EXECUTABLE} ${actor_exe} "${CMAKE_CURRENT_SOURCE_DIR}/${src}" "${CMAKE_CURRENT_BINARY_DIR}/${generated}" ${actor_compiler_flags} > /dev/null
-            DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/${src}"
+            DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/${src}" ${actor_exe}
             COMMENT "Compile actor: ${src}")
         endif()
       else()


### PR DESCRIPTION
Fixes #2985

This was originally done in 0443cf89eafdaaf7db813b3229f01a0debe0de37,
and removed in 75f692b9317b42bc3237e940228cf23d996dea35, but I'm
not sure why it was removed. I'm guessing it was a botched merge.

Separately it looks like 5c294e2646 removed this dependency in the name of fixing parallel builds on Windows. If this PR breaks parallel builds on windows, maybe we can just leave the WIN32 branch as is.