### PR TITLE
Add support for reading from an IKeyValueStore at a specified version.

### DIFF
--- a/cmake/CompileRocksDB.cmake
+++ b/cmake/CompileRocksDB.cmake
@@ -11,6 +11,7 @@ if (RocksDB_FOUND)
     CMAKE_ARGS -DUSE_RTTI=1 -DPORTABLE=${PORTABLE_ROCKSDB}
                -DCMAKE_CXX_STANDARD=${CMAKE_CXX_STANDARD}
                -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+	             -DCMAKE_CXX_FLAGS="-Wno-unused-command-line-argument"
                -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
                -DWITH_GFLAGS=OFF
                -DWITH_TESTS=OFF

--- a/fdbrpc/simulator.h
+++ b/fdbrpc/simulator.h
@@ -140,6 +140,7 @@ public:
 	struct MachineInfo {
 		ProcessInfo* machineProcess;
 		std::vector<ProcessInfo*> processes;
+		std::map<std::string, void*> nonFlowStores; // TODO: eliminate void*
 		std::map<std::string, Future<Reference<IAsyncFile>>> openFiles;
 		std::set<std::string> deletingFiles;
 		std::set<std::string> closingFiles;

--- a/fdbserver/CMakeLists.txt
+++ b/fdbserver/CMakeLists.txt
@@ -24,6 +24,7 @@ set(FDBSERVER_SRCS
   FDBExecHelper.actor.cpp
   FDBExecHelper.actor.h
   IDiskQueue.h
+  IKeyValueStore.actor.cpp
   IKeyValueStore.h
   IPager.h
   IVersionedStore.h

--- a/fdbserver/IKeyValueStore.actor.cpp
+++ b/fdbserver/IKeyValueStore.actor.cpp
@@ -1,0 +1,615 @@
+#include <cinttypes>
+
+#include "fdbserver/IKeyValueStore.h"
+#include "flow/Platform.h"
+#include "flow/UnitTest.h"
+#include "flow/actorcompiler.h" // has to be last include
+
+#define debug_printf(...)
+
+namespace {
+
+struct SimpleCounter {
+	SimpleCounter() : x(0), xt(0), t(timer()), start(t) {}
+	void operator+=(int n) { x += n; }
+	void operator++() { x++; }
+	int64_t get() { return x; }
+	double rate() {
+		double t2 = timer();
+		int r = (x - xt) / (t2 - t);
+		xt = x;
+		t = t2;
+		return r;
+	}
+	double avgRate() { return x / (timer() - start); }
+	int64_t x;
+	double t;
+	double start;
+	int64_t xt;
+	std::string toString() { return format("%lld/%.2f/%.2f", x, rate() / 1e6, avgRate() / 1e6); }
+};
+
+int randomSize(int max) {
+	int n = pow(deterministicRandom()->random01(), 3) * max;
+	return n;
+}
+
+StringRef randomString(Arena& arena, int len, char firstChar = 'a', char lastChar = 'z') {
+	++lastChar;
+	StringRef s = makeString(len, arena);
+	for (int i = 0; i < len; ++i) {
+		*(uint8_t*)(s.begin() + i) = (uint8_t)deterministicRandom()->randomInt(firstChar, lastChar);
+	}
+	return s;
+}
+
+Standalone<StringRef> randomString(int len, char firstChar = 'a', char lastChar = 'z') {
+	Standalone<StringRef> s;
+	(StringRef&)s = randomString(s.arena(), len, firstChar, lastChar);
+	return s;
+}
+
+KeyValue randomKV(int maxKeySize = 10, int maxValueSize = 5) {
+	int kLen = randomSize(1 + maxKeySize);
+	int vLen = maxValueSize > 0 ? randomSize(maxValueSize) : 0;
+
+	KeyValue kv;
+
+	kv.key = randomString(kv.arena(), kLen, 'a', 'm');
+	for (int i = 0; i < kLen; ++i) mutateString(kv.key)[i] = (uint8_t)deterministicRandom()->randomInt('a', 'm');
+
+	if (vLen > 0) {
+		kv.value = randomString(kv.arena(), vLen, 'n', 'z');
+		for (int i = 0; i < vLen; ++i) mutateString(kv.value)[i] = (uint8_t)deterministicRandom()->randomInt('o', 'z');
+	}
+
+	return kv;
+}
+
+// Does a random range read, doesn't trap/report errors
+ACTOR Future<Void> randomReader(IKeyValueStore* kvStore) {
+	try {
+		state Version v = 0;
+		loop {
+			wait(yield());
+			if (!v || deterministicRandom()->random01() > .01) {
+				v = kvStore->getLastCommittedVersion();
+			}
+
+			state KeyValue kv = randomKV(10, 0);
+			state int c = deterministicRandom()->randomInt(0, 100);
+			Standalone<RangeResultRef> ignored = wait(kvStore->readRangeAt({ kv.key, LiteralStringRef("\xff") }, v, c));
+		}
+	} catch (Error& e) {
+		if (e.code() != error_code_transaction_too_old) {
+			throw e;
+		}
+	}
+
+	return Void();
+}
+
+ACTOR Future<int> verifyRange(IKeyValueStore* kvStore, Key start, Key end, Version version,
+                              std::map<std::pair<std::string, Version>, Optional<std::string>>* written,
+                              int* pErrorCount) {
+	state int errors = 0;
+	if (end <= start) end = keyAfter(start);
+
+	state std::map<std::pair<std::string, Version>, Optional<std::string>>::const_iterator it =
+	    written->lower_bound(std::make_pair(start.toString(), 0));
+	state std::map<std::pair<std::string, Version>, Optional<std::string>>::const_iterator itEnd =
+	    written->upper_bound(std::make_pair(end.toString(), 0));
+	state std::map<std::pair<std::string, Version>, Optional<std::string>>::const_iterator itLast;
+
+	state std::vector<KeyValue> results;
+
+	// TODO: Use a smaller row/bytes limit to meaningfully test the limit logic.
+	// TODO: Reverse iteration.
+	state Standalone<RangeResultRef> read = wait(kvStore->readRangeAt({ start, end }, version));
+
+	while (1) {
+		for (const auto& kv : read) {
+			// Find the next written kv pair that would be present at this version
+			while (1) {
+				itLast = it;
+				if (it == itEnd) break;
+				++it;
+
+				// TODO: The `it == itEnd` check here is almost certainly wrong. Either that, or we shouldn't be
+				// unconditionally dereffing it in the printf.
+				if (itLast->first.second <= version && itLast->second.present() &&
+				    (it == itEnd || it->first.first != itLast->first.first || it->first.second > version)) {
+					debug_printf("VerifyRange(@%" PRId64 ", %s, %s) Found key in written map: %s\n", v,
+					             start.printable().c_str(), end.printable().c_str(), itLast->first.first.c_str());
+					break;
+				}
+			}
+
+			if (itLast == itEnd) {
+				++errors;
+				++*pErrorCount;
+				printf("VerifyRange(@%" PRId64 ", %s, %s) ERROR: Tree key '%s' vs nothing in written map.\n", version,
+				       start.printable().c_str(), end.printable().c_str(), kv.key.toString().c_str());
+				break;
+			}
+
+			if (kv.key != itLast->first.first) {
+				++errors;
+				++*pErrorCount;
+				printf("VerifyRange(@%" PRId64 ", %s, %s) ERROR: Tree key '%s' but expected '%s'\n", version,
+				       start.printable().c_str(), end.printable().c_str(), kv.key.toString().c_str(),
+				       itLast->first.first.c_str());
+				break;
+			}
+			if (kv.value != itLast->second.get()) {
+				++errors;
+				++*pErrorCount;
+				printf("VerifyRange(@%" PRId64 ", %s, %s) ERROR: Tree key '%s' has tree value '%s' but expected '%s'\n",
+				       version, start.printable().c_str(), end.printable().c_str(), kv.key.toString().c_str(),
+				       kv.value.toString().c_str(), itLast->second.get().c_str());
+				break;
+			}
+
+			ASSERT(errors == 0);
+
+			results.push_back(kv);
+		}
+		if (read.more) {
+			Standalone<RangeResultRef> r = wait(kvStore->readRangeAt({ read.readThrough.get(), end }, version));
+			read = r;
+		} else {
+			break;
+		}
+	}
+
+	// Make sure there are no further written kv pairs that would be present at this version.
+	while (1) {
+		itLast = it;
+		if (it == itEnd) break;
+		++it;
+		if (itLast->first.second <= version && itLast->second.present() &&
+		    (it == itEnd || it->first.first != itLast->first.first || it->first.second > version))
+			break;
+	}
+
+	if (itLast != itEnd) {
+		++errors;
+		++*pErrorCount;
+		printf("VerifyRange(@%" PRId64 ", %s, %s) ERROR: Tree range ended but written has @%" PRId64 " '%s'\n", version,
+		       start.printable().c_str(), end.printable().c_str(), itLast->first.second, itLast->first.first.c_str());
+	}
+
+	debug_printf("VerifyRangeReverse(@%" PRId64 ", %s, %s): start\n", version, start.printable().c_str(),
+	             end.printable().c_str());
+
+	// Now read the range from the tree in reverse order and compare to the saved results
+	Standalone<RangeResultRef> read = wait(kvStore->readRangeAt({ start, end }, version));
+
+	state std::vector<KeyValue>::const_reverse_iterator r = results.rbegin();
+
+	while (1) {
+		for (const auto& kv : read) {
+			if (r == results.rend()) {
+				++errors;
+				++*pErrorCount;
+				printf("VerifyRangeReverse(@%" PRId64 ", %s, %s) ERROR: Tree key '%s' vs nothing in written map.\n",
+				       version, start.printable().c_str(), end.printable().c_str(), kv.key.toString().c_str());
+				break;
+			}
+
+			if (kv.key != r->key) {
+				++errors;
+				++*pErrorCount;
+				printf("VerifyRangeReverse(@%" PRId64 ", %s, %s) ERROR: Tree key '%s' but expected '%s'\n", version,
+				       start.printable().c_str(), end.printable().c_str(), kv.key.toString().c_str(),
+				       r->key.toString().c_str());
+				break;
+			}
+			if (kv.value != r->value) {
+				++errors;
+				++*pErrorCount;
+				printf("VerifyRangeReverse(@%" PRId64
+				       ", %s, %s) ERROR: Tree key '%s' has tree value '%s' but expected '%s'\n",
+				       version, start.printable().c_str(), end.printable().c_str(), kv.value.toString().c_str(),
+				       kv.value.toString().c_str(), r->value.toString().c_str());
+				break;
+			}
+
+			++r;
+		}
+		if (read.more) {
+			Standalone<RangeResultRef> r = wait(kvStore->readRangeAt({ read.readThrough.get(), end }, version));
+			read = r;
+		} else {
+			break;
+		}
+	}
+
+	if (r != results.rend()) {
+		++errors;
+		++*pErrorCount;
+		printf("VerifyRangeReverse(@%" PRId64 ", %s, %s) ERROR: Tree range ended but written has '%s'\n", version,
+		       start.printable().c_str(), end.printable().c_str(), r->key.toString().c_str());
+	}
+
+	return errors;
+}
+
+// Verify the result of point reads for every set or cleared key at the given version
+ACTOR Future<int> seekAll(IKeyValueStore* kvStore, Version version,
+                          std::map<std::pair<std::string, Version>, Optional<std::string>>* written, int* pErrorCount) {
+	state std::map<std::pair<std::string, Version>, Optional<std::string>>::const_iterator it = written->cbegin();
+	state std::map<std::pair<std::string, Version>, Optional<std::string>>::const_iterator itEnd = written->cend();
+	state int errors = 0;
+
+	while (it != itEnd) {
+		state std::string key = it->first.first;
+		if (it->first.second == version) {
+			debug_printf("Verifying @%" PRId64 " '%s'\n", ver, key.c_str());
+			state Arena arena;
+			Optional<Value> value = wait(kvStore->readValueAt(KeyRef(arena, key), version));
+
+			const auto& expected = it->second;
+			if (expected.present()) {
+				if (value.castTo<StringRef>() != expected.castTo<StringRef>()) {
+					++errors;
+					++*pErrorCount;
+					if (value.present()) {
+						printf("Verify ERROR: value_incorrect: for '%s' found '%s' expected '%s' @%" PRId64 "\n",
+						       key.c_str(), value.get().toString().c_str(), expected.get().c_str(), version);
+					} else {
+						printf("Verify ERROR: value_missing: for '%s' expected '%s' @%" PRId64 "\n", key.c_str(),
+						       expected.get().c_str(), version);
+					}
+				}
+			} else {
+				if (value.present()) {
+					++errors;
+					++*pErrorCount;
+					printf("Verify ERROR: cleared_key_found: '%s' -> '%s' @%" PRId64 "\n", key.c_str(),
+					       value.get().toString().c_str(), version);
+				}
+			}
+		}
+		++it;
+	}
+	return errors;
+}
+
+ACTOR Future<Void> verify(IKeyValueStore* kvStore, FutureStream<Version> vStream,
+                          std::map<std::pair<std::string, Version>, Optional<std::string>>* written, int* pErrorCount,
+                          bool serial) {
+	state Future<int> fRangeAll;
+	state Future<int> fRangeRandom;
+	state Future<int> fSeekAll;
+
+	// Queue of committed versions still readable from kvStore
+	state std::deque<Version> committedVersions;
+
+	try {
+		loop {
+			state Version v = waitNext(vStream);
+			committedVersions.push_back(v);
+
+			// Remove expired versions
+			while (!committedVersions.empty() && committedVersions.front() < kvStore->getOldestVersion()) {
+				committedVersions.pop_front();
+			}
+
+			// Continue if the versions list is empty, which won't wait until it reaches the oldest readable
+			// kvStore version which will already be in vStream.
+			if (committedVersions.empty()) {
+				continue;
+			}
+
+			// Choose a random committed version.
+			v = committedVersions[deterministicRandom()->randomInt(0, committedVersions.size())];
+
+			debug_printf("Using committed version %" PRId64 "\n", v);
+
+			debug_printf("Verifying entire key range at version %" PRId64 "\n", v);
+			fRangeAll =
+			    verifyRange(kvStore, LiteralStringRef(""), LiteralStringRef("\xff\xff"), v, written, pErrorCount);
+
+			if (serial) {
+				wait(success(fRangeAll));
+			}
+
+			Key begin = randomKV().key;
+			Key end = randomKV().key;
+			debug_printf("Verifying range (%s, %s) at version %" PRId64 "\n", toString(begin).c_str(),
+			             toString(end).c_str(), v);
+			fRangeRandom = verifyRange(kvStore, begin, end, v, written, pErrorCount);
+			if (serial) {
+				wait(success(fRangeRandom));
+			}
+
+			debug_printf("Verifying seeks to each changed key at version %" PRId64 "\n", v);
+			fSeekAll = seekAll(kvStore, v, written, pErrorCount);
+			if (serial) {
+				wait(success(fSeekAll));
+			}
+
+			wait(success(fRangeAll) && success(fRangeRandom) && success(fSeekAll));
+
+			printf("Verified version %" PRId64 ", %d errors\n", v, *pErrorCount);
+
+			if (*pErrorCount != 0) break;
+		}
+	} catch (Error& e) {
+		if (e.code() != error_code_end_of_stream && e.code() != error_code_transaction_too_old) {
+			throw;
+		}
+	}
+	return Void();
+}
+
+} // namespace
+
+TEST_CASE("!/IKeyValueStore/correctness/") {
+	state bool serialTest = deterministicRandom()->coinflip();
+	state bool shortTest = deterministicRandom()->coinflip();
+
+	state int pageSize =
+	    shortTest ? 200 : (deterministicRandom()->coinflip() ? 4096 : deterministicRandom()->randomInt(200, 400));
+
+	state int64_t targetPageOps = shortTest ? 50000 : 1000000;
+	state bool pagerMemoryOnly = shortTest && (deterministicRandom()->random01() < .001);
+	state int maxKeySize = deterministicRandom()->randomInt(1, pageSize * 2);
+	state int maxValueSize = randomSize(pageSize * 25);
+	state int maxCommitSize = shortTest ? 1000 : randomSize(std::min<int>((maxKeySize + maxValueSize) * 20000, 10e6));
+	state double clearProbability = deterministicRandom()->random01() * .1;
+	state double clearSingleKeyProbability = deterministicRandom()->random01();
+	state double clearPostSetProbability = deterministicRandom()->random01() * .1;
+	state double coldStartProbability = pagerMemoryOnly ? 0 : (deterministicRandom()->random01() * 0.3);
+	state double advanceOldVersionProbability = deterministicRandom()->random01();
+	state Version versionIncrement = deterministicRandom()->randomInt64(1, 1e8);
+	state int maxVerificationMapEntries = 300e3;
+
+	printf("\n");
+	printf("targetPageOps: %" PRId64 "\n", targetPageOps);
+	printf("pagerMemoryOnly: %d\n", pagerMemoryOnly);
+	printf("serialTest: %d\n", serialTest);
+	printf("shortTest: %d\n", shortTest);
+	printf("pageSize: %d\n", pageSize);
+	printf("maxKeySize: %d\n", maxKeySize);
+	printf("maxValueSize: %d\n", maxValueSize);
+	printf("maxCommitSize: %d\n", maxCommitSize);
+	printf("clearProbability: %f\n", clearProbability);
+	printf("clearSingleKeyProbability: %f\n", clearSingleKeyProbability);
+	printf("clearPostSetProbability: %f\n", clearPostSetProbability);
+	printf("coldStartProbability: %f\n", coldStartProbability);
+	printf("advanceOldVersionProbability: %f\n", advanceOldVersionProbability);
+	printf("versionIncrement: %" PRId64 "\n", versionIncrement);
+	printf("maxVerificationMapEntries: %d\n", maxVerificationMapEntries);
+	printf("\n");
+
+	printf("Deleting existing test data...\n");
+	platform::eraseDirectoryRecursive("/tmp/fakeRocks");
+
+	printf("Initializing...\n");
+	state IKeyValueStore* kvStore = keyValueStoreRocksDB("/tmp/fakeRocks", deterministicRandom()->randomUniqueID(),
+	                                                     KeyValueStoreType::SSD_ROCKSDB_V1, false, false);
+	wait(kvStore->init());
+
+	state std::map<std::pair<std::string, Version>, Optional<std::string>> written;
+	state std::set<Key> keys;
+
+	state Version lastVer = kvStore->getLastCommittedVersion();
+	printf("Starting from version: %" PRId64 "\n", lastVer);
+
+	state Version version = lastVer + 1;
+	kvStore->setWriteVersion(version);
+
+	state SimpleCounter mutationBytes;
+	state SimpleCounter keyBytesInserted;
+	state SimpleCounter valueBytesInserted;
+	state SimpleCounter sets;
+	state SimpleCounter rangeClears;
+	state SimpleCounter keyBytesCleared;
+	state int errorCount;
+	state int mutationBytesThisCommit = 0;
+	state int mutationBytesTargetThisCommit = randomSize(maxCommitSize);
+
+	state PromiseStream<Version> committedVersions;
+	state Future<Void> verifyTask = verify(kvStore, committedVersions.getFuture(), &written, &errorCount, serialTest);
+	state Future<Void> randomTask = serialTest ? Void() : (randomReader(kvStore) || kvStore->getError());
+	committedVersions.send(lastVer);
+
+	state Future<Void> commit = Void();
+	state int64_t totalPageOps = 0;
+
+	while (totalPageOps < targetPageOps && written.size() < maxVerificationMapEntries) {
+		// Sometimes increment the version
+		if (deterministicRandom()->random01() < 0.10) {
+			++version;
+			kvStore->setWriteVersion(version);
+		}
+
+		// Sometimes do a clear range
+		if (deterministicRandom()->random01() < clearProbability) {
+			Key start = randomKV(maxKeySize, 1).key;
+			Key end = (deterministicRandom()->random01() < .01) ? keyAfter(start) : randomKV(maxKeySize, 1).key;
+
+			// Sometimes replace start and/or end with a close actual (previously used) value
+			if (deterministicRandom()->random01() < .10) {
+				auto i = keys.upper_bound(start);
+				if (i != keys.end()) start = *i;
+			}
+			if (deterministicRandom()->random01() < .10) {
+				auto i = keys.upper_bound(end);
+				if (i != keys.end()) end = *i;
+			}
+
+			// Do a single key clear based on probability or end being randomly chosen to be the same as begin
+			// (unlikely)
+			if (deterministicRandom()->random01() < clearSingleKeyProbability || end == start) {
+				end = keyAfter(start);
+			} else if (end < start) {
+				std::swap(end, start);
+			}
+
+			// Apply clear range to verification map
+			++rangeClears;
+			KeyRangeRef range(start, end);
+			debug_printf("      Mutation:  Clear '%s' to '%s' @%" PRId64 "\n", start.toString().c_str(),
+			             end.toString().c_str(), version);
+			auto e = written.lower_bound(std::make_pair(start.toString(), 0));
+			if (e != written.end()) {
+				auto last = e;
+				auto eEnd = written.lower_bound(std::make_pair(end.toString(), 0));
+				while (e != eEnd) {
+					auto w = *e;
+					++e;
+					// If e key is different from last and last was present then insert clear for last's key at version
+					if (last != eEnd &&
+					    ((e == eEnd || e->first.first != last->first.first) && last->second.present())) {
+						debug_printf("      Mutation:    Clearing key '%s' @%" PRId64 "\n", last->first.first.c_str(),
+						             version);
+
+						keyBytesCleared += last->first.first.size();
+						mutationBytes += last->first.first.size();
+						mutationBytesThisCommit += last->first.first.size();
+
+						// If the last set was at version then just make it not present
+						if (last->first.second == version) {
+							last->second.reset();
+						} else {
+							written[std::make_pair(last->first.first, version)].reset();
+						}
+					}
+					last = e;
+				}
+			}
+
+			kvStore->clear(range);
+
+			// Sometimes set the range start after the clear
+			if (deterministicRandom()->random01() < clearPostSetProbability) {
+				KeyValue kv = randomKV(0, maxValueSize);
+				kv.key = range.begin;
+				kvStore->set(kv);
+				written[std::make_pair(kv.key.toString(), version)] = kv.value.toString();
+			}
+		} else {
+			// Set a key
+			KeyValue kv = randomKV(maxKeySize, maxValueSize);
+			// Sometimes change key to a close previously used key
+			if (deterministicRandom()->random01() < .01) {
+				auto i = keys.upper_bound(kv.key);
+				if (i != keys.end()) kv.key = StringRef(kv.arena(), *i);
+			}
+
+			debug_printf("      Mutation:  Set '%s' -> '%s' @%" PRId64 "\n", kv.key.toString().c_str(),
+			             kv.value.toString().c_str(), version);
+
+			++sets;
+			keyBytesInserted += kv.key.size();
+			valueBytesInserted += kv.value.size();
+			mutationBytes += (kv.key.size() + kv.value.size());
+			mutationBytesThisCommit += (kv.key.size() + kv.value.size());
+
+			kvStore->set(kv);
+			written[std::make_pair(kv.key.toString(), version)] = kv.value.toString();
+			keys.insert(kv.key);
+		}
+
+		// Commit after any limits for this commit or the total test are reached
+		if (totalPageOps >= targetPageOps || written.size() >= maxVerificationMapEntries ||
+		    mutationBytesThisCommit >= mutationBytesTargetThisCommit) {
+			// Wait for previous commit to finish
+			wait(commit);
+			printf("Committed.  Next commit %d bytes, %" PRId64 " bytes.", mutationBytesThisCommit,
+			       mutationBytes.get());
+			printf("  Stats:  Insert %.2f MB/s  ClearedKeys %.2f MB/s  Total %.2f\n",
+			       (keyBytesInserted.rate() + valueBytesInserted.rate()) / 1e6, keyBytesCleared.rate() / 1e6,
+			       mutationBytes.rate() / 1e6);
+
+			Version v = version; // Avoid capture of version as a member of *this
+
+			// Sometimes advance the oldest version to close the gap between the oldest and latest versions by a random
+			// amount.
+			if (deterministicRandom()->random01() < advanceOldVersionProbability) {
+				kvStore->setOldestVersion(kvStore->getLastCommittedVersion() -
+				                          deterministicRandom()->randomInt64(0, kvStore->getLastCommittedVersion() -
+				                                                                    kvStore->getOldestVersion() + 1));
+			}
+
+			commit = map(kvStore->commit(), [=, &ops = totalPageOps](Void) {
+				// Notify the background verifier that version is committed and therefore readable
+				committedVersions.send(v);
+				return Void();
+			});
+
+			if (serialTest) {
+				// Wait for commit, wait for verification, then start new verification
+				wait(commit);
+				committedVersions.sendError(end_of_stream());
+				debug_printf("Waiting for verification to complete.\n");
+				wait(verifyTask);
+				committedVersions = PromiseStream<Version>();
+				verifyTask = verify(kvStore, committedVersions.getFuture(), &written, &errorCount, serialTest);
+			}
+
+			mutationBytesThisCommit = 0;
+			mutationBytesTargetThisCommit = randomSize(maxCommitSize);
+
+			// Recover from disk at random
+			if (!serialTest && deterministicRandom()->random01() < coldStartProbability) {
+				printf("Recovering from disk after next commit.\n");
+
+				// Wait for outstanding commit
+				debug_printf("Waiting for outstanding commit\n");
+				wait(commit);
+
+				// Stop and wait for the verifier task
+				committedVersions.sendError(end_of_stream());
+				debug_printf("Waiting for verification to complete.\n");
+				wait(verifyTask);
+
+				debug_printf("Closing kvStore\n");
+				Future<Void> closedFuture = kvStore->onClosed();
+				kvStore->close();
+				wait(closedFuture);
+
+				printf("Reopening kvStore from disk.\n");
+				kvStore = keyValueStoreRocksDB("/tmp/fakeRocks", deterministicRandom()->randomUniqueID(),
+				                               KeyValueStoreType::SSD_ROCKSDB_V1, false, false);
+				wait(kvStore->init());
+
+				Version v = kvStore->getLastCommittedVersion();
+				ASSERT(v == version);
+				printf("Recovered from disk.  Latest version %" PRId64 "\n", v);
+
+				// Create new promise stream and start the verifier again
+				committedVersions = PromiseStream<Version>();
+				verifyTask = verify(kvStore, committedVersions.getFuture(), &written, &errorCount, serialTest);
+				randomTask = randomReader(kvStore) || kvStore->getError();
+				committedVersions.send(v);
+			}
+
+			version += versionIncrement;
+			kvStore->setWriteVersion(version);
+		}
+
+		// Check for errors
+		ASSERT(errorCount == 0);
+	}
+
+	debug_printf("Waiting for outstanding commit\n");
+	wait(commit);
+	committedVersions.sendError(end_of_stream());
+	randomTask.cancel();
+	debug_printf("Waiting for verification to complete.\n");
+	wait(verifyTask);
+
+	// Check for errors
+	ASSERT(errorCount == 0);
+
+	state Future<Void> closedFuture = kvStore->onClosed();
+	kvStore->dispose();
+	debug_printf("Closing.\n");
+	wait(closedFuture);
+
+	return Void();
+}

--- a/fdbserver/IKeyValueStore.actor.cpp
+++ b/fdbserver/IKeyValueStore.actor.cpp
@@ -184,7 +184,7 @@ ACTOR Future<int> verifyRange(IKeyValueStore* kvStore, Key start, Key end, Versi
 
 	// Now read the range from the tree in reverse order and compare to the saved results
 	// TODO: This doesn't handle the start/end correctly.
-	Standalone<RangeResultRef> r = wait(kvStore->readRangeAt({ end, start }, version, -(1 << 30)));
+	Standalone<RangeResultRef> r = wait(kvStore->readRangeAt({ start, end }, version, -(1 << 30)));
 	read = r;
 
 	state std::vector<KeyValue>::const_reverse_iterator rit = results.rbegin();

--- a/fdbserver/IKeyValueStore.h
+++ b/fdbserver/IKeyValueStore.h
@@ -63,6 +63,12 @@ public:
 
 	virtual void enableSnapshot() {}
 
+	// Inform storage engines that run outside of flow that they need to shut down.  This is needed for
+	// RocksDB, since it manages a threadpool outside the simulator, and those threads could continue to write
+	// invalid data after the RocksDB database is reopened.  Most implementations used the default (empty)
+	// implementation of this method, as performing cleanup tasks here significantly reduces the coverage and
+	// accuracy of the simulator.
+	virtual void preSimulatedCrashHookForNonFlowStorageEngines() { }
 	/*
 	Concurrency contract
 		Causal consistency:

--- a/fdbserver/IKeyValueStore.h
+++ b/fdbserver/IKeyValueStore.h
@@ -40,27 +40,15 @@ public:
 	virtual KeyValueStoreType getType() = 0;
 	virtual void set( KeyValueRef keyValue, const Arena* arena = NULL ) = 0;
 	virtual void clear( KeyRangeRef range, const Arena* arena = NULL ) = 0;
-	virtual Future<Void> commit(Version version, bool sequential = false) { return commit(sequential); }
 	virtual Future<Void> commit(bool sequential = false) = 0;  // returns when prior sets and clears are (atomically) durable
 
-	virtual Future<Optional<Value>> readValue(KeyRef key, Version version, Optional<UID> debugID = Optional<UID>()) {
-		return readValue(key, debugID);
-	}
 	virtual Future<Optional<Value>> readValue( KeyRef key, Optional<UID> debugID = Optional<UID>() ) = 0;
 
 	// Like readValue(), but returns only the first maxLength bytes of the value if it is longer
-	virtual Future<Optional<Value>> readValuePrefix(KeyRef key, int maxLength, Version version,
-	                                                Optional<UID> debugID = Optional<UID>()) {
-		return readValuePrefix(key, maxLength, debugID);
-	}
 	virtual Future<Optional<Value>> readValuePrefix( KeyRef key, int maxLength, Optional<UID> debugID = Optional<UID>() ) = 0;
 
 	// If rowLimit>=0, reads first rows sorted ascending, otherwise reads last rows sorted descending
 	// The total size of the returned value (less the last entry) will be less than byteLimit
-	virtual Future<Standalone<RangeResultRef>> readRange(KeyRangeRef keys, Version version, int rowLimit = 1 << 30,
-	                                                     int byteLimit = 1 << 30) {
-		return readRange(keys, rowLimit, byteLimit);
-	}
 	virtual Future<Standalone<RangeResultRef>> readRange( KeyRangeRef keys, int rowLimit = 1<<30, int byteLimit = 1<<30 ) = 0;
 
 	// To debug MEMORY_RADIXTREE type ONLY
@@ -93,6 +81,30 @@ public:
 	virtual Future<Void> init() {
 		return Void();
 	}
+
+	// Versioned-specific interface.
+	virtual bool supportsVersions() { return false; }
+
+	virtual void setWriteVersion(Version version) {}
+	virtual Version getLastCommittedVersion() { return 0; }
+	virtual Version getOldestVersion() { return 0; }
+	virtual void setOldestVersion(Version version) {}
+
+	// TODO: Should the default implementations just fail an ASSERT?
+	virtual Future<Optional<Value>> readValueAt(KeyRef key, Version version, Optional<UID> debugID = Optional<UID>()) {
+		return readValue(key, debugID);
+	}
+
+	virtual Future<Optional<Value>> readValuePrefixAt(KeyRef key, int maxLength, Version version,
+	                                                  Optional<UID> debugID = Optional<UID>()) {
+		return readValuePrefix(key, maxLength, debugID);
+	}
+
+	virtual Future<Standalone<RangeResultRef>> readRangeAt(KeyRangeRef keys, Version version, int rowLimit = 1 << 30,
+	                                                       int byteLimit = 1 << 30) {
+		return readRange(keys, rowLimit, byteLimit);
+	}
+
 protected:
 	virtual ~IKeyValueStore() {}
 };

--- a/fdbserver/IKeyValueStore.h
+++ b/fdbserver/IKeyValueStore.h
@@ -40,15 +40,27 @@ public:
 	virtual KeyValueStoreType getType() = 0;
 	virtual void set( KeyValueRef keyValue, const Arena* arena = NULL ) = 0;
 	virtual void clear( KeyRangeRef range, const Arena* arena = NULL ) = 0;
+	virtual Future<Void> commit(Version version, bool sequential = false) { return commit(sequential); }
 	virtual Future<Void> commit(bool sequential = false) = 0;  // returns when prior sets and clears are (atomically) durable
 
+	virtual Future<Optional<Value>> readValue(KeyRef key, Version version, Optional<UID> debugID = Optional<UID>()) {
+		return readValue(key, debugID);
+	}
 	virtual Future<Optional<Value>> readValue( KeyRef key, Optional<UID> debugID = Optional<UID>() ) = 0;
 
 	// Like readValue(), but returns only the first maxLength bytes of the value if it is longer
+	virtual Future<Optional<Value>> readValuePrefix(KeyRef key, int maxLength, Version version,
+	                                                Optional<UID> debugID = Optional<UID>()) {
+		return readValuePrefix(key, maxLength, debugID);
+	}
 	virtual Future<Optional<Value>> readValuePrefix( KeyRef key, int maxLength, Optional<UID> debugID = Optional<UID>() ) = 0;
 
 	// If rowLimit>=0, reads first rows sorted ascending, otherwise reads last rows sorted descending
 	// The total size of the returned value (less the last entry) will be less than byteLimit
+	virtual Future<Standalone<RangeResultRef>> readRange(KeyRangeRef keys, Version version, int rowLimit = 1 << 30,
+	                                                     int byteLimit = 1 << 30) {
+		return readRange(keys, rowLimit, byteLimit);
+	}
 	virtual Future<Standalone<RangeResultRef>> readRange( KeyRangeRef keys, int rowLimit = 1<<30, int byteLimit = 1<<30 ) = 0;
 
 	// To debug MEMORY_RADIXTREE type ONLY

--- a/fdbserver/KeyValueStoreRocksDB.actor.cpp
+++ b/fdbserver/KeyValueStoreRocksDB.actor.cpp
@@ -9,6 +9,7 @@
 #endif // SSD_ROCKSDB_EXPERIMENTAL
 
 #include "fdbserver/IKeyValueStore.h"
+#include "fdbrpc/simulator.h"
 #include "flow/actorcompiler.h" // has to be last include
 
 #ifdef SSD_ROCKSDB_EXPERIMENTAL
@@ -46,264 +47,296 @@ rocksdb::Options getOptions() {
 }
 
 struct RocksDBKeyValueStore : IKeyValueStore {
-	using DB = rocksdb::DB*;
 	using CF = rocksdb::ColumnFamilyHandle*;
 
-	struct Writer : IThreadPoolReceiver {
-		DB& db;
-		UID id;
+	rocksdb::ReadOptions readOptions;
 
-		explicit Writer(DB& db, UID id) : db(db), id(id) {}
+	template<typename T>
+	void post(Reference<IThreadPool> const & threadPool, T & future) {
+		if (!g_network->isSimulated()) {
+			threadPool->post(future);
+		} else {
+			action(*future);
+			delete future;
+		}
+	}
 
-		~Writer() override {
-			if (db) {
-				delete db;
+	template<typename T>
+	struct StoreReceiver : IThreadPoolReceiver {
+		RocksDBKeyValueStore * const store;
+
+		explicit StoreReceiver(RocksDBKeyValueStore * store) : store(store) {}
+
+		void init() override {
+			if (store->proc != nullptr) {
+				ISimulator::currentProcess = store->proc;
 			}
 		}
 
-		void init() override {}
+		template<typename U>
+		std::enable_if_t<std::is_same_v<T, typename U::Receiver>, void> action(U &a){ store->action(a); }
+	};
 
-		Error statusToError(const rocksdb::Status& s) {
-			if (s == rocksdb::Status::IOError()) {
-				return io_error();
-			} else {
-				return unknown_error();
-			}
+	struct Writer : StoreReceiver<Writer> {
+		explicit Writer(RocksDBKeyValueStore * store) : StoreReceiver<Writer>(store) { }
+	};
+	struct Reader : StoreReceiver<Reader> {
+		explicit Reader(RocksDBKeyValueStore * store) : StoreReceiver<Reader>(store) { }
+	};
+
+	Error statusToError(const rocksdb::Status& s) {
+		if (s == rocksdb::Status::IOError()) {
+			return io_error();
+		} else {
+			return unknown_error();
 		}
+	}
 
-		struct OpenAction : TypedAction<Writer, OpenAction> {
-			std::string path;
-			ThreadReturnPromise<Void> done;
+	struct OpenAction : TypedAction<Writer, OpenAction> {
+		std::string path;
+		ThreadReturnPromise<Void> done;
 
-			double getTimeEstimate() {
-				return SERVER_KNOBS->COMMIT_TIME_ESTIMATE;
-			}
-		};
-		void action(OpenAction& a) {
-			std::vector<rocksdb::ColumnFamilyDescriptor> defaultCF = { rocksdb::ColumnFamilyDescriptor{
-				"default", getCFOptions() } };
-			std::vector<rocksdb::ColumnFamilyHandle*> handle;
-			auto status = rocksdb::DB::Open(getOptions(), a.path, defaultCF, &handle, &db);
-			if (!status.ok()) {
-				TraceEvent(SevError, "RocksDBError").detail("Error", status.ToString()).detail("Method", "Open");
-				a.done.sendError(statusToError(status));
-			} else {
-				TraceEvent(SevInfo, "RocksDB").detail("Path", a.path).detail("Method", "Open");
-				a.done.send(Void());
-			}
+		double getTimeEstimate() {
+			return SERVER_KNOBS->COMMIT_TIME_ESTIMATE;
 		}
+	};
 
-		struct DeleteVisitor : public rocksdb::WriteBatch::Handler {
-			VectorRef<KeyRangeRef>& deletes;
-			Arena& arena;
+	void action(OpenAction& a) {
+		std::vector<rocksdb::ColumnFamilyDescriptor> defaultCF = { rocksdb::ColumnFamilyDescriptor{
+			"default", getCFOptions() } };
+		std::vector<rocksdb::ColumnFamilyHandle*> handle;
+		rocksdb::DB * newDB = nullptr;
+		auto status = rocksdb::DB::Open(getOptions(), a.path, defaultCF, &handle, &newDB);
+		db.reset(newDB);
+		if (!status.ok()) {
+			handle.clear();
+			TraceEvent(SevWarn, "RocksDBError").detail("Warn", status.ToString()).detail("Method", "Open (will retry)");
+			// TODO: Back the database up instead of just nuking it!
+			rocksdb::DestroyDB(a.path, getOptions(), defaultCF);
+			status = rocksdb::DB::Open(getOptions(), a.path, defaultCF, &handle, &newDB);
+			db.reset(newDB);
+		}
+		if (!status.ok()) {
+			TraceEvent(SevError, "RocksDBError").detail("Error", status.ToString()).detail("Method", "Open");
+			a.done.sendError(statusToError(status));
+		} else {
+			a.done.send(Void());
+		}
+	}
 
-			DeleteVisitor(VectorRef<KeyRangeRef>& deletes, Arena& arena) : deletes(deletes), arena(arena) {}
+  struct DeleteVisitor : public rocksdb::WriteBatch::Handler {
+    VectorRef<KeyRangeRef>& deletes;
+    Arena& arena;
 
-			rocksdb::Status DeleteRangeCF(uint32_t /*column_family_id*/, const rocksdb::Slice& begin,
+    DeleteVisitor(VectorRef<KeyRangeRef>& deletes, Arena& arena) : deletes(deletes), arena(arena) {}
+
+    rocksdb::Status DeleteRangeCF(uint32_t /*column_family_id*/, const rocksdb::Slice& begin,
 			                              const rocksdb::Slice& end) override {
-				KeyRangeRef kr(toStringRef(begin), toStringRef(end));
-				deletes.push_back_deep(arena, kr);
-				return rocksdb::Status::OK();
-			}
-		};
+      KeyRangeRef kr(toStringRef(begin), toStringRef(end));
+      deletes.push_back_deep(arena, kr);
+      return rocksdb::Status::OK();
+    }
+  };
 
