### PR TITLE
Fix stack overflow in Redwood

### DIFF
--- a/fdbserver/VersionedBTree.actor.cpp
+++ b/fdbserver/VersionedBTree.actor.cpp
@@ -1837,6 +1837,7 @@ public:
 		state Version minStopVersion = cutoff.version - (BUGGIFY ? deterministicRandom()->randomInt(0, 10) : (self->remapCleanupWindow * SERVER_KNOBS->REDWOOD_REMAP_CLEANUP_LAG));
 		self->remapDestinationsSimOnly.clear();
 
+		state int sinceYield = 0;
 		loop {
 			state Optional<RemappedPage> p = wait(self->remapQueue.pop(cutoff));
 			debug_printf("DWALPager(%s) remapCleanup popped %s\n", self->filename.c_str(), ::toString(p).c_str());
@@ -1854,6 +1855,11 @@ public:
 			// If the stop flag is set and we've reached the minimum stop version according the the allowed lag then stop.
 			if (self->remapCleanupStop && p.get().version >= minStopVersion) {
 				break;
+			}
+
+			if(++sinceYield >= 100) {
+				sinceYield = 0;
+				wait(yield());
 			}
 		}
 


### PR DESCRIPTION
This PR resolves #4133 

Changes in this PR:

- Added yield to remap cleanup loop to prevent a stack overflow if too many queue entries are processed without waiting on IO.

### Style
- [x] All variable and function names make sense.
- [x] The code is properly formatted (consider running `git clang-format`).

### Performance
- [x] All CPU-hot paths are well optimized.
- [x] The proper containers are used (for example `std::vector` vs `VectorRef`).
- [x] There are no new known `SlowTask` traces.

### Testing
- [x] The code was sufficiently tested in simulation.
- [x] ~~If there are new parameters or knobs, different values are tested in simulation.~~
- [x] ~~`ASSERT`, `ASSERT_WE_THINK`, and `TEST` macros are added in appropriate places.~~
- [x] ~~Unit tests were added for new algorithms and data structure that make sense to unit-test~~
- [x] ~~If this is a bugfix: there is a test that can easily reproduce the bug.~~
