### PR TITLE
Make the RocksDB init method idempotent

### DIFF
--- a/fdbserver/IKeyValueStore.h
+++ b/fdbserver/IKeyValueStore.h
@@ -78,6 +78,8 @@ public:
 			commit()
 			read()
 	*/
+	// `init()` MUST be idempotent as it will be called more than once on a KeyValueStore in case
+	// of a rollback.
 	virtual Future<Void> init() {
 		return Void();
 	}

--- a/fdbserver/KeyValueStoreRocksDB.actor.cpp
+++ b/fdbserver/KeyValueStoreRocksDB.actor.cpp
@@ -123,6 +123,16 @@ struct RocksDBKeyValueStore : IKeyValueStore {
 			}
 		};
 		void action(OpenAction& a) {
+			// If the DB has already been initialized, this should be a no-op.
+			if (db != nullptr) {
+				TraceEvent(SevInfo, "RocksDB")
+				    .detail("Path", a.path)
+				    .detail("Method", "Open")
+				    .detail("Skipping", "Already Open");
+				a.done.send(Void());
+				return;
+			}
+
 			std::vector<rocksdb::ColumnFamilyDescriptor> defaultCF = { rocksdb::ColumnFamilyDescriptor{
 				"default", getCFOptions() } };
 			std::vector<rocksdb::ColumnFamilyHandle*> handle;
@@ -478,3 +488,45 @@ IKeyValueStore* keyValueStoreRocksDB(std::string const& path, UID logID, KeyValu
 	return nullptr;
 #endif // SSD_ROCKSDB_EXPERIMENTAL
 }
+
+#ifdef SSD_ROCKSDB_EXPERIMENTAL
+#include "flow/UnitTest.h"
+
+namespace {
+
+TEST_CASE("fdbserver/KeyValueStoreRocksDB/Reopen") {
+	state const std::string rocksDBTestDir = "rocksdb-kvstore-reopen-test-db";
+	platform::eraseDirectoryRecursive(rocksDBTestDir);
+
+	state IKeyValueStore* kvStore = new RocksDBKeyValueStore(rocksDBTestDir, deterministicRandom()->randomUniqueID());
+	wait(kvStore->init());
+
+	kvStore->set({ LiteralStringRef("foo"), LiteralStringRef("bar") });
+	wait(kvStore->commit(false));
+
+	Optional<Value> val = wait(kvStore->readValue(LiteralStringRef("foo")));
+	ASSERT(Optional<Value>(LiteralStringRef("bar")) == val);
+
+	Future<Void> closed = kvStore->onClosed();
+	kvStore->close();
+	wait(closed);
+
+	kvStore = new RocksDBKeyValueStore(rocksDBTestDir, deterministicRandom()->randomUniqueID());
+	wait(kvStore->init());
+	// Confirm that `init()` is idempotent.
+	wait(kvStore->init());
+
+	Optional<Value> val = wait(kvStore->readValue(LiteralStringRef("foo")));
+	ASSERT(Optional<Value>(LiteralStringRef("bar")) == val);
+
+	Future<Void> closed = kvStore->onClosed();
+	kvStore->close();
+	wait(closed);
+
+	platform::eraseDirectoryRecursive(rocksDBTestDir);
+	return Void();
+}
+
+} // namespace
+
+#endif // SSD_ROCKSDB_EXPERIMENTAL


### PR DESCRIPTION
This PR makes the RocksDB storage engine `init()` method idempotent. After a storage server rollback, the `init()` method gets called a second time. Prior to this PR, that would fail as it would attempt to open a second copy of the RocksDB DB, which is a contract violation. This PR also adds a comment to the KeyValueStore interface noting the requirement on `init()`.  

## General guideline:

- If this PR is ready to be merged (and all checkboxes below are either ticked or not applicable), make this a regular PR
- If this PR still needs work, please make this a draft PR
  - If you wish to get feedback/code-review, please add the label RFC to this PR

Please verify that all things listed below were considered and check them. If an item doesn't apply to this type of PR (for example a documentation change doesn't need to be performance tested), you should make a ~~strikethrough~~ (markdown syntax: `~~strikethrough~~`). More infos on the guidlines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

### Style

- [ ] All variable and function names make sense.
- [ ] The code is properly formatted (consider running `git clang-format`).

### Performance

- [ ] All CPU-hot paths are well optimized.
- [ ] The proper containers are used (for example `std::vector` vs `VectorRef`).
- [ ] There are no new known `SlowTask` traces.

### Testing

- [ ] The code was sufficiently tested in simulation.
- [ ] If there are new parameters or knobs, different values are tested in simulation.
- [ ] `ASSERT`, `ASSERT_WE_THINK`, and `TEST` macros are added in appropriate places.
- [ ] Unit tests were added for new algorithms and data structure that make sense to unit-test
- [ ] If this is a bugfix: there is a test that can easily reproduce the bug.
