### PR TITLE
loopback_cluster: Find `fdbcli` from `$BUILD` path

### DIFF
--- a/tests/loopback_cluster/run_cluster.sh
+++ b/tests/loopback_cluster/run_cluster.sh
@@ -40,7 +40,7 @@ for i in `seq 1 $2` ; do
 		${FDB} -p auto:${PORT_PREFIX}${j} -d $DATA -L $LOG -C $CLUSTER &
 	done
 	
-	CLI="$ROOT/bin/fdbcli -C ${CLUSTER} --exec"
+	CLI="$BUILD/bin/fdbcli -C ${CLUSTER} --exec"
 	( sleep 2 ; $CLI "configure new ssd single" ) &
 done;
 


### PR DESCRIPTION
Currently expects to find `fdbcli` in current path, which doesn't seem
right. `fdbcli` should always be in the directory where we'll find
`fdbserver`.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.
