### PR TITLE
Use STL for optional and variant

### DIFF
--- a/fdbclient/ClusterInterface.h
+++ b/fdbclient/ClusterInterface.h
@@ -192,8 +192,6 @@ struct SystemFailureStatus {
 	}
 };
 
-TRIVIALLY_DESTRUCTIBLE(SystemFailureStatus); // Allows VectorRef<SystemFailureStatus>
-
 struct FailureMonitoringReply {
 	constexpr static FileIdentifier file_identifier = 6820325;
 	VectorRef< SystemFailureStatus > changes;

--- a/fdbserver/VersionedBTree.actor.cpp
+++ b/fdbserver/VersionedBTree.actor.cpp
@@ -2732,8 +2732,6 @@ struct RedwoodRecordRef {
 	}
 };
 
-TRIVIALLY_DESTRUCTIBLE(RedwoodRecordRef); // Allows VectorRef<RedwoodRecordRef>
-
 struct BTreePage {
 	typedef DeltaTree<RedwoodRecordRef> BinaryTree;
 	typedef DeltaTree<RedwoodRecordRef, RedwoodRecordRef::DeltaValueOnly> ValueTree;

--- a/fdbserver/WorkerInterface.actor.h
+++ b/fdbserver/WorkerInterface.actor.h
@@ -639,11 +639,6 @@ struct DebugEntryRef {
 	}
 };
 
