### PR TITLE
Integrate team partitioned TLogServer with fake proxy to test commit

### DIFF
--- a/fdbserver/ptxn/TLogServer.actor.cpp
+++ b/fdbserver/ptxn/TLogServer.actor.cpp
@@ -576,30 +576,6 @@ struct LogGenerationData : NonCopyable, public ReferenceCounted<LogGenerationDat
 		specialCounter(cc, "SharedOverheadBytesInput", [tlogGroupData]() { return tlogGroupData->overheadBytesInput; });
 		specialCounter(
 		    cc, "SharedOverheadBytesDurable", [tlogGroupData]() { return tlogGroupData->overheadBytesDurable; });
-		specialCounter(cc, "KvstoreBytesUsed", [tlogGroupData]() {
-			return tlogGroupData->persistentData->getStorageBytes().used;
-		});
-		specialCounter(cc, "KvstoreBytesFree", [tlogGroupData]() {
-			return tlogGroupData->persistentData->getStorageBytes().free;
-		});
-		specialCounter(cc, "KvstoreBytesAvailable", [tlogGroupData]() {
-			return tlogGroupData->persistentData->getStorageBytes().available;
-		});
-		specialCounter(cc, "KvstoreBytesTotal", [tlogGroupData]() {
-			return tlogGroupData->persistentData->getStorageBytes().total;
-		});
-		specialCounter(cc, "QueueDiskBytesUsed", [tlogGroupData]() {
-			return tlogGroupData->rawPersistentQueue->getStorageBytes().used;
-		});
-		specialCounter(cc, "QueueDiskBytesFree", [tlogGroupData]() {
-			return tlogGroupData->rawPersistentQueue->getStorageBytes().free;
-		});
-		specialCounter(cc, "QueueDiskBytesAvailable", [tlogGroupData]() {
-			return tlogGroupData->rawPersistentQueue->getStorageBytes().available;
-		});
-		specialCounter(cc, "QueueDiskBytesTotal", [tlogGroupData]() {
-			return tlogGroupData->rawPersistentQueue->getStorageBytes().total;
-		});
 		specialCounter(
 		    cc, "PeekMemoryReserved", [tlogGroupData]() { return tlogGroupData->peekMemoryLimiter.activePermits(); });
 		specialCounter(

--- a/fdbserver/ptxn/TLogServer.actor.cpp
+++ b/fdbserver/ptxn/TLogServer.actor.cpp
@@ -417,6 +417,7 @@ struct TLogServerData : NonCopyable, public ReferenceCounted<TLogServerData> {
 	FlowLock peekMemoryLimiter;
 
 	PromiseStream<Future<Void>> sharedActors;
+	PromiseStream<Future<Void>> addActors;
 	Promise<Void> terminated;
 	FlowLock concurrentLogRouterReads;
 	FlowLock persistentDataCommitLock;
@@ -517,8 +518,8 @@ struct LogGenerationData : NonCopyable, public ReferenceCounted<LogGenerationDat
 	Counter bytesInput;
 	Counter bytesDurable;
 
-	// Log interface id for this generation. // Different TLogGroups in the same generation in the same tlog server
-	// share the same log ID.
+	// Log interface id for this generation.
+	// Different TLogGroups in the same generation in the same tlog server share the same log ID.
 	UID logId;
 	ProtocolVersion protocolVersion;
 
@@ -558,15 +559,8 @@ struct LogGenerationData : NonCopyable, public ReferenceCounted<LogGenerationDat
 	    logSystem(new AsyncVar<Reference<ILogSystem>>()), durableKnownCommittedVersion(0), minKnownCommittedVersion(0),
 	    terminated(tlogGroupData->terminated.getFuture()),
 	    // These are initialized differently on init() or recovery
-	    stopped(false), initialized(false), queueCommittingVersion(0), locality(locality), recoveryCount(epoch) {
-		startRole(Role::TRANSACTION_LOG,
-		          interf.id(),
-		          tlogGroupData->workerID,
-		          { { "SharedTLog", tlogGroupData->dbgid.shortString() } },
-		          context);
-
-		// TODO: remove this so that a log generation is only tracked once
-		addActor.send(traceRole(Role::TRANSACTION_LOG, interf.id()));
+	    stopped(false), initialized(false), version(0), queueCommittingVersion(0), locality(locality),
+	    recoveryCount(epoch) {
 
 		version.initMetric(LiteralStringRef("TLog.Version"), cc.id);
 		queueCommittedVersion.initMetric(LiteralStringRef("TLog.QueueCommittedVersion"), cc.id);
@@ -800,7 +794,9 @@ ACTOR Future<Void> doQueueCommit(Reference<TLogGroupData> self,
 	logData->queueCommittingVersion = ver;
 
 	g_network->setCurrentTask(TaskPriority::TLogCommitReply);
-	Future<Void> c = self->persistentQueue->commit();
+	// Currently only store commit messages in memory and not using persistent queue
+	// Future<Void> c = self->persistentQueue->commit();
+	Future<Void> c = Future<Void>(Void());
 	self->diskQueueCommitBytes = 0;
 	self->largeDiskQueueCommitBytes.set(false);
 
@@ -857,7 +853,7 @@ ACTOR Future<Void> commitQueue(Reference<TLogGroupData> self) {
 			wait(self->newLogData.onTrigger());
 			continue;
 		}
-
+		ASSERT(logData->tlogGroupData->tlogGroupID == self->tlogGroupID);
 		TraceEvent("CommitQueueNewLog", self->dbgid)
 		    .detail("LogId", logData->logId)
 		    .detail("Version", logData->version.get())
@@ -882,7 +878,9 @@ ACTOR Future<Void> commitQueue(Reference<TLogGroupData> self) {
 						wait(self->queueCommitEnd.whenAtLeast(self->queueCommitBegin) ||
 						     self->largeDiskQueueCommitBytes.onChange());
 					}
-					self->sharedActors.send(doQueueCommit(self, logData, missingFinalCommit));
+					if (logData->version.get() > logData->queueCommittedVersion.get()) {
+						self->sharedActors.send(doQueueCommit(self, logData, missingFinalCommit));
+					}
 					missingFinalCommit.clear();
 				}
 				when(wait(self->newLogData.onTrigger())) {}
@@ -944,7 +942,8 @@ ACTOR Future<Void> tLogCommit(Reference<TLogGroupData> self,
 		qe.messages = req.messages;
 		qe.id = logData->logId;
 		qe.storageTeamId = req.storageTeamID;
-		self->persistentQueue->push(qe, logData);
+		// Currently only store commit messages in memory and not using persistent queue
+		// self->persistentQueue->push(qe, logData);
 
 		self->diskQueueCommitBytes += qe.expectedSize();
 		if (self->diskQueueCommitBytes > SERVER_KNOBS->MAX_QUEUE_COMMIT_BYTES) {
@@ -1101,8 +1100,7 @@ ACTOR Future<Void> serveTLogInterface_PassivelyPull(
 				}
 			}
 		}
-		when(state TLogCommitRequest req = waitNext(tli.commit.getFuture())) {
-			//TraceEvent("TLogCommitReq", logData->logId).detail("Ver", req.version).detail("PrevVer", req.prevVersion).detail("LogVer", logData->version.get());
+		when(TLogCommitRequest req = waitNext(tli.commit.getFuture())) {
 			auto tlogGroup = activeGeneration.find(req.storageTeamID);
 			TEST(tlogGroup == activeGeneration.end()); // TLog group not found
 			if (tlogGroup == activeGeneration.end()) {
@@ -1114,14 +1112,14 @@ ACTOR Future<Void> serveTLogInterface_PassivelyPull(
 			if (logData->stopped) {
 				req.reply.sendError(tlog_stopped());
 			} else {
-				logData->addActor.send(tLogCommit(logData->tlogGroupData, req, logData));
+				self->addActors.send(tLogCommit(logData->tlogGroupData, req, logData));
 			}
 		}
 	}
 }
 
-void removeLog(Reference<TLogGroupData> self, Reference<LogGenerationData> logData) {
-
+void removeLog(Reference<LogGenerationData> logData) {
+	Reference<TLogGroupData> self = logData->tlogGroupData;
 	Reference<TLogServerData> tlogServerData = self->tLogServerData;
 	TraceEvent("TLogRemoved", self->dbgid)
 	    .detail("LogId", logData->logId)
@@ -1142,33 +1140,39 @@ void removeLog(Reference<TLogGroupData> self, Reference<LogGenerationData> logDa
 	}
 }
 
-ACTOR Future<Void> tlogGroupCore(Reference<TLogGroupData> self,
-                                 Reference<LogGenerationData> logData,
-                                 TLogInterface_PassivelyPull tli,
-                                 bool pulledRecoveryVersions) {
-	if (logData->removed.isReady()) {
+ACTOR Future<Void> tLogCore(Reference<TLogServerData> self,
+                            std::unordered_map<StorageTeamID, Reference<LogGenerationData>> activeGeneration,
+                            TLogInterface_PassivelyPull tli) {
+	if (self->removed.isReady()) {
 		wait(delay(0)); // to avoid iterator invalidation in restorePersistentState when removed is already ready
-		ASSERT(logData->removed.isError());
+		ASSERT(self->removed.isError());
 
-		if (logData->removed.getError().code() != error_code_worker_removed) {
-			throw logData->removed.getError();
+		if (self->removed.getError().code() != error_code_worker_removed) {
+			throw self->removed.getError();
 		}
 
-		removeLog(self, logData);
+		for (auto& logGroup : activeGeneration) {
+			removeLog(logGroup.second);
+		}
 		return Void();
 	}
 
-	state Future<Void> warningCollector = timeoutWarningCollector(
-	    logData->warningCollectorInput.getFuture(), 1.0, "TLogQueueCommitSlow", self->tlogGroupID);
-	state Future<Void> error = actorCollection(logData->addActor.getFuture());
-
-	logData->addActor.send(logData->removed);
+	self->addActors.send(self->removed);
 	// FIXME: update tlogMetrics to include new information, or possibly only have one copy for the shared instance
-	logData->addActor.send(traceCounters("TLogMetrics",
-	                                     logData->logId,
-	                                     SERVER_KNOBS->STORAGE_LOGGING_DELAY,
-	                                     &logData->cc,
-	                                     logData->logId.toString() + "/TLogMetrics"));
+	for (auto& logGroup : activeGeneration) {
+		self->sharedActors.send(traceCounters("TLogMetrics",
+		                                      logGroup.second->logId,
+		                                      SERVER_KNOBS->STORAGE_LOGGING_DELAY,
+		                                      &logGroup.second->cc,
+		                                      logGroup.second->logId.toString() + "/TLogMetrics"));
+	}
+	startRole(Role::TRANSACTION_LOG, tli.id(), self->workerID, { { "SharedTLog", self->dbgid.shortString() } });
+
+	// TODO: remove this so that a log generation is only tracked once
+	self->addActors.send(traceRole(Role::TRANSACTION_LOG, tli.id()));
+	self->addActors.send(serveTLogInterface_PassivelyPull(self, tli, activeGeneration));
+	self->addActors.send(waitFailureServer(tli.waitFailure.getFuture()));
+	state Future<Void> error = actorCollection(self->addActors.getFuture());
 
 	try {
 		wait(error);
@@ -1176,7 +1180,9 @@ ACTOR Future<Void> tlogGroupCore(Reference<TLogGroupData> self,
 	} catch (Error& e) {
 		if (e.code() != error_code_worker_removed)
 			throw;
-		removeLog(self, logData);
+		for (auto& logGroup : activeGeneration) {
+			removeLog(logGroup.second);
+		}
 		return Void();
 	}
 }
@@ -1312,8 +1318,7 @@ ACTOR Future<Void> tlogGroupStart(Reference<TLogGroupData> self, Reference<LogGe
 
 		wait(delay(0.0)); // if multiple recruitment requests were already in the promise stream make sure they are all
 		// started before any are removed
-
-		removeLog(self, logData);
+		removeLog(logData);
 	}
 	return Void();
 }
@@ -1346,6 +1351,7 @@ ACTOR Future<Void> tLogStart(Reference<TLogServerData> self, InitializeTLogReque
 	for (auto& group : req.tlogGroups) {
 		ASSERT(self->tlogGroups.count(group.logGroupId));
 		Reference<TLogGroupData> tlogGroupData = self->tlogGroups[group.logGroupId];
+		ASSERT(group.logGroupId == tlogGroupData->tlogGroupID);
 		Reference<LogGenerationData> newGenerationData = makeReference<LogGenerationData>(tlogGroupData,
 		                                                                                  recruited,
 		                                                                                  req.recruitmentID,
@@ -1356,7 +1362,7 @@ ACTOR Future<Void> tLogStart(Reference<TLogServerData> self, InitializeTLogReque
 		                                                                                  req.epoch,
 		                                                                                  "Recruited");
 
-		tlogGroupData->id_data[req.recruitmentID] = newGenerationData;
+		tlogGroupData->id_data[recruited.id()] = newGenerationData;
 		newGenerationData->removed = self->removed;
 		for (auto& storageTeam : newGenerationData->storageTeams) {
 			activeGeneration[storageTeam.first] = newGenerationData;
@@ -1367,17 +1373,8 @@ ACTOR Future<Void> tLogStart(Reference<TLogServerData> self, InitializeTLogReque
 	wait(waitForAll(tlogGroupStarts));
 	req.ptxnReply.send(recruited);
 
-	// should start tlog inerface and wait server here
-	self->sharedActors.send(serveTLogInterface_PassivelyPull(self, recruited, activeGeneration));
-	self->sharedActors.send(waitFailureServer(recruited.waitFailure.getFuture()));
 	TraceEvent("TLogStart", recruited.id());
-
-	state std::vector<Future<Void>> tlogGroupCores;
-	for (auto& group : self->tlogGroups) {
-		tlogGroupCores.push_back(
-		    tlogGroupCore(group.second, group.second->id_data[req.recruitmentID], recruited, false));
-	}
-	wait(waitForAll(tlogGroupCores));
+	wait(tLogCore(self, activeGeneration, recruited));
 	return Void();
 }
 
@@ -1486,7 +1483,7 @@ ACTOR Future<Void> tLog(std::vector<std::pair<IKeyValueStore*, IDiskQueue*>> per
 }
 
 namespace {
-ACTOR Future<Void> startTLogServers(std::vector<Future<Void>> actors,
+ACTOR Future<Void> startTLogServers(std::vector<Future<Void>>* actors,
                                     std::shared_ptr<test::TestDriverContext> context,
                                     std::string folder) {
 	state std::vector<InitializeTLogRequest> tLogInitializations;
@@ -1497,18 +1494,18 @@ ACTOR Future<Void> startTLogServers(std::vector<Future<Void>> actors,
 		tLogInitializations.emplace_back();
 		tLogInitializations.back().isPrimary = true;
 		tLogInitializations.back().tlogGroups = context->tLogGroups;
-		actors.push_back(ptxn::tLog(std::vector<std::pair<IKeyValueStore*, IDiskQueue*>>(),
-		                            makeReference<AsyncVar<ServerDBInfo>>(),
-		                            LocalityData(),
-		                            initializeTLog,
-		                            UID(0, 1),
-		                            UID(0, 2),
-		                            false,
-		                            Promise<Void>(),
-		                            Promise<Void>(),
-		                            folder,
-		                            makeReference<AsyncVar<bool>>(false),
-		                            makeReference<AsyncVar<UID>>(UID(0, 1))));
+		actors->push_back(ptxn::tLog(std::vector<std::pair<IKeyValueStore*, IDiskQueue*>>(),
+		                             makeReference<AsyncVar<ServerDBInfo>>(),
+		                             LocalityData(),
+		                             initializeTLog,
+		                             UID(0, 1),
+		                             UID(0, 2),
+		                             false,
+		                             Promise<Void>(),
+		                             Promise<Void>(),
+		                             folder,
+		                             makeReference<AsyncVar<bool>>(false),
+		                             makeReference<AsyncVar<UID>>(UID(0, 1))));
 		initializeTLog.send(tLogInitializations.back());
 	}
 
@@ -1527,14 +1524,18 @@ ACTOR Future<Void> startTLogServers(std::vector<Future<Void>> actors,
 
 TEST_CASE("/fdbserver/ptxn/test/run_tlog_server") {
 	test::TestDriverOptions options(params);
+	// Commit validation in real TLog is not supported for now
+	options.skipCommitValidation = true;
 	state std::vector<Future<Void>> actors;
 	state std::shared_ptr<test::TestDriverContext> context = test::initTestDriverContext(options);
 
-	state std::string folder = "simdb/unittests";
+	state std::string folder = "simdb" + deterministicRandom()->randomAlphaNumeric(10);
 	platform::createDirectory(folder);
 	// start a real TLog server
-	wait(startTLogServers(actors, context, folder));
+	wait(startTLogServers(&actors, context, folder));
 	// TODO: start fake proxy to talk to real TLog servers.
+	startFakeProxy(actors, context);
+	wait(quorum(actors, 1));
 	platform::eraseDirectoryRecursive(folder);
 	return Void();
 }

--- a/fdbserver/ptxn/test/Driver.h
+++ b/fdbserver/ptxn/test/Driver.h
@@ -62,6 +62,7 @@ struct TestDriverOptions {
 	static const int DEFAULT_NUM_TLOG_GROUPS = 4;
 	static const int DEFAULT_NUM_STORAGE_SERVERS = 3;
 	static const int DEFAULT_NUM_RESOLVERS = 2;
+	static const int DEFAULT_SKIP_COMMIT_VALIDATION = false;
 	static const MessageTransferModel DEFAULT_MESSAGE_TRANSFER_MODEL = MessageTransferModel::TLogActivelyPush;
 
 	int numCommits;
@@ -71,6 +72,7 @@ struct TestDriverOptions {
 	int numTLogGroups;
 	int numStorageServers;
 	int numResolvers;
+	bool skipCommitValidation;
 	MessageTransferModel transferModel;
 
 	explicit TestDriverOptions(const UnitTestParameters&);
@@ -80,11 +82,17 @@ struct TestDriverContext {
 	// Num commits to be created
 	int numCommits;
 
+	// commit version gap
+	int commitVersionGap;
+
 	// Teams
 	int numStorageTeamIDs;
 	std::vector<StorageTeamID> storageTeamIDs;
 
 	MessageTransferModel messageTransferModel;
+
+	// whether to skip persistence validation
+	bool skipCommitValidation;
 
 	// Proxies
 	bool useFakeProxy;
@@ -100,9 +108,11 @@ struct TestDriverContext {
 	int numTLogGroups;
 	std::vector<TLogGroup> tLogGroups;
 	std::unordered_map<TLogGroupID, std::shared_ptr<TLogInterfaceBase>> tLogGroupLeaders;
+	std::unordered_map<TLogGroupID, Version> tLogGroupVersion;
 	std::vector<std::shared_ptr<TLogInterfaceBase>> tLogInterfaces;
-	std::unordered_map<StorageTeamID, std::shared_ptr<TLogInterfaceBase>> storageTeamIDTLogInterfaceMapper;
+	std::unordered_map<StorageTeamID, TLogGroupID> storageTeamIDTLogGroupIDMapper;
 	std::shared_ptr<TLogInterfaceBase> getTLogInterface(const StorageTeamID&);
+	std::pair<Version, Version> getCommitVersionPair(const StorageTeamID& storageTeamId);
 
 	// Storage Server
 	bool useFakeStorageServer;

--- a/fdbserver/ptxn/test/FakeProxy.actor.cpp
+++ b/fdbserver/ptxn/test/FakeProxy.actor.cpp
@@ -42,11 +42,9 @@ ACTOR Future<Void> fakeProxy(std::shared_ptr<FakeProxyContext> pFakeProxyContext
 	state std::shared_ptr<TestDriverContext> pTestDriverContext = pFakeProxyContext->pTestDriverContext;
 	state int numStorageTeams = pFakeProxyContext->pTestDriverContext->numStorageTeamIDs;
 	state std::vector<CommitRecord>& commitRecord = pFakeProxyContext->pTestDriverContext->commitRecord;
-	state Version versionGap = 10000;
-	state Version version = versionGap;
 	state int i = 0;
 	loop {
-		std::cout << "Commit " << i << std::endl;
+		std::cout << "Proxy" << pFakeProxyContext->proxyID << " Commit " << i << std::endl;
 
 		std::unordered_map<StorageTeamID, std::vector<MutationRef>> fakeMutations;
 		ProxyTLogPushMessageSerializer serializer;
@@ -66,10 +64,11 @@ ACTOR Future<Void> fakeProxy(std::shared_ptr<FakeProxyContext> pFakeProxyContext
 		for (auto iter = fakeMutations.begin(); iter != fakeMutations.end(); ++iter) {
 			const StorageTeamID storageTeamID = iter->first;
 			auto& mutations = iter->second;
+			auto commitVersionPair = pTestDriverContext->getCommitVersionPair(storageTeamID);
 
 			// Here we use move semantic in order to keep the mutations in arena
 			// 	pTestDriverContext->mutationsArena
-			commitRecord.emplace_back(version, storageTeamID, std::move(mutations));
+			commitRecord.emplace_back(commitVersionPair.second, storageTeamID, std::move(mutations));
 
 			serializer.completeMessageWriting(storageTeamID);
 			Standalone<StringRef> encoded = serializer.getSerialized(storageTeamID);
@@ -77,14 +76,13 @@ ACTOR Future<Void> fakeProxy(std::shared_ptr<FakeProxyContext> pFakeProxyContext
 			                          storageTeamID,
 			                          encoded.arena(),
 			                          encoded,
-			                          version - versionGap,
-			                          version,
+			                          commitVersionPair.first,
+			                          commitVersionPair.second,
 			                          0,
 			                          0,
-			                          Optional<UID>());
+			                          Optional<UID>(deterministicRandom()->randomUniqueID()));
 			requests.push_back(pTestDriverContext->getTLogInterface(storageTeamID)->commit.getReply(request));
 		}
-		version += versionGap;
 
 		print::printCommitRecord(pTestDriverContext->commitRecord);
 
@@ -93,6 +91,11 @@ ACTOR Future<Void> fakeProxy(std::shared_ptr<FakeProxyContext> pFakeProxyContext
 		if (++i == pFakeProxyContext->numCommits) {
 			break;
 		}
+	}
+
+	if (pTestDriverContext->skipCommitValidation) {
+		std::cout << "Skipped commit persistence validation\n";
+		return Void();
 	}
 
 	// Wait for all commits being completed persisted/timeout

--- a/fdbserver/ptxn/test/FakeProxy.actor.h
+++ b/fdbserver/ptxn/test/FakeProxy.actor.h
@@ -40,6 +40,7 @@
 namespace ptxn::test {
 
 struct FakeProxyContext {
+	int proxyID;
 	int numCommits;
 
 	std::shared_ptr<TestDriverContext> pTestDriverContext;

--- a/fdbserver/ptxn/test/Utils.cpp
+++ b/fdbserver/ptxn/test/Utils.cpp
@@ -122,6 +122,10 @@ void print(const TestDriverOptions& option) {
 	          << formatKVPair("numStorageTeams", option.numStorageTeams) << std::endl
 	          << formatKVPair("numProxies", option.numProxies) << std::endl
 	          << formatKVPair("numTLogs", option.numTLogs) << std::endl
+	          << formatKVPair("numTLogGroups", option.numTLogGroups) << std::endl
+	          << formatKVPair("numStorageServers", option.numStorageServers) << std::endl
+	          << formatKVPair("numResolvers", option.numResolvers) << std::endl
+	          << formatKVPair("skipCommitValidation", option.skipCommitValidation) << std::endl
 	          << formatKVPair("Message Transfer Model", option.transferModel) << std::endl;
 }
 

--- a/flow/UnitTest.cpp
+++ b/flow/UnitTest.cpp
@@ -65,3 +65,11 @@ Optional<double> UnitTestParameters::getDouble(const std::string& name) const {
 	}
 	return {};
 }
+
+Optional<bool> UnitTestParameters::getBool(const std::string& name) const {
+	auto opt = get(name);
+	if (opt.present()) {
+		return static_cast<bool>(std::stoll(opt.get()));
+	}
+	return {};
+}

--- a/flow/UnitTest.h
+++ b/flow/UnitTest.h
@@ -68,6 +68,9 @@ struct UnitTestParameters {
 
 	// Get a parameter's value parsed as a double, will return !present() if parameter was not set
 	Optional<double> getDouble(const std::string& name) const;
+
+	// Get a parameter's value parsed as a bool, will return !present() if parameter was not set
+	Optional<bool> getBool(const std::string& name) const;
 };
 
 // Unit test definition structured as a linked list item

--- a/tests/ptxn/TLogServer.toml
+++ b/tests/ptxn/TLogServer.toml
@@ -1,5 +1,5 @@
 [[test]]
-testTitle = 'TLog Server Test'
+testTitle = 'Team Partitioned TLog Server Test 1'
 useDB = false
 startDelay = 0
 
@@ -7,3 +7,27 @@ startDelay = 0
     testName = 'UnitTests'
     maxTestCases = 1
     testsMatching = '/fdbserver/ptxn/test/run_tlog_server'
+
+    numProxies = 3
+    numTLogs = 4
+    numStorageTeams = 55
+    numTLogGroups = 8
+    skipCommitValidation = 1
+    numCommits = 20
+
+[[test]]
+testTitle = 'Team Partitioned TLog Server Test 2'
+useDB = false
+startDelay = 0
+
+    [[test.workload]]
+    testName = 'UnitTests'
+    maxTestCases = 1
+    testsMatching = '/fdbserver/ptxn/test/run_tlog_server'
+
+    numProxies = 3
+    numTLogs = 2
+    numStorageTeams = 10
+    numTLogGroups = 4
+    skipCommitValidation = 1
+    numCommits = 50

--- a/tests/ptxn/TLogServer.toml
+++ b/tests/ptxn/TLogServer.toml
@@ -26,8 +26,8 @@ startDelay = 0
     testsMatching = '/fdbserver/ptxn/test/run_tlog_server'
 
     numProxies = 3
-    numTLogs = 2
+    numTLogs = 1
     numStorageTeams = 10
     numTLogGroups = 4
     skipCommitValidation = 1
-    numCommits = 50
+    numCommits = 10


### PR DESCRIPTION
Integrate fake proxy to talk to team partitioned TLogServer.  

- Disk queue still has some problem so not enabled. It's not needed for implementing peek.
- Commit validation in TLogServer is disabled for now and will be added later.
- Testing: ptxn/TLogServer.toml 

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ x ] The PR has a description, explaining both the problem and the solution.
- [ x ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ x ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
