### PR TITLE
Restore target range handling bug fixes

### DIFF
--- a/fdbclient/FileBackupAgent.actor.cpp
+++ b/fdbclient/FileBackupAgent.actor.cpp
@@ -5237,6 +5237,11 @@ public:
 	                                     bool incrementalBackupOnly,
 	                                     Version beginVersion,
 	                                     UID randomUid) {
+		// The restore command line tool won't allow ranges to be empty, but correctness workloads somehow might.
+		if (ranges.empty()) {
+			throw restore_error();
+		}
+
 		state Reference<IBackupContainer> bc = IBackupContainer::openContainer(url.toString());
 
 		state BackupDescription desc = wait(bc->describeBackup(true));

--- a/fdbclient/FileBackupAgent.actor.cpp
+++ b/fdbclient/FileBackupAgent.actor.cpp
@@ -4590,8 +4590,9 @@ public:
 				restoreRanges.push_back(KeyRange(KeyRangeRef(restoreRange.range().begin, restoreRange.range().end)));
 			}
 		}
-		for (auto& restoreRange : restoreRanges)
-			ASSERT(restoreRange.contains(removePrefix) || removePrefix.size() == 0);
+		for (auto& restoreRange : restoreRanges) {
+			ASSERT(restoreRange.begin.startsWith(removePrefix) && restoreRange.end.startsWith(removePrefix));
+		}
 
 		tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
 		tr->setOption(FDBTransactionOptions::LOCK_AWARE);
