### PR TITLE
Add peek request handling for tlogs

### DIFF
--- a/fdbserver/ptxn/TLogPeekCursor.actor.cpp
+++ b/fdbserver/ptxn/TLogPeekCursor.actor.cpp
@@ -416,7 +416,7 @@ Future<bool> MergedStorageTeamPeekCursor::remoteMoreAvailableImpl() {
 		return false;
 	}
 
-	return peekRemoteForMergedStorageTeamCursor({ &cursorPtrs, &cursorHeap, &storageTeamIDCursorMapper });
+	return peekRemoteForMergedStorageTeamCursor({ { &cursorPtrs, &cursorHeap }, &storageTeamIDCursorMapper });
 }
 
 std::vector<StorageTeamID> MergedStorageTeamPeekCursor::getCursorTeamIDs() {

--- a/fdbserver/ptxn/TLogServer.actor.cpp
+++ b/fdbserver/ptxn/TLogServer.actor.cpp
@@ -1156,9 +1156,9 @@ ACTOR Future<Void> serveTLogInterface_PassivelyPull(
 			//    .detail("BeginVersion", req.beginVersion)
 			//    .detail("StorageTeam", req.storageTeamID)
 			//    .detail("Tag", req.tag.toString());
-			auto tlogGroup = activeGeneration.find(req.storageTeamID);
-			TEST(tlogGroup == activeGeneration.end()); // TLog peek: group not found
-			if (tlogGroup == activeGeneration.end()) {
+			auto tlogGroup = activeGeneration->find(req.storageTeamID);
+			TEST(tlogGroup == activeGeneration->end()); // TLog peek: group not found
+			if (tlogGroup == activeGeneration->end()) {
 				req.reply.sendError(tlog_group_not_found());
 				continue;
 			}

--- a/fdbserver/ptxn/TLogServer.actor.cpp
+++ b/fdbserver/ptxn/TLogServer.actor.cpp
@@ -955,8 +955,7 @@ ACTOR Future<Void> tLogCommit(Reference<TLogGroupData> self,
 	return Void();
 }
 
-ACTOR Future<Void> tLogPeekMessages(Reference<TLogGroupData> self,
-                                    TLogPeekRequest req,
+ACTOR Future<Void> tLogPeekMessages(TLogPeekRequest req,
                                     Reference<LogGenerationData> logData) {
 	state TLogPeekReply reply;
 	state TLogStorageServerMessageSerializer serializer(req.storageTeamID);
@@ -1000,7 +999,7 @@ ACTOR Future<Void> tLogPeekMessages(Reference<TLogGroupData> self,
 			serializer.completeVersionWriting();
 		}
 	} else {
-		// TODO: block here or return error?
+		req.reply.sendError(teamid_not_found());
 	}
 	serializer.completeMessageWriting();
 	Standalone<StringRef> buffer = serializer.getSerialized();
@@ -1164,7 +1163,7 @@ ACTOR Future<Void> serveTLogInterface_PassivelyPull(
 				continue;
 			}
 			Reference<LogGenerationData> logData = tlogGroup->second;
-			logData->addActor.send(tLogPeekMessages(logData->tlogGroupData, req, logData));
+			logData->addActor.send(tLogPeekMessages(req, logData));
 		}
 	}
 }
@@ -1669,7 +1668,7 @@ TEST_CASE("/fdbserver/ptxn/test/peek_tlog_server") {
 		std::cout << "\n";
 	}
 
-	state std::string folder = "simdb/unittests";
+	state std::string folder = "simdb/" + deterministicRandom()->randomAlphaNumeric(10);
 	platform::createDirectory(folder);
 	// start a real TLog server
 	wait(startTLogServers(&actors, context, folder));

--- a/fdbserver/ptxn/TLogServer.actor.cpp
+++ b/fdbserver/ptxn/TLogServer.actor.cpp
@@ -811,10 +811,10 @@ ACTOR Future<Void> doQueueCommit(Reference<TLogGroupData> self,
 
 ACTOR Future<Void> commitQueue(Reference<TLogGroupData> self) {
 	state Reference<LogGenerationData> logData;
+	state std::vector<Reference<LogGenerationData>> missingFinalCommit;
 
 	loop {
 		int foundCount = 0;
-		state std::vector<Reference<LogGenerationData>> missingFinalCommit;
 		for (auto it : self->id_data) {
 			if (!it.second->stopped) {
 				logData = it.second;

--- a/fdbserver/ptxn/TLogServer.actor.cpp
+++ b/fdbserver/ptxn/TLogServer.actor.cpp
@@ -1153,10 +1153,10 @@ ACTOR Future<Void> serveTLogInterface_PassivelyPull(
 			}
 		}
 		when(TLogPeekRequest req = waitNext(tli.peek.getFuture())) {
-			TraceEvent("TLogPeekReq")
-			    .detail("BeginVersion", req.beginVersion)
-			    .detail("StorageTeam", req.storageTeamID)
-			    .detail("Tag", req.tag.toString());
+			// TraceEvent("TLogPeekReq")
+			//    .detail("BeginVersion", req.beginVersion)
+			//    .detail("StorageTeam", req.storageTeamID)
+			//    .detail("Tag", req.tag.toString());
 			auto tlogGroup = activeGeneration.find(req.storageTeamID);
 			TEST(tlogGroup == activeGeneration.end()); // TLog peek: group not found
 			if (tlogGroup == activeGeneration.end()) {
@@ -1209,7 +1209,7 @@ ACTOR Future<Void> tLogCore(
 		return Void();
 	}
 
-	TraceEvent("TLogGroupCore", self->dbgid).detail("WorkerID", self->workerID);
+	TraceEvent("TLogCore", self->dbgid).detail("WorkerID", self->workerID);
 	self->addActors.send(self->removed);
 
 	// FIXME: update tlogMetrics to include new information, or possibly only have one copy for the shared instance
@@ -1627,7 +1627,6 @@ ACTOR Future<Void> commitPeekAndCheck(std::shared_ptr<test::TestDriverContext> p
 	int i = 0;
 	for (auto iter = deserializer.begin(); iter != deserializer.end(); ++iter, ++i) {
 		const VersionSubsequenceMutation& m = *iter;
-		// std::cout << *iter << "\n";
 		ASSERT_EQ(beginVersion, m.version);
 		ASSERT_EQ(i + 1, m.subsequence); // subsequence starts from 1
 		ASSERT(mutations[i] == m.mutation);

--- a/fdbserver/ptxn/test/Driver.actor.cpp
+++ b/fdbserver/ptxn/test/Driver.actor.cpp
@@ -102,7 +102,7 @@ std::shared_ptr<TestDriverContext> initTestDriverContext(const TestDriverOptions
 
 	context->numTLogGroups = options.numTLogGroups;
 	for (int i = 0; i < context->numTLogGroups; ++i) {
-		context->tLogGroups.push_back(TLogGroup(deterministicRandom()->randomUniqueID()));
+		context->tLogGroups.push_back(TLogGroup(randomUID()));
 		context->tLogGroupLeaders[context->tLogGroups.back().logGroupId] =
 		    context->tLogInterfaces[deterministicRandom()->randomInt(0, context->numTLogs)];
 	}
@@ -114,7 +114,7 @@ std::shared_ptr<TestDriverContext> initTestDriverContext(const TestDriverOptions
 		context->storageServerInterfaces.back()->initEndpoints();
 	}
 
-	// Assign teams to interfaces
+	// Assign storage teams to storage interfaces
 	auto assignTeamToInterface = [&](auto& mapper, auto interface) {
 		int numInterfaces = interface.size();
 		int index = 0;
@@ -128,12 +128,14 @@ std::shared_ptr<TestDriverContext> initTestDriverContext(const TestDriverOptions
 	};
 	assignTeamToInterface(context->storageTeamIDStorageServerInterfaceMapper, context->storageServerInterfaces);
 
+	// Assign storage teams to tlog groups
 	for (int i = 0, index = 0; i < context->numStorageTeamIDs; ++i) {
 		const StorageTeamID& storageTeamID = context->storageTeamIDs[i];
 		TLogGroup& tLogGroup = context->tLogGroups[index];
 		context->storageTeamIDTLogGroupIDMapper[storageTeamID] = tLogGroup.logGroupId;
 		// TODO: support tags when implementing pop
 		tLogGroup.storageTeams[storageTeamID] = {};
+
 		++index;
 		index %= context->tLogGroups.size();
 	}

--- a/fdbserver/ptxn/test/TestTLogPeek.actor.cpp
+++ b/fdbserver/ptxn/test/TestTLogPeek.actor.cpp
@@ -43,6 +43,7 @@ Future<Void> initializeTLogForPeekTest(MessageTransferModel transferModel, std::
 
 	return getFakeTLogActor(transferModel, pContext);
 }
+
 // Randomly peek data from FakeTLog and verify if the data is consistent
 ACTOR Future<Void> peekAndCheck(std::shared_ptr<FakeTLogContext> pContext) {
 	state std::vector<StorageTeamID>& storageTeamIDs = pContext->storageTeamIDs;

--- a/fdbserver/ptxn/test/Utils.h
+++ b/fdbserver/ptxn/test/Utils.h
@@ -58,8 +58,8 @@ typename Container::const_reference randomlyPick(const Container& container) {
 
 namespace print {
 
+void print(const TLogCommitRequest&);
 void print(const TLogCommitReply&);
-void print(const TLogPeekRequest&);
 void print(const TLogPeekRequest&);
 void print(const TLogPeekReply&);
 void print(const TestDriverOptions&);

--- a/tests/ptxn/TLogServer.toml
+++ b/tests/ptxn/TLogServer.toml
@@ -34,7 +34,6 @@ startDelay = 0
 
 [[test]]
 testTitle = 'Team Partitioned TLog Server Test 3: Commit and Peek'
->>>>>>> 853211fa7 (Fix broken promise error)
 useDB = false
 startDelay = 0
 

--- a/tests/ptxn/TLogServer.toml
+++ b/tests/ptxn/TLogServer.toml
@@ -33,7 +33,8 @@ startDelay = 0
     numCommits = 100
 
 [[test]]
-testTitle = 'Team Partitioned TLog Server Test 3'
+testTitle = 'Team Partitioned TLog Server Test 3: Commit and Peek'
+>>>>>>> 853211fa7 (Fix broken promise error)
 useDB = false
 startDelay = 0
 


### PR DESCRIPTION
Add peek request handling for tlogs and a test that commits, peeks, and verifies the data is correct.

More tests are needed to verify peek request wait for future version data.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
