### PR TITLE
Expose health metrics via special keys

### DIFF
--- a/documentation/sphinx/source/developer-guide.rst
+++ b/documentation/sphinx/source/developer-guide.rst
@@ -868,6 +868,56 @@ A user can see stats about data distribution like so::
   ('\xff\xff/metrics/data_distribution_stats/mako083', '{"ShardBytes":297000}')
   ('\xff\xff/metrics/data_distribution_stats/mako0909', '{"ShardBytes":741000}')
 
+Keys starting with ``\xff\xff/metrics/health/`` represent stats about the health of the cluster, suitable for use for application-level throttling.
+Some of this information is also available through ``\xff\xff/status/json``,
+but the ``\xff\xff/metrics/health/`` keys are much cheaper to read and may
+return data a few seconds old.
+
+  >>> for k, v in db.get_range_startswith('\xff\xff/metrics/health/'):
+  ...     print(k, v)
+  ...
+  ('\xff\xff/metrics/health/aggregate', '{"batchLimited":false,"tpsLimit":483988.66315011407,"worstStorageDurabilityLag":5000001,"worstStorageQueue":2036,"worstTLogQueue":300}')
+  ('\xff\xff/metrics/health/log/e639a9ad0373367784cc550c615c469b', '{"tLogQueue":300}')
+  ('\xff\xff/metrics/health/storage/ab2ce4caf743c9c1ae57063629c6678a', '{"cpuUsage":2.398696781487125,"diskUsage":0.059995917598039405,"storageDurabilityLag":5000001,"storageQueue":2036}')
+
+``\xff\xff/metrics/health/aggregate``
+
+Aggregate stats about cluster health. Reading this key alone is slightly cheaper than reading any of the per-process keys.
+
+========================= ======== ===============
+**Field**                 **Type** **Description**
+------------------------- -------- ---------------
+batchLimited              boolean  Whether or not the cluster is limiting batch priority transactions
+tpsLimit                  number   The rate at which normal priority transactions are allowed to start
+worstStorageDurabilityLag number   See the description for storageDurabilityLag
+worstStorageQueue         number   See the description for storageQueue
+worstTLogQueue            number   See the description for tLogQueue
+========================= ======== ===============
+
+``\xff\xff/metrics/health/log/<id>``
+
+Stats about the health of a particular transaction log
+
+========================= ======== ===============
+**Field**                 **Type** **Description**
+------------------------- -------- ---------------
+tLogQueue                 number   The number of bytes of mutations that need to be stored in memory on this transaction log process
+========================= ======== ===============
+
+``\xff\xff/metrics/health/storage/<id>``
+
+Stats about the health of a particular transaction log
+
+========================= ======== ===============
+**Field**                 **Type** **Description**
+------------------------- -------- ---------------
+cpuUsage                  number   The cpu percentage used by this storage process
+diskUsage                 number   The disk IO percentage used by this storage process
+storageDurabilityLag      number   The difference between the newest version and the durable version on this storage process. On a lightly loaded cluster this will stay just above 5000000.
+storageQueue              number   The number of bytes of mutations that need to be stored in memory on this storage process
+========================= ======== ===============
+
+
 Performance considerations
 ==========================
 

--- a/documentation/sphinx/source/developer-guide.rst
+++ b/documentation/sphinx/source/developer-guide.rst
@@ -850,14 +850,14 @@ Reads in the metrics module are not transactional and may require rpcs to comple
   >>> for k, v in db.get_range_startswith('\xff\xff/metrics/data_distribution_stats/', limit=3):
   ...     print(k, v)
   ...
-  ('\xff\xff/metrics/data_distribution_stats/', '{"ShardBytes":3828000}')
-  ('\xff\xff/metrics/data_distribution_stats/mako00079', '{"ShardBytes":2013000}')
-  ('\xff\xff/metrics/data_distribution_stats/mako00126', '{"ShardBytes":3201000}')
+  ('\xff\xff/metrics/data_distribution_stats/', '{"shard_bytes":3828000}')
+  ('\xff\xff/metrics/data_distribution_stats/mako00079', '{"shard_bytes":2013000}')
+  ('\xff\xff/metrics/data_distribution_stats/mako00126', '{"shard_bytes":3201000}')
 
 ========================= ======== ===============
 **Field**                 **Type** **Description**
 ------------------------- -------- ---------------
-ShardBytes                number   An estimate of the sum of kv sizes for this shard.
+shard_bytes               number   An estimate of the sum of kv sizes for this shard.
 ========================= ======== ===============
 
 Keys starting with ``\xff\xff/metrics/health/`` represent stats about the health of the cluster, suitable for application-level throttling.
@@ -866,23 +866,23 @@ Some of this information is also available in ``\xff\xff/status/json``, but thes
   >>> for k, v in db.get_range_startswith('\xff\xff/metrics/health/'):
   ...     print(k, v)
   ...
-  ('\xff\xff/metrics/health/aggregate', '{"batchLimited":false,"tpsLimit":483988.66315011407,"worstStorageDurabilityLag":5000001,"worstStorageQueue":2036,"worstTLogQueue":300}')
-  ('\xff\xff/metrics/health/log/e639a9ad0373367784cc550c615c469b', '{"tLogQueue":300}')
-  ('\xff\xff/metrics/health/storage/ab2ce4caf743c9c1ae57063629c6678a', '{"cpuUsage":2.398696781487125,"diskUsage":0.059995917598039405,"storageDurabilityLag":5000001,"storageQueue":2036}')
+  ('\xff\xff/metrics/health/aggregate', '{"batch_limited":false,"tps_limit":483988.66315011407,"worst_storage_durability_lag":5000001,"worst_storage_queue":2036,"worst_log_queue":300}')
+  ('\xff\xff/metrics/health/log/e639a9ad0373367784cc550c615c469b', '{"log_queue":300}')
+  ('\xff\xff/metrics/health/storage/ab2ce4caf743c9c1ae57063629c6678a', '{"cpu_usage":2.398696781487125,"disk_usage":0.059995917598039405,"storage_durability_lag":5000001,"storage_queue":2036}')
 
 ``\xff\xff/metrics/health/aggregate``
 
 Aggregate stats about cluster health. Reading this key alone is slightly cheaper than reading any of the per-process keys.
 
