### PR TITLE
Updated test parser to read new option correctly

### DIFF
--- a/fdbserver/tester.actor.cpp
+++ b/fdbserver/tester.actor.cpp
@@ -977,7 +977,9 @@ std::map<std::string, std::function<void(const std::string&)>> testSpecGlobalKey
 	      TraceEvent("TestParserTest").detail("ClientInfoLogging", value);
 	  } },
 	{ "startIncompatibleProcess",
-	  [](const std::string& value) { TraceEvent("TestParserTest").detail("ParsedStartIncompatibleProcess", value); } }
+	  [](const std::string& value) { TraceEvent("TestParserTest").detail("ParsedStartIncompatibleProcess", value); } },
+	{ "storageEngineExcludeType",
+	  [](const std::string& value) { TraceEvent("TestParserTest").detail("ParsedStorageEngineExcludeType", ""); } }
 };
 
 std::map<std::string, std::function<void(const std::string& value, TestSpec* spec)>> testSpecTestKeys = {

--- a/tests/restarting/to_6.3.10/CycleTestRestart-1.txt
+++ b/tests/restarting/to_6.3.10/CycleTestRestart-1.txt
@@ -1,3 +1,4 @@
+storageEngineExcludeType=-1
 testTitle=Clogged
     clearAfterTest=false
     testName=Cycle
@@ -28,5 +29,3 @@ testTitle=Clogged
     testName=SaveAndKill
     restartInfoLocation=simfdb/restartInfo.ini
     testDuration=10.0
-
-storageEngineExcludeType=-1

--- a/tests/restarting/to_6.3.10/CycleTestRestart-1.txt
+++ b/tests/restarting/to_6.3.10/CycleTestRestart-1.txt
@@ -28,3 +28,5 @@ testTitle=Clogged
     testName=SaveAndKill
     restartInfoLocation=simfdb/restartInfo.ini
     testDuration=10.0
+
+storageEngineExcludeType=-1

--- a/tests/restarting/to_6.3.10/CycleTestRestart-2.txt
+++ b/tests/restarting/to_6.3.10/CycleTestRestart-2.txt
@@ -1,3 +1,4 @@
+storageEngineExcludeType=-1
 testTitle=Clogged
     runSetup=false
     testName=Cycle
@@ -24,5 +25,3 @@ testTitle=Clogged
     machinesToLeave=3
     reboot=true
     testDuration=10.0
-
-storageEngineExcludeType=-1

--- a/tests/restarting/to_6.3.10/CycleTestRestart-2.txt
+++ b/tests/restarting/to_6.3.10/CycleTestRestart-2.txt
@@ -24,3 +24,5 @@ testTitle=Clogged
     machinesToLeave=3
     reboot=true
     testDuration=10.0
+
+storageEngineExcludeType=-1


### PR DESCRIPTION
https://github.com/apple/foundationdb/pull/4559 introduced a new test workload option `storageEngineExcludeType`, but was missing some code in `tester.actor.cpp` to recognize the option and avoid failing tests. Also added the option to some test files with the default option to ensure the option is being parsed properly.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
