### PR TITLE
Use boost version 1.67 exactly on release-6.2

### DIFF
--- a/cmake/CompileBoost.cmake
+++ b/cmake/CompileBoost.cmake
@@ -4,7 +4,11 @@ if(NOT BOOSTROOT AND NOT BOOST_ROOT)
   # We can fix this for boost versions > 1.70
   set(BOOST_ROOT /opt/boost_1_67_0)
 endif()
-find_package(Boost 1.67)
+
+# Bug in boost subprocess in 1.72! In release-6.3 and later we replaced the
+# boost subprocess usage with our own thing, but for release-6.2 it's important
+# that we use boost 1.67 exactly.
+find_package(Boost 1.67 EXACT)
 
 if(Boost_FOUND)
   add_library(boost_target INTERFACE)


### PR DESCRIPTION
Previously in the official foundationdb/foundationdb-build docker image cmake could build against boost 1.72. This is the same bug fixed in 697a9422f5605fdb86afc485f90877931121238b for release-6.3 and master. For release-6.2 we need to make sure we build against 1.67 exactly.

(Alternatively we could backport 697a9422f5605fdb86afc485f90877931121238b, but I prefer this in the interest of making the minimal possible change to release-6.2)