### PR TITLE
rewrote tlog recruitment logic so that it is deterministic

### DIFF
--- a/documentation/sphinx/source/mr-status-json-schemas.rst.inc
+++ b/documentation/sphinx/source/mr-status-json-schemas.rst.inc
@@ -27,6 +27,7 @@
                   "storage",
                   "transaction",
                   "resolution",
+                  "stateless",
                   "commit_proxy",
                   "grv_proxy",
                   "master",

--- a/fdbclient/Schemas.cpp
+++ b/fdbclient/Schemas.cpp
@@ -47,6 +47,7 @@ const KeyRef JSONSchemas::statusSchema = LiteralStringRef(R"statusSchema(
                   "storage",
                   "transaction",
                   "resolution",
+                  "stateless",
                   "commit_proxy",
                   "grv_proxy",
                   "master",

--- a/fdbrpc/Locality.h
+++ b/fdbrpc/Locality.h
@@ -34,7 +34,6 @@ struct ProcessClass {
 		ResolutionClass,
 		TesterClass,
 		CommitProxyClass,
-		GrvProxyClass,
 		MasterClass,
 		StatelessClass,
 		LogClass,
@@ -46,6 +45,7 @@ struct ProcessClass {
 		RatekeeperClass,
 		StorageCacheClass,
 		BackupClass,
+		GrvProxyClass,
 		InvalidClass = -1
 	};
 

--- a/fdbrpc/ReplicationPolicy.h
+++ b/fdbrpc/ReplicationPolicy.h
@@ -151,6 +151,10 @@ struct PolicyAcross final : IReplicationPolicy, public ReferenceCounted<PolicyAc
 		_policy->attributeKeys(set);
 	}
 
+	Reference<IReplicationPolicy> embeddedPolicy() { return _policy; }
+
+	std::string attributeKey() { return _attribKey; }
+
 protected:
 	int _count;
 	std::string _attribKey;

--- a/fdbrpc/ReplicationPolicy.h
+++ b/fdbrpc/ReplicationPolicy.h
@@ -151,9 +151,9 @@ struct PolicyAcross final : IReplicationPolicy, public ReferenceCounted<PolicyAc
 		_policy->attributeKeys(set);
 	}
 
-	Reference<IReplicationPolicy> embeddedPolicy() { return _policy; }
+	Reference<IReplicationPolicy> embeddedPolicy() const { return _policy; }
 
-	std::string attributeKey() { return _attribKey; }
+	const std::string& attributeKey() const { return _attribKey; }
 
 protected:
 	int _count;

--- a/fdbserver/ClusterController.actor.cpp
+++ b/fdbserver/ClusterController.actor.cpp
@@ -1063,7 +1063,6 @@ public:
 			}
 			return workers;
 		}
-		ASSERT(false);
 		return getWorkersForTlogsBackup(
 		    conf, required, desired, policy, id_used, checkStable, dcIds, exclusionWorkerIds);
 	}

--- a/fdbserver/ClusterController.actor.cpp
+++ b/fdbserver/ClusterController.actor.cpp
@@ -1200,8 +1200,7 @@ public:
 	                                               ProcessClass::Fitness unacceptableFitness,
 	                                               DatabaseConfiguration const& conf,
 	                                               std::map<Optional<Standalone<StringRef>>, int>& id_used,
-	                                               std::map<Optional<Standalone<StringRef>>, int> preferredSharing =
-	                                                   std::map<Optional<Standalone<StringRef>>, int>(),
+	                                               std::map<Optional<Standalone<StringRef>>, int> preferredSharing = {},
 	                                               bool checkStable = false) {
 		std::map<std::tuple<ProcessClass::Fitness, int, bool, int>, vector<WorkerDetails>> fitness_workers;
 
@@ -1238,8 +1237,7 @@ public:
 	    int amount,
 	    DatabaseConfiguration const& conf,
 	    std::map<Optional<Standalone<StringRef>>, int>& id_used,
-	    std::map<Optional<Standalone<StringRef>>, int> preferredSharing =
-	        std::map<Optional<Standalone<StringRef>>, int>(),
+	    std::map<Optional<Standalone<StringRef>>, int> preferredSharing = {},
 	    Optional<WorkerFitnessInfo> minWorker = Optional<WorkerFitnessInfo>(),
 	    bool checkStable = false) {
 		std::map<std::tuple<ProcessClass::Fitness, int, bool, int>, vector<WorkerDetails>> fitness_workers;
@@ -1961,15 +1959,10 @@ public:
 			                             ProcessClass::ExcludeFit,
 			                             db.config,
 			                             id_used,
-			                             std::map<Optional<Standalone<StringRef>>, int>(),
+			                             {},
 			                             true);
