### PR TITLE
Reboot simulated process on io_timeout error

### DIFF
--- a/fdbserver/SimulatedCluster.actor.cpp
+++ b/fdbserver/SimulatedCluster.actor.cpp
@@ -202,6 +202,10 @@ ACTOR Future<ISimulator::KillType> simulatedFDBDRebooter(Reference<ClusterConnec
 				if(g_network->isSimulated() && e.code() != error_code_io_timeout && (bool)g_network->global(INetwork::enASIOTimedOut))
 					TraceEvent(SevError, "IOTimeoutErrorSuppressed").detail("ErrorCode", e.code()).detail("RandomId", randomId).backtrace();
 
+				if (e.code() == error_code_io_timeout && !onShutdown.isReady()) {
+					onShutdown = ISimulator::RebootProcess;
+				}
+
 				if (onShutdown.isReady() && onShutdown.isError()) throw onShutdown.getError();
 				if(e.code() != error_code_actor_cancelled)
 					printf("SimulatedFDBDTerminated: %s\n", e.what());


### PR DESCRIPTION
This PR resolves https://github.com/apple/foundationdb/issues/4296.

On real clusters `fdbmonitor` automatically restarts processes that die due to `io_timeout`, so we should do the same in simulation.

### Style

- [x] ~All variable and function names make sense.~
- [x] The code is properly formatted (consider running `git clang-format`).

### Performance

- [x] ~All CPU-hot paths are well optimized.~
- [x] ~The proper containers are used (for example `std::vector` vs `VectorRef`).~
- [x] ~There are no new known `SlowTask` traces.~

### Testing

- [x] The code was sufficiently tested in simulation.
- [x] ~If there are new parameters or knobs, different values are tested in simulation.~
- [x] ~`ASSERT`, `ASSERT_WE_THINK`, and `TEST` macros are added in appropriate places.~
- [x] ~Unit tests were added for new algorithms and data structure that make sense to unit-test~
- [x] If this is a bugfix: there is a test that can easily reproduce the bug.
