### PR TITLE
Add a SevWarnAlways trace line to help debug a rare failure.

### DIFF
--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -2360,7 +2360,7 @@ ACTOR Future<Void> fetchKeys( StorageServer *data, AddingShard* shard ) {
 					if (debug_getRangeRetries >= 100) {
 						data->cx->enableLocalityLoadBalance = false;
 						// TODO: Add SevWarnAlways to say it was disabled.
-						TraceEvent(SevWarnAlways, "FKDisableLB");
+						TraceEvent(SevWarnAlways, "FKDisableLB").detail("FKID", fetchKeysID);
 					}
 
 					debug_getRangeRetries++;
@@ -2379,6 +2379,7 @@ ACTOR Future<Void> fetchKeys( StorageServer *data, AddingShard* shard ) {
 
 		//FIXME: remove when we no longer support upgrades from 5.X
 		data->cx->enableLocalityLoadBalance = true;
+		TraceEvent(SevWarnAlways, "FKReenableLB").detail("FKID", fetchKeysID);
 
 		// We have completed the fetch and write of the data, now we wait for MVCC window to pass.
 		//  As we have finished this work, we will allow more work to start...

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -2359,7 +2359,6 @@ ACTOR Future<Void> fetchKeys( StorageServer *data, AddingShard* shard ) {
 					//FIXME: remove when we no longer support upgrades from 5.X
 					if (debug_getRangeRetries >= 100) {
 						data->cx->enableLocalityLoadBalance = false;
-						// TODO: Add SevWarnAlways to say it was disabled.
 						TraceEvent(SevWarnAlways, "FKDisableLB").detail("FKID", fetchKeysID);
 					}
 

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -2360,6 +2360,7 @@ ACTOR Future<Void> fetchKeys( StorageServer *data, AddingShard* shard ) {
 					if (debug_getRangeRetries >= 100) {
 						data->cx->enableLocalityLoadBalance = false;
 						// TODO: Add SevWarnAlways to say it was disabled.
+						TraceEvent(SevWarnAlways, "FKDisableLB");
 					}
 
 					debug_getRangeRetries++;


### PR DESCRIPTION
Changes in this PR:

- Added a trace line to help debug a rare failure

### Style
- [x] All variable and function names make sense.
- [x] The code is properly formatted (consider running `git clang-format`).

### Performance
~- [ ] All CPU-hot paths are well optimized.~
~- [ ] The proper containers are used (for example `std::vector` vs `VectorRef`).~
~- [ ] There are no new known `SlowTask` traces.~

### Testing
~- [ ] The code was sufficiently tested in simulation.~
~- [ ] If there are new parameters or knobs, different values are tested in simulation.~
~- [ ] `ASSERT`, `ASSERT_WE_THINK`, and `TEST` macros are added in appropriate places.~
~- [ ] Unit tests were added for new algorithms and data structure that make sense to unit-test~
~- [ ] If this is a bugfix: there is a test that can easily reproduce the bug.~
