### PR TITLE
Execute exclude failed commands after shutting down the rest of data distribution

### DIFF
--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -4950,6 +4950,7 @@ ACTOR Future<Void> monitorBatchLimitedTime(Reference<AsyncVar<ServerDBInfo>> db,
 	}
 }
 
+// Runs the data distribution algorithm for FDB, including the DD Queue, DD tracker, and DD team collection
 ACTOR Future<Void> dataDistribution(Reference<DataDistributorData> self,
                                     PromiseStream<GetMetricsListRequest> getShardMetricsList,
                                     const DDEnabledState* ddEnabledState) {
@@ -5266,12 +5267,14 @@ ACTOR Future<Void> dataDistribution(Reference<DataDistributorData> self,
 				wait(removeKeysFromFailedServer(cx, removeFailedServer.getFuture().get(), lock, ddEnabledState));
 				wait(removeStorageServer(cx, removeFailedServer.getFuture().get(), lock, ddEnabledState));
 			} else {
-				if (err.code() != error_code_movekeys_conflict)
+				if (err.code() != error_code_movekeys_conflict) {
 					throw err;
+				}
 				bool ddEnabled = wait(isDataDistributionEnabled(cx, ddEnabledState));
 				TraceEvent("DataDistributionMoveKeysConflict").detail("DataDistributionEnabled", ddEnabled).error(err);
-				if (ddEnabled)
+				if (ddEnabled) {
 					throw err;
+				}
 			}
 		}
 	}

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -5259,7 +5259,9 @@ ACTOR Future<Void> dataDistribution(Reference<DataDistributorData> self,
 			primaryTeamCollection = Reference<DDTeamCollection>();
 			remoteTeamCollection = Reference<DDTeamCollection>();
 			wait(shards.clearAsync());
+			TraceEvent("DataDistributorTeamCollectionsDestroyed").error(err);
 			if (removeFailedServer.getFuture().isReady() && !removeFailedServer.getFuture().isError()) {
+				TraceEvent("RemoveFailedServer", removeFailedServer.getFuture().get()).error(err);
 				wait(removeKeysFromFailedServer(cx, removeFailedServer.getFuture().get(), lock, ddEnabledState));
 			}
 			if (err.code() != error_code_movekeys_conflict)

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -5692,7 +5692,8 @@ std::unique_ptr<DDTeamCollection> testTeamCollection(int teamSize,
 	                                                           makeReference<AsyncVar<bool>>(true),
 	                                                           true,
 	                                                           makeReference<AsyncVar<bool>>(false),
-	                                                           PromiseStream<GetMetricsRequest>()));
+	                                                           PromiseStream<GetMetricsRequest>(),
+	                                                           Promise<UID>()));
 
 	for (int id = 1; id <= processCount; ++id) {
 		UID uid(id, 0);
@@ -5733,7 +5734,8 @@ std::unique_ptr<DDTeamCollection> testMachineTeamCollection(int teamSize,
 	                                                           makeReference<AsyncVar<bool>>(true),
 	                                                           true,
 	                                                           makeReference<AsyncVar<bool>>(false),
-	                                                           PromiseStream<GetMetricsRequest>()));
+	                                                           PromiseStream<GetMetricsRequest>(),
+	                                                           Promise<UID>()));
 
 	for (int id = 1; id <= processCount; id++) {
 		UID uid(id, 0);

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -4144,12 +4144,12 @@ ACTOR Future<Void> storageServerTracker(
 				status.isUndesired = true;
 				status.isWrongConfiguration = true;
 				if (worstStatus == DDTeamCollection::Status::FAILED) {
-					while (!ddEnabledState->isDDEnabled()) {
-						wait(delay(1.0));
-					}
 					TraceEvent(SevWarn, "FailedServerRemoveKeys", self->distributorId)
 					    .detail("Server", server->id)
 					    .detail("Excluded", worstAddr.toString());
+					while (!ddEnabledState->isDDEnabled()) {
+						wait(delay(1.0));
+					}
 					if (self->removeFailedServer.canBeSet()) {
 						self->removeFailedServer.send(server->id);
 					}

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -4147,6 +4147,7 @@ ACTOR Future<Void> storageServerTracker(
 					TraceEvent(SevWarn, "FailedServerRemoveKeys", self->distributorId)
 					    .detail("Server", server->id)
 					    .detail("Excluded", worstAddr.toString());
+					wait(delay(0.0)); //Do not throw an error while still inside trackExcludedServers
 					while (!ddEnabledState->isDDEnabled()) {
 						wait(delay(1.0));
 					}

--- a/fdbserver/DataDistribution.actor.h
+++ b/fdbserver/DataDistribution.actor.h
@@ -178,7 +178,6 @@ public:
 	void moveShard(KeyRangeRef keys, std::vector<Team> destinationTeam);
 	void finishMove(KeyRangeRef keys);
 	void check();
-	void eraseServer(UID ssID);
 
 private:
 	struct OrderByTeamKey {

--- a/fdbserver/DataDistributionTracker.actor.cpp
+++ b/fdbserver/DataDistributionTracker.actor.cpp
@@ -999,10 +999,6 @@ void ShardsAffectedByTeamFailure::erase(Team team, KeyRange const& range) {
 	}
 }
 
-void ShardsAffectedByTeamFailure::eraseServer(UID ssID) {
-	storageServerShards[ssID] = 0;
-}
-
 void ShardsAffectedByTeamFailure::insert(Team team, KeyRange const& range) {
 	if (team_shards.insert(std::pair<Team, KeyRange>(team, range)).second) {
 		for (auto uid = team.servers.begin(); uid != team.servers.end(); ++uid)


### PR DESCRIPTION
This PR resolves #4440

Changes in this PR:

Exclude failed modifies the keyServers key space directly, however it does not prevent modifications happening in parallel from the data distribution queue. This means data distribution can end up with a state in the database that does not match its in memory state. For example, if a relocate shard has a start move keys complete, but the before finish move keys completes one of the destination servers is removed, that relocation will never complete.

This PR executes excludes fails after shutting down the data distribution queue, to prevent any inconsistency between the two different operations.

20k correctness passed

## General guideline:

- If this PR is ready to be merged (and all checkboxes below are either ticked or not applicable), make this a regular PR
- If this PR still needs work, please make this a draft PR
  - If you wish to get feedback/code-review, please add the label RFC to this PR

Please verify that all things listed below were considered and check them. If an item doesn't apply to this type of PR (for example a documentation change doesn't need to be performance tested), you should make a ~~strikethrough~~ (markdown syntax: `~~strikethrough~~`). More infos on the guidlines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

### Style

- [ ] All variable and function names make sense.
- [ ] The code is properly formatted (consider running `git clang-format`).

### Performance

- [ ] All CPU-hot paths are well optimized.
- [ ] The proper containers are used (for example `std::vector` vs `VectorRef`).
- [ ] There are no new known `SlowTask` traces.

### Testing

- [ ] The code was sufficiently tested in simulation.
- [ ] If there are new parameters or knobs, different values are tested in simulation.
- [ ] `ASSERT`, `ASSERT_WE_THINK`, and `TEST` macros are added in appropriate places.
- [ ] Unit tests were added for new algorithms and data structure that make sense to unit-test
- [ ] If this is a bugfix: there is a test that can easily reproduce the bug.
