### PR TITLE
Add C API unit tests

### DIFF
--- a/bindings/c/CMakeLists.txt
+++ b/bindings/c/CMakeLists.txt
@@ -71,8 +71,8 @@ if(NOT WIN32)
     test/mako/mako.h
     test/mako/utils.c
     test/mako/utils.h)
-  find_package(Threads REQUIRED)
   add_subdirectory(test/unit/third_party)
+  find_package(Threads REQUIRED)
   set(UNIT_TEST_SRCS
     test/unit/unit_tests.cpp
     test/unit/fdb_api.cpp

--- a/bindings/c/CMakeLists.txt
+++ b/bindings/c/CMakeLists.txt
@@ -100,6 +100,8 @@ if(NOT WIN32)
   target_link_libraries(fdb_c_ryw_benchmark PRIVATE fdb_c)
   target_link_libraries(fdb_c_txn_size_test PRIVATE fdb_c)
 
+  add_dependencies(fdb_c_setup_tests doctest)
+  add_dependencies(fdb_c_unit_tests doctest)
   target_include_directories(fdb_c_setup_tests PUBLIC ${DOCTEST_INCLUDE_DIR})
   target_include_directories(fdb_c_unit_tests PUBLIC ${DOCTEST_INCLUDE_DIR})
   target_link_libraries(fdb_c_setup_tests PRIVATE fdb_c Threads::Threads)

--- a/bindings/c/CMakeLists.txt
+++ b/bindings/c/CMakeLists.txt
@@ -71,17 +71,27 @@ if(NOT WIN32)
     test/mako/mako.h
     test/mako/utils.c
     test/mako/utils.h)
+  find_package(Threads REQUIRED)
+  add_subdirectory(test/unit/third_party)
+  set(UNIT_TEST_SRCS
+    test/unit/unit_tests.cpp
+    test/unit/fdb_api.cpp
+    test/unit/fdb_api.hpp)
 
   if(OPEN_FOR_IDE)
     add_library(fdb_c_performance_test OBJECT test/performance_test.c test/test.h)
     add_library(fdb_c_ryw_benchmark OBJECT test/ryw_benchmark.c test/test.h)
     add_library(fdb_c_txn_size_test OBJECT test/txn_size_test.c test/test.h)
     add_library(mako OBJECT ${MAKO_SRCS})
+    add_library(fdb_c_setup_tests OBJECT test/unit/setup_tests.cpp)
+    add_library(fdb_c_unit_tests OBJECT ${UNIT_TEST_SRCS})
   else()
     add_executable(fdb_c_performance_test test/performance_test.c test/test.h)
     add_executable(fdb_c_ryw_benchmark test/ryw_benchmark.c test/test.h)
     add_executable(fdb_c_txn_size_test test/txn_size_test.c test/test.h)
     add_executable(mako ${MAKO_SRCS})
+    add_executable(fdb_c_setup_tests test/unit/setup_tests.cpp)
+    add_executable(fdb_c_unit_tests ${UNIT_TEST_SRCS})
     strip_debug_symbols(fdb_c_performance_test)
     strip_debug_symbols(fdb_c_ryw_benchmark)
     strip_debug_symbols(fdb_c_txn_size_test)
@@ -89,9 +99,24 @@ if(NOT WIN32)
   target_link_libraries(fdb_c_performance_test PRIVATE fdb_c)
   target_link_libraries(fdb_c_ryw_benchmark PRIVATE fdb_c)
   target_link_libraries(fdb_c_txn_size_test PRIVATE fdb_c)
+
+  target_include_directories(fdb_c_setup_tests PUBLIC ${DOCTEST_INCLUDE_DIR})
+  target_include_directories(fdb_c_unit_tests PUBLIC ${DOCTEST_INCLUDE_DIR})
+  target_link_libraries(fdb_c_setup_tests PRIVATE fdb_c Threads::Threads)
+  target_link_libraries(fdb_c_unit_tests PRIVATE fdb_c Threads::Threads)
+
   # do not set RPATH for mako
   set_property(TARGET mako PROPERTY SKIP_BUILD_RPATH TRUE)
   target_link_libraries(mako PRIVATE fdb_c)
