### PR TITLE
Revert "Revert "Changed code flow to fix loophole that avoided the knob guarding higher protocol versions""

### DIFF
--- a/fdbclient/Knobs.cpp
+++ b/fdbclient/Knobs.cpp
@@ -92,7 +92,7 @@ void ClientKnobs::initialize(bool randomize) {
 	init( STORAGE_METRICS_TOO_MANY_SHARDS_DELAY,  15.0 );
 	init( AGGREGATE_HEALTH_METRICS_MAX_STALENESS,  0.5 );
 	init( DETAILED_HEALTH_METRICS_MAX_STALENESS,   5.0 );
-	init( TAG_ENCODE_KEY_SERVERS,                false ); if( randomize && BUGGIFY ) TAG_ENCODE_KEY_SERVERS = true;
+	init( TAG_ENCODE_KEY_SERVERS,                false ); // Setting true will break 6.3->6.2 downgrade capability
 
 	//KeyRangeMap
 	init( KRM_GET_RANGE_LIMIT,                     1e5 ); if( randomize && BUGGIFY ) KRM_GET_RANGE_LIMIT = 10;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -189,8 +189,8 @@ if(WITH_PYTHON)
     TEST_FILES restarting/from_5.2.0/ClientTransactionProfilingCorrectness-1.txt
                restarting/from_5.2.0/ClientTransactionProfilingCorrectness-2.txt)
   add_fdb_test(
-    TEST_FILES restarting/to_6.3.10/CycleTestRestart-1.txt
-               restarting/to_6.3.10/CycleTestRestart-2.txt)
+    TEST_FILES restarting/to_6.2.33/CycleTestRestart-1.txt
+               restarting/to_6.2.33/CycleTestRestart-2.txt)
   add_fdb_test(TEST_FILES slow/ApiCorrectness.txt)
   add_fdb_test(TEST_FILES slow/ApiCorrectnessAtomicRestore.txt)
   add_fdb_test(TEST_FILES slow/ApiCorrectnessSwitchover.txt)

--- a/tests/restarting/to_6.2.33/CycleTestRestart-1.txt
+++ b/tests/restarting/to_6.2.33/CycleTestRestart-1.txt
@@ -1,7 +1,7 @@
 testTitle=Clogged
-    runSetup=false
+    clearAfterTest=false
     testName=Cycle
-    transactionsPerSecond=2500.0
+    transactionsPerSecond=500.0
     nodeCount=2500
     testDuration=10.0
     expectedRate=0
@@ -24,3 +24,10 @@ testTitle=Clogged
     machinesToLeave=3
     reboot=true
     testDuration=10.0
+
+    testName=SaveAndKill
+    restartInfoLocation=simfdb/restartInfo.ini
+    testDuration=10.0
+
+storageEngineExcludeTypes=2,3
+maxTLogVersion=4

--- a/tests/restarting/to_6.2.33/CycleTestRestart-2.txt
+++ b/tests/restarting/to_6.2.33/CycleTestRestart-2.txt
@@ -1,7 +1,7 @@
 testTitle=Clogged
-    clearAfterTest=false
+    runSetup=false
     testName=Cycle
-    transactionsPerSecond=500.0
+    transactionsPerSecond=2500.0
     nodeCount=2500
     testDuration=10.0
     expectedRate=0
@@ -23,8 +23,4 @@ testTitle=Clogged
     machinesToKill=10
     machinesToLeave=3
     reboot=true
-    testDuration=10.0
-
-    testName=SaveAndKill
-    restartInfoLocation=simfdb/restartInfo.ini
     testDuration=10.0


### PR DESCRIPTION
Reverts apple/foundationdb#4707
Updated the 6.2 binary from https://github.com/apple/foundationdb/pull/4673 to account for a comparison mismatch for certain 6.3 version protocols. No changes made on 6.3. Awaiting testing results for confirmation.