### PR TITLE
Fix reporting issue with team descriptions in trace logs

### DIFF
--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -175,8 +175,11 @@ public:
 	}
 
 	vector<StorageServerInterface> getLastKnownServerInterfaces() const override {
-		vector<StorageServerInterface> v(servers.size());
-		for (const auto& server : servers) v.push_back(server->lastKnownInterface);
+		vector<StorageServerInterface> v;
+		v.reserve(servers.size());
+		for (const auto& server : servers) {
+			v.push_back(server->lastKnownInterface);
+		}
 		return v;
 	}
 	int size() const override {

--- a/fdbserver/DataDistributionQueue.actor.cpp
+++ b/fdbserver/DataDistributionQueue.actor.cpp
@@ -94,7 +94,7 @@ class ParallelTCInfo : public ReferenceCounted<ParallelTCInfo>, public IDataDist
 
 	template <class T>
 	vector<T> collect(std::function<vector<T>(IDataDistributionTeam const&)> func) const {
-		vector<T> result(teams.size());
+		vector<T> result;
 
 		for (const auto& team : teams) {
 			vector<T> newItems = func(*team);


### PR DESCRIPTION
Fix a couple places where we were creating vectors with default elements rather than reserving space.