### PR TITLE
Fix master branch failure on DDBalanceAndRemove.toml test

### DIFF
--- a/fdbclient/ManagementAPI.actor.cpp
+++ b/fdbclient/ManagementAPI.actor.cpp
@@ -1317,7 +1317,7 @@ ACTOR Future<Void> includeServers(Database cx, vector<AddressExclusion> servers,
 			}
 
 			for(auto& s : servers ) {
-				if (!s.isValid()) {
+				if (!s.isValid()) { // Include all excluded servers if input servers are invalid
 					if (failed) {
 						tr.clear(failedServersKeys);
 					} else {

--- a/fdbrpc/sim2.actor.cpp
+++ b/fdbrpc/sim2.actor.cpp
@@ -1217,21 +1217,40 @@ public:
 			if (tooManyDead) {
 				newKt = Reboot;
 				canSurvive = false;
-				TraceEvent("KillChanged").detail("KillType", kt).detail("NewKillType", newKt).detail("TLogPolicy", tLogPolicy->info()).detail("Reason", "tLogPolicy validates against dead processes.");
+				TraceEvent("KillChanged")
+				    .detail("KillType", kt)
+				    .detail("NewKillType", newKt)
+				    .detail("TLogPolicy", tLogPolicy->info())
+				    .detail("Reason", "Too many dead processes that cannot satisfy tLogPolicy.");
 			}
 			// Reboot and Delete if remaining machines do NOT fulfill policies
 			else if ((kt < RebootAndDelete) && notEnoughLeft) {
 				newKt = RebootAndDelete;
 				canSurvive = false;
-				TraceEvent("KillChanged").detail("KillType", kt).detail("NewKillType", newKt).detail("TLogPolicy", tLogPolicy->info()).detail("Reason", "tLogPolicy does not validates against remaining processes.");
+				TraceEvent("KillChanged")
+				    .detail("KillType", kt)
+				    .detail("NewKillType", newKt)
+				    .detail("TLogPolicy", tLogPolicy->info())
+				    .detail("Reason", "Not enough tLog left to satisfy tLogPolicy.");
 			}
 			else if ((kt < RebootAndDelete) && (nQuorum > uniqueMachines.size())) {
 				newKt = RebootAndDelete;
 				canSurvive = false;
-				TraceEvent("KillChanged").detail("KillType", kt).detail("NewKillType", newKt).detail("StoragePolicy", storagePolicy->info()).detail("Quorum", nQuorum).detail("Machines", uniqueMachines.size()).detail("Reason", "Not enough unique machines to perform auto configuration of coordinators.");
+				TraceEvent("KillChanged")
+				    .detail("KillType", kt)
+				    .detail("NewKillType", newKt)
+				    .detail("StoragePolicy", storagePolicy->info())
+				    .detail("Quorum", nQuorum)
+				    .detail("Machines", uniqueMachines.size())
+				    .detail("Reason", "Not enough unique machines to perform auto configuration of coordinators.");
 			}
 			else {
-				TraceEvent("CanSurviveKills").detail("KillType", kt).detail("TLogPolicy", tLogPolicy->info()).detail("StoragePolicy", storagePolicy->info()).detail("Quorum", nQuorum).detail("Machines", uniqueMachines.size());
+				TraceEvent("CanSurviveKills")
+				    .detail("KillType", kt)
+				    .detail("TLogPolicy", tLogPolicy->info())
+				    .detail("StoragePolicy", storagePolicy->info())
+				    .detail("Quorum", nQuorum)
+				    .detail("Machines", uniqueMachines.size());
 			}
 		}
 		if (newKillType) *newKillType = newKt;

--- a/fdbrpc/simulator.h
+++ b/fdbrpc/simulator.h
@@ -38,6 +38,7 @@ public:
 
 	// Order matters!
 	enum KillType { KillInstantly, InjectFaults, RebootAndDelete, RebootProcessAndDelete, Reboot, RebootProcess, None };
+	std::string getKillTypeString(KillType killType) { return ""; }
 
 	enum BackupAgentType { NoBackupAgents, WaitForType, BackupToFile, BackupToDB };
 

--- a/fdbrpc/simulator.h
+++ b/fdbrpc/simulator.h
@@ -38,7 +38,6 @@ public:
 
 	// Order matters!
 	enum KillType { KillInstantly, InjectFaults, RebootAndDelete, RebootProcessAndDelete, Reboot, RebootProcess, None };
-	std::string getKillTypeString(KillType killType) { return ""; }
 
 	enum BackupAgentType { NoBackupAgents, WaitForType, BackupToFile, BackupToDB };
 

--- a/fdbserver/ClusterController.actor.cpp
+++ b/fdbserver/ClusterController.actor.cpp
@@ -296,7 +296,12 @@ public:
 		return results;
 	}
 
-	std::vector<WorkerDetails> getWorkersForTlogs( DatabaseConfiguration const& conf, int32_t required, int32_t desired, Reference<IReplicationPolicy> const& policy, std::map< Optional<Standalone<StringRef>>, int>& id_used, bool checkStable = false, std::set<Optional<Key>> dcIds = std::set<Optional<Key>>(), std::vector<UID> exclusionWorkerIds = {}) {
+	std::vector<WorkerDetails> getWorkersForTlogs(DatabaseConfiguration const& conf, int32_t required, int32_t desired,
+	                                              Reference<IReplicationPolicy> const& policy,
+	                                              std::map<Optional<Standalone<StringRef>>, int>& id_used,
+	                                              bool checkStable = false,
+	                                              std::set<Optional<Key>> dcIds = std::set<Optional<Key>>(),
+	                                              std::vector<UID> exclusionWorkerIds = {}) {
 		std::map<std::pair<ProcessClass::Fitness,bool>, vector<WorkerDetails>> fitness_workers;
 		std::vector<WorkerDetails> results;
 		std::vector<LocalityData> unavailableLocals;
@@ -340,7 +345,13 @@ public:
 						bCompleted = true;
 						break;
 					}
-					TraceEvent(SevWarn,"GWFTADNotAcceptable", id).detail("Fitness", fitness).detail("Processes", logServerSet->size()).detail("Required", required).detail("TLogPolicy",policy->info()).detail("DesiredLogs", desired).detail("AddingDegraded", addingDegraded);
+					TraceEvent(SevWarn, "GWFTADNotAcceptable", id)
+					    .detail("Fitness", fitness)
+					    .detail("Processes", logServerSet->size())
+					    .detail("Required", required)
+					    .detail("TLogPolicy", policy->info())
+					    .detail("DesiredLogs", desired)
+					    .detail("AddingDegraded", addingDegraded);
 				}
 				// Try to select the desired size, if larger
 				else {
@@ -374,10 +385,22 @@ public:
 				tLocalities.push_back(object->interf.locality);
 			}
 
-			TraceEvent(SevWarn, "GetTLogTeamFailed").detail("Policy", policy->info()).detail("Processes", logServerSet->size()).detail("Workers", id_worker.size()).detail("FitnessGroups", fitness_workers.size())
-				.detail("TLogZones", ::describeZones(tLocalities)).detail("TLogDataHalls", ::describeDataHalls(tLocalities)).detail("MissingZones", ::describeZones(unavailableLocals))
-				.detail("MissingDataHalls", ::describeDataHalls(unavailableLocals)).detail("Required", required).detail("DesiredLogs", desired).detail("RatingTests",SERVER_KNOBS->POLICY_RATING_TESTS)
-				.detail("CheckStable", checkStable).detail("NumExclusionWorkers", exclusionWorkerIds.size()).detail("PolicyGenerations",SERVER_KNOBS->POLICY_GENERATIONS).backtrace();
+			TraceEvent(SevWarn, "GetTLogTeamFailed")
+			    .detail("Policy", policy->info())
+			    .detail("Processes", logServerSet->size())
+			    .detail("Workers", id_worker.size())
+			    .detail("FitnessGroups", fitness_workers.size())
+			    .detail("TLogZones", ::describeZones(tLocalities))
+			    .detail("TLogDataHalls", ::describeDataHalls(tLocalities))
+			    .detail("MissingZones", ::describeZones(unavailableLocals))
+			    .detail("MissingDataHalls", ::describeDataHalls(unavailableLocals))
+			    .detail("Required", required)
+			    .detail("DesiredLogs", desired)
+			    .detail("RatingTests", SERVER_KNOBS->POLICY_RATING_TESTS)
+			    .detail("CheckStable", checkStable)
+			    .detail("NumExclusionWorkers", exclusionWorkerIds.size())
+			    .detail("PolicyGenerations", SERVER_KNOBS->POLICY_GENERATIONS)
+			    .backtrace();
 
 			logServerSet->clear();
 			logServerSet.clear();

--- a/fdbserver/workloads/RemoveServersSafely.actor.cpp
+++ b/fdbserver/workloads/RemoveServersSafely.actor.cpp
@@ -149,6 +149,8 @@ struct RemoveServersSafelyWorkload : TestWorkload {
 		return processAddrs;
 	}
 
+	// Get the list of processes whose ip:port or ip matches netAddrs.
+	// Note: item in netAddrs may be ip (representing a machine) or ip:port (representing a process)
 	virtual std::vector<ISimulator::ProcessInfo*> getProcesses(std::set<AddressExclusion> const& netAddrs)
 	{
 		std::vector<ISimulator::ProcessInfo*>	processes;
@@ -172,10 +174,24 @@ struct RemoveServersSafelyWorkload : TestWorkload {
 			auto processNet = AddressExclusion(processInfo->address.ip, processInfo->address.port);
 			if (processAddrs.find(processNet) != processAddrs.end()) {
 				processes.push_back(processInfo);
-				TraceEvent("RemoveAndKill", functionId).detail("Step", "getProcessItem").detail("ProcessAddress", processInfo->address).detail("Process", describe(*processInfo)).detail("Failed", processInfo->failed).detail("Excluded", processInfo->excluded).detail("Rebooting", processInfo->rebooting).detail("Protected", g_simulator.protectedAddresses.count(processInfo->address));
+				TraceEvent("RemoveAndKill", functionId)
+				    .detail("Step", "ProcessToKill")
+				    .detail("ProcessAddress", processInfo->address)
+				    .detail("Process", describe(*processInfo))
+				    .detail("Failed", processInfo->failed)
+				    .detail("Excluded", processInfo->excluded)
+				    .detail("Rebooting", processInfo->rebooting)
+				    .detail("Protected", g_simulator.protectedAddresses.count(processInfo->address));
 			}
 			else {
-				TraceEvent("RemoveAndKill", functionId).detail("Step", "getProcessNoItem").detail("ProcessAddress", processInfo->address).detail("Process", describe(*processInfo)).detail("Failed", processInfo->failed).detail("Excluded", processInfo->excluded).detail("Rebooting", processInfo->rebooting).detail("Protected", g_simulator.protectedAddresses.count(processInfo->address));
+				TraceEvent("RemoveAndKill", functionId)
+				    .detail("Step", "ProcessNotToKill")
+				    .detail("ProcessAddress", processInfo->address)
+				    .detail("Process", describe(*processInfo))
+				    .detail("Failed", processInfo->failed)
+				    .detail("Excluded", processInfo->excluded)
+				    .detail("Rebooting", processInfo->rebooting)
+				    .detail("Protected", g_simulator.protectedAddresses.count(processInfo->address));
 			}
 		}
 		TraceEvent("RemoveAndKill", functionId).detail("Step", "getProcesses")
@@ -247,7 +263,7 @@ struct RemoveServersSafelyWorkload : TestWorkload {
 		// Identify the largest set of processes which can be killed
 		int	randomIndex;
 		bool bCanKillProcess;
-		ISimulator::ProcessInfo*	randomProcess;
+		ISimulator::ProcessInfo* randomProcess;
 
 		for (int killsLeft = killProcArray.size(); killsLeft > 0; killsLeft --)
 		{
@@ -270,7 +286,7 @@ struct RemoveServersSafelyWorkload : TestWorkload {
 				killableProcesses.push_back(randomProcess);
 				killableAddrs.push_back(AddressExclusion(randomProcess->address.ip, randomProcess->address.port));
 				TraceEvent("RemoveAndKill")
-				    .detail("Step", "identifyVictim")
+				    .detail("Step", "IdentifyVictim")
 				    .detail("VictimCount", killableAddrs.size())
 				    .detail("Victim", randomProcess->toString())
 				    .detail("Victims", describe(killableAddrs));
@@ -285,6 +301,8 @@ struct RemoveServersSafelyWorkload : TestWorkload {
 		return killableProcesses;
 	}
 
+	// toKill1 and toKill2 are a random subset of all processes. If simply kill all processes in toKill1 or toKill2,
+	// we may kill too many processes to make the cluster unavailable and stuck.
 	ACTOR static Future<Void> workloadMain( RemoveServersSafelyWorkload* self, Database cx, double waitSeconds,
 			std::set<AddressExclusion> toKill1, std::set<AddressExclusion> toKill2 ) {
 		wait( delay( waitSeconds ) );
@@ -294,13 +312,35 @@ struct RemoveServersSafelyWorkload : TestWorkload {
 		state std::vector<ISimulator::ProcessInfo*>	killProcArray;
 		state bool bClearedFirst;
 
-		TraceEvent("RemoveAndKill").detail("Step", "exclude list first").detail("ToKill", describe(toKill1)).detail("KillTotal", toKill1.size()).detail("ClusterAvailable", g_simulator.isAvailable());
+		TraceEvent("RemoveAndKill")
+		    .detail("Step", "exclude list first")
+		    .detail("ToKill", describe(toKill1))
+		    .detail("KillTotal", toKill1.size())
+		    .detail("ClusterAvailable", g_simulator.isAvailable());
+
+		// toKill1 may kill too many servers to make cluster unavailable.
+		// Get the processes in toKill1 that are safe to kill
+		killProcArray = self->protectServers(toKill1);
+		// Update the kill networks to the killable processes
+		toKill1 = self->getNetworks(killProcArray);
+		TraceEvent("RemoveAndKill")
+		    .detail("Step", "exclude list first")
+		    .detail("ToKillModified", describe(toKill1))
+		    .detail("KillTotalModified", toKill1.size())
+		    .detail("ClusterAvailable", g_simulator.isAvailable());
+
 		self->excludeAddresses(toKill1);
 
 		Optional<Void> result = wait( timeout( removeAndKill( self, cx, toKill1, NULL, false), self->kill1Timeout ) );
 
 		bClearedFirst = result.present();
-		TraceEvent("RemoveAndKill").detail("Step", "excluded list first").detail("Excluderesult", bClearedFirst ? "succeeded" : "failed").detail("KillTotal", toKill1.size()).detail("Processes", killProcArray.size()).detail("ToKill1", describe(toKill1)).detail("ClusterAvailable", g_simulator.isAvailable());
+		TraceEvent("RemoveAndKill")
+		    .detail("Step", "excluded list first")
+		    .detail("ExcludeResult", bClearedFirst ? "succeeded" : "failed")
+		    .detail("KillTotal", toKill1.size())
+		    .detail("Processes", killProcArray.size())
+		    .detail("ToKill1", describe(toKill1))
+		    .detail("ClusterAvailable", g_simulator.isAvailable());
 
 		// Include the servers, if unable to exclude
 		// Reinclude when buggify is on to increase the surface area of the next set of excludes
@@ -311,7 +351,8 @@ struct RemoveServersSafelyWorkload : TestWorkload {
 			self->includeAddresses(toKill1);
 		}
 
-		// Get the list of protected servers
+		// toKill2 may kill too many servers to make cluster unavailable.
+		// Get the processes in toKill2 that are safe to kill
 		killProcArray = self->protectServers(toKill2);
 
 		// Update the kill networks to the killable processes
@@ -390,9 +431,15 @@ struct RemoveServersSafelyWorkload : TestWorkload {
 		state UID functionId = nondeterministicRandom()->randomUniqueID();
 
 		// First clear the exclusion list and exclude the given list
-		TraceEvent("RemoveAndKill", functionId).detail("Step", "include all").detail("ClusterAvailable", g_simulator.isAvailable());
+		TraceEvent("RemoveAndKill", functionId)
+		    .detail("Step", "Including all")
+		    .detail("ClusterAvailable", g_simulator.isAvailable())
+		    .detail("MarkExcludeAsFailed", markExcludeAsFailed);
 		wait( includeServers( cx, vector<AddressExclusion>(1) ) );
-		TraceEvent("RemoveAndKill", functionId).detail("Step", "included all").detail("ClusterAvailable", g_simulator.isAvailable());
+		TraceEvent("RemoveAndKill", functionId)
+		    .detail("Step", "Included all")
+		    .detail("ClusterAvailable", g_simulator.isAvailable())
+		    .detail("MarkExcludeAsFailed", markExcludeAsFailed);
 		// Reinclude the addresses that were excluded, if present
 		if (pIncAddrs) {
 			self->includeAddresses(*pIncAddrs);
@@ -479,7 +526,8 @@ struct RemoveServersSafelyWorkload : TestWorkload {
 		    .detail("ToKill", describe(toKill))
 		    .detail("Addresses", describe(toKillArray))
 		    .detail("FailedAddresses", describe(toKillMarkFailedArray))
-		    .detail("ClusterAvailable", g_simulator.isAvailable());
+		    .detail("ClusterAvailable", g_simulator.isAvailable())
+		    .detail("MarkExcludeAsFailed", markExcludeAsFailed);
 		if (markExcludeAsFailed) {
 			wait( excludeServers( cx, toKillMarkFailedArray, true ) );
 		}

--- a/fdbserver/workloads/RemoveServersSafely.actor.cpp
+++ b/fdbserver/workloads/RemoveServersSafely.actor.cpp
@@ -301,7 +301,7 @@ struct RemoveServersSafelyWorkload : TestWorkload {
 		return killableProcesses;
 	}
 
-	// toKill1 and toKill2 are a random subset of all processes. If simply kill all processes in toKill1 or toKill2,
+	// toKill1 and toKill2 are two random subsets of all processes. If simply kill all processes in toKill1 or toKill2,
 	// we may kill too many processes to make the cluster unavailable and stuck.
 	ACTOR static Future<Void> workloadMain( RemoveServersSafelyWorkload* self, Database cx, double waitSeconds,
 			std::set<AddressExclusion> toKill1, std::set<AddressExclusion> toKill2 ) {


### PR DESCRIPTION
Master branch currently has 4 failures  out of 177,766  tests. This is a much higher failure rate that we want. It is also the type of tests that cause most of failures in nightly test.

**Failure analysis:** 
Simulation randomly picks two sets of processes to kill.

If we simply kill all processes in toKill1 or toKill2, we may kill too many processes to make the cluster unavailable. We won't be able to include those killed processes when the cluster is unavailable. So we get stuck in `includeServers()` (https://github.com/xumengpanda/foundationdb/blob/a2089b354afab43dab62d0ee9e30e3492258c669/fdbserver/workloads/RemoveServersSafely.actor.cpp#L350)

**Solution:**
Similar as how toKill2 were modified when  it can cause cluster unavailable (https://github.com/xumengpanda/foundationdb/blob/a2089b354afab43dab62d0ee9e30e3492258c669/fdbserver/workloads/RemoveServersSafely.actor.cpp#L356-L359), we should do the same thing for toKill1.


Acknowledgement: @fzhjon helped to triage the bug.
