### PR TITLE
Proxy serializes data for storage teams (dual-write path).

### DIFF
--- a/fdbclient/FDBTypes.h
+++ b/fdbclient/FDBTypes.h
@@ -63,6 +63,9 @@ using StorageTeamID = UID;
 
 const StorageTeamID txsTeam = UID(1, 1);
 
+// Transaction subsystem state (txnState) team.
+const TeamID txsTeam = UID(1, 1);
+
 }	// namespace ptxn
 
 #pragma pack(push, 1)

--- a/fdbclient/FDBTypes.h
+++ b/fdbclient/FDBTypes.h
@@ -61,10 +61,8 @@ namespace ptxn {
 using TLogGroupID = UID;
 using StorageTeamID = UID;
 
-const StorageTeamID txsTeam = UID(1, 1);
-
 // Transaction subsystem state (txnState) team.
-const TeamID txsTeam = UID(1, 1);
+const StorageTeamID txsTeam = UID(1, 1);
 
 }	// namespace ptxn
 

--- a/fdbclient/StorageServerInterface.h
+++ b/fdbclient/StorageServerInterface.h
@@ -162,7 +162,7 @@ struct ServerCacheInfo {
 	std::vector<Tag> tags; // all tags in both primary and remote DC for the key-range
 	std::vector<Reference<StorageInfo>> src_info;
 	std::vector<Reference<StorageInfo>> dest_info;
-	std::vector<ptxn::TeamID> teams; // primary and remote DC teams for the key range
+	std::set<ptxn::TeamID> teams; // primary and remote DC teams for the key range
 
 	void populateTags() {
 		if (tags.size())

--- a/fdbclient/StorageServerInterface.h
+++ b/fdbclient/StorageServerInterface.h
@@ -162,6 +162,7 @@ struct ServerCacheInfo {
 	std::vector<Tag> tags; // all tags in both primary and remote DC for the key-range
 	std::vector<Reference<StorageInfo>> src_info;
 	std::vector<Reference<StorageInfo>> dest_info;
+	std::vector<ptxn::TeamID> teams; // primary and remote DC teams for the key range
 
 	void populateTags() {
 		if (tags.size())

--- a/fdbclient/StorageServerInterface.h
+++ b/fdbclient/StorageServerInterface.h
@@ -162,7 +162,7 @@ struct ServerCacheInfo {
 	std::vector<Tag> tags; // all tags in both primary and remote DC for the key-range
 	std::vector<Reference<StorageInfo>> src_info;
 	std::vector<Reference<StorageInfo>> dest_info;
-	std::set<ptxn::TeamID> teams; // primary and remote DC teams for the key range
+	std::set<ptxn::StorageTeamID> teams; // primary and remote DC teams for the key range
 
 	void populateTags() {
 		if (tags.size())

--- a/fdbserver/CommitProxyServer.actor.cpp
+++ b/fdbserver/CommitProxyServer.actor.cpp
@@ -970,7 +970,7 @@ ACTOR Future<Void> assignMutationsToStorageServers(CommitBatchContext* self) {
 				auto ranges = pProxyCommitData->keyInfo.intersectingRanges(clearRange);
 				auto firstRange = ranges.begin();
 				++firstRange;
-				std::set<ptxn::TeamID> teams; // write m to these teams
+				std::set<ptxn::StorageTeamID> teams; // write m to these teams
 				if (firstRange == ranges.end()) {
 					// Fast path
 					DEBUG_MUTATION("ProxyCommit", self->commitVersion, m)

--- a/fdbserver/CommitProxyServer.actor.cpp
+++ b/fdbserver/CommitProxyServer.actor.cpp
@@ -970,7 +970,7 @@ ACTOR Future<Void> assignMutationsToStorageServers(CommitBatchContext* self) {
 				auto ranges = pProxyCommitData->keyInfo.intersectingRanges(clearRange);
 				auto firstRange = ranges.begin();
 				++firstRange;
-				std::set<ptxn::StorageTeamID> teams; // write m to these teams
+				std::set<ptxn::StorageTeamID> storageTeams; // write m to these teams
 				if (firstRange == ranges.end()) {
 					// Fast path
 					DEBUG_MUTATION("ProxyCommit", self->commitVersion, m)
@@ -981,7 +981,7 @@ ACTOR Future<Void> assignMutationsToStorageServers(CommitBatchContext* self) {
 					ranges.begin().value().populateTags();
 					self->toCommit.addTags(ranges.begin().value().tags);
 					auto& dstTeams = ranges.begin().value().teams;
-					teams.insert(dstTeams.begin(), dstTeams.end());
+					storageTeams.insert(dstTeams.begin(), dstTeams.end());
 
 					// check whether clear is sampled
 					if (checkSample && !trCost->get().clearIdxCosts.empty() &&
@@ -1000,7 +1000,7 @@ ACTOR Future<Void> assignMutationsToStorageServers(CommitBatchContext* self) {
 						r.value().populateTags();
 						allSources.insert(r.value().tags.begin(), r.value().tags.end());
 						auto& dstTeams = r.value().teams;
-						teams.insert(dstTeams.begin(), dstTeams.end());
+						storageTeams.insert(dstTeams.begin(), dstTeams.end());
 
 						// check whether clear is sampled
 						if (checkSample && !trCost->get().clearIdxCosts.empty() &&
@@ -1027,7 +1027,7 @@ ACTOR Future<Void> assignMutationsToStorageServers(CommitBatchContext* self) {
 					self->toCommit.addTag(cacheTag);
 				}
 				self->toCommit.writeTypedMessage(m);
-				self->teamMessageBuilder.writeMessage(m, teams);
+				self->teamMessageBuilder.writeMessage(m, storageTeams);
 			} else {
 				UNREACHABLE();
 			}

--- a/fdbserver/CommitProxyServer.actor.cpp
+++ b/fdbserver/CommitProxyServer.actor.cpp
@@ -1185,7 +1185,7 @@ ACTOR Future<Void> postResolution(CommitBatchContext* self) {
 			self->toCommit.addTxsTag();
 		}
 		self->toCommit.writeMessage(StringRef(m.begin(), m.size()), !firstMessage);
-		// self->teamMessageBuilder.writeMessage(m, teamID);
+		self->teamMessageBuilder.writeMessage(StringRef(m.begin(), m.size()), ptxn::txsTeam);
 		firstMessage = false;
 	}
 

--- a/fdbserver/CommitProxyServer.actor.cpp
+++ b/fdbserver/CommitProxyServer.actor.cpp
@@ -962,7 +962,9 @@ ACTOR Future<Void> assignMutationsToStorageServers(CommitBatchContext* self) {
 					self->toCommit.addTag(cacheTag);
 				}
 				self->toCommit.writeTypedMessage(m);
-				// self->teamMessageBuilder.writeMessage(m, teamID);
+
+				auto& teams = pProxyCommitData->keyInfo[m.param1].teams;
+				self->teamMessageBuilder.writeMessage(m, teams);
 			} else if (m.type == MutationRef::ClearRange) {
 				KeyRangeRef clearRange(KeyRangeRef(m.param1, m.param2));
 				auto ranges = pProxyCommitData->keyInfo.intersectingRanges(clearRange);

--- a/fdbserver/CommitProxyServer.actor.cpp
+++ b/fdbserver/CommitProxyServer.actor.cpp
@@ -22,8 +22,8 @@
 #include <iterator>
 #include <tuple>
 
-#include <fdbclient/DatabaseContext.h>
 #include "fdbclient/Atomic.h"
+#include "fdbclient/DatabaseContext.h"
 #include "fdbclient/FDBTypes.h"
 #include "fdbclient/Knobs.h"
 #include "fdbclient/CommitProxyInterface.h"

--- a/fdbserver/CommitProxyServer.actor.cpp
+++ b/fdbserver/CommitProxyServer.actor.cpp
@@ -1025,9 +1025,7 @@ ACTOR Future<Void> assignMutationsToStorageServers(CommitBatchContext* self) {
 					self->toCommit.addTag(cacheTag);
 				}
 				self->toCommit.writeTypedMessage(m);
-				for (const auto& team : teams) {
-					self->teamMessageBuilder.writeMessage(m, team);
-				}
+				self->teamMessageBuilder.writeMessage(m, teams);
 			} else {
 				UNREACHABLE();
 			}

--- a/fdbserver/ProxyCommitData.actor.h
+++ b/fdbserver/ProxyCommitData.actor.h
@@ -170,7 +170,7 @@ struct ProxyCommitData {
 	int updateCommitRequests = 0;
 	NotifiedDouble lastCommitTime;
 
-	vector<double> commitComputePerOperation;
+	std::vector<double> commitComputePerOperation;
 	UIDTransactionTagMap<TransactionCommitCostEstimation> ssTrTagCommitCost;
 	double lastMasterReset;
 	double lastResolverReset;
@@ -178,7 +178,7 @@ struct ProxyCommitData {
 	// The tag related to a storage server rarely change, so we keep a vector of tags for each key range to be slightly
 	// more CPU efficient. When a tag related to a storage server does change, we empty out all of these vectors to
 	// signify they must be repopulated. We do not repopulate them immediately to avoid a slow task.
-	const vector<Tag>& tagsForKey(StringRef key) {
+	const std::vector<Tag>& tagsForKey(StringRef key) {
 		auto& tags = keyInfo[key].tags;
 		if (!tags.size()) {
 			auto& r = keyInfo.rangeContaining(key).value();

--- a/fdbserver/ptxn/MessageTypes.h
+++ b/fdbserver/ptxn/MessageTypes.h
@@ -63,10 +63,16 @@ struct SubsequenceMutationItem {
 	std::variant<MutationRef, StringRef, struct SpanContextMessage> item_;
 
 	// Returns mutation in MutationRef format after deserialization.
-	const MutationRef& mutation() const { return std::get<MutationRef>(item_); }
+	const MutationRef& mutation() const {
+		ASSERT(isMutation());
+		return std::get<MutationRef>(item_);
+	}
 
 	// Returns SpanContextMessage after deserialization.
-	const struct SpanContextMessage& span() const { return std::get<struct SpanContextMessage>(item_); }
+	const struct SpanContextMessage& span() const {
+		ASSERT(item_.index() == 2);
+		return std::get<struct SpanContextMessage>(item_);
+	}
 
 	// Returns if the item is a mutation (MutationRef or StringRef)
 	bool isMutation() const { return item_.index() <= 1; }

--- a/fdbserver/ptxn/MessageTypes.h
+++ b/fdbserver/ptxn/MessageTypes.h
@@ -49,12 +49,15 @@ struct VersionSubsequence {
 	}
 };
 
-// Stores the mutations and their subsequences, or the relative order of each mutations. The order
-// is used in recovery.
+// Stores the mutations and their subsequences, or the relative order of each mutations.
+// The order is used in recovery and restoring from backups.
 struct SubsequenceMutationItem {
 	Subsequence subsequence;
+	// The mutation either in MutationRef form or in a serialized StringRef.
+	// When deserialized, we always store in MutationRef format.
 	std::variant<MutationRef, StringRef> mutation_;
 
+	// Returns mutation in MutationRef format after deserialization.
 	const MutationRef& mutation() const { return std::get<MutationRef>(mutation_); }
 
 	template <typename Reader>

--- a/fdbserver/ptxn/ProxyTLogPushMessageSerializer.cpp
+++ b/fdbserver/ptxn/ProxyTLogPushMessageSerializer.cpp
@@ -20,17 +20,49 @@
 
 #include "fdbserver/ptxn/ProxyTLogPushMessageSerializer.h"
 
+#include "fdbclient/FDBTypes.h"
+#include "fdbserver/SpanContextMessage.h"
+#include "fdbserver/ptxn/MessageTypes.h"
+#include "flow/Knobs.h"
+#include "flow/serialize.h"
+
 namespace ptxn {
 
-void ProxyTLogPushMessageSerializer::writeMessage(const MutationRef& mutation, const StorageTeamID& storageTeamID) {
-	writers[storageTeamID].writeItem(SubsequenceMutationItem{ currentSubsequence++, mutation });
+void ProxyTLogPushMessageSerializer::writeMessage(const MutationRef& mutation, const StorageTeamID& team) {
+	writeTransactionInfo(team);
+	writers[team].writeItem(SubsequenceMutationItem{ currentSubsequence++, mutation });
 }
 
-void ProxyTLogPushMessageSerializer::writeMessage(const StringRef& mutation, const StorageTeamID& teamID) {
-	writers[teamID].writeItem(SubsequenceMutationItem{ currentSubsequence++, mutation });
+void ProxyTLogPushMessageSerializer::writeMessage(const StringRef& mutation, const StorageTeamID& team) {
+	writeTransactionInfo(team);
+	writers[team].writeItem(SubsequenceMutationItem{ currentSubsequence++, mutation });
+}
+
+void ProxyTLogPushMessageSerializer::addTransactionInfo(const SpanID& context) {
+	TEST(!spanContext.isValid()); // addTransactionInfo with invalid SpanID
+	spanContext = context;
+	writtenTeams.clear();
+}
+
+bool ProxyTLogPushMessageSerializer::writeTransactionInfo(StorageTeamID team) {
+	if (!FLOW_KNOBS->WRITE_TRACING_ENABLED || writtenTeams.count(team) != 0 || !spanContext.isValid()) {
+		// TODO: add (logSystem->getTLogVersion() < TLogVersion::V6) as condition here
+		return false;
+	}
+
+	TEST(true); // Wrote SpanContextMessage to a tlog group
+	writtenTeams.insert(team);
+	writers[team].writeItem(SubsequenceMutationItem{ currentSubsequence++, SpanContextMessage(spanContext) });
+	return true;
 }
 
 void ProxyTLogPushMessageSerializer::writeMessage(const MutationRef& mutation, const std::set<StorageTeamID>& teams) {
+	// Write transaction info first for all teams
+	for (const auto& team : teams) {
+		// Note the increasing subsequence numbers.
+		writeTransactionInfo(team);
+	}
+
 	for (const auto& team : teams) {
 		// this mutation shares the same subsequence number
 		writers[team].writeItem(SubsequenceMutationItem{ currentSubsequence, mutation });

--- a/fdbserver/ptxn/ProxyTLogPushMessageSerializer.cpp
+++ b/fdbserver/ptxn/ProxyTLogPushMessageSerializer.cpp
@@ -53,8 +53,8 @@ Standalone<StringRef> ProxyTLogPushMessageSerializer::getSerialized(const Storag
 	return writers[storageTeamID].getSerialized();
 }
 
-std::unordered_map<TeamID, Standalone<StringRef>> ProxyTLogPushMessageSerializer::getAllSerialized() {
-	std::unordered_map<TeamID, Standalone<StringRef>> results;
+std::unordered_map<StorageTeamID, Standalone<StringRef>> ProxyTLogPushMessageSerializer::getAllSerialized() {
+	std::unordered_map<StorageTeamID, Standalone<StringRef>> results;
 	for (const auto& [teamID, writer] : writers) {
 		if (!writer.isWritingCompleted()) {
 			completeMessageWriting(teamID);

--- a/fdbserver/ptxn/ProxyTLogPushMessageSerializer.cpp
+++ b/fdbserver/ptxn/ProxyTLogPushMessageSerializer.cpp
@@ -26,6 +26,10 @@ void ProxyTLogPushMessageSerializer::writeMessage(const MutationRef& mutation, c
 	writers[storageTeamID].writeItem(SubsequenceMutationItem{ currentSubsequence++, mutation });
 }
 
+void ProxyTLogPushMessageSerializer::writeMessage(const StringRef& mutation, const StorageTeamID& teamID) {
+	writers[teamID].writeItem(SubsequenceMutationItem{ currentSubsequence++, mutation });
+}
+
 void ProxyTLogPushMessageSerializer::writeMessage(const MutationRef& mutation, const std::set<StorageTeamID>& teams) {
 	for (const auto& team : teams) {
 		// this mutation shares the same subsequence number

--- a/fdbserver/ptxn/ProxyTLogPushMessageSerializer.h
+++ b/fdbserver/ptxn/ProxyTLogPushMessageSerializer.h
@@ -21,6 +21,8 @@
 #ifndef FDBSERVER_PTXN_PROXYTLOGPUSHMESSAGESERIALIZER_H
 #define FDBSERVER_PTXN_PROXYTLOGPUSHMESSAGESERIALIZER_H
 
+#include "flow/Arena.h"
+#include <stdint.h>
 #pragma once
 
 #include <cstdint>
@@ -65,6 +67,9 @@ class ProxyTLogPushMessageSerializer {
 public:
 	// Writes a new mutation for a given TeamID.
 	void writeMessage(const MutationRef& mutation, const StorageTeamID& storageTeamID);
+
+	// Writes a new serialized mutation for a given TeamID.
+	void writeMessage(const StringRef& mutation, const TeamID& teamID);
 
 	// Adds span context about transactions.
 	void addTransactionInfo(const SpanID& context) {

--- a/fdbserver/ptxn/ProxyTLogPushMessageSerializer.h
+++ b/fdbserver/ptxn/ProxyTLogPushMessageSerializer.h
@@ -26,6 +26,7 @@
 #include <cstdint>
 #include <unordered_map>
 
+#include "fdbclient/FDBTypes.h"
 #include "fdbserver/ptxn/MessageTypes.h"
 #include "fdbserver/ptxn/Serializer.h"
 #include "flow/Arena.h"
@@ -47,7 +48,10 @@ struct ProxyTLogMessageHeader : MultipleItemHeaderBase {
 class ProxyTLogPushMessageSerializer {
 	// Maps the TeamID to the list of BinaryWriters
 	std::unordered_map<StorageTeamID, HeaderedItemsSerializer<ProxyTLogMessageHeader, SubsequenceMutationItem>> writers;
-	SpanID spanContext; // Transaction info. TODO: serialize this field
+
+	// Transaction info. Note different teams have different subsequence numbers.
+	SpanID spanContext;
+	std::set<StorageTeamID> writtenTeams; // Transaction info has been written to.
 
 	// Subsequence of the mutation
 	// NOTE: The subsequence is designed to start at 1. This allows a cursor,
@@ -59,8 +63,8 @@ class ProxyTLogPushMessageSerializer {
 	//  while(pCursor->hasMessage()) pCursor->getMessage();
 	// If the currentSubsequence starts at 0, we have to verify if the initial
 	// cursor is located at a mutation, or located at end-of-subsequences,
-	// brings extra complexity.
-	// This is the sequential of using unsigned integer as the subsequence.
+	// bringing extra complexity.
+	// This is the sequence by using unsigned integer.
 	Subsequence currentSubsequence = 1;
 
 public:
@@ -71,10 +75,7 @@ public:
 	void writeMessage(const StringRef& mutation, const StorageTeamID& teamID);
 
 	// Adds span context about transactions.
-	void addTransactionInfo(const SpanID& context) {
-		TEST(!spanContext.isValid()); // addTransactionInfo with invalid SpanID
-		spanContext = context;
-	}
+	void addTransactionInfo(const SpanID& context);
 
 	// Writes the same (clear range) mutation to all "teams".
 	void writeMessage(const MutationRef& mutation, const std::set<StorageTeamID>& teams);
@@ -87,6 +88,9 @@ public:
 
 	// Completes all teams' message writing and returns the serialized data.
 	std::unordered_map<StorageTeamID, Standalone<StringRef>> getAllSerialized();
+
+private:
+	bool writeTransactionInfo(StorageTeamID team);
 };
 
 // Deserialize the ProxyTLogPushMessage

--- a/fdbserver/ptxn/ProxyTLogPushMessageSerializer.h
+++ b/fdbserver/ptxn/ProxyTLogPushMessageSerializer.h
@@ -72,13 +72,13 @@ public:
 	void writeMessage(const MutationRef& mutation, const StorageTeamID& storageTeamID);
 
 	// Writes a new serialized mutation for a given TeamID.
-	void writeMessage(const StringRef& mutation, const StorageTeamID& teamID);
+	void writeMessage(const StringRef& mutation, const StorageTeamID& storageTeamID);
 
 	// Adds span context about transactions.
 	void addTransactionInfo(const SpanID& context);
 
 	// Writes the same (clear range) mutation to all "teams".
-	void writeMessage(const MutationRef& mutation, const std::set<StorageTeamID>& teams);
+	void writeMessage(const MutationRef& mutation, const std::set<StorageTeamID>& storageTeamIDs);
 
 	// For a given TeamID, mark the serializer not accepting more mutations, and write the header.
 	void completeMessageWriting(const StorageTeamID& storageTeamID);

--- a/fdbserver/ptxn/ProxyTLogPushMessageSerializer.h
+++ b/fdbserver/ptxn/ProxyTLogPushMessageSerializer.h
@@ -73,7 +73,7 @@ public:
 	}
 
 	// Writes the same (clear range) mutation to all "teams".
-	// void writeMessage(const MutationRef& mutation, const std::vector<TeamID>& teams);
+	void writeMessage(const MutationRef& mutation, const std::set<TeamID>& teams);
 
 	// For a given TeamID, mark the serializer not accepting more mutations, and write the header.
 	void completeMessageWriting(const StorageTeamID& storageTeamID);
@@ -82,7 +82,7 @@ public:
 	Standalone<StringRef> getSerialized(const StorageTeamID& storageTeamID);
 
 	// Completes all teams' message writing and returns the serialized data.
-	// std::unordered_map<StorageTeamID, Standalone<StringRef>> getAllSerialized();
+	std::unordered_map<StorageTeamID, Standalone<StringRef>> getAllSerialized();
 };
 
 // Deserialize the ProxyTLogPushMessage

--- a/fdbserver/ptxn/ProxyTLogPushMessageSerializer.h
+++ b/fdbserver/ptxn/ProxyTLogPushMessageSerializer.h
@@ -21,8 +21,6 @@
 #ifndef FDBSERVER_PTXN_PROXYTLOGPUSHMESSAGESERIALIZER_H
 #define FDBSERVER_PTXN_PROXYTLOGPUSHMESSAGESERIALIZER_H
 
-#include "flow/Arena.h"
-#include <stdint.h>
 #pragma once
 
 #include <cstdint>
@@ -30,6 +28,7 @@
 
 #include "fdbserver/ptxn/MessageTypes.h"
 #include "fdbserver/ptxn/Serializer.h"
+#include "flow/Arena.h"
 #include "flow/Error.h"
 
 namespace ptxn {

--- a/fdbserver/ptxn/ProxyTLogPushMessageSerializer.h
+++ b/fdbserver/ptxn/ProxyTLogPushMessageSerializer.h
@@ -68,7 +68,7 @@ public:
 	void writeMessage(const MutationRef& mutation, const StorageTeamID& storageTeamID);
 
 	// Writes a new serialized mutation for a given TeamID.
-	void writeMessage(const StringRef& mutation, const TeamID& teamID);
+	void writeMessage(const StringRef& mutation, const StorageTeamID& teamID);
 
 	// Adds span context about transactions.
 	void addTransactionInfo(const SpanID& context) {
@@ -77,7 +77,7 @@ public:
 	}
 
 	// Writes the same (clear range) mutation to all "teams".
-	void writeMessage(const MutationRef& mutation, const std::set<TeamID>& teams);
+	void writeMessage(const MutationRef& mutation, const std::set<StorageTeamID>& teams);
 
 	// For a given TeamID, mark the serializer not accepting more mutations, and write the header.
 	void completeMessageWriting(const StorageTeamID& storageTeamID);

--- a/fdbserver/ptxn/TLogStorageServerPeekMessageSerializer.cpp
+++ b/fdbserver/ptxn/TLogStorageServerPeekMessageSerializer.cpp
@@ -201,7 +201,7 @@ TLogStorageServerMessageDeserializer::iterator& TLogStorageServerMessageDeserial
 
 	SubsequenceMutationItem item = deserializer.deserializeItem();
 	currentItem.subsequence = item.subsequence;
-	currentItem.mutation = item.mutation;
+	currentItem.mutation = item.mutation();
 
 	return *this;
 }

--- a/fdbserver/ptxn/test/FakeProxy.actor.cpp
+++ b/fdbserver/ptxn/test/FakeProxy.actor.cpp
@@ -62,7 +62,7 @@ ACTOR Future<Void> fakeProxy(std::shared_ptr<FakeProxyContext> pFakeProxyContext
 			fakeMutations[storageTeamID].push_back(mutation);
 		}
 
-		state std::vector<Future<TLogCommitReply>> requests;
+		state std::vector<Future<TLogCommitReply>> replies;
 		for (auto iter = fakeMutations.begin(); iter != fakeMutations.end(); ++iter) {
 			const StorageTeamID storageTeamID = iter->first;
 			auto& mutations = iter->second;
@@ -71,10 +71,12 @@ ACTOR Future<Void> fakeProxy(std::shared_ptr<FakeProxyContext> pFakeProxyContext
 			// 	pTestDriverContext->mutationsArena
 			commitRecord.emplace_back(version, storageTeamID, std::move(mutations));
 
-			serializer.completeMessageWriting(storageTeamID);
-			Standalone<StringRef> encoded = serializer.getSerialized(storageTeamID);
+		}
+
+		std::unordered_map<TeamID, Standalone<StringRef>> messages = serializer.getAllSerialized();
+		for (const auto& [team, message] : messages) {
 			TLogCommitRequest request(deterministicRandom()->randomUniqueID(),
-			                          storageTeamID,
+			                          team,
 			                          encoded.arena(),
 			                          encoded,
 			                          version - versionGap,
@@ -82,13 +84,13 @@ ACTOR Future<Void> fakeProxy(std::shared_ptr<FakeProxyContext> pFakeProxyContext
 			                          0,
 			                          0,
 			                          Optional<UID>());
-			requests.push_back(pTestDriverContext->getTLogInterface(storageTeamID)->commit.getReply(request));
+			replies.push_back(pTestDriverContext->getTLogInterface(team)->commit.getReply(request));
 		}
 		version += versionGap;
 
 		print::printCommitRecord(pTestDriverContext->commitRecord);
 
-		wait(waitForAll(requests));
+		wait(waitForAll(replies));
 
 		if (++i == pFakeProxyContext->numCommits) {
 			break;

--- a/fdbserver/ptxn/test/FakeProxy.actor.cpp
+++ b/fdbserver/ptxn/test/FakeProxy.actor.cpp
@@ -73,12 +73,12 @@ ACTOR Future<Void> fakeProxy(std::shared_ptr<FakeProxyContext> pFakeProxyContext
 
 		}
 
-		std::unordered_map<TeamID, Standalone<StringRef>> messages = serializer.getAllSerialized();
+		std::unordered_map<StorageTeamID, Standalone<StringRef>> messages = serializer.getAllSerialized();
 		for (const auto& [team, message] : messages) {
 			TLogCommitRequest request(deterministicRandom()->randomUniqueID(),
 			                          team,
-			                          encoded.arena(),
-			                          encoded,
+			                          message.arena(),
+			                          message,
 			                          version - versionGap,
 			                          version,
 			                          0,

--- a/fdbserver/ptxn/test/FakeTLog.actor.cpp
+++ b/fdbserver/ptxn/test/FakeTLog.actor.cpp
@@ -118,7 +118,7 @@ void processTLogCommitRequest(std::shared_ptr<FakeTLogContext> pFakeTLogContext,
 	std::transform(seqMutations.begin(),
 	               seqMutations.end(),
 	               std::back_inserter(mutations),
-	               [](const SubsequenceMutationItem& item) { return item.mutation; });
+	               [](const SubsequenceMutationItem& item) { return item.mutation(); });
 	verifyMutationsInRecord(pFakeTLogContext->pTestDriverContext->commitRecord,
 	                        commitRequest.version,
 	                        commitRequest.storageTeamID,
@@ -128,7 +128,7 @@ void processTLogCommitRequest(std::shared_ptr<FakeTLogContext> pFakeTLogContext,
 	// "Persist" the data into memory
 	for (auto& seqMutation : seqMutations) {
 		const auto& subsequence = seqMutation.subsequence;
-		const auto& mutation = seqMutation.mutation;
+		const auto& mutation = seqMutation.mutation();
 		pFakeTLogContext->mutations[commitRequest.storageTeamID].push_back(
 		    pFakeTLogContext->persistenceArena,
 		    { commitRequest.version,
@@ -234,7 +234,7 @@ ACTOR Future<Void> fakeTLog_ActivelyPush(std::shared_ptr<FakeTLogContext> pFakeT
 			request.storageTeamID = commitRequest.storageTeamID;
 			request.arena = Arena();
 			for (auto iter = std::begin(seqMutations); iter != std::end(seqMutations); ++iter) {
-				const auto& mutation = iter->mutation;
+				const auto& mutation = iter->mutation();
 				request.mutations.emplace_back(request.arena,
 				                               MutationRef(request.arena,
 				                                           static_cast<MutationRef::Type>(mutation.type),

--- a/fdbserver/ptxn/test/TestSerialization.cpp
+++ b/fdbserver/ptxn/test/TestSerialization.cpp
@@ -142,6 +142,7 @@ bool testTransactionInfo() {
 	}
 
 	auto results = serializer.getAllSerialized();
+	int spanCount = 0;
 	for (const auto& [team, messages] : results) {
 		VectorRef<MutationRef> teamMutations;
 		if (team == team1) {
@@ -169,11 +170,13 @@ bool testTransactionInfo() {
 				const SpanContextMessage& span = seqMutations[i].span();
 				StringRef str(arena, BinaryWriter::toValue(span.spanContext, Unversioned()));
 				ASSERT(a.param1 == str);
+				spanCount++;
 			}
 		}
 	}
+	ASSERT(spanCount > 0);
 
-	std::cout << __FUNCTION__ << " passed.\n";
+	std::cout << __FUNCTION__ << " passed (" << spanCount << " SpanIDs).\n";
 	return true;
 }
 

--- a/fdbserver/ptxn/test/TestSerialization.cpp
+++ b/fdbserver/ptxn/test/TestSerialization.cpp
@@ -65,8 +65,8 @@ struct TestSerializerItem {
 bool testSubsequenceMutationItem() {
 	ptxn::ProxyTLogPushMessageSerializer serializer;
 
-	const ptxn::TeamID team1{ deterministicRandom()->randomUniqueID() };
-	const ptxn::TeamID team2{ deterministicRandom()->randomUniqueID() };
+	const ptxn::StorageTeamID team1{ deterministicRandom()->randomUniqueID() };
+	const ptxn::StorageTeamID team2{ deterministicRandom()->randomUniqueID() };
 
 	MutationRef mutation(MutationRef::SetValue, "KeyXX"_sr, "ValueYY"_sr);
 	serializer.writeMessage(mutation, team1);

--- a/fdbserver/ptxn/test/TestSerialization.cpp
+++ b/fdbserver/ptxn/test/TestSerialization.cpp
@@ -129,7 +129,7 @@ bool testTransactionInfo() {
 			// Randomly add this mutation to teams
 			for (int team = 0; team < 3; team++) {
 				if (deterministicRandom()->random01() < 0.5) {
-					if (written[team] != spanId) {
+					if (written[team] != spanId && FLOW_KNOBS->WRITE_TRACING_ENABLED) {
 						// Add Transaction Info for this team in ground truth
 						mutations[team].push_back(arena, transactionInfo);
 						written[team] = spanId;
@@ -174,7 +174,7 @@ bool testTransactionInfo() {
 			}
 		}
 	}
-	ASSERT(spanCount > 0);
+	ASSERT(spanCount > 0 || !FLOW_KNOBS->WRITE_TRACING_ENABLED);
 
 	std::cout << __FUNCTION__ << " passed (" << spanCount << " SpanIDs).\n";
 	return true;

--- a/fdbserver/ptxn/test/TestSerialization.cpp
+++ b/fdbserver/ptxn/test/TestSerialization.cpp
@@ -29,6 +29,7 @@
 #include "fdbserver/ptxn/Serializer.h"
 #include "fdbserver/ptxn/ProxyTLogPushMessageSerializer.h"
 #include "fdbserver/ptxn/TLogStorageServerPeekMessageSerializer.h"
+#include "fdbserver/ptxn/test/Utils.h"
 #include "flow/Error.h"
 #include "flow/IRandom.h"
 #include "flow/UnitTest.h"
@@ -69,8 +70,8 @@ struct TestSerializerItem {
 bool testSubsequenceMutationItem() {
 	ptxn::ProxyTLogPushMessageSerializer serializer;
 
-	const ptxn::StorageTeamID team1{ deterministicRandom()->randomUniqueID() };
-	const ptxn::StorageTeamID team2{ deterministicRandom()->randomUniqueID() };
+	const ptxn::StorageTeamID team1{ ptxn::test::getNewStorageTeamID() };
+	const ptxn::StorageTeamID team2{ ptxn::test::getNewStorageTeamID() };
 
 	MutationRef mutation(MutationRef::SetValue, "KeyXX"_sr, "ValueYY"_sr);
 	serializer.writeMessage(mutation, team1);
@@ -99,9 +100,9 @@ bool testSubsequenceMutationItem() {
 bool testTransactionInfo() {
 	ptxn::ProxyTLogPushMessageSerializer serializer;
 
-	const ptxn::StorageTeamID team1{ deterministicRandom()->randomUniqueID() };
-	const ptxn::StorageTeamID team2{ deterministicRandom()->randomUniqueID() };
-	const ptxn::StorageTeamID team3{ deterministicRandom()->randomUniqueID() };
+	const ptxn::StorageTeamID team1{ ptxn::test::getNewStorageTeamID() };
+	const ptxn::StorageTeamID team2{ ptxn::test::getNewStorageTeamID() };
+	const ptxn::StorageTeamID team3{ ptxn::test::getNewStorageTeamID() };
 	std::vector<ptxn::StorageTeamID> teams = { team1, team2, team3 };
 
 	// Mutations for each team before serialization, i.e., ground truth

--- a/fdbserver/ptxn/test/TestSerialization.cpp
+++ b/fdbserver/ptxn/test/TestSerialization.cpp
@@ -76,15 +76,14 @@ bool testSubsequenceMutationItem() {
 	BinaryWriter wr(IncludeVersion(ProtocolVersion::withPartitionTransaction()));
 	wr << mutation;
 	Standalone<StringRef> value = wr.toValue();
-	std::cout << "mutation: " << value.printable() << "\n";
-	serializer.writeMessage(value, team2);
-	serializer.completeMessageWriting(team2);
-	auto serializedTeam2 = serializer.getSerialized(team2);
+	StringRef m = value.substr(sizeof(uint64_t)); // skip protocol version
 
-	std::cout << "Team1: " << serializedTeam1.size() << "\n"
-	          << serializedTeam1.printable() << "\n"
-	          << "Team2: " << serializedTeam2.size() << "\n"
-	          << serializedTeam2.printable() << "\n";
+	// Have to use a different serializer to make sure subsequence is the same.
+	ptxn::ProxyTLogPushMessageSerializer serializer2;
+	serializer2.writeMessage(m, team2);
+	serializer2.completeMessageWriting(team2);
+	auto serializedTeam2 = serializer2.getSerialized(team2);
+
 	ASSERT(serializedTeam1 == serializedTeam2);
 
 	return true;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -276,6 +276,7 @@ if(WITH_PYTHON)
   endif()
 
   # Tests for partitioned transaction
+  add_fdb_test(TEST_FILES ptxn/CycleTest.toml)
   add_fdb_test(TEST_FILES ptxn/Driver.toml)
   add_fdb_test(TEST_FILES ptxn/Resolver.toml)
   add_fdb_test(TEST_FILES ptxn/Serialization.toml)

--- a/tests/ptxn/CycleTest.toml
+++ b/tests/ptxn/CycleTest.toml
@@ -1,0 +1,8 @@
+[[test]]
+testTitle = 'Cycle'
+
+    [[test.workload]]
+    testName = 'Cycle'
+    transactionsPerSecond = 250.0
+    testDuration = 10.0
+    expectedRate = 0.80

--- a/tests/ptxn/CycleTest.toml
+++ b/tests/ptxn/CycleTest.toml
@@ -5,4 +5,4 @@ testTitle = 'Cycle'
     testName = 'Cycle'
     transactionsPerSecond = 250.0
     testDuration = 10.0
-    expectedRate = 0.80
+    expectedRate = 0.60


### PR DESCRIPTION
Add serialization of transaction data in commit proxy's memory. Modify `SubsequenceMutationItem` to support span ID and write already serialized mutations out, which makes the serialization more complex than I would like to.

The follow-on PRs will actuall send team's data to tlog groups, which depends on tlog group recruitment. Another follow-on work is to manage team data in Proxies, i.e., update `ServerCacheInfo::teams`.

Correctness passed:
  20210518-161723-jingyu_zhou-f6fe5a0208a4b87e       compressed=True data_size=23490415 duration=6132277 ended=100880 fail_fast=10 max_runs=100000 pass=100022 priority=100 remaining=0 runtime=0:32:33 sanity=False started=100905 stopped=20210518-164956 submitted=20210518-161723 timeout=5400 username=jingyu_zhou

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
