### PR TITLE
Suppress array-bounds warnings in mako.c

### DIFF
--- a/bindings/c/CMakeLists.txt
+++ b/bindings/c/CMakeLists.txt
@@ -72,8 +72,6 @@ if(NOT WIN32)
     test/mako/utils.c
     test/mako/utils.h)
 
-  set_source_files_properties(test/mako/mako.c PROPERTIES COMPILE_FLAGS -Wno-array-bounds)
-
   if(OPEN_FOR_IDE)
     add_library(fdb_c_performance_test OBJECT test/performance_test.c test/test.h)
     add_library(fdb_c_ryw_benchmark OBJECT test/ryw_benchmark.c test/test.h)

--- a/bindings/c/CMakeLists.txt
+++ b/bindings/c/CMakeLists.txt
@@ -72,6 +72,8 @@ if(NOT WIN32)
     test/mako/utils.c
     test/mako/utils.h)
 
+  set_source_files_properties(test/mako/mako.c PROPERTIES COMPILE_FLAGS -Wno-array-bounds)
+
   if(OPEN_FOR_IDE)
     add_library(fdb_c_performance_test OBJECT test/performance_test.c test/test.h)
     add_library(fdb_c_ryw_benchmark OBJECT test/ryw_benchmark.c test/test.h)

--- a/bindings/c/test/mako/mako.c
+++ b/bindings/c/test/mako/mako.c
@@ -1034,6 +1034,9 @@ int parse_transaction(mako_args_t* args, char* optarg) {
 
 	op = 0;
 	while (*ptr) {
+// Clang gives false positive array bounds warning, which must be ignored:
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warray-bounds"
 		if (strncmp(ptr, "grv", 3) == 0) {
 			op = OP_GETREADVERSION;
 			ptr += 3;
@@ -1080,6 +1083,7 @@ int parse_transaction(mako_args_t* args, char* optarg) {
 			error = 1;
 			break;
 		}
+#pragma clang diagnostic pop
 
 		/* count */
 		num = 0;


### PR DESCRIPTION
This addresses https://github.com/apple/foundationdb/issues/3232 by suppressing overly aggressive warnings.