### PR TITLE
[fdbbackup] make credentials optional

### DIFF
--- a/fdbclient/BlobStore.actor.cpp
+++ b/fdbclient/BlobStore.actor.cpp
@@ -616,9 +616,8 @@ ACTOR Future<Reference<HTTP::Response>> doRequest_impl(Reference<BlobStoreEndpoi
 			// Finish/update the request headers (which includes Date header)
 			// This must be done AFTER the connection is ready because if credentials are coming from disk they are refreshed
 			// when a new connection is established and setAuthHeaders() would need the updated secret.
-			if (bstore->credentials.present()) {
-				bstore->setAuthHeaders(bstore->credentials.get(), verb, resource, headers);
-			}
+			bstore->setAuthHeaders(verb, resource, headers);
+
 			remoteAddress = rconn.conn->getPeerAddress();
 			wait(bstore->requestRate->getAllowance(1));
 			Reference<HTTP::Response> _r = wait(timeoutError(HTTP::doRequest(rconn.conn, verb, resource, headers, &contentCopy, contentLen, bstore->sendRate, &bstore->s_stats.bytes_sent, bstore->recvRate), requestTimeout));
@@ -988,7 +987,12 @@ std::string BlobStoreEndpoint::hmac_sha1(Credentials const &creds, std::string c
 	return SHA1::from_string(kopad);
 }
 
-void BlobStoreEndpoint::setAuthHeaders(Credentials const &creds, std::string const &verb, std::string const &resource, HTTP::Headers& headers) {
+void BlobStoreEndpoint::setAuthHeaders(std::string const &verb, std::string const &resource, HTTP::Headers& headers) {
+	if (!credentials.present()) {
+		return;
+	}
+	Credentials creds = credentials.get();
+
 	std::string &date = headers["Date"];
 
 	char dateBuf[20];

--- a/fdbclient/BlobStore.h
+++ b/fdbclient/BlobStore.h
@@ -171,7 +171,7 @@ public:
 	Future<Void> updateSecret();
 
 	// Calculates the authentication string from the secret key
-	std::string hmac_sha1(Credentials const &creds, std::string const &msg);
+	static std::string hmac_sha1(Credentials const &creds, std::string const &msg);
 
 	// Sets headers needed for Authorization (including Date which will be overwritten if present)
 	void setAuthHeaders(Credentials const &creds, std::string const &verb, std::string const &resource, HTTP::Headers &headers);

--- a/fdbclient/BlobStore.h
+++ b/fdbclient/BlobStore.h
@@ -174,7 +174,7 @@ public:
 	static std::string hmac_sha1(Credentials const &creds, std::string const &msg);
 
 	// Sets headers needed for Authorization (including Date which will be overwritten if present)
-	void setAuthHeaders(Credentials const &creds, std::string const &verb, std::string const &resource, HTTP::Headers &headers);
+	void setAuthHeaders(std::string const &verb, std::string const &resource, HTTP::Headers &headers);
 
 	// Prepend the HTTP request header to the given PacketBuffer, returning the new head of the buffer chain
 	static PacketBuffer * writeRequestHeader(std::string const &request, HTTP::Headers const &headers, PacketBuffer *dest);


### PR DESCRIPTION
When blob storage is configured on a private network (such as an AWS VPC Endpoint being used to access S3), there isn't a need to specify http auth. Instead of creating a "dummy" credential and putting that in a blob credentials file/in our repository, we would much prefer to just leave off the http credentials from the URL.

This PR moves the `key` and `secret` member variables into a `Credentials` struct wrapped by an `Optional`.