### PR TITLE
Added a new option to bypass unreadable protection in read your writes for calls to get

### DIFF
--- a/fdbclient/RYWIterator.cpp
+++ b/fdbclient/RYWIterator.cpp
@@ -42,7 +42,7 @@ const RYWIterator::SEGMENT_TYPE RYWIterator::typeMap[12] = {
 };
 
 RYWIterator::SEGMENT_TYPE RYWIterator::type() const {
-	if (is_unreadable())
+	if (is_unreadable() && !bypassUnreadable)
 		throw accessed_unreadable();
 
 	return typeMap[writes.type() * 3 + cache.type()];
@@ -72,7 +72,7 @@ ExtStringRef RYWIterator::endKey() {
 }
 
 const KeyValueRef* RYWIterator::kv(Arena& arena) {
-	if (is_unreadable())
+	if (is_unreadable() && !bypassUnreadable)
 		throw accessed_unreadable();
 
 	if (writes.is_unmodified_range()) {

--- a/fdbclient/RYWIterator.h
+++ b/fdbclient/RYWIterator.h
@@ -28,7 +28,7 @@
 class RYWIterator {
 public:
 	RYWIterator(SnapshotCache* snapshotCache, WriteMap* writeMap)
-	  : cache(snapshotCache), writes(writeMap), begin_key_cmp(0), end_key_cmp(0) {}
+	  : cache(snapshotCache), writes(writeMap), begin_key_cmp(0), end_key_cmp(0), bypassUnreadable(false) {}
 
 	enum SEGMENT_TYPE { UNKNOWN_RANGE, EMPTY_RANGE, KV };
 	static const SEGMENT_TYPE typeMap[12];
@@ -59,6 +59,8 @@ public:
 
 	void skipContiguousBack(KeyRef key);
 
+	void bypassUnreadableProtection() { bypassUnreadable = true; }
+
 	WriteMap::iterator& extractWriteMapIterator();
 	// Really this should return an iterator by value, but for performance it's convenient to actually grab the internal
 	// one.  Consider copying the return value if performance isn't critical. If you modify the returned iterator, it
@@ -72,6 +74,7 @@ private:
 	SnapshotCache::iterator cache;
 	WriteMap::iterator writes;
 	KeyValueRef temp;
+	bool bypassUnreadable;
 
 	void updateCmp();
 };

--- a/fdbclient/RYWIterator.h
+++ b/fdbclient/RYWIterator.h
@@ -74,7 +74,8 @@ private:
 	SnapshotCache::iterator cache;
 	WriteMap::iterator writes;
 	KeyValueRef temp;
-	bool bypassUnreadable;
+	bool bypassUnreadable; // When set, allows read from sections of keyspace that have become unreadable because of
+	                       // versionstamp operations
 
 	void updateCmp();
 };

--- a/fdbclient/ReadYourWrites.actor.cpp
+++ b/fdbclient/ReadYourWrites.actor.cpp
@@ -84,6 +84,9 @@ public:
 	static Future<Optional<Value>> read(ReadYourWritesTransaction* ryw, GetValueReq read, Iter* it) {
 		// This overload is required to provide postcondition: it->extractWriteMapIterator().segmentContains(read.key)
 
+		if (ryw->options.bypassUnreadable) {
+			it->bypassUnreadableProtection();
+		}
 		it->skip(read.key);
 		state bool dependent = it->is_dependent();
 		if (it->is_kv()) {
@@ -2236,6 +2239,11 @@ void ReadYourWritesTransaction::setOptionImpl(FDBTransactionOptions::Option opti
 	case FDBTransactionOptions::SPECIAL_KEY_SPACE_ENABLE_WRITES:
 		validateOptionValue(value, false);
 		options.specialKeySpaceChangeConfiguration = true;
+		break;
+	case FDBTransactionOptions::BYPASS_UNREADABLE:
+		validateOptionValue(value, false);
+		TraceEvent("ReadVersionStampValueOptionSet");
+		options.bypassUnreadable = true;
 		break;
 	default:
 		break;

--- a/fdbclient/ReadYourWrites.actor.cpp
+++ b/fdbclient/ReadYourWrites.actor.cpp
@@ -2242,7 +2242,6 @@ void ReadYourWritesTransaction::setOptionImpl(FDBTransactionOptions::Option opti
 		break;
 	case FDBTransactionOptions::BYPASS_UNREADABLE:
 		validateOptionValue(value, false);
-		TraceEvent("ReadVersionStampValueOptionSet");
 		options.bypassUnreadable = true;
 		break;
 	default:

--- a/fdbclient/ReadYourWrites.h
+++ b/fdbclient/ReadYourWrites.h
@@ -42,6 +42,7 @@ struct ReadYourWritesTransactionOptions {
 	double timeoutInSeconds;
 	int maxRetries;
 	int snapshotRywEnabled;
+	bool bypassUnreadable : 1;
 
 	ReadYourWritesTransactionOptions() {}
 	explicit ReadYourWritesTransactionOptions(Transaction const& tr);

--- a/fdbclient/SnapshotCache.h
+++ b/fdbclient/SnapshotCache.h
@@ -203,6 +203,7 @@ public:
 		bool is_empty_range() const { return type() == EMPTY_RANGE; }
 		bool is_dependent() const { return false; }
 		bool is_unreadable() const { return false; }
+		void bypassUnreadableProtection() {}
 
 		ExtStringRef beginKey() const {
 			if (offset == 0) {

--- a/fdbclient/vexillographer/fdb.options
+++ b/fdbclient/vexillographer/fdb.options
@@ -193,7 +193,7 @@ description is not currently required but encouraged.
     <Option name="distributed_transaction_trace_disable" code="601"
             description="Disable tracing for all transactions." />
     <Option name="transaction_bypass_unreadable" code="700"
-            description="Allows ``get`` operations to read from sections of keyspace that have become unreadable because of versionstamp operations."
+            description="Allows ``get`` operations to read from sections of keyspace that have become unreadable because of versionstamp operations. This sets the ``bypass_unreadable`` option of each transaction created by this database. See the transaction option description for more information."
             defaultFor="1100"/>
   </Scope>
   
@@ -288,7 +288,7 @@ description is not currently required but encouraged.
     <Option name="expensive_clear_cost_estimation_enable" code="1000"
                 description="Asks storage servers for how many bytes a clear key range contains. Otherwise uses the location cache to roughly estimate this." />
     <Option name="bypass_unreadable" code="1100"
-                description="Allows ``get`` operations to read from sections of keyspace that have become unreadable because of versionstamp operations." />            
+                description="Allows ``get`` operations to read from sections of keyspace that have become unreadable because of versionstamp operations. These reads will view versionstamp operations as if they were set operations." />            
   </Scope>
 
   <!-- The enumeration values matter - do not change them without

--- a/fdbclient/vexillographer/fdb.options
+++ b/fdbclient/vexillographer/fdb.options
@@ -288,7 +288,7 @@ description is not currently required but encouraged.
     <Option name="expensive_clear_cost_estimation_enable" code="1000"
                 description="Asks storage servers for how many bytes a clear key range contains. Otherwise uses the location cache to roughly estimate this." />
     <Option name="bypass_unreadable" code="1100"
-                description="Allows ``get`` operations to read from sections of keyspace that have become unreadable because of versionstamp operations. These reads will view versionstamp operations as if they were set operations." />            
+                description="Allows ``get`` operations to read from sections of keyspace that have become unreadable because of versionstamp operations. These reads will view versionstamp operations as if they were set operations that did not fill in the versionstamp." />            
   </Scope>
 
   <!-- The enumeration values matter - do not change them without

--- a/fdbclient/vexillographer/fdb.options
+++ b/fdbclient/vexillographer/fdb.options
@@ -192,6 +192,9 @@ description is not currently required but encouraged.
             description="Enable tracing for all transactions. This is the default." />
     <Option name="distributed_transaction_trace_disable" code="601"
             description="Disable tracing for all transactions." />
+    <Option name="transaction_bypass_unreadable" code="700"
+            description="Allows ``get`` operations to read from sections of keyspace that have become unreadable because of versionstamp operations."
+            defaultFor="1100"/>
   </Scope>
   
   <Scope name="TransactionOption">
@@ -284,6 +287,8 @@ description is not currently required but encouraged.
             description="Adds a parent to the Span of this transaction. Used for transaction tracing. A span can be identified with any 16 bytes"/>
     <Option name="expensive_clear_cost_estimation_enable" code="1000"
                 description="Asks storage servers for how many bytes a clear key range contains. Otherwise uses the location cache to roughly estimate this." />
+    <Option name="bypass_unreadable" code="1100"
+                description="Allows ``get`` operations to read from sections of keyspace that have become unreadable because of versionstamp operations." />            
   </Scope>
 
   <!-- The enumeration values matter - do not change them without

--- a/fdbserver/workloads/Unreadable.actor.cpp
+++ b/fdbserver/workloads/Unreadable.actor.cpp
@@ -313,6 +313,10 @@ struct UnreadableWorkload : TestWorkload {
 			state bool snapshot;
 			state KeySelectorRef begin;
 			state KeySelectorRef end;
+			state bool bypassUnreadable = deterministicRandom()->coinflip();
+			if (readVerisonStampValues) {
+				tr.setOption(FDBTransactionOptions::BYPASS_UNREADABLE);
+			}
 
 			setMap[normalKeys.begin] = ValueRef();
 			setMap[normalKeys.end] = ValueRef();
@@ -377,6 +381,9 @@ struct UnreadableWorkload : TestWorkload {
 						setMap = std::map<KeyRef, ValueRef>();
 						unreadableMap = KeyRangeMap<bool>();
 						tr = ReadYourWritesTransaction(cx);
+						if (bypassUnreadable) {
+							tr.setOption(FDBTransactionOptions::BYPASS_UNREADABLE);
+						}
 						arena = Arena();
 
 						setMap[normalKeys.begin] = ValueRef();
@@ -422,6 +429,9 @@ struct UnreadableWorkload : TestWorkload {
 						setMap = std::map<KeyRef, ValueRef>();
 						unreadableMap = KeyRangeMap<bool>();
 						tr = ReadYourWritesTransaction(cx);
+						if (bypassUnreadable) {
+							tr.setOption(FDBTransactionOptions::BYPASS_UNREADABLE);
+						}
 						arena = Arena();
 
 						setMap[normalKeys.begin] = ValueRef();
@@ -441,7 +451,7 @@ struct UnreadableWorkload : TestWorkload {
 
 					if (!value.isError() || value.getError().code() == error_code_accessed_unreadable) {
 						//TraceEvent("RYWT_Get").detail("Key", printable(key)).detail("IsUnreadable", value.isError());
-						if (snapshot) {
+						if (snapshot || bypassUnreadable) {
 							ASSERT(!value.isError());
 						} else {
 							ASSERT(unreadableMap[key] == value.isError());
@@ -451,6 +461,9 @@ struct UnreadableWorkload : TestWorkload {
 						setMap = std::map<KeyRef, ValueRef>();
 						unreadableMap = KeyRangeMap<bool>();
 						tr = ReadYourWritesTransaction(cx);
+						if (bypassUnreadable) {
+							tr.setOption(FDBTransactionOptions::BYPASS_UNREADABLE);
+						}
 						arena = Arena();
 
 						setMap[normalKeys.begin] = ValueRef();

--- a/fdbserver/workloads/Unreadable.actor.cpp
+++ b/fdbserver/workloads/Unreadable.actor.cpp
@@ -314,7 +314,7 @@ struct UnreadableWorkload : TestWorkload {
 			state KeySelectorRef begin;
 			state KeySelectorRef end;
 			state bool bypassUnreadable = deterministicRandom()->coinflip();
-			if (readVerisonStampValues) {
+			if (bypassUnreadable) {
 				tr.setOption(FDBTransactionOptions::BYPASS_UNREADABLE);
 			}
 


### PR DESCRIPTION
The main use case for this option is to read your writes for incomplete SetVersionstampValue atomic operations.

4 failures out of 200k, none of them are new.


# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
