### PR TITLE
Fix: the cluster controller role could be recruited on a process class with NeverAssign fitness

### DIFF
--- a/documentation/sphinx/source/release-notes.rst
+++ b/documentation/sphinx/source/release-notes.rst
@@ -2,6 +2,14 @@
 Release Notes
 #############
 
+6.2.22
+======
+
+Fixes
+-----
+
+* Coordinator class processes could be recruited as the cluster controller. `(PR #3282) <https://github.com/apple/foundationdb/pull/3282>`_
+
 6.2.21
 ======
 

--- a/fdbserver/worker.actor.cpp
+++ b/fdbserver/worker.actor.cpp
@@ -1465,7 +1465,12 @@ ACTOR Future<Void> fdbd(
 		Promise<Void> recoveredDiskFiles;
 
 		v.push_back(reportErrors(monitorAndWriteCCPriorityInfo(fitnessFilePath, asyncPriorityInfo), "MonitorAndWriteCCPriorityInfo"));
-		v.push_back( reportErrors( processClass == ProcessClass::TesterClass ? monitorLeader( connFile, cc ) : clusterController( connFile, cc , asyncPriorityInfo, recoveredDiskFiles.getFuture(), localities ), "ClusterController") );
+		if(processClass.machineClassFitness(ProcessClass::ClusterController) == ProcessClass::NeverAssign) {
+			v.push_back(reportErrors(monitorLeader(connFile, cc), "ClusterController"));
+		}
+		else {
+			v.push_back(reportErrors(clusterController(connFile, cc , asyncPriorityInfo, recoveredDiskFiles.getFuture(), localities), "ClusterController"));
+		}
 		v.push_back( reportErrors(extractClusterInterface( cc, ci ), "ExtractClusterInterface") );
 		v.push_back( reportErrors(failureMonitorClient( ci, true ), "FailureMonitorClient") );
 		v.push_back( reportErrorsExcept(workerServer(connFile, cc, localities, asyncPriorityInfo, processClass, dataFolder, memoryLimit, metricsConnFile, metricsPrefix, recoveredDiskFiles, memoryProfileThreshold, coordFolder, whitelistBinPaths), "WorkerServer", UID(), &normalWorkerErrors()) );


### PR DESCRIPTION
In 6.2, this would have just been a process of `coordinator` class.