### PR TITLE
Update supported Python versions in downloads.rst

### DIFF
--- a/documentation/sphinx/source/downloads.rst
+++ b/documentation/sphinx/source/downloads.rst
@@ -51,7 +51,7 @@ C
 
 FoundationDB's C bindings are installed with the FoundationDB client binaries. You can find more details in the :doc:`C API Documentation <api-c>`.
 
-Python 2.7 - 3.5
+Python 2.7 - 3.7
 ----------------
 
 On macOS and Windows, the FoundationDB Python API bindings are installed as part of your FoundationDB installation.


### PR DESCRIPTION
Per the [Python API docs](https://apple.github.io/foundationdb/api-python.html), Python versions 2.7-3.7 are now supported. This PR updates the [Download](https://www.foundationdb.org/download/) page to reflect that Py 3.6 and 3.7 are supported.