### PR TITLE
Allow Java driver to specify target_bytes directly

### DIFF
--- a/bindings/java/CMakeLists.txt
+++ b/bindings/java/CMakeLists.txt
@@ -59,6 +59,7 @@ set(JAVA_BINDING_SRCS
   src/main/com/apple/foundationdb/TransactionContext.java
   src/main/com/apple/foundationdb/EventKeeper.java
   src/main/com/apple/foundationdb/MapEventKeeper.java
+  src/main/com/apple/foundationdb/TargetBytesStrategy.java
   src/main/com/apple/foundationdb/testing/AbstractWorkload.java
   src/main/com/apple/foundationdb/testing/WorkloadContext.java
   src/main/com/apple/foundationdb/testing/Promise.java

--- a/bindings/java/src/junit/com/apple/foundationdb/EventKeeperTest.java
+++ b/bindings/java/src/junit/com/apple/foundationdb/EventKeeperTest.java
@@ -80,7 +80,7 @@ class EventKeeperTest {
 
 		RangeQuery query = new RangeQuery(txn, true, KeySelector.firstGreaterOrEqual(new byte[] { 0x00 }),
 		                                  KeySelector.firstGreaterOrEqual(new byte[] { (byte)0xFF }), -1, false,
-		                                  StreamingMode.ITERATOR, timer);
+		                                  StreamingMode.ITERATOR, TargetBytesStrategy.deferToNative(),timer);
 		AsyncIterator<KeyValue> iter = query.iterator();
 
 		List<KeyValue> iteratedItems = new ArrayList<>();

--- a/bindings/java/src/main/com/apple/foundationdb/EventKeeper.java
+++ b/bindings/java/src/main/com/apple/foundationdb/EventKeeper.java
@@ -167,6 +167,30 @@ public interface EventKeeper {
 			public boolean isTimeEvent() {
 				return true;
 			}
-		};
-	}
+		},
+        /**
+         * The number of transactions created
+         */
+        TRANSACTIONS_CREATED, 
+        /**
+         * The number of commits executed
+         */
+        COMMITS, 
+        /**
+         * The number of set() calls performed
+         */
+        DATA_SETS, 
+        /**
+         * The number of bytes written
+         */
+        BYTES_WRITTEN, 
+        /**
+         * The number of GET calls executed
+         */
+        GETS, 
+        /**
+         * The number of GET_KEY calls performed
+         */
+        GET_KEY;
+    }
 }

