### PR TITLE
Sort the failed sets before modifying them in attempts to make changes consistent

### DIFF
--- a/fdbclient/ManagementAPI.actor.cpp
+++ b/fdbclient/ManagementAPI.actor.cpp
@@ -1607,6 +1607,7 @@ ACTOR Future<std::set<NetworkAddress>> checkForExcludingServers(Database cx, vec
 
 			wait( delayJittered( 1.0 ) );  // SOMEDAY: watches!
 		} catch (Error& e) {
+			TraceEvent("CheckForExcludingServersError").error(e);
 			wait( tr.onError(e) );
 		}
 	}


### PR DESCRIPTION
This PR resolves a small issue found from https://github.com/apple/foundationdb/issues/4039, but does not resolve it completely. The other issues are being investigated in separate PRs.

Changes in this PR:

- Make the `toKill` and `toKillMarkFailed` overlap more consistently in terms of machines affected, to avoid going over the limit of how many machines we want to exclude

## General guideline:

- If this PR is ready to be merged (and all checkboxes below are either ticked or not applicable), make this a regular PR
- If this PR still needs work, please make this a draft PR
  - If you wish to get feedback/code-review, please add the label RFC to this PR

Please verify that all things listed below were considered and check them. If an item doesn't apply to this type of PR (for example a documentation change doesn't need to be performance tested), you should make a ~~strikethrough~~ (markdown syntax: `~~strikethrough~~`). More infos on the guidlines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

### Style
[x] All variable and function names make sense.
[x] The code is properly formatted (consider running `git clang-format`).

### Performance
~~[] All CP-hot paths are well optimized.~~
~~[] The proper containers are used (for example `std::vector` vs `VectorRef`).~~
~~[] There are no new known `SlowTask` traces.~~

### Testing
[x] The code was sufficiently tested in simulation.
~~[] If there are new parameters or knobs, different values are tested in simulation.~~
~~[] `ASSERT`, `ASSERT_WE_THINK`, and `TEST` macros are added in appropriate places.~~
~~[] Unit tests were added for new algorithms and data structure that make sense to unit-test~~
~~[] If this is a bugfix: there is a test that can easily reproduce the bug.~~
