### PR TITLE
Fixed 8 bugs related to recruitment of processes by the cluster controller

### DIFF
--- a/fdbrpc/Locality.cpp
+++ b/fdbrpc/Locality.cpp
@@ -63,7 +63,7 @@ ProcessClass::Fitness ProcessClass::machineClassFitness(ClusterRole role) const 
 		default:
 			return ProcessClass::NeverAssign;
 		}
-	case ProcessClass::CommitProxy:
+	case ProcessClass::CommitProxy: // Resolver, Master, CommitProxy, and GrvProxy need to be the same besides best fit
 		switch (_class) {
 		case ProcessClass::CommitProxyClass:
 			return ProcessClass::BestFit;
@@ -71,10 +71,6 @@ ProcessClass::Fitness ProcessClass::machineClassFitness(ClusterRole role) const 
 			return ProcessClass::GoodFit;
 		case ProcessClass::UnsetClass:
 			return ProcessClass::UnsetFit;
-		case ProcessClass::GrvProxyClass:
-			return ProcessClass::OkayFit;
-		case ProcessClass::ResolutionClass:
-			return ProcessClass::OkayFit;
 		case ProcessClass::TransactionClass:
 			return ProcessClass::OkayFit;
 		case ProcessClass::CoordinatorClass:
@@ -84,7 +80,7 @@ ProcessClass::Fitness ProcessClass::machineClassFitness(ClusterRole role) const 
 		default:
 			return ProcessClass::WorstFit;
 		}
-	case ProcessClass::GrvProxy:
+	case ProcessClass::GrvProxy: // Resolver, Master, CommitProxy, and GrvProxy need to be the same besides best fit
 		switch (_class) {
 		case ProcessClass::GrvProxyClass:
 			return ProcessClass::BestFit;
@@ -92,10 +88,6 @@ ProcessClass::Fitness ProcessClass::machineClassFitness(ClusterRole role) const 
 			return ProcessClass::GoodFit;
 		case ProcessClass::UnsetClass:
 			return ProcessClass::UnsetFit;
-		case ProcessClass::CommitProxyClass:
-			return ProcessClass::OkayFit;
-		case ProcessClass::ResolutionClass:
-			return ProcessClass::OkayFit;
 		case ProcessClass::TransactionClass:
 			return ProcessClass::OkayFit;
 		case ProcessClass::CoordinatorClass:
@@ -105,7 +97,7 @@ ProcessClass::Fitness ProcessClass::machineClassFitness(ClusterRole role) const 
 		default:
 			return ProcessClass::WorstFit;
 		}
-	case ProcessClass::Master:
+	case ProcessClass::Master: // Resolver, Master, CommitProxy, and GrvProxy need to be the same besides best fit
 		switch (_class) {
 		case ProcessClass::MasterClass:
 			return ProcessClass::BestFit;
@@ -113,7 +105,7 @@ ProcessClass::Fitness ProcessClass::machineClassFitness(ClusterRole role) const 
 			return ProcessClass::GoodFit;
 		case ProcessClass::UnsetClass:
 			return ProcessClass::UnsetFit;
-		case ProcessClass::ResolutionClass:
+		case ProcessClass::TransactionClass:
 			return ProcessClass::OkayFit;
 		case ProcessClass::CoordinatorClass:
 		case ProcessClass::TesterClass:
@@ -122,7 +114,7 @@ ProcessClass::Fitness ProcessClass::machineClassFitness(ClusterRole role) const 
 		default:
 			return ProcessClass::WorstFit;
 		}
