### PR TITLE
Add TLS support to fdbdecode

### DIFF
--- a/fdbbackup/BackupTLSConfig.cpp
+++ b/fdbbackup/BackupTLSConfig.cpp
@@ -1,0 +1,90 @@
+/*
+ * BackupTLSConfig.cpp
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <iostream>
+
+#include "fdbclient/NativeAPI.actor.h"
+#include "flow/Arena.h"
+#include "flow/Error.h"
+#include "flow/network.h"
+
+#include "fdbbackup/BackupTLSConfig.h"
+
+void BackupTLSConfig::setupBlobCredentials() {
+	// Add blob credentials files from the environment to the list collected from the command line.
+	const char* blobCredsFromENV = getenv("FDB_BLOB_CREDENTIALS");
+	if (blobCredsFromENV != nullptr) {
+		StringRef t((uint8_t*)blobCredsFromENV, strlen(blobCredsFromENV));
+		do {
+			StringRef file = t.eat(":");
+			if (file.size() != 0)
+				blobCredentials.push_back(file.toString());
+		} while (t.size() != 0);
+	}
+
+	// Update the global blob credential files list
+	std::vector<std::string>* pFiles = (std::vector<std::string>*)g_network->global(INetwork::enBlobCredentialFiles);
+	if (pFiles != nullptr) {
+		for (auto& f : blobCredentials) {
+			pFiles->push_back(f);
+		}
+	}
+}
+
+bool BackupTLSConfig::setupTLS() {
+	if (tlsCertPath.size()) {
+		try {
+			setNetworkOption(FDBNetworkOptions::TLS_CERT_PATH, tlsCertPath);
+		} catch (Error& e) {
+			std::cerr << "ERROR: cannot set TLS certificate path to " << tlsCertPath << " (" << e.what() << ")\n";
+			return false;
+		}
+	}
+
+	if (tlsCAPath.size()) {
+		try {
+			setNetworkOption(FDBNetworkOptions::TLS_CA_PATH, tlsCAPath);
+		} catch (Error& e) {
+			std::cerr << "ERROR: cannot set TLS CA path to " << tlsCAPath << " (" << e.what() << ")\n";
+			return false;
+		}
+	}
+	if (tlsKeyPath.size()) {
+		try {
+			if (tlsPassword.size())
+				setNetworkOption(FDBNetworkOptions::TLS_PASSWORD, tlsPassword);
+
+			setNetworkOption(FDBNetworkOptions::TLS_KEY_PATH, tlsKeyPath);
+		} catch (Error& e) {
+			std::cerr << "ERROR: cannot set TLS key path to " << tlsKeyPath << " (" << e.what() << ")\n";
+			return false;
+		}
+	}
+	if (tlsVerifyPeers.size()) {
+		try {
+			setNetworkOption(FDBNetworkOptions::TLS_VERIFY_PEERS, tlsVerifyPeers);
+		} catch (Error& e) {
+			std::cerr << "ERROR: cannot set TLS peer verification to " << tlsVerifyPeers << " (" << e.what()
+						<< ")\n";
+			return false;
+		}
+	}
+	return true;
+}

--- a/fdbbackup/BackupTLSConfig.h
+++ b/fdbbackup/BackupTLSConfig.h
@@ -1,0 +1,41 @@
+/*
+ * BackupTLSConfig.h
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FDBBACKUP_BACKUPTLSCONFIG_H
+#define FDBBACKUP_BACKUPTLSCONFIG_H
+#pragma once
+
+#include <string>
+#include <vector>
+
+// TLS and blob credentials for backups and setup for these credentials.
+struct BackupTLSConfig {
+	std::string tlsCertPath, tlsKeyPath, tlsCAPath, tlsPassword, tlsVerifyPeers;
+	std::vector<std::string> blobCredentials;
+
+	// Returns if TLS setup is successful
+	bool setupTLS();
+
+	// Sets up blob crentials. Add the file specified by FDB_BLOB_CREDENTIALS as well.
+	// Note this must be called after g_network is set up.
+	void setupBlobCredentials();
+};
+
+#endif // FDBBACKUP_BACKUPTLSCONFIG_H

--- a/fdbbackup/CMakeLists.txt
+++ b/fdbbackup/CMakeLists.txt
@@ -11,6 +11,8 @@ add_flow_target(EXECUTABLE NAME fdbconvert SRCS ${FDBCONVERT_SRCS})
 target_link_libraries(fdbconvert PRIVATE fdbclient)
 
 set(FDBDECODE_SRCS
+	BackupTLSConfig.h
+	BackupTLSConfig.cpp
 	FileDecoder.actor.cpp
 	FileConverter.h)
 add_flow_target(EXECUTABLE NAME fdbdecode SRCS ${FDBDECODE_SRCS})

--- a/fdbbackup/CMakeLists.txt
+++ b/fdbbackup/CMakeLists.txt
@@ -1,5 +1,7 @@
 set(FDBBACKUP_SRCS
-  backup.actor.cpp)
+	BackupTLSConfig.h
+	BackupTLSConfig.cpp
+	backup.actor.cpp)
 
 add_flow_target(EXECUTABLE NAME fdbbackup SRCS ${FDBBACKUP_SRCS})
 target_link_libraries(fdbbackup PRIVATE fdbclient)

--- a/fdbbackup/FileConverter.h
+++ b/fdbbackup/FileConverter.h
@@ -32,6 +32,7 @@ namespace file_converter {
 enum {
 	OPT_CONTAINER,
 	OPT_BEGIN_VERSION,
+	OPT_BLOB_CREDENTIALS,
 	OPT_CRASHONERROR,
 	OPT_END_VERSION,
 	OPT_TRACE,
@@ -56,6 +57,7 @@ CSimpleOpt::SOption gConverterOptions[] = { { OPT_CONTAINER, "-r", SO_REQ_SEP },
 	                                        { OPT_TRACE_LOG_GROUP, "--loggroup", SO_REQ_SEP },
 	                                        { OPT_INPUT_FILE, "-i", SO_REQ_SEP },
 	                                        { OPT_INPUT_FILE, "--input", SO_REQ_SEP },
+	                                        { OPT_BLOB_CREDENTIALS, "--blob_credentials", SO_REQ_SEP },
 #ifndef TLS_DISABLED
 	                                        TLS_OPTION_FLAGS
 #endif

--- a/fdbbackup/FileConverter.h
+++ b/fdbbackup/FileConverter.h
@@ -24,6 +24,7 @@
 
 #include <cinttypes>
 #include "flow/SimpleOpt.h"
+#include "flow/TLSConfig.actor.h"
 
 namespace file_converter {
 
@@ -55,6 +56,9 @@ CSimpleOpt::SOption gConverterOptions[] = { { OPT_CONTAINER, "-r", SO_REQ_SEP },
 	                                        { OPT_TRACE_LOG_GROUP, "--loggroup", SO_REQ_SEP },
 	                                        { OPT_INPUT_FILE, "-i", SO_REQ_SEP },
 	                                        { OPT_INPUT_FILE, "--input", SO_REQ_SEP },
+#ifndef TLS_DISABLED
+	                                        TLS_OPTION_FLAGS
+#endif
 	                                        { OPT_BUILD_FLAGS, "--build_flags", SO_NONE },
 	                                        { OPT_HELP, "-?", SO_NONE },
 	                                        { OPT_HELP, "-h", SO_NONE },

--- a/fdbbackup/FileDecoder.actor.cpp
+++ b/fdbbackup/FileDecoder.actor.cpp
@@ -38,7 +38,8 @@ extern bool g_crashOnError;
 namespace file_converter {
 
 void printDecodeUsage() {
-	std::cout << "\n"
+	std::cout << "Decoder for FoundationDB backup mutation logs.\n"
+	             "Usage: fdbdecode    [OPTIONS]\n"
 	             "  -r, --container   Container URL.\n"
 	             "  -i, --input FILE  Log file filter, only matched files are decoded.\n"
 	             "  --log             Enables trace file logging for the CLI session.\n"
@@ -103,7 +104,6 @@ int parseDecodeCommandLine(DecodeParams* param, CSimpleOpt* args) {
 		int optId = args->OptionId();
 		switch (optId) {
 		case OPT_HELP:
-			printDecodeUsage();
 			return FDB_EXIT_ERROR;
 
 		case OPT_CONTAINER:


### PR DESCRIPTION
Update description for `fdbdecode` and add TLS support so that it can directly read mutation log files from blob.

This is manually tested, e.g.,
`./fdbdecode --tls_certificate_file fullchain.pem --tls_ca_file fdb_root_ca_file.pem --tls_key_file private.key --blob_credentials blob.json -r 'blobstore://userid@blob.xxx.com/container_path/' -i 13263697214954,13263717214954`

`./fdbdecode -r 'blobstore://userid@blob.xxx.com/container_path/?sc=0' --blob_credentials blob.json -i 13263697214954,13263717214954`

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [x] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
