### PR TITLE
WIP: Client side of TSS POC

### DIFF
--- a/fdbcli/fdbcli.actor.cpp
+++ b/fdbcli/fdbcli.actor.cpp
@@ -470,9 +470,9 @@ void initHelp() {
 		"clear a range of keys from the database",
 		"All keys between BEGINKEY (inclusive) and ENDKEY (exclusive) are cleared from the database. This command will succeed even if the specified range is empty, but may fail because of conflicts." ESCAPINGK);
 	helpMap["configure"] = CommandHelp(
-		"configure [new] <single|double|triple|three_data_hall|three_datacenter|ssd|memory|memory-radixtree-beta|proxies=<PROXIES>|logs=<LOGS>|resolvers=<RESOLVERS>>*",
+		"configure [new] [tss] <single|double|triple|three_data_hall|three_datacenter|ssd|memory|memory-radixtree-beta|proxies=<PROXIES>|logs=<LOGS>|resolvers=<RESOLVERS>|count=<TSS-COUNT>>*",
 		"change the database configuration",
-		"The `new' option, if present, initializes a new database with the given configuration rather than changing the configuration of an existing one. When used, both a redundancy mode and a storage engine must be specified.\n\nRedundancy mode:\n  single - one copy of the data.  Not fault tolerant.\n  double - two copies of data (survive one failure).\n  triple - three copies of data (survive two failures).\n  three_data_hall - See the Admin Guide.\n  three_datacenter - See the Admin Guide.\n\nStorage engine:\n  ssd - B-Tree storage engine optimized for solid state disks.\n  memory - Durable in-memory storage engine for small datasets.\n\nproxies=<PROXIES>: Sets the desired number of proxies in the cluster. Must be at least 1, or set to -1 which restores the number of proxies to the default value.\n\nlogs=<LOGS>: Sets the desired number of log servers in the cluster. Must be at least 1, or set to -1 which restores the number of logs to the default value.\n\nresolvers=<RESOLVERS>: Sets the desired number of resolvers in the cluster. Must be at least 1, or set to -1 which restores the number of resolvers to the default value.\n\nSee the FoundationDB Administration Guide for more information.");
+		"The `new' option, if present, initializes a new database with the given configuration rather than changing the configuration of an existing one. When used, both a redundancy mode and a storage engine must be specified.\n\ntss: when enabled, configures the testing storage server for the cluster instead. When used with new to set up tss for the first time, it requires both a count and a storage engine. To disable the testing storage server, run \"configure tss count=0\".\n\nRedundancy mode:\n  single - one copy of the data.  Not fault tolerant.\n  double - two copies of data (survive one failure).\n  triple - three copies of data (survive two failures).\n  three_data_hall - See the Admin Guide.\n  three_datacenter - See the Admin Guide.\n\nStorage engine:\n  ssd - B-Tree storage engine optimized for solid state disks.\n  memory - Durable in-memory storage engine for small datasets.\n\nproxies=<PROXIES>: Sets the desired number of proxies in the cluster. Must be at least 1, or set to -1 which restores the number of proxies to the default value.\n\nlogs=<LOGS>: Sets the desired number of log servers in the cluster. Must be at least 1, or set to -1 which restores the number of logs to the default value.\n\nresolvers=<RESOLVERS>: Sets the desired number of resolvers in the cluster. Must be at least 1, or set to -1 which restores the number of resolvers to the default value.\n\nSee the FoundationDB Administration Guide for more information.");
 	helpMap["fileconfigure"] = CommandHelp(
 		"fileconfigure [new] <FILENAME>",
 		"change the database configuration from a file",
@@ -1021,6 +1021,13 @@ void printStatus(StatusObjectReader statusObj, StatusClient::StatusLevel level, 
 
 				if (statusObjConfig.get("log_routers", intVal))
 					outputString += format("\n  Desired Log Routers    - %d", intVal);
+
+				if (statusObjConfig.get("tss_count", intVal) && intVal > 0) {
+					outputString += format("\n  Desired TSS            - %d", intVal);
+
+					if (statusObjConfig.get("tss_storage_engine", strVal))
+						outputString += format("\n  TSS Storage Engine     - %s", strVal.c_str());
+				}
 
 				outputString += "\n  Usable Regions         - ";
 				if (statusObjConfig.get("usable_regions", intVal)) {

--- a/fdbclient/CMakeLists.txt
+++ b/fdbclient/CMakeLists.txt
@@ -58,6 +58,7 @@ set(FDBCLIENT_SRCS
   Status.h
   StatusClient.actor.cpp
   StatusClient.h
+  StorageServerInterface.cpp
   StorageServerInterface.h
   Subspace.cpp
   Subspace.h

--- a/fdbclient/DatabaseConfiguration.h
+++ b/fdbclient/DatabaseConfiguration.h
@@ -203,6 +203,10 @@ struct DatabaseConfiguration {
 	int32_t storageTeamSize;
 	KeyValueStoreType storageServerStoreType;
 
+	// Testing StorageServers
+	int32_t desiredTSSCount;
+	KeyValueStoreType testingStorageServerStoreType;
+
 	// Remote TLogs
 	int32_t desiredLogRouterCount;
 	int32_t remoteDesiredTLogCount;

--- a/fdbclient/DatabaseContext.h
+++ b/fdbclient/DatabaseContext.h
@@ -323,6 +323,9 @@ public:
 
 	static bool debugUseTags;
 	static const std::vector<std::string> debugTransactionTagChoices; 
+
+	// TODO should this be private?
+	void addTssMapping(StorageServerInterface ssi, StorageServerInterface tssi);
 };
 
 #endif

--- a/fdbclient/DatabaseContext.h
+++ b/fdbclient/DatabaseContext.h
@@ -41,7 +41,7 @@ public:
 	virtual ~StorageServerInfo();
 private:
 	DatabaseContext *cx;
-	StorageServerInfo( DatabaseContext *cx, StorageServerInterface const& interf, LocalityData const& locality ) : cx(cx), ReferencedInterface<StorageServerInterface>(interf, locality) {}
+	StorageServerInfo( DatabaseContext *cx, StorageServerInterface const& interf, LocalityData const& locality ) : cx(cx), ReferencedInterface<StorageServerInterface>(interf, locality) {printf("Creating Storage Server Info %s\n", interf.id().toString().c_str());}
 };
 
 typedef MultiInterface<ReferencedInterface<StorageServerInterface>> LocationInfo;
@@ -238,6 +238,9 @@ public:
 
 	std::map< UID, StorageServerInfo* > server_interf;
 
+	// this is to hold references for the StorageServerInfo for all active TSS servers, to track the mapping and keep the endpoints open because they'll never be in LocationCache
+	std::map< UID, Reference<StorageServerInfo> > tss_server_interf;
+
 	UID dbId;
 	bool internal; // Only contexts created through the C client and fdbcli are non-internal
 
@@ -326,7 +329,8 @@ public:
 	static const std::vector<std::string> debugTransactionTagChoices; 
 
 	// TODO should this be private?
-	void addTssMapping(StorageServerInterface ssi, StorageServerInterface tssi);
+	void maybeAddTssMapping(StorageServerInterface const& ssi);
+	void addTssMapping(StorageServerInterface const& ssi, StorageServerInterface const& tssi);
 };
 
 #endif

--- a/fdbclient/DatabaseContext.h
+++ b/fdbclient/DatabaseContext.h
@@ -192,6 +192,7 @@ public:
 	Reference<AsyncVar<Reference<ClusterConnectionFile>>> connectionFile;
 	AsyncTrigger masterProxiesChangeTrigger;
 	Future<Void> monitorMasterProxiesInfoChange;
+	Future<Void> monitorTssInfoChange;
 	Reference<ProxyInfo> masterProxies;
 	Reference<ProxyInfo> grvProxies;
 	bool provisional;

--- a/fdbclient/MasterProxyInterface.h
+++ b/fdbclient/MasterProxyInterface.h
@@ -108,6 +108,7 @@ struct ClientDBInfo {
 	int64_t clientTxnInfoSizeLimit;
 	Optional<Value> forward;
 	double transactionTagSampleRate;
+	std::vector<std::pair<UID, StorageServerInterface>> tssMapping; // logically map<ssid, tss interface> for all active TSS pairs
 
 	ClientDBInfo() : clientTxnInfoSampleRate(std::numeric_limits<double>::infinity()), clientTxnInfoSizeLimit(-1), transactionTagSampleRate(CLIENT_KNOBS->READ_TAG_SAMPLE_RATE) {}
 
@@ -119,7 +120,8 @@ struct ClientDBInfo {
 		if constexpr (!is_fb_function<Archive>) {
 			ASSERT(ar.protocolVersion().isValid());
 		}
-		serializer(ar, proxies, id, clientTxnInfoSampleRate, clientTxnInfoSizeLimit, forward, transactionTagSampleRate);
+		// TODO is adding tssMapping backwards compatible? If not, how to make it backwards compatible?
+		serializer(ar, proxies, id, clientTxnInfoSampleRate, clientTxnInfoSizeLimit, forward, transactionTagSampleRate, tssMapping);
 	}
 };
 

--- a/fdbclient/StorageServerInterface.cpp
+++ b/fdbclient/StorageServerInterface.cpp
@@ -30,7 +30,7 @@ bool TSSComparison::tssCompare(GetValueReply src, GetValueReply tss) {
 		printf("GetValue mismatch: src=%s, tss=%s\n", src.value.present() ? src.value.get().toString().c_str() : "missing", tss.value.present() ? tss.value.get().toString().c_str() : "missing");
 		return false;
 	}
-    // printf("tss GetValueReply matched!\n");
+    printf("tss GetValueReply matched!\n");
 	return true;
 }
 
@@ -41,7 +41,7 @@ bool TSSComparison::tssCompare(GetKeyReply src, GetKeyReply tss) {
         printf("GetKey mismatch\n");
 		return false;
 	}
-    // printf("tss GetKeyReply matched!\n");
+    printf("tss GetKeyReply matched!\n");
 	return true;
 }
 
