### PR TITLE
FDBCORE-617: Allocate mako prefix on stack

### DIFF
--- a/bindings/c/test/mako/utils.c
+++ b/bindings/c/test/mako/utils.c
@@ -73,12 +73,11 @@ int digits(int num) {
 void genkey(char* str, char* prefix, int prefixlen, int prefixpadding, int num, int rows, int len) {
         const int rowdigit = digits(rows);
         const int prefixoffset = prefixpadding ? len - (prefixlen + rowdigit) - 1 : 0;
-        char* prefixstr = (char*)malloc(sizeof(char) * (prefixlen + rowdigit + 1));
+        char* prefixstr = (char*)alloca(sizeof(char) * (prefixlen + rowdigit + 1));
         snprintf(prefixstr, prefixlen + rowdigit + 1, "%s%0.*d", prefix, rowdigit, num);
         memset(str, 'x', len);
         memcpy(str + prefixoffset, prefixstr, prefixlen + rowdigit);
         str[len - 1] = '\0';
-        free(prefixstr);
 }
 
 /* This is another sorting algorithm used to calculate latency parameters */


### PR DESCRIPTION
Allocate mako prefix on stack
