### PR TITLE
Remove async tracer

### DIFF
--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -1543,8 +1543,6 @@ void setNetworkOption(FDBNetworkOptions::Option option, Optional<StringRef> valu
 				openTracer(TracerType::DISABLED);
 			} else if (tracer == "logfile" || tracer == "file" || tracer == "log_file") {
 				openTracer(TracerType::LOG_FILE);
-			} else if (tracer == "network_async") {
-				openTracer(TracerType::NETWORK_ASYNC);
 			} else if (tracer == "network_lossy") {
 				openTracer(TracerType::NETWORK_LOSSY);
 			} else {

--- a/fdbserver/fdbserver.actor.cpp
+++ b/fdbserver/fdbserver.actor.cpp
@@ -1251,8 +1251,6 @@ private:
 					openTracer(TracerType::DISABLED);
 				} else if (tracer == "logfile" || tracer == "file" || tracer == "log_file") {
 					openTracer(TracerType::LOG_FILE);
-				} else if (tracer == "network_async") {
-					openTracer(TracerType::NETWORK_ASYNC);
 				} else if (tracer == "network_lossy") {
 					openTracer(TracerType::NETWORK_LOSSY);
 				} else {

--- a/flow/Tracing.actor.cpp
+++ b/flow/Tracing.actor.cpp
@@ -92,7 +92,7 @@ struct TraceRequest {
 		}
 
 		TraceEvent(SevInfo, "TracingSpanResizedBuffer").detail("OldSize", buffer_size).detail("NewSize", size);
-		std::unique_ptr<uint8_t[]> new_buffer = std::make_unique<uint8_t[]>(size);
+		auto new_buffer = std::make_unique<uint8_t[]>(size);
 		std::copy(buffer.get(), buffer.get() + data_size, new_buffer.get());
 		buffer = std::move(new_buffer);
 		buffer_size = size;

--- a/flow/Tracing.actor.cpp
+++ b/flow/Tracing.actor.cpp
@@ -24,6 +24,7 @@
 
 #include <functional>
 #include <iomanip>
+#include <memory>
 
 #include "flow/actorcompiler.h" // has to be last include
 
@@ -64,7 +65,7 @@ struct LogfileTracer : ITracer {
 };
 
 struct TraceRequest {
-	uint8_t* buffer;
+	std::unique_ptr<uint8_t[]> buffer;
 	// Amount of data in buffer (bytes).
 	std::size_t data_size;
 	// Size of buffer (bytes).
@@ -76,7 +77,7 @@ struct TraceRequest {
 
 	void write_bytes(const uint8_t* buf, std::size_t n) {
 		resize(n);
-		std::copy(buf, buf + n, buffer + data_size);
+		std::copy(buf, buf + n, buffer.get() + data_size);
 		data_size += n;
 	}
 
@@ -91,10 +92,9 @@ struct TraceRequest {
 		}
 
 		TraceEvent(SevInfo, "TracingSpanResizedBuffer").detail("OldSize", buffer_size).detail("NewSize", size);
-		uint8_t* new_buffer = new uint8_t[size];
-		std::copy(buffer, buffer + data_size, new_buffer);
-		free(buffer);
-		buffer = new_buffer;
+		std::unique_ptr<uint8_t[]> new_buffer = std::make_unique<uint8_t[]>(size);
+		std::copy(buffer.get(), buffer.get() + data_size, new_buffer.get());
+		buffer = std::move(new_buffer);
 		buffer_size = size;
 	}
 
@@ -122,28 +122,6 @@ ACTOR Future<Void> simulationStartServer() {
 		// array notation. In the future, the entire message should be
 		// deserialized to make sure all data is written correctly.
 		ASSERT(message[0] == (4 | 0b10010000) || (5 | 0b10010000));
-	}
-}
-
-ACTOR Future<Void> traceSend(FutureStream<TraceRequest> inputStream, std::queue<TraceRequest>* buffers, int* pendingMessages, bool* sendError) {
-	state NetworkAddress localAddress = NetworkAddress::parse("127.0.0.1:" + std::to_string(FLOW_KNOBS->TRACING_UDP_LISTENER_PORT));
-	state Reference<IUDPSocket> socket = wait(INetworkConnections::net()->createUDPSocket(localAddress));
-
-	loop choose {
-		when(state TraceRequest request = waitNext(inputStream)) {
-			try {
-				if (!(*sendError)) {
-					int bytesSent = wait(socket->send(request.buffer, request.buffer + request.data_size));
-					TEST(bytesSent > 0);  // Successfully sent serialized trace
-				}
-				 --(*pendingMessages);
-				request.reset();
-				buffers->push(request);
-			} catch (Error& e) {
-				TraceEvent("TracingSpanSendError").detail("Error", e.what());
-				*sendError = true;
-			}
-		}
 	}
 }
 
@@ -277,69 +255,6 @@ private:
 };
 
 #ifndef WIN32
