### PR TITLE
Reject incompatible communication per endpoint instead of per peer

### DIFF
--- a/fdbclient/CoordinationInterface.h
+++ b/fdbclient/CoordinationInterface.h
@@ -33,6 +33,8 @@ const int MAX_CLUSTER_FILE_BYTES = 60000;
 constexpr UID WLTOKEN_CLIENTLEADERREG_GETLEADER(-1, 2);
 constexpr UID WLTOKEN_CLIENTLEADERREG_OPENDATABASE(-1, 3);
 
+constexpr UID WLTOKEN_PROTOCOL_INFO(-1, 10);
+
 struct ClientLeaderRegInterface {
 	RequestStream< struct GetLeaderRequest > getLeader;
 	RequestStream< struct OpenDatabaseCoordRequest > openDatabase;
@@ -183,6 +185,32 @@ public:
 	explicit ClientCoordinators( Reference<ClusterConnectionFile> ccf );
 	explicit ClientCoordinators( Key clusterKey, std::vector<NetworkAddress> coordinators );
 	ClientCoordinators() {}
+};
+
+struct ProtocolInfoReply {
+	constexpr static FileIdentifier file_identifier = 7784298;
+	ProtocolVersion version;
+	template <class Ar>
+	void serialize(Ar& ar) {
+		uint64_t version_ = 0;
+		if (Ar::isSerializing) {
+			version_ = version.versionWithFlags();
+		}
+		serializer(ar, version_);
+		if (Ar::isDeserializing) {
+			version = ProtocolVersion(version_);
+		}
+	}
+};
+
+struct ProtocolInfoRequest {
+	constexpr static FileIdentifier file_identifier = 13261233;
+	ReplyPromise<ProtocolInfoReply> reply{ PeerCompatibilityPolicy{ RequirePeer::AtLeast,
+		                                                            ProtocolVersion::withStableInterfaces() } };
+	template <class Ar>
+	void serialize(Ar& ar) {
+		serializer(ar, reply);
+	}
 };
 
 #endif

--- a/fdbclient/CoordinationInterface.h
+++ b/fdbclient/CoordinationInterface.h
@@ -30,6 +30,9 @@
 
 const int MAX_CLUSTER_FILE_BYTES = 60000;
 
+constexpr UID WLTOKEN_CLIENTLEADERREG_GETLEADER(-1, 2);
+constexpr UID WLTOKEN_CLIENTLEADERREG_OPENDATABASE(-1, 3);
+
 struct ClientLeaderRegInterface {
 	RequestStream< struct GetLeaderRequest > getLeader;
 	RequestStream< struct OpenDatabaseCoordRequest > openDatabase;

--- a/fdbclient/MonitorLeader.actor.cpp
+++ b/fdbclient/MonitorLeader.actor.cpp
@@ -371,10 +371,6 @@ ClientCoordinators::ClientCoordinators( Key clusterKey, std::vector<NetworkAddre
 	ccf = Reference<ClusterConnectionFile>(new ClusterConnectionFile( ClusterConnectionString( coordinators, clusterKey ) ) );
 }
 
-
-UID WLTOKEN_CLIENTLEADERREG_GETLEADER( -1, 2 );
-UID WLTOKEN_CLIENTLEADERREG_OPENDATABASE( -1, 3 );
-
 ClientLeaderRegInterface::ClientLeaderRegInterface( NetworkAddress remote )
 	: getLeader( Endpoint({remote}, WLTOKEN_CLIENTLEADERREG_GETLEADER) ),
     openDatabase( Endpoint({remote}, WLTOKEN_CLIENTLEADERREG_OPENDATABASE) )

--- a/fdbclient/MultiVersionTransaction.actor.cpp
+++ b/fdbclient/MultiVersionTransaction.actor.cpp
@@ -1394,7 +1394,7 @@ bool ClientInfo::canReplace(Reference<ClientInfo> other) const {
 		return true;
 	}
 
-	return !protocolVersion.isCompatible(other->protocolVersion);
+	return !other->protocolVersion.hasStableInterfaces();
 }
 
 // UNIT TESTS

