### PR TITLE
Bugfixes/optimize unknown enpoints

### DIFF
--- a/fdbrpc/FlowTransport.actor.cpp
+++ b/fdbrpc/FlowTransport.actor.cpp
@@ -110,7 +110,7 @@ TaskPriority EndpointMap::getPriority(Endpoint::Token const& token) {
 		// we don't allow this priority to be "misused" for other stuff as we won't even
 		// attempt to find an endpoint if UnknownEndpoint is returned here
 		ASSERT(res != TaskPriority::UnknownEndpoint);
-		return static_cast<TaskPriority>(data[index].token().second());
+		return res;
 	}
 	return TaskPriority::UnknownEndpoint;
 }
@@ -905,7 +905,9 @@ static void scanPackets(TransportData* transport,
 		// we ignore packets to unknown endpoints if they're not going to a stream anyways, so we can just
 		// return here. The main place where this seems to happen is if a ReplyPromise is not waited on
 		// long enough.
-		// It would be slightly more elegant to put this if-block
+		// It would be slightly more elegant/readable to put this if-block into the deliver actor, but if
+		// we have many messages to UnknownEndpoint we want to optimize earlier. As deliver is an actor it
+		// will allocate some state on the heap and this prevents it from doing that.
 		if (priority != TaskPriority::UnknownEndpoint || (token.first() & TOKEN_STREAM_FLAG) == 0) {
 			deliver(transport, Endpoint({ peerAddress }, token), priority, std::move(reader), true);
 		}

--- a/fdbrpc/FlowTransport.actor.cpp
+++ b/fdbrpc/FlowTransport.actor.cpp
@@ -105,8 +105,13 @@ NetworkMessageReceiver* EndpointMap::get(Endpoint::Token const& token) {
 TaskPriority EndpointMap::getPriority(Endpoint::Token const& token) {
 	uint32_t index = token.second();
 	if (index < data.size() && data[index].token().first() == token.first() &&
-	    ((data[index].token().second() & 0xffffffff00000000LL) | index) == token.second())
+	    ((data[index].token().second() & 0xffffffff00000000LL) | index) == token.second()) {
+		auto res = static_cast<TaskPriority>(data[index].token().second());
+		// we don't allow this priority to be "misused" for other stuff as we won't even
+		// attempt to find an endpoint if UnknownEndpoint is returned here
+		ASSERT(res != TaskPriority::UnknownEndpoint);
 		return static_cast<TaskPriority>(data[index].token().second());
+	}
 	return TaskPriority::UnknownEndpoint;
 }
 
@@ -729,6 +734,12 @@ TransportData::~TransportData() {
 
 ACTOR static void deliver(TransportData* self, Endpoint destination, ArenaReader reader, bool inReadSocket) {
 	TaskPriority priority = self->endpoints.getPriority(destination.token);
+	if (priority == TaskPriority::UnknownEndpoint && (destination.token.first() & TOKEN_STREAM_FLAG) == 0) {
+		// we ignore packets to unknown endpoints if they're not going to a stream anyways, so we can just
+		// return here. The main place where this seems to happen is if a ReplyPromise is not waited on
+		// long enough.
+		return;
+	}
 	if (priority < TaskPriority::ReadSocket || !inReadSocket) {
 		wait(delay(0, priority));
 	} else {
@@ -777,9 +788,6 @@ ACTOR static void deliver(TransportData* self, Endpoint destination, ArenaReader
 			}
 		}
 	}
-
-	if (inReadSocket)
-		g_network->setCurrentTask(TaskPriority::ReadSocket);
 }
 
 static void scanPackets(TransportData* transport,

--- a/fdbrpc/fdbrpc.h
+++ b/fdbrpc/fdbrpc.h
@@ -52,6 +52,7 @@ struct FlowReceiver : private NetworkMessageReceiver {
 	// If already a remote endpoint, returns that.  Otherwise makes this
 	//   a local endpoint and returns that.
 	const Endpoint& getEndpoint(TaskPriority taskID) {
+		ASSERT(taskID != TaskPriority::UnknownEndpoint);
 		if (!endpoint.isValid()) {
 			m_isLocalEndpoint = true;
 			FlowTransport::transport().addEndpoint(endpoint, this, taskID);

--- a/flow/Net2.actor.cpp
+++ b/flow/Net2.actor.cpp
@@ -1155,7 +1155,6 @@ void Net2::run() {
 			++countTasks;
 			currentTaskID = ready.top().taskID;
 			priorityMetric = static_cast<int64_t>(currentTaskID);
-			minTaskID = std::min(minTaskID, currentTaskID);
 			Task* task = ready.top().task;
 			ready.pop();
 
@@ -1166,6 +1165,8 @@ void Net2::run() {
 			} catch (...) {
 				TraceEvent(SevError, "TaskError").error(unknown_error());
 			}
+
+			minTaskID = std::min(minTaskID, currentTaskID);
 
 			if (check_yield(TaskPriority::Max, true)) {
 				FDB_TRACE_PROBE(run_loop_yield);


### PR DESCRIPTION
PR into release-6.3 is here: #4480

We ran into a minor issue in production where `unknown_endpoint` shows up in our statistics too frequently. We tracked this down to two problems (both solved here):

1. If a message is sent to an unknown endpoint we do more work than necessary (we create a new actor, change priority through a wait, and then do nothing).
2. The accounting for priorities produces numbers that are a bit confusing (and inaccurate in this case).

## General guideline:

- If this PR is ready to be merged (and all checkboxes below are either ticked or not applicable), make this a regular PR
- If this PR still needs work, please make this a draft PR
  - If you wish to get feedback/code-review, please add the label RFC to this PR

Please verify that all things listed below were considered and check them. If an item doesn't apply to this type of PR (for example a documentation change doesn't need to be performance tested), you should make a ~~strikethrough~~ (markdown syntax: `~~strikethrough~~`). More infos on the guidlines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

### Style

- [x] All variable and function names make sense.
- [x] The code is properly formatted (consider running `git clang-format`).

### Performance

- [x] All CPU-hot paths are well optimized.
- [x] The proper containers are used (for example `std::vector` vs `VectorRef`).
- [x] There are no new known `SlowTask` traces.

### Testing

- [x] The code was sufficiently tested in simulation.
- [x] If there are new parameters or knobs, different values are tested in simulation.
- [x] `ASSERT`, `ASSERT_WE_THINK`, and `TEST` macros are added in appropriate places.
- [x] Unit tests were added for new algorithms and data structure that make sense to unit-test
- [x] If this is a bugfix: there is a test that can easily reproduce the bug.
