### PR TITLE
FastRestore: Simplify getAndComputeStagingKeys on RestoreApplier

### DIFF
--- a/fdbclient/BackupAgent.actor.h
+++ b/fdbclient/BackupAgent.actor.h
@@ -883,8 +883,7 @@ public:
 		}
 		TraceEvent t(SevWarn, "FileBackupError");
 		t.error(e).detail("BackupUID", uid).detail("Description", details).detail("TaskInstance", (uint64_t)taskInstance);
-		// These should not happen
-		ASSERT(e.code() != error_code_key_not_found);
+		// key_not_found could happen
 		if(e.code() == error_code_key_not_found)
 			t.backtrace();
 

--- a/fdbclient/BackupAgent.actor.h
+++ b/fdbclient/BackupAgent.actor.h
@@ -884,6 +884,7 @@ public:
 		TraceEvent t(SevWarn, "FileBackupError");
 		t.error(e).detail("BackupUID", uid).detail("Description", details).detail("TaskInstance", (uint64_t)taskInstance);
 		// These should not happen
+		ASSERT(e.code() != error_code_key_not_found);
 		if(e.code() == error_code_key_not_found)
 			t.backtrace();
 

--- a/fdbclient/FileBackupAgent.actor.cpp
+++ b/fdbclient/FileBackupAgent.actor.cpp
@@ -236,6 +236,7 @@ public:
 		TraceEvent t(SevWarn, "FileRestoreError");
 		t.error(e).detail("RestoreUID", uid).detail("Description", details).detail("TaskInstance", (uint64_t)taskInstance);
 		// These should not happen
+		ASSERT(e.code() != error_code_key_not_found);
 		if(e.code() == error_code_key_not_found)
 			t.backtrace();
 

--- a/fdbclient/FileBackupAgent.actor.cpp
+++ b/fdbclient/FileBackupAgent.actor.cpp
@@ -235,8 +235,7 @@ public:
 		}
 		TraceEvent t(SevWarn, "FileRestoreError");
 		t.error(e).detail("RestoreUID", uid).detail("Description", details).detail("TaskInstance", (uint64_t)taskInstance);
-		// These should not happen
-		ASSERT(e.code() != error_code_key_not_found);
+		// key_not_found could happen
 		if(e.code() == error_code_key_not_found)
 			t.backtrace();
 

