### PR TITLE
tLog component level test

### DIFF
--- a/fdbserver/CMakeLists.txt
+++ b/fdbserver/CMakeLists.txt
@@ -124,6 +124,8 @@ set(FDBSERVER_SRCS
   ptxn/test/FakeStorageServer.actor.h
   ptxn/test/FakeTLog.actor.cpp
   ptxn/test/FakeTLog.actor.h
+  ptxn/test/RealTLog.actor.cpp
+  ptxn/test/RealTLog.actor.h
   ptxn/test/TestResolver.actor.cpp
   ptxn/test/TestSerialization.cpp
 

--- a/fdbserver/ptxn/test/RealTLog.actor.cpp
+++ b/fdbserver/ptxn/test/RealTLog.actor.cpp
@@ -1,0 +1,274 @@
+/*
+ * TLog.actor.cpp
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "fdbserver/ptxn/test/RealTLog.actor.h"
+
+#include <vector>
+
+#include "fdbrpc/Locality.h"
+#include "fdbrpc/ReplicationPolicy.h"
+#include "fdbserver/TLogInterface.h"
+#include "fdbserver/ServerDBInfo.actor.h"
+#include "fdbserver/IDiskQueue.h"
+#include "fdbserver/WorkerInterface.actor.h"
+#include "fdbserver/LogSystem.h"
+#include "flow/actorcompiler.h" // has to be last include
+
+// This test starts a single tLog and runs commits, peeks, and pops using the tLog interface.
+// The test's purpose is to help with microbenchmarks and experimentation.
+// The storage server is assumed to run at infinite speed.
+
+// In the future this could support multiple tlogs (single or multiple groups),
+// along with higher level components such as TagPartitionedLogSystem.
+
+namespace ptxn {
+
+// build test state.
+std::shared_ptr<TLogDriverContext> initTLogDriverContext(const TestDriverOptions& options,
+                                                         const TestTLogDriverOptions tLogOptions) {
+	std::shared_ptr<TLogDriverContext> context(new TLogDriverContext());
+	context->logID = deterministicRandom()->randomUniqueID();
+	context->workerID = deterministicRandom()->randomUniqueID();
+	context->diskQueueBasename = tLogOptions.diskQueueBasename;
+	context->numCommits = options.numCommits;
+	context->dcID = LiteralStringRef("test");
+	context->tagLocality = 0; // one data center.
+	context->dbInfo = ServerDBInfo();
+	context->dbInfo.logSystemConfig.logSystemType = LogSystemType::tagPartitioned;
+
+	return context;
+}
+
+// run a single tLog.
+ACTOR Future<Void> getTLogCreateActor(std::shared_ptr<TestDriverContext> pTestDriverContext,
+                                      std::shared_ptr<TLogDriverContext> pTLogDriverContext,
+                                      TestTLogDriverOptions tLogOptions,
+                                      uint16_t processID) {
+
+	// build per-tLog state.
+	state std::shared_ptr<TLogContext> pTLogContext(new TLogContext());
+	pTLogContext->tagProcessID = processID;
+	pTLogContext->tLogID = deterministicRandom()->randomUniqueID();
+	pTLogContext->persistentQueue = openDiskQueue(pTLogDriverContext->diskQueueBasename,
+	                                              tLogOptions.diskQueueExtension,
+	                                              pTLogContext->tLogID,
+	                                              DiskQueueVersion::V1);
+	pTLogContext->persistentData = keyValueStoreMemory(tLogOptions.kvStoreFilename,
+	                                                   pTLogContext->tLogID,
+	                                                   tLogOptions.kvMemoryLimit,
+	                                                   "fdr",
+	                                                   KeyValueStoreType::MEMORY_RADIXTREE);
+	pTLogDriverContext->pTLogContext = pTLogContext;
+
+	// prepare tLog construction.
+	Standalone<StringRef> machineID = LiteralStringRef("machine");
+	LocalityData localities(
+	    Optional<Standalone<StringRef>>(), pTLogDriverContext->zoneID, machineID, pTLogDriverContext->dcID);
+	localities.set(LiteralStringRef("datacenter"), pTLogDriverContext->dcID);
+	Reference<AsyncVar<ServerDBInfo>> dbInfoRef = makeReference<AsyncVar<ServerDBInfo>>(pTLogDriverContext->dbInfo);
+	Reference<AsyncVar<bool>> isDegraded = FlowTransport::transport().getDegraded();
+	Reference<AsyncVar<UID>> activeSharedTLog(new AsyncVar<UID>(pTLogContext->tLogID));
+	state PromiseStream<InitializeTLogRequest> promiseStream = PromiseStream<InitializeTLogRequest>();
+	Promise<Void> oldLog;
+	Promise<Void> recovery;
+
+	// construct tLog.
+	state Future<Void> tl = tLog(pTLogContext->persistentData,
+	                             pTLogContext->persistentQueue,
+	                             dbInfoRef,
+	                             localities,
+	                             promiseStream,
+	                             pTLogContext->tLogID,
+	                             pTLogDriverContext->workerID,
+	                             false, /* restoreFromDisk */
+	                             oldLog,
+	                             recovery,
+	                             pTLogDriverContext->diskQueueBasename,
+	                             isDegraded,
+	                             activeSharedTLog);
+
+	// start tlog.
+	state InitializeTLogRequest initTlogReq = InitializeTLogRequest();
+	initTlogReq.isPrimary = true;
+	TLogInterface interface = wait(promiseStream.getReply(initTlogReq));
+	pTLogContext->realTLogInterface = interface;
+
+	// inform other actors tLog is ready.
+	pTLogContext->TLogCreated.send(true);
+
+	// wait for either test completion or abnormal failure.
+	choose {
+		when(wait(tl)) {}
+		when(bool testCompleted = wait(pTLogContext->realTLogTestCompleted.getFuture())) {}
+	}
+
+	return Void();
+}
+
+// sent commits through TLog interface.
+ACTOR Future<Void> getTLogCommitActor(std::shared_ptr<TestDriverContext> pTestDriverContext,
+                                      std::shared_ptr<TLogDriverContext> pTLogDriverContext) {
+	bool tLogReady = wait(pTLogDriverContext->pTLogContext->TLogStarted.getFuture());
+	state Version prev = 0;
+	state Version next = 1;
+	state int i = 0;
+	for (; i < pTLogDriverContext->numCommits; i++) {
+		Standalone<StringRef> key = StringRef(format("key %d", i));
+		Standalone<StringRef> val = StringRef(format("value %d", i));
+		MutationRef m(MutationRef::Type::SetValue, key, val);
+		Tag tag(pTLogDriverContext->tagLocality, pTLogDriverContext->pTLogContext->tagProcessID);
+
+		// build commit request
+		LogPushData toCommit(pTLogDriverContext->ls, pTLogDriverContext->pTLogContext->realTLogInterface);
+		UID spanID = deterministicRandom()->randomUniqueID();
+		toCommit.addTransactionInfo(spanID);
+		vector<Tag> tags = { tag };
+		toCommit.addTags(tags);
+		toCommit.writeTypedMessage(m);
+		int location = 0;
+		Standalone<StringRef> msg = toCommit.getMessages(location);
+
+		// send commit and wait for reply.
+		::TLogCommitRequest request(
+		    SpanID(), msg.arena(), prev, next, prev, prev, msg, deterministicRandom()->randomUniqueID());
+		::TLogCommitReply reply = wait(pTLogDriverContext->pTLogContext->realTLogInterface.commit.getReply(request));
+		prev++;
+		next++;
+	}
+
+	return Void();
+}
+
+// send peek/pop through TLog interface.
+ACTOR Future<Void> getTLogPeekActor(std::shared_ptr<TestDriverContext> pTestDriverContext,
+                                    std::shared_ptr<TLogDriverContext> pTLogDriverContext) {
+	bool tLogReady = wait(pTLogDriverContext->pTLogContext->TLogStarted.getFuture());
+
+	state Tag tag(pTLogDriverContext->tagLocality, pTLogDriverContext->pTLogContext->tagProcessID);
+	state Version begin = 1;
+	state int i;
+	for (i = 0; i < pTLogDriverContext->numCommits; i++) {
+		// wait for next message commit
+		::TLogPeekRequest request(begin, tag, false, false);
+		::TLogPeekReply reply =
+		    wait(pTLogDriverContext->pTLogContext->realTLogInterface.peekMessages.getReply(request));
+
+		// validate versions
+		ASSERT_GE(reply.maxKnownVersion, i);
+
+		// deserialize package, first the version header
+		ArenaReader rd = ArenaReader(reply.arena, reply.messages, AssumeVersion(g_network->protocolVersion()));
+		ASSERT_EQ(*(int32_t*)rd.peekBytes(4), VERSION_HEADER);
+		TagsAndMessage messageAndTags = TagsAndMessage();
+		int32_t dummy; // skip past VERSION_HEADER
+		Version ver;
+		rd >> dummy >> ver;
+
+		// deserialize transaction header
+		int32_t messageLength;
+		uint16_t tagCount;
+		uint32_t sub;
+		rd >> messageLength >> sub >> tagCount;
+		rd.readBytes(tagCount * sizeof(Tag));
+
+		// deserialize span id
+		SpanContextMessage contextMessage;
+		rd >> contextMessage;
+
+		// deserialize mutation header
+		rd >> messageLength >> sub >> tagCount;
+		rd.readBytes(tagCount * sizeof(Tag));
+
+		// deserialize mutation
+		MutationRef m;
+		rd >> m;
+
+		// validate data
+		Standalone<StringRef> expectedKey = StringRef(format("key %d", i));
+		Standalone<StringRef> expectedVal = StringRef(format("value %d", i));
+		ASSERT_WE_THINK(m.param1 == expectedKey);
+		ASSERT_WE_THINK(m.param2 == expectedVal);
+
+		// go directly to pop as there is no SS.
+		::TLogPopRequest requestPop(begin, begin, tag);
+		wait(pTLogDriverContext->pTLogContext->realTLogInterface.popMessages.getReply(requestPop));
+
+		begin++;
+	}
+
+	return Void();
+}
+
+// wait for all tLogs to be created (currently only one). Then build tLog group, then
+// signal transactions can start.
+ACTOR Future<Void> getTLogGroupActor(std::shared_ptr<TestDriverContext> pTestDriverContext,
+                                     std::shared_ptr<TLogDriverContext> pTLogDriverContext) {
+	state std::shared_ptr<TLogContext> pTLogContext = pTLogDriverContext->pTLogContext;
+	bool isCreated = wait(pTLogContext->TLogCreated.getFuture());
+
+	// setup log system and tlog group
+	pTLogDriverContext->tLogSet.tLogs.push_back(OptionalInterface<TLogInterface>(pTLogContext->realTLogInterface));
+	pTLogDriverContext->tLogSet.tLogLocalities.push_back(LocalityData());
+	pTLogDriverContext->tLogSet.tLogPolicy = Reference<IReplicationPolicy>(new PolicyOne());
+	pTLogDriverContext->tLogSet.locality = 0;
+	pTLogDriverContext->tLogSet.isLocal = true;
+	pTLogDriverContext->tLogSet.tLogVersion = TLogVersion::V6;
+
+	pTLogDriverContext->dbInfo.logSystemConfig.tLogs.push_back(pTLogDriverContext->tLogSet);
+	pTLogDriverContext->ls = ILogSystem::fromServerDBInfo(pTLogDriverContext->logID, pTLogDriverContext->dbInfo, false);
+
+	// start transactions
+	pTLogDriverContext->pTLogContext->TLogStarted.send(true);
+
+	std::vector<Future<Void>> actors;
+	actors.emplace_back(getTLogCommitActor(pTestDriverContext, pTLogDriverContext));
+	actors.emplace_back(getTLogPeekActor(pTestDriverContext, pTLogDriverContext));
+	wait(waitForAll(actors));
+
+	// tell tLog actor to initiate shutdown.
+	pTLogDriverContext->pTLogContext->realTLogTestCompleted.send(true);
+
+	return Void();
+}
+
+// create actors and return them in a list.
+void startActors(std::vector<Future<Void>>& actors,
+                 std::shared_ptr<TestDriverContext> pTestDriverContext,
+                 std::shared_ptr<TLogDriverContext> pTLogDriverContext,
+                 const TestTLogDriverOptions tLogOptions) {
+	actors.emplace_back(
+	    getTLogCreateActor(pTestDriverContext, pTLogDriverContext, tLogOptions, 0 /* processID used in tag */));
+	actors.emplace_back(getTLogGroupActor(pTestDriverContext, pTLogDriverContext));
+}
+
+} // namespace ptxn
+
+TEST_CASE("/fdbserver/ptxn/test/realtlogdriver") {
+	using namespace ptxn;
+
+	std::vector<Future<Void>> actors;
+	TestDriverOptions driverOptions(params);
+	TestTLogDriverOptions tLogOptions(params);
+	std::shared_ptr<TestDriverContext> context = initTestDriverContext(driverOptions);
+	std::shared_ptr<TLogDriverContext> realTLogContext = initTLogDriverContext(driverOptions, tLogOptions);
+	startActors(actors, context, realTLogContext, tLogOptions);
+	wait(waitForAll(actors));
+	return Void();
+}

