### PR TITLE
Fix deserialization performance issue

### DIFF
--- a/fdbserver/ptxn/TLogStorageServerPeekMessageSerializer.cpp
+++ b/fdbserver/ptxn/TLogStorageServerPeekMessageSerializer.cpp
@@ -156,8 +156,9 @@ TLogStorageServerMessageDeserializer::iterator::iterator(const Arena& serialized
 }
 
 bool TLogStorageServerMessageDeserializer::iterator::operator==(const iterator& another) const {
-	return (rawSerializedData == another.rawSerializedData && sectionIndex == another.sectionIndex &&
-	        itemIndex == another.itemIndex);
+	return rawSerializedData.begin() == another.rawSerializedData.begin() &&
+	       rawSerializedData.size() == another.rawSerializedData.size() && sectionIndex == another.sectionIndex &&
+	       itemIndex == another.itemIndex;
 }
 
 bool TLogStorageServerMessageDeserializer::iterator::operator!=(const iterator& another) const {


### PR DESCRIPTION
For the iterator, check StringRef::begin() and size() should be sufficient and avoid the expensive `memcmp()` calls.

Found by running `perf record -F 99 -ag ./build_output/bin/fdbserver -r test -b on --crash -s 1 -f tests/ptxn/Serialization.toml`.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
