### PR TITLE
Some cleanup of fdb_c_version.py

### DIFF
--- a/contrib/monitoring/fdb_c_version.py
+++ b/contrib/monitoring/fdb_c_version.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # fdb_c_version.py
 #
@@ -30,9 +30,9 @@ def error(message):
 
 def get_version_string(library_path):
     try:
-        lib = ctypes.cdll.LoadLibrary(os.path.abspath(library_path))
+        lib = ctypes.cdll.LoadLibrary(library_path)
     except Exception as e:
-        error('Could not load library %r: %s' % (library_path, e.message))
+        error('Could not load library %r: %s' % (library_path, str(e)))
 
     lib.fdb_get_error.restype = ctypes.c_char_p
 
@@ -41,13 +41,13 @@ def get_version_string(library_path):
         if r != 0:
             error('Error setting API version: %s (%d)' % (lib.fdb_get_error(r), r))
     except Exception as e:
-        error('Error calling fdb_select_api_version_impl: %s' % e.message)
+        error('Error calling fdb_select_api_version_impl: %s' % str(e))
 
     try:
         lib.fdb_get_client_version.restype = ctypes.c_char_p
-        version_str = lib.fdb_get_client_version()
+        version_str = lib.fdb_get_client_version().decode('utf-8')
     except Exception as e:
-        error('Error getting version information from client library: %s' % e.message)
+        error('Error getting version information from client library: %s' % str(e))
 
     version_components = version_str.split(',')
     package_version = '.'.join(version_components[0].split('.')[0:2])


### PR DESCRIPTION
These are some changes to fix issues with the recently added fdb_c_version.py.

* Support Python 3 and make it the default
* Use `str(e)` instead of `e.message` to print errors (some errors don't have a `message` field.
* Don't convert `library_path` to an absolute path so that we can load the system fdb_c.

I tested each of these cases manually. This should have no impact on other code.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

