### PR TITLE
docker: Load custom `bashrc` if available

### DIFF
--- a/build/docker/centos6/devel/Dockerfile
+++ b/build/docker/centos6/devel/Dockerfile
@@ -76,4 +76,9 @@ RUN rm -f /root/anaconda-ks.cfg && \
     '   j start --tarball $(find ${HOME}/build_output/packages -name correctness\*.tar.gz) "${@}"' \
     '}' \
     '' \
+    'USER_BASHRC="$HOME/src/.bashrc.local"' \
+    'if test -f "$USER_BASHRC"; then' \
+    '   source $USER_BASHRC' \
+    'fi' \
+    '' \
     >> .bashrc

--- a/build/docker/centos7/devel/Dockerfile
+++ b/build/docker/centos7/devel/Dockerfile
@@ -104,5 +104,10 @@ RUN rm -f /root/anaconda-ks.cfg && \
     '   j start --tarball $(find ${HOME}/build_output/packages -name correctness\*.tar.gz) "${@}"' \
     '}' \
     '' \
+    'USER_BASHRC="$HOME/src/.bashrc.local"' \
+    'if test -f "$USER_BASHRC"; then' \
+    '   source $USER_BASHRC' \
+    'fi' \
+    '' \
     'bash ${HOME}/docker_proxy.sh' \
     >> .bashrc


### PR DESCRIPTION
This will check if there is a `.bashrc.local` available in the synced directory,
and load it.

- This is useful so that any changes users make to `bashrc` in Okteto containers
doesn't get lost between re-deployement of containers.
- Can also used to automate setting up environment, e.g. copy various dotfiles
etc from the synced directory to $HOME folder during first run.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [X] The PR has a description, explaining both the problem and the solution.
- [X] The description mentions which forms of testing were done and the testing seems reasonable.
- [X] Every function/class/actor that was touched is reasonably well documented.
