### PR TITLE
align developer aliases with CI build commands

### DIFF
--- a/build/docker/centos6/devel/Dockerfile
+++ b/build/docker/centos6/devel/Dockerfile
@@ -66,10 +66,10 @@ RUN rm -f /root/anaconda-ks.cfg && \
     'source /opt/rh/rh-ruby26/enable' \
     '' \
     'function cmk() {' \
-    '    cmake -S ${HOME}/src/foundationdb -B ${HOME}/build_output -D USE_CCACHE=1 -D RocksDB_ROOT=/opt/rocksdb-6.10.1 -G Ninja && ninja -C build_output -j 84' \
+    '    cmake -S ${HOME}/src/foundationdb -B ${HOME}/build_output -D USE_CCACHE=ON -D USE_WERROR=ON -D RocksDB_ROOT=/opt/rocksdb-6.10.1 -D RUN_JUNIT_TESTS=ON -D RUN_JAVA_INTEGRATION_TESTS=ON -G Ninja && ninja -C ${HOME}/build_output -j 84' \
     '}' \
     'function ct() {' \
-    '    cd ${HOME}/build_output && ctest -j 32 --output-on-failure' \
+    '    cd ${HOME}/build_output && ctest -j 32 --no-compress-output -T test --output-on-failure' \
     '}' \
     'function j() {' \
     '   python3 -m joshua.joshua "${@}"' \

--- a/build/docker/centos7/devel/Dockerfile
+++ b/build/docker/centos7/devel/Dockerfile
@@ -94,10 +94,10 @@ RUN rm -f /root/anaconda-ks.cfg && \
     'source /opt/rh/rh-ruby26/enable' \
     '' \
     'function cmk() {' \
-    '    cmake -S ${HOME}/src/foundationdb -B ${HOME}/build_output -D USE_CCACHE=1 -D RocksDB_ROOT=/opt/rocksdb-6.10.1 -G Ninja && ninja -C build_output -j 84' \
+    '    cmake -S ${HOME}/src/foundationdb -B ${HOME}/build_output -D USE_CCACHE=ON -D USE_WERROR=ON -D RocksDB_ROOT=/opt/rocksdb-6.10.1 -D RUN_JUNIT_TESTS=ON -D RUN_JAVA_INTEGRATION_TESTS=ON -G Ninja && ninja -C ${HOME}/build_output -j 84' \
     '}' \
     'function ct() {' \
-    '    cd ${HOME}/build_output && ctest -j 32 --output-on-failure' \
+    '    cd ${HOME}/build_output && ctest -j 32 --no-compress-output -T test --output-on-failure' \
     '}' \
     'function j() {' \
     '   python3 -m joshua.joshua "${@}"' \


### PR DESCRIPTION
Developer aliases do not cover the same build/test options as CI, this leads to discrepancies between dev environment and CI environment builds. 

These commands are currently run in CI, and have been tested in a `devel` image by the author, and work as expected. 

These Dockerfiles are only maintained in the master branch. 

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [✅] The PR has a description, explaining both the problem and the solution.
- [✅] The description mentions which forms of testing were done and the testing seems reasonable.
- [⛔] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [✅] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [✅] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
