### PR TITLE
Trying io_uring as an alternative async IO

### DIFF
--- a/fdbrpc/AsyncFileIOUring.actor.h
+++ b/fdbrpc/AsyncFileIOUring.actor.h
@@ -1,0 +1,722 @@
+/*
+ * AsyncFileIOUring.actor.h
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2018 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#ifdef __linux__
+
+// When actually compiled (NO_INTELLISENSE), include the generated version of this file.  In intellisense use the source version.
+#if defined(NO_INTELLISENSE) && !defined(FLOW_ASYNCFILEIOURING_ACTOR_G_H)
+	#define FLOW_ASYNCFILEIOURING_ACTOR_G_H
+	#include "fdbrpc/AsyncFileIOUring.actor.g.h"
+#elif !defined(FLOW_ASYNCFILEIOURING_ACTOR_H)
+	#define FLOW_ASYNCFILEIOURING_ACTOR_H
+
+#include "fdbrpc/IAsyncFile.h"
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <sys/eventfd.h>
+#include <sys/syscall.h>
+#include "flow/Knobs.h"
+#include "flow/UnitTest.h"
+#include <stdio.h>
+#include "flow/crc32c.h"
+#include "liburing.h"
+#include "liburing/io_uring.h"
+#include "flow/genericactors.actor.h"
+#include "flow/actorcompiler.h"  // This must be the last #include.
+
+// DESCR struct SlowAioSubmit {
+// 	int64_t submitDuration; // ns
+// 	int64_t truncateDuration; // ns
+// 	int64_t numTruncates;
+// 	int64_t truncateBytes;
+// 	int64_t largestTruncate;
+// };
+
+class AsyncFileIOUring : public IAsyncFile, public ReferenceCounted<AsyncFileIOUring> {
+public:
+
+	static Future<Reference<IAsyncFile>> open( std::string filename, int flags, int mode, void* ignore ) {
+		ASSERT( flags & OPEN_UNBUFFERED );
+
+		if (flags & OPEN_LOCK)
+			mode |= 02000;  // Enable mandatory locking for this file if it is supported by the filesystem
+
+		std::string open_filename = filename;
+		if (flags & OPEN_ATOMIC_WRITE_AND_CREATE) {
+			ASSERT( (flags & OPEN_CREATE) && (flags & OPEN_READWRITE) && !(flags & OPEN_EXCLUSIVE) );
+			open_filename = filename + ".part";
+		}
+
+		int fd = ::open( open_filename.c_str(), openFlags(flags), mode );
+		if (fd<0) {
+			Error e = errno==ENOENT ? file_not_found() : io_error();
+			int ecode = errno;  // Save errno in case it is modified before it is used below
+			TraceEvent ev("AsyncFileIOUringOpenFailed");
+			ev.error(e).detail("Filename", filename).detailf("Flags", "%x", flags)
+			  .detailf("OSFlags", "%x", openFlags(flags)).detailf("Mode", "0%o", mode).GetLastError();
+			if(ecode == EINVAL)
+				ev.detail("Description", "Invalid argument - Does the target filesystem support IOUring?");
+			return e;
+		} else {
+			TraceEvent("AsyncFileIOUringOpen")
+				.detail("Filename", filename)
+				.detail("Flags", flags)
+				.detail("Mode", mode)
+				.detail("Fd", fd);
+		}
+
+		Reference<AsyncFileIOUring> r(new AsyncFileIOUring( fd, flags, filename ));
+
+		if (flags & OPEN_LOCK) {
+			// Acquire a "write" lock for the entire file
+			flock lockDesc;
+			lockDesc.l_type = F_WRLCK;
+			lockDesc.l_whence = SEEK_SET;
+			lockDesc.l_start = 0;
+			lockDesc.l_len = 0;  // "Specifying 0 for l_len has the special meaning: lock all bytes starting at the location specified by l_whence and l_start through to the end of file, no matter how large the file grows."
+			lockDesc.l_pid = 0;
+			if (fcntl(fd, F_SETLK, &lockDesc) == -1) {
+				TraceEvent(SevError, "UnableToLockFile").detail("Filename", filename).GetLastError();
+				return io_error();
+			}
+		}
+
+		struct stat buf;
+		if (fstat( fd, &buf )) {
+			TraceEvent("AsyncFileIOUringFStatError").detail("Fd",fd).detail("Filename", filename).GetLastError();
+			return io_error();
+		}
+
+		r->lastFileSize = r->nextFileSize = buf.st_size;
+		return Reference<IAsyncFile>(std::move(r));
+	}
+
+	static void init( Reference<IEventFD> ev, double ioTimeout ) {
+		// ASSERT( !FLOW_KNOBS->DISABLE_POSIX_KERNEL_AIO );
+		if( !g_network->isSimulated() ) {
+			ctx.countAIOSubmit.init(LiteralStringRef("AsyncFile.CountAIOSubmit"));
+			ctx.countAIOCollect.init(LiteralStringRef("AsyncFile.CountAIOCollect"));
+			ctx.submitMetric.init(LiteralStringRef("AsyncFile.Submit"));
+			ctx.countPreSubmitTruncate.init(LiteralStringRef("AsyncFile.CountPreAIOSubmitTruncate"));
+			ctx.preSubmitTruncateBytes.init(LiteralStringRef("AsyncFile.PreAIOSubmitTruncateBytes"));
+			// ctx.slowAioSubmitMetric.init(LiteralStringRef("AsyncFile.SlowAIOSubmit"));
+		}
+		
+		int rc = io_uring_queue_init(FLOW_KNOBS->MAX_OUTSTANDING, &ctx.ring, 0); 
+		//TODO or io_uring_queue_init_params here
+		if (rc<0) {
+			TraceEvent("IOSetupError").GetLastError();
+			throw io_error();
+		}
+		setTimeout(ioTimeout);
+		ctx.evfd = ev->getFD();
+		poll(ev);
+
+		g_network->setGlobal(INetwork::enRunCycleFunc, (flowGlobalType) &AsyncFileIOUring::launch);
+	}
+
+	static int get_eventfd() { return ctx.evfd; } //TODO
+	static void setTimeout(double ioTimeout) { ctx.setIOTimeout(ioTimeout); }
+
+	virtual void addref() { ReferenceCounted<AsyncFileIOUring>::addref(); }
+	virtual void delref() { ReferenceCounted<AsyncFileIOUring>::delref(); }
+
+	Future<int> read(void* data, int length, int64_t offset) override {
+		++countFileLogicalReads;
+		++countLogicalReads;
+		//printf("%p Begin logical read\n", getCurrentCoro());
+
+		if(failed) {
+			return io_timeout();
+		}
+
+		IOBlock *io = new IOBlock(IORING_OP_READ, fd); //TODO
+		// Use the vectorized version because single-read is only supported in very late linux kernels
+		io->buf = data;
+		io->nbytes = length;
+		io->offset = offset;
+
+		enqueue(io, "read", this);
+		Future<int> result = io->result.getFuture();
+
+		return result;
+	}
+	Future<Void> write(void const* data, int length, int64_t offset) override {
+		++countFileLogicalWrites;
+		++countLogicalWrites;
+		//printf("%p Begin logical write\n", getCurrentCoro());
+
+		if(failed) {
+			return io_timeout();
+		}
+
+		IOBlock *io = new IOBlock(IORING_OP_WRITE, fd); //TODO
+		io->buf = (void*)data;
+		io->nbytes = length;
+		io->offset = offset;
+
+		nextFileSize = std::max( nextFileSize, offset+length );
+
+		enqueue(io, "write", this);
+		Future<int> result = io->result.getFuture();
+
+		return success(result);
+	}
+// TODO(alexmiller): Remove when we upgrade the dev docker image to >14.10
+#ifndef FALLOC_FL_ZERO_RANGE
+#define FALLOC_FL_ZERO_RANGE 0x10
+#endif
+	Future<Void> zeroRange(int64_t offset, int64_t length) override {
+		bool success = false;
+		if (ctx.fallocateZeroSupported) {
+			int rc = fallocate( fd, FALLOC_FL_ZERO_RANGE, offset, length );
+			if (rc == EOPNOTSUPP) {
+				ctx.fallocateZeroSupported = false;
+			}
+			if (rc == 0) {
+				success = true;
+			}
+		}
+		return success ? Void() : IAsyncFile::zeroRange(offset, length);
+	}
+	Future<Void> truncate(int64_t size) override {
+		++countFileLogicalWrites;
+		++countLogicalWrites;
+
+		if(failed) {
+			return io_timeout();
+		}
+
+		int result = -1;
+		// IOURINGLogEvent(logFile, id, OpLogEntry::TRUNCATE, OpLogEntry::START, size / 4096);
+		bool completed = false;
+		double begin = timer_monotonic();
+
+		if( ctx.fallocateSupported && size >= lastFileSize ) {
+			result = fallocate( fd, 0, 0, size);
+			if (result != 0) {
+				int fallocateErrCode = errno;
+				TraceEvent("AsyncFileIOUringAllocateError").detail("Fd",fd).detail("Filename", filename).detail("Size", size).GetLastError();
+				if ( fallocateErrCode == EOPNOTSUPP ) {
+					// Mark fallocate as unsupported. Try again with truncate.
+					ctx.fallocateSupported = false;
+				} else {
+					// IOURINGLogEvent(logFile, id, OpLogEntry::TRUNCATE, OpLogEntry::COMPLETE, size / 4096, result);
+					return io_error();
+				}
+			} else {
+				completed = true;
+			}
+		}
+		if ( !completed )
+			result = ftruncate(fd, size);
+
+		double end = timer_monotonic();
+		if(nondeterministicRandom()->random01() < end-begin) {
+			TraceEvent("SlowIOURINGTruncate")
+				.detail("TruncateTime", end - begin)
+				.detail("TruncateBytes", size - lastFileSize);
+		}
+		// IOURINGLogEvent(logFile, id, OpLogEntry::TRUNCATE, OpLogEntry::COMPLETE, size / 4096, result);
+
+		if(result != 0) {
+			TraceEvent("AsyncFileIOUringTruncateError").detail("Fd",fd).detail("Filename", filename).GetLastError();
+			return io_error();
+		}
+
+		lastFileSize = nextFileSize = size;
+
+		return Void();
+	}
+
+	ACTOR static Future<Void> throwErrorIfFailed( Reference<AsyncFileIOUring> self, Future<Void> sync ) {
+		wait( sync );
+		if(self->failed) {
+			throw io_timeout();
+		}
+		return Void();
+	}
+
+	Future<Void> sync() override { //TODO
+		++countFileLogicalWrites;
+		++countLogicalWrites;
+
+		if(failed) {
+			return io_timeout();
+		}
+
+		// IOURINGLogEvent(logFile, id, OpLogEntry::SYNC, OpLogEntry::START);
+
+		Future<Void> fsync = throwErrorIfFailed(Reference<AsyncFileIOUring>::addRef(this), AsyncFileEIO::async_fdatasync(fd));  // Don't close the file until the asynchronous thing is done
+		// Alas, AIO f(data)sync doesn't seem to actually be implemented by the kernel
+		/*IOBlock *io = new IOBlock(IO_CMD_FDSYNC, fd);
+		submit(io, "write");
+		fsync=success(io->result.getFuture());*/
+
+		if (flags & OPEN_ATOMIC_WRITE_AND_CREATE) {
+			flags &= ~OPEN_ATOMIC_WRITE_AND_CREATE;
+
+			return AsyncFileEIO::waitAndAtomicRename( fsync, filename+".part", filename );
+		}
+
+		return fsync;
+	}
+	Future<int64_t> size() const override { return nextFileSize; }
+	int64_t debugFD() const override { return fd; }
+	std::string getFilename() const override { return filename; }
+	~AsyncFileIOUring() {
+		close(fd);
+	}
+
+	static void launch() {
+		if (ctx.queue.size() && ctx.outstanding < FLOW_KNOBS->MAX_OUTSTANDING - FLOW_KNOBS->MIN_SUBMIT) {
+			ctx.submitMetric = true;
+			
+			double begin = timer_monotonic();
+			if (!ctx.outstanding) ctx.ioStallBegin = begin;
+
+			// IOBlock* toStart[FLOW_KNOBS->MAX_OUTSTANDING];
+			int n = std::min<size_t>(FLOW_KNOBS->MAX_OUTSTANDING - ctx.outstanding, ctx.queue.size());
+
+			int64_t previousTruncateCount = ctx.countPreSubmitTruncate;
+			int64_t previousTruncateBytes = ctx.preSubmitTruncateBytes;
+			int64_t largestTruncate = 0;
+
+			for(int i=0; i<n; i++) {
+				auto io = ctx.queue.top();
+
+				// IOURINGLogBlockEvent(io, OpLogEntry::LAUNCH);
+
+				ctx.queue.pop();
+				// toStart[i] = io;
+
+				struct io_uring_sqe *sqe = io_uring_get_sqe(&ctx.ring);
+				sqe->ioprio = io->prio;
+				if (io->op == IORING_OP_READ) {
+					io_uring_prep_read(sqe, io->fd, io->buf, io->nbytes, io->offset);
+
+				} else {
+					io_uring_prep_write(sqe, io->fd, io->buf, io->nbytes, io->offset);
+				}
+				io_uring_sqe_set_data(sqe, io);
+
+				io->startTime = now();
+
+				if(ctx.ioTimeout > 0) {
+					ctx.appendToRequestList(io);
+				}
+
+				if (io->owner->lastFileSize != io->owner->nextFileSize) {
+					++ctx.countPreSubmitTruncate;
+					int64_t truncateSize = io->owner->nextFileSize - io->owner->lastFileSize;
+					ASSERT(truncateSize > 0);
+					ctx.preSubmitTruncateBytes += truncateSize;
+					largestTruncate = std::max(largestTruncate, truncateSize);
+					io->owner->truncate(io->owner->nextFileSize);
+				}
+			}
+			double truncateComplete = timer_monotonic();
+			// int rc = io_submit( ctx.iocx, n, (linux_iocb**)toStart );
+			/* Finally, submit the request */
+			int rc = io_uring_submit(&ctx.ring); //TODO
+
+			double end = timer_monotonic();
+
+			if(end-begin > FLOW_KNOBS->SLOW_LOOP_CUTOFF) {
+				// ctx.slowAioSubmitMetric->submitDuration = end-truncateComplete;
+				// ctx.slowAioSubmitMetric->truncateDuration = truncateComplete-begin;
+				// ctx.slowAioSubmitMetric->numTruncates = ctx.countPreSubmitTruncate - previousTruncateCount;
+				// ctx.slowAioSubmitMetric->truncateBytes = ctx.preSubmitTruncateBytes - previousTruncateBytes;
+				// ctx.slowAioSubmitMetric->largestTruncate = largestTruncate;
+				// ctx.slowAioSubmitMetric->log();
+
+				if(nondeterministicRandom()->random01() < end-begin) {
+					TraceEvent("SlowIOURINGLaunch")
+						.detail("IOSubmitTime", end-truncateComplete)
+						.detail("TruncateTime", truncateComplete-begin)
+						.detail("TruncateCount", ctx.countPreSubmitTruncate - previousTruncateCount)
+						.detail("TruncateBytes", ctx.preSubmitTruncateBytes - previousTruncateBytes)
+						.detail("LargestTruncate", largestTruncate);
+				}
+			}
+
+			ctx.submitMetric = false;
+			++ctx.countAIOSubmit;
+
+			double elapsed = timer_monotonic() - begin;
+			g_network->networkInfo.metrics.secSquaredSubmit += elapsed*elapsed/2;	
+
+			//TraceEvent("Launched").detail("N", rc).detail("Queued", ctx.queue.size()).detail("Elapsed", elapsed).detail("Outstanding", ctx.outstanding+rc);
+			//printf("launched: %d/%d in %f us (%d outstanding; lowest prio %d)\n", rc, ctx.queue.size(), elapsed*1e6, ctx.outstanding + rc, toStart[n-1]->getTask());
+			if (rc<0) {
+				TraceEvent("IOSubmitEventsFailed").detail("Error Code", -rc).GetLastError();
+				throw io_error();
+				// if (errno == EAGAIN) {
+				// 	rc = 0;
+				// } else {
+				// 	// IOURINGLogBlockEvent(toStart[0], OpLogEntry::COMPLETE, errno ? -errno : -1000000);
+				// 	// Other errors are assumed to represent failure to issue the first I/O in the list
+				// 	toStart[0]->setResult( errno ? -errno : -1000000 );
+				// 	rc = 1;
+				// }
+			} else
+				ctx.outstanding += rc;
+			if (rc != n) {
+				TraceEvent("IOSubmitEventsNotCompleted").detail("Submitted", n).detail("delivered", rc).GetLastError();
+				throw io_error();
+			}
+			// Any unsubmitted I/Os need to be requeued
+			// for(int i=rc; i<n; i++) {
+			// 	// IOURINGLogBlockEvent(toStart[i], OpLogEntry::REQUEUE);
+			// 	ctx.queue.push(toStart[i]);
+			// }
+		}
+	}
+
+	bool failed;
+private:
+	int fd, flags;
+	int64_t lastFileSize, nextFileSize;
+	std::string filename;
+	Int64MetricHandle countFileLogicalWrites;
+	Int64MetricHandle countFileLogicalReads;
+
+	Int64MetricHandle countLogicalWrites;
+	Int64MetricHandle countLogicalReads;
+
+	struct IOBlock : FastAllocated<IOBlock> {
+		void *buf;
+		unsigned nbytes;
+		off_t offset;
+		int op, fd;
+		Promise<int> result;
+		Reference<AsyncFileIOUring> owner;
+		int64_t prio;
+		IOBlock *prev;
+		IOBlock *next;
+		double startTime;
+
+		struct indirect_order_by_priority { bool operator () ( IOBlock* a, IOBlock* b ) { return a->prio < b->prio; } };
+
+		IOBlock(int op, int fd) : prev(nullptr), next(nullptr), startTime(0), op(op), fd(fd) {}
+
+		// TaskPriority getTask() const { return static_cast<TaskPriority>((prio>>32)+1); }
+		TaskPriority getTask() const { return static_cast<TaskPriority>(prio); }
+
+		ACTOR static void deliver( Promise<int> result, bool failed, int r, TaskPriority task ) {
+			wait( delay(0, task) );
+			if (failed) result.sendError(io_timeout());
+			else if (r < 0) result.sendError(io_error());
+			else result.send(r);
+		}
+
+		void setResult( int r ) {
+			if (r<0) {
+				struct stat fst;
+				fstat( fd, &fst );
+
+				errno = -r;
+				TraceEvent("AsyncFileIOUringIOError").GetLastError().detail("Fd", fd).detail("Op", op).detail("Nbytes", nbytes).detail("Offset", offset).detail("Ptr", int64_t(buf))
+					.detail("Size", fst.st_size).detail("Filename", owner->filename);
+			}
+			deliver( result, owner->failed, r, getTask() );
+			delete this;
+		}
+
+		void timeout(bool warnOnly) {
+			TraceEvent(SevWarnAlways, "AsyncFileIOUringTimeout").detail("Fd", fd).detail("Op", op).detail("Nbytes", nbytes).detail("Offset", offset).detail("Ptr", int64_t(buf))
+				.detail("Filename", owner->filename);
+			g_network->setGlobal(INetwork::enASIOTimedOut, (flowGlobalType)true);
+
+			if(!warnOnly)
+				owner->failed = true;
+		}
+	};
+
+	struct Context {
+		io_uring ring; //TODO
+		int evfd;
+		int prio;
+		int outstanding;
+		double ioStallBegin;
+		bool fallocateSupported;
+		bool fallocateZeroSupported;
+		std::priority_queue<IOBlock*, std::vector<IOBlock*>, IOBlock::indirect_order_by_priority> queue;
+		Int64MetricHandle countAIOSubmit;
+		Int64MetricHandle countAIOCollect;
+		Int64MetricHandle submitMetric;
+		
+		double ioTimeout;
+		bool timeoutWarnOnly;
+		IOBlock *submittedRequestList;
+
+		Int64MetricHandle countPreSubmitTruncate;
+		Int64MetricHandle preSubmitTruncateBytes;
+
+		// EventMetricHandle<SlowAioSubmit> slowAioSubmitMetric;
+
+		uint32_t opsIssued;
+		Context() : evfd(-1), outstanding(0), opsIssued(0), ioStallBegin(0), fallocateSupported(true), fallocateZeroSupported(true), submittedRequestList(nullptr) {
+			setIOTimeout(0);
+		}
+
+		void setIOTimeout(double timeout) {
+			ioTimeout = fabs(timeout);
+			timeoutWarnOnly = timeout < 0;
+		}
+
+		void appendToRequestList(IOBlock *io) {
+			ASSERT(!io->next && !io->prev);
+
+			if(submittedRequestList) {
+				io->prev = submittedRequestList->prev;
+				io->prev->next = io;
+
+				submittedRequestList->prev = io;
+				io->next = submittedRequestList;
+			}
+			else {
+				submittedRequestList = io;
+				io->next = io->prev = io;
+			}
+		}
+
+		void removeFromRequestList(IOBlock *io) {
+			if(io->next == nullptr) {
+				ASSERT(io->prev == nullptr);
+				return;
+			}
+
+			ASSERT(io->prev != nullptr);
+
+			if(io == io->next) {
+				ASSERT(io == submittedRequestList && io == io->prev);
+				submittedRequestList = nullptr;
+			}
+			else {
+				io->next->prev = io->prev;
+				io->prev->next = io->next;
+
+				if(submittedRequestList == io) {
+					submittedRequestList = io->next;
+				}
+			}
+
+			io->next = io->prev = nullptr;
+		}
+	};
+	static Context ctx;
+
+	explicit AsyncFileIOUring(int fd, int flags, std::string const& filename) : fd(fd), flags(flags), filename(filename), failed(false) {
+		ASSERT( !FLOW_KNOBS->DISABLE_POSIX_KERNEL_AIO );
+		if( !g_network->isSimulated() ) {
+			countFileLogicalWrites.init(LiteralStringRef("AsyncFile.CountFileLogicalWrites"), filename);
+			countFileLogicalReads.init( LiteralStringRef("AsyncFile.CountFileLogicalReads"), filename);
+			countLogicalWrites.init(LiteralStringRef("AsyncFile.CountLogicalWrites"));
+			countLogicalReads.init( LiteralStringRef("AsyncFile.CountLogicalReads"));
+		}
+	}
+
+	void enqueue( IOBlock* io, const char* op, AsyncFileIOUring* owner ) {
+		ASSERT( int64_t(io->buf) % 4096 == 0 && io->offset % 4096 == 0 && io->nbytes % 4096 == 0 );
+
+		// IOURINGLogBlockEvent(owner->logFile, io, OpLogEntry::START);
+
+		// io->flags |= 1; //TODOOOOO
+		// io->eventfd = ctx.evfd;
+		// io->prio = (int64_t(g_network->getCurrentTask())<<32) - (++ctx.opsIssued);//TODO
+		io->prio = int16_t(g_network->getCurrentTask());
+		//io->prio = - (++ctx.opsIssued);
+		io->owner = Reference<AsyncFileIOUring>::addRef(owner);
+
+		ctx.queue.push(io);
+	}
+
+	static int openFlags(int flags) {
+		int oflags = O_DIRECT | O_CLOEXEC;
+		ASSERT( bool(flags & OPEN_READONLY) != bool(flags & OPEN_READWRITE) );  // readonly xor readwrite
+		if( flags & OPEN_EXCLUSIVE ) oflags |= O_EXCL;
+		if( flags & OPEN_CREATE )    oflags |= O_CREAT;
+		if( flags & OPEN_READONLY )  oflags |= O_RDONLY;
+		if( flags & OPEN_READWRITE ) oflags |= O_RDWR;
+		if( flags & OPEN_ATOMIC_WRITE_AND_CREATE ) oflags |= O_TRUNC;
+		return oflags;
+	}
+
+	ACTOR static void poll( Reference<IEventFD> ev ) {
+		loop {
+			wait(success(ev->read())); //TODO
+
+			wait(delay(0, TaskPriority::DiskIOComplete));
+
+			// linux_ioresult ev[FLOW_KNOBS->MAX_OUTSTANDING];
+			// timespec tm; tm.tv_sec = 0; tm.tv_nsec = 0;
+
+			// int n;
+
+			// loop {
+			// 	n = io_getevents( ctx.iocx, 0, FLOW_KNOBS->MAX_OUTSTANDING, ev, &tm ); //TODO
+			// 	if (n>=0 || errno!=EINTR) break;
+			// }
+
+
+		    struct io_uring_cqe *cqe;
+		    int n = io_uring_wait_cqe(&ctx.ring, &cqe);
+
+			++ctx.countAIOCollect;
+			// printf("io_getevents: collected %d/%d in %f us (%d queued)\n", n, ctx.outstanding, (timer()-before)*1e6, ctx.queue.size());
+			if (n<0 || cqe->res < 0) {
+				// printf("io_getevents failed: %d\n", errno);
+				TraceEvent("IOGetEventsError").GetLastError();
+				throw io_error();
+			}
+			if (n) {
+				double t = timer_monotonic();
+				double elapsed = t - ctx.ioStallBegin;
+				ctx.ioStallBegin = t;
+				g_network->networkInfo.metrics.secSquaredDiskStall += elapsed*elapsed/2;
+			}
+
+			ctx.outstanding -= n;
+
+			if(ctx.ioTimeout > 0) {
+				double currentTime = now();
+				while(ctx.submittedRequestList && currentTime - ctx.submittedRequestList->startTime > ctx.ioTimeout) {
+					ctx.submittedRequestList->timeout(ctx.timeoutWarnOnly);
+					ctx.removeFromRequestList(ctx.submittedRequestList);
+				}
+			}
+
+
+
+		    /* Retrieve user data from CQE */
+		    void* ptr = io_uring_cqe_get_data(cqe);
+		    /* process this request here */
+
+
+			// for(int i=0; i<n; i++) {
+			IOBlock* iob = static_cast<IOBlock*>(ptr); //TODO
+
+			// IOURINGLogBlockEvent(iob, OpLogEntry::COMPLETE, ev[i].result);
+
+			if(ctx.ioTimeout > 0) {
+				ctx.removeFromRequestList(iob);
+			}
+
+			iob->setResult( cqe->res );
+			// }
+
+
+		    /* Mark this completion as seen */
+		    io_uring_cqe_seen(&ctx.ring, cqe);
+		}
+	}
+};
+
+ACTOR Future<Void> runTestOps(Reference<IAsyncFile> f, int numIterations, int fileSize, bool expectedToSucceed) {
+	state void *buf = FastAllocator<4096>::allocate(); // we leak this if there is an error, but that shouldn't be a big deal
+	state int iteration = 0;
+
+	state bool opTimedOut = false;
+
+	for(; iteration < numIterations; ++iteration) {
+		state std::vector<Future<Void>> futures;
+		state int numOps = deterministicRandom()->randomInt(1, 20);
+		for(; numOps > 0; --numOps) {
+			if(deterministicRandom()->coinflip()) {
+				futures.push_back(success(f->read(buf, 4096, deterministicRandom()->randomInt(0, fileSize)/4096*4096)));
+			}
+			else {
+				futures.push_back(f->write(buf, 4096, deterministicRandom()->randomInt(0, fileSize)/4096*4096));
+			}
+		}
+		state int fIndex = 0;
+		for(; fIndex < futures.size(); ++fIndex) {
+			try {
+				wait(futures[fIndex]);
+			}
+			catch(Error &e) {
+				ASSERT(!expectedToSucceed);
+				ASSERT(e.code() == error_code_io_timeout);
+				opTimedOut = true;
+			}
+		}
+
+		try {
+			wait(f->sync() && delay(0.1));
+			ASSERT(expectedToSucceed);
+		}
+		catch(Error &e) {
+			ASSERT(!expectedToSucceed && e.code() == error_code_io_timeout);
+		}
+	}
+	
+	FastAllocator<4096>::release(buf);
+
+	ASSERT(expectedToSucceed || opTimedOut);
+	return Void();
+}
+
+TEST_CASE("/fdbrpc/AsyncFileIOUring/RequestList") {
+	// This test does nothing in simulation because simulation doesn't support AsyncFileIOUring
+	if (!g_network->isSimulated()) {
+		state Reference<IAsyncFile> f;
+		try {
+			Reference<IAsyncFile> f_ = wait(AsyncFileIOUring::open(
+			    "/tmp/__IOURING_TEST_FILE__",
+			    IAsyncFile::OPEN_UNBUFFERED | IAsyncFile::OPEN_READWRITE | IAsyncFile::OPEN_CREATE, 0666, nullptr));
+			f = f_;
+			state int fileSize = 2 << 27; // ~100MB
+			wait(f->truncate(fileSize));
+
+			// Test that the request list works as intended with default timeout
+			AsyncFileIOUring::setTimeout(0.0);
+			wait(runTestOps(f, 100, fileSize, true));
+			ASSERT(!((AsyncFileIOUring*)f.getPtr())->failed);
+
+			// Test that the request list works as intended with long timeout
+			AsyncFileIOUring::setTimeout(20.0);
+			wait(runTestOps(f, 100, fileSize, true));
+			ASSERT(!((AsyncFileIOUring*)f.getPtr())->failed);
+
+			// Test that requests timeout correctly
+			AsyncFileIOUring::setTimeout(0.0001);
+			wait(runTestOps(f, 10, fileSize, false));
+			ASSERT(((AsyncFileIOUring*)f.getPtr())->failed);
+		} catch (Error& e) {
+			state Error err = e;
+			if(f) {
+				wait(AsyncFileEIO::deleteFile(f->getFilename(), true));
+			}
+			throw err;
+		}
+
+		wait(AsyncFileEIO::deleteFile(f->getFilename(), true));
+	}
+
+	return Void();
+}
+
+AsyncFileIOUring::Context AsyncFileIOUring::ctx;
+
+#include "flow/unactorcompiler.h"
+#endif 
+#endif

