### PR TITLE
Use consistent integer size for net2backtraces_count

### DIFF
--- a/flow/Platform.cpp
+++ b/flow/Platform.cpp
@@ -3221,7 +3221,7 @@ extern volatile void** net2backtraces;
 extern volatile size_t net2backtraces_offset;
 extern volatile size_t net2backtraces_max;
 extern volatile bool net2backtraces_overflow;
-extern volatile int64_t net2backtraces_count;
+extern volatile int net2backtraces_count;
 extern std::atomic<int64_t> net2RunLoopIterations;
 extern std::atomic<int64_t> net2RunLoopSleeps;
 extern void initProfiling();


### PR DESCRIPTION
`net2backtraces_count` is defined to be an `int` in Net2.actor.cpp. Defining it to be an `int64_t` here causes us to read 4 bytes of extra memory.