### PR TITLE
Construct FlowLock::Releaser before AsyncFileBlobStore upload

### DIFF
--- a/fdbclient/AsyncFileBlobStore.actor.h
+++ b/fdbclient/AsyncFileBlobStore.actor.h
@@ -225,8 +225,9 @@ private:
 
 		// Do the upload, and if it fails forward errors to m_error and also stop if anything else sends an error to m_error
 		// Also, hold a releaser for the concurrent upload slot while all that is going on.
-		f->m_parts.back()->etag = holdWhile(std::make_shared<FlowLock::Releaser>(f->m_concurrentUploads, 1),
-		                                    joinErrorGroup(doPartUpload(f, f->m_parts.back().getPtr()), f->m_error));
+		auto releaser = std::make_shared<FlowLock::Releaser>(f->m_concurrentUploads, 1);
+		f->m_parts.back()->etag =
+		    holdWhile(std::move(releaser), joinErrorGroup(doPartUpload(f, f->m_parts.back().getPtr()), f->m_error));
 
 		// Make a new part to write to
 		if(startNew)


### PR DESCRIPTION
This builds on https://github.com/apple/foundationdb/pull/3640, which fixed a potential memory leak, but not a potentially unreleased lock.