### PR TITLE
Cancel pending special key space reads on destroy

### DIFF
--- a/design/special-key-space.md
+++ b/design/special-key-space.md
@@ -20,7 +20,7 @@ Consequently, the special-key-space framework wants to integrate all client func
 If your feature is exposing information to clients and the results are easily formatted as key-value pairs, then you can use special-key-space to implement your client function.
 
 ## How
-If you choose to use, you need to implement a function class that inherits from `SpecialKeyRangeBaseImpl`, which has an abstract method `Future<Standalone<RangeResultRef>> getRange(Reference<ReadYourWritesTransaction> ryw, KeyRangeRef kr)`.
+If you choose to use, you need to implement a function class that inherits from `SpecialKeyRangeBaseImpl`, which has an abstract method `Future<Standalone<RangeResultRef>> getRange(ReadYourWritesTransaction* ryw, KeyRangeRef kr)`.
 This method can be treated as a callback, whose implementation details are determined by the developer.
 Once you fill out the method, register the function class to the corresponding key range.
 Below is a detailed example.
@@ -38,7 +38,7 @@ public:
         CountryToCapitalCity[LiteralStringRef("China")] = LiteralStringRef("Beijing");
     }
     // Implement the getRange interface
-    Future<Standalone<RangeResultRef>> getRange(Reference<ReadYourWritesTransaction> ryw,
+    Future<Standalone<RangeResultRef>> getRange(ReadYourWritesTransaction* ryw,
                                             KeyRangeRef kr) const override {
         
         Standalone<RangeResultRef> result;

--- a/fdbclient/ReadYourWrites.actor.cpp
+++ b/fdbclient/ReadYourWrites.actor.cpp
@@ -1230,7 +1230,7 @@ Future< Optional<Value> > ReadYourWritesTransaction::get( const Key& key, bool s
 	if (getDatabase()->apiVersionAtLeast(630)) {
 		if (specialKeys.contains(key)) {
 			TEST(true); // Special keys get
-			return getDatabase()->specialKeySpace->get(Reference<ReadYourWritesTransaction>::addRef(this), key);
+			return getDatabase()->specialKeySpace->get(this, key);
 		}
 	} else {
 		if (key == LiteralStringRef("\xff\xff/status/json")) {
@@ -1312,8 +1312,7 @@ Future< Standalone<RangeResultRef> > ReadYourWritesTransaction::getRange(
 	if (getDatabase()->apiVersionAtLeast(630)) {
 		if (specialKeys.contains(begin.getKey()) && end.getKey() <= specialKeys.end) {
 			TEST(true); // Special key space get range
-			return getDatabase()->specialKeySpace->getRange(Reference<ReadYourWritesTransaction>::addRef(this), begin,
-			                                                end, limits, reverse);
+			return getDatabase()->specialKeySpace->getRange(this, begin, end, limits, reverse);
 		}
 	} else {
 		if (begin.getKey() == LiteralStringRef("\xff\xff/worker_interfaces")) {

--- a/fdbclient/ReadYourWrites.h
+++ b/fdbclient/ReadYourWrites.h
@@ -124,6 +124,8 @@ public:
 
 	// Wait for all reads that are currently pending to complete
 	Future<Void> pendingReads() { return resetPromise.getFuture() || reading; }
+	// Throws before the lifetime of this transaction ends
+	Future<Void> resetFuture() { return resetPromise.getFuture(); }
 
 	// Used by ThreadSafeTransaction for exceptions thrown in void methods
 	Error deferredError;

--- a/fdbclient/SpecialKeySpace.actor.cpp
+++ b/fdbclient/SpecialKeySpace.actor.cpp
@@ -316,8 +316,7 @@ Future<Standalone<RangeResultRef>> ConflictingKeysImpl::getRange(ReadYourWritesT
 	return result;
 }
 
-ACTOR Future<Standalone<RangeResultRef>> ddStatsGetRangeActor(Reference<ReadYourWritesTransaction> ryw,
-                                                              KeyRangeRef kr) {
+ACTOR Future<Standalone<RangeResultRef>> ddStatsGetRangeActor(ReadYourWritesTransaction* ryw, KeyRangeRef kr) {
 	try {
 		auto keys = kr.removePrefix(ddStatsRange.begin);
 		Standalone<VectorRef<DDMetricsRef>> resultWithoutPrefix =
@@ -342,8 +341,7 @@ ACTOR Future<Standalone<RangeResultRef>> ddStatsGetRangeActor(Reference<ReadYour
 
 DDStatsRangeImpl::DDStatsRangeImpl(KeyRangeRef kr) : SpecialKeyRangeBaseImpl(kr) {}
 
-Future<Standalone<RangeResultRef>> DDStatsRangeImpl::getRange(Reference<ReadYourWritesTransaction> ryw,
-                                                              KeyRangeRef kr) const {
+Future<Standalone<RangeResultRef>> DDStatsRangeImpl::getRange(ReadYourWritesTransaction* ryw, KeyRangeRef kr) const {
 	return ddStatsGetRangeActor(ryw, kr);
 }
 

--- a/fdbclient/SpecialKeySpace.actor.h
+++ b/fdbclient/SpecialKeySpace.actor.h
@@ -36,8 +36,7 @@
 class SpecialKeyRangeBaseImpl {
 public:
 	// Each derived class only needs to implement this simple version of getRange
-	virtual Future<Standalone<RangeResultRef>> getRange(Reference<ReadYourWritesTransaction> ryw,
-	                                                    KeyRangeRef kr) const = 0;
+	virtual Future<Standalone<RangeResultRef>> getRange(ReadYourWritesTransaction* ryw, KeyRangeRef kr) const = 0;
 
 	explicit SpecialKeyRangeBaseImpl(KeyRangeRef kr) : range(kr) {}
 	KeyRangeRef getKeyRange() const { return range; }
@@ -61,10 +60,10 @@ public:
 		WORKERINTERFACE,
 	};
 
-	Future<Optional<Value>> get(Reference<ReadYourWritesTransaction> ryw, const Key& key);
+	Future<Optional<Value>> get(ReadYourWritesTransaction* ryw, const Key& key);
 
-	Future<Standalone<RangeResultRef>> getRange(Reference<ReadYourWritesTransaction> ryw, KeySelector begin,
-	                                            KeySelector end, GetRangeLimits limits, bool reverse = false);
+	Future<Standalone<RangeResultRef>> getRange(ReadYourWritesTransaction* ryw, KeySelector begin, KeySelector end,
+	                                            GetRangeLimits limits, bool reverse = false);
 
 	SpecialKeySpace(KeyRef spaceStartKey = Key(), KeyRef spaceEndKey = normalKeys.end, bool testOnly = true) {
 		// Default value is nullptr, begin of KeyRangeMap is Key()
@@ -108,16 +107,15 @@ public:
 	KeyRangeRef getKeyRange() const { return range; }
 
 private:
-	ACTOR static Future<Optional<Value>> getActor(SpecialKeySpace* sks, Reference<ReadYourWritesTransaction> ryw,
-	                                              KeyRef key);
+	ACTOR static Future<Optional<Value>> getActor(SpecialKeySpace* sks, ReadYourWritesTransaction* ryw, KeyRef key);
 
 	ACTOR static Future<Standalone<RangeResultRef>> checkModuleFound(SpecialKeySpace* sks,
-	                                                                 Reference<ReadYourWritesTransaction> ryw,
-	                                                                 KeySelector begin, KeySelector end,
-	                                                                 GetRangeLimits limits, bool reverse);
+	                                                                 ReadYourWritesTransaction* ryw, KeySelector begin,
+	                                                                 KeySelector end, GetRangeLimits limits,
+	                                                                 bool reverse);
 	ACTOR static Future<std::pair<Standalone<RangeResultRef>, Optional<SpecialKeySpace::MODULE>>>
-	getRangeAggregationActor(SpecialKeySpace* sks, Reference<ReadYourWritesTransaction> ryw, KeySelector begin,
-	                         KeySelector end, GetRangeLimits limits, bool reverse);
+	getRangeAggregationActor(SpecialKeySpace* sks, ReadYourWritesTransaction* ryw, KeySelector begin, KeySelector end,
+	                         GetRangeLimits limits, bool reverse);
 
 	KeyRangeMap<SpecialKeyRangeBaseImpl*> impls;
 	KeyRangeMap<SpecialKeySpace::MODULE> modules;
@@ -135,22 +133,19 @@ private:
 class ConflictingKeysImpl : public SpecialKeyRangeBaseImpl {
 public:
 	explicit ConflictingKeysImpl(KeyRangeRef kr);
-	Future<Standalone<RangeResultRef>> getRange(Reference<ReadYourWritesTransaction> ryw,
-	                                            KeyRangeRef kr) const override;
+	Future<Standalone<RangeResultRef>> getRange(ReadYourWritesTransaction* ryw, KeyRangeRef kr) const override;
 };
 
 class ReadConflictRangeImpl : public SpecialKeyRangeBaseImpl {
 public:
 	explicit ReadConflictRangeImpl(KeyRangeRef kr);
-	Future<Standalone<RangeResultRef>> getRange(Reference<ReadYourWritesTransaction> ryw,
-	                                            KeyRangeRef kr) const override;
+	Future<Standalone<RangeResultRef>> getRange(ReadYourWritesTransaction* ryw, KeyRangeRef kr) const override;
 };
 
 class WriteConflictRangeImpl : public SpecialKeyRangeBaseImpl {
 public:
 	explicit WriteConflictRangeImpl(KeyRangeRef kr);
-	Future<Standalone<RangeResultRef>> getRange(Reference<ReadYourWritesTransaction> ryw,
-	                                            KeyRangeRef kr) const override;
+	Future<Standalone<RangeResultRef>> getRange(ReadYourWritesTransaction* ryw, KeyRangeRef kr) const override;
 };
 
 class DDStatsRangeImpl : public SpecialKeyRangeBaseImpl {

--- a/fdbclient/SpecialKeySpace.actor.h
+++ b/fdbclient/SpecialKeySpace.actor.h
@@ -151,8 +151,7 @@ public:
 class DDStatsRangeImpl : public SpecialKeyRangeBaseImpl {
 public:
 	explicit DDStatsRangeImpl(KeyRangeRef kr);
-	Future<Standalone<RangeResultRef>> getRange(Reference<ReadYourWritesTransaction> ryw,
-	                                            KeyRangeRef kr) const override;
+	Future<Standalone<RangeResultRef>> getRange(ReadYourWritesTransaction* ryw, KeyRangeRef kr) const override;
 };
 
 #include "flow/unactorcompiler.h"


### PR DESCRIPTION
Previously the special key space would take a reference to the
transaction, but this doesn't make sense since the transaction might not
be refcounted

Some context: https://forums.foundationdb.org/t/use-after-free-when-having-addref-on-readyourwritestransaction-object/2127/4