### PR TITLE
Log a trace event on process termination

### DIFF
--- a/bindings/flow/tester/Tester.actor.cpp
+++ b/bindings/flow/tester/Tester.actor.cpp
@@ -1856,7 +1856,7 @@ ACTOR void _test_versionstamp() {
 int main( int argc, char** argv ) {
 	try {
 		platformInit();
-		registerCrashHandler();
+		registerSignalHandler();
 		setThreadLocalDeterministicRandomSeed(1);
 
 		// Get arguments

--- a/fdbbackup/backup.actor.cpp
+++ b/fdbbackup/backup.actor.cpp
@@ -2696,7 +2696,7 @@ int main(int argc, char* argv[]) {
 #ifdef ALLOC_INSTRUMENTATION
 		g_extra_memory = new uint8_t[1000000];
 #endif
-		registerCrashHandler();
+		registerSignalHandler();
 
 		// Set default of line buffering standard out and error
 		setvbuf(stdout, NULL, _IONBF, 0);

--- a/fdbcli/fdbcli.actor.cpp
+++ b/fdbcli/fdbcli.actor.cpp
@@ -4392,9 +4392,10 @@ int main(int argc, char **argv) {
 	uint64_t memLimit = 8LL << 30;
 	setMemoryQuota( memLimit );
 
-	registerCrashHandler();
+	registerSignalHandler();
 
 #ifdef __unixish__
+	// Replaces SIGINT handler from registerSignalHandler
 	struct sigaction act;
 
 	// We don't want ctrl-c to quit

--- a/fdbrpc/FlowTests.actor.cpp
+++ b/fdbrpc/FlowTests.actor.cpp
@@ -237,6 +237,7 @@ struct YieldMockNetwork : INetwork, ReferenceCounted<YieldMockNetwork> {
 	virtual double now() { return baseNetwork->now(); }
 	virtual double timer() { return baseNetwork->timer(); }
 	virtual void stop() { return baseNetwork->stop(); }
+	virtual void signalStop(int signal) { baseNetwork->signalStop(signal); }
 	virtual void addStopCallback( std::function<void()> fn ) { ASSERT(false); return; }
 	virtual bool isSimulated() const { return baseNetwork->isSimulated(); }
 	virtual void onMainThread(Promise<Void>&& signal, TaskPriority taskID) { return baseNetwork->onMainThread(std::move(signal), taskID); }

--- a/fdbrpc/sim2.actor.cpp
+++ b/fdbrpc/sim2.actor.cpp
@@ -869,6 +869,9 @@ public:
 	virtual void stop() {
 		isStopped = true;
 	}
+	virtual void signalStop(int signal) {
+		stop();
+	}
 	virtual void addStopCallback( std::function<void()> fn ) {
 		stopCallbacks.emplace_back(std::move(fn));
 	}

--- a/fdbserver/fdbserver.actor.cpp
+++ b/fdbserver/fdbserver.actor.cpp
@@ -1523,7 +1523,7 @@ int main(int argc, char* argv[]) {
 #ifdef ALLOC_INSTRUMENTATION
 		g_extra_memory = new uint8_t[1000000];
 #endif
-		registerCrashHandler();
+		registerSignalHandler();
 
 		// Set default of line buffering standard out and error
 		setvbuf(stdout, NULL, _IOLBF, BUFSIZ);

--- a/fdbserver/fdbserver.actor.cpp
+++ b/fdbserver/fdbserver.actor.cpp
@@ -1937,13 +1937,16 @@ int main(int argc, char* argv[]) {
 			rc = FDB_EXIT_ERROR;
 		}
 
-		int unseed = noUnseed ? 0 : deterministicRandom()->randomInt(0, 100001);
-		TraceEvent("ElapsedTime").detail("SimTime", now()-startNow).detail("RealTime", timer()-start)
-			.detail("RandomUnseed", unseed);
-
 		if (role==Simulation){
+			int unseed = noUnseed ? 0 : deterministicRandom()->randomInt(0, 100001);
+			TraceEvent("ElapsedTime").detail("SimTime", now()-startNow).detail("RealTime", timer()-start)
+				.detail("RandomUnseed", unseed);
+
 			printf("Unseed: %d\n", unseed);
 			printf("Elapsed: %f simsec, %f real seconds\n", now()-startNow, timer()-start);
+		}
+		else {
+			TraceEvent("ProcessTerminated");
 		}
 
 		//IFailureMonitor::failureMonitor().address_info.clear();

--- a/flow/Platform.cpp
+++ b/flow/Platform.cpp
@@ -3173,12 +3173,7 @@ void platformInit() {
 
 void terminationHandler(int sig) {
 #ifdef __linux__
-	TraceEvent(SevInfo, "ProcessTerminated")
-		.detail("Signal", sig)
-		.detail("Name", strsignal(sig));
-
-	flushTraceFileVoid();
-	_exit(sig + 128);
+	g_network->stop();
 #else
 	// No termination handler for other platforms!
 #endif

--- a/flow/Platform.cpp
+++ b/flow/Platform.cpp
@@ -3190,7 +3190,7 @@ void crashHandler(int sig) {
 	//  but the idea is that we're about to crash anyway...
 	std::string backtrace = platform::get_backtrace();
 
-	bool error = (sig != SIGUSR2 || sig != SIGQUIT);
+	bool error = (sig != SIGUSR2 && sig != SIGQUIT);
 
 	fflush(stdout);
 	TraceEvent(error ? SevError : SevInfo, error ? "Crash" : "ProcessTerminated")

--- a/flow/Platform.h
+++ b/flow/Platform.h
@@ -648,7 +648,7 @@ EXTERNC void flushAndExit(int exitCode);
 // Initilization code that's run at the beginning of every entry point (except fdbmonitor)
 void platformInit();
 
-void registerCrashHandler();
+void registerSignalHandler();
 void setupRunLoopProfiler();
 EXTERNC void setProfilingEnabled(int enabled);
 

--- a/flow/network.h
+++ b/flow/network.h
@@ -482,6 +482,9 @@ public:
 	virtual void stop() = 0;
 	// Terminate the program
 
+	virtual void signalStop(int signal) = 0;
+	// Terminate the program in a signal handler
+
 	virtual void addStopCallback( std::function<void()> fn ) = 0;
 	// Calls `fn` when stop() is called.
 	// addStopCallback can be called more than once, and each added `fn` will be run once.


### PR DESCRIPTION
This also adds SIGQUIT to the crash handler.

I haven't yet carefully looked at how signal-safe this is. We do something similar in the crash handler (in addition to other things), but in that case we deemed it acceptable because we were already crashing.