### PR TITLE
Fix bug where regions reported extra satellites

### DIFF
--- a/fdbcli/fdbcli.actor.cpp
+++ b/fdbcli/fdbcli.actor.cpp
@@ -1025,9 +1025,9 @@ void printStatus(StatusObjectReader statusObj, StatusClient::StatusLevel level, 
 					outputString += "\n  Regions: ";
 					regions = statusObjConfig["regions"].get_array();
 					bool isPrimary = false;
-					std::vector<std::string> regionSatelliteDCs;
 					std::string regionDC;
 					for (StatusObjectReader region : regions) {
+						std::vector<std::string> regionSatelliteDCs;
 						for (StatusObjectReader dc : region["datacenters"].get_array()) {
 							if (!dc.has("satellite")) {
 								regionDC = dc["id"].get_str();


### PR DESCRIPTION
Changes in this PR:

- When listing regions in fdbcli status, the second and later regions would erroneously include satellites from prior regions. This change causes the vector of satellites to be reset for each region.

## General guideline:

### Testing

- [x] The code was sufficiently tested in simulation.
