### PR TITLE
Add exportLibrary for exporting external clients from jar (release-7.0)

### DIFF
--- a/bindings/java/src/main/com/apple/foundationdb/JNIUtil.java
+++ b/bindings/java/src/main/com/apple/foundationdb/JNIUtil.java
@@ -30,7 +30,7 @@ import java.io.OutputStream;
  * Utility for loading a dynamic library from the classpath.
  *
  */
-class JNIUtil {
+public class JNIUtil {
 	private static final String SEPARATOR = "/";
 	private static final String LOADABLE_PREFIX = "FDB_LIBRARY_PATH_";
 	private static final String TEMPFILE_PREFIX = "fdbjni";
@@ -92,7 +92,7 @@ class JNIUtil {
 		File exported;
 
 		try {
-			exported = exportResource(path);
+			exported = exportResource(path, libName);
 		}
 		catch (IOException e) {
 			throw new UnsatisfiedLinkError(e.getMessage());
@@ -107,6 +107,19 @@ class JNIUtil {
 				// EAT, since we do not care that an eager deletion did not work...
 			}
 		}
+	}
+
+	/**
+	 * Export a library from classpath resources to a temporary file.
+	 *
+	 * @param libName the name of the library to attempt to export. This name should be
+	 *  undecorated with file extensions and, in the case of *nix, "lib" prefixes.
+	 * @return the exported temporary file
+	 */
+	public static File exportLibrary(String libName) throws IOException {
+		OS os = getRunningOS();
+		String path = getPath(os, libName);
+		return exportResource(path, libName);
 	}
 
 	/**
@@ -127,20 +140,21 @@ class JNIUtil {
 	 * Export a resource from the classpath to a temporary file.
 	 *
 	 * @param path the relative path of the file to load from the classpath
+	 * @param name an optional descriptive name to include in the temporary file's path
 	 *
 	 * @return the absolute path to the exported file
 	 * @throws IOException
 	 */
-	private static File exportResource(String path) throws IOException {
+	private static File exportResource(String path, String name) throws IOException {
 		InputStream resource = JNIUtil.class.getResourceAsStream(path);
 		if(resource == null)
 			throw new IllegalStateException("Embedded library jar:" + path + " not found");
-		File f = saveStreamAsTempFile(resource);
+		File f = saveStreamAsTempFile(resource, name);
 		return f;
 	}
 
-	private static File saveStreamAsTempFile(InputStream resource) throws IOException {
-		File f = File.createTempFile(TEMPFILE_PREFIX, TEMPFILE_SUFFIX);
+	private static File saveStreamAsTempFile(InputStream resource, String name) throws IOException {
+		File f = File.createTempFile(name.length() > 0 ? name : TEMPFILE_PREFIX, TEMPFILE_SUFFIX);
 		FileOutputStream outputStream = new FileOutputStream(f);
 		copyStream(resource, outputStream);
 		outputStream.flush();


### PR DESCRIPTION
Cherry pick https://github.com/apple/foundationdb/pull/4930 to release-7.0



After this change, users would be able to add all fdb shared libraries they need in the jar itself with something like `jar uf`, and then they could export them and add them with the network option. Users could also put their shared libraries and external clients in a separate jar.

Users could then add lines like
```
fdb.options().setExternalClientLibrary(JNIUtil.exportLibrary("fdb_c_6_2").getAbsolutePath());
fdb.options().setExternalClientLibrary(JNIUtil.exportLibrary("fdb_c_6_3").getAbsolutePath());
fdb.options().setExternalClientLibrary(JNIUtil.exportLibrary("fdb_c_7_0").getAbsolutePath());
```
at the beginning of their application for each server version they want to support.

The main libfdb_c.so client could also go in a jar, and it will already automatically get used if present.

I think that this should go in a release so that users can load external clients from their classpath sooner.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [x] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [x] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
