### PR TITLE
Removing spaces in SevWarn trace event names

### DIFF
--- a/fdbserver/FDBExecHelper.actor.cpp
+++ b/fdbserver/FDBExecHelper.actor.cpp
@@ -148,7 +148,10 @@ ACTOR Future<int> spawnProcess(std::string path,
 	state pid_t pid = pidAndReadFD.first;
 	state Optional<int> readFD = pidAndReadFD.second;
 	if (pid == -1) {
-		TraceEvent(SevWarnAlways, "SpawnProcess: Command failed to spawn").detail("Cmd", path).detail("Args", allArgs);
+		TraceEvent(SevWarnAlways, "SpawnProcessFailure")
+		    .detail("Reason", "Command failed to spawn")
+		    .detail("Cmd", path)
+		    .detail("Args", allArgs);
 		return -1;
 	} else if (pid > 0) {
 		state int status = -1;
@@ -160,7 +163,8 @@ ACTOR Future<int> spawnProcess(std::string path,
 			if (runTime > maxWaitTime) {
 				// timing out
 
-				TraceEvent(SevWarnAlways, "SpawnProcess : Command failed, timeout")
+				TraceEvent(SevWarnAlways, "SpawnProcessFailure")
+				    .detail("Reason", "Command failed, timeout")
 				    .detail("Cmd", path)
 				    .detail("Args", allArgs);
 				return -1;
@@ -175,9 +179,10 @@ ACTOR Future<int> spawnProcess(std::string path,
 			}
 
 			if (err < 0) {
-				TraceEvent event(SevWarnAlways, "SpawnProcess : Command failed");
+				TraceEvent event(SevWarnAlways, "SpawnProcessFailure");
 				setupTraceWithOutput(event, bytesRead, outputBuffer);
-				event.detail("Cmd", path)
+				event.detail("Reason", "Command failed")
+				    .detail("Cmd", path)
 				    .detail("Args", allArgs)
 				    .detail("Errno", WIFEXITED(status) ? WEXITSTATUS(status) : -1);
 				return -1;
@@ -194,14 +199,15 @@ ACTOR Future<int> spawnProcess(std::string path,
 			} else {
 				// child process completed
 				if (!(WIFEXITED(status) && WEXITSTATUS(status) == 0)) {
-					TraceEvent event(SevWarnAlways, "SpawnProcess : Command failed");
+					TraceEvent event(SevWarnAlways, "SpawnProcessFailure");
 					setupTraceWithOutput(event, bytesRead, outputBuffer);
-					event.detail("Cmd", path)
+					event.detail("Reason", "Command failed")
+					    .detail("Cmd", path)
 					    .detail("Args", allArgs)
 					    .detail("Errno", WIFEXITED(status) ? WEXITSTATUS(status) : -1);
 					return WIFEXITED(status) ? WEXITSTATUS(status) : -1;
 				}
-				TraceEvent event("SpawnProcess : Command status");
+				TraceEvent event("SpawnProcess_CommandStatus");
 				setupTraceWithOutput(event, bytesRead, outputBuffer);
 				event.detail("Cmd", path)
 				    .detail("Args", allArgs)


### PR DESCRIPTION
I hit a simulation failure where the test harness tried to output these SevWarn messages into the summary, which failed because the test harness makes the XML element name the trace event Type, and xml element names cannot contain spaces. I changed all of these to not have spaces in the trace event type, and added a detail field with the failure reason instead.

My only concern would be if there was some sort of automation looking for these specific event types, and changing the name broke that, but I couldn't find any in the test harness or in joshua.

This passed 10k correctness runs.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
