### PR TITLE
Add CLI argument to print build information

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,7 +72,8 @@ add_custom_target(branch_file ALL DEPENDS ${CURR_BRANCH_FILE})
 execute_process(
   COMMAND git rev-parse HEAD
   WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-  OUTPUT_VARIABLE CURRENT_GIT_VERSION_WNL)
+  OUTPUT_VARIABLE CURRENT_GIT_VERSION_WNL
+  OUTPUT_STRIP_TRAILING_WHITESPACE)
 string(STRIP "${CURRENT_GIT_VERSION_WNL}" CURRENT_GIT_VERSION)
 message(STATUS "Current git version ${CURRENT_GIT_VERSION}")
 
@@ -181,6 +182,12 @@ endif()
 if(CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
   add_link_options(-lexecinfo)
 endif()
+
+################################################################################
+# Build information
+################################################################################
+
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/fdbclient/BuildFlags.h.in ${CMAKE_CURRENT_BINARY_DIR}/fdbclient/BuildFlags.h)
 
 ################################################################################
 # process compile commands for IDE

--- a/fdbbackup/FileConverter.actor.cpp
+++ b/fdbbackup/FileConverter.actor.cpp
@@ -31,6 +31,7 @@
 #include "fdbclient/MutationList.h"
 #include "flow/flow.h"
 #include "flow/serialize.h"
