### PR TITLE
Fixed simulations which timeout setting starting configuration

### DIFF
--- a/fdbrpc/simulator.h
+++ b/fdbrpc/simulator.h
@@ -391,6 +391,7 @@ public:
 	std::string disablePrimary;
 	std::string disableRemote;
 	std::string originalRegions;
+	std::string startingDisabledConfiguration;
 	bool allowLogSetKills;
 	Optional<Standalone<StringRef>> remoteDcId;
 	bool hasSatelliteReplication;

--- a/fdbserver/SimulatedCluster.actor.cpp
+++ b/fdbserver/SimulatedCluster.actor.cpp
@@ -1179,9 +1179,6 @@ void SimulationConfig::generateNormalConfig(const TestConfig& testConfig) {
 			regionArr.push_back(remoteObj);
 		}
 
-		set_config("regions=" +
-		           json_spirit::write_string(json_spirit::mValue(regionArr), json_spirit::Output_options::none));
-
 		if (needsRemote) {
 			g_simulator.originalRegions = "regions=" + json_spirit::write_string(json_spirit::mValue(regionArr),
 			                                                                     json_spirit::Output_options::none);
@@ -1195,6 +1192,11 @@ void SimulationConfig::generateNormalConfig(const TestConfig& testConfig) {
 			disableRemote[1].get_obj()["datacenters"].get_array()[0].get_obj()["priority"] = -1;
 			g_simulator.disableRemote = "regions=" + json_spirit::write_string(json_spirit::mValue(disableRemote),
 			                                                                   json_spirit::Output_options::none);
+		} else {
+			// In order to generate a starting configuration with the remote disabled, do not apply the region
+			// configuration to the DatabaseConfiguration until after creating the starting conf string.
+			set_config("regions=" +
+			           json_spirit::write_string(json_spirit::mValue(regionArr), json_spirit::Output_options::none));
 		}
 	}
 
@@ -1274,6 +1276,12 @@ void setupSimulatedSystem(vector<Future<Void>>* systemActors,
 		} else {
 			ASSERT(false);
 		}
+	}
+
+	if (g_simulator.originalRegions != "") {
+		simconfig.set_config(g_simulator.originalRegions);
+		g_simulator.startingDisabledConfiguration = startingConfigString + " " + g_simulator.disableRemote;
+		startingConfigString += " " + g_simulator.originalRegions;
 	}
 
 	g_simulator.storagePolicy = simconfig.db.storagePolicy;

--- a/fdbserver/workloads/ChangeConfig.actor.cpp
+++ b/fdbserver/workloads/ChangeConfig.actor.cpp
@@ -61,10 +61,10 @@ struct ChangeConfigWorkload : TestWorkload {
 
 			wait(delay(5 * deterministicRandom()->random01()));
 			if (self->configMode.size()) {
-				if (g_simulator.usableRegions == 2) {
+				if (g_simulator.startingDisabledConfiguration != "") {
 					// It is not safe to allow automatic failover to a region which is not fully replicated,
 					// so wait for both regions to be fully replicated before enabling failover
-					wait(success(changeConfig(extraDB, g_simulator.disableRemote, true)));
+					wait(success(changeConfig(extraDB, g_simulator.startingDisabledConfiguration, true)));
 					TraceEvent("WaitForReplicasExtra");
 					wait(waitForFullReplication(extraDB));
 					TraceEvent("WaitForReplicasExtraEnd");
@@ -95,10 +95,10 @@ struct ChangeConfigWorkload : TestWorkload {
 		}
 
 		if (self->configMode.size()) {
-			// It is not safe to allow automatic failover to a region which is not fully replicated,
-			// so wait for both regions to be fully replicated before enabling failover
-			if (g_network->isSimulated() && g_simulator.usableRegions == 2) {
-				wait(success(changeConfig(cx, g_simulator.disableRemote, true)));
+			if (g_network->isSimulated() && g_simulator.startingDisabledConfiguration != "") {
+				// It is not safe to allow automatic failover to a region which is not fully replicated,
+				// so wait for both regions to be fully replicated before enabling failover
+				wait(success(changeConfig(cx, g_simulator.startingDisabledConfiguration, true)));
 				TraceEvent("WaitForReplicas");
 				wait(waitForFullReplication(cx));
 				TraceEvent("WaitForReplicasEnd");

--- a/fdbserver/workloads/ChangeConfig.actor.cpp
+++ b/fdbserver/workloads/ChangeConfig.actor.cpp
@@ -52,6 +52,8 @@ struct ChangeConfigWorkload : TestWorkload {
 
 	void getMetrics(vector<PerfMetric>& m) override {}
 
+	// When simulated two clusters for DR tests, this actor sets the starting configuration
+	// for the extra cluster.
 	ACTOR Future<Void> extraDatabaseConfigure(ChangeConfigWorkload* self) {
 		if (g_network->isSimulated() && g_simulator.extraDB) {
 			auto extraFile = makeReference<ClusterConnectionFile>(*g_simulator.extraDB);
@@ -59,10 +61,15 @@ struct ChangeConfigWorkload : TestWorkload {
 
 			wait(delay(5 * deterministicRandom()->random01()));
 			if (self->configMode.size()) {
+				if (g_simulator.usableRegions == 2) {
+					// It is not safe to allow automatic failover to a region which is not fully replicated,
+					// so wait for both regions to be fully replicated before enabling failover
+					wait(success(changeConfig(extraDB, g_simulator.disableRemote, true)));
+					TraceEvent("WaitForReplicasExtra");
+					wait(waitForFullReplication(extraDB));
+					TraceEvent("WaitForReplicasExtraEnd");
+				}
 				wait(success(changeConfig(extraDB, self->configMode, true)));
-				TraceEvent("WaitForReplicasExtra");
-				wait(waitForFullReplication(extraDB));
-				TraceEvent("WaitForReplicasExtraEnd");
 			}
 			if (self->networkAddresses.size()) {
 				if (self->networkAddresses == "auto")
@@ -75,6 +82,8 @@ struct ChangeConfigWorkload : TestWorkload {
 		return Void();
 	}
 
+	// Either changes the database configuration, or changes the coordinators based on the parameters
+	// of the workload.
 	ACTOR Future<Void> ChangeConfigClient(Database cx, ChangeConfigWorkload* self) {
 		wait(delay(self->minDelayBeforeChange +
 		           deterministicRandom()->random01() * (self->maxDelayBeforeChange - self->minDelayBeforeChange)));
@@ -86,10 +95,15 @@ struct ChangeConfigWorkload : TestWorkload {
 		}
 
 		if (self->configMode.size()) {
+			// It is not safe to allow automatic failover to a region which is not fully replicated,
+			// so wait for both regions to be fully replicated before enabling failover
+			if (g_network->isSimulated() && g_simulator.usableRegions == 2) {
+				wait(success(changeConfig(cx, g_simulator.disableRemote, true)));
+				TraceEvent("WaitForReplicas");
+				wait(waitForFullReplication(cx));
+				TraceEvent("WaitForReplicasEnd");
+			}
 			wait(success(changeConfig(cx, self->configMode, true)));
-			TraceEvent("WaitForReplicas");
-			wait(waitForFullReplication(cx));
-			TraceEvent("WaitForReplicasEnd");
 		}
 		if (self->networkAddresses.size()) {
 			if (self->networkAddresses == "auto")


### PR DESCRIPTION
Simulations with region configurations that enables automatic failover could failover before both regions are fully replicated.

2 failures out of 200k tests

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [x] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
