### PR TITLE
Add async rename

### DIFF
--- a/fdbrpc/AsyncFileWinASIO.actor.h
+++ b/fdbrpc/AsyncFileWinASIO.actor.h
@@ -128,6 +128,12 @@ public:
 
 		return result.getFuture();
 	}
+
+	static Future<Void> renameFile(std::string const& from, std::string const& to) {
+		::renameFile(from, to);
+		return Void();
+	}
+
 	virtual Future<Void> write( void const* data, int length, int64_t offset ) {
 		/*
 		FIXME

--- a/fdbrpc/IAsyncFile.h
+++ b/fdbrpc/IAsyncFile.h
@@ -20,6 +20,7 @@
 
 #ifndef FLOW_IASYNCFILE_H
 #define FLOW_IASYNCFILE_H
+#include <string>
 #pragma once
 
 #include <ctime>
@@ -97,6 +98,9 @@ public:
 
 	// Deletes the given file.  If mustBeDurable, returns only when the file is guaranteed to be deleted even after a power failure.
 	virtual Future< Void > deleteFile( std::string filename, bool mustBeDurable ) = 0;
+
+	// renames the file, doesn't sync the directory
+	virtual Future<Void> renameFile(std::string const& from, std::string const& to) = 0;
 
 	// Unlinks a file and then deletes it slowly by truncating the file repeatedly.
 	// If mustBeDurable, returns only when the file is guaranteed to be deleted even after a power failure.

--- a/fdbrpc/Net2FileSystem.cpp
+++ b/fdbrpc/Net2FileSystem.cpp
@@ -116,7 +116,7 @@ Net2FileSystem::Net2FileSystem(double ioTimeout, std::string fileSystemPath)
 }
 
 Future<Void> Net2FileSystem::renameFile(const std::string &from, const std::string &to) {
-	return Void();
+	return Net2AsyncFile::renameFile(from, to);
 }
 
 void Net2FileSystem::stop() {

--- a/fdbrpc/Net2FileSystem.cpp
+++ b/fdbrpc/Net2FileSystem.cpp
@@ -115,6 +115,10 @@ Net2FileSystem::Net2FileSystem(double ioTimeout, std::string fileSystemPath)
 #endif
 }
 
+Future<Void> Net2FileSystem::renameFile(const std::string &from, const std::string &to) {
+	return Void();
+}
+
 void Net2FileSystem::stop() {
 	Net2AsyncFile::stop();
 }

--- a/fdbrpc/Net2FileSystem.h
+++ b/fdbrpc/Net2FileSystem.h
@@ -20,6 +20,7 @@
 
 #ifndef FLOW_NET2FILESYSTEM_H
 #define FLOW_NET2FILESYSTEM_H
+#include <string>
 #pragma once
 
 #include "fdbrpc/IAsyncFile.h"
@@ -27,13 +28,15 @@
 class Net2FileSystem : public IAsyncFileSystem {
 public:
 	// Opens a file for asynchronous I/O
-	virtual Future< Reference<class IAsyncFile> > open( std::string filename, int64_t flags, int64_t mode );
+	Future< Reference<class IAsyncFile> > open( std::string filename, int64_t flags, int64_t mode ) override;
 
 	// Deletes the given file.  If mustBeDurable, returns only when the file is guaranteed to be deleted even after a power failure.
-	virtual Future< Void > deleteFile( std::string filename, bool mustBeDurable );
+	Future< Void > deleteFile( std::string filename, bool mustBeDurable ) override;
+
+	Future<Void> renameFile(std::string const& from, std::string const& to) override;
 
 	// Returns the time of the last modification of the file.
-	virtual Future< std::time_t > lastWriteTime( std::string filename );
+	Future< std::time_t > lastWriteTime( std::string filename ) override;
 
 	//void init();
 	static void stop();

--- a/fdbrpc/sim2.actor.cpp
+++ b/fdbrpc/sim2.actor.cpp
@@ -20,6 +20,7 @@
 
 #include <cinttypes>
 
+#include "IRandom.h"
 #include "fdbrpc/simulator.h"
 #include "flow/IThreadPool.h"
 #include "flow/Util.h"
@@ -1845,6 +1846,11 @@ Future< Reference<class IAsyncFile> > Sim2FileSystem::open( std::string filename
 Future< Void > Sim2FileSystem::deleteFile( std::string filename, bool mustBeDurable )
 {
 	return Sim2::deleteFileImpl(&g_sim2, filename, mustBeDurable);
+}
+
+Future<Void> Sim2FileSystem::renameFile(std::string const& from, std::string const& to) {
+	::renameFile(from, to);
+	return delay(deterministicRandom()->random01());
 }
 
 Future< std::time_t > Sim2FileSystem::lastWriteTime( std::string filename ) {

--- a/fdbrpc/sim2.actor.cpp
+++ b/fdbrpc/sim2.actor.cpp
@@ -20,7 +20,6 @@
 
 #include <cinttypes>
 
-#include "IRandom.h"
 #include "fdbrpc/simulator.h"
 #include "flow/IThreadPool.h"
 #include "flow/Util.h"

--- a/fdbrpc/sim2.actor.cpp
+++ b/fdbrpc/sim2.actor.cpp
@@ -22,7 +22,7 @@
 #include <string>
 
 #include "fdbrpc/simulator.h"
-#include "flow.h"
+#include "flow/flow.h"
 #include "flow/IThreadPool.h"
 #include "flow/Util.h"
 #include "fdbrpc/IAsyncFile.h"

--- a/fdbrpc/sim2.actor.cpp
+++ b/fdbrpc/sim2.actor.cpp
@@ -19,8 +19,10 @@
  */
 
 #include <cinttypes>
+#include <string>
 
 #include "fdbrpc/simulator.h"
+#include "flow.h"
 #include "flow/IThreadPool.h"
 #include "flow/Util.h"
 #include "fdbrpc/IAsyncFile.h"
@@ -1847,9 +1849,15 @@ Future< Void > Sim2FileSystem::deleteFile( std::string filename, bool mustBeDura
 	return Sim2::deleteFileImpl(&g_sim2, filename, mustBeDurable);
 }
 
-Future<Void> Sim2FileSystem::renameFile(std::string const& from, std::string const& to) {
+ACTOR Future<Void> renameFileImpl(std::string from, std::string to) {
+	wait(delay(0.5*deterministicRandom()->random01()));
 	::renameFile(from, to);
-	return delay(deterministicRandom()->random01());
+	wait(delay(0.5*deterministicRandom()->random01()));
+	return Void();
+}
+
+Future<Void> Sim2FileSystem::renameFile(std::string const& from, std::string const& to) {
+	return renameFileImpl(from, to);
 }
 
 Future< std::time_t > Sim2FileSystem::lastWriteTime( std::string filename ) {

--- a/fdbrpc/simulator.h
+++ b/fdbrpc/simulator.h
@@ -20,6 +20,7 @@
 
 #ifndef FLOW_SIMULATOR_H
 #define FLOW_SIMULATOR_H
+#include <string>
 #pragma once
 
 #include "flow/flow.h"
@@ -361,12 +362,14 @@ extern Future<Void> waitUntilDiskReady(Reference<DiskParameters> parameters, int
 class Sim2FileSystem : public IAsyncFileSystem {
 public:
 	// Opens a file for asynchronous I/O
-	virtual Future< Reference<class IAsyncFile> > open( std::string filename, int64_t flags, int64_t mode );
+	Future<Reference<class IAsyncFile>> open( std::string filename, int64_t flags, int64_t mode ) override;
 
 	// Deletes the given file.  If mustBeDurable, returns only when the file is guaranteed to be deleted even after a power failure.
-	virtual Future< Void > deleteFile( std::string filename, bool mustBeDurable );
+	Future<Void> deleteFile(std::string filename, bool mustBeDurable) override;
 
-	virtual Future< std::time_t > lastWriteTime( std::string filename );
+	Future<Void> renameFile(std::string const& from, std::string const& to) override;
+
+	Future< std::time_t > lastWriteTime( std::string filename ) override;
 
 	Sim2FileSystem() {}
 


### PR DESCRIPTION
We ran into issues where slow metadata operations on NFS slows down backup_agents enough to create failures. This causes a backup to slow down and potentially stall.

This change adds a new rename function to AsyncFileSystem that utilizes EIO in order to execute this in another thread. This will not make renames go faster, but it will not block the network thread.

This still needs to be plumbed into the backup_agent, but this will be added in a later PR.