### PR TITLE
Increase the maximum length of the error strings logged by test harness

### DIFF
--- a/contrib/TestHarness/Program.cs.cmake
+++ b/contrib/TestHarness/Program.cs.cmake
@@ -609,12 +609,14 @@ namespace SummarizeTest
             public List<string> Errors { get; set; }
             int maxErrorLength;
             int maxErrors;
+            bool errorsExceeded;
 
-            public ErrorOutputListener(int maxErrorLength = 100, int maxErrors = 10)
+            public ErrorOutputListener(int maxErrorLength = 1000, int maxErrors = 10)
             {
                 Errors = new List<string>();
                 this.maxErrorLength = maxErrorLength;
                 this.maxErrors = maxErrors;
+                this.errorsExceeded = false;
             }
 
             public bool hasError = false;
@@ -623,8 +625,18 @@ namespace SummarizeTest
                 if(!String.IsNullOrEmpty(errLine.Data))
                 {
                     hasError = true;
-                    if(Errors.Count < maxErrors)
-                        Errors.Add(errLine.Data.Substring(0, Math.Min(maxErrorLength, errLine.Data.Length)));
+                    if(Errors.Count < maxErrors) {
+                        if(errLine.Data.Length > maxErrorLength) {
+                            Errors.Add(errLine.Data.Substring(0, maxErrorLength) + "...");
+                        }
+                        else {
+                            Errors.Add(errLine.Data);
+                        }
+                    }
+                    else if(!errorsExceeded) {
+                        Errors.Add("TestHarness error limit exceeded");
+                        errorsExceeded = true;
+                    }
                 }
             }
         }


### PR DESCRIPTION
TestHarness has two mechanisms that it uses to limit the amount of stderr output logged. One is that the sum total of all error messages be below 1000 bytes, the second is that each message be limited to 100 bytes and that there are no more than 10 messages.

This latter mechanism doesn't need to be so restrictive, and in fact 100 bytes is too few to capture some errors that we're seeing on tests right now. Also, the second mechanism silently truncates errors rather than providing any indication of the truncation.

This change increases the limit of each message to 1000 bytes and tries to make it more obvious when truncation is happening.