### PR TITLE
Removing String.format from ByteArrayUtil.printable.

### DIFF
--- a/bindings/java/src/junit/com/apple/foundationdb/tuple/ByteArrayUtilTest.java
+++ b/bindings/java/src/junit/com/apple/foundationdb/tuple/ByteArrayUtilTest.java
@@ -1,0 +1,42 @@
+package com.apple.foundationdb.tuple;
+
+import java.nio.charset.Charset;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class ByteArrayUtilTest {
+	
+	@Test
+	void printableWorksForAllByteValues(){
+		//Quick test to make sure that no bytes are unprintable
+		byte[] bytes = new byte[2*((int)Byte.MAX_VALUE+1)];
+		for(int i=0; i< bytes.length;i++){
+			bytes[i] = (byte)(i & 0xff);
+		}
+
+		String value = ByteArrayUtil.printable(bytes);
+		String expected = "\\x00\\x01\\x02\\x03\\x04\\x05\\x06\\x07\\x08\\x09\\x0a\\x0b\\x0c\\x0d\\x0e\\x0f\\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17\\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\\x7f\\x80\\x81\\x82\\x83\\x84\\x85\\x86\\x87\\x88\\x89\\x8a\\x8b\\x8c\\x8d\\x8e\\x8f\\x90\\x91\\x92\\x93\\x94\\x95\\x96\\x97\\x98\\x99\\x9a\\x9b\\x9c\\x9d\\x9e\\x9f\\xa0\\xa1\\xa2\\xa3\\xa4\\xa5\\xa6\\xa7\\xa8\\xa9\\xaa\\xab\\xac\\xad\\xae\\xaf\\xb0\\xb1\\xb2\\xb3\\xb4\\xb5\\xb6\\xb7\\xb8\\xb9\\xba\\xbb\\xbc\\xbd\\xbe\\xbf\\xc0\\xc1\\xc2\\xc3\\xc4\\xc5\\xc6\\xc7\\xc8\\xc9\\xca\\xcb\\xcc\\xcd\\xce\\xcf\\xd0\\xd1\\xd2\\xd3\\xd4\\xd5\\xd6\\xd7\\xd8\\xd9\\xda\\xdb\\xdc\\xdd\\xde\\xdf\\xe0\\xe1\\xe2\\xe3\\xe4\\xe5\\xe6\\xe7\\xe8\\xe9\\xea\\xeb\\xec\\xed\\xee\\xef\\xf0\\xf1\\xf2\\xf3\\xf4\\xf5\\xf6\\xf7\\xf8\\xf9\\xfa\\xfb\\xfc\\xfd\\xfe\\xff";
+		Assertions.assertEquals(expected,value,"Incorrect printable string");
+	}
+
+	@Test
+	void printableWorksForAsciiStrings(){
+		char[] asciiChars = new char[]{
+			'!','"','#','$','%','&','\'','(',')','*','+',',','~','.','/',
+			'0','1','2','3','4','5','6','7','8','9',':',';','<','?','@',
+			'A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T','U','V','W','X','Y','Z',
+			'[','\\',']','^','_','`',
+			'a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q','r','s','t','u','v','w','x','y','z','{','|','}','~',(char)127
+		};
+
+		for(int i=0;i<asciiChars.length;i++){
+			String substring = new String(asciiChars,0,i);
+			byte[] asciiBytes = substring.getBytes(Charset.forName("UTF-8"));
+
+			String printable = ByteArrayUtil.printable(asciiBytes);
+			String expected = substring.replace("\\", "\\\\");
+			Assertions.assertEquals(expected,printable,"Incorrect printable string");
+		}
+	}
+}

--- a/bindings/java/src/main/com/apple/foundationdb/tuple/ByteArrayUtil.java
+++ b/bindings/java/src/main/com/apple/foundationdb/tuple/ByteArrayUtil.java
@@ -419,6 +419,9 @@ public class ByteArrayUtil extends FastByteComparisons {
 		return ByteBuffer.wrap(src).order(ByteOrder.LITTLE_ENDIAN).getLong();
 	}
 
+	private static final char[] hexChars =
+	    new char[] { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f' };
+
 	/**
 	 * Gets a human readable version of a byte array. The bytes that correspond with
 	 *  ASCII printable characters [32-127) are passed through. Other bytes are
@@ -437,7 +440,14 @@ public class ByteArrayUtil extends FastByteComparisons {
 			byte b = val[i];
 			if (b >= 32 && b < 127 && b != '\\') s.append((char)b);
 			else if (b == '\\') s.append("\\\\");
-			else s.append(String.format("\\x%02x", b));
+			else {
+				//use a lookup table here to avoid doing an expensive String.format() call
+				s.append("\\x");
+				int nib = (b & 0xF0) >> 4;
+				s.append(hexChars[nib]);
+				nib = b & 0x0F;
+				s.append(hexChars[nib]);
+			}
 		}
 		return s.toString();
 	}

--- a/bindings/java/src/tests.cmake
+++ b/bindings/java/src/tests.cmake
@@ -28,6 +28,7 @@
 set(JAVA_JUNIT_TESTS
   src/junit/com/apple/foundationdb/tuple/ArrayUtilSortTest.java
   src/junit/com/apple/foundationdb/tuple/ArrayUtilTest.java
+  src/junit/com/apple/foundationdb/tuple/ByteArrayUtilTest.java
   src/junit/com/apple/foundationdb/tuple/TupleComparisonTest.java
   src/junit/com/apple/foundationdb/tuple/TuplePackingTest.java
   src/junit/com/apple/foundationdb/tuple/TupleSerializationTest.java


### PR DESCRIPTION
String.format can be potentially expensive, and if using `printable()` within a hot loop that can be a performance penalty. Admittedly, it doesn't seem like a good idea to call printable() from within a hot loop, but if you have to, it's good for it to perform well.

This removes the `String.format` call and replaces it with a simple char lookup table. Also adds a test file to check that it does what the javadoc says it does.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
