### PR TITLE
Improve logging on the current view of the database configuration that the cluster controller is using.

### DIFF
--- a/fdbserver/ClusterController.actor.cpp
+++ b/fdbserver/ClusterController.actor.cpp
@@ -1692,31 +1692,31 @@ public:
 		if (req.configuration.regions.size() > 1) {
 			std::vector<RegionInfo> regions = req.configuration.regions;
 			if (regions[0].priority == regions[1].priority && regions[1].dcId == clusterControllerDcId.get()) {
-				TraceEvent("CCSwitchPrimaryDC", id)
+				TraceEvent("CCSwitchPrimaryDc", id)
 				    .detail("CCDcId", clusterControllerDcId.get())
-				    .detail("OldPrimaryDCId", regions[0].dcId)
-				    .detail("NewPrimaryDCid", regions[1].dcId);
+				    .detail("OldPrimaryDcId", regions[0].dcId)
+				    .detail("NewPrimaryDcId", regions[1].dcId);
 				std::swap(regions[0], regions[1]);
 			}
 
 			if (regions[1].dcId == clusterControllerDcId.get() &&
 			    (!versionDifferenceUpdated || datacenterVersionDifference >= SERVER_KNOBS->MAX_VERSION_DIFFERENCE)) {
 				if (regions[1].priority >= 0) {
-					TraceEvent("CCSwitchPrimaryDCVersionDifference", id)
+					TraceEvent("CCSwitchPrimaryDcVersionDifference", id)
 					    .detail("CCDcId", clusterControllerDcId.get())
-					    .detail("OldPrimaryDCId", regions[0].dcId)
-					    .detail("NewPrimaryDCid", regions[1].dcId);
+					    .detail("OldPrimaryDcId", regions[0].dcId)
+					    .detail("NewPrimaryDcId", regions[1].dcId);
 					std::swap(regions[0], regions[1]);
 				} else {
 					TraceEvent(SevWarnAlways, "CCDcPriorityNegative")
 					    .detail("DcId", regions[1].dcId)
 					    .detail("Priority", regions[1].priority)
-					    .detail("FindWorkersInDC", regions[0].dcId)
+					    .detail("FindWorkersInDc", regions[0].dcId)
 					    .detail("Warning", "Failover did not happen but CC is in remote DC");
 				}
 			}
 
-			TraceEvent("CCFindWorkersForConfiguraiton", id)
+			TraceEvent("CCFindWorkersForConfiguration", id)
 			    .detail("CCDcId", clusterControllerDcId.get())
 			    .detail("Region0DcId", regions[0].dcId)
 			    .detail("Region1DcId", regions[1].dcId)
@@ -1738,9 +1738,8 @@ public:
 				}
 				TraceEvent(SevWarn, "CCRecruitmentFailed", id)
 				    .detail("Reason", "Recruited Txn system and CC are in different DCs")
