### PR TITLE
Don't double count watches for too_many_watches

### DIFF
--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -2404,7 +2404,6 @@ Future<Version> Transaction::getRawReadVersion() {
 
 Future< Void > Transaction::watch( Reference<Watch> watch ) {
 	++cx->transactionWatchRequests;
-	cx->addWatch();
 	watches.push_back(watch);
 	return ::watch(watch, cx, options.readTags, info);
 }


### PR DESCRIPTION
It appears I botched a commit a while back: f6af6ec777