### PR TITLE
Fix base trace event name inconsistency

### DIFF
--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -2120,7 +2120,7 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 		    .detail("Primary", primary)
 		    .detail("AddedTeams", addedTeams)
 		    .detail("TeamsToBuild", teamsToBuild)
-		    .detail("CurrentTeams", teams.size())
+		    .detail("CurrentServerTeams", teams.size())
 		    .detail("DesiredTeams", desiredTeams)
 		    .detail("MaxTeams", maxTeams)
 		    .detail("StorageTeamSize", configuration.storageTeamSize)

--- a/fdbserver/QuietDatabase.actor.cpp
+++ b/fdbserver/QuietDatabase.actor.cpp
@@ -391,7 +391,7 @@ ACTOR Future<bool> getTeamCollectionValid(Database cx, WorkerInterface dataDistr
 			TraceEvent("GetTeamCollectionValid").detail("Stage", "GotString");
 
 			state int64_t currentTeams =
-			    boost::lexical_cast<int64_t>(teamCollectionInfoMessage.getValue("CurrentTeams"));
+			    boost::lexical_cast<int64_t>(teamCollectionInfoMessage.getValue("CurrentServerTeams"));
 			state int64_t desiredTeams =
 			    boost::lexical_cast<int64_t>(teamCollectionInfoMessage.getValue("DesiredTeams"));
 			state int64_t maxTeams = boost::lexical_cast<int64_t>(teamCollectionInfoMessage.getValue("MaxTeams"));
@@ -443,7 +443,7 @@ ACTOR Future<bool> getTeamCollectionValid(Database cx, WorkerInterface dataDistr
 				// TODO: Remove the constraint SERVER_KNOBS->DESIRED_TEAMS_PER_SERVER == 3 to ensure that
 				// the minimun team number per server (and per machine) is always > 0 for any number of replicas
 				TraceEvent("GetTeamCollectionValid")
-				    .detail("CurrentTeams", currentTeams)
+				    .detail("CurrentServerTeams", currentTeams)
 				    .detail("DesiredTeams", desiredTeams)
 				    .detail("MaxTeams", maxTeams)
 				    .detail("CurrentHealthyMachineTeams", healthyMachineTeams)


### PR DESCRIPTION
This is a cherry-pick of a [fix](https://github.com/apple/foundationdb/pull/4450) from `release-6.3`.
The [change](https://github.com/apple/foundationdb/pull/3933/commits/7ebb2e5c09564a35196b0a56cdcddbc705b232fc#diff-f3e66a6ee528a2fb4f9f61766269750c368f639ff9e231b00d6c514bbe5e21a6R2107) updated the trace attribute name
from CurrentTeams to CurrentServerTeams,
but did not change the code where QuietDatabase read the trace,
thus causing QuietDatabase to fail.

Related issue: #4521 #4522 

The fix is very straightforward to use the latest name `CurrentServerTeams` when reading the trace.

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] ~~Every function/class/actor that was touched is reasonably well documented.~~

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [x] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [x] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
