### PR TITLE
Backup's ProgramStart command line string was incomplete

### DIFF
--- a/fdbbackup/backup.actor.cpp
+++ b/fdbbackup/backup.actor.cpp
@@ -2554,7 +2554,13 @@ int main(int argc, char* argv[]) {
 	platformInit();
 	initSignalSafeUnwind();
 
-	int	status = FDB_EXIT_SUCCESS;
+	int status = FDB_EXIT_SUCCESS;
+
+	std::string commandLine;
+	for(int a=0; a<argc; a++) {
+		if (a) commandLine += ' ';
+		commandLine += argv[a];
+	}
 
 	try {
 #ifdef ALLOC_INSTRUMENTATION
@@ -3178,12 +3184,6 @@ int main(int argc, char* argv[]) {
 		{
 			delete args;
 			args = NULL;
-		}
-
-		std::string commandLine;
-		for(int a=0; a<argc; a++) {
-			if (a) commandLine += ' ';
-			commandLine += argv[a];
 		}
 
 		delete FLOW_KNOBS;


### PR DESCRIPTION
Arguments specified using an '=' would truncate the '=' and value.