### PR TITLE
report busiest write tag of each storage server

### DIFF
--- a/fdbclient/Schemas.cpp
+++ b/fdbclient/Schemas.cpp
@@ -354,7 +354,7 @@ const KeyRef JSONSchemas::statusSchema = LiteralStringRef(R"statusSchema(
                 "busy_read" : 0,
                 "busy_write" : 0,
                 "count" : 0,
-                "is_recommended": 0
+                "recommended_only": 0
             },
             "manual" : {
                 "count" : 0

--- a/fdbclient/Schemas.cpp
+++ b/fdbclient/Schemas.cpp
@@ -353,14 +353,10 @@ const KeyRef JSONSchemas::statusSchema = LiteralStringRef(R"statusSchema(
             "auto" : {
                 "busy_read" : 0,
                 "busy_write" : 0,
-                "count" : 0
+                "count" : 0,
+                "is_recommended": 0
             },
             "manual" : {
-                "count" : 0
-            },
-            "recommend" : {
-                "busy_read" : 0,
-                "busy_write" : 0,
                 "count" : 0
             }
          },

--- a/fdbclient/Schemas.cpp
+++ b/fdbclient/Schemas.cpp
@@ -191,6 +191,13 @@ const KeyRef JSONSchemas::statusSchema = LiteralStringRef(R"statusSchema(
                      "estimated_cost":{
                         "hz": 0.0
                      }
+                  },
+                  "busiest_write_tag":{
+                     "tag": "",
+                     "fractional_cost": 0.0,
+                     "estimated_cost":{
+                        "hz": 0.0
+                     }
                   }
                }
             ],

--- a/fdbserver/Ratekeeper.actor.cpp
+++ b/fdbserver/Ratekeeper.actor.cpp
@@ -887,14 +887,13 @@ Future<Void> refreshStorageServerCommitCost(RatekeeperData* self) {
 		}
 
 		TraceEvent("BusiestWriteTag", it->key)
-		    .detail("Elapsed", elapsed)
-		    .detail("Tag", printable(busiestTag))
-		    .detail("TagOps", maxCost.getOpsSum())
-		    .detail("TagCosts", maxCost.getCostSum())
-		    .detail("TagRate", maxRate)
-		    .detail("TagBusyness", maxBusyness)
-		    .detail("Reported", it->value.busiestWriteTag.present())
-		    .trackLatest(it->key.toString() + "/BusiestWriteTag");
+			.detail("Elapsed", elapsed)
+			.detail("Tag", printable(busiestTag))
+			.detail("TagOps", maxCost.getOpsSum())
+			.detail("TagCost", maxCost.getCostSum())
+			.detail("TotalCost", it->value.totalWriteCosts)
+			.detail("Reported", it->value.busiestWriteTag.present())
+			.trackLatest(it->key.toString() + "/BusiestWriteTag");
 
 		// reset statistics
 		it->value.tagCostEst.clear();

