### PR TITLE
Features/mimalloc

### DIFF
--- a/cmake/CompileMimalloc.cmake
+++ b/cmake/CompileMimalloc.cmake
@@ -3,7 +3,7 @@ find_package(mimalloc 1.6.7 QUIET)
 if(mimalloc_FOUND)
   add_library(Mimalloc INTERFACE)
   target_link_libraries(Mimalloc INTERFACE mimalloc-static)
-else()
+elseif(NOT WIN32)
   include(ExternalProject)
   ExternalProject_add(mimallocProject
     URL "https://github.com/microsoft/mimalloc/archive/v1.6.7.tar.gz"
@@ -16,4 +16,8 @@ else()
   add_library(Mimalloc STATIC IMPORTED)
   add_dependencies(Mimalloc mimallocProject)
   set_target_properties(Mimalloc PROPERTIES IMPORTED_LOCATION "${CMAKE_CURRENT_BINARY_DIR}/mimalloc/lib/mimalloc-1.6/libmimalloc.a")
+else()
+  # On Windows we currently don't use mimalloc as it doesn't compile
+  # unless we find it installed
+  add_library(Mimalloc INTERFACE)
 endif()

--- a/cmake/CompileMimalloc.cmake
+++ b/cmake/CompileMimalloc.cmake
@@ -1,4 +1,4 @@
-find_package(mimalloc 1.6.7)
+find_package(mimalloc 1.6.7 QUIET)
 
 if(mimalloc_FOUND)
   add_library(Mimalloc INTERFACE)
@@ -11,8 +11,9 @@ else()
     CMAKE_CACHE_ARGS -DCMAKE_INSTALL_PREFIX:PATH=${CMAKE_CURRENT_BINARY_DIR}/mimalloc
                      -DCMAKE_BUILD_TYPE:STRING=Release -DMI_BUILD_TESTS:BOOL=OFF
                      -DMI_BUILD_SHARED:BOOL=OFF -DMI_BUILD_STATIC:BOOL=ON
+    BUILD_BYPRODUCTS "${CMAKE_CURRENT_BINARY_DIR}/mimalloc/lib/mimalloc-1.6/libmimalloc.a"
     BUILD_ALWAYS ON)
-  add_library(Mimalloc INTERFACE)
+  add_library(Mimalloc STATIC IMPORTED)
   add_dependencies(Mimalloc mimallocProject)
-  target_link_libraries(Mimalloc INTERFACE "${CMAKE_CURRENT_BINARY_DIR}/mimalloc/lib/mimalloc-1.6/libmimalloc.a")
+  set_target_properties(Mimalloc PROPERTIES IMPORTED_LOCATION "${CMAKE_CURRENT_BINARY_DIR}/mimalloc/lib/mimalloc-1.6/libmimalloc.a")
 endif()

--- a/cmake/CompileMimalloc.cmake
+++ b/cmake/CompileMimalloc.cmake
@@ -1,0 +1,18 @@
+find_package(mimalloc 1.6.7)
+
+if(mimalloc_FOUND)
+  add_library(Mimalloc INTERFACE)
+  target_link_libraries(Mimalloc INTERFACE mimalloc-static)
+else()
+  include(ExternalProject)
+  ExternalProject_add(mimallocProject
+    URL "https://github.com/microsoft/mimalloc/archive/v1.6.7.tar.gz"
+    URL_HASH SHA256=111b718b496f297f128d842880e72e90e33953cf00b45ba0ccd2167e7340ed17
+    CMAKE_CACHE_ARGS -DCMAKE_INSTALL_PREFIX:PATH=${CMAKE_CURRENT_BINARY_DIR}/mimalloc
+                     -DCMAKE_BUILD_TYPE:STRING=Release -DMI_BUILD_TESTS:BOOL=OFF
+                     -DMI_BUILD_SHARED:BOOL=OFF -DMI_BUILD_STATIC:BOOL=ON
+    BUILD_ALWAYS ON)
+  add_library(Mimalloc INTERFACE)
+  add_dependencies(Mimalloc mimallocProject)
+  target_link_libraries(Mimalloc INTERFACE "${CMAKE_CURRENT_BINARY_DIR}/mimalloc/lib/mimalloc-1.6/libmimalloc.a")
+endif()

--- a/cmake/FDBComponents.cmake
+++ b/cmake/FDBComponents.cmake
@@ -124,7 +124,7 @@ endif()
 find_package(toml11 QUIET)
 if(toml11_FOUND)
   add_library(toml11_target INTERFACE)
-  add_dependencies(toml11_target INTERFACE toml11::toml11)
+  target_link_libraries(toml11_target INTERFACE toml11::toml11)
 else()
   include(ExternalProject)
 
@@ -139,6 +139,12 @@ else()
   add_dependencies(toml11_target toml11Project)
   target_include_directories(toml11_target SYSTEM INTERFACE ${CMAKE_CURRENT_BINARY_DIR}/toml11/include)
 endif()
+
+################################################################################
+# mimalloc
+################################################################################
+
+include(CompileMimalloc)
 
 ################################################################################
 

--- a/flow/CMakeLists.txt
+++ b/flow/CMakeLists.txt
@@ -112,7 +112,8 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/SourceVersion.h.cmake ${CMAKE_CURRENT
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/config.h)
 
 add_flow_target(STATIC_LIBRARY NAME flow SRCS ${FLOW_SRCS})
