### PR TITLE
Remove -Wno-unused-value for clang

### DIFF
--- a/cmake/ConfigureCompiler.cmake
+++ b/cmake/ConfigureCompiler.cmake
@@ -233,7 +233,6 @@ else()
       -Wno-unused-function
       -Wno-unused-local-typedef
       -Wno-unused-parameter
-      -Wno-unused-value
       )
     if (USE_CCACHE)
       add_compile_options(


### PR DESCRIPTION
This warning is necessary for the compiler to emit warnings when ignoring the return value of a non-cancellable actor. I think it keeps getting added back when we merge release-6.2 upstream so let's remove it in release-6.2