### PR TITLE
cleanup Dockerfile.c7.layered, add distcc

### DIFF
--- a/build/Dockerfile.c7.layered
+++ b/build/Dockerfile.c7.layered
@@ -65,6 +65,7 @@ RUN source /opt/rh/devtoolset-8/enable && \
     cd build && \
     cmake \
         -DCMAKE_BUILD_TYPE=Release \
+        -G Ninja \
         -DLLVM_INCLUDE_EXAMPLES=OFF \
         -DLLVM_INCLUDE_TESTS=OFF \
         ../llvm/llvm && \

--- a/build/Dockerfile.c7.layered
+++ b/build/Dockerfile.c7.layered
@@ -3,8 +3,7 @@ FROM centos:7
 WORKDIR /tmp
 
 RUN rpmkeys --import "http://pool.sks-keyservers.net/pks/lookup?op=get&search=0x3fa7e0328081bff6a14da29aa6a19b38d3d831ef" && \
-    curl -Ls https://download.mono-project.com/repo/centos7-stable.repo -o /etc/yum.repos.d/mono-centos7-stable.repo
-    rm mono-project.com.rpmkey.pgp && \
+    curl -Ls https://download.mono-project.com/repo/centos7-stable.repo -o /etc/yum.repos.d/mono-centos7-stable.repo && \
     yum repolist && \
     yum install -y \
         centos-release-scl \
