### PR TITLE
Not doing timeout check in WriteDuringRead if simulation is injecting…

### DIFF
--- a/fdbserver/workloads/WriteDuringRead.actor.cpp
+++ b/fdbserver/workloads/WriteDuringRead.actor.cpp
@@ -734,7 +734,9 @@ ACTOR Future<Void> randomTransaction(Database cx, WriteDuringReadWorkload* self,
 	state bool readAheadDisabled = deterministicRandom()->random01() < 0.5;
 	state bool snapshotRYWDisabled = deterministicRandom()->random01() < 0.5;
 	state bool useBatchPriority = deterministicRandom()->random01() < 0.5;
-	state int64_t timebomb = deterministicRandom()->random01() < 0.01 ? deterministicRandom()->randomInt64(1, 6000) : 0;
+	state int64_t timebomb = (FLOW_KNOBS->MAX_BUGGIFIED_DELAY == 0.0 && deterministicRandom()->random01() < 0.01)
+	                             ? deterministicRandom()->randomInt64(1, 6000)
+	                             : 0; // timebomb check can fail incorrectly if simulation injects delay longer than the timebomb
 	state std::vector<Future<Void>> operations;
 	state ActorCollection commits(false);
 	state std::vector<Future<Void>> watches;


### PR DESCRIPTION
In TSS testing I hit this simulation bug.
With low probability, WriteDuringRead tests the transaction timeout feature by setting a timeout on the transaction, and ensuring operations finish within that timeout.
Under normal circumstances this check would work, but simulation can add arbitrary delay to tasks, causing the timeout check to generate a false negative.
In the test I saw, all operations finished in time, but the call back into the waiting actor got a delay injected that was larger than the set timeout, so the check failed.
My proposed fix is to disable the timeout + check if run loop delay injection is enabled in simulation, but if anyone thinks there is a better fix, I'm open to that as well.

I tested that the fix worked on my failing test, and ran 10k runs of just the *WriteDuringRead* tests, which all passed.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
