### PR TITLE
Use VFSAsyncFile::checkInjectedError to detect injected faults

### DIFF
--- a/fdbserver/KeyValueStoreSQLite.actor.cpp
+++ b/fdbserver/KeyValueStoreSQLite.actor.cpp
@@ -309,7 +309,7 @@ struct SQLiteDB : NonCopyable {
 		int tables[] = {1, table, freetable};
 		TraceEvent("BTreeIntegrityCheckBegin").detail("Filename", filename);
 		char* e = sqlite3BtreeIntegrityCheck(btree, tables, 3, 1000, &errors, verbose);
-		if (!(g_network->isSimulated() && (g_simulator.getCurrentProcess()->fault_injection_p1 || g_simulator.getCurrentProcess()->rebooting))) {
+		if (!(g_network->isSimulated() && VFSAsyncFile::checkInjectedError())) {
 			TraceEvent((errors||e) ? SevError : SevInfo, "BTreeIntegrityCheckResults").detail("Filename", filename).detail("ErrorTotal", errors);
 			if(e != nullptr) {
 				// e is a string containing 1 or more lines.  Create a separate trace event for each line.
@@ -1657,7 +1657,7 @@ private:
 			if (checkIntegrityOnOpen || EXPENSIVE_VALIDATION) {
 				if(conn.check(false) != 0) {
 					// A corrupt btree structure must not be used.
-					if (g_network->isSimulated() && (g_simulator.getCurrentProcess()->fault_injection_p1 || g_simulator.getCurrentProcess()->machine->machineProcess->fault_injection_p1 || g_simulator.getCurrentProcess()->rebooting)) {
+					if (g_network->isSimulated() && VFSAsyncFile::checkInjectedError()) {
 						throw file_corrupt().asInjectedFault();
 					} else {
 						throw file_corrupt();


### PR DESCRIPTION
PR #4212  introduced VFSAsyncFile::checkInjectedError() to detect injected fault.
This pr simply changes the two places left.

### Style
- [ ] ~~All variable and function names make sense.~~
- [x] The code is properly formatted (consider running `git clang-format`).

### Performance
- [ ] ~~All CPU-hot paths are well optimized.~~
- [ ] ~~The proper containers are used (for example `std::vector` vs `VectorRef`).~~
- [ ] ~~There are no new known `SlowTask` traces.~~

### Testing
- [x] The code was sufficiently tested in simulation.
- [ ] ~~If there are new parameters or knobs, different values are tested in simulation.~~
- [ ] ~~`ASSERT`, `ASSERT_WE_THINK`, and `TEST` macros are added in appropriate places.~~
- [ ] ~~Unit tests were added for new algorithms and data structure that make sense to unit-test~~
- [ ] ~~If this is a bugfix: there is a test that can easily reproduce the bug.~~
