### PR TITLE
Revert PR#4630 and PR#4536 on release-6.3

### DIFF
--- a/documentation/sphinx/source/release-notes/release-notes-630.rst
+++ b/documentation/sphinx/source/release-notes/release-notes-630.rst
@@ -9,7 +9,6 @@ Release Notes
 * Change the default for --knob_tls_server_handshake_threads to 64. The previous was 1000. This avoids starting 1000 threads by default, but may adversely affect recovery time for large clusters using tls. Users with large tls clusters should consider explicitly setting this knob in their foundationdb.conf file. `(PR #4421) <https://github.com/apple/foundationdb/pull/4421>`_
 * Fix accounting error that could cause commits to incorrectly fail with ``proxy_memory_limit_exceeded``. `(PR #4526) <https://github.com/apple/foundationdb/pull/4526>`_
 * As an optimization, partial restore using target key ranges now filters backup log data prior to loading it into the database.  `(PR #4554) <https://github.com/apple/foundationdb/pull/4554>`_
-* Fix fault tolerance calculation when there are no tLogs in LogSet.  `(PR #4454) <https://github.com/apple/foundationdb/pull/4454>`_  
 
 6.3.11
 ======

--- a/fdbclient/FileBackupAgent.actor.cpp
+++ b/fdbclient/FileBackupAgent.actor.cpp
@@ -4047,10 +4047,8 @@ struct StartFullRestoreTaskFunc : RestoreTaskFuncBase {
 		for (const RangeFile& f : restorable.get().ranges) {
 			files.push_back({ f.version, f.fileName, true, f.blockSize, f.fileSize });
 		}
-		if (!CLIENT_KNOBS->RESTORE_IGNORE_LOG_FILES) {
-			for (const LogFile& f : restorable.get().logs) {
-				files.push_back({ f.beginVersion, f.fileName, false, f.blockSize, f.fileSize, f.endVersion });
-			}
+		for (const LogFile& f : restorable.get().logs) {
+			files.push_back({ f.beginVersion, f.fileName, false, f.blockSize, f.fileSize, f.endVersion });
 		}
 
 		state std::vector<RestoreConfig::RestoreFile>::iterator start = files.begin();

--- a/fdbclient/Knobs.cpp
+++ b/fdbclient/Knobs.cpp
@@ -164,7 +164,6 @@ void ClientKnobs::initialize(bool randomize) {
 	init( BACKUP_STATUS_DELAY,                    40.0 );
 	init( BACKUP_STATUS_JITTER,                   0.05 );
 	init( MIN_CLEANUP_SECONDS,                  3600.0 );
-	init( RESTORE_IGNORE_LOG_FILES,              false );
 
 	// Configuration
 	init( DEFAULT_AUTO_PROXIES,                      3 );

--- a/fdbclient/Knobs.h
+++ b/fdbclient/Knobs.h
@@ -160,7 +160,6 @@ public:
 	double BACKUP_STATUS_DELAY;
 	double BACKUP_STATUS_JITTER;
 	double MIN_CLEANUP_SECONDS;
-	bool RESTORE_IGNORE_LOG_FILES;   // Default is false. When set to true, the log files will be ignored during the restore, which can produce inconsistent restored data.
 
 	// Configuration
 	int32_t DEFAULT_AUTO_PROXIES;

--- a/fdbserver/Status.actor.cpp
+++ b/fdbserver/Status.actor.cpp
@@ -2107,13 +2107,6 @@ static JsonBuilderObject tlogFetcher(int* logFaultTolerance,
 	int localSetsWithNonNegativeFaultTolerance = 0;
 
 	for (const auto& tLogSet : tLogs) {
-		if (tLogSet.tLogs.size() == 0) {
-			// We can have LogSets where there are no tLogs but some LogRouters. It's the way
-			// recruiting is implemented for old LogRouters in TagPartitionedLogSystem, where
-			// it adds an empty LogSet for missing locality.
-			continue;
-		}
-
 		int failedLogs = 0;
 		for (auto& log : tLogSet.tLogs) {
 			JsonBuilderObject logObj;
@@ -2130,7 +2123,6 @@ static JsonBuilderObject tlogFetcher(int* logFaultTolerance,
 		}
 
 		if (tLogSet.isLocal) {
-			ASSERT_WE_THINK(tLogSet.tLogReplicationFactor > 0);
 			int currentFaultTolerance = tLogSet.tLogReplicationFactor - 1 - tLogSet.tLogWriteAntiQuorum - failedLogs;
 			if (currentFaultTolerance >= 0) {
 				localSetsWithNonNegativeFaultTolerance++;


### PR DESCRIPTION
After these two PRs were merged last Friday, correctness showed new failures in *Status related tests. 
Example: rare/LargeApiCorrectnessStatus.txt,  buggify=on, random seed=937634288. 

Reverted PRs:
PR#4630
PR#4536

After reverting these two PRs, correctness only found timeout in `BackupCorrectnessClean.txt` and longer latency in`LowLatency.txt` tests.  

Correctness results after reverting both PRs:
  20210411-023744-mengxu6312revert4536and4630-ebdb6138e4e51117 compressed=True data_size=21126684 duration=22733959 ended=408169 fail=5 fail_fast=5 max_runs=400000 pass=398177 priority=100 remaining=0 runtime=0:56:31 sanity=False started=408486 stopped=20210411-033415 submitted=20210411-023744 timeout=5400 username=mengxu6312revert4536and4630


# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
