### PR TITLE
Remove "a/" from tracing keys in special-key-space

### DIFF
--- a/bindings/c/test/unit/unit_tests.cpp
+++ b/bindings/c/test/unit/unit_tests.cpp
@@ -1744,7 +1744,7 @@ TEST_CASE("fdb_transaction_add_conflict_range") {
 }
 
 TEST_CASE("special-key-space valid transaction ID") {
-  auto value = get_value("\xff\xff/tracing/a/transaction_id", /* snapshot */ false, {});
+  auto value = get_value("\xff\xff/tracing/transaction_id", /* snapshot */ false, {});
   REQUIRE(value.has_value());
   uint64_t transaction_id = std::stoul(value.value());
   CHECK(transaction_id > 0);
@@ -1755,8 +1755,8 @@ TEST_CASE("special-key-space custom transaction ID") {
   fdb_check(tr.set_option(FDB_TR_OPTION_SPECIAL_KEY_SPACE_ENABLE_WRITES,
                           nullptr, 0));
   while (1) {
-    tr.set("\xff\xff/tracing/a/transaction_id", std::to_string(ULONG_MAX));
-    fdb::ValueFuture f1 = tr.get("\xff\xff/tracing/a/transaction_id",
+    tr.set("\xff\xff/tracing/transaction_id", std::to_string(ULONG_MAX));
+    fdb::ValueFuture f1 = tr.get("\xff\xff/tracing/transaction_id",
                                  /* snapshot */ false);
 
     fdb_error_t err = wait_future(f1);
@@ -1784,8 +1784,8 @@ TEST_CASE("special-key-space set transaction ID after write") {
                           nullptr, 0));
   while (1) {
     tr.set(key("foo"), "bar");
-    tr.set("\xff\xff/tracing/a/transaction_id", "0");
-    fdb::ValueFuture f1 = tr.get("\xff\xff/tracing/a/transaction_id",
+    tr.set("\xff\xff/tracing/transaction_id", "0");
+    fdb::ValueFuture f1 = tr.get("\xff\xff/tracing/transaction_id",
                                  /* snapshot */ false);
 
     fdb_error_t err = wait_future(f1);
@@ -1813,8 +1813,8 @@ TEST_CASE("special-key-space set token after write") {
                           nullptr, 0));
   while (1) {
     tr.set(key("foo"), "bar");
-    tr.set("\xff\xff/tracing/a/token", "false");
-    fdb::ValueFuture f1 = tr.get("\xff\xff/tracing/a/token",
+    tr.set("\xff\xff/tracing/token", "false");
+    fdb::ValueFuture f1 = tr.get("\xff\xff/tracing/token",
                                  /* snapshot */ false);
 
     fdb_error_t err = wait_future(f1);
@@ -1837,7 +1837,7 @@ TEST_CASE("special-key-space set token after write") {
 }
 
 TEST_CASE("special-key-space valid token") {
-  auto value = get_value("\xff\xff/tracing/a/token", /* snapshot */ false, {});
+  auto value = get_value("\xff\xff/tracing/token", /* snapshot */ false, {});
   REQUIRE(value.has_value());
   uint64_t token = std::stoul(value.value());
   CHECK(token > 0);
@@ -1848,8 +1848,8 @@ TEST_CASE("special-key-space disable tracing") {
   fdb_check(tr.set_option(FDB_TR_OPTION_SPECIAL_KEY_SPACE_ENABLE_WRITES,
                           nullptr, 0));
   while (1) {
-    tr.set("\xff\xff/tracing/a/token", "false");
-    fdb::ValueFuture f1 = tr.get("\xff\xff/tracing/a/token",
+    tr.set("\xff\xff/tracing/token", "false");
+    fdb::ValueFuture f1 = tr.get("\xff\xff/tracing/token",
                                  /* snapshot */ false);
 
     fdb_error_t err = wait_future(f1);
@@ -1874,7 +1874,7 @@ TEST_CASE("special-key-space disable tracing") {
 TEST_CASE("FDB_DB_OPTION_TRANSACTION_TRACE_DISABLE") {
   fdb_check(fdb_database_set_option(db, FDB_DB_OPTION_TRANSACTION_TRACE_DISABLE, nullptr, 0));
 
-  auto value = get_value("\xff\xff/tracing/a/token", /* snapshot */ false, {});
+  auto value = get_value("\xff\xff/tracing/token", /* snapshot */ false, {});
   REQUIRE(value.has_value());
   uint64_t token = std::stoul(value.value());
   CHECK(token == 0);
@@ -1889,8 +1889,8 @@ TEST_CASE("FDB_DB_OPTION_TRANSACTION_TRACE_DISABLE enable tracing for transactio
   fdb_check(tr.set_option(FDB_TR_OPTION_SPECIAL_KEY_SPACE_ENABLE_WRITES,
                           nullptr, 0));
   while (1) {
-    tr.set("\xff\xff/tracing/a/token", "true");
-    fdb::ValueFuture f1 = tr.get("\xff\xff/tracing/a/token",
+    tr.set("\xff\xff/tracing/token", "true");
+    fdb::ValueFuture f1 = tr.get("\xff\xff/tracing/token",
                                  /* snapshot */ false);
 
     fdb_error_t err = wait_future(f1);
@@ -1915,8 +1915,8 @@ TEST_CASE("FDB_DB_OPTION_TRANSACTION_TRACE_DISABLE enable tracing for transactio
 }
 
 TEST_CASE("special-key-space tracing get range") {
-  std::string tracingBegin = "\xff\xff/tracing/a/";
-  std::string tracingEnd = "\xff\xff/tracing/a0";
+  std::string tracingBegin = "\xff\xff/tracing/";
+  std::string tracingEnd = "\xff\xff/tracing0";
 
   fdb::Transaction tr(db);
   fdb_check(tr.set_option(FDB_TR_OPTION_SPECIAL_KEY_SPACE_ENABLE_WRITES,
@@ -1927,7 +1927,7 @@ TEST_CASE("special-key-space tracing get range") {
           (const uint8_t *)tracingBegin.c_str(),
           tracingBegin.size()
         ),
-        FDB_KEYSEL_LAST_LESS_OR_EQUAL(
+        FDB_KEYSEL_LAST_LESS_THAN(
           (const uint8_t *)tracingEnd.c_str(),
           tracingEnd.size()
         ) + 1, /* limit */ 0, /* target_bytes */ 0,

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -948,12 +948,8 @@ DatabaseContext::DatabaseContext(Reference<AsyncVar<Reference<ClusterConnectionF
 		            .withPrefix(SpecialKeySpace::getModuleRange(SpecialKeySpace::MODULE::MANAGEMENT).begin)));
 		registerSpecialKeySpaceModule(
 		    SpecialKeySpace::MODULE::TRACING, SpecialKeySpace::IMPLTYPE::READWRITE,
-		    // std::make_unique<TracingOptionsImpl>(
-		    //     SpecialKeySpace::getModuleRange(SpecialKeySpace::MODULE::TRACING)));
-		    // TODO: Temporary fix for an issue with special-key top level ranges.
 		    std::make_unique<TracingOptionsImpl>(
-		        KeyRangeRef(LiteralStringRef("a/"), LiteralStringRef("a0"))
-		            .withPrefix(SpecialKeySpace::getModuleRange(SpecialKeySpace::MODULE::TRACING).begin)));
+		        SpecialKeySpace::getModuleRange(SpecialKeySpace::MODULE::TRACING)));
 	}
 	if (apiVersionAtLeast(630)) {
 		registerSpecialKeySpaceModule(SpecialKeySpace::MODULE::TRANSACTION, SpecialKeySpace::IMPLTYPE::READONLY,


### PR DESCRIPTION
Changes in this PR:

- Removes `a/` from `tracing` namespace in special-key-space. For example, `\xff\xff/tracing/a/transaction_id` becomes `\xff\xff/tracing/transaction_id`.

### Style
- [x] All variable and function names make sense.
- [x] The code is properly formatted (consider running `git clang-format`).

### Performance
- [x] ~~All CPU-hot paths are well optimized.~~
- [x] ~~The proper containers are used (for example `std::vector` vs `VectorRef`).~~
- [x] ~~There are no new known `SlowTask` traces.~~

### Testing
- [x] The code was sufficiently tested in simulation.
- [x] ~~If there are new parameters or knobs, different values are tested in simulation.~~
- [x] ~~`ASSERT`, `ASSERT_WE_THINK`, and `TEST` macros are added in appropriate places.~~
- [x] ~~Unit tests were added for new algorithms and data structure that make sense to unit-test~~
- [x] If this is a bugfix: there is a test that can easily reproduce the bug.
