### PR TITLE
Fix a silent commit failure in SS commit pipeline

### DIFF
--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -3099,7 +3099,6 @@ ACTOR Future<Void> updateStorage(StorageServer* data) {
 			data->durableInProgress = durableInProgress.getFuture();
 			durable = data->storage.commit(); // Commit data up to(inclusive) version pendingCommitVersion
 			durableMinDelay = delay(SERVER_KNOBS->STORAGE_COMMIT_INTERVAL, TaskPriority::UpdateStorage);
-			debug_advanceMaxCommittedVersion(data->thisServerID, pendingCommitVersion);
 			if (finalCommit) {
 				wait(durable && durableMinDelay);
 				done = true;
@@ -3301,6 +3300,7 @@ ACTOR Future<bool> asyncPrepareVersionsForCommit_impl(StorageServerDisk* self, S
 		// Set the new durable version as part of the outstanding change set, before commit
 		data->storage.makeVersionDurable( newOldestVersion );
 	}
+	debug_advanceMaxCommittedVersion(data->thisServerID, newOldestVersion);
 
 	wait(forgetter.signal());
 	return finalCommit;

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -3274,11 +3274,8 @@ ACTOR Future<bool> asyncPrepareVersionsForCommit_impl(StorageServerDisk* self, S
 			}
 			if (stopEarly.isReady()) {
 				// Previous commit is done.
-				if (durable.isError()) {
-					throw durable.getError();
-				}
-				if (durableMinDelay.isError()) {
-					throw durableMinDelay.getError();
+				if (stopEarly.isError()) {
+					throw stopEarly.getError();
 				}
 				break;
 			}

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -3277,6 +3277,9 @@ ACTOR Future<bool> asyncPrepareVersionsForCommit_impl(StorageServerDisk* self, S
 				if (durable.isError()) {
 					throw durable.getError();
 				}
+				if (durableMinDelay.isError()) {
+					throw durableMinDelay.getError();
+				}
 				break;
 			}
 		} else {


### PR DESCRIPTION
- Moved `debug_advanceMaxCommittedVersion` to right before the commit future is waited. 
- Throw the storage engine commit failure that was previously silently swallowed.

This resolves #3885