### PR TITLE
Fix double counting of range reads in TransactionMetrics

### DIFF
--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -1902,7 +1902,6 @@ ACTOR Future<Standalone<RangeResultRef>> getRange( Database cx, Reference<Transa
 				}
 
 				++cx->transactionPhysicalReads;
-				++cx->transactionGetRangeRequests;
 				state GetKeyValuesReply rep;
 				try {
 					if (CLIENT_BUGGIFY) {


### PR DESCRIPTION
This removes a stray line that counted range reads for (some of the) physical range reads, when we intended to and already do count them for logical range reads.