### PR TITLE
HTTPS workarounds for strange socket behavior

### DIFF
--- a/fdbclient/HTTP.actor.cpp
+++ b/fdbclient/HTTP.actor.cpp
@@ -352,6 +352,9 @@ namespace HTTP {
 			send_start = timer();
 
 			loop {
+				wait(conn->onWritable());
+				wait( delay( 0, TaskPriority::WriteSocket ) );
+
 				// If we already got a response, before finishing sending the request, then close the connection,
 				// set the Connection header to "close" as a hint to the caller that this connection can't be used
 				// again, and break out of the send loop.
@@ -372,11 +375,6 @@ namespace HTTP {
 				pContent->sent(len);
 				if(pContent->empty())
 					break;
-
-				if(len == 0) {
-					wait(conn->onWritable());
-					wait( delay( 0, TaskPriority::WriteSocket ) );
-				}
 			}
 
 			wait(responseReading);


### PR DESCRIPTION
Workarounds for strange behaviors in Boost ssl sockets on MacOS and Linux.  When writing to the ssl socket, write_some() would sometimes return BrokenPipe instead of WouldBlock unless onWriteable on the raw socket was checked first.  On MacOS, even with the onWriteable check using a send size greater than 2016 (determined experimentally) would still result in the error.  Also consolidated two identical copies of SendBufferIterator.