### PR TITLE
Add txnRejectedForQueuedTooLong in ProxyStats

### DIFF
--- a/documentation/sphinx/source/mr-status-json-schemas.rst.inc
+++ b/documentation/sphinx/source/mr-status-json-schemas.rst.inc
@@ -546,6 +546,11 @@
                "counter":0,
                "roughness":0.0
             },
+            "rejected_for_queued_too_long":{
+               "hz":0.0,
+               "counter":0,
+               "roughness":0.0
+            },
             "committed":{
                "hz":0.0,
                "counter":0,

--- a/documentation/sphinx/source/release-notes/release-notes-630.rst
+++ b/documentation/sphinx/source/release-notes/release-notes-630.rst
@@ -90,7 +90,7 @@ Status
 * Removed fields ``worst_version_lag_storage_server`` and ``limiting_version_lag_storage_server`` from the ``cluster.qos`` section. The ``worst_data_lag_storage_server`` and ``limiting_data_lag_storage_server`` objects can be used instead. `(PR #3196) <https://github.com/apple/foundationdb/pull/3196>`_
 * If a process is unable to flush trace logs to disk, the problem will now be reported via the output of ``status`` command inside ``fdbcli``. `(PR #2605) <https://github.com/apple/foundationdb/pull/2605>`_ `(PR #2820) <https://github.com/apple/foundationdb/pull/2820>`_
 * When a configuration key is changed, it will always be included in ``status json`` output, even the value is reverted back to the default value. [6.3.5] `(PR #3610) <https://github.com/apple/foundationdb/pull/3610>`_
-* Added transactions.rejected_for_queued_too_long for bookkeeping the number of transactions rejected by commit proxy because its queuing time exceeds MVCC window. `(PR #4288) <https://github.com/apple/foundationdb/pull/4353>`_
+* Added transactions.rejected_for_queued_too_long for bookkeeping the number of transactions rejected by commit proxy because its queuing time exceeds MVCC window. `(PR #4353) <https://github.com/apple/foundationdb/pull/4353>`_
 
 Bindings
 --------

--- a/documentation/sphinx/source/release-notes/release-notes-630.rst
+++ b/documentation/sphinx/source/release-notes/release-notes-630.rst
@@ -90,6 +90,7 @@ Status
 * Removed fields ``worst_version_lag_storage_server`` and ``limiting_version_lag_storage_server`` from the ``cluster.qos`` section. The ``worst_data_lag_storage_server`` and ``limiting_data_lag_storage_server`` objects can be used instead. `(PR #3196) <https://github.com/apple/foundationdb/pull/3196>`_
 * If a process is unable to flush trace logs to disk, the problem will now be reported via the output of ``status`` command inside ``fdbcli``. `(PR #2605) <https://github.com/apple/foundationdb/pull/2605>`_ `(PR #2820) <https://github.com/apple/foundationdb/pull/2820>`_
 * When a configuration key is changed, it will always be included in ``status json`` output, even the value is reverted back to the default value. [6.3.5] `(PR #3610) <https://github.com/apple/foundationdb/pull/3610>`_
+* Added transactions.rejected_for_queued_too_long for bookkeeping the number of transactions rejected by commit proxy because its queuing time exceeds MVCC window. `(PR #4288) <https://github.com/apple/foundationdb/pull/4353>`_
 
 Bindings
 --------

--- a/fdbclient/Schemas.cpp
+++ b/fdbclient/Schemas.cpp
@@ -587,6 +587,11 @@ const KeyRef JSONSchemas::statusSchema = LiteralStringRef(R"statusSchema(
                "counter":0,
                "roughness":0.0
             },
+            "rejected_for_queued_too_long":{
+               "hz":0.0,
+               "counter":0,
+               "roughness":0.0
+            },
             "committed":{
                "hz":0.0,
                "counter":0,

--- a/fdbserver/MasterProxyServer.actor.cpp
+++ b/fdbserver/MasterProxyServer.actor.cpp
@@ -80,6 +80,7 @@ struct ProxyStats {
 	Counter txnDefaultPriorityStartIn, txnDefaultPriorityStartOut;
 	Counter txnCommitIn, txnCommitVersionAssigned, txnCommitResolving, txnCommitResolved, txnCommitOut, txnCommitOutSuccess, txnCommitErrors;
 	Counter txnConflicts;
+	Counter txnRejectedForQueuedTooLong;
 	Counter txnThrottled;
 	Counter commitBatchIn, commitBatchOut;
 	Counter mutationBytes;
@@ -162,6 +163,7 @@ struct ProxyStats {
 	    txnCommitResolved("TxnCommitResolved", cc), txnCommitOut("TxnCommitOut", cc),
 	    txnCommitOutSuccess("TxnCommitOutSuccess", cc), txnCommitErrors("TxnCommitErrors", cc),
 	    txnConflicts("TxnConflicts", cc), txnThrottled("TxnThrottled", cc), commitBatchIn("CommitBatchIn", cc),
+	    txnRejectedForQueuedTooLong("TxnRejectedForQueuedTooLong", cc),
 	    commitBatchOut("CommitBatchOut", cc), mutationBytes("MutationBytes", cc), mutations("Mutations", cc),
 	    conflictRanges("ConflictRanges", cc), keyServerLocationIn("KeyServerLocationIn", cc),
 	    keyServerLocationOut("KeyServerLocationOut", cc), keyServerLocationErrors("KeyServerLocationErrors", cc),
@@ -954,7 +956,7 @@ ACTOR Future<Void> commitBatch(
 		}
 		++self->stats.commitBatchOut;
 		self->stats.txnCommitOut += trs.size();
-		self->stats.txnConflicts += trs.size();
+		self->stats.txnRejectedForQueuedTooLong += trs.size();
 		return Void();
 	}
 

--- a/fdbserver/Status.actor.cpp
+++ b/fdbserver/Status.actor.cpp
@@ -1706,6 +1706,8 @@ ACTOR static Future<JsonBuilderObject> workloadStatusFetcher(Reference<AsyncVar<
 		StatusCounter mutations;
 		StatusCounter mutationBytes;
 		StatusCounter txnConflicts;
+		StatusCounter txnRejectedForQueuedTooLong;
+
 		StatusCounter txnStartOut;
 		StatusCounter txnSystemPriorityStartOut;
 		StatusCounter txnDefaultPriorityStartOut;
@@ -1718,6 +1720,7 @@ ACTOR static Future<JsonBuilderObject> workloadStatusFetcher(Reference<AsyncVar<
 			mutations.updateValues( StatusCounter(ps.getValue("Mutations")) );
 			mutationBytes.updateValues( StatusCounter(ps.getValue("MutationBytes")) );
 			txnConflicts.updateValues( StatusCounter(ps.getValue("TxnConflicts")) );
+			txnRejectedForQueuedTooLong.updateValues(StatusCounter(ps.getValue("TxnRejectedForQueuedTooLong")));
 			txnStartOut.updateValues( StatusCounter(ps.getValue("TxnStartOut")) );
 			txnSystemPriorityStartOut.updateValues(StatusCounter(ps.getValue("TxnSystemPriorityStartOut")));
 			txnDefaultPriorityStartOut.updateValues(StatusCounter(ps.getValue("TxnDefaultPriorityStartOut")));
@@ -1737,6 +1740,7 @@ ACTOR static Future<JsonBuilderObject> workloadStatusFetcher(Reference<AsyncVar<
 		JsonBuilderObject transactions;
 		transactions["conflicted"] = txnConflicts.getStatus();
 		transactions["started"] = txnStartOut.getStatus();
+		transactions["rejected_for_queued_too_long"] = txnRejectedForQueuedTooLong.getStatus();
 		transactions["started_immediate_priority"] = txnSystemPriorityStartOut.getStatus();
 		transactions["started_default_priority"] = txnDefaultPriorityStartOut.getStatus();
 		transactions["started_batch_priority"] = txnBatchPriorityStartOut.getStatus();


### PR DESCRIPTION
This PR backports https://github.com/apple/foundationdb/pull/4288 from 7.0 to 6.3

Changes in this PR:

- A transaction batch will be rejected immediately if it has been queued longer than the MVCC window, this commit counts this kind of rejection separately from `txnConflicts` 

- also added this field in `Status#workloadStatusFetcher` and changed schema accordingly.

### Style
- [x] All variable and function names make sense.
- [x] The code is properly formatted (consider running `git clang-format`).

### Performance
- [x] ~~All CPU-hot paths are well optimized.~~
- [x] ~~The proper containers are used (for example `std::vector` vs `VectorRef`).~~
- [x] ~~There are no new known `SlowTask` traces.~~

### Testing
- [x] The code was sufficiently tested in simulation.
- [x] ~~If there are new parameters or knobs, different values are tested in simulation.~~
- [x] ~~`ASSERT`, `ASSERT_WE_THINK`, and `TEST` macros are added in appropriate places.~~
- [x] ~~Unit tests were added for new algorithms and data structure that make sense to unit-test~~
- [x] ~~If this is a bugfix: there is a test that can easily reproduce the bug.~~