@@ -52,7 +52,7 @@ bool TSSComparison::tssCompare(GetKeyValuesReply src, GetKeyValuesReply tss) {
         printf("GetKeyValues mismatch\n");
 		return false;
 	}
-    // printf("tss GetKeyValues matched!\n");
+    printf("tss GetKeyValues matched!\n");
 	return true;
 }
 

--- a/fdbclient/StorageServerInterface.cpp
+++ b/fdbclient/StorageServerInterface.cpp
@@ -20,7 +20,7 @@
 
 #include "fdbclient/StorageServerInterface.h"
 
-// Includes template specializations for all tss comparisons on storage server types.
+// Includes template specializations for all tss operations on storage server types.
 // New StorageServerInterface reply types must be added here or it won't compile.
 
 template<>
@@ -30,7 +30,7 @@ bool TSSComparison::tssCompare(GetValueReply src, GetValueReply tss) {
 		printf("GetValue mismatch: src=%s, tss=%s\n", src.value.present() ? src.value.get().toString().c_str() : "missing", tss.value.present() ? tss.value.get().toString().c_str() : "missing");
 		return false;
 	}
-    printf("tss GetValueReply matched!\n");
+    printf("tss GetValueReply matched! src=%s, tss=%s\n", src.value.present() ? src.value.get().toString().c_str() : "missing", tss.value.present() ? tss.value.get().toString().c_str() : "missing");
 	return true;
 }
 
