### PR TITLE
Add targeting DC ids in the tlog recruitment event trace.

### DIFF
--- a/fdbserver/ClusterController.actor.cpp
+++ b/fdbserver/ClusterController.actor.cpp
@@ -359,20 +359,20 @@ public:
 		logServerMap = (LocalityMap<WorkerDetails>*)logServerSet.getPtr();
 
 		// Populate `unavailableLocals` and log the reason why the worker is considered as unavailable.
-		auto logWorkerUnavailable = [this, &unavailableLocals](const std::string& reason,
-		                                                       const WorkerDetails& details,
-		                                                       ProcessClass::Fitness fitness) {
+		auto logWorkerUnavailable = [this, &unavailableLocals, &dcList](const std::string& reason,
+		                                                                const WorkerDetails& details,
+		                                                                ProcessClass::Fitness fitness) {
 			unavailableLocals.push_back(details.interf.locality);
 
 			// Note that the recruitment happens only during initial database creation and recovery. So these trace
 			// events should be sparse.
-			// TODO(zhewu): Add targeting dcids.
 			TraceEvent("GetTLogTeamWorkerUnavailable", id)
 			    .detail("Reason", reason)
 			    .detail("WorkerID", details.interf.id())
 			    .detail("WorkerDC", details.interf.locality.dcId())
 			    .detail("Address", details.interf.addresses().toString())
-			    .detail("Fitness", fitness);
+			    .detail("Fitness", fitness)
+			    .detail("RecruitmentDcIds", dcList);
 		};
 
 		// Go through all the workers to list all the workers that can be recruited.


### PR DESCRIPTION
This is a cleanup after #4516 and #4518 . We also want to show the target DC IDs where the recruitment is going on.

10k Joshua run:

20210319-210932-zhewu-c5bdd7968acbe533             compressed=True data_size=22088549 duration=354133 ended=10180 fail_fast=10 max_runs=10000 pass=10000 pr=tlog-dcid priority=100 remaining=0 runtime=0:16:20 sanity=False started=10484 stopped=20210319-212552 submitted=20210319-210932 timeout=5400 username=zhewu

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [x] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
