### PR TITLE
Shorten keys larger than 64 bytes by hashing it

### DIFF
--- a/fdbclient/BlobStore.actor.cpp
+++ b/fdbclient/BlobStore.actor.cpp
@@ -951,6 +951,9 @@ Future<std::vector<std::string>> BlobStoreEndpoint::listBuckets() {
 std::string BlobStoreEndpoint::hmac_sha1(std::string const &msg) {
 	std::string key = secret;
 
+	if (key.size() > 64)
+		key = SHA1::from_string(key);
+
 	// First pad the key to 64 bytes.
 	key.append(64 - key.size(), '\0');
 


### PR DESCRIPTION
`key` larger than 64 bytes should be hashed to create a new `key`.

**From [HMAC: Keyed-Hashing for Message Authentication (RFC-2104)](https://tools.ietf.org/html/rfc2104#section-2)**
> The authentication key K can be of any length up to B, the
   block length of the hash function.  Applications that use keys longer
   than B bytes will first hash the key using H and then use the
   resultant L byte string as the actual key to HMAC. 

Resolves #3951 