### PR TITLE
Fix: explicitly cancel MVC thread futures for version monitors

### DIFF
--- a/fdbclient/MultiVersionTransaction.actor.cpp
+++ b/fdbclient/MultiVersionTransaction.actor.cpp
@@ -913,7 +913,8 @@ MultiVersionDatabase::MultiVersionDatabase(MultiVersionApi* api,
 			}
 		});
 
-		onMainThreadVoid([this]() { dbState->protocolVersionMonitor = dbState->monitorProtocolVersion(); }, nullptr);
+		Reference<DatabaseState> dbStateRef = dbState;
+		onMainThreadVoid([dbStateRef]() { dbStateRef->protocolVersionMonitor = dbStateRef->monitorProtocolVersion(); }, nullptr);
 	}
 }
 
@@ -1165,9 +1166,15 @@ void MultiVersionDatabase::DatabaseState::startLegacyVersionMonitors() {
 }
 
 // Cleans up state for the legacy version monitors to break reference cycles
-// Must be called from the main thread
 void MultiVersionDatabase::DatabaseState::close() {
-	legacyVersionMonitors.clear();
+	addref();
+	onMainThreadVoid(
+	    [this]() {
+		    protocolVersionMonitor.cancel();
+		    legacyVersionMonitors.clear();
+		    delref();
+	    },
+	    nullptr);
 }
 
 // Starts the connection monitor by creating a database object at an old version.
