### PR TITLE
Fix OPEN_FOR_IDE option for cmake

### DIFF
--- a/bindings/CMakeLists.txt
+++ b/bindings/CMakeLists.txt
@@ -1,6 +1,6 @@
-add_subdirectory(c)
 if(NOT OPEN_FOR_IDE)
   # flow bindings currently doesn't support that
+  add_subdirectory(c)
   add_subdirectory(flow)
 endif()
 add_subdirectory(python)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -263,10 +263,12 @@ if(WITH_PYTHON)
   add_fdb_test(TEST_FILES status/separate_not_enough_servers.txt)
   add_fdb_test(TEST_FILES status/single_process_too_many_config_params.txt)
 
-  add_test(
-    NAME multiversion_client/unit_tests
-    COMMAND $<TARGET_FILE:fdbserver> -r unittests -f /fdbclient/multiversionclient/
-  )
+  if(NOT OPEN_FOR_IDE)
+    add_test(
+      NAME multiversion_client/unit_tests
+      COMMAND $<TARGET_FILE:fdbserver> -r unittests -f /fdbclient/multiversionclient/
+    )
+  endif()
 
   verify_testing()
   if (NOT OPEN_FOR_IDE AND NOT WIN32)


### PR DESCRIPTION
`OPEN_FOR_IDE` is currently broken on master, this fixes it by excluding some targets.
```
CMake Error at bindings/c/CMakeLists.txt:122 (add_custom_command):
  Error evaluating generator expression:

    $<TARGET_FILE:fdb_c>

  Target "fdb_c" is not an executable or library.


CMake Error at tests/CMakeLists.txt:266 (add_test):
  Error evaluating generator expression:

    $<TARGET_FILE:fdbserver>

  Target "fdbserver" is not an executable or library.


CMake Error at bindings/c/CMakeLists.txt:122 (add_custom_command):
  Error evaluating generator expression:

    $<TARGET_FILE:fdb_c>

  Target "fdb_c" is not an executable or library.


-- Generating done
CMake Generate step failed.  Build files cannot be regenerated correctly.

```

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
