### PR TITLE
Support specifying proxy as process class and converting it to commit proxy

### DIFF
--- a/fdbcli/fdbcli.actor.cpp
+++ b/fdbcli/fdbcli.actor.cpp
@@ -471,8 +471,8 @@ void initHelp() {
 		"All keys between BEGINKEY (inclusive) and ENDKEY (exclusive) are cleared from the database. This command will succeed even if the specified range is empty, but may fail because of conflicts." ESCAPINGK);
 	helpMap["configure"] = CommandHelp(
 	    "configure [new] "
-	    "<single|double|triple|three_data_hall|three_datacenter|ssd|memory|memory-radixtree-beta|commit_proxies=<"
-	    "COMMIT_PROXIES>|grv_proxies=<GRV_PROXIES>|logs=<LOGS>|resolvers=<RESOLVERS>>*",
+	    "<single|double|triple|three_data_hall|three_datacenter|ssd|memory|memory-radixtree-beta|proxies=<PROXIES>|"
+	    "commit_proxies=<COMMIT_PROXIES>|grv_proxies=<GRV_PROXIES>|logs=<LOGS>|resolvers=<RESOLVERS>>*",
 	    "change the database configuration",
 	    "The `new' option, if present, initializes a new database with the given configuration rather than changing "
 	    "the configuration of an existing one. When used, both a redundancy mode and a storage engine must be "
@@ -480,8 +480,13 @@ void initHelp() {
 	    "of data (survive one failure).\n  triple - three copies of data (survive two failures).\n  three_data_hall - "
 	    "See the Admin Guide.\n  three_datacenter - See the Admin Guide.\n\nStorage engine:\n  ssd - B-Tree storage "
 	    "engine optimized for solid state disks.\n  memory - Durable in-memory storage engine for small "
-	    "datasets.\n\ncommit_proxies=<COMMIT_PROXIES>: Sets the desired number of commit proxies in the cluster. Must "
-	    "be at least 1, or set to -1 which restores the number of commit proxies to the default "
+	    "datasets.\n\nproxies=<PROXIES>: Sets the desired number of proxies in the cluster. The proxy role is being "
+		"deprecated and split into GRV proxy and Commit proxy, now prefer configure 'grv_proxies' and 'commit_proxies' "
+		"separately. Generally we should follow that 'commit_proxies' is three times of 'grv_proxies' and 'grv_proxies' "
+		"should be not more than 4. If 'proxies' is specified, it will be converted to 'grv_proxies' and 'commit_proxies'. "
+		"Must be at least 2 (1 GRV proxy, 1 Commit proxy), or set to -1 which restores the number of proxies to the "
+		"default value.\n\ncommit_proxies=<COMMIT_PROXIES>: Sets the desired number of commit proxies in the cluster. "
+	    "Must be at least 1, or set to -1 which restores the number of commit proxies to the default "
 	    "value.\n\ngrv_proxies=<GRV_PROXIES>: Sets the desired number of GRV proxies in the cluster. Must be at least "
 	    "1, or set to -1 which restores the number of GRV proxies to the default value.\n\nlogs=<LOGS>: Sets the "
 	    "desired number of log servers in the cluster. Must be at least 1, or set to -1 which restores the number of "

--- a/fdbclient/ManagementAPI.actor.cpp
+++ b/fdbclient/ManagementAPI.actor.cpp
@@ -83,7 +83,8 @@ std::map<std::string, std::string> configForToken( std::string const& mode ) {
 
 		if (key == "proxies" && isInteger(value)) {
 			printf("\nWarning: Proxy role is being split into GRV Proxy and Commit Proxy, now prefer configuring "
-			       "\"grv_proxies\" and \"commit_proxies\" separately.\n");
+			       "\"grv_proxies\" and \"commit_proxies\" separately. Generally we should follow that Commit proxies"
+			       "/GRV proxies >= 3 && 1 <= GRV proxies <= 4\n");
 			int proxiesCount = atoi(value.c_str());
 			if (proxiesCount < 2) {
 				printf("Error: At least 2 proxies (1 GRV proxy and Commit proxy) are required.\n");

--- a/fdbclient/ManagementAPI.actor.cpp
+++ b/fdbclient/ManagementAPI.actor.cpp
@@ -82,12 +82,17 @@ std::map<std::string, std::string> configForToken( std::string const& mode ) {
 		std::string value = mode.substr(pos+1);
 
 		if (key == "proxies" && isInteger(value)) {
-			printf("\nWarning: Proxy role is being split into GRV Proxy and Commit Proxy, now prefer configuring "
-			       "\"grv_proxies\" and \"commit_proxies\" separately. Generally we should follow that Commit proxies"
-			       "/GRV proxies >= 3 && 1 <= GRV proxies <= 4\n");
+			printf("Warning: Proxy role is being split into GRV Proxy and Commit Proxy, now prefer configuring "
+			       "'grv_proxies' and 'commit_proxies' separately. Generally we should follow that 'commit_proxies'"
+			       " is three times of 'grv_proxies' count and 'grv_proxies' should be not more than 4.\n");
 			int proxiesCount = atoi(value.c_str());
+			if (proxiesCount == -1) {
+				proxiesCount = CLIENT_KNOBS->DEFAULT_AUTO_GRV_PROXIES + CLIENT_KNOBS->DEFAULT_AUTO_COMMIT_PROXIES;
+				ASSERT_WE_THINK(proxiesCount >= 2);
+			}
+
 			if (proxiesCount < 2) {
-				printf("Error: At least 2 proxies (1 GRV proxy and Commit proxy) are required.\n");
+				printf("Error: At least 2 proxies (1 GRV proxy and 1 Commit proxy) are required.\n");
 				return out;
 			}
 
@@ -103,7 +108,8 @@ std::map<std::string, std::string> configForToken( std::string const& mode ) {
 			       grvProxyCount, commitProxyCount);
 
 			TraceEvent("DatabaseConfigurationProxiesSpecified")
-			    .detail("SpecifiedProxies", grvProxyCount)
+			    .detail("SpecifiedProxies", atoi(value.c_str()))
+			    .detail("EffectiveSpecifiedProxies", proxiesCount)
 			    .detail("ConvertedGrvProxies", grvProxyCount)
 			    .detail("ConvertedCommitProxies", commitProxyCount);
 		}

--- a/fdbrpc/Locality.h
+++ b/fdbrpc/Locality.h
@@ -78,6 +78,11 @@ public:
 		else if (s=="transaction") _class = TransactionClass;
 		else if (s=="resolution") _class = ResolutionClass;
 		else if (s=="commit_proxy") _class = CommitProxyClass;
+		else if (s=="proxy") {
+			_class = CommitProxyClass;
+			printf("WARNING: 'proxy' machine class is deprecated and will be automatically converted "
+					"'commit_proxy' machine class. Please use 'grv_proxy' or 'commit_proxy' specifically\n");
+		}
 		else if (s=="grv_proxy") _class = GrvProxyClass;
 		else if (s=="master") _class = MasterClass;
 		else if (s=="test") _class = TesterClass;
@@ -100,6 +105,11 @@ public:
 		else if (classStr=="transaction") _class = TransactionClass;
 		else if (classStr=="resolution") _class = ResolutionClass;
 		else if (classStr=="commit_proxy") _class = CommitProxyClass;
+		else if (classStr=="proxy") {
+			_class = CommitProxyClass;
+			printf("WARNING: 'proxy' machine class is deprecated and will be automatically converted "
+					"'commit_proxy' machine class. Please use 'grv_proxy' or 'commit_proxy' specifically\n");
+		}
 		else if (classStr=="grv_proxy") _class = GrvProxyClass;
 		else if (classStr=="master") _class = MasterClass;
 		else if (classStr=="test") _class = TesterClass;


### PR DESCRIPTION
Our prod operations and automation team is heavily using the 'proxy' class types. To reduce failures, we should support backward compatibility for specifying 'proxy' as process class, convert it to commit proxy and give warning of deprecated usage.