@@ -1215,11 +1222,10 @@ void MultiVersionDatabase::LegacyVersionMonitor::runGrvProbe(Reference<MultiVers
 	versionMonitor = mapThreadFuture<Version, Void>(tr->getReadVersion(), [this, dbState](ErrorOr<Version> v) {
 		onMainThreadVoid(
 		    [this, v, dbState]() {
-			    monitorRunning = false;
-
 			    // If the version attempt returns an error, we regard that as a connection (except
 			    // operation_cancelled)
 			    if (!v.isError() || v.getError().code() != error_code_operation_cancelled) {
+				    monitorRunning = false;
 				    dbState->protocolVersionChanged(client->protocolVersion);
 			    }
 		    },

--- a/fdbclient/MultiVersionTransaction.actor.cpp
+++ b/fdbclient/MultiVersionTransaction.actor.cpp
@@ -1035,6 +1035,10 @@ ThreadFuture<Void> MultiVersionDatabase::DatabaseState::monitorProtocolVersion()
 
 	return mapThreadFuture<ProtocolVersion, Void>(f, [this, expected](ErrorOr<ProtocolVersion> cv) {
 		if (cv.isError()) {
+			if (cv.getError().code() == error_code_operation_cancelled) {
+				return ErrorOr<Void>(cv.getError());
+			}
+
 			TraceEvent("ErrorGettingClusterProtocolVersion")
 			    .detail("ExpectedProtocolVersion", expected)
 			    .error(cv.getError());
@@ -1042,7 +1046,7 @@ ThreadFuture<Void> MultiVersionDatabase::DatabaseState::monitorProtocolVersion()
 
 		ProtocolVersion clusterVersion = !cv.isError() ? cv.get() : dbProtocolVersion.orDefault(currentProtocolVersion);
 		onMainThreadVoid([this, clusterVersion]() { protocolVersionChanged(clusterVersion); }, nullptr);
-		return Void();
+		return ErrorOr<Void>(Void());
 	});
 }
 
@@ -1053,6 +1057,8 @@ void MultiVersionDatabase::DatabaseState::protocolVersionChanged(ProtocolVersion
 	if (dbProtocolVersion.present() &&
 	    protocolVersion.normalizedVersion() == dbProtocolVersion.get().normalizedVersion()) {
 		dbProtocolVersion = protocolVersion;
+
+		protocolVersionMonitor.cancel();
 		protocolVersionMonitor = monitorProtocolVersion();
 	}
 
@@ -1139,6 +1145,8 @@ void MultiVersionDatabase::DatabaseState::updateDatabase(Reference<IDatabase> ne
 	}
 
 	dbVar->set(db);
+
+	protocolVersionMonitor.cancel();
 	protocolVersionMonitor = monitorProtocolVersion();
 }
 
@@ -1181,12 +1189,14 @@ void MultiVersionDatabase::LegacyVersionMonitor::startConnectionMonitor(
 			    onMainThreadVoid(
 			        [this, ready, dbState]() {
 				        if (ready.isError()) {
-					        TraceEvent(SevError, "FailedToOpenDatabaseOnClient")
-					            .error(ready.getError())
-					            .detail("LibPath", client->libPath);
+					        if (ready.getError().code() != error_code_operation_cancelled) {
+						        TraceEvent(SevError, "FailedToOpenDatabaseOnClient")
+						            .error(ready.getError())
+						            .detail("LibPath", client->libPath);
 
-					        client->failed = true;
-					        MultiVersionApi::api->updateSupportedVersions();
+						        client->failed = true;
+						        MultiVersionApi::api->updateSupportedVersions();
+					        }
 				        } else {
 					        runGrvProbe(dbState);
 				        }
@@ -1209,14 +1219,7 @@ void MultiVersionDatabase::LegacyVersionMonitor::runGrvProbe(Reference<MultiVers
 
 			    // If the version attempt returns an error, we regard that as a connection (except
 			    // operation_cancelled)
-			    if (v.isError() && v.getError().code() == error_code_operation_cancelled) {
-				    TraceEvent(SevError, "FailedToOpenDatabaseOnClient")
-				        .error(v.getError())
-				        .detail("LibPath", client->libPath);
-
-				    client->failed = true;
-				    MultiVersionApi::api->updateSupportedVersions();
-			    } else {
+			    if (!v.isError() || v.getError().code() != error_code_operation_cancelled) {
 				    dbState->protocolVersionChanged(client->protocolVersion);
 			    }
 		    },

--- a/fdbclient/MultiVersionTransaction.h
+++ b/fdbclient/MultiVersionTransaction.h
@@ -535,7 +535,11 @@ public:
 	// connect packet monitoring.
 	struct LegacyVersionMonitor {
 		LegacyVersionMonitor(Reference<ClientInfo> const& client) : client(client), monitorRunning(false) {}
-		~LegacyVersionMonitor() { TraceEvent("DestroyingVersionMonitor"); }
+		~LegacyVersionMonitor() {
+			if (versionMonitor.isValid()) {
+				versionMonitor.cancel();
+			}
+		}
 
 		// Starts the connection monitor by creating a database object at an old version.
 		// Must be called from the main thread

--- a/fdbclient/MultiVersionTransaction.h
+++ b/fdbclient/MultiVersionTransaction.h
@@ -517,7 +517,7 @@ public:
 
 		// Versions 5.0 and older do not support connection packet monitoring and require alternate techniques to
 		// determine the cluster version.
-		std::list<LegacyVersionMonitor> legacyVersionMonitors;
+		std::list<Reference<LegacyVersionMonitor>> legacyVersionMonitors;
 
 		Optional<ProtocolVersion> dbProtocolVersion;
 
@@ -532,13 +532,11 @@ public:
 
 	// A struct that enables monitoring whether the cluster is running an old version (<= 5.0) that doesn't support
 	// connect packet monitoring.
-	struct LegacyVersionMonitor {
+	struct LegacyVersionMonitor : ThreadSafeReferenceCounted<LegacyVersionMonitor> {
 		LegacyVersionMonitor(Reference<ClientInfo> const& client) : client(client), monitorRunning(false) {}
-		~LegacyVersionMonitor() {
-			if (versionMonitor.isValid()) {
-				versionMonitor.cancel();
-			}
-		}
+
+		// Terminates the version monitor to break reference cycles
+		void close();
 
 		// Starts the connection monitor by creating a database object at an old version.
 		// Must be called from the main thread

--- a/fdbclient/MultiVersionTransaction.h
+++ b/fdbclient/MultiVersionTransaction.h
@@ -492,7 +492,6 @@ public:
 		void startLegacyVersionMonitors();
 
 		// Cleans up state for the legacy version monitors to break reference cycles
-		// Must be called from the main thread
 		void close();
 
 		Reference<IDatabase> db;


### PR DESCRIPTION
Destruction of the thread futures for the protocol version monitors does not cancel the monitors. This explicitly calls cancel on the thread futures, which cancel the underlying activity.

This also fixes some issues that arose when the future returned a cancellation error.

- Passed 10K correctness tests
- Passed fdb_c_unit_tests
- Passed 10K binding tester runs
- Passed multithreaded_client.py tests

This also passed the same tests run in #4667.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

