### PR TITLE
added the ability to suspend processes from fdbcli

### DIFF
--- a/documentation/sphinx/source/downloads.rst
+++ b/documentation/sphinx/source/downloads.rst
@@ -10,38 +10,38 @@ macOS
 
 The macOS installation package is supported on macOS 10.7+. It includes the client and (optionally) the server.
 
-* `FoundationDB-6.2.23.pkg <https://www.foundationdb.org/downloads/6.2.23/macOS/installers/FoundationDB-6.2.23.pkg>`_
+* `FoundationDB-6.2.24.pkg <https://www.foundationdb.org/downloads/6.2.24/macOS/installers/FoundationDB-6.2.24.pkg>`_
 
 Ubuntu
 ------
 
 The Ubuntu packages are supported on 64-bit Ubuntu 12.04+, but beware of the Linux kernel bug in Ubuntu 12.x.
 
-* `foundationdb-clients-6.2.23-1_amd64.deb <https://www.foundationdb.org/downloads/6.2.23/ubuntu/installers/foundationdb-clients_6.2.23-1_amd64.deb>`_
-* `foundationdb-server-6.2.23-1_amd64.deb <https://www.foundationdb.org/downloads/6.2.23/ubuntu/installers/foundationdb-server_6.2.23-1_amd64.deb>`_ (depends on the clients package)
+* `foundationdb-clients-6.2.24-1_amd64.deb <https://www.foundationdb.org/downloads/6.2.24/ubuntu/installers/foundationdb-clients_6.2.24-1_amd64.deb>`_
+* `foundationdb-server-6.2.24-1_amd64.deb <https://www.foundationdb.org/downloads/6.2.24/ubuntu/installers/foundationdb-server_6.2.24-1_amd64.deb>`_ (depends on the clients package)
 
 RHEL/CentOS EL6
 ---------------
 
 The RHEL/CentOS EL6 packages are supported on 64-bit RHEL/CentOS 6.x.
 
-* `foundationdb-clients-6.2.23-1.el6.x86_64.rpm <https://www.foundationdb.org/downloads/6.2.23/rhel6/installers/foundationdb-clients-6.2.23-1.el6.x86_64.rpm>`_
-* `foundationdb-server-6.2.23-1.el6.x86_64.rpm <https://www.foundationdb.org/downloads/6.2.23/rhel6/installers/foundationdb-server-6.2.23-1.el6.x86_64.rpm>`_ (depends on the clients package)
+* `foundationdb-clients-6.2.24-1.el6.x86_64.rpm <https://www.foundationdb.org/downloads/6.2.24/rhel6/installers/foundationdb-clients-6.2.24-1.el6.x86_64.rpm>`_
+* `foundationdb-server-6.2.24-1.el6.x86_64.rpm <https://www.foundationdb.org/downloads/6.2.24/rhel6/installers/foundationdb-server-6.2.24-1.el6.x86_64.rpm>`_ (depends on the clients package)
 
 RHEL/CentOS EL7
 ---------------
 
 The RHEL/CentOS EL7 packages are supported on 64-bit RHEL/CentOS 7.x.
 
-* `foundationdb-clients-6.2.23-1.el7.x86_64.rpm <https://www.foundationdb.org/downloads/6.2.23/rhel7/installers/foundationdb-clients-6.2.23-1.el7.x86_64.rpm>`_
-* `foundationdb-server-6.2.23-1.el7.x86_64.rpm <https://www.foundationdb.org/downloads/6.2.23/rhel7/installers/foundationdb-server-6.2.23-1.el7.x86_64.rpm>`_ (depends on the clients package)
+* `foundationdb-clients-6.2.24-1.el7.x86_64.rpm <https://www.foundationdb.org/downloads/6.2.24/rhel7/installers/foundationdb-clients-6.2.24-1.el7.x86_64.rpm>`_
+* `foundationdb-server-6.2.24-1.el7.x86_64.rpm <https://www.foundationdb.org/downloads/6.2.24/rhel7/installers/foundationdb-server-6.2.24-1.el7.x86_64.rpm>`_ (depends on the clients package)
 
 Windows
 -------
 
 The Windows installer is supported on 64-bit Windows XP and later. It includes the client and (optionally) the server.
 
-* `foundationdb-6.2.23-x64.msi <https://www.foundationdb.org/downloads/6.2.23/windows/installers/foundationdb-6.2.23-x64.msi>`_
+* `foundationdb-6.2.24-x64.msi <https://www.foundationdb.org/downloads/6.2.24/windows/installers/foundationdb-6.2.24-x64.msi>`_
 
 API Language Bindings
 =====================
@@ -58,18 +58,18 @@ On macOS and Windows, the FoundationDB Python API bindings are installed as part
 
 If you need to use the FoundationDB Python API from other Python installations or paths, download the Python package:
 
