### PR TITLE
Add documentation for several missing fdbcli commands

### DIFF
--- a/documentation/sphinx/source/command-line-interface.rst
+++ b/documentation/sphinx/source/command-line-interface.rst
@@ -279,7 +279,9 @@ The ``lock`` command locks the database with a randomly generated lockUID.
 maintenance
 -----------
 
-The ``maintenance`` command marks a particular zone ID (i.e. fault domain) as being under maintenance. A zone that is under maintenance will not have data moved away from it even if processes in that zone fail. This is useful when the amount of time that the processes in a fault domain are expected to be absent is reasonably short. The syntax for this command is ``maintenance [on|off] [ZONEID] [SECONDS]``.
+The ``maintenance`` command marks a particular zone ID (i.e. fault domain) as being under maintenance. Its syntax is ``maintenance [on|off] [ZONEID] [SECONDS]``. 
+
+A zone that is under maintenance will not have data moved away from it even if processes in that zone fail. In particular, this means the cluster will not attempt to heal the replication factor as a result of failures in the maintenance zone. This is useful when the amount of time that the processes in a fault domain are expected to be absent is reasonably short and you don't want to move data to and from the affected processes. 
 
 Running this command with no arguments will display the state of any current maintenance.
 

--- a/documentation/sphinx/source/command-line-interface.rst
+++ b/documentation/sphinx/source/command-line-interface.rst
@@ -158,7 +158,7 @@ force_recovery_with_data_loss
 
 The ``force_recovery_with_data_loss`` command will recover a multi-region database to the specified datacenter. Its syntax is ``force_recovery_with_data_loss <DCID>``. It will likely result in the loss of the most recently committed mutations and is intended to be used if the primary datacenter has been lost. 
 
-This command will change the region configuration to have a positive priority for the chosen ``DCID`` and a negative priority for all other ``DCIDs``. It will also set ``usable_regions`` to 1. If the database has already recovered, this command does nothing.
+This command will change the :ref:`region configuration <configuration-configuring-regions>` to have a positive priority for the chosen ``DCID`` and a negative priority for all other ``DCIDs``. It will also set ``usable_regions`` to 1. If the database has already recovered, this command does nothing.
 
 get
 ---
@@ -305,17 +305,29 @@ profile
 
 The ``profile`` command is used to control various profiling actions.
 
+client
+^^^^^^
+
 ``profile client <get|set>``
 
 Reads or sets parameters of client transaction sampling. Use ``get`` to list the current parameters, and ``set <RATE|default> <SIZE|default>`` to set them. ``RATE`` is the fraction of transactions to be sampled, and ``SIZE`` is the amount (in bytes) of sampled data to store in the database.
+
+list
+^^^^
 
 ``profile list``
 
 Lists the processes that can be profiled using the ``flow`` and ``heap`` subcommands.
 
+flow
+^^^^
+
 ``profile flow run <DURATION> <FILENAME> <PROCESS...>``
 
 Enables flow profiling on the specifed processes for ``DURATION`` seconds. Profiling output will be stored at the specified filename relative to the fdbserver process's trace log directory. To profile all processes, use ``all`` for the ``PROCESS`` parameter.
+
+heap
+^^^^
 
 ``profile heap <PROCESS>``
 

--- a/documentation/sphinx/source/command-line-interface.rst
+++ b/documentation/sphinx/source/command-line-interface.rst
@@ -106,6 +106,13 @@ Set the process using ``configure [proxies|resolvers|logs]=<N>``, where ``<N>`` 
 
 For recommendations on appropriate values for process types in large clusters, see :ref:`guidelines-process-class-config`.
 
+consistencycheck
+----------------
+
+The ``consistencycheck`` command enables or disables consistency checking. Its syntax is ``consistencycheck [on|off]``. Calling it with ``on`` enables consistency checking, and ``off`` disables it. Calling it with no arguments displays whether consistency checking is currently enabled.
+
+You must be running an ``fdbserver`` process with the ``consistencycheck`` role to perform consistency checking.
+
 coordinators
 ------------
 
