### PR TITLE
Updated knobs to enable low priority reads when durability lag is larger than 200 seconds

### DIFF
--- a/documentation/sphinx/source/downloads.rst
+++ b/documentation/sphinx/source/downloads.rst
@@ -10,38 +10,38 @@ macOS
 
 The macOS installation package is supported on macOS 10.7+. It includes the client and (optionally) the server.
 
-* `FoundationDB-6.2.29.pkg <https://www.foundationdb.org/downloads/6.2.29/macOS/installers/FoundationDB-6.2.29.pkg>`_
+* `FoundationDB-6.2.30.pkg <https://www.foundationdb.org/downloads/6.2.30/macOS/installers/FoundationDB-6.2.30.pkg>`_
 
 Ubuntu
 ------
 
 The Ubuntu packages are supported on 64-bit Ubuntu 12.04+, but beware of the Linux kernel bug in Ubuntu 12.x.
 
-* `foundationdb-clients-6.2.29-1_amd64.deb <https://www.foundationdb.org/downloads/6.2.29/ubuntu/installers/foundationdb-clients_6.2.29-1_amd64.deb>`_
-* `foundationdb-server-6.2.29-1_amd64.deb <https://www.foundationdb.org/downloads/6.2.29/ubuntu/installers/foundationdb-server_6.2.29-1_amd64.deb>`_ (depends on the clients package)
+* `foundationdb-clients-6.2.30-1_amd64.deb <https://www.foundationdb.org/downloads/6.2.30/ubuntu/installers/foundationdb-clients_6.2.30-1_amd64.deb>`_
+* `foundationdb-server-6.2.30-1_amd64.deb <https://www.foundationdb.org/downloads/6.2.30/ubuntu/installers/foundationdb-server_6.2.30-1_amd64.deb>`_ (depends on the clients package)
 
 RHEL/CentOS EL6
 ---------------
 
 The RHEL/CentOS EL6 packages are supported on 64-bit RHEL/CentOS 6.x.
 
-* `foundationdb-clients-6.2.29-1.el6.x86_64.rpm <https://www.foundationdb.org/downloads/6.2.29/rhel6/installers/foundationdb-clients-6.2.29-1.el6.x86_64.rpm>`_
-* `foundationdb-server-6.2.29-1.el6.x86_64.rpm <https://www.foundationdb.org/downloads/6.2.29/rhel6/installers/foundationdb-server-6.2.29-1.el6.x86_64.rpm>`_ (depends on the clients package)
+* `foundationdb-clients-6.2.30-1.el6.x86_64.rpm <https://www.foundationdb.org/downloads/6.2.30/rhel6/installers/foundationdb-clients-6.2.30-1.el6.x86_64.rpm>`_
+* `foundationdb-server-6.2.30-1.el6.x86_64.rpm <https://www.foundationdb.org/downloads/6.2.30/rhel6/installers/foundationdb-server-6.2.30-1.el6.x86_64.rpm>`_ (depends on the clients package)
 
 RHEL/CentOS EL7
 ---------------
 
 The RHEL/CentOS EL7 packages are supported on 64-bit RHEL/CentOS 7.x.
 
-* `foundationdb-clients-6.2.29-1.el7.x86_64.rpm <https://www.foundationdb.org/downloads/6.2.29/rhel7/installers/foundationdb-clients-6.2.29-1.el7.x86_64.rpm>`_
-* `foundationdb-server-6.2.29-1.el7.x86_64.rpm <https://www.foundationdb.org/downloads/6.2.29/rhel7/installers/foundationdb-server-6.2.29-1.el7.x86_64.rpm>`_ (depends on the clients package)
+* `foundationdb-clients-6.2.30-1.el7.x86_64.rpm <https://www.foundationdb.org/downloads/6.2.30/rhel7/installers/foundationdb-clients-6.2.30-1.el7.x86_64.rpm>`_
+* `foundationdb-server-6.2.30-1.el7.x86_64.rpm <https://www.foundationdb.org/downloads/6.2.30/rhel7/installers/foundationdb-server-6.2.30-1.el7.x86_64.rpm>`_ (depends on the clients package)
 
 Windows
 -------
 
 The Windows installer is supported on 64-bit Windows XP and later. It includes the client and (optionally) the server.
 
