### PR TITLE
stop downloading RocksDB in dev container

### DIFF
--- a/build/docker/centos6/devel/Dockerfile
+++ b/build/docker/centos6/devel/Dockerfile
@@ -22,7 +22,7 @@ RUN echo -en "\n"\
     "source /opt/rh/rh-ruby24/enable\n"\
     "\n"\
     "function cmk() {\n"\
-    "    cmake -S ${HOME}/src/foundationdb -B build_output -D USE_CCACHE=1 -G Ninja && ninja -C build_output -j 84 \n"\
+    "    cmake -S ${HOME}/src/foundationdb -B build_output -D USE_CCACHE=1 -D RocksDB_ROOT=/opt/rocksdb-6.10.1 -G Ninja && ninja -C build_output -j 84 \n"\
     "}\n"\
     "function ct() {\n"\
     "    cd ${HOME}/build_output && ctest -j 32 --output-on-failure\n"\

--- a/build/docker/centos7/devel/Dockerfile
+++ b/build/docker/centos7/devel/Dockerfile
@@ -27,7 +27,7 @@ RUN echo -en "\n"\
     "source /opt/rh/rh-ruby26/enable\n"\
     "\n"\
     "function cmk() {\n"\
-    "    cmake -S ${HOME}/src/foundationdb -B build_output -D USE_CCACHE=1 -G Ninja && ninja -C build_output -j 84 \n"\
+    "    cmake -S ${HOME}/src/foundationdb -B build_output -D USE_CCACHE=1 -D RocksDB_ROOT=/opt/rocksdb-6.10.1 -G Ninja && ninja -C build_output -j 84 \n"\
     "}\n"\
     "function ct() {\n"\
     "    cd ${HOME}/build_output && ctest -j 32 --output-on-failure\n"\


### PR DESCRIPTION
This PR avoids the download of RocksDB for the development environment alias

Changes in this PR:
- updating the cmake command line in the `cmk` alias


### Style

- [✅ ] All variable and function names make sense.
- [✅ ] The code is properly formatted (consider running `git clang-format`).

### Performance

- [ ] ~~All CPU-hot paths are well optimized.~~
- [ ] ~~The proper containers are used (for example `std::vector` vs `VectorRef`).~~
- [ ] ~~There are no new known `SlowTask` traces.~~

### Testing

- [ ] ~~The code was sufficiently tested in simulation.~~
- [ ] ~~If there are new parameters or knobs, different values are tested in simulation.~~
- [ ] ~~`ASSERT`, `ASSERT_WE_THINK`, and `TEST` macros are added in appropriate places.~~
- [ ] ~~Unit tests were added for new algorithms and data structure that make sense to unit-test~~
- [ ] ~~If this is a bugfix: there is a test that can easily reproduce the bug.~~
