### PR TITLE
Logging more detailed information during Tlog recruitment

### DIFF
--- a/fdbserver/ClusterController.actor.cpp
+++ b/fdbserver/ClusterController.actor.cpp
@@ -352,7 +352,7 @@ public:
 			    .detail("WorkerID", details.interf.id())
 			    .detail("WorkerDC", details.interf.locality.dcId())
 			    .detail("Address", details.interf.addresses().toString())
-			    .detail("fitness", fitness);
+			    .detail("Fitness", fitness);
 		};
 
 		// Go through all the workers to list all the workers that can be recruited.

--- a/fdbserver/ClusterController.actor.cpp
+++ b/fdbserver/ClusterController.actor.cpp
@@ -369,13 +369,13 @@ public:
 		// Go through all the workers to list all the workers that can be recruited.
 		for (const auto& [worker_process_id, worker_info] : id_worker) {
 			const auto& worker_details = worker_info.details;
+			auto fitness = worker_details.processClass.machineClassFitness(ProcessClass::TLog);
 			if (std::find(exclusionWorkerIds.begin(), exclusionWorkerIds.end(), worker_details.interf.id()) !=
 			    exclusionWorkerIds.end()) {
-				logWorkerUnavailable("Worker is excluded", worker_details, ProcessClass::UnsetFit);
+				logWorkerUnavailable("Worker is excluded", worker_details, fitness);
 				continue;
 			}
 
-			auto fitness = worker_details.processClass.machineClassFitness(ProcessClass::TLog);
 			if (!workerAvailable(worker_info, checkStable)) {
 				logWorkerUnavailable("Worker is not available", worker_details, fitness);
 				continue;


### PR DESCRIPTION
This PR adds more logging information during Tlog worker recruitment.

When a worker is considered as unavailable during Tlog recruitment in the cluster controller, there are several reasons, and the current logging message is hard to tell what's the real cause. This makes debugging hard especially Tlog recruitment is critical for database availability.

Tested by existing unit tests and joshua tests.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [x] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
