### PR TITLE
Disallow calling blockUntilReady from main thread

### DIFF
--- a/documentation/sphinx/source/api-c.rst
+++ b/documentation/sphinx/source/api-c.rst
@@ -265,9 +265,9 @@ See :ref:`developer-guide-programming-with-futures` for further (language-indepe
 
 .. function:: fdb_error_t fdb_future_block_until_ready(FDBFuture* future)
 
-   Blocks the calling thread until the given Future is ready. It will return success even if the Future is set to an error -- you must call :func:`fdb_future_get_error()` to determine that. :func:`fdb_future_block_until_ready()` will return an error only in exceptional conditions (e.g. out of memory or other operating system resources).
+   Blocks the calling thread until the given Future is ready. It will return success even if the Future is set to an error -- you must call :func:`fdb_future_get_error()` to determine that. :func:`fdb_future_block_until_ready()` will return an error only in exceptional conditions (e.g. deadlock detected, out of memory or other operating system resources).
 
-   .. warning:: Never call this function from a callback passed to :func:`fdb_future_set_callback()`. This may block the thread on which :func:`fdb_run_network()` was invoked, resulting in a deadlock.
+   .. warning:: Never call this function from a callback passed to :func:`fdb_future_set_callback()`. This may block the thread on which :func:`fdb_run_network()` was invoked, resulting in a ``blocked_from_network_thread`` error.
 
 .. function:: fdb_bool_t fdb_future_is_ready(FDBFuture* future)
 

--- a/documentation/sphinx/source/api-error-codes.rst
+++ b/documentation/sphinx/source/api-error-codes.rst
@@ -112,7 +112,7 @@ FoundationDB may return the following error codes from API functions. If you nee
 +-----------------------------------------------+-----+--------------------------------------------------------------------------------+
 | invalid_cache_eviction_policy                 | 2024| Invalid cache eviction policy, only random and lru are supported               |
 +-----------------------------------------------+-----+--------------------------------------------------------------------------------+
-| blocked_from_network_thread                   | 2025| Attempted to block in a callback called from the network thread.               |
+| blocked_from_network_thread                   | 2025| Attempted to block in a callback called from the network thread                |
 +-----------------------------------------------+-----+--------------------------------------------------------------------------------+
 | incompatible_protocol_version                 | 2100| Incompatible protocol version                                                  |
 +-----------------------------------------------+-----+--------------------------------------------------------------------------------+

--- a/documentation/sphinx/source/api-error-codes.rst
+++ b/documentation/sphinx/source/api-error-codes.rst
@@ -110,6 +110,10 @@ FoundationDB may return the following error codes from API functions. If you nee
 +-----------------------------------------------+-----+--------------------------------------------------------------------------------+
 | transaction_read_only                         | 2023| Attempted to commit a transaction specified as read-only                       |
 +-----------------------------------------------+-----+--------------------------------------------------------------------------------+
+| invalid_cache_eviction_policy                 | 2024| Invalid cache eviction policy, only random and lru are supported               |
++-----------------------------------------------+-----+--------------------------------------------------------------------------------+
+| blocked_from_network_thread                   | 2025| Attempted to block in a callback called from the network thread.               |
++-----------------------------------------------+-----+--------------------------------------------------------------------------------+
 | incompatible_protocol_version                 | 2100| Incompatible protocol version                                                  |
 +-----------------------------------------------+-----+--------------------------------------------------------------------------------+
 | transaction_too_large                         | 2101| Transaction exceeds byte limit                                                 |

--- a/flow/ThreadHelper.actor.h
+++ b/flow/ThreadHelper.actor.h
@@ -197,10 +197,10 @@ public:
 	};
 
 	void blockUntilReady() {
-		if (g_network->isOnMainThread()) {
-			throw blocked_from_network_thread();
-		}
 		if (!isReady()) {
+			if (g_network->isOnMainThread()) {
+				throw blocked_from_network_thread();
+			}
 			BlockCallback cb(*this);
 		}
 	}

--- a/flow/ThreadHelper.actor.h
+++ b/flow/ThreadHelper.actor.h
@@ -197,12 +197,12 @@ public:
 	};
 
 	void blockUntilReady() {
-		if(isReadyUnsafe()) {
-			ThreadSpinLockHolder holder(mutex);
-			ASSERT(isReadyUnsafe());
+		if (g_network->isOnMainThread()) {
+			TraceEvent(SevWarnAlways, "AttemptToBlockOnMainThread").error(client_invalid_operation());
+			throw client_invalid_operation();
 		}
-		else {
-			BlockCallback cb( *this );
+		if (!isReady()) {
+			BlockCallback cb(*this);
 		}
 	}
 

--- a/flow/ThreadHelper.actor.h
+++ b/flow/ThreadHelper.actor.h
@@ -198,8 +198,7 @@ public:
 
 	void blockUntilReady() {
 		if (g_network->isOnMainThread()) {
-			TraceEvent(SevWarnAlways, "AttemptToBlockOnMainThread").error(client_invalid_operation());
-			throw client_invalid_operation();
+			throw blocked_from_network_thread();
 		}
 		if (!isReady()) {
 			BlockCallback cb(*this);

--- a/flow/Trace.cpp
+++ b/flow/Trace.cpp
@@ -473,7 +473,11 @@ public:
 			barriers->push(f);
 			writer->post( new WriterThread::Barrier );
 
-			f.getBlocking();
+			if (g_network->isSimulated()) {
+				ASSERT(f.isReady());
+			} else {
+				f.getBlocking();
+			}
 
 			opened = false;
 		}

--- a/flow/Trace.cpp
+++ b/flow/Trace.cpp
@@ -473,11 +473,7 @@ public:
 			barriers->push(f);
 			writer->post( new WriterThread::Barrier );
 
-			if (g_network->isSimulated()) {
-				ASSERT(f.isReady());
-			} else {
-				f.getBlocking();
-			}
+			f.getBlocking();
 
 			opened = false;
 		}

--- a/flow/error_definitions.h
+++ b/flow/error_definitions.h
@@ -135,6 +135,7 @@ ERROR( no_commit_version, 2021, "Transaction is read-only and therefore does not
 ERROR( environment_variable_network_option_failed, 2022, "Environment variable network option could not be set" )
 ERROR( transaction_read_only, 2023, "Attempted to commit a transaction specified as read-only" )
 ERROR( invalid_cache_eviction_policy, 2024, "Invalid cache eviction policy, only random and lru are supported" )
+ERROR( blocked_from_network_thread, 2025, "Attempted to block in a callback called from the network thread." )
 
 ERROR( incompatible_protocol_version, 2100, "Incompatible protocol version" )
 ERROR( transaction_too_large, 2101, "Transaction exceeds byte limit" )


### PR DESCRIPTION
As described in https://apple.github.io/foundationdb/api-c.html?highlight=fdb_future_block_until_ready#c.fdb_future_block_until_ready, it's an error to call fdb_future_block_until_ready from the main thread (the one running fdb_run_network). This PR changes the current behavior of deadlocking (difficult to debug and to know what to do to recover from it) to throwing an error and tracing a diagnostic.

I'm also wondering if it would be even better to have a new error code for this, in case the client doesn't have tracing enabled.