### PR TITLE
Walk TLogVersion forward for 7.0 now that 6.3 has been branched.

### DIFF
--- a/fdbclient/FDBTypes.h
+++ b/fdbclient/FDBTypes.h
@@ -718,11 +718,11 @@ struct TLogVersion {
 		V2 = 2, // 6.0
 		V3 = 3, // 6.1
 		V4 = 4, // 6.2
-		V5 = 5, // 7.0
+		V5 = 5, // 6.3
 		MIN_SUPPORTED = V2,
 		MAX_SUPPORTED = V5,
-		MIN_RECRUITABLE = V3,
-		DEFAULT = V4,
+		MIN_RECRUITABLE = V4,
+		DEFAULT = V5,
 	} version;
 
 	TLogVersion() : version(UNSET) {}


### PR DESCRIPTION
In 7.0, you'll be forced to upgrade from V3 -> V4, and we'll start new clusters on V5 by default.