### PR TITLE
Fix:Disable sanity check backup-metadata file

### DIFF
--- a/fdbclient/BackupContainer.actor.cpp
+++ b/fdbclient/BackupContainer.actor.cpp
@@ -1373,7 +1373,8 @@ public:
 			    wait(bc->readKeyspaceSnapshot(snapshot.get()));
 			restorable.ranges = std::move(results.first);
 			restorable.keyRanges = std::move(results.second);
-			if (g_network->isSimulated()) {
+			// TODO: Reenable the sanity check after TooManyFiles error is resolved
+			if (false && g_network->isSimulated()) {
 				// Sanity check key ranges
 				state std::map<std::string, KeyRange>::iterator rit;
 				for (rit = restorable.keyRanges.begin(); rit != restorable.keyRanges.end(); rit++) {


### PR DESCRIPTION
Which can increase the false positive rate of TooManyFiles error.

The backup-metadata file is not used by 6.2 restore or the new performant restore. 