--- a/fdbrpc/FlowTransport.actor.cpp
+++ b/fdbrpc/FlowTransport.actor.cpp
@@ -42,9 +42,8 @@
 
 static NetworkAddressList g_currentDeliveryPeerAddress = NetworkAddressList();
 
-const UID WLTOKEN_ENDPOINT_NOT_FOUND(-1, 0);
-const UID WLTOKEN_PING_PACKET(-1, 1);
-const UID TOKEN_IGNORE_PACKET(0, 2);
+constexpr UID WLTOKEN_ENDPOINT_NOT_FOUND(-1, 0);
+constexpr UID WLTOKEN_PING_PACKET(-1, 1);
 const uint64_t TOKEN_STREAM_FLAG = 1;
 
 
@@ -184,6 +183,24 @@ struct PingReceiver : NetworkMessageReceiver {
 	}
 	virtual void receive( ArenaReader& reader ) {
 		ReplyPromise<Void> reply; reader >> reply;
+		reply.send(Void());
+	}
+	virtual void receive(ArenaObjectReader& reader) {
+		ReplyPromise<Void> reply;
+		reader.deserialize(reply);
+		reply.send(Void());
+	}
+};
+
+struct ProtocolInfoReceiver : NetworkMessageReceiver {
+	ProtocolInfoReceiver(EndpointMap& endpoints) {
+		Endpoint::Token e = WLTOKEN_PING_PACKET;
+		endpoints.insert(this, e, TaskPriority::ReadSocket);
+		ASSERT(e == WLTOKEN_PING_PACKET);
+	}
+	virtual void receive(ArenaReader& reader) {
+		ReplyPromise<Void> reply;
+		reader >> reply;
 		reply.send(Void());
 	}
 	virtual void receive(ArenaObjectReader& reader) {

--- a/fdbrpc/FlowTransport.actor.cpp
+++ b/fdbrpc/FlowTransport.actor.cpp
@@ -158,10 +158,13 @@ TaskPriority EndpointMap::getPriority( Endpoint::Token const& token ) {
 	return TaskPriority::UnknownEndpoint;
 }
 
-void EndpointMap::remove( Endpoint::Token const& token, NetworkMessageReceiver* r ) {
+void EndpointMap::remove(Endpoint::Token const& token, NetworkMessageReceiver* r) {
 	uint32_t index = token.second();
-	ASSERT(index >= wellKnownEndpointCount);
-	if ( index < data.size() && data[index].token().first() == token.first() && ((data[index].token().second()&0xffffffff00000000LL)|index)==token.second() && data[index].receiver == r ) {
+	if (index < wellKnownEndpointCount) {
+		data[index].receiver = nullptr;
+	} else if (index < data.size() && data[index].token().first() == token.first() &&
+	           ((data[index].token().second() & 0xffffffff00000000LL) | index) == token.second() &&
+	           data[index].receiver == r) {
 		data[index].receiver = 0;
 		data[index].nextFree = firstFree;
 		firstFree = index;

--- a/fdbrpc/FlowTransport.actor.cpp
+++ b/fdbrpc/FlowTransport.actor.cpp
@@ -89,8 +89,7 @@ void EndpointMap::realloc() {
 }
 
 void EndpointMap::insertWellKnown(NetworkMessageReceiver* r, const Endpoint::Token& token, TaskPriority priority) {
-	ASSERT(r->isStream());
-	int index = token.first();
+	int index = token.second();
 	ASSERT(data[index].receiver == nullptr);
 	data[index].receiver = r;
 	data[index].token() =

--- a/fdbrpc/FlowTransport.actor.cpp
+++ b/fdbrpc/FlowTransport.actor.cpp
@@ -144,6 +144,9 @@ const Endpoint& EndpointMap::insert( NetworkAddressList localAddresses, std::vec
 
 NetworkMessageReceiver* EndpointMap::get( Endpoint::Token const& token ) {
 	uint32_t index = token.second();
+	if (index < wellKnownEndpointCount && data[index].receiver == nullptr) {
+		TraceEvent(SevWarnAlways, "WellKnownEndpointNotAdded").detail("Token", token);
+	}
 	if ( index < data.size() && data[index].token().first() == token.first() && ((data[index].token().second()&0xffffffff00000000LL)|index)==token.second() )
 		return data[index].receiver;
 	return 0;

--- a/fdbrpc/FlowTransport.h
+++ b/fdbrpc/FlowTransport.h
@@ -115,11 +115,22 @@ namespace std
 	};
 }
 
+enum class RequirePeer { Exactly, AtLeast };
+
+struct PeerCompatibilityPolicy {
+	RequirePeer requirement;
+	ProtocolVersion version;
+};
+
 class ArenaObjectReader;
 class NetworkMessageReceiver {
 public:
 	virtual void receive(ArenaObjectReader&) = 0;
 	virtual bool isStream() const { return false; }
+	virtual PeerCompatibilityPolicy peerCompatibilityPolicy() const {
+		// TODO(anoyes) Add "this process's protocol version" to INetwork interface and use that here instead.
+		return { RequirePeer::Exactly, currentProtocolVersion };
+	}
 };
 
 struct TransportData;

--- a/fdbrpc/fdbrpc.h
+++ b/fdbrpc/fdbrpc.h
@@ -66,6 +66,12 @@ struct FlowReceiver : public NetworkMessageReceiver {
 		endpoint = e;
 	}
 
+	void setPeerCompatibilityPolicy(const PeerCompatibilityPolicy& policy) { peerCompatibilityPolicy_ = policy; }
+
+	PeerCompatibilityPolicy peerCompatibilityPolicy() const override {
+		return peerCompatibilityPolicy_.orDefault(NetworkMessageReceiver::peerCompatibilityPolicy());
+	}
+
 	void makeWellKnownEndpoint(Endpoint::Token token, TaskPriority taskID) {
 		ASSERT(!endpoint.isValid());
 		m_isLocalEndpoint = true;
@@ -74,6 +80,7 @@ struct FlowReceiver : public NetworkMessageReceiver {
 	}
 
 private:
+	Optional<PeerCompatibilityPolicy> peerCompatibilityPolicy_;
 	Endpoint endpoint;
 	bool m_isLocalEndpoint;
 	bool m_stream;
@@ -120,6 +127,9 @@ public:
 	bool isSet() { return sav->isSet(); }
 	bool isValid() const { return sav != NULL; }
 	ReplyPromise() : sav(new NetSAV<T>(0, 1)) {}
+	explicit ReplyPromise(const PeerCompatibilityPolicy& policy) : ReplyPromise() {
+		sav->setPeerCompatibilityPolicy(policy);
+	}
 	ReplyPromise(const ReplyPromise& rhs) : sav(rhs.sav) { sav->addPromiseRef(); }
 	ReplyPromise(ReplyPromise&& rhs) noexcept : sav(rhs.sav) { rhs.sav = 0; }
 	~ReplyPromise() { if (sav) sav->delPromiseRef(); }
@@ -362,6 +372,9 @@ public:
 
 	FutureStream<T> getFuture() const { queue->addFutureRef(); return FutureStream<T>(queue); }
 	RequestStream() : queue(new NetNotifiedQueue<T>(0, 1)) {}
+	explicit RequestStream(PeerCompatibilityPolicy policy) : RequestStream() {
+		queue->setPeerCompatibilityPolicy(policy);
+	}
 	RequestStream(const RequestStream& rhs) : queue(rhs.queue) { queue->addPromiseRef(); }
 	RequestStream(RequestStream&& rhs) noexcept : queue(rhs.queue) { rhs.queue = 0; }
 	void operator=(const RequestStream& rhs) {

--- a/fdbrpc/sim2.actor.cpp
+++ b/fdbrpc/sim2.actor.cpp
@@ -85,8 +85,6 @@ void ISimulator::displayWorkers() const
 	return;
 }
 
-const UID TOKEN_ENDPOINT_NOT_FOUND(-1, -1);
-
 ISimulator* g_pSimulator = 0;
 thread_local ISimulator::ProcessInfo* ISimulator::currentProcess = 0;
 int openCount = 0;

--- a/fdbserver/Coordination.actor.cpp
+++ b/fdbserver/Coordination.actor.cpp
@@ -42,17 +42,6 @@ struct GenerationRegVal {
 	}
 };
 
-// The order of UIDs here must match the order in which makeWellKnownEndpoint is called.
-// UID WLTOKEN_CLIENTLEADERREG_GETLEADER( -1, 2 ); // from fdbclient/MonitorLeader.actor.cpp
-// UID WLTOKEN_CLIENTLEADERREG_OPENDATABASE( -1, 3 ); // from fdbclient/MonitorLeader.actor.cpp
-UID WLTOKEN_LEADERELECTIONREG_CANDIDACY( -1, 4 );
-UID WLTOKEN_LEADERELECTIONREG_ELECTIONRESULT( -1, 5 );
-UID WLTOKEN_LEADERELECTIONREG_LEADERHEARTBEAT( -1, 6 );
-UID WLTOKEN_LEADERELECTIONREG_FORWARD( -1, 7 );
-UID WLTOKEN_GENERATIONREG_READ( -1, 8 );
-UID WLTOKEN_GENERATIONREG_WRITE( -1, 9 );
-
-
 GenerationRegInterface::GenerationRegInterface( NetworkAddress remote )
 	: read( Endpoint({remote}, WLTOKEN_GENERATIONREG_READ) ),
 	  write( Endpoint({remote}, WLTOKEN_GENERATIONREG_WRITE) )

--- a/fdbserver/CoordinationInterface.h
+++ b/fdbserver/CoordinationInterface.h
@@ -24,6 +24,13 @@
 
 #include "fdbclient/CoordinationInterface.h"
 
+constexpr UID WLTOKEN_LEADERELECTIONREG_CANDIDACY(-1, 4);
+constexpr UID WLTOKEN_LEADERELECTIONREG_ELECTIONRESULT(-1, 5);
+constexpr UID WLTOKEN_LEADERELECTIONREG_LEADERHEARTBEAT(-1, 6);
+constexpr UID WLTOKEN_LEADERELECTIONREG_FORWARD(-1, 7);
+constexpr UID WLTOKEN_GENERATIONREG_READ(-1, 8);
+constexpr UID WLTOKEN_GENERATIONREG_WRITE(-1, 9);
+
 struct GenerationRegInterface {
 	constexpr static FileIdentifier file_identifier = 16726744;
 	RequestStream< struct GenerationRegReadRequest > read;

--- a/fdbserver/worker.actor.cpp
+++ b/fdbserver/worker.actor.cpp
@@ -1720,6 +1720,16 @@ ACTOR Future<Void> monitorLeaderRemotelyWithDelayedCandidacy( Reference<ClusterC
 	}
 }
 
+ACTOR Future<Void> serveProtocolInfo() {
+	state RequestStream<ProtocolInfoRequest> protocolInfo(
+	    PeerCompatibilityPolicy{ RequirePeer::AtLeast, ProtocolVersion::withStableInterfaces() });
+	protocolInfo.makeWellKnownEndpoint(WLTOKEN_PROTOCOL_INFO, TaskPriority::DefaultEndpoint);
+	loop {
+		ProtocolInfoRequest req = waitNext(protocolInfo.getFuture());
+		req.reply.send(ProtocolInfoReply{ currentProtocolVersion });
+	}
+}
+
 ACTOR Future<Void> fdbd(
 	Reference<ClusterConnectionFile> connFile,
 	LocalityData localities,
@@ -1734,6 +1744,8 @@ ACTOR Future<Void> fdbd(
 {
 	state vector<Future<Void>> actors;
 	state Promise<Void> recoveredDiskFiles;
+
+	actors.push_back(serveProtocolInfo());
 
 	try {
 		ServerCoordinators coordinators( connFile );

--- a/flow/IRandom.h
+++ b/flow/IRandom.h
@@ -65,7 +65,7 @@ class UID {
 public:
 	constexpr static FileIdentifier file_identifier = 15597147;
 	UID() { part[0] = part[1] = 0; }
-	UID( uint64_t a, uint64_t b ) { part[0]=a; part[1]=b; }
+	constexpr UID(uint64_t a, uint64_t b) : part{ a, b } {}
 	std::string toString() const;
 	std::string shortString() const;
 	bool isValid() const { return part[0] || part[1]; }

--- a/flow/ProtocolVersion.h
+++ b/flow/ProtocolVersion.h
@@ -39,16 +39,12 @@ class ProtocolVersion {
 public: // constants
 	static constexpr uint64_t versionFlagMask = 0x0FFFFFFFFFFFFFFFLL;
 	static constexpr uint64_t objectSerializerFlag = 0x1000000000000000LL;
-	static constexpr uint64_t compatibleProtocolVersionMask = 0xffffffffffff0000LL;
 	static constexpr uint64_t minValidProtocolVersion = 0x0FDB00A200060001LL;
 
 public:
 	constexpr explicit ProtocolVersion(uint64_t version) : _version(version) {}
 	constexpr ProtocolVersion() : _version(0) {}
 
-	constexpr bool isCompatible(ProtocolVersion other) const {
-		return (other.version() & compatibleProtocolVersionMask) == (version() & compatibleProtocolVersionMask);
-	}
 	constexpr bool isValid() const { return version() >= minValidProtocolVersion; }
 
 	constexpr uint64_t version() const { return _version & versionFlagMask; }
@@ -128,6 +124,7 @@ public: // introduced features
 	PROTOCOL_VERSION_FEATURE(0x0FDB00B063010000LL, ReportConflictingKeys);
 	PROTOCOL_VERSION_FEATURE(0x0FDB00B063010000LL, SmallEndpoints);
 	PROTOCOL_VERSION_FEATURE(0x0FDB00B063010000LL, CacheRole);
+	PROTOCOL_VERSION_FEATURE(0x0FDB00B070010000LL, StableInterfaces);
 };
 
 // These impact both communications and the deserialization of certain database and IKeyValueStore keys.


### PR DESCRIPTION
Currently we reject all communication with a peer if that peer has a different protocol version. The idea for this change is to selectively enable some endpoints to be "stable". By default endpoints will retain the "protocol version matches exactly" requirement. Here's the vision for what a "stable" endpoint would look like

1. Stable endpoints will require their peer to have a minimum protocol version
2. Messages handled by stable endpoints must obey flatbuffers schema evolution rules (you're allowed to append fields to tables, but not much else)
3. Endpoints must be prepared to handle any fields added after their minimum protocol version to be missing

- [ ] Update flow/README.md to explain the rules for stable endpoints
- [ ] Simulation test processes with different protocol versions
- [ ] Make it convenient to BUGGIFY fields missing at lower protocol versions
- [ ] Report the versions of coordinators in status if incompatible protocol version is the reason they can't connect
- [ ] Change multiversion client to ask the coordinators for their version and use the corresponding client instead of continually trying all clients.

I have the rough idea implemented so far, so I thought I'd share. I also refactored to hopefully make it easier to manage well known endpoints