### PR TITLE
Install asan in foundationdb-build docker image

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -61,8 +61,8 @@ RUN cd /opt/ && curl -L https://github.com/facebook/rocksdb/archive/v6.10.1.tar.
 ARG TIMEZONEINFO=America/Los_Angeles
 RUN rm -f /etc/localtime && ln -s /usr/share/zoneinfo/${TIMEZONEINFO} /etc/localtime
 
-LABEL version=0.1.18
-ENV DOCKER_IMAGEVER=0.1.18
+LABEL version=0.1.19
+ENV DOCKER_IMAGEVER=0.1.19
 ENV JAVA_HOME=/usr/lib/jvm/java-1.8.0
 ENV CC=/opt/rh/devtoolset-8/root/usr/bin/gcc
 ENV CXX=/opt/rh/devtoolset-8/root/usr/bin/g++

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -8,7 +8,7 @@ RUN yum install -y yum-utils &&\
     http://opensource.wandisco.com/centos/6/git/x86_64/wandisco-git-release-6-1.noarch.rpm &&\
   yum -y install devtoolset-8-8.1-1.el6 java-1.8.0-openjdk-devel \
     devtoolset-8-gcc-8.3.1 devtoolset-8-gcc-c++-8.3.1 \
-    devtoolset-8-libubsan-devel devtoolset-8-valgrind-devel \
+    devtoolset-8-libubsan-devel devtoolset-8-libasan-devel devtoolset-8-valgrind-devel \
     rh-python36-python-devel rh-ruby24 golang python27 rpm-build \
     mono-core debbuild python-pip dos2unix valgrind-devel ccache \
     distcc wget git lz4 lz4-devel lz4-static &&\

--- a/build/Dockerfile.devel
+++ b/build/Dockerfile.devel
@@ -1,4 +1,4 @@
-FROM foundationdb/foundationdb-build:0.1.18
+FROM foundationdb/foundationdb-build:0.1.19
 
 USER root
 

--- a/build/Dockerfile.devel
+++ b/build/Dockerfile.devel
@@ -50,8 +50,8 @@ RUN cp -iv /usr/local/bin/clang++ /usr/local/bin/clang++.deref &&\
 	ldconfig &&\
 	rm -rf /mnt/artifacts
 
-LABEL version=0.11.9
-ENV DOCKER_IMAGEVER=0.11.9
+LABEL version=0.11.10
+ENV DOCKER_IMAGEVER=0.11.10
 
 ENV CLANGCC=/usr/local/bin/clang.de8a65ef
 ENV CLANGCXX=/usr/local/bin/clang++.de8a65ef

--- a/build/docker-compose.yaml
+++ b/build/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   common: &common
-    image: foundationdb/foundationdb-build:0.1.18
+    image: foundationdb/foundationdb-build:0.1.19
 
   build-setup: &build-setup
     <<: *common


### PR DESCRIPTION
The enables using -DUSE_ASAN=1 (cmake option) to build an asan-enabled libfdb_c.so in the foundationdb-build docker image, which should be useful for detecting things like memory errors or memory leaks in the multiversion client. fdbserver simulation still isn't ready for asan. CC #3854 (not closing it for now to track publishing the new image)

Let me know if I missed anything required for updating the Dockerfile (I think I remembered everything)