### PR TITLE
Corrects spelling mistakes in various markdown files.

### DIFF
--- a/bindings/java/README.md
+++ b/bindings/java/README.md
@@ -31,7 +31,7 @@ make packages
 #### Multi-Platform Jar-File
 
 If you want to create a jar file that can run on more than one supported
-architecture (the offical one supports MacOS, Linux, and Windows), you can do
+architecture (the official one supports MacOS, Linux, and Windows), you can do
 that by executing the following steps:
 
 1. Create a directory called `lib` somewhere on your file system.

--- a/design/backup.md
+++ b/design/backup.md
@@ -47,7 +47,7 @@ take the same example
 
 Restoring to version vk (v10 < vk <= vn), needs KV ranges to be restored first and then replaying mutation logs. For
 each KV range (k1-k2, vx) that is restored we need to replay mutation log [(k1-k2, vx+1), .., (k1-k2, vk)]. But, this
-needs scanning complete muation log to get mutaions for k1-k2, that is sub-optimal, for any decent sized database
+needs scanning complete mutation log to get mutations for k1-k2, that is sub-optimal, for any decent sized database
 this will take forever.
 
 Instead looking at restore on key space, we can replay events on version space, that way we need to scan

--- a/design/recovery-internals.md
+++ b/design/recovery-internals.md
@@ -10,7 +10,7 @@ This document explains at the high level how the recovery works in a single clus
 
 This data structure contains transient information which is broadcast to all workers for a database, permitting them to communicate with each other. It contains, for example, the interfaces for cluster controller (CC), master, ratekeeper, and resolver, and holds the log system's configuration. Only part of the data structure, such as `ClientDBInfo` that contains the list of proxies, is  available to the client.
 
-Whenever a field of the `ServerDBInfo`is changed, the new value of the field, say new master's interface, will be sent to the CC and CC will propogate the new `ServerDBInfo` to all workers in the cluster.
+Whenever a field of the `ServerDBInfo`is changed, the new value of the field, say new master's interface, will be sent to the CC and CC will propagate the new `ServerDBInfo` to all workers in the cluster.
 
 ## When will recovery happen?
 Failure of certain roles in FDB can cause recovery. Those roles are cluster controller, master, proxy, transaction logs (tLog), resolvers, and log router.
@@ -69,7 +69,7 @@ The transaction system state before the recovery is the starting point for the c
 
 This phase locks the coordinated state (cstate) to make sure there is only one master who can change the cstate. Otherwise, we may end up with more than one master accepting commits after the recovery. To achieve that, the master needs to get currently alive tLogs’ interfaces and sends commands to tLogs to lock their states, preventing them from accepting any further writes.
 
-Recall that `ServerDBInfo` has master's interface and is propogated by CC to every process in a cluster. The current running tLogs can use the master interface in its `ServerDBInfo` to send itself's interface to master.
+Recall that `ServerDBInfo` has master's interface and is propagated by CC to every process in a cluster. The current running tLogs can use the master interface in its `ServerDBInfo` to send itself's interface to master.
 Master simply waits on receiving the `TLogRejoinRequest` streams: for each tLog’s interface received, the master compares the interface ID with the tLog ID read from cstate. Once the master collects enough old tLog interfaces, it will use the interfaces to lock those tLogs.
 The logic of collecting tLogs’ interfaces is implemented in `trackRejoins()` function.
 The logic of locking the tLogs is implemented in `epochEnd()` function in [TagPartitionedLogSystems.actor.cpp](https://github.com/apple/foundationdb/blob/master/fdbserver/TagPartitionedLogSystem.actor.cpp).

--- a/design/special-key-space.md
+++ b/design/special-key-space.md
@@ -1,5 +1,5 @@
 # Special-Key-Space
-This document discusses why we need the proposed special-key-space framwork. And for what problems the framework aims to solve and in what scenarios a developer should use it.   
+This document discusses why we need the proposed special-key-space framework. And for what problems the framework aims to solve and in what scenarios a developer should use it.   
 
 ## Motivation
 Currently, there are several client functions implemented as FDB calls by passing through special keys(`prefixed with \xff\xff`). Below are all existing features:
@@ -9,9 +9,9 @@ Currently, there are several client functions implemented as FDB calls by passin
 - **worker_interfaces**: `getRange("\xff\xff/worker_interfaces", <any_key>)`
 - **conflicting_keys**: `getRange("\xff\xff/transaction/conflicting_keys/", "\xff\xff/transaction/conflicting_keys/\xff")`
 
-At present, implementions are hard-coded and the pain points are obvious:
+At present, implementations are hard-coded and the pain points are obvious:
 - **Maintainability**: As more features added, the hard-coded snippets are hard to maintain 
-- **Granularity**: It is impossible to scale up and down. For example, you want a cheap call like `get("\xff\xff/status/json/<certain_field>")` instead of calling `status/json` and parsing the results. On the contrary, sometime you want to aggregate results from several similiar features like `getRange("\xff\xff/transaction/, \xff\xff/transaction/\xff")` to get all transaction related info. Both of them are not achievable at present.
+- **Granularity**: It is impossible to scale up and down. For example, you want a cheap call like `get("\xff\xff/status/json/<certain_field>")` instead of calling `status/json` and parsing the results. On the contrary, sometime you want to aggregate results from several similar features like `getRange("\xff\xff/transaction/, \xff\xff/transaction/\xff")` to get all transaction related info. Both of them are not achievable at present.
 - **Consistency**: While using FDB calls like `get` or `getRange`, the behavior that the result of `get("\xff\xff/B")` is not included in `getRange("\xff\xff/A", "\xff\xff/C")` is inconsistent with general FDB calls.
 
 Consequently, the special-key-space framework wants to integrate all client functions using special keys(`prefixed with \xff`) and solve the pain points listed above.

--- a/design/tuple.md
+++ b/design/tuple.md
@@ -105,7 +105,7 @@ Status: Standard (float and double) ; Reserved (long double)
 The binary representation should not be assumed to be canonicalized (as to multiple representations of NaN, for example) by a reader. This order sorts all numbers in the following way:
 
 * All negative NaN values with order determined by mantissa bits (which are semantically meaningless)
-* Negative inifinity
+* Negative infinity
 * All real numbers in the standard order (except that -0.0 < 0.0)
 * Positive infinity
 * All positive NaN values with order determined by mantissa bits


### PR DESCRIPTION
:peace_symbol: :v: :apple: 