### PR TITLE
add in uptime_seconds to machine level fields for `status json`

### DIFF
--- a/documentation/sphinx/source/mr-status-json-schemas.rst.inc
+++ b/documentation/sphinx/source/mr-status-json-schemas.rst.inc
@@ -757,7 +757,8 @@
             },
             "cpu":{
                "logical_core_utilization":0.4 // computed as cpu_seconds / elapsed_seconds; value may be capped at 0.5 due to hyper-threading
-            }
+            },
+            "uptime_seconds":1234.2345
          }
       }
    },

--- a/fdbclient/Schemas.cpp
+++ b/fdbclient/Schemas.cpp
@@ -817,7 +817,8 @@ const KeyRef JSONSchemas::statusSchema = LiteralStringRef(R"statusSchema(
             },
             "cpu":{
                "logical_core_utilization":0.4
-            }
+            },
+            "uptime_seconds":1234.2345
          }
       }
    },

--- a/fdbserver/Status.actor.cpp
+++ b/fdbserver/Status.actor.cpp
@@ -307,6 +307,7 @@ static JsonBuilderObject machineStatusFetcher(WorkerEvents mMetrics,
 			// If this machine ID does not already exist in the machineMap, add it
 			if (machineJsonMap.count(machineId) == 0) {
 				statusObj["machine_id"] = machineId;
+				statusObj["uptime_seconds"] = event.getValue("UptimeSeconds");
 
 				if (dcIds.count(it->first)) {
 					statusObj["datacenter_id"] = dcIds[it->first];

--- a/flow/SystemMonitor.cpp
+++ b/flow/SystemMonitor.cpp
@@ -253,6 +253,7 @@ SystemStatistics customSystemMonitor(std::string eventName, StatisticsState* sta
 			    .detail("DCID", machineState.dcId)
 			    .detail("ZoneID", machineState.zoneId)
 			    .detail("MachineID", machineState.machineId)
+			    .detail("UptimeSeconds", now() - machineState.monitorStartTime)
 			    .trackLatest("MachineMetrics");
 		}
 	}


### PR DESCRIPTION
fixes #4411 

**Changes:**

- Added the machine levels uptime to the `status json` command. Thus making it possible to determine even through process restarts how long a particular machine has been online.

  - This was done by adding to `MachineMetrics` a field called `UptimeSeconds` (which is calculated the same as otherwise in that file), and then being accessed in the status serializer.

**Testing Done:**

- Didn't add any unit tests as this isn't actually a new metric, it's just being exposed in status json now. So I didn't feel one was necessary for an update to the schema (there also didn't seem to be any existing tests for the schema that I could find so I felt this was fine).

- Manually tested, and validated that `status json` shows the correct machine uptime:

<details>
<summary>Start a cluster with 3 processes on the same machine, running `status json` all have the same uptime</summary>

[Full Response](https://gist.github.com/Mythra/9298a68293d0234958800cf5db651c09)

```
fdb> status json

{
[...]
    "cluster" : {
[...]
        "machines" : {
            "c7ae2fc5440f252bb97cb5b3f68c959d" : {
[...]
                "uptime_seconds" : "30.0003"
            }
        },
        "processes" : {
            "23095e2afdc28433b1377e317aa573a3" : {
                "address" : "127.0.0.1:4500",
[...]
                "uptime_seconds" : 30.000299999999999,
                "version" : "7.0.0"
            },
            "8200471ea029b35e3272efc8699552b1" : {
                "address" : "127.0.0.1:4501",
[...]
                "uptime_seconds" : 30.000299999999999,
                "version" : "7.0.0"
            },
            "d18370147949674a289b4e14fc665800" : {
                "address" : "127.0.0.1:4502",
[...]
                "uptime_seconds" : 30.000299999999999,
                "version" : "7.0.0"
            }
        },
[...]
}
```
</details>

<details>
<summary>After restarting two of the processes: machine, and one process match the original boot time. While the other two process times are new</summary>

[Full Log](https://gist.github.com/Mythra/c42f5bee916f5dc0ebc694477f72a79f)

```
fdb> status json

{
[...]
    "cluster" : {
[...]
        "machines" : {
            "c7ae2fc5440f252bb97cb5b3f68c959d" : {
                "address" : "127.0.0.1",
                "contributing_workers" : 3,
[...]
                "uptime_seconds" : "355.004"
            }
        },
[...]
        "processes" : {
            "0898cc149d02203f24ff1326f147c351" : {
                "address" : "127.0.0.1:4502",
[...]
                "uptime_seconds" : 45.000599999999999,
                "version" : "7.0.0"
            },
            "23095e2afdc28433b1377e317aa573a3" : {
                "address" : "127.0.0.1:4500",
[...]
                "uptime_seconds" : 355.00400000000002,
                "version" : "7.0.0"
            },
            "8bbf837b75079c46f3c4cf59c86de04b" : {
                "address" : "127.0.0.1:4501",
[...]
                "uptime_seconds" : 45.000700000000002,
                "version" : "7.0.0"
            }
        },
[...]
```

</details>

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.