### PR TITLE
Factor out the checks for test configuration in simulation tests + added new parameter

### DIFF
--- a/fdbserver/SimulatedCluster.actor.cpp
+++ b/fdbserver/SimulatedCluster.actor.cpp
@@ -1608,6 +1608,7 @@ void setupSimulatedSystem(vector<Future<Void>>* systemActors,
 	    .detail("StartingConfiguration", pStartingConfiguration->toString());
 }
 
+// Populates the TestConfig fields according to what is found in the test file.
 void checkTestConf(const char* testFile, TestConfig* testConfig) {
 	std::ifstream ifs;
 	ifs.open(testFile, std::ifstream::in);

--- a/fdbserver/SimulatedCluster.actor.cpp
+++ b/fdbserver/SimulatedCluster.actor.cpp
@@ -673,6 +673,9 @@ IPAddress makeIPAddressForSim(bool isIPv6, std::array<int, 4> parts) {
 
 #include "fdbclient/MonitorLeader.h"
 
+// Configures the system according to the given specifications in order to run
+// simulation, but with the additional consideration that it is meant to act
+// like a "rebooted" machine, mostly used for restarting tests.
 ACTOR Future<Void> restartSimulatedSystem(vector<Future<Void>>* systemActors,
                                           std::string baseFolder,
                                           int* pTesterCount,
@@ -1238,6 +1241,8 @@ void SimulationConfig::generateNormalConfig(TestConfig testConfig) {
 	}
 }
 
+// Configures the system according to the given specifications in order to run
+// simulation under the correct conditions
 void setupSimulatedSystem(vector<Future<Void>>* systemActors,
                           std::string baseFolder,
                           int* pTesterCount,

--- a/fdbserver/SimulatedCluster.actor.cpp
+++ b/fdbserver/SimulatedCluster.actor.cpp
@@ -840,7 +840,7 @@ ACTOR Future<Void> restartSimulatedSystem(vector<Future<Void>>* systemActors,
 }
 
 struct SimulationConfig {
-	explicit SimulationConfig(TestConfig testConfig);
+	explicit SimulationConfig(const TestConfig& testConfig);
 	int extraDB;
 
 	DatabaseConfiguration db;
@@ -854,10 +854,10 @@ struct SimulationConfig {
 	int coordinators;
 
 private:
-	void generateNormalConfig(TestConfig testConfig);
+	void generateNormalConfig(const TestConfig& testConfig);
 };
 
-SimulationConfig::SimulationConfig(TestConfig testConfig) {
+SimulationConfig::SimulationConfig(const TestConfig& testConfig) {
 	generateNormalConfig(testConfig);
 }
 
@@ -874,7 +874,7 @@ StringRef StringRefOf(const char* s) {
 	return StringRef((uint8_t*)s, strlen(s));
 }
 
-void SimulationConfig::generateNormalConfig(TestConfig testConfig) {
+void SimulationConfig::generateNormalConfig(const TestConfig& testConfig) {
 	set_config("new");
 	const bool simple = false; // Set true to simplify simulation configs for easier debugging
 	// generateMachineTeamTestConfig set up the number of servers per machine and the number of machines such that

--- a/fdbserver/SimulatedCluster.actor.cpp
+++ b/fdbserver/SimulatedCluster.actor.cpp
@@ -678,7 +678,7 @@ ACTOR Future<Void> restartSimulatedSystem(vector<Future<Void>>* systemActors,
                                           int* pTesterCount,
                                           Optional<ClusterConnectionString>* pConnString,
                                           Standalone<StringRef>* pStartingConfiguration,
-                                          int extraDB,
+                                          TestConfig testConfig,
                                           std::string whitelistBinPaths,
                                           ProtocolVersion protocolVersion) {
 	CSimpleIni ini;
@@ -698,7 +698,7 @@ ACTOR Future<Void> restartSimulatedSystem(vector<Future<Void>>* systemActors,
 		}
 		int desiredCoordinators = atoi(ini.GetValue("META", "desiredCoordinators"));
 		int testerCount = atoi(ini.GetValue("META", "testerCount"));
-		bool enableExtraDB = (extraDB == 3);
+		bool enableExtraDB = (testConfig.extraDB == 3);
 		ClusterConnectionString conn(ini.GetValue("META", "connectionString"));
 		if (enableExtraDB) {
 			g_simulator.extraDB = new ClusterConnectionString(ini.GetValue("META", "connectionString"));
@@ -837,7 +837,7 @@ ACTOR Future<Void> restartSimulatedSystem(vector<Future<Void>>* systemActors,
 }
 
 struct SimulationConfig {
-	explicit SimulationConfig(int extraDB, int minimumReplication, int minimumRegions);
+	explicit SimulationConfig(TestConfig testConfig);
 	int extraDB;
 
 	DatabaseConfiguration db;
@@ -851,11 +851,11 @@ struct SimulationConfig {
 	int coordinators;
 
 private:
-	void generateNormalConfig(int minimumReplication, int minimumRegions);
+	void generateNormalConfig(TestConfig testConfig);
 };
 
-SimulationConfig::SimulationConfig(int extraDB, int minimumReplication, int minimumRegions) : extraDB(extraDB) {
-	generateNormalConfig(minimumReplication, minimumRegions);
+SimulationConfig::SimulationConfig(TestConfig testConfig) {
+	generateNormalConfig(testConfig);
 }
 
 void SimulationConfig::set_config(std::string config) {
@@ -871,18 +871,18 @@ StringRef StringRefOf(const char* s) {
 	return StringRef((uint8_t*)s, strlen(s));
 }
 
-void SimulationConfig::generateNormalConfig(int minimumReplication, int minimumRegions) {
+void SimulationConfig::generateNormalConfig(TestConfig testConfig) {
 	set_config("new");
 	const bool simple = false; // Set true to simplify simulation configs for easier debugging
 	// generateMachineTeamTestConfig set up the number of servers per machine and the number of machines such that
 	// if we do not remove the surplus server and machine teams, the simulation test will report error.
 	// This is needed to make sure the number of server (and machine) teams is no larger than the desired number.
 	bool generateMachineTeamTestConfig = BUGGIFY_WITH_PROB(0.1) ? true : false;
-	bool generateFearless = simple ? false : (minimumRegions > 1 || deterministicRandom()->random01() < 0.5);
-	datacenters = simple
-	                  ? 1
-	                  : (generateFearless ? (minimumReplication > 0 || deterministicRandom()->random01() < 0.5 ? 4 : 6)
-	                                      : deterministicRandom()->randomInt(1, 4));
+	bool generateFearless = simple ? false : (testConfig.minimumRegions > 1 || deterministicRandom()->random01() < 0.5);
+	datacenters = simple ? 1
+	                     : (generateFearless
+	                            ? (testConfig.minimumReplication > 0 || deterministicRandom()->random01() < 0.5 ? 4 : 6)
+	                            : deterministicRandom()->randomInt(1, 4));
 	if (deterministicRandom()->random01() < 0.25)
 		db.desiredTLogCount = deterministicRandom()->randomInt(1, 7);
 	if (deterministicRandom()->random01() < 0.25)
@@ -892,6 +892,10 @@ void SimulationConfig::generateNormalConfig(int minimumReplication, int minimumR
 	if (deterministicRandom()->random01() < 0.25)
 		db.resolverCount = deterministicRandom()->randomInt(1, 7);
 	int storage_engine_type = deterministicRandom()->randomInt(0, 4);
+	// Continuously re-pick the storage engine type if it's the one we want to exclude
+	while (storage_engine_type == testConfig.storageEngineExcludeType) {
+		storage_engine_type = deterministicRandom()->randomInt(0, 4);
+	}
 	switch (storage_engine_type) {
 	case 0: {
 		TEST(true); // Simulated cluster using ssd storage engine
@@ -930,7 +934,7 @@ void SimulationConfig::generateNormalConfig(int minimumReplication, int minimumR
 		db.resolverCount = 1;
 	}
 	int replication_type = simple ? 1
-	                              : (std::max(minimumReplication,
+	                              : (std::max(testConfig.minimumReplication,
 	                                          datacenters > 4 ? deterministicRandom()->randomInt(1, 3)
 	                                                          : std::min(deterministicRandom()->randomInt(0, 6), 3)));
 	switch (replication_type) {
@@ -1078,7 +1082,7 @@ void SimulationConfig::generateNormalConfig(int minimumReplication, int minimumR
 
 			// We cannot run with a remote DC when MAX_READ_TRANSACTION_LIFE_VERSIONS is too small, because the log
 			// routers will not be able to keep up.
-			if (minimumRegions <= 1 &&
+			if (testConfig.minimumRegions <= 1 &&
 			    (deterministicRandom()->random01() < 0.25 ||
 			     SERVER_KNOBS->MAX_READ_TRANSACTION_LIFE_VERSIONS < SERVER_KNOBS->VERSIONS_PER_SECOND)) {
 				TEST(true); // Simulated cluster using one region
@@ -1124,7 +1128,7 @@ void SimulationConfig::generateNormalConfig(int minimumReplication, int minimumR
 				db.remoteDesiredTLogCount = deterministicRandom()->randomInt(1, 7);
 
 			bool useNormalDCsAsSatellites =
-			    datacenters > 4 && minimumRegions < 2 && deterministicRandom()->random01() < 0.3;
+			    datacenters > 4 && testConfig.minimumRegions < 2 && deterministicRandom()->random01() < 0.3;
 			StatusObject primarySatelliteObj;
 			primarySatelliteObj["id"] = useNormalDCsAsSatellites ? "1" : "2";
 			primarySatelliteObj["priority"] = 1;
@@ -1191,7 +1195,7 @@ void SimulationConfig::generateNormalConfig(int minimumReplication, int minimumR
 		}
 	}
 
-	if (generateFearless && minimumReplication > 1) {
+	if (generateFearless && testConfig.minimumReplication > 1) {
 		// low latency tests in fearless configurations need 4 machines per datacenter (3 for triple replication, 1 that
 		// is down during failures).
 		machine_count = 16;
@@ -1216,10 +1220,11 @@ void SimulationConfig::generateNormalConfig(int minimumReplication, int minimumR
 
 	// because we protect a majority of coordinators from being killed, it is better to run with low numbers of
 	// coordinators to prevent too many processes from being protected
-	coordinators =
-	    (minimumRegions <= 1 && BUGGIFY) ? deterministicRandom()->randomInt(1, std::max(machine_count, 2)) : 1;
+	coordinators = (testConfig.minimumRegions <= 1 && BUGGIFY)
+	                   ? deterministicRandom()->randomInt(1, std::max(machine_count, 2))
+	                   : 1;
 
-	if (minimumReplication > 1 && datacenters == 3) {
+	if (testConfig.minimumReplication > 1 && datacenters == 3) {
 		// low latency tests in 3 data hall mode need 2 other data centers with 2 machines each to avoid waiting for
 		// logs to recover.
 		machine_count = std::max(machine_count, 6);
@@ -1238,21 +1243,17 @@ void setupSimulatedSystem(vector<Future<Void>>* systemActors,
                           int* pTesterCount,
                           Optional<ClusterConnectionString>* pConnString,
                           Standalone<StringRef>* pStartingConfiguration,
-                          int extraDB,
-                          int minimumReplication,
-                          int minimumRegions,
                           std::string whitelistBinPaths,
-                          bool configureLocked,
-                          int logAntiQuorum,
+                          TestConfig testConfig,
                           ProtocolVersion protocolVersion) {
 	// SOMEDAY: this does not test multi-interface configurations
-	SimulationConfig simconfig(extraDB, minimumReplication, minimumRegions);
-	if (logAntiQuorum != -1) {
-		simconfig.db.tLogWriteAntiQuorum = logAntiQuorum;
+	SimulationConfig simconfig(testConfig);
+	if (testConfig.logAntiQuorum != -1) {
+		simconfig.db.tLogWriteAntiQuorum = testConfig.logAntiQuorum;
 	}
 	StatusObject startingConfigJSON = simconfig.db.toJSON(true);
 	std::string startingConfigString = "new";
-	if (configureLocked) {
+	if (testConfig.configureLocked) {
 		startingConfigString += " locked";
 	}
 	for (auto kv : startingConfigJSON) {
@@ -1338,7 +1339,7 @@ void setupSimulatedSystem(vector<Future<Void>>* systemActors,
 	TEST(!useIPv6); // Use IPv4
 
 	vector<NetworkAddress> coordinatorAddresses;
-	if (minimumRegions > 1) {
+	if (testConfig.minimumRegions > 1) {
 		// do not put coordinators in the primary region so that we can kill that region safely
 		int nonPrimaryDcs = dataCenters / 2;
 		for (int dc = 1; dc < dataCenters; dc += 2) {
@@ -1409,14 +1410,14 @@ void setupSimulatedSystem(vector<Future<Void>>* systemActors,
 	ClusterConnectionString conn(coordinatorAddresses, LiteralStringRef("TestCluster:0"));
 
 	// If extraDB==0, leave g_simulator.extraDB as null because the test does not use DR.
-	if (extraDB == 1) {
+	if (testConfig.extraDB == 1) {
 		// The DR database can be either a new database or itself
 		g_simulator.extraDB = new ClusterConnectionString(
 		    coordinatorAddresses, BUGGIFY ? LiteralStringRef("TestCluster:0") : LiteralStringRef("ExtraCluster:0"));
-	} else if (extraDB == 2) {
+	} else if (testConfig.extraDB == 2) {
 		// The DR database is a new database
 		g_simulator.extraDB = new ClusterConnectionString(coordinatorAddresses, LiteralStringRef("ExtraCluster:0"));
-	} else if (extraDB == 3) {
+	} else if (testConfig.extraDB == 3) {
 		// The DR database is the same database
 		g_simulator.extraDB = new ClusterConnectionString(coordinatorAddresses, LiteralStringRef("TestCluster:0"));
 	}
@@ -1427,7 +1428,7 @@ void setupSimulatedSystem(vector<Future<Void>>* systemActors,
 	    .detail("String", conn.toString())
 	    .detail("ConfigString", startingConfigString);
 
-	bool requiresExtraDBMachines = extraDB && g_simulator.extraDB->toString() != conn.toString();
+	bool requiresExtraDBMachines = testConfig.extraDB && g_simulator.extraDB->toString() != conn.toString();
 	int assignedMachines = 0, nonVersatileMachines = 0;
 	std::vector<ProcessClass::ClassType> processClassesSubSet = { ProcessClass::UnsetClass,
 		                                                          ProcessClass::ResolutionClass,
@@ -1602,13 +1603,7 @@ void setupSimulatedSystem(vector<Future<Void>>* systemActors,
 	    .detail("StartingConfiguration", pStartingConfiguration->toString());
 }
 
-void checkTestConf(const char* testFile,
-                   int& extraDB,
-                   int& minimumReplication,
-                   int& minimumRegions,
-                   int& configureLocked,
-                   int& logAntiQuorum,
-                   bool& startIncompatibleProcess) {
+void checkTestConf(const char* testFile, TestConfig* testConfig) {
 	std::ifstream ifs;
 	ifs.open(testFile, std::ifstream::in);
 	if (!ifs.good())
@@ -1630,26 +1625,31 @@ void checkTestConf(const char* testFile,
 		std::string value = removeWhitespace(line.substr(found + 1));
 
 		if (attrib == "extraDB") {
-			sscanf(value.c_str(), "%d", &extraDB);
+			sscanf(value.c_str(), "%d", &testConfig->extraDB);
 		}
 
 		if (attrib == "minimumReplication") {
-			sscanf(value.c_str(), "%d", &minimumReplication);
+			sscanf(value.c_str(), "%d", &testConfig->minimumReplication);
 		}
 
 		if (attrib == "minimumRegions") {
-			sscanf(value.c_str(), "%d", &minimumRegions);
+			sscanf(value.c_str(), "%d", &testConfig->minimumRegions);
 		}
 
 		if (attrib == "configureLocked") {
-			sscanf(value.c_str(), "%d", &configureLocked);
+			sscanf(value.c_str(), "%d", &testConfig->configureLocked);
 		}
 
 		if (attrib == "startIncompatibleProcess") {
-			startIncompatibleProcess = strcmp(value.c_str(), "true") == 0;
+			testConfig->startIncompatibleProcess = strcmp(value.c_str(), "true") == 0;
 		}
+
 		if (attrib == "logAntiQuorum") {
-			sscanf(value.c_str(), "%d", &logAntiQuorum);
+			sscanf(value.c_str(), "%d", &testConfig->logAntiQuorum);
+		}
+
+		if (attrib == "storageEngineExcludeType") {
+			sscanf(value.c_str(), "%d", &testConfig->storageEngineExcludeType);
 		}
 	}
 
@@ -1665,24 +1665,13 @@ ACTOR void setupAndRun(std::string dataFolder,
 	state Optional<ClusterConnectionString> connFile;
 	state Standalone<StringRef> startingConfiguration;
 	state int testerCount = 1;
-	state int extraDB = 0;
-	state int minimumReplication = 0;
-	state int minimumRegions = 0;
-	state int configureLocked = 0;
-	state int logAntiQuorum = -1;
-	state bool startIncompatibleProcess = false;
-	checkTestConf(testFile,
-	              extraDB,
-	              minimumReplication,
-	              minimumRegions,
-	              configureLocked,
-	              logAntiQuorum,
-	              startIncompatibleProcess);
-	g_simulator.hasDiffProtocolProcess = startIncompatibleProcess;
+	state TestConfig testConfig;
+	checkTestConf(testFile, &testConfig);
+	g_simulator.hasDiffProtocolProcess = testConfig.startIncompatibleProcess;
 	g_simulator.setDiffProtocol = false;
 
 	state ProtocolVersion protocolVersion = currentProtocolVersion;
-	if (startIncompatibleProcess) {
+	if (testConfig.startIncompatibleProcess) {
 		// isolates right most 1 bit of compatibleProtocolVersionMask to make this protocolVersion incompatible
 		uint64_t minAddToMakeIncompatible =
 		    ProtocolVersion::compatibleProtocolVersionMask & ~(ProtocolVersion::compatibleProtocolVersionMask - 1);
@@ -1717,7 +1706,7 @@ ACTOR void setupAndRun(std::string dataFolder,
 			                                         &testerCount,
 			                                         &connFile,
 			                                         &startingConfiguration,
-			                                         extraDB,
+			                                         testConfig,
 			                                         whitelistBinPaths,
 			                                         protocolVersion),
 			                  100.0));
@@ -1732,12 +1721,8 @@ ACTOR void setupAndRun(std::string dataFolder,
 			                     &testerCount,
 			                     &connFile,
 			                     &startingConfiguration,
-			                     extraDB,
-			                     minimumReplication,
-			                     minimumRegions,
 			                     whitelistBinPaths,
-			                     configureLocked,
-			                     logAntiQuorum,
+			                     testConfig,
 			                     protocolVersion);
 			wait(delay(1.0)); // FIXME: WHY!!!  //wait for machines to boot
 		}

--- a/fdbserver/TesterInterface.actor.h
+++ b/fdbserver/TesterInterface.actor.h
@@ -99,6 +99,22 @@ struct WorkloadRequest {
 	}
 };
 
+struct TestConfig {
+	int extraDB = 0;
+	int minimumReplication = 0;
+	int minimumRegions = 0;
+	int configureLocked = 0;
+	bool startIncompatibleProcess = false;
+	int logAntiQuorum = -1;
+	// Storage Engine Types: Verify match with SimulationConfig::generateNormalConfig
+	//	-1 = None
+	//	0 = "ssd"
+	//	1 = "memory"
+	//	2 = "memory-radixtree-beta"
+	//	3 = "ssd-redwood-experimental"
+	int storageEngineExcludeType = -1;
+};
+
 struct TesterInterface {
 	constexpr static FileIdentifier file_identifier = 4465210;
 	RequestStream<WorkloadRequest> recruitments;


### PR DESCRIPTION
As we add more and more arguments to the test configuration for a given test workload, the code begins to grow unwieldy. The goal of this is to factor out these extra arguments into a struct and pass them around to the appropriate places to be used.

This PR include a new argument `storageEngineExcludeType` that allows exclusion of a storage engine type when testing (mostly to prevent redwood from begin chosen for downgrades)

The main changes were to `SimulatedCluster.actor.cpp` in the construction of `SimulationConfig` and to the arguments of existing functions that used the parameters factored out into the new structure `TestConfig`, such as `restartSimulatedSystem` and `setupSimulatedSystem`

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
