### PR TITLE
Remove -Wno-unused-value

### DIFF
--- a/cmake/ConfigureCompiler.cmake
+++ b/cmake/ConfigureCompiler.cmake
@@ -259,7 +259,6 @@ else()
       -Wno-unused-function
       -Wno-unused-local-typedef
       -Wno-unused-parameter
-      -Wno-unused-value
       -Wno-self-assign
       )
     if (USE_CCACHE)


### PR DESCRIPTION
I don't know how this keeps reappearing. I've removed it several times already.