### PR TITLE
Change operation_failed to dd_not_found

### DIFF
--- a/fdbclient/SpecialKeySpace.actor.cpp
+++ b/fdbclient/SpecialKeySpace.actor.cpp
@@ -560,6 +560,7 @@ ACTOR Future<Standalone<RangeResultRef>> ddMetricsGetRangeActor(ReadYourWritesTr
 			return result;
 		} catch (Error& e) {
 			state Error err(e);
+			// dd_not_found is introduced in 700, and operation_failed is used in previous version
 			auto err_code =
 			    ryw->getDatabase()->apiVersionAtLeast(700) ? error_code_dd_not_found : error_code_operation_failed;
 			if (e.code() == err_code) {

--- a/fdbclient/SpecialKeySpace.actor.cpp
+++ b/fdbclient/SpecialKeySpace.actor.cpp
@@ -560,10 +560,7 @@ ACTOR Future<Standalone<RangeResultRef>> ddMetricsGetRangeActor(ReadYourWritesTr
 			return result;
 		} catch (Error& e) {
 			state Error err(e);
-			// dd_not_found is introduced in 700, and operation_failed is used in previous version
-			auto err_code =
-			    ryw->getDatabase()->apiVersionAtLeast(700) ? error_code_dd_not_found : error_code_operation_failed;
-			if (e.code() == err_code) {
+			if (e.code() == error_code_dd_not_found) {
 				TraceEvent(SevWarnAlways, "DataDistributorNotPresent")
 				    .detail("Operation", "DDMetricsReqestThroughSpecialKeys");
 				wait(delayJittered(FLOW_KNOBS->PREVENT_FAST_SPIN_DELAY));

--- a/fdbclient/SpecialKeySpace.actor.cpp
+++ b/fdbclient/SpecialKeySpace.actor.cpp
@@ -560,7 +560,7 @@ ACTOR Future<Standalone<RangeResultRef>> ddMetricsGetRangeActor(ReadYourWritesTr
 			return result;
 		} catch (Error& e) {
 			state Error err(e);
-			if (e.code() == error_code_operation_failed) {
+			if (e.code() == error_code_dd_not_found) {
 				TraceEvent(SevWarnAlways, "DataDistributorNotPresent")
 				    .detail("Operation", "DDMetricsReqestThroughSpecialKeys");
 				wait(delayJittered(FLOW_KNOBS->PREVENT_FAST_SPIN_DELAY));

--- a/fdbclient/SpecialKeySpace.actor.cpp
+++ b/fdbclient/SpecialKeySpace.actor.cpp
@@ -560,7 +560,9 @@ ACTOR Future<Standalone<RangeResultRef>> ddMetricsGetRangeActor(ReadYourWritesTr
 			return result;
 		} catch (Error& e) {
 			state Error err(e);
-			if (e.code() == error_code_dd_not_found) {
+			auto err_code =
+			    ryw->getDatabase()->apiVersionAtLeast(700) ? error_code_dd_not_found : error_code_operation_failed;
+			if (e.code() == err_code) {
 				TraceEvent(SevWarnAlways, "DataDistributorNotPresent")
 				    .detail("Operation", "DDMetricsReqestThroughSpecialKeys");
 				wait(delayJittered(FLOW_KNOBS->PREVENT_FAST_SPIN_DELAY));


### PR DESCRIPTION
`dd_not_found` is introduced in `7.0`, in `6.3` we used `operation_failed` instead

Changes in this PR:
- Catch `dd_not_found` error instead of `operation_failed` in special key implementation

### Style
- [x] All variable and function names make sense.
- [x] The code is properly formatted (consider running `git clang-format`).

### Performance
- [ ] ~~All CPU-hot paths are well optimized.~~
- [ ] ~~The proper containers are used (for example `std::vector` vs `VectorRef`).~~
- [x] There are no new known `SlowTask` traces.

### Testing
- [x] The code was sufficiently tested in simulation.
- [ ] ~~If there are new parameters or knobs, different values are tested in simulation.~~
- [ ] ~~`ASSERT`, `ASSERT_WE_THINK`, and `TEST` macros are added in appropriate places.~~
- [ ] ~~Unit tests were added for new algorithms and data structure that make sense to unit-test~~
- [x] If this is a bugfix: there is a test that can easily reproduce the bug.
