### PR TITLE
Unclear error message in fdbbackup if the backup url uses a symlink

### DIFF
--- a/fdbclient/BackupContainer.actor.cpp
+++ b/fdbclient/BackupContainer.actor.cpp
@@ -1545,9 +1545,13 @@ public:
 		// Remove trailing slashes on path
 		path.erase(path.find_last_not_of("\\/") + 1);
 
-		if(!g_network->isSimulated() && path != abspath(path)) {
-			TraceEvent(SevWarn, "BackupContainerLocalDirectory").detail("Description", "Backup path must be absolute (e.g. file:///some/path)").detail("URL", url).detail("Path", path);
-			throw io_error();
+		std::string absolutePath = abspath(path);
+		
+		if(!g_network->isSimulated() && path != absolutePath) {
+			TraceEvent(SevWarn, "BackupContainerLocalDirectory").detail("Description", "Backup path must be absolute (e.g. file:///some/path)").detail("URL", url).detail("Path", path).detail("AbsolutePath", absolutePath);
+			// throw io_error();
+			IBackupContainer::lastOpenError = format("Backup path '%s' must be the absolute path '%s'", path.c_str(), absolutePath.c_str());
+			throw backup_invalid_url();
 		}
 
 		// Finalized path written to will be will be <path>/backup-<uid>


### PR DESCRIPTION
# Unclear error message in fdbbackup if the backup url uses a symlink

## Problem statement
If a file backup url usesng a symlink then fdbbackup fails with an unclear error message 'Disk i/o operation failed'

## Steps to reproduce
1. Create a FDB cluster
2. Create a symlink file to a backup location
3. Start fdbbackup using the symlink file as the backup destination
```
fdbbackup start -C fdb-primary.cluster -d file:///mnt/backup/fdb/hot/9
```

## Expected result
Starting backup progress or a clear error message why it can not start

## Actual result
```
ERROR: 'Disk i/o operation failed' on URL 'file:///mnt/backup/fdb/hot/9'
```

## Findings
The BackupContainerLocalDirectory constructor compares the url file path with the it's absolute path and throws io_error if these paths are different. I don't know the reason of this checking, but the exception thrown does not contain any useful information about the failed check

Proposal
1. Put a clear informational message to IBackupContainer::lastOpenError
2. Throw backup_invalid_url instead of io_error for forcing fdbbackup exception handler to use IBackupContainer::lastOpenError

This pull request implements this proposal. The new error message is 
```
ERROR: 'Backup Container URL invalid' on URL 'file:///mnt/backup/fdb/hot/9': Backup path '/mnt/backup/fdb/hot/9' must be the absolute path '/mnt/synology/nfs/backup/fdb/hot/9'
```
