### PR TITLE
Fix accounting for time spent in run loop after breaking due to yield (release-6.3)

### DIFF
--- a/documentation/sphinx/source/release-notes/release-notes-630.rst
+++ b/documentation/sphinx/source/release-notes/release-notes-630.rst
@@ -4,10 +4,12 @@
 Release Notes
 #############
 
+
 6.3.13
 ======
 * Added ``commit_batching_window_size`` to the proxy roles section of status to record statistics about commit batching window size on each proxy. `(PR #4736) <https://github.com/apple/foundationdb/pull/4736>`_
 * The multi-version client now requires at most two client connections with version 6.2 or larger, regardless of how many external clients are configured. Clients older than 6.2 will continue to create an additional connection each. `(PR #4667) <https://github.com/apple/foundationdb/pull/4667>`_
+* Fix an accounting error that could potentially result in inaccuracies in priority busyness metrics. `(PR #4824) <https://github.com/apple/foundationdb/pull/4824>`_
 
 6.3.12
 ======

--- a/flow/Net2.actor.cpp
+++ b/flow/Net2.actor.cpp
@@ -1319,6 +1319,7 @@ void Net2::run() {
 			double newTaskBegin = timer_monotonic();
 			if (check_yield(TaskPriority::Max, tscNow)) {
 				checkForSlowTask(tscBegin, tscNow, newTaskBegin - taskBegin, currentTaskID);
+				taskBegin = newTaskBegin;	
 				FDB_TRACE_PROBE(run_loop_yield);
 				++countYields;
 				break;


### PR DESCRIPTION
Backport of #4824

When breaking from the inner run loop due to yield, we weren't updating the time used to record that we are running at run loop priority. As a result, our priority tracking could be inaccurate.

This is being backported because the reporting bug affects in-use versions and could have non-trivial impact.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
