### PR TITLE
When a configuration K/V pair is modified, always output the K/V pair values

### DIFF
--- a/documentation/sphinx/source/release-notes/release-notes-630.rst
+++ b/documentation/sphinx/source/release-notes/release-notes-630.rst
@@ -8,6 +8,7 @@ Release Notes
 =====
 
 * Fix an issue where ``fdbcli --exec 'exclude no_wait ...'`` would incorrectly report that processes can safely be removed from the cluster. `(PR #3566) <https://github.com/apple/foundationdb/pull/3566>`_
+* When a configuration key is changed, it will always be included in ``status json`` output, even the value is reverted back to the default value. `(PR #3610) <https://github.com/apple/foundationdb/pull/3610>`_
 
 6.3.4
 =====

--- a/fdbclient/DatabaseConfiguration.cpp
+++ b/fdbclient/DatabaseConfiguration.cpp
@@ -565,8 +565,8 @@ void DatabaseConfiguration::fromKeyValues(Standalone<VectorRef<KeyValueRef>> raw
 bool DatabaseConfiguration::isOverridden(std::string key) const {
 	key = configKeysPrefix.toString() + key;
 
-	if (mutableConfiguration.present() && mutableConfiguration.get().find(key) != mutableConfiguration.get().end()) {
-		return true;
+	if (mutableConfiguration.present()) {
+		return mutableConfiguration.get().find(key) != mutableConfiguration.get().end();
 	}
 
 	const int keyLen = key.size();

--- a/fdbclient/DatabaseConfiguration.cpp
+++ b/fdbclient/DatabaseConfiguration.cpp
@@ -224,110 +224,122 @@ bool DatabaseConfiguration::isValid() const {
 StatusObject DatabaseConfiguration::toJSON(bool noPolicies) const {
 	StatusObject result;
 
-	if( initialized ) {
-		std::string tlogInfo = tLogPolicy->info();
-		std::string storageInfo = storagePolicy->info();
-		bool customRedundancy = false;
-		if( tLogWriteAntiQuorum == 0 ) {
-			if( tLogReplicationFactor == 1 && storageTeamSize == 1 ) {
-				result["redundancy_mode"] = "single";
-			} else if( tLogReplicationFactor == 2 && storageTeamSize == 2 ) {
-				result["redundancy_mode"] = "double";
-			} else if( tLogReplicationFactor == 4 && storageTeamSize == 6 && tlogInfo == "dcid^2 x zoneid^2 x 1" && storageInfo == "dcid^3 x zoneid^2 x 1" ) {
-				result["redundancy_mode"] = "three_datacenter";
-			} else if( tLogReplicationFactor == 4 && storageTeamSize == 4 && tlogInfo == "dcid^2 x zoneid^2 x 1" && storageInfo == "dcid^2 x zoneid^2 x 1" ) {
-				result["redundancy_mode"] = "three_datacenter_fallback";
-			} else if( tLogReplicationFactor == 3 && storageTeamSize == 3 ) {
-				result["redundancy_mode"] = "triple";
-			} else if( tLogReplicationFactor == 4 && storageTeamSize == 3 && tlogInfo == "data_hall^2 x zoneid^2 x 1" && storageInfo == "data_hall^3 x 1" ) {
-				result["redundancy_mode"] = "three_data_hall";
-			} else if( tLogReplicationFactor == 4 && storageTeamSize == 2 && tlogInfo == "data_hall^2 x zoneid^2 x 1" && storageInfo == "data_hall^2 x 1" ) {
-				result["redundancy_mode"] = "three_data_hall_fallback";
-			} else {
-				customRedundancy = true;
-			}
+	if (!initialized) {
+		return result;
+	}
+
+	std::string tlogInfo = tLogPolicy->info();
+	std::string storageInfo = storagePolicy->info();
+	bool customRedundancy = false;
+	if (tLogWriteAntiQuorum == 0) {
+		if (tLogReplicationFactor == 1 && storageTeamSize == 1) {
+			result["redundancy_mode"] = "single";
+		} else if (tLogReplicationFactor == 2 && storageTeamSize == 2) {
+			result["redundancy_mode"] = "double";
+		} else if (tLogReplicationFactor == 4 && storageTeamSize == 6 && tlogInfo == "dcid^2 x zoneid^2 x 1" &&
+		           storageInfo == "dcid^3 x zoneid^2 x 1") {
+			result["redundancy_mode"] = "three_datacenter";
+		} else if (tLogReplicationFactor == 4 && storageTeamSize == 4 && tlogInfo == "dcid^2 x zoneid^2 x 1" &&
+		           storageInfo == "dcid^2 x zoneid^2 x 1") {
+			result["redundancy_mode"] = "three_datacenter_fallback";
+		} else if (tLogReplicationFactor == 3 && storageTeamSize == 3) {
+			result["redundancy_mode"] = "triple";
+		} else if (tLogReplicationFactor == 4 && storageTeamSize == 3 && tlogInfo == "data_hall^2 x zoneid^2 x 1" &&
+		           storageInfo == "data_hall^3 x 1") {
+			result["redundancy_mode"] = "three_data_hall";
+		} else if (tLogReplicationFactor == 4 && storageTeamSize == 2 && tlogInfo == "data_hall^2 x zoneid^2 x 1" &&
+		           storageInfo == "data_hall^2 x 1") {
+			result["redundancy_mode"] = "three_data_hall_fallback";
 		} else {
 			customRedundancy = true;
 		}
-
-		if(customRedundancy) {
-			result["storage_replicas"] = storageTeamSize;
-			result["log_replicas"] = tLogReplicationFactor;
-			result["log_anti_quorum"] = tLogWriteAntiQuorum;
-			if(!noPolicies) result["storage_replication_policy"] = storagePolicy->info();
-			if(!noPolicies)  result["log_replication_policy"] = tLogPolicy->info();
-		}
-
-		if (tLogVersion > TLogVersion::DEFAULT || isOverridden("log_version")) {
-			result["log_version"] = (int)tLogVersion;
-		}
-
-		if( tLogDataStoreType == KeyValueStoreType::SSD_BTREE_V1 && storageServerStoreType == KeyValueStoreType::SSD_BTREE_V1) {
-			result["storage_engine"] = "ssd-1";
-		} else if (tLogDataStoreType == KeyValueStoreType::SSD_BTREE_V2 && storageServerStoreType == KeyValueStoreType::SSD_BTREE_V2) {
-			result["storage_engine"] = "ssd-2";
-		} else if( tLogDataStoreType == KeyValueStoreType::SSD_BTREE_V2 && storageServerStoreType == KeyValueStoreType::SSD_REDWOOD_V1 ) {
-			result["storage_engine"] = "ssd-redwood-experimental";
-		} else if (tLogDataStoreType == KeyValueStoreType::SSD_BTREE_V2 && storageServerStoreType == KeyValueStoreType::SSD_ROCKSDB_V1) {
-			result["storage_engine"] = "ssd-rocksdb-experimental";
-		} else if( tLogDataStoreType == KeyValueStoreType::MEMORY && storageServerStoreType == KeyValueStoreType::MEMORY ) {
-			result["storage_engine"] = "memory-1";
-		} else if( tLogDataStoreType == KeyValueStoreType::SSD_BTREE_V2 && storageServerStoreType == KeyValueStoreType::MEMORY_RADIXTREE ) {
-			result["storage_engine"] = "memory-radixtree-beta";
-		} else if( tLogDataStoreType == KeyValueStoreType::SSD_BTREE_V2 && storageServerStoreType == KeyValueStoreType::MEMORY ) {
-			result["storage_engine"] = "memory-2";
-		} else {
-			result["storage_engine"] = "custom";
-		}
-
-		result["log_spill"] = (int)tLogSpillType;
-
-		if( remoteTLogReplicationFactor == 1 ) {
-			result["remote_redundancy_mode"] = "remote_single";
-		} else if( remoteTLogReplicationFactor == 2 ) {
-			result["remote_redundancy_mode"] = "remote_double";
-		} else if( remoteTLogReplicationFactor == 3 ) {
-			result["remote_redundancy_mode"] = "remote_triple";
-		} else if( remoteTLogReplicationFactor > 3 ) {
-			result["remote_log_replicas"] = remoteTLogReplicationFactor;
-			if(noPolicies && remoteTLogPolicy) result["remote_log_policy"] = remoteTLogPolicy->info();
-		}
-		result["usable_regions"] = usableRegions;
-
-		if(regions.size()) {
-			result["regions"] = getRegionJSON();
-		}
-
-		if (desiredTLogCount != -1 || isOverridden("logs")) {
-			result["logs"] = desiredTLogCount;
-		}
-		if (masterProxyCount != -1 || isOverridden("proxies")) {
-			result["proxies"] = masterProxyCount;
-		}
-		if (resolverCount != -1 || isOverridden("resolvers")) {
-			result["resolvers"] = resolverCount;
-		}
-		if (desiredLogRouterCount != -1 || isOverridden("log_routers")) {
-			result["log_routers"] = desiredLogRouterCount;
-		}
-		if (remoteDesiredTLogCount != -1 || isOverridden("remote_logs")) {
-			result["remote_logs"] = remoteDesiredTLogCount;
-		}
-		if (repopulateRegionAntiQuorum != 0 || isOverridden("repopulate_anti_quorum")) {
-			result["repopulate_anti_quorum"] = repopulateRegionAntiQuorum;
-		}
-		if (autoMasterProxyCount != CLIENT_KNOBS->DEFAULT_AUTO_PROXIES || isOverridden("auto_proxies")) {
-			result["auto_proxies"] = autoMasterProxyCount;
-		}
-		if (autoResolverCount != CLIENT_KNOBS->DEFAULT_AUTO_RESOLVERS || isOverridden("auto_resolvers")) {
-			result["auto_resolvers"] = autoResolverCount;
-		}
-		if (autoDesiredTLogCount != CLIENT_KNOBS->DEFAULT_AUTO_LOGS || isOverridden("auto_logs")) {
-			result["auto_logs"] = autoDesiredTLogCount;
-		}
-
-		result["backup_worker_enabled"] = (int32_t)backupWorkerEnabled;
+	} else {
+		customRedundancy = true;
 	}
+
+	if (customRedundancy) {
+		result["storage_replicas"] = storageTeamSize;
+		result["log_replicas"] = tLogReplicationFactor;
+		result["log_anti_quorum"] = tLogWriteAntiQuorum;
+		if (!noPolicies) result["storage_replication_policy"] = storagePolicy->info();
+		if (!noPolicies) result["log_replication_policy"] = tLogPolicy->info();
+	}
+
+	if (tLogVersion > TLogVersion::DEFAULT || isOverridden("log_version")) {
+		result["log_version"] = (int)tLogVersion;
+	}
+
+	if (tLogDataStoreType == KeyValueStoreType::SSD_BTREE_V1 &&
+	    storageServerStoreType == KeyValueStoreType::SSD_BTREE_V1) {
+		result["storage_engine"] = "ssd-1";
+	} else if (tLogDataStoreType == KeyValueStoreType::SSD_BTREE_V2 &&
+	           storageServerStoreType == KeyValueStoreType::SSD_BTREE_V2) {
+		result["storage_engine"] = "ssd-2";
+	} else if (tLogDataStoreType == KeyValueStoreType::SSD_BTREE_V2 &&
+	           storageServerStoreType == KeyValueStoreType::SSD_REDWOOD_V1) {
+		result["storage_engine"] = "ssd-redwood-experimental";
+	} else if (tLogDataStoreType == KeyValueStoreType::SSD_BTREE_V2 &&
+	           storageServerStoreType == KeyValueStoreType::SSD_ROCKSDB_V1) {
+		result["storage_engine"] = "ssd-rocksdb-experimental";
+	} else if (tLogDataStoreType == KeyValueStoreType::MEMORY && storageServerStoreType == KeyValueStoreType::MEMORY) {
+		result["storage_engine"] = "memory-1";
+	} else if (tLogDataStoreType == KeyValueStoreType::SSD_BTREE_V2 &&
+	           storageServerStoreType == KeyValueStoreType::MEMORY_RADIXTREE) {
+		result["storage_engine"] = "memory-radixtree-beta";
+	} else if (tLogDataStoreType == KeyValueStoreType::SSD_BTREE_V2 &&
+	           storageServerStoreType == KeyValueStoreType::MEMORY) {
+		result["storage_engine"] = "memory-2";
+	} else {
+		result["storage_engine"] = "custom";
+	}
+
+	result["log_spill"] = (int)tLogSpillType;
+
+	if (remoteTLogReplicationFactor == 1) {
+		result["remote_redundancy_mode"] = "remote_single";
+	} else if (remoteTLogReplicationFactor == 2) {
+		result["remote_redundancy_mode"] = "remote_double";
+	} else if (remoteTLogReplicationFactor == 3) {
+		result["remote_redundancy_mode"] = "remote_triple";
+	} else if (remoteTLogReplicationFactor > 3) {
+		result["remote_log_replicas"] = remoteTLogReplicationFactor;
+		if (noPolicies && remoteTLogPolicy) result["remote_log_policy"] = remoteTLogPolicy->info();
+	}
+	result["usable_regions"] = usableRegions;
+
+	if (regions.size()) {
+		result["regions"] = getRegionJSON();
+	}
+
+	if (desiredTLogCount != -1 || isOverridden("logs")) {
+		result["logs"] = desiredTLogCount;
+	}
+	if (masterProxyCount != -1 || isOverridden("proxies")) {
+		result["proxies"] = masterProxyCount;
+	}
+	if (resolverCount != -1 || isOverridden("resolvers")) {
+		result["resolvers"] = resolverCount;
+	}
+	if (desiredLogRouterCount != -1 || isOverridden("log_routers")) {
+		result["log_routers"] = desiredLogRouterCount;
+	}
+	if (remoteDesiredTLogCount != -1 || isOverridden("remote_logs")) {
+		result["remote_logs"] = remoteDesiredTLogCount;
+	}
+	if (repopulateRegionAntiQuorum != 0 || isOverridden("repopulate_anti_quorum")) {
+		result["repopulate_anti_quorum"] = repopulateRegionAntiQuorum;
+	}
+	if (autoMasterProxyCount != CLIENT_KNOBS->DEFAULT_AUTO_PROXIES || isOverridden("auto_proxies")) {
+		result["auto_proxies"] = autoMasterProxyCount;
+	}
+	if (autoResolverCount != CLIENT_KNOBS->DEFAULT_AUTO_RESOLVERS || isOverridden("auto_resolvers")) {
+		result["auto_resolvers"] = autoResolverCount;
+	}
+	if (autoDesiredTLogCount != CLIENT_KNOBS->DEFAULT_AUTO_LOGS || isOverridden("auto_logs")) {
+		result["auto_logs"] = autoDesiredTLogCount;
+	}
+
+	result["backup_worker_enabled"] = (int32_t)backupWorkerEnabled;
 
 	return result;
 }

--- a/fdbclient/DatabaseConfiguration.h
+++ b/fdbclient/DatabaseConfiguration.h
@@ -218,13 +218,7 @@ struct DatabaseConfiguration {
 		}
 	}
 
-	void fromKeyValues( Standalone<VectorRef<KeyValueRef>> rawConfig ) {
-		resetInternal();
-		this->rawConfiguration = rawConfig;
-		for(auto c=rawConfiguration.begin(); c!=rawConfiguration.end(); ++c)
-			setInternal(c->key, c->value);
-		setDefaultReplicationPolicy();
-	}
+	void fromKeyValues(Standalone<VectorRef<KeyValueRef>> rawConfig);
 
 private:
 	Optional< std::map<std::string, std::string> > mutableConfiguration;  // If present, rawConfiguration is not valid
@@ -236,6 +230,8 @@ private:
 	bool setInternal( KeyRef key, ValueRef value );
 	void resetInternal();
 	void setDefaultReplicationPolicy();
+
+	bool isOverridden(const std::string& key) const;
 };
 
 #endif

--- a/fdbclient/DatabaseConfiguration.h
+++ b/fdbclient/DatabaseConfiguration.h
@@ -231,7 +231,8 @@ private:
 	void resetInternal();
 	void setDefaultReplicationPolicy();
 
-	bool isOverridden(const std::string& key) const;
+	/// Check if the key is overridden by either mutableConfiguration or rawConfiguration
+	bool isOverridden(std::string key) const;
 };
 
 #endif


### PR DESCRIPTION
With this patch, if there is a configuration special key in the
database, even if the value is reverted to default/hidden, it will still
be forwarded when constructing a JSON string. This should address the
requirements described in https://github.com/apple/foundationdb/issues/3551.