### PR TITLE
Simple prefix compression for GetKeyValuesReply

### DIFF
--- a/fdbclient/FDBTypes.h
+++ b/fdbclient/FDBTypes.h
@@ -398,11 +398,11 @@ uint16_t longCommonPrefix(StringRef x, StringRef y) {
 
 template<>
 struct string_serialized_traits<KeyValueRef> : std::true_type {
-	int32_t getSize(const KeyValueRef& item) const {
+	int32_t getSize(const KeyValueRef& item, const KeyValueRef* prev) const {
 		return 2*sizeof(uint32_t) + item.key.size() + item.value.size();
 	}
 
-	uint32_t save(uint8_t* out, const KeyValueRef& item) const {
+	uint32_t save(uint8_t* out, const KeyValueRef& item, const KeyValueRef* prev) const {
 		auto begin = out;
 		uint32_t sz = item.key.size();
 		*reinterpret_cast<decltype(sz)*>(out) = sz;
@@ -418,7 +418,7 @@ struct string_serialized_traits<KeyValueRef> : std::true_type {
 	}
 
 	template <class Context>
-	uint32_t load(const uint8_t* data, KeyValueRef& t, Context& context) {
+	uint32_t load(const uint8_t* data, KeyValueRef& t, const KeyValueRef* prev, Context& context) {
 		auto begin = data;
 		uint32_t sz;
 		memcpy(&sz, data, sizeof(sz));

--- a/fdbclient/FDBTypes.h
+++ b/fdbclient/FDBTypes.h
@@ -378,7 +378,7 @@ struct KeyValueRef {
 	};
 };
 
-uint16_t longCommonPrefix(StringRef x, StringRef y) {
+inline uint16_t longCommonPrefix(StringRef x, StringRef y) {
 	uint16_t end = std::min<int>({ x.size(), y.size(), std::numeric_limits<uint16_t>::max() });
 	uint16_t i = 0;
 	constexpr auto kStepSize = 16;

--- a/fdbclient/FDBTypes.h
+++ b/fdbclient/FDBTypes.h
@@ -378,6 +378,24 @@ struct KeyValueRef {
 	};
 };
 
+uint16_t longCommonPrefix(StringRef x, StringRef y) {
+	uint16_t end = std::min<int>({ x.size(), y.size(), std::numeric_limits<uint16_t>::max() });
+	uint16_t i = 0;
+	constexpr auto kStepSize = 16;
+	for (; i + kStepSize < end; i += kStepSize) {
+		// Hopefully it compiles to a double-width compare instruction
+		if (std::memcmp(x.begin() + i, y.begin() + i, kStepSize)) {
+			break;
+		}
+	}
+	for (; i < end; ++i) {
+		if (x[i] != y[i]) {
+			break;
+		}
+	}
+	return i;
+}
+
 template<>
 struct string_serialized_traits<KeyValueRef> : std::true_type {
 	int32_t getSize(const KeyValueRef& item) const {


### PR DESCRIPTION
Change the serialization for `VectorRef<KeyValueRef, VecSerStrategy::String>` (used by GetKeyValuesReply), to do some simple prefix compression. The max key size allowed fits in a uint16_t, so replace the uint32_t we're currently using for key size with a uint16_t. Use the remaining uint16_t to indicate the length of the prefix borrowed from the previous key. The encoding for a key-value pair now looks like this:
```
2byte length of common key prefix
2byte length of key suffix
... key suffix ...
4byte length of value
... value ...
```
If the common prefix length is always zero, then messages are the same size as before.

Calculate the length of the common prefix using a linear scan. On the storage server, for every common byte we scan, we save a memcpy for that byte so I think it ends up being a wash. In the end we're just left with smaller network messages. The client does now need to do some extra memcpy'ing to restore the prefix.