### PR TITLE
Fix two valgrind false positives

### DIFF
--- a/fdbserver/IPager.h
+++ b/fdbserver/IPager.h
@@ -56,9 +56,6 @@ public:
 		if (userData != nullptr && userDataDestructor != nullptr) {
 			userDataDestructor(userData);
 		}
-		if (buffer != nullptr) {
-			VALGRIND_MAKE_MEM_UNDEFINED(buffer, bufferSize);
-		}
 	}
 
 	uint8_t const* begin() const { return (uint8_t*)buffer; }

--- a/flow/Arena.cpp
+++ b/flow/Arena.cpp
@@ -241,10 +241,11 @@ void* ArenaBlock::make4kAlignedBuffer(uint32_t size) {
 	r->aligned4kBuffer = allocateFast4kAligned(size);
 	// printf("Arena::aligned4kBuffer alloc size=%u ptr=%p\n", size, r->aligned4kBuffer);
 	r->nextBlockOffset = nextBlockOffset;
+	auto result = r->aligned4kBuffer;
 	makeNoAccess(r, sizeof(ArenaBlockRef));
 	nextBlockOffset = bigUsed;
 	bigUsed += sizeof(ArenaBlockRef);
-	return r->aligned4kBuffer;
+	return result;
 }
 
 void ArenaBlock::dependOn(Reference<ArenaBlock>& self, ArenaBlock* other) {


### PR DESCRIPTION
Previously, when running with FDB_VALGRIND_PRECISE, we would see a false positive since we dereferenced memory immediately after marking it no access. Also it no longer makes sense to mark an ArenaPage's buffer as anything but accessible in the destructor since ArenaPages have shared ownership of their buffers. Tested by re-running a failing valgrind seed and seeing it pass (no simulator behavior changes in this PR).

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