@@ -146,6 +153,12 @@ The format should be the same as the value of the ``configuration`` entry in sta
 
 "The ``new`` option, if present, initializes a new database with the given configuration rather than changing the configuration of an existing one.
 
+force_recovery_with_data_loss
+-----------------------------
+
+The ``force_recovery_with_data_loss`` command will recover a multi-region database to the specified datacenter. Its syntax is ``force_recovery_with_data_loss <DCID>``. It will likely result in the loss of the most recently committed mutations and is intended to be used if the primary datacenter has been lost. 
+
+This command will change the region configuration to have a positive priority for the chosen ``DCID`` and a negative priority for all other ``DCIDs``. It will also set ``usable_regions`` to 1. If the database has already recovered, this command does nothing.
 
 get
 ---
@@ -237,10 +250,42 @@ For each IP address or IP:port pair in ``<ADDRESS...>``, the command removes any
 
 For information on adding machines to a cluster, see :ref:`adding-machines-to-a-cluster`.
 
+kill
+----
+
+The ``kill`` command attempts to kill one or more processes in the cluster.
+
+``kill``
+
+With no arguments, ``kill`` populates the list of processes that can be killed. This must be run prior to running any other ``kill`` commands.
+
+``kill list``
+
+Displays all known processes. This is only useful when the database is unresponsive.
+
+``kill <ADDRESS>*``
+
+Attempts to kill all specified processes. Each address should include the IP and port of the process being targeted.
+
+``kill all``
+
+Attempts to kill all known processes in the cluster.
+
 lock
 ----
 
 The ``lock`` command locks the database with a randomly generated lockUID.
+
+maintenance
+-----------
+
+The ``maintenance`` command marks a particular zone ID (i.e. fault domain) as being under maintenance. A zone that is under maintenance will not have data moved away from it even if processes in that zone fail. This is useful when the amount of time that the processes in a fault domain are expected to be absent is reasonably short. The syntax for this command is ``maintenance [on|off] [ZONEID] [SECONDS]``.
+
+Running this command with no arguments will display the state of any current maintenance.
+
+Running ``maintenance on <ZONEID> <SECONDS>`` will turn maintenance on for the specified zone. A duration must be specified for the length of maintenance mode.
+
+Running ``maintenance off`` will turn off maintenance mode.
 
 option
 ------
@@ -254,6 +299,27 @@ If there is no active transaction, then the option will be applied to all operat
 If there is an active transaction (one created with ``begin``), then enabled options apply only to that transaction. Options cannot be disabled on an active transaction.
 
 Calling the ``option`` command with no parameters prints a list of all enabled options.
+
+profile
+-------
+
+The ``profile`` command is used to control various profiling actions.
+
+``profile client <get|set>``
+
+Reads or sets parameters of client transaction sampling. Use ``get`` to list the current parameters, and ``set <RATE|default> <SIZE|default>`` to set them. ``RATE`` is the fraction of transactions to be sampled, and ``SIZE`` is the amount (in bytes) of sampled data to store in the database.
+
+``profile list``
+
+Lists the processes that can be profiled using the ``flow`` and ``heap`` subcommands.
+
+``profile flow run <DURATION> <FILENAME> <PROCESS>*``
+
+Enables flow profiling on the specifed processes for ``DURATION`` seconds. Profiling output will be stored at the specified filename relative to the fdbserver process's trace log directory. To profile all processes, use ``all`` for the ``PROCESS`` parameter.
+
+``profile heap <PROCESS>``
+
+Enables heap profiling for the specified process.
 
 reset
 -----
@@ -271,6 +337,18 @@ set
 The ``set`` command sets a value for a given key. Its syntax is ``set <KEY> <VALUE>``. If ``<KEY>`` is not already present in the database, it will be created.
 
 Note that :ref:`characters can be escaped <cli-escaping>` when specifying keys (or values) in ``fdbcli``.
