### PR TITLE
Log dcIDs during TLog recruitment.

### DIFF
--- a/fdbserver/ClusterController.actor.cpp
+++ b/fdbserver/ClusterController.actor.cpp
@@ -335,6 +335,15 @@ public:
 		LocalityMap<WorkerDetails>* logServerMap;
 		bool bCompleted = false;
 
+		// Construct the list of DCs where the TLog recruitment is happening. This is mainly for logging purpose.
+		std::string dcList;
+		for (const auto& dc : dcIds) {
+			if (!dcList.empty()) {
+				dcList += ',';
+			}
+			dcList += dc;
+		}
+
 		logServerSet = Reference<LocalitySet>(new LocalityMap<WorkerDetails>());
 		logServerMap = (LocalityMap<WorkerDetails>*)logServerSet.getPtr();
 		for (auto& it : id_worker) {
@@ -373,6 +382,7 @@ public:
 						break;
 					}
 					TraceEvent(SevWarn, "GWFTADNotAcceptable", id)
+					    .detail("DcIds", dcList)
 					    .detail("Fitness", fitness)
 					    .detail("Processes", logServerSet->size())
 					    .detail("Required", required)
@@ -400,6 +410,7 @@ public:
 							tLocalities.push_back(object->interf.locality);
 						}
 						TraceEvent("GWFTADBestResults", id)
+						    .detail("DcIds", dcList)
 						    .detail("Fitness", fitness)
 						    .detail("Processes", logServerSet->size())
 						    .detail("BestCount", bestSet.size())
@@ -413,6 +424,7 @@ public:
 						break;
 					}
 					TraceEvent(SevWarn, "GWFTADNoBest", id)
+					    .detail("DcIds", dcList)
 					    .detail("Fitness", fitness)
 					    .detail("Processes", logServerSet->size())
 					    .detail("Required", required)
@@ -431,6 +443,7 @@ public:
 			}
 
 			TraceEvent(SevWarn, "GetTLogTeamFailed")
+			    .detail("DcIds", dcList)
 			    .detail("Policy", policy->info())
 			    .detail("Processes", logServerSet->size())
 			    .detail("Workers", id_worker.size())
@@ -457,6 +470,7 @@ public:
 		}
 
 		TraceEvent("GetTLogTeamDone")
+		    .detail("DcIds", dcList)
 		    .detail("Completed", bCompleted)
 		    .detail("Policy", policy->info())
 		    .detail("Results", results.size())

--- a/fdbserver/ClusterController.actor.cpp
+++ b/fdbserver/ClusterController.actor.cpp
@@ -341,7 +341,7 @@ public:
 			if (!dcList.empty()) {
 				dcList += ',';
 			}
-			dcList += dc;
+			dcList += printable(dc);
 		}
 
 		logServerSet = Reference<LocalitySet>(new LocalityMap<WorkerDetails>());


### PR DESCRIPTION
The current event trace during recruitment doesn't contain which datacenter the recruitment is executing. This is especially hard to debug in HA mode. So logging dc information can help us quickly identify the recruitment DC.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [x] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
