### PR TITLE
anoyes/cluster-for-java-test

### DIFF
--- a/bindings/java/CMakeLists.txt
+++ b/bindings/java/CMakeLists.txt
@@ -307,7 +307,7 @@ if(NOT OPEN_FOR_IDE)
     # 
     # Note: if you are running from ${BUILD_DIR}, additional tests of the native logic will be run. To avoid these, use
     #
-    # ctest . -R junit 
+    # ctest . -R java-unit
     #
     # ctest has lots of flexible command options, so be sure to refer to its documentation if you want to do something specific(documentation
     # can be found at https://cmake.org/cmake/help/v3.19/manual/ctest.1.html)
@@ -359,10 +359,9 @@ if(NOT OPEN_FOR_IDE)
     get_property(integration_jar_path TARGET fdb-integration PROPERTY JAR_FILE)
 
 
-    add_test(NAME java-integration 
-                    COMMAND ${CMAKE_COMMAND} 
-                    -E env "FDB_CLUSTER_FILE=${PROJECT_BINARY_DIR}/fdb.cluster"
-                    ${Java_JAVA_EXECUTABLE}
+    # add_fdbclient_test will set FDB_CLUSTER_FILE if it's not set already
+    add_fdbclient_test(NAME java-integration
+                    COMMAND ${Java_JAVA_EXECUTABLE}
                       -classpath "${target_jar}:${integration_jar_path}:${JUNIT_CLASSPATH}"
                       -Djava.library.path=${CMAKE_BINARY_DIR}/lib
                       org.junit.platform.console.ConsoleLauncher "--details=summary" "--class-path=${integration_jar_path}" "--scan-classpath" "--disable-banner"

--- a/bindings/java/CMakeLists.txt
+++ b/bindings/java/CMakeLists.txt
@@ -350,6 +350,11 @@ if(NOT OPEN_FOR_IDE)
     #
     # To add an integration test, add the relative class file path to the JAVA_INTEGRATION_TESTS variable in `src/tests.cmake`
     #
+    # All integration tests share the same fdb cluster, so you should design
+    # your test with that in mind (e.g. don't depend on the database being
+    # empty, consider generating a random prefix for the keys you write, use
+    # the directory layer with a unique path, etc.)
+    #
     add_jar(fdb-integration SOURCES ${JAVA_INTEGRATION_TESTS} ${JAVA_INTEGRATION_RESOURCES} INCLUDE_JARS fdb-java 
             ${CMAKE_BINARY_DIR}/packages/junit-jupiter-api-5.7.1.jar 
             ${CMAKE_BINARY_DIR}/packages/junit-jupiter-engine-5.7.1.jar

--- a/tests/TestRunner/tmp_cluster.py
+++ b/tests/TestRunner/tmp_cluster.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import os
 import shutil
 import subprocess
 import sys
@@ -52,6 +53,8 @@ if __name__ == '__main__':
     - All occurrences of @DATA_DIR@ will be replaced with the path to the data directory.
     - All occurrences of @LOG_DIR@ will be replaced with the path to the log directory.
     - All occurrences of @ETC_DIR@ will be replaced with the path to the configuration directory.
+
+    The environment variable FDB_CLUSTER_FILE is set to the generated cluster for the command if it is not set already.
     """)
     parser.add_argument('--build-dir', '-b', metavar='BUILD_DIRECTORY', help='FDB build directory', required=True)
     parser.add_argument('cmd', metavar="COMMAND", nargs="+", help="The command to run")
@@ -74,5 +77,7 @@ if __name__ == '__main__':
                 cmd_args.append(str(cluster.etc))
             else:
                 cmd_args.append(cmd)
-        errcode = subprocess.run(cmd_args, stdout=sys.stdout, stderr=sys.stderr).returncode
+        env = dict(**os.environ)
+        env['FDB_CLUSTER_FILE'] = env.get('FDB_CLUSTER_FILE', cluster.etc.joinpath('fdb.cluster'))
+        errcode = subprocess.run(cmd_args, stdout=sys.stdout, stderr=sys.stderr, env=env).returncode
     sys.exit(errcode)


### PR DESCRIPTION
This PR resolves #4390
Changes in this PR:

- Use add_fdbclient_test for java integration tests
- Change add_fdbclient_test to run its subcommand with FDB_CLUSTER_FILE set
-

## General guideline:

- If this PR is ready to be merged (and all checkboxes below are either ticked or not applicable), make this a regular PR
- If this PR still needs work, please make this a draft PR
  - If you wish to get feedback/code-review, please add the label RFC to this PR

Please verify that all things listed below were considered and check them. If an item doesn't apply to this type of PR (for example a documentation change doesn't need to be performance tested), you should make a ~~strikethrough~~ (markdown syntax: `~~strikethrough~~`). More infos on the guidlines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

### Style

- ~~[ ] All variable and function names make sense.~~
- ~~[ ] The code is properly formatted (consider running `git clang-format`).~~

### Performance

- [ ] ~~All CPU-hot paths are well optimized.~~
- [ ] ~~The proper containers are used (for example `std::vector` vs `VectorRef`).~~
- [ ] ~~There are no new known `SlowTask` traces.~~

### Testing

- [ ] ~~The code was sufficiently tested in simulation.~~
- [ ] ~~If there are new parameters or knobs, different values are tested in simulation.~~
- [ ] ~~`ASSERT`, `ASSERT_WE_THINK`, and `TEST` macros are added in appropriate places.~~
- [ ] ~~Unit tests were added for new algorithms and data structure that make sense to unit-test~~
- [ ] ~~If this is a bugfix: there is a test that can easily reproduce the bug.~~
