### PR TITLE
Only serialize span if TLogVersion >= 6

### DIFF
--- a/fdbserver/LogSystem.h
+++ b/fdbserver/LogSystem.h
@@ -985,7 +985,7 @@ private:
 	// Writes transaction info to the message stream for the given location if
 	// it has not already been written (for the current transaction).
 	void writeTransactionInfo(int location) {
-		if (!FLOW_KNOBS->WRITE_TRACING_ENABLED) {
+		if (!FLOW_KNOBS->WRITE_TRACING_ENABLED || logSystem->getTLogVersion() < TLogVersion::V6) {
 			return;
 		}
 		if (writtenLocations.count(location) == 0) {


### PR DESCRIPTION
To enable downgrades from 7.0.0 to 6.3.5, features associated with `TLogVersion::V6` need to be disabled by default in 7.0.0. This PR fixes an issue where `SpanContextMessage`s, a feature associated with `TLogVersion::V6` (#3748), were being sent from the proxy to the transaction logs even for `TLogVersion::V5`.

Fixes #3909.