### PR TITLE
Fix markdown of PR template

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -6,13 +6,13 @@ The general guidelines can be found [here](https://github.com/apple/foundationdb
 
 Please check each of the following things and check *all* boxes before accepting a PR.
 
-[ ] The PR has a description, explaining both the problem and the solution.
-[ ] The description mentions which forms of testing were done and the testing seems reasonable.
-[ ] Every function/class/actor that was touched is reasonably well documented.
+- [ ] The PR has a description, explaining both the problem and the solution.
+- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
+- [ ] Every function/class/actor that was touched is reasonably well documented.
 
 ## For Release-Branches
 
 If this PR is made against a release-branch, please also check the following:
 
-[ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
-[ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
+- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
+- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)


### PR DESCRIPTION
So I got the markdown for the PR template wrong :( This fixes it. I tested this by copy&pasting it into a GitHub PR and checked that the preview looked correct.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
