### PR TITLE
Fix memory bug in unit test

### DIFF
--- a/fdbclient/ManagementAPI.actor.cpp
+++ b/fdbclient/ManagementAPI.actor.cpp
@@ -2021,7 +2021,7 @@ TEST_CASE("/ManagementAPI/AutoQuorumChange/checkLocality") {
 		data.address.ip = IPAddress(i);
 
 		if(g_network->isSimulated()) {
-			g_simulator.newProcess(format("TestProcess%d", i).c_str(), data.address.ip, data.address.port, false, 1,
+			g_simulator.newProcess("TestCoordinator", data.address.ip, data.address.port, false, 1,
 			                       data.locality, ProcessClass(ProcessClass::CoordinatorClass, ProcessClass::CommandLineSource),
 			                       "", "");
 		}


### PR DESCRIPTION
I [recently](https://github.com/apple/foundationdb/pull/4285) introduced a bug in a unit test that causes an invalid memory access at the end of simulated runs of that unit test. This fixes that bug by making the name of the process a literal string.
