### PR TITLE
Added a hint in trace event when all replicas of some data …

### DIFF
--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -3415,7 +3415,7 @@ ACTOR Future<Void> teamTracker(DDTeamCollection* self, Reference<TCTeamInfo> tea
 						    .detail("Info", team->getDesc())
 						    .detail("ZeroHealthyServerTeams", self->zeroHealthyTeams->get())
 						    .detail("Hint", severity == SevWarnAlways ? "No replicas remain of some data"
-						                                              : "This team's priority changed");
+						                                              : "The priority of this team changed");
 						if (team->getPriority() == SERVER_KNOBS->PRIORITY_TEAM_0_LEFT) {
 							// 0 servers left in this team, data might be lost.
 							zeroServerLeftLogger = zeroServerLeftLogger_impl(self, team);

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -3181,7 +3181,7 @@ ACTOR Future<Void> zeroServerLeftLogger_impl(DDTeamCollection* self, Reference<T
 
 	for (auto const& shard : shards) {
 		sizes.emplace_back(brokenPromiseToNever(self->getShardMetrics.getReply(GetMetricsRequest(shard))));
-		TraceEvent(SevWarnAlways, "DDShardLost", self->distributorId)
+		TraceEvent(SevError, "DDShardLost", self->distributorId)
 		    .detail("ServerTeamID", team->getTeamID())
 		    .detail("ShardBegin", shard.begin)
 		    .detail("ShardEnd", shard.end);
@@ -3194,7 +3194,7 @@ ACTOR Future<Void> zeroServerLeftLogger_impl(DDTeamCollection* self, Reference<T
 		bytesLost += size.get().bytes;
 	}
 
-	TraceEvent(SevWarnAlways, "DDZeroServerLeftInTeam", self->distributorId)
+	TraceEvent(SevError, "DDZeroServerLeftInTeam", self->distributorId)
 	    .detail("Team", team->getDesc())
 	    .detail("TotalBytesLost", bytesLost);
 
@@ -3409,11 +3409,13 @@ ACTOR Future<Void> teamTracker(DDTeamCollection* self, Reference<TCTeamInfo> tea
 					}
 					if (logTeamEvents) {
 						int dataLoss = team->getPriority() == SERVER_KNOBS->PRIORITY_TEAM_0_LEFT;
-						Severity severity = dataLoss ? SevWarnAlways : SevInfo;
+						Severity severity = dataLoss ? SevError : SevInfo;
 						TraceEvent(severity, "ServerTeamPriorityChange", self->distributorId)
 						    .detail("Priority", team->getPriority())
 						    .detail("Info", team->getDesc())
-						    .detail("ZeroHealthyServerTeams", self->zeroHealthyTeams->get());
+						    .detail("ZeroHealthyServerTeams", self->zeroHealthyTeams->get())
+						    .detail("Hint", severity == SevError ? "No replicas remain of some data"
+						                                         : "This team's priority changed");
 						if (team->getPriority() == SERVER_KNOBS->PRIORITY_TEAM_0_LEFT) {
 							// 0 servers left in this team, data might be lost.
 							zeroServerLeftLogger = zeroServerLeftLogger_impl(self, team);


### PR DESCRIPTION
Added a hint field in the trace event when all replicas of some data are lost.

Changes in this PR:

- Changed some loggings from `SevWarnAlways` to `SevError` for better observability.

### Style
- [x] All variable and function names make sense.
- [x] The code is properly formatted (consider running `git clang-format`).

### Performance
~- [ ] All CPU-hot paths are well optimized.~
~- [ ] The proper containers are used (for example `std::vector` vs `VectorRef`).~
~- [ ] There are no new known `SlowTask` traces.~

### Testing
- [x] The code was sufficiently tested in simulation.
~- [ ] If there are new parameters or knobs, different values are tested in simulation.~
~- [ ] `ASSERT`, `ASSERT_WE_THINK`, and `TEST` macros are added in appropriate places.~
~- [ ] Unit tests were added for new algorithms and data structure that make sense to unit-test~
~- [ ] If this is a bugfix: there is a test that can easily reproduce the bug.~
