### PR TITLE
Fixed Typo in the Client Testing document

### DIFF
--- a/documentation/sphinx/source/client-testing.rst
+++ b/documentation/sphinx/source/client-testing.rst
@@ -315,7 +315,7 @@ and pass the test with ``-f``:
 
 .. code-block:: sh
 
-   fdbserver -r simulator -f testfile.txt
+   fdbserver -r simulation -f testfile.txt
 
 
 Running a Workload on an actual Cluster


### PR DESCRIPTION
See #4686

The Client Testing document https://apple.github.io/foundationdb/client-testing.html demands to run a simulator by launching fdbserver with simulator role. But such role doesn't exist

[oleg@fdbs ~]$ fdbserver -r simulator -f /mnt/host/root/home/oleg/work/fdb/FoundationDb/tests/fast/AtomicBackupCorrectness.txt
ERROR: Unknown role simulator' Try fdbserver --help' for more information.
The right role name is simulation, not simulator.