### PR TITLE
Stop running log file tracer in simulation

### DIFF
--- a/fdbserver/fdbserver.actor.cpp
+++ b/fdbserver/fdbserver.actor.cpp
@@ -1647,7 +1647,7 @@ int main(int argc, char* argv[]) {
 			//startOldSimulator();
 			startNewSimulator();
 			openTraceFile(NetworkAddress(), opts.rollsize, opts.maxLogsSize, opts.logFolder, "trace", opts.logGroup);
-			openTracer(TracerType(deterministicRandom()->randomInt(static_cast<int>(TracerType::DISABLED), static_cast<int>(TracerType::END))));
+			openTracer(TracerType(deterministicRandom()->randomInt(static_cast<int>(TracerType::DISABLED), static_cast<int>(TracerType::SIM_END))));
 		} else {
 			g_network = newNet2(opts.tlsConfig, opts.useThreadPool, true);
 			g_network->addStopCallback( Net2FileSystem::stop );

--- a/flow/Tracing.actor.cpp
+++ b/flow/Tracing.actor.cpp
@@ -365,7 +365,7 @@ void openTracer(TracerType type) {
 		g_tracer = new FastUDPTracer{};
 #endif
 		break;
-	case TracerType::END:
+	case TracerType::SIM_END:
 		ASSERT(false);
 		break;
 	}

--- a/flow/Tracing.h
+++ b/flow/Tracing.h
@@ -98,7 +98,7 @@ struct Span {
 enum class TracerType {
 	DISABLED = 0,
 	NETWORK_LOSSY = 1,
-	END = 2,  // Any tracers that come after END will not be tested in simulation
+	SIM_END = 2,  // Any tracers that come after SIM_END will not be tested in simulation
 	LOG_FILE = 3
 };
 

--- a/flow/Tracing.h
+++ b/flow/Tracing.h
@@ -97,9 +97,9 @@ struct Span {
 // values in this enum can change without notice.
 enum class TracerType {
 	DISABLED = 0,
-	LOG_FILE = 1,
-	NETWORK_LOSSY = 2,
-	END = 3
+	NETWORK_LOSSY = 1,
+	END = 2,  // Any tracers that come after END will not be tested in simulation
+	LOG_FILE = 3
 };
 
 struct ITracer {


### PR DESCRIPTION
Changes in this PR:

- Stop running log file tracer in simulation. This was causing a large amount of log output in certain scenarios, causing tests to fail that otherwise wouldn't.

## General guideline:

- If this PR is ready to be merged (and all checkboxes below are either ticked or not applicable), make this a regular PR
- If this PR still needs work, please make this a draft PR
  - If you wish to get feedback/code-review, please add the label RFC to this PR

Please verify that all things listed below were considered and check them. If an item doesn't apply to this type of PR (for example a documentation change doesn't need to be performance tested), you should make a ~~strikethrough~~ (markdown syntax: `~~strikethrough~~`). More infos on the guidlines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

### Style

- [ ] All variable and function names make sense.
- [ ] The code is properly formatted (consider running `git clang-format`).

### Performance

- [ ] All CPU-hot paths are well optimized.
- [ ] The proper containers are used (for example `std::vector` vs `VectorRef`).
- [ ] There are no new known `SlowTask` traces.

### Testing

- [ ] The code was sufficiently tested in simulation.
- [ ] If there are new parameters or knobs, different values are tested in simulation.
- [ ] `ASSERT`, `ASSERT_WE_THINK`, and `TEST` macros are added in appropriate places.
- [ ] Unit tests were added for new algorithms and data structure that make sense to unit-test
- [ ] If this is a bugfix: there is a test that can easily reproduce the bug.