--- a/fdbserver/ptxn/test/RealTLog.actor.h
+++ b/fdbserver/ptxn/test/RealTLog.actor.h
@@ -1,0 +1,97 @@
+/*
+ * FakeTLog.actor.h
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#if defined(NO_INTELLISENSE) && !defined(FDBSERVER_PTXN_TEST_REALTLOG_ACTOR_G_H)
+#define FDBSERVER_PTXN_TEST_REALTLOG_ACTOR_G_H
+#include "fdbserver/ptxn/test/RealTLog.actor.g.h"
+#elif !defined(FDBSERVER_PTXN_TEST_REALTLOG_ACTOR_H)
+#define FDBSERVER_PTXN_TEST_REALTLOG_ACTOR_H
+
+#include <memory>
+#include <unordered_map>
+
+#include "fdbclient/FDBTypes.h"
+#include "fdbserver/LogSystem.h"
+#include "fdbserver/ResolverInterface.h"
+#include "fdbserver/ptxn/test/Driver.h"
+#include "fdbserver/ptxn/TLogInterface.h"
+#include "fdbserver/ptxn/StorageServerInterface.h"
+#include "flow/flow.h"
+
+#include "flow/actorcompiler.h" // has to be last include
+
+#pragma once
+
+namespace ptxn {
+
+struct TestTLogDriverOptions {
+	std::string diskQueueBasename;
+	std::string diskQueueExtension;
+	std::string kvStoreFilename;
+	int64_t kvMemoryLimit;
+
+	explicit TestTLogDriverOptions(const UnitTestParameters& params) {
+		diskQueueBasename = params.get("diskQueueBasename").orDefault("folder");
+		diskQueueExtension = params.get("diskQueueFileExtension").orDefault("ext");
+		kvStoreFilename = params.get("kvStoreFilename").orDefault("kvstore");
+		kvMemoryLimit = params.getDouble("kvMemoryLimit").orDefault(0x500e6);
+	}
+};
+
+// state maintained for a single tlog.
+struct TLogContext {
+	UID tLogID;
+	::TLogInterface realTLogInterface;
+	uint16_t tagProcessID;
+	IKeyValueStore* persistentData;
+	IDiskQueue* persistentQueue;
+
+	// test states
+	Promise<bool> TLogCreated;
+	Promise<bool> TLogStarted;
+	Promise<bool> realTLogTestCompleted;
+};
+
+// state maintained for all tlogs.
+struct TLogDriverContext {
+
+	UID logID;
+	UID workerID;
+
+	// paramaters
+	std::string diskQueueBasename;
+	int numCommits;
+
+	// test driver state
+	std::shared_ptr<TLogContext> pTLogContext;
+
+	// fdb state
+	Reference<ILogSystem> ls;
+	ServerDBInfo dbInfo;
+	TLogSet tLogSet;
+	Standalone<StringRef> dcID;
+	Optional<Standalone<StringRef>> zoneID;
+	int8_t tagLocality;
+};
+
+} // namespace ptxn
+
+#include "flow/unactorcompiler.h"
+#endif // FDBSERVER_PTXN_TEST_REALTLOG_ACTOR_H

--- a/fdbserver/ptxn/test/RealTLog.actor.h
+++ b/fdbserver/ptxn/test/RealTLog.actor.h
@@ -72,6 +72,20 @@ struct TLogContext {
 // state maintained for all tlogs.
 struct TLogDriverContext {
 
+	Future<Void> sendCommitMessages(std::shared_ptr<TestDriverContext> pTestDriverContext) {
+		return sendCommitMessages_impl(pTestDriverContext, this);
+	}
+
+	ACTOR static Future<Void> sendCommitMessages_impl(std::shared_ptr<TestDriverContext> pTestDriverContext,
+	                                                  TLogDriverContext* pTLogDriverContext);
+
+	Future<Void> peekCommitMessages(std::shared_ptr<TestDriverContext> pTestDriverContext) {
+		return peekCommitMessages_impl(pTestDriverContext, this);
+	}
+
+	ACTOR static Future<Void> peekCommitMessages_impl(std::shared_ptr<TestDriverContext> pTestDriverContext,
+	                                                  TLogDriverContext* pTLogDriverContext);
+
 	UID logID;
 	UID workerID;
 


### PR DESCRIPTION
Add a new test to run a single stand-alone tlog. The test runs "numCommits" transactions using the tLog commit and peek interfaces. Data and versions are checked. This can be used for benchmarking. 

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
