### PR TITLE
Change SSVersionDiffLarge event severity to warning

### DIFF
--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -2687,7 +2687,9 @@ ACTOR Future<Void> updateServerMetrics( TCServerInfo *server ) {
 			}
 	} else if ( server->serverMetrics.get().versionLag > SERVER_KNOBS->DD_SS_FAILURE_VERSIONLAG  ) {
 		if (server->ssVersionTooFarBehind.get() == false) {
-			TraceEvent("SSVersionDiffLarge", server->collection->distributorId).detail("ServerId", server->id.toString()).detail("VersionLag", server->serverMetrics.get().versionLag);
+			TraceEvent(SevWarn, "SSVersionDiffLarge", server->collection->distributorId)
+			    .detail("ServerId", server->id.toString())
+			    .detail("VersionLag", server->serverMetrics.get().versionLag);
 			server->ssVersionTooFarBehind.set(true);
 			server->collection->addLaggingStorageServer(server->lastKnownInterface.locality.zoneId().get());
 		}


### PR DESCRIPTION
Changes in this PR:

- Change SSVersionDiffLarge event severity to warning to better identify lagging SS.

### Style

- [ ] ~~All variable and function names make sense.~~
- [ x ] The code is properly formatted (consider running `git clang-format`).

### Performance

- [ ] ~~All CPU-hot paths are well optimized.~~
- [ ] ~~The proper containers are used (for example `std::vector` vs `VectorRef`).~~
- [ ] ~~There are no new known `SlowTask` traces.~~

### Testing

- [ ] ~~The code was sufficiently tested in simulation.~~
- [ ] ~~If there are new parameters or knobs, different values are tested in simulation.~~
- [ ] ~~`ASSERT`, `ASSERT_WE_THINK`, and `TEST` macros are added in appropriate places.~~
- [ ] ~~Unit tests were added for new algorithms and data structure that make sense to unit-test~~
- [ ] ~~If this is a bugfix: there is a test that can easily reproduce the bug.~~
