### PR TITLE
Fix -Wreturn-type warning

### DIFF
--- a/fdbrpc/FlowTransport.actor.cpp
+++ b/fdbrpc/FlowTransport.actor.cpp
@@ -855,6 +855,9 @@ static bool checkCompatible(const PeerCompatibilityPolicy& policy, ProtocolVersi
 		return version.version() == policy.version.version();
 	case RequirePeer::AtLeast:
 		return version.version() >= policy.version.version();
+	default:
+		ASSERT(false);
+		return false;
 	}
 }
 


### PR DESCRIPTION
Fixes a warning due to "control reaches end of non-void function [-Wreturn-type]".

### Style
- [x] All variable and function names make sense.
- [x] The code is properly formatted (consider running `git clang-format`).

### Performance
- [x] ~All CPU-hot paths are well optimized.~
- [x] ~The proper containers are used (for example `std::vector` vs `VectorRef`).~
- [x] ~There are no new known `SlowTask` traces.~

### Testing
- [x] The code was sufficiently tested in simulation.
- [x] ~If there are new parameters or knobs, different values are tested in simulation.~
- [x] ~`ASSERT`, `ASSERT_WE_THINK`, and `TEST` macros are added in appropriate places.~
- [x] ~Unit tests were added for new algorithms and data structure that make sense to unit-test~
- [x]~ If this is a bugfix: there is a test that can easily reproduce the bug.~
