### PR TITLE
Tls verify warning

### DIFF
--- a/flow/TLSConfig.actor.cpp
+++ b/flow/TLSConfig.actor.cpp
@@ -778,7 +778,7 @@ bool TLSPolicy::verify_peer(bool preverified, X509_STORE_CTX* store_ctx) {
 	}
 
 	if(!preverified) {
-		TraceEvent("TLSPolicyFailure").suppressFor(1.0).detail("Reason", "preverification failed").detail("VerifyError", X509_verify_cert_error_string(X509_STORE_CTX_get_error(store_ctx)));
+		TraceEvent(SevWarn, "TLSPolicyFailure").suppressFor(1.0).detail("Reason", "preverification failed").detail("VerifyError", X509_verify_cert_error_string(X509_STORE_CTX_get_error(store_ctx)));
 		return false;
 	}
 
@@ -801,7 +801,7 @@ bool TLSPolicy::verify_peer(bool preverified, X509_STORE_CTX* store_ctx) {
 	if (!rc) {
 		// log the various failure reasons
 		for (std::string reason : verify_failure_reasons) {
-			TraceEvent("TLSPolicyFailure").suppressFor(1.0).detail("Reason", reason);
+			TraceEvent(SevWarn, "TLSPolicyFailure").suppressFor(1.0).detail("Reason", reason);
 		}
 	}
 	return rc;


### PR DESCRIPTION
This PR increases the Severity of TLS handshake errors from 10 to 20.  

## General guideline:

- If this PR is ready to be merged (and all checkboxes below are either ticked or not applicable), make this a regular PR
- If this PR still needs work, please make this a draft PR
  - If you wish to get feedback/code-review, please add the label RFC to this PR

Please verify that all things listed below were considered and check them. If an item doesn't apply to this type of PR (for example a documentation change doesn't need to be performance tested), you should make a ~~strikethrough~~ (markdown syntax: `~~strikethrough~~`). More infos on the guidlines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

### Style
- [ X ] All variable and function names make sense.
- [ X ] The code is properly formatted (consider running `git clang-format`).

### Performance
- [ X ] All CPU-hot paths are well optimized.
- [ X ] The proper containers are used (for example `std::vector` vs `VectorRef`).
- [ X ] There are no new known `SlowTask` traces.

### Testing
- [ X ] The code was sufficiently tested in simulation.
- [ X ] If there are new parameters or knobs, different values are tested in simulation.
- [ X ] `ASSERT`, `ASSERT_WE_THINK`, and `TEST` macros are added in appropriate places.
- ~~[ ] Unit tests were added for new algorithms and data structure that make sense to unit-test~~
- ~~[ ] If this is a bugfix: there is a test that can easily reproduce the bug.~~
