### PR TITLE
Remove "WiP" from the FDB Read and Write Path doc

### DIFF
--- a/documentation/sphinx/source/read-write-path.rst
+++ b/documentation/sphinx/source/read-write-path.rst
@@ -1,5 +1,5 @@
 ##############################
-FDB Read and Write Path (WiP)
+FDB Read and Write Path
 ##############################
 
 | Author: Meng Xu


### PR DESCRIPTION
This PR is resolves #...

Changes in this PR: Only change the doc text.

The rest of PR guideline is not applied here. 