### PR TITLE
Disable WITH_ROCKSDB_EXPERIMENTAL by default on gcc

### DIFF
--- a/cmake/FDBComponents.cmake
+++ b/cmake/FDBComponents.cmake
@@ -107,9 +107,7 @@ endif()
 ################################################################################
 
 set(SSD_ROCKSDB_EXPERIMENTAL OFF CACHE BOOL "Build with experimental RocksDB support")
-# RocksDB is currently enabled by default for GCC but does not build with the latest
-# Clang.
-if (SSD_ROCKSDB_EXPERIMENTAL OR GCC)
+if (SSD_ROCKSDB_EXPERIMENTAL)
   set(WITH_ROCKSDB_EXPERIMENTAL ON)
 else()
   set(WITH_ROCKSDB_EXPERIMENTAL OFF)


### PR DESCRIPTION
This will prevent build failures due to the lz4 dependency.