### PR TITLE
Replace lower priority txn request when limit is hit (release-7.0).

### DIFF
--- a/fdbserver/GrvProxyServer.actor.cpp
+++ b/fdbserver/GrvProxyServer.actor.cpp
@@ -107,7 +107,7 @@ struct GrvProxyStats {
 	                          id,
 	                          SERVER_KNOBS->LATENCY_METRICS_LOGGING_INTERVAL,
 	                          SERVER_KNOBS->LATENCY_SAMPLE_SIZE),
-	    grvLatencyBands("GRVLatencyMetrics", id, SERVER_KNOBS->STORAGE_LOGGING_DELAY) {
+	    grvLatencyBands("GRVLatencyBands", id, SERVER_KNOBS->STORAGE_LOGGING_DELAY) {
 		// The rate at which the limit(budget) is allowed to grow.
 		specialCounter(
 		    cc, "SystemAndDefaultTxnRateAllowed", [this]() { return int64_t(this->transactionRateAllowed); });


### PR DESCRIPTION
Patching #4977 to release-7.0.

Before this change, batch txns are counted together with system/normal txns. When workload is very large, batch txns will be put in queue but never have chance to be executed, thus taking spaces and reduce the throughput of normal txns.

Now in this change, when the limit is hit, we will pop lower priority txn requests, so that new-coming higher priority txn requests can replace them. I've verified that now when both workloads are heavy, batch txns throughput will be reduced to ~0, and normal txns throughput can stay at a way higher level compared to the previous behavior.

20210615-211301-renxuan-3d8b67fadee4252b           compressed=True data_size=23365187 duration=3636378 ended=102663 fail_fast=10 max_runs=100000 pass=100038 priority=100 remaining=0 runtime=0:22:56 sanity=False started=103589 stopped=20210615-213557 submitted=20210615-211301 timeout=5400 username=renxuan

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
