### PR TITLE
Rename ThreadSafeTransaction.cpp

### DIFF
--- a/fdbclient/CMakeLists.txt
+++ b/fdbclient/CMakeLists.txt
@@ -67,7 +67,7 @@ set(FDBCLIENT_SRCS
   TagThrottle.h
   TaskBucket.actor.cpp
   TaskBucket.h
-  ThreadSafeTransaction.actor.cpp
+  ThreadSafeTransaction.cpp
   ThreadSafeTransaction.h
   Tuple.cpp
   Tuple.h

--- a/fdbclient/ThreadSafeTransaction.cpp
+++ b/fdbclient/ThreadSafeTransaction.cpp
@@ -1,5 +1,5 @@
 /*
- * ThreadSafeTransaction.actor.cpp
+ * ThreadSafeTransaction.cpp
  *
  * This source file is part of the FoundationDB open source project
  *


### PR DESCRIPTION
This file doesn't contain actors, so it doesn't need the actor.cpp suffix.