### PR TITLE
Backup expiration will try a deep backup scan if initial scan suggests restorability requirements would be unmet.

### DIFF
--- a/fdbclient/BackupContainer.actor.cpp
+++ b/fdbclient/BackupContainer.actor.cpp
@@ -979,7 +979,7 @@ public:
 		// possible the metadata is wrong.  So, try the backup describe again but with the deepScan option set
 		// true so it will scan all log files in the backup to determine restorability and re-initialize the 
 		// log version metadata in the backup.
-		state bool useDeepScan = false;
+		state bool useDeepScan = BUGGIFY ? deterministicRandom()->coinflip() : false;
 		state Version scanBegin = 0;
 
 		loop {


### PR DESCRIPTION
This PR resolves #4315

### Performance
- [ ] ~~All CPU-hot paths are well optimized.~~
- [ ] ~~The proper containers are used (for example `std::vector` vs `VectorRef`).~~
- [ ] ~~There are no new known `SlowTask` traces.~~

### Testing
- [x] The code was sufficiently tested in simulation.
- [ ] ~~If there are new parameters or knobs, different values are tested in simulation.~~
- [ ] ~~`ASSERT`, `ASSERT_WE_THINK`, and `TEST` macros are added in appropriate places.~~
- [ ] ~~Unit tests were added for new algorithms and data structure that make sense to unit-test~~
- [ ] ~~If this is a bugfix: there is a test that can easily reproduce the bug.~~
