### PR TITLE
Add exception-safety to Deque::grow

### DIFF
--- a/flow/Deque.h
+++ b/flow/Deque.h
@@ -168,10 +168,11 @@ private:
 		if (newSize > max_size()) throw std::bad_alloc();
 		//printf("Growing to %lld (%u-%u mask %u)\n", (long long)newSize, begin, end, mask);
 		T* newArr = (T*)aligned_alloc(std::max(__alignof(T), sizeof(void*)),
-		                              newSize * sizeof(T)); // SOMEDAY: FastAllocator, exception safety
+		                              newSize * sizeof(T)); // SOMEDAY: FastAllocator
 		ASSERT(newArr != nullptr);
 		for (int i = begin; i != end; i++) {
-			new (&newArr[i - begin]) T(std::move(arr[i&mask]));
+			new (&newArr[i - begin]) T(std::move_if_noexcept(arr[i & mask]));
+			static_assert(std::is_nothrow_destructible_v<T>);
 			arr[i&mask].~T();
 		}
 		aligned_free(arr);

--- a/flow/Deque.h
+++ b/flow/Deque.h
@@ -170,8 +170,15 @@ private:
 		T* newArr = (T*)aligned_alloc(std::max(__alignof(T), sizeof(void*)),
 		                              newSize * sizeof(T)); // SOMEDAY: FastAllocator
 		ASSERT(newArr != nullptr);
+		try {
+			for (int i = begin; i != end; i++) {
+				new (&newArr[i - begin]) T(std::move_if_noexcept(arr[i & mask]));
+			}
+		} catch (...) {
+			aligned_free(newArr);
+			throw;
+		}
 		for (int i = begin; i != end; i++) {
-			new (&newArr[i - begin]) T(std::move_if_noexcept(arr[i & mask]));
 			static_assert(std::is_nothrow_destructible_v<T>);
 			arr[i&mask].~T();
 		}


### PR DESCRIPTION
If `Deque::grow` throws an exception while relocating its contents, it would leave the `Deque` in an unrecoverable state.