### PR TITLE
Fix tsan libfdb_c false positive

### DIFF
--- a/cmake/CompilerChecks.cmake
+++ b/cmake/CompilerChecks.cmake
@@ -32,7 +32,10 @@ function(use_libcxx out)
 endfunction()
 
 function(static_link_libcxx out)
-  if(APPLE)
+  if(USE_TSAN)
+    # Libc/libstdc++ static linking is not supported for tsan
+    set("${out}" OFF PARENT_SCOPE)
+  elseif(APPLE)
     set("${out}" OFF PARENT_SCOPE)
   elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
     default_linker(linker)

--- a/cmake/ConfigureCompiler.cmake
+++ b/cmake/ConfigureCompiler.cmake
@@ -22,7 +22,10 @@ static_link_libcxx(_static_link_libcxx)
 env_set(STATIC_LINK_LIBCXX "${_static_link_libcxx}" BOOL "Statically link libstdcpp/libc++")
 
 if(USE_LIBCXX AND STATIC_LINK_LIBCXX AND NOT USE_LD STREQUAL "LLD")
-  message(FATAL_ERROR "Unsupported configuration: STATIC_LINK_LIBCXX with libc+++ only works if USE_LD=LLD")
+  message(FATAL_ERROR "Unsupported configuration: STATIC_LINK_LIBCXX with libc++ only works if USE_LD=LLD")
+endif()
+if(STATIC_LINK_LIBCXX AND USE_TSAN)
+  message(FATAL_ERROR "Unsupported configuration: STATIC_LINK_LIBCXX doesn't work with tsan")
 endif()
 
 set(rel_debug_paths OFF)


### PR DESCRIPTION
Now mako/any application linking against libfdb_c can now compile with -fsanitize=thread and (as long as they link against libfdb_c built with -DUSE_TSAN=ON) not see any false positives (as far as I know, maybe there's more lurking somewhere)