@@ -52,7 +52,7 @@ bool TSSComparison::tssCompare(GetKeyValuesReply src, GetKeyValuesReply tss) {
         printf("GetKeyValues mismatch\n");
 		return false;
 	}
-    printf("tss GetKeyValues matched!\n");
+    printf("tss GetKeyValues matched! %d=%d\n", src.data.size(), tss.data.size());
 	return true;
 }
 

--- a/fdbclient/StorageServerInterface.cpp
+++ b/fdbclient/StorageServerInterface.cpp
@@ -1,0 +1,80 @@
+/*
+ * StorageServerInterface.cpp
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2018 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "fdbclient/StorageServerInterface.h"
+
+// Includes template specializations for all tss comparisons on storage server types.
+// New StorageServerInterface reply types must be added here or it won't compile.
+
+template<>
+bool TSSComparison::tssCompare(GetValueReply src, GetValueReply tss) {
+	if (src.value.present() != tss.value.present() || (src.value.present() && src.value.get() != tss.value.get())) {
+		// printf("GetValue mismatch for key %s: src=%s, tss=%s\n", req.key.toString().c_str(), src.get().present() ? src.get().value.toString().c_str() : "missing", tss.get.present() ? tss.get().value().toString().c_str() : "missing");
+		printf("GetValue mismatch: src=%s, tss=%s\n", src.value.present() ? src.value.get().toString().c_str() : "missing", tss.value.present() ? tss.value.get().toString().c_str() : "missing");
+		return false;
+	}
+    // printf("tss GetValueReply matched!\n");
+	return true;
+}
+
+template<>
+bool TSSComparison::tssCompare(GetKeyReply src, GetKeyReply tss) {
+	if (src.sel != tss.sel) {
+        // TODO print something useful
+        printf("GetKey mismatch\n");
+		return false;
+	}
+    // printf("tss GetKeyReply matched!\n");
+	return true;
+}
+
+template<>
+bool TSSComparison::tssCompare(GetKeyValuesReply src, GetKeyValuesReply tss) {
+	if (src.more != tss.more || src.cached != tss.cached || src.data != tss.data) {
+        // TODO print something useful
+        printf("GetKeyValues mismatch\n");
+		return false;
+	}
+    // printf("tss GetKeyValues matched!\n");
+	return true;
+}
+
+template<>
+bool TSSComparison::tssCompare(WatchValueReply src, WatchValueReply tss) {
+    // TODO should this check that both returned the same version?
+	return true;
+}
+
+
+// no-op template specializations for metrics replies
+template<>
+bool TSSComparison::tssCompare(StorageMetrics src, StorageMetrics tss) {
+	return true;
+}
+
+template<>
+bool TSSComparison::tssCompare(SplitMetricsReply src, SplitMetricsReply tss) {
+	return true;
+}
+
+template<>
+bool TSSComparison::tssCompare(ReadHotSubRangeReply src, ReadHotSubRangeReply tss) {
+	return true;
+}

--- a/fdbclient/StorageServerInterface.h
+++ b/fdbclient/StorageServerInterface.h
@@ -29,6 +29,7 @@
 #include "fdbrpc/LoadBalance.actor.h"
 #include "fdbrpc/Stats.h"
 #include "fdbrpc/TimedRequest.h"
+#include "fdbrpc/TSSComparison.h"
 #include "fdbclient/TagThrottle.h"
 
 // Dead code, removed in the next protocol version

--- a/fdbclient/SystemData.cpp
+++ b/fdbclient/SystemData.cpp
@@ -312,6 +312,37 @@ uint16_t cacheChangeKeyDecodeIndex( const KeyRef& key ) {
 	return idx;
 }
 
+const KeyRef tssMappingChangeKey = LiteralStringRef("\xff\x02/tssMappingChangeKey");
+const KeyRangeRef tssMappingKeys( LiteralStringRef("\xff/tss/"), LiteralStringRef("\xff/tss0") );
+const KeyRef tssMappingPrefix = tssMappingKeys.begin;
+
+const Key tssKeyFor( UID serverID ) {
+	BinaryWriter wr(Unversioned());
+	wr.serializeBytes( tssMappingPrefix );
+	wr << serverID;
+	return wr.toValue();
+}
+
+const Value tssValueFor( UID tssId ) {
+	BinaryWriter wr(Unversioned());
+	wr << tssId;
+	return wr.toValue();
+}
+
+UID decodeTssMappingKey( Key key ) {
+	UID serverID;
+	BinaryReader rd( key.removePrefix(tssMappingPrefix), Unversioned() );
+	rd >> serverID;
+	return serverID;
+}
+
+UID decodeTssMappingValue( Value value ) {
+	UID serverID;
+	BinaryReader rd( value, Unversioned() );
+	rd >> serverID;
+	return serverID;
+}
+
 const KeyRangeRef serverTagKeys(
 	LiteralStringRef("\xff/serverTag/"),
 	LiteralStringRef("\xff/serverTag0") );

--- a/fdbclient/SystemData.h
+++ b/fdbclient/SystemData.h
@@ -96,6 +96,16 @@ extern const KeyRef cacheChangePrefix;
 const Key cacheChangeKeyFor( uint16_t idx );
 uint16_t cacheChangeKeyDecodeIndex( const KeyRef& key );
 
+//    "\xff/tss/[[serverId]]" := "[[tssId]]"
+extern const KeyRef tssMappingChangeKey;
+extern const KeyRangeRef tssMappingKeys;
+extern const KeyRef tssMappingPrefix;
+
+const Key tssMappingKeyFor( UID serverId );
+const Value tssMappingValueFor ( UID tssId );
+UID decodeTssMappingKey(Key serverId);
+UID decodeTssMappingValue(Value serverId);
+
 // "\xff/serverTag/[[serverID]]" = "[[Tag]]"
 extern const KeyRangeRef serverTagKeys;
 extern const KeyRef serverTagPrefix;

--- a/fdbrpc/CMakeLists.txt
+++ b/fdbrpc/CMakeLists.txt
@@ -28,7 +28,8 @@ set(FDBRPC_SRCS
   sim2.actor.cpp
   sim_validation.cpp
   TimedRequest.h
-  TraceFileIO.cpp)
+  TraceFileIO.cpp
+  TSSComparison.h)
 
 set(FDBRPC_THIRD_PARTY_SRCS
   libcoroutine/Common.c

--- a/fdbrpc/LoadBalance.actor.h
+++ b/fdbrpc/LoadBalance.actor.h
@@ -167,9 +167,10 @@ Future<Optional<REPLY_TYPE(Request)>> makeRequest(RequestStream<Request> const* 
 	if(model) {
 		// TODO why not just store request stream in model instead of Endpoint? (maybe resource leak issues?) then we wouldn't have to make a new request stream?
 		// Send parallel request to TSS pair, if it exists
-		// TODO uncomment once actual TSS stuff set up. For now randomly simulate it
-		// Optional<Endpoint> tssEndpoint = model->getTss(stream->getEndpoint().token.first());
-		Optional<Endpoint> tssEndpoint = (deterministicRandom()->randomInt(0, 10) == 1) ? stream->getEndpoint() : Optional<Endpoint>();
+		Optional<Endpoint> tssEndpoint = model->getTssEndpoint(stream->getEndpoint().token.first());
+
+		// TODO remove old hack
+		// Optional<Endpoint> tssEndpoint = (deterministicRandom()->randomInt(0, 10) == 1) ? stream->getEndpoint() : Optional<Endpoint>();
 		
 		if (tssEndpoint.present()) {
 			//FIXME: optimize to avoid creating new netNotifiedQueue for each message

--- a/fdbrpc/QueueModel.cpp
+++ b/fdbrpc/QueueModel.cpp
@@ -18,6 +18,8 @@
  * limitations under the License.
  */
 
