### PR TITLE
Add a backwards-compatible 'proxies' field to status json (release-7.0)

### DIFF
--- a/documentation/sphinx/source/mr-status-json-schemas.rst.inc
+++ b/documentation/sphinx/source/mr-status-json-schemas.rst.inc
@@ -530,7 +530,7 @@
                "hz":0.0,
                "counter":0,
                "roughness":0.0
-            }, 
+            },
              "low_priority_reads":{ // measures number of incoming low priority read requests
                "hz":0.0,
                "counter":0,
@@ -692,7 +692,8 @@
          "auto_resolvers":1,
          "auto_logs":3,
          "backup_worker_enabled":1,
-         "commit_proxies":5 // this field will be absent if a value has not been explicitly set
+         "commit_proxies":5, // this field will be absent if a value has not been explicitly set
+         "proxies":6 // this field will be absent if a value has not been explicitly set
       },
       "data":{
          "least_operating_space_bytes_log_server":0,

--- a/fdbclient/DatabaseConfiguration.cpp
+++ b/fdbclient/DatabaseConfiguration.cpp
@@ -317,14 +317,26 @@ StatusObject DatabaseConfiguration::toJSON(bool noPolicies) const {
 		result["regions"] = getRegionJSON();
 	}
 
+	// Add to the `proxies` count for backwards compatibility with tools built before 7.0.
+	int32_t proxyCount = -1;
 	if (desiredTLogCount != -1 || isOverridden("logs")) {
 		result["logs"] = desiredTLogCount;
 	}
 	if (commitProxyCount != -1 || isOverridden("commit_proxies")) {
 		result["commit_proxies"] = commitProxyCount;
+		if (proxyCount != -1) {
+			proxyCount += commitProxyCount;
+		} else {
+			proxyCount = commitProxyCount;
+		}
 	}
 	if (grvProxyCount != -1 || isOverridden("grv_proxies")) {
 		result["grv_proxies"] = grvProxyCount;
+		if (proxyCount != -1) {
+			proxyCount += grvProxyCount;
+		} else {
+			proxyCount = grvProxyCount;
+		}
 	}
 	if (resolverCount != -1 || isOverridden("resolvers")) {
 		result["resolvers"] = resolverCount;
@@ -349,6 +361,9 @@ StatusObject DatabaseConfiguration::toJSON(bool noPolicies) const {
 	}
 	if (autoDesiredTLogCount != CLIENT_KNOBS->DEFAULT_AUTO_LOGS || isOverridden("auto_logs")) {
 		result["auto_logs"] = autoDesiredTLogCount;
+	}
+	if (proxyCount != -1) {
+		result["proxies"] = proxyCount;
 	}
 
 	result["backup_worker_enabled"] = (int32_t)backupWorkerEnabled;

--- a/fdbclient/Schemas.cpp
+++ b/fdbclient/Schemas.cpp
@@ -741,7 +741,8 @@ const KeyRef JSONSchemas::statusSchema = LiteralStringRef(R"statusSchema(
          "auto_logs":3,
          "commit_proxies":5,
          "grv_proxies":1,
-         "backup_worker_enabled":1
+         "backup_worker_enabled":1,
+         "proxies":6
       },
       "data":{
          "least_operating_space_bytes_log_server":0,


### PR DESCRIPTION
Cherry-pick https://github.com/apple/foundationdb/pull/4922 to release-7.0

The underlying problem was that the k8s operator was looking for a "proxies" field in the status json that was no longer present. Because of that, the operator thought that the database configuration was improperly applied, so it would repeatedly call configure through the fdbcli. Each call to configure interrupted data distribution initialization. DD would only start when the initialization managed to be fast enough to finish prior to the successive configure call.

The backwards compatible field ignores the auto proxies. I think this is the correct design, but I'm unsure.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
