### PR TITLE
Mako should be able to set loggroup

### DIFF
--- a/bindings/c/test/mako/mako.c
+++ b/bindings/c/test/mako/mako.c
@@ -1172,6 +1172,14 @@ int worker_process_main(mako_args_t* args, int worker_id, mako_shmhdr_t* shm, pi
 #endif
 	}
 
+	/* Set client Log group */
+	if (strlen(args->log_group) != 0) {
+		err = fdb_network_set_option(FDB_NET_OPTION_TRACE_LOG_GROUP, (uint8_t*)args->log_group, strlen(args->log_group));
+		if (err) {
+			fprintf(stderr, "ERROR: fdb_network_set_option(FDB_NET_OPTION_TRACE_LOG_GROUP): %s\n", fdb_get_error(err));
+		}
+	}
+
 	/* enable tracing if specified */
 	if (args->trace) {
 		fprintf(debugme,
@@ -1345,6 +1353,7 @@ int init_args(mako_args_t* args) {
 	args->verbose = 1;
 	args->flatbuffers = 0; /* internal */
 	args->knobs[0] = '\0';
+	args->log_group[0] = '\0';
 	args->trace = 0;
 	args->tracepath[0] = '\0';
 	args->traceformat = 0; /* default to client's default (XML) */
@@ -1505,6 +1514,7 @@ void usage() {
 	printf("%-24s %s\n", "-m, --mode=MODE", "Specify the mode (build, run, clean)");
 	printf("%-24s %s\n", "-z, --zipf", "Use zipfian distribution instead of uniform distribution");
 	printf("%-24s %s\n", "    --commitget", "Commit GETs");
+	printf("%-24s %s\n", "    --loggroup=LOGGROUP", "Set client log group");
 	printf("%-24s %s\n", "    --trace", "Enable tracing");
 	printf("%-24s %s\n", "    --tracepath=PATH", "Set trace file path");
 	printf("%-24s %s\n", "    --trace_format <xml|json>", "Set trace format (Default: json)");
@@ -1546,6 +1556,7 @@ int parse_args(int argc, char* argv[], mako_args_t* args) {
 			                                    { "verbose", required_argument, NULL, 'v' },
 			                                    { "mode", required_argument, NULL, 'm' },
 			                                    { "knobs", required_argument, NULL, ARG_KNOBS },
+			                                    { "loggroup", required_argument, NULL, ARG_LOGGROUP },
 			                                    { "tracepath", required_argument, NULL, ARG_TRACEPATH },
 			                                    { "trace_format", required_argument, NULL, ARG_TRACEFORMAT },
 			                                    { "streaming", required_argument, NULL, ARG_STREAMING_MODE },
@@ -1655,6 +1666,9 @@ int parse_args(int argc, char* argv[], mako_args_t* args) {
 			break;
 		case ARG_KNOBS:
 			memcpy(args->knobs, optarg, strlen(optarg) + 1);
+			break;
+		case ARG_LOGGROUP:
+			memcpy(args->log_group, optarg, strlen(optarg) + 1);
 			break;
 		case ARG_TRACE:
 			args->trace = 1;

--- a/bindings/c/test/mako/mako.h
+++ b/bindings/c/test/mako/mako.h
@@ -68,6 +68,7 @@ enum Arguments {
 	ARG_VERSION,
 	ARG_KNOBS,
 	ARG_FLATBUFFERS,
+	ARG_LOGGROUP,
 	ARG_TRACE,
 	ARG_TRACEPATH,
 	ARG_TRACEFORMAT,
@@ -97,6 +98,7 @@ typedef struct {
 	int ops[MAX_OP][3];
 } mako_txnspec_t;
 
+#define LOGGROUP_MAX 256
 #define KNOB_MAX 256
 #define TAGPREFIXLENGTH_MAX 8
 
@@ -122,6 +124,7 @@ typedef struct {
 	int verbose;
 	mako_txnspec_t txnspec;
 	char cluster_file[PATH_MAX];
+	char log_group[LOGGROUP_MAX];
 	int trace;
 	char tracepath[PATH_MAX];
 	int traceformat; /* 0 - XML, 1 - JSON */


### PR DESCRIPTION
This change allows a user to set a "loggroup" in mako.

I rebased this change on `release-6.3` and tested because the build was broken at the time of this PRs creation.

When loggroup is set, traces look like this:
```
<Event Severity="10" Time="1620162104.837037" DateTime="2021-05-04T21:01:44Z" Type="SetNetworkOption" ID="0000000000000000" Option="TRACE_LOG_GROUP" Machine="127.0.0.1:5454" LogGroup="testing123" />
```

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [X] The PR has a description, explaining both the problem and the solution.
- [X] The description mentions which forms of testing were done and the testing seems reasonable.
- [x] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
