### PR TITLE
When moving dispaching shard relocations, log the source and destinat…

### DIFF
--- a/fdbclient/FDBTypes.h
+++ b/fdbclient/FDBTypes.h
@@ -138,6 +138,10 @@ static std::string describe( Reference<T> const& item ) {
 	return item->toString();
 }
 
+static std::string describe(UID const& item) {
+	return item.shortString();
+}
+
 template <class T>
 static std::string describe( T const& item ) {
 	return item.toString();

--- a/fdbserver/DataDistributionQueue.actor.cpp
+++ b/fdbserver/DataDistributionQueue.actor.cpp
@@ -1045,6 +1045,9 @@ ACTOR Future<Void> dataDistributionRelocator( DDQueueData *self, RelocateData rd
 			} else {
 				TraceEvent(relocateShardInterval.severity, "RelocateShardHasDestination", distributorId)
 				    .detail("PairId", relocateShardInterval.pairID)
+				    .detail("KeyBegin", rd.keys.begin)
+				    .detail("KeyEnd", rd.keys.end)
+				    .detail("SourceServers", describe(rd.src))
 				    .detail("DestinationTeam", describe(destIds))
 				    .detail("ExtraIds", describe(extraIds));
 			}


### PR DESCRIPTION
When moving dispaching shard relocations, log the source and destination storage servers.

The current place where it logs the source and destination might not reflect the most accurate information, and it's not trivial to infer which destination SS is reading data from which source SS, but I will start from here.