### PR TITLE
Remove get_server_protocol from the Python bindings

### DIFF
--- a/bindings/c/test/unit/unit_tests.cpp
+++ b/bindings/c/test/unit/unit_tests.cpp
@@ -1513,7 +1513,7 @@ TEST_CASE("fdb_transaction_get_approximate_size") {
 	}
 }
 
-TEST_CASE("fdb_get_server_protocol") {
+TEST_CASE("fdb_database_get_server_protocol") {
 	// We don't really have any expectations other than "don't crash" here
 	FDBFuture* protocolFuture = fdb_database_get_server_protocol(db, 0);
 	uint64_t out;

--- a/bindings/python/fdb/__init__.py
+++ b/bindings/python/fdb/__init__.py
@@ -95,7 +95,6 @@ def api_version(ver):
         'transactional',
         'options',
         'StreamingMode',
-        'get_server_protocol'
     )
 
     _add_symbols(fdb.impl, list)

--- a/bindings/python/fdb/impl.py
+++ b/bindings/python/fdb/impl.py
@@ -1531,9 +1531,6 @@ def init_c_api():
     _capi.fdb_transaction_get_approximate_size.argtypes = [ctypes.c_void_p]
     _capi.fdb_transaction_get_approximate_size.restype = ctypes.c_void_p
 
-    _capi.fdb_get_server_protocol.argtypes = [ctypes.c_char_p]
-    _capi.fdb_get_server_protocol.restype = ctypes.c_void_p
-
     _capi.fdb_transaction_get_versionstamp.argtypes = [ctypes.c_void_p]
     _capi.fdb_transaction_get_versionstamp.restype = ctypes.c_void_p
 
@@ -1732,13 +1729,6 @@ def init_v13(local_address, event_model=None):
 open_databases = {}
 
 cacheLock = threading.Lock()
-
-def get_server_protocol(clusterFilePath=None):
-    with _network_thread_reentrant_lock:
-        if not _network_thread:
-            init()
-
-    return FutureUInt64(_capi.fdb_get_server_protocol(optionalParamToBytes(clusterFilePath)[0]))
 
 def open(cluster_file=None, event_model=None):
     """Opens the given database (or the default database of the cluster indicated


### PR DESCRIPTION
This function was moved and changed in the C API as part of #4662, so it no longer functions correctly in the Python bindings. The implementation of these in the bindings is incomplete (no documentation or testing, Python only), so rather than complete them now I'm removing it and deferring that task to later if we decide we want it.

This also renames a unit test for accuracy.

This passed 10K binding tester runs.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.