+
+  add_fdbclient_test(
+    NAME fdb_c_setup_tests
+    COMMAND $<TARGET_FILE:fdb_c_setup_tests>)
+  add_fdbclient_test(
+    NAME fdb_c_unit_tests
+    COMMAND $<TARGET_FILE:fdb_c_unit_tests>
+            @CLUSTER_FILE@
+            fdb)
 endif()
 
 set(c_workloads_srcs

--- a/bindings/c/test/unit/fdb_api.cpp
+++ b/bindings/c/test/unit/fdb_api.cpp
@@ -1,0 +1,219 @@
+/*
+ * fdb_api.cpp
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2020 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "fdb_api.hpp"
+
+#include <iostream>
+
+namespace fdb {
+
+// Future
+
+Future::~Future() {
+  fdb_future_destroy(future_);
+}
+
+bool Future::is_ready() {
+  return fdb_future_is_ready(future_);
+}
+
+[[nodiscard]] fdb_error_t Future::block_until_ready() {
+  return fdb_future_block_until_ready(future_);
+}
+
+[[nodiscard]] fdb_error_t Future::set_callback(FDBCallback callback,
+                                               void* callback_parameter) {
+  return fdb_future_set_callback(future_, callback, callback_parameter);
+}
+
+[[nodiscard]] fdb_error_t Future::get_error() {
+  return fdb_future_get_error(future_);
+}
+
+void Future::release_memory() {
+  fdb_future_release_memory(future_);
+}
+
+void Future::cancel() {
+  fdb_future_cancel(future_);
+}
+
+// Int64Future
+
+[[nodiscard]] fdb_error_t Int64Future::get(int64_t* out) {
+  return fdb_future_get_int64(future_, out);
+}
+
+// ValueFuture
+
+[[nodiscard]] fdb_error_t ValueFuture::get(fdb_bool_t* out_present,
+                                                 const uint8_t** out_value,
+                                                 int* out_value_length) {
+  return fdb_future_get_value(future_, out_present, out_value,
+                              out_value_length);
+}
+
+// KeyFuture
+
+[[nodiscard]] fdb_error_t KeyFuture::get(const uint8_t** out_key,
+                                             int* out_key_length) {
+  return fdb_future_get_key(future_, out_key, out_key_length);
+}
+
+// StringArrayFuture
+
+[[nodiscard]] fdb_error_t StringArrayFuture::get(const char*** out_strings,
+                                                 int* out_count) {
+  return fdb_future_get_string_array(future_, out_strings, out_count);
+}
+
+// KeyValueArrayFuture
+
+[[nodiscard]] fdb_error_t KeyValueArrayFuture::get(const FDBKeyValue** out_kv,
+                                                   int* out_count,
+                                                   fdb_bool_t* out_more) {
+  return fdb_future_get_keyvalue_array(future_, out_kv, out_count, out_more);
+}
+
+// Transaction
+
+Transaction::Transaction(FDBDatabase* db) {
+  if (fdb_error_t err = fdb_database_create_transaction(db, &tr_)) {
+    std::cerr << fdb_get_error(err) << std::endl;
+    std::abort();
+  }
+}
+
+Transaction::~Transaction() {
+  fdb_transaction_destroy(tr_);
+}
+
+void Transaction::reset() {
+  fdb_transaction_reset(tr_);
+}
+
+void Transaction::cancel() {
+  fdb_transaction_cancel(tr_);
+}
+
+[[nodiscard]] fdb_error_t Transaction::set_option(FDBTransactionOption option,
+                                                  const uint8_t* value,
+                                                  int value_length) {
+  return fdb_transaction_set_option(tr_, option, value, value_length);
+}
+
+void Transaction::set_read_version(int64_t version) {
+  fdb_transaction_set_read_version(tr_, version);
+}
+
+Int64Future Transaction::get_read_version() {
+  return Int64Future(fdb_transaction_get_read_version(tr_));
+}
+
+Int64Future Transaction::get_approximate_size() {
+  return Int64Future(fdb_transaction_get_approximate_size(tr_));
+}
+
+ValueFuture Transaction::get(const uint8_t* key_name, int key_name_length,
+                             fdb_bool_t snapshot) {
+  return ValueFuture(fdb_transaction_get(tr_, key_name, key_name_length,
+                                         snapshot));
+}
+
+KeyFuture Transaction::get_key(const uint8_t* key_name, int key_name_length,
+                                fdb_bool_t or_equal, int offset,
+                                fdb_bool_t snapshot) {
+  return KeyFuture(fdb_transaction_get_key(tr_, key_name, key_name_length,
+                                           or_equal, offset, snapshot));
+}
+
+StringArrayFuture Transaction::get_addresses_for_key(const uint8_t* key_name,
+                                                     int key_name_length) {
+  return StringArrayFuture(fdb_transaction_get_addresses_for_key(tr_, key_name,
+                           key_name_length));
+}
+
+KeyValueArrayFuture Transaction::get_range(const uint8_t* begin_key_name,
+                                           int begin_key_name_length,
+                                           fdb_bool_t begin_or_equal,
+                                           int begin_offset,
+                                           const uint8_t* end_key_name,
+                                           int end_key_name_length,
+                                           fdb_bool_t end_or_equal,
+                                           int end_offset,
+                                           int limit, int target_bytes,
+                                           FDBStreamingMode mode,
+                                           int iteration,
+                                           fdb_bool_t snapshot,
+                                           fdb_bool_t reverse) {
+  return KeyValueArrayFuture(fdb_transaction_get_range(tr_, begin_key_name,
+                                                       begin_key_name_length,
+                                                       begin_or_equal,
+                                                       begin_offset,
+                                                       end_key_name,
+                                                       end_key_name_length,
+                                                       end_or_equal,
+                                                       end_offset,
+                                                       limit, target_bytes,
+                                                       mode, iteration,
+                                                       snapshot, reverse));
+}
+
+EmptyFuture Transaction::watch(const uint8_t* key_name, int key_name_length) {
+  return EmptyFuture(fdb_transaction_watch(tr_, key_name, key_name_length));
+}
+
+EmptyFuture Transaction::commit() {
+  return EmptyFuture(fdb_transaction_commit(tr_));
+}
+
+EmptyFuture Transaction::on_error(fdb_error_t err) {
+  return EmptyFuture(fdb_transaction_on_error(tr_, err));
+}
+
+void Transaction::clear(const uint8_t* key_name, int key_name_length) {
+  return fdb_transaction_clear(tr_, key_name, key_name_length);
+}
+
+void Transaction::clear_range(const uint8_t* begin_key_name,
+                             int begin_key_name_length,
+                             const uint8_t* end_key_name,
+                             int end_key_name_length) {
+  fdb_transaction_clear_range(tr_, begin_key_name, begin_key_name_length,
+                              end_key_name, end_key_name_length);
+}
+
+void Transaction::set(const uint8_t* key_name, int key_name_length,
+                      const uint8_t* value, int value_length) {
+  fdb_transaction_set(tr_, key_name, key_name_length, value, value_length);
+}
+
+void Transaction::atomic_op(const uint8_t* key_name, int key_name_length,
+                            const uint8_t* param, int param_length,
+                            FDBMutationType operationType) {
+  return fdb_transaction_atomic_op(tr_, key_name, key_name_length, param,
+                                   param_length, operationType);
+}
+
+[[nodiscard]] fdb_error_t Transaction::get_committed_version(int64_t* out_version) {
+  return fdb_transaction_get_committed_version(tr_, out_version);
+}
+
+}  // namespace fdb

--- a/bindings/c/test/unit/fdb_api.cpp
+++ b/bindings/c/test/unit/fdb_api.cpp
@@ -135,10 +135,9 @@ KeyFuture Transaction::get_versionstamp() {
   return KeyFuture(fdb_transaction_get_versionstamp(tr_));
 }
 
-ValueFuture Transaction::get(const uint8_t* key_name, int key_name_length,
-                             fdb_bool_t snapshot) {
-  return ValueFuture(fdb_transaction_get(tr_, key_name, key_name_length,
-                                         snapshot));
+ValueFuture Transaction::get(std::string_view key, fdb_bool_t snapshot) {
+  return ValueFuture(fdb_transaction_get(tr_, (const uint8_t*)key.data(),
+                                         key.size(), snapshot));
 }
 
 KeyFuture Transaction::get_key(const uint8_t* key_name, int key_name_length,
@@ -148,10 +147,9 @@ KeyFuture Transaction::get_key(const uint8_t* key_name, int key_name_length,
                                            or_equal, offset, snapshot));
 }
 
-StringArrayFuture Transaction::get_addresses_for_key(const uint8_t* key_name,
-                                                     int key_name_length) {
-  return StringArrayFuture(fdb_transaction_get_addresses_for_key(tr_, key_name,
-                           key_name_length));
+StringArrayFuture Transaction::get_addresses_for_key(std::string_view key) {
+  return StringArrayFuture(fdb_transaction_get_addresses_for_key(tr_,
+                           (const uint8_t*)key.data(), key.size()));
 }
 
 KeyValueArrayFuture Transaction::get_range(const uint8_t* begin_key_name,
@@ -161,11 +159,10 @@ KeyValueArrayFuture Transaction::get_range(const uint8_t* begin_key_name,
                                            const uint8_t* end_key_name,
                                            int end_key_name_length,
                                            fdb_bool_t end_or_equal,
-                                           int end_offset,
-                                           int limit, int target_bytes,
+                                           int end_offset, int limit,
+                                           int target_bytes,
                                            FDBStreamingMode mode,
-                                           int iteration,
-                                           fdb_bool_t snapshot,
+                                           int iteration, fdb_bool_t snapshot,
                                            fdb_bool_t reverse) {
   return KeyValueArrayFuture(fdb_transaction_get_range(tr_, begin_key_name,
                                                        begin_key_name_length,
@@ -180,8 +177,8 @@ KeyValueArrayFuture Transaction::get_range(const uint8_t* begin_key_name,
                                                        snapshot, reverse));
 }
 
-EmptyFuture Transaction::watch(const uint8_t* key_name, int key_name_length) {
-  return EmptyFuture(fdb_transaction_watch(tr_, key_name, key_name_length));
+EmptyFuture Transaction::watch(std::string_view key) {
+  return EmptyFuture(fdb_transaction_watch(tr_, (const uint8_t*)key.data(), key.size()));
 }
 
 EmptyFuture Transaction::commit() {
@@ -192,28 +189,26 @@ EmptyFuture Transaction::on_error(fdb_error_t err) {
   return EmptyFuture(fdb_transaction_on_error(tr_, err));
 }
 
-void Transaction::clear(const uint8_t* key_name, int key_name_length) {
-  return fdb_transaction_clear(tr_, key_name, key_name_length);
+void Transaction::clear(std::string_view key) {
+  return fdb_transaction_clear(tr_, (const uint8_t*)key.data(), key.size());
 }
 
-void Transaction::clear_range(const uint8_t* begin_key_name,
-                              int begin_key_name_length,
-                              const uint8_t* end_key_name,
-                              int end_key_name_length) {
-  fdb_transaction_clear_range(tr_, begin_key_name, begin_key_name_length,
-                              end_key_name, end_key_name_length);
+void Transaction::clear_range(std::string_view begin_key,
+                              std::string_view end_key) {
+  fdb_transaction_clear_range(tr_, (const uint8_t*)begin_key.data(),
+                              begin_key.size(), (const uint8_t*)end_key.data(),
+                              end_key.size());
 }
 
-void Transaction::set(const uint8_t* key_name, int key_name_length,
-                      const uint8_t* value, int value_length) {
-  fdb_transaction_set(tr_, key_name, key_name_length, value, value_length);
+void Transaction::set(std::string_view key, std::string_view value) {
+  fdb_transaction_set(tr_, (const uint8_t*)key.data(), key.size(),
+                      (const uint8_t*)value.data(), value.size());
 }
 
-void Transaction::atomic_op(const uint8_t* key_name, int key_name_length,
-                            const uint8_t* param, int param_length,
-                            FDBMutationType operationType) {
-  return fdb_transaction_atomic_op(tr_, key_name, key_name_length, param,
-                                   param_length, operationType);
+void Transaction::atomic_op(std::string_view key, const uint8_t* param,
+                            int param_length, FDBMutationType operationType) {
+  return fdb_transaction_atomic_op(tr_, (const uint8_t*)key.data(), key.size(),
+                                   param, param_length, operationType);
 }
 
 [[nodiscard]] fdb_error_t Transaction::get_committed_version(int64_t* out_version) {

--- a/bindings/c/test/unit/fdb_api.cpp
+++ b/bindings/c/test/unit/fdb_api.cpp
@@ -64,8 +64,8 @@ void Future::cancel() {
 // ValueFuture
 
 [[nodiscard]] fdb_error_t ValueFuture::get(fdb_bool_t* out_present,
-                                                 const uint8_t** out_value,
-                                                 int* out_value_length) {
+                                           const uint8_t** out_value,
+                                           int* out_value_length) {
   return fdb_future_get_value(future_, out_present, out_value,
                               out_value_length);
 }
@@ -73,7 +73,7 @@ void Future::cancel() {
 // KeyFuture
 
 [[nodiscard]] fdb_error_t KeyFuture::get(const uint8_t** out_key,
-                                             int* out_key_length) {
+                                         int* out_key_length) {
   return fdb_future_get_key(future_, out_key, out_key_length);
 }
 
@@ -131,6 +131,10 @@ Int64Future Transaction::get_approximate_size() {
   return Int64Future(fdb_transaction_get_approximate_size(tr_));
 }
 
+KeyFuture Transaction::get_versionstamp() {
+  return KeyFuture(fdb_transaction_get_versionstamp(tr_));
+}
+
 ValueFuture Transaction::get(const uint8_t* key_name, int key_name_length,
                              fdb_bool_t snapshot) {
   return ValueFuture(fdb_transaction_get(tr_, key_name, key_name_length,
@@ -138,8 +142,8 @@ ValueFuture Transaction::get(const uint8_t* key_name, int key_name_length,
 }
 
 KeyFuture Transaction::get_key(const uint8_t* key_name, int key_name_length,
-                                fdb_bool_t or_equal, int offset,
-                                fdb_bool_t snapshot) {
+                               fdb_bool_t or_equal, int offset,
+                               fdb_bool_t snapshot) {
   return KeyFuture(fdb_transaction_get_key(tr_, key_name, key_name_length,
                                            or_equal, offset, snapshot));
 }
@@ -193,9 +197,9 @@ void Transaction::clear(const uint8_t* key_name, int key_name_length) {
 }
 
 void Transaction::clear_range(const uint8_t* begin_key_name,
-                             int begin_key_name_length,
-                             const uint8_t* end_key_name,
-                             int end_key_name_length) {
+                              int begin_key_name_length,
+                              const uint8_t* end_key_name,
+                              int end_key_name_length) {
   fdb_transaction_clear_range(tr_, begin_key_name, begin_key_name_length,
                               end_key_name, end_key_name_length);
 }

--- a/bindings/c/test/unit/fdb_api.cpp
+++ b/bindings/c/test/unit/fdb_api.cpp
@@ -215,4 +215,15 @@ void Transaction::atomic_op(std::string_view key, const uint8_t* param,
   return fdb_transaction_get_committed_version(tr_, out_version);
 }
 
+fdb_error_t Transaction::add_conflict_range(std::string_view begin_key,
+                                            std::string_view end_key,
+                                            FDBConflictRangeType type) {
+  return fdb_transaction_add_conflict_range(tr_,
+                                            (const uint8_t*)begin_key.data(),
+                                            begin_key.size(),
+                                            (const uint8_t*)end_key.data(),
+                                            end_key.size(),
+                                            type);
+}
+
 }  // namespace fdb

--- a/bindings/c/test/unit/fdb_api.hpp
+++ b/bindings/c/test/unit/fdb_api.hpp
@@ -43,6 +43,7 @@
 #include <foundationdb/fdb_c.h>
 
 #include <string>
+#include <string_view>
 
 namespace fdb {
 
@@ -180,10 +181,8 @@ class Transaction final {
   // any versionstamp operations in the transaction.
   KeyFuture get_versionstamp();
 
-  // Returns a future which will be set to the value of `key_name` in the
-  // database.
-  ValueFuture get(const uint8_t* key_name, int key_name_length,
-                  fdb_bool_t snapshot);
+  // Returns a future which will be set to the value of `key` in the database.
+  ValueFuture get(std::string_view key, fdb_bool_t snapshot);
 
   // Returns a future which will be set to the key in the database matching the
   // passed key selector.
@@ -191,8 +190,7 @@ class Transaction final {
                     fdb_bool_t or_equal, int offset, fdb_bool_t snapshot);
 
   // Returns a future which will be set to an array of strings.
-  StringArrayFuture get_addresses_for_key(const uint8_t* key_name,
-                                          int key_name_length);
+  StringArrayFuture get_addresses_for_key(std::string_view key);
 
   // Returns a future which will be set to an FDBKeyValue array.
   KeyValueArrayFuture get_range(const uint8_t* begin_key_name,
@@ -207,7 +205,7 @@ class Transaction final {
 
   // Wrapper around fdb_transaction_watch. Returns a future representing an
   // empty value.
-  EmptyFuture watch(const uint8_t* key_name, int key_name_length);
+  EmptyFuture watch(std::string_view key);
 
   // Wrapper around fdb_transaction_commit. Returns a future representing an
   // empty value.
@@ -218,19 +216,16 @@ class Transaction final {
   EmptyFuture on_error(fdb_error_t err);
 
   // Wrapper around fdb_transaction_clear.
-  void clear(const uint8_t* key_name, int key_name_length);
+  void clear(std::string_view key);
 
   // Wrapper around fdb_transaction_clear_range.
-  void clear_range(const uint8_t* begin_key_name, int begin_key_name_length,
-                   const uint8_t* end_key_name, int end_key_name_length);
+  void clear_range(std::string_view begin_key, std::string_view end_key);
 
   // Wrapper around fdb_transaction_set.
-  void set(const uint8_t* key_name, int key_name_length, const uint8_t* value,
-           int value_length);
+  void set(std::string_view key, std::string_view value);
 
   // Wrapper around fdb_transaction_atomic_op.
-  void atomic_op(const uint8_t* key_name, int key_name_length,
-                 const uint8_t* param, int param_length,
+  void atomic_op(std::string_view key, const uint8_t* param, int param_length,
                  FDBMutationType operationType);
 
   // Wrapper around fdb_transaction_get_committed_version.

--- a/bindings/c/test/unit/fdb_api.hpp
+++ b/bindings/c/test/unit/fdb_api.hpp
@@ -23,7 +23,7 @@
 //
 //   FDBTransaction *tr;
 //   fdb_database_create_transaction(db, &tr);
-//   FDBFuture *f = fdb_transaction_get(tr, (const uint8_t *)"foo", 3, true);
+//   FDBFuture *f = fdb_transaction_get(tr, (const uint8_t*)"foo", 3, true);
 //   fdb_future_block_until_ready(f);
 //   fdb_future_get_value(f, ...);
 //   fdb_future_destroy(f);
@@ -32,7 +32,7 @@
 // Using the wrapper classes defined here, it will instead look like:
 //
 //   fdb::Transaction tr(db);
-//   fdb::ValueFuture f = tr.get((const uint8_t *)"foo", 3, true);
+//   fdb::ValueFuture f = tr.get((const uint8_t*)"foo", 3, true);
 //   f.block_until_ready();
 //   f.get_value(f, ...);
 //

--- a/bindings/c/test/unit/fdb_api.hpp
+++ b/bindings/c/test/unit/fdb_api.hpp
@@ -231,6 +231,11 @@ class Transaction final {
   // Wrapper around fdb_transaction_get_committed_version.
   fdb_error_t get_committed_version(int64_t* out_version);
 
+  // Wrapper around fdb_transaction_add_conflict_range.
+  fdb_error_t add_conflict_range(std::string_view begin_key,
+                                 std::string_view end_key,
+                                 FDBConflictRangeType type);
+
  private:
   FDBTransaction* tr_;
 };

--- a/bindings/c/test/unit/fdb_api.hpp
+++ b/bindings/c/test/unit/fdb_api.hpp
@@ -1,0 +1,238 @@
+/*
+ * fdb_api.hpp
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2020 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// A collection of C++ classes to wrap the C API to improve memory management
+// and add types to futures. Using the old C API may look something like:
+//
+//   FDBTransaction *tr;
+//   fdb_database_create_transaction(db, &tr);
+//   FDBFuture *f = fdb_transaction_get(tr, (const uint8_t *)"foo", 3, true);
+//   fdb_future_block_until_ready(f);
+//   fdb_future_get_value(f, ...);
+//   fdb_future_destroy(f);
+//   fdb_transaction_destroy(tr);
+//
+// Using the wrapper classes defined here, it will instead look like:
+//
+//   fdb::Transaction tr(db);
+//   fdb::ValueFuture f = tr.get((const uint8_t *)"foo", 3, true);
+//   f.block_until_ready();
+//   f.get_value(f, ...);
+//
+
+#define FDB_API_VERSION 620
+#include <foundationdb/fdb_c.h>
+
+#include <string>
+
+namespace fdb {
+
+// Wrapper parent class to manage memory of an FDBFuture pointer. Cleans up
+// FDBFuture when this instance goes out of scope.
+class Future {
+ public:
+  virtual ~Future() = 0;
+
+  // Wrapper around fdb_future_is_ready.
+  bool is_ready();
+  // Wrapper around fdb_future_block_until_ready.
+  fdb_error_t block_until_ready();
+  // Wrapper around fdb_future_set_callback.
+  fdb_error_t set_callback(FDBCallback callback,
+                                   void* callback_parameter);
+  // Wrapper around fdb_future_get_error.
+  fdb_error_t get_error();
+  // Wrapper around fdb_future_release_memory.
+  void release_memory();
+  // Wrapper around fdb_future_cancel.
+  void cancel();
+
+  // Conversion operator to allow Future instances to work interchangeably as
+  // an FDBFuture object.
+  // operator FDBFuture* () const {
+  //   return future_;
+  // }
+
+ protected:
+  Future(FDBFuture *f) : future_(f) {}
+  FDBFuture* future_;
+};
+
+
+class Int64Future : public Future {
+ public:
+   // Call this function instead of fdb_future_get_int64 when using the
+   // Int64Future type. It's behavior is identical to fdb_future_get_int64.
+  fdb_error_t get(int64_t* out);
+  
+ private:
+  friend class Transaction;
+  Int64Future(FDBFuture* f) : Future(f) {}
+};
+
+
+class KeyFuture : public Future {
+ public:
+   // Call this function instead of fdb_future_get_key when using the KeyFuture
+   // type. It's behavior is identical to fdb_future_get_key.
+  fdb_error_t get(const uint8_t** out_key, int* out_key_length);
+
+ private:
+  friend class Transaction;
+  KeyFuture(FDBFuture* f) : Future(f) {}
+};
+
+
+class ValueFuture : public Future {
+ public:
+   // Call this function instead of fdb_future_get_value when using the
+   // ValueFuture type. It's behavior is identical to fdb_future_get_value.
+  fdb_error_t get(fdb_bool_t* out_present, const uint8_t** out_value,
+                  int* out_value_length);
+
+ private:
+  friend class Transaction;
+  ValueFuture(FDBFuture* f) : Future(f) {}
+};
+
+
+class StringArrayFuture : public Future {
+ public:
+   // Call this function instead of fdb_future_get_string_array when using the
+   // StringArrayFuture type. It's behavior is identical to
+   // fdb_future_get_string_array.
+  fdb_error_t get(const char*** out_strings, int* out_count);
+
+ private:
+  friend class Transaction;
+  StringArrayFuture(FDBFuture* f) : Future(f) {}
+};
+
+
+class KeyValueArrayFuture : public Future {
+ public:
+   // Call this function instead of fdb_future_get_keyvalue_array when using
+   // the KeyValueArrayFuture type. It's behavior is identical to
+   // fdb_future_get_keyvalue_array.
+  fdb_error_t get(const FDBKeyValue** out_kv, int* out_count,
+                  fdb_bool_t* out_more);
+
+ private:
+  friend class Transaction;
+  KeyValueArrayFuture(FDBFuture* f) : Future(f) {}
+};
+
+
+class EmptyFuture : public Future {
+ private:
+  friend class Transaction;
+  EmptyFuture(FDBFuture* f) : Future(f) {}
+};
+
+
+// Wrapper around FDBTransaction, providing the same set of calls as the C API.
+// Handles cleanup of memory, removing the need to call
+// fdb_transaction_destroy.
+class Transaction final {
+ public:
+  // Given an FDBDatabase, initializes a new transaction.
+  Transaction(FDBDatabase* db);
+  ~Transaction();
+
+  // Wrapper around fdb_transaction_reset.
+  void reset();
+
+  // Wrapper around fdb_transaction_cancel.
+  void cancel();
+
+  // Wrapper around fdb_transaction_set_option.
+  fdb_error_t set_option(FDBTransactionOption option, const uint8_t* value,
+                         int value_length);
+
+  // Wrapper around fdb_transaction_set_read_version.
+  void set_read_version(int64_t version);
+
+  // Returns a future which will be set to the transaction read version.
+  Int64Future get_read_version();
+
+  // Returns a future which will be set to the approximate transaction size so far.
+  Int64Future get_approximate_size();
+
+  // Returns a future which will be set to the value of `key_name` in the
+  // database.
+  ValueFuture get(const uint8_t* key_name, int key_name_length,
+                  fdb_bool_t snapshot);
+
+  // Returns a future which will be set to the key in the database matching the
+  // passed key selector.
+  KeyFuture get_key(const uint8_t* key_name, int key_name_length,
+                    fdb_bool_t or_equal, int offset, fdb_bool_t snapshot);
+
+  // Returns a future which will be set to an array of strings.
+  StringArrayFuture get_addresses_for_key(const uint8_t* key_name,
+                                          int key_name_length);
+
+  // Returns a future which will be set to an FDBKeyValue array.
+  KeyValueArrayFuture get_range(const uint8_t* begin_key_name,
+                                int begin_key_name_length,
+                                fdb_bool_t begin_or_equal, int begin_offset,
+                                const uint8_t* end_key_name,
+                                int end_key_name_length,
+                                fdb_bool_t end_or_equal, int end_offset,
+                                int limit, int target_bytes,
+                                FDBStreamingMode mode, int iteration,
+                                fdb_bool_t snapshot, fdb_bool_t reverse);
+
+  // Wrapper around fdb_transaction_watch. Returns a future representing an
+  // empty value.
+  EmptyFuture watch(const uint8_t* key_name, int key_name_length);
+
+  // Wrapper around fdb_transaction_commit. Returns a future representing an
+  // empty value.
+  EmptyFuture commit();
+
+  // Wrapper around fdb_transaction_on_error. Returns a future representing an
+  // empty value.
+  EmptyFuture on_error(fdb_error_t err);
+
+  // Wrapper around fdb_transaction_clear.
+  void clear(const uint8_t* key_name, int key_name_length);
+
+  // Wrapper around fdb_transaction_clear_range.
+  void clear_range(const uint8_t* begin_key_name, int begin_key_name_length,
+                   const uint8_t* end_key_name, int end_key_name_length);
+
+  // Wrapper around fdb_transaction_set.
+  void set(const uint8_t* key_name, int key_name_length, const uint8_t* value,
+           int value_length);
+
+  // Wrapper around fdb_transaction_atomic_op.
+  void atomic_op(const uint8_t* key_name, int key_name_length,
+                 const uint8_t* param, int param_length,
+                 FDBMutationType operationType);
+
+  // Wrapper around fdb_transaction_get_committed_version.
+  fdb_error_t get_committed_version(int64_t* out_version);
+
+ private:
+  FDBTransaction* tr_;
+};
+
+}  // namespace fdb

--- a/bindings/c/test/unit/fdb_api.hpp
+++ b/bindings/c/test/unit/fdb_api.hpp
@@ -176,6 +176,10 @@ class Transaction final {
   // Returns a future which will be set to the approximate transaction size so far.
   Int64Future get_approximate_size();
 
+  // Returns a future which will be set to the versionstamp which was used by
+  // any versionstamp operations in the transaction.
+  KeyFuture get_versionstamp();
+
   // Returns a future which will be set to the value of `key_name` in the
   // database.
   ValueFuture get(const uint8_t* key_name, int key_name_length,

--- a/bindings/c/test/unit/fdb_api.hpp
+++ b/bindings/c/test/unit/fdb_api.hpp
@@ -55,8 +55,7 @@ class Future {
   // Wrapper around fdb_future_block_until_ready.
   fdb_error_t block_until_ready();
   // Wrapper around fdb_future_set_callback.
-  fdb_error_t set_callback(FDBCallback callback,
-                                   void* callback_parameter);
+  fdb_error_t set_callback(FDBCallback callback, void* callback_parameter);
   // Wrapper around fdb_future_get_error.
   fdb_error_t get_error();
   // Wrapper around fdb_future_release_memory.

--- a/bindings/c/test/unit/fdb_api.hpp
+++ b/bindings/c/test/unit/fdb_api.hpp
@@ -37,6 +37,8 @@
 //   f.get_value(f, ...);
 //
 
+#pragma once
+
 #define FDB_API_VERSION 620
 #include <foundationdb/fdb_c.h>
 

--- a/bindings/c/test/unit/setup_tests.cpp
+++ b/bindings/c/test/unit/setup_tests.cpp
@@ -1,0 +1,75 @@
+/*
+ * setup_tests.cpp
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2020 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Unit tests for API setup, network initialization functions from the FDB C API.
+
+#define FDB_API_VERSION 620
+#include <foundationdb/fdb_c.h>
+#include <iostream>
+#include <thread>
+
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include "doctest.h"
+
+void fdb_check(fdb_error_t e) {
+  if (e) {
+    std::cerr << fdb_get_error(e) << std::endl;
+    std::abort();
+  }
+}
+
+TEST_CASE("setup") {
+  fdb_error_t err;
+  // Version passed here must be <= FDB_API_VERSION
+  err = fdb_select_api_version(9000);
+  CHECK(err);
+
+  // Select current API version
+  fdb_check(fdb_select_api_version(620));
+
+  // Error to call again after a successful return
+  err = fdb_select_api_version(620);
+  CHECK(err);
+
+  CHECK(fdb_get_max_api_version() >= 620);
+
+  fdb_check(fdb_setup_network());
+  // Calling a second time should fail
+  err = fdb_setup_network();
+  CHECK(err);
+
+  struct Context {
+    bool called = false;
+  };
+  Context context;
+  fdb_check(fdb_add_network_thread_completion_hook(
+      [](void *param) {
+        auto *context = static_cast<Context *>(param);
+        context->called = true;
+      },
+      &context));
+
+  std::thread network_thread{&fdb_run_network};
+
+  CHECK(!context.called);
+  fdb_check(fdb_stop_network());
+  network_thread.join();
+  CHECK(context.called);
+}

--- a/bindings/c/test/unit/third_party/CMakeLists.txt
+++ b/bindings/c/test/unit/third_party/CMakeLists.txt
@@ -6,8 +6,8 @@ ExternalProject_Add(
     doctest
     PREFIX ${CMAKE_BINARY_DIR}/doctest
     GIT_REPOSITORY https://github.com/onqtam/doctest.git
+    GIT_TAG 1c8da00c978c19e00a434b2b1f854fcffc9fba35 # v2.4.0
     TIMEOUT 10
-    UPDATE_COMMAND ${GIT_EXECUTABLE} pull
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ""
     INSTALL_COMMAND ""

--- a/bindings/c/test/unit/third_party/CMakeLists.txt
+++ b/bindings/c/test/unit/third_party/CMakeLists.txt
@@ -1,0 +1,18 @@
+# Download doctest repo.
+include(ExternalProject)
+find_package(Git REQUIRED)
+
+ExternalProject_Add(
+    doctest
+    PREFIX ${CMAKE_BINARY_DIR}/doctest
+    GIT_REPOSITORY https://github.com/onqtam/doctest.git
+    TIMEOUT 10
+    UPDATE_COMMAND ${GIT_EXECUTABLE} pull
+    CONFIGURE_COMMAND ""
+    BUILD_COMMAND ""
+    INSTALL_COMMAND ""
+    LOG_DOWNLOAD ON
+)
+
+ExternalProject_Get_Property(doctest source_dir)
+set(DOCTEST_INCLUDE_DIR ${source_dir}/doctest CACHE INTERNAL "Path to include folder for doctest")

--- a/bindings/c/test/unit/unit_tests.cpp
+++ b/bindings/c/test/unit/unit_tests.cpp
@@ -60,10 +60,6 @@ std::string key(const std::string& key) {
   return prefix + key;
 }
 
-std::size_t key_size(const std::string& key) {
-  return (prefix + key).size();
-}
-
 // Blocks until the given future is ready, returning an error code if there was
 // an issue.
 fdb_error_t wait_future(fdb::Future &f) {
@@ -355,7 +351,7 @@ TEST_CASE("fdb_future_get_key") {
     fdb::KeyFuture f1 = tr.get_key(
         FDB_KEYSEL_FIRST_GREATER_THAN(
           (const uint8_t *)key("a").c_str(),
-          key_size("a")
+          key("a").size()
         ), /* snapshot */ false);
 
     const uint8_t *key;