--- a/bindings/java/src/main/com/apple/foundationdb/FDBDatabase.java
+++ b/bindings/java/src/main/com/apple/foundationdb/FDBDatabase.java
@@ -26,6 +26,7 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 
+import com.apple.foundationdb.EventKeeper.Events;
 import com.apple.foundationdb.async.AsyncUtil;
 
 class FDBDatabase extends NativeObjectWrapper implements Database, OptionConsumer {
@@ -126,6 +127,10 @@ class FDBDatabase extends NativeObjectWrapper implements Database, OptionConsume
 		pointerReadLock.lock();
 		Transaction tr = null;
 		try {
+			if(eventKeeper != null ){
+				eventKeeper.increment(Events.JNI_CALL); //setting the option also accounts for a JNI call
+				eventKeeper.increment(Events.TRANSACTIONS_CREATED);
+			}
 			tr = new FDBTransaction(Database_createTransaction(getPtr()), this, e, eventKeeper);
 			tr.options().setUsedDuringCommitProtectionDisable();
 			return tr;

--- a/bindings/java/src/main/com/apple/foundationdb/FutureResults.java
+++ b/bindings/java/src/main/com/apple/foundationdb/FutureResults.java
@@ -67,7 +67,7 @@ class FutureResults extends NativeFuture<RangeResultInfo> {
 			pointerReadLock.lock();
 			if (buffer != null) {
 				try (DirectBufferIterator directIterator = new DirectBufferIterator(buffer)) {
-					FutureResults_getDirect(getPtr(), directIterator.getBuffer(), directIterator.getBuffer().capacity());
+					 FutureResults_getDirect(getPtr(), directIterator.getBuffer(), directIterator.getBuffer().capacity());
 					return new RangeResult(directIterator);
 				}
 			} else {
@@ -81,6 +81,6 @@ class FutureResults extends NativeFuture<RangeResultInfo> {
 	private boolean enableDirectBufferQueries = false;
 
 	private native RangeResult FutureResults_get(long cPtr) throws FDBException;
-	private native boolean FutureResults_getDirect(long cPtr, ByteBuffer buffer, int capacity)
+	private native void FutureResults_getDirect(long cPtr, ByteBuffer buffer, int capacity)
 		throws FDBException;
 }

--- a/bindings/java/src/main/com/apple/foundationdb/RangeResult.java
+++ b/bindings/java/src/main/com/apple/foundationdb/RangeResult.java
@@ -60,7 +60,7 @@ class RangeResult {
 
 	RangeResult(DirectBufferIterator iterator) {
 		iterator.readResultsSummary();
-		more = iterator.hasMore();
+		this.more = iterator.hasMore();
 
 		int count = iterator.count();
 		values = new ArrayList<KeyValue>(count);

--- a/bindings/java/src/main/com/apple/foundationdb/ReadTransaction.java
+++ b/bindings/java/src/main/com/apple/foundationdb/ReadTransaction.java
@@ -229,6 +229,44 @@ public interface ReadTransaction extends ReadTransactionContext {
 			int limit, boolean reverse, StreamingMode mode);
 
 	/**
+	 * Gets an ordered range of keys and values from the database. The begin
+	 *  and end keys are specified by {@code KeySelector}s, with the begin
+	 *  {@code KeySelector} inclusive and the end {@code KeySelector} exclusive.
+	 *
+	 * @see KeySelector
+	 * @see AsyncIterator
+	 *
+	 * @param begin the beginning of the range (inclusive)
+	 * @param end the end of the range (exclusive)
+	 * @param limit the maximum number of results to return. Limits results to the
+	 *  <i>first</i> keys in the range. Pass {@link #ROW_LIMIT_UNLIMITED} if this query
+	 *  should not limit the number of results. If {@code reverse} is {@code true} rows
+	 *  will be limited starting at the end of the range.
+	 * @param reverse return results starting at the end of the range in reverse order.
+	 *  Reading ranges in reverse is supported natively by the database and should
+	 *  have minimal extra cost.
+	 * @param mode provide a hint about how the results are to be used. This
+	 *  can provide speed improvements or efficiency gains based on the caller's
+	 *  knowledge of the upcoming access pattern.
+	 * @param byteLimitStrategy a strategy to hint the maximum number of bytes to return
+	 *  in a single range fetch(i.e. network call). This limit is soft, because the underlying database
+	 *  will always return a full row, even if that exceeds the specified limit.
+	 *
+	 * <p>
+	 *     When converting the result of this query to a list using {@link AsyncIterable#asList()} with the {@code ITERATOR} streaming
+	 *     mode, the query is automatically modified to fetch results in larger batches. This is done because it is
+	 *     known in advance that the {@link AsyncIterable#asList()} function will fetch all results in the range. If a limit is specified,
+	 *     the {@code EXACT} streaming mode will be used, and otherwise it will use {@code WANT_ALL}.
+	 *
+	 *     To achieve comparable performance when iterating over an entire range without using {@link AsyncIterable#asList()}, the same
+	 *     streaming mode would need to be used.
+	 * </p>
+	 * @return a handle to access the results of the asynchronous call
+	 */
+	AsyncIterable<KeyValue> getRange(KeySelector begin, KeySelector end,
+			int limit, boolean reverse, StreamingMode mode, TargetBytesStrategy byteLimitStrategy);
+
+	/**
 	 * Gets an ordered range of keys and values from the database.  The begin
 	 *  and end keys are specified by {@code byte[]} arrays, with the begin
 	 *  key inclusive and the end key exclusive.
@@ -261,6 +299,7 @@ public interface ReadTransaction extends ReadTransactionContext {
 	 */
 	AsyncIterable<KeyValue> getRange(byte[] begin, byte[] end,
 			int limit);
+
 
 	/**
 	 * Gets an ordered range of keys and values from the database.  The begin
@@ -319,6 +358,44 @@ public interface ReadTransaction extends ReadTransactionContext {
 	 */
 	AsyncIterable<KeyValue> getRange(byte[] begin, byte[] end,
 			int limit, boolean reverse, StreamingMode mode);
+
+	/**
+	 * Gets an ordered range of keys and values from the database.  The begin
+	 *  and end keys are specified by {@code byte[]} arrays, with the begin
+	 *  key inclusive and the end key exclusive.
+	 *
+	 * @see KeySelector
+	 * @see AsyncIterator
+	 *
+	 * @param begin the beginning of the range (inclusive)
+	 * @param end the end of the range (exclusive)
+	 * @param limit the maximum number of results to return. Limits results to the
+	 *  <i>first</i> keys in the range. Pass {@link #ROW_LIMIT_UNLIMITED} if this query
+	 *  should not limit the number of results. If {@code reverse} is {@code true} rows
+	 *  will be limited starting at the end of the range.
+	 * @param reverse return results starting at the end of the range in reverse order.
+	 *  Reading ranges in reverse is supported natively by the database and should
+	 *  have minimal extra cost.
+	 * @param mode provide a hint about how the results are to be used. This
+	 *  can provide speed improvements or efficiency gains based on the caller's
+	 *  knowledge of the upcoming access pattern.
+	 * @param byteLimitStrategy a strategy to hint the maximum number of bytes to return
+	 *  in a single range fetch(i.e. network call). This limit is soft, because the underlying database
+	 *  will always return a full row, even if that exceeds the specified limit.
+	 *
+	 * <p>
+	 *     When converting the result of this query to a list using {@link AsyncIterable#asList()} with the {@code ITERATOR} streaming
+	 *     mode, the query is automatically modified to fetch results in larger batches. This is done because it is
+	 *     known in advance that the {@link AsyncIterable#asList()} function will fetch all results in the range. If a limit is specified,
+	 *     the {@code EXACT} streaming mode will be used, and otherwise it will use {@code WANT_ALL}.
+	 *
+	 *     To achieve comparable performance when iterating over an entire range without using {@link AsyncIterable#asList()}, the same
+	 *     streaming mode would need to be used.
+	 * </p>
+	 * @return a handle to access the results of the asynchronous call
+	 */
+	AsyncIterable<KeyValue> getRange(byte[] begin, byte[] end,
+			int limit,boolean reverse, StreamingMode mode,TargetBytesStrategy byteLimitStrategy);
 
 	/**
 	 * Gets an ordered range of keys and values from the database.  The begin

--- a/bindings/java/src/main/com/apple/foundationdb/TargetBytesStrategy.java
+++ b/bindings/java/src/main/com/apple/foundationdb/TargetBytesStrategy.java
@@ -1,0 +1,202 @@
+/*
+ * TargetBytesStrategy.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2018 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apple.foundationdb;
+
+/**
+ * Strategy interface  for defining how to execute range queries and set the soft
+ * target bytes limit more flexibly in java.
+ * 
+ * Notes on operational realities:
+ * 
+ * The target_bytes flag in the FDB client is a soft hint limiting the amount of 
+ * <em>record data</em> that comes back (it does not include key and value size fields
+ * in its calculations). However, every getRange call is guaranteed to return at least
+ * 1 record (assuming that there is 1 record within the scan boundaries). This occurs
+ * even if the target_bytes limit is set to a lower value than the size of the record being
+ * returned. So if you are trying to read a record that is 1k in size, but the first buffer 
+ * is configured to 256, you'll still get that record back.
+ * 
+ * What these strategies do is allow the RangeQuery to control those buffer sizes more effectively.
+ * Larger buffer sizes will work more effectively for larger record sizes, but may consume more memory
+ * so be careful. Conversely, smaller buffer sizes may use less memory, but can be considerably slower, 
+ * depending on the size of the records being returned. 
+ * 
+ * The specific strategy itself matters as well. For known large scans, it may be more effective to use
+ * a fixed-size buffer space, to avoid wasting calls on small buffers. Similarly, for a known small scan,
+ * using fixed small buffers might be optimal. For most other cases, the power-of-2 strategy is probably
+ * the best performing overall.
+ * 
+ * Note that, for legacy compatibility reasons, the default strategy is to defer to the native library, which
+ * is a fixed-array strategy that grows such that the next buffer size is (more of less) 1.5 times larger
+ * than the previous (for more detail see {@code iteration_progression} in {@code bindings/c/fdb_c.cpp}). 
+ * This strategy performs well for very small keys, but may not be optimal when there are larger keys in the 
+ * dataset.
+ * 
+ */
+public interface TargetBytesStrategy {
+	// setting target limit bytes to be 0 will cause the native library to use its own internal bytes limiting
+	TargetBytesStrategy DEFAULT_NATIVE_STRATEGY = new Fixed(0);
+
+	/**
+	 * Get the target byte size to use for this iteration. Note that the target byte size is a hint,
+	 * not a requirement of the native layer (the native layer may ignore this value if it specifies a value that is
+	 * too large--by default around 2^16)
+	 *
+	 * @param iteration the iteration in the range scan
+	 * @return the target byte size for this iteration
+	 */
+	int getTargetByteSize(int iteration);
+
+	/**
+	 * Generate a Target bytes strategy such that at each iteration the buffer size is {@code 1<<(iteration+basePower)} where 
+	 * {@code basePower} is the smallest power of 2 that is larger than {@code initialSize}.
+	 * 
+	 * Note that if the power exceeds the maximum allowed native buffer size (around 2^16), then the returned buffer is scaled
+	 * down to be the maximum possible buffer size.
+	 * 
+	 * @param initialSize the initial buffer size. The first buffer size is actually the smallest power of 2 that is >= {@code initialSize}
+	 * @return a strategy which uses power of two growth in buffer sizes.
+	 */
+	public static TargetBytesStrategy powerOf2(int initialSize) { 
+		if(initialSize <0){
+			throw new IllegalArgumentException("Cannot create a buffer with a negative size");
+		} 	
+		return new PowerOf2(initialSize); 
+	}
+
+	/**
+	 * Generate a byte strategy such that the buffer size is the same for every iteration.
+	 * 
+	 * Note that if the size the maximum allowed native buffer size (around 2^16), then the returned buffer is scaled
+	 * down to be the maximum possible buffer size.
+	 * 
+	 * @param size the size of the buffer to use.
+	 * @return a strategy which uses a fixed size for every iteration
+	 */
+	public static TargetBytesStrategy fixed(int size) { 
+		if (size <-1 ){
+			throw new IllegalArgumentException("Cannot create a buffer with a negative size");
+		}
+		return new Fixed(size); 
+	}
+
+	/**
+	 * Generate a byte strategy which defers to the native buffering logic.
+	 * 
+	 * See {@code bindings/c/fdb_c.cpp} for more information on how the native buffering
+	 * logic works.
+	 * 
+	 * @return a strategy which defers to the native library for buffer sizing
+	 */
+	static TargetBytesStrategy deferToNative() { return DEFAULT_NATIVE_STRATEGY; }
+
+	/**
+	 * Create a strategy which uses a fixed set of values for the buffer sizes. If the iteration
+	 * exceeds the length of the passed in array, it will use the large value in the array for all subsequent
+	 * buffer sizes.
+	 * 
+	 * Note that if any size is larger than the maximum allowed buffer size, then it will be downscaled to
+	 * the largest allowed buffer size.
+	 * 
+	 * @param bufferSizes the array of buffers that are allowed. Must have at least one value
+	 * @return a strategy using {@code bufferSizes} as it's set of buffer sizes.
+	 */
+	static TargetBytesStrategy fixedArray(int... bufferSizes) { 
+		if(bufferSizes==null || bufferSizes.length <1 ){
+			throw new IllegalArgumentException("Cannot create a fixed array strategy without at least one buffer size");
+		}
+		return new FixedArray(bufferSizes); 
+	}
+
+	/**
+	 * Class representing a Fixed TargetBytesStrategy. To create, use {@link #fixed(int)}.
+	 */
+	static class Fixed implements TargetBytesStrategy {
+		// taken from the native layer, adjust if the native layer changes
+		private static final int MAX_FIXED_SIZE = 1<<17; 
+		private final int size;
+
+		@Override
+		public int getTargetByteSize(int iteration) {
+			return size;
+		}
+
+		private Fixed(int size) {
+			if (size > MAX_FIXED_SIZE) {
+				size = MAX_FIXED_SIZE;
+			}
+			this.size = size;
+		}
+	}
+
+	/**
+	 * Class representing a power-of-2 TargetBytesStrategy. To create, use {@link #powerOf2(int)}
+	 */
+	static class PowerOf2 implements TargetBytesStrategy {
+		private static final int MAX_ITERATION_POWER =
+		    17; // keep the buffer size at 131k or below (in practice, the native layer will bound it to 80k anyway)
+		private final int base;
+
+		private PowerOf2(int minSize) {
+			// find the smallest power of 2 lower than minSize, and that's the base
+			int b = 0;
+			int c = 1;
+			while (c < minSize) {
+				c <<= 1;
+				b++;
+			}
+			this.base = b;
+		}
+
+		@Override
+		public int getTargetByteSize(int iteration) {
+			int power = iteration + base;
+			if (power > MAX_ITERATION_POWER) {
+				power = MAX_ITERATION_POWER;
+			}
+			return 1 << (iteration + base);
+		}
+	}
+
+
+	/**
+	 * Class representing a fixed-array strategy. To create, use {@link #fixedArray(int...)}.
+	 */
+	static class FixedArray implements TargetBytesStrategy {
+		private final int[] values;
+
+		private FixedArray(int[] values) { this.values = values; }
+
+		@Override
+		public int getTargetByteSize(int iteration) {
+			if (iteration >= values.length) {
+				return values[values.length - 1];
+			} else {
+				return values[iteration];
+			}
+		}
+
+		@Override
+		public String toString() {
+			return "FixedArray [" +values[0] + "]";
+		}
+	}
+}

--- a/bindings/java/src/test/com/apple/foundationdb/test/ParallelRandomScan.java
+++ b/bindings/java/src/test/com/apple/foundationdb/test/ParallelRandomScan.java
@@ -58,7 +58,7 @@ public class ParallelRandomScan {
 		final AtomicInteger readsCompleted = new AtomicInteger(0);
 		final AtomicInteger errors = new AtomicInteger(0);
 		final Semaphore coordinator = new Semaphore(parallelism);
-		final ContinuousSample<Long> latencies = new ContinuousSample<>(1000);
+		final ContinuousSample<Long> latencies = new ContinuousSample.LongSample(1000);
 
 		try(Transaction tr = database.createTransaction()) {
 			tr.options().setReadYourWritesDisable();

--- a/bindings/java/src/test/com/apple/foundationdb/test/RangeScanBenchmark.java
+++ b/bindings/java/src/test/com/apple/foundationdb/test/RangeScanBenchmark.java
@@ -1,0 +1,759 @@
+/*
+ * RangeScanBenchmark.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2018 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.apple.foundationdb.test;
+
+import java.text.DecimalFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Random;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+import com.apple.foundationdb.Database;
+import com.apple.foundationdb.FDB;
+import com.apple.foundationdb.KeyValue;
+import com.apple.foundationdb.Range;
+import com.apple.foundationdb.StreamingMode;
+import com.apple.foundationdb.TargetBytesStrategy;
+import com.apple.foundationdb.Transaction;
+import com.apple.foundationdb.EventKeeper;
+import com.apple.foundationdb.EventKeeper.Events;
+import com.apple.foundationdb.test.ContinuousSample.DoubleSample;
+import com.apple.foundationdb.test.ContinuousSample.LongSample;
+import com.apple.foundationdb.tuple.ByteArrayUtil;
+
+/**
+ * A benchmarking tool for running a variety of different RangeQuery configurations
+ * on a single client machine.
+ *
+ * There are several dimensions to cover in this benchmark, in two different categories:
+ *
+ * 1. Data configuration
+ * 2. Query configuration
+ *
+ * In the category of Data configuration, we want to know:
+ *
+ * 1. number of records in database
+ * 2. total size of each record (or distribution, if you want it to be non-uniform)
+ *
+ * In the category of query configuration, we want:
+ *
+ * 1. number of records in scan
+ * 2. byte limit configuration(i.e. TargetBytesStrategy)
+ * 3. number of concurrent scans
+ */
+public class RangeScanBenchmark {
+
+	public static void main(String... args) throws Exception {
+		FDB fdb = FDB.selectAPIVersion(700);
+		fdb.enableDirectBufferQuery(true);
+
+		MapTimer timer = new MapTimer();
+		RunStatistics statistics = new RunStatistics(timer);
+		StatisticsFormat formatter = new SimpleComparisonFormat();
+		try (Database db = fdb.open(null, timer)) {
+			DataConfiguration config = configureDataLoad();
+			formatter.printDataSetup("Load" + config.numRows, config);
+			if (config != null) {
+				loadData(db, config);
+			}
+
+			Collection<QueryConfiguration> configuration = configureQueryRuns(config);
+
+			int runCnt = 0;
+			for (QueryConfiguration queryConfig : configuration) {
+				runQueryTest("queryTest" + runCnt, db, config, queryConfig, statistics, formatter);
+				runCnt++;
+			}
+
+			if (config.cleanUpAfter()) {
+				cleanUp(db, config);
+			}
+		}
+	}
+
+	private static DataConfiguration configureDataLoad() {
+		return new DataConfiguration(150, 1000, new Random(), true);
+	}
+
+	private static Collection<QueryConfiguration> configureQueryRuns(DataConfiguration dataCfg) {
+		List<QueryConfiguration> configs = new ArrayList<>();
+		for (int rowSize = 0; rowSize <= dataCfg.numRows; rowSize += 5) {
+			configs.add(new QueryConfiguration(1, 50, rowSize, false, StreamingMode.ITERATOR,
+			                                   TargetBytesStrategy.deferToNative()));
+		}
+		for (int rowSize = 0; rowSize <= dataCfg.numRows; rowSize += 5) {
+			configs.add(
+			    new QueryConfiguration(1, 50, rowSize, false, StreamingMode.ITERATOR, TargetBytesStrategy.fixed(-1)));
+		}
+		for (int rowSize = 0; rowSize <= dataCfg.numRows; rowSize += 5) {
+			configs.add(
+			    new QueryConfiguration(1, 50, rowSize, false, StreamingMode.ITERATOR,
+			                           TargetBytesStrategy.fixedArray(new int[] {
+			                               1024, 2048, 4096, 6144, 9216, 13824, 20736, 31104, 46656, 69984, 80000 })));
+		}
+
+		for (int rowSize = 0; rowSize <= dataCfg.numRows; rowSize += 5) {
+			configs.add(
+			    new QueryConfiguration(1, 50, rowSize, false, StreamingMode.ITERATOR,
+			                           TargetBytesStrategy.fixedArray(new int[] { 2048, 4096, 6144, 9216, 13824, 20736,
+			                                                                      31104, 46656, 69984, 80000 })));
+		}
+
+		for (int rowSize = 0; rowSize <= dataCfg.numRows; rowSize += 5) {
+			configs.add(new QueryConfiguration(1, 50, rowSize, false, StreamingMode.ITERATOR,
+			                                   TargetBytesStrategy.fixedArray(new int[] {
+			                                       4096, 6144, 9216, 13824, 20736, 31104, 46656, 69984, 80000 })));
+		}
+		for (int rowSize = 0; rowSize <= dataCfg.numRows; rowSize += 5) {
+			configs.add(new QueryConfiguration(1, 50, rowSize, false, StreamingMode.ITERATOR,
+			                                   TargetBytesStrategy.powerOf2(1024)));
+		}
+		for (int rowSize = 0; rowSize <= dataCfg.numRows; rowSize += 5) {
+			configs.add(new QueryConfiguration(1, 50, rowSize, false, StreamingMode.ITERATOR,
+			                                   TargetBytesStrategy.powerOf2(2048)));
+		}
+		for (int rowSize = 0; rowSize <= dataCfg.numRows; rowSize += 5) {
+			configs.add(new QueryConfiguration(1, 50, rowSize, false, StreamingMode.ITERATOR,
+			                                   TargetBytesStrategy.powerOf2(4096)));
+		}
+		return configs;
+		//	return Arrays.asList(
+		// full table scans
+		//		    new QueryConfiguration(1, 1, 0, false, StreamingMode.ITERATOR, TargetBytesStrategy.noLimit())
+		/*
+		new QueryConfiguration(2, 100, 0, false, StreamingMode.ITERATOR, TargetBytesStrategy.powerOf2(256)),
+		new QueryConfiguration(2, 100, 0, false, StreamingMode.ITERATOR, TargetBytesStrategy.powerOf2(512)),
+		new QueryConfiguration(2, 100, 0, false, StreamingMode.ITERATOR, TargetBytesStrategy.powerOf2(1024)),
+		new QueryConfiguration(2, 100, 0, false, StreamingMode.ITERATOR, TargetBytesStrategy.fixed(256)),
+		new QueryConfiguration(2, 100, 0, false, StreamingMode.ITERATOR, TargetBytesStrategy.fixed(512)),
+		new QueryConfiguration(2, 100, 0, false, StreamingMode.ITERATOR, TargetBytesStrategy.fixed(1024)),
+
+		//short scans
+		new QueryConfiguration(2, 100,50, false, StreamingMode.ITERATOR, TargetBytesStrategy.noLimit()),
+		new QueryConfiguration(2, 100,50, false, StreamingMode.ITERATOR, TargetBytesStrategy.powerOf2(256)),
+		new QueryConfiguration(2, 100,50, false, StreamingMode.ITERATOR, TargetBytesStrategy.powerOf2(512)),
+		new QueryConfiguration(2, 100,50, false, StreamingMode.ITERATOR, TargetBytesStrategy.powerOf2(1024)),
+		new QueryConfiguration(2, 100,50, false, StreamingMode.ITERATOR, TargetBytesStrategy.fixed(256)),
+		new QueryConfiguration(2, 100,50, false, StreamingMode.ITERATOR, TargetBytesStrategy.fixed(512)),
+		new QueryConfiguration(2, 100,50, false, StreamingMode.ITERATOR, TargetBytesStrategy.fixed(1024)),
+
+		//tiny scans
+		new QueryConfiguration(2, 100,5, false, StreamingMode.ITERATOR, TargetBytesStrategy.noLimit()),
+		new QueryConfiguration(2, 100,5, false, StreamingMode.ITERATOR, TargetBytesStrategy.powerOf2(256)),
+		new QueryConfiguration(2, 100,5, false, StreamingMode.ITERATOR, TargetBytesStrategy.powerOf2(512)),
+		new QueryConfiguration(2, 100,5, false, StreamingMode.ITERATOR, TargetBytesStrategy.powerOf2(1024)),
+		new QueryConfiguration(2, 100,5, false, StreamingMode.ITERATOR, TargetBytesStrategy.fixed(256)),
+		new QueryConfiguration(2, 100,5, false, StreamingMode.ITERATOR, TargetBytesStrategy.fixed(512)),
+		new QueryConfiguration(2, 100,5, false, StreamingMode.ITERATOR, TargetBytesStrategy.fixed(1024))
+		*/
+		//		);
+	}
+
+	private static void doQueryRun(Transaction tr, DataConfiguration dataConfig, QueryConfiguration config,
+	                               RunStatistics statistics) {
+		// select a random key
+		byte[] startKey = dataConfig.getMinKey();
+		byte[] endKey = ByteArrayUtil.strinc(dataConfig.getMaxKey()); // include the ending key
+
+		statistics.scanStarted();
+		Iterable<KeyValue> kvs =
+		    tr.getRange(startKey, endKey, config.rowsPerScan, config.reversed, config.mode, config.byteLimitStrategy);
+		int cnt = 0;
+		int byteSize = 0;
+		for (KeyValue kv : kvs) {
+			byte[] key = kv.getKey();
+			byte[] value = kv.getValue();
+			byteSize += key.length + value.length;
+			cnt++;
+		}
+		statistics.countRuntime(cnt, byteSize);
+	}
+
+	private static void runQueryTest(String testName, Database db, DataConfiguration dataConfig,
+	                                 QueryConfiguration config, RunStatistics statistics, StatisticsFormat formatter)
+	    throws Exception {
+		formatter.printTestSetup(testName, config);
+		// first warm up the query engine. Do this on a single thread
+		for (int i = 0; i < config.numWarmupRuns; i++) {
+			db.run(tr -> {
+				doQueryRun(tr, dataConfig, config, statistics);
+				return null;
+			});
+		}
+
+		// formatter.printTestRun("Warmup", statistics);
+		statistics.clear();
+
+		for (int i = 0; i < config.numIterations; i++) {
+			db.run(tr -> {
+				doQueryRun(tr, dataConfig, config, statistics);
+				return null;
+			});
+		}
+		formatter.printTestRun("Benchmark", statistics);
+		statistics.clear();
+
+		formatter.printTestComplete();
+	}
+
+	private static void loadData(Database db, DataConfiguration configuration) throws Exception {
+		db.run(tr -> {
+			while (configuration.hasNext()) {
+				KeyValue n = configuration.next();
+
+				tr.set(n.getKey(), n.getValue());
+			}
+
+			return null;
+		});
+	}
+
+	private static void cleanUp(Database db, DataConfiguration configuration) throws Exception {
+		db.run(tr -> {
+			tr.clear(new Range(configuration.getMinKey(), ByteArrayUtil.strinc(configuration.getMaxKey())));
+			return null;
+		});
+	}
+
+	private static class QueryConfiguration {
+		private final StreamingMode mode;
+		private final boolean reversed;
+		private final int rowsPerScan;
+		private final int numWarmupRuns;
+		private final int numIterations;
+		private final TargetBytesStrategy byteLimitStrategy;
+
+		public QueryConfiguration(int numWarmupRuns, int numIterations, int rowsPerScan, boolean reversed,
+		                          StreamingMode mode, TargetBytesStrategy byteLimitStrategy) {
+			this.mode = mode;
+			this.reversed = reversed;
+			this.rowsPerScan = rowsPerScan;
+			this.numWarmupRuns = numWarmupRuns;
+			this.numIterations = numIterations;
+			this.byteLimitStrategy = byteLimitStrategy;
+		}
+	}
+
+	private static class DataConfiguration implements Iterator<KeyValue> {
+		private final int numRows;
+		private final int recordSizeBytes;
+		private final Random random;
+		private final boolean cleanUpAfter;
+
+		public DataConfiguration(int numRows, int recordSizeBytes, Random random, boolean cleanUpAfter) {
+			this.numRows = numRows;
+			this.recordSizeBytes = recordSizeBytes;
+			this.cleanUpAfter = cleanUpAfter;
+			this.random = random;
+		}
+
+		private byte[] generateRandomKey() {
+			int size = recordSizeBytes / 2; // random.nextInt(recordSizeBytes - 1);
+			while (size == 0) {
+				size = random.nextInt(recordSizeBytes - 1);
+			}
+			byte[] key = new byte[size];
+			random.nextBytes(key);
+			while (key[0] == (byte)0xFF) {
+				key[0] = (byte)(random.nextInt() & 0x000000FF);
+			}
+
+			return key;
+		}
+
+		private int generated = 0;
+		private byte[] minKey;
+		private byte[] maxKey;
+
+		boolean cleanUpAfter() { return cleanUpAfter; }
+
+		public byte[] getMinKey() { return minKey; }
+
+		public byte[] getMaxKey() { return maxKey; }
+
+		@Override
+		public boolean hasNext() {
+			return generated < numRows;
+		}
+
+		@Override
+		public KeyValue next() {
+			if (!hasNext()) {
+				throw new NoSuchElementException();
+			}
+			generated++;
+			byte[] key = generateRandomKey();
+			byte[] value = new byte[recordSizeBytes - key.length];
+			random.nextBytes(value);
+
+			if (minKey == null) {
+				minKey = Arrays.copyOf(key, key.length);
+			}
+			if (ByteArrayUtil.compareUnsigned(minKey, key) > 0) {
+				if (minKey.length != key.length) {
+					minKey = Arrays.copyOf(key, key.length);
+				} else {
+					System.arraycopy(key, 0, minKey, 0, key.length);
+				}
+			}
+			if (maxKey == null) {
+				maxKey = Arrays.copyOf(key, key.length);
+			}
+			if (ByteArrayUtil.compareUnsigned(key, maxKey) > 0) {
+				if (maxKey.length != key.length) {
+					maxKey = Arrays.copyOf(key, key.length);
+				} else {
+					System.arraycopy(key, 0, maxKey, 0, key.length);
+				}
+			}
+			return new KeyValue(key, value);
+		}
+	}
+
+	private static class RunStatistics {
+		private final MapTimer txnTimer;
+		private LongSample queryFetchTimes = new LongSample(128); // for tracking query fetch times across runs
+		private LongSample recordsRead = new LongSample(128); // for tracking query fetch times across runs
+		private DoubleSample scanRuntime = new DoubleSample(128); // track number of batches required per 100
+		                                                          // records
+		private DoubleSample fullScanQueryThroughput =
+		    new DoubleSample(128); // for tracking query fetch times across runs
+
+		private long startTime;
+
+		private final MapTimer totalTimer = new MapTimer();
+
+		public RunStatistics(MapTimer timer) { this.txnTimer = timer; }
+
+		public void clear() {
+			txnTimer.clear();
+			totalTimer.clear();
+			queryFetchTimes = new LongSample(128);
+			fullScanQueryThroughput = new DoubleSample(128);
+			recordsRead = new LongSample(128);
+			scanRuntime = new DoubleSample(128);
+		}
+
+		public void countRuntime(int rowsReturned, int byteSize) {
+			// byteSize is mainly there to make sure that the key and value fields aren't optimized away
+			long totalRuntime = System.nanoTime() - startTime;
+			if (totalRuntime != 0) {
+				fullScanQueryThroughput.add(((double)rowsReturned) / totalRuntime);
+				scanRuntime.add(totalRuntime);
+			}
+			recordsRead.add(rowsReturned);
+			queryFetchTimes.add(txnTimer.getTimeNanos(EventKeeper.Events.RANGE_QUERY_FETCH_TIME_NANOS));
+			totalTimer.timeNanos(TOTAL_TIME_NANOS, totalRuntime);
+			totalTimer.count(Events.JNI_CALL, txnTimer.getCount(Events.JNI_CALL));
+			totalTimer.count(Events.BYTES_FETCHED, txnTimer.getCount(Events.BYTES_FETCHED));
+			totalTimer.count(Events.RANGE_QUERY_TUPLES_FETCHED, txnTimer.getCount(Events.RANGE_QUERY_TUPLES_FETCHED));
+			totalTimer.count(Events.RANGE_QUERY_FETCHES, txnTimer.getCount(Events.RANGE_QUERY_FETCHES));
+			totalTimer.increment(RANGE_QUERY_COUNT);
+		}
+
+		public void scanStarted() {
+			txnTimer.clear();
+			startTime = System.nanoTime();
+		}
+	}
+
+	private static final EventKeeper.Event RANGE_QUERY_COUNT = new EventKeeper.Event() {
+		@Override
+		public String name() {
+			return "RANGE_QUERY_COUNT";
+		}
+
+		@Override
+		public boolean isTimeEvent() {
+			return false;
+		}
+		@Override
+		public String toString() {
+			return name();
+		}
+	};
+	private static final EventKeeper.Event TOTAL_TIME_NANOS = new EventKeeper.Event() {
+		@Override
+		public String name() {
+			return "TOTAL_TIME_NANOS";
+		}
+
+		@Override
+		public boolean isTimeEvent() {
+			return true;
+		}
+		@Override
+		public String toString() {
+			return name();
+		}
+	};
+
+	private static String toTimeString(long timeNanos) {
+		double seconds = timeNanos / (double)1e9;
+		return String.format("%.9f", seconds);
+	}
+
+	private interface StatisticsFormat {
+		void printDataSetup(String label, DataConfiguration dataCfg);
+
+		void printTestSetup(String label, QueryConfiguration queryCfg);
+
+		void printTestRun(String label, RunStatistics statistics);
+
+		void printTestComplete();
+
+		void printSummary(RunStatistics statistics);
+
+		void printDetails(RunStatistics statistics);
+	}
+
+	private static abstract class BaseFormat implements StatisticsFormat {
+		protected final DecimalFormat lf = new DecimalFormat("#######");
+		protected final DecimalFormat df = new DecimalFormat("#######.###");
+
+		protected abstract String getHline(int numCols);
+		protected abstract String getColumnPattern(int numCols);
+		protected abstract String getHeaderPattern(int numCols);
+
+		@Override
+		public void printDataSetup(String label, DataConfiguration dataCfg) {
+			String cfgPattern = getColumnPattern(2);
+			String cfgHeaderPattern = getColumnPattern(2);
+			String hline = getHline(2);
+			System.out.printf(cfgHeaderPattern, "Data config", "value");
+			System.out.println(hline);
+			System.out.printf(cfgPattern, "Num records", dataCfg.numRows);
+			System.out.printf(cfgPattern, "Record size(bytes)", dataCfg.recordSizeBytes);
+			System.out.println(hline);
+			System.out.println();
+		}
+
+		@Override
+		public void printTestRun(String testName, RunStatistics statistics) {
+			System.out.println(testName);
+			printSummary(statistics);
+			printDetails(statistics);
+		}
+
+		protected String byteStrategyName(TargetBytesStrategy tbs) {
+			String strategyString;
+			if (tbs == TargetBytesStrategy.deferToNative()) {
+				strategyString = "noLimit";
+			} else if (tbs instanceof TargetBytesStrategy.PowerOf2) {
+				strategyString = "powerOf2(" + tbs.getTargetByteSize(0) + ")";
+			} else if (tbs instanceof TargetBytesStrategy.Fixed) {
+				strategyString = "fixed(" + tbs.getTargetByteSize(0) + ")";
+			} else {
+				strategyString = tbs.toString();
+			}
+			return strategyString;
+		}
+	}
+
+	private static class SimpleComparisonFormat extends BaseFormat {
+		private QueryConfiguration testCfg;
+		private DataConfiguration dataCfg;
+
+		@Override
+		public void printTestSetup(String label, QueryConfiguration queryCfg) {
+			this.testCfg = queryCfg;
+		}
+
+		@Override
+		public void printTestComplete() {}
+
+		@Override
+		public void printTestRun(String testName, RunStatistics statistics) {
+			// System.out.println(testName);
+			printSummary(statistics);
+			printDetails(statistics);
+		}
+
+		@Override
+		public void printSummary(RunStatistics statistics) {
+
+			String columnPattern = getColumnPattern(16);
+			EventKeeper timer = statistics.totalTimer;
+			System.out.printf(
+			    columnPattern, dataCfg.numRows, dataCfg.recordSizeBytes, byteStrategyName(testCfg.byteLimitStrategy),
+			    timer.getCount(RANGE_QUERY_COUNT), testCfg.rowsPerScan, timer.getCount(Events.JNI_CALL),
+			    lf.format(timer.getCount(Events.RANGE_QUERY_FETCHES) / timer.getCount(RANGE_QUERY_COUNT)),
+			    df.format(Math.floor(timer.getCount(Events.RANGE_QUERY_TUPLES_FETCHED) /
+			                         (double)timer.getCount(Events.RANGE_QUERY_FETCHES))),
+			    df.format(statistics.queryFetchTimes.median() / 1000f),
+			    df.format(statistics.queryFetchTimes.percentile(.90) / 1000f),
+			    df.format(statistics.scanRuntime.median() / 1000f), df.format(statistics.scanRuntime.p(.90) / 1000f),
+			    df.format(statistics.fullScanQueryThroughput.median() * 1e9),
+			    df.format(timer.getCount(Events.RANGE_QUERY_TUPLES_FETCHED) /
+			              (double)timer.getTimeNanos(TOTAL_TIME_NANOS) * 1e9),
+			    timer.getCount(Events.BYTES_FETCHED),
+			    df.format(timer.getCount(Events.BYTES_FETCHED) / timer.getCount(RANGE_QUERY_COUNT)));
+		}
+
+		@Override
+		public void printDetails(RunStatistics statistics) {
+			// no-op, all data is held in summary
+		}
+		@Override
+		protected String getHline(int numCols) {
+			return "";
+		}
+		@Override
+		protected String getColumnPattern(int numCols) {
+			String line = "%s";
+			for (int i = 0; i < numCols - 1; i++) {
+				line += ",%s";
+			}
+			line += "%n";
+			return line;
+		}
+		@Override
+		protected String getHeaderPattern(int numCols) {
+			return getColumnPattern(numCols);
+		}
+
+		@Override
+		public void printDataSetup(String label, DataConfiguration dataCfg) {
+			super.printDataSetup(label, dataCfg);
+
+			this.dataCfg = dataCfg;
+			String headerPattern = getHeaderPattern(16);
+			System.out.printf(headerPattern, "Num Records", "Record Size(bytes)", "Batch cfg", "Num Scans",
+			                  "Records/Scan", "Num JNI", "Num Fetches/Scan", "Records/Fetch",
+			                  "Median fetch time(micros)", "p90 fetch time(micros)", "Median scan runtime(micros)",
+			                  "p90 scan runtime(micros)", "Median scan throughput", "Overall scan throughput",
+			                  "Num bytes", "bytes/scan");
+		}
+	}
+
+	private static abstract class BaseDetailedTableFormat extends BaseFormat {
+
+		@Override
+		public void printTestSetup(String label, QueryConfiguration queryCfg) {
+			String cfgPattern = getColumnPattern(2);
+			String cfgHeaderPattern = getColumnPattern(2);
+			String hline = getHline(2);
+			System.out.printf(cfgHeaderPattern, "Query config", "value");
+			System.out.println(hline);
+			System.out.printf(cfgPattern, "warmup runs", queryCfg.numWarmupRuns);
+			System.out.printf(cfgPattern, "test runs", queryCfg.numIterations);
+			System.out.printf(cfgPattern, "max records/scan", queryCfg.rowsPerScan);
+			System.out.printf(cfgPattern, "reversed", queryCfg.reversed);
+			System.out.printf(cfgPattern, "mode", queryCfg.mode);
+
+			System.out.printf(cfgPattern, "byte-limit strategy", byteStrategyName(queryCfg.byteLimitStrategy));
+			System.out.println(hline);
+			System.out.println();
+		}
+
+		@Override
+		public void printSummary(RunStatistics statistics) {
+			EventKeeper totalTimer = statistics.totalTimer;
+			long rangeQueries = totalTimer.getCount(RANGE_QUERY_COUNT);
+			long totalRecordsRead = totalTimer.getCount(Events.RANGE_QUERY_TUPLES_FETCHED);
+			long totalTimeNanos = totalTimer.getTimeNanos(TOTAL_TIME_NANOS);
+			long totalFetches = totalTimer.getCount(Events.RANGE_QUERY_FETCHES);
+			long totalJni = totalTimer.getCount(Events.JNI_CALL);
+
+			String summaryPattern = getColumnPattern(2);
+			String summaryHline = getHline(2);
+			System.out.printf(getHeaderPattern(2), "Total Measures", "value");
+			System.out.println(summaryHline);
+			System.out.printf(summaryPattern, "scans", lf.format(rangeQueries));
+			System.out.printf(summaryPattern, "records", lf.format(totalRecordsRead));
+			System.out.printf(summaryPattern, "records/scan", (totalRecordsRead / rangeQueries));
+			System.out.printf(summaryPattern, "runtime(s)", toTimeString(totalTimeNanos));
+			System.out.printf(summaryPattern, "fetches", totalFetches);
+			System.out.printf(summaryPattern, "records/fetch", (totalRecordsRead / totalFetches));
+			System.out.printf(summaryPattern, "fetches/scan", (totalFetches / rangeQueries));
+			System.out.printf(summaryPattern, "JNI calls", totalJni);
+			System.out.printf(summaryPattern, "JNI calls/scan", (totalJni / rangeQueries));
+
+			double tputPerSec = ((double)totalRecordsRead / totalTimeNanos) * 1e9;
+			System.out.printf(summaryPattern, "Throughput(records/s):", df.format(tputPerSec));
+			System.out.printf(summaryPattern, "Bytes read", lf.format(totalTimer.getCount(Events.BYTES_FETCHED)));
+			System.out.printf(summaryPattern, "Bytes/scan",
+			                  df.format(totalTimer.getCount(Events.BYTES_FETCHED) / rangeQueries));
+			System.out.printf(summaryPattern, "Bytes/fetch",
+			                  df.format(totalTimer.getCount(Events.BYTES_FETCHED) / totalFetches));
+			System.out.println(summaryHline);
+		}
+
+		@Override
+		public void printDetails(RunStatistics statistics) {
+			DoubleSample fsqt = statistics.fullScanQueryThroughput;
+			LongSample qft = statistics.queryFetchTimes;
+			DoubleSample runtime = statistics.scanRuntime;
+
+			System.out.println("Detail Statistics");
+			String pattern = getColumnPattern(8); //
+			String headerPattern = getHeaderPattern(8);
+			String detailHline = getHline(8);
+			System.out.printf(headerPattern, "measurement", "min", "median", "p75", "p90", "p95", "max", "mean");
+			System.out.println(detailHline);
+			System.out.printf(pattern, "Throughput(records/s)", df.format(fsqt.min() * 1e9),
+			                  df.format(fsqt.median() * 1e9), df.format(fsqt.p(.75) * 1e9), df.format(fsqt.p(.9) * 1e9),
+			                  df.format(fsqt.p(.95) * 1e9), df.format(fsqt.max() * 1e9), df.format(fsqt.mean() * 1e9));
+			System.out.printf(pattern, "fetch latency(micros)", df.format(qft.min() / 1000f),
+			                  df.format(qft.median() / 1000f), df.format(qft.percentile(.75) / 1000f),
+			                  df.format(qft.percentile(.90) / 1000f), df.format(qft.percentile(.95) / 1000f),
+			                  df.format(qft.max() / 1000f), df.format(qft.mean() / 1000f));
+			System.out.printf(pattern, "scan runtime(micros)", df.format(runtime.min() / 1000f),
+			                  df.format(runtime.median() / 1000f), df.format(runtime.percentile(.75) / 1000f),
+			                  df.format(runtime.percentile(.90) / 1000f), df.format(runtime.percentile(.95) / 1000f),
+			                  df.format(runtime.max() / 1000f), df.format(runtime.mean() / 1000f));
+
+			System.out.println(detailHline);
+			System.out.println();
+		}
+		@Override
+		public void printTestComplete() {
+			// TODO Auto-generated method stub
+		}
+	}
+	private static class CsvTableFormat extends BaseDetailedTableFormat {
+
+		@Override
+		public void printTestComplete() {
+			System.out.println();
+		}
+
+		@Override
+		protected String getHline(int numCols) {
+			return ""; // no hlines in CSV format
+		}
+
+		@Override
+		protected String getColumnPattern(int numCols) {
+			String sep = ",";
+			String pattern = "%s";
+			for (int i = 0; i < numCols - 1; i++) {
+				pattern += sep + "%s";
+			}
+			pattern += "%n";
+			return pattern;
+		}
+
+		@Override
+		protected String getHeaderPattern(int numCols) {
+			return getColumnPattern(numCols);
+		}
+	}
+	private static class PrettyTableFormat extends BaseDetailedTableFormat {
+
+		private static String makeHline(int length) {
+			String hline = "=";
+			for (int i = 0; i < length; i++) {
+				hline += "=";
+			}
+			return hline;
+		}
+
+		@Override
+		public void printTestComplete() {
+			System.out.println();
+		}
+
+		@Override
+		protected String getColumnPattern(int numCols) {
+			String basePattern = "%-22s";
+			for (int i = 0; i < numCols - 1; i++) {
+				basePattern += " | %11s";
+			}
+			basePattern += "%n";
+			return basePattern;
+		}
+
+		@Override
+		protected String getHeaderPattern(int numCols) {
+			String basePattern = "%-22s";
+			for (int i = 0; i < numCols - 1; i++) {
+				basePattern += " |    %-8s";
+			}
+			basePattern += "%n";
+			return basePattern;
+		}
+
+		@Override
+		protected String getHline(int numCols) {
+			return makeHline(numCols * 14 + 8);
+		}
+	}
+
+	private static class MapTimer implements EventKeeper {
+		private final ConcurrentMap<Event, AtomicLong> counterMap = new ConcurrentHashMap<>();
+
+		@Override
+		public void count(Event event, long amt) {
+			AtomicLong l = counterMap.get(event);
+			if (l == null) {
+				l = new AtomicLong(0L);
+				AtomicLong old = counterMap.putIfAbsent(event, l);
+				if (old != null) {
+					l = old;
+				}
+			}
+			l.addAndGet(amt);
+		}
+
+		public void clear() { counterMap.clear(); }
+
+		public void printEvents(String prefix) {
+			System.out.println("[" + prefix + "] Events: ");
+			for (Map.Entry<Event, AtomicLong> entry : counterMap.entrySet()) {
+				Event event = entry.getKey();
+				long cnt = entry.getValue().get();
+				if (event.isTimeEvent()) {
+					System.out.printf("%s: %.3f micros%n", event.name(), cnt / 1000f);
+				} else {
+					System.out.printf("%s: %d %n", event.name(), cnt);
+				}
+			}
+			System.out.println("-------------------");
+		}
+
+		@Override
+		public void timeNanos(Event event, long nanos) {
+			count(event, nanos);
+		}
+
+		@Override
+		public long getCount(Event event) {
+			AtomicLong al = counterMap.get(event);
+			if (al == null) {
+				return 0L;
+			} else {
+				return al.get();
+			}
+		}
+
+		@Override
+		public long getTimeNanos(Event event) {
+			return getCount(event);
+		}
+	}
+}

--- a/bindings/java/src/test/com/apple/foundationdb/test/ScanBufferBenchmark.java
+++ b/bindings/java/src/test/com/apple/foundationdb/test/ScanBufferBenchmark.java
@@ -1,0 +1,151 @@
+/*
+ * ScanBufferBenchmark.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2018 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.apple.foundationdb.test;
+
+import java.util.AbstractMap;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+import com.apple.foundationdb.Database;
+import com.apple.foundationdb.FDB;
+import com.apple.foundationdb.KeyValue;
+import com.apple.foundationdb.Range;
+import com.apple.foundationdb.Transaction;
+import com.apple.foundationdb.TransactionTimer;
+import com.apple.foundationdb.tuple.ByteArrayUtil;
+
+public class ScanBufferBenchmark {
+
+    public static void main(String[] args) throws Exception {
+        int numRows = 1000;
+        int keySizeBytes = 20;
+        int valueSizeBytes = 20;
+        int iterations = 10;
+        int warmUpReads = 2;
+
+        FDB api = FDB.selectAPIVersion(700);
+        api.resizeDirectBufferPool(2, 110016);
+        api.enableDirectBufferQuery(true);
+        MapTimer timer = new MapTimer();
+        try (Database database = api.open(null, timer)) {
+            Map.Entry<byte[], byte[]> bounds = loadData(database, numRows, keySizeBytes, valueSizeBytes);
+            timer.printEvents("Data Load");
+            timer.clear();
+            try {
+                readData(database, timer, bounds, numRows, iterations,warmUpReads);
+            } finally {
+				database.run(tr -> {
+					tr.clear(new Range(bounds.getKey(),ByteArrayUtil.strinc(bounds.getValue())));
+					timer.printEvents("Clear");
+                    timer.clear();
+                    return null;
+				});
+			}
+        }
+    }
+
+	private static void readData(Database database, MapTimer timer, Map.Entry<byte[], byte[]> bounds, int numRows,
+	                             int iterations, int numWarmups) {
+		System.out.println("Warm up Reads:");
+		System.out.println("================");
+        AtomicLong totalFetchTimeNanos = new AtomicLong(0L);
+		for (int i = 0; i < numWarmups; i++) {
+			final String label = "WarmupRead " + i;
+            database.run(tr ->{
+                doRead(tr,timer,bounds,numRows,label);
+                totalFetchTimeNanos.addAndGet(timer.getTimeNanos(TransactionTimer.Events.RANGE_QUERY_FETCH_TIME_NANOS));
+                timer.clear();
+                return null;
+            });
+		}
+        System.out.printf("Total runtime: %.3f micros %n",totalFetchTimeNanos.get()/1000f);
+        System.out.printf("Avg runtime: %.3f micros %n",(totalFetchTimeNanos.get()/numWarmups)/1000f);
+		System.out.println("================");
+
+		System.out.println("Full Reads:");
+		System.out.println("================");
+        totalFetchTimeNanos.set(0L);
+		for (int i = 0; i < iterations; i++) {
+			final String label = "Read " + i;
+            database.run(tr ->{
+                doRead(tr,timer,bounds,numRows,label);
+                totalFetchTimeNanos.addAndGet(timer.getTimeNanos(TransactionTimer.Events.RANGE_QUERY_FETCH_TIME_NANOS));
+                timer.clear();
+                return null;
+            });
+		}
+        System.out.printf("Total runtime: %.3f micros %n",totalFetchTimeNanos.get()/1000f);
+        System.out.printf("Avg runtime: %.3f micros %n",(totalFetchTimeNanos.get()/iterations)/1000f);
+		System.out.println("================");
+	}
+
+	private static void doRead(Transaction tr, MapTimer timer, Map.Entry<byte[], byte[]> bounds, int numRows, String label) {
+		Iterator<KeyValue> kvs = tr.getRange(bounds.getKey(), ByteArrayUtil.strinc(bounds.getValue())).iterator();
+		int cnt = 0;
+		while (kvs.hasNext()) {
+			KeyValue kv = kvs.next();
+			// forcibly materialize the keys and values
+			byte[] key = kv.getKey();
+			byte[] value = kv.getValue();
+			cnt++;
+		}
+
+		timer.printEvents(label + "(numRows=" + cnt + ")");
+	}
+
+	private static Map.Entry<byte[], byte[]> loadData(Database database, int numRows, int keySizeBytes, int valueSizeBytes) throws Exception {
+        /*
+         * Returns the smallest and the largest byte[] loaded
+         */
+        return database.run(tr -> {
+            byte[] minKey = null;
+            byte[] maxKey = null;
+
+            Random randomGen = new Random();
+            byte[] key = new byte[keySizeBytes];
+            byte[] value = new byte[valueSizeBytes];
+            for (int i = 0; i < numRows; i++) {
+                randomGen.nextBytes(key);
+                randomGen.nextBytes(value);
+                if(key[0] == (byte)0xFF){
+                    key[0] = (byte)0xEF;
+                }
+                if (minKey == null) {
+                    minKey = Arrays.copyOf(key, key.length);
+                } else if (ByteArrayUtil.compareUnsigned(minKey, key) > 0) {
+                    System.arraycopy(key, 0, minKey, 0, key.length);
+                }
+                if (maxKey == null) {
+                    maxKey = Arrays.copyOf(key, key.length);
+                } else if (ByteArrayUtil.compareUnsigned(key, maxKey) > 0) {
+                    System.arraycopy(key, 0, maxKey, 0, key.length);
+                }
+
+                tr.set(key, value);
+            }
+            return new AbstractMap.SimpleEntry<>(minKey, maxKey);
+        });
+    }
+}

--- a/bindings/java/src/tests.cmake
+++ b/bindings/java/src/tests.cmake
@@ -53,6 +53,7 @@ set(JAVA_INTEGRATION_TESTS
 # utility classes, and so forth)
 set(JAVA_INTEGRATION_RESOURCES
   src/integration/com/apple/foundationdb/RequiresDatabase.java
+  src/integration/com/apple/foundationdb/MapTimer.java
 )
 
 


### PR DESCRIPTION
This PR resolves #4413

Changes in this PR:

- allows java code to specify a `TargetBytesStrategy`, which can control the buffer sizing directly
- prevents native code from overriding larger buffer sizes
- Adds a benchmark for simple scans that changes target bytes strategy
- Adds integration test to make sure that the TargetBytesStrategy is being obeyed properly

## General guideline:

- If this PR is ready to be merged (and all checkboxes below are either ticked or not applicable), make this a regular PR
- If this PR still needs work, please make this a draft PR
  - If you wish to get feedback/code-review, please add the label RFC to this PR

Please verify that all things listed below were considered and check them. If an item doesn't apply to this type of PR (for example a documentation change doesn't need to be performance tested), you should make a ~~strikethrough~~ (markdown syntax: `~~strikethrough~~`). More infos on the guidlines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

### Style

- [X ] All variable and function names make sense.
- [ X] The code is properly formatted (consider running `git clang-format`).

### Performance

~~- [ ] All CPU-hot paths are well optimized.~~
~~- [ ] The proper containers are used (for example `std::vector` vs `VectorRef`).~~
~~- [ ] There are no new known `SlowTask` traces.~~

### Testing

~~- [ ] The code was sufficiently tested in simulation.~~
~~- [ ] If there are new parameters or knobs, different values are tested in simulation.~~
~~- [ ] `ASSERT`, `ASSERT_WE_THINK`, and `TEST` macros are added in appropriate places.~~
- [X ] Unit tests were added for new algorithms and data structure that make sense to unit-test
~~- [ ] If this is a bugfix: there is a test that can easily reproduce the bug.~~
