### PR TITLE
Fix a race between submit and abort backup

### DIFF
--- a/fdbclient/BackupAgent.actor.h
+++ b/fdbclient/BackupAgent.actor.h
@@ -428,7 +428,8 @@ public:
 		return runRYWTransaction(cx, [=](Reference<ReadYourWritesTransaction> tr){ return discontinueBackup(tr, tagName); });
 	}
 
-	Future<Void> abortBackup(Database cx, Key tagName, bool partial = false, bool abortOldBackup = false, bool dstOnly = false);
+	Future<Void> abortBackup(Database cx, Key tagName, bool partial = false, bool abortOldBackup = false,
+	                         bool dstOnly = false, bool waitForDestUID = false);
 
 	Future<std::string> getStatus(Database cx, int errorLimit, Key tagName);
 

--- a/fdbclient/DatabaseBackupAgent.actor.cpp
+++ b/fdbclient/DatabaseBackupAgent.actor.cpp
@@ -2098,7 +2098,8 @@ public:
 		return Void();
 	}
 
-	ACTOR static Future<Void> abortBackup(DatabaseBackupAgent* backupAgent, Database cx, Key tagName, bool partial, bool abortOldBackup, bool dstOnly) {
+	ACTOR static Future<Void> abortBackup(DatabaseBackupAgent* backupAgent, Database cx, Key tagName, bool partial,
+	                                      bool abortOldBackup, bool dstOnly, bool waitForDestUID) {
 		state Reference<ReadYourWritesTransaction> tr(new ReadYourWritesTransaction(cx));
 		state Key logUidValue, destUidValue;
 		state UID logUid, destUid;
@@ -2125,7 +2126,7 @@ public:
 				UID destUid = destUidFuture.get();
 				if (destUid.isValid()) {
 					destUidValue = BinaryWriter::toValue(destUid, Unversioned());
-				} else if (destUidValue.size() == 0) {
+				} else if (destUidValue.size() == 0 && waitForDestUID) {
 					// Give DR task a chance to update destUid to avoid the problem of
 					// leftover version key. If we got an commit_unknown_result before,
 					// reuse the previous destUidValue.
@@ -2459,8 +2460,9 @@ Future<Void> DatabaseBackupAgent::discontinueBackup(Reference<ReadYourWritesTran
 	return DatabaseBackupAgentImpl::discontinueBackup(this, tr, tagName);
 }
 
-Future<Void> DatabaseBackupAgent::abortBackup(Database cx, Key tagName, bool partial, bool abortOldBackup, bool dstOnly){
-	return DatabaseBackupAgentImpl::abortBackup(this, cx, tagName, partial, abortOldBackup, dstOnly);
+Future<Void> DatabaseBackupAgent::abortBackup(Database cx, Key tagName, bool partial, bool abortOldBackup, bool dstOnly,
+                                              bool waitForDestUID) {
+	return DatabaseBackupAgentImpl::abortBackup(this, cx, tagName, partial, abortOldBackup, dstOnly, waitForDestUID);
 }
 
 Future<std::string> DatabaseBackupAgent::getStatus(Database cx, int errorLimit, Key tagName) {

--- a/fdbclient/DatabaseBackupAgent.actor.cpp
+++ b/fdbclient/DatabaseBackupAgent.actor.cpp
@@ -2125,9 +2125,10 @@ public:
 				UID destUid = destUidFuture.get();
 				if (destUid.isValid()) {
 					destUidValue = BinaryWriter::toValue(destUid, Unversioned());
-				} else {
+				} else if (destUidValue.size() == 0) {
 					// Give DR task a chance to update destUid to avoid the problem of
-					// leftover version key.
+					// leftover version key. If we got an commit_unknown_result before,
+					// reuse the previous destUidValue.
 					throw not_committed();
 				}
 

--- a/fdbserver/workloads/BackupToDBCorrectness.actor.cpp
+++ b/fdbserver/workloads/BackupToDBCorrectness.actor.cpp
@@ -339,6 +339,7 @@ struct BackupToDBCorrectnessWorkload : TestWorkload {
 
 			try {
 				tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
+				tr->setOption(FDBTransactionOptions::LOCK_AWARE);
 
 				// Check the left over tasks
 				// We have to wait for the list to empty since an abort and get status

--- a/fdbserver/workloads/BackupToDBCorrectness.actor.cpp
+++ b/fdbserver/workloads/BackupToDBCorrectness.actor.cpp
@@ -545,9 +545,11 @@ struct BackupToDBCorrectnessWorkload : TestWorkload {
 
 				TraceEvent("BARW_AbortBackupExtra", randomID).detail("BackupTag", printable(self->backupTag));
 				try {
-					wait(backupAgent.abortBackup(self->extraDB, self->backupTag));
-				}
-				catch (Error& e) {
+					// This abort can race with submitBackup such that destUID may
+					// not be set yet. Adding "waitForDestUID" flag to avoid the race.
+					wait(backupAgent.abortBackup(self->extraDB, self->backupTag, /*partial=*/false,
+					                             /*abortOldBackup=*/false, /*dstOnly=*/false, /*waitForDestUID*/ true));
+				} catch (Error& e) {
 					TraceEvent("BARW_AbortBackupExtraException", randomID).error(e);
 					if (e.code() != error_code_backup_unneeded)
 						throw;

--- a/fdbserver/workloads/BackupToDBUpgrade.actor.cpp
+++ b/fdbserver/workloads/BackupToDBUpgrade.actor.cpp
@@ -148,6 +148,7 @@ struct BackupToDBUpgradeWorkload : TestWorkload {
 
 			try {
 				tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
+				tr->setOption(FDBTransactionOptions::LOCK_AWARE);
 
 				// Check the left over tasks
 				// We have to wait for the list to empty since an abort and get status


### PR DESCRIPTION
After submit a backup, immediately abort the backup may cause a rare race
condition, which results in `BackupCorrectnessLeftoverVersionKey` error.

Specifically, in the `StartFullBackupTaskFunc`:
1st Txn sets the `destUid` at the source database and the 2nd Txn writes it to the dest DB.

An abort can come after the 1st Txn succeeds, and clears the config rage so
that the 2nd Txn above would fail. Because 2nd Txn didn't write `destUid`, the
3rd Txn of abort can't read the correct source DB for `latestVersionKey`, which
contains the `destUid` value.

The fix is to let the 1st Txn of abort to wait until `destUid` becomes valid, and this is wait is currently only added to the test workload, i.e., `BackupToDBCorrectness.actor.cpp`. The `fdbdr` command behaves as before.