### PR TITLE
Support generating arbitrary number of mutations in storage server test

### DIFF
--- a/fdbclient/FDBTypes.h
+++ b/fdbclient/FDBTypes.h
@@ -703,6 +703,8 @@ struct KeyValueStoreType {
 	// Only add new ones just before END.
 	// SS storeType is END before the storageServerInterface is initialized.
 	enum StoreType { SSD_BTREE_V1, MEMORY, SSD_BTREE_V2, SSD_REDWOOD_V1, MEMORY_RADIXTREE, SSD_ROCKSDB_V1, END };
+	constexpr static const StoreType ALL[] = { SSD_BTREE_V1,   MEMORY,           SSD_BTREE_V2,
+		                                       SSD_REDWOOD_V1, MEMORY_RADIXTREE, SSD_ROCKSDB_V1 };
 
 	KeyValueStoreType() : type(END) {}
 	KeyValueStoreType(StoreType type) : type(type) {
@@ -734,6 +736,16 @@ struct KeyValueStoreType {
 		default:
 			return "unknown";
 		}
+	}
+
+	static KeyValueStoreType fromString(const std::string& typeStr) {
+		for (StoreType t : ALL) {
+			auto kvst = KeyValueStoreType(t);
+			if (kvst.toString() == typeStr) {
+				return kvst;
+			}
+		}
+		return KeyValueStoreType(END);
 	}
 
 private:

--- a/fdbclient/FDBTypes.h
+++ b/fdbclient/FDBTypes.h
@@ -703,8 +703,6 @@ struct KeyValueStoreType {
 	// Only add new ones just before END.
 	// SS storeType is END before the storageServerInterface is initialized.
 	enum StoreType { SSD_BTREE_V1, MEMORY, SSD_BTREE_V2, SSD_REDWOOD_V1, MEMORY_RADIXTREE, SSD_ROCKSDB_V1, END };
-	constexpr static const StoreType ALL[] = { SSD_BTREE_V1,   MEMORY,           SSD_BTREE_V2,
-		                                       SSD_REDWOOD_V1, MEMORY_RADIXTREE, SSD_ROCKSDB_V1 };
 
 	KeyValueStoreType() : type(END) {}
 	KeyValueStoreType(StoreType type) : type(type) {
@@ -739,13 +737,16 @@ struct KeyValueStoreType {
 	}
 
 	static KeyValueStoreType fromString(const std::string& typeStr) {
-		for (StoreType t : ALL) {
-			auto kvst = KeyValueStoreType(t);
-			if (kvst.toString() == typeStr) {
-				return kvst;
-			}
-		}
-		return KeyValueStoreType(END);
+		static const std::unordered_map<std::string, StoreType> STR_TO_TYPE = {
+			{ "ssd-1", SSD_BTREE_V1 },
+			{ "ssd-2", SSD_BTREE_V2 },
+			{ "ssd-redwood-experimental", SSD_REDWOOD_V1 },
+			{ "ssd-rocksdb-experimental", SSD_ROCKSDB_V1 },
+			{ "memory", MEMORY },
+			{ "memory-radixtree-beta", MEMORY_RADIXTREE }
+		};
+		auto it = STR_TO_TYPE.find(typeStr);
+		return KeyValueStoreType(it == STR_TO_TYPE.end() ? END : it->second);
 	}
 
 private:

--- a/fdbserver/MockLogSystem.cpp
+++ b/fdbserver/MockLogSystem.cpp
@@ -38,6 +38,11 @@ MockLogSystem::MockLogSystem(const MockLogSystem& that) : cursor(that.cursor) {
 	logMethodName(__func__);
 }
 
+MockLogSystem& MockLogSystem::operator=(const MockLogSystem& that) {
+	cursor = that.cursor;
+	return *this;
+}
+
 void MockLogSystem::addref() {
 	logMethodName(__func__);
 	ReferenceCounted<MockLogSystem>::addref();

--- a/fdbserver/MockLogSystem.cpp
+++ b/fdbserver/MockLogSystem.cpp
@@ -39,6 +39,7 @@ MockLogSystem::MockLogSystem(const MockLogSystem& that) : cursor(that.cursor) {
 }
 
 MockLogSystem& MockLogSystem::operator=(const MockLogSystem& that) {
+	logMethodName(__func__);
 	cursor = that.cursor;
 	return *this;
 }

--- a/fdbserver/MockLogSystem.h
+++ b/fdbserver/MockLogSystem.h
@@ -29,9 +29,10 @@ struct MockLogSystem : ILogSystem, ReferenceCounted<MockLogSystem> {
 
 	MockLogSystem();
 
-	MockLogSystem(const MockLogSystem& that);
-	MockLogSystem(const MockLogSystem&& that) = delete;
-	MockLogSystem& operator=(const MockLogSystem&) = delete;
+	MockLogSystem(const MockLogSystem&);
+	MockLogSystem& operator=(const MockLogSystem&);
+
+	MockLogSystem(const MockLogSystem&&) = delete;
 	MockLogSystem& operator=(const MockLogSystem&&) = delete;
 
 	void addref() final;

--- a/fdbserver/MockPeekCursor.cpp
+++ b/fdbserver/MockPeekCursor.cpp
@@ -18,10 +18,21 @@
  * limitations under the License.
  */
 
+#include <ostream>
 #include "MockPeekCursor.h"
 
 const static bool LOG_METHOD_CALLS = false;
-const static bool LOG_MESSAGES = true;
+const static bool LOG_MESSAGES = false;
+
+std::ostream& operator<<(std::ostream& os, const MockPeekCursor::VersionedMessage& versionedMessage) {
+	os << "VersionedMessage [version: " << versionedMessage.version << " sub: " << versionedMessage.sub
+	   << " message: " << StringRef(versionedMessage.message).toHexString() << " tags: ";
+	for (auto tag : versionedMessage.tags) {
+		os << tag.toString() << " ";
+	}
+	os << "]";
+	return os;
+}
 
 static void logMethodName(std::string methodName) {
 	if (LOG_METHOD_CALLS) {

--- a/fdbserver/MockPeekCursor.h
+++ b/fdbserver/MockPeekCursor.h
@@ -21,76 +21,74 @@
 #ifndef FDBSERVER_MOCK_PEEK_CURSOR
 #define FDBSERVER_MOCK_PEEK_CURSOR
 
-#include <ostream>
+#include <iosfwd>
 #include "fdbserver/LogSystem.h"
 
-struct VersionedMessage {
-	// Every message should be able to have independent arenas so that they can be freed separately after consumed.
-	Arena arena;
-	Version version;
-	// Subversion is not used for now.
-	uint32_t sub = 0;
-	StringRef message;
-	VectorRef<Tag> tags{};
-	VersionedMessage() = default;
-	VersionedMessage(const Arena& arena, Version version, const StringRef& message, const VectorRef<Tag>& tags)
-	  : arena(arena), version(version), message(message), tags(tags) {}
-
-	friend std::ostream& operator<<(std::ostream& os, const VersionedMessage& versionedMessage) {
-		os << "VersionedMessage [version: " << versionedMessage.version << " sub: " << versionedMessage.sub
-		   << " message: " << StringRef(versionedMessage.message).toHexString() << " tags: ";
-		for (auto tag : versionedMessage.tags) {
-			os << tag.toString() << " ";
-		}
-		os << "]";
-		return os;
-	}
-};
-
-struct VersionedMessageSupplier final : ReferenceCounted<VersionedMessageSupplier> {
-	int i = 0;
-	int end;
-	VectorRef<Tag> tags{};
-	int advanceVersionsPerMutation;
-
-	Optional<VersionedMessage> get() {
-		// std::cout << "OnDemandVersionedMessageSupplier get " << i << ", end " << end << std::endl;
-		ASSERT(i <= end);
-		if (i == end) {
-			return Optional<VersionedMessage>();
-		}
-		Arena arena;
-		MutationRef mutation(arena,
-		                     MutationRef::SetValue,
-		                     StringRef(arena, "Key-" + std::to_string(i)),
-		                     StringRef(arena, "Value-" + std::to_string(i)));
-		StringRef str = StringRef(arena, BinaryWriter::toValue(mutation, AssumeVersion(currentProtocolVersion)));
-		Version version = i * advanceVersionsPerMutation + 1;
-		VersionedMessage message(arena, version, str, tags);
-
-		i++;
-		return Optional<VersionedMessage>(message);
-	}
-
-	static Version commitVersion(int id, int advanceVersionsPerMutation) { return id * advanceVersionsPerMutation + 1; }
-
-	explicit VersionedMessageSupplier(const int end, const VectorRef<Tag> tags, const int advanceVersionsPerMutation)
-	  : end(end), tags(tags), advanceVersionsPerMutation(advanceVersionsPerMutation) {}
-
-	VersionedMessageSupplier(const VersionedMessageSupplier& that)
-	  : i(that.i), end(that.end), tags(that.tags), advanceVersionsPerMutation(that.advanceVersionsPerMutation) {}
-	VersionedMessageSupplier& operator=(const VersionedMessageSupplier& that) {
-		i = that.i;
-		end = that.end;
-		tags = that.tags;
-		return *this;
-	}
-
-	void addref() { ReferenceCounted<VersionedMessageSupplier>::addref(); }
-	void delref() { ReferenceCounted<VersionedMessageSupplier>::delref(); }
-};
-
 struct MockPeekCursor final : ILogSystem::IPeekCursor, ReferenceCounted<MockPeekCursor> {
+
+	struct VersionedMessage {
+		// Every message should be able to have independent arenas so that they can be freed separately after consumed.
+		Arena arena;
+		Version version;
+		// Subversion is not used for now.
+		uint32_t sub = 0;
+		StringRef message;
+		VectorRef<Tag> tags;
+		VersionedMessage() = default;
+		VersionedMessage(const Arena& arena, Version version, const StringRef& message, const VectorRef<Tag>& tags)
+		  : arena(arena), version(version), message(message), tags(tags) {}
+
+		friend std::ostream& operator<<(std::ostream& os, const VersionedMessage& versionedMessage);
+	};
+
+	struct VersionedMessageSupplier final : ReferenceCounted<VersionedMessageSupplier> {
+		int i = 0;
+		int end;
+		Standalone<VectorRef<Tag>> tags;
+		int advanceVersionsPerMutation;
+
+		Optional<VersionedMessage> get() {
+			// std::cout << "OnDemandVersionedMessageSupplier get " << i << ", end " << end << std::endl;
+			ASSERT(i <= end);
+			if (i == end) {
+				return Optional<VersionedMessage>();
+			}
+			Arena arena;
+			// TODO: Support keys in random order.
+			MutationRef mutation(arena,
+			                     MutationRef::SetValue,
+			                     StringRef(arena, "Key-" + std::to_string(i)),
+			                     StringRef(arena, "Value-" + std::to_string(i)));
+			StringRef str = StringRef(arena, BinaryWriter::toValue(mutation, AssumeVersion(currentProtocolVersion)));
+			Version version = i * advanceVersionsPerMutation + 1;
+			VersionedMessage message(arena, version, str, tags);
+
+			i++;
+			return Optional<VersionedMessage>(message);
+		}
+
+		static Version commitVersion(int id, int advanceVersionsPerMutation) {
+			return id * advanceVersionsPerMutation + 1;
+		}
+
+		explicit VersionedMessageSupplier(const int end,
+		                                  const Standalone<VectorRef<Tag>> tags,
+		                                  const int advanceVersionsPerMutation)
+		  : end(end), tags(tags), advanceVersionsPerMutation(advanceVersionsPerMutation) {}
+
+		VersionedMessageSupplier(const VersionedMessageSupplier& that)
+		  : i(that.i), end(that.end), tags(that.tags), advanceVersionsPerMutation(that.advanceVersionsPerMutation) {}
+		VersionedMessageSupplier& operator=(const VersionedMessageSupplier& that) {
+			i = that.i;
+			end = that.end;
+			tags = that.tags;
+			advanceVersionsPerMutation = that.advanceVersionsPerMutation;
+			return *this;
+		}
+
+		using ReferenceCounted<VersionedMessageSupplier>::addref;
+		using ReferenceCounted<VersionedMessageSupplier>::delref;
+	};
 
 	// Every time when getMore() is called, the end of supplier is extended by nMutationsPerMore until it reaches
 	// maxMutations().
@@ -105,7 +103,7 @@ struct MockPeekCursor final : ILogSystem::IPeekCursor, ReferenceCounted<MockPeek
 	LogMessageVersion curVersion;
 	// This can be updated every time reader() is called, so we do not need to keep its status. It's here just for
 	// managing the pointer returned by reader().
-	std::unique_ptr<ArenaReader> curReader = std::unique_ptr<ArenaReader>();
+	std::unique_ptr<ArenaReader> curReader = nullptr;
 
 	MockPeekCursor(int nMutationsPerMore,
 	               Optional<int> maxMutations,

--- a/tests/ptxn/StorageServer.toml
+++ b/tests/ptxn/StorageServer.toml
@@ -7,3 +7,8 @@ startDelay = 0
     testName = 'UnitTests'
     maxTestCases = 1
     testsMatching = 'fdbserver/ptxn/test/storageserver'
+
+    nMutationsPerMore = 20
+    maxMutations = 200
+    advanceVersionsPerMutation = 1000
+    verifyId = 198


### PR DESCRIPTION
This can be updated to standalone performance testing for storage server (including the MVCC part). But there are too many dimensions that we can test. I'm not sure which ones are most important to the team. So I'd like to push the less controversial part out for review first and discuss what other knobs (e.g. Make `maxVersionsInMemory` different from default) that we should have.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
