### PR TITLE
Make getDesiredClusterKeyName const

### DIFF
--- a/fdbclient/ManagementAPI.actor.cpp
+++ b/fdbclient/ManagementAPI.actor.cpp
@@ -1125,7 +1125,7 @@ struct NameQuorumChange final : IQuorumChange {
 	                                                      CoordinatorsResult& t) override {
 		return otherChange->getDesiredCoordinators(tr, oldCoordinators, cf, t);
 	}
-	std::string getDesiredClusterKeyName() const { return newName; }
+	std::string getDesiredClusterKeyName() const override { return newName; }
 };
 Reference<IQuorumChange> nameQuorumChange(std::string const& name, Reference<IQuorumChange> const& other) {
 	return Reference<IQuorumChange>(new NameQuorumChange( name, other ));

--- a/fdbclient/ManagementAPI.actor.h
+++ b/fdbclient/ManagementAPI.actor.h
@@ -140,7 +140,7 @@ struct IQuorumChange : ReferenceCounted<IQuorumChange> {
 	                                                              vector<NetworkAddress> oldCoordinators,
 	                                                              Reference<ClusterConnectionFile>,
 	                                                              CoordinatorsResult&) = 0;
-	virtual std::string getDesiredClusterKeyName() { return std::string(); }
+	virtual std::string getDesiredClusterKeyName() const { return std::string(); }
 };
 
 // Change to use the given set of coordination servers


### PR DESCRIPTION
This fixes a virtual function overload in NameQuorumChange