### PR TITLE
Resolvers track new teams or staled teams

### DIFF
--- a/fdbserver/Resolver.actor.cpp
+++ b/fdbserver/Resolver.actor.cpp
@@ -111,10 +111,8 @@ ACTOR Future<Void> resolveBatch(Reference<Resolver> self, ResolveTransactionBatc
 	    req.prevVersion >= 0 ? req.reply.getEndpoint().getPrimaryAddress() : NetworkAddress();
 	state ProxyRequestsInfo& proxyInfo = self->proxyInfoMap[proxyAddress];
 
-	if (req.prevVersion < 0) {
-		// The first request, set teams' beginVersion
-		self->versionTracker.addTeams(req.teams, req.version);
-	}
+	self->versionTracker.addTeams(req.newTeams, req.version);
+	self->versionTracker.removeTeams(req.staleTeams);
 
 	++self->resolveBatchIn;
 
@@ -185,7 +183,7 @@ ACTOR Future<Void> resolveBatch(Reference<Resolver> self, ResolveTransactionBatc
 
 		// Update team versions
 		if (req.prevVersion >= 0) { // Not first request
-			reply.previousCommitVersions = self->versionTracker.updateTeams(req.teams, req.version);
+			reply.previousCommitVersions = self->versionTracker.updateTeams(req.updatedTeams, req.version);
 		}
 
 		// Detect conflicts

--- a/fdbserver/ResolverInterface.h
+++ b/fdbserver/ResolverInterface.h
@@ -112,7 +112,9 @@ struct ResolveTransactionBatchRequest {
 	VectorRef<int> txnStateTransactions;
 	ReplyPromise<ResolveTransactionBatchReply> reply;
 	Optional<UID> debugID;
-	std::vector<ptxn::StorageTeamID> teams; // Teams updated in this batch
+	std::vector<ptxn::StorageTeamID> updatedTeams; // Teams updated in this batch
+	std::vector<ptxn::StorageTeamID> newTeams; // New teams added in this batch
+	std::vector<ptxn::StorageTeamID> staleTeams; // Teams that become stale in this batch
 
 	template <class Archive>
 	void serialize(Archive& ar) {
@@ -126,7 +128,9 @@ struct ResolveTransactionBatchRequest {
 		           arena,
 		           debugID,
 		           spanContext,
-		           teams);
+		           updatedTeams,
+		           newTeams,
+		           staleTeams);
 	}
 };
 

--- a/fdbserver/ptxn/TeamVersionTracker.actor.cpp
+++ b/fdbserver/ptxn/TeamVersionTracker.actor.cpp
@@ -37,6 +37,12 @@ void TeamVersionTracker::addTeams(const std::vector<StorageTeamID>& teams, Versi
 	}
 }
 
