### PR TITLE
Don't rely on const reference lifetime extension

### DIFF
--- a/flow/Trace.h
+++ b/flow/Trace.h
@@ -457,7 +457,11 @@ private:
 	TraceEvent& detailfNoMetric( std::string&& key, const char* valueFormat, ... );
 	TraceEvent& detailImpl( std::string&& key, std::string&& value, bool writeEventMetricField=true );
 public:
-	TraceEvent& backtrace(const std::string& prefix = "");
+	TraceEvent& backtrace() {
+		std::string empty;
+		return backtrace(empty);
+	}
+	TraceEvent& backtrace(const std::string& prefix);
 	TraceEvent& trackLatest(const std::string& trackingKey );
 	TraceEvent& sample( double sampleRate, bool logSampleRate=true );
 


### PR DESCRIPTION
I saw a Sev40 with an `addr2line` pointing at the `std::basic_string` destructor at a call to `backtrace()` in the `std::basic_string` destructor. This change caused that log line to go away. 

I honestly get a little tripped up sometimes around const reference lifetime extension, so there's a chance that the previous was safe and this is a false positive. This is definitely safe, however. SSO strings should make this fine performance wise, but I could add a static empty string if needed.