### PR TITLE
Network Busyness Java API

### DIFF
--- a/bindings/java/fdbJNI.cpp
+++ b/bindings/java/fdbJNI.cpp
@@ -580,6 +580,9 @@ JNIEXPORT void JNICALL Java_com_apple_foundationdb_FDBDatabase_Database_1setOpti
 	}
 }
 
+// Get network thread busyness (updated every 1s)
+// A value of 0 indicates that the client is more or less idle
+// A value of 1 (or more) indicates that the client is saturated
 JNIEXPORT jdouble JNICALL Java_com_apple_foundationdb_FDBDatabase_Database_1getMainThreadBusyness(JNIEnv* jenv,
 																								  jobject,
 																								  jlong dbPtr) {

--- a/bindings/java/fdbJNI.cpp
+++ b/bindings/java/fdbJNI.cpp
@@ -584,14 +584,14 @@ JNIEXPORT void JNICALL Java_com_apple_foundationdb_FDBDatabase_Database_1setOpti
 // A value of 0 indicates that the client is more or less idle
 // A value of 1 (or more) indicates that the client is saturated
 JNIEXPORT jdouble JNICALL Java_com_apple_foundationdb_FDBDatabase_Database_1getMainThreadBusyness(JNIEnv* jenv,
-																								  jobject,
-																								  jlong dbPtr) {
+                                                                                                  jobject,
+                                                                                                  jlong dbPtr) {
 	if (!dbPtr) {
 		throwParamNotNull(jenv);
 		return 0;
 	}
 	FDBDatabase* database = (FDBDatabase*)dbPtr;
-	return (jdouble) fdb_database_get_main_thread_busyness(database);
+	return (jdouble)fdb_database_get_main_thread_busyness(database);
 }
 
 JNIEXPORT jboolean JNICALL Java_com_apple_foundationdb_FDB_Error_1predicate(JNIEnv* jenv,

--- a/bindings/java/fdbJNI.cpp
+++ b/bindings/java/fdbJNI.cpp
@@ -580,6 +580,17 @@ JNIEXPORT void JNICALL Java_com_apple_foundationdb_FDBDatabase_Database_1setOpti
 	}
 }
 
+JNIEXPORT jdouble JNICALL Java_com_apple_foundationdb_FDBDatabase_Database_1getMainThreadBusyness(JNIEnv* jenv,
+																								  jobject,
+																								  jlong dbPtr) {
+	if (!dbPtr) {
+		throwParamNotNull(jenv);
+		return 0;
+	}
+	FDBDatabase* database = (FDBDatabase*)dbPtr;
+	return (jdouble) fdb_database_get_main_thread_busyness(database);
+}
+
 JNIEXPORT jboolean JNICALL Java_com_apple_foundationdb_FDB_Error_1predicate(JNIEnv* jenv,
                                                                             jobject,
                                                                             jint predicate,

--- a/bindings/java/src/main/com/apple/foundationdb/Database.java
+++ b/bindings/java/src/main/com/apple/foundationdb/Database.java
@@ -81,6 +81,15 @@ public interface Database extends AutoCloseable, TransactionContext {
 	DatabaseOptions options();
 
 	/**
+	 * Returns a value which indicates the saturation of the client
+	 * <br>
+	 * <b>Note:</b> By default, this value is updated every second
+	 *
+	 * @return a value where 0 indicates that the client is idle and 1 (or larger) indicates that the client is saturated.
+	 */
+	double getMainThreadBusyness();
+
+	/**
 	 * Runs a read-only transactional function against this {@code Database} with retry logic.
 	 *  {@link Function#apply(Object) apply(ReadTransaction)} will be called on the
 	 *  supplied {@link Function} until a non-retryable

--- a/bindings/java/src/main/com/apple/foundationdb/FDBDatabase.java
+++ b/bindings/java/src/main/com/apple/foundationdb/FDBDatabase.java
@@ -151,6 +151,16 @@ class FDBDatabase extends NativeObjectWrapper implements Database, OptionConsume
 	}
 
 	@Override
+	public double getMainThreadBusyness() {
+		pointerReadLock.lock();
+		try {
+			return Database_getMainThreadBusyness(getPtr());
+		} finally {
+			pointerReadLock.unlock();
+		}
+	}
+
+	@Override
 	public Executor getExecutor() {
 		return executor;
 	}
@@ -163,4 +173,5 @@ class FDBDatabase extends NativeObjectWrapper implements Database, OptionConsume
 	private native long Database_createTransaction(long cPtr);
 	private native void Database_dispose(long cPtr);
 	private native void Database_setOption(long cPtr, int code, byte[] value) throws FDBException;
+	private native double Database_getMainThreadBusyness(long cPtr);
 }

--- a/bindings/java/src/test/com/apple/foundationdb/test/AsyncStackTester.java
+++ b/bindings/java/src/test/com/apple/foundationdb/test/AsyncStackTester.java
@@ -510,6 +510,12 @@ public class AsyncStackTester {
 				db.options().setTransactionCausalReadRisky();
 				db.options().setTransactionIncludePortInAddress();
 
+				// Test network busyness
+				double busyness = db.getMainThreadBusyness();
+				if (busyness < 0) {
+					throw new IllegalStateException("Network busyness cannot be less than 0");
+				}
+
 				tr.options().setPrioritySystemImmediate();
 				tr.options().setPriorityBatch();
 				tr.options().setCausalReadRisky();


### PR DESCRIPTION
This PR adds Java support for calling the network busyness API which was implemented in #4504 

Passed 10k joshua runs for bindingtester.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [x] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
