### PR TITLE
Tag api-version with each special key range implementation

### DIFF
--- a/fdbclient/DatabaseContext.h
+++ b/fdbclient/DatabaseContext.h
@@ -343,7 +343,8 @@ public:
 	AsyncTrigger updateCache;
 	std::vector<std::unique_ptr<SpecialKeyRangeBaseImpl>> specialKeySpaceModules;
 	std::unique_ptr<SpecialKeySpace> specialKeySpace;
-	void registerSpecialKeySpaceModule(SpecialKeySpace::MODULE module, std::unique_ptr<SpecialKeyRangeBaseImpl> impl);
+	void registerSpecialKeySpaceModule(SpecialKeySpace::MODULE module, std::unique_ptr<SpecialKeyRangeBaseImpl> impl,
+	                                   int apiVersion);
 
 	static bool debugUseTags;
 	static const std::vector<std::string> debugTransactionTagChoices; 

--- a/fdbserver/workloads/SpecialKeySpaceCorrectness.actor.cpp
+++ b/fdbserver/workloads/SpecialKeySpaceCorrectness.actor.cpp
@@ -95,7 +95,7 @@ struct SpecialKeySpaceCorrectnessWorkload : TestWorkload {
 			self->impls.push_back(std::make_shared<SKSCTestImpl>(KeyRangeRef(startKey, endKey)));
 			// Although there are already ranges registered, the testing range will replace them
 			cx->specialKeySpace->registerKeyRange(SpecialKeySpace::MODULE::TESTONLY, self->keys.back(),
-			                                      self->impls.back().get());
+			                                      self->impls.back().get(), 630);
 			// generate keys in each key range
 			int keysInRange = deterministicRandom()->randomInt(self->minKeysPerRange, self->maxKeysPerRange + 1);
 			self->keysCount += keysInRange;


### PR DESCRIPTION
Discussed with Andrew. Although this is not required to do, I think it's better to have.

The pr does two things:
- Tag API-version with each special key range implementation

Although we do not explicitly use it right now, it may be useful in the future.


- Registration will ignore implementation on the existing overlapping range with higher versions

For example, if we want to update the implementation `Impl` introduced in `700`, on  `range`, in a new version like `800`, we have two choices.
We can change the `Impl` to handle version changes and not change the registration code
```
if(apiVersionAtLeast(700)) {
        // register Impl on range
}
```
Or if the update is big enough to have a new implementation, let's call `ImplV2`, then the registration code should be
```
if(apiVersionAtLeast(800)) {
        // register ImplV2 on range
}
if(apiVersionAtLeast(700)) {
        // register Impl on range
}
```
We'll ignore the second registration if we already register in a higher version.
But for clients with version less than `800`, they are still using `Impl`, with nothing to change. 
