### PR TITLE
Add bytes_per_second unit in histograms

### DIFF
--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -311,7 +311,7 @@ public:
 		    bytes(Histogram::getHistogram(STORAGESERVER_HISTOGRAM_GROUP, FETCH_KEYS_BYTES_HISTOGRAM,
 		                                  Histogram::Unit::bytes)),
 		    bandwidth(Histogram::getHistogram(STORAGESERVER_HISTOGRAM_GROUP, FETCH_KEYS_BYTES_PER_SECOND_HISTOGRAM,
-		                                      Histogram::Unit::bytes)) {}
+		                                      Histogram::Unit::bytes_per_second)) {}
 	} fetchKeysHistograms;
 
 	class CurrentRunningFetchKeys {

--- a/flow/Histogram.h
+++ b/flow/Histogram.h
@@ -26,6 +26,7 @@
 
 #include <string>
 #include <map>
+#include <unordered_map>
 
 #ifdef _WIN32
 #include <intrin.h>
@@ -57,11 +58,16 @@ HistogramRegistry& GetHistogramRegistry();
  */
 class Histogram sealed : public ReferenceCounted<Histogram> {
 public:
-	enum class Unit { microseconds, bytes };
+	enum class Unit { microseconds, bytes, bytes_per_second };
 
 private:
+	static const std::unordered_map<Unit, std::string> UnitToStringMapper;
+
 	Histogram(std::string group, std::string op, Unit unit, HistogramRegistry& registry)
 	  : group(group), op(op), unit(unit), registry(registry), ReferenceCounted<Histogram>() {
+
+		ASSERT(UnitToStringMapper.find(unit) != UnitToStringMapper.end());
+
 		clear();
 	}
 


### PR DESCRIPTION
- Add bytes_per_second Unit for histogram
- Includes unit when logging histogram information
- Fixs StorageServer histograms so it uses the correct unit.

### Style
[] All variable and function names make sense.
[*] The code is properly formatted (consider running `git clang-format`).

### Testing
[] The code was sufficiently tested in simulation.
[] If there are new parameters or knobs, different values are tested in simulation.
[] `ASSERT`, `ASSERT_WE_THINK`, and `TEST` macros are added in appropriate places.
[] Unit tests were added for new algorithms and data structure that make sense to unit-test
[] If this is a bugfix: there is a test that can easily reproduce the bug.
