### PR TITLE
Don't run consistency check until after the backup is discontinued

### DIFF
--- a/tests/restarting/from_7.0.0/SnapIncrementalRestore-1.toml
+++ b/tests/restarting/from_7.0.0/SnapIncrementalRestore-1.toml
@@ -16,6 +16,7 @@ runConsistencyCheck = false
 testTitle = 'PreSnapWorkloads'
 simBackupAgents = 'BackupToFile'
 clearAfterTest = false
+runConsistencyCheck = false
 
     [[test.workload]]
     testName = 'SimpleAtomicAdd'
@@ -24,6 +25,7 @@ clearAfterTest = false
 testTitle = 'TakeSnap'
 simBackupAgents = 'BackupToFile'
 clearAfterTest = false
+runConsistencyCheck = false
 
     [[test.workload]]
     testName = 'SnapTest'


### PR DESCRIPTION
Updating this workload to be in line with the other backup workloads. Some of the other workloads explicitly remove the backup agents from the simulator to allow the database to quiesce, this change instead postpones the quiescent check until the backup agent is stopped normally