### PR TITLE
Adding TraceEvent when a worker is removed from cluster controller.

### DIFF
--- a/fdbserver/ClusterController.actor.cpp
+++ b/fdbserver/ClusterController.actor.cpp
@@ -3096,9 +3096,9 @@ ACTOR Future<Void> workerAvailabilityWatch(WorkerInterface worker,
 				cluster->id_worker.erase(worker.locality.processId());
 				cluster->updateWorkerList.set(worker.locality.processId(), Optional<ProcessData>());
 				TraceEvent("ClusterControllerWorkerFailed", cluster->id)
-					.detail("WorkerProcessId", worker.locality.processId())
-					.detail("WorkerProcessClass", failedWorkerInfo.details.processClass.toString())
-					.detail("WorkerAddress", worker.address());
+					.detail("ProcessId", worker.locality.processId())
+					.detail("ProcessClass", failedWorkerInfo.details.processClass.toString())
+					.detail("Address", worker.address());
 				return Void();
 			}
 		}

--- a/fdbserver/ClusterController.actor.cpp
+++ b/fdbserver/ClusterController.actor.cpp
@@ -3095,7 +3095,10 @@ ACTOR Future<Void> workerAvailabilityWatch(WorkerInterface worker,
 				cluster->removedDBInfoEndpoints.insert(worker.updateServerDBInfo.getEndpoint());
 				cluster->id_worker.erase(worker.locality.processId());
 				cluster->updateWorkerList.set(worker.locality.processId(), Optional<ProcessData>());
-				TraceEvent("ClusterFailedWorker", cluster->id).detail("WorkerProcessId", worker.locality.processId());
+				TraceEvent("ClusterControllerWorkerFailed", cluster->id)
+					.detail("WorkerProcessId", worker.locality.processId())
+					.detail("WorkerProcessClass", failedWorkerInfo.details.processClass.toString())
+					.detail("WorkerAddress", worker.address());
 				return Void();
 			}
 		}

--- a/fdbserver/ClusterController.actor.cpp
+++ b/fdbserver/ClusterController.actor.cpp
@@ -3095,6 +3095,7 @@ ACTOR Future<Void> workerAvailabilityWatch(WorkerInterface worker,
 				cluster->removedDBInfoEndpoints.insert(worker.updateServerDBInfo.getEndpoint());
 				cluster->id_worker.erase(worker.locality.processId());
 				cluster->updateWorkerList.set(worker.locality.processId(), Optional<ProcessData>());
+				TraceEvent("ClusterFailedWorker", cluster->id).detail("WorkerProcessId", worker.locality.processId());
 				return Void();
 			}
 		}

--- a/fdbserver/ClusterController.actor.cpp
+++ b/fdbserver/ClusterController.actor.cpp
@@ -3092,13 +3092,13 @@ ACTOR Future<Void> workerAvailabilityWatch(WorkerInterface worker,
 				if (worker.locality.processId() == cluster->masterProcessId) {
 					cluster->masterProcessId = Optional<Key>();
 				}
-				cluster->removedDBInfoEndpoints.insert(worker.updateServerDBInfo.getEndpoint());
-				cluster->id_worker.erase(worker.locality.processId());
-				cluster->updateWorkerList.set(worker.locality.processId(), Optional<ProcessData>());
 				TraceEvent("ClusterControllerWorkerFailed", cluster->id)
 					.detail("ProcessId", worker.locality.processId())
 					.detail("ProcessClass", failedWorkerInfo.details.processClass.toString())
 					.detail("Address", worker.address());
+				cluster->removedDBInfoEndpoints.insert(worker.updateServerDBInfo.getEndpoint());
+				cluster->id_worker.erase(worker.locality.processId());
+				cluster->updateWorkerList.set(worker.locality.processId(), Optional<ProcessData>());
 				return Void();
 			}
 		}


### PR DESCRIPTION
Put description here...
Adding TraceEvent when a worker is removed from cluster controller.

Joshua Test Run:
20210427-234349-neethuhaneeshabingi-4475c28eb626c378 compressed=True data_size=23064173 duration=4817701 ended=103281 fail=1 fail_fast=10 max_runs=100000 pass=99999 priority=100 remaining=0 runtime=1:53:16 sanity=False started=103302 stopped=20210428-013705 submitted=20210427-234349 timeout=5400 username=neethuhaneeshabingi

Simulation Test log:
Command: build_output/bin/fdbserver -r simulation --crash --logsize 1024MB -f src/foundationdb/tests/fast/BackupCorrectness.toml -s 235461 -b on
Log: Event Severity="10" Time="148.085736" DateTime="2021-04-29T00:17:33Z" Type="ClusterWorkerFailed" Machine="2.0.1.0:1" ID="fdf2765d9846a8d7" WorkerProcessId="7b840c8d8bd67f36f7bf59bbbd049f3c" LogGroup="default" Roles="BK,CC,CD,GP,SS,TL" 

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
