### PR TITLE
Cherry pick #4596 and #4599 into release-6.3

### DIFF
--- a/fdbrpc/simulator.h
+++ b/fdbrpc/simulator.h
@@ -383,6 +383,7 @@ public:
 	std::string disablePrimary;
 	std::string disableRemote;
 	std::string originalRegions;
+	std::string startingDisabledConfiguration;
 	bool allowLogSetKills;
 	Optional<Standalone<StringRef>> remoteDcId;
 	bool hasSatelliteReplication;

--- a/fdbserver/Coordination.actor.cpp
+++ b/fdbserver/Coordination.actor.cpp
@@ -411,9 +411,16 @@ ACTOR Future<Void> leaderRegister(LeaderElectionRegInterface interf, Key key) {
 					nextNominee = *availableLeaders.begin();
 				}
 
+				// If the current leader's priority became worse, we still need to notified all clients because now one
+				// of them might be better than the leader. In addition, even though FitnessRemote is better than
+				// FitnessUnknown, we still need to notified clients so that monitorLeaderRemotely has a change to switch
+				// from passively monitoring the leader to actively attempting to become the leader.
 				if (!currentNominee.present() || !nextNominee.present() ||
 				    !currentNominee.get().equalInternalId(nextNominee.get()) ||
-				    nextNominee.get() > currentNominee.get()) {
+				    nextNominee.get() > currentNominee.get() ||
+				    (currentNominee.get().getPriorityInfo().dcFitness ==
+				         ClusterControllerPriorityInfo::FitnessUnknown &&
+				     nextNominee.get().getPriorityInfo().dcFitness == ClusterControllerPriorityInfo::FitnessRemote)) {
 					TraceEvent("NominatingLeader")
 					    .detail("NextNominee", nextNominee.present() ? nextNominee.get().changeID : UID())
 					    .detail("CurrentNominee", currentNominee.present() ? currentNominee.get().changeID : UID())

--- a/fdbserver/SimulatedCluster.actor.cpp
+++ b/fdbserver/SimulatedCluster.actor.cpp
@@ -1148,9 +1148,6 @@ void SimulationConfig::generateNormalConfig(const TestConfig& testConfig) {
 			regionArr.push_back(remoteObj);
 		}
 
-		set_config("regions=" +
-		           json_spirit::write_string(json_spirit::mValue(regionArr), json_spirit::Output_options::none));
-
 		if (needsRemote) {
 			g_simulator.originalRegions = "regions=" + json_spirit::write_string(json_spirit::mValue(regionArr),
 			                                                                     json_spirit::Output_options::none);
@@ -1164,6 +1161,11 @@ void SimulationConfig::generateNormalConfig(const TestConfig& testConfig) {
 			disableRemote[1].get_obj()["datacenters"].get_array()[0].get_obj()["priority"] = -1;
 			g_simulator.disableRemote = "regions=" + json_spirit::write_string(json_spirit::mValue(disableRemote),
 			                                                                   json_spirit::Output_options::none);
+		} else {
+			// In order to generate a starting configuration with the remote disabled, do not apply the region
+			// configuration to the DatabaseConfiguration until after creating the starting conf string.
+			set_config("regions=" +
+			           json_spirit::write_string(json_spirit::mValue(regionArr), json_spirit::Output_options::none));
 		}
 	}
 
@@ -1242,6 +1244,12 @@ void setupSimulatedSystem(vector<Future<Void>>* systemActors,
 		} else {
 			ASSERT(false);
 		}
+	}
+
+	if (g_simulator.originalRegions != "") {
+		simconfig.set_config(g_simulator.originalRegions);
+		g_simulator.startingDisabledConfiguration = startingConfigString + " " + g_simulator.disableRemote;
+		startingConfigString += " " + g_simulator.originalRegions;
 	}
 
 	g_simulator.storagePolicy = simconfig.db.storagePolicy;

--- a/fdbserver/workloads/ChangeConfig.actor.cpp
+++ b/fdbserver/workloads/ChangeConfig.actor.cpp
@@ -60,10 +60,10 @@ struct ChangeConfigWorkload : TestWorkload {
 
 			wait(delay(5 * deterministicRandom()->random01()));
 			if (self->configMode.size()) {
-				if (g_simulator.usableRegions == 2) {
+				if (g_simulator.startingDisabledConfiguration != "") {
 					// It is not safe to allow automatic failover to a region which is not fully replicated,
 					// so wait for both regions to be fully replicated before enabling failover
-					wait(success(changeConfig(extraDB, g_simulator.disableRemote, true)));
+					wait(success(changeConfig(extraDB, g_simulator.startingDisabledConfiguration, true)));
 					TraceEvent("WaitForReplicasExtra");
 					wait(waitForFullReplication(extraDB));
 					TraceEvent("WaitForReplicasExtraEnd");
@@ -95,10 +95,10 @@ struct ChangeConfigWorkload : TestWorkload {
 		}
 
 		if (self->configMode.size()) {
-			// It is not safe to allow automatic failover to a region which is not fully replicated,
-			// so wait for both regions to be fully replicated before enabling failover
-			if (g_network->isSimulated() && g_simulator.usableRegions == 2) {
-				wait(success(changeConfig(cx, g_simulator.disableRemote, true)));
+			if (g_network->isSimulated() && g_simulator.startingDisabledConfiguration != "") {
+				// It is not safe to allow automatic failover to a region which is not fully replicated,
+				// so wait for both regions to be fully replicated before enabling failover
+				wait(success(changeConfig(cx, g_simulator.startingDisabledConfiguration, true)));
 				TraceEvent("WaitForReplicas");
 				wait(waitForFullReplication(cx));
 				TraceEvent("WaitForReplicasEnd");


### PR DESCRIPTION
These are the fixes @etschannen did on master to resolve test start up timeout issue (e.g., SwizzledRollbackSideband.txt).

100K tests all passed:
20210405-191834-zhewu_4619-896e44cecce881c0        compressed=True data_size=20344237 duration=5810848 ended=108614 fail_fast=10 max_runs=100000 pass=100001 priority=100 remaining=0 runtime=0:28:55 sanity=False started=108637 stopped=20210405-194729 submitted=20210405-191834 timeout=5400 username=zhewu_4619

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [x] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [x] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [x] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