-========================= ======== ===============
-**Field**                 **Type** **Description**
-------------------------- -------- ---------------
-batchLimited              boolean  Whether or not the cluster is limiting batch priority transactions
-tpsLimit                  number   The rate at which normal priority transactions are allowed to start
-worstStorageDurabilityLag number   See the description for storageDurabilityLag
-worstStorageQueue         number   See the description for storageQueue
-worstTLogQueue            number   See the description for tLogQueue
-========================= ======== ===============
+============================ ======== ===============
+**Field**                    **Type** **Description**
+---------------------------- -------- ---------------
+batch_limited                boolean  Whether or not the cluster is limiting batch priority transactions
+tps_limit                    number   The rate at which normal priority transactions are allowed to start
+worst_storage_durability_lag number   See the description for storage_durability_lag
+worst_storage_queue          number   See the description for storage_queue
+worst_log_queue              number   See the description for log_queue
+============================ ======== ===============
 
 ``\xff\xff/metrics/health/log/<id>``
 
@@ -891,21 +891,21 @@ Stats about the health of a particular transaction log process
 ========================= ======== ===============
 **Field**                 **Type** **Description**
 ------------------------- -------- ---------------
-tLogQueue                 number   The number of bytes of mutations that need to be stored in memory on this transaction log process
+log_queue                 number   The number of bytes of mutations that need to be stored in memory on this transaction log process
 ========================= ======== ===============
 
 ``\xff\xff/metrics/health/storage/<id>``
 
 Stats about the health of a particular storage process
 
-========================= ======== ===============
-**Field**                 **Type** **Description**
-------------------------- -------- ---------------
-cpuUsage                  number   The cpu percentage used by this storage process
-diskUsage                 number   The disk IO percentage used by this storage process
-storageDurabilityLag      number   The difference between the newest version and the durable version on this storage process. On a lightly loaded cluster this will stay just above 5000000.
-storageQueue              number   The number of bytes of mutations that need to be stored in memory on this storage process
-========================= ======== ===============
+========================== ======== ===============
+**Field**                  **Type** **Description**
+-------------------------- -------- ---------------
+cpu_usage                  number   The cpu percentage used by this storage process
+disk_usage                 number   The disk IO percentage used by this storage process
+storage_durability_lag     number   The difference between the newest version and the durable version on this storage process. On a lightly loaded cluster this will stay just above 5000000.
+storage_queue              number   The number of bytes of mutations that need to be stored in memory on this storage process
+========================== ======== ===============
 
 Caveats
 ~~~~~~~

--- a/documentation/sphinx/source/developer-guide.rst
+++ b/documentation/sphinx/source/developer-guide.rst
@@ -896,7 +896,7 @@ worstTLogQueue            number   See the description for tLogQueue
 
 ``\xff\xff/metrics/health/log/<id>``
 
-Stats about the health of a particular transaction log
+Stats about the health of a particular transaction log process
 
 ========================= ======== ===============
 **Field**                 **Type** **Description**
@@ -906,7 +906,7 @@ tLogQueue                 number   The number of bytes of mutations that need to
 
 ``\xff\xff/metrics/health/storage/<id>``
 
-Stats about the health of a particular transaction log
+Stats about the health of a particular storage process
 
 ========================= ======== ===============
 **Field**                 **Type** **Description**

--- a/documentation/sphinx/source/developer-guide.rst
+++ b/documentation/sphinx/source/developer-guide.rst
@@ -850,15 +850,14 @@ Reads in the metrics module are not transactional and may require rpcs to comple
   >>> for k, v in db.get_range_startswith('\xff\xff/metrics/data_distribution_stats/', limit=3):
   ...     print(k, v)
   ...
-  ('\xff\xff/metrics/data_distribution_stats/', '{"ShardBytes":3828000,"Storages":["697f39751849d70067eabd1b079478a5"]}')
-  ('\xff\xff/metrics/data_distribution_stats/mako00079', '{"ShardBytes":2013000,"Storages":["697f39751849d70067eabd1b079478a5"]}')
-  ('\xff\xff/metrics/data_distribution_stats/mako00126', '{"ShardBytes":3201000,"Storages":["697f39751849d70067eabd1b079478a5"]}')
+  ('\xff\xff/metrics/data_distribution_stats/', '{"ShardBytes":3828000}')
+  ('\xff\xff/metrics/data_distribution_stats/mako00079', '{"ShardBytes":2013000}')
+  ('\xff\xff/metrics/data_distribution_stats/mako00126', '{"ShardBytes":3201000}')
 
 ========================= ======== ===============
 **Field**                 **Type** **Description**
 ------------------------- -------- ---------------
 ShardBytes                number   An estimate of the sum of kv sizes for this shard.
-Storages                  [string] A list of the storage process ids currently responsible for this shard.
 ========================= ======== ===============
 
 Keys starting with ``\xff\xff/metrics/health/`` represent stats about the health of the cluster, suitable for application-level throttling.

--- a/documentation/sphinx/source/developer-guide.rst
+++ b/documentation/sphinx/source/developer-guide.rst
@@ -845,30 +845,21 @@ Metrics module
 
 Reads in the metrics module are not transactional and may require rpcs to complete.
 
-The key ``\xff\xff/metrics/data_distribution_stats/<begin>`` represent stats about the shard that begins at ``<begin>``. The value is a json object with a "ShardBytes" field. More fields may be added in the future.
+``\xff\xff/metrics/data_distribution_stats/<begin>`` represent stats about the shard that begins at ``<begin>``
 
