### PR TITLE
Bugfixes/max durable write delay

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,4 @@ temp/
 /compile_commands.json
 /.ccls-cache
 .clangd/
+.cache/

--- a/flow/Knobs.cpp
+++ b/flow/Knobs.cpp
@@ -131,7 +131,7 @@ void FlowKnobs::initialize(bool randomize, bool isSimulated) {
 	init( DISABLE_POSIX_KERNEL_AIO,                              0 );
 
 	//AsyncFileNonDurable
-	init( NON_DURABLE_MAX_WRITE_DELAY,                         5.0 );
+	init( NON_DURABLE_MAX_WRITE_DELAY,                         2.0 ); if( randomize && BUGGIFY ) NON_DURABLE_MAX_WRITE_DELAY = 5.0;
 	init( MAX_PRIOR_MODIFICATION_DELAY,                        1.0 ); if( randomize && BUGGIFY ) MAX_PRIOR_MODIFICATION_DELAY = 10.0;
 
 	//GenericActors


### PR DESCRIPTION
Backport of a change from #4695 which sets the default value of the `NON_DURABLE_MAX_WRITE_DELAY` knob to 2.0 and the buggified value to 5.0.

This has been tested extensively on `master`.

<img width="531" alt="image" src="https://user-images.githubusercontent.com/65370928/116426639-86cd4d00-a800-11eb-9c36-20beae23d304.png">


# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
