### PR TITLE
DD should inform proxy about storage team changes

### DIFF
--- a/fdbclient/CommitProxyInterface.h
+++ b/fdbclient/CommitProxyInterface.h
@@ -86,8 +86,7 @@ struct CommitProxyInterface {
 			exclusionSafetyCheckReq =
 			    RequestStream<struct ExclusionSafetyCheckRequest>(commit.getEndpoint().getAdjustedEndpoint(8));
 			getDDMetrics = RequestStream<struct GetDDMetricsRequest>(commit.getEndpoint().getAdjustedEndpoint(9));
-			ssTeamChange =
-				RequestStream<struct SSTeamChangeRequest>(commit.getEndpoint().getAdjustedEndpoint(10));
+			ssTeamChange = RequestStream<struct SSTeamChangeRequest>(commit.getEndpoint().getAdjustedEndpoint(10));
 		}
 	}
 
@@ -514,11 +513,11 @@ struct ExclusionSafetyCheckRequest {
 };
 
 struct SSTeamChangeRequest {
-	constexpr static FileIdentifier file_identifier = 13852702; // TODO: how to choose this value?
-	// TODO: Add info about SS team changes
+	constexpr static FileIdentifier file_identifier = 13852702; // TODO: Need to choose an appropriate value here
+	// TODO: Need to add info about the SS team change that triggered this request.
 	ReplyPromise<Void> reply;
 
-	explicit SSTeamChangeRequest() {}
+	SSTeamChangeRequest() {}
 
 	template <class Ar>
 	void serialize(Ar& ar) {

--- a/fdbclient/CommitProxyInterface.h
+++ b/fdbclient/CommitProxyInterface.h
@@ -60,6 +60,7 @@ struct CommitProxyInterface {
 	RequestStream<struct ProxySnapRequest> proxySnapReq;
 	RequestStream<struct ExclusionSafetyCheckRequest> exclusionSafetyCheckReq;
 	RequestStream<struct GetDDMetricsRequest> getDDMetrics;
+	RequestStream<struct SSTeamChangeRequest> ssTeamChange;
 
 	UID id() const { return commit.getEndpoint().token; }
 	std::string toString() const { return id().shortString(); }
@@ -85,6 +86,8 @@ struct CommitProxyInterface {
 			exclusionSafetyCheckReq =
 			    RequestStream<struct ExclusionSafetyCheckRequest>(commit.getEndpoint().getAdjustedEndpoint(8));
 			getDDMetrics = RequestStream<struct GetDDMetricsRequest>(commit.getEndpoint().getAdjustedEndpoint(9));
+			ssTeamChange =
+				RequestStream<struct SSTeamChangeRequest>(commit.getEndpoint().getAdjustedEndpoint(10));
 		}
 	}
 
@@ -101,6 +104,7 @@ struct CommitProxyInterface {
 		streams.push_back(proxySnapReq.getReceiver());
 		streams.push_back(exclusionSafetyCheckReq.getReceiver());
 		streams.push_back(getDDMetrics.getReceiver());
+		streams.push_back(ssTeamChange.getReceiver());
 		FlowTransport::transport().addEndpoints(streams);
 	}
 };
@@ -506,6 +510,19 @@ struct ExclusionSafetyCheckRequest {
 	template <class Ar>
 	void serialize(Ar& ar) {
 		serializer(ar, exclusions, reply);
+	}
+};
+
+struct SSTeamChangeRequest {
+	constexpr static FileIdentifier file_identifier = 13852702; // TODO: how to choose this value?
+	// TODO: Add info about SS team changes
+	ReplyPromise<Void> reply;
+
+	explicit SSTeamChangeRequest() {}
+
+	template <class Ar>
+	void serialize(Ar& ar) {
+		serializer(ar);
 	}
 };
 

--- a/fdbserver/CommitProxyServer.actor.cpp
+++ b/fdbserver/CommitProxyServer.actor.cpp
@@ -1784,6 +1784,11 @@ ACTOR Future<Void> proxyCheckSafeExclusion(Reference<AsyncVar<ServerDBInfo>> db,
 	return Void();
 }
 
+ACTOR Future<Void> proxyApplySSTeamChange(SSTeamChangeRequest ssTeamChangeReq) {
+	ssTeamChangeReq.reply.send(Void());
+	return Void();
+}
+
 ACTOR Future<Void> reportTxnTagCommitCost(UID myID,
                                           Reference<AsyncVar<ServerDBInfo>> db,
                                           UIDTransactionTagMap<TransactionCommitCostEstimation>* ssTrTagCommitCost) {
@@ -2035,6 +2040,9 @@ ACTOR Future<Void> commitProxyServerCore(CommitProxyInterface proxy,
 			}
 			addActor.send(broadcastTxnRequest(req, SERVER_KNOBS->TXN_STATE_SEND_AMOUNT, true));
 			wait(yield());
+		}
+		when(SSTeamChangeRequest ssTeamChangeReq = waitNext(proxy.ssTeamChange.getFuture())) {
+			addActor.send(proxyApplySSTeamChange(ssTeamChangeReq));
 		}
 	}
 }

--- a/fdbserver/CommitProxyServer.actor.cpp
+++ b/fdbserver/CommitProxyServer.actor.cpp
@@ -1784,9 +1784,9 @@ ACTOR Future<Void> proxyCheckSafeExclusion(Reference<AsyncVar<ServerDBInfo>> db,
 	return Void();
 }
 
-ACTOR Future<Void> proxyApplySSTeamChange(SSTeamChangeRequest ssTeamChangeReq) {
+void proxyApplySSTeamChange(SSTeamChangeRequest ssTeamChangeReq) {
+	// TODO: Need to update the SS team info on the proxy.
 	ssTeamChangeReq.reply.send(Void());
-	return Void();
 }
 
 ACTOR Future<Void> reportTxnTagCommitCost(UID myID,
@@ -2042,7 +2042,7 @@ ACTOR Future<Void> commitProxyServerCore(CommitProxyInterface proxy,
 			wait(yield());
 		}
 		when(SSTeamChangeRequest ssTeamChangeReq = waitNext(proxy.ssTeamChange.getFuture())) {
-			addActor.send(proxyApplySSTeamChange(ssTeamChangeReq));
+			proxyApplySSTeamChange(ssTeamChangeReq);
 		}
 	}
 }


### PR DESCRIPTION
Set up an RPC channel between DD and proxy so DD can inform proxy about storage team changes.

NOTE: Making proxy to actually update the storage team information on receiving an RPC from DD will be done in a follow up PR. (This is because proxies currently don't initialize the storage team information when they start.)

Changes:

CommitProxyInterface.h: Add a new RequestStream to CommitProxyInterface so DD can inform
proxy about storage team changes.

CommitProxyServer.actor.cpp:
commitProxyServerCore(): Extend this method so as to process the new RequestStream that has
been added to the CommitProxyInterface.
proxyApplySSTeamChange(): A new method that updates the local storage team info on receiving
a team change notification from DD.

DataDistribution.actor.cpp:

notifySSTeamChange(): A new actor method that informs proxy about a storage team change
and then waits for a reply.

addTeam(), removeTeam(): Extend these methods to inform proxy about team changes.

Testing: Ran simulation tests. Noticed SEGV in a number of tests in addTeam() but it appears that failure is not because of the changes in this PR.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
