### PR TITLE
Simulation bug fix involving process reboot and destruction/recreation of KVSQLite

### DIFF
--- a/fdbrpc/AsyncFileCached.actor.h
+++ b/fdbrpc/AsyncFileCached.actor.h
@@ -230,8 +230,6 @@ public:
 		return filename;
 	}
 
-	std::vector<AFCPage*> const& getFlushable() { return flushable; }
-
 	void setRateControl(Reference<IRateControl> const& rc) override { rateControl = rc; }
 
 	Reference<IRateControl> const& getRateControl() override { return rateControl; }
@@ -252,8 +250,8 @@ public:
 			}
 
 			auto f = quiesce();
-			//TraceEvent("AsyncFileCachedDel").detail("Filename", filename)
-			//	.detail("Refcount", debugGetReferenceCount()).detail("CanDie", f.isReady()).backtrace();
+			TraceEvent("AsyncFileCachedDel").detail("Filename", filename)
+				.detail("Refcount", debugGetReferenceCount()).detail("CanDie", f.isReady()).backtrace();
 			if (f.isReady())
 				delete this;
 			else
@@ -303,7 +301,7 @@ private:
 	AsyncFileCached(Reference<IAsyncFile> uncached, const std::string& filename, int64_t length,
 	                Reference<EvictablePageCache> pageCache)
 	  : uncached(uncached), filename(filename), length(length), prevLength(length), pageCache(pageCache),
-	    currentTruncate(Void()), currentTruncateSize(0), rateControl(nullptr) {
+	    currentTruncate(Void()), currentTruncateSize(0) {
 		if( !g_network->isSimulated() ) {
 			countFileCacheWrites.init(LiteralStringRef("AsyncFile.CountFileCacheWrites"), filename);
 			countFileCacheReads.init(LiteralStringRef("AsyncFile.CountFileCacheReads"), filename);

--- a/fdbserver/KeyValueStoreSQLite.actor.cpp
+++ b/fdbserver/KeyValueStoreSQLite.actor.cpp
@@ -1897,6 +1897,7 @@ private:
 			dbFile->setRateControl({});
 			rc->wakeWaiters();
 		}
+		dbFile.clear();
 
 		if(walFile && walFile->getRateControl()) {
 			TraceEvent(SevDebug, "KeyValueStoreSQLiteShutdownRateControl").detail("Filename", walFile->getFilename());
@@ -1904,6 +1905,7 @@ private:
 			walFile->setRateControl({});
 			rc->wakeWaiters();
 		}
+		walFile.clear();
 	}
 
 	ACTOR static Future<Void> stopOnError( KeyValueStoreSQLite* self ) {


### PR DESCRIPTION
Changes in this PR:

- In simulation, KVStoreSQLite can outlive its process during a simulated reboot so its file references must be cleared explicitly during shutdown instead of implicitly during destruction.
- Code cleanup in AFCached, removing unnecessary things.

### Style
- [x] All variable and function names make sense.
- [x] The code is properly formatted (consider running `git clang-format`).

### Performance
- [ ] ~~All CPU-hot paths are well optimized.~~
- [ ] ~~The proper containers are used (for example `std::vector` vs `VectorRef`).~~
- [ ] ~~There are no new known `SlowTask` traces.~~

### Testing
- [ ] The code was sufficiently tested in simulation.
- [ ] ~~If there are new parameters or knobs, different values are tested in simulation.~~
- [ ] ~~`ASSERT`, `ASSERT_WE_THINK`, and `TEST` macros are added in appropriate places.~~
- [ ] ~~Unit tests were added for new algorithms and data structure that make sense to unit-test~~
- [ ] ~~If this is a bugfix: there is a test that can easily reproduce the bug.~~
