### PR TITLE
Add MinV2 and AddV2 test into AtomicOp workload

### DIFF
--- a/fdbserver/workloads/AtomicOps.actor.cpp
+++ b/fdbserver/workloads/AtomicOps.actor.cpp
@@ -55,8 +55,7 @@ struct AtomicOpsWorkload : TestWorkload {
 		ubsum = 0;
 
 		int64_t randNum = sharedRandomNumber / 10;
-		if(opType == -1)
-			opType = randNum % 8;
+		if (opType == -1) opType = randNum % 10;
 
 		switch(opType) {
 		case 0:
@@ -91,6 +90,15 @@ struct AtomicOpsWorkload : TestWorkload {
 			TEST(true); //Testing atomic ByteMax
 			opType = MutationRef::ByteMax;
 			break;
+		case 8:
+			TEST(true); // Testing atomic MinV2
+			opType = MutationRef::MinV2;
+		case 9:
+			TEST(true); // Testing atomic AndV2
+			opType = MutationRef::AndV2;
+		// case 10:
+		// 	TEST(true); // Testing atomic CompareAndClear Not supported yet
+		// 	opType = MutationRef::CompareAndClear
 		default:
 			ASSERT(false);
 		}


### PR DESCRIPTION
This resolves part of https://github.com/apple/foundationdb/issues/3762.

CompareAndClear should be tested separately.

Merge to 6.3 branch because it is only simulation change.