-	case ProcessClass::Resolver:
+	case ProcessClass::Resolver: // Resolver, Master, CommitProxy, and GrvProxy need to be the same besides best fit
 		switch (_class) {
 		case ProcessClass::ResolutionClass:
 			return ProcessClass::BestFit;
@@ -147,8 +139,6 @@ ProcessClass::Fitness ProcessClass::machineClassFitness(ClusterRole role) const 
 			return ProcessClass::GoodFit;
 		case ProcessClass::UnsetClass:
 			return ProcessClass::UnsetFit;
-		case ProcessClass::ResolutionClass:
-			return ProcessClass::OkayFit;
 		case ProcessClass::TransactionClass:
 			return ProcessClass::OkayFit;
 		case ProcessClass::CoordinatorClass:
@@ -167,8 +157,6 @@ ProcessClass::Fitness ProcessClass::machineClassFitness(ClusterRole role) const 
 			return ProcessClass::GoodFit;
 		case ProcessClass::UnsetClass:
 			return ProcessClass::UnsetFit;
-		case ProcessClass::ResolutionClass:
-			return ProcessClass::OkayFit;
 		case ProcessClass::TransactionClass:
 			return ProcessClass::OkayFit;
 		case ProcessClass::CoordinatorClass:

--- a/fdbserver/ClusterController.actor.cpp
+++ b/fdbserver/ClusterController.actor.cpp
@@ -345,6 +345,7 @@ public:
 		Reference<LocalitySet> logServerSet;
 		LocalityMap<WorkerDetails>* logServerMap;
 		bool bCompleted = false;
+		desired = std::max(required, desired);
 
 		// Construct the list of DCs where the TLog recruitment is happening. This is mainly for logging purpose.
 		std::string dcList;

--- a/fdbserver/ClusterController.actor.cpp
+++ b/fdbserver/ClusterController.actor.cpp
@@ -855,8 +855,8 @@ public:
 				auto thisFit = it.processClass.machineClassFitness(role);
 				worstFit = std::max(worstFit, thisFit);
 				bestFit = std::min(bestFit, thisFit);
-				degraded |= it.degraded;
-				inClusterControllerDC |= (it.interf.locality.dcId() == ccDcId);
+				degraded = it.degraded || degraded;
+				inClusterControllerDC = (it.interf.locality.dcId() == ccDcId) || inClusterControllerDC;
 
 				auto thisUsed = id_used.find(it.interf.locality.processId());
 				if (thisUsed == id_used.end()) {

--- a/fdbserver/ClusterController.actor.cpp
+++ b/fdbserver/ClusterController.actor.cpp
@@ -1033,7 +1033,7 @@ public:
 
 		// If one of the first process recruitments is forced to share a process, allow all of next recruitments
 		// to also share a process.
-		auto maxUsed = std::max(std::max(first_commit_proxy.used, first_grv_proxy.used), first_resolver.used);
+		auto maxUsed = std::max({ first_commit_proxy.used, first_grv_proxy.used, first_resolver.used });
 		first_commit_proxy.used = maxUsed;
 		first_grv_proxy.used = maxUsed;
 		first_resolver.used = maxUsed;
@@ -1225,8 +1225,7 @@ public:
 
 					// If one of the first process recruitments is forced to share a process, allow all of next
 					// recruitments to also share a process.
-					auto maxUsed =
-					    std::max(std::max(first_commit_proxy.used, first_grv_proxy.used), first_resolver.used);
+					auto maxUsed = std::max({ first_commit_proxy.used, first_grv_proxy.used, first_resolver.used });
 					first_commit_proxy.used = maxUsed;
 					first_grv_proxy.used = maxUsed;
 					first_resolver.used = maxUsed;
@@ -1424,7 +1423,7 @@ public:
 		// Do not trigger better master exists if the cluster controller is excluded, since the master will change
 		// anyways once the cluster controller is moved
 		if (id_worker[clusterControllerProcessId].priorityInfo.isExcluded) {
-			TraceEvent("WorseMasterExists", id).detail("Reason", "ClusterControllerExcluded");
+			TraceEvent("NewRecruitmentIsWorse", id).detail("Reason", "ClusterControllerExcluded");
 			return false;
 		}
 
@@ -1437,7 +1436,7 @@ public:
 		// Get master process
 		auto masterWorker = id_worker.find(dbi.master.locality.processId());
 		if (masterWorker == id_worker.end()) {
-			TraceEvent("WorseMasterExists", id)
+			TraceEvent("NewRecruitmentIsWorse", id)
 			    .detail("Reason", "CannotFindMaster")
 			    .detail("ProcessID", dbi.master.locality.processId());
 			return false;
@@ -1456,7 +1455,7 @@ public:
 			for (auto& it : logSet.tLogs) {
 				auto tlogWorker = id_worker.find(it.interf().filteredLocality.processId());
 				if (tlogWorker == id_worker.end()) {
-					TraceEvent("WorseMasterExists", id)
+					TraceEvent("NewRecruitmentIsWorse", id)
 					    .detail("Reason", "CannotFindTLog")
 					    .detail("ProcessID", it.interf().filteredLocality.processId());
 					return false;
@@ -1480,7 +1479,7 @@ public:
 			for (auto& it : logSet.logRouters) {
 				auto tlogWorker = id_worker.find(it.interf().filteredLocality.processId());
 				if (tlogWorker == id_worker.end()) {
-					TraceEvent("WorseMasterExists", id)
+					TraceEvent("NewRecruitmentIsWorse", id)
 					    .detail("Reason", "CannotFindLogRouter")
 					    .detail("ProcessID", it.interf().filteredLocality.processId());
 					return false;
@@ -1500,7 +1499,7 @@ public:
 			for (const auto& worker : logSet.backupWorkers) {
 				auto workerIt = id_worker.find(worker.interf().locality.processId());
 				if (workerIt == id_worker.end()) {
-					TraceEvent("WorseMasterExists", id)
+					TraceEvent("NewRecruitmentIsWorse", id)
 					    .detail("Reason", "CannotFindBackupWorker")
 					    .detail("ProcessID", worker.interf().locality.processId());
 					return false;
@@ -1523,7 +1522,7 @@ public:
 		for (auto& it : dbi.client.commitProxies) {
 			auto commitProxyWorker = id_worker.find(it.processId);
 			if (commitProxyWorker == id_worker.end()) {
-				TraceEvent("WorseMasterExists", id)
+				TraceEvent("NewRecruitmentIsWorse", id)
 				    .detail("Reason", "CannotFindCommitProxy")
 				    .detail("ProcessID", it.processId);
 				return false;
@@ -1542,7 +1541,7 @@ public:
 		for (auto& it : dbi.client.grvProxies) {
 			auto grvProxyWorker = id_worker.find(it.processId);
 			if (grvProxyWorker == id_worker.end()) {
-				TraceEvent("WorseMasterExists", id)
+				TraceEvent("NewRecruitmentIsWorse", id)
 				    .detail("Reason", "CannotFindGrvProxy")
 				    .detail("ProcessID", it.processId);
 				return false;
@@ -1561,7 +1560,7 @@ public:
 		for (auto& it : dbi.resolvers) {
 			auto resolverWorker = id_worker.find(it.locality.processId());
 			if (resolverWorker == id_worker.end()) {
-				TraceEvent("WorseMasterExists", id)
+				TraceEvent("NewRecruitmentIsWorse", id)
 				    .detail("Reason", "CannotFindResolver")
 				    .detail("ProcessID", it.locality.processId());
 				return false;
@@ -1596,7 +1595,7 @@ public:
 
 		old_id_used[masterWorker->first]++;
 		if (oldMasterFit < newMasterFit) {
-			TraceEvent("WorseMasterExists", id)
+			TraceEvent("NewRecruitmentIsWorse", id)
 			    .detail("OldMasterFit", oldMasterFit)
 			    .detail("NewMasterFit", newMasterFit)
 			    .detail("OldIsCC", dbi.master.locality.processId() == clusterControllerProcessId)
@@ -1700,7 +1699,7 @@ public:
 			return true;
 		}
 		if (!oldSatelliteFallback && newSatelliteFallback) {
-			TraceEvent("WorseMasterExists", id)
+			TraceEvent("NewRecruitmentIsWorse", id)
 			    .detail("OldSatelliteFallback", oldSatelliteFallback)
 			    .detail("NewSatelliteFallback", newSatelliteFallback);
 			return false;
@@ -1713,7 +1712,7 @@ public:
 			return true;
 		}
 		if (oldSatelliteRegionFit > newSatelliteRegionFit) {
-			TraceEvent("WorseMasterExists", id)
+			TraceEvent("NewRecruitmentIsWorse", id)
 			    .detail("OldSatelliteRegionFit", oldSatelliteRegionFit)
 			    .detail("NewSatelliteRegionFit", newSatelliteRegionFit);
 			return false;
@@ -1782,7 +1781,7 @@ public:
 		    clusterControllerDcId, ProcessClass::GrvProxy, ProcessClass::ExcludeFit, db.config, id_used, true);
 		auto first_resolver = getWorkerForRoleInDatacenter(
 		    clusterControllerDcId, ProcessClass::Resolver, ProcessClass::ExcludeFit, db.config, id_used, true);
-		auto maxUsed = std::max(std::max(first_commit_proxy.used, first_grv_proxy.used), first_resolver.used);
+		auto maxUsed = std::max({ first_commit_proxy.used, first_grv_proxy.used, first_resolver.used });
 		first_commit_proxy.used = maxUsed;
 		first_grv_proxy.used = maxUsed;
 		first_resolver.used = maxUsed;
@@ -1870,7 +1869,7 @@ public:
 		}
 
 		if (oldFit < newFit) {
-			TraceEvent("WorseMasterExists", id)
+			TraceEvent("NewRecruitmentIsWorse", id)
 			    .detail("OldMasterFit", oldMasterFit)
 			    .detail("NewMasterFit", newMasterFit)
 			    .detail("OldTLogFit", oldTLogFit.toString())

--- a/fdbserver/ClusterController.actor.cpp
+++ b/fdbserver/ClusterController.actor.cpp
@@ -426,12 +426,12 @@ public:
 			auto fitness = std::get<0>(workerIter->first);
 			auto used = std::get<1>(workerIter->first);
 			if (fitness > requiredFitness || used > requiredUsed) {
-				requiredFitness = fitness;
-				requiredUsed = used;
 				if (logServerSet->size() >= required && logServerSet->validate(policy)) {
 					bCompleted = true;
 					break;
 				}
+				requiredFitness = fitness;
+				requiredUsed = used;
 			}
 
 			if (std::get<2>(workerIter->first)) {
@@ -501,12 +501,12 @@ public:
 			for (auto workerIter = fitness_workers.begin(); workerIter != fitness_workers.end(); ++workerIter) {
 				auto fitness = std::get<0>(workerIter->first);
 				auto used = std::get<1>(workerIter->first);
+				if (fitness > requiredFitness || (fitness == requiredFitness && used > requiredUsed)) {
+					break;
+				}
 				auto addingDegraded = std::get<2>(workerIter->first);
 				if (addingDegraded) {
 					continue;
-				}
-				if (fitness > requiredFitness || (fitness == requiredFitness && used > requiredUsed)) {
-					break;
 				}
 				for (auto& worker : workerIter->second) {
 					logServerMap->add(worker.interf.locality, &worker);
@@ -524,13 +524,13 @@ public:
 			for (auto workerIter = fitness_workers.begin(); workerIter != fitness_workers.end(); ++workerIter) {
 				auto fitness = std::get<0>(workerIter->first);
 				auto used = std::get<1>(workerIter->first);
+				if (fitness > requiredFitness || (fitness == requiredFitness && used > requiredUsed)) {
+					break;
+				}
 				auto addingDegraded = std::get<2>(workerIter->first);
 				auto inCCDC = std::get<3>(workerIter->first);
 				if (inCCDC || (!requiredDegraded && addingDegraded)) {
 					continue;
-				}
-				if (fitness > requiredFitness || (fitness == requiredFitness && used > requiredUsed)) {
-					break;
 				}
 				for (auto& worker : workerIter->second) {
 					logServerMap->add(worker.interf.locality, &worker);
@@ -545,13 +545,13 @@ public:
 		for (auto workerIter = fitness_workers.begin(); workerIter != fitness_workers.end(); ++workerIter) {
 			auto fitness = std::get<0>(workerIter->first);
 			auto used = std::get<1>(workerIter->first);
+			if (fitness > requiredFitness || (fitness == requiredFitness && used > requiredUsed)) {
+				break;
+			}
 			auto addingDegraded = std::get<2>(workerIter->first);
 			auto inCCDC = std::get<3>(workerIter->first);
 			if ((!requiredInCCDC && inCCDC) || (!requiredDegraded && addingDegraded)) {
 				continue;
-			}
-			if (fitness > requiredFitness || (fitness == requiredFitness && used > requiredUsed)) {
-				break;
 			}
 			for (auto& worker : workerIter->second) {
 				logServerMap->add(worker.interf.locality, &worker);

--- a/fdbserver/ClusterController.actor.cpp
+++ b/fdbserver/ClusterController.actor.cpp
@@ -407,16 +407,17 @@ public:
 
 			// This worker is a candidate for TLog recruitment.
 			bool inCCDC = worker_details.interf.locality.dcId() == clusterControllerDcId;
+			// Prefer recruiting a TransactionClass non-degraded process over a LogClass degraded process
+			if (worker_details.degraded) {
+				fitness = std::max(fitness, ProcessClass::GoodFit);
+			}
 			fitness_workers[std::make_tuple(fitness, id_used[worker_process_id], worker_details.degraded, inCCDC)]
 			    .push_back(worker_details);
 		}
 
-		//  FIXME: it's not clear whether this is necessary.
-		for (int fitness = ProcessClass::BestFit; fitness != ProcessClass::NeverAssign; fitness++) {
-			auto fitnessEnum = (ProcessClass::Fitness)fitness;
-			for (int addingDegraded = 0; addingDegraded < 2; addingDegraded++) {
-				fitness_workers[std::make_tuple(fitnessEnum, 0, addingDegraded, false)];
-			}
+		// Make sure we check for tlogs at the required size before adding processses from the next fitness level
+		for (int fitness = ProcessClass::GoodFit; fitness != ProcessClass::NeverAssign; fitness++) {
+			fitness_workers[std::make_tuple((ProcessClass::Fitness)fitness, 0, true, false)];
 		}
 		results.reserve(results.size() + id_worker.size());
 		for (auto workerIter = fitness_workers.begin(); workerIter != fitness_workers.end(); ++workerIter) {
@@ -432,7 +433,7 @@ public:
 				logServerMap->add(worker.interf.locality, &worker);
 			}
 
-			if (logServerSet->size() < (std::get<2>(workerIter->first) ? required : desired)) {
+			if (logServerSet->size() < (addingDegraded ? required : desired)) {
 			} else if (logServerSet->size() == required || logServerSet->size() <= desired) {
 				if (logServerSet->validate(policy)) {
 					for (auto& object : logServerMap->getObjects()) {
@@ -742,29 +743,40 @@ public:
 		return results;
 	}
 
+	// Allows the comparison of two different recruitments to determine which one is better
+	// Tlog recruitment is different from all the other roles, in that it avoids degraded processes
+	// And tried to avoid recruitment in the same DC as the cluster controller
 	struct RoleFitness {
 		ProcessClass::Fitness bestFit;
 		ProcessClass::Fitness worstFit;
 		ProcessClass::ClusterRole role;
 		int count;
+		int worstUsed;
 		bool worstIsDegraded;
+		bool inClusterControllerDC;
 
 		RoleFitness(int bestFit, int worstFit, int count, ProcessClass::ClusterRole role)
 		  : bestFit((ProcessClass::Fitness)bestFit), worstFit((ProcessClass::Fitness)worstFit), count(count),
-		    role(role), worstIsDegraded(false) {}
+		    role(role), worstUsed(1), worstIsDegraded(false), inClusterControllerDC(false) {}
 
 		RoleFitness(int fitness, int count, ProcessClass::ClusterRole role)
 		  : bestFit((ProcessClass::Fitness)fitness), worstFit((ProcessClass::Fitness)fitness), count(count), role(role),
-		    worstIsDegraded(false) {}
+		    worstUsed(1), worstIsDegraded(false), inClusterControllerDC(false) {}
 
 		RoleFitness()
 		  : bestFit(ProcessClass::NeverAssign), worstFit(ProcessClass::NeverAssign), role(ProcessClass::NoRole),
-		    count(0), worstIsDegraded(false) {}
+		    count(0), worstUsed(1), worstIsDegraded(false), inClusterControllerDC(false) {}
 
-		RoleFitness(vector<WorkerDetails> workers, ProcessClass::ClusterRole role) : role(role) {
-			worstFit = ProcessClass::GoodFit;
+		RoleFitness(const vector<WorkerDetails>& workers,
+		            ProcessClass::ClusterRole role,
+		            const std::map<Optional<Standalone<StringRef>>, int>& id_used,
+		            Optional<Standalone<StringRef>> ccDcId)
+		  : role(role) {
+			worstFit = ProcessClass::BestFit;
 			worstIsDegraded = false;
+			inClusterControllerDC = false;
 			bestFit = ProcessClass::NeverAssign;
+			worstUsed = 1;
 			for (auto& it : workers) {
 				auto thisFit = it.processClass.machineClassFitness(role);
 				if (thisFit > worstFit) {
@@ -774,7 +786,24 @@ public:
 					worstIsDegraded = worstIsDegraded || it.degraded;
 				}
 				bestFit = std::min(bestFit, thisFit);
+				auto thisUsed = id_used.find(it.interf.locality.processId());
+				if (thisUsed == id_used.end()) {
+					TraceEvent(SevError, "UsedNotFound").detail("ProcessId", it.interf.locality.processId().get());
+					ASSERT(false);
+				}
+				if (thisUsed->second == 0) {
+					TraceEvent(SevError, "UsedIsZero").detail("ProcessId", it.interf.locality.processId().get());
+					ASSERT(false);
+				}
+				worstUsed = std::max(worstUsed, thisUsed->second);
+				// only tlogs avoid the cluster controller dc
+				if (role == ProcessClass::TLog && it.interf.locality.dcId() == ccDcId) {
+					inClusterControllerDC = true;
+				}
 			}
+			// Every recruitment will attempt to recruit the preferred amount through GoodFit,
+			// So a recruitment which only has BestFit is not better than one that has a GoodFit process
+			worstFit = std::max(worstFit, ProcessClass::GoodFit);
 			count = workers.size();
 			// degraded is only used for recruitment of tlogs
 			if (role != ProcessClass::TLog) {
@@ -785,87 +814,45 @@ public:
 		bool operator<(RoleFitness const& r) const {
 			if (worstFit != r.worstFit)
 				return worstFit < r.worstFit;
+			if (worstUsed != r.worstUsed)
+				return worstUsed < r.worstUsed;
+			if (count != r.count)
+				return count > r.count;
 			if (worstIsDegraded != r.worstIsDegraded)
 				return r.worstIsDegraded;
+			if (inClusterControllerDC != r.inClusterControllerDC)
+				return r.inClusterControllerDC;
 			// FIXME: TLog recruitment process does not guarantee the best fit is not worsened.
 			if (role != ProcessClass::TLog && role != ProcessClass::LogRouter && bestFit != r.bestFit)
 				return bestFit < r.bestFit;
-			return count > r.count;
+			return false;
 		}
 		bool operator>(RoleFitness const& r) const { return r < *this; }
 		bool operator<=(RoleFitness const& r) const { return !(*this > r); }
 		bool operator>=(RoleFitness const& r) const { return !(*this < r); }
-
-		bool betterFitness(RoleFitness const& r) const {
-			if (worstFit != r.worstFit)
-				return worstFit < r.worstFit;
-			if (worstIsDegraded != r.worstIsDegraded)
-				return r.worstFit;
-			if (bestFit != r.bestFit)
-				return bestFit < r.bestFit;
-			return false;
-		}
 
 		bool betterCount(RoleFitness const& r) const {
 			if (count > r.count)
 				return true;
 			if (worstFit != r.worstFit)
 				return worstFit < r.worstFit;
+			if (worstUsed != r.worstUsed)
+				return worstUsed < r.worstUsed;
 			if (worstIsDegraded != r.worstIsDegraded)
-				return r.worstFit;
+				return r.worstIsDegraded;
+			if (inClusterControllerDC != r.inClusterControllerDC)
+				return r.inClusterControllerDC;
 			return false;
 		}
 
 		bool operator==(RoleFitness const& r) const {
-			return worstFit == r.worstFit && bestFit == r.bestFit && count == r.count &&
-			       worstIsDegraded == r.worstIsDegraded;
+			return worstFit == r.worstFit && worstUsed == r.worstUsed && bestFit == r.bestFit && count == r.count &&
+			       worstIsDegraded == r.worstIsDegraded && inClusterControllerDC == r.inClusterControllerDC;
 		}
 
-		std::string toString() const { return format("%d %d %d %d", bestFit, worstFit, count, worstIsDegraded); }
-	};
-
-	struct RoleFitnessPair {
-		RoleFitness proxy;
-		RoleFitness grvProxy;
-		RoleFitness resolver;
-
-		RoleFitnessPair() {}
-		RoleFitnessPair(RoleFitness const& proxy, RoleFitness const& grvProxy, RoleFitness const& resolver)
-		  : proxy(proxy), grvProxy(grvProxy), resolver(resolver) {}
-
-		bool operator<(RoleFitnessPair const& r) const {
-			if (proxy.betterFitness(r.proxy)) {
-				return true;
-			}
-			if (r.proxy.betterFitness(proxy)) {
-				return false;
-			}
-			if (grvProxy.betterFitness(r.grvProxy)) {
-				return true;
-			}
-			if (r.grvProxy.betterFitness(grvProxy)) {
-				return false;
-			}
-			if (resolver.betterFitness(r.resolver)) {
-				return true;
-			}
-			if (r.resolver.betterFitness(resolver)) {
-				return false;
-			}
-			if (proxy.count != r.proxy.count) {
-				return proxy.count > r.proxy.count;
-			}
-			if (grvProxy.count != r.grvProxy.count) {
-				return grvProxy.count > r.grvProxy.count;
-			}
-			return resolver.count > r.resolver.count;
-		}
-		bool operator>(RoleFitnessPair const& r) const { return r < *this; }
-		bool operator<=(RoleFitnessPair const& r) const { return !(*this > r); }
-		bool operator>=(RoleFitnessPair const& r) const { return !(*this < r); }
-
-		bool operator==(RoleFitnessPair const& r) const {
-			return proxy == r.proxy && grvProxy == r.grvProxy && resolver == r.resolver;
+		std::string toString() const {
+			return format(
+			    "%d %d %d %d %d %d", worstFit, worstUsed, count, worstIsDegraded, inClusterControllerDC, bestFit);
 		}
 	};
 
@@ -914,9 +901,9 @@ public:
 		if (!goodRemoteRecruitmentTime.isReady() &&
 		    ((RoleFitness(
 		          SERVER_KNOBS->EXPECTED_TLOG_FITNESS, req.configuration.getDesiredRemoteLogs(), ProcessClass::TLog)
-		          .betterCount(RoleFitness(remoteLogs, ProcessClass::TLog))) ||
+		          .betterCount(RoleFitness(remoteLogs, ProcessClass::TLog, id_used, clusterControllerDcId))) ||
 		     (RoleFitness(SERVER_KNOBS->EXPECTED_LOG_ROUTER_FITNESS, req.logRouterCount, ProcessClass::LogRouter)
-		          .betterCount(RoleFitness(logRouters, ProcessClass::LogRouter))))) {
+		          .betterCount(RoleFitness(logRouters, ProcessClass::LogRouter, id_used, clusterControllerDcId))))) {
 			throw operation_failed();
 		}
 
@@ -980,6 +967,13 @@ public:
 		auto first_resolver = getWorkerForRoleInDatacenter(
 		    dcId, ProcessClass::Resolver, ProcessClass::ExcludeFit, req.configuration, id_used);
 
+		// If one of the first process recruitments is forced to share a process, allow all of next recruitments
+		// to also share a process.
+		auto maxUsed = std::max(std::max(first_commit_proxy.used, first_grv_proxy.used), first_resolver.used);
+		first_commit_proxy.used = maxUsed;
+		first_grv_proxy.used = maxUsed;
+		first_resolver.used = maxUsed;
+
 		auto commit_proxies = getWorkersForRoleInDatacenter(dcId,
 		                                                    ProcessClass::CommitProxy,
 		                                                    req.configuration.getDesiredCommitProxies(),
@@ -1031,24 +1025,24 @@ public:
 
 		if (!goodRecruitmentTime.isReady() &&
 		    (RoleFitness(SERVER_KNOBS->EXPECTED_TLOG_FITNESS, req.configuration.getDesiredLogs(), ProcessClass::TLog)
-		         .betterCount(RoleFitness(tlogs, ProcessClass::TLog)) ||
+		         .betterCount(RoleFitness(tlogs, ProcessClass::TLog, id_used, clusterControllerDcId)) ||
 		     (region.satelliteTLogReplicationFactor > 0 && req.configuration.usableRegions > 1 &&
 		      RoleFitness(SERVER_KNOBS->EXPECTED_TLOG_FITNESS,
 		                  req.configuration.getDesiredSatelliteLogs(dcId),
 		                  ProcessClass::TLog)
-		          .betterCount(RoleFitness(satelliteLogs, ProcessClass::TLog))) ||
+		          .betterCount(RoleFitness(satelliteLogs, ProcessClass::TLog, id_used, clusterControllerDcId))) ||
 		     RoleFitness(SERVER_KNOBS->EXPECTED_COMMIT_PROXY_FITNESS,
 		                 req.configuration.getDesiredCommitProxies(),
 		                 ProcessClass::CommitProxy)
-		         .betterCount(RoleFitness(commit_proxies, ProcessClass::CommitProxy)) ||
+		         .betterCount(RoleFitness(commit_proxies, ProcessClass::CommitProxy, id_used, clusterControllerDcId)) ||
 		     RoleFitness(SERVER_KNOBS->EXPECTED_GRV_PROXY_FITNESS,
 		                 req.configuration.getDesiredGrvProxies(),
 		                 ProcessClass::GrvProxy)
-		         .betterCount(RoleFitness(grv_proxies, ProcessClass::GrvProxy)) ||
+		         .betterCount(RoleFitness(grv_proxies, ProcessClass::GrvProxy, id_used, clusterControllerDcId)) ||
 		     RoleFitness(SERVER_KNOBS->EXPECTED_RESOLVER_FITNESS,
 		                 req.configuration.getDesiredResolvers(),
 		                 ProcessClass::Resolver)
-		         .betterCount(RoleFitness(resolvers, ProcessClass::Resolver)))) {
+		         .betterCount(RoleFitness(resolvers, ProcessClass::Resolver, id_used, clusterControllerDcId)))) {
 			return operation_failed();
 		}
 
@@ -1149,7 +1143,7 @@ public:
 
 			auto datacenters = getDatacenters(req.configuration);
 
-			RoleFitnessPair bestFitness;
+			std::tuple<RoleFitness, RoleFitness, RoleFitness> bestFitness;
 			int numEquivalent = 1;
 			Optional<Key> bestDC;
 
@@ -1164,6 +1158,14 @@ public:
 					    dcId, ProcessClass::GrvProxy, ProcessClass::ExcludeFit, req.configuration, used);
 					auto first_resolver = getWorkerForRoleInDatacenter(
 					    dcId, ProcessClass::Resolver, ProcessClass::ExcludeFit, req.configuration, used);
+
+					// If one of the first process recruitments is forced to share a process, allow all of next
+					// recruitments to also share a process.
+					auto maxUsed =
+					    std::max(std::max(first_commit_proxy.used, first_grv_proxy.used), first_resolver.used);
+					first_commit_proxy.used = maxUsed;
+					first_grv_proxy.used = maxUsed;
+					first_resolver.used = maxUsed;
 
 					auto commit_proxies = getWorkersForRoleInDatacenter(dcId,
 					                                                    ProcessClass::CommitProxy,
@@ -1186,9 +1188,10 @@ public:
 					                                               used,
 					                                               first_resolver);
 
-					RoleFitnessPair fitness(RoleFitness(commit_proxies, ProcessClass::CommitProxy),
-					                        RoleFitness(grv_proxies, ProcessClass::GrvProxy),
-					                        RoleFitness(resolvers, ProcessClass::Resolver));
+					auto fitness = std::make_tuple(
+					    RoleFitness(commit_proxies, ProcessClass::CommitProxy, used, clusterControllerDcId),
+					    RoleFitness(grv_proxies, ProcessClass::GrvProxy, used, clusterControllerDcId),
+					    RoleFitness(resolvers, ProcessClass::Resolver, used, clusterControllerDcId));
 
 					if (dcId == clusterControllerDcId) {
 						bestFitness = fitness;
@@ -1206,7 +1209,7 @@ public:
 						if (req.configuration.backupWorkerEnabled) {
 							const int nBackup = std::max<int>(tlogs.size(), req.maxOldLogRouters);
 							auto backupWorkers = getWorkersForRoleInDatacenter(
-							    dcId, ProcessClass::Backup, nBackup, req.configuration, id_used);
+							    dcId, ProcessClass::Backup, nBackup, req.configuration, used);
 							std::transform(backupWorkers.begin(),
 							               backupWorkers.end(),
 							               std::back_inserter(result.backupWorkers),
@@ -1254,19 +1257,19 @@ public:
 			if (!goodRecruitmentTime.isReady() &&
 			    (RoleFitness(
 			         SERVER_KNOBS->EXPECTED_TLOG_FITNESS, req.configuration.getDesiredLogs(), ProcessClass::TLog)
-			         .betterCount(RoleFitness(tlogs, ProcessClass::TLog)) ||
+			         .betterCount(RoleFitness(tlogs, ProcessClass::TLog, id_used, clusterControllerDcId)) ||
 			     RoleFitness(SERVER_KNOBS->EXPECTED_COMMIT_PROXY_FITNESS,
 			                 req.configuration.getDesiredCommitProxies(),
 			                 ProcessClass::CommitProxy)
-			         .betterCount(bestFitness.proxy) ||
+			         .betterCount(std::get<0>(bestFitness)) ||
 			     RoleFitness(SERVER_KNOBS->EXPECTED_GRV_PROXY_FITNESS,
 			                 req.configuration.getDesiredGrvProxies(),
 			                 ProcessClass::GrvProxy)
-			         .betterCount(bestFitness.grvProxy) ||
+			         .betterCount(std::get<1>(bestFitness)) ||
 			     RoleFitness(SERVER_KNOBS->EXPECTED_RESOLVER_FITNESS,
 			                 req.configuration.getDesiredResolvers(),
 			                 ProcessClass::Resolver)
-			         .betterCount(bestFitness.resolver))) {
+			         .betterCount(std::get<2>(bestFitness)))) {
 				throw operation_failed();
 			}
 
@@ -1337,6 +1340,12 @@ public:
 		}
 	}
 
+	void updateIdUsed(const vector<WorkerDetails>& workers, std::map<Optional<Standalone<StringRef>>, int>& id_used) {
+		for (auto& it : workers) {
+			id_used[it.interf.locality.processId()]++;
+		}
+	}
+
 	// FIXME: determine when to fail the cluster controller when a primaryDC has not been set
 
 	// This function returns true when the cluster controller determines it is worth forcing
@@ -1351,6 +1360,7 @@ public:
 		// Do not trigger better master exists if the cluster controller is excluded, since the master will change
 		// anyways once the cluster controller is moved
 		if (id_worker[clusterControllerProcessId].priorityInfo.isExcluded) {
+			TraceEvent("WorseMasterExists", id).detail("Reason", "ClusterControllerExcluded");
 			return false;
 		}
 
@@ -1363,6 +1373,9 @@ public:
 		// Get master process
 		auto masterWorker = id_worker.find(dbi.master.locality.processId());
 		if (masterWorker == id_worker.end()) {
+			TraceEvent("WorseMasterExists", id)
+			    .detail("Reason", "CannotFindMaster")
+			    .detail("ProcessID", dbi.master.locality.processId());
 			return false;
 		}
 
@@ -1378,10 +1391,18 @@ public:
 		for (auto& logSet : dbi.logSystemConfig.tLogs) {
 			for (auto& it : logSet.tLogs) {
 				auto tlogWorker = id_worker.find(it.interf().filteredLocality.processId());
-				if (tlogWorker == id_worker.end())
+				if (tlogWorker == id_worker.end()) {
+					TraceEvent("WorseMasterExists", id)
+					    .detail("Reason", "CannotFindTLog")
+					    .detail("ProcessID", it.interf().filteredLocality.processId());
 					return false;
-				if (tlogWorker->second.priorityInfo.isExcluded)
+				}
+				if (tlogWorker->second.priorityInfo.isExcluded) {
+					TraceEvent("BetterMasterExists", id)
+					    .detail("Reason", "TLogExcluded")
+					    .detail("ProcessID", it.interf().filteredLocality.processId());
 					return true;
+				}
 
 				if (logSet.isLocal && logSet.locality == tagLocalitySatellite) {
 					satellite_tlogs.push_back(tlogWorker->second.details);
@@ -1394,10 +1415,18 @@ public:
 
 			for (auto& it : logSet.logRouters) {
 				auto tlogWorker = id_worker.find(it.interf().filteredLocality.processId());
-				if (tlogWorker == id_worker.end())
+				if (tlogWorker == id_worker.end()) {
+					TraceEvent("WorseMasterExists", id)
+					    .detail("Reason", "CannotFindLogRouter")
+					    .detail("ProcessID", it.interf().filteredLocality.processId());
 					return false;
-				if (tlogWorker->second.priorityInfo.isExcluded)
+				}
+				if (tlogWorker->second.priorityInfo.isExcluded) {
+					TraceEvent("BetterMasterExists", id)
+					    .detail("Reason", "LogRouterExcluded")
+					    .detail("ProcessID", it.interf().filteredLocality.processId());
 					return true;
+				}
 				if (!logRouterAddresses.count(tlogWorker->second.details.interf.address())) {
 					logRouterAddresses.insert(tlogWorker->second.details.interf.address());
 					log_routers.push_back(tlogWorker->second.details);
@@ -1406,10 +1435,18 @@ public:
 
 			for (const auto& worker : logSet.backupWorkers) {
 				auto workerIt = id_worker.find(worker.interf().locality.processId());
-				if (workerIt == id_worker.end())
+				if (workerIt == id_worker.end()) {
+					TraceEvent("WorseMasterExists", id)
+					    .detail("Reason", "CannotFindBackupWorker")
+					    .detail("ProcessID", worker.interf().locality.processId());
 					return false;
-				if (workerIt->second.priorityInfo.isExcluded)
+				}
+				if (workerIt->second.priorityInfo.isExcluded) {
+					TraceEvent("BetterMasterExists", id)
+					    .detail("Reason", "BackupWorkerExcluded")
+					    .detail("ProcessID", worker.interf().locality.processId());
 					return true;
+				}
 				if (backup_addresses.count(workerIt->second.details.interf.address()) == 0) {
 					backup_addresses.insert(workerIt->second.details.interf.address());
 					backup_workers.push_back(workerIt->second.details);
@@ -1421,10 +1458,18 @@ public:
 		std::vector<WorkerDetails> commitProxyClasses;
 		for (auto& it : dbi.client.commitProxies) {
 			auto commitProxyWorker = id_worker.find(it.processId);
-			if (commitProxyWorker == id_worker.end())
+			if (commitProxyWorker == id_worker.end()) {
+				TraceEvent("WorseMasterExists", id)
+				    .detail("Reason", "CannotFindCommitProxy")
+				    .detail("ProcessID", it.processId);
 				return false;
-			if (commitProxyWorker->second.priorityInfo.isExcluded)
+			}
+			if (commitProxyWorker->second.priorityInfo.isExcluded) {
+				TraceEvent("BetterMasterExists", id)
+				    .detail("Reason", "CommitProxyExcluded")
+				    .detail("ProcessID", it.processId);
 				return true;
+			}
 			commitProxyClasses.push_back(commitProxyWorker->second.details);
 		}
 
@@ -1432,10 +1477,18 @@ public:
 		std::vector<WorkerDetails> grvProxyClasses;
 		for (auto& it : dbi.client.grvProxies) {
 			auto grvProxyWorker = id_worker.find(it.processId);
-			if (grvProxyWorker == id_worker.end())
+			if (grvProxyWorker == id_worker.end()) {
+				TraceEvent("WorseMasterExists", id)
+				    .detail("Reason", "CannotFindGrvProxy")
+				    .detail("ProcessID", it.processId);
 				return false;
-			if (grvProxyWorker->second.priorityInfo.isExcluded)
+			}
+			if (grvProxyWorker->second.priorityInfo.isExcluded) {
+				TraceEvent("BetterMasterExists", id)
+				    .detail("Reason", "GrvProxyExcluded")
+				    .detail("ProcessID", it.processId);
 				return true;
+			}
 			grvProxyClasses.push_back(grvProxyWorker->second.details);
 		}
 
@@ -1443,10 +1496,18 @@ public:
 		std::vector<WorkerDetails> resolverClasses;
 		for (auto& it : dbi.resolvers) {
 			auto resolverWorker = id_worker.find(it.locality.processId());
-			if (resolverWorker == id_worker.end())
+			if (resolverWorker == id_worker.end()) {
+				TraceEvent("WorseMasterExists", id)
+				    .detail("Reason", "CannotFindResolver")
+				    .detail("ProcessID", it.locality.processId());
 				return false;
-			if (resolverWorker->second.priorityInfo.isExcluded)
+			}
+			if (resolverWorker->second.priorityInfo.isExcluded) {
+				TraceEvent("BetterMasterExists", id)
+				    .detail("Reason", "ResolverExcluded")
+				    .detail("ProcessID", it.locality.processId());
 				return true;
+			}
 			resolverClasses.push_back(resolverWorker->second.details);
 		}
 
@@ -1459,7 +1520,9 @@ public:
 		}
 
 		std::map<Optional<Standalone<StringRef>>, int> id_used;
+		std::map<Optional<Standalone<StringRef>>, int> old_id_used;
 		id_used[clusterControllerProcessId]++;
+		old_id_used[clusterControllerProcessId]++;
 		WorkerFitnessInfo mworker = getWorkerForRoleInDatacenter(
 		    clusterControllerDcId, ProcessClass::Master, ProcessClass::NeverAssign, db.config, id_used, true);
 		auto newMasterFit = mworker.worker.processClass.machineClassFitness(ProcessClass::Master);
@@ -1467,11 +1530,25 @@ public:
 			newMasterFit = std::max(newMasterFit, ProcessClass::ExcludeFit);
 		}
 
-		if (oldMasterFit < newMasterFit)
+		old_id_used[masterWorker->first]++;
+		if (oldMasterFit < newMasterFit) {
+			TraceEvent("WorseMasterExists", id)
+			    .detail("OldMasterFit", oldMasterFit)
+			    .detail("NewMasterFit", newMasterFit)
+			    .detail("OldIsCC", dbi.master.locality.processId() == clusterControllerProcessId)
+			    .detail("NewIsCC", mworker.worker.interf.locality.processId() == clusterControllerProcessId);
+			;
 			return false;
+		}
 		if (oldMasterFit > newMasterFit || (dbi.master.locality.processId() == clusterControllerProcessId &&
-		                                    mworker.worker.interf.locality.processId() != clusterControllerProcessId))
+		                                    mworker.worker.interf.locality.processId() != clusterControllerProcessId)) {
+			TraceEvent("BetterMasterExists", id)
+			    .detail("OldMasterFit", oldMasterFit)
+			    .detail("NewMasterFit", newMasterFit)
+			    .detail("OldIsCC", dbi.master.locality.processId() == clusterControllerProcessId)
+			    .detail("NewIsCC", mworker.worker.interf.locality.processId() == clusterControllerProcessId);
 			return true;
+		}
 
 		std::set<Optional<Key>> primaryDC;
 		std::set<Optional<Key>> remoteDC;
@@ -1493,7 +1570,8 @@ public:
 		}
 
 		// Check tLog fitness
-		RoleFitness oldTLogFit(tlogs, ProcessClass::TLog);
+		updateIdUsed(tlogs, old_id_used);
+		RoleFitness oldTLogFit(tlogs, ProcessClass::TLog, old_id_used, clusterControllerDcId);
 		auto newTLogs = getWorkersForTlogs(db.config,
 		                                   db.config.tLogReplicationFactor,
 		                                   db.config.getDesiredLogs(),
@@ -1501,10 +1579,7 @@ public:
 		                                   id_used,
 		                                   true,
 		                                   primaryDC);
-		RoleFitness newTLogFit(newTLogs, ProcessClass::TLog);
-
-		if (oldTLogFit < newTLogFit)
-			return false;
+		RoleFitness newTLogFit(newTLogs, ProcessClass::TLog, id_used, clusterControllerDcId);
 
 		bool oldSatelliteFallback = false;
 
@@ -1520,13 +1595,16 @@ public:
 			}
 		}
 
-		RoleFitness oldSatelliteTLogFit(satellite_tlogs, ProcessClass::TLog);
+		updateIdUsed(satellite_tlogs, old_id_used);
+		RoleFitness oldSatelliteTLogFit(satellite_tlogs, ProcessClass::TLog, old_id_used, clusterControllerDcId);
 		bool newSatelliteFallback = false;
-		auto newSatelliteTLogs =
-		    (region.satelliteTLogReplicationFactor > 0 && db.config.usableRegions > 1)
-		        ? getWorkersForSatelliteLogs(db.config, region, remoteRegion, id_used, newSatelliteFallback, true)
-		        : satellite_tlogs;
-		RoleFitness newSatelliteTLogFit(newSatelliteTLogs, ProcessClass::TLog);
+		auto newSatelliteTLogs = satellite_tlogs;
+		RoleFitness newSatelliteTLogFit = oldSatelliteTLogFit;
+		if (region.satelliteTLogReplicationFactor > 0 && db.config.usableRegions > 1) {
+			newSatelliteTLogs =
+			    getWorkersForSatelliteLogs(db.config, region, remoteRegion, id_used, newSatelliteFallback, true);
+			newSatelliteTLogFit = RoleFitness(newSatelliteTLogs, ProcessClass::TLog, id_used, clusterControllerDcId);
+		}
 
 		std::map<Optional<Key>, int32_t> satellite_priority;
 		for (auto& r : region.satellites) {
@@ -1551,55 +1629,72 @@ public:
 			}
 		}
 
-		if (oldSatelliteFallback && !newSatelliteFallback)
+		if (oldSatelliteFallback && !newSatelliteFallback) {
+			TraceEvent("BetterMasterExists", id)
+			    .detail("OldSatelliteFallback", oldSatelliteFallback)
+			    .detail("NewSatelliteFallback", newSatelliteFallback);
 			return true;
-		if (!oldSatelliteFallback && newSatelliteFallback)
+		}
+		if (!oldSatelliteFallback && newSatelliteFallback) {
+			TraceEvent("WorseMasterExists", id)
+			    .detail("OldSatelliteFallback", oldSatelliteFallback)
+			    .detail("NewSatelliteFallback", newSatelliteFallback);
 			return false;
+		}
 
-		if (oldSatelliteRegionFit < newSatelliteRegionFit)
+		if (oldSatelliteRegionFit < newSatelliteRegionFit) {
+			TraceEvent("BetterMasterExists", id)
+			    .detail("OldSatelliteRegionFit", oldSatelliteRegionFit)
+			    .detail("NewSatelliteRegionFit", newSatelliteRegionFit);
 			return true;
-		if (oldSatelliteRegionFit > newSatelliteRegionFit)
+		}
+		if (oldSatelliteRegionFit > newSatelliteRegionFit) {
+			TraceEvent("WorseMasterExists", id)
+			    .detail("OldSatelliteRegionFit", oldSatelliteRegionFit)
+			    .detail("NewSatelliteRegionFit", newSatelliteRegionFit);
 			return false;
+		}
 
-		if (oldSatelliteTLogFit < newSatelliteTLogFit)
-			return false;
-
-		RoleFitness oldRemoteTLogFit(remote_tlogs, ProcessClass::TLog);
+		updateIdUsed(remote_tlogs, old_id_used);
+		RoleFitness oldRemoteTLogFit(remote_tlogs, ProcessClass::TLog, old_id_used, clusterControllerDcId);
 		std::vector<UID> exclusionWorkerIds;
 		auto fn = [](const WorkerDetails& in) { return in.interf.id(); };
 		std::transform(newTLogs.begin(), newTLogs.end(), std::back_inserter(exclusionWorkerIds), fn);
 		std::transform(newSatelliteTLogs.begin(), newSatelliteTLogs.end(), std::back_inserter(exclusionWorkerIds), fn);
-		RoleFitness newRemoteTLogFit(
-		    (db.config.usableRegions > 1 && (dbi.recoveryState == RecoveryState::ALL_LOGS_RECRUITED ||
-		                                     dbi.recoveryState == RecoveryState::FULLY_RECOVERED))
-		        ? getWorkersForTlogs(db.config,
-		                             db.config.getRemoteTLogReplicationFactor(),
-		                             db.config.getDesiredRemoteLogs(),
-		                             db.config.getRemoteTLogPolicy(),
-		                             id_used,
-		                             true,
-		                             remoteDC,
-		                             exclusionWorkerIds)
-		        : remote_tlogs,
-		    ProcessClass::TLog);
-		if (oldRemoteTLogFit < newRemoteTLogFit)
-			return false;
+		RoleFitness newRemoteTLogFit = oldRemoteTLogFit;
+		if (db.config.usableRegions > 1 && (dbi.recoveryState == RecoveryState::ALL_LOGS_RECRUITED ||
+		                                    dbi.recoveryState == RecoveryState::FULLY_RECOVERED)) {
+			newRemoteTLogFit = RoleFitness(getWorkersForTlogs(db.config,
+			                                                  db.config.getRemoteTLogReplicationFactor(),
+			                                                  db.config.getDesiredRemoteLogs(),
+			                                                  db.config.getRemoteTLogPolicy(),
+			                                                  id_used,
+			                                                  true,
+			                                                  remoteDC,
+			                                                  exclusionWorkerIds),
+			                               ProcessClass::TLog,
+			                               id_used,
+			                               clusterControllerDcId);
+		}
 		int oldRouterCount =
 		    oldTLogFit.count * std::max<int>(1, db.config.desiredLogRouterCount / std::max(1, oldTLogFit.count));
 		int newRouterCount =
 		    newTLogFit.count * std::max<int>(1, db.config.desiredLogRouterCount / std::max(1, newTLogFit.count));
-		RoleFitness oldLogRoutersFit(log_routers, ProcessClass::LogRouter);
-		RoleFitness newLogRoutersFit(
-		    (db.config.usableRegions > 1 && dbi.recoveryState == RecoveryState::FULLY_RECOVERED)
-		        ? getWorkersForRoleInDatacenter(*remoteDC.begin(),
-		                                        ProcessClass::LogRouter,
-		                                        newRouterCount,
-		                                        db.config,
-		                                        id_used,
-		                                        Optional<WorkerFitnessInfo>(),
-		                                        true)
-		        : log_routers,
-		    ProcessClass::LogRouter);
+		updateIdUsed(log_routers, old_id_used);
+		RoleFitness oldLogRoutersFit(log_routers, ProcessClass::LogRouter, old_id_used, clusterControllerDcId);
+		RoleFitness newLogRoutersFit = oldLogRoutersFit;
+		if (db.config.usableRegions > 1 && dbi.recoveryState == RecoveryState::FULLY_RECOVERED) {
+			newLogRoutersFit = RoleFitness(getWorkersForRoleInDatacenter(*remoteDC.begin(),
+			                                                             ProcessClass::LogRouter,
+			                                                             newRouterCount,
+			                                                             db.config,
+			                                                             id_used,
+			                                                             Optional<WorkerFitnessInfo>(),
+			                                                             true),
+			                               ProcessClass::LogRouter,
+			                               id_used,
+			                               clusterControllerDcId);
+		}
 
 		if (oldLogRoutersFit.count < oldRouterCount) {
 			oldLogRoutersFit.worstFit = ProcessClass::NeverAssign;
@@ -1607,13 +1702,15 @@ public:
 		if (newLogRoutersFit.count < newRouterCount) {
 			newLogRoutersFit.worstFit = ProcessClass::NeverAssign;
 		}
-		if (oldLogRoutersFit < newLogRoutersFit)
-			return false;
 
 		// Check proxy/grvProxy/resolver fitness
-		RoleFitnessPair oldInFit(RoleFitness(commitProxyClasses, ProcessClass::CommitProxy),
-		                         RoleFitness(grvProxyClasses, ProcessClass::GrvProxy),
-		                         RoleFitness(resolverClasses, ProcessClass::Resolver));
+		updateIdUsed(commitProxyClasses, old_id_used);
+		updateIdUsed(grvProxyClasses, old_id_used);
+		updateIdUsed(resolverClasses, old_id_used);
+		RoleFitness oldCommitProxyFit(
+		    commitProxyClasses, ProcessClass::CommitProxy, old_id_used, clusterControllerDcId);
+		RoleFitness oldGrvProxyFit(grvProxyClasses, ProcessClass::GrvProxy, old_id_used, clusterControllerDcId);
+		RoleFitness oldResolverFit(resolverClasses, ProcessClass::Resolver, old_id_used, clusterControllerDcId);
 
 		auto first_commit_proxy = getWorkerForRoleInDatacenter(
 		    clusterControllerDcId, ProcessClass::CommitProxy, ProcessClass::ExcludeFit, db.config, id_used, true);
@@ -1621,6 +1718,10 @@ public:
 		    clusterControllerDcId, ProcessClass::GrvProxy, ProcessClass::ExcludeFit, db.config, id_used, true);
 		auto first_resolver = getWorkerForRoleInDatacenter(
 		    clusterControllerDcId, ProcessClass::Resolver, ProcessClass::ExcludeFit, db.config, id_used, true);
+		auto maxUsed = std::max(std::max(first_commit_proxy.used, first_grv_proxy.used), first_resolver.used);
+		first_commit_proxy.used = maxUsed;
+		first_grv_proxy.used = maxUsed;
+		first_resolver.used = maxUsed;
 		auto commit_proxies = getWorkersForRoleInDatacenter(clusterControllerDcId,
 		                                                    ProcessClass::CommitProxy,
 		                                                    db.config.getDesiredCommitProxies(),
@@ -1643,25 +1744,13 @@ public:
 		                                               first_resolver,
 		                                               true);
 
-		RoleFitnessPair newInFit(RoleFitness(commit_proxies, ProcessClass::CommitProxy),
-		                         RoleFitness(grv_proxies, ProcessClass::GrvProxy),
-		                         RoleFitness(resolvers, ProcessClass::Resolver));
-		if (oldInFit.proxy.betterFitness(newInFit.proxy) || oldInFit.grvProxy.betterFitness(newInFit.grvProxy) ||
-		    oldInFit.resolver.betterFitness(newInFit.resolver)) {
-			return false;
-		}
-
-		// Because a configuration with fewer proxies or resolvers does not cause this function to fail,
-		// we need an extra check to determine if the total number of processes has been reduced.
-		// This is mainly helpful in avoiding situations where killing a degraded process
-		// would result in a configuration with less total processes than desired.
-		if (oldTLogFit.count + oldInFit.proxy.count + oldInFit.grvProxy.count + oldInFit.resolver.count >
-		    newTLogFit.count + newInFit.proxy.count + newInFit.grvProxy.count + newInFit.resolver.count) {
-			return false;
-		}
+		RoleFitness newCommitProxyFit(commit_proxies, ProcessClass::CommitProxy, id_used, clusterControllerDcId);
+		RoleFitness newGrvProxyFit(grv_proxies, ProcessClass::GrvProxy, id_used, clusterControllerDcId);
+		RoleFitness newResolverFit(resolvers, ProcessClass::Resolver, id_used, clusterControllerDcId);
 
 		// Check backup worker fitness
-		RoleFitness oldBackupWorkersFit(backup_workers, ProcessClass::Backup);
+		updateIdUsed(backup_workers, old_id_used);
+		RoleFitness oldBackupWorkersFit(backup_workers, ProcessClass::Backup, old_id_used, clusterControllerDcId);
 		const int nBackup = backup_addresses.size();
 		RoleFitness newBackupWorkersFit(getWorkersForRoleInDatacenter(clusterControllerDcId,
 		                                                              ProcessClass::Backup,
@@ -1670,35 +1759,75 @@ public:
 		                                                              id_used,
 		                                                              Optional<WorkerFitnessInfo>(),
 		                                                              true),
-		                                ProcessClass::Backup);
+		                                ProcessClass::Backup,
+		                                id_used,
+		                                clusterControllerDcId);
 
-		if (oldTLogFit > newTLogFit || oldInFit > newInFit || oldSatelliteTLogFit > newSatelliteTLogFit ||
-		    oldRemoteTLogFit > newRemoteTLogFit || oldLogRoutersFit > newLogRoutersFit ||
-		    oldBackupWorkersFit > newBackupWorkersFit) {
+		auto oldFit = std::make_tuple(oldTLogFit,
+		                              oldSatelliteTLogFit,
+		                              oldCommitProxyFit,
+		                              oldGrvProxyFit,
+		                              oldResolverFit,
+		                              oldBackupWorkersFit,
+		                              oldRemoteTLogFit,
+		                              oldLogRoutersFit);
+		auto newFit = std::make_tuple(newTLogFit,
+		                              newSatelliteTLogFit,
+		                              newCommitProxyFit,
+		                              newGrvProxyFit,
+		                              newResolverFit,
+		                              newBackupWorkersFit,
+		                              newRemoteTLogFit,
+		                              newLogRoutersFit);
+
+		if (oldFit > newFit) {
 			TraceEvent("BetterMasterExists", id)
 			    .detail("OldMasterFit", oldMasterFit)
 			    .detail("NewMasterFit", newMasterFit)
 			    .detail("OldTLogFit", oldTLogFit.toString())
 			    .detail("NewTLogFit", newTLogFit.toString())
-			    .detail("OldProxyFit", oldInFit.proxy.toString())
-			    .detail("NewProxyFit", newInFit.proxy.toString())
-			    .detail("OldGrvProxyFit", oldInFit.grvProxy.toString())
-			    .detail("NewGrvProxyFit", newInFit.grvProxy.toString())
-			    .detail("OldResolverFit", oldInFit.resolver.toString())
-			    .detail("NewResolverFit", newInFit.resolver.toString())
 			    .detail("OldSatelliteFit", oldSatelliteTLogFit.toString())
 			    .detail("NewSatelliteFit", newSatelliteTLogFit.toString())
+			    .detail("OldCommitProxyFit", oldCommitProxyFit.toString())
+			    .detail("NewCommitProxyFit", newCommitProxyFit.toString())
+			    .detail("OldGrvProxyFit", oldGrvProxyFit.toString())
+			    .detail("NewGrvProxyFit", newGrvProxyFit.toString())
+			    .detail("OldResolverFit", oldResolverFit.toString())
+			    .detail("NewResolverFit", newResolverFit.toString())
+			    .detail("OldBackupWorkerFit", oldBackupWorkersFit.toString())
+			    .detail("NewBackupWorkerFit", newBackupWorkersFit.toString())
 			    .detail("OldRemoteFit", oldRemoteTLogFit.toString())
 			    .detail("NewRemoteFit", newRemoteTLogFit.toString())
 			    .detail("OldRouterFit", oldLogRoutersFit.toString())
 			    .detail("NewRouterFit", newLogRoutersFit.toString())
-			    .detail("OldBackupWorkerFit", oldBackupWorkersFit.toString())
-			    .detail("NewBackupWorkerFit", newBackupWorkersFit.toString())
 			    .detail("OldSatelliteFallback", oldSatelliteFallback)
 			    .detail("NewSatelliteFallback", newSatelliteFallback);
 			return true;
 		}
 
+		if (oldFit < newFit) {
+			TraceEvent("WorseMasterExists", id)
+			    .detail("OldMasterFit", oldMasterFit)
+			    .detail("NewMasterFit", newMasterFit)
+			    .detail("OldTLogFit", oldTLogFit.toString())
+			    .detail("NewTLogFit", newTLogFit.toString())
+			    .detail("OldSatelliteFit", oldSatelliteTLogFit.toString())
+			    .detail("NewSatelliteFit", newSatelliteTLogFit.toString())
+			    .detail("OldCommitProxyFit", oldCommitProxyFit.toString())
+			    .detail("NewCommitProxyFit", newCommitProxyFit.toString())
+			    .detail("OldGrvProxyFit", oldGrvProxyFit.toString())
+			    .detail("NewGrvProxyFit", newGrvProxyFit.toString())
+			    .detail("OldResolverFit", oldResolverFit.toString())
+			    .detail("NewResolverFit", newResolverFit.toString())
+			    .detail("OldBackupWorkerFit", oldBackupWorkersFit.toString())
+			    .detail("NewBackupWorkerFit", newBackupWorkersFit.toString())
+			    .detail("OldRemoteFit", oldRemoteTLogFit.toString())
+			    .detail("NewRemoteFit", newRemoteTLogFit.toString())
+			    .detail("OldRouterFit", oldLogRoutersFit.toString())
+			    .detail("NewRouterFit", newLogRoutersFit.toString())
+			    .detail("OldSatelliteFallback", oldSatelliteFallback)
+			    .detail("NewSatelliteFallback", newSatelliteFallback);
+		}
 		return false;
 	}
 


### PR DESCRIPTION
tlog recruitment used a degraded LogClass process over a non-degraded TransactionClass process.

tlog recruitment would not use TransactionClass processes if it fulfulled the required amount with LogClass processes.

Better master exists did not account for how many times a process had been used when comparing recruitments.

Better master exists did not account for the fact that tlogs prefer to be in a different dc than the cluster controller.

RoleFitness comparison did not properly order count before degraded or bestFit.

betterCount was returning worstFit when worstIsDegraded did not match.

backupWorker recruitment did not attempt to avoid sharing processes with other roles.

If any of the commit_proxy, grv_proxy, or resolver are forced to share a process, allow the recruitment for all of them to share to an equal degree, this change allows BetterMasterExists to be refactors as a tuple comparison.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
