### PR TITLE
Add benchmark for deserializing GetKeyValuesReply

### DIFF
--- a/flow/Arena.h
+++ b/flow/Arena.h
@@ -782,12 +782,12 @@ struct VectorRefPreserializer<T, VecSerStrategy::String> {
 
 	void invalidate() { _cached_size = -1; }
 	void add(const T& item) {
-		if (_cached_size > 0) {
+		if (_cached_size >= 0) {
 			_cached_size += _string_traits.getSize(item);
 		}
 	}
 	void remove(const T& item) {
-		if (_cached_size > 0) {
+		if (_cached_size >= 0) {
 			_cached_size -= _string_traits.getSize(item);
 		}
 	}

--- a/flowbench/CMakeLists.txt
+++ b/flowbench/CMakeLists.txt
@@ -8,6 +8,7 @@ set(FLOWBENCH_SRCS
   BenchRef.cpp
   BenchStream.actor.cpp
   BenchTimer.cpp
+  GetKeyValuesReply.cpp
   GlobalData.h
   GlobalData.cpp)
 

--- a/flowbench/GetKeyValuesReply.cpp
+++ b/flowbench/GetKeyValuesReply.cpp
@@ -1,0 +1,53 @@
+/*
+ * GetKeyValuesReply.cpp
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "benchmark/benchmark.h"
+
+#include "fdbclient/StorageServerInterface.h"
+#include "flow/IRandom.h"
+#include "flow/ThreadHelper.actor.h"
+#include "flow/ObjectSerializer.h"
+#include "flow/serialize.h"
+
+static void bench_kv_reply_deser(benchmark::State& benchState) {
+	GetKeyValuesReply rep;
+	const size_t keySize = benchState.range(0);
+	const size_t valSize = benchState.range(1);
+	const size_t keys = 80000 / (keySize + valSize);
+	for (size_t i = 0; i < keys; ++i) {
+		BinaryWriter keyWriter(Unversioned());
+		keyWriter << i;
+		keyWriter.serializeBytes(deterministicRandom()->randomAlphaNumeric(keySize - sizeof(i)).c_str(),
+		                         keySize - sizeof(i));
+		rep.data.push_back_deep(
+		    rep.arena, KeyValueRef(keyWriter.toValue(), StringRef(deterministicRandom()->randomAlphaNumeric(valSize))));
+	}
+	auto serialized = ObjectWriter::toValue(rep, Unversioned());
+
+	while (benchState.KeepRunning()) {
+		ArenaObjectReader reader(serialized.arena(), serialized, Unversioned());
+		GetKeyValuesReply rep2;
+		reader.deserialize(rep2);
+		benchmark::DoNotOptimize(rep2);
+	}
+	benchState.SetBytesProcessed(benchState.iterations() * keys * (keySize + valSize));
+}
+
+BENCHMARK(bench_kv_reply_deser)->Ranges({ { 8, 128 }, { 0, 1024 } })->ReportAggregatesOnly(true);

--- a/flowbench/flowbench.actor.cpp
+++ b/flowbench/flowbench.actor.cpp
@@ -24,6 +24,8 @@
 #include "flow/ThreadHelper.actor.h"
 #include <thread>
 
+#include "flow/actorcompiler.h" // This must be the last include
+
 ACTOR template <class T>
 Future<T> stopNetworkAfter(Future<T> what) {
 	try {


### PR DESCRIPTION
Also fix a bug in VectorRefPreserializer

Put description here...

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
