### PR TITLE
Log std::exception::what when creating an unknown_error

### DIFF
--- a/flow/Error.cpp
+++ b/flow/Error.cpp
@@ -57,13 +57,25 @@ Error internal_error_impl( const char* file, int line ) {
 	return Error(error_code_internal_error);
 }
 
-Error::Error(int error_code)
-	: error_code(error_code), flags(0)
-{
+Error::Error(int error_code) : error_code(error_code), flags(0) {
 	if (TRACE_SAMPLE()) TraceEvent(SevSample, "ErrorCreated").detail("ErrorCode", error_code);
-	//std::cout << "Error: " << error_code << std::endl;
+	// std::cout << "Error: " << error_code << std::endl;
 	if (error_code >= 3000 && error_code < 6000) {
-		TraceEvent(SevError, "SystemError").error(*this).backtrace();
+		{
+			TraceEvent te(SevError, "SystemError");
+			te.error(*this).backtrace();
+			if (error_code == error_code_unknown_error) {
+				auto exception = std::current_exception();
+				if (exception) {
+					try {
+						std::rethrow_exception(exception);
+					} catch (std::exception& e) {
+						te.detail("StdException", e.what());
+					} catch (...) {
+					}
+				}
+			}
+		}
 		if (g_crashOnError) {
 			flushOutputStreams();
 			flushTraceFileVoid();


### PR DESCRIPTION
unknown_error usually gets created when an exception of some type other
than `Error` is thrown. If the current exception is a std::exception
(and it usually is), we can log more information about it - which is
(incredibly!) helpful for figuring out what the heck happened.

### Style
- [x] All variable and function names make sense.
- [x] The code is properly formatted (consider running `git clang-format`).

### Performance
- [ ] ~~All CPU-hot paths are well optimized.~~
- [ ] ~~The proper containers are used (for example `std::vector` vs `VectorRef`).~~
- [ ] ~~There are no new known `SlowTask` traces.~~

### Testing
- [x] The code was sufficiently tested in simulation.
- [ ] ~~If there are new parameters or knobs, different values are tested in simulation.~~
- [ ] ~~`ASSERT`, `ASSERT_WE_THINK`, and `TEST` macros are added in appropriate places.~~
- [ ] ~~Unit tests were added for new algorithms and data structure that make sense to unit-test~~
- [ ] ~~If this is a bugfix: there is a test that can easily reproduce the bug.~~
