### PR TITLE
Add global configuration framework implementation

### DIFF
--- a/fdbcli/fdbcli.actor.cpp
+++ b/fdbcli/fdbcli.actor.cpp
@@ -3891,8 +3891,8 @@ ACTOR Future<int> cli(CLIOptions opt, LineNoise* plinenoise) {
 							Tuple rate = Tuple().appendDouble(sampleRate);
 							Tuple size = Tuple().append(sizeLimit);
 							tr->setOption(FDBTransactionOptions::SPECIAL_KEY_SPACE_ENABLE_WRITES);
-							tr->set(fdbClientInfoTxnSampleRate.withPrefix(SpecialKeySpace::getModuleRange(SpecialKeySpace::MODULE::GLOBALCONFIG).begin), rate.pack());
-							tr->set(fdbClientInfoTxnSizeLimit.withPrefix(SpecialKeySpace::getModuleRange(SpecialKeySpace::MODULE::GLOBALCONFIG).begin), size.pack());
+							tr->set(GlobalConfig::prefixedKey(fdbClientInfoTxnSampleRate), rate.pack());
+							tr->set(GlobalConfig::prefixedKey(fdbClientInfoTxnSizeLimit), size.pack());
 							if (!intrans) {
 								wait(commitTransaction(tr));
 							}

--- a/fdbcli/fdbcli.actor.cpp
+++ b/fdbcli/fdbcli.actor.cpp
@@ -3842,8 +3842,10 @@ ACTOR Future<int> cli(CLIOptions opt, LineNoise* plinenoise) {
 								is_error = true;
 								continue;
 							}
-							const double sampleRateDbl = GlobalConfig::globalConfig().get<double>(fdbClientInfoTxnSampleRate, std::numeric_limits<double>::infinity());
-							const int64_t sizeLimit = GlobalConfig::globalConfig().get<int64_t>(fdbClientInfoTxnSizeLimit, -1);
+							const double sampleRateDbl = GlobalConfig::globalConfig().get<double>(
+							    fdbClientInfoTxnSampleRate, std::numeric_limits<double>::infinity());
+							const int64_t sizeLimit =
+							    GlobalConfig::globalConfig().get<int64_t>(fdbClientInfoTxnSizeLimit, -1);
 							std::string sampleRateStr = "default", sizeLimitStr = "default";
 							if (!std::isinf(sampleRateDbl)) {
 								sampleRateStr = boost::lexical_cast<std::string>(sampleRateDbl);

--- a/fdbcli/fdbcli.actor.cpp
+++ b/fdbcli/fdbcli.actor.cpp
@@ -24,6 +24,7 @@
 #include "fdbclient/Status.h"
 #include "fdbclient/StatusClient.h"
 #include "fdbclient/DatabaseContext.h"
+#include "fdbclient/GlobalConfig.actor.h"
 #include "fdbclient/NativeAPI.actor.h"
 #include "fdbclient/ReadYourWrites.h"
 #include "fdbclient/ClusterInterface.h"
@@ -3841,25 +3842,14 @@ ACTOR Future<int> cli(CLIOptions opt, LineNoise* plinenoise) {
 								is_error = true;
 								continue;
 							}
-							state Future<Optional<Standalone<StringRef>>> sampleRateFuture =
-							    tr->get(fdbClientInfoTxnSampleRate);
-							state Future<Optional<Standalone<StringRef>>> sizeLimitFuture =
-							    tr->get(fdbClientInfoTxnSizeLimit);
-							wait(makeInterruptable(success(sampleRateFuture) && success(sizeLimitFuture)));
+							const double sampleRateDbl = GlobalConfig::globalConfig().get<double>(fdbClientInfoTxnSampleRate, std::numeric_limits<double>::infinity());
+							const int64_t sizeLimit = GlobalConfig::globalConfig().get<int64_t>(fdbClientInfoTxnSizeLimit, -1);
 							std::string sampleRateStr = "default", sizeLimitStr = "default";
-							if (sampleRateFuture.get().present()) {
-								const double sampleRateDbl =
-								    BinaryReader::fromStringRef<double>(sampleRateFuture.get().get(), Unversioned());
-								if (!std::isinf(sampleRateDbl)) {
-									sampleRateStr = boost::lexical_cast<std::string>(sampleRateDbl);
-								}
+							if (!std::isinf(sampleRateDbl)) {
+								sampleRateStr = boost::lexical_cast<std::string>(sampleRateDbl);
 							}
-							if (sizeLimitFuture.get().present()) {
-								const int64_t sizeLimit =
-								    BinaryReader::fromStringRef<int64_t>(sizeLimitFuture.get().get(), Unversioned());
-								if (sizeLimit != -1) {
-									sizeLimitStr = boost::lexical_cast<std::string>(sizeLimit);
-								}
+							if (sizeLimit != -1) {
+								sizeLimitStr = boost::lexical_cast<std::string>(sizeLimit);
 							}
 							printf("Client profiling rate is set to %s and size limit is set to %s.\n",
 							       sampleRateStr.c_str(),
@@ -3897,8 +3887,12 @@ ACTOR Future<int> cli(CLIOptions opt, LineNoise* plinenoise) {
 									continue;
 								}
 							}
-							tr->set(fdbClientInfoTxnSampleRate, BinaryWriter::toValue(sampleRate, Unversioned()));
-							tr->set(fdbClientInfoTxnSizeLimit, BinaryWriter::toValue(sizeLimit, Unversioned()));
+
+							Tuple rate = Tuple().appendDouble(sampleRate);
+							Tuple size = Tuple().append(sizeLimit);
+							tr->setOption(FDBTransactionOptions::SPECIAL_KEY_SPACE_ENABLE_WRITES);
+							tr->set(fdbClientInfoTxnSampleRate.withPrefix(SpecialKeySpace::getModuleRange(SpecialKeySpace::MODULE::GLOBALCONFIG).begin), rate.pack());
+							tr->set(fdbClientInfoTxnSizeLimit.withPrefix(SpecialKeySpace::getModuleRange(SpecialKeySpace::MODULE::GLOBALCONFIG).begin), size.pack());
 							if (!intrans) {
 								wait(commitTransaction(tr));
 							}

--- a/fdbclient/CMakeLists.txt
+++ b/fdbclient/CMakeLists.txt
@@ -28,6 +28,7 @@ set(FDBCLIENT_SRCS
   FDBOptions.h
   FDBTypes.h
   FileBackupAgent.actor.cpp
+  GlobalConfig.h
   GlobalConfig.actor.h
   GlobalConfig.actor.cpp
   GrvProxyInterface.h

--- a/fdbclient/CMakeLists.txt
+++ b/fdbclient/CMakeLists.txt
@@ -28,6 +28,8 @@ set(FDBCLIENT_SRCS
   FDBOptions.h
   FDBTypes.h
   FileBackupAgent.actor.cpp
+  GlobalConfig.actor.h
+  GlobalConfig.actor.cpp
   GrvProxyInterface.h
   HTTP.actor.cpp
   IClientApi.h

--- a/fdbclient/CommitProxyInterface.h
+++ b/fdbclient/CommitProxyInterface.h
@@ -113,6 +113,7 @@ struct ClientDBInfo {
 	vector<CommitProxyInterface> commitProxies;
 	Optional<CommitProxyInterface>
 	    firstCommitProxy; // not serialized, used for commitOnFirstProxy when the commit proxies vector has been shrunk
+	vector<Standalone<std::pair<Version, VectorRef<MutationRef>>>> history;
 	double clientTxnInfoSampleRate;
 	int64_t clientTxnInfoSizeLimit;
 	Optional<Value> forward;
@@ -132,15 +133,8 @@ struct ClientDBInfo {
 		if constexpr (!is_fb_function<Archive>) {
 			ASSERT(ar.protocolVersion().isValid());
 		}
-		serializer(ar,
-		           grvProxies,
-		           commitProxies,
-		           id,
-		           clientTxnInfoSampleRate,
-		           clientTxnInfoSizeLimit,
-		           forward,
-		           transactionTagSampleRate,
-		           transactionTagSampleCost);
+		serializer(ar, grvProxies, commitProxies, id, history, clientTxnInfoSampleRate, clientTxnInfoSizeLimit,
+	               forward, transactionTagSampleRate, transactionTagSampleCost);
 	}
 };
 

--- a/fdbclient/CommitProxyInterface.h
+++ b/fdbclient/CommitProxyInterface.h
@@ -31,6 +31,7 @@
 #include "fdbclient/CommitTransaction.h"
 #include "fdbserver/RatekeeperInterface.h"
 #include "fdbclient/TagThrottle.h"
+#include "fdbclient/GlobalConfig.h"
 
 #include "fdbrpc/Stats.h"
 #include "fdbrpc/TimedRequest.h"
@@ -114,7 +115,7 @@ struct ClientDBInfo {
 	Optional<CommitProxyInterface>
 	    firstCommitProxy; // not serialized, used for commitOnFirstProxy when the commit proxies vector has been shrunk
 	Optional<Value> forward;
-	vector<Standalone<std::pair<Version, VectorRef<MutationRef>>>> history;
+	vector<VersionHistory> history;
 
 	ClientDBInfo() {}
 

--- a/fdbclient/CommitProxyInterface.h
+++ b/fdbclient/CommitProxyInterface.h
@@ -113,17 +113,10 @@ struct ClientDBInfo {
 	vector<CommitProxyInterface> commitProxies;
 	Optional<CommitProxyInterface>
 	    firstCommitProxy; // not serialized, used for commitOnFirstProxy when the commit proxies vector has been shrunk
-	vector<Standalone<std::pair<Version, VectorRef<MutationRef>>>> history;
-	double clientTxnInfoSampleRate;
-	int64_t clientTxnInfoSizeLimit;
 	Optional<Value> forward;
-	double transactionTagSampleRate;
-	double transactionTagSampleCost;
+	vector<Standalone<std::pair<Version, VectorRef<MutationRef>>>> history;
 
-	ClientDBInfo()
-	  : clientTxnInfoSampleRate(std::numeric_limits<double>::infinity()), clientTxnInfoSizeLimit(-1),
-	    transactionTagSampleRate(CLIENT_KNOBS->READ_TAG_SAMPLE_RATE),
-	    transactionTagSampleCost(CLIENT_KNOBS->COMMIT_SAMPLE_COST) {}
+	ClientDBInfo() {}
 
 	bool operator==(ClientDBInfo const& r) const { return id == r.id; }
 	bool operator!=(ClientDBInfo const& r) const { return id != r.id; }
@@ -133,8 +126,7 @@ struct ClientDBInfo {
 		if constexpr (!is_fb_function<Archive>) {
 			ASSERT(ar.protocolVersion().isValid());
 		}
-		serializer(ar, grvProxies, commitProxies, id, history, clientTxnInfoSampleRate, clientTxnInfoSizeLimit,
-	               forward, transactionTagSampleRate, transactionTagSampleCost);
+		serializer(ar, grvProxies, commitProxies, id, forward, history);
 	}
 };
 

--- a/fdbclient/GlobalConfig.actor.cpp
+++ b/fdbclient/GlobalConfig.actor.cpp
@@ -149,7 +149,7 @@ ACTOR Future<Void> GlobalConfig::updater(GlobalConfig* self, Reference<AsyncVar<
 				// ascending version order.
 				for (const auto& vh : history) {
 					if (vh.version <= self->lastUpdate) {
-						continue;  // already applied this mutation
+						continue; // already applied this mutation
 					}
 
 					for (const auto& mutation : vh.mutations.contents()) {

--- a/fdbclient/GlobalConfig.actor.cpp
+++ b/fdbclient/GlobalConfig.actor.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "fdbclient/GlobalConfig.actor.h"
+#include "fdbclient/SpecialKeySpace.actor.h"
 #include "fdbclient/SystemData.h"
 #include "fdbclient/Tuple.h"
 #include "flow/flow.h"
@@ -47,6 +48,10 @@ GlobalConfig& GlobalConfig::globalConfig() {
 	void* res = g_network->global(INetwork::enGlobalConfig);
 	ASSERT(res);
 	return *reinterpret_cast<GlobalConfig*>(res);
+}
+
+Key GlobalConfig::prefixedKey(KeyRef key) {
+	return key.withPrefix(SpecialKeySpace::getModuleRange(SpecialKeySpace::MODULE::GLOBALCONFIG).begin);
 }
 
 const ConfigValue GlobalConfig::get(KeyRef name) {

--- a/fdbclient/GlobalConfig.actor.cpp
+++ b/fdbclient/GlobalConfig.actor.cpp
@@ -123,7 +123,13 @@ ACTOR Future<Void> GlobalConfig::updater(GlobalConfig* self, Reference<AsyncVar<
 				// history updates or the protocol version changed, so it
 				// must re-read the entire configuration range.
 				wait(self->refresh(self));
-				self->lastUpdate = dbInfo->get().history.back().contents().first;
+				// TODO: This check is a temporary fix while old functionality
+				// for setting ClientDBInfo fields exist, but eventually it
+				// should be replaced with an assert that the size of `history`
+				// is greater than 0.
+				if (dbInfo->get().history.size() > 0) {
+					self->lastUpdate = dbInfo->get().history.back().contents().first;
+				}
 			} else {
 				// Apply history in order, from lowest version to highest
 				// version. Mutation history should already be stored in

--- a/fdbclient/GlobalConfig.actor.cpp
+++ b/fdbclient/GlobalConfig.actor.cpp
@@ -18,6 +18,7 @@
  * limitations under the License.
  */
 
+#include "fdbclient/DatabaseContext.h"
 #include "fdbclient/GlobalConfig.actor.h"
 #include "fdbclient/SpecialKeySpace.actor.h"
 #include "fdbclient/SystemData.h"
@@ -133,6 +134,10 @@ ACTOR Future<Void> GlobalConfig::updater(GlobalConfig* self, Reference<AsyncVar<
 	loop {
 		try {
 			wait(dbInfo->onChange());
+
+			if (dbInfo->get().id.second() != 123456789) {
+				continue;
+			}
 
 			auto& history = dbInfo->get().history;
 			if (history.size() == 0 || (self->lastUpdate < history[0].version && self->lastUpdate != 0)) {

--- a/fdbclient/GlobalConfig.actor.cpp
+++ b/fdbclient/GlobalConfig.actor.cpp
@@ -26,6 +26,12 @@
 
 #include "flow/actorcompiler.h"  // This must be the last #include.
 
+const KeyRef fdbClientInfoTxnSampleRate = LiteralStringRef("fdbClientInfo/client_txn_sample_rate");
+const KeyRef fdbClientInfoTxnSizeLimit = LiteralStringRef("fdbClientInfo/client_txn_size_limit");
+
+const KeyRef transactionTagSampleRate = LiteralStringRef("transactionTagSampleRate");
+const KeyRef transactionTagSampleCost = LiteralStringRef("transactionTagSampleCost");
+
 GlobalConfig::GlobalConfig() : lastUpdate(0) {}
 
 void GlobalConfig::create(DatabaseContext* cx, Reference<AsyncVar<ClientDBInfo>> dbInfo) {

--- a/fdbclient/GlobalConfig.actor.cpp
+++ b/fdbclient/GlobalConfig.actor.cpp
@@ -1,0 +1,60 @@
+/*
+ * GlobalConfig.actor.cpp
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "fdbclient/GlobalConfig.actor.h"
+
+#include "flow/actorcompiler.h"  // This must be the last #include.
+
+GlobalConfig::GlobalConfig() : lastUpdate(0) {}
+
+void GlobalConfig::create(DatabaseContext* cx, Reference<AsyncVar<ClientDBInfo>> dbInfo) {
+	auto config = new GlobalConfig{}; // TODO: memory leak?
+	config->cx = Database(cx);
+	g_network->setGlobal(INetwork::enGlobalConfig, config);
+	config->_updater = updater(config, dbInfo);
+}
+
+GlobalConfig& GlobalConfig::globalConfig() {
+	void* res = g_network->global(INetwork::enGlobalConfig);
+	ASSERT(res);
+	return *reinterpret_cast<GlobalConfig*>(res);
+}
+
+const std::any GlobalConfig::get(StringRef name) {
+	auto it = data.find(name);
+	if (it == data.end()) {
+		return nullptr;
+	}
+	return it->second;
+}
+
+Future<Void> GlobalConfig::onInitialized() {
+	return initialized.getFuture();
+}
+
+void GlobalConfig::insert(KeyRef key, ValueRef value) {
+	Tuple t = Tuple::unpack(value);
+	// TODO: Add more Tuple types
+	if (t.getType(0) == Tuple::ElementType::UTF8) {
+		data[key] = t.getString(0);
+	} else if (t.getType(0) == Tuple::ElementType::INT) {
+		data[key] = t.getInt(0);
+	}
+}

--- a/fdbclient/GlobalConfig.actor.cpp
+++ b/fdbclient/GlobalConfig.actor.cpp
@@ -129,13 +129,8 @@ ACTOR Future<Void> GlobalConfig::updater(GlobalConfig* self, Reference<AsyncVar<
 				// history updates or the protocol version changed, so it
 				// must re-read the entire configuration range.
 				wait(self->refresh(self));
-				// TODO: This check is a temporary fix while old functionality
-				// for setting ClientDBInfo fields exist, but eventually it
-				// should be replaced with an assert that the size of `history`
-				// is greater than 0.
-				if (dbInfo->get().history.size() > 0) {
-					self->lastUpdate = dbInfo->get().history.back().contents().first;
-				}
+				ASSERT(dbInfo->get().history.size() > 0);
+				self->lastUpdate = dbInfo->get().history.back().contents().first;
 			} else {
 				// Apply history in order, from lowest version to highest
 				// version. Mutation history should already be stored in

--- a/fdbclient/GlobalConfig.actor.cpp
+++ b/fdbclient/GlobalConfig.actor.cpp
@@ -129,8 +129,9 @@ ACTOR Future<Void> GlobalConfig::updater(GlobalConfig* self, Reference<AsyncVar<
 				// history updates or the protocol version changed, so it
 				// must re-read the entire configuration range.
 				wait(self->refresh(self));
-				ASSERT(dbInfo->get().history.size() > 0);
-				self->lastUpdate = dbInfo->get().history.back().contents().first;
+				if (dbInfo->get().history.size() > 0) {
+					self->lastUpdate = dbInfo->get().history.back().contents().first;
+				}
 			} else {
 				// Apply history in order, from lowest version to highest
 				// version. Mutation history should already be stored in

--- a/fdbclient/GlobalConfig.actor.cpp
+++ b/fdbclient/GlobalConfig.actor.cpp
@@ -40,7 +40,7 @@ GlobalConfig& GlobalConfig::globalConfig() {
 const std::any GlobalConfig::get(StringRef name) {
 	auto it = data.find(name);
 	if (it == data.end()) {
-		return nullptr;
+		return std::any{};
 	}
 	return it->second;
 }
@@ -51,10 +51,15 @@ Future<Void> GlobalConfig::onInitialized() {
 
 void GlobalConfig::insert(KeyRef key, ValueRef value) {
 	Tuple t = Tuple::unpack(value);
-	// TODO: Add more Tuple types
 	if (t.getType(0) == Tuple::ElementType::UTF8) {
 		data[key] = t.getString(0);
 	} else if (t.getType(0) == Tuple::ElementType::INT) {
 		data[key] = t.getInt(0);
+	} else if (t.getType(0) == Tuple::ElementType::FLOAT) {
+		data[key] = t.getFloat(0);
+	} else if (t.getType(0) == Tuple::ElementType::DOUBLE) {
+		data[key] = t.getDouble(0);
+	} else {
+		ASSERT(false);
 	}
 }

--- a/fdbclient/GlobalConfig.actor.cpp
+++ b/fdbclient/GlobalConfig.actor.cpp
@@ -72,7 +72,7 @@ Future<Void> GlobalConfig::onInitialized() {
 }
 
 void GlobalConfig::insert(KeyRef key, ValueRef value) {
-	Arena arena(1);
+	Arena arena(key.expectedSize() + value.expectedSize());
 	KeyRef stableKey = KeyRef(arena, key);
 	try {
 		Tuple t = Tuple::unpack(value);

--- a/fdbclient/GlobalConfig.actor.cpp
+++ b/fdbclient/GlobalConfig.actor.cpp
@@ -19,6 +19,10 @@
  */
 
 #include "fdbclient/GlobalConfig.actor.h"
+#include "fdbclient/SystemData.h"
+#include "fdbclient/Tuple.h"
+#include "flow/flow.h"
+#include "flow/genericactors.actor.h"
 
 #include "flow/actorcompiler.h"  // This must be the last #include.
 
@@ -61,17 +65,21 @@ Future<Void> GlobalConfig::onInitialized() {
 
 void GlobalConfig::insert(KeyRef key, ValueRef value) {
 	KeyRef stableKey = KeyRef(arena, key);
-	Tuple t = Tuple::unpack(value);
-	if (t.getType(0) == Tuple::ElementType::UTF8) {
-		data[stableKey] = t.getString(0);
-	} else if (t.getType(0) == Tuple::ElementType::INT) {
-		data[stableKey] = t.getInt(0);
-	} else if (t.getType(0) == Tuple::ElementType::FLOAT) {
-		data[stableKey] = t.getFloat(0);
-	} else if (t.getType(0) == Tuple::ElementType::DOUBLE) {
-		data[stableKey] = t.getDouble(0);
-	} else {
-		ASSERT(false);
+	try {
+		Tuple t = Tuple::unpack(value);
+		if (t.getType(0) == Tuple::ElementType::UTF8) {
+			data[stableKey] = t.getString(0);
+		} else if (t.getType(0) == Tuple::ElementType::INT) {
+			data[stableKey] = t.getInt(0);
+		} else if (t.getType(0) == Tuple::ElementType::FLOAT) {
+			data[stableKey] = t.getFloat(0);
+		} else if (t.getType(0) == Tuple::ElementType::DOUBLE) {
+			data[stableKey] = t.getDouble(0);
+		} else {
+			ASSERT(false);
+		}
+	} catch (Error& e) {
+		TraceEvent("GlobalConfigTupleError").detail("What", e.what());
 	}
 }
 

--- a/fdbclient/GlobalConfig.actor.cpp
+++ b/fdbclient/GlobalConfig.actor.cpp
@@ -28,11 +28,11 @@
 
 #include "flow/actorcompiler.h"  // This must be the last #include.
 
-const KeyRef fdbClientInfoTxnSampleRate = LiteralStringRef("config/fdbClientInfo/client_txn_sample_rate");
-const KeyRef fdbClientInfoTxnSizeLimit = LiteralStringRef("config/fdbClientInfo/client_txn_size_limit");
+const KeyRef fdbClientInfoTxnSampleRate = LiteralStringRef("config/fdb_client_info/client_txn_sample_rate");
+const KeyRef fdbClientInfoTxnSizeLimit = LiteralStringRef("config/fdb_client_info/client_txn_size_limit");
 
-const KeyRef transactionTagSampleRate = LiteralStringRef("config/transactionTagSampleRate");
-const KeyRef transactionTagSampleCost = LiteralStringRef("config/transactionTagSampleCost");
+const KeyRef transactionTagSampleRate = LiteralStringRef("config/transaction_tag_sample_rate");
+const KeyRef transactionTagSampleCost = LiteralStringRef("config/transaction_tag_sample_cost");
 
 GlobalConfig::GlobalConfig() : lastUpdate(0) {}
 

--- a/fdbclient/GlobalConfig.actor.cpp
+++ b/fdbclient/GlobalConfig.actor.cpp
@@ -103,7 +103,7 @@ ACTOR Future<Void> GlobalConfig::refresh(GlobalConfig* self) {
 	Transaction tr(self->cx);
 	Standalone<RangeResultRef> result = wait(tr.getRange(globalConfigDataKeys, CLIENT_KNOBS->TOO_MANY));
 	for (const auto& kv : result) {
-		KeyRef systemKey = kv.key.removePrefix(globalConfigDataPrefix);
+		KeyRef systemKey = kv.key.removePrefix(globalConfigKeysPrefix);
 		self->insert(systemKey, kv.value);
 	}
 	return Void();

--- a/fdbclient/GlobalConfig.actor.h
+++ b/fdbclient/GlobalConfig.actor.h
@@ -60,6 +60,10 @@ public:
 	static void create(DatabaseContext* cx, Reference<AsyncVar<ClientDBInfo>> dbInfo);
 	static GlobalConfig& globalConfig();
 
+	// Use this function to turn a global configuration key defined above into
+	// the full path needed to set the value in the database.
+	static Key prefixedKey(KeyRef key);
+
 	// Get a value from the framework. Values are returned in a ConfigValue
 	// struct which also contains a reference to the arena containing the
 	// memory for the object. As long as the caller keeps a reference to the

--- a/fdbclient/GlobalConfig.actor.h
+++ b/fdbclient/GlobalConfig.actor.h
@@ -60,19 +60,17 @@ public:
 	static void create(DatabaseContext* cx, Reference<AsyncVar<ClientDBInfo>> dbInfo);
 	static GlobalConfig& globalConfig();
 
+	// Get a value from the framework. Values are returned in a ConfigValue
+	// struct which also contains a reference to the arena containing the
+	// memory for the object. As long as the caller keeps a reference to the
+	// returned ConfigValue, the value is guaranteed to be readable (if it
+	// exists).
 	const ConfigValue get(KeyRef name);
 	const std::map<KeyRef, ConfigValue> get(KeyRangeRef range);
 
-	template <typename T, typename std::enable_if<std::is_arithmetic<T>{}, bool>::type = true>
-	const T get(KeyRef name) {
-		try {
-			auto any = get(name).value;
-			return std::any_cast<T>(any);
-		} catch (Error& e) {
-			throw;
-		}
-	}
-
+	// For arithmetic value types, returns a copy of the value for the given
+	// key, or the supplied default value if the framework does not know about
+	// the key.
 	template <typename T, typename std::enable_if<std::is_arithmetic<T>{}, bool>::type = true>
 	const T get(KeyRef name, T defaultVal) {
 		try {

--- a/fdbclient/GlobalConfig.actor.h
+++ b/fdbclient/GlobalConfig.actor.h
@@ -32,13 +32,12 @@
 
 #include "fdbclient/CommitProxyInterface.h"
 #include "fdbclient/ReadYourWrites.h"
-#include "fdbclient/SystemData.h"
-#include "fdbclient/Tuple.h"
-#include "flow/flow.h"
-#include "flow/genericactors.actor.h"
-#include "flow/Knobs.h"
 
 #include "flow/actorcompiler.h" // has to be last include
+
+// The global configuration is a series of typed key-value pairs synced to all
+// nodes (server and client) in an FDB cluster in an eventually consistent
+// manner.
 
 class GlobalConfig {
 public:
@@ -51,6 +50,10 @@ public:
 
 	const std::any get(KeyRef name);
 	const std::map<KeyRef, std::any> get(KeyRangeRef range);
+
+	// To write into the global configuration, submit a transaction to
+	// \xff\xff/global_config/<your-key> with <your-value> encoded using the
+	// FDB tuple typecodes.
 
 	Future<Void> onInitialized();
 

--- a/fdbclient/GlobalConfig.actor.h
+++ b/fdbclient/GlobalConfig.actor.h
@@ -48,7 +48,6 @@ extern const KeyRef transactionTagSampleCost;
 
 class GlobalConfig {
 public:
-	GlobalConfig();
 	GlobalConfig(const GlobalConfig&) = delete;
 	GlobalConfig& operator=(const GlobalConfig&) = delete;
 
@@ -85,6 +84,8 @@ public:
 	Future<Void> onInitialized();
 
 private:
+	GlobalConfig();
+
 	void insert(KeyRef key, ValueRef value);
 	void erase(KeyRef key);
 	void erase(KeyRangeRef range);

--- a/fdbclient/GlobalConfig.actor.h
+++ b/fdbclient/GlobalConfig.actor.h
@@ -132,6 +132,7 @@ private:
 	// of the global configuration keyspace.
 	void erase(KeyRangeRef range);
 
+	ACTOR static Future<Void> migrate(GlobalConfig* self);
 	ACTOR static Future<Void> refresh(GlobalConfig* self);
 	ACTOR static Future<Void> updater(GlobalConfig* self, Reference<AsyncVar<ClientDBInfo>> dbInfo);
 

--- a/fdbclient/GlobalConfig.actor.h
+++ b/fdbclient/GlobalConfig.actor.h
@@ -1,0 +1,132 @@
+/*
+ * GlobalConfig.actor.h
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#if defined(NO_INTELLISENSE) && !defined(FDBCLIENT_GLOBALCONFIG_ACTOR_G_H)
+#define FDBCLIENT_GLOBALCONFIG_ACTOR_G_H
+#include "fdbclient/GlobalConfig.actor.g.h"
+#elif !defined(FDBCLIENT_GLOBALCONFIG_ACTOR_H)
+#define FDBCLIENT_GLOBALCONFIG_ACTOR_H
+
+#include <any>
+#include <unordered_map>
+
+#include "fdbclient/CommitProxyInterface.h"
+#include "fdbclient/ReadYourWrites.h"
+#include "fdbclient/SystemData.h"
+#include "fdbclient/Tuple.h"
+#include "flow/flow.h"
+#include "flow/genericactors.actor.h"
+#include "flow/Knobs.h"
+
+#include "flow/actorcompiler.h" // has to be last include
+
+class GlobalConfig {
+public:
+	GlobalConfig();
+	GlobalConfig(const GlobalConfig&) = delete;
+	GlobalConfig& operator=(const GlobalConfig&) = delete;
+
+	static void create(DatabaseContext* cx, Reference<AsyncVar<ClientDBInfo>> dbInfo);
+	static GlobalConfig& globalConfig();
+	const std::any get(StringRef name);
+	Future<Void> onInitialized();
+
+private:
+	void insert(KeyRef key, ValueRef value);
+
+	ACTOR static Future<Void> refresh(GlobalConfig* self) {
+		Transaction tr(self->cx);
+		Standalone<RangeResultRef> result = wait(tr.getRange(globalConfigDataKeys, CLIENT_KNOBS->TOO_MANY));
+		for (const auto& kv : result) {
+			KeyRef systemKey = kv.key.removePrefix(globalConfigDataPrefix);
+			self->insert(systemKey, kv.value);
+		}
+		return Void();
+	}
+
+	ACTOR static Future<Void> updater(GlobalConfig* self, Reference<AsyncVar<ClientDBInfo>> dbInfo) {
+		wait(refresh(self));
+		self->initialized.send(Void());
+
+		loop {
+			try {
+				wait(dbInfo->onChange());
+
+				auto& history = dbInfo->get().history;
+				if (history.size() == 0 || (self->lastUpdate < history[0].first && self->lastUpdate != 0)) {
+					// This process missed too many global configuration
+					// history updates or the protocol version changed, so it
+					// must re-read the entire configuration range.
+					wait(refresh(self));
+					self->lastUpdate = dbInfo->get().history.back().contents().first;
+				} else {
+					// Apply history in order, from lowest version to highest
+					// version. Mutation history should already be stored in
+					// ascending version order.
+					for (int i = 0; i < history.size(); ++i) {
+						std::pair<Version, VectorRef<MutationRef>> pair = history[i].contents();
+
+						Version version = pair.first;
+						if (version <= self->lastUpdate) {
+							continue;  // already applied this mutation
+						}
+
+						VectorRef<MutationRef>& mutations = pair.second;
+						for (const auto& mutation : mutations) {
+							if (mutation.type == MutationRef::SetValue) {
+								self->insert(mutation.param1, mutation.param2);
+							} else if (mutation.type == MutationRef::ClearRange) {
+								// TODO: Could be optimized if using std::map..
+								KeyRangeRef range(mutation.param1, mutation.param2);
+								auto it = self->data.begin();
+								while (it != self->data.end()) {
+									if (range.contains(it->first)) {
+										it = self->data.erase(it);
+									} else {
+										++it;
+									}
+								}
+							} else {
+								ASSERT(false);
+							}
+						}
+
+						ASSERT(version > self->lastUpdate);
+						self->lastUpdate = version;
+					}
+				}
+			} catch (Error& e) {
+				throw;
+			}
+		}
+	}
+
+	Database cx;
+	Future<Void> _updater;
+	Promise<Void> initialized;
+	// TODO: Arena to store all data in
+	// TODO: Change to std::map for faster range access
+	std::unordered_map<StringRef, std::any> data;
+	Version lastUpdate;
+};
+
+#endif

--- a/fdbclient/GlobalConfig.actor.h
+++ b/fdbclient/GlobalConfig.actor.h
@@ -39,6 +39,13 @@
 // nodes (server and client) in an FDB cluster in an eventually consistent
 // manner.
 
+// Keys
+extern const KeyRef fdbClientInfoTxnSampleRate;
+extern const KeyRef fdbClientInfoTxnSizeLimit;
+
+extern const KeyRef transactionTagSampleRate;
+extern const KeyRef transactionTagSampleCost;
+
 class GlobalConfig {
 public:
 	GlobalConfig();
@@ -50,6 +57,26 @@ public:
 
 	const std::any get(KeyRef name);
 	const std::map<KeyRef, std::any> get(KeyRangeRef range);
+
+	template <typename T>
+	const T get(KeyRef name) {
+		try {
+			auto any = get(name);
+			return std::any_cast<T>(any);
+		} catch (Error& e) {
+			throw;
+		}
+	}
+
+	template <typename T>
+	const T get(KeyRef name, T defaultVal) {
+		auto any = get(name);
+		if (any.has_value()) {
+			return std::any_cast<T>(any);
+		}
+
+		return defaultVal;
+	}
 
 	// To write into the global configuration, submit a transaction to
 	// \xff\xff/global_config/<your-key> with <your-value> encoded using the

--- a/fdbclient/GlobalConfig.actor.h
+++ b/fdbclient/GlobalConfig.actor.h
@@ -32,6 +32,7 @@
 #include <unordered_map>
 
 #include "fdbclient/CommitProxyInterface.h"
+#include "fdbclient/GlobalConfig.h"
 #include "fdbclient/ReadYourWrites.h"
 
 #include "flow/actorcompiler.h" // has to be last include
@@ -62,6 +63,8 @@ public:
 
 	// Use this function to turn a global configuration key defined above into
 	// the full path needed to set the value in the database.
+	//
+	// For example, given "config/a", returns "\xff\xff/global_config/config/a".
 	static Key prefixedKey(KeyRef key);
 
 	// Get a value from the framework. Values are returned in a ConfigValue
@@ -91,8 +94,11 @@ public:
 
 	// To write into the global configuration, submit a transaction to
 	// \xff\xff/global_config/<your-key> with <your-value> encoded using the
-	// FDB tuple typecodes.
+	// FDB tuple typecodes. Use the helper function `prefixedKey` to correctly
+	// prefix your global configuration key.
 
+	// Triggers the returned future when the global configuration singleton has
+	// been created and is ready.
 	Future<Void> onInitialized();
 
 private:

--- a/fdbclient/GlobalConfig.h
+++ b/fdbclient/GlobalConfig.h
@@ -28,6 +28,9 @@
 struct VersionHistory {
 	constexpr static FileIdentifier file_identifier = 5863456;
 
+	VersionHistory() {}
+	VersionHistory(Version v) : version(v) {}
+
 	Version version;
 	Standalone<VectorRef<MutationRef>> mutations;
 

--- a/fdbclient/GlobalConfig.h
+++ b/fdbclient/GlobalConfig.h
@@ -1,0 +1,45 @@
+/*
+ * GlobalConfig.h
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "fdbclient/CommitTransaction.h"
+#include "fdbclient/FDBTypes.h"
+
+// Used to store a list of mutations made to the global configuration at a
+// specific version.
+struct VersionHistory {
+	constexpr static FileIdentifier file_identifier = 5863456;
+
+	Version version;
+	Standalone<VectorRef<MutationRef>> mutations;
+
+	bool operator<(const VersionHistory& other) const { return version < other.version; }
+
+	int expectedSize() const { return sizeof(version) + mutations.expectedSize(); }
+
+	template <typename Ar>
+	void serialize(Ar& ar) {
+		// The version is not serialized because this object is only sent over
+		// the network during a write. In this case, the version is included in
+		// the key, while this object will be written to the value.
+		serializer(ar, mutations);
+	}
+};

--- a/fdbclient/GlobalConfig.h
+++ b/fdbclient/GlobalConfig.h
@@ -37,9 +37,6 @@ struct VersionHistory {
 
 	template <typename Ar>
 	void serialize(Ar& ar) {
-		// The version is not serialized because this object is only sent over
-		// the network during a write. In this case, the version is included in
-		// the key, while this object will be written to the value.
-		serializer(ar, mutations);
+		serializer(ar, mutations, version);
 	}
 };

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -5380,9 +5380,8 @@ void Transaction::checkDeferredError() {
 
 Reference<TransactionLogInfo> Transaction::createTrLogInfoProbabilistically(const Database& cx) {
 	if (!cx->isError()) {
-		double sampleRate = GlobalConfig::globalConfig().get<double>(fdbClientInfoTxnSampleRate,
-		                                                             std::numeric_limits<double>::infinity());
-		double clientSamplingProbability = std::isinf(sampleRate) ? CLIENT_KNOBS->CSI_SAMPLING_PROBABILITY : sampleRate;
+		double clientSamplingProbability = GlobalConfig::globalConfig().get<double>(
+		    fdbClientInfoTxnSampleRate, CLIENT_KNOBS->CSI_SAMPLING_PROBABILITY);
 		if (((networkOptions.logClientInfo.present() && networkOptions.logClientInfo.get()) || BUGGIFY) &&
 		    deterministicRandom()->random01() < clientSamplingProbability &&
 		    (!g_network->isSimulated() || !g_simulator.speedUpSimulation)) {

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -509,7 +509,7 @@ ACTOR static Future<Void> clientStatusUpdateActor(DatabaseContext* cx) {
 			wait(GlobalConfig::globalConfig().onInitialized());
 			double sampleRate = GlobalConfig::globalConfig().get<double>(fdbClientInfoTxnSampleRate, std::numeric_limits<double>::infinity());
 			double clientSamplingProbability = std::isinf(sampleRate) ? CLIENT_KNOBS->CSI_SAMPLING_PROBABILITY : sampleRate;
-			double sizeLimit = GlobalConfig::globalConfig().get<double>(fdbClientInfoTxnSizeLimit, -1);
+			int64_t sizeLimit = GlobalConfig::globalConfig().get<int64_t>(fdbClientInfoTxnSizeLimit, -1);
 			int64_t clientTxnInfoSizeLimit = sizeLimit == -1 ? CLIENT_KNOBS->CSI_SIZE_LIMIT : sizeLimit;
 			if (!trChunksQ.empty() && deterministicRandom()->random01() < clientSamplingProbability)
 				wait(delExcessClntTxnEntriesActor(&tr, clientTxnInfoSizeLimit));

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -507,8 +507,10 @@ ACTOR static Future<Void> clientStatusUpdateActor(DatabaseContext* cx) {
 			}
 			cx->clientStatusUpdater.outStatusQ.clear();
 			wait(GlobalConfig::globalConfig().onInitialized());
-			double sampleRate = GlobalConfig::globalConfig().get<double>(fdbClientInfoTxnSampleRate, std::numeric_limits<double>::infinity());
-			double clientSamplingProbability = std::isinf(sampleRate) ? CLIENT_KNOBS->CSI_SAMPLING_PROBABILITY : sampleRate;
+			double sampleRate = GlobalConfig::globalConfig().get<double>(fdbClientInfoTxnSampleRate,
+			                                                             std::numeric_limits<double>::infinity());
+			double clientSamplingProbability =
+			    std::isinf(sampleRate) ? CLIENT_KNOBS->CSI_SAMPLING_PROBABILITY : sampleRate;
 			int64_t sizeLimit = GlobalConfig::globalConfig().get<int64_t>(fdbClientInfoTxnSizeLimit, -1);
 			int64_t clientTxnInfoSizeLimit = sizeLimit == -1 ? CLIENT_KNOBS->CSI_SIZE_LIMIT : sizeLimit;
 			if (!trChunksQ.empty() && deterministicRandom()->random01() < clientSamplingProbability)
@@ -1277,8 +1279,10 @@ bool DatabaseContext::sampleReadTags() const {
 }
 
 bool DatabaseContext::sampleOnCost(uint64_t cost) const {
-	double sampleCost = GlobalConfig::globalConfig().get<double>(transactionTagSampleCost, CLIENT_KNOBS->COMMIT_SAMPLE_COST);
-	if (sampleCost <= 0) return false;
+	double sampleCost =
+	    GlobalConfig::globalConfig().get<double>(transactionTagSampleCost, CLIENT_KNOBS->COMMIT_SAMPLE_COST);
+	if (sampleCost <= 0)
+		return false;
 	return deterministicRandom()->random01() <= (double)cost / sampleCost;
 }
 
@@ -5374,11 +5378,14 @@ void Transaction::checkDeferredError() {
 	cx->checkDeferredError();
 }
 
-Reference<TransactionLogInfo> Transaction::createTrLogInfoProbabilistically(const Database &cx) {
-	if(!cx->isError()) {
-		double sampleRate = GlobalConfig::globalConfig().get<double>(fdbClientInfoTxnSampleRate, std::numeric_limits<double>::infinity());
+Reference<TransactionLogInfo> Transaction::createTrLogInfoProbabilistically(const Database& cx) {
+	if (!cx->isError()) {
+		double sampleRate = GlobalConfig::globalConfig().get<double>(fdbClientInfoTxnSampleRate,
+		                                                             std::numeric_limits<double>::infinity());
 		double clientSamplingProbability = std::isinf(sampleRate) ? CLIENT_KNOBS->CSI_SAMPLING_PROBABILITY : sampleRate;
-		if (((networkOptions.logClientInfo.present() && networkOptions.logClientInfo.get()) || BUGGIFY) && deterministicRandom()->random01() < clientSamplingProbability && (!g_network->isSimulated() || !g_simulator.speedUpSimulation)) {
+		if (((networkOptions.logClientInfo.present() && networkOptions.logClientInfo.get()) || BUGGIFY) &&
+		    deterministicRandom()->random01() < clientSamplingProbability &&
+		    (!g_network->isSimulated() || !g_simulator.speedUpSimulation)) {
 			return makeReference<TransactionLogInfo>(TransactionLogInfo::DATABASE);
 		}
 	}

--- a/fdbclient/SpecialKeySpace.actor.cpp
+++ b/fdbclient/SpecialKeySpace.actor.cpp
@@ -1380,22 +1380,22 @@ Future<Standalone<RangeResultRef>> GlobalConfigImpl::getRange(ReadYourWritesTran
 	auto& globalConfig = GlobalConfig::globalConfig();
 	KeyRangeRef modified =
 	    KeyRangeRef(kr.begin.removePrefix(getKeyRange().begin), kr.end.removePrefix(getKeyRange().begin));
-	std::map<KeyRef, ConfigValue> values = globalConfig.get(modified);
+	std::map<KeyRef, Reference<ConfigValue>> values = globalConfig.get(modified);
 	for (const auto& [key, config] : values) {
 		Key prefixedKey = key.withPrefix(getKeyRange().begin);
-		if (config.value.has_value()) {
-			if (config.value.type() == typeid(StringRef)) {
+		if (config.isValid() && config->value.has_value()) {
+			if (config->value.type() == typeid(StringRef)) {
 				result.push_back_deep(result.arena(),
-				                      KeyValueRef(prefixedKey, std::any_cast<StringRef>(config.value).toString()));
-			} else if (config.value.type() == typeid(int64_t)) {
+				                      KeyValueRef(prefixedKey, std::any_cast<StringRef>(config->value).toString()));
+			} else if (config->value.type() == typeid(int64_t)) {
 				result.push_back_deep(result.arena(),
-				                      KeyValueRef(prefixedKey, std::to_string(std::any_cast<int64_t>(config.value))));
-			} else if (config.value.type() == typeid(float)) {
+				                      KeyValueRef(prefixedKey, std::to_string(std::any_cast<int64_t>(config->value))));
+			} else if (config->value.type() == typeid(float)) {
 				result.push_back_deep(result.arena(),
-				                      KeyValueRef(prefixedKey, std::to_string(std::any_cast<float>(config.value))));
-			} else if (config.value.type() == typeid(double)) {
+				                      KeyValueRef(prefixedKey, std::to_string(std::any_cast<float>(config->value))));
+			} else if (config->value.type() == typeid(double)) {
 				result.push_back_deep(result.arena(),
-				                      KeyValueRef(prefixedKey, std::to_string(std::any_cast<double>(config.value))));
+				                      KeyValueRef(prefixedKey, std::to_string(std::any_cast<double>(config->value))));
 			} else {
 				ASSERT(false);
 			}

--- a/fdbclient/SpecialKeySpace.actor.cpp
+++ b/fdbclient/SpecialKeySpace.actor.cpp
@@ -1378,19 +1378,24 @@ Future<Standalone<RangeResultRef>> GlobalConfigImpl::getRange(ReadYourWritesTran
 	Standalone<RangeResultRef> result;
 
 	auto& globalConfig = GlobalConfig::globalConfig();
-	KeyRangeRef modified = KeyRangeRef(kr.begin.removePrefix(getKeyRange().begin), kr.end.removePrefix(getKeyRange().begin));
+	KeyRangeRef modified =
+	    KeyRangeRef(kr.begin.removePrefix(getKeyRange().begin), kr.end.removePrefix(getKeyRange().begin));
 	std::map<KeyRef, ConfigValue> values = globalConfig.get(modified);
 	for (const auto& [key, config] : values) {
 		Key prefixedKey = key.withPrefix(getKeyRange().begin);
 		if (config.value.has_value()) {
 			if (config.value.type() == typeid(StringRef)) {
-				result.push_back_deep(result.arena(), KeyValueRef(prefixedKey, std::any_cast<StringRef>(config.value).toString()));
+				result.push_back_deep(result.arena(),
+				                      KeyValueRef(prefixedKey, std::any_cast<StringRef>(config.value).toString()));
 			} else if (config.value.type() == typeid(int64_t)) {
-				result.push_back_deep(result.arena(), KeyValueRef(prefixedKey, std::to_string(std::any_cast<int64_t>(config.value))));
+				result.push_back_deep(result.arena(),
+				                      KeyValueRef(prefixedKey, std::to_string(std::any_cast<int64_t>(config.value))));
 			} else if (config.value.type() == typeid(float)) {
-				result.push_back_deep(result.arena(), KeyValueRef(prefixedKey, std::to_string(std::any_cast<float>(config.value))));
+				result.push_back_deep(result.arena(),
+				                      KeyValueRef(prefixedKey, std::to_string(std::any_cast<float>(config.value))));
 			} else if (config.value.type() == typeid(double)) {
-				result.push_back_deep(result.arena(), KeyValueRef(prefixedKey, std::to_string(std::any_cast<double>(config.value))));
+				result.push_back_deep(result.arena(),
+				                      KeyValueRef(prefixedKey, std::to_string(std::any_cast<double>(config.value))));
 			} else {
 				ASSERT(false);
 			}

--- a/fdbclient/SpecialKeySpace.actor.cpp
+++ b/fdbclient/SpecialKeySpace.actor.cpp
@@ -1377,8 +1377,7 @@ GlobalConfigImpl::GlobalConfigImpl(KeyRangeRef kr) : SpecialKeyRangeRWImpl(kr) {
 // framework within the range specified. The special-key-space getrange
 // function should only be used for informational purposes. All values are
 // returned as strings regardless of their true type.
-Future<Standalone<RangeResultRef>> GlobalConfigImpl::getRange(ReadYourWritesTransaction* ryw,
-                                                              KeyRangeRef kr) const {
+Future<Standalone<RangeResultRef>> GlobalConfigImpl::getRange(ReadYourWritesTransaction* ryw, KeyRangeRef kr) const {
 	Standalone<RangeResultRef> result;
 
 	auto& globalConfig = GlobalConfig::globalConfig();
@@ -1417,7 +1416,8 @@ void GlobalConfigImpl::set(ReadYourWritesTransaction* ryw, const KeyRef& key, co
 // Writes global configuration changes to durable memory. Also writes the
 // changes made in the transaction to a recent history set, and updates the
 // latest version which the global configuration was updated at.
-ACTOR Future<Optional<std::string>> globalConfigCommitActor(GlobalConfigImpl* globalConfig, ReadYourWritesTransaction* ryw) {
+ACTOR Future<Optional<std::string>> globalConfigCommitActor(GlobalConfigImpl* globalConfig,
+                                                            ReadYourWritesTransaction* ryw) {
 	state Transaction& tr = ryw->getTransaction();
 
 	// History should only contain three most recent updates. If it currently
@@ -1494,8 +1494,7 @@ void GlobalConfigImpl::clear(ReadYourWritesTransaction* ryw, const KeyRef& key) 
 
 TracingOptionsImpl::TracingOptionsImpl(KeyRangeRef kr) : SpecialKeyRangeRWImpl(kr) {}
 
-Future<Standalone<RangeResultRef>> TracingOptionsImpl::getRange(ReadYourWritesTransaction* ryw,
-                                                                KeyRangeRef kr) const {
+Future<Standalone<RangeResultRef>> TracingOptionsImpl::getRange(ReadYourWritesTransaction* ryw, KeyRangeRef kr) const {
 	Standalone<RangeResultRef> result;
 	for (const auto& option : SpecialKeySpace::getTracingOptions()) {
 		auto key = getKeyRange().begin.withSuffix(option);

--- a/fdbclient/SpecialKeySpace.actor.cpp
+++ b/fdbclient/SpecialKeySpace.actor.cpp
@@ -1434,6 +1434,7 @@ ACTOR Future<Optional<std::string>> globalConfigCommitActor(GlobalConfigImpl* gl
 		//   clear_range(\xff/globalConfig/h, \xff/globalConfig/h/1000) results
 		//   in zero key-value pairs being deleted (999 is lexicographically
 		//   larger than 1000, and the range is exclusive).
+		// Delete the oldest key(s) in the history to make room for new data.
 		for (int i = 0; i < keys.size() - (kGlobalConfigMaxHistorySize - 1); ++i) {
 			tr.clear(keys[i]);
 		}

--- a/fdbclient/SpecialKeySpace.actor.cpp
+++ b/fdbclient/SpecialKeySpace.actor.cpp
@@ -1379,18 +1379,18 @@ Future<Standalone<RangeResultRef>> GlobalConfigImpl::getRange(ReadYourWritesTran
 
 	auto& globalConfig = GlobalConfig::globalConfig();
 	KeyRangeRef modified = KeyRangeRef(kr.begin.removePrefix(getKeyRange().begin), kr.end.removePrefix(getKeyRange().begin));
-	std::map<KeyRef, std::any> values = globalConfig.get(modified);
-	for (const auto& [key, any] : values) {
+	std::map<KeyRef, ConfigValue> values = globalConfig.get(modified);
+	for (const auto& [key, config] : values) {
 		Key prefixedKey = key.withPrefix(getKeyRange().begin);
-		if (any.has_value()) {
-			if (any.type() == typeid(Standalone<StringRef>)) {
-				result.push_back_deep(result.arena(), KeyValueRef(prefixedKey, std::any_cast<Standalone<StringRef>>(any).contents()));
-			} else if (any.type() == typeid(int64_t)) {
-				result.push_back_deep(result.arena(), KeyValueRef(prefixedKey, std::to_string(std::any_cast<int64_t>(any))));
-			} else if (any.type() == typeid(float)) {
-				result.push_back_deep(result.arena(), KeyValueRef(prefixedKey, std::to_string(std::any_cast<float>(any))));
-			} else if (any.type() == typeid(double)) {
-				result.push_back_deep(result.arena(), KeyValueRef(prefixedKey, std::to_string(std::any_cast<double>(any))));
+		if (config.value.has_value()) {
+			if (config.value.type() == typeid(StringRef)) {
+				result.push_back_deep(result.arena(), KeyValueRef(prefixedKey, std::any_cast<StringRef>(config.value).toString()));
+			} else if (config.value.type() == typeid(int64_t)) {
+				result.push_back_deep(result.arena(), KeyValueRef(prefixedKey, std::to_string(std::any_cast<int64_t>(config.value))));
+			} else if (config.value.type() == typeid(float)) {
+				result.push_back_deep(result.arena(), KeyValueRef(prefixedKey, std::to_string(std::any_cast<float>(config.value))));
+			} else if (config.value.type() == typeid(double)) {
+				result.push_back_deep(result.arena(), KeyValueRef(prefixedKey, std::to_string(std::any_cast<double>(config.value))));
 			} else {
 				ASSERT(false);
 			}

--- a/fdbclient/SpecialKeySpace.actor.cpp
+++ b/fdbclient/SpecialKeySpace.actor.cpp
@@ -1449,7 +1449,7 @@ ACTOR Future<Optional<std::string>> globalConfigCommitActor(GlobalConfigImpl* gl
 	state RangeMap<Key, std::pair<bool, Optional<Value>>, KeyRangeRef>::iterator iter = ranges.begin();
 	while (iter != ranges.end()) {
 		Key bareKey = iter->begin().removePrefix(globalConfig->getKeyRange().begin);
-		Key systemKey = bareKey.withPrefix(globalConfigDataPrefix);
+		Key systemKey = bareKey.withPrefix(globalConfigKeysPrefix);
 		std::pair<bool, Optional<Value>> entry = iter->value();
 		if (entry.first) {
 			if (entry.second.present()) {
@@ -1497,6 +1497,8 @@ void GlobalConfigImpl::clear(ReadYourWritesTransaction* ryw, const KeyRangeRef& 
 void GlobalConfigImpl::clear(ReadYourWritesTransaction* ryw, const KeyRef& key) {
 	ryw->getSpecialKeySpaceWriteMap().insert(key, std::make_pair(true, Optional<Value>()));
 }
+
+TracingOptionsImpl::TracingOptionsImpl(KeyRangeRef kr) : SpecialKeyRangeRWImpl(kr) {}
 
 Future<Standalone<RangeResultRef>> TracingOptionsImpl::getRange(ReadYourWritesTransaction* ryw,
                                                                 KeyRangeRef kr) const {

--- a/fdbclient/SpecialKeySpace.actor.h
+++ b/fdbclient/SpecialKeySpace.actor.h
@@ -146,6 +146,7 @@ public:
 		CONFIGURATION, // Configuration of the cluster
 		CONNECTIONSTRING,
 		ERRORMSG, // A single key space contains a json string which describes the last error in special-key-space
+		GLOBALCONFIG, // Global configuration options synchronized to all nodes
 		MANAGEMENT, // Management-API
 		METRICS, // data-distribution metrics
 		TESTONLY, // only used by correctness tests
@@ -334,6 +335,16 @@ public:
 	explicit ConsistencyCheckImpl(KeyRangeRef kr);
 	Future<Standalone<RangeResultRef>> getRange(ReadYourWritesTransaction* ryw, KeyRangeRef kr) const override;
 	Future<Optional<std::string>> commit(ReadYourWritesTransaction* ryw) override;
+};
+
+class GlobalConfigImpl : public SpecialKeyRangeRWImpl {
+public:
+	explicit GlobalConfigImpl(KeyRangeRef kr);
+	Future<Standalone<RangeResultRef>> getRange(ReadYourWritesTransaction* ryw, KeyRangeRef kr) const override;
+	void set(ReadYourWritesTransaction* ryw, const KeyRef& key, const ValueRef& value) override;
+	Future<Optional<std::string>> commit(ReadYourWritesTransaction* ryw) override;
+	void clear(ReadYourWritesTransaction* ryw, const KeyRangeRef& range) override;
+	void clear(ReadYourWritesTransaction* ryw, const KeyRef& key) override;
 };
 
 class TracingOptionsImpl : public SpecialKeyRangeRWImpl {

--- a/fdbclient/SystemData.cpp
+++ b/fdbclient/SystemData.cpp
@@ -757,7 +757,8 @@ const KeyRef tagThrottleLimitKey = LiteralStringRef("\xff\x02/throttledTags/manu
 const KeyRef tagThrottleCountKey = LiteralStringRef("\xff\x02/throttledTags/manualThrottleCount");
 
 // Client status info prefix
-const KeyRangeRef fdbClientInfoPrefixRange(LiteralStringRef("\xff\x02/fdbClientInfo/"), LiteralStringRef("\xff\x02/fdbClientInfo0"));
+const KeyRangeRef fdbClientInfoPrefixRange(LiteralStringRef("\xff\x02/fdbClientInfo/"),
+                                           LiteralStringRef("\xff\x02/fdbClientInfo0"));
 // See remaining fields in GlobalConfig.actor.h
 
 // ConsistencyCheck settings

--- a/fdbclient/SystemData.cpp
+++ b/fdbclient/SystemData.cpp
@@ -632,11 +632,11 @@ std::string encodeFailedServersKey(AddressExclusion const& addr) {
 	return failedServersPrefix.toString() + addr.toString();
 }
 
-const KeyRangeRef globalConfigKeys( LiteralStringRef("\xff/globalConfig/"), LiteralStringRef("\xff/globalConfig0") );
-const KeyRef globalConfigPrefix = globalConfigKeys.begin;
+// const KeyRangeRef globalConfigKeys( LiteralStringRef("\xff/globalConfig/"), LiteralStringRef("\xff/globalConfig0") );
+// const KeyRef globalConfigPrefix = globalConfigKeys.begin;
 
 const KeyRangeRef globalConfigDataKeys( LiteralStringRef("\xff/globalConfig/k/"), LiteralStringRef("\xff/globalConfig/k0") );
-const KeyRef globalConfigDataPrefix = globalConfigDataKeys.begin;
+const KeyRef globalConfigKeysPrefix = globalConfigDataKeys.begin;
 
 const KeyRangeRef globalConfigHistoryKeys( LiteralStringRef("\xff/globalConfig/h/"), LiteralStringRef("\xff/globalConfig/h0") );
 const KeyRef globalConfigHistoryPrefix = globalConfigHistoryKeys.begin;

--- a/fdbclient/SystemData.cpp
+++ b/fdbclient/SystemData.cpp
@@ -757,10 +757,8 @@ const KeyRef tagThrottleLimitKey = LiteralStringRef("\xff\x02/throttledTags/manu
 const KeyRef tagThrottleCountKey = LiteralStringRef("\xff\x02/throttledTags/manualThrottleCount");
 
 // Client status info prefix
-const KeyRangeRef fdbClientInfoPrefixRange(LiteralStringRef("\xff\x02/fdbClientInfo/"),
-                                           LiteralStringRef("\xff\x02/fdbClientInfo0"));
-const KeyRef fdbClientInfoTxnSampleRate = LiteralStringRef("\xff\x02/fdbClientInfo/client_txn_sample_rate/");
-const KeyRef fdbClientInfoTxnSizeLimit = LiteralStringRef("\xff\x02/fdbClientInfo/client_txn_size_limit/");
+const KeyRangeRef fdbClientInfoPrefixRange(LiteralStringRef("\xff\x02/fdbClientInfo/"), LiteralStringRef("\xff\x02/fdbClientInfo0"));
+// See remaining fields in GlobalConfig.actor.h
 
 // ConsistencyCheck settings
 const KeyRef fdbShouldConsistencyCheckBeSuspended = LiteralStringRef("\xff\x02/ConsistencyCheck/Suspend");

--- a/fdbclient/SystemData.cpp
+++ b/fdbclient/SystemData.cpp
@@ -632,7 +632,18 @@ std::string encodeFailedServersKey(AddressExclusion const& addr) {
 	return failedServersPrefix.toString() + addr.toString();
 }
 
-const KeyRangeRef workerListKeys(LiteralStringRef("\xff/worker/"), LiteralStringRef("\xff/worker0"));
+const KeyRangeRef globalConfigKeys( LiteralStringRef("\xff/globalConfig/"), LiteralStringRef("\xff/globalConfig0") );
+const KeyRef globalConfigPrefix = globalConfigKeys.begin;
+
+const KeyRangeRef globalConfigDataKeys( LiteralStringRef("\xff/globalConfig/k/"), LiteralStringRef("\xff/globalConfig/k0") );
+const KeyRef globalConfigDataPrefix = globalConfigDataKeys.begin;
+
+const KeyRangeRef globalConfigHistoryKeys( LiteralStringRef("\xff/globalConfig/h/"), LiteralStringRef("\xff/globalConfig/h0") );
+const KeyRef globalConfigHistoryPrefix = globalConfigHistoryKeys.begin;
+
+const KeyRef globalConfigVersionKey = LiteralStringRef("\xff/globalConfig/v");
+
+const KeyRangeRef workerListKeys( LiteralStringRef("\xff/worker/"), LiteralStringRef("\xff/worker0") );
 const KeyRef workerListPrefix = workerListKeys.begin;
 
 const Key workerListKeyFor(StringRef processID) {

--- a/fdbclient/SystemData.h
+++ b/fdbclient/SystemData.h
@@ -249,9 +249,9 @@ extern const KeyRef globalConfigKeysPrefix;
 extern const KeyRangeRef globalConfigHistoryKeys;
 extern const KeyRef globalConfigHistoryPrefix;
 
-//   "\xff/globalConfig/v" := "version,protocol"
-//   Read-only key which returns the version and protocol of the most recent
-//   data written to the global configuration keyspace.
+//   "\xff/globalConfig/v" := "version"
+//   Read-only key which returns the commit version of the most recent mutation
+//   made to the global configuration keyspace.
 extern const KeyRef globalConfigVersionKey;
 
 //	"\xff/workers/[[processID]]" := ""

--- a/fdbclient/SystemData.h
+++ b/fdbclient/SystemData.h
@@ -230,6 +230,30 @@ extern const KeyRef failedServersVersionKey; // The value of this key shall be c
 const AddressExclusion decodeFailedServersKey(KeyRef const& key); // where key.startsWith(failedServersPrefix)
 std::string encodeFailedServersKey(AddressExclusion const&);
 
+//   "\xff/globalConfig/[[option]]" := "value"
+//	 An umbrella prefix for global configuration data synchronized to all nodes.
+extern const KeyRangeRef globalConfigData;
+extern const KeyRef globalConfigDataPrefix;
+
+//   "\xff/globalConfig/k/[[key]]" := "value"
+//	 Key-value pairs that have been set. The range this keyspace represents
+//	 contains all globally configured options.
+extern const KeyRangeRef globalConfigDataKeys;
+extern const KeyRef globalConfigDataPrefix;
+
+//   "\xff/globalConfig/h/[[version]]" := "value"
+//   Maps a commit version to a list of mutations made to the global
+//   configuration at that commit. Shipped to nodes periodically. In general,
+//   clients should not write to keys in this keyspace; it will be written
+//   automatically when updating global configuration keys.
+extern const KeyRangeRef globalConfigHistoryKeys;
+extern const KeyRef globalConfigHistoryPrefix;
+
+//   "\xff/globalConfig/v" := "version,protocol"
+//   Read-only key which returns the version and protocol of the most recent
+//   data written to the global configuration keyspace.
+extern const KeyRef globalConfigVersionKey;
+
 //	"\xff/workers/[[processID]]" := ""
 //	Asynchronously updated by the cluster controller, this is a list of fdbserver processes that have joined the cluster
 //	and are currently (recently) available

--- a/fdbclient/SystemData.h
+++ b/fdbclient/SystemData.h
@@ -379,8 +379,6 @@ extern const KeyRangeRef applyMutationsKeyVersionCountRange;
 
 // FdbClient Info prefix
 extern const KeyRangeRef fdbClientInfoPrefixRange;
-extern const KeyRef fdbClientInfoTxnSampleRate;
-extern const KeyRef fdbClientInfoTxnSizeLimit;
 
 // Consistency Check settings
 extern const KeyRef fdbShouldConsistencyCheckBeSuspended;

--- a/fdbclient/SystemData.h
+++ b/fdbclient/SystemData.h
@@ -232,14 +232,14 @@ std::string encodeFailedServersKey(AddressExclusion const&);
 
 //   "\xff/globalConfig/[[option]]" := "value"
 //	 An umbrella prefix for global configuration data synchronized to all nodes.
-extern const KeyRangeRef globalConfigData;
-extern const KeyRef globalConfigDataPrefix;
+// extern const KeyRangeRef globalConfigData;
+// extern const KeyRef globalConfigDataPrefix;
 
 //   "\xff/globalConfig/k/[[key]]" := "value"
 //	 Key-value pairs that have been set. The range this keyspace represents
 //	 contains all globally configured options.
 extern const KeyRangeRef globalConfigDataKeys;
-extern const KeyRef globalConfigDataPrefix;
+extern const KeyRef globalConfigKeysPrefix;
 
 //   "\xff/globalConfig/h/[[version]]" := "value"
 //   Maps a commit version to a list of mutations made to the global

--- a/fdbclient/Tuple.cpp
+++ b/fdbclient/Tuple.cpp
@@ -44,9 +44,10 @@ static size_t find_string_terminator(const StringRef data, size_t offset) {
 // If encoding and the sign bit is 1 (the number is negative), flip all the bits.
 // If decoding and the sign bit is 0 (the number is negative), flip all the bits.
 // Otherwise, the number is positive, so flip the sign bit.
-static void adjust_floating_point(uint8_t *bytes, size_t size, bool encode) {
-	if((encode && ((uint8_t)(bytes[0] & 0x80) != (uint8_t)0x00)) || (!encode && ((uint8_t)(bytes[0] & 0x80) != (uint8_t)0x80))) {
-		for(size_t i = 0; i < size; i++) {
+static void adjust_floating_point(uint8_t* bytes, size_t size, bool encode) {
+	if ((encode && ((uint8_t)(bytes[0] & 0x80) != (uint8_t)0x00)) ||
+	    (!encode && ((uint8_t)(bytes[0] & 0x80) != (uint8_t)0x80))) {
+		for (size_t i = 0; i < size; i++) {
 			bytes[i] ^= (uint8_t)0xff;
 		}
 	} else {
@@ -65,14 +66,11 @@ Tuple::Tuple(StringRef const& str, bool exclude_incomplete) {
 			i = find_string_terminator(str, i + 1) + 1;
 		} else if (data[i] >= '\x0c' && data[i] <= '\x1c') {
 			i += abs(data[i] - '\x14') + 1;
-		}
-		else if(data[i] == 0x20) {
+		} else if (data[i] == 0x20) {
 			i += sizeof(float) + 1;
-		}
-		else if(data[i] == 0x21) {
+		} else if (data[i] == 0x21) {
 			i += sizeof(double) + 1;
-		}
-		else if(data[i] == '\x00') {
+		} else if (data[i] == '\x00') {
 			i += 1;
 		} else {
 			throw invalid_tuple_data_type();
@@ -145,26 +143,26 @@ Tuple& Tuple::append(int64_t value) {
 	return *this;
 }
 
-Tuple& Tuple::appendFloat( float value ) {
-	offsets.push_back( data.size() );
+Tuple& Tuple::appendFloat(float value) {
+	offsets.push_back(data.size());
 	float swap = bigEndianFloat(value);
-	uint8_t *bytes = (uint8_t*)&swap;
+	uint8_t* bytes = (uint8_t*)&swap;
 	adjust_floating_point(bytes, sizeof(float), true);
 
-	data.push_back( data.arena(), 0x20 );
-	data.append( data.arena(), bytes, sizeof(float) );
+	data.push_back(data.arena(), 0x20);
+	data.append(data.arena(), bytes, sizeof(float));
 	return *this;
 }
 
-Tuple& Tuple::appendDouble( double value ) {
-	offsets.push_back( data.size() );
+Tuple& Tuple::appendDouble(double value) {
+	offsets.push_back(data.size());
 	double swap = value;
 	swap = bigEndianDouble(swap);
-	uint8_t *bytes = (uint8_t*)&swap;
+	uint8_t* bytes = (uint8_t*)&swap;
 	adjust_floating_point(bytes, sizeof(double), true);
 
-	data.push_back( data.arena(), 0x21 );
-	data.append( data.arena(), bytes, sizeof(double) );
+	data.push_back(data.arena(), 0x21);
+	data.append(data.arena(), bytes, sizeof(double));
 	return *this;
 }
 
@@ -189,14 +187,11 @@ Tuple::ElementType Tuple::getType(size_t index) const {
 		return ElementType::UTF8;
 	} else if (code >= '\x0c' && code <= '\x1c') {
 		return ElementType::INT;
-	}
-	else if(code == 0x20) {
+	} else if (code == 0x20) {
 		return ElementType::FLOAT;
-	}
-	else if(code == 0x21) {
+	} else if (code == 0x21) {
 		return ElementType::DOUBLE;
-	}
-	else {
+	} else {
 		throw invalid_tuple_data_type();
 	}
 }
@@ -292,12 +287,12 @@ int64_t Tuple::getInt(size_t index, bool allow_incomplete) const {
 
 // TODO: Combine with bindings/flow/Tuple.*. This code is copied from there.
 float Tuple::getFloat(size_t index) const {
-	if(index >= offsets.size()) {
+	if (index >= offsets.size()) {
 		throw invalid_tuple_index();
 	}
 	ASSERT_LT(offsets[index], data.size());
 	uint8_t code = data[offsets[index]];
-	if(code != 0x20) {
+	if (code != 0x20) {
 		throw invalid_tuple_data_type();
 	}
 
@@ -305,18 +300,18 @@ float Tuple::getFloat(size_t index) const {
 	uint8_t* bytes = (uint8_t*)&swap;
 	ASSERT_LE(offsets[index] + 1 + sizeof(float), data.size());
 	swap = *(float*)(data.begin() + offsets[index] + 1);
-	adjust_floating_point( bytes, sizeof(float), false );
+	adjust_floating_point(bytes, sizeof(float), false);
 
 	return bigEndianFloat(swap);
 }
 
 double Tuple::getDouble(size_t index) const {
-	if(index >= offsets.size()) {
+	if (index >= offsets.size()) {
 		throw invalid_tuple_index();
 	}
 	ASSERT_LT(offsets[index], data.size());
 	uint8_t code = data[offsets[index]];
-	if(code != 0x21) {
+	if (code != 0x21) {
 		throw invalid_tuple_data_type();
 	}
 
@@ -324,7 +319,7 @@ double Tuple::getDouble(size_t index) const {
 	uint8_t* bytes = (uint8_t*)&swap;
 	ASSERT_LE(offsets[index] + 1 + sizeof(double), data.size());
 	swap = *(double*)(data.begin() + offsets[index] + 1);
-	adjust_floating_point( bytes, sizeof(double), false );
+	adjust_floating_point(bytes, sizeof(double), false);
 
 	return bigEndianDouble(swap);
 }

--- a/fdbclient/Tuple.h
+++ b/fdbclient/Tuple.h
@@ -47,7 +47,7 @@ struct Tuple {
 		return append(t);
 	}
 
-	enum ElementType { NULL_TYPE, INT, BYTES, UTF8 };
+	enum ElementType { NULL_TYPE, INT, BYTES, UTF8, FLOAT, DOUBLE };
 
 	// this is number of elements, not length of data
 	size_t size() const { return offsets.size(); }
@@ -55,6 +55,8 @@ struct Tuple {
 	ElementType getType(size_t index) const;
 	Standalone<StringRef> getString(size_t index) const;
 	int64_t getInt(size_t index, bool allow_incomplete = false) const;
+	float getFloat(size_t index) const;
+	double getDouble(size_t index) const;
 
 	KeyRange range(Tuple const& tuple = Tuple()) const;
 

--- a/fdbclient/Tuple.h
+++ b/fdbclient/Tuple.h
@@ -38,6 +38,10 @@ struct Tuple {
 	Tuple& append(Tuple const& tuple);
 	Tuple& append(StringRef const& str, bool utf8 = false);
 	Tuple& append(int64_t);
+	// There are some ambiguous append calls in fdbclient, so to make it easier
+	// to add append for floats and doubles, name them differently for now.
+	Tuple& appendFloat(float);
+	Tuple& appendDouble(double);
 	Tuple& appendNull();
 
 	StringRef pack() const { return StringRef(data.begin(), data.size()); }

--- a/fdbserver/ClusterController.actor.cpp
+++ b/fdbserver/ClusterController.actor.cpp
@@ -3233,10 +3233,10 @@ ACTOR Future<Void> monitorGlobalConfig(ClusterControllerData::DBInfo* db) {
 						historyCommitVersion = bigEndian64(historyCommitVersion);
 						vh.version = historyCommitVersion;
 
-						clientInfo.history.push_back(vh);
+						clientInfo.history.push_back(std::move(vh));
 					}
 
-					clientInfo.id = deterministicRandom()->randomUniqueID();
+					clientInfo.id = UID(deterministicRandom()->randomUniqueID().first(), 123456789);
 					db->clientInfo->set(clientInfo);
 				}
 

--- a/fdbserver/ClusterController.actor.cpp
+++ b/fdbserver/ClusterController.actor.cpp
@@ -3206,7 +3206,6 @@ ACTOR Future<Void> monitorClientTxnInfoConfigs(ClusterControllerData::DBInfo* db
 					state ProtocolVersion protocolVersion;
 					versionReader >> commitVersion >> serializationOrder >> protocolVersion;
 
-					state Arena arena;
 					if (protocolVersion == g_network->protocolVersion()) {
 						Standalone<RangeResultRef> globalConfigHistory = wait(tr.getRange(globalConfigHistoryKeys, CLIENT_KNOBS->TOO_MANY));
 						// If the global configuration version key has been
@@ -3228,7 +3227,7 @@ ACTOR Future<Void> monitorClientTxnInfoConfigs(ClusterControllerData::DBInfo* db
 							BinaryReader mutationReader = BinaryReader(kv.value, AssumeVersion(protocolVersion));
 							VectorRef<MutationRef> mutations;
 							mutationReader >> mutations;
-							data.second = VectorRef(arena, mutations);
+							data.second = VectorRef(data.arena(), mutations);
 
 							clientInfo.history.push_back(data);
 						}

--- a/fdbserver/ClusterController.actor.cpp
+++ b/fdbserver/ClusterController.actor.cpp
@@ -3190,6 +3190,11 @@ ACTOR Future<Void> monitorServerInfoConfig(ClusterControllerData::DBInfo* db) {
 	}
 }
 
+// Monitors the global configuration version key for changes. When changes are
+// made, the global configuration history is read and any updates are sent to
+// all processes in the system by updating the ClientDBInfo object. The
+// GlobalConfig actor class contains the functionality to read the latest
+// history and update the processes local view.
 ACTOR Future<Void> monitorGlobalConfig(ClusterControllerData::DBInfo* db) {
 	loop {
 		state ReadYourWritesTransaction tr(db->db);

--- a/fdbserver/ClusterController.actor.cpp
+++ b/fdbserver/ClusterController.actor.cpp
@@ -2716,7 +2716,7 @@ void clusterRegisterMaster(ClusterControllerData* self, RegisterMasterRequest co
 		clientInfo.id = deterministicRandom()->randomUniqueID();
 		clientInfo.commitProxies = req.commitProxies;
 		clientInfo.grvProxies = req.grvProxies;
-		db->clientInfo->set( clientInfo );
+		db->clientInfo->set(clientInfo);
 		dbInfo.client = db->clientInfo->get();
 	}
 
@@ -3702,25 +3702,29 @@ ACTOR Future<Void> clusterControllerCore(ClusterControllerFullInterface interf,
 	state ClusterControllerData self(interf, locality);
 	state Future<Void> coordinationPingDelay = delay(SERVER_KNOBS->WORKER_COORDINATION_PING_DELAY);
 	state uint64_t step = 0;
-	state Future<ErrorOr<Void>> error = errorOr( actorCollection( self.addActor.getFuture() ) );
+	state Future<ErrorOr<Void>> error = errorOr(actorCollection(self.addActor.getFuture()));
 
-	self.addActor.send( clusterWatchDatabase( &self, &self.db ) );  // Start the master database
-	self.addActor.send( self.updateWorkerList.init( self.db.db ) );
-	self.addActor.send( statusServer( interf.clientInterface.databaseStatus.getFuture(), &self, coordinators));
-	self.addActor.send( timeKeeper(&self) );
-	self.addActor.send( monitorProcessClasses(&self) );
-	self.addActor.send( monitorServerInfoConfig(&self.db) );
+	self.addActor.send(clusterWatchDatabase(&self, &self.db)); // Start the master database
+	self.addActor.send(self.updateWorkerList.init(self.db.db));
+	self.addActor.send(statusServer(interf.clientInterface.databaseStatus.getFuture(), &self, coordinators));
+	self.addActor.send(timeKeeper(&self));
+	self.addActor.send(monitorProcessClasses(&self));
+	self.addActor.send(monitorServerInfoConfig(&self.db));
 	self.addActor.send(monitorGlobalConfig(&self.db));
-	self.addActor.send( updatedChangingDatacenters(&self) );
-	self.addActor.send( updatedChangedDatacenters(&self) );
-	self.addActor.send( updateDatacenterVersionDifference(&self) );
-	self.addActor.send( handleForcedRecoveries(&self, interf) );
-	self.addActor.send( monitorDataDistributor(&self) );
-	self.addActor.send( monitorRatekeeper(&self) );
-	self.addActor.send( dbInfoUpdater(&self) );
-	self.addActor.send( traceCounters("ClusterControllerMetrics", self.id, SERVER_KNOBS->STORAGE_LOGGING_DELAY, &self.clusterControllerMetrics, self.id.toString() + "/ClusterControllerMetrics") );
-	self.addActor.send( traceRole(Role::CLUSTER_CONTROLLER, interf.id()) );
-	//printf("%s: I am the cluster controller\n", g_network->getLocalAddress().toString().c_str());
+	self.addActor.send(updatedChangingDatacenters(&self));
+	self.addActor.send(updatedChangedDatacenters(&self));
+	self.addActor.send(updateDatacenterVersionDifference(&self));
+	self.addActor.send(handleForcedRecoveries(&self, interf));
+	self.addActor.send(monitorDataDistributor(&self));
+	self.addActor.send(monitorRatekeeper(&self));
+	self.addActor.send(dbInfoUpdater(&self));
+	self.addActor.send(traceCounters("ClusterControllerMetrics",
+	                                 self.id,
+	                                 SERVER_KNOBS->STORAGE_LOGGING_DELAY,
+	                                 &self.clusterControllerMetrics,
+	                                 self.id.toString() + "/ClusterControllerMetrics"));
+	self.addActor.send(traceRole(Role::CLUSTER_CONTROLLER, interf.id()));
+	// printf("%s: I am the cluster controller\n", g_network->getLocalAddress().toString().c_str());
 
 	loop choose {
 		when(ErrorOr<Void> err = wait(error)) {

--- a/fdbserver/workloads/ClientTransactionProfileCorrectness.actor.cpp
+++ b/fdbserver/workloads/ClientTransactionProfileCorrectness.actor.cpp
@@ -275,8 +275,8 @@ struct ClientTransactionProfileCorrectnessWorkload : TestWorkload {
 							tr->setOption(FDBTransactionOptions::LOCK_AWARE);
 							Tuple rate = Tuple().appendDouble(sampleProbability);
 							Tuple size = Tuple().append(sizeLimit);
-							tr->set(fdbClientInfoTxnSampleRate.withPrefix(SpecialKeySpace::getModuleRange(SpecialKeySpace::MODULE::GLOBALCONFIG).begin), rate.pack());
-							tr->set(fdbClientInfoTxnSizeLimit.withPrefix(SpecialKeySpace::getModuleRange(SpecialKeySpace::MODULE::GLOBALCONFIG).begin), size.pack());
+							tr->set(GlobalConfig::prefixedKey(fdbClientInfoTxnSampleRate), rate.pack());
+							tr->set(GlobalConfig::prefixedKey(fdbClientInfoTxnSizeLimit), size.pack());
 							return Void();
 						}
 					 ));

--- a/fdbserver/workloads/ClientTransactionProfileCorrectness.actor.cpp
+++ b/fdbserver/workloads/ClientTransactionProfileCorrectness.actor.cpp
@@ -269,17 +269,15 @@ struct ClientTransactionProfileCorrectnessWorkload : TestWorkload {
 
 	ACTOR Future<Void> changeProfilingParameters(Database cx, int64_t sizeLimit, double sampleProbability) {
 
-		wait(runRYWTransaction(cx, [=](Reference<ReadYourWritesTransaction> tr) -> Future<Void>
-						{
-							tr->setOption(FDBTransactionOptions::SPECIAL_KEY_SPACE_ENABLE_WRITES);
-							tr->setOption(FDBTransactionOptions::LOCK_AWARE);
-							Tuple rate = Tuple().appendDouble(sampleProbability);
-							Tuple size = Tuple().append(sizeLimit);
-							tr->set(GlobalConfig::prefixedKey(fdbClientInfoTxnSampleRate), rate.pack());
-							tr->set(GlobalConfig::prefixedKey(fdbClientInfoTxnSizeLimit), size.pack());
-							return Void();
-						}
-					 ));
+		wait(runRYWTransaction(cx, [=](Reference<ReadYourWritesTransaction> tr) -> Future<Void> {
+			tr->setOption(FDBTransactionOptions::SPECIAL_KEY_SPACE_ENABLE_WRITES);
+			tr->setOption(FDBTransactionOptions::LOCK_AWARE);
+			Tuple rate = Tuple().appendDouble(sampleProbability);
+			Tuple size = Tuple().append(sizeLimit);
+			tr->set(GlobalConfig::prefixedKey(fdbClientInfoTxnSampleRate), rate.pack());
+			tr->set(GlobalConfig::prefixedKey(fdbClientInfoTxnSizeLimit), size.pack());
+			return Void();
+		}));
 		return Void();
 	}
 

--- a/fdbserver/workloads/SpecialKeySpaceCorrectness.actor.cpp
+++ b/fdbserver/workloads/SpecialKeySpaceCorrectness.actor.cpp
@@ -21,6 +21,7 @@
 #include "boost/lexical_cast.hpp"
 #include "boost/algorithm/string.hpp"
 
+#include "fdbclient/GlobalConfig.actor.h"
 #include "fdbclient/ManagementAPI.actor.h"
 #include "fdbclient/NativeAPI.actor.h"
 #include "fdbclient/ReadYourWrites.h"

--- a/flow/network.h
+++ b/flow/network.h
@@ -481,7 +481,8 @@ public:
 		enBlobCredentialFiles = 10,
 		enNetworkAddressesFunc = 11,
 		enClientFailureMonitor = 12,
-		enSQLiteInjectedError = 13
+		enSQLiteInjectedError = 13,
+		enGlobalConfig = 14
 	};
 
 	virtual void longTaskCheck(const char* name) {}


### PR DESCRIPTION
This PR introduces an implementation of the global configuration framework, designed by @sfc-gh-mpilman.

Design doc: https://docs.google.com/document/d/1kye2aHHkwvg3Ze-aldeHO9BprWkfLmldG88DuvHbWAs/edit#

The global configuration framework is an eventually consistent configuration mechanism to efficiently make runtime changes to all clients and servers. It works by only broadcasting changes made to the configuration, allowing the amount of data broadcast to nodes to be small. Nodes that fall behind can catch up by reading the `\xff/globalConfig/k/ - \xff/globalConfig/k0` key range.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
