### PR TITLE
Add multi-cluster FDB java tests through cmake

### DIFF
--- a/bindings/java/CMakeLists.txt
+++ b/bindings/java/CMakeLists.txt
@@ -363,13 +363,18 @@ if(NOT OPEN_FOR_IDE)
     get_property(integration_jar_path TARGET fdb-integration PROPERTY JAR_FILE)
 
 
-    add_test(NAME java-integration 
-                    COMMAND ${CMAKE_COMMAND} 
-                    -E env "FDB_CLUSTER_FILE=${PROJECT_BINARY_DIR}/fdb.cluster"
-                    ${Java_JAVA_EXECUTABLE}
+    add_fdbclient_test(NAME java-integration 
+                    COMMAND ${Java_JAVA_EXECUTABLE}
                       -classpath "${target_jar}:${integration_jar_path}:${JUNIT_CLASSPATH}"
                       -Djava.library.path=${CMAKE_BINARY_DIR}/lib
-                      org.junit.platform.console.ConsoleLauncher "--details=summary" "--class-path=${integration_jar_path}" "--scan-classpath" "--disable-banner"
+                      org.junit.platform.console.ConsoleLauncher "--details=summary" "--class-path=${integration_jar_path}" "--scan-classpath" "--disable-banner" "-T MultiClient"
+    )
+
+    add_multi_fdbclient_test(NAME java-multi-integration
+                    COMMAND ${Java_JAVA_EXECUTABLE}
+                    -classpath "${target_jar}:${integration_jar_path}:${JUNIT_CLASSPATH}"
+                    -Djava.library.path=${CMAKE_BINARY_DIR}/lib
+                    org.junit.platform.console.ConsoleLauncher "--details=summary" "--class-path=${integration_jar_path}" "--scan-classpath" "--disable-banner" "-t MultiClient"
     )
 
   endif()

--- a/bindings/java/src/README.md
+++ b/bindings/java/src/README.md
@@ -23,3 +23,18 @@ To run _only_ integration tests, run `ctest -R integration` from `${BUILD_DIR}/b
 
 There are lots of other useful `ctest` commands, which we don't need to get into here. For more information,
 see the [https://cmake.org/cmake/help/v3.19/manual/ctest.1.html](ctest documentation).
+
+### Multi-Client tests
+Multi-Client tests are integration tests that can only be executed when multiple clusters are running. To write a multi-client
+test, do the following:
+
+1. Tag all tests that require multiple clients with `@Tag("MultiClient")`
+2. Ensure that your tests have the `MultiClientHelper` extension present, and Registered as an extension
+3. Ensure that your test class is in the the JAVA_INTEGRATION_TESTS list in `test.cmake`
+
+( see `BasicMultiClientIntegrationTest` for a good reference example)
+
+It is important to note that it requires significant time to start and stop 3 separate clusters; if the underying test takes a long time to run,
+ctest will time out and kill the test. When that happens, there is no guarantee that the FDB clusters will be properly stopped! It is thus
+in your best interest to ensure that all tests run in a relatively small amount of time, or have a longer timeout attached.
+

--- a/bindings/java/src/integration/com/apple/foundationdb/BasicMultiClientIntegrationTest.java
+++ b/bindings/java/src/integration/com/apple/foundationdb/BasicMultiClientIntegrationTest.java
@@ -1,0 +1,69 @@
+/*
+ * BasicMultiClientIntegrationTest
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2018 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.apple.foundationdb;
+
+import java.util.Collection;
+import java.util.Random;
+
+import com.apple.foundationdb.tuple.Tuple;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+/**
+ * Simple class to test multi-client logic.
+ *
+ * Note that all Multi-client-only tests _must_ be tagged with "MultiClient", which will ensure that they are excluded
+ * from non-multi-threaded tests.
+ */
+public class BasicMultiClientIntegrationTest {
+	@RegisterExtension public  static final MultiClientHelper clientHelper = new MultiClientHelper();
+
+	@Test
+	@Tag("MultiClient")
+	void testMultiClientWritesAndReadsData() throws Exception {
+		FDB fdb = FDB.selectAPIVersion(630);
+		fdb.options().setKnob("min_trace_severity=5");
+
+		Collection<Database> dbs = clientHelper.openDatabases(fdb); // the clientHelper will close the databases for us
+		System.out.print("Starting tests.");
+		Random rand = new Random();
+		for (int counter = 0; counter < 25; ++counter) {
+			for (Database db : dbs) {
+				String key = Integer.toString(rand.nextInt(100000000));
+				String val = Integer.toString(rand.nextInt(100000000));
+
+				db.run(tr -> {
+					tr.set(Tuple.from(key).pack(), Tuple.from(val).pack());
+					return null;
+				});
+
+				String fetchedVal = db.run(tr -> {
+					byte[] result = tr.get(Tuple.from(key).pack()).join();
+					return Tuple.fromBytes(result).getString(0);
+				});
+				Assertions.assertEquals(val, fetchedVal, "Wrong result!");
+			}
+			Thread.sleep(200);
+		}
+	}
+}

--- a/bindings/java/src/integration/com/apple/foundationdb/DirectoryTest.java
+++ b/bindings/java/src/integration/com/apple/foundationdb/DirectoryTest.java
@@ -19,8 +19,6 @@
  */
 package com.apple.foundationdb;
 
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;

--- a/bindings/java/src/integration/com/apple/foundationdb/MultiClientHelper.java
+++ b/bindings/java/src/integration/com/apple/foundationdb/MultiClientHelper.java
@@ -1,0 +1,82 @@
+/*
+ * MultiClientHelper.java
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2018 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.apple.foundationdb;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+/**
+ * Callback to help define a multi-client scenario and ensure that 
+ * the clients can be configured properly.
+ */
+public class MultiClientHelper implements BeforeAllCallback,AfterEachCallback{
+	private String[] clusterFiles;
+	private Collection<Database> openDatabases;
+	
+	public static String[] readClusterFromEnv() {
+		/*
+		 * Reads the cluster file lists from the ENV variable
+		 * FDB_CLUSTERS.
+		 */
+		String clusterFilesProp = System.getenv("FDB_CLUSTERS");
+		if (clusterFilesProp == null) {
+			throw new IllegalStateException("Missing FDB cluster connection file names");
+		}
+
+		return clusterFilesProp.split(";");
+	}
+
+	Collection<Database> openDatabases(FDB fdb){
+		if(openDatabases!=null){
+			return openDatabases;
+		}
+		if(clusterFiles==null){
+			clusterFiles = readClusterFromEnv();
+		}
+		Collection<Database> dbs = new ArrayList<Database>();
+		for (String arg : clusterFiles) {
+			System.out.printf("Opening Cluster: %s\n", arg);
+			dbs.add(fdb.open(arg));
+		}
+
+		this.openDatabases = dbs;
+		return dbs;
+	}
+
+	@Override
+	public void beforeAll(ExtensionContext arg0) throws Exception {
+		clusterFiles = readClusterFromEnv();
+	}
+
+	@Override
+	public void afterEach(ExtensionContext arg0) throws Exception {
+		//close any databases that have been opened	
+		if(openDatabases!=null){
+			for(Database db : openDatabases){
+				db.close();
+			}
+		}
+		openDatabases = null;
+	}
+
+}

--- a/bindings/java/src/tests.cmake
+++ b/bindings/java/src/tests.cmake
@@ -46,12 +46,14 @@ set(JUNIT_RESOURCES
 set(JAVA_INTEGRATION_TESTS
   src/integration/com/apple/foundationdb/DirectoryTest.java
   src/integration/com/apple/foundationdb/RangeQueryIntegrationTest.java
+  src/integration/com/apple/foundationdb/BasicMultiClientIntegrationTest.java
 )
 
 # Resources that are used in integration testing, but are not explicitly test files (JUnit rules,
 # utility classes, and so forth)
 set(JAVA_INTEGRATION_RESOURCES
   src/integration/com/apple/foundationdb/RequiresDatabase.java
+  src/integration/com/apple/foundationdb/MultiClientHelper.java
 )
 
 

--- a/cmake/AddFdbTest.cmake
+++ b/cmake/AddFdbTest.cmake
@@ -375,3 +375,95 @@ function(package_bindingtester)
   add_custom_target(bindingtester ALL DEPENDS ${tar_file})
   add_dependencies(bindingtester copy_bindingtester_binaries)
 endfunction()
+
+# Creates a single cluster before running the specified command (usually a ctest test)
+function(add_fdbclient_test)
+  set(options DISABLED ENABLED)
+  set(oneValueArgs NAME)
+  set(multiValueArgs COMMAND)
+  cmake_parse_arguments(T "${options}" "${oneValueArgs}" "${multiValueArgs}" "${ARGN}")
+  if(OPEN_FOR_IDE)
+    return()
+  endif()
+  if(NOT T_ENABLED AND T_DISABLED)
+    return()
+  endif()
+  if(NOT T_NAME)
+    message(FATAL_ERROR "NAME is a required argument for add_fdbclient_test")
+  endif()
+  if(NOT T_COMMAND)
+    message(FATAL_ERROR "COMMAND is a required argument for add_fdbclient_test")
+  endif()
+  message(STATUS "Adding Client test ${T_NAME}")
+  add_test(NAME "${T_NAME}"
+    COMMAND ${CMAKE_SOURCE_DIR}/tests/TestRunner/tmp_cluster.py
+            --build-dir ${CMAKE_BINARY_DIR}
+            --
+            ${T_COMMAND})
+  set_tests_properties("${T_NAME}" PROPERTIES TIMEOUT 60) 
+endfunction()
+
+# Creates 3 distinct clusters before running the specified command.
+# This is useful for testing features that require multiple clusters (like the
+# multi-cluster FDB client)
+function(add_multi_fdbclient_test)
+  set(options DISABLED ENABLED)
+  set(oneValueArgs NAME)
+  set(multiValueArgs COMMAND)
+  cmake_parse_arguments(T "${options}" "${oneValueArgs}" "${multiValueArgs}" "${ARGN}")
+  if(OPEN_FOR_IDE)
+    return()
+  endif()
+  if(NOT T_ENABLED AND T_DISABLED)
+    return()
+  endif()
+  if(NOT T_NAME)
+    message(FATAL_ERROR "NAME is a required argument for add_multi_fdbclient_test")
+  endif()
+  if(NOT T_COMMAND)
+    message(FATAL_ERROR "COMMAND is a required argument for add_multi_fdbclient_test")
+  endif()
+  message(STATUS "Adding Client test ${T_NAME}")
+  add_test(NAME "${T_NAME}"
+    COMMAND ${CMAKE_SOURCE_DIR}/tests/TestRunner/tmp_multi_cluster.py
+            --build-dir ${CMAKE_BINARY_DIR}
+            --clusters 3
+            --
+            ${T_COMMAND})
+  set_tests_properties("${T_NAME}" PROPERTIES TIMEOUT 60) 
+endfunction()
+
+function(add_java_test)
+  set(options DISABLED ENABLED)
+  set(oneValueArgs NAME CLASS)
+  set(multiValueArgs CLASS_PATH)
+  cmake_parse_arguments(T "${options}" "${oneValueArgs}" "${multiValueArgs}" "${ARGN}")
+  if(NOT T_ENABLED AND T_DISABLED)
+    return()
+  endif()
+  if(NOT T_NAME)
+    message(FATAL_ERROR "NAME is a required argument for add_java_test")
+  endif()
+  if(NOT T_CLASS)
+    message(FATAL_ERROR "CLASS is a required argument for add_java_test")
+  endif()
+  set(cp "")
+  set(separator ":")
+  if (WIN32)
+    set(separator ";")
+  endif()
+  message(STATUS "CLASSPATH ${T_CLASS_PATH}")
+  foreach(path ${T_CLASS_PATH})
+    if(cp)
+      set(cp "${cp}${separator}${path}")
+    else()
+      set(cp "${path}")
+    endif()
+  endforeach()
+  add_fdbclient_test(
+    NAME ${T_NAME}
+    COMMAND ${Java_JAVA_EXECUTABLE}
+            -cp "${cp}"
+            -Djava.library.path=${CMAKE_BINARY_DIR}/lib
+            ${T_CLASS} "@CLUSTER_FILE@")
+endfunction()

--- a/tests/TestRunner/local_cluster.py
+++ b/tests/TestRunner/local_cluster.py
@@ -1,0 +1,121 @@
+from pathlib import Path
+from argparse import ArgumentParser
+import random
+import string
+import subprocess
+import sys
+import socket
+
+
+def get_free_port():
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(('0.0.0.0', 0))
+        return s.getsockname()[1]
+
+
+class LocalCluster:
+    configuration_template = """
+## foundationdb.conf
+##
+## Configuration file for FoundationDB server processes
+## Full documentation is available at
+## https://apple.github.io/foundationdb/configuration.html#the-configuration-file
+
+[fdbmonitor]
+
+[general]
+restart_delay = 10
+## by default, restart_backoff = restart_delay_reset_interval = restart_delay
+# initial_restart_delay = 0
+# restart_backoff = 60
+# restart_delay_reset_interval = 60
+cluster_file = {etcdir}/fdb.cluster
+# delete_envvars =
+# kill_on_configuration_change = true
+
+## Default parameters for individual fdbserver processes
+[fdbserver]
+command = {fdbserver_bin}
+public_address = auto:$ID
+listen_address = public
+datadir = {datadir}
+logdir = {logdir}
+# logsize = 10MiB
+# maxlogssize = 100MiB
+# machine_id =
+# datacenter_id =
+# class =
+# memory = 8GiB
+# storage_memory = 1GiB
+# cache_memory = 2GiB
+# metrics_cluster =
+# metrics_prefix =
+
+## An individual fdbserver process with id 4000
+## Parameters set here override defaults from the [fdbserver] section
+[fdbserver.{server_port}]
+    """
+
+    valid_letters_for_secret = string.ascii_letters + string.digits
+
+    def __init__(self, basedir: str, fdbserver_binary: str, fdbmonitor_binary: str,
+                 fdbcli_binary: str, create_config=True, port=None, ip_address=None):
+        self.basedir = Path(basedir)
+        self.fdbserver_binary = Path(fdbserver_binary)
+        self.fdbmonitor_binary = Path(fdbmonitor_binary)
+        self.fdbcli_binary = Path(fdbcli_binary)
+        for b in (self.fdbserver_binary, self.fdbmonitor_binary, self.fdbcli_binary):
+            assert b.exists(), "{} does not exist".format(b)
+        if not self.basedir.exists():
+            self.basedir.mkdir()
+        self.etc = self.basedir.joinpath('etc')
+        self.log = self.basedir.joinpath('log')
+        self.data = self.basedir.joinpath('data')
+        self.etc.mkdir(exist_ok=True)
+        self.log.mkdir(exist_ok=True)
+        self.data.mkdir(exist_ok=True)
+        self.port = get_free_port() if port is None else port
+        self.ip_address = '127.0.0.1' if ip_address is None else ip_address
+        self.running = False
+        self.process = None
+        self.fdbmonitor_logfile = None
+        if create_config:
+            with open(self.etc.joinpath('fdb.cluster'), 'x') as f:
+                random_string = lambda len : ''.join(random.choice(LocalCluster.valid_letters_for_secret) for i in range(len))
+                f.write('{desc}:{secret}@{ip_addr}:{server_port}'.format(
+                    desc=random_string(8),
+                    secret=random_string(8),
+                    ip_addr=self.ip_address,
+                    server_port=self.port
+                ))
+                with open(self.etc.joinpath('foundationdb.conf'), 'x') as f:
+                    f.write(LocalCluster.configuration_template.format(
+                        etcdir=self.etc,
+                        fdbserver_bin=self.fdbserver_binary,
+                        datadir=self.data,
+                        logdir=self.log,
+                        server_port=self.port
+                    ))
+
+    def __enter__(self):
+        assert not self.running, "Can't start a server that is already running"
+        args = [str(self.fdbmonitor_binary),
+                '--conffile',
+                str(self.etc.joinpath('foundationdb.conf')),
+                '--lockfile',
+                str(self.etc.joinpath('fdbmonitor.lock'))]
+        self.fdbmonitor_logfile = open(self.log.joinpath('fdbmonitor.log'), 'w')
+        self.process = subprocess.Popen(args, stdout=self.fdbmonitor_logfile, stderr=self.fdbmonitor_logfile)
+        self.running = True
+        return self
+
+    def __exit__(self, xc_type, exc_value, traceback):
+        assert self.running, "Server is not running"
+        if self.process.poll() is None:
+            self.process.terminate()
+        self.running = False
+
+    def create_database(self, storage='ssd'):
+        args = [self.fdbcli_binary, '-C', self.etc.joinpath('fdb.cluster'), '--exec',
+                'configure new single {}'.format(storage)]
+        subprocess.run(args)

--- a/tests/TestRunner/tmp_cluster.py
+++ b/tests/TestRunner/tmp_cluster.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+
+import os
+import shutil
+import subprocess
+import sys
+import socket
+from local_cluster import LocalCluster
+from argparse import ArgumentParser, RawDescriptionHelpFormatter
+from random import choice
+from pathlib import Path
+
+class TempCluster:
+    def __init__(self, build_dir: str,port: str = None):
+        self.build_dir = Path(build_dir).resolve()
+        assert self.build_dir.exists(), "{} does not exist".format(build_dir)
+        assert self.build_dir.is_dir(), "{} is not a directory".format(build_dir)
+        tmp_dir = self.build_dir.joinpath(
+            'tmp',
+            ''.join(choice(LocalCluster.valid_letters_for_secret) for i in range(16)))
+        tmp_dir.mkdir(parents=True)
+        self.cluster = LocalCluster(tmp_dir,
+                                    self.build_dir.joinpath('bin', 'fdbserver'),
+                                    self.build_dir.joinpath('bin', 'fdbmonitor'),
+                                    self.build_dir.joinpath('bin', 'fdbcli'),
+                                    port = port)
+        self.log = self.cluster.log
+        self.etc = self.cluster.etc
+        self.data = self.cluster.data
+        self.tmp_dir = tmp_dir
+
+    def __enter__(self):
+        self.cluster.__enter__()
+        self.cluster.create_database()
+        return self
+
+    def __exit__(self, xc_type, exc_value, traceback):
+        self.cluster.__exit__(xc_type, exc_value, traceback)
+        shutil.rmtree(self.tmp_dir)
+
+    def close(self):
+        self.cluster.__exit__(None,None,None)
+        shutil.rmtree(self.tmp_dir)
+
+
+if __name__ == '__main__':
+    parser = ArgumentParser(formatter_class=RawDescriptionHelpFormatter,
+                            description="""
+    This script automatically configures a temporary local cluster on the machine
+    and then calls a command while this cluster is running. As soon as the command
+    returns, the configured cluster is killed and all generated data is deleted.
+    This is useful for testing: if a test needs access to a fresh fdb cluster, one
+    can simply pass the test command to this script.
+
+    The command to run after the cluster started. Before the command is executed,
+    the following arguments will be preprocessed:
+    - All occurrences of @CLUSTER_FILE@ will be replaced with the path to the generated cluster file.
+    - All occurrences of @DATA_DIR@ will be replaced with the path to the data directory.
+    - All occurrences of @LOG_DIR@ will be replaced with the path to the log directory.
+    - All occurrences of @ETC_DIR@ will be replaced with the path to the configuration directory.
+
+    The environment variable FDB_CLUSTER_FILE is set to the generated cluster for the command if it is not set already.
+    """)
+    parser.add_argument('--build-dir', '-b', metavar='BUILD_DIRECTORY', help='FDB build directory', required=True)
+    parser.add_argument('cmd', metavar="COMMAND", nargs="+", help="The command to run")
+    args = parser.parse_args()
+    errcode = 1
+    with TempCluster(args.build_dir) as cluster:
+        print("log-dir: {}".format(cluster.log))
+        print("etc-dir: {}".format(cluster.etc))
+        print("data-dir: {}".format(cluster.data))
+        print("cluster-file: {}".format(cluster.etc.joinpath('fdb.cluster')))
+        cmd_args = []
+        for cmd in args.cmd:
+            if cmd == '@CLUSTER_FILE@':
+                cmd_args.append(str(cluster.etc.joinpath('fdb.cluster')))
+            elif cmd == '@DATA_DIR@':
+                cmd_args.append(str(cluster.data))
+            elif cmd == '@LOG_DIR@':
+                cmd_args.append(str(cluster.log))
+            elif cmd == '@ETC_DIR@':
+                cmd_args.append(str(cluster.etc))
+            else:
+                cmd_args.append(cmd)
+        env = dict(**os.environ)
+        env['FDB_CLUSTER_FILE'] = env.get('FDB_CLUSTER_FILE', cluster.etc.joinpath('fdb.cluster'))
+        errcode = subprocess.run(cmd_args, stdout=sys.stdout, stderr=sys.stderr, env=env).returncode
+    sys.exit(errcode)

--- a/tests/TestRunner/tmp_multi_cluster.py
+++ b/tests/TestRunner/tmp_multi_cluster.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+
+#
+# tmp_multi_cluster.py
+#
+# This source file is part of the FoundationDB open source project
+#
+# Copyright 2013-2018 Apple Inc. and the FoundationDB project authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import os
+import subprocess
+import sys
+import shutil
+from pathlib import Path
+from argparse import ArgumentParser, RawDescriptionHelpFormatter
+from tmp_cluster import TempCluster
+
+
+if __name__ == '__main__':
+	parser = ArgumentParser(formatter_class=RawDescriptionHelpFormatter,description="""
+	This script automatically configures N temporary local clusters on the machine and then
+	calls a command while these clusters are running. As soon as the command returns, all
+	configured clusters are killed and all generated data is deleted.
+
+	The purpose of this is to support testing a set of integration tests using multiple clusters
+	(i.e. using the Multi-threaded client). 
+	""")
+	parser.add_argument('--build-dir','-b',metavar='BUILD_DIRECTORY',help='FDB build director',required=True)
+	parser.add_argument('--clusters','-c',metavar='NUM_CLUSTERS',type=int,help='The number of clusters to run',required=True)
+	parser.add_argument('cmd', metavar='COMMAND',nargs='+',help='The command to run')
+	args = parser.parse_args()
+	errcode = 1
+
+	#spawn all the clusters
+	base_dir = args.build_dir
+	num_clusters = args.clusters
+
+	build_dir=Path(base_dir)
+	bin_dir=build_dir.joinpath('bin')
+
+	clusters = []
+	for c in range(1,num_clusters+1):
+		# now start the cluster up
+		local_c = TempCluster(args.build_dir, port="{}501".format(c))
+
+		local_c.__enter__()
+		clusters.append(local_c) 
+	
+	# all clusters should be running now, so run the subcommand
+	# TODO (bfines): pass through the proper ENV commands so that the client can find everything
+	cluster_paths = ';'.join([str(cluster.etc.joinpath('fdb.cluster')) for cluster in clusters])
+	print(cluster_paths)
+	env = dict(**os.environ)
+	env['FDB_CLUSTERS'] = env.get('FDB_CLUSTERS',cluster_paths)
+	errcode = subprocess.run(args.cmd,stdout=sys.stdout,stderr=sys.stderr,env=env).returncode
+
+	# shutdown all the running clusters
+	for tc in clusters:
+		tc.close()
+
+	sys.exit(errcode)
+	


### PR DESCRIPTION
This PR assists PR #4339 in order to make it easier to write tests against the multi-threaded java client.

Changes in this PR:

- Brings over `tmp_cluster.py` and `local_cluster.py` to the 6.3 branch
- Adds a "MultiClient" run for ctest
- Filters out multi-client tagged tests (tests that are tagged with `@Tag("MultiClient")` from normal integration tests

## General guideline:

- If this PR is ready to be merged (and all checkboxes below are either ticked or not applicable), make this a regular PR
- If this PR still needs work, please make this a draft PR
  - If you wish to get feedback/code-review, please add the label RFC to this PR

Please verify that all things listed below were considered and check them. If an item doesn't apply to this type of PR (for example a documentation change doesn't need to be performance tested), you should make a ~~strikethrough~~ (markdown syntax: `~~strikethrough~~`). More infos on the guidlines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

### Style

- [X ] All variable and function names make sense.
- [X ] The code is properly formatted (consider running `git clang-format`).

### Performance

~~- [ ] All CPU-hot paths are well optimized.~~
~~- [ ] The proper containers are used (for example `std::vector` vs `VectorRef`).~~
~~- [ ] There are no new known `SlowTask` traces.~~

### Testing

~~- [ ] The code was sufficiently tested in simulation.~~
~~- [ ] If there are new parameters or knobs, different values are tested in simulation.~~
~~- [ ] `ASSERT`, `ASSERT_WE_THINK`, and `TEST` macros are added in appropriate places.~~
~~- [ ] Unit tests were added for new algorithms and data structure that make sense to unit-test~~
~~- [ ] If this is a bugfix: there is a test that can easily reproduce the bug.~~
