### PR TITLE
Docs, fix and hack for Fault Tolerance 

### DIFF
--- a/fdbclient/DatabaseConfiguration.h
+++ b/fdbclient/DatabaseConfiguration.h
@@ -174,7 +174,8 @@ struct DatabaseConfiguration {
 			return 1 + std::min(std::max(tLogReplicationFactor - 1 - tLogWriteAntiQuorum, worstSatellite - 1),
 			                    storageTeamSize - 1);
 		} else if (worstSatellite > 0) {
-			return std::min(tLogReplicationFactor + worstSatellite - 2 - tLogWriteAntiQuorum, storageTeamSize - 1);
+			// Primary and Satellite tLogs are synchronously replicated, hence we can lose all but 1.
+			return std::min(tLogReplicationFactor + worstSatellite - 1 - tLogWriteAntiQuorum, storageTeamSize - 1);
 		}
 		return std::min(tLogReplicationFactor - 1 - tLogWriteAntiQuorum, storageTeamSize - 1);
 	}

--- a/fdbclient/DatabaseConfiguration.h
+++ b/fdbclient/DatabaseConfiguration.h
@@ -51,9 +51,19 @@ struct RegionInfo {
 	int32_t priority;
 
 	Reference<IReplicationPolicy> satelliteTLogPolicy;
+
+	// Number of tLogs that should be recruited in satellite datacenters.
 	int32_t satelliteDesiredTLogCount;
+
+	// Total number of copies made for each mutation across all satellite tLogs in all DCs.
 	int32_t satelliteTLogReplicationFactor;
+
+	// Number of tLog replies we can ignore when waiting for quorum. Hence, effective quorum is
+	// satelliteDesiredTLogCount -  satelliteTLogWriteAntiQuorum. Locality of individual tLogs is not taken
+	// into account.
 	int32_t satelliteTLogWriteAntiQuorum;
+
+	// Number of satellite datacenters for current region, as set by `satellite_redundancy_mode`.
 	int32_t satelliteTLogUsableDcs;
 
 	Reference<IReplicationPolicy> satelliteTLogPolicyFallback;
@@ -63,27 +73,32 @@ struct RegionInfo {
 
 	std::vector<SatelliteInfo> satellites;
 
-	RegionInfo() : priority(0), satelliteDesiredTLogCount(-1), satelliteTLogReplicationFactor(0), satelliteTLogWriteAntiQuorum(0), satelliteTLogUsableDcs(1),
-		satelliteTLogReplicationFactorFallback(0), satelliteTLogWriteAntiQuorumFallback(0), satelliteTLogUsableDcsFallback(0) {}
+	RegionInfo()
+	  : priority(0), satelliteDesiredTLogCount(-1), satelliteTLogReplicationFactor(0), satelliteTLogWriteAntiQuorum(0),
+	    satelliteTLogUsableDcs(1), satelliteTLogReplicationFactorFallback(0), satelliteTLogWriteAntiQuorumFallback(0),
+	    satelliteTLogUsableDcsFallback(0) {}
 
 	struct sort_by_priority {
-		bool operator ()(RegionInfo const&a, RegionInfo const& b) const { return a.priority > b.priority; }
+		bool operator()(RegionInfo const& a, RegionInfo const& b) const { return a.priority > b.priority; }
 	};
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, dcId, priority, satelliteTLogPolicy, satelliteDesiredTLogCount, satelliteTLogReplicationFactor, satelliteTLogWriteAntiQuorum, satelliteTLogUsableDcs,
-			satelliteTLogPolicyFallback, satelliteTLogReplicationFactorFallback, satelliteTLogWriteAntiQuorumFallback, satelliteTLogUsableDcsFallback, satellites);
+		serializer(ar, dcId, priority, satelliteTLogPolicy, satelliteDesiredTLogCount, satelliteTLogReplicationFactor,
+		           satelliteTLogWriteAntiQuorum, satelliteTLogUsableDcs, satelliteTLogPolicyFallback,
+		           satelliteTLogReplicationFactorFallback, satelliteTLogWriteAntiQuorumFallback,
+		           satelliteTLogUsableDcsFallback, satellites);
 	}
 };
 
 struct DatabaseConfiguration {
 	DatabaseConfiguration();
 
-	void applyMutation( MutationRef mutation );
-	bool set( KeyRef key, ValueRef value );  // Returns true if a configuration option that requires recovery to take effect is changed
-	bool clear( KeyRangeRef keys );
-	Optional<ValueRef> get( KeyRef key ) const;
+	void applyMutation(MutationRef mutation);
+	bool set(KeyRef key,
+	         ValueRef value); // Returns true if a configuration option that requires recovery to take effect is changed
+	bool clear(KeyRangeRef keys);
+	Optional<ValueRef> get(KeyRef key) const;
 
 	bool isValid() const;
 
@@ -92,62 +107,73 @@ struct DatabaseConfiguration {
 	std::string toString() const;
 	StatusObject toJSON(bool noPolicies = false) const;
 	StatusArray getRegionJSON() const;
-	
-	RegionInfo getRegion( Optional<Key> dcId ) const {
-		if(!dcId.present()) {
+
+	RegionInfo getRegion(Optional<Key> dcId) const {
+		if (!dcId.present()) {
 			return RegionInfo();
 		}
-		for(auto& r : regions) {
-			if(r.dcId == dcId.get()) {
+		for (auto& r : regions) {
+			if (r.dcId == dcId.get()) {
 				return r;
 			}
 		}
 		return RegionInfo();
 	}
 
-	int expectedLogSets( Optional<Key> dcId ) const {
+	int expectedLogSets(Optional<Key> dcId) const {
 		int result = 1;
-		if(dcId.present() && getRegion(dcId.get()).satelliteTLogReplicationFactor > 0 && usableRegions > 1) {
+		if (dcId.present() && getRegion(dcId.get()).satelliteTLogReplicationFactor > 0 && usableRegions > 1) {
 			result++;
 		}
-		
-		if(usableRegions > 1) {
+
+		if (usableRegions > 1) {
 			result++;
 		}
 		return result;
 	}
 
+	// Counts the number of DCs required including remote and satellites for current database configuraiton.
 	int32_t minDatacentersRequired() const {
 		int minRequired = 0;
-		for(auto& r : regions) {
+		for (auto& r : regions) {
 			minRequired += 1 + r.satellites.size();
 		}
 		return minRequired;
 	}
+
 	int32_t minZonesRequiredPerDatacenter() const {
-		int minRequired = std::max( remoteTLogReplicationFactor, std::max(tLogReplicationFactor, storageTeamSize) );
-		for(auto& r : regions) {
-			minRequired = std::max( minRequired, r.satelliteTLogReplicationFactor/std::max(1, r.satelliteTLogUsableDcs) );
+		int minRequired = std::max(remoteTLogReplicationFactor, std::max(tLogReplicationFactor, storageTeamSize));
+		for (auto& r : regions) {
+			minRequired =
+			    std::max(minRequired, r.satelliteTLogReplicationFactor / std::max(1, r.satelliteTLogUsableDcs));
 		}
 		return minRequired;
 	}
 
-	//Killing an entire datacenter counts as killing one zone in modes that support it
+	// Retuns the maximum number of discrete failures a cluster can tolerate.
+	// In HA mode, `fullyReplicatedRegions` is set to false initially when data is being
+	// replicated to remote, and will be true later. `forAvailablity` is set to true
+	// if we want to account the number for machines that can recruit new tLogs/SS after failures.
+	// Killing an entire datacenter counts as killing one zone in modes that support it
 	int32_t maxZoneFailuresTolerated(int fullyReplicatedRegions, bool forAvailability) const {
 		int worstSatellite = regions.size() ? std::numeric_limits<int>::max() : 0;
 		int regionsWithNonNegativePriority = 0;
-		for(auto& r : regions) {
-			if(r.priority >= 0) {
+		for (auto& r : regions) {
+			if (r.priority >= 0) {
 				regionsWithNonNegativePriority++;
 			}
-			worstSatellite = std::min(worstSatellite, r.satelliteTLogReplicationFactor - r.satelliteTLogWriteAntiQuorum);
-			if(r.satelliteTLogUsableDcsFallback > 0) {
-				worstSatellite = std::min(worstSatellite, r.satelliteTLogReplicationFactorFallback - r.satelliteTLogWriteAntiQuorumFallback);
+			worstSatellite =
+			    std::min(worstSatellite, r.satelliteTLogReplicationFactor - r.satelliteTLogWriteAntiQuorum);
+			if (r.satelliteTLogUsableDcsFallback > 0) {
+				worstSatellite = std::min(worstSatellite, r.satelliteTLogReplicationFactorFallback -
+				                                              r.satelliteTLogWriteAntiQuorumFallback);
 			}
 		}
-		if(usableRegions > 1 && fullyReplicatedRegions > 1 && worstSatellite > 0 && (!forAvailability || regionsWithNonNegativePriority > 1)) {
-			return 1 + std::min(std::max(tLogReplicationFactor - 1 - tLogWriteAntiQuorum, worstSatellite - 1), storageTeamSize - 1);
-		} else if(worstSatellite > 0) {
+		if (usableRegions > 1 && fullyReplicatedRegions > 1 && worstSatellite > 0 &&
+		    (!forAvailability || regionsWithNonNegativePriority > 1)) {
+			return 1 + std::min(std::max(tLogReplicationFactor - 1 - tLogWriteAntiQuorum, worstSatellite - 1),
+			                    storageTeamSize - 1);
+		} else if (worstSatellite > 0) {
 			return std::min(tLogReplicationFactor + worstSatellite - 2 - tLogWriteAntiQuorum, storageTeamSize - 1);
 		}
 		return std::min(tLogReplicationFactor - 1 - tLogWriteAntiQuorum, storageTeamSize - 1);
@@ -185,27 +211,47 @@ struct DatabaseConfiguration {
 	// Backup Workers
 	bool backupWorkerEnabled;
 
-	//Data centers
-	int32_t usableRegions;
+	// Data centers
+	int32_t usableRegions;  // Number of regions which have a replica of the database.
 	int32_t repopulateRegionAntiQuorum;
 	std::vector<RegionInfo> regions;
 
 	// Excluded servers (no state should be here)
-	bool isExcludedServer( NetworkAddressList ) const;
+	bool isExcludedServer(NetworkAddressList) const;
 	std::set<AddressExclusion> getExcludedServers() const;
 
-	int32_t getDesiredProxies() const { if(masterProxyCount == -1) return autoMasterProxyCount; return masterProxyCount; }
-	int32_t getDesiredResolvers() const { if(resolverCount == -1) return autoResolverCount; return resolverCount; }
-	int32_t getDesiredLogs() const { if(desiredTLogCount == -1) return autoDesiredTLogCount; return desiredTLogCount; }
-	int32_t getDesiredRemoteLogs() const { if(remoteDesiredTLogCount == -1) return getDesiredLogs(); return remoteDesiredTLogCount;  }
-	int32_t getDesiredSatelliteLogs( Optional<Key> dcId ) const {
-		auto desired = getRegion(dcId).satelliteDesiredTLogCount;
-		if(desired == -1) return autoDesiredTLogCount; return desired;
+	int32_t getDesiredProxies() const {
+		if (masterProxyCount == -1) return autoMasterProxyCount;
+		return masterProxyCount;
 	}
-	int32_t getRemoteTLogReplicationFactor() const { if(remoteTLogReplicationFactor == 0) return tLogReplicationFactor; return remoteTLogReplicationFactor; }
-	Reference<IReplicationPolicy> getRemoteTLogPolicy() const { if(remoteTLogReplicationFactor == 0) return tLogPolicy; return remoteTLogPolicy; }
+	int32_t getDesiredResolvers() const {
+		if (resolverCount == -1) return autoResolverCount;
+		return resolverCount;
+	}
+	int32_t getDesiredLogs() const {
+		if (desiredTLogCount == -1) return autoDesiredTLogCount;
+		return desiredTLogCount;
+	}
+	int32_t getDesiredRemoteLogs() const {
+		if (remoteDesiredTLogCount == -1) return getDesiredLogs();
+		return remoteDesiredTLogCount;
+	}
+	int32_t getDesiredSatelliteLogs(Optional<Key> dcId) const {
 
-	bool operator == ( DatabaseConfiguration const& rhs ) const {
+		auto desired = getRegion(dcId).satelliteDesiredTLogCount;
+		if (desired == -1) return autoDesiredTLogCount;
+		return desired;
+	}
+	int32_t getRemoteTLogReplicationFactor() const {
+		if (remoteTLogReplicationFactor == 0) return tLogReplicationFactor;
+		return remoteTLogReplicationFactor;
+	}
+	Reference<IReplicationPolicy> getRemoteTLogPolicy() const {
+		if (remoteTLogReplicationFactor == 0) return tLogPolicy;
+		return remoteTLogPolicy;
+	}
+
+	bool operator==(DatabaseConfiguration const& rhs) const {
 		const_cast<DatabaseConfiguration*>(this)->makeConfigurationImmutable();
 		const_cast<DatabaseConfiguration*>(&rhs)->makeConfigurationImmutable();
 		return rawConfiguration == rhs.rawConfiguration;
@@ -216,8 +262,7 @@ struct DatabaseConfiguration {
 		if (!ar.isDeserializing) makeConfigurationImmutable();
 		serializer(ar, rawConfiguration);
 		if (ar.isDeserializing) {
-			for(auto c=rawConfiguration.begin(); c!=rawConfiguration.end(); ++c)
-				setInternal(c->key, c->value);
+			for (auto c = rawConfiguration.begin(); c != rawConfiguration.end(); ++c) setInternal(c->key, c->value);
 			setDefaultReplicationPolicy();
 		}
 	}
@@ -225,13 +270,13 @@ struct DatabaseConfiguration {
 	void fromKeyValues(Standalone<VectorRef<KeyValueRef>> rawConfig);
 
 private:
-	Optional< std::map<std::string, std::string> > mutableConfiguration;  // If present, rawConfiguration is not valid
-	Standalone<VectorRef<KeyValueRef>> rawConfiguration;   // sorted by key
+	Optional<std::map<std::string, std::string>> mutableConfiguration; // If present, rawConfiguration is not valid
+	Standalone<VectorRef<KeyValueRef>> rawConfiguration; // sorted by key
 
 	void makeConfigurationMutable();
 	void makeConfigurationImmutable();
 
-	bool setInternal( KeyRef key, ValueRef value );
+	bool setInternal(KeyRef key, ValueRef value);
 	void resetInternal();
 	void setDefaultReplicationPolicy();
 

--- a/fdbserver/LogSystemConfig.h
+++ b/fdbserver/LogSystemConfig.h
@@ -78,7 +78,7 @@ struct serializable_traits<OptionalInterface<Interface>> : std::true_type {
 	}
 };
 
-
+// Contains a generation of tLogs for an individual DC.
 struct TLogSet {
 	constexpr static FileIdentifier file_identifier = 6302317;
 	std::vector<OptionalInterface<TLogInterface>> tLogs;

--- a/fdbserver/Status.actor.cpp
+++ b/fdbserver/Status.actor.cpp
@@ -1945,7 +1945,14 @@ static JsonBuilderObject tlogFetcher(int* logFaultTolerance, const std::vector<T
 			if(currentFaultTolerance >= 0) {
 				localSetsWithNonNegativeFaultTolerance++;
 			}
-			minFaultTolerance = std::min(minFaultTolerance, currentFaultTolerance);
+
+			if (tLogs[i].locality == tagLocalitySatellite) {
+				// FIXME: This hack to bump satellite fault tolerance, is to make it consistent
+				//  with 6.2.
+				minFaultTolerance = std::min(minFaultTolerance, currentFaultTolerance + 1);
+			} else {
+				minFaultTolerance = std::min(minFaultTolerance, currentFaultTolerance);
+			}
 		}
 
 		if (tLogs[i].isLocal && tLogs[i].locality == tagLocalitySatellite) {

--- a/fdbserver/Status.actor.cpp
+++ b/fdbserver/Status.actor.cpp
@@ -1607,6 +1607,7 @@ ACTOR static Future<vector<std::pair<MasterProxyInterface, EventMap>>> getProxie
 	return results;
 }
 
+// Returns the number of zones eligble for recruiting new tLogs after failures, to maintain the current replication factor.
 static int getExtraTLogEligibleZones(const vector<WorkerDetails>& workers, const DatabaseConfiguration& configuration) {
 	std::set<StringRef> allZones;
 	std::map<Key,std::set<StringRef>> dcId_zone;


### PR DESCRIPTION
This PR is partially addresses #4163 but by no means resolves it.

Changes in this PR:

This PR consists of three patches, each revertable on its own:

- Some comments and clang-format on code around fault-tolerance.
- Fix a bug where we calculated fault-tolerance wrong when keys are not fully replicated. Fault tolerance in that case should of total tLog replicas should be primary and satellite tLogs - 1.
- HACK: Ignore fault-tolerance of satellite to keep the fault-tolerance number same as 6.2. This is not a fix, but we will have a fix soon, with clear definition of fault tolerance.
- [TODO] Same for fault_tolerance_without_losing_availability

## General guideline:

### Style
- [ ] All variable and function names make sense.
- [ ] The code is properly formatted (consider running `git clang-format`).

### Performance
- ~[ ] All CPU-hot paths are well optimized.~
- [ ] The proper containers are used (for example `std::vector` vs `VectorRef`).
- [ ] There are no new known `SlowTask` traces.

### Testing
- [ ] The code was sufficiently tested in simulation.
- [ ] If there are new parameters or knobs, different values are tested in simulation.
- [ ] `ASSERT`, `ASSERT_WE_THINK`, and `TEST` macros are added in appropriate places.
- [ ] Unit tests were added for new algorithms and data structure that make sense to unit-test
- [ ] If this is a bugfix: there is a test that can easily reproduce the bug.
