### PR TITLE
Fix the ability to disable building RocksDB with GCC

### DIFF
--- a/cmake/FDBComponents.cmake
+++ b/cmake/FDBComponents.cmake
@@ -109,7 +109,7 @@ endif()
 set(SSD_ROCKSDB_EXPERIMENTAL OFF CACHE BOOL "Build with experimental RocksDB support")
 # RocksDB is currently enabled by default for GCC but does not build with the latest
 # Clang.
-if (SSD_ROCKSDB_EXPERIMENTAL OR GCC)
+if (SSD_ROCKSDB_EXPERIMENTAL AND GCC)
   set(WITH_ROCKSDB_EXPERIMENTAL ON)
 else()
   set(WITH_ROCKSDB_EXPERIMENTAL OFF)


### PR DESCRIPTION
Prior to this change, it was impossible to disable building RocksDB with GCC. This change has the negative side effect of making it impossible to build RocksDB on not GCC, but that is a minor issue as the version of RocksDB we use doesn't build with the version of Clang we use (we need a release with https://github.com/facebook/rocksdb/pull/7025 in it).