### PR TITLE
Backport #3426 to release-6.2

### DIFF
--- a/fdbclient/ClusterInterface.h
+++ b/fdbclient/ClusterInterface.h
@@ -94,23 +94,15 @@ struct ClientVersionRef {
 
 	ClientVersionRef(Arena &arena, ClientVersionRef const& cv) : clientVersion(arena, cv.clientVersion), sourceVersion(arena, cv.sourceVersion), protocolVersion(arena, cv.protocolVersion) {}
 	ClientVersionRef(StringRef clientVersion, StringRef sourceVersion, StringRef protocolVersion) : clientVersion(clientVersion), sourceVersion(sourceVersion), protocolVersion(protocolVersion) {}
-	ClientVersionRef(std::string versionString) {
-		size_t index = versionString.find(",");
-		if(index == versionString.npos) {
+	ClientVersionRef(StringRef versionString) {
+		std::vector<StringRef> parts = versionString.splitAny(LiteralStringRef(","));
+		if (parts.size() != 3) {
 			initUnknown();
 			return;
 		}
-
-		clientVersion = StringRef((uint8_t*)&versionString[0], index);
-
-		size_t nextIndex = versionString.find(",", index+1);
-		if(index == versionString.npos) {
-			initUnknown();
-			return;
-		}
-
-		sourceVersion = StringRef((uint8_t*)&versionString[index+1], nextIndex-(index+1));
-		protocolVersion = StringRef((uint8_t*)&versionString[nextIndex+1], versionString.length()-(nextIndex+1));
+		clientVersion = parts[0];
+		sourceVersion = parts[1];
+		protocolVersion = parts[2];
 	}
 
 	void initUnknown() {

--- a/fdbclient/MultiVersionTransaction.actor.cpp
+++ b/fdbclient/MultiVersionTransaction.actor.cpp
@@ -1357,7 +1357,7 @@ void ClientInfo::loadProtocolVersion() {
 	}
 
 	char *next;
-	std::string protocolVersionStr = ClientVersionRef(version).protocolVersion.toString();
+	std::string protocolVersionStr = ClientVersionRef(StringRef(version)).protocolVersion.toString();
 	protocolVersion = ProtocolVersion(strtoull(protocolVersionStr.c_str(), &next, 16));
 
 	ASSERT(protocolVersion.version() != 0 && protocolVersion.version() != ULLONG_MAX);

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -963,14 +963,9 @@ void setNetworkOption(FDBNetworkOptions::Option option, Optional<StringRef> valu
 			ASSERT(value.present());
 
 			Standalone<VectorRef<ClientVersionRef>> supportedVersions;
-			std::string versionString = value.get().toString();
-
-			size_t index = 0;
-			size_t nextIndex = 0;
-			while(nextIndex != versionString.npos) {
-				nextIndex = versionString.find(';', index);
-				supportedVersions.push_back_deep(supportedVersions.arena(), ClientVersionRef(versionString.substr(index, nextIndex-index)));
-				index = nextIndex + 1;
+			std::vector<StringRef> supportedVersionsStrings = value.get().splitAny(LiteralStringRef(";"));
+			for (StringRef versionString: supportedVersionsStrings) {
+				supportedVersions.push_back_deep(supportedVersions.arena(), ClientVersionRef(versionString));
 			}
 
 			ASSERT(supportedVersions.size() > 0);

--- a/flow/Arena.h
+++ b/flow/Arena.h
@@ -552,6 +552,15 @@ public:
 		return eatAny(StringRef((const uint8_t *)sep, strlen(sep)), foundSeparator);
 	}
 
+	std::vector<StringRef> splitAny(StringRef sep) const {
+		StringRef r = *this;
+		std::vector<StringRef> tokens;
+		while (r.size()) {
+			tokens.push_back(r.eatAny(sep, nullptr));
+		}
+		return tokens;
+	}
+
 private:
 	// Unimplemented; blocks conversion through std::string
 	StringRef( char* );


### PR DESCRIPTION
This fixes undefined behavior in the creation of `ClientVersionRef`.