### PR TITLE
Multi-version client: don't copy external libraries if we aren't using multiple threads

### DIFF
--- a/tests/python_tests/multithreaded_client.py
+++ b/tests/python_tests/multithreaded_client.py
@@ -40,7 +40,7 @@ fdb.options.set_trace_enable(args.client_log_dir)
 fdb.options.set_knob("min_trace_severity=5")
 
 if not args.skip_so_files:
-    print "Loading .so files"
+    print("Loading .so files")
     fdb.options.set_external_client_directory(args.build_dir + '/lib')
 
 if args.threads > 0:


### PR DESCRIPTION
Changes in this PR:

The recent change to add client threading support through the multi-version client had a behavior change to cause external clients to be copied even when we aren't using multiple threads. One side effect of this is that if the primary library is included in your list of external libraries, we will now generate an extra trace file for the copied primary library.

### Style

- [x] All variable and function names make sense.
- [x] The code is properly formatted (consider running `git clang-format`).

### Performance

- [x] All CPU-hot paths are well optimized.
- [x] The proper containers are used (for example `std::vector` vs `VectorRef`).
- [x] There are no new known `SlowTask` traces.

### Testing

- [x] The code was sufficiently tested in simulation.
- [x] If there are new parameters or knobs, different values are tested in simulation.
- [x] `ASSERT`, `ASSERT_WE_THINK`, and `TEST` macros are added in appropriate places.
- [x] Unit tests were added for new algorithms and data structure that make sense to unit-test
- [x] If this is a bugfix: there is a test that can easily reproduce the bug.
