### PR TITLE
The workload sometimes would wrongly report a passed tests as failed …

### DIFF
--- a/fdbserver/workloads/ReadHotDetection.actor.cpp
+++ b/fdbserver/workloads/ReadHotDetection.actor.cpp
@@ -109,6 +109,7 @@ struct ReadHotDetectionWorkload : TestWorkload {
 				for (const auto& kr : keyRanges) {
 					if (kr.keys.contains(self->readKey)) {
 						self->passed = true;
+						return Void();
 					}
 				}
 				// The key ranges deemed read hot does not contain the readKey, which is impossible here.


### PR DESCRIPTION
…due to not return after the hotkey is found.