### PR TITLE
Bug fix:  HTTPS requests could hang.

### DIFF
--- a/documentation/sphinx/source/release-notes.rst
+++ b/documentation/sphinx/source/release-notes.rst
@@ -2,6 +2,14 @@
 Release Notes
 #############
 
+6.2.21
+======
+
+Fixes
+-----
+
+* HTTPS requests made by backup could hang indefinitely.  `(PR #3027) <https://github.com/apple/foundationdb/pull/3027>`_
+
 6.2.20
 ======
 

--- a/fdbclient/HTTP.actor.cpp
+++ b/fdbclient/HTTP.actor.cpp
@@ -91,10 +91,6 @@ namespace HTTP {
 	// Returns the number of bytes read.
 	ACTOR Future<int> read_into_string(Reference<IConnection> conn, std::string *buf, int maxlen) {
 		loop {
-			// Wait for connection to have something to read
-			wait(conn->onReadable());
-			wait( delay( 0, TaskPriority::ReadSocket ) );
-
 			// Read into buffer
 			int originalSize = buf->size();
 			// TODO:  resize is zero-initializing the space we're about to overwrite, so do something else, which probably means
@@ -107,6 +103,10 @@ namespace HTTP {
 			// Make sure data was actually read, it's possible for there to be none.
 			if(len > 0)
 				return len;
+
+			// Wait for connection to have something to read
+			wait(conn->onReadable());
+			wait( delay( 0, TaskPriority::ReadSocket ) );
 		}
 	}
 
@@ -352,9 +352,6 @@ namespace HTTP {
 			send_start = timer();
 
 			loop {
-				wait(conn->onWritable());
-				wait( delay( 0, TaskPriority::WriteSocket ) );
-
 				// If we already got a response, before finishing sending the request, then close the connection,
 				// set the Connection header to "close" as a hint to the caller that this connection can't be used
 				// again, and break out of the send loop.
@@ -375,6 +372,11 @@ namespace HTTP {
 				pContent->sent(len);
 				if(pContent->empty())
 					break;
+
+				if(len == 0) {
+					wait(conn->onWritable());
+					wait( delay( 0, TaskPriority::WriteSocket ) );
+				}
 			}
 
 			wait(responseReading);

--- a/flow/network.h
+++ b/flow/network.h
@@ -364,9 +364,11 @@ public:
 
 	virtual Future<Void> connectHandshake() = 0;
 
+	// Precondition: write() has been called and last returned 0
 	// returns when write() can write at least one byte (or may throw an error if the connection dies)
 	virtual Future<Void> onWritable() = 0;
 
+	// Precondition: read() has been called and last returned 0
 	// returns when read() can read at least one byte (or may throw an error if the connection dies)
 	virtual Future<Void> onReadable() = 0;
 


### PR DESCRIPTION
HTTP client was using stated contract for IConnection, which was different from the contract assumed by FlowTransport and implemented by SSLConnection.  Updated HTTP client, added comments to IConnection to clarify the actual interface contract.

This only has been an issue since the switch to boost ssl_socket.