### PR TITLE
Decrement commitBatchesMemBytesCount when rejecting commit batch

### DIFF
--- a/fdbserver/CommitProxyServer.actor.cpp
+++ b/fdbserver/CommitProxyServer.actor.cpp
@@ -1407,8 +1407,10 @@ ACTOR Future<Void> commitBatch(ProxyCommitData* self,
 	/////// Phase 1: Pre-resolution processing (CPU bound except waiting for a version # which is separately pipelined
 	/// and *should* be available by now (unless empty commit); ordered; currently atomic but could yield)
 	wait(CommitBatch::preresolutionProcessing(&context));
-	if (context.rejected)
+	if (context.rejected) {
+		self->commitBatchesMemBytesCount -= currentBatchMemBytesCount;
 		return Void();
+	}
 
 	/////// Phase 2: Resolution (waiting on the network; pipelined)
 	wait(CommitBatch::getResolution(&context));


### PR DESCRIPTION
This issue relates to: #4523 

We were never decrementing commitBatchesMemBytesCount when rejecting a commit batch causing this value to "blow up". This PR address this to make sure we are decrementing before returning.

This PR passes 10k Joshua runs

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [x] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
