### PR TITLE
Add tracing to fileopen failure before throwing error for more info

### DIFF
--- a/flow/Platform.cpp
+++ b/flow/Platform.cpp
@@ -2273,7 +2273,8 @@ std::string readFileBytes( std::string const& filename, int maxSize ) {
 	if (!f) {
 		TraceEvent(SevError, "FileOpenError")
 			.detail("Filename", filename)
-			.detail("Errno", errno);
+			.detail("Errno", errno)
+			.detail("ErrorDescription", strerror(errno));
 		throw file_not_readable();
 	}
 	try {

--- a/flow/Platform.cpp
+++ b/flow/Platform.cpp
@@ -2271,7 +2271,7 @@ std::string readFileBytes( std::string const& filename, int maxSize ) {
 	std::string s;
 	FILE* f = fopen(filename.c_str(), "rb" FOPEN_CLOEXEC_MODE);
 	if (!f) {
-		TraceEvent(SevError, "FileOpenError")
+		TraceEvent(SevWarn, "FileOpenError")
 			.detail("Filename", filename)
 			.detail("Errno", errno)
 			.detail("ErrorDescription", strerror(errno));

--- a/flow/Platform.cpp
+++ b/flow/Platform.cpp
@@ -18,7 +18,6 @@
  * limitations under the License.
  */
 
-#include <errno.h>
 #ifdef _WIN32
 // This has to come as the first include on Win32 for rand_s() to be found
 #define _CRT_RAND_S
@@ -26,6 +25,7 @@
 #include <math.h> // For _set_FMA3_enable workaround in platformInit
 #endif
 
+#include <errno.h>
 #include "flow/Platform.h"
 #include "flow/Arena.h"
 

--- a/flow/Platform.cpp
+++ b/flow/Platform.cpp
@@ -18,7 +18,7 @@
  * limitations under the License.
  */
 
-#include <sys/errno.h>
+#include <errno.h>
 #ifdef _WIN32
 // This has to come as the first include on Win32 for rand_s() to be found
 #define _CRT_RAND_S

--- a/flow/Platform.cpp
+++ b/flow/Platform.cpp
@@ -18,6 +18,7 @@
  * limitations under the License.
  */
 
+#include <sys/errno.h>
 #ifdef _WIN32
 // This has to come as the first include on Win32 for rand_s() to be found
 #define _CRT_RAND_S
@@ -2269,7 +2270,12 @@ int64_t fileSize(std::string const& filename) {
 std::string readFileBytes( std::string const& filename, int maxSize ) {
 	std::string s;
 	FILE* f = fopen(filename.c_str(), "rb" FOPEN_CLOEXEC_MODE);
-	if (!f) throw file_not_readable();
+	if (!f) {
+		TraceEvent(SevError, "FileOpenError")
+			.detail("Filename", filename)
+			.detail("Errno", errno);
+		throw file_not_readable();
+	}
 	try {
 		fseek(f, 0, SEEK_END);
 		size_t size = ftell(f);


### PR DESCRIPTION
Changes in this PR:
Added a trace line in the `readFileBytes` path to provide more details about what caused `fopen` to fail