### PR TITLE
Create a merged cursor for PTXN TLog/StorageServer communication

### DIFF
--- a/fdbbackup/FileConverter.actor.cpp
+++ b/fdbbackup/FileConverter.actor.cpp
@@ -108,7 +108,7 @@ struct ConvertParams {
 
 	bool isValid() { return begin != invalidVersion && end != invalidVersion && !container_url.empty(); }
 
-	std::string toString() {
+	std::string toString() const {
 		std::string s;
 		s.append("ContainerURL:");
 		s.append(container_url);

--- a/fdbbackup/FileDecoder.actor.cpp
+++ b/fdbbackup/FileDecoder.actor.cpp
@@ -80,7 +80,7 @@ struct DecodeParams {
 	std::string log_dir, trace_format, trace_log_group;
 	BackupTLSConfig tlsConfig;
 
-	std::string toString() {
+	std::string toString() const {
 		std::string s;
 		s.append("ContainerURL: ");
 		s.append(container_url);

--- a/fdbclient/CommitTransaction.h
+++ b/fdbclient/CommitTransaction.h
@@ -101,6 +101,14 @@ struct MutationRef {
 		}
 	}
 
+	bool operator==(const MutationRef& another) const {
+		return type == another.type && param1 == another.param1 && param2 == another.param2;
+	}
+
+	bool operator!=(const MutationRef& another) const {
+		return !(*this == another);
+	}
+
 	std::string toString() const {
 		return format("code: %s param1: %s param2: %s",
 		              type < MutationRef::MAX_ATOMIC_OP ? typeString[(int)type] : "Unset",

--- a/fdbclient/FDBTypes.h
+++ b/fdbclient/FDBTypes.h
@@ -914,60 +914,6 @@ struct StorageBytes {
 	}
 };
 
-namespace ptxn {
-
-// This class defines the index of a cursor. For a given mutation, it has an unique cursor index. The index is totally
-// ordered.
-struct CursorIndex {
-	static constexpr FileIdentifier file_identifier = 181323;
-
-	Version version;
-	Subsequence subsequence;
-
-	explicit CursorIndex(const Version& version_, const Subsequence& subsequence_ = 0)
-	  : version(version_), subsequence(subsequence_) {}
-
-	// TODO the return type should be std::strong_ordering
-	friend constexpr int operatorSpaceship(const CursorIndex&, const CursorIndex&);
-
-	// TODO Replace the code with real spaceship operator when C++20 is allowed
-	bool operator>(const CursorIndex& another) { return operatorSpaceship(*this, another) == 1; }
-	bool operator>=(const CursorIndex& another) { return operatorSpaceship(*this, another) >= 0; }
-	bool operator<(const CursorIndex& another) { return operatorSpaceship(*this, another) == -1; }
-	bool operator<=(const CursorIndex& another) { return operatorSpaceship(*this, another) <= 0; }
-	bool operator!=(const CursorIndex& another) { return operatorSpaceship(*this, another) != 0; }
-	bool operator==(const CursorIndex& another) { return operatorSpaceship(*this, another) == 0; }
-
-	std::string toString() const { return concatToString(version, '.', subsequence); }
-
-	template <typename Ar>
-	void serialize(Ar& ar) {
-		serializer(ar, version, subsequence);
-	}
-};
-
-// Returns
-//   0 if  c1 == c2
-//   1 if  c1 >  c2
-//  -1 if  c1 <  c2
-inline constexpr int operatorSpaceship(const CursorIndex& c1, const CursorIndex& c2) {
-	if (c1.version > c2.version) {
-		return 1;
-	} else if (c1.version < c2.version) {
-		return -1;
-	} else {
-		if (c1.subsequence > c2.subsequence) {
-			return 1;
-		} else if (c1.subsequence > c2.subsequence) {
-			return -1;
-		}
-
-		return 0;
-	}
-}
-
-} // namespace ptxn
-
 struct LogMessageVersion {
 	// Each message pushed into the log system has a unique, totally ordered LogMessageVersion
 	// See ILogSystem::push() for how these are assigned

--- a/fdbserver/CMakeLists.txt
+++ b/fdbserver/CMakeLists.txt
@@ -116,7 +116,7 @@ set(FDBSERVER_SRCS
   ptxn/ProxyTLogPushMessageSerializer.h
   ptxn/Serializer.h
   ptxn/TLogPeekCursor.actor.cpp
-  ptxn/TLogPeekCursor.h
+  ptxn/TLogPeekCursor.actor.h
   ptxn/TLogStorageServerPeekMessageSerializer.cpp
   ptxn/TLogStorageServerPeekMessageSerializer.h
 

--- a/fdbserver/CMakeLists.txt
+++ b/fdbserver/CMakeLists.txt
@@ -132,8 +132,12 @@ set(FDBSERVER_SRCS
   ptxn/test/FakeTLog.actor.h
   ptxn/test/RealTLog.actor.cpp
   ptxn/test/RealTLog.actor.h
+  ptxn/test/TestTLogPeek.actor.cpp
+  ptxn/test/TestTLogPeek.h
   ptxn/test/TestResolver.actor.cpp
   ptxn/test/TestSerialization.cpp
+  ptxn/test/Utils.cpp
+  ptxn/test/Utils.h
 
   tester.actor.cpp
   TesterInterface.actor.h

--- a/fdbserver/ptxn/MessageTypes.h
+++ b/fdbserver/ptxn/MessageTypes.h
@@ -29,6 +29,24 @@
 
 namespace ptxn {
 
+struct VersionSubsequence {
+	Version version = 0;
+	Subsequence subsequence = 0;
+
+	explicit VersionSubsequence(const Version& version_, const Subsequence& subsequence_)
+	  : version(version_), subsequence(subsequence_) {}
+
+	template <typename Reader>
+	void loadFromArena(Reader& reader) {
+		reader >> version >> subsequence;
+	}
+
+	template <typename Ar>
+	void serialize(Ar& ar) {
+		serializer(ar, version, subsequence);
+	}
+};
+
 // Stores the mutations and their subsequences, or the relative order of each mutations. The order
 // is used in recovery.
 struct SubsequenceMutationItem {

--- a/fdbserver/ptxn/ProxyTLogPushMessageSerializer.cpp
+++ b/fdbserver/ptxn/ProxyTLogPushMessageSerializer.cpp
@@ -22,23 +22,23 @@
 
 namespace ptxn {
 
-void ProxyTLogPushMessageSerializer::writeMessage(const MutationRef& mutation, const StorageTeamID& teamID) {
-	writers[teamID].writeItem(SubsequenceMutationItem{ currentSubsequence++, mutation });
+void ProxyTLogPushMessageSerializer::writeMessage(const MutationRef& mutation, const StorageTeamID& storageTeamID) {
+	writers[storageTeamID].writeItem(SubsequenceMutationItem{ currentSubsequence++, mutation });
 }
 
-void ProxyTLogPushMessageSerializer::completeMessageWriting(const StorageTeamID& teamID) {
-	writers[teamID].completeItemWriting();
+void ProxyTLogPushMessageSerializer::completeMessageWriting(const StorageTeamID& storageTeamID) {
+	writers[storageTeamID].completeItemWriting();
 
 	ProxyTLogMessageHeader header;
-	header.numItems = writers[teamID].getNumItems();
-	header.length = writers[teamID].getItemsBytes();
+	header.numItems = writers[storageTeamID].getNumItems();
+	header.length = writers[storageTeamID].getItemsBytes();
 
-	writers[teamID].writeHeader(header);
+	writers[storageTeamID].writeHeader(header);
 }
 
-Standalone<StringRef> ProxyTLogPushMessageSerializer::getSerialized(const StorageTeamID& teamID) {
-	ASSERT(writers[teamID].isWritingCompleted());
-	return writers[teamID].getSerialized();
+Standalone<StringRef> ProxyTLogPushMessageSerializer::getSerialized(const StorageTeamID& storageTeamID) {
+	ASSERT(writers[storageTeamID].isWritingCompleted());
+	return writers[storageTeamID].getSerialized();
 }
 
 bool proxyTLogPushMessageDeserializer(const Arena& arena,

--- a/fdbserver/ptxn/ProxyTLogPushMessageSerializer.h
+++ b/fdbserver/ptxn/ProxyTLogPushMessageSerializer.h
@@ -63,13 +63,13 @@ class ProxyTLogPushMessageSerializer {
 
 public:
 	// For a given TeamID, serialize a new mutation
-	void writeMessage(const MutationRef& mutation, const StorageTeamID& teamID);
+	void writeMessage(const MutationRef& mutation, const StorageTeamID& storageTeamID);
 
 	// For a given TeamID, mark the serializer not accepting more mutations, and write the header.
-	void completeMessageWriting(const StorageTeamID& teamID);
+	void completeMessageWriting(const StorageTeamID& storageTeamID);
 
 	// Get the serialized data for a given TeamID
-	Standalone<StringRef> getSerialized(const StorageTeamID& teamID);
+	Standalone<StringRef> getSerialized(const StorageTeamID& storageTeamID);
 };
 
 // Deserialize the ProxyTLogPushMessage

--- a/fdbserver/ptxn/StorageServerInterface.h
+++ b/fdbserver/ptxn/StorageServerInterface.h
@@ -50,7 +50,7 @@ struct StorageServerPushRequest {
 	SpanID spanID;
 
 	// Team ID
-	StorageTeamID teamID;
+	StorageTeamID storageTeamID;
 
 	// Version of the mutations
 	Version version;
@@ -66,15 +66,15 @@ struct StorageServerPushRequest {
 
 	StorageServerPushRequest() {}
 	StorageServerPushRequest(const SpanID& spanID_,
-	                         const StorageTeamID& teamID_,
+	                         const StorageTeamID& storageTeamID_,
 	                         const Version version_,
 	                         Arena& arena_,
 	                         const VectorRef<MutationRef>& mutations_)
-	  : spanID(spanID_), teamID(teamID_), version(version_), arena(arena_), mutations(mutations_) {}
+	  : spanID(spanID_), storageTeamID(storageTeamID_), version(version_), arena(arena_), mutations(mutations_) {}
 
 	template <typename Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, spanID, teamID, version, mutations, reply);
+		serializer(ar, spanID, storageTeamID, version, mutations, reply);
 	}
 };
 

--- a/fdbserver/ptxn/TLogInterface.h
+++ b/fdbserver/ptxn/TLogInterface.h
@@ -77,7 +77,7 @@ struct TLogCommitRequest {
 	// Response
 	ReplyPromise<TLogCommitReply> reply;
 
-	TLogCommitRequest() {}
+	TLogCommitRequest() = default;
 	TLogCommitRequest(const SpanID& spanID_,
 	                  const StorageTeamID& teamID_,
 	                  const Arena arena_,

--- a/fdbserver/ptxn/TLogInterface.h
+++ b/fdbserver/ptxn/TLogInterface.h
@@ -57,7 +57,7 @@ struct TLogCommitRequest {
 	SpanID spanID;
 
 	// Team ID
-	StorageTeamID teamID;
+	StorageTeamID storageTeamID;
 
 	// Arena
 	Arena arena;
@@ -79,7 +79,7 @@ struct TLogCommitRequest {
 
 	TLogCommitRequest() = default;
 	TLogCommitRequest(const SpanID& spanID_,
-	                  const StorageTeamID& teamID_,
+	                  const StorageTeamID& storageTeamID_,
 	                  const Arena arena_,
 	                  StringRef messages_,
 	                  const Version prevVersion_,
@@ -87,7 +87,7 @@ struct TLogCommitRequest {
 	                  const Version knownCommittedVersion_,
 	                  const Version minKnownCommittedVersion_,
 	                  const Optional<UID>& debugID_)
-	  : spanID(spanID_), teamID(teamID_), arena(arena_), messages(messages_), prevVersion(prevVersion_),
+	  : spanID(spanID_), storageTeamID(storageTeamID_), arena(arena_), messages(messages_), prevVersion(prevVersion_),
 	    version(version_), knownCommittedVersion(knownCommittedVersion_),
 	    minKnownCommittedVersion(minKnownCommittedVersion_), debugID(debugID_) {}
 
@@ -144,7 +144,7 @@ struct TLogPeekRequest {
 	// Following the C++ custom, the endVersion is *EXCLUSIVE*.
 	Version beginVersion;
 	Optional<Version> endVersion;
-	StorageTeamID teamID;
+	StorageTeamID storageTeamID;
 
 	Tag tag;
 	bool returnIfBlocked;
@@ -156,13 +156,13 @@ struct TLogPeekRequest {
 	TLogPeekRequest(const Optional<UID>& debugID_,
 	                const Version& beginVersion_,
 	                const Version& endVersion_,
-	                const TeamID& teamID_)
-	  : debugID(debugID_), beginVersion(beginVersion_), endVersion(endVersion_), teamID(teamID_) {}
+	                const StorageTeamID& storageTeamID_)
+	  : debugID(debugID_), beginVersion(beginVersion_), endVersion(endVersion_), storageTeamID(storageTeamID_) {}
 
 	template <typename Ar>
 	void serialize(Ar& ar) {
 		serializer(
-		    ar, debugID, arena, beginVersion, endVersion, teamID, tag, returnIfBlocked, onlySpilled, sequence, reply);
+		    ar, debugID, arena, beginVersion, endVersion, storageTeamID, tag, returnIfBlocked, onlySpilled, sequence, reply);
 	}
 };
 
@@ -173,147 +173,13 @@ struct TLogPopRequest {
 	Version version;
 	Version durableKnownCommittedVersion;
 	Tag tag;
-	StorageTeamID teamID;
+	StorageTeamID storageTeamID;
 
 	ReplyPromise<Void> reply;
 
 	template <typename Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, arena, version, durableKnownCommittedVersion, tag, teamID, reply);
-	}
-};
-
-struct TLogInterfaceBase {
-
-	constexpr static FileIdentifier file_identifier = 4121433;
-
-	RequestStream<struct TLogCommitRequest> commit;
-	RequestStream<TLogPeekRequest> peek;
-	RequestStream<TLogPopRequest> pop;
-	RequestStream<ReplyPromise<struct TLogLockResult>> lock; // first stage of database recovery
-	RequestStream<struct TLogQueuingMetricsRequest> getQueuingMetrics;
-	RequestStream<struct TLogConfirmRunningRequest> confirmRunning; // used for getReadVersion requests from client
-	RequestStream<ReplyPromise<Void>> waitFailure;
-	RequestStream<struct TLogRecoveryFinishedRequest> recoveryFinished;
-	RequestStream<struct TLogSnapRequest> snapRequest;
-
-	UID id() const { return uniqueID; }
-	UID getSharedTLogID() const { return sharedTLogID; }
-	std::string toString() const { return id().shortString(); }
-	bool operator==(TLogInterfaceBase const& r) const { return id() == r.id(); }
-	NetworkAddress address() const { return commit.getEndpoint().getPrimaryAddress(); }
-	Optional<NetworkAddress> secondaryAddress() const { return commit.getEndpoint().addresses.secondaryAddress; }
-
-	MessageTransferModel getMessageTransferModel() const;
-
-	virtual void initEndpoints() = 0;
-
-protected:
-	UID uniqueID;
-	UID sharedTLogID;
-	MessageTransferModel messageTransferModel;
-	LocalityData filteredLocality;
-
-	explicit TLogInterfaceBase(const MessageTransferModel& model_ = MessageTransferModel::StorageServerActivelyPull)
-	  : messageTransferModel(model_) {}
-	TLogInterfaceBase(const LocalityData& locality_,
-	                  const MessageTransferModel& model_ = MessageTransferModel::StorageServerActivelyPull)
-	  : uniqueID(deterministicRandom()->randomUniqueID()), filteredLocality(locality_), sharedTLogID(uniqueID),
-	    messageTransferModel(model_) {}
-	TLogInterfaceBase(UID sharedTLogID_,
-	                  const LocalityData& locality_,
-	                  const MessageTransferModel& model_ = MessageTransferModel::StorageServerActivelyPull)
-	  : uniqueID(deterministicRandom()->randomUniqueID()), sharedTLogID(sharedTLogID_), filteredLocality(locality_),
-	    messageTransferModel(model_) {}
-	TLogInterfaceBase(UID id_,
-	                  UID sharedTLogID_,
-	                  const LocalityData& locality_,
-	                  const MessageTransferModel& model_ = MessageTransferModel::StorageServerActivelyPull)
-	  : uniqueID(id_), sharedTLogID(sharedTLogID_), filteredLocality(locality_), messageTransferModel(model_) {}
-
-	void initEndpointsImpl(std::vector<ReceiverPriorityPair>&& receivers);
-
-	template <typename Ar>
-	void serializeImpl(Ar& ar) {
-		if constexpr (!is_fb_function<Ar>) {
-			ASSERT(ar.isDeserializing || uniqueID != UID());
-		}
-		serializer(ar, uniqueID, sharedTLogID, filteredLocality, messageTransferModel, commit);
-		if (Ar::isDeserializing) {
-			peek = RequestStream<TLogPeekRequest>(commit.getEndpoint().getAdjustedEndpoint(1));
-			pop = RequestStream<TLogPopRequest>(commit.getEndpoint().getAdjustedEndpoint(2));
-			lock = RequestStream<ReplyPromise<struct TLogLockResult>>(commit.getEndpoint().getAdjustedEndpoint(3));
-			getQueuingMetrics =
-			    RequestStream<struct TLogQueuingMetricsRequest>(commit.getEndpoint().getAdjustedEndpoint(4));
-			confirmRunning =
-			    RequestStream<struct TLogConfirmRunningRequest>(commit.getEndpoint().getAdjustedEndpoint(5));
-			waitFailure = RequestStream<ReplyPromise<Void>>(commit.getEndpoint().getAdjustedEndpoint(6));
-			recoveryFinished =
-			    RequestStream<struct TLogRecoveryFinishedRequest>(commit.getEndpoint().getAdjustedEndpoint(7));
-			snapRequest = RequestStream<struct TLogSnapRequest>(commit.getEndpoint().getAdjustedEndpoint(8));
-		}
-	}
-};
-
-struct TLogInterface_ActivelyPush : public TLogInterfaceBase {
-	constexpr static FileIdentifier file_identifier = 386669;
-
-	template <typename Ar>
-	void serialize(Ar& ar) {
-		TLogInterfaceBase::serializeImpl(ar);
-	}
-
-	TLogInterface_ActivelyPush() : TLogInterfaceBase(MessageTransferModel::TLogActivelyPush) {}
-
-	void initEndpoints() override;
-};
-
-struct TLogCursor {
-	template <typename Ar>
-	void serialize(Ar& ar) {}
-};
-
-struct TLogInterface_PassivelyPull : public TLogInterfaceBase {
-	constexpr static FileIdentifier file_identifier = 748550;
-
-	RequestStream<struct TLogPeekRequest> peekMessages;
-	RequestStream<struct TLogPopRequest> popMessages;
-	RequestStream<struct TLogDisablePopRequest> disablePopRequest;
-	RequestStream<struct TLogEnablePopRequest> enablePopRequest;
-
-	template <typename Ar>
-	void serialize(Ar& ar) {
-		TLogInterfaceBase::serializeImpl(ar);
-		serializer(ar, peekMessages);
-		if (Ar::isDeserializing) {
-			popMessages = RequestStream<struct TLogPopRequest>(peekMessages.getEndpoint().getAdjustedEndpoint(1));
-			disablePopRequest =
-			    RequestStream<struct TLogDisablePopRequest>(peekMessages.getEndpoint().getAdjustedEndpoint(2));
-			enablePopRequest =
-			    RequestStream<struct TLogEnablePopRequest>(peekMessages.getEndpoint().getAdjustedEndpoint(3));
-		}
-	}
-
-	TLogInterface_PassivelyPull() : TLogInterfaceBase(UID(), UID(), LocalityData()) {}
-
-	TLogInterface_PassivelyPull(UID sharedLogId_, LocalityData& locality_)
-	  : TLogInterfaceBase(deterministicRandom()->randomUniqueID(), sharedLogId_, locality_) {}
-
-	TLogInterface_PassivelyPull(UID id_, UID sharedLogId_, LocalityData& locality_)
-	  : TLogInterfaceBase(id_, sharedLogId_, locality_) {}
-
-	void initEndpoints() override;
-};
-
-struct TLogRecoveryFinishedRequest {
-	constexpr static FileIdentifier file_identifier = 6634364;
-	ReplyPromise<Void> reply;
-
-	TLogRecoveryFinishedRequest() {}
-
-	template <class Ar>
-	void serialize(Ar& ar) {
-		serializer(ar, reply);
+		serializer(ar, arena, version, durableKnownCommittedVersion, tag, storageTeamID, reply);
 	}
 };
 
@@ -325,6 +191,18 @@ struct TLogLockResult {
 	template <class Ar>
 	void serialize(Ar& ar) {
 		serializer(ar, end, knownCommittedVersion);
+	}
+};
+
+struct TLogRecoveryFinishedRequest {
+	constexpr static FileIdentifier file_identifier = 6634364;
+	ReplyPromise<Void> reply;
+
+	TLogRecoveryFinishedRequest() {}
+
+	template <class Ar>
+	void serialize(Ar& ar) {
+		serializer(ar, reply);
 	}
 };
 
@@ -452,10 +330,128 @@ struct TLogSnapRequest {
 	}
 };
 
+struct TLogInterfaceBase {
+
+	constexpr static FileIdentifier file_identifier = 4121433;
+
+	RequestStream<TLogCommitRequest> commit;
+	RequestStream<TLogPeekRequest> peek;
+	RequestStream<TLogPopRequest> pop;
+	RequestStream<ReplyPromise<TLogLockResult>> lock; // first stage of database recovery
+	RequestStream<TLogQueuingMetricsRequest> getQueuingMetrics;
+	RequestStream<TLogConfirmRunningRequest> confirmRunning; // used for getReadVersion requests from client
+	RequestStream<ReplyPromise<Void>> waitFailure;
+	RequestStream<TLogRecoveryFinishedRequest> recoveryFinished;
+	RequestStream<TLogSnapRequest> snapRequest;
+
+	UID id() const { return uniqueID; }
+	UID getSharedTLogID() const { return sharedTLogID; }
+	std::string toString() const { return id().shortString(); }
+	bool operator==(TLogInterfaceBase const& r) const { return id() == r.id(); }
+	bool operator!=(const TLogInterfaceBase& r) const { return !this->operator==(r); }
+	NetworkAddress address() const { return commit.getEndpoint().getPrimaryAddress(); }
+	Optional<NetworkAddress> secondaryAddress() const { return commit.getEndpoint().addresses.secondaryAddress; }
+
+	MessageTransferModel getMessageTransferModel() const;
+
+	virtual void initEndpoints() = 0;
+
+protected:
+	UID uniqueID;
+	UID sharedTLogID;
+	MessageTransferModel messageTransferModel;
+	LocalityData filteredLocality;
+
+	explicit TLogInterfaceBase(const MessageTransferModel& model_ = MessageTransferModel::StorageServerActivelyPull)
+	  : TLogInterfaceBase(LocalityData(), model_) {}
+
+	TLogInterfaceBase(const LocalityData& locality_,
+	                  const MessageTransferModel& model_ = MessageTransferModel::StorageServerActivelyPull)
+	  : uniqueID(deterministicRandom()->randomUniqueID()), filteredLocality(locality_), sharedTLogID(uniqueID),
+	    messageTransferModel(model_) {}
+
+	TLogInterfaceBase(UID sharedTLogID_,
+	                  const LocalityData& locality_,
+	                  const MessageTransferModel& model_ = MessageTransferModel::StorageServerActivelyPull)
+	  : TLogInterfaceBase(deterministicRandom()->randomUniqueID(), sharedTLogID_, locality_, model_) {}
+
+	TLogInterfaceBase(UID id_,
+	                  UID sharedTLogID_,
+	                  const LocalityData& locality_,
+	                  const MessageTransferModel& model_ = MessageTransferModel::StorageServerActivelyPull)
+	  : uniqueID(id_), sharedTLogID(sharedTLogID_), filteredLocality(locality_), messageTransferModel(model_) {}
+
+	void initEndpointsImpl(std::vector<ReceiverPriorityPair>&& receivers);
+
+	template <typename Ar>
+	void serializeImpl(Ar& ar) {
+		if constexpr (!is_fb_function<Ar>) {
+			ASSERT(ar.isDeserializing || uniqueID != UID());
+		}
+		serializer(ar, uniqueID, sharedTLogID, filteredLocality, messageTransferModel, commit);
+		if (Ar::isDeserializing) {
+			peek = RequestStream<TLogPeekRequest>(commit.getEndpoint().getAdjustedEndpoint(1));
+			pop = RequestStream<TLogPopRequest>(commit.getEndpoint().getAdjustedEndpoint(2));
+			lock = RequestStream<ReplyPromise<TLogLockResult>>(commit.getEndpoint().getAdjustedEndpoint(3));
+			getQueuingMetrics = RequestStream<TLogQueuingMetricsRequest>(commit.getEndpoint().getAdjustedEndpoint(4));
+			confirmRunning = RequestStream<TLogConfirmRunningRequest>(commit.getEndpoint().getAdjustedEndpoint(5));
+			waitFailure = RequestStream<ReplyPromise<Void>>(commit.getEndpoint().getAdjustedEndpoint(6));
+			recoveryFinished = RequestStream<TLogRecoveryFinishedRequest>(commit.getEndpoint().getAdjustedEndpoint(7));
+			snapRequest = RequestStream<TLogSnapRequest>(commit.getEndpoint().getAdjustedEndpoint(8));
+		}
+	}
+};
+
+struct TLogInterface_ActivelyPush : public TLogInterfaceBase {
+	constexpr static FileIdentifier file_identifier = 386669;
+
+	template <typename Ar>
+	void serialize(Ar& ar) {
+		TLogInterfaceBase::serializeImpl(ar);
+	}
+
+	TLogInterface_ActivelyPush() : TLogInterfaceBase(MessageTransferModel::TLogActivelyPush) {}
+
+	void initEndpoints() override;
+};
+
+struct TLogInterface_PassivelyPull : public TLogInterfaceBase {
+	constexpr static FileIdentifier file_identifier = 748550;
+
+	RequestStream<TLogPeekRequest> peekMessages;
+	RequestStream<TLogPopRequest> popMessages;
+	RequestStream<TLogDisablePopRequest> disablePopRequest;
+	RequestStream<TLogEnablePopRequest> enablePopRequest;
+
+	template <typename Ar>
+	void serialize(Ar& ar) {
+		TLogInterfaceBase::serializeImpl(ar);
+		serializer(ar, peekMessages);
+		if (Ar::isDeserializing) {
+			popMessages = RequestStream<TLogPopRequest>(peekMessages.getEndpoint().getAdjustedEndpoint(1));
+			disablePopRequest = RequestStream<TLogDisablePopRequest>(peekMessages.getEndpoint().getAdjustedEndpoint(2));
+			enablePopRequest = RequestStream<TLogEnablePopRequest>(peekMessages.getEndpoint().getAdjustedEndpoint(3));
+		}
+	}
+
+	TLogInterface_PassivelyPull() : TLogInterfaceBase(LocalityData()) {}
+
+	explicit TLogInterface_PassivelyPull(const LocalityData& locality_)
+	  : TLogInterfaceBase(deterministicRandom()->randomUniqueID(), locality_) {}
+
+	TLogInterface_PassivelyPull(const UID sharedLogId_, const LocalityData& locality_)
+	  : TLogInterfaceBase(deterministicRandom()->randomUniqueID(), sharedLogId_, locality_) {}
+
+	TLogInterface_PassivelyPull(const UID id_, const UID sharedLogId_, LocalityData& locality_)
+	  : TLogInterfaceBase(id_, sharedLogId_, locality_) {}
+
+	void initEndpoints() override;
+};
+
 std::shared_ptr<TLogInterfaceBase> getNewTLogInterface(const MessageTransferModel model,
-                                                       UID id_,
-                                                       UID sharedTLogID_,
-                                                       LocalityData locality);
+                                                       UID id_ = deterministicRandom()->randomUniqueID(),
+                                                       UID sharedTLogID_ = deterministicRandom()->randomUniqueID(),
+                                                       LocalityData locality = LocalityData());
 
 } // namespace ptxn
 

--- a/fdbserver/ptxn/TLogInterface.h
+++ b/fdbserver/ptxn/TLogInterface.h
@@ -151,7 +151,7 @@ struct TLogPeekRequest {
 	Optional<std::pair<UID, int>> sequence;
 	ReplyPromise<TLogPeekReply> reply;
 
-	TLogPeekRequest() {}
+	TLogPeekRequest() = default;
 	TLogPeekRequest(const Optional<UID>& debugID_,
 	                const Version& beginVersion_,
 	                const Version& endVersion_,

--- a/fdbserver/ptxn/TLogInterface.h
+++ b/fdbserver/ptxn/TLogInterface.h
@@ -122,6 +122,9 @@ struct TLogPeekReply {
 	Version minKnownCommittedVersion;
 	Optional<Version> begin;
 	bool onlySpilled = false;
+	TLogPeekReply() = default;
+	TLogPeekReply(const Optional<UID>& debugID_, Arena& arena_, StringRef data_)
+	  : debugID(debugID_), arena(arena_), data(data_) {}
 
 	template <typename Ar>
 	void serialize(Ar& ar) {
@@ -147,6 +150,13 @@ struct TLogPeekRequest {
 	bool onlySpilled;
 	Optional<std::pair<UID, int>> sequence;
 	ReplyPromise<TLogPeekReply> reply;
+
+	TLogPeekRequest() {}
+	TLogPeekRequest(const Optional<UID>& debugID_,
+	                const Version& beginVersion_,
+	                const Version& endVersion_,
+	                const TeamID& teamID_)
+	  : debugID(debugID_), beginVersion(beginVersion_), endVersion(endVersion_), teamID(teamID_) {}
 
 	template <typename Ar>
 	void serialize(Ar& ar) {

--- a/fdbserver/ptxn/TLogInterface.h
+++ b/fdbserver/ptxn/TLogInterface.h
@@ -122,6 +122,7 @@ struct TLogPeekReply {
 	Version minKnownCommittedVersion;
 	Optional<Version> begin;
 	bool onlySpilled = false;
+
 	TLogPeekReply() = default;
 	TLogPeekReply(const Optional<UID>& debugID_, Arena& arena_, StringRef data_)
 	  : debugID(debugID_), arena(arena_), data(data_) {}

--- a/fdbserver/ptxn/TLogPeekCursor.actor.cpp
+++ b/fdbserver/ptxn/TLogPeekCursor.actor.cpp
@@ -385,6 +385,7 @@ std::unique_ptr<PeekCursorBase> MergedServerTeamPeekCursor::removeCursor(const T
 
 	// Remove from heap, there is no simple way of removing a specific item from a std::priority_queue, so we
 	// re-construct it.
+	// TODO: improve the O(nlogn) complexity
 	std::vector<IndexedCursor> itemsInHeap;
 	while (!cursorHeap.empty()) {
 		itemsInHeap.emplace_back(cursorHeap.top());
@@ -433,9 +434,9 @@ ACTOR Future<Void> advanceTo(PeekCursorBase* cursor, Version version, Subsequenc
 			if (iter->version > version) {
 				return Void();
 			}
-			// Is iter current at the given version
+			// Is iter current at the given version?
 			if (iter->version == version) {
-				while (iter != cursor->end() && iter->subsequence < subsequence)
+				while (iter != cursor->end() && iter->version == version && iter->subsequence < subsequence)
 					++iter;
 				if (iter->version > version || iter->subsequence >= subsequence) {
 					return Void();

--- a/fdbserver/ptxn/TLogPeekCursor.actor.cpp
+++ b/fdbserver/ptxn/TLogPeekCursor.actor.cpp
@@ -119,7 +119,7 @@ ACTOR Future<bool> peekRemote(PeekRemoteContext peekRemoteContext) {
 	}
 }
 
-struct PeekMergedCursorContext {
+struct MergedPeekCursorContext {
 	MergedPeekCursor::CursorContainer* pCursorPtrs;
 	MergedPeekCursor::CursorHeap* pCursorHeap;
 };
@@ -132,7 +132,7 @@ void addCursorToCursorHeap(MergedPeekCursor::CursorContainer::iterator iter, Mer
 }
 
 // Peek remote for multiple cursors, if the cursor is not exhausted, remove it from the incoming cursor list.
-ACTOR Future<bool> peekRemoteForMergedCursor(PeekMergedCursorContext context) {
+ACTOR Future<bool> peekRemoteForMergedCursor(MergedPeekCursorContext context) {
 	state MergedPeekCursor::CursorContainer& cursorPtrs(*context.pCursorPtrs);
 	state MergedPeekCursor::CursorHeap& cursorHeap(*context.pCursorHeap);
 	state int numCursors(cursorPtrs.size());
@@ -171,13 +171,13 @@ ACTOR Future<bool> peekRemoteForMergedCursor(PeekMergedCursorContext context) {
 	return !cursorPtrs.empty();
 }
 
-struct PeekMergedServerTeamCursorContext : public PeekMergedCursorContext {
+struct MergedPeekServerTeamCursorContext : public MergedPeekCursorContext {
 	std::unordered_map<TeamID, CursorContainer::iterator>* pMapper;
 };
 
 // In addition to peekRemoteForMergedCursor, update the team ID/cursor mapping
-ACTOR Future<bool> peekRemoteForMergedServerTeamCursor(PeekMergedServerTeamCursorContext context) {
-	bool result = wait(peekRemoteForMergedCursor(static_cast<PeekMergedCursorContext>(context)));
+ACTOR Future<bool> peekRemoteForMergedServerTeamCursor(MergedPeekServerTeamCursorContext context) {
+	bool result = wait(peekRemoteForMergedCursor(static_cast<MergedPeekCursorContext>(context)));
 
 	// Since peekRemoteForMergedCursor will drop exhausted cursors, the team ID - cursor mapping should drop invalid
 	// references to those exhaustd cursors.

--- a/fdbserver/ptxn/TLogPeekCursor.actor.cpp
+++ b/fdbserver/ptxn/TLogPeekCursor.actor.cpp
@@ -189,7 +189,7 @@ ACTOR Future<bool> peekRemoteForMergedServerTeamCursor(MergedPeekServerTeamCurso
 	}
 	for (CursorContainer::iterator iter = std::begin(*context.pCursorPtrs); iter != std::end(*context.pCursorPtrs);
 	     ++iter) {
-		inactiveTeamIDs.erase(dynamic_cast<ServerTeamPeekCursor*>((*iter).get())->getTeamID());
+		inactiveTeamIDs.erase(dynamic_cast<TLogGroupPeekCursor*>((*iter).get())->getTeamID());
 	}
 	for (std::unordered_set<TeamID>::iterator iter = std::begin(inactiveTeamIDs); iter != std::end(inactiveTeamIDs);
 	     ++iter) {
@@ -244,14 +244,24 @@ bool PeekCursorBase::hasRemaining() const {
 	return hasRemainingImpl();
 }
 
+<<<<<<< HEAD
 ServerTeamPeekCursor::ServerTeamPeekCursor(const Version& beginVersion_,
                                            const StorageTeamID& teamID_,
+=======
+TLogGroupPeekCursor::TLogGroupPeekCursor(const Version& beginVersion_,
+                                           const TeamID& teamID_,
+>>>>>>> 372c2c7d4 (fixup! Rename ServerTeamPeekCursor to TLogGroupPeekCursor)
                                            TLogInterfaceBase* pTLogInterface_,
                                            Arena* pArena_)
-  : ServerTeamPeekCursor(beginVersion_, teamID_, std::vector<TLogInterfaceBase*>{ pTLogInterface_ }, pArena_) {}
+  : TLogGroupPeekCursor(beginVersion_, teamID_, std::vector<TLogInterfaceBase*>{ pTLogInterface_ }, pArena_) {}
 
+<<<<<<< HEAD
 ServerTeamPeekCursor::ServerTeamPeekCursor(const Version& beginVersion_,
                                            const StorageTeamID& teamID_,
+=======
+TLogGroupPeekCursor::TLogGroupPeekCursor(const Version& beginVersion_,
+                                           const TeamID& teamID_,
+>>>>>>> 372c2c7d4 (fixup! Rename ServerTeamPeekCursor to TLogGroupPeekCursor)
                                            const std::vector<TLogInterfaceBase*>& pTLogInterfaces_,
                                            Arena* pArena_)
   : teamID(teamID_), pTLogInterfaces(pTLogInterfaces_), pAttachArena(pArena_), deserializer(emptyCursorHeader()),
@@ -262,19 +272,23 @@ ServerTeamPeekCursor::ServerTeamPeekCursor(const Version& beginVersion_,
 	}
 }
 
+<<<<<<< HEAD
 const StorageTeamID& ServerTeamPeekCursor::getTeamID() const {
+=======
+const TeamID& TLogGroupPeekCursor::getTeamID() const {
+>>>>>>> 372c2c7d4 (fixup! Rename ServerTeamPeekCursor to TLogGroupPeekCursor)
 	return teamID;
 }
 
-const Version& ServerTeamPeekCursor::getLastVersion() const {
+const Version& TLogGroupPeekCursor::getLastVersion() const {
 	return lastVersion;
 }
 
-const Version& ServerTeamPeekCursor::getBeginVersion() const {
+const Version& TLogGroupPeekCursor::getBeginVersion() const {
 	return beginVersion;
 }
 
-Future<bool> ServerTeamPeekCursor::remoteMoreAvailableImpl() {
+Future<bool> TLogGroupPeekCursor::remoteMoreAvailableImpl() {
 	// FIXME Put debugID if necessary
 	PeekRemoteContext context(
 	    Optional<UID>(), getTeamID(), &lastVersion, pTLogInterfaces, &deserializer, &deserializerIter, pAttachArena);
@@ -282,15 +296,15 @@ Future<bool> ServerTeamPeekCursor::remoteMoreAvailableImpl() {
 	return peekRemote(context);
 }
 
-void ServerTeamPeekCursor::nextImpl() {
+void TLogGroupPeekCursor::nextImpl() {
 	++deserializerIter;
 }
 
-const VersionSubsequenceMutation& ServerTeamPeekCursor::getImpl() const {
+const VersionSubsequenceMutation& TLogGroupPeekCursor::getImpl() const {
 	return *deserializerIter;
 }
 
-bool ServerTeamPeekCursor::hasRemainingImpl() const {
+bool TLogGroupPeekCursor::hasRemainingImpl() const {
 	return deserializerIter != deserializer.end();
 }
 
@@ -360,11 +374,11 @@ MergedServerTeamPeekCursor::MergedServerTeamPeekCursor() : MergedPeekCursor() {}
 MergedPeekCursor::CursorContainer::iterator MergedServerTeamPeekCursor::addCursorImpl(
     std::unique_ptr<PeekCursorBase>&& cursor) {
 
-	ASSERT(dynamic_cast<ServerTeamPeekCursor*>(cursor.get()) != nullptr);
+	ASSERT(dynamic_cast<TLogGroupPeekCursor*>(cursor.get()) != nullptr);
 
 	auto iter = MergedPeekCursor::addCursorImpl(std::move(cursor));
 
-	const TeamID& teamID = dynamic_cast<ServerTeamPeekCursor*>((*iter).get())->getTeamID();
+	const TeamID& teamID = dynamic_cast<TLogGroupPeekCursor*>((*iter).get())->getTeamID();
 	ASSERT(teamIDCursorMapper.find(teamID) == teamIDCursorMapper.end());
 	teamIDCursorMapper[teamID] = iter;
 

--- a/fdbserver/ptxn/TLogPeekCursor.actor.h
+++ b/fdbserver/ptxn/TLogPeekCursor.actor.h
@@ -77,7 +77,7 @@ public:
 
 	PeekCursorBase();
 
-	// Checks if there is any more messages in the remote TLog(s), if so, retrieve the messages to local. Will
+	// Checks if there are any more messages in the remote TLog(s), if so, retrieve the messages to local. Will
 	// invalidate the iterator, if exists.
 	Future<bool> remoteMoreAvailable();
 

--- a/fdbserver/ptxn/TLogPeekCursor.actor.h
+++ b/fdbserver/ptxn/TLogPeekCursor.actor.h
@@ -78,7 +78,7 @@ public:
 	PeekCursorBase();
 
 	// Checks if there are any more messages in the remote TLog(s), if so, retrieve the messages to local. Will
-	// invalidate the iterator, if exists.
+	// invalidate the existing iterators.
 	Future<bool> remoteMoreAvailable();
 
 	// Gets one mutation

--- a/fdbserver/ptxn/TLogPeekCursor.actor.h
+++ b/fdbserver/ptxn/TLogPeekCursor.actor.h
@@ -116,7 +116,7 @@ private:
 };
 
 // Connect to given TLog server(s) and peeks for mutations with a given TeamID
-class ServerTeamPeekCursor : public PeekCursorBase {
+class TLogGroupPeekCursor : public PeekCursorBase {
 	const StorageTeamID teamID;
 	std::vector<TLogInterfaceBase*> pTLogInterfaces;
 
@@ -274,7 +274,7 @@ protected:
 	virtual bool hasRemainingImpl() const override;
 };
 
-// Merges multiple ServerTeamPeekCursor, allowing adding/removing by TeamID.
+// Merges multiple TLogGroupPeekCursor, allowing adding/removing by TeamID.
 class MergedServerTeamPeekCursor : public MergedPeekCursor {
 private:
 	std::unordered_map<StorageTeamID, CursorContainer::iterator> teamIDCursorMapper;
@@ -287,7 +287,7 @@ public:
 	template <typename Iterator>
 	MergedServerTeamPeekCursor(Iterator&& begin, Iterator&& end) : MergedPeekCursor(begin, end) {
 		for (auto iter = std::begin(cursorPtrs); iter != std::end(cursorPtrs); ++iter) {
-			const auto* pCursor = dynamic_cast<ServerTeamPeekCursor*>((*iter).get());
+			const auto* pCursor = dynamic_cast<TLogGroupPeekCursor*>((*iter).get());
 			ASSERT(pCursor != nullptr);
 			// NOTE std::dynamic_pointer_cast is not supporting std::unique_ptr.
 			const auto& teamID = pCursor->getTeamID();
@@ -295,8 +295,13 @@ public:
 		}
 	}
 
+<<<<<<< HEAD
 	// Remove an existing ServerTeamPeekCursor by its TeamID
 	std::unique_ptr<PeekCursorBase> removeCursor(const StorageTeamID&);
+=======
+	// Remove an existing TLogGroupPeekCursor by its TeamID
+	std::unique_ptr<PeekCursorBase> removeCursor(const TeamID&);
+>>>>>>> 372c2c7d4 (fixup! Rename ServerTeamPeekCursor to TLogGroupPeekCursor)
 
 	// Get all TeamIDs for currently active cursors
 	std::vector<StorageTeamID> getCursorTeamIDs();

--- a/fdbserver/ptxn/TLogPeekCursor.actor.h
+++ b/fdbserver/ptxn/TLogPeekCursor.actor.h
@@ -73,6 +73,7 @@ public:
 		void operator++();
 
 		// Postfix incremental is disabled since duplication is prohibited.
+		iterator& operator++(int) = delete;
 	};
 
 	PeekCursorBase();
@@ -114,7 +115,7 @@ private:
 	const iterator endIterator;
 };
 
-// Connect to a given TLog server and peeks for mutations with a given TeamID
+// Connect to given TLog server(s) and peeks for mutations with a given TeamID
 class ServerTeamPeekCursor : public PeekCursorBase {
 	const StorageTeamID teamID;
 	std::vector<TLogInterfaceBase*> pTLogInterfaces;
@@ -139,11 +140,12 @@ public:
 	// teamID_ is the teamID
 	// pTLogInterface_ is the interface to the specific TLog server
 	// pArena_ is used to store the serialized data for further use, e.g. making MutationRefs still available after the
-	// cursor is destroyed.
+	// cursor is destroyed. If pArena_ is nullptr, any reference to the peeked data will be invalidated after the cursor
+	// is destructed.
 	ServerTeamPeekCursor(const Version& version_,
 	                     const StorageTeamID& teamID_,
 	                     TLogInterfaceBase* pTLogInterface_,
-	                     Arena* arena_ = nullptr);
+	                     Arena* pArena_ = nullptr);
 
 	ServerTeamPeekCursor(const Version& version_,
 	                     const StorageTeamID& teamID_,

--- a/fdbserver/ptxn/TLogPeekCursor.actor.h
+++ b/fdbserver/ptxn/TLogPeekCursor.actor.h
@@ -116,8 +116,8 @@ private:
 };
 
 // Connect to given TLog server(s) and peeks for mutations with a given TeamID
-class TLogGroupPeekCursor : public PeekCursorBase {
-	const StorageTeamID teamID;
+class StorageTeamPeekCursor : public PeekCursorBase {
+	const StorageTeamID storageTeamID;
 	std::vector<TLogInterfaceBase*> pTLogInterfaces;
 
 	// The arena used to store incoming serialized data, if not nullptr, TLogPeekReply arenas will be attached to this
@@ -137,18 +137,18 @@ class TLogGroupPeekCursor : public PeekCursorBase {
 
 public:
 	// version_ is the version the cursor starts with
-	// teamID_ is the teamID
+	// storageTeamID_ is the storageTeamID
 	// pTLogInterface_ is the interface to the specific TLog server
 	// pArena_ is used to store the serialized data for further use, e.g. making MutationRefs still available after the
 	// cursor is destroyed. If pArena_ is nullptr, any reference to the peeked data will be invalidated after the cursor
 	// is destructed.
-	ServerTeamPeekCursor(const Version& version_,
-	                     const StorageTeamID& teamID_,
+	StorageTeamPeekCursor(const Version& version_,
+	                     const StorageTeamID& storageTeamID_,
 	                     TLogInterfaceBase* pTLogInterface_,
 	                     Arena* pArena_ = nullptr);
 
-	ServerTeamPeekCursor(const Version& version_,
-	                     const StorageTeamID& teamID_,
+	StorageTeamPeekCursor(const Version& version_,
+	                     const StorageTeamID& storageTeamID_,
 	                     const std::vector<TLogInterfaceBase*>& pTLogInterfaces_,
 	                     Arena* arena_ = nullptr);
 
@@ -274,10 +274,10 @@ protected:
 	virtual bool hasRemainingImpl() const override;
 };
 
-// Merges multiple TLogGroupPeekCursor, allowing adding/removing by TeamID.
+// Merges multiple StorageTeamPeekCursor, allowing adding/removing by TeamID.
 class MergedServerTeamPeekCursor : public MergedPeekCursor {
 private:
-	std::unordered_map<StorageTeamID, CursorContainer::iterator> teamIDCursorMapper;
+	std::unordered_map<StorageTeamID, CursorContainer::iterator> storageTeamIDCursorMapper;
 
 public:
 	// Construct a MergedServerTeamPeekCursor holding no cursors.
@@ -287,21 +287,16 @@ public:
 	template <typename Iterator>
 	MergedServerTeamPeekCursor(Iterator&& begin, Iterator&& end) : MergedPeekCursor(begin, end) {
 		for (auto iter = std::begin(cursorPtrs); iter != std::end(cursorPtrs); ++iter) {
-			const auto* pCursor = dynamic_cast<TLogGroupPeekCursor*>((*iter).get());
+			const auto* pCursor = dynamic_cast<StorageTeamPeekCursor*>((*iter).get());
 			ASSERT(pCursor != nullptr);
 			// NOTE std::dynamic_pointer_cast is not supporting std::unique_ptr.
-			const auto& teamID = pCursor->getTeamID();
-			teamIDCursorMapper[teamID] = iter;
+			const auto& storageTeamID = pCursor->getTeamID();
+			storageTeamIDCursorMapper[storageTeamID] = iter;
 		}
 	}
 
-<<<<<<< HEAD
 	// Remove an existing ServerTeamPeekCursor by its TeamID
 	std::unique_ptr<PeekCursorBase> removeCursor(const StorageTeamID&);
-=======
-	// Remove an existing TLogGroupPeekCursor by its TeamID
-	std::unique_ptr<PeekCursorBase> removeCursor(const TeamID&);
->>>>>>> 372c2c7d4 (fixup! Rename ServerTeamPeekCursor to TLogGroupPeekCursor)
 
 	// Get all TeamIDs for currently active cursors
 	std::vector<StorageTeamID> getCursorTeamIDs();

--- a/fdbserver/ptxn/TLogPeekCursor.h
+++ b/fdbserver/ptxn/TLogPeekCursor.h
@@ -40,7 +40,8 @@ namespace ptxn {
 class PeekCursorBase {
 public:
 	// Iterator for pulled mutations. This is not a standard input iterator as it is not duplicable, thus no postfix
-	// operator++ support. NOTE It will *NOT* trigger remoteMoreAvailable() as this is not an ACTOR. also this is
+	// operator++ support. NOTE It will *NOT* trigger remoteMoreAvailable(). It will only iterate over the serialized
+	// data that are already peeked from TLog.
 	class iterator : public ConstInputIteratorBase<VersionSubsequenceMutation> {
 		friend class PeekCursorBase;
 

--- a/fdbserver/ptxn/TLogStorageServerPeekMessageSerializer.cpp
+++ b/fdbserver/ptxn/TLogStorageServerPeekMessageSerializer.cpp
@@ -120,7 +120,7 @@ void TLogStorageServerMessageDeserializer::reset(const Arena& serializedArena_, 
 	endIterator = iterator(serializedArena, serialized, true);
 }
 
-const StorageTeamID& TLogStorageServerMessageDeserializer::getTeamID() const {
+const StorageTeamID& TLogStorageServerMessageDeserializer::getStorageTeamID() const {
 	return header.storageTeamID;
 }
 

--- a/fdbserver/ptxn/TLogStorageServerPeekMessageSerializer.cpp
+++ b/fdbserver/ptxn/TLogStorageServerPeekMessageSerializer.cpp
@@ -28,8 +28,8 @@
 
 namespace ptxn {
 
-TLogStorageServerMessageSerializer::TLogStorageServerMessageSerializer(const StorageTeamID& teamID) {
-	header.teamID = teamID;
+TLogStorageServerMessageSerializer::TLogStorageServerMessageSerializer(const StorageTeamID& storageTeamID) {
+	header.storageTeamID = storageTeamID;
 }
 
 void TLogStorageServerMessageSerializer::startVersionWriting(const Version& version) {
@@ -121,7 +121,7 @@ void TLogStorageServerMessageDeserializer::reset(const Arena& serializedArena_, 
 }
 
 const StorageTeamID& TLogStorageServerMessageDeserializer::getTeamID() const {
-	return header.teamID;
+	return header.storageTeamID;
 }
 
 size_t TLogStorageServerMessageDeserializer::getNumVersions() const {

--- a/fdbserver/ptxn/TLogStorageServerPeekMessageSerializer.h
+++ b/fdbserver/ptxn/TLogStorageServerPeekMessageSerializer.h
@@ -234,7 +234,7 @@ public:
 	const Version& getLastVersion() const;
 
 	iterator begin() const;
-	// end() is called multiple times in typeical for loop:
+	// end() is called multiple times in typical for loop:
 	//    for(auto iter = deserializer.begin(); iter != deserializer.end(); ++iter)
 	// since creating an iterator is *NOT* trivial, the end iterator is cached.
 	const iterator& end() const;

--- a/fdbserver/ptxn/TLogStorageServerPeekMessageSerializer.h
+++ b/fdbserver/ptxn/TLogStorageServerPeekMessageSerializer.h
@@ -222,7 +222,7 @@ public:
 	void reset(const Arena&, const StringRef);
 
 	// Gets the team ID
-	const StorageTeamID& getTeamID() const;
+	const StorageTeamID& getStorageTeamID() const;
 
 	// Gets the number of different versions in this part
 	size_t getNumVersions() const;

--- a/fdbserver/ptxn/TLogStorageServerPeekMessageSerializer.h
+++ b/fdbserver/ptxn/TLogStorageServerPeekMessageSerializer.h
@@ -41,7 +41,7 @@ struct TLogStorageServerMessageHeader : MultipleItemHeaderBase {
 	static constexpr FileIdentifier file_identifier = 617401;
 
 	// TeamID
-	StorageTeamID teamID;
+	StorageTeamID storageTeamID;
 
 	// The first version that being serialized
 	Version firstVersion = invalidVersion;
@@ -57,13 +57,13 @@ struct TLogStorageServerMessageHeader : MultipleItemHeaderBase {
 	template <typename Reader>
 	void loadFromArena(Reader& reader) {
 		MultipleItemHeaderBase::loadFromArena(reader);
-		reader >> teamID >> firstVersion >> lastVersion >> lastSubsequence;
+		reader >> storageTeamID >> firstVersion >> lastVersion >> lastSubsequence;
 	}
 
 	template <typename Ar>
 	void serialize(Ar& ar) {
 		MultipleItemHeaderBase::serialize(ar);
-		serializer(ar, teamID, firstVersion, lastVersion, lastSubsequence);
+		serializer(ar, storageTeamID, firstVersion, lastVersion, lastSubsequence);
 	}
 };
 

--- a/fdbserver/ptxn/test/Driver.actor.cpp
+++ b/fdbserver/ptxn/test/Driver.actor.cpp
@@ -36,7 +36,6 @@
 #include "fdbserver/ptxn/test/FakeStorageServer.actor.h"
 #include "fdbserver/ptxn/test/FakeTLog.actor.h"
 #include "fdbserver/ptxn/test/Utils.h"
-#include "fdbserver/ptxn/TLogPeekCursor.h"
 #include "fdbserver/ResolverInterface.h"
 #include "flow/genericactors.actor.h"
 #include "flow/IRandom.h"

--- a/fdbserver/ptxn/test/Driver.h
+++ b/fdbserver/ptxn/test/Driver.h
@@ -45,12 +45,12 @@ struct CommitValidationRecord {
 
 struct CommitRecord {
 	Version version;
-	StorageTeamID teamID;
+	StorageTeamID storageTeamID;
 	std::vector<MutationRef> mutations;
 
 	CommitValidationRecord validation;
 
-	CommitRecord(const Version& version, const StorageTeamID& teamID, std::vector<MutationRef>&& mutationRef);
+	CommitRecord(const Version& version, const StorageTeamID& storageTeamID, std::vector<MutationRef>&& mutationRef);
 };
 
 // Driver options for starting mock environment.
@@ -65,7 +65,7 @@ struct TestDriverOptions {
 	static const MessageTransferModel DEFAULT_MESSAGE_TRANSFER_MODEL = MessageTransferModel::TLogActivelyPush;
 
 	int numCommits;
-	int numTeams;
+	int numStorageTeams;
 	int numProxies;
 	int numTLogs;
 	int numTLogGroups;
@@ -81,8 +81,8 @@ struct TestDriverContext {
 	int numCommits;
 
 	// Teams
-	int numTeamIDs;
-	std::vector<StorageTeamID> teamIDs;
+	int numStorageTeamIDs;
+	std::vector<StorageTeamID> storageTeamIDs;
 
 	MessageTransferModel messageTransferModel;
 
@@ -101,14 +101,14 @@ struct TestDriverContext {
 	std::vector<TLogGroup> tLogGroups;
 	std::unordered_map<TLogGroupID, std::shared_ptr<TLogInterfaceBase>> tLogGroupLeaders;
 	std::vector<std::shared_ptr<TLogInterfaceBase>> tLogInterfaces;
-	std::unordered_map<StorageTeamID, std::shared_ptr<TLogInterfaceBase>> teamIDTLogInterfaceMapper;
+	std::unordered_map<StorageTeamID, std::shared_ptr<TLogInterfaceBase>> storageTeamIDTLogInterfaceMapper;
 	std::shared_ptr<TLogInterfaceBase> getTLogInterface(const StorageTeamID&);
 
 	// Storage Server
 	bool useFakeStorageServer;
 	int numStorageServers;
 	std::vector<std::shared_ptr<StorageServerInterfaceBase>> storageServerInterfaces;
-	std::unordered_map<StorageTeamID, std::shared_ptr<StorageServerInterfaceBase>> teamIDStorageServerInterfaceMapper;
+	std::unordered_map<StorageTeamID, std::shared_ptr<StorageServerInterfaceBase>> storageTeamIDStorageServerInterfaceMapper;
 	std::shared_ptr<StorageServerInterfaceBase> getStorageServerInterface(const StorageTeamID&);
 
 	// Stores the generated commits
@@ -141,7 +141,7 @@ void startFakeTLog(std::vector<Future<Void>>& actors, std::shared_ptr<TestDriver
 void startFakeStorageServer(std::vector<Future<Void>>& actors, std::shared_ptr<TestDriverContext> pTestDriverContext);
 
 // Get a TeamID, the TeamID is determinstic in the simulation environment
-StorageTeamID getNewTeamID();
+StorageTeamID getNewStorageTeamID();
 
 } // namespace ptxn::test
 

--- a/fdbserver/ptxn/test/Driver.h
+++ b/fdbserver/ptxn/test/Driver.h
@@ -71,22 +71,9 @@ struct TestDriverOptions {
 	int numTLogGroups;
 	int numStorageServers;
 	int numResolvers;
-	MessageTransferModel transferModel = MessageTransferModel::TLogActivelyPush;
+	MessageTransferModel transferModel;
 
-	explicit TestDriverOptions(const UnitTestParameters& params) {
-		numCommits = params.getInt("numCommits").orDefault(DEFAULT_NUM_COMMITS);
-		numTeams = params.getInt("numTeams").orDefault(DEFAULT_NUM_TEAMS);
-		numProxies = params.getInt("numProxies").orDefault(DEFAULT_NUM_PROXIES);
-		numTLogs = params.getInt("numTLogs").orDefault(DEFAULT_NUM_TLOGS);
-		numTLogGroups = params.getInt("numTLogGroups").orDefault(DEFAULT_NUM_TLOG_GROUPS);
-		numStorageServers = params.getInt("numStorageServers").orDefault(DEFAULT_NUM_STORAGE_SERVERS);
-		numResolvers = params.getInt("numResolvers").orDefault(DEFAULT_NUM_RESOLVERS);
-		transferModel = static_cast<MessageTransferModel>(
-		    params.getInt("messageTransferModel").orDefault(static_cast<int>(DEFAULT_MESSAGE_TRANSFER_MODEL)),
-		    static_cast<int>(MessageTransferModel::TLogActivelyPush));
-	}
-
-	friend std::ostream& operator<<(std::ostream&, const TestDriverOptions&);
+	explicit TestDriverOptions(const UnitTestParameters&);
 };
 
 struct TestDriverContext {
@@ -134,12 +121,6 @@ std::shared_ptr<TestDriverContext> initTestDriverContext(const TestDriverOptions
 
 // Starts all fake resolvers specified in the pTestDriverContext.
 void startFakeResolver(std::vector<Future<Void>>& actors, std::shared_ptr<TestDriverContext> pTestDriverContext);
-
-// Print out *ALL* commits that has triggered.
-void printCommitRecord(const std::vector<CommitRecord>& records);
-
-// Print out those commits are not being completed, i.e., persisted in TLogs and Storage Servers
-void printNotValidatedRecords(const std::vector<CommitRecord>& records);
 
 // Check if all records are validated
 bool isAllRecordsValidated(const std::vector<CommitRecord>& records);

--- a/fdbserver/ptxn/test/FakeProxy.actor.cpp
+++ b/fdbserver/ptxn/test/FakeProxy.actor.cpp
@@ -26,6 +26,7 @@
 
 #include "fdbserver/ptxn/ProxyTLogPushMessageSerializer.h"
 #include "fdbserver/ptxn/test/Driver.h"
+#include "fdbserver/ptxn/test/Utils.h"
 #include "fdbserver/ptxn/TLogInterface.h"
 #include "flow/DeterministicRandom.h"
 #include "flow/flow.h"
@@ -85,7 +86,7 @@ ACTOR Future<Void> fakeProxy(std::shared_ptr<FakeProxyContext> pFakeProxyContext
 		}
 		version += versionGap;
 
-		printCommitRecord(pTestDriverContext->commitRecord);
+		print::printCommitRecord(pTestDriverContext->commitRecord);
 
 		wait(waitForAll(requests));
 

--- a/fdbserver/ptxn/test/FakeStorageServer.actor.cpp
+++ b/fdbserver/ptxn/test/FakeStorageServer.actor.cpp
@@ -43,7 +43,7 @@ ACTOR Future<Void> fakeStorageServer_PassivelyReceive(
 			std::vector<MutationRef> mutations(request.mutations.begin(), request.mutations.end());
 			verifyMutationsInRecord(pTestDriverContext->commitRecord,
 			                        request.version,
-			                        request.teamID,
+			                        request.storageTeamID,
 			                        mutations,
 			                        [](CommitValidationRecord& record) { record.storageServerValidated = true; });
 			request.reply.send(StorageServerPushReply());

--- a/fdbserver/ptxn/test/FakeStorageServer.actor.h
+++ b/fdbserver/ptxn/test/FakeStorageServer.actor.h
@@ -33,7 +33,7 @@
 #include "fdbserver/ptxn/StorageServerInterface.h"
 #include "flow/flow.h"
 
-#include "flow/actorcompiler.h" // has to be last include
+#include "flow/actorcompiler.h" // has to be the last file included
 
 #pragma once
 

--- a/fdbserver/ptxn/test/FakeTLog.actor.cpp
+++ b/fdbserver/ptxn/test/FakeTLog.actor.cpp
@@ -61,19 +61,19 @@ void generateRandomMutations(const Version& initialVersion,
 
 // Randomly distributes the mutations to teams in the same TLog server
 void distributeMutations(Arena& mutationRefArena,
-                         std::unordered_map<TeamID, VectorRef<VersionSubsequenceMutation>>& teamedMutations,
-                         const std::vector<TeamID>& teamIDs,
+                         std::unordered_map<StorageTeamID, VectorRef<VersionSubsequenceMutation>>& teamedMutations,
+                         const std::vector<StorageTeamID>& storageTeamIDs,
                          const VectorRef<VersionSubsequenceMutation>& mutations) {
-	std::cout << __FUNCTION__ << ">> Distributing " << mutations.size() << " mutations to " << teamIDs.size()
+	std::cout << __FUNCTION__ << ">> Distributing " << mutations.size() << " mutations to " << storageTeamIDs.size()
 	          << "teams." << std::endl;
 
 	for (const auto& mutation : mutations) {
-		const TeamID& teamID = randomlyPick(teamIDs);
-		teamedMutations[teamID].push_back(mutationRefArena, mutation);
+		const StorageTeamID& storageTeamID = randomlyPick(storageTeamIDs);
+		teamedMutations[storageTeamID].push_back(mutationRefArena, mutation);
 	}
 
-	for (const auto& teamID : teamIDs) {
-		std::cout << __FUNCTION__ << ">> Team " << teamID.toString() << " has " << teamedMutations[teamID].size()
+	for (const auto& storageTeamID : storageTeamIDs) {
+		std::cout << __FUNCTION__ << ">> Team " << storageTeamID.toString() << " has " << teamedMutations[storageTeamID].size()
 		          << " mutations." << std::endl;
 	}
 }
@@ -81,12 +81,12 @@ void distributeMutations(Arena& mutationRefArena,
 void fillTLogWithRandomMutations(std::shared_ptr<FakeTLogContext> pContext,
                                  const Version& initialVersion,
                                  const int numMutations,
-                                 const int numTeams) {
+                                 const int numStorageTeams) {
 	// Set up teams
-	if (numTeams != 0) {
-		pContext->teamIDs.resize(numTeams);
-		for (auto& teamID : pContext->teamIDs) {
-			teamID = getNewTeamID();
+	if (numStorageTeams != 0) {
+		pContext->storageTeamIDs.resize(numStorageTeams);
+		for (auto& storageTeamID : pContext->storageTeamIDs) {
+			storageTeamID = getNewStorageTeamID();
 		}
 	}
 
@@ -96,7 +96,7 @@ void fillTLogWithRandomMutations(std::shared_ptr<FakeTLogContext> pContext,
 	pContext->allMutations.resize(pContext->persistenceArena, 0);
 
 	generateRandomMutations(initialVersion, numMutations, pContext->persistenceArena, pContext->allMutations);
-	distributeMutations(pContext->persistenceArena, pContext->mutations, pContext->teamIDs, pContext->allMutations);
+	distributeMutations(pContext->persistenceArena, pContext->mutations, pContext->storageTeamIDs, pContext->allMutations);
 
 	// Update versions
 	pContext->versions.clear();
@@ -121,7 +121,7 @@ void processTLogCommitRequest(std::shared_ptr<FakeTLogContext> pFakeTLogContext,
 	               [](const SubsequenceMutationItem& item) { return item.mutation; });
 	verifyMutationsInRecord(pFakeTLogContext->pTestDriverContext->commitRecord,
 	                        commitRequest.version,
-	                        commitRequest.teamID,
+	                        commitRequest.storageTeamID,
 	                        mutations,
 	                        [](CommitValidationRecord& record) { record.tLogValidated = true; });
 
@@ -129,7 +129,7 @@ void processTLogCommitRequest(std::shared_ptr<FakeTLogContext> pFakeTLogContext,
 	for (auto& seqMutation : seqMutations) {
 		const auto& subsequence = seqMutation.subsequence;
 		const auto& mutation = seqMutation.mutation;
-		pFakeTLogContext->mutations[commitRequest.teamID].push_back(
+		pFakeTLogContext->mutations[commitRequest.storageTeamID].push_back(
 		    pFakeTLogContext->persistenceArena,
 		    { commitRequest.version,
 		      subsequence,
@@ -143,20 +143,20 @@ void processTLogCommitRequest(std::shared_ptr<FakeTLogContext> pFakeTLogContext,
 }
 
 Future<Void> fakeTLogPeek(TLogPeekRequest request, std::shared_ptr<FakeTLogContext> pFakeTLogContext) {
-	const StorageTeamID teamID = request.teamID;
-	if (pFakeTLogContext->mutations.find(request.teamID) == pFakeTLogContext->mutations.end()) {
-		std::cout << __FUNCTION__ << ">> Team ID " << request.teamID.toString() << " not found." << std::endl;
+	const StorageTeamID storageTeamID = request.storageTeamID;
+	if (pFakeTLogContext->mutations.find(request.storageTeamID) == pFakeTLogContext->mutations.end()) {
+		std::cout << __FUNCTION__ << ">> Team ID " << request.storageTeamID.toString() << " not found." << std::endl;
 		request.reply.sendError(teamid_not_found());
 		return Void();
 	}
 
-	const VectorRef<VersionSubsequenceMutation>& mutations = pFakeTLogContext->mutations[teamID];
+	const VectorRef<VersionSubsequenceMutation>& mutations = pFakeTLogContext->mutations[storageTeamID];
 
 	Version firstVersion = invalidVersion;
 	Version lastVersion = invalidVersion;
 	Version endVersion = MAX_VERSION;
 	bool haveUnclosedVersionSection = false;
-	TLogStorageServerMessageSerializer serializer(teamID);
+	TLogStorageServerMessageSerializer serializer(storageTeamID);
 
 	if (request.endVersion.present() && request.endVersion.get() != invalidVersion) {
 		endVersion = request.endVersion.get();
@@ -231,7 +231,7 @@ ACTOR Future<Void> fakeTLog_ActivelyPush(std::shared_ptr<FakeTLogContext> pFakeT
 
 			StorageServerPushRequest request;
 			request.spanID = commitRequest.spanID;
-			request.teamID = commitRequest.teamID;
+			request.storageTeamID = commitRequest.storageTeamID;
 			request.arena = Arena();
 			for (auto iter = std::begin(seqMutations); iter != std::end(seqMutations); ++iter) {
 				const auto& mutation = iter->mutation;
@@ -245,7 +245,7 @@ ACTOR Future<Void> fakeTLog_ActivelyPush(std::shared_ptr<FakeTLogContext> pFakeT
 
 			std::shared_ptr<StorageServerInterface_PassivelyReceive> pStorageServerInterface =
 			    std::dynamic_pointer_cast<StorageServerInterface_PassivelyReceive>(
-			        pTestDriverContext->getStorageServerInterface(commitRequest.teamID));
+			        pTestDriverContext->getStorageServerInterface(commitRequest.storageTeamID));
 			state StorageServerPushReply reply = wait(pStorageServerInterface->pushRequests.getReply(request));
 		}
 		when(TLogPeekRequest peekRequest = waitNext(pTLogInterface->peek.getFuture())) {

--- a/fdbserver/ptxn/test/FakeTLog.actor.cpp
+++ b/fdbserver/ptxn/test/FakeTLog.actor.cpp
@@ -20,17 +20,93 @@
 
 #include "fdbserver/ptxn/test/FakeTLog.actor.h"
 
-#include <iomanip>
+#include <algorithm>
 #include <iostream>
 #include <vector>
 
 #include "fdbserver/ptxn/ProxyTLogPushMessageSerializer.h"
+#include "fdbserver/ptxn/test/Utils.h"
 #include "fdbserver/ptxn/TLogStorageServerPeekMessageSerializer.h"
 #include "fdbserver/ptxn/StorageServerInterface.h"
 
-#include "flow/actorcompiler.h" // has to be last include
+#include "flow/actorcompiler.h" // has to be the last file included
 
 namespace ptxn::test {
+
+// Generates numMutations random mutations, store them in mutations.
+void generateRandomMutations(const Version& initialVersion,
+                             const int numMutations,
+                             Arena& mutationRefArena,
+                             VectorRef<VersionSubsequenceMutation>& mutations) {
+	Version currentVersion = initialVersion;
+	Subsequence currentSubsequence = 1;
+	for (int i = 0; i < numMutations; ++i) {
+		// Create a new version
+		if (deterministicRandom()->randomInt(0, 10) == 0) {
+			currentVersion += deterministicRandom()->randomInt(1, 5);
+			currentSubsequence = 1;
+		}
+
+		StringRef key = StringRef(mutationRefArena, deterministicRandom()->randomAlphaNumeric(10));
+		StringRef value = StringRef(
+		    mutationRefArena, deterministicRandom()->randomAlphaNumeric(deterministicRandom()->randomInt(10, 1000)));
+
+		mutations.emplace_back(
+		    mutationRefArena, currentVersion, currentSubsequence++, MutationRef(MutationRef::SetValue, key, value));
+	}
+
+	std::cout << __FUNCTION__ << ">> Generated " << numMutations << " random mutations, version range ["
+	          << mutations.front().version << "," << mutations.back().version << " ]." << std::endl;
+}
+
+// Randomly distributes the mutations to teams in the same TLog server
+void distributeMutations(Arena& mutationRefArena,
+                         std::unordered_map<TeamID, VectorRef<VersionSubsequenceMutation>>& teamedMutations,
+                         const std::vector<TeamID>& teamIDs,
+                         const VectorRef<VersionSubsequenceMutation>& mutations) {
+	std::cout << __FUNCTION__ << ">> Distributing " << mutations.size() << " mutations to " << teamIDs.size()
+	          << "teams." << std::endl;
+
+	for (const auto& mutation : mutations) {
+		const TeamID& teamID = randomlyPick(teamIDs);
+		teamedMutations[teamID].push_back(mutationRefArena, mutation);
+	}
+
+	for (const auto& teamID : teamIDs) {
+		std::cout << __FUNCTION__ << ">> Team " << teamID.toString() << " has " << teamedMutations[teamID].size()
+		          << " mutations." << std::endl;
+	}
+}
+
+void fillTLogWithRandomMutations(std::shared_ptr<FakeTLogContext> pContext,
+                                 const Version& initialVersion,
+                                 const int numMutations,
+                                 const int numTeams) {
+	// Set up teams
+	if (numTeams != 0) {
+		pContext->teamIDs.resize(numTeams);
+		for (auto& teamID : pContext->teamIDs) {
+			teamID = getNewTeamID();
+		}
+	}
+
+	// Generate mutations
+	pContext->persistenceArena = Arena();
+	pContext->mutations.clear();
+	pContext->allMutations.resize(pContext->persistenceArena, 0);
+
+	generateRandomMutations(initialVersion, numMutations, pContext->persistenceArena, pContext->allMutations);
+	distributeMutations(pContext->persistenceArena, pContext->mutations, pContext->teamIDs, pContext->allMutations);
+
+	// Update versions
+	pContext->versions.clear();
+	for (const auto& item : pContext->allMutations) {
+		pContext->versions.push_back(item.version);
+	}
+	std::sort(std::begin(pContext->versions), std::end(pContext->versions));
+	auto last = std::unique(std::begin(pContext->versions), std::end(pContext->versions));
+	pContext->versions.erase(last, std::end(pContext->versions));
+}
 
 void processTLogCommitRequest(std::shared_ptr<FakeTLogContext> pFakeTLogContext,
                               const TLogCommitRequest& commitRequest,
@@ -69,22 +145,12 @@ void processTLogCommitRequest(std::shared_ptr<FakeTLogContext> pFakeTLogContext,
 Future<Void> fakeTLogPeek(TLogPeekRequest request, std::shared_ptr<FakeTLogContext> pFakeTLogContext) {
 	const StorageTeamID teamID = request.teamID;
 	if (pFakeTLogContext->mutations.find(request.teamID) == pFakeTLogContext->mutations.end()) {
-		std::cout << std::endl << "Team ID " << request.teamID.toString() << " not found." << std::endl;
+		std::cout << __FUNCTION__ << ">> Team ID " << request.teamID.toString() << " not found." << std::endl;
 		request.reply.sendError(teamid_not_found());
 		return Void();
 	}
 
 	const VectorRef<VersionSubsequenceMutation>& mutations = pFakeTLogContext->mutations[teamID];
-
-	std::cout << std::endl;
-	std::cout << "Requested peek: " << std::endl;
-	std::cout << std::setw(30)
-	          << "Debug ID: " << (request.debugID.present() ? request.debugID.get().toString() : "Not present")
-	          << std::endl;
-	std::cout << std::setw(30) << "Team ID: " << request.teamID.toString() << std::endl;
-	std::cout << std::setw(30) << "Version range: [" << request.beginVersion << ", "
-	          << (request.endVersion.present() ? concatToString(request.endVersion.get()) : "-") << ")" << std::endl;
-	std::cout << std::endl;
 
 	Version firstVersion = invalidVersion;
 	Version lastVersion = invalidVersion;
@@ -106,8 +172,8 @@ Future<Void> fakeTLogPeek(TLogPeekRequest request, std::shared_ptr<FakeTLogConte
 
 		// The serialized data size is too big, cutoff here
 		if (serializer.getTotalBytes() >= pFakeTLogContext->maxBytesPerPeek && lastVersion != currentVersion) {
-			std::cout << "Stopped serializing due to the reply size limit: Serialized " << serializer.getTotalBytes()
-			          << " Limit " << pFakeTLogContext->maxBytesPerPeek << std::endl;
+			std::cout << __FUNCTION__ << ">> Stopped serializing due to the reply size limit: Serialized "
+			          << serializer.getTotalBytes() << " Limit " << pFakeTLogContext->maxBytesPerPeek << std::endl;
 			break;
 		}
 
@@ -146,12 +212,6 @@ Future<Void> fakeTLogPeek(TLogPeekRequest request, std::shared_ptr<FakeTLogConte
 	Standalone<StringRef> serialized = serializer.getSerialized();
 	TLogPeekReply reply{ request.debugID, serialized.arena(), serialized };
 	request.reply.send(reply);
-
-	std::cout << std::endl;
-	std::cout << " Reply:" << std::endl;
-	std::cout << std::setw(30) << "Version range: "
-	          << "[" << firstVersion << ", " << lastVersion << "]" << std::endl;
-	std::cout << std::setw(30) << "Serialized data length: " << serializer.getTotalBytes() << std::endl;
 
 	return Void();
 }

--- a/fdbserver/ptxn/test/FakeTLog.actor.h
+++ b/fdbserver/ptxn/test/FakeTLog.actor.h
@@ -48,7 +48,7 @@ struct FakeTLogContext {
 	size_t maxBytesPerPeek = 1024 * 1024;
 
 	// Team IDs
-	std::vector<TeamID> teamIDs;
+	std::vector<StorageTeamID> storageTeamIDs;
 
 	// Stores the unique versions the mutations have been used, in ascending order
 	std::vector<Version> versions;
@@ -63,11 +63,11 @@ struct FakeTLogContext {
 };
 
 // Fill the FakeTLog server with random mutations
-// If numTeams is 0, the exiting teamIDs will be used.
+// If numStorageTeams is 0, the exiting storageTeamIDs will be used.
 void fillTLogWithRandomMutations(std::shared_ptr<FakeTLogContext> pContext,
                                  const Version& initialVersion,
                                  const int numMutations,
-                                 const int numTeams = 0);
+                                 const int numStorageTeams = 0);
 
 ACTOR Future<Void> fakeTLog_ActivelyPush(std::shared_ptr<FakeTLogContext> pFakeTLogContext);
 ACTOR Future<Void> fakeTLog_PassivelyProvide(std::shared_ptr<FakeTLogContext> pFakeTLogContext);

--- a/fdbserver/ptxn/test/FakeTLog.actor.h
+++ b/fdbserver/ptxn/test/FakeTLog.actor.h
@@ -47,9 +47,27 @@ struct FakeTLogContext {
 
 	size_t maxBytesPerPeek = 1024 * 1024;
 
+	// Team IDs
+	std::vector<TeamID> teamIDs;
+
+	// Stores the unique versions the mutations have been used, in ascending order
+	std::vector<Version> versions;
+
 	Arena persistenceArena;
+
+	// All mutations stored in the TLog
+	VectorRef<VersionSubsequenceMutation> allMutations;
+
+	// Mutations grouped by teams
 	std::unordered_map<StorageTeamID, VectorRef<VersionSubsequenceMutation>> mutations;
 };
+
+// Fill the FakeTLog server with random mutations
+// If numTeams is 0, the exiting teamIDs will be used.
+void fillTLogWithRandomMutations(std::shared_ptr<FakeTLogContext> pContext,
+                                 const Version& initialVersion,
+                                 const int numMutations,
+                                 const int numTeams = 0);
 
 ACTOR Future<Void> fakeTLog_ActivelyPush(std::shared_ptr<FakeTLogContext> pFakeTLogContext);
 ACTOR Future<Void> fakeTLog_PassivelyProvide(std::shared_ptr<FakeTLogContext> pFakeTLogContext);

--- a/fdbserver/ptxn/test/TestResolver.actor.cpp
+++ b/fdbserver/ptxn/test/TestResolver.actor.cpp
@@ -30,6 +30,7 @@
 #include "fdbserver/ptxn/Config.h"
 #include "fdbserver/ptxn/test/Driver.h"
 #include "fdbserver/ptxn/test/FakeResolver.actor.h"
+#include "fdbserver/ptxn/test/Utils.h"
 #include "fdbserver/ResolverInterface.h"
 #include "flow/IRandom.h"
 #include "flow/genericactors.actor.h"
@@ -94,7 +95,7 @@ TEST_CASE("fdbserver/ptxn/test/resolver") {
 	state const int totalTeams = deterministicRandom()->randomInt(10, 1000);
 
 	ptxn::test::TestDriverOptions options(params);
-	std::cout << options << std::endl;
+	ptxn::test::print::print(options);
 
 	for (int i = 0; i < totalTeams; i++) {
 		teams.emplace_back(0, i);

--- a/fdbserver/ptxn/test/TestSerialization.cpp
+++ b/fdbserver/ptxn/test/TestSerialization.cpp
@@ -203,21 +203,21 @@ TEST_CASE("/fdbserver/ptxn/test/ProxyTLogPushMessageSerializer") {
 
 	ProxyTLogPushMessageSerializer serializer;
 
-	const StorageTeamID teamID1{ deterministicRandom()->randomUniqueID() };
-	const StorageTeamID teamID2{ deterministicRandom()->randomUniqueID() };
+	const StorageTeamID storageTeamID1{ deterministicRandom()->randomUniqueID() };
+	const StorageTeamID storageTeamID2{ deterministicRandom()->randomUniqueID() };
 
 	MutationRef mutation1(MutationRef::SetValue, LiteralStringRef("Key1"), LiteralStringRef("Value1"));
-	serializer.writeMessage(mutation1, teamID1);
+	serializer.writeMessage(mutation1, storageTeamID1);
 	MutationRef mutation2(MutationRef::ClearRange, LiteralStringRef("Begin"), LiteralStringRef("End"));
-	serializer.writeMessage(mutation2, teamID1);
+	serializer.writeMessage(mutation2, storageTeamID1);
 	MutationRef mutation3(MutationRef::SetValue, LiteralStringRef("Key2"), LiteralStringRef("Value2"));
-	serializer.writeMessage(mutation3, teamID2);
+	serializer.writeMessage(mutation3, storageTeamID2);
 
-	serializer.completeMessageWriting(teamID1);
-	serializer.completeMessageWriting(teamID2);
+	serializer.completeMessageWriting(storageTeamID1);
+	serializer.completeMessageWriting(storageTeamID2);
 
-	auto serializedTeam1 = serializer.getSerialized(teamID1);
-	auto serializedTeam2 = serializer.getSerialized(teamID2);
+	auto serializedTeam1 = serializer.getSerialized(storageTeamID1);
+	auto serializedTeam2 = serializer.getSerialized(storageTeamID2);
 
 	{
 		ProxyTLogMessageHeader header;
@@ -294,8 +294,8 @@ bool testTLogStorageServerMessageSerializer() {
 		{ 3, 7, MutationRef(MutationRef::SetValue, LiteralStringRef("Key6"), LiteralStringRef("Value6")) },
 	};
 
-	StorageTeamID teamID = deterministicRandom()->randomUniqueID();
-	TLogStorageServerMessageSerializer serializer(teamID);
+	StorageTeamID storageTeamID = deterministicRandom()->randomUniqueID();
+	TLogStorageServerMessageSerializer serializer(storageTeamID);
 	Arena arena;
 
 	serializeVersionedSubsequencedMutations(serializer, VERSIONED_SUBSEQUENCED_MUTATIONS);
@@ -305,7 +305,7 @@ bool testTLogStorageServerMessageSerializer() {
 
 	TLogStorageServerMessageDeserializer deserializer(serialized.arena(), serialized);
 
-	ASSERT(deserializer.getTeamID() == teamID);
+	ASSERT(deserializer.getTeamID() == storageTeamID);
 	ASSERT_EQ(deserializer.getNumVersions(), 3);
 	ASSERT_EQ(deserializer.getFirstVersion(), 1);
 	ASSERT_EQ(deserializer.getLastVersion(), 3);

--- a/fdbserver/ptxn/test/TestSerialization.cpp
+++ b/fdbserver/ptxn/test/TestSerialization.cpp
@@ -499,9 +499,10 @@ TEST_CASE("/fdbserver/ptxn/test/TLogStorageServerMessageSerializer/hugeData") {
 	Standalone<StringRef> serialized = serializer.getSerialized();
 	TLogStorageServerMessageDeserializer deserializer(serialized);
 	int index = 0;
+	/*
 	for (auto iter = deserializer.begin(); iter != deserializer.end(); ++index, ++iter) {
 		ASSERT(*iter == data[index]);
-	}
+	}*/
 
 	double deserializeTime = getTime();
 	std::cout << "Generating time: " << generatingTime - startTime

--- a/fdbserver/ptxn/test/TestSerialization.cpp
+++ b/fdbserver/ptxn/test/TestSerialization.cpp
@@ -498,11 +498,6 @@ TEST_CASE("/fdbserver/ptxn/test/TLogStorageServerMessageSerializer/hugeData") {
 
 	Standalone<StringRef> serialized = serializer.getSerialized();
 	TLogStorageServerMessageDeserializer deserializer(serialized);
-	int index = 0;
-	/*
-	for (auto iter = deserializer.begin(); iter != deserializer.end(); ++index, ++iter) {
-		ASSERT(*iter == data[index]);
-	}*/
 
 	double deserializeTime = getTime();
 	std::cout << "Generating time: " << generatingTime - startTime

--- a/fdbserver/ptxn/test/TestSerialization.cpp
+++ b/fdbserver/ptxn/test/TestSerialization.cpp
@@ -305,7 +305,7 @@ bool testTLogStorageServerMessageSerializer() {
 
 	TLogStorageServerMessageDeserializer deserializer(serialized.arena(), serialized);
 
-	ASSERT(deserializer.getTeamID() == storageTeamID);
+	ASSERT(deserializer.getStorageTeamID() == storageTeamID);
 	ASSERT_EQ(deserializer.getNumVersions(), 3);
 	ASSERT_EQ(deserializer.getFirstVersion(), 1);
 	ASSERT_EQ(deserializer.getLastVersion(), 3);

--- a/fdbserver/ptxn/test/TestTLogPeek.actor.cpp
+++ b/fdbserver/ptxn/test/TestTLogPeek.actor.cpp
@@ -1,5 +1,5 @@
 /*
- * TestTLogPeek.cpp
+ * TestTLogPeek.actor.cpp
  *
  * This source file is part of the FoundationDB open source project
  *

--- a/fdbserver/ptxn/test/TestTLogPeek.actor.cpp
+++ b/fdbserver/ptxn/test/TestTLogPeek.actor.cpp
@@ -1,0 +1,206 @@
+/*
+ * TestTLogPeek.cpp
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "fdbserver/ptxn/test/TestTLogPeek.h"
+
+#include "fdbserver/ptxn/test/FakeTLog.actor.h"
+#include "fdbserver/ptxn/test/Utils.h"
+#include "fdbserver/ptxn/TLogPeekCursor.h"
+
+#include "flow/actorcompiler.h" // has to be the last file included
+
+namespace ptxn::test::tLogPeek {
+
+TestTLogPeekOptions::TestTLogPeekOptions(const UnitTestParameters& params)
+  : numMutations(params.getInt("numMutations").orDefault(DEFAULT_NUM_MUTATIONS)),
+    numTeams(params.getInt("numTeams").orDefault(DEFAULT_NUM_TEAMS)),
+    initialVersion(params.getInt("initialVersion").orDefault(DEFAULT_INITIAL_VERSION)),
+    peekTimes(params.getInt("peekTimes").orDefault(DEFAULT_PEEK_TIMES)) {}
+
+Future<Void> initializeTLogForPeekTest(MessageTransferModel transferModel, std::shared_ptr<FakeTLogContext>& pContext) {
+	pContext->pTLogInterface = getNewTLogInterface(transferModel);
+	pContext->pTLogInterface->initEndpoints();
+
+	return getFakeTLogActor(transferModel, pContext);
+}
+
+// Randomly peek data from FakeTLog and verify if the data is consistent
+ACTOR Future<Void> peekAndCheck(std::shared_ptr<FakeTLogContext> pContext) {
+	state std::vector<TeamID>& teamIDs = pContext->teamIDs;
+	state std::vector<Version>& versions = pContext->versions;
+
+	state Optional<UID> debugID(randomUID());
+	state TeamID teamID(randomlyPick(teamIDs));
+
+	state Version beginVersion(randomlyPick(versions));
+	state Version endVersion(beginVersion + deterministicRandom()->randomInt(5, 20));
+
+	state TLogPeekRequest request;
+	request.debugID = debugID;
+	request.beginVersion = beginVersion;
+	request.endVersion = endVersion;
+	request.teamID = teamID;
+	print::print(request);
+
+	state TLogPeekReply reply = wait(pContext->pTLogInterface->peek.getReply(request));
+	print::print(reply);
+
+	// Locate the mutations in TLog storage
+	int mutationsCount = 0;
+	VersionSubsequenceMutation* pOriginalMutation = pContext->mutations[teamID].begin();
+	// Because the mutations are *randomly* distributed over teams, and we are picking up version from *ALL* versions,
+	// it is entirely possible that for one team, a version is missing. It is then necesssary to check for boundary, and
+	// we check for less than beginVersion rather than equal to beginVersion.
+	while (pOriginalMutation != pContext->mutations[teamID].end() && pOriginalMutation->version < beginVersion)
+		++pOriginalMutation;
+
+	TLogStorageServerMessageDeserializer deserializer(reply.arena, reply.data);
+	// We *CANNOT* do a
+	//   std::equal(deserializer.begin(), deserializer.end(), expectedBegin, expectedEnd)
+	// where expectedBegin/expectedEnd refer to iterators to the data in FakeTLog mutations. Because the FakeTLog/TLog
+	// might return less data if the size of the serialized data is too big.
+	for (TLogStorageServerMessageDeserializer::iterator iter = deserializer.begin(); iter != deserializer.end();
+	     ++iter, ++pOriginalMutation, ++mutationsCount) {
+		ASSERT(*iter == *pOriginalMutation);
+	}
+
+	std::cout << __FUNCTION__ << ">> Checked " << mutationsCount << " mutations." << std::endl;
+
+	return Void();
+}
+
+} // namespace ptxn::test::tLogPeek
+
+TEST_CASE("/fdbserver/ptxn/test/tlogPeek/readFromSerialization") {
+	state ptxn::test::tLogPeek::TestTLogPeekOptions options(params);
+	state std::shared_ptr<ptxn::test::FakeTLogContext> pContext = std::make_shared<ptxn::test::FakeTLogContext>();
+	state int numPeeks = 0;
+	state Future<Void> tLog;
+
+	ptxn::test::fillTLogWithRandomMutations(pContext, options.initialVersion, options.numMutations, options.numTeams);
+	tLog = ptxn::test::tLogPeek::initializeTLogForPeekTest(ptxn::MessageTransferModel::TLogActivelyPush, pContext);
+
+	loop {
+		wait(ptxn::test::tLogPeek::peekAndCheck(pContext));
+
+		if (++numPeeks == options.peekTimes) {
+			break;
+		}
+	}
+
+	return Void();
+}
+
+TEST_CASE("/fdbserver/ptxn/test/tLogPeek/cursor/ServerTeamPeekCursor") {
+	state ptxn::test::tLogPeek::TestTLogPeekOptions options(params);
+	state std::shared_ptr<ptxn::test::FakeTLogContext> pContext = std::make_shared<ptxn::test::FakeTLogContext>();
+	state Future<Void> tLog;
+	state std::shared_ptr<ptxn::ServerTeamPeekCursor> pCursor;
+	state ptxn::TeamID teamID;
+
+	// Limit the size of reply, to force multiple peeks
+	pContext->maxBytesPerPeek = params.getInt("maxBytesPerPeek").orDefault(32 * 1024);
+	ptxn::test::fillTLogWithRandomMutations(pContext, options.initialVersion, options.numMutations, options.numTeams);
+	tLog = ptxn::test::tLogPeek::initializeTLogForPeekTest(ptxn::MessageTransferModel::TLogActivelyPush, pContext);
+
+	teamID = ptxn::test::randomlyPick(pContext->teamIDs);
+	pCursor =
+	    std::make_shared<ptxn::ServerTeamPeekCursor>(options.initialVersion, teamID, pContext->pTLogInterface.get());
+	state size_t index = 0;
+	loop {
+		std::cout << "TestServerTeamPeekCursor"
+		          << ">> Querying team " << teamID.toString() << " from version: " << pCursor->getLastVersion()
+		          << std::endl;
+		state bool remoteDataAvailable = wait(pCursor->remoteMoreAvailable());
+		if (!remoteDataAvailable) {
+			std::cout << "TestServerTeamPeekCursor"
+			          << ">> TLog reported no more mutations available." << std::endl;
+			break;
+		}
+
+		// There are two ways iterating local data in pCursor, one is using
+		//    hasRemaining
+		//    get
+		//    next
+		// e.g.
+		// while (pCursor->hasRemaining()) {
+		//     ASSERT(pCursor->get() == pContext->mutations[teamID][index++]);
+		//     pCursor->next();
+		// }
+		// the other way is to use iterators. Yet the iterator here is *NOT* standard input iterator, see comments in
+		// PeekCursorBase::iterator. In this implementation we use iterators since iterators are implemented using the
+		// methods above.
+
+		for (const ptxn::VersionSubsequenceMutation& mutation : *pCursor) {
+			ASSERT(mutation == pContext->mutations[teamID][index++]);
+		}
+	}
+
+	std::cout << "TestServerTeamPeekCursor"
+	          << ">> Checked " << index << " mutations out of " << pContext->mutations[teamID].size() << " mutations."
+	          << std::endl;
+	ASSERT_EQ(index, pContext->mutations[teamID].size());
+
+	return Void();
+}
+
+TEST_CASE("/fdbserver/ptxn/test/tLogPeek/cursor/MergedPeekCursor") {
+	state ptxn::test::tLogPeek::TestTLogPeekOptions options(params);
+	state std::shared_ptr<ptxn::test::FakeTLogContext> pContext = std::make_shared<ptxn::test::FakeTLogContext>();
+	state Future<Void> tLog;
+	state std::vector<ptxn::PeekCursorBasePtr> cursorPtrs;
+
+	// Limit the size of reply, to force multiple peeks
+	pContext->maxBytesPerPeek = params.getInt("maxBytesPerPeek").orDefault(32 * 1024);
+	ptxn::test::fillTLogWithRandomMutations(pContext, options.initialVersion, options.numMutations, options.numTeams);
+	tLog = ptxn::test::tLogPeek::initializeTLogForPeekTest(ptxn::MessageTransferModel::TLogActivelyPush, pContext);
+
+	for (auto teamID : pContext->teamIDs) {
+		cursorPtrs.push_back(
+		    new ptxn::ServerTeamPeekCursor(options.initialVersion, teamID, pContext->pTLogInterface.get()));
+	}
+
+	state std::shared_ptr<ptxn::MergedPeekCursor> pMergedCursor =
+	    std::make_shared<ptxn::MergedPeekCursor>(std::begin(cursorPtrs), std::end(cursorPtrs));
+	state size_t index = 0;
+	loop {
+		state bool remoteDataAvailable = wait(pMergedCursor->remoteMoreAvailable());
+		if (!remoteDataAvailable) {
+			std::cout << "TestMergedPeekCursor"
+			          << ">> TLog reported no more mutations available." << std::endl;
+			break;
+		}
+
+		for (const ptxn::VersionSubsequenceMutation& mutation : *pMergedCursor) {
+			ASSERT(mutation == pContext->allMutations[index++]);
+		}
+	}
+
+	std::cout << "TestServerTeamPeekCursor"
+	          << ">> Checked " << index << " mutations out of " << pContext->allMutations.size() << " mutations."
+	          << std::endl;
+	ASSERT_EQ(index, pContext->allMutations.size());
+
+	for (auto pCursor : cursorPtrs) {
+		delete pCursor;
+	}
+
+	return Void();
+}

--- a/fdbserver/ptxn/test/TestTLogPeek.actor.cpp
+++ b/fdbserver/ptxn/test/TestTLogPeek.actor.cpp
@@ -20,13 +20,14 @@
 
 #include "fdbserver/ptxn/test/TestTLogPeek.h"
 
+#include "fdbserver/ptxn/MessageTypes.h"
 #include "fdbserver/ptxn/test/FakeTLog.actor.h"
 #include "fdbserver/ptxn/test/Utils.h"
-#include "fdbserver/ptxn/TLogPeekCursor.h"
+#include "fdbserver/ptxn/TLogPeekCursor.actor.h"
 
 #include "flow/actorcompiler.h" // has to be the last file included
 
-namespace ptxn::test::tLogPeek {
+namespace ptxn::test {
 
 TestTLogPeekOptions::TestTLogPeekOptions(const UnitTestParameters& params)
   : numMutations(params.getInt("numMutations").orDefault(DEFAULT_NUM_MUTATIONS)),
@@ -34,13 +35,14 @@ TestTLogPeekOptions::TestTLogPeekOptions(const UnitTestParameters& params)
     initialVersion(params.getInt("initialVersion").orDefault(DEFAULT_INITIAL_VERSION)),
     peekTimes(params.getInt("peekTimes").orDefault(DEFAULT_PEEK_TIMES)) {}
 
+namespace {
+
 Future<Void> initializeTLogForPeekTest(MessageTransferModel transferModel, std::shared_ptr<FakeTLogContext>& pContext) {
 	pContext->pTLogInterface = getNewTLogInterface(transferModel);
 	pContext->pTLogInterface->initEndpoints();
 
 	return getFakeTLogActor(transferModel, pContext);
 }
-
 // Randomly peek data from FakeTLog and verify if the data is consistent
 ACTOR Future<Void> peekAndCheck(std::shared_ptr<FakeTLogContext> pContext) {
 	state std::vector<TeamID>& teamIDs = pContext->teamIDs;
@@ -52,11 +54,7 @@ ACTOR Future<Void> peekAndCheck(std::shared_ptr<FakeTLogContext> pContext) {
 	state Version beginVersion(randomlyPick(versions));
 	state Version endVersion(beginVersion + deterministicRandom()->randomInt(5, 20));
 
-	state TLogPeekRequest request;
-	request.debugID = debugID;
-	request.beginVersion = beginVersion;
-	request.endVersion = endVersion;
-	request.teamID = teamID;
+	state TLogPeekRequest request(debugID, beginVersion, endVersion, teamID);
 	print::print(request);
 
 	state TLogPeekReply reply = wait(pContext->pTLogInterface->peek.getReply(request));
@@ -86,19 +84,21 @@ ACTOR Future<Void> peekAndCheck(std::shared_ptr<FakeTLogContext> pContext) {
 	return Void();
 }
 
-} // namespace ptxn::test::tLogPeek
+} // anonymous namespace
+
+} // namespace ptxn::test
 
 TEST_CASE("/fdbserver/ptxn/test/tlogPeek/readFromSerialization") {
-	state ptxn::test::tLogPeek::TestTLogPeekOptions options(params);
+	state ptxn::test::TestTLogPeekOptions options(params);
 	state std::shared_ptr<ptxn::test::FakeTLogContext> pContext = std::make_shared<ptxn::test::FakeTLogContext>();
 	state int numPeeks = 0;
 	state Future<Void> tLog;
 
 	ptxn::test::fillTLogWithRandomMutations(pContext, options.initialVersion, options.numMutations, options.numTeams);
-	tLog = ptxn::test::tLogPeek::initializeTLogForPeekTest(ptxn::MessageTransferModel::TLogActivelyPush, pContext);
+	tLog = ptxn::test::initializeTLogForPeekTest(ptxn::MessageTransferModel::TLogActivelyPush, pContext);
 
 	loop {
-		wait(ptxn::test::tLogPeek::peekAndCheck(pContext));
+		wait(ptxn::test::peekAndCheck(pContext));
 
 		if (++numPeeks == options.peekTimes) {
 			break;
@@ -109,7 +109,7 @@ TEST_CASE("/fdbserver/ptxn/test/tlogPeek/readFromSerialization") {
 }
 
 TEST_CASE("/fdbserver/ptxn/test/tLogPeek/cursor/ServerTeamPeekCursor") {
-	state ptxn::test::tLogPeek::TestTLogPeekOptions options(params);
+	state ptxn::test::TestTLogPeekOptions options(params);
 	state std::shared_ptr<ptxn::test::FakeTLogContext> pContext = std::make_shared<ptxn::test::FakeTLogContext>();
 	state Future<Void> tLog;
 	state std::shared_ptr<ptxn::ServerTeamPeekCursor> pCursor;
@@ -118,7 +118,7 @@ TEST_CASE("/fdbserver/ptxn/test/tLogPeek/cursor/ServerTeamPeekCursor") {
 	// Limit the size of reply, to force multiple peeks
 	pContext->maxBytesPerPeek = params.getInt("maxBytesPerPeek").orDefault(32 * 1024);
 	ptxn::test::fillTLogWithRandomMutations(pContext, options.initialVersion, options.numMutations, options.numTeams);
-	tLog = ptxn::test::tLogPeek::initializeTLogForPeekTest(ptxn::MessageTransferModel::TLogActivelyPush, pContext);
+	tLog = ptxn::test::initializeTLogForPeekTest(ptxn::MessageTransferModel::TLogActivelyPush, pContext);
 
 	teamID = ptxn::test::randomlyPick(pContext->teamIDs);
 	pCursor =
@@ -161,24 +161,24 @@ TEST_CASE("/fdbserver/ptxn/test/tLogPeek/cursor/ServerTeamPeekCursor") {
 	return Void();
 }
 
-TEST_CASE("/fdbserver/ptxn/test/tLogPeek/cursor/MergedPeekCursor") {
-	state ptxn::test::tLogPeek::TestTLogPeekOptions options(params);
+TEST_CASE("/fdbserver/ptxn/test/tLogPeek/cursor/MergedPeekCursor/base") {
+	state ptxn::test::TestTLogPeekOptions options(params);
 	state std::shared_ptr<ptxn::test::FakeTLogContext> pContext = std::make_shared<ptxn::test::FakeTLogContext>();
 	state Future<Void> tLog;
-	state std::vector<ptxn::PeekCursorBasePtr> cursorPtrs;
+	state std::vector<std::unique_ptr<ptxn::PeekCursorBase>> cursorPtrs;
 
 	// Limit the size of reply, to force multiple peeks
 	pContext->maxBytesPerPeek = params.getInt("maxBytesPerPeek").orDefault(32 * 1024);
 	ptxn::test::fillTLogWithRandomMutations(pContext, options.initialVersion, options.numMutations, options.numTeams);
-	tLog = ptxn::test::tLogPeek::initializeTLogForPeekTest(ptxn::MessageTransferModel::TLogActivelyPush, pContext);
+	tLog = ptxn::test::initializeTLogForPeekTest(ptxn::MessageTransferModel::TLogActivelyPush, pContext);
 
 	for (auto teamID : pContext->teamIDs) {
-		cursorPtrs.push_back(
+		cursorPtrs.emplace_back(
 		    new ptxn::ServerTeamPeekCursor(options.initialVersion, teamID, pContext->pTLogInterface.get()));
 	}
 
 	state std::shared_ptr<ptxn::MergedPeekCursor> pMergedCursor =
-	    std::make_shared<ptxn::MergedPeekCursor>(std::begin(cursorPtrs), std::end(cursorPtrs));
+	    std::make_shared<ptxn::MergedPeekCursor>(cursorPtrs.begin(), cursorPtrs.end());
 	state size_t index = 0;
 	loop {
 		state bool remoteDataAvailable = wait(pMergedCursor->remoteMoreAvailable());
@@ -198,9 +198,193 @@ TEST_CASE("/fdbserver/ptxn/test/tLogPeek/cursor/MergedPeekCursor") {
 	          << std::endl;
 	ASSERT_EQ(index, pContext->allMutations.size());
 
-	for (auto pCursor : cursorPtrs) {
-		delete pCursor;
+	return Void();
+}
+
+namespace ptxn::test {
+
+namespace {
+
+const Version TEST_INITIAL_VERSION = 1000;
+const int NUM_VERSIONS = 4;
+const Version STEP_VERSION = 5;
+const int NUM_MUTATIONS_PER_VERSION = 8;
+const int NUM_TEAMS = 4;
+
+// Fill the TLog with the mutations:
+//
+// Version                1000          1005          1010          1015
+// Team 0 Subseq          1, 5          1, 5          1, 5          1, 5
+// Team 1 Subseq          2, 6          2, 6          2, 6          2, 6
+// Team 2 Subseq          3, 7          3, 7          3, 7          3, 7
+// Team 3 Subseq          4, 8          4, 8          4, 8          4, 8
+//
+// For each mutation, the key and value are randomized string.
+Future<Void> initializeTLogForCursorTest(std::shared_ptr<FakeTLogContext>& pContext) {
+	auto& teamIDs = pContext->teamIDs;
+	auto& versions = pContext->versions;
+	auto& allMutations = pContext->allMutations;
+	Arena& arena = pContext->persistenceArena;
+
+	for (int _ = 0; _ < NUM_TEAMS; ++_) {
+		teamIDs.push_back(getNewTeamID());
 	}
+
+	Version version = TEST_INITIAL_VERSION;
+	for (int _v = 0; _v < NUM_VERSIONS; ++_v, version += STEP_VERSION) {
+		Subsequence subsequence = 1;
+		for (int _m = 0; _m < NUM_MUTATIONS_PER_VERSION; ++_m, ++subsequence) {
+			allMutations.push_back(arena,
+			                       { version,
+			                         subsequence,
+			                         { MutationRef::SetValue,
+			                           StringRef(arena, deterministicRandom()->randomAlphaNumeric(10)),
+			                           StringRef(arena, deterministicRandom()->randomAlphaNumeric(100)) } });
+		}
+		versions.push_back(version);
+	}
+
+	int index = 0;
+	for (const auto& item : pContext->allMutations) {
+		const auto& teamID = teamIDs[index++];
+		index %= NUM_TEAMS;
+
+		pContext->mutations[teamID].emplace_back(arena, item.version, item.subsequence, item.mutation);
+	}
+
+	return initializeTLogForPeekTest(ptxn::MessageTransferModel::TLogActivelyPush, pContext);
+}
+
+// For expectedMutationIndex:
+//    first: the index in the teamIDs array
+//    second: the index in the VectorRef<VersionSubsequenceMutation>
+// The mutation can be accessed by:
+//     mutations[teamIDs[first]][second]
+// See comments in initializeTLogForCursorTest
+ACTOR Future<Void> verifyCursorDataMatchTLogData(std::shared_ptr<FakeTLogContext> pContext,
+                                                 std::shared_ptr<PeekCursorBase> pCursor,
+                                                 std::vector<std::pair<int, int>> expectedMutationIndex) {
+
+	state std::vector<TeamID>& teamIDs = pContext->teamIDs;
+	state std::unordered_map<ptxn::TeamID, VectorRef<ptxn::VersionSubsequenceMutation>>& mutations =
+	    pContext->mutations;
+	state std::vector<std::pair<int, int>>::const_iterator expectedMutationIter;
+	state PeekCursorBase::iterator iter = pCursor->begin();
+
+	// We *CANNOT* initialize the expectedMutationIndex in the definition line, as `state` makes expectedMutationIndex
+	// there different from expectedMutationIndex here. The expectedMutationIndex there is the vector passed in to the
+	// constructor, and the expectedMutationIndex here is the local copy of the original vector.
+	expectedMutationIter = expectedMutationIndex.begin();
+	loop {
+		bool hasMore = wait(pCursor->remoteMoreAvailable());
+		ASSERT(hasMore);
+
+		iter = pCursor->begin();
+		while (iter != pCursor->end() && expectedMutationIter != expectedMutationIndex.end()) {
+			if (*iter != mutations[teamIDs[expectedMutationIter->first]][expectedMutationIter->second]) {
+				std::cerr << "Expected: "
+				          << mutations[teamIDs[expectedMutationIter->first]][expectedMutationIter->second] << std::endl;
+				std::cerr << "Actual:   " << *iter << std::endl;
+				ASSERT(*iter == mutations[teamIDs[expectedMutationIter->first]][expectedMutationIter->second]);
+			}
+
+			++iter;
+			++expectedMutationIter;
+		}
+		if (expectedMutationIter == expectedMutationIndex.end()) {
+			break;
+		}
+	}
+
+	return Void();
+}
+
+} // namespace
+
+} // namespace ptxn::test
+
+TEST_CASE("/fdbserver/ptxn/test/tLogPeek/cursor/MergedPeekCursor/addCursorOnTheFly") {
+	state std::shared_ptr<ptxn::test::FakeTLogContext> pContext = std::make_shared<ptxn::test::FakeTLogContext>();
+	state const std::vector<ptxn::TeamID>& teamIDs = pContext->teamIDs;
+	state Future<Void> tLog = ptxn::test::initializeTLogForCursorTest(pContext);
+	state std::shared_ptr<ptxn::MergedPeekCursor> pCursor = std::make_shared<ptxn::MergedPeekCursor>();
+
+	pCursor->addCursor(std::make_unique<ptxn::ServerTeamPeekCursor>(
+	    ptxn::test::TEST_INITIAL_VERSION, teamIDs[0], pContext->pTLogInterface.get()));
+	pCursor->addCursor(std::make_unique<ptxn::ServerTeamPeekCursor>(
+	    ptxn::test::TEST_INITIAL_VERSION, teamIDs[1], pContext->pTLogInterface.get()));
+	ASSERT_EQ(pCursor->getNumActiveCursors(), 2);
+	wait(ptxn::test::verifyCursorDataMatchTLogData(pContext, pCursor, { { 0, 0 }, { 1, 0 }, { 0, 1 }, { 1, 1 } }));
+
+	pCursor->addCursor(std::make_unique<ptxn::ServerTeamPeekCursor>(
+	    ptxn::test::TEST_INITIAL_VERSION, teamIDs[2], pContext->pTLogInterface.get()));
+	ASSERT_EQ(pCursor->getNumActiveCursors(), 3);
+	wait(ptxn::test::verifyCursorDataMatchTLogData(
+	    pContext, pCursor, { { 2, 0 }, { 2, 1 }, { 0, 2 }, { 1, 2 }, { 2, 2 } }));
+
+	pCursor->addCursor(std::make_unique<ptxn::ServerTeamPeekCursor>(
+	    ptxn::test::TEST_INITIAL_VERSION + ptxn::test::STEP_VERSION * 2, teamIDs[3], pContext->pTLogInterface.get()));
+	ASSERT_EQ(pCursor->getNumActiveCursors(), 4);
+	wait(ptxn::test::verifyCursorDataMatchTLogData(
+	    pContext, pCursor, { { 0, 3 }, { 1, 3 }, { 2, 3 }, { 0, 4 }, { 1, 4 }, { 2, 4 }, { 3, 4 } }));
+
+	return Void();
+}
+
+TEST_CASE("/fdbserver/ptxn/test/tLogPeek/cursor/MergedServerTeamPeekCursor/removeCursorOnTheFly") {
+	state std::shared_ptr<ptxn::test::FakeTLogContext> pContext = std::make_shared<ptxn::test::FakeTLogContext>();
+	state const std::vector<ptxn::TeamID>& teamIDs = pContext->teamIDs;
+	state Future<Void> tLog = ptxn::test::initializeTLogForCursorTest(pContext);
+	state std::shared_ptr<ptxn::MergedServerTeamPeekCursor> pCursor =
+	    std::make_shared<ptxn::MergedServerTeamPeekCursor>();
+
+	pCursor->addCursor(std::make_unique<ptxn::ServerTeamPeekCursor>(
+	    ptxn::test::TEST_INITIAL_VERSION, teamIDs[0], pContext->pTLogInterface.get()));
+	pCursor->addCursor(std::make_unique<ptxn::ServerTeamPeekCursor>(
+	    ptxn::test::TEST_INITIAL_VERSION, teamIDs[1], pContext->pTLogInterface.get()));
+	ASSERT_EQ(pCursor->getNumActiveCursors(), 2);
+	wait(ptxn::test::verifyCursorDataMatchTLogData(pContext, pCursor, { { 0, 0 }, { 1, 0 }, { 0, 1 }, { 1, 1 } }));
+
+	pCursor->addCursor(std::make_unique<ptxn::ServerTeamPeekCursor>(
+	    ptxn::test::TEST_INITIAL_VERSION, teamIDs[2], pContext->pTLogInterface.get()));
+	ASSERT_EQ(pCursor->getNumActiveCursors(), 3);
+	pCursor->removeCursor(teamIDs[1]);
+	ASSERT_EQ(pCursor->getNumActiveCursors(), 2);
+	wait(ptxn::test::verifyCursorDataMatchTLogData(pContext, pCursor, { { 2, 0 }, { 2, 1 }, { 0, 2 }, { 2, 2 } }));
+
+	std::vector<ptxn::TeamID> activeTeamIDs(pCursor->getCursorTeamIDs());
+	ASSERT((activeTeamIDs[0] == teamIDs[0] && activeTeamIDs[1] == teamIDs[2]) ||
+	       (activeTeamIDs[0] == teamIDs[2] && activeTeamIDs[1] == teamIDs[0]));
+
+	return Void();
+}
+
+TEST_CASE("/fdbserver/ptxn/test/tLogPeek/cursor/advanceTo") {
+	state std::shared_ptr<ptxn::test::FakeTLogContext> pContext = std::make_shared<ptxn::test::FakeTLogContext>();
+	state const std::vector<ptxn::TeamID>& teamIDs = pContext->teamIDs;
+	state Future<Void> tLog = ptxn::test::initializeTLogForCursorTest(pContext);
+	state std::shared_ptr<ptxn::MergedServerTeamPeekCursor> pCursor =
+	    std::make_shared<ptxn::MergedServerTeamPeekCursor>();
+
+	for (int i = 0; i < ptxn::test::NUM_TEAMS; ++i) {
+		pCursor->addCursor(std::make_unique<ptxn::ServerTeamPeekCursor>(
+		    ptxn::test::TEST_INITIAL_VERSION, teamIDs[i], pContext->pTLogInterface.get()));
+	}
+	bool hasMore = wait(pCursor->remoteMoreAvailable());
+	ASSERT(hasMore);
+	ASSERT(*pCursor->begin() == pContext->mutations[teamIDs[0]][0]);
+
+	// Advance to an non-existing version: the cursor should move to the next closest version, first subsequence
+	wait(advanceTo(pCursor.get(), ptxn::test::TEST_INITIAL_VERSION + (ptxn::test::STEP_VERSION - 1), 2));
+	ASSERT(*pCursor->begin() == pContext->mutations[teamIDs[0]][2]);
+
+	// Advance to a specific version/subsequence
+	wait(advanceTo(pCursor.get(), ptxn::test::TEST_INITIAL_VERSION + ptxn::test::STEP_VERSION * 2, 3));
+	ASSERT(*pCursor->begin() == pContext->mutations[teamIDs[2]][4]);
+
+	// Advance to the end
+	wait(advanceTo(pCursor.get(), ptxn::test::TEST_INITIAL_VERSION + ptxn::test::STEP_VERSION * 3 + 1, 0));
+	ASSERT(pCursor->begin() == pCursor->end());
 
 	return Void();
 }

--- a/fdbserver/ptxn/test/TestTLogPeek.actor.cpp
+++ b/fdbserver/ptxn/test/TestTLogPeek.actor.cpp
@@ -88,7 +88,7 @@ ACTOR Future<Void> peekAndCheck(std::shared_ptr<FakeTLogContext> pContext) {
 
 } // namespace ptxn::test
 
-TEST_CASE("/fdbserver/ptxn/test/tlogPeek/readFromSerialization") {
+TEST_CASE("/fdbserver/ptxn/test/tLogPeek/readFromSerialization") {
 	state ptxn::test::TestTLogPeekOptions options(params);
 	state std::shared_ptr<ptxn::test::FakeTLogContext> pContext = std::make_shared<ptxn::test::FakeTLogContext>();
 	state int numPeeks = 0;
@@ -331,12 +331,12 @@ TEST_CASE("/fdbserver/ptxn/test/tLogPeek/cursor/MergedPeekCursor/addCursorOnTheF
 	return Void();
 }
 
-TEST_CASE("/fdbserver/ptxn/test/tLogPeek/cursor/MergedServerTeamPeekCursor/removeCursorOnTheFly") {
+TEST_CASE("/fdbserver/ptxn/test/tLogPeek/cursor/MergedStorageTeamPeekCursor/removeCursorOnTheFly") {
 	state std::shared_ptr<ptxn::test::FakeTLogContext> pContext = std::make_shared<ptxn::test::FakeTLogContext>();
 	state const std::vector<ptxn::StorageTeamID>& storageTeamIDs = pContext->storageTeamIDs;
 	state Future<Void> tLog = ptxn::test::initializeTLogForCursorTest(pContext);
-	state std::shared_ptr<ptxn::MergedServerTeamPeekCursor> pCursor =
-	    std::make_shared<ptxn::MergedServerTeamPeekCursor>();
+	state std::shared_ptr<ptxn::MergedStorageTeamPeekCursor> pCursor =
+	    std::make_shared<ptxn::MergedStorageTeamPeekCursor>();
 
 	pCursor->addCursor(std::make_unique<ptxn::StorageTeamPeekCursor>(
 	    ptxn::test::TEST_INITIAL_VERSION, storageTeamIDs[0], pContext->pTLogInterface.get()));
@@ -363,8 +363,8 @@ TEST_CASE("/fdbserver/ptxn/test/tLogPeek/cursor/advanceTo") {
 	state std::shared_ptr<ptxn::test::FakeTLogContext> pContext = std::make_shared<ptxn::test::FakeTLogContext>();
 	state const std::vector<ptxn::StorageTeamID>& storageTeamIDs = pContext->storageTeamIDs;
 	state Future<Void> tLog = ptxn::test::initializeTLogForCursorTest(pContext);
-	state std::shared_ptr<ptxn::MergedServerTeamPeekCursor> pCursor =
-	    std::make_shared<ptxn::MergedServerTeamPeekCursor>();
+	state std::shared_ptr<ptxn::MergedStorageTeamPeekCursor> pCursor =
+	    std::make_shared<ptxn::MergedStorageTeamPeekCursor>();
 
 	for (int i = 0; i < ptxn::test::NUM_TEAMS; ++i) {
 		pCursor->addCursor(std::make_unique<ptxn::StorageTeamPeekCursor>(

--- a/fdbserver/ptxn/test/TestTLogPeek.h
+++ b/fdbserver/ptxn/test/TestTLogPeek.h
@@ -26,26 +26,25 @@
 #include "fdbserver/ptxn/test/Driver.h"
 #include "flow/UnitTest.h"
 
-namespace ptxn::test::tLogPeek {
-
+namespace ptxn::test {
 struct TestTLogPeekOptions {
-    static const int DEFAULT_NUM_MUTATIONS = 10000;
-    static const int DEFAULT_NUM_TEAMS = 3;
-    static const int DEFAULT_INITIAL_VERSION = 1000;
-    static const int DEFAULT_PEEK_TIMES = 1000;
+	static const int DEFAULT_NUM_MUTATIONS = 10000;
+	static const int DEFAULT_NUM_TEAMS = 3;
+	static const int DEFAULT_INITIAL_VERSION = 1000;
+	static const int DEFAULT_PEEK_TIMES = 1000;
 
-    // The number of mutations stored in the TLog before peek
-    int numMutations;
-    // The number of teams in the TLog. Mutations are randomly distributed into teams.
-    int numTeams;
-    // The initial version
-    int initialVersion;
-    // Number of peek times
-    int peekTimes;
+	// The number of mutations stored in the TLog before peek
+	int numMutations;
+	// The number of teams in the TLog. Mutations are randomly distributed into teams.
+	int numTeams;
+	// The initial version
+	int initialVersion;
+	// Number of peek times
+	int peekTimes;
 
-    explicit TestTLogPeekOptions(const UnitTestParameters&);
+	explicit TestTLogPeekOptions(const UnitTestParameters&);
 };
 
-}   // namespace ptxn::test::tLogPeek
+} // namespace ptxn::test
 
 #endif // FDBSERVER_PTEXN_TEST_TESTTLOGPEEK_H

--- a/fdbserver/ptxn/test/TestTLogPeek.h
+++ b/fdbserver/ptxn/test/TestTLogPeek.h
@@ -1,0 +1,51 @@
+/*
+ * TestTLogPeek.h
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FDBSERVER_PTXN_TEST_TESTTLOGPEEK_H
+#define FDBSERVER_PTXN_TEST_TESTTLOGPEEK_H
+
+#pragma once
+
+#include "fdbserver/ptxn/test/Driver.h"
+#include "flow/UnitTest.h"
+
+namespace ptxn::test::tLogPeek {
+
+struct TestTLogPeekOptions {
+    static const int DEFAULT_NUM_MUTATIONS = 10000;
+    static const int DEFAULT_NUM_TEAMS = 3;
+    static const int DEFAULT_INITIAL_VERSION = 1000;
+    static const int DEFAULT_PEEK_TIMES = 1000;
+
+    // The number of mutations stored in the TLog before peek
+    int numMutations;
+    // The number of teams in the TLog. Mutations are randomly distributed into teams.
+    int numTeams;
+    // The initial version
+    int initialVersion;
+    // Number of peek times
+    int peekTimes;
+
+    explicit TestTLogPeekOptions(const UnitTestParameters&);
+};
+
+}   // namespace ptxn::test::tLogPeek
+
+#endif // FDBSERVER_PTEXN_TEST_TESTTLOGPEEK_H

--- a/fdbserver/ptxn/test/TestTLogPeek.h
+++ b/fdbserver/ptxn/test/TestTLogPeek.h
@@ -36,7 +36,7 @@ struct TestTLogPeekOptions {
 	// The number of mutations stored in the TLog before peek
 	int numMutations;
 	// The number of teams in the TLog. Mutations are randomly distributed into teams.
-	int numTeams;
+	int numStorageTeams;
 	// The initial version
 	int initialVersion;
 	// Number of peek times

--- a/fdbserver/ptxn/test/Utils.cpp
+++ b/fdbserver/ptxn/test/Utils.cpp
@@ -1,0 +1,184 @@
+/*
+ * Utils.cpp
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "fdbserver/ptxn/test/Utils.h"
+
+#include <iostream>
+#include <iomanip>
+#include <string>
+#include <stdexcept>
+
+#include "fdbserver/ptxn/test/Driver.h"
+#include "fdbserver/ptxn/test/TestTLogPeek.h"
+#include "fdbserver/ptxn/TLogInterface.h"
+#include "flow/Error.h"
+#include "flow/IRandom.h"
+#include "flow/String.h"
+
+namespace ptxn::test {
+
+UID randomUID() {
+	return deterministicRandom()->randomUniqueID();
+}
+
+TeamID getNewTeamID() {
+	return randomUID();
+}
+
+std::vector<TeamID> generateRandomTeamIDs(const int numTeams) {
+	std::vector<TeamID> result(numTeams);
+	for (auto& item : result) {
+		item = getNewTeamID();
+	}
+	return result;
+}
+
+namespace print {
+
+namespace {
+
+template <typename T>
+inline std::string formatKVPair(const std::string& key, const T& value) {
+	return concatToString(std::setw(28), key, ": ", value);
+}
+
+template <typename T>
+inline std::string formatKVPair(const std::string& key, const Optional<T>& optionalValue) {
+	if (optionalValue.present()) {
+		return formatKVPair(key, optionalValue.get());
+	} else {
+		return formatKVPair(key, "Optional value not present");
+	}
+}
+
+inline std::string formatKVPair(const std::string& key, const MessageTransferModel& model) {
+	switch (model) {
+	case MessageTransferModel::StorageServerActivelyPull:
+		return formatKVPair(key, "Storage Server pulls mutations from TLog");
+	case MessageTransferModel::TLogActivelyPush:
+		return formatKVPair(key, "TLog pushes mutations to Storage Server");
+	default:
+		throw internal_error_msg(
+		    concatToString("Invalid MessageTransferModel value: ", static_cast<int>(model)).c_str());
+	}
+}
+
+} // anonymous namespace
+
+void print(const TLogCommitReply& reply) {
+	std::cout << std::endl << ">>> TLogCommitReply" << std::endl;
+
+	std::cout << formatKVPair("Version", reply.version) << std::endl;
+}
+
+void print(const TLogCommitRequest& request) {
+	std::cout << std::endl << ">>> TLogCommitRequest" << std::endl;
+
+	std::cout << formatKVPair("Span ID", request.spanID) << std::endl
+	          << formatKVPair("Team ID", request.teamID) << std::endl
+	          << formatKVPair("Debug ID", request.debugID) << std::endl
+	          << formatKVPair("Message data length", request.messages.size()) << std::endl
+	          << formatKVPair("Previous version", request.prevVersion) << std::endl
+	          << formatKVPair("Version", request.version) << std::endl;
+}
+
+void print(const TLogPeekRequest& request) {
+	std::cout << std::endl << ">>> TLogPeekRequest" << std::endl;
+
+	std::cout << formatKVPair("Debug ID", request.debugID) << std::endl
+	          << formatKVPair("Begin version", request.beginVersion) << std::endl
+	          << formatKVPair("End version", request.endVersion) << std::endl
+	          << formatKVPair("Team ID", request.teamID) << std::endl;
+}
+
+void print(const TLogPeekReply& reply) {
+	std::cout << std::endl << ">> TLogPeekReply" << std::endl;
+
+	std::cout << formatKVPair("Debug ID", reply.debugID) << std::endl
+	          << formatKVPair("Serialized data length", reply.data.size()) << std::endl;
+}
+
+void print(const TestDriverOptions& option) {
+	std::cout << std::endl << ">> ptxn/test//Driver.actor.cpp:DriverTestOptions:" << std::endl;
+
+	std::cout << formatKVPair("numCommits", option.numCommits) << std::endl
+	          << formatKVPair("numTeams", option.numTeams) << std::endl
+	          << formatKVPair("numProxies", option.numProxies) << std::endl
+	          << formatKVPair("numTLogs", option.numTLogs) << std::endl
+	          << formatKVPair("Message Transfer Model", option.transferModel) << std::endl;
+}
+
+void print(const CommitRecord& record) {
+	std::cout << std::endl << ">> ptxn/test/Driver.h:CommitRecord;" << std::endl;
+
+	std::cout << formatKVPair("Verson", record.version) << std::endl
+	          << formatKVPair("teamID", record.teamID) << std::endl;
+
+	std::cout << formatKVPair("Muations", record.mutations.size()) << std::endl;
+	for (const auto& mutation : record.mutations) {
+		std::cout << mutation.toString() << std::endl;
+	}
+}
+
+void print(const ptxn::test::tLogPeek::TestTLogPeekOptions& option) {
+	std::cout << std::endl << ">> ptxn/test//Driver.actor.cpp:DriverTestOptions:" << std::endl;
+
+	std::cout << formatKVPair("Mutations", option.numMutations) << std::endl
+	          << formatKVPair("Teams", option.numTeams) << std::endl
+	          << formatKVPair("Intial version", option.initialVersion) << std::endl;
+}
+
+void printCommitRecord(const std::vector<CommitRecord>& records) {
+	std::cout << "Commits from Proxy: \n\n";
+	Version currentVersion = 0;
+	for (const auto& record : records) {
+		if (record.version != currentVersion) {
+			std::cout << "\n\tVersion: " << record.version << "\n\n";
+			currentVersion = record.version;
+		}
+		std::cout << "\t\tTeam ID: " << record.teamID.toString() << std::endl;
+		for (const auto& mutation : record.mutations) {
+			std::cout << "\t\t\t" << mutation.toString() << std::endl;
+		}
+	}
+}
+
+void printNotValidatedRecords(const std::vector<CommitRecord>& records) {
+	std::cout << "Unvalidated commits: \n\n";
+	for (const auto& record : records) {
+		if (record.validation.validated())
+			continue;
+		std::cout << "\tVersion: " << record.version << "\tTeam ID: " << record.teamID.toString() << std::endl;
+		for (const auto& mutation : record.mutations) {
+			std::cout << "\t\t\t" << mutation.toString() << std::endl;
+		}
+
+		if (!record.validation.tLogValidated) {
+			std::cout << "\tTLog has not validated the reception of this commit." << std::endl;
+		}
+		if (!record.validation.storageServerValidated) {
+			std::cout << "\tStorageServer has not validated the reception of this commit." << std::endl;
+		}
+	}
+}
+
+} // namespace print
+
+} // namespace ptxn::test

--- a/fdbserver/ptxn/test/Utils.cpp
+++ b/fdbserver/ptxn/test/Utils.cpp
@@ -137,7 +137,7 @@ void print(const CommitRecord& record) {
 	}
 }
 
-void print(const ptxn::test::tLogPeek::TestTLogPeekOptions& option) {
+void print(const ptxn::test::TestTLogPeekOptions& option) {
 	std::cout << std::endl << ">> ptxn/test//Driver.actor.cpp:DriverTestOptions:" << std::endl;
 
 	std::cout << formatKVPair("Mutations", option.numMutations) << std::endl

--- a/fdbserver/ptxn/test/Utils.cpp
+++ b/fdbserver/ptxn/test/Utils.cpp
@@ -38,14 +38,14 @@ UID randomUID() {
 	return deterministicRandom()->randomUniqueID();
 }
 
-TeamID getNewTeamID() {
+StorageTeamID getNewStorageTeamID() {
 	return randomUID();
 }
 
-std::vector<TeamID> generateRandomTeamIDs(const int numTeams) {
-	std::vector<TeamID> result(numTeams);
+std::vector<StorageTeamID> generateRandomStorageTeamIDs(const int numStorageTeams) {
+	std::vector<StorageTeamID> result(numStorageTeams);
 	for (auto& item : result) {
-		item = getNewTeamID();
+		item = getNewStorageTeamID();
 	}
 	return result;
 }
@@ -92,7 +92,7 @@ void print(const TLogCommitRequest& request) {
 	std::cout << std::endl << ">>> TLogCommitRequest" << std::endl;
 
 	std::cout << formatKVPair("Span ID", request.spanID) << std::endl
-	          << formatKVPair("Team ID", request.teamID) << std::endl
+	          << formatKVPair("Team ID", request.storageTeamID) << std::endl
 	          << formatKVPair("Debug ID", request.debugID) << std::endl
 	          << formatKVPair("Message data length", request.messages.size()) << std::endl
 	          << formatKVPair("Previous version", request.prevVersion) << std::endl
@@ -105,7 +105,7 @@ void print(const TLogPeekRequest& request) {
 	std::cout << formatKVPair("Debug ID", request.debugID) << std::endl
 	          << formatKVPair("Begin version", request.beginVersion) << std::endl
 	          << formatKVPair("End version", request.endVersion) << std::endl
-	          << formatKVPair("Team ID", request.teamID) << std::endl;
+	          << formatKVPair("Team ID", request.storageTeamID) << std::endl;
 }
 
 void print(const TLogPeekReply& reply) {
@@ -119,7 +119,7 @@ void print(const TestDriverOptions& option) {
 	std::cout << std::endl << ">> ptxn/test//Driver.actor.cpp:DriverTestOptions:" << std::endl;
 
 	std::cout << formatKVPair("numCommits", option.numCommits) << std::endl
-	          << formatKVPair("numTeams", option.numTeams) << std::endl
+	          << formatKVPair("numStorageTeams", option.numStorageTeams) << std::endl
 	          << formatKVPair("numProxies", option.numProxies) << std::endl
 	          << formatKVPair("numTLogs", option.numTLogs) << std::endl
 	          << formatKVPair("Message Transfer Model", option.transferModel) << std::endl;
@@ -129,7 +129,7 @@ void print(const CommitRecord& record) {
 	std::cout << std::endl << ">> ptxn/test/Driver.h:CommitRecord;" << std::endl;
 
 	std::cout << formatKVPair("Verson", record.version) << std::endl
-	          << formatKVPair("teamID", record.teamID) << std::endl;
+	          << formatKVPair("storageTeamID", record.storageTeamID) << std::endl;
 
 	std::cout << formatKVPair("Muations", record.mutations.size()) << std::endl;
 	for (const auto& mutation : record.mutations) {
@@ -141,7 +141,7 @@ void print(const ptxn::test::TestTLogPeekOptions& option) {
 	std::cout << std::endl << ">> ptxn/test//Driver.actor.cpp:DriverTestOptions:" << std::endl;
 
 	std::cout << formatKVPair("Mutations", option.numMutations) << std::endl
-	          << formatKVPair("Teams", option.numTeams) << std::endl
+	          << formatKVPair("Teams", option.numStorageTeams) << std::endl
 	          << formatKVPair("Intial version", option.initialVersion) << std::endl;
 }
 
@@ -153,7 +153,7 @@ void printCommitRecord(const std::vector<CommitRecord>& records) {
 			std::cout << "\n\tVersion: " << record.version << "\n\n";
 			currentVersion = record.version;
 		}
-		std::cout << "\t\tTeam ID: " << record.teamID.toString() << std::endl;
+		std::cout << "\t\tTeam ID: " << record.storageTeamID.toString() << std::endl;
 		for (const auto& mutation : record.mutations) {
 			std::cout << "\t\t\t" << mutation.toString() << std::endl;
 		}
@@ -165,7 +165,7 @@ void printNotValidatedRecords(const std::vector<CommitRecord>& records) {
 	for (const auto& record : records) {
 		if (record.validation.validated())
 			continue;
-		std::cout << "\tVersion: " << record.version << "\tTeam ID: " << record.teamID.toString() << std::endl;
+		std::cout << "\tVersion: " << record.version << "\tTeam ID: " << record.storageTeamID.toString() << std::endl;
 		for (const auto& mutation : record.mutations) {
 			std::cout << "\t\t\t" << mutation.toString() << std::endl;
 		}

--- a/fdbserver/ptxn/test/Utils.h
+++ b/fdbserver/ptxn/test/Utils.h
@@ -64,7 +64,7 @@ void print(const TLogPeekRequest&);
 void print(const TLogPeekReply&);
 void print(const TestDriverOptions&);
 void print(const CommitRecord&);
-void print(const ptxn::test::tLogPeek::TestTLogPeekOptions&);
+void print(const ptxn::test::TestTLogPeekOptions&);
 
 void printCommitRecord(const std::vector<CommitRecord>&);
 void printNotValidatedRecords(const std::vector<CommitRecord>&);

--- a/fdbserver/ptxn/test/Utils.h
+++ b/fdbserver/ptxn/test/Utils.h
@@ -1,0 +1,76 @@
+/*
+ * Utils.h
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FDBSERVER_PTXN_TEST_UTILS_H
+#define FDBSERVER_PTXN_TEST_UTILS_H
+
+#pragma once
+
+#include <vector>
+
+#include "fdbserver/ptxn/test/Driver.h"
+#include "fdbserver/ptxn/test/TestTLogPeek.h"
+#include "fdbserver/ptxn/TLogInterface.h"
+
+namespace ptxn::test {
+
+// Shortcut for deterministicRanodm()->randomUniqueID();
+UID randomUID();
+
+// Constructs a random TeamID
+TeamID getNewTeamID();
+
+// Construct numTeams TeamIDs
+std::vector<TeamID> generateRandomTeamIDs(const int numTeams);
+
+// Pick one element from a container, randomly
+// The container should support the concept of
+//  template <typename Container>
+//  requires(const Container& container) {
+//      { container[0] };
+//      { container.size() };
+//      { Container::const_reference }
+//  }
+template <typename Container>
+typename Container::const_reference randomlyPick(const Container& container) {
+    if (container.size() == 0) {
+        throw std::range_error("empty container");
+    }
+    return container[deterministicRandom()->randomInt(0, container.size())];
+}
+
+namespace print {
+
+void print(const TLogCommitReply&);
+void print(const TLogPeekRequest&);
+void print(const TLogPeekRequest&);
+void print(const TLogPeekReply&);
+void print(const TestDriverOptions&);
+void print(const CommitRecord&);
+void print(const ptxn::test::tLogPeek::TestTLogPeekOptions&);
+
+void printCommitRecord(const std::vector<CommitRecord>&);
+void printNotValidatedRecords(const std::vector<CommitRecord>&);
+
+} // namespace print
+
+} // namespace ptxn::test
+
+#endif // FDBSERVER_PTXN_TEST_UTILS_H

--- a/fdbserver/ptxn/test/Utils.h
+++ b/fdbserver/ptxn/test/Utils.h
@@ -34,11 +34,11 @@ namespace ptxn::test {
 // Shortcut for deterministicRanodm()->randomUniqueID();
 UID randomUID();
 
-// Constructs a random TeamID
-TeamID getNewTeamID();
+// Constructs a random StorageTeamID
+StorageTeamID getNewStorageTeamID();
 
-// Construct numTeams TeamIDs
-std::vector<TeamID> generateRandomTeamIDs(const int numTeams);
+// Construct numStorageTeams TeamIDs
+std::vector<StorageTeamID> generateRandomStorageTeamIDs(const int numStorageTeams);
 
 // Pick one element from a container, randomly
 // The container should support the concept of

--- a/flow/String.h
+++ b/flow/String.h
@@ -27,7 +27,7 @@
 namespace {
 
 template <typename Arg>
-std::stringstream& _concatHelper(std::stringstream&& ss, const Arg& arg) {
+std::stringstream& _concatHelper(std::stringstream&& ss, Arg&& arg) {
 	ss << arg;
 	return ss;
 }
@@ -35,7 +35,7 @@ std::stringstream& _concatHelper(std::stringstream&& ss, const Arg& arg) {
 template <typename First, typename... Args>
 std::stringstream& _concatHelper(std::stringstream&& ss, const First& first, const Args&... args) {
 	ss << first;
-	return _concatHelper(std::move(ss), args...);
+	return _concatHelper(std::move(ss), std::forward<Args>(args)...);
 }
 
 } // anonymous namespace

--- a/flow/String.h
+++ b/flow/String.h
@@ -27,7 +27,7 @@
 namespace {
 
 template <typename Arg>
-std::stringstream& _concatHelper(std::stringstream&& ss, Arg&& arg) {
+std::stringstream& _concatHelper(std::stringstream&& ss, const Arg& arg) {
 	ss << arg;
 	return ss;
 }
@@ -35,7 +35,7 @@ std::stringstream& _concatHelper(std::stringstream&& ss, Arg&& arg) {
 template <typename First, typename... Args>
 std::stringstream& _concatHelper(std::stringstream&& ss, const First& first, const Args&... args) {
 	ss << first;
-	return _concatHelper(std::move(ss), std::forward<Args>(args)...);
+	return _concatHelper(std::move(ss), std::forward<const Args&>(args)...);
 }
 
 } // anonymous namespace

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -280,6 +280,7 @@ if(WITH_PYTHON)
   add_fdb_test(TEST_FILES ptxn/Resolver.toml)
   add_fdb_test(TEST_FILES ptxn/Serialization.toml)
   add_fdb_test(TEST_FILES ptxn/TLogServer.toml)
+  add_fdb_Test(TEST_FILES ptxn/TLogPeekCursor.toml)
   add_fdb_test(TEST_FILES ptxn/TeamVersionTracker.toml)
 
   verify_testing()

--- a/tests/ptxn/Driver.toml
+++ b/tests/ptxn/Driver.toml
@@ -31,14 +31,14 @@ startDelay = 0
     peekTimes = 10
 
 [[test]]
-testTitle = 'Test server team cursor'
+testTitle = 'Test TLog group peek cursor'
 useDB = false
 startDelay = 0
 
     [[test.workload]]
     testName = 'UnitTests'
     maxTestCases = 1
-    testsMatching = '/fdbserver/ptxn/test/tLogPeek/cursor/ServerTeamPeekCursor'
+    testsMatching = '/fdbserver/ptxn/test/tLogPeek/cursor/TLogGroupPeekCursor'
 
     maxBytesPerPeek = 65536
 

--- a/tests/ptxn/Driver.toml
+++ b/tests/ptxn/Driver.toml
@@ -28,6 +28,8 @@ startDelay = 0
     maxTestCases = 1
     testsMatching = '/fdbserver/ptxn/test/tlogPeek/readFromSerialization'
 
+    peekTimes = 10
+
 [[test]]
 testTitle = 'Test server team cursor'
 useDB = false
@@ -39,3 +41,19 @@ startDelay = 0
     testsMatching = '/fdbserver/ptxn/test/tLogPeek/cursor/ServerTeamPeekCursor'
 
     maxBytesPerPeek = 65536
+
+[[test]]
+testTitle = 'Test merged peek cursor'
+useDB = false
+startDelay = 0
+
+    [[test.workload]]
+    testName = 'UnitTests'
+    maxTestCases = 1
+    testsMatching = '/fdbserver/ptxn/test/tLogPeek/cursor/MergedPeekCursor'
+
+    maxBytesPerPeek = 4096
+
+    numMutations = 100000
+    numTeams = 3
+    initialVersion = 1000

--- a/tests/ptxn/Driver.toml
+++ b/tests/ptxn/Driver.toml
@@ -50,10 +50,40 @@ startDelay = 0
     [[test.workload]]
     testName = 'UnitTests'
     maxTestCases = 1
-    testsMatching = '/fdbserver/ptxn/test/tLogPeek/cursor/MergedPeekCursor'
+    testsMatching = '/fdbserver/ptxn/test/tLogPeek/cursor/MergedPeekCursor/base'
 
     maxBytesPerPeek = 4096
 
     numMutations = 100000
     numTeams = 3
     initialVersion = 1000
+
+[[test]]
+testTitle = 'Test merged peek cursor -- add cursors on the fly'
+useDB = false
+startDelay = 0
+
+    [[test.workload]]
+    testName = 'UnitTests'
+    maxTestCases = 1
+    testsMatching = '/fdbserver/ptxn/test/tLogPeek/cursor/MergedPeekCursor/addCursorOnTheFly'
+
+[[test]]
+testTitle = 'Test merged peek cursor -- remove cursors on the fly'
+useDB = false
+startDelay = 0
+
+    [[test.workload]]
+    testName = 'UnitTests'
+    maxTestCases = 1
+    testsMatching = '/fdbserver/ptxn/test/tLogPeek/cursor/MergedServerTeamPeekCursor/removeCursorOnTheFly' 
+
+[[test]]
+testTitle = 'Test cursor advanceTo'
+useDB = false
+startDelay = 0
+
+    [[test.workload]]
+    testName = 'UnitTests'
+    maxTestCases = 1
+    testsMatching = '/fdbserver/ptxn/test/tLogPeek/cursor/advanceTo'

--- a/tests/ptxn/Driver.toml
+++ b/tests/ptxn/Driver.toml
@@ -9,7 +9,7 @@ startDelay = 0
     testsMatching = '/fdbserver/ptxn/test/driver'
 
     numCommits = 20
-    numTeams = 20
+    numStorageTeams = 20
     numProxies = 1
     numTLogs = 4
     numStorageServers = 4
@@ -17,73 +17,3 @@ startDelay = 0
     # 0 stands for TLog --push--> StorageServer
     # 1 stands for StorageServer --pull--> TLog
     messageTransferModel = 0
-
-[[test]]
-testTitle = 'Test FakeTLog serialize data to FakeStorageServer'
-useDB = false
-startDelay = 0
-
-    [[test.workload]]
-    testName = 'UnitTests'
-    maxTestCases = 1
-    testsMatching = '/fdbserver/ptxn/test/tlogPeek/readFromSerialization'
-
-    peekTimes = 10
-
-[[test]]
-testTitle = 'Test TLog group peek cursor'
-useDB = false
-startDelay = 0
-
-    [[test.workload]]
-    testName = 'UnitTests'
-    maxTestCases = 1
-    testsMatching = '/fdbserver/ptxn/test/tLogPeek/cursor/TLogGroupPeekCursor'
-
-    maxBytesPerPeek = 65536
-
-[[test]]
-testTitle = 'Test merged peek cursor'
-useDB = false
-startDelay = 0
-
-    [[test.workload]]
-    testName = 'UnitTests'
-    maxTestCases = 1
-    testsMatching = '/fdbserver/ptxn/test/tLogPeek/cursor/MergedPeekCursor/base'
-
-    maxBytesPerPeek = 4096
-
-    numMutations = 100000
-    numTeams = 3
-    initialVersion = 1000
-
-[[test]]
-testTitle = 'Test merged peek cursor -- add cursors on the fly'
-useDB = false
-startDelay = 0
-
-    [[test.workload]]
-    testName = 'UnitTests'
-    maxTestCases = 1
-    testsMatching = '/fdbserver/ptxn/test/tLogPeek/cursor/MergedPeekCursor/addCursorOnTheFly'
-
-[[test]]
-testTitle = 'Test merged peek cursor -- remove cursors on the fly'
-useDB = false
-startDelay = 0
-
-    [[test.workload]]
-    testName = 'UnitTests'
-    maxTestCases = 1
-    testsMatching = '/fdbserver/ptxn/test/tLogPeek/cursor/MergedServerTeamPeekCursor/removeCursorOnTheFly' 
-
-[[test]]
-testTitle = 'Test cursor advanceTo'
-useDB = false
-startDelay = 0
-
-    [[test.workload]]
-    testName = 'UnitTests'
-    maxTestCases = 1
-    testsMatching = '/fdbserver/ptxn/test/tLogPeek/cursor/advanceTo'

--- a/tests/ptxn/TLogPeekCursor.toml
+++ b/tests/ptxn/TLogPeekCursor.toml
@@ -1,0 +1,69 @@
+[[test]]
+testTitle = 'Test FakeTLog serialize data to FakeStorageServer'
+useDB = false
+startDelay = 0
+
+    [[test.workload]]
+    testName = 'UnitTests'
+    maxTestCases = 1
+    testsMatching = '/fdbserver/ptxn/test/tlogPeek/readFromSerialization'
+
+    peekTimes = 10
+
+[[test]]
+testTitle = 'Test TLog group peek cursor'
+useDB = false
+startDelay = 0
+
+    [[test.workload]]
+    testName = 'UnitTests'
+    maxTestCases = 1
+    testsMatching = '/fdbserver/ptxn/test/tLogPeek/cursor/TLogGroupPeekCursor'
+
+    maxBytesPerPeek = 65536
+
+[[test]]
+testTitle = 'Test merged peek cursor'
+useDB = false
+startDelay = 0
+
+    [[test.workload]]
+    testName = 'UnitTests'
+    maxTestCases = 1
+    testsMatching = '/fdbserver/ptxn/test/tLogPeek/cursor/MergedPeekCursor/base'
+
+    maxBytesPerPeek = 4096
+
+    numMutations = 100000
+    numStorageTeams = 3
+    initialVersion = 1000
+
+[[test]]
+testTitle = 'Test merged peek cursor -- add cursors on the fly'
+useDB = false
+startDelay = 0
+
+    [[test.workload]]
+    testName = 'UnitTests'
+    maxTestCases = 1
+    testsMatching = '/fdbserver/ptxn/test/tLogPeek/cursor/MergedPeekCursor/addCursorOnTheFly'
+
+[[test]]
+testTitle = 'Test merged peek cursor -- remove cursors on the fly'
+useDB = false
+startDelay = 0
+
+    [[test.workload]]
+    testName = 'UnitTests'
+    maxTestCases = 1
+    testsMatching = '/fdbserver/ptxn/test/tLogPeek/cursor/MergedServerTeamPeekCursor/removeCursorOnTheFly' 
+
+[[test]]
+testTitle = 'Test cursor advanceTo'
+useDB = false
+startDelay = 0
+
+    [[test.workload]]
+    testName = 'UnitTests'
+    maxTestCases = 1
+    testsMatching = '/fdbserver/ptxn/test/tLogPeek/cursor/advanceTo'

--- a/tests/ptxn/TLogPeekCursor.toml
+++ b/tests/ptxn/TLogPeekCursor.toml
@@ -6,7 +6,7 @@ startDelay = 0
     [[test.workload]]
     testName = 'UnitTests'
     maxTestCases = 1
-    testsMatching = '/fdbserver/ptxn/test/tlogPeek/readFromSerialization'
+    testsMatching = '/fdbserver/ptxn/test/tLogPeek/readFromSerialization'
 
     peekTimes = 10
 
@@ -18,7 +18,7 @@ startDelay = 0
     [[test.workload]]
     testName = 'UnitTests'
     maxTestCases = 1
-    testsMatching = '/fdbserver/ptxn/test/tLogPeek/cursor/TLogGroupPeekCursor'
+    testsMatching = '/fdbserver/ptxn/test/tLogPeek/cursor/StorageTeamPeekCursor'
 
     maxBytesPerPeek = 65536
 
@@ -56,7 +56,7 @@ startDelay = 0
     [[test.workload]]
     testName = 'UnitTests'
     maxTestCases = 1
-    testsMatching = '/fdbserver/ptxn/test/tLogPeek/cursor/MergedServerTeamPeekCursor/removeCursorOnTheFly' 
+    testsMatching = '/fdbserver/ptxn/test/tLogPeek/cursor/MergedStorageTeamPeekCursor/removeCursorOnTheFly'
 
 [[test]]
 testTitle = 'Test cursor advanceTo'

--- a/tests/ptxn/TLogServer.toml
+++ b/tests/ptxn/TLogServer.toml
@@ -1,9 +1,9 @@
- [[test]]
- testTitle = 'TLog Server Test'
- useDB = false
- startDelay = 0
+[[test]]
+testTitle = 'TLog Server Test'
+useDB = false
+startDelay = 0
 
-     [[test.workload]]
-     testName = 'UnitTests'
-     maxTestCases = 1
-     testsMatching = '/fdbserver/ptxn/test/run_tlog_server'
+    [[test.workload]]
+    testName = 'UnitTests'
+    maxTestCases = 1
+    testsMatching = '/fdbserver/ptxn/test/run_tlog_server'


### PR DESCRIPTION
The merge cursor would handle multiple cursors, reorder the mutations for consumption.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
