### PR TITLE
Fix invalid memory access in ReadHotDetection test

### DIFF
--- a/fdbserver/workloads/ReadHotDetection.actor.cpp
+++ b/fdbserver/workloads/ReadHotDetection.actor.cpp
@@ -73,7 +73,7 @@ struct ReadHotDetectionWorkload : TestWorkload {
 		loop {
 			try {
 				for (int i = 0; i < self->keyCount; i++) {
-					auto key = StringRef(format("testkey%08x", i));
+					Standalone<StringRef> key = StringRef(format("testkey%08x", i));
 					if (key == self->readKey) {
 						tr.set(key, largeValue);
 					} else {


### PR DESCRIPTION
This was due to storing a value in a non-standalone StringRef.