### PR TITLE
Add openssl for TLS debugging

### DIFF
--- a/packaging/docker/release/Dockerfile
+++ b/packaging/docker/release/Dockerfile
@@ -31,7 +31,8 @@ RUN apt-get update && \
 		less>=487-0.1 \
 		vim>=2:8.0.1453-1ubuntu1.4 \
 		net-tools>=1.60+git20161116.90da8a0-1ubuntu1 \
-		jq>=1.5+dfsg-2 && \
+		jq>=1.5+dfsg-2 \
+        openssl>=1.1.1-1ubuntu2.1~18.04.9 && \
 	rm -rf /var/lib/apt/lists/*
 
 COPY misc/tini-amd64.sha256sum /tmp/

--- a/packaging/docker/release/Dockerfile
+++ b/packaging/docker/release/Dockerfile
@@ -2,7 +2,7 @@
 #
 # This source file is part of the FoundationDB open source project
 #
-# Copyright 2013-2018 Apple Inc. and the FoundationDB project authors
+# Copyright 2013-2021 Apple Inc. and the FoundationDB project authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -32,7 +32,7 @@ RUN apt-get update && \
 		vim>=2:8.0.1453-1ubuntu1.4 \
 		net-tools>=1.60+git20161116.90da8a0-1ubuntu1 \
 		jq>=1.5+dfsg-2 \
-        openssl>=1.1.1-1ubuntu2.1~18.04.9 && \
+		openssl>=1.1.1-1ubuntu2.1~18.04.9 && \
 	rm -rf /var/lib/apt/lists/*
 
 COPY misc/tini-amd64.sha256sum /tmp/


### PR DESCRIPTION
Adding `openssl` for debugging TLS related issues.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [x] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [x] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
