### PR TITLE
Fix nightly failure in ReportConflictingKeys test

### DIFF
--- a/design/special-key-space.md
+++ b/design/special-key-space.md
@@ -88,7 +88,7 @@ We introduce this `module` concept after a [discussion](https://forums.foundatio
   - `\xff\xff/transaction/read_conflict_range/, \xff\xff/transaction/read_conflict_range0` : read conflict ranges of the transaction
   - `\xff\xff/transaction/write_conflict_range/, \xff\xff/transaction/write_conflict_range0` : write conflict ranges of the transaction
 - METRICS: `\xff\xff/metrics/, \xff\xff/metrics0`, all metrics like data-distribution metrics or healthy metrics are planned to put here. All need to call the rpc, so time_out error s may happen. Right now we have:
-  - `\xff\xff/metrics/data_distribution_stats, \xff\xff/metrics/data_distribution_stats` : stats info about data-distribution
+  - `\xff\xff/metrics/data_distribution_stats/, \xff\xff/metrics/data_distribution_stats0` : stats info about data-distribution
 - WORKERINTERFACE : `\xff\xff/worker_interfaces/, \xff\xff/worker_interfaces0`, which is compatible with previous implementation, thus should not be used to add new functions.
 
 In addition, all singleKeyRanges are formatted as modules and cannot be used again. In particular, you should call `get` not `getRange` on these keys. Below are existing ones:

--- a/fdbserver/MasterProxyServer.actor.cpp
+++ b/fdbserver/MasterProxyServer.actor.cpp
@@ -499,6 +499,7 @@ struct ResolutionRequestBuilder {
 	vector<ResolveTransactionBatchRequest> requests;
 	vector<vector<int>> transactionResolverMap;
 	vector<CommitTransactionRef*> outTr;
+	std::vector<std::vector<std::vector<int>>> txReadConflictRangeIndexMap; // Used to report conflicting keys, the format is [CommitTransactionRef_Index][Resolver_Index][Read_Conflict_Range_Index_on_Resolver] -> read_conflict_range's original index in the commitTransactionRef
 
 	ResolutionRequestBuilder( ProxyCommitData* self, Version version, Version prevVersion, Version lastReceivedVersion) : self(self), requests(self->resolvers.size()) {
 		for(auto& req : requests) {
@@ -537,7 +538,9 @@ struct ResolutionRequestBuilder {
 				getOutTransaction(0, trIn.read_snapshot).mutations.push_back(requests[0].arena, m);
 			}
 		}
-		for(auto& r : trIn.read_conflict_ranges) {
+		std::vector<std::vector<int>> rCRIndexMap(requests.size()); // [resolver_index][read_conflict_range_index_on_the_resolver] -> read_conflict_range's original index
+		for(int idx = 0; idx < trIn.read_conflict_ranges.size(); ++idx) {
+			const auto& r = trIn.read_conflict_ranges[idx];
 			auto ranges = self->keyResolvers.intersectingRanges( r );
 			std::set<int> resolvers;
 			for(auto &ir : ranges) {
@@ -549,9 +552,12 @@ struct ResolutionRequestBuilder {
 				}
 			}
 			ASSERT(resolvers.size());
-			for(int resolver : resolvers)
+			for(int resolver : resolvers) {
 				getOutTransaction( resolver, trIn.read_snapshot ).read_conflict_ranges.push_back( requests[resolver].arena, r );
+				rCRIndexMap[resolver].push_back(idx);
+			}
 		}
+		txReadConflictRangeIndexMap.push_back(std::move(rCRIndexMap));
 		for(auto& r : trIn.write_conflict_ranges) {
 			auto ranges = self->keyResolvers.intersectingRanges( r );
 			std::set<int> resolvers;
@@ -866,6 +872,7 @@ ACTOR Future<Void> commitBatch(
 	}
 
 	state vector<vector<int>> transactionResolverMap = std::move( requests.transactionResolverMap );
+	state std::vector<std::vector<std::vector<int>>> txReadConflictRangeIndexMap = std::move(requests.txReadConflictRangeIndexMap); // used for reporting conflicting keys
 	state Future<Void> releaseFuture = releaseResolvingAfter(self, releaseDelay, localBatchNumber);
 
 	/////// Phase 2: Resolution (waiting on the network; pipelined)
@@ -1295,9 +1302,9 @@ ACTOR Future<Void> commitBatch(
 			if (trs[t].transaction.report_conflicting_keys) {
 				Standalone<VectorRef<int>> conflictingKRIndices;
 				for (int resolverInd : transactionResolverMap[t]) {
-					auto const& cKRs = resolution[resolverInd].conflictingKeyRangeMap[nextTr[resolverInd]];
+					auto const& cKRs = resolution[resolverInd].conflictingKeyRangeMap[nextTr[resolverInd]]; // nextTr[resolverInd] -> index of this trs[t] on the resolver
 					for (auto const& rCRIndex : cKRs)
-						conflictingKRIndices.push_back(conflictingKRIndices.arena(), rCRIndex);
+						conflictingKRIndices.push_back(conflictingKRIndices.arena(), txReadConflictRangeIndexMap[t][resolverInd][rCRIndex]); // read_conflict_range can change when sent to resolvers, mapping the index from resolver-side to original index in commitTransactionRef
 				}
 				// At least one keyRange index should be returned
 				ASSERT(conflictingKRIndices.size());


### PR DESCRIPTION
Two minors:
- fix typos in special-key-space doc
- add assertions and traces in `ReportConflictingKeys` for debugging

Major one (`MasterProxyServer.actor.cpp`):
Fix a bug caught by a nightly test that happens when we have multiple resolvers.
Previously, I only add logic to handle the case that `commitTransactionRef` is only sent to specific resolvers. However, not only the `commitTransactionRef` but also the `read_conflict_range` is can be omitted.  Thus I need to add the logic to handle the index mapping for `read_conflict_range`. 

Context: in the beginning, we return narrowed key ranges from resolvers, which contains conflicting keys. After discussion, to reduce overhead, we change to send back indices of `read_conflict_range` that caused conflicts. Instead of returning keys,  numbers are much cheaper. (However, by returning indices we lose the benefit to narrow the key range. And all the returned conflicting key ranges are original read_conflict_range or union of some)

Here is a simple example to explain this read_conflict_range index mismatch issue.
We have 2 `commitTransactionRef` and each has two `read_conflict_range`, which we call them `tr1`, `tr2` and `rcr1.1` `rcr1.2` `rcr2.1` `rcr2.2`, respectively. In addition, we have two resolvers `R1` and `R2`.

The previous implementation assumed if `tr1` is sent to `R1` or `R2`, then all its `read_conflict_range` are sent to `R1` or `R2`. 
However, it can happen:
`rcr1.1` is sent to `R1` and `rcr1.2` is sent to `R2`. Now, we have `tr1R1` and `tr1R2`, whose `read_conflict_range`s are a subset of original `tr1`'s.
In this case, if `rcr1.2` causes conflicts and `R2` returns `index-0` afterward (since `rcr1.2` is the first `read_conflict_range` in `tr1R2`). We need to map this `0` to `1` to find the right `read_conflict_range` in `tr1`.

The code did not have this mapping and thus failed.