### PR TITLE
Apply clang-tidy's performance-inefficient-vector-operation fix

### DIFF
--- a/documentation/tutorial/tutorial.actor.cpp
+++ b/documentation/tutorial/tutorial.actor.cpp
@@ -460,6 +460,7 @@ int main(int argc, char* argv[]) {
 	}
 	// now we start the actors
 	std::vector<Future<Void>> all;
+	all.reserve(toRun.size());
 	for (auto& f : toRun) {
 		all.emplace_back(f());
 	}

--- a/fdbclient/ManagementAPI.actor.cpp
+++ b/fdbclient/ManagementAPI.actor.cpp
@@ -1059,7 +1059,8 @@ ACTOR Future<Optional<CoordinatorsResult>> changeQuorumChecker(Transaction* tr, 
 
 	vector<Future<Optional<LeaderInfo>>> leaderServers;
 	ClientCoordinators coord( Reference<ClusterConnectionFile>( new ClusterConnectionFile( conn ) ) );
-	for( int i = 0; i < coord.clientLeaderServers.size(); i++ )
+	leaderServers.reserve(coord.clientLeaderServers.size());
+	for (int i = 0; i < coord.clientLeaderServers.size(); i++)
 		leaderServers.push_back( retryBrokenPromise( coord.clientLeaderServers[i].getLeader, GetLeaderRequest( coord.clusterKey, UID() ), TaskPriority::CoordinationReply ) );
 
 	choose {
@@ -1138,7 +1139,8 @@ ACTOR Future<CoordinatorsResult> changeQuorum(Database cx, Reference<IQuorumChan
 
 			vector<Future<Optional<LeaderInfo>>> leaderServers;
 			ClientCoordinators coord( Reference<ClusterConnectionFile>( new ClusterConnectionFile( conn ) ) );
-			for( int i = 0; i < coord.clientLeaderServers.size(); i++ )
+			leaderServers.reserve(coord.clientLeaderServers.size());
+			for (int i = 0; i < coord.clientLeaderServers.size(); i++)
 				leaderServers.push_back( retryBrokenPromise( coord.clientLeaderServers[i].getLeader, GetLeaderRequest( coord.clusterKey, UID() ), TaskPriority::CoordinationReply ) );
 
 			choose {
@@ -1224,6 +1226,7 @@ struct AutoQuorumChange final : IQuorumChange {
 		// Check availability
 		ClientCoordinators coord(ccf);
 		vector<Future<Optional<LeaderInfo>>> leaderServers;
+		leaderServers.reserve(coord.clientLeaderServers.size());
 		for (int i = 0; i < coord.clientLeaderServers.size(); i++) {
 			leaderServers.push_back( retryBrokenPromise( coord.clientLeaderServers[i].getLeader, GetLeaderRequest( coord.clusterKey, UID() ), TaskPriority::CoordinationReply ) );
 		}

--- a/fdbclient/MonitorLeader.actor.cpp
+++ b/fdbclient/MonitorLeader.actor.cpp
@@ -463,7 +463,8 @@ ACTOR Future<MonitorLeaderInfo> monitorLeaderOneGeneration( Reference<ClusterCon
 
 	std::vector<Future<Void>> actors;
 	// Ask all coordinators if the worker is considered as a leader (leader nominee) by the coordinator.
-	for(int i=0; i<coordinators.clientLeaderServers.size(); i++)
+	actors.reserve(coordinators.clientLeaderServers.size());
+	for (int i = 0; i < coordinators.clientLeaderServers.size(); i++)
 		actors.push_back( monitorNominee( coordinators.clusterKey, coordinators.clientLeaderServers[i], &nomineeChange, &nominees[i] ) );
 	allActors = waitForAll(actors);
 
@@ -646,7 +647,8 @@ ACTOR Future<Void> monitorLeaderForProxies( Key clusterKey, vector<NetworkAddres
 
 	std::vector<Future<Void>> actors;
 	// Ask all coordinators if the worker is considered as a leader (leader nominee) by the coordinator.
-	for(int i=0; i<clientLeaderServers.size(); i++) {
+	actors.reserve(clientLeaderServers.size());
+	for (int i = 0; i < clientLeaderServers.size(); i++) {
 		actors.push_back( monitorNominee( clusterKey, clientLeaderServers[i], &nomineeChange, &nominees[i] ) );
 	}
 	actors.push_back( getClientInfoFromLeader( knownLeader, clientData ) );

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -1775,7 +1775,8 @@ ACTOR Future<Optional<StorageServerInterface>> fetchServerInterface( Database cx
 
 ACTOR Future<Optional<vector<StorageServerInterface>>> transactionalGetServerInterfaces( Future<Version> ver, Database cx, TransactionInfo info, vector<UID> ids, TagSet tags ) {
 	state vector< Future< Optional<StorageServerInterface> > > serverListEntries;
-	for( int s = 0; s < ids.size(); s++ ) {
+	serverListEntries.reserve(ids.size());
+	for (int s = 0; s < ids.size(); s++) {
 		serverListEntries.push_back( fetchServerInterface( cx, info, ids[s], tags, ver ) );
 	}
 
@@ -4915,6 +4916,7 @@ ACTOR Future<bool> checkSafeExclusions(Database cx, vector<AddressExclusion> exc
 	TraceEvent("ExclusionSafetyCheckCoordinators");
 	state ClientCoordinators coordinatorList(cx->getConnectionFile());
 	state vector<Future<Optional<LeaderInfo>>> leaderServers;
+	leaderServers.reserve(coordinatorList.clientLeaderServers.size());
 	for (int i = 0; i < coordinatorList.clientLeaderServers.size(); i++) {
 		leaderServers.push_back(retryBrokenPromise(coordinatorList.clientLeaderServers[i].getLeader,
 		                                           GetLeaderRequest(coordinatorList.clusterKey, UID()),

--- a/fdbclient/StatusClient.actor.cpp
+++ b/fdbclient/StatusClient.actor.cpp
@@ -290,6 +290,7 @@ ACTOR Future<Optional<StatusObject>> clientCoordinatorsStatusFetcher(Reference<C
 		state StatusObject statusObj;
 
 		state vector<Future<Optional<LeaderInfo>>> leaderServers;
+		leaderServers.reserve(coord.clientLeaderServers.size());
 		for (int i = 0; i < coord.clientLeaderServers.size(); i++)
 			leaderServers.push_back(retryBrokenPromise(coord.clientLeaderServers[i].getLeader, GetLeaderRequest(coord.clusterKey, UID()), TaskPriority::CoordinationReply));
 

--- a/fdbclient/TagThrottle.actor.cpp
+++ b/fdbclient/TagThrottle.actor.cpp
@@ -278,6 +278,7 @@ namespace ThrottleApi {
 		loop {
 			try {
 				state std::vector<Future<Optional<Value>>> values;
+				values.reserve(keys.size());
 				for(auto key : keys) {
 					values.push_back(tr.get(key));
 				}

--- a/fdbclient/TaskBucket.actor.cpp
+++ b/fdbclient/TaskBucket.actor.cpp
@@ -446,8 +446,8 @@ public:
 		// Since the futures have to be kept in a vector to be compatible with waitForAny(), we'll keep a queue
 		// of available slots in it.  Initially, they're all available.
 		state std::vector<int> availableSlots;
-		for(int i = 0; i < tasks.size(); ++i)
-			availableSlots.push_back(i);
+		availableSlots.reserve(tasks.size());
+		for (int i = 0; i < tasks.size(); ++i) availableSlots.push_back(i);
 
 		state std::vector<Future<Reference<Task>>> getTasks;
 		state unsigned int getBatchSize = 1;

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -339,8 +339,8 @@ private:
 
 	ACTOR Future<Void> doUpdateStorageMetrics( TCTeamInfo* self ) {
 		std::vector<Future<Void>> updates;
-		for( int i = 0; i< self->servers.size(); i++ )
-			updates.push_back( updateServerMetrics( self->servers[i] ) );
+		updates.reserve(self->servers.size());
+		for (int i = 0; i < self->servers.size(); i++) updates.push_back(updateServerMetrics(self->servers[i]));
 		wait( waitForAll( updates ) );
 		return Void();
 	}
@@ -5078,7 +5078,8 @@ ACTOR Future<Void> ddSnapCreateCore(DistributorSnapRequest snapReq, Reference<As
 		// disable tlog pop on local tlog nodes
 		state std::vector<TLogInterface> tlogs = db->get().logSystemConfig.allLocalLogs(false);
 		std::vector<Future<Void>> disablePops;
-		for (const auto & tlog : tlogs) {
+		disablePops.reserve(tlogs.size());
+		for (const auto& tlog : tlogs) {
 			disablePops.push_back(
 				transformErrors(throwErrorOr(tlog.disablePopRequest.tryGetReply(TLogDisablePopRequest(snapReq.snapUID))), snap_disable_tlog_pop_failed())
 				);
@@ -5094,7 +5095,8 @@ ACTOR Future<Void> ddSnapCreateCore(DistributorSnapRequest snapReq, Reference<As
 			.detail("SnapPayload", snapReq.snapPayload)
 			.detail("SnapUID", snapReq.snapUID);
 		std::vector<Future<Void>> storageSnapReqs;
-		for (const auto & worker : storageWorkers) {
+		storageSnapReqs.reserve(storageWorkers.size());
+		for (const auto& worker : storageWorkers) {
 			storageSnapReqs.push_back(
 				transformErrors(throwErrorOr(worker.workerSnapReq.tryGetReply(WorkerSnapRequest(snapReq.snapPayload, snapReq.snapUID, LiteralStringRef("storage")))), snap_storage_failed())
 				);
@@ -5106,7 +5108,8 @@ ACTOR Future<Void> ddSnapCreateCore(DistributorSnapRequest snapReq, Reference<As
 			.detail("SnapUID", snapReq.snapUID);
 		// snap local tlog nodes
 		std::vector<Future<Void>> tLogSnapReqs;
-		for (const auto & tlog : tlogs) {
+		tLogSnapReqs.reserve(tlogs.size());
+		for (const auto& tlog : tlogs) {
 			tLogSnapReqs.push_back(
 				transformErrors(throwErrorOr(tlog.snapRequest.tryGetReply(TLogSnapRequest(snapReq.snapPayload, snapReq.snapUID, LiteralStringRef("tlog")))), snap_tlog_failed())
 				);
@@ -5118,7 +5121,8 @@ ACTOR Future<Void> ddSnapCreateCore(DistributorSnapRequest snapReq, Reference<As
 			.detail("SnapUID", snapReq.snapUID);
 		// enable tlog pop on local tlog nodes
 		std::vector<Future<Void>> enablePops;
-		for (const auto & tlog : tlogs) {
+		enablePops.reserve(tlogs.size());
+		for (const auto& tlog : tlogs) {
 			enablePops.push_back(
 				transformErrors(throwErrorOr(tlog.enablePopRequest.tryGetReply(TLogEnablePopRequest(snapReq.snapUID))), snap_enable_tlog_pop_failed())
 				);
@@ -5134,7 +5138,8 @@ ACTOR Future<Void> ddSnapCreateCore(DistributorSnapRequest snapReq, Reference<As
 			.detail("SnapPayload", snapReq.snapPayload)
 			.detail("SnapUID", snapReq.snapUID);
 		std::vector<Future<Void>> coordSnapReqs;
-		for (const auto & worker : coordWorkers) {
+		coordSnapReqs.reserve(coordWorkers.size());
+		for (const auto& worker : coordWorkers) {
 			coordSnapReqs.push_back(
 				transformErrors(throwErrorOr(worker.workerSnapReq.tryGetReply(WorkerSnapRequest(snapReq.snapPayload, snapReq.snapUID, LiteralStringRef("coord")))), snap_coord_failed())
 				);
@@ -5171,7 +5176,8 @@ ACTOR Future<Void> ddSnapCreateCore(DistributorSnapRequest snapReq, Reference<As
 			std::vector<TLogInterface> tlogs = db->get().logSystemConfig.allLocalLogs(false);
 			try {
 				std::vector<Future<Void>> enablePops;
-				for (const auto & tlog : tlogs) {
+				enablePops.reserve(tlogs.size());
+				for (const auto& tlog : tlogs) {
 					enablePops.push_back(
 						transformErrors(throwErrorOr(tlog.enablePopRequest.tryGetReply(TLogEnablePopRequest(snapReq.snapUID))), snap_enable_tlog_pop_failed())
 						);

--- a/fdbserver/DiskQueue.actor.cpp
+++ b/fdbserver/DiskQueue.actor.cpp
@@ -480,7 +480,8 @@ public:
 
 	ACTOR static Future<Void> openFiles( RawDiskQueue_TwoFiles* self ) {
 		state vector<Future<Reference<IAsyncFile>>> fs;
-		for(int i=0; i<2; i++)
+		fs.reserve(2);
+		for (int i = 0; i < 2; i++)
 			fs.push_back( IAsyncFileSystem::filesystem()->open( self->filename(i), IAsyncFile::OPEN_READWRITE | IAsyncFile::OPEN_UNCACHED | IAsyncFile::OPEN_UNBUFFERED | IAsyncFile::OPEN_LOCK, 0 ) );
 		wait( waitForAllReady(fs) );
 
@@ -516,8 +517,8 @@ public:
 		// process could have written (but not synchronized) data to the file which we will read but which
 		// might not survive a reboot.  The recovery code assumes otherwise and could corrupt the disk.
 		vector<Future<Void>> syncs;
-		for(int i=0; i<fs.size(); i++)
-			syncs.push_back( fs[i].get()->sync() );
+		syncs.reserve(fs.size());
+		for (int i = 0; i < fs.size(); i++) syncs.push_back(fs[i].get()->sync());
 		wait(waitForAll(syncs));
 
 		// Successfully opened or created; fill in self->files[]
@@ -573,8 +574,8 @@ public:
 
 			// Get the file sizes
 			vector<Future<int64_t>> fsize;
-			for(int i=0; i<2; i++)
-				fsize.push_back( self->files[i].f->size() );
+			fsize.reserve(2);
+			for (int i = 0; i < 2; i++) fsize.push_back(self->files[i].f->size());
 			vector<int64_t> file_sizes = wait( getAll(fsize) );
 			for(int i=0; i<2; i++) {
 				// SOMEDAY: If the file size is not a multiple of page size, it may never be shortened.  Change this?

--- a/fdbserver/FDBExecHelper.actor.cpp
+++ b/fdbserver/FDBExecHelper.actor.cpp
@@ -125,6 +125,7 @@ ACTOR Future<int> spawnProcess(std::string path, std::vector<std::string> args, 
 	}
 
 	std::vector<char*> paramList;
+	paramList.reserve(args.size());
 	for (int i = 0; i < args.size(); i++) {
 		paramList.push_back(&args[i][0]);
 	}

--- a/fdbserver/LeaderElection.actor.cpp
+++ b/fdbserver/LeaderElection.actor.cpp
@@ -67,7 +67,8 @@ Future<Void> buggifyDelayedAsyncVar( Reference<AsyncVar<T>> &var ) {
 
 ACTOR Future<Void> changeLeaderCoordinators( ServerCoordinators coordinators, Value forwardingInfo ) {
 	std::vector<Future<Void>> forwardRequests;
-	for( int i = 0; i < coordinators.leaderElectionServers.size(); i++ )
+	forwardRequests.reserve(coordinators.leaderElectionServers.size());
+	for (int i = 0; i < coordinators.leaderElectionServers.size(); i++)
 		forwardRequests.push_back( retryBrokenPromise( coordinators.leaderElectionServers[i].forward, ForwardRequest( coordinators.clusterKey, forwardingInfo ) ) );
 	int quorum_size = forwardRequests.size()/2 + 1;
 	wait( quorum( forwardRequests, quorum_size ) );
@@ -108,7 +109,8 @@ ACTOR Future<Void> tryBecomeLeaderInternal(ServerCoordinators coordinators, Valu
 		myInfo.updateChangeID( asyncPriorityInfo->get() );
 
 		vector<Future<Void>> cand;
-		for(int i=0; i<coordinators.leaderElectionServers.size(); i++)
+		cand.reserve(coordinators.leaderElectionServers.size());
+		for (int i = 0; i < coordinators.leaderElectionServers.size(); i++)
 			cand.push_back( submitCandidacy( coordinators.clusterKey, coordinators.leaderElectionServers[i], myInfo, prevChangeID, nominees, i ) );
 		candidacies = waitForAll(cand);
 

--- a/fdbserver/QuietDatabase.actor.cpp
+++ b/fdbserver/QuietDatabase.actor.cpp
@@ -221,8 +221,8 @@ ACTOR Future<vector<StorageServerInterface>> getStorageServers( Database cx, boo
 			ASSERT( !serverList.more && serverList.size() < CLIENT_KNOBS->TOO_MANY );
 
 			vector<StorageServerInterface> servers;
-			for( int i = 0; i < serverList.size(); i++ )
-				servers.push_back( decodeServerListValue( serverList[i].value ) );
+			servers.reserve(serverList.size());
+			for (int i = 0; i < serverList.size(); i++) servers.push_back(decodeServerListValue(serverList[i].value));
 			return servers;
 		}
 		catch(Error &e) {

--- a/fdbserver/Ratekeeper.actor.cpp
+++ b/fdbserver/Ratekeeper.actor.cpp
@@ -1358,6 +1358,7 @@ ACTOR Future<Void> ratekeeper(RatekeeperInterface rkInterf, Reference<AsyncVar<S
 		.detail("Rate", (SERVER_KNOBS->TARGET_BYTES_PER_STORAGE_SERVER - SERVER_KNOBS->SPRING_BYTES_STORAGE_SERVER) / ((((double)SERVER_KNOBS->MAX_READ_TRANSACTION_LIFE_VERSIONS) / SERVER_KNOBS->VERSIONS_PER_SECOND) + 2.0));
 
 	tlogInterfs = dbInfo->get().logSystemConfig.allLocalLogs();
+	tlogTrackers.reserve(tlogInterfs.size());
 	for (int i = 0; i < tlogInterfs.size(); i++) {
 		tlogTrackers.push_back( splitError( trackTLogQueueInfo(&self, tlogInterfs[i]), err ) );
 	}

--- a/fdbserver/RestoreController.actor.cpp
+++ b/fdbserver/RestoreController.actor.cpp
@@ -890,6 +890,7 @@ ACTOR static Future<Void> initializeVersionBatch(std::map<UID, RestoreApplierInt
 	    .detail("BatchIndex", batchIndex)
 	    .detail("Appliers", appliersInterf.size());
 	std::vector<std::pair<UID, RestoreVersionBatchRequest>> requestsToAppliers;
+	requestsToAppliers.reserve(appliersInterf.size());
 	for (auto& applier : appliersInterf) {
 		requestsToAppliers.emplace_back(applier.first, RestoreVersionBatchRequest(batchIndex));
 	}
@@ -899,6 +900,7 @@ ACTOR static Future<Void> initializeVersionBatch(std::map<UID, RestoreApplierInt
 	    .detail("BatchIndex", batchIndex)
 	    .detail("Loaders", loadersInterf.size());
 	std::vector<std::pair<UID, RestoreVersionBatchRequest>> requestsToLoaders;
+	requestsToLoaders.reserve(loadersInterf.size());
 	for (auto& loader : loadersInterf) {
 		requestsToLoaders.emplace_back(loader.first, RestoreVersionBatchRequest(batchIndex));
 	}
@@ -1029,6 +1031,7 @@ ACTOR static Future<Void> notifyLoadersVersionBatchFinished(std::map<UID, Restor
                                                             int batchIndex) {
 	TraceEvent("FastRestoreControllerPhaseNotifyLoadersVersionBatchFinishedStart").detail("BatchIndex", batchIndex);
 	std::vector<std::pair<UID, RestoreVersionBatchRequest>> requestsToLoaders;
+	requestsToLoaders.reserve(loadersInterf.size());
 	for (auto& loader : loadersInterf) {
 		requestsToLoaders.emplace_back(loader.first, RestoreVersionBatchRequest(batchIndex));
 	}

--- a/fdbserver/RestoreLoader.actor.cpp
+++ b/fdbserver/RestoreLoader.actor.cpp
@@ -879,6 +879,7 @@ ACTOR Future<Void> sendMutationsToApplier(
 			// to improve bandwidth from a loader to appliers
 			if (msgSize >= SERVER_KNOBS->FASTRESTORE_LOADER_SEND_MUTATION_MSG_BYTES) {
 				std::vector<std::pair<UID, RestoreSendVersionedMutationsRequest>> requests;
+				requests.reserve(applierIDs.size());
 				for (const UID& applierID : applierIDs) {
 					requests.emplace_back(
 					    applierID, RestoreSendVersionedMutationsRequest(batchIndex, asset, msgIndex, isRangeFile,
@@ -903,6 +904,7 @@ ACTOR Future<Void> sendMutationsToApplier(
 	if (msgSize > 0) {
 		// TODO: Sanity check each asset has been received exactly once!
 		std::vector<std::pair<UID, RestoreSendVersionedMutationsRequest>> requests;
+		requests.reserve(applierIDs.size());
 		for (const UID& applierID : applierIDs) {
 			requests.emplace_back(applierID,
 			                      RestoreSendVersionedMutationsRequest(batchIndex, asset, msgIndex, isRangeFile,
@@ -1308,6 +1310,7 @@ ACTOR static Future<Void> parseLogFileToMutationsOnLoader(NotifiedVersion* pProc
 // Return applier IDs that are used to apply key-values
 std::vector<UID> getApplierIDs(std::map<Key, UID>& rangeToApplier) {
 	std::vector<UID> applierIDs;
+	applierIDs.reserve(rangeToApplier.size());
 	for (auto& applier : rangeToApplier) {
 		applierIDs.push_back(applier.second);
 	}

--- a/fdbserver/SimulatedCluster.actor.cpp
+++ b/fdbserver/SimulatedCluster.actor.cpp
@@ -1279,6 +1279,7 @@ void setupSimulatedSystem(vector<Future<Void>>* systemActors, std::string baseFo
 			}
 
 			std::vector<IPAddress> ips;
+			ips.reserve(processesPerMachine);
 			for (int i = 0; i < processesPerMachine; i++) {
 				ips.push_back(makeIPAddressForSim(useIPv6, { 2, dc, deterministicRandom()->randomInt(1, i + 2), machine }));
 			}
@@ -1294,7 +1295,8 @@ void setupSimulatedSystem(vector<Future<Void>>* systemActors, std::string baseFo
 
 			if (requiresExtraDBMachines) {
 				std::vector<IPAddress> extraIps;
-				for (int i = 0; i < processesPerMachine; i++){
+				extraIps.reserve(processesPerMachine);
+				for (int i = 0; i < processesPerMachine; i++) {
 					extraIps.push_back(makeIPAddressForSim(useIPv6, { 4, dc, deterministicRandom()->randomInt(1, i + 2), machine }));
 				}
 

--- a/fdbserver/Status.actor.cpp
+++ b/fdbserver/Status.actor.cpp
@@ -1656,10 +1656,11 @@ static Future<vector<std::pair<iface, EventMap>>> getServerMetrics(vector<iface>
 ACTOR template <class iface>
 static Future<vector<TraceEventFields>> getServerBusiestWriteTags(vector<iface> servers, std::unordered_map<NetworkAddress, WorkerInterface> address_workers, WorkerDetails rkWorker) {
     state vector<Future<Optional<TraceEventFields>>> futures;
-    for (const auto& s : servers) {
+	futures.reserve(servers.size());
+	for (const auto& s : servers) {
 		futures.push_back(latestEventOnWorker(rkWorker.interf, s.id().toString() + "/BusiestWriteTag"));
-    }
-    wait(waitForAll(futures));
+	}
+	wait(waitForAll(futures));
 
 	vector<TraceEventFields> result(servers.size());
 	for(int i = 0; i < servers.size(); ++ i) {

--- a/fdbserver/TagPartitionedLogSystem.actor.cpp
+++ b/fdbserver/TagPartitionedLogSystem.actor.cpp
@@ -761,7 +761,8 @@ struct TagPartitionedLogSystem : ILogSystem, ReferenceCounted<TagPartitionedLogS
 		}
 
 		std::vector< Reference<ILogSystem::IPeekCursor> > cursors;
-		for(auto tag : tags) {
+		cursors.reserve(tags.size());
+		for (auto tag : tags) {
 			cursors.push_back(peek(dbgid, begin, end, tag, parallelGetMore));
 		}
 		return makeReference<ILogSystem::BufferedCursor>(cursors, begin, end.present() ? end.get() + 1 : getPeekEnd(),
@@ -914,7 +915,8 @@ struct TagPartitionedLogSystem : ILogSystem, ReferenceCounted<TagPartitionedLogS
 
 		if(peekLocality < 0 || localEnd == invalidVersion || localEnd <= begin) {
 			std::vector< Reference<ILogSystem::IPeekCursor> > cursors;
-			for(int i = 0; i < maxTxsTags; i++) {
+			cursors.reserve(maxTxsTags);
+			for (int i = 0; i < maxTxsTags; i++) {
 				cursors.push_back(peekAll(dbgid, begin, end, Tag(tagLocalityTxs, i), true));
 			}
 			//SOMEDAY: remove once upgrades from 6.2 are no longer supported
@@ -928,7 +930,8 @@ struct TagPartitionedLogSystem : ILogSystem, ReferenceCounted<TagPartitionedLogS
 		try {
 			if(localEnd >= end) {
 				std::vector< Reference<ILogSystem::IPeekCursor> > cursors;
-				for(int i = 0; i < maxTxsTags; i++) {
+				cursors.reserve(maxTxsTags);
+				for (int i = 0; i < maxTxsTags; i++) {
 					cursors.push_back(peekLocal(dbgid, Tag(tagLocalityTxs, i), begin, end, true, peekLocality));
 				}
 				//SOMEDAY: remove once upgrades from 6.2 are no longer supported
@@ -965,7 +968,8 @@ struct TagPartitionedLogSystem : ILogSystem, ReferenceCounted<TagPartitionedLogS
 		} catch( Error& e ) {
 			if(e.code() == error_code_worker_removed) {
 				std::vector< Reference<ILogSystem::IPeekCursor> > cursors;
-				for(int i = 0; i < maxTxsTags; i++) {
+				cursors.reserve(maxTxsTags);
+				for (int i = 0; i < maxTxsTags; i++) {
 					cursors.push_back(peekAll(dbgid, begin, end, Tag(tagLocalityTxs, i), true));
 				}
 				//SOMEDAY: remove once upgrades from 6.2 are no longer supported
@@ -2262,7 +2266,8 @@ struct TagPartitionedLogSystem : ILogSystem, ReferenceCounted<TagPartitionedLogS
 			req.txsTags = self->txsTags;
 		}
 
-		for( int i = 0; i < remoteWorkers.remoteTLogs.size(); i++ )
+		remoteTLogInitializationReplies.reserve(remoteWorkers.remoteTLogs.size());
+		for (int i = 0; i < remoteWorkers.remoteTLogs.size(); i++)
 			remoteTLogInitializationReplies.push_back( transformErrors( throwErrorOr( remoteWorkers.remoteTLogs[i].tLog.getReplyUnlessFailedFor( remoteTLogReqs[i], SERVER_KNOBS->TLOG_TIMEOUT, SERVER_KNOBS->MASTER_FAILURE_SLOPE_DURING_RECOVERY ) ), master_recovery_failed() ) );
 
 		TraceEvent("RemoteLogRecruitment_InitializingRemoteLogs").detail("StartVersion", logSet->startVersion).detail("LocalStart", self->tLogs[0]->startVersion).detail("LogRouterTags", self->logRouterTags);
@@ -2281,7 +2286,8 @@ struct TagPartitionedLogSystem : ILogSystem, ReferenceCounted<TagPartitionedLogS
 		filterLocalityDataForPolicy(logSet->tLogPolicy, &logSet->tLogLocalities);
 
 		std::vector<Future<Void>> recoveryComplete;
-		for( int i = 0; i < logSet->logServers.size(); i++)
+		recoveryComplete.reserve(logSet->logServers.size());
+		for (int i = 0; i < logSet->logServers.size(); i++)
 			recoveryComplete.push_back( transformErrors( throwErrorOr( logSet->logServers[i]->get().interf().recoveryFinished.getReplyUnlessFailedFor( TLogRecoveryFinishedRequest(), SERVER_KNOBS->TLOG_TIMEOUT, SERVER_KNOBS->MASTER_FAILURE_SLOPE_DURING_RECOVERY ) ), master_recovery_failed() ) );
 
 		self->remoteRecoveryComplete = waitForAll(recoveryComplete);
@@ -2483,7 +2489,8 @@ struct TagPartitionedLogSystem : ILogSystem, ReferenceCounted<TagPartitionedLogS
 			req.txsTags = logSystem->txsTags;
 		}
 
-		for( int i = 0; i < recr.tLogs.size(); i++ )
+		initializationReplies.reserve(recr.tLogs.size());
+		for (int i = 0; i < recr.tLogs.size(); i++)
 			initializationReplies.push_back( transformErrors( throwErrorOr( recr.tLogs[i].tLog.getReplyUnlessFailedFor( reqs[i], SERVER_KNOBS->TLOG_TIMEOUT, SERVER_KNOBS->MASTER_FAILURE_SLOPE_DURING_RECOVERY ) ), master_recovery_failed() ) );
 
 		state std::vector<Future<Void>> recoveryComplete;
@@ -2545,7 +2552,8 @@ struct TagPartitionedLogSystem : ILogSystem, ReferenceCounted<TagPartitionedLogS
 				req.txsTags = logSystem->txsTags;
 			}
 
-			for( int i = 0; i < recr.satelliteTLogs.size(); i++ )
+			satelliteInitializationReplies.reserve(recr.satelliteTLogs.size());
+			for (int i = 0; i < recr.satelliteTLogs.size(); i++)
 				satelliteInitializationReplies.push_back( transformErrors( throwErrorOr( recr.satelliteTLogs[i].tLog.getReplyUnlessFailedFor( sreqs[i], SERVER_KNOBS->TLOG_TIMEOUT, SERVER_KNOBS->MASTER_FAILURE_SLOPE_DURING_RECOVERY ) ), master_recovery_failed() ) );
 
 			wait( waitForAll( satelliteInitializationReplies ) || oldRouterRecruitment );

--- a/fdbserver/VersionedBTree.actor.cpp
+++ b/fdbserver/VersionedBTree.actor.cpp
@@ -7162,6 +7162,7 @@ TEST_CASE("!/redwood/correctness/unit/deltaTree/IntIntPair") {
 
 	// Repeatedly seek for one of a set of pregenerated random pairs and time it.
 	std::vector<IntIntPair> randomPairs;
+	randomPairs.reserve(10 * N);
 	for (int i = 0; i < 10 * N; ++i) {
 		randomPairs.push_back(randomPair());
 	}

--- a/fdbserver/masterserver.actor.cpp
+++ b/fdbserver/masterserver.actor.cpp
@@ -406,6 +406,7 @@ ACTOR Future<Void> newSeedServers( Reference<MasterData> self, RecruitFromConfig
 
 Future<Void> waitCommitProxyFailure(vector<CommitProxyInterface> const& commitProxies) {
 	std::vector<Future<Void>> failed;
+	failed.reserve(commitProxies.size());
 	for (auto commitProxy : commitProxies) {
 		failed.push_back(waitFailureClient(commitProxy.waitFailure, SERVER_KNOBS->TLOG_TIMEOUT,
 		                                   -SERVER_KNOBS->TLOG_TIMEOUT / SERVER_KNOBS->SECONDS_BEFORE_NO_FAILURE_DELAY,
@@ -417,7 +418,8 @@ Future<Void> waitCommitProxyFailure(vector<CommitProxyInterface> const& commitPr
 
 Future<Void> waitGrvProxyFailure( vector<GrvProxyInterface> const& grvProxies ) {
 	vector<Future<Void>> failed;
-	for(int i=0; i<grvProxies.size(); i++)
+	failed.reserve(grvProxies.size());
+	for (int i = 0; i < grvProxies.size(); i++)
 		failed.push_back(waitFailureClient(grvProxies[i].waitFailure, SERVER_KNOBS->TLOG_TIMEOUT,
 		                                   -SERVER_KNOBS->TLOG_TIMEOUT / SERVER_KNOBS->SECONDS_BEFORE_NO_FAILURE_DELAY,
 		                                   /*trace=*/true));
@@ -427,6 +429,7 @@ Future<Void> waitGrvProxyFailure( vector<GrvProxyInterface> const& grvProxies ) 
 
 Future<Void> waitResolverFailure( vector<ResolverInterface> const& resolvers ) {
 	std::vector<Future<Void>> failed;
+	failed.reserve(resolvers.size());
 	for (auto resolver : resolvers) {
 		failed.push_back(waitFailureClient(resolver.waitFailure, SERVER_KNOBS->TLOG_TIMEOUT,
 		                                   -SERVER_KNOBS->TLOG_TIMEOUT / SERVER_KNOBS->SECONDS_BEFORE_NO_FAILURE_DELAY,
@@ -1366,6 +1369,7 @@ ACTOR static Future<Void> recruitBackupWorkers(Reference<MasterData> self, Datab
 
 	state std::vector<std::pair<UID, Tag>> idsTags; // worker IDs and tags for current epoch
 	state int logRouterTags = self->logSystem->getLogRouterTags();
+	idsTags.reserve(logRouterTags);
 	for (int i = 0; i < logRouterTags; i++) {
 		idsTags.emplace_back(deterministicRandom()->randomUniqueID(), Tag(tagLocalityLogRouter, i));
 	}

--- a/fdbserver/networktest.actor.cpp
+++ b/fdbserver/networktest.actor.cpp
@@ -223,11 +223,13 @@ ACTOR Future<Void> networkTestClient( std:: string testServers ) {
 	state int completed = 0;
 	state LatencyStats latency;
 
-	for( int i = 0; i < servers.size(); i++ ) {
+	interfs.reserve(servers.size());
+	for (int i = 0; i < servers.size(); i++) {
 		interfs.push_back( NetworkTestInterface( servers[i] ) );
 	}
 
 	state std::vector<Future<Void>> clients;
+	clients.reserve(FLOW_KNOBS->NETWORK_TEST_CLIENT_COUNT);
 	for (int i = 0; i < FLOW_KNOBS->NETWORK_TEST_CLIENT_COUNT; i++) {
 		clients.push_back(testClient(interfs, &sent, &completed, &latency));
 	}

--- a/fdbserver/tester.actor.cpp
+++ b/fdbserver/tester.actor.cpp
@@ -265,20 +265,20 @@ struct CompoundWorkload : TestWorkload {
 	}
 	Future<Void> setup(Database const& cx) override {
 		vector<Future<Void>> all;
-		for(int w=0; w<workloads.size(); w++)
-			all.push_back( workloads[w]->setup(cx) );
+		all.reserve(workloads.size());
+		for (int w = 0; w < workloads.size(); w++) all.push_back(workloads[w]->setup(cx));
 		return waitForAll(all);
 	}
 	Future<Void> start(Database const& cx) override {
 		vector<Future<Void>> all;
-		for(int w=0; w<workloads.size(); w++)
-			all.push_back( workloads[w]->start(cx) );
+		all.reserve(workloads.size());
+		for (int w = 0; w < workloads.size(); w++) all.push_back(workloads[w]->start(cx));
 		return waitForAll(all);
 	}
 	Future<bool> check(Database const& cx) override {
 		vector<Future<bool>> all;
-		for(int w=0; w<workloads.size(); w++)
-			all.push_back( workloads[w]->check(cx) );
+		all.reserve(workloads.size());
+		for (int w = 0; w < workloads.size(); w++) all.push_back(workloads[w]->check(cx));
 		return allTrue(all);
 	}
 	void getMetrics(vector<PerfMetric>& m) override {
@@ -679,7 +679,8 @@ ACTOR Future<DistributedTestResults> runWorkload( Database cx, std::vector< Test
 		state std::vector< Future<ErrorOr<Void>> > setups;
 		printf("setting up test (%s)...\n", printable(spec.title).c_str());
 		TraceEvent("TestSetupStart").detail("WorkloadTitle", spec.title);
-		for(int i= 0; i < workloads.size(); i++)
+		setups.reserve(workloads.size());
+		for (int i = 0; i < workloads.size(); i++)
 			setups.push_back( workloads[i].setup.template getReplyUnlessFailedFor<Void>( waitForFailureTime, 0) );
 		wait( waitForAll( setups ) );
 		throwIfError(setups, "SetupFailedForWorkload" + printable(spec.title));
@@ -690,7 +691,8 @@ ACTOR Future<DistributedTestResults> runWorkload( Database cx, std::vector< Test
 		TraceEvent("TestStarting").detail("WorkloadTitle", spec.title);
 		printf("running test (%s)...\n", printable(spec.title).c_str());
 		state std::vector< Future<ErrorOr<Void>> > starts;
-		for(int i= 0; i < workloads.size(); i++)
+		starts.reserve(workloads.size());
+		for (int i = 0; i < workloads.size(); i++)
 			starts.push_back( workloads[i].start.template getReplyUnlessFailedFor<Void>(waitForFailureTime, 0) );
 		wait( waitForAll( starts ) );
 		throwIfError(starts, "StartFailedForWorkload" + printable(spec.title));
@@ -708,7 +710,8 @@ ACTOR Future<DistributedTestResults> runWorkload( Database cx, std::vector< Test
 
 		printf("checking test (%s)...\n", printable(spec.title).c_str());
 
-		for(int i= 0; i < workloads.size(); i++)
+		checks.reserve(workloads.size());
+		for (int i = 0; i < workloads.size(); i++)
 			checks.push_back(workloads[i].check.template getReplyUnlessFailedFor<CheckReply>(waitForFailureTime, 0));
 		wait( waitForAll( checks ) );
 
@@ -726,7 +729,8 @@ ACTOR Future<DistributedTestResults> runWorkload( Database cx, std::vector< Test
 		state std::vector< Future<ErrorOr<vector<PerfMetric>>> > metricTasks;
 		printf("fetching metrics (%s)...\n", printable(spec.title).c_str());
 		TraceEvent("TestFetchingMetrics").detail("WorkloadTitle", spec.title);
-		for(int i= 0; i < workloads.size(); i++)
+		metricTasks.reserve(workloads.size());
+		for (int i = 0; i < workloads.size(); i++)
 			metricTasks.push_back( workloads[i].metrics.template getReplyUnlessFailedFor<vector<PerfMetric>>(waitForFailureTime, 0) );
 		wait( waitForAll( metricTasks ) );
 		throwIfError(metricTasks, "MetricFailedForWorkload" + printable(spec.title));
@@ -1314,8 +1318,8 @@ ACTOR Future<Void> runTests( Reference<AsyncVar<Optional<struct ClusterControlle
 	}
 
 	vector<TesterInterface> ts;
-	for(int i=0; i<workers.size(); i++)
-		ts.push_back(workers[i].interf.testerInterface);
+	ts.reserve(workers.size());
+	for (int i = 0; i < workers.size(); i++) ts.push_back(workers[i].interf.testerInterface);
 
 	wait( runTests( cc, ci, ts, tests, startingConfiguration, locality) );
 	return Void();

--- a/fdbserver/workloads/AsyncFileRead.actor.cpp
+++ b/fdbserver/workloads/AsyncFileRead.actor.cpp
@@ -279,7 +279,8 @@ struct AsyncFileReadWorkload : public AsyncFileWorkload
 
 			std::vector<Future<Void>> readers;
 
-			for(int i=0; i<self->numParallelReads; i++)
+			readers.reserve(self->numParallelReads);
+			for (int i = 0; i < self->numParallelReads; i++)
 				readers.push_back( readLoop(self, i, self->fixedRate / self->numParallelReads) );
 			wait(waitForAll(readers));
 

--- a/fdbserver/workloads/ConsistencyCheck.actor.cpp
+++ b/fdbserver/workloads/ConsistencyCheck.actor.cpp
@@ -644,8 +644,8 @@ struct ConsistencyCheckWorkload : TestWorkload
 		}
 
 		state vector<int> shardOrder;
-		for(int k = 0; k < ranges.size(); k++)
-			shardOrder.push_back(k);
+		shardOrder.reserve(ranges.size());
+		for (int k = 0; k < ranges.size(); k++) shardOrder.push_back(k);
 		if(self->shuffleShards) {
 			uint32_t seed = self->sharedRandomNumber + self->repetitions;
 			DeterministicRandom sharedRandom( seed == 0 ? 1 : seed );
@@ -707,7 +707,8 @@ struct ConsistencyCheckWorkload : TestWorkload
 			loop {
 				try {
 					vector< Future< Optional<Value> > > serverListEntries;
-					for(int s=0; s<storageServers.size(); s++)
+					serverListEntries.reserve(storageServers.size());
+					for (int s = 0; s < storageServers.size(); s++)
 						serverListEntries.push_back( tr.get( serverListKeyFor(storageServers[s]) ) );
 					state vector<Optional<Value>> serverListValues = wait( getAll(serverListEntries) );
 					for(int s=0; s<serverListValues.size(); s++) {

--- a/fdbserver/workloads/DDBalance.actor.cpp
+++ b/fdbserver/workloads/DDBalance.actor.cpp
@@ -219,6 +219,7 @@ struct DDBalanceWorkload : TestWorkload {
 			while(nextBin == currentBin) nextBin = deterministicRandom()->randomInt(key_space_drift,self->binCount+key_space_drift);
 
 			vector<Future<Void>> fs;
+			fs.reserve(self->actorsPerClient / self->moversPerClient);
 			for (int i = 0; i < self->actorsPerClient / self->moversPerClient; i++)
 				fs.push_back( self->ddBalanceWorker(cx, self, moverId, currentBin, nextBin, i*self->nodesPerActor, (i+1)*self->nodesPerActor, clientBegin, &lastTime, 1.0 / self->transactionsPerSecond));
 			wait( waitForAll(fs) );

--- a/fdbserver/workloads/KVStoreTest.actor.cpp
+++ b/fdbserver/workloads/KVStoreTest.actor.cpp
@@ -309,6 +309,7 @@ ACTOR Future<Void> testKVStoreMain( KVStoreTestWorkload* workload, KVTest* ptest
 			}
 		} else {
 			vector<Future<Void>> actors;
+			actors.reserve(100);
 			for (int a = 0; a < 100; a++)
 				actors.push_back(testKVReadSaturation(&test, &workload->readLatency, &workload->reads));
 			wait(timeout(waitForAll(actors), workload->testDuration, Void()));

--- a/fdbserver/workloads/Mako.actor.cpp
+++ b/fdbserver/workloads/Mako.actor.cpp
@@ -386,6 +386,7 @@ struct MakoWorkload : TestWorkload {
 
 	ACTOR Future<Void> _runBenchmark(Database cx, MakoWorkload* self) {
 		std::vector<Future<Void>> clients;
+		clients.reserve(self->actorCountPerClient);
 		for (int c = 0; c < self->actorCountPerClient; ++c) {
 			clients.push_back(self->makoClient(cx, self, self->actorCountPerClient / self->transactionsPerSecond, c));
 		}

--- a/fdbserver/workloads/ParallelRestore.actor.cpp
+++ b/fdbserver/workloads/ParallelRestore.actor.cpp
@@ -42,6 +42,7 @@ struct RunRestoreWorkerWorkload : TestWorkload {
 		TraceEvent("RunParallelRestoreWorkerWorkload").detail("Start", "RestoreToolDB").detail("Workers", num_myWorkers);
 		printf("RunParallelRestoreWorkerWorkload, we will start %d restore workers\n", num_myWorkers);
 		std::vector<Future<Void>> myWorkers;
+		myWorkers.reserve(num_myWorkers);
 		for (int i = 0; i < num_myWorkers; ++i) {
 			myWorkers.push_back(_restoreWorker(cx, LocalityData()));
 		}

--- a/fdbserver/workloads/Performance.actor.cpp
+++ b/fdbserver/workloads/Performance.actor.cpp
@@ -113,8 +113,8 @@ struct PerformanceWorkload : TestWorkload {
 		}
 
 		vector<TesterInterface> ts;
-		for(int i=0; i<workers.size(); i++)
-			ts.push_back(workers[i].interf.testerInterface);
+		ts.reserve(workers.size());
+		for (int i = 0; i < workers.size(); i++) ts.push_back(workers[i].interf.testerInterface);
 		return ts;
 	}
 

--- a/fdbserver/workloads/Ping.actor.cpp
+++ b/fdbserver/workloads/Ping.actor.cpp
@@ -170,11 +170,11 @@ struct PingWorkload : TestWorkload {
 	ACTOR Future<Void> pinger( PingWorkload *self, Database cx ) {
 		vector<PingWorkloadInterface> testers = wait( self->fetchInterfaces( self, cx ) );
 		vector<RequestStream<LoadedPingRequest>> peers;
-		for(int i=0; i<testers.size(); i++)
-			peers.push_back( testers[i].payloadPing );
+		peers.reserve(testers.size());
+		for (int i = 0; i < testers.size(); i++) peers.push_back(testers[i].payloadPing);
 		vector<Future<Void>> pingers;
-		for(int i=0; i<self->actorCount; i++)
-			pingers.push_back( self->pinger( self, peers ) );
+		pingers.reserve(self->actorCount);
+		for (int i = 0; i < self->actorCount; i++) pingers.push_back(self->pinger(self, peers));
 		wait( waitForAll(pingers) );
 		return Void();
 	}
@@ -182,11 +182,11 @@ struct PingWorkload : TestWorkload {
 	ACTOR Future<Void> workerPinger( PingWorkload* self ) {
 		vector<WorkerDetails> workers = wait( getWorkers( self->dbInfo ) );
 		vector<RequestStream<LoadedPingRequest>> peers;
-		for(int i=0; i<workers.size(); i++)
-			peers.push_back( workers[i].interf.debugPing );
+		peers.reserve(workers.size());
+		for (int i = 0; i < workers.size(); i++) peers.push_back(workers[i].interf.debugPing);
 		vector<Future<Void>> pingers;
-		for(int i=0; i<self->actorCount; i++)
-			pingers.push_back( self->pinger( self, peers ) );
+		pingers.reserve(self->actorCount);
+		for (int i = 0; i < self->actorCount; i++) pingers.push_back(self->pinger(self, peers));
 		wait( waitForAll(pingers) );
 		return Void();
 	}

--- a/fdbserver/workloads/PubSubMultiples.actor.cpp
+++ b/fdbserver/workloads/PubSubMultiples.actor.cpp
@@ -87,8 +87,8 @@ struct PubSubMultiplesWorkload : TestWorkload {
 	ACTOR Future<Void> createNodes( PubSubMultiplesWorkload *self, Database cx ) {
 		state PubSub ps(cx);
 		vector<Future<Void>> actors;
-		for(int i=0; i<self->actorCount; i++)
-			actors.push_back( self->createNodeSwath( self, i, cx->clone() ) );
+		actors.reserve(self->actorCount);
+		for (int i = 0; i < self->actorCount; i++) actors.push_back(self->createNodeSwath(self, i, cx->clone()));
 		wait( waitForAll( actors ) );
 		TraceEvent("PSMNodesCreated").detail("ClientIdx", self->clientId);
 		return Void();
@@ -106,8 +106,8 @@ struct PubSubMultiplesWorkload : TestWorkload {
 
 	ACTOR Future<Void> startTests( PubSubMultiplesWorkload *self, Database cx ) {
 		vector<Future<Void>> subscribers;
-		for(int i=0; i<self->actorCount; i++)
-			subscribers.push_back( self->createSubscriptions( self, i, cx ) );
+		subscribers.reserve(self->actorCount);
+		for (int i = 0; i < self->actorCount; i++) subscribers.push_back(self->createSubscriptions(self, i, cx));
 		wait( waitForAll( subscribers ) );
 
 		state Future<Void> sender = self->messageSender( self, cx );

--- a/fdbserver/workloads/RandomMoveKeys.actor.cpp
+++ b/fdbserver/workloads/RandomMoveKeys.actor.cpp
@@ -121,8 +121,8 @@ struct MoveKeysWorkload : TestWorkload {
 		for(int s=0; s<destinationTeam.size(); s++)
 			desc += format("%s (%llx),", destinationTeam[s].address().toString().c_str(), destinationTeam[s].id().first());
 		vector<UID> destinationTeamIDs;
-		for(int s=0; s<destinationTeam.size(); s++)
-			destinationTeamIDs.push_back( destinationTeam[s].id() );
+		destinationTeamIDs.reserve(destinationTeam.size());
+		for (int s = 0; s < destinationTeam.size(); s++) destinationTeamIDs.push_back(destinationTeam[s].id());
 
 		TraceEvent(relocateShardInterval.begin())
 			.detail("KeyBegin", printable(keys.begin)).detail("KeyEnd", printable(keys.end))

--- a/fdbserver/workloads/ReadWrite.actor.cpp
+++ b/fdbserver/workloads/ReadWrite.actor.cpp
@@ -233,7 +233,8 @@ struct ReadWriteWorkload : KVWorkload {
 					         wait(db->get().clusterInterface.getWorkers.tryGetReply(GetWorkersRequest()))) {
 						if( workerList.present() ) {
 							std::vector<Future<ErrorOr<Void>>> dumpRequests;
-							for( int i = 0; i < workerList.get().size(); i++)
+							dumpRequests.reserve(workerList.get().size());
+							for (int i = 0; i < workerList.get().size(); i++)
 								dumpRequests.push_back( workerList.get()[i].interf.traceBatchDumpRequest.tryGetReply( TraceBatchDumpRequest() ) );
 							wait( waitForAll( dumpRequests ) );
 							return true;
@@ -611,10 +612,11 @@ struct ReadWriteWorkload : KVWorkload {
 						keys.push_back(startKey + op);
 				}
 
-				for (int op = 0; op<writes; op++)
-					values.push_back(self->randomValue());
+				values.reserve(writes);
+				for (int op = 0; op < writes; op++) values.push_back(self->randomValue());
 
-				for (int op = 0; op<extra_read_conflict_ranges + extra_write_conflict_ranges; op++)
+				extra_ranges.reserve(extra_read_conflict_ranges + extra_write_conflict_ranges);
+				for (int op = 0; op < extra_read_conflict_ranges + extra_write_conflict_ranges; op++)
 					extra_ranges.push_back(singleKeyRange( deterministicRandom()->randomUniqueID().toString() ));
 
 				state Trans tr(cx);

--- a/fdbserver/workloads/SnapTest.actor.cpp
+++ b/fdbserver/workloads/SnapTest.actor.cpp
@@ -157,6 +157,7 @@ public: // workload functions
 		state Transaction tr(cx);
 		state vector<int64_t> keys;
 
+		keys.reserve(1000);
 		for (int i = 0; i < 1000; i++) {
 			keys.push_back(deterministicRandom()->randomInt64(0, INT64_MAX - 2));
 		}

--- a/fdbserver/workloads/Throughput.actor.cpp
+++ b/fdbserver/workloads/Throughput.actor.cpp
@@ -86,8 +86,8 @@ struct RWTransactor : ITransactor {
 
 		for(int op = 0; op < self->reads || op < self->writes; op++ )
 			keys.push_back( self->randomKey() );
-		for(int op = 0; op < self->writes; op++ )
-			values.push_back( self->randomValue() );
+		values.reserve(self->writes);
+		for (int op = 0; op < self->writes; op++) values.push_back(self->randomValue());
 
 		loop {
 			try {
@@ -97,8 +97,8 @@ struct RWTransactor : ITransactor {
 				state double rrLatency = -t_rv * self->reads;
 
 				state vector<Future<Optional<Value>>> reads;
-				for(int i=0; i<self->reads; i++)
-					reads.push_back( getLatency( tr.get( keys[i] ), &rrLatency ) );
+				reads.reserve(self->reads);
+				for (int i = 0; i < self->reads; i++) reads.push_back(getLatency(tr.get(keys[i]), &rrLatency));
 				wait( waitForAll(reads) );
 				for(int i=0; i<self->writes; i++)
 					tr.set( keys[i], values[i] );

--- a/fdbserver/workloads/UnitPerf.actor.cpp
+++ b/fdbserver/workloads/UnitPerf.actor.cpp
@@ -35,8 +35,8 @@ ACTOR Future<Void> unitPerfTest() {
 
 	state int counter = 0;
 	state vector<Future<Void>> sleepy;
-	for(int i=0; i<100000; i++)
-		sleepy.push_back( sleepyActor( .1, &counter ) );
+	sleepy.reserve(100000);
+	for (int i = 0; i < 100000; i++) sleepy.push_back(sleepyActor(.1, &counter));
 
 	wait( delay(10) );
 	sleepy.clear();

--- a/fdbserver/workloads/WorkerErrors.actor.cpp
+++ b/fdbserver/workloads/WorkerErrors.actor.cpp
@@ -39,14 +39,16 @@ struct WorkerErrorsWorkload : TestWorkload {
 
 	ACTOR Future< std::vector< TraceEventFields > > latestEventOnWorkers( std::vector<WorkerDetails> workers ) {
 		state vector<Future<TraceEventFields>> eventTraces;
-		for(int c = 0; c < workers.size(); c++) {
+		eventTraces.reserve(workers.size());
+		for (int c = 0; c < workers.size(); c++) {
 			eventTraces.push_back( workers[c].interf.eventLogRequest.getReply( EventLogRequest() ) );
 		}
 
 		wait( timeoutError( waitForAll( eventTraces ), 2.0 ) );
 
 		vector<TraceEventFields> results;
-		for(int i = 0; i < eventTraces.size(); i++) {
+		results.reserve(eventTraces.size());
+		for (int i = 0; i < eventTraces.size(); i++) {
 			results.push_back( eventTraces[i].get() );
 		}
 

--- a/flow/IndexedSet.cpp
+++ b/flow/IndexedSet.cpp
@@ -263,8 +263,8 @@ TEST_CASE("performance/flow/IndexedSet/integers") {
 	std::mt19937_64 urng(deterministicRandom()->randomUInt32());
 
 	std::vector<int> x;
-	for (int i = 0; i<1000000; i++)
-		x.push_back(deterministicRandom()->randomInt(0, 10000000));
+	x.reserve(1000000);
+	for (int i = 0; i < 1000000; i++) x.push_back(deterministicRandom()->randomInt(0, 10000000));
 
 	IndexedSet<int, int> is;
 	double start = timer();
@@ -462,8 +462,8 @@ TEST_CASE("/flow/IndexedSet/all numbers") {
 	std::mt19937_64 urng(deterministicRandom()->randomUInt32());
 
 	std::vector<int> allNumbers;
-	for (int i = 0; i<1000000; i++)
-		allNumbers.push_back(i);
+	allNumbers.reserve(1000000);
+	for (int i = 0; i < 1000000; i++) allNumbers.push_back(i);
 	std::shuffle(allNumbers.begin(), allNumbers.end(), urng);
 
 	for (int i = 0; i<allNumbers.size(); i++)


### PR DESCRIPTION
This PR resolves #...

Changes in this PR:

-
-
-

## General guideline:

- If this PR is ready to be merged (and all checkboxes below are either ticked or not applicable), make this a regular PR
- If this PR still needs work, please make this a draft PR
  - If you wish to get feedback/code-review, please add the label RFC to this PR

Please verify that all things listed below were considered and check them. If an item doesn't apply to this type of PR (for example a documentation change doesn't need to be performance tested), you should make a ~~strikethrough~~ (markdown syntax: `~~strikethrough~~`). More infos on the guidlines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

### Style

- [] ~~All variable and function names make sense.~~
- [x] The code is properly formatted (consider running `git clang-format`).

### Performance

- [x] All CPU-hot paths are well optimized.
- [] ~~The proper containers are used (for example `std::vector` vs `VectorRef`).~~
- [x] There are no new known `SlowTask` traces.

### Testing

- [x] The code was sufficiently tested in simulation.
- [ ] ~~If there are new parameters or knobs, different values are tested in simulation.~~
- [ ] ~~`ASSERT`, `ASSERT_WE_THINK`, and `TEST` macros are added in appropriate places.~~
- [ ] ~~Unit tests were added for new algorithms and data structure that make sense to unit-test~~
- [ ] ~~If this is a bugfix: there is a test that can easily reproduce the bug.~~
