### PR TITLE
Fix several leaks

### DIFF
--- a/bindings/c/fdb_c.cpp
+++ b/bindings/c/fdb_c.cpp
@@ -129,16 +129,7 @@ extern "C" DLLEXPORT fdb_error_t fdb_run_network() {
 	CATCH_AND_RETURN(API->runNetwork(););
 }
 
-#ifdef ADDRESS_SANITIZER
-extern "C" void __lsan_do_leak_check();
-#endif
-
 extern "C" DLLEXPORT fdb_error_t fdb_stop_network() {
-#ifdef ADDRESS_SANITIZER
-	// fdb_stop_network intentionally leaks a bunch of memory, so let's do the
-	// leak check before that so it's meaningful
-	__lsan_do_leak_check();
-#endif
 	CATCH_AND_RETURN(API->stopNetwork(););
 }
 

--- a/bindings/java/CMakeLists.txt
+++ b/bindings/java/CMakeLists.txt
@@ -259,6 +259,10 @@ if(NOT OPEN_FOR_IDE)
   set(TEST_CP ${tests_jar} ${target_jar})
 
   if(RUN_JUNIT_TESTS OR RUN_JAVA_INTEGRATION_TESTS)
+    if (USE_SANITIZER)
+      message(WARNING "Cannot run java tests with sanitizer builds")
+      return()
+    endif()
     # We use Junit libraries for both JUnit and integration testing structures, so download in either case
     # https://search.maven.org/remotecontent?filepath=org/junit/jupiter/junit-jupiter-engine/5.7.1/junit-jupiter-engine-5.7.1.jar
     file(DOWNLOAD "https://search.maven.org/remotecontent?filepath=org/junit/jupiter/junit-jupiter-engine/5.7.1/junit-jupiter-engine-5.7.1.jar"

--- a/contrib/Joshua/scripts/correctnessTest.sh
+++ b/contrib/Joshua/scripts/correctnessTest.sh
@@ -1,3 +1,7 @@
 #!/bin/sh
+
+# Simulation currently has memory leaks. We need to investigate before we can enable leak detection in joshua.
+export ASAN_OPTIONS="detect_leaks=0"
+
 OLDBINDIR="${OLDBINDIR:-/app/deploy/global_data/oldBinaries}"
 mono bin/TestHarness.exe joshua-run "${OLDBINDIR}" false

--- a/fdbcli/FlowLineNoise.actor.cpp
+++ b/fdbcli/FlowLineNoise.actor.cpp
@@ -127,7 +127,7 @@ LineNoise::LineNoise(std::function<void(std::string const&, std::vector<std::str
 }
 
 LineNoise::~LineNoise() {
-	threadPool.clear();
+	threadPool->stop();
 }
 
 Future<Optional<std::string>> LineNoise::read(std::string const& prompt) {

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -586,7 +586,8 @@ ACTOR Future<Void> updateCachedRanges(DatabaseContext* self, std::map<UID, Stora
 			// the cyclic reference to self.
 			tr = Transaction();
 			wait(delay(0)); // Give ourselves the chance to get cancelled if self was destroyed
-			wait(self->updateCache.onTrigger());
+			wait(brokenPromiseToNever(self->updateCache.onTrigger())); // brokenPromiseToNever because self might get
+			                                                           // destroyed elsewhere while we're waiting here.
 			tr = Transaction(Database(Reference<DatabaseContext>::addRef(self)));
 			tr.setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
 			tr.setOption(FDBTransactionOptions::READ_LOCK_AWARE);

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -410,6 +410,14 @@ ACTOR static Future<Void> delExcessClntTxnEntriesActor(Transaction* tr, int64_t 
 	}
 }
 
+// Delref and addref self to give self a chance to get destroyed.
+ACTOR static Future<Void> refreshTransaction(DatabaseContext* self, Transaction* tr) {
+	*tr = Transaction();
+	wait(delay(0)); // Give ourselves the chance to get cancelled if self was destroyed
+	*tr = Transaction(Database(Reference<DatabaseContext>::addRef(self)));
+	return Void();
+}
+
 // The reason for getting a pointer to DatabaseContext instead of a reference counted object is because reference
 // counting will increment reference count for DatabaseContext which holds the future of this actor. This creates a
 // cyclic reference and hence this actor and Database object will not be destroyed at all.
@@ -421,6 +429,9 @@ ACTOR static Future<Void> clientStatusUpdateActor(DatabaseContext* cx) {
 	state int txBytes = 0;
 
 	loop {
+		// Need to make sure that we eventually destroy tr. We can't rely on getting cancelled to do this because of
+		// the cyclic reference to self.
+		wait(refreshTransaction(cx, &tr));
 		try {
 			ASSERT(cx->clientStatusUpdater.outStatusQ.empty());
 			cx->clientStatusUpdater.inStatusQ.swap(cx->clientStatusUpdater.outStatusQ);
@@ -458,7 +469,6 @@ ACTOR static Future<Void> clientStatusUpdateActor(DatabaseContext* cx) {
 			    BUGGIFY ? deterministicRandom()->randomInt(200e3, 1.5 * CLIENT_KNOBS->TRANSACTION_SIZE_LIMIT)
 			            : 0.8 * CLIENT_KNOBS->TRANSACTION_SIZE_LIMIT;
 			state std::vector<TrInfoChunk>::iterator tracking_iter = trChunksQ.begin();
-			tr = Transaction(Database(Reference<DatabaseContext>::addRef(cx)));
 			ASSERT(commitQ.empty() && (txBytes == 0));
 			loop {
 				state std::vector<TrInfoChunk>::iterator iter = tracking_iter;
@@ -504,10 +514,6 @@ ACTOR static Future<Void> clientStatusUpdateActor(DatabaseContext* cx) {
 			if (!trChunksQ.empty() && deterministicRandom()->random01() < clientSamplingProbability)
 				wait(delExcessClntTxnEntriesActor(&tr, clientTxnInfoSizeLimit));
 
-			// tr is destructed because it hold a reference to DatabaseContext which creates a cycle mentioned above.
-			// Hence destroy the transacation before sleeping to give a chance for the actor to be cleanedup if the
-			// Database is destroyed by the user.
-			tr = Transaction();
 			wait(delay(CLIENT_KNOBS->CSI_STATUS_DELAY));
 		} catch (Error& e) {
 			if (e.code() == error_code_actor_cancelled) {
@@ -515,10 +521,6 @@ ACTOR static Future<Void> clientStatusUpdateActor(DatabaseContext* cx) {
 			}
 			cx->clientStatusUpdater.outStatusQ.clear();
 			TraceEvent(SevWarnAlways, "UnableToWriteClientStatus").error(e);
-			// tr is destructed because it hold a reference to DatabaseContext which creates a cycle mentioned above.
-			// Hence destroy the transacation before sleeping to give a chance for the actor to be cleanedup if the
-			// Database is destroyed by the user.
-			tr = Transaction();
 			wait(delay(10.0));
 		}
 	}
@@ -667,9 +669,7 @@ ACTOR Future<Void> monitorCacheList(DatabaseContext* self) {
 		loop {
 			// Need to make sure that we eventually destroy tr. We can't rely on getting cancelled to do this because of
 			// the cyclic reference to self.
-			tr = Transaction();
-			wait(delay(0)); // Give ourselves the chance to get cancelled if self was destroyed
-			tr = Transaction(Database(Reference<DatabaseContext>::addRef(self)));
+			wait(refreshTransaction(self, &tr));
 			try {
 				Standalone<RangeResultRef> cacheList =
 				    wait(tr.getRange(storageCacheServerKeys, CLIENT_KNOBS->TOO_MANY));

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -592,7 +592,6 @@ ACTOR Future<Void> updateCachedRanges(DatabaseContext* self, std::map<UID, Stora
 			tr.setOption(FDBTransactionOptions::READ_LOCK_AWARE);
 			try {
 				Standalone<RangeResultRef> range = wait(tr.getRange(storageCacheKeys, CLIENT_KNOBS->TOO_MANY));
-				tr = Transaction();
 				ASSERT(!range.more);
 				std::vector<Reference<ReferencedInterface<StorageServerInterface>>> cacheInterfaces;
 				cacheInterfaces.reserve(cacheServers->size());
@@ -673,7 +672,6 @@ ACTOR Future<Void> monitorCacheList(DatabaseContext* self) {
 			try {
 				Standalone<RangeResultRef> cacheList =
 				    wait(tr.getRange(storageCacheServerKeys, CLIENT_KNOBS->TOO_MANY));
-				tr = Transaction();
 				ASSERT(!cacheList.more);
 				bool hasChanges = false;
 				std::map<UID, StorageServerInterface> allCacheServers;

--- a/fdbserver/worker.actor.cpp
+++ b/fdbserver/worker.actor.cpp
@@ -891,7 +891,7 @@ ACTOR Future<Void> traceRole(Role role, UID roleId) {
 	}
 }
 
-ACTOR Future<Void> workerSnapCreate(WorkerSnapRequest snapReq, StringRef snapFolder) {
+ACTOR Future<Void> workerSnapCreate(WorkerSnapRequest snapReq, Standalone<StringRef> snapFolder) {
 	state ExecCmdValueString snapArg(snapReq.snapPayload);
 	try {
 		int err = wait(execHelper(&snapArg, snapReq.snapUID, snapFolder.toString(), snapReq.role.toString()));

--- a/fdbserver/workloads/ApiCorrectness.actor.cpp
+++ b/fdbserver/workloads/ApiCorrectness.actor.cpp
@@ -619,7 +619,7 @@ public:
 		// Get the keys from the memory store and compare them
 		state int i;
 		for (i = 0; i < selectors.size(); i++) {
-			KeyRef key = self->store.getKey(selectors[i]);
+			Key key = self->store.getKey(selectors[i]);
 			if (keys[i].startsWith(StringRef(self->clientPrefix)) && keys[i] != key)
 				result = false;
 			else if (keys[i] < StringRef(self->clientPrefix) && key != self->store.startKey())

--- a/flow/Arena.cpp
+++ b/flow/Arena.cpp
@@ -22,6 +22,11 @@
 
 #include "flow/UnitTest.h"
 
+// We don't align memory properly, and we need to tell lsan about that.
+extern "C" const char* __lsan_default_options(void) {
+	return "use_unaligned=1";
+}
+
 // See https://dox.ipxe.org/memcheck_8h_source.html and https://dox.ipxe.org/valgrind_8h_source.html for an explanation
 // of valgrind client requests
 #if VALGRIND

--- a/flow/FastAlloc.cpp
+++ b/flow/FastAlloc.cpp
@@ -314,13 +314,13 @@ void* FastAllocator<Size>::allocate() {
 		initThread();
 	}
 
-#ifdef USE_GPERFTOOLS
-	return malloc(Size);
+#if defined(USE_GPERFTOOLS) || defined(ADDRESS_SANITIZER)
+	return aligned_alloc(Size == 4096 ? Size : alignof(void*), Size);
 #endif
 
 #if VALGRIND
 	if (valgrindPrecise()) {
-		return aligned_alloc(Size, Size);
+		return aligned_alloc(Size == 4096 ? Size : alignof(void*), Size);
 	}
 #endif
 
@@ -368,8 +368,8 @@ void FastAllocator<Size>::release(void* ptr) {
 		initThread();
 	}
 
-#ifdef USE_GPERFTOOLS
-	return free(ptr);
+#if defined(USE_GPERFTOOLS) || defined(ADDRESS_SANITIZER)
+	return aligned_free(ptr);
 #endif
 
 #if VALGRIND

--- a/flow/FastAlloc.cpp
+++ b/flow/FastAlloc.cpp
@@ -315,14 +315,14 @@ void* FastAllocator<Size>::allocate() {
 	}
 
 #if defined(USE_GPERFTOOLS) || defined(ADDRESS_SANITIZER)
-	// Some usages of FastAllocator<4096> require 4096 byte alignment
-	return aligned_alloc(Size == 4096 ? Size : alignof(void*), Size);
+	// Some usages of FastAllocator require 4096 byte alignment.
+	return aligned_alloc(Size >= 4096 ? 4096 : alignof(void*), Size);
 #endif
 
 #if VALGRIND
 	if (valgrindPrecise()) {
-		// Some usages of FastAllocator<4096> require 4096 byte alignment
-		return aligned_alloc(Size == 4096 ? Size : alignof(void*), Size);
+		// Some usages of FastAllocator require 4096 byte alignment
+		return aligned_alloc(Size >= 4096 ? 4096 : alignof(void*), Size);
 	}
 #endif
 

--- a/flow/FastAlloc.cpp
+++ b/flow/FastAlloc.cpp
@@ -315,11 +315,13 @@ void* FastAllocator<Size>::allocate() {
 	}
 
 #if defined(USE_GPERFTOOLS) || defined(ADDRESS_SANITIZER)
+	// Some usages of FastAllocator<4096> require 4096 byte alignment
 	return aligned_alloc(Size == 4096 ? Size : alignof(void*), Size);
 #endif
 
 #if VALGRIND
 	if (valgrindPrecise()) {
+		// Some usages of FastAllocator<4096> require 4096 byte alignment
 		return aligned_alloc(Size == 4096 ? Size : alignof(void*), Size);
 	}
 #endif

--- a/flow/Net2.actor.cpp
+++ b/flow/Net2.actor.cpp
@@ -48,6 +48,10 @@
 #include "flow/genericactors.actor.h"
 #include "flow/Util.h"
 
+#ifdef ADDRESS_SANITIZER
+#include <sanitizer/lsan_interface.h>
+#endif
+
 // See the comment in TLSConfig.actor.h for the explanation of why this module breaking include was done.
 #include "fdbrpc/IAsyncFile.h"
 
@@ -242,6 +246,10 @@ public:
 	void processThreadReady();
 	void trackAtPriority(TaskPriority priority, double now);
 	void stopImmediately() {
+#ifdef ADDRESS_SANITIZER
+		// Do leak check before intentionally leaking a bunch of memory
+		__lsan_do_leak_check();
+#endif
 		stopped = true;
 		decltype(ready) _1;
 		ready.swap(_1);


### PR DESCRIPTION
Fix several memory leaks and a thread leak. I've been using leak sanitizer (comes with ASAN) and thread sanitizer to find these.

fdb_c_external_client_unit_tests is still showing memory leaks, indicating a possible memory leak in the multi-version client.

Passed 10k tests in joshua.