### PR TITLE
Fix the link title in a 6.2.33 release note

### DIFF
--- a/documentation/sphinx/source/release-notes/release-notes-620.rst
+++ b/documentation/sphinx/source/release-notes/release-notes-620.rst
@@ -6,7 +6,7 @@ Release Notes
 
 6.2.33
 ======
-* Fixed an issue where storage servers could shutdown with ``unknown_error``. `(PR #4380) <https://github.com/apple/foundationdb/pull/4437>`_
+* Fixed an issue where storage servers could shutdown with ``unknown_error``. `(PR #4437) <https://github.com/apple/foundationdb/pull/4437>`_
 * Fix backup agent stall when writing to local filesystem with slow metadata operations. `(PR #4428) <https://github.com/apple/foundationdb/pull/4428>`_
 * Backup agent no longer uses 4k block caching layer on local output files so that write operations are larger. `(PR #4428) <https://github.com/apple/foundationdb/pull/4428>`_
 


### PR DESCRIPTION
The 6.2 release notes had a link with a bad title (wrong PR number). This seemingly broke the build on release-6.3 during the final merge up (or maybe it was a coincidental transient error?), so I've already fixed in the release-6.3 merge PR (#4496) and it's soon to be merged to master. This is backporting the fix to release-6.2.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