-		struct CommitAction : TypedAction<Writer, CommitAction> {
-			std::unique_ptr<rocksdb::WriteBatch> batchToCommit;
-			ThreadReturnPromise<Void> done;
-			double getTimeEstimate() override { return SERVER_KNOBS->COMMIT_TIME_ESTIMATE; }
-		};
-		void action(CommitAction& a) {
-			Standalone<VectorRef<KeyRangeRef>> deletes;
-			DeleteVisitor dv(deletes, deletes.arena());
-			ASSERT(a.batchToCommit->Iterate(&dv).ok());
-			// If there are any range deletes, we should have added them to be deleted.
-			ASSERT(!deletes.empty() || !a.batchToCommit->HasDeleteRange());
-			rocksdb::WriteOptions options;
-			options.sync = !SERVER_KNOBS->ROCKSDB_UNSAFE_AUTO_FSYNC;
-			auto s = db->Write(options, a.batchToCommit.get());
-			if (!s.ok()) {
-				TraceEvent(SevError, "RocksDBError").detail("Error", s.ToString()).detail("Method", "Commit");
-				a.done.sendError(statusToError(s));
-			} else {
-				a.done.send(Void());
-				for (const auto& keyRange : deletes) {
-					auto begin = toSlice(keyRange.begin);
-					auto end = toSlice(keyRange.end);
-					ASSERT(db->SuggestCompactRange(db->DefaultColumnFamily(), &begin, &end).ok());
-				}
+	struct CommitAction : TypedAction<Writer, CommitAction> {
+		std::unique_ptr<rocksdb::WriteBatch> batchToCommit;
+		ThreadReturnPromise<Void> done;
+		double getTimeEstimate() override { return SERVER_KNOBS->COMMIT_TIME_ESTIMATE; }
+	};
+	void action(CommitAction& a) {
+		Standalone<VectorRef<KeyRangeRef>> deletes;
+ 		DeleteVisitor dv(deletes, deletes.arena());
+ 		ASSERT(a.batchToCommit->Iterate(&dv).ok());
+ 		// If there are any range deletes, we should have added them to be deleted.
+ 		ASSERT(!deletes.empty() || !a.batchToCommit->HasDeleteRange());
+		rocksdb::WriteOptions options;
+		options.sync = true;
+		auto s = db->Write(options, a.batchToCommit.get());
+		if (!s.ok()) {
+			TraceEvent(SevError, "RocksDBError").detail("Error", s.ToString()).detail("Method", "Commit");
+			a.done.sendError(statusToError(s));
+		} else {
+			a.done.send(Void());
+			for (const auto& keyRange : deletes) {
+				auto begin = toSlice(keyRange.begin);
+				auto end = toSlice(keyRange.end);
+				ASSERT(db->SuggestCompactRange(db->DefaultColumnFamily(), &begin, &end).ok());
 			}
 		}
+	}
 
-		struct CloseAction : TypedAction<Writer, CloseAction> {
-			ThreadReturnPromise<Void> done;
-			std::string path;
-			bool deleteOnClose;
-			CloseAction(std::string path, bool deleteOnClose) : path(path), deleteOnClose(deleteOnClose) {}
-			double getTimeEstimate() override { return SERVER_KNOBS->COMMIT_TIME_ESTIMATE; }
-		};
-		void action(CloseAction& a) {
-			if (db == nullptr) {
-				a.done.send(Void());
-				return;
-			}
+	struct CloseAction : TypedAction<Writer, CloseAction> {
+		ThreadReturnPromise<Void> done;
+		std::string path;
+		bool deleteOnClose;
+		CloseAction(std::string path, bool deleteOnClose) : path(path), deleteOnClose(deleteOnClose) {}
+		double getTimeEstimate() override { return SERVER_KNOBS->COMMIT_TIME_ESTIMATE; }
+	};
+	void action(CloseAction& a) {
+		if (db) {
 			auto s = db->Close();
 			if (!s.ok()) {
 				TraceEvent(SevError, "RocksDBError").detail("Error", s.ToString()).detail("Method", "Close");
 			}
+			db = nullptr;
 			if (a.deleteOnClose) {
 				std::vector<rocksdb::ColumnFamilyDescriptor> defaultCF = { rocksdb::ColumnFamilyDescriptor{
 					"default", getCFOptions() } };
-				s = rocksdb::DestroyDB(a.path, getOptions(), defaultCF);
-				if (!s.ok()) {
-					TraceEvent(SevError, "RocksDBError").detail("Error", s.ToString()).detail("Method", "Destroy");
-				} else {
-					TraceEvent(SevInfo, "RocksDB").detail("Path", a.path).detail("Method", "Destroy");
-				}
+				rocksdb::DestroyDB(a.path, getOptions(), defaultCF);
 			}
-			TraceEvent(SevInfo, "RocksDB").detail("Path", a.path).detail("Method", "Close");
-			a.done.send(Void());
 		}
+		if (proc) {
+			proc->machine->nonFlowStores.erase(a.path);
+			proc = nullptr;
+		}
+		a.done.send(Void());
+	}
+
+	struct ReadValueAction : TypedAction<Reader, ReadValueAction> {
+		Key key;
+		Optional<UID> debugID;
+		ThreadReturnPromise<Optional<Value>> result;
+		ReadValueAction(KeyRef key, Optional<UID> debugID)
+			: key(key), debugID(debugID)
+		{}
+		double getTimeEstimate() override { return SERVER_KNOBS->READ_VALUE_TIME_ESTIMATE; }
 	};
-
-	struct Reader : IThreadPoolReceiver {
-		DB& db;
-
-		explicit Reader(DB& db) : db(db) {}
-
-		void init() override {}
-
-		struct ReadValueAction : TypedAction<Reader, ReadValueAction> {
-			Key key;
-			Optional<UID> debugID;
-			ThreadReturnPromise<Optional<Value>> result;
-			ReadValueAction(KeyRef key, Optional<UID> debugID)
-				: key(key), debugID(debugID)
-			{}
-			double getTimeEstimate() override { return SERVER_KNOBS->READ_VALUE_TIME_ESTIMATE; }
-		};
-		void action(ReadValueAction& a) {
-			Optional<TraceBatch> traceBatch;
-			if (a.debugID.present()) {
-				traceBatch = { TraceBatch{} };
-				traceBatch.get().addEvent("GetValueDebug", a.debugID.get().first(), "Reader.Before");
-			}
-			rocksdb::PinnableSlice value;
-			auto s = db->Get({}, db->DefaultColumnFamily(), toSlice(a.key), &value);
-			if (a.debugID.present()) {
-				traceBatch.get().addEvent("GetValueDebug", a.debugID.get().first(), "Reader.After");
-				traceBatch.get().dump();
-			}
-			if (s.ok()) {
-				a.result.send(Value(toStringRef(value)));
-			} else {
-				if (!s.IsNotFound()) {
-					TraceEvent(SevError, "RocksDBError").detail("Error", s.ToString()).detail("Method", "ReadValue");
-				}
-				a.result.send(Optional<Value>());
-			}
+	void action(ReadValueAction& a) {
+		Optional<TraceBatch> traceBatch;
+		if (a.debugID.present()) {
+			traceBatch = { TraceBatch{} };
+			traceBatch.get().addEvent("GetValueDebug", a.debugID.get().first(), "Reader.Before");
 		}
-
-		struct ReadValuePrefixAction : TypedAction<Reader, ReadValuePrefixAction> {
-			Key key;
-			int maxLength;
-			Optional<UID> debugID;
-			ThreadReturnPromise<Optional<Value>> result;
-			ReadValuePrefixAction(Key key, int maxLength, Optional<UID> debugID) : key(key), maxLength(maxLength), debugID(debugID) {};
-			virtual double getTimeEstimate() { return SERVER_KNOBS->READ_VALUE_TIME_ESTIMATE; }
-		};
-		void action(ReadValuePrefixAction& a) {
-			rocksdb::PinnableSlice value;
-			Optional<TraceBatch> traceBatch;
-			if (a.debugID.present()) {
-				traceBatch = { TraceBatch{} };
-				traceBatch.get().addEvent("GetValuePrefixDebug", a.debugID.get().first(),
-				                          "Reader.Before"); //.detail("TaskID", g_network->getCurrentTask());
-			}
-			auto s = db->Get({}, db->DefaultColumnFamily(), toSlice(a.key), &value);
-			if (a.debugID.present()) {
-				traceBatch.get().addEvent("GetValuePrefixDebug", a.debugID.get().first(),
-				                          "Reader.After"); //.detail("TaskID", g_network->getCurrentTask());
-				traceBatch.get().dump();
-			}
-			if (s.ok()) {
-				a.result.send(Value(StringRef(reinterpret_cast<const uint8_t*>(value.data()),
-											  std::min(value.size(), size_t(a.maxLength)))));
-			} else {
-				TraceEvent(SevError, "RocksDBError").detail("Error", s.ToString()).detail("Method", "ReadValuePrefix");
-				a.result.send(Optional<Value>());
-			}
+		rocksdb::PinnableSlice value;
+		auto s = db->Get(readOptions, db->DefaultColumnFamily(), toSlice(a.key), &value);
+		if (a.debugID.present()) {
+			traceBatch.get().addEvent("GetValueDebug", a.debugID.get().first(), "Reader.After");
+			traceBatch.get().dump();
 		}
+		if (s.ok()) {
+			a.result.send(Value(toStringRef(value)));
+		} else {
+			if (!s.IsNotFound()) {
+				TraceEvent(SevError, "RocksDBError").detail("Error", s.ToString()).detail("Method", "ReadValue");
+			}
+			a.result.send(Optional<Value>());
+		}
+	}
 
-		struct ReadRangeAction : TypedAction<Reader, ReadRangeAction>, FastAllocated<ReadRangeAction> {
-			KeyRange keys;
-			int rowLimit, byteLimit;
-			ThreadReturnPromise<Standalone<RangeResultRef>> result;
-			ReadRangeAction(KeyRange keys, int rowLimit, int byteLimit) : keys(keys), rowLimit(rowLimit), byteLimit(byteLimit) {}
-			virtual double getTimeEstimate() { return SERVER_KNOBS->READ_RANGE_TIME_ESTIMATE; }
-		};
-		void action(ReadRangeAction& a) {
-			Standalone<RangeResultRef> result;
-			if (a.rowLimit == 0 || a.byteLimit == 0) {
-				a.result.send(result);
+	struct ReadValuePrefixAction : TypedAction<Reader, ReadValuePrefixAction> {
+		Key key;
+		int maxLength;
+		Optional<UID> debugID;
+		ThreadReturnPromise<Optional<Value>> result;
+		ReadValuePrefixAction(Key key, int maxLength, Optional<UID> debugID)
+		  : key(key), maxLength(maxLength), debugID(debugID){};
+		virtual double getTimeEstimate() { return SERVER_KNOBS->READ_VALUE_TIME_ESTIMATE; }
+	};
+	void action(ReadValuePrefixAction& a) {
+		rocksdb::PinnableSlice value;
+		Optional<TraceBatch> traceBatch;
+		if (a.debugID.present()) {
+			traceBatch = { TraceBatch{} };
+			traceBatch.get().addEvent("GetValuePrefixDebug", a.debugID.get().first(),
+			                          "Reader.Before");
+		}
+		auto s = db->Get({}, db->DefaultColumnFamily(), toSlice(a.key), &value);
+		if (a.debugID.present()) {
+			traceBatch.get().addEvent("GetValuePrefixDebug", a.debugID.get().first(),
+			                          "Reader.After");
+			traceBatch.get().dump();
+		}
+		if (s.ok()) {
+			a.result.send(Value(StringRef(reinterpret_cast<const uint8_t*>(value.data()),
+			                              std::min(value.size(), size_t(a.maxLength)))));
+		} else {
+			if (!s.IsNotFound()) {
+				TraceEvent(SevError, "RocksDBError")
+				    .detail("Error", s.ToString())
+				    .detail("Method", "ReadValuePrefix")
+				    .detail("Key", a.key);
 			}
-			int accumulatedBytes = 0;
-			rocksdb::Status s;
-			if (a.rowLimit >= 0) {
-				rocksdb::ReadOptions options;
-				auto endSlice = toSlice(a.keys.end);
-				options.iterate_upper_bound = &endSlice;
-				auto cursor = std::unique_ptr<rocksdb::Iterator>(db->NewIterator(options));
-				cursor->Seek(toSlice(a.keys.begin));
-				while (cursor->Valid() && toStringRef(cursor->key()) < a.keys.end) {
-					KeyValueRef kv(toStringRef(cursor->key()), toStringRef(cursor->value()));
-					accumulatedBytes += sizeof(KeyValueRef) + kv.expectedSize();
-					result.push_back_deep(result.arena(), kv);
-					// Calling `cursor->Next()` is potentially expensive, so short-circut here just in case.
-					if (result.size() >= a.rowLimit || accumulatedBytes >= a.byteLimit) {
-						break;
-					}
-					cursor->Next();
-				}
-				s = cursor->status();
-			} else {
-				rocksdb::ReadOptions options;
-				auto beginSlice = toSlice(a.keys.begin);
-				options.iterate_lower_bound = &beginSlice;
-				auto cursor = std::unique_ptr<rocksdb::Iterator>(db->NewIterator(options));
-				cursor->SeekForPrev(toSlice(a.keys.end));
-				if (cursor->Valid() && toStringRef(cursor->key()) == a.keys.end) {
-					cursor->Prev();
-				}
-				while (cursor->Valid() && toStringRef(cursor->key()) >= a.keys.begin) {
-					KeyValueRef kv(toStringRef(cursor->key()), toStringRef(cursor->value()));
-					accumulatedBytes += sizeof(KeyValueRef) + kv.expectedSize();
-					result.push_back_deep(result.arena(), kv);
-					// Calling `cursor->Prev()` is potentially expensive, so short-circut here just in case.
-					if (result.size() >= -a.rowLimit || accumulatedBytes >= a.byteLimit) {
-						break;
-					}
-					cursor->Prev();
-				}
-				s = cursor->status();
-			}
+			a.result.send(Optional<Value>());
+		}
+	}
 
-			if (!s.ok()) {
-				TraceEvent(SevError, "RocksDBError").detail("Error", s.ToString()).detail("Method", "ReadRange");
-			}
-			result.more =
-			    (result.size() == a.rowLimit) || (result.size() == -a.rowLimit) || (accumulatedBytes >= a.byteLimit);
-			if (result.more) {
-			  result.readThrough = result[result.size()-1].key;
-			}
+	struct ReadRangeAction : TypedAction<Reader, ReadRangeAction>, FastAllocated<ReadRangeAction> {
+		KeyRange keys;
+		int rowLimit, byteLimit;
+		ThreadReturnPromise<Standalone<RangeResultRef>> result;
+		ReadRangeAction(KeyRange keys, int rowLimit, int byteLimit)
+		  : keys(keys), rowLimit(rowLimit), byteLimit(byteLimit) {}
+		virtual double getTimeEstimate() { return SERVER_KNOBS->READ_RANGE_TIME_ESTIMATE; }
+	};
+	void action(ReadRangeAction& a) {
+		Standalone<RangeResultRef> result;
+		if (a.rowLimit == 0 || a.byteLimit == 0) {
 			a.result.send(result);
 		}
-	};
+		int accumulatedBytes = 0;
+		ASSERT(a.byteLimit > 0);
+		if (a.rowLimit == 0) {
+			a.result.send(result);
+			return;
+		}
+		rocksdb::Status s;
+		if (a.rowLimit > 0) {
+			rocksdb::ReadOptions options;
+			auto endSlice = toSlice(a.keys.end);
+			options.iterate_upper_bound = &endSlice;
+			auto cursor = std::unique_ptr<rocksdb::Iterator>(db->NewIterator(options));
+			cursor->Seek(toSlice(a.keys.begin));
+			while (cursor->Valid() && toStringRef(cursor->key()) < a.keys.end) {
+				KeyValueRef kv(toStringRef(cursor->key()), toStringRef(cursor->value()));
+				accumulatedBytes += sizeof(KeyValueRef) + kv.expectedSize();
+				result.push_back_deep(result.arena(), kv);
+				// Calling `cursor->Next()` is potentially expensive, so short-circut here just in case.
+				if (result.size() >= a.rowLimit || accumulatedBytes >= a.byteLimit) {
+					break;
+				}
+				cursor->Next();
+			}
+			s = cursor->status();
+		} else {
+			rocksdb::ReadOptions options;
+			auto beginSlice = toSlice(a.keys.begin);
+			options.iterate_lower_bound = &beginSlice;
+			auto cursor = std::unique_ptr<rocksdb::Iterator>(db->NewIterator(options));
+			cursor->SeekForPrev(toSlice(a.keys.end));
+			if (cursor->Valid() && toStringRef(cursor->key()) == a.keys.end) {
+				cursor->Prev();
+			}
+			while (cursor->Valid() && toStringRef(cursor->key()) >= a.keys.begin) {
+				KeyValueRef kv(toStringRef(cursor->key()), toStringRef(cursor->value()));
+				accumulatedBytes += sizeof(KeyValueRef) + kv.expectedSize();
+				result.push_back_deep(result.arena(), kv);
+				// Calling `cursor->Prev()` is potentially expensive, so short-circut here just in case.
+				if (result.size() >= -a.rowLimit || accumulatedBytes >= a.byteLimit) {
+					break;
+				}
+				cursor->Prev();
+			}
+			s = cursor->status();
+		}
+		if (!(s.ok() || s.IsNotFound())) {
+			TraceEvent(SevError, "RocksDBError").detail("Error", s.ToString()).detail("Method", "ReadRange");
+		}
+		result.more =
+		    (result.size() == a.rowLimit) || (result.size() == -a.rowLimit) || (accumulatedBytes >= a.byteLimit);
+		if (result.more) {
+			result.readThrough = result[result.size() - 1].key;
+		}
+		a.result.send(result);
+	}
 
-	DB db = nullptr;
+	std::unique_ptr<rocksdb::DB> db;
+	ISimulator::ProcessInfo * proc = nullptr;
+
 	std::string path;
 	UID id;
 	Reference<IThreadPool> writeThread;
 	Reference<IThreadPool> readThreads;
+
 	Promise<Void> errorPromise;
 	Promise<Void> closePromise;
 	std::unique_ptr<rocksdb::WriteBatch> writeBatch;
@@ -312,11 +345,18 @@ struct RocksDBKeyValueStore : IKeyValueStore {
 		: path(path)
 		, id(id)
 	{
+		int nReaders = SERVER_KNOBS->ROCKSDB_READ_PARALLELISM;
 		writeThread = createGenericThreadPool();
 		readThreads = createGenericThreadPool();
-		writeThread->addThread(new Writer(db, id));
-		for (unsigned i = 0; i < SERVER_KNOBS->ROCKSDB_READ_PARALLELISM; ++i) {
-			readThreads->addThread(new Reader(db));
+		if (g_network->isSimulated()) {
+			proc = g_simulator.getCurrentProcess();
+			nReaders = 0;
+			proc->machine->nonFlowStores[path] = (IKeyValueStore*)this;
+		} else {
+			writeThread->addThread(new Writer(this));
+		}
+		for (unsigned i = 0; i < nReaders; ++i) {
+			readThreads->addThread(new Reader(this));
 		}
 	}
 
@@ -326,15 +366,20 @@ struct RocksDBKeyValueStore : IKeyValueStore {
 
 	ACTOR static void doClose(RocksDBKeyValueStore* self, bool deleteOnClose) {
 		wait(self->readThreads->stop());
-		auto a = new Writer::CloseAction(self->path, deleteOnClose);
+		auto a = new CloseAction(self->path, deleteOnClose);
 		auto f = a->done.getFuture();
-		self->writeThread->post(a);
+		self->post(self->writeThread, a);
 		wait(f);
 		wait(self->writeThread->stop());
 		if (self->closePromise.canBeSet()) self->closePromise.send(Void());
 		if (self->errorPromise.canBeSet()) self->errorPromise.send(Never());
 		delete self;
 	}
+
+	void preSimulatedCrashHookForNonFlowStorageEngines() override {
+		close();
+	}
+
 
 	Future<Void> onClosed() override {
 		return closePromise.getFuture();
@@ -353,10 +398,10 @@ struct RocksDBKeyValueStore : IKeyValueStore {
 	}
 
 	Future<Void> init() override {
-		std::unique_ptr<Writer::OpenAction> a(new Writer::OpenAction());
+		auto * a = new OpenAction();
 		a->path = path;
 		auto res = a->done.getFuture();
-		writeThread->post(a.release());
+		post(writeThread, a);
 		return res;
 	}
 
@@ -380,31 +425,31 @@ struct RocksDBKeyValueStore : IKeyValueStore {
 		if (writeBatch == nullptr) {
 			return Void();
 		}
-		auto a = new Writer::CommitAction();
+		auto a = new CommitAction();
 		a->batchToCommit = std::move(writeBatch);
 		auto res = a->done.getFuture();
-		writeThread->post(a);
+		post(writeThread, a);
 		return res;
 	}
 
 	Future<Optional<Value>> readValue(KeyRef key, Optional<UID> debugID) override {
-		auto a = new Reader::ReadValueAction(key, debugID);
+		auto a = new ReadValueAction(key, debugID);
 		auto res = a->result.getFuture();
-		readThreads->post(a);
+		post(readThreads, a);
 		return res;
 	}
 
 	Future<Optional<Value>> readValuePrefix(KeyRef key, int maxLength, Optional<UID> debugID) override {
-		auto a = new Reader::ReadValuePrefixAction(key, maxLength, debugID);
+		auto a = new ReadValuePrefixAction(key, maxLength, debugID);
 		auto res = a->result.getFuture();
-		readThreads->post(a);
+		post(readThreads, a);
 		return res;
 	}
 
 	Future<Standalone<RangeResultRef>> readRange(KeyRangeRef keys, int rowLimit, int byteLimit) override {
-		auto a = new Reader::ReadRangeAction(keys, rowLimit, byteLimit);
+		auto a = new ReadRangeAction(keys, rowLimit, byteLimit);
 		auto res = a->result.getFuture();
-		readThreads->post(a);
+		post(readThreads, a);
 		return res;
 	}
 

--- a/flow/IThreadPool.h
+++ b/flow/IThreadPool.h
@@ -69,6 +69,7 @@ public:
 template <class Object, class ActionType>
 class TypedAction : public ThreadAction {
 public:
+	using Receiver = Object;
 	virtual void operator()(IThreadPoolReceiver* p) {
 		Object* o = (Object*)p;
 		o->action(*(ActionType*)this);


### PR DESCRIPTION
This PR is resolves #...

Changes in this PR:

-
-
-

## General guideline:

- If this PR is ready to be merged (and all checkboxes below are either ticked or not applicable), make this a regular PR
- If this PR still needs work, please make this a draft PR
  - If you wish to get feedback/code-review, please add the label RFC to this PR

Please verify that all things listed below were considered and check them. If an item doesn't apply to this type of PR (for example a documentation change doesn't need to be performance tested), you should make a ~~strikethrough~~ (markdown syntax: `~~strikethrough~~`). More infos on the guidlines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

### Style
- [ ] All variable and function names make sense.
- [ ] The code is properly formatted (consider running `git clang-format`).

### Performance
- [ ] All CPU-hot paths are well optimized.
- [ ] The proper containers are used (for example `std::vector` vs `VectorRef`).
- [ ] There are no new known `SlowTask` traces.

### Testing
- [ ] The code was sufficiently tested in simulation.
- [ ] If there are new parameters or knobs, different values are tested in simulation.
- [ ] `ASSERT`, `ASSERT_WE_THINK`, and `TEST` macros are added in appropriate places.
- [ ] Unit tests were added for new algorithms and data structure that make sense to unit-test
- [ ] If this is a bugfix: there is a test that can easily reproduce the bug.
