### PR TITLE
Make sure that fdb_c.h is c90 compliant

### DIFF
--- a/bindings/c/CMakeLists.txt
+++ b/bindings/c/CMakeLists.txt
@@ -111,6 +111,12 @@ if(NOT WIN32)
   set_property(TARGET mako PROPERTY SKIP_BUILD_RPATH TRUE)
   target_link_libraries(mako PRIVATE fdb_c)
 
+  # Make sure that fdb_c.h is compatible with c89
+  add_executable(fdb_c89_test test/fdb_c89_test.c)
+  set_property(TARGET fdb_c89_test PROPERTY C_STANDARD 90)
+  target_compile_options(fdb_c89_test PRIVATE -Wall -Wextra -Wpedantic -Werror)
+  target_link_libraries(fdb_c89_test PRIVATE fdb_c)
+
   add_fdbclient_test(
     NAME fdb_c_setup_tests
     COMMAND $<TARGET_FILE:fdb_c_setup_tests>)

--- a/bindings/c/CMakeLists.txt
+++ b/bindings/c/CMakeLists.txt
@@ -111,11 +111,11 @@ if(NOT WIN32)
   set_property(TARGET mako PROPERTY SKIP_BUILD_RPATH TRUE)
   target_link_libraries(mako PRIVATE fdb_c)
 