+void TeamVersionTracker::removeTeams(const std::vector<StorageTeamID>& teams) {
+	for (const auto& team : teams) {
+		versions.erase(team);
+	}
+}
+
 std::map<StorageTeamID, Version> TeamVersionTracker::updateTeams(const std::vector<StorageTeamID>& teams,
                                                                  Version commitVersion) {
 	if (commitVersion > maxCV) {

--- a/fdbserver/ptxn/TeamVersionTracker.h
+++ b/fdbserver/ptxn/TeamVersionTracker.h
@@ -41,6 +41,9 @@ public:
 	// Adds "teams" to the tracker with their "beginVersion", i.e., first PCV.
 	void addTeams(const std::vector<StorageTeamID>& teams, Version beginVersion);
 
+	// Removes stale "teams" from this tracker.
+	void removeTeams(const std::vector<StorageTeamID>& teams);
+
 	// Updates "teams" with new commitVersion. Returns each team's PCV in a map.
 	std::map<StorageTeamID, Version> updateTeams(const std::vector<StorageTeamID>& teams, Version commitVersion);
 

--- a/fdbserver/ptxn/test/TestResolver.actor.cpp
+++ b/fdbserver/ptxn/test/TestResolver.actor.cpp
@@ -113,7 +113,7 @@ bool trackerTest() {
 		ASSERT_EQ(tracker.getCommitVersion(team), cv2);
 	}
 	for (const auto team : removedTeams) {
-		ASSERT_EQ(tracker.getCommitVersion(team), initialVersion);
+		ASSERT_EQ(tracker.getCommitVersion(team), invalidVersion);
 	}
 	std::pair<ptxn::StorageTeamID, Version> p = tracker.mostLaggingTeam();
 	ASSERT_EQ(p.second, cv1);

--- a/fdbserver/ptxn/test/TestResolver.actor.cpp
+++ b/fdbserver/ptxn/test/TestResolver.actor.cpp
@@ -28,6 +28,7 @@
 
 #include "fdbclient/FDBTypes.h"
 #include "fdbserver/ptxn/Config.h"
+#include "fdbserver/ptxn/TeamVersionTracker.h"
 #include "fdbserver/ptxn/test/Driver.h"
 #include "fdbserver/ptxn/test/FakeResolver.actor.h"
 #include "fdbserver/ptxn/test/Utils.h"
@@ -63,7 +64,7 @@ std::vector<ResolveTransactionBatchRequest> makeTxnBatch(Version prevVersion,
 		r.prevVersion = pv;
 		r.version = current;
 		r.lastReceivedVersion = prevVersion;
-		r.teams = getRandomTeams(teams);
+		r.updatedTeams = getRandomTeams(teams);
 
 		pv = current;
 		current += increment;
@@ -80,6 +81,44 @@ int findBatch(std::vector<ResolveTransactionBatchRequest> batches, Version v) {
 	}
 	ASSERT(false);
 	return -1;
+}
+
+bool trackerTest() {
+	ptxn::TeamVersionTracker tracker;
+	std::vector<ptxn::StorageTeamID> teams;
+	const int totalTeams = 10;
+	for (int i = 0; i < totalTeams; i++) {
+		teams.emplace_back(0, i);
+	}
+	const Version initialVersion = 100;
+	tracker.addTeams(teams, initialVersion);
+	ASSERT_EQ(tracker.getCommitVersion({0, 1}), initialVersion);
+	ASSERT_EQ(tracker.getMaxCommitVersion(), initialVersion);
+
+	std::vector<ptxn::StorageTeamID> updatedTeams, newTeams, removedTeams;
+	for (int i = 0; i < totalTeams/2; i++) {
+		updatedTeams.emplace_back(0, i);
+		newTeams.emplace_back(0, totalTeams + i);
+		removedTeams.emplace_back(0, totalTeams - i - 1);
+	}
+	const Version cv1 = 200, cv2 = 200;
+	tracker.updateTeams(updatedTeams, cv1);
+	tracker.addTeams(newTeams, cv2);
+	tracker.removeTeams(removedTeams);
+
+	for (const auto team : updatedTeams) {
+		ASSERT_EQ(tracker.getCommitVersion(team), cv1);
+	}
+	for (const auto team : newTeams) {
+		ASSERT_EQ(tracker.getCommitVersion(team), cv2);
+	}
+	for (const auto team : removedTeams) {
+		ASSERT_EQ(tracker.getCommitVersion(team), initialVersion);
+	}
+	std::pair<ptxn::StorageTeamID, Version> p = tracker.mostLaggingTeam();
+	ASSERT_EQ(p.second, cv1);
+
+	return true;
 }
 
 } // anonymous namespace
@@ -114,7 +153,7 @@ TEST_CASE("fdbserver/ptxn/test/resolver") {
 		req.lastReceivedVersion = -1;
 		// triggers debugging trace events at Resolvers
 		req.debugID = deterministicRandom()->randomUniqueID();
-		req.teams = teams;
+		req.newTeams = teams;
 
 		replies.push_back(brokenPromiseToNever(r->resolve.getReply(req)));
 	}
@@ -156,14 +195,16 @@ TEST_CASE("fdbserver/ptxn/test/resolver") {
 		int idx = findBatch(batches, v); // the i'th request
 
 		auto& pcvGot = replies[idx].get().previousCommitVersions;
-		ASSERT_EQ(batches[idx].teams.size(), pcvGot.size());
-		for (const auto& team : batches[idx].teams) {
+		ASSERT_EQ(batches[idx].updatedTeams.size(), pcvGot.size());
+		for (const auto& team : batches[idx].updatedTeams) {
 			auto it = pcvGot.find(team);
 			ASSERT(it != pcvGot.end());
 			ASSERT_EQ(pcv[team], it->second);
 			pcv[team] = batches[idx].version;
 		}
 	}
+
+	ASSERT(trackerTest());
 
 	return Void();
 }


### PR DESCRIPTION
Because DD can create new teams and remove old teams dynamically, Resolvers
are changed track these teams' changes, notified by proxies.

20210611-230704-jzhou-eafcb05684df6850             compressed=True data_size=24574346 duration=6538006 ended=101421 fail=1 fail_fast=10 max_runs=100000 pass=100330 priority=100 remaining=0 runtime=0:40:59 sanity=False started=101445 stopped=20210611-234803 submitted=20210611-230704 timeout=5400 username=jzhou

This one failure is not related.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