-A user can see stats about data distribution like so::
-
-TODO update with "Storages" field, add table with schema like in health keys, and document caveats. ShardBytes is an estimate.
-
-  >>> for k, v in db.get_range_startswith('\xff\xff/metrics/data_distribution_stats/'):
+  >>> for k, v in db.get_range_startswith('\xff\xff/metrics/data_distribution_stats/', limit=3):
   ...     print(k, v)
   ...
-  ('\xff\xff/metrics/data_distribution_stats/', '{"ShardBytes":330000}')
-  ('\xff\xff/metrics/data_distribution_stats/mako00509', '{"ShardBytes":330000}')
-  ('\xff\xff/metrics/data_distribution_stats/mako0099', '{"ShardBytes":330000}')
-  ('\xff\xff/metrics/data_distribution_stats/mako01468', '{"ShardBytes":297000}')
-  ('\xff\xff/metrics/data_distribution_stats/mako023', '{"ShardBytes":264000}')
-  ('\xff\xff/metrics/data_distribution_stats/mako0289', '{"ShardBytes":297000}')
-  ('\xff\xff/metrics/data_distribution_stats/mako037', '{"ShardBytes":330000}')
-  ('\xff\xff/metrics/data_distribution_stats/mako042', '{"ShardBytes":264000}')
-  ('\xff\xff/metrics/data_distribution_stats/mako0457', '{"ShardBytes":297000}')
-  ('\xff\xff/metrics/data_distribution_stats/mako0524', '{"ShardBytes":264000}')
-  ('\xff\xff/metrics/data_distribution_stats/mako058', '{"ShardBytes":297000}')
-  ('\xff\xff/metrics/data_distribution_stats/mako064', '{"ShardBytes":297000}')
-  ('\xff\xff/metrics/data_distribution_stats/mako0718', '{"ShardBytes":264000}')
-  ('\xff\xff/metrics/data_distribution_stats/mako083', '{"ShardBytes":297000}')
-  ('\xff\xff/metrics/data_distribution_stats/mako0909', '{"ShardBytes":741000}')
+  ('\xff\xff/metrics/data_distribution_stats/', '{"ShardBytes":3828000,"Storages":["697f39751849d70067eabd1b079478a5"]}')
+  ('\xff\xff/metrics/data_distribution_stats/mako00079', '{"ShardBytes":2013000,"Storages":["697f39751849d70067eabd1b079478a5"]}')
+  ('\xff\xff/metrics/data_distribution_stats/mako00126', '{"ShardBytes":3201000,"Storages":["697f39751849d70067eabd1b079478a5"]}')
+
+========================= ======== ===============
+**Field**                 **Type** **Description**
+------------------------- -------- ---------------
+ShardBytes                number   An estimate of the sum of kv sizes for this shard.
+Storages                  [string] A list of the storage process ids currently responsible for this shard.
+========================= ======== ===============
 
 Keys starting with ``\xff\xff/metrics/health/`` represent stats about the health of the cluster, suitable for application-level throttling.
 Some of this information is also available in ``\xff\xff/status/json``, but these keys are significantly cheaper (in terms of server resources) to read.
@@ -920,7 +911,7 @@ storageQueue              number   The number of bytes of mutations that need to
 Caveats
 ~~~~~~~
 
-#. ``\xff\xff/metrics/health/`` These keys may return data that's several seconds old, and the data may not be available for a brief period during recovery. This will be indicated by the keys briefly not being present when read. Clients should be prepared for these keys to be absent.
+#. ``\xff\xff/metrics/health/`` These keys may return data that's several seconds old, and the data may not be available for a brief period during recovery. This will be indicated by the keys being absent.
 
 Performance considerations
 ==========================

--- a/documentation/sphinx/source/developer-guide.rst
+++ b/documentation/sphinx/source/developer-guide.rst
@@ -849,6 +849,8 @@ The key ``\xff\xff/metrics/data_distribution_stats/<begin>`` represent stats abo
 
 A user can see stats about data distribution like so::
 
+TODO update with "Storages" field, add table with schema like in health keys, and document caveats. ShardBytes is an estimate.
+
   >>> for k, v in db.get_range_startswith('\xff\xff/metrics/data_distribution_stats/'):
   ...     print(k, v)
   ...
@@ -868,10 +870,8 @@ A user can see stats about data distribution like so::
   ('\xff\xff/metrics/data_distribution_stats/mako083', '{"ShardBytes":297000}')
   ('\xff\xff/metrics/data_distribution_stats/mako0909', '{"ShardBytes":741000}')
 
-Keys starting with ``\xff\xff/metrics/health/`` represent stats about the health of the cluster, suitable for use for application-level throttling.
-Some of this information is also available through ``\xff\xff/status/json``,
-but the ``\xff\xff/metrics/health/`` keys are much cheaper to read and may
-return data a few seconds old.
+Keys starting with ``\xff\xff/metrics/health/`` represent stats about the health of the cluster, suitable for application-level throttling.
+Some of this information is also available in ``\xff\xff/status/json``, but these keys are significantly cheaper (in terms of server resources) to read.
 
   >>> for k, v in db.get_range_startswith('\xff\xff/metrics/health/'):
   ...     print(k, v)
@@ -917,6 +917,10 @@ storageDurabilityLag      number   The difference between the newest version and
 storageQueue              number   The number of bytes of mutations that need to be stored in memory on this storage process
 ========================= ======== ===============
 
+Caveats
+~~~~~~~
+
+#. ``\xff\xff/metrics/health/`` These keys may return data that's several seconds old, and the data may not be available for a brief period during recovery. This will be indicated by the keys briefly not being present when read. Clients should be prepared for these keys to be absent.
 
 Performance considerations
 ==========================

--- a/documentation/sphinx/source/developer-guide.rst
+++ b/documentation/sphinx/source/developer-guide.rst
@@ -903,7 +903,7 @@ Stats about the health of a particular storage process
 -------------------------- -------- ---------------
 cpu_usage                  number   The cpu percentage used by this storage process
 disk_usage                 number   The disk IO percentage used by this storage process
