### PR TITLE
Update tlogs to parse span context from TLogCommitRequest messages

### DIFF
--- a/fdbclient/FDBTypes.h
+++ b/fdbclient/FDBTypes.h
@@ -129,10 +129,29 @@ enum { txsTagOld = -1, invalidTagOld = -100 };
 
 struct TagsAndMessage {
 	StringRef message;
+	SpanID spanContext;
 	VectorRef<Tag> tags;
 
 	TagsAndMessage() {}
+	TagsAndMessage(SpanID spanContext) : spanContext(spanContext) {}
 	TagsAndMessage(StringRef message, VectorRef<Tag> tags) : message(message), tags(tags) {}
+
+	// Reads transaction info from the buffer rd. Returns SpanID and number of
+	// transactions in output parameters. T can be ArenaReader or BinaryReader.
+	template <class T>
+	static void loadTransactionInfoFromArena(T* rd, SpanID *context, uint16_t* transactions) {
+		SpanID spanContext;
+		uint16_t numTransactions;
+
+		*rd >> spanContext >> numTransactions;
+
+		if (context) {
+			*context = spanContext;
+		}
+		if (transactions) {
+			*transactions = numTransactions;
+		}
+	}
 
 	// Loads tags and message from a serialized buffer. "rd" is checkpointed at
 	// its begining position to allow the caller to rewind if needed.

--- a/fdbclient/FDBTypes.h
+++ b/fdbclient/FDBTypes.h
@@ -136,20 +136,21 @@ struct TagsAndMessage {
 	TagsAndMessage(SpanID spanContext) : spanContext(spanContext) {}
 	TagsAndMessage(StringRef message, VectorRef<Tag> tags) : message(message), tags(tags) {}
 
-	// Reads transaction info from the buffer rd. Returns SpanID and number of
-	// transactions in output parameters. T can be ArenaReader or BinaryReader.
+	// Reads transaction info from the buffer rd. Returns the SpanID and the number
+	// of mutations in the transaction as output parameters. T can be ArenaReader
+	// or BinaryReader.
 	template <class T>
-	static void loadTransactionInfoFromArena(T* rd, SpanID *context, uint16_t* transactions) {
+	static void loadTransactionInfoFromArena(T* rd, SpanID* context, uint16_t* mutations) {
 		SpanID spanContext;
-		uint16_t numTransactions;
+		uint16_t numMutations;
 
-		*rd >> spanContext >> numTransactions;
+		*rd >> spanContext >> numMutations;
 
 		if (context) {
 			*context = spanContext;
 		}
-		if (transactions) {
-			*transactions = numTransactions;
+		if (mutations) {
+			*mutations = numMutations;
 		}
 	}
 

--- a/fdbserver/ApplyMetadataMutation.h
+++ b/fdbserver/ApplyMetadataMutation.h
@@ -39,10 +39,10 @@ inline bool isMetadataMutation(MutationRef const& m) {
 
 Reference<StorageInfo> getStorageInfo(UID id, std::map<UID, Reference<StorageInfo>>* storageCache, IKeyValueStore* txnStateStore);
 
-void applyMetadataMutations(ProxyCommitData& proxyCommitData, Arena& arena, Reference<ILogSystem> logSystem,
-                            const VectorRef<MutationRef>& mutations, LogPushData* pToCommit, bool& confChange,
-                            Version popVersion, bool initialCommit);
-void applyMetadataMutations(const UID& dbgid, Arena& arena, const VectorRef<MutationRef>& mutations,
-                            IKeyValueStore* txnStateStore);
+void applyMetadataMutations(SpanID const& spanContext, ProxyCommitData& proxyCommitData, Arena& arena,
+                            Reference<ILogSystem> logSystem, const VectorRef<MutationRef>& mutations,
+                            LogPushData* pToCommit, bool& confChange, Version popVersion, bool initialCommit);
+void applyMetadataMutations(SpanID const& spanContext, const UID& dbgid, Arena& arena,
+                            const VectorRef<MutationRef>& mutations, IKeyValueStore* txnStateStore);
 
 #endif

--- a/fdbserver/LogSystem.h
+++ b/fdbserver/LogSystem.h
@@ -668,7 +668,7 @@ struct ILogSystem {
 		// Never returns normally, but throws an error if the subsystem stops working
 
 	//Future<Void> push( UID bundle, int64_t seq, VectorRef<TaggedMessageRef> messages );
-	virtual Future<Version> push( Version prevVersion, Version version, Version knownCommittedVersion, Version minKnownCommittedVersion, struct LogPushData& data, Optional<UID> debugID = Optional<UID>() ) = 0;
+	virtual Future<Version> push( Version prevVersion, Version version, Version knownCommittedVersion, Version minKnownCommittedVersion, struct LogPushData& data, SpanID spanContext, Optional<UID> debugID = Optional<UID>() ) = 0;
 		// Waits for the version number of the bundle (in this epoch) to be prevVersion (i.e. for all pushes ordered earlier)
 		// Puts the given messages into the bundle, each with the given tags, and with message versions (version, 0) - (version, N)
 		// Changes the version number of the bundle to be version (unblocking the next push)
@@ -818,10 +818,26 @@ struct CompareFirst {
 	}
 };
 
+// Structure to store serialized mutations sent from the proxy to the
+// transaction logs. The serialization repeats with the following format:
+//
+// +----------------------------+ +----------+
+// |        Span Context        | | # of mut |
+// +----------------------------+ +----------+
+// <--------- 128 bits ---------> <- 16 bits->
+//
+// +----------------------+ +----------------------+ +----------+ +----------------+         +----------------------+
+// |     Message size     | |      Subsequence     | | # of tags| |      Tag       | . . . . |       Mutation       |
+// +----------------------+ +----------------------+ +----------+ +----------------+         +----------------------+
+// <------- 32 bits ------> <------- 32 bits ------> <- 16 bits-> <---- 24 bits --->         <---- variable bits --->
+//
+// . . . (repeating according to # of mutations field) . . .
+//
 struct LogPushData : NonCopyable {
 	// Log subsequences have to start at 1 (the MergedPeekCursor relies on this to make sure we never have !hasMessage() in the middle of data for a version
 
-	explicit LogPushData(Reference<ILogSystem> logSystem) : logSystem(logSystem), subsequence(1) {
+	explicit LogPushData(Reference<ILogSystem> logSystem)
+			: logSystem(logSystem), subsequence(1), numTransactions(0), wroteTransactionInfo(false) {
 		for(auto& log : logSystem->getLogSystemConfig().tLogs) {
 			if(log.isLocal) {
 				for(int i = 0; i < log.tLogs.size(); i++) {
@@ -849,7 +865,14 @@ struct LogPushData : NonCopyable {
 		next_message_tags.insert(next_message_tags.end(), tags.begin(), tags.end());
 	}
 
-	void addMessage( StringRef rawMessageWithoutLength, bool usePreviousLocations ) {
+	// Add transaction info to be written by the first mutation in the transaction
+	void addTransactionInfo(SpanID context, uint16_t transactions) {
+		spanContext = context;
+		numTransactions = transactions;
+		wroteTransactionInfo = false;
+	}
+
+	void writeMessage( StringRef rawMessageWithoutLength, bool usePreviousLocations ) {
 		if( !usePreviousLocations ) {
 			prev_tags.clear();
 			if(logSystem->hasRemoteLogs()) {
@@ -865,15 +888,22 @@ struct LogPushData : NonCopyable {
 		uint32_t subseq = this->subsequence++;
 		uint32_t msgsize = rawMessageWithoutLength.size() + sizeof(subseq) + sizeof(uint16_t) + sizeof(Tag)*prev_tags.size();
 		for(int loc : msg_locations) {
+			if (!wroteTransactionInfo) {
+				messagesWriter[loc] << spanContext << numTransactions;
+			}
 			messagesWriter[loc] << msgsize << subseq << uint16_t(prev_tags.size());
 			for(auto& tag : prev_tags)
 				messagesWriter[loc] << tag;
 			messagesWriter[loc].serializeBytes(rawMessageWithoutLength);
 		}
+
+		spanContext = SpanID();
+		numTransactions = 0;
+		wroteTransactionInfo = true;
 	}
 
 	template <class T>
-	void addTypedMessage(T const& item, bool allLocations = false) {
+	void writeTypedMessage(T const& item, bool allLocations = false) {
 		prev_tags.clear();
 		if(logSystem->hasRemoteLogs()) {
 			prev_tags.push_back( logSystem->getRandomRouterTag() );
@@ -891,6 +921,9 @@ struct LogPushData : NonCopyable {
 		for(int loc : msg_locations) {
 			if (first) {
 				BinaryWriter& wr = messagesWriter[loc];
+				if (!wroteTransactionInfo) {
+					wr << spanContext << numTransactions;
+				}
 				firstOffset = wr.getLength();
 				wr << uint32_t(0) << subseq << uint16_t(prev_tags.size());
 				for(auto& tag : prev_tags)
@@ -906,6 +939,12 @@ struct LogPushData : NonCopyable {
 				wr.serializeBytes( (uint8_t*)from.getData() + firstOffset, firstLength );
 			}
 		}
+		// Reset transaction information after first message in transaction is
+		// written. Future transactions should reset this state by calling
+		// addTransactionInfo.
+		spanContext = SpanID();
+		numTransactions = 0;
+		wroteTransactionInfo = true;
 		next_message_tags.clear();
 	}
 
@@ -920,6 +959,9 @@ private:
 	std::vector<BinaryWriter> messagesWriter;
 	std::vector<int> msg_locations;
 	uint32_t subsequence;
+	SpanID spanContext;
+	uint16_t numTransactions;
+	bool wroteTransactionInfo;
 };
 
 #endif

--- a/fdbserver/LogSystemPeekCursor.actor.cpp
+++ b/fdbserver/LogSystemPeekCursor.actor.cpp
@@ -27,7 +27,7 @@
 
 ILogSystem::ServerPeekCursor::ServerPeekCursor( Reference<AsyncVar<OptionalInterface<TLogInterface>>> const& interf, Tag tag, Version begin, Version end, bool returnIfBlocked, bool parallelGetMore )
 			: interf(interf), tag(tag), messageVersion(begin), end(end), hasMsg(false), rd(results.arena, results.messages, Unversioned()), randomID(deterministicRandom()->randomUniqueID()), poppedVersion(0),
-			  returnIfBlocked(returnIfBlocked), sequence(0), onlySpilled(false), parallelGetMore(parallelGetMore), lastReset(0), slowReplies(0), fastReplies(0), unknownReplies(0), resetCheck(Void()), mutationsRemaining(0)
+			  returnIfBlocked(returnIfBlocked), sequence(0), onlySpilled(false), parallelGetMore(parallelGetMore), lastReset(0), slowReplies(0), fastReplies(0), unknownReplies(0), resetCheck(Void())
 {
 	this->results.maxKnownVersion = 0;
 	this->results.minKnownCommittedVersion = 0;
@@ -36,7 +36,7 @@ ILogSystem::ServerPeekCursor::ServerPeekCursor( Reference<AsyncVar<OptionalInter
 
 ILogSystem::ServerPeekCursor::ServerPeekCursor( TLogPeekReply const& results, LogMessageVersion const& messageVersion, LogMessageVersion const& end, TagsAndMessage const& message, bool hasMsg, Version poppedVersion, Tag tag )
 			: results(results), tag(tag), rd(results.arena, results.messages, Unversioned()), messageVersion(messageVersion), end(end), messageAndTags(message), hasMsg(hasMsg), 
-			  randomID(deterministicRandom()->randomUniqueID()), poppedVersion(poppedVersion), returnIfBlocked(false), sequence(0), onlySpilled(false), parallelGetMore(false), lastReset(0), slowReplies(0), fastReplies(0), unknownReplies(0), resetCheck(Void()), mutationsRemaining(0)
+			  randomID(deterministicRandom()->randomUniqueID()), poppedVersion(poppedVersion), returnIfBlocked(false), sequence(0), onlySpilled(false), parallelGetMore(false), lastReset(0), slowReplies(0), fastReplies(0), unknownReplies(0), resetCheck(Void())
 {
 	//TraceEvent("SPC_Clone", randomID);
 	this->results.maxKnownVersion = 0;
@@ -93,14 +93,7 @@ void ILogSystem::ServerPeekCursor::nextMessage() {
 		ASSERT(!rd.empty());
 	}
 
-	// TraceEvent("LUKAS_ServerPeekCursor::nextMessage");
-	/*
-	if (mutationsRemaining == 0) {
-		SpanID spanContext;
-		TagsAndMessage::loadTransactionInfoFromArena(&rd, &spanContext, &mutationsRemaining);
-	}
-	*/
-
+	// TODO: Handle span context header
 	messageAndTags.loadFromArena(&rd, &messageVersion.sub);
 	DEBUG_TAGS_AND_MESSAGE("ServerPeekCursor", messageVersion.version, messageAndTags.getRawMessage()).detail("CursorID", this->randomID);
 	// Rewind and consume the header so that reader() starts from the message.
@@ -108,7 +101,6 @@ void ILogSystem::ServerPeekCursor::nextMessage() {
 	rd.readBytes(messageAndTags.getHeaderSize());
 	hasMsg = true;
 	//TraceEvent("SPC_NextMessageB", randomID).detail("MessageVersion", messageVersion.toString());
-	// --mutationsRemaining;
 }
 
 StringRef ILogSystem::ServerPeekCursor::getMessage() {

--- a/fdbserver/LogSystemPeekCursor.actor.cpp
+++ b/fdbserver/LogSystemPeekCursor.actor.cpp
@@ -93,6 +93,7 @@ void ILogSystem::ServerPeekCursor::nextMessage() {
 		ASSERT(!rd.empty());
 	}
 
+	// TODO: Handle span context header
 	messageAndTags.loadFromArena(&rd, &messageVersion.sub);
 	DEBUG_TAGS_AND_MESSAGE("ServerPeekCursor", messageVersion.version, messageAndTags.getRawMessage()).detail("CursorID", this->randomID);
 	// Rewind and consume the header so that reader() starts from the message.

--- a/fdbserver/MutationTracking.cpp
+++ b/fdbserver/MutationTracking.cpp
@@ -52,32 +52,39 @@ TraceEvent debugKeyRangeEnabled( const char* context, Version version, KeyRangeR
 TraceEvent debugTagsAndMessageEnabled( const char* context, Version version, StringRef commitBlob ) {
 	BinaryReader rdr(commitBlob, AssumeVersion(currentProtocolVersion));
 	while (!rdr.empty()) {
-		if (*(int32_t*)rdr.peekBytes(4) == VERSION_HEADER) {
-			int32_t dummy;
-			rdr >> dummy >> version;
-			continue;
-		}
-		TagsAndMessage msg;
-		msg.loadFromArena(&rdr, nullptr);
-		bool logAdapterMessage = std::any_of(
-				msg.tags.begin(), msg.tags.end(), [](const Tag& t) { return t == txsTag || t.locality == tagLocalityTxs; });
-		StringRef mutationData = msg.getMessageWithoutTags();
-		uint8_t mutationType = *mutationData.begin();
-		if (logAdapterMessage) {
-			// Skip the message, as there will always be an idential non-logAdapterMessage mutation
-			// that we can match against in the same commit.
-		} else if (LogProtocolMessage::startsLogProtocolMessage(mutationType)) {
-			BinaryReader br(mutationData, AssumeVersion(rdr.protocolVersion()));
-			LogProtocolMessage lpm;
-			br >> lpm;
-			rdr.setProtocolVersion(br.protocolVersion());
-		} else {
-			MutationRef m;
-			BinaryReader br(mutationData, AssumeVersion(rdr.protocolVersion()));
-			br >> m;
-			TraceEvent&& event = debugMutation(context, version, m);
-			if (event.isEnabled()) {
-				return std::move(event.detail("MessageTags", msg.tags));
+		SpanID spanContext;
+		uint16_t numTransactions = 0;
+		TagsAndMessage::loadTransactionInfoFromArena(&rdr, &spanContext, &numTransactions);
+
+		for (uint16_t i = 0; i < numTransactions; ++i) {
+			if (*(int32_t*)rdr.peekBytes(4) == VERSION_HEADER) {
+				int32_t dummy;
+				rdr >> dummy >> version;
+				continue;
+			}
+
+			TagsAndMessage msg;
+			msg.loadFromArena(&rdr, nullptr);
+			bool logAdapterMessage = std::any_of(
+					msg.tags.begin(), msg.tags.end(), [](const Tag& t) { return t == txsTag || t.locality == tagLocalityTxs; });
+			StringRef mutationData = msg.getMessageWithoutTags();
+			uint8_t mutationType = *mutationData.begin();
+			if (logAdapterMessage) {
+				// Skip the message, as there will always be an idential non-logAdapterMessage mutation
+				// that we can match against in the same commit.
+			} else if (LogProtocolMessage::startsLogProtocolMessage(mutationType)) {
+				BinaryReader br(mutationData, AssumeVersion(rdr.protocolVersion()));
+				LogProtocolMessage lpm;
+				br >> lpm;
+				rdr.setProtocolVersion(br.protocolVersion());
+			} else {
+				MutationRef m;
+				BinaryReader br(mutationData, AssumeVersion(rdr.protocolVersion()));
+				br >> m;
+				TraceEvent&& event = debugMutation(context, version, m);
+				if (event.isEnabled()) {
+					return std::move(event.detail("MessageTags", msg.tags));
+				}
 			}
 		}
 	}

--- a/fdbserver/MutationTracking.cpp
+++ b/fdbserver/MutationTracking.cpp
@@ -53,10 +53,10 @@ TraceEvent debugTagsAndMessageEnabled( const char* context, Version version, Str
 	BinaryReader rdr(commitBlob, AssumeVersion(currentProtocolVersion));
 	while (!rdr.empty()) {
 		SpanID spanContext;
-		uint16_t numTransactions = 0;
-		TagsAndMessage::loadTransactionInfoFromArena(&rdr, &spanContext, &numTransactions);
+		uint16_t numMutations = 0;
+		TagsAndMessage::loadTransactionInfoFromArena(&rdr, &spanContext, &numMutations);
 
-		for (uint16_t i = 0; i < numTransactions; ++i) {
+		for (uint16_t i = 0; i < numMutations; ++i) {
 			if (*(int32_t*)rdr.peekBytes(4) == VERSION_HEADER) {
 				int32_t dummy;
 				rdr >> dummy >> version;

--- a/fdbserver/TLogInterface.h
+++ b/fdbserver/TLogInterface.h
@@ -240,6 +240,7 @@ struct TLogCommitReply {
 
 struct TLogCommitRequest {
 	constexpr static FileIdentifier file_identifier = 4022206;
+	SpanID spanContext;
 	Arena arena;
 	Version prevVersion, version, knownCommittedVersion, minKnownCommittedVersion;
 
@@ -249,11 +250,11 @@ struct TLogCommitRequest {
 	Optional<UID> debugID;
 
 	TLogCommitRequest() {}
-	TLogCommitRequest( const Arena& a, Version prevVersion, Version version, Version knownCommittedVersion, Version minKnownCommittedVersion, StringRef messages, Optional<UID> debugID )
-		: arena(a), prevVersion(prevVersion), version(version), knownCommittedVersion(knownCommittedVersion), minKnownCommittedVersion(minKnownCommittedVersion), messages(messages), debugID(debugID) {}
+	TLogCommitRequest( SpanID spanContext, const Arena& a, Version prevVersion, Version version, Version knownCommittedVersion, Version minKnownCommittedVersion, StringRef messages, Optional<UID> debugID )
+		: spanContext(spanContext), arena(a), prevVersion(prevVersion), version(version), knownCommittedVersion(knownCommittedVersion), minKnownCommittedVersion(minKnownCommittedVersion), messages(messages), debugID(debugID) {}
 	template <class Ar>
 	void serialize( Ar& ar ) {
-		serializer(ar, prevVersion, version, knownCommittedVersion, minKnownCommittedVersion, messages, reply, arena, debugID);
+		serializer(ar, prevVersion, version, knownCommittedVersion, minKnownCommittedVersion, messages, reply, arena, debugID, spanContext);
 	}
 };
 

--- a/fdbserver/TagPartitionedLogSystem.actor.cpp
+++ b/fdbserver/TagPartitionedLogSystem.actor.cpp
@@ -499,7 +499,8 @@ struct TagPartitionedLogSystem : ILogSystem, ReferenceCounted<TagPartitionedLogS
 	}
 
 	Future<Version> push(Version prevVersion, Version version, Version knownCommittedVersion,
-	                     Version minKnownCommittedVersion, LogPushData& data, Optional<UID> debugID) final {
+	                     Version minKnownCommittedVersion, LogPushData& data, SpanID spanContext,
+	                     Optional<UID> debugID) final {
 		// FIXME: Randomize request order as in LegacyLogSystem?
 		vector<Future<Void>> quorumResults;
 		vector<Future<TLogCommitReply>> allReplies;
@@ -509,7 +510,7 @@ struct TagPartitionedLogSystem : ILogSystem, ReferenceCounted<TagPartitionedLogS
 				vector<Future<Void>> tLogCommitResults;
 				for(int loc=0; loc< it->logServers.size(); loc++) {
 					Standalone<StringRef> msg = data.getMessages(location);
-					allReplies.push_back( it->logServers[loc]->get().interf().commit.getReply( TLogCommitRequest( msg.arena(), prevVersion, version, knownCommittedVersion, minKnownCommittedVersion, msg, debugID ), TaskPriority::ProxyTLogCommitReply ) );
+					allReplies.push_back( it->logServers[loc]->get().interf().commit.getReply( TLogCommitRequest( spanContext, msg.arena(), prevVersion, version, knownCommittedVersion, minKnownCommittedVersion, msg, debugID ), TaskPriority::ProxyTLogCommitReply ) );
 					Future<Void> commitSuccess = success(allReplies.back());
 					addActor.get().send(commitSuccess);
 					tLogCommitResults.push_back(commitSuccess);

--- a/fdbserver/masterserver.actor.cpp
+++ b/fdbserver/masterserver.actor.cpp
@@ -1564,7 +1564,7 @@ ACTOR Future<Void> masterCore( Reference<MasterData> self ) {
 		}
 	}
 
-	applyMetadataMutations(self->dbgid, recoveryCommitRequest.arena, tr.mutations.slice(mmApplied, tr.mutations.size()),
+	applyMetadataMutations(SpanID(), self->dbgid, recoveryCommitRequest.arena, tr.mutations.slice(mmApplied, tr.mutations.size()),
 	                       self->txnStateStore);
 	mmApplied = tr.mutations.size();
 


### PR DESCRIPTION
It appears to be a limitation that I cannot stack this PR on top of #3622 without creating a branch for #3622. This PR should only contain the changes not included in #3622.

Dependent on #3622.

Updates how transaction logs parse `TLogCommitRequest.messages` requests from the proxy based on the updated serialization format in #3622. Reads in the number of mutations and uses the value to parse that many mutations before repeating the process if there are bytes remaining.

Doesn't use span context info for anything yet -- that will come in a future PR.