### PR TITLE
Disabling some broken java tests

### DIFF
--- a/bindings/java/src/junit/com/apple/foundationdb/EventKeeperTest.java
+++ b/bindings/java/src/junit/com/apple/foundationdb/EventKeeperTest.java
@@ -30,7 +30,9 @@ import com.apple.foundationdb.async.AsyncIterator;
 import com.apple.foundationdb.tuple.ByteArrayUtil;
 
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+
 
 /**
  * Basic test code for testing basic Transaction Timer logic.
@@ -41,6 +43,7 @@ import org.junit.jupiter.api.Test;
 class EventKeeperTest {
 
 	@Test
+	@Disabled("Ignored because ctest will actually add the library and cause this to segfault")
 	void testSetVersion() throws Exception {
 
 		EventKeeper timer = new MapEventKeeper();
@@ -57,6 +60,7 @@ class EventKeeperTest {
 	}
 
 	@Test
+	@Disabled("Ignored because ctest will actually add the library and cause this to segfault")
 	void testGetReadVersion() throws Exception {
 		EventKeeper timer = new MapEventKeeper();
 


### PR DESCRIPTION
There are two tests in `EventKeeperTest` that don't really test for anything--they are just present to verify that a particular metric is being incremented. But the test design relies on not having the FDB native libs available to the system. In `ctest`, this is never true. 

There are three possible approaches:

1. put in a special case junit test area just for those two small tests so that ctest will test them without the library
2. Ignore those tests as they aren't meaningfully important.
3. redesign those tests to allow for the library being present

Option 3 would likely have some (extremely minor) performance implications (an extra method call, which isn't exactly expensive and HotSpot might inline it anyway, but still), and Option 1 is like using a bazooka to go dove hunting--the tests just aren't worth that extra level. Therefore, I opted for Option 2 for now. If the determination of risk-reward on these tests differ and/or more tests that don't want the FDB native libs loaded appear, we can go back to option 1.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [X ] The PR has a description, explaining both the problem and the solution.
- [X ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ X] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

~- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)~
~- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)~
