### PR TITLE
Adding histogram in master proxy in 6.3 to track critical components' latency on GRV and commit critical path

### DIFF
--- a/fdbserver/LogSystem.h
+++ b/fdbserver/LogSystem.h
@@ -28,6 +28,7 @@
 #include "fdbserver/WorkerInterface.actor.h"
 #include "fdbclient/DatabaseConfiguration.h"
 #include "flow/IndexedSet.h"
+#include "flow/Histogram.h"
 #include "fdbrpc/ReplicationPolicy.h"
 #include "fdbrpc/Locality.h"
 #include "fdbrpc/Replication.h"
@@ -52,6 +53,7 @@ public:
 	std::vector<Reference<AsyncVar<OptionalInterface<TLogInterface>>>> logRouters;
 	std::vector<Reference<AsyncVar<OptionalInterface<BackupInterface>>>> backupWorkers;
 	std::vector<Reference<ConnectionResetInfo>> connectionResetTrackers;
+	std::vector<Reference<Histogram>> tlogPushDistTrackers;
 	int32_t tLogWriteAntiQuorum;
 	int32_t tLogReplicationFactor;
 	std::vector<LocalityData> tLogLocalities; // Stores the localities of the log servers

--- a/flow/Histogram.cpp
+++ b/flow/Histogram.cpp
@@ -116,10 +116,12 @@ void Histogram::writeToLog() {
 	TraceEvent e(SevInfo, "Histogram");
 	e.detail("Group", group).detail("Op", op).detail("Unit", UnitToStringMapper.at(unit));
 
+	int totalCount = 0;
 	for (uint32_t i = 0; i < 32; i++) {
 		uint32_t value = ((uint32_t)1) << (i + 1);
 
 		if (buckets[i]) {
+			totalCount += buckets[i];
 			switch (unit) {
 			case Unit::microseconds:
 				e.detail(format("LessThan%u.%03u", value / 1000, value % 1000), buckets[i]);
@@ -133,6 +135,7 @@ void Histogram::writeToLog() {
 			}
 		}
 	}
+	e.detail("TotalCount", totalCount);
 }
 
 #pragma endregion // Histogram


### PR DESCRIPTION


Put description here...

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
