### PR TITLE
Post release cleanup 6.3.9

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@
 # limitations under the License.
 cmake_minimum_required(VERSION 3.13)
 project(foundationdb
-  VERSION 6.3.9
+  VERSION 6.3.10
   DESCRIPTION "FoundationDB is a scalable, fault-tolerant, ordered key-value store with full ACID transactions."
   HOMEPAGE_URL "http://www.foundationdb.org/"
   LANGUAGES C CXX ASM)

--- a/packaging/msi/FDBInstaller.wxs
+++ b/packaging/msi/FDBInstaller.wxs
@@ -32,7 +32,7 @@
 
 <Wix xmlns='http://schemas.microsoft.com/wix/2006/wi'>
   <Product Name='$(var.Title)'
-           Id='{0AB36B0F-2187-4ECD-9E7E-983EDD966CEB}'
+           Id='{4F01CFD6-596A-4224-BF7D-4AEF30BA2083}'
            UpgradeCode='{A95EA002-686E-4164-8356-C715B7F8B1C8}'
            Version='$(var.Version)'
            Manufacturer='$(var.Manufacturer)'


### PR DESCRIPTION
Step 11 of the release script. 

For 6.3 release (CMake), I have to trick the script by copying the old _versions.target_ from 6.1 (or 6.2) to foundationdb repo, although the file will not be committed. 