-target_link_libraries(flow PRIVATE stacktrace)
+include(CompileMimalloc)
+target_link_libraries(flow PUBLIC stacktrace Mimalloc)
 if (NOT APPLE AND NOT WIN32)
   set (FLOW_LIBS ${FLOW_LIBS} rt)
 elseif(WIN32)

--- a/flow/CMakeLists.txt
+++ b/flow/CMakeLists.txt
@@ -112,8 +112,7 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/SourceVersion.h.cmake ${CMAKE_CURRENT
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/config.h)
 
 add_flow_target(STATIC_LIBRARY NAME flow SRCS ${FLOW_SRCS})
-include(CompileMimalloc)
-target_link_libraries(flow PUBLIC stacktrace Mimalloc)
+target_link_libraries(flow PRIVATE stacktrace Mimalloc)
 if (NOT APPLE AND NOT WIN32)
   set (FLOW_LIBS ${FLOW_LIBS} rt)
 elseif(WIN32)

--- a/flow/FastAlloc.h
+++ b/flow/FastAlloc.h
@@ -191,15 +191,11 @@ template <class Object>
 class FastAllocated {
 public:
 	[[nodiscard]] static void* operator new(size_t s) {
-		if (s != sizeof(Object)) abort();
-		INSTRUMENT_ALLOCATE(typeid(Object).name());
-		void* p = FastAllocator < sizeof(Object) <= 64 ? 64 : nextFastAllocatedSize(sizeof(Object)) > ::allocate();
-		return p;
+		return ::malloc(s);
 	}
 
 	static void operator delete(void* s) {
-		INSTRUMENT_RELEASE(typeid(Object).name());
-		FastAllocator<sizeof(Object) <= 64 ? 64 : nextFastAllocatedSize(sizeof(Object))>::release(s);
+		return ::free(s);
 	}
 	// Redefine placement new so you can still use it
 	static void* operator new( size_t, void* p ) { return p; }
@@ -207,35 +203,11 @@ public:
 };
 
 [[nodiscard]] inline void* allocateFast(int size) {
-	if (size <= 16) return FastAllocator<16>::allocate();
-	if (size <= 32) return FastAllocator<32>::allocate();
-	if (size <= 64) return FastAllocator<64>::allocate();
-	if (size <= 96) return FastAllocator<96>::allocate();
-	if (size <= 128) return FastAllocator<128>::allocate();
-	if (size <= 256) return FastAllocator<256>::allocate();
-	if (size <= 512) return FastAllocator<512>::allocate();
-	if (size <= 1024) return FastAllocator<1024>::allocate();
-	if (size <= 2048) return FastAllocator<2048>::allocate();
-	if (size <= 4096) return FastAllocator<4096>::allocate();
-	if (size <= 8192) return FastAllocator<8192>::allocate();
-	if (size <= 16384) return FastAllocator<16384>::allocate();
-	return new uint8_t[size];
+	return ::malloc(size);
 }
 
 inline void freeFast(int size, void* ptr) {
-	if (size <= 16) return FastAllocator<16>::release(ptr);
-	if (size <= 32) return FastAllocator<32>::release(ptr);
-	if (size <= 64) return FastAllocator<64>::release(ptr);
-	if (size <= 96) return FastAllocator<96>::release(ptr);
-	if (size <= 128) return FastAllocator<128>::release(ptr);
-	if (size <= 256) return FastAllocator<256>::release(ptr);
-	if (size <= 512) return FastAllocator<512>::release(ptr);
-	if (size <= 1024) return FastAllocator<1024>::release(ptr);
-	if (size <= 2048) return FastAllocator<2048>::release(ptr);
-	if (size <= 4096) return FastAllocator<4096>::release(ptr);
-	if (size <= 8192) return FastAllocator<8192>::release(ptr);
-	if (size <= 16384) return FastAllocator<16384>::release(ptr);
-	delete[](uint8_t*)ptr;
+	::free(ptr);
 }
 
 #endif


### PR DESCRIPTION
This PR adds [mimalloc](https://github.com/microsoft/mimalloc) for all allocations that are not fast allocated. `mimalloc` seems to be faster than `malloc` for most allocation patterns (even when removing FastAlloc entirely, I couldn't see a performance regression in perf sanity).

We still use standard malloc in many places (for example all usages of STL containers like vector and string).

Changes in this PR:

- Fetch and build mimalloc in cmake
- Statically link against mimalloc

## General guideline:

- If this PR is ready to be merged (and all checkboxes below are either ticked or not applicable), make this a regular PR
- If this PR still needs work, please make this a draft PR
  - If you wish to get feedback/code-review, please add the label RFC to this PR

Please verify that all things listed below were considered and check them. If an item doesn't apply to this type of PR (for example a documentation change doesn't need to be performance tested), you should make a ~~strikethrough~~ (markdown syntax: `~~strikethrough~~`). More infos on the guidlines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

### Style
- [x] All variable and function names make sense.
- [x] The code is properly formatted (consider running `git clang-format`).

### Performance
- [x] All CPU-hot paths are well optimized.
- ~~[ ] The proper containers are used (for example `std::vector` vs `VectorRef`).~~
- ~~[ ] There are no new known `SlowTask` traces.~~

### Testing
- ~~[ ] The code was sufficiently tested in simulation.~~
- ~~[ ] If there are new parameters or knobs, different values are tested in simulation.~~
- ~~[ ] `ASSERT`, `ASSERT_WE_THINK`, and `TEST` macros are added in appropriate places.~~
- ~~[ ] Unit tests were added for new algorithms and data structure that make sense to unit-test~~
- ~~[ ] If this is a bugfix: there is a test that can easily reproduce the bug.~~
