### PR TITLE
Add IndexedSet::const_iterator

### DIFF
--- a/flow/IKeyValueContainer.h
+++ b/flow/IKeyValueContainer.h
@@ -69,22 +69,30 @@ bool operator<(CompatibleWithKey const& l, KeyValueMapPair const& r) {
 
 class IKeyValueContainer {
 public:
-	typedef typename IndexedSet<KeyValueMapPair, uint64_t>::iterator iterator;
+	using const_iterator = IndexedSet<KeyValueMapPair, uint64_t>::const_iterator;
+	using iterator = IndexedSet<KeyValueMapPair, uint64_t>::iterator;
 
 	IKeyValueContainer() = default;
 	~IKeyValueContainer() = default;
 
-	bool empty() { return data.empty(); }
+	bool empty() const { return data.empty(); }
 	void clear() { return data.clear(); }
 
-	std::tuple<size_t, size_t, size_t> size() { return std::make_tuple(0, 0, 0); }
+	std::tuple<size_t, size_t, size_t> size() const { return std::make_tuple(0, 0, 0); }
 
+	const_iterator find(const StringRef& key) const { return data.find(key); }
 	iterator find(const StringRef& key) { return data.find(key); }
+	const_iterator begin() const { return data.begin(); }
 	iterator begin() { return data.begin(); }
+	const_iterator end() const { return data.end(); }
 	iterator end() { return data.end(); }
 
+	const_iterator lower_bound(const StringRef& key) const { return data.lower_bound(key); }
 	iterator lower_bound(const StringRef& key) { return data.lower_bound(key); }
+	const_iterator upper_bound(const StringRef& key) const { return data.upper_bound(key); }
 	iterator upper_bound(const StringRef& key) { return data.upper_bound(key); }
+	const_iterator previous(const_iterator i) const { return data.previous(i); }
+	const_iterator previous(iterator i) const { return data.previous(const_iterator{ i }); }
 	iterator previous(iterator i) { return data.previous(i); }
 
 	void erase(iterator begin, iterator end) { data.erase(begin, end); }
@@ -96,7 +104,8 @@ public:
 		return data.insert(pairs, replaceExisting);
 	}
 
-	uint64_t sumTo(iterator to) { return data.sumTo(to); }
+	uint64_t sumTo(const_iterator to) const { return data.sumTo(to); }
+	uint64_t sumTo(iterator to) const { return data.sumTo(const_iterator{ to }); }
 
 	static int getElementBytes() { return IndexedSet<KeyValueMapPair, uint64_t>::getElementBytes(); }
 

--- a/flow/IKeyValueContainer.h
+++ b/flow/IKeyValueContainer.h
@@ -85,7 +85,7 @@ public:
 
 	iterator lower_bound(const StringRef& key) { return data.lower_bound(key); }
 	iterator upper_bound(const StringRef& key) { return data.upper_bound(key); }
-	iterator previous(iterator i) const { return data.previous(i); }
+	iterator previous(iterator i) { return data.previous(i); }
 
 	void erase(iterator begin, iterator end) { data.erase(begin, end); }
 	iterator insert(const StringRef& key, const StringRef& val, bool replaceExisting = true) {

--- a/flow/IKeyValueContainer.h
+++ b/flow/IKeyValueContainer.h
@@ -84,8 +84,10 @@ public:
 	iterator find(const StringRef& key) { return data.find(key); }
 	const_iterator begin() const { return data.begin(); }
 	iterator begin() { return data.begin(); }
+	const_iterator cbegin() const { return begin(); }
 	const_iterator end() const { return data.end(); }
 	iterator end() { return data.end(); }
+	const_iterator cend() const { return end(); }
 
 	const_iterator lower_bound(const StringRef& key) const { return data.lower_bound(key); }
 	iterator lower_bound(const StringRef& key) { return data.lower_bound(key); }

--- a/flow/IndexedSet.cpp
+++ b/flow/IndexedSet.cpp
@@ -503,11 +503,7 @@ TEST_CASE("/flow/IndexedSet/all numbers") {
 }
 
 template <class T>
-struct is_const_ref {
-	static constexpr bool value = std::is_const_v<typename std::remove_reference_t<T>>;
-};
-template <class T>
-static constexpr bool is_const_ref_v = is_const_ref<T>::value;
+static constexpr bool is_const_ref_v = std::is_const_v<typename std::remove_reference_t<T>>;
 
 TEST_CASE("/flow/IndexedSet/const_iterator") {
 	struct Key {

--- a/flow/IndexedSet.cpp
+++ b/flow/IndexedSet.cpp
@@ -222,7 +222,7 @@ struct IndexedSetHarness {
 	result end() { return s.end(); }
 	const_result lower_bound(K const& k) const { return s.lower_bound(k); }
 	result lower_bound(K const& k) { return s.lower_bound(k); }
-	result upper_bound(K const& k) const { return s.upper_bound(k); }
+	const_result upper_bound(K const& k) const { return s.upper_bound(k); }
 	result upper_bound(K const& k) { return s.upper_bound(k); }
 	void erase(K const& k) { s.erase(k); }
 };
@@ -502,6 +502,13 @@ TEST_CASE("/flow/IndexedSet/all numbers") {
 	return Void();
 }
 
+template <class T>
+struct is_const_ref {
+	static constexpr bool value = std::is_const_v<typename std::remove_reference_t<T>>;
+};
+template <class T>
+static constexpr bool is_const_ref_v = is_const_ref<T>::value;
+
 TEST_CASE("/flow/IndexedSet/const_iterator") {
 	struct Key {
 		int key;
@@ -511,41 +518,48 @@ TEST_CASE("/flow/IndexedSet/const_iterator") {
 		int metric;
 		explicit Metric(int metric) : metric(metric) {}
 	};
+
 	IndexedSet<int, int64_t> is;
 	for (int i = 0; i < 10; ++i) is.insert(i, 1);
-	static_assert(!std::is_const_v<decltype(is)>);
-	static_assert(!std::is_const_v<decltype(*is.begin())>);
-	static_assert(!std::is_const_v<decltype(*is.previous(is.end()))>);
-	static_assert(!std::is_const_v<decltype(*is.index(Metric{ 5 }))>);
-	static_assert(!std::is_const_v<decltype(*is.find(Key{ 5 }))>);
-	static_assert(!std::is_const_v<decltype(*is.upper_bound(Key{ 5 }))>);
-	static_assert(!std::is_const_v<decltype(*is.lower_bound(Key{ 5 }))>);
-	static_assert(!std::is_const_v<decltype(*is.lastLessOrEqual(Key{ 5 }))>);
-	static_assert(!std::is_const_v<decltype(*is.lastItem())>);
+
+	IndexedSet<int, int64_t>& ncis = is;
+	static_assert(!is_const_ref_v<decltype(ncis)>);
+	static_assert(!is_const_ref_v<decltype(*ncis.begin())>);
+	static_assert(is_const_ref_v<decltype(*ncis.cbegin())>);
+	static_assert(!is_const_ref_v<decltype(*ncis.previous(ncis.end()))>);
+	static_assert(is_const_ref_v<decltype(*ncis.previous(ncis.cend()))>);
+	static_assert(!is_const_ref_v<decltype(*ncis.index(Metric{ 5 }))>);
+	static_assert(!is_const_ref_v<decltype(*ncis.find(Key{ 5 }))>);
+	static_assert(!is_const_ref_v<decltype(*ncis.upper_bound(Key{ 5 }))>);
+	static_assert(!is_const_ref_v<decltype(*ncis.lower_bound(Key{ 5 }))>);
+	static_assert(!is_const_ref_v<decltype(*ncis.lastLessOrEqual(Key{ 5 }))>);
+	static_assert(!is_const_ref_v<decltype(*ncis.lastItem())>);
 
 	const IndexedSet<int, int64_t>& cis = is;
-	static_assert(std::is_const_v<typename std::remove_reference_t<decltype(cis)>>);
-	static_assert(std::is_const_v<typename std::remove_reference_t<decltype(*cis.begin())>>);
-	static_assert(std::is_const_v<typename std::remove_reference_t<decltype(*cis.previous(cis.end()))>>);
-	static_assert(std::is_const_v<typename std::remove_reference_t<decltype(*cis.previous(is.end()))>>);
-	static_assert(std::is_const_v<typename std::remove_reference_t<decltype(*cis.index(Metric{ 5 }))>>);
-	static_assert(std::is_const_v<typename std::remove_reference_t<decltype(*cis.find(Key{ 5 }))>>);
-	static_assert(std::is_const_v<typename std::remove_reference_t<decltype(*cis.upper_bound(Key{ 5 }))>>);
-	static_assert(std::is_const_v<typename std::remove_reference_t<decltype(*cis.lower_bound(Key{ 5 }))>>);
-	static_assert(std::is_const_v<typename std::remove_reference_t<decltype(*cis.lastLessOrEqual(Key{ 5 }))>>);
-	static_assert(std::is_const_v<typename std::remove_reference_t<decltype(*cis.lastItem())>>);
+	static_assert(is_const_ref_v<decltype(cis)>);
+	static_assert(is_const_ref_v<decltype(*cis.begin())>);
+	static_assert(is_const_ref_v<decltype(*cis.cbegin())>);
+	static_assert(is_const_ref_v<decltype(*cis.previous(cis.end()))>);
+	static_assert(is_const_ref_v<decltype(*cis.previous(cis.cend()))>);
+	static_assert(is_const_ref_v<decltype(*cis.previous(ncis.end()))>);
+	static_assert(is_const_ref_v<decltype(*cis.previous(ncis.cend()))>);
+	static_assert(is_const_ref_v<decltype(*cis.index(Metric{ 5 }))>);
+	static_assert(is_const_ref_v<decltype(*cis.find(Key{ 5 }))>);
+	static_assert(is_const_ref_v<decltype(*cis.upper_bound(Key{ 5 }))>);
+	static_assert(is_const_ref_v<decltype(*cis.lower_bound(Key{ 5 }))>);
+	static_assert(is_const_ref_v<decltype(*cis.lastLessOrEqual(Key{ 5 }))>);
+	static_assert(is_const_ref_v<decltype(*cis.lastItem())>);
 
-	for (auto& val : is) {
-		static_assert(!std::is_const_v<typename std::remove_reference_t<decltype(val)>>);
+	for (auto& val : ncis) {
+		static_assert(!is_const_ref_v<decltype(val)>);
 	}
-	for (const auto& val : is) {
-		static_assert(std::is_const_v<typename std::remove_reference_t<decltype(val)>>);
+	for (const auto& val : ncis) {
+		static_assert(is_const_ref_v<decltype(val)>);
 	}
 	for (auto& val : cis) {
-		static_assert(std::is_const_v<typename std::remove_reference_t<decltype(val)>>);
+		static_assert(is_const_ref_v<decltype(val)>);
 	}
 
 	return Void();
 }
-
 void forceLinkIndexedSetTests() {}

--- a/flow/IndexedSet.cpp
+++ b/flow/IndexedSet.cpp
@@ -210,12 +210,12 @@ struct IndexedSetHarness {
 	map s;
 
 	void insert(K const& k) { s.insert(K(k), 1); }
-	result find(K const& k) const { return s.find(k); }
-	result not_found() const { return s.end(); }
-	result begin() const { return s.begin(); }
-	result end() const { return s.end(); }
-	result lower_bound(K const& k) const { return s.lower_bound(k); }
-	result upper_bound(K const& k) const { return s.upper_bound(k); }
+	result find(K const& k) { return s.find(k); }
+	result not_found() { return s.end(); }
+	result begin() { return s.begin(); }
+	result end() { return s.end(); }
+	result lower_bound(K const& k) { return s.lower_bound(k); }
+	result upper_bound(K const& k) { return s.upper_bound(k); }
 	void erase(K const& k) { s.erase(k); }
 };
 

--- a/flow/IndexedSet.cpp
+++ b/flow/IndexedSet.cpp
@@ -527,6 +527,7 @@ TEST_CASE("/flow/IndexedSet/const_iterator") {
 	static_assert(std::is_const_v<typename std::remove_reference_t<decltype(cis)>>);
 	static_assert(std::is_const_v<typename std::remove_reference_t<decltype(*cis.begin())>>);
 	static_assert(std::is_const_v<typename std::remove_reference_t<decltype(*cis.previous(cis.end()))>>);
+	static_assert(std::is_const_v<typename std::remove_reference_t<decltype(*cis.previous(is.end()))>>);
 	static_assert(std::is_const_v<typename std::remove_reference_t<decltype(*cis.index(Metric{ 5 }))>>);
 	static_assert(std::is_const_v<typename std::remove_reference_t<decltype(*cis.find(Key{ 5 }))>>);
 	static_assert(std::is_const_v<typename std::remove_reference_t<decltype(*cis.upper_bound(Key{ 5 }))>>);

--- a/flow/IndexedSet.h
+++ b/flow/IndexedSet.h
@@ -319,7 +319,7 @@ private:
 	}
 
 	template <int direction, bool isConst>
-	static void _moveIterator(std::conditional_t<isConst, const Node, Node>*& node) {
+	static void moveIteratorImpl(std::conditional_t<isConst, const Node, Node>*& node) {
 		if (node->child[0 ^ direction]) {
 			node = node->child[0 ^ direction];
 			while (node->child[1 ^ direction]) node = node->child[1 ^ direction];
@@ -332,11 +332,11 @@ private:
 	// direction 0 = left, 1 = right
 	template <int direction>
 	static void moveIterator(Node const*& node) {
-		_moveIterator<direction, true>(node);
+		moveIteratorImpl<direction, true>(node);
 	}
 	template <int direction>
 	static void moveIterator(Node*& node) {
-		_moveIterator<direction, false>(node);
+		moveIteratorImpl<direction, false>(node);
 	}
 
 public: // but testonly

--- a/flow/IndexedSet.h
+++ b/flow/IndexedSet.h
@@ -170,6 +170,7 @@ public:
 	iterator end() { return iterator{}; }
 
 	const_iterator previous(const_iterator i) const { return ConstImpl::previous(*this, i); }
+	const_iterator previous(iterator i) const { return ConstImpl::previous(*this, const_iterator{ i }); }
 	iterator previous(iterator i) { return NonConstImpl::previous(*this, i); }
 
 	const_iterator lastItem() const { return ConstImpl::lastItem(*this); }

--- a/flow/IndexedSet.h
+++ b/flow/IndexedSet.h
@@ -285,11 +285,11 @@ public:
 
 	// Return the metric inserted with item x
 	Metric getMetric(const_iterator x) const;
-	Metric getMetric(iterator x) { return sumTo(const_iterator{ x }); }
+	Metric getMetric(iterator x) const { return getMetric(const_iterator{ x }); }
 
 	// Return the sum of getMetric(x) for begin()<=x<to
 	Metric sumTo(const_iterator to) const;
-	Metric sumTo(iterator to) { return sumTo(const_iterator{ to }); }
+	Metric sumTo(iterator to) const { return sumTo(const_iterator{ to }); }
 
 	// Return the sum of getMetric(x) for begin<=x<end
 	Metric sumRange(const_iterator begin, const_iterator end) const { return sumTo(end) - sumTo(begin); }
@@ -1220,7 +1220,7 @@ template <class Key>
 typename IndexedSet<T, Metric>::template Impl<isConst>::IteratorT IndexedSet<T, Metric>::Impl<isConst>::upper_bound(
     IndexedSet<T, Metric>::Impl<isConst>::SetT& self, const Key& key) {
 	NodeT* t = self.root;
-	if (!t) return IteratorT{};
+	if (!t) return self.end();
 	bool not_less;
 	while (true) {
 		not_less = !(key < t->data);
@@ -1269,7 +1269,7 @@ template <class T, class Metric>
 Metric IndexedSet<T, Metric>::getMetric(typename IndexedSet<T, Metric>::const_iterator x) const {
 	Metric m = x.node->total;
 	for(int i=0; i<2; i++)
-		if (x.i->child[i]) m = m - x.node->child[i]->total;
+		if (x.node->child[i]) m = m - x.node->child[i]->total;
 	return m;
 }
 

--- a/flow/IndexedSet.h
+++ b/flow/IndexedSet.h
@@ -166,8 +166,11 @@ public:
 
 	const_iterator begin() const { return ConstImpl::begin(*this); };
 	iterator begin() { return NonConstImpl::begin(*this); };
+	const_iterator cbegin() const { return begin(); }
+
 	const_iterator end() const { return const_iterator{}; }
 	iterator end() { return iterator{}; }
+	const_iterator cend() const { return end(); }
 
 	const_iterator previous(const_iterator i) const { return ConstImpl::previous(*this, i); }
 	const_iterator previous(iterator i) const { return ConstImpl::previous(*this, const_iterator{ i }); }
@@ -406,8 +409,10 @@ public:
 	Map() {}
 	const_iterator begin() const { return set.begin(); }
 	iterator begin() { return set.begin(); }
+	const_iterator cbegin() const { return begin(); }
 	const_iterator end() const { return set.end(); }
 	iterator end() { return set.end(); }
+	const_iterator cend() const { return end(); }
 	const_iterator lastItem() const { return set.lastItem(); }
 	iterator lastItem() { return set.lastItem(); }
 	const_iterator previous(const_iterator i) const { return set.previous(i); }

--- a/flow/IndexedSet.h
+++ b/flow/IndexedSet.h
@@ -131,8 +131,6 @@ private: // Forward-declare IndexedSet::Node because Clang is much stricter abou
 
 		static IteratorT begin(SetT&);
 
-		static IteratorT end(SetT&);
-
 		template <bool constIterator>
 		static IteratorImpl<isConst || constIterator> previous(SetT&, IteratorImpl<constIterator>);
 
@@ -168,8 +166,8 @@ public:
 
 	const_iterator begin() const { return ConstImpl::begin(*this); };
 	iterator begin() { return NonConstImpl::begin(*this); };
-	const_iterator end() const { return ConstImpl::end(*this); }
-	iterator end() { return NonConstImpl::end(*this); }
+	const_iterator end() const { return const_iterator{}; }
+	iterator end() { return iterator{}; }
 
 	const_iterator previous(const_iterator i) const { return ConstImpl::previous(*this, i); }
 	iterator previous(iterator i) { return NonConstImpl::previous(*this, i); }
@@ -746,13 +744,6 @@ typename IndexedSet<T, Metric>::template Impl<isConst>::IteratorT IndexedSet<T, 
 	NodeT* x = self.root;
 	while (x && x->child[0]) x = x->child[0];
 	return IteratorT{ x };
-}
-
-template <class T, class Metric>
-template <bool isConst>
-typename IndexedSet<T, Metric>::template Impl<isConst>::IteratorT IndexedSet<T, Metric>::Impl<isConst>::end(
-    IndexedSet<T, Metric>::Impl<isConst>::SetT& self) {
-	return IteratorT{};
 }
 
 template <class T, class Metric>

--- a/flow/IndexedSet.h
+++ b/flow/IndexedSet.h
@@ -158,6 +158,9 @@ private: // Forward-declare IndexedSet::Node because Clang is much stricter abou
 		static IteratorT lastItem(SetT&);
 	};
 
+	using ConstImpl = Impl<true>;
+	using NonConstImpl = Impl<false>;
+
 public:
 	using iterator = IteratorImpl<false>;
 	using const_iterator = IteratorImpl<true>;
@@ -167,19 +170,19 @@ public:
 	IndexedSet(IndexedSet&& r) BOOST_NOEXCEPT : root(r.root) { r.root = NULL; }
 	IndexedSet& operator=(IndexedSet&& r) BOOST_NOEXCEPT { delete root; root = r.root; r.root = 0; return *this; }
 
-	const_iterator begin() const { return Impl<true>::begin(*this); };
-	iterator begin() { return Impl<false>::begin(*this); };
-	const_iterator end() const { return Impl<true>::end(*this); }
-	iterator end() { return Impl<false>::end(*this); }
+	const_iterator begin() const { return ConstImpl::begin(*this); };
+	iterator begin() { return NonConstImpl::begin(*this); };
+	const_iterator end() const { return ConstImpl::end(*this); }
+	iterator end() { return NonConstImpl::end(*this); }
 
-	const_iterator previous(const_iterator i) const { return Impl<true>::previous(*this, i); }
+	const_iterator previous(const_iterator i) const { return ConstImpl::previous(*this, i); }
 	template <bool constIterator>
 	IteratorImpl<constIterator> previous(IteratorImpl<constIterator> i) {
-		return Impl<false>::previous(*this, i);
+		return NonConstImpl::previous(*this, i);
 	};
 
-	const_iterator lastItem() const { return Impl<true>::lastItem(*this); }
-	iterator lastItem() { return Impl<false>::lastItem(*this); }
+	const_iterator lastItem() const { return ConstImpl::lastItem(*this); }
+	iterator lastItem() { return NonConstImpl::lastItem(*this); }
 
 	bool empty() const { return !root; }
 	void clear() { delete root; root = NULL; }
@@ -230,56 +233,56 @@ public:
 	// Returns x such that key==*x, or end()
 	template <class Key>
 	const_iterator find(const Key& key) const {
-		return Impl<true>::find(*this, key);
+		return ConstImpl::find(*this, key);
 	}
 
 	template <class Key>
 	iterator find(const Key& key) {
-		return Impl<false>::find(*this, key);
+		return NonConstImpl::find(*this, key);
 	}
 
 	// Returns the smallest x such that *x>=key, or end()
 	template <class Key>
 	const_iterator lower_bound(const Key& key) const {
-		return Impl<true>::lower_bound(*this, key);
+		return ConstImpl::lower_bound(*this, key);
 	}
 
 	template <class Key>
 	iterator lower_bound(const Key& key) {
-		return Impl<false>::lower_bound(*this, key);
+		return NonConstImpl::lower_bound(*this, key);
 	};
 
 	// Returns the smallest x such that *x>key, or end()
 	template <class Key>
 	const_iterator upper_bound(const Key& key) const {
-		return Impl<true>::upper_bound(*this, key);
+		return ConstImpl::upper_bound(*this, key);
 	}
 
 	template <class Key>
 	iterator upper_bound(const Key& key) {
-		return Impl<false>::upper_bound(*this, key);
+		return NonConstImpl::upper_bound(*this, key);
 	};
 
 	// Returns the largest x such that *x<=key, or end()
 	template <class Key>
 	const_iterator lastLessOrEqual(const Key& key) const {
-		return Impl<true>::lastLessOrEqual(*this, key);
+		return ConstImpl::lastLessOrEqual(*this, key);
 	};
 
 	template <class Key>
 	iterator lastLessOrEqual(const Key& key) {
-		return Impl<false>::lastLessOrEqual(*this, key);
+		return NonConstImpl::lastLessOrEqual(*this, key);
 	}
 
 	// Returns smallest x such that sumTo(x+1) > metric, or end()
 	template <class M>
 	const_iterator index(M const& metric) const {
-		return Impl<true>::index(*this, metric);
+		return ConstImpl::index(*this, metric);
 	};
 
 	template <class M>
 	iterator index(M const& metric) {
-		return Impl<false>::index(*this, metric);
+		return NonConstImpl::index(*this, metric);
 	}
 
 	// Return the metric inserted with item x

--- a/flow/IndexedSet.h
+++ b/flow/IndexedSet.h
@@ -323,27 +323,25 @@ private:
 			newNode->parent = oldNode->parent;
 	}
 
-	// direction 0 = left, 1 = right
-	template <int direction>
-	static void moveIterator(Node* &i){
-		if (i->child[0 ^ direction]) {
-			i = i->child[0 ^ direction];
-			while (i->child[1 ^ direction]) i = i->child[1 ^ direction];
+	template <int direction, bool isConst>
+	static void _moveIterator(std::conditional_t<isConst, const Node, Node>*& node) {
+		if (node->child[0 ^ direction]) {
+			node = node->child[0 ^ direction];
+			while (node->child[1 ^ direction]) node = node->child[1 ^ direction];
 		} else {
-			while (i->parent && i->parent->child[0 ^ direction] == i) i = i->parent;
-			i = i->parent;
+			while (node->parent && node->parent->child[0 ^ direction] == node) node = node->parent;
+			node = node->parent;
 		}
 	}
 
+	// direction 0 = left, 1 = right
 	template <int direction>
-	static void moveIterator(const Node*& i) {
-		if (i->child[0 ^ direction]) {
-			i = i->child[0 ^ direction];
-			while (i->child[1 ^ direction]) i = i->child[1 ^ direction];
-		} else {
-			while (i->parent && i->parent->child[0 ^ direction] == i) i = i->parent;
-			i = i->parent;
-		}
+	static void moveIterator(Node const*& node) {
+		_moveIterator<direction, true>(node);
+	}
+	template <int direction>
+	static void moveIterator(Node*& node) {
+		_moveIterator<direction, false>(node);
 	}
 
 public: // but testonly

--- a/flow/IndexedSet.h
+++ b/flow/IndexedSet.h
@@ -106,8 +106,10 @@ private: // Forward-declare IndexedSet::Node because Clang is much stricter abou
 		bool operator!=(const IteratorImpl<isConst>& r) const { return node != r.node; }
 		// following two methods are for memory storage engine(KeyValueStoreMemory class) use only
 		// in order to have same interface as radixtree
-		StringRef& getKey(uint8_t* dummyContent) const { return node->data.key; }
-		StringRef& getValue() const { return node->data.value; }
+		typename std::conditional_t<isConst, const StringRef, StringRef>& getKey(uint8_t* dummyContent) const {
+			return node->data.key;
+		}
+		typename std::conditional_t<isConst, const StringRef, StringRef>& getValue() const { return node->data.value; }
 	};
 
 	template <bool isConst>

--- a/flow/IndexedSet.h
+++ b/flow/IndexedSet.h
@@ -91,12 +91,7 @@ private: // Forward-declare IndexedSet::Node because Clang is much stricter abou
 		typename std::conditional_t<isConst, const IndexedSet::Node, IndexedSet::Node>* i;
 
 		template <typename = std::enable_if_t<isConst>>
-		IteratorImpl<isConst>(const IteratorImpl<false>& nonConstIter) : i(nonConstIter.i) {}
-		template <typename = std::enable_if_t<isConst>>
-		IteratorImpl<isConst>& operator=(const IteratorImpl<false>& nonConstIter) {
-			i = nonConstIter.i;
-			return *this;
-		}
+		explicit IteratorImpl<isConst>(const IteratorImpl<false>& nonConstIter) : i(nonConstIter.i) {}
 
 		explicit IteratorImpl(decltype(i) n = nullptr) : i(n){};
 
@@ -285,13 +280,17 @@ public:
 
 	// Return the metric inserted with item x
 	Metric getMetric(const_iterator x) const;
+	Metric getMetric(iterator x) { return sumTo(const_iterator{ x }); }
 
 	// Return the sum of getMetric(x) for begin()<=x<to
 	Metric sumTo(const_iterator to) const;
+	Metric sumTo(iterator to) { return sumTo(const_iterator{ to }); }
 
 	// Return the sum of getMetric(x) for begin<=x<end
 	Metric sumRange(const_iterator begin, const_iterator end) const { return sumTo(end) - sumTo(begin); }
-	Metric sumRange(iterator begin, iterator end) const { return sumTo(end) - sumTo(begin); }
+	Metric sumRange(iterator begin, iterator end) const {
+		return sumTo(const_iterator{ end }) - sumTo(const_iterator{ begin });
+	}
 
 	// Return the sum of getMetric(x) for all x s.t. begin <= *x && *x < end
 	template <class Key>

--- a/flow/IndexedSet.h
+++ b/flow/IndexedSet.h
@@ -159,9 +159,9 @@ public:
 	using iterator = IteratorImpl<false>;
 	using const_iterator = IteratorImpl<true>;
 
-	IndexedSet() : root(NULL) {};
+	IndexedSet() : root(nullptr){};
 	~IndexedSet() { delete root; }
-	IndexedSet(IndexedSet&& r) BOOST_NOEXCEPT : root(r.root) { r.root = NULL; }
+	IndexedSet(IndexedSet&& r) BOOST_NOEXCEPT : root(r.root) { r.root = nullptr; }
 	IndexedSet& operator=(IndexedSet&& r) BOOST_NOEXCEPT { delete root; root = r.root; r.root = 0; return *this; }
 
 	const_iterator begin() const { return ConstImpl::begin(*this); };
@@ -176,7 +176,10 @@ public:
 	iterator lastItem() { return NonConstImpl::lastItem(*this); }
 
 	bool empty() const { return !root; }
-	void clear() { delete root; root = NULL; }
+	void clear() {
+		delete root;
+		root = nullptr;
+	}
 	void swap( IndexedSet& r ) { std::swap( root, r.root ); }
 
 	// Place data in the set with the given metric.  If an item equal to data is already in the set and,
@@ -856,17 +859,17 @@ typename IndexedSet<T,Metric>::iterator IndexedSet<T,Metric>::insert(T_&& data, 
 template <class T, class Metric>
 int IndexedSet<T,Metric>::insert(const std::vector<std::pair<T,Metric>>& dataVector, bool replaceExisting) {
 	int num_inserted = 0;
-	Node *blockStart = NULL;
-	Node *blockEnd = NULL;
+	Node* blockStart = nullptr;
+	Node* blockEnd = nullptr;
 
 	for(int i = 0; i < dataVector.size(); ++i) {
 		Metric metric = dataVector[i].second;
 		T data = std::move(dataVector[i].first);
 
 		int d = 1; // direction
-		if(blockStart == NULL || (blockEnd != NULL && data >= blockEnd->data)) {
-			blockEnd = NULL;
-			if (root == NULL) {
+		if (blockStart == nullptr || (blockEnd != nullptr && data >= blockEnd->data)) {
+			blockEnd = nullptr;
+			if (root == nullptr) {
 				root = new Node(std::move(data), metric);
 				num_inserted++;
 				blockStart = root;
@@ -1062,7 +1065,7 @@ void IndexedSet<T,Metric>::erase( typename IndexedSet<T,Metric>::iterator begin,
 	int heightDelta = leftHeightDelta + rightHeightDelta; 
 
 	// Rebalance and update metrics for all nodes from subRoot up to the root
-	for(auto p = subRoot; p != NULL; p = p->parent) {
+	for (auto p = subRoot; p != nullptr; p = p->parent) {
 		p->total = p->total - metricDelta;
 
 		auto& pc = p->parent ? p->parent->child[p->parent->child[1]==p] : root;


### PR DESCRIPTION
Allows constant iteration over an `IndexedSet`, `Map`, or `IKeyValueContainer`. Outside of unit tests, this PR does not actually implement constant iteration anywhere, that can be done in separate pull requests.