### PR TITLE
Support non-string value fields in JSON tracing

### DIFF
--- a/fdbclient/CommitTransaction.h
+++ b/fdbclient/CommitTransaction.h
@@ -140,7 +140,7 @@ struct MutationRef {
 
 template <>
 struct Traceable<MutationRef> : std::true_type {
-	static std::string toString(MutationRef const& value) { return value.toString(); }
+	static TraceValue toTraceValue(MutationRef const& value) { return value.toString(); }
 };
 
 static inline std::string getTypeString(MutationRef::Type type) {

--- a/fdbclient/FDBTypes.h
+++ b/fdbclient/FDBTypes.h
@@ -251,7 +251,7 @@ struct Traceable<std::vector<T>> : std::true_type {
 		auto result = TraceValue::create<TraceVector>();
 		auto &vec = result.get<TraceVector>();
 		for (const auto &v : value) {
-			vec.push_back(Traceable<T>::toTraceValue(v));
+			vec.emplace_back(Traceable<T>::toTraceValue(v).toString());
 		}
 		return result;
 	}
@@ -268,7 +268,7 @@ struct Traceable<std::set<T>> : std::true_type {
 		auto result = TraceValue::create<TraceVector>();
 		auto &vec = result.get<TraceVector>();
 		for (const auto &v : value) {
-			vec.push_back(Traceable<T>::toTraceValue(v));
+			vec.emplace_back(Traceable<T>::toTraceValue(v).toString());
 		}
 		return result;
 	}

--- a/fdbclient/FDBTypes.h
+++ b/fdbclient/FDBTypes.h
@@ -363,15 +363,16 @@ struct KeyRangeRef {
 template <>
 struct Traceable<KeyRangeRef> : std::true_type {
 	static TraceValue toTraceValue(const KeyRangeRef& value) {
-		auto begin = Traceable<StringRef>::toTraceValue(value.begin).value;
-		auto end = Traceable<StringRef>::toTraceValue(value.end).value;
-		TraceValue result;
-		result.value.reserve(begin.size() + end.size() + 3);
-		std::copy(begin.begin(), begin.end(), std::back_inserter(result.value));
-		result.value.push_back(' ');
-		result.value.push_back('-');
-		result.value.push_back(' ');
-		std::copy(end.begin(), end.end(), std::back_inserter(result.value));
+		auto begin = Traceable<StringRef>::toTraceValue(value.begin).get<TraceString>().value;
+		auto end = Traceable<StringRef>::toTraceValue(value.end).get<TraceString>().value;
+		TraceValue result("");
+		auto& resultString = result.get<TraceString>().value;
+		resultString.reserve(begin.size() + end.size() + 3);
+		std::copy(begin.begin(), begin.end(), std::back_inserter(resultString));
+		resultString.push_back(' ');
+		resultString.push_back('-');
+		resultString.push_back(' ');
+		std::copy(end.begin(), end.end(), std::back_inserter(resultString));
 		return result;
 	}
 };
@@ -464,7 +465,7 @@ struct string_serialized_traits<KeyValueRef> : std::true_type {
 template <>
 struct Traceable<KeyValueRef> : std::true_type {
 	static TraceValue toTraceValue(const KeyValueRef& value) {
-		return Traceable<KeyRef>::toTraceValue(value.key).value + format(":%d", value.value.size());
+		return TraceValue(Traceable<KeyRef>::toTraceValue(value.key).toString() + format(":%d", value.value.size()));
 	}
 };
 

--- a/fdbclient/FDBTypes.h
+++ b/fdbclient/FDBTypes.h
@@ -123,7 +123,7 @@ struct struct_like_traits<Tag> : std::true_type {
 
 template <>
 struct Traceable<Tag> : std::true_type {
-	static std::string toString(const Tag& value) { return value.toString(); }
+	static TraceValue toTraceValue(const Tag& value) { return value.toString(); }
 };
 
 static const Tag invalidTag{ tagLocalitySpecial, 0 };
@@ -247,7 +247,7 @@ std::string describe(std::vector<T> const& items, int max_items = -1) {
 
 template <typename T>
 struct Traceable<std::vector<T>> : std::true_type {
-	static std::string toString(const std::vector<T>& value) { return describe(value); }
+	static TraceValue toTraceValue(const std::vector<T>& value) { return describe(value); }
 };
 
 template <class T>
@@ -257,7 +257,7 @@ std::string describe(std::set<T> const& items, int max_items = -1) {
 
 template <typename T>
 struct Traceable<std::set<T>> : std::true_type {
-	static std::string toString(const std::set<T>& value) { return describe(value); }
+	static TraceValue toTraceValue(const std::set<T>& value) { return describe(value); }
 };
 
 std::string printable(const StringRef& val);
@@ -362,16 +362,16 @@ struct KeyRangeRef {
 
 template <>
 struct Traceable<KeyRangeRef> : std::true_type {
-	static std::string toString(const KeyRangeRef& value) {
-		auto begin = Traceable<StringRef>::toString(value.begin);
-		auto end = Traceable<StringRef>::toString(value.end);
-		std::string result;
-		result.reserve(begin.size() + end.size() + 3);
-		std::copy(begin.begin(), begin.end(), std::back_inserter(result));
-		result.push_back(' ');
-		result.push_back('-');
-		result.push_back(' ');
-		std::copy(end.begin(), end.end(), std::back_inserter(result));
+	static TraceValue toTraceValue(const KeyRangeRef& value) {
+		auto begin = Traceable<StringRef>::toTraceValue(value.begin).value;
+		auto end = Traceable<StringRef>::toTraceValue(value.end).value;
+		TraceValue result;
+		result.value.reserve(begin.size() + end.size() + 3);
+		std::copy(begin.begin(), begin.end(), std::back_inserter(result.value));
+		result.value.push_back(' ');
+		result.value.push_back('-');
+		result.value.push_back(' ');
+		std::copy(end.begin(), end.end(), std::back_inserter(result.value));
 		return result;
 	}
 };
@@ -463,8 +463,8 @@ struct string_serialized_traits<KeyValueRef> : std::true_type {
 
 template <>
 struct Traceable<KeyValueRef> : std::true_type {
-	static std::string toString(const KeyValueRef& value) {
-		return Traceable<KeyRef>::toString(value.key) + format(":%d", value.value.size());
+	static TraceValue toTraceValue(const KeyValueRef& value) {
+		return Traceable<KeyRef>::toTraceValue(value.key).value + format(":%d", value.value.size());
 	}
 };
 
@@ -709,8 +709,8 @@ struct RangeResultRef : VectorRef<KeyValueRef> {
 
 template <>
 struct Traceable<RangeResultRef> : std::true_type {
-	static std::string toString(const RangeResultRef& value) {
-		return Traceable<VectorRef<KeyValueRef>>::toString(value);
+	static TraceValue toTraceValue(const RangeResultRef& value) {
+		return Traceable<VectorRef<KeyValueRef>>::toTraceValue(value);
 	}
 };
 
@@ -759,7 +759,7 @@ private:
 
 template <>
 struct Traceable<KeyValueStoreType> : std::true_type {
-	static std::string toString(KeyValueStoreType const& value) { return value.toString(); }
+	static TraceValue toTraceValue(KeyValueStoreType const& value) { return value.toString(); }
 };
 
 struct TLogVersion {
@@ -812,7 +812,7 @@ struct TLogVersion {
 
 template <>
 struct Traceable<TLogVersion> : std::true_type {
-	static std::string toString(TLogVersion const& value) { return Traceable<Version>::toString(value.version); }
+	static TraceValue toTraceValue(TLogVersion const& value) { return Traceable<Version>::toTraceValue(value.version); }
 };
 
 struct TLogSpillType {

--- a/fdbclient/FDBTypes.h
+++ b/fdbclient/FDBTypes.h
@@ -247,7 +247,14 @@ std::string describe(std::vector<T> const& items, int max_items = -1) {
 
 template <typename T>
 struct Traceable<std::vector<T>> : std::true_type {
-	static TraceValue toTraceValue(const std::vector<T>& value) { return describe(value); }
+	static TraceValue toTraceValue(const std::vector<T>& value) {
+		auto result = TraceValue::create<TraceVector>();
+		auto &vec = result.get<TraceVector>();
+		for (const auto &v : value) {
+			vec.push_back(Traceable<T>::toTraceValue(v));
+		}
+		return result;
+	}
 };
 
 template <class T>

--- a/fdbclient/FDBTypes.h
+++ b/fdbclient/FDBTypes.h
@@ -264,7 +264,14 @@ std::string describe(std::set<T> const& items, int max_items = -1) {
 
 template <typename T>
 struct Traceable<std::set<T>> : std::true_type {
-	static TraceValue toTraceValue(const std::set<T>& value) { return describe(value); }
+	static TraceValue toTraceValue(const std::set<T>& value) {
+		auto result = TraceValue::create<TraceVector>();
+		auto &vec = result.get<TraceVector>();
+		for (const auto &v : value) {
+			vec.push_back(Traceable<T>::toTraceValue(v));
+		}
+		return result;
+	}
 };
 
 std::string printable(const StringRef& val);

--- a/fdbclient/SnapshotCache.h
+++ b/fdbclient/SnapshotCache.h
@@ -137,14 +137,14 @@ inline bool operator>=(const ExtStringRef& lhs, const ExtStringRef& rhs) {
 
 template <>
 struct Traceable<ExtStringRef> : std::true_type {
-	static std::string toString(const ExtStringRef str) {
+	static TraceValue toTraceValue(const ExtStringRef str) {
 		std::string result;
 		result.reserve(str.size());
 		std::copy(str.base.begin(), str.base.end(), std::back_inserter(result));
 		for (int i = 0; i < str.extra_zero_bytes; ++i) {
 			result.push_back('\0');
 		}
-		return Traceable<std::string>::toString(result);
+		return Traceable<std::string>::toTraceValue(result);
 	}
 };
 

--- a/fdbrpc/Stats.h
+++ b/fdbrpc/Stats.h
@@ -59,11 +59,9 @@ template <>
 struct Traceable<ICounter*> : std::true_type {
 	static TraceValue toTraceValue(ICounter const* counter) {
 		if (counter->hasRate() && counter->hasRoughness()) {
-			return TraceValue(
-			    format("[%g,%g,%lld]", counter->getRate(), counter->getRoughness(), (long long)counter->getValue()),
-			    false);
+			return TraceValue::create<TraceCounter>(counter->getRate(), counter->getRoughness(), counter->getValue());
 		} else {
-			return TraceValue(format("%lld", (long long)counter->getValue()), false);
+			return TraceValue::create<TraceNumeric>(format("%lld", (long long)counter->getValue()));
 		}
 	}
 };

--- a/fdbrpc/Stats.h
+++ b/fdbrpc/Stats.h
@@ -57,11 +57,13 @@ struct ICounter {
 
 template <>
 struct Traceable<ICounter*> : std::true_type {
-	static std::string toString(ICounter const* counter) {
+	static TraceValue toTraceValue(ICounter const* counter) {
 		if (counter->hasRate() && counter->hasRoughness()) {
-			return format("%g %g %lld", counter->getRate(), counter->getRoughness(), (long long)counter->getValue());
+			return TraceValue(
+			    format("[%g,%g,%lld]", counter->getRate(), counter->getRoughness(), (long long)counter->getValue()),
+			    false);
 		} else {
-			return format("%lld", (long long)counter->getValue());
+			return TraceValue(format("%lld", (long long)counter->getValue()), false);
 		}
 	}
 };
@@ -122,8 +124,8 @@ private:
 
 template <>
 struct Traceable<Counter> : std::true_type {
-	static std::string toString(Counter const& counter) {
-		return Traceable<ICounter*>::toString((ICounter const*)&counter);
+	static TraceValue toTraceValue(Counter const& counter) {
+		return Traceable<ICounter*>::toTraceValue((ICounter const*)&counter);
 	}
 };
 

--- a/fdbserver/IDiskQueue.h
+++ b/fdbserver/IDiskQueue.h
@@ -99,7 +99,7 @@ public:
 
 template <>
 struct Traceable<IDiskQueue::location> : std::true_type {
-	static std::string toString(const IDiskQueue::location& value) { return value; }
+	static TraceValue toTraceValue(const IDiskQueue::location& value) { return TraceValue(value); }
 };
 
 // FIXME: One should be able to use SFINAE to choose between serialize and serialize_unversioned.

--- a/fdbserver/Ratekeeper.actor.cpp
+++ b/fdbserver/Ratekeeper.actor.cpp
@@ -1335,7 +1335,8 @@ void updateRate(RatekeeperData* self, RatekeeperLimits* limits) {
 		TraceEvent(name.c_str(), self->id)
 		    .detail("TPSLimit", limits->tpsLimit)
 		    .detail("Reason", limitReason)
-		    .detail("ReasonServerID", reasonID == UID() ? std::string() : Traceable<UID>::toTraceValue(reasonID).value)
+		    .detail("ReasonServerID",
+		            reasonID == UID() ? std::string() : Traceable<UID>::toTraceValue(reasonID).toString())
 		    .detail("ReleasedTPS", self->smoothReleasedTransactions.smoothRate())
 		    .detail("ReleasedBatchTPS", self->smoothBatchReleasedTransactions.smoothRate())
 		    .detail("TPSBasis", actualTps)

--- a/fdbserver/Ratekeeper.actor.cpp
+++ b/fdbserver/Ratekeeper.actor.cpp
@@ -1335,7 +1335,7 @@ void updateRate(RatekeeperData* self, RatekeeperLimits* limits) {
 		TraceEvent(name.c_str(), self->id)
 		    .detail("TPSLimit", limits->tpsLimit)
 		    .detail("Reason", limitReason)
-		    .detail("ReasonServerID", reasonID == UID() ? std::string() : Traceable<UID>::toString(reasonID))
+		    .detail("ReasonServerID", reasonID == UID() ? std::string() : Traceable<UID>::toTraceValue(reasonID).value)
 		    .detail("ReleasedTPS", self->smoothReleasedTransactions.smoothRate())
 		    .detail("ReleasedBatchTPS", self->smoothBatchReleasedTransactions.smoothRate())
 		    .detail("TPSBasis", actualTps)

--- a/fdbserver/Status.actor.cpp
+++ b/fdbserver/Status.actor.cpp
@@ -430,7 +430,7 @@ struct RolesInfo {
 				continue;
 			}
 
-			latencyBands[band] = StatusCounter(itr->second.value).getCounter();
+			latencyBands[band] = StatusCounter(itr->second.toString()).getCounter();
 		}
 
 		return latencyBands;

--- a/fdbserver/Status.actor.cpp
+++ b/fdbserver/Status.actor.cpp
@@ -430,7 +430,7 @@ struct RolesInfo {
 				continue;
 			}
 
-			latencyBands[band] = StatusCounter(itr->second).getCounter();
+			latencyBands[band] = StatusCounter(itr->second.value).getCounter();
 		}
 
 		return latencyBands;

--- a/flow/Arena.h
+++ b/flow/Arena.h
@@ -1309,18 +1309,11 @@ struct Traceable<VectorRef<T>> {
 	constexpr static bool value = Traceable<T>::value;
 
 	static TraceValue toTraceValue(const VectorRef<T>& value) {
-		TraceValue result = TraceValue::create<TraceString>("[");
-		auto& resultString = result.get<TraceString>().value;
-		bool first = true;
+		auto result = TraceValue::create<TraceVector>();
+		auto& vec = result.get<TraceVector>();
 		for (const auto& v : value) {
-			if (first) {
-				first = false;
-			} else {
-				resultString.push_back(',');
-			}
-			resultString += Traceable<T>::toTraceValue(v).toString();
+			vec.push_back(Traceable<T>::toTraceValue(v));
 		}
-		resultString.push_back(']');
 		return result;
 	}
 };

--- a/flow/Arena.h
+++ b/flow/Arena.h
@@ -292,7 +292,7 @@ inline void save(Archive& ar, const Optional<T>& value) {
 template <class T>
 struct Traceable<Optional<T>> : std::conditional<Traceable<T>::value, std::true_type, std::false_type>::type {
 	static TraceValue toTraceValue(const Optional<T>& value) {
-		return TraceValue(value.present() ? Traceable<T>::toTraceValue(value.get()).value : "[not set]");
+		return value.present() ? Traceable<T>::toTraceValue(value.get()) : TraceValue("[not set]");
 	}
 };
 
@@ -615,7 +615,7 @@ template <>
 struct Traceable<StringRef> : TraceableStringImpl<StringRef> {};
 
 inline std::string StringRef::printable() const {
-	return Traceable<StringRef>::toTraceValue(*this).value;
+	return Traceable<StringRef>::toTraceValue(*this).toString();
 }
 
 template <class T>
@@ -1309,17 +1309,18 @@ struct Traceable<VectorRef<T>> {
 	constexpr static bool value = Traceable<T>::value;
 
 	static TraceValue toTraceValue(const VectorRef<T>& value) {
-		TraceValue result("[", false);
+		TraceValue result = TraceValue::create<TraceString>("[");
+		auto& resultString = result.get<TraceString>().value;
 		bool first = true;
 		for (const auto& v : value) {
 			if (first) {
 				first = false;
 			} else {
-				result.value.push_back(',');
+				resultString.push_back(',');
 			}
-			result.value += Traceable<T>::toTraceValue(v).value;
+			resultString += Traceable<T>::toTraceValue(v).toString();
 		}
-		result.value.push_back(']');
+		resultString.push_back(']');
 		return result;
 	}
 };

--- a/flow/Arena.h
+++ b/flow/Arena.h
@@ -1309,17 +1309,17 @@ struct Traceable<VectorRef<T>> {
 	constexpr static bool value = Traceable<T>::value;
 
 	static std::string toString(const VectorRef<T>& value) {
-		std::stringstream ss;
+		std::string result;
 		bool first = true;
 		for (const auto& v : value) {
 			if (first) {
 				first = false;
 			} else {
-				ss << ' ';
+				result.push_back(' ');
 			}
-			ss << Traceable<T>::toString(v);
+			result += Traceable<T>::toString(v);
 		}
-		return ss.str();
+		return result;
 	}
 };
 

--- a/flow/Arena.h
+++ b/flow/Arena.h
@@ -1312,7 +1312,7 @@ struct Traceable<VectorRef<T>> {
 		auto result = TraceValue::create<TraceVector>();
 		auto& vec = result.get<TraceVector>();
 		for (const auto& v : value) {
-			vec.push_back(Traceable<T>::toTraceValue(v));
+			vec.emplace_back(Traceable<T>::toTraceValue(v).toString());
 		}
 		return result;
 	}

--- a/flow/CMakeLists.txt
+++ b/flow/CMakeLists.txt
@@ -64,6 +64,7 @@ set(FLOW_SRCS
   ThreadSafeQueue.h
   Trace.cpp
   Trace.h
+  TraceValue.cpp
   Tracing.h
   Tracing.actor.cpp
   TreeBenchmark.h

--- a/flow/ITrace.h
+++ b/flow/ITrace.h
@@ -23,6 +23,8 @@
 #include <string>
 #include <set>
 
+#include "flow/TraceValue.h"
+
 class StringRef;
 
 struct ITraceLogWriter {
@@ -39,7 +41,8 @@ struct ITraceLogWriter {
 
 class TraceEventFields;
 
-struct ITraceLogFormatter {
+class ITraceLogFormatter {
+public:
 	virtual const char* getExtension() = 0;
 	virtual const char* getHeader() = 0; // Called when starting a new file
 	virtual const char* getFooter() = 0; // Called when ending a file

--- a/flow/JsonTraceLogFormatter.cpp
+++ b/flow/JsonTraceLogFormatter.cpp
@@ -62,7 +62,9 @@ public:
 			} else {
 				result.push_back(',');
 			}
-			result += tv.toString();
+			result.push_back('\"');
+			result += tv;
+			result.push_back('\"');
 		}
 		result.push_back(']');
 		return result;

--- a/flow/JsonTraceLogFormatter.cpp
+++ b/flow/JsonTraceLogFormatter.cpp
@@ -51,6 +51,20 @@ public:
 	std::string operator()(TraceString const& v) const { return "\"" + escapeString(v.value) + "\""; }
 	std::string operator()(TraceCounter const& v) const { return format("[%g,%g,%lld]", v.rate, v.roughness, v.value); }
 	std::string operator()(TraceNumeric const& v) const { return v.value; }
+	std::string operator()(TraceVector const& v) const {
+		std::string result = "[";
+		bool first = true;
+		for (const auto& tv : v.values) {
+			if (first) {
+				first = false;
+			} else {
+				result.push_back(',');
+			}
+			result += tv.toString();
+		}
+		result.push_back(']');
+		return result;
+	}
 } jsonValueFormatter;
 
 void JsonTraceLogFormatter::addref() {

--- a/flow/JsonTraceLogFormatter.cpp
+++ b/flow/JsonTraceLogFormatter.cpp
@@ -23,7 +23,9 @@
 
 #include <sstream>
 
-static std::string escapeString(const std::string& source) {
+namespace {
+
+std::string escapeString(const std::string& source) {
 	std::string result;
 	for (auto c : source) {
 		if (c == '"') {
@@ -66,6 +68,8 @@ public:
 		return result;
 	}
 } jsonValueFormatter;
+
+} //namespace
 
 void JsonTraceLogFormatter::addref() {
 	ReferenceCounted<JsonTraceLogFormatter>::addref();

--- a/flow/JsonTraceLogFormatter.h
+++ b/flow/JsonTraceLogFormatter.h
@@ -21,7 +21,8 @@
 #include "flow/FastRef.h"
 #include "flow/Trace.h"
 
-struct JsonTraceLogFormatter : public ITraceLogFormatter, ReferenceCounted<JsonTraceLogFormatter> {
+class JsonTraceLogFormatter : public ITraceLogFormatter, ReferenceCounted<JsonTraceLogFormatter> {
+public:
 	const char* getExtension() override;
 	const char* getHeader() override; // Called when starting a new file
 	const char* getFooter() override; // Called when ending a file

--- a/flow/Trace.cpp
+++ b/flow/Trace.cpp
@@ -1241,7 +1241,7 @@ std::string TraceEvent::printRealTime(double time) {
 	struct tm result;
 	ss << std::put_time(::gmtime_r(&ts, &result), "%Y-%m-%dT%H:%M:%SZ");
 #endif
-	return ss.str();
+	return std::move(ss).str();
 }
 
 TraceInterval& TraceInterval::begin() {

--- a/flow/Trace.cpp
+++ b/flow/Trace.cpp
@@ -478,7 +478,7 @@ public:
 					for (auto itr = events[idx].begin(); itr != events[idx].end(); ++itr) {
 						if (itr->first == "Time") {
 							time = TraceEvent::getCurrentTime();
-							rolledFields.addField("Time", format("%.6f", time));
+							rolledFields.addField("Time", TraceValue::create<TraceNumeric>(format("%.6f", time)));
 							rolledFields.addField("OriginalTime", itr->second);
 						} else if (itr->first == "DateTime") {
 							UNSTOPPABLE_ASSERT(time > 0); // "Time" field should always come first
@@ -925,7 +925,7 @@ bool TraceEvent::init() {
 		}
 
 		detail("Severity", int(severity));
-		detail("Time", "0.000000");
+		detail("Time", TraceValue::create<TraceNumeric>(std::string("0.000000")));
 		timeIndex = fields.size() - 1;
 		if (FLOW_KNOBS && FLOW_KNOBS->TRACE_DATETIME_ENABLED) {
 			detail("DateTime", "");
@@ -1329,7 +1329,7 @@ void TraceBatch::dump() {
 
 TraceBatch::EventInfo::EventInfo(double time, const char* name, uint64_t id, const char* location) {
 	fields.addField("Severity", format("%d", (int)TRACE_BATCH_IMPLICIT_SEVERITY));
-	fields.addField("Time", format("%.6f", time));
+	fields.addField("Time", TraceValue::create<TraceNumeric>(format("%.6f", time)));
 	if (FLOW_KNOBS && FLOW_KNOBS->TRACE_DATETIME_ENABLED) {
 		fields.addField("DateTime", printRealTime(time));
 	}
@@ -1340,7 +1340,7 @@ TraceBatch::EventInfo::EventInfo(double time, const char* name, uint64_t id, con
 
 TraceBatch::AttachInfo::AttachInfo(double time, const char* name, uint64_t id, uint64_t to) {
 	fields.addField("Severity", format("%d", (int)TRACE_BATCH_IMPLICIT_SEVERITY));
-	fields.addField("Time", format("%.6f", time));
+	fields.addField("Time", TraceValue::create<TraceNumeric>(format("%.6f", time)));
 	if (FLOW_KNOBS && FLOW_KNOBS->TRACE_DATETIME_ENABLED) {
 		fields.addField("DateTime", printRealTime(time));
 	}
@@ -1351,7 +1351,7 @@ TraceBatch::AttachInfo::AttachInfo(double time, const char* name, uint64_t id, u
 
 TraceBatch::BuggifyInfo::BuggifyInfo(double time, int activated, int line, std::string file) {
 	fields.addField("Severity", format("%d", (int)TRACE_BATCH_IMPLICIT_SEVERITY));
-	fields.addField("Time", format("%.6f", time));
+	fields.addField("Time", TraceValue::create<TraceNumeric>(format("%.6f", time)));
 	if (FLOW_KNOBS && FLOW_KNOBS->TRACE_DATETIME_ENABLED) {
 		fields.addField("DateTime", printRealTime(time));
 	}

--- a/flow/Trace.cpp
+++ b/flow/Trace.cpp
@@ -1402,7 +1402,7 @@ const TraceEventFields::Field& TraceEventFields::operator[](int index) const {
 	return fields.at(index);
 }
 
-bool TraceEventFields::tryGetValue(std::string key, std::string& outValue) const {
+bool TraceEventFields::tryGetValue(const std::string& key, std::string& outValue) const {
 	for (auto itr = begin(); itr != end(); ++itr) {
 		if (itr->first == key) {
 			outValue = itr->second;
@@ -1413,7 +1413,7 @@ bool TraceEventFields::tryGetValue(std::string key, std::string& outValue) const
 	return false;
 }
 
-std::string TraceEventFields::getValue(std::string key) const {
+std::string TraceEventFields::getValue(const std::string& key) const {
 	std::string value;
 	if (tryGetValue(key, value)) {
 		return value;
@@ -1475,7 +1475,7 @@ void parseNumericValue(std::string const& s, int64_t& outValue, bool permissive 
 }
 
 template <class T>
-T getNumericValue(TraceEventFields const& fields, std::string key, bool permissive) {
+T getNumericValue(TraceEventFields const& fields, const std::string& key, bool permissive) {
 	std::string field = fields.getValue(key);
 
 	try {
@@ -1498,15 +1498,15 @@ T getNumericValue(TraceEventFields const& fields, std::string key, bool permissi
 }
 } // namespace
 
-int TraceEventFields::getInt(std::string key, bool permissive) const {
+int TraceEventFields::getInt(const std::string& key, bool permissive) const {
 	return getNumericValue<int>(*this, key, permissive);
 }
 
-int64_t TraceEventFields::getInt64(std::string key, bool permissive) const {
+int64_t TraceEventFields::getInt64(const std::string& key, bool permissive) const {
 	return getNumericValue<int64_t>(*this, key, permissive);
 }
 
-double TraceEventFields::getDouble(std::string key, bool permissive) const {
+double TraceEventFields::getDouble(const std::string& key, bool permissive) const {
 	return getNumericValue<double>(*this, key, permissive);
 }
 

--- a/flow/Trace.cpp
+++ b/flow/Trace.cpp
@@ -396,7 +396,7 @@ public:
 		annotateEvent(fields);
 
 		if (!trackLatestKey.empty()) {
-			fields.addField("TrackLatestType", TraceValue("Original"));
+			fields.addField("TrackLatestType", "Original");
 		}
 
 		if (!isOpen() &&
@@ -485,7 +485,7 @@ public:
 							rolledFields.addField("DateTime", printRealTime(time));
 							rolledFields.addField("OriginalDateTime", itr->second);
 						} else if (itr->first == "TrackLatestType") {
-							rolledFields.addField("TrackLatestType", TraceValue("Rolled"));
+							rolledFields.addField("TrackLatestType", "Rolled");
 						} else {
 							rolledFields.addField(itr->first, itr->second);
 						}
@@ -925,7 +925,7 @@ bool TraceEvent::init() {
 		}
 
 		detail("Severity", int(severity));
-		detail("Time", TraceValue::create<TraceNumeric>(std::string("0.000000")));
+		detail("Time", TraceValue::create<TraceNumeric>("0.000000"));
 		timeIndex = fields.size() - 1;
 		if (FLOW_KNOBS && FLOW_KNOBS->TRACE_DATETIME_ENABLED) {
 			detail("DateTime", "");
@@ -1168,7 +1168,7 @@ void TraceEvent::log() {
 		try {
 			if (enabled) {
 				double time = TraceEvent::getCurrentTime();
-				fields.mutate(timeIndex).second = TraceValue(format("%.6f", time));
+				fields.mutate(timeIndex).second = format("%.6f", time);
 				if (FLOW_KNOBS && FLOW_KNOBS->TRACE_DATETIME_ENABLED) {
 					fields.mutate(timeIndex + 1).second = printRealTime(time);
 				}
@@ -1333,9 +1333,9 @@ TraceBatch::EventInfo::EventInfo(double time, const char* name, uint64_t id, con
 	if (FLOW_KNOBS && FLOW_KNOBS->TRACE_DATETIME_ENABLED) {
 		fields.addField("DateTime", printRealTime(time));
 	}
-	fields.addField("Type", TraceValue(name));
+	fields.addField("Type", name);
 	fields.addField("ID", format("%016" PRIx64, id));
-	fields.addField("Location", TraceValue(location));
+	fields.addField("Location", location);
 }
 
 TraceBatch::AttachInfo::AttachInfo(double time, const char* name, uint64_t id, uint64_t to) {
@@ -1344,7 +1344,7 @@ TraceBatch::AttachInfo::AttachInfo(double time, const char* name, uint64_t id, u
 	if (FLOW_KNOBS && FLOW_KNOBS->TRACE_DATETIME_ENABLED) {
 		fields.addField("DateTime", printRealTime(time));
 	}
-	fields.addField("Type", TraceValue(name));
+	fields.addField("Type", name);
 	fields.addField("ID", format("%016" PRIx64, id));
 	fields.addField("To", format("%016" PRIx64, to));
 }
@@ -1355,7 +1355,7 @@ TraceBatch::BuggifyInfo::BuggifyInfo(double time, int activated, int line, std::
 	if (FLOW_KNOBS && FLOW_KNOBS->TRACE_DATETIME_ENABLED) {
 		fields.addField("DateTime", printRealTime(time));
 	}
-	fields.addField("Type", TraceValue("BuggifySection"));
+	fields.addField("Type", "BuggifySection");
 	fields.addField("Activated", format("%d", activated));
 	fields.addField("File", std::move(file));
 	fields.addField("Line", format("%d", line));

--- a/flow/Trace.cpp
+++ b/flow/Trace.cpp
@@ -983,12 +983,9 @@ TraceEvent& TraceEvent::detailImpl(std::string&& key, TraceValue&& traceValue, b
 	init();
 	if (enabled) {
 		++g_allocation_tracing_disabled;
-		// FIXME: Enable truncating again
-		/*
-		if (maxFieldLength >= 0 && valueStr.size() > maxFieldLength) {
-		    valueStr = valueStr.substr(0, maxFieldLength) + "...";
+		if (maxFieldLength >= 0) {
+			traceValue.truncate(maxFieldLength);
 		}
-		*/
 
 		if (writeEventMetricField) {
 			tmpEventMetric->setField(key.c_str(), Standalone<StringRef>(StringRef(traceValue.toString())));

--- a/flow/Trace.cpp
+++ b/flow/Trace.cpp
@@ -1368,6 +1368,16 @@ void TraceEventFields::addField(const std::string& key, const TraceValue& value)
 	fields.emplace_back(key, value);
 }
 
+void TraceEventFields::addField(const std::string& key, TraceValue&& value) {
+	bytes += key.size() + value.value.size();
+	fields.emplace_back(key, std::move(value));
+}
+
+void TraceEventFields::addField(std::string&& key, const TraceValue& value) {
+	bytes += key.size() + value.value.size();
+	fields.emplace_back(std::move(key), value);
+}
+
 void TraceEventFields::addField(std::string&& key, TraceValue&& value) {
 	bytes += key.size() + value.value.size();
 	fields.emplace_back(std::move(key), std::move(value));

--- a/flow/Trace.h
+++ b/flow/Trace.h
@@ -210,7 +210,7 @@ struct Traceable : std::false_type {};
 #define FORMAT_TRACEABLE(type, fmt)                                                                                    \
 	template <>                                                                                                        \
 	struct Traceable<type> : std::true_type {                                                                          \
-		static std::string toString(type value) { return format(fmt, value); }                                         \
+		static std::string toString(type const& value) { return format(fmt, value); }                                  \
 	}
 
 FORMAT_TRACEABLE(bool, "%d");

--- a/flow/Trace.h
+++ b/flow/Trace.h
@@ -236,6 +236,11 @@ FORMAT_NUMERIC_TRACEABLE(volatile unsigned long long, "%llu");
 FORMAT_NUMERIC_TRACEABLE(volatile double, "%g");
 
 template <>
+struct Traceable<TraceValue> : std::true_type {
+	static TraceValue toTraceValue(TraceValue const& traceValue) { return traceValue; }
+};
+
+template <>
 struct Traceable<bool> : std::true_type {
 	static TraceValue toTraceValue(bool value) { return TraceValue::create<TraceBool>(value); }
 };

--- a/flow/Trace.h
+++ b/flow/Trace.h
@@ -229,7 +229,6 @@ FORMAT_NUMERIC_TRACEABLE(unsigned long int, "%lu");
 FORMAT_NUMERIC_TRACEABLE(long long int, "%lld");
 FORMAT_NUMERIC_TRACEABLE(unsigned long long int, "%llu");
 FORMAT_NUMERIC_TRACEABLE(double, "%g");
-FORMAT_NUMERIC_TRACEABLE(void*, "%p");
 FORMAT_NUMERIC_TRACEABLE(volatile long, "%ld");
 FORMAT_NUMERIC_TRACEABLE(volatile unsigned long, "%lu");
 FORMAT_NUMERIC_TRACEABLE(volatile long long, "%lld");
@@ -239,6 +238,11 @@ FORMAT_NUMERIC_TRACEABLE(volatile double, "%g");
 template <>
 struct Traceable<bool> : std::true_type {
 	static TraceValue toTraceValue(bool value) { return TraceValue::create<TraceBool>(value); }
+};
+
+template <>
+struct Traceable<void*> : std::true_type {
+	static TraceValue toTraceValue(void *value) { return format("%p", value); }
 };
 
 template <>

--- a/flow/Trace.h
+++ b/flow/Trace.h
@@ -282,7 +282,7 @@ struct TraceableString<const char*> {
 
 	static bool atEnd(const char* value, const char* iter) { return *iter == '\0'; }
 
-	static TraceValue toTraceValue(const char* value) { return TraceValue(std::string(value)); }
+	static TraceValue toTraceValue(const char* value) { return TraceValue(value); }
 };
 
 std::string traceableStringToString(const char* value, size_t S);
@@ -305,7 +305,7 @@ struct TraceableString<char*> {
 
 	static bool atEnd(char* value, const char* iter) { return *iter == '\0'; }
 
-	static TraceValue toTraceValue(char* value) { return std::string(value); }
+	static TraceValue toTraceValue(char* value) { return TraceValue(value); }
 };
 
 template <class T>
@@ -329,7 +329,7 @@ struct TraceableStringImpl : std::true_type {
 		if (nonPrintables == 0 && numBackslashes == 0) {
 			return TraceableString<T>::toTraceValue(std::forward<Str>(value));
 		}
-		TraceValue result = TraceValue("");
+		TraceValue result;
 		auto& resultString = result.get<TraceString>().value;
 		resultString.reserve(size - nonPrintables + (nonPrintables * 4) + numBackslashes);
 		for (auto iter = TraceableString<T>::begin(value); !TraceableString<T>::atEnd(value, iter); ++iter) {
@@ -360,7 +360,8 @@ template <>
 struct Traceable<std::string> : TraceableStringImpl<std::string> {};
 
 template <class T>
-struct SpecialTraceMetricType : std::is_integral<T>::type {
+struct SpecialTraceMetricType
+  : std::conditional_t<std::is_integral_v<T> || std::is_enum_v<T>, std::true_type, std::false_type> {
 	static int64_t getValue(T v) { return v; }
 };
 

--- a/flow/Trace.h
+++ b/flow/Trace.h
@@ -341,8 +341,7 @@ template <>
 struct Traceable<std::string> : TraceableStringImpl<std::string> {};
 
 template <class T>
-struct SpecialTraceMetricType
-  : std::conditional<std::is_integral<T>::value || std::is_enum<T>::value, std::true_type, std::false_type>::type {
+struct SpecialTraceMetricType : std::is_integral<T>::type {
 	static int64_t getValue(T v) { return v; }
 };
 

--- a/flow/Trace.h
+++ b/flow/Trace.h
@@ -96,6 +96,8 @@ public:
 	void setAnnotated();
 
 	void addField(const std::string& key, const TraceValue& value);
+	void addField(const std::string& key, TraceValue&& value);
+	void addField(std::string&& key, const TraceValue& value);
 	void addField(std::string&& key, TraceValue&& value);
 
 	const Field& operator[](int index) const;

--- a/flow/Trace.h
+++ b/flow/Trace.h
@@ -252,7 +252,7 @@ struct TraceableString {
 
 	static bool atEnd(const Str& value, decltype(value.begin()) iter) { return iter == value.end(); }
 
-	static TraceValue toTraceValue(const Str& value) { return TraceValue(value.toString()); }
+	static TraceValue toTraceValue(const Str& value) { return value.toString(); }
 };
 
 template <>
@@ -287,7 +287,7 @@ struct TraceableString<char[S]> {
 		return iter - value == S - 1; // Exclude trailing \0 byte
 	}
 
-	static TraceValue toTraceValue(const char* value) { return TraceValue(traceableStringToString(value, S)); }
+	static TraceValue toTraceValue(const char* value) { return traceableStringToString(value, S); }
 };
 
 template <>
@@ -296,7 +296,7 @@ struct TraceableString<char*> {
 
 	static bool atEnd(char* value, const char* iter) { return *iter == '\0'; }
 
-	static TraceValue toTraceValue(char* value) { return TraceValue(std::string(value)); }
+	static TraceValue toTraceValue(char* value) { return std::string(value); }
 };
 
 template <class T>

--- a/flow/Trace.h
+++ b/flow/Trace.h
@@ -86,11 +86,11 @@ public:
 	void addField(std::string&& key, std::string&& value);
 
 	const Field& operator[](int index) const;
-	bool tryGetValue(std::string key, std::string& outValue) const;
-	std::string getValue(std::string key) const;
-	int getInt(std::string key, bool permissive = false) const;
-	int64_t getInt64(std::string key, bool permissive = false) const;
-	double getDouble(std::string key, bool permissive = false) const;
+	bool tryGetValue(const std::string& key, std::string& outValue) const;
+	std::string getValue(const std::string& key) const;
+	int getInt(const std::string& key, bool permissive = false) const;
+	int64_t getInt64(const std::string& key, bool permissive = false) const;
+	double getDouble(const std::string& key, bool permissive = false) const;
 
 	Field& mutate(int index);
 

--- a/flow/TraceValue.cpp
+++ b/flow/TraceValue.cpp
@@ -43,7 +43,7 @@ void TraceVector::push_back(TraceValue&& tv) {
 	values.push_back(std::move(tv));
 }
 
-size_t TraceVector::heapSize() const {
+size_t TraceVector::size() const {
 	size_t result = 0;
 	for (const auto& v : values) {
 		result += v.size();
@@ -81,7 +81,7 @@ std::string TraceValue::toString() && {
 }
 
 size_t TraceValue::size() const {
-	return sizeof(TraceValue) + std::visit([](auto const& v) { return v.heapSize(); }, value);
+	return std::visit([](auto const& v) { return v.size(); }, value);
 }
 
 void TraceValue::truncate(int maxFieldLength) {

--- a/flow/TraceValue.cpp
+++ b/flow/TraceValue.cpp
@@ -73,7 +73,7 @@ TraceValue::TraceValue(std::string const& value) : TraceValue(std::in_place_type
 TraceValue::TraceValue(std::string&& value) : TraceValue(std::in_place_type<TraceString>, std::move(value)) {}
 
 std::string TraceValue::toString() const& {
-	return std::visit([](const auto& val) { return val.toString(); }, value);
+	return std::visit([](auto const& val) { return val.toString(); }, value);
 }
 
 std::string TraceValue::toString() && {

--- a/flow/TraceValue.cpp
+++ b/flow/TraceValue.cpp
@@ -1,15 +1,64 @@
-#include "TraceValue.h"
+/*
+ * TraceValue.cpp
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2018 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-namespace {
+#include "flow/Arena.h"
+#include "flow/TraceValue.h"
 
-std::string toString(const TraceString& traceString) {
-	return traceString.value;
+std::string TraceBool::toString() const {
+	return format("%d", value);
 }
 
-std::string toString(const TraceString& trac)
+std::string TraceCounter::toString() const {
+	return format("%g %g %lld", rate, roughness, value);
+}
 
-} // namespace
+void TraceVector::truncate(int maxFieldLength) {
+	this->maxFieldLength = maxFieldLength;
+}
 
-TraceValue::toString() const {
-	return std::visit([](const auto& val) { return val.toString() });
+void TraceVector::push_back(TraceValue&& tv) {
+	values.push_back(std::move(tv));
+}
+
+size_t TraceVector::heapSize() const {
+	size_t result = 0;
+	for (const auto& v : values) {
+		result += v.size();
+	}
+	return result;
+}
+
+std::string TraceVector::toString() const {
+	std::string result;
+	bool first = true;
+	for (const auto& v : values) {
+		if (first) {
+			first = false;
+		} else {
+			result.push_back(' ');
+		}
+		result += v.toString();
+		if (maxFieldLength >= 0 && result.size() > maxFieldLength) {
+			result = result.substr(0, maxFieldLength) + "...";
+			return result;
+		}
+	}
+	return result;
 }

--- a/flow/TraceValue.cpp
+++ b/flow/TraceValue.cpp
@@ -1,0 +1,15 @@
+#include "TraceValue.h"
+
+namespace {
+
+std::string toString(const TraceString& traceString) {
+	return traceString.value;
+}
+
+std::string toString(const TraceString& trac)
+
+} // namespace
+
+TraceValue::toString() const {
+	return std::visit([](const auto& val) { return val.toString() });
+}

--- a/flow/TraceValue.cpp
+++ b/flow/TraceValue.cpp
@@ -69,9 +69,6 @@ std::string TraceVector::toString() const {
 	return result;
 }
 
-TraceValue::TraceValue(std::string const& value) : TraceValue(std::in_place_type<TraceString>, value) {}
-TraceValue::TraceValue(std::string&& value) : TraceValue(std::in_place_type<TraceString>, std::move(value)) {}
-
 std::string TraceValue::toString() const& {
 	return std::visit([](auto const& val) { return val.toString(); }, value);
 }

--- a/flow/TraceValue.cpp
+++ b/flow/TraceValue.cpp
@@ -39,10 +39,6 @@ void TraceVector::truncate(int maxFieldLength) {
 	this->maxFieldLength = maxFieldLength;
 }
 
-void TraceVector::push_back(TraceValue&& tv) {
-	values.push_back(std::move(tv));
-}
-
 size_t TraceVector::size() const {
 	size_t result = 0;
 	for (const auto& v : values) {
@@ -60,7 +56,7 @@ std::string TraceVector::toString() const {
 		} else {
 			result.push_back(' ');
 		}
-		result += v.toString();
+		result += v;
 		if (maxFieldLength >= 0 && result.size() > maxFieldLength) {
 			result = result.substr(0, maxFieldLength) + "...";
 			return result;

--- a/flow/TraceValue.h
+++ b/flow/TraceValue.h
@@ -110,7 +110,9 @@ struct TraceVector {
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, maxFieldLength, values);
+		// FIXME: Fix serialization once flatbuffers implementation supports
+		// recursive types
+		serializer(ar, maxFieldLength);
 	}
 };
 

--- a/flow/TraceValue.h
+++ b/flow/TraceValue.h
@@ -38,6 +38,7 @@ public:
 	std::string toString() const { return format("%d", value); }
 
 	static constexpr size_t heapSize() { return 0; }
+	static constexpr void truncate(int) {}
 
 	template <class Ar>
 	void serialize(Ar& ar) {
@@ -55,6 +56,12 @@ public:
 
 	size_t heapSize() const { return value.size(); }
 
+	void truncate(int maxFieldLength) {
+		if (value.size() > maxFieldLength) {
+			value = value.substr(0, maxFieldLength) + "...";
+		}
+	}
+
 	template <class Ar>
 	void serialize(Ar& ar) {
 		serializer(ar, value);
@@ -70,6 +77,7 @@ public:
 	std::string toString() const { return value; }
 
 	size_t heapSize() const { return value.size(); }
+	static constexpr void truncate(int) {}
 
 	template <class Ar>
 	void serialize(Ar& ar) {
@@ -88,6 +96,8 @@ public:
 	std::string toString() const { return format("%g %g %lld", rate, roughness, value); }
 
 	static constexpr size_t heapSize() { return 0; }
+	static constexpr void truncate(int) {}
+
 	template <class Ar>
 	void serialize(Ar& ar) {
 		serializer(ar, rate, roughness, value);
@@ -130,6 +140,10 @@ public:
 
 	size_t size() const {
 		return sizeof(TraceValue) + std::visit([](auto const& v) { return v.heapSize(); }, value);
+	}
+
+	void truncate(int maxFieldLength) {
+		std::visit([maxFieldLength](auto& v) { v.truncate(maxFieldLength); }, value);
 	}
 
 	template <class Ar>

--- a/flow/TraceValue.h
+++ b/flow/TraceValue.h
@@ -1,0 +1,141 @@
+/*
+ * TraceValue.h
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2018 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __FLOW_TRACE_VALUE__
+#define __FLOW_TRACE_VALUE__
+#pragma once
+
+#include <string>
+
+// forward declare format from flow.h as we
+// can't include flow.h here
+std::string format(const char* form, ...);
+
+struct TraceBool {
+	bool value;
+
+public:
+	TraceBool() : value(false) {}
+	TraceBool(bool value) : value(value) {}
+
+	std::string toString() const { return format("%d", value); }
+
+	static constexpr size_t heapSize() { return 0; }
+
+	template <class Ar>
+	void serialize(Ar& ar) {
+		serializer(ar, value);
+	}
+};
+
+struct TraceString final {
+	std::string value;
+
+public:
+	TraceString() = default;
+	TraceString(std::string const& value) : value(value) {}
+	std::string toString() const { return value; }
+
+	size_t heapSize() const { return value.size(); }
+
+	template <class Ar>
+	void serialize(Ar& ar) {
+		serializer(ar, value);
+	}
+};
+
+struct TraceNumeric final {
+	std::string value;
+
+public:
+	TraceNumeric() = default;
+	TraceNumeric(std::string const& value) : value(value) {}
+	std::string toString() const { return value; }
+
+	size_t heapSize() const { return value.size(); }
+
+	template <class Ar>
+	void serialize(Ar& ar) {
+		serializer(ar, value);
+	}
+};
+
+struct TraceCounter {
+	double rate;
+	double roughness;
+	int64_t value;
+
+public:
+	TraceCounter() : rate(0.0), roughness(0.0), value(0) {}
+	TraceCounter(double rate, double roughness, int64_t value) : rate(rate), roughness(roughness), value(value) {}
+	std::string toString() const { return format("%g %g %lld", rate, roughness, value); }
+
+	static constexpr size_t heapSize() { return 0; }
+	template <class Ar>
+	void serialize(Ar& ar) {
+		serializer(ar, rate, roughness, value);
+	}
+};
+
+struct TraceValue {
+	std::variant<TraceString, TraceBool, TraceCounter, TraceNumeric> value;
+	template <class T, class... Args>
+	explicit TraceValue(std::in_place_type_t<T> typeId, Args&&... args) : value(typeId, std::forward<Args>(args)...) {}
+
+public:
+	TraceValue(std::string const& value = "") : TraceValue(std::in_place_type<TraceString>, std::move(value)) {}
+
+	template <class T, class... Args>
+	static TraceValue create(Args&&... args) {
+		return TraceValue(std::in_place_type<T>, std::forward<Args>(args)...);
+	}
+	template <class T>
+	T const& get() const& {
+		return std::get<T>(value);
+	}
+	template <class T>
+	T& get() & {
+		return std::get<T>(value);
+	}
+	template <class T>
+	T&& get() && {
+		return std::get<T>(std::move(value));
+	}
+
+	std::string toString() const {
+		return std::visit([](const auto& val) { return val.toString(); }, value);
+	}
+
+	template <class Formatter>
+	std::string format(Formatter const& f) const {
+		return std::visit(f, value);
+	}
+
+	size_t size() const {
+		return sizeof(TraceValue) + std::visit([](auto const& v) { return v.heapSize(); }, value);
+	}
+
+	template <class Ar>
+	void serialize(Ar& ar) {
+		serializer(ar, value);
+	}
+};
+
+#endif

--- a/flow/TraceValue.h
+++ b/flow/TraceValue.h
@@ -25,13 +25,14 @@
 #include <string>
 
 struct TraceBool {
+	constexpr static FileIdentifier file_identifier = 7918345;
 	bool value;
 
 	TraceBool(bool value = false) : value(value) {}
 
 	std::string toString() const;
 
-	static constexpr size_t heapSize() { return 0; }
+	static constexpr size_t size() { return 1; }
 	static constexpr void truncate(int) {}
 
 	template <class Ar>
@@ -41,13 +42,14 @@ struct TraceBool {
 };
 
 struct TraceString final {
+	constexpr static FileIdentifier file_identifier = 8923844;
 	std::string value;
 
 	TraceString(std::string const& value = "") : value(value) {}
 	TraceString(std::string&& value) : value(std::move(value)) {}
 	std::string const& toString() const& { return value; }
 	std::string toString() && { return std::move(value); }
-	size_t heapSize() const { return value.size(); }
+	size_t size() const { return value.size(); }
 	void truncate(int maxFieldLength);
 
 	template <class Ar>
@@ -57,6 +59,7 @@ struct TraceString final {
 };
 
 struct TraceNumeric final {
+	constexpr static FileIdentifier file_identifier = 285900351;
 	std::string value;
 
 	TraceNumeric(std::string const& value = "") : value(value) {}
@@ -64,7 +67,7 @@ struct TraceNumeric final {
 	std::string toString() const& { return value; }
 	std::string toString() && { return std::move(value); }
 
-	size_t heapSize() const { return value.size(); }
+	size_t size() const { return value.size(); }
 	static constexpr void truncate(int) {}
 
 	template <class Ar>
@@ -74,6 +77,7 @@ struct TraceNumeric final {
 };
 
 struct TraceCounter {
+	constexpr static FileIdentifier file_identifier = 19843497;
 	double rate;
 	double roughness;
 	int64_t value;
@@ -82,7 +86,9 @@ struct TraceCounter {
 	TraceCounter(double rate, double roughness, int64_t value) : rate(rate), roughness(roughness), value(value) {}
 
 	std::string toString() const;
-	static constexpr size_t heapSize() { return 0; }
+	size_t size() const {
+		return toString().size();
+	}
 	static constexpr void truncate(int) {}
 
 	template <class Ar>
@@ -92,18 +98,19 @@ struct TraceCounter {
 };
 
 struct TraceVector {
+	constexpr static FileIdentifier file_identifier = 6925899;
 	int maxFieldLength{ -1 };
 	std::vector<struct TraceValue> values;
 
 	TraceVector() = default;
 	void push_back(TraceValue&&);
-	size_t heapSize() const;
+	size_t size() const;
 	void truncate(int maxFieldLength);
 	std::string toString() const;
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, values);
+		serializer(ar, maxFieldLength, values);
 	}
 };
 
@@ -113,6 +120,7 @@ struct TraceValue {
 	explicit TraceValue(std::in_place_type_t<T> typeId, Args&&... args) : value(typeId, std::forward<Args>(args)...) {}
 
 public:
+	constexpr static FileIdentifier file_identifier = 2947802;
 	TraceValue(std::string const& value = "");
 	TraceValue(std::string&& value);
 

--- a/flow/TraceValue.h
+++ b/flow/TraceValue.h
@@ -126,14 +126,17 @@ public:
 	}
 	template <class T>
 	T const& get() const& {
+		ASSERT(std::holds_alternative<T>(value));
 		return std::get<T>(value);
 	}
 	template <class T>
 	T& get() & {
+		ASSERT(std::holds_alternative<T>(value));
 		return std::get<T>(value);
 	}
 	template <class T>
 	T&& get() && {
+		ASSERT(std::holds_alternative<T>(value));
 		return std::get<T>(std::move(value));
 	}
 

--- a/flow/TraceValue.h
+++ b/flow/TraceValue.h
@@ -102,19 +102,22 @@ struct TraceCounter {
 struct TraceVector {
 	constexpr static FileIdentifier file_identifier = 6925899;
 	int maxFieldLength{ -1 };
-	std::vector<struct TraceValue> values;
+	// TODO: Support serialization of recursive types in flatbuffers implementation
+	// so that this can be a std::vector<struct TraceValue>
+	std::vector<std::string> values;
 
 	TraceVector() = default;
-	void push_back(TraceValue&&);
+	template <class U>
+	auto emplace_back(U&& value) {
+		return values.emplace_back(std::forward<U>(value));
+	}
 	size_t size() const;
 	void truncate(int maxFieldLength);
 	std::string toString() const;
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		// FIXME: Fix serialization once flatbuffers implementation supports
-		// recursive types
-		serializer(ar, maxFieldLength);
+		serializer(ar, maxFieldLength, values);
 	}
 };
 

--- a/flow/TraceValue.h
+++ b/flow/TraceValue.h
@@ -46,6 +46,7 @@ struct TraceString final {
 
 	TraceString() = default;
 	TraceString(std::string const& value) : value(value) {}
+	TraceString(std::string&& value) : value(std::move(value)) {}
 	std::string const& toString() const& { return value; }
 	std::string toString() && { return std::move(value); }
 
@@ -68,6 +69,7 @@ struct TraceNumeric final {
 
 	TraceNumeric() = default;
 	TraceNumeric(std::string const& value) : value(value) {}
+	TraceNumeric(std::string&& value) : value(std::move(value)) {}
 	std::string toString() const& { return value; }
 	std::string toString() && { return std::move(value); }
 
@@ -120,7 +122,8 @@ struct TraceValue {
 	explicit TraceValue(std::in_place_type_t<T> typeId, Args&&... args) : value(typeId, std::forward<Args>(args)...) {}
 
 public:
-	TraceValue(std::string const& value = "") : TraceValue(std::in_place_type<TraceString>, std::move(value)) {}
+	TraceValue(std::string const& value = "") : TraceValue(std::in_place_type<TraceString>, value) {}
+	TraceValue(std::string&& value) : TraceValue(std::in_place_type<TraceString>, std::move(value)) {}
 
 	template <class T, class... Args>
 	static TraceValue create(Args&&... args) {

--- a/flow/TraceValue.h
+++ b/flow/TraceValue.h
@@ -46,7 +46,8 @@ struct TraceString final {
 
 	TraceString() = default;
 	TraceString(std::string const& value) : value(value) {}
-	std::string toString() const { return value; }
+	std::string const& toString() const& { return value; }
+	std::string toString() && { return std::move(value); }
 
 	size_t heapSize() const { return value.size(); }
 
@@ -67,7 +68,8 @@ struct TraceNumeric final {
 
 	TraceNumeric() = default;
 	TraceNumeric(std::string const& value) : value(value) {}
-	std::string toString() const { return value; }
+	std::string toString() const& { return value; }
+	std::string toString() && { return std::move(value); }
 
 	size_t heapSize() const { return value.size(); }
 	static constexpr void truncate(int) {}
@@ -140,8 +142,12 @@ public:
 		return std::get<T>(std::move(value));
 	}
 
-	std::string toString() const {
+	std::string toString() const& {
 		return std::visit([](const auto& val) { return val.toString(); }, value);
+	}
+
+	std::string toString() && {
+		return std::visit([](auto&& val) { return std::move(val).toString(); }, value);
 	}
 
 	template <class Formatter>

--- a/flow/TraceValue.h
+++ b/flow/TraceValue.h
@@ -45,8 +45,9 @@ struct TraceString final {
 	constexpr static FileIdentifier file_identifier = 8923844;
 	std::string value;
 
-	TraceString(std::string const& value = "") : value(value) {}
-	TraceString(std::string&& value) : value(std::move(value)) {}
+	TraceString() = default;
+	template <class U, typename std::enable_if_t<!std::is_same_v<std::decay_t<U>, TraceString>, int> = 0>
+	TraceString(U&& value) : value(std::forward<U>(value)) {}
 	std::string const& toString() const& { return value; }
 	std::string toString() && { return std::move(value); }
 	size_t size() const { return value.size(); }
@@ -62,8 +63,9 @@ struct TraceNumeric final {
 	constexpr static FileIdentifier file_identifier = 285900351;
 	std::string value;
 
-	TraceNumeric(std::string const& value = "") : value(value) {}
-	TraceNumeric(std::string&& value) : value(std::move(value)) {}
+	TraceNumeric() = default;
+	template <class U, typename std::enable_if_t<!std::is_same_v<std::decay_t<U>, TraceNumeric>, int> = 0>
+	TraceNumeric(U&& value) : value(std::forward<U>(value)) {}
 	std::string toString() const& { return value; }
 	std::string toString() && { return std::move(value); }
 
@@ -123,8 +125,9 @@ struct TraceValue {
 
 public:
 	constexpr static FileIdentifier file_identifier = 2947802;
-	TraceValue(std::string const& value = "");
-	TraceValue(std::string&& value);
+	TraceValue() : value(TraceString{}) {}
+	template <class U, typename std::enable_if_t<!std::is_same_v<std::decay_t<U>, TraceValue>, int> = 0>
+	TraceValue(U&& value) : value(TraceString(std::forward<U>(value))) {}
 
 	template <class T, class... Args>
 	static TraceValue create(Args&&... args) {

--- a/flow/XmlTraceLogFormatter.h
+++ b/flow/XmlTraceLogFormatter.h
@@ -27,7 +27,8 @@
 #include "flow/FastRef.h"
 #include "flow/Trace.h"
 
-struct XmlTraceLogFormatter : public ITraceLogFormatter, ReferenceCounted<XmlTraceLogFormatter> {
+class XmlTraceLogFormatter : public ITraceLogFormatter, ReferenceCounted<XmlTraceLogFormatter> {
+public:
 	void addref() override;
 	void delref() override;
 

--- a/flow/XmlTraceLogFormatter.h
+++ b/flow/XmlTraceLogFormatter.h
@@ -35,7 +35,6 @@ struct XmlTraceLogFormatter : public ITraceLogFormatter, ReferenceCounted<XmlTra
 	const char* getHeader() override;
 	const char* getFooter() override;
 
-	void escape(std::stringstream& ss, std::string source);
 	std::string formatEvent(const TraceEventFields& fields) override;
 };
 

--- a/flow/network.h
+++ b/flow/network.h
@@ -192,7 +192,7 @@ private:
 
 template <>
 struct Traceable<IPAddress> : std::true_type {
-	static std::string toString(const IPAddress& value) { return value.toString(); }
+	static TraceValue toTraceValue(const IPAddress& value) { return TraceValue(value.toString()); }
 };
 
 struct NetworkAddress {
@@ -265,7 +265,7 @@ struct NetworkAddress {
 
 template <>
 struct Traceable<NetworkAddress> : std::true_type {
-	static std::string toString(const NetworkAddress& value) { return value.toString(); }
+	static TraceValue toTraceValue(const NetworkAddress& value) { return TraceValue(value.toString()); }
 };
 
 namespace std {

--- a/flow/network.h
+++ b/flow/network.h
@@ -192,7 +192,7 @@ private:
 
 template <>
 struct Traceable<IPAddress> : std::true_type {
-	static TraceValue toTraceValue(const IPAddress& value) { return TraceValue(value.toString()); }
+	static TraceValue toTraceValue(const IPAddress& value) { return value.toString(); }
 };
 
 struct NetworkAddress {
@@ -265,7 +265,7 @@ struct NetworkAddress {
 
 template <>
 struct Traceable<NetworkAddress> : std::true_type {
-	static TraceValue toTraceValue(const NetworkAddress& value) { return TraceValue(value.toString()); }
+	static TraceValue toTraceValue(const NetworkAddress& value) { return value.toString(); }
 };
 
 namespace std {

--- a/flowbench/BenchTrace.cpp
+++ b/flowbench/BenchTrace.cpp
@@ -1,0 +1,95 @@
+/*
+ * BenchTrach.cpp
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2020 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "fdbrpc/Stats.h"
+#include "flow/network.h"
+#include "flow/Platform.h"
+#include "flow/Trace.h"
+
+#include "benchmark/benchmark.h"
+
+class SampleTrace {
+	TraceEvent te;
+	int numFields;
+
+	inline std::string fieldKey() { return format("F%d", numFields++); }
+
+public:
+	SampleTrace() : te("Sample"), numFields(0) {}
+	template <class T, class... Args>
+	void createAndDetail(Args&&... args) {
+		te.detail(fieldKey(), T(std::forward<Args>(args)...));
+	}
+	template <class U>
+	void detail(U&& val) {
+		te.detail(fieldKey(), std::forward<U>(val));
+	}
+};
+
+static void bench_trace_simple(benchmark::State& state) {
+	openTraceFile(NetworkAddress(),
+	              TRACE_DEFAULT_ROLL_SIZE,
+	              TRACE_DEFAULT_MAX_LOGS_SIZE,
+	              platform::getWorkingDirectory(),
+	              "trace",
+	              "",
+	              "");
+	while (state.KeepRunning()) {
+		SampleTrace te;
+	}
+	state.SetItemsProcessed(static_cast<long>(state.iterations()));
+}
+
+static void bench_trace(benchmark::State& state) {
+	openTraceFile(NetworkAddress(),
+	              TRACE_DEFAULT_ROLL_SIZE,
+	              TRACE_DEFAULT_MAX_LOGS_SIZE,
+	              platform::getWorkingDirectory(),
+	              "trace",
+	              "",
+	              "");
+	CounterCollection cc("CC");
+	Counter c("C", cc);
+	std::string shortString = ".....";
+	std::string longString(1000, '.');
+	while (state.KeepRunning()) {
+		SampleTrace te;
+		te.createAndDetail<bool>();
+		te.createAndDetail<signed char>();
+		te.createAndDetail<unsigned char>();
+		te.createAndDetail<short>();
+		te.createAndDetail<unsigned short>();
+		te.createAndDetail<int>();
+		te.createAndDetail<unsigned>();
+		te.createAndDetail<long int>();
+		te.createAndDetail<unsigned long int>();
+		te.createAndDetail<long long int>();
+		te.createAndDetail<unsigned long long int>();
+		te.createAndDetail<std::string>();
+		te.createAndDetail<std::string>(1000, '.');
+		te.detail(shortString);
+		te.detail(longString);
+		te.detail(c);
+	}
+	state.SetItemsProcessed(static_cast<long>(state.iterations()));
+}
+
+BENCHMARK(bench_trace_simple)->ReportAggregatesOnly(true);
+BENCHMARK(bench_trace)->ReportAggregatesOnly(true);

--- a/flowbench/BenchTrace.cpp
+++ b/flowbench/BenchTrace.cpp
@@ -18,6 +18,7 @@
  * limitations under the License.
  */
 
+#include "fdbclient/FDBTypes.h"
 #include "fdbrpc/Stats.h"
 #include "flow/network.h"
 #include "flow/Platform.h"
@@ -69,9 +70,13 @@ static void bench_trace(benchmark::State& state) {
 	Counter c("C", cc);
 	std::string shortString = "xxxxx";
 	std::string longString(100, 'x');
-	Standalone<VectorRef<int>> vec;
+	Standalone<VectorRef<int>> vec1;
+	std::vector<int> vec2;
 	for (int i = 0; i < 10; ++i) {
-		vec.push_back(vec.arena(), i);
+		vec1.push_back(vec1.arena(), i);
+	}
+	for (int i = 10; i < 20; ++i) {
+		vec2.push_back(i);
 	}
 	while (state.KeepRunning()) {
 		SampleTrace te;
@@ -91,7 +96,8 @@ static void bench_trace(benchmark::State& state) {
 		te.detail(shortString);
 		te.detail(longString);
 		te.detail(c);
-		te.detail(vec);
+		te.detail(vec1);
+		te.detail(vec2);
 	}
 	state.SetItemsProcessed(static_cast<long>(state.iterations()));
 }

--- a/flowbench/BenchTrace.cpp
+++ b/flowbench/BenchTrace.cpp
@@ -68,7 +68,11 @@ static void bench_trace(benchmark::State& state) {
 	CounterCollection cc("CC");
 	Counter c("C", cc);
 	std::string shortString = "xxxxx";
-	std::string longString(1000, 'x');
+	std::string longString(100, 'x');
+	Standalone<VectorRef<int>> vec;
+	for (int i = 0; i < 10; ++i) {
+		vec.push_back(vec.arena(), i);
+	}
 	while (state.KeepRunning()) {
 		SampleTrace te;
 		te.createAndDetail<bool>();
@@ -83,10 +87,11 @@ static void bench_trace(benchmark::State& state) {
 		te.createAndDetail<long long int>();
 		te.createAndDetail<unsigned long long int>();
 		te.createAndDetail<std::string>();
-		te.createAndDetail<std::string>(1000, '.');
+		te.createAndDetail<std::string>(100, 'x');
 		te.detail(shortString);
 		te.detail(longString);
 		te.detail(c);
+		te.detail(vec);
 	}
 	state.SetItemsProcessed(static_cast<long>(state.iterations()));
 }

--- a/flowbench/BenchTrace.cpp
+++ b/flowbench/BenchTrace.cpp
@@ -67,8 +67,8 @@ static void bench_trace(benchmark::State& state) {
 	              "");
 	CounterCollection cc("CC");
 	Counter c("C", cc);
-	std::string shortString = ".....";
-	std::string longString(1000, '.');
+	std::string shortString = "xxxxx";
+	std::string longString(1000, 'x');
 	while (state.KeepRunning()) {
 		SampleTrace te;
 		te.createAndDetail<bool>();

--- a/flowbench/BenchTrace.cpp
+++ b/flowbench/BenchTrace.cpp
@@ -72,11 +72,15 @@ static void bench_trace(benchmark::State& state) {
 	std::string longString(100, 'x');
 	Standalone<VectorRef<int>> vec1;
 	std::vector<int> vec2;
+	std::set<int> s;
 	for (int i = 0; i < 10; ++i) {
 		vec1.push_back(vec1.arena(), i);
 	}
 	for (int i = 10; i < 20; ++i) {
 		vec2.push_back(i);
+	}
+	for (int i = 20; i < 30; ++i) {
+		s.insert(i);
 	}
 	while (state.KeepRunning()) {
 		SampleTrace te;
@@ -98,6 +102,7 @@ static void bench_trace(benchmark::State& state) {
 		te.detail(c);
 		te.detail(vec1);
 		te.detail(vec2);
+		te.detail(s);
 	}
 	state.SetItemsProcessed(static_cast<long>(state.iterations()));
 }

--- a/flowbench/BenchTrace.cpp
+++ b/flowbench/BenchTrace.cpp
@@ -1,5 +1,5 @@
 /*
- * BenchTrach.cpp
+ * BenchTrace.cpp
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/flowbench/CMakeLists.txt
+++ b/flowbench/CMakeLists.txt
@@ -8,6 +8,7 @@ set(FLOWBENCH_SRCS
   BenchRef.cpp
   BenchStream.actor.cpp
   BenchTimer.cpp
+  BenchTrace.cpp
   GlobalData.h
   GlobalData.cpp)
 

--- a/flowbench/flowbench.actor.cpp
+++ b/flowbench/flowbench.actor.cpp
@@ -44,6 +44,7 @@ int main(int argc, char** argv) {
 	}
 	platformInit();
 	g_network = newNet2(TLSConfig(), false, true);
+	selectTraceFormatter("json");
 	Promise<Void> benchmarksDone;
 	std::thread benchmarkThread([&]() {
 		benchmark::RunSpecifiedBenchmarks();

--- a/flowbench/flowbench.actor.cpp
+++ b/flowbench/flowbench.actor.cpp
@@ -22,6 +22,7 @@
 #include "fdbclient/NativeAPI.actor.h"
 #include "fdbclient/ThreadSafeTransaction.h"
 #include "flow/ThreadHelper.actor.h"
+#include "flow/TLSConfig.actor.h"
 #include <thread>
 
 ACTOR template <class T>
@@ -41,13 +42,14 @@ int main(int argc, char** argv) {
 	if (benchmark::ReportUnrecognizedArguments(argc, argv)) {
 		return 1;
 	}
-	setupNetwork();
+	platformInit();
+	g_network = newNet2(TLSConfig(), false, true);
 	Promise<Void> benchmarksDone;
 	std::thread benchmarkThread([&]() {
 		benchmark::RunSpecifiedBenchmarks();
 		onMainThreadVoid([&]() { benchmarksDone.send(Void()); }, nullptr);
 	});
 	auto f = stopNetworkAfter(benchmarksDone.getFuture());
-	runNetwork();
+	g_network->run();
 	benchmarkThread.join();
 }


### PR DESCRIPTION
This PR supports tracing non-string value fields in JSON tracing.

Changes in this PR:

- Fix a bug in the `flowbench` driver
- Add microbenchmarking for generating trace events
- Various minor tracing performance optimizations to avoid unnecessary copies
- Add a TraceValue class to help the `JsonTraceLogFormatter` differentiate between string value fields and all other fields.
- Support customized tracing for booleans, lists, numbers, counters, and strings

### Style

- [x] All variable and function names make sense.
- [x] The code is properly formatted (consider running `git clang-format`).

### Performance

- [x] All CPU-hot paths are well optimized.
- [x] The proper containers are used (for example `std::vector` vs `VectorRef`).
- [x] There are no new known `SlowTask` traces.

### Testing

- [ ] The code was sufficiently tested in simulation.
- [x] If there are new parameters or knobs, different values are tested in simulation.
- [x] ~`ASSERT`, `ASSERT_WE_THINK`, and `TEST` macros are added in appropriate places.~
- [x] Unit tests were added for new algorithms and data structure that make sense to unit-test
- [x] ~If this is a bugfix: there is a test that can easily reproduce the bug.~
