### PR TITLE
Properly set simulation test for perpetual storage wiggle and bug fixing

### DIFF
--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -3987,7 +3987,7 @@ ACTOR Future<Void> perpetualStorageWiggler(AsyncTrigger* stopSignal,
 	for (const auto& info : self->pid2server_info[self->wigglingPid.get()]) {
 		excludedServerIds.push_back(info->id);
 	}
-	if (self->teams.size() > 1 && _exclusionSafetyCheck(excludedServerIds, self)) { // pre-check health status
+	if (self->healthyTeamCount > 1 && _exclusionSafetyCheck(excludedServerIds, self)) { // pre-check health status
 		TEST(true); // start the first wiggling
 
 		auto fv = self->excludeStorageServersForWiggle(self->wigglingPid.get());
@@ -4019,7 +4019,7 @@ ACTOR Future<Void> perpetualStorageWiggler(AsyncTrigger* stopSignal,
 				for (const auto& info : self->pid2server_info[self->wigglingPid.get()]) {
 					excludedServerIds.push_back(info->id);
 				}
-				if (self->teams.size() > 1 && _exclusionSafetyCheck(excludedServerIds, self)) {
+				if (self->healthyTeamCount > 1 && _exclusionSafetyCheck(excludedServerIds, self)) {
 					TEST(true); // start wiggling
 
 					auto fv = self->excludeStorageServersForWiggle(pid);
@@ -4072,7 +4072,7 @@ ACTOR Future<Void> perpetualStorageWiggler(AsyncTrigger* stopSignal,
 				if (count >= SERVER_KNOBS->DD_STORAGE_WIGGLE_PAUSE_THRESHOLD && !isPaused) {
 					pauseWiggle.trigger();
 				} else if (isPaused && count < SERVER_KNOBS->DD_STORAGE_WIGGLE_PAUSE_THRESHOLD &&
-				           self->teams.size() > 1 && _exclusionSafetyCheck(excludedServerIds, self)) {
+				           self->healthyTeamCount > 1 && _exclusionSafetyCheck(excludedServerIds, self)) {
 					restart.trigger();
 				}
 				ddQueueCheck = delay(SERVER_KNOBS->CHECK_TEAM_DELAY, TaskPriority::DataDistributionLow);


### PR DESCRIPTION
1. Modify simulation test setting: properly set perpetual_storage_wiggle value to its original value. This change makes all test of which waitQuiescentStart=true also can test perpetual wiggle.
2. Fix time-out bug. Sometimes invalid wiggle server appears because the data distributor changing prevents the wiggler from properly setting the status to NONE, which makes this server unavailable afterward. If the number of invalid wiggle server keep increasing, finally the cluster will be unavailable. This PR let servers check whether they are invalid wiggling server and set themselves healthy if so to fix the bug. 
3. Fix the double wigglers bug. Now only primary DC can have a wiggler that controls both primary DC and secondary DC wiggle.
4. Add trace details to help debug; Code refactor.

---

The difference between this PR and #4929 is the health check is done on `healthyTeamCount` but not `teams.size()` as written in #4929. This address what Joshua found in nightly correctness ensemble (`sfcjoshua-tail-errors 20210611-055339-nightly_correctness_master-9bf3146f249f21d4`).

Would not merge it until 200k test pass with 100% perpetual wiggle on.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
