### PR TITLE
Upgrade api version from 700 to 710

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@
 # limitations under the License.
 cmake_minimum_required(VERSION 3.13)
 project(foundationdb
-  VERSION 7.0.0
+  VERSION 7.1.0
   DESCRIPTION "FoundationDB is a scalable, fault-tolerant, ordered key-value store with full ACID transactions."
   HOMEPAGE_URL "http://www.foundationdb.org/"
   LANGUAGES C CXX ASM)

--- a/bindings/bindingtester/__init__.py
+++ b/bindings/bindingtester/__init__.py
@@ -26,7 +26,7 @@ sys.path[:0] = [os.path.join(os.path.dirname(__file__), '..', '..', 'bindings', 
 
 import util
 
-FDB_API_VERSION = 700
+FDB_API_VERSION = 710
 
 LOGGING = {
     'version': 1,

--- a/bindings/bindingtester/bindingtester.py
+++ b/bindings/bindingtester/bindingtester.py
@@ -157,7 +157,7 @@ def choose_api_version(selected_api_version, tester_min_version, tester_max_vers
             api_version = min_version
         elif random.random() < 0.9:
             api_version = random.choice([v for v in [13, 14, 16, 21, 22, 23, 100, 200, 300, 400, 410, 420, 430,
-                                                     440, 450, 460, 500, 510, 520, 600, 610, 620, 630, 700] if v >= min_version and v <= max_version])
+                                                     440, 450, 460, 500, 510, 520, 600, 610, 620, 630, 700, 710] if v >= min_version and v <= max_version])
         else:
             api_version = random.randint(min_version, max_version)
 

--- a/bindings/bindingtester/known_testers.py
+++ b/bindings/bindingtester/known_testers.py
@@ -20,7 +20,7 @@
 
 import os
 
-MAX_API_VERSION = 700
+MAX_API_VERSION = 710
 COMMON_TYPES = ['null', 'bytes', 'string', 'int', 'uuid', 'bool', 'float', 'double', 'tuple']
 ALL_TYPES = COMMON_TYPES + ['versionstamp']
 

--- a/bindings/bindingtester/tests/scripted.py
+++ b/bindings/bindingtester/tests/scripted.py
@@ -34,7 +34,7 @@ fdb.api_version(FDB_API_VERSION)
 
 
 class ScriptedTest(Test):
-    TEST_API_VERSION = 700
+    TEST_API_VERSION = 710
 
     def __init__(self, subspace):
         super(ScriptedTest, self).__init__(subspace, ScriptedTest.TEST_API_VERSION, ScriptedTest.TEST_API_VERSION)

--- a/bindings/c/fdb_c.cpp
+++ b/bindings/c/fdb_c.cpp
@@ -19,7 +19,7 @@
  */
 
 #include <cstdint>
-#define FDB_API_VERSION 700
+#define FDB_API_VERSION 710
 #define FDB_INCLUDE_LEGACY_TYPES
 
 #include "fdbclient/MultiVersionTransaction.h"

--- a/bindings/c/foundationdb/fdb_c.h
+++ b/bindings/c/foundationdb/fdb_c.h
@@ -27,10 +27,10 @@
 #endif
 
 #if !defined(FDB_API_VERSION)
-#error You must #define FDB_API_VERSION prior to including fdb_c.h (current version is 700)
+#error You must #define FDB_API_VERSION prior to including fdb_c.h (current version is 710)
 #elif FDB_API_VERSION < 13
 #error API version no longer supported (upgrade to 13)
-#elif FDB_API_VERSION > 700
+#elif FDB_API_VERSION > 710
 #error Requested API version requires a newer version of this header
 #endif
 
@@ -97,7 +97,7 @@ typedef struct key {
 	const uint8_t* key;
 	int key_length;
 } FDBKey;
-#if FDB_API_VERSION >= 700
+#if FDB_API_VERSION >= 710
 typedef struct keyvalue {
 	const uint8_t* key;
 	int key_length;

--- a/bindings/c/test/fdb_c90_test.c
+++ b/bindings/c/test/fdb_c90_test.c
@@ -1,9 +1,9 @@
-#define FDB_API_VERSION 700
+#define FDB_API_VERSION 710
 #include <foundationdb/fdb_c.h>
 
 int main(int argc, char* argv[]) {
 	(void)argc;
 	(void)argv;
-	fdb_select_api_version(700);
+	fdb_select_api_version(710);
 	return 0;
 }

--- a/bindings/c/test/mako/mako.h
+++ b/bindings/c/test/mako/mako.h
@@ -3,7 +3,7 @@
 #pragma once
 
 #ifndef FDB_API_VERSION
-#define FDB_API_VERSION 700
+#define FDB_API_VERSION 710
 #endif
 
 #include <foundationdb/fdb_c.h>

--- a/bindings/c/test/performance_test.c
+++ b/bindings/c/test/performance_test.c
@@ -641,7 +641,7 @@ void runTests(struct ResultSet* rs) {
 int main(int argc, char** argv) {
 	srand(time(NULL));
 	struct ResultSet* rs = newResultSet();
-	checkError(fdb_select_api_version(700), "select API version", rs);
+	checkError(fdb_select_api_version(710), "select API version", rs);
 	printf("Running performance test at client version: %s\n", fdb_get_client_version());
 
 	valueStr = (uint8_t*)malloc((sizeof(uint8_t)) * valueSize);

--- a/bindings/c/test/ryw_benchmark.c
+++ b/bindings/c/test/ryw_benchmark.c
@@ -285,7 +285,7 @@ void runTests(struct ResultSet* rs) {
 int main(int argc, char** argv) {
 	srand(time(NULL));
 	struct ResultSet* rs = newResultSet();
-	checkError(fdb_select_api_version(700), "select API version", rs);
+	checkError(fdb_select_api_version(710), "select API version", rs);
 	printf("Running RYW Benchmark test at client version: %s\n", fdb_get_client_version());
 
 	keys = generateKeys(numKeys, keySize);

--- a/bindings/c/test/test.h
+++ b/bindings/c/test/test.h
@@ -29,7 +29,7 @@
 #include <inttypes.h>
 
 #ifndef FDB_API_VERSION
-#define FDB_API_VERSION 700
+#define FDB_API_VERSION 710
 #endif
 
 #include <foundationdb/fdb_c.h>

--- a/bindings/c/test/txn_size_test.c
+++ b/bindings/c/test/txn_size_test.c
@@ -97,7 +97,7 @@ void runTests(struct ResultSet* rs) {
 int main(int argc, char** argv) {
 	srand(time(NULL));
 	struct ResultSet* rs = newResultSet();
-	checkError(fdb_select_api_version(700), "select API version", rs);
+	checkError(fdb_select_api_version(710), "select API version", rs);
 	printf("Running performance test at client version: %s\n", fdb_get_client_version());
 
 	keys = generateKeys(numKeys, KEY_SIZE);

--- a/bindings/c/test/unit/fdb_api.hpp
+++ b/bindings/c/test/unit/fdb_api.hpp
@@ -39,7 +39,7 @@
 
 #pragma once
 
-#define FDB_API_VERSION 700
+#define FDB_API_VERSION 710
 #include <foundationdb/fdb_c.h>
 
 #include <string>

--- a/bindings/c/test/unit/setup_tests.cpp
+++ b/bindings/c/test/unit/setup_tests.cpp
@@ -20,7 +20,7 @@
 
 // Unit tests for API setup, network initialization functions from the FDB C API.
 
-#define FDB_API_VERSION 700
+#define FDB_API_VERSION 710
 #include <foundationdb/fdb_c.h>
 #include <iostream>
 #include <thread>
@@ -42,13 +42,13 @@ TEST_CASE("setup") {
 	CHECK(err);
 
 	// Select current API version
-	fdb_check(fdb_select_api_version(700));
+	fdb_check(fdb_select_api_version(710));
 
 	// Error to call again after a successful return
-	err = fdb_select_api_version(700);
+	err = fdb_select_api_version(710);
 	CHECK(err);
 
-	CHECK(fdb_get_max_api_version() >= 700);
+	CHECK(fdb_get_max_api_version() >= 710);
 
 	fdb_check(fdb_setup_network());
 	// Calling a second time should fail

--- a/bindings/c/test/unit/unit_tests.cpp
+++ b/bindings/c/test/unit/unit_tests.cpp
@@ -20,7 +20,7 @@
 
 // Unit tests for the FoundationDB C API.
 
-#define FDB_API_VERSION 700
+#define FDB_API_VERSION 710
 #include <foundationdb/fdb_c.h>
 #include <assert.h>
 #include <string.h>
@@ -2151,7 +2151,7 @@ int main(int argc, char** argv) {
 		          << "Usage: fdb_c_unit_tests /path/to/cluster_file key_prefix [externalClient]" << std::endl;
 		return 1;
 	}
-	fdb_check(fdb_select_api_version(700));
+	fdb_check(fdb_select_api_version(710));
 	if (argc == 4) {
 		std::string externalClientLibrary = argv[3];
 		fdb_check(fdb_network_set_option(

--- a/bindings/c/test/workloads/SimpleWorkload.cpp
+++ b/bindings/c/test/workloads/SimpleWorkload.cpp
@@ -18,7 +18,7 @@
  * limitations under the License.
  */
 
-#define FDB_API_VERSION 700
+#define FDB_API_VERSION 710
 #include "foundationdb/fdb_c.h"
 #undef DLLEXPORT
 #include "workloads.h"
@@ -266,7 +266,7 @@ struct SimpleWorkload : FDBWorkload {
 		insertsPerTx = context->getOption("insertsPerTx", 100ul);
 		opsPerTx = context->getOption("opsPerTx", 100ul);
 		runFor = context->getOption("runFor", 10.0);
-		auto err = fdb_select_api_version(700);
+		auto err = fdb_select_api_version(710);
 		if (err) {
 			context->trace(
 			    FDBSeverity::Info, "SelectAPIVersionFailed", { { "Error", std::string(fdb_get_error(err)) } });

--- a/bindings/flow/fdb_flow.actor.cpp
+++ b/bindings/flow/fdb_flow.actor.cpp
@@ -37,7 +37,7 @@ THREAD_FUNC networkThread(void* fdb) {
 }
 
 ACTOR Future<Void> _test() {
-	API* fdb = FDB::API::selectAPIVersion(700);
+	API* fdb = FDB::API::selectAPIVersion(710);
 	auto db = fdb->createDatabase();
 	state Reference<Transaction> tr = db->createTransaction();
 
@@ -81,7 +81,7 @@ ACTOR Future<Void> _test() {
 }
 
 void fdb_flow_test() {
-	API* fdb = FDB::API::selectAPIVersion(700);
+	API* fdb = FDB::API::selectAPIVersion(710);
 	fdb->setupNetwork();
 	startThread(networkThread, fdb);
 

--- a/bindings/flow/fdb_flow.h
+++ b/bindings/flow/fdb_flow.h
@@ -23,7 +23,7 @@
 
 #include <flow/flow.h>
 
-#define FDB_API_VERSION 700
+#define FDB_API_VERSION 710
 #include <bindings/c/foundationdb/fdb_c.h>
 #undef DLLEXPORT
 

--- a/bindings/flow/tester/Tester.actor.cpp
+++ b/bindings/flow/tester/Tester.actor.cpp
@@ -1863,7 +1863,7 @@ ACTOR void _test_versionstamp() {
 	try {
 		g_network = newNet2(TLSConfig());
 
-		API* fdb = FDB::API::selectAPIVersion(700);
+		API* fdb = FDB::API::selectAPIVersion(710);
 
 		fdb->setupNetwork();
 		startThread(networkThread, fdb);

--- a/bindings/go/README.md
+++ b/bindings/go/README.md
@@ -9,7 +9,7 @@ This package requires:
 - [Mono](http://www.mono-project.com/) (macOS or Linux) or [Visual Studio](https://www.visualstudio.com/) (Windows)  (build-time only)
 - FoundationDB C API 2.0.x-6.1.x (part of the [FoundationDB client packages](https://apple.github.io/foundationdb/downloads.html#c))
 
-Use of this package requires the selection of a FoundationDB API version at runtime. This package currently supports FoundationDB API versions 200-700.
+Use of this package requires the selection of a FoundationDB API version at runtime. This package currently supports FoundationDB API versions 200-710.
 
 To install this package, you can run the "fdb-go-install.sh" script (for versions 5.0.x and greater):
 

--- a/bindings/go/src/fdb/cluster.go
+++ b/bindings/go/src/fdb/cluster.go
@@ -22,7 +22,7 @@
 
 package fdb
 
-// #define FDB_API_VERSION 700
+// #define FDB_API_VERSION 710
 // #include <foundationdb/fdb_c.h>
 import "C"
 

--- a/bindings/go/src/fdb/database.go
+++ b/bindings/go/src/fdb/database.go
@@ -22,7 +22,7 @@
 
 package fdb
 
-// #define FDB_API_VERSION 700
+// #define FDB_API_VERSION 710
 // #include <foundationdb/fdb_c.h>
 import "C"
 

--- a/bindings/go/src/fdb/doc.go
+++ b/bindings/go/src/fdb/doc.go
@@ -46,7 +46,7 @@ A basic interaction with the FoundationDB API is demonstrated below:
 
     func main() {
         // Different API versions may expose different runtime behaviors.
-        fdb.MustAPIVersion(700)
+        fdb.MustAPIVersion(710)
 
         // Open the default database from the system cluster
         db := fdb.MustOpenDefault()

--- a/bindings/go/src/fdb/errors.go
+++ b/bindings/go/src/fdb/errors.go
@@ -22,7 +22,7 @@
 
 package fdb
 
-// #define FDB_API_VERSION 700
+// #define FDB_API_VERSION 710
 // #include <foundationdb/fdb_c.h>
 import "C"
 

--- a/bindings/go/src/fdb/fdb.go
+++ b/bindings/go/src/fdb/fdb.go
@@ -22,7 +22,7 @@
 
 package fdb
 
-// #define FDB_API_VERSION 700
+// #define FDB_API_VERSION 710
 // #include <foundationdb/fdb_c.h>
 // #include <stdlib.h>
 import "C"
@@ -108,7 +108,7 @@ func (opt NetworkOptions) setOpt(code int, param []byte) error {
 // library, an error will be returned. APIVersion must be called prior to any
 // other functions in the fdb package.
 //
-// Currently, this package supports API versions 200 through 700.
+// Currently, this package supports API versions 200 through 710.
 //
 // Warning: When using the multi-version client API, setting an API version that
 // is not supported by a particular client library will prevent that client from
@@ -116,7 +116,7 @@ func (opt NetworkOptions) setOpt(code int, param []byte) error {
 // the API version of your application after upgrading your client until the
 // cluster has also been upgraded.
 func APIVersion(version int) error {
-	headerVersion := 700
+	headerVersion := 710
 
 	networkMutex.Lock()
 	defer networkMutex.Unlock()
@@ -128,7 +128,7 @@ func APIVersion(version int) error {
 		return errAPIVersionAlreadySet
 	}
 
-	if version < 200 || version > 700 {
+	if version < 200 || version > 710 {
 		return errAPIVersionNotSupported
 	}
 

--- a/bindings/go/src/fdb/fdb_test.go
+++ b/bindings/go/src/fdb/fdb_test.go
@@ -32,7 +32,7 @@ import (
 func ExampleOpenDefault() {
 	var e error
 
-	e = fdb.APIVersion(700)
+	e = fdb.APIVersion(710)
 	if e != nil {
 		fmt.Printf("Unable to set API version: %v\n", e)
 		return
@@ -52,7 +52,7 @@ func ExampleOpenDefault() {
 }
 
 func TestVersionstamp(t *testing.T) {
-	fdb.MustAPIVersion(700)
+	fdb.MustAPIVersion(710)
 	db := fdb.MustOpenDefault()
 
 	setVs := func(t fdb.Transactor, key fdb.Key) (fdb.FutureKey, error) {
@@ -98,7 +98,7 @@ func TestVersionstamp(t *testing.T) {
 }
 
 func ExampleTransactor() {
-	fdb.MustAPIVersion(700)
+	fdb.MustAPIVersion(710)
 	db := fdb.MustOpenDefault()
 
 	setOne := func(t fdb.Transactor, key fdb.Key, value []byte) error {
@@ -149,7 +149,7 @@ func ExampleTransactor() {
 }
 
 func ExampleReadTransactor() {
-	fdb.MustAPIVersion(700)
+	fdb.MustAPIVersion(710)
 	db := fdb.MustOpenDefault()
 
 	getOne := func(rt fdb.ReadTransactor, key fdb.Key) ([]byte, error) {
@@ -202,7 +202,7 @@ func ExampleReadTransactor() {
 }
 
 func ExamplePrefixRange() {
-	fdb.MustAPIVersion(700)
+	fdb.MustAPIVersion(710)
 	db := fdb.MustOpenDefault()
 
 	tr, e := db.CreateTransaction()
@@ -241,7 +241,7 @@ func ExamplePrefixRange() {
 }
 
 func ExampleRangeIterator() {
-	fdb.MustAPIVersion(700)
+	fdb.MustAPIVersion(710)
 	db := fdb.MustOpenDefault()
 
 	tr, e := db.CreateTransaction()

--- a/bindings/go/src/fdb/futures.go
+++ b/bindings/go/src/fdb/futures.go
@@ -23,7 +23,7 @@
 package fdb
 
 //  #cgo LDFLAGS: -lfdb_c -lm
-//  #define FDB_API_VERSION 700
+//  #define FDB_API_VERSION 710
 //  #include <foundationdb/fdb_c.h>
 //  #include <string.h>
 //

--- a/bindings/go/src/fdb/range.go
+++ b/bindings/go/src/fdb/range.go
@@ -22,7 +22,7 @@
 
 package fdb
 
-// #define FDB_API_VERSION 700
+// #define FDB_API_VERSION 710
 // #include <foundationdb/fdb_c.h>
 import "C"
 

--- a/bindings/go/src/fdb/transaction.go
+++ b/bindings/go/src/fdb/transaction.go
@@ -22,7 +22,7 @@
 
 package fdb
 
-// #define FDB_API_VERSION 700
+// #define FDB_API_VERSION 710
 // #include <foundationdb/fdb_c.h>
 import "C"
 

--- a/bindings/java/JavaWorkload.cpp
+++ b/bindings/java/JavaWorkload.cpp
@@ -19,7 +19,7 @@
  */
 
 #include <foundationdb/ClientWorkload.h>
-#define FDB_API_VERSION 700
+#define FDB_API_VERSION 710
 #include <foundationdb/fdb_c.h>
 
 #include <jni.h>
@@ -375,7 +375,7 @@ struct JVM {
 		jmethodID selectMethod =
 		    env->GetStaticMethodID(fdbClass, "selectAPIVersion", "(I)Lcom/apple/foundationdb/FDB;");
 		checkException();
-		auto fdbInstance = env->CallStaticObjectMethod(fdbClass, selectMethod, jint(700));
+		auto fdbInstance = env->CallStaticObjectMethod(fdbClass, selectMethod, jint(710));
 		checkException();
 		env->CallObjectMethod(fdbInstance, getMethod(fdbClass, "disableShutdownHook", "()V"));
 		checkException();

--- a/bindings/java/fdbJNI.cpp
+++ b/bindings/java/fdbJNI.cpp
@@ -21,7 +21,7 @@
 #include <jni.h>
 #include <string.h>
 
-#define FDB_API_VERSION 700
+#define FDB_API_VERSION 710
 
 #include <foundationdb/fdb_c.h>
 

--- a/bindings/java/src/integration/com/apple/foundationdb/DirectoryTest.java
+++ b/bindings/java/src/integration/com/apple/foundationdb/DirectoryTest.java
@@ -42,7 +42,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
  */
 @ExtendWith(RequiresDatabase.class)
 class DirectoryTest {
-	private static final FDB fdb = FDB.selectAPIVersion(700);
+	private static final FDB fdb = FDB.selectAPIVersion(710);
 
 	@Test
 	void testCanCreateDirectory() throws Exception {

--- a/bindings/java/src/integration/com/apple/foundationdb/RangeQueryIntegrationTest.java
+++ b/bindings/java/src/integration/com/apple/foundationdb/RangeQueryIntegrationTest.java
@@ -41,7 +41,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
  */
 @ExtendWith(RequiresDatabase.class)
 class RangeQueryIntegrationTest {
-	private static final FDB fdb = FDB.selectAPIVersion(700);
+	private static final FDB fdb = FDB.selectAPIVersion(710);
 
 	@BeforeEach
 	@AfterEach

--- a/bindings/java/src/integration/com/apple/foundationdb/RequiresDatabase.java
+++ b/bindings/java/src/integration/com/apple/foundationdb/RequiresDatabase.java
@@ -80,7 +80,7 @@ public class RequiresDatabase implements ExecutionCondition, BeforeAllCallback {
 		 * assume that if we are here, then canRunIntegrationTest() is returning true and we don't have to bother
 		 * checking it.
 		 */
-		try (Database db = FDB.selectAPIVersion(700).open()) {
+		try (Database db = FDB.selectAPIVersion(710).open()) {
 			db.run(tr -> {
 				CompletableFuture<byte[]> future = tr.get("test".getBytes());
 

--- a/bindings/java/src/junit/com/apple/foundationdb/FDBLibraryRule.java
+++ b/bindings/java/src/junit/com/apple/foundationdb/FDBLibraryRule.java
@@ -37,7 +37,7 @@ public class FDBLibraryRule implements BeforeAllCallback {
 
 	public FDBLibraryRule(int apiVersion) { this.apiVersion = apiVersion; }
 
-	public static FDBLibraryRule current() { return new FDBLibraryRule(700); }
+	public static FDBLibraryRule current() { return new FDBLibraryRule(710); }
 
 	public static FDBLibraryRule v63() { return new FDBLibraryRule(630); }
 

--- a/bindings/java/src/main/com/apple/foundationdb/FDB.java
+++ b/bindings/java/src/main/com/apple/foundationdb/FDB.java
@@ -35,7 +35,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  *   This call is required before using any other part of the API. The call allows
  *   an error to be thrown at this point to prevent client code from accessing a later library
  *   with incorrect assumptions from the current version. The API version documented here is version
- *   {@code 700}.<br><br>
+ *   {@code 710}.<br><br>
  *  FoundationDB encapsulates multiple versions of its interface by requiring
  *   the client to explicitly specify the version of the API it uses. The purpose
  *   of this design is to allow you to upgrade the server, client libraries, or
@@ -183,8 +183,8 @@ public class FDB {
 		}
 		if(version < 510)
 			throw new IllegalArgumentException("API version not supported (minimum 510)");
-		if(version > 700)
-			throw new IllegalArgumentException("API version not supported (maximum 700)");
+		if(version > 710)
+			throw new IllegalArgumentException("API version not supported (maximum 710)");
 
 		Select_API_version(version);
 		singleton = new FDB(version);

--- a/bindings/java/src/main/overview.html.in
+++ b/bindings/java/src/main/overview.html.in
@@ -13,7 +13,7 @@ and then added to your classpath.<br>
 <h1>Getting started</h1>
 To start using FoundationDB from Java, create an instance of the 
 {@link com.apple.foundationdb.FDB FoundationDB API interface} with the version of the
-API that you want to use (this release of the FoundationDB Java API supports versions between {@code 510} and {@code 700}).
+API that you want to use (this release of the FoundationDB Java API supports versions between {@code 510} and {@code 710}).
 With this API object you can then open {@link com.apple.foundationdb.Cluster Cluster}s and
 {@link com.apple.foundationdb.Database Database}s and start using
 {@link com.apple.foundationdb.Transaction Transaction}s.
@@ -29,7 +29,7 @@ import com.apple.foundationdb.tuple.Tuple;
 
 public class Example {
   public static void main(String[] args) {
-    FDB fdb = FDB.selectAPIVersion(700);
+    FDB fdb = FDB.selectAPIVersion(710);
 
     try(Database db = fdb.open()) {
       // Run an operation on the database

--- a/bindings/java/src/test/com/apple/foundationdb/test/AbstractTester.java
+++ b/bindings/java/src/test/com/apple/foundationdb/test/AbstractTester.java
@@ -27,7 +27,7 @@ import com.apple.foundationdb.Database;
 import com.apple.foundationdb.FDB;
 
 public abstract class AbstractTester {
-	public static final int API_VERSION = 700;
+	public static final int API_VERSION = 710;
 	protected static final int NUM_RUNS = 25;
 	protected static final Charset ASCII = Charset.forName("ASCII");
 

--- a/bindings/java/src/test/com/apple/foundationdb/test/BlockingBenchmark.java
+++ b/bindings/java/src/test/com/apple/foundationdb/test/BlockingBenchmark.java
@@ -33,7 +33,7 @@ public class BlockingBenchmark {
 	private static final int PARALLEL = 100;
 
 	public static void main(String[] args) throws InterruptedException {
-		FDB fdb = FDB.selectAPIVersion(700);
+		FDB fdb = FDB.selectAPIVersion(710);
 
 		// The cluster file DOES NOT need to be valid, although it must exist.
 		//  This is because the database is never really contacted in this test.

--- a/bindings/java/src/test/com/apple/foundationdb/test/ConcurrentGetSetGet.java
+++ b/bindings/java/src/test/com/apple/foundationdb/test/ConcurrentGetSetGet.java
@@ -48,7 +48,7 @@ public class ConcurrentGetSetGet {
 	}
 
 	public static void main(String[] args) {
-		try(Database database = FDB.selectAPIVersion(700).open()) {
+		try(Database database = FDB.selectAPIVersion(710).open()) {
 			new ConcurrentGetSetGet().apply(database);
 		}
 	}

--- a/bindings/java/src/test/com/apple/foundationdb/test/Example.java
+++ b/bindings/java/src/test/com/apple/foundationdb/test/Example.java
@@ -26,7 +26,7 @@ import com.apple.foundationdb.tuple.Tuple;
 
 public class Example {
 	public static void main(String[] args) {
-		FDB fdb = FDB.selectAPIVersion(700);
+		FDB fdb = FDB.selectAPIVersion(710);
 
 		try(Database db = fdb.open()) {
 			// Run an operation on the database

--- a/bindings/java/src/test/com/apple/foundationdb/test/IterableTest.java
+++ b/bindings/java/src/test/com/apple/foundationdb/test/IterableTest.java
@@ -31,7 +31,7 @@ public class IterableTest {
 	public static void main(String[] args) throws InterruptedException {
 		final int reps = 1000;
 		try {
-			FDB fdb = FDB.selectAPIVersion(700);
+			FDB fdb = FDB.selectAPIVersion(710);
 			try(Database db = fdb.open()) {
 				runTests(reps, db);
 			}

--- a/bindings/java/src/test/com/apple/foundationdb/test/LocalityTests.java
+++ b/bindings/java/src/test/com/apple/foundationdb/test/LocalityTests.java
@@ -34,7 +34,7 @@ import com.apple.foundationdb.tuple.ByteArrayUtil;
 public class LocalityTests {
 
 	public static void main(String[] args) {
-		FDB fdb = FDB.selectAPIVersion(700);
+		FDB fdb = FDB.selectAPIVersion(710);
 		try(Database database = fdb.open(args[0])) {
 			try(Transaction tr = database.createTransaction()) {
 				String[] keyAddresses = LocalityUtil.getAddressesForKey(tr, "a".getBytes()).join();

--- a/bindings/java/src/test/com/apple/foundationdb/test/ParallelRandomScan.java
+++ b/bindings/java/src/test/com/apple/foundationdb/test/ParallelRandomScan.java
@@ -43,7 +43,7 @@ public class ParallelRandomScan {
 	private static final int PARALLELISM_STEP = 5;
 
 	public static void main(String[] args) throws InterruptedException {
-		FDB api = FDB.selectAPIVersion(700);
+		FDB api = FDB.selectAPIVersion(710);
 		try(Database database = api.open(args[0])) {
 			for(int i = PARALLELISM_MIN; i <= PARALLELISM_MAX; i += PARALLELISM_STEP) {
 				runTest(database, i, ROWS, DURATION_MS);

--- a/bindings/java/src/test/com/apple/foundationdb/test/RangeTest.java
+++ b/bindings/java/src/test/com/apple/foundationdb/test/RangeTest.java
@@ -34,7 +34,7 @@ import com.apple.foundationdb.Transaction;
 import com.apple.foundationdb.async.AsyncIterable;
 
 public class RangeTest {
-	private static final int API_VERSION = 700;
+	private static final int API_VERSION = 710;
 
 	public static void main(String[] args) {
 		System.out.println("About to use version " + API_VERSION);

--- a/bindings/java/src/test/com/apple/foundationdb/test/SerialInsertion.java
+++ b/bindings/java/src/test/com/apple/foundationdb/test/SerialInsertion.java
@@ -34,7 +34,7 @@ public class SerialInsertion {
 	private static final int NODES = 1000000;
 
 	public static void main(String[] args) {
-		FDB api = FDB.selectAPIVersion(700);
+		FDB api = FDB.selectAPIVersion(710);
 		try(Database database = api.open()) {
 			long start = System.currentTimeMillis();
 

--- a/bindings/java/src/test/com/apple/foundationdb/test/SerialIteration.java
+++ b/bindings/java/src/test/com/apple/foundationdb/test/SerialIteration.java
@@ -39,7 +39,7 @@ public class SerialIteration {
 	private static final int THREAD_COUNT = 1;
 
 	public static void main(String[] args) throws InterruptedException {
-		FDB api = FDB.selectAPIVersion(700);
+		FDB api = FDB.selectAPIVersion(710);
 		try(Database database = api.open(args[0])) {
 			for(int i = 1; i <= THREAD_COUNT; i++) {
 				runThreadedTest(database, i);

--- a/bindings/java/src/test/com/apple/foundationdb/test/SerialTest.java
+++ b/bindings/java/src/test/com/apple/foundationdb/test/SerialTest.java
@@ -30,7 +30,7 @@ public class SerialTest {
 	public static void main(String[] args) throws InterruptedException {
 		final int reps = 1000;
 		try {
-			FDB fdb = FDB.selectAPIVersion(700);
+			FDB fdb = FDB.selectAPIVersion(710);
 			try(Database db = fdb.open()) {
 				runTests(reps, db);
 			}

--- a/bindings/java/src/test/com/apple/foundationdb/test/SnapshotTransactionTest.java
+++ b/bindings/java/src/test/com/apple/foundationdb/test/SnapshotTransactionTest.java
@@ -39,7 +39,7 @@ public class SnapshotTransactionTest {
 	private static final Subspace SUBSPACE = new Subspace(Tuple.from("test", "conflict_ranges"));
 
 	public static void main(String[] args) {
-		FDB fdb = FDB.selectAPIVersion(700);
+		FDB fdb = FDB.selectAPIVersion(710);
 		try(Database db = fdb.open()) {
 			snapshotReadShouldNotConflict(db);
 			snapshotShouldNotAddConflictRange(db);

--- a/bindings/java/src/test/com/apple/foundationdb/test/TupleTest.java
+++ b/bindings/java/src/test/com/apple/foundationdb/test/TupleTest.java
@@ -37,7 +37,7 @@ public class TupleTest {
 	public static void main(String[] args) throws NoSuchFieldException {
 		final int reps = 1000;
 		try {
-			FDB fdb = FDB.selectAPIVersion(700);
+			FDB fdb = FDB.selectAPIVersion(710);
 			try(Database db = fdb.open()) {
 				runTests(reps, db);
 			}

--- a/bindings/java/src/test/com/apple/foundationdb/test/VersionstampSmokeTest.java
+++ b/bindings/java/src/test/com/apple/foundationdb/test/VersionstampSmokeTest.java
@@ -32,7 +32,7 @@ import com.apple.foundationdb.tuple.Versionstamp;
 
 public class VersionstampSmokeTest {
 	public static void main(String[] args) {
-		FDB fdb = FDB.selectAPIVersion(700);
+		FDB fdb = FDB.selectAPIVersion(710);
 		try(Database db = fdb.open()) {
 			db.run(tr -> {
 				tr.clear(Tuple.from("prefix").range());

--- a/bindings/java/src/test/com/apple/foundationdb/test/WatchTest.java
+++ b/bindings/java/src/test/com/apple/foundationdb/test/WatchTest.java
@@ -34,7 +34,7 @@ import com.apple.foundationdb.Transaction;
 public class WatchTest {
 
 	public static void main(String[] args) {
-		FDB fdb = FDB.selectAPIVersion(700);
+		FDB fdb = FDB.selectAPIVersion(710);
 		try(Database database = fdb.open(args[0])) {
 			database.options().setLocationCacheSize(42);
 			try(Transaction tr = database.createTransaction()) {

--- a/bindings/python/fdb/__init__.py
+++ b/bindings/python/fdb/__init__.py
@@ -52,7 +52,7 @@ def get_api_version():
 
 
 def api_version(ver):
-    header_version = 700
+    header_version = 710
 
     if '_version' in globals():
         if globals()['_version'] != ver:

--- a/bindings/python/fdb/impl.py
+++ b/bindings/python/fdb/impl.py
@@ -253,7 +253,7 @@ def transactional(*tr_args, **tr_kwargs):
             @functools.wraps(func)
             def wrapper(*args, **kwargs):
                 # We can't throw this from the decorator, as when a user runs
-                # >>> import fdb ; fdb.api_version(700)
+                # >>> import fdb ; fdb.api_version(710)
                 # the code above uses @transactional before the API version is set
                 if fdb.get_api_version() >= 630 and inspect.isgeneratorfunction(func):
                     raise ValueError("Generators can not be wrapped with fdb.transactional")

--- a/bindings/python/tests/size_limit_tests.py
+++ b/bindings/python/tests/size_limit_tests.py
@@ -22,7 +22,7 @@ import fdb
 import sys
 
 if __name__ == '__main__':
-    fdb.api_version(700)
+    fdb.api_version(710)
 
 @fdb.transactional
 def setValue(tr, key, value):

--- a/bindings/ruby/lib/fdb.rb
+++ b/bindings/ruby/lib/fdb.rb
@@ -36,7 +36,7 @@ module FDB
     end
   end
   def self.api_version(version)
-    header_version = 700
+    header_version = 710
     if self.is_api_version_selected?()
       if @@chosen_version != version
         raise "FDB API already loaded at version #{@@chosen_version}."

--- a/build/cmake/package_tester/fdb_c_app/app.c
+++ b/build/cmake/package_tester/fdb_c_app/app.c
@@ -1,7 +1,7 @@
-#define FDB_API_VERSION 700
+#define FDB_API_VERSION 710
 #include <foundationdb/fdb_c.h>
 
 int main(int argc, char* argv[]) {
-	fdb_select_api_version(700);
+	fdb_select_api_version(710);
 	return 0;
 }

--- a/build/cmake/package_tester/modules/tests.sh
+++ b/build/cmake/package_tester/modules/tests.sh
@@ -65,7 +65,7 @@ then
        python setup.py install
        successOr "Installing python bindings failed"
        popd
-       python -c 'import fdb; fdb.api_version(700)'
+       python -c 'import fdb; fdb.api_version(710)'
        successOr "Loading python bindings failed"
 
        # Test cmake and pkg-config integration: https://github.com/apple/foundationdb/issues/1483

--- a/documentation/sphinx/source/administration.rst
+++ b/documentation/sphinx/source/administration.rst
@@ -235,7 +235,7 @@ If you interrupt the exclude command with Ctrl-C after seeing the "waiting for s
 
 7) If you ever want to add a removed machine back to the cluster, you will have to take it off the excluded servers list to which it was added in step 3. This can be done using the ``include`` command of ``fdbcli``. If attempting to re-include a failed server, this can be done using the ``include failed`` command of ``fdbcli``. Typing ``exclude`` with no parameters will tell you the current list of excluded and failed machines.
 
-As of api version 710, excluding servers can be done with the :ref:`special key space management module <special-key-space-management-module>` as well.
+As of api version 700, excluding servers can be done with the :ref:`special key space management module <special-key-space-management-module>` as well.
 
 Moving a cluster
 ================

--- a/documentation/sphinx/source/administration.rst
+++ b/documentation/sphinx/source/administration.rst
@@ -235,7 +235,7 @@ If you interrupt the exclude command with Ctrl-C after seeing the "waiting for s
 
 7) If you ever want to add a removed machine back to the cluster, you will have to take it off the excluded servers list to which it was added in step 3. This can be done using the ``include`` command of ``fdbcli``. If attempting to re-include a failed server, this can be done using the ``include failed`` command of ``fdbcli``. Typing ``exclude`` with no parameters will tell you the current list of excluded and failed machines.
 
-As of api version 700, excluding servers can be done with the :ref:`special key space management module <special-key-space-management-module>` as well.
+As of api version 710, excluding servers can be done with the :ref:`special key space management module <special-key-space-management-module>` as well.
 
 Moving a cluster
 ================

--- a/documentation/sphinx/source/api-c.rst
+++ b/documentation/sphinx/source/api-c.rst
@@ -133,7 +133,7 @@ API versioning
 
 Prior to including ``fdb_c.h``, you must define the ``FDB_API_VERSION`` macro. This, together with the :func:`fdb_select_api_version()` function, allows programs written against an older version of the API to compile and run with newer versions of the C library. The current version of the FoundationDB C API is |api-version|. ::
 
-  #define FDB_API_VERSION 700
+  #define FDB_API_VERSION 710
   #include <foundationdb/fdb_c.h>
 
 .. function:: fdb_error_t fdb_select_api_version(int version)

--- a/documentation/sphinx/source/api-common.rst.inc
+++ b/documentation/sphinx/source/api-common.rst.inc
@@ -148,7 +148,7 @@
 .. |atomic-versionstamps-tuple-warning-value| replace::
     At this time, versionstamped values are not compatible with the Tuple layer except in Java, Python, and Go. Note that this implies versionstamped values may not be used with the Subspace and Directory layers except in those languages.
 
-.. |api-version| replace:: 700
+.. |api-version| replace:: 710
 
 .. |streaming-mode-blurb1| replace::
     When using |get-range-func| and similar interfaces, API clients can request large ranges of the database to iterate over.  Making such a request doesn't necessarily mean that the client will consume all of the data in the range - sometimes the client doesn't know how far it intends to iterate in advance.  FoundationDB tries to balance latency and bandwidth by requesting data for iteration in batches.

--- a/documentation/sphinx/source/api-python.rst
+++ b/documentation/sphinx/source/api-python.rst
@@ -108,7 +108,7 @@ Opening a database
 After importing the ``fdb`` module and selecting an API version, you probably want to open a :class:`Database` using :func:`open`::
 
     import fdb
-    fdb.api_version(700)
+    fdb.api_version(710)
     db = fdb.open()
 
 .. function:: open( cluster_file=None, event_model=None )

--- a/documentation/sphinx/source/api-ruby.rst
+++ b/documentation/sphinx/source/api-ruby.rst
@@ -93,7 +93,7 @@ Opening a database
 After requiring the ``FDB`` gem and selecting an API version, you probably want to open a :class:`Database` using :func:`open`::
 
     require 'fdb'
-    FDB.api_version 700
+    FDB.api_version 710
     db = FDB.open
 
 .. function:: open( cluster_file=nil ) -> Database

--- a/documentation/sphinx/source/api-version-upgrade-guide.rst
+++ b/documentation/sphinx/source/api-version-upgrade-guide.rst
@@ -9,6 +9,14 @@ This document provides an overview of changes that an application developer may 
 
 For more details about API versions, see :ref:`api-versions`.
 
+.. _api-version-upgrade-guide-710:
+
+API version 710
+===============
+
+General
+-------
+
 .. _api-version-upgrade-guide-700:
 
 API version 700

--- a/documentation/sphinx/source/class-scheduling-go.rst
+++ b/documentation/sphinx/source/class-scheduling-go.rst
@@ -29,7 +29,7 @@ Before using the API, we need to specify the API version. This allows programs t
 
 .. code-block:: go
 
-  fdb.MustAPIVersion(700)
+  fdb.MustAPIVersion(710)
 
 Next, we open a FoundationDB database.  The API will connect to the FoundationDB cluster indicated by the :ref:`default cluster file <default-cluster-file>`.
 
@@ -78,7 +78,7 @@ If this is all working, it looks like we are ready to start building a real appl
 
   func main() {
       // Different API versions may expose different runtime behaviors.
-      fdb.MustAPIVersion(700)
+      fdb.MustAPIVersion(710)
 
       // Open the default database from the system cluster
       db := fdb.MustOpenDefault()
@@ -666,7 +666,7 @@ Here's the code for the scheduling tutorial:
   }
 
   func main() {
-    fdb.MustAPIVersion(700)
+    fdb.MustAPIVersion(710)
     db := fdb.MustOpenDefault()
     db.Options().SetTransactionTimeout(60000)  // 60,000 ms = 1 minute
     db.Options().SetTransactionRetryLimit(100)

--- a/documentation/sphinx/source/class-scheduling-java.rst
+++ b/documentation/sphinx/source/class-scheduling-java.rst
@@ -30,7 +30,7 @@ Before using the API, we need to specify the API version. This allows programs t
   private static final Database db;
 
   static {
-    fdb = FDB.selectAPIVersion(700);
+    fdb = FDB.selectAPIVersion(710);
     db = fdb.open();
   }
 
@@ -66,7 +66,7 @@ If this is all working, it looks like we are ready to start building a real appl
     private static final Database db;
 
     static {
-      fdb = FDB.selectAPIVersion(700);
+      fdb = FDB.selectAPIVersion(710);
       db = fdb.open();
     }
 
@@ -441,7 +441,7 @@ Here's the code for the scheduling tutorial:
     private static final Database db;
 
     static {
-      fdb = FDB.selectAPIVersion(700);
+      fdb = FDB.selectAPIVersion(710);
       db = fdb.open();
       db.options().setTransactionTimeout(60000);  // 60,000 ms = 1 minute
       db.options().setTransactionRetryLimit(100);

--- a/documentation/sphinx/source/class-scheduling-ruby.rst
+++ b/documentation/sphinx/source/class-scheduling-ruby.rst
@@ -23,7 +23,7 @@ Open a Ruby interactive interpreter and import the FoundationDB API module::
 
 Before using the API, we need to specify the API version. This allows programs to maintain compatibility even if the API is modified in future versions::
 
-    > FDB.api_version 700
+    > FDB.api_version 710
     => nil
 
 Next, we open a FoundationDB database.  The API will connect to the FoundationDB cluster indicated by the :ref:`default cluster file <default-cluster-file>`. ::
@@ -46,7 +46,7 @@ If this is all working, it looks like we are ready to start building a real appl
 .. code-block:: ruby
 
     require 'fdb'
-    FDB.api_version 700
+    FDB.api_version 710
     @db = FDB.open
     @db['hello'] = 'world'
     print 'hello ', @db['hello']
@@ -373,7 +373,7 @@ Here's the code for the scheduling tutorial:
 
     require 'fdb'
 
-    FDB.api_version 700
+    FDB.api_version 710
 
     ####################################
     ##        Initialization          ##

--- a/documentation/sphinx/source/class-scheduling.rst
+++ b/documentation/sphinx/source/class-scheduling.rst
@@ -30,7 +30,7 @@ Open a Python interactive interpreter and import the FoundationDB API module::
 
 Before using the API, we need to specify the API version. This allows programs to maintain compatibility even if the API is modified in future versions::
 
-    >>> fdb.api_version(700)
+    >>> fdb.api_version(710)
 
 Next, we open a FoundationDB database.  The API will connect to the FoundationDB cluster indicated by the :ref:`default cluster file <default-cluster-file>`. ::
 
@@ -48,7 +48,7 @@ When this command returns without exception, the modification is durably stored 
 If this is all working, it looks like we are ready to start building a real application. For reference, here's the full code for "hello world"::
 
     import fdb
-    fdb.api_version(700)
+    fdb.api_version(710)
     db = fdb.open()
     db[b'hello'] = b'world'
     print 'hello', db[b'hello']
@@ -91,7 +91,7 @@ FoundationDB includes a few tools that make it easy to model data using this app
 opening a :ref:`directory <developer-guide-directories>` in the database::
 
     import fdb
-    fdb.api_version(700)
+    fdb.api_version(710)
 
     db = fdb.open()
     scheduling = fdb.directory.create_or_open(db, ('scheduling',))
@@ -337,7 +337,7 @@ Here's the code for the scheduling tutorial::
     import fdb
     import fdb.tuple
 
-    fdb.api_version(700)
+    fdb.api_version(710)
 
 
     ####################################

--- a/documentation/sphinx/source/developer-guide.rst
+++ b/documentation/sphinx/source/developer-guide.rst
@@ -918,7 +918,7 @@ Caveats
 Read/write modules
 ------------------
 
-As of api version 700, some modules in the special key space allow writes as
+As of api version 710, some modules in the special key space allow writes as
 well as reads. In these modules, a user can expect that mutations (i.e. sets,
 clears, etc) do not have side-effects outside of the current transaction
 until commit is called (the same is true for writes to the normal key space).

--- a/documentation/sphinx/source/developer-guide.rst
+++ b/documentation/sphinx/source/developer-guide.rst
@@ -918,7 +918,7 @@ Caveats
 Read/write modules
 ------------------
 
-As of api version 710, some modules in the special key space allow writes as
+As of api version 700, some modules in the special key space allow writes as
 well as reads. In these modules, a user can expect that mutations (i.e. sets,
 clears, etc) do not have side-effects outside of the current transaction
 until commit is called (the same is true for writes to the normal key space).

--- a/documentation/sphinx/source/hierarchical-documents-java.rst
+++ b/documentation/sphinx/source/hierarchical-documents-java.rst
@@ -69,7 +69,7 @@ Here’s a basic implementation of the recipe.
         private static final long EMPTY_ARRAY = -1;
 
         static {
-            fdb = FDB.selectAPIVersion(700);
+            fdb = FDB.selectAPIVersion(710);
             db = fdb.open();
             docSpace = new Subspace(Tuple.from("D"));
         }

--- a/documentation/sphinx/source/multimaps-java.rst
+++ b/documentation/sphinx/source/multimaps-java.rst
@@ -74,7 +74,7 @@ Here’s a simple implementation of multimaps with multisets as described:
         private static final int N = 100;
 
         static {
-            fdb = FDB.selectAPIVersion(700);
+            fdb = FDB.selectAPIVersion(710);
             db = fdb.open();
             multi = new Subspace(Tuple.from("M"));
         }

--- a/documentation/sphinx/source/priority-queues-java.rst
+++ b/documentation/sphinx/source/priority-queues-java.rst
@@ -74,7 +74,7 @@ Here's a basic implementation of the model:
         private static final Random randno;
 
         static{
-            fdb = FDB.selectAPIVersion(700);
+            fdb = FDB.selectAPIVersion(710);
             db = fdb.open();
             pq = new Subspace(Tuple.from("P"));
 

--- a/documentation/sphinx/source/queues-java.rst
+++ b/documentation/sphinx/source/queues-java.rst
@@ -73,7 +73,7 @@ The following is a simple implementation of the basic pattern:
         private static final Random randno;
 
         static{
-            fdb = FDB.selectAPIVersion(700);
+            fdb = FDB.selectAPIVersion(710);
             db = fdb.open();
             queue = new Subspace(Tuple.from("Q"));
             randno = new Random();

--- a/documentation/sphinx/source/simple-indexes-java.rst
+++ b/documentation/sphinx/source/simple-indexes-java.rst
@@ -87,7 +87,7 @@ In this example, we’re storing user data based on user ID but sometimes need t
         private static final Subspace index;
 
         static {
-            fdb = FDB.selectAPIVersion(700);
+            fdb = FDB.selectAPIVersion(710);
             db = fdb.open();
             main = new Subspace(Tuple.from("user"));
             index = new Subspace(Tuple.from("zipcode_index"));

--- a/documentation/sphinx/source/tables-java.rst
+++ b/documentation/sphinx/source/tables-java.rst
@@ -62,7 +62,7 @@ Here’s a simple implementation of the basic table pattern:
         private static final Subspace colIndex;
 
         static {
-            fdb = FDB.selectAPIVersion(700);
+            fdb = FDB.selectAPIVersion(710);
             db = fdb.open();
             table = new Subspace(Tuple.from("T"));
             rowIndex = table.subspace(Tuple.from("R"));

--- a/documentation/sphinx/source/vector-java.rst
+++ b/documentation/sphinx/source/vector-java.rst
@@ -77,7 +77,7 @@ Here’s the basic pattern:
         private static final Subspace vector;
 
         static {
-            fdb = FDB.selectAPIVersion(700);
+            fdb = FDB.selectAPIVersion(710);
             db = fdb.open();
             vector = new Subspace(Tuple.from("V"));
         }

--- a/recipes/go-recipes/blob.go
+++ b/recipes/go-recipes/blob.go
@@ -78,7 +78,7 @@ func read_blob(t fdb.ReadTransactor, blob_subspace subspace.Subspace) ([]byte, e
 }
 
 func main() {
-	fdb.MustAPIVersion(700)
+	fdb.MustAPIVersion(710)
 
 	db := fdb.MustOpenDefault()
 

--- a/recipes/go-recipes/doc.go
+++ b/recipes/go-recipes/doc.go
@@ -219,7 +219,7 @@ func (doc Doc) GetDoc(trtr fdb.Transactor, doc_id int) interface{} {
 }
 
 func main() {
-	fdb.MustAPIVersion(700)
+	fdb.MustAPIVersion(710)
 
 	db := fdb.MustOpenDefault()
 

--- a/recipes/go-recipes/graph.go
+++ b/recipes/go-recipes/graph.go
@@ -124,7 +124,7 @@ func (graph *Graph) get_in_neighbors(trtr fdb.Transactor, node int) ([]int, erro
 }
 
 func main() {
-	fdb.MustAPIVersion(700)
+	fdb.MustAPIVersion(710)
 
 	db := fdb.MustOpenDefault()
 

--- a/recipes/go-recipes/indirect.go
+++ b/recipes/go-recipes/indirect.go
@@ -93,7 +93,7 @@ func (wrkspc Workspace) Session(foo func(directory.DirectorySubspace)) (err erro
 }
 
 func main() {
-	fdb.MustAPIVersion(700)
+	fdb.MustAPIVersion(710)
 
 	db := fdb.MustOpenDefault()
 

--- a/recipes/go-recipes/multi.go
+++ b/recipes/go-recipes/multi.go
@@ -132,7 +132,7 @@ func (multi MultiMap) MultiIsElement(trtr fdb.Transactor, index, value interface
 
 func main() {
 
-	fdb.MustAPIVersion(700)
+	fdb.MustAPIVersion(710)
 
 	db := fdb.MustOpenDefault()
 

--- a/recipes/go-recipes/priority.go
+++ b/recipes/go-recipes/priority.go
@@ -117,7 +117,7 @@ func (prty Priority) Peek(trtr fdb.Transactor, max bool) interface{} {
 }
 
 func main() {
-	fdb.MustAPIVersion(700)
+	fdb.MustAPIVersion(710)
 
 	db := fdb.MustOpenDefault()
 

--- a/recipes/go-recipes/queue.go
+++ b/recipes/go-recipes/queue.go
@@ -107,7 +107,7 @@ func (q *Queue) FirstItem(trtr fdb.Transactor) (interface{}, error) {
 func main() {
 	fmt.Println("Queue Example Program")
 
-	fdb.MustAPIVersion(700)
+	fdb.MustAPIVersion(710)
 
 	db := fdb.MustOpenDefault()
 

--- a/recipes/go-recipes/table.go
+++ b/recipes/go-recipes/table.go
@@ -144,7 +144,7 @@ func (tbl Table) TableGetCol(tr fdb.ReadTransactor, col int) ([]interface{}, err
 }
 
 func main() {
-	fdb.MustAPIVersion(700)
+	fdb.MustAPIVersion(710)
 
 	db := fdb.MustOpenDefault()
 

--- a/versions.target
+++ b/versions.target
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <Version>7.0.0</Version>
-    <PackageName>7.0</PackageName>
+    <Version>7.1.0</Version>
+    <PackageName>7.1</PackageName>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Changing api version from `700` to `710` and cmake target to `7.1`. The binding tests passed (earlier failure was due to `TraceEvent::errorKind`, which was fixed in #4772).

20210506-055506-jingyu_zhou-8203d120d80d7899       compressed=True data_size=74155460 duration=1984346 ended=103231 fail_fast=10 max_runs=100000 pass=100186 priority=100 remaining=0 runtime=0:15:45 sanity=False started=103267 stopped=20210506-061051 submitted=20210506-055506 timeout=5400 username=jingyu_zhou

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