-			getWorkerForRoleInDatacenter(regions[0].dcId,
-			                             ProcessClass::Master,
-			                             ProcessClass::ExcludeFit,
-			                             db.config,
-			                             id_used,
-			                             std::map<Optional<Standalone<StringRef>>, int>(),
-			                             true);
+			getWorkerForRoleInDatacenter(
+			    regions[0].dcId, ProcessClass::Master, ProcessClass::ExcludeFit, db.config, id_used, {}, true);
 
 			std::set<Optional<Key>> primaryDC;
 			primaryDC.insert(regions[0].dcId);
@@ -1985,27 +1978,12 @@ public:
 				getWorkersForSatelliteLogs(db.config, regions[0], regions[1], id_used, satelliteFallback, true);
 			}
 
-			getWorkerForRoleInDatacenter(regions[0].dcId,
-			                             ProcessClass::Resolver,
-			                             ProcessClass::ExcludeFit,
-			                             db.config,
-			                             id_used,
-			                             std::map<Optional<Standalone<StringRef>>, int>(),
-			                             true);
-			getWorkerForRoleInDatacenter(regions[0].dcId,
-			                             ProcessClass::CommitProxy,
-			                             ProcessClass::ExcludeFit,
-			                             db.config,
-			                             id_used,
-			                             std::map<Optional<Standalone<StringRef>>, int>(),
-			                             true);
-			getWorkerForRoleInDatacenter(regions[0].dcId,
-			                             ProcessClass::GrvProxy,
-			                             ProcessClass::ExcludeFit,
-			                             db.config,
-			                             id_used,
-			                             std::map<Optional<Standalone<StringRef>>, int>(),
-			                             true);
+			getWorkerForRoleInDatacenter(
+			    regions[0].dcId, ProcessClass::Resolver, ProcessClass::ExcludeFit, db.config, id_used, {}, true);
+			getWorkerForRoleInDatacenter(
+			    regions[0].dcId, ProcessClass::CommitProxy, ProcessClass::ExcludeFit, db.config, id_used, {}, true);
+			getWorkerForRoleInDatacenter(
+			    regions[0].dcId, ProcessClass::GrvProxy, ProcessClass::ExcludeFit, db.config, id_used, {}, true);
 
 			vector<Optional<Key>> dcPriority;
 			dcPriority.push_back(regions[0].dcId);
@@ -2217,13 +2195,8 @@ public:
 		std::map<Optional<Standalone<StringRef>>, int> old_id_used;
 		id_used[clusterControllerProcessId]++;
 		old_id_used[clusterControllerProcessId]++;
