### PR TITLE
Fix Snapshot test failure

### DIFF
--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -5100,9 +5100,8 @@ ACTOR Future<Void> ddSnapCreateCore(DistributorSnapRequest snapReq, Reference<As
 			.detail("SnapPayload", snapReq.snapPayload)
 			.detail("SnapUID", snapReq.snapUID)
 			.error(e, true /*includeCancelled */);
-		if (e.code() == error_code_snap_storage_failed
-			|| e.code() == error_code_snap_tlog_failed
-			|| e.code() == error_code_operation_cancelled) {
+		if (e.code() == error_code_snap_storage_failed || e.code() == error_code_snap_tlog_failed ||
+		    e.code() == error_code_operation_cancelled || e.code() == error_code_snap_disable_tlog_pop_failed) {
 			// enable tlog pop on local tlog nodes
 			std::vector<TLogInterface> tlogs = db->get().logSystemConfig.allLocalLogs(false);
 			try {

--- a/fdbserver/TLogServer.actor.cpp
+++ b/fdbserver/TLogServer.actor.cpp
@@ -1083,18 +1083,13 @@ ACTOR Future<Void> processPopRequests(TLogData* self, Reference<LogData> logData
 		}
 	}
 	wait(waitForAll(ignoredPops));
+	TraceEvent("ResetIgnorePopRequest")
+	    .detail("IgnorePopRequest", self->ignorePopRequest)
+	    .detail("IgnorePopDeadline", self->ignorePopDeadline);
 	return Void();
 }
 
 ACTOR Future<Void> tLogPop( TLogData* self, TLogPopRequest req, Reference<LogData> logData ) {
-	// timeout check for ignorePopRequest
-	if (self->ignorePopRequest && (g_network->now() > self->ignorePopDeadline)) {
-		TraceEvent("EnableTLogPlayAllIgnoredPops").detail("IgnoredPopDeadline", self->ignorePopDeadline);
-		wait(processPopRequests(self, logData));
-		TraceEvent("ResetIgnorePopRequest")
-		    .detail("IgnorePopRequest", self->ignorePopRequest)
-		    .detail("IgnorePopDeadline", self->ignorePopDeadline);
-	}
 	if (self->ignorePopRequest) {
 		TraceEvent(SevDebug, "IgnoringPopRequest").detail("IgnorePopDeadline", self->ignorePopDeadline);
 
@@ -2267,6 +2262,11 @@ ACTOR Future<Void> serveTLogInterface( TLogData* self, TLogInterface tli, Refere
 		}
 		when( TLogSnapRequest snapReq = waitNext( tli.snapRequest.getFuture() ) ) {
 			logData->addActor.send( tLogSnapCreate( snapReq, self, logData) );
+		}
+		when(wait(self->ignorePopRequest ? delayUntil(self->ignorePopDeadline) : Never())) {
+			TEST(true); // Hit ignorePopDeadline
+			TraceEvent("EnableTLogPlayAllIgnoredPops").detail("IgnoredPopDeadline", self->ignorePopDeadline);
+			logData->addActor.send(processPopRequests(self, logData));
 		}
 	}
 }

--- a/fdbserver/workloads/SnapTest.actor.cpp
+++ b/fdbserver/workloads/SnapTest.actor.cpp
@@ -219,6 +219,7 @@ public: // workload functions
 						snapFailed = true;
 						break;
 					}
+					wait(delay(5.0));
 				}
 			}
 			CSimpleIni ini;


### PR DESCRIPTION
This PR resolves https://github.com/apple/foundationdb/issues/4293.

Changes in this PR:

- Add delay between `SnapTest` retries.
- Reenable pops on tlogs even if some tlogs never disable pops.
- Enforce disable pop deadline even if no more pop requests are received.

### Style

- [x] All variable and function names make sense.
- [x] The code is properly formatted (consider running `git clang-format`).

### Performance

- [x] All CPU-hot paths are well optimized.
- [x] The proper containers are used (for example `std::vector` vs `VectorRef`).
- [x] There are no new known `SlowTask` traces.

### Testing

- [x] The code was sufficiently tested in simulation.
- [x] If there are new parameters or knobs, different values are tested in simulation.
- [x] `ASSERT`, `ASSERT_WE_THINK`, and `TEST` macros are added in appropriate places.
- [x] ~Unit tests were added for new algorithms and data structure that make sense to unit-test~
- [x] If this is a bugfix: there is a test that can easily reproduce the bug.
