### PR TITLE
Fix global config not triggering changes on server processes

### DIFF
--- a/fdbclient/ActorLineageProfiler.cpp
+++ b/fdbclient/ActorLineageProfiler.cpp
@@ -296,17 +296,6 @@ boost::asio::io_context& ActorLineageProfilerT::context() {
 
 SampleIngestor::~SampleIngestor() {}
 
-// Callback used to update the sampling profilers run frequency whenever the
-// frequency changes.
-void samplingProfilerUpdateFrequency(std::optional<std::any> freq) {
-	double frequency = 0;
-	if (freq.has_value()) {
-		frequency = std::any_cast<double>(freq.value());
-	}
-	TraceEvent(SevInfo, "SamplingProfilerUpdateFrequency").detail("Frequency", frequency);
-	ActorLineageProfiler::instance().setFrequency(frequency);
-}
-
 void ProfilerConfigT::reset(std::map<std::string, std::string> const& config) {
 	bool expectNoMore = false, useFluentD = false, useTCP = false;
 	std::string endpoint;
@@ -368,6 +357,17 @@ std::map<std::string, std::string> ProfilerConfigT::getConfig() const {
 		ingestor->getConfig(res);
 	}
 	return res;
+}
+
+// Callback used to update the sampling profilers run frequency whenever the
+// frequency changes.
+void samplingProfilerUpdateFrequency(std::optional<std::any> freq) {
+	double frequency = 0;
+	if (freq.has_value()) {
+		frequency = std::any_cast<double>(freq.value());
+	}
+	TraceEvent(SevInfo, "SamplingProfilerUpdateFrequency").detail("Frequency", frequency);
+	ActorLineageProfiler::instance().setFrequency(frequency);
 }
 
 // Callback used to update the sample collector window size.

--- a/fdbclient/GlobalConfig.actor.h
+++ b/fdbclient/GlobalConfig.actor.h
@@ -68,21 +68,19 @@ struct ConfigValue : ReferenceCounted<ConfigValue> {
 class GlobalConfig : NonCopyable {
 public:
 	// Creates a GlobalConfig singleton, accessed by calling GlobalConfig().
-	// This function should only be called once by each process (however, it is
-	// idempotent and calling it multiple times will have no effect).
-	static void create(DatabaseContext* cx, Reference<AsyncVar<ClientDBInfo>> dbInfo);
+	// This function requires a database context object to allow global
+	// configuration to run transactions on the database, and a ClientDBInfo
+	// object to read the latest global configuration history. The
+	// std::function parameter should refer to a function that triggers when
+	// the ClientDBInfo object is changed. This function should only be called
+	// once by each process (however, it is idempotent and calling it multiple
+	// times will have no effect).
+	static void create(DatabaseContext* cx, const ClientDBInfo* dbInfo, std::function<Future<Void>()> onChange);
 
 	// Returns a reference to the global GlobalConfig object. Clients should
 	// call this function whenever they need to read a value out of the global
 	// configuration.
 	static GlobalConfig& globalConfig();
-
-	// Updates the ClientDBInfo object used by global configuration to read new
-	// data. For server processes, this value needs to be set by the cluster
-	// controller, but global config is initialized before the cluster
-	// controller is, so this function provides a mechanism to update the
-	// object after initialization.
-	void updateDBInfo(Reference<AsyncVar<ClientDBInfo>> dbInfo);
 
 	// Use this function to turn a global configuration key defined above into
 	// the full path needed to set the value in the database.
@@ -156,10 +154,11 @@ private:
 
 	ACTOR static Future<Void> migrate(GlobalConfig* self);
 	ACTOR static Future<Void> refresh(GlobalConfig* self);
-	ACTOR static Future<Void> updater(GlobalConfig* self);
+	ACTOR static Future<Void> updater(GlobalConfig* self,
+	                                  const ClientDBInfo* dbInfo,
+	                                  std::function<Future<Void>()> onChange);
 
 	Database cx;
-	Reference<AsyncVar<ClientDBInfo>> dbInfo;
 	Future<Void> _updater;
 	Promise<Void> initialized;
 	AsyncTrigger configChanged;

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -1564,8 +1564,7 @@ Database Database::createDatabase(Reference<ClusterConnectionFile> connFile,
 		                         /*switchable*/ true);
 	}
 
-	GlobalConfig::create(
-	    db, std::addressof(clientInfo->get()), std::bind(&AsyncVar<ClientDBInfo>::onChange, clientInfo));
+	GlobalConfig::create(db, clientInfo, std::addressof(clientInfo->get()));
 	GlobalConfig::globalConfig().trigger(samplingFrequency, samplingProfilerUpdateFrequency);
 	GlobalConfig::globalConfig().trigger(samplingWindow, samplingProfilerUpdateWindow);
 	return Database(db);

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -962,10 +962,6 @@ DatabaseContext::DatabaseContext(Reference<AsyncVar<Reference<ClusterConnectionF
 	getValueSubmitted.init(LiteralStringRef("NativeAPI.GetValueSubmitted"));
 	getValueCompleted.init(LiteralStringRef("NativeAPI.GetValueCompleted"));
 
-	GlobalConfig::create(this, clientInfo);
-	GlobalConfig::globalConfig().trigger(samplingFrequency, samplingProfilerUpdateFrequency);
-	GlobalConfig::globalConfig().trigger(samplingWindow, samplingProfilerUpdateWindow);
-
 	monitorProxiesInfoChange = monitorProxiesChange(clientInfo, &proxiesChangeTrigger);
 	clientStatusUpdater.actor = clientStatusUpdateActor(this);
 	cacheListMonitor = monitorCacheList(this);
@@ -1568,6 +1564,10 @@ Database Database::createDatabase(Reference<ClusterConnectionFile> connFile,
 		                         /*switchable*/ true);
 	}
 
+	GlobalConfig::create(
+	    db, std::addressof(clientInfo->get()), std::bind(&AsyncVar<ClientDBInfo>::onChange, clientInfo));
+	GlobalConfig::globalConfig().trigger(samplingFrequency, samplingProfilerUpdateFrequency);
+	GlobalConfig::globalConfig().trigger(samplingWindow, samplingProfilerUpdateWindow);
 	return Database(db);
 }
 

--- a/fdbserver/ClusterController.actor.cpp
+++ b/fdbserver/ClusterController.actor.cpp
@@ -135,9 +135,7 @@ public:
 		                                                                         true,
 		                                                                         TaskPriority::DefaultEndpoint,
 		                                                                         true)) // SOMEDAY: Locality!
