### PR TITLE
Fix a clang -Wunused-private-field warning

### DIFF
--- a/fdbclient/MultiVersionTransaction.actor.cpp
+++ b/fdbclient/MultiVersionTransaction.actor.cpp
@@ -773,7 +773,7 @@ void MultiVersionTransaction::reset() {
 // MultiVersionDatabase
 MultiVersionDatabase::MultiVersionDatabase(MultiVersionApi* api, int threadIdx, std::string clusterFilePath,
                                            Reference<IDatabase> db, bool openConnectors)
-  : dbState(new DatabaseState()), threadIdx(threadIdx) {
+  : dbState(new DatabaseState()) {
 	dbState->db = db;
 	dbState->dbVar->set(db);
 

--- a/fdbclient/MultiVersionTransaction.h
+++ b/fdbclient/MultiVersionTransaction.h
@@ -397,7 +397,6 @@ private:
 	};
 
 	const Reference<DatabaseState> dbState;
-	const int threadIdx;
 	friend class MultiVersionTransaction;
 };
 


### PR DESCRIPTION
Another option would be to mark `threadIdx` as `[[maybe_unused]]`