### PR TITLE
Make PTXN Driver test configurable

### DIFF
--- a/fdbserver/ptxn/test/Driver.actor.cpp
+++ b/fdbserver/ptxn/test/Driver.actor.cpp
@@ -285,11 +285,6 @@ TEST_CASE("/fdbserver/ptxn/test/driver") {
 	TestDriverOptions options(params);
 	std::cout << options << std::endl;
 
-	/*
-	    for(auto iter = params.params.begin(); iter != params.params.end(); ++iter) {
-	        std::cout<< "key: " << iter->first << "\tvalue: " << iter->second <<std::endl;
-	    }*/
-
 	std::shared_ptr<TestDriverContext> context = initTestDriverContext(options);
 	std::vector<Future<Void>> actors;
 

--- a/fdbserver/ptxn/test/Driver.h
+++ b/fdbserver/ptxn/test/Driver.h
@@ -52,6 +52,9 @@ struct CommitRecord {
 };
 
 struct TestDriverContext {
+	// Num commits to be created
+	int numCommits;
+
 	// Teams
 	int numTeamIDs;
 	std::vector<TeamID> teamIDs;
@@ -96,7 +99,7 @@ void verifyMutationsInRecord(std::vector<CommitRecord>& record,
                              const Version&,
                              const TeamID&,
                              const std::vector<MutationRef>& mutations,
-							 std::function<void(CommitValidationRecord&)> validateUpdater);
+                             std::function<void(CommitValidationRecord&)> validateUpdater);
 
 } // namespace ptxn
 

--- a/flow/UnitTest.cpp
+++ b/flow/UnitTest.cpp
@@ -20,6 +20,8 @@
 
 #include "flow/UnitTest.h"
 
+#include <string>
+
 UnitTestCollection g_unittests = { nullptr };
 
 UnitTest::UnitTest(const char* name, const char* file, int line, TestFunction func)
@@ -32,14 +34,6 @@ void UnitTestParameters::set(const std::string& name, const std::string& value) 
 	params[name] = value;
 }
 
-Optional<std::string> UnitTestParameters::get(const std::string& name) const {
-	auto it = params.find(name);
-	if (it != params.end()) {
-		return it->second;
-	}
-	return {};
-}
-
 void UnitTestParameters::set(const std::string& name, int64_t value) {
 	set(name, format("%" PRId64, value));
 };
@@ -48,10 +42,18 @@ void UnitTestParameters::set(const std::string& name, double value) {
 	set(name, format("%g", value));
 };
 
+Optional<std::string> UnitTestParameters::get(const std::string& name) const {
+	auto it = params.find(name);
+	if (it != params.end()) {
+		return it->second;
+	}
+	return {};
+}
+
 Optional<int64_t> UnitTestParameters::getInt(const std::string& name) const {
 	auto opt = get(name);
 	if (opt.present()) {
-		return atoll(opt.get().c_str());
+		return static_cast<int64_t>(std::stoll(opt.get()));
 	}
 	return {};
 }
@@ -59,7 +61,7 @@ Optional<int64_t> UnitTestParameters::getInt(const std::string& name) const {
 Optional<double> UnitTestParameters::getDouble(const std::string& name) const {
 	auto opt = get(name);
 	if (opt.present()) {
-		return atof(opt.get().c_str());
+		return std::stod(opt.get());
 	}
 	return {};
 }

--- a/tests/ptxn/Driver.toml
+++ b/tests/ptxn/Driver.toml
@@ -7,3 +7,14 @@ startDelay = 0
     testName = 'UnitTests'
     maxTestCases = 1
     testsMatching = '/fdbserver/ptxn/test/driver'
+
+    numCommits = 20
+    numTeams = 20
+    numProxies = 1
+    numTLogs = 4
+    numStorageServers = 4
+    numResolvers = 10
+    # 0 stands for TLog --push--> StorageServer
+    # 1 stands for StorageServer --pull--> TLog
+    messageTransferModel = 0
+


### PR DESCRIPTION
This patch depends on #4617.

The PTXN Driver test is configurable via the Driver.toml, as illustrated
in this commit.


# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