@@ -5183,7 +5184,8 @@ public:
 	}
 
 	ACTOR static Future<Optional<Version>> getLastRestorable(FileBackupAgent* backupAgent,
-	                                                         Reference<ReadYourWritesTransaction> tr, Key tagName,
+	                                                         Reference<ReadYourWritesTransaction> tr,
+	                                                         Key tagName,
 	                                                         bool snapshot) {
 		tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
 		tr->setOption(FDBTransactionOptions::LOCK_AWARE);
@@ -5577,7 +5579,8 @@ Future<std::string> FileBackupAgent::getStatusJSON(Database cx, std::string tagN
 	return FileBackupAgentImpl::getStatusJSON(this, cx, tagName);
 }
 
-Future<Optional<Version>> FileBackupAgent::getLastRestorable(Reference<ReadYourWritesTransaction> tr, Key tagName,
+Future<Optional<Version>> FileBackupAgent::getLastRestorable(Reference<ReadYourWritesTransaction> tr,
+                                                             Key tagName,
                                                              bool snapshot) {
 	return FileBackupAgentImpl::getLastRestorable(this, tr, tagName, snapshot);
 }

--- a/fdbserver/workloads/BackupCorrectness.actor.cpp
+++ b/fdbserver/workloads/BackupCorrectness.actor.cpp
@@ -33,8 +33,8 @@ struct BackupAndRestoreCorrectnessWorkload : TestWorkload {
 	int backupRangesCount, backupRangeLengthMax;
 	bool differentialBackup, performRestore, agentRequest;
 	Standalone<VectorRef<KeyRangeRef>> backupRanges;
-	std::vector<std::string> prefixesMandatory;
-	Standalone<VectorRef<KeyRangeRef>> skipRestoreRanges;
+	std::vector<std::string> prefixesAllowed;
+	std::vector<Standalone<KeyRangeRef>> skippedRestoreRanges;
 	Standalone<VectorRef<KeyRangeRef>> restoreRanges;
 	static int backupAgentRequests;
 	bool locked;
@@ -68,7 +68,7 @@ struct BackupAndRestoreCorrectnessWorkload : TestWorkload {
 		agentRequest = getOption(options, LiteralStringRef("simBackupAgents"), true);
 		allowPauses = getOption(options, LiteralStringRef("allowPauses"), true);
 		shareLogRange = getOption(options, LiteralStringRef("shareLogRange"), false);
-		prefixesMandatory = getOption(options, LiteralStringRef("prefixesMandatory"), std::vector<std::string>());
+		prefixesAllowed = getOption(options, LiteralStringRef("prefixesAllowed"), std::vector<std::string>());
 		shouldSkipRestoreRanges = deterministicRandom()->random01() < 0.3 ? true : false;
 
 		TraceEvent("BARW_ClientId").detail("Id", wcx.clientId);
@@ -104,32 +104,45 @@ struct BackupAndRestoreCorrectnessWorkload : TestWorkload {
 			}
 		}
 
-		if (performRestore && !prefixesMandatory.empty() && shouldSkipRestoreRanges) {
+		if (performRestore && !prefixesAllowed.empty() && shouldSkipRestoreRanges) {
 			for (auto& range : backupRanges) {
 				bool intersection = false;
-				for (auto& prefix : prefixesMandatory) {
-					KeyRange mandatoryRange(KeyRangeRef(prefix, strinc(prefix)));
-					if (range.intersects(mandatoryRange))
+				for (auto& prefix : prefixesAllowed) {
+					KeyRange prefixRange(KeyRangeRef(prefix, strinc(prefix)));
+					if (range.intersects(prefixRange)) {
 						intersection = true;
+					}
 					TraceEvent("BARW_PrefixSkipRangeDetails")
-					    .detail("PrefixMandatory", printable(mandatoryRange))
-					    .detail("BackUpRange", printable(range))
+					    .detail("PrefixMandatory", printable(prefix))
+					    .detail("BackupRange", printable(range))
 					    .detail("Intersection", intersection);
 				}
-				if (!intersection && deterministicRandom()->random01() < 0.5)
-					skipRestoreRanges.push_back(skipRestoreRanges.arena(), range);
-				else
-					restoreRanges.push_back(restoreRanges.arena(), range);
+				// If the backup range intersects with prefixesAllowed or a coin flip is true then use it as a restore
+				// range as well, otherwise skip it.
+				if (intersection || deterministicRandom()->coinflip()) {
+					restoreRanges.push_back_deep(restoreRanges.arena(), range);
+				} else {
+					skippedRestoreRanges.push_back(range);
+				}
 			}
 		} else {
 			restoreRanges = backupRanges;
 		}
+
+		// If no random backup ranges intersected with prefixesAllowed or won the coin flip then restoreRanges will be
+		// empty, so move an item from skippedRestoreRanges to restoreRanges.
+		if (restoreRanges.empty()) {
+			ASSERT(!skippedRestoreRanges.empty());
+			restoreRanges.push_back_deep(restoreRanges.arena(), skippedRestoreRanges.back());
+			skippedRestoreRanges.pop_back();
+		}
+
 		for (auto& range : restoreRanges) {
 			TraceEvent("BARW_RestoreRange", randomID)
 			    .detail("RangeBegin", printable(range.begin))
 			    .detail("RangeEnd", printable(range.end));
 		}
-		for (auto& range : skipRestoreRanges) {
+		for (auto& range : skippedRestoreRanges) {
 			TraceEvent("BARW_SkipRange", randomID)
 			    .detail("RangeBegin", printable(range.begin))
 			    .detail("RangeEnd", printable(range.end));
@@ -171,8 +184,8 @@ struct BackupAndRestoreCorrectnessWorkload : TestWorkload {
 		loop {
 			try {
 				state int restoreIndex;
-				for (restoreIndex = 0; restoreIndex < self->skipRestoreRanges.size(); restoreIndex++) {
-					state KeyRangeRef range = self->skipRestoreRanges[restoreIndex];
+				for (restoreIndex = 0; restoreIndex < self->skippedRestoreRanges.size(); restoreIndex++) {
+					state KeyRangeRef range = self->skippedRestoreRanges[restoreIndex];
 					Standalone<StringRef> restoreTag(self->backupTag.toString() + "_" + std::to_string(restoreIndex));
 					Standalone<RangeResultRef> res = wait(tr.getRange(range, GetRangeLimits::ROW_LIMIT_UNLIMITED));
 					if (!res.empty()) {

--- a/tests/fast/BackupCorrectnessClean.toml
+++ b/tests/fast/BackupCorrectnessClean.toml
@@ -50,7 +50,7 @@ simBackupAgents = 'BackupToFile'
     restoreAfter = 60.0
     performRestore = true
     allowPauses = false
-    prefixesMandatory = 'a,A,m'
+    prefixesAllowed = 'a,A,m'
 
     [[test.workload]]
     testName = 'BackupAndRestoreCorrectness'

--- a/tests/fast/BackupCorrectnessClean.toml
+++ b/tests/fast/BackupCorrectnessClean.toml
@@ -50,7 +50,7 @@ simBackupAgents = 'BackupToFile'
     restoreAfter = 60.0
     performRestore = true
     allowPauses = false
-    prefixesAllowed = 'a,A,m'
+    restorePrefixesToInclude = 'a,A,m'
 
     [[test.workload]]
     testName = 'BackupAndRestoreCorrectness'


### PR DESCRIPTION
- BackupCorrectness workload would sometimes generate an empty restore target range set.  This would cause the test to time out because restore() would still queue the job, but then during execution the restore tasks would repeatedly fail because the restore range set is empty.  BackupCorrectness should no longer generate empty restore ranges, but just in case restore() will now throw an error if the target ranges are empty which will cause a much faster failure.  

- Restore start was not properly checking restore target ranges against the remove prefix option.

- Some code clarity changes.

Passed 30k runs of only BackupCorrectness and BackupCorrectnessClean.  Code changes are restricted to BackupCorrectness and restore().

Passed 20k runs of all correctness tests.  I think CI just got lucky and found an unrelated failure.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
