### PR TITLE
Improvement on special key space

### DIFF
--- a/fdbclient/DatabaseContext.h
+++ b/fdbclient/DatabaseContext.h
@@ -317,7 +317,7 @@ public:
 
 	std::vector<std::unique_ptr<SpecialKeyRangeBaseImpl>> specialKeySpaceModules;
 	std::unique_ptr<SpecialKeySpace> specialKeySpace;
-	void registerSpecialKeySpaceModule(std::unique_ptr<SpecialKeyRangeBaseImpl> module);
+	void registerSpecialKeySpaceModule(SpecialKeySpace::MODULE module, std::unique_ptr<SpecialKeyRangeBaseImpl> impl);
 
 	static bool debugUseTags;
 	static const std::vector<std::string> debugTransactionTagChoices; 

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -529,7 +529,7 @@ struct WorkerInterfacesSpecialKeyImpl : SpecialKeyRangeBaseImpl {
 struct SingleSpecialKeyImpl : SpecialKeyRangeBaseImpl {
 	Future<Standalone<RangeResultRef>> getRange(Reference<ReadYourWritesTransaction> ryw,
 	                                            KeyRangeRef kr) const override {
-		if (!kr.contains(k)) return Standalone<RangeResultRef>();
+		ASSERT(kr.contains(k));
 		return map(f(ryw), [k = k](Optional<Value> v) {
 			Standalone<RangeResultRef> result;
 			if (v.present()) {

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -529,6 +529,7 @@ struct WorkerInterfacesSpecialKeyImpl : SpecialKeyRangeBaseImpl {
 struct SingleSpecialKeyImpl : SpecialKeyRangeBaseImpl {
 	Future<Standalone<RangeResultRef>> getRange(Reference<ReadYourWritesTransaction> ryw,
 	                                            KeyRangeRef kr) const override {
+		if (!kr.contains(k)) return Standalone<RangeResultRef>();
 		return map(f(ryw), [k = k](Optional<Value> v) {
 			Standalone<RangeResultRef> result;
 			if (v.present()) {
@@ -583,7 +584,7 @@ DatabaseContext::DatabaseContext(Reference<AsyncVar<Reference<ClusterConnectionF
     transactionsProcessBehind("ProcessBehind", cc), outstandingWatches(0), latencies(1000), readLatencies(1000),
     commitLatencies(1000), GRVLatencies(1000), mutationsPerCommit(1000), bytesPerCommit(1000), mvCacheInsertLocation(0),
     healthMetricsLastUpdated(0), detailedHealthMetricsLastUpdated(0), internal(internal),
-    specialKeySpace(std::make_unique<SpecialKeySpace>(specialKeys.begin, specialKeys.end)) {
+    specialKeySpace(std::make_unique<SpecialKeySpace>(specialKeys.begin, specialKeys.end, /* test */ false)) {
 	dbId = deterministicRandom()->randomUniqueID();
 	connected = clientInfo->get().proxies.size() ? Void() : clientInfo->onChange();
 

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -620,7 +620,7 @@ DatabaseContext::DatabaseContext(Reference<AsyncVar<Reference<ClusterConnectionF
     transactionsProcessBehind("ProcessBehind", cc), outstandingWatches(0), latencies(1000), readLatencies(1000),
     commitLatencies(1000), GRVLatencies(1000), mutationsPerCommit(1000), bytesPerCommit(1000), mvCacheInsertLocation(0),
     healthMetricsLastUpdated(0), detailedHealthMetricsLastUpdated(0), internal(internal),
-    specialKeySpace(std::make_unique<SpecialKeySpace>(normalKeys.begin, specialKeys.end)) {
+    specialKeySpace(std::make_unique<SpecialKeySpace>(specialKeys.begin, specialKeys.end)) {
 	dbId = deterministicRandom()->randomUniqueID();
 	connected = clientInfo->get().proxies.size() ? Void() : clientInfo->onChange();
 

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -603,12 +603,12 @@ DatabaseContext::DatabaseContext(Reference<AsyncVar<Reference<ClusterConnectionF
 	monitorMasterProxiesInfoChange = monitorMasterProxiesChange(clientInfo, &masterProxiesChangeTrigger);
 	clientStatusUpdater.actor = clientStatusUpdateActor(this);
 	if (apiVersionAtLeast(630)) {
-		registerSpecialKeySpaceModule(SpecialKeySpace::TRANSACTION, std::make_unique<ConflictingKeysImpl>(conflictingKeysRange));
-		registerSpecialKeySpaceModule(SpecialKeySpace::TRANSACTION, std::make_unique<ReadConflictRangeImpl>(readConflictRangeKeysRange));
-		registerSpecialKeySpaceModule(SpecialKeySpace::TRANSACTION, std::make_unique<WriteConflictRangeImpl>(writeConflictRangeKeysRange));
-		registerSpecialKeySpaceModule(SpecialKeySpace::WORKERINTERFACE, std::make_unique<WorkerInterfacesSpecialKeyImpl>(KeyRangeRef(
+		registerSpecialKeySpaceModule(SpecialKeySpace::MODULE::TRANSACTION, std::make_unique<ConflictingKeysImpl>(conflictingKeysRange));
+		registerSpecialKeySpaceModule(SpecialKeySpace::MODULE::TRANSACTION, std::make_unique<ReadConflictRangeImpl>(readConflictRangeKeysRange));
+		registerSpecialKeySpaceModule(SpecialKeySpace::MODULE::TRANSACTION, std::make_unique<WriteConflictRangeImpl>(writeConflictRangeKeysRange));
+		registerSpecialKeySpaceModule(SpecialKeySpace::MODULE::WORKERINTERFACE, std::make_unique<WorkerInterfacesSpecialKeyImpl>(KeyRangeRef(
 		    LiteralStringRef("\xff\xff/worker_interfaces/"), LiteralStringRef("\xff\xff/worker_interfaces0"))));
-		registerSpecialKeySpaceModule(SpecialKeySpace::STATUSJSON, std::make_unique<SingleSpecialKeyImpl>(
+		registerSpecialKeySpaceModule(SpecialKeySpace::MODULE::STATUSJSON, std::make_unique<SingleSpecialKeyImpl>(
 		    LiteralStringRef("\xff\xff/status/json"),
 		    [](Reference<ReadYourWritesTransaction> ryw) -> Future<Optional<Value>> {
 			    if (ryw->getDatabase().getPtr() && ryw->getDatabase()->getConnectionFile()) {
@@ -617,7 +617,7 @@ DatabaseContext::DatabaseContext(Reference<AsyncVar<Reference<ClusterConnectionF
 				    return Optional<Value>();
 			    }
 		    }));
-		registerSpecialKeySpaceModule(SpecialKeySpace::CLUSTERFILEPATH, std::make_unique<SingleSpecialKeyImpl>(
+		registerSpecialKeySpaceModule(SpecialKeySpace::MODULE::CLUSTERFILEPATH, std::make_unique<SingleSpecialKeyImpl>(
 		    LiteralStringRef("\xff\xff/cluster_file_path"),
 		    [](Reference<ReadYourWritesTransaction> ryw) -> Future<Optional<Value>> {
 			    try {
@@ -631,7 +631,7 @@ DatabaseContext::DatabaseContext(Reference<AsyncVar<Reference<ClusterConnectionF
 			    return Optional<Value>();
 		    }));
 
-		registerSpecialKeySpaceModule(SpecialKeySpace::CONNECTIONSTRING, std::make_unique<SingleSpecialKeyImpl>(
+		registerSpecialKeySpaceModule(SpecialKeySpace::MODULE::CONNECTIONSTRING, std::make_unique<SingleSpecialKeyImpl>(
 		    LiteralStringRef("\xff\xff/connection_string"),
 		    [](Reference<ReadYourWritesTransaction> ryw) -> Future<Optional<Value>> {
 			    try {

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -494,9 +494,9 @@ Future<HealthMetrics> DatabaseContext::getHealthMetrics(bool detailed = false) {
 	return getHealthMetricsActor(this, detailed);
 }
 
-void DatabaseContext::registerSpecialKeySpaceModule(std::unique_ptr<SpecialKeyRangeBaseImpl> module) {
-	specialKeySpace->registerKeyRange(module->getKeyRange(), module.get());
-	specialKeySpaceModules.push_back(std::move(module));
+void DatabaseContext::registerSpecialKeySpaceModule(SpecialKeySpace::MODULE module, std::unique_ptr<SpecialKeyRangeBaseImpl> impl) {
+	specialKeySpace->registerKeyRange(module, impl->getKeyRange(), impl.get());
+	specialKeySpaceModules.push_back(std::move(impl));
 }
 
 ACTOR Future<Standalone<RangeResultRef>> getWorkerInterfaces(Reference<ClusterConnectionFile> clusterFile);
@@ -545,43 +545,6 @@ struct SingleSpecialKeyImpl : SpecialKeyRangeBaseImpl {
 private:
 	Key k;
 	std::function<Future<Optional<Value>>(Reference<ReadYourWritesTransaction>)> f;
-};
-
-struct TransactionModule : SpecialKeyRangeBaseImpl {
-	Future<Standalone<RangeResultRef>> getRange(Reference<ReadYourWritesTransaction> ryw,
-	                                            KeyRangeRef kr) const override {
-		return getRange_(ryw, kr, this);
-	}
-
-	TransactionModule(KeyRangeRef kr) : SpecialKeyRangeBaseImpl(kr) {
-		impls.emplace_back(std::make_unique<ConflictingKeysImpl>(conflictingKeysRange));
-		impls.emplace_back(std::make_unique<ReadConflictRangeImpl>(readConflictRangeKeysRange));
-		impls.emplace_back(std::make_unique<WriteConflictRangeImpl>(writeConflictRangeKeysRange));
-	}
-
-private:
-	ACTOR static Future<Standalone<RangeResultRef>> getRange_(Reference<ReadYourWritesTransaction> ryw, KeyRangeRef kr,
-	                                                          const TransactionModule* self) {
-		state std::vector<Future<Standalone<RangeResultRef>>> futures;
-		futures.reserve(self->impls.size());
-		for (const auto& impl : self->impls) {
-			auto implRange = impl->getKeyRange();
-			auto begin = std::max(kr.begin, implRange.begin);
-			auto end = std::min(kr.end, implRange.end);
-			if (begin < end) {
-				futures.push_back(impl->getRange(ryw, KeyRangeRef(begin, end)));
-			}
-		}
-		self = nullptr;
-		wait(waitForAll(futures));
-		Standalone<RangeResultRef> result;
-		for (const auto& f : futures) {
-			result.append(result.arena(), f.get().begin(), f.get().size());
-			result.arena().dependsOn(f.get().arena());
-		}
-		return result;
-	}
-	std::vector<std::unique_ptr<SpecialKeyRangeBaseImpl>> impls;
 };
 
 DatabaseContext::DatabaseContext(Reference<AsyncVar<Reference<ClusterConnectionFile>>> connectionFile,
@@ -640,11 +603,12 @@ DatabaseContext::DatabaseContext(Reference<AsyncVar<Reference<ClusterConnectionF
 	monitorMasterProxiesInfoChange = monitorMasterProxiesChange(clientInfo, &masterProxiesChangeTrigger);
 	clientStatusUpdater.actor = clientStatusUpdateActor(this);
 	if (apiVersionAtLeast(630)) {
-		registerSpecialKeySpaceModule(std::make_unique<TransactionModule>(
-		    KeyRangeRef(LiteralStringRef("\xff\xff/transaction/"), LiteralStringRef("\xff\xff/transaction0"))));
-		registerSpecialKeySpaceModule(std::make_unique<WorkerInterfacesSpecialKeyImpl>(KeyRangeRef(
+		registerSpecialKeySpaceModule(SpecialKeySpace::TRANSACTION, std::make_unique<ConflictingKeysImpl>(conflictingKeysRange));
+		registerSpecialKeySpaceModule(SpecialKeySpace::TRANSACTION, std::make_unique<ReadConflictRangeImpl>(readConflictRangeKeysRange));
+		registerSpecialKeySpaceModule(SpecialKeySpace::TRANSACTION, std::make_unique<WriteConflictRangeImpl>(writeConflictRangeKeysRange));
+		registerSpecialKeySpaceModule(SpecialKeySpace::WORKERINTERFACE, std::make_unique<WorkerInterfacesSpecialKeyImpl>(KeyRangeRef(
 		    LiteralStringRef("\xff\xff/worker_interfaces/"), LiteralStringRef("\xff\xff/worker_interfaces0"))));
-		registerSpecialKeySpaceModule(std::make_unique<SingleSpecialKeyImpl>(
+		registerSpecialKeySpaceModule(SpecialKeySpace::STATUSJSON, std::make_unique<SingleSpecialKeyImpl>(
 		    LiteralStringRef("\xff\xff/status/json"),
 		    [](Reference<ReadYourWritesTransaction> ryw) -> Future<Optional<Value>> {
 			    if (ryw->getDatabase().getPtr() && ryw->getDatabase()->getConnectionFile()) {
@@ -653,7 +617,7 @@ DatabaseContext::DatabaseContext(Reference<AsyncVar<Reference<ClusterConnectionF
 				    return Optional<Value>();
 			    }
 		    }));
-		registerSpecialKeySpaceModule(std::make_unique<SingleSpecialKeyImpl>(
+		registerSpecialKeySpaceModule(SpecialKeySpace::CLUSTERFILEPATH, std::make_unique<SingleSpecialKeyImpl>(
 		    LiteralStringRef("\xff\xff/cluster_file_path"),
 		    [](Reference<ReadYourWritesTransaction> ryw) -> Future<Optional<Value>> {
 			    try {
@@ -667,7 +631,7 @@ DatabaseContext::DatabaseContext(Reference<AsyncVar<Reference<ClusterConnectionF
 			    return Optional<Value>();
 		    }));
 
-		registerSpecialKeySpaceModule(std::make_unique<SingleSpecialKeyImpl>(
+		registerSpecialKeySpaceModule(SpecialKeySpace::CONNECTIONSTRING, std::make_unique<SingleSpecialKeyImpl>(
 		    LiteralStringRef("\xff\xff/connection_string"),
 		    [](Reference<ReadYourWritesTransaction> ryw) -> Future<Optional<Value>> {
 			    try {

--- a/fdbclient/SpecialKeySpace.actor.cpp
+++ b/fdbclient/SpecialKeySpace.actor.cpp
@@ -28,30 +28,30 @@
 // It does have overhead here since we query all keys twice in the worst case.
 // However, moving the KeySelector while handling other parameters like limits makes the code much more complex and hard
 // to maintain; Thus, separate each part to make the code easy to understand and more compact
-ACTOR Future<Void> SpecialKeyRangeBaseImpl::normalizeKeySelectorActor(const SpecialKeyRangeBaseImpl* pkrImpl,
+ACTOR Future<Void> SpecialKeyRangeBaseImpl::normalizeKeySelectorActor(const SpecialKeyRangeBaseImpl* skrImpl,
                                                                       Reference<ReadYourWritesTransaction> ryw,
                                                                       KeySelector* ks) {
 	ASSERT(!ks->orEqual); // should be removed before calling
 	ASSERT(ks->offset != 1); // never being called if KeySelector is already normalized
 
-	state Key startKey(pkrImpl->range.begin);
-	state Key endKey(pkrImpl->range.end);
+	state Key startKey(skrImpl->range.begin);
+	state Key endKey(skrImpl->range.end);
 
 	if (ks->offset < 1) {
 		// less than the given key
-		if (pkrImpl->range.contains(ks->getKey())) endKey = keyAfter(ks->getKey());
+		if (skrImpl->range.contains(ks->getKey())) endKey = keyAfter(ks->getKey());
 	} else {
 		// greater than the given key
-		if (pkrImpl->range.contains(ks->getKey())) startKey = ks->getKey();
+		if (skrImpl->range.contains(ks->getKey())) startKey = ks->getKey();
 	}
 
 	TraceEvent(SevDebug, "NormalizeKeySelector")
 	    .detail("OriginalKey", ks->getKey())
 	    .detail("OriginalOffset", ks->offset)
-	    .detail("SpecialKeyRangeStart", pkrImpl->range.begin)
-	    .detail("SpecialKeyRangeEnd", pkrImpl->range.end);
+	    .detail("SpecialKeyRangeStart", skrImpl->range.begin)
+	    .detail("SpecialKeyRangeEnd", skrImpl->range.end);
 
-	Standalone<RangeResultRef> result = wait(pkrImpl->getRange(ryw, KeyRangeRef(startKey, endKey)));
+	Standalone<RangeResultRef> result = wait(skrImpl->getRange(ryw, KeyRangeRef(startKey, endKey)));
 	if (result.size() == 0) {
 		TraceEvent("ZeroElementsIntheRange").detail("Start", startKey).detail("End", endKey);
 		return Void();
@@ -77,8 +77,8 @@ ACTOR Future<Void> SpecialKeyRangeBaseImpl::normalizeKeySelectorActor(const Spec
 	TraceEvent(SevDebug, "NormalizeKeySelector")
 	    .detail("NormalizedKey", ks->getKey())
 	    .detail("NormalizedOffset", ks->offset)
-	    .detail("SpecialKeyRangeStart", pkrImpl->range.begin)
-	    .detail("SpecialKeyRangeEnd", pkrImpl->range.end);
+	    .detail("SpecialKeyRangeStart", skrImpl->range.begin)
+	    .detail("SpecialKeyRangeEnd", skrImpl->range.end);
 	return Void();
 }
 

--- a/fdbclient/SpecialKeySpace.actor.cpp
+++ b/fdbclient/SpecialKeySpace.actor.cpp
@@ -27,7 +27,7 @@
 // If the corresponding key is not in this special key range, it will move as far as possible to adjust the offset to 1
 // It does have overhead here since we query all keys twice in the worst case.
 // However, moving the KeySelector while handling other parameters like limits makes the code much more complex and hard
-// to maintain Separate each part to make the code easy to understand and more compact
+// to maintain; Thus, separate each part to make the code easy to understand and more compact
 ACTOR Future<Void> SpecialKeyRangeBaseImpl::normalizeKeySelectorActor(const SpecialKeyRangeBaseImpl* pkrImpl,
                                                                       Reference<ReadYourWritesTransaction> ryw,
                                                                       KeySelector* ks) {

--- a/fdbclient/SpecialKeySpace.actor.cpp
+++ b/fdbclient/SpecialKeySpace.actor.cpp
@@ -99,9 +99,9 @@ ACTOR Future<Void> normalizeKeySelectorActor(SpecialKeySpace* sks, Reference<Rea
 	    sks->getImpls().rangeContaining(ks->getKey());
 	while ((ks->offset < 1 && iter != sks->getImpls().ranges().begin()) ||
 	       (ks->offset > 1 && iter != sks->getImpls().ranges().end())) {
-		onModuleRead(ryw, sks->getImplToModuleMap().at(iter->value()), *lastModuleRead);
 		if (iter->value() != nullptr) {
 			wait(moveKeySelectorOverRangeActor(iter->value(), ryw, ks));
+			onModuleRead(ryw, sks->getImplToModuleMap().at(iter->value()), *lastModuleRead);
 		}
 		ks->offset < 1 ? --iter : ++iter;
 	}
@@ -172,8 +172,8 @@ SpecialKeySpace::getRangeAggregationActor(SpecialKeySpace* sks, Reference<ReadYo
 	if (reverse) {
 		while (iter != ranges.begin()) {
 			--iter;
-			onModuleRead(ryw, sks->getImplToModuleMap().at(iter->value()), lastModuleRead);
 			if (iter->value() == nullptr) continue;
+			onModuleRead(ryw, sks->getImplToModuleMap().at(iter->value()), lastModuleRead);
 			KeyRangeRef kr = iter->range();
 			KeyRef keyStart = kr.contains(begin.getKey()) ? begin.getKey() : kr.begin;
 			KeyRef keyEnd = kr.contains(end.getKey()) ? end.getKey() : kr.end;
@@ -195,8 +195,8 @@ SpecialKeySpace::getRangeAggregationActor(SpecialKeySpace* sks, Reference<ReadYo
 		}
 	} else {
 		for (iter = ranges.begin(); iter != ranges.end(); ++iter) {
-			onModuleRead(ryw, sks->getImplToModuleMap().at(iter->value()), lastModuleRead);
 			if (iter->value() == nullptr) continue;
+			onModuleRead(ryw, sks->getImplToModuleMap().at(iter->value()), lastModuleRead);
 			KeyRangeRef kr = iter->range();
 			KeyRef keyStart = kr.contains(begin.getKey()) ? begin.getKey() : kr.begin;
 			KeyRef keyEnd = kr.contains(end.getKey()) ? end.getKey() : kr.end;

--- a/fdbclient/SpecialKeySpace.actor.cpp
+++ b/fdbclient/SpecialKeySpace.actor.cpp
@@ -145,7 +145,7 @@ ACTOR Future<Standalone<RangeResultRef>> SpecialKeySpace::checkModuleFound(Speci
 	    wait(SpecialKeySpace::getRangeAggregationActor(sks, ryw, begin, end, limits, reverse));
 	if (ryw && !ryw->specialKeySpaceRelaxed()) {
 		auto module = result.second;
-		if (!module.present()) {
+		if (!module.present() || module.get() == SpecialKeySpace::MODULE::UNKNOWN) {
 			throw special_keys_no_module_found();
 		}
 	}

--- a/fdbclient/SpecialKeySpace.actor.cpp
+++ b/fdbclient/SpecialKeySpace.actor.cpp
@@ -132,8 +132,8 @@ ACTOR Future<Standalone<RangeResultRef>> SpecialKeySpace::checkModuleFound(Speci
 	std::pair<Standalone<RangeResultRef>, Optional<SpecialKeySpace::MODULE>> result =
 	    wait(SpecialKeySpace::getRangeAggregationActor(sks, ryw, begin, end, limits, reverse));
 	if (ryw && !ryw->specialKeySpaceRelaxed()) {
-		auto module = result.second.orDefault(SpecialKeySpace::NOTEXIST);
-		if (module == SpecialKeySpace::NOTEXIST) {
+		auto module = result.second;
+		if (!module.present()) {
 			throw special_keys_no_module_found();
 		}
 	}
@@ -333,9 +333,9 @@ TEST_CASE("/fdbclient/SpecialKeySpace/Unittest") {
 	SpecialKeyRangeTestImpl pkr1(KeyRangeRef(LiteralStringRef("/cat/"), LiteralStringRef("/cat/\xff")), "small", 10);
 	SpecialKeyRangeTestImpl pkr2(KeyRangeRef(LiteralStringRef("/dog/"), LiteralStringRef("/dog/\xff")), "medium", 100);
 	SpecialKeyRangeTestImpl pkr3(KeyRangeRef(LiteralStringRef("/pig/"), LiteralStringRef("/pig/\xff")), "large", 1000);
-	sks.registerKeyRange(SpecialKeySpace::TESTONLY, pkr1.getKeyRange(), &pkr1);
-	sks.registerKeyRange(SpecialKeySpace::TESTONLY, pkr2.getKeyRange(), &pkr2);
-	sks.registerKeyRange(SpecialKeySpace::TESTONLY, pkr3.getKeyRange(), &pkr3);
+	sks.registerKeyRange(SpecialKeySpace::MODULE::TESTONLY, pkr1.getKeyRange(), &pkr1);
+	sks.registerKeyRange(SpecialKeySpace::MODULE::TESTONLY, pkr2.getKeyRange(), &pkr2);
+	sks.registerKeyRange(SpecialKeySpace::MODULE::TESTONLY, pkr3.getKeyRange(), &pkr3);
 	auto nullRef = Reference<ReadYourWritesTransaction>();
 	// get
 	{

--- a/fdbclient/SpecialKeySpace.actor.cpp
+++ b/fdbclient/SpecialKeySpace.actor.cpp
@@ -99,7 +99,7 @@ ACTOR Future<Void> normalizeKeySelectorActor(SpecialKeySpace* sks, Reference<Rea
 	    sks->getImpls().rangeContaining(ks->getKey());
 	while ((ks->offset < 1 && iter != sks->getImpls().ranges().begin()) ||
 	       (ks->offset > 1 && iter != sks->getImpls().ranges().end())) {
-		onModuleRead(ryw, sks->getImplToModuleMap()[iter->value()], *lastModuleRead);
+		onModuleRead(ryw, sks->getImplToModuleMap().at(iter->value()), *lastModuleRead);
 		if (iter->value() != nullptr) {
 			wait(moveKeySelectorOverRangeActor(iter->value(), ryw, ks));
 		}
@@ -172,7 +172,7 @@ SpecialKeySpace::getRangeAggregationActor(SpecialKeySpace* sks, Reference<ReadYo
 	if (reverse) {
 		while (iter != ranges.begin()) {
 			--iter;
-			onModuleRead(ryw, sks->getImplToModuleMap()[iter->value()], lastModuleRead);
+			onModuleRead(ryw, sks->getImplToModuleMap().at(iter->value()), lastModuleRead);
 			if (iter->value() == nullptr) continue;
 			KeyRangeRef kr = iter->range();
 			KeyRef keyStart = kr.contains(begin.getKey()) ? begin.getKey() : kr.begin;
@@ -195,7 +195,7 @@ SpecialKeySpace::getRangeAggregationActor(SpecialKeySpace* sks, Reference<ReadYo
 		}
 	} else {
 		for (iter = ranges.begin(); iter != ranges.end(); ++iter) {
-			onModuleRead(ryw, sks->getImplToModuleMap()[iter->value()], lastModuleRead);
+			onModuleRead(ryw, sks->getImplToModuleMap().at(iter->value()), lastModuleRead);
 			if (iter->value() == nullptr) continue;
 			KeyRangeRef kr = iter->range();
 			KeyRef keyStart = kr.contains(begin.getKey()) ? begin.getKey() : kr.begin;

--- a/fdbclient/SpecialKeySpace.actor.h
+++ b/fdbclient/SpecialKeySpace.actor.h
@@ -50,7 +50,14 @@ protected:
 
 class SpecialKeySpace {
 public:
-	enum MODULE { TRANSACTION, WORKERINTERFACE, STATUSJSON, CLUSTERFILEPATH, CONNECTIONSTRING, TESTONLY, NOTEXIST };
+	enum class MODULE {
+		TESTONLY, // only used by tests
+		TRANSACTION,
+		WORKERINTERFACE,
+		STATUSJSON,
+		CLUSTERFILEPATH,
+		CONNECTIONSTRING
+	};
 
 	Future<Optional<Value>> get(Reference<ReadYourWritesTransaction> ryw, const Key& key);
 
@@ -75,7 +82,9 @@ public:
 	}
 	KeyRangeMap<SpecialKeyRangeBaseImpl*>& getImpls() { return impls; }
 	KeyRangeRef getKeyRange() const { return range; }
-	const std::unordered_map<SpecialKeyRangeBaseImpl*, SpecialKeySpace::MODULE>& getImplToModuleMap() const { return implToModule; }
+	const std::unordered_map<SpecialKeyRangeBaseImpl*, SpecialKeySpace::MODULE>& getImplToModuleMap() const {
+		return implToModule;
+	}
 
 private:
 	ACTOR static Future<Optional<Value>> getActor(SpecialKeySpace* sks, Reference<ReadYourWritesTransaction> ryw,

--- a/fdbclient/SpecialKeySpace.actor.h
+++ b/fdbclient/SpecialKeySpace.actor.h
@@ -75,7 +75,7 @@ public:
 	}
 	KeyRangeMap<SpecialKeyRangeBaseImpl*>& getImpls() { return impls; }
 	KeyRangeRef getKeyRange() const { return range; }
-	std::map<SpecialKeyRangeBaseImpl*, SpecialKeySpace::MODULE> getImplToModuleMap() const { return implToModule; }
+	const std::unordered_map<SpecialKeyRangeBaseImpl*, SpecialKeySpace::MODULE>& getImplToModuleMap() const { return implToModule; }
 
 private:
 	ACTOR static Future<Optional<Value>> getActor(SpecialKeySpace* sks, Reference<ReadYourWritesTransaction> ryw,
@@ -91,7 +91,7 @@ private:
 
 	KeyRangeMap<SpecialKeyRangeBaseImpl*> impls;
 	KeyRange range;
-	std::map<SpecialKeyRangeBaseImpl*, SpecialKeySpace::MODULE> implToModule;
+	std::unordered_map<SpecialKeyRangeBaseImpl*, SpecialKeySpace::MODULE> implToModule;
 };
 
 // Use special key prefix "\xff\xff/transaction/conflicting_keys/<some_key>",

--- a/fdbclient/SpecialKeySpace.actor.h
+++ b/fdbclient/SpecialKeySpace.actor.h
@@ -101,6 +101,8 @@ private:
 	KeyRangeMap<SpecialKeyRangeBaseImpl*> impls;
 	KeyRange range;
 	std::unordered_map<SpecialKeyRangeBaseImpl*, SpecialKeySpace::MODULE> implToModule;
+
+	static std::unordered_map<SpecialKeySpace::MODULE, KeyRange> moduleToBoundary;
 };
 
 // Use special key prefix "\xff\xff/transaction/conflicting_keys/<some_key>",

--- a/fdbclient/SpecialKeySpace.actor.h
+++ b/fdbclient/SpecialKeySpace.actor.h
@@ -41,8 +41,6 @@ public:
 
 	explicit SpecialKeyRangeBaseImpl(KeyRangeRef kr) : range(kr) {}
 	KeyRangeRef getKeyRange() const { return range; }
-	ACTOR Future<Void> normalizeKeySelectorActor(const SpecialKeyRangeBaseImpl* pkrImpl,
-	                                             Reference<ReadYourWritesTransaction> ryw, KeySelector* ks);
 
 	virtual ~SpecialKeyRangeBaseImpl() {}
 
@@ -71,17 +69,20 @@ public:
 		ASSERT(impls.rangeContaining(kr.begin) == impls.rangeContaining(kr.end) && impls[kr.begin] == nullptr);
 		impls.insert(kr, impl);
 	}
+	KeyRangeMap<SpecialKeyRangeBaseImpl*>& getImpls() { return impls; }
+	KeyRangeRef getKeyRange() const { return range; }
 
 private:
-	ACTOR static Future<Optional<Value>> getActor(SpecialKeySpace* sks, Reference<ReadYourWritesTransaction> ryw, KeyRef key);
+	ACTOR static Future<Optional<Value>> getActor(SpecialKeySpace* sks, Reference<ReadYourWritesTransaction> ryw,
+	                                              KeyRef key);
 
 	ACTOR static Future<Standalone<RangeResultRef>> checkModuleFound(SpecialKeySpace* sks,
-	                                                          Reference<ReadYourWritesTransaction> ryw,
-	                                                          KeySelector begin, KeySelector end, GetRangeLimits limits,
-	                                                          bool reverse);
-	ACTOR static Future<std::pair<Standalone<RangeResultRef>, Optional<SpecialKeyRangeBaseImpl*>>> getRangeAggregationActor(
-	    SpecialKeySpace* sks, Reference<ReadYourWritesTransaction> ryw, KeySelector begin, KeySelector end,
-	    GetRangeLimits limits, bool reverse);
+	                                                                 Reference<ReadYourWritesTransaction> ryw,
+	                                                                 KeySelector begin, KeySelector end,
+	                                                                 GetRangeLimits limits, bool reverse);
+	ACTOR static Future<std::pair<Standalone<RangeResultRef>, Optional<SpecialKeyRangeBaseImpl*>>>
+	getRangeAggregationActor(SpecialKeySpace* sks, Reference<ReadYourWritesTransaction> ryw, KeySelector begin,
+	                         KeySelector end, GetRangeLimits limits, bool reverse);
 
 	KeyRangeMap<SpecialKeyRangeBaseImpl*> impls;
 	KeyRange range;

--- a/fdbclient/SpecialKeySpace.actor.h
+++ b/fdbclient/SpecialKeySpace.actor.h
@@ -73,14 +73,14 @@ public:
 	}
 
 private:
-	ACTOR static Future<Optional<Value>> getActor(SpecialKeySpace* pks, Reference<ReadYourWritesTransaction> ryw, KeyRef key);
+	ACTOR static Future<Optional<Value>> getActor(SpecialKeySpace* sks, Reference<ReadYourWritesTransaction> ryw, KeyRef key);
 
-	ACTOR static Future<Standalone<RangeResultRef>> checkModuleFound(SpecialKeySpace* pks,
+	ACTOR static Future<Standalone<RangeResultRef>> checkModuleFound(SpecialKeySpace* sks,
 	                                                          Reference<ReadYourWritesTransaction> ryw,
 	                                                          KeySelector begin, KeySelector end, GetRangeLimits limits,
 	                                                          bool reverse);
 	ACTOR static Future<std::pair<Standalone<RangeResultRef>, Optional<SpecialKeyRangeBaseImpl*>>> getRangeAggregationActor(
-	    SpecialKeySpace* pks, Reference<ReadYourWritesTransaction> ryw, KeySelector begin, KeySelector end,
+	    SpecialKeySpace* sks, Reference<ReadYourWritesTransaction> ryw, KeySelector begin, KeySelector end,
 	    GetRangeLimits limits, bool reverse);
 
 	KeyRangeMap<SpecialKeyRangeBaseImpl*> impls;

--- a/fdbserver/workloads/ReportConflictingKeys.actor.cpp
+++ b/fdbserver/workloads/ReportConflictingKeys.actor.cpp
@@ -133,9 +133,9 @@ struct ReportConflictingKeysWorkload : TestWorkload {
 				tr2.setOption(FDBTransactionOptions::REPORT_CONFLICTING_KEYS);
 				// If READ_YOUR_WRITES_DISABLE set, it behaves like native transaction object
 				// where overlapped conflict ranges are not merged.
-				if (deterministicRandom()->random01() < 0.5)
+				if (deterministicRandom()->coinflip())
 					tr1.setOption(FDBTransactionOptions::READ_YOUR_WRITES_DISABLE);
-				if (deterministicRandom()->random01() < 0.5)
+				if (deterministicRandom()->coinflip())
 					tr2.setOption(FDBTransactionOptions::READ_YOUR_WRITES_DISABLE);
 				// We have the two tx with same grv, then commit the first
 				// If the second one is not able to commit due to conflicts, verify the returned conflicting keys

--- a/fdbserver/workloads/SpecialKeySpaceCorrectness.actor.cpp
+++ b/fdbserver/workloads/SpecialKeySpaceCorrectness.actor.cpp
@@ -323,6 +323,7 @@ struct SpecialKeySpaceCorrectnessWorkload : TestWorkload {
 					    .detail("End", end.toString())
 					    .detail("Ryw", ryw);
 					had_error = true;
+					++self->wrongResults;
 				}
 				++correct_iter;
 				++test_iter;
@@ -338,6 +339,7 @@ struct SpecialKeySpaceCorrectnessWorkload : TestWorkload {
 				    .detail("Ryw", ryw);
 				++correct_iter;
 				had_error = true;
+				++self->wrongResults;
 			}
 			while (test_iter != testResultFuture.get().end()) {
 				TraceEvent(SevError, "TestFailure")
@@ -350,6 +352,7 @@ struct SpecialKeySpaceCorrectnessWorkload : TestWorkload {
 				    .detail("Ryw", ryw);
 				++test_iter;
 				had_error = true;
+				++self->wrongResults;
 			}
 			if (had_error) break;
 		}

--- a/fdbserver/workloads/SpecialKeySpaceCorrectness.actor.cpp
+++ b/fdbserver/workloads/SpecialKeySpaceCorrectness.actor.cpp
@@ -108,7 +108,7 @@ struct SpecialKeySpaceCorrectnessWorkload : TestWorkload {
 		return Void();
 	}
 	ACTOR Future<Void> _start(Database cx, SpecialKeySpaceCorrectnessWorkload* self) {
-		wait(timeout(self->testCrossModuleRead(cx, self) && self->getRangeCallActor(cx, self) &&
+		wait(timeout(self->testModuleRangeReadErrors(cx, self) && self->getRangeCallActor(cx, self) &&
 		                 testConflictRanges(cx, /*read*/ true, self) && testConflictRanges(cx, /*read*/ false, self),
 		             self->testDuration, Void()));
 		return Void();
@@ -224,7 +224,7 @@ struct SpecialKeySpaceCorrectnessWorkload : TestWorkload {
 		return GetRangeLimits(rowLimits, byteLimits);
 	}
 
-	ACTOR Future<Void> testCrossModuleRead(Database cx_, SpecialKeySpaceCorrectnessWorkload* self) {
+	ACTOR Future<Void> testModuleRangeReadErrors(Database cx_, SpecialKeySpaceCorrectnessWorkload* self) {
 		Database cx = cx_->clone();
 		state Reference<ReadYourWritesTransaction> tx = Reference(new ReadYourWritesTransaction(cx));
 		// begin key outside module range

--- a/fdbserver/workloads/SpecialKeySpaceCorrectness.actor.cpp
+++ b/fdbserver/workloads/SpecialKeySpaceCorrectness.actor.cpp
@@ -95,7 +95,8 @@ struct SpecialKeySpaceCorrectnessWorkload : TestWorkload {
 			self->keys.push_back_deep(self->keys.arena(), KeyRangeRef(startKey, endKey));
 			self->impls.push_back(std::make_shared<SKSCTestImpl>(KeyRangeRef(startKey, endKey)));
 			// Although there are already ranges registered, the testing range will replace them
-			cx->specialKeySpace->registerKeyRange(self->keys.back(), self->impls.back().get());
+			cx->specialKeySpace->registerKeyRange(SpecialKeySpace::TESTONLY, self->keys.back(),
+			                                      self->impls.back().get());
 			// generate keys in each key range
 			int keysInRange = deterministicRandom()->randomInt(self->minKeysPerRange, self->maxKeysPerRange + 1);
 			self->keysCount += keysInRange;

--- a/fdbserver/workloads/SpecialKeySpaceCorrectness.actor.cpp
+++ b/fdbserver/workloads/SpecialKeySpaceCorrectness.actor.cpp
@@ -95,7 +95,7 @@ struct SpecialKeySpaceCorrectnessWorkload : TestWorkload {
 			self->keys.push_back_deep(self->keys.arena(), KeyRangeRef(startKey, endKey));
 			self->impls.push_back(std::make_shared<SKSCTestImpl>(KeyRangeRef(startKey, endKey)));
 			// Although there are already ranges registered, the testing range will replace them
-			cx->specialKeySpace->registerKeyRange(SpecialKeySpace::TESTONLY, self->keys.back(),
+			cx->specialKeySpace->registerKeyRange(SpecialKeySpace::MODULE::TESTONLY, self->keys.back(),
 			                                      self->impls.back().get());
 			// generate keys in each key range
 			int keysInRange = deterministicRandom()->randomInt(self->minKeysPerRange, self->maxKeysPerRange + 1);

--- a/fdbserver/workloads/SpecialKeySpaceCorrectness.actor.cpp
+++ b/fdbserver/workloads/SpecialKeySpaceCorrectness.actor.cpp
@@ -110,7 +110,7 @@ struct SpecialKeySpaceCorrectnessWorkload : TestWorkload {
 		state double lastTime = now();
 		loop {
 			wait(poisson(&lastTime, 1.0 / self->transactionsPerSecond));
-			state bool reverse = deterministicRandom()->random01() < 0.5;
+			state bool reverse = deterministicRandom()->coinflip();
 			state GetRangeLimits limit = self->randomLimits();
 			state KeySelector begin = self->randomKeySelector();
 			state KeySelector end = self->randomKeySelector();
@@ -188,13 +188,12 @@ struct SpecialKeySpaceCorrectnessWorkload : TestWorkload {
 		} else {
 			// pick up existing keys from registered key ranges
 			KeyRangeRef randomKeyRangeRef = keys[deterministicRandom()->randomInt(0, keys.size())];
-			randomKey = deterministicRandom()->random01() < 0.5 ? randomKeyRangeRef.begin : randomKeyRangeRef.end;
+			randomKey = deterministicRandom()->coinflip() ? randomKeyRangeRef.begin : randomKeyRangeRef.end;
 		}
 		// return Key(deterministicRandom()->randomAlphaNumeric(keyBytes)).withPrefix(prefix);
 		// covers corner cases where offset points outside the key space
 		int offset = deterministicRandom()->randomInt(-keysCount.getValue() - 1, keysCount.getValue() + 2);
-		bool orEqual = deterministicRandom()->random01() < 0.5;
-		return KeySelectorRef(randomKey, orEqual, offset);
+		return KeySelectorRef(randomKey, deterministicRandom()->coinflip(), offset);
 	}
 
 	GetRangeLimits randomLimits() {

--- a/tests/fast/RandomUnitTests.txt
+++ b/tests/fast/RandomUnitTests.txt
@@ -3,4 +3,4 @@ testName=UnitTests
 startDelay=0
 useDB=false
 maxTestCases=1
-testsMatching=/fdbclient/SpecialKeySpace
+testsMatching=/

--- a/tests/fast/RandomUnitTests.txt
+++ b/tests/fast/RandomUnitTests.txt
@@ -3,4 +3,4 @@ testName=UnitTests
 startDelay=0
 useDB=false
 maxTestCases=1
-testsMatching=/
+testsMatching=/fdbclient/SpecialKeySpace


### PR DESCRIPTION
- Allow all clients to run the test in `ReportConflictingKeys` and `SpecialKeySpaceCorrectness`
- Reformat part of the code for `module` in special-key-space
- Add tests to make sure `special_keys_cross_module_read` is thrown correctly
- Solve several [issues](https://github.com/apple/foundationdb/issues/2979)

TODO(In following PRs):

- Add documentation for the `module` concept in special-key-space
- Merge [dd_metrics](https://github.com/apple/foundationdb/pull/2547) into special-key-space