### PR TITLE
This resolves issue #3739 by exposing time since last full recovery.

### DIFF
--- a/documentation/sphinx/source/mr-status-json-schemas.rst.inc
+++ b/documentation/sphinx/source/mr-status-json-schemas.rst.inc
@@ -446,6 +446,8 @@
          }
       ],
       "recovery_state":{
+         "time_since_last_recovered":1,
+         "number_of_old_generations_of_tlogs":1,
          "required_resolvers":1,
          "required_proxies":1,
          "required_grv_proxies":1,

--- a/documentation/sphinx/source/mr-status-json-schemas.rst.inc
+++ b/documentation/sphinx/source/mr-status-json-schemas.rst.inc
@@ -447,7 +447,6 @@
       ],
       "recovery_state":{
          "time_since_last_recovered":1,
-         "number_of_old_generations_of_tlogs":1,
          "required_resolvers":1,
          "required_proxies":1,
          "required_grv_proxies":1,

--- a/documentation/sphinx/source/mr-status-json-schemas.rst.inc
+++ b/documentation/sphinx/source/mr-status-json-schemas.rst.inc
@@ -446,7 +446,7 @@
          }
       ],
       "recovery_state":{
-         "time_since_last_recovered":1,
+         "seconds_since_last_recovered":1,
          "required_resolvers":1,
          "required_proxies":1,
          "required_grv_proxies":1,

--- a/fdbclient/Schemas.cpp
+++ b/fdbclient/Schemas.cpp
@@ -482,7 +482,7 @@ const KeyRef JSONSchemas::statusSchema = LiteralStringRef(R"statusSchema(
 )statusSchema"
                                                           R"statusSchema(
       "recovery_state":{
-         "time_since_last_recovered":1,
+         "seconds_since_last_recovered":1,
          "required_resolvers":1,
          "required_proxies":1,
          "required_grv_proxies":1,

--- a/fdbclient/Schemas.cpp
+++ b/fdbclient/Schemas.cpp
@@ -482,7 +482,7 @@ const KeyRef JSONSchemas::statusSchema = LiteralStringRef(R"statusSchema(
 )statusSchema"
                                                           R"statusSchema(
       "recovery_state":{
-         "time_since_last_db_turned_available_seconds":1,
+         "time_since_last_recovered":1,
          "number_of_old_generations_of_tlogs":1,
          "required_resolvers":1,
          "required_proxies":1,

--- a/fdbclient/Schemas.cpp
+++ b/fdbclient/Schemas.cpp
@@ -483,7 +483,6 @@ const KeyRef JSONSchemas::statusSchema = LiteralStringRef(R"statusSchema(
                                                           R"statusSchema(
       "recovery_state":{
          "time_since_last_recovered":1,
-         "number_of_old_generations_of_tlogs":1,
          "required_resolvers":1,
          "required_proxies":1,
          "required_grv_proxies":1,

--- a/fdbclient/Schemas.cpp
+++ b/fdbclient/Schemas.cpp
@@ -482,7 +482,8 @@ const KeyRef JSONSchemas::statusSchema = LiteralStringRef(R"statusSchema(
 )statusSchema"
                                                           R"statusSchema(
       "recovery_state":{
-         "time_since_last_fully_recovered_seconds":1,
+         "time_since_last_db_turned_available_seconds":1,
+         "number_of_old_generations_of_tlogs":1,
          "required_resolvers":1,
          "required_proxies":1,
          "required_grv_proxies":1,

--- a/fdbclient/Schemas.cpp
+++ b/fdbclient/Schemas.cpp
@@ -482,6 +482,7 @@ const KeyRef JSONSchemas::statusSchema = LiteralStringRef(R"statusSchema(
 )statusSchema"
                                                           R"statusSchema(
       "recovery_state":{
+         "time_since_last_fully_recovered_seconds":1,
          "required_resolvers":1,
          "required_proxies":1,
          "required_grv_proxies":1,

--- a/fdbserver/Status.actor.cpp
+++ b/fdbserver/Status.actor.cpp
@@ -1041,7 +1041,8 @@ ACTOR static Future<JsonBuilderObject> recoveryStateStatusFetcher(Database cx, W
 		message = JsonString::makeMessage(RecoveryStatus::names[mStatusCode], RecoveryStatus::descriptions[mStatusCode]);
 		*statusCode = mStatusCode;
 
-		if (mStatusCode == RecoveryStatus::fully_recovered) {
+		std::string fullyRecoveredAtVersion;
+		if (mStatusCode == RecoveryStatus::fully_recovered && md.tryGetValue("FullyRecoveredAtVersion", fullyRecoveredAtVersion)) {
 			Version rv = wait(tr.getReadVersion());
 			int64_t fullyRecoveredAtVersion = md.getInt64("FullyRecoveredAtVersion");
 			double lastFullyRecoveredSecondsAgo = std::max(0, rv - fullyRecoveredAtVersion) / (double)SERVER_KNOBS->VERSIONS_PER_SECOND;

--- a/fdbserver/Status.actor.cpp
+++ b/fdbserver/Status.actor.cpp
@@ -1050,10 +1050,10 @@ ACTOR static Future<JsonBuilderObject> recoveryStateStatusFetcher(Database cx, W
 			int64_t availableAtVersion = dbAvailableMsg.getInt64("AvailableAtVersion");
 			if (!rv.isError()) {
 				double lastRecoveredSecondsAgo = std::max((int64_t)0, (int64_t)(rv.get() - availableAtVersion)) / (double)SERVER_KNOBS->VERSIONS_PER_SECOND;
-				message["time_since_last_recovered"] = lastRecoveredSecondsAgo;
+				message["seconds_since_last_recovered"] = lastRecoveredSecondsAgo;
 			}
 		} else {
-			message["time_since_last_db_turned_available_seconds"] = -1;
+			message["seconds_since_last_recovered"] = -1;
 		}
 
 		// Add additional metadata for certain statuses

--- a/fdbserver/Status.actor.cpp
+++ b/fdbserver/Status.actor.cpp
@@ -1048,15 +1048,12 @@ ACTOR static Future<JsonBuilderObject> recoveryStateStatusFetcher(Database cx, W
 		const TraceEventFields& dbAvailableMsg = mDBAvailableF.get();
 		if (dbAvailableMsg.size() > 0) {
 			int64_t availableAtVersion = dbAvailableMsg.getInt64("AvailableAtVersion");
-			int numOfOldGensOfLogs = dbAvailableMsg.getInt("NumOfOldGensOfLogs");
 			if (!rv.isError()) {
 				double lastRecoveredSecondsAgo = std::max((int64_t)0, (int64_t)(rv.get() - availableAtVersion)) / (double)SERVER_KNOBS->VERSIONS_PER_SECOND;
 				message["time_since_last_recovered"] = lastRecoveredSecondsAgo;
 			}
-			message["number_of_old_generations_of_tlogs"] = numOfOldGensOfLogs;
 		} else {
 			message["time_since_last_db_turned_available_seconds"] = -1;
-			message["number_of_old_generations_of_tlogs"] = -1;
 		}
 
 		// Add additional metadata for certain statuses

--- a/fdbserver/masterserver.actor.cpp
+++ b/fdbserver/masterserver.actor.cpp
@@ -1689,10 +1689,10 @@ ACTOR Future<Void> masterCore( Reference<MasterData> self ) {
 		.detail("RecoveryDuration", recoveryDuration)
 		.trackLatest("MasterRecoveryState");
 
-	TraceEvent("MasterRecoverFDBAvailable", self->dbgid)
+	TraceEvent("MasterRecoveryAvailable", self->dbgid)
 		.detail("NumOfOldGensOfLogs", self->cstate.myDBState.oldTLogData.size())
-		.detail("AvailabelAtVersion", self->version)
-		.trackLatest("MasterRecoverFDBAvailable");
+		.detail("AvailableAtVersion", self->version)
+		.trackLatest("MasterRecoveryAvailable");
 
 	if( self->resolvers.size() > 1 )
 		self->addActor.send( resolutionBalancing(self) );

--- a/fdbserver/masterserver.actor.cpp
+++ b/fdbserver/masterserver.actor.cpp
@@ -1690,7 +1690,6 @@ ACTOR Future<Void> masterCore( Reference<MasterData> self ) {
 		.trackLatest("MasterRecoveryState");
 
 	TraceEvent("MasterRecoveryAvailable", self->dbgid)
-		.detail("NumOfOldGensOfLogs", self->cstate.myDBState.oldTLogData.size())
 		.detail("AvailableAtVersion", self->version)
 		.trackLatest("MasterRecoveryAvailable");
 

--- a/fdbserver/masterserver.actor.cpp
+++ b/fdbserver/masterserver.actor.cpp
@@ -1276,8 +1276,6 @@ ACTOR Future<Void> trackTlogRecovery( Reference<MasterData> self, Reference<Asyn
 			.detail("Status", RecoveryStatus::names[RecoveryStatus::fully_recovered])
 			.trackLatest("MasterRecoveryState");
 
-			TraceEvent("MasterRecoveryFullyRecovered").trackLatest("MasterRecoveryFullyRecovered");
-
 			TraceEvent("MasterRecoveryGenerations", self->dbgid)
 			.detail("ActiveGenerations", 1)
 			.trackLatest("MasterRecoveryGenerations");

--- a/fdbserver/masterserver.actor.cpp
+++ b/fdbserver/masterserver.actor.cpp
@@ -1274,7 +1274,7 @@ ACTOR Future<Void> trackTlogRecovery( Reference<MasterData> self, Reference<Asyn
 			TraceEvent("MasterRecoveryState", self->dbgid)
 			.detail("StatusCode", RecoveryStatus::fully_recovered)
 			.detail("Status", RecoveryStatus::names[RecoveryStatus::fully_recovered])
-			.detail("FullyRecoveredAtVersion", self->version);
+			.detail("FullyRecoveredAtVersion", self->version)
 			.trackLatest("MasterRecoveryState");
 
 			TraceEvent("MasterRecoveryGenerations", self->dbgid)

--- a/fdbserver/masterserver.actor.cpp
+++ b/fdbserver/masterserver.actor.cpp
@@ -1274,6 +1274,7 @@ ACTOR Future<Void> trackTlogRecovery( Reference<MasterData> self, Reference<Asyn
 			TraceEvent("MasterRecoveryState", self->dbgid)
 			.detail("StatusCode", RecoveryStatus::fully_recovered)
 			.detail("Status", RecoveryStatus::names[RecoveryStatus::fully_recovered])
+			.detail("FullyRecoveredAtVersion", self->version);
 			.trackLatest("MasterRecoveryState");
 
 			TraceEvent("MasterRecoveryGenerations", self->dbgid)

--- a/fdbserver/masterserver.actor.cpp
+++ b/fdbserver/masterserver.actor.cpp
@@ -1276,6 +1276,8 @@ ACTOR Future<Void> trackTlogRecovery( Reference<MasterData> self, Reference<Asyn
 			.detail("Status", RecoveryStatus::names[RecoveryStatus::fully_recovered])
 			.trackLatest("MasterRecoveryState");
 
+			TraceEvent("MasterRecoveryFullyRecovered").trackLatest("MasterRecoveryFullyRecovered");
+
 			TraceEvent("MasterRecoveryGenerations", self->dbgid)
 			.detail("ActiveGenerations", 1)
 			.trackLatest("MasterRecoveryGenerations");

--- a/fdbserver/masterserver.actor.cpp
+++ b/fdbserver/masterserver.actor.cpp
@@ -1689,6 +1689,11 @@ ACTOR Future<Void> masterCore( Reference<MasterData> self ) {
 		.detail("RecoveryDuration", recoveryDuration)
 		.trackLatest("MasterRecoveryState");
 
+	TraceEvent("MasterRecoverFDBAvailable", self->dbgid)
+		.detail("NumOfOldGensOfLogs", self->cstate.myDBState.oldTLogData.size())
+		.detail("AvailabelAtVersion", self->version)
+		.trackLatest("MasterRecoverFDBAvailable");
+
 	if( self->resolvers.size() > 1 )
 		self->addActor.send( resolutionBalancing(self) );
 


### PR DESCRIPTION
This expose a new field under `recovery_state` named `time_since_last_fully_recovered_seconds` which has a value of either

- -1 if the current generation has not fully recovered yet;
- Or the time, in seconds, since current generation fully recovered.