--- a/fdbserver/RestoreApplier.actor.cpp
+++ b/fdbserver/RestoreApplier.actor.cpp
@@ -220,6 +220,7 @@ ACTOR Future<Optional<Value>> getValue(Reference<ReadYourWritesTransaction> tr, 
 		return v;
 	} catch (Error& e) {
 		if (e.code() == error_code_key_not_found) {
+			ASSERT(false); // Should not happen
 			keysNotFound->insert(i);
 			return Optional<Value>();
 		} else {

--- a/fdbserver/RestoreApplier.actor.cpp
+++ b/fdbserver/RestoreApplier.actor.cpp
@@ -213,22 +213,6 @@ ACTOR static Future<Void> applyClearRangeMutations(Standalone<VectorRef<KeyRange
 	return Void();
 }
 
-ACTOR Future<Optional<Value>> getValue(Reference<ReadYourWritesTransaction> tr, Key key, int i,
-                                       std::set<int>* keysNotFound) {
-	try {
-		Optional<Value> v = wait(tr->get(key));
-		return v;
-	} catch (Error& e) {
-		if (e.code() == error_code_key_not_found) {
-			ASSERT(false); // Should not happen
-			keysNotFound->insert(i);
-			return Optional<Value>();
-		} else {
-			throw;
-		}
-	}
-}
-
 // Get keys in incompleteStagingKeys and precompute the stagingKey which is stored in batchData->stagingKeys
 ACTOR static Future<Void> getAndComputeStagingKeys(
     std::map<Key, std::map<Key, StagingKey>::iterator> incompleteStagingKeys, double delayTime, Database cx,

--- a/fdbserver/RestoreApplier.actor.cpp
+++ b/fdbserver/RestoreApplier.actor.cpp
@@ -244,28 +244,23 @@ ACTOR static Future<Void> getAndComputeStagingKeys(
 	    .detail("BatchIndex", batchIndex)
 	    .detail("GetKeys", incompleteStagingKeys.size())
 	    .detail("DelayTime", delayTime);
-	state std::set<int> keysNotFound;
 
-	state int i = 0;
 	loop {
 		try {
+			int i = 0;
 			tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
 			tr->setOption(FDBTransactionOptions::LOCK_AWARE);
-			i = 0;
 			for (auto& key : incompleteStagingKeys) {
-				if (!keysNotFound.count(i)) { // only get exist-keys
-					fValues[i] = getValue(tr, key.first, i, &keysNotFound);
-				}
-				++i;
+				fValues[i++] = tr->get(key.first);
 			}
 			wait(waitForAll(fValues));
 			break;
 		} catch (Error& e) {
-			bool ok = (e.code() != error_code_key_not_found);
-			if (!ok || retries++ > incompleteStagingKeys.size()) {
-				TraceEvent(!ok ? SevError : SevWarnAlways, "GetAndComputeStagingKeys", applierID)
+			if (retries++ > incompleteStagingKeys.size()) {
+				TraceEvent(SevWarnAlways, "GetAndComputeStagingKeys", applierID)
+				    .suppressFor(1.0)
+				    .detail("RandomUID", randomID)
 				    .detail("BatchIndex", batchIndex)
-				    .detail("KeyIndex", i)
 				    .error(e);
 			}
 			wait(tr->onError(e));
@@ -275,7 +270,7 @@ ACTOR static Future<Void> getAndComputeStagingKeys(
 	ASSERT(fValues.size() == incompleteStagingKeys.size());
 	int i = 0;
 	for (auto& key : incompleteStagingKeys) {
-		if (keysNotFound.count(i) || (!fValues[i].get().present())) { // Key not exist in DB
+		if (!fValues[i].get().present()) { // Key not exist in DB
 			// if condition: fValues[i].Valid() && fValues[i].isReady() && !fValues[i].isError() &&
 			TraceEvent(SevWarn, "FastRestoreApplierGetAndComputeStagingKeysNoBaseValueInDB", applierID)
 			    .detail("BatchIndex", batchIndex)

--- a/fdbserver/RestoreCommon.actor.cpp
+++ b/fdbserver/RestoreCommon.actor.cpp
@@ -122,8 +122,7 @@ Future<Void> RestoreConfigFR::logError(Database cx, Error e, std::string const& 
 	}
 	TraceEvent t(SevWarn, "FileRestoreError");
 	t.error(e).detail("RestoreUID", uid).detail("Description", details).detail("TaskInstance", (uint64_t)taskInstance);
-	// These should not happen
-	ASSERT(e.code() != error_code_key_not_found);
+	// key_not_found could happen
 	if (e.code() == error_code_key_not_found) t.backtrace();
 
 	return updateErrorInfo(cx, e, details);

--- a/fdbserver/RestoreCommon.actor.cpp
+++ b/fdbserver/RestoreCommon.actor.cpp
@@ -123,6 +123,7 @@ Future<Void> RestoreConfigFR::logError(Database cx, Error e, std::string const& 
 	TraceEvent t(SevWarn, "FileRestoreError");
 	t.error(e).detail("RestoreUID", uid).detail("Description", details).detail("TaskInstance", (uint64_t)taskInstance);
 	// These should not happen
+	ASSERT(e.code() != error_code_key_not_found);
 	if (e.code() == error_code_key_not_found) t.backtrace();
 
 	return updateErrorInfo(cx, e, details);


### PR DESCRIPTION
It turns out that the PR https://github.com/apple/foundationdb/pull/3283 complicates things. 
Txn handles the keys-not-exist by returning `Optional<Value>()`. 
This can simplify code.

Lesson learned: error_code_key_not_found is not an error thrown from txn. It is a customized error thrown from the old backup agent. ¯\_(ツ)_/¯ 