### PR TITLE
Fix issue -3905

### DIFF
--- a/fdbclient/ReadYourWrites.actor.cpp
+++ b/fdbclient/ReadYourWrites.actor.cpp
@@ -1309,7 +1309,8 @@ Future< Standalone<RangeResultRef> > ReadYourWritesTransaction::getRange(
 	bool reverse )
 {
 	if (getDatabase()->apiVersionAtLeast(630)) {
-		if (specialKeys.contains(begin.getKey()) && end.getKey() <= specialKeys.end) {
+		if (specialKeys.contains(begin.getKey()) && specialKeys.begin <= end.getKey() &&
+		    end.getKey() <= specialKeys.end) {
 			TEST(true); // Special key space get range
 			return getDatabase()->specialKeySpace->getRange(this, begin, end, limits, reverse);
 		}

--- a/fdbclient/SpecialKeySpace.actor.cpp
+++ b/fdbclient/SpecialKeySpace.actor.cpp
@@ -129,7 +129,7 @@ ACTOR Future<Void> normalizeKeySelectorActor(SpecialKeySpace* sks, ReadYourWrite
 
 	if (!ks->isFirstGreaterOrEqual()) {
 		// The Key Selector clamps up to the legal key space
-		TraceEvent(SevInfo, "ReadToBoundary")
+		TraceEvent(SevDebug, "ReadToBoundary")
 		    .detail("TerminateKey", ks->getKey())
 		    .detail("TerminateOffset", ks->offset);
 		if (ks->offset < 1)

--- a/fdbserver/workloads/FuzzApiCorrectness.actor.cpp
+++ b/fdbserver/workloads/FuzzApiCorrectness.actor.cpp
@@ -418,7 +418,11 @@ struct FuzzApiCorrectnessWorkload : TestWorkload {
 			for (size_t j = 0; j < key_size; ++j)
 				skey.append(1, (char) deterministicRandom()->randomInt(0, 256));
 
-			return Key(skey);
+			// 10% of the time generating keys after \xff\xff to test special keys code
+			if (deterministicRandom()->random01() < 0.1)
+				return Key(skey).withPrefix(specialKeys.begin);
+			else
+				return Key(skey);
 		}
 
 		static Value makeValue() {

--- a/fdbserver/workloads/FuzzApiCorrectness.actor.cpp
+++ b/fdbserver/workloads/FuzzApiCorrectness.actor.cpp
@@ -667,7 +667,8 @@ struct FuzzApiCorrectnessWorkload : TestWorkload {
 					limit = deterministicRandom()->randomInt(0, INT_MAX)+1;
 			}
 
-			bool isSpecialKeyRange = specialKeys.contains(keysel1.getKey()) && keysel2.getKey() <= specialKeys.end;
+			bool isSpecialKeyRange = specialKeys.contains(keysel1.getKey()) && specialKeys.begin <= keysel2.getKey() &&
+			                         keysel2.getKey() <= specialKeys.end;
 
 			contract = {
 				std::make_pair(error_code_range_limits_invalid, ExceptionContract::possibleButRequiredIf(limit < 0)),
@@ -705,7 +706,8 @@ struct FuzzApiCorrectnessWorkload : TestWorkload {
 			keysel2 = makeKeySel();
 			limits = makeRangeLimits();
 
-			bool isSpecialKeyRange = specialKeys.contains(keysel1.getKey()) && keysel2.getKey() <= specialKeys.end;
+			bool isSpecialKeyRange = specialKeys.contains(keysel1.getKey()) && specialKeys.begin <= keysel2.getKey() &&
+			                         keysel2.getKey() <= specialKeys.end;
 
 			contract = {
 				std::make_pair(error_code_range_limits_invalid,
@@ -755,7 +757,7 @@ struct FuzzApiCorrectnessWorkload : TestWorkload {
 					limit = deterministicRandom()->randomInt(0, INT_MAX)+1;
 			}
 
-			bool isSpecialKeyRange = specialKeys.contains(key1) && key2 <= specialKeys.end;
+			bool isSpecialKeyRange = specialKeys.contains(key1) && specialKeys.begin <= key2 && key2 <= specialKeys.end;
 
 			contract = {
 				std::make_pair(error_code_inverted_range, ExceptionContract::requiredIf(key1 > key2)),
@@ -795,7 +797,7 @@ struct FuzzApiCorrectnessWorkload : TestWorkload {
 			key2 = makeKey();
 			limits = makeRangeLimits();
 
-			bool isSpecialKeyRange = specialKeys.contains(key1) && key2 <= specialKeys.end;
+			bool isSpecialKeyRange = specialKeys.contains(key1) && specialKeys.begin <= key2 && key2 <= specialKeys.end;
 
 			contract = {
 				std::make_pair(error_code_inverted_range, ExceptionContract::requiredIf(key1 > key2)),

--- a/fdbserver/workloads/FuzzApiCorrectness.actor.cpp
+++ b/fdbserver/workloads/FuzzApiCorrectness.actor.cpp
@@ -418,8 +418,8 @@ struct FuzzApiCorrectnessWorkload : TestWorkload {
 			for (size_t j = 0; j < key_size; ++j)
 				skey.append(1, (char) deterministicRandom()->randomInt(0, 256));
 
-			// 10% of the time generating keys after \xff\xff to test special keys code
-			if (deterministicRandom()->random01() < 0.1)
+			// 15% (= 20% * 75%) of the time generating keys after \xff\xff to test special keys code
+			if (deterministicRandom()->random01() < 0.2)
 				return Key(skey).withPrefix(specialKeys.begin);
 			else
 				return Key(skey);

--- a/fdbserver/workloads/SpecialKeySpaceCorrectness.actor.cpp
+++ b/fdbserver/workloads/SpecialKeySpaceCorrectness.actor.cpp
@@ -119,8 +119,8 @@ struct SpecialKeySpaceCorrectnessWorkload : TestWorkload {
 		Future<Void> f;
 		{
 			ReadYourWritesTransaction ryw{ cx->clone() };
-			if(!ryw.getDatabase()->apiVersionAtLeast(630)) {
-				//This test is not valid for API versions smaller than 630
+			if (!ryw.getDatabase()->apiVersionAtLeast(630)) {
+				// This test is not valid for API versions smaller than 630
 				return;
 			}
 			f = success(ryw.get(LiteralStringRef("\xff\xff/status/json")));
@@ -352,6 +352,18 @@ struct SpecialKeySpaceCorrectnessWorkload : TestWorkload {
 			tx->reset();
 		} catch (Error& e) {
 			throw;
+		}
+		// base key of the end key selector not in (\xff\xff, \xff\xff\xff), throw key_outside_legal_range()
+		try {
+			const KeySelector startKeySelector = KeySelectorRef(LiteralStringRef("\xff\xff/test"), true, -200);
+			const KeySelector endKeySelector = KeySelectorRef(LiteralStringRef("test"), true, -10);
+			Standalone<RangeResultRef> result =
+			    wait(tx->getRange(startKeySelector, endKeySelector, GetRangeLimits(CLIENT_KNOBS->TOO_MANY)));
+			ASSERT(false);
+		} catch (Error& e) {
+			if (e.code() == error_code_actor_cancelled) throw;
+			ASSERT(e.code() == error_code_key_outside_legal_range);
+			tx->reset();
 		}
 
 		return Void();


### PR DESCRIPTION
Previously, we throw `special_keys_cross_module_read` when `SPECIAL_KEY_SPACE_RELAXED` is not enabled if start key is in the special key range but the end key is not.
We did not add the same behavior when `SPECIAL_KEY_SPACE_RELAXED` is enabled, 
thus we saw the inverted range error in #3905 .

This pr does three things: 
- `getRange` only enters the special keyspace code path when both begin key and end key are in (\xff\xff, \xff\xff\xff).

- update the contract in the FuzzApiCorrectness test

- add a test to test this behavior in the SpecialKeySpaceCorrectness test

- Increase the probability(to 15%) of the randomly generated keys in `FuzzApiCorrectness` to go after `\xff\xff`