### PR TITLE
Cherry pick #3698 to release-6.3

### DIFF
--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -1517,9 +1517,11 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 			return;
 		// Record all team collections IDs
 		for (int i = 0; i < teamCollections.size(); ++i) {
-			TraceEvent("TraceAllInfo", distributorId)
-			    .detail("TeamCollectionIndex", i)
-			    .detail("Primary", teamCollections[i]->primary);
+			if (teamCollections[i] != nullptr) {
+				TraceEvent("TraceAllInfo", distributorId)
+				    .detail("TeamCollectionIndex", i)
+				    .detail("Primary", teamCollections[i]->primary);
+			}
 		}
 
 		TraceEvent("TraceAllInfo", distributorId).detail("Primary", primary);


### PR DESCRIPTION
We see segfault failure in release-6.3 joshua run recently (reference: #4593), and it appears that this issue has been fixed in master 7 month ago. So this PR cherry-pick the fix into release-6.3.

100K joshua run passed:
20210330-232404-zhewu_4594-c66be81196788115        compressed=True data_size=20342059 duration=5550892 ended=105589 fail_fast=10 max_runs=100000 pass=100001 priority=100 remaining=0 runtime=0:27:43 sanity=False started=107992 stopped=20210330-235147 submitted=20210330-232404 timeout=5400 username=zhewu_4594

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
