### PR TITLE
Change dd_tracker_cancelled to 1215 to avoid conflict

### DIFF
--- a/flow/error_definitions.h
+++ b/flow/error_definitions.h
@@ -86,7 +86,7 @@ ERROR( please_reboot_delete, 1208, "Reboot of server process requested, with del
 ERROR( master_proxy_failed, 1209, "Master terminating because a Proxy failed" )
 ERROR( master_resolver_failed, 1210, "Master terminating because a Resolver failed" )
 ERROR( server_overloaded, 1211, "Server is under too much load and cannot respond" )
-ERROR(dd_tracker_cancelled, 1212, "The data distribution tracker has been cancelled")
+ERROR( dd_tracker_cancelled, 1215, "The data distribution tracker has been cancelled" )
 
 // 15xx Platform errors
 ERROR( platform_error, 1500, "Platform error" )


### PR DESCRIPTION
This is safe because it's not been in a release, and it doesn't get
serialized.