+
+setclass
+--------
+
+The ``setclass`` command can be used to change the :ref:`process class <guidelines-process-class-config>` for a given process. Its syntax is ``setclass [<ADDRESS> <CLASS>]``. If no arguments are specified, then the process classes of all processes are listed. Setting the class to ``default`` to revert to the process class specified on the command line.
+
+The available process classes are ``unset``, ``storage``, ``transaction``, ``resolution``, ``proxy``, ``master``, ``test``, ``unset``, ``stateless``, ``log``, ``router``, ``cluster_controller``, ``fast_restore``, ``data_distributor``, ``coordinator``, ``ratekeeper``, ``storage_cache``, ``backup``, and ``default``.
+
+sleep
+-----
+
+The ``sleep`` command inserts a delay before running the next command. Its syntax is ``sleep <SECONDS>``. This command can be useful when ``fdbcli`` is run with the ``--exec`` flag to control the timing of commands.
 
 .. _cli-status:
 
@@ -381,3 +459,16 @@ unlock
 ------
 
 The ``unlock`` command unlocks the database with the specified lock UID. Because this is a potentially dangerous operation, users must copy a passphrase before the unlock command is executed.
+
+writemode
+---------
+
+Controls whether or not ``fdbcli`` can perform sets and clears.
+
+``writemode off``
+
+Disables writing from ``fdbcli`` (the default). In this mode, attempting to set or clear keys will result in an error.
+
+``writemode on``
+
+Enables writing from ``fdbcli``.

--- a/documentation/sphinx/source/command-line-interface.rst
+++ b/documentation/sphinx/source/command-line-interface.rst
@@ -263,7 +263,7 @@ With no arguments, ``kill`` populates the list of processes that can be killed. 
 
 Displays all known processes. This is only useful when the database is unresponsive.
 
-``kill <ADDRESS>*``
+``kill <ADDRESS...>``
 
 Attempts to kill all specified processes. Each address should include the IP and port of the process being targeted.
 
@@ -313,7 +313,7 @@ Reads or sets parameters of client transaction sampling. Use ``get`` to list the
 
 Lists the processes that can be profiled using the ``flow`` and ``heap`` subcommands.
 
-``profile flow run <DURATION> <FILENAME> <PROCESS>*``
+``profile flow run <DURATION> <FILENAME> <PROCESS...>``
 
 Enables flow profiling on the specifed processes for ``DURATION`` seconds. Profiling output will be stored at the specified filename relative to the fdbserver process's trace log directory. To profile all processes, use ``all`` for the ``PROCESS`` parameter.
 

--- a/fdbcli/fdbcli.actor.cpp
+++ b/fdbcli/fdbcli.actor.cpp
@@ -481,18 +481,18 @@ void initHelp() {
 		"change cluster coordinators or description",
 		"If 'auto' is specified, coordinator addresses will be choosen automatically to support the configured redundancy level. (If the current set of coordinators are healthy and already support the redundancy level, nothing will be changed.)\n\nOtherwise, sets the coordinators to the list of IP:port pairs specified by <ADDRESS>+. An fdbserver process must be running on each of the specified addresses.\n\ne.g. coordinators 10.0.0.1:4000 10.0.0.2:4000 10.0.0.3:4000\n\nIf 'description=desc' is specified then the description field in the cluster\nfile is changed to desc, which must match [A-Za-z0-9_]+.");
 	helpMap["exclude"] =
