### PR TITLE
Add Resolver role to unit test

### DIFF
--- a/fdbserver/CMakeLists.txt
+++ b/fdbserver/CMakeLists.txt
@@ -116,6 +116,7 @@ set(FDBSERVER_SRCS
   ptxn/test/Driver.h
   ptxn/test/FakeProxy.actor.cpp
   ptxn/test/FakeProxy.actor.h
+  ptxn/test/FakeResolver.actor.h
   ptxn/test/FakeStorageServer.actor.cpp
   ptxn/test/FakeStorageServer.actor.h
   ptxn/test/FakeTLog.actor.cpp

--- a/fdbserver/masterserver.actor.cpp
+++ b/fdbserver/masterserver.actor.cpp
@@ -770,6 +770,9 @@ ACTOR Future<Void> updateLocalityForDcId(Optional<Key> dcId,
 	}
 }
 
+// Recovers transaction state store (TSS) and then sets critical metadata such
+// as recoveryTransactionVersion, database configuration, storage tags, and
+// localities.
 ACTOR Future<Void> readTransactionSystemState(Reference<MasterData> self,
                                               Reference<ILogSystem> oldLogSystem,
                                               Version txsPoppedVersion) {
@@ -1009,6 +1012,10 @@ void updateConfigForForcedRecovery(Reference<MasterData> self,
 	initialConfChanges->push_back(regionCommit);
 }
 
+// Recovers transaction system states from old log system and then waits for
+// either 1) successful recruitment; or 2) if recovery stalls for >1s, a
+// provisional master receives an "emergency transaction" from fdbcli for a new
+// recruitment with different database configurations.
 ACTOR Future<Void> recoverFrom(Reference<MasterData> self,
                                Reference<ILogSystem> oldLogSystem,
                                vector<StorageServerInterface>* seedServers,

--- a/fdbserver/ptxn/test/Driver.h
+++ b/fdbserver/ptxn/test/Driver.h
@@ -30,6 +30,7 @@
 #include "fdbserver/ptxn/Config.h"
 #include "fdbserver/ptxn/StorageServerInterface.h"
 #include "fdbserver/ptxn/TLogInterface.h"
+#include "fdbserver/ResolverInterface.h"
 
 namespace ptxn {
 
@@ -59,6 +60,10 @@ struct TestDriverContext {
 
 	// Proxies
 	int numProxies;
+
+	// Resolvers
+	int numResolvers;
+	std::vector<std::shared_ptr<ResolverInterface>> resolverInterfaces;
 
 	// TLog
 	int numTLogs;

--- a/fdbserver/ptxn/test/FakeResolver.actor.h
+++ b/fdbserver/ptxn/test/FakeResolver.actor.h
@@ -1,0 +1,41 @@
+/*
+ * FakeResolver.actor.h
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#if defined(NO_INTELLISENSE) && !defined(FDBSERVER_PTXN_TEST_FAKERESOLVER_ACTOR_G_H)
+#define FDBSERVER_PTXN_TEST_FAKERESOLVER_ACTOR_G_H
+#include "fdbserver/ptxn/test/FakeResolver.actor.g.h"
+#elif !defined(FDBSERVER_PTXN_TEST_FAKERESOLVER_ACTOR_H)
+#define FDBSERVER_PTXN_TEST_FAKERESOLVER_ACTOR_H
+
+
+#include "fdbclient/FDBTypes.h"
+#include "fdbserver/ResolverInterface.h"
+#include "fdbserver/WorkerInterface.actor.h"
+#include "flow/flow.h"
+
+#include "flow/actorcompiler.h" // has to be last include
+
+#pragma once
+
+// This is defined Resolver.actor.cpp
+ACTOR Future<Void> resolverCore(ResolverInterface resolver, InitializeResolverRequest initReq);
+
+#include "flow/unactorcompiler.h"
+#endif // FDBSERVER_PTXN_TEST_FAKERESOLVER_ACTOR_H

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -263,6 +263,7 @@ if(WITH_PYTHON)
 
   # Tests for partitioned transaction
   add_fdb_test(TEST_FILES ptxn/Driver.toml)
+  add_fdb_test(TEST_FILES ptxn/Resolver.toml)
   add_fdb_test(TEST_FILES ptxn/Serialization.toml)
 
   verify_testing()

--- a/tests/ptxn/Resolver.toml
+++ b/tests/ptxn/Resolver.toml
@@ -1,0 +1,9 @@
+[[test]]
+testTitle = 'Resolver Test'
+useDB = false
+startDelay = 0
+
+    [[test.workload]]
+    testName = 'UnitTests'
+    maxTestCases = 1
+    testsMatching = 'fdbserver/ptxn/test/resolver'


### PR DESCRIPTION
Fake a resolver in the unit test for testing. I manually ran the new unit test and it works.

The CI failure is not related restart test failures.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
