### PR TITLE
Add resolver unit tests

### DIFF
--- a/fdbserver/CMakeLists.txt
+++ b/fdbserver/CMakeLists.txt
@@ -121,6 +121,7 @@ set(FDBSERVER_SRCS
   ptxn/test/FakeStorageServer.actor.h
   ptxn/test/FakeTLog.actor.cpp
   ptxn/test/FakeTLog.actor.h
+  ptxn/test/TestResolver.actor.cpp
   ptxn/test/TestSerialization.cpp
 
   tester.actor.cpp

--- a/fdbserver/ptxn/test/Driver.actor.cpp
+++ b/fdbserver/ptxn/test/Driver.actor.cpp
@@ -18,7 +18,6 @@
  * limitations under the License.
  */
 
-#include "fdbserver/ResolverInterface.h"
 #include "fdbserver/ptxn/test/Driver.h"
 
 #include <iostream>
@@ -32,6 +31,7 @@
 #include "fdbserver/ptxn/test/FakeResolver.actor.h"
 #include "fdbserver/ptxn/test/FakeStorageServer.actor.h"
 #include "fdbserver/ptxn/test/FakeTLog.actor.h"
+#include "fdbserver/ResolverInterface.h"
 #include "flow/IRandom.h"
 #include "flow/Trace.h"
 #include "flow/genericactors.actor.h"
@@ -184,8 +184,7 @@ void startFakeResolver(std::vector<Future<Void>>& actors, std::shared_ptr<TestDr
 		req.commitProxyCount = pTestDriverContext->numProxies;
 		req.resolverCount = pTestDriverContext->numResolvers;
 
-		Future<Void> core = ::resolverCore(*recruited, req);
-		actors.emplace_back(core);
+		actors.emplace_back(::resolverCore(*recruited, req));
 		pTestDriverContext->resolverInterfaces.push_back(recruited);
 	}
 }

