### PR TITLE
Fix UDP simulation bug

### DIFF
--- a/fdbrpc/sim2.actor.cpp
+++ b/fdbrpc/sim2.actor.cpp
@@ -1796,6 +1796,7 @@ public:
 	  : id(deterministicRandom()->randomUniqueID()), process(g_simulator.getCurrentProcess()), peerAddress(peerAddress),
 	    actors(false), _localAddress(localAddress) {
 		g_sim2.addressMap.emplace(_localAddress, process);
+		ASSERT(process->boundUDPSockets.find(localAddress) == process->boundUDPSockets.end());
 		process->boundUDPSockets.emplace(localAddress, this);
 	}
 	~UDPSimSocket() {
@@ -1909,6 +1910,9 @@ Future<Reference<IUDPSocket>> Sim2::createUDPSocket(NetworkAddress toAddr) {
 		localAddress.ip = IPAddress(process->address.ip.toV4() + deterministicRandom()->randomInt(0, 256));
 	}
 	localAddress.port = deterministicRandom()->randomInt(40000, 60000);
+	while (process->boundUDPSockets.find(localAddress) != process->boundUDPSockets.end()) {
+		localAddress.port = deterministicRandom()->randomInt(40000, 60000);
+	}
 	return Reference<IUDPSocket>(new UDPSimSocket(localAddress, toAddr));
 }
 


### PR DESCRIPTION
The nightly surfaced a failure in the UDP simulation test.

Commit: `15b2f77de6477592e22779fece7af2744e20fec2`
Test: `fast/UDP.toml`
Buggify: `on`
Seed: `833187778`

Root cause:

- Sockets are [created with a randomly selected port](https://github.com/apple/foundationdb/blob/master/fdbrpc/sim2.actor.cpp#L1911) in the range [40000, 60000]. If two sockets are created and happen to randomly generate the same port *before the first socket is closed*, this issue occurs.

Changes in this PR:

- If the randomly generated port for a socket is currently in use, generate a new random port for the socket. Continue until the socket has an unassigned port.
- Add an `ASSERT` to crash early if a new socket is created with the same port as an existing socket.

Passed 10k runs of just `fast/UDP.toml` on Joshua.

### Style
- [x] All variable and function names make sense.
- [x] The code is properly formatted (consider running `git clang-format`).

### Performance
- [x] ~~All CPU-hot paths are well optimized.~~
- [x] ~~The proper containers are used (for example `std::vector` vs `VectorRef`).~~
- [x] ~~There are no new known `SlowTask` traces.~~

### Testing
- [x] The code was sufficiently tested in simulation.
- [x] ~~If there are new parameters or knobs, different values are tested in simulation.~~
- [x] `ASSERT`, `ASSERT_WE_THINK`, and `TEST` macros are added in appropriate places.
- [x] ~~Unit tests were added for new algorithms and data structure that make sense to unit-test~~
- [x] If this is a bugfix: there is a test that can easily reproduce the bug.
