### PR TITLE
Expose CommitBatchingWindowSize metric to fdbcli status

### DIFF
--- a/fdbclient/Schemas.cpp
+++ b/fdbclient/Schemas.cpp
@@ -181,6 +181,18 @@ const KeyRef JSONSchemas::statusSchema = LiteralStringRef(R"statusSchema(
                      "p99":0.0,
                      "p99.9":0.0
                   },
+                  "commit_batching_window_size":{
+                     "count":0,
+                     "min":0.0,
+                     "max":0.0,
+                     "median":0.0,
+                     "mean":0.0,
+                     "p25":0.0,
+                     "p90":0.0,
+                     "p95":0.0,
+                     "p99":0.0,
+                     "p99.9":0.0
+                  },
                   "grv_latency_bands":{
                      "$map": 1
                   },

--- a/fdbserver/Status.actor.cpp
+++ b/fdbserver/Status.actor.cpp
@@ -615,6 +615,11 @@ struct RolesInfo {
 			TraceEventFields const& commitLatencyBands = metrics.at("CommitLatencyBands");
 			if (commitLatencyBands.size()) {
 				obj["commit_latency_bands"] = addLatencyBandInfo(commitLatencyBands);
+			} 
+
+			TraceEventFields const& commitBatchingWindowSize = metrics.at("CommitBatchingWindowSize");
+			if (commitBatchingWindowSize.size()) {
+				obj["commit_batching_window_size"] = addLatencyStatistics(commitBatchingWindowSize);
 			}
 		} catch (Error& e) {
 			if (e.code() != error_code_attribute_not_found) {
@@ -1839,7 +1844,7 @@ ACTOR static Future<vector<std::pair<CommitProxyInterface, EventMap>>> getCommit
 	vector<std::pair<CommitProxyInterface, EventMap>> results =
 	    wait(getServerMetrics(db->get().client.commitProxies,
 	                          address_workers,
-	                          std::vector<std::string>{ "CommitLatencyMetrics", "CommitLatencyBands" }));
+	                          std::vector<std::string>{ "CommitLatencyMetrics", "CommitLatencyBands", "CommitBatchingWindowSize"}));
 
 	return results;
 }


### PR DESCRIPTION
Changes:

Schemas.cpp:
- Extend JSON schema to include aggregated information about
CommitBatchingWindowSize samples.

Status.actor.cpp:
- Extend getStorageServersAndMetrics() to gather metrics about
CommitBatchingWindowSize.
- Extend CommitProxy AddRole() to populate the status-JSON object
with the metrics about CommitBatchingWindowSize.

Testing:
- Ran simulated tests. There were some failures, a couple of them (restarting/from_7.0.0/ConfigureTestRestart-1.txt and restarting/from_7.0.0/ConfigureTestRestart-2.txt) are known to have failed on Snowflake nightly tests too, I don't know the status of the other failures.
- Manual testing: Started a FoundationDB cluster and verified that commitBatchingWindowSize is getting populated in the "status json" output:

                    {
                        "commit_batching_window_size" : {
                            "count" : 23,
                            "max" : 0.00102881,
                            "mean" : 0.0010019200000000001,
                            "median" : 0.001,
                            "min" : 0.001,
                            "p25" : 0.001,
                            "p90" : 0.001,
                            "p95" : 0.001,
                            "p99" : 0.0010152399999999999,
                            "p99.9" : 0.0010152399999999999
                        },

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [x] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
