### PR TITLE
Fix a backup progress true-up bug

### DIFF
--- a/fdbserver/BackupProgress.actor.cpp
+++ b/fdbserver/BackupProgress.actor.cpp
@@ -115,7 +115,7 @@ std::map<std::tuple<LogEpoch, Version, int>, std::map<Tag, Version>> BackupProgr
 					// ASSERT(info.logRouterTags == epochTags[rit->first]);
 
 					updateTagVersions(&tagVersions, &tags, rit->second, info.epochEnd, adjustedBeginVersion, epoch);
-					break;
+					if (tags.empty()) break;
 				}
 				rit++;
 			}


### PR DESCRIPTION
Sometimes, the true-up has to go backup multiple epochs for saved versions,
because a tag's progress can be missing in an epoch. In other words, we need to
check progress for all tags.

This part of #2858