### PR TITLE
Disable SnapIncrementalRestore tests temporarily

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -170,7 +170,7 @@ if(WITH_PYTHON)
   add_fdb_test(TEST_FILES rare/WriteTagThrottling.toml)
   add_fdb_test(
     TEST_FILES restarting/from_7.0.0/SnapIncrementalRestore-1.toml
-               restarting/from_7.0.0/SnapIncrementalRestore-2.toml)
+               restarting/from_7.0.0/SnapIncrementalRestore-2.toml IGNORE)
   add_fdb_test(
     TEST_FILES restarting/from_7.0.0/ConfigureTestRestart-1.txt
                restarting/from_7.0.0/ConfigureTestRestart-2.txt)


### PR DESCRIPTION
Avoid running joshua correctness on these test files until https://github.com/apple/foundationdb/issues/3873 is resolved