### PR TITLE
Add seed initialization in snapshot c unit test 

### DIFF
--- a/bindings/c/test/unit/unit_tests.cpp
+++ b/bindings/c/test/unit/unit_tests.cpp
@@ -34,6 +34,7 @@
 #include <thread>
 #include <tuple>
 #include <vector>
+#include <random>
 
 #define DOCTEST_CONFIG_IMPLEMENT
 #include "doctest.h"
@@ -2047,14 +2048,13 @@ TEST_CASE("fdb_database_force_recovery_with_data_loss") {
 }
 
 std::string random_hex_string(size_t length) {
-	srand(time(0)); // set random seed
-	auto randchar = []() -> char {
-		const char charset[] = "0123456789"
-		                       "ABCDEF"
-		                       "abcdef";
-		const size_t max_index = (sizeof(charset) - 1);
-		return charset[rand() % max_index];
-	};
+	const char charset[] = "0123456789"
+	                       "ABCDEF"
+	                       "abcdef";
+	// construct a random generator engine from a time-based seed:
+	std::default_random_engine generator(time(nullptr));
+	std::uniform_int_distribution<int> distribution(0, strlen(charset) - 1);
+	auto randchar = [&charset, &generator, &distribution]() -> char { return charset[distribution(generator)]; };
 	std::string str(length, 0);
 	std::generate_n(str.begin(), length, randchar);
 	return str;

--- a/bindings/c/test/unit/unit_tests.cpp
+++ b/bindings/c/test/unit/unit_tests.cpp
@@ -2047,6 +2047,7 @@ TEST_CASE("fdb_database_force_recovery_with_data_loss") {
 }
 
 std::string random_hex_string(size_t length) {
+	srand(time(0)); // set random seed
 	auto randchar = []() -> char {
 		const char charset[] = "0123456789"
 		                       "ABCDEF"


### PR DESCRIPTION
#4241  forgot to initialize the random seed in the unit test, this pr simply add it and change the code to use C++ random generator instead of the C `rand()`.


### Style
- [ ] ~~All variable and function names make sense.~~
- [x] The code is properly formatted (consider running `git clang-format`).

### Performance
- [ ] ~~All CPU-hot paths are well optimized.~~
- [ ] ~~The proper containers are used (for example `std::vector` vs `VectorRef`).~~
- [ ] ~~There are no new known `SlowTask` traces.~~

### Testing
- [x] The code was sufficiently tested in simulation.
- [ ] ~~If there are new parameters or knobs, different values are tested in simulation.~~
- [ ] ~~`ASSERT`, `ASSERT_WE_THINK`, and `TEST` macros are added in appropriate places.~~
- [ ] ~~Unit tests were added for new algorithms and data structure that make sense to unit-test~~
- [ ] ~~If this is a bugfix: there is a test that can easily reproduce the bug.~~
