### PR TITLE
Fix GetReadVersionReply.recentRequests to reflect a proxy's number of recent requests in the commit stats.

### DIFF
--- a/fdbserver/MasterProxyServer.actor.cpp
+++ b/fdbserver/MasterProxyServer.actor.cpp
@@ -1411,13 +1411,13 @@ ACTOR Future<GetReadVersionReply> getLiveCommittedVersion(ProxyCommitData* commi
 	rep.version = commitData->committedVersion.get();
 	rep.locked = commitData->locked;
 	rep.metadataVersion = commitData->metadataVersion;
-	rep.recentRequests = commitData->stats.getRecentRequests();
 
 	for (auto v : versions) {
 		if(v.version > rep.version) {
 			rep = v;
 		}
 	}
+	rep.recentRequests = commitData->stats.getRecentRequests();
 
 	if (debugID.present()) {
 		g_traceBatch.addEvent("TransactionDebug", debugID.get().first(), "MasterProxyServer.getLiveCommittedVersion.After");


### PR DESCRIPTION
This is a bug I found when working on https://github.com/apple/foundationdb/pull/3307 and decide to make the change a patch against 6.3.

- The problem is that GetReadVersionReply.recentRequests should always reflect the serving proxy's number of recent requests. Currently we may override it with other proxy's reply which is always 0 [1].

[1] https://github.com/apple/foundationdb/blob/master/fdbserver/MasterProxyServer.actor.cpp#L2086