### PR TITLE
Updated test parser to read new option correctly (6.3)

### DIFF
--- a/fdbserver/tester.actor.cpp
+++ b/fdbserver/tester.actor.cpp
@@ -926,6 +926,9 @@ ACTOR Future<bool> runTest(Database cx,
 	return ok;
 }
 
+// Reads the test spec in order to decide what tests to run and what
+// type of configuration to run it with. If an attribute is in a test spec
+// but not handled properly in this function, the test may log an error.
 vector<TestSpec> readTests(ifstream& ifs) {
 	TestSpec spec;
 	vector<TestSpec> result;

--- a/fdbserver/tester.actor.cpp
+++ b/fdbserver/tester.actor.cpp
@@ -1054,6 +1054,8 @@ vector<TestSpec> readTests(ifstream& ifs) {
 			}
 			// else { } It is enable by default for tester
 			TraceEvent("TestParserTest").detail("ClientInfoLogging", value);
+		} else if (attrib == "storageEngineExcludeType") {
+			TraceEvent("TestParserTest").detail("ParsedStorageEngineExcludeType", "");
 		} else {
 			if (attrib == "testName") {
 				if (workloadOptions.size()) {

--- a/tests/fast/MoveKeysCycle.txt
+++ b/tests/fast/MoveKeysCycle.txt
@@ -18,3 +18,5 @@ testTitle=MoveKeysCycle
     machinesToLeave=3
     reboot=true
     testDuration=10.0
+
+storageEngineExcludeType=-1


### PR DESCRIPTION
Backporting https://github.com/apple/foundationdb/pull/4573 fix to 6.3 as well. The test parsing code between 7.0 and 6.3 are different, so the code changes are not cherry-picked from the original commit. This is necessary on 6.3 to fix a missed part from https://github.com/apple/foundationdb/pull/4559.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [x] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [x] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [x] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
