### PR TITLE
Fix a compile error: Related to pr 3961

### DIFF
--- a/fdbclient/BackupContainerAzureBlobStore.actor.cpp
+++ b/fdbclient/BackupContainerAzureBlobStore.actor.cpp
@@ -90,7 +90,7 @@ public:
 			}
 			m_cursor += length;
 			auto p = static_cast<char const*>(data);
-			buffer.insert(buffer.cend(), p, p + length);
+			buffer.append(p, length);
 			if (buffer.size() > bufferLimit) {
 				return sync();
 			} else {


### PR DESCRIPTION
This PR resolves a compile error when compiling `master` branch using the default `foundationdb/foundationdb-build` docker along with the flag `cmake -DBUILD_AZURE_BACKUP=ON`

Changes in this PR:

- A one line fix to BackupContainerAzureBlobStore.actor.cpp:93 related to a use of std::string::insert and some c++ version differences
- PR may be edited further by @sfc-gh-tclinkenbeard . 
- See https://github.com/apple/foundationdb/pull/3961#issuecomment-787401185
- Code in question is included only if compiled with `cmake -DBUILD_AZURE_BACKUP=ON`

### Style

- [ ] ~~All variable and function names make sense.~~
- [ ] ~~The code is properly formatted (consider running `git clang-format`).~~

### Performance

- [ ] ~~All CPU-hot paths are well optimized.~~
- [ ] ~~The proper containers are used (for example `std::vector` vs `VectorRef`).~~
- [ ] ~~There are no new known `SlowTask` traces.~~

### Testing

- [ ] ~~The code was sufficiently tested in simulation.~~
- [ ] ~~If there are new parameters or knobs, different values are tested in simulation.~~
- [ ] ~~`ASSERT`, `ASSERT_WE_THINK`, and `TEST` macros are added in appropriate places.~~
- [ ] ~~Unit tests were added for new algorithms and data structure that make sense to unit-test~~
- [ ] ~~If this is a bugfix: there is a test that can easily reproduce the bug.~~

I will be happy to manually test the feature once I confirm some other URL format issues I am tracking.