### PR TITLE
Misc/bug fixes

### DIFF
--- a/fdbserver/ClusterController.actor.cpp
+++ b/fdbserver/ClusterController.actor.cpp
@@ -1210,7 +1210,7 @@ public:
 		bool oldSatelliteFallback = false;
 
 		for(auto& logSet : dbi.logSystemConfig.tLogs) {
-			if(logSet.isLocal && logSet.locality == tagLocalitySatellite) {
+			if(region.satelliteTLogPolicy.isValid() && logSet.isLocal && logSet.locality == tagLocalitySatellite) {
 				oldSatelliteFallback = logSet.tLogPolicy->info() != region.satelliteTLogPolicy->info();
 				ASSERT(!oldSatelliteFallback || logSet.tLogPolicy->info() == region.satelliteTLogPolicyFallback->info());
 				break;

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -186,7 +186,7 @@ struct StorageServerDisk {
 private:
 	struct StorageServer* data;
 	IKeyValueStore* storage;
-	bool _canPipelineCommits;
+	const bool _canPipelineCommits;
 
 	ACTOR static Future<Key> readFirstKey( IKeyValueStore* storage, KeyRangeRef range ) {
 		Standalone<RangeResultRef> r = wait( storage->readRange( range, 1 ) );


### PR DESCRIPTION
- Fixed a rare segmentation fault caused by invalid pointer.
- Declare `_canPipelineCommits` as `const` as suggested.