### PR TITLE
Fix special keys doc

### DIFF
--- a/documentation/sphinx/source/developer-guide.rst
+++ b/documentation/sphinx/source/developer-guide.rst
@@ -937,13 +937,13 @@ Management module
 
 The management module is for temporary cluster configuration changes. For
 example, in order to safely remove a process from the cluster, one can add an
-exclusion to the ``\xff\xff/management/exclude/`` key prefix that matches
+exclusion to the ``\xff\xff/management/excluded/`` key prefix that matches
 that process, and wait for necessary data to be moved away.
 
-#. ``\xff\xff/management/exclude/<exclusion>`` Read/write. Indicates that the cluster should move data away from processes matching ``<exclusion>``, so that they can be safely removed. See :ref:`removing machines from a cluster <removing-machines-from-a-cluster>` for documentation for the corresponding fdbcli command.
+#. ``\xff\xff/management/excluded/<exclusion>`` Read/write. Indicates that the cluster should move data away from processes matching ``<exclusion>``, so that they can be safely removed. See :ref:`removing machines from a cluster <removing-machines-from-a-cluster>` for documentation for the corresponding fdbcli command.
 #. ``\xff\xff/management/failed/<exclusion>`` Read/write. Indicates that the cluster should consider matching processes as permanently failed. This allows the cluster to avoid maintaining extra state and doing extra work in the hope that these processes come back. See :ref:`removing machines from a cluster <removing-machines-from-a-cluster>` for documentation for the corresponding fdbcli command.
 #. ``\xff\xff/management/inProgressExclusion/<address>`` Read-only. Indicates that the process matching ``<address>`` matches an exclusion, but still has necessary data and can't yet be safely removed.
-#. ``\xff\xff/management/options/exclude/force`` Read/write. Setting this key disables safety checks for writes to ``\xff\xff/management/exclude/<exclusion>``. Setting this key only has an effect in the current transaction and is not persisted on commit.
+#. ``\xff\xff/management/options/excluded/force`` Read/write. Setting this key disables safety checks for writes to ``\xff\xff/management/excluded/<exclusion>``. Setting this key only has an effect in the current transaction and is not persisted on commit.
 #. ``\xff\xff/management/options/failed/force`` Read/write. Setting this key disables safety checks for writes to ``\xff\xff/management/failed/<exclusion>``. Setting this key only has an effect in the current transaction and is not persisted on commit.
 
 An exclusion is syntactically either an ip address (e.g. ``127.0.0.1``), or

--- a/fdbclient/ManagementAPI.actor.cpp
+++ b/fdbclient/ManagementAPI.actor.cpp
@@ -1288,7 +1288,7 @@ ACTOR Future<Void> excludeServers(Database cx, vector<AddressExclusion> servers,
 		loop {
 			try{
 				ryw.setOption(FDBTransactionOptions::SPECIAL_KEY_SPACE_ENABLE_WRITES);
-				ryw.set(SpecialKeySpace::getManagementApiCommandOptionSpecialKey(failed ? "failed" : "exclude", "force"), ValueRef());
+				ryw.set(SpecialKeySpace::getManagementApiCommandOptionSpecialKey(failed ? "failed" : "excluded", "force"), ValueRef());
 				for(auto& s : servers) {
 					Key addr = failed ? SpecialKeySpace::getManagementApiCommandPrefix("failed").withSuffix(s.toString())
 									  : SpecialKeySpace::getManagementApiCommandPrefix("exclude").withSuffix(s.toString());

--- a/fdbclient/SpecialKeySpace.actor.h
+++ b/fdbclient/SpecialKeySpace.actor.h
@@ -174,7 +174,7 @@ public:
 		return managementApiCommandToRange.at(command).begin;
 	}
 	static Key getManagementApiCommandOptionSpecialKey(const std::string& command, const std::string& option);
-	static const std::unordered_set<std::string>& getManagementApiOptionsSet() { return options; }
+	static const std::set<std::string>& getManagementApiOptionsSet() { return options; }
 
 private:
 	ACTOR static Future<Optional<Value>> getActor(SpecialKeySpace* sks, ReadYourWritesTransaction* ryw, KeyRef key);
@@ -195,7 +195,7 @@ private:
 	static std::unordered_map<SpecialKeySpace::MODULE, KeyRange> moduleToBoundary;
 	static std::unordered_map<std::string, KeyRange>
 	    managementApiCommandToRange; // management command to its special keys' range
-	static std::unordered_set<std::string> options; // "<command>/<option>"
+	static std::set<std::string> options; // "<command>/<option>"
 
 	// Initialize module boundaries, used to handle cross_module_read
 	void modulesBoundaryInit();

--- a/fdbserver/workloads/SpecialKeySpaceCorrectness.actor.cpp
+++ b/fdbserver/workloads/SpecialKeySpaceCorrectness.actor.cpp
@@ -562,6 +562,7 @@ struct SpecialKeySpaceCorrectnessWorkload : TestWorkload {
 			    CLIENT_KNOBS->TOO_MANY));
 			ASSERT(res.size() == SpecialKeySpace::getManagementApiOptionsSet().size());
 			for (int i = 0; i < res.size() - 1; ++i) ASSERT(res[i].key < res[i + 1].key);
+			tx->reset();
 		}
 		return Void();
 	}


### PR DESCRIPTION
For `exclude` command, the related special key is `\xff\xff/management/excluded/`
And the corresponding option special key for `force` is `\xff\xff/management/options/excluded/force`.

Fix the bug using `unordered_set` and add a test to catch it.
Fix another memory bug.