### PR TITLE
Don't inject TSS faults if speedUpSimulation is set

### DIFF
--- a/fdbserver/QuietDatabase.actor.cpp
+++ b/fdbserver/QuietDatabase.actor.cpp
@@ -358,11 +358,7 @@ ACTOR Future<int64_t> getMaxStorageServerQueueSize(Database cx, Reference<AsyncV
 			    .detail("SS", servers[i].id());
 			throw attribute_not_found();
 		}
-		// Ignore TSS in add delay mode since it can purposefully freeze forever
-		if (!servers[i].isTss() || !g_network->isSimulated() ||
-		    g_simulator.tssMode != ISimulator::TSSMode::EnabledAddDelay) {
-			messages.push_back(getStorageMetricsTimeout(servers[i].id(), itr->second));
-		}
+		messages.push_back(getStorageMetricsTimeout(servers[i].id(), itr->second));
 	}
 
 	wait(waitForAll(messages));

--- a/fdbserver/workloads/ConsistencyCheck.actor.cpp
+++ b/fdbserver/workloads/ConsistencyCheck.actor.cpp
@@ -1498,10 +1498,7 @@ struct ConsistencyCheckWorkload : TestWorkload {
 								    .error(e);
 
 								// All shards should be available in quiscence
-								if (self->performQuiescentChecks &&
-								    ((g_network->isSimulated() &&
-								      g_simulator.tssMode != ISimulator::TSSMode::EnabledAddDelay) ||
-								     !storageServerInterfaces[j].isTss())) {
+								if (self->performQuiescentChecks) {
 									self->testFailure("Storage server unavailable");
 									return false;
 								}


### PR DESCRIPTION
Fixes a simulation bug with TSS fault injection, where the infinite sleep caused markus' double recruitment case to trigger.
I also removed the logic in the consistency check and quiet database that checked the infinite sleep, since with this fix, they should no longer fail indefinitely.

Failed 2 out of 100k correctness tests, but they appear unrelated, as neither of them had TSS enabled, and these changes only change behavior when TSS is enabled with fault injection.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
