### PR TITLE
Cherry pick #4515 into release-6.3: populate min_replicas_remaining fields in the cluster status for all regions.

### DIFF
--- a/fdbclient/DatabaseConfiguration.h
+++ b/fdbclient/DatabaseConfiguration.h
@@ -160,33 +160,44 @@ struct DatabaseConfiguration {
 	}
 
 	// Retuns the maximum number of discrete failures a cluster can tolerate.
-	// In HA mode, `fullyReplicatedRegions` is set to false initially when data is being
-	// replicated to remote, and will be true later. `forAvailablity` is set to true
+	// In HA mode, `fullyReplicatedRegions` is set to 1 initially when data is being
+	// replicated to remote, and will be incremented later. `forAvailablity` is set to true
 	// if we want to account the number for machines that can recruit new tLogs/SS after failures.
-	// Killing an entire datacenter counts as killing one zone in modes that support it
+	// Killing an entire datacenter counts as killing one zone in modes that support it.
 	int32_t maxZoneFailuresTolerated(int fullyReplicatedRegions, bool forAvailability) const {
-		int worstSatellite = regions.size() ? std::numeric_limits<int>::max() : 0;
+		int worstSatelliteTLogReplicationFactor = regions.size() ? std::numeric_limits<int>::max() : 0;
 		int regionsWithNonNegativePriority = 0;
 		for (auto& r : regions) {
 			if (r.priority >= 0) {
 				regionsWithNonNegativePriority++;
 			}
-			worstSatellite =
-			    std::min(worstSatellite, r.satelliteTLogReplicationFactor - r.satelliteTLogWriteAntiQuorum);
+			worstSatelliteTLogReplicationFactor = std::min(
+			    worstSatelliteTLogReplicationFactor, r.satelliteTLogReplicationFactor - r.satelliteTLogWriteAntiQuorum);
 			if (r.satelliteTLogUsableDcsFallback > 0) {
-				worstSatellite = std::min(
-				    worstSatellite, r.satelliteTLogReplicationFactorFallback - r.satelliteTLogWriteAntiQuorumFallback);
+				worstSatelliteTLogReplicationFactor =
+				    std::min(worstSatelliteTLogReplicationFactor,
+				             r.satelliteTLogReplicationFactorFallback - r.satelliteTLogWriteAntiQuorumFallback);
 			}
 		}
-		if (usableRegions > 1 && fullyReplicatedRegions > 1 && worstSatellite > 0 &&
-		    (!forAvailability || regionsWithNonNegativePriority > 1)) {
-			return 1 + std::min(std::max(tLogReplicationFactor - 1 - tLogWriteAntiQuorum, worstSatellite - 1),
-			                    storageTeamSize - 1);
-		} else if (worstSatellite > 0) {
-			// Primary and Satellite tLogs are synchronously replicated, hence we can lose all but 1.
-			return std::min(tLogReplicationFactor + worstSatellite - 1 - tLogWriteAntiQuorum, storageTeamSize - 1);
+
+		if (worstSatelliteTLogReplicationFactor <= 0) {
+			// HA is not enabled in this database. Return single cluster zone failures to tolerate.
+			return std::min(tLogReplicationFactor - 1 - tLogWriteAntiQuorum, storageTeamSize - 1);
 		}
-		return std::min(tLogReplicationFactor - 1 - tLogWriteAntiQuorum, storageTeamSize - 1);
+
+		// Compute HA enabled database zone failure tolerance.
+		auto isGeoReplicatedData = [this, &fullyReplicatedRegions]() {
+			return usableRegions > 1 && fullyReplicatedRegions > 1;
+		};
+
+		if (isGeoReplicatedData() && (!forAvailability || regionsWithNonNegativePriority > 1)) {
+			return 1 + std::min(std::max(tLogReplicationFactor - 1 - tLogWriteAntiQuorum,
+			                             worstSatelliteTLogReplicationFactor - 1),
+			                    storageTeamSize - 1);
+		}
+		// Primary and Satellite tLogs are synchronously replicated, hence we can lose all but 1.
+		return std::min(tLogReplicationFactor + worstSatelliteTLogReplicationFactor - 1 - tLogWriteAntiQuorum,
+		                storageTeamSize - 1);
 	}
 
 	// MasterProxy Servers

--- a/fdbserver/Status.actor.cpp
+++ b/fdbserver/Status.actor.cpp
@@ -1518,7 +1518,7 @@ static JsonBuilderObject configurationFetcher(Optional<DatabaseConfiguration> co
 
 ACTOR static Future<JsonBuilderObject> dataStatusFetcher(WorkerDetails ddWorker,
                                                          DatabaseConfiguration configuration,
-                                                         int* minReplicasRemaining) {
+                                                         int* minStorageReplicasRemaining) {
 	state JsonBuilderObject statusObjData;
 
 	try {
@@ -1581,9 +1581,9 @@ ACTOR static Future<JsonBuilderObject> dataStatusFetcher(WorkerDetails ddWorker,
 		}
 
 		JsonBuilderArray teamTrackers;
-		for (int i = 0; i < 2; i++) {
-			TraceEventFields inFlight = dataInfo[3 + i];
-			if (!inFlight.size()) {
+		for (int i = 3; i < 5; i++) {
+			const TraceEventFields& inFlight = dataInfo[i];
+			if (inFlight.size() == 0) {
 				continue;
 			}
 
@@ -1607,19 +1607,16 @@ ACTOR static Future<JsonBuilderObject> dataStatusFetcher(WorkerDetails ddWorker,
 				stateSectionObj["healthy"] = false;
 				stateSectionObj["name"] = "missing_data";
 				stateSectionObj["description"] = "No replicas remain of some data";
-				stateSectionObj["min_replicas_remaining"] = 0;
 				replicas = 0;
 			} else if (highestPriority >= SERVER_KNOBS->PRIORITY_TEAM_1_LEFT) {
 				stateSectionObj["healthy"] = false;
 				stateSectionObj["name"] = "healing";
 				stateSectionObj["description"] = "Only one replica remains of some data";
-				stateSectionObj["min_replicas_remaining"] = 1;
 				replicas = 1;
 			} else if (highestPriority >= SERVER_KNOBS->PRIORITY_TEAM_2_LEFT) {
 				stateSectionObj["healthy"] = false;
 				stateSectionObj["name"] = "healing";
 				stateSectionObj["description"] = "Only two replicas remain of some data";
-				stateSectionObj["min_replicas_remaining"] = 2;
 				replicas = 2;
 			} else if (highestPriority >= SERVER_KNOBS->PRIORITY_TEAM_UNHEALTHY) {
 				stateSectionObj["healthy"] = false;
@@ -1653,6 +1650,10 @@ ACTOR static Future<JsonBuilderObject> dataStatusFetcher(WorkerDetails ddWorker,
 				stateSectionObj["name"] = "healthy";
 			}
 
+			// Track the number of min replicas the storage servers in this region has. The sum of the replicas from
+			// both primary and remote region give the total number of data replicas this database currently has.
+			stateSectionObj["min_replicas_remaining"] = replicas;
+
 			if (!stateSectionObj.empty()) {
 				team_tracker["state"] = stateSectionObj;
 				teamTrackers.push_back(team_tracker);
@@ -1661,10 +1662,13 @@ ACTOR static Future<JsonBuilderObject> dataStatusFetcher(WorkerDetails ddWorker,
 				}
 			}
 
+			// Update minStorageReplicasRemaining. It is mainly used for fault tolerance computation later. Note that
+			// FDB treats the entire remote region as one zone, and all the zones in the remote region are in the same
+			// failure domain.
 			if (primary) {
-				*minReplicasRemaining = std::max(*minReplicasRemaining, 0) + replicas;
+				*minStorageReplicasRemaining = std::max(*minStorageReplicasRemaining, 0) + replicas;
 			} else if (replicas > 0) {
-				*minReplicasRemaining = std::max(*minReplicasRemaining, 0) + 1;
+				*minStorageReplicasRemaining = std::max(*minStorageReplicasRemaining, 0) + 1;
 			}
 		}
 		statusObjData["team_trackers"] = teamTrackers;
@@ -1743,7 +1747,7 @@ ACTOR static Future<vector<std::pair<MasterProxyInterface, EventMap>>> getProxie
 	return results;
 }
 
-// Returns the number of zones eligble for recruiting new tLogs after failures, to maintain the current replication
+// Returns the number of zones eligble for recruiting new tLogs after zone failures, to maintain the current replication
 // factor.
 static int getExtraTLogEligibleZones(const vector<WorkerDetails>& workers, const DatabaseConfiguration& configuration) {
 	std::set<StringRef> allZones;
@@ -1761,17 +1765,20 @@ static int getExtraTLogEligibleZones(const vector<WorkerDetails>& workers, const
 	if (configuration.regions.size() == 0) {
 		return allZones.size() - std::max(configuration.tLogReplicationFactor, configuration.storageTeamSize);
 	}
+
 	int extraTlogEligibleZones = 0;
 	int regionsWithNonNegativePriority = 0;
-	for (auto& region : configuration.regions) {
+	int maxRequiredReplicationFactor =
+	    std::max(configuration.remoteTLogReplicationFactor,
+	             std::max(configuration.tLogReplicationFactor, configuration.storageTeamSize));
+	for (const auto& region : configuration.regions) {
 		if (region.priority >= 0) {
-			int eligible = dcId_zone[region.dcId].size() -
-			               std::max(configuration.remoteTLogReplicationFactor,
-			                        std::max(configuration.tLogReplicationFactor, configuration.storageTeamSize));
+			int eligible = dcId_zone[region.dcId].size() - maxRequiredReplicationFactor;
+
 			// FIXME: does not take into account fallback satellite policies
 			if (region.satelliteTLogReplicationFactor > 0 && configuration.usableRegions > 1) {
 				int totalSatelliteEligible = 0;
-				for (auto& sat : region.satellites) {
+				for (const auto& sat : region.satellites) {
 					totalSatelliteEligible += dcId_zone[sat.dcId].size();
 				}
 				eligible = std::min<int>(eligible, totalSatelliteEligible - region.satelliteTLogReplicationFactor);
@@ -1783,6 +1790,8 @@ static int getExtraTLogEligibleZones(const vector<WorkerDetails>& workers, const
 		}
 	}
 	if (regionsWithNonNegativePriority > 1) {
+		// If the database is replicated across multiple regions, we can afford to lose one entire region without
+		// losing data.
 		extraTlogEligibleZones++;
 	}
 	return extraTlogEligibleZones;
@@ -2097,9 +2106,9 @@ static JsonBuilderObject tlogFetcher(int* logFaultTolerance,
 	int minFaultTolerance = 1000;
 	int localSetsWithNonNegativeFaultTolerance = 0;
 
-	for (int i = 0; i < tLogs.size(); i++) {
+	for (const auto& tLogSet : tLogs) {
 		int failedLogs = 0;
-		for (auto& log : tLogs[i].tLogs) {
+		for (auto& log : tLogSet.tLogs) {
 			JsonBuilderObject logObj;
 			bool failed = !log.present() || !address_workers.count(log.interf().address());
 			logObj["id"] = log.id().shortString();
@@ -2113,13 +2122,13 @@ static JsonBuilderObject tlogFetcher(int* logFaultTolerance,
 			}
 		}
 
-		if (tLogs[i].isLocal) {
-			int currentFaultTolerance = tLogs[i].tLogReplicationFactor - 1 - tLogs[i].tLogWriteAntiQuorum - failedLogs;
+		if (tLogSet.isLocal) {
+			int currentFaultTolerance = tLogSet.tLogReplicationFactor - 1 - tLogSet.tLogWriteAntiQuorum - failedLogs;
 			if (currentFaultTolerance >= 0) {
 				localSetsWithNonNegativeFaultTolerance++;
 			}
 
-			if (tLogs[i].locality == tagLocalitySatellite) {
+			if (tLogSet.locality == tagLocalitySatellite) {
 				// FIXME: This hack to bump satellite fault tolerance, is to make it consistent
 				//  with 6.2.
 				minFaultTolerance = std::min(minFaultTolerance, currentFaultTolerance + 1);
@@ -2128,17 +2137,17 @@ static JsonBuilderObject tlogFetcher(int* logFaultTolerance,
 			}
 		}
 
-		if (tLogs[i].isLocal && tLogs[i].locality == tagLocalitySatellite) {
-			sat_log_replication_factor = tLogs[i].tLogReplicationFactor;
-			sat_log_write_anti_quorum = tLogs[i].tLogWriteAntiQuorum;
-			sat_log_fault_tolerance = tLogs[i].tLogReplicationFactor - 1 - tLogs[i].tLogWriteAntiQuorum - failedLogs;
-		} else if (tLogs[i].isLocal) {
-			log_replication_factor = tLogs[i].tLogReplicationFactor;
-			log_write_anti_quorum = tLogs[i].tLogWriteAntiQuorum;
-			log_fault_tolerance = tLogs[i].tLogReplicationFactor - 1 - tLogs[i].tLogWriteAntiQuorum - failedLogs;
+		if (tLogSet.isLocal && tLogSet.locality == tagLocalitySatellite) {
+			sat_log_replication_factor = tLogSet.tLogReplicationFactor;
+			sat_log_write_anti_quorum = tLogSet.tLogWriteAntiQuorum;
+			sat_log_fault_tolerance = tLogSet.tLogReplicationFactor - 1 - tLogSet.tLogWriteAntiQuorum - failedLogs;
+		} else if (tLogSet.isLocal) {
+			log_replication_factor = tLogSet.tLogReplicationFactor;
+			log_write_anti_quorum = tLogSet.tLogWriteAntiQuorum;
+			log_fault_tolerance = tLogSet.tLogReplicationFactor - 1 - tLogSet.tLogWriteAntiQuorum - failedLogs;
 		} else {
-			remote_log_replication_factor = tLogs[i].tLogReplicationFactor;
-			remote_log_fault_tolerance = tLogs[i].tLogReplicationFactor - 1 - failedLogs;
+			remote_log_replication_factor = tLogSet.tLogReplicationFactor;
+			remote_log_fault_tolerance = tLogSet.tLogReplicationFactor - 1 - failedLogs;
 		}
 	}
 	if (minFaultTolerance == 1000) {
@@ -2181,6 +2190,8 @@ static JsonBuilderArray tlogFetcher(int* logFaultTolerance,
                                     std::unordered_map<NetworkAddress, WorkerInterface> const& address_workers) {
 	JsonBuilderArray tlogsArray;
 	JsonBuilderObject tlogsStatus;
+
+	// First, fetch from the current TLog generation.
 	tlogsStatus = tlogFetcher(logFaultTolerance, db->get().logSystemConfig.tLogs, address_workers);
 	tlogsStatus["epoch"] = db->get().logSystemConfig.epoch;
 	tlogsStatus["current"] = true;
@@ -2188,6 +2199,8 @@ static JsonBuilderArray tlogFetcher(int* logFaultTolerance,
 		tlogsStatus["begin_version"] = db->get().logSystemConfig.recoveredAt.get();
 	}
 	tlogsArray.push_back(tlogsStatus);
+
+	// fetch all the old generations of TLogs.
 	for (auto it : db->get().logSystemConfig.oldTLogs) {
 		JsonBuilderObject oldTlogsStatus = tlogFetcher(logFaultTolerance, it.tLogs, address_workers);
 		oldTlogsStatus["epoch"] = it.epoch;
@@ -2203,7 +2216,7 @@ static JsonBuilderObject faultToleranceStatusFetcher(DatabaseConfiguration confi
                                                      ServerCoordinators coordinators,
                                                      std::vector<WorkerDetails>& workers,
                                                      int extraTlogEligibleZones,
-                                                     int minReplicasRemaining,
+                                                     int minStorageReplicasRemaining,
                                                      int oldLogFaultTolerance,
                                                      int fullyReplicatedRegions,
                                                      bool underMaintenance) {
@@ -2243,8 +2256,8 @@ static JsonBuilderObject faultToleranceStatusFetcher(DatabaseConfiguration confi
 	// max zone failures that we can tolerate to not lose data
 	int zoneFailuresWithoutLosingData = std::min(maxZoneFailures, maxCoordinatorZoneFailures);
 
-	if (minReplicasRemaining >= 0) {
-		zoneFailuresWithoutLosingData = std::min(zoneFailuresWithoutLosingData, minReplicasRemaining - 1);
+	if (minStorageReplicasRemaining >= 0) {
+		zoneFailuresWithoutLosingData = std::min(zoneFailuresWithoutLosingData, minStorageReplicasRemaining - 1);
 	}
 
 	// oldLogFaultTolerance means max failures we can tolerate to lose logs data. -1 means we lose data or availability.
@@ -2491,10 +2504,9 @@ ACTOR Future<StatusReply> clusterGetStatus(
     Version datacenterVersionDifference) {
 	state double tStart = timer();
 
-	// Check if master worker is present
 	state JsonBuilderArray messages;
 	state std::set<std::string> status_incomplete_reasons;
-	state WorkerDetails mWorker;
+	state WorkerDetails mWorker; // Master worker
 	state WorkerDetails ddWorker; // DataDistributor worker
 	state WorkerDetails rkWorker; // Ratekeeper worker
 
@@ -2507,6 +2519,7 @@ ACTOR Future<StatusReply> clusterGetStatus(
 			messages.push_back(
 			    JsonString::makeMessage("unreachable_master_worker", "Unable to locate the master worker."));
 		}
+
 		// Get the DataDistributor worker interface
 		Optional<WorkerDetails> _ddWorker;
 		if (db->get().distributor.present()) {
@@ -2535,12 +2548,12 @@ ACTOR Future<StatusReply> clusterGetStatus(
 
 		// Get latest events for various event types from ALL workers
 		// WorkerEvents is a map of worker's NetworkAddress to its event string
-		// The pair represents worker responses and a set of worker NetworkAddress strings which did not respond
+		// The pair represents worker responses and a set of worker NetworkAddress strings which did not respond.
 		std::vector<Future<Optional<std::pair<WorkerEvents, std::set<std::string>>>>> futures;
 		futures.push_back(latestEventOnWorkers(workers, "MachineMetrics"));
 		futures.push_back(latestEventOnWorkers(workers, "ProcessMetrics"));
 		futures.push_back(latestEventOnWorkers(workers, "NetworkMetrics"));
-		futures.push_back(latestErrorOnWorkers(workers));
+		futures.push_back(latestErrorOnWorkers(workers)); // Get all latest errors.
 		futures.push_back(latestEventOnWorkers(workers, "TraceFileOpenError"));
 		futures.push_back(latestEventOnWorkers(workers, "ProgramStart"));
 
@@ -2555,13 +2568,13 @@ ACTOR Future<StatusReply> clusterGetStatus(
 
 		// For each (optional) pair, if the pair is present and not empty then add the unreachable workers to the set.
 		for (auto pair : workerEventsVec) {
-			if (pair.present() && pair.get().second.size())
+			if (pair.present() && !pair.get().second.empty())
 				mergeUnreachable.insert(pair.get().second.begin(), pair.get().second.end());
 		}
 
 		// We now have a unique set of workers who were in some way unreachable.  If there is anything in that set,
 		// create a message for it and include the list of unreachable processes.
-		if (mergeUnreachable.size()) {
+		if (!mergeUnreachable.empty()) {
 			JsonBuilderObject message =
 			    JsonBuilder::makeMessage("unreachable_processes", "The cluster has some unreachable processes.");
 			JsonBuilderArray unreachableProcs;
@@ -2669,11 +2682,11 @@ ACTOR Future<StatusReply> clusterGetStatus(
 			state Future<ErrorOr<vector<std::pair<MasterProxyInterface, EventMap>>>> proxyFuture =
 			    errorOr(getProxiesAndMetrics(db, address_workers));
 
-			state int minReplicasRemaining = -1;
+			state int minStorageReplicasRemaining = -1;
 			state int fullyReplicatedRegions = -1;
 			state Future<Optional<Value>> primaryDCFO = getActivePrimaryDC(cx, &fullyReplicatedRegions, &messages);
 			std::vector<Future<JsonBuilderObject>> futures2;
-			futures2.push_back(dataStatusFetcher(ddWorker, configuration.get(), &minReplicasRemaining));
+			futures2.push_back(dataStatusFetcher(ddWorker, configuration.get(), &minStorageReplicasRemaining));
 			futures2.push_back(workloadStatusFetcher(
 			    db, workers, mWorker, rkWorker, &qos, &data_overlay, &status_incomplete_reasons, storageServerFuture));
 			futures2.push_back(layerStatusFetcher(cx, &messages, &status_incomplete_reasons));
@@ -2688,18 +2701,16 @@ ACTOR Future<StatusReply> clusterGetStatus(
 				statusObj["logs"] = tlogFetcher(&logFaultTolerance, db, address_workers);
 			}
 
-			if (configuration.present()) {
-				int extraTlogEligibleZones = getExtraTLogEligibleZones(workers, configuration.get());
-				statusObj["fault_tolerance"] =
-				    faultToleranceStatusFetcher(configuration.get(),
-				                                coordinators,
-				                                workers,
-				                                extraTlogEligibleZones,
-				                                minReplicasRemaining,
-				                                logFaultTolerance,
-				                                fullyReplicatedRegions,
-				                                loadResult.present() && loadResult.get().healthyZone.present());
-			}
+			int extraTlogEligibleZones = getExtraTLogEligibleZones(workers, configuration.get());
+			statusObj["fault_tolerance"] =
+			    faultToleranceStatusFetcher(configuration.get(),
+			                                coordinators,
+			                                workers,
+			                                extraTlogEligibleZones,
+			                                minStorageReplicasRemaining,
+			                                logFaultTolerance,
+			                                fullyReplicatedRegions,
+			                                loadResult.present() && loadResult.get().healthyZone.present());
 
 			state JsonBuilderObject configObj =
 			    configurationFetcher(configuration, coordinators, &status_incomplete_reasons);


### PR DESCRIPTION
We need to cherry pick #4515 (which updates fault tolerance field) in release-6.3, and included in release 6.3.12.

No failures in 100K joshua test

20210408-205825-zhewu_4634-9a0a693c1c282e38        compressed=True data_size=20343759 duration=5205258 ended=107372 fail_fast=10 max_runs=100000 pass=100002 priority=100 remaining=0 runtime=0:26:18 sanity=False started=107714 stopped=20210408-212443 submitted=20210408-205825 timeout=5400 username=zhewu_4634

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
