### PR TITLE
Bugfixes/optimize unknown endpoints 6.3

### DIFF
--- a/fdbrpc/FlowTransport.actor.cpp
+++ b/fdbrpc/FlowTransport.actor.cpp
@@ -1483,7 +1483,7 @@ static void sendLocal(TransportData* self, ISerializeSource const& what, const E
 
 	ASSERT(copy.size() > 0);
 	TaskPriority priority = self->endpoints.getPriority(destination.token);
-	if (priority != TaskPriority::UnknownEndpoint || (destination.token.first() & TOKEN_STREAM_FLAG) == 0) {
+	if (priority != TaskPriority::UnknownEndpoint || (destination.token.first() & TOKEN_STREAM_FLAG) != 0) {
 		deliver(
 		    self, destination, priority, ArenaReader(copy.arena(), copy, AssumeVersion(currentProtocolVersion)), false);
 	}

--- a/fdbrpc/FlowTransport.actor.cpp
+++ b/fdbrpc/FlowTransport.actor.cpp
@@ -152,7 +152,7 @@ TaskPriority EndpointMap::getPriority(Endpoint::Token const& token) {
 		// we don't allow this priority to be "misused" for other stuff as we won't even
 		// attempt to find an endpoint if UnknownEndpoint is returned here
 		ASSERT(res != TaskPriority::UnknownEndpoint);
-		return static_cast<TaskPriority>(data[index].token().second());
+		return res;
 	}
 	return TaskPriority::UnknownEndpoint;
 }
@@ -1035,7 +1035,9 @@ static void scanPackets(TransportData* transport,
 		// we ignore packets to unknown endpoints if they're not going to a stream anyways, so we can just
 		// return here. The main place where this seems to happen is if a ReplyPromise is not waited on
 		// long enough.
-		// It would be slightly more elegant to put this if-block
+		// It would be slightly more elegant/readable to put this if-block into the deliver actor, but if
+		// we have many messages to UnknownEndpoint we want to optimize earlier. As deliver is an actor it
+		// will allocate some state on the heap and this prevents it from doing that.
 		if (priority != TaskPriority::UnknownEndpoint || (token.first() & TOKEN_STREAM_FLAG) == 0) {
 			deliver(transport, Endpoint({ peerAddress }, token), priority, std::move(reader), true);
 		}

--- a/fdbrpc/FlowTransport.actor.cpp
+++ b/fdbrpc/FlowTransport.actor.cpp
@@ -1035,10 +1035,8 @@ static void scanPackets(TransportData* transport,
 		// we ignore packets to unknown endpoints if they're not going to a stream anyways, so we can just
 		// return here. The main place where this seems to happen is if a ReplyPromise is not waited on
 		// long enough.
-		// It would be slightly more elegant/readable to put this if-block into the deliver actor, but if
-		// we have many messages to UnknownEndpoint we want to optimize earlier. As deliver is an actor it
-		// will allocate some state on the heap and this prevents it from doing that.
-		if (priority != TaskPriority::UnknownEndpoint || (token.first() & TOKEN_STREAM_FLAG) == 0) {
+		// It would be slightly more elegant to put this if-block
+		if (priority != TaskPriority::UnknownEndpoint || (token.first() & TOKEN_STREAM_FLAG) != 0) {
 			deliver(transport, Endpoint({ peerAddress }, token), priority, std::move(reader), true);
 		}
 

--- a/fdbrpc/FlowTransport.actor.cpp
+++ b/fdbrpc/FlowTransport.actor.cpp
@@ -867,14 +867,18 @@ TransportData::~TransportData() {
 	}
 }
 
-ACTOR static void deliver(TransportData* self, Endpoint destination, ArenaReader reader, bool inReadSocket) {
-	TaskPriority priority = self->endpoints.getPriority(destination.token);
-	if (priority == TaskPriority::UnknownEndpoint && (destination.token.first() & TOKEN_STREAM_FLAG) == 0) {
-		// we ignore packets to unknown endpoints if they're not going to a stream anyways, so we can just
-		// return here. The main place where this seems to happen is if a ReplyPromise is not waited on
-		// long enough.
-		return;
-	}
+// This actor looks up the task associated with an endpoint
+// and sends the message to it. The actual deserialization will
+// be done by that task (see NetworkMessageReceiver).
+ACTOR static void deliver(TransportData* self,
+                          Endpoint destination,
+                          TaskPriority priority,
+                          ArenaReader reader,
+                          bool inReadSocket) {
+	// We want to run the task at the right priority. If the priority
+	// is higher than the current priority (which is ReadSocket) we
+	// can just upgrade. Otherwise we'll context switch so that we
+	// don't block other tasks that might run with a higher priority.
 	if (priority < TaskPriority::ReadSocket || !inReadSocket) {
 		wait(delay(0, priority));
 	} else {
@@ -1027,7 +1031,14 @@ static void scanPackets(TransportData* transport,
 		}
 
 		ASSERT(!reader.empty());
-		deliver(transport, Endpoint({ peerAddress }, token), std::move(reader), true);
+		TaskPriority priority = transport->endpoints.getPriority(token);
+		// we ignore packets to unknown endpoints if they're not going to a stream anyways, so we can just
+		// return here. The main place where this seems to happen is if a ReplyPromise is not waited on
+		// long enough.
+		// It would be slightly more elegant to put this if-block
+		if (priority != TaskPriority::UnknownEndpoint || (token.first() & TOKEN_STREAM_FLAG) == 0) {
+			deliver(transport, Endpoint({ peerAddress }, token), priority, std::move(reader), true);
+		}
 
 		unprocessed_begin = p = p + packetLen;
 	}
@@ -1471,7 +1482,11 @@ static void sendLocal(TransportData* self, ISerializeSource const& what, const E
 #endif
 
 	ASSERT(copy.size() > 0);
-	deliver(self, destination, ArenaReader(copy.arena(), copy, AssumeVersion(currentProtocolVersion)), false);
+	TaskPriority priority = self->endpoints.getPriority(destination.token);
+	if (priority != TaskPriority::UnknownEndpoint || (destination.token.first() & TOKEN_STREAM_FLAG) == 0) {
+		deliver(
+		    self, destination, priority, ArenaReader(copy.arena(), copy, AssumeVersion(currentProtocolVersion)), false);
+	}
 }
 
 static ReliablePacket* sendPacket(TransportData* self,

--- a/fdbrpc/FlowTransport.actor.cpp
+++ b/fdbrpc/FlowTransport.actor.cpp
@@ -1035,7 +1035,9 @@ static void scanPackets(TransportData* transport,
 		// we ignore packets to unknown endpoints if they're not going to a stream anyways, so we can just
 		// return here. The main place where this seems to happen is if a ReplyPromise is not waited on
 		// long enough.
-		// It would be slightly more elegant to put this if-block
+		// It would be slightly more elegant/readable to put this if-block into the deliver actor, but if
+		// we have many messages to UnknownEndpoint we want to optimize earlier. As deliver is an actor it
+		// will allocate some state on the heap and this prevents it from doing that.
 		if (priority != TaskPriority::UnknownEndpoint || (token.first() & TOKEN_STREAM_FLAG) != 0) {
 			deliver(transport, Endpoint({ peerAddress }, token), priority, std::move(reader), true);
 		}

--- a/fdbrpc/fdbrpc.h
+++ b/fdbrpc/fdbrpc.h
@@ -52,6 +52,7 @@ struct FlowReceiver : public NetworkMessageReceiver {
 	// If already a remote endpoint, returns that.  Otherwise makes this
 	//   a local endpoint and returns that.
 	const Endpoint& getEndpoint(TaskPriority taskID) {
+		ASSERT(taskID != TaskPriority::UnknownEndpoint);
 		if (!endpoint.isValid()) {
 			m_isLocalEndpoint = true;
 			FlowTransport::transport().addEndpoint(endpoint, this, taskID);

--- a/flow/Net2.actor.cpp
+++ b/flow/Net2.actor.cpp
@@ -1299,10 +1299,6 @@ void Net2::run() {
 		while (!ready.empty()) {
 			++countTasks;
 			currentTaskID = ready.top().taskID;
-			if (currentTaskID < minTaskID) {
-				trackAtPriority(currentTaskID, taskBegin);
-				minTaskID = currentTaskID;
-			}
 			priorityMetric = static_cast<int64_t>(currentTaskID);
 			Task* task = ready.top().task;
 			ready.pop();
@@ -1313,6 +1309,11 @@ void Net2::run() {
 				TraceEvent(SevError, "TaskError").error(e);
 			} catch (...) {
 				TraceEvent(SevError, "TaskError").error(unknown_error());
+			}
+
+			if (currentTaskID < minTaskID) {
+				trackAtPriority(currentTaskID, taskBegin);
+				minTaskID = currentTaskID;
 			}
 
 			double tscNow = timestampCounter();


### PR DESCRIPTION
This is a cherry-pick of #4473

We ran into a minor issue in production where unknown_endpoint shows up in our statistics too frequently. We tracked this down to two problems (both solved here):

If a message is sent to an unknown endpoint we do more work than necessary (we create a new actor, change priority through a wait, and then do nothing).
The accounting for priorities produces numbers that are a bit confusing (and inaccurate in this case).
This has been tested as a patch for 6.2 on a large QA cluster. For the version on master I tested this just by making sure that a local cluster comes up and is functional.