### PR TITLE
remove unnecessary version check in fdbcli commands kill, suspend and expensive_data_check

### DIFF
--- a/fdbcli/fdbcli.actor.cpp
+++ b/fdbcli/fdbcli.actor.cpp
@@ -3766,11 +3766,8 @@ ACTOR Future<int> cli(CLIOptions opt, LineNoise* plinenoise) {
 						printf("\n");
 					} else if (tokencmp(tokens[1], "all")) {
 						for (auto it : address_interface) {
-							if (db->apiVersionAtLeast(700))
-								BinaryReader::fromStringRef<ClientWorkerInterface>(it.second.first, IncludeVersion())
-								    .reboot.send(RebootRequest());
-							else
-								tr->set(LiteralStringRef("\xff\xff/reboot_worker"), it.second.first);
+							BinaryReader::fromStringRef<ClientWorkerInterface>(it.second.first, IncludeVersion())
+							    .reboot.send(RebootRequest());
 						}
 						if (address_interface.size() == 0) {
 							fprintf(stderr,
@@ -3790,13 +3787,9 @@ ACTOR Future<int> cli(CLIOptions opt, LineNoise* plinenoise) {
 
 						if (!is_error) {
 							for (int i = 1; i < tokens.size(); i++) {
-								if (db->apiVersionAtLeast(700))
-									BinaryReader::fromStringRef<ClientWorkerInterface>(
-									    address_interface[tokens[i]].first, IncludeVersion())
-									    .reboot.send(RebootRequest());
-								else
-									tr->set(LiteralStringRef("\xff\xff/reboot_worker"),
-									        address_interface[tokens[i]].first);
+								BinaryReader::fromStringRef<ClientWorkerInterface>(address_interface[tokens[i]].first,
+								                                                   IncludeVersion())
+								    .reboot.send(RebootRequest());
 							}
 							printf("Attempted to kill %zu processes\n", tokens.size() - 1);
 						}
@@ -3853,13 +3846,9 @@ ACTOR Future<int> cli(CLIOptions opt, LineNoise* plinenoise) {
 								tr->setOption(FDBTransactionOptions::TIMEOUT,
 								              StringRef((uint8_t*)&timeout_ms, sizeof(int64_t)));
 								for (int i = 2; i < tokens.size(); i++) {
-									if (db->apiVersionAtLeast(700))
-										BinaryReader::fromStringRef<ClientWorkerInterface>(
-										    address_interface[tokens[i]].first, IncludeVersion())
-										    .reboot.send(RebootRequest(false, false, seconds));
-									else
-										tr->set(LiteralStringRef("\xff\xff/suspend_worker"),
-										        address_interface[tokens[i]].first);
+									BinaryReader::fromStringRef<ClientWorkerInterface>(
+									    address_interface[tokens[i]].first, IncludeVersion())
+									    .reboot.send(RebootRequest(false, false, seconds));
 								}
 								printf("Attempted to suspend %zu processes\n", tokens.size() - 2);
 							}
@@ -4155,11 +4144,8 @@ ACTOR Future<int> cli(CLIOptions opt, LineNoise* plinenoise) {
 						printf("\n");
 					} else if (tokencmp(tokens[1], "all")) {
 						for (auto it : address_interface) {
-							if (db->apiVersionAtLeast(700))
-								BinaryReader::fromStringRef<ClientWorkerInterface>(it.second.first, IncludeVersion())
-								    .reboot.send(RebootRequest(false, true));
-							else
-								tr->set(LiteralStringRef("\xff\xff/reboot_and_check_worker"), it.second.first);
+							BinaryReader::fromStringRef<ClientWorkerInterface>(it.second.first, IncludeVersion())
+							    .reboot.send(RebootRequest(false, true));
 						}
 						if (address_interface.size() == 0) {
 							fprintf(stderr,
@@ -4179,13 +4165,9 @@ ACTOR Future<int> cli(CLIOptions opt, LineNoise* plinenoise) {
 
 						if (!is_error) {
 							for (int i = 1; i < tokens.size(); i++) {
-								if (db->apiVersionAtLeast(700))
-									BinaryReader::fromStringRef<ClientWorkerInterface>(
-									    address_interface[tokens[i]].first, IncludeVersion())
-									    .reboot.send(RebootRequest(false, true));
-								else
-									tr->set(LiteralStringRef("\xff\xff/reboot_and_check_worker"),
-									        address_interface[tokens[i]].first);
+								BinaryReader::fromStringRef<ClientWorkerInterface>(address_interface[tokens[i]].first,
+								                                                   IncludeVersion())
+								    .reboot.send(RebootRequest(false, true));
 							}
 							printf("Attempted to kill and check %zu processes\n", tokens.size() - 1);
 						}


### PR DESCRIPTION
The `db` in fdbcli is initialized as _-1_ and all `db->apiVersionAtLeast(…)` will succeed whatever the version is considering the [code](https://github.com/apple/foundationdb/blob/master/fdbclient/DatabaseContext.h#L230) .
Thus the check is okay to remove.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
