### PR TITLE
Clean up and document the integration of ctest and junit.

### DIFF
--- a/bindings/java/CMakeLists.txt
+++ b/bindings/java/CMakeLists.txt
@@ -107,9 +107,7 @@ set(JAVA_TESTS_SRCS
   src/test/com/apple/foundationdb/test/WatchTest.java
   src/test/com/apple/foundationdb/test/WhileTrueTest.java)
 
-set(JAVA_JUNIT_TESTS
-  src/junit/com/apple/foundationdb/tuple/AllTests.java
-  src/junit/com/apple/foundationdb/tuple/ArrayUtilTests.java)
+include(src/junit/tests.cmake)
 
 set(GENERATED_JAVA_DIR ${CMAKE_CURRENT_BINARY_DIR}/src/main/com/apple/foundationdb)
 file(MAKE_DIRECTORY ${GENERATED_JAVA_DIR})
@@ -275,10 +273,33 @@ if(NOT OPEN_FOR_IDE)
       EXPECTED_HASH SHA256=4877670629ab96f34f5f90ab283125fcd9acb7e683e66319a68be6eb2cca60de)
     add_jar(fdb-junit SOURCES ${JAVA_JUNIT_TESTS} INCLUDE_JARS fdb-java ${CMAKE_BINARY_DIR}/packages/junit-4.13.jar)
     get_property(junit_jar_path TARGET fdb-junit PROPERTY JAR_FILE)
-    add_test(NAME junit
-      COMMAND ${Java_JAVA_EXECUTABLE}
-              -cp "${target_jar}:${junit_jar_path}:${CMAKE_BINARY_DIR}/packages/junit-4.13.jar:${CMAKE_BINARY_DIR}/packages/hamcrest-all-1.3.jar"
-              -Djava.library.path=${CMAKE_BINARY_DIR}/lib
-              org.junit.runner.JUnitCore "com.apple.foundationdb.tuple.AllTests")
+
+#      Add a ctest test configuration for each Junit class in the JAVA_JUNIT_TESTS variable.
+#
+#      To add a new junit test, add the class to the JAVA_JUNIT_TESTS variable in `src/junit/tests.cmake`. Note that if you run a Suite, 
+#      ctest will NOT display underlying details of the suite itself, so it's best to avoid junit suites in general. Also,
+#      if you need a different runner other than JUnitCore, you'll have to modify this so be aware.
+#
+#      To run tests (once built): navigate to bindings/java and type
+#
+#      ctest .
+#
+#      To see details of what tests run and what failures, use
+#
+#      ctest . --output-on-failure
+#
+#      And so on (see ctest documentation for more details)
+    
+    foreach(JTEST IN LISTS JAVA_JUNIT_TESTS)
+            string(REPLACE "/" "." TEST_CLASS ${JTEST})
+            string(REGEX REPLACE ".java$" "" TEST_CLASS ${TEST_CLASS})
+            string(REGEX REPLACE "^src.junit." "" TEST_CLASS ${TEST_CLASS})
+            add_test(NAME ${TEST_CLASS}
+        COMMAND ${Java_JAVA_EXECUTABLE}
+                -cp "${target_jar}:${junit_jar_path}:${CMAKE_BINARY_DIR}/packages/junit-4.13.jar:${CMAKE_BINARY_DIR}/packages/hamcrest-all-1.3.jar"
+                -Djava.library.path=${CMAKE_BINARY_DIR}/lib
+                org.junit.runner.JUnitCore "${TEST_CLASS}"
+        )
+    endforeach()
   endif()
 endif()

--- a/bindings/java/src/junit/README.md
+++ b/bindings/java/src/junit/README.md
@@ -1,0 +1,27 @@
+Adding JUnit tests
+===
+
+For java development, it's often useful to use JUnit for testing due to the excellent tooling support.
+
+To add a new JUnit test, do the following:
+
+1. Write your test
+2. Add the test path to `tests.cmake`, using the relative path starting at `com`(for example, `com/apple/foundationdb/tuple/ArrayUtilTests.java` will add the `ArrayUtilTests` test file).
+3. re-run cmake in your build directory. This will ensure your test gets picked up.
+4. from your build directory, navigate to `bindings/java`
+5. run `ctest .`
+
+This will run JUnit tests through the `ctest` framework that cmake supports easily.
+
+# Appendix: Useful ctest commands for the Java developer
+
+1. To display output for ctest:
+    `ctest . --output-on-failure`
+2. To run just a single test:
+    `ctest -R {fully qualified class name}`
+3. To fail fast (on the first test):
+    `ctest . --stop-on-failure`
+4. To re-run only failed tests:
+    `ctest . --rerun-failed`
+5. To make ctest run using multiple threads
+    `ctest . -j{Num threads}`

--- a/bindings/java/src/junit/tests.cmake
+++ b/bindings/java/src/junit/tests.cmake
@@ -1,0 +1,28 @@
+#
+# tests.cmake
+#
+# This source file is part of the FoundationDB open source project
+#
+# Copyright 2013-2018 Apple Inc. and the FoundationDB project authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# This is a convenience file to separate the JUnit test file listing from the rest
+# of the cmake logic so that we don't accidentally break anything when adding/removing
+# JUnit tests from the cmake construction
+#
+set(JAVA_JUNIT_TESTS
+  src/junit/com/apple/foundationdb/tuple/ArrayUtilTests.java
+  )
+


### PR DESCRIPTION
This adds the ability to run junit tests through ctest a little more
easily (no Suites required). It also adds a small amount of
documentation to explain to the average developer how to go about using
Junit effectively.

This PR resolves #4323 

Changes in this PR:

- JUnit tests in the java bindings directory now run as separate ctest items, so that we no longer require using a Suite

Note: This is a build-only fix, there should be no impact on performance or reliability of FDB proper.

## General guideline:

- If this PR is ready to be merged (and all checkboxes below are either ticked or not applicable), make this a regular PR
- If this PR still needs work, please make this a draft PR
  - If you wish to get feedback/code-review, please add the label RFC to this PR

Please verify that all things listed below were considered and check them. If an item doesn't apply to this type of PR (for example a documentation change doesn't need to be performance tested), you should make a ~~strikethrough~~ (markdown syntax: `~~strikethrough~~`). More infos on the guidlines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

### Style
- [ X] All variable and function names make sense.
- [ X] The code is properly formatted (consider running `git clang-format`).

### Performance
- [ ] ~~All CPU-hot paths are well optimized.~~
- [ ] ~~The proper containers are used (for example `std::vector` vs `VectorRef`).~~
- [ ] ~~There are no new known `SlowTask` traces.~~

### Testing
- [ ] ~~The code was sufficiently tested in simulation.~~
- [ ] ~~If there are new parameters or knobs, different values are tested in simulation.~~
- [ ] ~~`ASSERT`, `ASSERT_WE_THINK`, and `TEST` macros are added in appropriate places.~~
- [ ] ~~Unit tests were added for new algorithms and data structure that make sense to unit-test~~
- [ ] ~~If this is a bugfix: there is a test that can easily reproduce the bug.~~
