### PR TITLE
Added extra options to test config that specify maxtlogversion and array of excluded storage engine types (6.3 port)

### DIFF
--- a/fdbserver/SimulatedCluster.actor.cpp
+++ b/fdbserver/SimulatedCluster.actor.cpp
@@ -19,6 +19,7 @@
  */
 
 #include <fstream>
+#include <sstream>
 #include "fdbrpc/simulator.h"
 #include "fdbclient/DatabaseContext.h"
 #include "fdbserver/TesterInterface.actor.h"
@@ -846,6 +847,9 @@ StringRef StringRefOf(const char* s) {
 	return StringRef((uint8_t*)s, strlen(s));
 }
 
+// Generates and sets an appropriate configuration for the database according to
+// the provided testConfig. Some attributes are randomly generated for more coverage
+// of different combinations
 void SimulationConfig::generateNormalConfig(const TestConfig& testConfig) {
 	set_config("new");
 	const bool simple = false; // Set true to simplify simulation configs for easier debugging
@@ -866,7 +870,9 @@ void SimulationConfig::generateNormalConfig(const TestConfig& testConfig) {
 		db.resolverCount = deterministicRandom()->randomInt(1, 7);
 	int storage_engine_type = deterministicRandom()->randomInt(0, 4);
 	// Continuously re-pick the storage engine type if it's the one we want to exclude
-	while (storage_engine_type == testConfig.storageEngineExcludeType) {
+	while (std::find(testConfig.storageEngineExcludeTypes.begin(),
+	                 testConfig.storageEngineExcludeTypes.end(),
+	                 storage_engine_type) != testConfig.storageEngineExcludeTypes.end()) {
 		storage_engine_type = deterministicRandom()->randomInt(0, 4);
 	}
 	switch (storage_engine_type) {
@@ -957,11 +963,11 @@ void SimulationConfig::generateNormalConfig(const TestConfig& testConfig) {
 	if (deterministicRandom()->random01() < 0.5) {
 		int logSpill = deterministicRandom()->randomInt(TLogSpillType::VALUE, TLogSpillType::END);
 		set_config(format("log_spill:=%d", logSpill));
-		int logVersion = deterministicRandom()->randomInt(TLogVersion::MIN_RECRUITABLE, TLogVersion::MAX_SUPPORTED + 1);
+		int logVersion = deterministicRandom()->randomInt(TLogVersion::MIN_RECRUITABLE, testConfig.maxTLogVersion + 1);
 		set_config(format("log_version:=%d", logVersion));
 	} else {
 		if (deterministicRandom()->random01() < 0.7)
-			set_config(format("log_version:=%d", TLogVersion::MAX_SUPPORTED));
+			set_config(format("log_version:=%d", testConfig.maxTLogVersion));
 		if (deterministicRandom()->random01() < 0.5)
 			set_config(format("log_spill:=%d", TLogSpillType::DEFAULT));
 	}
@@ -1620,8 +1626,17 @@ void checkTestConf(const char* testFile, TestConfig* testConfig) {
 			sscanf(value.c_str(), "%d", &testConfig->logAntiQuorum);
 		}
 
-		if (attrib == "storageEngineExcludeType") {
-			sscanf(value.c_str(), "%d", &testConfig->storageEngineExcludeType);
+		if (attrib == "storageEngineExcludeTypes") {
+			std::stringstream ss(value);
+			for (int i; ss >> i;) {
+				testConfig->storageEngineExcludeTypes.push_back(i);
+				if (ss.peek() == ',') {
+					ss.ignore();
+				}
+			}
+		}
+		if (attrib == "maxTLogVersion") {
+			sscanf(value.c_str(), "%d", &testConfig->maxTLogVersion);
 		}
 	}
 

--- a/fdbserver/TesterInterface.actor.h
+++ b/fdbserver/TesterInterface.actor.h
@@ -109,12 +109,15 @@ struct TestConfig {
 	bool startIncompatibleProcess = false;
 	int logAntiQuorum = -1;
 	// Storage Engine Types: Verify match with SimulationConfig::generateNormalConfig
-	//	-1 = None
 	//	0 = "ssd"
 	//	1 = "memory"
 	//	2 = "memory-radixtree-beta"
 	//	3 = "ssd-redwood-experimental"
-	int storageEngineExcludeType = -1;
+	// Requires a comma-separated list of numbers WITHOUT whitespaces
+	std::vector<int> storageEngineExcludeTypes;
+	// Set the maximum TLog version that can be selected for a test
+	// Refer to FDBTypes.h::TLogVersion. Defaults to the maximum supported version.
+	int maxTLogVersion = TLogVersion::MAX_SUPPORTED;
 };
 
 struct TesterInterface {

--- a/fdbserver/tester.actor.cpp
+++ b/fdbserver/tester.actor.cpp
@@ -1057,8 +1057,10 @@ vector<TestSpec> readTests(ifstream& ifs) {
 			}
 			// else { } It is enable by default for tester
 			TraceEvent("TestParserTest").detail("ClientInfoLogging", value);
-		} else if (attrib == "storageEngineExcludeType") {
-			TraceEvent("TestParserTest").detail("ParsedStorageEngineExcludeType", "");
+		} else if (attrib == "storageEngineExcludeTypes") {
+			TraceEvent("TestParserTest").detail("ParsedStorageEngineExcludeTypes", "");
+		} else if (attrib == "maxTLogVersion") {
+			TraceEvent("TestParserTest").detail("ParsedMaxTLogVersion", "");
 		} else {
 			if (attrib == "testName") {
 				if (workloadOptions.size()) {

--- a/tests/fast/MoveKeysCycle.txt
+++ b/tests/fast/MoveKeysCycle.txt
@@ -19,4 +19,5 @@ testTitle=MoveKeysCycle
     reboot=true
     testDuration=10.0
 
-storageEngineExcludeType=-1
+storageEngineExcludeTypes=-1,-2
+maxTLogVersion=5


### PR DESCRIPTION
6.3 Port of https://github.com/apple/foundationdb/pull/4628. The changes are not a direct copy from the master branch because the test parsing code is slightly different on 6.3. Otherwise, the functions changed are the same. This change is required to support downgrade testing from 6.3 to 6.2.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [x] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [x] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [x] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
