### PR TITLE
Not swallowing exceptions on malformed XML

### DIFF
--- a/contrib/TraceLogHelper/JsonParser.cs
+++ b/contrib/TraceLogHelper/JsonParser.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * JsonParser.cs
  *
  * This source file is part of the FoundationDB open source project
@@ -34,9 +34,10 @@ namespace Magnesium
 	{
 		static Random r = new Random();
 
+		// dummy parameter nonFatalParseError to match xml
 		public static IEnumerable<Event> Parse(System.IO.Stream stream, string file,
 			bool keepOriginalElement = false, double startTime = -1, double endTime = Double.MaxValue,
-			double samplingFactor = 1.0)
+			double samplingFactor = 1.0, Action<string> nonFatalErrorMessage = null)
 		{
 			using (var reader = new System.IO.StreamReader(stream))
 			{


### PR DESCRIPTION
I accidentally created a trace event with an invalid xml detail name that caused the xml file to not parse correctly.
Because this parsing code swallowed the exceptions and essentially just truncated the trace file, the error presented itself as "TestUnexpectedlyNotFinished" in joshua because it wasn't parsing all of the trace events.
Unless there is a case i'm missing, it seems like it would be much better to propagate this error so that, if this happens again, it's much easier to debug what went wrong.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