-* `foundationdb-6.2.29-x64.msi <https://www.foundationdb.org/downloads/6.2.29/windows/installers/foundationdb-6.2.29-x64.msi>`_
+* `foundationdb-6.2.30-x64.msi <https://www.foundationdb.org/downloads/6.2.30/windows/installers/foundationdb-6.2.30-x64.msi>`_
 
 API Language Bindings
 =====================
@@ -58,18 +58,18 @@ On macOS and Windows, the FoundationDB Python API bindings are installed as part
 
 If you need to use the FoundationDB Python API from other Python installations or paths, download the Python package:
 
-* `foundationdb-6.2.29.tar.gz <https://www.foundationdb.org/downloads/6.2.29/bindings/python/foundationdb-6.2.29.tar.gz>`_
+* `foundationdb-6.2.30.tar.gz <https://www.foundationdb.org/downloads/6.2.30/bindings/python/foundationdb-6.2.30.tar.gz>`_
 
 Ruby 1.9.3/2.0.0+
 -----------------
 
-* `fdb-6.2.29.gem <https://www.foundationdb.org/downloads/6.2.29/bindings/ruby/fdb-6.2.29.gem>`_
+* `fdb-6.2.30.gem <https://www.foundationdb.org/downloads/6.2.30/bindings/ruby/fdb-6.2.30.gem>`_
 
 Java 8+
 -------
 
-* `fdb-java-6.2.29.jar <https://www.foundationdb.org/downloads/6.2.29/bindings/java/fdb-java-6.2.29.jar>`_
-* `fdb-java-6.2.29-javadoc.jar <https://www.foundationdb.org/downloads/6.2.29/bindings/java/fdb-java-6.2.29-javadoc.jar>`_
+* `fdb-java-6.2.30.jar <https://www.foundationdb.org/downloads/6.2.30/bindings/java/fdb-java-6.2.30.jar>`_
+* `fdb-java-6.2.30-javadoc.jar <https://www.foundationdb.org/downloads/6.2.30/bindings/java/fdb-java-6.2.30-javadoc.jar>`_
 
 Go 1.11+
 --------

--- a/documentation/sphinx/source/release-notes/release-notes-620.rst
+++ b/documentation/sphinx/source/release-notes/release-notes-620.rst
@@ -4,6 +4,16 @@
 Release Notes
 #############
 
+6.2.30
+======
+* A storage server which has fallen behind will deprioritize reads in order to catch up. This change causes some saturating workloads to experience high read latencies instead of high GRV latencies. `(PR #4218) <https://github.com/apple/foundationdb/pull/4218>`_
+* Added ``low_priority_queries`` to the ``processes.roles`` section of status to record the number of deprioritized reads on each storage server. `(PR #4218) <https://github.com/apple/foundationdb/pull/4218>`_
+* Added ``low_priority_reads`` to the ``workload.operations`` section of status to record the total number of deprioritized reads. `(PR #4218) <https://github.com/apple/foundationdb/pull/4218>`_
+* Backup to locally mounted filesystems now appends to files in large block writes, 1MB each by default. `(PR #4199) <https://github.com/apple/foundationdb/pull/4199>`_
+* Changed the default SSL implementation from OpenSSL to BoringSSL `(PR #4153) <https://github.com/apple/foundationdb/pull/4153>`_
+* SQLite now supports configurable disk write rate limiting. `(PR #4259) <https://github.com/apple/foundationdb/pull/4259>`_
+* If a disk operation takes more than two minutes, the system will treat the disk as failed. `(PR #4243) <https://github.com/apple/foundationdb/pull/4243>`_
+
 6.2.29
 ======
 * Fix invalid memory access on data distributor when snapshotting large clusters. `(PR #4076) <https://github.com/apple/foundationdb/pull/4076>`_

