### PR TITLE
7.0 cherrypick - Not doing timeout check in WriteDuringRead if simulation is injecting…

### DIFF
--- a/fdbserver/workloads/WriteDuringRead.actor.cpp
+++ b/fdbserver/workloads/WriteDuringRead.actor.cpp
@@ -734,7 +734,9 @@ ACTOR Future<Void> randomTransaction(Database cx, WriteDuringReadWorkload* self,
 	state bool readAheadDisabled = deterministicRandom()->random01() < 0.5;
 	state bool snapshotRYWDisabled = deterministicRandom()->random01() < 0.5;
 	state bool useBatchPriority = deterministicRandom()->random01() < 0.5;
-	state int64_t timebomb = deterministicRandom()->random01() < 0.01 ? deterministicRandom()->randomInt64(1, 6000) : 0;
+	state int64_t timebomb = (FLOW_KNOBS->MAX_BUGGIFIED_DELAY == 0.0 && deterministicRandom()->random01() < 0.01)
+	                             ? deterministicRandom()->randomInt64(1, 6000)
+	                             : 0; // timebomb check can fail incorrectly if simulation injects delay longer than the timebomb
 	state std::vector<Future<Void>> operations;
 	state ActorCollection commits(false);
 	state std::vector<Future<Void>> watches;


### PR DESCRIPTION
… arbitrary delays

Fixes a simulation failure on 7.0, cherrypick of https://github.com/apple/foundationdb/pull/4893.
Passes 10k correctness runs of only WriteDuringRead variants.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [x] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [x] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [x] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
