### PR TITLE
Fix Valgrind error InvalidSuppression_FastRestoreWorkerError

### DIFF
--- a/fdbserver/RestoreApplier.actor.cpp
+++ b/fdbserver/RestoreApplier.actor.cpp
@@ -89,7 +89,9 @@ ACTOR Future<Void> restoreApplierCore(RestoreApplierInterface applierInterf, int
 				}
 			}
 		} catch (Error& e) {
-			TraceEvent(SevWarn, "FastRestoreApplierError", self->id()).detail("RequestType", requestTypeStr).error(e);
+			TraceEvent(SevWarn, "FastRestoreApplierError", self->id())
+			    .detail("RequestType", requestTypeStr)
+			    .error(e, true);
 			break;
 		}
 	}

--- a/fdbserver/RestoreLoader.actor.cpp
+++ b/fdbserver/RestoreLoader.actor.cpp
@@ -116,7 +116,7 @@ ACTOR Future<Void> restoreLoaderCore(RestoreLoaderInterface loaderInterf, int no
 				}
 			}
 		} catch (Error& e) {
-			TraceEvent(SevWarn, "FastRestoreLoader", self->id()).detail("RequestType", requestTypeStr).error(e);
+			TraceEvent(SevWarn, "FastRestoreLoader", self->id()).detail("RequestType", requestTypeStr).error(e, true);
 			break;
 		}
 	}

--- a/fdbserver/RestoreWorker.actor.cpp
+++ b/fdbserver/RestoreWorker.actor.cpp
@@ -240,7 +240,7 @@ ACTOR Future<Void> startRestoreWorker(Reference<RestoreWorkerData> self, Restore
 				}
 			}
 		} catch (Error& e) {
-			TraceEvent(SevWarn, "FastRestoreWorkerError").detail("RequestType", requestTypeStr).error(e);
+			TraceEvent(SevWarn, "FastRestoreWorkerError").detail("RequestType", requestTypeStr).error(e, true);
 			break;
 		}
 	}


### PR DESCRIPTION
Trace.error() must explicitly include `error_code_actor_cancelled`
to handle the error.

Typically, we will not report error on `error_code_actor_cancelled `.
In the fast restore worker, we want to know when fast restore worker exists for more diagnosis info.