--- a/fdbserver/Knobs.cpp
+++ b/fdbserver/Knobs.cpp
@@ -453,11 +453,11 @@ ServerKnobs::ServerKnobs(bool randomize, ClientKnobs* clientKnobs, bool isSimula
 	init( SPRING_BYTES_STORAGE_SERVER_BATCH,                   100e6 ); if( smallStorageTarget ) SPRING_BYTES_STORAGE_SERVER_BATCH = 150e3;
 	init( STORAGE_HARD_LIMIT_BYTES,                           1500e6 ); if( smallStorageTarget ) STORAGE_HARD_LIMIT_BYTES = 4500e3;
 	init( STORAGE_DURABILITY_LAG_HARD_MAX,                    2000e6 ); if( smallStorageTarget ) STORAGE_DURABILITY_LAG_HARD_MAX = 100e6;
-	init( STORAGE_DURABILITY_LAG_SOFT_MAX,                     200e6 ); if( smallStorageTarget ) STORAGE_DURABILITY_LAG_SOFT_MAX = 10e6;
+	init( STORAGE_DURABILITY_LAG_SOFT_MAX,                     250e6 ); if( smallStorageTarget ) STORAGE_DURABILITY_LAG_SOFT_MAX = 10e6;
 
 	//FIXME: Low priority reads are disabled by assigning very high knob values, reduce knobs for 7.0
 	init( LOW_PRIORITY_STORAGE_QUEUE_BYTES,                    775e8 ); if( smallStorageTarget ) LOW_PRIORITY_STORAGE_QUEUE_BYTES = 1750e3;
-	init( LOW_PRIORITY_DURABILITY_LAG,                         275e8 ); if( smallStorageTarget ) LOW_PRIORITY_DURABILITY_LAG = 15e6;
+	init( LOW_PRIORITY_DURABILITY_LAG,                         200e6 ); if( smallStorageTarget ) LOW_PRIORITY_DURABILITY_LAG = 15e6;
 
 	bool smallTlogTarget = randomize && BUGGIFY;
 	init( TARGET_BYTES_PER_TLOG,                              2400e6 ); if( smallTlogTarget ) TARGET_BYTES_PER_TLOG = 2000e3;
@@ -483,7 +483,7 @@ ServerKnobs::ServerKnobs(bool randomize, ClientKnobs* clientKnobs, bool isSimula
 	init( MAX_TPS_HISTORY_SAMPLES,                               600 );
 	init( NEEDED_TPS_HISTORY_SAMPLES,                            200 );
 	init( TARGET_DURABILITY_LAG_VERSIONS,                      350e6 ); // Should be larger than STORAGE_DURABILITY_LAG_SOFT_MAX
-	init( TARGET_DURABILITY_LAG_VERSIONS_BATCH,                250e6 ); // Should be larger than STORAGE_DURABILITY_LAG_SOFT_MAX
+	init( TARGET_DURABILITY_LAG_VERSIONS_BATCH,                150e6 ); // Should be larger than STORAGE_DURABILITY_LAG_SOFT_MAX
 	init( DURABILITY_LAG_UNLIMITED_THRESHOLD,                   50e6 );
 	init( INITIAL_DURABILITY_LAG_MULTIPLIER,                    1.02 );
 	init( DURABILITY_LAG_REDUCTION_RATE,                      0.9999 );


### PR DESCRIPTION
Also update release notes for the 6.2.30 release.

This PR is resolves #...

Changes in this PR:

-
-
-

## General guideline:

- If this PR is ready to be merged (and all checkboxes below are either ticked or not applicable), make this a regular PR
- If this PR still needs work, please make this a draft PR
  - If you wish to get feedback/code-review, please add the label RFC to this PR

Please verify that all things listed below were considered and check them. If an item doesn't apply to this type of PR (for example a documentation change doesn't need to be performance tested), you should make a ~~strikethrough~~ (markdown syntax: `~~strikethrough~~`). More infos on the guidlines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

### Style
- [ ] All variable and function names make sense.
- [ ] The code is properly formatted (consider running `git clang-format`).

### Performance
- [ ] All CPU-hot paths are well optimized.
- [ ] The proper containers are used (for example `std::vector` vs `VectorRef`).
- [ ] There are no new known `SlowTask` traces.

### Testing
- [ ] The code was sufficiently tested in simulation.
- [ ] If there are new parameters or knobs, different values are tested in simulation.
- [ ] `ASSERT`, `ASSERT_WE_THINK`, and `TEST` macros are added in appropriate places.
- [ ] Unit tests were added for new algorithms and data structure that make sense to unit-test
- [ ] If this is a bugfix: there is a test that can easily reproduce the bug.
