### PR TITLE
Fix potential invalid memory access bug.

### DIFF
--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -3755,9 +3755,9 @@ Future<Void> Transaction::onError( Error const& e ) {
 
 	return e;
 }
-ACTOR Future<StorageMetrics> getStorageMetricsLargeKeyRange(Database cx, KeyRangeRef keys);
+ACTOR Future<StorageMetrics> getStorageMetricsLargeKeyRange(Database cx, KeyRange keys);
 
-ACTOR Future<StorageMetrics> doGetStorageMetrics(Database cx, KeyRangeRef keys, Reference<LocationInfo> locationInfo) {
+ACTOR Future<StorageMetrics> doGetStorageMetrics(Database cx, KeyRange keys, Reference<LocationInfo> locationInfo) {
 	loop {
 		try {
 			WaitMetricsRequest req(keys, StorageMetrics(), StorageMetrics());
@@ -3779,7 +3779,7 @@ ACTOR Future<StorageMetrics> doGetStorageMetrics(Database cx, KeyRangeRef keys, 
 	}
 }
 
-ACTOR Future<StorageMetrics> getStorageMetricsLargeKeyRange(Database cx, KeyRangeRef keys) {
+ACTOR Future<StorageMetrics> getStorageMetricsLargeKeyRange(Database cx, KeyRange keys) {
 
 	vector<pair<KeyRange, Reference<LocationInfo>>> locations = wait(getKeyRangeLocations(
 	    cx, keys, std::numeric_limits<int>::max(), false, &StorageServerInterface::waitMetrics, TransactionInfo(TaskPriority::DataDistribution)));


### PR DESCRIPTION
These two actors take a reference type, without necessary mechanism to ensure the lifetime of the referenced memory is long enough. And thus these two actors(actually maybe all actors) should not take reference types but copies of data(or at least reference counted types) that it would work on.

Specifically, the only call site of function `getStorageMetricsLargeKeyRange()` is inside `Transaction::getStorageMetrics(KeyRange&, int)`, where a `KeyRangeRef` is created based on the `KeyRange&` passed in. Now if for some reason(for example in the case that got fixed in d198c310f4b47cfb84eb752eb56bf5388e098677) the lifetime of the underlying `KeyRange` ends after the first `wait()` is hit inside `getStorageMetricsLargeKeyRange()`, the `KeyRangeRef` now points to invalid memory and thus the segmentation fault happens sometime later.

This specific bug is hard to capture by Valgrind/simulation because it is on the path that involves both client and server side.