### PR TITLE
Make ConnectionReset logs query friendly #3977

### DIFF
--- a/fdbserver/LogSystemPeekCursor.actor.cpp
+++ b/fdbserver/LogSystemPeekCursor.actor.cpp
@@ -138,7 +138,7 @@ ACTOR Future<Void> resetChecker( ILogSystem::ServerPeekCursor* self, NetworkAddr
 	self->unknownReplies = 0;
 	self->fastReplies = 0;
 	wait(delay(SERVER_KNOBS->PEEK_STATS_INTERVAL));
-	TraceEvent("SlowPeekStats")
+	TraceEvent("SlowPeekStats", self->randomID)
 	    .detail("PeerAddress", addr)
 	    .detail("SlowReplies", self->slowReplies)
 	    .detail("FastReplies", self->fastReplies)
@@ -147,7 +147,7 @@ ACTOR Future<Void> resetChecker( ILogSystem::ServerPeekCursor* self, NetworkAddr
 	if (self->slowReplies >= SERVER_KNOBS->PEEK_STATS_SLOW_AMOUNT &&
 	    self->slowReplies / double(self->slowReplies + self->fastReplies) >= SERVER_KNOBS->PEEK_STATS_SLOW_RATIO) {
 
-		TraceEvent("ConnectionResetSlowPeek")
+		TraceEvent("ConnectionResetSlowPeek", self->randomID)
 		    .detail("PeerAddress", addr)
 		    .detail("SlowReplies", self->slowReplies)
 		    .detail("FastReplies", self->fastReplies)

--- a/fdbserver/LogSystemPeekCursor.actor.cpp
+++ b/fdbserver/LogSystemPeekCursor.actor.cpp
@@ -138,8 +138,20 @@ ACTOR Future<Void> resetChecker( ILogSystem::ServerPeekCursor* self, NetworkAddr
 	self->unknownReplies = 0;
 	self->fastReplies = 0;
 	wait(delay(SERVER_KNOBS->PEEK_STATS_INTERVAL));
-	TraceEvent("SlowPeekStats").detail("PeerAddress", addr).detail("SlowReplies", self->slowReplies).detail("FastReplies", self->fastReplies).detail("UnknownReplies", self->unknownReplies);
-	if(self->slowReplies >= SERVER_KNOBS->PEEK_STATS_SLOW_AMOUNT && self->slowReplies/double(self->slowReplies+self->fastReplies) >= SERVER_KNOBS->PEEK_STATS_SLOW_RATIO) {
+	TraceEvent("SlowPeekStats")
+	    .detail("PeerAddress", addr)
+	    .detail("SlowReplies", self->slowReplies)
+	    .detail("FastReplies", self->fastReplies)
+	    .detail("UnknownReplies", self->unknownReplies);
+
+	if (self->slowReplies >= SERVER_KNOBS->PEEK_STATS_SLOW_AMOUNT &&
+	    self->slowReplies / double(self->slowReplies + self->fastReplies) >= SERVER_KNOBS->PEEK_STATS_SLOW_RATIO) {
+
+		TraceEvent("ConnectionResetSlowPeek")
+		    .detail("PeerAddress", addr)
+		    .detail("SlowReplies", self->slowReplies)
+		    .detail("FastReplies", self->fastReplies)
+		    .detail("UnknownReplies", self->unknownReplies);
 		FlowTransport::transport().resetConnection(addr);
 		self->lastReset = now();
 	}

--- a/fdbserver/MasterProxyServer.actor.cpp
+++ b/fdbserver/MasterProxyServer.actor.cpp
@@ -567,7 +567,7 @@ ACTOR Future<Void> commitBatch(
 		g_traceBatch.addEvent("CommitDebug", debugID.get().first(), "MasterProxyServer.commitBatch.Before");
 
 	if(localBatchNumber-self->latestLocalCommitBatchResolving.get()>SERVER_KNOBS->RESET_MASTER_BATCHES && now()-self->lastMasterReset>SERVER_KNOBS->RESET_MASTER_DELAY) {
-		TraceEvent(SevWarnAlways, "ConnectionResetMaster")
+		TraceEvent(SevWarnAlways, "ConnectionResetMaster", self->dbgid)
 		    .detail("PeerAddress", self->master.address())
 		    .detail("CurrentBatch", localBatchNumber)
 		    .detail("InProcessBatch", self->latestLocalCommitBatchResolving.get());
@@ -635,7 +635,7 @@ ACTOR Future<Void> commitBatch(
 	    now() - self->lastResolverReset > SERVER_KNOBS->RESET_RESOLVER_DELAY) {
 
 		for (int r = 0; r<self->resolvers.size(); r++) {
-			TraceEvent(SevWarnAlways, "ConnectionResetResolver")
+			TraceEvent(SevWarnAlways, "ConnectionResetResolver", self->dbgid)
 			    .detail("PeerAddr", self->resolvers[r].address())
 			    .detail("CurrentBatch", localBatchNumber)
 			    .detail("InProcessBatch", self->latestLocalCommitBatchLogging.get());


### PR DESCRIPTION
All TraceLogs that are related to ConnectionReset should be prefixed with
ConnectionReset. This should make it easy to query and aggregate by address and
role.

These logs should be enough to make Splunk queries and make timecharts quite easily.
Another alternative is logging them periodically, but I'm not sure if that adds any value
currently.