### PR TITLE
Make fdbmonitor understand $PID, so that --parentpid is usable on fdbserver

### DIFF
--- a/documentation/sphinx/source/configuration.rst
+++ b/documentation/sphinx/source/configuration.rst
@@ -300,6 +300,7 @@ Contains default parameters for all fdbserver processes on this machine. These s
 * ``locality_dcid``: Datacenter identifier key. All processes physically located in a datacenter should share the id. No default value. If you are depending on datacenter based replication this must be set on all processes.
 * ``locality_data_hall``: Data hall identifier key. All processes physically located in a data hall should share the id. No default value. If you are depending on data hall based replication this must be set on all processes.
 * ``io_trust_seconds``: Time in seconds that a read or write operation is allowed to take before timing out with an error. If an operation times out, all future operations on that file will fail with an error as well. Only has an effect when using AsyncFileKAIO in Linux. If unset, defaults to 0 which means timeout is disabled.
+* ``parentpid``: Die if the process ID of its parent differs from the one given.  The argument should always be ``$PID``, which will be substituted with the process ID of fdbmonitor.  Using this parameter will cause all fdbserver processes started by fdbmonitor to die if fdbmonitor is killed.
 
 .. note:: In addition to the options above, TLS settings as described for the :ref:`TLS plugin <configuring-tls>` can be specified in the [fdbserver] section.
 

--- a/fdbmonitor/fdbmonitor.cpp
+++ b/fdbmonitor/fdbmonitor.cpp
@@ -504,6 +504,8 @@ public:
 
 		const char* id_s = ssection.c_str() + strlen(section.c_str()) + 1;
 
+		const std::string pid_s = std::to_string(getpid());
+
 		for (auto i : keys) {
 			if (!strcmp(i.pItem, "command") || !strcmp(i.pItem, "restart_delay") ||
 			    !strcmp(i.pItem, "initial_restart_delay") || !strcmp(i.pItem, "restart_backoff") ||
@@ -515,9 +517,12 @@ public:
 			std::string opt = get_value_multi(ini, i.pItem, ssection.c_str(), section.c_str(), "general", nullptr);
 
 			std::size_t pos = 0;
-
 			while ((pos = opt.find("$ID", pos)) != opt.npos)
 				opt.replace(pos, 3, id_s, strlen(id_s));
+
+			pos = 0;
+			while ((pos = opt.find("$PID", pos)) != opt.npos)
+				opt.replace(pos, 4, pid_s);
 
 			const char* flagName = i.pItem + 5;
 			if (strncmp("flag_", i.pItem, 5) == 0 && strlen(flagName) > 0) {


### PR DESCRIPTION
Previously, --parentpid was only supported on windows.  #1496 extended that to other platforms for a CI usecase.  On Linux, `prctl(PR_SET_PDEATHSIG, SIGHUP)` should arrange for the subsequently exec()'d fdbserver to get a SIGHUP and die if fdbmonitor is killed.  In local testing, I've confirmed that this works, but I've also seen evidence that on some hosts/clusters it appears to possibly not work.

Therefore, having --parentpid as a backup for the cases where it seems like hosts might not properly support PR_SET_PDEATHSIG is nice.

This was tested by running a local cluster, and confirming that $PID is properly translated into the fdbmonitor process ID.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
