### PR TITLE
flow: fix ifdef fall-through on FreeBSD

### DIFF
--- a/flow/Platform.actor.cpp
+++ b/flow/Platform.actor.cpp
@@ -2406,7 +2406,7 @@ ACTOR Future<vector<std::string>> findFiles( std::string directory, std::string 
 	return result;
 }
 
-#elif (defined(__linux__) || defined(__APPLE__))
+#elif (defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__))
 #define FILE_ATTRIBUTE_DATA mode_t
 
 bool acceptFile( FILE_ATTRIBUTE_DATA fileAttributes, std::string const& name, std::string const& extension ) {


### PR DESCRIPTION
The preceding `#ifdef _WIN32`  falls through on FreeBSD without this.

This could possibly be a `__unixish_` if desired.

### Style

- [x] All variable and function names make sense.
- [x] The code is properly formatted (consider running `git clang-format`).

### Performance

~All CPU-hot paths are well optimized~
~The proper containers are used (for example `std::vector` vs `VectorRef`)~
~There are no new known `SlowTask` traces~

### Testing

~The code was sufficiently tested in simulation~
~If there are new parameters or knobs, different values are tested in simulation~
~`ASSERT`, `ASSERT_WE_THINK`, and `TEST` macros are added in appropriate places~
~Unit tests were added for new algorithms and data structure that make sense to unit-test~
~If this is a bugfix: there is a test that can easily reproduce the bug~
