### PR TITLE
Add makeReference function

### DIFF
--- a/FDBLibTLS/FDBLibTLSPolicy.cpp
+++ b/FDBLibTLS/FDBLibTLSPolicy.cpp
@@ -293,12 +293,12 @@ bool FDBLibTLSPolicy::set_verify_peers(int count, const uint8_t* verify_peers[],
 					break;
 				}
 				if(split == start || verifyString[split-1] != '\\') {
-					Reference<FDBLibTLSVerify> verify = Reference<FDBLibTLSVerify>(new FDBLibTLSVerify(verifyString.substr(start,split-start)));
+					auto verify = makeReference<FDBLibTLSVerify>(verifyString.substr(start, split - start));
 					verify_rules.push_back(verify);
 					start = split+1;
 				}
 			}
-			Reference<FDBLibTLSVerify> verify = Reference<FDBLibTLSVerify>(new FDBLibTLSVerify(verifyString.substr(start)));
+			auto verify = makeReference<FDBLibTLSVerify>(verifyString.substr(start));
 			verify_rules.push_back(verify);
 		} catch ( const std::runtime_error& ) {
 			verify_rules.clear();

--- a/FDBLibTLS/verify-test.cpp
+++ b/FDBLibTLS/verify-test.cpp
@@ -66,7 +66,7 @@ static void logf(const char* event, void* uid, bool is_error, ...) {
 int FDBLibTLSVerifyTest::run() {
 	Reference<FDBLibTLSVerify> verify;
 	try {
-		verify = Reference<FDBLibTLSVerify>(new FDBLibTLSVerify(input));
+		verify = makeReference<FDBLibTLSVerify>(input);
 	} catch ( const std::runtime_error& e ) {
 		if (valid) {
 			std::cerr << "FAIL: Verify test failed, but should have succeeded - '" << input << "'\n";
@@ -102,8 +102,8 @@ int FDBLibTLSVerifyTest::run() {
 }
 
 static int policy_verify_test() {
-	Reference<FDBLibTLSPlugin> plugin = Reference<FDBLibTLSPlugin>(new FDBLibTLSPlugin());
-	Reference<FDBLibTLSPolicy> policy = Reference<FDBLibTLSPolicy>(new FDBLibTLSPolicy(plugin, (ITLSLogFunc)logf));
+	auto plugin = makeReference<FDBLibTLSPlugin>();
+	auto policy = makeReference<FDBLibTLSPolicy>(plugin, (ITLSLogFunc)logf);
 
 	const char *verify_peers[] = {
 		"S.CN=abc",
@@ -116,9 +116,9 @@ static int policy_verify_test() {
 		(int)strlen(verify_peers[2]),
 	};
 	Reference<FDBLibTLSVerify> verify_rules[] = {
-		Reference<FDBLibTLSVerify>(new FDBLibTLSVerify(std::string(verify_peers[0], verify_peers_len[0]))),
-		Reference<FDBLibTLSVerify>(new FDBLibTLSVerify(std::string(verify_peers[1], verify_peers_len[1]))),
-		Reference<FDBLibTLSVerify>(new FDBLibTLSVerify(std::string(verify_peers[2], verify_peers_len[2]))),
+		makeReference<FDBLibTLSVerify>(std::string(verify_peers[0], verify_peers_len[0])),
+		makeReference<FDBLibTLSVerify>(std::string(verify_peers[1], verify_peers_len[1])),
+		makeReference<FDBLibTLSVerify>(std::string(verify_peers[2], verify_peers_len[2])),
 	};
 
 	if (!policy->set_verify_peers(3, (const uint8_t **)verify_peers, verify_peers_len)) {

--- a/fdbbackup/FileConverter.actor.cpp
+++ b/fdbbackup/FileConverter.actor.cpp
@@ -298,7 +298,7 @@ struct MutationFilesReadProgress : public ReferenceCounted<MutationFilesReadProg
 		// Attempt decode the first few blocks of log files until beginVersion is consumed
 		std::vector<Future<Void>> fileDecodes;
 		for (int i = 0; i < asyncFiles.size(); i++) {
-			Reference<FileProgress> fp(new FileProgress(asyncFiles[i].get(), i));
+			auto fp = makeReference<FileProgress>(asyncFiles[i].get(), i);
 			progress->fileProgress.push_back(fp);
 			fileDecodes.push_back(
 			    decodeToVersion(fp, progress->beginVersion, progress->endVersion, progress->getLogFile(i)));

--- a/fdbbackup/backup.actor.cpp
+++ b/fdbbackup/backup.actor.cpp
@@ -3790,7 +3790,7 @@ int main(int argc, char* argv[]) {
 		auto initCluster = [&](bool quiet = false) {
 			auto resolvedClusterFile = ClusterConnectionFile::lookupClusterFileName(clusterFile);
 			try {
-				ccf = Reference<ClusterConnectionFile>(new ClusterConnectionFile(resolvedClusterFile.first));
+				ccf = makeReference<ClusterConnectionFile>(resolvedClusterFile.first);
 			}
 			catch (Error& e) {
 				if(!quiet)
@@ -3813,7 +3813,7 @@ int main(int argc, char* argv[]) {
 		if(sourceClusterFile.size()) {
 			auto resolvedSourceClusterFile = ClusterConnectionFile::lookupClusterFileName(sourceClusterFile);
 			try {
-				sourceCcf = Reference<ClusterConnectionFile>(new ClusterConnectionFile(resolvedSourceClusterFile.first));
+				sourceCcf = makeReference<ClusterConnectionFile>(resolvedSourceClusterFile.first);
 			}
 			catch (Error& e) {
 				fprintf(stderr, "%s\n", ClusterConnectionFile::getErrorString(resolvedSourceClusterFile, e).c_str());

--- a/fdbcli/fdbcli.actor.cpp
+++ b/fdbcli/fdbcli.actor.cpp
@@ -2509,7 +2509,7 @@ ACTOR Future<bool> setClass( Database db, std::vector<StringRef> tokens ) {
 
 Reference<ReadYourWritesTransaction> getTransaction(Database db, Reference<ReadYourWritesTransaction> &tr, FdbOptions *options, bool intrans) {
 	if(!tr || !intrans) {
-		tr = Reference<ReadYourWritesTransaction>(new ReadYourWritesTransaction(db));
+		tr = makeReference<ReadYourWritesTransaction>(db);
 		options->apply(tr);
 	}
 
@@ -3011,7 +3011,7 @@ ACTOR Future<int> cli(CLIOptions opt, LineNoise* plinenoise) {
 
 	state std::pair<std::string, bool> resolvedClusterFile = ClusterConnectionFile::lookupClusterFileName( opt.clusterFile );
 	try {
-		ccf = Reference<ClusterConnectionFile>( new ClusterConnectionFile( resolvedClusterFile.first ) );
+		ccf = makeReference<ClusterConnectionFile>(resolvedClusterFile.first);
 	} catch (Error& e) {
 		fprintf(stderr, "%s\n", ClusterConnectionFile::getErrorString(resolvedClusterFile, e).c_str());
 		return 1;
@@ -3472,7 +3472,7 @@ ACTOR Future<int> cli(CLIOptions opt, LineNoise* plinenoise) {
 						                                               LiteralStringRef("\xff\xff/worker_interfaces0")),
 						                                   CLIENT_KNOBS->TOO_MANY)));
 						ASSERT(!kvs.more);
-						Reference<FlowLock> connectLock(new FlowLock(CLIENT_KNOBS->CLI_CONNECT_PARALLELISM));
+						auto connectLock = makeReference<FlowLock>(CLIENT_KNOBS->CLI_CONNECT_PARALLELISM);
 						std::vector<Future<Void>> addInterfs;
 						for( auto it : kvs ) {
 							addInterfs.push_back(addInterface(&address_interface, connectLock, it));
@@ -3537,7 +3537,7 @@ ACTOR Future<int> cli(CLIOptions opt, LineNoise* plinenoise) {
 						                                               LiteralStringRef("\xff\xff/worker_interfaces0")),
 						                                   CLIENT_KNOBS->TOO_MANY)));
 						ASSERT(!kvs.more);
-						Reference<FlowLock> connectLock(new FlowLock(CLIENT_KNOBS->CLI_CONNECT_PARALLELISM));
+						auto connectLock = makeReference<FlowLock>(CLIENT_KNOBS->CLI_CONNECT_PARALLELISM);
 						std::vector<Future<Void>> addInterfs;
 						for( auto it : kvs ) {
 							addInterfs.push_back(addInterface(&address_interface, connectLock, it));
@@ -3875,7 +3875,7 @@ ACTOR Future<int> cli(CLIOptions opt, LineNoise* plinenoise) {
 						                                               LiteralStringRef("\xff\xff/worker_interfaces0")),
 						                                   CLIENT_KNOBS->TOO_MANY)));
 						ASSERT(!kvs.more);
-						Reference<FlowLock> connectLock(new FlowLock(CLIENT_KNOBS->CLI_CONNECT_PARALLELISM));
+						auto connectLock = makeReference<FlowLock>(CLIENT_KNOBS->CLI_CONNECT_PARALLELISM);
 						std::vector<Future<Void>> addInterfs;
 						for( auto it : kvs ) {
 							addInterfs.push_back(addInterface(&address_interface, connectLock, it));

--- a/fdbclient/BackupAgentBase.actor.cpp
+++ b/fdbclient/BackupAgentBase.actor.cpp
@@ -638,7 +638,8 @@ ACTOR Future<Void> applyMutations(Database cx, Key uid, Key addPrefix, Key remov
 
 			for (int i = 0; i < ranges.size(); ++i) {
 				results.push_back(PromiseStream<RCGroup>());
-				locks.push_back(Reference<FlowLock>( new FlowLock(std::max(CLIENT_KNOBS->APPLY_MAX_LOCK_BYTES/ranges.size(), CLIENT_KNOBS->APPLY_MIN_LOCK_BYTES))));
+				locks.push_back(makeReference<FlowLock>(
+				    std::max(CLIENT_KNOBS->APPLY_MAX_LOCK_BYTES / ranges.size(), CLIENT_KNOBS->APPLY_MIN_LOCK_BYTES)));
 				rc.push_back(readCommitted(cx, results[i], locks[i], ranges[i], decodeBKMutationLogKey));
 			}
 

--- a/fdbclient/BackupContainer.actor.cpp
+++ b/fdbclient/BackupContainer.actor.cpp
@@ -363,8 +363,7 @@ Future<std::vector<std::string>> IBackupContainer::listContainers(const std::str
 
 ACTOR Future<Version> timeKeeperVersionFromDatetime(std::string datetime, Database db) {
 	state KeyBackedMap<int64_t, Version> versionMap(timeKeeperPrefixRange.begin);
-	state Reference<ReadYourWritesTransaction> tr =
-	    Reference<ReadYourWritesTransaction>(new ReadYourWritesTransaction(db));
+	state Reference<ReadYourWritesTransaction> tr = makeReference<ReadYourWritesTransaction>(db);
 
 	state int64_t time = BackupAgentBase::parseTime(datetime);
 	if (time < 0) {

--- a/fdbclient/BlobStore.actor.cpp
+++ b/fdbclient/BlobStore.actor.cpp
@@ -222,7 +222,8 @@ Reference<BlobStoreEndpoint> BlobStoreEndpoint::fromString(std::string const &ur
 		StringRef key = c.eat(":");
 		StringRef secret = c.eat();
 
-		return Reference<BlobStoreEndpoint>(new BlobStoreEndpoint(host.toString(), service.toString(), key.toString(), secret.toString(), knobs, extraHeaders));
+		return makeReference<BlobStoreEndpoint>(host.toString(), service.toString(), key.toString(), secret.toString(),
+		                                        knobs, extraHeaders);
 
 	} catch(std::string &err) {
 		if(error != nullptr)

--- a/fdbclient/DatabaseBackupAgent.actor.cpp
+++ b/fdbclient/DatabaseBackupAgent.actor.cpp
@@ -159,9 +159,9 @@ namespace dbBackup {
 
 		ACTOR static Future<Key> addTask(Reference<ReadYourWritesTransaction> tr, Reference<TaskBucket> taskBucket, Reference<Task> parentTask, Key begin, Key end, TaskCompletionKey completionKey, Reference<TaskFuture> waitFor = Reference<TaskFuture>()) {
 			Key doneKey = wait(completionKey.get(tr, taskBucket));
-			Reference<Task> task(new Task(BackupRangeTaskFunc::name, BackupRangeTaskFunc::version, doneKey));
+		    auto task = makeReference<Task>(BackupRangeTaskFunc::name, BackupRangeTaskFunc::version, doneKey);
 
-			copyDefaultParameters(parentTask, task);
+		    copyDefaultParameters(parentTask, task);
 
 			task->params[BackupAgentBase::keyBeginKey] = begin;
 			task->params[BackupAgentBase::keyEndKey] = end;
@@ -263,8 +263,8 @@ namespace dbBackup {
 
 				state int valueLoc = 0;
 				state int committedValueLoc = 0;
-				state Reference<ReadYourWritesTransaction> tr = Reference<ReadYourWritesTransaction>( new ReadYourWritesTransaction(cx) );
-				loop{
+			    state Reference<ReadYourWritesTransaction> tr = makeReference<ReadYourWritesTransaction>(cx);
+			    loop{
 					try {
 						tr->reset();
 						tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
@@ -447,9 +447,9 @@ namespace dbBackup {
 		ACTOR static Future<Key> addTask(Reference<ReadYourWritesTransaction> tr, Reference<TaskBucket> taskBucket, Reference<Task> parentTask, TaskCompletionKey completionKey, Reference<TaskFuture> waitFor = Reference<TaskFuture>()) {
 			// After the BackupRangeTask completes, set the stop key which will stop the BackupLogsTask
 			Key doneKey = wait(completionKey.get(tr, taskBucket));
-			Reference<Task> task(new Task(FinishFullBackupTaskFunc::name, FinishFullBackupTaskFunc::version, doneKey));
+		    auto task = makeReference<Task>(FinishFullBackupTaskFunc::name, FinishFullBackupTaskFunc::version, doneKey);
 
-			copyDefaultParameters(parentTask, task);
+		    copyDefaultParameters(parentTask, task);
 
 			if (!waitFor) {
 				return taskBucket->addTask(tr, task, parentTask->params[Task::reservedTaskParamValidKey], task->params[BackupAgentBase::keyFolderId]);
@@ -497,9 +497,9 @@ namespace dbBackup {
 
 		ACTOR static Future<Key> addTask(Reference<ReadYourWritesTransaction> tr, Reference<TaskBucket> taskBucket, Reference<Task> parentTask, Version endVersion, TaskCompletionKey completionKey, Reference<TaskFuture> waitFor = Reference<TaskFuture>()) {
 			Key doneKey = wait(completionKey.get(tr, taskBucket));
-			Reference<Task> task(new Task(EraseLogRangeTaskFunc::name, EraseLogRangeTaskFunc::version, doneKey, 1));
+		    auto task = makeReference<Task>(EraseLogRangeTaskFunc::name, EraseLogRangeTaskFunc::version, doneKey, 1);
 
-			copyDefaultParameters(parentTask, task);
+		    copyDefaultParameters(parentTask, task);
 
 			task->params[DatabaseBackupAgent::keyBeginVersion] = BinaryWriter::toValue(1, Unversioned()); //FIXME: remove in 6.X, only needed for 5.2 backward compatibility
 			task->params[DatabaseBackupAgent::keyEndVersion] = BinaryWriter::toValue(endVersion, Unversioned());
@@ -692,8 +692,8 @@ namespace dbBackup {
 
 				for (int j = results.size(); j < prefetchTo; j ++) {
 					results.push_back(PromiseStream<RCGroup>());
-					locks.push_back(Reference<FlowLock>(new FlowLock(CLIENT_KNOBS->COPY_LOG_READ_AHEAD_BYTES)));
-					rc.push_back(readCommitted(taskBucket->src, results[j], Future<Void>(Void()), locks[j], ranges[j], decodeBKMutationLogKey, true, true, true));
+				    locks.push_back(makeReference<FlowLock>(CLIENT_KNOBS->COPY_LOG_READ_AHEAD_BYTES));
+				    rc.push_back(readCommitted(taskBucket->src, results[j], Future<Void>(Void()), locks[j], ranges[j], decodeBKMutationLogKey, true, true, true));
 				}
 
 				// copy the range
@@ -731,9 +731,9 @@ namespace dbBackup {
 
 		ACTOR static Future<Key> addTask(Reference<ReadYourWritesTransaction> tr, Reference<TaskBucket> taskBucket, Reference<Task> parentTask, Version beginVersion, Version endVersion, TaskCompletionKey completionKey, Reference<TaskFuture> waitFor = Reference<TaskFuture>()) {
 			Key doneKey = wait(completionKey.get(tr, taskBucket));
-			Reference<Task> task(new Task(CopyLogRangeTaskFunc::name, CopyLogRangeTaskFunc::version, doneKey, 1));
+		    auto task = makeReference<Task>(CopyLogRangeTaskFunc::name, CopyLogRangeTaskFunc::version, doneKey, 1);
 
-			copyDefaultParameters(parentTask, task);
+		    copyDefaultParameters(parentTask, task);
 
 			task->params[DatabaseBackupAgent::keyBeginVersion] = BinaryWriter::toValue(beginVersion, Unversioned());
 			task->params[DatabaseBackupAgent::keyEndVersion] = BinaryWriter::toValue(endVersion, Unversioned());
@@ -852,9 +852,9 @@ namespace dbBackup {
 
 		ACTOR static Future<Key> addTask(Reference<ReadYourWritesTransaction> tr, Reference<TaskBucket> taskBucket, Reference<Task> parentTask, Version prevBeginVersion, Version beginVersion, TaskCompletionKey completionKey, Reference<TaskFuture> waitFor = Reference<TaskFuture>()) {
 			Key doneKey = wait(completionKey.get(tr, taskBucket));
-			Reference<Task> task(new Task(CopyLogsTaskFunc::name, CopyLogsTaskFunc::version, doneKey, 1));
+		    auto task = makeReference<Task>(CopyLogsTaskFunc::name, CopyLogsTaskFunc::version, doneKey, 1);
 
-			copyDefaultParameters(parentTask, task);
+		    copyDefaultParameters(parentTask, task);
 			task->params[BackupAgentBase::keyBeginVersion] = BinaryWriter::toValue(beginVersion, Unversioned());
 			task->params[DatabaseBackupAgent::keyPrevBeginVersion] = BinaryWriter::toValue(prevBeginVersion, Unversioned());
 
@@ -931,9 +931,10 @@ namespace dbBackup {
 
 		ACTOR static Future<Key> addTask(Reference<ReadYourWritesTransaction> tr, Reference<TaskBucket> taskBucket, Reference<Task> parentTask, TaskCompletionKey completionKey, Reference<TaskFuture> waitFor = Reference<TaskFuture>()) {
 			Key doneKey = wait(completionKey.get(tr, taskBucket));
-			Reference<Task> task(new Task(FinishedFullBackupTaskFunc::name, FinishedFullBackupTaskFunc::version, doneKey));
+		    auto task =
+		        makeReference<Task>(FinishedFullBackupTaskFunc::name, FinishedFullBackupTaskFunc::version, doneKey);
 
-			copyDefaultParameters(parentTask, task);
+		    copyDefaultParameters(parentTask, task);
 
 			if (!waitFor) {
 				return taskBucket->addTask(tr, task, parentTask->params[Task::reservedTaskParamValidKey], task->params[BackupAgentBase::keyFolderId]);
@@ -1032,9 +1033,9 @@ namespace dbBackup {
 
 		ACTOR static Future<Key> addTask(Reference<ReadYourWritesTransaction> tr, Reference<TaskBucket> taskBucket, Reference<Task> parentTask, Version prevBeginVersion, Version beginVersion, TaskCompletionKey completionKey, Reference<TaskFuture> waitFor = Reference<TaskFuture>()) {
 			Key doneKey = wait(completionKey.get(tr, taskBucket));
-			Reference<Task> task(new Task(CopyDiffLogsTaskFunc::name, CopyDiffLogsTaskFunc::version, doneKey, 1));
+		    auto task = makeReference<Task>(CopyDiffLogsTaskFunc::name, CopyDiffLogsTaskFunc::version, doneKey, 1);
 
-			copyDefaultParameters(parentTask, task);
+		    copyDefaultParameters(parentTask, task);
 
 			task->params[DatabaseBackupAgent::keyBeginVersion] = BinaryWriter::toValue(beginVersion, Unversioned());
 			task->params[DatabaseBackupAgent::keyPrevBeginVersion] = BinaryWriter::toValue(prevBeginVersion, Unversioned());
@@ -1210,9 +1211,10 @@ namespace dbBackup {
 
 		ACTOR static Future<Key> addTask(Reference<ReadYourWritesTransaction> tr, Reference<TaskBucket> taskBucket, Reference<Task> parentTask, Version beginVersion, Version endVersion, TaskCompletionKey completionKey, Reference<TaskFuture> waitFor = Reference<TaskFuture>()) {
 			Key doneKey = wait(completionKey.get(tr, taskBucket));
-			Reference<Task> task(new Task(OldCopyLogRangeTaskFunc::name, OldCopyLogRangeTaskFunc::version, doneKey, 1));
+		    auto task =
+		        makeReference<Task>(OldCopyLogRangeTaskFunc::name, OldCopyLogRangeTaskFunc::version, doneKey, 1);
 
-			copyDefaultParameters(parentTask, task);
+		    copyDefaultParameters(parentTask, task);
 
 			task->params[DatabaseBackupAgent::keyBeginVersion] = BinaryWriter::toValue(beginVersion, Unversioned());
 			task->params[DatabaseBackupAgent::keyEndVersion] = BinaryWriter::toValue(endVersion, Unversioned());
@@ -1289,9 +1291,9 @@ namespace dbBackup {
 
 		ACTOR static Future<Key> addTask(Reference<ReadYourWritesTransaction> tr, Reference<TaskBucket> taskBucket, Reference<Task> parentTask, TaskCompletionKey completionKey, Reference<TaskFuture> waitFor = Reference<TaskFuture>()) {
 			Key doneKey = wait(completionKey.get(tr, taskBucket));
-			Reference<Task> task(new Task(AbortOldBackupTaskFunc::name, AbortOldBackupTaskFunc::version, doneKey, 1));
+		    auto task = makeReference<Task>(AbortOldBackupTaskFunc::name, AbortOldBackupTaskFunc::version, doneKey, 1);
 
-			copyDefaultParameters(parentTask, task);
+		    copyDefaultParameters(parentTask, task);
 
 			if (!waitFor) {
 				return taskBucket->addTask(tr, task, parentTask->params[Task::reservedTaskParamValidKey], task->params[BackupAgentBase::keyFolderId]);
@@ -1498,9 +1500,9 @@ namespace dbBackup {
 
 		ACTOR static Future<Key> addTask(Reference<ReadYourWritesTransaction> tr, Reference<TaskBucket> taskBucket, Reference<Task> parentTask, TaskCompletionKey completionKey, Reference<TaskFuture> waitFor = Reference<TaskFuture>()) {
 			Key doneKey = wait(completionKey.get(tr, taskBucket));
-			Reference<Task> task(new Task(BackupRestorableTaskFunc::name, BackupRestorableTaskFunc::version, doneKey));
+		    auto task = makeReference<Task>(BackupRestorableTaskFunc::name, BackupRestorableTaskFunc::version, doneKey);
 
-			copyDefaultParameters(parentTask, task);
+		    copyDefaultParameters(parentTask, task);
 
 			if (!waitFor) {
 				return taskBucket->addTask(tr, task, parentTask->params[Task::reservedTaskParamValidKey], task->params[BackupAgentBase::keyFolderId]);
@@ -1691,9 +1693,9 @@ namespace dbBackup {
 		ACTOR static Future<Key> addTask(Reference<ReadYourWritesTransaction> tr, Reference<TaskBucket> taskBucket, Key logUid, Key backupUid, Key keyAddPrefix, Key keyRemovePrefix, Key keyConfigBackupRanges, Key tagName, TaskCompletionKey completionKey, Reference<TaskFuture> waitFor = Reference<TaskFuture>(), bool databasesInSync=false)
 		{
 			Key doneKey = wait(completionKey.get(tr, taskBucket));
-			Reference<Task> task(new Task(StartFullBackupTaskFunc::name, StartFullBackupTaskFunc::version, doneKey));
+		    auto task = makeReference<Task>(StartFullBackupTaskFunc::name, StartFullBackupTaskFunc::version, doneKey);
 
-			task->params[BackupAgentBase::keyFolderId] = backupUid;
+		    task->params[BackupAgentBase::keyFolderId] = backupUid;
 			task->params[BackupAgentBase::keyConfigLogUid] = logUid;
 			task->params[DatabaseBackupAgent::keyAddPrefix] = keyAddPrefix;
 			task->params[DatabaseBackupAgent::keyRemovePrefix] = keyRemovePrefix;
@@ -2227,7 +2229,7 @@ public:
 			}
 		}
 
-		tr = Reference<ReadYourWritesTransaction>(new ReadYourWritesTransaction(cx));
+		tr = makeReference<ReadYourWritesTransaction>(cx);
 		loop {
 			tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
 			tr->setOption(FDBTransactionOptions::LOCK_AWARE);
@@ -2335,7 +2337,7 @@ public:
 			}
 		}
 
-		tr = Reference<ReadYourWritesTransaction>(new ReadYourWritesTransaction(cx));
+		tr = makeReference<ReadYourWritesTransaction>(cx);
 		loop {
 			try {
 				tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);

--- a/fdbclient/FileBackupAgent.actor.cpp
+++ b/fdbclient/FileBackupAgent.actor.cpp
@@ -1403,8 +1403,8 @@ namespace fileBackup {
 					else {
 						ASSERT(snapshotBatchSize.present());
 						// Batch future key exists in the config so create future from it
-						snapshotBatchFuture = Reference<TaskFuture>(new TaskFuture(futureBucket, snapshotBatchFutureKey.get()));
-					}
+					    snapshotBatchFuture = makeReference<TaskFuture>(futureBucket, snapshotBatchFutureKey.get());
+				    }
 
 					break;
 				} catch(Error &e) {

--- a/fdbclient/MonitorLeader.actor.cpp
+++ b/fdbclient/MonitorLeader.actor.cpp
@@ -368,7 +368,7 @@ ClientCoordinators::ClientCoordinators( Key clusterKey, std::vector<NetworkAddre
 	for (const auto& coord : coordinators) {
 		clientLeaderServers.push_back( ClientLeaderRegInterface( coord ) );
 	}
-	ccf = Reference<ClusterConnectionFile>(new ClusterConnectionFile( ClusterConnectionString( coordinators, clusterKey ) ) );
+	ccf = makeReference<ClusterConnectionFile>(ClusterConnectionString(coordinators, clusterKey));
 }
 
 
@@ -477,7 +477,8 @@ ACTOR Future<MonitorLeaderInfo> monitorLeaderOneGeneration( Reference<ClusterCon
 		if (leader.present()) {
 			if( leader.get().first.forward ) {
 				TraceEvent("MonitorLeaderForwarding").detail("NewConnStr", leader.get().first.serializedInfo.toString()).detail("OldConnStr", info.intermediateConnFile->getConnectionString().toString());
-				info.intermediateConnFile = Reference<ClusterConnectionFile>(new ClusterConnectionFile(connFile->getFilename(), ClusterConnectionString(leader.get().first.serializedInfo.toString())));
+				info.intermediateConnFile = makeReference<ClusterConnectionFile>(
+				    connFile->getFilename(), ClusterConnectionString(leader.get().first.serializedInfo.toString()));
 				return info;
 			}
 			if(connFile != info.intermediateConnFile) {
@@ -505,7 +506,7 @@ template <class LeaderInterface>
 Future<Void> monitorLeaderRemotely(Reference<ClusterConnectionFile> const& connFile,
 						   Reference<AsyncVar<Optional<LeaderInterface>>> const& outKnownLeader) {
 	LeaderDeserializer<LeaderInterface> deserializer;
-	Reference<AsyncVar<Value>> serializedInfo( new AsyncVar<Value> );
+	auto serializedInfo = makeReference<AsyncVar<Value>>();
 	Future<Void> m = monitorLeaderRemotelyInternal( connFile, serializedInfo );
 	return m || deserializer( serializedInfo, outKnownLeader );
 }

--- a/fdbclient/MonitorLeader.h
+++ b/fdbclient/MonitorLeader.h
@@ -100,7 +100,7 @@ template <class LeaderInterface>
 Future<Void> monitorLeader(Reference<ClusterConnectionFile> const& connFile,
 						   Reference<AsyncVar<Optional<LeaderInterface>>> const& outKnownLeader) {
 	LeaderDeserializer<LeaderInterface> deserializer;
-	Reference<AsyncVar<Value>> serializedInfo( new AsyncVar<Value> );
+	auto serializedInfo = makeReference<AsyncVar<Value>>();
 	Future<Void> m = monitorLeaderInternal( connFile, serializedInfo );
 	return m || deserializer( serializedInfo, outKnownLeader );
 }

--- a/fdbclient/MultiVersionTransaction.actor.cpp
+++ b/fdbclient/MultiVersionTransaction.actor.cpp
@@ -438,7 +438,7 @@ Reference<IDatabase> DLApi::createDatabase609(const char *clusterFilePath) {
 		}));
 	});
 
-	return Reference<DLDatabase>(new DLDatabase(api, dbFuture));
+	return makeReference<DLDatabase>(api, dbFuture);
 }
 
 Reference<IDatabase> DLApi::createDatabase(const char *clusterFilePath) {
@@ -907,7 +907,8 @@ void MultiVersionDatabase::DatabaseState::stateChanged() {
 
 void MultiVersionDatabase::DatabaseState::addConnection(Reference<ClientInfo> client, std::string clusterFilePath) {
 	clients.push_back(client);
-	connectionAttempts.push_back(Reference<Connector>(new Connector(Reference<DatabaseState>::addRef(this), client, clusterFilePath)));
+	connectionAttempts.push_back(
+	    makeReference<Connector>(Reference<DatabaseState>::addRef(this), client, clusterFilePath));
 }
 
 void MultiVersionDatabase::DatabaseState::startConnections() {
@@ -974,7 +975,7 @@ Reference<ClientInfo> MultiVersionApi::getLocalClient() {
 
 void MultiVersionApi::selectApiVersion(int apiVersion) {
 	if(!localClient) {
-		localClient = Reference<ClientInfo>(new ClientInfo(ThreadSafeApi::api));
+		localClient = makeReference<ClientInfo>(ThreadSafeApi::api);
 	}
 
 	if(this->apiVersion != 0 && this->apiVersion != apiVersion) {
@@ -1033,7 +1034,7 @@ void MultiVersionApi::addExternalLibrary(std::string path) {
 
 	if(externalClients.count(filename) == 0) {
 		TraceEvent("AddingExternalClient").detail("LibraryPath", filename);
-		externalClients[filename] = Reference<ClientInfo>(new ClientInfo(new DLApi(path), path));
+		externalClients[filename] = makeReference<ClientInfo>(new DLApi(path), path);
 	}
 }
 
@@ -1050,7 +1051,7 @@ void MultiVersionApi::addExternalLibraryDirectory(std::string path) {
 		std::string lib = abspath(joinPath(path, filename));
 		if(externalClients.count(filename) == 0) {
 			TraceEvent("AddingExternalClient").detail("LibraryPath", filename);
-			externalClients[filename] = Reference<ClientInfo>(new ClientInfo(new DLApi(lib), lib));
+			externalClients[filename] = makeReference<ClientInfo>(new DLApi(lib), lib);
 		}	
 	}
 }
@@ -1753,7 +1754,7 @@ struct DLTest {
 	static Reference<FdbCApi> getApi() {
 		static Reference<FdbCApi> api;
 		if(!api) {
-			api = Reference<FdbCApi>(new FdbCApi());
+			api = makeReference<FdbCApi>();
 
 			// Functions needed for DLSingleAssignmentVar
 			api->futureSetCallback = [](FdbCApi::FDBFuture *f, FdbCApi::FDBCallback callback, void *callbackParameter) {  

--- a/fdbclient/S3BlobStore.actor.cpp
+++ b/fdbclient/S3BlobStore.actor.cpp
@@ -235,8 +235,8 @@ Reference<S3BlobStoreEndpoint> S3BlobStoreEndpoint::fromString(std::string const
 		StringRef key = c.eat(":");
 		StringRef secret = c.eat();
 
-		return Reference<S3BlobStoreEndpoint>(new S3BlobStoreEndpoint(
-		    host.toString(), service.toString(), key.toString(), secret.toString(), knobs, extraHeaders));
+		return makeReference<S3BlobStoreEndpoint>(host.toString(), service.toString(), key.toString(),
+		                                          secret.toString(), knobs, extraHeaders);
 
 	} catch (std::string& err) {
 		if (error != nullptr) *error = err;

--- a/fdbclient/StatusClient.actor.cpp
+++ b/fdbclient/StatusClient.actor.cpp
@@ -558,7 +558,7 @@ ACTOR Future<Void> timeoutMonitorLeader(Database db) {
 Future<StatusObject> StatusClient::statusFetcher( Database db ) {
 	db->lastStatusFetch = now();
 	if(!db->statusClusterInterface) {
-		db->statusClusterInterface = Reference<AsyncVar<Optional<ClusterInterface>>>(new AsyncVar<Optional<ClusterInterface>>);
+		db->statusClusterInterface = makeReference<AsyncVar<Optional<ClusterInterface>>>();
 		db->statusLeaderMon = timeoutMonitorLeader(db);
 	}
 

--- a/fdbclient/TaskBucket.actor.cpp
+++ b/fdbclient/TaskBucket.actor.cpp
@@ -513,7 +513,7 @@ public:
 	}
 
 	ACTOR static Future<Void> run(Database cx, Reference<TaskBucket> taskBucket, Reference<FutureBucket> futureBucket, double *pollDelay, int maxConcurrentTasks) {
-		state Reference<AsyncVar<bool>> paused = Reference<AsyncVar<bool>>( new AsyncVar<bool>(true) );
+		state Reference<AsyncVar<bool>> paused = makeReference<AsyncVar<bool>>(true);
 		state Future<Void> watchPausedFuture = watchPaused(cx, taskBucket, paused);
 		taskBucket->metricLogger = traceCounters("TaskBucketMetrics", taskBucket->dbgid, CLIENT_KNOBS->TASKBUCKET_LOGGING_DELAY, &taskBucket->cc);
 		loop {
@@ -528,7 +528,7 @@ public:
 	static Future<Standalone<StringRef>> addIdle(Reference<ReadYourWritesTransaction> tr, Reference<TaskBucket> taskBucket) {
 		taskBucket->setOptions(tr);
 
-		Reference<Task> newTask(new Task(IdleTaskFunc::name, IdleTaskFunc::version));
+		auto newTask = makeReference<Task>(IdleTaskFunc::name, IdleTaskFunc::version);
 		return taskBucket->addTask(tr, newTask);
 	}
 
@@ -991,7 +991,7 @@ Future<Void> FutureBucket::clear(Reference<ReadYourWritesTransaction> tr){
 Reference<TaskFuture> FutureBucket::future(Reference<ReadYourWritesTransaction> tr){
 	setOptions(tr);
 
-	Reference<TaskFuture> taskFuture(new TaskFuture(Reference<FutureBucket>::addRef(this)));
+	auto taskFuture = makeReference<TaskFuture>(Reference<FutureBucket>::addRef(this));
 	taskFuture->addBlock(tr, StringRef());
 
 	return taskFuture;
@@ -1002,7 +1002,7 @@ Future<bool> FutureBucket::isEmpty(Reference<ReadYourWritesTransaction> tr) {
 }
 
 Reference<TaskFuture> FutureBucket::unpack(Key key) {
-	return Reference<TaskFuture>(new TaskFuture(Reference<FutureBucket>::addRef(this), key));
+	return makeReference<TaskFuture>(Reference<FutureBucket>::addRef(this), key);
 }
 
 class TaskFutureImpl {
@@ -1028,7 +1028,7 @@ public:
 		for (int i = 0; i < vectorFuture.size(); ++i) {
 			Key key = StringRef(deterministicRandom()->randomUniqueID().toString());
 			taskFuture->addBlock(tr, key);
-			Reference<Task> task(new Task());
+			auto task = makeReference<Task>();
 			task->params[Task::reservedTaskParamKeyType] = LiteralStringRef("UnblockFuture");
 			task->params[Task::reservedTaskParamKeyFuture] = taskFuture->key;
 			task->params[Task::reservedTaskParamKeyBlockID] = key;
@@ -1111,7 +1111,7 @@ public:
 				// If we see a new task ID and the old one isn't empty then process the task accumulated so far and make a new task
 				if(taskID.size() != 0 && taskID != lastTaskID) {
 					actions.push_back(performAction(tr, taskBucket, taskFuture, task));
-					task = Reference<Task>(new Task());
+					task = makeReference<Task>();
 				}
 				task->params[key] = s.value;
 				lastTaskID = taskID;

--- a/fdbclient/VersionedMap.h
+++ b/fdbclient/VersionedMap.h
@@ -135,10 +135,10 @@ namespace PTreeImpl {
 				// and should drop its reference count
 				Reference<PTree<T>> r;
 				if (which)
-					r = Reference<PTree<T>>( new PTree<T>( node->priority, node->data, node->child(0, at), ptr, at ) );
-				else
-					r = Reference<PTree<T>>( new PTree<T>( node->priority, node->data, ptr, node->child(1, at), at ) );
-				node->pointer[2].clear();
+				    r = makeReference<PTree<T>>(node->priority, node->data, node->child(0, at), ptr, at);
+			    else
+				    r = makeReference<PTree<T>>(node->priority, node->data, ptr, node->child(1, at), at);
+			    node->pointer[2].clear();
 				return r;
 			} else {
 				if (node->updated)
@@ -150,10 +150,10 @@ namespace PTreeImpl {
 		}
 		if ( node->updated ) {
 			if (which)
-				return Reference<PTree<T>>( new PTree<T>( node->priority, node->data, node->child(0, at), ptr, at ) );
-			else
-				return Reference<PTree<T>>( new PTree<T>( node->priority, node->data, ptr, node->child(1, at), at ) );
-		} else {
+			    return makeReference<PTree<T>>(node->priority, node->data, node->child(0, at), ptr, at);
+		    else
+			    return makeReference<PTree<T>>(node->priority, node->data, ptr, node->child(1, at), at);
+	    } else {
 			node->lastUpdateVersion = at;
 			node->replacedPointer = which;
 			node->pointer[2] = ptr;
@@ -269,8 +269,8 @@ namespace PTreeImpl {
 	template<class T>
 	void insert(Reference<PTree<T>>& p, Version at, const T& x) {
 		if (!p){
-			p = Reference<PTree<T>>(new PTree<T>(x, at));
-		} else {
+		    p = makeReference<PTree<T>>(x, at);
+	    } else {
 			bool direction = !(x < p->data);
 			Reference<PTree<T>> child = p->child(direction, at);
 			insert(child, at, x);
@@ -425,8 +425,8 @@ namespace PTreeImpl {
 		if (!left) return right;
 		if (!right) return left;
 
-		Reference<PTree<T>> r = Reference<PTree<T>>(new PTree<T>(lastNode(left, at)->data, at));
-		if (EXPENSIVE_VALIDATION) {
+	    Reference<PTree<T>> r = makeReference<PTree<T>>(lastNode(left, at)->data, at);
+	    if (EXPENSIVE_VALIDATION) {
 			ASSERT( r->data < firstNode(right, at)->data);
 		}
 		Reference<PTree<T>> a = left;

--- a/fdbrpc/AsyncFileCached.actor.cpp
+++ b/fdbrpc/AsyncFileCached.actor.cpp
@@ -60,7 +60,8 @@ Future<Reference<IAsyncFile>> AsyncFileCached::open_impl( std::string filename, 
 		if(cacheItr == simulatorPageCaches.end()) {
 			int64_t pageCacheSize4k = (BUGGIFY) ? FLOW_KNOBS->BUGGIFY_SIM_PAGE_CACHE_4K : FLOW_KNOBS->SIM_PAGE_CACHE_4K;
 			int64_t pageCacheSize64k = (BUGGIFY) ? FLOW_KNOBS->BUGGIFY_SIM_PAGE_CACHE_64K : FLOW_KNOBS->SIM_PAGE_CACHE_64K;
-			auto caches = std::make_pair(Reference<EvictablePageCache>(new EvictablePageCache(4096, pageCacheSize4k)), Reference<EvictablePageCache>(new EvictablePageCache(65536, pageCacheSize64k)));
+			auto caches = std::make_pair(makeReference<EvictablePageCache>(4096, pageCacheSize4k),
+			                             makeReference<EvictablePageCache>(65536, pageCacheSize64k));
 			simulatorPageCaches[g_network->getLocalAddress()] = caches;
 			pageCache = (flags & IAsyncFile::OPEN_LARGE_PAGES) ? caches.second : caches.first;
 		}
@@ -69,10 +70,10 @@ Future<Reference<IAsyncFile>> AsyncFileCached::open_impl( std::string filename, 
 	}
 	else {
 		if(flags & IAsyncFile::OPEN_LARGE_PAGES) {
-			if(!pc64k.present()) pc64k = Reference<EvictablePageCache>(new EvictablePageCache(65536, FLOW_KNOBS->PAGE_CACHE_64K));
+			if (!pc64k.present()) pc64k = makeReference<EvictablePageCache>(65536, FLOW_KNOBS->PAGE_CACHE_64K);
 			pageCache = pc64k.get();
 		} else {
-			if(!pc4k.present()) pc4k = Reference<EvictablePageCache>(new EvictablePageCache(4096, FLOW_KNOBS->PAGE_CACHE_4K));
+			if (!pc4k.present()) pc4k = makeReference<EvictablePageCache>(4096, FLOW_KNOBS->PAGE_CACHE_4K);
 			pageCache = pc4k.get();
 		}
 	}

--- a/fdbrpc/AsyncFileEIO.actor.h
+++ b/fdbrpc/AsyncFileEIO.actor.h
@@ -172,11 +172,11 @@ public:
 
 	static Future<Void> async_fdatasync( int fd ) {
 		// Used by AsyncFileKAIO, since kernel AIO doesn't really implement fdatasync yet
-		return sync_impl( fd, Reference<ErrorInfo>(new ErrorInfo) );
+		return sync_impl(fd, makeReference<ErrorInfo>());
 	}
 	static Future<Void> async_fsync( int fd ) {
 		// Used by AsyncFileKAIO, since kernel AIO doesn't really implement fsync yet
-		return sync_impl( fd, Reference<ErrorInfo>(new ErrorInfo), true );
+		return sync_impl(fd, makeReference<ErrorInfo>(), true);
 	}
 	ACTOR static Future<Void> waitAndAtomicRename( Future<Void> fsync, std::string part_filename, std::string final_filename ) {
 		// First wait for the data in the part file to be durable

--- a/fdbrpc/AsyncFileNonDurable.actor.h
+++ b/fdbrpc/AsyncFileNonDurable.actor.h
@@ -74,9 +74,7 @@ public:
 			when( wait(success( g_simulator.getCurrentProcess()->shutdownSignal.getFuture() )) ) {
 				throw io_error().asInjectedFault();
 			}
-			when( Reference<IAsyncFile> f = wait( wrappedFile ) ) {
-				return Reference<AsyncFileDetachable>( new AsyncFileDetachable(f) );
-			}
+			when(Reference<IAsyncFile> f = wait(wrappedFile)) { return makeReference<AsyncFileDetachable>(f); }
 		}
 	}
 

--- a/fdbrpc/FlowTests.actor.cpp
+++ b/fdbrpc/FlowTests.actor.cpp
@@ -682,7 +682,7 @@ TEST_CASE("/flow/flow/yieldedFuture/progress")
 	// Check that if check_yield always returns true, the yieldedFuture will do nothing immediately but will
 	// get one thing done per "tick" (per delay(0) returning).
 
-	Reference<YieldMockNetwork> yn( new YieldMockNetwork );
+	auto yn = makeReference<YieldMockNetwork>();
 
 	yn->nextYield = 0;
 
@@ -717,7 +717,7 @@ TEST_CASE("/flow/flow/yieldedFuture/random")
 {
 	// Check expectations about exactly how yieldedFuture responds to check_yield results
 
-	Reference<YieldMockNetwork> yn( new YieldMockNetwork );
+	auto yn = makeReference<YieldMockNetwork>();
 
 	for(int r=0; r<100; r++) {
 		Promise<Void> p;
@@ -765,7 +765,7 @@ TEST_CASE("/flow/perf/yieldedFuture")
 	double start;
 	int N = 1000000;
 
-	Reference<YieldMockNetwork> yn( new YieldMockNetwork );
+	auto yn = makeReference<YieldMockNetwork>();
 
 	yn->nextYield = 2*N + 100;
 

--- a/fdbrpc/FlowTransport.actor.cpp
+++ b/fdbrpc/FlowTransport.actor.cpp
@@ -283,7 +283,7 @@ TransportData::TransportData(uint64_t transportId)
 		transportId(transportId),
 		numIncompatibleConnections(0)
 {
-	degraded = Reference<AsyncVar<bool>>( new AsyncVar<bool>(false) );
+	degraded = makeReference<AsyncVar<bool>>(false);
 	pingLogger = pingLatencyLogger(this);
 }
 
@@ -1192,7 +1192,7 @@ Reference<Peer> TransportData::getPeer( NetworkAddress const& address ) {
 Reference<Peer> TransportData::getOrOpenPeer( NetworkAddress const& address, bool startConnectionKeeper ) {
 	auto peer = getPeer(address);
 	if(!peer) {
-		peer = Reference<Peer>( new Peer(this, address) );
+		peer = makeReference<Peer>(this, address);
 		if(startConnectionKeeper && !isLocalAddress(address)) {
 			peer->connect = connectionKeeper(peer);
 		}

--- a/fdbrpc/Replication.h
+++ b/fdbrpc/Replication.h
@@ -184,7 +184,7 @@ public:
 			localitySet = itKeyValue->_resultset;
 		}
 		else {
-			localitySet = Reference<LocalitySet>(new LocalitySet(*_localitygroup));
+			localitySet = makeReference<LocalitySet>(*_localitygroup);
 			_cachemisses ++;
 			// If the key is not within the current key set, skip it because no items within
 			// the current entry array has the key
@@ -213,7 +213,7 @@ public:
 
 	// This function is used to create an subset containing the specified entries
 	Reference<LocalitySet> restrict(std::vector<LocalityEntry> const&	entryArray) {
-		Reference<LocalitySet>	localitySet(new LocalitySet(*_localitygroup));
+		auto localitySet = makeReference<LocalitySet>(*_localitygroup);
 		for (auto& entry : entryArray) {
 			localitySet->add(getRecordViaEntry(entry), *this);
 		}
@@ -509,7 +509,7 @@ struct LocalityGroup : public LocalitySet {
 
 	LocalityEntry const& add(LocalityData const& data) {
 		// _recordArray.size() is the new entry index for the new data
-		Reference<LocalityRecord>	record(new LocalityRecord(convertToAttribMap(data), _recordArray.size()));
+		auto record = makeReference<LocalityRecord>(convertToAttribMap(data), _recordArray.size());
 		_recordArray.push_back(record);
 		return LocalitySet::add(record, *this);
 	}
@@ -552,7 +552,7 @@ struct LocalityGroup : public LocalitySet {
 
 	// Convert locality data to sorted vector of int pairs
 	Reference<KeyValueMap>	convertToAttribMap(LocalityData const&	data) {
-		Reference<KeyValueMap>	attribHashMap(new KeyValueMap);
+		auto attribHashMap = makeReference<KeyValueMap>();
 		for (auto& dataPair : data._data) {
 			auto indexKey = keyIndex(dataPair.first);
 			auto indexValue = valueIndex(dataPair.second);

--- a/fdbrpc/sim2.actor.cpp
+++ b/fdbrpc/sim2.actor.cpp
@@ -426,8 +426,10 @@ public:
 
 	static bool should_poll() { return false; }
 
-	ACTOR static Future<Reference<IAsyncFile>> open( std::string filename, int flags, int mode,
-													Reference<DiskParameters> diskParameters = Reference<DiskParameters>(new DiskParameters(25000, 150000000)), bool delayOnWrite = true ) {
+	ACTOR static Future<Reference<IAsyncFile>> open(
+	    std::string filename, int flags, int mode,
+	    Reference<DiskParameters> diskParameters = makeReference<DiskParameters>(25000, 150000000),
+	    bool delayOnWrite = true) {
 		state ISimulator::ProcessInfo* currentProcess = g_simulator.getCurrentProcess();
 		state TaskPriority currentTaskID = g_network->getCurrentTask();
 
@@ -793,8 +795,8 @@ public:
 			return waitForProcessAndConnect( toAddr, this );
 		}
 		auto peerp = getProcessByAddress(toAddr);
-		Reference<Sim2Conn> myc( new Sim2Conn( getCurrentProcess() ) );
-		Reference<Sim2Conn> peerc( new Sim2Conn( peerp ) );
+		auto myc = makeReference<Sim2Conn>(getCurrentProcess());
+		auto peerc = makeReference<Sim2Conn>(peerp);
 
 		myc->connect(peerc, toAddr);
 		IPAddress localIp;
@@ -1843,7 +1845,8 @@ Future< Reference<class IAsyncFile> > Sim2FileSystem::open( std::string filename
 			}
 			// Simulated disk parameters are shared by the AsyncFileNonDurable and the underlying SimpleFile.
 			// This way, they can both keep up with the time to start the next operation
-			Reference<DiskParameters> diskParameters(new DiskParameters(FLOW_KNOBS->SIM_DISK_IOPS, FLOW_KNOBS->SIM_DISK_BANDWIDTH));
+			auto diskParameters =
+			    makeReference<DiskParameters>(FLOW_KNOBS->SIM_DISK_IOPS, FLOW_KNOBS->SIM_DISK_BANDWIDTH);
 			machineCache[actualFilename] = AsyncFileNonDurable::open(filename, actualFilename, SimpleFile::open(filename, flags, mode, diskParameters, false), diskParameters);
 		}
 		Future<Reference<IAsyncFile>> f = AsyncFileDetachable::open( machineCache[actualFilename] );

--- a/fdbserver/ApplyMetadataMutation.cpp
+++ b/fdbserver/ApplyMetadataMutation.cpp
@@ -32,7 +32,7 @@ Reference<StorageInfo> getStorageInfo(UID id, std::map<UID, Reference<StorageInf
 	Reference<StorageInfo> storageInfo;
 	auto cacheItr = storageCache->find(id);
 	if(cacheItr == storageCache->end()) {
-		storageInfo = Reference<StorageInfo>( new StorageInfo() );
+		storageInfo = makeReference<StorageInfo>();
 		storageInfo->tag = decodeServerTagValue( txnStateStore->readValue( serverTagKeyFor(id) ).get().get() );
 		storageInfo->interf = decodeServerListValue( txnStateStore->readValue( serverListKeyFor(id) ).get().get() );
 		(*storageCache)[id] = storageInfo;
@@ -127,7 +127,7 @@ void applyMetadataMutations(SpanID const& spanContext, UID const& dbgid, Arena& 
 					if(storageCache) {
 						auto cacheItr = storageCache->find(id);
 						if(cacheItr == storageCache->end()) {
-							Reference<StorageInfo> storageInfo = Reference<StorageInfo>( new StorageInfo() );
+							Reference<StorageInfo> storageInfo = makeReference<StorageInfo>();
 							storageInfo->tag = tag;
 							Optional<Key> interfKey = txnStateStore->readValue( serverListKeyFor(id) ).get();
 							if(interfKey.present()) {
@@ -198,7 +198,7 @@ void applyMetadataMutations(SpanID const& spanContext, UID const& dbgid, Arena& 
 
 						auto cacheItr = storageCache->find(id);
 						if(cacheItr == storageCache->end()) {
-							Reference<StorageInfo> storageInfo = Reference<StorageInfo>( new StorageInfo() );
+							Reference<StorageInfo> storageInfo = makeReference<StorageInfo>();
 							storageInfo->interf = interf;
 							Optional<Key> tagKey = txnStateStore->readValue( serverTagKeyFor(id) ).get();
 							if(tagKey.present()) {
@@ -221,7 +221,7 @@ void applyMetadataMutations(SpanID const& spanContext, UID const& dbgid, Arena& 
 					auto &p = (*uid_applyMutationsData)[uid];
 					p.endVersion = BinaryReader::fromStringRef<Version>(m.param2, Unversioned());
 					if(p.keyVersion == Reference<KeyRangeMap<Version>>())
-						p.keyVersion = Reference<KeyRangeMap<Version>>( new KeyRangeMap<Version>() );
+						p.keyVersion = makeReference<KeyRangeMap<Version>>();
 					if(!p.worker.isValid() || p.worker.isReady()) {
 						auto addPrefixValue = txnStateStore->readValue(uid.withPrefix(applyMutationsAddPrefixRange.begin)).get();
 						auto removePrefixValue = txnStateStore->readValue(uid.withPrefix(applyMutationsRemovePrefixRange.begin)).get();
@@ -241,7 +241,7 @@ void applyMetadataMutations(SpanID const& spanContext, UID const& dbgid, Arena& 
 						Key k = m.param1.substr(applyMutationsKeyVersionMapRange.begin.size() + sizeof(UID));
 						auto &p = (*uid_applyMutationsData)[uid];
 						if(p.keyVersion == Reference<KeyRangeMap<Version>>())
-							p.keyVersion = Reference<KeyRangeMap<Version>>( new KeyRangeMap<Version>() );
+							p.keyVersion = makeReference<KeyRangeMap<Version>>();
 						p.keyVersion->rawInsert( k, BinaryReader::fromStringRef<Version>(m.param2, Unversioned()) );
 					}
 				}
@@ -416,7 +416,7 @@ void applyMetadataMutations(SpanID const& spanContext, UID const& dbgid, Arena& 
 						if(uid == uid2) {
 							auto &p = (*uid_applyMutationsData)[uid];
 							if(p.keyVersion == Reference<KeyRangeMap<Version>>())
-								p.keyVersion = Reference<KeyRangeMap<Version>>( new KeyRangeMap<Version>() );
+								p.keyVersion = makeReference<KeyRangeMap<Version>>();
 							p.keyVersion->rawErase( KeyRangeRef( m.param1.substr(applyMutationsKeyVersionMapRange.begin.size() + sizeof(UID)), m.param2.substr(applyMutationsKeyVersionMapRange.begin.size() + sizeof(UID))) );
 						}
 					}

--- a/fdbserver/ClusterController.actor.cpp
+++ b/fdbserver/ClusterController.actor.cpp
@@ -113,12 +113,13 @@ public:
 		bool cachePopulated;
 		std::map<NetworkAddress, std::pair<double, OpenDatabaseRequest>> clientStatus;
 
-		DBInfo() : masterRegistrationCount(0), recoveryStalled(false), forceRecovery(false), unfinishedRecoveries(0), logGenerations(0), cachePopulated(false),
-			clientInfo( new AsyncVar<ClientDBInfo>( ClientDBInfo() ) ), dbInfoCount(0),
-			serverInfo( new AsyncVar<ServerDBInfo>( ServerDBInfo() ) ),
-			db( DatabaseContext::create( clientInfo, Future<Void>(), LocalityData(), true, TaskPriority::DefaultEndpoint, true ) )  // SOMEDAY: Locality!
-		{
-		}
+		DBInfo()
+		  : masterRegistrationCount(0), recoveryStalled(false), forceRecovery(false), unfinishedRecoveries(0),
+		    logGenerations(0), cachePopulated(false), clientInfo(new AsyncVar<ClientDBInfo>()), dbInfoCount(0),
+		    serverInfo(new AsyncVar<ServerDBInfo>()),
+		    db(DatabaseContext::create(clientInfo, Future<Void>(), LocalityData(), true, TaskPriority::DefaultEndpoint,
+		                               true)) // SOMEDAY: Locality!
+		{}
 
 		void setDistributor(const DataDistributorInterface& interf) {
 			auto newInfo = serverInfo->get();
@@ -2188,7 +2189,7 @@ void registerWorker( RegisterWorkerRequest req, ClusterControllerData *self ) {
 #define TIME_KEEPER_VERSION LiteralStringRef("1")
 
 ACTOR Future<Void> timeKeeperSetVersion(ClusterControllerData *self) {
-	state Reference<ReadYourWritesTransaction> tr = Reference<ReadYourWritesTransaction>(new ReadYourWritesTransaction(self->cx));
+	state Reference<ReadYourWritesTransaction> tr = makeReference<ReadYourWritesTransaction>(self->cx);
 	loop {
 		try {
 			tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
@@ -2216,7 +2217,7 @@ ACTOR Future<Void> timeKeeper(ClusterControllerData *self) {
 	wait(timeKeeperSetVersion(self));
 
 	loop {
-		state Reference<ReadYourWritesTransaction> tr = Reference<ReadYourWritesTransaction>(new ReadYourWritesTransaction(self->cx));
+		state Reference<ReadYourWritesTransaction> tr = makeReference<ReadYourWritesTransaction>(self->cx);
 		loop {
 			try {
 				if(!g_network->isSimulated()) {

--- a/fdbserver/Coordination.actor.cpp
+++ b/fdbserver/Coordination.actor.cpp
@@ -276,11 +276,12 @@ ACTOR Future<Void> leaderRegister(LeaderElectionRegInterface interf, Key key) {
 	state Future<Void> notifyCheck = delay(SERVER_KNOBS->NOTIFICATION_FULL_CLEAR_TIME / SERVER_KNOBS->MIN_NOTIFICATIONS);
 	state ClientData clientData;
 	state int clientCount = 0;
-	state Reference<AsyncVar<bool>> hasConnectedClients = Reference<AsyncVar<bool>>( new AsyncVar<bool>(false) );
+	state Reference<AsyncVar<bool>> hasConnectedClients = makeReference<AsyncVar<bool>>(false);
 	state ActorCollection actors(false);
 	state Future<Void> leaderMon;
 	state AsyncVar<Value> leaderInterface;
-	state Reference<AsyncVar<Optional<LeaderInfo>>> currentElectedLeader = Reference<AsyncVar<Optional<LeaderInfo>>>( new AsyncVar<Optional<LeaderInfo>>() );
+	state Reference<AsyncVar<Optional<LeaderInfo>>> currentElectedLeader =
+	    makeReference<AsyncVar<Optional<LeaderInfo>>>();
 
 	loop choose {
 		when ( OpenDatabaseCoordRequest req = waitNext( interf.openDatabase.getFuture() ) ) {

--- a/fdbserver/DataDistributionTracker.actor.cpp
+++ b/fdbserver/DataDistributionTracker.actor.cpp
@@ -717,7 +717,7 @@ void restartShardTrackers(DataDistributionTracker* self, KeyRangeRef keys, Optio
 			continue;
 		}
 
-		Reference<AsyncVar<Optional<ShardMetrics>>> shardMetrics(new AsyncVar<Optional<ShardMetrics>>());
+		auto shardMetrics = makeReference<AsyncVar<Optional<ShardMetrics>>>();
 
 		// For the case where the new tracker will take over at the boundaries of current shard(s)
 		//  we can use the old size if it is available. This will be the case when merging shards.

--- a/fdbserver/DiskQueue.actor.cpp
+++ b/fdbserver/DiskQueue.actor.cpp
@@ -241,7 +241,7 @@ public:
 
 		void setFile(Reference<IAsyncFile> f) {
 			this->f = f;
-			this->syncQueue = Reference<SyncQueue>( new SyncQueue(1, f) );
+			this->syncQueue = makeReference<SyncQueue>(1, f);
 		}
 	};
 	File files[2];  // After readFirstAndLastPages(), files[0] is logically before files[1] (pushes are always into files[1])

--- a/fdbserver/KeyValueStoreSQLite.actor.cpp
+++ b/fdbserver/KeyValueStoreSQLite.actor.cpp
@@ -1510,7 +1510,7 @@ private:
 		Reference<ReadCursor> getCursor() {
 			Reference<ReadCursor> cursor = *ppReadCursor;
 			if (!cursor) {
-				*ppReadCursor = cursor = Reference<ReadCursor>(new ReadCursor);
+				*ppReadCursor = cursor = makeReference<ReadCursor>();
 				cursor->init(conn);
 			}
 			return cursor;

--- a/fdbserver/LeaderElection.actor.cpp
+++ b/fdbserver/LeaderElection.actor.cpp
@@ -59,7 +59,7 @@ ACTOR template <class T> Future<Void> buggifyDelayedAsyncVar( Reference<AsyncVar
 
 template <class T>
 Future<Void> buggifyDelayedAsyncVar( Reference<AsyncVar<T>> &var ) {
-	Reference<AsyncVar<T>> in( new AsyncVar<T> );
+	auto in = makeReference<AsyncVar<T>>();
 	auto f = buggifyDelayedAsyncVar(in, var);
 	var = in;
 	return f;

--- a/fdbserver/LeaderElection.h
+++ b/fdbserver/LeaderElection.h
@@ -60,7 +60,7 @@ Future<Void> tryBecomeLeader( ServerCoordinators const& coordinators,
 							  bool hasConnected,
 							  Reference<AsyncVar<ClusterControllerPriorityInfo>> const& asyncPriorityInfo)
 {
-	Reference<AsyncVar<Value>> serializedInfo(new AsyncVar<Value>);
+	auto serializedInfo = makeReference<AsyncVar<Value>>();
 	Future<Void> m = tryBecomeLeaderInternal(coordinators, ObjectWriter::toValue(proposedInterface, IncludeVersion()),
 	                                         serializedInfo, hasConnected, asyncPriorityInfo);
 	return m || asyncDeserialize(serializedInfo, outKnownLeader);

--- a/fdbserver/LogRouter.actor.cpp
+++ b/fdbserver/LogRouter.actor.cpp
@@ -116,7 +116,7 @@ struct LogRouterData {
 
 	//only callable after getTagData returns a null reference
 	Reference<TagData> createTagData(Tag tag, Version popped, Version knownCommittedVersion) {
-		Reference<TagData> newTagData(new TagData(tag, popped, knownCommittedVersion));
+		auto newTagData = makeReference<TagData>(tag, popped, knownCommittedVersion);
 		tag_data[tag.id] = newTagData;
 		return newTagData;
 	}
@@ -138,7 +138,7 @@ struct LogRouterData {
 			}
 		}
 
-		eventCacheHolder = Reference<EventCacheHolder>( new EventCacheHolder(dbgid.shortString() + ".PeekLocation") );
+		eventCacheHolder = makeReference<EventCacheHolder>(dbgid.shortString() + ".PeekLocation");
 
 		specialCounter(cc, "Version", [this](){ return this->version.get(); });
 		specialCounter(cc, "MinPopped", [this](){ return this->minPopped.get(); });

--- a/fdbserver/LogSystemPeekCursor.actor.cpp
+++ b/fdbserver/LogSystemPeekCursor.actor.cpp
@@ -48,7 +48,8 @@ ILogSystem::ServerPeekCursor::ServerPeekCursor( TLogPeekReply const& results, Lo
 }
 
 Reference<ILogSystem::IPeekCursor> ILogSystem::ServerPeekCursor::cloneNoMore() {
-	return Reference<ILogSystem::ServerPeekCursor>( new ILogSystem::ServerPeekCursor( results, messageVersion, end, messageAndTags, hasMsg, poppedVersion, tag ) );
+	return makeReference<ILogSystem::ServerPeekCursor>(results, messageVersion, end, messageAndTags, hasMsg,
+	                                                   poppedVersion, tag);
 }
 
 void ILogSystem::ServerPeekCursor::setProtocolVersion( ProtocolVersion version ) {
@@ -351,7 +352,7 @@ ILogSystem::MergedPeekCursor::MergedPeekCursor( std::vector<Reference<AsyncVar<O
 	bool parallelGetMore, std::vector< LocalityData > const& tLogLocalities, Reference<IReplicationPolicy> const tLogPolicy, int tLogReplicationFactor )
 	: bestServer(bestServer), readQuorum(readQuorum), tag(tag), currentCursor(0), hasNextMessage(false), messageVersion(begin), randomID(deterministicRandom()->randomUniqueID()), tLogReplicationFactor(tLogReplicationFactor) {
 	if(tLogPolicy) {
-		logSet = Reference<LogSet>( new LogSet() );
+		logSet = makeReference<LogSet>();
 		logSet->tLogPolicy = tLogPolicy;
 		logSet->tLogLocalities = tLogLocalities;
 		filterLocalityDataForPolicy(logSet->tLogPolicy, &logSet->tLogLocalities);
@@ -359,7 +360,8 @@ ILogSystem::MergedPeekCursor::MergedPeekCursor( std::vector<Reference<AsyncVar<O
 	}
 
 	for( int i = 0; i < logServers.size(); i++ ) {
-		Reference<ILogSystem::ServerPeekCursor> cursor( new ILogSystem::ServerPeekCursor( logServers[i], tag, begin, end, bestServer >= 0, parallelGetMore ) );
+		auto cursor = makeReference<ILogSystem::ServerPeekCursor>(logServers[i], tag, begin, end, bestServer >= 0,
+		                                                          parallelGetMore);
 		//TraceEvent("MPC_Starting", randomID).detail("Cursor", cursor->randomID).detail("End", end);
 		serverCursors.push_back( cursor );
 	}
@@ -378,7 +380,8 @@ Reference<ILogSystem::IPeekCursor> ILogSystem::MergedPeekCursor::cloneNoMore() {
 	for( auto it : serverCursors ) {
 		cursors.push_back(it->cloneNoMore());
 	}
-	return Reference<ILogSystem::MergedPeekCursor>( new ILogSystem::MergedPeekCursor( cursors, messageVersion, bestServer, readQuorum, nextVersion, logSet, tLogReplicationFactor ) );
+	return makeReference<ILogSystem::MergedPeekCursor>(cursors, messageVersion, bestServer, readQuorum, nextVersion,
+	                                                   logSet, tLogReplicationFactor);
 }
 
 void ILogSystem::MergedPeekCursor::setProtocolVersion( ProtocolVersion version ) {
@@ -589,7 +592,8 @@ ILogSystem::SetPeekCursor::SetPeekCursor( std::vector<Reference<LogSet>> const& 
 	int maxServers = 0;
 	for( int i = 0; i < logSets.size(); i++ ) {
 		for( int j = 0; j < logSets[i]->logServers.size(); j++) {
-			Reference<ILogSystem::ServerPeekCursor> cursor( new ILogSystem::ServerPeekCursor( logSets[i]->logServers[j], tag, begin, end, true, parallelGetMore ) );
+			auto cursor = makeReference<ILogSystem::ServerPeekCursor>(logSets[i]->logServers[j], tag, begin, end, true,
+			                                                          parallelGetMore);
 			serverCursors[i].push_back( cursor );
 		}
 		maxServers = std::max<int>(maxServers, serverCursors[i].size());
@@ -616,7 +620,8 @@ Reference<ILogSystem::IPeekCursor> ILogSystem::SetPeekCursor::cloneNoMore() {
 			cursors[i].push_back( serverCursors[i][j]->cloneNoMore() );
 		}
 	}
-	return Reference<ILogSystem::SetPeekCursor>( new ILogSystem::SetPeekCursor( logSets, cursors, messageVersion, bestSet, bestServer, nextVersion, useBestSet ) );
+	return makeReference<ILogSystem::SetPeekCursor>(logSets, cursors, messageVersion, bestSet, bestServer, nextVersion,
+	                                                useBestSet);
 }
 
 void ILogSystem::SetPeekCursor::setProtocolVersion( ProtocolVersion version ) {
@@ -999,7 +1004,8 @@ ILogSystem::BufferedCursor::BufferedCursor( std::vector<Reference<AsyncVar<Optio
 	messages.reserve(SERVER_KNOBS->DESIRED_OUTSTANDING_MESSAGES);
 	cursorMessages.resize(logServers.size());
 	for( int i = 0; i < logServers.size(); i++ ) {
-		Reference<ILogSystem::ServerPeekCursor> cursor( new ILogSystem::ServerPeekCursor( logServers[i], tag, begin, end, false, parallelGetMore ) );
+		auto cursor =
+		    makeReference<ILogSystem::ServerPeekCursor>(logServers[i], tag, begin, end, false, parallelGetMore);
 		cursors.push_back( cursor );
 	}
 }

--- a/fdbserver/RestoreApplier.actor.cpp
+++ b/fdbserver/RestoreApplier.actor.cpp
@@ -43,8 +43,7 @@ ACTOR static Future<Void> handleApplyToDBRequest(RestoreVersionBatchRequest req,
 void handleUpdateRateRequest(RestoreUpdateRateRequest req, Reference<RestoreApplierData> self);
 
 ACTOR Future<Void> restoreApplierCore(RestoreApplierInterface applierInterf, int nodeIndex, Database cx) {
-	state Reference<RestoreApplierData> self =
-	    Reference<RestoreApplierData>(new RestoreApplierData(applierInterf.id(), nodeIndex));
+	state Reference<RestoreApplierData> self = makeReference<RestoreApplierData>(applierInterf.id(), nodeIndex);
 	state ActorCollection actors(false);
 	state Future<Void> exitRole = Never();
 

--- a/fdbserver/RestoreController.actor.cpp
+++ b/fdbserver/RestoreController.actor.cpp
@@ -108,7 +108,7 @@ ACTOR Future<Void> startRestoreController(Reference<RestoreWorkerData> controlle
 	ASSERT(controllerWorker.isValid());
 	ASSERT(controllerWorker->controllerInterf.present());
 	state Reference<RestoreControllerData> self =
-	    Reference<RestoreControllerData>(new RestoreControllerData(controllerWorker->controllerInterf.get().id()));
+	    makeReference<RestoreControllerData>(controllerWorker->controllerInterf.get().id());
 	state Future<Void> error = actorCollection(self->addActor.getFuture());
 
 	try {
@@ -373,8 +373,8 @@ ACTOR static Future<Version> processRestoreRequest(Reference<RestoreControllerDa
 		    .detail("BatchSize", versionBatch->size)
 		    .detail("RunningVersionBatches", self->runningVersionBatches.get())
 		    .detail("VersionBatches", versionBatches.size());
-		self->batch[batchIndex] = Reference<ControllerBatchData>(new ControllerBatchData());
-		self->batchStatus[batchIndex] = Reference<ControllerBatchStatus>(new ControllerBatchStatus());
+		self->batch[batchIndex] = makeReference<ControllerBatchData>();
+		self->batchStatus[batchIndex] = makeReference<ControllerBatchStatus>();
 		fBatches.push_back(distributeWorkloadPerVersionBatch(self, batchIndex, cx, request, *versionBatch));
 		// Wait a bit to give the current version batch a head start from the next version batch
 		wait(delay(SERVER_KNOBS->FASTRESTORE_VB_LAUNCH_DELAY));

--- a/fdbserver/RestoreLoader.actor.cpp
+++ b/fdbserver/RestoreLoader.actor.cpp
@@ -218,8 +218,7 @@ ACTOR Future<Void> dispatchRequests(Reference<RestoreLoaderData> self) {
 
 ACTOR Future<Void> restoreLoaderCore(RestoreLoaderInterface loaderInterf, int nodeIndex, Database cx,
                                      RestoreControllerInterface ci) {
-	state Reference<RestoreLoaderData> self =
-	    Reference<RestoreLoaderData>(new RestoreLoaderData(loaderInterf.id(), nodeIndex, ci));
+	state Reference<RestoreLoaderData> self = makeReference<RestoreLoaderData>(loaderInterf.id(), nodeIndex, ci);
 	state Future<Void> error = actorCollection(self->addActor.getFuture());
 	state ActorCollection actors(false); // actors whose errors can be ignored
 	state Future<Void> exitRole = Never();

--- a/fdbserver/RestoreLoader.actor.h
+++ b/fdbserver/RestoreLoader.actor.h
@@ -188,7 +188,7 @@ struct RestoreLoaderData : RestoreRoleData, public ReferenceCounted<RestoreLoade
 		nodeID = loaderInterfID;
 		nodeIndex = assignedIndex;
 		role = RestoreRole::Loader;
-		hasPendingRequests = Reference<AsyncVar<bool>>(new AsyncVar<bool>(false));
+		hasPendingRequests = makeReference<AsyncVar<bool>>(false);
 	}
 
 	~RestoreLoaderData() = default;
@@ -216,8 +216,8 @@ struct RestoreLoaderData : RestoreRoleData, public ReferenceCounted<RestoreLoade
 
 	void initVersionBatch(int batchIndex) {
 		TraceEvent("FastRestoreLoaderInitVersionBatch", nodeID).detail("BatchIndex", batchIndex);
-		batch[batchIndex] = Reference<LoaderBatchData>(new LoaderBatchData(nodeID, batchIndex));
-		status[batchIndex] = Reference<LoaderBatchStatus>(new LoaderBatchStatus());
+		batch[batchIndex] = makeReference<LoaderBatchData>(nodeID, batchIndex);
+		status[batchIndex] = makeReference<LoaderBatchStatus>();
 	}
 
 	void resetPerRestoreRequest() {

--- a/fdbserver/RestoreWorker.actor.cpp
+++ b/fdbserver/RestoreWorker.actor.cpp
@@ -340,10 +340,9 @@ ACTOR Future<Void> monitorleader(Reference<AsyncVar<RestoreWorkerInterface>> lea
 ACTOR Future<Void> _restoreWorker(Database cx, LocalityData locality) {
 	state ActorCollection actors(false);
 	state Future<Void> myWork = Never();
-	state Reference<AsyncVar<RestoreWorkerInterface>> leader =
-	    Reference<AsyncVar<RestoreWorkerInterface>>(new AsyncVar<RestoreWorkerInterface>());
+	state Reference<AsyncVar<RestoreWorkerInterface>> leader = makeReference<AsyncVar<RestoreWorkerInterface>>();
 	state RestoreWorkerInterface myWorkerInterf;
-	state Reference<RestoreWorkerData> self = Reference<RestoreWorkerData>(new RestoreWorkerData());
+	state Reference<RestoreWorkerData> self = makeReference<RestoreWorkerData>();
 
 	myWorkerInterf.initEndpoints();
 	self->workerID = myWorkerInterf.id();

--- a/fdbserver/VersionedBTree.actor.cpp
+++ b/fdbserver/VersionedBTree.actor.cpp
@@ -2224,10 +2224,10 @@ Reference<IPagerSnapshot> DWALPager::getReadSnapshot(Version v) {
 
 void DWALPager::addLatestSnapshot() {
 	Promise<Void> expired;
-	snapshots.push_back({ pLastCommittedHeader->committedVersion, expired,
-	                      Reference<DWALPagerSnapshot>(new DWALPagerSnapshot(this, pLastCommittedHeader->getMetaKey(),
-	                                                                         pLastCommittedHeader->committedVersion,
-	                                                                         expired.getFuture())) });
+	snapshots.push_back(
+	    { pLastCommittedHeader->committedVersion, expired,
+	      makeReference<DWALPagerSnapshot>(this, pLastCommittedHeader->getMetaKey(),
+	                                       pLastCommittedHeader->committedVersion, expired.getFuture()) });
 }
 
 // TODO: Move this to a flow header once it is mature.
@@ -4996,7 +4996,7 @@ public:
 			  : parent(toCopy.parent), pageID(toCopy.pageID), page(toCopy.page), cursor(toCopy.cursor) {}
 
 			// Convenience method for copying a PageCursor
-			Reference<PageCursor> copy() const { return Reference<PageCursor>(new PageCursor(*this)); }
+			Reference<PageCursor> copy() const { return makeReference<PageCursor>(*this); }
 
 			const BTreePage* btPage() const { return (const BTreePage*)page->begin(); }
 
@@ -5026,7 +5026,7 @@ public:
 				}
 
 				return map(child, [=](Reference<const IPage> page) {
-					return Reference<PageCursor>(new PageCursor(id, page, Reference<PageCursor>::addRef(this)));
+					return makeReference<PageCursor>(id, page, Reference<PageCursor>::addRef(this));
 				});
 			}
 
@@ -5102,7 +5102,7 @@ public:
 			// Otherwise read the root page
 			Future<Reference<const IPage>> root = readPage(pager, rootPageID, &dbBegin, &dbEnd);
 			return map(root, [=](Reference<const IPage> p) {
-				pageCursor = Reference<PageCursor>(new PageCursor(rootPageID, p));
+				pageCursor = makeReference<PageCursor>(rootPageID, p);
 				return Void();
 			});
 		}

--- a/fdbserver/fdbserver.actor.cpp
+++ b/fdbserver/fdbserver.actor.cpp
@@ -1444,13 +1444,12 @@ private:
 					fprintf(stderr, "%s\n", ClusterConnectionString::getErrorString(connectionString, e).c_str());
 					throw;
 				}
-				connectionFile = Reference<ClusterConnectionFile>(new ClusterConnectionFile(connFile, ccs));
+				auto connectionFile = makeReference<ClusterConnectionFile>(connFile, ccs);
 			} else {
 				std::pair<std::string, bool> resolvedClusterFile;
 				try {
 					resolvedClusterFile = ClusterConnectionFile::lookupClusterFileName(connFile);
-					connectionFile =
-					    Reference<ClusterConnectionFile>(new ClusterConnectionFile(resolvedClusterFile.first));
+					connectionFile = makeReference<ClusterConnectionFile>(resolvedClusterFile.first);
 				} catch (Error& e) {
 					fprintf(stderr, "%s\n", ClusterConnectionFile::getErrorString(resolvedClusterFile, e).c_str());
 					throw;

--- a/fdbserver/masterserver.actor.cpp
+++ b/fdbserver/masterserver.actor.cpp
@@ -240,41 +240,16 @@ struct MasterData : NonCopyable, ReferenceCounted<MasterData> {
 
 	std::vector<WorkerInterface> backupWorkers; // Recruited backup workers from cluster controller.
 
-	MasterData(
-		Reference<AsyncVar<ServerDBInfo>> const& dbInfo,
-		MasterInterface const& myInterface,
-		ServerCoordinators const& coordinators,
-		ClusterControllerFullInterface const& clusterController,
-		Standalone<StringRef> const& dbId,
-		PromiseStream<Future<Void>> const& addActor,
-		bool forceRecovery
-		)
-		: dbgid(myInterface.id()),
-		  myInterface(myInterface),
-		  dbInfo(dbInfo),
-		  cstate(coordinators, addActor, dbgid),
-		  coordinators(coordinators),
-		  clusterController(clusterController),
-		  dbId(dbId),
-		  forceRecovery(forceRecovery),
-		  safeLocality(tagLocalityInvalid),
-		  primaryLocality(tagLocalityInvalid),
-		  neverCreated(false),
-		  lastEpochEnd(invalidVersion),
-		  liveCommittedVersion(invalidVersion),
-		  databaseLocked(false),
-		  minKnownCommittedVersion(invalidVersion),
-		  recoveryTransactionVersion(invalidVersion),
-		  lastCommitTime(0),
-		  registrationCount(0),
-		  version(invalidVersion),
-		  lastVersionTime(0),
-		  txnStateStore(0),
-		  memoryLimit(2e9),
-		  addActor(addActor),
-		  hasConfiguration(false),
-		  recruitmentStalled( Reference<AsyncVar<bool>>( new AsyncVar<bool>() ) )
-	{
+	MasterData(Reference<AsyncVar<ServerDBInfo>> const& dbInfo, MasterInterface const& myInterface,
+	           ServerCoordinators const& coordinators, ClusterControllerFullInterface const& clusterController,
+	           Standalone<StringRef> const& dbId, PromiseStream<Future<Void>> const& addActor, bool forceRecovery)
+	  : dbgid(myInterface.id()), myInterface(myInterface), dbInfo(dbInfo), cstate(coordinators, addActor, dbgid),
+	    coordinators(coordinators), clusterController(clusterController), dbId(dbId), forceRecovery(forceRecovery),
+	    safeLocality(tagLocalityInvalid), primaryLocality(tagLocalityInvalid), neverCreated(false),
+	    lastEpochEnd(invalidVersion), liveCommittedVersion(invalidVersion), databaseLocked(false),
+	    minKnownCommittedVersion(invalidVersion), recoveryTransactionVersion(invalidVersion), lastCommitTime(0),
+	    registrationCount(0), version(invalidVersion), lastVersionTime(0), txnStateStore(0), memoryLimit(2e9),
+	    addActor(addActor), hasConfiguration(false), recruitmentStalled(makeReference<AsyncVar<bool>>(false)) {
 		if(forceRecovery && !myInterface.locality.dcId().present()) {
 			TraceEvent(SevError, "ForcedRecoveryRequiresDcID");
 			forceRecovery = false;

--- a/fdbserver/tester.actor.cpp
+++ b/fdbserver/tester.actor.cpp
@@ -1320,8 +1320,8 @@ ACTOR Future<Void> runTests( Reference<AsyncVar<Optional<struct ClusterControlle
 ACTOR Future<Void> runTests( Reference<ClusterConnectionFile> connFile, test_type_t whatToRun, test_location_t at, 
 		int minTestersExpected, std::string fileName, StringRef startingConfiguration, LocalityData locality ) {
 	state vector<TestSpec> testSpecs;
-	Reference<AsyncVar<Optional<ClusterControllerFullInterface>>> cc( new AsyncVar<Optional<ClusterControllerFullInterface>> );
-	Reference<AsyncVar<Optional<ClusterInterface>>> ci( new AsyncVar<Optional<ClusterInterface>> );
+	auto cc = makeReference<AsyncVar<Optional<ClusterControllerFullInterface>>>();
+	auto ci = makeReference<AsyncVar<Optional<ClusterInterface>>>();
 	vector<Future<Void>> actors;
 	actors.push_back( reportErrors(monitorLeader( connFile, cc ), "MonitorLeader") );
 	actors.push_back( reportErrors(extractClusterInterface( cc,ci ),"ExtractClusterInterface") );
@@ -1368,7 +1368,7 @@ ACTOR Future<Void> runTests( Reference<ClusterConnectionFile> connFile, test_typ
 
 	Future<Void> tests;
 	if (at == TEST_HERE) {
-		Reference<AsyncVar<ServerDBInfo>> db( new AsyncVar<ServerDBInfo> );
+		auto db = makeReference<AsyncVar<ServerDBInfo>>();
 		vector<TesterInterface> iTesters(1);
 		actors.push_back( reportErrors(monitorServerDBInfo( cc, LocalityData(), db ), "MonitorServerDBInfo") );  // FIXME: Locality
 		actors.push_back( reportErrors(testerServerCore( iTesters[0], connFile, db, locality ), "TesterServerCore") );

--- a/fdbserver/worker.actor.cpp
+++ b/fdbserver/worker.actor.cpp
@@ -127,7 +127,7 @@ ACTOR static Future<Void> extractClientInfo( Reference<AsyncVar<ServerDBInfo>> d
 }
 
 Database openDBOnServer( Reference<AsyncVar<ServerDBInfo>> const& db, TaskPriority taskID, bool enableLocalityLoadBalance, bool lockAware ) {
-	Reference<AsyncVar<ClientDBInfo>> info( new AsyncVar<ClientDBInfo> );
+	auto info = makeReference<AsyncVar<ClientDBInfo>>();
 	return DatabaseContext::create( info, extractClientInfo(db, info), enableLocalityLoadBalance ? db->get().myLocality : LocalityData(), enableLocalityLoadBalance, taskID, lockAware );
 }
 
@@ -1715,7 +1715,8 @@ ACTOR Future<MonitorLeaderInfo> monitorLeaderRemotelyOneGeneration( Reference<Cl
 		if (leader.present()) {
 			if(leader.get().present()) {
 				if( leader.get().get().forward ) {
-					info.intermediateConnFile = Reference<ClusterConnectionFile>(new ClusterConnectionFile(connFile->getFilename(), ClusterConnectionString(leader.get().get().serializedInfo.toString())));
+					info.intermediateConnFile = makeReference<ClusterConnectionFile>(
+					    connFile->getFilename(), ClusterConnectionString(leader.get().get().serializedInfo.toString()));
 					return info;
 				}
 				if(connFile != info.intermediateConnFile) {
@@ -1764,7 +1765,7 @@ template <class LeaderInterface>
 Future<Void> monitorLeaderRemotely(Reference<ClusterConnectionFile> const& connFile,
 						   Reference<AsyncVar<Optional<LeaderInterface>>> const& outKnownLeader) {
 	LeaderDeserializer<LeaderInterface> deserializer;
-	Reference<AsyncVar<Value>> serializedInfo( new AsyncVar<Value> );
+	auto serializedInfo = makeReference<AsyncVar<Value>>();
 	Future<Void> m = monitorLeaderRemotelyInternal( connFile, serializedInfo );
 	return m || deserializer( serializedInfo, outKnownLeader );
 }
@@ -1830,10 +1831,11 @@ ACTOR Future<Void> fdbd(
 		// Only one process can execute on a dataFolder from this point onwards
 
 		std::string fitnessFilePath = joinPath(dataFolder, "fitness");
-		Reference<AsyncVar<Optional<ClusterControllerFullInterface>>> cc(new AsyncVar<Optional<ClusterControllerFullInterface>>);
-		Reference<AsyncVar<Optional<ClusterInterface>>> ci(new AsyncVar<Optional<ClusterInterface>>);
-		Reference<AsyncVar<ClusterControllerPriorityInfo>> asyncPriorityInfo(new AsyncVar<ClusterControllerPriorityInfo>(getCCPriorityInfo(fitnessFilePath, processClass)));
-		Reference<AsyncVar<ServerDBInfo>> dbInfo( new AsyncVar<ServerDBInfo>(ServerDBInfo()) );
+		auto cc = makeReference<AsyncVar<Optional<ClusterControllerFullInterface>>>();
+		auto ci = makeReference<AsyncVar<Optional<ClusterInterface>>>();
+		auto asyncPriorityInfo =
+		    makeReference<AsyncVar<ClusterControllerPriorityInfo>>(getCCPriorityInfo(fitnessFilePath, processClass));
+		auto dbInfo = makeReference<AsyncVar<ServerDBInfo>>();
 
 		actors.push_back(reportErrors(monitorAndWriteCCPriorityInfo(fitnessFilePath, asyncPriorityInfo), "MonitorAndWriteCCPriorityInfo"));
 		if (processClass.machineClassFitness(ProcessClass::ClusterController) == ProcessClass::NeverAssign) {

--- a/fdbserver/workloads/ApiWorkload.h
+++ b/fdbserver/workloads/ApiWorkload.h
@@ -280,7 +280,7 @@ struct ApiWorkload : TestWorkload {
 
 		useExtraDB = g_simulator.extraDB != nullptr;
 		if(useExtraDB) {
-			Reference<ClusterConnectionFile> extraFile(new ClusterConnectionFile(*g_simulator.extraDB));
+			auto extraFile = makeReference<ClusterConnectionFile>(*g_simulator.extraDB);
 			extraDB = Database::createDatabase(extraFile, -1);
 		}
 	}

--- a/fdbserver/workloads/AsyncFile.actor.h
+++ b/fdbserver/workloads/AsyncFile.actor.h
@@ -118,7 +118,7 @@ struct AsyncFileWorkload : TestWorkload
 		{
 			state Reference<IAsyncFile> file = wait(IAsyncFileSystem::filesystem()->open(self->path, flags, 0666));
 			if(self->fileHandle.getPtr() == nullptr)
-				self->fileHandle = Reference<AsyncFileHandle>(new AsyncFileHandle(file, self->path, fileCreated));
+				self->fileHandle = makeReference<AsyncFileHandle>(file, self->path, fileCreated);
 			else
 				self->fileHandle->file = file;
 

--- a/fdbserver/workloads/AsyncFile.cpp
+++ b/fdbserver/workloads/AsyncFile.cpp
@@ -76,7 +76,7 @@ AsyncFileWorkload::AsyncFileWorkload(WorkloadContext const& wcx)
 
 Reference<AsyncFileBuffer> AsyncFileWorkload::allocateBuffer(size_t size)
 {
-	return Reference<AsyncFileBuffer>(new AsyncFileBuffer(size, unbufferedIO));
+	return makeReference<AsyncFileBuffer>(size, unbufferedIO);
 }
 
 Future<bool> AsyncFileWorkload::check(Database const& cx)

--- a/fdbserver/workloads/AtomicSwitchover.actor.cpp
+++ b/fdbserver/workloads/AtomicSwitchover.actor.cpp
@@ -39,7 +39,7 @@ struct AtomicSwitchoverWorkload : TestWorkload {
 
 		backupRanges.push_back_deep(backupRanges.arena(), normalKeys);
 
-		Reference<ClusterConnectionFile> extraFile(new ClusterConnectionFile(*g_simulator.extraDB));
+		auto extraFile = makeReference<ClusterConnectionFile>(*g_simulator.extraDB);
 		extraDB = Database::createDatabase(extraFile, -1);
 	}
 

--- a/fdbserver/workloads/BackupAndParallelRestoreCorrectness.actor.cpp
+++ b/fdbserver/workloads/BackupAndParallelRestoreCorrectness.actor.cpp
@@ -622,7 +622,7 @@ struct BackupAndParallelRestoreCorrectnessWorkload : TestWorkload {
 
 						wait(delay(5.0));
 						wait(tr->commit());
-						tr = Reference<ReadYourWritesTransaction>(new ReadYourWritesTransaction(cx));
+						tr = makeReference<ReadYourWritesTransaction>(cx);
 						int64_t _taskCount = wait(backupAgent.getTaskCount(tr));
 						taskCount = _taskCount;
 

--- a/fdbserver/workloads/BackupCorrectness.actor.cpp
+++ b/fdbserver/workloads/BackupCorrectness.actor.cpp
@@ -604,7 +604,7 @@ struct BackupAndRestoreCorrectnessWorkload : TestWorkload {
 						printf("%.6f %-10s Wait #%4d for %lld tasks to end\n", now(), randomID.toString().c_str(), waitCycles, (long long) taskCount);
 
 						wait(delay(5.0));
-						tr = Reference<ReadYourWritesTransaction>(new ReadYourWritesTransaction(cx));
+						tr = makeReference<ReadYourWritesTransaction>(cx);
 						int64_t _taskCount = wait( backupAgent.getTaskCount(tr) );
 						taskCount = _taskCount;
 

--- a/fdbserver/workloads/BackupToDBAbort.actor.cpp
+++ b/fdbserver/workloads/BackupToDBAbort.actor.cpp
@@ -36,7 +36,7 @@ struct BackupToDBAbort : TestWorkload {
 
 		backupRanges.push_back_deep(backupRanges.arena(), normalKeys);
 
-		Reference<ClusterConnectionFile> extraFile(new ClusterConnectionFile(*g_simulator.extraDB));
+		auto extraFile = makeReference<ClusterConnectionFile>(*g_simulator.extraDB);
 		extraDB = Database::createDatabase(extraFile, -1);
 
 		lockid = UID(0xbeeffeed, 0xdecaf00d);

--- a/fdbserver/workloads/BackupToDBCorrectness.actor.cpp
+++ b/fdbserver/workloads/BackupToDBCorrectness.actor.cpp
@@ -103,7 +103,7 @@ struct BackupToDBCorrectnessWorkload : TestWorkload {
 			}
 		}
 
-		Reference<ClusterConnectionFile> extraFile(new ClusterConnectionFile(*g_simulator.extraDB));
+		auto extraFile = makeReference<ClusterConnectionFile>(*g_simulator.extraDB);
 		extraDB = Database::createDatabase(extraFile, -1);
 
 		TraceEvent("BARW_Start").detail("Locked", locked);
@@ -354,7 +354,7 @@ struct BackupToDBCorrectnessWorkload : TestWorkload {
 					printf("%.6f %-10s Wait #%4d for %lld tasks to end\n", now(), randomID.toString().c_str(), waitCycles, (long long) taskCount);
 
 					wait(delay(5.0));
-					tr = Reference<ReadYourWritesTransaction>(new ReadYourWritesTransaction(cx));
+					tr = makeReference<ReadYourWritesTransaction>(cx);
 					int64_t _taskCount = wait( backupAgent->getTaskCount(tr) );
 					taskCount = _taskCount;
 

--- a/fdbserver/workloads/BackupToDBUpgrade.actor.cpp
+++ b/fdbserver/workloads/BackupToDBUpgrade.actor.cpp
@@ -68,7 +68,7 @@ struct BackupToDBUpgradeWorkload : TestWorkload {
 			}
 		}
 
-		Reference<ClusterConnectionFile> extraFile(new ClusterConnectionFile(*g_simulator.extraDB));
+		auto extraFile = makeReference<ClusterConnectionFile>(*g_simulator.extraDB);
 		extraDB = Database::createDatabase(extraFile, -1);
 
 		TraceEvent("DRU_Start");

--- a/fdbserver/workloads/ChangeConfig.actor.cpp
+++ b/fdbserver/workloads/ChangeConfig.actor.cpp
@@ -54,7 +54,7 @@ struct ChangeConfigWorkload : TestWorkload {
 
 	ACTOR Future<Void> extraDatabaseConfigure(ChangeConfigWorkload *self) {
 		if (g_network->isSimulated() && g_simulator.extraDB) {
-			Reference<ClusterConnectionFile> extraFile(new ClusterConnectionFile(*g_simulator.extraDB));
+			auto extraFile = makeReference<ClusterConnectionFile>(*g_simulator.extraDB);
 			state Database extraDB = Database::createDatabase(extraFile, -1);
 
 			wait(delay(5*deterministicRandom()->random01()));

--- a/fdbserver/workloads/DataDistributionMetrics.actor.cpp
+++ b/fdbserver/workloads/DataDistributionMetrics.actor.cpp
@@ -71,8 +71,7 @@ struct DataDistributionMetricsWorkload : KVWorkload {
 	}
 
 	ACTOR Future<Void> resultConsistencyCheckClient(Database cx, DataDistributionMetricsWorkload* self) {
-		state Reference<ReadYourWritesTransaction> tr =
-		    Reference<ReadYourWritesTransaction>(new ReadYourWritesTransaction(cx));
+		state Reference<ReadYourWritesTransaction> tr = makeReference<ReadYourWritesTransaction>(cx);
 		loop {
 			try {
 				wait(delay(self->delayPerLoop));
@@ -138,8 +137,7 @@ struct DataDistributionMetricsWorkload : KVWorkload {
 		}
 		// TODO : find why this not work
 		// wait(quietDatabase(cx, self->dbInfo, "PopulateTPCC"));
-		state Reference<ReadYourWritesTransaction> tr =
-		    Reference<ReadYourWritesTransaction>(new ReadYourWritesTransaction(cx));
+		state Reference<ReadYourWritesTransaction> tr = makeReference<ReadYourWritesTransaction>(cx);
 		try {
 			state Standalone<RangeResultRef> result = wait(tr->getRange(ddStatsRange, CLIENT_KNOBS->SHARD_COUNT_LIMIT));
 			ASSERT(!result.more);

--- a/fdbserver/workloads/DifferentClustersSameRV.actor.cpp
+++ b/fdbserver/workloads/DifferentClustersSameRV.actor.cpp
@@ -37,7 +37,7 @@ struct DifferentClustersSameRVWorkload : TestWorkload {
 
 	DifferentClustersSameRVWorkload(WorkloadContext const& wcx) : TestWorkload(wcx) {
 		ASSERT(g_simulator.extraDB != nullptr);
-		Reference<ClusterConnectionFile> extraFile(new ClusterConnectionFile(*g_simulator.extraDB));
+		auto extraFile = makeReference<ClusterConnectionFile>(*g_simulator.extraDB);
 		extraDB = Database::createDatabase(extraFile, -1);
 		testDuration = getOption(options, LiteralStringRef("testDuration"), 100.0);
 		switchAfter = getOption(options, LiteralStringRef("switchAfter"), 50.0);
@@ -139,8 +139,8 @@ struct DifferentClustersSameRVWorkload : TestWorkload {
 		TraceEvent("DifferentClusters_CopiedDatabase");
 		wait(advanceVersion(self->extraDB, rv));
 		TraceEvent("DifferentClusters_AdvancedVersion");
-		wait(cx->switchConnectionFile(Reference<ClusterConnectionFile>(
-		    new ClusterConnectionFile(self->extraDB->getConnectionFile()->getConnectionString()))));
+		wait(cx->switchConnectionFile(
+		    makeReference<ClusterConnectionFile>(self->extraDB->getConnectionFile()->getConnectionString())));
 		TraceEvent("DifferentClusters_SwitchedConnectionFile");
 		state Transaction tr(cx);
 		tr.setVersion(rv);

--- a/fdbserver/workloads/DiskDurability.actor.cpp
+++ b/fdbserver/workloads/DiskDurability.actor.cpp
@@ -120,7 +120,7 @@ struct DiskDurabilityWorkload : public AsyncFileWorkload
 		{
 			state Reference<IAsyncFile> file = wait(IAsyncFileSystem::filesystem()->open(self->path, flags, 0666));
 			if(self->fileHandle.getPtr() == nullptr)
-				self->fileHandle = Reference<AsyncFileHandle>(new AsyncFileHandle(file, self->path, false));
+				self->fileHandle = makeReference<AsyncFileHandle>(file, self->path, false);
 			else
 				self->fileHandle->file = file;
 		}
@@ -148,7 +148,7 @@ struct DiskDurabilityWorkload : public AsyncFileWorkload
 	}
 
 	ACTOR static Future<Void> worker(DiskDurabilityWorkload *self) {
-		state Reference<AsyncFileBuffer> buffer = Reference<AsyncFileBuffer>(new AsyncFileBuffer(_PAGE_SIZE, true));
+		state Reference<AsyncFileBuffer> buffer = makeReference<AsyncFileBuffer>(_PAGE_SIZE, true);
 		state int logfp = (int)ceil(log2(self->filePages));
 		loop {
 			int block = intHash(std::min<int>(deterministicRandom()->randomInt(0, 1 << deterministicRandom()->randomInt(0, logfp)), self->filePages - 1)) % self->filePages;

--- a/fdbserver/workloads/ReportConflictingKeys.actor.cpp
+++ b/fdbserver/workloads/ReportConflictingKeys.actor.cpp
@@ -191,7 +191,7 @@ struct ReportConflictingKeysWorkload : TestWorkload {
 					    tr2->getRange(ckr, CLIENT_KNOBS->TOO_MANY);
 					ASSERT(conflictingKeyRangesFuture.isReady());
 
-					tr2 = Reference<ReadYourWritesTransaction>(new ReadYourWritesTransaction(cx));
+					tr2 = makeReference<ReadYourWritesTransaction>(cx);
 
 					const Standalone<RangeResultRef> conflictingKeyRanges = conflictingKeyRangesFuture.get();
 					ASSERT(conflictingKeyRanges.size() &&

--- a/fdbserver/workloads/SpecialKeySpaceCorrectness.actor.cpp
+++ b/fdbserver/workloads/SpecialKeySpaceCorrectness.actor.cpp
@@ -63,7 +63,7 @@ struct SpecialKeySpaceCorrectnessWorkload : TestWorkload {
 
 	Future<Void> _setup(Database cx, SpecialKeySpaceCorrectnessWorkload* self) {
 		cx->specialKeySpace = std::make_unique<SpecialKeySpace>();
-		self->ryw = Reference(new ReadYourWritesTransaction(cx));
+		self->ryw = makeReference<ReadYourWritesTransaction>(cx);
 		self->ryw->setOption(FDBTransactionOptions::SPECIAL_KEY_SPACE_RELAXED);
 		self->ryw->setOption(FDBTransactionOptions::SPECIAL_KEY_SPACE_ENABLE_WRITES);
 		self->ryw->setVersion(100);
@@ -278,7 +278,7 @@ struct SpecialKeySpaceCorrectnessWorkload : TestWorkload {
 
 	ACTOR Future<Void> testSpecialKeySpaceErrors(Database cx_, SpecialKeySpaceCorrectnessWorkload* self) {
 		Database cx = cx_->clone();
-		state Reference<ReadYourWritesTransaction> tx = Reference(new ReadYourWritesTransaction(cx));
+		state Reference<ReadYourWritesTransaction> tx = makeReference<ReadYourWritesTransaction>(cx);
 		// begin key outside module range
 		try {
 			wait(success(tx->getRange(
@@ -442,8 +442,8 @@ struct SpecialKeySpaceCorrectnessWorkload : TestWorkload {
 		TEST(!read); // test write conflict range special key implementation
 		// Get a default special key range instance
 		Database cx = cx_->clone();
-		state Reference<ReadYourWritesTransaction> tx = Reference(new ReadYourWritesTransaction(cx));
-		state Reference<ReadYourWritesTransaction> referenceTx = Reference(new ReadYourWritesTransaction(cx));
+		state Reference<ReadYourWritesTransaction> tx = makeReference<ReadYourWritesTransaction>(cx);
+		state Reference<ReadYourWritesTransaction> referenceTx = makeReference<ReadYourWritesTransaction>(cx);
 		state bool ryw = deterministicRandom()->coinflip();
 		if (!ryw) {
 			tx->setOption(FDBTransactionOptions::READ_YOUR_WRITES_DISABLE);
@@ -588,7 +588,7 @@ struct SpecialKeySpaceCorrectnessWorkload : TestWorkload {
 	ACTOR Future<Void> managementApiCorrectnessActor(Database cx_, SpecialKeySpaceCorrectnessWorkload* self) {
 		// All management api related tests
 		Database cx = cx_->clone();
-		state Reference<ReadYourWritesTransaction> tx = Reference(new ReadYourWritesTransaction(cx));
+		state Reference<ReadYourWritesTransaction> tx = makeReference<ReadYourWritesTransaction>(cx);
 		// test ordered option keys
 		{
 			tx->setOption(FDBTransactionOptions::SPECIAL_KEY_SPACE_ENABLE_WRITES);

--- a/fdbserver/workloads/Throughput.actor.cpp
+++ b/fdbserver/workloads/Throughput.actor.cpp
@@ -290,7 +290,7 @@ struct ThroughputWorkload : TestWorkload {
 	ThroughputWorkload(WorkloadContext const& wcx)
 		: TestWorkload(wcx), activeActors(0), totalLatencyIntegral(0), totalTransactionsIntegral(0)
 	{
-		Reference<MeasureMulti> multi( new MeasureMulti );
+		auto multi = makeReference<MeasureMulti>();
 		measurer = multi;
 
 		targetLatency = getOption( options, LiteralStringRef("targetLatency"), 0.05 );

--- a/fdbserver/workloads/TimeKeeperCorrectness.actor.cpp
+++ b/fdbserver/workloads/TimeKeeperCorrectness.actor.cpp
@@ -68,7 +68,7 @@ struct TimeKeeperCorrectnessWorkload : TestWorkload {
 
 	ACTOR static Future<bool> _check(Database cx, TimeKeeperCorrectnessWorkload *self) {
 		state KeyBackedMap<int64_t, Version> dbTimeKeeper = KeyBackedMap<int64_t, Version>(timeKeeperPrefixRange.begin);
-		state Reference<ReadYourWritesTransaction> tr = Reference<ReadYourWritesTransaction>(new ReadYourWritesTransaction(cx));
+		state Reference<ReadYourWritesTransaction> tr = makeReference<ReadYourWritesTransaction>(cx);
 
 		TraceEvent(SevInfo, "TKCorrectness_CheckStart")
 				.detail("TimeKeeperMaxEntries", SERVER_KNOBS->TIME_KEEPER_MAX_ENTRIES)

--- a/fdbserver/workloads/VersionStamp.actor.cpp
+++ b/fdbserver/workloads/VersionStamp.actor.cpp
@@ -156,7 +156,7 @@ struct VersionStampWorkload : TestWorkload {
 
 	ACTOR Future<bool> _check(Database cx, VersionStampWorkload* self) {
 		if (self->validateExtraDB) {
-			Reference<ClusterConnectionFile> extraFile(new ClusterConnectionFile(*g_simulator.extraDB));
+			auto extraFile = makeReference<ClusterConnectionFile>(*g_simulator.extraDB);
 			cx = Database::createDatabase(extraFile, -1);
 		}
 		state ReadYourWritesTransaction tr(cx);
@@ -301,7 +301,7 @@ struct VersionStampWorkload : TestWorkload {
 		state Database extraDB;
 
 		if (g_simulator.extraDB != nullptr) {
-			Reference<ClusterConnectionFile> extraFile(new ClusterConnectionFile(*g_simulator.extraDB));
+			auto extraFile = makeReference<ClusterConnectionFile>(*g_simulator.extraDB);
 			extraDB = Database::createDatabase(extraFile, -1);
 		}
 

--- a/fdbserver/workloads/Watches.actor.cpp
+++ b/fdbserver/workloads/Watches.actor.cpp
@@ -155,7 +155,7 @@ struct WatchesWorkload : TestWorkload {
 						//TraceEvent("WatcherSetFinish").detail("Watch", printable(watchKey)).detail("Set", printable(setKey)).detail("Value", printable( watchValue ) ).detail("Ver", tr->getCommittedVersion());
 					} else {
 						//TraceEvent("WatcherWatch").detail("Watch", printable(watchKey));
-						state Future<Void> watchFuture = tr->watch(Reference<Watch>(new Watch(watchKey, watchValue)));
+						state Future<Void> watchFuture = tr->watch(makeReference<Watch>(watchKey, watchValue));
 						wait(tr->commit());
 						if (BUGGIFY) {
 							// Make watch future outlive transaction
@@ -229,7 +229,7 @@ struct WatchesWorkload : TestWorkload {
 						if( !firstAttempt || endValue != startValue ) {
 							TraceEvent(SevError, "WatcherError").detail("FirstAttempt", firstAttempt).detail("StartValue", printable( startValue )).detail("EndValue", printable( endValue )).detail("ExpectedValue", printable(expectedValue)).detail("EndVersion", tr2.getReadVersion().get()); 
 						}
-						state Future<Void> watchFuture = tr2.watch( Reference<Watch>( new Watch(endKey, startValue) ) );
+						state Future<Void> watchFuture = tr2.watch(makeReference<Watch>(endKey, startValue));
 						wait( tr2.commit() );
 						wait( watchFuture );
 						firstAttempt = false;

--- a/fdbserver/workloads/WriteDuringRead.actor.cpp
+++ b/fdbserver/workloads/WriteDuringRead.actor.cpp
@@ -76,7 +76,7 @@ struct WriteDuringReadWorkload : TestWorkload {
 
 		useExtraDB = g_simulator.extraDB != nullptr;
 		if(useExtraDB) {
-			Reference<ClusterConnectionFile> extraFile(new ClusterConnectionFile(*g_simulator.extraDB));
+			auto extraFile = makeReference<ClusterConnectionFile>(*g_simulator.extraDB);
 			extraDB = Database::createDatabase(extraFile, -1);
 			useSystemKeys = false;
 		}

--- a/flow/FastRef.h
+++ b/flow/FastRef.h
@@ -161,6 +161,11 @@ private:
 	P *ptr;
 };
 
+template <class P, class... Args>
+Reference<P> makeReference(Args&&... args) {
+	return Reference<P>(new P(std::forward<Args>(args)...));
+}
+
 template <class P>
 bool operator==( const Reference<P>& lhs, const Reference<P>& rhs ) {
 	return lhs.getPtr() == rhs.getPtr();

--- a/flow/Profiler.actor.cpp
+++ b/flow/Profiler.actor.cpp
@@ -185,7 +185,7 @@ struct Profiler {
 
 	ACTOR static Future<Void> profile(Profiler* self, int period, std::string outfn) {
 		// Open and truncate output file
-		state Reference<SyncFileForSim> outFile = Reference<SyncFileForSim>(new SyncFileForSim(outfn));
+		state Reference<SyncFileForSim> outFile = makeReference<SyncFileForSim>(outfn);
 		if(!outFile->isOpen()) {
 			TraceEvent(SevWarn, "FailedToOpenProfilingOutputFile").detail("Filename", outfn).GetLastError();
 			return Void();

--- a/flow/README.md
+++ b/flow/README.md
@@ -488,7 +488,7 @@ To create a reference counted instance of a class `T`, you instantiate a `Refere
 stack with a pointer to your `T` object:
 
 ```c++
-Reference<T> refCountedInstance(new T());
+auto refCountedInstance = makeReference<T>();
 ```
 The `Reference<T>` class automatically calls addref on your `T` instance every time it is copied
 (such as by argument passing or assignment), but not when the object is initially created

--- a/flow/TDMetric.actor.h
+++ b/flow/TDMetric.actor.h
@@ -266,7 +266,7 @@ struct MetricUtil {
 		// If we don't have a valid metric reference yet and the create flag was set then create one and possibly put it in the map
 		if(!m && create) {
 			// Metric not found in collection but create is set then create it in the map
-			m = Reference<T>(new T(mname, initial));
+			m = makeReference<T>(mname, initial);
 			if(useMap) {
 				collection->metricMap[mname] = m.template castTo<BaseMetric>();
 				collection->metricAdded.trigger();

--- a/flow/TLSConfig.actor.cpp
+++ b/flow/TLSConfig.actor.cpp
@@ -153,7 +153,7 @@ void ConfigureSSLContext( const LoadedTLSConfig& loaded, boost::asio::ssl::conte
 		context->set_verify_mode(boost::asio::ssl::context::verify_peer | boost::asio::ssl::verify_fail_if_no_peer_cert);
 
 		if (loaded.isTLSEnabled()) {
-			Reference<TLSPolicy> tlsPolicy = Reference<TLSPolicy>(new TLSPolicy(loaded.getEndpointType()));
+			auto tlsPolicy = makeReference<TLSPolicy>(loaded.getEndpointType());
 			tlsPolicy->set_verify_peers({ loaded.getVerifyPeers() });
 
 			context->set_verify_callback([policy=tlsPolicy, onPolicyFailure](bool preverified, boost::asio::ssl::verify_context& ctx) {

--- a/flow/ThreadHelper.actor.h
+++ b/flow/ThreadHelper.actor.h
@@ -539,7 +539,7 @@ struct CompletionCallback : public ThreadCallback, ReferenceCounted<CompletionCa
 //FIXME: does not support cancellation
 template<class T>
 Future<T> unsafeThreadFutureToFuture(ThreadFuture<T> threadFuture) {
-	Reference<CompletionCallback<T>> callback = Reference<CompletionCallback<T>>(new CompletionCallback<T>(threadFuture));
+	auto callback = makeReference<CompletionCallback<T>>(threadFuture);
 	callback->self = callback;
 	threadFuture.callOrSetAsCallback(callback.getPtr(), callback->userParam, 0);
 	return callback->promise.getFuture();

--- a/flow/genericactors.actor.h
+++ b/flow/genericactors.actor.h
@@ -663,13 +663,9 @@ class ReferencedObject : NonCopyable, public ReferenceCounted<ReferencedObject<V
 			value = std::move(v);
 		}
 
-		static Reference<ReferencedObject<V>> from(V const& v) {
-			return Reference<ReferencedObject<V>>(new ReferencedObject<V>(v));
-		}
+	    static Reference<ReferencedObject<V>> from(V const& v) { return makeReference<ReferencedObject<V>>(v); }
 
-		static Reference<ReferencedObject<V>> from(V&& v) {
-			return Reference<ReferencedObject<V>>(new ReferencedObject<V>(std::move(v)));
-		}
+	    static Reference<ReferencedObject<V>> from(V&& v) { return makeReference<ReferencedObject<V>>(std::move(v)); }
 
 	private:
 		V value;

--- a/flowbench/BenchRef.cpp
+++ b/flowbench/BenchRef.cpp
@@ -57,7 +57,7 @@ struct Factory<RefType::SharedPointer> {
 
 template <>
 struct Factory<RefType::FlowReference> {
-	static Reference<Empty> create() { return Reference<Empty>(new Empty{}); }
+	static Reference<Empty> create() { return makeReference<Empty>(); }
 	static void cleanup(const Reference<Empty>&) {}
 };
 


### PR DESCRIPTION
This PR adds a `makeReference` function, similar to `std::make_shared`, which has the advantage of making code less verbose, particularly for long type names. It also makes FDB code similar to standard C++ code by removing uses of the `new` keyword.

A few potential memory leaks are also fixed.