### PR TITLE
fix memory leak when sending never() to a ReplyPromise()

### DIFF
--- a/fdbrpc/fdbrpc.h
+++ b/fdbrpc/fdbrpc.h
@@ -121,6 +121,9 @@ public:
 	void sendError(const E& exc) const {
 		sav->sendError(exc);
 	}
+	void sendNever() const {
+		sendError(never_reply());
+	}
 
 	Future<T> getFuture() const {
 		sav->addFutureRef();

--- a/fdbrpc/fdbrpc.h
+++ b/fdbrpc/fdbrpc.h
@@ -121,6 +121,8 @@ public:
 	void sendError(const E& exc) const {
 		sav->sendError(exc);
 	}
+	// Call this function when a server will never send a reply to avoid sending
+	// a broken_promise when the ReplyPromise is destroyed
 	void sendNever() const {
 		sendError(never_reply());
 	}

--- a/fdbrpc/networksender.actor.h
+++ b/fdbrpc/networksender.actor.h
@@ -37,6 +37,9 @@ void networkSender(Future<T> input, Endpoint endpoint) {
 		FlowTransport::transport().sendUnreliable(SerializeSource<ErrorOr<EnsureTable<T>>>(value), endpoint, false);
 	} catch (Error& err) {
 		// if (err.code() == error_code_broken_promise) return;
+		if (err.code() == error_code_never_reply) {
+			return;
+		}
 		ASSERT(err.code() != error_code_actor_cancelled);
 		FlowTransport::transport().sendUnreliable(SerializeSource<ErrorOr<EnsureTable<T>>>(err), endpoint, false);
 	}

--- a/fdbrpc/networksender.actor.h
+++ b/fdbrpc/networksender.actor.h
@@ -30,6 +30,7 @@
 #include "flow/flow.h"
 #include "flow/actorcompiler.h" // This must be the last #include.
 
+// This actor is used by FlowTransport to serialize the response to a ReplyPromise across the network
 ACTOR template <class T>
 void networkSender(Future<T> input, Endpoint endpoint) {
 	try {

--- a/fdbserver/ClusterController.actor.cpp
+++ b/fdbserver/ClusterController.actor.cpp
@@ -2477,7 +2477,7 @@ void registerWorker(RegisterWorkerRequest req, ClusterControllerData* self) {
 		checkOutstandingRequests(self);
 	} else if (info->second.details.interf.id() != w.id() || req.generation >= info->second.gen) {
 		if (!info->second.reply.isSet()) {
-			info->second.reply.send(Never());
+			info->second.reply.sendNever();
 		}
 		info->second.reply = req.reply;
 		info->second.details.processClass = newProcessClass;

--- a/fdbserver/LogRouter.actor.cpp
+++ b/fdbserver/LogRouter.actor.cpp
@@ -517,7 +517,7 @@ ACTOR Future<Void> logRouterPeekMessages(LogRouterData* self, TLogPeekRequest re
 		    .detail("Begin", req.begin)
 		    .detail("Popped", poppedVer)
 		    .detail("Start", self->startVersion);
-		req.reply.send(Never());
+		req.reply.sendNever();
 		if (req.sequence.present()) {
 			auto& trackerData = self->peekTracker[peekId];
 			auto& sequenceData = trackerData.sequence_version[sequence + 1];

--- a/fdbserver/OldTLogServer_6_0.actor.cpp
+++ b/fdbserver/OldTLogServer_6_0.actor.cpp
@@ -1743,7 +1743,7 @@ ACTOR Future<Void> respondToRecovered(TLogInterface tli, Promise<Void> recoveryC
 		if (finishedRecovery) {
 			req.reply.send(Void());
 		} else {
-			req.reply.send(Never());
+			req.reply.sendNever();
 		}
 	}
 }

--- a/fdbserver/OldTLogServer_6_2.actor.cpp
+++ b/fdbserver/OldTLogServer_6_2.actor.cpp
@@ -2173,7 +2173,7 @@ ACTOR Future<Void> respondToRecovered(TLogInterface tli, Promise<Void> recoveryC
 		if (finishedRecovery) {
 			req.reply.send(Void());
 		} else {
-			req.reply.send(Never());
+			req.reply.sendNever();
 		}
 	}
 }

--- a/fdbserver/Resolver.actor.cpp
+++ b/fdbserver/Resolver.actor.cpp
@@ -307,13 +307,13 @@ ACTOR Future<Void> resolveBatch(Reference<Resolver> self, ResolveTransactionBatc
 			req.reply.send(batchItr->second);
 		} else {
 			TEST(true); // No outstanding batches for version on proxy
-			req.reply.send(Never());
+			req.reply.sendNever();
 		}
 	} else {
 		ASSERT_WE_THINK(false); // The first non-duplicate request with this proxyAddress, including this one, should
 		                        // have inserted this item in the map!
 		// TEST(true); // No prior proxy requests
-		req.reply.send(Never());
+		req.reply.sendNever();
 	}
 
 	++self->resolveBatchOut;

--- a/fdbserver/TLogServer.actor.cpp
+++ b/fdbserver/TLogServer.actor.cpp
@@ -2242,7 +2242,7 @@ ACTOR Future<Void> respondToRecovered(TLogInterface tli, Promise<Void> recoveryC
 		if (finishedRecovery) {
 			req.reply.send(Void());
 		} else {
-			req.reply.send(Never());
+			req.reply.sendNever();
 		}
 	}
 }

--- a/fdbserver/masterserver.actor.cpp
+++ b/fdbserver/masterserver.actor.cpp
@@ -629,10 +629,10 @@ ACTOR Future<Standalone<CommitTransactionRef>> provisionalMaster(Reference<Maste
 				rep.metadataVersion = metadataVersion;
 				req.reply.send(rep);
 			} else
-				req.reply.send(Never()); // We can't perform causally consistent reads without recovering
+				req.reply.sendNever(); // We can't perform causally consistent reads without recovering
 		}
 		when(CommitTransactionRequest req = waitNext(parent->provisionalCommitProxies[0].commit.getFuture())) {
-			req.reply.send(Never()); // don't reply (clients always get commit_unknown_result)
+			req.reply.sendNever(); // don't reply (clients always get commit_unknown_result)
 			auto t = &req.transaction;
 			if (t->read_snapshot == parent->lastEpochEnd && //< So no transactions can fall between the read snapshot
 			                                                // and the recovery transaction this (might) be merged with
@@ -662,7 +662,7 @@ ACTOR Future<Standalone<CommitTransactionRef>> provisionalMaster(Reference<Maste
 		}
 		when(GetKeyServerLocationsRequest req =
 		         waitNext(parent->provisionalCommitProxies[0].getKeyServersLocations.getFuture())) {
-			req.reply.send(Never());
+			req.reply.sendNever();
 		}
 		when(wait(waitCommitProxyFailure)) { throw worker_removed(); }
 		when(wait(waitGrvProxyFailure)) { throw worker_removed(); }
@@ -1097,7 +1097,7 @@ ACTOR Future<Void> getVersion(Reference<MasterData> self, GetCommitVersionReques
 
 	if (proxyItr == self->lastCommitProxyVersionReplies.end()) {
 		// Request from invalid proxy (e.g. from duplicate recruitment request)
-		req.reply.send(Never());
+		req.reply.sendNever();
 		return Void();
 	}
 
@@ -1113,7 +1113,7 @@ ACTOR Future<Void> getVersion(Reference<MasterData> self, GetCommitVersionReques
 		            // implementation
 		ASSERT(req.requestNum <
 		       proxyItr->second.latestRequestNum.get()); // The latest request can never be acknowledged
-		req.reply.send(Never());
+		req.reply.sendNever();
 	} else {
 		GetCommitVersionReply rep;
 

--- a/flow/error_definitions.h
+++ b/flow/error_definitions.h
@@ -79,6 +79,7 @@ ERROR( broken_promise, 1100, "Broken promise" )
 ERROR( operation_cancelled, 1101, "Asynchronous operation cancelled" )
 ERROR( future_released, 1102, "Future has been released" )
 ERROR( connection_leaked, 1103, "Connection object leaked" )
+ERROR( never_reply, 1104, "Never reply to the request" )
 
 ERROR( recruitment_failed, 1200, "Recruitment of a server failed" )   // Be careful, catching this will delete the data of a storage server or tlog permanently
 ERROR( move_to_removed_server, 1201, "Attempt to move keys to a storage server that was removed" )


### PR DESCRIPTION
Fixes #4482

The PR adds a sendNever() to reply promise, which avoid leaking void actors.

Passed 20k correctness test. 1 failure happened, but that bug reproduced on master without this PR.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
