### PR TITLE
Added detailed logging for PRIORITY_TEAM_0_LEFT

### DIFF
--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -2206,7 +2206,7 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 
 				if (addedTeams <= 0 && self->teams.size() == 0) {
 					TraceEvent(SevWarn, "NoTeamAfterBuildTeam", self->distributorId)
-					    .detail("ServdfTeamNum", self->teams.size())
+					    .detail("ServerTeamNum", self->teams.size())
 					    .detail("Debug", "Check information below");
 					// Debug: set true for traceAllInfo() to print out more information
 					self->traceAllInfo();
@@ -3133,7 +3133,7 @@ ACTOR Future<Void> teamTracker(DDTeamCollection* self, Reference<TCTeamInfo> tea
 					}
 
 					if(logTeamEvents) {
-						TraceEvent("ServewrTeamHealthDifference", self->distributorId)
+						TraceEvent("ServerTeamHealthDifference", self->distributorId)
 						    .detail("ServerTeam", team->getDesc())
 						    .detail("LastOptimal", lastOptimal)
 						    .detail("LastHealthy", lastHealthy)

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -3258,7 +3258,7 @@ ACTOR Future<Void> teamTracker(DDTeamCollection* self, Reference<TCTeamInfo> tea
 					if(logTeamEvents) {
 						TraceEvent("ServerTeamHealthNotReady", self->distributorId)
 						    .detail("HealthyServerTeamCount", self->healthyTeamCount)
-						    .detail("ServgetTeamIDerTeamID", team->getTeamID());
+						    .detail("ServerTeamID", team->getTeamID());
 					}
 				}
 			}

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -203,7 +203,7 @@ public:
 		}
 	}
 
-	UID getTeamID() override { return id; }
+	std::string getTeamID() override { return id.shortString(); }
 
 	virtual vector<StorageServerInterface> getLastKnownServerInterfaces() {
 		vector<StorageServerInterface> v;
@@ -1362,7 +1362,7 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 			    .detail("Healthy", team->isHealthy())
 			    .detail("TeamSize", team->size())
 			    .detail("MemberIDs", team->getServerIDsStr())
-			    .detail("TeamID", team->getTeamID().shortString());
+			    .detail("TeamID", team->getTeamID());
 		}
 	}
 
@@ -2491,7 +2491,7 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 				TraceEvent("ServerTeamRemoved")
 				    .detail("Primary", primary)
 				    .detail("TeamServerIDs", teams[t]->getServerIDsStr())
-				    .detail("TeamID", teams[t]->getTeamID().shortString());
+				    .detail("TeamID", teams[t]->getTeamID());
 				// removeTeam also needs to remove the team from the machine team info.
 				removeTeam(teams[t]);
 				t--;
