### PR TITLE
Support restoring multiple key ranges into different target versions in simulation

### DIFF
--- a/fdbclient/BackupAgent.actor.h
+++ b/fdbclient/BackupAgent.actor.h
@@ -271,12 +271,15 @@ public:
 
 	enum ERestoreState { UNITIALIZED = 0, QUEUED = 1, STARTING = 2, RUNNING = 3, COMPLETED = 4, ABORTED = 5 };
 	static StringRef restoreStateText(ERestoreState id);
+	using RestoreKeyRangesVersion = std::pair<Standalone<VectorRef<KeyRangeRef>>, Version>;
 
 	// parallel restore
 	Future<Void> parallelRestoreFinish(Database cx, UID randomUID, bool unlockDB = true);
 	Future<Void> submitParallelRestore(Database cx, Key backupTag, Standalone<VectorRef<KeyRangeRef>> backupRanges,
 	                                   Key bcUrl, Version targetVersion, bool lockDB, UID randomUID, Key addPrefix,
 	                                   Key removePrefix);
+	Future<Void> submitParallelRestore(Database cx, Key backupTag, std::vector<RestoreKeyRangesVersion> requests,
+	                                   Key bcUrl, bool lockDB, UID randomUID, Key addPrefix, Key removePrefix);
 	Future<Void> atomicParallelRestore(Database cx, Key tagName, Standalone<VectorRef<KeyRangeRef>> ranges,
 	                                   Key addPrefix, Key removePrefix);
 

--- a/fdbclient/FDBTypes.h
+++ b/fdbclient/FDBTypes.h
@@ -183,6 +183,10 @@ inline std::string describe( const int item ) {
 	return format("%d", item);
 }
 
