### PR TITLE
Fix test to handle case where worker interface list is empty

### DIFF
--- a/fdbserver/workloads/SpecialKeySpaceCorrectness.actor.cpp
+++ b/fdbserver/workloads/SpecialKeySpaceCorrectness.actor.cpp
@@ -378,12 +378,13 @@ struct SpecialKeySpaceCorrectnessWorkload : TestWorkload {
 			    wait(tx->getRange(KeyRangeRef(LiteralStringRef("\xff\xff/worker_interfaces/"),
 			                                  LiteralStringRef("\xff\xff/worker_interfaces0")),
 			                      CLIENT_KNOBS->TOO_MANY));
-			// We should have at least 1 process in the cluster
-			ASSERT(result.size());
-			state KeyValueRef entry = deterministicRandom()->randomChoice(result);
-			Optional<Value> singleRes = wait(tx->get(entry.key));
-			ASSERT(singleRes.present() && singleRes.get() == entry.value);
-			tx->reset();
+			// Note: there's possibility we get zero workers
+			if (result.size()) {
+				state KeyValueRef entry = deterministicRandom()->randomChoice(result);
+				Optional<Value> singleRes = wait(tx->get(entry.key));
+				if (singleRes.present())
+					ASSERT(singleRes.get() == entry.value);
+			}
 		} catch (Error& e) {
 			wait(tx->onError(e));
 		}


### PR DESCRIPTION
This backports a test fix introduced in https://github.com/apple/foundationdb/pull/4255/ to resolve a correctness issue on the release-6.3 branch. Note this is not done as a cherry pick because the original commit that made this change was part of a much larger change.

This change already exists on both master and release-7.0.

Passed 100K correctness with 1 failure in a different test.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [x] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [x] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
