### PR TITLE
Only print general help once in fdbcli

### DIFF
--- a/fdbcli/fdbcli.actor.cpp
+++ b/fdbcli/fdbcli.actor.cpp
@@ -629,10 +629,10 @@ void printHelpOverview() {
 	printf("\nList of commands:\n\n");
 	for (const auto& [command, help] : helpMap) {
 		if (help.short_desc.size()) printf(" %s:\n      %s\n", command.c_str(), help.short_desc.c_str());
-		printf("\nFor information on a specific command, type `help <command>'.");
-		printf("\nFor information on escaping keys and values, type `help escaping'.");
-		printf("\nFor information on available options, type `help options'.\n\n");
 	}
+	printf("\nFor information on a specific command, type `help <command>'.");
+	printf("\nFor information on escaping keys and values, type `help escaping'.");
+	printf("\nFor information on available options, type `help options'.\n\n");
 }
 
 void printHelp(StringRef command) {


### PR DESCRIPTION
This seems to have been inadvertently changed in
5b2e88b187c485d80119808c85e97fff98a30f8e.