### PR TITLE
Make enums automatically binary serializable

### DIFF
--- a/fdbbackup/backup.actor.cpp
+++ b/fdbbackup/backup.actor.cpp
@@ -72,45 +72,32 @@ using std::endl;
 #include "flow/SimpleOpt.h"
 #include "flow/actorcompiler.h"  // This must be the last #include.
 
-
 // Type of program being executed
-enum enumProgramExe {
-	EXE_AGENT,
-	EXE_BACKUP,
-	EXE_RESTORE,
-	EXE_FASTRESTORE_TOOL,
-	EXE_DR_AGENT,
-	EXE_DB_BACKUP,
-	EXE_UNDEFINED
+enum class ProgramExe { AGENT, BACKUP, RESTORE, FASTRESTORE_TOOL, DR_AGENT, DB_BACKUP, UNDEFINED };
+
+enum class BackupType {
+	UNDEFINED = 0,
+	START,
+	MODIFY,
+	STATUS,
+	ABORT,
+	WAIT,
+	DISCONTINUE,
+	PAUSE,
+	RESUME,
+	EXPIRE,
+	DELETE,
+	DESCRIBE,
+	LIST,
+	QUERY,
+	DUMP,
+	CLEANUP
 };
 
-enum enumBackupType {
-	BACKUP_UNDEFINED = 0,
-	BACKUP_START,
-	BACKUP_MODIFY,
-	BACKUP_STATUS,
-	BACKUP_ABORT,
-	BACKUP_WAIT,
-	BACKUP_DISCONTINUE,
-	BACKUP_PAUSE,
-	BACKUP_RESUME,
-	BACKUP_EXPIRE,
-	BACKUP_DELETE,
-	BACKUP_DESCRIBE,
-	BACKUP_LIST,
-	BACKUP_QUERY,
-	BACKUP_DUMP,
-	BACKUP_CLEANUP
-};
-
-enum enumDBType {
-	DB_UNDEFINED=0, DB_START, DB_STATUS, DB_SWITCH, DB_ABORT, DB_PAUSE, DB_RESUME
-};
+enum class DBType { UNDEFINED = 0, START, STATUS, SWITCH, ABORT, PAUSE, RESUME };
 
 // New fast restore reuses the type from legacy slow restore
-enum enumRestoreType {
-	RESTORE_UNKNOWN, RESTORE_START, RESTORE_STATUS, RESTORE_ABORT, RESTORE_WAIT
-};
+enum class RestoreType { UNKNOWN, START, STATUS, ABORT, WAIT };
 
 //
 enum {
@@ -1258,30 +1245,29 @@ static void printDBBackupUsage(bool devhelp) {
 	return;
 }
 
-static void printUsage(enumProgramExe programExe, bool devhelp)
-{
+static void printUsage(ProgramExe programExe, bool devhelp) {
 
 	switch (programExe)
 	{
-	case EXE_AGENT:
+	case ProgramExe::AGENT:
 		printAgentUsage(devhelp);
 		break;
-	case EXE_BACKUP:
+	case ProgramExe::BACKUP:
 		printBackupUsage(devhelp);
 		break;
-	case EXE_RESTORE:
+	case ProgramExe::RESTORE:
 		printRestoreUsage(devhelp);
 		break;
-	case EXE_FASTRESTORE_TOOL:
+	case ProgramExe::FASTRESTORE_TOOL:
 		printFastRestoreUsage(devhelp);
 		break;
-	case EXE_DR_AGENT:
+	case ProgramExe::DR_AGENT:
 		printDBAgentUsage(devhelp);
 		break;
-	case EXE_DB_BACKUP:
+	case ProgramExe::DB_BACKUP:
 		printDBBackupUsage(devhelp);
 		break;
-	case EXE_UNDEFINED:
+	case ProgramExe::UNDEFINED:
 	default:
 		break;
 	}
@@ -1292,9 +1278,8 @@ static void printUsage(enumProgramExe programExe, bool devhelp)
 extern bool g_crashOnError;
 
 // Return the type of program executable based on the name of executable file
-enumProgramExe	getProgramType(std::string programExe)
-{
-	enumProgramExe	enProgramExe = EXE_UNDEFINED;
+ProgramExe getProgramType(std::string programExe) {
+	ProgramExe enProgramExe = ProgramExe::UNDEFINED;
 
 	// lowercase the string
 	std::transform(programExe.begin(), programExe.end(), programExe.begin(), ::tolower);
@@ -1321,71 +1306,70 @@ enumProgramExe	getProgramType(std::string programExe)
 	if ((programExe.length() >= exeAgent.size())																		&&
 		(programExe.compare(programExe.length()-exeAgent.size(), exeAgent.size(), (const char*) exeAgent.begin()) == 0)	)
 	{
-		enProgramExe = EXE_AGENT;
+		enProgramExe = ProgramExe::AGENT;
 	}
 
 	// Check if backup
 	else if ((programExe.length() >= exeBackup.size())																	&&
 		(programExe.compare(programExe.length() - exeBackup.size(), exeBackup.size(), (const char*)exeBackup.begin()) == 0))
 	{
-		enProgramExe = EXE_BACKUP;
+		enProgramExe = ProgramExe::BACKUP;
 	}
 
 	// Check if restore
 	else if ((programExe.length() >= exeRestore.size())																		&&
 		(programExe.compare(programExe.length() - exeRestore.size(), exeRestore.size(), (const char*)exeRestore.begin()) == 0))
 	{
-		enProgramExe = EXE_RESTORE;
+		enProgramExe = ProgramExe::RESTORE;
 	}
 
 	// Check if restore
 	else if ((programExe.length() >= exeFastRestoreTool.size()) &&
 	         (programExe.compare(programExe.length() - exeFastRestoreTool.size(), exeFastRestoreTool.size(),
 	                             (const char*)exeFastRestoreTool.begin()) == 0)) {
-		enProgramExe = EXE_FASTRESTORE_TOOL;
+		enProgramExe = ProgramExe::FASTRESTORE_TOOL;
 	}
 
 	// Check if db agent
 	else if ((programExe.length() >= exeDatabaseAgent.size()) &&
 	         (programExe.compare(programExe.length() - exeDatabaseAgent.size(), exeDatabaseAgent.size(),
 	                             (const char*)exeDatabaseAgent.begin()) == 0)) {
-		enProgramExe = EXE_DR_AGENT;
+		enProgramExe = ProgramExe::DR_AGENT;
 	}
 
 	// Check if db backup
 	else if ((programExe.length() >= exeDatabaseBackup.size()) &&
 	         (programExe.compare(programExe.length() - exeDatabaseBackup.size(), exeDatabaseBackup.size(),
 	                             (const char*)exeDatabaseBackup.begin()) == 0)) {
-		enProgramExe = EXE_DB_BACKUP;
+		enProgramExe = ProgramExe::DB_BACKUP;
 	}
 
 	return enProgramExe;
 }
 
-enumBackupType	getBackupType(std::string backupType)
-{
-	enumBackupType	enBackupType = BACKUP_UNDEFINED;
+BackupType getBackupType(std::string backupType) {
+	BackupType enBackupType = BackupType::UNDEFINED;
 
 	// lowercase the string
 	std::transform(backupType.begin(), backupType.end(), backupType.begin(), ::tolower);
 
-	static std::map<std::string, enumBackupType> values;
+	static std::map<std::string, BackupType> values;
 	if(values.empty()) {
-		values["start"] = BACKUP_START;
-		values["status"] = BACKUP_STATUS;
-		values["abort"] = BACKUP_ABORT;
-		values["cleanup"] = BACKUP_CLEANUP;
-		values["wait"] = BACKUP_WAIT;
-		values["discontinue"] = BACKUP_DISCONTINUE;
-		values["pause"] = BACKUP_PAUSE;
-		values["resume"] = BACKUP_RESUME;
-		values["expire"] = BACKUP_EXPIRE;
-		values["delete"] = BACKUP_DELETE;
-		values["describe"] = BACKUP_DESCRIBE;
-		values["list"] = BACKUP_LIST;
-		values["query"] = BACKUP_QUERY;
-		values["dump"] = BACKUP_DUMP;
-		values["modify"] = BACKUP_MODIFY;
+		values["start"] = BackupType::START;
+		values["status"] = BackupType::STATUS;
+		values["abort"] = BackupType::ABORT;
+		values["cleanup"] = BackupType::CLEANUP;
+		values["wait"] = BackupType::WAIT;
+		values["discontinue"] = BackupType::DISCONTINUE;
+		values["pause"] = BackupType::PAUSE;
+		values["resume"] = BackupType::RESUME;
+		values["expire"] = BackupType::EXPIRE;
+		values["delete"] = BackupType::DELETE;
+		values["describe"] = BackupType::DESCRIBE;
+		values["list"] = BackupType::LIST;
+		values["query"] = BackupType::QUERY;
+		values["dump"] = BackupType::DUMP;
+		values["modify"] = BackupType::MODIFY;
 	}
 
 	auto i = values.find(backupType);
@@ -1395,29 +1379,28 @@ enumBackupType	getBackupType(std::string backupType)
 	return enBackupType;
 }
 
-enumRestoreType getRestoreType(std::string name) {
-	if(name == "start") return RESTORE_START;
-	if(name == "abort") return RESTORE_ABORT;
-	if(name == "status") return RESTORE_STATUS;
-	if(name == "wait") return RESTORE_WAIT;
-	return RESTORE_UNKNOWN;
+RestoreType getRestoreType(std::string name) {
+	if (name == "start") return RestoreType::START;
+	if (name == "abort") return RestoreType::ABORT;
+	if (name == "status") return RestoreType::STATUS;
+	if (name == "wait") return RestoreType::WAIT;
+	return RestoreType::UNKNOWN;
 }
 
-enumDBType getDBType(std::string dbType)
-{
-	enumDBType enBackupType = DB_UNDEFINED;
+DBType getDBType(std::string dbType) {
+	DBType enBackupType = DBType::UNDEFINED;
 
 	// lowercase the string
 	std::transform(dbType.begin(), dbType.end(), dbType.begin(), ::tolower);
 
-	static std::map<std::string, enumDBType> values;
+	static std::map<std::string, DBType> values;
 	if(values.empty()) {
-		values["start"] = DB_START;
-		values["status"] = DB_STATUS;
-		values["switch"] = DB_SWITCH;
-		values["abort"] = DB_ABORT;
-		values["pause"] = DB_PAUSE;
-		values["resume"] = DB_RESUME;
+		values["start"] = DBType::START;
+		values["status"] = DBType::STATUS;
+		values["switch"] = DBType::SWITCH;
+		values["abort"] = DBType::ABORT;
+		values["pause"] = DBType::PAUSE;
+		values["resume"] = DBType::RESUME;
 	}
 
 	auto i = values.find(dbType);
@@ -1427,7 +1410,8 @@ enumDBType getDBType(std::string dbType)
 	return enBackupType;
 }
 
-ACTOR Future<std::string> getLayerStatus(Reference<ReadYourWritesTransaction> tr, std::string name, std::string id, enumProgramExe exe, Database dest, bool snapshot = false) {
+ACTOR Future<std::string> getLayerStatus(Reference<ReadYourWritesTransaction> tr, std::string name, std::string id,
+                                         ProgramExe exe, Database dest, bool snapshot = false) {
 	// This process will write a document that looks like this:
 	// { backup : { $expires : {<subdoc>}, version: <version from approximately 30 seconds from now> }
 	// so that the value under 'backup' will eventually expire to null and thus be ignored by
@@ -1459,7 +1443,7 @@ ACTOR Future<std::string> getLayerStatus(Reference<ReadYourWritesTransaction> tr
 	o.create("process_cpu_seconds")     = getProcessorTimeProcess();
 	o.create("configured_workers") = CLIENT_KNOBS->BACKUP_TASKS_PER_AGENT;
 
-	if(exe == EXE_AGENT) {
+	if (exe == ProgramExe::AGENT) {
 		static S3BlobStoreEndpoint::Stats last_stats;
 		static double last_ts = 0;
 		S3BlobStoreEndpoint::Stats current_stats = S3BlobStoreEndpoint::s_stats;
@@ -1531,8 +1515,7 @@ ACTOR Future<std::string> getLayerStatus(Reference<ReadYourWritesTransaction> tr
 
 			j++;
 		}
-	}
-	else if(exe == EXE_DR_AGENT) {
+	} else if (exe == ProgramExe::DR_AGENT) {
 		state DatabaseBackupAgent dba;
 		state Reference<ReadYourWritesTransaction> tr2(new ReadYourWritesTransaction(dest));
 		tr2->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
@@ -1676,8 +1659,9 @@ ACTOR Future<Void> updateAgentPollRate(Database src, std::string rootKey, std::s
 	}
 }
 
-ACTOR Future<Void> statusUpdateActor(Database statusUpdateDest, std::string name, enumProgramExe exe, double *pollDelay, Database taskDest = Database(),
-										std::string id = nondeterministicRandom()->randomUniqueID().toString()) {
+ACTOR Future<Void> statusUpdateActor(Database statusUpdateDest, std::string name, ProgramExe exe, double* pollDelay,
+                                     Database taskDest = Database(),
+                                     std::string id = nondeterministicRandom()->randomUniqueID().toString()) {
 	state std::string metaKey = layerStatusMetaPrefixRange.begin.toString() + "json/" + name;
 	state std::string rootKey = backupStatusPrefixRange.begin.toString() + name + "/json";
 	state std::string instanceKey = rootKey + "/" + "agent-" + id;
@@ -1734,8 +1718,9 @@ ACTOR Future<Void> statusUpdateActor(Database statusUpdateDest, std::string name
 ACTOR Future<Void> runDBAgent(Database src, Database dest) {
 	state double pollDelay = 1.0 / CLIENT_KNOBS->BACKUP_AGGREGATE_POLL_RATE;
 	std::string id = nondeterministicRandom()->randomUniqueID().toString();
-	state Future<Void> status = statusUpdateActor(src, "dr_backup", EXE_DR_AGENT, &pollDelay, dest, id);
-	state Future<Void> status_other = statusUpdateActor(dest, "dr_backup_dest", EXE_DR_AGENT, &pollDelay, dest, id);
+	state Future<Void> status = statusUpdateActor(src, "dr_backup", ProgramExe::DR_AGENT, &pollDelay, dest, id);
+	state Future<Void> status_other =
+	    statusUpdateActor(dest, "dr_backup_dest", ProgramExe::DR_AGENT, &pollDelay, dest, id);
 
 	state DatabaseBackupAgent backupAgent(src);
 
@@ -1760,7 +1745,7 @@ ACTOR Future<Void> runDBAgent(Database src, Database dest) {
 
 ACTOR Future<Void> runAgent(Database db) {
 	state double pollDelay = 1.0 / CLIENT_KNOBS->BACKUP_AGGREGATE_POLL_RATE;
-	state Future<Void> status = statusUpdateActor(db, "backup", EXE_AGENT, &pollDelay);
+	state Future<Void> status = statusUpdateActor(db, "backup", ProgramExe::AGENT, &pollDelay);
 
 	state FileBackupAgent backupAgent;
 
@@ -2953,22 +2938,22 @@ int main(int argc, char* argv[]) {
 		setvbuf(stdout, NULL, _IONBF, 0);
 		setvbuf(stderr, NULL, _IONBF, 0);
 
-		enumProgramExe programExe = getProgramType(argv[0]);
-		enumBackupType backupType = BACKUP_UNDEFINED;
-		enumRestoreType restoreType = RESTORE_UNKNOWN;
-		enumDBType dbType = DB_UNDEFINED;
+		ProgramExe programExe = getProgramType(argv[0]);
+		BackupType backupType = BackupType::UNDEFINED;
+		RestoreType restoreType = RestoreType::UNKNOWN;
+		DBType dbType = DBType::UNDEFINED;
 
 		CSimpleOpt* args = NULL;
 
 		switch (programExe)
 		{
-		case EXE_AGENT:
+		case ProgramExe::AGENT:
 			args = new CSimpleOpt(argc, argv, g_rgAgentOptions, SO_O_EXACT);
 			break;
-		case EXE_DR_AGENT:
+		case ProgramExe::DR_AGENT:
 			args = new CSimpleOpt(argc, argv, g_rgDBAgentOptions, SO_O_EXACT);
 			break;
-		case EXE_BACKUP:
+		case ProgramExe::BACKUP:
 			// Display backup help, if no arguments
 			if (argc < 2) {
 				printBackupUsage(false);
@@ -2981,52 +2966,52 @@ int main(int argc, char* argv[]) {
 				// Create the appropriate simple opt
 				switch (backupType)
 				{
-				case BACKUP_START:
+				case BackupType::START:
 					args = new CSimpleOpt(argc-1, &argv[1], g_rgBackupStartOptions, SO_O_EXACT);
 					break;
-				case BACKUP_STATUS:
+				case BackupType::STATUS:
 					args = new CSimpleOpt(argc - 1, &argv[1], g_rgBackupStatusOptions, SO_O_EXACT);
 					break;
-				case BACKUP_ABORT:
+				case BackupType::ABORT:
 					args = new CSimpleOpt(argc - 1, &argv[1], g_rgBackupAbortOptions, SO_O_EXACT);
 					break;
-				case BACKUP_CLEANUP:
+				case BackupType::CLEANUP:
 					args = new CSimpleOpt(argc - 1, &argv[1], g_rgBackupCleanupOptions, SO_O_EXACT);
 					break;
-				case BACKUP_WAIT:
+				case BackupType::WAIT:
 					args = new CSimpleOpt(argc - 1, &argv[1], g_rgBackupWaitOptions, SO_O_EXACT);
 					break;
-				case BACKUP_DISCONTINUE:
+				case BackupType::DISCONTINUE:
 					args = new CSimpleOpt(argc - 1, &argv[1], g_rgBackupDiscontinueOptions, SO_O_EXACT);
 					break;
-				case BACKUP_PAUSE:
+				case BackupType::PAUSE:
 					args = new CSimpleOpt(argc - 1, &argv[1], g_rgBackupPauseOptions, SO_O_EXACT);
 					break;
-				case BACKUP_RESUME:
+				case BackupType::RESUME:
 					args = new CSimpleOpt(argc - 1, &argv[1], g_rgBackupPauseOptions, SO_O_EXACT);
 					break;
-				case BACKUP_EXPIRE:
+				case BackupType::EXPIRE:
 					args = new CSimpleOpt(argc - 1, &argv[1], g_rgBackupExpireOptions, SO_O_EXACT);
 					break;
-				case BACKUP_DELETE:
+				case BackupType::DELETE:
 					args = new CSimpleOpt(argc - 1, &argv[1], g_rgBackupDeleteOptions, SO_O_EXACT);
 					break;
-				case BACKUP_DESCRIBE:
+				case BackupType::DESCRIBE:
 					args = new CSimpleOpt(argc - 1, &argv[1], g_rgBackupDescribeOptions, SO_O_EXACT);
 					break;
-				case BACKUP_DUMP:
+				case BackupType::DUMP:
 					args = new CSimpleOpt(argc - 1, &argv[1], g_rgBackupDumpOptions, SO_O_EXACT);
 					break;
-				case BACKUP_LIST:
+				case BackupType::LIST:
 					args = new CSimpleOpt(argc - 1, &argv[1], g_rgBackupListOptions, SO_O_EXACT);
 					break;
-				case BACKUP_QUERY:
+				case BackupType::QUERY:
 					args = new CSimpleOpt(argc - 1, &argv[1], g_rgBackupQueryOptions, SO_O_EXACT);
 					break;
-				case BACKUP_MODIFY:
+				case BackupType::MODIFY:
 					args = new CSimpleOpt(argc - 1, &argv[1], g_rgBackupModifyOptions, SO_O_EXACT);
 					break;
-				case BACKUP_UNDEFINED:
+				case BackupType::UNDEFINED:
 				default:
 					// Display help, if requested
 					if ((strcmp(argv[1], "-h") == 0)		||
@@ -3044,7 +3029,7 @@ int main(int argc, char* argv[]) {
 				}
 			}
 			break;
-		case EXE_DB_BACKUP:
+		case ProgramExe::DB_BACKUP:
 			// Display backup help, if no arguments
 			if (argc < 2) {
 				printDBBackupUsage(false);
@@ -3057,25 +3042,25 @@ int main(int argc, char* argv[]) {
 				// Create the appropriate simple opt
 				switch (dbType)
 				{
-				case DB_START:
+				case DBType::START:
 					args = new CSimpleOpt(argc-1, &argv[1], g_rgDBStartOptions, SO_O_EXACT);
 					break;
-				case DB_STATUS:
+				case DBType::STATUS:
 					args = new CSimpleOpt(argc - 1, &argv[1], g_rgDBStatusOptions, SO_O_EXACT);
 					break;
-				case DB_SWITCH:
+				case DBType::SWITCH:
 					args = new CSimpleOpt(argc - 1, &argv[1], g_rgDBSwitchOptions, SO_O_EXACT);
 					break;
-				case DB_ABORT:
+				case DBType::ABORT:
 					args = new CSimpleOpt(argc - 1, &argv[1], g_rgDBAbortOptions, SO_O_EXACT);
 					break;
-				case DB_PAUSE:
+				case DBType::PAUSE:
 					args = new CSimpleOpt(argc - 1, &argv[1], g_rgDBPauseOptions, SO_O_EXACT);
 					break;
-				case DB_RESUME:
+				case DBType::RESUME:
 					args = new CSimpleOpt(argc - 1, &argv[1], g_rgDBPauseOptions, SO_O_EXACT);
 					break;
-				case DB_UNDEFINED:
+				case DBType::UNDEFINED:
 				default:
 					// Display help, if requested
 					if ((strcmp(argv[1], "-h") == 0)		||
@@ -3093,14 +3078,14 @@ int main(int argc, char* argv[]) {
 				}
 			}
 			break;
-		case EXE_RESTORE:
+		case ProgramExe::RESTORE:
 			if (argc < 2) {
 				printRestoreUsage(false);
 				return FDB_EXIT_ERROR;
 			}
 			// Get the restore operation type
 			restoreType = getRestoreType(argv[1]);
-			if(restoreType == RESTORE_UNKNOWN) {
+			if (restoreType == RestoreType::UNKNOWN) {
 				// Display help, if requested
 				if ((strcmp(argv[1], "-h") == 0)		||
 					(strcmp(argv[1], "--help") == 0)	)
@@ -3116,14 +3101,14 @@ int main(int argc, char* argv[]) {
 			}
 			args = new CSimpleOpt(argc - 1, argv + 1, g_rgRestoreOptions, SO_O_EXACT);
 			break;
-		case EXE_FASTRESTORE_TOOL:
+		case ProgramExe::FASTRESTORE_TOOL:
 			if (argc < 2) {
 				printFastRestoreUsage(false);
 				return FDB_EXIT_ERROR;
 			}
 			// Get the restore operation type
 			restoreType = getRestoreType(argv[1]);
-			if (restoreType == RESTORE_UNKNOWN) {
+			if (restoreType == RestoreType::UNKNOWN) {
 				// Display help, if requested
 				if ((strcmp(argv[1], "-h") == 0) || (strcmp(argv[1], "--help") == 0)) {
 					printFastRestoreUsage(false);
@@ -3136,7 +3121,7 @@ int main(int argc, char* argv[]) {
 			}
 			args = new CSimpleOpt(argc - 1, argv + 1, g_rgRestoreOptions, SO_O_EXACT);
 			break;
-		case EXE_UNDEFINED:
+		case ProgramExe::UNDEFINED:
 		default:
 			fprintf(stderr, "FoundationDB " FDB_VT_PACKAGE_NAME " (v" FDB_VT_VERSION ")\n");
 			fprintf(stderr, "ERROR: Unable to determine program type based on executable `%s'\n", argv[0]);
@@ -3555,14 +3540,14 @@ int main(int argc, char* argv[]) {
 		{
 			switch (programExe)
 			{
-			case EXE_AGENT:
+			case ProgramExe::AGENT:
 				fprintf(stderr, "ERROR: Backup Agent does not support argument value `%s'\n", args->File(argLoop));
 				printHelpTeaser(argv[0]);
 				return FDB_EXIT_ERROR;
 				break;
 
 				// Add the backup key range
-			case EXE_BACKUP:
+			case ProgramExe::BACKUP:
 				// Error, if the keys option was not specified
 				if (backupKeys.size() == 0) {
 					fprintf(stderr, "ERROR: Unknown backup option value `%s'\n", args->File(argLoop));
@@ -3581,26 +3566,26 @@ int main(int argc, char* argv[]) {
 				}
 				break;
 
-			case EXE_RESTORE:
+			case ProgramExe::RESTORE:
 				fprintf(stderr, "ERROR: FDB Restore does not support argument value `%s'\n", args->File(argLoop));
 				printHelpTeaser(argv[0]);
 				return FDB_EXIT_ERROR;
 				break;
 
-			case EXE_FASTRESTORE_TOOL:
+			case ProgramExe::FASTRESTORE_TOOL:
 				fprintf(stderr, "ERROR: FDB Fast Restore Tool does not support argument value `%s'\n",
 				        args->File(argLoop));
 				printHelpTeaser(argv[0]);
 				return FDB_EXIT_ERROR;
 				break;
 
-			case EXE_DR_AGENT:
+			case ProgramExe::DR_AGENT:
 				fprintf(stderr, "ERROR: DR Agent does not support argument value `%s'\n", args->File(argLoop));
 				printHelpTeaser(argv[0]);
 				return FDB_EXIT_ERROR;
 				break;
 
-			case EXE_DB_BACKUP:
+			case ProgramExe::DB_BACKUP:
 				// Error, if the keys option was not specified
 				if (backupKeys.size() == 0) {
 					fprintf(stderr, "ERROR: Unknown DR option value `%s'\n", args->File(argLoop));
@@ -3619,7 +3604,7 @@ int main(int argc, char* argv[]) {
 				}
 				break;
 
-			case EXE_UNDEFINED:
+			case ProgramExe::UNDEFINED:
 			default:
 				return FDB_EXIT_ERROR;
 			}
@@ -3832,16 +3817,15 @@ int main(int argc, char* argv[]) {
 
 		switch (programExe)
 		{
-		case EXE_AGENT:
+		case ProgramExe::AGENT:
 			if(!initCluster())
 				return FDB_EXIT_ERROR;
 			f = stopAfter(runAgent(db));
 			break;
-		case EXE_BACKUP:
+		case ProgramExe::BACKUP:
 			switch (backupType)
 			{
-			case BACKUP_START:
-			{
+			case BackupType::START: {
 				if(!initCluster())
 					return FDB_EXIT_ERROR;
 				// Test out the backup url to make sure it parses.  Doesn't test to make sure it's actually writeable.
@@ -3852,8 +3836,7 @@ int main(int argc, char* argv[]) {
 				break;
 			}
 
-			case BACKUP_MODIFY:
-			{
+			case BackupType::MODIFY: {
 				if(!initCluster())
 					return FDB_EXIT_ERROR;
 
@@ -3861,49 +3844,49 @@ int main(int argc, char* argv[]) {
 				break;
 			}
 
-			case BACKUP_STATUS:
+			case BackupType::STATUS:
 				if(!initCluster())
 					return FDB_EXIT_ERROR;
 				f = stopAfter( statusBackup(db, tagName, true, jsonOutput) );
 				break;
 
-			case BACKUP_ABORT:
+			case BackupType::ABORT:
 				if(!initCluster())
 					return FDB_EXIT_ERROR;
 				f = stopAfter( abortBackup(db, tagName) );
 				break;
 
-			case BACKUP_CLEANUP:
+			case BackupType::CLEANUP:
 				if(!initCluster())
 					return FDB_EXIT_ERROR;
 				f = stopAfter( cleanupMutations(db, deleteData) );
 				break;
 
-			case BACKUP_WAIT:
+			case BackupType::WAIT:
 				if(!initCluster())
 					return FDB_EXIT_ERROR;
 				f = stopAfter( waitBackup(db, tagName, stopWhenDone) );
 				break;
 
-			case BACKUP_DISCONTINUE:
+			case BackupType::DISCONTINUE:
 				if(!initCluster())
 					return FDB_EXIT_ERROR;
 				f = stopAfter( discontinueBackup(db, tagName, waitForDone) );
 				break;
 
-			case BACKUP_PAUSE:
+			case BackupType::PAUSE:
 				if(!initCluster())
 					return FDB_EXIT_ERROR;
 				f = stopAfter( changeBackupResumed(db, true) );
 				break;
 
-			case BACKUP_RESUME:
+			case BackupType::RESUME:
 				if(!initCluster())
 					return FDB_EXIT_ERROR;
 				f = stopAfter( changeBackupResumed(db, false) );
 				break;
 
-			case BACKUP_EXPIRE:
+			case BackupType::EXPIRE:
 				initTraceFile();
 				// Must have a usable cluster if either expire DateTime options were used
 				if(!expireDatetime.empty() || !expireRestorableAfterDatetime.empty()) {
@@ -3913,12 +3896,12 @@ int main(int argc, char* argv[]) {
 				f = stopAfter( expireBackupData(argv[0], destinationContainer, expireVersion, expireDatetime, db, forceAction, expireRestorableAfterVersion, expireRestorableAfterDatetime) );
 				break;
 
-			case BACKUP_DELETE:
+			case BackupType::DELETE:
 				initTraceFile();
 				f = stopAfter( deleteBackupContainer(argv[0], destinationContainer) );
 				break;
 
-			case BACKUP_DESCRIBE:
+			case BackupType::DESCRIBE:
 				initTraceFile();
 				// If timestamp lookups are desired, require a cluster file
 				if(describeTimestamps && !initCluster())
@@ -3928,23 +3911,23 @@ int main(int argc, char* argv[]) {
 				f = stopAfter( describeBackup(argv[0], destinationContainer, describeDeep, describeTimestamps ? Optional<Database>(db) : Optional<Database>(), jsonOutput) );
 				break;
 
-			case BACKUP_LIST:
+			case BackupType::LIST:
 				initTraceFile();
 				f = stopAfter( listBackup(baseUrl) );
 				break;
 
-			case BACKUP_QUERY:
+			case BackupType::QUERY:
 				initTraceFile();
 				f = stopAfter(queryBackup(argv[0], destinationContainer, backupKeysFilter, restoreVersion,
 				                          restoreClusterFileOrig, restoreTimestamp, !quietDisplay));
 				break;
 
-			case BACKUP_DUMP:
+			case BackupType::DUMP:
 				initTraceFile();
 				f = stopAfter( dumpBackupData(argv[0], destinationContainer, dumpBegin, dumpEnd) );
 				break;
 
-			case BACKUP_UNDEFINED:
+			case BackupType::UNDEFINED:
 			default:
 				fprintf(stderr, "ERROR: Unsupported backup action %s\n", argv[1]);
 				printHelpTeaser(argv[0]);
@@ -3953,9 +3936,9 @@ int main(int argc, char* argv[]) {
 			}
 
 			break;
-		case EXE_RESTORE:
+		case ProgramExe::RESTORE:
 			if(dryRun) {
-				if(restoreType != RESTORE_START) {
+				if (restoreType != RestoreType::START) {
 					fprintf(stderr, "Restore dry run only works for 'start' command\n");
 					return FDB_EXIT_ERROR;
 				}
@@ -3983,39 +3966,39 @@ int main(int argc, char* argv[]) {
 			}
 
 			switch(restoreType) {
-				case RESTORE_START:
-					f = stopAfter(runRestore(db, restoreClusterFileOrig, tagName, restoreContainer, backupKeys,
-				                             beginVersion, restoreVersion, restoreTimestamp, !dryRun, !quietDisplay,
-				                             waitForDone, addPrefix, removePrefix, incrementalBackupOnly));
-					break;
-				case RESTORE_WAIT:
-					f = stopAfter( success(ba.waitRestore(db, KeyRef(tagName), true)) );
-					break;
-				case RESTORE_ABORT:
-				    f = stopAfter(
+			case RestoreType::START:
+				f = stopAfter(runRestore(db, restoreClusterFileOrig, tagName, restoreContainer, backupKeys,
+				                         beginVersion, restoreVersion, restoreTimestamp, !dryRun, !quietDisplay,
+				                         waitForDone, addPrefix, removePrefix, incrementalBackupOnly));
+				break;
+			case RestoreType::WAIT:
+				f = stopAfter(success(ba.waitRestore(db, KeyRef(tagName), true)));
+				break;
+			case RestoreType::ABORT:
+				f =
+				    stopAfter(
 				        map(ba.abortRestore(db, KeyRef(tagName)), [tagName](FileBackupAgent::ERestoreState s) -> Void {
 					        printf("RESTORE_ABORT Tag: %s  State: %s\n", tagName.c_str(),
 					               FileBackupAgent::restoreStateText(s).toString().c_str());
 					        return Void();
 				        }));
-				    break;
-				case RESTORE_STATUS:
-					// If no tag is specifically provided then print all tag status, don't just use "default"
-					if(tagProvided)
-						tag = tagName;
-					f = stopAfter( map(ba.restoreStatus(db, KeyRef(tag)), [](std::string s) -> Void {
-						printf("%s\n", s.c_str());
-						return Void();
-					}) );
-					break;
-				default:
-					throw restore_error();
+				break;
+			case RestoreType::STATUS:
+				// If no tag is specifically provided then print all tag status, don't just use "default"
+				if (tagProvided) tag = tagName;
+				f = stopAfter(map(ba.restoreStatus(db, KeyRef(tag)), [](std::string s) -> Void {
+					printf("%s\n", s.c_str());
+					return Void();
+				}));
+				break;
+			default:
+				throw restore_error();
 			}
 			break;
-		case EXE_FASTRESTORE_TOOL:
+		case ProgramExe::FASTRESTORE_TOOL:
 			// Support --dest_cluster_file option as fdbrestore does
 			if (dryRun) {
-				if (restoreType != RESTORE_START) {
+				if (restoreType != RestoreType::START) {
 					fprintf(stderr, "Restore dry run only works for 'start' command\n");
 					return FDB_EXIT_ERROR;
 				}
@@ -4044,16 +4027,16 @@ int main(int argc, char* argv[]) {
 			}
 			// TODO: We have not implemented the code commented out in this case
 			switch (restoreType) {
-			case RESTORE_START:
+			case RestoreType::START:
 				f = stopAfter(runFastRestoreTool(db, tagName, restoreContainer, backupKeys, restoreVersion, !dryRun,
 				                                 !quietDisplay, waitForDone));
 				break;
-			case RESTORE_WAIT:
+			case RestoreType::WAIT:
 				printf("[TODO][ERROR] FastRestore does not support RESTORE_WAIT yet!\n");
 				throw restore_error();
 				//					f = stopAfter( success(ba.waitRestore(db, KeyRef(tagName), true)) );
 				break;
-			case RESTORE_ABORT:
+			case RestoreType::ABORT:
 				printf("[TODO][ERROR] FastRestore does not support RESTORE_ABORT yet!\n");
 				throw restore_error();
 				//					f = stopAfter( map(ba.abortRestore(db, KeyRef(tagName)),
@@ -4062,7 +4045,7 @@ int main(int argc, char* argv[]) {
 				// FileBackupAgent::restoreStateText(s).toString().c_str()); 						return Void();
 				//					}) );
 				break;
-			case RESTORE_STATUS:
+			case RestoreType::STATUS:
 				printf("[TODO][ERROR] FastRestore does not support RESTORE_STATUS yet!\n");
 				throw restore_error();
 				// If no tag is specifically provided then print all tag status, don't just use "default"
@@ -4076,35 +4059,35 @@ int main(int argc, char* argv[]) {
 				throw restore_error();
 			}
 			break;
-		case EXE_DR_AGENT:
+		case ProgramExe::DR_AGENT:
 			if(!initCluster())
 				return FDB_EXIT_ERROR;
 			f = stopAfter( runDBAgent(sourceDb, db) );
 			break;
-		case EXE_DB_BACKUP:
+		case ProgramExe::DB_BACKUP:
 			if(!initCluster())
 				return FDB_EXIT_ERROR;
 			switch (dbType)
 			{
-			case DB_START:
+			case DBType::START:
 				f = stopAfter( submitDBBackup(sourceDb, db, backupKeys, tagName) );
 				break;
-			case DB_STATUS:
+			case DBType::STATUS:
 				f = stopAfter( statusDBBackup(sourceDb, db, tagName, maxErrors) );
 				break;
-			case DB_SWITCH:
+			case DBType::SWITCH:
 				f = stopAfter( switchDBBackup(sourceDb, db, backupKeys, tagName, forceAction) );
 				break;
-			case DB_ABORT:
+			case DBType::ABORT:
 				f = stopAfter( abortDBBackup(sourceDb, db, tagName, partial, dstOnly) );
 				break;
-			case DB_PAUSE:
+			case DBType::PAUSE:
 				f = stopAfter( changeDBBackupResumed(sourceDb, db, true) );
 				break;
-			case DB_RESUME:
+			case DBType::RESUME:
 				f = stopAfter( changeDBBackupResumed(sourceDb, db, false) );
 				break;
-			case DB_UNDEFINED:
+			case DBType::UNDEFINED:
 			default:
 				fprintf(stderr, "ERROR: Unsupported DR action %s\n", argv[1]);
 				printHelpTeaser(argv[0]);
@@ -4112,7 +4095,7 @@ int main(int argc, char* argv[]) {
 				break;
 			}
 			break;
-		case EXE_UNDEFINED:
+		case ProgramExe::UNDEFINED:
 		default:
 			return FDB_EXIT_ERROR;
 		}

--- a/fdbclient/ClientWorkerInterface.h
+++ b/fdbclient/ClientWorkerInterface.h
@@ -93,7 +93,5 @@ struct ProfilerRequest {
 		serializer(ar, reply, type, action, duration, outputFile);
 	}
 };
-BINARY_SERIALIZABLE( ProfilerRequest::Type );
-BINARY_SERIALIZABLE( ProfilerRequest::Action );
 
 #endif

--- a/fdbclient/TagThrottle.h
+++ b/fdbclient/TagThrottle.h
@@ -169,7 +169,7 @@ struct TagThrottleValue {
 	template<class Ar>
 	void serialize(Ar& ar) {
 		if(ar.protocolVersion().hasTagThrottleValueReason()) {
-			serializer(ar, tpsRate, expirationTime, initialDuration, reinterpret_cast<uint8_t&>(reason));
+			serializer(ar, tpsRate, expirationTime, initialDuration, reason);
 		}
 		else if(ar.protocolVersion().hasTagThrottleValue()) {
 			serializer(ar, tpsRate, expirationTime, initialDuration);
@@ -215,8 +215,6 @@ namespace ThrottleApi {
 
 	Future<Void> enableAuto(Database const& db, bool const& enabled);
 };
-
-BINARY_SERIALIZABLE(TransactionPriority);
 
 template<class Value>
 using TransactionTagMap = std::unordered_map<TransactionTag, Value, std::hash<TransactionTagRef>>;

--- a/fdbserver/LogSystemConfig.h
+++ b/fdbserver/LogSystemConfig.h
@@ -203,7 +203,6 @@ enum class LogSystemType {
 	empty = 0, // Never used.
 	tagPartitioned = 2,
 };
-BINARY_SERIALIZABLE(LogSystemType);
 
 struct LogSystemConfig {
 	constexpr static FileIdentifier file_identifier = 16360847;

--- a/fdbserver/RecoveryState.h
+++ b/fdbserver/RecoveryState.h
@@ -28,7 +28,6 @@
 // is slightly more detailed and is used by the status infrastructure.  But I'm scared to make changes to the former so close to 1.0 release, so I'm making the latter.
 
 enum class RecoveryState { UNINITIALIZED = 0, READING_CSTATE = 1, LOCKING_CSTATE = 2, RECRUITING = 3, RECOVERY_TRANSACTION = 4, WRITING_CSTATE = 5, ACCEPTING_COMMITS = 6, ALL_LOGS_RECRUITED = 7, STORAGE_RECOVERED = 8, FULLY_RECOVERED = 9 };
-BINARY_SERIALIZABLE( RecoveryState );
 
 namespace RecoveryStatus {
 	enum RecoveryStatus {

--- a/fdbserver/RestoreUtil.h
+++ b/fdbserver/RestoreUtil.h
@@ -80,7 +80,6 @@ using VersionedMutationsVec = Standalone<VectorRef<VersionedMutation>>;
 using SampledMutationsVec = Standalone<VectorRef<SampledMutation>>;
 
 enum class RestoreRole { Invalid = 0, Controller = 1, Loader, Applier };
-BINARY_SERIALIZABLE(RestoreRole);
 std::string getRoleStr(RestoreRole role);
 extern const std::vector<std::string> RestoreRoleStr;
 extern int numRoles;

--- a/fdbserver/fdbserver.actor.cpp
+++ b/fdbserver/fdbserver.actor.cpp
@@ -877,7 +877,7 @@ void restoreRoleFilesHelper(std::string dirSrc, std::string dirToMove, std::stri
 }
 
 namespace {
-enum Role {
+enum class ServerRole {
 	ConsistencyCheck,
 	CreateTemplateDatabase,
 	DSLTest,
@@ -905,7 +905,7 @@ struct CLIOptions {
 	int maxLogs = 0;
 	bool maxLogsSet = false;
 
-	Role role = FDBD;
+	ServerRole role = ServerRole::FDBD;
 	uint32_t randomSeed = platform::getRandomSeed();
 
 	const char* testFile = "tests/default.txt";
@@ -1040,35 +1040,35 @@ private:
 			case OPT_ROLE:
 				sRole = args.OptionArg();
 				if (!strcmp(sRole, "fdbd"))
-					role = FDBD;
+					role = ServerRole::FDBD;
 				else if (!strcmp(sRole, "simulation"))
-					role = Simulation;
+					role = ServerRole::Simulation;
 				else if (!strcmp(sRole, "test"))
-					role = Test;
+					role = ServerRole::Test;
 				else if (!strcmp(sRole, "multitest"))
-					role = MultiTester;
+					role = ServerRole::MultiTester;
 				else if (!strcmp(sRole, "skiplisttest"))
-					role = SkipListTest;
+					role = ServerRole::SkipListTest;
 				else if (!strcmp(sRole, "search"))
-					role = SearchMutations;
+					role = ServerRole::SearchMutations;
 				else if (!strcmp(sRole, "dsltest"))
-					role = DSLTest;
+					role = ServerRole::DSLTest;
 				else if (!strcmp(sRole, "versionedmaptest"))
-					role = VersionedMapTest;
+					role = ServerRole::VersionedMapTest;
 				else if (!strcmp(sRole, "createtemplatedb"))
-					role = CreateTemplateDatabase;
+					role = ServerRole::CreateTemplateDatabase;
 				else if (!strcmp(sRole, "networktestclient"))
-					role = NetworkTestClient;
+					role = ServerRole::NetworkTestClient;
 				else if (!strcmp(sRole, "networktestserver"))
-					role = NetworkTestServer;
+					role = ServerRole::NetworkTestServer;
 				else if (!strcmp(sRole, "restore"))
-					role = Restore;
+					role = ServerRole::Restore;
 				else if (!strcmp(sRole, "kvfileintegritycheck"))
-					role = KVFileIntegrityCheck;
+					role = ServerRole::KVFileIntegrityCheck;
 				else if (!strcmp(sRole, "kvfilegeneratesums"))
-					role = KVFileGenerateIOLogChecksums;
+					role = ServerRole::KVFileGenerateIOLogChecksums;
 				else if (!strcmp(sRole, "consistencycheck"))
-					role = ConsistencyCheck;
+					role = ServerRole::ConsistencyCheck;
 				else {
 					fprintf(stderr, "ERROR: Unknown role `%s'\n", sRole);
 					printHelpTeaser(argv[0]);
@@ -1421,8 +1421,8 @@ private:
 		bool autoPublicAddress =
 		    std::any_of(publicAddressStrs.begin(), publicAddressStrs.end(),
 		                [](const std::string& addr) { return StringRef(addr).startsWith(LiteralStringRef("auto:")); });
-		if ((role != Simulation && role != CreateTemplateDatabase && role != KVFileIntegrityCheck &&
-		     role != KVFileGenerateIOLogChecksums) ||
+		if ((role != ServerRole::Simulation && role != ServerRole::CreateTemplateDatabase &&
+		     role != ServerRole::KVFileIntegrityCheck && role != ServerRole::KVFileGenerateIOLogChecksums) ||
 		    autoPublicAddress) {
 
 			if (seedSpecified && !fileExists(connFile)) {
@@ -1469,7 +1469,7 @@ private:
 			flushAndExit(FDB_EXIT_ERROR);
 		}
 
-		if (role == ConsistencyCheck) {
+		if (role == ServerRole::ConsistencyCheck) {
 			if (!publicAddressStrs.empty()) {
 				fprintf(stderr, "ERROR: Public address cannot be specified for consistency check processes\n");
 				printHelpTeaser(argv[0]);
@@ -1479,18 +1479,18 @@ private:
 			publicAddresses.address = NetworkAddress(publicIP, ::getpid());
 		}
 
-		if (role == Simulation) {
+		if (role == ServerRole::Simulation) {
 			Optional<bool> buggifyOverride = checkBuggifyOverride(testFile);
 			if (buggifyOverride.present()) buggifyEnabled = buggifyOverride.get();
 		}
 
-		if (role == SearchMutations && !targetKey) {
+		if (role == ServerRole::SearchMutations && !targetKey) {
 			fprintf(stderr, "ERROR: please specify a target key\n");
 			printHelpTeaser(argv[0]);
 			flushAndExit(FDB_EXIT_ERROR);
 		}
 
-		if (role == NetworkTestClient && !testServersStr.size()) {
+		if (role == ServerRole::NetworkTestClient && !testServersStr.size()) {
 			fprintf(stderr, "ERROR: please specify --testservers\n");
 			printHelpTeaser(argv[0]);
 			flushAndExit(FDB_EXIT_ERROR);
@@ -1550,7 +1550,7 @@ int main(int argc, char* argv[]) {
 		const auto opts = CLIOptions::parseArgs(argc, argv);
 		const auto role = opts.role;
 
-		if (role == Simulation) printf("Random seed is %u...\n", opts.randomSeed);
+		if (role == ServerRole::Simulation) printf("Random seed is %u...\n", opts.randomSeed);
 
 		if (opts.zoneId.present())
 			printf("ZoneId set to %s, dcId to %s\n", printable(opts.zoneId).c_str(), printable(opts.dcId).c_str());
@@ -1570,7 +1570,7 @@ int main(int argc, char* argv[]) {
 		CLIENT_KNOBS = clientKnobs;
 
 		if (!serverKnobs->setKnob("log_directory", opts.logFolder)) ASSERT(false);
-		if (role != Simulation) {
+		if (role != ServerRole::Simulation) {
 			if (!serverKnobs->setKnob("commit_batches_mem_bytes_hard_limit", std::to_string(opts.memLimit)))
 				ASSERT(false);
 		}
@@ -1597,9 +1597,9 @@ int main(int argc, char* argv[]) {
 		if (!serverKnobs->setKnob("server_mem_limit", std::to_string(opts.memLimit))) ASSERT(false);
 
 		// Reinitialize knobs in order to update knobs that are dependent on explicitly set knobs
-		flowKnobs->initialize(true, role == Simulation);
+		flowKnobs->initialize(true, role == ServerRole::Simulation);
 		clientKnobs->initialize(true);
-		serverKnobs->initialize(true, clientKnobs, role == Simulation);
+		serverKnobs->initialize(true, clientKnobs, role == ServerRole::Simulation);
 
 		// evictionPolicyStringToEnum will throw an exception if the string is not recognized as a valid
 		EvictablePageCache::evictionPolicyStringToEnum(flowKnobs->CACHE_EVICTION_POLICY);
@@ -1609,17 +1609,17 @@ int main(int argc, char* argv[]) {
 			flushAndExit(FDB_EXIT_ERROR);
 		}
 
-		if (role == SkipListTest) {
+		if (role == ServerRole::SkipListTest) {
 			skipListTest();
 			flushAndExit(FDB_EXIT_SUCCESS);
 		}
 
-		if (role == DSLTest) {
+		if (role == ServerRole::DSLTest) {
 			dsltest();
 			flushAndExit(FDB_EXIT_SUCCESS);
 		}
 
-		if (role == VersionedMapTest) {
+		if (role == ServerRole::VersionedMapTest) {
 			versionedMapTest();
 			flushAndExit(FDB_EXIT_SUCCESS);
 		}
@@ -1631,7 +1631,7 @@ int main(int argc, char* argv[]) {
 
 		std::vector<Future<Void>> listenErrors;
 
-		if (role == Simulation || role == CreateTemplateDatabase) {
+		if (role == ServerRole::Simulation || role == ServerRole::CreateTemplateDatabase) {
 			//startOldSimulator();
 			startNewSimulator();
 			openTraceFile(NetworkAddress(), opts.rollsize, opts.maxLogsSize, opts.logFolder, "trace", opts.logGroup);
@@ -1640,7 +1640,8 @@ int main(int argc, char* argv[]) {
 			g_network->addStopCallback( Net2FileSystem::stop );
 			FlowTransport::createInstance(false, 1);
 
-			const bool expectsPublicAddress = (role == FDBD || role == NetworkTestServer || role == Restore);
+			const bool expectsPublicAddress =
+			    (role == ServerRole::FDBD || role == ServerRole::NetworkTestServer || role == ServerRole::Restore);
 			if (opts.publicAddressStrs.empty()) {
 				if (expectsPublicAddress) {
 					fprintf(stderr, "ERROR: The -p or --public_address option is required\n");
@@ -1733,7 +1734,7 @@ int main(int argc, char* argv[]) {
 
 		Future<Optional<Void>> f;
 
-		if (role == Simulation) {
+		if (role == ServerRole::Simulation) {
 			TraceEvent("Simulation").detail("TestFile", opts.testFile);
 
 			clientKnobs->trace();
@@ -1855,7 +1856,7 @@ int main(int argc, char* argv[]) {
 			}
 			setupAndRun(dataFolder, opts.testFile, opts.restarting, (isRestoring >= 1), opts.whitelistBinPaths);
 			g_simulator.run();
-		} else if (role == FDBD) {
+		} else if (role == ServerRole::FDBD) {
 			// Update the global blob credential files list so that both fast
 			// restore workers and backup workers can access blob storage.
 			std::vector<std::string>* pFiles =
@@ -1898,40 +1899,40 @@ int main(int argc, char* argv[]) {
 				f = stopAfter(waitForAll(actors));
 				g_network->run();
 			}
-		} else if (role == MultiTester) {
+		} else if (role == ServerRole::MultiTester) {
 			setupRunLoopProfiler();
 			f = stopAfter(runTests(opts.connectionFile, TEST_TYPE_FROM_FILE,
 			                       opts.testOnServers ? TEST_ON_SERVERS : TEST_ON_TESTERS, opts.minTesterCount,
 			                       opts.testFile, StringRef(), opts.localities));
 			g_network->run();
-		} else if (role == Test) {
+		} else if (role == ServerRole::Test) {
 			setupRunLoopProfiler();
 			auto m = startSystemMonitor(opts.dataFolder, opts.zoneId, opts.zoneId);
 			f = stopAfter(runTests(opts.connectionFile, TEST_TYPE_FROM_FILE, TEST_HERE, 1, opts.testFile, StringRef(),
 			                       opts.localities));
 			g_network->run();
-		} else if (role == ConsistencyCheck) {
+		} else if (role == ServerRole::ConsistencyCheck) {
 			setupRunLoopProfiler();
 
 			auto m = startSystemMonitor(opts.dataFolder, opts.zoneId, opts.zoneId);
 			f = stopAfter(runTests(opts.connectionFile, TEST_TYPE_CONSISTENCY_CHECK, TEST_HERE, 1, opts.testFile,
 			                       StringRef(), opts.localities));
 			g_network->run();
-		} else if (role == CreateTemplateDatabase) {
+		} else if (role == ServerRole::CreateTemplateDatabase) {
 			createTemplateDatabase();
-		} else if (role == NetworkTestClient) {
+		} else if (role == ServerRole::NetworkTestClient) {
 			f = stopAfter(networkTestClient(opts.testServersStr));
 			g_network->run();
-		} else if (role == NetworkTestServer) {
+		} else if (role == ServerRole::NetworkTestServer) {
 			f = stopAfter( networkTestServer() );
 			g_network->run();
-		} else if (role == Restore) {
+		} else if (role == ServerRole::Restore) {
 			f = stopAfter(restoreWorker(opts.connectionFile, opts.localities, opts.dataFolder));
 			g_network->run();
-		} else if (role == KVFileIntegrityCheck) {
+		} else if (role == ServerRole::KVFileIntegrityCheck) {
 			f = stopAfter(KVFileCheck(opts.kvFile, true));
 			g_network->run();
-		} else if (role == KVFileGenerateIOLogChecksums) {
+		} else if (role == ServerRole::KVFileGenerateIOLogChecksums) {
 			Optional<Void> result;
 			try {
 				GenerateIOLogChecksumFile(opts.kvFile);
@@ -1953,7 +1954,7 @@ int main(int argc, char* argv[]) {
 		TraceEvent("ElapsedTime").detail("SimTime", now()-startNow).detail("RealTime", timer()-start)
 			.detail("RandomUnseed", unseed);
 
-		if (role==Simulation){
+		if (role == ServerRole::Simulation) {
 			printf("Unseed: %d\n", unseed);
 			printf("Elapsed: %f simsec, %f real seconds\n", now()-startNow, timer()-start);
 		}
@@ -1990,7 +1991,7 @@ int main(int argc, char* argv[]) {
 			cout << "  " << i->second << " " << i->first << endl;*/
 		//	cout << "  " << Actor::allActors[i]->getName() << endl;
 
-		if (role == Simulation) {
+		if (role == ServerRole::Simulation) {
 			unsigned long sevErrorEventsLogged = TraceEvent::CountEventsLoggedAt(SevError);
 			if (sevErrorEventsLogged > 0) {
 				printf("%lu SevError events logged\n", sevErrorEventsLogged);

--- a/fdbserver/workloads/ClientTransactionProfileCorrectness.actor.cpp
+++ b/fdbserver/workloads/ClientTransactionProfileCorrectness.actor.cpp
@@ -36,15 +36,14 @@ namespace ClientLogEventsParser {
 		FdbClientLogEvents::EventGetVersion_V2 gv;
 		reader >> gv;
 		ASSERT(gv.latency < 10000);
-		ASSERT(gv.priorityType >= 0 && gv.priorityType < FdbClientLogEvents::PRIORITY_END);
 	}
 
 	void parseEventGetVersion_V3(BinaryReader &reader) {
 		FdbClientLogEvents::EventGetVersion_V3 gv;
 		reader >> gv;
 		ASSERT(gv.latency < 10000);
-		ASSERT(gv.priorityType >= 0 && gv.priorityType < FdbClientLogEvents::PRIORITY_END && gv.readVersion > 0);
-	}
+	    ASSERT(gv.readVersion > 0);
+    }
 
 	void parseEventGet(BinaryReader &reader) {
 		FdbClientLogEvents::EventGet g;
@@ -142,25 +141,25 @@ bool checkTxInfoEntryFormat(BinaryReader &reader) {
 		reader >> event;
 		switch (event.type)
 		{
-		case FdbClientLogEvents::GET_VERSION_LATENCY:
+		case FdbClientLogEvents::EventType::GET_VERSION_LATENCY:
 			parser->parseGetVersion(reader);
 			break;
-		case FdbClientLogEvents::GET_LATENCY:
+		case FdbClientLogEvents::EventType::GET_LATENCY:
 			parser->parseGet(reader);
 			break;
-		case FdbClientLogEvents::GET_RANGE_LATENCY:
+		case FdbClientLogEvents::EventType::GET_RANGE_LATENCY:
 			parser->parseGetRange(reader);
 			break;
-		case FdbClientLogEvents::COMMIT_LATENCY:
+		case FdbClientLogEvents::EventType::COMMIT_LATENCY:
 			parser->parseCommit(reader);
 			break;
-		case FdbClientLogEvents::ERROR_GET:
+		case FdbClientLogEvents::EventType::ERROR_GET:
 			parser->parseErrorGet(reader);
 			break;
-		case FdbClientLogEvents::ERROR_GET_RANGE:
+		case FdbClientLogEvents::EventType::ERROR_GET_RANGE:
 			parser->parseErrorGetRange(reader);
 			break;
-		case FdbClientLogEvents::ERROR_COMMIT:
+		case FdbClientLogEvents::EventType::ERROR_COMMIT:
 			parser->parseErrorCommit(reader);
 			break;
 		default:


### PR DESCRIPTION
Changes in this PR:

- Makes enums automatically binary-serializable, removing the need to use the `BINARY_SERIALIZABLE` outside `serialize.h`
- Uses enum classes to improve type safety in client log events, as well as `fdbserver.actor.cpp` and `backup.actor.cpp`

### Style
- [x] All variable and function names make sense.
- [x] The code is properly formatted (consider running `git clang-format`).

### Performance
- [x] All CPU-hot paths are well optimized.
- [x] The proper containers are used (for example `std::vector` vs `VectorRef`).
- [x] There are no new known `SlowTask` traces.

### Testing
- [x] The code was sufficiently tested in simulation.
- [x] If there are new parameters or knobs, different values are tested in simulation.
- [x] `ASSERT`, `ASSERT_WE_THINK`, and `TEST` macros are added in appropriate places.
- [x] Unit tests were added for new algorithms and data structure that make sense to unit-test
- [x] If this is a bugfix: there is a test that can easily reproduce the bug.
