### PR TITLE
Make ctest use --crash when running simulation tests.

### DIFF
--- a/cmake/AddFdbTest.cmake
+++ b/cmake/AddFdbTest.cmake
@@ -120,6 +120,7 @@ function(add_fdb_test)
     -b ${PROJECT_BINARY_DIR}
     -t ${test_type}
     -O ${OLD_FDBSERVER_BINARY}
+    --crash
     --aggregate-traces ${TEST_AGGREGATE_TRACES}
     --log-format ${TEST_LOG_FORMAT}
     --keep-logs ${TEST_KEEP_LOGS}

--- a/tests/TestRunner/TestRunner.py
+++ b/tests/TestRunner/TestRunner.py
@@ -283,6 +283,8 @@ def run_simulation_test(basedir, options):
     if options.buggify:
         pargs.append('-b')
         pargs.append('on')
+    if options.crash:
+        pargs.append('--crash')
     pargs.append('--trace_format')
     pargs.append(options.log_format)
     test_dir = td.get_current_test_dir()
@@ -384,6 +386,8 @@ if __name__ == '__main__':
                         help='Path to the old binary to use for upgrade tests')
     parser.add_argument('-S', '--symbolicate', action='store_true', default=False,
                         help='Symbolicate backtraces in trace events')
+    parser.add_argument('--crash', action='store_true', default=False,
+                        help='Test ASSERT failures should crash the test')
     parser.add_argument('--aggregate-traces', default='NONE',
                         choices=['NONE', 'FAILED', 'ALL'])
     parser.add_argument('--keep-logs', default='FAILED',


### PR DESCRIPTION
So that tests with ASSERTion failures don't cause CI to run slow and
produce massive logs.  There's also rarely a reason to continue through
assertion failures.