### PR TITLE
Fix boost download links (release-6.2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ that Visual Studio is used to compile.
 
 1. Install Visual Studio 2017 (Community Edition is tested)
 1. Install cmake Version 3.12 or higher [CMake](https://cmake.org/)
-1. Download version 1.67 of [Boost](https://sourceforge.net/projects/boost/files/boost/1.67.0/).
+1. Download version 1.67 of [Boost](https://boostorg.jfrog.io/artifactory/main/release/1.67.0/source/boost_1_67_0.tar.bz2).
 1. Unpack boost (you don't need to compile it)
 1. Install [Mono](http://www.mono-project.com/download/stable/).
 1. Install a [JDK](http://www.oracle.com/technetwork/java/javase/downloads/index.html). FoundationDB currently builds with Java 8.

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -32,7 +32,7 @@ RUN adduser --comment '' fdb && chown fdb /opt
 # wget of bintray without forcing UTF-8 encoding results in 403 Forbidden
 # Old versions of FDB need boost 1.67
 RUN cd /opt/ &&\
-    curl -L https://dl.bintray.com/boostorg/release/1.67.0/source/boost_1_67_0.tar.bz2 -o boost_1_67_0.tar.bz2 &&\
+    curl -L https://boostorg.jfrog.io/artifactory/main/release/1.67.0/source/boost_1_67_0.tar.bz2 -o boost_1_67_0.tar.bz2 &&\
     echo "2684c972994ee57fc5632e03bf044746f6eb45d4920c343937a465fd67a5adba  boost_1_67_0.tar.bz2" > boost-sha-67.txt &&\
     sha256sum -c boost-sha-67.txt &&\
     tar -xjf boost_1_67_0.tar.bz2 &&\
@@ -41,7 +41,7 @@ RUN cd /opt/ &&\
 # install Boost 1.72
 # wget of bintray without forcing UTF-8 encoding results in 403 Forbidden
 RUN cd /tmp/ &&\
-    curl -L https://dl.bintray.com/boostorg/release/1.72.0/source/boost_1_72_0.tar.bz2 -o boost_1_72_0.tar.bz2 &&\
+    curl -L https://boostorg.jfrog.io/artifactory/main/release/1.72.0/source/boost_1_72_0.tar.bz2 -o boost_1_72_0.tar.bz2 &&\
     echo "59c9b274bc451cf91a9ba1dd2c7fdcaf5d60b1b3aa83f2c9fa143417cc660722  boost_1_72_0.tar.bz2" > boost-sha-72.txt &&\
     sha256sum -c boost-sha-72.txt &&\
     tar -xjf boost_1_72_0.tar.bz2 &&\

--- a/build/cmake/Dockerfile
+++ b/build/cmake/Dockerfile
@@ -13,7 +13,7 @@ RUN curl -L https://github.com/Kitware/CMake/releases/download/v3.13.4/cmake-3.1
     cd /tmp && tar xf cmake.tar.gz && cp -r cmake-3.13.4-Linux-x86_64/* /usr/local/
 
 # install boost
-RUN curl -L https://dl.bintray.com/boostorg/release/1.67.0/source/boost_1_67_0.tar.bz2 > /tmp/boost.tar.bz2 &&\
+RUN curl -L https://boostorg.jfrog.io/artifactory/main/release/1.67.0/source/boost_1_67_0.tar.bz2 > /tmp/boost.tar.bz2 &&\
     cd /tmp && echo "2684c972994ee57fc5632e03bf044746f6eb45d4920c343937a465fd67a5adba  boost.tar.bz2" > boost-sha.txt &&\
     sha256sum -c boost-sha.txt && tar xf boost.tar.bz2 && cp -r boost_1_67_0/boost /usr/local/include/ &&\
     rm -rf boost.tar.bz2 boost_1_67_0

--- a/cmake/CompileBoost.cmake
+++ b/cmake/CompileBoost.cmake
@@ -16,7 +16,7 @@ if(Boost_FOUND)
 else()
   include(ExternalProject)
   ExternalProject_add(boostProject
-    URL "https://dl.bintray.com/boostorg/release/1.67.0/source/boost_1_67_0.tar.bz2"
+    URL "https://boostorg.jfrog.io/artifactory/main/release/1.67.0/source/boost_1_67_0.tar.bz2"
     URL_HASH SHA256=2684c972994ee57fc5632e03bf044746f6eb45d4920c343937a465fd67a5adba
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ""


### PR DESCRIPTION
Cherry pick https://github.com/apple/foundationdb/pull/4746 to release-6.2



Bintray is shut down, so our download links for boost need to be updated. I replaced them with links from https://www.boost.org/users/history/ (also see https://sourceforge.net/p/boost/discussion/23622/thread/9fa9141990/?limit=25).

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [x] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [x] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [x] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
