### PR TITLE
Backport 5b74556733228482bfc64ab6c3ef2894e9d139c4 to release-6.2

### DIFF
--- a/fdbclient/ManagementAPI.actor.cpp
+++ b/fdbclient/ManagementAPI.actor.cpp
@@ -1974,9 +1974,9 @@ TEST_CASE("/ManagementAPI/AutoQuorumChange/checkLocality") {
 		data.address.ip = IPAddress(i);
 
 		if (g_network->isSimulated()) {
-			g_simulator.newProcess(
-			    format("TestProcess%d", i).c_str(), data.address.ip, data.address.port, false, 1, data.locality,
-			    ProcessClass(ProcessClass::CoordinatorClass, ProcessClass::CommandLineSource), "", "");
+			g_simulator.newProcess("TestCoordinator", data.address.ip, data.address.port, false, 1, data.locality,
+			                       ProcessClass(ProcessClass::CoordinatorClass, ProcessClass::CommandLineSource), "",
+			                       "");
 		}
 
 		workers.push_back(data);


### PR DESCRIPTION
Fix bug in code I recently added where the process name memory was not long-lived and was later used.