### PR TITLE
Add tini as PID 1 to docker image

### DIFF
--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get update && \
 		lsof>=4.89+dfsg-0.1 \
 		tcptraceroute>=1.5beta7+debian-4build1 \
 		telnet>=0.17-41 \
-		netcat>= 1.10-41.1 \
+		netcat>=1.10-41.1 \
 		strace>=4.21-1ubuntu1 \
 		tcpdump>=4.9.3-0ubuntu0.18.04.1 \
 		less>=487-0.1 \
@@ -84,3 +84,13 @@ ENV FDB_COORDINATOR ""
 ENV FDB_COORDINATOR_PORT 4500
 ENV FDB_CLUSTER_FILE_CONTENTS ""
 ENV FDB_PROCESS_CLASS unset
+
+# Adding tini as PID 1 https://github.com/krallin/tini
+ARG TINI_VERSION=v0.19.0
+RUN curl -sLO https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-amd64 && \
+    curl -sLO https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-amd64.sha256sum && \
+	sha256sum -c tini-amd64.sha256sum && \
+	rm -f tini-amd64.sha256sum && \
+    chmod +x tini-amd64 && \
+	mv tini-amd64 /usr/bin/tini
+ENTRYPOINT ["/usr/bin/tini", "-g", "--"]


### PR DESCRIPTION
This PR resolves #2511

Changes in this PR:

- Adding tini as PID 1

## General guideline:

- If this PR is ready to be merged (and all checkboxes below are either ticked or not applicable), make this a regular PR
- If this PR still needs work, please make this a draft PR
  - If you wish to get feedback/code-review, please add the label RFC to this PR

Please verify that all things listed below were considered and check them. If an item doesn't apply to this type of PR (for example a documentation change doesn't need to be performance tested), you should make a ~~strikethrough~~ (markdown syntax: `~~strikethrough~~`). More infos on the guidlines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

### Style

- [x] All variable and function names make sense.
- [x] The code is properly formatted (consider running `git clang-format`).

### Performance

- [ ] ~~All CPU-hot paths are well optimized.~~
- [ ] ~~The proper containers are used (for example `std::vector` vs `VectorRef`).~~
- [ ] ~~There are no new known `SlowTask` traces.~~

### Testing

- [ ] ~~The code was sufficiently tested in simulation.~~
- [ ] ~~If there are new parameters or knobs, different values are tested in simulation.~~
- [ ] ~~`ASSERT`, `ASSERT_WE_THINK`, and `TEST` macros are added in appropriate places.~~
- [ ] ~~Unit tests were added for new algorithms and data structure that make sense to unit-test~~
- [ ] ~~If this is a bugfix: there is a test that can easily reproduce the bug.~~
