### PR TITLE
Fix roughness elapsed time

### DIFF
--- a/fdbrpc/Stats.actor.cpp
+++ b/fdbrpc/Stats.actor.cpp
@@ -45,7 +45,7 @@ double Counter::getRate() const {
 }
 
 double Counter::getRoughness() const {
-	double elapsed = now() - roughness_interval_start;
+	double elapsed = last_event - roughness_interval_start;
 	if(elapsed == 0) {
 		return -1;
 	}


### PR DESCRIPTION
The roughness changes made in #2741 claimed that the end of a measurement window after the last event was not considered for roughness. However, that does not seem to have actually been the case. Instead, the entire window plus the time extending to the last event of the previous window were counted.

This had the effect of skewing the mean time between increments because it counted the last span as 0 increments rather than a partial increment. For example, if we have a window running from 10 to 15s, the last previous increment at 8s, and one new increment at 12s, then the old method would compute a mean increment time as (15-8)/1 = 7s. The new approach will ignore all the time after the last increment, and would yield (12-8)/1 = 4s. 

The latter more accurately reflects the time between the increments we observed, and in the case that the next increment happens at, say 16s, we would no longer have a mean that is larger than any of the overlapping increments.