### PR TITLE
Fix TraceEventOverflow error in HealthMetricsApi workload

### DIFF
--- a/fdbserver/workloads/HealthMetricsApi.actor.cpp
+++ b/fdbserver/workloads/HealthMetricsApi.actor.cpp
@@ -168,7 +168,7 @@ struct HealthMetricsApiWorkload : TestWorkload {
 				traceDiskUsage.detail(format("Storage-%s", ss.first.toString().c_str()), storageStats.diskUsage);
 			}
 			TraceEvent traceTLogQueue("TLogQueue");
-			traceTLogQueue.setMaxFieldLength(10000).setMaxEventLength(11000);
+			traceTLogQueue.setMaxEventLength(10000);
 			for (const auto& ss : healthMetrics.tLogQueue) {
 				self->detailedWorstTLogQueue = std::max(self->detailedWorstTLogQueue, ss.second);
 				traceTLogQueue.detail(format("TLog-%s", ss.first.toString().c_str()), ss.second);

--- a/fdbserver/workloads/HealthMetricsApi.actor.cpp
+++ b/fdbserver/workloads/HealthMetricsApi.actor.cpp
@@ -168,6 +168,7 @@ struct HealthMetricsApiWorkload : TestWorkload {
 				traceDiskUsage.detail(format("Storage-%s", ss.first.toString().c_str()), storageStats.diskUsage);
 			}
 			TraceEvent traceTLogQueue("TLogQueue");
+			traceTLogQueue.setMaxFieldLength(10000).setMaxEventLength(11000);
 			for (const auto& ss : healthMetrics.tLogQueue) {
 				self->detailedWorstTLogQueue = std::max(self->detailedWorstTLogQueue, ss.second);
 				traceTLogQueue.detail(format("TLog-%s", ss.first.toString().c_str()), ss.second);


### PR DESCRIPTION
Fix TraceEventOverflow error in HealthMetricsApi workload.

2 failed tests are unrelated unit test `/flow/flow/FlowMutex`.

  20210613-010706-jzhou-1692d8417464e976             compressed=True data_size=23756603 duration=4098050 ended=104747 fail=3 fail_fast=10 max_runs=100000 pass=100011 priority=100 remaining=0 runtime=0:22:32 sanity=False started=106265 stopped=20210613-012938 submitted=20210613-010706 timeout=5400 username=jzhou

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
