### PR TITLE
go: Don't complain about unsafe pointer conversion in stringRefToSlice

### DIFF
--- a/bindings/go/src/fdb/futures.go
+++ b/bindings/go/src/fdb/futures.go
@@ -273,6 +273,7 @@ type futureKeyValueArray struct {
 	*future
 }
 
+//go:nocheckptr
 func stringRefToSlice(ptr unsafe.Pointer) []byte {
 	size := *((*C.int)(unsafe.Pointer(uintptr(ptr) + 8)))
 


### PR DESCRIPTION
Running Go bindings with `-race` argument will enable instrumentation to check
pointer conversions, and complain about potential unsafe conversion in
`stringRefToSlice`.

This patch adds annotation `go:nocheckptr` annotation to skip that check, since
our conversion is safe, and can let users take advantage of check for their code
without this false positive.

It will be useful to check if, we can potentially rewrite this code to obey Go
pointer conversion rules.

FIXES #2843