### PR TITLE
Fix: correctness packages included removed/future tests

### DIFF
--- a/cmake/AddFdbTest.cmake
+++ b/cmake/AddFdbTest.cmake
@@ -237,7 +237,9 @@ function(create_correctness_package)
                                      ${out_dir}/joshua_test
     COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_SOURCE_DIR}/contrib/Joshua/scripts/correctnessTimeout.sh
                                      ${out_dir}/joshua_timeout
-    COMMAND ${CMAKE_COMMAND} -E tar cfz ${tar_file} *
+    COMMAND ${CMAKE_COMMAND} -E tar cfz ${tar_file} ${package_files}
+                                                    ${out_dir}/joshua_test
+                                                    ${out_dir}/joshua_timeout
     WORKING_DIRECTORY ${out_dir}
     COMMENT "Package correctness archive"
     )
@@ -262,7 +264,9 @@ function(create_valgrind_correctness_package)
                                        ${out_dir}/joshua_test
       COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_SOURCE_DIR}/contrib/Joshua/scripts/valgrindTimeout.sh
                                        ${out_dir}/joshua_timeout
-      COMMAND ${CMAKE_COMMAND} -E tar cfz ${tar_file} *
+      COMMAND ${CMAKE_COMMAND} -E tar cfz ${tar_file} ${package_files}
+                                                      ${out_dir}/joshua_test
+                                                      ${out_dir}/joshua_timeout
       WORKING_DIRECTORY ${out_dir}
       COMMENT "Package valgrind correctness archive"
       )


### PR DESCRIPTION
As part of the changes in #3218, the correctness and valgrind correctness packages would copy the test files to another directory and pack up the entire thing. Existing tests in that directory are not removed, so if a test gets deleted or if you go back in time and build an old version that's missing a newer test, you might include extra test files.

This change makes it so the package built specifically lists all the files to be included, meaning that any random extra files will still persist in the folder but be excluded from the package.