-* `foundationdb-6.2.23.tar.gz <https://www.foundationdb.org/downloads/6.2.23/bindings/python/foundationdb-6.2.23.tar.gz>`_
+* `foundationdb-6.2.24.tar.gz <https://www.foundationdb.org/downloads/6.2.24/bindings/python/foundationdb-6.2.24.tar.gz>`_
 
 Ruby 1.9.3/2.0.0+
 -----------------
 
-* `fdb-6.2.23.gem <https://www.foundationdb.org/downloads/6.2.23/bindings/ruby/fdb-6.2.23.gem>`_
+* `fdb-6.2.24.gem <https://www.foundationdb.org/downloads/6.2.24/bindings/ruby/fdb-6.2.24.gem>`_
 
 Java 8+
 -------
 
-* `fdb-java-6.2.23.jar <https://www.foundationdb.org/downloads/6.2.23/bindings/java/fdb-java-6.2.23.jar>`_
-* `fdb-java-6.2.23-javadoc.jar <https://www.foundationdb.org/downloads/6.2.23/bindings/java/fdb-java-6.2.23-javadoc.jar>`_
+* `fdb-java-6.2.24.jar <https://www.foundationdb.org/downloads/6.2.24/bindings/java/fdb-java-6.2.24.jar>`_
+* `fdb-java-6.2.24-javadoc.jar <https://www.foundationdb.org/downloads/6.2.24/bindings/java/fdb-java-6.2.24-javadoc.jar>`_
 
 Go 1.11+
 --------

--- a/documentation/sphinx/source/release-notes/release-notes-620.rst
+++ b/documentation/sphinx/source/release-notes/release-notes-620.rst
@@ -4,6 +4,14 @@
 Release Notes
 #############
 
+6.2.24
+======
+
+Features
+--------
+
+* Added the ``suspend`` command to ``fdbcli`` which kills a process and prevents it from rejoining the cluster for a specified duration. `(PR #3550) <https://github.com/apple/foundationdb/pull/3550>`_
+
 6.2.23
 ======
 

