### PR TITLE
Make sure only uppercase characters follow underscore in test titles

### DIFF
--- a/tests/DDMetricsExclude.txt
+++ b/tests/DDMetricsExclude.txt
@@ -1,4 +1,4 @@
-testTitle=DDMetricsExclude_populate
+testTitle=DDMetricsExclude_Populate
     testName=Mako
     testDuration=30.0
     transactionsPerSecond=100000
@@ -14,7 +14,7 @@ testTitle=DDMetricsExclude_populate
     runBenchmark=true
     preserveData=true
 
-testTitle=DDMetricsExclude_test
+testTitle=DDMetricsExclude_Test
     testName=Mako
     testDuration=60.0
     transactionsPerSecond=100000

--- a/tests/fast/ConstrainedRandomSelector.toml
+++ b/tests/fast/ConstrainedRandomSelector.toml
@@ -1,5 +1,5 @@
 [[test]]
-testTitle = 'RYOW_test'
+testTitle = 'RYOW_Test'
 
     [[test.workload]]
     testName = 'RandomSelector'

--- a/tests/fast/RandomSelector.toml
+++ b/tests/fast/RandomSelector.toml
@@ -1,5 +1,5 @@
 [[test]]
-testTitle = 'RYOW_test'
+testTitle = 'RYOW_Test'
 
     [[test.workload]]
     testName = 'RandomSelector'

--- a/tests/fast/SelectorCorrectness.toml
+++ b/tests/fast/SelectorCorrectness.toml
@@ -1,5 +1,5 @@
 [[test]]
-testTitle = 'RYOW_test'
+testTitle = 'RYOW_Test'
 
     [[test.workload]]
     testName = 'SelectorCorrectness'

--- a/tests/randomSelector.txt
+++ b/tests/randomSelector.txt
@@ -1,2 +1,2 @@
-testTitle=RYOW_test
+testTitle=RYOW_Test
     testName=RandomSelector

--- a/tests/selectorCorrectness.txt
+++ b/tests/selectorCorrectness.txt
@@ -1,2 +1,2 @@
-testTitle=RYOW_test
+testTitle=RYOW_Test
     testName=SelectorCorrectness

--- a/tests/slow/DDBalanceAndRemove.toml
+++ b/tests/slow/DDBalanceAndRemove.toml
@@ -1,5 +1,5 @@
 [[test]]
-testTitle = 'DDBalance_test'
+testTitle = 'DDBalance_Test'
 
     [[test.workload]]
     testName = 'DDBalance'

--- a/tests/slow/DDBalanceAndRemoveStatus.toml
+++ b/tests/slow/DDBalanceAndRemoveStatus.toml
@@ -1,5 +1,5 @@
 [[test]]
-testTitle = 'DDBalance_test'
+testTitle = 'DDBalance_Test'
 
     [[test.workload]]
     testName = 'DDBalance'

--- a/tests/slow/SwizzledDdBalance.toml
+++ b/tests/slow/SwizzledDdBalance.toml
@@ -1,5 +1,5 @@
 [[test]]
-testTitle = 'DDBalance_test'
+testTitle = 'DDBalance_Test'
 
     [[test.workload]]
     testName = 'DDBalance'

--- a/tests/slow/ddbalance.toml
+++ b/tests/slow/ddbalance.toml
@@ -1,5 +1,5 @@
 [[test]]
-testTitle = 'DDBalance_test'
+testTitle = 'DDBalance_Test'
 
     [[test.workload]]
     testName = 'DDBalance'


### PR DESCRIPTION
These test titles are used in trace lines, so having an underscore followed by a lower-case character leads to invalid trace lines.