### PR TITLE
Fix bug in simulated coordinator selection

### DIFF
--- a/fdbclient/ManagementAPI.actor.cpp
+++ b/fdbclient/ManagementAPI.actor.cpp
@@ -2020,9 +2020,11 @@ TEST_CASE("/ManagementAPI/AutoQuorumChange/checkLocality") {
 		data.locality.set(LiteralStringRef("machineid"), StringRef(machineId));
 		data.address.ip = IPAddress(i);
 
-		g_simulator.newProcess(format("TestProcess%d", i).c_str(), data.address.ip, data.address.port, false, 1,
-		                       data.locality, ProcessClass(ProcessClass::CoordinatorClass, ProcessClass::CommandLineSource),
-		                       "", "");
+		if(g_network->isSimulated()) {
+			g_simulator.newProcess(format("TestProcess%d", i).c_str(), data.address.ip, data.address.port, false, 1,
+			                       data.locality, ProcessClass(ProcessClass::CoordinatorClass, ProcessClass::CommandLineSource),
+			                       "", "");
+		}
 
 		workers.push_back(data);
 	}

--- a/fdbclient/ManagementAPI.actor.cpp
+++ b/fdbclient/ManagementAPI.actor.cpp
@@ -990,7 +990,7 @@ ACTOR Future<CoordinatorsResult::Type> changeQuorum( Database cx, Reference<IQuo
 			if(g_network->isSimulated()) {
 				for(int i = 0; i < (desiredCoordinators.size()/2)+1; i++) {
 					auto process = g_simulator.getProcessByAddress(desiredCoordinators[i]);
-					ASSERT(process->isReliable());
+					ASSERT(process->isReliable() || process->rebooting);
 
 					g_simulator.protectedAddresses.insert(process->addresses.address);
 					if(process->addresses.secondaryAddress.present()) {

--- a/fdbclient/ManagementAPI.actor.cpp
+++ b/fdbclient/ManagementAPI.actor.cpp
@@ -2020,6 +2020,10 @@ TEST_CASE("/ManagementAPI/AutoQuorumChange/checkLocality") {
 		data.locality.set(LiteralStringRef("machineid"), StringRef(machineId));
 		data.address.ip = IPAddress(i);
 
+		g_simulator.newProcess(format("TestProcess%d", i).c_str(), data.address.ip, data.address.port, false, 1,
+		                       data.locality, ProcessClass(ProcessClass::CoordinatorClass, ProcessClass::CommandLineSource),
+		                       "", "");
+
 		workers.push_back(data);
 	}
 


### PR DESCRIPTION
The simulator could choose an unreliable process (one that has had fault injection enabled) to be a coordinator, even though this is something it had been trying to prevent.

This bug had been previously identified and addressed in #2802, but there seems to have been a bug in that fix that still allowed unreliable processes to be chosen.

### Testing
- [x] The code was sufficiently tested in simulation.
- [x] `ASSERT`, `ASSERT_WE_THINK`, and `TEST` macros are added in appropriate places.
- [x] If this is a bugfix: there is a test that can easily reproduce the bug.
