### PR TITLE
Revert "Actually close files in simulation" (release-7.0)

### DIFF
--- a/fdbrpc/AsyncFileNonDurable.actor.h
+++ b/fdbrpc/AsyncFileNonDurable.actor.h
@@ -276,20 +276,6 @@ public:
 			Future<Void> deleteFuture = deleteFile(this);
 			if (!deleteFuture.isReady())
 				filesBeingDeleted[filename] = deleteFuture;
-		} else if (isSoleOwner()) {
-			// isSoleOwner is a bit confusing here. What we mean is that the openFiles map is the sole owner. If we
-			// remove the file from the map to make sure it gets closed.
-			auto& openFiles = g_simulator.getCurrentProcess()->machine->openFiles;
-			auto iter = openFiles.find(filename);
-			// the file could've been renamed (DiskQueue does that for example). In that case the file won't be in the
-			// map anymore.
-			if (iter != openFiles.end()) {
-				// even if the filename exists, it doesn't mean that it references the same file. It could be that the
-				// file was renamed and later a file with the same name was opened.
-				if (iter->second.canGet() && iter->second.get().getPtr() == this) {
-					openFiles.erase(filename);
-				}
-			}
 		}
 	}
 

--- a/fdbrpc/sim2.actor.cpp
+++ b/fdbrpc/sim2.actor.cpp
@@ -537,10 +537,7 @@ public:
 
 	std::string getFilename() const override { return actualFilename; }
 
-	~SimpleFile() override {
-		_close(h);
-		--openCount;
-	}
+	~SimpleFile() override { _close(h); }
 
 private:
 	int h;
@@ -1941,7 +1938,10 @@ public:
 		TraceEvent("ClogInterface")
 		    .detail("IP", ip.toString())
 		    .detail("Delay", seconds)
-		    .detail("Queue", mode == ClogSend ? "Send" : mode == ClogReceive ? "Receive" : "All");
+		    .detail("Queue",
+		            mode == ClogSend      ? "Send"
+		            : mode == ClogReceive ? "Receive"
+		                                  : "All");
 
 		if (mode == ClogSend || mode == ClogAll)
 			g_clogging.clogSendFor(ip, seconds);
@@ -2415,9 +2415,9 @@ int sf_open(const char* filename, int flags, int convFlags, int mode) {
 	                       GENERIC_READ | ((flags & IAsyncFile::OPEN_READWRITE) ? GENERIC_WRITE : 0),
 	                       FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
 	                       nullptr,
-	                       (flags & IAsyncFile::OPEN_EXCLUSIVE)
-	                           ? CREATE_NEW
-	                           : (flags & IAsyncFile::OPEN_CREATE) ? OPEN_ALWAYS : OPEN_EXISTING,
+	                       (flags & IAsyncFile::OPEN_EXCLUSIVE) ? CREATE_NEW
+	                       : (flags & IAsyncFile::OPEN_CREATE)  ? OPEN_ALWAYS
+	                                                            : OPEN_EXISTING,
 	                       FILE_ATTRIBUTE_NORMAL,
 	                       nullptr);
 	int h = -1;

--- a/flow/flow.h
+++ b/flow/flow.h
@@ -805,8 +805,6 @@ public:
 	bool isValid() const { return sav != 0; }
 	bool isReady() const { return sav->isSet(); }
 	bool isError() const { return sav->isError(); }
-	// returns true if get can be called on this future (counterpart of canBeSet on Promises)
-	bool canGet() const { return isValid() && isReady() && !isError(); }
 	Error& getError() const {
 		ASSERT(isError());
 		return sav->error_state;


### PR DESCRIPTION
Cherry pick https://github.com/apple/foundationdb/pull/4756 to release-7.0

Reverts apple/foundationdb#4562. It was causing segfaults in simulation.