### PR TITLE
Use =delete to disable special member functions

### DIFF
--- a/fdbclient/DatabaseContext.h
+++ b/fdbclient/DatabaseContext.h
@@ -345,7 +345,7 @@ public:
 	std::vector<std::unique_ptr<SpecialKeyRangeReadImpl>> specialKeySpaceModules;
 	std::unique_ptr<SpecialKeySpace> specialKeySpace;
 	void registerSpecialKeySpaceModule(SpecialKeySpace::MODULE module, SpecialKeySpace::IMPLTYPE type,
-	                                   std::unique_ptr<SpecialKeyRangeReadImpl> impl);
+	                                   std::unique_ptr<SpecialKeyRangeReadImpl> &&impl);
 
 	static bool debugUseTags;
 	static const std::vector<std::string> debugTransactionTagChoices; 

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -697,7 +697,7 @@ Future<HealthMetrics> DatabaseContext::getHealthMetrics(bool detailed = false) {
 }
 
 void DatabaseContext::registerSpecialKeySpaceModule(SpecialKeySpace::MODULE module, SpecialKeySpace::IMPLTYPE type,
-                                                    std::unique_ptr<SpecialKeyRangeReadImpl> impl) {
+                                                    std::unique_ptr<SpecialKeyRangeReadImpl> &&impl) {
 	specialKeySpace->registerKeyRange(module, type, impl->getKeyRange(), impl.get());
 	specialKeySpaceModules.push_back(std::move(impl));
 }

--- a/flow/Arena.h
+++ b/flow/Arena.h
@@ -85,11 +85,12 @@ struct TrackIt {
 class NonCopyable
 {
   protected:
-	NonCopyable () {}
-	~NonCopyable () {} /// Protected non-virtual destructor
-  private:
-	NonCopyable (const NonCopyable &);
-	NonCopyable & operator = (const NonCopyable &);
+	NonCopyable()=default;
+	~NonCopyable()=default; /// Protected non-virtual destructor
+	NonCopyable(NonCopyable&&)=default;
+	NonCopyable &operator=(NonCopyable&&)=default;
+	NonCopyable(const NonCopyable&)=delete;
+	NonCopyable &operator=(const NonCopyable &)=delete;
 };
 
 // An Arena is a custom allocator that consists of a set of ArenaBlocks.  Allocation is performed by bumping a pointer
@@ -174,9 +175,7 @@ struct ArenaBlock : NonCopyable, ThreadSafeReferenceCounted<ArenaBlock>
 	static ArenaBlock* create(int dataSize, Reference<ArenaBlock>& next);
 	void destroy();
 	void destroyLeaf();
-
-private:
-	static void* operator new(size_t s); // not implemented
+	static void* operator new(size_t s)=delete;
 };
 
 inline void* operator new ( size_t size, Arena& p ) {

--- a/flow/FastAlloc.h
+++ b/flow/FastAlloc.h
@@ -118,6 +118,7 @@ public:
 	static volatile int32_t pageCount;
 #endif
 
+	FastAllocator()=delete;
 private:
 #ifdef VALGRIND
 	static unsigned long vLock;
@@ -147,7 +148,6 @@ private:
 	}
 	static void* freelist;
 
-	FastAllocator();  // not implemented
 	static void initThread();
 	static void getMagazine();
 	static void releaseMagazine(void*);

--- a/flow/IThreadPool.cpp
+++ b/flow/IThreadPool.cpp
@@ -71,11 +71,10 @@ class ThreadPool : public IThreadPool, public ReferenceCounted<ThreadPool> {
 		PThreadAction action;
 		ActionWrapper(PThreadAction action) : action(action) {}
 		// HACK: Boost won't use move constructors, so we just assume the last copy made is the one that will be called or cancelled
-		ActionWrapper(ActionWrapper const& r) : action(r.action) { const_cast<ActionWrapper&>(r).action=NULL; }
-		void operator()() { Thread::dispatch(action); action = NULL; }
+		ActionWrapper(ActionWrapper const& r) : action(r.action) { const_cast<ActionWrapper&>(r).action=nullptr; }
+		void operator()() { Thread::dispatch(action); action = nullptr; }
 		~ActionWrapper() { if (action) { action->cancel(); } }
-	private:
-		ActionWrapper &operator=(ActionWrapper const&);
+		ActionWrapper &operator=(ActionWrapper const&)=delete;
 	};
 public:
 	ThreadPool(int stackSize) : dontstop(ios), mode(Run), stackSize(stackSize) {}


### PR DESCRIPTION
This has the benefits of:
- Easier to understand compiler error messages
- Moves some errors from link-time to compile-time
- NonCopyable classes can still specify default move constructors