### PR TITLE
Add AWS CLI tool for downloading from s3 (release-7.0)

### DIFF
--- a/packaging/docker/Dockerfile.eks
+++ b/packaging/docker/Dockerfile.eks
@@ -16,9 +16,13 @@ RUN yum install -y \
   traceroute \
   telnet \
   tcpdump \
+  unzip \
   vim
 
 #todo: nload, iperf, numademo
+
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.0.30.zip" -o "awscliv2.zip" \
+    &&  unzip awscliv2.zip && ./aws/install && rm -rf aws
 
 COPY misc/tini-amd64.sha256sum /tmp/
 # Adding tini as PID 1 https://github.com/krallin/tini


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/foundationdb/pull/4899

To enable fast loading of YCSB data into EKS clusters, this adds the aws cli tool used to download from s3.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
