### PR TITLE
 fileconfigure fails with Assertion false failed

### DIFF
--- a/fdbclient/Schemas.cpp
+++ b/fdbclient/Schemas.cpp
@@ -888,7 +888,7 @@ const KeyRef JSONSchemas::clusterConfigurationSchema = LiteralStringRef(R"config
     "auto_grv_proxies":1,
     "auto_resolvers":1,
     "auto_logs":3,
-    "commit_proxies":5
+    "commit_proxies":5,
     "grv_proxies":1
 })configSchema");
 


### PR DESCRIPTION
When I'm trying to set up region configuration with `fileconfigure` command in fdbcli, I receive an error

```
fdb> fileconfigure regions_2dcs.json
Assertion false failed @ /home/oleg/work/fdb/foundationdb/fdbcli/fdbcli.actor.cpp 1988:
  addr2line -e fdbcli.debug -p -C -f -i 0x996353 0x413e93 0x508ba5 0x50d27b 0x510ed8 0x5174a1 0x5cff78 0x9bc998 0x68ada2 0x4d837f 0x7fea1cdb41a3
ERROR: An internal error occurred (4100)
```

The reason is an incorrect json schema in fdbclient/Schemas.cpp