### PR TITLE
Add the ability to instrument java driver actions

### DIFF
--- a/bindings/java/CMakeLists.txt
+++ b/bindings/java/CMakeLists.txt
@@ -58,6 +58,7 @@ set(JAVA_BINDING_SRCS
   src/main/com/apple/foundationdb/Transaction.java
   src/main/com/apple/foundationdb/TransactionContext.java
   src/main/com/apple/foundationdb/EventKeeper.java
+  src/main/com/apple/foundationdb/MapEventKeeper.java
   src/main/com/apple/foundationdb/testing/AbstractWorkload.java
   src/main/com/apple/foundationdb/testing/WorkloadContext.java
   src/main/com/apple/foundationdb/testing/Promise.java

--- a/bindings/java/CMakeLists.txt
+++ b/bindings/java/CMakeLists.txt
@@ -57,6 +57,7 @@ set(JAVA_BINDING_SRCS
   src/main/com/apple/foundationdb/subspace/Subspace.java
   src/main/com/apple/foundationdb/Transaction.java
   src/main/com/apple/foundationdb/TransactionContext.java
+  src/main/com/apple/foundationdb/EventKeeper.java
   src/main/com/apple/foundationdb/testing/AbstractWorkload.java
   src/main/com/apple/foundationdb/testing/WorkloadContext.java
   src/main/com/apple/foundationdb/testing/Promise.java

--- a/bindings/java/src/integration/com/apple/foundationdb/RangeQueryIntegrationTest.java
+++ b/bindings/java/src/integration/com/apple/foundationdb/RangeQueryIntegrationTest.java
@@ -21,18 +21,9 @@ package com.apple.foundationdb;
 
 import java.util.Iterator;
 import java.util.Map;
-import java.util.TreeMap;
-import java.util.AbstractMap;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.NavigableMap;
 import java.util.Random;
 import java.util.TreeMap;
-import java.util.concurrent.Callable;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.function.Consumer;
 
 import com.apple.foundationdb.async.AsyncIterable;
 import com.apple.foundationdb.async.AsyncIterator;
@@ -45,7 +36,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
- * Integration tests around Range Queries. This requires a running FDB instance to work properly; 
+ * Integration tests around Range Queries. This requires a running FDB instance to work properly;
  * all tests will be skipped if it can't connect to a running instance relatively quickly.
  */
 @ExtendWith(RequiresDatabase.class)
@@ -111,7 +102,7 @@ class RangeQueryIntegrationTest {
 	@Test
 	void rangeQueryReturnsResults() throws Exception {
 		/*
-		 * A quick test that if you insert a record, then do a range query which includes 
+		 * A quick test that if you insert a record, then do a range query which includes
 		 * the record, it'll be returned
 		 */
 		try (Database db = fdb.open()) {

--- a/bindings/java/src/junit/com/apple/foundationdb/EventKeeperTest.java
+++ b/bindings/java/src/junit/com/apple/foundationdb/EventKeeperTest.java
@@ -1,0 +1,150 @@
+/*
+ * EventKeeperTest.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.apple.foundationdb;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.apple.foundationdb.EventKeeper.Events;
+import com.apple.foundationdb.async.AsyncIterator;
+import com.apple.foundationdb.tuple.ByteArrayUtil;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Basic test code for testing basic Transaction Timer logic.
+ *
+ * These tests don't check for a whole lot, they just verify that
+ * instrumentation works as expected for specific patterns.
+ */
+class EventKeeperTest {
+
+	@Test
+	void testSetVersion() throws Exception {
+
+		EventKeeper timer = new TestKeeper();
+
+		try (FDBTransaction txn = new FDBTransaction(1, null, null, timer)) {
+			Assertions.assertThrows(UnsatisfiedLinkError.class,
+			                        () -> { txn.setReadVersion(1L); }, "Test should call a bad native method");
+			long jniCalls = timer.getCount(Events.JNI_CALL);
+
+			Assertions.assertEquals(1L, jniCalls, "Unexpected number of JNI calls:");
+		} catch (UnsatisfiedLinkError ignored) {
+		}
+	}
+
+	@Test
+	void testGetReadVersion() throws Exception {
+		EventKeeper timer = new TestKeeper();
+
+		try (FDBTransaction txn = new FDBTransaction(1, null, null, timer)) {
+			Assertions.assertThrows(UnsatisfiedLinkError.class,
+			                        () -> { txn.getReadVersion(); }, "Test should call a bad native method");
+			long jniCalls = timer.getCount(Events.JNI_CALL);
+
+			Assertions.assertEquals(1L, jniCalls, "Unexpected number of JNI calls:");
+		} catch (UnsatisfiedLinkError ignored) {
+		}
+	}
+
+	@Test
+	void testGetRangeRecordsFetches() throws Exception {
+		EventKeeper timer = new TestKeeper();
+		List<KeyValue> testKvs = Arrays.asList(new KeyValue("hello".getBytes(), "goodbye".getBytes()));
+
+		FDBTransaction txn = new FakeFDBTransaction(testKvs, 1L, null, null);
+
+		RangeQuery query = new RangeQuery(txn, true, KeySelector.firstGreaterOrEqual(new byte[] { 0x00 }),
+		                                  KeySelector.firstGreaterOrEqual(new byte[] { (byte)0xFF }), -1, false,
+		                                  StreamingMode.ITERATOR, timer);
+		AsyncIterator<KeyValue> iter = query.iterator();
+
+		List<KeyValue> iteratedItems = new ArrayList<>();
+		while (iter.hasNext()) {
+			iteratedItems.add(iter.next());
+		}
+
+		// basic verification that we got back what we expected to get back.
+		Assertions.assertEquals(testKvs.size(), iteratedItems.size(), "Incorrect iterated list, size incorrect.");
+
+		int expectedByteSize = 0;
+		for (KeyValue expected : testKvs) {
+			byte[] eKey = expected.getKey();
+			byte[] eVal = expected.getValue();
+			expectedByteSize += eKey.length + 4;
+			expectedByteSize += eVal.length + 4;
+			boolean found = false;
+			for (KeyValue actual : iteratedItems) {
+				byte[] aKey = actual.getKey();
+				byte[] aVal = actual.getValue();
+				if (ByteArrayUtil.compareTo(eKey, 0, eKey.length, aKey, 0, aKey.length) == 0) {
+					int cmp = ByteArrayUtil.compareTo(eVal, 0, eVal.length, aVal, 0, aVal.length);
+					Assertions.assertEquals(0, cmp, "Incorrect value returned");
+					found = true;
+					break;
+				}
+			}
+
+			Assertions.assertTrue(found, "missing key!");
+		}
+
+		// now check the timer and see if it recorded any events
+		Assertions.assertEquals(1, timer.getCount(Events.RANGE_QUERY_FETCHES), "Unexpected number of chunk fetches");
+		Assertions.assertEquals(testKvs.size(), timer.getCount(Events.RANGE_QUERY_TUPLES_FETCHED),
+		                        "Unexpected number of tuples fetched");
+		Assertions.assertEquals(expectedByteSize, timer.getCount(Events.BYTES_FETCHED),
+		                        "Incorrect number of bytes fetched");
+	}
+
+	/* private helper methods and classes */
+	private static class TestKeeper implements EventKeeper {
+		private Map<Event, Long> counterMap = new HashMap<>();
+
+		@Override
+		public void count(Event event, long amt) {
+			Long currCnt = counterMap.get(event);
+			if (currCnt == null) {
+				counterMap.put(event, amt);
+			} else {
+				counterMap.put(event, currCnt + amt);
+			}
+		}
+
+		@Override
+		public void timeNanos(Event event, long nanos) {
+			count(event, nanos);
+		}
+
+		@Override
+		public long getCount(Event event) {
+			return counterMap.getOrDefault(event, 0L);
+		}
+
+		@Override
+		public long getTimeNanos(Event event) {
+			return counterMap.getOrDefault(event, 0L);
+		}
+	}
+}

--- a/bindings/java/src/junit/com/apple/foundationdb/EventKeeperTest.java
+++ b/bindings/java/src/junit/com/apple/foundationdb/EventKeeperTest.java
@@ -112,7 +112,7 @@ class EventKeeperTest {
 
 		// now check the timer and see if it recorded any events
 		Assertions.assertEquals(1, timer.getCount(Events.RANGE_QUERY_FETCHES), "Unexpected number of chunk fetches");
-		Assertions.assertEquals(testKvs.size(), timer.getCount(Events.RANGE_QUERY_TUPLES_FETCHED),
+		Assertions.assertEquals(testKvs.size(), timer.getCount(Events.RANGE_QUERY_RECORDS_FETCHED),
 		                        "Unexpected number of tuples fetched");
 		Assertions.assertEquals(expectedByteSize, timer.getCount(Events.BYTES_FETCHED),
 		                        "Incorrect number of bytes fetched");
@@ -124,12 +124,7 @@ class EventKeeperTest {
 
 		@Override
 		public void count(Event event, long amt) {
-			Long currCnt = counterMap.get(event);
-			if (currCnt == null) {
-				counterMap.put(event, amt);
-			} else {
-				counterMap.put(event, currCnt + amt);
-			}
+			counterMap.compute(event, (e,present)->present==null? amt:amt+present);
 		}
 
 		@Override

--- a/bindings/java/src/junit/com/apple/foundationdb/FakeFDBTransaction.java
+++ b/bindings/java/src/junit/com/apple/foundationdb/FakeFDBTransaction.java
@@ -67,6 +67,15 @@ public class FakeFDBTransaction extends FDBTransaction {
 		}
 	}
 
+	public FakeFDBTransaction(List<KeyValue> backingData, long cPtr, Database db,
+	                          Executor executor) {
+		this(cPtr, db, executor);
+
+		for (KeyValue entry : backingData) {
+			this.backingData.put(entry.getKey(), entry.getValue());
+		}
+	}
+
 	@Override
 	public CompletableFuture<byte[]> get(byte[] key) {
 		return CompletableFuture.completedFuture(this.backingData.get(key));
@@ -92,7 +101,7 @@ public class FakeFDBTransaction extends FDBTransaction {
 
 		// holder variable so that we can pass the range to the results function safely
 		final NavigableMap<byte[], byte[]> retMap = range;
-		FutureResults fr = new FutureResults(-1L, false, executor) {
+		FutureResults fr = new FutureResults(-1L, false, executor, null) {
 			@Override
 			protected void registerMarshalCallback(Executor executor) {
 				// no-op

--- a/bindings/java/src/main/com/apple/foundationdb/Database.java
+++ b/bindings/java/src/main/com/apple/foundationdb/Database.java
@@ -63,6 +63,17 @@ public interface Database extends AutoCloseable, TransactionContext {
 	Transaction createTransaction(Executor e);
 
 	/**
+	 * Creates a {@link Transaction} that operates on this {@code Database} with the given {@link Executor}
+	 * for asynchronous callbacks.
+	 *
+	 * @param e the {@link Executor} to use when executing asynchronous callbacks for the database
+	 * @param eventKeeper the {@link EventKeeper} to use when tracking instrumented calls for the transaction.
+	 *
+	 * @return a newly created {@code Transaction} that reads from and writes to this {@code Database}.
+	 */
+	Transaction createTransaction(Executor e, EventKeeper eventKeeper);
+
+	/**
 	 * Returns a set of options that can be set on a {@code Database}
 	 *
 	 * @return a set of database-specific options affecting this {@code Database}

--- a/bindings/java/src/main/com/apple/foundationdb/EventKeeper.java
+++ b/bindings/java/src/main/com/apple/foundationdb/EventKeeper.java
@@ -1,0 +1,178 @@
+/*
+ * TransactionTimer.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.apple.foundationdb;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A device for externally instrumenting the FDB java driver, for monitoring
+ * purposes.
+ *
+ * Note that implementations as expected to be thread-safe, and may be manipulated
+ * from multiple threads even in nicely single-threaded-looking applications.
+ */
+public interface EventKeeper {
+
+    /**
+     * Count the number of events which occurred.
+     * 
+     * @param event the event which occurred
+     * @param amt the number of times that even occurred
+     */
+    void count(Event event, long amt);
+
+    /**
+     * Convenience method to add 1 to the number of events which occurred.
+     * 
+     * @param event the event which occurred.
+     */
+    default void increment(Event event) {
+        count(event, 1L);
+    }
+
+    /**
+     * Count the time taken to perform an event, in nanoseconds.
+     * 
+     * Note that {@code event.isTimeEvent()} should return true here.
+     * 
+     * @param event the event which was timed (the event should be a time event).
+     * @param nanos the amount of time taken (in nanoseconds)
+     */
+    void timeNanos(Event event, long nanos);
+
+    /**
+     * Count the time taken to perform an action, in the specified units.
+     * 
+     * Note that {@code event.isTimeEvent()} should return true.
+     * 
+     * @param event the event which was timed.
+     * @param duration the time taken
+     * @param theUnit the unit of time in which the time measurement was taken
+     */
+    default void time(Event event, long duration, TimeUnit theUnit){
+        timeNanos(event,theUnit.toNanos(duration));
+    }
+
+    /**
+     * Get the number of events which occurred since this timer was created.
+     * 
+     * If the event was never recorded, then this returns 0.
+     * 
+     * @param event the event to get the count for
+     * @return the number of times the event was triggered. If the event has never been triggered,
+     * then this returns 0
+     */
+    long getCount(Event event);
+
+    /**
+     * Get the amount of time taken by this event, in nanoseconds.
+     * 
+     * @param event the event to get the time for
+     * @return  the total time measured for this event, in nanoseconds. If the event was never recorded,
+     * return 0 instead.
+     */
+    long getTimeNanos(Event event);
+
+    /**
+     * Get the amount of time taken by this event, in the specified units.
+     * 
+     * Important note: If the time that was measured in nanoseconds does not evenly divide the unit that
+     * is specified (which is likely, considering time), then some precision may be lost in the conversion. Use
+     * this carefully.
+     * 
+     * @param event the event to get the time for
+     * @param theUnit the unit to get time in
+     * @return  the total time measured for this event, in the specified unit. If the event was never recorded,
+     * return 0.
+     */
+    default long getTime(Event event, TimeUnit theUnit){
+        return theUnit.convert(getTimeNanos(event),TimeUnit.NANOSECONDS);
+    }
+
+    /**
+     * Marker interface for tracking the specific type of event that occurs, and metadata about said event.
+     * 
+     * Implementations should be sure to provide a quality {@code equals} and {@code hashCode}.
+     */
+    interface Event {
+        /**
+         * @return the name of this event, as a unique string. This name should generally be unique, because 
+         * it's likely that {@code EventKeeper} implementations will rely on this for uniqueness.
+         */
+        String name();
+
+        /**
+         * @return true if this event represents a timed event, rather than a counter event. 
+         */
+        default boolean isTimeEvent() {
+            return false;
+        };
+    }
+
+    /**
+     * An enumeration of static events which occur within the FDB Java driver.
+     */
+    enum Events implements Event {
+        /**
+         * The number of JNI calls that were exercised.
+         */
+        JNI_CALL,
+
+        /**
+         * The total number of bytes fetched over the network, from
+         * {@link Transaction#get(byte[])}, {@link Transaction#getKey(KeySelector)},
+         * {@link Transaction#getRange(KeySelector, KeySelector)} (and related method
+         * overrides), or any other read-type operation which occurs on a Transaction
+         */
+        BYTES_FETCHED,
+
+        /**
+         * The number of times a DirectBuffer was used to transfer a range query chunk
+         * across the JNI boundary
+         */
+        RANGE_QUERY_DIRECT_BUFFER_HIT,
+        /**
+         * The number of times a range query chunk was unable to use a DirectBuffer to
+         * transfer data across the JNI boundary
+         */
+        RANGE_QUERY_DIRECT_BUFFER_MISS,
+        /**
+         * The number of direct fetches made during a range query
+         */
+        RANGE_QUERY_FETCHES,
+        /**
+         * The number of tuples fetched during a range query
+         */
+        RANGE_QUERY_TUPLES_FETCHED,
+        /**
+         * The number of times a range query chunk fetch failed
+         */
+        RANGE_QUERY_CHUNK_FAILED,
+        /**
+         * The time taken to perform an internal `getRange` fetch, in nanoseconds
+         */
+        RANGE_QUERY_FETCH_TIME_NANOS {
+            @Override
+            public boolean isTimeEvent() {
+                return true;
+            }
+        };
+    }
+}

--- a/bindings/java/src/main/com/apple/foundationdb/EventKeeper.java
+++ b/bindings/java/src/main/com/apple/foundationdb/EventKeeper.java
@@ -1,5 +1,5 @@
 /*
- * TransactionTimer.java
+ * EventKeeper.java
  *
  * This source file is part of the FoundationDB open source project
  *
@@ -160,7 +160,7 @@ public interface EventKeeper {
         /**
          * The number of tuples fetched during a range query
          */
-        RANGE_QUERY_TUPLES_FETCHED,
+        RANGE_QUERY_RECORDS_FETCHED,
         /**
          * The number of times a range query chunk fetch failed
          */

--- a/bindings/java/src/main/com/apple/foundationdb/EventKeeper.java
+++ b/bindings/java/src/main/com/apple/foundationdb/EventKeeper.java
@@ -136,7 +136,7 @@ public interface EventKeeper {
         JNI_CALL,
 
         /**
-         * The total number of bytes fetched over the network, from
+         * The total number of bytes pulled from the native layer, including length delimiters., from
          * {@link Transaction#get(byte[])}, {@link Transaction#getKey(KeySelector)},
          * {@link Transaction#getRange(KeySelector, KeySelector)} (and related method
          * overrides), or any other read-type operation which occurs on a Transaction

--- a/bindings/java/src/main/com/apple/foundationdb/EventKeeper.java
+++ b/bindings/java/src/main/com/apple/foundationdb/EventKeeper.java
@@ -30,149 +30,143 @@ import java.util.concurrent.TimeUnit;
  */
 public interface EventKeeper {
 
-    /**
-     * Count the number of events which occurred.
-     * 
-     * @param event the event which occurred
-     * @param amt the number of times that even occurred
-     */
-    void count(Event event, long amt);
+	/**
+	 * Count the number of events which occurred.
+	 *
+	 * @param event the event which occurred
+	 * @param amt the number of times that even occurred
+	 */
+	void count(Event event, long amt);
 
-    /**
-     * Convenience method to add 1 to the number of events which occurred.
-     * 
-     * @param event the event which occurred.
-     */
-    default void increment(Event event) {
-        count(event, 1L);
-    }
+	/**
+	 * Convenience method to add 1 to the number of events which occurred.
+	 *
+	 * @param event the event which occurred.
+	 */
+	default void increment(Event event) { count(event, 1L); }
 
-    /**
-     * Count the time taken to perform an event, in nanoseconds.
-     * 
-     * Note that {@code event.isTimeEvent()} should return true here.
-     * 
-     * @param event the event which was timed (the event should be a time event).
-     * @param nanos the amount of time taken (in nanoseconds)
-     */
-    void timeNanos(Event event, long nanos);
+	/**
+	 * Count the time taken to perform an event, in nanoseconds.
+	 *
+	 * Note that {@code event.isTimeEvent()} should return true here.
+	 *
+	 * @param event the event which was timed (the event should be a time event).
+	 * @param nanos the amount of time taken (in nanoseconds)
+	 */
+	void timeNanos(Event event, long nanos);
 
-    /**
-     * Count the time taken to perform an action, in the specified units.
-     * 
-     * Note that {@code event.isTimeEvent()} should return true.
-     * 
-     * @param event the event which was timed.
-     * @param duration the time taken
-     * @param theUnit the unit of time in which the time measurement was taken
-     */
-    default void time(Event event, long duration, TimeUnit theUnit){
-        timeNanos(event,theUnit.toNanos(duration));
-    }
+	/**
+	 * Count the time taken to perform an action, in the specified units.
+	 *
+	 * Note that {@code event.isTimeEvent()} should return true.
+	 *
+	 * @param event the event which was timed.
+	 * @param duration the time taken
+	 * @param theUnit the unit of time in which the time measurement was taken
+	 */
+	default void time(Event event, long duration, TimeUnit theUnit) { timeNanos(event, theUnit.toNanos(duration)); }
 
-    /**
-     * Get the number of events which occurred since this timer was created.
-     * 
-     * If the event was never recorded, then this returns 0.
-     * 
-     * @param event the event to get the count for
-     * @return the number of times the event was triggered. If the event has never been triggered,
-     * then this returns 0
-     */
-    long getCount(Event event);
+	/**
+	 * Get the number of events which occurred since this timer was created.
+	 *
+	 * If the event was never recorded, then this returns 0.
+	 *
+	 * @param event the event to get the count for
+	 * @return the number of times the event was triggered. If the event has never been triggered,
+	 * then this returns 0
+	 */
+	long getCount(Event event);
 
-    /**
-     * Get the amount of time taken by this event, in nanoseconds.
-     * 
-     * @param event the event to get the time for
-     * @return  the total time measured for this event, in nanoseconds. If the event was never recorded,
-     * return 0 instead.
-     */
-    long getTimeNanos(Event event);
+	/**
+	 * Get the amount of time taken by this event, in nanoseconds.
+	 *
+	 * @param event the event to get the time for
+	 * @return  the total time measured for this event, in nanoseconds. If the event was never recorded,
+	 * return 0 instead.
+	 */
+	long getTimeNanos(Event event);
 
-    /**
-     * Get the amount of time taken by this event, in the specified units.
-     * 
-     * Important note: If the time that was measured in nanoseconds does not evenly divide the unit that
-     * is specified (which is likely, considering time), then some precision may be lost in the conversion. Use
-     * this carefully.
-     * 
-     * @param event the event to get the time for
-     * @param theUnit the unit to get time in
-     * @return  the total time measured for this event, in the specified unit. If the event was never recorded,
-     * return 0.
-     */
-    default long getTime(Event event, TimeUnit theUnit){
-        return theUnit.convert(getTimeNanos(event),TimeUnit.NANOSECONDS);
-    }
+	/**
+	 * Get the amount of time taken by this event, in the specified units.
+	 *
+	 * Important note: If the time that was measured in nanoseconds does not evenly divide the unit that
+	 * is specified (which is likely, considering time), then some precision may be lost in the conversion. Use
+	 * this carefully.
+	 *
+	 * @param event the event to get the time for
+	 * @param theUnit the unit to get time in
+	 * @return  the total time measured for this event, in the specified unit. If the event was never recorded,
+	 * return 0.
+	 */
+	default long getTime(Event event, TimeUnit theUnit) {
+		return theUnit.convert(getTimeNanos(event), TimeUnit.NANOSECONDS);
+	}
 
-    /**
-     * Marker interface for tracking the specific type of event that occurs, and metadata about said event.
-     * 
-     * Implementations should be sure to provide a quality {@code equals} and {@code hashCode}.
-     */
-    interface Event {
-        /**
-         * @return the name of this event, as a unique string. This name should generally be unique, because 
-         * it's likely that {@code EventKeeper} implementations will rely on this for uniqueness.
-         */
-        String name();
+	/**
+	 * Marker interface for tracking the specific type of event that occurs, and metadata about said event.
+	 *
+	 * Implementations should be sure to provide a quality {@code equals} and {@code hashCode}.
+	 */
+	interface Event {
+		/**
+		 * @return the name of this event, as a unique string. This name should generally be unique, because
+		 * it's likely that {@code EventKeeper} implementations will rely on this for uniqueness.
+		 */
+		String name();
 
-        /**
-         * @return true if this event represents a timed event, rather than a counter event. 
-         */
-        default boolean isTimeEvent() {
-            return false;
-        };
-    }
+		/**
+		 * @return true if this event represents a timed event, rather than a counter event.
+		 */
+		default boolean isTimeEvent() { return false; };
+	}
 
-    /**
-     * An enumeration of static events which occur within the FDB Java driver.
-     */
-    enum Events implements Event {
-        /**
-         * The number of JNI calls that were exercised.
-         */
-        JNI_CALL,
+	/**
+	 * An enumeration of static events which occur within the FDB Java driver.
+	 */
+	enum Events implements Event {
+		/**
+		 * The number of JNI calls that were exercised.
+		 */
+		JNI_CALL,
 
-        /**
-         * The total number of bytes pulled from the native layer, including length delimiters., from
-         * {@link Transaction#get(byte[])}, {@link Transaction#getKey(KeySelector)},
-         * {@link Transaction#getRange(KeySelector, KeySelector)} (and related method
-         * overrides), or any other read-type operation which occurs on a Transaction
-         */
-        BYTES_FETCHED,
+		/**
+		 * The total number of bytes pulled from the native layer, including length delimiters., from
+		 * {@link Transaction#get(byte[])}, {@link Transaction#getKey(KeySelector)},
+		 * {@link Transaction#getRange(KeySelector, KeySelector)} (and related method
+		 * overrides), or any other read-type operation which occurs on a Transaction
+		 */
+		BYTES_FETCHED,
 
-        /**
-         * The number of times a DirectBuffer was used to transfer a range query chunk
-         * across the JNI boundary
-         */
-        RANGE_QUERY_DIRECT_BUFFER_HIT,
-        /**
-         * The number of times a range query chunk was unable to use a DirectBuffer to
-         * transfer data across the JNI boundary
-         */
-        RANGE_QUERY_DIRECT_BUFFER_MISS,
-        /**
-         * The number of direct fetches made during a range query
-         */
-        RANGE_QUERY_FETCHES,
-        /**
-         * The number of tuples fetched during a range query
-         */
-        RANGE_QUERY_RECORDS_FETCHED,
-        /**
-         * The number of times a range query chunk fetch failed
-         */
-        RANGE_QUERY_CHUNK_FAILED,
-        /**
-         * The time taken to perform an internal `getRange` fetch, in nanoseconds
-         */
-        RANGE_QUERY_FETCH_TIME_NANOS {
-            @Override
-            public boolean isTimeEvent() {
-                return true;
-            }
-        };
-    }
+		/**
+		 * The number of times a DirectBuffer was used to transfer a range query chunk
+		 * across the JNI boundary
+		 */
+		RANGE_QUERY_DIRECT_BUFFER_HIT,
+		/**
+		 * The number of times a range query chunk was unable to use a DirectBuffer to
+		 * transfer data across the JNI boundary
+		 */
+		RANGE_QUERY_DIRECT_BUFFER_MISS,
+		/**
+		 * The number of direct fetches made during a range query
+		 */
+		RANGE_QUERY_FETCHES,
+		/**
+		 * The number of tuples fetched during a range query
+		 */
+		RANGE_QUERY_RECORDS_FETCHED,
+		/**
+		 * The number of times a range query chunk fetch failed
+		 */
+		RANGE_QUERY_CHUNK_FAILED,
+		/**
+		 * The time taken to perform an internal `getRange` fetch, in nanoseconds
+		 */
+		RANGE_QUERY_FETCH_TIME_NANOS {
+			@Override
+			public boolean isTimeEvent() {
+				return true;
+			}
+		};
+	}
 }

--- a/bindings/java/src/main/com/apple/foundationdb/FDB.java
+++ b/bindings/java/src/main/com/apple/foundationdb/FDB.java
@@ -378,18 +378,64 @@ public class FDB {
 	 *  defining the FoundationDB cluster. This can be {@code null} if the
 	 *  <a href="/foundationdb/administration.html#default-cluster-file" target="_blank">default fdb.cluster file</a>
 	 *  is to be used.
+	 * @param eventKeeper the EventKeeper to use for instrumentation calls, or {@code null} if no instrumentation is desired.
+	 *
+	 * @return a {@code CompletableFuture} that will be set to a FoundationDB {@link Database}
+	 */
+	public Database open(String clusterFilePath, EventKeeper eventKeeper) throws FDBException {
+		return open(clusterFilePath, DEFAULT_EXECUTOR, eventKeeper);
+	}
+
+	/**
+	 * Initializes networking if required and connects to the cluster specified by {@code clusterFilePath}.<br>
+	 *  <br>
+	 *  A single client can use this function multiple times to connect to different
+	 *  clusters simultaneously, with each invocation requiring its own cluster file.
+	 *  To connect to multiple clusters running at different, incompatible versions,
+	 *  the <a href="/foundationdb/api-general.html#multi-version-client-api" target="_blank">multi-version client API</a>
+	 *  must be used.
+	 *
+	 * @param clusterFilePath the
+	 *  <a href="/foundationdb/administration.html#foundationdb-cluster-file" target="_blank">cluster file</a>
+	 *  defining the FoundationDB cluster. This can be {@code null} if the
+	 *  <a href="/foundationdb/administration.html#default-cluster-file" target="_blank">default fdb.cluster file</a>
+	 *  is to be used.
 	 * @param e the {@link Executor} to use to execute asynchronous callbacks
 	 *
 	 * @return a {@code CompletableFuture} that will be set to a FoundationDB {@link Database}
 	 */
 	public Database open(String clusterFilePath, Executor e) throws FDBException {
+		return open(clusterFilePath, e, null);
+	}
+
+	/**
+	 * Initializes networking if required and connects to the cluster specified by {@code clusterFilePath}.<br>
+	 *  <br>
+	 *  A single client can use this function multiple times to connect to different
+	 *  clusters simultaneously, with each invocation requiring its own cluster file.
+	 *  To connect to multiple clusters running at different, incompatible versions,
+	 *  the <a href="/foundationdb/api-general.html#multi-version-client-api" target="_blank">multi-version client API</a>
+	 *  must be used.
+	 *
+	 * @param clusterFilePath the
+	 *  <a href="/foundationdb/administration.html#foundationdb-cluster-file" target="_blank">cluster file</a>
+	 *  defining the FoundationDB cluster. This can be {@code null} if the
+	 *  <a href="/foundationdb/administration.html#default-cluster-file" target="_blank">default fdb.cluster file</a>
+	 *  is to be used.
+	 * @param e the {@link Executor} to use to execute asynchronous callbacks
+	 * @param eventKeeper the {@link EventKeeper} to use to record instrumentation metrics, or {@code null} if no 
+	 *  instrumentation is desired.
+	 *
+	 * @return a {@code CompletableFuture} that will be set to a FoundationDB {@link Database}
+	 */
+	public Database open(String clusterFilePath, Executor e,EventKeeper eventKeeper) throws FDBException {
 		synchronized(this) {
 			if(!isConnected()) {
 				startNetwork();
 			}
 		}
 
-		return new FDBDatabase(Database_create(clusterFilePath), e);
+		return new FDBDatabase(Database_create(clusterFilePath), e, eventKeeper);
 	}
 
 	/**

--- a/bindings/java/src/main/com/apple/foundationdb/FDB.java
+++ b/bindings/java/src/main/com/apple/foundationdb/FDB.java
@@ -428,7 +428,7 @@ public class FDB {
 	 *
 	 * @return a {@code CompletableFuture} that will be set to a FoundationDB {@link Database}
 	 */
-	public Database open(String clusterFilePath, Executor e,EventKeeper eventKeeper) throws FDBException {
+	public Database open(String clusterFilePath, Executor e, EventKeeper eventKeeper) throws FDBException {
 		synchronized(this) {
 			if(!isConnected()) {
 				startNetwork();

--- a/bindings/java/src/main/com/apple/foundationdb/FDBDatabase.java
+++ b/bindings/java/src/main/com/apple/foundationdb/FDBDatabase.java
@@ -37,7 +37,7 @@ class FDBDatabase extends NativeObjectWrapper implements Database, OptionConsume
 		this(cPtr, executor, null);
 	}
 
-	protected FDBDatabase(long cPtr, Executor executor,EventKeeper eventKeeper) {
+	protected FDBDatabase(long cPtr, Executor executor, EventKeeper eventKeeper) {
 		super(cPtr);
 		this.executor = executor;
 		this.options = new DatabaseOptions(this);
@@ -118,6 +118,11 @@ class FDBDatabase extends NativeObjectWrapper implements Database, OptionConsume
 
 	@Override
 	public Transaction createTransaction(Executor e) {
+		return createTransaction(e, eventKeeper);
+	}
+
+	@Override
+	public Transaction createTransaction(Executor e, EventKeeper eventKeeper) {
 		pointerReadLock.lock();
 		Transaction tr = null;
 		try {

--- a/bindings/java/src/main/com/apple/foundationdb/FDBDatabase.java
+++ b/bindings/java/src/main/com/apple/foundationdb/FDBDatabase.java
@@ -31,11 +31,17 @@ import com.apple.foundationdb.async.AsyncUtil;
 class FDBDatabase extends NativeObjectWrapper implements Database, OptionConsumer {
 	private DatabaseOptions options;
 	private final Executor executor;
+	private final EventKeeper eventKeeper;
 
 	protected FDBDatabase(long cPtr, Executor executor) {
+		this(cPtr, executor, null);
+	}
+
+	protected FDBDatabase(long cPtr, Executor executor,EventKeeper eventKeeper) {
 		super(cPtr);
 		this.executor = executor;
 		this.options = new DatabaseOptions(this);
+		this.eventKeeper = eventKeeper;
 	}
 
 	@Override
@@ -115,11 +121,11 @@ class FDBDatabase extends NativeObjectWrapper implements Database, OptionConsume
 		pointerReadLock.lock();
 		Transaction tr = null;
 		try {
-			tr = new FDBTransaction(Database_createTransaction(getPtr()), this, e);
+			tr = new FDBTransaction(Database_createTransaction(getPtr()), this, e, eventKeeper);
 			tr.options().setUsedDuringCommitProtectionDisable();
 			return tr;
-		} catch(RuntimeException err) {
-			if(tr != null) {
+		} catch (RuntimeException err) {
+			if (tr != null) {
 				tr.close();
 			}
 

--- a/bindings/java/src/main/com/apple/foundationdb/FDBTransaction.java
+++ b/bindings/java/src/main/com/apple/foundationdb/FDBTransaction.java
@@ -267,7 +267,7 @@ class FDBTransaction extends NativeObjectWrapper implements Transaction, OptionC
 		}
 		pointerReadLock.lock();
 		try {
-			return new FutureResult(Transaction_get(getPtr(), key, isSnapshot), executor);
+			return new FutureResult(Transaction_get(getPtr(), key, isSnapshot), executor, eventKeeper);
 		} finally {
 			pointerReadLock.unlock();
 		}
@@ -288,7 +288,7 @@ class FDBTransaction extends NativeObjectWrapper implements Transaction, OptionC
 		pointerReadLock.lock();
 		try {
 			return new FutureKey(Transaction_getKey(getPtr(), 
-							selector.getKey(), selector.orEqual(), selector.getOffset(), isSnapshot), executor);
+							selector.getKey(), selector.orEqual(), selector.getOffset(), isSnapshot), executor, eventKeeper);
 		} finally {
 			pointerReadLock.unlock();
 		}
@@ -593,7 +593,7 @@ class FDBTransaction extends NativeObjectWrapper implements Transaction, OptionC
 		}
 		pointerReadLock.lock();
 		try {
-			return new FutureKey(Transaction_getVersionstamp(getPtr()), executor);
+			return new FutureKey(Transaction_getVersionstamp(getPtr()), executor, eventKeeper);
 		} finally {
 			pointerReadLock.unlock();
 		}

--- a/bindings/java/src/main/com/apple/foundationdb/FDBTransaction.java
+++ b/bindings/java/src/main/com/apple/foundationdb/FDBTransaction.java
@@ -267,18 +267,7 @@ class FDBTransaction extends NativeObjectWrapper implements Transaction, OptionC
 		}
 		pointerReadLock.lock();
 		try {
-			CompletableFuture<byte[]> future =
-			    new FutureResult(Transaction_get(getPtr(), key, isSnapshot), executor);
-			if (eventKeeper != null) {
-				future = future.thenApply((bytes) -> {
-					if (bytes != null) {
-						eventKeeper.count(Events.BYTES_FETCHED, bytes.length);
-					}
-					return bytes;
-				});
-			}
-
-			return future;
+			return new FutureResult(Transaction_get(getPtr(), key, isSnapshot), executor,eventKeeper);
 		} finally {
 			pointerReadLock.unlock();
 		}
@@ -298,18 +287,9 @@ class FDBTransaction extends NativeObjectWrapper implements Transaction, OptionC
 		}
 		pointerReadLock.lock();
 		try {
-			CompletableFuture<byte[]> future = new FutureKey(
+			return new FutureKey(
 			    Transaction_getKey(getPtr(), selector.getKey(), selector.orEqual(), selector.getOffset(), isSnapshot),
-			    executor);
-			if (eventKeeper != null) {
-				future = future.thenApply((bytes) -> {
-					if (bytes != null) {
-						eventKeeper.count(Events.BYTES_FETCHED, bytes.length);
-					}
-					return bytes;
-				});
-			}
-			return future;
+			    executor,eventKeeper);
 		} finally {
 			pointerReadLock.unlock();
 		}

--- a/bindings/java/src/main/com/apple/foundationdb/FDBTransaction.java
+++ b/bindings/java/src/main/com/apple/foundationdb/FDBTransaction.java
@@ -191,7 +191,7 @@ class FDBTransaction extends NativeObjectWrapper implements Transaction, OptionC
 		this(cPtr,database,executor,null);
 	}
 
-	protected FDBTransaction(long cPtr, Database database, Executor executor,EventKeeper eventKeeper) {
+	protected FDBTransaction(long cPtr, Database database, Executor executor, EventKeeper eventKeeper) {
 		super(cPtr);
 		this.database = database;
 		this.executor = executor;
@@ -318,7 +318,7 @@ class FDBTransaction extends NativeObjectWrapper implements Transaction, OptionC
 	@Override
 	public AsyncIterable<KeyValue> getRange(KeySelector begin, KeySelector end,
 			int limit, boolean reverse, StreamingMode mode) {
-		return new RangeQuery(this, false, begin, end, limit, reverse, mode,eventKeeper);
+		return new RangeQuery(this, false, begin, end, limit, reverse, mode, eventKeeper);
 	}
 	@Override
 	public AsyncIterable<KeyValue> getRange(KeySelector begin, KeySelector end,
@@ -406,7 +406,7 @@ class FDBTransaction extends NativeObjectWrapper implements Transaction, OptionC
 				Transaction_getRange(getPtr(), begin.getKey(), begin.orEqual(), begin.getOffset(),
 									 end.getKey(), end.orEqual(), end.getOffset(), rowLimit, targetBytes,
 									 streamingMode, iteration, isSnapshot, reverse),
-				FDB.instance().isDirectBufferQueriesEnabled(), executor,eventKeeper);
+				FDB.instance().isDirectBufferQueriesEnabled(), executor, eventKeeper);
 		} finally {
 			pointerReadLock.unlock();
 		}

--- a/bindings/java/src/main/com/apple/foundationdb/FDBTransaction.java
+++ b/bindings/java/src/main/com/apple/foundationdb/FDBTransaction.java
@@ -26,6 +26,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.function.Function;
 
+import com.apple.foundationdb.EventKeeper.Events;
 import com.apple.foundationdb.async.AsyncIterable;
 import com.apple.foundationdb.async.AsyncUtil;
 import com.apple.foundationdb.tuple.ByteArrayUtil;
@@ -34,6 +35,7 @@ class FDBTransaction extends NativeObjectWrapper implements Transaction, OptionC
 	private final Database database;
 	private final Executor executor;
 	private final TransactionOptions options;
+	private final EventKeeper eventKeeper;
 
 	private boolean transactionOwner;
 	public final ReadTransaction snapshot;
@@ -83,9 +85,9 @@ class FDBTransaction extends NativeObjectWrapper implements Transaction, OptionC
 		//  getRange -> KeySelectors
 		///////////////////
 		@Override
-		public AsyncIterable<KeyValue> getRange(KeySelector begin, KeySelector end,
-				int limit, boolean reverse, StreamingMode mode) {
-			return new RangeQuery(FDBTransaction.this, true, begin, end, limit, reverse, mode);
+		public AsyncIterable<KeyValue> getRange(KeySelector begin, KeySelector end, int limit, boolean reverse,
+		                                        StreamingMode mode) {
+			return new RangeQuery(FDBTransaction.this, true, begin, end, limit, reverse, mode, eventKeeper);
 		}
 		@Override
 		public AsyncIterable<KeyValue> getRange(KeySelector begin, KeySelector end,
@@ -185,9 +187,15 @@ class FDBTransaction extends NativeObjectWrapper implements Transaction, OptionC
 	}
 
 	protected FDBTransaction(long cPtr, Database database, Executor executor) {
+		//added for backwards compatibility with subclasses contained in different projects
+		this(cPtr,database,executor,null);
+	}
+
+	protected FDBTransaction(long cPtr, Database database, Executor executor,EventKeeper eventKeeper) {
 		super(cPtr);
 		this.database = database;
 		this.executor = executor;
+		this.eventKeeper = eventKeeper;
 		snapshot = new ReadSnapshot();
 		options = new TransactionOptions(this);
 		transactionOwner = true;
@@ -210,6 +218,17 @@ class FDBTransaction extends NativeObjectWrapper implements Transaction, OptionC
 
 	@Override
 	public void setReadVersion(long version) {
+		/*
+		 * Note that this is done outside of the lock, because we don't want to rely on
+		 * the caller code being particularly efficient, and if we get a bad
+		 * implementation of a eventKeeper, we could end up holding the pointerReadLock for an
+		 * arbitrary amount of time; this would be Bad(TM), so we execute this outside
+		 * the lock, so that in the worst case only the caller thread itself can be hurt
+		 * by bad callbacks.
+		 */
+		if (eventKeeper != null) {
+			eventKeeper.increment(Events.JNI_CALL);
+		}
 		pointerReadLock.lock();
 		try {
 			Transaction_setVersion(getPtr(), version);
@@ -223,6 +242,9 @@ class FDBTransaction extends NativeObjectWrapper implements Transaction, OptionC
 	 */
 	@Override
 	public CompletableFuture<Long> getReadVersion() {
+		if (eventKeeper != null) {
+			eventKeeper.increment(Events.JNI_CALL);
+		}
 		pointerReadLock.lock();
 		try {
 			return new FutureInt64(Transaction_getReadVersion(getPtr()), executor);
@@ -240,6 +262,9 @@ class FDBTransaction extends NativeObjectWrapper implements Transaction, OptionC
 	}
 
 	private CompletableFuture<byte[]> get_internal(byte[] key, boolean isSnapshot) {
+		if (eventKeeper != null) {
+			eventKeeper.increment(Events.JNI_CALL);
+		}
 		pointerReadLock.lock();
 		try {
 			return new FutureResult(Transaction_get(getPtr(), key, isSnapshot), executor);
@@ -257,10 +282,13 @@ class FDBTransaction extends NativeObjectWrapper implements Transaction, OptionC
 	}
 
 	private CompletableFuture<byte[]> getKey_internal(KeySelector selector, boolean isSnapshot) {
+		if (eventKeeper != null) {
+			eventKeeper.increment(Events.JNI_CALL);
+		}
 		pointerReadLock.lock();
 		try {
-			return new FutureKey(Transaction_getKey(getPtr(),
-					selector.getKey(), selector.orEqual(), selector.getOffset(), isSnapshot), executor);
+			return new FutureKey(Transaction_getKey(getPtr(), 
+							selector.getKey(), selector.orEqual(), selector.getOffset(), isSnapshot), executor);
 		} finally {
 			pointerReadLock.unlock();
 		}
@@ -268,6 +296,9 @@ class FDBTransaction extends NativeObjectWrapper implements Transaction, OptionC
 
 	@Override
 	public CompletableFuture<Long> getEstimatedRangeSizeBytes(byte[] begin, byte[] end) {
+		if (eventKeeper != null) {
+			eventKeeper.increment(Events.JNI_CALL);
+		}
 		pointerReadLock.lock();
 		try {
 			return new FutureInt64(Transaction_getEstimatedRangeSizeBytes(getPtr(), begin, end), executor);
@@ -287,7 +318,7 @@ class FDBTransaction extends NativeObjectWrapper implements Transaction, OptionC
 	@Override
 	public AsyncIterable<KeyValue> getRange(KeySelector begin, KeySelector end,
 			int limit, boolean reverse, StreamingMode mode) {
-		return new RangeQuery(this, false, begin, end, limit, reverse, mode);
+		return new RangeQuery(this, false, begin, end, limit, reverse, mode,eventKeeper);
 	}
 	@Override
 	public AsyncIterable<KeyValue> getRange(KeySelector begin, KeySelector end,
@@ -359,9 +390,12 @@ class FDBTransaction extends NativeObjectWrapper implements Transaction, OptionC
 
 	// Users of this function must close the returned FutureResults when finished
 	protected FutureResults getRange_internal(
-			KeySelector begin, KeySelector end,
-			int rowLimit, int targetBytes, int streamingMode,
-			int iteration, boolean isSnapshot, boolean reverse) {
+					KeySelector begin, KeySelector end, 
+					int rowLimit, int targetBytes, int streamingMode, 
+					int iteration, boolean isSnapshot, boolean reverse) {
+		if (eventKeeper != null) {
+			eventKeeper.increment(Events.JNI_CALL);
+		}
 		pointerReadLock.lock();
 		try {
 			/*System.out.println(String.format(
@@ -372,7 +406,7 @@ class FDBTransaction extends NativeObjectWrapper implements Transaction, OptionC
 				Transaction_getRange(getPtr(), begin.getKey(), begin.orEqual(), begin.getOffset(),
 									 end.getKey(), end.orEqual(), end.getOffset(), rowLimit, targetBytes,
 									 streamingMode, iteration, isSnapshot, reverse),
-				FDB.instance().isDirectBufferQueriesEnabled(), executor);
+				FDB.instance().isDirectBufferQueriesEnabled(), executor,eventKeeper);
 		} finally {
 			pointerReadLock.unlock();
 		}
@@ -410,8 +444,10 @@ class FDBTransaction extends NativeObjectWrapper implements Transaction, OptionC
 		addConflictRange(key, ByteArrayUtil.join(key, new byte[] { (byte)0 }), ConflictRangeType.WRITE);
 	}
 
-	private void addConflictRange(byte[] keyBegin, byte[] keyEnd,
-			ConflictRangeType type) {
+	private void addConflictRange(byte[] keyBegin, byte[] keyEnd, ConflictRangeType type) {
+		if (eventKeeper != null) {
+			eventKeeper.increment(Events.JNI_CALL);
+		}
 		pointerReadLock.lock();
 		try {
 			Transaction_addConflictRange(getPtr(), keyBegin, keyEnd, type.code());
@@ -444,8 +480,11 @@ class FDBTransaction extends NativeObjectWrapper implements Transaction, OptionC
 
 	@Override
 	public void set(byte[] key, byte[] value) {
-		if(key == null || value == null)
+		if (key == null || value == null)
 			throw new IllegalArgumentException("Keys/Values must be non-null");
+		if (eventKeeper != null) {
+			eventKeeper.increment(Events.JNI_CALL);
+		}
 		pointerReadLock.lock();
 		try {
 			Transaction_set(getPtr(), key, value);
@@ -456,8 +495,11 @@ class FDBTransaction extends NativeObjectWrapper implements Transaction, OptionC
 
 	@Override
 	public void clear(byte[] key) {
-		if(key == null)
+		if (key == null)
 			throw new IllegalArgumentException("Key cannot be null");
+		if (eventKeeper != null) {
+			eventKeeper.increment(Events.JNI_CALL);
+		}
 		pointerReadLock.lock();
 		try {
 			Transaction_clear(getPtr(), key);
@@ -468,8 +510,11 @@ class FDBTransaction extends NativeObjectWrapper implements Transaction, OptionC
 
 	@Override
 	public void clear(byte[] beginKey, byte[] endKey) {
-		if(beginKey == null || endKey == null)
+		if (beginKey == null || endKey == null)
 			throw new IllegalArgumentException("Keys cannot be null");
+		if (eventKeeper != null) {
+			eventKeeper.increment(Events.JNI_CALL);
+		}
 		pointerReadLock.lock();
 		try {
 			Transaction_clear(getPtr(), beginKey, endKey);
@@ -491,6 +536,9 @@ class FDBTransaction extends NativeObjectWrapper implements Transaction, OptionC
 
 	@Override
 	public void mutate(MutationType optype, byte[] key, byte[] value) {
+		if (eventKeeper != null) {
+			eventKeeper.increment(Events.JNI_CALL);
+		}
 		pointerReadLock.lock();
 		try {
 			Transaction_mutate(getPtr(), optype.code(), key, value);
@@ -501,6 +549,9 @@ class FDBTransaction extends NativeObjectWrapper implements Transaction, OptionC
 
 	@Override
 	public void setOption(int code, byte[] param) {
+		if (eventKeeper != null) {
+			eventKeeper.increment(Events.JNI_CALL);
+		}
 		pointerReadLock.lock();
 		try {
 			Transaction_setOption(getPtr(), code, param);
@@ -511,6 +562,9 @@ class FDBTransaction extends NativeObjectWrapper implements Transaction, OptionC
 
 	@Override
 	public CompletableFuture<Void> commit() {
+		if (eventKeeper != null) {
+			eventKeeper.increment(Events.JNI_CALL);
+		}
 		pointerReadLock.lock();
 		try {
 			return new FutureVoid(Transaction_commit(getPtr()), executor);
@@ -521,6 +575,9 @@ class FDBTransaction extends NativeObjectWrapper implements Transaction, OptionC
 
 	@Override
 	public Long getCommittedVersion() {
+		if (eventKeeper != null) {
+			eventKeeper.increment(Events.JNI_CALL);
+		}
 		pointerReadLock.lock();
 		try {
 			return Transaction_getCommittedVersion(getPtr());
@@ -531,6 +588,9 @@ class FDBTransaction extends NativeObjectWrapper implements Transaction, OptionC
 
 	@Override
 	public CompletableFuture<byte[]> getVersionstamp() {
+		if (eventKeeper != null) {
+			eventKeeper.increment(Events.JNI_CALL);
+		}
 		pointerReadLock.lock();
 		try {
 			return new FutureKey(Transaction_getVersionstamp(getPtr()), executor);
@@ -541,6 +601,9 @@ class FDBTransaction extends NativeObjectWrapper implements Transaction, OptionC
 
 	@Override
 	public CompletableFuture<Long> getApproximateSize() {
+		if (eventKeeper != null) {
+			eventKeeper.increment(Events.JNI_CALL);
+		}
 		pointerReadLock.lock();
 		try {
 			return new FutureInt64(Transaction_getApproximateSize(getPtr()), executor);
@@ -551,6 +614,9 @@ class FDBTransaction extends NativeObjectWrapper implements Transaction, OptionC
 
 	@Override
 	public CompletableFuture<Void> watch(byte[] key) throws FDBException {
+		if (eventKeeper != null) {
+			eventKeeper.increment(Events.JNI_CALL);
+		}
 		pointerReadLock.lock();
 		try {
 			return new FutureVoid(Transaction_watch(getPtr(), key), executor);
@@ -561,24 +627,27 @@ class FDBTransaction extends NativeObjectWrapper implements Transaction, OptionC
 
 	@Override
 	public CompletableFuture<Transaction> onError(Throwable e) {
-		if((e instanceof CompletionException || e instanceof ExecutionException) && e.getCause() != null) {
+		if ((e instanceof CompletionException || e instanceof ExecutionException) && e.getCause() != null) {
 			e = e.getCause();
 		}
-		if(!(e instanceof FDBException)) {
+		if (!(e instanceof FDBException)) {
 			CompletableFuture<Transaction> future = new CompletableFuture<>();
 			future.completeExceptionally(e);
 			return future;
 		}
+		if (eventKeeper != null) {
+			eventKeeper.increment(Events.JNI_CALL);
+		}
 		pointerReadLock.lock();
 		try {
-			CompletableFuture<Void> f = new FutureVoid(Transaction_onError(getPtr(), ((FDBException)e).getCode()), executor);
+			CompletableFuture<Void> f = new FutureVoid(Transaction_onError(getPtr(), ((FDBException) e).getCode()),
+					executor);
 			final Transaction tr = transfer();
-			return f.thenApply(v -> tr)
-				.whenComplete((v, t) -> {
-					if(t != null) {
-						tr.close();
-					}
-				});
+			return f.thenApply(v -> tr).whenComplete((v, t) -> {
+				if (t != null) {
+					tr.close();
+				}
+			});
 		} finally {
 			pointerReadLock.unlock();
 			if(!transactionOwner) {
@@ -589,6 +658,9 @@ class FDBTransaction extends NativeObjectWrapper implements Transaction, OptionC
 
 	@Override
 	public void cancel() {
+		if(eventKeeper!=null){
+			eventKeeper.increment(Events.JNI_CALL);
+		}
 		pointerReadLock.lock();
 		try {
 			Transaction_cancel(getPtr());
@@ -598,6 +670,9 @@ class FDBTransaction extends NativeObjectWrapper implements Transaction, OptionC
 	}
 
 	public CompletableFuture<String[]> getAddressesForKey(byte[] key) {
+		if(eventKeeper!=null){
+			eventKeeper.increment(Events.JNI_CALL);
+		}
 		pointerReadLock.lock();
 		try {
 			return new FutureStrings(Transaction_getKeyLocations(getPtr(), key), executor);
@@ -647,6 +722,9 @@ class FDBTransaction extends NativeObjectWrapper implements Transaction, OptionC
 
 	@Override
 	protected void closeInternal(long cPtr) {
+		if(eventKeeper!=null){
+			eventKeeper.increment(Events.JNI_CALL);
+		}
 		if(transactionOwner) {
 			Transaction_dispose(cPtr);
 		}

--- a/bindings/java/src/main/com/apple/foundationdb/FDBTransaction.java
+++ b/bindings/java/src/main/com/apple/foundationdb/FDBTransaction.java
@@ -289,7 +289,7 @@ class FDBTransaction extends NativeObjectWrapper implements Transaction, OptionC
 		try {
 			return new FutureKey(
 			    Transaction_getKey(getPtr(), selector.getKey(), selector.orEqual(), selector.getOffset(), isSnapshot),
-			    executor,eventKeeper);
+			    executor, eventKeeper);
 		} finally {
 			pointerReadLock.unlock();
 		}

--- a/bindings/java/src/main/com/apple/foundationdb/FutureKey.java
+++ b/bindings/java/src/main/com/apple/foundationdb/FutureKey.java
@@ -26,7 +26,7 @@ import com.apple.foundationdb.EventKeeper.Events;
 
 class FutureKey extends NativeFuture<byte[]> {
 	private final EventKeeper eventKeeper;
-	FutureKey(long cPtr, Executor executor,EventKeeper eventKeeper) {
+	FutureKey(long cPtr, Executor executor, EventKeeper eventKeeper) {
 		super(cPtr);
 		this.eventKeeper = eventKeeper;
 		registerMarshalCallback(executor);
@@ -40,8 +40,9 @@ class FutureKey extends NativeFuture<byte[]> {
 	@Override
 	protected void postMarshal(byte[] value) {
 		if(value!=null && eventKeeper!=null){
-			eventKeeper.count(Events.BYTES_FETCHED,value.length);
+			eventKeeper.count(Events.BYTES_FETCHED, value.length);
 		}
+		super.postMarshal(value);
 	}
 
 	private native byte[] FutureKey_get(long cPtr) throws FDBException;

--- a/bindings/java/src/main/com/apple/foundationdb/FutureKey.java
+++ b/bindings/java/src/main/com/apple/foundationdb/FutureKey.java
@@ -22,22 +22,15 @@ package com.apple.foundationdb;
 
 import java.util.concurrent.Executor;
 
-import com.apple.foundationdb.EventKeeper.Events;
-
 class FutureKey extends NativeFuture<byte[]> {
-	private final EventKeeper eventKeeper;
-	FutureKey(long cPtr, Executor executor, EventKeeper eventKeeper) {
+	FutureKey(long cPtr, Executor executor) {
 		super(cPtr);
 		registerMarshalCallback(executor);
-		this.eventKeeper = eventKeeper;
 	}
 
 	@Override
 	protected byte[] getIfDone_internal(long cPtr) throws FDBException {
 		byte[] bytes = FutureKey_get(cPtr);
-		if (eventKeeper != null) {
-			eventKeeper.count(Events.BYTES_FETCHED, bytes.length);
-		}
 		return bytes;
 	}
 

--- a/bindings/java/src/main/com/apple/foundationdb/FutureResult.java
+++ b/bindings/java/src/main/com/apple/foundationdb/FutureResult.java
@@ -22,24 +22,16 @@ package com.apple.foundationdb;
 
 import java.util.concurrent.Executor;
 
-import com.apple.foundationdb.EventKeeper.Events;
-
 class FutureResult extends NativeFuture<byte[]> {
-	private final EventKeeper eventKeeper;
 
-	FutureResult(long cPtr, Executor executor, EventKeeper eventKeeper) {
+	FutureResult(long cPtr, Executor executor) {
 		super(cPtr);
-		this.eventKeeper = eventKeeper;
 		registerMarshalCallback(executor);
 	}
 
 	@Override
 	protected byte[] getIfDone_internal(long cPtr) throws FDBException {
-		byte[] bytes = FutureResult_get(cPtr);
-		if (eventKeeper != null) {
-			eventKeeper.count(Events.BYTES_FETCHED, bytes.length);
-		}
-		return bytes;
+		return FutureResult_get(cPtr);
 	}
 
 	private native byte[] FutureResult_get(long cPtr) throws FDBException;

--- a/bindings/java/src/main/com/apple/foundationdb/FutureResult.java
+++ b/bindings/java/src/main/com/apple/foundationdb/FutureResult.java
@@ -27,7 +27,7 @@ import com.apple.foundationdb.EventKeeper.Events;
 class FutureResult extends NativeFuture<byte[]> {
 	private final EventKeeper eventKeeper;
 
-	FutureResult(long cPtr, Executor executor,EventKeeper eventKeeper) {
+	FutureResult(long cPtr, Executor executor, EventKeeper eventKeeper) {
 		super(cPtr);
 		this.eventKeeper = eventKeeper;
 		registerMarshalCallback(executor);
@@ -43,6 +43,7 @@ class FutureResult extends NativeFuture<byte[]> {
 		if(value!=null && eventKeeper!=null){
 			eventKeeper.count(Events.BYTES_FETCHED, value.length);
 		}
+		super.postMarshal(value);
 	}
 
 	private native byte[] FutureResult_get(long cPtr) throws FDBException;

--- a/bindings/java/src/main/com/apple/foundationdb/FutureResults.java
+++ b/bindings/java/src/main/com/apple/foundationdb/FutureResults.java
@@ -35,7 +35,7 @@ class FutureResults extends NativeFuture<RangeResultInfo> {
 	}
 
 	@Override
-	protected void postMarshal() {
+	protected void postMarshal(RangeResultInfo rri) {
 		// We can't close because this class actually marshals on-demand
 	}
 

--- a/bindings/java/src/main/com/apple/foundationdb/MapEventKeeper.java
+++ b/bindings/java/src/main/com/apple/foundationdb/MapEventKeeper.java
@@ -1,0 +1,58 @@
+/*
+ * MapEventKeeper.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.apple.foundationdb;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * A simple map-based EventKeeper.
+ *
+ * This class is thread-safe(per the {@link EventKeeper} spec). It holds all counters in memory;
+ */
+public class MapEventKeeper implements EventKeeper {
+	private final ConcurrentMap<Event, AtomicLong> map = new ConcurrentHashMap<>();
+
+	@Override
+	public void count(Event event, long amt) {
+		AtomicLong cnt = map.computeIfAbsent(event, (l) -> new AtomicLong(0L));
+		cnt.addAndGet(amt);
+	}
+
+	@Override
+	public void timeNanos(Event event, long nanos) {
+		count(event, nanos);
+	}
+
+	@Override
+	public long getCount(Event event) {
+		AtomicLong lng = map.get(event);
+		if (lng == null) {
+			return 0L;
+		}
+		return lng.get();
+	}
+
+	@Override
+	public long getTimeNanos(Event event) {
+		return getCount(event);
+	}
+}

--- a/bindings/java/src/main/com/apple/foundationdb/NativeFuture.java
+++ b/bindings/java/src/main/com/apple/foundationdb/NativeFuture.java
@@ -54,8 +54,8 @@ abstract class NativeFuture<T> extends CompletableFuture<T> implements AutoClose
 	}
 
 	private void marshalWhenDone() {
+		T val = null;
 		try {
-			T val = null;
 			boolean shouldComplete = false;
 			try {
 				pointerReadLock.lock();
@@ -77,11 +77,11 @@ abstract class NativeFuture<T> extends CompletableFuture<T> implements AutoClose
 		} catch(Throwable t) {
 			completeExceptionally(t);
 		} finally {
-			postMarshal();
+			postMarshal(val);
 		}
 	}
 
-	protected void postMarshal() {
+	protected void postMarshal(T value) {
 		close();
 	}
 

--- a/bindings/java/src/main/com/apple/foundationdb/NativeFuture.java
+++ b/bindings/java/src/main/com/apple/foundationdb/NativeFuture.java
@@ -53,7 +53,7 @@ abstract class NativeFuture<T> extends CompletableFuture<T> implements AutoClose
 		}
 	}
 
-	void marshalWhenDone() {
+	private void marshalWhenDone() {
 		try {
 			T val = null;
 			boolean shouldComplete = false;

--- a/bindings/java/src/main/com/apple/foundationdb/NativeFuture.java
+++ b/bindings/java/src/main/com/apple/foundationdb/NativeFuture.java
@@ -53,7 +53,7 @@ abstract class NativeFuture<T> extends CompletableFuture<T> implements AutoClose
 		}
 	}
 
-	private void marshalWhenDone() {
+	void marshalWhenDone() {
 		try {
 			T val = null;
 			boolean shouldComplete = false;

--- a/bindings/java/src/main/com/apple/foundationdb/RangeQuery.java
+++ b/bindings/java/src/main/com/apple/foundationdb/RangeQuery.java
@@ -288,7 +288,7 @@ class RangeQuery implements AsyncIterable<KeyValue>, Iterable<KeyValue> {
 						// (note: account for the length fields as well when recording the bytes
 						// fetched)
 						eventKeeper.count(Events.BYTES_FETCHED, result.getKey().length + result.getValue().length + 8);
-						eventKeeper.increment(Events.RANGE_QUERY_TUPLES_FETCHED);
+						eventKeeper.increment(Events.RANGE_QUERY_RECORDS_FETCHED);
 					}
 
 					// If this is the first call to next() on a chunk there cannot

--- a/bindings/java/src/main/com/apple/foundationdb/RangeQuery.java
+++ b/bindings/java/src/main/com/apple/foundationdb/RangeQuery.java
@@ -24,7 +24,6 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executor;
 import java.util.function.BiConsumer;
 
 import com.apple.foundationdb.EventKeeper.Events;
@@ -227,6 +226,7 @@ class RangeQuery implements AsyncIterable<KeyValue>, Iterable<KeyValue> {
 
 			BiConsumer<RangeResultInfo,Throwable> cons = new FetchComplete(fetchingChunk,nextFuture);
 			if(eventKeeper!=null){
+				eventKeeper.increment(Events.RANGE_QUERY_FETCHES);
 				cons = cons.andThen((r,t)->{
 					eventKeeper.timeNanos(Events.RANGE_QUERY_FETCH_TIME_NANOS, System.nanoTime()-sTime);
 				});

--- a/bindings/java/src/main/com/apple/foundationdb/tuple/FastByteComparisons.java
+++ b/bindings/java/src/main/com/apple/foundationdb/tuple/FastByteComparisons.java
@@ -73,6 +73,13 @@ abstract class FastByteComparisons {
     }
 
     /**
+     * @return a byte[] comparator for use in sorting, collections, and so on internally
+     * to the Java code.
+     */
+    public static Comparator<byte[]> comparator(){
+        return LexicographicalComparerHolder.getBestComparer();
+    }
+    /**
      * Pure Java Comparer
      *
      * @return
@@ -290,9 +297,5 @@ abstract class FastByteComparisons {
                 return length1 - length2;
             }
         }
-    }
-
-    public static Comparator<byte[]> comparator() {
-        return LexicographicalComparerHolder.BEST_COMPARER;
     }
 }

--- a/bindings/java/src/tests.cmake
+++ b/bindings/java/src/tests.cmake
@@ -32,6 +32,7 @@ set(JAVA_JUNIT_TESTS
   src/junit/com/apple/foundationdb/tuple/TuplePackingTest.java
   src/junit/com/apple/foundationdb/tuple/TupleSerializationTest.java
   src/junit/com/apple/foundationdb/RangeQueryTest.java
+  src/junit/com/apple/foundationdb/EventKeeperTest.java
   )
 
 # Resources that are used in unit testing, but are not explicitly test files (JUnit rules, utility


### PR DESCRIPTION
This PR resolves #4384 

Changes in this PR:

- Adds an `EventKeeper` interface to allow external plug-in instrumentation
- Adds some (limited) instrumentation to `FDBTransaction` and `RangeQuery` 
- Adds testing to verify instrumentation at java driver level only.

## General guideline:

- If this PR is ready to be merged (and all checkboxes below are either ticked or not applicable), make this a regular PR
- If this PR still needs work, please make this a draft PR
  - If you wish to get feedback/code-review, please add the label RFC to this PR

Please verify that all things listed below were considered and check them. If an item doesn't apply to this type of PR (for example a documentation change doesn't need to be performance tested), you should make a ~~strikethrough~~ (markdown syntax: `~~strikethrough~~`). More infos on the guidlines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

### Style

- [x] All variable and function names make sense.
- [x] The code is properly formatted (consider running `git clang-format`).

### Performance

~~- [ ] All CPU-hot paths are well optimized.~~
~~- [ ] The proper containers are used (for example `std::vector` vs `VectorRef`).~~
~~- [ ] There are no new known `SlowTask` traces.~~

### Testing

~~- [ ] The code was sufficiently tested in simulation.~~
~~- [ ] If there are new parameters or knobs, different values are tested in simulation.~~
~~- [ ] `ASSERT`, `ASSERT_WE_THINK`, and `TEST` macros are added in appropriate places.~~
- [x] Unit tests were added for new algorithms and data structure that make sense to unit-test
~~- [ ] If this is a bugfix: there is a test that can easily reproduce the bug.~~
