### PR TITLE
Add Azure backup dependencies to Docker image

### DIFF
--- a/build/docker/centos6/build/Dockerfile
+++ b/build/docker/centos6/build/Dockerfile
@@ -43,7 +43,6 @@ RUN sed -i -e '/enabled/d' /etc/yum.repos.d/CentOS-Base.repo && \
         tcl-devel \
         unzip \
         wget \
-        libcurl-devel \
         libuuid-devel && \
     yum clean all && \
     rm -rf /var/cache/yum

--- a/build/docker/centos6/build/Dockerfile
+++ b/build/docker/centos6/build/Dockerfile
@@ -31,6 +31,7 @@ RUN sed -i -e '/enabled/d' /etc/yum.repos.d/CentOS-Base.repo && \
         golang \
         java-1.8.0-openjdk-devel \
         libcurl-devel \
+        libuuid-devel \
         libxslt \
         lz4 \
         lz4-devel \
@@ -42,8 +43,7 @@ RUN sed -i -e '/enabled/d' /etc/yum.repos.d/CentOS-Base.repo && \
         rpm-build \
         tcl-devel \
         unzip \
-        wget \
-        libuuid-devel && \
+        wget && \
     yum clean all && \
     rm -rf /var/cache/yum
 

--- a/build/docker/centos6/build/Dockerfile
+++ b/build/docker/centos6/build/Dockerfile
@@ -42,7 +42,9 @@ RUN sed -i -e '/enabled/d' /etc/yum.repos.d/CentOS-Base.repo && \
         rpm-build \
         tcl-devel \
         unzip \
-        wget && \
+        wget \
+        libcurl-devel \
+        libuuid-devel && \
     yum clean all && \
     rm -rf /var/cache/yum
 

--- a/build/docker/centos7/build/Dockerfile
+++ b/build/docker/centos7/build/Dockerfile
@@ -26,6 +26,7 @@ RUN rpmkeys --import mono-project.com.rpmkey.pgp && \
         golang \
         java-11-openjdk-devel \
         libcurl-devel \
+        libuuid-devel \
         libxslt \
         lz4 \
         lz4-devel \
@@ -37,8 +38,7 @@ RUN rpmkeys --import mono-project.com.rpmkey.pgp && \
         rpm-build \
         tcl-devel \
         unzip \
-        wget \
-        libuuid-devel && \
+        wget && \
     yum clean all && \
     rm -rf /var/cache/yum
 

--- a/build/docker/centos7/build/Dockerfile
+++ b/build/docker/centos7/build/Dockerfile
@@ -37,7 +37,9 @@ RUN rpmkeys --import mono-project.com.rpmkey.pgp && \
         rpm-build \
         tcl-devel \
         unzip \
-        wget && \
+        wget \
+        libcurl-devel \
+        libuuid-devel && \
     yum clean all && \
     rm -rf /var/cache/yum
 

--- a/build/docker/centos7/build/Dockerfile
+++ b/build/docker/centos7/build/Dockerfile
@@ -38,7 +38,6 @@ RUN rpmkeys --import mono-project.com.rpmkey.pgp && \
         tcl-devel \
         unzip \
         wget \
-        libcurl-devel \
         libuuid-devel && \
     yum clean all && \
     rm -rf /var/cache/yum


### PR DESCRIPTION
This PR allows `-DBUILD_AZURE_BACKUP` to be enabled on the default docker image.

### Style

- [x] ~All variable and function names make sense.~
- [x] ~The code is properly formatted (consider running `git clang-format`).~

### Performance

- [x] ~All CPU-hot paths are well optimized.~
- [x] ~The proper containers are used (for example `std::vector` vs `VectorRef`).~
- [x] ~There are no new known `SlowTask` traces.~

### Testing

- [x] ~The code was sufficiently tested in simulation.~
- [x] ~If there are new parameters or knobs, different values are tested in simulation.~
- [x] ~`ASSERT`, `ASSERT_WE_THINK`, and `TEST` macros are added in appropriate places.~
- [x] ~Unit tests were added for new algorithms and data structure that make sense to unit-test~
- [x] ~If this is a bugfix: there is a test that can easily reproduce the bug.~
