### PR TITLE
Use SSE2 intrinsics to find longest common prefix

### DIFF
--- a/fdbserver/DeltaTree.h
+++ b/fdbserver/DeltaTree.h
@@ -32,7 +32,7 @@ typedef uint64_t Word;
 static inline int commonPrefixLength(uint8_t const* ap, uint8_t const* bp, int cl) {
 	int i = 0;
 
-	for (; i + 128 < cl; i += 128) {
+	for (; i + 16 < cl; i += 16) {
 		__m128i a = _mm_loadu_si128((__m128i*)(ap + i));
 		__m128i b = _mm_loadu_si128((__m128i*)(bp + i));
 		int r = _mm_movemask_epi8(_mm_cmpeq_epi8(a, b));

--- a/fdbserver/DeltaTree.h
+++ b/fdbserver/DeltaTree.h
@@ -37,7 +37,7 @@ static inline int commonPrefixLength(uint8_t const* ap, uint8_t const* bp, int c
 		__m128i b = _mm_loadu_si128((__m128i*)(bp + i));
 		int r = _mm_movemask_epi8(_mm_cmpeq_epi8(a, b));
 		if (r != 0xFFFF) {
-			return clz(r) / 4 + i;
+			return ctz(~r) + i;
 		}
 	}
 


### PR DESCRIPTION
This PR adds SSE2 intrinsics to the method to find the longest common prefix. Benchmark results:

Before
```
Testing !/redwood/correctness/unit/RedwoodRecordRef
DeltaTest() on random large records 0.163069 M/s  3538.33 MB/s
DeltaTest() on random small records 163.069 M/s  6376.88 MB/s
5700000000 getCommonPrefixLen(skip=50) 515.447 M/s
5700000000 getCommonPrefixLen(skip=0) 114.42 M/s
1300000000 writeDelta(commonPrefix=57) 101.44 M/s
130000000 writeDelta() 44.4518 M/s
```

After
```
Testing !/redwood/correctness/unit/RedwoodRecordRef
DeltaTest() on random large records 0.317222 M/s  7141.03 MB/s
DeltaTest() on random small records 317.222 M/s  12397 MB/s
5700000000 getCommonPrefixLen(skip=50) 441.804 M/s
5700000000 getCommonPrefixLen(skip=0) 118.944 M/s
1300000000 writeDelta(commonPrefix=57) 101.98 M/s
130000000 writeDelta() 53.5847 M/s
```

Run on an r5d.2xl.