### PR TITLE
Switch to BoringSSL by default

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -79,7 +79,7 @@ RUN cd /opt/ && curl -L https://github.com/facebook/rocksdb/archive/v6.10.1.tar.
 RUN cd /opt/ && curl -L https://github.com/manticoresoftware/manticoresearch/raw/master/misc/junit/ctest2junit.xsl -o ctest2junit.xsl
 
 # Setting this environment variable switches from OpenSSL to BoringSSL
-#ENV OPENSSL_ROOT_DIR=/opt/boringssl
+ENV OPENSSL_ROOT_DIR=/opt/boringssl
 
 # install BoringSSL:  TODO: They don't seem to have releases(?)  I picked today's master SHA.
 RUN cd /opt &&\

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -110,8 +110,8 @@ RUN cd /opt/boringssl/build &&\
 ARG TIMEZONEINFO=America/Los_Angeles
 RUN rm -f /etc/localtime && ln -s /usr/share/zoneinfo/${TIMEZONEINFO} /etc/localtime
 
-LABEL version=0.1.22
-ENV DOCKER_IMAGEVER=0.1.22
+LABEL version=0.1.23
+ENV DOCKER_IMAGEVER=0.1.23
 ENV JAVA_HOME=/usr/lib/jvm/java-1.8.0
 ENV CC=/opt/rh/devtoolset-8/root/usr/bin/gcc
 ENV CXX=/opt/rh/devtoolset-8/root/usr/bin/g++

--- a/build/Dockerfile.devel
+++ b/build/Dockerfile.devel
@@ -1,4 +1,4 @@
-ARG IMAGE_TAG=0.1.21
+ARG IMAGE_TAG=0.1.23
 FROM foundationdb/foundationdb-build:${IMAGE_TAG}
 
 USER root
@@ -51,8 +51,8 @@ RUN cp -iv /usr/local/bin/clang++ /usr/local/bin/clang++.deref &&\
 	ldconfig &&\
 	rm -rf /mnt/artifacts
 
-LABEL version=0.11.13
-ENV DOCKER_IMAGEVER=0.11.13
+LABEL version=0.11.14
+ENV DOCKER_IMAGEVER=0.11.14
 
 ENV CLANGCC=/usr/local/bin/clang.de8a65ef
 ENV CLANGCXX=/usr/local/bin/clang++.de8a65ef

--- a/build/docker-compose.yaml
+++ b/build/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   common: &common
-    image: foundationdb/foundationdb-build:0.1.22
+    image: foundationdb/foundationdb-build:0.1.23
 
   build-setup: &build-setup
     <<: *common

--- a/cmake/FDBComponents.cmake
+++ b/cmake/FDBComponents.cmake
@@ -12,6 +12,8 @@ endif()
 # SSL
 ################################################################################
 
+include(CheckSymbolExists)
+
 set(DISABLE_TLS OFF CACHE BOOL "Don't try to find LibreSSL and always build without TLS support")
 if(DISABLE_TLS)
   set(WITH_TLS OFF)
@@ -24,6 +26,14 @@ else()
 		if (LIBRESSL_FOUND)
 			add_library(OpenSSL::SSL ALIAS LibreSSL)
 		endif()
+  else()
+    set(CMAKE_REQUIRED_INCLUDES ${OPENSSL_INCLUDE_DIR})
+    check_symbol_exists(OPENSSL_INIT_NO_ATEXIT "openssl/crypto.h" OPENSSL_HAS_NO_ATEXIT)
+    if(OPENSSL_HAS_NO_ATEXIT)
+      add_compile_options(-DHAVE_OPENSSL_INIT_NO_ATEXIT)
+    else()
+      message(STATUS "Found OpenSSL without OPENSSL_INIT_NO_ATEXIT:  assuming BoringSSL")
+    endif()
   endif()
 	if(OPENSSL_FOUND OR LIBRESSL_FOUND)
     set(WITH_TLS ON)

--- a/flow/TLSConfig.actor.cpp
+++ b/flow/TLSConfig.actor.cpp
@@ -28,9 +28,7 @@ TLSPolicy::~TLSPolicy() {}
 namespace TLS {
 
 void DisableOpenSSLAtExitHandler() {
-#ifdef TLS_DISABLED
-	return;
-#else
+#ifdef HAVE_OPENSSL_INIT_NO_ATEXIT
 	static bool once = false;
 	if (!once) {
 		once = true;
@@ -43,9 +41,7 @@ void DisableOpenSSLAtExitHandler() {
 }
 
 void DestroyOpenSSLGlobalState() {
-#ifdef TLS_DISABLED
-	return;
-#else
+#ifdef HAVE_OPENSSL_INIT_NO_ATEXIT
 	OPENSSL_cleanup();
 #endif
 }


### PR DESCRIPTION
This PR changes the default SSL implementation from OpenSSL to BoringSSL.  We're considering doing this in production.

Changes in this PR:

- Set OPENSSL_ROOT_DIR to point to the version of BoringSSL included in the build docker
- Update some #ifdefs to work with BoringSSL.

## General guideline:

### Style
- [X] All variable and function names make sense.
- [X] The code is properly formatted (consider running `git clang-format`).

### Performance
- [X] All CPU-hot paths are well optimized.
- [X] The proper containers are used (for example `std::vector` vs `VectorRef`).
- [X] There are no new known `SlowTask` traces.

### Testing
- ~~[ ] The code was sufficiently tested in simulation.~~
- [X] If there are new parameters or knobs, different values are tested in simulation.
- ~~[ ] `ASSERT`, `ASSERT_WE_THINK`, and `TEST` macros are added in appropriate places.~~
- ~~[ ] Unit tests were added for new algorithms and data structure that make sense to unit-test~~
- ~~[ ] If this is a bugfix: there is a test that can easily reproduce the bug.~~

Simulation doesn't touch this code path, but we run the boringssl unit tests after compiling it.  This has been tested + benchmarked on real hardware (vs. 6.3, but this PR is against 6.2).