### PR TITLE
Docker image updates

### DIFF
--- a/build/docker/centos6/build/Dockerfile
+++ b/build/docker/centos6/build/Dockerfile
@@ -216,6 +216,14 @@ RUN source /opt/rh/devtoolset-8/enable && \
     cd .. && \
     rm -rf /tmp/*
 
+# download old fdbserver binaries
+ARG FDB_VERSION="6.2.29"
+RUN mkdir -p /opt/foundationdb/old && \
+    curl -Ls https://www.foundationdb.org/downloads/misc/fdbservers-${FDB_VERSION}.tar.gz | \
+        tar --no-same-owner --directory /opt/foundationdb/old -xz && \
+    chmod +x /opt/foundationdb/old/* && \
+    ln -sf /opt/foundationdb/old/fdbserver-${FDB_VERSION} /opt/foundationdb/old/fdbserver
+
 # build/install distcc
 RUN source /opt/rh/devtoolset-8/enable && \
     source /opt/rh/rh-python36/enable && \

--- a/build/docker/centos6/devel/Dockerfile
+++ b/build/docker/centos6/devel/Dockerfile
@@ -28,7 +28,7 @@ RUN source /opt/rh/devtoolset-8/enable && \
         subprocess32 && \
     mkdir fdb-joshua && \
     cd fdb-joshua && \
-    git clone --branch code_pipeline https://github.com/FoundationDB/fdb-joshua . && \
+    git clone https://github.com/FoundationDB/fdb-joshua . && \
     pip3 install /tmp/fdb-joshua && \
     cd /tmp && \
     curl -Ls https://amazon-eks.s3.us-west-2.amazonaws.com/1.18.9/2020-11-02/bin/linux/amd64/kubectl -o kubectl && \
@@ -43,20 +43,13 @@ RUN source /opt/rh/devtoolset-8/enable && \
     ./aws/install && \
     rm -rf /tmp/*
 
-ARG OLD_FDB_BINARY_DIR=/app/deploy/global_data/oldBinaries/
-ARG OLD_TLS_LIBRARY_DIR=/app/deploy/runtime/.tls_5_1/
 ARG FDB_VERSION="6.2.29"
-RUN mkdir -p ${OLD_FDB_BINARY_DIR} \
-             ${OLD_TLS_LIBRARY_DIR} \
-             /usr/lib/foundationdb/plugins && \
-    curl -Ls https://www.foundationdb.org/downloads/misc/fdbservers-${FDB_VERSION}.tar.gz | tar -xz -C ${OLD_FDB_BINARY_DIR} && \
-    rm -f ${OLD_FDB_BINARY_DIR}/*.sha256 && \
-    chmod +x ${OLD_FDB_BINARY_DIR}/* && \
-    curl -Ls https://www.foundationdb.org/downloads/misc/joshua_tls_library.tar.gz | tar -xz -C ${OLD_TLS_LIBRARY_DIR} --strip-components=1 && \
+RUN mkdir -p /usr/lib/foundationdb/plugins && \
+    curl -Ls https://www.foundationdb.org/downloads/misc/joshua_tls_library.tar.gz | \
+        tar --strip-components=1 --no-same-owner --directory /usr/lib/foundationdb/plugins -xz && \
+    ln -sf /usr/lib/foundationdb/plugins/FDBGnuTLS.so /usr/lib/foundationdb/plugins/fdb-libressl-plugin.so && \
     curl -Ls https://www.foundationdb.org/downloads/${FDB_VERSION}/linux/libfdb_c_${FDB_VERSION}.so -o /usr/lib64/libfdb_c_${FDB_VERSION}.so && \
-    ln -s /usr/lib64/libfdb_c_${FDB_VERSION}.so /usr/lib64/libfdb_c.so && \
-    ln -s ${OLD_TLS_LIBRARY_DIR}/FDBGnuTLS.so /usr/lib/foundationdb/plugins/fdb-libressl-plugin.so && \
-    ln -s ${OLD_TLS_LIBRARY_DIR}/FDBGnuTLS.so /usr/lib/foundationdb/plugins/FDBGnuTLS.so
+    ln -sf /usr/lib64/libfdb_c_${FDB_VERSION}.so /usr/lib64/libfdb_c.so
 
 WORKDIR /root
 RUN rm -f /root/anaconda-ks.cfg && \
@@ -65,8 +58,13 @@ RUN rm -f /root/anaconda-ks.cfg && \
     'source /opt/rh/rh-python36/enable' \
     'source /opt/rh/rh-ruby26/enable' \
     '' \
+    'function cmk_ci() {' \
+    '    cmake -S ${HOME}/src/foundationdb -B ${HOME}/build_output -D USE_CCACHE=ON -D USE_WERROR=ON -D RocksDB_ROOT=/opt/rocksdb-6.10.1 -D RUN_JUNIT_TESTS=ON -D RUN_JAVA_INTEGRATION_TESTS=ON -G Ninja && \' \
+    '    ninja -v -C ${HOME}/build_output -j 84 all packages strip_targets' \
+    '}' \
     'function cmk() {' \
-    '    cmake -S ${HOME}/src/foundationdb -B ${HOME}/build_output -D USE_CCACHE=ON -D USE_WERROR=ON -D RocksDB_ROOT=/opt/rocksdb-6.10.1 -D RUN_JUNIT_TESTS=ON -D RUN_JAVA_INTEGRATION_TESTS=ON -G Ninja && ninja -C ${HOME}/build_output -j 84' \
+    '    cmake -S ${HOME}/src/foundationdb -B ${HOME}/build_output -D USE_CCACHE=ON -D USE_WERROR=ON -D RocksDB_ROOT=/opt/rocksdb-6.10.1 -D RUN_JUNIT_TESTS=ON -D RUN_JAVA_INTEGRATION_TESTS=ON -G Ninja && \' \
+    '    ninja -C ${HOME}/build_output -j 84' \
     '}' \
     'function ct() {' \
     '    cd ${HOME}/build_output && ctest -j 32 --no-compress-output -T test --output-on-failure' \

--- a/build/docker/centos7/build/Dockerfile
+++ b/build/docker/centos7/build/Dockerfile
@@ -200,6 +200,14 @@ RUN source /opt/rh/devtoolset-8/enable && \
     cd .. && \
     rm -rf /tmp/*
 
+# download old fdbserver binaries
+ARG FDB_VERSION="6.2.29"
+RUN mkdir -p /opt/foundationdb/old && \
+    curl -Ls https://www.foundationdb.org/downloads/misc/fdbservers-${FDB_VERSION}.tar.gz | \
+        tar --no-same-owner --directory /opt/foundationdb/old -xz && \
+    chmod +x /opt/foundationdb/old/* && \
+    ln -sf /opt/foundationdb/old/fdbserver-${FDB_VERSION} /opt/foundationdb/old/fdbserver
+
 # build/install distcc
 RUN source /opt/rh/devtoolset-8/enable && \
     if [ "$(uname -p)" == "aarch64" ]; then \

--- a/build/docker/centos7/devel/Dockerfile
+++ b/build/docker/centos7/devel/Dockerfile
@@ -31,7 +31,7 @@ RUN source /opt/rh/devtoolset-8/enable && \
         subprocess32 && \
     mkdir fdb-joshua && \
     cd fdb-joshua && \
-    git clone --branch code_pipeline https://github.com/FoundationDB/fdb-joshua . && \
+    git clone https://github.com/FoundationDB/fdb-joshua . && \
     pip3 install /tmp/fdb-joshua && \
     cd /tmp && \
     curl -Ls https://amazon-eks.s3.us-west-2.amazonaws.com/1.18.9/2020-11-02/bin/linux/amd64/kubectl -o kubectl && \
@@ -46,20 +46,13 @@ RUN source /opt/rh/devtoolset-8/enable && \
     ./aws/install && \
     rm -rf /tmp/*
 
-ARG OLD_FDB_BINARY_DIR=/app/deploy/global_data/oldBinaries/
-ARG OLD_TLS_LIBRARY_DIR=/app/deploy/runtime/.tls_5_1/
 ARG FDB_VERSION="6.2.29"
-RUN mkdir -p ${OLD_FDB_BINARY_DIR} \
-             ${OLD_TLS_LIBRARY_DIR} \
-             /usr/lib/foundationdb/plugins && \
-    curl -Ls https://www.foundationdb.org/downloads/misc/fdbservers-${FDB_VERSION}.tar.gz | tar -xz -C ${OLD_FDB_BINARY_DIR} && \
-    rm -f ${OLD_FDB_BINARY_DIR}/*.sha256 && \
-    chmod +x ${OLD_FDB_BINARY_DIR}/* && \
-    curl -Ls https://www.foundationdb.org/downloads/misc/joshua_tls_library.tar.gz | tar -xz -C ${OLD_TLS_LIBRARY_DIR} --strip-components=1 && \
+RUN mkdir -p /usr/lib/foundationdb/plugins && \
+    curl -Ls https://www.foundationdb.org/downloads/misc/joshua_tls_library.tar.gz | \
+        tar --strip-components=1 --no-same-owner --directory /usr/lib/foundationdb/plugins -xz && \
+    ln -sf /usr/lib/foundationdb/plugins/FDBGnuTLS.so /usr/lib/foundationdb/plugins/fdb-libressl-plugin.so && \
     curl -Ls https://www.foundationdb.org/downloads/${FDB_VERSION}/linux/libfdb_c_${FDB_VERSION}.so -o /usr/lib64/libfdb_c_${FDB_VERSION}.so && \
-    ln -s /usr/lib64/libfdb_c_${FDB_VERSION}.so /usr/lib64/libfdb_c.so && \
-    ln -s ${OLD_TLS_LIBRARY_DIR}/FDBGnuTLS.so /usr/lib/foundationdb/plugins/fdb-libressl-plugin.so && \
-    ln -s ${OLD_TLS_LIBRARY_DIR}/FDBGnuTLS.so /usr/lib/foundationdb/plugins/FDBGnuTLS.so
+    ln -sf /usr/lib64/libfdb_c_${FDB_VERSION}.so /usr/lib64/libfdb_c.so
 
 WORKDIR /root
 RUN curl -Ls https://update.code.visualstudio.com/latest/server-linux-x64/stable -o /tmp/vscode-server-linux-x64.tar.gz && \
@@ -93,8 +86,13 @@ RUN rm -f /root/anaconda-ks.cfg && \
     'source /opt/rh/rh-python36/enable' \
     'source /opt/rh/rh-ruby26/enable' \
     '' \
+    'function cmk_ci() {' \
+    '    cmake -S ${HOME}/src/foundationdb -B ${HOME}/build_output -D USE_CCACHE=ON -D USE_WERROR=ON -D RocksDB_ROOT=/opt/rocksdb-6.10.1 -D RUN_JUNIT_TESTS=ON -D RUN_JAVA_INTEGRATION_TESTS=ON -G Ninja && \' \
+    '    ninja -v -C ${HOME}/build_output -j 84 all packages strip_targets' \
+    '}' \
     'function cmk() {' \
-    '    cmake -S ${HOME}/src/foundationdb -B ${HOME}/build_output -D USE_CCACHE=ON -D USE_WERROR=ON -D RocksDB_ROOT=/opt/rocksdb-6.10.1 -D RUN_JUNIT_TESTS=ON -D RUN_JAVA_INTEGRATION_TESTS=ON -G Ninja && ninja -C ${HOME}/build_output -j 84' \
+    '    cmake -S ${HOME}/src/foundationdb -B ${HOME}/build_output -D USE_CCACHE=ON -D USE_WERROR=ON -D RocksDB_ROOT=/opt/rocksdb-6.10.1 -D RUN_JUNIT_TESTS=ON -D RUN_JAVA_INTEGRATION_TESTS=ON -G Ninja && \' \
+    '    ninja -C ${HOME}/build_output -j 84' \
     '}' \
     'function ct() {' \
     '    cd ${HOME}/build_output && ctest -j 32 --no-compress-output -T test --output-on-failure' \
@@ -106,4 +104,5 @@ RUN rm -f /root/anaconda-ks.cfg && \
     '   j start --tarball $(find ${HOME}/build_output/packages -name correctness\*.tar.gz) "${@}"' \
     '}' \
     '' \
+    'bash ${HOME}/docker_proxy.sh' \
     >> .bashrc

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,7 +15,7 @@ set(TEST_EXCLUDE ".^" CACHE STRING "Exclude all tests matching the given regex")
 if(WITH_PYTHON)
   find_program(OLD_FDBSERVER_BINARY
     fdbserver
-    HINTS /usr/sbin /usr/libexec /usr/local/sbin /usr/local/libexec)
+    HINTS /opt/foundationdb/old /usr/sbin /usr/libexec /usr/local/sbin /usr/local/libexec)
   if(OLD_FDBSERVER_BINARY)
     message(STATUS "Use old fdb at ${OLD_FDBSERVER_BINARY}")
   else()


### PR DESCRIPTION
CI build was not able to test upgrade/downgrade
    - add old fdb binaries to build image and update cmake to look in the right place
Testing CI failures was cumbersome and involved inspecting buildspec files
    - add new alias `cmk_ci` to devel image so CI style builds can be performed by engineers 
The TLS lib install uses non-intuitive path
    - update FDBTLS lib install for joshua
    - remove old fdb binaries install from devel -- moved to build image
The joshua install steps in the devel docker file reference a non-existent git branch
    - get the default fdb-joshua branch when building the devel image

- [✅] The PR has a description, explaining both the problem and the solution.
- [✅] The description mentions which forms of testing were done and the testing seems reasonable.
- [✅] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
