### PR TITLE
Make TraceBatch no longer thread hostile

### DIFF
--- a/flow/Trace.cpp
+++ b/flow/Trace.cpp
@@ -1254,7 +1254,7 @@ void TraceBatch::dump() {
 		g_traceLog.writeEvent(buggifyBatch[i].fields, "", false);
 	}
 
-	onMainThreadVoid([](){ g_traceLog.flush(); }, NULL);
+	onMainThreadVoid([](){ g_traceLog.flush(); }, nullptr);
 	eventBatch.clear();
 	attachBatch.clear();
 	buggifyBatch.clear();

--- a/flow/Trace.cpp
+++ b/flow/Trace.cpp
@@ -183,7 +183,7 @@ private:
 		if(g_network->isSimulated()) {
 			return roleInfoMap[g_network->getLocalAddress()];
 		}
-		
+
 		return roleInfo;
 	}
 
@@ -261,7 +261,7 @@ public:
 	Reference<BarrierList> barriers;
 
 	struct WriterThread : IThreadPoolReceiver {
-		WriterThread( Reference<BarrierList> barriers, Reference<ITraceLogWriter> logWriter, Reference<ITraceLogFormatter> formatter ) 
+		WriterThread( Reference<BarrierList> barriers, Reference<ITraceLogWriter> logWriter, Reference<ITraceLogFormatter> formatter )
 			: barriers(barriers), logWriter(logWriter), formatter(formatter) {}
 
 		virtual void init() {}
@@ -1067,7 +1067,7 @@ TraceEvent& TraceEvent::setMaxFieldLength(int maxFieldLength) {
 	ASSERT(!logged);
 	if(maxFieldLength == 0) {
 		this->maxFieldLength = FLOW_KNOBS ? FLOW_KNOBS->MAX_TRACE_FIELD_LENGTH : 495;
-	} 
+	}
 	else {
 		this->maxFieldLength = maxFieldLength;
 	}
@@ -1079,7 +1079,7 @@ TraceEvent& TraceEvent::setMaxEventLength(int maxEventLength) {
 	ASSERT(!logged);
 	if(maxEventLength == 0) {
 		this->maxEventLength = FLOW_KNOBS ? FLOW_KNOBS->MAX_TRACE_EVENT_LENGTH : 4000;
-	} 
+	}
 	else {
 		this->maxEventLength = maxEventLength;
 	}
@@ -1254,7 +1254,7 @@ void TraceBatch::dump() {
 		g_traceLog.writeEvent(buggifyBatch[i].fields, "", false);
 	}
 
-	g_traceLog.flush();
+	onMainThreadVoid([](){ g_traceLog.flush(); }, NULL);
 	eventBatch.clear();
 	attachBatch.clear();
 	buggifyBatch.clear();


### PR DESCRIPTION
`TraceBatch::flush()` calls `Net2::now()` from whatever thread `flush()` is called from, which causes a race with `Net2::updateNow()`. This PR moves the call to `flush()` onto the main thread which (should) make `TraceBatch` thread compatible.