-struct AsyncUDPTracer : public UDPTracer {
-public:
-	AsyncUDPTracer() : pending_messages_(0), send_error_(false) {}
-
-	~AsyncUDPTracer() override {
-		while (!buffers_.empty()) {
-			auto& request = buffers_.front();
-			buffers_.pop();
-			free(request.buffer);
-		}
-	}
-
-	TracerType type() const override { return TracerType::NETWORK_ASYNC; }
-
-	// Serializes the given span to msgpack format and sends the data via UDP.
-	void trace(Span const& span) override {
-		static std::once_flag once;
-		std::call_once(once, [&]() {
-			send_actor_ = traceSend(stream_.getFuture(), &buffers_, &pending_messages_, &send_error_);
-			log_actor_ = traceLog(&pending_messages_, &send_error_);
-			if (g_network->isSimulated()) {
-				udp_server_actor_ = simulationStartServer();
-			}
-		});
-
-		if (span.location.name.size() == 0) {
-			return;
-		}
-
-		// ASSERT(!send_actor_.isReady());
-		// ASSERT(!log_actor_.isReady());
-
-		if (buffers_.empty()) {
-			buffers_.push(TraceRequest{
-				.buffer = new uint8_t[kTraceBufferSize],
-				.data_size = 0,
-				.buffer_size = kTraceBufferSize
-			});
-		}
-
-		auto request = buffers_.front();
-		buffers_.pop();
-
-		serialize_span(span, request);
-
-		++pending_messages_;
-		stream_.send(request);
-	}
-
-private:
-	// Sending data is asynchronous and it is necessary to keep the buffer
-	// around until the send completes. Therefore, multiple buffers may be
-	// needed at any one time to handle multiple send calls.
-	std::queue<TraceRequest> buffers_;
-	int pending_messages_;
-	bool send_error_;
-
-	PromiseStream<TraceRequest> stream_;
-	Future<Void> send_actor_;
-	Future<Void> log_actor_;
-	Future<Void> udp_server_actor_;
-};
-
 ACTOR Future<Void> fastTraceLogger(int* unreadyMessages, int* failedMessages, int* totalMessages, bool* sendError) {
 	state bool sendErrorReset = false;
 
@@ -363,13 +278,11 @@ ACTOR Future<Void> fastTraceLogger(int* unreadyMessages, int* failedMessages, in
 struct FastUDPTracer : public UDPTracer {
 	FastUDPTracer() : socket_fd_(-1), unready_socket_messages_(0), failed_messages_(0), total_messages_(0), send_error_(false) {
 		request_ = TraceRequest{
-			.buffer = new uint8_t[kTraceBufferSize],
+			.buffer = std::make_unique<uint8_t[]>(kTraceBufferSize),
 			.data_size = 0,
 			.buffer_size = kTraceBufferSize
 		};
 	}
-
-	~FastUDPTracer() override { free(request_.buffer); }
 
 	TracerType type() const override { return TracerType::NETWORK_LOSSY; }
 
@@ -403,7 +316,7 @@ struct FastUDPTracer : public UDPTracer {
 
 		serialize_span(span, request_);
 
-		int bytesSent = send(socket_fd_, request_.buffer, request_.data_size, MSG_DONTWAIT);
+		int bytesSent = send(socket_fd_, request_.buffer.get(), request_.data_size, MSG_DONTWAIT);
 		if (bytesSent == -1) {
 			// Will forgo checking errno here, and assume all error messages
 			// should be treated the same.
@@ -446,11 +359,6 @@ void openTracer(TracerType type) {
 		break;
 	case TracerType::LOG_FILE:
 		g_tracer = new LogfileTracer{};
-		break;
-	case TracerType::NETWORK_ASYNC:
-#ifndef WIN32
-		g_tracer = new AsyncUDPTracer{};
-#endif
 		break;
 	case TracerType::NETWORK_LOSSY:
 #ifndef WIN32

--- a/flow/Tracing.h
+++ b/flow/Tracing.h
@@ -95,9 +95,8 @@ struct Span {
 enum class TracerType {
 	DISABLED = 0,
 	LOG_FILE = 1,
-	NETWORK_ASYNC = 2,
-	NETWORK_LOSSY = 3,
-	END = 4
+	NETWORK_LOSSY = 2,
+	END = 3
 };
 
 struct ITracer {

--- a/flow/Tracing.h
+++ b/flow/Tracing.h
@@ -92,6 +92,9 @@ struct Span {
 	std::unordered_map<StringRef, StringRef> tags;
 };
 
+// The user selects a tracer using a string passed to fdbserver on boot.
+// Clients should not refer to TracerType directly, and mappings of names to
+// values in this enum can change without notice.
 enum class TracerType {
 	DISABLED = 0,
 	LOG_FILE = 1,


### PR DESCRIPTION
Should fix #4292 (see this issue for an explanation of what went wrong).

Changes in this PR:

- Removes `AsyncUDPTracer`, which was used to serialize `Span`s and send them as UDP packets to a server.
- Updates `TraceRequest` object to use `unique_ptr` for better memory management.



## General guideline:

- If this PR is ready to be merged (and all checkboxes below are either ticked or not applicable), make this a regular PR
- If this PR still needs work, please make this a draft PR
  - If you wish to get feedback/code-review, please add the label RFC to this PR

Please verify that all things listed below were considered and check them. If an item doesn't apply to this type of PR (for example a documentation change doesn't need to be performance tested), you should make a ~~strikethrough~~ (markdown syntax: `~~strikethrough~~`). More infos on the guidlines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

### Style

- [x] All variable and function names make sense.
- [x] The code is properly formatted (consider running `git clang-format`).

### Performance

- [x] All CPU-hot paths are well optimized.
- [x] ~~The proper containers are used (for example `std::vector` vs `VectorRef`).~~
- [x] ~~There are no new known `SlowTask` traces.~~

### Testing

- [x] The code was sufficiently tested in simulation.
- [x] ~~If there are new parameters or knobs, different values are tested in simulation.~~
- [x] ~~`ASSERT`, `ASSERT_WE_THINK`, and `TEST` macros are added in appropriate places.~~
- [x] ~~Unit tests were added for new algorithms and data structure that make sense to unit-test~~
- [x] ~~If this is a bugfix: there is a test that can easily reproduce the bug.~~