-storage_durability_lag     number   The difference between the newest version and the durable version on this storage process. On a lightly loaded cluster this will stay just above 5000000.
+storage_durability_lag     number   The difference between the newest version and the durable version on this storage process. On a lightly loaded cluster this will stay just above 5000000 [#max_read_transaction_life_versions]_.
 storage_queue              number   The number of bytes of mutations that need to be stored in memory on this storage process
 ========================== ======== ===============
 
@@ -1113,3 +1113,4 @@ If you see one of those errors, the best way of action is to fail the client.
 At a first glance this looks very similar to an ``commit_unknown_result``. However, these errors lack the one guarantee ``commit_unknown_result`` still gives to the user: if the commit has already been sent to the database, the transaction could get committed at a later point in time. This means that if you retry the transaction, your new transaction might race with the old transaction. While this technically doesn't violate any consistency guarantees, abandoning a transaction means that there are no causality guaranatees.
 
 .. [#conflicting_keys] In practice, the transaction probably committed successfully. However, if you're running multiple resolvers then it's possible for a transaction to cause another to abort even if it doesn't commit successfully.
+.. [#max_read_transaction_life_versions] The number 5000000 comes from the server knob MAX_READ_TRANSACTION_LIFE_VERSIONS

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -514,10 +514,11 @@ public:
 };
 
 ACTOR Future<Standalone<RangeResultRef>> ddMetricsGetRangeActor(ReadYourWritesTransaction* ryw, KeyRangeRef kr) {
-	auto keys = kr.removePrefix(ddStatsRange.begin);
+	state KeyRangeRef keys = kr.removePrefix(ddStatsRange.begin);
 	state Standalone<VectorRef<DDMetricsRef>> resultWithoutPrefix =
 	    wait(waitDataDistributionMetricsList(ryw->getDatabase(), keys, CLIENT_KNOBS->STORAGE_METRICS_SHARD_LIMIT));
 	state Standalone<RangeResultRef> result;
+	ryw->getDatabase()->invalidateCache(keys);
 	for (const auto& ddMetricsRef_ : resultWithoutPrefix) {
 		state DDMetricsRef ddMetricsRef = ddMetricsRef_;
 		// each begin key is the previous end key, thus we only encode the begin key in the result

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -557,11 +557,11 @@ static Standalone<RangeResultRef> healthMetricsToKVPairs(const HealthMetrics& me
 	if (CLIENT_BUGGIFY) return result;
 	if (kr.contains(LiteralStringRef("\xff\xff/metrics/health/aggregate")) && metrics.worstStorageDurabilityLag != 0) {
 		json_spirit::mObject statsObj;
-		statsObj["batchLimited"] = metrics.batchLimited;
-		statsObj["tpsLimit"] = metrics.tpsLimit;
-		statsObj["worstStorageDurabilityLag"] = metrics.worstStorageDurabilityLag;
-		statsObj["worstStorageQueue"] = metrics.worstStorageQueue;
-		statsObj["worstTLogQueue"] = metrics.worstTLogQueue;
+		statsObj["batch_limited"] = metrics.batchLimited;
+		statsObj["tps_limit"] = metrics.tpsLimit;
+		statsObj["worst_storage_durability_lag"] = metrics.worstStorageDurabilityLag;
+		statsObj["worst_storage_queue"] = metrics.worstStorageQueue;
+		statsObj["worst_log_queue"] = metrics.worstTLogQueue;
 		std::string statsString =
 		    json_spirit::write_string(json_spirit::mValue(statsObj), json_spirit::Output_options::raw_utf8);
 		ValueRef bytes(result.arena(), statsString);
@@ -580,7 +580,7 @@ static Standalone<RangeResultRef> healthMetricsToKVPairs(const HealthMetrics& me
 			if (phase == 1) {
 				if (k < kr.end) {
 					json_spirit::mObject statsObj;
-					statsObj["tLogQueue"] = logStats;
+					statsObj["log_queue"] = logStats;
 					std::string statsString =
 					    json_spirit::write_string(json_spirit::mValue(statsObj), json_spirit::Output_options::raw_utf8);
 					ValueRef bytes(result.arena(), statsString);
@@ -603,10 +603,10 @@ static Standalone<RangeResultRef> healthMetricsToKVPairs(const HealthMetrics& me
 			if (phase == 1) {
 				if (k < kr.end) {
 					json_spirit::mObject statsObj;
-					statsObj["storageDurabilityLag"] = storageStats.storageDurabilityLag;
-					statsObj["storageQueue"] = storageStats.storageQueue;
-					statsObj["cpuUsage"] = storageStats.cpuUsage;
-					statsObj["diskUsage"] = storageStats.diskUsage;
+					statsObj["storage_durability_lag"] = storageStats.storageDurabilityLag;
+					statsObj["storage_queue"] = storageStats.storageQueue;
+					statsObj["cpu_usage"] = storageStats.cpuUsage;
+					statsObj["disk_usage"] = storageStats.diskUsage;
 					std::string statsString =
 					    json_spirit::write_string(json_spirit::mValue(statsObj), json_spirit::Output_options::raw_utf8);
 					ValueRef bytes(result.arena(), statsString);
@@ -1458,9 +1458,7 @@ ACTOR Future< pair<KeyRange,Reference<LocationInfo>> > getKeyLocation_internal( 
 }
 
 template <class F>
-Future<pair<KeyRange, Reference<LocationInfo>>> getKeyLocation(Database const& cx, Key const& key,
-                                                               F StorageServerInterface::*member,
-                                                               TransactionInfo const& info, bool isBackward = false) {
+Future<pair<KeyRange, Reference<LocationInfo>>> getKeyLocation( Database const& cx, Key const& key, F StorageServerInterface::*member, TransactionInfo const& info, bool isBackward = false ) {
 	auto ssi = cx->getCachedLocation( key, isBackward );
 	if (!ssi.second) {
 		return getKeyLocation_internal( cx, key, info, isBackward );

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -596,7 +596,7 @@ public:
 
 static Standalone<RangeResultRef> healthMetricsToKVPairs(const HealthMetrics& metrics, KeyRangeRef kr) {
 	Standalone<RangeResultRef> result;
-	if (kr.contains(LiteralStringRef("\xff\xff/metrics/health/aggregate"))) {
+	if (kr.contains(LiteralStringRef("\xff\xff/metrics/health/aggregate")) && metrics.worstStorageDurabilityLag != 0) {
 		json_spirit::mObject statsObj;
 		statsObj["batchLimited"] = metrics.batchLimited;
 		statsObj["tpsLimit"] = metrics.tpsLimit;

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -502,54 +502,7 @@ void DatabaseContext::registerSpecialKeySpaceModule(SpecialKeySpace::MODULE modu
 
 ACTOR Future<Standalone<RangeResultRef>> getWorkerInterfaces(Reference<ClusterConnectionFile> clusterFile);
 ACTOR Future<Optional<Value>> getJSON(Database db);
-template <class F>
-Future<pair<KeyRange, Reference<LocationInfo>>> getKeyLocation(Database const& cx, Key const& key,
-                                                               F StorageServerInterface::*member,
-                                                               TransactionInfo const& info, bool isBackward = false);
 
-class DDStatsRangeImpl : public SpecialKeyRangeAsyncImpl {
-public:
-	explicit DDStatsRangeImpl(KeyRangeRef kr);
-	Future<Standalone<RangeResultRef>> getRange(ReadYourWritesTransaction* ryw, KeyRangeRef kr) const override;
-};
-
-ACTOR Future<Standalone<RangeResultRef>> ddMetricsGetRangeActor(ReadYourWritesTransaction* ryw, KeyRangeRef kr) {
-	state KeyRangeRef keys = kr.removePrefix(ddStatsRange.begin);
-	state Standalone<VectorRef<DDMetricsRef>> resultWithoutPrefix =
-	    wait(waitDataDistributionMetricsList(ryw->getDatabase(), keys, CLIENT_KNOBS->STORAGE_METRICS_SHARD_LIMIT));
-	state Standalone<RangeResultRef> result;
-	ryw->getDatabase()->invalidateCache(keys);
-	for (const auto& ddMetricsRef_ : resultWithoutPrefix) {
-		state DDMetricsRef ddMetricsRef = ddMetricsRef_;
-		// each begin key is the previous end key, thus we only encode the begin key in the result
-		state KeyRef beginKey = ddMetricsRef.beginKey.withPrefix(ddStatsRange.begin, result.arena());
-		state pair<KeyRange, Reference<LocationInfo>> ssi = wait(getKeyLocation(
-		    ryw->getDatabase(), ddMetricsRef.beginKey, &StorageServerInterface::getValue, ryw->getTransactionInfo()));
-		// Use json string encoded in utf-8 to encode the values, easy for adding more fields in the future
-		JsonBuilderObject statsObj;
-		statsObj["ShardBytes"] = ddMetricsRef.shardBytes;
-		JsonBuilderArray storages;
-		std::vector<UID> uids;
-		for (int i = 0; i < ssi.second->size(); ++i) {
-			uids.push_back(ssi.second->getId(i));
-		}
-		std::sort(uids.begin(), uids.end());
-		for (const auto& uid : uids) {
-			storages.push_back(uid.toString());
-		}
-		statsObj["Storages"] = storages;
-		std::string statsString = statsObj.getJson();
-		ValueRef bytes(result.arena(), statsString);
-		result.push_back(result.arena(), KeyValueRef(beginKey, bytes));
-	}
-	return result;
-}
-
-DDStatsRangeImpl::DDStatsRangeImpl(KeyRangeRef kr) : SpecialKeyRangeAsyncImpl(kr) {}
-
-Future<Standalone<RangeResultRef>> DDStatsRangeImpl::getRange(ReadYourWritesTransaction* ryw, KeyRangeRef kr) const {
-	return ddMetricsGetRangeActor(ryw, kr);
-}
 struct WorkerInterfacesSpecialKeyImpl : SpecialKeyRangeBaseImpl {
 	Future<Standalone<RangeResultRef>> getRange(ReadYourWritesTransaction* ryw, KeyRangeRef kr) const override {
 		if (ryw->getDatabase().getPtr() && ryw->getDatabase()->getConnectionFile()) {
@@ -1507,7 +1460,7 @@ ACTOR Future< pair<KeyRange,Reference<LocationInfo>> > getKeyLocation_internal( 
 template <class F>
 Future<pair<KeyRange, Reference<LocationInfo>>> getKeyLocation(Database const& cx, Key const& key,
                                                                F StorageServerInterface::*member,
-                                                               TransactionInfo const& info, bool isBackward) {
+                                                               TransactionInfo const& info, bool isBackward = false) {
 	auto ssi = cx->getCachedLocation( key, isBackward );
 	if (!ssi.second) {
 		return getKeyLocation_internal( cx, key, info, isBackward );

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -596,6 +596,7 @@ public:
 
 static Standalone<RangeResultRef> healthMetricsToKVPairs(const HealthMetrics& metrics, KeyRangeRef kr) {
 	Standalone<RangeResultRef> result;
+	if (CLIENT_BUGGIFY) return result;
 	if (kr.contains(LiteralStringRef("\xff\xff/metrics/health/aggregate")) && metrics.worstStorageDurabilityLag != 0) {
 		json_spirit::mObject statsObj;
 		statsObj["batchLimited"] = metrics.batchLimited;

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -529,8 +529,13 @@ ACTOR Future<Standalone<RangeResultRef>> ddMetricsGetRangeActor(ReadYourWritesTr
 		JsonBuilderObject statsObj;
 		statsObj["ShardBytes"] = ddMetricsRef.shardBytes;
 		JsonBuilderArray storages;
+		std::vector<UID> uids;
 		for (int i = 0; i < ssi.second->size(); ++i) {
-			storages.push_back(ssi.second->getId(i).toString());
+			uids.push_back(ssi.second->getId(i));
+		}
+		std::sort(uids.begin(), uids.end());
+		for (const auto& uid : uids) {
+			storages.push_back(uid.toString());
 		}
 		statsObj["Storages"] = storages;
 		std::string statsString = statsObj.getJson();

--- a/fdbclient/Schemas.cpp
+++ b/fdbclient/Schemas.cpp
@@ -853,3 +853,37 @@ const KeyRef JSONSchemas::latencyBandConfigurationSchema = LiteralStringRef(R"co
         "max_commit_bytes":0
     }
 })configSchema");
+
+const KeyRef JSONSchemas::dataDistributionStatsSchema = LiteralStringRef(R"""(
+{
+  "ShardBytes": 1947000,
+  "Storages": [
+    "697f39751849d70067eabd1b079478a5"
+  ]
+}
+)""");
+
+const KeyRef JSONSchemas::logHealthSchema = LiteralStringRef(R"""(
+{
+  "tLogQueue": 156
+}
+)""");
+
+const KeyRef JSONSchemas::storageHealthSchema = LiteralStringRef(R"""(
+{
+  "cpuUsage": 3.28629447047675,
+  "diskUsage": 0.19997897369207954,
+  "storageDurabilityLag": 5050809,
+  "storageQueue": 2030
+}
+)""");
+
+const KeyRef JSONSchemas::aggregateHealthSchema = LiteralStringRef(R"""(
+{
+  "batchLimited": false,
+  "tpsLimit": 457082.8105811302,
+  "worstStorageDurabilityLag": 5050809,
+  "worstStorageQueue": 2030,
+  "worstTLogQueue": 156
+}
+)""");

--- a/fdbclient/Schemas.cpp
+++ b/fdbclient/Schemas.cpp
@@ -856,31 +856,31 @@ const KeyRef JSONSchemas::latencyBandConfigurationSchema = LiteralStringRef(R"co
 
 const KeyRef JSONSchemas::dataDistributionStatsSchema = LiteralStringRef(R"""(
 {
-  "ShardBytes": 1947000
+  "shard_bytes": 1947000
 }
 )""");
 
 const KeyRef JSONSchemas::logHealthSchema = LiteralStringRef(R"""(
 {
-  "tLogQueue": 156
+  "log_queue": 156
 }
 )""");
 
 const KeyRef JSONSchemas::storageHealthSchema = LiteralStringRef(R"""(
 {
-  "cpuUsage": 3.28629447047675,
-  "diskUsage": 0.19997897369207954,
-  "storageDurabilityLag": 5050809,
-  "storageQueue": 2030
+  "cpu_usage": 3.28629447047675,
+  "disk_usage": 0.19997897369207954,
+  "storage_durability_lag": 5050809,
+  "storage_queue": 2030
 }
 )""");
 
 const KeyRef JSONSchemas::aggregateHealthSchema = LiteralStringRef(R"""(
 {
-  "batchLimited": false,
-  "tpsLimit": 457082.8105811302,
-  "worstStorageDurabilityLag": 5050809,
-  "worstStorageQueue": 2030,
-  "worstTLogQueue": 156
+  "batch_limited": false,
+  "tps_limit": 457082.8105811302,
+  "worst_storage_durability_lag": 5050809,
+  "worst_storage_queue": 2030,
+  "worst_log_queue": 156
 }
 )""");

--- a/fdbclient/Schemas.cpp
+++ b/fdbclient/Schemas.cpp
@@ -856,10 +856,7 @@ const KeyRef JSONSchemas::latencyBandConfigurationSchema = LiteralStringRef(R"co
 
 const KeyRef JSONSchemas::dataDistributionStatsSchema = LiteralStringRef(R"""(
 {
-  "ShardBytes": 1947000,
-  "Storages": [
-    "697f39751849d70067eabd1b079478a5"
-  ]
+  "ShardBytes": 1947000
 }
 )""");
 

--- a/fdbclient/Schemas.h
+++ b/fdbclient/Schemas.h
@@ -30,6 +30,10 @@ struct JSONSchemas {
 	static const KeyRef statusSchema;
 	static const KeyRef clusterConfigurationSchema;
 	static const KeyRef latencyBandConfigurationSchema;
+	static const KeyRef dataDistributionStatsSchema;
+	static const KeyRef logHealthSchema;
+	static const KeyRef storageHealthSchema;
+	static const KeyRef aggregateHealthSchema;
 };
 
 #endif /* FDBCLIENT_SCHEMAS_H */

--- a/fdbclient/SpecialKeySpace.actor.cpp
+++ b/fdbclient/SpecialKeySpace.actor.cpp
@@ -350,26 +350,22 @@ Future<Standalone<RangeResultRef>> ConflictingKeysImpl::getRange(ReadYourWritesT
 }
 
 ACTOR Future<Standalone<RangeResultRef>> ddMetricsGetRangeActor(ReadYourWritesTransaction* ryw, KeyRangeRef kr) {
-	try {
-		auto keys = kr.removePrefix(ddStatsRange.begin);
-		Standalone<VectorRef<DDMetricsRef>> resultWithoutPrefix =
-		    wait(waitDataDistributionMetricsList(ryw->getDatabase(), keys, CLIENT_KNOBS->STORAGE_METRICS_SHARD_LIMIT));
-		Standalone<RangeResultRef> result;
-		for (const auto& ddMetricsRef : resultWithoutPrefix) {
-			// each begin key is the previous end key, thus we only encode the begin key in the result
-			KeyRef beginKey = ddMetricsRef.beginKey.withPrefix(ddStatsRange.begin, result.arena());
-			// Use json string encoded in utf-8 to encode the values, easy for adding more fields in the future
-			json_spirit::mObject statsObj;
-			statsObj["ShardBytes"] = ddMetricsRef.shardBytes;
-			std::string statsString =
-			    json_spirit::write_string(json_spirit::mValue(statsObj), json_spirit::Output_options::raw_utf8);
-			ValueRef bytes(result.arena(), statsString);
-			result.push_back(result.arena(), KeyValueRef(beginKey, bytes));
-		}
-		return result;
-	} catch (Error& e) {
-		throw;
+	auto keys = kr.removePrefix(ddStatsRange.begin);
+	Standalone<VectorRef<DDMetricsRef>> resultWithoutPrefix =
+	    wait(waitDataDistributionMetricsList(ryw->getDatabase(), keys, CLIENT_KNOBS->STORAGE_METRICS_SHARD_LIMIT));
+	Standalone<RangeResultRef> result;
+	for (const auto& ddMetricsRef : resultWithoutPrefix) {
+		// each begin key is the previous end key, thus we only encode the begin key in the result
+		KeyRef beginKey = ddMetricsRef.beginKey.withPrefix(ddStatsRange.begin, result.arena());
+		// Use json string encoded in utf-8 to encode the values, easy for adding more fields in the future
+		json_spirit::mObject statsObj;
+		statsObj["ShardBytes"] = ddMetricsRef.shardBytes;
+		std::string statsString =
+		    json_spirit::write_string(json_spirit::mValue(statsObj), json_spirit::Output_options::raw_utf8);
+		ValueRef bytes(result.arena(), statsString);
+		result.push_back(result.arena(), KeyValueRef(beginKey, bytes));
 	}
+	return result;
 }
 
 DDStatsRangeImpl::DDStatsRangeImpl(KeyRangeRef kr) : SpecialKeyRangeAsyncImpl(kr) {}

--- a/fdbclient/SpecialKeySpace.actor.cpp
+++ b/fdbclient/SpecialKeySpace.actor.cpp
@@ -348,3 +348,32 @@ Future<Standalone<RangeResultRef>> ConflictingKeysImpl::getRange(ReadYourWritesT
 	}
 	return result;
 }
+
+ACTOR Future<Standalone<RangeResultRef>> ddMetricsGetRangeActor(ReadYourWritesTransaction* ryw, KeyRangeRef kr) {
+	try {
+		auto keys = kr.removePrefix(ddStatsRange.begin);
+		Standalone<VectorRef<DDMetricsRef>> resultWithoutPrefix =
+		    wait(waitDataDistributionMetricsList(ryw->getDatabase(), keys, CLIENT_KNOBS->STORAGE_METRICS_SHARD_LIMIT));
+		Standalone<RangeResultRef> result;
+		for (const auto& ddMetricsRef : resultWithoutPrefix) {
+			// each begin key is the previous end key, thus we only encode the begin key in the result
+			KeyRef beginKey = ddMetricsRef.beginKey.withPrefix(ddStatsRange.begin, result.arena());
+			// Use json string encoded in utf-8 to encode the values, easy for adding more fields in the future
+			json_spirit::mObject statsObj;
+			statsObj["ShardBytes"] = ddMetricsRef.shardBytes;
+			std::string statsString =
+			    json_spirit::write_string(json_spirit::mValue(statsObj), json_spirit::Output_options::raw_utf8);
+			ValueRef bytes(result.arena(), statsString);
+			result.push_back(result.arena(), KeyValueRef(beginKey, bytes));
+		}
+		return result;
+	} catch (Error& e) {
+		throw;
+	}
+}
+
+DDStatsRangeImpl::DDStatsRangeImpl(KeyRangeRef kr) : SpecialKeyRangeAsyncImpl(kr) {}
+
+Future<Standalone<RangeResultRef>> DDStatsRangeImpl::getRange(ReadYourWritesTransaction* ryw, KeyRangeRef kr) const {
+	return ddMetricsGetRangeActor(ryw, kr);
+}

--- a/fdbclient/SpecialKeySpace.actor.cpp
+++ b/fdbclient/SpecialKeySpace.actor.cpp
@@ -348,28 +348,3 @@ Future<Standalone<RangeResultRef>> ConflictingKeysImpl::getRange(ReadYourWritesT
 	}
 	return result;
 }
-
-ACTOR Future<Standalone<RangeResultRef>> ddMetricsGetRangeActor(ReadYourWritesTransaction* ryw, KeyRangeRef kr) {
-	auto keys = kr.removePrefix(ddStatsRange.begin);
-	Standalone<VectorRef<DDMetricsRef>> resultWithoutPrefix =
-	    wait(waitDataDistributionMetricsList(ryw->getDatabase(), keys, CLIENT_KNOBS->STORAGE_METRICS_SHARD_LIMIT));
-	Standalone<RangeResultRef> result;
-	for (const auto& ddMetricsRef : resultWithoutPrefix) {
-		// each begin key is the previous end key, thus we only encode the begin key in the result
-		KeyRef beginKey = ddMetricsRef.beginKey.withPrefix(ddStatsRange.begin, result.arena());
-		// Use json string encoded in utf-8 to encode the values, easy for adding more fields in the future
-		json_spirit::mObject statsObj;
-		statsObj["ShardBytes"] = ddMetricsRef.shardBytes;
-		std::string statsString =
-		    json_spirit::write_string(json_spirit::mValue(statsObj), json_spirit::Output_options::raw_utf8);
-		ValueRef bytes(result.arena(), statsString);
-		result.push_back(result.arena(), KeyValueRef(beginKey, bytes));
-	}
-	return result;
-}
-
-DDStatsRangeImpl::DDStatsRangeImpl(KeyRangeRef kr) : SpecialKeyRangeAsyncImpl(kr) {}
-
-Future<Standalone<RangeResultRef>> DDStatsRangeImpl::getRange(ReadYourWritesTransaction* ryw, KeyRangeRef kr) const {
-	return ddMetricsGetRangeActor(ryw, kr);
-}

--- a/fdbclient/SpecialKeySpace.actor.cpp
+++ b/fdbclient/SpecialKeySpace.actor.cpp
@@ -360,7 +360,7 @@ ACTOR Future<Standalone<RangeResultRef>> ddMetricsGetRangeActor(ReadYourWritesTr
 			KeyRef beginKey = ddMetricsRef.beginKey.withPrefix(ddStatsRange.begin, result.arena());
 			// Use json string encoded in utf-8 to encode the values, easy for adding more fields in the future
 			json_spirit::mObject statsObj;
-			statsObj["ShardBytes"] = ddMetricsRef.shardBytes;
+			statsObj["shard_bytes"] = ddMetricsRef.shardBytes;
 			std::string statsString =
 			    json_spirit::write_string(json_spirit::mValue(statsObj), json_spirit::Output_options::raw_utf8);
 			ValueRef bytes(result.arena(), statsString);

--- a/fdbclient/SpecialKeySpace.actor.h
+++ b/fdbclient/SpecialKeySpace.actor.h
@@ -190,5 +190,11 @@ public:
 	Future<Standalone<RangeResultRef>> getRange(ReadYourWritesTransaction* ryw, KeyRangeRef kr) const override;
 };
 
+class DDStatsRangeImpl : public SpecialKeyRangeAsyncImpl {
+public:
+	explicit DDStatsRangeImpl(KeyRangeRef kr);
+	Future<Standalone<RangeResultRef>> getRange(ReadYourWritesTransaction* ryw, KeyRangeRef kr) const override;
+};
+
 #include "flow/unactorcompiler.h"
 #endif

--- a/fdbclient/SpecialKeySpace.actor.h
+++ b/fdbclient/SpecialKeySpace.actor.h
@@ -190,11 +190,5 @@ public:
 	Future<Standalone<RangeResultRef>> getRange(ReadYourWritesTransaction* ryw, KeyRangeRef kr) const override;
 };
 
-class DDStatsRangeImpl : public SpecialKeyRangeAsyncImpl {
-public:
-	explicit DDStatsRangeImpl(KeyRangeRef kr);
-	Future<Standalone<RangeResultRef>> getRange(ReadYourWritesTransaction* ryw, KeyRangeRef kr) const override;
-};
-
 #include "flow/unactorcompiler.h"
 #endif

--- a/fdbserver/workloads/DataDistributionMetrics.actor.cpp
+++ b/fdbserver/workloads/DataDistributionMetrics.actor.cpp
@@ -157,13 +157,15 @@ struct DataDistributionMetricsWorkload : KVWorkload {
 					    .detail("ErrorStr", errorStr.c_str())
 					    .detail("JSON", json_spirit::write_string(json_spirit::mValue(result[i].value.toString())));
 				totalBytes += valueObj["ShardBytes"].get_int64();
-				for (const auto& s : valueObj["Storages"].get_array()) {
-					UID::fromString(s.get_str()); // Will throw if it's not a valid uid
-				}
 			}
 			self->avgBytes = totalBytes / self->numShards;
 			// fetch data-distribution stats for a smaller range
 			ASSERT(result.size());
+			state int idx = deterministicRandom()->randomInt(0, result.size());
+			Standalone<RangeResultRef> res = wait(tr->getRange(
+			    KeyRangeRef(result[idx].key, idx + 1 < result.size() ? result[idx + 1].key : ddStatsRange.end), 100));
+			ASSERT_WE_THINK(res.size() == 1 && res[0] == result[idx]); // It works good now. However, not sure in any
+			                                                           // case of data-distribution, the number changes
 		} catch (Error& e) {
 			TraceEvent(SevError, "FailedToRetrieveDDMetrics").detail("Error", e.what());
 			throw;

--- a/fdbserver/workloads/DataDistributionMetrics.actor.cpp
+++ b/fdbserver/workloads/DataDistributionMetrics.actor.cpp
@@ -152,11 +152,13 @@ struct DataDistributionMetricsWorkload : KVWorkload {
 				std::string errorStr;
 				auto valueObj = readJSONStrictly(result[i].value.toString()).get_obj();
 				TEST(true); // data_distribution_stats schema validation
-				if (!schemaMatch(schema, valueObj, errorStr, SevError, true))
+				if (!schemaMatch(schema, valueObj, errorStr, SevError, true)) {
 					TraceEvent(SevError, "DataDistributionStatsSchemaValidationFailed")
 					    .detail("ErrorStr", errorStr.c_str())
 					    .detail("JSON", json_spirit::write_string(json_spirit::mValue(result[i].value.toString())));
-				totalBytes += valueObj["ShardBytes"].get_int64();
+					return false;
+				}
+				totalBytes += valueObj["shard_bytes"].get_int64();
 			}
 			self->avgBytes = totalBytes / self->numShards;
 			// fetch data-distribution stats for a smaller range


### PR DESCRIPTION
Implements a slight variant of proposal 2 in https://forums.foundationdb.org/t/add-health-metrics-feature-to-special-key-space/2193/6. The difference is that logs and storages have separate keys now, allowing to define their schemas more precisely.

Also adds a field "Storages" to the data_distribution_stats which indicates the storage ids responsible for a shard. This combines well with the health metrics feature for application-level throttling. For example you could (if it makes sense for your application) move write load away from shards with high storage queue. Technically you could have gotten this information by joining information from status json and the locality api, but it would be less precise, more complicated, and more expensive.

Would like to get some feedback on the following:

1. Does including a storages field in data_distribution_stats make sense to other people?
I decided to remove this from this PR, since it seems out of scope and a bit rushed
2. I think we should agree on either snake_case, camelCase, or PascalCase for json fields in special keys. FWIW status json seems to be all snake_case.
Updated everything to be snake_case to match status json
3. Ideas for correctness testing for these new special keys
4. Are we ok with adding this to api version 630?