### PR TITLE
Tweak glibc malloc settings so we can have TLS threadpools without ex…

### DIFF
--- a/fdbserver/Knobs.cpp
+++ b/fdbserver/Knobs.cpp
@@ -445,6 +445,7 @@ void ServerKnobs::initialize(bool randomize, ClientKnobs* clientKnobs, bool isSi
 	init( MAX_REBOOT_TIME,                                       5.0 ); if( longReboots ) MAX_REBOOT_TIME = 20.0;
 	init( LOG_DIRECTORY,                                          ".");  // Will be set to the command line flag.
 	init( SERVER_MEM_LIMIT,                                8LL << 30 );
+	init( SERVER_MALLOC_ARENA_MAX,                                  6); // If set too high, we waste a lot of virtual memory.  If set too low, then threads will contend on a mutex inside malloc (glibc malloc only)
 
 	//Ratekeeper
 	bool slowRatekeeper = randomize && BUGGIFY;

--- a/fdbserver/Knobs.h
+++ b/fdbserver/Knobs.h
@@ -371,6 +371,7 @@ public:
 	double MAX_REBOOT_TIME;
 	std::string LOG_DIRECTORY;
 	int64_t SERVER_MEM_LIMIT;
+	int SERVER_MALLOC_ARENA_MAX; // This only has an effect on systms that use glibc malloc.
 
 	//Ratekeeper
 	double SMOOTHING_AMOUNT;

--- a/fdbserver/fdbserver.actor.cpp
+++ b/fdbserver/fdbserver.actor.cpp
@@ -1599,6 +1599,11 @@ int main(int argc, char* argv[]) {
 			flushAndExit(FDB_EXIT_ERROR);
 		}
 
+#if defined(__linux__) // is there a better way to detect glibc malloc?
+		// need to do this before we start spawning threads, so before we start running flow actors.
+		mallopt(M_ARENA_MAX, SERVER_KNOBS->SERVER_MALLOC_ARENA_MAX);
+#endif
+
 		if (role == SkipListTest) {
 			skipListTest();
 			flushAndExit(FDB_EXIT_SUCCESS);


### PR DESCRIPTION
…hausting virtual memory.  We set MALLOC_ARENA_MAX to a low value, which will cause malloc mutex contention during TLS connection storms, but should not cause contention during normal forward operation