+#include <cinttypes>
+
 #include "fdbrpc/QueueModel.h"
 #include "fdbrpc/LoadBalance.h"
 
@@ -44,7 +46,7 @@ void QueueModel::endRequest( uint64_t id, double latency, double penalty, double
 		d.increaseBackoffTime = 0.0;
 	}
 
-	if(penalty > 0) {
+	if (penalty > 0) {
 		d.penalty = penalty;
 	}
 }

--- a/fdbrpc/QueueModel.cpp
+++ b/fdbrpc/QueueModel.cpp
@@ -64,8 +64,9 @@ void QueueModel::updateTssEndpoint(uint64_t id, UID generation, Endpoint tssEndp
 	if (!d.tss.present()) {
 		tssCount++;
 	}
+	d.tssGeneration = generation;
 	// TODO REMOVE print
-	printf("Setting tss endpoint for %d\n at %s", id, generation.toString().c_str());
+	printf("Setting tss endpoint for %" PRIu64 " at %s\n", id, generation.toString().c_str());
 	d.tss = Optional<Endpoint>(tssEndpoint);
 }
 
@@ -75,8 +76,9 @@ void QueueModel::removeOldTssEndpoints(UID currentGeneration) {
 		for (auto& it : data) {
 			if (it.second.tss.present() && it.second.tssGeneration != currentGeneration) {
 				// TODO REMOVE print
-				printf("Removing tss endpoint for %d\n", it.first);
+				printf("Removing tss endpoint for %" PRIu64 " because its generation %s doesn't match the current one %s\n", it.first, it.second.tssGeneration.toString().c_str(), currentGeneration.toString().c_str());
 				it.second.tss = Optional<Endpoint>();
+				it.second.tssGeneration = currentGeneration;
 				tssCount--;
 			}
 		}

--- a/fdbrpc/QueueModel.cpp
+++ b/fdbrpc/QueueModel.cpp
@@ -59,16 +59,21 @@ double QueueModel::addRequest( uint64_t id ) {
 	return d.penalty;
 }
 
-void QueueModel::updateTss( std::unordered_map<uint64_t, Endpoint> tssEndpointMap ) {
-	if (tssCount == 0 && tssEndpointMap.empty()) {
-		// optization to avoid doing anything if there are no tss mappings to add or clean up
-		return;
+void QueueModel::updateTssEndpoint(uint64_t id, UID generation, Endpoint tssEndpoint) {
+	auto& d = data[id];
+	if (!d.tss.present()) {
+		tssCount++;
 	}
+	// TODO REMOVE print
+	printf("Setting tss endpoint for %d\n at %s", id, generation.toString().c_str());
+	d.tss = Optional<Endpoint>(tssEndpoint);
+}
 
+void QueueModel::removeOldTssEndpoints(UID currentGeneration) {
 	if (tssCount > 0) {
 		// expire old tss mappings that aren't present in new mapping
 		for (auto& it : data) {
-			if (it.second.tss.present() && !tssEndpointMap.count(it.first)) {
+			if (it.second.tss.present() && it.second.tssGeneration != currentGeneration) {
 				// TODO REMOVE print
 				printf("Removing tss endpoint for %d\n", it.first);
 				it.second.tss = Optional<Endpoint>();
@@ -76,20 +81,9 @@ void QueueModel::updateTss( std::unordered_map<uint64_t, Endpoint> tssEndpointMa
 			}
 		}
 	}
-
-	// add or update mapping
-	for (auto& it: tssEndpointMap) {
-		auto& d  = data[it.first];
-		if (!d.tss.present()) {
-			tssCount++;	
-		}
-		// TODO REMOVE print
-		printf("Setting tss endpoint for %d\n", it.first);
-		d.tss = Optional<Endpoint>(it.second);
-	}
 }
 
-Optional<Endpoint> QueueModel::getTss(uint64_t id) {
+Optional<Endpoint> QueueModel::getTssEndpoint(uint64_t id) {
 	return data[id].tss;
 }
 

--- a/fdbrpc/TSSComparison.h
+++ b/fdbrpc/TSSComparison.h
@@ -28,8 +28,8 @@
 // TODO is there a way to do this static method without a class?
 class TSSComparison {
     public:
-        template<class T>
-        static bool tssCompare(T src, T tss);
+        template<class Resp>
+        static bool tssCompare(Resp src, Resp tss);
 };
 
 #endif

--- a/fdbrpc/TSSComparison.h
+++ b/fdbrpc/TSSComparison.h
@@ -1,0 +1,35 @@
+/*
+ * TSSComparison.h
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2018 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * This header is to declare the tss comparison function that LoadBalance.Actor.h needs to be aware of to call,
+ * But StorageServerInterface.h needs to implement on the types defined in SSI.h.
+ */
+#ifndef FDBRPC_TSS_COMPARISON_H
+#define FDBRPC_TSS_COMPARISON_H
+
+// TODO is there a way to do this static method without a class?
+class TSSComparison {
+    public:
+        template<class T>
+        static bool tssCompare(T src, T tss);
+};
+
+#endif

--- a/fdbrpc/fdbrpc.h
+++ b/fdbrpc/fdbrpc.h
@@ -308,6 +308,7 @@ public:
 		if (queue->isRemoteEndpoint()) {
 			Future<Void> disc = makeDependent<T>(IFailureMonitor::failureMonitor()).onDisconnectOrFailure(getEndpoint(taskID));
 			if (disc.isReady()) {
+				printf("got disconnect or failure 1 :O\n");
 				return ErrorOr<REPLY_TYPE(X)>(request_maybe_delivered());
 			}
 			Reference<Peer> peer = FlowTransport::transport().sendUnreliable(SerializeSource<T>(value), getEndpoint(taskID), true);
@@ -324,6 +325,7 @@ public:
 		if (queue->isRemoteEndpoint()) {
 			Future<Void> disc = makeDependent<T>(IFailureMonitor::failureMonitor()).onDisconnectOrFailure(getEndpoint());
 			if (disc.isReady()) {
+				printf("got disconnect or failure 2 :O\n");
 				return ErrorOr<REPLY_TYPE(X)>(request_maybe_delivered());
 			}
 			Reference<Peer> peer = FlowTransport::transport().sendUnreliable(SerializeSource<T>(value), getEndpoint(), true);

--- a/flow/genericactors.actor.h
+++ b/flow/genericactors.actor.h
@@ -1239,6 +1239,8 @@ ACTOR template <class T> Future<T> brokenPromiseToMaybeDelivered( Future<T> in )
 		return t;
 	} catch (Error& e) {
 		if (e.code() == error_code_broken_promise) {
+			// TODO REMOVE!
+			printf("broken promise!!");
 			throw request_maybe_delivered();
 		}
 		throw;


### PR DESCRIPTION
Changes in this PR:

- CLI command to configure tss settings
- TSS settings and mapping stored in system keyspace
- ClusterController and Clients track changes in TSS mapping
- Clients duplicate SS requests to TSS endpoints if SS has a paired TSS
- Clients compare the result of the duplicate replies
- Clients record failures properly for later inspection

## General guideline:

- If this PR is ready to be merged (and all checkboxes below are either ticked or not applicable), make this a regular PR
- If this PR still needs work, please make this a draft PR
  - If you wish to get feedback/code-review, please add the label RFC to this PR

Please verify that all things listed below were considered and check them. If an item doesn't apply to this type of PR (for example a documentation change doesn't need to be performance tested), you should make a ~~strikethrough~~ (markdown syntax: `~~strikethrough~~`). More infos on the guidlines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

### Style

- [ ] All variable and function names make sense.
- [ ] The code is properly formatted (consider running `git clang-format`).

### Performance

- [ ] All CPU-hot paths are well optimized.
- [ ] The proper containers are used (for example `std::vector` vs `VectorRef`).
- [ ] There are no new known `SlowTask` traces.

### Testing

- [ ] The code was sufficiently tested in simulation.
- [ ] If there are new parameters or knobs, different values are tested in simulation.
- [ ] `ASSERT`, `ASSERT_WE_THINK`, and `TEST` macros are added in appropriate places.
- [ ] Unit tests were added for new algorithms and data structure that make sense to unit-test
- [ ] If this is a bugfix: there is a test that can easily reproduce the bug.
