### PR TITLE
Fix transaction retry typo for other lang tutorials (in 6.2)

### DIFF
--- a/documentation/sphinx/source/class-scheduling-go.rst
+++ b/documentation/sphinx/source/class-scheduling-go.rst
@@ -229,7 +229,7 @@ Furthermore, this version can only be called with a ``Database``, making it impo
 Note that by default, the operation will be retried an infinite number of times and the transaction will never time out. It is therefore recommended that the client choose a default transaction retry limit or timeout value that is suitable for their application. This can be set either at the transaction level using the ``SetRetryLimit`` or ``SetTimeout`` transaction options or at the database level with the ``SetTransactionRetryLimit`` or ``SetTransactionTimeout`` database options. For example, one can set a one minute timeout on each transaction and a default retry limit of 100 by calling::
 
     db.Options().SetTransactionTimeout(60000)  // 60,000 ms = 1 minute
-    db.Options().SetRetryLimit(100)
+    db.Options().SetTransactionRetryLimit(100)
 
 Making some sample classes
 --------------------------

--- a/documentation/sphinx/source/class-scheduling-java.rst
+++ b/documentation/sphinx/source/class-scheduling-java.rst
@@ -157,7 +157,7 @@ If instead you pass a :class:`Transaction` for the :class:`TransactionContext` p
 Note that by default, the operation will be retried an infinite number of times and the transaction will never time out. It is therefore recommended that the client choose a default transaction retry limit or timeout value that is suitable for their application. This can be set either at the transaction level using the ``setRetryLimit`` or ``setTimeout`` transaction options or at the database level with the ``setTransactionRetryLimit`` or ``setTransactionTimeout`` database options. For example, one can set a one minute timeout on each transaction and a default retry limit of 100 by calling::
 
     db.options().setTransactionTimeout(60000);  // 60,000 ms = 1 minute
-    db.options().setRetryLimit(100);
+    db.options().setTransactionRetryLimit(100);
 
 Making some sample classes
 --------------------------
@@ -444,7 +444,7 @@ Here's the code for the scheduling tutorial:
       fdb = FDB.selectAPIVersion(620);
       db = fdb.open();
       db.options().setTransactionTimeout(60000);  // 60,000 ms = 1 minute
-      db.options().setRetryLimit(100);
+      db.options().setTransactionRetryLimit(100);
     }
 
     // Generate 1,620 classes like '9:00 chem for dummies'

--- a/documentation/sphinx/source/class-scheduling-ruby.rst
+++ b/documentation/sphinx/source/class-scheduling-ruby.rst
@@ -126,7 +126,7 @@ If instead you pass a :class:`Transaction` for the ``db_or_tr`` parameter, the t
 Note that by default, the operation will be retried an infinite number of times and the transaction will never time out. It is therefore recommended that the client choose a default transaction retry limit or timeout value that is suitable for their application. This can be set either at the transaction level using the ``set_retry_limit`` or ``set_timeout`` transaction options or at the database level with the ``set_transaction_retry_limit`` or ``set_transaction_timeout`` database options. For example, one can set a one minute timeout on each transaction and a default retry limit of 100 by calling::
 
     @db.options.set_transaction_timeout(60000)  # 60,000 ms = 1 minute
-    @db.options.set_retry_limit(100)
+    @db.options.set_transaction_retry_limit(100)
 
 Making some sample classes
 --------------------------


### PR DESCRIPTION
Cherrypick @schedutron's fix https://github.com/apple/foundationdb/commit/d1c823b3d710d509e303fb5c66de18e350fea07e to release-6.2