-		WorkerFitnessInfo mworker = getWorkerForRoleInDatacenter(clusterControllerDcId,
-		                                                         ProcessClass::Master,
-		                                                         ProcessClass::NeverAssign,
-		                                                         db.config,
-		                                                         id_used,
-		                                                         std::map<Optional<Standalone<StringRef>>, int>(),
-		                                                         true);
+		WorkerFitnessInfo mworker = getWorkerForRoleInDatacenter(
+		    clusterControllerDcId, ProcessClass::Master, ProcessClass::NeverAssign, db.config, id_used, {}, true);
 		auto newMasterFit = mworker.worker.processClass.machineClassFitness(ProcessClass::Master);
 		if (db.config.isExcludedServer(mworker.worker.interf.addresses())) {
 			newMasterFit = std::max(newMasterFit, ProcessClass::ExcludeFit);
@@ -2382,17 +2355,16 @@ public:
 		RoleFitness oldLogRoutersFit(log_routers, ProcessClass::LogRouter, old_id_used);
 		RoleFitness newLogRoutersFit = oldLogRoutersFit;
 		if (db.config.usableRegions > 1 && dbi.recoveryState == RecoveryState::FULLY_RECOVERED) {
-			newLogRoutersFit =
-			    RoleFitness(getWorkersForRoleInDatacenter(*remoteDC.begin(),
-			                                              ProcessClass::LogRouter,
-			                                              newRouterCount,
-			                                              db.config,
-			                                              id_used,
-			                                              std::map<Optional<Standalone<StringRef>>, int>(),
-			                                              Optional<WorkerFitnessInfo>(),
-			                                              true),
-			                ProcessClass::LogRouter,
-			                id_used);
+			newLogRoutersFit = RoleFitness(getWorkersForRoleInDatacenter(*remoteDC.begin(),
+			                                                             ProcessClass::LogRouter,
+			                                                             newRouterCount,
+			                                                             db.config,
+			                                                             id_used,
+			                                                             {},
+			                                                             Optional<WorkerFitnessInfo>(),
+			                                                             true),
+			                               ProcessClass::LogRouter,
+			                               id_used);
 		}
 
 		if (oldLogRoutersFit.count < oldRouterCount) {
@@ -2477,7 +2449,7 @@ public:
 		                                                              nBackup,
 		                                                              db.config,
 		                                                              id_used,
-		                                                              std::map<Optional<Standalone<StringRef>>, int>(),
+		                                                              {},
 		                                                              Optional<WorkerFitnessInfo>(),
 		                                                              true),
 		                                ProcessClass::Backup,
@@ -2917,7 +2889,7 @@ void checkBetterDDOrRK(ClusterControllerData* self) {
 	                                                               ProcessClass::NeverAssign,
 	                                                               self->db.config,
 	                                                               id_used,
-	                                                               std::map<Optional<Standalone<StringRef>>, int>(),
+	                                                               {},
 	                                                               true)
 	                                .worker;
 	if (self->onMasterIsBetter(newRKWorker, ProcessClass::Ratekeeper)) {
@@ -2933,7 +2905,7 @@ void checkBetterDDOrRK(ClusterControllerData* self) {
 	                                                               ProcessClass::NeverAssign,
 	                                                               self->db.config,
 	                                                               id_used,
-	                                                               std::map<Optional<Standalone<StringRef>>, int>(),
+	                                                               {},
 	                                                               true)
 	                                .worker;
 	if (self->onMasterIsBetter(newDDWorker, ProcessClass::DataDistributor)) {

--- a/fdbserver/SimulatedCluster.actor.cpp
+++ b/fdbserver/SimulatedCluster.actor.cpp
@@ -733,7 +733,7 @@ ACTOR Future<Void> restartSimulatedSystem(vector<Future<Void>>* systemActors,
 			ProcessClass::ClassType cType =
 			    (ProcessClass::ClassType)(atoi(ini.GetValue(machineIdString.c_str(), "mClass")));
 			// using specialized class types can lead to nondeterministic recruitment
-			if (cType == ProcessClass::MasterClass || cType == ProcessClass::ResolutionClass) {
+			if (cType == ProcessClass::GrvProxyClass || cType == ProcessClass::ResolutionClass) {
 				cType = ProcessClass::StatelessClass;
 			}
 			ProcessClass processClass = ProcessClass(cType, ProcessClass::CommandLineSource);

--- a/fdbserver/SimulatedCluster.actor.cpp
+++ b/fdbserver/SimulatedCluster.actor.cpp
@@ -733,7 +733,7 @@ ACTOR Future<Void> restartSimulatedSystem(vector<Future<Void>>* systemActors,
 			ProcessClass::ClassType cType =
 			    (ProcessClass::ClassType)(atoi(ini.GetValue(machineIdString.c_str(), "mClass")));
 			// using specialized class types can lead to nondeterministic recruitment
-			if (cType == ProcessClass::GrvProxyClass || cType == ProcessClass::ResolutionClass) {
+			if (cType == ProcessClass::MasterClass || cType == ProcessClass::ResolutionClass) {
 				cType = ProcessClass::StatelessClass;
 			}
 			ProcessClass processClass = ProcessClass(cType, ProcessClass::CommandLineSource);

--- a/fdbserver/WorkerInterface.actor.h
+++ b/fdbserver/WorkerInterface.actor.h
@@ -130,6 +130,8 @@ struct WorkerDetails {
 	WorkerDetails(const WorkerInterface& interf, ProcessClass processClass, bool degraded)
 	  : interf(interf), processClass(processClass), degraded(degraded) {}
 
+	bool operator<(const WorkerDetails& r) const { return interf.id() < r.interf.id(); }
+
 	template <class Ar>
 	void serialize(Ar& ar) {
 		serializer(ar, interf, processClass, degraded);

--- a/fdbserver/workloads/LowLatency.actor.cpp
+++ b/fdbserver/workloads/LowLatency.actor.cpp
@@ -40,7 +40,7 @@ struct LowLatencyWorkload : TestWorkload {
 	  : TestWorkload(wcx), operations("Operations"), retries("Retries"), ok(true) {
 		testDuration = getOption(options, LiteralStringRef("testDuration"), 600.0);
 		maxGRVLatency = getOption(options, LiteralStringRef("maxGRVLatency"), 20.0);
-		maxCommitLatency = getOption(options, LiteralStringRef("maxCommitLatency"), 33.0);
+		maxCommitLatency = getOption(options, LiteralStringRef("maxCommitLatency"), 30.0);
 		checkDelay = getOption(options, LiteralStringRef("checkDelay"), 1.0);
 		testWrites = getOption(options, LiteralStringRef("testWrites"), true);
 		testKey = getOption(options, LiteralStringRef("testKey"), LiteralStringRef("testKey"));

--- a/fdbserver/workloads/LowLatency.actor.cpp
+++ b/fdbserver/workloads/LowLatency.actor.cpp
@@ -40,7 +40,7 @@ struct LowLatencyWorkload : TestWorkload {
 	  : TestWorkload(wcx), operations("Operations"), retries("Retries"), ok(true) {
 		testDuration = getOption(options, LiteralStringRef("testDuration"), 600.0);
 		maxGRVLatency = getOption(options, LiteralStringRef("maxGRVLatency"), 20.0);
-		maxCommitLatency = getOption(options, LiteralStringRef("maxCommitLatency"), 30.0);
+		maxCommitLatency = getOption(options, LiteralStringRef("maxCommitLatency"), 33.0);
 		checkDelay = getOption(options, LiteralStringRef("checkDelay"), 1.0);
 		testWrites = getOption(options, LiteralStringRef("testWrites"), true);
 		testKey = getOption(options, LiteralStringRef("testKey"), LiteralStringRef("testKey"));

--- a/flow/Knobs.cpp
+++ b/flow/Knobs.cpp
@@ -135,7 +135,7 @@ void FlowKnobs::initialize(bool randomize, bool isSimulated) {
 	init( DISABLE_POSIX_KERNEL_AIO,                              0 );
 
 	//AsyncFileNonDurable
-	init( NON_DURABLE_MAX_WRITE_DELAY,                         5.0 );
+	init( NON_DURABLE_MAX_WRITE_DELAY,                         2.0 ); if( randomize && BUGGIFY ) NON_DURABLE_MAX_WRITE_DELAY = 5.0;
 	init( MAX_PRIOR_MODIFICATION_DELAY,                        1.0 ); if( randomize && BUGGIFY ) MAX_PRIOR_MODIFICATION_DELAY = 10.0;
 
 	//GenericActors


### PR DESCRIPTION
The goal of this rewrite is to prevent better master exists from triggering spuriously because tlogs randomly get located on different processes each time the function is called.

Changing the recruitment logic also has the benefit that now the cluster controller will ensure Log class processes are recruited before Transaction class processes.

Passed: 934930
Failed: 10

Failing tests:

RandomSeed="994272039" BuggifyEnabled="1" TestFile="tests/slow/SwizzledCycleTest.toml" 
TooManyFiles

RandomSeed="325685976" BuggifyEnabled="1" TestFile="tests/slow/FastTriggeredWatches.toml" 
Test timed out

RandomSeed="58742398" BuggifyEnabled="1" TestFile="tests/fast/SwizzledRollbackSideband.toml" 
Error starting workload

JoshuaMessage Severity="40" Error="JoshuaTimeout" TimeoutCommandRun="true" PythonError="Command './joshua_timeout' timed out after 180 seconds”

RandomSeed="199525603" BuggifyEnabled="1" TestFile="tests/rare/CloggedCycleWithKills.toml" 
RecoveryDelayedTooManyOldGenerations

RandomSeed="228055023" BuggifyEnabled="1" OldBinary="fdbserver" TestFile="tests/restarting/from_7.0.0/ConfigureTestRestart-1.txt"

RandomSeed="228055024" BuggifyEnabled="1" OldBinary="fdbserver" TestFile="tests/restarting/from_7.0.0/ConfigureTestRestart-2.txt"
TesterRecruitmentTimeout

RandomSeed="224073052" BuggifyEnabled="0" OldBinary="fdbserver" TestFile="tests/restarting/from_6.2.29/SnapTestAttrition-1.txt"
SetupAndRunError Error="timed_out"

RandomSeed="5142395" BuggifyEnabled="1" OldBinary="fdbserver" TestFile="tests/restarting/from_7.0.0/SnapIncrementalRestore-1.toml" 
TestFailure Error="timed_out"

RandomSeed="699167286" BuggifyEnabled="1" TestFile="tests/fast/TxnStateStoreCycleTest.toml"
TooManyFiles

RandomSeed="854128356" BuggifyEnabled="1" OldBinary="fdbserver" TestFile="tests/restarting/from_7.0.0/SnapIncrementalRestore-1.toml"
TestFailure Error="timed_out"

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
