### PR TITLE
Replace lower priority txn request when limit is hit (release-6.3).

### DIFF
--- a/fdbclient/Schemas.cpp
+++ b/fdbclient/Schemas.cpp
@@ -163,6 +163,18 @@ const KeyRef JSONSchemas::statusSchema = LiteralStringRef(R"statusSchema(
                         "p95":0.0,
                         "p99":0.0,
                         "p99.9":0.0
+                     },
+                     "batch":{
+                        "count":0,
+                        "min":0.0,
+                        "max":0.0,
+                        "median":0.0,
+                        "mean":0.0,
+                        "p25":0.0,
+                        "p90":0.0,
+                        "p95":0.0,
+                        "p99":0.0,
+                        "p99.9":0.0
                      }
                   },
                   "read_latency_statistics":{

--- a/fdbserver/MasterProxyServer.actor.cpp
+++ b/fdbserver/MasterProxyServer.actor.cpp
@@ -392,6 +392,31 @@ ACTOR Future<Void> getRate(UID myID,
 	}
 }
 
+// Respond with an unreadable version to the GetReadVersion request when the GRV limit is hit.
+void proxyGRVThresholdExceeded(const GetReadVersionRequest* req, ProxyStats* stats) {
+	++stats->txnRequestErrors;
+	// FIXME: send an error instead of giving an unreadable version when the client can support the error:
+	// req.reply.sendError(proxy_memory_limit_exceeded());
+	GetReadVersionReply rep;
+	rep.version = 1;
+	rep.locked = true;
+	req->reply.send(rep);
+	if (req->priority == TransactionPriority::IMMEDIATE) {
+		TraceEvent(SevWarnAlways, "ProxyGRVThresholdExceededSystem").suppressFor(60);
+	} else if (req->priority == TransactionPriority::DEFAULT) {
+		TraceEvent(SevWarnAlways, "ProxyGRVThresholdExceededDefault").suppressFor(60);
+	} else {
+		TraceEvent(SevWarnAlways, "ProxyGRVThresholdExceededBatch").suppressFor(60);
+	}
+}
+
+// Drop a GetReadVersion request from a queue, by responding an error to the request.
+void dropRequestFromQueue(Deque<GetReadVersionRequest>* queue, ProxyStats* stats) {
+	proxyGRVThresholdExceeded(&queue->front(), stats);
+	queue->pop_front();
+}
+
+// Put a GetReadVersion request into the queue corresponding to its priority.
 ACTOR Future<Void> queueTransactionStartRequests(Reference<AsyncVar<ServerDBInfo>> db,
                                                  Deque<GetReadVersionRequest>* systemQueue,
                                                  Deque<GetReadVersionRequest>* defaultQueue,
@@ -407,16 +432,30 @@ ACTOR Future<Void> queueTransactionStartRequests(Reference<AsyncVar<ServerDBInfo
 	loop choose {
 		when(GetReadVersionRequest req = waitNext(readVersionRequests)) {
 			// WARNING: this code is run at a high priority, so it needs to do as little work as possible
+			bool canBeQueued = true;
 			if (stats->txnRequestIn.getValue() - stats->txnRequestOut.getValue() >
 			    SERVER_KNOBS->START_TRANSACTION_MAX_QUEUE_SIZE) {
-				++stats->txnRequestErrors;
-				// FIXME: send an error instead of giving an unreadable version when the client can support the error:
-				// req.reply.sendError(proxy_memory_limit_exceeded());
-				GetReadVersionReply rep;
-				rep.version = 1;
-				rep.locked = true;
-				req.reply.send(rep);
-				TraceEvent(SevWarnAlways, "ProxyGRVThresholdExceeded").suppressFor(60);
+				// When the limit is hit, try to drop requests from the lower priority queues.
+				if (req.priority == TransactionPriority::BATCH) {
+					canBeQueued = false;
+				} else if (req.priority == TransactionPriority::DEFAULT) {
+					if (!batchQueue->empty()) {
+						dropRequestFromQueue(batchQueue, stats);
+					} else {
+						canBeQueued = false;
+					}
+				} else {
+					if (!batchQueue->empty()) {
+						dropRequestFromQueue(batchQueue, stats);
+					} else if (!defaultQueue->empty()) {
+						dropRequestFromQueue(defaultQueue, stats);
+					} else {
+						canBeQueued = false;
+					}
+				}
+			}
+			if (!canBeQueued) {
+				proxyGRVThresholdExceeded(&req, stats);
 			} else {
 				stats->addRequest(req.transactionCount);
 				// TODO: check whether this is reasonable to do in the fast path


### PR DESCRIPTION
Cherrypicking #4977 to release 6.3. Also, adding GRVBatchLatencyMetrics to release-6.3, which is already in release-7.0 and above.

Before this change, batch txns are counted together with system/normal txns. When workload is very large, batch txns will be put in queue but never have chance to be executed, thus taking spaces and reduce the throughput of normal txns.

Now in this change, when the limit is hit, we will pop lower priority txn requests, so that new-coming higher priority txn requests can replace them. I've verified that now when both workloads are heavy, batch txns throughput will be reduced to ~0, and normal txns throughput can stay at a way higher level compared to the previous behavior.

20210615-185957-renxuan-8fcb95656e18baec           compressed=True data_size=21415399 duration=4112160 ended=102136 fail_fast=10 max_runs=100000 pass=100001 priority=100 remaining=0 runtime=0:44:07 sanity=False started=102211 stopped=20210615-194404 submitted=20210615-185957 timeout=5400 username=renxuan

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
