### PR TITLE
Shorten larger keys to 64 bytes by hashing it

### DIFF
--- a/fdbclient/BlobStore.actor.cpp
+++ b/fdbclient/BlobStore.actor.cpp
@@ -951,8 +951,12 @@ Future<std::vector<std::string>> BlobStoreEndpoint::listBuckets() {
 std::string BlobStoreEndpoint::hmac_sha1(std::string const &msg) {
 	std::string key = secret;
 
-	// First pad the key to 64 bytes.
-	key.append(64 - key.size(), '\0');
+	if (key.size() > 64) {
+		key = SHA1::from_string(key);
+	} else {
+		// First pad the key to 64 bytes.
+		key.append(64 - key.size(), '\0');
+	}
 
 	std::string kipad = key;
 	for(int i = 0; i < 64; ++i)


### PR DESCRIPTION
Resolves #3951 