### PR TITLE
Improve load balancing performance (release-6.3)

### DIFF
--- a/fdbrpc/LoadBalance.actor.h
+++ b/fdbrpc/LoadBalance.actor.h
@@ -75,109 +75,169 @@ struct LoadBalancedReply {
 Optional<LoadBalancedReply> getLoadBalancedReply(const LoadBalancedReply* reply);
 Optional<LoadBalancedReply> getLoadBalancedReply(const void*);
 
-// Returns true if we got a value for our request
-// Throws an error if the request returned an error that should bubble out
-// Returns false if we got an error that should result in reissuing the request
-template <class T>
-bool checkAndProcessResult(ErrorOr<T> result, Reference<ModelHolder> holder, bool atMostOnce, bool triedAllOptions) {
-	Optional<LoadBalancedReply> loadBalancedReply;
-	if (!result.isError()) {
-		loadBalancedReply = getLoadBalancedReply(&result.get());
+// Stores state for a request made by the load balancer
+template <class Request>
+struct RequestData : NonCopyable {
+	Future<ErrorOr<REPLY_TYPE(Request)>> response;
+	Reference<ModelHolder> modelHolder;
+	Future<Void> backoffDelay;
+	RequestStream<Request> const* stream = nullptr;
+	bool triedAllOptions = false;
+
+	bool requestStarted = false; // true once the request has been sent to an alternative
+	bool requestProcessed = false; // true once a response has been received and handled by checkAndProcessResult
+
+	// Whether or not the response future is valid
+	// This is true once setupRequest is called, even though at that point the response is Never().
+	bool isValid() { return response.isValid(); }
+
+	// Initializes the request state and starts the backoff delay
+	void setupRequest(double backoff, bool triedAllOptions, RequestStream<Request> const* stream) {
+		backoffDelay = (backoff > 0) ? delay(backoff) : Void();
+		response = Never();
+		modelHolder = Reference<ModelHolder>();
+		requestStarted = false;
+		requestProcessed = false;
+
+		this->stream = stream;
+		this->triedAllOptions = triedAllOptions;
 	}
 
-	int errCode;
-	if (loadBalancedReply.present()) {
-		errCode =
-		    loadBalancedReply.get().error.present() ? loadBalancedReply.get().error.get().code() : error_code_success;
-	} else {
-		errCode = result.isError() ? result.getError().code() : error_code_success;
+	// Sends the request to the configured stream
+	// This should not be called until after setupRequest has been called and the backoff delay has elapsed
+	void startRequest(Request request, QueueModel* model) {
+		ASSERT(stream);
+		ASSERT(backoffDelay.isReady());
+
+		backoffDelay = Never();
+		modelHolder = Reference<ModelHolder>(new ModelHolder(model, stream->getEndpoint().token.first()));
+		response = stream->tryGetReply(request);
+		requestStarted = true;
 	}
 
-	bool maybeDelivered = errCode == error_code_broken_promise || errCode == error_code_request_maybe_delivered;
-	bool receivedResponse = loadBalancedReply.present() ? !loadBalancedReply.get().error.present() : result.present();
-	receivedResponse = receivedResponse || (!maybeDelivered && errCode != error_code_process_behind);
-	bool futureVersion = errCode == error_code_future_version || errCode == error_code_process_behind;
+	// Implementation of the logic to handle a response.
+	// Checks the state of the response, updates the queue model, and returns one of the following outcomes:
+	// A return value of true means that the request completed successfully
+	// A return value of false means that the request failed but should be retried
+	// A return value with an error means that the error should be thrown back to original caller
+	static ErrorOr<bool> checkAndProcessResultImpl(ErrorOr<REPLY_TYPE(Request)> result,
+	                                               Reference<ModelHolder> modelHolder,
+	                                               bool atMostOnce,
+	                                               bool triedAllOptions) {
+		ASSERT(modelHolder);
 
-	holder->release(
-	    receivedResponse, futureVersion, loadBalancedReply.present() ? loadBalancedReply.get().penalty : -1.0);
+		Optional<LoadBalancedReply> loadBalancedReply;
+		if (!result.isError()) {
+			loadBalancedReply = getLoadBalancedReply(&result.get());
+		}
 
-	if (errCode == error_code_server_overloaded) {
+		int errCode;
+		if (loadBalancedReply.present()) {
+			errCode = loadBalancedReply.get().error.present() ? loadBalancedReply.get().error.get().code()
+			                                                  : error_code_success;
+		} else {
+			errCode = result.isError() ? result.getError().code() : error_code_success;
+		}
+
+		bool maybeDelivered = errCode == error_code_broken_promise || errCode == error_code_request_maybe_delivered;
+		bool receivedResponse =
+		    loadBalancedReply.present() ? !loadBalancedReply.get().error.present() : result.present();
+		receivedResponse = receivedResponse || (!maybeDelivered && errCode != error_code_process_behind);
+		bool futureVersion = errCode == error_code_future_version || errCode == error_code_process_behind;
+
+		modelHolder->release(
+		    receivedResponse, futureVersion, loadBalancedReply.present() ? loadBalancedReply.get().penalty : -1.0);
+
+		if (errCode == error_code_server_overloaded) {
+			return false;
+		}
+
+		if (loadBalancedReply.present() && !loadBalancedReply.get().error.present()) {
+			return true;
+		}
+
+		if (!loadBalancedReply.present() && result.present()) {
+			return true;
+		}
+
+		if (receivedResponse) {
+			return loadBalancedReply.present() ? loadBalancedReply.get().error.get() : result.getError();
+		}
+
+		if (atMostOnce && maybeDelivered) {
+			return request_maybe_delivered();
+		}
+
+		if (triedAllOptions && errCode == error_code_process_behind) {
+			return process_behind();
+		}
+
 		return false;
 	}
 
-	if (loadBalancedReply.present() && !loadBalancedReply.get().error.present()) {
-		return true;
+	// Checks the state of the response, updates the queue model, and returns one of the following outcomes:
+	// A return value of true means that the request completed successfully
+	// A return value of false means that the request failed but should be retried
+	// In the event of a non-retryable failure, an error is thrown indicating the failure
+	bool checkAndProcessResult(bool atMostOnce) {
+		ASSERT(response.isReady());
+		requestProcessed = true;
+
+		ErrorOr<bool> outcome =
+		    checkAndProcessResultImpl(response.get(), std::move(modelHolder), atMostOnce, triedAllOptions);
+
+		if (outcome.isError()) {
+			throw outcome.getError();
+		} else if (!outcome.get()) {
+			response = Future<ErrorOr<REPLY_TYPE(Request)>>();
+		}
+
+		return outcome.get();
 	}
 
-	if (!loadBalancedReply.present() && result.present()) {
-		return true;
+	// Convert this request to a lagging request. Such a request is no longer being waited on, but it still needs to be
+	// processed so we can update the queue model.
+	void makeLaggingRequest() {
+		ASSERT(response.isValid());
+		ASSERT(!response.isReady());
+		ASSERT(modelHolder);
+		ASSERT(modelHolder->model);
+
+		QueueModel* model = modelHolder->model;
+		if (model->laggingRequestCount > FLOW_KNOBS->MAX_LAGGING_REQUESTS_OUTSTANDING ||
+		    model->laggingRequests.isReady()) {
+			model->laggingRequests.cancel();
+			model->laggingRequestCount = 0;
+			model->addActor = PromiseStream<Future<Void>>();
+			model->laggingRequests = actorCollection(model->addActor.getFuture(), &model->laggingRequestCount);
+		}
+
+		// We need to process the lagging request in order to update the queue model
+		Reference<ModelHolder> holderCapture = std::move(modelHolder);
+		bool triedAllOptionsCapture = triedAllOptions;
+		Future<Void> updateModel =
+		    map(response, [holderCapture, triedAllOptionsCapture](ErrorOr<REPLY_TYPE(Request)> result) {
+			    checkAndProcessResultImpl(result, holderCapture, false, triedAllOptionsCapture);
+			    return Void();
+		    });
+		model->addActor.send(updateModel);
 	}
 
-	if (receivedResponse) {
-		throw loadBalancedReply.present() ? loadBalancedReply.get().error.get() : result.getError();
-	}
-
-	if (atMostOnce && maybeDelivered) {
-		throw request_maybe_delivered();
-	}
-
-	if (triedAllOptions && errCode == error_code_process_behind) {
-		throw process_behind();
-	}
-
-	return false;
-}
-
-ACTOR template <class Request>
-Future<Optional<REPLY_TYPE(Request)>> makeRequest(RequestStream<Request> const* stream,
-                                                  Request request,
-                                                  double backoff,
-                                                  Future<Void> requestUnneeded,
-                                                  QueueModel* model,
-                                                  bool isFirstRequest,
-                                                  bool atMostOnce,
-                                                  bool triedAllOptions) {
-	if (backoff > 0.0) {
-		wait(delay(backoff) || requestUnneeded);
-	}
-
-	if (requestUnneeded.isReady()) {
-		return Optional<REPLY_TYPE(Request)>();
-	}
-
-	state Reference<ModelHolder> holder(new ModelHolder(model, stream->getEndpoint().token.first()));
-
-	ErrorOr<REPLY_TYPE(Request)> result = wait(stream->tryGetReply(request));
-	if (checkAndProcessResult(result, holder, atMostOnce, triedAllOptions)) {
-		return result.get();
-	} else {
-		return Optional<REPLY_TYPE(Request)>();
-	}
-}
-
-template <class Reply>
-void addLaggingRequest(Future<Optional<Reply>> reply, Promise<Void> requestFinished, QueueModel* model) {
-	requestFinished.send(Void());
-	if (!reply.isReady()) {
-		if (model) {
-			if (model->laggingRequestCount > FLOW_KNOBS->MAX_LAGGING_REQUESTS_OUTSTANDING ||
-			    model->laggingRequests.isReady()) {
-				model->laggingRequests.cancel();
-				model->laggingRequestCount = 0;
-				model->addActor = PromiseStream<Future<Void>>();
-				model->laggingRequests = actorCollection(model->addActor.getFuture(), &model->laggingRequestCount);
-			}
-
-			model->addActor.send(success(errorOr(reply)));
+	~RequestData() {
+		// If the request has been started but hasn't completed, mark it as a lagging request
+		if (requestStarted && !requestProcessed && modelHolder && modelHolder->model) {
+			makeLaggingRequest();
 		}
 	}
-}
+};
 
-// Keep trying to get a reply from any of servers until success or cancellation; tries to take into account
-//   failMon's information for load balancing and avoiding failed servers
+// Try to get a reply from one of the alternatives until success, cancellation, or certain errors.
+// Load balancing has a budget to race requests to a second alternative if the first request is slow.
+// Tries to take into account failMon's information for load balancing and avoiding failed servers.
 // If ALL the servers are failed and the list of servers is not fresh, throws an exception to let the caller refresh the
-// list of servers. When model is set, load balance among alternatives in the same DC, aiming to balance request queue
-// length on these interfaces. If too many interfaces in the same DC are bad, try remote interfaces.
+// list of servers.
+// When model is set, load balance among alternatives in the same DC aims to balance request queue length on these
+// interfaces. If too many interfaces in the same DC are bad, try remote interfaces.
 ACTOR template <class Interface, class Request, class Multi>
 Future<REPLY_TYPE(Request)> loadBalance(
     Reference<MultiInterface<Multi>> alternatives,
@@ -185,10 +245,12 @@ Future<REPLY_TYPE(Request)> loadBalance(
     Request request = Request(),
     TaskPriority taskID = TaskPriority::DefaultPromiseEndpoint,
     bool atMostOnce = false, // if true, throws request_maybe_delivered() instead of retrying automatically
-    QueueModel* model = NULL) {
-	state Future<Optional<REPLY_TYPE(Request)>> firstRequest;
+    QueueModel* model = nullptr) {
+
+	state RequestData<Request> firstRequestData;
+	state RequestData<Request> secondRequestData;
+
 	state Optional<uint64_t> firstRequestEndpoint;
-	state Future<Optional<REPLY_TYPE(Request)>> secondRequest;
 	state Future<Void> secondDelay = Never();
 
 	state Promise<Void> requestFinished;
@@ -320,7 +382,7 @@ Future<REPLY_TYPE(Request)> loadBalance(
 		}
 
 		// Find an alternative, if any, that is not failed, starting with
-		// nextAlt. This logic matters only if model == NULL. Otherwise, the
+		// nextAlt. This logic matters only if model == nullptr. Otherwise, the
 		// bestAlt and nextAlt have been decided.
 		state RequestStream<Request> const* stream = NULL;
 		for (int alternativeNum = 0; alternativeNum < alternatives->size(); alternativeNum++) {
@@ -340,7 +402,7 @@ Future<REPLY_TYPE(Request)> loadBalance(
 			stream = NULL;
 		}
 
-		if (!stream && !firstRequest.isValid()) {
+		if (!stream && !firstRequestData.isValid()) {
 			// Everything is down!  Wait for someone to be up.
 
 			vector<Future<Void>> ok(alternatives->size());
@@ -391,50 +453,40 @@ Future<REPLY_TYPE(Request)> loadBalance(
 			numAttempts = 0; // now that we've got a server back, reset the backoff
 		} else if (!stream) {
 			// Only the first location is available.
-			Optional<REPLY_TYPE(Request)> result = wait(firstRequest);
-			if (result.present()) {
-				return result.get();
-			}
+			loop choose {
+				when(wait(firstRequestData.backoffDelay)) { firstRequestData.startRequest(request, model); }
+				when(ErrorOr<REPLY_TYPE(Request)> result = wait(firstRequestData.response)) {
+					if (firstRequestData.checkAndProcessResult(atMostOnce)) {
+						return result.get();
+					}
 
-			firstRequest = Future<Optional<REPLY_TYPE(Request)>>();
-			firstRequestEndpoint = Optional<uint64_t>();
-		} else if (firstRequest.isValid()) {
+					firstRequestEndpoint = Optional<uint64_t>();
+					break;
+				}
+			}
+		} else if (firstRequestData.isValid()) {
 			// Issue a second request, the first one is taking a long time.
-			secondRequest = makeRequest(
-			    stream, request, backoff, requestFinished.getFuture(), model, false, atMostOnce, triedAllOptions);
+			secondRequestData.setupRequest(backoff, triedAllOptions, stream);
 			state bool firstFinished = false;
 
-			loop {
-				choose {
-					when(ErrorOr<Optional<REPLY_TYPE(Request)>> result =
-					         wait(firstRequest.isValid() ? errorOr(firstRequest) : Never())) {
-						if (result.isError() || result.get().present()) {
-							addLaggingRequest(secondRequest, requestFinished, model);
-							if (result.isError()) {
-								throw result.getError();
-							} else {
-								return result.get().get();
-							}
-						}
-
-						firstRequest = Future<Optional<REPLY_TYPE(Request)>>();
-						firstRequestEndpoint = Optional<uint64_t>();
-						firstFinished = true;
+			loop choose {
+				when(wait(firstRequestData.backoffDelay)) { firstRequestData.startRequest(request, model); }
+				when(wait(secondRequestData.backoffDelay)) { secondRequestData.startRequest(request, model); }
+				when(ErrorOr<REPLY_TYPE(Request)> result =
+				         wait(firstRequestData.response.isValid() ? firstRequestData.response : Never())) {
+					if (firstRequestData.checkAndProcessResult(atMostOnce)) {
+						return result.get();
 					}
-					when(ErrorOr<Optional<REPLY_TYPE(Request)>> result = wait(errorOr(secondRequest))) {
-						if (result.isError() || result.get().present()) {
-							if (!firstFinished) {
-								addLaggingRequest(firstRequest, requestFinished, model);
-							}
-							if (result.isError()) {
-								throw result.getError();
-							} else {
-								return result.get().get();
-							}
-						}
 
-						break;
+					firstRequestEndpoint = Optional<uint64_t>();
+					firstFinished = true;
+				}
+				when(ErrorOr<REPLY_TYPE(Request)> result = wait(secondRequestData.response)) {
+					if (secondRequestData.checkAndProcessResult(atMostOnce)) {
+						return result.get();
 					}
+
+					break;
 				}
 			}
 
@@ -445,13 +497,13 @@ Future<REPLY_TYPE(Request)> loadBalance(
 			}
 		} else {
 			// Issue a request, if it takes too long to get a reply, go around the loop
-			firstRequest = makeRequest(
-			    stream, request, backoff, requestFinished.getFuture(), model, true, atMostOnce, triedAllOptions);
+			firstRequestData.setupRequest(backoff, triedAllOptions, stream);
 			firstRequestEndpoint = stream->getEndpoint().token.first();
 
 			loop {
 				choose {
-					when(ErrorOr<Optional<REPLY_TYPE(Request)>> result = wait(errorOr(firstRequest))) {
+					when(wait(firstRequestData.backoffDelay)) { firstRequestData.startRequest(request, model); }
+					when(ErrorOr<REPLY_TYPE(Request)> result = wait(firstRequestData.response)) {
 						if (model) {
 							model->secondMultiplier =
 							    std::max(model->secondMultiplier - FLOW_KNOBS->SECOND_REQUEST_MULTIPLIER_DECAY, 1.0);
@@ -460,15 +512,10 @@ Future<REPLY_TYPE(Request)> loadBalance(
 							             FLOW_KNOBS->SECOND_REQUEST_MAX_BUDGET);
 						}
 
-						if (result.isError()) {
-							throw result.getError();
+						if (firstRequestData.checkAndProcessResult(atMostOnce)) {
+							return result.get();
 						}
 
-						if (result.get().present()) {
-							return result.get().get();
-						}
-
-						firstRequest = Future<Optional<REPLY_TYPE(Request)>>();
 						firstRequestEndpoint = Optional<uint64_t>();
 						break;
 					}

--- a/fdbrpc/LoadBalance.actor.h
+++ b/fdbrpc/LoadBalance.actor.h
@@ -122,7 +122,7 @@ struct RequestData : NonCopyable {
 	// A return value of true means that the request completed successfully
 	// A return value of false means that the request failed but should be retried
 	// A return value with an error means that the error should be thrown back to original caller
-	static ErrorOr<bool> checkAndProcessResultImpl(Reply result,
+	static ErrorOr<bool> checkAndProcessResultImpl(Reply const& result,
 	                                               Reference<ModelHolder> modelHolder,
 	                                               bool atMostOnce,
 	                                               bool triedAllOptions) {


### PR DESCRIPTION
This is a backport of #4561 being done to fix a performance regression that impacts 6.3 clusters.

Between FDB 3 and FDB 6, load balancing got more expensive, causing a reduction in client throughput. This seems to be largely because an extra actor was added to the call stack in FDB 6.

This PR refactors load balancing to remove the makeRequest actor in an attempt to recapture that lost performance.

This has been tested with a few synthetic performance workloads, and the results demonstrated that the performance of this code is almost as good as the FDB 3 load balancing (75+% of the gap has closed) without removing any of the new logic.

Correctness passed 100K tests.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [x] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
