### PR TITLE
Documentation fixes (release-6.3)

### DIFF
--- a/documentation/sphinx/source/administration.rst
+++ b/documentation/sphinx/source/administration.rst
@@ -28,7 +28,7 @@ Starting and stopping
 
 After installation, FoundationDB is set to start automatically. You can manually start and stop the database with the commands shown below.
 
-These commands start and stop the master ``fdbmonitor`` process, which in turn starts ``fdbserver`` and ``backup-agent`` processes.  See :ref:`administration_fdbmonitor` for details.
+These commands start and stop the ``fdbmonitor`` process, which in turn starts ``fdbserver`` and ``backup-agent`` processes.  See :ref:`administration_fdbmonitor` for details.
 
 Linux
 -----

--- a/documentation/sphinx/source/api-c.rst
+++ b/documentation/sphinx/source/api-c.rst
@@ -475,7 +475,9 @@ Applications must provide error handling and an appropriate retry loop around th
       |snapshot|
 
 .. function:: FDBFuture* fdb_transaction_get_estimated_range_size_bytes( FDBTransaction* tr, uint8_t const* begin_key_name, int begin_key_name_length, uint8_t const* end_key_name, int end_key_name_length)
+
    Returns an estimated byte size of the key range.
+
    .. note:: The estimated size is calculated based on the sampling done by FDB server. The sampling algorithm works roughly in this way: the larger the key-value pair is, the more likely it would be sampled and the more accurate its sampled size would be. And due to that reason it is recommended to use this API to query against large ranges for accuracy considerations. For a rough reference, if the returned size is larger than 3MB, one can consider the size to be accurate.
 
    |future-return0| the estimated size of the key range given. |future-return1| call :func:`fdb_future_get_int64()` to extract the size, |future-return2|

--- a/documentation/sphinx/source/api-python.rst
+++ b/documentation/sphinx/source/api-python.rst
@@ -799,17 +799,15 @@ Transaction misc functions
 
 .. method:: Transaction.get_estimated_range_size_bytes(begin_key, end_key)
 
-    Get the estimated byte size of the given key range. Returns a :class:`FutureInt64`.
+    Gets the estimated byte size of the given key range. Returns a :class:`FutureInt64`.
+
     .. note:: The estimated size is calculated based on the sampling done by FDB server. The sampling algorithm works roughly in this way: the larger the key-value pair is, the more likely it would be sampled and the more accurate its sampled size would be. And due to that reason it is recommended to use this API to query against large ranges for accuracy considerations. For a rough reference, if the returned size is larger than 3MB, one can consider the size to be accurate.
-
-.. _api-python-transaction-options:
-
-Transaction misc functions
---------------------------
 
 .. method:: Transaction.get_approximate_size()
 
-    |transaction-get-approximate-size-blurb|. Returns a :class:`FutureInt64`.
+    |transaction-get-approximate-size-blurb| Returns a :class:`FutureInt64`.
+
+.. _api-python-transaction-options:
 
 Transaction options
 -------------------

--- a/documentation/sphinx/source/api-ruby.rst
+++ b/documentation/sphinx/source/api-ruby.rst
@@ -743,12 +743,13 @@ Transaction misc functions
 
 .. method:: Transaction.get_estimated_range_size_bytes(begin_key, end_key)
 
-    Get the estimated byte size of the given key range. Returns a :class:`Int64Future`.
+    Gets the estimated byte size of the given key range. Returns a :class:`Int64Future`.
+
     .. note:: The estimated size is calculated based on the sampling done by FDB server. The sampling algorithm works roughly in this way: the larger the key-value pair is, the more likely it would be sampled and the more accurate its sampled size would be. And due to that reason it is recommended to use this API to query against large ranges for accuracy considerations. For a rough reference, if the returned size is larger than 3MB, one can consider the size to be accurate.
 
 .. method:: Transaction.get_approximate_size() -> Int64Future
 
-    |transaction-get-approximate-size-blurb|. Returns a :class:`Int64Future`.
+    |transaction-get-approximate-size-blurb| Returns a :class:`Int64Future`.
 
 Transaction options
 -------------------


### PR DESCRIPTION
This is a backport of #4952 and #4919.

The estimated range size bytes function and similar functions had a few rendering issues in the Sphinx documentation. This attempts to address them.

Remove use of the word "master" to describe fdbmonitor in documentation.

No testing done except for the PR build.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [x] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [x] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [x] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
