### PR TITLE
Factor out the checks for test configuration in simulation tests + added new parameter (6.3)

### DIFF
--- a/fdbserver/SimulatedCluster.actor.cpp
+++ b/fdbserver/SimulatedCluster.actor.cpp
@@ -829,7 +829,7 @@ private:
 	void generateNormalConfig(const TestConfig& testConfig);
 };
 
-SimulationConfig::SimulationConfig(const TestConfig& testConfig) {
+SimulationConfig::SimulationConfig(const TestConfig& testConfig) : extraDB(testConfig.extraDB) {
 	generateNormalConfig(testConfig);
 }
 

--- a/fdbserver/SimulatedCluster.actor.cpp
+++ b/fdbserver/SimulatedCluster.actor.cpp
@@ -812,7 +812,7 @@ ACTOR Future<Void> restartSimulatedSystem(vector<Future<Void>>* systemActors,
 }
 
 struct SimulationConfig {
-	explicit SimulationConfig(TestConfig testConfig);
+	explicit SimulationConfig(const TestConfig& testConfig);
 	int extraDB;
 
 	DatabaseConfiguration db;
@@ -826,10 +826,10 @@ struct SimulationConfig {
 	int coordinators;
 
 private:
-	void generateNormalConfig(TestConfig testConfig);
+	void generateNormalConfig(const TestConfig& testConfig);
 };
 
-SimulationConfig::SimulationConfig(TestConfig testConfig) {
+SimulationConfig::SimulationConfig(const TestConfig& testConfig) {
 	generateNormalConfig(testConfig);
 }
 
@@ -846,7 +846,7 @@ StringRef StringRefOf(const char* s) {
 	return StringRef((uint8_t*)s, strlen(s));
 }
 
-void SimulationConfig::generateNormalConfig(TestConfig testConfig) {
+void SimulationConfig::generateNormalConfig(const TestConfig& testConfig) {
 	set_config("new");
 	const bool simple = false; // Set true to simplify simulation configs for easier debugging
 	// generateMachineTeamTestConfig set up the number of servers per machine and the number of machines such that

--- a/fdbserver/SimulatedCluster.actor.cpp
+++ b/fdbserver/SimulatedCluster.actor.cpp
@@ -646,6 +646,9 @@ IPAddress makeIPAddressForSim(bool isIPv6, std::array<int, 4> parts) {
 
 #include "fdbclient/MonitorLeader.h"
 
+// Configures the system according to the given specifications in order to run
+// simulation, but with the additional consideration that it is meant to act
+// like a "rebooted" machine, mostly used for restarting tests.
 ACTOR Future<Void> restartSimulatedSystem(vector<Future<Void>>* systemActors,
                                           std::string baseFolder,
                                           int* pTesterCount,
@@ -1207,6 +1210,8 @@ void SimulationConfig::generateNormalConfig(TestConfig testConfig) {
 	}
 }
 
+// Configures the system according to the given specifications in order to run
+// simulation under the correct conditions
 void setupSimulatedSystem(vector<Future<Void>>* systemActors,
                           std::string baseFolder,
                           int* pTesterCount,

--- a/fdbserver/SimulatedCluster.actor.cpp
+++ b/fdbserver/SimulatedCluster.actor.cpp
@@ -1632,8 +1632,6 @@ ACTOR void setupAndRun(std::string dataFolder,
 	state int testerCount = 1;
 	state TestConfig testConfig;
 	checkTestConf(testFile, &testConfig);
-	g_simulator.hasDiffProtocolProcess = testConfig.startIncompatibleProcess;
-	g_simulator.setDiffProtocol = false;
 
 	state ProtocolVersion protocolVersion = currentProtocolVersion;
 	if (testConfig.startIncompatibleProcess) {

--- a/fdbserver/SimulatedCluster.actor.cpp
+++ b/fdbserver/SimulatedCluster.actor.cpp
@@ -651,8 +651,9 @@ ACTOR Future<Void> restartSimulatedSystem(vector<Future<Void>>* systemActors,
                                           int* pTesterCount,
                                           Optional<ClusterConnectionString>* pConnString,
                                           Standalone<StringRef>* pStartingConfiguration,
-                                          int extraDB,
-                                          std::string whitelistBinPaths) {
+                                          TestConfig testConfig,
+                                          std::string whitelistBinPaths,
+                                          ProtocolVersion protocolVersion) {
 	CSimpleIni ini;
 	ini.SetUnicode();
 	ini.LoadFile(joinPath(baseFolder, "restartInfo.ini").c_str());
@@ -670,7 +671,7 @@ ACTOR Future<Void> restartSimulatedSystem(vector<Future<Void>>* systemActors,
 		}
 		int desiredCoordinators = atoi(ini.GetValue("META", "desiredCoordinators"));
 		int testerCount = atoi(ini.GetValue("META", "testerCount"));
-		bool enableExtraDB = (extraDB == 3);
+		bool enableExtraDB = (testConfig.extraDB == 3);
 		ClusterConnectionString conn(ini.GetValue("META", "connectionString"));
 		if (enableExtraDB) {
 			g_simulator.extraDB = new ClusterConnectionString(ini.GetValue("META", "connectionString"));
@@ -808,7 +809,7 @@ ACTOR Future<Void> restartSimulatedSystem(vector<Future<Void>>* systemActors,
 }
 
 struct SimulationConfig {
-	explicit SimulationConfig(int extraDB, int minimumReplication, int minimumRegions);
+	explicit SimulationConfig(TestConfig testConfig);
 	int extraDB;
 
 	DatabaseConfiguration db;
@@ -822,11 +823,11 @@ struct SimulationConfig {
 	int coordinators;
 
 private:
-	void generateNormalConfig(int minimumReplication, int minimumRegions);
+	void generateNormalConfig(TestConfig testConfig);
 };
 
-SimulationConfig::SimulationConfig(int extraDB, int minimumReplication, int minimumRegions) : extraDB(extraDB) {
-	generateNormalConfig(minimumReplication, minimumRegions);
+SimulationConfig::SimulationConfig(TestConfig testConfig) {
+	generateNormalConfig(testConfig);
 }
 
 void SimulationConfig::set_config(std::string config) {
@@ -842,18 +843,18 @@ StringRef StringRefOf(const char* s) {
 	return StringRef((uint8_t*)s, strlen(s));
 }
 
-void SimulationConfig::generateNormalConfig(int minimumReplication, int minimumRegions) {
+void SimulationConfig::generateNormalConfig(TestConfig testConfig) {
 	set_config("new");
 	const bool simple = false; // Set true to simplify simulation configs for easier debugging
 	// generateMachineTeamTestConfig set up the number of servers per machine and the number of machines such that
 	// if we do not remove the surplus server and machine teams, the simulation test will report error.
 	// This is needed to make sure the number of server (and machine) teams is no larger than the desired number.
 	bool generateMachineTeamTestConfig = BUGGIFY_WITH_PROB(0.1) ? true : false;
-	bool generateFearless = simple ? false : (minimumRegions > 1 || deterministicRandom()->random01() < 0.5);
-	datacenters = simple
-	                  ? 1
-	                  : (generateFearless ? (minimumReplication > 0 || deterministicRandom()->random01() < 0.5 ? 4 : 6)
-	                                      : deterministicRandom()->randomInt(1, 4));
+	bool generateFearless = simple ? false : (testConfig.minimumRegions > 1 || deterministicRandom()->random01() < 0.5);
+	datacenters = simple ? 1
+	                     : (generateFearless
+	                            ? (testConfig.minimumReplication > 0 || deterministicRandom()->random01() < 0.5 ? 4 : 6)
+	                            : deterministicRandom()->randomInt(1, 4));
 	if (deterministicRandom()->random01() < 0.25)
 		db.desiredTLogCount = deterministicRandom()->randomInt(1, 7);
 	if (deterministicRandom()->random01() < 0.25)
@@ -861,6 +862,10 @@ void SimulationConfig::generateNormalConfig(int minimumReplication, int minimumR
 	if (deterministicRandom()->random01() < 0.25)
 		db.resolverCount = deterministicRandom()->randomInt(1, 7);
 	int storage_engine_type = deterministicRandom()->randomInt(0, 4);
+	// Continuously re-pick the storage engine type if it's the one we want to exclude
+	while (storage_engine_type == testConfig.storageEngineExcludeType) {
+		storage_engine_type = deterministicRandom()->randomInt(0, 4);
+	}
 	switch (storage_engine_type) {
 	case 0: {
 		TEST(true); // Simulated cluster using ssd storage engine
@@ -898,7 +903,7 @@ void SimulationConfig::generateNormalConfig(int minimumReplication, int minimumR
 		db.resolverCount = 1;
 	}
 	int replication_type = simple ? 1
-	                              : (std::max(minimumReplication,
+	                              : (std::max(testConfig.minimumReplication,
 	                                          datacenters > 4 ? deterministicRandom()->randomInt(1, 3)
 	                                                          : std::min(deterministicRandom()->randomInt(0, 6), 3)));
 	switch (replication_type) {
@@ -1046,7 +1051,7 @@ void SimulationConfig::generateNormalConfig(int minimumReplication, int minimumR
 
 			// We cannot run with a remote DC when MAX_READ_TRANSACTION_LIFE_VERSIONS is too small, because the log
 			// routers will not be able to keep up.
-			if (minimumRegions <= 1 &&
+			if (testConfig.minimumRegions <= 1 &&
 			    (deterministicRandom()->random01() < 0.25 ||
 			     SERVER_KNOBS->MAX_READ_TRANSACTION_LIFE_VERSIONS < SERVER_KNOBS->VERSIONS_PER_SECOND)) {
 				TEST(true); // Simulated cluster using one region
@@ -1092,7 +1097,7 @@ void SimulationConfig::generateNormalConfig(int minimumReplication, int minimumR
 				db.remoteDesiredTLogCount = deterministicRandom()->randomInt(1, 7);
 
 			bool useNormalDCsAsSatellites =
-			    datacenters > 4 && minimumRegions < 2 && deterministicRandom()->random01() < 0.3;
+			    datacenters > 4 && testConfig.minimumRegions < 2 && deterministicRandom()->random01() < 0.3;
 			StatusObject primarySatelliteObj;
 			primarySatelliteObj["id"] = useNormalDCsAsSatellites ? "1" : "2";
 			primarySatelliteObj["priority"] = 1;
@@ -1159,7 +1164,7 @@ void SimulationConfig::generateNormalConfig(int minimumReplication, int minimumR
 		}
 	}
 
-	if (generateFearless && minimumReplication > 1) {
+	if (generateFearless && testConfig.minimumReplication > 1) {
 		// low latency tests in fearless configurations need 4 machines per datacenter (3 for triple replication, 1 that
 		// is down during failures).
 		machine_count = 16;
@@ -1184,10 +1189,11 @@ void SimulationConfig::generateNormalConfig(int minimumReplication, int minimumR
 
 	// because we protect a majority of coordinators from being killed, it is better to run with low numbers of
 	// coordinators to prevent too many processes from being protected
-	coordinators =
-	    (minimumRegions <= 1 && BUGGIFY) ? deterministicRandom()->randomInt(1, std::max(machine_count, 2)) : 1;
+	coordinators = (testConfig.minimumRegions <= 1 && BUGGIFY)
+	                   ? deterministicRandom()->randomInt(1, std::max(machine_count, 2))
+	                   : 1;
 
-	if (minimumReplication > 1 && datacenters == 3) {
+	if (testConfig.minimumReplication > 1 && datacenters == 3) {
 		// low latency tests in 3 data hall mode need 2 other data centers with 2 machines each to avoid waiting for
 		// logs to recover.
 		machine_count = std::max(machine_count, 6);
@@ -1206,16 +1212,17 @@ void setupSimulatedSystem(vector<Future<Void>>* systemActors,
                           int* pTesterCount,
                           Optional<ClusterConnectionString>* pConnString,
                           Standalone<StringRef>* pStartingConfiguration,
-                          int extraDB,
-                          int minimumReplication,
-                          int minimumRegions,
                           std::string whitelistBinPaths,
-                          bool configureLocked) {
+                          TestConfig testConfig,
+                          ProtocolVersion protocolVersion) {
 	// SOMEDAY: this does not test multi-interface configurations
-	SimulationConfig simconfig(extraDB, minimumReplication, minimumRegions);
+	SimulationConfig simconfig(testConfig);
+	if (testConfig.logAntiQuorum != -1) {
+		simconfig.db.tLogWriteAntiQuorum = testConfig.logAntiQuorum;
+	}
 	StatusObject startingConfigJSON = simconfig.db.toJSON(true);
 	std::string startingConfigString = "new";
-	if (configureLocked) {
+	if (testConfig.configureLocked) {
 		startingConfigString += " locked";
 	}
 	for (auto kv : startingConfigJSON) {
@@ -1301,7 +1308,7 @@ void setupSimulatedSystem(vector<Future<Void>>* systemActors,
 	TEST(!useIPv6);
 
 	vector<NetworkAddress> coordinatorAddresses;
-	if (minimumRegions > 1) {
+	if (testConfig.minimumRegions > 1) {
 		// do not put coordinators in the primary region so that we can kill that region safely
 		int nonPrimaryDcs = dataCenters / 2;
 		for (int dc = 1; dc < dataCenters; dc += 2) {
@@ -1372,14 +1379,14 @@ void setupSimulatedSystem(vector<Future<Void>>* systemActors,
 	ClusterConnectionString conn(coordinatorAddresses, LiteralStringRef("TestCluster:0"));
 
 	// If extraDB==0, leave g_simulator.extraDB as null because the test does not use DR.
-	if (extraDB == 1) {
+	if (testConfig.extraDB == 1) {
 		// The DR database can be either a new database or itself
 		g_simulator.extraDB = new ClusterConnectionString(
 		    coordinatorAddresses, BUGGIFY ? LiteralStringRef("TestCluster:0") : LiteralStringRef("ExtraCluster:0"));
-	} else if (extraDB == 2) {
+	} else if (testConfig.extraDB == 2) {
 		// The DR database is a new database
 		g_simulator.extraDB = new ClusterConnectionString(coordinatorAddresses, LiteralStringRef("ExtraCluster:0"));
-	} else if (extraDB == 3) {
+	} else if (testConfig.extraDB == 3) {
 		// The DR database is the same database
 		g_simulator.extraDB = new ClusterConnectionString(coordinatorAddresses, LiteralStringRef("TestCluster:0"));
 	}
@@ -1390,7 +1397,7 @@ void setupSimulatedSystem(vector<Future<Void>>* systemActors,
 	    .detail("String", conn.toString())
 	    .detail("ConfigString", startingConfigString);
 
-	bool requiresExtraDBMachines = extraDB && g_simulator.extraDB->toString() != conn.toString();
+	bool requiresExtraDBMachines = testConfig.extraDB && g_simulator.extraDB->toString() != conn.toString();
 	int assignedMachines = 0, nonVersatileMachines = 0;
 	std::vector<ProcessClass::ClassType> processClassesSubSet = { ProcessClass::UnsetClass,
 		                                                          ProcessClass::ResolutionClass,
@@ -1555,11 +1562,8 @@ void setupSimulatedSystem(vector<Future<Void>>* systemActors,
 	    .detail("StartingConfiguration", pStartingConfiguration->toString());
 }
 
-void checkTestConf(const char* testFile,
-                   int& extraDB,
-                   int& minimumReplication,
-                   int& minimumRegions,
-                   int& configureLocked) {
+
+void checkTestConf(const char* testFile, TestConfig* testConfig) {
 	std::ifstream ifs;
 	ifs.open(testFile, std::ifstream::in);
 	if (!ifs.good())
@@ -1581,19 +1585,31 @@ void checkTestConf(const char* testFile,
 		std::string value = removeWhitespace(line.substr(found + 1));
 
 		if (attrib == "extraDB") {
-			sscanf(value.c_str(), "%d", &extraDB);
+			sscanf(value.c_str(), "%d", &testConfig->extraDB);
 		}
 
 		if (attrib == "minimumReplication") {
-			sscanf(value.c_str(), "%d", &minimumReplication);
+			sscanf(value.c_str(), "%d", &testConfig->minimumReplication);
 		}
 
 		if (attrib == "minimumRegions") {
-			sscanf(value.c_str(), "%d", &minimumRegions);
+			sscanf(value.c_str(), "%d", &testConfig->minimumRegions);
 		}
 
 		if (attrib == "configureLocked") {
-			sscanf(value.c_str(), "%d", &configureLocked);
+			sscanf(value.c_str(), "%d", &testConfig->configureLocked);
+		}
+
+		if (attrib == "startIncompatibleProcess") {
+			testConfig->startIncompatibleProcess = strcmp(value.c_str(), "true") == 0;
+		}
+
+		if (attrib == "logAntiQuorum") {
+			sscanf(value.c_str(), "%d", &testConfig->logAntiQuorum);
+		}
+
+		if (attrib == "storageEngineExcludeType") {
+			sscanf(value.c_str(), "%d", &testConfig->storageEngineExcludeType);
 		}
 	}
 
@@ -1609,11 +1625,18 @@ ACTOR void setupAndRun(std::string dataFolder,
 	state Optional<ClusterConnectionString> connFile;
 	state Standalone<StringRef> startingConfiguration;
 	state int testerCount = 1;
-	state int extraDB = 0;
-	state int minimumReplication = 0;
-	state int minimumRegions = 0;
-	state int configureLocked = 0;
-	checkTestConf(testFile, extraDB, minimumReplication, minimumRegions, configureLocked);
+	state TestConfig testConfig;
+	checkTestConf(testFile, &testConfig);
+	g_simulator.hasDiffProtocolProcess = testConfig.startIncompatibleProcess;
+	g_simulator.setDiffProtocol = false;
+
+	state ProtocolVersion protocolVersion = currentProtocolVersion;
+	if (testConfig.startIncompatibleProcess) {
+		// isolates right most 1 bit of compatibleProtocolVersionMask to make this protocolVersion incompatible
+		uint64_t minAddToMakeIncompatible =
+		    ProtocolVersion::compatibleProtocolVersionMask & ~(ProtocolVersion::compatibleProtocolVersionMask - 1);
+		protocolVersion = ProtocolVersion(currentProtocolVersion.version() + minAddToMakeIncompatible);
+	}
 
 	// TODO (IPv6) Use IPv6?
 	wait(g_simulator.onProcess(
@@ -1642,8 +1665,9 @@ ACTOR void setupAndRun(std::string dataFolder,
 			                                         &testerCount,
 			                                         &connFile,
 			                                         &startingConfiguration,
-			                                         extraDB,
-			                                         whitelistBinPaths),
+			                                         testConfig,
+			                                         whitelistBinPaths,
+			                                         protocolVersion),
 			                  100.0));
 			// FIXME: snapshot restore does not support multi-region restore, hence restore it as single region always
 			if (restoring) {
@@ -1656,11 +1680,9 @@ ACTOR void setupAndRun(std::string dataFolder,
 			                     &testerCount,
 			                     &connFile,
 			                     &startingConfiguration,
-			                     extraDB,
-			                     minimumReplication,
-			                     minimumRegions,
 			                     whitelistBinPaths,
-			                     configureLocked);
+			                     testConfig,
+			                     protocolVersion);
 			wait(delay(1.0)); // FIXME: WHY!!!  //wait for machines to boot
 		}
 		std::string clusterFileDir = joinPath(dataFolder, deterministicRandom()->randomUniqueID().toString());

--- a/fdbserver/SimulatedCluster.actor.cpp
+++ b/fdbserver/SimulatedCluster.actor.cpp
@@ -655,8 +655,7 @@ ACTOR Future<Void> restartSimulatedSystem(vector<Future<Void>>* systemActors,
                                           Optional<ClusterConnectionString>* pConnString,
                                           Standalone<StringRef>* pStartingConfiguration,
                                           TestConfig testConfig,
-                                          std::string whitelistBinPaths,
-                                          ProtocolVersion protocolVersion) {
+                                          std::string whitelistBinPaths) {
 	CSimpleIni ini;
 	ini.SetUnicode();
 	ini.LoadFile(joinPath(baseFolder, "restartInfo.ini").c_str());
@@ -1219,8 +1218,7 @@ void setupSimulatedSystem(vector<Future<Void>>* systemActors,
                           Optional<ClusterConnectionString>* pConnString,
                           Standalone<StringRef>* pStartingConfiguration,
                           std::string whitelistBinPaths,
-                          TestConfig testConfig,
-                          ProtocolVersion protocolVersion) {
+                          TestConfig testConfig) {
 	// SOMEDAY: this does not test multi-interface configurations
 	SimulationConfig simconfig(testConfig);
 	if (testConfig.logAntiQuorum != -1) {
@@ -1634,14 +1632,6 @@ ACTOR void setupAndRun(std::string dataFolder,
 	state TestConfig testConfig;
 	checkTestConf(testFile, &testConfig);
 
-	state ProtocolVersion protocolVersion = currentProtocolVersion;
-	if (testConfig.startIncompatibleProcess) {
-		// isolates right most 1 bit of compatibleProtocolVersionMask to make this protocolVersion incompatible
-		uint64_t minAddToMakeIncompatible =
-		    ProtocolVersion::compatibleProtocolVersionMask & ~(ProtocolVersion::compatibleProtocolVersionMask - 1);
-		protocolVersion = ProtocolVersion(currentProtocolVersion.version() + minAddToMakeIncompatible);
-	}
-
 	// TODO (IPv6) Use IPv6?
 	wait(g_simulator.onProcess(
 	    g_simulator.newProcess("TestSystem",
@@ -1670,8 +1660,7 @@ ACTOR void setupAndRun(std::string dataFolder,
 			                                         &connFile,
 			                                         &startingConfiguration,
 			                                         testConfig,
-			                                         whitelistBinPaths,
-			                                         protocolVersion),
+			                                         whitelistBinPaths),
 			                  100.0));
 			// FIXME: snapshot restore does not support multi-region restore, hence restore it as single region always
 			if (restoring) {
@@ -1685,8 +1674,7 @@ ACTOR void setupAndRun(std::string dataFolder,
 			                     &connFile,
 			                     &startingConfiguration,
 			                     whitelistBinPaths,
-			                     testConfig,
-			                     protocolVersion);
+			                     testConfig);
 			wait(delay(1.0)); // FIXME: WHY!!!  //wait for machines to boot
 		}
 		std::string clusterFileDir = joinPath(dataFolder, deterministicRandom()->randomUniqueID().toString());

--- a/fdbserver/SimulatedCluster.actor.cpp
+++ b/fdbserver/SimulatedCluster.actor.cpp
@@ -1567,7 +1567,7 @@ void setupSimulatedSystem(vector<Future<Void>>* systemActors,
 	    .detail("StartingConfiguration", pStartingConfiguration->toString());
 }
 
-
+// Populates the TestConfig fields according to what is found in the test file.
 void checkTestConf(const char* testFile, TestConfig* testConfig) {
 	std::ifstream ifs;
 	ifs.open(testFile, std::ifstream::in);

--- a/fdbserver/SimulatedCluster.actor.cpp
+++ b/fdbserver/SimulatedCluster.actor.cpp
@@ -811,6 +811,7 @@ ACTOR Future<Void> restartSimulatedSystem(vector<Future<Void>>* systemActors,
 	return Void();
 }
 
+// Configuration details compiled in a structure used when setting up a simulated cluster
 struct SimulationConfig {
 	explicit SimulationConfig(const TestConfig& testConfig);
 	int extraDB;

--- a/fdbserver/TesterInterface.actor.h
+++ b/fdbserver/TesterInterface.actor.h
@@ -99,6 +99,8 @@ struct WorkloadRequest {
 	}
 };
 
+// Configuration details specified in workload test files that change the simulation
+// environment details
 struct TestConfig {
 	int extraDB = 0;
 	int minimumReplication = 0;

--- a/fdbserver/TesterInterface.actor.h
+++ b/fdbserver/TesterInterface.actor.h
@@ -99,6 +99,22 @@ struct WorkloadRequest {
 	}
 };
 
+struct TestConfig {
+	int extraDB = 0;
+	int minimumReplication = 0;
+	int minimumRegions = 0;
+	int configureLocked = 0;
+	bool startIncompatibleProcess = false;
+	int logAntiQuorum = -1;
+	// Storage Engine Types: Verify match with SimulationConfig::generateNormalConfig
+	//	-1 = None
+	//	0 = "ssd"
+	//	1 = "memory"
+	//	2 = "memory-radixtree-beta"
+	//	3 = "ssd-redwood-experimental"
+	int storageEngineExcludeType = -1;
+};
+
 struct TesterInterface {
 	constexpr static FileIdentifier file_identifier = 4465210;
 	RequestStream<WorkloadRequest> recruitments;


### PR DESCRIPTION
This PR is the cherry-pick of the commits in https://github.com/apple/foundationdb/pull/4537 and https://github.com/apple/foundationdb/pull/4544 from `master` to `release-6.3`. The reason these changes need to go into 6.3 is to support a test configuration that allows redwood as a storage engine type to be disabled for particular simulation tests. This is necessary for testing correctness of 6.3->6.2 downgrades.

There are some additional changes that remove references to fields only present on master and were carried over through the cherry-pick. `protocolVersion` as a parameter, and references to `g_simulator.hasDiffProtocolProcess` and `g_simulator.setDiffProtocol` were removed.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [x] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [x] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [x] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
