### PR TITLE
Add missing messages to schema and rename one to match later versions

### DIFF
--- a/documentation/sphinx/source/mr-status-json-schemas.rst.inc
+++ b/documentation/sphinx/source/mr-status-json-schemas.rst.inc
@@ -362,7 +362,9 @@
                   "layer_status_incomplete",
                   "database_availability_timeout",
                   "consistencycheck_suspendkey_fetch_timeout",
-                  "consistencycheck_disabled"
+                  "consistencycheck_disabled",
+                  "primary_dc_missing",
+                  "fetch_primary_dc_timeout"
                ]
             },
             "issues":[

--- a/documentation/sphinx/source/mr-status.rst
+++ b/documentation/sphinx/source/mr-status.rst
@@ -88,6 +88,8 @@ cluster.messages                      unreachable_ratekeeper_worker         Unab
 cluster.messages                      unreachable_processes                 The cluster has some unreachable processes.
 cluster.messages                      unreadable_configuration              Unable to read database configuration.
 cluster.messages                      layer_status_incomplete               Some or all of the layers subdocument could not be read.
+cluster.messages                      primary_dc_missing                    Unable to determine primary datacenter.
+cluster.messages                      fetch_primary_dc_timeout              Fetching primary DC timed out.
 cluster.processes.<process>.messages  file_open_error                       Unable to open ‘<file>’ (<os_error>).
 cluster.processes.<process>.messages  incorrect_cluster_file_contents       Cluster file contents do not match current cluster connection string. Verify cluster file is writable and has not been overwritten externally.
 cluster.processes.<process>.messages  io_error                              <error> occured in <subsystem>

--- a/fdbclient/Schemas.cpp
+++ b/fdbclient/Schemas.cpp
@@ -387,7 +387,9 @@ const KeyRef JSONSchemas::statusSchema = LiteralStringRef(R"statusSchema(
                   "consistencycheck_suspendkey_fetch_timeout",
                   "consistencycheck_disabled",
                   "duplicate_mutation_streams",
-                  "duplicate_mutation_fetch_timeout"
+                  "duplicate_mutation_fetch_timeout",
+                  "primary_dc_missing",
+                  "fetch_primary_dc_timeout"
                ]
             },
             "issues":[

--- a/fdbserver/Status.actor.cpp
+++ b/fdbserver/Status.actor.cpp
@@ -2165,7 +2165,7 @@ ACTOR Future<Optional<Value>> getActivePrimaryDC(Database cx, JsonBuilderArray* 
 		} catch (Error& e) {
 			if (e.code() == error_code_timed_out) {
 				messages->push_back(
-				    JsonString::makeMessage("fetch_primary_dc_timedout", "Fetching primary DC timed out."));
+				    JsonString::makeMessage("fetch_primary_dc_timeout", "Fetching primary DC timed out."));
 				return Optional<Value>();
 			} else {
 				wait(tr.onError(e));


### PR DESCRIPTION
The backport of a change in later versions didn't include some updates to the schema and a change to the name of one of the messages.