### PR TITLE
Port lost changes from PR #4004

### DIFF
--- a/fdbserver/CommitProxyServer.actor.cpp
+++ b/fdbserver/CommitProxyServer.actor.cpp
@@ -569,7 +569,7 @@ ACTOR Future<Void> preresolutionProcessing(CommitBatchContext* self) {
 	if (self->localBatchNumber - self->pProxyCommitData->latestLocalCommitBatchResolving.get() >
 	        SERVER_KNOBS->RESET_MASTER_BATCHES &&
 	    now() - self->pProxyCommitData->lastMasterReset > SERVER_KNOBS->RESET_MASTER_DELAY) {
-		TraceEvent(SevWarnAlways, "ResetMasterNetwork")
+		TraceEvent(SevWarnAlways, "ResetMasterNetwork", self->pProxyCommitData->dbgid)
 		    .detail("CurrentBatch", self->localBatchNumber)
 		    .detail("InProcessBatch", self->pProxyCommitData->latestLocalCommitBatchResolving.get());
 		FlowTransport::transport().resetConnection(self->pProxyCommitData->master.address());
@@ -687,10 +687,11 @@ ACTOR Future<Void> getResolution(CommitBatchContext* self) {
 	if (self->localBatchNumber - self->pProxyCommitData->latestLocalCommitBatchLogging.get() >
 	        SERVER_KNOBS->RESET_RESOLVER_BATCHES &&
 	    now() - self->pProxyCommitData->lastResolverReset > SERVER_KNOBS->RESET_RESOLVER_DELAY) {
-		TraceEvent(SevWarnAlways, "ResetResolverNetwork")
-		    .detail("CurrentBatch", self->localBatchNumber)
-		    .detail("InProcessBatch", self->pProxyCommitData->latestLocalCommitBatchLogging.get());
 		for (int r = 0; r < self->pProxyCommitData->resolvers.size(); r++) {
+			TraceEvent(SevWarnAlways, "ResetResolverNetwork", self->pProxyCommitData->dbgid)
+			    .detail("PeerAddr", self->pProxyCommitData->resolvers[r].address())
+			    .detail("CurrentBatch", self->localBatchNumber)
+			    .detail("InProcessBatch", self->pProxyCommitData->latestLocalCommitBatchLogging.get());
 			FlowTransport::transport().resetConnection(self->pProxyCommitData->resolvers[r].address());
 		}
 		self->pProxyCommitData->lastResolverReset = now();


### PR DESCRIPTION
The problem is described in https://github.com/apple/foundationdb/issues/4426.

MasterProxyServer.actor.cpp on master is replaced with CommitProxyServer.actor.cpp and GrvProxyServer.actor.cpp and changes in #4004 is lost.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [x] Every function/class/actor that was touched is reasonably well documented.


