### PR TITLE
Fixed a bug in isReliable() of a simulated process

### DIFF
--- a/fdbrpc/simulator.h
+++ b/fdbrpc/simulator.h
@@ -105,7 +105,11 @@ public:
 
 		Future<KillType> onShutdown() { return shutdownSignal.getFuture(); }
 
-		bool isReliable() const { return !failed && fault_injection_p1 == 0 && fault_injection_p2 == 0 && !failedDisk; }
+		bool isReliable() const {
+			return !failed && fault_injection_p1 == 0 && fault_injection_p2 == 0 && !failedDisk &&
+			       (!machine || (machine->machineProcess->fault_injection_p1 == 0 &&
+			                     machine->machineProcess->fault_injection_p2 == 0));
+		}
 		bool isAvailable() const { return !isExcluded() && isReliable(); }
 		bool isExcluded() const { return excluded; }
 		bool isCleared() const { return cleared; }


### PR DESCRIPTION
Fixes issue #4445

Changes in this PR:

Injected faults add a fault injection probability to both the process and its machine, however the isReliable() check did not look to see if it was enabled for the machine. This lead to a bug where simulation thought a process was reliable when it was not.

20k correctness tests passed

## General guideline:

- If this PR is ready to be merged (and all checkboxes below are either ticked or not applicable), make this a regular PR
- If this PR still needs work, please make this a draft PR
  - If you wish to get feedback/code-review, please add the label RFC to this PR

Please verify that all things listed below were considered and check them. If an item doesn't apply to this type of PR (for example a documentation change doesn't need to be performance tested), you should make a ~~strikethrough~~ (markdown syntax: `~~strikethrough~~`). More infos on the guidlines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

### Style

- [ ] All variable and function names make sense.
- [ ] The code is properly formatted (consider running `git clang-format`).

### Performance

- [ ] All CPU-hot paths are well optimized.
- [ ] The proper containers are used (for example `std::vector` vs `VectorRef`).
- [ ] There are no new known `SlowTask` traces.

### Testing

- [ ] The code was sufficiently tested in simulation.
- [ ] If there are new parameters or knobs, different values are tested in simulation.
- [ ] `ASSERT`, `ASSERT_WE_THINK`, and `TEST` macros are added in appropriate places.
- [ ] Unit tests were added for new algorithms and data structure that make sense to unit-test
- [ ] If this is a bugfix: there is a test that can easily reproduce the bug.