--- a/fdbserver/Status.actor.cpp
+++ b/fdbserver/Status.actor.cpp
@@ -1632,7 +1632,7 @@ static Future<vector<std::pair<iface, EventMap>>> getServerMetrics(vector<iface>
 ACTOR template <class iface>
 static Future<vector<TraceEventFields>> getServerBusiestWriteTags(vector<iface> servers, std::unordered_map<NetworkAddress, WorkerInterface> address_workers, WorkerDetails rkWorker) {
     state vector<Future<Optional<TraceEventFields>>> futures;
-    for (auto s : servers) {
+    for (const auto& s : servers) {
 		futures.push_back(latestEventOnWorker(rkWorker.interf, s.id().toString() + "/BusiestWriteTag"));
     }
     wait(waitForAll(futures));
@@ -1876,10 +1876,10 @@ ACTOR static Future<JsonBuilderObject> workloadStatusFetcher(Reference<AsyncVar<
 		autoThrottledTagsObj["busy_read"] = autoThrottledTagsBusyRead;
 		autoThrottledTagsObj["busy_write"] = autoThrottledTagsBusyWrite;
 		if(autoThrottlingEnabled) {
-			autoThrottledTagsObj["is_recommended"] = 0;
+			autoThrottledTagsObj["recommended_only"] = 0;
 		}
 		else {
-			autoThrottledTagsObj["is_recommended"] = 1;
+			autoThrottledTagsObj["recommended_only"] = 1;
 		}
 
 		throttledTagsObj["auto"] = autoThrottledTagsObj;

--- a/fdbserver/Status.actor.cpp
+++ b/fdbserver/Status.actor.cpp
@@ -512,29 +512,29 @@ struct RolesInfo {
 				}
 			}
 
-            TraceEventFields const& busiestWriteTag = metrics.at("BusiestWriteTag");
-            if(busiestWriteTag.size()) {
-                int64_t tagCost = busiestWriteTag.getInt64("TagCost");
+			TraceEventFields const& busiestWriteTag = metrics.at("BusiestWriteTag");
+			if(busiestWriteTag.size()) {
+				int64_t tagCost = busiestWriteTag.getInt64("TagCost");
 
-                if(tagCost > 0) {
-                    JsonBuilderObject busiestWriteTagObj;
+				if(tagCost > 0) {
+				    JsonBuilderObject busiestWriteTagObj;
 
-                    int64_t totalCost = busiestWriteTag.getInt64("TotalCost");
-                    ASSERT(totalCost > 0);
+				    int64_t totalCost = busiestWriteTag.getInt64("TotalCost");
+				    ASSERT(totalCost > 0);
 
-                    busiestWriteTagObj["tag"] = busiestWriteTag.getValue("Tag");
-                    busiestWriteTagObj["fractional_cost"] = (double)tagCost / totalCost;
+				    busiestWriteTagObj["tag"] = busiestWriteTag.getValue("Tag");
+				    busiestWriteTagObj["fractional_cost"] = (double)tagCost / totalCost;
 
-                    double elapsed = busiestWriteTag.getDouble("Elapsed");
-                    if(elapsed > 0) {
-                        JsonBuilderObject estimatedCostObj;
-                        estimatedCostObj["hz"] = tagCost / elapsed;
-                        busiestWriteTagObj["estimated_cost"] = estimatedCostObj;
-                    }
+				    double elapsed = busiestWriteTag.getDouble("Elapsed");
+				    if(elapsed > 0) {
+					JsonBuilderObject estimatedCostObj;
+					estimatedCostObj["hz"] = tagCost / elapsed;
+					busiestWriteTagObj["estimated_cost"] = estimatedCostObj;
+				    }
 
-                    obj["busiest_write_tag"] = busiestWriteTagObj;
-                }
-            }
+				    obj["busiest_write_tag"] = busiestWriteTagObj;
+				}
+			}
 		} catch (Error& e) {
 			if(e.code() != error_code_attribute_not_found)
 				throw e;

--- a/fdbserver/Status.actor.cpp
+++ b/fdbserver/Status.actor.cpp
@@ -1871,28 +1871,18 @@ ACTOR static Future<JsonBuilderObject> workloadStatusFetcher(Reference<AsyncVar<
 		(*qos)["batch_released_transactions_per_second"] = batchTransPerSec;
 
 		JsonBuilderObject throttledTagsObj;
-		JsonBuilderObject autoThrottledTagsObj, recommendThrottleTagsObj;
+		JsonBuilderObject autoThrottledTagsObj;
+		autoThrottledTagsObj["count"] = autoThrottledTags;
+		autoThrottledTagsObj["busy_read"] = autoThrottledTagsBusyRead;
+		autoThrottledTagsObj["busy_write"] = autoThrottledTagsBusyWrite;
 		if(autoThrottlingEnabled) {
-			autoThrottledTagsObj["count"] = autoThrottledTags;
-			autoThrottledTagsObj["busy_read"] = autoThrottledTagsBusyRead;
-			autoThrottledTagsObj["busy_write"] = autoThrottledTagsBusyWrite;
-
-			recommendThrottleTagsObj["count"] = 0;
-			recommendThrottleTagsObj["busy_read"] = 0;
-			recommendThrottleTagsObj["busy_write"] = 0;
+			autoThrottledTagsObj["is_recommended"] = 0;
 		}
 		else {
-			recommendThrottleTagsObj["count"] = autoThrottledTags;
-			recommendThrottleTagsObj["busy_read"] = autoThrottledTagsBusyRead;
-			recommendThrottleTagsObj["busy_write"] = autoThrottledTagsBusyWrite;
-
-			autoThrottledTagsObj["count"] = 0;
-			autoThrottledTagsObj["busy_read"] = 0;
-			autoThrottledTagsObj["busy_write"] = 0;
+			autoThrottledTagsObj["is_recommended"] = 1;
 		}
 
 		throttledTagsObj["auto"] = autoThrottledTagsObj;
-		throttledTagsObj["recommend"] = recommendThrottleTagsObj;
 
 		JsonBuilderObject manualThrottledTagsObj;
 		manualThrottledTagsObj["count"] = manualThrottledTags;

--- a/fdbserver/workloads/TagThrottleApi.actor.cpp
+++ b/fdbserver/workloads/TagThrottleApi.actor.cpp
@@ -45,19 +45,19 @@ struct TagThrottleApiWorkload : TestWorkload {
 	}
 
 	virtual Future<Void> start(Database const& cx) {
-        // choose a version to check compatibility.
-        double choice = deterministicRandom()->random01();
-        if(choice < 0.3) {
-            apiVersion = 630;
-        }
-        else if(choice < 0.7){
-            apiVersion = 700;
-        }
-        else {
-            apiVersion = Database::API_VERSION_LATEST;
-        }
-        TraceEvent("VersionStampApiVersion").detail("ApiVersion", apiVersion);
-        cx->apiVersion = apiVersion;
+		// choose a version to check compatibility.
+		double choice = deterministicRandom()->random01();
+		if(choice < 0.3) {
+			apiVersion = 630;
+		}
+		else if(choice < 0.7){
+			apiVersion = 700;
+		}
+		else {
+			apiVersion = Database::API_VERSION_LATEST;
+		}
+		TraceEvent("VersionStampApiVersion").detail("ApiVersion", apiVersion);
+		cx->apiVersion = apiVersion;
 
 		if (this->clientId != 0) return Void();
 		return timeout(runThrottleApi(this, cx), testDuration, Void());

--- a/fdbserver/workloads/TagThrottleApi.actor.cpp
+++ b/fdbserver/workloads/TagThrottleApi.actor.cpp
@@ -165,9 +165,9 @@ struct TagThrottleApiWorkload : TestWorkload {
 				++activeAutoThrottledTags;
 			}
 
-            if(self->apiVersion == 630) {
-                ASSERT(tag.reason == TagThrottledReason::UNSET);
-            }
+			if(self->apiVersion == 630) {
+				ASSERT(tag.reason == TagThrottledReason::UNSET);
+			}
 		}
 
 		ASSERT(manualThrottledTags <= SERVER_KNOBS->MAX_MANUAL_THROTTLED_TRANSACTION_TAGS);
@@ -187,14 +187,14 @@ struct TagThrottleApiWorkload : TestWorkload {
 	}
 
 	ACTOR Future<Void> getRecommendedTags(TagThrottleApiWorkload* self, Database cx) {
-        std::vector<TagThrottleInfo> tags = wait(ThrottleApi::getRecommendedTags(cx, CLIENT_KNOBS->TOO_MANY));
+		std::vector<TagThrottleInfo> tags = wait(ThrottleApi::getRecommendedTags(cx, CLIENT_KNOBS->TOO_MANY));
 
-        for(auto& tag : tags) {
-            ASSERT(tag.throttleType == TagThrottleType::AUTO);
-            if(self->apiVersion == 630) {
-                ASSERT(tag.reason == TagThrottledReason::UNSET);
-            }
-        }
+		for(auto& tag : tags) {
+			ASSERT(tag.throttleType == TagThrottleType::AUTO);
+			if(self->apiVersion == 630) {
+				ASSERT(tag.reason == TagThrottledReason::UNSET);
+			}
+		}
 		return Void();
 	}
 


### PR DESCRIPTION
* update `status json` to report busiest write tag of each storage server
* update TagThrottleApiWorkload