### PR TITLE
Expose "bounce impact" and Storage Server "version catch-up rate" metrics

### DIFF
--- a/documentation/sphinx/source/mr-status-json-schemas.rst.inc
+++ b/documentation/sphinx/source/mr-status-json-schemas.rst.inc
@@ -477,6 +477,7 @@
       ],
       "recovery_state":{
          "seconds_since_last_recovered":1,
+         "seconds_since_fully_recovered":1,
          "required_resolvers":1,
          "required_commit_proxies":1,
          "required_grv_proxies":1,

--- a/documentation/sphinx/source/mr-status-json-schemas.rst.inc
+++ b/documentation/sphinx/source/mr-status-json-schemas.rst.inc
@@ -121,6 +121,16 @@
                      "counter":0,
                      "roughness":0.0
                   },
+                  "fetched_versions":{
+                     "hz":0.0,
+                     "counter":0,
+                     "roughness":0.0
+                  },
+                  "fetch_frequency":{
+                     "hz":0.0,
+                     "counter":0,
+                     "roughness":0.0
+                  },
                   "grv_latency_statistics":{ // GRV Latency metrics are grouped according to priority (currently batch or default).
                      "default":{
                          "count":0,

--- a/documentation/sphinx/source/mr-status-json-schemas.rst.inc
+++ b/documentation/sphinx/source/mr-status-json-schemas.rst.inc
@@ -126,7 +126,7 @@
                      "counter":0,
                      "roughness":0.0
                   },
-                  "fetch_frequency":{
+                  "fetches_from_logs":{
                      "hz":0.0,
                      "counter":0,
                      "roughness":0.0

--- a/documentation/sphinx/source/mr-status-json-schemas.rst.inc
+++ b/documentation/sphinx/source/mr-status-json-schemas.rst.inc
@@ -477,7 +477,6 @@
       ],
       "recovery_state":{
          "seconds_since_last_recovered":1,
-         "seconds_since_fully_recovered":1,
          "required_resolvers":1,
          "required_commit_proxies":1,
          "required_grv_proxies":1,
@@ -503,6 +502,10 @@
          "required_logs":3,
          "missing_logs":"7f8d623d0cb9966e",
          "active_generations":1,
+         "bounce_impact":{
+            "can_clean_bounce":true,
+            "reason":""
+         },
          "description":"Recovery complete."
       },
       "workload":{

--- a/documentation/sphinx/source/mr-status-json-schemas.rst.inc
+++ b/documentation/sphinx/source/mr-status-json-schemas.rst.inc
@@ -502,10 +502,6 @@
          "required_logs":3,
          "missing_logs":"7f8d623d0cb9966e",
          "active_generations":1,
-         "bounce_impact":{
-            "can_clean_bounce":true,
-            "reason":""
-         },
          "description":"Recovery complete."
       },
       "workload":{
@@ -608,6 +604,10 @@
       "data_distribution_disabled_for_rebalance":true,
       "data_distribution_disabled":true,
       "active_primary_dc":"pv",
+      "bounce_impact":{
+         "can_clean_bounce":true,
+         "reason":""
+      },
       "configuration":{
          "log_anti_quorum":0,
          "log_replicas":2,

--- a/documentation/sphinx/source/release-notes/release-notes-700.rst
+++ b/documentation/sphinx/source/release-notes/release-notes-700.rst
@@ -33,7 +33,7 @@ Status
 * Added ``commit_batching_window_size`` to the proxy roles section of status to record statistics about commit batching window size on each proxy. `(PR #4735) <https://github.com/apple/foundationdb/pull/4735>`_
 * Added ``cluster.bounce_impact`` section to status to report if there will be any extra effects when bouncing the cluster, and if so, the reason for those effects. `(PR #4770) <https://github.com/apple/foundationdb/pull/4770>`_
 * Added ``fetched_versions`` to the storage metrics section of status to report how fast a storage server is catching up in versions. `(PR #4770) <https://github.com/apple/foundationdb/pull/4770>`_
-* Added ``fetch_frequency`` to the storage metrics section of status to report the version fetching frequency of a storage server. `(PR #4770) <https://github.com/apple/foundationdb/pull/4770>`_
+* Added ``fetch_frequency`` to the storage metrics section of status to report how frequently a storage server fetches updates from transaction logs. `(PR #4770) <https://github.com/apple/foundationdb/pull/4770>`_
 
 Bindings
 --------

--- a/documentation/sphinx/source/release-notes/release-notes-700.rst
+++ b/documentation/sphinx/source/release-notes/release-notes-700.rst
@@ -31,7 +31,7 @@ Fixes
 Status
 ------
 * Added ``commit_batching_window_size`` to the proxy roles section of status to record statistics about commit batching window size on each proxy. `(PR #4735) <https://github.com/apple/foundationdb/pull/4735>`_
-* Added ``bounce_impact`` to the recovery_state section of status to report if the cluster is bounceable and if not, the reason for why it is not bounceable. `(PR #4770) <https://github.com/apple/foundationdb/pull/4770>`_
+* Added ``cluster.bounce_impact`` section to status to report if there will be any extra effects when bouncing the cluster, and if so, the reason for those effects. `(PR #4770) <https://github.com/apple/foundationdb/pull/4770>`_
 
 Bindings
 --------

--- a/documentation/sphinx/source/release-notes/release-notes-700.rst
+++ b/documentation/sphinx/source/release-notes/release-notes-700.rst
@@ -31,7 +31,7 @@ Fixes
 Status
 ------
 * Added ``commit_batching_window_size`` to the proxy roles section of status to record statistics about commit batching window size on each proxy. `(PR #4735) <https://github.com/apple/foundationdb/pull/4735>`_
-
+* Added ``seconds_since_fully_recovered`` to the recovery_state section of status to report the time, in seconds, since last full recovery. `(PR #4770) <https://github.com/apple/foundationdb/pull/4770>`_
 
 Bindings
 --------

--- a/documentation/sphinx/source/release-notes/release-notes-700.rst
+++ b/documentation/sphinx/source/release-notes/release-notes-700.rst
@@ -32,6 +32,8 @@ Status
 ------
 * Added ``commit_batching_window_size`` to the proxy roles section of status to record statistics about commit batching window size on each proxy. `(PR #4735) <https://github.com/apple/foundationdb/pull/4735>`_
 * Added ``cluster.bounce_impact`` section to status to report if there will be any extra effects when bouncing the cluster, and if so, the reason for those effects. `(PR #4770) <https://github.com/apple/foundationdb/pull/4770>`_
+* Added ``fetched_versions`` to the storage metrics section of status to report how fast a storage server is catching up in versions. `(PR #4770) <https://github.com/apple/foundationdb/pull/4770>`_
+* Added ``fetch_frequency`` to the storage metrics section of status to report the version fetching frequency of a storage server. `(PR #4770) <https://github.com/apple/foundationdb/pull/4770>`_
 
 Bindings
 --------

--- a/documentation/sphinx/source/release-notes/release-notes-700.rst
+++ b/documentation/sphinx/source/release-notes/release-notes-700.rst
@@ -31,7 +31,7 @@ Fixes
 Status
 ------
 * Added ``commit_batching_window_size`` to the proxy roles section of status to record statistics about commit batching window size on each proxy. `(PR #4735) <https://github.com/apple/foundationdb/pull/4735>`_
-* Added ``seconds_since_fully_recovered`` to the recovery_state section of status to report the time, in seconds, since last full recovery. `(PR #4770) <https://github.com/apple/foundationdb/pull/4770>`_
+* Added ``bounce_impact`` to the recovery_state section of status to report if the cluster is bounceable and if not, the reason for why it is not bounceable. `(PR #4770) <https://github.com/apple/foundationdb/pull/4770>`_
 
 Bindings
 --------

--- a/documentation/sphinx/source/release-notes/release-notes-700.rst
+++ b/documentation/sphinx/source/release-notes/release-notes-700.rst
@@ -33,7 +33,7 @@ Status
 * Added ``commit_batching_window_size`` to the proxy roles section of status to record statistics about commit batching window size on each proxy. `(PR #4735) <https://github.com/apple/foundationdb/pull/4735>`_
 * Added ``cluster.bounce_impact`` section to status to report if there will be any extra effects when bouncing the cluster, and if so, the reason for those effects. `(PR #4770) <https://github.com/apple/foundationdb/pull/4770>`_
 * Added ``fetched_versions`` to the storage metrics section of status to report how fast a storage server is catching up in versions. `(PR #4770) <https://github.com/apple/foundationdb/pull/4770>`_
-* Added ``fetch_frequency`` to the storage metrics section of status to report how frequently a storage server fetches updates from transaction logs. `(PR #4770) <https://github.com/apple/foundationdb/pull/4770>`_
+* Added ``fetches_from_logs`` to the storage metrics section of status to report how frequently a storage server fetches updates from transaction logs. `(PR #4770) <https://github.com/apple/foundationdb/pull/4770>`_
 
 Bindings
 --------

--- a/fdbclient/Schemas.cpp
+++ b/fdbclient/Schemas.cpp
@@ -149,7 +149,7 @@ const KeyRef JSONSchemas::statusSchema = LiteralStringRef(R"statusSchema(
                      "counter":0,
                      "roughness":0.0
                   },
-                  "fetch_frequency":{
+                  "fetches_from_logs":{
                      "hz":0.0,
                      "counter":0,
                      "roughness":0.0

--- a/fdbclient/Schemas.cpp
+++ b/fdbclient/Schemas.cpp
@@ -521,7 +521,6 @@ const KeyRef JSONSchemas::statusSchema = LiteralStringRef(R"statusSchema(
                                                           R"statusSchema(
       "recovery_state":{
          "seconds_since_last_recovered":1,
-         "seconds_since_fully_recovered":1,
          "required_resolvers":1,
          "required_commit_proxies":1,
          "required_grv_proxies":1,
@@ -547,6 +546,10 @@ const KeyRef JSONSchemas::statusSchema = LiteralStringRef(R"statusSchema(
          "required_logs":3,
          "missing_logs":"7f8d623d0cb9966e",
          "active_generations":1,
+         "bounce_impact":{
+            "can_clean_bounce":true,
+            "reason":""
+         },
          "description":"Recovery complete."
       },
       "workload":{

--- a/fdbclient/Schemas.cpp
+++ b/fdbclient/Schemas.cpp
@@ -521,6 +521,7 @@ const KeyRef JSONSchemas::statusSchema = LiteralStringRef(R"statusSchema(
                                                           R"statusSchema(
       "recovery_state":{
          "seconds_since_last_recovered":1,
+         "seconds_since_fully_recovered":1,
          "required_resolvers":1,
          "required_commit_proxies":1,
          "required_grv_proxies":1,

--- a/fdbclient/Schemas.cpp
+++ b/fdbclient/Schemas.cpp
@@ -546,10 +546,6 @@ const KeyRef JSONSchemas::statusSchema = LiteralStringRef(R"statusSchema(
          "required_logs":3,
          "missing_logs":"7f8d623d0cb9966e",
          "active_generations":1,
-         "bounce_impact":{
-            "can_clean_bounce":true,
-            "reason":""
-         },
          "description":"Recovery complete."
       },
       "workload":{
@@ -652,6 +648,10 @@ const KeyRef JSONSchemas::statusSchema = LiteralStringRef(R"statusSchema(
       "data_distribution_disabled_for_rebalance":true,
       "data_distribution_disabled":true,
       "active_primary_dc":"pv",
+      "bounce_impact":{
+         "can_clean_bounce":true,
+         "reason":""
+      },
       "configuration":{
          "log_anti_quorum":0,
          "log_replicas":2,

--- a/fdbclient/Schemas.cpp
+++ b/fdbclient/Schemas.cpp
@@ -144,6 +144,16 @@ const KeyRef JSONSchemas::statusSchema = LiteralStringRef(R"statusSchema(
                      "counter":0,
                      "roughness":0.0
                   },
+                  "fetched_versions":{
+                     "hz":0.0,
+                     "counter":0,
+                     "roughness":0.0
+                  },
+                  "fetch_frequency":{
+                     "hz":0.0,
+                     "counter":0,
+                     "roughness":0.0
+                  },
                   "grv_latency_statistics":{
                      "default":{
                         "count":0,

--- a/fdbserver/LogSystem.h
+++ b/fdbserver/LogSystem.h
@@ -410,6 +410,8 @@ struct ILogSystem {
 
 		virtual Optional<UID> getPrimaryPeekLocation() const = 0;
 
+		virtual Optional<UID> getCurrentPeekLocation() const = 0;
+
 		virtual void addref() = 0;
 
 		virtual void delref() = 0;
@@ -473,6 +475,7 @@ struct ILogSystem {
 		Version popped() const override;
 		Version getMinKnownCommittedVersion() const override;
 		Optional<UID> getPrimaryPeekLocation() const override;
+		Optional<UID> getCurrentPeekLocation() const override;
 
 		void addref() override { ReferenceCounted<ServerPeekCursor>::addref(); }
 
@@ -534,6 +537,7 @@ struct ILogSystem {
 		Version popped() const override;
 		Version getMinKnownCommittedVersion() const override;
 		Optional<UID> getPrimaryPeekLocation() const override;
+		Optional<UID> getCurrentPeekLocation() const override;
 
 		void addref() override { ReferenceCounted<MergedPeekCursor>::addref(); }
 
@@ -589,6 +593,7 @@ struct ILogSystem {
 		Version popped() const override;
 		Version getMinKnownCommittedVersion() const override;
 		Optional<UID> getPrimaryPeekLocation() const override;
+		Optional<UID> getCurrentPeekLocation() const override;
 
 		void addref() override { ReferenceCounted<SetPeekCursor>::addref(); }
 
@@ -620,6 +625,7 @@ struct ILogSystem {
 		Version popped() const override;
 		Version getMinKnownCommittedVersion() const override;
 		Optional<UID> getPrimaryPeekLocation() const override;
+		Optional<UID> getCurrentPeekLocation() const override;
 
 		void addref() override { ReferenceCounted<MultiCursor>::addref(); }
 
@@ -698,6 +704,7 @@ struct ILogSystem {
 		Version popped() const override;
 		Version getMinKnownCommittedVersion() const override;
 		Optional<UID> getPrimaryPeekLocation() const override;
+		Optional<UID> getCurrentPeekLocation() const override;
 
 		void addref() override { ReferenceCounted<BufferedCursor>::addref(); }
 

--- a/fdbserver/LogSystemPeekCursor.actor.cpp
+++ b/fdbserver/LogSystemPeekCursor.actor.cpp
@@ -393,10 +393,14 @@ Version ILogSystem::ServerPeekCursor::getMinKnownCommittedVersion() const {
 }
 
 Optional<UID> ILogSystem::ServerPeekCursor::getPrimaryPeekLocation() const {
-	if (interf) {
+	if (interf->get().present()) {
 		return interf->get().id();
 	}
 	return Optional<UID>();
+}
+
+Optional<UID> ILogSystem::ServerPeekCursor::getCurrentPeekLocation() const {
+	return ILogSystem::ServerPeekCursor::getPrimaryPeekLocation();
 }
 
 Version ILogSystem::ServerPeekCursor::popped() const {
@@ -669,6 +673,13 @@ Version ILogSystem::MergedPeekCursor::getMinKnownCommittedVersion() const {
 Optional<UID> ILogSystem::MergedPeekCursor::getPrimaryPeekLocation() const {
 	if (bestServer >= 0) {
 		return serverCursors[bestServer]->getPrimaryPeekLocation();
+	}
+	return Optional<UID>();
+}
+
+Optional<UID> ILogSystem::MergedPeekCursor::getCurrentPeekLocation() const {
+	if (currentCursor >= 0) {
+		return serverCursors[currentCursor]->getPrimaryPeekLocation();
 	}
 	return Optional<UID>();
 }
@@ -1023,6 +1034,13 @@ Optional<UID> ILogSystem::SetPeekCursor::getPrimaryPeekLocation() const {
 	return Optional<UID>();
 }
 
+Optional<UID> ILogSystem::SetPeekCursor::getCurrentPeekLocation() const {
+	if (currentCursor >= 0 && currentSet >= 0) {
+		return serverCursors[currentSet][currentCursor]->getPrimaryPeekLocation();
+	}
+	return Optional<UID>();
+}
+
 Version ILogSystem::SetPeekCursor::popped() const {
 	Version poppedVersion = 0;
 	for (auto& cursors : serverCursors) {
@@ -1121,6 +1139,10 @@ Version ILogSystem::MultiCursor::getMinKnownCommittedVersion() const {
 
 Optional<UID> ILogSystem::MultiCursor::getPrimaryPeekLocation() const {
 	return cursors.back()->getPrimaryPeekLocation();
+}
+
+Optional<UID> ILogSystem::MultiCursor::getCurrentPeekLocation() const {
+	return cursors.back()->getCurrentPeekLocation();
 }
 
 Version ILogSystem::MultiCursor::popped() const {
@@ -1400,6 +1422,10 @@ Version ILogSystem::BufferedCursor::getMinKnownCommittedVersion() const {
 }
 
 Optional<UID> ILogSystem::BufferedCursor::getPrimaryPeekLocation() const {
+	return Optional<UID>();
+}
+
+Optional<UID> ILogSystem::BufferedCursor::getCurrentPeekLocation() const {
 	return Optional<UID>();
 }
 

--- a/fdbserver/LogSystemPeekCursor.actor.cpp
+++ b/fdbserver/LogSystemPeekCursor.actor.cpp
@@ -393,7 +393,7 @@ Version ILogSystem::ServerPeekCursor::getMinKnownCommittedVersion() const {
 }
 
 Optional<UID> ILogSystem::ServerPeekCursor::getPrimaryPeekLocation() const {
-	if (interf->get().present()) {
+	if (interf && interf->get().present()) {
 		return interf->get().id();
 	}
 	return Optional<UID>();

--- a/fdbserver/Status.actor.cpp
+++ b/fdbserver/Status.actor.cpp
@@ -1183,8 +1183,6 @@ ACTOR static Future<JsonBuilderObject> recoveryStateStatusFetcher(Database cx,
 			message["missing_logs"] = md.getValue("MissingIDs").c_str();
 		}
 
-		message["bounce_impact"] = getBounceImpactInfo(mStatusCode);
-
 		// TODO:  time_in_recovery: 0.5
 		//        time_in_state: 0.1
 
@@ -2791,6 +2789,7 @@ ACTOR Future<StatusReply> clusterGetStatus(
 
 		statusObj["protocol_version"] = format("%" PRIx64, g_network->protocolVersion().version());
 		statusObj["connection_string"] = coordinators.ccf->getConnectionString().toString();
+		statusObj["bounce_impact"] = getBounceImpactInfo(statusCode);
 
 		state Optional<DatabaseConfiguration> configuration;
 		state Optional<LoadConfigurationResult> loadResult;

--- a/fdbserver/Status.actor.cpp
+++ b/fdbserver/Status.actor.cpp
@@ -491,6 +491,8 @@ struct RolesInfo {
 			obj["mutation_bytes"] = StatusCounter(storageMetrics.getValue("MutationBytes")).getStatus();
 			obj["mutations"] = StatusCounter(storageMetrics.getValue("Mutations")).getStatus();
 			obj.setKeyRawNumber("local_rate", storageMetrics.getValue("LocalRate"));
+			obj["fetched_versions"] = StatusCounter(storageMetrics.getValue("FetchedVersions")).getStatus();
+			obj["fetch_frequency"] = StatusCounter(storageMetrics.getValue("FetchFrequency")).getStatus();
 
 			Version version = storageMetrics.getInt64("Version");
 			Version durableVersion = storageMetrics.getInt64("DurableVersion");

--- a/fdbserver/Status.actor.cpp
+++ b/fdbserver/Status.actor.cpp
@@ -492,7 +492,7 @@ struct RolesInfo {
 			obj["mutations"] = StatusCounter(storageMetrics.getValue("Mutations")).getStatus();
 			obj.setKeyRawNumber("local_rate", storageMetrics.getValue("LocalRate"));
 			obj["fetched_versions"] = StatusCounter(storageMetrics.getValue("FetchedVersions")).getStatus();
-			obj["fetch_frequency"] = StatusCounter(storageMetrics.getValue("FetchFrequency")).getStatus();
+			obj["fetches_from_logs"] = StatusCounter(storageMetrics.getValue("FetchesFromLogs")).getStatus();
 
 			Version version = storageMetrics.getInt64("Version");
 			Version durableVersion = storageMetrics.getInt64("DurableVersion");

--- a/fdbserver/Status.actor.cpp
+++ b/fdbserver/Status.actor.cpp
@@ -1168,6 +1168,13 @@ ACTOR static Future<JsonBuilderObject> recoveryStateStatusFetcher(Database cx,
 			message["required_resolvers"] = requiredResolvers;
 		} else if (mStatusCode == RecoveryStatus::locking_old_transaction_servers) {
 			message["missing_logs"] = md.getValue("MissingIDs").c_str();
+		} else if (mStatusCode == RecoveryStatus::fully_recovered) {
+			if (!rv.isError()) {
+				int64_t fullyRecoveredAtVersion = md.getInt64("FullyRecoveredAtVersion");
+				double secondsSinceFulyRecovered = std::max((int64_t)0, (int64_t)(rv.get() - fullyRecoveredAtVersion)) /
+							                       (double)SERVER_KNOBS->VERSIONS_PER_SECOND;
+				message["seconds_since_fully_recovered"] = secondsSinceFulyRecovered;
+			}
 		}
 		// TODO:  time_in_recovery: 0.5
 		//        time_in_state: 0.1

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -681,7 +681,7 @@ public:
 		Counter fetchWaitingMS, fetchWaitingCount, fetchExecutingMS, fetchExecutingCount;
 		Counter readsRejected;
 		Counter fetchedVersions;
-		Counter fetchFrequency;
+		Counter fetchesFromLogs;
 
 		LatencySample readLatencySample;
 		LatencyBands readLatencyBands;
@@ -700,10 +700,10 @@ public:
 		    fetchWaitingMS("FetchWaitingMS", cc), fetchWaitingCount("FetchWaitingCount", cc),
 		    fetchExecutingMS("FetchExecutingMS", cc), fetchExecutingCount("FetchExecutingCount", cc),
 		    readsRejected("ReadsRejected", cc), fetchedVersions("FetchedVersions", cc),
-		    fetchFrequency("FetchFrequency", cc), readLatencySample("ReadLatencyMetrics",
-                                                                    self->thisServerID,
-                                                                    SERVER_KNOBS->LATENCY_METRICS_LOGGING_INTERVAL,
-                                                                    SERVER_KNOBS->LATENCY_SAMPLE_SIZE),
+		    fetchesFromLogs("FetchesFromLogs", cc), readLatencySample("ReadLatencyMetrics",
+                                                                      self->thisServerID,
+                                                                      SERVER_KNOBS->LATENCY_METRICS_LOGGING_INTERVAL,
+                                                                      SERVER_KNOBS->LATENCY_SAMPLE_SIZE),
 		    readLatencyBands("ReadLatencyBands", self->thisServerID, SERVER_KNOBS->STORAGE_LOGGING_DELAY) {
 			specialCounter(cc, "LastTLogVersion", [self]() { return self->lastTLogVersion; });
 			specialCounter(cc, "Version", [self]() { return self->version.get(); });
@@ -3529,7 +3529,7 @@ ACTOR Future<Void> update(StorageServer* data, bool* pReceivedUpdate) {
 				data->otherError.getFuture().get();
 
 			data->counters.fetchedVersions += (ver - data->version.get());
-			++data->counters.fetchFrequency;
+			++data->counters.fetchesFromLogs;
 			Optional<UID> curSourceTLogID = cursor->getCurrentPeekLocation();
 
 			if (curSourceTLogID != data->sourceTLogID) {


### PR DESCRIPTION
Task: Report bounce impact in fdbcli status

Changes:

Schemas.cpp: Extend the JSON schema to include new fields that report
whether the cluster is bounceable and if not, report the reason for why it 
is not bounceable.

Status.actor.cpp: Extend recoveryStateStatusFetcher() to populate the
bounce related field(s).

mr-status-json-schemas.rst.inc: Update the schema to reflect the change
made in Schemas.cpp.

release-notes-700.rst: Add a note about the new status fields in "Status"
section.

Task: Report how fast an SS is catching up to its tLog-SS lag

Changes:

LogSystem.h, LogSystemPeekCursor.actor.cpp:  Add APIs to find the ID
of the tLog from which an SS has fetched the latest set of versions.

storagegroupserver.actor.cpp: 

- Add two new counters to StorageServer::Counters in order to capture
(a) SS version fetch rate and (b) SS version fetch frequency.

- Add a new field to StorageServer in order to capture the ID of the tLog
from which the latest set of versions have been fetched.

- update(): Populate the new counters; report the source tLog ID in a 
 trace event (and report the tLog ID only when it changes).

Status.actor.cpp: Extend Storage Server addRole() to report the SS
version fetch rate and the SS version fetch frequency.

Schemas.cpp: Extend the JSON schema to report the new metrics.

mr-status-json-schemas.rst.inc: Update the schema to reflect the
changes made to the JSON schema.
    
release-notes-700.rst: Add a note about the new metrics in "Status"
section.

Testing: 

Simulation tests: Started simulation tests.

Manual testing: 

Ran "status json" on a local cluster and verified that the new metrics are getting
populated:

    "cluster" : {
        "active_primary_dc" : "",
        "bounce_impact" : {
            "can_clean_bounce" : true
        },
        "clients" : {
            "count" : 0
        },

                        "durable_version" : 505285,
                        "fetch_frequency" : {
                            "counter" : 3,
                            "hz" : 0.39999899999999999,
                            "roughness" : 0.54349499999999995
                        },
                        "fetched_versions" : {
                            "counter" : 4327357,
                            "hz" : 865469,
                            "roughness" : 3339620
                        },

Dumped the value of "sourceTLogID" to stdout and verified that it is a valid one. (Don't
know how to test the trace event).

- Verified that the documentation related changes are getting rendered properly (by
checking the modified files on GitHub).

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
