### PR TITLE
Features/better sim output

### DIFF
--- a/cmake/Jemalloc.cmake
+++ b/cmake/Jemalloc.cmake
@@ -3,7 +3,7 @@ add_library(jemalloc INTERFACE)
 set(USE_JEMALLOC ON)
 # We don't want to use jemalloc on Windows
 # Nor on FreeBSD, where jemalloc is the default system allocator
-if(USE_SANITIZER OR WIN32 OR (CMAKE_SYSTEM_NAME STREQUAL "FreeBSD"))
+if(USE_SANITIZER OR WIN32 OR (CMAKE_SYSTEM_NAME STREQUAL "FreeBSD") OR APPLE)
   set(USE_JEMALLOC OFF)
   return()
 endif()

--- a/fdbserver/tester.actor.cpp
+++ b/fdbserver/tester.actor.cpp
@@ -415,6 +415,7 @@ void printSimulatedTopology() {
 		}
 		indent += "  ";
 		printf("%sAddress: %s\n", indent.c_str(), p->address.toString().c_str(), p->name);
+		indent += "  ";
 		printf("%sClass: %s\n", indent.c_str(), p->startingClass.toString().c_str());
 		printf("%sName: %s\n", indent.c_str(), p->name);
 	}


### PR DESCRIPTION
This PR adds some debugging output to simulation runs. When running a simulated test, it is often time consuming to figure out what the actual topology of the simulated cluster looks like. This is especially annoying when debugging timeout errors (as these often are caused by a cluster that can't successfully recovery and so figuring out why it doesn't recover requires knowledge about the used topology). Doing this was possible by looking through the trace files, but this should make the process faster.

Additionally this deactivates jemalloc on macOS (I was running into segfaults and it's probably not worth debugging these and we should just use malloc on macOS).

This has been tested by running it locally on my machine. As this doesn't make any changes except printing some information to stdout at startup, a joshua run is not necessary.

Sample output:

```
startingConfiguration:new backup_worker_enabled:=0 commit_proxies:=3 grv_proxies:=1 log_spill:=2 log_version:=6 three_data_hall ssd-redwood-experimental usable_regions:=1 start
Simulated Cluster Topology:
===========================
    zoneId: 1329133cacc1a949b4b67c398a2cd058
      machineId: 1329133cacc1a949b4b67c398a2cd058
        Address: [abcd::3:4:3:2]:1
          Class: test
          Name: Server
    zoneId: 17ad2f4941b6b1eb7dee1d79c7b116a1
      machineId: 07e00b448387afedefa9ab78c45d90c4
        Address: 1.1.1.1:1
          Class: test
          Name: TestSystem
    zoneId: 6b94e21fc0aef866bb9495d0533c401c
      machineId: 6b94e21fc0aef866bb9495d0533c401c
        Address: [abcd::3:4:3:6]:1
          Class: test
          Name: Server
    zoneId: 6d7cf45c0a9a707d795da9f1d6f78752
      machineId: 6d7cf45c0a9a707d795da9f1d6f78752
        Address: [abcd::3:4:3:3]:1
          Class: test
          Name: Server
    zoneId: 996adbf2e0bc2bd572b480412ab9cacb
      machineId: 996adbf2e0bc2bd572b480412ab9cacb
        Address: [abcd::3:4:3:1]:1
          Class: test
          Name: Server
    zoneId: b1ade1e00690d1920962292f4988d9f3
      machineId: b1ade1e00690d1920962292f4988d9f3
        Address: [abcd::3:4:3:4]:1
          Class: test
          Name: Server
    zoneId: b5f0943cd27698058d0dfad2d68cf861
      machineId: b5f0943cd27698058d0dfad2d68cf861
        Address: [abcd::3:4:3:5]:1
          Class: test
          Name: Server
    zoneId: f213a21a4755f23e2d8814f82f688464
      machineId: f213a21a4755f23e2d8814f82f688464
        Address: [abcd::3:4:3:7]:1
          Class: test
          Name: Server
dcId: 0
  dataHallId: 0
    zoneId: c366cd8fe093c3a0056e263f62e3462f
      machineId: 2b41110a10c2059924f7d92fc6ee0c11
        Address: [abcd::2:0:1:3]:2
          Class: storage_cache
          Name: Server
        Address: [abcd::2:0:1:3]:1
          Class: storage_cache
          Name: Server
    zoneId: d9831d8facdf540c519aa46f3b9d9028
      machineId: 7cf7ffa2abd5139a4f01d9bde7798f27
        Address: [abcd::2:0:1:2]:1
          Class: storage
          Name: Server
        Address: [abcd::2:0:1:2]:2
          Class: storage
          Name: Server
    zoneId: e2c1a6f6d4380460caa58dc43408c2eb
      machineId: 63094fc1ed2b11da2d132f574069b651
        Address: [abcd::2:0:2:1]:2
          Class: storage
          Name: Server
        Address: [abcd::2:0:1:1]:1
          Class: storage
          Name: Server
    zoneId: f6af665b42b4b55a328f4b7dc7ee666f
      machineId: 9aff54a2e6487738e16e95dc2f910b3e
        Address: [abcd::2:0:1:0]:1
          Class: unset
          Name: Server
        Address: [abcd::2:0:1:0]:2
          Class: unset
          Name: Server
dcId: 1
  dataHallId: 1
    zoneId: 458a13b287184362a9e574f3747bbe86
      machineId: d220e1396f37a8f6c664392a11fe96e9
        Address: [abcd::2:1:1:0]:1
          Class: master
          Name: Server
        Address: [abcd::2:1:1:0]:2
          Class: master
          Name: Server
    zoneId: 66803887c9b6b35b7ca9911fd48e410e
      machineId: 012550121ba5c6e268705fa84005d88c
        Address: [abcd::2:1:1:2]:1
          Class: transaction
          Name: Server
        Address: [abcd::2:1:1:2]:2
          Class: transaction
          Name: Server
    zoneId: d4c59ea2fbb67f10f150dfe132e01cca
      machineId: 3ab855d9d73c254a9dbd54ae098701b2
        Address: [abcd::2:1:2:1]:2
          Class: storage
          Name: Server
        Address: [abcd::2:1:1:1]:1
          Class: storage
          Name: Server
dcId: 2
  dataHallId: 2
    zoneId: be87f3609d05e21e09b5b589f580791b
      machineId: 06415e997401d571fd40d83e7d7f4602
        Address: [abcd::2:2:1:1]:1
          Class: storage
          Name: Server
        Address: [abcd::2:2:2:1]:2
          Class: storage
          Name: Server
    zoneId: d8278adc3bfd3bba164d020d1b211db1
      machineId: 53e3564c1959865440ecb031a36576f4
        Address: [abcd::2:2:1:0]:1
          Class: unset
          Name: Server
        Address: [abcd::2:2:1:0]:2
          Class: unset
          Name: Server
    zoneId: fee6da8411f1836dcebbbdb861782697
      machineId: 36ab439c63cb870e14a0b741613178ad
        Address: [abcd::2:2:2:2]:2
          Class: transaction
          Name: Server
        Address: [abcd::2:2:1:2]:1
          Class: transaction
          Name: Server
```

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [x] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