+#include "fdbclient/BuildFlags.h"
 #include "flow/actorcompiler.h" // has to be last include
 
 namespace file_converter {
@@ -51,10 +52,15 @@ void printConvertUsage() {
 	          << "  --trace_format FORMAT\n"
 	          << "                  Select the format of the trace files. xml (the default) and json are supported.\n"
 	          << "                  Has no effect unless --log is specified.\n"
+	          << "  --build_flags   Print build information and exit.\n"
 	          << "  -h, --help      Display this help and exit.\n"
 	          << "\n";
 
 	return;
+}
+
+void printBuildInformation() {
+	printf("%s", jsonBuildInformation().c_str());
 }
 
 void printLogFiles(std::string msg, const std::vector<LogFile>& files) {
@@ -534,6 +540,10 @@ int parseCommandLine(ConvertParams* param, CSimpleOpt* args) {
 
 		case OPT_TRACE_LOG_GROUP:
 			param->trace_log_group = args->OptionArg();
+			break;
+		case OPT_BUILD_FLAGS:
+			printBuildInformation();
+			return FDB_EXIT_ERROR;
 			break;
 		}
 	}

--- a/fdbbackup/FileConverter.h
+++ b/fdbbackup/FileConverter.h
@@ -38,6 +38,7 @@ enum {
 	OPT_TRACE_FORMAT,
 	OPT_TRACE_LOG_GROUP,
 	OPT_INPUT_FILE,
+	OPT_BUILD_FLAGS,
 	OPT_HELP
 };
 
@@ -54,6 +55,7 @@ CSimpleOpt::SOption gConverterOptions[] = { { OPT_CONTAINER, "-r", SO_REQ_SEP },
 	                                        { OPT_TRACE_LOG_GROUP, "--loggroup", SO_REQ_SEP },
 	                                        { OPT_INPUT_FILE, "-i", SO_REQ_SEP },
 	                                        { OPT_INPUT_FILE, "--input", SO_REQ_SEP },
+	                                        { OPT_BUILD_FLAGS, "--build_flags", SO_NONE },
 	                                        { OPT_HELP, "-?", SO_NONE },
 	                                        { OPT_HELP, "-h", SO_NONE },
 	                                        { OPT_HELP, "--help", SO_NONE },

--- a/fdbbackup/FileDecoder.actor.cpp
+++ b/fdbbackup/FileDecoder.actor.cpp
@@ -28,6 +28,7 @@
 #include "fdbclient/MutationList.h"
 #include "flow/flow.h"
 #include "flow/serialize.h"
+#include "fdbclient/BuildFlags.h"
 #include "flow/actorcompiler.h" // has to be last include
 
 #define SevDecodeInfo SevVerbose
@@ -41,8 +42,13 @@ void printDecodeUsage() {
 	             "  -r, --container   Container URL.\n"
 	             "  -i, --input FILE  Log file to be decoded.\n"
 	             "  --crash           Crash on serious error.\n"
+	             "  --build_flags     Print build information and exit.\n"
 	             "\n";
 	return;
+}
+
+void printBuildInformation() {
+	printf("%s", jsonBuildInformation().c_str());
 }
 
 struct DecodeParams {
@@ -120,6 +126,10 @@ int parseDecodeCommandLine(DecodeParams* param, CSimpleOpt* args) {
 
 		case OPT_TRACE_LOG_GROUP:
 			param->trace_log_group = args->OptionArg();
+			break;
+		case OPT_BUILD_FLAGS:
+			printBuildInformation();
+			return FDB_EXIT_ERROR;
 			break;
 		}
 	}

--- a/fdbbackup/backup.actor.cpp
+++ b/fdbbackup/backup.actor.cpp
@@ -68,6 +68,7 @@ using std::endl;
 #endif
 
 #include "fdbclient/versions.h"
+#include "fdbclient/BuildFlags.h"
 
 #include "flow/SimpleOpt.h"
 #include "flow/actorcompiler.h"  // This must be the last #include.
@@ -152,6 +153,7 @@ enum {
 	OPT_HELP,
 	OPT_DEVHELP,
 	OPT_VERSION,
+	OPT_BUILD_FLAGS,
 	OPT_PARENTPID,
 	OPT_CRASHONERROR,
 	OPT_NOBUFSTDOUT,
@@ -174,11 +176,12 @@ enum {
 
 // Top level binary commands.
 CSimpleOpt::SOption g_rgOptions[] = {
-	{ OPT_VERSION, "-v",        SO_NONE },
-	{ OPT_VERSION, "--version", SO_NONE },
-	{ OPT_HELP,    "-?",        SO_NONE },
-	{ OPT_HELP,    "-h",        SO_NONE },
-	{ OPT_HELP,    "--help",    SO_NONE },
+	{ OPT_VERSION,     "-v",            SO_NONE },
+	{ OPT_VERSION,     "--version",     SO_NONE },
+	{ OPT_BUILD_FLAGS, "--build_flags", SO_NONE },
+	{ OPT_HELP,        "-?",            SO_NONE },
+	{ OPT_HELP,        "-h",            SO_NONE },
+	{ OPT_HELP,        "--help",        SO_NONE },
 
 	SO_END_OF_OPTIONS
 };
@@ -192,6 +195,7 @@ CSimpleOpt::SOption g_rgAgentOptions[] = {
 	{ OPT_KNOB, "--knob_", SO_REQ_SEP },
 	{ OPT_VERSION, "--version", SO_NONE },
 	{ OPT_VERSION, "-v", SO_NONE },
+	{ OPT_BUILD_FLAGS, "--build_flags", SO_NONE },
 	{ OPT_QUIET, "-q", SO_NONE },
 	{ OPT_QUIET, "--quiet", SO_NONE },
 	{ OPT_TRACE, "--log", SO_NONE },
@@ -706,6 +710,7 @@ CSimpleOpt::SOption g_rgDBAgentOptions[] = {
 	{ OPT_KNOB,            "--knob_",          SO_REQ_SEP },
 	{ OPT_VERSION,         "--version",        SO_NONE },
 	{ OPT_VERSION,         "-v",               SO_NONE },
+	{ OPT_BUILD_FLAGS,     "--build_flags",    SO_NONE },
 	{ OPT_QUIET,           "-q",               SO_NONE },
 	{ OPT_QUIET,           "--quiet",          SO_NONE },
 	{ OPT_TRACE,           "--log",            SO_NONE },
@@ -908,6 +913,10 @@ static void printVersion() {
 	printf("protocol %llx\n", (long long) currentProtocolVersion.version());
 }
 
+static void printBuildInformation() {
+	printf("%s", jsonBuildInformation().c_str());
+}
+
 const char *BlobCredentialInfo =
 	"  BLOB CREDENTIALS\n"
 	"     Blob account secret keys can optionally be omitted from blobstore:// URLs, in which case they will be\n"
@@ -947,6 +956,7 @@ static void printAgentUsage(bool devhelp) {
 #ifndef TLS_DISABLED
 	printf(TLS_HELP);
 #endif
+	printf("  --build_flags  Print build information and exit.\n");
 	printf("  -v, --version  Print version information and exit.\n");
 	printf("  -h, --help     Display this help and exit.\n");
 
@@ -979,6 +989,7 @@ static void printBackupUsage(bool devhelp) {
 	       "delete | describe | list | query | cleanup) [ACTION_OPTIONS]\n\n",
 	       exeBackup.toString().c_str());
 	printf(" TOP LEVEL OPTIONS:\n");
+	printf("  --build_flags  Print build information and exit.\n");
 	printf("  -v, --version  Print version information and exit.\n");
 	printf("  -h, --help     Display this help and exit.\n");
 	printf("\n");
@@ -1081,6 +1092,7 @@ static void printRestoreUsage(bool devhelp ) {
 	printf("Usage: %s [TOP_LEVEL_OPTIONS] (start | status | abort | wait) [OPTIONS]\n\n", exeRestore.toString().c_str());
 
 	printf(" TOP LEVEL OPTIONS:\n");
+	printf("  --build_flags  Print build information and exit.\n");
 	printf("  -v, --version  Print version information and exit.\n");
 	printf("  -h, --help     Display this help and exit.\n");
 	printf("\n");
@@ -1174,6 +1186,7 @@ static void printDBAgentUsage(bool devhelp) {
 #ifndef TLS_DISABLED
 	printf(TLS_HELP);
 #endif
+	printf("  --build_flags  Print build information and exit.\n");
 	printf("  -v, --version  Print version information and exit.\n");
 	printf("  -h, --help     Display this help and exit.\n");
 	if (devhelp) {
@@ -1193,6 +1206,7 @@ static void printDBBackupUsage(bool devhelp) {
 	printf("Usage: %s [TOP_LEVEL_OPTIONS] (start | status | switch | abort | pause | resume) [OPTIONS]\n\n", exeDatabaseBackup.toString().c_str());
 
 	printf(" TOP LEVEL OPTIONS:\n");
+	printf("  --build_flags  Print build information and exit.\n");
 	printf("  -v, --version  Print version information and exit.\n");
 	printf("  -h, --help     Display this help and exit.\n");
 	printf("\n");
@@ -3196,6 +3210,10 @@ int main(int argc, char* argv[]) {
 					break;
 				case OPT_VERSION:
 					printVersion();
+					return FDB_EXIT_SUCCESS;
+					break;
+				case OPT_BUILD_FLAGS:
+					printBuildInformation();
 					return FDB_EXIT_SUCCESS;
 					break;
 				case OPT_NOBUFSTDOUT:

--- a/fdbcli/fdbcli.actor.cpp
+++ b/fdbcli/fdbcli.actor.cpp
@@ -51,6 +51,7 @@
 #endif
 
 #include "fdbclient/versions.h"
+#include "fdbclient/BuildFlags.h"
 
 #include "flow/actorcompiler.h"  // This must be the last #include.
 
@@ -70,6 +71,7 @@ enum {
 	OPT_NO_HINTS,
 	OPT_STATUS_FROM_JSON,
 	OPT_VERSION,
+	OPT_BUILD_FLAGS,
 	OPT_TRACE_FORMAT,
 	OPT_KNOB,
 	OPT_DEBUG_TLS
@@ -90,6 +92,7 @@ CSimpleOpt::SOption g_rgOptions[] = { { OPT_CONNFILE, "-C", SO_REQ_SEP },
 	                                  { OPT_STATUS_FROM_JSON, "--status-from-json", SO_REQ_SEP },
 	                                  { OPT_VERSION, "--version", SO_NONE },
 	                                  { OPT_VERSION, "-v", SO_NONE },
+	                                  { OPT_BUILD_FLAGS, "--build_flags", SO_NONE },
 	                                  { OPT_TRACE_FORMAT, "--trace_format", SO_REQ_SEP },
 	                                  { OPT_KNOB, "--knob_", SO_REQ_SEP },
 	                                  { OPT_DEBUG_TLS, "--debug-tls", SO_NONE },
@@ -433,6 +436,7 @@ static void printProgramUsage(const char* name) {
 	       "                 Changes a knob option. KNOBNAME should be lowercase.\n"
 				 "  --debug-tls    Prints the TLS configuration and certificate chain, then exits.\n"
 				 "                 Useful in reporting and diagnosing TLS issues.\n"
+	       "  --build_flags  Print build information and exit.\n"
 	       "  -v, --version  Print FoundationDB CLI version information and exit.\n"
 	       "  -h, --help     Display this help and exit.\n");
 }
@@ -628,6 +632,10 @@ void printVersion() {
 	printf("FoundationDB CLI " FDB_VT_PACKAGE_NAME " (v" FDB_VT_VERSION ")\n");
 	printf("source version %s\n", getSourceVersion());
 	printf("protocol %" PRIx64 "\n", currentProtocolVersion.version());
+}
+
+void printBuildInformation() {
+	printf("%s", jsonBuildInformation().c_str());
 }
 
 void printHelpOverview() {
@@ -2968,6 +2976,9 @@ struct CLIOptions {
 				break;
 			case OPT_VERSION:
 				printVersion();
+				return FDB_EXIT_SUCCESS;
+			case OPT_BUILD_FLAGS:
+				printBuildInformation();
 				return FDB_EXIT_SUCCESS;
 		}
 		return -1;

--- a/fdbclient/BuildFlags.h.in
+++ b/fdbclient/BuildFlags.h.in
@@ -25,6 +25,14 @@
 
 #include "fdbclient/JSONDoc.h"
 
+#ifdef __GLIBC__
+#define C_VERSION_MAJOR __GLIBC__
+#define C_VERSION_MINOR __GLIBC_MINOR__
+#else
+#define C_VERSION_MAJOR 0
+#define C_VERSION_MINOR 0
+#endif
+
 // FDB info.
 const std::string kGitHash = "@CURRENT_GIT_VERSION_WNL@";
 const std::string kFdbVersion = "@FDB_VERSION@";
@@ -42,8 +50,8 @@ const std::string kCMakeVersion = "@CMAKE_VERSION@";
 const std::string kCCacheEnabled = "@USE_CCACHE@";
 
 // GNU C library major and minor versions.
-constexpr int kCVersionMajor = __GLIBC__;
-constexpr int kCVersionMinor = __GLIBC_MINOR__;
+constexpr int kCVersionMajor = C_VERSION_MAJOR;
+constexpr int kCVersionMinor = C_VERSION_MINOR;
 
 // C++ standard. Possible values are 201402L, 201703L, etc...
 constexpr int kCppStandard = __cplusplus;

--- a/fdbclient/BuildFlags.h.in
+++ b/fdbclient/BuildFlags.h.in
@@ -1,0 +1,72 @@
+/*
+ * BuildFlags.h
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2020 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FDBCLIENT_BUILDFLAGS_H
+#define FDBCLIENT_BUILDFLAGS_H
+
+#include <string>
+
+#include "fdbclient/JSONDoc.h"
+
+// FDB info.
+const std::string kGitHash = "@CURRENT_GIT_VERSION_WNL@";
+const std::string kFdbVersion = "@FDB_VERSION@";
+
+// System architecture.
+const std::string kArch = "@CMAKE_SYSTEM@";
+// ID of compiler used for build, ie "Clang", "GNU", etc...
+const std::string kCompiler = "@CMAKE_CXX_COMPILER_ID@";
+
+// Library versions.
+const std::string kBoostVersion = "@Boost_LIB_VERSION@";
+
+// Build info and flags.
+const std::string kCMakeVersion = "@CMAKE_VERSION@";
+const std::string kCCacheEnabled = "@USE_CCACHE@";
+
+// GNU C library major and minor versions.
+constexpr int kCVersionMajor = __GLIBC__;
+constexpr int kCVersionMinor = __GLIBC_MINOR__;
+
+// C++ standard. Possible values are 201402L, 201703L, etc...
+constexpr int kCppStandard = __cplusplus;
+
+// Returns a JSON string with information about how the binary was built.
+std::string jsonBuildInformation() {
+	json_spirit::mValue json;	
+	JSONDoc doc(json);
+
+	doc.create("git_hash") = kGitHash;
+	doc.create("fdb_version") = kFdbVersion;
+
+	doc.create("arch") = kArch;
+	doc.create("compiler") = kCompiler;
+
+	doc.create("boost_version") = kBoostVersion;
+	doc.create("cmake_version") = kCMakeVersion;
+	doc.create("ccache") = kCCacheEnabled;
+
+	doc.create("glibc_version") = std::to_string(kCVersionMajor) + "." + std::to_string(kCVersionMinor);
+	doc.create("cpp_standard") = kCppStandard;
+
+	return json_spirit::write_string(json, json_spirit::pretty_print) + "\n";
+}
+
+#endif

--- a/fdbserver/fdbserver.actor.cpp
+++ b/fdbserver/fdbserver.actor.cpp
@@ -39,6 +39,7 @@
 #include "fdbclient/RestoreWorkerInterface.actor.h"
 #include "fdbclient/SystemData.h"
 #include "fdbclient/versions.h"
+#include "fdbclient/BuildFlags.h"
 #include "fdbmonitor/SimpleIni.h"
 #include "fdbrpc/AsyncFileCached.actor.h"
 #include "fdbrpc/Net2FileSystem.h"
@@ -87,8 +88,8 @@
 enum {
 	OPT_CONNFILE, OPT_SEEDCONNFILE, OPT_SEEDCONNSTRING, OPT_ROLE, OPT_LISTEN, OPT_PUBLICADDR, OPT_DATAFOLDER, OPT_LOGFOLDER, OPT_PARENTPID, OPT_TRACER, OPT_NEWCONSOLE,
 	OPT_NOBOX, OPT_TESTFILE, OPT_RESTARTING, OPT_RESTORING, OPT_RANDOMSEED, OPT_KEY, OPT_MEMLIMIT, OPT_STORAGEMEMLIMIT, OPT_CACHEMEMLIMIT, OPT_MACHINEID,
-	OPT_DCID, OPT_MACHINE_CLASS, OPT_BUGGIFY, OPT_VERSION, OPT_CRASHONERROR, OPT_HELP, OPT_NETWORKIMPL, OPT_NOBUFSTDOUT, OPT_BUFSTDOUTERR, OPT_TRACECLOCK,
-	OPT_NUMTESTERS, OPT_DEVHELP, OPT_ROLLSIZE, OPT_MAXLOGS, OPT_MAXLOGSSIZE, OPT_KNOB, OPT_TESTSERVERS, OPT_TEST_ON_SERVERS, OPT_METRICSCONNFILE,
+	OPT_DCID, OPT_MACHINE_CLASS, OPT_BUGGIFY, OPT_VERSION, OPT_BUILD_FLAGS, OPT_CRASHONERROR, OPT_HELP, OPT_NETWORKIMPL, OPT_NOBUFSTDOUT, OPT_BUFSTDOUTERR,
+	OPT_TRACECLOCK, OPT_NUMTESTERS, OPT_DEVHELP, OPT_ROLLSIZE, OPT_MAXLOGS, OPT_MAXLOGSSIZE, OPT_KNOB, OPT_TESTSERVERS, OPT_TEST_ON_SERVERS, OPT_METRICSCONNFILE,
 	OPT_METRICSPREFIX, OPT_LOGGROUP, OPT_LOCALITY, OPT_IO_TRUST_SECONDS, OPT_IO_TRUST_WARN_ONLY, OPT_FILESYSTEM, OPT_PROFILER_RSS_SIZE, OPT_KVFILE,
 	OPT_TRACE_FORMAT, OPT_WHITELIST_BINPATH, OPT_BLOB_CREDENTIAL_FILE
 };
@@ -149,6 +150,7 @@ CSimpleOpt::SOption g_rgOptions[] = {
 	{ OPT_BUGGIFY,               "--buggify",                   SO_REQ_SEP },
 	{ OPT_VERSION,               "-v",                          SO_NONE },
 	{ OPT_VERSION,               "--version",                   SO_NONE },
+	{ OPT_BUILD_FLAGS,           "--build_flags",               SO_NONE },
 	{ OPT_CRASHONERROR,          "--crash",                     SO_NONE },
 	{ OPT_NETWORKIMPL,           "-N",                          SO_REQ_SEP },
 	{ OPT_NETWORKIMPL,           "--network",                   SO_REQ_SEP },
@@ -475,6 +477,10 @@ void* parentWatcher(void *arg) {
 }
 #endif
 
+static void printBuildInformation() {
+	printf("%s", jsonBuildInformation().c_str());
+}
+
 static void printVersion() {
 	printf("FoundationDB " FDB_VT_PACKAGE_NAME " (v" FDB_VT_VERSION ")\n");
 	printf("source version %s\n", getSourceVersion());
@@ -604,6 +610,7 @@ static void printUsage( const char *name, bool devhelp ) {
 	printOptionUsage("-v, --version", "Print version information and exit.");
 	printOptionUsage("-h, -?, --help", "Display this help and exit.");
 	if( devhelp ) {
+		printf("  --build_flags  Print build information and exit.\n");
 		printOptionUsage("-r ROLE, --role ROLE",
 			   " Server role (valid options are fdbd, test, multitest,"
 			   " simulation, networktestclient, networktestserver, restore"
@@ -1040,6 +1047,9 @@ private:
 				printVersion();
 				flushAndExit(FDB_EXIT_SUCCESS);
 				break;
+			case OPT_BUILD_FLAGS:
+				printBuildInformation();
+				flushAndExit(FDB_EXIT_SUCCESS);
 			case OPT_NOBUFSTDOUT:
 				setvbuf(stdout, nullptr, _IONBF, 0);
 				setvbuf(stderr, nullptr, _IONBF, 0);


### PR DESCRIPTION
Adds a command line argument to most of the FDB binaries to print build information.

Example:

```
$ ./bin/fdbserver --build_flags
{
    "arch" : "Linux-5.6.6-300.fc32.x86_64",
    "boost_version" : "1_72",
    "ccache" : "ON",
    "cmake_version" : "3.13.4",
    "compiler" : "Clang",
    "cpp_standard" : 201703,
    "fdb_version" : "7.0.0",
    "git_hash" : "989299dc748a33040c0f6aa811d2399a0092c1da",
    "glibc_version" : "2.12"
}
```

Binaries that support the `--build_flags` option:

* `fdbserver`
* `fdbcli`
* `backup_agent`
* `fdbbackup`
* `fdbrestore`
* `fastrestore_tool`
* `dr_agent`
* `fdbdr`
* `fdbconvert`
* `fdbdecode`

Dependent on #3771.