### PR TITLE
Fix line length of test macro + comments to be within the 120 character limit

### DIFF
--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -2478,6 +2478,7 @@ ACTOR Future<Version> watchValue(Future<Version> version,
 				wait(delay(CLIENT_KNOBS->WRONG_SHARD_SERVER_DELAY, info.taskID));
 			} else if (e.code() == error_code_watch_cancelled || e.code() == error_code_process_behind) {
 				TEST(e.code() == error_code_watch_cancelled); // Too many watches on the storage server, poll for changes instead
+				TEST(e.code() == error_code_watch_cancelled); // Too many watches on storage server, poll for changes
 				TEST(e.code() == error_code_process_behind); // The storage servers are all behind
 				wait(delay(CLIENT_KNOBS->WATCH_POLLING_TIME, info.taskID));
 			} else if (e.code() == error_code_timed_out) { // The storage server occasionally times out watches in case

--- a/fdbserver/CommitProxyServer.actor.cpp
+++ b/fdbserver/CommitProxyServer.actor.cpp
@@ -1062,7 +1062,8 @@ ACTOR Future<Void> postResolution(CommitBatchContext* self) {
 	state const Optional<UID>& debugID = self->debugID;
 	state Span span("MP:postResolution"_loc, self->span.context);
 
-	TEST(pProxyCommitData->latestLocalCommitBatchLogging.get() < localBatchNumber - 1); // Queuing post-resolution commit processing
+	bool queuedCommits = pProxyCommitData->latestLocalCommitBatchLogging.get() < localBatchNumber - 1;
+	TEST(queuedCommits); // Queuing post-resolution commit processing
 	wait(pProxyCommitData->latestLocalCommitBatchLogging.whenAtLeast(localBatchNumber - 1));
 	wait(yield(TaskPriority::ProxyCommitYield1));
 

--- a/fdbserver/DiskQueue.actor.cpp
+++ b/fdbserver/DiskQueue.actor.cpp
@@ -884,7 +884,9 @@ public:
 		uint8_t const* begin = contents.begin();
 		uint8_t const* end = contents.end();
 		TEST(contents.size() && pushedPageCount()); // More than one push between commits
-		TEST(contents.size() >= 4 && pushedPageCount() && backPage().remainingCapacity() < 4); // Push right at the end of a page, possibly splitting size
+
+		bool pushAtEndOfPage = contents.size() >= 4 && pushedPageCount() && backPage().remainingCapacity() < 4;
+		TEST(pushAtEndOfPage); // Push right at the end of a page, possibly splitting size
 		while (begin != end) {
 			if (!pushedPageCount() || !backPage().remainingCapacity())
 				addEmptyPage();
@@ -1363,7 +1365,8 @@ private:
 		// The fully durable popped point is self->lastPoppedSeq; tell the raw queue that.
 		int f;
 		int64_t p;
-		TEST(self->lastPoppedSeq / sizeof(Page) != self->poppedSeq / sizeof(Page)); // DiskQueue: Recovery popped position not fully durable
+		bool poppedNotDurable = self->lastPoppedSeq / sizeof(Page) != self->poppedSeq / sizeof(Page);
+		TEST(poppedNotDurable); // DiskQueue: Recovery popped position not fully durable
 		self->findPhysicalLocation(self->lastPoppedSeq, &f, &p, "lastPoppedSeq");
 		wait(self->rawQueue->setPoppedPage(f, p, pageFloor(self->lastPoppedSeq)));
 

--- a/fdbserver/Ratekeeper.actor.cpp
+++ b/fdbserver/Ratekeeper.actor.cpp
@@ -1496,7 +1496,8 @@ ACTOR Future<Void> ratekeeper(RatekeeperInterface rkInterf, Reference<AsyncVar<S
 					p.lastTagPushTime = now();
 
 					reply.throttledTags = self.throttledTags.getClientRates(self.autoThrottlingEnabled);
-					TEST(reply.throttledTags.present() && reply.throttledTags.get().size() > 0); // Returning tag throttles to a proxy
+					bool returningTagsToProxy = reply.throttledTags.present() && reply.throttledTags.get().size() > 0;
+					TEST(returningTagsToProxy); // Returning tag throttles to a proxy
 				}
 
 				reply.healthMetrics.update(self.healthMetrics, true, req.detailed);

--- a/fdbserver/masterserver.actor.cpp
+++ b/fdbserver/masterserver.actor.cpp
@@ -1110,7 +1110,6 @@ ACTOR Future<Void> getVersion(Reference<MasterData> self, GetCommitVersionReques
 		req.reply.send(itr->second);
 	} else if (req.requestNum <= proxyItr->second.latestRequestNum.get()) {
 		TEST(true); // Old request for previously acknowledged sequence - may be impossible with current FlowTransport
-		            // implementation
 		ASSERT(req.requestNum <
 		       proxyItr->second.latestRequestNum.get()); // The latest request can never be acknowledged
 		req.reply.send(Never());
@@ -1133,8 +1132,9 @@ ACTOR Future<Void> getVersion(Reference<MasterData> self, GetCommitVersionReques
 			                                        SERVER_KNOBS->VERSIONS_PER_SECOND * (t1 - self->lastVersionTime)));
 
 			TEST(self->version - rep.prevVersion == 1); // Minimum possible version gap
-			TEST(self->version - rep.prevVersion ==
-			     SERVER_KNOBS->MAX_READ_TRANSACTION_LIFE_VERSIONS); // Maximum possible version gap
+
+			bool maxVersionGap = self->version - rep.prevVersion == SERVER_KNOBS->MAX_READ_TRANSACTION_LIFE_VERSIONS;
+			TEST(maxVersionGap); // Maximum possible version gap
 			self->lastVersionTime = t1;
 
 			if (self->resolverNeedingChanges.count(req.requestingProxy)) {
@@ -1998,11 +1998,11 @@ ACTOR Future<Void> masterServer(MasterInterface mi,
 			self->addActor.getFuture().pop();
 		}
 
-		TEST(err.code() == error_code_master_tlog_failed); // Master: terminated because of a tLog failure
-		TEST(err.code() == error_code_commit_proxy_failed); // Master: terminated because of a commit proxy failure
-		TEST(err.code() == error_code_grv_proxy_failed); // Master: terminated because of a GRV proxy failure
-		TEST(err.code() == error_code_master_resolver_failed); // Master: terminated because of a resolver failure
-		TEST(err.code() == error_code_master_backup_worker_failed); // Master: terminated because of a backup worker failure
+		TEST(err.code() == error_code_master_tlog_failed); // Master: terminated due to tLog failure
+		TEST(err.code() == error_code_commit_proxy_failed); // Master: terminated due to commit proxy failure
+		TEST(err.code() == error_code_grv_proxy_failed); // Master: terminated due to GRV proxy failure
+		TEST(err.code() == error_code_master_resolver_failed); // Master: terminated due to resolver failure
+		TEST(err.code() == error_code_master_backup_worker_failed); // Master: terminated due to backup worker failure
 
 		if (normalMasterErrors().count(err.code())) {
 			TraceEvent("MasterTerminated", mi.id()).error(err);


### PR DESCRIPTION
The code coverage tool requires a comment to exist on the same line as the associated `TEST` macro. As a result, we had some cases where the line length exceeded the desired 120 characters. Leaving these lines too long makes things complicated for anybody using tools that automatically format their files, as these lines have to be repeatedly fixed.

This change updates the macros to reduce the comment length and/or extract the `TEST` condition to a separate variable.

Because this is mostly a formatting change, I did not seek to understand what was going on in the affected functions and therefore I did not add any documentation to those functions.

This passed 10K correctness tests. Because it doesn't change logic at all, I haven't run more than that.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [x] Every function/class/actor that was touched is reasonably well documented.