### PR TITLE
Catch special key error in FuzzApiCorrectness test

### DIFF
--- a/fdbserver/workloads/FuzzApiCorrectness.actor.cpp
+++ b/fdbserver/workloads/FuzzApiCorrectness.actor.cpp
@@ -622,6 +622,14 @@ struct FuzzApiCorrectnessWorkload : TestWorkload {
 				std::make_pair(
 				    error_code_special_keys_no_module_found,
 				    ExceptionContract::possibleIf(specialKeys.contains(key) && !workload->specialKeysRelaxed)),
+				std::make_pair(error_code_timed_out, ExceptionContract::possibleIf(specialKeys.contains(key))),
+				// Read this particular special key may throw special_keys_api_failure
+				std::make_pair(
+				    error_code_special_keys_api_failure,
+				    ExceptionContract::possibleIf(
+				        key ==
+				        LiteralStringRef("auto_coordinators")
+				            .withPrefix(SpecialKeySpace::getModuleRange(SpecialKeySpace::MODULE::MANAGEMENT).begin)))
 			};
 		}
 
@@ -691,6 +699,9 @@ struct FuzzApiCorrectnessWorkload : TestWorkload {
 				               ExceptionContract::possibleIf(isSpecialKeyRange && !workload->specialKeysRelaxed)),
 				std::make_pair(error_code_special_keys_no_module_found,
 				               ExceptionContract::possibleIf(isSpecialKeyRange && !workload->specialKeysRelaxed)),
+				// Read some special keys, e.g. status/json, can throw timed_out
+				std::make_pair(error_code_timed_out, ExceptionContract::possibleIf(isSpecialKeyRange)),
+				std::make_pair(error_code_special_keys_api_failure, ExceptionContract::possibleIf(isSpecialKeyRange)),
 				std::make_pair(error_code_accessed_unreadable, ExceptionContract::Possible)
 			};
 		}
@@ -731,6 +742,8 @@ struct FuzzApiCorrectnessWorkload : TestWorkload {
 				               ExceptionContract::possibleIf(isSpecialKeyRange && !workload->specialKeysRelaxed)),
 				std::make_pair(error_code_special_keys_no_module_found,
 				               ExceptionContract::possibleIf(isSpecialKeyRange && !workload->specialKeysRelaxed)),
+				std::make_pair(error_code_timed_out, ExceptionContract::possibleIf(isSpecialKeyRange)),
+				std::make_pair(error_code_special_keys_api_failure, ExceptionContract::possibleIf(isSpecialKeyRange)),
 				std::make_pair(error_code_accessed_unreadable, ExceptionContract::Possible)
 			};
 		}
@@ -767,6 +780,10 @@ struct FuzzApiCorrectnessWorkload : TestWorkload {
 			}
 
 			bool isSpecialKeyRange = specialKeys.contains(key1) && specialKeys.begin <= key2 && key2 <= specialKeys.end;
+			// Read this particular special key may throw special_keys_api_failure
+			Key autoCoordinatorSpecialKey =
+			    LiteralStringRef("auto_coordinators")
+			        .withPrefix(SpecialKeySpace::getModuleRange(SpecialKeySpace::MODULE::MANAGEMENT).begin);
 
 			contract = {
 				std::make_pair(error_code_inverted_range, ExceptionContract::requiredIf(key1 > key2)),
@@ -781,6 +798,10 @@ struct FuzzApiCorrectnessWorkload : TestWorkload {
 				               ExceptionContract::possibleIf(isSpecialKeyRange && !workload->specialKeysRelaxed)),
 				std::make_pair(error_code_special_keys_no_module_found,
 				               ExceptionContract::possibleIf(isSpecialKeyRange && !workload->specialKeysRelaxed)),
+				std::make_pair(error_code_timed_out, ExceptionContract::possibleIf(isSpecialKeyRange)),
+				std::make_pair(error_code_special_keys_api_failure,
+				               ExceptionContract::possibleIf(key1 <= autoCoordinatorSpecialKey &&
+				                                             autoCoordinatorSpecialKey < key2)),
 				std::make_pair(error_code_accessed_unreadable, ExceptionContract::Possible)
 			};
 		}
@@ -807,6 +828,9 @@ struct FuzzApiCorrectnessWorkload : TestWorkload {
 			limits = makeRangeLimits();
 
 			bool isSpecialKeyRange = specialKeys.contains(key1) && specialKeys.begin <= key2 && key2 <= specialKeys.end;
+			Key autoCoordinatorSpecialKey =
+			    LiteralStringRef("auto_coordinators")
+			        .withPrefix(SpecialKeySpace::getModuleRange(SpecialKeySpace::MODULE::MANAGEMENT).begin);
 
 			contract = {
 				std::make_pair(error_code_inverted_range, ExceptionContract::requiredIf(key1 > key2)),
@@ -822,6 +846,10 @@ struct FuzzApiCorrectnessWorkload : TestWorkload {
 				               ExceptionContract::possibleIf(isSpecialKeyRange && !workload->specialKeysRelaxed)),
 				std::make_pair(error_code_special_keys_no_module_found,
 				               ExceptionContract::possibleIf(isSpecialKeyRange && !workload->specialKeysRelaxed)),
+				std::make_pair(error_code_timed_out, ExceptionContract::possibleIf(isSpecialKeyRange)),
+				std::make_pair(error_code_special_keys_api_failure,
+				               ExceptionContract::possibleIf((key1 <= autoCoordinatorSpecialKey) &&
+				                                             (autoCoordinatorSpecialKey < key2))),
 				std::make_pair(error_code_accessed_unreadable, ExceptionContract::Possible)
 			};
 		}


### PR DESCRIPTION
This PR resolves #4371 

`timed_out`(e.g. `\xff\xff/status/json`) and `special_keys_api_failure`(e.g. the newly added `\xff\xff/management/auto_coordinators`) can happen in very rare cases.

### Style

- [x] All variable and function names make sense.
- [x] The code is properly formatted (consider running `git clang-format`).

### Performance

- [ ] ~~All CPU-hot paths are well optimized.~~
- [ ] ~~The proper containers are used (for example `std::vector` vs `VectorRef`).~~
- [ ] ~~There are no new known `SlowTask` traces.~~

### Testing

- [x] The code was sufficiently tested in simulation.
- [ ] ~~If there are new parameters or knobs, different values are tested in simulation.~~
- [ ] ~~`ASSERT`, `ASSERT_WE_THINK`, and `TEST` macros are added in appropriate places.~~
- [ ] ~~Unit tests were added for new algorithms and data structure that make sense to unit-test~~
- [x] If this is a bugfix: there is a test that can easily reproduce the bug.
