### PR TITLE
Revert "Changed code flow to fix loophole that avoided the knob guarding higher protocol versions"

### DIFF
--- a/fdbclient/Knobs.cpp
+++ b/fdbclient/Knobs.cpp
@@ -92,7 +92,7 @@ void ClientKnobs::initialize(bool randomize) {
 	init( STORAGE_METRICS_TOO_MANY_SHARDS_DELAY,  15.0 );
 	init( AGGREGATE_HEALTH_METRICS_MAX_STALENESS,  0.5 );
 	init( DETAILED_HEALTH_METRICS_MAX_STALENESS,   5.0 );
-	init( TAG_ENCODE_KEY_SERVERS,                false ); // Setting true will break 6.3->6.2 downgrade capability
+	init( TAG_ENCODE_KEY_SERVERS,                false ); if( randomize && BUGGIFY ) TAG_ENCODE_KEY_SERVERS = true;
 
 	//KeyRangeMap
 	init( KRM_GET_RANGE_LIMIT,                     1e5 ); if( randomize && BUGGIFY ) KRM_GET_RANGE_LIMIT = 10;

--- a/fdbserver/MoveKeys.actor.cpp
+++ b/fdbserver/MoveKeys.actor.cpp
@@ -18,7 +18,6 @@
  * limitations under the License.
  */
 
-#include "fdbclient/Knobs.h"
 #include "flow/Util.h"
 #include "fdbrpc/FailureMonitor.h"
 #include "fdbclient/SystemData.h"
@@ -1191,8 +1190,6 @@ ACTOR Future<Void> moveKeys(Database cx,
 	return Void();
 }
 
-// Called by the master server to write the very first transaction to the database
-// establishing a set of shard servers and all invariants of the systemKeys.
 void seedShardServers(Arena& arena, CommitTransactionRef& tr, vector<StorageServerInterface> servers) {
 	std::map<Optional<Value>, Tag> dcId_locality;
 	std::map<UID, Tag> server_tag;
@@ -1213,27 +1210,22 @@ void seedShardServers(Arena& arena, CommitTransactionRef& tr, vector<StorageServ
 	tr.read_snapshot = 0;
 	tr.read_conflict_ranges.push_back_deep(arena, allKeys);
 
-	for (auto& s : servers) {
-		tr.set(arena, serverTagKeyFor(s.id()), serverTagValue(server_tag[s.id()]));
-		tr.set(arena, serverListKeyFor(s.id()), serverListValue(s));
+	for (int s = 0; s < servers.size(); s++) {
+		tr.set(arena, serverTagKeyFor(servers[s].id()), serverTagValue(server_tag[servers[s].id()]));
+		tr.set(arena, serverListKeyFor(servers[s].id()), serverListValue(servers[s]));
 	}
 
 	std::vector<Tag> serverTags;
-	std::vector<UID> serverSrcUID;
-	for (auto& s : servers) {
-		serverTags.push_back(server_tag[s.id()]);
-		serverSrcUID.push_back(s.id());
-	}
-
-	auto ksValue = CLIENT_KNOBS->TAG_ENCODE_KEY_SERVERS ? keyServersValue(serverTags)
-	                                                    : keyServersValue(Standalone<RangeResultRef>(), serverSrcUID);
+	for (int i = 0; i < servers.size(); i++)
+		serverTags.push_back(server_tag[servers[i].id()]);
 
 	// We have to set this range in two blocks, because the master tracking of "keyServersLocations" depends on a change
 	// to a specific
 	//   key (keyServersKeyServersKey)
-	krmSetPreviouslyEmptyRange(tr, arena, keyServersPrefix, KeyRangeRef(KeyRef(), allKeys.end), ksValue, Value());
+	krmSetPreviouslyEmptyRange(
+	    tr, arena, keyServersPrefix, KeyRangeRef(KeyRef(), allKeys.end), keyServersValue(serverTags), Value());
 
-	for (auto& s : servers) {
-		krmSetPreviouslyEmptyRange(tr, arena, serverKeysPrefixFor(s.id()), allKeys, serverKeysTrue, serverKeysFalse);
-	}
+	for (int s = 0; s < servers.size(); s++)
+		krmSetPreviouslyEmptyRange(
+		    tr, arena, serverKeysPrefixFor(servers[s].id()), allKeys, serverKeysTrue, serverKeysFalse);
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -189,8 +189,8 @@ if(WITH_PYTHON)
     TEST_FILES restarting/from_5.2.0/ClientTransactionProfilingCorrectness-1.txt
                restarting/from_5.2.0/ClientTransactionProfilingCorrectness-2.txt)
   add_fdb_test(
-    TEST_FILES restarting/to_6.2.33/CycleTestRestart-1.txt
-               restarting/to_6.2.33/CycleTestRestart-2.txt)
+    TEST_FILES restarting/to_6.3.10/CycleTestRestart-1.txt
+               restarting/to_6.3.10/CycleTestRestart-2.txt)
   add_fdb_test(TEST_FILES slow/ApiCorrectness.txt)
   add_fdb_test(TEST_FILES slow/ApiCorrectnessAtomicRestore.txt)
   add_fdb_test(TEST_FILES slow/ApiCorrectnessSwitchover.txt)

--- a/tests/restarting/to_6.3.10/CycleTestRestart-1.txt
+++ b/tests/restarting/to_6.3.10/CycleTestRestart-1.txt
@@ -1,7 +1,7 @@
 testTitle=Clogged
-    runSetup=false
+    clearAfterTest=false
     testName=Cycle
-    transactionsPerSecond=2500.0
+    transactionsPerSecond=500.0
     nodeCount=2500
     testDuration=10.0
     expectedRate=0
@@ -23,4 +23,8 @@ testTitle=Clogged
     machinesToKill=10
     machinesToLeave=3
     reboot=true
+    testDuration=10.0
+
+    testName=SaveAndKill
+    restartInfoLocation=simfdb/restartInfo.ini
     testDuration=10.0

--- a/tests/restarting/to_6.3.10/CycleTestRestart-2.txt
+++ b/tests/restarting/to_6.3.10/CycleTestRestart-2.txt
@@ -1,7 +1,7 @@
 testTitle=Clogged
-    clearAfterTest=false
+    runSetup=false
     testName=Cycle
-    transactionsPerSecond=500.0
+    transactionsPerSecond=2500.0
     nodeCount=2500
     testDuration=10.0
     expectedRate=0
@@ -24,10 +24,3 @@ testTitle=Clogged
     machinesToLeave=3
     reboot=true
     testDuration=10.0
-
-    testName=SaveAndKill
-    restartInfoLocation=simfdb/restartInfo.ini
-    testDuration=10.0
-
-storageEngineExcludeTypes=2,3
-maxTLogVersion=4


### PR DESCRIPTION
Reverts apple/foundationdb#4469 due to nightly correctness failures in `20210423-044228-nightly_correctness_release-6.3-0daa283027479e7c`