+inline std::string describe( const Version item ) {
+	return format("%ld", item);
+}
+
 // Allows describeList to work on a vector of std::string
 static std::string describe(const std::string& s) {
 	return s;
@@ -260,6 +264,7 @@ std::string printable( const KeyRangeRef& range );
 std::string printable( const VectorRef<StringRef>& val );
 std::string printable( const VectorRef<KeyValueRef>& val );
 std::string printable( const KeyValueRef& val );
+std::string printable( const VectorRef<KeyRangeRef>& val );
 
 template <class T>
 std::string printable( const Optional<T>& val ) {

--- a/fdbclient/FileBackupAgent.actor.cpp
+++ b/fdbclient/FileBackupAgent.actor.cpp
@@ -3677,7 +3677,8 @@ public:
 			if (targetVersion == invalidVersion && desc.maxRestorableVersion.present()) {
 				targetVersion = desc.maxRestorableVersion.get();
 				TraceEvent(SevWarn, "FastRestoreSubmitRestoreRequestWithInvalidTargetVersion")
-					.detail("OverrideTargetVersion", targetVersion);
+					.detail("OverrideTargetVersion", targetVersion)
+					.detail("RequestIndex", requestIndex);
 			}
 			
 			Optional<RestorableFileSet> restoreSet = wait(bc->getRestoreSet(targetVersion));
@@ -3691,7 +3692,8 @@ public:
 			actualTargetVersions.push_back(targetVersion);
 			TraceEvent("FastRestoreSubmitSingleRestoreRequest")
 				.detail("KeyRanges", printable(requests[requestIndex].first))
-				.detail("Version", targetVersion);
+				.detail("Version", targetVersion)
+				.detail("RequestIndex", requestIndex);
 		}
 
 		TraceEvent("FastRestoreSubmitRestoreRequest")

--- a/fdbclient/FileBackupAgent.actor.cpp
+++ b/fdbclient/FileBackupAgent.actor.cpp
@@ -21,6 +21,7 @@
 #include "fdbclient/BackupAgent.actor.h"
 #include "fdbclient/BackupContainer.h"
 #include "fdbclient/DatabaseContext.h"
+#include "fdbclient/FDBTypes.h"
 #include "fdbclient/Knobs.h"
 #include "fdbclient/ManagementAPI.actor.h"
 #include "fdbclient/Status.h"
@@ -3662,32 +3663,39 @@ public:
 	}
 
 	ACTOR static Future<Void> submitParallelRestore(Database cx, Key backupTag,
-	                                                Standalone<VectorRef<KeyRangeRef>> backupRanges, Key bcUrl,
-	                                                Version targetVersion, bool lockDB, UID randomUID, Key addPrefix,
-	                                                Key removePrefix) {
+	                                                std::vector<FileBackupAgent::RestoreKeyRangesVersion> requests, Key bcUrl,
+	                                                bool lockDB, UID randomUID, Key addPrefix, Key removePrefix) {
 		// Sanity check backup is valid
 		state Reference<IBackupContainer> bc = IBackupContainer::openContainer(bcUrl.toString());
 		state BackupDescription desc = wait(bc->describeBackup());
 		wait(desc.resolveVersionTimes(cx));
 
-		if (targetVersion == invalidVersion && desc.maxRestorableVersion.present()) {
-			targetVersion = desc.maxRestorableVersion.get();
-			TraceEvent(SevWarn, "FastRestoreSubmitRestoreRequestWithInvalidTargetVersion")
-			    .detail("OverrideTargetVersion", targetVersion);
-		}
+		state std::vector<Version> actualTargetVersions;
+		state int requestIndex;
+		for (requestIndex = 0; requestIndex < requests.size(); requestIndex++) {
+			state Version targetVersion = requests[requestIndex].second;
+			if (targetVersion == invalidVersion && desc.maxRestorableVersion.present()) {
+				targetVersion = desc.maxRestorableVersion.get();
+				TraceEvent(SevWarn, "FastRestoreSubmitRestoreRequestWithInvalidTargetVersion")
+					.detail("OverrideTargetVersion", targetVersion);
+			}
+			
+			Optional<RestorableFileSet> restoreSet = wait(bc->getRestoreSet(targetVersion));
 
-		Optional<RestorableFileSet> restoreSet = wait(bc->getRestoreSet(targetVersion));
-
-		if (!restoreSet.present()) {
-			TraceEvent(SevWarn, "FileBackupAgentRestoreNotPossible")
-			    .detail("BackupContainer", bc->getURL())
-			    .detail("TargetVersion", targetVersion);
-			throw restore_invalid_version();
+			if (!restoreSet.present()) {
+				TraceEvent(SevWarn, "FileBackupAgentRestoreNotPossible")
+					.detail("BackupContainer", bc->getURL())
+					.detail("TargetVersion", targetVersion);
+				throw restore_invalid_version();
+			}
+			actualTargetVersions.push_back(targetVersion);
+			TraceEvent("FastRestoreSubmitSingleRestoreRequest")
+				.detail("KeyRanges", printable(requests[requestIndex].first))
+				.detail("Version", targetVersion);
 		}
 
 		TraceEvent("FastRestoreSubmitRestoreRequest")
-		    .detail("BackupDesc", desc.toString())
-		    .detail("TargetVersion", targetVersion);
+		    .detail("BackupDesc", desc.toString());
 
 		state Reference<ReadYourWritesTransaction> tr(new ReadYourWritesTransaction(cx));
 		state int restoreIndex = 0;
@@ -3720,17 +3728,19 @@ public:
 			tr->setOption(FDBTransactionOptions::LOCK_AWARE);
 			try {
 				// Note: we always lock DB here in case DB is modified at the bacupRanges boundary.
-				for (restoreIndex = 0; restoreIndex < backupRanges.size(); restoreIndex++) {
-					auto range = backupRanges[restoreIndex];
-					Standalone<StringRef> restoreTag(backupTag.toString() + "_" + std::to_string(restoreIndex));
-					// Register the request request in DB, which will be picked up by restore worker leader
-					struct RestoreRequest restoreRequest(restoreIndex, restoreTag, bcUrl, targetVersion, range,
-					                                     deterministicRandom()->randomUniqueID(), addPrefix,
-					                                     removePrefix);
-					tr->set(restoreRequestKeyFor(restoreRequest.index), restoreRequestValue(restoreRequest));
+				for (int i = 0; i < requests.size(); i++) {
+					for (const auto& range : requests[i].first) {
+						Standalone<StringRef> restoreTag(backupTag.toString() + "_" + std::to_string(restoreIndex));
+						// Register the request request in DB, which will be picked up by restore worker leader
+						struct RestoreRequest restoreRequest(restoreIndex, restoreTag, bcUrl, actualTargetVersions[i], range,
+															deterministicRandom()->randomUniqueID(), addPrefix,
+															removePrefix);
+						tr->set(restoreRequestKeyFor(restoreRequest.index), restoreRequestValue(restoreRequest));
+						restoreIndex++;
+					}
 				}
 				tr->set(restoreRequestTriggerKey,
-				        restoreRequestTriggerValue(deterministicRandom()->randomUniqueID(), backupRanges.size()));
+				        restoreRequestTriggerValue(deterministicRandom()->randomUniqueID(), restoreIndex));
 				wait(tr->commit()); // Trigger restore
 				break;
 			} catch (Error& e) {
@@ -3738,6 +3748,7 @@ public:
 				    .detail("RestoreIndex", restoreIndex)
 				    .error(e);
 				numTries++;
+				restoreIndex = 0;
 				wait(tr->onError(e));
 			}
 		}
@@ -4652,7 +4663,7 @@ public:
 			TraceEvent("AtomicParallelRestoreStartRestore");
 			Version targetVersion = -1;
 			bool lockDB = true;
-			wait(submitParallelRestore(cx, tagName, ranges, KeyRef(bc->getURL()), targetVersion, lockDB, randomUid,
+			wait(submitParallelRestore(cx, tagName, {{ranges, targetVersion}}, KeyRef(bc->getURL()), lockDB, randomUid,
 			                           addPrefix, removePrefix));
 			state bool hasPrefix = (addPrefix.size() > 0 || removePrefix.size() > 0);
 			TraceEvent("AtomicParallelRestoreWaitForRestoreFinish").detail("HasPrefix", hasPrefix);
@@ -4694,8 +4705,14 @@ Future<Void> FileBackupAgent::submitParallelRestore(Database cx, Key backupTag,
                                                     Standalone<VectorRef<KeyRangeRef>> backupRanges, Key bcUrl,
                                                     Version targetVersion, bool lockDB, UID randomUID, Key addPrefix,
                                                     Key removePrefix) {
-	return FileBackupAgentImpl::submitParallelRestore(cx, backupTag, backupRanges, bcUrl, targetVersion, lockDB,
+	return FileBackupAgentImpl::submitParallelRestore(cx, backupTag, {{backupRanges, targetVersion}}, bcUrl, lockDB,
 	                                                  randomUID, addPrefix, removePrefix);
+}
+
+Future<Void> FileBackupAgent::submitParallelRestore(Database cx, Key backupTag,
+                                                    std::vector<RestoreKeyRangesVersion> requests, Key bcUrl,
+                                                    bool lockDB, UID randomUID, Key addPrefix, Key removePrefix) {
+	return FileBackupAgentImpl::submitParallelRestore(cx, backupTag, requests, bcUrl, lockDB, randomUID, addPrefix, removePrefix);
 }
 
 Future<Void> FileBackupAgent::atomicParallelRestore(Database cx, Key tagName, Standalone<VectorRef<KeyRangeRef>> ranges,

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -189,6 +189,13 @@ std::string printable( const KeyRangeRef& range ) {
 	return printable(range.begin) + " - " + printable(range.end);
 }
 
+std::string printable( const VectorRef<KeyRangeRef>& val ) {
+	std::string s;
+	for(int i=0; i<val.size(); i++)
+		s = s + printable(val[i]) + " ";
+	return s;
+}
+
 int unhex( char c ) {
 	if (c >= '0' && c <= '9')
 		return c-'0';

--- a/fdbserver/RestoreApplier.actor.h
+++ b/fdbserver/RestoreApplier.actor.h
@@ -395,6 +395,7 @@ struct RestoreApplierData : RestoreRoleData, public ReferenceCounted<RestoreAppl
 	void resetPerRestoreRequest() {
 		batch.clear();
 		finishedBatch = NotifiedVersion(0);
+		versionBatchId = NotifiedVersion(0);
 	}
 
 	std::string describeNode() {

--- a/fdbserver/RestoreController.actor.cpp
+++ b/fdbserver/RestoreController.actor.cpp
@@ -562,7 +562,7 @@ ACTOR static Future<Void> distributeWorkloadPerVersionBatch(Reference<RestoreCon
 	    .detail("BatchIndex", batchIndex)
 	    .detail("BatchSize", versionBatch.size)
 	    .detail("RunningVersionBatches", self->runningVersionBatches.get());
-	
+
 	self->runningVersionBatches.set(self->runningVersionBatches.get() + 1);
 
 	// In case sampling data takes too much memory on controller

--- a/fdbserver/RestoreController.actor.cpp
+++ b/fdbserver/RestoreController.actor.cpp
@@ -35,6 +35,7 @@
 #include "fdbserver/RestoreLoader.actor.h"
 
 #include "flow/Platform.h"
+#include "flow/Trace.h"
 #include "flow/actorcompiler.h" // This must be the last #include.
 
 ACTOR static Future<Void> clearDB(Database cx);
@@ -76,7 +77,7 @@ void splitKeyRangeForAppliers(Reference<ControllerBatchData> batchData,
 ACTOR Future<Void> sampleBackups(Reference<RestoreControllerData> self, RestoreControllerInterface ci) {
 	loop {
 		try {
-			RestoreSamplesRequest req = waitNext(ci.samples.getFuture());
+			RestoreSamplesRequest req = waitNext(ci.samples.getFuture()); 
 			TraceEvent(SevDebug, "FastRestoreControllerSampleBackups")
 			    .detail("SampleID", req.id)
 			    .detail("BatchIndex", req.batchIndex)
@@ -111,18 +112,19 @@ ACTOR Future<Void> startRestoreController(Reference<RestoreWorkerData> controlle
 	ASSERT(controllerWorker->controllerInterf.present());
 	state Reference<RestoreControllerData> self =
 	    Reference<RestoreControllerData>(new RestoreControllerData(controllerWorker->controllerInterf.get().id()));
+	state Future<Void> error = actorCollection(self->addActor.getFuture());
 
 	try {
 		// recruitRestoreRoles must come after controllerWorker has finished collectWorkerInterface
 		wait(recruitRestoreRoles(controllerWorker, self));
 
-		actors.add(updateHeartbeatTime(self));
-		actors.add(checkRolesLiveness(self));
-		actors.add(updateProcessMetrics(self));
-		actors.add(traceProcessMetrics(self, "RestoreController"));
-		actors.add(sampleBackups(self, controllerWorker->controllerInterf.get()));
+		self->addActor.send(updateHeartbeatTime(self));
+		self->addActor.send(checkRolesLiveness(self));
+		self->addActor.send(updateProcessMetrics(self));
+		self->addActor.send(traceProcessMetrics(self, "RestoreController"));
+		self->addActor.send(sampleBackups(self, controllerWorker->controllerInterf.get()));
 
-		wait(startProcessRestoreRequests(self, cx));
+		wait(startProcessRestoreRequests(self, cx) || error);
 	} catch (Error& e) {
 		if (e.code() != error_code_operation_cancelled) {
 			TraceEvent(SevError, "FastRestoreControllerStart").detail("Reason", "Unexpected unhandled error").error(e);
@@ -304,7 +306,6 @@ ACTOR static Future<Version> processRestoreRequest(Reference<RestoreControllerDa
 	state std::vector<RestoreFileFR> logFiles;
 	state std::vector<RestoreFileFR> allFiles;
 	state Version minRangeVersion = MAX_VERSION;
-	state Future<Void> error = actorCollection(self->addActor.getFuture());
 
 	self->initBackupContainer(request.url);
 
@@ -383,7 +384,7 @@ ACTOR static Future<Version> processRestoreRequest(Reference<RestoreControllerDa
 	}
 
 	try {
-		wait(waitForAll(fBatches) || error);
+		wait(waitForAll(fBatches));
 	} catch (Error& e) {
 		TraceEvent(SevError, "FastRestoreControllerDispatchVersionBatchesUnexpectedError").error(e);
 	}
@@ -561,7 +562,7 @@ ACTOR static Future<Void> distributeWorkloadPerVersionBatch(Reference<RestoreCon
 	    .detail("BatchIndex", batchIndex)
 	    .detail("BatchSize", versionBatch.size)
 	    .detail("RunningVersionBatches", self->runningVersionBatches.get());
-
+	
 	self->runningVersionBatches.set(self->runningVersionBatches.get() + 1);
 
 	// In case sampling data takes too much memory on controller
@@ -689,7 +690,6 @@ void splitKeyRangeForAppliers(Reference<ControllerBatchData> batchData,
 
 ACTOR static Future<std::vector<RestoreRequest>> collectRestoreRequests(Database cx) {
 	state std::vector<RestoreRequest> restoreRequests;
-	state Future<Void> watch4RestoreRequest;
 	state ReadYourWritesTransaction tr(cx);
 
 	// restoreRequestTriggerKey should already been set
@@ -1086,7 +1086,13 @@ ACTOR static Future<Void> updateHeartbeatTime(Reference<RestoreControllerData> s
 		}
 
 		fTimeout = delay(SERVER_KNOBS->FASTRESTORE_HEARTBEAT_DELAY);
-		wait(waitForAll(fReplies) || fTimeout);
+		// Here we have to handle error, otherwise controller worker will fail and exit.
+		try {
+			wait(waitForAll(fReplies) || fTimeout);
+		} catch (Error& e) {
+			TraceEvent(SevDebug, "FastRestoreUpdateHeartbeatError").error(e);
+		}
+
 		// Update the most recent heart beat time for each role
 		for (int i = 0; i < fReplies.size(); ++i) {
 			if (fReplies[i].isReady()) {

--- a/fdbserver/RestoreController.actor.h
+++ b/fdbserver/RestoreController.actor.h
@@ -177,7 +177,8 @@ struct RestoreControllerData : RestoreRoleData, public ReferenceCounted<RestoreC
 		versionBatches.clear();
 		batch.clear();
 		batchStatus.clear();
-		finishedBatch = NotifiedVersion();
+		finishedBatch = NotifiedVersion(0);
+		versionBatchId = NotifiedVersion(0);
 		ASSERT(runningVersionBatches.get() == 0);
 	}
 

--- a/fdbserver/RestoreLoader.actor.h
+++ b/fdbserver/RestoreLoader.actor.h
@@ -224,6 +224,7 @@ struct RestoreLoaderData : RestoreRoleData, public ReferenceCounted<RestoreLoade
 		batch.clear();
 		status.clear();
 		finishedBatch = NotifiedVersion(0);
+		versionBatchId = NotifiedVersion(0);
 	}
 
 	void initBackupContainer(Key url) {

--- a/fdbserver/workloads/BackupAndParallelRestoreCorrectness.actor.cpp
+++ b/fdbserver/workloads/BackupAndParallelRestoreCorrectness.actor.cpp
@@ -27,6 +27,8 @@
 #include "fdbserver/RestoreCommon.actor.h"
 #include "fdbserver/workloads/workloads.actor.h"
 #include "fdbserver/workloads/BulkSetup.actor.h"
+#include "flow/Arena.h"
+#include "flow/IRandom.h"
 #include "flow/actorcompiler.h" // This must be the last #include.
 
 #define TEST_ABORT_FASTRESTORE	0
@@ -358,6 +360,30 @@ struct BackupAndParallelRestoreCorrectnessWorkload : TestWorkload {
 		return Void();
 	}
 
+	// TODO: Support using key ranges to filter the restorable files set and get a smaller version than keyspace's
+	// minimum restorable version.
+	static Version pickRandomTargetVersion(const BackupDescription& desc) {
+		Version targetVersion = -1;
+		if (desc.maxRestorableVersion.present()) {
+			if (deterministicRandom()->random01() < 0.1) {
+				targetVersion = desc.minRestorableVersion.get();
+			} else if (deterministicRandom()->random01() < 0.1) {
+				targetVersion = desc.maxRestorableVersion.get();
+			} else if (deterministicRandom()->random01() < 0.5 &&
+						desc.minRestorableVersion.get() < desc.contiguousLogEnd.get()) {
+				// The assertion may fail because minRestorableVersion may be decided by snapshot version.
+				// ASSERT_WE_THINK(desc.minRestorableVersion.get() <= desc.contiguousLogEnd.get());
+				// This assertion can fail when contiguousLogEnd < maxRestorableVersion and
+				// the snapshot version > contiguousLogEnd. I.e., there is a gap between
+				// contiguousLogEnd and snapshot version.
+				// ASSERT_WE_THINK(desc.contiguousLogEnd.get() > desc.maxRestorableVersion.get());
+				targetVersion = deterministicRandom()->randomInt64(desc.minRestorableVersion.get(),
+																	desc.contiguousLogEnd.get());
+			}
+		}
+		return targetVersion;
+	}
+
 	ACTOR static Future<Void> _start(Database cx, BackupAndParallelRestoreCorrectnessWorkload* self) {
 		state FileBackupAgent backupAgent;
 		state Future<Void> extraBackup;
@@ -474,42 +500,43 @@ struct BackupAndParallelRestoreCorrectnessWorkload : TestWorkload {
 				ASSERT(self->usePartitionedLogs == desc.partitioned);
 				ASSERT(desc.minRestorableVersion.present()); // We must have a valid backup now.
 
-				state Version targetVersion = -1;
-				if (desc.maxRestorableVersion.present()) {
-					if (deterministicRandom()->random01() < 0.1) {
-						targetVersion = desc.minRestorableVersion.get();
-					} else if (deterministicRandom()->random01() < 0.1) {
-						targetVersion = desc.maxRestorableVersion.get();
-					} else if (deterministicRandom()->random01() < 0.5 &&
-					           desc.minRestorableVersion.get() < desc.contiguousLogEnd.get()) {
-						// The assertion may fail because minRestorableVersion may be decided by snapshot version.
-						// ASSERT_WE_THINK(desc.minRestorableVersion.get() <= desc.contiguousLogEnd.get());
-						// This assertion can fail when contiguousLogEnd < maxRestorableVersion and
-						// the snapshot version > contiguousLogEnd. I.e., there is a gap between
-						// contiguousLogEnd and snapshot version.
-						// ASSERT_WE_THINK(desc.contiguousLogEnd.get() > desc.maxRestorableVersion.get());
-						targetVersion = deterministicRandom()->randomInt64(desc.minRestorableVersion.get(),
-						                                                   desc.contiguousLogEnd.get());
-					}
-				}
 
 				TraceEvent("BAFRW_Restore", randomID)
 				    .detail("LastBackupContainer", lastBackupContainer->getURL())
 				    .detail("MinRestorableVersion", desc.minRestorableVersion.get())
 				    .detail("MaxRestorableVersion", desc.maxRestorableVersion.get())
-				    .detail("ContiguousLogEnd", desc.contiguousLogEnd.get())
-				    .detail("TargetVersion", targetVersion);
+				    .detail("ContiguousLogEnd", desc.contiguousLogEnd.get());
 
 				state std::vector<Future<Version>> restores;
 				state std::vector<Standalone<StringRef>> restoreTags;
 
+				// Either restore all backup ranges to single target version or break the backup ranges into several
+				// splits and restore each split to its own target version.
+				// TODO: Support restoring key ranges to a smaller version than whole backup's minimum restotable version.
+				std::vector<FileBackupAgent::RestoreKeyRangesVersion> restoreRequests;
+				if (deterministicRandom()->random01() < 0.1) {
+					restoreRequests.emplace_back(self->backupRanges, pickRandomTargetVersion(desc));
+				} else {
+					int beginIndex = 0;
+					while (beginIndex < self->backupRanges.size()) {
+						Standalone<VectorRef<KeyRangeRef>> keyRanges;
+						int size = deterministicRandom()->randomInt(0, self->backupRanges.size() - beginIndex) + 1;
+						keyRanges.append(self->backupRanges.arena(), self->backupRanges.begin() + beginIndex, size);
+						restoreRequests.emplace_back(keyRanges, pickRandomTargetVersion(desc));
+						beginIndex += size;
+					}
+					ASSERT(beginIndex == self->backupRanges.size());
+				}
+
 				// Submit parallel restore requests
 				TraceEvent("BackupAndParallelRestoreWorkload")
-				    .detail("PrepareRestores", self->backupRanges.size())
+				    .detail("PrepareRestoresTotalNumKeyRanges", self->backupRanges.size())
+					.detail("PrepareRestoresTotalNumSplits", restoreRequests.size())
 				    .detail("AddPrefix", self->addPrefix)
 				    .detail("RemovePrefix", self->removePrefix);
-				wait(backupAgent.submitParallelRestore(cx, self->backupTag, self->backupRanges,
-				                                       KeyRef(lastBackupContainer->getURL()), targetVersion,
+
+				wait(backupAgent.submitParallelRestore(cx, self->backupTag, restoreRequests,
+				                                       KeyRef(lastBackupContainer->getURL()),
 				                                       self->locked, randomID, self->addPrefix, self->removePrefix));
 				TraceEvent("BackupAndParallelRestoreWorkload")
 				    .detail("TriggerRestore", "Setting up restoreRequestTriggerKey");

--- a/fdbserver/workloads/BackupAndParallelRestoreCorrectness.actor.cpp
+++ b/fdbserver/workloads/BackupAndParallelRestoreCorrectness.actor.cpp
@@ -29,6 +29,7 @@
 #include "fdbserver/workloads/BulkSetup.actor.h"
 #include "flow/Arena.h"
 #include "flow/IRandom.h"
+#include "flow/Trace.h"
 #include "flow/actorcompiler.h" // This must be the last #include.
 
 #define TEST_ABORT_FASTRESTORE	0
@@ -113,7 +114,16 @@ struct BackupAndParallelRestoreCorrectnessWorkload : TestWorkload {
 			else
 				backupRanges.push_back_deep(backupRanges.arena(),
 				                            KeyRangeRef(strinc(LiteralStringRef("\x00\x00\x01")), normalKeys.end));
-		} else if (backupRangesCount <= 0) {
+		} else if (backupRangesCount == -2) {
+			if (deterministicRandom()->random01() < 0.3) {
+				backupRangesCount = -1;
+			} else {
+				backupRangesCount = deterministicRandom()->randomInt(1, 11);
+			}
+			TraceEvent("BackupAndParallelRestoreWorkload").detail("BackupRangesCountOverride", backupRangesCount);
+		}
+
+		if (backupRangesCount == -1) {
 			backupRanges.push_back_deep(backupRanges.arena(), normalKeys);
 		} else {
 			// Add backup ranges

--- a/tests/slow/ParallelRestoreNewBackupCorrectnessAtomicOp.toml
+++ b/tests/slow/ParallelRestoreNewBackupCorrectnessAtomicOp.toml
@@ -33,7 +33,9 @@ timeout = 360000
     testName = 'BackupAndParallelRestoreCorrectness'
     backupAfter = 10.0
     restoreAfter = 60.0
-    backupRangesCount = -1
+    # backupRangesCount -1 means backup the entire normal keyspace
+    # backupRangesCount -2 means number backup ranges is randomly generated in [-1, 10]
+    backupRangesCount = -2
     # use new backup
     usePartitionedLogs = true
 

--- a/tests/slow/ParallelRestoreNewBackupCorrectnessCycle.toml
+++ b/tests/slow/ParallelRestoreNewBackupCorrectnessCycle.toml
@@ -28,8 +28,9 @@ timeout = 360000
     testName = 'BackupAndParallelRestoreCorrectness'
     backupAfter = 10.0
     restoreAfter = 60.0
-    # backupRangesCount<0 means backup the entire normal keyspace
-    backupRangesCount = -1
+    # backupRangesCount -1 means backup the entire normal keyspace
+    # backupRangesCount -2 means number backup ranges is randomly generated in [-1, 10]
+    backupRangesCount = -2
     usePartitionedLogs = true
 
     [[test.workload]]

--- a/tests/slow/ParallelRestoreNewBackupCorrectnessMultiCycles.toml
+++ b/tests/slow/ParallelRestoreNewBackupCorrectnessMultiCycles.toml
@@ -51,8 +51,9 @@ timeout = 360000
     testName = 'BackupAndParallelRestoreCorrectness'
     backupAfter = 10.0
     restoreAfter = 60.0
-    # backupRangesCount<0 means backup the entire normal keyspace
-    backupRangesCount = 10
+    # backupRangesCount -1 means backup the entire normal keyspace
+    # backupRangesCount -2 means number backup ranges is randomly generated in [-1, 10]
+    backupRangesCount = -2
     usePartitionedLogs = true
 
     [[test.workload]]

--- a/tests/slow/ParallelRestoreNewBackupCorrectnessMultiCycles.toml
+++ b/tests/slow/ParallelRestoreNewBackupCorrectnessMultiCycles.toml
@@ -52,7 +52,7 @@ timeout = 360000
     backupAfter = 10.0
     restoreAfter = 60.0
     # backupRangesCount<0 means backup the entire normal keyspace
-    backupRangesCount = -1
+    backupRangesCount = 10
     usePartitionedLogs = true
 
     [[test.workload]]

--- a/tests/slow/ParallelRestoreOldBackupCorrectnessAtomicOp.toml
+++ b/tests/slow/ParallelRestoreOldBackupCorrectnessAtomicOp.toml
@@ -31,7 +31,9 @@ timeout = 360000
     testName = 'BackupAndParallelRestoreCorrectness'
     backupAfter = 10.0
     restoreAfter = 60.0
-    backupRangesCount = -1
+    # backupRangesCount -1 means backup the entire normal keyspace
+    # backupRangesCount -2 means number backup ranges is randomly generated in [-1, 10]
+    backupRangesCount = -2
     #    use old backup
     usePartitionedLogs = false
 

--- a/tests/slow/ParallelRestoreOldBackupCorrectnessCycle.toml
+++ b/tests/slow/ParallelRestoreOldBackupCorrectnessCycle.toml
@@ -28,8 +28,9 @@ timeout = 360000
     testName = 'BackupAndParallelRestoreCorrectness'
     backupAfter = 10.0
     restoreAfter = 60.0
-    # backupRangesCount<0 means backup the entire normal keyspace
-    backupRangesCount = -1
+    # backupRangesCount -1 means backup the entire normal keyspace
+    # backupRangesCount -2 means number backup ranges is randomly generated in [-1, 10]
+    backupRangesCount = -2
     usePartitionedLogs = false
 
     [[test.workload]]

--- a/tests/slow/ParallelRestoreOldBackupCorrectnessMultiCycles.toml
+++ b/tests/slow/ParallelRestoreOldBackupCorrectnessMultiCycles.toml
@@ -51,8 +51,9 @@ timeout = 360000
     testName = 'BackupAndParallelRestoreCorrectness'
     backupAfter = 10.0
     restoreAfter = 60.0
-    # backupRangesCount<0 means backup the entire normal keyspace
-    backupRangesCount = -1
+    # backupRangesCount -1 means backup the entire normal keyspace
+    # backupRangesCount -2 means number backup ranges is randomly generated in [-1, 10]
+    backupRangesCount = -2
     usePartitionedLogs = false
 
     [[test.workload]]


### PR DESCRIPTION
1. Extend submitParallelRestore API to support restoring multiple key ranges to different target versions.
2. Change restore framework to accommodate this change such as error handling in restore controller.
3. Support randomly generating the number of backup of key ranges in restore tests so that we can actually test this in current restore tests.
4. TODO: Currently we only support restoring key ranges to a target version that is >= the keyspace's minimum restorable version, we will support restoring a version >= key ranges' minimum restorable version.