### PR TITLE
Fix file identifier conflicts

### DIFF
--- a/fdbclient/ManagementAPI.actor.cpp
+++ b/fdbclient/ManagementAPI.actor.cpp
@@ -1089,14 +1089,19 @@ struct AutoQuorumChange : IQuorumChange {
 		// Check availability
 		ClientCoordinators coord(ccf);
 		vector<Future<Optional<LeaderInfo>>> leaderServers;
-		for( int i = 0; i < coord.clientLeaderServers.size(); i++ )
+		for (int i = 0; i < coord.clientLeaderServers.size(); i++) {
 			leaderServers.push_back( retryBrokenPromise( coord.clientLeaderServers[i].getLeader, GetLeaderRequest( coord.clusterKey, UID() ), TaskPriority::CoordinationReply ) );
+		}
 		Optional<vector<Optional<LeaderInfo>>> results =
 		    wait(timeout(getAll(leaderServers), CLIENT_KNOBS->IS_ACCEPTABLE_DELAY));
-		if (!results.present()) return false; // Not all responded
-		for (auto& r : results.get())
-			if (!r.present())
+		if (!results.present()) {
+			return false;
+		} // Not all responded
+		for (auto& r : results.get()) {
+			if (!r.present()) {
 				return false;   // Coordinator doesn't know about this database?
+			}
+		}
 
 		// Check exclusions
 		for(auto& c : oldCoordinators) {

--- a/fdbclient/ManagementAPI.actor.cpp
+++ b/fdbclient/ManagementAPI.actor.cpp
@@ -1091,9 +1091,10 @@ struct AutoQuorumChange : IQuorumChange {
 		vector<Future<Optional<LeaderInfo>>> leaderServers;
 		for( int i = 0; i < coord.clientLeaderServers.size(); i++ )
 			leaderServers.push_back( retryBrokenPromise( coord.clientLeaderServers[i].getLeader, GetLeaderRequest( coord.clusterKey, UID() ), TaskPriority::CoordinationReply ) );
-		Optional<vector<Optional<LeaderInfo>>> results = wait( timeout( getAll(leaderServers), CLIENT_KNOBS->IS_ACCEPTABLE_DELAY ) );
-		if (!results.present()) return false;  // Not all responded
-		for(auto& r : results.get())
+		Optional<vector<Optional<LeaderInfo>>> results =
+		    wait(timeout(getAll(leaderServers), CLIENT_KNOBS->IS_ACCEPTABLE_DELAY));
+		if (!results.present()) return false; // Not all responded
+		for (auto& r : results.get())
 			if (!r.present())
 				return false;   // Coordinator doesn't know about this database?
 

--- a/fdbclient/MasterProxyInterface.h
+++ b/fdbclient/MasterProxyInterface.h
@@ -433,7 +433,7 @@ struct GetDDMetricsRequest {
 
 struct ProxySnapRequest
 {
-	constexpr static FileIdentifier file_identifier = 22204900;
+	constexpr static FileIdentifier file_identifier = 5427684;
 	Arena arena;
 	StringRef snapPayload;
 	UID snapUID;

--- a/fdbclient/RestoreWorkerInterface.actor.h
+++ b/fdbclient/RestoreWorkerInterface.actor.h
@@ -71,7 +71,7 @@ struct RestoreSysInfo {
 };
 
 struct RestoreWorkerInterface {
-	constexpr static FileIdentifier file_identifier = 99601798;
+	constexpr static FileIdentifier file_identifier = 15715718;
 	UID interfID;
 
 	RequestStream<RestoreSimpleRequest> heartbeat;
@@ -101,7 +101,7 @@ struct RestoreWorkerInterface {
 };
 
 struct RestoreRoleInterface {
-	constexpr static FileIdentifier file_identifier = 62531339;
+	constexpr static FileIdentifier file_identifier = 12199691;
 	UID nodeID;
 	RestoreRole role;
 
@@ -124,7 +124,7 @@ struct RestoreRoleInterface {
 };
 
 struct RestoreLoaderInterface : RestoreRoleInterface {
-	constexpr static FileIdentifier file_identifier = 84244651;
+	constexpr static FileIdentifier file_identifier = 358571;
 
 	RequestStream<RestoreSimpleRequest> heartbeat;
 	RequestStream<RestoreSysInfoRequest> updateRestoreSysInfo;
@@ -165,7 +165,7 @@ struct RestoreLoaderInterface : RestoreRoleInterface {
 };
 
 struct RestoreApplierInterface : RestoreRoleInterface {
-	constexpr static FileIdentifier file_identifier = 54253048;
+	constexpr static FileIdentifier file_identifier = 3921400;
 
 	RequestStream<RestoreSimpleRequest> heartbeat;
 	RequestStream<RestoreSendVersionedMutationsRequest> sendMutationVector;
@@ -289,7 +289,7 @@ struct RestoreAsset {
 };
 
 struct LoadingParam {
-	constexpr static FileIdentifier file_identifier = 17023837;
+	constexpr static FileIdentifier file_identifier = 246621;
 
 	bool isRangeFile;
 	Key url;
@@ -326,7 +326,7 @@ struct LoadingParam {
 };
 
 struct RestoreRecruitRoleReply : TimedRequest {
-	constexpr static FileIdentifier file_identifier = 30310092;
+	constexpr static FileIdentifier file_identifier = 13532876;
 
 	UID id;
 	RestoreRole role;
@@ -359,7 +359,7 @@ struct RestoreRecruitRoleReply : TimedRequest {
 };
 
 struct RestoreRecruitRoleRequest : TimedRequest {
-	constexpr static FileIdentifier file_identifier = 87022360;
+	constexpr static FileIdentifier file_identifier = 3136280;
 
 	RestoreRole role;
 	int nodeIndex; // Each role is a node
@@ -385,7 +385,7 @@ struct RestoreRecruitRoleRequest : TimedRequest {
 
 // Static info. across version batches
 struct RestoreSysInfoRequest : TimedRequest {
-	constexpr static FileIdentifier file_identifier = 75960741;
+	constexpr static FileIdentifier file_identifier = 8851877;
 
 	RestoreSysInfo sysInfo;
 	Standalone<VectorRef<std::pair<KeyRangeRef, Version>>> rangeVersions;
@@ -411,7 +411,7 @@ struct RestoreSysInfoRequest : TimedRequest {
 };
 
 struct RestoreLoadFileReply : TimedRequest {
-	constexpr static FileIdentifier file_identifier = 34077902;
+	constexpr static FileIdentifier file_identifier = 523470;
 
 	LoadingParam param;
 	MutationsVec samples; // sampled mutations
@@ -436,7 +436,7 @@ struct RestoreLoadFileReply : TimedRequest {
 
 // Sample_Range_File and Assign_Loader_Range_File, Assign_Loader_Log_File
 struct RestoreLoadFileRequest : TimedRequest {
-	constexpr static FileIdentifier file_identifier = 26557364;
+	constexpr static FileIdentifier file_identifier = 9780148;
 
 	int batchIndex;
 	LoadingParam param;
@@ -459,7 +459,7 @@ struct RestoreLoadFileRequest : TimedRequest {
 };
 
 struct RestoreSendMutationsToAppliersRequest : TimedRequest {
-	constexpr static FileIdentifier file_identifier = 68827305;
+	constexpr static FileIdentifier file_identifier = 1718441;
 
 	int batchIndex; // version batch index
 	std::map<Key, UID> rangeToApplier;
@@ -485,7 +485,7 @@ struct RestoreSendMutationsToAppliersRequest : TimedRequest {
 };
 
 struct RestoreSendVersionedMutationsRequest : TimedRequest {
-	constexpr static FileIdentifier file_identifier = 69764565;
+	constexpr static FileIdentifier file_identifier = 2655701;
 
 	int batchIndex; // version batch index
 	RestoreAsset asset; // Unique identifier for the current restore asset
@@ -516,7 +516,7 @@ struct RestoreSendVersionedMutationsRequest : TimedRequest {
 };
 
 struct RestoreVersionBatchRequest : TimedRequest {
-	constexpr static FileIdentifier file_identifier = 97223537;
+	constexpr static FileIdentifier file_identifier = 13337457;
 
 	int batchIndex;
 
@@ -560,7 +560,7 @@ struct RestoreFinishRequest : TimedRequest {
 };
 
 struct RestoreRequest {
-	constexpr static FileIdentifier file_identifier = 49589770;
+	constexpr static FileIdentifier file_identifier = 16035338;
 
 	int index;
 	Key tagName;

--- a/fdbrpc/fdbrpc.h
+++ b/fdbrpc/fdbrpc.h
@@ -103,11 +103,8 @@ struct NetSAV : SAV<T>, FlowReceiver, FastAllocated<NetSAV<T>> {
 	}
 };
 
-
-
 template <class T>
-class ReplyPromise sealed : public ComposedIdentifier<T, 0x2>
-{
+class ReplyPromise sealed : public ComposedIdentifier<T, 1> {
 public:
 	template <class U>
 	void send(U&& value) const {

--- a/fdbserver/CoordinationInterface.h
+++ b/fdbserver/CoordinationInterface.h
@@ -138,7 +138,7 @@ struct CandidacyRequest {
 };
 
 struct ElectionResultRequest {
-	constexpr static FileIdentifier file_identifier = 78924329;
+	constexpr static FileIdentifier file_identifier = 11815465;
 	Key key;
 	vector<NetworkAddress> coordinators;
 	UID knownLeader;

--- a/fdbserver/DataDistributorInterface.h
+++ b/fdbserver/DataDistributorInterface.h
@@ -96,7 +96,7 @@ struct GetDataDistributorMetricsRequest {
 
 struct DistributorSnapRequest
 {
-	constexpr static FileIdentifier file_identifier = 22204900;
+	constexpr static FileIdentifier file_identifier = 5427684;
 	Arena arena;
 	StringRef snapPayload;
 	UID snapUID;
@@ -114,7 +114,7 @@ struct DistributorSnapRequest
 
 struct DistributorExclusionSafetyCheckReply
 {
-	constexpr static FileIdentifier file_identifier = 382104712;
+	constexpr static FileIdentifier file_identifier = 13005960;
 	bool safe;
 
 	DistributorExclusionSafetyCheckReply() : safe(false) {}

--- a/fdbserver/RestoreUtil.h
+++ b/fdbserver/RestoreUtil.h
@@ -73,7 +73,7 @@ std::string getHexString(StringRef input);
 bool debugFRMutation(const char* context, Version version, MutationRef const& mutation);
 
 struct RestoreCommonReply {
-	constexpr static FileIdentifier file_identifier = 56140435;
+	constexpr static FileIdentifier file_identifier = 5808787;
 	UID id; // unique ID of the server who sends the reply
 	bool isDuplicated;
 
@@ -93,7 +93,7 @@ struct RestoreCommonReply {
 };
 
 struct RestoreSimpleRequest : TimedRequest {
-	constexpr static FileIdentifier file_identifier = 83557801;
+	constexpr static FileIdentifier file_identifier = 16448937;
 
 	ReplyPromise<RestoreCommonReply> reply;
 

--- a/fdbserver/WorkerInterface.actor.h
+++ b/fdbserver/WorkerInterface.actor.h
@@ -378,7 +378,7 @@ struct InitializeLogRouterRequest {
 };
 
 struct InitializeBackupReply {
-	constexpr static FileIdentifier file_identifier = 63843557;
+	constexpr static FileIdentifier file_identifier = 13511909;
 	struct BackupInterface interf;
 	LogEpoch backupEpoch;
 
@@ -392,7 +392,7 @@ struct InitializeBackupReply {
 };
 
 struct InitializeBackupRequest {
-	constexpr static FileIdentifier file_identifier = 68354279;
+	constexpr static FileIdentifier file_identifier = 1245415;
 	UID reqId;
 	LogEpoch recruitedEpoch; // The epoch the worker is recruited.
 	LogEpoch backupEpoch; // The epoch the worker should work on. If different from the recruitedEpoch, then it refers

--- a/flow/Arena.h
+++ b/flow/Arena.h
@@ -212,7 +212,7 @@ inline void save( Archive& ar, const Arena& p ) {
 //    assertion failures are preferable. This is the main reason we
 //    don't intend to use std::optional directly.
 template <class T>
-class Optional : public ComposedIdentifier<T, 0x10> {
+class Optional : public ComposedIdentifier<T, 4> {
 public:
 	Optional() = default;
 
@@ -783,7 +783,7 @@ struct VectorRefPreserializer<T, VecSerStrategy::String> {
 };
 
 template <class T, VecSerStrategy SerStrategy = VecSerStrategy::FlatBuffers>
-class VectorRef : public ComposedIdentifier<T, 0x8>, public VectorRefPreserializer<T, SerStrategy> {
+class VectorRef : public ComposedIdentifier<T, 3>, public VectorRefPreserializer<T, SerStrategy> {
 	using VPS = VectorRefPreserializer<T, SerStrategy>;
 	friend class VectorRef<T, SerStrategy == VecSerStrategy::FlatBuffers ? VecSerStrategy::String
 	                                                                     : VecSerStrategy::FlatBuffers>;

--- a/flow/FileIdentifier.h
+++ b/flow/FileIdentifier.h
@@ -48,6 +48,8 @@ struct FileIdentifierForBase<T, false> {};
 template <class T>
 struct FileIdentifierForBase<T, true> {
 	static constexpr FileIdentifier value = T::file_identifier;
+	static_assert(CompositionDepthFor<T>::value > 0 || T::file_identifier < (1 << 24),
+	              "non-composed file identifiers must be less than 2^24");
 };
 
 template <class T>

--- a/flow/FileIdentifier.h
+++ b/flow/FileIdentifier.h
@@ -32,6 +32,13 @@ struct HasFileIdentifierMember : std::false_type {};
 template <typename T>
 struct HasFileIdentifierMember<T, decltype((void)T::file_identifier, 0)> : std::true_type {};
 
+template <typename T, typename = int>
+struct CompositionDepthFor : std::integral_constant<int, 0> {};
+
+template <typename T>
+struct CompositionDepthFor<T, decltype((void)T::composition_depth, 0)>
+  : std::integral_constant<int, T::composition_depth> {};
+
 template <class T, bool>
 struct FileIdentifierForBase;
 
@@ -52,16 +59,27 @@ struct HasFileIdentifier : std::false_type {};
 template <typename T>
 struct HasFileIdentifier<T, decltype((void)FileIdentifierFor<T>::value, 0)> : std::true_type {};
 
-template <class T, uint32_t B, bool = HasFileIdentifier<T>::value>
+template <class T, uint8_t B, bool = (HasFileIdentifier<T>::value && CompositionDepthFor<T>::value < 2)>
 struct ComposedIdentifier;
 
-template <class T, uint32_t B>
-struct ComposedIdentifier<T, B, true>
-{
-	static constexpr FileIdentifier file_identifier = (B << 24) | FileIdentifierFor<T>::value;
+// Manually specified file identifiers must be less than 2^24.
+// The first 8 bits are used to identify the wrapper classes:
+//   The 5th-8th bits represent the inner wrapper class
+//   The 1st-4th bits represent the outer wrapper class
+// Types with more than two level of composition do not get file identifiers.
+template <class T, uint8_t B>
+struct ComposedIdentifier<T, B, true> {
+	static_assert(CompositionDepthFor<T>::value < 2);
+	static constexpr int composed_identifier_offset = (CompositionDepthFor<T>::value == 1) ? 28 : 24;
+	static_assert(B > 0 && B < 16, "Up to 15 types of composed identifiers allowed");
+	static_assert(FileIdentifierFor<T>::value < (1 << composed_identifier_offset));
+
+public:
+	static constexpr int composition_depth = CompositionDepthFor<T>::value + 1;
+	static constexpr FileIdentifier file_identifier = (B << composed_identifier_offset) | FileIdentifierFor<T>::value;
 };
 
-template <class T, uint32_t B>
+template <class T, uint8_t B>
 struct ComposedIdentifier<T, B, false> {};
 
 template <class T, uint32_t B, bool = HasFileIdentifier<T>::value>

--- a/flow/flat_buffers.h
+++ b/flow/flat_buffers.h
@@ -1216,6 +1216,7 @@ namespace detail {
 template <class T>
 struct YesFileIdentifier {
 	constexpr static FileIdentifier file_identifier = FileIdentifierFor<T>::value;
+	constexpr static bool composition_depth = CompositionDepthFor<T>::value;
 };
 struct NoFileIdentifier {};
 }; // namespace detail

--- a/flow/flow.h
+++ b/flow/flow.h
@@ -132,7 +132,7 @@ public:
 class Never {};
 
 template <class T>
-class ErrorOr : public ComposedIdentifier<T, 0x1> {
+class ErrorOr : public ComposedIdentifier<T, 2> {
 public:
 	ErrorOr() : ErrorOr(default_error_or()) {}
 	ErrorOr(Error const& error) : error(error) { memset(&value, 0, sizeof(value)); }

--- a/flow/serialize.h
+++ b/flow/serialize.h
@@ -156,6 +156,7 @@ struct PairFileIdentifier<F, S, false> {};
 
 template <class F, class S>
 struct PairFileIdentifier<F, S, true> {
+	// FIXME: pair<A,B> and pair<B,A> have the same file identifier
 	constexpr static FileIdentifier value = FileIdentifierFor<F>::value ^ FileIdentifierFor<S>::value;
 };
 
@@ -171,7 +172,15 @@ public:
 };
 
 template <class T, class Allocator>
-struct FileIdentifierFor<std::vector<T, Allocator>> : ComposedIdentifierExternal<T, 0x10> {};
+struct FileIdentifierFor<std::vector<T, Allocator>> : ComposedIdentifierExternal<T, 5> {};
+
+template <class T, class Allocator>
+struct CompositionDepthFor<std::vector<T, Allocator>> : std::integral_constant<int, CompositionDepthFor<T>::value + 1> {
+};
+
+template <class F, class S>
+struct CompositionDepthFor<std::pair<F, S>>
+  : std::integral_constant<int, std::max(CompositionDepthFor<F>::value, CompositionDepthFor<S>::value)> {};
 
 template <class Archive, class T>
 inline void save( Archive& ar, const std::vector<T>& value ) {

--- a/flow/serialize.h
+++ b/flow/serialize.h
@@ -148,21 +148,6 @@ public:
 	}
 };
 
-template <class F, class S, bool = HasFileIdentifier<F>::value&& HasFileIdentifier<S>::value>
-struct PairFileIdentifier;
-
-template <class F, class S>
-struct PairFileIdentifier<F, S, false> {};
-
-template <class F, class S>
-struct PairFileIdentifier<F, S, true> {
-	// FIXME: pair<A,B> and pair<B,A> have the same file identifier
-	constexpr static FileIdentifier value = FileIdentifierFor<F>::value ^ FileIdentifierFor<S>::value;
-};
-
-template <class F, class S>
-struct FileIdentifierFor<std::pair<F, S>> : PairFileIdentifier<F, S> {};
-
 template <class Archive, class T1, class T2>
 class Serializer< Archive, std::pair<T1,T2>, void > {
 public:
@@ -177,10 +162,6 @@ struct FileIdentifierFor<std::vector<T, Allocator>> : ComposedIdentifierExternal
 template <class T, class Allocator>
 struct CompositionDepthFor<std::vector<T, Allocator>> : std::integral_constant<int, CompositionDepthFor<T>::value + 1> {
 };
-
-template <class F, class S>
-struct CompositionDepthFor<std::pair<F, S>>
-  : std::integral_constant<int, std::max(CompositionDepthFor<F>::value, CompositionDepthFor<S>::value)> {};
 
 template <class Archive, class T>
 inline void save( Archive& ar, const std::vector<T>& value ) {


### PR DESCRIPTION
This addresses https://github.com/apple/foundationdb/issues/3405. The first byte of a file identifier is now reserved for composed identifiers, while the next 3 bytes are manually specified. This helps to avoid file identifier conflicts  There are the following restrictions:
- All manually specified file identifiers must be less than 2^24
- There are a maximum of 15 allowed composed identifiers
- Only 2 levels of composition are allowed (types with 3 or more levels of composition like `ReplyPromise<ErrorOr<Optional<T>>>` will not get file identifiers and should be wrapped in other classes if necessary).