### PR TITLE
Fix deserialization issue with out of order SpanContextMessage

### DIFF
--- a/fdbserver/ApplyMetadataMutation.cpp
+++ b/fdbserver/ApplyMetadataMutation.cpp
@@ -55,12 +55,12 @@ void applyMetadataMutations(SpanID const& spanContext, UID const& dbgid, Arena& 
                             std::map<Tag, Version>* tag_popped, bool initialCommit) {
 	//std::map<keyRef, vector<uint16_t>> cacheRangeInfo;
 	std::map<KeyRef, MutationRef> cachedRangeInfo;
-	if (toCommit) {
-		toCommit->addTransactionInfo(spanContext);
-	}
 
 	for (auto const& m : mutations) {
 		//TraceEvent("MetadataMutation", dbgid).detail("M", m.toString());
+		if (toCommit) {
+			toCommit->addTransactionInfo(spanContext);
+		}
 
 		if (m.param1.size() && m.param1[0] == systemKeys.begin[0] && m.type == MutationRef::SetValue) {
 			if(m.param1.startsWith(keyServersPrefix)) {

--- a/fdbserver/LogSystem.h
+++ b/fdbserver/LogSystem.h
@@ -934,6 +934,11 @@ struct LogPushData : NonCopyable {
 			for (int loc : msg_locations) {
 				writeTransactionInfo(loc);
 			}
+		} else {
+			// When writing a metadata message, make sure transaction state has
+			// been reset. If you are running into this assertion, make sure
+			// you are calling addTransactionInfo before each transaction.
+			ASSERT(transactionSubseq == 0);
 		}
 
 		uint32_t subseq = this->subsequence++;

--- a/fdbserver/LogSystem.h
+++ b/fdbserver/LogSystem.h
@@ -934,6 +934,8 @@ struct LogPushData : NonCopyable {
 			// subsequence wasn't actually used and can be decremented.
 			if (!updatedLocation) {
 				this->subsequence--;
+				TEST(true);  // No new SpanContextMessage written to transaction logs
+				ASSERT(this->subsequence > 0);
 			}
 		} else {
 			// When writing a metadata message, make sure transaction state has
@@ -992,6 +994,7 @@ private:
 			return false;
 		}
 
+		TEST(true);  // Wrote SpanContextMessage to a transaction log
 		writtenLocations.insert(location);
 
 		BinaryWriter& wr = messagesWriter[location];


### PR DESCRIPTION
**Failed test:** *slow/ParallelRestoreOldBackupCorrectnessCycle.toml*
**Seed:** *891553841*
**Buggify:** *off*
**Commit:** *053cbc23690db7af63ee874c7d7ae1ce7cf999ff*
**Compiler:** *gcc/g++*

```
./bin/fdbserver -r simulation -f ../foundationdb/tests/slow/ParallelRestoreOldBackupCorrectnessCycle.toml --buggify off --seed 891553841
```

This addresses a failure found in the nightly, related to https://github.com/apple/foundationdb/pull/3748. The error caused was an [assertion failure](https://github.com/apple/foundationdb/blob/053cbc23690db7af63ee874c7d7ae1ce7cf999ff/flow/serialize.h#L109) in `serialize.h` where the protocol version was 0 when attempting to deserialize a `MutationRef`.

After investigation, there are a few things that went wrong. First, a bug in [`applyMetadataMutations`](https://github.com/apple/foundationdb/blob/053cbc23690db7af63ee874c7d7ae1ce7cf999ff/fdbserver/ApplyMetadataMutation.cpp#L48) caused multiple metadata `LogProtocolMessage` messages to be written to the transaction logs without resetting the transaction state in between each message. The effect of this was that `SpanContextMessage`s were not being sent to some transaction logs in specific conditions, and more importantly smaller subsequence values were written for later messages in the message stream (see second issue below).

The proxy accepts a batch of transactions, breaks them down into individual mutations, and sends a stream of mutations to the transaction logs. Additional `LogProtocolMessage`s are also interspersed throughout this stream, which are special metadata messages used to tell the transaction logs which protocol version to use. In addition, #3748 adds a new message type, `SpanContextMessage`. This message is prepended to each set of mutations in a transaction to allow the transaction logs to identify which mutations are part of which transaction. Therefore, there can be one or more mutations for each `SpanContextMessage` in the message stream between the proxy and the transaction logs.

When writing a message (a `LogProtocolMessage`, `SpanContextMessage`, or mutation) on the commit proxy, it is not written to just one "location" (transaction log). Each message has a set of transaction logs it will be sent to. If a transaction consists of more than one mutation, it is possible for each mutation to have a slightly different set of destination transaction logs (this is based on the key of the mutation). Thus, when writing a message, state is kept about whether each transaction log in the messages destination has had a `SpanContextMessage` written to it already. By failing to reset this state, the next time a metadata message was written, if it had a destination which overlapped with the previous message, no `SpanContextMessage` was written to this transaction log because the system thought it had already written the `SpanContextMessage` to the location. Additionally, for transaction logs that had not had a `SpanContextMessage` written to them yet, one was written using the smaller subsequence value from the first `SpanContextMessage` written in the transaction. This PR adds an assertion to make sure transaction state has been cleared when writing a metadata message.

The second issue is that subsequence values inserted into `SpanContextMessage`s in certain situations were being set to a smaller value than previous messages written to the message stream. This caused the receiver to incorrectly reorder them. The end effect was the storage server attempting to deserialize a `MutationRef` before reading a `LogProtocolMessage`. But since the receipt of a `LogProtocolMessage` is what [allows the storage server to set its protocol version](https://github.com/apple/foundationdb/blob/053cbc23690db7af63ee874c7d7ae1ce7cf999ff/fdbserver/storageserver.actor.cpp#L2956), attempting to deserialize the `MutationRef` caused an assertion failure saying the protocol version had not been set.

The case where this issue occurs is when writing multiple mutations for a single transaction. Previously, all mutations for a given transaction would use the same subsequence value for their `SpanContextMessage`s. But later `LogProtocolMessage`s written for later mutations in a transaction [continued to increment the `subsequence` field](https://github.com/apple/foundationdb/blob/053cbc23690db7af63ee874c7d7ae1ce7cf999ff/fdbserver/LogSystem.h#L939). Since `LogProtocolMessage`s are written before `SpanContextMessage`s, they should always have a smaller subsequence value.

When the [messages are read in by the cursor system](https://github.com/apple/foundationdb/blob/053cbc23690db7af63ee874c7d7ae1ce7cf999ff/fdbserver/LogSystemPeekCursor.actor.cpp#L96), subsequence information is stored in a [`LogMessageVersion`](https://github.com/apple/foundationdb/blob/053cbc23690db7af63ee874c7d7ae1ce7cf999ff/fdbclient/FDBTypes.h#L857) type, which implements `operator<` for comparison. This comparison is used in [`ILogSystem::ServerPeekCursor::advanceTo`](https://github.com/apple/foundationdb/blob/053cbc23690db7af63ee874c7d7ae1ce7cf999ff/fdbserver/LogSystemPeekCursor.actor.cpp#L124), which is where I believe the messages get reordered (it may be somewhere else, not 100% sure here).

The fix I implemented for the second issue is to always assign the latest `subsequence` value to `SpanContextMessage`s.