### PR TITLE
Fix msgpack dependency (release-7.0)

### DIFF
--- a/cmake/GetMsgpack.cmake
+++ b/cmake/GetMsgpack.cmake
@@ -16,4 +16,5 @@ else()
 
   ExternalProject_Get_property(msgpackProject SOURCE_DIR)
   target_include_directories(msgpack SYSTEM INTERFACE "${SOURCE_DIR}/include")
+  add_dependencies(msgpack msgpackProject)
 endif()


### PR DESCRIPTION
Backport of #4759 to fix an issue when building a cmake component with an fdb_c dependency but not an explicit fdbclient dependency.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
