### PR TITLE
fixed a rare simulation bug where missingFinalCommit could be skipped by two successive logSystem changes

### DIFF
--- a/fdbserver/OldTLogServer_6_0.actor.cpp
+++ b/fdbserver/OldTLogServer_6_0.actor.cpp
@@ -1498,10 +1498,10 @@ ACTOR Future<Void> doQueueCommit(TLogData* self,
 
 ACTOR Future<Void> commitQueue(TLogData* self) {
 	state Reference<LogData> logData;
+	state std::vector<Reference<LogData>> missingFinalCommit;
 
 	loop {
 		int foundCount = 0;
-		state std::vector<Reference<LogData>> missingFinalCommit;
 		for (auto it : self->id_data) {
 			if (!it.second->stopped) {
 				logData = it.second;

--- a/fdbserver/OldTLogServer_6_2.actor.cpp
+++ b/fdbserver/OldTLogServer_6_2.actor.cpp
@@ -1925,10 +1925,10 @@ ACTOR Future<Void> doQueueCommit(TLogData* self,
 
 ACTOR Future<Void> commitQueue(TLogData* self) {
 	state Reference<LogData> logData;
+	state std::vector<Reference<LogData>> missingFinalCommit;
 
 	loop {
 		int foundCount = 0;
-		state std::vector<Reference<LogData>> missingFinalCommit;
 		for (auto it : self->id_data) {
 			if (!it.second->stopped) {
 				logData = it.second;

--- a/fdbserver/TLogServer.actor.cpp
+++ b/fdbserver/TLogServer.actor.cpp
@@ -1965,10 +1965,10 @@ ACTOR Future<Void> doQueueCommit(TLogData* self,
 
 ACTOR Future<Void> commitQueue(TLogData* self) {
 	state Reference<LogData> logData;
+	state std::vector<Reference<LogData>> missingFinalCommit;
 
 	loop {
 		int foundCount = 0;
-		state std::vector<Reference<LogData>> missingFinalCommit;
 		for (auto it : self->id_data) {
 			if (!it.second->stopped) {
 				logData = it.second;


### PR DESCRIPTION
This resulted in a recovery never reaching the fully_committed state and causing the test to timeout.

passed 200k correctness on a separate branch where the problem was found while fixing other correctness issues.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [x] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
