### PR TITLE
TestHarness uses fdbserver version as upper bound for upgrade tests

### DIFF
--- a/contrib/Joshua/scripts/correctnessTest.sh
+++ b/contrib/Joshua/scripts/correctnessTest.sh
@@ -1,3 +1,5 @@
 #!/bin/sh
+
 OLDBINDIR="${OLDBINDIR:-/app/deploy/global_data/oldBinaries}"
-mono bin/TestHarness.exe joshua-run "${OLDBINDIR}" false
+FDBVER=`"${SCRIPTDIR}/bin/fdbserver" --version | head -n1 | sed -e 's/.*(v//' -e 's/[-a-zA-Z]*)//'`
+mono bin/TestHarness.exe joshua-run "${OLDBINDIR}" "${FDBVER}" false

--- a/contrib/Joshua/scripts/correctnessTest.sh
+++ b/contrib/Joshua/scripts/correctnessTest.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
 OLDBINDIR="${OLDBINDIR:-/app/deploy/global_data/oldBinaries}"
-FDBVER=`"${SCRIPTDIR}/bin/fdbserver" --version | head -n1 | sed -e 's/.*(v//' -e 's/[-a-zA-Z]*)//'`
+FDBVER=`bin/fdbserver --version | head -n1 | sed -e 's/.*(v//' -e 's/[-a-zA-Z]*)//'`
 mono bin/TestHarness.exe joshua-run "${OLDBINDIR}" "${FDBVER}" false

--- a/contrib/Joshua/scripts/valgrindTest.sh
+++ b/contrib/Joshua/scripts/valgrindTest.sh
@@ -1,3 +1,5 @@
 #!/bin/sh
+
 OLDBINDIR="${OLDBINDIR:-/app/deploy/global_data/oldBinaries}"
-mono bin/TestHarness.exe joshua-run "${OLDBINDIR}" true
+FDBVER=`"${SCRIPTDIR}/bin/fdbserver" --version | head -n1 | sed -e 's/.*(v//' -e 's/[-a-zA-Z]*)//'`
+mono bin/TestHarness.exe joshua-run "${OLDBINDIR}" "${FDBVER}" true

--- a/contrib/Joshua/scripts/valgrindTest.sh
+++ b/contrib/Joshua/scripts/valgrindTest.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
 OLDBINDIR="${OLDBINDIR:-/app/deploy/global_data/oldBinaries}"
-FDBVER=`"${SCRIPTDIR}/bin/fdbserver" --version | head -n1 | sed -e 's/.*(v//' -e 's/[-a-zA-Z]*)//'`
+FDBVER=`bin/fdbserver --version | head -n1 | sed -e 's/.*(v//' -e 's/[-a-zA-Z]*)//'`
 mono bin/TestHarness.exe joshua-run "${OLDBINDIR}" "${FDBVER}" true

--- a/contrib/TestHarness/Program.cs.cmake
+++ b/contrib/TestHarness/Program.cs.cmake
@@ -1522,7 +1522,7 @@ namespace SummarizeTest
             Console.WriteLine("  TestHarness auto [temp/runDir] [directory] [shareDir] <useValgrind> <maxTries>");
             Console.WriteLine("  TestHarness remote [queue folder] [root foundation folder] [duration in hours] [amount of tests] [all/fast/<test_path>] [scope]");
             Console.WriteLine("  TestHarness extract-errors [summary-file] [error-summary-file]");
-            Console.WriteLine("  TestHarness joshua-run <useValgrind> <maxTries>");
+            Console.WriteLine("  TestHarness joshua-run [oldBinaryDir] [fdbVersion] <useValgrind> <maxTries>");
             VersionInfo();
             return 1;
         }


### PR DESCRIPTION
This fixes #3942.