### PR TITLE
Report recommended tx tag to be throttled to status json

### DIFF
--- a/documentation/sphinx/source/command-line-interface.rst
+++ b/documentation/sphinx/source/command-line-interface.rst
@@ -456,16 +456,20 @@ disable
 
 ``throttle disable auto``
 
-Disables cluster auto-throttling for busy transaction tags. This does not disable any currently active throttles. To do so, run the following command after disabling auto-throttling::
-
-> throttle off auto
+Disables cluster auto-throttling for busy transaction tags. This may not disable currently active throttles immediately, seconds of delay is expected.
 
 list
 ^^^^
 
-``throttle list [LIMIT]``
+``throttle list [throttled|recommended|all] [LIMIT]``
 
-Prints a list of currently active transaction tag throttles.
+Prints a list of currently active transaction tag throttles, or recommended transaction tag throttles if auto-throttling is disabled.
+
+``throttled`` - list active transaction tag throttles.
+
+``recommended`` - list transaction tag throttles recommended by the ratekeeper, but not active yet.
+
+``all`` - list both active and recommended transaction tag throttles.
 
 ``LIMIT`` - The number of throttles to print. Defaults to 100.
 

--- a/documentation/sphinx/source/mr-status-json-schemas.rst.inc
+++ b/documentation/sphinx/source/mr-status-json-schemas.rst.inc
@@ -313,11 +313,18 @@
          "batch_released_transactions_per_second":0,
          "released_transactions_per_second":0,
          "throttled_tags":{
-            "auto":{
-               "count":0
+            "auto" : {
+                "busy_read" : 0,
+                "busy_write" : 0,
+                "count" : 0
             },
-            "manual":{
-               "count":0
+            "manual" : {
+                "count" : 1
+            },
+            "recommend" : {
+                "busy_read" : 0,
+                "busy_write" : 0,
+                "count" : 0
             }
          },
          "limiting_queue_bytes_storage_server":0,

--- a/documentation/sphinx/source/mr-status.rst
+++ b/documentation/sphinx/source/mr-status.rst
@@ -132,3 +132,13 @@ log_server_min_free_space           Log server running out of space (approaching
 log_server_min_free_space_ratio     Log server running out of space (approaching 5% limit).
 storage_server_durability_lag       Storage server durable version falling behind.
 =================================== ====================================================
+
+The JSON path ``cluster.qos.throttled_tags``, when it exists, is an Object containing ``"auto"`` , ``"manual"`` and ``"recommended"``.  The possible fields for those object are in the following table:
+
+=================================== ====================================================
+Name                                Description
+=================================== ====================================================
+count                               How many tags are throttled
+busy_read                           How many tags are throttled because of busy read
+busy_write                          How many tags are throttled because of busy write
+=================================== ====================================================

--- a/fdbcli/fdbcli.actor.cpp
+++ b/fdbcli/fdbcli.actor.cpp
@@ -4109,9 +4109,9 @@ ACTOR Future<int> cli(CLIOptions opt, LineNoise* plinenoise) {
 								reportThrottled = true; reportRecommended = true;
 							}
 							else if(!tokencmp(tokens[2], "throttled")){
-                                printf("ERROR: failed to parse `%s'.\n", printable(tokens[2]).c_str());
-                                is_error = true;
-                                continue;
+								printf("ERROR: failed to parse `%s'.\n", printable(tokens[2]).c_str());
+								is_error = true;
+								continue;
 							}
 						}
 
@@ -4131,11 +4131,11 @@ ACTOR Future<int> cli(CLIOptions opt, LineNoise* plinenoise) {
 							wait(store(tags, ThrottleApi::getThrottledTags(db, throttleListLimit, true)));
 						}
 						else if(reportThrottled) {
-                            wait(store(tags, ThrottleApi::getThrottledTags(db, throttleListLimit)));
-                        }
+							wait(store(tags, ThrottleApi::getThrottledTags(db, throttleListLimit)));
+						}
 						else if(reportRecommended) {
-                            wait(store(tags, ThrottleApi::getRecommendedTags(db, throttleListLimit)));
-                        }
+							wait(store(tags, ThrottleApi::getRecommendedTags(db, throttleListLimit)));
+						}
 
 						bool anyLogged = false;
 						for(auto itr = tags.begin(); itr != tags.end(); ++itr) {

--- a/fdbcli/fdbcli.actor.cpp
+++ b/fdbcli/fdbcli.actor.cpp
@@ -2541,6 +2541,16 @@ void throttleGenerator(const char* text, const char *line, std::vector<std::stri
 		const char* opts[] = { "auto", nullptr };
 		arrayGenerator(text, line, opts, lc);
 	}
+	else if(tokens.size() >= 2 && tokencmp(tokens[1], "list")) {
+		if(tokens.size() == 2) {
+			const char* opts[] = { "throttled", "recommended", "all", nullptr };
+			arrayGenerator(text, line, opts, lc);
+		}
+		else if(tokens.size() == 3) {
+			const char* opts[] = {"LIMITS", nullptr};
+			arrayGenerator(text, line, opts, lc);
+		}
+	}
 }
 
 void fdbcliCompCmd(std::string const& text, std::vector<std::string>& lc) {
@@ -2660,6 +2670,9 @@ std::vector<const char*> throttleHintGenerator(std::vector<StringRef> const& tok
 	}
 	else if((tokencmp(tokens[1], "enable") || tokencmp(tokens[1], "disable")) && tokens.size() == 2) {
 		return { "auto" };
+	}
+	else if(tokens.size() == 2 && tokencmp(tokens[1], "list")) {
+        return {"[throttled|recommended|all]", "[LIMITS]"};
 	}
 	else if(tokens.size() == 2 && inArgument) {
 		return { "[ARGS]" };
@@ -4077,8 +4090,8 @@ ACTOR Future<int> cli(CLIOptions opt, LineNoise* plinenoise) {
 						continue;
 					}
 					else if(tokencmp(tokens[1], "list")) {
-						if(tokens.size() > 3) {
-							printf("Usage: throttle list [LIMIT]\n");
+						if(tokens.size() > 4) {
+							printf("Usage: throttle list [throttled|recommended|all] [LIMIT]\n");
 							printf("\n");
 							printf("Lists tags that are currently throttled.\n");
 							printf("The default LIMIT is 100 tags.\n");
@@ -4086,36 +4099,72 @@ ACTOR Future<int> cli(CLIOptions opt, LineNoise* plinenoise) {
 							continue;
 						}
 
-						state int throttleListLimit = 100;
+						state bool reportThrottled = true;
+						state bool reportRecommended = false;
 						if(tokens.size() >= 3) {
+							if(tokencmp(tokens[2], "recommended")) {
+								reportThrottled = false; reportRecommended = true;
+							}
+							else if(tokencmp(tokens[2], "all")){
+								reportThrottled = true; reportRecommended = true;
+							}
+							else if(!tokencmp(tokens[2], "throttled")){
+                                printf("ERROR: failed to parse `%s'.\n", printable(tokens[2]).c_str());
+                                is_error = true;
+                                continue;
+							}
+						}
+
+						state int throttleListLimit = 100;
+						if(tokens.size() >= 4) {
 							char *end;
 							throttleListLimit = std::strtol((const char*)tokens[2].begin(), &end, 10);
-							if ((tokens.size() > 3 && !std::isspace(*end)) || (tokens.size() == 3 && *end != '\0')) {
-								printf("ERROR: failed to parse limit `%s'.\n", printable(tokens[2]).c_str());
+							if ((tokens.size() > 4 && !std::isspace(*end)) || (tokens.size() == 3 && *end != '\0')) {
+								printf("ERROR: failed to parse limit `%s'.\n", printable(tokens[3]).c_str());
 								is_error = true;
 								continue;
 							}
 						}
 
-						std::vector<TagThrottleInfo> tags = wait(ThrottleApi::getThrottledTags(db, throttleListLimit));
+						state std::vector<TagThrottleInfo> tags; // = wait(ThrottleApi::getThrottledTags(db, throttleListLimit));
+						if(reportThrottled && reportRecommended) {
+							wait(store(tags, ThrottleApi::getThrottledTags(db, throttleListLimit, true)));
+						}
+						else if(reportThrottled) {
+                            wait(store(tags, ThrottleApi::getThrottledTags(db, throttleListLimit)));
+                        }
+						else if(reportRecommended) {
+                            wait(store(tags, ThrottleApi::getRecommendedTags(db, throttleListLimit)));
+                        }
 
 						bool anyLogged = false;
 						for(auto itr = tags.begin(); itr != tags.end(); ++itr) {
 							if(itr->expirationTime > now()) {
 								if(!anyLogged) {
 									printf("Throttled tags:\n\n");
-									printf("  Rate (txn/s) | Expiration (s) | Priority  | Type   | Tag\n");
-									printf(" --------------+----------------+-----------+--------+------------------\n");
+									printf("  Rate (txn/s) | Expiration (s) | Priority  | Type   | Reason     |Tag\n");
+									printf(" --------------+----------------+-----------+--------+------------+------\n");
 									
 									anyLogged = true;
 								}
 
-								printf("  %12d | %13ds | %9s | %6s | %s\n", 
-									(int)(itr->tpsRate), 
-									std::min((int)(itr->expirationTime-now()), (int)(itr->initialDuration)), 
-									transactionPriorityToString(itr->priority, false), 
-									itr->throttleType == TagThrottleType::AUTO ? "auto" : "manual", 
-									itr->tag.toString().c_str());
+								std::string reasonStr = "unset";
+								if(itr->reason == TagThrottledReason::MANUAL){
+									reasonStr = "manual";
+								}
+								else if(itr->reason == TagThrottledReason::BUSY_WRITE) {
+									reasonStr = "busy write";
+								}
+								else if(itr->reason == TagThrottledReason::BUSY_READ) {
+									reasonStr = "busy read";
+								}
+
+								printf("  %12d | %13ds | %9s | %6s | %10s |%s\n", (int)(itr->tpsRate),
+								       std::min((int)(itr->expirationTime - now()), (int)(itr->initialDuration)),
+								       transactionPriorityToString(itr->priority, false),
+								       itr->throttleType == TagThrottleType::AUTO ? "auto" : "manual",
+								       reasonStr.c_str(),
+								       itr->tag.toString().c_str());
 							}
 						}
 
@@ -4124,7 +4173,7 @@ ACTOR Future<int> cli(CLIOptions opt, LineNoise* plinenoise) {
 							printf("Usage: throttle list [LIMIT]\n");
 						}
 						if(!anyLogged) {
-							printf("There are no throttled tags\n");
+							printf("There are no %s tags\n", reportThrottled ? "throttled" : "recommended");
 						}
 					}
 					else if(tokencmp(tokens[1], "on")) {	

--- a/fdbcli/fdbcli.actor.cpp
+++ b/fdbcli/fdbcli.actor.cpp
@@ -2671,8 +2671,13 @@ std::vector<const char*> throttleHintGenerator(std::vector<StringRef> const& tok
 	else if((tokencmp(tokens[1], "enable") || tokencmp(tokens[1], "disable")) && tokens.size() == 2) {
 		return { "auto" };
 	}
-	else if(tokens.size() == 2 && tokencmp(tokens[1], "list")) {
-        return {"[throttled|recommended|all]", "[LIMITS]"};
+	else if(tokens.size() >= 2 && tokencmp(tokens[1], "list")) {
+		if(tokens.size() == 2) {
+			return { "[throttled|recommended|all]", "[LIMITS]" };
+		}
+		else if(tokens.size() == 3 && (tokencmp(tokens[2], "throttled") || tokencmp(tokens[2], "recommended") || tokencmp(tokens[2], "all"))){
+			return {"[LIMITS]"};
+		}
 	}
 	else if(tokens.size() == 2 && inArgument) {
 		return { "[ARGS]" };
@@ -4118,8 +4123,8 @@ ACTOR Future<int> cli(CLIOptions opt, LineNoise* plinenoise) {
 						state int throttleListLimit = 100;
 						if(tokens.size() >= 4) {
 							char *end;
-							throttleListLimit = std::strtol((const char*)tokens[2].begin(), &end, 10);
-							if ((tokens.size() > 4 && !std::isspace(*end)) || (tokens.size() == 3 && *end != '\0')) {
+							throttleListLimit = std::strtol((const char*)tokens[3].begin(), &end, 10);
+							if ((tokens.size() > 4 && !std::isspace(*end)) || (tokens.size() == 4 && *end != '\0')) {
 								printf("ERROR: failed to parse limit `%s'.\n", printable(tokens[3]).c_str());
 								is_error = true;
 								continue;

--- a/fdbcli/fdbcli.actor.cpp
+++ b/fdbcli/fdbcli.actor.cpp
@@ -4126,7 +4126,7 @@ ACTOR Future<int> cli(CLIOptions opt, LineNoise* plinenoise) {
 							}
 						}
 
-						state std::vector<TagThrottleInfo> tags; // = wait(ThrottleApi::getThrottledTags(db, throttleListLimit));
+						state std::vector<TagThrottleInfo> tags;
 						if(reportThrottled && reportRecommended) {
 							wait(store(tags, ThrottleApi::getThrottledTags(db, throttleListLimit, true)));
 						}

--- a/fdbclient/TagThrottle.actor.cpp
+++ b/fdbclient/TagThrottle.actor.cpp
@@ -223,9 +223,9 @@ namespace ThrottleApi {
 
 		ASSERT(initialDuration > 0);
 
-	    if(throttleType == TagThrottleType::MANUAL) {
-		    reason = TagThrottledReason::MANUAL;
-	    }
+		if(throttleType == TagThrottleType::MANUAL) {
+			reason = TagThrottledReason::MANUAL;
+		}
 		TagThrottleValue throttle(tpsRate, expirationTime.present() ? expirationTime.get() : 0, initialDuration,
 	                              reason.present() ? reason.get() : TagThrottledReason::UNSET);
 		BinaryWriter wr(IncludeVersion(ProtocolVersion::withTagThrottleValue()));

--- a/fdbclient/TagThrottle.actor.cpp
+++ b/fdbclient/TagThrottle.actor.cpp
@@ -216,7 +216,7 @@ namespace ThrottleApi {
 	}
 
 	ACTOR Future<Void> throttleTags(Database db, TagSet tags, double tpsRate, double initialDuration,
-                                    TagThrottleType throttleType, TransactionPriority priority, Optional<double> expirationTime = Optional<double>()) {
+                                    TagThrottleType throttleType, TransactionPriority priority, Optional<double> expirationTime) {
 		state Transaction tr(db);
 		state Key key = TagThrottleKey(tags, throttleType, priority).toKey();
 

--- a/fdbclient/TagThrottle.actor.cpp
+++ b/fdbclient/TagThrottle.actor.cpp
@@ -217,7 +217,7 @@ namespace ThrottleApi {
 
 	ACTOR Future<Void> throttleTags(Database db, TagSet tags, double tpsRate, double initialDuration,
                                     TagThrottleType throttleType, TransactionPriority priority, Optional<double> expirationTime,
-                                    Optional<uint8_t> reason) {
+                                    Optional<TagThrottledReason> reason) {
 		state Transaction tr(db);
 		state Key key = TagThrottleKey(tags, throttleType, priority).toKey();
 

--- a/fdbclient/TagThrottle.h
+++ b/fdbclient/TagThrottle.h
@@ -115,8 +115,11 @@ enum class TagThrottleType : uint8_t {
 	AUTO
 };
 
-struct TagThrottledReason {
-	static constexpr uint8_t UNSET = 0, MANUAL = 1, BUSY_READ = 2, BUSY_WRITE = 3;
+enum class TagThrottledReason: uint8_t {
+	UNSET = 0,
+	MANUAL,
+	BUSY_READ,
+	BUSY_WRITE
 };
 
 struct TagThrottleKey {
@@ -136,10 +139,10 @@ struct TagThrottleValue {
 	double tpsRate;
 	double expirationTime;
 	double initialDuration;
-	uint8_t reason;
+	TagThrottledReason reason;
 
 	TagThrottleValue() : tpsRate(0), expirationTime(0), initialDuration(0), reason(TagThrottledReason::UNSET) {}
-	TagThrottleValue(double tpsRate, double expirationTime, double initialDuration, uint8_t reason)
+	TagThrottleValue(double tpsRate, double expirationTime, double initialDuration, TagThrottledReason reason)
 		: tpsRate(tpsRate), expirationTime(expirationTime), initialDuration(initialDuration), reason(reason) {}
 
 	static TagThrottleValue fromValue(const ValueRef& value);
@@ -147,7 +150,8 @@ struct TagThrottleValue {
 	//To change this serialization, ProtocolVersion::TagThrottleValue must be updated, and downgrades need to be considered
 	template<class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, tpsRate, expirationTime, initialDuration, reason);
+		uint8_t* reasonPtr = (uint8_t*)&reason;
+		serializer(ar, tpsRate, expirationTime, initialDuration, *reasonPtr);
 	}
 };
 
@@ -158,9 +162,9 @@ struct TagThrottleInfo {
 	double tpsRate;
 	double expirationTime;
 	double initialDuration;
-	uint8_t reason;
+	TagThrottledReason reason;
 
-	TagThrottleInfo(TransactionTag tag, TagThrottleType throttleType, TransactionPriority priority, double tpsRate, double expirationTime, double initialDuration, uint8_t reason = TagThrottledReason::UNSET)
+	TagThrottleInfo(TransactionTag tag, TagThrottleType throttleType, TransactionPriority priority, double tpsRate, double expirationTime, double initialDuration, TagThrottledReason reason = TagThrottledReason::UNSET)
 		: tag(tag), throttleType(throttleType), priority(priority), tpsRate(tpsRate), expirationTime(expirationTime), initialDuration(initialDuration), reason(reason) {}
 
 	TagThrottleInfo(TagThrottleKey key, TagThrottleValue value)
@@ -177,7 +181,7 @@ namespace ThrottleApi {
 
 	Future<Void> throttleTags(Database const& db, TagSet const& tags, double const& tpsRate, double const& initialDuration, 
 	                         TagThrottleType const& throttleType, TransactionPriority const& priority, Optional<double> const& expirationTime = Optional<double>(),
-                              Optional<uint8_t> const& reason = Optional<uint8_t>());
+                              Optional<TagThrottledReason> const& reason = Optional<TagThrottledReason>());
 
 	Future<bool> unthrottleTags(Database const& db, TagSet const& tags, Optional<TagThrottleType> const& throttleType, Optional<TransactionPriority> const& priority);
 

--- a/fdbclient/TagThrottle.h
+++ b/fdbclient/TagThrottle.h
@@ -167,6 +167,7 @@ struct TagThrottleInfo {
 
 namespace ThrottleApi {
 	Future<std::vector<TagThrottleInfo>> getThrottledTags(Database const& db, int const& limit);
+	Future<std::vector<TagThrottleInfo>> getRecommendedTags(Database const& db, int limit);
 
 	Future<Void> throttleTags(Database const& db, TagSet const& tags, double const& tpsRate, double const& initialDuration, 
 	                         TagThrottleType const& throttleType, TransactionPriority const& priority, Optional<double> const& expirationTime = Optional<double>());

--- a/fdbclient/TagThrottle.h
+++ b/fdbclient/TagThrottle.h
@@ -150,8 +150,15 @@ struct TagThrottleValue {
 	//To change this serialization, ProtocolVersion::TagThrottleValue must be updated, and downgrades need to be considered
 	template<class Ar>
 	void serialize(Ar& ar) {
-		uint8_t* reasonPtr = (uint8_t*)&reason;
-		serializer(ar, tpsRate, expirationTime, initialDuration, *reasonPtr);
+		if(ar.protocolVersion().hasTagThrottleValueReason()) {
+			serializer(ar, tpsRate, expirationTime, initialDuration, reinterpret_cast<uint8_t&>(reason));
+		}
+		else if(ar.protocolVersion().hasTagThrottleValue()) {
+			serializer(ar, tpsRate, expirationTime, initialDuration);
+			if(ar.isDeserializing) {
+			    reason = TagThrottledReason::UNSET;
+			}
+		}
 	}
 };
 

--- a/fdbclient/TagThrottle.h
+++ b/fdbclient/TagThrottle.h
@@ -166,7 +166,7 @@ struct TagThrottleInfo {
 };
 
 namespace ThrottleApi {
-	Future<std::vector<TagThrottleInfo>> getThrottledTags(Database const& db, int const& limit);
+	Future<std::vector<TagThrottleInfo>> getThrottledTags(Database const& db, int const& limit, bool const& containsRecommend = false);
 	Future<std::vector<TagThrottleInfo>> getRecommendedTags(Database const& db, int limit);
 
 	Future<Void> throttleTags(Database const& db, TagSet const& tags, double const& tpsRate, double const& initialDuration, 

--- a/fdbserver/Ratekeeper.actor.cpp
+++ b/fdbserver/Ratekeeper.actor.cpp
@@ -1213,8 +1213,8 @@ void updateRate(RatekeeperData* self, RatekeeperLimits* limits) {
 			.detail("WorstStorageServerDurabilityLag", worstDurabilityLag)
 			.detail("LimitingStorageServerDurabilityLag", limitingDurabilityLag)
 			.detail("TagsAutoThrottled", self->throttledTags.autoThrottleCount())
-		    .detail("TagsAutoThrottledBusyRead", self->throttledTags.busyReadTagCount)
-		    .detail("TagsAutoThrottledBusyWrite", self->throttledTags.busyWriteTagCount)
+			.detail("TagsAutoThrottledBusyRead", self->throttledTags.busyReadTagCount)
+			.detail("TagsAutoThrottledBusyWrite", self->throttledTags.busyWriteTagCount)
 			.detail("TagsManuallyThrottled", self->throttledTags.manualThrottleCount())
 			.detail("AutoThrottlingEnabled", self->autoThrottlingEnabled)
 			.trackLatest(name);

--- a/fdbserver/Status.actor.cpp
+++ b/fdbserver/Status.actor.cpp
@@ -1784,22 +1784,22 @@ ACTOR static Future<JsonBuilderObject> workloadStatusFetcher(Reference<AsyncVar<
 		JsonBuilderObject throttledTagsObj;
 		JsonBuilderObject autoThrottledTagsObj, recommendThrottleTagsObj;
 		if(autoThrottlingEnabled) {
-            autoThrottledTagsObj["count"] = autoThrottledTags;
+			autoThrottledTagsObj["count"] = autoThrottledTags;
 			autoThrottledTagsObj["busy_read"] = autoThrottledTagsBusyRead;
 			autoThrottledTagsObj["busy_write"] = autoThrottledTagsBusyWrite;
 
-            recommendThrottleTagsObj["count"] = 0;
+			recommendThrottleTagsObj["count"] = 0;
 			recommendThrottleTagsObj["busy_read"] = 0;
 			recommendThrottleTagsObj["busy_write"] = 0;
 		}
 		else {
-            recommendThrottleTagsObj["count"] = autoThrottledTags;
-            recommendThrottleTagsObj["busy_read"] = autoThrottledTagsBusyRead;
-            recommendThrottleTagsObj["busy_write"] = autoThrottledTagsBusyWrite;
+			recommendThrottleTagsObj["count"] = autoThrottledTags;
+			recommendThrottleTagsObj["busy_read"] = autoThrottledTagsBusyRead;
+			recommendThrottleTagsObj["busy_write"] = autoThrottledTagsBusyWrite;
 
-            autoThrottledTagsObj["count"] = 0;
-            autoThrottledTagsObj["busy_read"] = 0;
-            autoThrottledTagsObj["busy_write"] = 0;
+			autoThrottledTagsObj["count"] = 0;
+			autoThrottledTagsObj["busy_read"] = 0;
+			autoThrottledTagsObj["busy_write"] = 0;
 		}
 
 		throttledTagsObj["auto"] = autoThrottledTagsObj;

--- a/fdbserver/Status.actor.cpp
+++ b/fdbserver/Status.actor.cpp
@@ -1751,6 +1751,8 @@ ACTOR static Future<JsonBuilderObject> workloadStatusFetcher(Reference<AsyncVar<
 		double transPerSec = ratekeeper.getDouble("ReleasedTPS");
 		double batchTransPerSec = ratekeeper.getDouble("ReleasedBatchTPS");
 		int autoThrottledTags = ratekeeper.getInt("TagsAutoThrottled");
+		int autoThrottledTagsBusyRead = ratekeeper.getInt("TagsAutoThrottledBusyRead");
+		int autoThrottledTagsBusyWrite = ratekeeper.getInt("TagsAutoThrottledBusyWrite");
 		int manualThrottledTags = ratekeeper.getInt("TagsManuallyThrottled");
 		int ssCount = ratekeeper.getInt("StorageServers");
 		int tlogCount = ratekeeper.getInt("TLogs");
@@ -1781,8 +1783,25 @@ ACTOR static Future<JsonBuilderObject> workloadStatusFetcher(Reference<AsyncVar<
 
 		JsonBuilderObject throttledTagsObj;
 		JsonBuilderObject autoThrottledTagsObj, recommendThrottleTagsObj;
-		autoThrottledTagsObj["count"] = autoThrottlingEnabled ? autoThrottledTags : 0;
-		recommendThrottleTagsObj["count"] = autoThrottlingEnabled ? 0 : autoThrottlingEnabled;
+		if(autoThrottlingEnabled) {
+            autoThrottledTagsObj["count"] = autoThrottledTags;
+			autoThrottledTagsObj["busy_read"] = autoThrottledTagsBusyRead;
+			autoThrottledTagsObj["busy_write"] = autoThrottledTagsBusyWrite;
+
+            recommendThrottleTagsObj["count"] = 0;
+			recommendThrottleTagsObj["busy_read"] = 0;
+			recommendThrottleTagsObj["busy_write"] = 0;
+		}
+		else {
+            recommendThrottleTagsObj["count"] = autoThrottledTags;
+            recommendThrottleTagsObj["busy_read"] = autoThrottledTagsBusyRead;
+            recommendThrottleTagsObj["busy_write"] = autoThrottledTagsBusyWrite;
+
+            autoThrottledTagsObj["count"] = 0;
+            autoThrottledTagsObj["busy_read"] = 0;
+            autoThrottledTagsObj["busy_write"] = 0;
+		}
+
 		throttledTagsObj["auto"] = autoThrottledTagsObj;
 		throttledTagsObj["recommend"] = recommendThrottleTagsObj;
 

--- a/flow/ProtocolVersion.h
+++ b/flow/ProtocolVersion.h
@@ -128,6 +128,7 @@ public: // introduced features
 	PROTOCOL_VERSION_FEATURE(0x0FDB00B063010000LL, ReportConflictingKeys);
 	PROTOCOL_VERSION_FEATURE(0x0FDB00B063010000LL, SmallEndpoints);
 	PROTOCOL_VERSION_FEATURE(0x0FDB00B063010000LL, CacheRole);
+	PROTOCOL_VERSION_FEATURE(0x0FDB00B070010001LL, TagThrottleValueReason);
 };
 
 // These impact both communications and the deserialization of certain database and IKeyValueStore keys.


### PR DESCRIPTION
* add command line support: `throttle list [throttled|recommended|all]`
* add status json support for recommended tags
```JSON
        "throttled_tags" : {
                "auto" : {
                    "busy_read" : 0,
                    "busy_write" : 0,
                    "count" : 0
                },
                "manual" : {
                    "count" : 1
                },
                "recommend" : {
                    "busy_read" : 0,
                    "busy_write" : 0,
                    "count" : 0
                }
            },
```
* Let `enableAutoThrottle` take effects. Stop all auto-throttled tags once `enableAutoThrottled` is set to false.