### PR TITLE
Add txnRejectedForQueuedTooLong in ProxyStats

### DIFF
--- a/documentation/sphinx/source/mr-status-json-schemas.rst.inc
+++ b/documentation/sphinx/source/mr-status-json-schemas.rst.inc
@@ -557,6 +557,11 @@
                "counter":0,
                "roughness":0.0
             },
+            "rejected_for_queued_too_long":{
+               "hz":0.0,
+               "counter":0,
+               "roughness":0.0
+            },
             "committed":{
                "hz":0.0,
                "counter":0,

--- a/documentation/sphinx/source/release-notes/release-notes-700.rst
+++ b/documentation/sphinx/source/release-notes/release-notes-700.rst
@@ -29,7 +29,7 @@ Fixes
 
 Status
 ------
-* Added transactions.rejected_for_queued_too_long to bookkeeping the number of transactions rejected by commit proxy because its queuing time exceeds MVCC window. `(PR #4288) <https://github.com/apple/foundationdb/pull/4288>`_
+* Added transactions.rejected_for_queued_too_long for bookkeeping the number of transactions rejected by commit proxy because its queuing time exceeds MVCC window. `(PR #4288) <https://github.com/apple/foundationdb/pull/4288>`_
 
 
 Bindings

--- a/documentation/sphinx/source/release-notes/release-notes-700.rst
+++ b/documentation/sphinx/source/release-notes/release-notes-700.rst
@@ -29,7 +29,7 @@ Fixes
 
 Status
 ------
-
+* Added transactions.rejected_for_queued_too_long to bookkeeping the number of transactions rejected by commit proxy because its queuing time exceeds MVCC window. `(PR #4288) <https://github.com/apple/foundationdb/pull/4288>`_
 
 
 Bindings

--- a/fdbclient/Schemas.cpp
+++ b/fdbclient/Schemas.cpp
@@ -601,6 +601,11 @@ const KeyRef JSONSchemas::statusSchema = LiteralStringRef(R"statusSchema(
                "counter":0,
                "roughness":0.0
             },
+            "rejected_for_queued_too_long":{
+               "hz":0.0,
+               "counter":0,
+               "roughness":0.0
+            },
             "committed":{
                "hz":0.0,
                "counter":0,

--- a/fdbserver/CommitProxyServer.actor.cpp
+++ b/fdbserver/CommitProxyServer.actor.cpp
@@ -587,7 +587,7 @@ ACTOR Future<Void> preresolutionProcessing(CommitBatchContext* self) {
 		}
 		++pProxyCommitData->stats.commitBatchOut;
 		pProxyCommitData->stats.txnCommitOut += trs.size();
-		pProxyCommitData->stats.txnConflicts += trs.size();
+		pProxyCommitData->stats.txnRejectedForQueuedTooLong += trs.size();
 		self->rejected = true;
 		return Void();
 	}

--- a/fdbserver/ProxyCommitData.actor.h
+++ b/fdbserver/ProxyCommitData.actor.h
@@ -52,6 +52,7 @@ struct ProxyStats {
 	Counter txnCommitIn, txnCommitVersionAssigned, txnCommitResolving, txnCommitResolved, txnCommitOut,
 	    txnCommitOutSuccess, txnCommitErrors;
 	Counter txnConflicts;
+	Counter txnRejectedForQueuedTooLong;
 	Counter commitBatchIn, commitBatchOut;
 	Counter mutationBytes;
 	Counter mutations;
@@ -82,15 +83,16 @@ struct ProxyStats {
 
 	explicit ProxyStats(UID id, Version* pVersion, NotifiedVersion* pCommittedVersion,
 	                    int64_t* commitBatchesMemBytesCountPtr)
-	  : cc("ProxyStats", id.toString()), maxComputeNS(0), minComputeNS(1e12),
-	    txnCommitIn("TxnCommitIn", cc), txnCommitVersionAssigned("TxnCommitVersionAssigned", cc),
-	    txnCommitResolving("TxnCommitResolving", cc), txnCommitResolved("TxnCommitResolved", cc),
-	    txnCommitOut("TxnCommitOut", cc), txnCommitOutSuccess("TxnCommitOutSuccess", cc),
-	    txnCommitErrors("TxnCommitErrors", cc), txnConflicts("TxnConflicts", cc), commitBatchIn("CommitBatchIn", cc),
-	    commitBatchOut("CommitBatchOut", cc), mutationBytes("MutationBytes", cc), mutations("Mutations", cc),
-	    conflictRanges("ConflictRanges", cc), keyServerLocationIn("KeyServerLocationIn", cc),
-	    keyServerLocationOut("KeyServerLocationOut", cc), keyServerLocationErrors("KeyServerLocationErrors", cc),
-	    lastCommitVersionAssigned(0), txnExpensiveClearCostEstCount("ExpensiveClearCostEstCount", cc),
+	  : cc("ProxyStats", id.toString()), maxComputeNS(0), minComputeNS(1e12), txnCommitIn("TxnCommitIn", cc),
+	    txnCommitVersionAssigned("TxnCommitVersionAssigned", cc), txnCommitResolving("TxnCommitResolving", cc),
+	    txnCommitResolved("TxnCommitResolved", cc), txnCommitOut("TxnCommitOut", cc),
+	    txnCommitOutSuccess("TxnCommitOutSuccess", cc), txnCommitErrors("TxnCommitErrors", cc),
+	    txnConflicts("TxnConflicts", cc), commitBatchIn("CommitBatchIn", cc),
+	    txnRejectedForQueuedTooLong("TxnRejectedForQueuedTooLong", cc), commitBatchOut("CommitBatchOut", cc),
+	    mutationBytes("MutationBytes", cc), mutations("Mutations", cc), conflictRanges("ConflictRanges", cc),
+	    keyServerLocationIn("KeyServerLocationIn", cc), keyServerLocationOut("KeyServerLocationOut", cc),
+	    keyServerLocationErrors("KeyServerLocationErrors", cc), lastCommitVersionAssigned(0),
+	    txnExpensiveClearCostEstCount("ExpensiveClearCostEstCount", cc),
 	    commitLatencySample("CommitLatencyMetrics", id, SERVER_KNOBS->LATENCY_METRICS_LOGGING_INTERVAL,
 	                        SERVER_KNOBS->LATENCY_SAMPLE_SIZE),
 	    commitLatencyBands("CommitLatencyMetrics", id, SERVER_KNOBS->STORAGE_LOGGING_DELAY) {

--- a/fdbserver/Status.actor.cpp
+++ b/fdbserver/Status.actor.cpp
@@ -1818,6 +1818,7 @@ ACTOR static Future<JsonBuilderObject> workloadStatusFetcher(Reference<AsyncVar<
 		StatusCounter mutations;
 		StatusCounter mutationBytes;
 		StatusCounter txnConflicts;
+		StatusCounter txnRejectedForQueuedTooLong;
 		StatusCounter txnCommitOutSuccess;
 		StatusCounter txnKeyLocationOut;
 		StatusCounter txnMemoryErrors;
@@ -1834,6 +1835,7 @@ ACTOR static Future<JsonBuilderObject> workloadStatusFetcher(Reference<AsyncVar<
 			mutations.updateValues(StatusCounter(cps.getValue("Mutations")));
 			mutationBytes.updateValues(StatusCounter(cps.getValue("MutationBytes")));
 			txnConflicts.updateValues(StatusCounter(cps.getValue("TxnConflicts")));
+			txnRejectedForQueuedTooLong.updateValues(StatusCounter(cps.getValue("TxnRejectedForQueuedTooLong")));
 			txnCommitOutSuccess.updateValues(StatusCounter(cps.getValue("TxnCommitOutSuccess")));
 			txnKeyLocationOut.updateValues(StatusCounter(cps.getValue("KeyServerLocationOut")));
 			txnMemoryErrors.updateValues(StatusCounter(cps.getValue("KeyServerLocationErrors")));
@@ -1848,6 +1850,7 @@ ACTOR static Future<JsonBuilderObject> workloadStatusFetcher(Reference<AsyncVar<
 		JsonBuilderObject transactions;
 		transactions["conflicted"] = txnConflicts.getStatus();
 		transactions["started"] = txnStartOut.getStatus();
+		transactions["rejected_for_queued_too_long"] = txnRejectedForQueuedTooLong.getStatus();
 		transactions["started_immediate_priority"] = txnSystemPriorityStartOut.getStatus();
 		transactions["started_default_priority"] = txnDefaultPriorityStartOut.getStatus();
 		transactions["started_batch_priority"] = txnBatchPriorityStartOut.getStatus();


### PR DESCRIPTION
This PR is a follow up of https://github.com/apple/foundationdb/pull/4113

Changes in this PR:

- A transaction batch will be rejected immediately if it has been queued longer than the MVCC window, this commit counts this kind of rejection separately from `txnConflicts` 

- also added this field in `Status#workloadStatusFetcher` and changed schema accordingly.

### Style
- [x] All variable and function names make sense.
- [x] The code is properly formatted (consider running `git clang-format`).

### Performance
- [x] ~~All CPU-hot paths are well optimized.~~
- [x] ~~The proper containers are used (for example `std::vector` vs `VectorRef`).~~
- [x] ~~There are no new known `SlowTask` traces.~~

### Testing
- [x] The code was sufficiently tested in simulation.(4000 runs all succeeds)
- [x] ~~If there are new parameters or knobs, different values are tested in simulation.~~
- [x] ~~`ASSERT`, `ASSERT_WE_THINK`, and `TEST` macros are added in appropriate places.~~
- [x] ~~Unit tests were added for new algorithms and data structure that make sense to unit-test~~
- [x] ~~If this is a bugfix: there is a test that can easily reproduce the bug.~~
