### PR TITLE
TSS downgrade changes

### DIFF
--- a/fdbserver/SimulatedCluster.actor.cpp
+++ b/fdbserver/SimulatedCluster.actor.cpp
@@ -170,6 +170,9 @@ class TestConfig {
 			if (attrib == "maxTLogVersion") {
 				sscanf(value.c_str(), "%d", &maxTLogVersion);
 			}
+			if (attrib == "disableTss") {
+				sscanf(value.c_str(), "%d", &disableTss);
+			}
 			if (attrib == "restartInfoLocation") {
 				isFirstTestInRestart = true;
 			}
@@ -186,6 +189,8 @@ public:
 	bool startIncompatibleProcess = false;
 	int logAntiQuorum = -1;
 	bool isFirstTestInRestart = false;
+	// 7.0 cannot be downgraded to 6.3 after enabling TSS, so disable TSS for 6.3 downgrade tests
+	bool disableTss = false;
 	// Storage Engine Types: Verify match with SimulationConfig::generateNormalConfig
 	//	0 = "ssd"
 	//	1 = "memory"
@@ -234,6 +239,7 @@ public:
 		    .add("logAntiQuorum", &logAntiQuorum)
 		    .add("storageEngineExcludeTypes", &storageEngineExcludeTypes)
 		    .add("maxTLogVersion", &maxTLogVersion)
+		    .add("disableTss", &disableTss)
 		    .add("simpleConfig", &simpleConfig)
 		    .add("generateFearless", &generateFearless)
 		    .add("datacenters", &datacenters)
@@ -1191,7 +1197,7 @@ void SimulationConfig::generateNormalConfig(const TestConfig& testConfig) {
 	}
 
 	int tssCount = 0;
-	if (!testConfig.simpleConfig && deterministicRandom()->random01() < 0.25) {
+	if (!testConfig.simpleConfig && !testConfig.disableTss && deterministicRandom()->random01() < 0.25) {
 		// 1 or 2 tss
 		tssCount = deterministicRandom()->randomInt(1, 3);
 	}

--- a/fdbserver/tester.actor.cpp
+++ b/fdbserver/tester.actor.cpp
@@ -1046,7 +1046,9 @@ std::map<std::string, std::function<void(const std::string&)>> testSpecGlobalKey
 	{ "storageEngineExcludeTypes",
 	  [](const std::string& value) { TraceEvent("TestParserTest").detail("ParsedStorageEngineExcludeTypes", ""); } },
 	{ "maxTLogVersion",
-	  [](const std::string& value) { TraceEvent("TestParserTest").detail("ParsedMaxTLogVersion", ""); } }
+	  [](const std::string& value) { TraceEvent("TestParserTest").detail("ParsedMaxTLogVersion", ""); } },
+	{ "disableTss",
+	  [](const std::string& value) { TraceEvent("TestParserTest").detail("ParsedDisableTSS", ""); } }
 };
 
 std::map<std::string, std::function<void(const std::string& value, TestSpec* spec)>> testSpecTestKeys = {

--- a/tests/restarting/to_6.3.10/CycleTestRestart-1.txt
+++ b/tests/restarting/to_6.3.10/CycleTestRestart-1.txt
@@ -1,5 +1,6 @@
 storageEngineExcludeTypes=-1,-2
 maxTLogVersion=6
+disableTss=true
 testTitle=Clogged
     clearAfterTest=false
     testName=Cycle

--- a/tests/restarting/to_6.3.10/CycleTestRestart-2.txt
+++ b/tests/restarting/to_6.3.10/CycleTestRestart-2.txt
@@ -1,5 +1,6 @@
 storageEngineExcludeTypes=-1,-2
 maxTLogVersion=6
+disableTss=true
 testTitle=Clogged
     runSetup=false
     testName=Cycle


### PR DESCRIPTION
Since TSS introduces new private mutations, once TSS is enabled, a 7.0 -> 6.3 downgrade could cause ASSERT failures in the storage server, if the cluster was downgraded within 5 seconds of a TSS private mutation being sent to servers.
So, we will just recommend not to downgrade 7.0 -> 6.3 if TSS has been enabled.
Thus, the only downgrade testing we have to do is test 7.0 with TSS disabled downgrading to 6.3, checking that the StorageServerInterface data format change is downgrade-able as expected.

Testing:
I did manual testing locally to confirm that downgrading without enabling TSS is fine, and that downgrading immediately after enabling TSS causes the "unknown private mutations" assert to fail in the storage server.
I added a new flag in downgrade tests to disable TSS, and ran 10k 6.3 downgrade tests with this change, which all passed.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