-  # Make sure that fdb_c.h is compatible with c89
-  add_executable(fdb_c89_test test/fdb_c89_test.c)
-  set_property(TARGET fdb_c89_test PROPERTY C_STANDARD 90)
-  target_compile_options(fdb_c89_test PRIVATE -Wall -Wextra -Wpedantic -Werror)
-  target_link_libraries(fdb_c89_test PRIVATE fdb_c)
+  # Make sure that fdb_c.h is compatible with c90
+  add_executable(fdb_c90_test test/fdb_c90_test.c)
+  set_property(TARGET fdb_c90_test PROPERTY C_STANDARD 90)
+  target_compile_options(fdb_c90_test PRIVATE -Wall -Wextra -Wpedantic -Werror)
+  target_link_libraries(fdb_c90_test PRIVATE fdb_c)
 
   add_fdbclient_test(
     NAME fdb_c_setup_tests

--- a/bindings/c/foundationdb/fdb_c.h
+++ b/bindings/c/foundationdb/fdb_c.h
@@ -45,12 +45,17 @@
 #define WARN_UNUSED_RESULT
 #endif
 
-// With default settings, gcc will not warn about unprototyped functions being called, so it
-// is easy to erroneously call a function which is not available at FDB_API_VERSION and then
-// get an error only at runtime.  These macros ensure a compile error in such cases, and
-// attempt to make the compile error slightly informative.
-#define This_FoundationDB_API_function_is_removed_at_this_FDB_API_VERSION() [=====]
-#define FDB_REMOVED_FUNCTION This_FoundationDB_API_function_is_removed_at_this_FDB_API_VERSION(0)
+/*
+ * With default settings, gcc will not warn about unprototyped functions being
+ * called, so it is easy to erroneously call a function which is not available
+ * at FDB_API_VERSION and then get an error only at runtime.  These macros
+ * ensure a compile error in such cases, and attempt to make the compile error
+ * slightly informative.
+ */
+#define This_FoundationDB_API_function_is_removed_at_this_FDB_API_VERSION()    \
+  [== == = ]
+#define FDB_REMOVED_FUNCTION                                                   \
+  This_FoundationDB_API_function_is_removed_at_this_FDB_API_VERSION(0)
 
 #include <stdint.h>
 
@@ -244,12 +249,15 @@ extern "C" {
     fdb_transaction_get_committed_version( FDBTransaction* tr,
                                            int64_t* out_version );
 
-    // This function intentionally returns an FDBFuture instead of an integer directly,
-    // so that calling this API can see the effect of previous mutations on the transaction.
-    // Specifically, mutations are applied asynchronously by the main thread. In order to
-    // see them, this call has to be serviced by the main thread too.
-    DLLEXPORT WARN_UNUSED_RESULT FDBFuture*
-    fdb_transaction_get_approximate_size(FDBTransaction* tr);
+    /*
+     * This function intentionally returns an FDBFuture instead of an integer
+     * directly, so that calling this API can see the effect of previous
+     * mutations on the transaction. Specifically, mutations are applied
+     * asynchronously by the main thread. In order to see them, this call has to
+     * be serviced by the main thread too.
+     */
+    DLLEXPORT WARN_UNUSED_RESULT FDBFuture *
+    fdb_transaction_get_approximate_size(FDBTransaction *tr);
 
     DLLEXPORT WARN_UNUSED_RESULT FDBFuture*
     fdb_get_server_protocol(const char* clusterFilePath);
@@ -301,7 +309,7 @@ extern "C" {
     typedef struct FDB_cluster FDBCluster;
 
     typedef enum {
-        // This option is only a placeholder for C compatibility and should not be used
+        /* This option is only a placeholder for C compatibility and should not be used */
         FDB_CLUSTER_OPTION_DUMMY_DO_NOT_USE=-1
     } FDBClusterOption;
 #endif

--- a/bindings/c/test/fdb_c89_test.c
+++ b/bindings/c/test/fdb_c89_test.c
@@ -1,0 +1,7 @@
+#define FDB_API_VERSION 700
+#include <foundationdb/fdb_c.h>
+
+int main(int argc, char* argv[]) {
+	fdb_select_api_version(700);
+	return 0;
+}

--- a/bindings/c/test/fdb_c90_test.c
+++ b/bindings/c/test/fdb_c90_test.c
@@ -2,6 +2,8 @@
 #include <foundationdb/fdb_c.h>
 
 int main(int argc, char* argv[]) {
+	(void)argc;
+	(void)argv;
 	fdb_select_api_version(700);
 	return 0;
 }

--- a/fdbclient/vexillographer/c.cs
+++ b/fdbclient/vexillographer/c.cs
@@ -52,8 +52,8 @@ namespace vexillographer
         {
             string parameterComment = "";
             if (o.scope.ToString().EndsWith("Option"))
-                parameterComment = String.Format("{0}// {1}\n", indent, "Parameter: " + o.getParameterComment());
-            return String.Format("{0}// {2}\n{5}{0}{1}{3}={4}", indent, prefix, o.comment, o.name.ToUpper(), o.code, parameterComment);
+                parameterComment = String.Format("{0}/* {1} */\n", indent, "Parameter: " + o.getParameterComment());
+            return String.Format("{0}/* {2} */\n{5}{0}{1}{3}={4}", indent, prefix, o.comment, o.name.ToUpper(), o.code, parameterComment);
         }
 
         private static void writeCEnum(TextWriter outFile, Scope scope, IEnumerable<Option> options)


### PR DESCRIPTION
It came up [here](https://github.com/apple/foundationdb/pull/4094#discussion_r546991555) that we don't know if we need to keep compatibility with c90 for fdb_c.h. It looks like we are currently compatible, so add a test to keep it that way.

## General guideline:

- If this PR is ready to be merged (and all checkboxes below are either ticked or not applicable), make this a regular PR
- If this PR still needs work, please make this a draft PR
  - If you wish to get feedback/code-review, please add the label RFC to this PR

Please verify that all things listed below were considered and check them. If an item doesn't apply to this type of PR (for example a documentation change doesn't need to be performance tested), you should make a ~~strikethrough~~ (markdown syntax: `~~strikethrough~~`). More infos on the guidlines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

### Style
- [ ] ~~All variable and function names make sense.~~
- [x] The code is properly formatted (consider running `git clang-format`).

### Performance
- [ ] ~~All CPU-hot paths are well optimized.~~
- [ ] ~~The proper containers are used (for example `std::vector` vs `VectorRef`).~~
- [ ] ~~There are no new known `SlowTask` traces.~~

### Testing
- [ ] ~~The code was sufficiently tested in simulation.~~
- [ ] ~~If there are new parameters or knobs, different values are tested in simulation.~~
- [ ] ~~`ASSERT`, `ASSERT_WE_THINK`, and `TEST` macros are added in appropriate places.~~
- [ ] ~~Unit tests were added for new algorithms and data structure that make sense to unit-test~~
- [ ] ~~If this is a bugfix: there is a test that can easily reproduce the bug.~~