-		{
-			GlobalConfig::globalConfig().updateDBInfo(clientInfo);
-		}
+		{}
 
 		void setDistributor(const DataDistributorInterface& interf) {
 			auto newInfo = serverInfo->get();
@@ -3767,7 +3765,7 @@ ACTOR Future<Void> monitorGlobalConfig(ClusterControllerData::DBInfo* db) {
 				tr.setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
 				tr.setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
 				state Optional<Value> globalConfigVersion = wait(tr.get(globalConfigVersionKey));
-				state ClientDBInfo clientInfo = db->clientInfo->get();
+				state ClientDBInfo clientInfo = db->serverInfo->get().client;
 
 				if (globalConfigVersion.present()) {
 					// Since the history keys end with versionstamps, they
@@ -3825,6 +3823,15 @@ ACTOR Future<Void> monitorGlobalConfig(ClusterControllerData::DBInfo* db) {
 					}
 
 					clientInfo.id = deterministicRandom()->randomUniqueID();
+
+					// Update ServerDBInfo so fdbserver processes receive updated history.
+					ServerDBInfo serverInfo = db->serverInfo->get();
+					serverInfo.id = deterministicRandom()->randomUniqueID();
+					serverInfo.infoGeneration = ++db->dbInfoCount;
+					serverInfo.client = clientInfo;
+					db->serverInfo->set(serverInfo);
+
+					// Update ClientDBInfo so client processes receive updated history.
 					db->clientInfo->set(clientInfo);
 				}
 

--- a/fdbserver/worker.actor.cpp
+++ b/fdbserver/worker.actor.cpp
@@ -153,8 +153,7 @@ Database openDBOnServer(Reference<AsyncVar<ServerDBInfo>> const& db,
 	                                  enableLocalityLoadBalance,
 	                                  taskID,
 	                                  lockAware);
-	GlobalConfig::create(
-	    cx.getPtr(), std::addressof(db->get().client), std::bind(&AsyncVar<ServerDBInfo>::onChange, db));
+	GlobalConfig::create(cx.getPtr(), db, std::addressof(db->get().client));
 	GlobalConfig::globalConfig().trigger(samplingFrequency, samplingProfilerUpdateFrequency);
 	GlobalConfig::globalConfig().trigger(samplingWindow, samplingProfilerUpdateWindow);
 	return cx;

--- a/flow/genericactors.actor.h
+++ b/flow/genericactors.actor.h
@@ -697,6 +697,16 @@ private:
 	AsyncVar<Void> v;
 };
 
+// Binds an AsyncTrigger object to an AsyncVar, so when the AsyncVar changes
+// the AsyncTrigger is triggered.
+ACTOR template <class T>
+void forward(Reference<AsyncVar<T>> from, AsyncTrigger* to) {
+	loop {
+		wait(from->onChange());
+		to->trigger();
+	}
+}
+
 class Debouncer : NonCopyable {
 public:
 	explicit Debouncer(double delay) { worker = debounceWorker(this, delay); }


### PR DESCRIPTION
See #4330 and [this wiki page](https://github.com/apple/foundationdb/wiki/Global-Configuration-Framework) for context on global configuration.

This PR fixes an issue where only clients were being updated when keys in global configuration changed.

* When a role (such as a storage server or tlog) starts up, it calls `openDBOnServer` to create a `DatabaseContext` object, in order to be able to run transactions and do other database related things.
* `openDBOnServer` ends up calling into the `DatabaseContext` constructor. This constructor is also used by clients to create an initial database object. Based on this, I was running global configurations initialization function in the `DatabaseContext` constructor.
* If running using less than one `fdbserver` binary per role, multiple FDB roles will run per binary. This means there will be multiple calls to the `DatabaseContext` constructor.
* The previous way global configuration was determining when to update its internal key-value pairs was to watch for a change on a roles' `ClientDBInfo` object -- this is something that should be updated on each role by the cluster controller on demand.
* However, the global configuration initialization function can only be run once -- so later roles that came into `DatabaseContext` and tried to pass their unique `ClientDBInfo` object to global configuration were being ignored.
* The solution was to switch which `ClientDBInfo` object global configuration uses. There is a `ClientDBInfo` object created in `openDBOnServer` for each role, but there is also a `ClientDBInfo` that resides in `ServerDBInfo` (`ServerDBInfo` is the same object for all role).
* Now, global configuration accepts a pointer to the `ClientDBInfo` object it can read to determine the latest global configuration history, as well as a `std::function` used to determine when global configuration has changed.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
