### PR TITLE
Lightweight, power of two spaced histogram implementation + automatic reporting

### DIFF
--- a/fdbrpc/sim2.actor.cpp
+++ b/fdbrpc/sim2.actor.cpp
@@ -102,8 +102,6 @@ bool onlyBeforeSimulatorInit() {
 
 const UID TOKEN_ENDPOINT_NOT_FOUND(-1, -1);
 
-ISimulator* g_pSimulator = 0;
-thread_local ISimulator::ProcessInfo* ISimulator::currentProcess = 0;
 int openCount = 0;
 
 struct SimClogging {

--- a/fdbrpc/simulator.h
+++ b/fdbrpc/simulator.h
@@ -23,6 +23,7 @@
 #pragma once
 
 #include "flow/flow.h"
+#include "flow/Histogram.h"
 #include "fdbrpc/FailureMonitor.h"
 #include "fdbrpc/Locality.h"
 #include "fdbrpc/IAsyncFile.h"
@@ -54,6 +55,7 @@ public:
 		LocalityData	locality;
 		ProcessClass startingClass;
 		TDMetricCollection tdmetrics;
+		HistogramRegistry histograms;
 		std::map<NetworkAddress, Reference<IListener>> listenerMap;
 		bool failed;
 		bool excluded;

--- a/fdbserver/workloads/KVStoreTest.actor.cpp
+++ b/fdbserver/workloads/KVStoreTest.actor.cpp
@@ -28,9 +28,9 @@
 extern IKeyValueStore *makeDummyKeyValueStore();
 
 template <class T>
-class Histogram {
+class TestHistogram {
 public:
-	Histogram(int minSamples = 100) : minSamples(minSamples) { reset(); }
+	TestHistogram(int minSamples = 100) : minSamples(minSamples) { reset(); }
 
 	void reset(){
 		N = 0;
@@ -153,7 +153,7 @@ struct KVTest {
 	}
 };
 
-ACTOR Future<Void> testKVRead( KVTest* test, Key key, Histogram<float>* latency, PerfIntCounter* count ) {
+ACTOR Future<Void> testKVRead( KVTest* test, Key key, TestHistogram<float>* latency, PerfIntCounter* count ) {
 	//state Version s1 = test->lastCommit;
 	state Version s2 = test->lastDurable;
 
@@ -171,7 +171,7 @@ ACTOR Future<Void> testKVRead( KVTest* test, Key key, Histogram<float>* latency,
 	return Void();
 }
 
-ACTOR Future<Void> testKVReadSaturation( KVTest* test, Histogram<float>* latency, PerfIntCounter* count ) {
+ACTOR Future<Void> testKVReadSaturation( KVTest* test, TestHistogram<float>* latency, PerfIntCounter* count ) {
 	while (true) {
 		state double begin = timer();
 		Optional<Value> val = wait( test->store->readValue(test->randomKey()) );
@@ -181,7 +181,7 @@ ACTOR Future<Void> testKVReadSaturation( KVTest* test, Histogram<float>* latency
 	}
 }
 
-ACTOR Future<Void> testKVCommit( KVTest* test, Histogram<float>* latency, PerfIntCounter* count ) {
+ACTOR Future<Void> testKVCommit( KVTest* test, TestHistogram<float>* latency, PerfIntCounter* count ) {
 	state Version v = test->lastSet;
 	test->lastCommit = v;
 	state double begin = timer();
@@ -202,7 +202,7 @@ struct KVStoreTestWorkload : TestWorkload {
 	bool doSetup, doClear, doCount;
 	std::string filename;
 	PerfIntCounter reads, sets, commits;
-	Histogram<float> readLatency, commitLatency;
+	TestHistogram<float> readLatency, commitLatency;
 	double setupTook;
 	std::string storeType;
 
@@ -232,7 +232,7 @@ struct KVStoreTestWorkload : TestWorkload {
 		return Void();
 	}
 	virtual Future<bool> check( Database const& cx ) { return true; }
-	void metricsFromHistogram(vector<PerfMetric>& m, std::string name, Histogram<float>& h){
+	void metricsFromHistogram(vector<PerfMetric>& m, std::string name, TestHistogram<float>& h){
 		m.push_back( PerfMetric( "Min " + name, 1000.0 * h.min(), true) );
 		m.push_back( PerfMetric( "Average " + name, 1000.0 * h.mean(), true) );
 		m.push_back( PerfMetric( "Median " + name, 1000.0 * h.medianEstimate(), true) );

--- a/flow/CMakeLists.txt
+++ b/flow/CMakeLists.txt
@@ -24,6 +24,8 @@ set(FLOW_SRCS
   FileTraceLogWriter.h
   Hash3.c
   Hash3.h
+  Histogram.cpp
+  Histogram.h
   IDispatched.h
   IRandom.h
   IThreadPool.cpp

--- a/flow/Histogram.cpp
+++ b/flow/Histogram.cpp
@@ -71,7 +71,7 @@ void HistogramRegistry::unregisterHistogram(Histogram * h) {
             .detail("group", h->group)
             .detail("op", h->op);
     }
-    ASSERT_EQ(histograms.erase(h->name()), 1);
+    ASSERT(histograms.erase(h->name()) == 1);
 }
 
 void HistogramRegistry::logReport() {
@@ -101,21 +101,11 @@ void Histogram::writeToLog() {
             case Unit::microseconds:
             {
                 uint32_t usec = ((uint32_t)1)<<i;
-                // C++20: format string using std::format.  eg: std::format("{:03d}", usec % 100) 
-                // size:  3 bytes after decimal
-                //        1 bytes for decimal
-                //        1 byte for null
-                //        7 bytes in 4 million
-
-                char decimal[12];
-                snprintf(decimal, 12, "%u.%03u", usec / 1000, usec % 1000);
-                e.detail(decimal, buckets[i]);
+                e.detail(format("%u.%03u", usec / 1000, usec % 1000), buckets[i]);
                 break;
             }
             case Unit::bytes:
-                char decimal[11];
-                snprintf(decimal, 11, "%u", ((uint32_t)1)<<i);
-                e.detail(decimal, buckets[i]);
+                e.detail(format("%u", ((uint32_t)1)<<i), buckets[i]);
                 break;
             default:
                 ASSERT(false);

--- a/flow/Histogram.cpp
+++ b/flow/Histogram.cpp
@@ -1,0 +1,125 @@
+/*
+ * Histogram.cpp
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2018 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <flow/Histogram.h>
+#include <flow/Trace.h>
+// TODO: remove dependency on fdbrpc.
+
+// we need to be able to check if we're in simulation so that the histograms are properly
+// scoped to the right "machine".
+// either we pull g_simulator into flow, or flow (and the I/O path) will be unable to log performance
+// metrics.
+#include <fdbrpc/simulator.h>
+
+// pull in some global pointers too:  These types are implemented in fdbrpc/sim2.actor.cpp, which is not available here.  Yuck.
+// If you're not using the simulator, these will remain null, and all should be well.
+
+// TODO: create a execution context abstraction that allows independent flow instances within a process.
+// The simulator would be the main user of it, and histogram would be the only other user (for now).
+ISimulator* g_pSimulator = nullptr;
+thread_local ISimulator::ProcessInfo* ISimulator::currentProcess = nullptr;
+
+// Fallback registry when we're not in simulation -- if we had execution contexts we wouldn't need to check if
+// we have a simulated contex here; we'd just use the current context regardless.
+static HistogramRegistry * globalHistograms = nullptr;
+
+HistogramRegistry & GetHistogramRegistry() {
+    ISimulator::ProcessInfo * info = g_simulator.getCurrentProcess();
+
+    if (info) {
+        // in simulator; scope histograms to simulated process
+        return info->histograms;
+    }
+    // avoid link order issues where the registry hasn't been initialized, but we're
+    // instantiating a histogram
+    if (globalHistograms == nullptr) {
+        globalHistograms = new HistogramRegistry();
+    }
+    return *globalHistograms;
+}
+
+void HistogramRegistry::registerHistogram(Histogram * h) {
+    if (histograms.find(h->name()) != histograms.end()) {
+        TraceEvent(SevError, "HistogramDoubleRegistered")
+            .detail("group", h->group)
+            .detail("op", h->op);
+        ASSERT(false);
+    }
+    histograms.insert(std::pair<std::string, Histogram*>(h->name(), h));
+}
+
+void HistogramRegistry::unregisterHistogram(Histogram * h) {
+    if (histograms.find(h->name()) == histograms.end()) {
+        TraceEvent(SevError, "HistogramNotRegistered")
+            .detail("group", h->group)
+            .detail("op", h->op);
+    }
+    ASSERT_EQ(histograms.erase(h->name()), 1);
+}
+
+void HistogramRegistry::logReport() {
+    for (auto & i : histograms) {
+        i.second->writeToLog();
+        i.second->clear();
+    }
+}
+
+void Histogram::writeToLog() {
+    bool active = false;
+    for (uint32_t i = 0; i < 32; i++) {
+        if (buckets[i]) {
+            active = true;
+            break;
+        }
+    }
+    if (!active) {
+        return ;
+    }
+
+    TraceEvent e(SevInfo, "Histogram");
+    e.detail("Group", group).detail("Op", op);
+    for (uint32_t i = 0; i < 32; i++) {
+        if (buckets[i]) {
+            switch(unit) {
+            case Unit::microseconds:
+            {
+                uint32_t usec = ((uint32_t)1)<<i;
+                // C++20: format string using std::format.  eg: std::format("{:03d}", usec % 100) 
+                // size:  3 bytes after decimal
+                //        1 bytes for decimal
+                //        1 byte for null
+                //        7 bytes in 4 million
+
+                char decimal[12];
+                snprintf(decimal, 12, "%u.%03u", usec / 1000, usec % 1000);
+                e.detail(decimal, buckets[i]);
+                break;
+            }
+            case Unit::bytes:
+                char decimal[11];
+                snprintf(decimal, 11, "%u", ((uint32_t)1)<<i);
+                e.detail(decimal, buckets[i]);
+                break;
+            default:
+                ASSERT(false);
+            }
+        }
+    }
+}

--- a/flow/Histogram.h
+++ b/flow/Histogram.h
@@ -1,0 +1,96 @@
+/*
+ * Histogram.h
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2018 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FLOW_HISTOGRAM_H
+#define FLOW_HISTOGRAM_H
+#pragma once
+
+#include <string>
+#include <map>
+
+#ifdef _WIN32
+#include <intrin.h>
+#pragma intrinsic(_BitScanReverse)
+#endif
+
+class Histogram;
+
+class HistogramRegistry {
+    public:
+        void registerHistogram(Histogram * h);
+        void unregisterHistogram(Histogram * h);
+        void logReport();
+    private:
+        std::map<std::string, Histogram*> histograms;
+};
+
+// TODO: This should be scoped properly for simulation (instead of just having all the "machines" share one histogram namespace)
+HistogramRegistry & GetHistogramRegistry();
+
+class Histogram {
+public:
+    enum class Unit {
+        microseconds,
+        bytes
+    };
+
+    Histogram(char const * group, char const * op, Unit unit) : group(group), op(op), unit(unit), registry(GetHistogramRegistry()) {
+        clear();
+        registry.registerHistogram(this);
+    }
+
+    ~Histogram() {
+        registry.unregisterHistogram(this);
+    }
+
+    inline void sample(uint32_t sample) {
+#ifdef _WIN32
+        unsigned long index;
+        buckets[_BitScanReverse(&index, sample) ? index : 0]++;
+#else
+        buckets[sample ? (31 - __builtin_clz(sample)) : 0]++;
+#endif
+    }
+
+    inline void sampleSeconds(double delta) {
+        sample((uint32_t)(delta * 1000000)); // convert to microseconds and truncate to integer
+    }
+
+    void clear() {
+        for (uint32_t i : buckets) {
+            i = 0;
+        }
+    }
+    void writeToLog();
+
+    std::string name() {
+        return group + ":" + op;
+    }
+
+    std::string const group;
+    std::string const op;
+    Unit const unit;
+    HistogramRegistry & registry;
+    
+private:
+    uint32_t buckets[32];
+};
+
+#endif // FLOW_HISTOGRAM_H

--- a/flow/Histogram.h
+++ b/flow/Histogram.h
@@ -22,6 +22,8 @@
 #define FLOW_HISTOGRAM_H
 #pragma once
 
+#include <flow/Arena.h>
+
 #include <string>
 #include <map>
 
@@ -51,7 +53,7 @@ public:
         bytes
     };
 
-    Histogram(char const * group, char const * op, Unit unit) : group(group), op(op), unit(unit), registry(GetHistogramRegistry()) {
+    Histogram(StringRef group, StringRef op, Unit unit) : group(group.toString()), op(op.toString()), unit(unit), registry(GetHistogramRegistry()) {
         clear();
         registry.registerHistogram(this);
     }
@@ -74,7 +76,7 @@ public:
     }
 
     void clear() {
-        for (uint32_t i : buckets) {
+        for (uint32_t & i : buckets) {
             i = 0;
         }
     }

--- a/flow/SystemMonitor.cpp
+++ b/flow/SystemMonitor.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "flow/flow.h"
+#include "flow/Histogram.h"
 #include "flow/Platform.h"
 #include "flow/TDMetric.actor.h"
 #include "flow/SystemMonitor.h"
@@ -59,6 +60,7 @@ SystemStatistics customSystemMonitor(std::string eventName, StatisticsState *sta
 	netData.init();
 	if (!DEBUG_DETERMINISM && currentStats.initialized) {
 		{
+			GetHistogramRegistry().logReport();
 			TraceEvent(eventName.c_str())
 				.detail("Elapsed", currentStats.elapsed)
 				.detail("CPUSeconds", currentStats.processCPUSeconds)

--- a/flow/Trace.cpp
+++ b/flow/Trace.cpp
@@ -676,6 +676,13 @@ TraceEvent::TraceEvent(TraceEvent &&ev) {
 	tmpEventMetric = ev.tmpEventMetric;
 	trackingKey = ev.trackingKey;
 	type = ev.type;
+	timeIndex = ev.timeIndex;
+
+	for (int i = 0; i < 5; i++) {
+		eventCounts[i] = ev.eventCounts[i];
+	}
+
+	networkThread = ev.networkThread;
 
 	ev.initialized = true;
 	ev.enabled = false;
@@ -684,6 +691,7 @@ TraceEvent::TraceEvent(TraceEvent &&ev) {
 }
 
 TraceEvent& TraceEvent::operator=(TraceEvent &&ev) {
+	// Note: still broken if ev and this are the same memory address.
 	enabled = ev.enabled;
 	err = ev.err;
 	fields = std::move(ev.fields);
@@ -696,6 +704,13 @@ TraceEvent& TraceEvent::operator=(TraceEvent &&ev) {
 	tmpEventMetric = ev.tmpEventMetric;
 	trackingKey = ev.trackingKey;
 	type = ev.type;
+	timeIndex = ev.timeIndex;
+
+	for (int i = 0; i < 5; i++) {
+		eventCounts[i] = ev.eventCounts[i];
+	}
+
+	networkThread = ev.networkThread;
 
 	ev.initialized = true;
 	ev.enabled = false;

--- a/flow/flow.vcxproj
+++ b/flow/flow.vcxproj
@@ -22,11 +22,13 @@
     <ClCompile Include="FileTraceLogWriter.cpp" />
     <ClCompile Include="XmlTraceLogFormatter.cpp" />
     <ClCompile Include="JsonTraceLogFormatter.cpp" />
+    <ClCompile Include="Histogram.cpp" />
     <ClInclude Include="FileTraceLogWriter.h" />
     <ClInclude Include="XmlTraceLogFormatter.h" />
     <ClInclude Include="JsonTraceLogFormatter.h" />
     <ClInclude Include="MetricSample.h" />
     <ClInclude Include="Profiler.h" />
+    <ClInclude Include="Histogram.h" />
     <ActorCompiler Include="Profiler.actor.cpp" />
     <ActorCompiler Include="Net2.actor.cpp" />
     <ClCompile Include="IThreadPool.cpp" />


### PR DESCRIPTION
I tested this on a feature branch (against code that's been rewritten there).  Here's an example of how to use it:

```
diff --git a/fdbrpc/FlowTransport.actor.cpp b/fdbrpc/FlowTransport.actor.cpp
index 0e9f1e54b..400a2cdd3 100644
--- a/fdbrpc/FlowTransport.actor.cpp
+++ b/fdbrpc/FlowTransport.actor.cpp
@@ -34,6 +34,7 @@
 #include "flow/ActorCollection.h"
 #include "flow/Error.h"
 #include "flow/flow.h"
+#include "flow/Histogram.h"
 #include "flow/Net2Packet.h"
 #include "flow/TDMetric.actor.h"
 #include "flow/ObjectSerializer.h"
@@ -236,6 +237,10 @@ public:
 	Int64MetricHandle countConnClosedWithError;
 	Int64MetricHandle countConnClosedWithoutError;
 
+	Histogram readSizeDistribution = {"N2", "ReadSize", Histogram::Unit::bytes};
+	Histogram writeSizeDistribution = {"N2", "WriteSize", Histogram::Unit::bytes};
+	Histogram writeLatencyDistribution = {"N2", "WriteLatency", Histogram::Unit::microseconds};
+
 	std::map<NetworkAddress, std::pair<uint64_t, double>> incompatiblePeers;
 	AsyncTrigger incompatiblePeersChanged;
 	uint32_t numIncompatibleConnections;
@@ -470,10 +475,17 @@ ACTOR Future<Void> connectionWriter( Reference<Peer> self, Reference<IConnection
 			// state int toSend = self->unsent.getUnsent()->unsentBytesInQueue(FLOW_KNOBS->MAX_PACKET_SEND_BYTES);
 			state size_t sent;
 
+			state double start = now();
+
 			wait(conn->asyncWrite(self->unsent.getUnsent(), &sent, FLOW_KNOBS->MAX_PACKET_SEND_BYTES));
 
+			double stop = now();
+
 			// ASSERT_EQ(toSend, sent);
 
+			self->transport->writeLatencyDistribution.sampleSeconds(stop - start);
+			self->transport->writeSizeDistribution.sample(sent);
+
 			if (sent) {
 				self->bytesSent += sent;
 				self->transport->bytesSent += sent;
```

Here's example output.  The goal of this PR is to standardize the API and lifecycle semantics.  We should revisit the log format:
```
$ grep Histogram fdb-temp-cluster/1/log/trace.172.17.0.1.4500.1604179426.SUCb0x.0.1.xml | head
<Event Severity="10" Time="1604179431.404571" Type="Histogram" ID="0000000000000000" Group="N2" Op="WriteLatency" 0.001="40" Machine="172.17.0.1:4500" LogGroup="default" Roles="CC,CD,SS" />
<Event Severity="10" Time="1604179431.404571" Type="Histogram" ID="0000000000000000" Group="N2" Op="WriteSize" 32="1" 64="20" 128="9" 256="1" 512="6" 1024="2" 16384="1" Machine="172.17.0.1:4500" LogGroup="default" Roles="CC,CD,SS" />
<Event Severity="10" Time="1604179436.404581" Type="Histogram" ID="0000000000000000" Group="N2" Op="WriteLatency" 0.001="871" Machine="172.17.0.1:4500" LogGroup="default" Roles="CC,CD,MP,SS,TL" />
<Event Severity="10" Time="1604179436.404581" Type="Histogram" ID="0000000000000000" Group="N2" Op="WriteSize" 32="1" 64="468" 128="291" 256="28" 512="28" 1024="26" 2048="16" 4096="5" 8192="7" 16384="1" Machine="172.17.0.1:4500" LogGroup="default" Roles="CC,CD,MP,SS,TL" />
<Event Severity="10" Time="1604179441.404611" Type="Histogram" ID="0000000000000000" Group="N2" Op="WriteLatency" 0.001="1614" Machine="172.17.0.1:4500" LogGroup="default" Roles="CC,CD,MP,SS,TL" />
<Event Severity="10" Time="1604179441.404611" Type="Histogram" ID="0000000000000000" Group="N2" Op="WriteSize" 32="1" 64="890" 128="545" 256="52" 512="38" 1024="43" 2048="21" 4096="10" 8192="13" 16384="1" Machine="172.17.0.1:4500" LogGroup="default" Roles="CC,CD,MP,SS,TL" />
```