### PR TITLE
Add versionstamp endianness information to public documentation

### DIFF
--- a/documentation/sphinx/source/api-common.rst.inc
+++ b/documentation/sphinx/source/api-common.rst.inc
@@ -136,7 +136,8 @@
     Transforms ``param`` using a versionstamp for the transaction. This parameter must be at least 14 bytes long. The final 4 bytes will be interpreted as a 32-bit little-endian integer denoting an index into the parameter at which to perform the transformation, and then trimmed off the key. The 10 bytes in the parameter beginning at the index will be overwritten with the versionstamp. If the index plus 10 bytes points past the end of the parameter, the result will be an error. Sets ``key`` in the database to the transformed parameter.
 
 .. |atomic-versionstamps-1| replace::
-    A versionstamp is a 10 byte, unique, monotonically (but not sequentially) increasing value for each committed transaction. The first 8 bytes are the committed version of the database. The last 2 bytes are monotonic in the serialization order for transactions.
+    A versionstamp is a 10 byte, unique, monotonically (but not sequentially) increasing value for each committed transaction. The first 8 bytes are the committed version of the database (serialized in big-endian order). The last 2 bytes are monotonic in the serialization order for transactions (serialized in big-endian order).
+
 
 .. |atomic-versionstamps-2| replace::
     A transaction is not permitted to read any transformed key or value previously set within that transaction, and an attempt to do so will result in an ``accessed_unreadable`` error.  The range of keys marked unreadable when setting a versionstamped key begins at the transactions's read version if it is known, otherwise a versionstamp of all ``0x00`` bytes is conservatively assumed.  The upper bound of the unreadable range is a versionstamp of all ``0xFF`` bytes.


### PR DESCRIPTION
Changes in this PR:

- Add serialization endianness info for versionstamps. Currently this info is missing from the C, Python, and Ruby APIs.
- The Java documentation already contains endianness info for versionstamps (see https://apple.github.io/foundationdb/javadoc/com/apple/foundationdb/MutationType.html#SET_VERSIONSTAMPED_KEY).
- The Go documentation also contains this info (https://pkg.go.dev/github.com/apple/foundationdb/bindings/go/src/fdb?utm_source=godoc#Transaction.SetVersionstampedKey).

Versionstamps are written [here](https://github.com/apple/foundationdb/blob/335df9b052ca1f5f6e3ef9c88bc10f83c1d255a7/fdbclient/Atomic.h#L249).

## General guideline:

- If this PR is ready to be merged (and all checkboxes below are either ticked or not applicable), make this a regular PR
- If this PR still needs work, please make this a draft PR
  - If you wish to get feedback/code-review, please add the label RFC to this PR

Please verify that all things listed below were considered and check them. If an item doesn't apply to this type of PR (for example a documentation change doesn't need to be performance tested), you should make a ~~strikethrough~~ (markdown syntax: `~~strikethrough~~`). More infos on the guidlines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

### Style

- [x] ~~All variable and function names make sense.~~
- [x] ~~The code is properly formatted (consider running `git clang-format`).~~

### Performance

- [x] ~~All CPU-hot paths are well optimized.~~
- [x] ~~The proper containers are used (for example `std::vector` vs `VectorRef`).~~
- [x] ~~There are no new known `SlowTask` traces.~~

### Testing

- [x] ~~The code was sufficiently tested in simulation.~~
- [x] ~~If there are new parameters or knobs, different values are tested in simulation.~~
- [x] ~~`ASSERT`, `ASSERT_WE_THINK`, and `TEST` macros are added in appropriate places.~~
- [x] ~~Unit tests were added for new algorithms and data structure that make sense to unit-test~~
- [x] ~~If this is a bugfix: there is a test that can easily reproduce the bug.~~
