### PR TITLE
cmake: skip jemalloc on FreeBSD

### DIFF
--- a/cmake/Jemalloc.cmake
+++ b/cmake/Jemalloc.cmake
@@ -1,12 +1,13 @@
 add_library(jemalloc INTERFACE)
 
 set(USE_JEMALLOC ON)
-if(USE_SANITIZER OR WIN32)
+# We don't want to use jemalloc on Windows
+# Nor on FreeBSD, where jemalloc is the default system allocator
+if(USE_SANITIZER OR WIN32 OR (CMAKE_SYSTEM_NAME STREQUAL "FreeBSD"))
   set(USE_JEMALLOC OFF)
   return()
 endif()
 
-# We don't want to use jemalloc on Windows
 find_path(JEMALLOC_INCLUDE_DIR
   NAMES
   jemalloc/jemalloc.h


### PR DESCRIPTION
FreeBSD is the upstream for jemalloc so it's the system malloc already.

See https://github.com/apple/foundationdb/pull/4222 for previous jemalloc work.

Changes in this PR:

- move WIN32 comment to where the relevant code is
- exclude jemalloc if OS==FreeBSD

### Style

- n/a
 
### Performance

- n/a

### Testing

- still waiting on FreeBSD builds to complete