### PR TITLE
Add ASSERT to help clang-tidy

### DIFF
--- a/fdbserver/DeltaTree.h
+++ b/fdbserver/DeltaTree.h
@@ -391,7 +391,8 @@ public:
 			DecodedNode* n = root;
 			bool addLeftChild = false;
 
-			while (n != nullptr) {
+			ASSERT(n != nullptr);
+			while (true) {
 				int cmp = k.compare(n->item, skipLen);
 
 				if (cmp >= 0) {

--- a/fdbserver/DeltaTree.h
+++ b/fdbserver/DeltaTree.h
@@ -386,7 +386,11 @@ public:
 		// have changed (they won't if k already exists in the tree but was deleted).
 		// Returns true if successful, false if k does not fit in the space available
 		// or if k is already in the tree (and was not already deleted).
+		// Insertion on an empty tree returns false as well.
 		bool insert(const T& k, int skipLen = 0, int maxHeightAllowed = std::numeric_limits<int>::max()) {
+			if (root == nullptr) {
+				return false;
+			}
 			int height = 1;
 			DecodedNode* n = root;
 			bool addLeftChild = false;
@@ -432,7 +436,6 @@ public:
 				return false;
 			}
 
-			ASSERT(n != nullptr);
 			// Insert k as the left or right child of n, depending on the value of addLeftChild
 			// First, see if it will fit.
 			const T* prev = addLeftChild ? n->prev : &n->item;

--- a/fdbserver/DeltaTree.h
+++ b/fdbserver/DeltaTree.h
@@ -391,7 +391,6 @@ public:
 			DecodedNode* n = root;
 			bool addLeftChild = false;
 
-			ASSERT(n != nullptr);
 			while (true) {
 				int cmp = k.compare(n->item, skipLen);
 
@@ -433,6 +432,7 @@ public:
 				return false;
 			}
 
+			ASSERT(n != nullptr);
 			// Insert k as the left or right child of n, depending on the value of addLeftChild
 			// First, see if it will fit.
 			const T* prev = addLeftChild ? n->prev : &n->item;


### PR DESCRIPTION
If n == nullptr here, then we'll dereference a nullptr. Add an assert.