### PR TITLE
Bugfixes/double ss

### DIFF
--- a/fdbserver/QuietDatabase.actor.cpp
+++ b/fdbserver/QuietDatabase.actor.cpp
@@ -284,6 +284,8 @@ ACTOR Future<vector<WorkerInterface>> getStorageWorkers(Database cx,
 	return result;
 }
 
+// Helper function to extract he maximum SQ size of all provided messages. All futures in the
+// messages vector have to be ready.
 int64_t extractMaxQueueSize(const std::vector<Future<TraceEventFields>>& messages,
                             const std::vector<StorageServerInterface>& servers) {
 
@@ -315,6 +317,7 @@ int64_t extractMaxQueueSize(const std::vector<Future<TraceEventFields>>& message
 	return maxQueueSize;
 }
 
+// Timeout wrapper when getting the storage metrics. This will do some additional tracing
 ACTOR Future<TraceEventFields> getStorageMetricsTimeout(UID storage, WorkerInterface wi) {
 	state Future<TraceEventFields> result =
 	    wi.eventLogRequest.getReply(EventLogRequest(StringRef(storage.toString() + "/StorageMetrics")));
@@ -608,6 +611,8 @@ ACTOR Future<Void> reconfigureAfter(Database cx,
 	return Void();
 }
 
+// Waits until a database quiets down (no data in flight, small tlog queue, low SQ, no active data distribution). This
+// requires the database to be available and healthy in order to succeed.
 ACTOR Future<Void> waitForQuietDatabase(Database cx,
                                         Reference<AsyncVar<ServerDBInfo>> dbInfo,
                                         std::string phase,

--- a/fdbserver/QuietDatabase.actor.cpp
+++ b/fdbserver/QuietDatabase.actor.cpp
@@ -284,6 +284,52 @@ ACTOR Future<vector<WorkerInterface>> getStorageWorkers(Database cx,
 	return result;
 }
 
+int64_t extractMaxQueueSize(const std::vector<Future<TraceEventFields>>& messages,
+                            const std::vector<StorageServerInterface>& servers) {
+
+	int64_t maxQueueSize = 0;
+	UID maxQueueServer;
+
+	for (int i = 0; i < messages.size(); i++) {
+		try {
+			auto queueSize = getQueueSize(messages[i].get());
+			if (queueSize > maxQueueSize) {
+				maxQueueSize = queueSize;
+				maxQueueServer = servers[i].id();
+			}
+		} catch (Error& e) {
+			TraceEvent("QuietDatabaseFailure")
+			    .detail("Reason", "Failed to extract MaxStorageServerQueue")
+			    .detail("SS", servers[i].id());
+			for (auto& m : messages) {
+				TraceEvent("Messages").detail("Info", m.get().toString());
+			}
+			throw;
+		}
+	}
+
+	TraceEvent("QuietDatabaseGotMaxStorageServerQueueSize")
+	    .detail("Stage", "MaxComputed")
+	    .detail("Max", maxQueueSize)
+	    .detail("MaxQueueServer", format("%016" PRIx64, maxQueueServer.first()));
+	return maxQueueSize;
+}
+
+ACTOR Future<TraceEventFields> getStorageMetricsTimeout(UID storage, WorkerInterface wi) {
+	state Future<TraceEventFields> result =
+	    wi.eventLogRequest.getReply(EventLogRequest(StringRef(storage.toString() + "/StorageMetrics")));
+	state Future<Void> timeout = delay(1.0);
+	choose {
+		when(TraceEventFields res = wait(result)) { return res; }
+		when(wait(timeout)) {
+			TraceEvent("QuietDatabaseFailure")
+			    .detail("Reason", "Could not fetch StorageMetrics")
+			    .detail("Storage", format("%016" PRIx64, storage.first()));
+			throw timed_out();
+		}
+	}
+};
+
 // Gets the maximum size of all the storage server queues
 ACTOR Future<int64_t> getMaxStorageServerQueueSize(Database cx, Reference<AsyncVar<ServerDBInfo>> dbInfo) {
 	TraceEvent("MaxStorageServerQueueSize").detail("Stage", "ContactingStorageServers");
@@ -311,9 +357,7 @@ ACTOR Future<int64_t> getMaxStorageServerQueueSize(Database cx, Reference<AsyncV
 		// Ignore TSS in add delay mode since it can purposefully freeze forever
 		if (!servers[i].isTss() || !g_network->isSimulated() ||
 		    g_simulator.tssMode != ISimulator::TSSMode::EnabledAddDelay) {
-			messages.push_back(timeoutError(itr->second.eventLogRequest.getReply(EventLogRequest(
-			                                    StringRef(servers[i].id().toString() + "/StorageMetrics"))),
-			                                1.0));
+			messages.push_back(getStorageMetricsTimeout(servers[i].id(), itr->second));
 		}
 	}
 
@@ -321,23 +365,7 @@ ACTOR Future<int64_t> getMaxStorageServerQueueSize(Database cx, Reference<AsyncV
 
 	TraceEvent("MaxStorageServerQueueSize").detail("Stage", "ComputingMax").detail("MessageCount", messages.size());
 
-	state int64_t maxQueueSize = 0;
-	state int i = 0;
-	for (; i < messages.size(); i++) {
-		try {
-			maxQueueSize = std::max(maxQueueSize, getQueueSize(messages[i].get()));
-		} catch (Error& e) {
-			TraceEvent("QuietDatabaseFailure")
-			    .detail("Reason", "Failed to extract MaxStorageServerQueue")
-			    .detail("SS", servers[i].id());
-			for (auto& m : messages) {
-				TraceEvent("Messages").detail("Info", m.get().toString());
-			}
-			throw;
-		}
-	}
-
-	return maxQueueSize;
+	return extractMaxQueueSize(messages, servers);
 }
 
 // Gets the size of the data distribution queue.  If reportInFlight is true, then data in flight is considered part of
@@ -590,6 +618,13 @@ ACTOR Future<Void> waitForQuietDatabase(Database cx,
                                         int64_t maxPoppedVersionLag = 30e6) {
 	state Future<Void> reconfig =
 	    reconfigureAfter(cx, 100 + (deterministicRandom()->random01() * 100), dbInfo, "QuietDatabase");
+	state Future<int64_t> dataInFlight;
+	state Future<std::pair<int64_t, int64_t>> tLogQueueInfo;
+	state Future<int64_t> dataDistributionQueueSize;
+	state Future<bool> teamCollectionValid;
+	state Future<int64_t> storageQueueSize;
+	state Future<bool> dataDistributionActive;
+	state Future<bool> storageServersRecruiting;
 
 	auto traceMessage = "QuietDatabase" + phase + "Begin";
 	TraceEvent(traceMessage.c_str());
@@ -613,15 +648,13 @@ ACTOR Future<Void> waitForQuietDatabase(Database cx,
 			TraceEvent("QuietDatabaseGotDataDistributor", distributorUID)
 			    .detail("Locality", distributorWorker.locality.toString());
 
-			state Future<int64_t> dataInFlight = getDataInFlight(cx, distributorWorker);
-			state Future<std::pair<int64_t, int64_t>> tLogQueueInfo = getTLogQueueInfo(cx, dbInfo);
-			state Future<int64_t> dataDistributionQueueSize =
-			    getDataDistributionQueueSize(cx, distributorWorker, dataInFlightGate == 0);
-			state Future<bool> teamCollectionValid = getTeamCollectionValid(cx, distributorWorker);
-			state Future<int64_t> storageQueueSize = getMaxStorageServerQueueSize(cx, dbInfo);
-			state Future<bool> dataDistributionActive = getDataDistributionActive(cx, distributorWorker);
-			state Future<bool> storageServersRecruiting =
-			    getStorageServersRecruiting(cx, distributorWorker, distributorUID);
+			dataInFlight = getDataInFlight(cx, distributorWorker);
+			tLogQueueInfo = getTLogQueueInfo(cx, dbInfo);
+			dataDistributionQueueSize = getDataDistributionQueueSize(cx, distributorWorker, dataInFlightGate == 0);
+			teamCollectionValid = getTeamCollectionValid(cx, distributorWorker);
+			storageQueueSize = getMaxStorageServerQueueSize(cx, dbInfo);
+			dataDistributionActive = getDataDistributionActive(cx, distributorWorker);
+			storageServersRecruiting = getStorageServersRecruiting(cx, distributorWorker, distributorUID);
 
 			wait(success(dataInFlight) && success(tLogQueueInfo) && success(dataDistributionQueueSize) &&
 			     success(teamCollectionValid) && success(storageQueueSize) && success(dataDistributionActive) &&
@@ -661,6 +694,7 @@ ACTOR Future<Void> waitForQuietDatabase(Database cx,
 				}
 			}
 		} catch (Error& e) {
+			TraceEvent(("QuietDatabase" + phase + "Error").c_str()).error(e, true);
 			if (e.code() != error_code_actor_cancelled && e.code() != error_code_attribute_not_found &&
 			    e.code() != error_code_timed_out)
 				TraceEvent(("QuietDatabase" + phase + "Error").c_str()).error(e);
@@ -670,7 +704,38 @@ ACTOR Future<Void> waitForQuietDatabase(Database cx,
 			if (e.code() != error_code_attribute_not_found && e.code() != error_code_timed_out)
 				throw;
 
-			TraceEvent(("QuietDatabase" + phase + "Retry").c_str()).error(e);
+			auto evtType = "QuietDatabase" + phase + "Retry";
+			TraceEvent evt(evtType.c_str());
+			evt.error(e);
+			int notReadyCount = 0;
+			if (dataInFlight.isReady() && dataInFlight.isError()) {
+				auto key = "NotReady" + std::to_string(notReadyCount++);
+				evt.detail(key.c_str(), "dataInFlight");
+			}
+			if (tLogQueueInfo.isReady() && tLogQueueInfo.isError()) {
+				auto key = "NotReady" + std::to_string(notReadyCount++);
+				evt.detail(key.c_str(), "tLogQueueInfo");
+			}
+			if (dataDistributionQueueSize.isReady() && dataDistributionQueueSize.isError()) {
+				auto key = "NotReady" + std::to_string(notReadyCount++);
+				evt.detail(key.c_str(), "dataDistributionQueueSize");
+			}
+			if (teamCollectionValid.isReady() && teamCollectionValid.isError()) {
+				auto key = "NotReady" + std::to_string(notReadyCount++);
+				evt.detail(key.c_str(), "teamCollectionValid");
+			}
+			if (storageQueueSize.isReady() && storageQueueSize.isError()) {
+				auto key = "NotReady" + std::to_string(notReadyCount++);
+				evt.detail(key.c_str(), "storageQueueSize");
+			}
+			if (dataDistributionActive.isReady() && dataDistributionActive.isError()) {
+				auto key = "NotReady" + std::to_string(notReadyCount++);
+				evt.detail(key.c_str(), "dataDistributionActive");
+			}
+			if (storageServersRecruiting.isReady() && storageServersRecruiting.isError()) {
+				auto key = "NotReady" + std::to_string(notReadyCount++);
+				evt.detail(key.c_str(), "storageServersRecruiting");
+			}
 			wait(delay(1.0));
 			numSuccesses = 0;
 		}

--- a/fdbserver/SimulatedCluster.actor.cpp
+++ b/fdbserver/SimulatedCluster.actor.cpp
@@ -53,17 +53,19 @@ const int MACHINE_REBOOT_TIME = 10;
 
 bool destructed = false;
 
+// given a std::variant T, this templated class will define type which will be a variant of all types in T plus Args...
 template <class T, class... Args>
-struct concatenate_variant_t;
+struct variant_add_t;
 
 template <class... Args1, class... Args2>
-struct concatenate_variant_t<std::variant<Args1...>, Args2...> {
+struct variant_add_t<std::variant<Args1...>, Args2...> {
 	using type = std::variant<Args1..., Args2...>;
 };
 
 template <class T, class... Args>
-using concatenate_variant = typename concatenate_variant_t<T, Args...>::type;
+using variant_add = typename variant_add_t<T, Args...>::type;
 
+// variant_with_optional_t::type will be a std::variant<Args..., Optional<Args>...>
 template <class... Args>
 struct variant_with_optional_t;
 
@@ -74,12 +76,13 @@ struct variant_with_optional_t<Single> {
 
 template <class Head, class... Tail>
 struct variant_with_optional_t<Head, Tail...> {
-	using type = concatenate_variant<typename variant_with_optional_t<Tail...>::type, Head, Optional<Head>>;
+	using type = variant_add<typename variant_with_optional_t<Tail...>::type, Head, Optional<Head>>;
 };
 
 template <class... Args>
 using variant_with_optional = typename variant_with_optional_t<Args...>::type;
 
+// Expects a std::variant and will make a pointer out of each argument
 template <class T>
 struct add_pointers_t;
 

--- a/flow/CMakeLists.txt
+++ b/flow/CMakeLists.txt
@@ -67,6 +67,7 @@ set(FLOW_SRCS
   Tracing.h
   Tracing.actor.cpp
   TreeBenchmark.h
+  TypeTraits.h
   UnitTest.cpp
   UnitTest.h
   XmlTraceLogFormatter.cpp

--- a/flow/TypeTraits.h
+++ b/flow/TypeTraits.h
@@ -1,0 +1,55 @@
+/*
+ * TypeTraits.h
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2018 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// This file, similar to `type_traits` in the standard library, contains utility types that can be used for template
+// metaprogramming. While they can be very useful and simplify certain things, please be aware that their use will
+// increase compilation times significantly. Therefore it is not recommended to use them in header file if not
+// absosultely necessary.
+#pragma once
+#include <variant>
+
+// This type class will take two std::variant types and concatenate them
+template <class L, class R>
+struct variant_concat_t;
+
+template <class... Args1, class... Args2>
+struct variant_concat_t<std::variant<Args1...>, std::variant<Args2...>> {
+	using type = std::variant<Args1..., Args2...>;
+};
+
+// Helper definition for variant_concat_t. Instead of using `typename variant_concat_t<...>::type` one can simply use
+// `variant_concat<...>`
+template <class L, class R>
+using variant_concat = typename variant_concat_t<L, R>::type;
+
+// Takes a std::variant as first argument and applies Fun to all of them. For example: typename
+// variant_map_t<std::variant<int, bool>, std::add_pointer_t>::type will be defined as std::variant<int*, bool*>
+template <class T, template <class> class Fun>
+struct variant_map_t;
+
+template <class... Args, template <class> class Fun>
+struct variant_map_t<std::variant<Args...>, Fun> {
+	using type = std::variant<Fun<Args>...>;
+};
+
+// Helper definition for variant_map_t. Instead of using `typename variant_map<...>::type` one can simple use
+// `varirant_map<...>` which is equivalent but shorter.
+template <class T, template <class> class Fun>
+using variant_map = typename variant_map_t<T, Fun>::type;


### PR DESCRIPTION
This change makes it less likely for storages multiple storages to be recruited on a single worker. However, there are some caveats:

1. Seed servers will always be recruited. The reason for this is simple: we can't remove a storage server until the database recovered. So if the initial recovery after the initial `configure` fails, all storages might already be occupied with seed servers. This should be a very minor downside as these old seed servers will be removed right after the recovery (and they won't have any data).
2. Storage migration still occasionally recruits multiple storages on one worker.

This was tested by running 10k simulation tests which resulted in 0 failures.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