@@ -2958,7 +2958,7 @@ ACTOR Future<Void> serverTeamRemover(DDTeamCollection* self) {
 
 			TraceEvent("ServerTeamRemover", self->distributorId)
 			    .detail("ServerTeamToRemove", st->getServerIDsStr())
-			    .detail("ServerTeamID", st->getTeamID().shortString())
+			    .detail("ServerTeamID", st->getTeamID())
 			    .detail("NumProcessTeamsOnTheServerTeam", maxNumProcessTeams)
 			    .detail("CurrentServerTeams", self->teams.size())
 			    .detail("DesiredServerTeams", desiredServerTeams);
@@ -2988,7 +2988,7 @@ ACTOR Future<Void> zeroServerLeftLogger_impl(DDTeamCollection* self, Reference<T
 	for (auto const& shard : shards) {
 		sizes.emplace_back(brokenPromiseToNever(self->getShardMetrics.getReply(GetMetricsRequest(shard))));
 		TraceEvent(SevWarnAlways, "DDShardLost", self->distributorId)
-		    .detail("ServerTeamID", team->getTeamID().shortString())
+		    .detail("ServerTeamID", team->getTeamID())
 		    .detail("ShardBegin", shard.begin)
 		    .detail("ShardEnd", shard.end);
 	}
@@ -3258,7 +3258,7 @@ ACTOR Future<Void> teamTracker(DDTeamCollection* self, Reference<TCTeamInfo> tea
 					if(logTeamEvents) {
 						TraceEvent("ServerTeamHealthNotReady", self->distributorId)
 						    .detail("HealthyServerTeamCount", self->healthyTeamCount)
-						    .detail("ServerTeamID", team->getTeamID().shortString());
+						    .detail("ServgetTeamIDerTeamID", team->getTeamID());
 					}
 				}
 			}

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -3180,8 +3180,8 @@ ACTOR Future<Void> teamTracker(DDTeamCollection* self, Reference<TCTeamInfo> tea
 						zeroServerLeftLogger = Void();
 					}
 					if (logTeamEvents) {
-						auto dataLoss = team->getPriority() == SERVER_KNOBS->PRIORITY_TEAM_0_LEFT;
-						auto severity = dataLoss ? SevWarnAlways : SevInfo;
+						int dataLoss = team->getPriority() == SERVER_KNOBS->PRIORITY_TEAM_0_LEFT;
+						Severity severity = dataLoss ? SevWarnAlways : SevInfo;
 						TraceEvent(severity, "ServerTeamPriorityChange", self->distributorId)
 						    .detail("Priority", team->getPriority())
 						    .detail("Info", team->getDesc())

--- a/fdbserver/DataDistribution.actor.h
+++ b/fdbserver/DataDistribution.actor.h
@@ -63,7 +63,7 @@ struct IDataDistributionTeam {
 
 	std::string getDesc() {
 		const auto& servers = getLastKnownServerInterfaces();
-		std::string s = format("[TeamID - %s]", getTeamID().shortString());
+		std::string s = format("[TeamID - %s]", getTeamID().shortString().c_str());
 		s += format("Size %d; ", servers.size());
 		for(int i=0; i<servers.size(); i++) {
 			if (i) s += ", ";

--- a/fdbserver/DataDistribution.actor.h
+++ b/fdbserver/DataDistribution.actor.h
@@ -59,10 +59,12 @@ struct IDataDistributionTeam {
 	virtual bool isWrongConfiguration() = 0;
 	virtual void setWrongConfiguration(bool) = 0;
 	virtual void addServers(const vector<UID> &servers) = 0;
+	virtual UID getTeamID() = 0;
 
 	std::string getDesc() {
 		const auto& servers = getLastKnownServerInterfaces();
-		std::string s = format("Size %d; ", servers.size());
+		std::string s = format("[TeamID - %s]", getTeamID().shortString());
+		s += format("Size %d; ", servers.size());
 		for(int i=0; i<servers.size(); i++) {
 			if (i) s += ", ";
 			s += servers[i].address().toString() + " " + servers[i].id().shortString();

--- a/fdbserver/DataDistribution.actor.h
+++ b/fdbserver/DataDistribution.actor.h
@@ -59,11 +59,11 @@ struct IDataDistributionTeam {
 	virtual bool isWrongConfiguration() = 0;
 	virtual void setWrongConfiguration(bool) = 0;
 	virtual void addServers(const vector<UID> &servers) = 0;
-	virtual UID getTeamID() = 0;
+	virtual std::string getTeamID() = 0;
 
 	std::string getDesc() {
 		const auto& servers = getLastKnownServerInterfaces();
-		std::string s = format("TeamID:%s", getTeamID().shortString().c_str());
+		std::string s = format("TeamID:%s", getTeamID().c_str());
 		s += format("Size %d; ", servers.size());
 		for(int i=0; i<servers.size(); i++) {
 			if (i) s += ", ";

--- a/fdbserver/DataDistribution.actor.h
+++ b/fdbserver/DataDistribution.actor.h
@@ -63,7 +63,7 @@ struct IDataDistributionTeam {
 
 	std::string getDesc() {
 		const auto& servers = getLastKnownServerInterfaces();
-		std::string s = format("[TeamID - %s]", getTeamID().shortString().c_str());
+		std::string s = format("TeamID:%s", getTeamID().shortString().c_str());
 		s += format("Size %d; ", servers.size());
 		for(int i=0; i<servers.size(); i++) {
 			if (i) s += ", ";

--- a/fdbserver/DataDistributionQueue.actor.cpp
+++ b/fdbserver/DataDistributionQueue.actor.cpp
@@ -82,11 +82,14 @@ struct RelocateData {
 };
 
 class ParallelTCInfo : public ReferenceCounted<ParallelTCInfo>, public IDataDistributionTeam {
+private:
+	UID id;
+
 public:
 	vector<Reference<IDataDistributionTeam>> teams;
 	vector<UID> tempServerIDs;
 
-	ParallelTCInfo() { }
+	ParallelTCInfo() : id(deterministicRandom()->randomUniqueID()) {}
 
 	void addTeam(Reference<IDataDistributionTeam> team) {
 		teams.push_back(team);
@@ -250,6 +253,8 @@ public:
 		ASSERT(!teams.empty());
 		teams[0]->addServers(servers);
 	}
+
+	UID getTeamID() override { return id; }
 };
 
 struct Busyness {

--- a/fdbserver/DataDistributionQueue.actor.cpp
+++ b/fdbserver/DataDistributionQueue.actor.cpp
@@ -254,7 +254,14 @@ public:
 		teams[0]->addServers(servers);
 	}
 
-	UID getTeamID() override { return id; }
+	std::string getTeamID() override {
+		std::string id;
+		for (int i = 0; i < teams.size(); i++) {
+			auto const& team = teams[i];
+			id += (i == teams.size() - 1) ? team->getTeamID() : format("%s, ", team->getTeamID().c_str());
+		}
+		return id;
+	}
 };
 
 struct Busyness {

--- a/fdbserver/DataDistributionQueue.actor.cpp
+++ b/fdbserver/DataDistributionQueue.actor.cpp
@@ -82,14 +82,11 @@ struct RelocateData {
 };
 
 class ParallelTCInfo : public ReferenceCounted<ParallelTCInfo>, public IDataDistributionTeam {
-private:
-	UID id;
-
 public:
 	vector<Reference<IDataDistributionTeam>> teams;
 	vector<UID> tempServerIDs;
 
-	ParallelTCInfo() : id(deterministicRandom()->randomUniqueID()) {}
+	ParallelTCInfo() {}
 
 	void addTeam(Reference<IDataDistributionTeam> team) {
 		teams.push_back(team);

--- a/fdbserver/Knobs.cpp
+++ b/fdbserver/Knobs.cpp
@@ -221,6 +221,7 @@ ServerKnobs::ServerKnobs(bool randomize, ClientKnobs* clientKnobs, bool isSimula
 	init( DD_ENABLE_VERBOSE_TRACING,                           false ); if( randomize && BUGGIFY ) DD_ENABLE_VERBOSE_TRACING = true;
 	init( DD_TEAMS_INFO_PRINT_INTERVAL,                           60 ); if( randomize && BUGGIFY ) DD_TEAMS_INFO_PRINT_INTERVAL = 10;
 	init( DD_TEAMS_INFO_PRINT_YIELD_COUNT,                       100 ); if( randomize && BUGGIFY ) DD_TEAMS_INFO_PRINT_YIELD_COUNT = deterministicRandom()->random01() * 1000 + 1;
+	init( DD_TEAM_ZERO_SERVER_LEFT_LOG_DELAY,                    120 );
 
 	// TeamRemover
 	init( TR_FLAG_DISABLE_MACHINE_TEAM_REMOVER,                false ); if( randomize && BUGGIFY ) TR_FLAG_DISABLE_MACHINE_TEAM_REMOVER = deterministicRandom()->random01() < 0.1 ? true : false; // false by default. disable the consistency check when it's true

--- a/fdbserver/Knobs.cpp
+++ b/fdbserver/Knobs.cpp
@@ -221,7 +221,7 @@ ServerKnobs::ServerKnobs(bool randomize, ClientKnobs* clientKnobs, bool isSimula
 	init( DD_ENABLE_VERBOSE_TRACING,                           false ); if( randomize && BUGGIFY ) DD_ENABLE_VERBOSE_TRACING = true;
 	init( DD_TEAMS_INFO_PRINT_INTERVAL,                           60 ); if( randomize && BUGGIFY ) DD_TEAMS_INFO_PRINT_INTERVAL = 10;
 	init( DD_TEAMS_INFO_PRINT_YIELD_COUNT,                       100 ); if( randomize && BUGGIFY ) DD_TEAMS_INFO_PRINT_YIELD_COUNT = deterministicRandom()->random01() * 1000 + 1;
-	init( DD_TEAM_ZERO_SERVER_LEFT_LOG_DELAY,                    120 );
+	init( DD_TEAM_ZERO_SERVER_LEFT_LOG_DELAY,                    120 ); if( randomize && BUGGIFY ) DD_TEAM_ZERO_SERVER_LEFT_LOG_DELAY = 5;
 
 	// TeamRemover
 	init( TR_FLAG_DISABLE_MACHINE_TEAM_REMOVER,                false ); if( randomize && BUGGIFY ) TR_FLAG_DISABLE_MACHINE_TEAM_REMOVER = deterministicRandom()->random01() < 0.1 ? true : false; // false by default. disable the consistency check when it's true

--- a/fdbserver/Knobs.h
+++ b/fdbserver/Knobs.h
@@ -184,6 +184,7 @@ public:
 	bool DD_ENABLE_VERBOSE_TRACING;
 	int DD_TEAMS_INFO_PRINT_INTERVAL;
 	int DD_TEAMS_INFO_PRINT_YIELD_COUNT;
+	int DD_TEAM_ZERO_SERVER_LEFT_LOG_DELAY;
 
 	// TeamRemover to remove redundant teams
 	bool TR_FLAG_DISABLE_MACHINE_TEAM_REMOVER; // disable the machineTeamRemover actor


### PR DESCRIPTION
Added detailed logging, with level `SevWarnAlways`, when there is no servers left in a server team, because if all servers in a server team are permanently lost, all shards on them will not be able to be replicated to other servers and thus that means data in those shards are now lost.