### PR TITLE
Replace calls to deprecated methods

### DIFF
--- a/bindings/java/src/main/com/apple/foundationdb/tuple/FastByteComparisons.java
+++ b/bindings/java/src/main/com/apple/foundationdb/tuple/FastByteComparisons.java
@@ -205,7 +205,18 @@ abstract class FastByteComparisons {
                         (PrivilegedAction<Object>) () -> {
                             try {
                                 Field f = Unsafe.class.getDeclaredField("theUnsafe");
-                                f.setAccessible(true);
+                                String javaVersion = System.getProperty("java.version");
+                                int version = Integer.parseInt(javaVersion);
+                                if(version < 13) {
+                                    if(!f.isAccessible()) {
+                                        f.setAccessible(true);
+                                    }
+                                } else {
+                                    Unsafe testInstance = (Unsafe) f.get(null);
+                                    if(!f.canAccess(testInstance)) {
+                                        f.setAccessible(true);
+                                    }
+                                }
                                 return f.get(null);
                             } catch (NoSuchFieldException e) {
                                 // It doesn't matter what we throw;

--- a/bindings/java/src/test/com/apple/foundationdb/test/TupleTest.java
+++ b/bindings/java/src/test/com/apple/foundationdb/test/TupleTest.java
@@ -228,8 +228,17 @@ public class TupleTest {
 				// the reflection.
 				Field f = Tuple.class.getDeclaredField("memoizedPackedSize");
 				AccessController.doPrivileged((PrivilegedExceptionAction<Void>) () -> {
-					if(!f.isAccessible()) {
-						f.setAccessible(true);
+					String javaVersion = System.getProperty("java.version");
+					int version = Integer.parseInt(javaVersion);
+					if(version < 13) {
+					    if(!f.isAccessible()) {
+                            f.setAccessible(true);
+                        }
+					} else {
+					    Tuple testInstance = new Tuple();
+					    if(!f.canAccess(testInstance)) {
+                            f.setAccessible(true);
+                        }
 					}
 					f.setInt(t, 2 + s.getBytes("UTF-8").length);
 					return null;


### PR DESCRIPTION
This pull request (PR) resolves [issue 3190](https://github.com/apple/foundationdb/issues/3190).  It replaces calls to deprecated methods for Java 13 and keeps backwards compatibility for Java 12 callers.

A note on this pattern, a Java compiler diagnostic warning will be emitted from Java 12: 

```
[  0%] Built target actorcompiler
[  1%] Built target vexillographer
[  2%] Check old build system wasn't used in source dir
[  3%] Check old build system wasn't used in source dir
[  3%] Built target boostProject
[  3%] Built target coveragetool
[  3%] Built target branch_file
[  3%] Built target toml11
[  4%] Built target thirdparty
[  4%] Built target fdbrpc_actors_versions_h_check
[  4%] Built target flow_actors_versions_h_check
[  4%] Check old build system wasn't used in source dir
[  4%] Check old build system wasn't used in source dir
[  5%] Check old build system wasn't used in source dir
[  5%] Check old build system wasn't used in source dir
[  5%] Built target coverage_fdbcli
[  5%] Built target fdb_sqlite
[  5%] Check old build system wasn't used in source dir
[  5%] Built target fdbclient_actors_versions_h_check
[  5%] Built target fdbserver_actors_versions_h_check
[  5%] Built target fdbmonitor_versions_h_check
[  5%] Built target fdbcli_actors_versions_h_check
[  5%] Built target coverage_fdbbackup
[  5%] Check old build system wasn't used in source dir
[  5%] Built target fdbbackup_actors_versions_h_check
[  5%] Built target coverage_fdbdecode
[  5%] Check old build system wasn't used in source dir
[  5%] Built target fdbdecode_actors_versions_h_check
[  5%] Built target coverage_fdbconvert
[  5%] Built target fdb_c_generated
[  5%] Built target TraceLogHelper
[  5%] Built target fdb_c_options
[  5%] Built target actor_flamegraph
[  5%] Built target fdbconvert_actors_versions_h_check
[  5%] Built target exported_symbols_list
[  7%] Built target copy_go_sources
[  7%] Built target coverage_fdb_flow_tester
[  8%] Built target coverage_fdb_flow
[  8%] Check old build system wasn't used in source dir
[  8%] Check old build system wasn't used in source dir
[  8%] Built target fdb_python_options
[  8%] Built target copy_license
[  8%] Built target fdb_java_options
[  8%] Built target ruby_options
[  8%] Built target coverage_tutorial
[  8%] Built target fdb_flow_tester_actors_versions_h_check
[  8%] Built target fdb_flow_actors_versions_h_check
[  8%] Check old build system wasn't used in source dir
[  8%] Built target coverage_flow
[  9%] Built target flow_actors
[ 10%] Built target fdboptions
[ 11%] Built target coverage_fdbrpc
[ 12%] Built target fdbrpc_actors
[ 12%] Built target coverage_fdbclient
[ 12%] Built target tutorial_actors_versions_h_check
[ 14%] Built target fdbclient_actors
[ 14%] Built target coverage_fdbserver
[ 14%] Built target fdbdecode_actors
[ 14%] Built target fdbmonitor
[ 14%] Built target fdbcli_actors
[ 14%] Built target fdbbackup_actors
[ 30%] Built target fdbconvert_actors
[ 30%] Built target fdbserver_actors
[ 30%] Built target TestHarness
[ 30%] Built target go_options_file
[ 30%] Built target fdb_flow_actors
[ 30%] Built target tutorial_actors
[ 31%] Built target python_binding
[ 31%] Built target fdb_flow_tester_actors
[ 31%] Built target strip_only_fdbmonitor
[ 31%] Built target prepare_fdbmonitor_install
[ 36%] Built target flow
[ 40%] Built target fdbrpc
[ 46%] Built target fdbclient
[ 46%] Built target fdb_c
[ 47%] Built target tutorial
[ 47%] Built target fdbconvert
[ 47%] Built target fdbdecode
[ 48%] Built target fdbbackup
[ 48%] Built target strip_only_fdb_c
[ 49%] Built target fdb_go
[ 49%] Built target c_workloads
[ 49%] Built target fdb_java
[ 50%] Built target fdb_c_performance_test
[ 50%] Built target fdbcli
[ 50%] Built target fdb_c_ryw_benchmark
[ 50%] Built target fdb_c_txn_size_test
[ 50%] Built target mako
[ 51%] Built target strip_only_fdbbackup
[ 51%] Building Java objects for fdb-java.jar
[ 51%] Built target tuple_go
[ 52%] Built target strip_only_fdbcli
[ 53%] Built target java_workloads
[ 53%] Built target prepare_fdbbackup_install
[ 53%] Built target directory_go
[ 53%] Built target subspace_go
[ 53%] Built target prepare_fdbcli_install
[ 53%] Built target fdb_go_tester
[ 54%] Built target fdb_flow
[ 54%] Built target fdb_flow_tester
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
1 warning
[ 54%] Generating CMakeFiles/fdb-java.dir/java_class_filelist
[ 54%] Creating Java archive fdb-java-7.0.0.jar
[ 54%] Built target fdb-java
[ 54%] Building Java objects for foundationdb-tests.jar
[ 54%] Unpack jar-file
[ 54%] Built target unpack_jar
[ 54%] Built target copy_lib
[ 54%] Built target fat-jar
Note: src/test/com/apple/foundationdb/test/TupleTest.java uses or overrides a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
1 warning
[ 54%] Generating CMakeFiles/foundationdb-tests.dir/java_class_filelist
[ 54%] Creating Java archive foundationdb-tests.jar
[ 54%] Built target foundationdb-tests
Copy Flow tester for bindingtester
[ 54%] Built target fdb-java-tests
Copy Java bindings for bindingtester
Copy generated.go for bindingtester
Copy python/fdb/fdboptions.py to bindingtester
Copy java/foundationdb-tests.jar to bindingtester
[ 54%] Built target copy_binding_output_files
[ 85%] Built target fdbserver
[ 85%] Built target strip_only_fdbserver
[ 85%] Built target prepare_fdbserver_install
[ 86%] Built target copy_bindingtester_binaries
[100%] Built target package_tests
[100%] Built target bindingtester

Build finished
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apple/foundationdb/3684)
<!-- Reviewable:end -->
