### PR TITLE
Fix a trace event name that has a space in it

### DIFF
--- a/fdbserver/workloads/SnapTest.actor.cpp
+++ b/fdbserver/workloads/SnapTest.actor.cpp
@@ -86,7 +86,7 @@ public: // variables
 public: // ctor & dtor
 	SnapTestWorkload(WorkloadContext const& wcx)
 	  : TestWorkload(wcx), numSnaps(0), maxSnapDelay(0.0), testID(0), snapUID() {
-		TraceEvent("SnapTestWorkload Constructor");
+		TraceEvent("SnapTestWorkloadConstructor");
 		std::string workloadName = "SnapTest";
 		maxRetryCntToRetrieveMessage = 10;
 


### PR DESCRIPTION
Removes a space from a trace event name in the snapshot test workload.