### PR TITLE
Add unit tests for SmallVectorRef and VectorRef

### DIFF
--- a/flow/Arena.cpp
+++ b/flow/Arena.cpp
@@ -426,10 +426,9 @@ void testIteratorIncrement() {
 	}
 	{
 		int i = 0;
-		for (auto iter = xs.begin(); iter != xs.end();) {
+		for (auto iter = xs.begin(); iter != xs.end() && i < xs.size() - 1;) {
 			ASSERT(*++iter == StringRef(std::to_string(++i)));
 		}
-		ASSERT(i == size);
 	}
 }
 

--- a/flow/Arena.cpp
+++ b/flow/Arena.cpp
@@ -430,6 +430,38 @@ void testIteratorIncrement() {
 			ASSERT(*++iter == StringRef(std::to_string(++i)));
 		}
 	}
+	{
+		int i = 0;
+		for (auto iter = xs.begin(); iter < xs.end();) {
+			ASSERT(*iter == StringRef(std::to_string(i)));
+			iter += 2;
+			i += 2;
+		}
+	}
+	{
+		int i = xs.size() - 1;
+		for (auto iter = xs.end() - 1; iter >= xs.begin();) {
+			ASSERT(*iter == StringRef(std::to_string(i)));
+			iter -= 2;
+			i -= 2;
+		}
+	}
+	{
+		int i = 0;
+		for (auto iter = xs.begin(); iter < xs.end();) {
+			ASSERT(*iter == StringRef(std::to_string(i)));
+			iter = iter + 2;
+			i += 2;
+		}
+	}
+	{
+		int i = xs.size() - 1;
+		for (auto iter = xs.end() - 1; iter >= xs.begin();) {
+			ASSERT(*iter == StringRef(std::to_string(i)));
+			iter = iter - 2;
+			i -= 2;
+		}
+	}
 }
 
 template <template <class> class VectorRefLike>
@@ -460,7 +492,24 @@ void testAppend() {
 	VectorRefLike<StringRef> ys;
 	ys.append(a, xs.begin(), xs.size());
 	ASSERT(xs.size() == ys.size());
-	ASSERT(xs == ys);
+	ASSERT(std::equal(xs.begin(), xs.end(), ys.begin()));
+}
+
+template <template <class> class VectorRefLike>
+void testCopy() {
+	Standalone<VectorRefLike<StringRef>> xs;
+	int size = deterministicRandom()->randomInt(0, 100);
+	for (int i = 0; i < size; ++i) {
+		xs.push_back_deep(xs.arena(), StringRef(std::to_string(i)));
+	}
+	Arena a;
+	VectorRefLike<StringRef> ys(a, xs);
+	xs = Standalone<VectorRefLike<StringRef>>();
+	int i = 0;
+	for (const auto& y : ys) {
+		ASSERT(y == StringRef(std::to_string(i++)));
+	}
+	ASSERT(i == size);
 }
 
 template <template <class> class VectorRefLike>

--- a/flow/Arena.cpp
+++ b/flow/Arena.cpp
@@ -518,6 +518,7 @@ void testVectorLike() {
 	testIteratorIncrement<VectorRefLike>();
 	testReverseIterator<VectorRefLike>();
 	testAppend<VectorRefLike>();
+	testCopy<VectorRefLike>();
 }
 } // namespace
 

--- a/flow/Arena.cpp
+++ b/flow/Arena.cpp
@@ -433,9 +433,42 @@ void testIteratorIncrement() {
 }
 
 template <template <class> class VectorRefLike>
+void testReverseIterator() {
+	VectorRefLike<StringRef> xs;
+	Arena a;
+	int size = deterministicRandom()->randomInt(0, 100);
+	for (int i = 0; i < size; ++i) {
+		xs.push_back_deep(a, StringRef(std::to_string(i)));
+	}
+	ASSERT(xs.size() == size);
+
+	int i = xs.size() - 1;
+	for (auto iter = xs.rbegin(); iter != xs.rend();) {
+		ASSERT(*iter++ == StringRef(std::to_string(i--)));
+	}
+	ASSERT(i == -1);
+}
+
+template <template <class> class VectorRefLike>
+void testAppend() {
+	VectorRefLike<StringRef> xs;
+	Arena a;
+	int size = deterministicRandom()->randomInt(0, 100);
+	for (int i = 0; i < size; ++i) {
+		xs.push_back_deep(a, StringRef(std::to_string(i)));
+	}
+	VectorRefLike<StringRef> ys;
+	ys.append(a, xs.begin(), xs.size());
+	ASSERT(xs.size() == ys.size());
+	ASSERT(xs == ys);
+}
+
+template <template <class> class VectorRefLike>
 void testVectorLike() {
 	testRangeBasedForLoop<VectorRefLike>();
 	testIteratorIncrement<VectorRefLike>();
+	testReverseIterator<VectorRefLike>();
+	testAppend<VectorRefLike>();
 }
 } // namespace
 
@@ -452,5 +485,13 @@ template <class T>
 using SmallVectorRefProxy = SmallVectorRef<T>;
 TEST_CASE("/flow/Arena/SmallVectorRef") {
 	testVectorLike<SmallVectorRefProxy>();
+	return Void();
+}
+
+// Fix number of template parameters
+template <class T>
+using SmallVectorRef10Proxy = SmallVectorRef<T, 10>;
+TEST_CASE("/flow/Arena/SmallVectorRef10") {
+	testVectorLike<SmallVectorRef10Proxy>();
 	return Void();
 }

--- a/flow/Arena.h
+++ b/flow/Arena.h
@@ -1068,7 +1068,7 @@ public:
 			if (i < InlineMembers) {
 				return vec->arr[i];
 			} else {
-				return vec->data[i];
+				return vec->data[i - InlineMembers];
 			}
 		}
 		reference get() const { return get(idx); }

--- a/flow/Arena.h
+++ b/flow/Arena.h
@@ -1066,6 +1066,10 @@ public:
 			res.idx -= diff;
 			return res;
 		}
+		friend difference_type operator-(const self_t& lhs, const self_t& rhs) {
+			ASSERT(lhs.vec == rhs.vec);
+			return lhs.idx - rhs.idx;
+		}
 
 		self_t& operator++() {
 			++idx;


### PR DESCRIPTION
Test that SmallVectorRef is a drop-in replacement for VectorRef. Includes changes from #3509.

TODO make sure test coverage is adequate.