### PR TITLE
status: Ignore LogSets with no tLogs when computing FT

### DIFF
--- a/fdbserver/Status.actor.cpp
+++ b/fdbserver/Status.actor.cpp
@@ -1948,6 +1948,13 @@ static JsonBuilderObject tlogFetcher(int* logFaultTolerance, const std::vector<T
 	int localSetsWithNonNegativeFaultTolerance = 0;
 
 	for (int i = 0; i < tLogs.size(); i++) {
+		if (tLogs[i].tLogs.size() == 0) {
+			// We can have LogSets where there are no tLogs but some LogRouters. Its the way
+			// recruiting is implemented for old LogRouters in TagPartitionedLogSystem, where
+			// it adds an empty LogSet for missing locality.
+			continue;
+		}
+
 		int failedLogs = 0;
 		for (auto& log : tLogs[i].tLogs) {
 			JsonBuilderObject logObj;
@@ -1964,6 +1971,7 @@ static JsonBuilderObject tlogFetcher(int* logFaultTolerance, const std::vector<T
 		}
 
 		if (tLogs[i].isLocal) {
+			ASSERT_WE_THINK(tLogs[i].tLogReplicationFactor > 0);
 			int currentFaultTolerance = tLogs[i].tLogReplicationFactor - 1 - tLogs[i].tLogWriteAntiQuorum - failedLogs;
 			if(currentFaultTolerance >= 0) {
 				localSetsWithNonNegativeFaultTolerance++;

--- a/fdbserver/Status.actor.cpp
+++ b/fdbserver/Status.actor.cpp
@@ -1949,7 +1949,7 @@ static JsonBuilderObject tlogFetcher(int* logFaultTolerance, const std::vector<T
 
 	for (int i = 0; i < tLogs.size(); i++) {
 		if (tLogs[i].tLogs.size() == 0) {
-			// We can have LogSets where there are no tLogs but some LogRouters. Its the way
+			// We can have LogSets where there are no tLogs but some LogRouters. It's the way
 			// recruiting is implemented for old LogRouters in TagPartitionedLogSystem, where
 			// it adds an empty LogSet for missing locality.
 			continue;


### PR DESCRIPTION
We can have LogSets where there are no tLogs but some LogRouters. Its
the way recruiting is implemented for old LogRouters in
TagPartitionedLogSystem, where it adds an empty LogSet for missing
locality.

Here's where the new LogSets are being added for missing locality:

https://github.com/apple/foundationdb/blob/7066513109f7b7f4ae716e07c1b595251cafcb18/fdbserver/TagPartitionedLogSystem.actor.cpp#L1996-L2001

https://github.com/apple/foundationdb/blob/7066513109f7b7f4ae716e07c1b595251cafcb18/fdbserver/TagPartitionedLogSystem.actor.cpp#L2041-L2045

## General guideline:

- If this PR is ready to be merged (and all checkboxes below are either ticked or not applicable), make this a regular PR
- If this PR still needs work, please make this a draft PR
  - If you wish to get feedback/code-review, please add the label RFC to this PR

Please verify that all things listed below were considered and check them. If an item doesn't apply to this type of PR (for example a documentation change doesn't need to be performance tested), you should make a ~~strikethrough~~ (markdown syntax: `~~strikethrough~~`). More infos on the guidlines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

### Style

- [x] All variable and function names make sense.
- [x] The code is properly formatted (consider running `git clang-format`).

### Performance

- [x] All CPU-hot paths are well optimized.
- [x] The proper containers are used (for example `std::vector` vs `VectorRef`).
- [x] There are no new known `SlowTask` traces.

### Testing

- [x] The code was sufficiently tested in simulation.
- [x] If there are new parameters or knobs, different values are tested in simulation.
- [x] `ASSERT`, `ASSERT_WE_THINK`, and `TEST` macros are added in appropriate places.
- [x] Unit tests were added for new algorithms and data structure that make sense to unit-test
- [x] If this is a bugfix: there is a test that can easily reproduce the bug.
