### PR TITLE
Add /fdbclient/multiversionclient/ to ctest, and fix thread safety

### DIFF
--- a/fdbclient/MultiVersionTransaction.actor.cpp
+++ b/fdbclient/MultiVersionTransaction.actor.cpp
@@ -1987,6 +1987,9 @@ THREAD_FUNC runSingleAssignmentVarTest(void* arg) {
 			tf.validate();
 
 			tf.future.extractPtr(); // leaks
+			for (auto t : tf.threads) {
+				waitThread(t);
+			}
 		}
 
 		for (int numRuns = 0; numRuns < 25; ++numRuns) {
@@ -2057,11 +2060,13 @@ struct AbortableTest {
 
 TEST_CASE("/fdbclient/multiversionclient/AbortableSingleAssignmentVar") {
 	state volatile bool done = false;
-	g_network->startThread(runSingleAssignmentVarTest<AbortableTest>, (void*)&done);
+	state THREAD_HANDLE thread = g_network->startThread(runSingleAssignmentVarTest<AbortableTest>, (void*)&done);
 
 	while (!done) {
 		wait(delay(1.0));
 	}
+
+	waitThread(thread);
 
 	return Void();
 }
@@ -2134,19 +2139,23 @@ TEST_CASE("/fdbclient/multiversionclient/DLSingleAssignmentVar") {
 	state volatile bool done = false;
 
 	MultiVersionApi::api->callbackOnMainThread = true;
-	g_network->startThread(runSingleAssignmentVarTest<DLTest>, (void*)&done);
+	state THREAD_HANDLE thread = g_network->startThread(runSingleAssignmentVarTest<DLTest>, (void*)&done);
 
 	while (!done) {
 		wait(delay(1.0));
 	}
+
+	waitThread(thread);
 
 	done = false;
 	MultiVersionApi::api->callbackOnMainThread = false;
-	g_network->startThread(runSingleAssignmentVarTest<DLTest>, (void*)&done);
+	thread = g_network->startThread(runSingleAssignmentVarTest<DLTest>, (void*)&done);
 
 	while (!done) {
 		wait(delay(1.0));
 	}
+
+	waitThread(thread);
 
 	return Void();
 }
@@ -2172,11 +2181,13 @@ struct MapTest {
 
 TEST_CASE("/fdbclient/multiversionclient/MapSingleAssignmentVar") {
 	state volatile bool done = false;
-	g_network->startThread(runSingleAssignmentVarTest<MapTest>, (void*)&done);
+	state THREAD_HANDLE thread = g_network->startThread(runSingleAssignmentVarTest<MapTest>, (void*)&done);
 
 	while (!done) {
 		wait(delay(1.0));
 	}
+
+	waitThread(thread);
 
 	return Void();
 }
@@ -2209,11 +2220,13 @@ struct FlatMapTest {
 
 TEST_CASE("/fdbclient/multiversionclient/FlatMapSingleAssignmentVar") {
 	state volatile bool done = false;
-	g_network->startThread(runSingleAssignmentVarTest<FlatMapTest>, (void*)&done);
+	state THREAD_HANDLE thread = g_network->startThread(runSingleAssignmentVarTest<FlatMapTest>, (void*)&done);
 
 	while (!done) {
 		wait(delay(1.0));
 	}
+
+	waitThread(thread);
 
 	return Void();
 }

--- a/fdbclient/MultiVersionTransaction.actor.cpp
+++ b/fdbclient/MultiVersionTransaction.actor.cpp
@@ -1975,6 +1975,12 @@ ACTOR Future<Void> checkUndestroyedFutures(std::vector<ThreadSingleAssignmentVar
 	return Void();
 }
 
+// Common code for tests of single assignment vars. Tests both correctness and thread safety.
+// T should be a class that has a static method with the following signature:
+//
+//     static FutureInfo createThreadFuture(FutureInfo f);
+//
+// See AbortableTest for an example T type
 template <class T>
 THREAD_FUNC runSingleAssignmentVarTest(void* arg) {
 	noUnseed = true;

--- a/flow/FastRef.h
+++ b/flow/FastRef.h
@@ -36,20 +36,14 @@ public:
 		// The performance of this seems comparable to a version with less strict memory ordering (see e.g.
 		// https://www.boost.org/doc/libs/1_57_0/doc/html/atomic/usage_examples.html#boost_atomic.usage_examples.example_reference_counters),
 		// on both x86 and ARM, with gcc8.
-		if (referenceCount.fetch_sub(1) == 1) {
-			return true;
-		}
-		return false;
+		return referenceCount.fetch_sub(1) == 1;
 	}
 	void delref() const {
 		if (delref_no_destroy())
 			delete (Subclass*)this;
 	}
 	void setrefCountUnsafe(int32_t count) const { referenceCount.store(count); }
-	int32_t debugGetReferenceCount() const {
-		return referenceCount.load();
-	} // Never use in production code, only for tracing
-	bool isSoleOwnerUnsafe() const { return referenceCount.load() == 1; }
+	int32_t debugGetReferenceCount() const { return referenceCount.load(); }
 
 private:
 	ThreadSafeReferenceCounted(const ThreadSafeReferenceCounted&) /* = delete*/;

--- a/flow/FastRef.h
+++ b/flow/FastRef.h
@@ -25,6 +25,13 @@
 #include <atomic>
 #include <cstdint>
 
+// The thread safety this class provides is that it's safe to call addref and
+// delref on the same object concurrently in different threads. Subclass does
+// not get deleted until after all calls to delref complete.
+//
+// Importantly, this class does _not_ make accessing Subclass automatically
+// thread safe. Clients will need to provide their own external synchronization
+// for that.
 template <class Subclass>
 class ThreadSafeReferenceCounted {
 public:

--- a/flowbench/BenchRef.cpp
+++ b/flowbench/BenchRef.cpp
@@ -26,12 +26,14 @@
 #include <memory>
 
 struct Empty : public ReferenceCounted<Empty>, public FastAllocated<Empty> {};
+struct EmptyTSRC : public ThreadSafeReferenceCounted<EmptyTSRC>, public FastAllocated<EmptyTSRC> {};
 
 enum class RefType {
 	RawPointer,
 	UniquePointer,
 	SharedPointer,
 	FlowReference,
+	FlowReferenceThreadSafe,
 };
 
 template <RefType refType>
@@ -61,6 +63,12 @@ struct Factory<RefType::FlowReference> {
 	static void cleanup(const Reference<Empty>&) {}
 };
 
+template <>
+struct Factory<RefType::FlowReferenceThreadSafe> {
+	static Reference<EmptyTSRC> create() { return makeReference<EmptyTSRC>(); }
+	static void cleanup(const Reference<EmptyTSRC>&) {}
+};
+
 template <RefType refType>
 static void bench_ref_create_and_destroy(benchmark::State& state) {
 	while (state.KeepRunning()) {
@@ -86,7 +94,9 @@ BENCHMARK_TEMPLATE(bench_ref_create_and_destroy, RefType::RawPointer)->ReportAgg
 BENCHMARK_TEMPLATE(bench_ref_create_and_destroy, RefType::UniquePointer)->ReportAggregatesOnly(true);
 BENCHMARK_TEMPLATE(bench_ref_create_and_destroy, RefType::SharedPointer)->ReportAggregatesOnly(true);
 BENCHMARK_TEMPLATE(bench_ref_create_and_destroy, RefType::FlowReference)->ReportAggregatesOnly(true);
+BENCHMARK_TEMPLATE(bench_ref_create_and_destroy, RefType::FlowReferenceThreadSafe)->ReportAggregatesOnly(true);
 
 BENCHMARK_TEMPLATE(bench_ref_copy, RefType::RawPointer)->ReportAggregatesOnly(true);
 BENCHMARK_TEMPLATE(bench_ref_copy, RefType::SharedPointer)->ReportAggregatesOnly(true);
 BENCHMARK_TEMPLATE(bench_ref_copy, RefType::FlowReference)->ReportAggregatesOnly(true);
+BENCHMARK_TEMPLATE(bench_ref_copy, RefType::FlowReferenceThreadSafe)->ReportAggregatesOnly(true);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -261,6 +261,10 @@ if(WITH_PYTHON)
   add_fdb_test(TEST_FILES status/separate_not_enough_servers.txt)
   add_fdb_test(TEST_FILES status/single_process_too_many_config_params.txt)
 
+  add_test(
+    NAME multiversion_client/unit_tests
+    COMMAND $<TARGET_FILE:fdbserver> -r unittests -f /fdbclient/multiversionclient/
+  )
 
   verify_testing()
   if (NOT OPEN_FOR_IDE AND NOT WIN32)


### PR DESCRIPTION
Add some existing thread safety tests to ctest, so that if you build with -DUSE_TSAN=ON and run ctest, then these tests are also run.

Also change the implementation of ThreadSafeReferenceCounted so that the usage of debugGetReferenceCount in tests is thread safe.

Testing was done by running the /fdbclient/multiversionclient/ tests under TSAN, and also a small benchmark consisting of calling addref and delref in a loop in several threads shows this does not degrade performance on x86 or ARM.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