--- a/fdbcli/fdbcli.actor.cpp
+++ b/fdbcli/fdbcli.actor.cpp
@@ -3254,11 +3254,11 @@ ACTOR Future<int> cli(CLIOptions opt, LineNoise* plinenoise) {
 						}
 						wait( waitForAll(addInterfs) );
 						if(address_interface.size() == 0) {
-							printf("\nNo addresses can be killed.\n");
+							printf("\nNo addresses can be suspended.\n");
 						} else if(address_interface.size() == 1) {
-							printf("\nThe following address can be killed:\n");
+							printf("\nThe following address can be suspended:\n");
 						} else {
-							printf("\nThe following %zu addresses can be killed:\n", address_interface.size());
+							printf("\nThe following %zu addresses can be suspended:\n", address_interface.size());
 						}
 						for( auto it : address_interface ) {
 							printf("%s\n", printable(it.first).c_str());

--- a/fdbcli/fdbcli.actor.cpp
+++ b/fdbcli/fdbcli.actor.cpp
@@ -553,6 +553,10 @@ void initHelp() {
 		"kill all|list|<ADDRESS>*",
 		"attempts to kill one or more processes in the cluster",
 		"If no addresses are specified, populates the list of processes which can be killed. Processes cannot be killed before this list has been populated.\n\nIf `all' is specified, attempts to kill all known processes.\n\nIf `list' is specified, displays all known processes. This is only useful when the database is unresponsive.\n\nFor each IP:port pair in <ADDRESS>*, attempt to kill the specified process.");
+	helpMap["suspend"] = CommandHelp(
+		"suspend <SECONDS> <ADDRESS>*",
+		"attempts to suspend one or more processes in the cluster",
+		"If parameters are specified, populates the list of processes which can be suspended. Processes cannot be suspended before this list has been populated.\n\nFor each IP:port pair in <ADDRESS>*, attempt to suspend the processes for the specified SECONDS after which the process will die.");
 	helpMap["profile"] = CommandHelp(
 		"<type> <action> <ARGS>",
 		"namespace for all the profiling-related commands.",
@@ -3234,6 +3238,59 @@ ACTOR Future<int> cli(CLIOptions opt, LineNoise* plinenoise) {
 								tr->set(LiteralStringRef("\xff\xff/reboot_worker"), address_interface[tokens[i]].first);
 							}
 							printf("Attempted to kill %zu processes\n", tokens.size() - 1);
+						}
+					}
+					continue;
+				}
+
+				if (tokencmp(tokens[0], "suspend")) {
+					getTransaction(db, tr, options, intrans);
+					if (tokens.size() == 1) {
+						Standalone<RangeResultRef> kvs = wait( makeInterruptable( tr->getRange(KeyRangeRef(LiteralStringRef("\xff\xff/worker_interfaces"), LiteralStringRef("\xff\xff\xff")), 1) ) );
+						Reference<FlowLock> connectLock(new FlowLock(CLIENT_KNOBS->CLI_CONNECT_PARALLELISM));
+						std::vector<Future<Void>> addInterfs;
+						for( auto it : kvs ) {
+							addInterfs.push_back(addInterface(&address_interface, connectLock, it));
+						}
+						wait( waitForAll(addInterfs) );
+						if(address_interface.size() == 0) {
+							printf("\nNo addresses can be killed.\n");
+						} else if(address_interface.size() == 1) {
+							printf("\nThe following address can be killed:\n");
+						} else {
+							printf("\nThe following %zu addresses can be killed:\n", address_interface.size());
+						}
+						for( auto it : address_interface ) {
+							printf("%s\n", printable(it.first).c_str());
+						}
+						printf("\n");
+					} else if(tokens.size() == 2) {
+						printUsage(tokens[0]);
+						is_error = true;
+					} else {
+						for(int i = 2; i < tokens.size(); i++) {
+							if(!address_interface.count(tokens[i])) {
+								printf("ERROR: process `%s' not recognized.\n", printable(tokens[i]).c_str());
+								is_error = true;
+								break;
+							}
+						}
+
+						if(!is_error) {
+							double seconds;
+							int n=0;
+							auto secondsStr = tokens[1].toString();
+							if (sscanf(secondsStr.c_str(), "%lf%n", &seconds, &n) != 1 || n != secondsStr.size()) {
+								printUsage(tokens[0]);
+								is_error = true;
+							} else {
+								int64_t timeout_ms = seconds*1000;
+								tr->setOption(FDBTransactionOptions::TIMEOUT, StringRef((uint8_t *)&timeout_ms, sizeof(int64_t)));
+								for(int i = 2; i < tokens.size(); i++) {
+									tr->set(LiteralStringRef("\xff\xff/suspend_worker"), address_interface[tokens[i]].first);
+								}
+								printf("Attempted to suspend %zu processes\n", tokens.size() - 2);
+							}
 						}
 					}
 					continue;

--- a/fdbcli/fdbcli.actor.cpp
+++ b/fdbcli/fdbcli.actor.cpp
@@ -556,7 +556,7 @@ void initHelp() {
 	helpMap["suspend"] = CommandHelp(
 		"suspend <SECONDS> <ADDRESS>*",
 		"attempts to suspend one or more processes in the cluster",
-		"If parameters are specified, populates the list of processes which can be suspended. Processes cannot be suspended before this list has been populated.\n\nFor each IP:port pair in <ADDRESS>*, attempt to suspend the processes for the specified SECONDS after which the process will die.");
+		"If no parameters are specified, populates the list of processes which can be suspended. Processes cannot be suspended before this list has been populated.\n\nFor each IP:port pair in <ADDRESS>*, attempt to suspend the processes for the specified SECONDS after which the process will die.");
 	helpMap["profile"] = CommandHelp(
 		"<type> <action> <ARGS>",
 		"namespace for all the profiling-related commands.",

--- a/fdbclient/ReadYourWrites.actor.cpp
+++ b/fdbclient/ReadYourWrites.actor.cpp
@@ -1610,13 +1610,19 @@ void ReadYourWritesTransaction::atomicOp( const KeyRef& key, const ValueRef& ope
 }
 
 void ReadYourWritesTransaction::set( const KeyRef& key, const ValueRef& value ) {
-	if (key == LiteralStringRef("\xff\xff/reboot_worker")){
-		BinaryReader::fromStringRef<ClientWorkerInterface>(value, IncludeVersion()).reboot.send( RebootRequest() );
-		return;
-	}
-	if (key == LiteralStringRef("\xff\xff/reboot_and_check_worker")){
-		BinaryReader::fromStringRef<ClientWorkerInterface>(value, IncludeVersion()).reboot.send( RebootRequest(false, true) );
-		return;
+	if (key.startsWith(systemKeys.end)) {
+		if (key == LiteralStringRef("\xff\xff/reboot_worker")){
+			BinaryReader::fromStringRef<ClientWorkerInterface>(value, IncludeVersion()).reboot.send( RebootRequest() );
+			return;
+		}
+		if (key == LiteralStringRef("\xff\xff/suspend_worker")){
+			BinaryReader::fromStringRef<ClientWorkerInterface>(value, IncludeVersion()).reboot.send( RebootRequest(false, false, options.timeoutInSeconds) );
+			return;
+		}
+		if (key == LiteralStringRef("\xff\xff/reboot_and_check_worker")){
+			BinaryReader::fromStringRef<ClientWorkerInterface>(value, IncludeVersion()).reboot.send( RebootRequest(false, true) );
+			return;
+		}
 	}
 	if (key == metadataVersionKey) {
 		throw client_invalid_operation();


### PR DESCRIPTION
The purpose of this command is to kill a process and prevent it from rejoining the cluster for a period of time. In particular, if a process is degraded such that it is either much slower than other processes, or its network connection is unstable, having the process in the cluster can impact the performance of the whole cluster.