### PR TITLE
Remove using namespace std::rel_ops

### DIFF
--- a/fdbclient/CoordinationInterface.h
+++ b/fdbclient/CoordinationInterface.h
@@ -103,8 +103,12 @@ struct LeaderInfo {
 	LeaderInfo() : forward(false) {}
 	LeaderInfo(UID changeID) : changeID(changeID), forward(false) {}
 
-	bool operator < (LeaderInfo const& r) const { return changeID < r.changeID; }
-	bool operator == (LeaderInfo const& r) const { return changeID == r.changeID; }
+	bool operator<(LeaderInfo const& r) const { return changeID < r.changeID; }
+	bool operator>(LeaderInfo const& r) const { return r < *this; }
+	bool operator<=(LeaderInfo const& r) const { return !(*this > r); }
+	bool operator>=(LeaderInfo const& r) const { return !(*this < r); }
+	bool operator==(LeaderInfo const& r) const { return changeID == r.changeID; }
+	bool operator!=(LeaderInfo const& r) const { return !(*this == r); }
 
 	// The first 7 bits of ChangeID represent cluster controller process class fitness, the lower the better
 	void updateChangeID(ClusterControllerPriorityInfo info) {

--- a/fdbclient/DatabaseConfiguration.h
+++ b/fdbclient/DatabaseConfiguration.h
@@ -206,6 +206,7 @@ struct DatabaseConfiguration {
 		const_cast<DatabaseConfiguration*>(&rhs)->makeConfigurationImmutable();
 		return rawConfiguration == rhs.rawConfiguration;
 	}
+	bool operator!=(DatabaseConfiguration const& rhs) const { return !(*this == rhs); }
 
 	template <class Ar>
 	void serialize(Ar& ar) {

--- a/fdbclient/FDBTypes.h
+++ b/fdbclient/FDBTypes.h
@@ -858,6 +858,9 @@ struct LogMessageVersion {
 		if (r.version<version) return false;
 		return sub < r.sub;
 	}
+	bool operator>(LogMessageVersion const& r) const { return r < *this; }
+	bool operator<=(LogMessageVersion const& r) const { return !(*this > r); }
+	bool operator>=(LogMessageVersion const& r) const { return !(*this < r); }
 
 	bool operator==(LogMessageVersion const& r) const { return version == r.version && sub == r.sub; }
 
@@ -944,6 +947,7 @@ struct ClusterControllerPriorityInfo {
 	uint8_t dcFitness;
 
 	bool operator== (ClusterControllerPriorityInfo const& r) const { return processClassFitness == r.processClassFitness && isExcluded == r.isExcluded && dcFitness == r.dcFitness; }
+	bool operator!=(ClusterControllerPriorityInfo const& r) const { return !(*this == r); }
 	ClusterControllerPriorityInfo()
 	  : ClusterControllerPriorityInfo(/*ProcessClass::UnsetFit*/ 2, false,
 	                                  ClusterControllerPriorityInfo::FitnessUnknown) {}

--- a/fdbclient/RYWIterator.cpp
+++ b/fdbclient/RYWIterator.cpp
@@ -95,6 +95,9 @@ RYWIterator& RYWIterator::operator--() {
 }
 
 bool RYWIterator::operator == ( const RYWIterator& r ) const { return cache == r.cache && writes == r.writes; }
+bool RYWIterator::operator!=(const RYWIterator& r) const {
+	return !(*this == r);
+}
 
 void RYWIterator::skip( KeyRef key ) {     // Changes *this to the segment containing key (so that beginKey()<=key && key < endKey())
 	cache.skip(key);

--- a/fdbclient/RYWIterator.h
+++ b/fdbclient/RYWIterator.h
@@ -50,6 +50,7 @@ public:
 	RYWIterator& operator--();
 
 	bool operator == ( const RYWIterator& r ) const;
+	bool operator!=(const RYWIterator& r) const;
 
 	void skip( KeyRef key );
 	

--- a/fdbclient/SnapshotCache.h
+++ b/fdbclient/SnapshotCache.h
@@ -245,6 +245,7 @@ public:
 		}
 
 		bool operator == ( const iterator& r ) const { return it == r.it && offset == r.offset; }
+		bool operator!=(const iterator& r) const { return !(*this == r); }
 
 		void skip( KeyRef key ) {      // Changes *this to the segment containing key (so that beginKey()<=key && key < endKey())
 			if( key == allKeys.end ) {

--- a/fdbclient/StatusClient.actor.cpp
+++ b/fdbclient/StatusClient.actor.cpp
@@ -276,8 +276,8 @@ void JSONDoc::mergeValueInto(json_spirit::mValue &dst, const json_spirit::mValue
 			break;
 
 		default:
-			if(dst != src)
-				dst = json_spirit::mObject({{"ERROR", "Values do not match."}, {"a", dst}, {"b", src}});
+		    if (!(dst == src))
+			    dst = json_spirit::mObject({ { "ERROR", "Values do not match." }, { "a", dst }, { "b", src } });
 	}
 }
 

--- a/fdbclient/VersionedMap.cpp
+++ b/fdbclient/VersionedMap.cpp
@@ -22,6 +22,7 @@ struct VersionedMapHarness {
 		const K& operator->() const { return it.key(); }
 
 		bool operator==(result const& k) const { return it == k.it; }
+		bool operator!=(result const& k) const { return !(*this == k); }
 	};
 
 	map s;

--- a/fdbclient/WriteMap.h
+++ b/fdbclient/WriteMap.h
@@ -37,6 +37,7 @@ struct RYWMutation {
 	bool operator == (const RYWMutation& r) const {
 		return value == r.value && type == r.type;
 	}
+	bool operator!=(const RYWMutation& r) const { return !(*this == r); }
 };
 
 class OperationStack {

--- a/fdbrpc/Locality.h
+++ b/fdbrpc/Locality.h
@@ -179,6 +179,7 @@ public:
 		return ((_data.size() == rhs._data.size())													&&
 					  (std::equal(_data.begin(), _data.end(), rhs._data.begin())));
 	}
+	bool operator!=(LocalityData const& rhs) const { return !(*this == rhs); }
 
 	Optional<Standalone<StringRef>>	get(StringRef key) const {
 		auto pos = _data.find(key);

--- a/fdbrpc/ReplicationTypes.h
+++ b/fdbrpc/ReplicationTypes.h
@@ -49,10 +49,12 @@ struct AttribValue {
 	int	_id;
 	explicit AttribValue():_id(-1) {}
 	explicit AttribValue(int id):_id(id) {}
-	bool operator==(AttribValue const& source) const
-	{	return _id == source._id;	}
-	bool operator<(AttribValue const& source) const
-	{	return _id < source._id;	}
+	bool operator==(AttribValue const& source) const { return _id == source._id; }
+	bool operator!=(AttribValue const& source) const { return !(*this == source); }
+	bool operator<(AttribValue const& source) const { return _id < source._id; }
+	bool operator>(AttribValue const& source) const { return source < *this; }
+	bool operator<=(AttribValue const& source) const { return !(*this > source); }
+	bool operator>=(AttribValue const& source) const { return !(*this < source); }
 };
 struct LocalityEntry {
 	int	_id;

--- a/fdbserver/ArtMutationBuffer.h
+++ b/fdbserver/ArtMutationBuffer.h
@@ -55,6 +55,7 @@ public:
         bool operator==(const const_iterator &other) const {
             return (artIterator) == (other.artIterator);
         }
+        bool operator!=(const const_iterator& other) const { return !(*this == other); }
 
         const_iterator &operator++() {
             ++(artIterator);

--- a/fdbserver/ClusterController.actor.cpp
+++ b/fdbserver/ClusterController.actor.cpp
@@ -570,6 +570,9 @@ public:
 			if (role != ProcessClass::TLog && role != ProcessClass::LogRouter && bestFit != r.bestFit) return bestFit < r.bestFit;
 			return count > r.count;
 		}
+		bool operator>(RoleFitness const& r) const { return r < *this; }
+		bool operator<=(RoleFitness const& r) const { return !(*this > r); }
+		bool operator>=(RoleFitness const& r) const { return !(*this < r); }
 
 		bool betterFitness (RoleFitness const& r) const {
 			if (worstFit != r.worstFit) return worstFit < r.worstFit;
@@ -615,6 +618,9 @@ public:
 			}
 			return resolver.count > r.resolver.count;
 		}
+		bool operator>(RoleFitnessPair const& r) const { return r < *this; }
+		bool operator<=(RoleFitnessPair const& r) const { return !(*this > r); }
+		bool operator>=(RoleFitnessPair const& r) const { return !(*this < r); }
 
 		bool operator == (RoleFitnessPair const& r) const { return proxy == r.proxy && resolver == r.resolver; }
 	};

--- a/fdbserver/CoordinationInterface.h
+++ b/fdbserver/CoordinationInterface.h
@@ -63,9 +63,13 @@ struct UniqueGeneration {
 		if (r.generation < generation) return false;
 		return uid < r.uid;
 	}
+	bool operator>(UniqueGeneration const& r) const { return r < *this; }
+	bool operator<=(UniqueGeneration const& r) const { return !(*this > r); }
+	bool operator>=(UniqueGeneration const& r) const { return !(*this < r); }
 	bool operator == (UniqueGeneration const& r) const {
 		return generation == r.generation && uid == r.uid;
 	}
+	bool operator!=(UniqueGeneration const& r) const { return !(*this == r); }
 	template <class Ar>
 	void serialize(Ar& ar) {
 		serializer(ar, generation, uid);

--- a/fdbserver/DBCoreState.h
+++ b/fdbserver/DBCoreState.h
@@ -149,6 +149,7 @@ struct DBCoreState {
 		       pseudoLocalities == r.pseudoLocalities;
 	}
 	bool operator==(const DBCoreState& rhs) const { return isEqual(rhs); }
+	bool operator!=(const DBCoreState& rhs) const { return !isEqual(rhs); }
 
 	template <class Archive>
 	void serialize(Archive& ar) {

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -352,6 +352,7 @@ struct ServerStatus {
 	const char* toString() const { return isFailed ? "Failed" : isUndesired ? "Undesired" : "Healthy"; }
 
 	bool operator == (ServerStatus const& r) const { return isFailed == r.isFailed && isUndesired == r.isUndesired && isWrongConfiguration == r.isWrongConfiguration && locality == r.locality && initialized == r.initialized; }
+	bool operator!=(ServerStatus const& r) const { return !(*this == r); }
 
 	//If a process has reappeared without the storage server that was on it (isFailed == true), we don't need to exclude it
 	//We also don't need to exclude processes who are in the wrong configuration (since those servers will be removed)

--- a/fdbserver/DataDistribution.actor.h
+++ b/fdbserver/DataDistribution.actor.h
@@ -135,9 +135,13 @@ public:
 			if( servers == r.servers ) return primary < r.primary;
 			return servers < r.servers;
 		}
+		bool operator>(const Team& r) const { return r < *this; }
+		bool operator<=(const Team& r) const { return !(*this > r); }
+		bool operator>=(const Team& r) const { return !(*this < r); }
 		bool operator == ( const Team& r ) const {
 			return servers == r.servers && primary == r.primary;
 		}
+		bool operator!=(const Team& r) const { return !(*this == r); }
 	};
 
 	// This tracks the data distribution on the data distribution server so that teamTrackers can

--- a/fdbserver/DataDistributionQueue.actor.cpp
+++ b/fdbserver/DataDistributionQueue.actor.cpp
@@ -79,6 +79,7 @@ struct RelocateData {
 	bool operator== (const RelocateData& rhs) const {
 		return priority == rhs.priority && boundaryPriority == rhs.boundaryPriority && healthPriority == rhs.healthPriority && keys == rhs.keys && startTime == rhs.startTime && workFactor == rhs.workFactor && src == rhs.src && completeSources == rhs.completeSources && wantsNewServers == rhs.wantsNewServers && randomId == rhs.randomId;
 	}
+	bool operator!=(const RelocateData& rhs) const { return !(*this == rhs); }
 };
 
 class ParallelTCInfo : public ReferenceCounted<ParallelTCInfo>, public IDataDistributionTeam {

--- a/fdbserver/IDiskQueue.h
+++ b/fdbserver/IDiskQueue.h
@@ -50,6 +50,9 @@ public:
 			if (hi>r.hi) return false;
 			return lo < r.lo;
 		}
+		bool operator>(location const& r) const { return r < *this; }
+		bool operator<=(location const& r) const { return !(*this > r); }
+		bool operator>=(location const& r) const { return !(*this < r); }
 
 		bool operator == (const location& r) const {
 			return hi == r.hi && lo == r.lo;

--- a/fdbserver/LogSystemDiskQueueAdapter.h
+++ b/fdbserver/LogSystemDiskQueueAdapter.h
@@ -33,6 +33,7 @@ struct PeekTxsInfo {
 	bool operator == (const PeekTxsInfo& r) const {
 		return primaryLocality == r.primaryLocality && secondaryLocality == r.secondaryLocality && knownCommittedVersion == r.knownCommittedVersion;
 	}
+	bool operator!=(const PeekTxsInfo& r) const { return !(*this == r); }
 
 	PeekTxsInfo(int8_t primaryLocality, int8_t secondaryLocality, Version knownCommittedVersion) : primaryLocality(primaryLocality), secondaryLocality(secondaryLocality), knownCommittedVersion(knownCommittedVersion) {}
 };

--- a/fdbserver/VersionedBTree.actor.cpp
+++ b/fdbserver/VersionedBTree.actor.cpp
@@ -2153,6 +2153,7 @@ struct SplitStringRef {
 		const uint8_t* next;
 
 		inline bool operator==(const const_iterator& rhs) const { return ptr == rhs.ptr; }
+		inline bool operator!=(const const_iterator& rhs) const { return !(*this == rhs); }
 
 		inline const_iterator& operator++() {
 			++ptr;
@@ -6254,8 +6255,12 @@ struct IntIntPair {
 	}
 
 	bool operator==(const IntIntPair& rhs) const { return compare(rhs) == 0; }
+	bool operator!=(const IntIntPair& rhs) const { return compare(rhs) != 0; }
 
 	bool operator<(const IntIntPair& rhs) const { return compare(rhs) < 0; }
+	bool operator>(const IntIntPair& rhs) const { return compare(rhs) > 0; }
+	bool operator<=(const IntIntPair& rhs) const { return compare(rhs) <= 0; }
+	bool operator>=(const IntIntPair& rhs) const { return compare(rhs) >= 0; }
 
 	int deltaSize(const IntIntPair& base, int skipLen, bool worstcase) const { return sizeof(Delta); }
 

--- a/flow/Arena.h
+++ b/flow/Arena.h
@@ -889,6 +889,10 @@ public:
 			if ((*this)[i] != rhs[i]) return false;
 		return true;
 	}
+	template <VecSerStrategy S>
+	bool operator!=(VectorRef<T, S> const& rhs) const {
+		return !(*this == rhs);
+	}
 
 	// Warning: Do not mutate a VectorRef that has previously been copy constructed or assigned,
 	// since copies will share data

--- a/flow/Deque.h
+++ b/flow/Deque.h
@@ -108,6 +108,7 @@ public:
 				return false;
 		return true;
 	}
+	bool operator!=(const Deque& r) const { return !(*this == r); }
 
 	~Deque() {
 		cleanup();

--- a/flow/FastRef.h
+++ b/flow/FastRef.h
@@ -165,5 +165,9 @@ template <class P>
 bool operator==( const Reference<P>& lhs, const Reference<P>& rhs ) {
 	return lhs.getPtr() == rhs.getPtr();
 }
+template <class P>
+bool operator!=(const Reference<P>& lhs, const Reference<P>& rhs) {
+	return !(lhs == rhs);
+}
 
 #endif

--- a/flow/IKeyValueContainer.h
+++ b/flow/IKeyValueContainer.h
@@ -49,6 +49,9 @@ struct KeyValueMapPair {
 	}
 
 	bool operator<(KeyValueMapPair const& r) const { return key < r.key; }
+	bool operator>(KeyValueMapPair const& r) const { return r < *this; }
+	bool operator<=(KeyValueMapPair const& r) const { return !(*this > r); }
+	bool operator>=(KeyValueMapPair const& r) const { return !(*this < r); }
 	bool operator==(KeyValueMapPair const& r) const { return key == r.key; }
 	bool operator!=(KeyValueMapPair const& r) const { return key != r.key; }
 };

--- a/flow/IRandom.h
+++ b/flow/IRandom.h
@@ -79,6 +79,9 @@ public:
 	bool operator == ( const UID& r ) const { return part[0]==r.part[0] && part[1]==r.part[1]; }
 	bool operator != ( const UID& r ) const { return part[0]!=r.part[0] || part[1]!=r.part[1]; }
 	bool operator < ( const UID& r ) const { return part[0] < r.part[0] || (part[0] == r.part[0] && part[1] < r.part[1]); }
+	bool operator>(const UID& r) const { return r < *this; }
+	bool operator<=(const UID& r) const { return !(*this > r); }
+	bool operator>=(const UID& r) const { return !(*this < r); }
 
 	uint64_t hash() const { return first(); }
 	uint64_t first() const { return part[0]; }

--- a/flow/IndexedSet.h
+++ b/flow/IndexedSet.h
@@ -376,7 +376,9 @@ public:
 		return ::compare(key, r);
 	}
 	bool operator<(MapPair<Key,Value> const& r) const { return key < r.key; }
+	bool operator>(MapPair<Key, Value> const& r) const { return key > r.key; }
 	bool operator<=(MapPair<Key,Value> const& r) const { return key <= r.key; }
+	bool operator>=(MapPair<Key, Value> const& r) const { return key >= r.key; }
 	bool operator==(MapPair<Key,Value> const& r) const { return key == r.key; }
 	bool operator!=(MapPair<Key,Value> const& r) const { return key != r.key; }
 

--- a/flow/TreeBenchmark.h
+++ b/flow/TreeBenchmark.h
@@ -63,6 +63,7 @@ struct MapHarness {
 		const K& operator->() const { return it->first; }
 
 		bool operator==(result const& k) const { return it == k.it; }
+		bool operator!=(result const& k) const { return it != k.it; }
 	};
 
 	map s;

--- a/flow/flow.h
+++ b/flow/flow.h
@@ -48,8 +48,6 @@
 
 #include <boost/version.hpp>
 
-using namespace std::rel_ops;
-
 #define TEST(condition)                                                                                                \
 	if (!(condition)) {                                                                                                \
 	} else {                                                                                                           \

--- a/flow/network.h
+++ b/flow/network.h
@@ -223,6 +223,9 @@ struct NetworkAddress {
 			return ip < r.ip;
 		return port < r.port;
 	}
+	bool operator>(NetworkAddress const& r) const { return r < *this; }
+	bool operator<=(NetworkAddress const& r) const { return !(*this > r); }
+	bool operator>=(NetworkAddress const& r) const { return !(*this < r); }
 
 	bool isValid() const { return ip.isValid() || port != 0; }
 	bool isPublic() const { return !(flags & FLAG_PRIVATE); }


### PR DESCRIPTION
`using namespace std::rel_ops;`

This causes the following to not compile
```
#include <utility>
#include <vector>

using namespace std::rel_ops;

int main() {
    std::vector<int> xs;
    return xs.rbegin() != xs.rend();
}
```

See https://godbolt.org/z/s1977n.

This would mean that we have to write some extra boilerplate comparison operators now