### PR TITLE
Remove unused parameters in registrationClient method

### DIFF
--- a/fdbserver/worker.actor.cpp
+++ b/fdbserver/worker.actor.cpp
@@ -507,9 +507,6 @@ ACTOR Future<Void> registrationClient(Reference<AsyncVar<Optional<ClusterControl
                                       Reference<AsyncVar<Optional<DataDistributorInterface>>> ddInterf,
                                       Reference<AsyncVar<Optional<RatekeeperInterface>>> rkInterf,
                                       Reference<AsyncVar<bool>> degraded,
-                                      PromiseStream<ErrorInfo> errors,
-                                      LocalityData locality,
-                                      Reference<AsyncVar<ServerDBInfo>> dbInfo,
                                       Reference<ClusterConnectionFile> connFile,
                                       Reference<AsyncVar<std::set<std::string>>> issues) {
 	// Keeps the cluster controller (as it may be re-elected) informed that this worker exists
@@ -1287,9 +1284,6 @@ ACTOR Future<Void> workerServer(Reference<ClusterConnectionFile> connFile,
 		                                       ddInterf,
 		                                       rkInterf,
 		                                       degraded,
-		                                       errors,
-		                                       locality,
-		                                       dbInfo,
 		                                       connFile,
 		                                       issues));
 


### PR DESCRIPTION
100k joshua run: 20210616-221423-zhewu-4991-eda5176d17c858ce

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
