### PR TITLE
Expose "bounce impact" and Storage Server "version catch-up rate" metrics

### DIFF
--- a/documentation/sphinx/source/mr-status-json-schemas.rst.inc
+++ b/documentation/sphinx/source/mr-status-json-schemas.rst.inc
@@ -118,6 +118,16 @@
                      "counter":0,
                      "roughness":0.0
                   },
+                  "fetched_versions":{
+                     "hz":0.0,
+                     "counter":0,
+                     "roughness":0.0
+                  },
+                  "fetches_from_logs":{
+                     "hz":0.0,
+                     "counter":0,
+                     "roughness":0.0
+                  },
                   "grv_latency_statistics":{
                      "default":{
                          "count":0,
@@ -580,6 +590,10 @@
       "data_distribution_disabled_for_rebalance":true,
       "data_distribution_disabled":true,
       "active_primary_dc":"pv",
+      "bounce_impact":{
+         "can_clean_bounce":true,
+         "reason":""
+      },
       "configuration":{
          "log_anti_quorum":0,
          "log_replicas":2,

--- a/documentation/sphinx/source/release-notes/release-notes-630.rst
+++ b/documentation/sphinx/source/release-notes/release-notes-630.rst
@@ -10,6 +10,9 @@ Release Notes
 * Added ``commit_batching_window_size`` to the proxy roles section of status to record statistics about commit batching window size on each proxy. `(PR #4736) <https://github.com/apple/foundationdb/pull/4736>`_
 * The multi-version client now requires at most two client connections with version 6.2 or larger, regardless of how many external clients are configured. Clients older than 6.2 will continue to create an additional connection each. `(PR #4667) <https://github.com/apple/foundationdb/pull/4667>`_
 * Fix an accounting error that could potentially result in inaccuracies in priority busyness metrics. `(PR #4824) <https://github.com/apple/foundationdb/pull/4824>`_
+* Added ``cluster.bounce_impact`` section to status to report if there will be any extra effects when bouncing the cluster, and if so, the reason for those effects. `(PR #4770) <https://github.com/apple/foundationdb/pull/>`_
+* Added ``fetched_versions`` to the storage metrics section of status to report how fast a storage server is catching up in versions. `(PR #4770) <https://github.com/apple/foundationdb/pull/>`_
+* Added ``fetches_from_logs`` to the storage metrics section of status to report how frequently a storage server fetches updates from transaction logs. `(PR #4770) <https://github.com/apple/foundationdb/pull/>`_
 
 6.3.12
 ======

--- a/documentation/sphinx/source/release-notes/release-notes-630.rst
+++ b/documentation/sphinx/source/release-notes/release-notes-630.rst
@@ -10,9 +10,9 @@ Release Notes
 * Added ``commit_batching_window_size`` to the proxy roles section of status to record statistics about commit batching window size on each proxy. `(PR #4736) <https://github.com/apple/foundationdb/pull/4736>`_
 * The multi-version client now requires at most two client connections with version 6.2 or larger, regardless of how many external clients are configured. Clients older than 6.2 will continue to create an additional connection each. `(PR #4667) <https://github.com/apple/foundationdb/pull/4667>`_
 * Fix an accounting error that could potentially result in inaccuracies in priority busyness metrics. `(PR #4824) <https://github.com/apple/foundationdb/pull/4824>`_
-* Added ``cluster.bounce_impact`` section to status to report if there will be any extra effects when bouncing the cluster, and if so, the reason for those effects. `(PR #4847) <https://github.com/apple/foundationdb/pull/4847>`_
-* Added ``fetched_versions`` to the storage metrics section of status to report how fast a storage server is catching up in versions. `(PR #4847) <https://github.com/apple/foundationdb/pull/4847>`_
-* Added ``fetches_from_logs`` to the storage metrics section of status to report how frequently a storage server fetches updates from transaction logs. `(PR #4847) <https://github.com/apple/foundationdb/pull/4847>`_
+* Added ``cluster.bounce_impact`` section to status to report if there will be any extra effects when bouncing the cluster, and if so, the reason for those effects. `(PR #4770) <https://github.com/apple/foundationdb/pull/4770>`_
+* Added ``fetched_versions`` to the storage metrics section of status to report how fast a storage server is catching up in versions. `(PR #4770) <https://github.com/apple/foundationdb/pull/4770>`_
+* Added ``fetches_from_logs`` to the storage metrics section of status to report how frequently a storage server fetches updates from transaction logs. `(PR #4770) <https://github.com/apple/foundationdb/pull/4770>`_
 
 6.3.12
 ======

--- a/documentation/sphinx/source/release-notes/release-notes-630.rst
+++ b/documentation/sphinx/source/release-notes/release-notes-630.rst
@@ -10,9 +10,9 @@ Release Notes
 * Added ``commit_batching_window_size`` to the proxy roles section of status to record statistics about commit batching window size on each proxy. `(PR #4736) <https://github.com/apple/foundationdb/pull/4736>`_
 * The multi-version client now requires at most two client connections with version 6.2 or larger, regardless of how many external clients are configured. Clients older than 6.2 will continue to create an additional connection each. `(PR #4667) <https://github.com/apple/foundationdb/pull/4667>`_
 * Fix an accounting error that could potentially result in inaccuracies in priority busyness metrics. `(PR #4824) <https://github.com/apple/foundationdb/pull/4824>`_
-* Added ``cluster.bounce_impact`` section to status to report if there will be any extra effects when bouncing the cluster, and if so, the reason for those effects. `(PR #4770) <https://github.com/apple/foundationdb/pull/>`_
-* Added ``fetched_versions`` to the storage metrics section of status to report how fast a storage server is catching up in versions. `(PR #4770) <https://github.com/apple/foundationdb/pull/>`_
-* Added ``fetches_from_logs`` to the storage metrics section of status to report how frequently a storage server fetches updates from transaction logs. `(PR #4770) <https://github.com/apple/foundationdb/pull/>`_
+* Added ``cluster.bounce_impact`` section to status to report if there will be any extra effects when bouncing the cluster, and if so, the reason for those effects. `(PR #4847) <https://github.com/apple/foundationdb/pull/4847>`_
+* Added ``fetched_versions`` to the storage metrics section of status to report how fast a storage server is catching up in versions. `(PR #4847) <https://github.com/apple/foundationdb/pull/4847>`_
+* Added ``fetches_from_logs`` to the storage metrics section of status to report how frequently a storage server fetches updates from transaction logs. `(PR #4847) <https://github.com/apple/foundationdb/pull/4847>`_
 
 6.3.12
 ======

--- a/fdbclient/Schemas.cpp
+++ b/fdbclient/Schemas.cpp
@@ -141,6 +141,16 @@ const KeyRef JSONSchemas::statusSchema = LiteralStringRef(R"statusSchema(
                      "counter":0,
                      "roughness":0.0
                   },
+                  "fetched_versions":{
+                     "hz":0.0,
+                     "counter":0,
+                     "roughness":0.0
+                  },
+                  "fetches_from_logs":{
+                     "hz":0.0,
+                     "counter":0,
+                     "roughness":0.0
+                  },
                   "grv_latency_statistics":{
                      "default":{
                         "count":0,
@@ -621,6 +631,10 @@ const KeyRef JSONSchemas::statusSchema = LiteralStringRef(R"statusSchema(
       "data_distribution_disabled_for_rebalance":true,
       "data_distribution_disabled":true,
       "active_primary_dc":"pv",
+      "bounce_impact":{
+         "can_clean_bounce":true,
+         "reason":""
+      },
       "configuration":{
          "log_anti_quorum":0,
          "log_replicas":2,

--- a/fdbserver/LogSystem.h
+++ b/fdbserver/LogSystem.h
@@ -407,6 +407,8 @@ struct ILogSystem {
 
 		virtual Optional<UID> getPrimaryPeekLocation() = 0;
 
+		virtual Optional<UID> getCurrentPeekLocation() = 0;
+
 		virtual void addref() = 0;
 
 		virtual void delref() = 0;
@@ -470,6 +472,7 @@ struct ILogSystem {
 		virtual Version popped();
 		virtual Version getMinKnownCommittedVersion();
 		virtual Optional<UID> getPrimaryPeekLocation();
+		virtual Optional<UID> getCurrentPeekLocation();
 
 		virtual void addref() { ReferenceCounted<ServerPeekCursor>::addref(); }
 
@@ -531,6 +534,7 @@ struct ILogSystem {
 		virtual Version popped();
 		virtual Version getMinKnownCommittedVersion();
 		virtual Optional<UID> getPrimaryPeekLocation();
+		virtual Optional<UID> getCurrentPeekLocation();
 
 		virtual void addref() { ReferenceCounted<MergedPeekCursor>::addref(); }
 
@@ -586,6 +590,7 @@ struct ILogSystem {
 		virtual Version popped();
 		virtual Version getMinKnownCommittedVersion();
 		virtual Optional<UID> getPrimaryPeekLocation();
+		virtual Optional<UID> getCurrentPeekLocation();
 
 		virtual void addref() { ReferenceCounted<SetPeekCursor>::addref(); }
 
@@ -617,6 +622,7 @@ struct ILogSystem {
 		virtual Version popped();
 		virtual Version getMinKnownCommittedVersion();
 		virtual Optional<UID> getPrimaryPeekLocation();
+		virtual Optional<UID> getCurrentPeekLocation();
 
 		virtual void addref() { ReferenceCounted<MultiCursor>::addref(); }
 
@@ -695,6 +701,7 @@ struct ILogSystem {
 		virtual Version popped();
 		virtual Version getMinKnownCommittedVersion();
 		virtual Optional<UID> getPrimaryPeekLocation();
+		virtual Optional<UID> getCurrentPeekLocation();
 
 		virtual void addref() { ReferenceCounted<BufferedCursor>::addref(); }
 

--- a/fdbserver/LogSystemPeekCursor.actor.cpp
+++ b/fdbserver/LogSystemPeekCursor.actor.cpp
@@ -390,10 +390,14 @@ Version ILogSystem::ServerPeekCursor::getMinKnownCommittedVersion() {
 }
 
 Optional<UID> ILogSystem::ServerPeekCursor::getPrimaryPeekLocation() {
-	if (interf) {
+	if (interf && interf->get().present()) {
 		return interf->get().id();
 	}
 	return Optional<UID>();
+}
+
+Optional<UID> ILogSystem::ServerPeekCursor::getCurrentPeekLocation() {
+	return ILogSystem::ServerPeekCursor::getPrimaryPeekLocation();
 }
 
 Version ILogSystem::ServerPeekCursor::popped() {
@@ -666,6 +670,13 @@ Version ILogSystem::MergedPeekCursor::getMinKnownCommittedVersion() {
 Optional<UID> ILogSystem::MergedPeekCursor::getPrimaryPeekLocation() {
 	if (bestServer >= 0) {
 		return serverCursors[bestServer]->getPrimaryPeekLocation();
+	}
+	return Optional<UID>();
+}
+
+Optional<UID> ILogSystem::MergedPeekCursor::getCurrentPeekLocation() {
+	if (currentCursor >= 0) {
+		return serverCursors[currentCursor]->getPrimaryPeekLocation();
 	}
 	return Optional<UID>();
 }
@@ -1020,6 +1031,13 @@ Optional<UID> ILogSystem::SetPeekCursor::getPrimaryPeekLocation() {
 	return Optional<UID>();
 }
 
+Optional<UID> ILogSystem::SetPeekCursor::getCurrentPeekLocation() {
+	if (currentCursor >= 0 && currentSet >= 0) {
+		return serverCursors[currentSet][currentCursor]->getPrimaryPeekLocation();
+	}
+	return Optional<UID>();
+}
+
 Version ILogSystem::SetPeekCursor::popped() {
 	Version poppedVersion = 0;
 	for (auto& cursors : serverCursors) {
@@ -1118,6 +1136,10 @@ Version ILogSystem::MultiCursor::getMinKnownCommittedVersion() {
 
 Optional<UID> ILogSystem::MultiCursor::getPrimaryPeekLocation() {
 	return cursors.back()->getPrimaryPeekLocation();
+}
+
+Optional<UID> ILogSystem::MultiCursor::getCurrentPeekLocation() {
+	return cursors.back()->getCurrentPeekLocation();
 }
 
 Version ILogSystem::MultiCursor::popped() {
@@ -1397,6 +1419,10 @@ Version ILogSystem::BufferedCursor::getMinKnownCommittedVersion() {
 }
 
 Optional<UID> ILogSystem::BufferedCursor::getPrimaryPeekLocation() {
+	return Optional<UID>();
+}
+
+Optional<UID> ILogSystem::BufferedCursor::getCurrentPeekLocation() {
 	return Optional<UID>();
 }
 

--- a/fdbserver/Status.actor.cpp
+++ b/fdbserver/Status.actor.cpp
@@ -387,6 +387,19 @@ JsonBuilderObject getLagObject(int64_t versions) {
 	return lag;
 }
 
+static JsonBuilderObject getBounceImpactInfo(int recoveryStatusCode) {
+	JsonBuilderObject bounceImpact;
+
+	if (recoveryStatusCode == RecoveryStatus::fully_recovered) {
+		bounceImpact["can_clean_bounce"] = true;
+	} else {
+		bounceImpact["can_clean_bounce"] = false;
+		bounceImpact["reason"] = "cluster hasn't fully recovered yet";
+	}
+
+	return bounceImpact;
+}
+
 struct MachineMemoryInfo {
 	double memoryUsage;
 	double aggregateLimit;
@@ -478,6 +491,8 @@ struct RolesInfo {
 			obj["mutation_bytes"] = StatusCounter(storageMetrics.getValue("MutationBytes")).getStatus();
 			obj["mutations"] = StatusCounter(storageMetrics.getValue("Mutations")).getStatus();
 			obj.setKeyRawNumber("local_rate", storageMetrics.getValue("LocalRate"));
+			obj["fetched_versions"] = StatusCounter(storageMetrics.getValue("FetchedVersions")).getStatus();
+			obj["fetches_from_logs"] = StatusCounter(storageMetrics.getValue("FetchesFromLogs")).getStatus();
 
 			Version version = storageMetrics.getInt64("Version");
 			Version durableVersion = storageMetrics.getInt64("DurableVersion");
@@ -1089,6 +1104,7 @@ ACTOR static Future<JsonBuilderObject> recoveryStateStatusFetcher(WorkerDetails 
 		} else if (mStatusCode == RecoveryStatus::locking_old_transaction_servers) {
 			message["missing_logs"] = md.getValue("MissingIDs").c_str();
 		}
+
 		// TODO:  time_in_recovery: 0.5
 		//        time_in_state: 0.1
 
@@ -2630,6 +2646,7 @@ ACTOR Future<StatusReply> clusterGetStatus(
 
 		statusObj["protocol_version"] = format("%" PRIx64, currentProtocolVersion.version());
 		statusObj["connection_string"] = coordinators.ccf->getConnectionString().toString();
+		statusObj["bounce_impact"] = getBounceImpactInfo(statusCode);
 
 		state Optional<DatabaseConfiguration> configuration;
 		state Optional<LoadConfigurationResult> loadResult;

--- a/fdbserver/Status.actor.cpp
+++ b/fdbserver/Status.actor.cpp
@@ -491,8 +491,13 @@ struct RolesInfo {
 			obj["mutation_bytes"] = StatusCounter(storageMetrics.getValue("MutationBytes")).getStatus();
 			obj["mutations"] = StatusCounter(storageMetrics.getValue("Mutations")).getStatus();
 			obj.setKeyRawNumber("local_rate", storageMetrics.getValue("LocalRate"));
-			obj["fetched_versions"] = StatusCounter(storageMetrics.getValue("FetchedVersions")).getStatus();
-			obj["fetches_from_logs"] = StatusCounter(storageMetrics.getValue("FetchesFromLogs")).getStatus();
+			try {
+				obj["fetched_versions"] = StatusCounter(storageMetrics.getValue("FetchedVersions")).getStatus();
+				obj["fetches_from_logs"] = StatusCounter(storageMetrics.getValue("FetchesFromLogs")).getStatus();
+			} catch (Error& e) {
+				if (e.code() != error_code_attribute_not_found)
+					throw e;
+			}
 
 			Version version = storageMetrics.getInt64("Version");
 			Version durableVersion = storageMetrics.getInt64("DurableVersion");


### PR DESCRIPTION
Expose "bounce impact" and Storage Server "version catch-up rate" metrics

Note: This is a cherry-pick of commit 4133e79c1fd4a1ae8930cb56899de57962799e71 (PR: https://github.com/apple/foundationdb/pull/4770).

- Report bounce impact in fdbcli status

Changes:

Schemas.cpp: Extend the JSON schema to include new fields that report
whether the cluster is bounceable and if not, report the reason for why it
is not bounceable.

Status.actor.cpp: Extend recoveryStateStatusFetcher() to populate the
bounce related field(s).

mr-status-json-schemas.rst.inc: Update the schema to reflect the change
made in Schemas.cpp.

release-notes-630.rst: Add a note about the new status fields in "Status"
section.

- Report how fast an SS is catching up to its tLog-SS lag

Changes:

LogSystem.h, LogSystemPeekCursor.actor.cpp: Add APIs to find the ID
of the tLog from which an SS has fetched the latest set of versions.

storagegroupserver.actor.cpp:

Add two new counters to StorageServer::Counters in order to capture
(a) SS version fetch rate and (b) SS version fetch frequency.

Add a new field to StorageServer in order to capture the ID of the tLog
from which the latest set of versions have been fetched.

update(): Populate the new counters; report the source tLog ID in a
trace event (and report the tLog ID only when it changes).

Status.actor.cpp: Extend Storage Server addRole() to report the SS
version fetch rate and the SS version fetch frequency.

Schemas.cpp: Extend the JSON schema to report the new metrics.

mr-status-json-schemas.rst.inc: Update the schema to reflect the
changes made to the JSON schema.

release-notes-630.rst: Add a note about the new metrics in "Status"
section.

Testing:

- Started simulation tests.

- Manual testing: Ran "status json" on a local cluster and verified that the new metrics
are getting populated:

        "bounce_impact" : {
            "can_clean_bounce" : true
        },


                        "fetched_versions" : {
                            "counter" : 159760104,
                            "hz" : 1237970,
                            "roughness" : 1689860
                        },
                        "fetches_from_logs" : {
                            "counter" : 167,
                            "hz" : 1.3999900000000001,
                            "roughness" : 0.91103299999999998
                        },

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
