### PR TITLE
Set up blob credentials for backup workers

### DIFF
--- a/fdbbackup/backup.actor.cpp
+++ b/fdbbackup/backup.actor.cpp
@@ -955,7 +955,7 @@ static void printBackupUsage(bool devhelp) {
 	printf("  -e ERRORLIMIT  The maximum number of errors printed by status (default is 10).\n");
 	printf("  -k KEYS        List of key ranges to backup.\n"
 		   "                 If not specified, the entire database will be backed up.\n");
-	printf("  -p, --partitioned_log  Starts with new type of backup system using partitioned logs.\n");
+	printf("  --partitioned_log_experimental  Starts with new type of backup system using partitioned logs.\n");
 	printf("  -n, --dryrun   For backup start or restore start, performs a trial run with no actual changes made.\n");
 	printf("  --log          Enables trace file logging for the CLI session.\n"
 		   "  --logdir PATH  Specifes the output directory for trace files. If\n"

--- a/fdbserver/fdbserver.actor.cpp
+++ b/fdbserver/fdbserver.actor.cpp
@@ -941,7 +941,7 @@ struct CLIOptions {
 	double fileIoTimeout = 0.0;
 	bool fileIoWarnOnly = false;
 	uint64_t rsssize = -1;
-	std::vector<std::string> blobCredentials; // used for fast restore workers
+	std::vector<std::string> blobCredentials; // used for fast restore workers & backup workers
 	const char* blobCredsFromENV = nullptr;
 
 	Reference<ClusterConnectionFile> connectionFile;
@@ -1846,6 +1846,16 @@ int main(int argc, char* argv[]) {
 			setupAndRun(dataFolder, opts.testFile, opts.restarting, (isRestoring >= 1), opts.whitelistBinPaths);
 			g_simulator.run();
 		} else if (role == FDBD) {
+			// Update the global blob credential files list so that both fast
+			// restore workers and backup workers can access blob storage.
+			std::vector<std::string>* pFiles =
+			    (std::vector<std::string>*)g_network->global(INetwork::enBlobCredentialFiles);
+			if (pFiles != nullptr) {
+				for (auto& f : opts.blobCredentials) {
+					pFiles->push_back(f);
+				}
+			}
+
 			// Call fast restore for the class FastRestoreClass. This is a short-cut to run fast restore in circus
 			if (opts.processClass == ProcessClass::FastRestoreClass) {
 				printf("Run as fast restore worker\n");
@@ -1853,15 +1863,6 @@ int main(int argc, char* argv[]) {
 				auto dataFolder = opts.dataFolder;
 				if (!dataFolder.size())
 					dataFolder = format("fdb/%d/", opts.publicAddresses.address.port); // SOMEDAY: Better default
-
-				// Update the global blob credential files list
-				std::vector<std::string>* pFiles =
-				    (std::vector<std::string>*)g_network->global(INetwork::enBlobCredentialFiles);
-				if (pFiles != nullptr) {
-					for (auto& f : opts.blobCredentials) {
-						pFiles->push_back(f);
-					}
-				}
 
 				vector<Future<Void>> actors(listenErrors.begin(), listenErrors.end());
 				actors.push_back(restoreWorker(opts.connectionFile, opts.localities, dataFolder));


### PR DESCRIPTION
This is needed so that backup workers (fdbserver) can upload files to blobs.

This is part of #2858.