### PR TITLE
Add JSON trace support in TestHarness

### DIFF
--- a/contrib/TestHarness/CMakeLists.txt
+++ b/contrib/TestHarness/CMakeLists.txt
@@ -3,7 +3,7 @@ set(SRCS
   Properties/AssemblyInfo.cs)
 
 set(TEST_HARNESS_REFERENCES
-  "-r:System,System.Core,System.Xml.Linq,System.Data.DataSetExtensions,Microsoft.CSharp,System.Data,System.Xml,${TraceLogHelperDll}")
+  "-r:System,System.Core,System.Xml.Linq,System.Data.DataSetExtensions,Microsoft.CSharp,System.Data,System.Xml,System.Runtime.Serialization,${TraceLogHelperDll}")
 
 set(out_file ${CMAKE_BINARY_DIR}/packages/bin/TestHarness.exe)
 

--- a/contrib/TestHarness/Program.cs
+++ b/contrib/TestHarness/Program.cs
@@ -29,6 +29,7 @@ using System.Diagnostics;
 using System.ComponentModel;
 using System.Runtime.InteropServices;
 using System.Xml;
+using System.Runtime.Serialization.Json;
 
 namespace SummarizeTest
 {
@@ -359,20 +360,22 @@ namespace SummarizeTest
                 {
                     ErrorOutputListener errorListener = new ErrorOutputListener();
                     process.StartInfo.UseShellExecute = false;
+                    string tlsPluginArg = "";
                     if (tlsPluginFile.Length > 0) {
                         process.StartInfo.EnvironmentVariables["FDB_TLS_PLUGIN"] = tlsPluginFile;
+                        tlsPluginArg = "--tls_plugin=" + tlsPluginFile;
                     }
                     process.StartInfo.RedirectStandardOutput = true;
                     var args = "";
                     if (willRestart && oldBinaryName.EndsWith("alpha6"))
                     {
-                        args = string.Format("-Rs 1000000000 -r simulation {0} -s {1} -f \"{2}\" -b {3} --tls_plugin={4} --crash",
-                            IsRunningOnMono() ? "" : "-q", seed, testFile, buggify ? "on" : "off", tlsPluginFile);
+                        args = string.Format("-Rs 1000000000 -r simulation {0} -s {1} -f \"{2}\" -b {3} {4} --crash",
+                            IsRunningOnMono() ? "" : "-q", seed, testFile, buggify ? "on" : "off", tlsPluginArg);
                     }
                     else
                     {
-                        args = string.Format("-Rs 1GB -r simulation {0} -s {1} -f \"{2}\" -b {3} --tls_plugin={4} --crash",
-                            IsRunningOnMono() ? "" : "-q", seed, testFile, buggify ? "on" : "off", tlsPluginFile);
+                        args = string.Format("-Rs 1GB -r simulation {0} -s {1} -f \"{2}\" -b {3} {4} --crash",
+                            IsRunningOnMono() ? "" : "-q", seed, testFile, buggify ? "on" : "off", tlsPluginArg);
                     }
                     if (restarting) args = args + " --restarting";
                     if (useValgrind && !willRestart)
@@ -477,7 +480,7 @@ namespace SummarizeTest
                     memCheckThread.Join();
                     consoleThread.Join();
 
-                    var traceFiles = Directory.GetFiles(tempPath, "trace*.xml");
+                    var traceFiles = Directory.GetFiles(tempPath, "trace*.*", SearchOption.TopDirectoryOnly).Where(s => s.EndsWith(".xml") || s.EndsWith(".json")).ToArray();
                     if (traceFiles.Length == 0)
                     {
                         if (!traceToStdout)
@@ -658,6 +661,10 @@ namespace SummarizeTest
             return whats.ToArray();
         }
 
+        delegate IEnumerable<Magnesium.Event> parseDelegate(System.IO.Stream stream, string file,
+            bool keepOriginalElement = false, double startTime = -1, double endTime = Double.MaxValue,
+            double samplingFactor = 1.0);
+
         static int Summarize(string[] traceFiles, string summaryFileName,
             string errorFileName, bool? killed, List<string> outputErrors, int? exitCode, long? peakMemory,
             string uid, string valgrindOutputFileName, int expectedUnseed, out int unseed, out bool retryableError, bool logOnRetryableError,
@@ -689,7 +696,12 @@ namespace SummarizeTest
                 {
                     try
                     {
-                        foreach (var ev in Magnesium.XmlParser.Parse(traceFile, traceFileName))
+                        parseDelegate parse;
+                        if (traceFileName.EndsWith(".json"))
+                            parse = Magnesium.JsonParser.Parse;
+                        else
+                            parse = Magnesium.XmlParser.Parse;
+                        foreach (var ev in parse(traceFile, traceFileName))
                         {
                             Magnesium.Severity newSeverity;
                             if (severityMap.TryGetValue(new KeyValuePair<string, Magnesium.Severity>(ev.Type, ev.Severity), out newSeverity))
@@ -1089,10 +1101,19 @@ namespace SummarizeTest
 
         private static void AppendToSummary(string summaryFileName, XElement xout, bool traceToStdout = false, bool shouldLock = true)
         {
+            bool useXml = true;
+            if (summaryFileName.EndsWith(".json"))
+                useXml = false;
+
             if (traceToStdout)
             {
-                using (var wr = System.Xml.XmlWriter.Create(Console.OpenStandardOutput(), new System.Xml.XmlWriterSettings() { OmitXmlDeclaration = true, Encoding = new System.Text.UTF8Encoding(false) }))
-                    xout.WriteTo(wr);
+                if (useXml) {
+                    using (var wr = System.Xml.XmlWriter.Create(Console.OpenStandardOutput(), new System.Xml.XmlWriterSettings() { OmitXmlDeclaration = true, Encoding = new System.Text.UTF8Encoding(false) }))
+                        xout.WriteTo(wr);
+                } else {
+                    using (var wr = System.Runtime.Serialization.Json.JsonReaderWriterFactory.CreateJsonWriter(Console.OpenStandardOutput()))
+                        xout.WriteTo(wr);
+                }
                 Console.WriteLine();
                 return;
             }
@@ -1103,7 +1124,6 @@ namespace SummarizeTest
                 takeLock(summaryFileName);
             try
             {
-
                 using (var f = System.IO.File.Open(summaryFileName, System.IO.FileMode.Append, System.IO.FileAccess.Write))
                 {
                     if (f.Length == 0)
@@ -1111,8 +1131,13 @@ namespace SummarizeTest
                         byte[] bytes = Encoding.UTF8.GetBytes("<Trace>");
                         f.Write(bytes, 0, bytes.Length);
                     }
-                    using (var wr = System.Xml.XmlWriter.Create(f, new System.Xml.XmlWriterSettings() { OmitXmlDeclaration = true }))
-                        xout.Save(wr);
+                    if (useXml) {
+                        using (var wr = System.Xml.XmlWriter.Create(f, new System.Xml.XmlWriterSettings() { OmitXmlDeclaration = true }))
+                            xout.Save(wr);
+                    } else {
+                        using (var wr = System.Runtime.Serialization.Json.JsonReaderWriterFactory.CreateJsonWriter(f))
+                            xout.WriteTo(wr);
+                    }
                     var endl = Encoding.UTF8.GetBytes(Environment.NewLine);
                     f.Write(endl, 0, endl.Length);
                 }
@@ -1123,6 +1148,7 @@ namespace SummarizeTest
                     releaseLock(summaryFileName);
             }
         }
+
         private static void AppendXmlMessageToSummary(string summaryFileName, XElement xout, bool traceToStdout = false, string testFile = null,
             int? seed = null, bool? buggify = null, bool? determinismCheck = null, string oldBinaryName = null)
         {

--- a/contrib/TraceLogHelper/JsonParser.cs
+++ b/contrib/TraceLogHelper/JsonParser.cs
@@ -51,7 +51,7 @@ namespace Magnesium
 					}
 					catch (Exception e)
 					{
-						throw new Exception(string.Format("Failed to parse {0}", root), e);
+						throw new Exception(string.Format("Failed to parse JSON {0}", root), e);
 					}
 					if (ev != null) yield return ev;
 				}
@@ -80,8 +80,9 @@ namespace Magnesium
 				TraceFile = file,
 				DDetails = xEvent.Elements()
 					.Where(a=>a.Name != "Type" && a.Name != "Time" && a.Name != "Machine" && a.Name != "ID" && a.Name != "Severity" && (!rolledEvent || a.Name != "OriginalTime"))
-					.ToDictionary(a=>string.Intern(a.Name.LocalName), a=>(object)a.Value),
-				original = keepOriginalElement ? xEvent : null,
+					// When the key contains a colon character, it gets parsed as a:item
+					.ToDictionary(a=>a.Name.LocalName == "item" ? a.Attribute("item").Value : string.Intern(a.Name.LocalName), a=>(object)a.Value),
+				original = keepOriginalElement ? xEvent : null
 			};
 		}
 

--- a/contrib/TraceLogHelper/XmlParser.cs
+++ b/contrib/TraceLogHelper/XmlParser.cs
@@ -53,7 +53,7 @@ namespace Magnesium
 					}
 					catch (Exception e)
 					{
-						throw new Exception(string.Format("Failed to parse {0}", xev), e);
+						throw new Exception(string.Format("Failed to parse XML {0}", xev), e);
 					}
 					if (ev != null) yield return ev;
 				}


### PR DESCRIPTION
This PR will enable TestHarness to read trace logs in JSON format.
The "TLS Plugin" change piggy backed to this PR is not necessarily required, but this will allow us (Snowflake) to test with older version of FDB.