### PR TITLE
Add knob to increase mako TPS sampling rate

### DIFF
--- a/bindings/c/test/mako/mako.c
+++ b/bindings/c/test/mako/mako.c
@@ -2104,7 +2104,8 @@ int stats_process_main(mako_args_t* args, mako_stats_t* stats, volatile double* 
 		clock_gettime(CLOCK_MONOTONIC_COARSE, &timer_now);
 
 		/* print stats every stats_samplerate milliseconds */
-		if (timer_now.tv_nsec > timer_prev.tv_nsec + args->stats_samplerate * 1000000) {
+	if (timer_now.tv_sec * 1000000000.0 + timer_now.tv_nsec >
+		timer_prev.tv_sec * 1000000000.0 + timer_prev.tv_nsec + args->stats_samplerate * 1000000) {
 
 			/* adjust throttle rate if needed */
 			if (args->tpsmax != args->tpsmin) {

--- a/bindings/c/test/mako/mako.c
+++ b/bindings/c/test/mako/mako.c
@@ -1387,7 +1387,7 @@ void usage() {
 	printf("%-24s %s\n", "    --tpsmin=TPS", "Specify the target min TPS");
 	printf("%-24s %s\n", "    --tpsinterval=SEC", "Specify the TPS change interval (Default: 10 seconds)");
 	printf("%-24s %s\n", "    --tpschange=<sin|square|pulse>", "Specify the TPS change type (Default: sin)");
-	printf("%-24s %s\n", "    --stats-samplerate=RATE", "Specify the sampling rate for tps stats (Default: sample once per 1000 ms)");
+	printf("%-24s %s\n", "    --stats_samplerate=RATE", "Specify the sampling rate for tps stats (Default: sample once per 1000 ms)");
 	printf("%-24s %s\n", "    --sampling=RATE", "Specify the sampling rate for latency stats");
 	printf("%-24s %s\n", "-m, --mode=MODE", "Specify the mode (build, run, clean)");
 	printf("%-24s %s\n", "-z, --zipf", "Use zipfian distribution instead of uniform distribution");
@@ -1661,7 +1661,7 @@ int validate_args(mako_args_t* args) {
 		}
 	}
 	if (args->stats_samplerate < 100) {
-		fprintf(stderr, "ERROR: --stats-samplerate must be set to sample every 100 ms or more\n");
+		fprintf(stderr, "ERROR: --stats_samplerate must be set to sample every 100 ms or more\n");
 		return -1;
 	}
 	return 0;

--- a/bindings/c/test/mako/mako.c
+++ b/bindings/c/test/mako/mako.c
@@ -1222,7 +1222,7 @@ int init_args(mako_args_t* args) {
 	args->tpsmin = -1;
 	args->tpsinterval = 10;
 	args->tpschange = TPS_SIN;
-	args->stats_samplerate = 1000;
+	args->stats_samplerate = 100;
 	args->sampling = 1000;
 	args->key_length = 32;
 	args->value_length = 16;

--- a/bindings/c/test/mako/mako.h
+++ b/bindings/c/test/mako/mako.h
@@ -64,6 +64,7 @@ enum Arguments {
 	ARG_VALLEN,
 	ARG_TPS,
 	ARG_COMMITGET,
+	ARG_STATSSAMPLERATE,
 	ARG_SAMPLING,
 	ARG_VERSION,
 	ARG_KNOBS,
@@ -114,6 +115,7 @@ typedef struct {
 	int tpsmin;
 	int tpsinterval;
 	int tpschange;
+	int stats_samplerate;
 	int sampling;
 	int key_length;
 	int value_length;


### PR DESCRIPTION
This PR does not resolve an issue currently -- it *should* resolve aliasing problems in `mako` TPS data. That is being tested and this can be brought out of draft when that's clear.

Changes in this PR:

- add `--stats-samplerate` which sets the stats sampling rate in mHz (that's millihertz, not megahertz). Defaults to 1000 mHz = 1 Hz. You can increase this value up to 1 sample per 100 ms, i.e. 1 kHz.

TODO:
- [ ] samplerate should NOT use an inverse unit. It's confusing. ("increasing" the sample rate should mean a bigger number not smaller)
- [ ] `--sampling` should be renamed to reflect that it only controls the latency sampling rate if this sample rate and `--stats-samplerate` cannot be combined.