### PR TITLE
Fix invalid memory writes in TLS certificate refresh

### DIFF
--- a/documentation/sphinx/source/release-notes.rst
+++ b/documentation/sphinx/source/release-notes.rst
@@ -102,6 +102,7 @@ Fixes only impacting 6.3.0+
 ---------------------------
 
 * Renamed ``MIN_DELAY_STORAGE_CANDIDACY_SECONDS`` knob to ``MIN_DELAY_CC_WORST_FIT_CANDIDACY_SECONDS``. [6.3.2] `(PR #3327) <https://github.com/apple/foundationdb/pull/3327>`_
+* Refreshing TLS certificates could cause crashes. [6.3.2] `(PR #3352) <https://github.com/apple/foundationdb/pull/3352>`_
 
 Earlier release notes
 ---------------------

--- a/flow/TLSConfig.actor.cpp
+++ b/flow/TLSConfig.actor.cpp
@@ -287,7 +287,7 @@ ACTOR static Future<Void> readEntireFile( std::string filename, std::string* des
 		throw file_too_large();
 	}
 	destination->resize(filesize);
-	wait(success(file->read(&destination[0], filesize, 0)));
+	wait(success(file->read(&((*destination)[0]), filesize, 0)));
 	return Void();
 }
 
@@ -313,7 +313,7 @@ ACTOR Future<LoadedTLSConfig> TLSConfig::loadAsync(const TLSConfig* self) {
 	if (CAPath.size()) {
 		reads.push_back( readEntireFile( CAPath, &loaded.tlsCABytes ) );
 	} else {
-		loaded.tlsCABytes = self->tlsKeyBytes;
+		loaded.tlsCABytes = self->tlsCABytes;
 	}
 
 	wait(waitForAll(reads));


### PR DESCRIPTION
Refreshing TLS files was done to an incorrect location that resulted in random memory being wiped out. Also fixed a typo that loaded the key bytes into the CA bytes in some cases.