### PR TITLE
Add override keyword properly to squash compiler warnings

### DIFF
--- a/fdbclient/SpecialKeySpace.actor.h
+++ b/fdbclient/SpecialKeySpace.actor.h
@@ -100,7 +100,7 @@ class SpecialKeyRangeAsyncImpl : public SpecialKeyRangeReadImpl {
 public:
 	explicit SpecialKeyRangeAsyncImpl(KeyRangeRef kr) : SpecialKeyRangeReadImpl(kr) {}
 
-	Future<Standalone<RangeResultRef>> getRange(ReadYourWritesTransaction* ryw, KeyRangeRef kr) const = 0;
+	Future<Standalone<RangeResultRef>> getRange(ReadYourWritesTransaction* ryw, KeyRangeRef kr) const override = 0;
 
 	// calling with a cache object to have consistent results if we need to call rpc
 	Future<Standalone<RangeResultRef>> getRange(ReadYourWritesTransaction* ryw, KeyRangeRef kr,

--- a/fdbrpc/FailureMonitor.h
+++ b/fdbrpc/FailureMonitor.h
@@ -138,8 +138,8 @@ public:
 class SimpleFailureMonitor : public IFailureMonitor {
 public:
 	SimpleFailureMonitor();
-	void setStatus(NetworkAddress const& address, FailureStatus const& status);
-	void endpointNotFound(Endpoint const&);
+	void setStatus(NetworkAddress const& address, FailureStatus const& status) override;
+	void endpointNotFound(Endpoint const&) override;
 	void notifyDisconnect(NetworkAddress const&) override;
 
 	Future<Void> onStateChanged(Endpoint const& endpoint) override;

--- a/flow/TDMetric.actor.h
+++ b/flow/TDMetric.actor.h
@@ -1046,7 +1046,7 @@ public:
 	void addref() override { ReferenceCounted<DynamicEventMetric>::addref(); }
 	void delref() override { ReferenceCounted<DynamicEventMetric>::delref(); }
 
-	void onEnable() {
+	void onEnable() override {
 		// Must initialize fields, previously knobs may not have been set.
 		// Note that future fields will be okay because the field constructor will init and the knobs will be set.
 		time.init();


### PR DESCRIPTION
This PR adds the override keyword in specific files to clean up warnings given by the compiler
