### PR TITLE
Decrease maximumTotalData in WriteDuringRead workload

### DIFF
--- a/fdbserver/workloads/WriteDuringRead.actor.cpp
+++ b/fdbserver/workloads/WriteDuringRead.actor.cpp
@@ -55,7 +55,7 @@ struct WriteDuringReadWorkload : TestWorkload {
 		slowModeStart = getOption(options, LiteralStringRef("slowModeStart"), 1000.0);
 		numOps = getOption(options, LiteralStringRef("numOps"), 21);
 		rarelyCommit = getOption(options, LiteralStringRef("rarelyCommit"), false);
-		maximumTotalData = getOption(options, LiteralStringRef("maximumTotalData"), 7e6);
+		maximumTotalData = getOption(options, LiteralStringRef("maximumTotalData"), 3e6);
 		minNode = getOption(options, LiteralStringRef("minNode"), 0);
 		useSystemKeys = getOption(options, LiteralStringRef("useSystemKeys"), deterministicRandom()->random01() < 0.5);
 		adjacentKeys = deterministicRandom()->random01() < 0.5;


### PR DESCRIPTION
This is a backport of #3989.

This fixes an "Out of Memory" error in the WriteDuringReadClean test (#3988)

Passed 10K correctness.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [x] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [x] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [x] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
