### PR TITLE
Add versionstamp serialization endianness to API documentation

### DIFF
--- a/documentation/sphinx/source/api-common.rst.inc
+++ b/documentation/sphinx/source/api-common.rst.inc
@@ -136,7 +136,8 @@
     Transforms ``param`` using a versionstamp for the transaction. This parameter must be at least 14 bytes long. The final 4 bytes will be interpreted as a 32-bit little-endian integer denoting an index into the parameter at which to perform the transformation, and then trimmed off the key. The 10 bytes in the parameter beginning at the index will be overwritten with the versionstamp. If the index plus 10 bytes points past the end of the parameter, the result will be an error. Sets ``key`` in the database to the transformed parameter.
 
 .. |atomic-versionstamps-1| replace::
-    A versionstamp is a 10 byte, unique, monotonically (but not sequentially) increasing value for each committed transaction. The first 8 bytes are the committed version of the database. The last 2 bytes are monotonic in the serialization order for transactions.
+    A versionstamp is a 10 byte, unique, monotonically (but not sequentially) increasing value for each committed transaction. The first 8 bytes are the committed version of the database (serialized in big-endian order). The last 2 bytes are monotonic in the serialization order for transactions (serialized in big-endian order).
+
 
 .. |atomic-versionstamps-2| replace::
     A transaction is not permitted to read any transformed key or value previously set within that transaction, and an attempt to do so will result in an ``accessed_unreadable`` error.  The range of keys marked unreadable when setting a versionstamped key begins at the transactions's read version if it is known, otherwise a versionstamp of all ``0x00`` bytes is conservatively assumed.  The upper bound of the unreadable range is a versionstamp of all ``0xFF`` bytes.


### PR DESCRIPTION
This is a small documentation change adding information about the endianness of serialized versionstamps. Currently this info is missing from the C, Python, and Ruby APIs. The Java documentation contains endianness info for versionstamps (see https://apple.github.io/foundationdb/javadoc/com/apple/foundationdb/MutationType.html#SET_VERSIONSTAMPED_KEY), as does the Go documentation (https://pkg.go.dev/github.com/apple/foundationdb/bindings/go/src/fdb?utm_source=godoc#Transaction.SetVersionstampedKey).

This PR is a low risk change (documentation change only) and would help developers using the API as a reference when using versionstamps. For example, I spent more than a few hours recently debugging why my versions were incorrect because the C API did not state versionstamps are written in big-endian order. Without this change, we would have to wait until 7.0 for the documentation to be updated.

See #4478.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [x] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [x] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [x] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
