### PR TITLE
Last backup timestamp string changed to UTC, future last backup becomes just a warning.

### DIFF
--- a/fdbclient/BackupAgent.actor.h
+++ b/fdbclient/BackupAgent.actor.h
@@ -232,7 +232,7 @@ public:
 		time_t curTime = t;
 		char buffer[128];
 		struct tm* timeinfo;
-		timeinfo = localtime(&curTime);
+		timeinfo = gmtime(&curTime);
 		strftime(buffer, 128, "%Y-%m-%d-%H-%M-%S", timeinfo);
 
 		std::string time(buffer);

--- a/fdbclient/FileBackupAgent.actor.cpp
+++ b/fdbclient/FileBackupAgent.actor.cpp
@@ -3813,6 +3813,9 @@ public:
 
 		if ((lastBackupTimestamp.present()) && (lastBackupTimestamp.get() >= nowStr)) {
 			fprintf(stderr, "WARNING: The last backup `%s' appears to have started in the future.\n", printable(lastBackupTimestamp.get()).c_str());
+			if(lastBackupTimestamp.get() == nowStr) {
+				throw backup_error();
+			}
 		}
 
 		KeyRangeMap<int> backupRangeSet;

--- a/fdbclient/FileBackupAgent.actor.cpp
+++ b/fdbclient/FileBackupAgent.actor.cpp
@@ -3812,8 +3812,7 @@ public:
 		Optional<Value> lastBackupTimestamp = wait(backupAgent->lastBackupTimestamp().get(tr));
 
 		if ((lastBackupTimestamp.present()) && (lastBackupTimestamp.get() >= nowStr)) {
-			fprintf(stderr, "ERROR: The last backup `%s' happened in the future.\n", printable(lastBackupTimestamp.get()).c_str());
-			throw backup_error();
+			fprintf(stderr, "WARNING: The last backup `%s' appears to have started in the future.\n", printable(lastBackupTimestamp.get()).c_str());
 		}
 
 		KeyRangeMap<int> backupRangeSet;

--- a/fdbclient/FileBackupAgent.actor.cpp
+++ b/fdbclient/FileBackupAgent.actor.cpp
@@ -3812,10 +3812,8 @@ public:
 		Optional<Value> lastBackupTimestamp = wait(backupAgent->lastBackupTimestamp().get(tr));
 
 		if ((lastBackupTimestamp.present()) && (lastBackupTimestamp.get() >= nowStr)) {
-			fprintf(stderr, "WARNING: The last backup `%s' appears to have started in the future.\n", printable(lastBackupTimestamp.get()).c_str());
-			if(lastBackupTimestamp.get() == nowStr) {
-				throw backup_error();
-			}
+			fprintf(stderr, "ERROR: The last backup `%s' appears to have started in the future.\n", printable(lastBackupTimestamp.get()).c_str());
+			throw backup_error();
 		}
 
 		KeyRangeMap<int> backupRangeSet;


### PR DESCRIPTION
This PR is resolves #4168 

Changes in this PR:

- Last backup timestamp string changed to UTC
- Future last backup becomes just a warning.

### Style
- [x] All variable and function names make sense.
- [x] The code is properly formatted (consider running `git clang-format`).

### Performance
- [x] All CPU-hot paths are well optimized.
- [x] The proper containers are used (for example `std::vector` vs `VectorRef`).
- [x] There are no new known `SlowTask` traces.

### Testing
- [x] The code was sufficiently tested in simulation.
- [x] ~~If there are new parameters or knobs, different values are tested in simulation.~~
- [x] ~~`ASSERT`, `ASSERT_WE_THINK`, and `TEST` macros are added in appropriate places.~~
- [x] ~~Unit tests were added for new algorithms and data structure that make sense to unit-test~~
- [x] ~~If this is a bugfix: there is a test that can easily reproduce the bug.~~
