### PR TITLE
perpetual storage wiggling command line support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@ bindings/java/foundationdb-client*.jar
 bindings/java/foundationdb-tests*.jar
 bindings/java/fdb-java-*-sources.jar
 packaging/msi/FDBInstaller.msi
-
+builds/
 # Generated source, build, and packaging files
 *.g.cpp
 *.g.h

--- a/fdbcli/fdbcli.actor.cpp
+++ b/fdbcli/fdbcli.actor.cpp
@@ -496,7 +496,8 @@ void initHelp() {
 	helpMap["configure"] = CommandHelp(
 	    "configure [new] "
 	    "<single|double|triple|three_data_hall|three_datacenter|ssd|memory|memory-radixtree-beta|proxies=<PROXIES>|"
-	    "commit_proxies=<COMMIT_PROXIES>|grv_proxies=<GRV_PROXIES>|logs=<LOGS>|resolvers=<RESOLVERS>>*",
+	    "commit_proxies=<COMMIT_PROXIES>|grv_proxies=<GRV_PROXIES>|logs=<LOGS>|resolvers=<RESOLVERS>>*|"
+	    "perpetual_storage_wiggle=<WIGGLE_SPEED>",
 	    "change the database configuration",
 	    "The `new' option, if present, initializes a new database with the given configuration rather than changing "
 	    "the configuration of an existing one. When used, both a redundancy mode and a storage engine must be "
@@ -517,8 +518,11 @@ void initHelp() {
 	    "1, or set to -1 which restores the number of GRV proxies to the default value.\n\nlogs=<LOGS>: Sets the "
 	    "desired number of log servers in the cluster. Must be at least 1, or set to -1 which restores the number of "
 	    "logs to the default value.\n\nresolvers=<RESOLVERS>: Sets the desired number of resolvers in the cluster. "
-	    "Must be at least 1, or set to -1 which restores the number of resolvers to the default value.\n\nSee the "
-	    "FoundationDB Administration Guide for more information.");
+	    "Must be at least 1, or set to -1 which restores the number of resolvers to the default value.\n\n"
+	    "perpetual_storage_wiggle=<WIGGLE_SPEED>: Set the value speed (a.k.a., the number of processes that the Data "
+	    "Distributor should wiggle at a time). Currently, only 0 and 1 are supported. The value 0 means to disable the "
+	    "perpetual storage wiggle.\n\n"
+	    "See the FoundationDB Administration Guide for more information.");
 	helpMap["fileconfigure"] = CommandHelp(
 	    "fileconfigure [new] <FILENAME>",
 	    "change the database configuration from a file",
@@ -2766,6 +2770,7 @@ void configureGenerator(const char* text, const char* line, std::vector<std::str
 		                   "grv_proxies=",
 		                   "logs=",
 		                   "resolvers=",
+		                   "perpetual_storage_wiggle=",
 		                   nullptr };
 	arrayGenerator(text, line, opts, lc);
 }

--- a/fdbclient/DatabaseConfiguration.h
+++ b/fdbclient/DatabaseConfiguration.h
@@ -239,6 +239,9 @@ struct DatabaseConfiguration {
 	int32_t repopulateRegionAntiQuorum;
 	std::vector<RegionInfo> regions;
 
+	// Perpetual Storage Setting
+	int32_t perpetualStorageWiggleSpeed;
+
 	// Excluded servers (no state should be here)
 	bool isExcludedServer(NetworkAddressList) const;
 	std::set<AddressExclusion> getExcludedServers() const;

--- a/fdbclient/ManagementAPI.actor.cpp
+++ b/fdbclient/ManagementAPI.actor.cpp
@@ -134,6 +134,14 @@ std::map<std::string, std::string> configForToken(std::string const& mode) {
 			    BinaryWriter::toValue(regionObj, IncludeVersion(ProtocolVersion::withRegionConfiguration())).toString();
 		}
 
+		if (key == "perpetual_storage_wiggle" && isInteger(value)) {
+			int ppWiggle = atoi(value.c_str());
+			if (ppWiggle >= 2 || ppWiggle < 0) {
+				printf("Error: Only 0 and 1 are valid values of perpetual_storage_wiggle at present.\n");
+				return out;
+			}
+			out[p + key] = value;
+		}
 		return out;
 	}
 

--- a/fdbclient/Schemas.cpp
+++ b/fdbclient/Schemas.cpp
@@ -727,7 +727,8 @@ const KeyRef JSONSchemas::statusSchema = LiteralStringRef(R"statusSchema(
          "auto_logs":3,
          "commit_proxies":5,
          "grv_proxies":1,
-         "backup_worker_enabled":1
+         "backup_worker_enabled":1,
+         "perpetual_storage_wiggle":0
       },
       "data":{
          "least_operating_space_bytes_log_server":0,

--- a/fdbclient/SystemData.cpp
+++ b/fdbclient/SystemData.cpp
@@ -594,6 +594,9 @@ ProcessClass decodeProcessClassValue(ValueRef const& value) {
 const KeyRangeRef configKeys(LiteralStringRef("\xff/conf/"), LiteralStringRef("\xff/conf0"));
 const KeyRef configKeysPrefix = configKeys.begin;
 
+const KeyRef perpetualStorageWiggleKey(LiteralStringRef("\xff/conf/perpetual_storage_wiggle"));
+const KeyRef wigglingStorageServerKey(LiteralStringRef("\xff/storageWiggleUID"));
+
 const KeyRef triggerDDTeamInfoPrintKey(LiteralStringRef("\xff/triggerDDTeamInfoPrint"));
 
 const KeyRangeRef excludedServersKeys(LiteralStringRef("\xff/conf/excluded/"), LiteralStringRef("\xff/conf/excluded0"));

--- a/fdbclient/SystemData.cpp
+++ b/fdbclient/SystemData.cpp
@@ -595,7 +595,7 @@ const KeyRangeRef configKeys(LiteralStringRef("\xff/conf/"), LiteralStringRef("\
 const KeyRef configKeysPrefix = configKeys.begin;
 
 const KeyRef perpetualStorageWiggleKey(LiteralStringRef("\xff/conf/perpetual_storage_wiggle"));
-const KeyRef wigglingStorageServerKey(LiteralStringRef("\xff/storageWiggleUID"));
+const KeyRef wigglingStorageServerKey(LiteralStringRef("\xff/storageWigglePID"));
 
 const KeyRef triggerDDTeamInfoPrintKey(LiteralStringRef("\xff/triggerDDTeamInfoPrint"));
 

--- a/fdbclient/SystemData.h
+++ b/fdbclient/SystemData.h
@@ -196,6 +196,8 @@ UID decodeProcessClassKeyOld(KeyRef const& key);
 extern const KeyRangeRef configKeys;
 extern const KeyRef configKeysPrefix;
 
+extern const KeyRef perpetualStorageWiggleKey;
+extern const KeyRef wigglingStorageServerKey;
 // Change the value of this key to anything and that will trigger detailed data distribution team info log.
 extern const KeyRef triggerDDTeamInfoPrintKey;
 


### PR DESCRIPTION
Implement the following command in fdbcli
```
configure perpetual_storage_wiggle=speed
```
The value speed will be the number of processes that the Data Distributor should exclude at a time. We’re currently only planning to support up to 1. So any value different than 0 or 1 will return an error.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
