### PR TITLE
Improve const-correctness

### DIFF
--- a/fdbclient/RYWIterator.cpp
+++ b/fdbclient/RYWIterator.cpp
@@ -32,18 +32,28 @@ const RYWIterator::SEGMENT_TYPE RYWIterator::typeMap[12] = {
 		// DEPENDENT_WRITE
 		RYWIterator::UNKNOWN_RANGE, RYWIterator::KV, RYWIterator::KV };
 
-RYWIterator::SEGMENT_TYPE RYWIterator::type() {
+RYWIterator::SEGMENT_TYPE RYWIterator::type() const {
 	if (is_unreadable())
 		throw accessed_unreadable();
 
 	return typeMap[ writes.type()*3 + cache.type() ];
 }
 
-bool RYWIterator::is_kv() { return type() == KV; }
-bool RYWIterator::is_unknown_range() { return type() == UNKNOWN_RANGE; }
-bool RYWIterator::is_empty_range() { return type() == EMPTY_RANGE; }
-bool RYWIterator::is_dependent() { return writes.type() == WriteMap::iterator::DEPENDENT_WRITE; }
-bool RYWIterator::is_unreadable() { return writes.is_unreadable(); }
+bool RYWIterator::is_kv() const {
+	return type() == KV;
+}
+bool RYWIterator::is_unknown_range() const {
+	return type() == UNKNOWN_RANGE;
+}
+bool RYWIterator::is_empty_range() const {
+	return type() == EMPTY_RANGE;
+}
+bool RYWIterator::is_dependent() const {
+	return writes.type() == WriteMap::iterator::DEPENDENT_WRITE;
+}
+bool RYWIterator::is_unreadable() const {
+	return writes.is_unreadable();
+}
 
 ExtStringRef RYWIterator::beginKey() { return begin_key_cmp <= 0 ? writes.beginKey() : cache.beginKey(); }
 ExtStringRef RYWIterator::endKey() { return end_key_cmp <= 0 ? cache.endKey() : writes.endKey(); }

--- a/fdbclient/RYWIterator.h
+++ b/fdbclient/RYWIterator.h
@@ -32,13 +32,13 @@ public:
 	enum SEGMENT_TYPE { UNKNOWN_RANGE, EMPTY_RANGE, KV };
 	static const SEGMENT_TYPE typeMap[12];
 
-	SEGMENT_TYPE type();
+	SEGMENT_TYPE type() const;
 
-	bool is_kv();
-	bool is_unknown_range();
-	bool is_empty_range();
-	bool is_unreadable();
-	bool is_dependent();
+	bool is_kv() const;
+	bool is_unknown_range() const;
+	bool is_empty_range() const;
+	bool is_unreadable() const;
+	bool is_dependent() const;
 
 	ExtStringRef beginKey();
 	ExtStringRef endKey();

--- a/fdbclient/SnapshotCache.h
+++ b/fdbclient/SnapshotCache.h
@@ -31,7 +31,7 @@ struct ExtStringRef {
 	ExtStringRef() : extra_zero_bytes(0) {}
 	ExtStringRef( StringRef const& s, int extra_zero_bytes=0 ) : base( s ), extra_zero_bytes(extra_zero_bytes) {}
 
-	Standalone<StringRef> toStandaloneStringRef() {
+	Standalone<StringRef> toStandaloneStringRef() const {
 		auto s = makeString( size() );
 		if (base.size() > 0) {
 			memcpy(mutateString(s), base.begin(), base.size());
@@ -40,7 +40,7 @@ struct ExtStringRef {
 		return s;
 	};
 
-	StringRef toArenaOrRef( Arena& a ) {
+	StringRef toArenaOrRef(Arena& a) const {
 		if (extra_zero_bytes) {
 			StringRef dest = StringRef( new(a) uint8_t[ size() ], size() );
 			if (base.size() > 0) {
@@ -52,12 +52,12 @@ struct ExtStringRef {
 			return base;
 	}
 
-	StringRef assertRef() {
+	StringRef assertRef() const {
 		ASSERT( extra_zero_bytes == 0 );
 		return base;
 	}
 
-	StringRef toArena( Arena& a ) {
+	StringRef toArena(Arena& a) const {
 		if (extra_zero_bytes) {
 			StringRef dest = StringRef( new(a) uint8_t[ size() ], size() );
 			if (base.size() > 0) {
@@ -186,19 +186,19 @@ public:
 
 		enum SEGMENT_TYPE { UNKNOWN_RANGE, EMPTY_RANGE, KV };
 
-		SEGMENT_TYPE type() {
+		SEGMENT_TYPE type() const {
 			if (!offset) return UNKNOWN_RANGE;
 			if (offset&1) return EMPTY_RANGE;
 			return KV;
 		}
 
-		bool is_kv() { return type() == KV; }
-		bool is_unknown_range() { return type() == UNKNOWN_RANGE; }
-		bool is_empty_range() { return type() == EMPTY_RANGE; }
-		bool is_dependent() { return false; }
-		bool is_unreadable() { return false; }
+		bool is_kv() const { return type() == KV; }
+		bool is_unknown_range() const { return type() == UNKNOWN_RANGE; }
+		bool is_empty_range() const { return type() == EMPTY_RANGE; }
+		bool is_dependent() const { return false; }
+		bool is_unreadable() const { return false; }
 
-		ExtStringRef beginKey() {
+		ExtStringRef beginKey() const {
 			if (offset == 0) {
 				auto prev = it;
 				prev.decrementNonEnd();
@@ -208,7 +208,7 @@ public:
 			else
 				return ExtStringRef( it->values[ (offset-2)>>1 ].key, offset&1 );
 		}
-		ExtStringRef endKey() {
+		ExtStringRef endKey() const {
 			if (offset == 0)
 				return it->beginKey;
 			else if (offset == it->segments()-1)
@@ -217,7 +217,7 @@ public:
 				return ExtStringRef( it->values[ (offset-1)>>1 ].key, 1-(offset&1) );
 		}
 
-		const KeyValueRef* kv(Arena& arena) { // only if is_kv()
+		const KeyValueRef* kv(Arena& arena) const { // only if is_kv()
 			return &it->values[(offset - 2) >> 1];
 		}
 

--- a/fdbclient/WriteMap.h
+++ b/fdbclient/WriteMap.h
@@ -346,13 +346,17 @@ public:
 		bool is_unreadable() const { return offset ? entry().following_keys_unreadable : entry().is_unreadable; }
 
 		bool is_independent() const {
+			ASSERT(is_operation());
 			return entry().following_keys_cleared || !entry().stack.isDependent();
-		} // Defined if is_operation()
+		}
 
 		ExtStringRef beginKey() const { return ExtStringRef(entry().key, offset && entry().stack.size()); }
 		ExtStringRef endKey() const { return offset ? nextEntry().key : ExtStringRef(entry().key, 1); }
 
-		OperationStack const& op() const { return entry().stack; } // Only if is_operation()
+		OperationStack const& op() const {
+			ASSERT(is_operation());
+			return entry().stack;
+		}
 
 		iterator& operator++() {
 			if (!offset && !equalsKeyAfter( entry().key, nextEntry().key )) {

--- a/fdbclient/WriteMap.h
+++ b/fdbclient/WriteMap.h
@@ -333,25 +333,27 @@ public:
 
 		enum SEGMENT_TYPE { UNMODIFIED_RANGE, CLEARED_RANGE, INDEPENDENT_WRITE, DEPENDENT_WRITE };
 
-		SEGMENT_TYPE type() {
+		SEGMENT_TYPE type() const {
 			if (offset) 
 				return entry().following_keys_cleared ? CLEARED_RANGE : UNMODIFIED_RANGE;
 			else
 				return entry().stack.isDependent() ? DEPENDENT_WRITE : INDEPENDENT_WRITE;
 		}
-		bool is_cleared_range() { return offset && entry().following_keys_cleared; }
-		bool is_unmodified_range() { return offset && !entry().following_keys_cleared; }
-		bool is_operation() { return !offset; }
-		bool is_conflict_range() { return offset ? entry().following_keys_conflict : entry().is_conflict; }
-		bool is_unreadable() { return offset ? entry().following_keys_unreadable : entry().is_unreadable; }
+		bool is_cleared_range() const { return offset && entry().following_keys_cleared; }
+		bool is_unmodified_range() const { return offset && !entry().following_keys_cleared; }
+		bool is_operation() const { return !offset; }
+		bool is_conflict_range() const { return offset ? entry().following_keys_conflict : entry().is_conflict; }
+		bool is_unreadable() const { return offset ? entry().following_keys_unreadable : entry().is_unreadable; }
 
-		bool is_independent() { return entry().following_keys_cleared || !entry().stack.isDependent(); }  // Defined if is_operation()
+		bool is_independent() const {
+			return entry().following_keys_cleared || !entry().stack.isDependent();
+		} // Defined if is_operation()
 
-		ExtStringRef beginKey() { return ExtStringRef( entry().key, offset && entry().stack.size() ); }
-		ExtStringRef endKey() { return offset ? nextEntry().key : ExtStringRef( entry().key, 1 ); }
+		ExtStringRef beginKey() const { return ExtStringRef(entry().key, offset && entry().stack.size()); }
+		ExtStringRef endKey() const { return offset ? nextEntry().key : ExtStringRef(entry().key, 1); }
 
-		OperationStack const& op() { return entry().stack; }  // Only if is_operation()
-		
+		OperationStack const& op() const { return entry().stack; } // Only if is_operation()
+
 		iterator& operator++() {
 			if (!offset && !equalsKeyAfter( entry().key, nextEntry().key )) {
 				offset = true;
@@ -392,8 +394,8 @@ public:
 		friend class WriteMap;
 		void reset( Tree const& tree, Version ver ) { this->tree = tree; this->at = ver; this->finger.clear(); beginLen=endLen=0; offset = false; }
 
-		WriteMapEntry const& entry() { return finger[beginLen-1]->data; }
-		WriteMapEntry const& nextEntry() { return finger[endLen-1]->data; }
+		WriteMapEntry const& entry() const { return finger[beginLen - 1]->data; }
+		WriteMapEntry const& nextEntry() const { return finger[endLen - 1]->data; }
 
 		bool keyAtBegin() { return !offset || !entry().stack.size(); }
 

--- a/fdbserver/IKeyValueStore.h
+++ b/fdbserver/IKeyValueStore.h
@@ -57,7 +57,7 @@ public:
 	virtual std::tuple<size_t, size_t, size_t> getSize() const { return std::make_tuple(0, 0, 0); }
 
 	// Returns the amount of free and total space for this store, in bytes
-	virtual StorageBytes getStorageBytes() = 0;
+	virtual StorageBytes getStorageBytes() const = 0;
 
 	virtual void resyncLog() {}
 

--- a/fdbserver/IKeyValueStore.h
+++ b/fdbserver/IKeyValueStore.h
@@ -37,9 +37,9 @@ public:
 
 class IKeyValueStore : public IClosable {
 public:
-	virtual KeyValueStoreType getType() = 0;
-	virtual void set( KeyValueRef keyValue, const Arena* arena = NULL ) = 0;
-	virtual void clear( KeyRangeRef range, const Arena* arena = NULL ) = 0;
+	virtual KeyValueStoreType getType() const = 0;
+	virtual void set(KeyValueRef keyValue, const Arena* arena = nullptr) = 0;
+	virtual void clear(KeyRangeRef range, const Arena* arena = nullptr) = 0;
 	virtual Future<Void> commit(bool sequential = false) = 0;  // returns when prior sets and clears are (atomically) durable
 
 	virtual Future<Optional<Value>> readValue( KeyRef key, Optional<UID> debugID = Optional<UID>() ) = 0;
@@ -54,7 +54,7 @@ public:
 	// To debug MEMORY_RADIXTREE type ONLY
 	// Returns (1) how many key & value pairs have been inserted (2) how many nodes have been created (3) how many
 	// key size is less than 12 bytes
-	virtual std::tuple<size_t, size_t, size_t> getSize() { return std::make_tuple(0, 0, 0); }
+	virtual std::tuple<size_t, size_t, size_t> getSize() const { return std::make_tuple(0, 0, 0); }
 
 	// Returns the amount of free and total space for this store, in bytes
 	virtual StorageBytes getStorageBytes() = 0;

--- a/fdbserver/IPager.h
+++ b/fdbserver/IPager.h
@@ -85,7 +85,7 @@ public:
 	// Returns the usable size of pages returned by the pager (i.e. the size of the page that isn't pager overhead).
 	// For a given pager instance, separate calls to this function must return the same value.
 	// Only valid to call after recovery is complete.
-	virtual int getUsablePageSize() = 0;
+	virtual int getUsablePageSize() const = 0;
 
 	// Allocate a new page ID for a subsequent write.  The page will be considered in-use after the next commit
 	// regardless of whether or not it was written to.
@@ -131,7 +131,7 @@ public:
 	// Sets the next commit version
 	virtual void setCommitVersion(Version v) = 0;
 
-	virtual StorageBytes getStorageBytes() = 0;
+	virtual StorageBytes getStorageBytes() const = 0;
 
 	// Count of pages in use by the pager client
 	virtual Future<int64_t> getUserPageCount() = 0;
@@ -142,10 +142,10 @@ public:
 	virtual Future<Void> init() = 0;
 
 	// Returns latest committed version
-	virtual Version getLatestVersion() = 0;
+	virtual Version getLatestVersion() const = 0;
 
 	// Returns the oldest readable version as of the most recent committed version
-	virtual Version getOldestVersion() = 0;
+	virtual Version getOldestVersion() const = 0;
 
 	// Sets the oldest readable version to be put into affect at the next commit.
 	// The pager can reuse pages that were freed at a version less than v.

--- a/fdbserver/IVersionedStore.h
+++ b/fdbserver/IVersionedStore.h
@@ -45,9 +45,9 @@ public:
 
 class IVersionedStore : public IClosable {
 public:
-	virtual KeyValueStoreType getType() = 0;
-	virtual bool supportsMutation(int op) = 0; // If this returns true, then mutate(op, ...) may be called
-	virtual StorageBytes getStorageBytes() = 0;
+	virtual KeyValueStoreType getType() const = 0;
+	virtual bool supportsMutation(int op) const = 0; // If this returns true, then mutate(op, ...) may be called
+	virtual StorageBytes getStorageBytes() const = 0;
 
 	// Writes are provided in an ordered stream.
 	// A write is considered part of (a change leading to) the version determined by the previous call to
@@ -58,11 +58,11 @@ public:
 	virtual void mutate(int op, StringRef param1, StringRef param2) = 0;
 	virtual void setWriteVersion(Version) = 0; // The write version must be nondecreasing
 	virtual void setOldestVersion(Version v) = 0; // Set oldest readable version to be used in next commit
-	virtual Version getOldestVersion() = 0; // Get oldest readable version
+	virtual Version getOldestVersion() const = 0; // Get oldest readable version
 	virtual Future<Void> commit() = 0;
 
 	virtual Future<Void> init() = 0;
-	virtual Version getLatestVersion() = 0;
+	virtual Version getLatestVersion() const = 0;
 
 	// readAtVersion() may only be called on a version which has previously been passed to setWriteVersion() and never
 	// previously passed

--- a/fdbserver/KeyValueStoreCompressTestData.actor.cpp
+++ b/fdbserver/KeyValueStoreCompressTestData.actor.cpp
@@ -47,7 +47,7 @@ struct KeyValueStoreCompressTestData : IKeyValueStore {
 	}
 
 	virtual KeyValueStoreType getType() const override { return store->getType(); }
-	virtual StorageBytes getStorageBytes() override { return store->getStorageBytes(); }
+	virtual StorageBytes getStorageBytes() const override { return store->getStorageBytes(); }
 
 	virtual void set(KeyValueRef keyValue, const Arena* arena = nullptr) override {
 		store->set( KeyValueRef( keyValue.key, pack(keyValue.value) ), arena );

--- a/fdbserver/KeyValueStoreCompressTestData.actor.cpp
+++ b/fdbserver/KeyValueStoreCompressTestData.actor.cpp
@@ -35,35 +35,52 @@ struct KeyValueStoreCompressTestData : IKeyValueStore {
 
 	KeyValueStoreCompressTestData(IKeyValueStore* store) : store(store) {}
 
-	virtual Future<Void> getError() { return store->getError(); }
-	virtual Future<Void> onClosed() { return store->onClosed(); }
-	virtual void dispose() { store->dispose(); delete this; }
-	virtual void close() { store->close(); delete this; }
+	virtual Future<Void> getError() override { return store->getError(); }
+	virtual Future<Void> onClosed() override { return store->onClosed(); }
+	virtual void dispose() override {
+		store->dispose();
+		delete this;
+	}
+	virtual void close() override {
+		store->close();
+		delete this;
+	}
 
-	virtual KeyValueStoreType getType() { return store->getType(); }
-	virtual StorageBytes getStorageBytes() { return store->getStorageBytes(); }
+	virtual KeyValueStoreType getType() const override { return store->getType(); }
+	virtual StorageBytes getStorageBytes() override { return store->getStorageBytes(); }
 
-	virtual void set( KeyValueRef keyValue, const Arena* arena = NULL ) {
+	virtual void set(KeyValueRef keyValue, const Arena* arena = nullptr) override {
 		store->set( KeyValueRef( keyValue.key, pack(keyValue.value) ), arena );
 	}
-	virtual void clear( KeyRangeRef range, const Arena* arena = NULL ) { store->clear( range, arena ); }
+	virtual void clear(KeyRangeRef range, const Arena* arena = nullptr) override { store->clear(range, arena); }
 	virtual Future<Void> commit(bool sequential = false) { return store->commit(sequential); }
 
-	virtual Future<Optional<Value>> readValue( KeyRef key, Optional<UID> debugID = Optional<UID>() ) {
+	virtual Future<Optional<Value>> readValue(KeyRef key, Optional<UID> debugID = Optional<UID>()) override {
 		return doReadValue(store, key, debugID);
-	}
-	ACTOR static Future<Optional<Value>> doReadValue( IKeyValueStore* store, Key key, Optional<UID> debugID ) {
-		Optional<Value> v = wait( store->readValue(key, debugID) );
-		if (!v.present()) return v;
-		return unpack(v.get());
 	}
 
 	// Note that readValuePrefix doesn't do anything in this implementation of IKeyValueStore, so the "atomic bomb" problem is still
 	// present if you are using this storage interface, but this storage interface is not used by customers ever. However, if you want
 	// to try to test malicious atomic op workloads with compressed values for some reason, you will need to fix this.
-	virtual Future<Optional<Value>> readValuePrefix( KeyRef key, int maxLength, Optional<UID> debugID = Optional<UID>() ) {
+	virtual Future<Optional<Value>> readValuePrefix(KeyRef key, int maxLength,
+	                                                Optional<UID> debugID = Optional<UID>()) override {
 		return doReadValuePrefix( store, key, maxLength, debugID );
 	}
+
+	// If rowLimit>=0, reads first rows sorted ascending, otherwise reads last rows sorted descending
+	// The total size of the returned value (less the last entry) will be less than byteLimit
+	virtual Future<Standalone<RangeResultRef>> readRange(KeyRangeRef keys, int rowLimit = 1 << 30,
+	                                                     int byteLimit = 1 << 30) override {
+		return doReadRange(store, keys, rowLimit, byteLimit);
+	}
+
+private:
+	ACTOR static Future<Optional<Value>> doReadValue(IKeyValueStore* store, Key key, Optional<UID> debugID) {
+		Optional<Value> v = wait(store->readValue(key, debugID));
+		if (!v.present()) return v;
+		return unpack(v.get());
+	}
+
 	ACTOR static Future<Optional<Value>> doReadValuePrefix( IKeyValueStore* store, Key key, int maxLength, Optional<UID> debugID ) {
 		Optional<Value> v = wait( doReadValue(store, key, debugID) );
 		if (!v.present()) return v;
@@ -74,12 +91,6 @@ struct KeyValueStoreCompressTestData : IKeyValueStore {
 			return v;
 		}
 	}
-
-	// If rowLimit>=0, reads first rows sorted ascending, otherwise reads last rows sorted descending
-	// The total size of the returned value (less the last entry) will be less than byteLimit
-	virtual Future<Standalone<RangeResultRef>> readRange( KeyRangeRef keys, int rowLimit = 1<<30, int byteLimit = 1<<30 ) {
-		return doReadRange(store, keys, rowLimit, byteLimit);
-	}
 	ACTOR Future<Standalone<RangeResultRef>> doReadRange( IKeyValueStore* store, KeyRangeRef keys, int rowLimit, int byteLimit ) {
 		Standalone<RangeResultRef> _vs = wait( store->readRange(keys, rowLimit, byteLimit) );
 		Standalone<RangeResultRef> vs = _vs; // Get rid of implicit const& from wait statement
@@ -89,7 +100,6 @@ struct KeyValueStoreCompressTestData : IKeyValueStore {
 		return vs;
 	}
 
-private:
 	// These implement the actual "compression" scheme
 	static Value pack( Value val ) {
 		if (!val.size()) return val;

--- a/fdbserver/KeyValueStoreMemory.actor.cpp
+++ b/fdbserver/KeyValueStoreMemory.actor.cpp
@@ -65,14 +65,14 @@ public:
 
 	virtual std::tuple<size_t, size_t, size_t> getSize() const override { return data.size(); }
 
-	int64_t getAvailableSize() {
+	int64_t getAvailableSize() const {
 		int64_t residentSize = data.sumTo(data.end()) + queue.totalSize() + // doesn't account for overhead in queue
 		                       transactionSize;
 
 		return memoryLimit - residentSize;
 	}
 
-	virtual StorageBytes getStorageBytes() override {
+	virtual StorageBytes getStorageBytes() const override {
 		StorageBytes diskQueueBytes = log->getStorageBytes();
 
 		// Try to bound how many in-memory bytes we might need to write to disk if we commit() now

--- a/fdbserver/KeyValueStoreRocksDB.actor.cpp
+++ b/fdbserver/KeyValueStoreRocksDB.actor.cpp
@@ -346,9 +346,7 @@ struct RocksDBKeyValueStore : IKeyValueStore {
 		doClose(this, false);
 	}
 
-	KeyValueStoreType getType() override {
-		return KeyValueStoreType(KeyValueStoreType::SSD_ROCKSDB_V1);
-	}
+	KeyValueStoreType getType() const override { return KeyValueStoreType(KeyValueStoreType::SSD_ROCKSDB_V1); }
 
 	Future<Void> init() override {
 		std::unique_ptr<Writer::OpenAction> a(new Writer::OpenAction());
@@ -406,7 +404,7 @@ struct RocksDBKeyValueStore : IKeyValueStore {
 		return res;
 	}
 
-	StorageBytes getStorageBytes() override {
+	StorageBytes getStorageBytes() const override {
 		int64_t free;
 		int64_t total;
 

--- a/fdbserver/KeyValueStoreSQLite.actor.cpp
+++ b/fdbserver/KeyValueStoreSQLite.actor.cpp
@@ -1452,7 +1452,7 @@ public:
 	virtual Future<Void> onClosed() override { return stopped.getFuture(); }
 
 	virtual KeyValueStoreType getType() const override { return type; }
-	virtual StorageBytes getStorageBytes() override;
+	virtual StorageBytes getStorageBytes() const override;
 
 	virtual void set(KeyValueRef keyValue, const Arena* arena = nullptr) override;
 	virtual void clear(KeyRangeRef range, const Arena* arena = nullptr) override;
@@ -1965,7 +1965,7 @@ KeyValueStoreSQLite::~KeyValueStoreSQLite() {
 	//printf("dbf=%lld bytes, wal=%lld bytes\n", getFileSize((filename+".fdb").c_str()), getFileSize((filename+".fdb-wal").c_str()));
 }
 
-StorageBytes KeyValueStoreSQLite::getStorageBytes() {
+StorageBytes KeyValueStoreSQLite::getStorageBytes() const {
 	int64_t free;
 	int64_t total;
 

--- a/fdbserver/KeyValueStoreSQLite.actor.cpp
+++ b/fdbserver/KeyValueStoreSQLite.actor.cpp
@@ -1445,26 +1445,23 @@ struct ThreadSafeCounter {
 
 class KeyValueStoreSQLite : public IKeyValueStore {
 public:
-	virtual void dispose() {
-		doClose(this, true);
-	}
-	virtual void close() {
-		doClose(this, false);
-	}
+	virtual void dispose() override { doClose(this, true); }
+	virtual void close() override { doClose(this, false); }
 
-	virtual Future<Void> getError() { return delayed( readThreads->getError() || writeThread->getError() ); }
-	virtual Future<Void> onClosed() { return stopped.getFuture(); }
+	virtual Future<Void> getError() override { return delayed(readThreads->getError() || writeThread->getError()); }
+	virtual Future<Void> onClosed() override { return stopped.getFuture(); }
 
-	virtual KeyValueStoreType getType() { return type; }
-	virtual StorageBytes getStorageBytes();
+	virtual KeyValueStoreType getType() const override { return type; }
+	virtual StorageBytes getStorageBytes() override;
 
-	virtual void set( KeyValueRef keyValue, const Arena* arena = NULL );
-	virtual void clear( KeyRangeRef range, const Arena* arena = NULL );
-	virtual Future<Void> commit(bool sequential = false);
+	virtual void set(KeyValueRef keyValue, const Arena* arena = nullptr) override;
+	virtual void clear(KeyRangeRef range, const Arena* arena = nullptr) override;
+	virtual Future<Void> commit(bool sequential = false) override;
 
-	virtual Future<Optional<Value>> readValue( KeyRef key, Optional<UID> debugID );
-	virtual Future<Optional<Value>> readValuePrefix( KeyRef key, int maxLength, Optional<UID> debugID );
-	virtual Future<Standalone<RangeResultRef>> readRange( KeyRangeRef keys, int rowLimit = 1<<30, int byteLimit = 1<<30 );
+	virtual Future<Optional<Value>> readValue(KeyRef key, Optional<UID> debugID) override;
+	virtual Future<Optional<Value>> readValuePrefix(KeyRef key, int maxLength, Optional<UID> debugID) override;
+	virtual Future<Standalone<RangeResultRef>> readRange(KeyRangeRef keys, int rowLimit = 1 << 30,
+	                                                     int byteLimit = 1 << 30) override;
 
 	KeyValueStoreSQLite(std::string const& filename, UID logID, KeyValueStoreType type, bool checkChecksums, bool checkIntegrity);
 	~KeyValueStoreSQLite();
@@ -2081,4 +2078,3 @@ ACTOR Future<Void> KVFileCheck(std::string filename, bool integrity) {
 
 	return Void();
 }
-

--- a/fdbserver/StorageMetrics.actor.h
+++ b/fdbserver/StorageMetrics.actor.h
@@ -100,9 +100,6 @@ struct TransientStorageMetricSample : StorageMetricSample {
 
 	TransientStorageMetricSample( int64_t metricUnitsPerSample ) : StorageMetricSample(metricUnitsPerSample) {}
 
-	bool roll( KeyRef key, int64_t metric ) {
-		return deterministicRandom()->random01() < (double)metric / metricUnitsPerSample;	//< SOMEDAY: Better randomInt64?
-	}
 
 	// Returns the sampled metric value (possibly 0, possibly increased by the sampling factor)
 	int64_t addAndExpire( KeyRef key, int64_t metric, double expiration ) {
@@ -164,6 +161,11 @@ struct TransientStorageMetricSample : StorageMetricSample {
 	}
 
 private:
+	bool roll(KeyRef key, int64_t metric) const {
+		return deterministicRandom()->random01() <
+		       (double)metric / metricUnitsPerSample; //< SOMEDAY: Better randomInt64?
+	}
+
 	int64_t add( KeyRef key, int64_t metric ) {
 		if (!metric) return 0;
 		int64_t mag = metric<0 ? -metric : metric;
@@ -195,7 +197,7 @@ struct StorageServerMetrics {
 	    bytesReadSample(SERVER_KNOBS->BYTES_READ_UNITS_PER_SAMPLE) {}
 
 	// Get the current estimated metrics for the given keys
-	StorageMetrics getMetrics( KeyRangeRef const& keys ) {
+	StorageMetrics getMetrics(KeyRangeRef const& keys) const {
 		StorageMetrics result;
 		result.bytes = byteSample.getEstimate( keys );
 		result.bytesPerKSecond = bandwidthSample.getEstimate( keys ) * SERVER_KNOBS->STORAGE_METRICS_AVERAGE_INTERVAL_PER_KSECONDS;
@@ -305,9 +307,9 @@ struct StorageServerMetrics {
 	//static void waitMetrics( StorageServerMetrics* const& self, WaitMetricsRequest const& req );
 
 	// This function can run on untrusted user data.  We must validate all divisions carefully.
-	KeyRef getSplitKey( int64_t remaining, int64_t estimated, int64_t limits, int64_t used, int64_t infinity,
-		bool isLastShard, StorageMetricSample& sample, double divisor, KeyRef const& lastKey, KeyRef const& key, bool hasUsed ) 
-	{	
+	KeyRef getSplitKey(int64_t remaining, int64_t estimated, int64_t limits, int64_t used, int64_t infinity,
+	                   bool isLastShard, const StorageMetricSample& sample, double divisor, KeyRef const& lastKey,
+	                   KeyRef const& key, bool hasUsed) const {
 		ASSERT(remaining >= 0);
 		ASSERT(limits > 0);
 		ASSERT(divisor > 0);
@@ -335,7 +337,7 @@ struct StorageServerMetrics {
 		return key;
 	}
 
-	void splitMetrics( SplitMetricsRequest req ) {
+	void splitMetrics(SplitMetricsRequest req) const {
 		try {
 			SplitMetricsReply reply;
 			KeyRef lastKey = req.keys.begin;
@@ -378,7 +380,8 @@ struct StorageServerMetrics {
 		}
 	}
 
-	void getStorageMetrics( GetStorageMetricsRequest req, StorageBytes sb, double bytesInputRate, int64_t versionLag, double lastUpdate ){
+	void getStorageMetrics(GetStorageMetricsRequest req, StorageBytes sb, double bytesInputRate, int64_t versionLag,
+	                       double lastUpdate) const {
 		GetStorageMetricsReply rep;
 
 		// SOMEDAY: make bytes dynamic with hard disk space
@@ -417,7 +420,7 @@ struct StorageServerMetrics {
 	// readBytes/sizeBytes exceeds the `readDensityRatio`. Please make sure to run unit tests
 	// `StorageMetricsSampleTests.txt` after change made.
 	std::vector<KeyRangeRef> getReadHotRanges(KeyRangeRef shard, double readDensityRatio, int64_t baseChunkSize,
-	                                          int64_t minShardReadBandwidthPerKSeconds) {
+	                                          int64_t minShardReadBandwidthPerKSeconds) const {
 		std::vector<KeyRangeRef> toReturn;
 		double shardSize = (double)byteSample.getEstimate(shard);
 		int64_t shardReadBandwidth = bytesReadSample.getEstimate(shard);
@@ -433,7 +436,7 @@ struct StorageServerMetrics {
 			return toReturn;
 		}
 		KeyRef beginKey = shard.begin;
-		IndexedSet<Key, int64_t>::iterator endKey =
+		auto endKey =
 		    byteSample.sample.index(byteSample.sample.sumTo(byteSample.sample.lower_bound(beginKey)) + baseChunkSize);
 		while (endKey != byteSample.sample.end()) {
 			if (*endKey > shard.end) {
@@ -466,7 +469,7 @@ struct StorageServerMetrics {
 		return toReturn;
 	}
 
-	void getReadHotRanges(ReadHotSubRangeRequest req) {
+	void getReadHotRanges(ReadHotSubRangeRequest req) const {
 		ReadHotSubRangeReply reply;
 		std::vector<KeyRangeRef> v = getReadHotRanges(req.keys, SERVER_KNOBS->SHARD_MAX_READ_DENSITY_RATIO,
 		                                              SERVER_KNOBS->READ_HOT_SUB_RANGE_CHUNK_SIZE,

--- a/fdbserver/VersionedBTree.actor.cpp
+++ b/fdbserver/VersionedBTree.actor.cpp
@@ -2983,9 +2983,9 @@ public:
 		return m_pager->getLatestVersion();
 	}
 
-	Version getWriteVersion() override { return m_writeVersion; }
+	Version getWriteVersion() const { return m_writeVersion; }
 
-	Version getLastCommittedVersion() override { return m_lastCommittedVersion; }
+	Version getLastCommittedVersion() const { return m_lastCommittedVersion; }
 
 	VersionedBTree(IPager2* pager, std::string name)
 	  : m_pager(pager), m_writeVersion(invalidVersion), m_lastCommittedVersion(invalidVersion), m_pBuffer(nullptr),

--- a/fdbserver/VersionedBTree.actor.cpp
+++ b/fdbserver/VersionedBTree.actor.cpp
@@ -5492,7 +5492,7 @@ public:
 
 	KeyValueStoreType getType() const override { return KeyValueStoreType::SSD_REDWOOD_V1; }
 
-	StorageBytes getStorageBytes() override { return m_tree->getStorageBytes(); }
+	StorageBytes getStorageBytes() const override { return m_tree->getStorageBytes(); }
 
 	Future<Void> getError() { return delayed(m_error.getFuture()); };
 

--- a/flow/IKeyValueContainer.h
+++ b/flow/IKeyValueContainer.h
@@ -109,7 +109,7 @@ public:
 	uint64_t sumTo(const_iterator to) const { return data.sumTo(to); }
 	uint64_t sumTo(iterator to) const { return data.sumTo(const_iterator{ to }); }
 
-	static int getElementBytes() { return IndexedSet<KeyValueMapPair, uint64_t>::getElementBytes(); }
+	static constexpr int getElementBytes() { return IndexedSet<KeyValueMapPair, uint64_t>::getElementBytes(); }
 
 private:
 	IKeyValueContainer(IKeyValueContainer const&); // unimplemented

--- a/flow/IndexedSet.h
+++ b/flow/IndexedSet.h
@@ -298,7 +298,7 @@ public:
 	}
 
 	// Return the amount of memory used by an entry in the IndexedSet
-	static int getElementBytes() { return sizeof(Node); }
+	constexpr static int getElementBytes() { return sizeof(Node); }
 
 private:
 	// Copy operations unimplemented.  SOMEDAY: Implement and make public.

--- a/flow/MetricSample.h
+++ b/flow/MetricSample.h
@@ -31,13 +31,13 @@ struct MetricSample {
 	
 	explicit MetricSample(int64_t metricUnitsPerSample) : metricUnitsPerSample(metricUnitsPerSample) {}
 
-	int64_t getMetric(const T& Key) {
+	int64_t getMetric(const T& Key) const {
 		auto i = sample.find(Key);
 		if (i == sample.end())
 			return 0;
 		else
 			return sample.getMetric(i);
-	}	
+	}
 };
 
 template <class T>
@@ -45,10 +45,6 @@ struct TransientMetricSample : MetricSample<T> {
 	Deque< std::tuple<double, T, int64_t> > queue;
 
 	explicit TransientMetricSample(int64_t metricUnitsPerSample) : MetricSample<T>(metricUnitsPerSample) { }
-
-	bool roll(int64_t metric) {
-		return nondeterministicRandom()->random01() < (double)metric / this->metricUnitsPerSample;	//< SOMEDAY: Better randomInt64?
-	}
 
 	// Returns the sampled metric value (possibly 0, possibly increased by the sampling factor)
 	int64_t addAndExpire(const T& key, int64_t metric, double expiration) {
@@ -75,6 +71,11 @@ struct TransientMetricSample : MetricSample<T> {
 	}
 
 private:
+	bool roll(int64_t metric) const {
+		return nondeterministicRandom()->random01() <
+		       (double)metric / this->metricUnitsPerSample; //< SOMEDAY: Better randomInt64?
+	}
+
 	int64_t add(const T& key, int64_t metric) {
 		if (!metric) return 0;
 		int64_t mag = std::abs(metric);
@@ -101,12 +102,8 @@ struct TransientThresholdMetricSample : MetricSample<T> {
 
 	TransientThresholdMetricSample(int64_t metricUnitsPerSample, int64_t threshold) : MetricSample<T>(metricUnitsPerSample), thresholdLimit(threshold) { }
 
-	bool roll(int64_t metric) {
-		return nondeterministicRandom()->random01() < (double)metric / this->metricUnitsPerSample;	//< SOMEDAY: Better randomInt64?
-	}
-
 	template <class U>
-	bool isAboveThreshold(const U& key) {
+	bool isAboveThreshold(const U& key) const {
 		auto i = thresholdCrossedSet.find(key);
 		if (i == thresholdCrossedSet.end())
 			return false;
@@ -146,6 +143,11 @@ struct TransientThresholdMetricSample : MetricSample<T> {
 	}
 
 private:
+	bool roll(int64_t metric) const {
+		return nondeterministicRandom()->random01() <
+		       (double)metric / this->metricUnitsPerSample; //< SOMEDAY: Better randomInt64?
+	}
+
 	template <class T_>
 	int64_t add(T_&& key, int64_t metric) {
 		if (!metric) return 0;

--- a/flow/RadixTree.h
+++ b/flow/RadixTree.h
@@ -296,7 +296,7 @@ public:
 	// iterators
 	iterator find(const StringRef& key);
 	iterator begin();
-    iterator end();
+	iterator end() const;
 	iterator previous(iterator i);
 	// modifications
 	std::pair<iterator, bool> insert(const StringRef& key, const StringRef& val, bool replaceExisting = true);
@@ -311,7 +311,7 @@ public:
 	iterator lower_bound(const StringRef& key);
 	iterator upper_bound(const StringRef& key);
 	// access
-	uint64_t sumTo(iterator to);
+	uint64_t sumTo(iterator to) const;
 
 private:
     size_type m_size;
@@ -584,7 +584,7 @@ StringRef radix_tree::iterator::getKey(uint8_t* content) const {
 	return StringRef(content, (m_pointee->m_depth + m_pointee->getKeySize()));
 }
 
-radix_tree::iterator radix_tree::end() {
+radix_tree::iterator radix_tree::end() const {
 	return iterator(NULL);
 }
 
@@ -717,7 +717,7 @@ radix_tree::iterator radix_tree::upper_bound(const StringRef& key, node* node) {
 }
 
 // Return the sum of getT(x) for begin()<=x<to
-uint64_t radix_tree::sumTo(iterator to) {
+uint64_t radix_tree::sumTo(iterator to) const {
 	if(to == end()) {
         return m_root ? total_bytes : 0;
     }

--- a/flow/RadixTree.h
+++ b/flow/RadixTree.h
@@ -257,7 +257,9 @@ public:
 	radix_tree(const radix_tree& other) = delete; // delete
 	radix_tree& operator=(const radix_tree other) = delete; // delete
 
-	inline std::tuple<size_type, size_type, size_type> size() { return std::make_tuple(m_size, m_node, inline_keys); }
+	inline std::tuple<size_type, size_type, size_type> size() const {
+		return std::make_tuple(m_size, m_node, inline_keys);
+	}
 
 	// Return the amount of memory used by an entry in the RadixTree
 	static int getElementBytes(node* node) {


### PR DESCRIPTION
Using the recently added IndexedSet::const_iterator (#3185), we can improve the const-correctness of many functions. In this PR const is added in some places where applicable. Also, wherever I came across the following while adding const, I made additional changes:

- virtual function overrides are marked as override
- NULL is replaced with nullptr
- git clang-format is applied