### PR TITLE
Fix multiple (inline) definitions of canReplyWith

### DIFF
--- a/fdbserver/StorageCache.actor.cpp
+++ b/fdbserver/StorageCache.actor.cpp
@@ -43,7 +43,7 @@
 // Need to look into refactoring common code out for better code readability and to avoid duplication
 
 // TODO rename wrong_shard_server error to wrong_cache_server
-inline bool canReplyWith(Error e) {
+static inline bool canReplyWith(Error e) {
 	switch (e.code()) {
 	case error_code_transaction_too_old:
 	case error_code_future_version:

--- a/fdbserver/StorageCache.actor.cpp
+++ b/fdbserver/StorageCache.actor.cpp
@@ -42,8 +42,9 @@
 // TODO storageCache server shares quite a bit of storageServer functionality, although simplified
 // Need to look into refactoring common code out for better code readability and to avoid duplication
 
+namespace {
 // TODO rename wrong_shard_server error to wrong_cache_server
-static inline bool canReplyWith(Error e) {
+bool canReplyWith(Error e) {
 	switch (e.code()) {
 	case error_code_transaction_too_old:
 	case error_code_future_version:
@@ -56,6 +57,8 @@ static inline bool canReplyWith(Error e) {
 		return false;
 	};
 }
+} // namespace
+
 class StorageCacheUpdater;
 
 struct AddingCacheRange : NonCopyable {

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -72,7 +72,7 @@
 
 #define SHORT_CIRCUT_ACTUAL_STORAGE 0
 
-inline bool canReplyWith(Error e) {
+static inline bool canReplyWith(Error e) {
 	switch (e.code()) {
 	case error_code_transaction_too_old:
 	case error_code_future_version:

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -72,7 +72,8 @@
 
 #define SHORT_CIRCUT_ACTUAL_STORAGE 0
 
-static inline bool canReplyWith(Error e) {
+namespace {
+bool canReplyWith(Error e) {
 	switch (e.code()) {
 	case error_code_transaction_too_old:
 	case error_code_future_version:
@@ -85,6 +86,7 @@ static inline bool canReplyWith(Error e) {
 		return false;
 	};
 }
+} // namespace
 
 struct AddingShard : NonCopyable {
 	KeyRange keys;


### PR DESCRIPTION
canReplyWith was declared inline in two translation units with different
definitions. When building with clang, this resulted in
storageserver.actor.cpp using the definition from
StorageCache.actor.cpp. Fix that by giving both symbols internal
linkage.

For testing, I observed that `canReplyWith(watch_cancelled())` called in storageserver.actor.cpp returned false before my change and true after. I will follow up with the results of 10k simulation runs.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
