### PR TITLE
Add perl + flamegraph to EKS docker images

### DIFF
--- a/packaging/docker/Dockerfile.eks
+++ b/packaging/docker/Dockerfile.eks
@@ -9,6 +9,7 @@ RUN yum install -y \
   nc \
   net-tools \
   perf \
+  perl \
   python38 \
   python3-pip \
   strace \
@@ -21,6 +22,7 @@ RUN yum install -y \
 #todo: nload, iperf, numademo
 
 COPY misc/tini-amd64.sha256sum /tmp/
+COPY misc/flamegraph.sha256sum /tmp/
 # Adding tini as PID 1 https://github.com/krallin/tini
 ARG TINI_VERSION=v0.19.0
 RUN curl -sLO https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-amd64 && \
@@ -30,6 +32,13 @@ RUN curl -sLO https://github.com/krallin/tini/releases/download/${TINI_VERSION}/
 
 COPY sidecar/requirements.txt /tmp
 RUN pip3 install -r /tmp/requirements.txt
+
+# Install flamegraph
+RUN curl -sLO https://raw.githubusercontent.com/brendangregg/FlameGraph/90533539b75400297092f973163b8a7b067c66d3/stackcollapse-perf.pl && \
+  curl -sLO https://raw.githubusercontent.com/brendangregg/FlameGraph/90533539b75400297092f973163b8a7b067c66d3/flamegraph.pl && \
+  sha256sum -c /tmp/flamegraph.sha256sum && \
+  chmod +x stackcollapse-perf.pl flamegraph.pl && \
+  mv stackcollapse-perf.pl flamegraph.pl /usr/bin
 
 # TODO: Only used by sidecar
 RUN groupadd --gid 4059 fdb && \

--- a/packaging/docker/misc/flamegraph.sha256sum
+++ b/packaging/docker/misc/flamegraph.sha256sum
@@ -1,0 +1,2 @@
+a682ac46497d6fdbf9904d1e405d3aea3ad255fcb156f6b2b1a541324628dfc0  flamegraph.pl
+5bcfb73ff2c2ab7bf2ad2b851125064780b58c51cc602335ec0001bec92679a5  stackcollapse-perf.pl


### PR DESCRIPTION
This adds flamegraph.pl to the EKS docker images, which allows us to generate flamegraph.svg's during performance runs.
 
# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