-// TODO: This is necessary because IPAddress uses boost::variant
-// instead of std::variant. If we switch to std::variant, we don't
-// need to explicitly mark DebugEntryRef trivially destructible
-TRIVIALLY_DESTRUCTIBLE(DebugEntryRef); // Allows VectorRef<DebugEntryRef>
-
 struct DiskStoreRequest {
 	constexpr static FileIdentifier file_identifier = 1986262;
 	bool includePartialStores;

--- a/fdbserver/workloads/TPCC.actor.cpp
+++ b/fdbserver/workloads/TPCC.actor.cpp
@@ -458,7 +458,7 @@ struct TPCC : TestWorkload {
 		state int d_id = deterministicRandom()->randomInt(0, 10);
 		state int i;
 		state Order order;
-		state VectorRef<OrderLine> orderLines;
+		state std::vector<OrderLine> orderLines;
 		try {
 			state Customer customer = wait(getRandomCustomer(self, &tr, w_id, d_id));
 			order.o_w_id = customer.c_w_id;
@@ -481,7 +481,7 @@ struct TPCC : TestWorkload {
 				BinaryReader r(olValue.get(), IncludeVersion());
 				OrderLine ol;
 				serializer(r, ol);
-				orderLines.push_back(order.arena, ol);
+				orderLines.push_back(ol);
 			}
 		} catch (Error& e) {
 			return false;

--- a/fdbserver/workloads/TPCCWorkload.h
+++ b/fdbserver/workloads/TPCCWorkload.h
@@ -295,6 +295,4 @@ const std::vector<std::string> syllables = {
 
 } // namespace TPCCWorkload
 
-TRIVIALLY_DESTRUCTIBLE(TPCCWorkload::OrderLine); // Allows VectorRef<TPCCWorkload::OrderLine>
-
 #endif

--- a/flow/Arena.h
+++ b/flow/Arena.h
@@ -302,23 +302,6 @@ inline void save(Archive& ar, const Optional<T>& value) {
 	}
 }
 
-// This class is necessary because Optional<T> is effectively trivially
-// destructible if T is trivially destructible, but we can't SFINAE out
-// destructors until C++20, so we still define the destructor for
-// Optional<T> even if it's trivial
-template <class T>
-struct trivially_destructible : public std::is_trivially_destructible<T> {};
-
-template <class T>
-struct trivially_destructible<Optional<T>> : public trivially_destructible<T> {};
-
-// If std::is_trivially_destructible_v<T> is false only because T has a field
-// Optional<U> where U is trivially destructible, we can manually specify that
-// T is trivially_destructible
-#define TRIVIALLY_DESTRUCTIBLE(T)                                                                                      \
-	template <>                                                                                                        \
-	struct trivially_destructible<T> : std::true_type {}
-
 template<class T>
 struct Traceable<Optional<T>> : std::conditional<Traceable<T>::value, std::true_type, std::false_type>::type {
 	static std::string toString(const Optional<T>& value) {
@@ -802,7 +785,7 @@ public:
 
 	// T must be trivially copyable!
 	// T must be trivially destructible, because ~T is never called
-	static_assert(trivially_destructible<T>::value);
+	static_assert(std::is_trivially_destructible_v<T>);
 	VectorRef() : data(0), m_size(0), m_capacity(0) {}
 
 	template <VecSerStrategy S>

--- a/flow/Arena.h
+++ b/flow/Arena.h
@@ -217,14 +217,17 @@ inline void save( Archive& ar, const Arena& p ) {
 //    std::optional was available.
 // 2) When you call get but no value is present Optional gives an
 //    assertion failure. std::optional, on the other hand, would
-//    throw std::bad_optional_access.
+//    throw std::bad_optional_access. It is easier to debug assertion
+//    failures, and FDB generally does not handle std exceptions, so
+//    assertion failures are preferable. This is the main reason we
+//    don't intend to use std::optional directly.
 template <class T>
 class Optional : public ComposedIdentifier<T, 0x10> {
 public:
 	Optional() = default;
 
 	template <class U>
-	Optional(const U& t) : impl(t) {}
+	Optional(const U& t) : impl(std::in_place, t) {}
 
 	/* This conversion constructor was nice, but combined with the prior constructor it means that Optional<int> can be converted to Optional<Optional<int>> in the wrong way
 	(a non-present Optional<int> converts to a non-present Optional<Optional<int>>).

--- a/flow/ObjectSerializerTraits.h
+++ b/flow/ObjectSerializerTraits.h
@@ -157,12 +157,12 @@ struct struct_like_traits : std::false_type {
 };
 
 template <class... Alternatives>
-struct union_like_traits<boost::variant<Alternatives...>> : std::true_type {
-	using Member = boost::variant<Alternatives...>;
+struct union_like_traits<std::variant<Alternatives...>> : std::true_type {
+	using Member = std::variant<Alternatives...>;
 	using alternatives = pack<Alternatives...>;
 	template <class Context>
 	static uint8_t index(const Member& variant, Context&) {
-		return variant.which();
+		return variant.index();
 	}
 	template <class Context>
 	static bool empty(const Member& variant, Context&) {
@@ -171,7 +171,7 @@ struct union_like_traits<boost::variant<Alternatives...>> : std::true_type {
 
 	template <int i, class Context>
 	static const index_t<i, alternatives>& get(const Member& variant, Context&) {
-		return boost::get<index_t<i, alternatives>>(variant);
+		return std::get<index_t<i, alternatives>>(variant);
 	}
 
 	template <size_t i, class Alternative, class Context>

--- a/flow/README.md
+++ b/flow/README.md
@@ -335,7 +335,7 @@ you are holding the corresponding future.
     - Unions
     ```
     // Flow type
-    using T = boost::variant<A, B, C>;
+    using T = std::variant<A, B, C>;
 
     // IDL equivalent
     union T { A, B, C}
@@ -363,7 +363,7 @@ you are holding the corresponding future.
     - `scalar_traits` corresponds to a flatbuffers struct. See `UID` for an example.
     - `vector_like_traits` corresponds to a flatbuffers vector. See `VectorRef` for an example.
     - `dynamic_size_traits` corresponds to a flatbuffers vector of uint8_t. See `StringRef` for an example.
-    - `union_like_traits` corresponds to a flatbuffers union. See `boost::variant` for an example.
+    - `union_like_traits` corresponds to a flatbuffers union. See `std::variant` for an example.
 
 1. Potential Gotchas
     - Flatbuffers 'vtables' are collected from default-constructed instances of

--- a/flow/flat_buffers.cpp
+++ b/flow/flat_buffers.cpp
@@ -302,7 +302,7 @@ TEST_CASE("flow/FlatBuffers/serializeDeserializeMembers") {
 namespace unit_tests {
 
 TEST_CASE("flow/FlatBuffers/variant") {
-	using V = boost::variant<int, double, Nested2>;
+	using V = std::variant<int, double, Nested2>;
 	V v1;
 	V v2;
 	Arena arena;
@@ -313,21 +313,21 @@ TEST_CASE("flow/FlatBuffers/variant") {
 	out = save_members(context, FileIdentifier{}, v1);
 	// print_buffer(out, arena.get_size(out));
 	load_members(out, context, v2);
-	ASSERT(boost::get<int>(v1) == boost::get<int>(v2));
+	ASSERT(std::get<int>(v1) == std::get<int>(v2));
 
 	v1 = 1.0;
 	out = save_members(context, FileIdentifier{}, v1);
 	// print_buffer(out, arena.get_size(out));
 	load_members(out, context, v2);
-	ASSERT(boost::get<double>(v1) == boost::get<double>(v2));
+	ASSERT(std::get<double>(v1) == std::get<double>(v2));
 
 	v1 = Nested2{ 1, { "abc", "def" }, 2 };
 	out = save_members(context, FileIdentifier{}, v1);
 	// print_buffer(out, arena.get_size(out));
 	load_members(out, context, v2);
-	ASSERT(boost::get<Nested2>(v1).a == boost::get<Nested2>(v2).a);
-	ASSERT(boost::get<Nested2>(v1).b == boost::get<Nested2>(v2).b);
-	ASSERT(boost::get<Nested2>(v1).c == boost::get<Nested2>(v2).c);
+	ASSERT(std::get<Nested2>(v1).a == std::get<Nested2>(v2).a);
+	ASSERT(std::get<Nested2>(v1).b == std::get<Nested2>(v2).b);
+	ASSERT(std::get<Nested2>(v1).c == std::get<Nested2>(v2).c);
 	return Void();
 }
 
@@ -370,7 +370,7 @@ struct Y1 {
 
 struct Y2 {
 	int a;
-	boost::variant<int> b;
+	std::variant<int> b;
 
 	template <class Archiver>
 	void serialize(Archiver& ar) {

--- a/flow/network.cpp
+++ b/flow/network.cpp
@@ -39,9 +39,9 @@ bool IPAddress::operator<(const IPAddress& rhs) const {
 
 std::string IPAddress::toString() const {
 	if (isV6()) {
-		return boost::asio::ip::address_v6(boost::get<IPAddressStore>(addr)).to_string();
+		return boost::asio::ip::address_v6(std::get<IPAddressStore>(addr)).to_string();
 	} else {
-		auto ip = boost::get<uint32_t>(addr);
+		auto ip = std::get<uint32_t>(addr);
 		return format("%d.%d.%d.%d", (ip >> 24) & 0xff, (ip >> 16) & 0xff, (ip >> 8) & 0xff, ip & 0xff);
 	}
 }
@@ -57,10 +57,10 @@ Optional<IPAddress> IPAddress::parse(std::string str) {
 
 bool IPAddress::isValid() const {
 	if (isV6()) {
-		const auto& ip = boost::get<IPAddressStore>(addr);
+		const auto& ip = std::get<IPAddressStore>(addr);
 		return std::any_of(ip.begin(), ip.end(), [](uint8_t part) { return part != 0; });
 	}
-	return boost::get<uint32_t>(addr) != 0;
+	return std::get<uint32_t>(addr) != 0;
 }
 
 NetworkAddress NetworkAddress::parse( std::string const& s ) {


### PR DESCRIPTION
This simplifies the code some and allows us to use type traits more effectively. It also allows us to get rid of the `TRIVIALLY_DESTRUCTIBLE` macro.