### PR TITLE
Fix data race in fdb_get_server_protocol

### DIFF
--- a/bindings/c/test/unit/unit_tests.cpp
+++ b/bindings/c/test/unit/unit_tests.cpp
@@ -40,6 +40,8 @@
 #include "doctest.h"
 #include "fdbclient/rapidjson/document.h"
 
+#include "flow/config.h"
+
 #include "fdb_api.hpp"
 
 void fdb_check(fdb_error_t e) {
@@ -1965,6 +1967,11 @@ std::string get_valid_status_json() {
 }
 
 TEST_CASE("fdb_database_reboot_worker") {
+#ifdef USE_TSAN
+	MESSAGE(
+	    "fdb_database_reboot_worker disabled for tsan, since fdbmonitor doesn't seem to restart the killed process");
+	return;
+#endif
 	std::string status_json = get_valid_status_json();
 	rapidjson::Document statusJson;
 	statusJson.Parse(status_json.c_str());

--- a/bindings/c/test/unit/unit_tests.cpp
+++ b/bindings/c/test/unit/unit_tests.cpp
@@ -1520,7 +1520,10 @@ TEST_CASE("fdb_get_server_protocol") {
 	fdb_future_destroy(protocolFuture);
 
 	// "Default" cluster file version
-	fdb_future_destroy(fdb_get_server_protocol(nullptr));
+	protocolFuture = fdb_get_server_protocol(nullptr);
+	fdb_check(fdb_future_block_until_ready(protocolFuture));
+	fdb_check(fdb_future_get_uint64(protocolFuture, &out));
+	fdb_future_destroy(protocolFuture);
 }
 
 TEST_CASE("fdb_transaction_watch read_your_writes_disable") {

--- a/bindings/c/test/unit/unit_tests.cpp
+++ b/bindings/c/test/unit/unit_tests.cpp
@@ -1511,12 +1511,16 @@ TEST_CASE("fdb_transaction_get_approximate_size") {
 }
 
 TEST_CASE("fdb_get_server_protocol") {
+	// We don't really have any expectations other than "don't crash" here
 	FDBFuture* protocolFuture = fdb_get_server_protocol(clusterFilePath.c_str());
 	uint64_t out;
 
 	fdb_check(fdb_future_block_until_ready(protocolFuture));
 	fdb_check(fdb_future_get_uint64(protocolFuture, &out));
 	fdb_future_destroy(protocolFuture);
+
+	// "Default" cluster file version
+	fdb_future_destroy(fdb_get_server_protocol(nullptr));
 }
 
 TEST_CASE("fdb_transaction_watch read_your_writes_disable") {

--- a/fdbclient/ThreadSafeTransaction.cpp
+++ b/fdbclient/ThreadSafeTransaction.cpp
@@ -402,10 +402,11 @@ const char* ThreadSafeApi::getClientVersion() {
 }
 
 ThreadFuture<uint64_t> ThreadSafeApi::getServerProtocol(const char* clusterFilePath) {
-	auto [clusterFile, isDefault] = ClusterConnectionFile::lookupClusterFileName(std::string(clusterFilePath));
-
-	Reference<ClusterConnectionFile> f = Reference<ClusterConnectionFile>(new ClusterConnectionFile(clusterFile));
-	return onMainThread([f]() -> Future<uint64_t> { return getCoordinatorProtocols(f); });
+	return onMainThread([clusterFilePath = std::string(clusterFilePath)]() -> Future<uint64_t> {
+		auto [clusterFile, isDefault] = ClusterConnectionFile::lookupClusterFileName(clusterFilePath);
+		Reference<ClusterConnectionFile> f = Reference<ClusterConnectionFile>(new ClusterConnectionFile(clusterFile));
+		return getCoordinatorProtocols(f);
+	});
 }
 
 void ThreadSafeApi::setNetworkOption(FDBNetworkOptions::Option option, Optional<StringRef> value) {

--- a/fdbclient/ThreadSafeTransaction.cpp
+++ b/fdbclient/ThreadSafeTransaction.cpp
@@ -401,6 +401,8 @@ const char* ThreadSafeApi::getClientVersion() {
 	return clientVersion.c_str();
 }
 
+// Wait until a quorum of coordinators with the same protocol version are available, and then return that protocol
+// version.
 ThreadFuture<uint64_t> ThreadSafeApi::getServerProtocol(const char* clusterFilePath) {
 	return onMainThread([clusterFilePath = std::string(clusterFilePath)]() -> Future<uint64_t> {
 		auto [clusterFile, isDefault] = ClusterConnectionFile::lookupClusterFileName(clusterFilePath);

--- a/flow/Net2.actor.cpp
+++ b/flow/Net2.actor.cpp
@@ -221,6 +221,7 @@ public:
 	uint64_t tasksIssued;
 	TDMetricCollection tdmetrics;
 	double currentTime;
+	// May be accessed off the network thread, e.g. by onMainThread
 	std::atomic<bool> stopped;
 	mutable std::map<IPAddress, bool> addressOnHostCache;
 

--- a/flow/Net2.actor.cpp
+++ b/flow/Net2.actor.cpp
@@ -221,7 +221,7 @@ public:
 	uint64_t tasksIssued;
 	TDMetricCollection tdmetrics;
 	double currentTime;
-	bool stopped;
+	std::atomic<bool> stopped;
 	mutable std::map<IPAddress, bool> addressOnHostCache;
 
 	std::atomic<bool> started;


### PR DESCRIPTION
Fix a data race in the new fdb_get_server_protocol function found by running its unit test under TSAN. TSAN confirmed the fix as well.

```
2: WARNING: ThreadSanitizer: data race (pid=47)
2:   Write of size 4 at 0x7b1c00000770 by thread T1:
2:     #0 ThreadUnsafeReferenceCounted<ClusterConnectionFile>::addref() const /home/anoyes/workspace/foundationdb/flow/FastRef.h:71:24 (libfdb_c.so+0x4b93aa)
2:     #1 void addref<ClusterConnectionFile>(ClusterConnectionFile*) /home/anoyes/workspace/foundationdb/flow/FastRef.h:94:7 (libfdb_c.so+0x4b93aa)
2:     #2 Reference<ClusterConnectionFile>::Reference(Reference<ClusterConnectionFile> const&) /home/anoyes/workspace/foundationdb/flow/FastRef.h:114:4 (libfdb_c.so+0x4b93aa)
2:     #3 (anonymous namespace)::GetCoordinatorProtocolsActorState<(anonymous namespace)::GetCoordinatorProtocolsActor>::GetCoordinatorProtocolsActorState(Reference<ClusterConnectionFile> const&) /home/anoyes/workspace/foundationdb/fdbclient/NativeAPI.actor.cpp:4877:4 (libfdb_c.so+0x4b93aa)
2:     #4 (anonymous namespace)::GetCoordinatorProtocolsActor::GetCoordinatorProtocolsActor(Reference<ClusterConnectionFile> const&) /home/anoyes/build/foundationdb-tsan/fdbclient/NativeAPI.actor.g.cpp:22966:6 (libfdb_c.so+0x4b93aa)
2:     #5 getCoordinatorProtocols(Reference<ClusterConnectionFile> const&) /home/anoyes/workspace/foundationdb/fdbclient/NativeAPI.actor.cpp:4877:30 (libfdb_c.so+0x4b93aa)
2:     #6 ThreadSafeApi::getServerProtocol(char const*)::$_36::operator()() const /home/anoyes/workspace/foundationdb/fdbclient/ThreadSafeTransaction.cpp:408:57 (libfdb_c.so+0xb84ec7)
2:     #7 (anonymous namespace)::DoOnMainThreadActorState<unsigned long, ThreadSafeApi::getServerProtocol(char const*)::$_36, (anonymous namespace)::DoOnMainThreadActor<unsigned long, ThreadSafeApi::getServerProtocol(char const*)::$_36> >::a_body1cont2(Void const&, int) /home/anoyes/workspace/foundationdb/flow/ThreadHelper.actor.h:539:34 (libfdb_c.so+0xb84ec7)
2:     #8 (anonymous namespace)::DoOnMainThreadActorState<unsigned long, ThreadSafeApi::getServerProtocol(char const*)::$_36, (anonymous namespace)::DoOnMainThreadActor<unsigned long, ThreadSafeApi::getServerProtocol(char const*)::$_36> >::a_body1when1(Void const&, int) /home/anoyes/build/foundationdb-tsan/flow/ThreadHelper.actor.g.h:674:15 (libfdb_c.so+0xb84ec7)
2:     #9 (anonymous namespace)::DoOnMainThreadActorState<unsigned long, ThreadSafeApi::getServerProtocol(char const*)::$_36, (anonymous namespace)::DoOnMainThreadActor<unsigned long, ThreadSafeApi::getServerProtocol(char const*)::$_36> >::a_callback_fire(ActorCallback<(anonymous namespace)::DoOnMainThreadActor<unsigned long, ThreadSafeApi::getServerProtocol(char const*)::$_36>, 0, Void>*, Void const&) /home/anoyes/build/foundationdb-tsan/flow/ThreadHelper.actor.g.h:695:4 (libfdb_c.so+0xb8479d)
2:     #10 ActorCallback<(anonymous namespace)::DoOnMainThreadActor<unsigned long, ThreadSafeApi::getServerProtocol(char const*)::$_36>, 0, Void>::fire(Void const&) /home/anoyes/workspace/foundationdb/flow/flow.h:1016:78 (libfdb_c.so+0xb8479d)
2:     #11 void SAV<Void>::send<Void>(Void&&) /home/anoyes/workspace/foundationdb/flow/flow.h:465:23 (libfdb_c.so+0x4086b2)
2:     #12 void Promise<Void>::send<Void>(Void&&) const /home/anoyes/workspace/foundationdb/flow/flow.h:782:8 (libfdb_c.so+0xcc058e)
2:     #13 N2::PromiseTask::operator()() /home/anoyes/workspace/foundationdb/flow/Net2.actor.cpp:1157:11 (libfdb_c.so+0xcc058e)
2:     #14 N2::Net2::run() /home/anoyes/workspace/foundationdb/flow/Net2.actor.cpp:1493:5 (libfdb_c.so+0xca13b0)
2:     #15 runNetwork() /home/anoyes/workspace/foundationdb/fdbclient/NativeAPI.actor.cpp:1774:13 (libfdb_c.so+0x499eb4)
2:     #16 ThreadSafeApi::runNetwork() /home/anoyes/workspace/foundationdb/fdbclient/ThreadSafeTransaction.cpp:428:3 (libfdb_c.so+0xb6661c)
2:     #17 MultiVersionApi::runNetwork() /home/anoyes/workspace/foundationdb/fdbclient/MultiVersionTransaction.actor.cpp:1521:20 (libfdb_c.so+0x41e9dd)
2:     #18 fdb_run_network /home/anoyes/workspace/foundationdb/bindings/c/fdb_c.cpp:129:45 (libfdb_c.so+0x3f7645)
2:     #19 decltype(std::__1::forward<int (*)()>(fp)()) std::__1::__invoke<int (*)()>(int (*&&)()) /usr/local/bin/../include/c++/v1/type_traits:3539:173 (fdb_c_unit_tests+0x384856)
2:     #20 void std::__1::__thread_execute<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, int (*)()>(std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, int (*)()>&, std::__1::__tuple_indices<>) /usr/local/bin/../include/c++/v1/thread:273:5 (fdb_c_unit_tests+0x384856)
2:     #21 void* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, int (*)()> >(void*) /usr/local/bin/../include/c++/v1/thread:284:5 (fdb_c_unit_tests+0x384856)
2: 
2:   Previous write of size 4 at 0x7b1c00000770 by main thread:
2:     #0 ThreadUnsafeReferenceCounted<ClusterConnectionFile>::delref_no_destroy() const /home/anoyes/workspace/foundationdb/flow/FastRef.h:76:43 (libfdb_c.so+0x6455e4)
2:     #1 ThreadUnsafeReferenceCounted<ClusterConnectionFile>::delref() const /home/anoyes/workspace/foundationdb/flow/FastRef.h:73:7 (libfdb_c.so+0x6455e4)
2:     #2 void delref<ClusterConnectionFile>(ClusterConnectionFile*) /home/anoyes/workspace/foundationdb/flow/FastRef.h:99:7 (libfdb_c.so+0x6455e4)
2:     #3 Reference<ClusterConnectionFile>::~Reference() /home/anoyes/workspace/foundationdb/flow/FastRef.h:130:4 (libfdb_c.so+0x6455e4)
2:     #4 ThreadSafeApi::getServerProtocol(char const*)::$_36::~$_36() /home/anoyes/workspace/foundationdb/fdbclient/ThreadSafeTransaction.cpp:408:22 (libfdb_c.so+0xb65efe)
2:     #5 ThreadSafeApi::getServerProtocol(char const*) /home/anoyes/workspace/foundationdb/fdbclient/ThreadSafeTransaction.cpp:408:2 (libfdb_c.so+0xb65efe)
2:     #6 MultiVersionApi::getServerProtocol(char const*) /home/anoyes/workspace/foundationdb/fdbclient/MultiVersionTransaction.actor.cpp:1161:32 (libfdb_c.so+0x419d4c)
2:     #7 fdb_get_server_protocol /home/anoyes/workspace/foundationdb/bindings/c/fdb_c.cpp:580:59 (libfdb_c.so+0x3fa5bd)
2:     #8 _DOCTEST_ANON_FUNC_100() /home/anoyes/workspace/foundationdb/bindings/c/test/unit/unit_tests.cpp:1517:30 (fdb_c_unit_tests+0x34f184)
2:     #9 doctest::Context::run() /home/anoyes/build/foundationdb-tsan/doctest/src/doctest/doctest/doctest.h:6112:21 (fdb_c_unit_tests+0x325e94)
2:     #10 main /home/anoyes/workspace/foundationdb/bindings/c/test/unit/unit_tests.cpp:2153:20 (fdb_c_unit_tests+0x35f7f1)
2: 
2:   Location is heap block of size 112 at 0x7b1c00000770 allocated by main thread:
2:     #0 operator new(unsigned long) <null> (fdb_c_unit_tests+0x31694e)
2:     #1 ThreadSafeApi::getServerProtocol(char const*) /home/anoyes/workspace/foundationdb/fdbclient/ThreadSafeTransaction.cpp:407:72 (libfdb_c.so+0xb658fc)
2:     #2 MultiVersionApi::getServerProtocol(char const*) /home/anoyes/workspace/foundationdb/fdbclient/MultiVersionTransaction.actor.cpp:1161:32 (libfdb_c.so+0x419d4c)
2:     #3 fdb_get_server_protocol /home/anoyes/workspace/foundationdb/bindings/c/fdb_c.cpp:580:59 (libfdb_c.so+0x3fa5bd)
2:     #4 _DOCTEST_ANON_FUNC_100() /home/anoyes/workspace/foundationdb/bindings/c/test/unit/unit_tests.cpp:1517:30 (fdb_c_unit_tests+0x34f184)
2:     #5 doctest::Context::run() /home/anoyes/build/foundationdb-tsan/doctest/src/doctest/doctest/doctest.h:6112:21 (fdb_c_unit_tests+0x325e94)
2:     #6 main /home/anoyes/workspace/foundationdb/bindings/c/test/unit/unit_tests.cpp:2153:20 (fdb_c_unit_tests+0x35f7f1)
2: 
2:   Thread T1 (tid=49, running) created by main thread at:
2:     #0 pthread_create <null> (fdb_c_unit_tests+0x29df32)
2:     #1 std::__1::__libcpp_thread_create(unsigned long*, void* (*)(void*), void*) /usr/local/bin/../include/c++/v1/__threading_support:394:10 (fdb_c_unit_tests+0x372da6)
2:     #2 std::__1::thread::thread<int (*)(), void>(int (*&&)()) /usr/local/bin/../include/c++/v1/thread:300:16 (fdb_c_unit_tests+0x372da6)
2:     #3 main /home/anoyes/workspace/foundationdb/bindings/c/test/unit/unit_tests.cpp:2148:14 (fdb_c_unit_tests+0x35f6dd)
2: 
2: SUMMARY: ThreadSanitizer: data race /home/anoyes/workspace/foundationdb/flow/FastRef.h:71:24 in ThreadUnsafeReferenceCounted<ClusterConnectionFile>::addref() const


```

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [x] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
