### PR TITLE
add epoch info to trace events when tLog begins (for release-6.3)

### DIFF
--- a/fdbserver/OldTLogServer_6_2.actor.cpp
+++ b/fdbserver/OldTLogServer_6_2.actor.cpp
@@ -2818,7 +2818,10 @@ ACTOR Future<Void> restorePersistentState(TLogData* self,
 		removed.push_back(errorOr(logData->removed));
 		logsByVersion.emplace_back(ver, id1);
 
-		TraceEvent("TLogPersistentStateRestore", self->dbgid).detail("LogId", logData->logId).detail("Ver", ver);
+		TraceEvent("TLogPersistentStateRestore", self->dbgid)
+			.detail("LogId", logData->logId)
+			.detail("Ver", ver)
+			.detail("RecoveryCount", logData->recoveryCount);
 		// Restore popped keys.  Pop operations that took place after the last (committed) updatePersistentDataVersion
 		// might be lost, but that is fine because we will get the corresponding data back, too.
 		tagKeys = prefixRange(rawId.withPrefix(persistTagPoppedKeys.begin));
@@ -3056,7 +3059,7 @@ ACTOR Future<Void> tLogStart(TLogData* self, InitializeTLogRequest req, Locality
 	self->popOrder.push_back(recruited.id());
 	self->spillOrder.push_back(recruited.id());
 
-	TraceEvent("TLogStart", logData->logId);
+	TraceEvent("TLogStart", logData->logId).detail("RecoveryCount", logData->recoveryCount);
 
 	state Future<Void> updater;
 	state bool pulledRecoveryVersions = false;

--- a/fdbserver/TLogServer.actor.cpp
+++ b/fdbserver/TLogServer.actor.cpp
@@ -2870,7 +2870,10 @@ ACTOR Future<Void> restorePersistentState(TLogData* self,
 		removed.push_back(errorOr(logData->removed));
 		logsByVersion.emplace_back(ver, id1);
 
-		TraceEvent("TLogPersistentStateRestore", self->dbgid).detail("LogId", logData->logId).detail("Ver", ver);
+		TraceEvent("TLogPersistentStateRestore", self->dbgid)
+			.detail("LogId", logData->logId)
+			.detail("Ver", ver)
+			.detail("RecoveryCount", logData->recoveryCount);
 		// Restore popped keys.  Pop operations that took place after the last (committed) updatePersistentDataVersion
 		// might be lost, but that is fine because we will get the corresponding data back, too.
 		tagKeys = prefixRange(rawId.withPrefix(persistTagPoppedKeys.begin));
@@ -3116,7 +3119,7 @@ ACTOR Future<Void> tLogStart(TLogData* self, InitializeTLogRequest req, Locality
 	self->popOrder.push_back(recruited.id());
 	self->spillOrder.push_back(recruited.id());
 
-	TraceEvent("TLogStart", logData->logId);
+	TraceEvent("TLogStart", logData->logId).detail("RecoveryCount", logData->recoveryCount);
 
 	state Future<Void> updater;
 	state bool pulledRecoveryVersions = false;


### PR DESCRIPTION
When using trace events to look into a long recovery, we often need to distinguish TLogs of different generations.
However, it is hard to get such information from existing trace events.
Thus, we decide to add RecoveryCount info to events when any TLog begins.

Q: Why do not leverage the existing "TLog Role Begin" event to carry the RecoveryCount info?
A: When the current "TLog Role Begin" event is created, logData->RecoveryCount is unset yet.

Passed 100K joshua tests.

Add RecoveryCount info to TLogPersistentStateRestore event and TLogStart events in restorePersistentState() and tLogStart() respectively.
We add the events to both TLogServer.actor.cpp and OldTLogServer_6.2.actor.cpp.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
