### PR TITLE
Add some entries to `.gitignore` 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,6 +85,7 @@ flow/coveragetool/obj
 /compile_commands.json
 /.ccls-cache
 /.clangd
+/.cache
 
 # Temporary and user configuration files
 *~

--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,8 @@ trace.*.xml
 *.user
 .idea/
 .project
+.projectile
+.dir-locals.el
 .pydevproject
 .vscode
 .vs/


### PR DESCRIPTION
- Add `.cache` directory to `.gitignore`. Seems to be default for index  cache in some setups. 
- Also, ignore `.projectile` and `.dir-locals.el` which are Emacs project setup files.
 
# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [X] The PR has a description, explaining both the problem and the solution.
- [X] The description mentions which forms of testing were done and the testing seems reasonable.
- [X] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
