### PR TITLE
Add a way to decorate the trace event created by `traceCounters` with more details.

### DIFF
--- a/fdbrpc/Stats.actor.cpp
+++ b/fdbrpc/Stats.actor.cpp
@@ -76,7 +76,9 @@ void CounterCollection::logToTraceEvent(TraceEvent &te) const {
 	}
 }
 
-ACTOR Future<Void> traceCounters(std::string traceEventName, UID traceEventID, double interval, CounterCollection* counters, std::string trackLatestName) {
+ACTOR Future<Void> traceCounters(std::string traceEventName, UID traceEventID, double interval,
+                                 CounterCollection* counters, std::string trackLatestName,
+                                 std::function<void(TraceEvent&)> decorator) {
 	wait(delay(0)); // Give an opportunity for all members used in special counters to be initialized
 
 	for (ICounter* c : counters->counters)
@@ -89,6 +91,7 @@ ACTOR Future<Void> traceCounters(std::string traceEventName, UID traceEventID, d
 		te.detail("Elapsed", now() - last_interval);
 
 		counters->logToTraceEvent(te);
+		decorator(te);
 
 		if (!trackLatestName.empty()) {
 			te.trackLatest(trackLatestName);

--- a/fdbrpc/Stats.h
+++ b/fdbrpc/Stats.h
@@ -132,7 +132,9 @@ struct SpecialCounter : ICounter, FastAllocated<SpecialCounter<F>>, NonCopyable 
 template <class F>
 static void specialCounter(CounterCollection& collection, std::string const& name, F && f) { new SpecialCounter<F>(collection, name, std::move(f)); }
 
-Future<Void> traceCounters(std::string const& traceEventName, UID const& traceEventID, double const& interval, CounterCollection* const& counters, std::string const& trackLatestName = std::string());
+Future<Void> traceCounters(std::string const& traceEventName, UID const& traceEventID, double const& interval,
+                           CounterCollection* const& counters, std::string const& trackLatestName = std::string(),
+                           std::function<void(TraceEvent&)> const& decorator = [](TraceEvent& te) {});
 
 class LatencyBands {
 public:

--- a/fdbserver/LogRouter.actor.cpp
+++ b/fdbserver/LogRouter.actor.cpp
@@ -149,9 +149,11 @@ struct LogRouterData {
 		specialCounter(cc, "WaitForVersionMaxMS", [this](){ double val = this->maxWaitForVersionTime; this->maxWaitForVersionTime = 0; return 1000*val; });
 		specialCounter(cc, "GetMoreMS", [this](){ double val = this->getMoreTime; this->getMoreTime = 0; return 1000*val; });
 		specialCounter(cc, "GetMoreMaxMS", [this](){ double val = this->maxGetMoreTime; this->maxGetMoreTime = 0; return 1000*val; });
-		specialCounter(cc, "PrimaryPeekLocation", [this]() { return this->primaryPeekLocation; });
-		logger =
-		    traceCounters("LogRouterMetrics", dbgid, SERVER_KNOBS->WORKER_LOGGING_INTERVAL, &cc, "LogRouterMetrics");
+		logger = traceCounters("LogRouterMetrics", dbgid, SERVER_KNOBS->WORKER_LOGGING_INTERVAL, &cc,
+		                       "LogRouterMetrics", [this](TraceEvent& te) {
+			                       te.detail("PrimaryPeekLocation", this->primaryPeekLocation);
+			                       te.detail("RouterTag", this->routerTag)
+		                       });
 	}
 };
 

--- a/fdbserver/LogRouter.actor.cpp
+++ b/fdbserver/LogRouter.actor.cpp
@@ -153,7 +153,7 @@ struct LogRouterData {
 		specialCounter(cc, "WaitForVersionMaxMS", [this](){ double val = this->maxWaitForVersionTime; this->maxWaitForVersionTime = 0; return 1000*val; });
 		specialCounter(cc, "GetMoreMS", [this](){ double val = this->getMoreTime; this->getMoreTime = 0; return 1000*val; });
 		specialCounter(cc, "GetMoreMaxMS", [this](){ double val = this->maxGetMoreTime; this->maxGetMoreTime = 0; return 1000*val; });
-		specialCounter(cc, "Geneartion", [this]() { return this->generation; });
+		specialCounter(cc, "Generation", [this]() { return this->generation; });
 		logger = traceCounters("LogRouterMetrics", dbgid, SERVER_KNOBS->WORKER_LOGGING_INTERVAL, &cc,
 		                       "LogRouterMetrics", [this](TraceEvent& te) {
 			                       te.detail("PrimaryPeekLocation", this->primaryPeekLocation);

--- a/fdbserver/LogRouter.actor.cpp
+++ b/fdbserver/LogRouter.actor.cpp
@@ -152,7 +152,7 @@ struct LogRouterData {
 		logger = traceCounters("LogRouterMetrics", dbgid, SERVER_KNOBS->WORKER_LOGGING_INTERVAL, &cc,
 		                       "LogRouterMetrics", [this](TraceEvent& te) {
 			                       te.detail("PrimaryPeekLocation", this->primaryPeekLocation);
-			                       te.detail("RouterTag", this->routerTag);
+			                       te.detail("RouterTag", this->routerTag.toString());
 		                       });
 	}
 };

--- a/fdbserver/LogRouter.actor.cpp
+++ b/fdbserver/LogRouter.actor.cpp
@@ -149,7 +149,8 @@ struct LogRouterData {
 		specialCounter(cc, "WaitForVersionMaxMS", [this](){ double val = this->maxWaitForVersionTime; this->maxWaitForVersionTime = 0; return 1000*val; });
 		specialCounter(cc, "GetMoreMS", [this](){ double val = this->getMoreTime; this->getMoreTime = 0; return 1000*val; });
 		specialCounter(cc, "GetMoreMaxMS", [this](){ double val = this->maxGetMoreTime; this->maxGetMoreTime = 0; return 1000*val; });
-		specialCounter(cc, "PrimaryPeekLocation", [this]() { return this->primaryPeekLocation; }) logger =
+		specialCounter(cc, "PrimaryPeekLocation", [this]() { return this->primaryPeekLocation; });
+		logger =
 		    traceCounters("LogRouterMetrics", dbgid, SERVER_KNOBS->WORKER_LOGGING_INTERVAL, &cc, "LogRouterMetrics");
 	}
 };

--- a/fdbserver/LogRouter.actor.cpp
+++ b/fdbserver/LogRouter.actor.cpp
@@ -90,7 +90,7 @@ struct LogRouterData {
 	double maxWaitForVersionTime = 0;
 	double getMoreTime = 0;
 	double maxGetMoreTime = 0;
-	uint64_t generation = -1;
+	int64_t generation = -1;
 
 	struct PeekTrackerData {
 		std::map<int, Promise<std::pair<Version, bool>>> sequence_version;

--- a/fdbserver/LogRouter.actor.cpp
+++ b/fdbserver/LogRouter.actor.cpp
@@ -152,7 +152,7 @@ struct LogRouterData {
 		logger = traceCounters("LogRouterMetrics", dbgid, SERVER_KNOBS->WORKER_LOGGING_INTERVAL, &cc,
 		                       "LogRouterMetrics", [this](TraceEvent& te) {
 			                       te.detail("PrimaryPeekLocation", this->primaryPeekLocation);
-			                       te.detail("RouterTag", this->routerTag)
+			                       te.detail("RouterTag", this->routerTag);
 		                       });
 	}
 };

--- a/fdbserver/TLogServer.actor.cpp
+++ b/fdbserver/TLogServer.actor.cpp
@@ -576,6 +576,7 @@ struct LogData : NonCopyable, public ReferenceCounted<LogData> {
 		specialCounter(cc, "QueueDiskBytesTotal", [tLogData](){ return tLogData->rawPersistentQueue->getStorageBytes().total; });
 		specialCounter(cc, "PeekMemoryReserved", [tLogData]() { return tLogData->peekMemoryLimiter.activePermits(); });
 		specialCounter(cc, "PeekMemoryRequestsStalled", [tLogData]() { return tLogData->peekMemoryLimiter.waiters(); });
+		specialCounter(cc, "Geneartion", [this]() { return this->recoveryCount; });
 	}
 
 	~LogData() {

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -3406,9 +3406,10 @@ ACTOR Future<Void> metricsCore( StorageServer* self, StorageServerInterface ssi 
 
 	wait( self->byteSampleRecovery );
 
+	Tag tag = self->tag;
 	actors.add(traceCounters("StorageMetrics", self->thisServerID, SERVER_KNOBS->STORAGE_LOGGING_DELAY,
 	                         &self->counters.cc, self->thisServerID.toString() + "/StorageMetrics",
-	                         [self](TraceEvent& te) { te.detail("Tag", self->tag); }));
+	                         [tag](TraceEvent& te) { te.detail("Tag", tag.toString()); }));
 
 	loop {
 		choose {

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -3406,7 +3406,9 @@ ACTOR Future<Void> metricsCore( StorageServer* self, StorageServerInterface ssi 
 
 	wait( self->byteSampleRecovery );
 
-	actors.add(traceCounters("StorageMetrics", self->thisServerID, SERVER_KNOBS->STORAGE_LOGGING_DELAY, &self->counters.cc, self->thisServerID.toString() + "/StorageMetrics"));
+	actors.add(traceCounters("StorageMetrics", self->thisServerID, SERVER_KNOBS->STORAGE_LOGGING_DELAY,
+	                         &self->counters.cc, self->thisServerID.toString() + "/StorageMetrics",
+	                         [self](TraceEvent& te) { te.detail("Tag", self->tag); }));
 
 	loop {
 		choose {


### PR DESCRIPTION
- Attach the paired TLog ID to `LogRouterMetrics` and router tag for better discoverability.
- Attach the storage server's tag to `StorageMetrics` too.
- Attach the generation(recovery count) to TLog and LogRouter metrics.