-				    .detail("CCDcID", clusterControllerDcId.get())
-				    .detail("RecruitedTxnSystemDcID", regions[0].dcId)
-				    .detail("Action", "CC tries to recruit in its DC");
+				    .detail("CCDcId", clusterControllerDcId.get())
+				    .detail("RecruitedTxnSystemDcId", regions[0].dcId);
 				throw no_more_servers();
 			} catch (Error& e) {
 				if (!goodRemoteRecruitmentTime.isReady() && regions[1].dcId != clusterControllerDcId.get()) {
@@ -1750,7 +1749,7 @@ public:
 				if (e.code() != error_code_no_more_servers || regions[1].priority < 0) {
 					throw;
 				}
-				TraceEvent(SevWarn, "AttemptingRecruitmentInRemoteDC", id)
+				TraceEvent(SevWarn, "AttemptingRecruitmentInRemoteDc", id)
 				    .detail("SetPrimaryDesired", setPrimaryDesired)
 				    .error(e);
 				auto reply = findWorkersForConfigurationFromDC(req, regions[1].dcId);

--- a/fdbserver/masterserver.actor.cpp
+++ b/fdbserver/masterserver.actor.cpp
@@ -711,15 +711,10 @@ ACTOR Future<vector<Standalone<CommitTransactionRef>>> recruitEverything(Referen
 		TraceEvent("MasterRecoveryState", self->dbgid)
 		    .detail("StatusCode", RecoveryStatus::recruiting_transaction_servers)
 		    .detail("Status", RecoveryStatus::names[RecoveryStatus::recruiting_transaction_servers])
-		    .detail("RequiredTLogs", self->configuration.tLogReplicationFactor)
-		    .detail("DesiredTLogs", self->configuration.getDesiredLogs())
+		    .detail("Conf", self->configuration.toString())
 		    .detail("RequiredCommitProxies", 1)
-		    .detail("DesiredCommitProxies", self->configuration.getDesiredCommitProxies())
 		    .detail("RequiredGrvProxies", 1)
-		    .detail("DesiredGrvProxies", self->configuration.getDesiredGrvProxies())
 		    .detail("RequiredResolvers", 1)
-		    .detail("DesiredResolvers", self->configuration.getDesiredResolvers())
-		    .detail("StoreType", self->configuration.storageServerStoreType)
 		    .trackLatest("MasterRecoveryState");
 
 	// FIXME: we only need log routers for the same locality as the master
@@ -732,14 +727,25 @@ ACTOR Future<vector<Standalone<CommitTransactionRef>>> recruitEverything(Referen
 	    wait(brokenPromiseToNever(self->clusterController.recruitFromConfiguration.getReply(
 	        RecruitFromConfigurationRequest(self->configuration, self->lastEpochEnd == 0, maxLogRouters))));
 
+	std::string primaryDcIds, remoteDcIds;
+
 	self->primaryDcId.clear();
 	self->remoteDcIds.clear();
 	if (recruits.dcId.present()) {
 		self->primaryDcId.push_back(recruits.dcId);
+		if (!primaryDcIds.empty()) {
+			primaryDcIds += ',';
+		}
+		primaryDcIds += printable(recruits.dcId);
 		if (self->configuration.regions.size() > 1) {
-			self->remoteDcIds.push_back(recruits.dcId.get() == self->configuration.regions[0].dcId
-			                                ? self->configuration.regions[1].dcId
-			                                : self->configuration.regions[0].dcId);
+			Key remoteDcId = recruits.dcId.get() == self->configuration.regions[0].dcId
+			                     ? self->configuration.regions[1].dcId
+			                     : self->configuration.regions[0].dcId;
+			self->remoteDcIds.push_back(remoteDcId);
+			if (!remoteDcIds.empty()) {
+				remoteDcIds += ',';
+			}
+			remoteDcIds += printable(remoteDcId);
 		}
 	}
 	self->backupWorkers.swap(recruits.backupWorkers);
@@ -755,6 +761,8 @@ ACTOR Future<vector<Standalone<CommitTransactionRef>>> recruitEverything(Referen
 	    .detail("OldLogRouters", recruits.oldLogRouters.size())
 	    .detail("StorageServers", recruits.storageServers.size())
 	    .detail("BackupWorkers", self->backupWorkers.size())
+	    .detail("PrimaryDCIds", primaryDcIds)
+	    .detail("RemoteDCIds", remoteDcIds)
 	    .trackLatest("MasterRecoveryState");
 
 	// Actually, newSeedServers does both the recruiting and initialization of the seed servers; so if this is a brand

--- a/fdbserver/masterserver.actor.cpp
+++ b/fdbserver/masterserver.actor.cpp
@@ -761,8 +761,8 @@ ACTOR Future<vector<Standalone<CommitTransactionRef>>> recruitEverything(Referen
 	    .detail("OldLogRouters", recruits.oldLogRouters.size())
 	    .detail("StorageServers", recruits.storageServers.size())
 	    .detail("BackupWorkers", self->backupWorkers.size())
-	    .detail("PrimaryDCIds", primaryDcIds)
-	    .detail("RemoteDCIds", remoteDcIds)
+	    .detail("PrimaryDcIds", primaryDcIds)
+	    .detail("RemoteDcIds", remoteDcIds)
 	    .trackLatest("MasterRecoveryState");
 
 	// Actually, newSeedServers does both the recruiting and initialization of the seed servers; so if this is a brand


### PR DESCRIPTION
1. Add logging when DC switch happens;
2. Add logging when CC recruits workers;
3. Log the DC Ids when master recruits everrthing.

20210524-195906-renxuan-13e040d67739fe53           compressed=True data_size=23376650 duration=8558269 ended=102300 fail=2 fail_fast=10 max_runs=100000 pass=100028 priority=100 remaining=0 runtime=0:57:52 sanity=False started=102551 stopped=20210524-205658 submitted=20210524-195906 timeout=5400 username=renxuan

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
