### PR TITLE
More aggressively cleanup a bad process ID file in simulation

### DIFF
--- a/fdbserver/worker.actor.cpp
+++ b/fdbserver/worker.actor.cpp
@@ -1556,7 +1556,8 @@ ACTOR Future<UID> createAndLockProcessIdFile(std::string folder) {
 					if(!g_network->isSimulated()) {
 						throw;
 					}
-					deleteFile(lockFilePath);
+					lockFile = ErrorOr<Reference<IAsyncFile>>();
+					wait(IAsyncFileSystem::filesystem()->deleteFile(lockFilePath, true));
 				}
 			}
 		}


### PR DESCRIPTION
It seems some of the file handling mechanisms of simulation prevented the file from being cleaned up properly. This changes the delete function called and drops the reference to the `IAsyncFile` handle so that simulation can clean it up properly.