### PR TITLE
Fix isMetadataMutation condition

### DIFF
--- a/fdbserver/ApplyMetadataMutation.cpp
+++ b/fdbserver/ApplyMetadataMutation.cpp
@@ -58,7 +58,7 @@ void applyMetadataMutations(UID const& dbgid, Arena& arena, VectorRef<MutationRe
 	for (auto const& m : mutations) {
 		//TraceEvent("MetadataMutation", dbgid).detail("M", m.toString());
 
-		if (m.param1.size() && m.param1[0] == systemKeys.begin[0] && m.type == MutationRef::SetValue) {
+		if (m.type == MutationRef::SetValue && systemKeys.contains(m.param1)) {
 			if(m.param1.startsWith(keyServersPrefix)) {
 				if(keyInfo) {
 					KeyRef k = m.param1.removePrefix(keyServersPrefix);
@@ -301,8 +301,7 @@ void applyMetadataMutations(UID const& dbgid, Arena& arena, VectorRef<MutationRe
 				confChange = true;
 				TEST(true);  // Recovering at a higher version.
 			}
-		}
-		else if (m.param2.size() && m.param2[0] == systemKeys.begin[0] && m.type == MutationRef::ClearRange) {
+		} else if (m.type == MutationRef::ClearRange && KeyRangeRef(m.param1, m.param2).intersects(systemKeys)) {
 			KeyRangeRef range(m.param1, m.param2);
 
 			if (keyServersKeys.intersects(range)) {

--- a/fdbserver/ApplyMetadataMutation.cpp
+++ b/fdbserver/ApplyMetadataMutation.cpp
@@ -58,7 +58,7 @@ void applyMetadataMutations(UID const& dbgid, Arena& arena, VectorRef<MutationRe
 	for (auto const& m : mutations) {
 		//TraceEvent("MetadataMutation", dbgid).detail("M", m.toString());
 
-		if (m.type == MutationRef::SetValue && systemKeys.contains(m.param1)) {
+		if (m.param1.size() && m.param1[0] == systemKeys.begin[0] && m.type == MutationRef::SetValue) {
 			if(m.param1.startsWith(keyServersPrefix)) {
 				if(keyInfo) {
 					KeyRef k = m.param1.removePrefix(keyServersPrefix);
@@ -301,7 +301,7 @@ void applyMetadataMutations(UID const& dbgid, Arena& arena, VectorRef<MutationRe
 				confChange = true;
 				TEST(true);  // Recovering at a higher version.
 			}
-		} else if (m.type == MutationRef::ClearRange && KeyRangeRef(m.param1, m.param2).intersects(systemKeys)) {
+		} else if (m.param2.size() > 1 && m.param2[0] == systemKeys.begin[0] && m.type == MutationRef::ClearRange) {
 			KeyRangeRef range(m.param1, m.param2);
 
 			if (keyServersKeys.intersects(range)) {

--- a/fdbserver/ApplyMetadataMutation.h
+++ b/fdbserver/ApplyMetadataMutation.h
@@ -33,8 +33,10 @@
 
 inline bool isMetadataMutation(MutationRef const& m) {
 	// FIXME: This is conservative - not everything in system keyspace is necessarily processed by applyMetadataMutations
-	return (m.type == MutationRef::SetValue && m.param1.size() && m.param1[0] == systemKeys.begin[0] && !m.param1.startsWith(nonMetadataSystemKeys.begin)) ||
-		(m.type == MutationRef::ClearRange && m.param2.size() && m.param2[0] == systemKeys.begin[0] && !nonMetadataSystemKeys.contains(KeyRangeRef(m.param1, m.param2)) );
+	return (m.type == MutationRef::SetValue && systemKeys.contains(m.param1) &&
+	        !nonMetadataSystemKeys.contains(m.param1)) ||
+	       (m.type == MutationRef::ClearRange && KeyRangeRef(m.param1, m.param2).intersects(systemKeys) &&
+	        !nonMetadataSystemKeys.contains(KeyRangeRef(m.param1, m.param2)));
 }
 
 Reference<StorageInfo> getStorageInfo(UID id, std::map<UID, Reference<StorageInfo>>* storageCache, IKeyValueStore* txnStateStore);

--- a/fdbserver/ApplyMetadataMutation.h
+++ b/fdbserver/ApplyMetadataMutation.h
@@ -33,9 +33,9 @@
 
 inline bool isMetadataMutation(MutationRef const& m) {
 	// FIXME: This is conservative - not everything in system keyspace is necessarily processed by applyMetadataMutations
-	return (m.type == MutationRef::SetValue && systemKeys.contains(m.param1) &&
-	        !nonMetadataSystemKeys.contains(m.param1)) ||
-	       (m.type == MutationRef::ClearRange && KeyRangeRef(m.param1, m.param2).intersects(systemKeys) &&
+	return (m.type == MutationRef::SetValue && m.param1.size() && m.param1[0] == systemKeys.begin[0] &&
+	        !m.param1.startsWith(nonMetadataSystemKeys.begin)) ||
+	       (m.type == MutationRef::ClearRange && m.param2.size() > 1 && m.param2[0] == systemKeys.begin[0] &&
 	        !nonMetadataSystemKeys.contains(KeyRangeRef(m.param1, m.param2)));
 }
 

--- a/flowbench/BenchMetadataCheck.cpp
+++ b/flowbench/BenchMetadataCheck.cpp
@@ -46,7 +46,7 @@ static void bench_check_metadata1(benchmark::State& state) {
 static void bench_check_metadata2(benchmark::State& state) {
 	const auto& m = mutations[state.range(0)];
 	while (state.KeepRunning()) {
-		benchmark::DoNotOptimize(m.param2.size() && m.param2[0] == systemKeys.begin[0]); // && m.param2.size() > 1);
+		benchmark::DoNotOptimize(m.param2.size() > 1 && m.param2[0] == systemKeys.begin[0]); // && m.param2.size() > 1);
 	}
 	state.SetItemsProcessed(static_cast<long>(state.iterations()));
 }

--- a/flowbench/BenchMetadataCheck.cpp
+++ b/flowbench/BenchMetadataCheck.cpp
@@ -1,0 +1,55 @@
+/*
+ * BenchMetadataCheck.cpp
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2020 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "benchmark/benchmark.h"
+
+#include "fdbclient/FDBTypes.h"
+#include "fdbclient/SystemData.h"
+
+// These benchmarks test the performance of different checks methods
+// of checking for metadata mutations in applyMetadataMutations
+
+static const std::array<MutationRef, 5> mutations = {
+	MutationRef(MutationRef::Type::ClearRange, normalKeys.begin, normalKeys.end),
+	MutationRef(MutationRef::Type::ClearRange, LiteralStringRef("a"), LiteralStringRef("b")),
+	MutationRef(MutationRef::Type::ClearRange, LiteralStringRef("aaaaaaaaaa"), LiteralStringRef("bbbbbbbbbb")),
+	MutationRef(MutationRef::Type::ClearRange, normalKeys.begin, systemKeys.end),
+	MutationRef(MutationRef::Type::ClearRange, LiteralStringRef("a").withPrefix(systemKeys.begin),
+	            LiteralStringRef("b").withPrefix(systemKeys.begin)),
+};
+
+static void bench_check_metadata1(benchmark::State& state) {
+	const auto& m = mutations[state.range(0)];
+	while (state.KeepRunning()) {
+		benchmark::DoNotOptimize(KeyRangeRef(m.param1, m.param2).intersects(systemKeys));
+	}
+	state.SetItemsProcessed(static_cast<long>(state.iterations()));
+}
+
+static void bench_check_metadata2(benchmark::State& state) {
+	const auto& m = mutations[state.range(0)];
+	while (state.KeepRunning()) {
+		benchmark::DoNotOptimize(m.param2.size() && m.param2[0] == systemKeys.begin[0]); // && m.param2.size() > 1);
+	}
+	state.SetItemsProcessed(static_cast<long>(state.iterations()));
+}
+
+BENCHMARK(bench_check_metadata1)->DenseRange(0, mutations.size() - 1)->ReportAggregatesOnly(true);
+BENCHMARK(bench_check_metadata2)->DenseRange(0, mutations.size() - 1)->ReportAggregatesOnly(true);

--- a/flowbench/CMakeLists.txt
+++ b/flowbench/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(FLOWBENCH_SRCS
   flowbench.actor.cpp
+  BenchMetadataCheck.cpp
   BenchIterate.cpp
   BenchPopulate.cpp
   BenchRandom.cpp


### PR DESCRIPTION
This applies a fix from the closed PR https://github.com/apple/foundationdb/pull/3663 that prevents `clear(normalKeys)` from being classified as a metadata mutation.