### PR TITLE
Fix: when a file open completes synchronously, it wasn't being stored in the openFiles map

### DIFF
--- a/fdbrpc/AsyncFileCached.actor.h
+++ b/fdbrpc/AsyncFileCached.actor.h
@@ -141,16 +141,19 @@ public:
 	// Opens a file that uses the FDB in-memory page cache
 	static Future<Reference<IAsyncFile>> open(std::string filename, int flags, int mode) {
 		//TraceEvent("AsyncFileCachedOpen").detail("Filename", filename);
-		if (openFiles.find(filename) == openFiles.end()) {
+		auto itr = openFiles.find(filename);
+		if (itr == openFiles.end()) {
 			auto f = open_impl(filename, flags, mode);
 			if (f.isReady() && f.isError())
 				return f;
-			if (!f.isReady())
-				openFiles[filename] = UnsafeWeakFutureReference<IAsyncFile>(f);
-			else
-				return f.get();
+
+			itr = openFiles.try_emplace(filename, f).first;
+
+			// We return here instead of falling through to the outer scope so that we don't delete all references to
+			// the underlying file before returning
+			return itr->second.get();
 		}
-		return openFiles[filename].get();
+		return itr->second.get();
 	}
 
 	Future<int> read(void* data, int length, int64_t offset) override {

--- a/fdbrpc/AsyncFileCached.actor.h
+++ b/fdbrpc/AsyncFileCached.actor.h
@@ -147,7 +147,11 @@ public:
 			if (f.isReady() && f.isError())
 				return f;
 
-			itr = openFiles.try_emplace(filename, f).first;
+			auto result = openFiles.try_emplace(filename, f);
+
+			// This should be inserting a new entry
+			ASSERT(result.second);
+			itr = result.first;
 
 			// We return here instead of falling through to the outer scope so that we don't delete all references to
 			// the underlying file before returning


### PR DESCRIPTION
Fixes bug introduced in #4893 and resolves #4897.

The refactoring of AsyncFileCached changed the implementation of `open_impl` so that it wasn't modifying anything in `openFiles` directly. In the case where a file was opened synchronously, this code path had been responsible for implicitly inserting an entry into the map.

This fix changes `open` so that an entry is inserted into the map regardless of whether it is ready.

This bug is not currently reproducible in simulation (see #4901), so the fix was verified with a real-world cluster. Previously configuring a cluster would trigger assertion failures, and it now does not.

Passed 10K correctness.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
