### PR TITLE
FDBCORE-617: Allocate mako prefix on stack

### DIFF
--- a/bindings/c/test/mako/utils.c
+++ b/bindings/c/test/mako/utils.c
@@ -78,7 +78,6 @@ void genkey(char* str, char* prefix, int prefixlen, int prefixpadding, int num, 
         memset(str, 'x', len);
         memcpy(str + prefixoffset, prefixstr, prefixlen + rowdigit);
         str[len - 1] = '\0';
-        free(prefixstr);
 }
 
 /* This is another sorting algorithm used to calculate latency parameters */

--- a/bindings/c/test/mako/utils.c
+++ b/bindings/c/test/mako/utils.c
@@ -73,7 +73,7 @@ int digits(int num) {
 void genkey(char* str, char* prefix, int prefixlen, int prefixpadding, int num, int rows, int len) {
         const int rowdigit = digits(rows);
         const int prefixoffset = prefixpadding ? len - (prefixlen + rowdigit) - 1 : 0;
-        char* prefixstr = (char*)malloc(sizeof(char) * (prefixlen + rowdigit + 1));
+        char* prefixstr = (char*)alloca(sizeof(char) * (prefixlen + rowdigit + 1));
         snprintf(prefixstr, prefixlen + rowdigit + 1, "%s%0.*d", prefix, rowdigit, num);
         memset(str, 'x', len);
         memcpy(str + prefixoffset, prefixstr, prefixlen + rowdigit);


### PR DESCRIPTION
Allocate prefix on stack to create mako keys.