### PR TITLE
Bug fix: remove the check of Content-MD5 on responses

### DIFF
--- a/fdbclient/HTTP.actor.cpp
+++ b/fdbclient/HTTP.actor.cpp
@@ -281,11 +281,6 @@ namespace HTTP {
 			throw http_bad_response();
 		}
 
-		// If there is actual response content, check the MD5 sum against the Content-MD5 response header
-		if(r->content.size() > 0)
-			if(!r->verifyMD5(false))  // false arg means do not fail if the Content-MD5 header is missing.
-				throw http_bad_response();
-
 		return Void();
 	}
 


### PR DESCRIPTION
The [AWS S3 specs](https://docs.aws.amazon.com/AmazonS3/latest/API/s3-api.pdf) don't specify there will be `Content-MD5` header on responses (except to some special requests).

https://forums.foundationdb.org/t/foundatiodbbackup-against-azure-blobstore-unknown-error/2404/8