### PR TITLE
Avoid non-coordinator reporting coordinator role indefinitely

### DIFF
--- a/fdbserver/Coordination.actor.cpp
+++ b/fdbserver/Coordination.actor.cpp
@@ -215,10 +215,6 @@ TEST_CASE("/fdbserver/Coordination/localGenerationReg/simple") {
 }
 
 ACTOR Future<Void> openDatabase(ClientData* db, int* clientCount, Reference<AsyncVar<bool>> hasConnectedClients, OpenDatabaseCoordRequest req) {
-	if(db->clientInfo->get().read().id != req.knownClientInfoID && !db->clientInfo->get().read().forward.present()) {
-		req.reply.send( db->clientInfo->get() );
-		return Void();
-	}
 	++(*clientCount);
 	hasConnectedClients->set(true);
 	
@@ -247,11 +243,6 @@ ACTOR Future<Void> openDatabase(ClientData* db, int* clientCount, Reference<Asyn
 }
 
 ACTOR Future<Void> remoteMonitorLeader( int* clientCount, Reference<AsyncVar<bool>> hasConnectedClients, Reference<AsyncVar<Optional<LeaderInfo>>> currentElectedLeader, ElectionResultRequest req ) {
-	if (currentElectedLeader->get().present() && req.knownLeader != currentElectedLeader->get().get().changeID) {
-		req.reply.send( currentElectedLeader->get() );
-		return Void();
-	}
-
 	++(*clientCount);
 	hasConnectedClients->set(true);
 
@@ -293,16 +284,24 @@ ACTOR Future<Void> leaderRegister(LeaderElectionRegInterface interf, Key key) {
 
 	loop choose {
 		when ( OpenDatabaseCoordRequest req = waitNext( interf.openDatabase.getFuture() ) ) {
-			if(!leaderMon.isValid()) {
-				leaderMon = monitorLeaderForProxies(req.clusterKey, req.coordinators, &clientData, currentElectedLeader);
+			if (clientData.clientInfo->get().read().id != req.knownClientInfoID && !clientData.clientInfo->get().read().forward.present()) {
+				req.reply.send(clientData.clientInfo->get());
+			} else {
+				if(!leaderMon.isValid()) {
+					leaderMon = monitorLeaderForProxies(req.clusterKey, req.coordinators, &clientData, currentElectedLeader);
+				}
+				actors.add(openDatabase(&clientData, &clientCount, hasConnectedClients, req));
 			}
-			actors.add(openDatabase(&clientData, &clientCount, hasConnectedClients, req));
 		}
 		when ( ElectionResultRequest req = waitNext( interf.electionResult.getFuture() ) ) {
-			if(!leaderMon.isValid()) {
-				leaderMon = monitorLeaderForProxies(req.key, req.coordinators, &clientData, currentElectedLeader);
+			if (currentElectedLeader->get().present() && req.knownLeader != currentElectedLeader->get().get().changeID) {
+				req.reply.send(currentElectedLeader->get());
+			} else {
+				if(!leaderMon.isValid()) {
+					leaderMon = monitorLeaderForProxies(req.key, req.coordinators, &clientData, currentElectedLeader);
+				}
+				actors.add(remoteMonitorLeader(&clientCount, hasConnectedClients, currentElectedLeader, req));
 			}
-			actors.add( remoteMonitorLeader( &clientCount, hasConnectedClients, currentElectedLeader, req ) );
 		}
 		when ( GetLeaderRequest req = waitNext( interf.getLeader.getFuture() ) ) {
 			if (currentNominee.present() && currentNominee.get().changeID != req.knownLeader) {


### PR DESCRIPTION
When a process receives a message to the coordination interface, it in most circumstances starts reporting that it is a coordinator. If a non-coordinator process gets the `OpenDatabaseCoordRequest` or `ElectionResultRequest` message, it would start a function call `monitorLeaderForProxies` that would prevent this non-coordinator from stopping acting like a coordinator.

This change prevents starting `monitorLeaderForProxies` in circumstances where the request immediately returns, since it is not required.

This doesn't prevent a non-coordinator from ever reporting itself as a coordinator, but it does limit the amount of time it will do so in some cases. I'm not sure if the example I observed in #2837 matches one of these cases or not.