@@ -443,11 +439,11 @@ TEST_CASE("fdb_future_get_keyvalue_array") {
     fdb::KeyValueArrayFuture f1 = tr.get_range(
         FDB_KEYSEL_FIRST_GREATER_OR_EQUAL(
           (const uint8_t *)key("a").c_str(),
-          key_size("a")
+          key("a").size()
         ),
         FDB_KEYSEL_LAST_LESS_OR_EQUAL(
           (const uint8_t *)key("c").c_str(),
-          key_size("c")
+          key("c").size()
         ) + 1, /* limit */ 0, /* target_bytes */ 0,
         /* FDBStreamingMode */ FDB_STREAMING_MODE_WANT_ALL, /* iteration */ 0,
         /* snapshot */ false, /* reverse */ 0);
@@ -834,11 +830,11 @@ TEST_CASE("fdb_transaction_get_range reverse") {
     auto result = get_range(
         tr, FDB_KEYSEL_FIRST_GREATER_OR_EQUAL(
           (const uint8_t*)key("a").c_str(),
-          key_size("a")
+          key("a").size()
         ),
         FDB_KEYSEL_LAST_LESS_OR_EQUAL(
           (const uint8_t*)key("d").c_str(),
-          key_size("d")
+          key("d").size()
         ) + 1, /* limit */ 0, /* target_bytes */ 0,
         /* FDBStreamingMode */ FDB_STREAMING_MODE_WANT_ALL, /* iteration */ 0,
         /* snapshot */ false, /* reverse */ 1);
@@ -880,11 +876,11 @@ TEST_CASE("fdb_transaction_get_range limit") {
     auto result = get_range(
         tr, FDB_KEYSEL_FIRST_GREATER_OR_EQUAL(
           (const uint8_t*)key("a").c_str(),
-          key_size("a")
+          key("a").size()
         ),
         FDB_KEYSEL_LAST_LESS_OR_EQUAL(
           (const uint8_t*)key("d").c_str(),
-          key_size("d")
+          key("d").size()
         ) + 1, /* limit */ 2, /* target_bytes */ 0,
         /* FDBStreamingMode */ FDB_STREAMING_MODE_WANT_ALL, /* iteration */ 0,
         /* snapshot */ false, /* reverse */ 0);
@@ -918,11 +914,11 @@ TEST_CASE("fdb_transaction_get_range FDB_STREAMING_MODE_EXACT") {
     auto result = get_range(
         tr, FDB_KEYSEL_FIRST_GREATER_OR_EQUAL(
           (const uint8_t*)key("a").c_str(),
-          key_size("a")
+          key("a").size()
         ),
         FDB_KEYSEL_LAST_LESS_OR_EQUAL(
           (const uint8_t*)key("d").c_str(),
-          key_size("d")
+          key("d").size()
         ) + 1, /* limit */ 3, /* target_bytes */ 0,
         /* FDBStreamingMode */ FDB_STREAMING_MODE_EXACT, /* iteration */ 0,
         /* snapshot */ false, /* reverse */ 0);

--- a/bindings/c/test/unit/unit_tests.cpp
+++ b/bindings/c/test/unit/unit_tests.cpp
@@ -120,8 +120,7 @@ void insert_data(FDBDatabase *db,
     fdb_error_t err = wait_future(f1);
     if (err) {
       fdb::EmptyFuture f2 = tr.on_error(err);
-      fdb_error_t err2 = wait_future(f2);
-      fdb_check(err2);
+      fdb_check(wait_future(f2));
       continue;
     }
     break;
@@ -176,8 +175,7 @@ void get_range(fdb::Transaction& tr, const uint8_t* begin_key_name,
     fdb_error_t err = wait_future(f1);
     if (err) {
       fdb::EmptyFuture f2 = tr.on_error(err);
-      fdb_error_t err2 = wait_future(f2);
-      fdb_check(err2);
+      fdb_check(wait_future(f2));
       continue;
     }
 
@@ -202,7 +200,7 @@ struct Event {
     cv.notify_all();
   }
 
-private:
+ private:
   std::mutex mutex;
   std::condition_variable cv;
   bool complete = false;
@@ -273,8 +271,7 @@ TEST_CASE("fdb_future_get_int64") {
     fdb_error_t err = wait_future(f1);
     if (err) {
       fdb::EmptyFuture f2 = tr.on_error(err);
-      fdb_error_t err2 = wait_future(f2);
-      fdb_check(err2);
+      fdb_check(wait_future(f2));
       continue;
     }
 
@@ -302,8 +299,7 @@ TEST_CASE("fdb_future_get_key") {
     fdb_error_t err = wait_future(f1);
     if (err) {
       fdb::EmptyFuture f2 = tr.on_error(err);
-      fdb_error_t err2 = wait_future(f2);
-      fdb_check(err2);
+      fdb_check(wait_future(f2));
       continue;
     }
 
@@ -331,8 +327,7 @@ TEST_CASE("fdb_future_get_value") {
     fdb_error_t err = wait_future(f1);
     if (err) {
       fdb::EmptyFuture f2 = tr.on_error(err);
-      fdb_error_t err2 = wait_future(f2);
-      fdb_check(err2);
+      fdb_check(wait_future(f2));
       continue;
     }
 
@@ -360,8 +355,7 @@ TEST_CASE("fdb_future_get_string_array") {
     fdb_error_t err = wait_future(f1);
     if (err) {
       fdb::EmptyFuture f2 = tr.on_error(err);
-      fdb_error_t err2 = wait_future(f2);
-      fdb_check(err2);
+      fdb_check(wait_future(f2));
       continue;
     }
 
@@ -394,8 +388,7 @@ TEST_CASE("fdb_future_get_keyvalue_array") {
     fdb_error_t err = wait_future(f1);
     if (err) {
       fdb::EmptyFuture f2 = tr.on_error(err);
-      fdb_error_t err2 = wait_future(f2);
-      fdb_check(err2);
+      fdb_check(wait_future(f2));
       continue;
     }
 
@@ -469,8 +462,7 @@ TEST_CASE("write system key") {
     fdb_error_t err = wait_future(f1);
     if (err) {
       fdb::EmptyFuture f2 = tr.on_error(err);
-      fdb_error_t err2 = wait_future(f2);
-      fdb_check(err2);
+      fdb_check(wait_future(f2));
       continue;
     }
     break;
@@ -500,8 +492,7 @@ TEST_CASE("fdb_transaction read_your_writes") {
     fdb_error_t err = wait_future(f1);
     if (err) {
       fdb::EmptyFuture f2 = tr.on_error(err);
-      fdb_error_t err2 = wait_future(f2);
-      fdb_check(err2);
+      fdb_check(wait_future(f2));
       continue;
     }
 
@@ -522,7 +513,7 @@ TEST_CASE("fdb_transaction_set_option") {
   clear_data(db);
 
   // SUBCASE("integer parameter value_length != 8") {
-  //   // If the option accepts an int as a paremeter, value_length must be set to
+  //   // If the option accepts an int as a parameter, value_length must be set to
   //   // 8.
   //   int64_t timeout = 100;
   //   CHECK(tr.set_option(FDB_TR_OPTION_TIMEOUT, (const uint8_t *)&timeout, 5));
@@ -539,8 +530,7 @@ TEST_CASE("fdb_transaction_set_option") {
       fdb_error_t err = wait_future(f1);
       if (err) {
         fdb::EmptyFuture f2 = tr.on_error(err);
-        fdb_error_t err2 = wait_future(f2);
-        fdb_check(err2);
+        fdb_check(wait_future(f2));
         continue;
       }
 
@@ -564,8 +554,7 @@ TEST_CASE("fdb_transaction_set_option") {
       fdb_error_t err = wait_future(f1);
       if (err) {
         fdb::EmptyFuture f2 = tr.on_error(err);
-        fdb_error_t err2 = wait_future(f2);
-        fdb_check(err2);
+        fdb_check(wait_future(f2));
         continue;
       }
 
@@ -592,8 +581,7 @@ TEST_CASE("fdb_transaction_set_option") {
       fdb_error_t err = wait_future(f1);
       if (err) {
         fdb::EmptyFuture f3 = tr.on_error(err);
-        fdb_error_t err2 = wait_future(f3);
-        fdb_check(err2);
+        fdb_check(wait_future(f3));
         continue;
       }
 
@@ -608,12 +596,7 @@ TEST_CASE("fdb_transaction_set_option") {
       err = wait_future(f2);
       if (err) {
         fdb::EmptyFuture f3 = tr.on_error(err);
-        fdb_error_t err2 = wait_future(f3);
-
-        if (err2) {
-          fdb_check(err2);
-          break;
-        }
+        fdb_check(wait_future(f3));
         continue;
       }
       fdb_check(f2.get(&out_present, (const uint8_t **)&val, &vallen));
@@ -759,8 +742,7 @@ TEST_CASE("fdb_transaction_clear") {
     fdb_error_t err = wait_future(f1);
     if (err) {
       fdb::EmptyFuture f2 = tr.on_error(err);
-      fdb_error_t err2 = wait_future(f2);
-      fdb_check(err2);
+      fdb_check(wait_future(f2));
       continue;
     }
     break;
@@ -790,8 +772,7 @@ TEST_CASE("fdb_transaction_clear") {
 //     fdb_error_t err = wait_future(f1);
 //     if (err) {
 //       fdb::EmptyFuture f2 = tr.on_error(err);
-//       fdb_error_t err2 = wait_future(f2);
-//       fdb_check(err2);
+//       fdb_check(wait_future(f2));
 //       continue;
 //     }
 //     break;
@@ -809,8 +790,7 @@ TEST_CASE("fdb_transaction_get_committed_version read_only") {
     fdb_error_t err = wait_future(f1);
     if (err) {
       fdb::EmptyFuture f2 = tr.on_error(err);
-      fdb_error_t err2 = wait_future(f2);
-      fdb_check(err2);
+      fdb_check(wait_future(f2));
       continue;
     }
 
@@ -830,8 +810,7 @@ TEST_CASE("fdb_transaction_get_committed_version") {
     fdb_error_t err = wait_future(f1);
     if (err) {
       fdb::EmptyFuture f2 = tr.on_error(err);
-      fdb_error_t err2 = wait_future(f2);
-      fdb_check(err2);
+      fdb_check(wait_future(f2));
       continue;
     }
 
@@ -852,8 +831,7 @@ TEST_CASE("fdb_transaction_get_committed_version") {
 //     fdb_error_t err = wait_future(f1);
 //     if (err) {
 //       fdb::EmptyFuture f2 = tr.on_error(err);
-//       fdb_error_t err2 = wait_future(f2);
-//       fdb_check(err2);
+//       fdb_check(wait_future(f2));
 //       continue;
 //     }
 //
@@ -918,8 +896,7 @@ TEST_CASE("fdb_transaction_watch") {
     fdb_error_t err = wait_future(f2);
     if (err) {
       fdb::EmptyFuture f3 = tr.on_error(err);
-      fdb_error_t err2 = wait_future(f3);
-      fdb_check(err2);
+      fdb_check(wait_future(f3));
       continue;
     }
 

--- a/bindings/c/test/unit/unit_tests.cpp
+++ b/bindings/c/test/unit/unit_tests.cpp
@@ -628,7 +628,7 @@ TEST_CASE("fdb_transaction_set_option timeout") {
   fdb_check(tr.set_option(FDB_TR_OPTION_TIMEOUT, (const uint8_t *)&timeout,
                           sizeof(timeout)));
 
-  fdb_error_t err;
+  fdb_error_t err = 0;
   while (!err) {
     fdb::ValueFuture f1 = tr.get((const uint8_t *)"foo", 3, /* snapshot */ false);
     err = wait_future(f1);
@@ -648,7 +648,7 @@ TEST_CASE("FDB_DB_OPTION_TRANSACTION_TIMEOUT") {
                                     sizeof(timeout)));
 
   fdb::Transaction tr(db);
-  fdb_error_t err;
+  fdb_error_t err = 0;
   while (!err) {
     fdb::ValueFuture f1 = tr.get((const uint8_t *)"foo", 3, /* snapshot */ false);
     err = wait_future(f1);

--- a/bindings/c/test/unit/unit_tests.cpp
+++ b/bindings/c/test/unit/unit_tests.cpp
@@ -36,8 +36,6 @@
 #include <vector>
 
 #define DOCTEST_CONFIG_IMPLEMENT
-#define DOCTEST_CONFIG_NO_EXCEPTIONS_BUT_WITH_ALL_ASSERTS
-#define DOCTEST_CONFIG_NO_POSIX_SIGNALS
 #include "doctest.h"
 
 #include "fdb_api.hpp"
@@ -1520,7 +1518,10 @@ TEST_CASE("fdb_transaction_cancel") {
   fdb_check(wait_future(f2));
 }
 
-TEST_CASE("block_from_callback") {
+// Feature not live yet, re-enable when checking if a blocking call is made
+// from the network thread is live.
+TEST_CASE("block_from_callback"
+		  * doctest::skip(true)) {
   fdb::Transaction tr(db);
   fdb::ValueFuture f1 = tr.get((const uint8_t *)"foo", 3, /*snapshot*/ true);
   struct Context {

--- a/bindings/c/test/unit/unit_tests.cpp
+++ b/bindings/c/test/unit/unit_tests.cpp
@@ -212,7 +212,7 @@ void clear_data(FDBDatabase *db) {
   insert_data(db, {});
 }
 
-struct Event {
+struct FdbEvent {
   void wait() {
     std::unique_lock<std::mutex> l(mutex);
     cv.wait(l, [this]() { return this->complete; });
@@ -233,7 +233,7 @@ TEST_CASE("fdb_future_set_callback") {
   fdb::Transaction tr(db);
   fdb::ValueFuture f1 = tr.get((const uint8_t *)"foo", 3, /*snapshot*/ true);
   struct Context {
-    Event event;
+    FdbEvent event;
   };
   Context context;
   fdb_check(f1.set_callback(+[](FDBFuture *f1, void *param) {
@@ -1478,7 +1478,7 @@ TEST_CASE("fdb_transaction_watch") {
   fdb::Transaction tr(db);
 
   struct Context {
-    Event event;
+    FdbEvent event;
   };
   Context context;
 
@@ -1524,7 +1524,7 @@ TEST_CASE("block_from_callback") {
   fdb::Transaction tr(db);
   fdb::ValueFuture f1 = tr.get((const uint8_t *)"foo", 3, /*snapshot*/ true);
   struct Context {
-    Event event;
+    FdbEvent event;
     fdb::Transaction *tr;
   };
   Context context;

--- a/bindings/c/test/unit/unit_tests.cpp
+++ b/bindings/c/test/unit/unit_tests.cpp
@@ -850,15 +850,13 @@ TEST_CASE("fdb_transaction_get_range reverse") {
       CHECK(result.more);
     }
 
-    // Read data in reverse order, keeping in mind that out_count might be
-    // smaller than requested.
+    // Read data in reverse order.
     auto it = data.rbegin();
-    std::advance(it, data.size() - result.kvs.size());
-    for (auto results_it = result.kvs.begin(); it != data.rend(); ++it) {
+    for (auto results_it = result.kvs.begin(); results_it != result.kvs.end(); ++results_it, ++it) {
       std::string data_key = it->first;
       std::string data_value = it->second;
 
-      auto [key, value] = *results_it++;
+      auto [key, value] = *results_it;
 
       CHECK(data_key.compare(key) == 0);
       CHECK(data[data_key].compare(value) == 0);

--- a/bindings/c/test/unit/unit_tests.cpp
+++ b/bindings/c/test/unit/unit_tests.cpp
@@ -1688,6 +1688,48 @@ TEST_CASE("fdb_transaction_cancel") {
   fdb_check(wait_future(f2));
 }
 
+TEST_CASE("fdb_error_predicate") {
+  CHECK(fdb_error_predicate(FDB_ERROR_PREDICATE_RETRYABLE, 1007)); // transaction_too_old
+  CHECK(fdb_error_predicate(FDB_ERROR_PREDICATE_RETRYABLE, 1020)); // not_committed
+  CHECK(fdb_error_predicate(FDB_ERROR_PREDICATE_RETRYABLE, 1038)); // database_locked
+
+  CHECK(!fdb_error_predicate(FDB_ERROR_PREDICATE_RETRYABLE, 1036)); // accessed_unreadable
+  CHECK(!fdb_error_predicate(FDB_ERROR_PREDICATE_RETRYABLE, 2000)); // client_invalid_operation
+  CHECK(!fdb_error_predicate(FDB_ERROR_PREDICATE_RETRYABLE, 2004)); // key_outside_legal_range
+  CHECK(!fdb_error_predicate(FDB_ERROR_PREDICATE_RETRYABLE, 2005)); // inverted_range
+  CHECK(!fdb_error_predicate(FDB_ERROR_PREDICATE_RETRYABLE, 2006)); // invalid_option_value
+  CHECK(!fdb_error_predicate(FDB_ERROR_PREDICATE_RETRYABLE, 2007)); // invalid_option
+  CHECK(!fdb_error_predicate(FDB_ERROR_PREDICATE_RETRYABLE, 2011)); // version_invalid
+  CHECK(!fdb_error_predicate(FDB_ERROR_PREDICATE_RETRYABLE, 2020)); // transaction_invalid_version
+  CHECK(!fdb_error_predicate(FDB_ERROR_PREDICATE_RETRYABLE, 2023)); // transaction_read_only
+  CHECK(!fdb_error_predicate(FDB_ERROR_PREDICATE_RETRYABLE, 2100)); // incompatible_protocol_version
+  CHECK(!fdb_error_predicate(FDB_ERROR_PREDICATE_RETRYABLE, 2101)); // transaction_too_large
+  CHECK(!fdb_error_predicate(FDB_ERROR_PREDICATE_RETRYABLE, 2102)); // key_too_large
+  CHECK(!fdb_error_predicate(FDB_ERROR_PREDICATE_RETRYABLE, 2103)); // value_too_large
+  CHECK(!fdb_error_predicate(FDB_ERROR_PREDICATE_RETRYABLE, 2108)); // unsupported_operation
+  CHECK(!fdb_error_predicate(FDB_ERROR_PREDICATE_RETRYABLE, 2200)); // api_version_unset
+  CHECK(!fdb_error_predicate(FDB_ERROR_PREDICATE_RETRYABLE, 4000)); // unknown_error
+  CHECK(!fdb_error_predicate(FDB_ERROR_PREDICATE_RETRYABLE, 4001)); // internal_error
+
+  CHECK(fdb_error_predicate(FDB_ERROR_PREDICATE_MAYBE_COMMITTED, 1021)); // commit_unknown_result
+
+  CHECK(!fdb_error_predicate(FDB_ERROR_PREDICATE_MAYBE_COMMITTED, 1000)); // operation_failed
+  CHECK(!fdb_error_predicate(FDB_ERROR_PREDICATE_MAYBE_COMMITTED, 1004)); // timed_out
+  CHECK(!fdb_error_predicate(FDB_ERROR_PREDICATE_MAYBE_COMMITTED, 1025)); // transaction_cancelled
+  CHECK(!fdb_error_predicate(FDB_ERROR_PREDICATE_MAYBE_COMMITTED, 1038)); // database_locked
+  CHECK(!fdb_error_predicate(FDB_ERROR_PREDICATE_MAYBE_COMMITTED, 1101)); // operation_cancelled
+  CHECK(!fdb_error_predicate(FDB_ERROR_PREDICATE_MAYBE_COMMITTED, 2002)); // commit_read_incomplete
+
+  CHECK(fdb_error_predicate(FDB_ERROR_PREDICATE_RETRYABLE_NOT_COMMITTED, 1007)); // transaction_too_old
+  CHECK(fdb_error_predicate(FDB_ERROR_PREDICATE_RETRYABLE_NOT_COMMITTED, 1020)); // not_committed
+  CHECK(fdb_error_predicate(FDB_ERROR_PREDICATE_RETRYABLE_NOT_COMMITTED, 1038)); // database_locked
+
+  CHECK(!fdb_error_predicate(FDB_ERROR_PREDICATE_RETRYABLE_NOT_COMMITTED, 1021)); // commit_unknown_result
+  CHECK(!fdb_error_predicate(FDB_ERROR_PREDICATE_RETRYABLE_NOT_COMMITTED, 1025)); // transaction_cancelled
+  CHECK(!fdb_error_predicate(FDB_ERROR_PREDICATE_RETRYABLE_NOT_COMMITTED, 1031)); // transaction_timed_out
+  CHECK(!fdb_error_predicate(FDB_ERROR_PREDICATE_RETRYABLE_NOT_COMMITTED, 1040)); // proxy_memory_limit_exceeded
+}
+
 // Feature not live yet, re-enable when checking if a blocking call is made
 // from the network thread is live.
 TEST_CASE("block_from_callback"

--- a/bindings/c/test/unit/unit_tests.cpp
+++ b/bindings/c/test/unit/unit_tests.cpp
@@ -354,10 +354,6 @@ TEST_CASE("fdb_future_get_key") {
           key("a").size()
         ), /* snapshot */ false);
 
-    const uint8_t *key;
-    int keylen;
-    CHECK(f1.get(&key, &keylen));
-
     fdb_error_t err = wait_future(f1);
     if (err) {
       fdb::EmptyFuture f2 = tr.on_error(err);
@@ -365,6 +361,8 @@ TEST_CASE("fdb_future_get_key") {
       continue;
     }
 
+    const uint8_t *key;
+    int keylen;
     fdb_check(f1.get(&key, &keylen));
 
     std::string dbKey((const char *)key, keylen);
@@ -380,11 +378,6 @@ TEST_CASE("fdb_future_get_value") {
   while (1) {
     fdb::ValueFuture f1 = tr.get(key("foo"), /* snapshot */ false);
 
-    int out_present;
-    char *val;
-    int vallen;
-    CHECK(f1.get(&out_present, (const uint8_t **)&val, &vallen));
-
     fdb_error_t err = wait_future(f1);
     if (err) {
       fdb::EmptyFuture f2 = tr.on_error(err);
@@ -392,6 +385,9 @@ TEST_CASE("fdb_future_get_value") {
       continue;
     }
 
+    int out_present;
+    char *val;
+    int vallen;
     fdb_check(f1.get(&out_present, (const uint8_t **)&val, &vallen));
 
     CHECK(out_present);
@@ -408,10 +404,6 @@ TEST_CASE("fdb_future_get_string_array") {
   while (1) {
     fdb::StringArrayFuture f1 = tr.get_addresses_for_key(key("foo"));
 
-    const char **strings;
-    int count;
-    CHECK(f1.get(&strings, &count));
-
     fdb_error_t err = wait_future(f1);
     if (err) {
       fdb::EmptyFuture f2 = tr.on_error(err);
@@ -419,6 +411,8 @@ TEST_CASE("fdb_future_get_string_array") {
       continue;
     }
 
+    const char **strings;
+    int count;
     fdb_check(f1.get(&strings, &count));
 
     CHECK(count > 0);
@@ -448,11 +442,6 @@ TEST_CASE("fdb_future_get_keyvalue_array") {
         /* FDBStreamingMode */ FDB_STREAMING_MODE_WANT_ALL, /* iteration */ 0,
         /* snapshot */ false, /* reverse */ 0);
 
-    FDBKeyValue const *out_kv;
-    int out_count;
-    int out_more;
-    CHECK(f1.get(&out_kv, &out_count, &out_more));
-
     fdb_error_t err = wait_future(f1);
     if (err) {
       fdb::EmptyFuture f2 = tr.on_error(err);
@@ -460,6 +449,9 @@ TEST_CASE("fdb_future_get_keyvalue_array") {
       continue;
     }
 
+    FDBKeyValue const *out_kv;
+    int out_count;
+    int out_more;
     fdb_check(f1.get(&out_kv, &out_count, &out_more));
 
     CHECK(out_count > 0);

--- a/bindings/c/test/unit/unit_tests.cpp
+++ b/bindings/c/test/unit/unit_tests.cpp
@@ -1634,13 +1634,14 @@ TEST_CASE("fdb_transaction_watch max watches") {
 }
 
 TEST_CASE("fdb_transaction_watch") {
-  fdb::Transaction tr(db);
+  insert_data(db, create_data({ { "foo", "foo" } }));
 
   struct Context {
     FdbEvent event;
   };
   Context context;
 
+  fdb::Transaction tr(db);
   while (1) {
     fdb::EmptyFuture f1 = tr.watch(key("foo"));
     fdb::EmptyFuture f2 = tr.commit();
@@ -1658,12 +1659,12 @@ TEST_CASE("fdb_transaction_watch") {
           context->event.set();
         },
         &context));
+
+    // Update value for key "foo" to trigger the watch.
+    insert_data(db, create_data({ { "foo", "bar" } }));
+    context.event.wait();
     break;
   }
-
-  // Insert data for key "foo" to trigger the watch.
-  insert_data(db, create_data({ { "foo", "bar" } }));
-  context.event.wait();
 }
 
 TEST_CASE("fdb_transaction_cancel") {

--- a/bindings/c/test/unit/unit_tests.cpp
+++ b/bindings/c/test/unit/unit_tests.cpp
@@ -1,0 +1,1005 @@
+/*
+ * unit_tests.cpp
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2020 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Unit tests for the FoundationDB C API.
+
+#define FDB_API_VERSION 620
+#include <foundationdb/fdb_c.h>
+#include <assert.h>
+
+#include <condition_variable>
+#include <iostream>
+#include <map>
+#include <mutex>
+#include <stdexcept>
+#include <thread>
+#include <vector>
+
+#define DOCTEST_CONFIG_IMPLEMENT
+#define DOCTEST_CONFIG_NO_EXCEPTIONS_BUT_WITH_ALL_ASSERTS
+#define DOCTEST_CONFIG_NO_POSIX_SIGNALS
+#include "doctest.h"
+
+#include "fdb_api.hpp"
+
+// Macros to replace bare key with prefixed key.
+#define KEY(key) (const uint8_t *)(prefix + key).c_str()
+#define KEYSIZE(key) (prefix + key).size()
+
+void fdb_check(fdb_error_t e) {
+  if (e) {
+    std::cerr << fdb_get_error(e) << std::endl;
+    std::abort();
+  }
+}
+
+FDBDatabase *fdb_open_database(const char *clusterFile) {
+  FDBDatabase *db;
+  fdb_check(fdb_create_database(clusterFile, &db));
+  return db;
+}
+
+static FDBDatabase *db = nullptr;
+static std::string prefix;
+
+// Blocks until the given future is ready, returning an error code if there was
+// an issue.
+fdb_error_t wait_future(fdb::Future &f) {
+  fdb_check(f.block_until_ready());
+  return f.get_error();
+}
+
+// Given a string s, returns the "lowest" string greater than any string that
+// starts with s. Taken from
+// https://github.com/apple/foundationdb/blob/e7d72f458c6a985fdfa677ae021f357d6f49945b/flow/flow.cpp#L223.
+std::string strinc(const std::string &s) {
+  int index;
+  for (index = s.size() - 1; index >= 0; --index) {
+    if ((uint8_t)s[index] != 255) {
+      break;
+    }
+  }
+
+  assert(index >= 0);
+
+  std::string r = s.substr(0, index + 1);
+  char *p = r.data();
+  p[r.size() - 1]++;
+  return r;
+}
+
+TEST_CASE("strinc") {
+  CHECK(strinc("a").compare("b") == 0);
+  CHECK(strinc("y").compare("z") == 0);
+  CHECK(strinc("!").compare("\"") == 0);
+  CHECK(strinc("*").compare("+") == 0);
+}
+
+// Helper function to add `prefix` to all keys in the given map. Returns a new
+// map.
+std::map<std::string, std::string>
+create_data(std::map<std::string, std::string> &&map) {
+  std::map<std::string, std::string> out;
+  for (const auto & [ key, val ] : map) {
+    out[prefix + key] = val;
+  }
+  return out;
+}
+
+// Clears all data in the database, then inserts the given key value pairs.
+void insert_data(FDBDatabase *db,
+                 const std::map<std::string, std::string> &data) {
+  fdb::Transaction tr(db);
+  auto end_key = strinc(prefix);
+  while (1) {
+    tr.clear_range((const uint8_t *)prefix.c_str(), prefix.size(),
+                   (const uint8_t *)end_key.c_str(), end_key.size());
+    for (const auto & [ key, val ] : data) {
+      tr.set((const uint8_t *)key.c_str(), key.size(),
+             (const uint8_t *)val.c_str(), val.size());
+    }
+
+    fdb::EmptyFuture f1 = tr.commit();
+    fdb_error_t err = wait_future(f1);
+    if (err) {
+      fdb::EmptyFuture f2 = tr.on_error(err);
+      fdb_error_t err2 = wait_future(f2);
+      fdb_check(err2);
+      continue;
+    }
+    break;
+  }
+}
+
+// Get the value associated with `key_name` from the database, storing results
+// in `out_present`, `val`, and `vallen`. Accepts a list of transaction options
+// to apply (values for options not supported). Returns an error if one
+// occurred.
+fdb_error_t get_value(const uint8_t *key_name, int key_name_length,
+                      fdb_bool_t snapshot,
+                      std::vector<FDBTransactionOption> options,
+                      fdb_bool_t *out_present, char **val, int *vallen) {
+  fdb::Transaction tr(db);
+  while (1) {
+    for (auto &option : options) {
+      fdb_check(tr.set_option(option, nullptr, 0));
+    }
+    fdb::ValueFuture f1 = tr.get(key_name, key_name_length, snapshot);
+
+    fdb_error_t err = wait_future(f1);
+    if (err) {
+      fdb::EmptyFuture f2 = tr.on_error(err);
+      fdb_error_t err2 = wait_future(f2);
+      if (err2) {
+        return err2;
+      }
+      continue;
+    }
+
+    return f1.get(out_present, (const uint8_t **)val, vallen);
+  }
+}
+
+// Helper function to get a range of kv pairs and return the results in
+// `out_kv`, `out_count`, and `out_more`.
+void get_range(fdb::Transaction& tr, const uint8_t* begin_key_name,
+               int begin_key_name_length, fdb_bool_t begin_or_equal,
+               int begin_offset, const uint8_t* end_key_name,
+               int end_key_name_length, fdb_bool_t end_or_equal, int end_offset,
+               int limit, int target_bytes, FDBStreamingMode mode,
+               int iteration, fdb_bool_t snapshot, fdb_bool_t reverse,
+               const FDBKeyValue** out_kv, int* out_count,
+               fdb_bool_t* out_more) {
+  while (1) {
+    fdb::KeyValueArrayFuture f1 = tr.get_range(
+        begin_key_name, begin_key_name_length, begin_or_equal, begin_offset,
+        end_key_name, end_key_name_length, end_or_equal, end_offset, limit,
+        target_bytes, mode, iteration, snapshot, reverse);
+
+    fdb_error_t err = wait_future(f1);
+    if (err) {
+      fdb::EmptyFuture f2 = tr.on_error(err);
+      fdb_error_t err2 = wait_future(f2);
+      fdb_check(err2);
+      continue;
+    }
+
+    fdb_check(f1.get(out_kv, out_count, out_more));
+    break;
+  }
+}
+
+// Clears all data in the database.
+void clear_data(FDBDatabase *db) {
+  insert_data(db, {});
+}
+
+struct Event {
+  void wait() {
+    std::unique_lock<std::mutex> l(mutex);
+    cv.wait(l, [this]() { return this->complete; });
+  }
+  void set() {
+    std::unique_lock<std::mutex> l(mutex);
+    complete = true;
+    cv.notify_all();
+  }
+
+private:
+  std::mutex mutex;
+  std::condition_variable cv;
+  bool complete = false;
+};
+
+TEST_CASE("fdb_future_set_callback") {
+  fdb::Transaction tr(db);
+  fdb::ValueFuture f1 = tr.get((const uint8_t *)"foo", 3, /*snapshot*/ true);
+  struct Context {
+    Event event;
+  };
+  Context context;
+  fdb_check(f1.set_callback(+[](FDBFuture *f1, void *param) {
+                              auto *context =
+                                  static_cast<Context *>(param);
+                              context->event.set();
+                            },
+                            &context));
+  fdb_check(f1.block_until_ready());
+  context.event.wait();
+}
+
+TEST_CASE("fdb_future_cancel after future completion") {
+  fdb::Transaction tr(db);
+
+  fdb::ValueFuture f1 = tr.get((const uint8_t *)"foo", 3, false);
+  fdb_check(f1.block_until_ready());
+  // Should have no effect
+  f1.cancel();
+
+  int out_present;
+  char *val;
+  int vallen;
+  fdb_check(f1.get(&out_present, (const uint8_t **)&val, &vallen));
+}
+
+TEST_CASE("fdb_future_is_ready") {
+  fdb::Transaction tr(db);
+  fdb::ValueFuture f1 = tr.get((const uint8_t *)"foo", 3, false);
+
+  CHECK(!f1.is_ready());
+  fdb_check(f1.block_until_ready());
+  CHECK(f1.is_ready());
+}
+
+TEST_CASE("fdb_future_release_memory") {
+  fdb::Transaction tr(db);
+
+  fdb::ValueFuture f1 = tr.get((const uint8_t *)"foo", 3, false);
+  fdb_check(f1.block_until_ready());
+
+  int out_present;
+  char *val;
+  int vallen;
+  fdb_check(f1.get(&out_present, (const uint8_t **)&val, &vallen));
+
+  f1.release_memory();
+  fdb_error_t err = f1.get(&out_present,
+                                 (const uint8_t **)&val, &vallen);
+  CHECK(err == 1102); // future_released
+}
+
+TEST_CASE("fdb_future_get_int64") {
+  fdb::Transaction tr(db);
+  while (1) {
+    fdb::Int64Future f1 = tr.get_read_version();
+
+    fdb_error_t err = wait_future(f1);
+    if (err) {
+      fdb::EmptyFuture f2 = tr.on_error(err);
+      fdb_error_t err2 = wait_future(f2);
+      fdb_check(err2);
+      continue;
+    }
+
+    int64_t rv;
+    fdb_check(f1.get(&rv));
+    CHECK(rv > 0);
+    break;
+  }
+}
+
+TEST_CASE("fdb_future_get_key") {
+  insert_data(db,
+              create_data({ { "a", "1" }, { "baz", "2" }, { "bar", "3" } }));
+
+  fdb::Transaction tr(db);
+  while (1) {
+    fdb::KeyFuture f1 = tr.get_key(
+        FDB_KEYSEL_FIRST_GREATER_THAN(KEY("a"), KEYSIZE("a")),
+        /* snapshot */ false);
+
+    const uint8_t *key;
+    int keylen;
+    CHECK(f1.get(&key, &keylen));
+
+    fdb_error_t err = wait_future(f1);
+    if (err) {
+      fdb::EmptyFuture f2 = tr.on_error(err);
+      fdb_error_t err2 = wait_future(f2);
+      fdb_check(err2);
+      continue;
+    }
+
+    fdb_check(f1.get(&key, &keylen));
+
+    std::string dbKey((const char *)key, keylen);
+    CHECK(dbKey.compare(prefix + "bar") == 0);
+    break;
+  }
+}
+
+TEST_CASE("fdb_future_get_value") {
+  insert_data(db, create_data({ { "foo", "bar" } }));
+
+  fdb::Transaction tr(db);
+  while (1) {
+    fdb::ValueFuture f1 = tr.get(KEY("foo"), KEYSIZE("foo"),
+                                 /* snapshot */ false);
+
+    int out_present;
+    char *val;
+    int vallen;
+    CHECK(f1.get(&out_present, (const uint8_t **)&val, &vallen));
+
+    fdb_error_t err = wait_future(f1);
+    if (err) {
+      fdb::EmptyFuture f2 = tr.on_error(err);
+      fdb_error_t err2 = wait_future(f2);
+      fdb_check(err2);
+      continue;
+    }
+
+    fdb_check(f1.get(&out_present, (const uint8_t **)&val, &vallen));
+
+    CHECK(out_present);
+    std::string dbValue(val, vallen);
+    CHECK(dbValue.compare("bar") == 0);
+    break;
+  }
+}
+
+TEST_CASE("fdb_future_get_string_array") {
+  insert_data(db, create_data({ { "foo", "bar" } }));
+
+  fdb::Transaction tr(db);
+  while (1) {
+    fdb::StringArrayFuture f1 = tr.get_addresses_for_key(KEY("foo"),
+                                                         KEYSIZE("foo"));
+
+    const char **strings;
+    int count;
+    CHECK(f1.get(&strings, &count));
+
+    fdb_error_t err = wait_future(f1);
+    if (err) {
+      fdb::EmptyFuture f2 = tr.on_error(err);
+      fdb_error_t err2 = wait_future(f2);
+      fdb_check(err2);
+      continue;
+    }
+
+    fdb_check(f1.get(&strings, &count));
+
+    CHECK(count > 0);
+    break;
+  }
+}
+
+TEST_CASE("fdb_future_get_keyvalue_array") {
+  std::map<std::string, std::string> data =
+      create_data({ { "a", "1" }, { "b", "2" }, { "c", "3" }, { "d", "4" } });
+  insert_data(db, data);
+
+  fdb::Transaction tr(db);
+  while (1) {
+    fdb::KeyValueArrayFuture f1 = tr.get_range(
+        FDB_KEYSEL_FIRST_GREATER_OR_EQUAL(KEY("a"), KEYSIZE("a")),
+        FDB_KEYSEL_LAST_LESS_OR_EQUAL(KEY("c"), KEYSIZE("c")) + 1,
+        /* limit */ 0, /* target_bytes */ 0,
+        /* FDBStreamingMode */ FDB_STREAMING_MODE_WANT_ALL, /* iteration */ 0,
+        /* snapshot */ false, /* reverse */ 0);
+
+    FDBKeyValue const *out_kv;
+    int out_count;
+    int out_more;
+    CHECK(f1.get(&out_kv, &out_count, &out_more));
+
+    fdb_error_t err = wait_future(f1);
+    if (err) {
+      fdb::EmptyFuture f2 = tr.on_error(err);
+      fdb_error_t err2 = wait_future(f2);
+      fdb_check(err2);
+      continue;
+    }
+
+    fdb_check(f1.get(&out_kv, &out_count, &out_more));
+
+    CHECK(out_count > 0);
+    CHECK(out_count <= 3);
+    if (out_count < 3) {
+      CHECK(out_more);
+    }
+
+    for (int i = 0; i < out_count; ++i) {
+      FDBKeyValue kv = *out_kv++;
+
+      std::string key((const char *)kv.key, kv.key_length);
+      std::string value((const char *)kv.value, kv.value_length);
+
+      CHECK(data[key].compare(value) == 0);
+    }
+    break;
+  }
+}
+
+TEST_CASE("cannot read system key") {
+  fdb::Transaction tr(db);
+
+  std::string syskey("\xff/coordinators");
+  fdb::ValueFuture f1 = tr.get((const uint8_t *)syskey.c_str(), syskey.size(),
+                               /* snapshot */ false);
+
+  fdb_error_t err = wait_future(f1);
+  CHECK(err == 2004); // key_outside_legal_range
+}
+
+TEST_CASE("read system key") {
+  fdb::Transaction tr(db);
+
+  std::string syskey("\xff/coordinators");
+  int out_present;
+  char *val;
+  int vallen;
+  fdb_check(get_value((const uint8_t *)syskey.c_str(), syskey.size(),
+                      /* snapshot */ false, { FDB_TR_OPTION_READ_SYSTEM_KEYS },
+                      &out_present, &val, &vallen));
+  CHECK(out_present);
+}
+
+TEST_CASE("cannot write system key") {
+  fdb::Transaction tr(db);
+
+  std::string syskey("\xff\x02");
+  tr.set((const uint8_t *)syskey.c_str(), syskey.size(),
+         (const uint8_t *)"bar", 3);
+
+  fdb::EmptyFuture f1 = tr.commit();
+  fdb_error_t err = wait_future(f1);
+  CHECK(err == 2004); // key_outside_legal_range
+}
+
+TEST_CASE("write system key") {
+  fdb::Transaction tr(db);
+
+  std::string syskey("\xff\x02");
+  fdb_check(tr.set_option(FDB_TR_OPTION_ACCESS_SYSTEM_KEYS, nullptr, 0));
+  tr.set((const uint8_t *)syskey.c_str(), syskey.size(),
+         (const uint8_t *)"bar", 3);
+
+  while (1) {
+    fdb::EmptyFuture f1 = tr.commit();
+
+    fdb_error_t err = wait_future(f1);
+    if (err) {
+      fdb::EmptyFuture f2 = tr.on_error(err);
+      fdb_error_t err2 = wait_future(f2);
+      fdb_check(err2);
+      continue;
+    }
+    break;
+  }
+
+  int out_present;
+  char *val;
+  int vallen;
+  fdb_check(get_value((const uint8_t *)syskey.c_str(), syskey.size(),
+                      /* snapshot */ false, { FDB_TR_OPTION_READ_SYSTEM_KEYS },
+                      &out_present, &val, &vallen));
+
+  CHECK(out_present);
+  std::string value(val, vallen);
+  CHECK(value.compare("bar") == 0);
+}
+
+TEST_CASE("fdb_transaction read_your_writes") {
+  fdb::Transaction tr(db);
+  clear_data(db);
+
+  while (1) {
+    tr.set((const uint8_t *)"foo", 3, (const uint8_t *)"bar", 3);
+    fdb::ValueFuture f1 = tr.get((const uint8_t *)"foo", 3, /*snapshot*/ false);
+
+    // Read before committing, should read the initial write.
+    fdb_error_t err = wait_future(f1);
+    if (err) {
+      fdb::EmptyFuture f2 = tr.on_error(err);
+      fdb_error_t err2 = wait_future(f2);
+      fdb_check(err2);
+      continue;
+    }
+
+    int out_present;
+    char *val;
+    int vallen;
+    fdb_check(f1.get(&out_present, (const uint8_t **)&val, &vallen));
+
+    CHECK(out_present);
+    std::string value(val, vallen);
+    CHECK(value.compare("bar") == 0);
+    break;
+  }
+}
+
+TEST_CASE("fdb_transaction_set_option") {
+  fdb::Transaction tr(db);
+  clear_data(db);
+
+  // SUBCASE("integer parameter value_length != 8") {
+  //   // If the option accepts an int as a paremeter, value_length must be set to
+  //   // 8.
+  //   int64_t timeout = 100;
+  //   CHECK(tr.set_option(FDB_TR_OPTION_TIMEOUT, (const uint8_t *)&timeout, 5));
+  // }
+
+  SUBCASE("read_your_writes_disable") {
+    while (1) {
+      fdb_check(tr.set_option(FDB_TR_OPTION_READ_YOUR_WRITES_DISABLE, nullptr, 0));
+      tr.set((const uint8_t *)"foo", 3, (const uint8_t *)"bar", 3);
+      fdb::ValueFuture f1 = tr.get((const uint8_t *)"foo", 3, /*snapshot*/ false);
+
+      // Read before committing, shouldn't read the initial write because
+      // read_your_writes is disabled.
+      fdb_error_t err = wait_future(f1);
+      if (err) {
+        fdb::EmptyFuture f2 = tr.on_error(err);
+        fdb_error_t err2 = wait_future(f2);
+        fdb_check(err2);
+        continue;
+      }
+
+      int out_present;
+      char *val;
+      int vallen;
+      fdb_check(f1.get(&out_present, (const uint8_t **)&val, &vallen));
+
+      CHECK(!out_present);
+      break;
+    }
+  }
+
+  SUBCASE("snapshot_read_your_writes_enable") {
+    while (1) {
+      // Enable read your writes for snapshot reads.
+      fdb_check(tr.set_option(FDB_TR_OPTION_SNAPSHOT_RYW_ENABLE, nullptr, 0));
+      tr.set((const uint8_t *)"foo", 3, (const uint8_t *)"bar", 3);
+      fdb::ValueFuture f1 = tr.get((const uint8_t *)"foo", 3, /*snapshot*/ true);
+
+      fdb_error_t err = wait_future(f1);
+      if (err) {
+        fdb::EmptyFuture f2 = tr.on_error(err);
+        fdb_error_t err2 = wait_future(f2);
+        fdb_check(err2);
+        continue;
+      }
+
+      int out_present;
+      char *val;
+      int vallen;
+      fdb_check(f1.get(&out_present, (const uint8_t **)&val, &vallen));
+
+      CHECK(out_present);
+      std::string value(val, vallen);
+      CHECK(value.compare("bar") == 0);
+      break;
+    }
+  }
+
+  SUBCASE("snapshot_read_your_writes_disable") {
+    while (1) {
+      // Disable read your writes for snapshot reads.
+      fdb_check(tr.set_option(FDB_TR_OPTION_SNAPSHOT_RYW_DISABLE, nullptr, 0));
+      tr.set((const uint8_t *)"foo", 3, (const uint8_t *)"bar", 3);
+      fdb::ValueFuture f1 = tr.get((const uint8_t *)"foo", 3, /*snapshot*/ true);
+      fdb::ValueFuture f2 = tr.get((const uint8_t *)"foo", 3, /*snapshot*/ false);
+
+      fdb_error_t err = wait_future(f1);
+      if (err) {
+        fdb::EmptyFuture f3 = tr.on_error(err);
+        fdb_error_t err2 = wait_future(f3);
+        fdb_check(err2);
+        continue;
+      }
+
+      int out_present;
+      char *val;
+      int vallen;
+      fdb_check(f1.get(&out_present, (const uint8_t **)&val, &vallen));
+
+      CHECK(!out_present);
+
+      // Non-snapshot reads should still read writes in the transaction.
+      err = wait_future(f2);
+      if (err) {
+        fdb::EmptyFuture f3 = tr.on_error(err);
+        fdb_error_t err2 = wait_future(f3);
+
+        if (err2) {
+          fdb_check(err2);
+          break;
+        }
+        continue;
+      }
+      fdb_check(f2.get(&out_present, (const uint8_t **)&val, &vallen));
+
+      CHECK(out_present);
+      std::string value(val, vallen);
+      CHECK(value.compare("bar") == 0);
+      break;
+    }
+  }
+}
+
+TEST_CASE("fdb_transaction_set_read_version old_version") {
+  fdb::Transaction tr(db);
+
+  tr.set_read_version(1);
+  fdb::ValueFuture f1 = tr.get((const uint8_t *)"foo", 3, /*snapshot*/ true);
+
+  fdb_error_t err = wait_future(f1);
+  CHECK(err == 1007); // transaction_too_old
+}
+
+TEST_CASE("fdb_transaction_set_read_version future_version") {
+  fdb::Transaction tr(db);
+
+  tr.set_read_version(1UL << 62);
+  fdb::ValueFuture f1 = tr.get((const uint8_t *)"foo", 3, /*snapshot*/ true);
+
+  fdb_error_t err = wait_future(f1);
+  CHECK(err == 1009); // future_version
+}
+
+TEST_CASE("fdb_transaction_get_range reverse") {
+  std::map<std::string, std::string> data =
+      create_data({ { "a", "1" }, { "b", "2" }, { "c", "3" }, { "d", "4" } });
+  insert_data(db, data);
+
+  fdb::Transaction tr(db);
+
+  FDBKeyValue const *out_kv;
+  int out_count;
+  int out_more;
+  get_range(tr, FDB_KEYSEL_FIRST_GREATER_OR_EQUAL(KEY("a"), KEYSIZE("a")),
+      FDB_KEYSEL_LAST_LESS_OR_EQUAL(KEY("d"), KEYSIZE("d")) + 1,
+      /* limit */ 0, /* target_bytes */ 0,
+      /* FDBStreamingMode */ FDB_STREAMING_MODE_WANT_ALL, /* iteration */ 0,
+      /* snapshot */ false, /* reverse */ 1, &out_kv, &out_count, &out_more);
+
+  CHECK(out_count > 0);
+  CHECK(out_count <= 4);
+  if (out_count < 4) {
+    CHECK(out_more);
+  }
+
+  // Read data in reverse order, keeping in mind that out_count might be
+  // smaller than requested.
+  auto it = data.rbegin();
+  std::advance(it, data.size() - out_count);
+  for (; it != data.rend(); ++it) {
+    std::string data_key = it->first;
+    std::string data_value = it->second;
+
+    FDBKeyValue kv = *out_kv++;
+    std::string key((const char *)kv.key, kv.key_length);
+    std::string value((const char *)kv.value, kv.value_length);
+
+    CHECK(data_key.compare(key) == 0);
+    CHECK(data[data_key].compare(value) == 0);
+  }
+}
+
+// Flaky (or broken)
+// TEST_CASE("fdb_transaction_get_range limit") {
+//   std::map<std::string, std::string> data =
+//       create_data({ { "a", "1" }, { "b", "2" }, { "c", "3" }, { "d", "4" } });
+//   insert_data(db, data);
+// 
+//   fdb::Transaction tr(db);
+// 
+//   FDBKeyValue const *out_kv;
+//   int out_count;
+//   int out_more;
+//   get_range(tr, FDB_KEYSEL_FIRST_GREATER_OR_EQUAL(KEY("a"), KEYSIZE("a")),
+//       FDB_KEYSEL_LAST_LESS_OR_EQUAL(KEY("d"), KEYSIZE("d")) + 1,
+//       /* limit */ 2, /* target_bytes */ 0,
+//       /* FDBStreamingMode */ FDB_STREAMING_MODE_WANT_ALL, /* iteration */ 0,
+//       /* snapshot */ false, /* reverse */ 0, &out_kv, &out_count, &out_more);
+// 
+//   CHECK(out_count > 0);
+//   CHECK(out_count <= 2);
+//   if (out_count < 4) {
+//     CHECK(out_more);
+//   }
+// 
+//   for (int i = 0; i < out_count; ++i) {
+//     FDBKeyValue kv = *out_kv++;
+// 
+//     std::string key((const char *)kv.key, kv.key_length);
+//     std::string value((const char *)kv.value, kv.value_length);
+// 
+//     CHECK(data[key].compare(value) == 0);
+//   }
+// }
+
+TEST_CASE("fdb_transaction_get_range FDB_STREAMING_MODE_EXACT") {
+  std::map<std::string, std::string> data =
+      create_data({ { "a", "1" }, { "b", "2" }, { "c", "3" }, { "d", "4" } });
+  insert_data(db, data);
+
+  fdb::Transaction tr(db);
+
+  FDBKeyValue const *out_kv;
+  int out_count;
+  int out_more;
+  get_range(tr, FDB_KEYSEL_FIRST_GREATER_OR_EQUAL(KEY("a"), KEYSIZE("a")),
+      FDB_KEYSEL_LAST_LESS_OR_EQUAL(KEY("d"), KEYSIZE("d")) + 1,
+      /* limit */ 3, /* target_bytes */ 0,
+      /* FDBStreamingMode */ FDB_STREAMING_MODE_EXACT, /* iteration */ 0,
+      /* snapshot */ false, /* reverse */ 0, &out_kv, &out_count, &out_more);
+
+  CHECK(out_count == 3);
+  CHECK(out_more);
+
+  for (int i = 0; i < out_count; ++i) {
+    FDBKeyValue kv = *out_kv++;
+
+    std::string key((const char *)kv.key, kv.key_length);
+    std::string value((const char *)kv.value, kv.value_length);
+
+    CHECK(data[key].compare(value) == 0);
+  }
+}
+
+TEST_CASE("fdb_transaction_clear") {
+  insert_data(db, create_data({ { "foo", "bar" } }));
+
+  fdb::Transaction tr(db);
+  while (1) {
+    tr.clear(KEY("foo"), KEYSIZE("foo"));
+
+    fdb::EmptyFuture f1 = tr.commit();
+
+    fdb_error_t err = wait_future(f1);
+    if (err) {
+      fdb::EmptyFuture f2 = tr.on_error(err);
+      fdb_error_t err2 = wait_future(f2);
+      fdb_check(err2);
+      continue;
+    }
+    break;
+  }
+
+  int out_present;
+  char *val;
+  int vallen;
+  fdb_check(get_value(KEY("foo"), KEYSIZE("foo"), /* snapshot */ false, {},
+                      &out_present, &val, &vallen));
+
+  CHECK(!out_present);
+}
+
+// Atomic operations not supported in FDB 3. TODO: Re-enable for FDB 6 (and add
+// tests for more atomic ops).
+// TEST_CASE("fdb_transaction_atomic_op FDB_MUTATION_TYPE_ADD") {
+//   clear_data(db);
+//
+//   fdb::Transaction tr(db);
+//   int64_t param = 1;
+//   while (1) {
+//     tr.atomic_op(KEY("foo"), KEYSIZE("foo"), (const uint8_t *)&param,
+//                  sizeof(param), FDB_MUTATION_TYPE_ADD);
+//     fdb::EmptyFuture f1 = tr.commit();
+//
+//     fdb_error_t err = wait_future(f1);
+//     if (err) {
+//       fdb::EmptyFuture f2 = tr.on_error(err);
+//       fdb_error_t err2 = wait_future(f2);
+//       fdb_check(err2);
+//       continue;
+//     }
+//     break;
+//   }
+//
+//   // TODO: Get key "foo" and make sure value has been set to 1
+// }
+
+TEST_CASE("fdb_transaction_get_committed_version read_only") {
+  // Read-only transaction should have a committed version of -1.
+  fdb::Transaction tr(db);
+  while (1) {
+    fdb::ValueFuture f1 = tr.get((const uint8_t *)"foo", 3, /*snapshot*/ false);
+
+    fdb_error_t err = wait_future(f1);
+    if (err) {
+      fdb::EmptyFuture f2 = tr.on_error(err);
+      fdb_error_t err2 = wait_future(f2);
+      fdb_check(err2);
+      continue;
+    }
+
+    int64_t out_version;
+    fdb_check(tr.get_committed_version(&out_version));
+    CHECK(out_version == -1);
+    break;
+  }
+}
+
+TEST_CASE("fdb_transaction_get_committed_version") {
+  fdb::Transaction tr(db);
+  while (1) {
+    tr.set(KEY("foo"), KEYSIZE("foo"), (const uint8_t *)"bar", 3);
+    fdb::EmptyFuture f1 = tr.commit();
+
+    fdb_error_t err = wait_future(f1);
+    if (err) {
+      fdb::EmptyFuture f2 = tr.on_error(err);
+      fdb_error_t err2 = wait_future(f2);
+      fdb_check(err2);
+      continue;
+    }
+
+    int64_t out_version;
+    fdb_check(tr.get_committed_version(&out_version));
+    CHECK(out_version >= 0);
+    break;
+  }
+}
+
+// Not supported in FDB 3. TODO: Re-enable for FDB 6.
+// TEST_CASE("fdb_transaction_get_approximate_size") {
+//   fdb::Transaction tr(db);
+//   while (1) {
+//     tr.set(KEY("foo"), KEYSIZE("foo"), (const uint8_t *)"bar", 3);
+//     fdb::Int64Future f1 = tr.get_approximate_size();
+//
+//     fdb_error_t err = wait_future(f1);
+//     if (err) {
+//       fdb::EmptyFuture f2 = tr.on_error(err);
+//       fdb_error_t err2 = wait_future(f2);
+//       fdb_check(err2);
+//       continue;
+//     }
+//
+//     int64_t size;
+//     fdb_check(f1.get(&size));
+//     CHECK(size >= 3);
+//     break;
+//   }
+// }
+
+TEST_CASE("fdb_transaction_watch read_your_writes_disable") {
+  // Watches created on a transaction with the option READ_YOUR_WRITES_DISABLE
+  // should return a watches_disabled error.
+  fdb::Transaction tr(db);
+  fdb_check(tr.set_option(FDB_TR_OPTION_READ_YOUR_WRITES_DISABLE, nullptr, 0));
+  fdb::EmptyFuture f1 = tr.watch(KEY("foo"), KEYSIZE("foo"));
+
+  CHECK(wait_future(f1) == 1034); // watches_disabled
+}
+
+TEST_CASE("fdb_transaction_watch reset") {
+  // Resetting (or destroying) an uncommitted transaction should cause watches
+  // created by the transaction to fail with a transaction_cancelled error.
+  fdb::Transaction tr(db);
+  fdb::EmptyFuture f1 = tr.watch(KEY("foo"), KEYSIZE("foo"));
+  tr.reset();
+  CHECK(wait_future(f1) == 1025); // transaction_cancelled
+}
+
+TEST_CASE("fdb_transaction_watch max watches") {
+  int64_t max_watches = 3;
+  fdb_check(fdb_database_set_option(db, FDB_DB_OPTION_MAX_WATCHES,
+                                    (const uint8_t *)&max_watches, 8));
+
+  fdb::Transaction tr(db);
+  fdb::EmptyFuture f1 = tr.watch(KEY("a"), KEYSIZE("a"));
+  fdb::EmptyFuture f2 = tr.watch(KEY("b"), KEYSIZE("b"));
+  fdb::EmptyFuture f3 = tr.watch(KEY("c"), KEYSIZE("c"));
+  fdb::EmptyFuture f4 = tr.watch(KEY("d"), KEYSIZE("d"));
+  fdb::EmptyFuture f5 = tr.commit();
+
+  CHECK(wait_future(f1) == 1032); // too_many_watches
+
+  // Reset available number of watches.
+  max_watches = 10000;
+  fdb_check(fdb_database_set_option(db, FDB_DB_OPTION_MAX_WATCHES,
+                                    (const uint8_t *)&max_watches, 8));
+}
+
+TEST_CASE("fdb_transaction_watch") {
+  fdb::Transaction tr(db);
+
+  struct Context {
+    Event event;
+  };
+  Context context;
+
+  while (1) {
+    fdb::EmptyFuture f1 = tr.watch(KEY("foo"), KEYSIZE("foo"));
+    fdb::EmptyFuture f2 = tr.commit();
+
+    fdb_error_t err = wait_future(f2);
+    if (err) {
+      fdb::EmptyFuture f3 = tr.on_error(err);
+      fdb_error_t err2 = wait_future(f3);
+      fdb_check(err2);
+      continue;
+    }
+
+    fdb_check(f1.set_callback(+[](FDBFuture *f1, void *param) {
+                                auto *context =
+                                    static_cast<Context *>(param);
+                                context->event.set();
+                              },
+                              &context));
+    break;
+  }
+
+  // Insert data for key "foo" to trigger the watch.
+  insert_data(db, create_data({ { "foo", "bar" } }));
+  context.event.wait();
+}
+
+TEST_CASE("fdb_transaction_cancel") {
+  // Cannot use transaction after cancelling it...
+  fdb::Transaction tr(db);
+  tr.cancel();
+  fdb::ValueFuture f1 = tr.get((const uint8_t *)"foo", 3, /* snapshot */ false);
+  CHECK(wait_future(f1) == 1025); // transaction_cancelled
+
+  // ... until the transaction has been reset.
+  tr.reset();
+  fdb::ValueFuture f2 = tr.get((const uint8_t *)"foo", 3, /* snapshot */ false);
+  fdb_check(wait_future(f2));
+}
+
+TEST_CASE("block_from_callback") {
+  fdb::Transaction tr(db);
+  fdb::ValueFuture f1 = tr.get((const uint8_t *)"foo", 3, /*snapshot*/ true);
+  struct Context {
+    Event event;
+    fdb::Transaction *tr;
+  };
+  Context context;
+  context.tr = &tr;
+  fdb_check(f1.set_callback(
+      +[](FDBFuture *f1, void *param) {
+            auto *context = static_cast<Context *>(param);
+            fdb::ValueFuture f2 = context->tr->get((const uint8_t *)"bar", 3,
+                                                /*snapshot*/ true);
+            fdb_error_t error = f2.block_until_ready();
+            if (error) {
+              CHECK(error == /*blocked_from_network_thread*/ 2025);
+            }
+            context->event.set();
+          },
+      &context));
+  context.event.wait();
+}
+
+int main(int argc, char **argv) {
+  if (argc != 3) {
+    std::cout << "Unit tests for the FoundationDB C API.\n"
+              << "Usage: fdb_c_unit_tests /path/to/cluster_file key_prefix"
+              << std::endl;
+    return 1;
+  }
+
+  doctest::Context context;
+
+  fdb_check(fdb_select_api_version(620));
+  fdb_check(fdb_setup_network());
+  std::thread network_thread{ &fdb_run_network };
+
+  db = fdb_open_database(argv[1]);
+  prefix = argv[2];
+  int res = context.run();
+  fdb_database_destroy(db);
+
+  if (context.shouldExit()) {
+    fdb_check(fdb_stop_network());
+    network_thread.join();
+    return res;
+  }
+  fdb_check(fdb_stop_network());
+  network_thread.join();
+
+  return res;
+}

--- a/cmake/ConfigureCompiler.cmake
+++ b/cmake/ConfigureCompiler.cmake
@@ -41,7 +41,6 @@ endif()
 add_compile_options(-DCMAKE_BUILD)
 add_compile_definitions(BOOST_ERROR_CODE_HEADER_ONLY BOOST_SYSTEM_NO_DEPRECATED)
 
-set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
 if(ALLOC_INSTRUMENTATION)
   add_compile_options(-DALLOC_INSTRUMENTATION)

--- a/cmake/ConfigureCompiler.cmake
+++ b/cmake/ConfigureCompiler.cmake
@@ -41,6 +41,7 @@ endif()
 add_compile_options(-DCMAKE_BUILD)
 add_compile_definitions(BOOST_ERROR_CODE_HEADER_ONLY BOOST_SYSTEM_NO_DEPRECATED)
 
+set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
 if(ALLOC_INSTRUMENTATION)
   add_compile_options(-DALLOC_INSTRUMENTATION)


### PR DESCRIPTION
Adds unit tests covering C API functionality. Behavior is tested based off functionality described in the [documentation](https://apple.github.io/foundationdb/api-c.html).

Unit tests use [doctest](https://github.com/onqtam/doctest) as the testing framework. The doctest header is downloaded during the build process. Produces two new binaries, `fdb_c_setup_tests` and `fdb_c_unit_tests`.

Uses #3808 to add binaries to ctest, which will run with them with a temporary `fdbserver`. Run with ctest by specifying the name of the binary as regex, ie `ctest -R unit_tests -VV`.

Thanks to @sfc-gh-anoyes for helping with this work.