### PR TITLE
build: don't clash with FreeBSD native defines

### DIFF
--- a/flow/ThreadPrimitives.h
+++ b/flow/ThreadPrimitives.h
@@ -47,9 +47,9 @@
 
 // TODO: We should make this dependent on the CPU. Maybe cmake
 // can set this variable properly?
-constexpr size_t CACHE_LINE_SIZE = 64;
+constexpr size_t MAX_CACHE_LINE_SIZE = 64;
 
-class alignas(CACHE_LINE_SIZE) ThreadSpinLock {
+class alignas(MAX_CACHE_LINE_SIZE) ThreadSpinLock {
 public:
 // #ifdef _WIN32
 	ThreadSpinLock() {
@@ -90,7 +90,7 @@ private:
 	std::atomic_flag isLocked = ATOMIC_FLAG_INIT;
 	// We want a spin lock to occupy a cache line in order to
 	// prevent false sharing.
-	std::array<uint8_t, CACHE_LINE_SIZE - sizeof(isLocked)> padding;
+	std::array<uint8_t, MAX_CACHE_LINE_SIZE - sizeof(isLocked)> padding;
 };
 
 class ThreadSpinLockHolder {


### PR DESCRIPTION
In #3506,  a new preprocessor define is introduced, which clashes with [FreeBSD's own](https://cgit.freebsd.org/src/tree/sys/amd64/include/param.h#n88) :

```
# /usr/include/machine/param.h
/*
 * CACHE_LINE_SIZE is the compile-time maximum cache line size for an
 * architecture.  It should be used with appropriate caution.
 */
#define CACHE_LINE_SHIFT        6
#define CACHE_LINE_SIZE         (1 << CACHE_LINE_SHIFT)
```

Proposed fix is to prepend `MAX_` to the FDB code, which is then unique again.

### Style

- [x] All variable and function names make sense.
- [x] The code is properly formatted (consider running `git clang-format`).

### Performance

~All CPU-hot paths are well optimized~
~The proper containers are used (for example `std::vector` vs `VectorRef`)~
~There are no new known `SlowTask` traces~

### Testing

~The code was sufficiently tested in simulation~
~If there are new parameters or knobs, different values are tested in simulation~
~`ASSERT`, `ASSERT_WE_THINK`, and `TEST` macros are added in appropriate places~
~Unit tests were added for new algorithms and data structure that make sense to unit-test~
~If this is a bugfix: there is a test that can easily reproduce the bug~
