### PR TITLE
Update special_keys_cross_module_read error handler

### DIFF
--- a/fdbclient/SpecialKeySpace.actor.cpp
+++ b/fdbclient/SpecialKeySpace.actor.cpp
@@ -109,6 +109,8 @@ ACTOR Future<Void> moveKeySelectorOverRangeActor(const SpecialKeyRangeBaseImpl* 
 // It does have overhead here since we query all keys twice in the worst case.
 // However, moving the KeySelector while handling other parameters like limits makes the code much more complex and hard
 // to maintain; Thus, separate each part to make the code easy to understand and more compact
+// Boundary is the range of the legal key space, which, by default is the range of the module
+// And (\xff\xff, \xff\xff\xff\xff) if SPECIAL_KEY_SPACE_RELAXED is turned on
 ACTOR Future<Void> normalizeKeySelectorActor(SpecialKeySpace* sks, ReadYourWritesTransaction* ryw, KeySelector* ks,
                                              KeyRangeRef boundary, int* actualOffset,
                                              Standalone<RangeResultRef>* result,
@@ -165,7 +167,6 @@ ACTOR Future<Standalone<RangeResultRef>> SpecialKeySpace::getRangeAggregationAct
 	state RangeMap<Key, SpecialKeyRangeBaseImpl*, KeyRangeRef>::Iterator iter;
 	state int actualBeginOffset;
 	state int actualEndOffset;
-	// state Optional<SpecialKeySpace::MODULE> lastModuleRead;
 	state KeyRangeRef moduleBoundary;
 	// used to cache result from potential first read
 	state Optional<Standalone<RangeResultRef>> cache;

--- a/fdbclient/SpecialKeySpace.actor.h
+++ b/fdbclient/SpecialKeySpace.actor.h
@@ -111,6 +111,8 @@ public:
 	SpecialKeySpace(KeyRef spaceStartKey = Key(), KeyRef spaceEndKey = normalKeys.end, bool testOnly = true)
 	  : range(KeyRangeRef(spaceStartKey, spaceEndKey)), impls(nullptr, spaceEndKey),
 	    modules(testOnly ? SpecialKeySpace::MODULE::TESTONLY : SpecialKeySpace::MODULE::UNKNOWN, spaceEndKey) {
+		// Default begin of KeyRangeMap is Key(), insert the range to update start key if needed
+		impls.insert(range, nullptr);
 		if (!testOnly) modulesBoundaryInit(); // testOnly is used in the correctness workload
 	}
 	// Initialize module boundaries, used to handle cross_module_read
@@ -153,9 +155,10 @@ private:
 	                                                                 ReadYourWritesTransaction* ryw, KeySelector begin,
 	                                                                 KeySelector end, GetRangeLimits limits,
 	                                                                 bool reverse);
-	ACTOR static Future<std::pair<Standalone<RangeResultRef>, Optional<SpecialKeySpace::MODULE>>>
-	getRangeAggregationActor(SpecialKeySpace* sks, ReadYourWritesTransaction* ryw, KeySelector begin, KeySelector end,
-	                         GetRangeLimits limits, bool reverse);
+	ACTOR static Future<Standalone<RangeResultRef>> getRangeAggregationActor(SpecialKeySpace* sks,
+	                                                                         ReadYourWritesTransaction* ryw,
+	                                                                         KeySelector begin, KeySelector end,
+	                                                                         GetRangeLimits limits, bool reverse);
 	KeyRange range;
 	KeyRangeMap<SpecialKeyRangeBaseImpl*> impls;
 	KeyRangeMap<SpecialKeySpace::MODULE> modules;

--- a/fdbclient/SpecialKeySpace.actor.h
+++ b/fdbclient/SpecialKeySpace.actor.h
@@ -151,7 +151,7 @@ public:
 private:
 	ACTOR static Future<Optional<Value>> getActor(SpecialKeySpace* sks, ReadYourWritesTransaction* ryw, KeyRef key);
 
-	ACTOR static Future<Standalone<RangeResultRef>> checkModuleFound(SpecialKeySpace* sks,
+	ACTOR static Future<Standalone<RangeResultRef>> checkRYWValid(SpecialKeySpace* sks,
 	                                                                 ReadYourWritesTransaction* ryw, KeySelector begin,
 	                                                                 KeySelector end, GetRangeLimits limits,
 	                                                                 bool reverse);

--- a/fdbclient/SpecialKeySpace.actor.h
+++ b/fdbclient/SpecialKeySpace.actor.h
@@ -108,12 +108,9 @@ public:
 	Future<Standalone<RangeResultRef>> getRange(ReadYourWritesTransaction* ryw, KeySelector begin, KeySelector end,
 	                                            GetRangeLimits limits, bool reverse = false);
 
-	SpecialKeySpace(KeyRef spaceStartKey = Key(), KeyRef spaceEndKey = normalKeys.end, bool testOnly = true) {
-		// Default value is nullptr, begin of KeyRangeMap is Key()
-		impls = KeyRangeMap<SpecialKeyRangeBaseImpl*>(nullptr, spaceEndKey);
-		range = KeyRangeRef(spaceStartKey, spaceEndKey);
-		modules = KeyRangeMap<SpecialKeySpace::MODULE>(
-		    testOnly ? SpecialKeySpace::MODULE::TESTONLY : SpecialKeySpace::MODULE::UNKNOWN, spaceEndKey);
+	SpecialKeySpace(KeyRef spaceStartKey = Key(), KeyRef spaceEndKey = normalKeys.end, bool testOnly = true)
+	  : range(KeyRangeRef(spaceStartKey, spaceEndKey)), impls(nullptr, spaceEndKey),
+	    modules(testOnly ? SpecialKeySpace::MODULE::TESTONLY : SpecialKeySpace::MODULE::UNKNOWN, spaceEndKey) {
 		if (!testOnly) modulesBoundaryInit(); // testOnly is used in the correctness workload
 	}
 	// Initialize module boundaries, used to handle cross_module_read
@@ -159,10 +156,9 @@ private:
 	ACTOR static Future<std::pair<Standalone<RangeResultRef>, Optional<SpecialKeySpace::MODULE>>>
 	getRangeAggregationActor(SpecialKeySpace* sks, ReadYourWritesTransaction* ryw, KeySelector begin, KeySelector end,
 	                         GetRangeLimits limits, bool reverse);
-
+	KeyRange range;
 	KeyRangeMap<SpecialKeyRangeBaseImpl*> impls;
 	KeyRangeMap<SpecialKeySpace::MODULE> modules;
-	KeyRange range;
 
 	static std::unordered_map<SpecialKeySpace::MODULE, KeyRange> moduleToBoundary;
 };

--- a/fdbserver/workloads/SpecialKeySpaceCorrectness.actor.cpp
+++ b/fdbserver/workloads/SpecialKeySpaceCorrectness.actor.cpp
@@ -307,9 +307,9 @@ struct SpecialKeySpaceCorrectnessWorkload : TestWorkload {
 		}
 		// No module found error case with keys
 		try {
-			wait(success(tx->getRange(
-			    KeyRangeRef(LiteralStringRef("\xff\xff/A_no_module_related_prefix"), LiteralStringRef("\xff\xff/I_am_also_not_in_any_module")),
-			    CLIENT_KNOBS->TOO_MANY)));
+			wait(success(tx->getRange(KeyRangeRef(LiteralStringRef("\xff\xff/A_no_module_related_prefix"),
+			                                      LiteralStringRef("\xff\xff/I_am_also_not_in_any_module")),
+			                          CLIENT_KNOBS->TOO_MANY)));
 			ASSERT(false);
 		} catch (Error& e) {
 			if (e.code() == error_code_actor_cancelled) throw;

--- a/fdbserver/workloads/SpecialKeySpaceCorrectness.actor.cpp
+++ b/fdbserver/workloads/SpecialKeySpaceCorrectness.actor.cpp
@@ -338,6 +338,17 @@ struct SpecialKeySpaceCorrectnessWorkload : TestWorkload {
 		} catch (Error& e) {
 			throw;
 		}
+		try {
+			tx->addReadConflictRange(singleKeyRange(LiteralStringRef("readKey")));
+			const KeyRef key = LiteralStringRef("\xff\xff/transaction/a_to_be_the_first");
+			KeySelector begin = KeySelectorRef(key, false, 0);
+			KeySelector end = KeySelectorRef(key, false, 2);
+			Standalone<RangeResultRef> result = wait(tx->getRange(begin, end, GetRangeLimits(CLIENT_KNOBS->TOO_MANY)));
+			ASSERT(result.readToBegin && !result.readThroughEnd);
+			tx->reset();
+		} catch (Error& e) {
+			throw;
+		}
 
 		return Void();
 	}

--- a/fdbserver/workloads/SpecialKeySpaceCorrectness.actor.cpp
+++ b/fdbserver/workloads/SpecialKeySpaceCorrectness.actor.cpp
@@ -203,7 +203,6 @@ struct SpecialKeySpaceCorrectnessWorkload : TestWorkload {
 
 	KeySelector randomKeySelector() {
 		Key randomKey;
-		// TODO : add randomness to pickup existing keys
 		if (deterministicRandom()->random01() < absoluteRandomProb) {
 			Key prefix;
 			if (deterministicRandom()->random01() < absoluteRandomProb)
@@ -287,7 +286,8 @@ struct SpecialKeySpaceCorrectnessWorkload : TestWorkload {
 			tx->setOption(FDBTransactionOptions::SPECIAL_KEY_SPACE_RELAXED);
 			const KeyRef startKey = LiteralStringRef("\xff\xff/transactio");
 			const KeyRef endKey = LiteralStringRef("\xff\xff/transaction1");
-			Standalone<RangeResultRef> result = wait(tx->getRange(KeyRangeRef(startKey, endKey), GetRangeLimits(CLIENT_KNOBS->TOO_MANY)));
+			Standalone<RangeResultRef> result =
+			    wait(tx->getRange(KeyRangeRef(startKey, endKey), GetRangeLimits(CLIENT_KNOBS->TOO_MANY)));
 			// The whole transaction module should be empty
 			ASSERT(!result.size());
 			tx->reset();


### PR DESCRIPTION
The pr for this [post](https://forums.foundationdb.org/t/thoughts-on-cross-module-read-error-in-special-key-space/2177/10).
The goal is to make each module is treated as its own little keyspace by default.
The `special_keys_cross_module_read` error is thrown in two scenarios right now:

- Base keys of the begin key selector and the end key selector belong to different modules
- Two base keys belong to the same module, but one or two of them will read through the module’s boundary during key resolution

The code is to make the second one legal and set `readToBegin` or `readThroughEnd` as reference.

Also, the code adds an assertion for the `ryw` to be not `null`, which was the case in unit tests. Since we already have the correctness workload, the unit tests can be removed, and then `ryw` should never be null.