### PR TITLE
Fix early cutoff when DR copies logs

### DIFF
--- a/fdbclient/BackupAgentBase.actor.cpp
+++ b/fdbclient/BackupAgentBase.actor.cpp
@@ -743,6 +743,9 @@ ACTOR Future<Void> applyMutations(Database cx,
 			wait(coalesceKeyVersionCache(
 			    uid, newEndVersion, keyVersion, commit, committedVersion, addActor, &commitLock));
 			beginVersion = newEndVersion;
+			if (BUGGIFY) {
+				wait(delay(2.0));
+			}
 		}
 	} catch (Error& e) {
 		TraceEvent(e.code() == error_code_restore_missing_data ? SevWarnAlways : SevError, "ApplyMutationsError")

--- a/fdbclient/DatabaseBackupAgent.actor.cpp
+++ b/fdbclient/DatabaseBackupAgent.actor.cpp
@@ -1072,7 +1072,7 @@ struct CopyLogsTaskFunc : TaskFuncBase {
 
 			wait(waitForAll(addTaskVector) && taskBucket->finish(tr, task));
 		} else {
-			if (appliedVersion <= stopVersionData) {
+			if (appliedVersion < applyVersion) {
 				wait(delay(FLOW_KNOBS->PREVENT_FAST_SPIN_DELAY));
 				wait(success(CopyLogsTaskFunc::addTask(
 				    tr, taskBucket, task, prevBeginVersion, beginVersion, TaskCompletionKey::signal(onDone))));

--- a/fdbserver/workloads/BackupToDBCorrectness.actor.cpp
+++ b/fdbserver/workloads/BackupToDBCorrectness.actor.cpp
@@ -687,6 +687,8 @@ struct BackupToDBCorrectnessWorkload : TestWorkload {
 				wait(success(restoreTool.waitBackup(cx, self->restoreTag)));
 				wait(restoreTool.unlockBackup(cx, self->restoreTag));
 
+				// Make sure no more data is written to the restored range
+				// after the restore completes.
 				state std::vector<Standalone<RangeResultRef>> res1 = wait(readRanges(cx, restoreRange, self->backupPrefix));
 				wait(delay(5));
 				state std::vector<Standalone<RangeResultRef>> res2 = wait(readRanges(cx, restoreRange, self->backupPrefix));

--- a/fdbserver/workloads/BackupToDBCorrectness.actor.cpp
+++ b/fdbserver/workloads/BackupToDBCorrectness.actor.cpp
@@ -694,8 +694,8 @@ struct BackupToDBCorrectnessWorkload : TestWorkload {
 					auto range2 = res2.at(i);
 					ASSERT(range1.size() == range2.size());
 
-					for (int j = 0; i < range1.size(); ++j) {
-						ASSERT(range1[i].key == range2[i].key && range1[i].value == range2[i].value);
+					for (int j = 0; j < range1.size(); ++j) {
+						ASSERT(range1[j].key == range2[j].key && range1[j].value == range2[j].value);
 					}
 				}
 			}

--- a/fdbserver/workloads/BackupToDBCorrectness.actor.cpp
+++ b/fdbserver/workloads/BackupToDBCorrectness.actor.cpp
@@ -24,7 +24,9 @@
 #include "fdbserver/workloads/BulkSetup.actor.h"
 #include "flow/actorcompiler.h" // This must be the last #include.
 
-// A workload which test the correctness of backup and restore process
+// A workload which test the correctness of backup and restore process. The
+// database must be idle after the restore completes, and this workload checks
+// that the restore range does not change post restore.
 struct BackupToDBCorrectnessWorkload : TestWorkload {
 	double backupAfter, abortAndRestartAfter, restoreAfter;
 	double backupStartAt, restoreStartAfterBackupFinished, stopDifferentialAfter;


### PR DESCRIPTION
Fixes a conditional that was potentially causing data copying to stop early during DR backup.

Background:
* Disaster recovery is a special form of backup that backs up one FDB database to another FDB database. Read more about it at https://apple.github.io/foundationdb/backups.html.
* DR locks the destination database during a backup to ensure consistency, and therefore needs to know when the backup has completed in order to unlock the database.
* The current check used to determine if the backup is complete checks whether the version of the latest applied mutation is greater than or equal to the "stop version", or what version the backup should end at. Instead, the check should be made against `applyVersion`, which determines which versions have actually been applied.
* The potential issue arises when the latest version applied falls between `stopVersionData` and `applyVersion`. Theoretically, this could cause the database to complete the backup and then unlock the database when in reality not all versions have been written to the destination FDB database yet.
* This PR also adds a test that tries to detect this issue by comparing the backup range in the destination database at a five second interval after the backup finishes, and checks whether the ranges match. This test hasn't been able to cause a failure yet though.

Passed 49,995/50,000 `BackupToDBCorrectness.toml` runs on Joshua. The five failures were various related failures that are being or have been fixed (have not rebased this branch onto the latest master in a little while).

Thanks to @sfc-gh-etschannen for the help debugging this issue.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [x] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
