### PR TITLE
Fixed a bug where the loop might get stuck.

### DIFF
--- a/fdbserver/StorageMetrics.actor.h
+++ b/fdbserver/StorageMetrics.actor.h
@@ -436,7 +436,13 @@ struct StorageServerMetrics {
 		IndexedSet<Key, int64_t>::iterator endKey =
 		    byteSample.sample.index(byteSample.sample.sumTo(byteSample.sample.lower_bound(beginKey)) + baseChunkSize);
 		while (endKey != byteSample.sample.end()) {
-			if (*endKey > shard.end) endKey = byteSample.sample.lower_bound(shard.end);
+			if (*endKey > shard.end) {
+				endKey = byteSample.sample.lower_bound(shard.end);
+				if (*endKey == beginKey) {
+					// No need to increment endKey since otherwise it would stuck here forever.
+					break;
+				}
+			}
 			if (*endKey == beginKey) {
 				++endKey;
 				continue;


### PR DESCRIPTION
This fixes a rare bug where `endKey` might be reset to the `beginKey` by the `lower_bound` call, and thus the loop makes no progress and got stuck.