### PR TITLE
Properly set simulation test for perpetual storage wiggle and bug fixing

### DIFF
--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -4073,6 +4073,8 @@ ACTOR Future<Void> perpetualStorageWiggler(AsyncTrigger* stopSignal,
 
 	if (self->wigglingPid.present()) {
 		self->includeStorageServersForWiggle(self->wigglingPid.get());
+		TraceEvent("PerpetualStorageWiggleExitingPause", self->distributorId)
+			.detail("ProcessId", self->wigglingPid.get());
 		self->wigglingPid.reset();
 	}
 

--- a/fdbserver/DataDistributionQueue.actor.cpp
+++ b/fdbserver/DataDistributionQueue.actor.cpp
@@ -993,7 +993,7 @@ ACTOR Future<Void> dataDistributionRelocator(DDQueueData* self, RelocateData rd,
 				allHealthy = true;
 				anyWithSource = false;
 				bestTeams.clear();
-				// Get team from teamCollections in diffrent DCs and find the best one
+				// Get team from teamCollections in different DCs and find the best one
 				while (tciIndex < self->teamCollections.size()) {
 					double inflightPenalty = SERVER_KNOBS->INFLIGHT_PENALTY_HEALTHY;
 					if (rd.healthPriority == SERVER_KNOBS->PRIORITY_TEAM_UNHEALTHY ||

--- a/fdbserver/Knobs.cpp
+++ b/fdbserver/Knobs.cpp
@@ -131,7 +131,7 @@ void ServerKnobs::initialize(bool randomize, ClientKnobs* clientKnobs, bool isSi
 	init( PRIORITY_RECOVER_MOVE,                                 110 );
 	init( PRIORITY_REBALANCE_UNDERUTILIZED_TEAM,                 120 );
 	init( PRIORITY_REBALANCE_OVERUTILIZED_TEAM,                  121 );
-	init( PRIORITY_PERPETUAL_STORAGE_WIGGLE,                     140 );
+	init( PRIORITY_PERPETUAL_STORAGE_WIGGLE,                     139 );
 	init( PRIORITY_TEAM_HEALTHY,                                 140 );
 	init( PRIORITY_TEAM_CONTAINS_UNDESIRED_SERVER,               150 );
 	init( PRIORITY_TEAM_REDUNDANT,                               200 );

--- a/fdbserver/workloads/ConsistencyCheck.actor.cpp
+++ b/fdbserver/workloads/ConsistencyCheck.actor.cpp
@@ -1777,6 +1777,7 @@ struct ConsistencyCheckWorkload : TestWorkload {
 				if (!found) {
 					TraceEvent("ConsistencyCheck_NoStorage")
 					    .detail("Address", addr)
+					    .detail("ProcessId", workers[i].interf.locality.processId())
 					    .detail("ProcessClassEqualToStorageClass",
 					            (int)(workers[i].processClass == ProcessClass::StorageClass));
 					missingStorage.push_back(workers[i].interf.locality.dcId());

--- a/fdbserver/workloads/workloads.actor.h
+++ b/fdbserver/workloads/workloads.actor.h
@@ -159,6 +159,7 @@ public:
 		simConnectionFailuresDisableDuration = 0;
 		simBackupAgents = ISimulator::BackupAgentType::NoBackupAgents;
 		simDrAgents = ISimulator::BackupAgentType::NoBackupAgents;
+		restorePerpetualWiggleSetting = true;
 	}
 	TestSpec(StringRef title,
 	         bool dump,
@@ -169,8 +170,8 @@ public:
 	  : title(title), dumpAfterTest(dump), clearAfterTest(clear), startDelay(startDelay), useDB(useDB), timeout(600),
 	    databasePingDelay(databasePingDelay), runConsistencyCheck(g_network->isSimulated()),
 	    runConsistencyCheckOnCache(false), runConsistencyCheckOnTSS(false), waitForQuiescenceBegin(true),
-	    waitForQuiescenceEnd(true), simCheckRelocationDuration(false), simConnectionFailuresDisableDuration(0),
-	    simBackupAgents(ISimulator::BackupAgentType::NoBackupAgents),
+	    waitForQuiescenceEnd(true), restorePerpetualWiggleSetting(true), simCheckRelocationDuration(false),
+	    simConnectionFailuresDisableDuration(0), simBackupAgents(ISimulator::BackupAgentType::NoBackupAgents),
 	    simDrAgents(ISimulator::BackupAgentType::NoBackupAgents) {
 		phases = TestWorkload::SETUP | TestWorkload::EXECUTION | TestWorkload::CHECK | TestWorkload::METRICS;
 		if (databasePingDelay < 0)
@@ -191,6 +192,11 @@ public:
 	bool runConsistencyCheckOnTSS;
 	bool waitForQuiescenceBegin;
 	bool waitForQuiescenceEnd;
+	bool restorePerpetualWiggleSetting; // whether set perpetual_storage_wiggle as the value after run
+	                                      // QuietDatabase. QuietDatabase always disables perpetual storage wiggle on
+	                                      // purpose. If waitForQuiescenceBegin == true and we want to keep perpetual
+	                                      // storage wiggle the same setting as before during testing, this value should
+	                                      // be set true.
 
 	bool simCheckRelocationDuration; // If set to true, then long duration relocations generate SevWarnAlways messages.
 	                                 // Once any workload sets this to true, it will be true for the duration of the


### PR DESCRIPTION
1. Modify simulation test setting: properly set perpetual_storage_wiggle value to its original value. This change makes all test of which waitQuiescentStart=true also can test perpetual wiggle.
2. Fix time-out bug. Sometimes invalid wiggle server appears because the data distributor changing prevents the wiggler from properly setting the status to NONE, which makes this server unavailable afterward. If the number of invalid wiggle server keep increasing, finally the cluster will be unavailable. This PR let servers check whether they are invalid wiggling server and set themselves healthy if so to fix the bug.
3. Fix the double wigglers bug. Now only primary DC can have a wiggler that controls both primary DC and secondary DC wiggle.
4. Add trace details to help debug; Code refactor.

100k 100% wiggle on test pass.
# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
