### PR TITLE
Use only one IP address that matches the hostname

### DIFF
--- a/packaging/docker/create_server_environment.bash
+++ b/packaging/docker/create_server_environment.bash
@@ -23,21 +23,18 @@
 source /var/fdb/scripts/create_cluster_file.bash
 
 function create_server_environment() {
-	fdb_dir=/var/fdb
-	env_file=$fdb_dir/.fdbenv
-
-	: > $env_file
+	env_file=/var/fdb/.fdbenv
 
 	if [[ "$FDB_NETWORKING_MODE" == "host" ]]; then
 		public_ip=127.0.0.1
 	elif [[ "$FDB_NETWORKING_MODE" == "container" ]]; then
-		public_ip=$(grep `hostname` /etc/hosts | sed -e "s/\s *`hostname`.*//")
+		public_ip=$(hostname -i | awk '{print $1}')
 	else
 		echo "Unknown FDB Networking mode \"$FDB_NETWORKING_MODE\"" 1>&2
 		exit 1
 	fi
 
-	echo "export PUBLIC_IP=$public_ip" >> $env_file
+	echo "export PUBLIC_IP=$public_ip" > $env_file
 	if [[ -z $FDB_COORDINATOR && -z "$FDB_CLUSTER_FILE_CONTENTS" ]]; then
 		FDB_CLUSTER_FILE_CONTENTS="docker:docker@$public_ip:$FDB_PORT"
 	fi

--- a/packaging/docker/fdb.bash
+++ b/packaging/docker/fdb.bash
@@ -26,4 +26,4 @@ source /var/fdb/.fdbenv
 echo "Starting FDB server on $PUBLIC_IP:$FDB_PORT"
 fdbserver --listen_address 0.0.0.0:$FDB_PORT --public_address $PUBLIC_IP:$FDB_PORT \
 	--datadir /var/fdb/data --logdir /var/fdb/logs \
-	--locality_zoneid=`hostname` --locality_machineid=`hostname` --class $FDB_PROCESS_CLASS
+	--locality_zoneid="$(hostname)" --locality_machineid="$(hostname)" --class $FDB_PROCESS_CLASS


### PR DESCRIPTION
This PR resolves #4484

Changes in this PR:

- Make use of `hostname -i`  and use only the first IP address

## General guideline:

- If this PR is ready to be merged (and all checkboxes below are either ticked or not applicable), make this a regular PR
- If this PR still needs work, please make this a draft PR
  - If you wish to get feedback/code-review, please add the label RFC to this PR

Please verify that all things listed below were considered and check them. If an item doesn't apply to this type of PR (for example a documentation change doesn't need to be performance tested), you should make a ~~strikethrough~~ (markdown syntax: `~~strikethrough~~`). More infos on the guidlines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

### Style

- [x] ~~All variable and function names make sense.~~
- [x] ~~The code is properly formatted (consider running `git clang-format`).~~

### Performance

- [x] ~~All CPU-hot paths are well optimized.~~~~
- [x] ~~The proper containers are used (for example `std::vector` vs `VectorRef`).~~
- [x] ~~There are no new known `SlowTask` traces.~~

### Testing

- [x] ~~The code was sufficiently tested in simulation.~~
- [x] ~~If there are new parameters or knobs, different values are tested in simulation.~~
- [x] ~~`ASSERT`, `ASSERT_WE_THINK`, and `TEST` macros are added in appropriate places.~~
- [x] ~~Unit tests were added for new algorithms and data structure that make sense to unit-test~~
- [x] ~~If this is a bugfix: there is a test that can easily reproduce the bug.~~
