### PR TITLE
Fix wild pointer to destructed DD that causes DD crash rarely

### DIFF
--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -2996,10 +2996,6 @@ ACTOR Future<Void> teamTracker(DDTeamCollection* self, Reference<TCTeamInfo> tea
 			// because the teamTracker can be triggered after a DDTeamCollection was destroyed and
 			// before the other DDTeamCollection is destroyed.
 			for (int i = 0; i < self->teamCollections.size(); ++i) {
-				TraceEvent("TeamTracker", self->distributorId)
-				    .detail("Primary", self->primary)
-				    .detail("TeamCollectionIndex", i)
-				    .detail("TeamCollectionPtr", (long long)self->teamCollections[i]);
 				if (self->teamCollections[i] == nullptr) {
 					throw actor_cancelled();
 				}

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -3216,7 +3216,7 @@ ACTOR Future<Void> teamTracker(DDTeamCollection* self, Reference<TCTeamInfo> tea
 						rs.priority = maxPriority;
 
 						self->output.send(rs);
-						TraceEvent("SendRelocateToDDQx100", self->distributorId)
+						TraceEvent("SendRelocateToDDQueue", self->distributorId)
 						    .suppressFor(1.0)
 						    .detail("Primary", self->primary)
 						    .detail("Team", team->getDesc())

--- a/flow/error_definitions.h
+++ b/flow/error_definitions.h
@@ -30,6 +30,7 @@
 
 // 1xxx Normal failure (plausibly these should not even be "errors", but they are failures of
 //   the way operations are currently defined)
+// clang-format off
 ERROR( success, 0, "Success" )
 ERROR( end_of_stream, 1, "End of stream" )
 ERROR( operation_failed, 1000, "Operation failed")
@@ -228,6 +229,7 @@ ERROR( snap_with_recovery_unsupported, 2508, "Cluster recovery during snapshot o
 // 4xxx Internal errors (those that should be generated only by bugs) are decimal 4xxx
 ERROR( unknown_error, 4000, "An unknown error occurred" )  // C++ exception not of type Error
 ERROR( internal_error, 4100, "An internal error occurred" )
+// clang-format on
 
 #undef ERROR
 #endif

--- a/flow/error_definitions.h
+++ b/flow/error_definitions.h
@@ -70,7 +70,7 @@ ERROR( connection_unreferenced, 1048, "No peer references for connection" )
 ERROR( connection_idle, 1049, "Connection closed after idle timeout" )
 ERROR( disk_adapter_reset, 1050, "The disk queue adpater reset" )
 ERROR( batch_transaction_throttled, 1051, "Batch GRV request rate limit exceeded")
-ERROR(dd_cancelled, 1052, "Data distribution components cancelled")
+ERROR( dd_cancelled, 1052, "Data distribution components cancelled")
 
 ERROR( broken_promise, 1100, "Broken promise" )
 ERROR( operation_cancelled, 1101, "Asynchronous operation cancelled" )

--- a/flow/error_definitions.h
+++ b/flow/error_definitions.h
@@ -70,6 +70,7 @@ ERROR( connection_unreferenced, 1048, "No peer references for connection" )
 ERROR( connection_idle, 1049, "Connection closed after idle timeout" )
 ERROR( disk_adapter_reset, 1050, "The disk queue adpater reset" )
 ERROR( batch_transaction_throttled, 1051, "Batch GRV request rate limit exceeded")
+ERROR(dd_cancelled, 1052, "Data distribution components cancelled")
 
 ERROR( broken_promise, 1100, "Broken promise" )
 ERROR( operation_cancelled, 1101, "Asynchronous operation cancelled" )

--- a/flow/flow.h
+++ b/flow/flow.h
@@ -795,13 +795,9 @@ public:
 	bool isValid() const { return sav != NULL; }
 	Promise() : sav(new SAV<T>(0, 1)) {}
 	Promise(const Promise& rhs) : sav(rhs.sav) {
-		//TraceEvent("MXTestPromiseCopy").detail("RHS", (long long) rhs.sav).detail("MySAV",(long long) sav);
 		sav->addPromiseRef();
 	}
-	Promise(Promise&& rhs) BOOST_NOEXCEPT : sav(rhs.sav) {
-		//TraceEvent("MXTestPromiseMove");
-		rhs.sav = 0; // Should be nullptr
-	}
+	Promise(Promise&& rhs) BOOST_NOEXCEPT : sav(rhs.sav) { rhs.sav = 0; }
 	~Promise() { if (sav) sav->delPromiseRef(); }
 
 	void operator=(const Promise& rhs) {

--- a/flow/flow.h
+++ b/flow/flow.h
@@ -408,7 +408,7 @@ struct SingleCallback {
 	}
 };
 
-// SAV is short for Single Assigment Variable: It can be assigned for only once!
+// SAV is short for Single Assignment Variable: It can be assigned for only once!
 template <class T>
 struct SAV : private Callback<T>, FastAllocated<SAV<T>> {
 	int promises; // one for each promise (and one for an active actor if this is an actor)
@@ -794,8 +794,14 @@ public:
 	bool canBeSet() { return sav->canBeSet(); }
 	bool isValid() const { return sav != NULL; }
 	Promise() : sav(new SAV<T>(0, 1)) {}
-	Promise(const Promise& rhs) : sav(rhs.sav) { sav->addPromiseRef(); }
-	Promise(Promise&& rhs) BOOST_NOEXCEPT : sav(rhs.sav) { rhs.sav = 0; }
+	Promise(const Promise& rhs) : sav(rhs.sav) {
+		//TraceEvent("MXTestPromiseCopy").detail("RHS", (long long) rhs.sav).detail("MySAV",(long long) sav);
+		sav->addPromiseRef();
+	}
+	Promise(Promise&& rhs) BOOST_NOEXCEPT : sav(rhs.sav) {
+		//TraceEvent("MXTestPromiseMove");
+		rhs.sav = 0; // Should be nullptr
+	}
 	~Promise() { if (sav) sav->delPromiseRef(); }
 
 	void operator=(const Promise& rhs) {

--- a/flow/genericactors.actor.h
+++ b/flow/genericactors.actor.h
@@ -613,7 +613,12 @@ protected:
 		Promise<Void> noDestroy = trigger;  // The send(Void()) or even V::operator= could cause destroyOnCancel,
 			                                // which could undo the change to i.value here.  Keeping the promise reference count >= 2
 			                                // prevents destroyOnCancel from erasing anything from the map.
-
+		if (noDestroy.getPromiseReferenceCount() < 2) {
+			TraceEvent(SevError, "MXPromiseIncorrectMove")
+			    .detail("PromiseCount", noDestroy.getPromiseReferenceCount())
+			    .detail("FutureCount", noDestroy.getFutureReferenceCount());
+		}
+		ASSERT_WE_THINK(trigger.isValid()); // = should not move the variable trigger
 		if (v == defaultValue)
 			items.erase(k);
 		else

--- a/flow/genericactors.actor.h
+++ b/flow/genericactors.actor.h
@@ -613,16 +613,11 @@ protected:
 		Promise<Void> noDestroy = trigger;  // The send(Void()) or even V::operator= could cause destroyOnCancel,
 			                                // which could undo the change to i.value here.  Keeping the promise reference count >= 2
 			                                // prevents destroyOnCancel from erasing anything from the map.
-		if (noDestroy.getPromiseReferenceCount() < 2) {
-			TraceEvent(SevError, "MXPromiseIncorrectMove")
-			    .detail("PromiseCount", noDestroy.getPromiseReferenceCount())
-			    .detail("FutureCount", noDestroy.getFutureReferenceCount());
-		}
-		ASSERT_WE_THINK(trigger.isValid()); // = should not move the variable trigger
-		if (v == defaultValue)
+		if (v == defaultValue) {
 			items.erase(k);
-		else
+		} else {
 			i.value = v;
+		}
 
 		trigger.send(Void());
 	}


### PR DESCRIPTION
This fixes the rare bug that has been a ghost in nightly test for a while. The most recent bug reproduction is at https://github.com/apple/foundationdb/issues/3525. 

**Bug analysis:**
teamTracker only works when all DDTeamCollections are valid.
However, teamTracker can be triggered by zeroTeamSignalling event 
after a DDTeamCollection is destructed and the other DDTeamCollection has not been
destructed yet.

This causes teamTracker to uses a pointer to the destructed DDTeamCollection and thus
has mysterious failure.

**Fix**
When DDTeamCollection is destructed, we need to reset other  DDTeamCollections' pointer that points to the destructed DDTeamCollection. 

In TeamTracker, we check all DDTeamCollections are valid; otherwise, throw actor_cancelled() error. 