### PR TITLE
Fix clang11 warning

### DIFF
--- a/flow/flat_buffers.h
+++ b/flow/flat_buffers.h
@@ -625,7 +625,7 @@ struct TraverseMessageTypes : Context {
 		// we don't need to check for recursion here because the next call
 		// to operator() will do that and we don't generate a vtable for the
 		// vector-like type itself
-		T t;
+		T t{};
 		(*this)(t);
 	}
 
@@ -640,7 +640,7 @@ struct TraverseMessageTypes : Context {
 private:
 	template <class T, class... Ts>
 	void union_helper(pack<T, Ts...>) {
-		T t;
+		T t{};
 		(*this)(t);
 		union_helper(pack<Ts...>{});
 	}


### PR DESCRIPTION
Apparently clang11 warns if you pass uninitialized memory to a function
accepting a const reference. Seems fair. This change doesn't actually
fix any bugs, but it silences the warning.