@@ -106,11 +105,29 @@ RUN curl -Ls https://dl.bintray.com/boostorg/release/1.67.0/source/boost_1_67_0.
     rm -rf /tmp/*
 
 # install boost 1.72 to /opt
-RUN curl -Ls https://dl.bintray.com/boostorg/release/1.72.0/source/boost_1_72_0.tar.bz2 -o boost_1_72_0.tar.bz2 && \
+RUN source /opt/rh/devtoolset-8/enable && \
+    curl -Ls https://dl.bintray.com/boostorg/release/1.72.0/source/boost_1_72_0.tar.bz2 -o boost_1_72_0.tar.bz2 && \
     echo "59c9b274bc451cf91a9ba1dd2c7fdcaf5d60b1b3aa83f2c9fa143417cc660722  boost_1_72_0.tar.bz2" > boost-sha-72.txt && \
     sha256sum -c boost-sha-72.txt && \
     tar --no-same-owner --directory /opt -xjf boost_1_72_0.tar.bz2 && \
+    cd /opt/boost_1_72_0 &&\
+    ./bootstrap.sh --with-libraries=context &&\
+    ./b2 link=static cxxflags=-std=c++14 --prefix=/opt/boost_1_72_0 install &&\
     rm -rf /opt/boost_1_72_0/libs && \
+    rm -rf /tmp/*
+
+# jemalloc (needed for FDB after 6.3)
+RUN source /opt/rh/devtoolset-8/enable && \
+    curl -Ls https://github.com/jemalloc/jemalloc/releases/download/5.2.1/jemalloc-5.2.1.tar.bz2 -o jemalloc-5.2.1.tar.bz2 && \
+    echo "34330e5ce276099e2e8950d9335db5a875689a4c6a56751ef3b1d8c537f887f6  jemalloc-5.2.1.tar.bz2" > jemalloc-sha.txt && \
+    sha256sum -c jemalloc-sha.txt && \
+    mkdir jemalloc && \
+    tar --strip-components 1 --no-same-owner --no-same-permissions --directory jemalloc -xjf jemalloc-5.2.1.tar.bz2 && \
+    cd jemalloc && \
+    ./configure --enable-static --disable-cxx && \
+    make && \
+    make install && \
+    cd .. && \
     rm -rf /tmp/*
 
 # Install CCACHE

--- a/build/Dockerfile.c7.layered
+++ b/build/Dockerfile.c7.layered
@@ -1,81 +1,158 @@
 FROM centos:7
 
-RUN yum install -y centos-release-scl scl-utils
-RUN rpmkeys --import "http://pool.sks-keyservers.net/pks/lookup?op=get&search=0x3fa7e0328081bff6a14da29aa6a19b38d3d831ef"
-RUN	curl https://download.mono-project.com/repo/centos7-stable.repo | tee /etc/yum.repos.d/mono-centos7-stable.repo
-RUN yum install -y curl rpm-build wget git unzip devtoolset-8 devtoolset-8-libubsan-devel devtoolset-8-valgrind-devel \
-	rh-ruby26 go-toolset-7 rh-git218 rh-python36-devel java-11-openjdk-devel.x86_64 mono-devel dos2unix dpkg rh-python36 \ 
-	lz4 lz4-devel lz4-static
+WORKDIR /tmp
+
+RUN rpmkeys --import "http://pool.sks-keyservers.net/pks/lookup?op=get&search=0x3fa7e0328081bff6a14da29aa6a19b38d3d831ef" && \
+    curl -Ls https://download.mono-project.com/repo/centos7-stable.repo -o /etc/yum.repos.d/mono-centos7-stable.repo
+    rm mono-project.com.rpmkey.pgp && \
+    yum repolist && \
+    yum install -y \
+        centos-release-scl \
+        scl-utils && \
+    yum install -y \
+        autoconf \
+        automake \
+        binutils-devel \
+        curl \
+        devtoolset-8 \
+        devtoolset-8-libubsan-devel \
+        devtoolset-8-valgrind-devel \
+        dos2unix \
+        dpkg \
+        git \
+        go-toolset-7 \
+        java-11-openjdk-devel.x86_64 \
+        lz4 \
+        lz4-devel \
+        lz4-static \
+        mono-devel \
+        rh-git218 \
+        rh-python36 \
+        rh-python36-devel \
+        rh-ruby26 \
+        rpm-build \
+        unzip \
+        wget && \
+    yum clean all && \
+    rm -rf /var/cache/yum
 
 # install Ninja
-RUN cd /tmp && curl -L https://github.com/ninja-build/ninja/archive/v1.9.0.zip -o ninja.zip &&\
-    unzip ninja.zip && cd ninja-1.9.0 && scl enable devtoolset-8 -- ./configure.py --bootstrap && cp ninja /usr/bin &&\
-    cd .. && rm -rf ninja-1.9.0 ninja.zip
+RUN source /opt/rh/devtoolset-8/enable && \
+    curl -Ls https://github.com/ninja-build/ninja/archive/v1.9.0.zip -o ninja.zip && \
+    unzip ninja.zip && \
+    cd ninja-1.9.0 && \
+    ./configure.py --bootstrap && \
+    cp ninja /usr/bin && \
+    cd .. && \
+    rm -rf /tmp/*
 
 # install cmake
-RUN curl -L https://github.com/Kitware/CMake/releases/download/v3.13.4/cmake-3.13.4-Linux-x86_64.tar.gz -o /tmp/cmake.tar.gz &&\
-    echo "563a39e0a7c7368f81bfa1c3aff8b590a0617cdfe51177ddc808f66cc0866c76  /tmp/cmake.tar.gz" > /tmp/cmake-sha.txt &&\
-    sha256sum -c /tmp/cmake-sha.txt &&\
-    cd /tmp && tar xf cmake.tar.gz &&\
-    cp -r cmake-3.13.4-Linux-x86_64/* /usr/local/ &&\
-    rm -rf cmake.tar.gz cmake-3.13.4-Linux-x86_64 cmake-sha.txt
+RUN curl -Ls https://github.com/Kitware/CMake/releases/download/v3.13.4/cmake-3.13.4-Linux-x86_64.tar.gz -o cmake.tar.gz && \
+    echo "563a39e0a7c7368f81bfa1c3aff8b590a0617cdfe51177ddc808f66cc0866c76  cmake.tar.gz" > cmake-sha.txt && \
+    sha256sum -c cmake-sha.txt && \
+    mkdir cmake && \
+    tar --strip-components 1 --no-same-owner --directory cmake -xf cmake.tar.gz && \
+    cp -r cmake/* /usr/local/ && \
+    rm -rf /tmp/*
 
 # install LLVM
-RUN curl -L https://github.com/llvm/llvm-project/releases/download/llvmorg-11.0.0/llvm-project-11.0.0.tar.xz > /tmp/llvm.tar.xz
-RUN cd tmp &&\
-	echo "b7b639fc675fa1c86dd6d0bc32267be9eb34451748d2efd03f674b773000e92b  llvm.tar.xz" > llvm-sha.txt &&\
-	sha256sum -c llvm-sha.txt
-RUN cd /tmp && tar xf llvm.tar.xz --no-same-owner
-RUN mkdir /tmp/build && cd /tmp/build &&\
-	scl enable devtoolset-8 -- cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DLLVM_INCLUDE_EXAMPLES=OFF -DLLVM_INCLUDE_TESTS=OFF \
-	-DLLVM_ENABLE_PROJECTS="clang;clang-tools-extra;compiler-rt;libcxx;libcxxabi;libunwind;lld;lldb"\
-	-DLLVM_STATIC_LINK_CXX_STDLIB=ON ../llvm-project-11.0.0/llvm
-RUN cd /tmp/build && cmake --build .
-RUN cd /tmp/build && cmake --build . --target install
-RUN rm -rf /tmp/*
+RUN source /opt/rh/devtoolset-8/enable && \
+    curl -Ls https://github.com/llvm/llvm-project/releases/download/llvmorg-11.0.0/llvm-project-11.0.0.tar.xz -o llvm.tar.xz && \
+    echo "b7b639fc675fa1c86dd6d0bc32267be9eb34451748d2efd03f674b773000e92b  llvm.tar.xz" > llvm-sha.txt && \
+    sha256sum -c llvm-sha.txt && \
+    mkdir llvm && \
+    tar --strip-components 1 --no-same-owner --directory llvm -xf llvm.tar.xz && \
+    mkdir build && \
+    cd build && \
+    cmake \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DLLVM_INCLUDE_EXAMPLES=OFF \
+        -DLLVM_INCLUDE_TESTS=OFF \
+        ../llvm/llvm && \
+    cmake --build . && \
+    cmake --build . --target install && \
+    cd .. && \
+    rm -rf /tmp/*
 
 # install openssl
-RUN cd /tmp && curl -L https://www.openssl.org/source/openssl-1.1.1h.tar.gz -o openssl.tar.gz &&\
-    echo "5c9ca8774bd7b03e5784f26ae9e9e6d749c9da2438545077e6b3d755a06595d9  openssl.tar.gz" > openssl-sha.txt &&\
-    sha256sum -c openssl-sha.txt && tar -xzf openssl.tar.gz &&\
-    cd openssl-1.1.1h && scl enable devtoolset-8 -- ./config CFLAGS="-fPIC -O3" --prefix=/usr/local &&\
-    scl enable devtoolset-8 -- make -j`nproc` && scl enable devtoolset-8 -- make -j1 install &&\
-    ln -sv /usr/local/lib64/lib*.so.1.1 /usr/lib64/ &&\
-    cd /tmp/ && rm -rf /tmp/openssl-1.1.1h /tmp/openssl.tar.gz
+RUN source /opt/rh/devtoolset-8/enable && \
+    curl -Ls https://www.openssl.org/source/openssl-1.1.1h.tar.gz -o openssl.tar.gz && \
+    echo "5c9ca8774bd7b03e5784f26ae9e9e6d749c9da2438545077e6b3d755a06595d9  openssl.tar.gz" > openssl-sha.txt && \
+    sha256sum -c openssl-sha.txt && \
+    mkdir openssl && \
+    tar --strip-components 1 --no-same-owner --directory openssl -xf openssl.tar.gz && \
+    cd openssl && \
+    ./config CFLAGS="-fPIC -O3" --prefix=/usr/local && \
+    make -j`nproc` && \
+    make -j1 install && \
+    ln -sv /usr/local/lib64/lib*.so.1.1 /usr/lib64/ && \
+    cd .. && \
+    rm -rf /tmp/*
 
 # install RocksDB
-RUN cd /opt/ && curl -L https://github.com/facebook/rocksdb/archive/v6.10.1.tar.gz -o rocksdb.tar.gz &&\
-    echo "d573d2f15cdda883714f7e0bc87b814a8d4a53a82edde558f08f940e905541ee  rocksdb.tar.gz" > rocksdb-sha.txt &&\
-    sha256sum -c rocksdb-sha.txt && tar xf rocksdb.tar.gz && rm -rf rocksdb.tar.gz rocksdb-sha.txt
+RUN curl -Ls https://github.com/facebook/rocksdb/archive/v6.10.1.tar.gz -o rocksdb.tar.gz && \
+    echo "d573d2f15cdda883714f7e0bc87b814a8d4a53a82edde558f08f940e905541ee  rocksdb.tar.gz" > rocksdb-sha.txt && \
+    sha256sum -c rocksdb-sha.txt && \
+    tar --directory /opt -xf rocksdb.tar.gz && \
+    rm -rf /tmp/*
 
 # install Boost
-# wget of bintray without forcing UTF-8 encoding results in 403 Forbidden
-RUN cd /opt/ &&\
-    curl -L https://dl.bintray.com/boostorg/release/1.67.0/source/boost_1_67_0.tar.bz2 -o boost_1_67_0.tar.bz2 &&\
-    echo "2684c972994ee57fc5632e03bf044746f6eb45d4920c343937a465fd67a5adba  boost_1_67_0.tar.bz2" > boost-sha-67.txt &&\
-    sha256sum -c boost-sha-67.txt &&\
-    tar -xjf boost_1_67_0.tar.bz2 &&\
-    rm -rf boost_1_67_0.tar.bz2 boost-sha-67.txt boost_1_67_0/libs &&\
-    curl -L https://dl.bintray.com/boostorg/release/1.72.0/source/boost_1_72_0.tar.bz2 -o boost_1_72_0.tar.bz2 &&\
-    echo "59c9b274bc451cf91a9ba1dd2c7fdcaf5d60b1b3aa83f2c9fa143417cc660722  boost_1_72_0.tar.bz2" > boost-sha-72.txt &&\
-    sha256sum -c boost-sha-72.txt &&\
-    tar -xjf boost_1_72_0.tar.bz2 &&\
-    rm -rf boost_1_72_0.tar.bz2 boost-sha-72.txt boost_1_72_0/libs
+# install boost 1.67 to /opt
+RUN curl -Ls https://dl.bintray.com/boostorg/release/1.67.0/source/boost_1_67_0.tar.bz2 -o boost_1_67_0.tar.bz2 && \
+    echo "2684c972994ee57fc5632e03bf044746f6eb45d4920c343937a465fd67a5adba  boost_1_67_0.tar.bz2" > boost-sha-67.txt && \
+    sha256sum -c boost-sha-67.txt && \
+    tar --no-same-owner --directory /opt -xjf boost_1_67_0.tar.bz2 && \
+    rm -rf /opt/boost_1_67_0/libs && \
+    rm -rf /tmp/*
 
+# install boost 1.72 to /opt
+RUN curl -Ls https://dl.bintray.com/boostorg/release/1.72.0/source/boost_1_72_0.tar.bz2 -o boost_1_72_0.tar.bz2 && \
+    echo "59c9b274bc451cf91a9ba1dd2c7fdcaf5d60b1b3aa83f2c9fa143417cc660722  boost_1_72_0.tar.bz2" > boost-sha-72.txt && \
+    sha256sum -c boost-sha-72.txt && \
+    tar --no-same-owner --directory /opt -xjf boost_1_72_0.tar.bz2 && \
+    rm -rf /opt/boost_1_72_0/libs && \
+    rm -rf /tmp/*
 
 # Install CCACHE
-RUN cd /tmp && curl -L https://github.com/ccache/ccache/releases/download/v4.0/ccache-4.0.tar.gz > ccache.tar.gz &&\
-    echo "ac97af86679028ebc8555c99318352588ff50f515fc3a7f8ed21a8ad367e3d45  ccache.tar.gz" > ccache-sha256.txt &&\
-    sha256sum -c ccache-sha256.txt &&\
-    tar xf ccache.tar.gz && rm -rf build && mkdir build && cd build && cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DZSTD_FROM_INTERNET=ON ../ccache-4.0 &&\
-    cmake --build . --target install && cd / && rm -rf tmp/build && rm -rf tmp/ccache-4.0
+RUN source /opt/rh/devtoolset-8/enable && \
+    curl -Ls https://github.com/ccache/ccache/releases/download/v4.0/ccache-4.0.tar.gz -o ccache.tar.gz && \
+    echo "ac97af86679028ebc8555c99318352588ff50f515fc3a7f8ed21a8ad367e3d45  ccache.tar.gz" > ccache-sha256.txt && \
+    sha256sum -c ccache-sha256.txt && \
+    mkdir ccache &&\
+    tar --strip-components 1 --no-same-owner --directory ccache -xf ccache.tar.gz && \
+    mkdir build && \
+    cd build && \
+    cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DZSTD_FROM_INTERNET=ON ../ccache && \
+    cmake --build . --target install && \
+    cd .. && \
+    rm -rf /tmp/*
 
 # Install toml11
-RUN cd /tmp && curl -L https://github.com/ToruNiina/toml11/archive/v3.4.0.tar.gz > toml.tar.gz &&\
-    echo "bc6d733efd9216af8c119d8ac64a805578c79cc82b813e4d1d880ca128bd154d  toml.tar.gz" > toml-sha256.txt &&\
-    sha256sum -c toml-sha256.txt &&\
-    tar xf toml.tar.gz && rm -rf build && mkdir build && cd build && cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -Dtoml11_BUILD_TEST=OFF ../toml11-3.4.0 &&\
-    cmake --build . --target install && cd / && rm -rf tmp/build && rm -rf tmp/toml11-3.4.0
+RUN source /opt/rh/devtoolset-8/enable && \
+    curl -Ls https://github.com/ToruNiina/toml11/archive/v3.4.0.tar.gz -o toml.tar.gz && \
+    echo "bc6d733efd9216af8c119d8ac64a805578c79cc82b813e4d1d880ca128bd154d  toml.tar.gz" > toml-sha256.txt && \
+    sha256sum -c toml-sha256.txt && \
+    mkdir toml && \
+    tar --strip-components 1 --no-same-owner --directory toml -xf toml.tar.gz && \
+    mkdir build && \
+    cd build && \
+    cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -Dtoml11_BUILD_TEST=OFF ../toml && \
+    cmake --build . --target install && \
+    cd .. && \
+    rm -rf /tmp/*
 
-# do some cleanup
-RUN rm -rf /tmp/* && yum clean all && rm -rf /var/cache/yum
+# build/install distcc
+RUN source /opt/rh/devtoolset-8/enable && \
+    source /opt/rh/rh-python36/enable && \
+    curl -Ls https://github.com/distcc/distcc/archive/v3.3.5.tar.gz -o distcc.tar.gz && \
+    echo "13a4b3ce49dfc853a3de550f6ccac583413946b3a2fa778ddf503a9edc8059b0  distcc.tar.gz" > distcc-sha256.txt && \
+    sha256sum -c distcc-sha256.txt && \
+    mkdir distcc && \
+    tar --strip-components 1 --no-same-owner --directory distcc -xf distcc.tar.gz && \
+    cd distcc && \
+    ./autogen.sh && \
+    ./configure && \
+    make && \
+    make install && \
+    cd .. && \
+    rm -rf /tmp/*


### PR DESCRIPTION
This PR is resolves #...

Changes in this PR:
Add distcc to c7.layered Dockerfile
cleanup Dockerfile for general readability
Implement pattern where each RUN directive cleans up after itself
source devtoolset-8 where needed, and avoid running scl enable before commands
change LLVM compile so it works (Ninja is failing)

This will be the base image for other centos7 containerized work. 

## General guideline:

- If this PR is ready to be merged (and all checkboxes below are either ticked or not applicable), make this a regular PR
- If this PR still needs work, please make this a draft PR
  - If you wish to get feedback/code-review, please add the label RFC to this PR

Please verify that all things listed below were considered and check them. If an item doesn't apply to this type of PR (for example a documentation change doesn't need to be performance tested), you should make a ~~strikethrough~~ (markdown syntax: `~~strikethrough~~`). More infos on the guidlines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

### Style
~~- [ ] All variable and function names make sense.~~
- [✅] The code is properly formatted (consider running `git clang-format`).

### Performance
~~- [ ] All CPU-hot paths are well optimized.~~
~~- [ ] The proper containers are used (for example `std::vector` vs `VectorRef`).~~
~~- [ ] There are no new known `SlowTask` traces.~~

### Testing
~~- [ ] The code was sufficiently tested in simulation.~~
~~- [ ] If there are new parameters or knobs, different values are tested in simulation.~~
~~- [ ] `ASSERT`, `ASSERT_WE_THINK`, and `TEST` macros are added in appropriate places.~~
~~- [ ] Unit tests were added for new algorithms and data structure that make sense to unit-test~~
~~- [ ] If this is a bugfix: there is a test that can easily reproduce the bug.~~
