### PR TITLE
Point-in-time recofery from a dr-based cold backup

### DIFF
--- a/fdbbackup/backup.actor.cpp
+++ b/fdbbackup/backup.actor.cpp
@@ -159,6 +159,7 @@ enum {
 	OPT_SOURCE_CLUSTER,
 	OPT_DEST_CLUSTER,
 	OPT_CLEANUP,
+	OPT_DSTONLY,
 
 	OPT_TRACE_FORMAT,
 };
@@ -803,7 +804,8 @@ CSimpleOpt::SOption g_rgDBAbortOptions[] = {
 	{ OPT_DEST_CLUSTER, "-d", SO_REQ_SEP },
 	{ OPT_DEST_CLUSTER, "--destination", SO_REQ_SEP },
 	{ OPT_CLEANUP, "--cleanup", SO_NONE },
-	{ OPT_TAGNAME, "-t", SO_REQ_SEP },
+	{ OPT_DSTONLY, "--dstonly", SO_NONE },
+    { OPT_TAGNAME, "-t", SO_REQ_SEP },
 	{ OPT_TAGNAME, "--tagname", SO_REQ_SEP },
 	{ OPT_TRACE, "--log", SO_NONE },
 	{ OPT_TRACE_DIR, "--logdir", SO_REQ_SEP },
@@ -1165,6 +1167,7 @@ static void printDBBackupUsage(bool devhelp) {
 	printf("  -k KEYS        List of key ranges to backup.\n"
 	       "                 If not specified, the entire database will be backed up.\n");
 	printf("  --cleanup      Abort will attempt to stop mutation logging on the source cluster.\n");
+	printf("  --dstonly      Abort will not make any changes on the source cluster.\n");
 #ifndef TLS_DISABLED
 	printf(TLS_HELP);
 #endif
@@ -1944,11 +1947,11 @@ ACTOR Future<Void> statusBackup(Database db, std::string tagName, bool showError
 	return Void();
 }
 
-ACTOR Future<Void> abortDBBackup(Database src, Database dest, std::string tagName, bool partial) {
+ACTOR Future<Void> abortDBBackup(Database src, Database dest, std::string tagName, bool partial, bool dstOnly) {
 	try {
 		state DatabaseBackupAgent backupAgent(src);
 
-		wait(backupAgent.abortBackup(dest, Key(tagName), partial));
+		wait(backupAgent.abortBackup(dest, Key(tagName), partial, dstOnly));
 		wait(backupAgent.unlockBackup(dest, Key(tagName)));
 
 		printf("The DR on tag `%s' was successfully aborted.\n", printable(StringRef(tagName)).c_str());
@@ -2881,6 +2884,7 @@ int main(int argc, char* argv[]) {
 		uint64_t traceMaxLogsSize = TRACE_DEFAULT_MAX_LOGS_SIZE;
 		ESOError lastError;
 		bool partial = true;
+		bool dstOnly = false;
 		LocalityData localities;
 		uint64_t memLimit = 8LL << 30;
 		Optional<uint64_t> ti;
@@ -3058,6 +3062,9 @@ int main(int argc, char* argv[]) {
 				break;
 			case OPT_CLEANUP:
 				partial = false;
+				break;
+			case OPT_DSTONLY:
+				dstOnly = true;
 				break;
 			case OPT_KNOB: {
 				std::string syn = args->OptionSyntax();
@@ -3708,7 +3715,7 @@ int main(int argc, char* argv[]) {
 				f = stopAfter(switchDBBackup(sourceDb, db, backupKeys, tagName, forceAction));
 				break;
 			case DB_ABORT:
-				f = stopAfter(abortDBBackup(sourceDb, db, tagName, partial));
+				f = stopAfter(abortDBBackup(sourceDb, db, tagName, partial, dstOnly));
 				break;
 			case DB_PAUSE:
 				f = stopAfter(changeDBBackupResumed(sourceDb, db, true));

--- a/fdbclient/BackupAgent.actor.h
+++ b/fdbclient/BackupAgent.actor.h
@@ -68,6 +68,7 @@ public:
 	static const Key keyConfigStopWhenDoneKey;
 	static const Key keyStateStatus;
 	static const Key keyStateStop;
+	static const Key keyStateLogBeginVersion;
 	static const Key keyLastUid;
 	static const Key keyBeginKey;
 	static const Key keyEndKey;

--- a/fdbclient/BackupAgent.actor.h
+++ b/fdbclient/BackupAgent.actor.h
@@ -479,7 +479,11 @@ public:
 		    cx, [=](Reference<ReadYourWritesTransaction> tr) { return discontinueBackup(tr, tagName); });
 	}
 
-	Future<Void> abortBackup(Database cx, Key tagName, bool partial = false, bool abortOldBackup = false, bool dstOnly = false);
+	Future<Void> abortBackup(Database cx,
+	                         Key tagName,
+	                         bool partial = false,
+	                         bool abortOldBackup = false,
+	                         bool dstOnly = false);
 
 	Future<std::string> getStatus(Database cx, int errorLimit, Key tagName);
 

--- a/fdbclient/BackupAgent.actor.h
+++ b/fdbclient/BackupAgent.actor.h
@@ -478,7 +478,7 @@ public:
 		    cx, [=](Reference<ReadYourWritesTransaction> tr) { return discontinueBackup(tr, tagName); });
 	}
 
-	Future<Void> abortBackup(Database cx, Key tagName, bool partial = false, bool abortOldBackup = false);
+	Future<Void> abortBackup(Database cx, Key tagName, bool partial = false, bool abortOldBackup = false, bool dstOnly = false);
 
 	Future<std::string> getStatus(Database cx, int errorLimit, Key tagName);
 

--- a/fdbclient/BackupAgentBase.actor.cpp
+++ b/fdbclient/BackupAgentBase.actor.cpp
@@ -105,6 +105,7 @@ const Key BackupAgentBase::keyConfigBackupRanges = LiteralStringRef("config_back
 const Key BackupAgentBase::keyConfigStopWhenDoneKey = LiteralStringRef("config_stop_when_done");
 const Key BackupAgentBase::keyStateStop = LiteralStringRef("state_stop");
 const Key BackupAgentBase::keyStateStatus = LiteralStringRef("state_status");
+const Key BackupAgentBase::keyStateLogBeginVersion = LiteralStringRef("last_begin_version");
 const Key BackupAgentBase::keyLastUid = LiteralStringRef("last_uid");
 const Key BackupAgentBase::keyBeginKey = LiteralStringRef("beginKey");
 const Key BackupAgentBase::keyEndKey = LiteralStringRef("endKey");

--- a/fdbclient/DatabaseBackupAgent.actor.cpp
+++ b/fdbclient/DatabaseBackupAgent.actor.cpp
@@ -1254,7 +1254,8 @@ struct CopyDiffLogsTaskFunc : TaskFuncBase {
 		}
 
 		// set the log version to the state
-		tr->set(StringRef(states.pack(DatabaseBackupAgent::keyStateLogBeginVersion)), BinaryWriter::toValue(beginVersion, Unversioned()));
+		tr->set(StringRef(states.pack(DatabaseBackupAgent::keyStateLogBeginVersion)),
+		        BinaryWriter::toValue(beginVersion, Unversioned()));
 		
 		if (!stopWhenDone.present()) {
 			state Reference<TaskFuture> allPartsDone = futureBucket->future(tr);
@@ -2835,7 +2836,8 @@ public:
 
 		if (! dstOnly) {
 			state Future<Void> partialTimeout = partial ? delay(30.0) : Never();
-			state Reference<ReadYourWritesTransaction> srcTr(new ReadYourWritesTransaction(backupAgent->taskBucket->src));
+			state Reference<ReadYourWritesTransaction> srcTr(
+			    new ReadYourWritesTransaction(backupAgent->taskBucket->src));
 			state Version beginVersion;
 			state Version endVersion;
 


### PR DESCRIPTION
This PR is a rebase of #4274 for 6.2

It adds things necessary for point-in-time recovery from a dr-based cold backup

It includes
- Capability of detaching a dr clone (reeviosily merged to 6.3 #3483
- Provide log version information to fdbdr status (previously in #4274)
