### PR TITLE
Add File field in TestFailure event for cycleCheck and incrementCheck

### DIFF
--- a/fdbserver/workloads/Cycle.actor.cpp
+++ b/fdbserver/workloads/Cycle.actor.cpp
@@ -207,7 +207,10 @@ struct CycleWorkload : TestWorkload {
 	}
 	ACTOR Future<bool> cycleCheck( Database cx, CycleWorkload* self, bool ok ) {
 		if (self->transactions.getMetric().value() < self->testDuration * self->minExpectedTransactionsPerSecond) {
-			TraceEvent(SevWarnAlways, "TestFailure").detail("Reason", "Rate below desired rate").detail("Details", format("%.2f", self->transactions.getMetric().value() / (self->transactionsPerSecond * self->testDuration)))
+			TraceEvent(SevWarnAlways, "TestFailure")
+				.detail("Reason", "Rate below desired rate")
+				.detail("File", __FILE__)
+				.detail("Details", format("%.2f", self->transactions.getMetric().value() / (self->transactionsPerSecond * self->testDuration)))
 				.detail("TransactionsAchieved", self->transactions.getMetric().value())
 				.detail("MinTransactionsExpected", self->testDuration * self->minExpectedTransactionsPerSecond)
 				.detail("TransactionGoal", self->transactionsPerSecond * self->testDuration);

--- a/fdbserver/workloads/Increment.actor.cpp
+++ b/fdbserver/workloads/Increment.actor.cpp
@@ -135,7 +135,10 @@ struct Increment : TestWorkload {
 	}
 	ACTOR Future<bool> incrementCheck( Database cx, Increment* self, bool ok ) {
 		if (self->transactions.getMetric().value() < self->testDuration * self->minExpectedTransactionsPerSecond) {
-			TraceEvent(SevWarnAlways, "TestFailure").detail("Reason", "Rate below desired rate").detail("Details", format("%.2f", self->transactions.getMetric().value() / (self->transactionsPerSecond * self->testDuration)))
+			TraceEvent(SevWarnAlways, "TestFailure")
+				.detail("Reason", "Rate below desired rate")
+				.detail("File", __FILE__)
+				.detail("Details", format("%.2f", self->transactions.getMetric().value() / (self->transactionsPerSecond * self->testDuration)))
 				.detail("TransactionsAchieved", self->transactions.getMetric().value())
 				.detail("MinTransactionsExpected", self->testDuration * self->minExpectedTransactionsPerSecond)
 				.detail("TransactionGoal", self->transactionsPerSecond * self->testDuration);


### PR DESCRIPTION
In workloads, cycleCheck and incrementCheck, both might trigger a test
failure with reason "Rate below desired rate", and the other text are
the same. Adding a File field will help differentiate these two events.