### PR TITLE
Fix the place when changing dd system key without changing the lock key

### DIFF
--- a/fdbclient/SpecialKeySpace.actor.cpp
+++ b/fdbclient/SpecialKeySpace.actor.cpp
@@ -2061,9 +2061,20 @@ Future<Optional<std::string>> DataDistributionImpl::commit(ReadYourWritesTransac
 				try {
 					int mode = boost::lexical_cast<int>(iter->value().second.get().toString());
 					Value modeVal = BinaryWriter::toValue(mode, Unversioned());
-					if (mode == 0 || mode == 1)
+					if (mode == 0 || mode == 1) {
+						// Whenever configuration changes or DD related system keyspace is changed,
+						// actor must grab the moveKeysLockOwnerKey and update moveKeysLockWriteKey.
+						// This prevents concurrent write to the same system keyspace.
+						// When the owner of the DD related system keyspace changes, DD will reboot
+						BinaryWriter wrMyOwner(Unversioned());
+						wrMyOwner << dataDistributionModeLock;
+						ryw->getTransaction().set(moveKeysLockOwnerKey, wrMyOwner.toValue());
+						BinaryWriter wrLastWrite(Unversioned());
+						wrLastWrite << deterministicRandom()->randomUniqueID();
+						ryw->getTransaction().set(moveKeysLockWriteKey, wrLastWrite.toValue());
+						// set mode
 						ryw->getTransaction().set(dataDistributionModeKey, modeVal);
-					else
+					} else
 						msg = ManagementAPIError::toJsonString(false,
 						                                       "datadistribution",
 						                                       "Please set the value of the data_distribution/mode to "

--- a/fdbserver/workloads/SpecialKeySpaceCorrectness.actor.cpp
+++ b/fdbserver/workloads/SpecialKeySpaceCorrectness.actor.cpp
@@ -624,7 +624,7 @@ struct SpecialKeySpaceCorrectnessWorkload : TestWorkload {
 
 	ACTOR Future<Void> managementApiCorrectnessActor(Database cx_, SpecialKeySpaceCorrectnessWorkload* self) {
 		// All management api related tests
-		Database cx = cx_->clone();
+		state Database cx = cx_->clone();
 		state Reference<ReadYourWritesTransaction> tx = makeReference<ReadYourWritesTransaction>(cx);
 		// test ordered option keys
 		{
@@ -1423,6 +1423,40 @@ struct SpecialKeySpaceCorrectnessWorkload : TestWorkload {
 					break;
 				} catch (Error& e) {
 					wait(tx->onError(e));
+				}
+			}
+		}
+		// make sure when we change dd related special keys, we grab the two system keys,
+		// i.e. moveKeysLockOwnerKey and moveKeysLockWriteKey
+		{
+			state Reference<ReadYourWritesTransaction> tr1(new ReadYourWritesTransaction(cx));
+			state Reference<ReadYourWritesTransaction> tr2(new ReadYourWritesTransaction(cx));
+			loop {
+				try {
+					Version readVersion = wait(tr1->getReadVersion());
+					tr2->setVersion(readVersion);
+					tr1->setOption(FDBTransactionOptions::SPECIAL_KEY_SPACE_ENABLE_WRITES);
+					tr2->setOption(FDBTransactionOptions::READ_SYSTEM_KEYS);
+					KeyRef ddPrefix = SpecialKeySpace::getManagementApiCommandPrefix("datadistribution");
+					tr1->set(LiteralStringRef("mode").withPrefix(ddPrefix), LiteralStringRef("1"));
+					wait(tr1->commit());
+					// randomly read the moveKeysLockOwnerKey/moveKeysLockWriteKey
+					// both of them should be grabbed when changing dd mode
+					wait(success(
+					    tr2->get(deterministicRandom()->coinflip() ? moveKeysLockOwnerKey : moveKeysLockWriteKey)));
+					// tr2 shoulde never succeed, just write to a key to make it not a read-only transaction
+					tr2->set(LiteralStringRef("unused_key"), LiteralStringRef(""));
+					wait(tr2->commit());
+					ASSERT(false); // commit should always fail due to conflict
+				} catch (Error& e) {
+					if (e.code() != error_code_not_committed) {
+						// when buggify is enabled, it's possible we get other retriable errors
+						wait(tr2->onError(e));
+						tr1->reset();
+					} else {
+						// loop until we get conflict error
+						break;
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Cherry-pick PR #4877  , the transaction should grab moveKeysLockOwnerKey and moveKeysLockWriteKey when update data distribution related system keys.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [x] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [x] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
