### PR TITLE
Open random tracer in simulation

### DIFF
--- a/fdbserver/fdbserver.actor.cpp
+++ b/fdbserver/fdbserver.actor.cpp
@@ -1635,6 +1635,7 @@ int main(int argc, char* argv[]) {
 			//startOldSimulator();
 			startNewSimulator();
 			openTraceFile(NetworkAddress(), opts.rollsize, opts.maxLogsSize, opts.logFolder, "trace", opts.logGroup);
+			openTracer(TracerType(deterministicRandom()->randomInt(static_cast<int>(TracerType::DISABLED), static_cast<int>(TracerType::END))));
 		} else {
 			g_network = newNet2(opts.tlsConfig, opts.useThreadPool, true);
 			g_network->addStopCallback( Net2FileSystem::stop );

--- a/flow/Tracing.cpp
+++ b/flow/Tracing.cpp
@@ -30,6 +30,9 @@ struct NoopTracer : ITracer {
 struct LogfileTracer : ITracer {
 	TracerType type() const { return TracerType::LOG_FILE; }
 	void trace(Span const& span) override {
+		if (g_network->isSimulated()) {
+			return;
+		}
 		TraceEvent te(SevInfo, "TracingSpan", span.context);
 		te.detail("Location", span.location.name)
 			.detail("Begin", format("%.6f", span.begin))

--- a/flow/Tracing.cpp
+++ b/flow/Tracing.cpp
@@ -60,6 +60,9 @@ void openTracer(TracerType type) {
 	case TracerType::LOG_FILE:
 		g_tracer = new LogfileTracer{};
 		break;
+	case TracerType::END:
+		ASSERT(false);
+		break;
 	}
 }
 

--- a/flow/Tracing.h
+++ b/flow/Tracing.h
@@ -73,7 +73,11 @@ struct Span {
 	SmallVectorRef<SpanID> parents;
 };
 
-enum class TracerType { DISABLED, LOG_FILE };
+enum class TracerType {
+	DISABLED = 0,
+	LOG_FILE = 1,
+	END = 2
+};
 
 struct ITracer {
 	virtual ~ITracer();


### PR DESCRIPTION
Tracing should be tested in simulation. This PR opens a random tracer when a simulation test is run.

**Context:** #3329.

@sfc-gh-mpilman should `TraceEvent`s be disabled in simulation? Could this effect speed of simulation tests?