### PR TITLE
Do not allow descriptor to change on upgrade tests

### DIFF
--- a/tests/restarting/from_7.0.0/ConfigureTestRestart-1.txt
+++ b/tests/restarting/from_7.0.0/ConfigureTestRestart-1.txt
@@ -3,6 +3,7 @@ clearAfterTest=false
 
     testName=ConfigureDatabase
     testDuration=30.0
+    allowDescriptorChange=false
 
     testName=RandomClogging
     testDuration=30.0

--- a/tests/restarting/from_7.0.0/ConfigureTestRestart-2.txt
+++ b/tests/restarting/from_7.0.0/ConfigureTestRestart-2.txt
@@ -3,6 +3,7 @@ runSetup=false
 
     testName=ConfigureDatabase
     testDuration=300.0
+    allowDescriptorChange=false
 
     testName=RandomClogging
     testDuration=300.0


### PR DESCRIPTION
The upgrade test (step 1) may choose to modify the descriptor name and kill the cluster before all the processes have made the change. In this case (in step 2), an error could be generated if descriptor mismatches are disallowed. The error is only generated if a knob is set. It is possible the knob was off in step 1 and on in step 2.

For more information see: [issue4984](https://github.com/apple/foundationdb/issues/4984)

This PR adds a switch to the upgrade test forcing the knob to be the same in both steps 1 and 2 of the upgrade. If the knob is set to enable cross cluster traffic, mismatched descriptors is not an error. Otherwise, the descriptor will not be changed so there will also be no error. 

Tested by recreating the original problem, then retesting with the fix. 