### PR TITLE
go: Update Stringer interface on Tuple and Subspace

### DIFF
--- a/bindings/go/src/fdb/directory/directorySubspace.go
+++ b/bindings/go/src/fdb/directory/directorySubspace.go
@@ -23,6 +23,8 @@
 package directory
 
 import (
+	"fmt"
+	"strings"
 	"github.com/apple/foundationdb/bindings/go/src/fdb"
 	"github.com/apple/foundationdb/bindings/go/src/fdb/subspace"
 )
@@ -41,6 +43,18 @@ type directorySubspace struct {
 	dl    directoryLayer
 	path  []string
 	layer []byte
+}
+
+// String implements the fmt.Stringer interface and returns human-readable
+// string representation of this object.
+func (ds directorySubspace) String() string {
+	var path string
+	if len(ds.path) > 0 {
+		path = "(" + strings.Join(ds.path, ",") + ")"
+	} else {
+		path = "nil"
+	}
+	return fmt.Sprintf("DirectorySubspace(%s, %s)", path, fdb.Printable(ds.Bytes()))
 }
 
 func (d directorySubspace) CreateOrOpen(t fdb.Transactor, path []string, layer []byte) (DirectorySubspace, error) {

--- a/bindings/go/src/fdb/subspace/subspace.go
+++ b/bindings/go/src/fdb/subspace/subspace.go
@@ -35,6 +35,8 @@ package subspace
 import (
 	"bytes"
 	"errors"
+	"fmt"
+
 	"github.com/apple/foundationdb/bindings/go/src/fdb"
 	"github.com/apple/foundationdb/bindings/go/src/fdb/tuple"
 )
@@ -42,6 +44,8 @@ import (
 // Subspace represents a well-defined region of keyspace in a FoundationDB
 // database.
 type Subspace interface {
+	fmt.Stringer
+
 	// Sub returns a new Subspace whose prefix extends this Subspace with the
 	// encoding of the provided element(s). If any of the elements are not a
 	// valid tuple.TupleElement, Sub will panic.
@@ -103,6 +107,12 @@ func FromBytes(b []byte) Subspace {
 	s := make([]byte, len(b))
 	copy(s, b)
 	return subspace{s}
+}
+
+// String implements the fmt.Stringer interface and return the subspace
+// as a human readable byte string provided by fdb.Printable.
+func (s subspace) String() string {
+	return fdb.Printable(s.b)
 }
 
 func (s subspace) Sub(el ...tuple.TupleElement) Subspace {

--- a/bindings/go/src/fdb/subspace/subspace.go
+++ b/bindings/go/src/fdb/subspace/subspace.go
@@ -44,8 +44,6 @@ import (
 // Subspace represents a well-defined region of keyspace in a FoundationDB
 // database.
 type Subspace interface {
-	fmt.Stringer
-
 	// Sub returns a new Subspace whose prefix extends this Subspace with the
 	// encoding of the provided element(s). If any of the elements are not a
 	// valid tuple.TupleElement, Sub will panic.

--- a/bindings/go/src/fdb/subspace/subspace.go
+++ b/bindings/go/src/fdb/subspace/subspace.go
@@ -112,7 +112,7 @@ func FromBytes(b []byte) Subspace {
 // String implements the fmt.Stringer interface and return the subspace
 // as a human readable byte string provided by fdb.Printable.
 func (s subspace) String() string {
-	return fdb.Printable(s.b)
+	return fmt.Sprintf("Subspace(rawPrefix=%s)", fdb.Printable(s.b))
 }
 
 func (s subspace) Sub(el ...tuple.TupleElement) Subspace {

--- a/bindings/go/src/fdb/subspace/subspace.go
+++ b/bindings/go/src/fdb/subspace/subspace.go
@@ -86,7 +86,7 @@ type Subspace interface {
 }
 
 type subspace struct {
-	b []byte
+	rawPrefix []byte
 }
 
 // AllKeys returns the Subspace corresponding to all keys in a FoundationDB
@@ -112,7 +112,7 @@ func FromBytes(b []byte) Subspace {
 // String implements the fmt.Stringer interface and return the subspace
 // as a human readable byte string provided by fdb.Printable.
 func (s subspace) String() string {
-	return fmt.Sprintf("Subspace(rawPrefix=%s)", fdb.Printable(s.b))
+	return fmt.Sprintf("Subspace(rawPrefix=%s)", fdb.Printable(s.rawPrefix))
 }
 
 func (s subspace) Sub(el ...tuple.TupleElement) Subspace {
@@ -120,35 +120,35 @@ func (s subspace) Sub(el ...tuple.TupleElement) Subspace {
 }
 
 func (s subspace) Bytes() []byte {
-	return s.b
+	return s.rawPrefix
 }
 
 func (s subspace) Pack(t tuple.Tuple) fdb.Key {
-	return fdb.Key(concat(s.b, t.Pack()...))
+	return fdb.Key(concat(s.rawPrefix, t.Pack()...))
 }
 
 func (s subspace) PackWithVersionstamp(t tuple.Tuple) (fdb.Key, error) {
-	return t.PackWithVersionstamp(s.b)
+	return t.PackWithVersionstamp(s.rawPrefix)
 }
 
 func (s subspace) Unpack(k fdb.KeyConvertible) (tuple.Tuple, error) {
 	key := k.FDBKey()
-	if !bytes.HasPrefix(key, s.b) {
+	if !bytes.HasPrefix(key, s.rawPrefix) {
 		return nil, errors.New("key is not in subspace")
 	}
-	return tuple.Unpack(key[len(s.b):])
+	return tuple.Unpack(key[len(s.rawPrefix):])
 }
 
 func (s subspace) Contains(k fdb.KeyConvertible) bool {
-	return bytes.HasPrefix(k.FDBKey(), s.b)
+	return bytes.HasPrefix(k.FDBKey(), s.rawPrefix)
 }
 
 func (s subspace) FDBKey() fdb.Key {
-	return fdb.Key(s.b)
+	return fdb.Key(s.rawPrefix)
 }
 
 func (s subspace) FDBRangeKeys() (fdb.KeyConvertible, fdb.KeyConvertible) {
-	return fdb.Key(concat(s.b, 0x00)), fdb.Key(concat(s.b, 0xFF))
+	return fdb.Key(concat(s.rawPrefix, 0x00)), fdb.Key(concat(s.rawPrefix, 0xFF))
 }
 
 func (s subspace) FDBRangeKeySelectors() (fdb.Selectable, fdb.Selectable) {

--- a/bindings/go/src/fdb/subspace/subspace_test.go
+++ b/bindings/go/src/fdb/subspace/subspace_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestSubspaceString(t *testing.T) {
 	printed := fmt.Sprint(Sub([]byte("hello"), "world", 42, 0x99))
-	expected := "\\x01hello\\x00\\x02world\\x00\\x15*\\x15\\x99"
+	expected := "Subspace(rawPrefix=\\x01hello\\x00\\x02world\\x00\\x15*\\x15\\x99)"
 
 	if printed != expected {
 		t.Fatalf("printed subspace result differs, expected %v, got %v", expected, printed)

--- a/bindings/go/src/fdb/subspace/subspace_test.go
+++ b/bindings/go/src/fdb/subspace/subspace_test.go
@@ -1,0 +1,15 @@
+package subspace
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestSubspaceString(t *testing.T) {
+	printed := fmt.Sprint(Sub([]byte("hello"), "world", 42, 0x99))
+	expected := "\\x01hello\\x00\\x02world\\x00\\x15*\\x15\\x99"
+
+	if printed != expected {
+		t.Fatalf("printed subspace result differs, expected %v, got %v", expected, printed)
+	}
+}

--- a/bindings/go/src/fdb/tuple/tuple.go
+++ b/bindings/go/src/fdb/tuple/tuple.go
@@ -66,6 +66,12 @@ type TupleElement interface{}
 // packing T (modulo type normalization to []byte, uint64, and int64).
 type Tuple []TupleElement
 
+// String implements the fmt.Stringer interface and return the tuple
+// as a human readable byte string provided by fdb.Printable.
+func (t Tuple) String() string {
+	return fdb.Printable(t.Pack())
+}
+
 // UUID wraps a basic byte array as a UUID. We do not provide any special
 // methods for accessing or generating the UUID, but as Go does not provide
 // a built-in UUID type, this simple wrapper allows for other libraries

--- a/bindings/go/src/fdb/tuple/tuple.go
+++ b/bindings/go/src/fdb/tuple/tuple.go
@@ -43,6 +43,8 @@ import (
 	"fmt"
 	"math"
 	"math/big"
+	"strconv"
+	"strings"
 
 	"github.com/apple/foundationdb/bindings/go/src/fdb"
 )
@@ -66,10 +68,47 @@ type TupleElement interface{}
 // packing T (modulo type normalization to []byte, uint64, and int64).
 type Tuple []TupleElement
 
-// String implements the fmt.Stringer interface and return the tuple
-// as a human readable byte string provided by fdb.Printable.
-func (t Tuple) String() string {
-	return fdb.Printable(t.Pack())
+// String implements the fmt.Stringer interface and returns human-readable
+// string representation of this tuple. For most elements, we use the
+// object's default string representation.
+func (tuple Tuple) String() string {
+	sb := strings.Builder{}
+	printTuple(tuple, &sb)
+	return sb.String()
+}
+
+func printTuple(tuple Tuple, sb *strings.Builder) {
+	// TODO: Add VersionStamp printer
+	sb.WriteString("(")
+
+	for i, t := range tuple {
+		switch t := t.(type) {
+		case Tuple:
+			printTuple(t, sb)
+		case nil:
+			sb.WriteString("<nil>")
+		case string:
+			sb.WriteString(strconv.Quote(t))
+		case UUID:
+			sb.WriteString("UUID(")
+			sb.WriteString(t.String())
+			sb.WriteString(")")
+		case []byte:
+			sb.WriteString("b\"")
+			sb.WriteString(fdb.Printable(t))
+			sb.WriteString("\"")
+		default:
+			// For user-defined and standard types, we use standard Go
+			// printer, which itself uses Stringer interface.
+			fmt.Fprintf(sb, "%v", t)
+		}
+
+		if (i < len(tuple) - 1) {
+			sb.WriteString(", ")
+		}
+	}
+
+	sb.WriteString(")")
 }
 
 // UUID wraps a basic byte array as a UUID. We do not provide any special
@@ -78,6 +117,10 @@ func (t Tuple) String() string {
 // to write the output of their UUID type as a 16-byte array into
 // an instance of this type.
 type UUID [16]byte
+
+func (uuid UUID) String() string {
+	return fmt.Sprintf("%x-%x-%x-%x-%x", uuid[0:4], uuid[4:6], uuid[6:8], uuid[8:10], uuid[10:])
+}
 
 // Versionstamp is struct for a FoundationDB verionstamp. Versionstamps are
 // 12 bytes long composed of a 10 byte transaction version and a 2 byte user

--- a/bindings/go/src/fdb/tuple/tuple.go
+++ b/bindings/go/src/fdb/tuple/tuple.go
@@ -78,7 +78,6 @@ func (tuple Tuple) String() string {
 }
 
 func printTuple(tuple Tuple, sb *strings.Builder) {
-	// TODO: Add VersionStamp printer
 	sb.WriteString("(")
 
 	for i, t := range tuple {
@@ -129,6 +128,11 @@ func (uuid UUID) String() string {
 type Versionstamp struct {
 	TransactionVersion [10]byte
 	UserVersion        uint16
+}
+
+// Returns a human-readable string for this Versionstamp.
+func (vs Versionstamp) String() string {
+	return fmt.Sprintf("Versionstamp(%s, %d)", fdb.Printable(vs.TransactionVersion[:]), vs.UserVersion)
 }
 
 var incompleteTransactionVersion = [10]byte{0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF}

--- a/bindings/go/src/fdb/tuple/tuple_test.go
+++ b/bindings/go/src/fdb/tuple/tuple_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/gob"
 	"flag"
+	"fmt"
 	"math/rand"
 	"os"
 	"testing"
@@ -116,5 +117,14 @@ func BenchmarkTuplePacking(b *testing.B) {
 				_ = tuple.Pack()
 			}
 		})
+	}
+}
+
+func TestTupleString(t *testing.T) {
+	printed := fmt.Sprint(Tuple{[]byte("hello"), "world", 42, 0x99})
+	expected := "\\x01hello\\x00\\x02world\\x00\\x15*\\x15\\x99"
+
+	if printed != expected {
+		t.Fatalf("printed tuple result differs, expected %v, got %v", expected, printed)
 	}
 }

--- a/bindings/go/src/fdb/tuple/tuple_test.go
+++ b/bindings/go/src/fdb/tuple/tuple_test.go
@@ -141,7 +141,10 @@ func TestTupleString(t *testing.T) {
 			Tuple{"UUID", testUUID},
 			"(\"UUID\", UUID(1100aabb-ccdd-eeff-1100-aabbccddeeff))",
 		},
-		// TODO: Add VersionStamp testcase
+		{
+			Tuple{"Versionstamp", Versionstamp{[10]byte{0, 0, 0, 0xaa, 0, 0xbb, 0, 0xcc, 0, 0xdd}, 620}},
+			"(\"Versionstamp\", Versionstamp(\\x00\\x00\\x00\\xaa\\x00\\xbb\\x00\\xcc\\x00\\xdd, 620))",
+		},
 	}
 
 	for _, testCase := range testCases {

--- a/bindings/go/src/fdb/tuple/tuple_test.go
+++ b/bindings/go/src/fdb/tuple/tuple_test.go
@@ -121,10 +121,33 @@ func BenchmarkTuplePacking(b *testing.B) {
 }
 
 func TestTupleString(t *testing.T) {
-	printed := fmt.Sprint(Tuple{[]byte("hello"), "world", 42, 0x99})
-	expected := "\\x01hello\\x00\\x02world\\x00\\x15*\\x15\\x99"
+	testCases :=[ ]struct {
+		input    Tuple
+		expected string
+	}{
+		{
+			Tuple{[]byte("hello"), "world", 42, 0x99},
+			"(b\"hello\", \"world\", 42, 153)",
+		},
+		{
+			Tuple{nil, Tuple{"Ok", Tuple{1, 2}, "Go"}, 42, 0x99},
+			"(<nil>, (\"Ok\", (1, 2), \"Go\"), 42, 153)",
+		},
+		{
+			Tuple{"Bool", true, false},
+			"(\"Bool\", true, false)",
+		},
+		{
+			Tuple{"UUID", testUUID},
+			"(\"UUID\", UUID(1100aabb-ccdd-eeff-1100-aabbccddeeff))",
+		},
+		// TODO: Add VersionStamp testcase
+	}
 
-	if printed != expected {
-		t.Fatalf("printed tuple result differs, expected %v, got %v", expected, printed)
+	for _, testCase := range testCases {
+		printed := fmt.Sprint(testCase.input)
+		if printed != testCase.expected {
+			t.Fatalf("printed tuple result differs, expected %v, got %v", testCase.expected, printed)
+		}
 	}
 }


### PR DESCRIPTION
This PR is built on top of yet unmerged #2421. 

- Instead of printing plain bytes, this one produces human-readable output which is consistent with out Python and Java bindings. The examples of output can be found in `test_tuple.go` file in this patch.
- Minor refactoring by renaming `Subspace.b` to `Subspace.rawPrefix`.
- Implements `Stringer` interface for `UUID`.
- Don't enforce `fmt.String()` in `Subspace` interface. This will enforce implementing `String()` for all types that implement Subspace, which in turn will break out current build. Since Go uses duck-typing, its also unnecessary because any type that implements `String()` will automatically be treated as `String()`.

Notes:
- ~~Currently, `Stringer` for VersionStamp is missing.~~
- Missing `DirectorySubspace.String()` testcases.