### PR TITLE
Inform boost context of valgrind usage

### DIFF
--- a/bindings/go/CMakeLists.txt
+++ b/bindings/go/CMakeLists.txt
@@ -43,7 +43,7 @@ set(go_options_file ${GO_DEST}/src/fdb/generated.go)
 
 set(go_env GOPATH=${GOPATH}
   C_INCLUDE_PATH=${CMAKE_BINARY_DIR}/bindings/c/foundationdb:${CMAKE_SOURCE_DIR}/bindings/c
-  CGO_LDFLAGS=-L${CMAKE_BINARY_DIR}/lib\ ${SANITIZER_LINK_OPTIONS})
+  CGO_LDFLAGS=-L${CMAKE_BINARY_DIR}/lib)
 
 foreach(src_file IN LISTS SRCS)
   set(dest_file ${GO_DEST}/${src_file})

--- a/bindings/go/CMakeLists.txt
+++ b/bindings/go/CMakeLists.txt
@@ -43,7 +43,7 @@ set(go_options_file ${GO_DEST}/src/fdb/generated.go)
 
 set(go_env GOPATH=${GOPATH}
   C_INCLUDE_PATH=${CMAKE_BINARY_DIR}/bindings/c/foundationdb:${CMAKE_SOURCE_DIR}/bindings/c
-  CGO_LDFLAGS=-L${CMAKE_BINARY_DIR}/lib)
+  CGO_LDFLAGS=-L${CMAKE_BINARY_DIR}/lib\ ${SANITIZER_LINK_OPTIONS})
 
 foreach(src_file IN LISTS SRCS)
   set(dest_file ${GO_DEST}/${src_file})

--- a/cmake/CompileBoost.cmake
+++ b/cmake/CompileBoost.cmake
@@ -62,8 +62,13 @@ if(USE_SANITIZER)
     message(FATAL_ERROR "Sanitizers are not supported on Windows")
   endif()
   message(STATUS "A sanitizer is enabled, need to build boost from source")
-  compile_boost(TARGET boost_asan BUILD_ARGS context-impl=ucontext
-    CXXFLAGS ${SANITIZER_COMPILE_OPTIONS} LDFLAGS ${SANITIZER_LINK_OPTIONS})
+  if (USE_VALGRIND)
+    compile_boost(TARGET boost_asan BUILD_ARGS valgrind=on
+      CXXFLAGS ${SANITIZER_COMPILE_OPTIONS} LDFLAGS ${SANITIZER_LINK_OPTIONS})
+  else()
+    compile_boost(TARGET boost_asan BUILD_ARGS context-impl=ucontext
+      CXXFLAGS ${SANITIZER_COMPILE_OPTIONS} LDFLAGS ${SANITIZER_LINK_OPTIONS})
+  endif()
   return()
 endif()
 

--- a/cmake/ConfigureCompiler.cmake
+++ b/cmake/ConfigureCompiler.cmake
@@ -168,7 +168,10 @@ else()
     if(NOT CLANG)
       message(FATAL_ERROR "Unsupported configuration: USE_MSAN only works with Clang")
     endif()
-    list(APPEND SANITIZER_COMPILE_OPTIONS -fsanitize=memory -fsanitize-memory-track-origins=2)
+    list(APPEND SANITIZER_COMPILE_OPTIONS
+      -fsanitize=memory
+      -fsanitize-memory-track-origins=2
+      -DBOOST_USE_UCONTEXT)
     list(APPEND SANITIZER_LINK_OPTIONS -fsanitize=memory)
   endif()
 
@@ -180,23 +183,25 @@ else()
     list(APPEND SANITIZER_COMPILE_OPTIONS
       -fsanitize=undefined
       # TODO(atn34) Re-enable -fsanitize=alignment once https://github.com/apple/foundationdb/issues/1434 is resolved
-      -fno-sanitize=alignment)
+      -fno-sanitize=alignment
+      -DBOOST_USE_UCONTEXT)
     list(APPEND SANITIZER_LINK_OPTIONS -fsanitize=undefined)
   endif()
 
   if(USE_TSAN)
-    list(APPEND SANITIZER_COMPILE_OPTIONS -fsanitize=thread)
+    list(APPEND SANITIZER_COMPILE_OPTIONS -fsanitize=thread -DBOOST_USE_UCONTEXT)
     list(APPEND SANITIZER_LINK_OPTIONS -fsanitize=thread)
   endif()
 
-  set(USE_SANITIZER OFF)
+  if(USE_VALGRIND)
+    list(APPEND SANITIZER_COMPILE_OPTIONS -DBOOST_USE_VALGRIND)
+  endif()
+
   if(SANITIZER_COMPILE_OPTIONS)
     add_compile_options(${SANITIZER_COMPILE_OPTIONS})
-    set(USE_SANITIZER ON)
   endif()
   if(SANITIZER_LINK_OPTIONS)
     add_link_options(${SANITIZER_LINK_OPTIONS})
-    set(USE_SANITIZER ON)
   endif()
 
   if(PORTABLE_BINARY)

--- a/cmake/FDBComponents.cmake
+++ b/cmake/FDBComponents.cmake
@@ -97,6 +97,10 @@ if(GO_EXECUTABLE AND NOT WIN32)
 else()
   set(WITH_GO OFF)
 endif()
+if (USE_SANITIZER)
+  # Disable building go for sanitizers, since _stacktester doesn't link properly
+  set(WITH_GO OFF)
+endif()
 
 ################################################################################
 # Ruby


### PR DESCRIPTION
This fixes the "client switching stacks?" warning that valgrind is
currently issuing.

Also fix a memory error that currently doesn't manifest because of the
way FastAllocator works (if you free a small buffer and then immediately
allocate the same size buffer in FastAllocator you always get the same
buffer back). You can see it if you set `FDB_VALGRIND_PRECISE=` in the environment (causes
FastAllocator to use malloc)

Also minor refactoring and cleanup of CoroFlow.actor.cpp

Also (probably) fix the other sanitizer builds. I tested ASAN

## General guideline:

- If this PR is ready to be merged (and all checkboxes below are either ticked or not applicable), make this a regular PR
- If this PR still needs work, please make this a draft PR
  - If you wish to get feedback/code-review, please add the label RFC to this PR

Please verify that all things listed below were considered and check them. If an item doesn't apply to this type of PR (for example a documentation change doesn't need to be performance tested), you should make a ~~strikethrough~~ (markdown syntax: `~~strikethrough~~`). More infos on the guidlines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

### Style

- [x] All variable and function names make sense.
- [x] The code is properly formatted (consider running `git clang-format`).

### Performance

- [ ] All CPU-hot paths are well optimized.
- [ ] ~~The proper containers are used (for example `std::vector` vs `VectorRef`).~~
- [ ] ~~There are no new known `SlowTask` traces.~~

### Testing

- [x] The code was sufficiently tested in simulation.
- ~~[ ] If there are new parameters or knobs, different values are tested in simulation.~~
- [x] `ASSERT`, `ASSERT_WE_THINK`, and `TEST` macros are added in appropriate places.
- ~~[ ] Unit tests were added for new algorithms and data structure that make sense to unit-test~~
- [x] If this is a bugfix: there is a test that can easily reproduce the bug.