--- a/fdbserver/ptxn/test/Driver.actor.cpp
+++ b/fdbserver/ptxn/test/Driver.actor.cpp
@@ -299,13 +299,11 @@ TEST_CASE("/fdbserver/ptxn/test/driver") {
 }
 
 TEST_CASE("fdbserver/ptxn/test/resolver") {
-	using namespace ptxn;
-
-	TestDriverOptions options(params);
+	ptxn::TestDriverOptions options(params);
 	std::cout << options << std::endl;
 
-	std::shared_ptr<TestDriverContext> context = initTestDriverContext(options);
-	std::vector<Future<Void>> actors;
+	state std::vector<Future<Void>> actors;
+	state std::shared_ptr<ptxn::TestDriverContext> context = ptxn::initTestDriverContext();
 
 	startFakeResolver(actors, context);
 	std::cout << "Started " << context->numResolvers << " Resolvers\n";

--- a/fdbserver/ptxn/test/Driver.actor.cpp
+++ b/fdbserver/ptxn/test/Driver.actor.cpp
@@ -35,41 +35,8 @@
 #include "flow/IRandom.h"
 #include "flow/Trace.h"
 #include "flow/genericactors.actor.h"
-#include "flow/UnitTest.h"
 
 namespace ptxn {
-
-struct TestDriverOptions {
-	static const int DEFAULT_NUM_COMMITS = 3;
-	static const int DEFAULT_NUM_TEAMS = 10;
-	static const int DEFAULT_NUM_PROXIES = 1;
-	static const int DEFAULT_NUM_TLOGS = 3;
-	static const int DEFAULT_NUM_STORAGE_SERVERS = 3;
-	static const int DEFAULT_NUM_RESOLVERS = 2;
-	static const MessageTransferModel DEFAULT_MESSAGE_TRANSFER_MODEL = MessageTransferModel::TLogActivelyPush;
-
-	int numCommits;
-	int numTeams;
-	int numProxies;
-	int numTLogs;
-	int numStorageServers;
-	int numResolvers;
-	MessageTransferModel transferModel = MessageTransferModel::TLogActivelyPush;
-
-	explicit TestDriverOptions(const UnitTestParameters& params) {
-		numCommits = params.getInt("numCommits").orDefault(DEFAULT_NUM_COMMITS);
-		numTeams = params.getInt("numTeams").orDefault(DEFAULT_NUM_TEAMS);
-		numProxies = params.getInt("numProxies").orDefault(DEFAULT_NUM_PROXIES);
-		numTLogs = params.getInt("numTLogs").orDefault(DEFAULT_NUM_TLOGS);
-		numStorageServers = params.getInt("numStorageServers").orDefault(DEFAULT_NUM_STORAGE_SERVERS);
-		numResolvers = params.getInt("numResolvers").orDefault(DEFAULT_NUM_RESOLVERS);
-		transferModel = static_cast<MessageTransferModel>(
-		    params.getInt("messageTransferModel").orDefault(static_cast<int>(DEFAULT_MESSAGE_TRANSFER_MODEL)),
-		    static_cast<int>(MessageTransferModel::TLogActivelyPush));
-	}
-
-	friend std::ostream& operator<<(std::ostream&, const TestDriverOptions&);
-};
 
 std::ostream& operator<<(std::ostream& stream, const TestDriverOptions& option) {
 	stream << "Values for ptxn/Driver.actor.cpp:DriverTestOptions:" << std::endl;

--- a/fdbserver/ptxn/test/Driver.h
+++ b/fdbserver/ptxn/test/Driver.h
@@ -85,6 +85,12 @@ struct TestDriverContext {
 	std::vector<CommitRecord> commitRecord;
 };
 
+// Returns an initialized TestDriverContext with default values.
+std::shared_ptr<TestDriverContext> initTestDriverContext();
+
+// Starts all fake resolvers specified in the pTestDriverContext.
+void startFakeResolver(std::vector<Future<Void>>& actors, std::shared_ptr<TestDriverContext> pTestDriverContext);
+
 // Print out *ALL* commits that has triggered.
 void printCommitRecord(const std::vector<CommitRecord>& records);
 

--- a/fdbserver/ptxn/test/Driver.h
+++ b/fdbserver/ptxn/test/Driver.h
@@ -31,6 +31,7 @@
 #include "fdbserver/ptxn/StorageServerInterface.h"
 #include "fdbserver/ptxn/TLogInterface.h"
 #include "fdbserver/ResolverInterface.h"
+#include "flow/UnitTest.h"
 
 namespace ptxn {
 
@@ -49,6 +50,39 @@ struct CommitRecord {
 	CommitValidationRecord validation;
 
 	CommitRecord(const Version& version, const TeamID& teamID, std::vector<MutationRef>&& mutationRef);
+};
+
+// Driver options for starting mock environment.
+struct TestDriverOptions {
+	static const int DEFAULT_NUM_COMMITS = 3;
+	static const int DEFAULT_NUM_TEAMS = 10;
+	static const int DEFAULT_NUM_PROXIES = 1;
+	static const int DEFAULT_NUM_TLOGS = 3;
+	static const int DEFAULT_NUM_STORAGE_SERVERS = 3;
+	static const int DEFAULT_NUM_RESOLVERS = 2;
+	static const MessageTransferModel DEFAULT_MESSAGE_TRANSFER_MODEL = MessageTransferModel::TLogActivelyPush;
+
+	int numCommits;
+	int numTeams;
+	int numProxies;
+	int numTLogs;
+	int numStorageServers;
+	int numResolvers;
+	MessageTransferModel transferModel = MessageTransferModel::TLogActivelyPush;
+
+	explicit TestDriverOptions(const UnitTestParameters& params) {
+		numCommits = params.getInt("numCommits").orDefault(DEFAULT_NUM_COMMITS);
+		numTeams = params.getInt("numTeams").orDefault(DEFAULT_NUM_TEAMS);
+		numProxies = params.getInt("numProxies").orDefault(DEFAULT_NUM_PROXIES);
+		numTLogs = params.getInt("numTLogs").orDefault(DEFAULT_NUM_TLOGS);
+		numStorageServers = params.getInt("numStorageServers").orDefault(DEFAULT_NUM_STORAGE_SERVERS);
+		numResolvers = params.getInt("numResolvers").orDefault(DEFAULT_NUM_RESOLVERS);
+		transferModel = static_cast<MessageTransferModel>(
+		    params.getInt("messageTransferModel").orDefault(static_cast<int>(DEFAULT_MESSAGE_TRANSFER_MODEL)),
+		    static_cast<int>(MessageTransferModel::TLogActivelyPush));
+	}
+
+	friend std::ostream& operator<<(std::ostream&, const TestDriverOptions&);
 };
 
 struct TestDriverContext {
@@ -85,8 +119,8 @@ struct TestDriverContext {
 	std::vector<CommitRecord> commitRecord;
 };
 
-// Returns an initialized TestDriverContext with default values.
-std::shared_ptr<TestDriverContext> initTestDriverContext();
+// Returns an initialized TestDriverContext with default values specified in "options".
+std::shared_ptr<TestDriverContext> initTestDriverContext(const TestDriverOptions& options);
 
 // Starts all fake resolvers specified in the pTestDriverContext.
 void startFakeResolver(std::vector<Future<Void>>& actors, std::shared_ptr<TestDriverContext> pTestDriverContext);

--- a/fdbserver/ptxn/test/TestResolver.actor.cpp
+++ b/fdbserver/ptxn/test/TestResolver.actor.cpp
@@ -1,0 +1,66 @@
+/*
+ * TestResolver.actor.cpp
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "fdbserver/ptxn/test/Driver.h"
+
+#include <iostream>
+#include <memory>
+#include <vector>
+
+#include "fdbclient/FDBTypes.h"
+#include "fdbserver/ptxn/Config.h"
+#include "fdbserver/ptxn/test/FakeResolver.actor.h"
+#include "fdbserver/ResolverInterface.h"
+#include "flow/IRandom.h"
+#include "flow/genericactors.actor.h"
+#include "flow/UnitTest.h"
+
+ TEST_CASE("fdbserver/ptxn/test/resolver") {
+	ptxn::TestDriverOptions options(params);
+	std::cout << options << std::endl;
+
+	state std::vector<Future<Void>> actors;
+	state std::shared_ptr<ptxn::TestDriverContext> context = ptxn::initTestDriverContext();
+
+	startFakeResolver(actors, context);
+	std::cout<<"Started " << context->numResolvers << " Resolvers\n";
+
+	const Version lastEpochEnd = 100;
+	state std::vector<Future<ResolveTransactionBatchReply>> replies;
+	// Imitates resolver initialization from the master server
+	for (auto& r : context->resolverInterfaces) {
+		ResolveTransactionBatchRequest req;
+		req.prevVersion = -1;
+		req.version = lastEpochEnd;
+		req.lastReceivedVersion = -1;
+		// triggers debugging trace events at Resolvers
+		req.debugID = deterministicRandom()->randomUniqueID();
+
+		replies.push_back(brokenPromiseToNever(r->resolve.getReply(req)));
+	}
+
+	wait(waitForAll(replies));
+	for (auto& f : replies) {
+		ASSERT(f.isReady() && f.isValid());
+	}
+	std::cout << "Initialized " << replies.size() << " Resolvers\n";
+
+	return Void();
+}

--- a/fdbserver/ptxn/test/TestResolver.actor.cpp
+++ b/fdbserver/ptxn/test/TestResolver.actor.cpp
@@ -18,31 +18,59 @@
  * limitations under the License.
  */
 
-#include "fdbserver/ptxn/test/Driver.h"
-
+#include <algorithm>
 #include <iostream>
+#include <map>
 #include <memory>
+#include <random>
+#include <stdint.h>
 #include <vector>
 
 #include "fdbclient/FDBTypes.h"
 #include "fdbserver/ptxn/Config.h"
+#include "fdbserver/ptxn/test/Driver.h"
 #include "fdbserver/ptxn/test/FakeResolver.actor.h"
 #include "fdbserver/ResolverInterface.h"
 #include "flow/IRandom.h"
 #include "flow/genericactors.actor.h"
 #include "flow/UnitTest.h"
 
- TEST_CASE("fdbserver/ptxn/test/resolver") {
+namespace {
+
+// Makes a batch of "n" requests starting at "beginVersion", where each batch
+// increases by "increment" amount.
+std::vector<ResolveTransactionBatchRequest> makeTxnBatch(Version prevVersion, Version beginVersion, int n, int64_t increment) {
+	std::vector<ResolveTransactionBatchRequest> batch(n);
+
+	Version current = beginVersion;
+	Version pv = prevVersion;
+	for (auto& r : batch) {
+		r.prevVersion = pv;
+		r.version = current;
+		r.lastReceivedVersion = prevVersion;
+
+		pv = current;
+		current += increment;
+	}
+
+	return batch;
+}
+
+} // anonymous namespace
+
+TEST_CASE("fdbserver/ptxn/test/resolver") {
 	ptxn::TestDriverOptions options(params);
 	std::cout << options << std::endl;
 
+	state const Version lastEpochEnd = 100;
+	state const int totalRequests = 10;
+>>>>>>> Test batches to a resolver
 	state std::vector<Future<Void>> actors;
 	state std::shared_ptr<ptxn::TestDriverContext> context = ptxn::initTestDriverContext();
 
 	startFakeResolver(actors, context);
-	std::cout<<"Started " << context->numResolvers << " Resolvers\n";
+	std::cout << "Started " << context->numResolvers << " Resolvers\n";
 
-	const Version lastEpochEnd = 100;
 	state std::vector<Future<ResolveTransactionBatchReply>> replies;
 	// Imitates resolver initialization from the master server
 	for (auto& r : context->resolverInterfaces) {
@@ -57,10 +85,30 @@
 	}
 
 	wait(waitForAll(replies));
-	for (auto& f : replies) {
+	for (const auto& f : replies) {
 		ASSERT(f.isReady() && f.isValid());
 	}
 	std::cout << "Initialized " << replies.size() << " Resolvers\n";
+
+	// Generate 10 batches, send in a random order, and verify all responses.
+	state Version beginVersion = 200;
+	state int64_t increment = 7;
+
+	std::vector<ResolveTransactionBatchRequest> batch = makeTxnBatch(lastEpochEnd, beginVersion, totalRequests, increment);
+	std::mt19937 g(deterministicRandom()->randomUInt32());
+	std::shuffle(batch.begin(), batch.end(), g);
+
+	replies.clear();
+	for (auto& req : batch) {
+		replies.push_back(brokenPromiseToNever(context->resolverInterfaces[0]->resolve.getReply(req)));
+	}
+
+	// Note even though requests are processed in order at Resolver. The
+	// responses could be received out of order.
+	wait(waitForAll(replies));
+	for (const auto& f : replies) {
+		ASSERT(f.isReady() && f.isValid());
+	}
 
 	return Void();
 }

--- a/fdbserver/ptxn/test/TestResolver.actor.cpp
+++ b/fdbserver/ptxn/test/TestResolver.actor.cpp
@@ -33,7 +33,6 @@
 #include "fdbserver/ResolverInterface.h"
 #include "flow/IRandom.h"
 #include "flow/genericactors.actor.h"
-#include "flow/UnitTest.h"
 
 namespace {
 
@@ -59,15 +58,15 @@ std::vector<ResolveTransactionBatchRequest> makeTxnBatch(Version prevVersion, Ve
 } // anonymous namespace
 
 TEST_CASE("fdbserver/ptxn/test/resolver") {
+	state const Version lastEpochEnd = 100;
+	state const int totalRequests = 10;
+	state std::vector<Future<Void>> actors;
+	state std::shared_ptr<ptxn::TestDriverContext> context;
+
 	ptxn::TestDriverOptions options(params);
 	std::cout << options << std::endl;
 
-	state const Version lastEpochEnd = 100;
-	state const int totalRequests = 10;
->>>>>>> Test batches to a resolver
-	state std::vector<Future<Void>> actors;
-	state std::shared_ptr<ptxn::TestDriverContext> context = ptxn::initTestDriverContext();
-
+	context = ptxn::initTestDriverContext(options);
 	startFakeResolver(actors, context);
 	std::cout << "Started " << context->numResolvers << " Resolvers\n";
 

--- a/fdbserver/ptxn/test/TestResolver.actor.cpp
+++ b/fdbserver/ptxn/test/TestResolver.actor.cpp
@@ -19,11 +19,11 @@
  */
 
 #include <algorithm>
+#include <cstdint>
 #include <iostream>
 #include <map>
 #include <memory>
 #include <random>
-#include <stdint.h>
 #include <vector>
 
 #include "fdbclient/FDBTypes.h"


### PR DESCRIPTION
Add a simple test that sends several empty batches of transactions to a Resolver.

Manually tested the unit test.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
