### PR TITLE
Only destroy db if non-null

### DIFF
--- a/fdbclient/MultiVersionTransaction.h
+++ b/fdbclient/MultiVersionTransaction.h
@@ -163,7 +163,11 @@ class DLDatabase : public IDatabase, ThreadSafeReferenceCounted<DLDatabase> {
 public:
 	DLDatabase(Reference<FdbCApi> api, FdbCApi::FDBDatabase *db) : api(api), db(db), ready(Void()) {}
 	DLDatabase(Reference<FdbCApi> api, ThreadFuture<FdbCApi::FDBDatabase*> dbFuture);
-	~DLDatabase() { api->databaseDestroy(db); }
+	~DLDatabase() {
+		if (db) {
+			api->databaseDestroy(db);
+		}
+	}
 
 	ThreadFuture<Void> onReady();
 


### PR DESCRIPTION
It could be the case that db is null for old client versions