### PR TITLE
Fix minor issues for aarch64

### DIFF
--- a/cmake/ConfigureCompiler.cmake
+++ b/cmake/ConfigureCompiler.cmake
@@ -311,9 +311,9 @@ else()
   endif()
 
   if(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
-    # Graviton or later
+    # Graviton2 or later
     # https://github.com/aws/aws-graviton-gettting-started
-    add_compile_options(-march=armv8-a+crc+simd)
+    add_compile_options(-march=armv8.2-a+crc+simd)
   endif()
 
   # Check whether we can use dtrace probes

--- a/cmake/InstallLayout.cmake
+++ b/cmake/InstallLayout.cmake
@@ -303,15 +303,15 @@ set(CPACK_RPM_CLIENTS-EL7_PACKAGE_NAME "foundationdb-clients")
 set(CPACK_RPM_SERVER-EL7_PACKAGE_NAME "foundationdb-server")
 set(CPACK_RPM_SERVER-VERSIONED_PACKAGE_NAME "foundationdb-server-${PROJECT_VERSION}")
 
-set(CPACK_RPM_CLIENTS-EL7_FILE_NAME "${rpm-clients-filename}.el7.x86_64.rpm")
-set(CPACK_RPM_CLIENTS-VERSIONED_FILE_NAME "${rpm-clients-filename}.versioned.x86_64.rpm")
-set(CPACK_RPM_SERVER-EL7_FILE_NAME "${rpm-server-filename}.el7.x86_64.rpm")
-set(CPACK_RPM_SERVER-VERSIONED_FILE_NAME "${rpm-server-filename}.versioned.x86_64.rpm")
+set(CPACK_RPM_CLIENTS-EL7_FILE_NAME "${rpm-clients-filename}.el7.${CMAKE_SYSTEM_PROCESSOR}.rpm")
+set(CPACK_RPM_CLIENTS-VERSIONED_FILE_NAME "${rpm-clients-filename}.versioned.${CMAKE_SYSTEM_PROCESSOR}.rpm")
+set(CPACK_RPM_SERVER-EL7_FILE_NAME "${rpm-server-filename}.el7.${CMAKE_SYSTEM_PROCESSOR}.rpm")
+set(CPACK_RPM_SERVER-VERSIONED_FILE_NAME "${rpm-server-filename}.versioned.${CMAKE_SYSTEM_PROCESSOR}.rpm")
 
-set(CPACK_RPM_CLIENTS-EL7_DEBUGINFO_FILE_NAME "${rpm-clients-filename}.el7-debuginfo.x86_64.rpm")
-set(CPACK_RPM_CLIENTS-VERSIONED_DEBUGINFO_FILE_NAME "${rpm-clients-filename}.versioned-debuginfo.x86_64.rpm")
-set(CPACK_RPM_SERVER-EL7_DEBUGINFO_FILE_NAME "${rpm-server-filename}.el7-debuginfo.x86_64.rpm")
-set(CPACK_RPM_SERVER-VERSIONED_DEBUGINFO_FILE_NAME "${rpm-server-filename}.versioned-debuginfo.x86_64.rpm")
+set(CPACK_RPM_CLIENTS-EL7_DEBUGINFO_FILE_NAME "${rpm-clients-filename}.el7-debuginfo.${CMAKE_SYSTEM_PROCESSOR}.rpm")
+set(CPACK_RPM_CLIENTS-VERSIONED_DEBUGINFO_FILE_NAME "${rpm-clients-filename}.versioned-debuginfo.${CMAKE_SYSTEM_PROCESSOR}.rpm")
+set(CPACK_RPM_SERVER-EL7_DEBUGINFO_FILE_NAME "${rpm-server-filename}.el7-debuginfo.${CMAKE_SYSTEM_PROCESSOR}.rpm")
+set(CPACK_RPM_SERVER-VERSIONED_DEBUGINFO_FILE_NAME "${rpm-server-filename}.versioned-debuginfo.${CMAKE_SYSTEM_PROCESSOR}.rpm")
 
 file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/packaging/emptydir")
 fdb_install(DIRECTORY "${CMAKE_BINARY_DIR}/packaging/emptydir/" DESTINATION data COMPONENT server)
@@ -377,8 +377,13 @@ set(CPACK_RPM_CLIENTS-VERSIONED_PRE_UNINSTALL_SCRIPT_FILE
 # Configuration for DEB
 ################################################################################
 
-set(CPACK_DEBIAN_CLIENTS-DEB_FILE_NAME "${deb-clients-filename}_amd64.deb")
-set(CPACK_DEBIAN_SERVER-DEB_FILE_NAME "${deb-server-filename}_amd64.deb")
+if (CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64")
+  set(CPACK_DEBIAN_CLIENTS-DEB_FILE_NAME "${deb-clients-filename}_amd64.deb")
+  set(CPACK_DEBIAN_SERVER-DEB_FILE_NAME "${deb-server-filename}_amd64.deb")
+else()
+  set(CPACK_DEBIAN_CLIENTS-DEB_FILE_NAME "${deb-clients-filename}_${CMAKE_SYSTEM_PROCESSOR}.deb")
+  set(CPACK_DEBIAN_SERVER-DEB_FILE_NAME "${deb-server-filename}_${CMAKE_SYSTEM_PROCESSOR}.deb")
+endif()
 set(CPACK_DEB_COMPONENT_INSTALL ON)
 set(CPACK_DEBIAN_DEBUGINFO_PACKAGE ${GENERATE_DEBUG_PACKAGES})
 set(CPACK_DEBIAN_PACKAGE_SECTION "database")
@@ -427,8 +432,8 @@ endif()
 ################################################################################
 
 set(CPACK_ARCHIVE_COMPONENT_INSTALL ON)
-set(CPACK_ARCHIVE_CLIENTS-TGZ_FILE_NAME "${deb-clients-filename}.x86_64")
-set(CPACK_ARCHIVE_SERVER-TGZ_FILE_NAME "${deb-server-filename}.x86_64")
+set(CPACK_ARCHIVE_CLIENTS-TGZ_FILE_NAME "${deb-clients-filename}.${CMAKE_SYSTEM_PROCESSOR}")
+set(CPACK_ARCHIVE_SERVER-TGZ_FILE_NAME "${deb-server-filename}.${CMAKE_SYSTEM_PROCESSOR}")
 
 ################################################################################
 # Server configuration

--- a/flow/Platform.actor.cpp
+++ b/flow/Platform.actor.cpp
@@ -2371,7 +2371,7 @@ ACTOR Future<vector<std::string>> findFiles( std::string directory, std::string 
                                              bool directoryOnly, bool async) {
 	INJECT_FAULT( platform_error, "findFiles" ); // findFiles failed (Win32)
 	state vector<std::string> result;
-	state int64_t tsc_begin = __rdtsc();
+	state int64_t tsc_begin = timestampCounter();
 
 
 	state WIN32_FIND_DATA fd;
@@ -2390,9 +2390,9 @@ ACTOR Future<vector<std::string>> findFiles( std::string directory, std::string 
 			}
 			if (!FindNextFile( h, &fd ))
 				break;
-			if (async && __rdtsc() - tsc_begin > FLOW_KNOBS->TSC_YIELD_TIME && !g_network->isSimulated()) {
+			if (async && timestampCounter() - tsc_begin > FLOW_KNOBS->TSC_YIELD_TIME && !g_network->isSimulated()) {
 				wait( yield() );
-				tsc_begin = __rdtsc();
+				tsc_begin = timestampCounter();
 			}
 		}
 		if (GetLastError() != ERROR_NO_MORE_FILES) {
@@ -2421,7 +2421,7 @@ ACTOR Future<vector<std::string>> findFiles( std::string directory, std::string 
                                              bool directoryOnly, bool async) {
 	INJECT_FAULT( platform_error, "findFiles" ); // findFiles failed
 	state vector<std::string> result;
-	state int64_t tsc_begin = __rdtsc();
+	state int64_t tsc_begin = timestampCounter();
 
 	state DIR *dip = nullptr;
 
@@ -2451,9 +2451,9 @@ ACTOR Future<vector<std::string>> findFiles( std::string directory, std::string 
 			    (!directoryOnly && acceptFile(buf.st_mode, name, extension))) {
 				result.push_back( name );
 			}
-			if (async && __rdtsc() - tsc_begin > FLOW_KNOBS->TSC_YIELD_TIME && !g_network->isSimulated()) {
+			if (async && timestampCounter() - tsc_begin > FLOW_KNOBS->TSC_YIELD_TIME && !g_network->isSimulated()) {
 				wait( yield() );
-				tsc_begin = __rdtsc();
+				tsc_begin = timestampCounter();
 			}
 		}
 

--- a/flow/ThreadPrimitives.h
+++ b/flow/ThreadPrimitives.h
@@ -64,10 +64,10 @@ public:
 	}
 	void enter() {
 		while (isLocked.test_and_set(std::memory_order_acquire))
-#ifndef __aarch64__
-			_mm_pause();
+#ifdef __aarch64__
+			__asm__ volatile("isb");
 #else
-			; /* spin */
+			_mm_pause();
 #endif
 #if VALGRIND
 		ANNOTATE_RWLOCK_ACQUIRED(this, true);


### PR DESCRIPTION
This PR is fixes minor issues for aarch64.

Changes in this PR:

- Use timestampCounter() instead of __rdtsc()
- Use appropriate architecture name in the package names
- Do not generate "amd64" deb packages
- Use isb instruction in the spin latch

## General guideline:

- If this PR is ready to be merged (and all checkboxes below are either ticked or not applicable), make this a regular PR
- If this PR still needs work, please make this a draft PR
  - If you wish to get feedback/code-review, please add the label RFC to this PR

Please verify that all things listed below were considered and check them. If an item doesn't apply to this type of PR (for example a documentation change doesn't need to be performance tested), you should make a ~~strikethrough~~ (markdown syntax: `~~strikethrough~~`). More infos on the guidlines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

### Style
- [ ] All variable and function names make sense.
- [ ] The code is properly formatted (consider running `git clang-format`).

### Performance
- [ ] All CPU-hot paths are well optimized.
- [ ] The proper containers are used (for example `std::vector` vs `VectorRef`).
- [ ] There are no new known `SlowTask` traces.

### Testing
- [ ] The code was sufficiently tested in simulation.
- [ ] If there are new parameters or knobs, different values are tested in simulation.
- [ ] `ASSERT`, `ASSERT_WE_THINK`, and `TEST` macros are added in appropriate places.
- [ ] Unit tests were added for new algorithms and data structure that make sense to unit-test
- [ ] If this is a bugfix: there is a test that can easily reproduce the bug.
