### PR TITLE
Enable the RocksDB engine by default with GCC

### DIFF
--- a/cmake/CompileRocksDB.cmake
+++ b/cmake/CompileRocksDB.cmake
@@ -59,11 +59,14 @@ else()
   set(ROCKSDB_LIBRARIES
       ${BINARY_DIR}/librocksdb.a)
 
+  ExternalProject_Get_Property(rocksdb SOURCE_DIR)
+  set (ROCKSDB_INCLUDE_DIR "${SOURCE_DIR}/include")
+
   set(ROCKSDB_FOUND TRUE)
 endif()
 
 message(STATUS "Found RocksDB library: ${ROCKSDB_LIBRARIES}")
-message(STATUS "Found RocksDB includes: ${ROCKSDB_INCLUDE_DIRS}")
+message(STATUS "Found RocksDB includes: ${ROCKSDB_INCLUDE_DIR}")
 
 mark_as_advanced(
     ROCKSDB_LIBRARIES

--- a/cmake/FDBComponents.cmake
+++ b/cmake/FDBComponents.cmake
@@ -12,7 +12,7 @@ endif()
 # SSL
 ################################################################################
 include(CheckSymbolExists)
- 
+
 set(DISABLE_TLS OFF CACHE BOOL "Don't try to find OpenSSL and always build without TLS support")
 if(DISABLE_TLS)
   set(WITH_TLS OFF)
@@ -107,7 +107,9 @@ endif()
 ################################################################################
 
 set(SSD_ROCKSDB_EXPERIMENTAL OFF CACHE BOOL "Build with experimental RocksDB support")
-if (SSD_ROCKSDB_EXPERIMENTAL)
+# RocksDB is currently enabled by default for GCC but does not build with the latest
+# Clang.
+if (SSD_ROCKSDB_EXPERIMENTAL OR GCC)
   set(WITH_ROCKSDB_EXPERIMENTAL ON)
 else()
   set(WITH_ROCKSDB_EXPERIMENTAL OFF)

--- a/fdbserver/SimulatedCluster.actor.cpp
+++ b/fdbserver/SimulatedCluster.actor.cpp
@@ -734,7 +734,7 @@ void SimulationConfig::generateNormalConfig(int minimumReplication, int minimumR
 	if (deterministicRandom()->random01() < 0.25) db.desiredTLogCount = deterministicRandom()->randomInt(1,7);
 	if (deterministicRandom()->random01() < 0.25) db.masterProxyCount = deterministicRandom()->randomInt(1,7);
 	if (deterministicRandom()->random01() < 0.25) db.resolverCount = deterministicRandom()->randomInt(1,7);
-	int storage_engine_type = deterministicRandom()->randomInt(0, 4);
+/*	int storage_engine_type = deterministicRandom()->randomInt(0, 4);
 	switch (storage_engine_type) {
 	case 0: {
 		TEST(true); // Simulated cluster using ssd storage engine
@@ -758,7 +758,8 @@ void SimulationConfig::generateNormalConfig(int minimumReplication, int minimumR
 		}
 	default:
 		ASSERT(false); // Programmer forgot to adjust cases.
-	}
+	} */
+	set_config("ssd-rocksdb-experimental");
 	//	if (deterministicRandom()->random01() < 0.5) {
 	//		set_config("ssd");
 	//	} else {

--- a/fdbserver/SimulatedCluster.actor.cpp
+++ b/fdbserver/SimulatedCluster.actor.cpp
@@ -734,7 +734,7 @@ void SimulationConfig::generateNormalConfig(int minimumReplication, int minimumR
 	if (deterministicRandom()->random01() < 0.25) db.desiredTLogCount = deterministicRandom()->randomInt(1,7);
 	if (deterministicRandom()->random01() < 0.25) db.masterProxyCount = deterministicRandom()->randomInt(1,7);
 	if (deterministicRandom()->random01() < 0.25) db.resolverCount = deterministicRandom()->randomInt(1,7);
-/*	int storage_engine_type = deterministicRandom()->randomInt(0, 4);
+	int storage_engine_type = deterministicRandom()->randomInt(0, 4);
 	switch (storage_engine_type) {
 	case 0: {
 		TEST(true); // Simulated cluster using ssd storage engine
@@ -758,8 +758,7 @@ void SimulationConfig::generateNormalConfig(int minimumReplication, int minimumR
 		}
 	default:
 		ASSERT(false); // Programmer forgot to adjust cases.
-	} */
-	set_config("ssd-rocksdb-experimental");
+	}
 	//	if (deterministicRandom()->random01() < 0.5) {
 	//		set_config("ssd");
 	//	} else {


### PR DESCRIPTION
RocksDB currently does not build with Clang 10 (the version in the dev Docker container), so this is only turning on for GCC.

This PR also steals a fix to the RocksDB auto-download path from @sears .