### PR TITLE
allow simulation properties to be overwritten

### DIFF
--- a/fdbserver/TesterInterface.actor.h
+++ b/fdbserver/TesterInterface.actor.h
@@ -100,27 +100,6 @@ struct WorkloadRequest {
 	}
 };
 
-// Configuration details specified in workload test files that change the simulation
-// environment details
-struct TestConfig {
-	int extraDB = 0;
-	int minimumReplication = 0;
-	int minimumRegions = 0;
-	int configureLocked = 0;
-	bool startIncompatibleProcess = false;
-	int logAntiQuorum = -1;
-	// Storage Engine Types: Verify match with SimulationConfig::generateNormalConfig
-	//	0 = "ssd"
-	//	1 = "memory"
-	//	2 = "memory-radixtree-beta"
-	//	3 = "ssd-redwood-experimental"
-	// Requires a comma-separated list of numbers WITHOUT whitespaces
-	std::vector<int> storageEngineExcludeTypes;
-	// Set the maximum TLog version that can be selected for a test
-	// Refer to FDBTypes.h::TLogVersion. Defaults to the maximum supported version.
-	int maxTLogVersion = TLogVersion::MAX_SUPPORTED;
-};
-
 struct TesterInterface {
 	constexpr static FileIdentifier file_identifier = 4465210;
 	RequestStream<WorkloadRequest> recruitments;

--- a/fdbserver/tester.actor.cpp
+++ b/fdbserver/tester.actor.cpp
@@ -1249,20 +1249,6 @@ std::vector<TestSpec> readTOMLTests_(std::string fileName) {
 
 	const toml::value& conf = toml::parse(fileName);
 
-	// Handle all global settings
-	for (const auto& [k, v] : conf.as_table()) {
-		if (k == "test") {
-			continue;
-		}
-		if (testSpecGlobalKeys.find(k) != testSpecGlobalKeys.end()) {
-			testSpecGlobalKeys[k](toml_to_string(v));
-		} else {
-			TraceEvent(SevError, "TestSpecUnrecognizedGlobalParam")
-			    .detail("Attrib", k)
-			    .detail("Value", toml_to_string(v));
-		}
-	}
-
 	// Then parse each test
 	const toml::array& tests = toml::find(conf, "test").as_array();
 	for (const toml::value& test : tests) {

--- a/tests/fast/AtomicBackupToDBCorrectness.toml
+++ b/tests/fast/AtomicBackupToDBCorrectness.toml
@@ -1,3 +1,4 @@
+[configuration]
 extraDB = 1
 
 [[test]]

--- a/tests/fast/BackupToDBCorrectness.toml
+++ b/tests/fast/BackupToDBCorrectness.toml
@@ -1,3 +1,4 @@
+[configuration]
 extraDB = 1
 
 [[test]]

--- a/tests/fast/BackupToDBCorrectnessClean.toml
+++ b/tests/fast/BackupToDBCorrectnessClean.toml
@@ -1,3 +1,4 @@
+[configuration]
 extraDB = 1
 
 [[test]]

--- a/tests/fast/ConfigureLocked.toml
+++ b/tests/fast/ConfigureLocked.toml
@@ -1,4 +1,5 @@
-configureLocked = 1
+[configuration]
+configureLocked = true
 
 [[test]]
 testTitle = 'ConfigureLocked'

--- a/tests/fast/FuzzApiCorrectness.toml
+++ b/tests/fast/FuzzApiCorrectness.toml
@@ -1,3 +1,4 @@
+[configuration]
 StderrSeverity = 30
 
 [[test]]

--- a/tests/fast/FuzzApiCorrectnessClean.toml
+++ b/tests/fast/FuzzApiCorrectnessClean.toml
@@ -1,3 +1,4 @@
+[configuration]
 StderrSeverity = 30
 
 [[test]]

--- a/tests/fast/KillRegionCycle.toml
+++ b/tests/fast/KillRegionCycle.toml
@@ -1,3 +1,4 @@
+[configuration]
 minimumRegions = 2
 
 [[test]]

--- a/tests/fast/LongStackWriteDuringRead.toml
+++ b/tests/fast/LongStackWriteDuringRead.toml
@@ -1,3 +1,4 @@
+[configuration]
 StderrSeverity = 30
 
 [[test]]

--- a/tests/fast/LowLatency.toml
+++ b/tests/fast/LowLatency.toml
@@ -1,3 +1,4 @@
+[configuration]
 buggify = false
 minimumReplication = 2
 

--- a/tests/fast/ProtocolVersion.toml
+++ b/tests/fast/ProtocolVersion.toml
@@ -1,3 +1,4 @@
+[configuration]
 startIncompatibleProcess = true
 
 [[test]]

--- a/tests/fast/ReportConflictingKeys.toml
+++ b/tests/fast/ReportConflictingKeys.toml
@@ -1,3 +1,4 @@
+[configuration]
 buggify = false
 
 [[test]]

--- a/tests/fast/WriteDuringRead.toml
+++ b/tests/fast/WriteDuringRead.toml
@@ -1,3 +1,4 @@
+[configuration]
 StderrSeverity = 30
 
 [[test]]

--- a/tests/fast/WriteDuringReadClean.toml
+++ b/tests/fast/WriteDuringReadClean.toml
@@ -1,3 +1,4 @@
+[configuration]
 StderrSeverity = 30
 
 [[test]]

--- a/tests/rare/ConflictRangeCheck.toml
+++ b/tests/rare/ConflictRangeCheck.toml
@@ -1,3 +1,4 @@
+[configuration]
 buggify = false
 
 [[test]]

--- a/tests/rare/ConflictRangeRYOWCheck.toml
+++ b/tests/rare/ConflictRangeRYOWCheck.toml
@@ -1,3 +1,4 @@
+[configuration]
 buggify = false
 
 [[test]]

--- a/tests/restarting/from_7.0.0/SnapIncrementalRestore-1.toml
+++ b/tests/restarting/from_7.0.0/SnapIncrementalRestore-1.toml
@@ -1,3 +1,4 @@
+[configuration]
 logAntiQuorum = 0
 
 [[test]] 

--- a/tests/slow/ApiCorrectnessSwitchover.toml
+++ b/tests/slow/ApiCorrectnessSwitchover.toml
@@ -1,3 +1,4 @@
+[configuration]
 extraDB = 2
 
 [[test]]

--- a/tests/slow/DifferentClustersSameRV.toml
+++ b/tests/slow/DifferentClustersSameRV.toml
@@ -1,3 +1,4 @@
+[configuration]
 extraDB = 2
 
 [[test]]

--- a/tests/slow/LowLatencyWithFailures.toml
+++ b/tests/slow/LowLatencyWithFailures.toml
@@ -1,3 +1,4 @@
+[configuration]
 minimumReplication = 2
 
 [[test]]

--- a/tests/slow/ParallelRestoreNewBackupCorrectnessAtomicOp.toml
+++ b/tests/slow/ParallelRestoreNewBackupCorrectnessAtomicOp.toml
@@ -1,4 +1,5 @@
 # Disable buggify for parallel restore
+#[configuration]
 #buggify=on
 
 [[test]]

--- a/tests/slow/ParallelRestoreNewBackupCorrectnessCycle.toml
+++ b/tests/slow/ParallelRestoreNewBackupCorrectnessCycle.toml
@@ -1,4 +1,5 @@
 # Disable buggify for parallel restore
+#[configuration]
 #buggify=off
 
 [[test]]

--- a/tests/slow/ParallelRestoreNewBackupCorrectnessMultiCycles.toml
+++ b/tests/slow/ParallelRestoreNewBackupCorrectnessMultiCycles.toml
@@ -1,4 +1,5 @@
 # Disable buggify for parallel restore
+#[configuration]
 #buggify=off
 
 [[test]]

--- a/tests/slow/ParallelRestoreNewBackupWriteDuringReadAtomicRestore.toml
+++ b/tests/slow/ParallelRestoreNewBackupWriteDuringReadAtomicRestore.toml
@@ -1,3 +1,4 @@
+[configuration]
 StderrSeverity = 30
 
 [[test]]

--- a/tests/slow/ParallelRestoreOldBackupCorrectnessAtomicOp.toml
+++ b/tests/slow/ParallelRestoreOldBackupCorrectnessAtomicOp.toml
@@ -1,4 +1,5 @@
 # Disable buggify for parallel restore
+#[configuration]
 #buggify=on
 
 [[test]]

--- a/tests/slow/ParallelRestoreOldBackupCorrectnessMultiCycles.toml
+++ b/tests/slow/ParallelRestoreOldBackupCorrectnessMultiCycles.toml
@@ -1,4 +1,5 @@
 # Disable buggify for parallel restore
+#[configuration]
 #buggify=off
 
 [[test]]

--- a/tests/slow/ParallelRestoreOldBackupWriteDuringReadAtomicRestore.toml
+++ b/tests/slow/ParallelRestoreOldBackupWriteDuringReadAtomicRestore.toml
@@ -1,3 +1,4 @@
+[configuration]
 StderrSeverity = 30
 
 [[test]]

--- a/tests/slow/SharedBackupCorrectness.toml
+++ b/tests/slow/SharedBackupCorrectness.toml
@@ -1,3 +1,4 @@
+[configuration]
 extraDB = 1
 
 [[test]]

--- a/tests/slow/SharedBackupToDBCorrectness.toml
+++ b/tests/slow/SharedBackupToDBCorrectness.toml
@@ -1,3 +1,4 @@
+[configuration]
 extraDB = 1
 
 [[test]]

--- a/tests/slow/VersionStampBackupToDB.toml
+++ b/tests/slow/VersionStampBackupToDB.toml
@@ -1,3 +1,4 @@
+[configuration]
 extraDB = 2
 
 [[test]]

--- a/tests/slow/VersionStampSwitchover.toml
+++ b/tests/slow/VersionStampSwitchover.toml
@@ -1,3 +1,4 @@
+[configuration]
 extraDB = 2
 
 [[test]]

--- a/tests/slow/WriteDuringReadAtomicRestore.toml
+++ b/tests/slow/WriteDuringReadAtomicRestore.toml
@@ -1,3 +1,4 @@
+[configuration]
 StderrSeverity = 30
 
 [[test]]

--- a/tests/slow/WriteDuringReadSwitchover.toml
+++ b/tests/slow/WriteDuringReadSwitchover.toml
@@ -1,3 +1,4 @@
+[configuration]
 StderrSeverity = 30
 extraDB = 2
 


### PR DESCRIPTION
This PR adds functionality to the simulator so we can overwrite properties like number of machines, storage engine to be used etc in the toml file.

A toml file can now have a `[configuration]` section which will contain properties for the simulator. This is useful if we want to test certain configurations or if a test requires a certain config. Adding more properties is very simple (it is controlled by one map in `SimulatedCluster.actor.cpp`. An example for a configuration would look like this:

```
[configuration]
config = 'triple'
storageEngineType = 3
processesPerMachine = 3
coordinators = 3
machineCount = 15
```

In order to test I ran 10k simulation tests (as this changes the toml format, I had to verify that it doesn't break anything). Additionally I changed a toml file and added the lines above and verified that the simulator did the right thing.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [x] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
