### PR TITLE
Increase size of latency sample

### DIFF
--- a/fdbserver/Knobs.cpp
+++ b/fdbserver/Knobs.cpp
@@ -531,7 +531,7 @@ ServerKnobs::ServerKnobs(bool randomize, ClientKnobs* clientKnobs, bool isSimula
 	init( TIME_KEEPER_MAX_ENTRIES,                3600 * 24 * 30 * 6 ); if( randomize && BUGGIFY ) { TIME_KEEPER_MAX_ENTRIES = 2; }
 
 	// Server request latency measurement
-	init( LATENCY_SAMPLE_SIZE,                                 10000 );
+	init( LATENCY_SAMPLE_SIZE,                                100000 );
 	init( LATENCY_METRICS_LOGGING_INTERVAL,                     60.0 );
 
 	// clang-format on


### PR DESCRIPTION
This increases the size of the latency sample by a factor of 10. I mainly opened this for purposes of discussion, with the target number up for consideration.

At the prior value of 10000, we would have an expected 10 samples beyond the 99.9th percentile, which will probably be fairly noisy. Increasing this number improves that, but it should be balanced against memory usage (8 bytes per sample) and the cost of sorting the samples (currently done at the logging time once per minute).

Increasing by a factor of 10 seemed reasonable to me, but I'm open to feedback.

As mentioned previously, there are other more involved changes to improve our accuracy proposed in other issues.