### PR TITLE
Extend lifetime of dataDistributionTracker to avoid heap use after free

### DIFF
--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -4319,8 +4319,8 @@ ACTOR Future<Void> dataDistribution(Reference<DataDistributorData> self)
 			    reportErrorsExcept(dataDistributionTracker(initData, cx, output, shardsAffectedByTeamFailure,
 			                                               getShardMetrics, getAverageShardBytes.getFuture(),
 			                                               readyToStart, anyZeroHealthyTeams, self->ddId, &shards),
-			                       "DDTracker", self->ddId, &normalDDQueueErrors())
-			        actors.push_back(dataDistributionTrackerFuture);
+			                       "DDTracker", self->ddId, &normalDDQueueErrors());
+			actors.push_back(dataDistributionTrackerFuture);
 			actors.push_back(reportErrorsExcept(
 			    dataDistributionQueue(cx, output, input.getFuture(), getShardMetrics, processingUnhealthy, tcis,
 			                          shardsAffectedByTeamFailure, lock, getAverageShardBytes, self->ddId,


### PR DESCRIPTION
Attempt to fix this memory error reported by valgrind:
```
==3970== Invalid read of size 8                                                                                                                                                                                                                                                 [757/922]
==3970==    at 0xC73D77: onChange (genericactors.actor.h:694)
==3970==    by 0xC73D77: a_body1 (DataDistributionTracker.actor.cpp:616)
==3970==    by 0xC73D77: ShardEvaluatorActor (DataDistributionTracker.actor.g.cpp:3338)
==3970==    by 0xC73D77: shardEvaluator(DataDistributionTracker* const&, Standalone<KeyRangeRef> const&, Reference<AsyncVar<Optional<ShardMetrics> > > const&, Reference<HasBeenTrueFor> const&) (DataDistributionTracker.actor.cpp:610)
==3970==    by 0xC75396: a_body1cont6loopBody1 (DataDistributionTracker.actor.cpp:697)
==3970==    by 0xC75396: a_body1cont6loopHead1 (DataDistributionTracker.actor.g.cpp:3852)
==3970==    by 0xC75396: a_body1cont6loopBody1cont2 (DataDistributionTracker.actor.g.cpp:3969)
==3970==    by 0xC75396: a_body1cont6loopBody1cont1when1 (DataDistributionTracker.actor.g.cpp:3981)
==3970==    by 0xC75396: a_body1cont6loopBody1cont1when1 (DataDistributionTracker.actor.g.cpp:3979)
==3970==    by 0xC75396: a_callback_fire (DataDistributionTracker.actor.g.cpp:4002)
==3970==    by 0xC75396: ActorCallback<(anonymous namespace)::ShardTrackerActor, 5, Void>::fire(Void const&) (flow.h:1009)
==3970==    by 0xC8379F: void SAV<Void>::send<Void>(Void&&) (flow.h:449)
==3970==    by 0x2484C97: send<Void> (flow.h:783)
==3970==    by 0x2484C97: execTask (sim2.actor.cpp:1665)
==3970==    by 0x2484C97: Sim2::RunLoopActorState<Sim2::RunLoopActor>::a_body1loopBody1cont1(Void const&, int) [clone .constprop.2497] (sim2.actor.cpp:972)
==3970==    by 0x24A24CF: a_body1loopBody1when1 (sim2.actor.g.cpp:6798)
==3970==    by 0x24A24CF: Sim2::RunLoopActorState<Sim2::RunLoopActor>::a_body1loopBody1(int) (sim2.actor.g.cpp:6712)
==3970==    by 0x2484D9C: a_body1loopHead1 (sim2.actor.g.cpp:6695)
==3970==    by 0x2484D9C: Sim2::RunLoopActorState<Sim2::RunLoopActor>::a_body1loopBody1cont1(Void const&, int) [clone .constprop.2497] (sim2.actor.g.cpp:6761)
==3970==    by 0x24A25FB: a_body1loopBody1when1 (sim2.actor.g.cpp:6798)
==3970==    by 0x24A25FB: a_callback_fire (sim2.actor.g.cpp:6819)
==3970==    by 0x24A25FB: ActorCallback<Sim2::RunLoopActor, 0, Void>::fire(Void const&) (flow.h:1009)
==3970==    by 0xC8379F: void SAV<Void>::send<Void>(Void&&) (flow.h:449)
==3970==    by 0x25627C3: send<Void> (flow.h:783)
==3970==    by 0x25627C3: operator() (Net2.actor.cpp:936)
==3970==    by 0x25627C3: N2::Net2::run() (Net2.actor.cpp:1270)
==3970==    by 0x24A2732: Sim2::run() (sim2.actor.cpp:986)
==3970==    by 0x80B863: main (fdbserver.actor.cpp:1858)
==3970==  Address 0x10f7b740 is 320 bytes inside a block of size 512 free'd
==3970==    at 0x253BF5C: FastAllocator<512>::release(void*) (FastAlloc.cpp:354)
==3970==    by 0xC6A6E3: a_body1Catch1 (DataDistributionTracker.actor.g.cpp:5690)
==3970==    by 0xC6A6E3: (anonymous namespace)::DataDistributionTrackerActorState<(anonymous namespace)::DataDistributionTrackerActor>::a_body1Catch2(Error const&, int) [clone .isra.1162] (DataDistributionTracker.actor.cpp:892)
==3970==    by 0xC6A741: (anonymous namespace)::DataDistributionTrackerActorState<(anonymous namespace)::DataDistributionTrackerActor>::a_callback_error(ActorCallback<(anonymous namespace)::DataDistributionTrackerActor, 2, Void>*, Error) [clone .isra.1166] (DataDistributionTracker
.actor.g.cpp:6163)
==3970==    by 0xC6A7EC: (anonymous namespace)::DataDistributionTrackerActor::cancel() (DataDistributionTracker.actor.g.cpp:6234)
==3970==    by 0xB8E500: ~ReportErrorsExceptActorState (genericactors.actor.g.h:12241)
==3970==    by 0xB8E500: a_body1Catch1 (genericactors.actor.g.h:12274)
==3970==    by 0xB8E500: (anonymous namespace)::ReportErrorsExceptActorState<Void, (anonymous namespace)::ReportErrorsExceptActor<Void> >::a_body1Catch2(Error const&, int) [clone .isra.3764] (genericactors.actor.h:1083)
==3970==    by 0xB8E5B6: a_callback_error (genericactors.actor.g.h:12380)
==3970==    by 0xB8E5B6: cancel (genericactors.actor.g.h:12427)
==3970==    by 0xB8E5B6: (anonymous namespace)::ReportErrorsExceptActor<Void>::cancel() (genericactors.actor.g.h:12422)
==3970==    by 0x9008EB: remove (flow.h:377)
==3970==    by 0x9008EB: Quorum<Void>::cancel() (genericactors.actor.h:918)
==3970==    by 0xBE16E5: remove (flow.h:377)
==3970==    by 0xBE16E5: a_exitChoose9 (DataDistribution.actor.g.cpp:24225)
==3970==    by 0xBE16E5: a_callback_error (DataDistribution.actor.g.cpp:24261)
==3970==    by 0xBE16E5: (anonymous namespace)::DataDistributionActor::cancel() (DataDistribution.actor.g.cpp:24570)
==3970==    by 0xB8E500: ~ReportErrorsExceptActorState (genericactors.actor.g.h:12241)
==3970==    by 0xB8E500: a_body1Catch1 (genericactors.actor.g.h:12274)
==3970==    by 0xB8E500: (anonymous namespace)::ReportErrorsExceptActorState<Void, (anonymous namespace)::ReportErrorsExceptActor<Void> >::a_body1Catch2(Error const&, int) [clone .isra.3764] (genericactors.actor.h:1083)
==3970==    by 0xB8E5B6: a_callback_error (genericactors.actor.g.h:12380)
==3970==    by 0xB8E5B6: cancel (genericactors.actor.g.h:12427)
==3970==    by 0xB8E5B6: (anonymous namespace)::ReportErrorsExceptActor<Void>::cancel() (genericactors.actor.g.h:12422)
==3970==    by 0xBA98A5: (anonymous namespace)::DataDistributorActorState<(anonymous namespace)::DataDistributorActor>::~DataDistributorActorState() (DataDistribution.actor.g.cpp:27977)
==3970==    by 0xBA9EA5: a_body1cont1 (DataDistribution.actor.g.cpp:28028)
==3970==    by 0xBA9EA5: a_body1cont3 (DataDistribution.actor.g.cpp:28466)
==3970==    by 0xBA9EA5: a_body1cont2 (DataDistribution.actor.g.cpp:28062)
==3970==    by 0xBA9EA5: a_body1break1 (DataDistribution.actor.g.cpp:28116)
==3970==    by 0xBA9EA5: (anonymous namespace)::DataDistributorActorState<(anonymous namespace)::DataDistributorActor>::a_body1loopBody1when2(HaltDataDistributorRequest&&, int) [clone .isra.3984] (DataDistribution.actor.g.cpp:28170)
```