### PR TITLE
Add network option to set tracer in fdbclient

### DIFF
--- a/bindings/c/test/unit/unit_tests.cpp
+++ b/bindings/c/test/unit/unit_tests.cpp
@@ -1882,19 +1882,19 @@ TEST_CASE("special-key-space disable tracing") {
   }
 }
 
-TEST_CASE("FDB_DB_OPTION_TRANSACTION_TRACE_DISABLE") {
-  fdb_check(fdb_database_set_option(db, FDB_DB_OPTION_TRANSACTION_TRACE_DISABLE, nullptr, 0));
+TEST_CASE("FDB_DB_OPTION_DISTRIBUTED_TRANSACTION_TRACE_DISABLE") {
+  fdb_check(fdb_database_set_option(db, FDB_DB_OPTION_DISTRIBUTED_TRANSACTION_TRACE_DISABLE, nullptr, 0));
 
   auto value = get_value("\xff\xff/tracing/token", /* snapshot */ false, {});
   REQUIRE(value.has_value());
   uint64_t token = std::stoul(value.value());
   CHECK(token == 0);
 
-  fdb_check(fdb_database_set_option(db, FDB_DB_OPTION_TRANSACTION_TRACE_ENABLE, nullptr, 0));
+  fdb_check(fdb_database_set_option(db, FDB_DB_OPTION_DISTRIBUTED_TRANSACTION_TRACE_ENABLE, nullptr, 0));
 }
 
-TEST_CASE("FDB_DB_OPTION_TRANSACTION_TRACE_DISABLE enable tracing for transaction") {
-  fdb_check(fdb_database_set_option(db, FDB_DB_OPTION_TRANSACTION_TRACE_DISABLE, nullptr, 0));
+TEST_CASE("FDB_DB_OPTION_DISTRIBUTED_TRANSACTION_TRACE_DISABLE enable tracing for transaction") {
+  fdb_check(fdb_database_set_option(db, FDB_DB_OPTION_DISTRIBUTED_TRANSACTION_TRACE_DISABLE, nullptr, 0));
 
   fdb::Transaction tr(db);
   fdb_check(tr.set_option(FDB_TR_OPTION_SPECIAL_KEY_SPACE_ENABLE_WRITES,
@@ -1922,7 +1922,7 @@ TEST_CASE("FDB_DB_OPTION_TRANSACTION_TRACE_DISABLE enable tracing for transactio
     break;
   }
 
-  fdb_check(fdb_database_set_option(db, FDB_DB_OPTION_TRANSACTION_TRACE_ENABLE, nullptr, 0));
+  fdb_check(fdb_database_set_option(db, FDB_DB_OPTION_DISTRIBUTED_TRANSACTION_TRACE_ENABLE, nullptr, 0));
 }
 
 TEST_CASE("special-key-space tracing get range") {

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -1541,6 +1541,23 @@ void setNetworkOption(FDBNetworkOptions::Option option, Optional<StringRef> valu
 			validateOptionValue(value, false);
 			networkOptions.runLoopProfilingEnabled = true;
 			break;
+		case FDBNetworkOptions::CLIENT_TRACER: {
+			validateOptionValue(value, true);
+			std::string tracer = value.get().toString();
+			if (tracer == "none" || tracer == "disabled") {
+				openTracer(TracerType::DISABLED);
+			} else if (tracer == "logfile" || tracer == "file" || tracer == "log_file") {
+				openTracer(TracerType::LOG_FILE);
+			} else if (tracer == "network_async") {
+				openTracer(TracerType::NETWORK_ASYNC);
+			} else if (tracer == "network_lossy") {
+				openTracer(TracerType::NETWORK_LOSSY);
+			} else {
+				fprintf(stderr, "ERROR: Unknown or unsupported tracer: `%s'", tracer.c_str());
+				throw invalid_option_value();
+			}
+			break;
+		}
 		default:
 			break;
 	}

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -1213,11 +1213,11 @@ void DatabaseContext::setOption( FDBDatabaseOptions::Option option, Optional<Str
 				validateOptionValue(value, false);
 				snapshotRywEnabled--;
 				break;
-			case FDBDatabaseOptions::TRANSACTION_TRACE_ENABLE:
+			case FDBDatabaseOptions::DISTRIBUTED_TRANSACTION_TRACE_ENABLE:
 				validateOptionValue(value, false);
 				transactionTracingEnabled++;
 				break;
-			case FDBDatabaseOptions::TRANSACTION_TRACE_DISABLE:
+			case FDBDatabaseOptions::DISTRIBUTED_TRANSACTION_TRACE_DISABLE:
 				validateOptionValue(value, false);
 				transactionTracingEnabled--;
 				break;
@@ -1541,7 +1541,7 @@ void setNetworkOption(FDBNetworkOptions::Option option, Optional<StringRef> valu
 			validateOptionValue(value, false);
 			networkOptions.runLoopProfilingEnabled = true;
 			break;
-		case FDBNetworkOptions::CLIENT_TRACER: {
+		case FDBNetworkOptions::DISTRIBUTED_CLIENT_TRACER: {
 			validateOptionValue(value, true);
 			std::string tracer = value.get().toString();
 			if (tracer == "none" || tracer == "disabled") {

--- a/fdbclient/vexillographer/fdb.options
+++ b/fdbclient/vexillographer/fdb.options
@@ -125,6 +125,9 @@ description is not currently required but encouraged.
     <Option name="client_buggify_section_fired_probability" code="83"
             paramType="Int" paramDescription="probability expressed as a percentage between 0 and 100"
             description="Set the probability of an active CLIENT_BUGGIFY section being fired. A section will only fire if it was activated" />
+    <Option name="client_tracer" code="90"
+            paramType="String" paramDescription="Tracer type. Choose from none, log_file, network_async, or network_lossy"
+            description="Set a tracer to run on the client. Should be set to the same tracer set on the server." />
     <Option name="supported_client_versions" code="1000"
             paramType="String" paramDescription="[release version],[source version],[protocol version];..."
             description="This option is set automatically to communicate the list of supported clients to the active client."

--- a/fdbclient/vexillographer/fdb.options
+++ b/fdbclient/vexillographer/fdb.options
@@ -125,9 +125,9 @@ description is not currently required but encouraged.
     <Option name="client_buggify_section_fired_probability" code="83"
             paramType="Int" paramDescription="probability expressed as a percentage between 0 and 100"
             description="Set the probability of an active CLIENT_BUGGIFY section being fired. A section will only fire if it was activated" />
-    <Option name="client_tracer" code="90"
-            paramType="String" paramDescription="Tracer type. Choose from none, log_file, network_async, or network_lossy"
-            description="Set a tracer to run on the client. Should be set to the same tracer set on the server." />
+    <Option name="distributed_client_tracer" code="90"
+            paramType="String" paramDescription="Distributed tracer type. Choose from none, log_file, network_async, or network_lossy"
+            description="Set a tracer to run on the client. Should be set to the same value as the tracer set on the server." />
     <Option name="supported_client_versions" code="1000"
             paramType="String" paramDescription="[release version],[source version],[protocol version];..."
             description="This option is set automatically to communicate the list of supported clients to the active client."
@@ -185,9 +185,9 @@ description is not currently required but encouraged.
     <Option name="transaction_include_port_in_address" code="505"
             description="Addresses returned by get_addresses_for_key include the port when enabled. As of api version 630, this option is enabled by default and setting this has no effect."
             defaultFor="23"/>
-    <Option name="transaction_trace_enable" code="600"
+    <Option name="distributed_transaction_trace_enable" code="600"
             description="Enable tracing for all transactions. This is the default." />
-    <Option name="transaction_trace_disable" code="601"
+    <Option name="distributed_transaction_trace_disable" code="601"
             description="Disable tracing for all transactions." />
   </Scope>
   


### PR DESCRIPTION
Changes in this PR:

- In order to capture spans emitted in fdbclient code, a tracer must be opened (using `openTracer`) in `fdbclient` and `fdbserver` code separately.
- Add a network option to set the tracer in fdbclient.
- Eventually, the goal is to allow one universal option to set the tracer in both client and server.

## General guideline:

### Style
- [x] All variable and function names make sense.
- [x] The code is properly formatted (consider running `git clang-format`).

### Performance
- ~~[ ] All CPU-hot paths are well optimized.~~
- ~~[ ] The proper containers are used (for example `std::vector` vs `VectorRef`).~~
- [x] There are no new known `SlowTask` traces.

### Testing
- [x] The code was sufficiently tested in simulation.
- [x] If there are new parameters or knobs, different values are tested in simulation.
- ~~[ ] `ASSERT`, `ASSERT_WE_THINK`, and `TEST` macros are added in appropriate places.~~
- ~~[ ] Unit tests were added for new algorithms and data structure that make sense to unit-test~~
- ~~[ ] If this is a bugfix: there is a test that can easily reproduce the bug.~~
