### PR TITLE
Make the ping enpoint a stable interface

### DIFF
--- a/fdbrpc/FlowTransport.actor.cpp
+++ b/fdbrpc/FlowTransport.actor.cpp
@@ -188,14 +188,28 @@ struct EndpointNotFoundReceiver final : NetworkMessageReceiver {
 	}
 };
 
+struct PingRequest {
+	constexpr static FileIdentifier file_identifier = 4707015;
+	ReplyPromise<Void> reply{ PeerCompatibilityPolicy{ RequirePeer::AtLeast,
+	                                                   ProtocolVersion::withStableInterfaces() } };
+	template <class Ar>
+	void serialize(Ar& ar) {
+		serializer(ar, reply);
+	}
+};
+
 struct PingReceiver final : NetworkMessageReceiver {
 	PingReceiver(EndpointMap& endpoints) {
 		endpoints.insertWellKnown(this, WLTOKEN_PING_PACKET, TaskPriority::ReadSocket);
 	}
 	void receive(ArenaObjectReader& reader) override {
-		ReplyPromise<Void> reply;
-		reader.deserialize(reply);
-		reply.send(Void());
+		PingRequest req;
+		reader.deserialize(req);
+		req.reply.send(Void());
+	}
+	PeerCompatibilityPolicy peerCompatibilityPolicy() const override {
+		return PeerCompatibilityPolicy{ RequirePeer::AtLeast,
+		                                ProtocolVersion::withStableInterfaces() };
 	}
 };
 
@@ -440,8 +454,8 @@ ACTOR Future<Void> connectionMonitor( Reference<Peer> peer ) {
 		wait (delayJittered(FLOW_KNOBS->CONNECTION_MONITOR_LOOP_TIME, TaskPriority::ReadSocket));
 
 		// TODO: Stop monitoring and close the connection with no onDisconnect requests outstanding
-		state ReplyPromise<Void> reply;
-		FlowTransport::transport().sendUnreliable( SerializeSource<ReplyPromise<Void>>(reply), remotePingEndpoint, true );
+		state PingRequest pingRequest;
+		FlowTransport::transport().sendUnreliable( SerializeSource<PingRequest>(pingRequest), remotePingEndpoint, true );
 		state int64_t startingBytes = peer->bytesReceived;
 		state int timeouts = 0;
 		state double startTime = now();
@@ -464,7 +478,7 @@ ACTOR Future<Void> connectionMonitor( Reference<Peer> peer ) {
 					startingBytes = peer->bytesReceived;
 					timeouts++;
 				}
-				when (wait( reply.getFuture() )) {
+				when (wait( pingRequest.reply.getFuture() )) {
 					if(peer->destination.isPublic()) {
 						peer->pingLatencies.addSample(now() - startTime);
 					}
@@ -1162,12 +1176,15 @@ ACTOR static Future<Void> connectionReader(
 						}
 					}
 				}
-				if (compatible || peerProtocolVersion.hasStableInterfaces()) {
-					scanPackets( transport, unprocessed_begin, unprocessed_end, arena, peerAddress, peerProtocolVersion );
-				}
-				else if(!expectConnectPacket) {
-					unprocessed_begin = unprocessed_end;
-					peer->resetPing.trigger();
+
+				if(!expectConnectPacket) {
+					if (compatible || peerProtocolVersion.hasStableInterfaces()) {
+						scanPackets( transport, unprocessed_begin, unprocessed_end, arena, peerAddress, peerProtocolVersion );
+					}
+					else {
+						unprocessed_begin = unprocessed_end;
+						peer->resetPing.trigger();
+					}
 				}
 
 				if (readWillBlock)


### PR DESCRIPTION
This PR resolves #4294

Changes in this PR:

- Ping endpoint is a stable endpoint so that incompatible connections can be kept alive
- Fix bug where we could start scanning for packets before finishing the connect packet

### Style
- [x] All variable and function names make sense.

### Testing
- [x] The code was sufficiently tested in simulation.
- [x] If this is a bugfix: there is a test that can easily reproduce the bug.
