### PR TITLE
Move compiler definitions into config file

### DIFF
--- a/flow/CMakeLists.txt
+++ b/flow/CMakeLists.txt
@@ -99,6 +99,7 @@ if(UNIX AND NOT APPLE)
 endif()
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/SourceVersion.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/SourceVersion.h)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/config.h)
 
 add_flow_target(STATIC_LIBRARY NAME flow SRCS ${FLOW_SRCS})
 if (NOT APPLE AND NOT WIN32)

--- a/flow/FastAlloc.h
+++ b/flow/FastAlloc.h
@@ -24,6 +24,7 @@
 
 #include "flow/Error.h"
 #include "flow/Platform.h"
+#include "flow/config.h"
 
 // ALLOC_INSTRUMENTATION_STDOUT enables non-sampled logging of all allocations and deallocations to stdout to be processed by tools/alloc_instrumentation.py
 //#define ALLOC_INSTRUMENTATION_STDOUT ENABLED(NOT_IN_CLEAN)

--- a/flow/Platform.h
+++ b/flow/Platform.h
@@ -22,6 +22,8 @@
 #define FLOW_PLATFORM_H
 #pragma once
 
+#include "flow/config.h"
+
 #if (defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__))
 #define __unixish__ 1
 #endif

--- a/flow/config.h.cmake
+++ b/flow/config.h.cmake
@@ -1,0 +1,50 @@
+#cmakedefine ALLOC_INSTRUMENTATION
+#cmakedefine NDEBUG
+#cmakedefine FDB_RELEASE
+#ifdef FDB_RELEASE
+# define FDB_CLEAN_BUILD
+#endif // FDB_RELEASE
+#cmakedefine OPEN_FOR_IDE
+#ifdef WIN32
+# define USE_USEFIBERS
+# define _WIN32_WINNT ${WINDOWS_TARGET}
+# define WINVER ${WINDOWS_TARGET}
+# define NTDDI_VERSION 0x05020000
+# define BOOST_ALL_NO_LIB
+#else
+# cmakedefine USE_UCONTEXT
+# cmakedefine USE_ASAN
+# cmakedefine USE_MSAN
+# cmakedefine USE_UBSAN
+# cmakedefine USE_UCONTEXT
+# if defined(USE_ASAN) || \
+     defined(USE_MSAN) || \
+     defined(USE_UBSAN) || \
+     defined(USE_TSAN)
+#  define DUSE_SANITIZER
+# #endif
+# #ifdef USE_ASAN
+#  define ADDRESS_SANITIZER
+# endif // USE_ASAN
+# ifdef USE_MSAN
+#  define MEMORY_SANITIZER
+# endif
+# ifdef USE_UBSAN
+#  define UNDEFINED_BEHAVIOR_SANITIZER
+# endif
+# ifdef USE_TSAN
+#  define THREAD_SANITIZER
+#  define DYNAMIC_ANNOTATIONS_EXTERNAL_IMPL 1
+# endif
+# cmakedefine USE_GCOV
+# cmakedefine USE_VALGRIND
+# ifdef USE_VALGRIND
+#  define VALGRIND 1
+# endif
+# cmakedefine WITH_LIBCXX
+# if !defined(WITH_LIBCXX) && defined(__APPLE__)
+#  define WITH_LIBCXX
+# endif
+# cmakedefine DTRACE_PROBES
+# cmakedefine HAS_ALIGNED_ALLOC
+#endif // WIN32

--- a/flow/config.h.cmake
+++ b/flow/config.h.cmake
@@ -15,7 +15,6 @@
 # cmakedefine USE_ASAN
 # cmakedefine USE_MSAN
 # cmakedefine USE_UBSAN
-# define USE_UCONTEXT
 # if defined(USE_ASAN) || \
      defined(USE_MSAN) || \
      defined(USE_UBSAN) || \

--- a/flow/config.h.cmake
+++ b/flow/config.h.cmake
@@ -12,11 +12,10 @@
 # define NTDDI_VERSION 0x05020000
 # define BOOST_ALL_NO_LIB
 #else
-# cmakedefine USE_UCONTEXT
 # cmakedefine USE_ASAN
 # cmakedefine USE_MSAN
 # cmakedefine USE_UBSAN
-# cmakedefine USE_UCONTEXT
+# define USE_UCONTEXT
 # if defined(USE_ASAN) || \
      defined(USE_MSAN) || \
      defined(USE_UBSAN) || \
@@ -40,10 +39,6 @@
 # cmakedefine USE_VALGRIND
 # ifdef USE_VALGRIND
 #  define VALGRIND 1
-# endif
-# cmakedefine WITH_LIBCXX
-# if !defined(WITH_LIBCXX) && defined(__APPLE__)
-#  define WITH_LIBCXX
 # endif
 # cmakedefine DTRACE_PROBES
 # cmakedefine HAS_ALIGNED_ALLOC


### PR DESCRIPTION
This is just a refactoring change: instead of having all compiler definitions in cmake, I moved them into a header file. This should make the code much more readable