### PR TITLE
150 was too short and we were seeing false positives (release-7.0)

### DIFF
--- a/tests/slow/DifferentClustersSameRV.toml
+++ b/tests/slow/DifferentClustersSameRV.toml
@@ -6,7 +6,7 @@ clearAfterTest = false
 
     [[test.workload]]
     testName = 'DifferentClustersSameRV'
-    testDuration = 150
+    testDuration = 500
     switchAfter = 50
     keyToRead = 'someKey'
     keyToWatch = 'anotherKey'


### PR DESCRIPTION
Cherry pick https://github.com/apple/foundationdb/pull/4945 to release-7.0



This fixes a failure in last night's release-7.0 correctness run

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [x] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [x] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
