### PR TITLE
Add span info to mutations sent from proxy -> tlog

### DIFF
--- a/fdbserver/ApplyMetadataMutation.cpp
+++ b/fdbserver/ApplyMetadataMutation.cpp
@@ -56,6 +56,10 @@ void applyMetadataMutations(SpanID const& spanContext, UID const& dbgid, Arena& 
                             bool initialCommit) {
 	//std::map<keyRef, vector<uint16_t>> cacheRangeInfo;
 	std::map<KeyRef, MutationRef> cachedRangeInfo;
+	if (toCommit) {
+		toCommit->addTransactionInfo(spanContext);
+	}
+
 	for (auto const& m : mutations) {
 		//TraceEvent("MetadataMutation", dbgid).detail("M", m.toString());
 
@@ -102,7 +106,6 @@ void applyMetadataMutations(SpanID const& spanContext, UID const& dbgid, Arena& 
 					TraceEvent(SevDebug, "SendingPrivateMutation", dbgid).detail("Original", m.toString()).detail("Privatized", privatized.toString()).detail("Server", serverKeysDecodeServer(m.param1))
 						.detail("TagKey", serverTagKeyFor( serverKeysDecodeServer(m.param1) )).detail("Tag", decodeServerTagValue( txnStateStore->readValue( serverTagKeyFor( serverKeysDecodeServer(m.param1) ) ).get().get() ).toString());
 
-					toCommit->addTransactionInfo(spanContext, 1);
 					toCommit->addTag( decodeServerTagValue( txnStateStore->readValue( serverTagKeyFor( serverKeysDecodeServer(m.param1) ) ).get().get() ) );
 					toCommit->writeTypedMessage(privatized);
 				}
@@ -115,7 +118,6 @@ void applyMetadataMutations(SpanID const& spanContext, UID const& dbgid, Arena& 
 					privatized.param1 = m.param1.withPrefix(systemKeys.begin, arena);
 					TraceEvent("ServerTag", dbgid).detail("Server", id).detail("Tag", tag.toString());
 
-					toCommit->addTransactionInfo(spanContext, 2);
 					toCommit->addTag(tag);
 					toCommit->writeTypedMessage(LogProtocolMessage());
 					toCommit->addTag(tag);
@@ -170,7 +172,6 @@ void applyMetadataMutations(SpanID const& spanContext, UID const& dbgid, Arena& 
 					MutationRef privatized = m;
 					privatized.param1 = m.param1.withPrefix(systemKeys.begin, arena);
 					//TraceEvent(SevDebug, "SendingPrivateMutation", dbgid).detail("Original", m.toString()).detail("Privatized", privatized.toString());
-					toCommit->addTransactionInfo(spanContext, 1);
 					toCommit->addTag( cacheTag );
 					toCommit->writeTypedMessage(privatized);
 				}
@@ -288,14 +289,12 @@ void applyMetadataMutations(SpanID const& spanContext, UID const& dbgid, Arena& 
 					allTags.insert(cacheTag);
 
 					if (m.param1 == lastEpochEndKey) {
-						toCommit->addTransactionInfo(spanContext, 1);
 						toCommit->addTags(allTags);
 						toCommit->writeTypedMessage(LogProtocolMessage());
 					}
 
 					MutationRef privatized = m;
 					privatized.param1 = m.param1.withPrefix(systemKeys.begin, arena);
-					toCommit->addTransactionInfo(spanContext, 1);
 					toCommit->addTags(allTags);
 					toCommit->writeTypedMessage(privatized);
 				}
@@ -352,7 +351,6 @@ void applyMetadataMutations(SpanID const& spanContext, UID const& dbgid, Arena& 
 							privatized.param1 = kv.key.withPrefix(systemKeys.begin, arena);
 							privatized.param2 = keyAfter(kv.key, arena).withPrefix(systemKeys.begin, arena);
 
-							toCommit->addTransactionInfo(spanContext, 1);
 							toCommit->addTag(decodeServerTagValue(kv.value));
 							toCommit->writeTypedMessage(privatized);
 						}
@@ -544,7 +542,6 @@ void applyMetadataMutations(SpanID const& spanContext, UID const& dbgid, Arena& 
 			}
 
 			// Add the tags to both begin and end mutations
-			toCommit->addTransactionInfo(spanContext, 2);
 			toCommit->addTags(allTags);
 			toCommit->writeTypedMessage(mutationBegin);
 			toCommit->addTags(allTags);

--- a/fdbserver/ApplyMetadataMutation.h
+++ b/fdbserver/ApplyMetadataMutation.h
@@ -39,10 +39,10 @@ inline bool isMetadataMutation(MutationRef const& m) {
 
 Reference<StorageInfo> getStorageInfo(UID id, std::map<UID, Reference<StorageInfo>>* storageCache, IKeyValueStore* txnStateStore);
 
-void applyMetadataMutations(ProxyCommitData& proxyCommitData, Arena& arena, Reference<ILogSystem> logSystem,
-                            const VectorRef<MutationRef>& mutations, LogPushData* pToCommit, bool& confChange,
-                            Version popVersion, bool initialCommit);
-void applyMetadataMutations(const UID& dbgid, Arena& arena, const VectorRef<MutationRef>& mutations,
-                            IKeyValueStore* txnStateStore);
+void applyMetadataMutations(SpanID const& spanContext, ProxyCommitData& proxyCommitData, Arena& arena,
+                            Reference<ILogSystem> logSystem, const VectorRef<MutationRef>& mutations,
+                            LogPushData* pToCommit, bool& confChange, Version popVersion, bool initialCommit);
+void applyMetadataMutations(SpanID const& spanContext, const UID& dbgid, Arena& arena,
+                            const VectorRef<MutationRef>& mutations, IKeyValueStore* txnStateStore);
 
 #endif

--- a/fdbserver/LogSystem.h
+++ b/fdbserver/LogSystem.h
@@ -668,7 +668,7 @@ struct ILogSystem {
 		// Never returns normally, but throws an error if the subsystem stops working
 
 	//Future<Void> push( UID bundle, int64_t seq, VectorRef<TaggedMessageRef> messages );
-	virtual Future<Version> push( Version prevVersion, Version version, Version knownCommittedVersion, Version minKnownCommittedVersion, struct LogPushData& data, Optional<UID> debugID = Optional<UID>() ) = 0;
+	virtual Future<Version> push( Version prevVersion, Version version, Version knownCommittedVersion, Version minKnownCommittedVersion, struct LogPushData& data, SpanID spanContext, Optional<UID> debugID = Optional<UID>() ) = 0;
 		// Waits for the version number of the bundle (in this epoch) to be prevVersion (i.e. for all pushes ordered earlier)
 		// Puts the given messages into the bundle, each with the given tags, and with message versions (version, 0) - (version, N)
 		// Changes the version number of the bundle to be version (unblocking the next push)
@@ -818,10 +818,26 @@ struct CompareFirst {
 	}
 };
 
+// Structure to store serialized mutations sent from the proxy to the
+// transaction logs. The serialization repeats with the following format:
+//
+// +----------------------------+ +----------+
+// |        Span Context        | | # of mut |
+// +----------------------------+ +----------+
+// <--------- 128 bits ---------> <- 16 bits->
+//
+// +----------------------+ +----------------------+ +----------+ +----------------+         +----------------------+
+// |     Message size     | |      Subsequence     | | # of tags| |      Tag       | . . . . |       Mutation       |
+// +----------------------+ +----------------------+ +----------+ +----------------+         +----------------------+
+// <------- 32 bits ------> <------- 32 bits ------> <- 16 bits-> <---- 24 bits --->         <---- variable bits --->
+//
+// . . . (repeating according to # of mutations field) . . .
+//
 struct LogPushData : NonCopyable {
 	// Log subsequences have to start at 1 (the MergedPeekCursor relies on this to make sure we never have !hasMessage() in the middle of data for a version
 
-	explicit LogPushData(Reference<ILogSystem> logSystem) : logSystem(logSystem), subsequence(1) {
+	explicit LogPushData(Reference<ILogSystem> logSystem)
+			: logSystem(logSystem), subsequence(1), numTransactions(0), wroteTransactionInfo(false) {
 		for(auto& log : logSystem->getLogSystemConfig().tLogs) {
 			if(log.isLocal) {
 				for(int i = 0; i < log.tLogs.size(); i++) {
@@ -849,7 +865,14 @@ struct LogPushData : NonCopyable {
 		next_message_tags.insert(next_message_tags.end(), tags.begin(), tags.end());
 	}
 
-	void addMessage( StringRef rawMessageWithoutLength, bool usePreviousLocations ) {
+	// Add transaction info to be written by the first mutation in the transaction
+	void addTransactionInfo(SpanID context, uint16_t transactions) {
+		spanContext = context;
+		numTransactions = transactions;
+		wroteTransactionInfo = false;
+	}
+
+	void writeMessage( StringRef rawMessageWithoutLength, bool usePreviousLocations ) {
 		if( !usePreviousLocations ) {
 			prev_tags.clear();
 			if(logSystem->hasRemoteLogs()) {
@@ -865,15 +888,22 @@ struct LogPushData : NonCopyable {
 		uint32_t subseq = this->subsequence++;
 		uint32_t msgsize = rawMessageWithoutLength.size() + sizeof(subseq) + sizeof(uint16_t) + sizeof(Tag)*prev_tags.size();
 		for(int loc : msg_locations) {
+			if (!wroteTransactionInfo) {
+				messagesWriter[loc] << spanContext << numTransactions;
+			}
 			messagesWriter[loc] << msgsize << subseq << uint16_t(prev_tags.size());
 			for(auto& tag : prev_tags)
 				messagesWriter[loc] << tag;
 			messagesWriter[loc].serializeBytes(rawMessageWithoutLength);
 		}
+
+		spanContext = SpanID();
+		numTransactions = 0;
+		wroteTransactionInfo = true;
 	}
 
 	template <class T>
-	void addTypedMessage(T const& item, bool allLocations = false) {
+	void writeTypedMessage(T const& item, bool allLocations = false) {
 		prev_tags.clear();
 		if(logSystem->hasRemoteLogs()) {
 			prev_tags.push_back( logSystem->getRandomRouterTag() );
@@ -891,6 +921,9 @@ struct LogPushData : NonCopyable {
 		for(int loc : msg_locations) {
 			if (first) {
 				BinaryWriter& wr = messagesWriter[loc];
+				if (!wroteTransactionInfo) {
+					wr << spanContext << numTransactions;
+				}
 				firstOffset = wr.getLength();
 				wr << uint32_t(0) << subseq << uint16_t(prev_tags.size());
 				for(auto& tag : prev_tags)
@@ -906,6 +939,12 @@ struct LogPushData : NonCopyable {
 				wr.serializeBytes( (uint8_t*)from.getData() + firstOffset, firstLength );
 			}
 		}
+		// Reset transaction information after first message in transaction is
+		// written. Future transactions should reset this state by calling
+		// addTransactionInfo.
+		spanContext = SpanID();
+		numTransactions = 0;
+		wroteTransactionInfo = true;
 		next_message_tags.clear();
 	}
 
@@ -920,6 +959,9 @@ private:
 	std::vector<BinaryWriter> messagesWriter;
 	std::vector<int> msg_locations;
 	uint32_t subsequence;
+	SpanID spanContext;
+	uint16_t numTransactions;
+	bool wroteTransactionInfo;
 };
 
 #endif

--- a/fdbserver/MasterProxyServer.actor.cpp
+++ b/fdbserver/MasterProxyServer.actor.cpp
@@ -513,7 +513,7 @@ ACTOR Future<Void> addBackupMutations(ProxyCommitData* self, std::map<Key, Mutat
 	state int yieldBytes = 0;
 	state BinaryWriter valueWriter(Unversioned());
 
-	// TODO: Add transaction info here
+	toCommit->addTransactionInfo(SpanID());
 
 	// Serialize the log range mutations within the map
 	for (; logRangeMutation != logRangeMutations->end(); ++logRangeMutation)
@@ -1023,7 +1023,7 @@ ACTOR Future<Void> assignMutationsToStorageServers(CommitBatchContext* self) {
 		state int mutationNum = 0;
 		state VectorRef<MutationRef>* pMutations = &trs[self->transactionNum].transaction.mutations;
 
-		self->toCommit.addTransactionInfo(trs[self->transactionNum].spanContext, pMutations->size());
+		self->toCommit.addTransactionInfo(trs[self->transactionNum].spanContext);
 
 		for (; mutationNum < pMutations->size(); mutationNum++) {
 			if(self->yieldBytes > SERVER_KNOBS->DESIRED_TOTAL_BYTES) {
@@ -1222,7 +1222,7 @@ ACTOR Future<Void> postResolution(CommitBatchContext* self) {
 	// txnState (transaction subsystem state) tag: message extracted from log adapter
 	bool firstMessage = true;
 	// TODO: Revisit this, not sure what Span to pass yet
-	self->toCommit.addTransactionInfo(SpanID(), self->msg.messages.size());
+	self->toCommit.addTransactionInfo(SpanID());
 	for(auto m : self->msg.messages) {
 		if(firstMessage) {
 			self->toCommit.addTxsTag();

--- a/fdbserver/TLogInterface.h
+++ b/fdbserver/TLogInterface.h
@@ -250,11 +250,11 @@ struct TLogCommitRequest {
 	Optional<UID> debugID;
 
 	TLogCommitRequest() {}
-	TLogCommitRequest( SpanID spanContext, const Arena& a, Version prevVersion, Version version, Version knownCommittedVersion, Version minKnownCommittedVersion, StringRef messages, Optional<UID> debugID )
-		: spanContext(spanContext), arena(a), prevVersion(prevVersion), version(version), knownCommittedVersion(knownCommittedVersion), minKnownCommittedVersion(minKnownCommittedVersion), messages(messages), debugID(debugID) {}
+	TLogCommitRequest( const SpanID& context, const Arena& a, Version prevVersion, Version version, Version knownCommittedVersion, Version minKnownCommittedVersion, StringRef messages, Optional<UID> debugID )
+		: spanContext(context), arena(a), prevVersion(prevVersion), version(version), knownCommittedVersion(knownCommittedVersion), minKnownCommittedVersion(minKnownCommittedVersion), messages(messages), debugID(debugID) {}
 	template <class Ar>
 	void serialize( Ar& ar ) {
-		serializer(ar, prevVersion, version, knownCommittedVersion, minKnownCommittedVersion, messages, reply, arena, debugID, spanContext);
+		serializer(ar, prevVersion, version, knownCommittedVersion, minKnownCommittedVersion, messages, reply, arena, spanContext, debugID);
 	}
 };
 

--- a/fdbserver/TLogInterface.h
+++ b/fdbserver/TLogInterface.h
@@ -240,6 +240,7 @@ struct TLogCommitReply {
 
 struct TLogCommitRequest {
 	constexpr static FileIdentifier file_identifier = 4022206;
+	SpanID spanContext;
 	Arena arena;
 	Version prevVersion, version, knownCommittedVersion, minKnownCommittedVersion;
 
@@ -249,11 +250,11 @@ struct TLogCommitRequest {
 	Optional<UID> debugID;
 
 	TLogCommitRequest() {}
-	TLogCommitRequest( const Arena& a, Version prevVersion, Version version, Version knownCommittedVersion, Version minKnownCommittedVersion, StringRef messages, Optional<UID> debugID )
-		: arena(a), prevVersion(prevVersion), version(version), knownCommittedVersion(knownCommittedVersion), minKnownCommittedVersion(minKnownCommittedVersion), messages(messages), debugID(debugID) {}
+	TLogCommitRequest( SpanID spanContext, const Arena& a, Version prevVersion, Version version, Version knownCommittedVersion, Version minKnownCommittedVersion, StringRef messages, Optional<UID> debugID )
+		: spanContext(spanContext), arena(a), prevVersion(prevVersion), version(version), knownCommittedVersion(knownCommittedVersion), minKnownCommittedVersion(minKnownCommittedVersion), messages(messages), debugID(debugID) {}
 	template <class Ar>
 	void serialize( Ar& ar ) {
-		serializer(ar, prevVersion, version, knownCommittedVersion, minKnownCommittedVersion, messages, reply, arena, debugID);
+		serializer(ar, prevVersion, version, knownCommittedVersion, minKnownCommittedVersion, messages, reply, arena, debugID, spanContext);
 	}
 };
 

--- a/fdbserver/TagPartitionedLogSystem.actor.cpp
+++ b/fdbserver/TagPartitionedLogSystem.actor.cpp
@@ -499,7 +499,8 @@ struct TagPartitionedLogSystem : ILogSystem, ReferenceCounted<TagPartitionedLogS
 	}
 
 	Future<Version> push(Version prevVersion, Version version, Version knownCommittedVersion,
-	                     Version minKnownCommittedVersion, LogPushData& data, Optional<UID> debugID) final {
+	                     Version minKnownCommittedVersion, LogPushData& data, SpanID spanContext,
+	                     Optional<UID> debugID) final {
 		// FIXME: Randomize request order as in LegacyLogSystem?
 		vector<Future<Void>> quorumResults;
 		vector<Future<TLogCommitReply>> allReplies;
@@ -509,7 +510,7 @@ struct TagPartitionedLogSystem : ILogSystem, ReferenceCounted<TagPartitionedLogS
 				vector<Future<Void>> tLogCommitResults;
 				for(int loc=0; loc< it->logServers.size(); loc++) {
 					Standalone<StringRef> msg = data.getMessages(location);
-					allReplies.push_back( it->logServers[loc]->get().interf().commit.getReply( TLogCommitRequest( msg.arena(), prevVersion, version, knownCommittedVersion, minKnownCommittedVersion, msg, debugID ), TaskPriority::ProxyTLogCommitReply ) );
+					allReplies.push_back( it->logServers[loc]->get().interf().commit.getReply( TLogCommitRequest( spanContext, msg.arena(), prevVersion, version, knownCommittedVersion, minKnownCommittedVersion, msg, debugID ), TaskPriority::ProxyTLogCommitReply ) );
 					Future<Void> commitSuccess = success(allReplies.back());
 					addActor.get().send(commitSuccess);
 					tLogCommitResults.push_back(commitSuccess);

--- a/fdbserver/TagPartitionedLogSystem.actor.cpp
+++ b/fdbserver/TagPartitionedLogSystem.actor.cpp
@@ -499,8 +499,8 @@ struct TagPartitionedLogSystem : ILogSystem, ReferenceCounted<TagPartitionedLogS
 	}
 
 	Future<Version> push(Version prevVersion, Version version, Version knownCommittedVersion,
-	                     Version minKnownCommittedVersion, LogPushData& data, SpanID spanContext,
-	                     Optional<UID> debugID) final {
+	                     Version minKnownCommittedVersion, LogPushData& data,
+	                     SpanID const& spanContext, Optional<UID> debugID) final {
 		// FIXME: Randomize request order as in LegacyLogSystem?
 		vector<Future<Void>> quorumResults;
 		vector<Future<TLogCommitReply>> allReplies;

--- a/fdbserver/masterserver.actor.cpp
+++ b/fdbserver/masterserver.actor.cpp
@@ -1564,7 +1564,7 @@ ACTOR Future<Void> masterCore( Reference<MasterData> self ) {
 		}
 	}
 
-	applyMetadataMutations(self->dbgid, recoveryCommitRequest.arena, tr.mutations.slice(mmApplied, tr.mutations.size()),
+	applyMetadataMutations(SpanID(), self->dbgid, recoveryCommitRequest.arena, tr.mutations.slice(mmApplied, tr.mutations.size()),
 	                       self->txnStateStore);
 	mmApplied = tr.mutations.size();
 


### PR DESCRIPTION
Updates serialization format of `TLogCommitRequest.messages` sent from the proxy to the transaction logs. Adds span context information for each set of mutations so the transaction logs can identify the transaction a mutation belongs to, allowing for better tracing of requests through the system. See #3329 for context.

The old serialization format contained an arbitrary number of mutations the proxy would batch and send to the tlogs, in the format:

```
+----------------------+ +----------------------+ +----------+ +----------------+         +----------------------+
|     Message size     | |      Subsequence     | | # of tags| |      Tag       | . . . . |       Mutation       |
+----------------------+ +----------------------+ +----------+ +----------------+         +----------------------+
<------- 32 bits ------> <------- 32 bits ------> <- 16 bits-> <---- 24 bits --->         <---- variable bits --->
```

... repeating for some number of mutations. The new format adds a span context for each set of mutations corresponding to a transaction in the following format:

```
+----------------------------+ +----------+
|        Span context        | | # of mut |
+----------------------------+ +----------+
<--------- 128 bits ---------> <- 16 bits->

+----------------------+ +----------------------+ +----------+ +----------------+         +----------------------+
|     Message size     | |      Subsequence     | | # of tags| |      Tag       | . . . . |       Mutation       |
+----------------------+ +----------------------+ +----------+ +----------------+         +----------------------+
<------- 32 bits ------> <------- 32 bits ------> <- 16 bits-> <---- 24 bits --->         <---- variable bits --->

. . .
```

where the second line will be repeated for each mutation in the transaction. The entire format will be repeated for each transaction.

This adds an overhead of 18 bytes per transaction for `TLogCommitRequest` messages from the proxy -> tlogs (this data is also persisted to disk so will require more disk space). Still undergoing testing to look into how/if this impacts performance.

Also updates `LogPushData::addMessage` and `LogPushData::addTypedMessage` to `LogPushData::writeMessage` and `LogPushData::writeTypedMessage` to reflect that these functions actually write their data to the `BinaryWriter`.

There is some remaining work to be done around determining the correct span context to pass in certain situations (see `SpanID()`).