### PR TITLE
specify docutils version -- cherry-pick 4621 from master

### DIFF
--- a/documentation/sphinx/requirements.txt
+++ b/documentation/sphinx/requirements.txt
@@ -2,4 +2,5 @@
 setuptools>=20.10.0
 sphinx==1.5.6
 sphinx-bootstrap-theme==0.4.8
+docutils==0.16
 pygments-style-solarized


### PR DESCRIPTION
set docutils version discretely for documentation build. 

docutils 0.17 was released on 3-April-2021 and caused out documentation build to break. There are unicode/utf-8 characters in the some part of the docutils package/documentation that cause sphinx_build to fail to parse with the error: 

```
# Sphinx version: 1.5.6
# Python version: 3.6.12 (CPython)
# Docutils version: 0.17 release
# Jinja2 version: 2.11.3
# Last messages:

# Loaded extensions:
Traceback (most recent call last):
  File "/root/build_output/documentation/venv/lib64/python3.6/site-packages/sphinx/cmdline.py", line 295, in main
    opts.warningiserror, opts.tags, opts.verbosity, opts.jobs)
  File "/root/build_output/documentation/venv/lib64/python3.6/site-packages/sphinx/application.py", line 189, in __init__
    self.setup_extension(extension)
  File "/root/build_output/documentation/venv/lib64/python3.6/site-packages/sphinx/application.py", line 512, in setup_extension
    mod = __import__(extension, None, None, ['setup'])
  File "/root/build_output/documentation/venv/lib64/python3.6/site-packages/sphinx/builders/latex.py", line 32, in <module>
    from sphinx.writers.latex import LaTeXWriter
  File "/root/build_output/documentation/venv/lib64/python3.6/site-packages/sphinx/writers/latex.py", line 22, in <module>
    from docutils.writers.latex2e import Babel
  File "/root/build_output/documentation/venv/lib64/python3.6/site-packages/docutils/writers/latex2e/__init__.py", line 575, in <module>
    for line in fp:
  File "/opt/rh/rh-python36/root/usr/lib64/python3.6/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc2 in position 69: ordinal not in range(128)
```

Updating all of the packages in the `documentation/sphinx/requirements.txt` did not remedy the failure. The root cause was discovered by manually running the sphinx_build command (as constructed by cmake) and adding the `-vvv` and the `-P` command line options. This allowed inspection of the python stack and visibility into the failing `input` that was causing the failure. 

There is likely a way through this error that involves re-configuring docutils (with a `docutils.conf` file) but this seemed the simplest solution at this time.  

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [✅] The PR has a description, explaining both the problem and the solution.
- [✅] The description mentions which forms of testing were done and the testing seems reasonable.
- [✅] Every function/class/actor that was touched is reasonably well documented.
