### PR TITLE
Fix boost build on OS X

### DIFF
--- a/cmake/CompileBoost.cmake
+++ b/cmake/CompileBoost.cmake
@@ -10,7 +10,7 @@ function(compile_boost)
   set(BOOST_COMPILER_FLAGS -fvisibility=hidden -fPIC -std=c++14 -w)
   set(BOOST_CXX_COMPILER "${CMAKE_CXX_COMPILER}")
   if(APPLE)
-    set(BOOST_TOOLSET "darwin")
+    set(BOOST_TOOLSET "clang-darwin")
     # this is to fix a weird macOS issue -- by default
     # cmake would otherwise pass a compiler that can't
     # compile boost


### PR DESCRIPTION
The current OS X build is failing with
```
clang: error: unknown argument: '-fcoalesce-templates'
```
I found the fix from this [post](https://github.com/alisw/alidist/pull/2159)

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