-	    CommandHelp("exclude [FORCE] [failed] [no_wait] <ADDRESS>*", "exclude servers from the database",
+	    CommandHelp("exclude [FORCE] [failed] [no_wait] <ADDRESS...>", "exclude servers from the database",
 	                "If no addresses are specified, lists the set of excluded servers.\n\nFor each IP address or "
-	                "IP:port pair in <ADDRESS>*, adds the address to the set of excluded servers then waits until all "
+	                "IP:port pair in <ADDRESS...>, adds the address to the set of excluded servers then waits until all "
 	                "database state has been safely moved away from the specified servers. If 'no_wait' is set, the "
 	                "command returns \nimmediately without checking if the exclusions have completed successfully.\n"
 	                "If 'FORCE' is set, the command does not perform safety checks before excluding.\n"
 	                "If 'failed' is set, the transaction log queue is dropped pre-emptively before waiting\n"
 	                "for data movement to finish and the server cannot be included again.");
 	helpMap["include"] = CommandHelp(
-		"include all|<ADDRESS>*",
+		"include all|<ADDRESS...>",
 		"permit previously-excluded servers to rejoin the database",
-		"If `all' is specified, the excluded servers list is cleared.\n\nFor each IP address or IP:port pair in <ADDRESS>*, removes any matching exclusions from the excluded servers list. (A specified IP will match all IP:* exclusion entries)");
+		"If `all' is specified, the excluded servers list is cleared.\n\nFor each IP address or IP:port pair in <ADDRESS...>, removes any matching exclusions from the excluded servers list. (A specified IP will match all IP:* exclusion entries)");
 	helpMap["setclass"] = CommandHelp(
 		"setclass [<ADDRESS> <CLASS>]",
 		"change the class of a process",
@@ -553,9 +553,9 @@ void initHelp() {
 		"enables or disables sets and clears",
 		"Setting or clearing keys from the CLI is not recommended.");
 	helpMap["kill"] = CommandHelp(
-		"kill all|list|<ADDRESS>*",
+		"kill all|list|<ADDRESS...>",
 		"attempts to kill one or more processes in the cluster",
-		"If no addresses are specified, populates the list of processes which can be killed. Processes cannot be killed before this list has been populated.\n\nIf `all' is specified, attempts to kill all known processes.\n\nIf `list' is specified, displays all known processes. This is only useful when the database is unresponsive.\n\nFor each IP:port pair in <ADDRESS>*, attempt to kill the specified process.");
+		"If no addresses are specified, populates the list of processes which can be killed. Processes cannot be killed before this list has been populated.\n\nIf `all' is specified, attempts to kill all known processes.\n\nIf `list' is specified, displays all known processes. This is only useful when the database is unresponsive.\n\nFor each IP:port pair in <ADDRESS ...>, attempt to kill the specified process.");
 	helpMap["profile"] = CommandHelp(
 		"profile <client|list|flow|heap> <action> <ARGS>",
 		"namespace for all the profiling-related commands.",
@@ -1835,42 +1835,42 @@ ACTOR Future<bool> configure( Database db, std::vector<StringRef> tokens, Refere
 		break;
 	case ConfigurationResult::DATABASE_UNAVAILABLE:
 		printf("ERROR: The database is unavailable\n");
-		printf("Type `configure FORCE <TOKEN>*' to configure without this check\n");
+		printf("Type `configure FORCE <TOKEN...>' to configure without this check\n");
 		ret=true;
 		break;
 	case ConfigurationResult::STORAGE_IN_UNKNOWN_DCID:
 		printf("ERROR: All storage servers must be in one of the known regions\n");
-		printf("Type `configure FORCE <TOKEN>*' to configure without this check\n");
+		printf("Type `configure FORCE <TOKEN...>' to configure without this check\n");
 		ret=true;
 		break;
 	case ConfigurationResult::REGION_NOT_FULLY_REPLICATED:
 		printf("ERROR: When usable_regions > 1, all regions with priority >= 0 must be fully replicated before changing the configuration\n");
-		printf("Type `configure FORCE <TOKEN>*' to configure without this check\n");
+		printf("Type `configure FORCE <TOKEN...>' to configure without this check\n");
 		ret=true;
 		break;
 	case ConfigurationResult::MULTIPLE_ACTIVE_REGIONS:
 		printf("ERROR: When changing usable_regions, only one region can have priority >= 0\n");
-		printf("Type `configure FORCE <TOKEN>*' to configure without this check\n");
+		printf("Type `configure FORCE <TOKEN...>' to configure without this check\n");
 		ret=true;
 		break;
 	case ConfigurationResult::REGIONS_CHANGED:
 		printf("ERROR: The region configuration cannot be changed while simultaneously changing usable_regions\n");
-		printf("Type `configure FORCE <TOKEN>*' to configure without this check\n");
+		printf("Type `configure FORCE <TOKEN...>' to configure without this check\n");
 		ret=true;
 		break;
 	case ConfigurationResult::NOT_ENOUGH_WORKERS:
 		printf("ERROR: Not enough processes exist to support the specified configuration\n");
-		printf("Type `configure FORCE <TOKEN>*' to configure without this check\n");
+		printf("Type `configure FORCE <TOKEN...>' to configure without this check\n");
 		ret=true;
 		break;
 	case ConfigurationResult::REGION_REPLICATION_MISMATCH:
 		printf("ERROR: `three_datacenter' replication is incompatible with region configuration\n");
-		printf("Type `configure FORCE <TOKEN>*' to configure without this check\n");
+		printf("Type `configure FORCE <TOKEN...>' to configure without this check\n");
 		ret=true;
 		break;
 	case ConfigurationResult::DCID_MISSING:
 		printf("ERROR: `No storage servers in one of the specified regions\n");
-		printf("Type `configure FORCE <TOKEN>*' to configure without this check\n");
+		printf("Type `configure FORCE <TOKEN...>' to configure without this check\n");
 		ret=true;
 		break;
 	case ConfigurationResult::SUCCESS:
@@ -1997,12 +1997,12 @@ ACTOR Future<bool> fileConfigure(Database db, std::string filePath, bool isNewDa
 		break;
 	case ConfigurationResult::REGION_REPLICATION_MISMATCH:
 		printf("ERROR: `three_datacenter' replication is incompatible with region configuration\n");
-		printf("Type `fileconfigure FORCE <TOKEN>*' to configure without this check\n");
+		printf("Type `fileconfigure FORCE <TOKEN...>' to configure without this check\n");
 		ret=true;
 		break;
 	case ConfigurationResult::DCID_MISSING:
 		printf("ERROR: `No storage servers in one of the specified regions\n");
-		printf("Type `fileconfigure FORCE <TOKEN>*' to configure without this check\n");
+		printf("Type `fileconfigure FORCE <TOKEN...>' to configure without this check\n");
 		ret=true;
 		break;
 	case ConfigurationResult::SUCCESS:
@@ -2191,7 +2191,7 @@ ACTOR Future<bool> exclude( Database db, std::vector<StringRef> tokens, Referenc
 					    "Please check that this exclusion does not bring down an entire storage team.\n"
 					    "Please also ensure that the exclusion will keep a majority of coordinators alive.\n"
 					    "You may add more storage processes or coordinators to make the operation safe.\n"
-					    "Type `exclude FORCE failed <ADDRESS>*' to exclude without performing safety checks.\n";
+					    "Type `exclude FORCE failed <ADDRESS...>' to exclude without performing safety checks.\n";
 					printf("%s", errorStr.c_str());
 					return true;
 				}
@@ -2200,7 +2200,7 @@ ACTOR Future<bool> exclude( Database db, std::vector<StringRef> tokens, Referenc
 
 			state std::string errorString = "ERROR: Could not calculate the impact of this exclude on the total free space in the cluster.\n"
 											"Please try the exclude again in 30 seconds.\n"
-										    "Type `exclude FORCE <ADDRESS>*' to exclude without checking free space.\n";
+										    "Type `exclude FORCE <ADDRESS...>' to exclude without checking free space.\n";
 
 			StatusObjectReader statusObj(status);
 
@@ -2276,7 +2276,7 @@ ACTOR Future<bool> exclude( Database db, std::vector<StringRef> tokens, Referenc
 
 			if( ssExcludedCount==ssTotalCount || (1-worstFreeSpaceRatio)*ssTotalCount/(ssTotalCount-ssExcludedCount) > 0.9 ) {
 				printf("ERROR: This exclude may cause the total free space in the cluster to drop below 10%%.\n"
-					   "Type `exclude FORCE <ADDRESS>*' to exclude without checking free space.\n");
+					   "Type `exclude FORCE <ADDRESS...>' to exclude without checking free space.\n");
 				return true;
 			}
 		}
@@ -3562,7 +3562,7 @@ ACTOR Future<int> cli(CLIOptions opt, LineNoise* plinenoise) {
 						}
 						if (tokencmp(tokens[2], "run")) {
 							if (tokens.size() < 6) {
-								printf("ERROR: Usage: profile flow run <DURATION_IN_SECONDS> <FILENAME> <PROCESS>*\n");
+								printf("ERROR: Usage: profile flow run <DURATION_IN_SECONDS> <FILENAME> <PROCESS...>\n");
 								is_error = true;
 								continue;
 							}

--- a/fdbcli/fdbcli.actor.cpp
+++ b/fdbcli/fdbcli.actor.cpp
@@ -494,13 +494,13 @@ void initHelp() {
 		"permit previously-excluded servers to rejoin the database",
 		"If `all' is specified, the excluded servers list is cleared.\n\nFor each IP address or IP:port pair in <ADDRESS>*, removes any matching exclusions from the excluded servers list. (A specified IP will match all IP:* exclusion entries)");
 	helpMap["setclass"] = CommandHelp(
-		"setclass <ADDRESS> <unset|storage|transaction|default>",
+		"setclass [<ADDRESS> <CLASS>]",
 		"change the class of a process",
-		"If no address and class are specified, lists the classes of all servers.\n\nSetting the class to `default' resets the process class to the class specified on the command line.");
+		"If no address and class are specified, lists the classes of all servers.\n\nSetting the class to `default' resets the process class to the class specified on the command line. The available classes are `unset', `storage', `transaction', `resolution', `proxy', `master', `test', `unset', `stateless', `log', `router', `cluster_controller', `fast_restore', `data_distributor', `coordinator', `ratekeeper', `storage_cache', `backup', and `default'.");
 	helpMap["status"] = CommandHelp(
 		"status [minimal|details|json]",
 		"get the status of a FoundationDB cluster",
-		"If the cluster is down, this command will print a diagnostic which may be useful in figuring out what is wrong. If the cluster is running, this command will print cluster statistics.\n\nSpecifying 'minimal' will provide a minimal description of the status of your database.\n\nSpecifying 'details' will provide load information for individual workers.\n\nSpecifying 'json' will provide status information in a machine readable JSON format.");
+		"If the cluster is down, this command will print a diagnostic which may be useful in figuring out what is wrong. If the cluster is running, this command will print cluster statistics.\n\nSpecifying `minimal' will provide a minimal description of the status of your database.\n\nSpecifying `details' will provide load information for individual workers.\n\nSpecifying `json' will provide status information in a machine readable JSON format.");
 	helpMap["exit"] = CommandHelp("exit", "exit the CLI", "");
 	helpMap["quit"] = CommandHelp();
 	helpMap["waitconnected"] = CommandHelp();
@@ -3562,7 +3562,7 @@ ACTOR Future<int> cli(CLIOptions opt, LineNoise* plinenoise) {
 						}
 						if (tokencmp(tokens[2], "run")) {
 							if (tokens.size() < 6) {
-								printf("ERROR: Usage: profile flow run <duration in seconds> <filename> <hosts>\n");
+								printf("ERROR: Usage: profile flow run <DURATION_IN_SECONDS> <FILENAME> <PROCESS>*\n");
 								is_error = true;
 								continue;
 							}
@@ -3629,7 +3629,7 @@ ACTOR Future<int> cli(CLIOptions opt, LineNoise* plinenoise) {
 					}
 					if (tokencmp(tokens[1], "heap")) {
 						if (tokens.size() != 3) {
-							printf("ERROR: Usage: profile heap host\n");
+							printf("ERROR: Usage: profile heap <PROCESS>\n");
 							is_error = true;
 							continue;
 						}


### PR DESCRIPTION
These commands are present when typing ``help`` in ``fdbcli``, but they were not part of our online documentation.

Some of these commands control features which are currently not very well documented (e.g. profiling, consistency check, zone IDs). I've regarded adding that extra documentation as being outside the scope of this PR, but we should work to add it in the future. I don't think that it should prevent us from adding this documentation, but if there is disagreement I can omit some commands as needed.