### PR TITLE
Use default initializer for TraceEvent::errorKind

### DIFF
--- a/flow/Trace.h
+++ b/flow/Trace.h
@@ -483,7 +483,7 @@ private:
 	std::string trackingKey;
 	TraceEventFields fields;
 	Severity severity;
-	ErrorKind errorKind;
+	ErrorKind errorKind{ ErrorKind::Unset };
 	const char* type;
 	UID id;
 	Error err;


### PR DESCRIPTION
This backports https://github.com/apple/foundationdb/pull/4772.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
