### PR TITLE
MutationRef serialization depended on uninitialized data

### DIFF
--- a/fdbclient/CommitTransaction.h
+++ b/fdbclient/CommitTransaction.h
@@ -107,7 +107,7 @@ struct MutationRef {
 
 	template <class Ar>
 	void serialize( Ar& ar ) {
-		if (!ar.isDeserializing && type == ClearRange && equalsKeyAfter(param1, param2)) {
+		if (ar.isSerializing && type == ClearRange && equalsKeyAfter(param1, param2)) {
 			StringRef empty;
 			serializer(ar, type, param2, empty);
 		} else {


### PR DESCRIPTION
During vtable collection, neither `isSerializing` or `isDeserializing` is true. In this case, we are calling `serialize` with an uninitialized `MutationRef`, so we can't inspect its `type` member.