### PR TITLE
Replace lower priority txn request when limit is hit.

### DIFF
--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -4976,9 +4976,6 @@ ACTOR Future<Version> extractReadVersion(Location location,
 	if (trLogInfo)
 		trLogInfo->addLog(FdbClientLogEvents::EventGetVersion_V3(
 		    startTime, cx->clientLocality.dcId(), latency, priority, rep.version));
-	if (rep.version == 1 && rep.locked) {
-		throw proxy_memory_limit_exceeded();
-	}
 	if (rep.locked && !lockAware)
 		throw database_locked();
 

--- a/fdbserver/GrvProxyServer.actor.cpp
+++ b/fdbserver/GrvProxyServer.actor.cpp
@@ -107,7 +107,7 @@ struct GrvProxyStats {
 	                          id,
 	                          SERVER_KNOBS->LATENCY_METRICS_LOGGING_INTERVAL,
 	                          SERVER_KNOBS->LATENCY_SAMPLE_SIZE),
-	    grvLatencyBands("GRVLatencyMetrics", id, SERVER_KNOBS->STORAGE_LOGGING_DELAY) {
+	    grvLatencyBands("GRVLatencyBands", id, SERVER_KNOBS->STORAGE_LOGGING_DELAY) {
 		// The rate at which the limit(budget) is allowed to grow.
 		specialCounter(
 		    cc, "SystemAndDefaultTxnRateAllowed", [this]() { return int64_t(this->transactionRateAllowed); });


### PR DESCRIPTION
Before this change, batch txns are counted together with system/normal txns. When workload is very large, batch txns will be put in queue but never have chance to be executed, thus taking spaces and reduce the throughput of normal txns.

Now in this change, when the limit is hit, we will pop lower priority txn requests, so that new-coming higher priority txn requests can replace them. I've verified that now when both workloads are heavy, batch txns throughput will be reduced to ~0, and normal txns throughput can stay at a way higher level compared to the previous behavior.

20210614-212215-renxuan-499a3d72693f99be           compressed=True data_size=23760870 duration=3343345 ended=101151 fail=2 fail_fast=10 max_runs=100000 pass=100016 priority=100 remaining=0 runtime=0:48:03 sanity=False started=101718 stopped=20210614-221018 submitted=20210614-212215 timeout=5400 username=renxuan
The 2 failed tests are caused by #4971.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [x] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