--- a/fdbrpc/CMakeLists.txt
+++ b/fdbrpc/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(FDBRPC_SRCS
   AsyncFileCached.actor.h
   AsyncFileEIO.actor.h
+  AsyncFileIOUring.actor.h
   AsyncFileKAIO.actor.h
   AsyncFileNonDurable.actor.h
   AsyncFileReadAhead.actor.h
@@ -31,7 +32,11 @@ set(FDBRPC_SRCS
 
 set(FDBRPC_THIRD_PARTY_SRCS
   libcoroutine/Common.c
-  libcoroutine/Coro.c)
+  libcoroutine/Coro.c
+  liburing/queue.c
+  liburing/register.c
+  liburing/setup.c
+  liburing/syscall.c)
 
 if(APPLE)
   list(APPEND FDBRPC_THIRD_PARTY_SRCS libcoroutine/asm.S)
@@ -66,5 +71,7 @@ add_flow_target(STATIC_LIBRARY NAME fdbrpc
   SRCS ${FDBRPC_SRCS}
   DISABLE_ACTOR_DIAGNOSTICS ${FDBRPC_SRCS_DISABLE_ACTOR_DIAGNOSTICS})
 target_include_directories(fdbrpc PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/libeio)
+target_include_directories(fdbrpc PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/liburing/include)
+target_include_directories(thirdparty PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/liburing/include)
 target_link_libraries(fdbrpc PRIVATE thirdparty)
 target_link_libraries(fdbrpc PUBLIC flow)

--- a/fdbrpc/Net2FileSystem.cpp
+++ b/fdbrpc/Net2FileSystem.cpp
@@ -34,7 +34,7 @@
 #include "fdbrpc/AsyncFileCached.actor.h"
 #include "fdbrpc/AsyncFileEIO.actor.h"
 #include "fdbrpc/AsyncFileWinASIO.actor.h"
-#include "fdbrpc/AsyncFileKAIO.actor.h"
+#include "fdbrpc/AsyncFileIOUring.actor.h"
 #include "flow/AsioReactor.h"
 #include "flow/Platform.h"
 #include "fdbrpc/AsyncFileWriteChecker.h"
@@ -65,7 +65,7 @@ Future< Reference<class IAsyncFile> > Net2FileSystem::open( std::string filename
 	// EIO.
 	if ((flags & IAsyncFile::OPEN_UNBUFFERED) && !(flags & IAsyncFile::OPEN_NO_AIO) &&
 	    !FLOW_KNOBS->DISABLE_POSIX_KERNEL_AIO)
-		f = AsyncFileKAIO::open(filename, flags, mode, nullptr);
+		f = AsyncFileIOUring::open(filename, flags, mode, nullptr);
 	else
 #endif
 	f = Net2AsyncFile::open(filename, flags, mode, static_cast<boost::asio::io_service*> ((void*) g_network->global(INetwork::enASIOService)));
@@ -94,7 +94,7 @@ Net2FileSystem::Net2FileSystem(double ioTimeout, std::string fileSystemPath)
 	Net2AsyncFile::init();
 #ifdef __linux__
 	if (!FLOW_KNOBS->DISABLE_POSIX_KERNEL_AIO)
-		AsyncFileKAIO::init( Reference<IEventFD>(N2::ASIOReactor::getEventFD()), ioTimeout );
+		AsyncFileIOUring::init( Reference<IEventFD>(N2::ASIOReactor::getEventFD()), ioTimeout );
 
 	if (fileSystemPath.empty()) {
 		checkFileSystem = false;

--- a/fdbrpc/liburing/include/liburing.h
+++ b/fdbrpc/liburing/include/liburing.h
@@ -1,0 +1,613 @@
+/* SPDX-License-Identifier: MIT */
+#ifndef LIB_URING_H
+#define LIB_URING_H
+
+#include <sys/socket.h>
+#include <sys/uio.h>
+#include <sys/stat.h>
+#include <errno.h>
+#include <signal.h>
+#include <stdbool.h>
+#include <inttypes.h>
+#include <time.h>
+#include <linux/swab.h>
+#include "liburing/compat.h"
+#include "liburing/io_uring.h"
+#include "liburing/barrier.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Library interface to io_uring
+ */
+struct io_uring_sq {
+	unsigned *khead;
+	unsigned *ktail;
+	unsigned *kring_mask;
+	unsigned *kring_entries;
+	unsigned *kflags;
+	unsigned *kdropped;
+	unsigned *array;
+	struct io_uring_sqe *sqes;
+
+	unsigned sqe_head;
+	unsigned sqe_tail;
+
+	size_t ring_sz;
+	void *ring_ptr;
+
+	unsigned pad[4];
+};
+
+struct io_uring_cq {
+	unsigned *khead;
+	unsigned *ktail;
+	unsigned *kring_mask;
+	unsigned *kring_entries;
+	unsigned *kflags;
+	unsigned *koverflow;
+	struct io_uring_cqe *cqes;
+
+	size_t ring_sz;
+	void *ring_ptr;
+
+	unsigned pad[4];
+};
+
+struct io_uring {
+	struct io_uring_sq sq;
+	struct io_uring_cq cq;
+	unsigned flags;
+	int ring_fd;
+
+	unsigned features;
+	unsigned pad[3];
+};
+
+/*
+ * Library interface
+ */
+
+/*
+ * return an allocated io_uring_probe structure, or NULL if probe fails (for
+ * example, if it is not available). The caller is responsible for freeing it
+ */
+extern struct io_uring_probe *io_uring_get_probe_ring(struct io_uring *ring);
+/* same as io_uring_get_probe_ring, but takes care of ring init and teardown */
+extern struct io_uring_probe *io_uring_get_probe(void);
+
+/*
+ * frees a probe allocated through io_uring_get_probe() or
+ * io_uring_get_probe_ring()
+ */
+extern void io_uring_free_probe(struct io_uring_probe *probe);
+
+static inline int io_uring_opcode_supported(struct io_uring_probe *p, int op)
+{
+	if (op > p->last_op)
+		return 0;
+	return (p->ops[op].flags & IO_URING_OP_SUPPORTED) != 0;
+}
+
+extern int io_uring_queue_init_params(unsigned entries, struct io_uring *ring,
+	struct io_uring_params *p);
+extern int io_uring_queue_init(unsigned entries, struct io_uring *ring,
+	unsigned flags);
+extern int io_uring_queue_mmap(int fd, struct io_uring_params *p,
+	struct io_uring *ring);
+extern int io_uring_ring_dontfork(struct io_uring *ring);
+extern void io_uring_queue_exit(struct io_uring *ring);
+unsigned io_uring_peek_batch_cqe(struct io_uring *ring,
+	struct io_uring_cqe **cqes, unsigned count);
+extern int io_uring_wait_cqes(struct io_uring *ring,
+	struct io_uring_cqe **cqe_ptr, unsigned wait_nr,
+	struct __kernel_timespec *ts, sigset_t *sigmask);
+extern int io_uring_wait_cqe_timeout(struct io_uring *ring,
+	struct io_uring_cqe **cqe_ptr, struct __kernel_timespec *ts);
+extern int io_uring_submit(struct io_uring *ring);
+extern int io_uring_submit_and_wait(struct io_uring *ring, unsigned wait_nr);
+extern struct io_uring_sqe *io_uring_get_sqe(struct io_uring *ring);
+
+extern int io_uring_register_buffers(struct io_uring *ring,
+					const struct iovec *iovecs,
+					unsigned nr_iovecs);
+extern int io_uring_unregister_buffers(struct io_uring *ring);
+extern int io_uring_register_files(struct io_uring *ring, const int *files,
+					unsigned nr_files);
+extern int io_uring_unregister_files(struct io_uring *ring);
+extern int io_uring_register_files_update(struct io_uring *ring, unsigned off,
+					int *files, unsigned nr_files);
+extern int io_uring_register_eventfd(struct io_uring *ring, int fd);
+extern int io_uring_register_eventfd_async(struct io_uring *ring, int fd);
+extern int io_uring_unregister_eventfd(struct io_uring *ring);
+extern int io_uring_register_probe(struct io_uring *ring,
+					struct io_uring_probe *p, unsigned nr);
+extern int io_uring_register_personality(struct io_uring *ring);
+extern int io_uring_unregister_personality(struct io_uring *ring, int id);
+extern int io_uring_register_restrictions(struct io_uring *ring,
+					  struct io_uring_restriction *res,
+					  unsigned int nr_res);
+extern int io_uring_enable_rings(struct io_uring *ring);
+extern int __io_uring_sqring_wait(struct io_uring *ring);
+
+/*
+ * Helper for the peek/wait single cqe functions. Exported because of that,
+ * but probably shouldn't be used directly in an application.
+ */
+extern int __io_uring_get_cqe(struct io_uring *ring,
+			      struct io_uring_cqe **cqe_ptr, unsigned submit,
+			      unsigned wait_nr, sigset_t *sigmask);
+
+#define LIBURING_UDATA_TIMEOUT	((__u64) -1)
+
+#define io_uring_for_each_cqe(ring, head, cqe)				\
+	/*								\
+	 * io_uring_smp_load_acquire() enforces the order of tail	\
+	 * and CQE reads.						\
+	 */								\
+	for (head = *(ring)->cq.khead;					\
+	     (cqe = (head != io_uring_smp_load_acquire((ring)->cq.ktail) ? \
+		&(ring)->cq.cqes[head & (*(ring)->cq.kring_mask)] : NULL)); \
+	     head++)							\
+
+/*
+ * Must be called after io_uring_for_each_cqe()
+ */
+static inline void io_uring_cq_advance(struct io_uring *ring,
+				       unsigned nr)
+{
+	if (nr) {
+		struct io_uring_cq *cq = &ring->cq;
+
+		/*
+		 * Ensure that the kernel only sees the new value of the head
+		 * index after the CQEs have been read.
+		 */
+		io_uring_smp_store_release(cq->khead, *cq->khead + nr);
+	}
+}
+
+/*
+ * Must be called after io_uring_{peek,wait}_cqe() after the cqe has
+ * been processed by the application.
+ */
+static inline void io_uring_cqe_seen(struct io_uring *ring,
+				     struct io_uring_cqe *cqe)
+{
+	if (cqe)
+		io_uring_cq_advance(ring, 1);
+}
+
+/*
+ * Command prep helpers
+ */
+static inline void io_uring_sqe_set_data(struct io_uring_sqe *sqe, void *data)
+{
+	sqe->user_data = (unsigned long) data;
+}
+
+static inline void *io_uring_cqe_get_data(const struct io_uring_cqe *cqe)
+{
+	return (void *) (uintptr_t) cqe->user_data;
+}
+
+static inline void io_uring_sqe_set_flags(struct io_uring_sqe *sqe,
+					  unsigned flags)
+{
+	sqe->flags = flags;
+}
+
+static inline void io_uring_prep_rw(int op, struct io_uring_sqe *sqe, int fd,
+				    const void *addr, unsigned len,
+				    __u64 offset)
+{
+	sqe->opcode = op;
+	sqe->flags = 0;
+	sqe->ioprio = 0;
+	sqe->fd = fd;
+	sqe->off = offset;
+	sqe->addr = (unsigned long) addr;
+	sqe->len = len;
+	sqe->rw_flags = 0;
+	sqe->user_data = 0;
+	sqe->__pad2[0] = sqe->__pad2[1] = sqe->__pad2[2] = 0;
+}
+
+static inline void io_uring_prep_splice(struct io_uring_sqe *sqe,
+					int fd_in, int64_t off_in,
+					int fd_out, int64_t off_out,
+					unsigned int nbytes,
+					unsigned int splice_flags)
+{
+	io_uring_prep_rw(IORING_OP_SPLICE, sqe, fd_out, NULL, nbytes, off_out);
+	sqe->splice_off_in = off_in;
+	sqe->splice_fd_in = fd_in;
+	sqe->splice_flags = splice_flags;
+}
+
+static inline void io_uring_prep_tee(struct io_uring_sqe *sqe,
+				     int fd_in, int fd_out,
+				     unsigned int nbytes,
+				     unsigned int splice_flags)
+{
+	io_uring_prep_rw(IORING_OP_TEE, sqe, fd_out, NULL, nbytes, 0);
+	sqe->splice_off_in = 0;
+	sqe->splice_fd_in = fd_in;
+	sqe->splice_flags = splice_flags;
+}
+
+static inline void io_uring_prep_readv(struct io_uring_sqe *sqe, int fd,
+				       const struct iovec *iovecs,
+				       unsigned nr_vecs, off_t offset)
+{
+	io_uring_prep_rw(IORING_OP_READV, sqe, fd, iovecs, nr_vecs, offset);
+}
+
+static inline void io_uring_prep_read_fixed(struct io_uring_sqe *sqe, int fd,
+					    void *buf, unsigned nbytes,
+					    off_t offset, int buf_index)
+{
+	io_uring_prep_rw(IORING_OP_READ_FIXED, sqe, fd, buf, nbytes, offset);
+	sqe->buf_index = buf_index;
+}
+
+static inline void io_uring_prep_writev(struct io_uring_sqe *sqe, int fd,
+					const struct iovec *iovecs,
+					unsigned nr_vecs, off_t offset)
+{
+	io_uring_prep_rw(IORING_OP_WRITEV, sqe, fd, iovecs, nr_vecs, offset);
+}
+
+static inline void io_uring_prep_write_fixed(struct io_uring_sqe *sqe, int fd,
+					     const void *buf, unsigned nbytes,
+					     off_t offset, int buf_index)
+{
+	io_uring_prep_rw(IORING_OP_WRITE_FIXED, sqe, fd, buf, nbytes, offset);
+	sqe->buf_index = buf_index;
+}
+
+static inline void io_uring_prep_recvmsg(struct io_uring_sqe *sqe, int fd,
+					 struct msghdr *msg, unsigned flags)
+{
+	io_uring_prep_rw(IORING_OP_RECVMSG, sqe, fd, msg, 1, 0);
+	sqe->msg_flags = flags;
+}
+
+static inline void io_uring_prep_sendmsg(struct io_uring_sqe *sqe, int fd,
+					 const struct msghdr *msg, unsigned flags)
+{
+	io_uring_prep_rw(IORING_OP_SENDMSG, sqe, fd, msg, 1, 0);
+	sqe->msg_flags = flags;
+}
+
+static inline void io_uring_prep_poll_add(struct io_uring_sqe *sqe, int fd,
+					  unsigned poll_mask)
+{
+	io_uring_prep_rw(IORING_OP_POLL_ADD, sqe, fd, NULL, 0, 0);
+#if __BYTE_ORDER == __BIG_ENDIAN
+	poll_mask = __swahw32(poll_mask);
+#endif
+	sqe->poll32_events = poll_mask;
+}
+
+static inline void io_uring_prep_poll_remove(struct io_uring_sqe *sqe,
+					     void *user_data)
+{
+	io_uring_prep_rw(IORING_OP_POLL_REMOVE, sqe, -1, user_data, 0, 0);
+}
+
+static inline void io_uring_prep_fsync(struct io_uring_sqe *sqe, int fd,
+				       unsigned fsync_flags)
+{
+	io_uring_prep_rw(IORING_OP_FSYNC, sqe, fd, NULL, 0, 0);
+	sqe->fsync_flags = fsync_flags;
+}
+
+static inline void io_uring_prep_nop(struct io_uring_sqe *sqe)
+{
+	io_uring_prep_rw(IORING_OP_NOP, sqe, -1, NULL, 0, 0);
+}
+
+static inline void io_uring_prep_timeout(struct io_uring_sqe *sqe,
+					 struct __kernel_timespec *ts,
+					 unsigned count, unsigned flags)
+{
+	io_uring_prep_rw(IORING_OP_TIMEOUT, sqe, -1, ts, 1, count);
+	sqe->timeout_flags = flags;
+}
+
+static inline void io_uring_prep_timeout_remove(struct io_uring_sqe *sqe,
+						__u64 user_data, unsigned flags)
+{
+	io_uring_prep_rw(IORING_OP_TIMEOUT_REMOVE, sqe, -1,
+				(void *)(unsigned long)user_data, 0, 0);
+	sqe->timeout_flags = flags;
+}
+
+static inline void io_uring_prep_accept(struct io_uring_sqe *sqe, int fd,
+					struct sockaddr *addr,
+					socklen_t *addrlen, int flags)
+{
+	io_uring_prep_rw(IORING_OP_ACCEPT, sqe, fd, addr, 0,
+				(__u64) (unsigned long) addrlen);
+	sqe->accept_flags = flags;
+}
+
+static inline void io_uring_prep_cancel(struct io_uring_sqe *sqe, void *user_data,
+					int flags)
+{
+	io_uring_prep_rw(IORING_OP_ASYNC_CANCEL, sqe, -1, user_data, 0, 0);
+	sqe->cancel_flags = flags;
+}
+
+static inline void io_uring_prep_link_timeout(struct io_uring_sqe *sqe,
+					      struct __kernel_timespec *ts,
+					      unsigned flags)
+{
+	io_uring_prep_rw(IORING_OP_LINK_TIMEOUT, sqe, -1, ts, 1, 0);
+	sqe->timeout_flags = flags;
+}
+
+static inline void io_uring_prep_connect(struct io_uring_sqe *sqe, int fd,
+					 const struct sockaddr *addr,
+					 socklen_t addrlen)
+{
+	io_uring_prep_rw(IORING_OP_CONNECT, sqe, fd, addr, 0, addrlen);
+}
+
+static inline void io_uring_prep_files_update(struct io_uring_sqe *sqe,
+					      int *fds, unsigned nr_fds,
+					      int offset)
+{
+	io_uring_prep_rw(IORING_OP_FILES_UPDATE, sqe, -1, fds, nr_fds, offset);
+}
+
+static inline void io_uring_prep_fallocate(struct io_uring_sqe *sqe, int fd,
+					   int mode, off_t offset, off_t len)
+{
+
+	io_uring_prep_rw(IORING_OP_FALLOCATE, sqe, fd,
+			(const uintptr_t *) (unsigned long) len, mode, offset);
+}
+
+static inline void io_uring_prep_openat(struct io_uring_sqe *sqe, int dfd,
+					const char *path, int flags, mode_t mode)
+{
+	io_uring_prep_rw(IORING_OP_OPENAT, sqe, dfd, path, mode, 0);
+	sqe->open_flags = flags;
+}
+
+static inline void io_uring_prep_close(struct io_uring_sqe *sqe, int fd)
+{
+	io_uring_prep_rw(IORING_OP_CLOSE, sqe, fd, NULL, 0, 0);
+}
+
+static inline void io_uring_prep_read(struct io_uring_sqe *sqe, int fd,
+				      void *buf, unsigned nbytes, off_t offset)
+{
+	io_uring_prep_rw(IORING_OP_READ, sqe, fd, buf, nbytes, offset);
+}
+
+static inline void io_uring_prep_write(struct io_uring_sqe *sqe, int fd,
+				       const void *buf, unsigned nbytes, off_t offset)
+{
+	io_uring_prep_rw(IORING_OP_WRITE, sqe, fd, buf, nbytes, offset);
+}
+
+struct statx;
+static inline void io_uring_prep_statx(struct io_uring_sqe *sqe, int dfd,
+				const char *path, int flags, unsigned mask,
+				struct statx *statxbuf)
+{
+	io_uring_prep_rw(IORING_OP_STATX, sqe, dfd, path, mask,
+				(__u64) (unsigned long) statxbuf);
+	sqe->statx_flags = flags;
+}
+
+static inline void io_uring_prep_fadvise(struct io_uring_sqe *sqe, int fd,
+					 off_t offset, off_t len, int advice)
+{
+	io_uring_prep_rw(IORING_OP_FADVISE, sqe, fd, NULL, len, offset);
+	sqe->fadvise_advice = advice;
+}
+
+static inline void io_uring_prep_madvise(struct io_uring_sqe *sqe, void *addr,
+					 off_t length, int advice)
+{
+	io_uring_prep_rw(IORING_OP_MADVISE, sqe, -1, addr, length, 0);
+	sqe->fadvise_advice = advice;
+}
+
+static inline void io_uring_prep_send(struct io_uring_sqe *sqe, int sockfd,
+				      const void *buf, size_t len, int flags)
+{
+	io_uring_prep_rw(IORING_OP_SEND, sqe, sockfd, buf, len, 0);
+	sqe->msg_flags = flags;
+}
+
+static inline void io_uring_prep_recv(struct io_uring_sqe *sqe, int sockfd,
+				      void *buf, size_t len, int flags)
+{
+	io_uring_prep_rw(IORING_OP_RECV, sqe, sockfd, buf, len, 0);
+	sqe->msg_flags = flags;
+}
+
+static inline void io_uring_prep_openat2(struct io_uring_sqe *sqe, int dfd,
+					const char *path, struct open_how *how)
+{
+	io_uring_prep_rw(IORING_OP_OPENAT2, sqe, dfd, path, sizeof(*how),
+				(uint64_t) (uintptr_t) how);
+}
+
+struct epoll_event;
+static inline void io_uring_prep_epoll_ctl(struct io_uring_sqe *sqe, int epfd,
+					   int fd, int op,
+					   struct epoll_event *ev)
+{
+	io_uring_prep_rw(IORING_OP_EPOLL_CTL, sqe, epfd, ev, op, fd);
+}
+
+static inline void io_uring_prep_provide_buffers(struct io_uring_sqe *sqe,
+						 void *addr, int len, int nr,
+						 int bgid, int bid)
+{
+	io_uring_prep_rw(IORING_OP_PROVIDE_BUFFERS, sqe, nr, addr, len, bid);
+	sqe->buf_group = bgid;
+}
+
+static inline void io_uring_prep_remove_buffers(struct io_uring_sqe *sqe,
+						int nr, int bgid)
+{
+	io_uring_prep_rw(IORING_OP_REMOVE_BUFFERS, sqe, nr, NULL, 0, 0);
+	sqe->buf_group = bgid;
+}
+
+static inline void io_uring_prep_shutdown(struct io_uring_sqe *sqe, int fd,
+					  int how)
+{
+	io_uring_prep_rw(IORING_OP_SHUTDOWN, sqe, fd, NULL, how, 0);
+}
+
+static inline void io_uring_prep_unlinkat(struct io_uring_sqe *sqe, int dfd,
+					  const char *path, int flags)
+{
+	io_uring_prep_rw(IORING_OP_UNLINKAT, sqe, dfd, path, 0, 0);
+	sqe->unlink_flags = flags;
+}
+
+static inline void io_uring_prep_renameat(struct io_uring_sqe *sqe, int olddfd,
+					  const char *oldpath, int newdfd,
+					  const char *newpath, int flags)
+{
+	io_uring_prep_rw(IORING_OP_RENAMEAT, sqe, olddfd, oldpath, newdfd,
+				(uint64_t) (uintptr_t) newpath);
+	sqe->rename_flags = flags;
+}
+
+/*
+ * Returns number of unconsumed (if SQPOLL) or unsubmitted entries exist in
+ * the SQ ring
+ */
+static inline unsigned io_uring_sq_ready(struct io_uring *ring)
+{
+	/*
+	 * Without a barrier, we could miss an update and think the SQ wasn't ready.
+	 * We don't need the load acquire for non-SQPOLL since then we drive updates.
+	 */
+	if (ring->flags & IORING_SETUP_SQPOLL)
+		return ring->sq.sqe_tail - io_uring_smp_load_acquire(ring->sq.khead);
+
+	/* always use real head, to avoid losing sync for short submit */
+	return ring->sq.sqe_tail - *ring->sq.khead;
+}
+
+/*
+ * Returns how much space is left in the SQ ring.
+ */
+static inline unsigned io_uring_sq_space_left(struct io_uring *ring)
+{
+	return *ring->sq.kring_entries - io_uring_sq_ready(ring);
+}
+
+/*
+ * Only applicable when using SQPOLL - allows the caller to wait for space
+ * to free up in the SQ ring, which happens when the kernel side thread has
+ * consumed one or more entries. If the SQ ring is currently non-full, no
+ * action is taken. Note: may return -EINVAL if the kernel doesn't support
+ * this feature.
+ */
+static inline int io_uring_sqring_wait(struct io_uring *ring)
+{
+	if (!(ring->flags & IORING_SETUP_SQPOLL))
+		return 0;
+	if (io_uring_sq_space_left(ring))
+		return 0;
+
+	return __io_uring_sqring_wait(ring);
+}
+
+/*
+ * Returns how many unconsumed entries are ready in the CQ ring
+ */
+static inline unsigned io_uring_cq_ready(struct io_uring *ring)
+{
+	return io_uring_smp_load_acquire(ring->cq.ktail) - *ring->cq.khead;
+}
+
+/*
+ * Returns true if the eventfd notification is currently enabled
+ */
+static inline bool io_uring_cq_eventfd_enabled(struct io_uring *ring)
+{
+	if (!ring->cq.kflags)
+		return true;
+
+	return !(*ring->cq.kflags & IORING_CQ_EVENTFD_DISABLED);
+}
+
+/*
+ * Toggle eventfd notification on or off, if an eventfd is registered with
+ * the ring.
+ */
+static inline int io_uring_cq_eventfd_toggle(struct io_uring *ring,
+					     bool enabled)
+{
+	uint32_t flags;
+
+	if (!!enabled == io_uring_cq_eventfd_enabled(ring))
+		return 0;
+
+	if (!ring->cq.kflags)
+		return -EOPNOTSUPP;
+
+	flags = *ring->cq.kflags;
+
+	if (enabled)
+		flags &= ~IORING_CQ_EVENTFD_DISABLED;
+	else
+		flags |= IORING_CQ_EVENTFD_DISABLED;
+
+	IO_URING_WRITE_ONCE(*ring->cq.kflags, flags);
+
+	return 0;
+}
+
+/*
+ * Return an IO completion, waiting for 'wait_nr' completions if one isn't
+ * readily available. Returns 0 with cqe_ptr filled in on success, -errno on
+ * failure.
+ */
+static inline int io_uring_wait_cqe_nr(struct io_uring *ring,
+				      struct io_uring_cqe **cqe_ptr,
+				      unsigned wait_nr)
+{
+	return __io_uring_get_cqe(ring, cqe_ptr, 0, wait_nr, NULL);
+}
+
+/*
+ * Return an IO completion, if one is readily available. Returns 0 with
+ * cqe_ptr filled in on success, -errno on failure.
+ */
+static inline int io_uring_peek_cqe(struct io_uring *ring,
+				    struct io_uring_cqe **cqe_ptr)
+{
+	return io_uring_wait_cqe_nr(ring, cqe_ptr, 0);
+}
+
+/*
+ * Return an IO completion, waiting for it if necessary. Returns 0 with
+ * cqe_ptr filled in on success, -errno on failure.
+ */
+static inline int io_uring_wait_cqe(struct io_uring *ring,
+				    struct io_uring_cqe **cqe_ptr)
+{
+	return io_uring_wait_cqe_nr(ring, cqe_ptr, 1);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/fdbrpc/liburing/include/liburing/barrier.h
+++ b/fdbrpc/liburing/include/liburing/barrier.h
@@ -1,0 +1,73 @@
+/* SPDX-License-Identifier: MIT */
+#ifndef LIBURING_BARRIER_H
+#define LIBURING_BARRIER_H
+
+/*
+From the kernel documentation file refcount-vs-atomic.rst:
+
+A RELEASE memory ordering guarantees that all prior loads and
+stores (all po-earlier instructions) on the same CPU are completed
+before the operation. It also guarantees that all po-earlier
+stores on the same CPU and all propagated stores from other CPUs
+must propagate to all other CPUs before the release operation
+(A-cumulative property). This is implemented using
+:c:func:`smp_store_release`.
+
+An ACQUIRE memory ordering guarantees that all post loads and
+stores (all po-later instructions) on the same CPU are
+completed after the acquire operation. It also guarantees that all
+po-later stores on the same CPU must propagate to all other CPUs
+after the acquire operation executes. This is implemented using
+:c:func:`smp_acquire__after_ctrl_dep`.
+*/
+
+#ifdef __cplusplus
+#include <atomic>
+
+template <typename T>
+static inline void IO_URING_WRITE_ONCE(T &var, T val)
+{
+	std::atomic_store_explicit(reinterpret_cast<std::atomic<T> *>(&var),
+				   val, std::memory_order_relaxed);
+}
+template <typename T>
+static inline T IO_URING_READ_ONCE(const T &var)
+{
+	return std::atomic_load_explicit(
+		reinterpret_cast<const std::atomic<T> *>(&var),
+		std::memory_order_relaxed);
+}
+
+template <typename T>
+static inline void io_uring_smp_store_release(T *p, T v)
+{
+	std::atomic_store_explicit(reinterpret_cast<std::atomic<T> *>(p), v,
+				   std::memory_order_release);
+}
+
+template <typename T>
+static inline T io_uring_smp_load_acquire(const T *p)
+{
+	return std::atomic_load_explicit(
+		reinterpret_cast<const std::atomic<T> *>(p),
+		std::memory_order_acquire);
+}
+#else
+#include <stdatomic.h>
+
+#define IO_URING_WRITE_ONCE(var, val)				\
+	atomic_store_explicit((_Atomic __typeof__(var) *)&(var),	\
+			      (val), memory_order_relaxed)
+#define IO_URING_READ_ONCE(var)					\
+	atomic_load_explicit((_Atomic __typeof__(var) *)&(var),	\
+			     memory_order_relaxed)
+
+#define io_uring_smp_store_release(p, v)			\
+	atomic_store_explicit((_Atomic __typeof__(*(p)) *)(p), (v), \
+			      memory_order_release)
+#define io_uring_smp_load_acquire(p)				\
+	atomic_load_explicit((_Atomic __typeof__(*(p)) *)(p),	\
+			     memory_order_acquire)
+#endif
+
+#endif /* defined(LIBURING_BARRIER_H) */

--- a/fdbrpc/liburing/include/liburing/compat.h
+++ b/fdbrpc/liburing/include/liburing/compat.h
@@ -1,0 +1,22 @@
+/* SPDX-License-Identifier: MIT */
+#ifndef LIBURING_COMPAT_H
+#define LIBURING_COMPAT_H
+
+typedef int __kernel_rwf_t;
+
+#include <stdint.h>
+
+struct __kernel_timespec {
+	int64_t		tv_sec;
+	long long	tv_nsec;
+};
+
+#include <inttypes.h>
+
+struct open_how {
+	uint64_t	flags;
+	uint64_t	mode;
+	uint64_t	resolve;
+};
+
+#endif

--- a/fdbrpc/liburing/include/liburing/io_uring.h
+++ b/fdbrpc/liburing/include/liburing/io_uring.h
@@ -1,0 +1,355 @@
+/* SPDX-License-Identifier: (GPL-2.0 WITH Linux-syscall-note) OR MIT */
+/*
+ * Header file for the io_uring interface.
+ *
+ * Copyright (C) 2019 Jens Axboe
+ * Copyright (C) 2019 Christoph Hellwig
+ */
+#ifndef LINUX_IO_URING_H
+#define LINUX_IO_URING_H
+
+#include <linux/fs.h>
+#include <linux/types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * IO submission data structure (Submission Queue Entry)
+ */
+struct io_uring_sqe {
+	__u8	opcode;		/* type of operation for this sqe */
+	__u8	flags;		/* IOSQE_ flags */
+	__u16	ioprio;		/* ioprio for the request */
+	__s32	fd;		/* file descriptor to do IO on */
+	union {
+		__u64	off;	/* offset into file */
+		__u64	addr2;
+	};
+	union {
+		__u64	addr;	/* pointer to buffer or iovecs */
+		__u64	splice_off_in;
+	};
+	__u32	len;		/* buffer size or number of iovecs */
+	union {
+		__kernel_rwf_t	rw_flags;
+		__u32		fsync_flags;
+		__u16		poll_events;	/* compatibility */
+		__u32		poll32_events;	/* word-reversed for BE */
+		__u32		sync_range_flags;
+		__u32		msg_flags;
+		__u32		timeout_flags;
+		__u32		accept_flags;
+		__u32		cancel_flags;
+		__u32		open_flags;
+		__u32		statx_flags;
+		__u32		fadvise_advice;
+		__u32		splice_flags;
+		__u32		rename_flags;
+		__u32		unlink_flags;
+	};
+	__u64	user_data;	/* data to be passed back at completion time */
+	union {
+		struct {
+			/* pack this to avoid bogus arm OABI complaints */
+			union {
+				/* index into fixed buffers, if used */
+				__u16	buf_index;
+				/* for grouped buffer selection */
+				__u16	buf_group;
+			} __attribute__((packed));
+			/* personality to use, if used */
+			__u16	personality;
+			__s32	splice_fd_in;
+		};
+		__u64	__pad2[3];
+	};
+};
+
+enum {
+	IOSQE_FIXED_FILE_BIT,
+	IOSQE_IO_DRAIN_BIT,
+	IOSQE_IO_LINK_BIT,
+	IOSQE_IO_HARDLINK_BIT,
+	IOSQE_ASYNC_BIT,
+	IOSQE_BUFFER_SELECT_BIT,
+};
+
+/*
+ * sqe->flags
+ */
+/* use fixed fileset */
+#define IOSQE_FIXED_FILE	(1U << IOSQE_FIXED_FILE_BIT)
+/* issue after inflight IO */
+#define IOSQE_IO_DRAIN		(1U << IOSQE_IO_DRAIN_BIT)
+/* links next sqe */
+#define IOSQE_IO_LINK		(1U << IOSQE_IO_LINK_BIT)
+/* like LINK, but stronger */
+#define IOSQE_IO_HARDLINK	(1U << IOSQE_IO_HARDLINK_BIT)
+/* always go async */
+#define IOSQE_ASYNC		(1U << IOSQE_ASYNC_BIT)
+/* select buffer from sqe->buf_group */
+#define IOSQE_BUFFER_SELECT	(1U << IOSQE_BUFFER_SELECT_BIT)
+
+/*
+ * io_uring_setup() flags
+ */
+#define IORING_SETUP_IOPOLL	(1U << 0)	/* io_context is polled */
+#define IORING_SETUP_SQPOLL	(1U << 1)	/* SQ poll thread */
+#define IORING_SETUP_SQ_AFF	(1U << 2)	/* sq_thread_cpu is valid */
+#define IORING_SETUP_CQSIZE	(1U << 3)	/* app defines CQ size */
+#define IORING_SETUP_CLAMP	(1U << 4)	/* clamp SQ/CQ ring sizes */
+#define IORING_SETUP_ATTACH_WQ	(1U << 5)	/* attach to existing wq */
+#define IORING_SETUP_R_DISABLED	(1U << 6)	/* start with ring disabled */
+
+enum {
+	IORING_OP_NOP,
+	IORING_OP_READV,
+	IORING_OP_WRITEV,
+	IORING_OP_FSYNC,
+	IORING_OP_READ_FIXED,
+	IORING_OP_WRITE_FIXED,
+	IORING_OP_POLL_ADD,
+	IORING_OP_POLL_REMOVE,
+	IORING_OP_SYNC_FILE_RANGE,
+	IORING_OP_SENDMSG,
+	IORING_OP_RECVMSG,
+	IORING_OP_TIMEOUT,
+	IORING_OP_TIMEOUT_REMOVE,
+	IORING_OP_ACCEPT,
+	IORING_OP_ASYNC_CANCEL,
+	IORING_OP_LINK_TIMEOUT,
+	IORING_OP_CONNECT,
+	IORING_OP_FALLOCATE,
+	IORING_OP_OPENAT,
+	IORING_OP_CLOSE,
+	IORING_OP_FILES_UPDATE,
+	IORING_OP_STATX,
+	IORING_OP_READ,
+	IORING_OP_WRITE,
+	IORING_OP_FADVISE,
+	IORING_OP_MADVISE,
+	IORING_OP_SEND,
+	IORING_OP_RECV,
+	IORING_OP_OPENAT2,
+	IORING_OP_EPOLL_CTL,
+	IORING_OP_SPLICE,
+	IORING_OP_PROVIDE_BUFFERS,
+	IORING_OP_REMOVE_BUFFERS,
+	IORING_OP_TEE,
+	IORING_OP_SHUTDOWN,
+	IORING_OP_RENAMEAT,
+	IORING_OP_UNLINKAT,
+
+	/* this goes last, obviously */
+	IORING_OP_LAST,
+};
+
+/*
+ * sqe->fsync_flags
+ */
+#define IORING_FSYNC_DATASYNC	(1U << 0)
+
+/*
+ * sqe->timeout_flags
+ */
+#define IORING_TIMEOUT_ABS	(1U << 0)
+
+/*
+ * sqe->splice_flags
+ * extends splice(2) flags
+ */
+#define SPLICE_F_FD_IN_FIXED	(1U << 31) /* the last bit of __u32 */
+
+/*
+ * IO completion data structure (Completion Queue Entry)
+ */
+struct io_uring_cqe {
+	__u64	user_data;	/* sqe->data submission passed back */
+	__s32	res;		/* result code for this event */
+	__u32	flags;
+};
+
+/*
+ * cqe->flags
+ *
+ * IORING_CQE_F_BUFFER	If set, the upper 16 bits are the buffer ID
+ */
+#define IORING_CQE_F_BUFFER		(1U << 0)
+
+enum {
+	IORING_CQE_BUFFER_SHIFT		= 16,
+};
+
+/*
+ * Magic offsets for the application to mmap the data it needs
+ */
+#define IORING_OFF_SQ_RING		0ULL
+#define IORING_OFF_CQ_RING		0x8000000ULL
+#define IORING_OFF_SQES			0x10000000ULL
+
+/*
+ * Filled with the offset for mmap(2)
+ */
+struct io_sqring_offsets {
+	__u32 head;
+	__u32 tail;
+	__u32 ring_mask;
+	__u32 ring_entries;
+	__u32 flags;
+	__u32 dropped;
+	__u32 array;
+	__u32 resv1;
+	__u64 resv2;
+};
+
+/*
+ * sq_ring->flags
+ */
+#define IORING_SQ_NEED_WAKEUP	(1U << 0) /* needs io_uring_enter wakeup */
+#define IORING_SQ_CQ_OVERFLOW	(1U << 1) /* CQ ring is overflown */
+
+struct io_cqring_offsets {
+	__u32 head;
+	__u32 tail;
+	__u32 ring_mask;
+	__u32 ring_entries;
+	__u32 overflow;
+	__u32 cqes;
+	__u32 flags;
+	__u32 resv1;
+	__u64 resv2;
+};
+
+/*
+ * cq_ring->flags
+ */
+
+/* disable eventfd notifications */
+#define IORING_CQ_EVENTFD_DISABLED	(1U << 0)
+
+/*
+ * io_uring_enter(2) flags
+ */
+#define IORING_ENTER_GETEVENTS	(1U << 0)
+#define IORING_ENTER_SQ_WAKEUP	(1U << 1)
+#define IORING_ENTER_SQ_WAIT	(1U << 2)
+#define IORING_ENTER_EXT_ARG	(1U << 3)
+
+/*
+ * Passed in for io_uring_setup(2). Copied back with updated info on success
+ */
+struct io_uring_params {
+	__u32 sq_entries;
+	__u32 cq_entries;
+	__u32 flags;
+	__u32 sq_thread_cpu;
+	__u32 sq_thread_idle;
+	__u32 features;
+	__u32 wq_fd;
+	__u32 resv[3];
+	struct io_sqring_offsets sq_off;
+	struct io_cqring_offsets cq_off;
+};
+
+/*
+ * io_uring_params->features flags
+ */
+#define IORING_FEAT_SINGLE_MMAP		(1U << 0)
+#define IORING_FEAT_NODROP		(1U << 1)
+#define IORING_FEAT_SUBMIT_STABLE	(1U << 2)
+#define IORING_FEAT_RW_CUR_POS		(1U << 3)
+#define IORING_FEAT_CUR_PERSONALITY	(1U << 4)
+#define IORING_FEAT_FAST_POLL		(1U << 5)
+#define IORING_FEAT_POLL_32BITS 	(1U << 6)
+#define IORING_FEAT_SQPOLL_NONFIXED	(1U << 7)
+#define IORING_FEAT_EXT_ARG		(1U << 8)
+
+/*
+ * io_uring_register(2) opcodes and arguments
+ */
+enum {
+	IORING_REGISTER_BUFFERS			= 0,
+	IORING_UNREGISTER_BUFFERS		= 1,
+	IORING_REGISTER_FILES			= 2,
+	IORING_UNREGISTER_FILES			= 3,
+	IORING_REGISTER_EVENTFD			= 4,
+	IORING_UNREGISTER_EVENTFD		= 5,
+	IORING_REGISTER_FILES_UPDATE		= 6,
+	IORING_REGISTER_EVENTFD_ASYNC		= 7,
+	IORING_REGISTER_PROBE			= 8,
+	IORING_REGISTER_PERSONALITY		= 9,
+	IORING_UNREGISTER_PERSONALITY		= 10,
+	IORING_REGISTER_RESTRICTIONS		= 11,
+	IORING_REGISTER_ENABLE_RINGS		= 12,
+
+	/* this goes last */
+	IORING_REGISTER_LAST
+};
+
+struct io_uring_files_update {
+	__u32 offset;
+	__u32 resv;
+	__aligned_u64 /* __s32 * */ fds;
+};
+
+#define IO_URING_OP_SUPPORTED	(1U << 0)
+
+struct io_uring_probe_op {
+	__u8 op;
+	__u8 resv;
+	__u16 flags;	/* IO_URING_OP_* flags */
+	__u32 resv2;
+};
+
+struct io_uring_probe {
+	__u8 last_op;	/* last opcode supported */
+	__u8 ops_len;	/* length of ops[] array below */
+	__u16 resv;
+	__u32 resv2[3];
+	struct io_uring_probe_op ops[];
+};
+
+struct io_uring_restriction {
+	__u16 opcode;
+	union {
+		__u8 register_op; /* IORING_RESTRICTION_REGISTER_OP */
+		__u8 sqe_op;      /* IORING_RESTRICTION_SQE_OP */
+		__u8 sqe_flags;   /* IORING_RESTRICTION_SQE_FLAGS_* */
+	};
+	__u8 resv;
+	__u32 resv2[3];
+};
+
+/*
+ * io_uring_restriction->opcode values
+ */
+enum {
+	/* Allow an io_uring_register(2) opcode */
+	IORING_RESTRICTION_REGISTER_OP		= 0,
+
+	/* Allow an sqe opcode */
+	IORING_RESTRICTION_SQE_OP		= 1,
+
+	/* Allow sqe flags */
+	IORING_RESTRICTION_SQE_FLAGS_ALLOWED	= 2,
+
+	/* Require sqe flags (these flags must be set on each submission) */
+	IORING_RESTRICTION_SQE_FLAGS_REQUIRED	= 3,
+
+	IORING_RESTRICTION_LAST
+};
+
+struct io_uring_getevents_arg {
+	__u64	sigmask;
+	__u32	sigmask_sz;
+	__u32	pad;
+	__u64	ts;
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/fdbrpc/liburing/queue.c
+++ b/fdbrpc/liburing/queue.c
@@ -1,0 +1,387 @@
+/* SPDX-License-Identifier: MIT */
+#define _POSIX_C_SOURCE 200112L
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/mman.h>
+#include <unistd.h>
+#include <errno.h>
+#include <string.h>
+#include <stdbool.h>
+
+#include "liburing/compat.h"
+#include "liburing/io_uring.h"
+#include "liburing.h"
+#include "liburing/barrier.h"
+
+#include "syscall.h"
+
+/*
+ * Returns true if we're not using SQ thread (thus nobody submits but us)
+ * or if IORING_SQ_NEED_WAKEUP is set, so submit thread must be explicitly
+ * awakened. For the latter case, we set the thread wakeup flag.
+ */
+static inline bool sq_ring_needs_enter(struct io_uring *ring, unsigned *flags)
+{
+	if (!(ring->flags & IORING_SETUP_SQPOLL))
+		return true;
+	if (IO_URING_READ_ONCE(*ring->sq.kflags) & IORING_SQ_NEED_WAKEUP) {
+		*flags |= IORING_ENTER_SQ_WAKEUP;
+		return true;
+	}
+
+	return false;
+}
+
+static inline bool cq_ring_needs_flush(struct io_uring *ring)
+{
+	return IO_URING_READ_ONCE(*ring->sq.kflags) & IORING_SQ_CQ_OVERFLOW;
+}
+
+static int __io_uring_peek_cqe(struct io_uring *ring,
+			       struct io_uring_cqe **cqe_ptr)
+{
+	struct io_uring_cqe *cqe;
+	unsigned head;
+	int err = 0;
+
+	do {
+		io_uring_for_each_cqe(ring, head, cqe)
+			break;
+		if (cqe) {
+			if (cqe->user_data == LIBURING_UDATA_TIMEOUT) {
+				if (cqe->res < 0)
+					err = cqe->res;
+				io_uring_cq_advance(ring, 1);
+				if (!err)
+					continue;
+				cqe = NULL;
+			}
+		}
+		break;
+	} while (1);
+
+	*cqe_ptr = cqe;
+	return err;
+}
+
+struct get_data {
+	unsigned submit;
+	unsigned wait_nr;
+	unsigned get_flags;
+	int sz;
+	void *arg;
+};
+
+static int _io_uring_get_cqe(struct io_uring *ring, struct io_uring_cqe **cqe_ptr,
+			     struct get_data *data)
+{
+	struct io_uring_cqe *cqe = NULL;
+	const int to_wait = data->wait_nr;
+	int ret = 0, err;
+
+	do {
+		bool cq_overflow_flush = false;
+		unsigned flags = 0;
+
+		err = __io_uring_peek_cqe(ring, &cqe);
+		if (err)
+			break;
+		if (!cqe && !to_wait && !data->submit) {
+			if (!cq_ring_needs_flush(ring)) {
+				err = -EAGAIN;
+				break;
+			}
+			cq_overflow_flush = true;
+		}
+		if (data->wait_nr && cqe)
+			data->wait_nr--;
+		if (data->wait_nr || cq_overflow_flush)
+			flags = IORING_ENTER_GETEVENTS | data->get_flags;
+		if (data->submit)
+			sq_ring_needs_enter(ring, &flags);
+		if (data->wait_nr || data->submit || cq_overflow_flush)
+			ret = __sys_io_uring_enter2(ring->ring_fd, data->submit,
+					data->wait_nr, flags, data->arg,
+					data->sz);
+		if (ret < 0) {
+			err = -errno;
+		} else if (ret == (int)data->submit) {
+			data->submit = 0;
+			/*
+			 * When SETUP_IOPOLL is set, __sys_io_uring enter()
+			 * must be called to reap new completions but the call
+			 * won't be made if both wait_nr and submit are zero
+			 * so preserve wait_nr.
+			 */
+			if (!(ring->flags & IORING_SETUP_IOPOLL))
+				data->wait_nr = 0;
+		} else {
+			data->submit -= ret;
+		}
+		if (cqe)
+			break;
+	} while (!err);
+
+	*cqe_ptr = cqe;
+	return err;
+}
+
+int __io_uring_get_cqe(struct io_uring *ring, struct io_uring_cqe **cqe_ptr,
+		       unsigned submit, unsigned wait_nr, sigset_t *sigmask)
+{
+	struct get_data data = {
+		.submit		= submit,
+		.wait_nr 	= wait_nr,
+		.get_flags	= 0,
+		.sz		= _NSIG / 8,
+		.arg		= sigmask,
+	};
+
+	return _io_uring_get_cqe(ring, cqe_ptr, &data);
+}
+
+/*
+ * Fill in an array of IO completions up to count, if any are available.
+ * Returns the amount of IO completions filled.
+ */
+unsigned io_uring_peek_batch_cqe(struct io_uring *ring,
+				 struct io_uring_cqe **cqes, unsigned count)
+{
+	unsigned ready;
+	bool overflow_checked = false;
+
+again:
+	ready = io_uring_cq_ready(ring);
+	if (ready) {
+		unsigned head = *ring->cq.khead;
+		unsigned mask = *ring->cq.kring_mask;
+		unsigned last;
+		int i = 0;
+
+		count = count > ready ? ready : count;
+		last = head + count;
+		for (;head != last; head++, i++)
+			cqes[i] = &ring->cq.cqes[head & mask];
+
+		return count;
+	}
+
+	if (overflow_checked)
+		goto done;
+
+	if (cq_ring_needs_flush(ring)) {
+		__sys_io_uring_enter(ring->ring_fd, 0, 0,
+				     IORING_ENTER_GETEVENTS, NULL);
+		overflow_checked = true;
+		goto again;
+	}
+
+done:
+	return 0;
+}
+
+/*
+ * Sync internal state with kernel ring state on the SQ side. Returns the
+ * number of pending items in the SQ ring, for the shared ring.
+ */
+int __io_uring_flush_sq(struct io_uring *ring)
+{
+	struct io_uring_sq *sq = &ring->sq;
+	const unsigned mask = *sq->kring_mask;
+	unsigned ktail, to_submit;
+
+	if (sq->sqe_head == sq->sqe_tail) {
+		ktail = *sq->ktail;
+		goto out;
+	}
+
+	/*
+	 * Fill in sqes that we have queued up, adding them to the kernel ring
+	 */
+	ktail = *sq->ktail;
+	to_submit = sq->sqe_tail - sq->sqe_head;
+	while (to_submit--) {
+		sq->array[ktail & mask] = sq->sqe_head & mask;
+		ktail++;
+		sq->sqe_head++;
+	}
+
+	/*
+	 * Ensure that the kernel sees the SQE updates before it sees the tail
+	 * update.
+	 */
+	io_uring_smp_store_release(sq->ktail, ktail);
+out:
+	return ktail - *sq->khead;
+}
+
+/*
+ * If we have kernel support for IORING_ENTER_EXT_ARG, then we can use that
+ * more efficiently than queueing an internal timeout command.
+ */
+static int io_uring_wait_cqes_new(struct io_uring *ring,
+				  struct io_uring_cqe **cqe_ptr,
+				  unsigned wait_nr, struct __kernel_timespec *ts,
+				  sigset_t *sigmask)
+{
+	struct io_uring_getevents_arg arg = {
+		.sigmask	= (unsigned long) sigmask,
+		.sigmask_sz	= _NSIG / 8,
+		.ts		= (unsigned long) ts
+	};
+	struct get_data data = {
+		.submit		= __io_uring_flush_sq(ring),
+		.wait_nr	= wait_nr,
+		.get_flags	= IORING_ENTER_EXT_ARG,
+		.sz		= sizeof(arg),
+		.arg		= &arg
+	};
+
+	return _io_uring_get_cqe(ring, cqe_ptr, &data);
+}
+
+/*
+ * Like io_uring_wait_cqe(), except it accepts a timeout value as well. Note
+ * that an sqe is used internally to handle the timeout. Applications using
+ * this function must never set sqe->user_data to LIBURING_UDATA_TIMEOUT!
+ *
+ * If 'ts' is specified, the application need not call io_uring_submit() before
+ * calling this function, as we will do that on its behalf. From this it also
+ * follows that this function isn't safe to use for applications that split SQ
+ * and CQ handling between two threads and expect that to work without
+ * synchronization, as this function manipulates both the SQ and CQ side.
+ */
+int io_uring_wait_cqes(struct io_uring *ring, struct io_uring_cqe **cqe_ptr,
+		       unsigned wait_nr, struct __kernel_timespec *ts,
+		       sigset_t *sigmask)
+{
+	unsigned to_submit = 0;
+
+	if (ts) {
+		struct io_uring_sqe *sqe;
+		int ret;
+
+		if (ring->features & IORING_FEAT_EXT_ARG)
+			return io_uring_wait_cqes_new(ring, cqe_ptr, wait_nr,
+							ts, sigmask);
+
+		/*
+		 * If the SQ ring is full, we may need to submit IO first
+		 */
+		sqe = io_uring_get_sqe(ring);
+		if (!sqe) {
+			ret = io_uring_submit(ring);
+			if (ret < 0)
+				return ret;
+			sqe = io_uring_get_sqe(ring);
+			if (!sqe)
+				return -EAGAIN;
+		}
+		io_uring_prep_timeout(sqe, ts, wait_nr, 0);
+		sqe->user_data = LIBURING_UDATA_TIMEOUT;
+		to_submit = __io_uring_flush_sq(ring);
+	}
+
+	return __io_uring_get_cqe(ring, cqe_ptr, to_submit, wait_nr, sigmask);
+}
+
+/*
+ * See io_uring_wait_cqes() - this function is the same, it just always uses
+ * '1' as the wait_nr.
+ */
+int io_uring_wait_cqe_timeout(struct io_uring *ring,
+			      struct io_uring_cqe **cqe_ptr,
+			      struct __kernel_timespec *ts)
+{
+	return io_uring_wait_cqes(ring, cqe_ptr, 1, ts, NULL);
+}
+
+/*
+ * Submit sqes acquired from io_uring_get_sqe() to the kernel.
+ *
+ * Returns number of sqes submitted
+ */
+static int __io_uring_submit(struct io_uring *ring, unsigned submitted,
+			     unsigned wait_nr)
+{
+	unsigned flags;
+	int ret;
+
+	flags = 0;
+	if (sq_ring_needs_enter(ring, &flags) || wait_nr) {
+		if (wait_nr || (ring->flags & IORING_SETUP_IOPOLL))
+			flags |= IORING_ENTER_GETEVENTS;
+
+		ret = __sys_io_uring_enter(ring->ring_fd, submitted, wait_nr,
+						flags, NULL);
+		if (ret < 0)
+			return -errno;
+	} else
+		ret = submitted;
+
+	return ret;
+}
+
+static int __io_uring_submit_and_wait(struct io_uring *ring, unsigned wait_nr)
+{
+	return __io_uring_submit(ring, __io_uring_flush_sq(ring), wait_nr);
+}
+
+/*
+ * Submit sqes acquired from io_uring_get_sqe() to the kernel.
+ *
+ * Returns number of sqes submitted
+ */
+int io_uring_submit(struct io_uring *ring)
+{
+	return __io_uring_submit_and_wait(ring, 0);
+}
+
+/*
+ * Like io_uring_submit(), but allows waiting for events as well.
+ *
+ * Returns number of sqes submitted
+ */
+int io_uring_submit_and_wait(struct io_uring *ring, unsigned wait_nr)
+{
+	return __io_uring_submit_and_wait(ring, wait_nr);
+}
+
+static inline struct io_uring_sqe *
+__io_uring_get_sqe(struct io_uring_sq *sq, unsigned int __head)
+{
+	unsigned int __next = (sq)->sqe_tail + 1;
+	struct io_uring_sqe *__sqe = NULL;
+
+	if (__next - __head <= *(sq)->kring_entries) {
+		__sqe = &(sq)->sqes[(sq)->sqe_tail & *(sq)->kring_mask];
+		(sq)->sqe_tail = __next;
+	}
+	return __sqe;
+}
+
+/*
+ * Return an sqe to fill. Application must later call io_uring_submit()
+ * when it's ready to tell the kernel about it. The caller may call this
+ * function multiple times before calling io_uring_submit().
+ *
+ * Returns a vacant sqe, or NULL if we're full.
+ */
+struct io_uring_sqe *io_uring_get_sqe(struct io_uring *ring)
+{
+	struct io_uring_sq *sq = &ring->sq;
+
+	return __io_uring_get_sqe(sq, io_uring_smp_load_acquire(sq->khead));
+}
+
+int __io_uring_sqring_wait(struct io_uring *ring)
+{
+	int ret;
+
+	ret = __sys_io_uring_enter(ring->ring_fd, 0, 0, IORING_ENTER_SQ_WAIT,
+					NULL);
+	if (ret < 0)
+		ret = -errno;
+	return ret;
+}

--- a/fdbrpc/liburing/register.c
+++ b/fdbrpc/liburing/register.c
@@ -1,0 +1,189 @@
+/* SPDX-License-Identifier: MIT */
+#define _POSIX_C_SOURCE 200112L
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/mman.h>
+#include <unistd.h>
+#include <errno.h>
+#include <string.h>
+
+#include "liburing/compat.h"
+#include "liburing/io_uring.h"
+#include "liburing.h"
+
+#include "syscall.h"
+
+int io_uring_register_buffers(struct io_uring *ring, const struct iovec *iovecs,
+			      unsigned nr_iovecs)
+{
+	int ret;
+
+	ret = __sys_io_uring_register(ring->ring_fd, IORING_REGISTER_BUFFERS,
+					iovecs, nr_iovecs);
+	if (ret < 0)
+		return -errno;
+
+	return 0;
+}
+
+int io_uring_unregister_buffers(struct io_uring *ring)
+{
+	int ret;
+
+	ret = __sys_io_uring_register(ring->ring_fd, IORING_UNREGISTER_BUFFERS,
+					NULL, 0);
+	if (ret < 0)
+		return -errno;
+
+	return 0;
+}
+
+/*
+ * Register an update for an existing file set. The updates will start at
+ * 'off' in the original array, and 'nr_files' is the number of files we'll
+ * update.
+ *
+ * Returns number of files updated on success, -ERROR on failure.
+ */
+int io_uring_register_files_update(struct io_uring *ring, unsigned off,
+				   int *files, unsigned nr_files)
+{
+	struct io_uring_files_update up = {
+		.offset	= off,
+		.fds	= (unsigned long) files,
+	};
+	int ret;
+
+	ret = __sys_io_uring_register(ring->ring_fd,
+					IORING_REGISTER_FILES_UPDATE, &up,
+					nr_files);
+	if (ret < 0)
+		return -errno;
+
+	return ret;
+}
+
+int io_uring_register_files(struct io_uring *ring, const int *files,
+			      unsigned nr_files)
+{
+	int ret;
+
+	ret = __sys_io_uring_register(ring->ring_fd, IORING_REGISTER_FILES,
+					files, nr_files);
+	if (ret < 0)
+		return -errno;
+
+	return 0;
+}
+
+int io_uring_unregister_files(struct io_uring *ring)
+{
+	int ret;
+
+	ret = __sys_io_uring_register(ring->ring_fd, IORING_UNREGISTER_FILES,
+					NULL, 0);
+	if (ret < 0)
+		return -errno;
+
+	return 0;
+}
+
+int io_uring_register_eventfd(struct io_uring *ring, int event_fd)
+{
+	int ret;
+
+	ret = __sys_io_uring_register(ring->ring_fd, IORING_REGISTER_EVENTFD,
+					&event_fd, 1);
+	if (ret < 0)
+		return -errno;
+
+	return 0;
+}
+
+int io_uring_unregister_eventfd(struct io_uring *ring)
+{
+	int ret;
+
+	ret = __sys_io_uring_register(ring->ring_fd, IORING_UNREGISTER_EVENTFD,
+					NULL, 0);
+	if (ret < 0)
+		return -errno;
+
+	return 0;
+}
+
+int io_uring_register_eventfd_async(struct io_uring *ring, int event_fd)
+{
+	int ret;
+
+	ret = __sys_io_uring_register(ring->ring_fd, IORING_REGISTER_EVENTFD_ASYNC,
+			&event_fd, 1);
+	if (ret < 0)
+		return -errno;
+
+	return 0;
+}
+
+int io_uring_register_probe(struct io_uring *ring, struct io_uring_probe *p,
+			    unsigned int nr_ops)
+{
+	int ret;
+
+	ret = __sys_io_uring_register(ring->ring_fd, IORING_REGISTER_PROBE,
+					p, nr_ops);
+	if (ret < 0)
+		return -errno;
+
+	return 0;
+}
+
+int io_uring_register_personality(struct io_uring *ring)
+{
+	int ret;
+
+	ret = __sys_io_uring_register(ring->ring_fd, IORING_REGISTER_PERSONALITY,
+					NULL, 0);
+	if (ret < 0)
+		return -errno;
+
+	return ret;
+}
+
+int io_uring_unregister_personality(struct io_uring *ring, int id)
+{
+	int ret;
+
+	ret = __sys_io_uring_register(ring->ring_fd, IORING_UNREGISTER_PERSONALITY,
+					NULL, id);
+	if (ret < 0)
+		return -errno;
+
+	return ret;
+}
+
+int io_uring_register_restrictions(struct io_uring *ring,
+				   struct io_uring_restriction *res,
+				   unsigned int nr_res)
+{
+	int ret;
+
+	ret = __sys_io_uring_register(ring->ring_fd, IORING_REGISTER_RESTRICTIONS,
+				      res, nr_res);
+	if (ret < 0)
+		return -errno;
+
+	return 0;
+}
+
+int io_uring_enable_rings(struct io_uring *ring)
+{
+	int ret;
+
+	ret = __sys_io_uring_register(ring->ring_fd,
+				      IORING_REGISTER_ENABLE_RINGS, NULL, 0);
+	if (ret < 0)
+		return -errno;
+
+	return ret;
+}

--- a/fdbrpc/liburing/setup.c
+++ b/fdbrpc/liburing/setup.c
@@ -1,0 +1,216 @@
+/* SPDX-License-Identifier: MIT */
+#define _DEFAULT_SOURCE
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/mman.h>
+#include <unistd.h>
+#include <errno.h>
+#include <string.h>
+#include <stdlib.h>
+#include <signal.h>
+
+#include "liburing/compat.h"
+#include "liburing/io_uring.h"
+#include "liburing.h"
+
+#include "syscall.h"
+
+static void io_uring_unmap_rings(struct io_uring_sq *sq, struct io_uring_cq *cq)
+{
+	munmap(sq->ring_ptr, sq->ring_sz);
+	if (cq->ring_ptr && cq->ring_ptr != sq->ring_ptr)
+		munmap(cq->ring_ptr, cq->ring_sz);
+}
+
+static int io_uring_mmap(int fd, struct io_uring_params *p,
+			 struct io_uring_sq *sq, struct io_uring_cq *cq)
+{
+	size_t size;
+	int ret;
+
+	sq->ring_sz = p->sq_off.array + p->sq_entries * sizeof(unsigned);
+	cq->ring_sz = p->cq_off.cqes + p->cq_entries * sizeof(struct io_uring_cqe);
+
+	if (p->features & IORING_FEAT_SINGLE_MMAP) {
+		if (cq->ring_sz > sq->ring_sz)
+			sq->ring_sz = cq->ring_sz;
+		cq->ring_sz = sq->ring_sz;
+	}
+	sq->ring_ptr = mmap(0, sq->ring_sz, PROT_READ | PROT_WRITE,
+			MAP_SHARED | MAP_POPULATE, fd, IORING_OFF_SQ_RING);
+	if (sq->ring_ptr == MAP_FAILED)
+		return -errno;
+
+	if (p->features & IORING_FEAT_SINGLE_MMAP) {
+		cq->ring_ptr = sq->ring_ptr;
+	} else {
+		cq->ring_ptr = mmap(0, cq->ring_sz, PROT_READ | PROT_WRITE,
+				MAP_SHARED | MAP_POPULATE, fd, IORING_OFF_CQ_RING);
+		if (cq->ring_ptr == MAP_FAILED) {
+			cq->ring_ptr = NULL;
+			ret = -errno;
+			goto err;
+		}
+	}
+
+	sq->khead = sq->ring_ptr + p->sq_off.head;
+	sq->ktail = sq->ring_ptr + p->sq_off.tail;
+	sq->kring_mask = sq->ring_ptr + p->sq_off.ring_mask;
+	sq->kring_entries = sq->ring_ptr + p->sq_off.ring_entries;
+	sq->kflags = sq->ring_ptr + p->sq_off.flags;
+	sq->kdropped = sq->ring_ptr + p->sq_off.dropped;
+	sq->array = sq->ring_ptr + p->sq_off.array;
+
+	size = p->sq_entries * sizeof(struct io_uring_sqe);
+	sq->sqes = mmap(0, size, PROT_READ | PROT_WRITE,
+				MAP_SHARED | MAP_POPULATE, fd,
+				IORING_OFF_SQES);
+	if (sq->sqes == MAP_FAILED) {
+		ret = -errno;
+err:
+		io_uring_unmap_rings(sq, cq);
+		return ret;
+	}
+
+	cq->khead = cq->ring_ptr + p->cq_off.head;
+	cq->ktail = cq->ring_ptr + p->cq_off.tail;
+	cq->kring_mask = cq->ring_ptr + p->cq_off.ring_mask;
+	cq->kring_entries = cq->ring_ptr + p->cq_off.ring_entries;
+	cq->koverflow = cq->ring_ptr + p->cq_off.overflow;
+	cq->cqes = cq->ring_ptr + p->cq_off.cqes;
+	if (p->cq_off.flags)
+		cq->kflags = cq->ring_ptr + p->cq_off.flags;
+	return 0;
+}
+
+/*
+ * For users that want to specify sq_thread_cpu or sq_thread_idle, this
+ * interface is a convenient helper for mmap()ing the rings.
+ * Returns -errno on error, or zero on success.  On success, 'ring'
+ * contains the necessary information to read/write to the rings.
+ */
+int io_uring_queue_mmap(int fd, struct io_uring_params *p, struct io_uring *ring)
+{
+	int ret;
+
+	memset(ring, 0, sizeof(*ring));
+	ret = io_uring_mmap(fd, p, &ring->sq, &ring->cq);
+	if (!ret) {
+		ring->flags = p->flags;
+		ring->ring_fd = fd;
+	}
+	return ret;
+}
+
+/*
+ * Ensure that the mmap'ed rings aren't available to a child after a fork(2).
+ * This uses madvise(..., MADV_DONTFORK) on the mmap'ed ranges.
+ */
+int io_uring_ring_dontfork(struct io_uring *ring)
+{
+	size_t len;
+	int ret;
+
+	if (!ring->sq.ring_ptr || !ring->sq.sqes || !ring->cq.ring_ptr)
+		return -EINVAL;
+
+	len = *ring->sq.kring_entries * sizeof(struct io_uring_sqe);
+	ret = madvise(ring->sq.sqes, len, MADV_DONTFORK);
+	if (ret == -1)
+		return -errno;
+
+	len = ring->sq.ring_sz;
+	ret = madvise(ring->sq.ring_ptr, len, MADV_DONTFORK);
+	if (ret == -1)
+		return -errno;
+
+	if (ring->cq.ring_ptr != ring->sq.ring_ptr) {
+		len = ring->cq.ring_sz;
+		ret = madvise(ring->cq.ring_ptr, len, MADV_DONTFORK);
+		if (ret == -1)
+			return -errno;
+	}
+
+	return 0;
+}
+
+int io_uring_queue_init_params(unsigned entries, struct io_uring *ring,
+			       struct io_uring_params *p)
+{
+	int fd, ret;
+
+	fd = __sys_io_uring_setup(entries, p);
+	if (fd < 0)
+		return -errno;
+
+	ret = io_uring_queue_mmap(fd, p, ring);
+	if (ret) {
+		close(fd);
+		return ret;
+	}
+
+	ring->features = p->features;
+	return 0;
+}
+
+/*
+ * Returns -errno on error, or zero on success. On success, 'ring'
+ * contains the necessary information to read/write to the rings.
+ */
+int io_uring_queue_init(unsigned entries, struct io_uring *ring, unsigned flags)
+{
+	struct io_uring_params p;
+
+	memset(&p, 0, sizeof(p));
+	p.flags = flags;
+
+	return io_uring_queue_init_params(entries, ring, &p);
+}
+
+void io_uring_queue_exit(struct io_uring *ring)
+{
+	struct io_uring_sq *sq = &ring->sq;
+	struct io_uring_cq *cq = &ring->cq;
+
+	munmap(sq->sqes, *sq->kring_entries * sizeof(struct io_uring_sqe));
+	io_uring_unmap_rings(sq, cq);
+	close(ring->ring_fd);
+}
+
+struct io_uring_probe *io_uring_get_probe_ring(struct io_uring *ring)
+{
+	struct io_uring_probe *probe;
+	int r;
+
+	size_t len = sizeof(*probe) + 256 * sizeof(struct io_uring_probe_op);
+	probe = malloc(len);
+	memset(probe, 0, len);
+	r = io_uring_register_probe(ring, probe, 256);
+	if (r < 0)
+		goto fail;
+
+	return probe;
+fail:
+	free(probe);
+	return NULL;
+}
+
+struct io_uring_probe *io_uring_get_probe(void)
+{
+	struct io_uring ring;
+	struct io_uring_probe* probe = NULL;
+
+	int r = io_uring_queue_init(2, &ring, 0);
+	if (r < 0)
+		return NULL;
+
+	probe = io_uring_get_probe_ring(&ring);
+	io_uring_queue_exit(&ring);
+	return probe;
+}
+
+void io_uring_free_probe(struct io_uring_probe *probe)
+{
+	free(probe);
+}

--- a/fdbrpc/liburing/syscall.c
+++ b/fdbrpc/liburing/syscall.c
@@ -1,0 +1,63 @@
+/* SPDX-License-Identifier: MIT */
+#define _DEFAULT_SOURCE
+
+/*
+ * Will go away once libc support is there
+ */
+#include <unistd.h>
+#include <sys/syscall.h>
+#include <sys/uio.h>
+#include "liburing/compat.h"
+#include "liburing/io_uring.h"
+#include "syscall.h"
+
+#ifdef __alpha__
+/*
+ * alpha is the only exception, all other architectures
+ * have common numbers for new system calls.
+ */
+# ifndef __NR_io_uring_setup
+#  define __NR_io_uring_setup		535
+# endif
+# ifndef __NR_io_uring_enter
+#  define __NR_io_uring_enter		536
+# endif
+# ifndef __NR_io_uring_register
+#  define __NR_io_uring_register	537
+# endif
+#else /* !__alpha__ */
+# ifndef __NR_io_uring_setup
+#  define __NR_io_uring_setup		425
+# endif
+# ifndef __NR_io_uring_enter
+#  define __NR_io_uring_enter		426
+# endif
+# ifndef __NR_io_uring_register
+#  define __NR_io_uring_register	427
+# endif
+#endif
+
+int __sys_io_uring_register(int fd, unsigned opcode, const void *arg,
+			    unsigned nr_args)
+{
+	return syscall(__NR_io_uring_register, fd, opcode, arg, nr_args);
+}
+
+int __sys_io_uring_setup(unsigned entries, struct io_uring_params *p)
+{
+	return syscall(__NR_io_uring_setup, entries, p);
+}
+
+int __sys_io_uring_enter2(int fd, unsigned to_submit, unsigned min_complete,
+			 unsigned flags, sigset_t *sig, int sz)
+{
+	return syscall(__NR_io_uring_enter, fd, to_submit, min_complete,
+			flags, sig, sz);
+}
+
+int __sys_io_uring_enter(int fd, unsigned to_submit, unsigned min_complete,
+			 unsigned flags, sigset_t *sig)
+{
+	return __sys_io_uring_enter2(fd, to_submit, min_complete, flags, sig,
+					_NSIG / 8);
+}

--- a/fdbrpc/liburing/syscall.h
+++ b/fdbrpc/liburing/syscall.h
@@ -1,0 +1,20 @@
+/* SPDX-License-Identifier: MIT */
+#ifndef LIBURING_SYSCALL_H
+#define LIBURING_SYSCALL_H
+
+#include <signal.h>
+
+struct io_uring_params;
+
+/*
+ * System calls
+ */
+extern int __sys_io_uring_setup(unsigned entries, struct io_uring_params *p);
+extern int __sys_io_uring_enter(int fd, unsigned to_submit,
+	unsigned min_complete, unsigned flags, sigset_t *sig);
+extern int __sys_io_uring_enter2(int fd, unsigned to_submit,
+	unsigned min_complete, unsigned flags, sigset_t *sig, int sz);
+extern int __sys_io_uring_register(int fd, unsigned int opcode, const void *arg,
+	unsigned int nr_args);
+
+#endif

--- a/tests/AsyncFileIOUringUnitTest.txt
+++ b/tests/AsyncFileIOUringUnitTest.txt
@@ -1,0 +1,7 @@
+testTitle=UnitTests
+startDelay=0
+useDB=false
+
+    testName=UnitTests
+    maxTestCases=0
+    testsMatching=/fdbrpc/AsyncFileIOUring/RequestList


### PR DESCRIPTION
This PR resolves #2128 

Changes in this PR:

- It adds a new dependency liburing, that wraps low-level sys-calls and makes using io_uring easier
- A new AsyncFileIOUring.actor.h that aims at being a faster replacement of KAIO, of course, contingent on superior performance
-

TODO:
- [ ] It, of course, needs extensive testing. 
- [ ] Right now it uses a blocking call in the `poll` method. I'm not sure whether this or the original `eventfd` is a good approach. Again, needs some testing
- [ ] It requires kernel v5.6. Could change this dependency to 5.1 if needed.
- [ ] Maybe also change some truncation-related function calls to async too. 

### Style
- [ ] All variable and function names make sense.
- [ ] The code is properly formatted (consider running `git clang-format`).

### Performance
- [ ] All CPU-hot paths are well optimized.
- [ ] The proper containers are used (for example `std::vector` vs `VectorRef`).
- [ ] There are no new known `SlowTask` traces.

### Testing
- [ ] The code was sufficiently tested in simulation.
- [ ] If there are new parameters or knobs, different values are tested in simulation.
- [ ] `ASSERT`, `ASSERT_WE_THINK`, and `TEST` macros are added in appropriate places.
- [ ] Unit tests were added for new algorithms and data structure that make sense to unit-test
- [ ] If this is a bugfix: there is a test that can easily reproduce the bug.
