### PR TITLE
Remove unused log routers before full recovery

### DIFF
--- a/fdbserver/LogRouter.actor.cpp
+++ b/fdbserver/LogRouter.actor.cpp
@@ -610,7 +610,8 @@ ACTOR Future<Void> checkRemoved(Reference<AsyncVar<ServerDBInfo>> db, uint64_t r
 	loop {
 		bool isDisplaced =
 		    ((db->get().recoveryCount > recoveryCount && db->get().recoveryState != RecoveryState::UNINITIALIZED) ||
-		     (db->get().recoveryCount == recoveryCount && db->get().recoveryState == RecoveryState::FULLY_RECOVERED));
+		     (db->get().recoveryCount == recoveryCount &&
+		      db->get().recoveryState >= RecoveryState::ALL_LOGS_RECRUITED));
 		isDisplaced = isDisplaced && !db->get().logSystemConfig.hasLogRouter(myInterface.id());
 		if (isDisplaced) {
 			throw worker_removed();


### PR DESCRIPTION
This PR gives us a signal on how recovery has progressed by removing old, no longer needed log routers.

### Style
- [x] All variable and function names make sense.
- [x] The code is properly formatted (consider running `git clang-format`).

### Performance
- ~~[ ] All CPU-hot paths are well optimized.~~
- ~~[ ] The proper containers are used (for example `std::vector` vs `VectorRef`).~~
- ~~[ ] There are no new known `SlowTask` traces.~~

### Testing
- [x] The code was sufficiently tested in simulation.
- ~~[ ] If there are new parameters or knobs, different values are tested in simulation.~~
- ~~[ ] `ASSERT`, `ASSERT_WE_THINK`, and `TEST` macros are added in appropriate places.~~
- ~~[ ] Unit tests were added for new algorithms and data structure that make sense to unit-test~~
- ~~[ ] If this is a bugfix: there is a test that can easily reproduce the bug.~~
