### PR TITLE
Remove unnecessary special case handling from JsonParser

### DIFF
--- a/contrib/TraceLogHelper/JsonParser.cs
+++ b/contrib/TraceLogHelper/JsonParser.cs
@@ -80,8 +80,7 @@ namespace Magnesium
 				TraceFile = file,
 				DDetails = xEvent.Elements()
 					.Where(a=>a.Name != "Type" && a.Name != "Time" && a.Name != "Machine" && a.Name != "ID" && a.Name != "Severity" && (!rolledEvent || a.Name != "OriginalTime"))
-					// When the key contains a colon character, it gets parsed as a:item
-					.ToDictionary(a=>a.Name.LocalName == "item" ? a.Attribute("item").Value : string.Intern(a.Name.LocalName), a=>(object)a.Value),
+					.ToDictionary(a=>string.Intern(a.Name.LocalName), a=>(object)a.Value),
 				original = keepOriginalElement ? xEvent : null
 			};
 		}


### PR DESCRIPTION
We once added a special case handling in case JSON trace logs contain XML-unfriendly characters.
However, FDB supports both XML and JSON and we know that it won't contain such characters.
Therefore removing the (somewhat hacky) special handling here.