### PR TITLE
Cherry pick #4625 to release-6.3

### DIFF
--- a/fdbclient/FileBackupAgent.actor.cpp
+++ b/fdbclient/FileBackupAgent.actor.cpp
@@ -4038,8 +4038,10 @@ struct StartFullRestoreTaskFunc : RestoreTaskFuncBase {
 		for (const RangeFile& f : restorable.get().ranges) {
 			files.push_back({ f.version, f.fileName, true, f.blockSize, f.fileSize });
 		}
-		for (const LogFile& f : restorable.get().logs) {
-			files.push_back({ f.beginVersion, f.fileName, false, f.blockSize, f.fileSize, f.endVersion });
+		if (!CLIENT_KNOBS->RESTORE_IGNORE_LOG_FILES) {
+			for (const LogFile& f : restorable.get().logs) {
+				files.push_back({ f.beginVersion, f.fileName, false, f.blockSize, f.fileSize, f.endVersion });
+			}
 		}
 
 		state std::vector<RestoreConfig::RestoreFile>::iterator start = files.begin();

--- a/fdbclient/Knobs.cpp
+++ b/fdbclient/Knobs.cpp
@@ -164,6 +164,7 @@ void ClientKnobs::initialize(bool randomize) {
 	init( BACKUP_STATUS_DELAY,                    40.0 );
 	init( BACKUP_STATUS_JITTER,                   0.05 );
 	init( MIN_CLEANUP_SECONDS,                  3600.0 );
+	init( RESTORE_IGNORE_LOG_FILES,              false );
 
 	// Configuration
 	init( DEFAULT_AUTO_PROXIES,                      3 );

--- a/fdbclient/Knobs.h
+++ b/fdbclient/Knobs.h
@@ -160,6 +160,7 @@ public:
 	double BACKUP_STATUS_DELAY;
 	double BACKUP_STATUS_JITTER;
 	double MIN_CLEANUP_SECONDS;
+	bool RESTORE_IGNORE_LOG_FILES;   // Default is false. When set to true, the log files will be ignored during the restore, which can produce inconsistent restored data.
 
 	// Configuration
 	int32_t DEFAULT_AUTO_PROXIES;


### PR DESCRIPTION
#4565 completely ignores log files. We should make it a knob and get it merged. The knob should be disabled at all times, thus not affecting existing code. The knob should only be enabled when we know the restored data are inconsistent and still want to do so.

Joshua test:
20210408-180848-renxuan-823f2ad63aaee7d5           compressed=True data_size=20342970 duration=4738393 ended=106564 fail_fast=10 max_runs=100000 pass=100001 priority=100 remaining=0 runtime=0:26:24 sanity=False started=107427 stopped=20210408-183512 submitted=20210408-180848 timeout=5400 username=renxuan

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [x] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [x] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [x] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
