### PR TITLE
Adding compareSuffix to reduce temporary StringRef allocations

### DIFF
--- a/flow/Arena.h
+++ b/flow/Arena.h
@@ -510,9 +510,15 @@ public:
 	int expectedSize() const { return size(); }
 
 	int compare(StringRef const& other) const {
-		size_t minSize = std::min(size(), other.size());
-		if (minSize != 0) {
-			int c = memcmp(begin(), other.begin(), minSize);
+		return compareSuffix(other, 0);
+	}
+
+	int compareSuffix(StringRef const& other, int prefixLen) const {
+		//pre: prefixLen <= size() && prefixLen <= other.size()
+		size_t minSuffixSize = std::min(size(), other.size()) - prefixLen;
+		UNSTOPPABLE_ASSERT( minSuffixSize >= 0 );
+		if (minSuffixSize != 0) {
+			int c = memcmp(begin() + prefixLen, other.begin() + prefixLen, minSuffixSize);
 			if (c != 0) return c;
 		}
 		return ::compare(size(), other.size());

--- a/flow/Arena.h
+++ b/flow/Arena.h
@@ -510,13 +510,17 @@ public:
 	int expectedSize() const { return size(); }
 
 	int compare(StringRef const& other) const {
-		return compareSuffix(other, 0);
+		size_t minSize = std::min(size(), other.size());
+		if (minSize != 0) {
+			int c = memcmp(begin(), other.begin(), minSize);
+			if (c != 0) return c;
+		}
+		return ::compare(size(), other.size());
 	}
 
 	int compareSuffix(StringRef const& other, int prefixLen) const {
 		//pre: prefixLen <= size() && prefixLen <= other.size()
 		size_t minSuffixSize = std::min(size(), other.size()) - prefixLen;
-		UNSTOPPABLE_ASSERT( minSuffixSize >= 0 );
 		if (minSuffixSize != 0) {
 			int c = memcmp(begin() + prefixLen, other.begin() + prefixLen, minSuffixSize);
 			if (c != 0) return c;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -75,6 +75,7 @@ if(WITH_PYTHON)
   add_fdb_test(TEST_FILES RedwoodPerfSet.txt IGNORE)
   add_fdb_test(TEST_FILES RedwoodPerfPrefixCompression.txt IGNORE)
   add_fdb_test(TEST_FILES RedwoodPerfSequentialInsert.txt IGNORE)
+  add_fdb_test(TEST_FILES RedwoodPerfRandomRangeScans.txt IGNORE)
   add_fdb_test(TEST_FILES RocksDBTest.txt IGNORE)
   add_fdb_test(TEST_FILES SampleNoSimAttrition.txt IGNORE)
   if (NOT USE_UBSAN) # TODO re-enable in UBSAN after https://github.com/apple/foundationdb/issues/2410 is resolved

--- a/tests/RedwoodPerfRandomRangeScans.txt
+++ b/tests/RedwoodPerfRandomRangeScans.txt
@@ -1,0 +1,6 @@
+testTitle=UnitTests
+testName=UnitTests
+startDelay=0
+useDB=false
+maxTestCases=0
+testsMatching=!/redwood/performance/randomRangeScans


### PR DESCRIPTION
This PR is resolves #4261

Changes in this PR:

- Adding compareSuffix function to StringRef
- Using compareSuffix instead of compare in RedwoodRecordRef's compare and the query_range bounds check

## General guideline:

- If this PR is ready to be merged (and all checkboxes below are either ticked or not applicable), make this a regular PR
- If this PR still needs work, please make this a draft PR
  - If you wish to get feedback/code-review, please add the label RFC to this PR

Please verify that all things listed below were considered and check them. If an item doesn't apply to this type of PR (for example a documentation change doesn't need to be performance tested), you should make a ~~strikethrough~~ (markdown syntax: `~~strikethrough~~`). More infos on the guidlines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

### Style
- [ ] All variable and function names make sense.
- [ ] The code is properly formatted (consider running `git clang-format`).

### Performance
- [ ] All CPU-hot paths are well optimized.
- [ ] The proper containers are used (for example `std::vector` vs `VectorRef`).
- [ ] There are no new known `SlowTask` traces.

### Testing
- [ ] The code was sufficiently tested in simulation.
- [ ] If there are new parameters or knobs, different values are tested in simulation.
- [ ] `ASSERT`, `ASSERT_WE_THINK`, and `TEST` macros are added in appropriate places.
- [ ] Unit tests were added for new algorithms and data structure that make sense to unit-test
- [ ] If this is a bugfix: there is a test that can easily reproduce the bug.
