### PR TITLE
Cherrypick "Histograms for storage server write path components." to 7.0

### DIFF
--- a/fdbserver/StorageMetrics.actor.h
+++ b/fdbserver/StorageMetrics.actor.h
@@ -31,6 +31,14 @@ const StringRef STORAGESERVER_HISTOGRAM_GROUP = LiteralStringRef("StorageServer"
 const StringRef FETCH_KEYS_LATENCY_HISTOGRAM = LiteralStringRef("FetchKeysLatency");
 const StringRef FETCH_KEYS_BYTES_HISTOGRAM = LiteralStringRef("FetchKeysSize");
 const StringRef FETCH_KEYS_BYTES_PER_SECOND_HISTOGRAM = LiteralStringRef("FetchKeysBandwidth");
+const StringRef TLOG_CURSOR_READS_LATENCY_HISTOGRAM = LiteralStringRef("TLogCursorReadsLatency");
+const StringRef SS_VERSION_LOCK_LATENCY_HISTOGRAM = LiteralStringRef("SSVersionLockLatency");
+const StringRef EAGER_READS_LATENCY_HISTOGRAM = LiteralStringRef("EagerReadsLatency");
+const StringRef FETCH_KEYS_PTREE_UPDATES_LATENCY_HISTOGRAM = LiteralStringRef("FetchKeysPTreeUpdatesLatency");
+const StringRef TLOG_MSGS_PTREE_UPDATES_LATENCY_HISTOGRAM = LiteralStringRef("TLogMsgsPTreeUpdatesLatency");
+const StringRef STORAGE_UPDATES_DURABLE_LATENCY_HISTOGRAM = LiteralStringRef("StorageUpdatesDurableLatency");
+const StringRef STORAGE_COMMIT_LATENCY_HISTOGRAM = LiteralStringRef("StorageCommitLatency");
+const StringRef SS_DURABLE_VERSION_UPDATE_LATENCY_HISTOGRAM = LiteralStringRef("SSDurableVersionUpdateLatency");
 
 struct StorageMetricSample {
 	IndexedSet<Key, int64_t> sample;

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -364,6 +364,15 @@ public:
 		                                      Histogram::Unit::bytes_per_second)) {}
 	} fetchKeysHistograms;
 
+	Reference<Histogram> tlogCursorReadsLatencyHistogram;
+	Reference<Histogram> ssVersionLockLatencyHistogram;
+	Reference<Histogram> eagerReadsLatencyHistogram;
+	Reference<Histogram> fetchKeysPTreeUpdatesLatencyHistogram;
+	Reference<Histogram> tLogMsgsPTreeUpdatesLatencyHistogram;
+	Reference<Histogram> storageUpdatesDurableLatencyHistogram;
+	Reference<Histogram> storageCommitLatencyHistogram;
+	Reference<Histogram> ssDurableVersionUpdateLatencyHistogram;
+
 	// watch map operations
 	Reference<ServerWatchMetadata> getWatchMetadata(KeyRef key) const;
 	KeyRef setWatchMetadata(Reference<ServerWatchMetadata> metadata);
@@ -780,7 +789,31 @@ public:
 	    counters(this), tag(invalidTag), maxQueryQueue(0), thisServerID(ssi.id()), tssInQuarantine(false),
 	    readQueueSizeMetric(LiteralStringRef("StorageServer.ReadQueueSize")), behind(false), versionBehind(false),
 	    byteSampleClears(false, LiteralStringRef("\xff\xff\xff")), noRecentUpdates(false), lastUpdate(now()),
-	    poppedAllAfter(std::numeric_limits<Version>::max()), cpuUsage(0.0), diskUsage(0.0) {
+	    poppedAllAfter(std::numeric_limits<Version>::max()), cpuUsage(0.0), diskUsage(0.0),
+	    tlogCursorReadsLatencyHistogram(Histogram::getHistogram(STORAGESERVER_HISTOGRAM_GROUP,
+	                                                            TLOG_CURSOR_READS_LATENCY_HISTOGRAM,
+	                                                            Histogram::Unit::microseconds)),
+	    ssVersionLockLatencyHistogram(Histogram::getHistogram(STORAGESERVER_HISTOGRAM_GROUP,
+	                                                          SS_VERSION_LOCK_LATENCY_HISTOGRAM,
+	                                                          Histogram::Unit::microseconds)),
+	    eagerReadsLatencyHistogram(Histogram::getHistogram(STORAGESERVER_HISTOGRAM_GROUP,
+	                                                       EAGER_READS_LATENCY_HISTOGRAM,
+	                                                       Histogram::Unit::microseconds)),
+	    fetchKeysPTreeUpdatesLatencyHistogram(Histogram::getHistogram(STORAGESERVER_HISTOGRAM_GROUP,
+	                                                                  FETCH_KEYS_PTREE_UPDATES_LATENCY_HISTOGRAM,
+	                                                                  Histogram::Unit::microseconds)),
+	    tLogMsgsPTreeUpdatesLatencyHistogram(Histogram::getHistogram(STORAGESERVER_HISTOGRAM_GROUP,
+	                                                                 TLOG_MSGS_PTREE_UPDATES_LATENCY_HISTOGRAM,
+	                                                                 Histogram::Unit::microseconds)),
+	    storageUpdatesDurableLatencyHistogram(Histogram::getHistogram(STORAGESERVER_HISTOGRAM_GROUP,
+	                                                                  STORAGE_UPDATES_DURABLE_LATENCY_HISTOGRAM,
+	                                                                  Histogram::Unit::microseconds)),
+	    storageCommitLatencyHistogram(Histogram::getHistogram(STORAGESERVER_HISTOGRAM_GROUP,
+	                                                          STORAGE_COMMIT_LATENCY_HISTOGRAM,
+	                                                          Histogram::Unit::microseconds)),
+	    ssDurableVersionUpdateLatencyHistogram(Histogram::getHistogram(STORAGESERVER_HISTOGRAM_GROUP,
+	                                                                   SS_DURABLE_VERSION_UPDATE_LATENCY_HISTOGRAM,
+	                                                                   Histogram::Unit::microseconds)) {
 		version.initMetric(LiteralStringRef("StorageServer.Version"), counters.cc.id);
 		oldestVersion.initMetric(LiteralStringRef("StorageServer.OldestVersion"), counters.cc.id);
 		durableVersion.initMetric(LiteralStringRef("StorageServer.DurableVersion"), counters.cc.id);
@@ -3397,12 +3430,14 @@ ACTOR Future<Void> update(StorageServer* data, bool* pReceivedUpdate) {
 
 		state Reference<ILogSystem::IPeekCursor> cursor = data->logCursor;
 
+		state double beforeTLogCursorReads = now();
 		loop {
 			wait(cursor->getMore());
 			if (!cursor->isExhausted()) {
 				break;
 			}
 		}
+		data->tlogCursorReadsLatencyHistogram->sampleSeconds(now() - beforeTLogCursorReads);
 		if (cursor->popped() > 0) {
 			throw worker_removed();
 		}
@@ -3422,6 +3457,7 @@ ACTOR Future<Void> update(StorageServer* data, bool* pReceivedUpdate) {
 			    .detailf("From", "%016llx", debug_lastLoadBalanceResultEndpointToken)
 			    .detail("Duration", now() - start)
 			    .detail("Version", data->version.get());
+		data->ssVersionLockLatencyHistogram->sampleSeconds(now() - start);
 
 		start = now();
 		state UpdateEagerReadInfo eager;
@@ -3492,6 +3528,7 @@ ACTOR Future<Void> update(StorageServer* data, bool* pReceivedUpdate) {
 			// selectively
 			eager = UpdateEagerReadInfo();
 		}
+		data->eagerReadsLatencyHistogram->sampleSeconds(now() - start);
 
 		if (now() - start > 0.1)
 			TraceEvent("SSSlowTakeLock2", data->thisServerID)
@@ -3511,6 +3548,7 @@ ACTOR Future<Void> update(StorageServer* data, bool* pReceivedUpdate) {
 		state bool injectedChanges = false;
 		state int changeNum = 0;
 		state int mutationBytes = 0;
+		state double beforeFetchKeysUpdates = now();
 		for (; changeNum < fii.changes.size(); changeNum++) {
 			state int mutationNum = 0;
 			state VerUpdateRef* pUpdate = &fii.changes[changeNum];
@@ -3524,10 +3562,12 @@ ACTOR Future<Void> update(StorageServer* data, bool* pReceivedUpdate) {
 				}
 			}
 		}
+		data->fetchKeysPTreeUpdatesLatencyHistogram->sampleSeconds(now() - beforeFetchKeysUpdates);
 
 		state Version ver = invalidVersion;
 		cloneCursor2->setProtocolVersion(data->logProtocol);
 		state SpanID spanContext = SpanID();
+		state double beforeTLogMsgsUpdates = now();
 		for (; cloneCursor2->hasMessage(); cloneCursor2->nextMessage()) {
 			if (mutationBytes > SERVER_KNOBS->DESIRED_UPDATE_BYTES) {
 				mutationBytes = 0;
@@ -3620,6 +3660,7 @@ ACTOR Future<Void> update(StorageServer* data, bool* pReceivedUpdate) {
 					    .detail("Version", cloneCursor2->version().toString());
 			}
 		}
+		data->tLogMsgsPTreeUpdatesLatencyHistogram->sampleSeconds(now() - beforeTLogMsgsUpdates);
 
 		if (ver != invalidVersion) {
 			data->lastVersionWithData = ver;
@@ -3740,6 +3781,7 @@ ACTOR Future<Void> updateStorage(StorageServer* data) {
 		state int64_t bytesLeft = SERVER_KNOBS->STORAGE_COMMIT_BYTES;
 
 		// Write mutations to storage until we reach the desiredVersion or have written too much (bytesleft)
+		state double beforeStorageUpdates = now();
 		loop {
 			state bool done = data->storage.makeVersionMutationsDurable(newOldestVersion, desiredVersion, bytesLeft);
 			// We want to forget things from these data structures atomically with changing oldestVersion (and "before",
@@ -3757,8 +3799,10 @@ ACTOR Future<Void> updateStorage(StorageServer* data) {
 		// Set the new durable version as part of the outstanding change set, before commit
 		if (startOldestVersion != newOldestVersion)
 			data->storage.makeVersionDurable(newOldestVersion);
+		data->storageUpdatesDurableLatencyHistogram->sampleSeconds(now() - beforeStorageUpdates);
 
 		debug_advanceMaxCommittedVersion(data->thisServerID, newOldestVersion);
+		state double beforeStorageCommit = now();
 		state Future<Void> durable = data->storage.commit();
 		state Future<Void> durableDelay = Void();
 
@@ -3767,6 +3811,7 @@ ACTOR Future<Void> updateStorage(StorageServer* data) {
 		}
 
 		wait(ioTimeoutError(durable, SERVER_KNOBS->MAX_STORAGE_COMMIT_TIME));
+		data->storageCommitLatencyHistogram->sampleSeconds(now() - beforeStorageCommit);
 
 		debug_advanceMinCommittedVersion(data->thisServerID, newOldestVersion);
 
@@ -3791,6 +3836,7 @@ ACTOR Future<Void> updateStorage(StorageServer* data) {
 		// Taking and releasing the durableVersionLock ensures that no eager reads both begin before the commit was
 		// effective and are applied after we change the durable version. Also ensure that we have to lock while calling
 		// changeDurableVersion, because otherwise the latest version of mutableData might be partially loaded.
+		state double beforeSSDurableVersionUpdate = now();
 		wait(data->durableVersionLock.take());
 		data->popVersion(data->durableVersion.get() + 1);
 
@@ -3803,6 +3849,7 @@ ACTOR Future<Void> updateStorage(StorageServer* data) {
 		}
 
 		data->durableVersionLock.release();
+		data->ssDurableVersionUpdateLatencyHistogram->sampleSeconds(now() - beforeSSDurableVersionUpdate);
 
 		//TraceEvent("StorageServerDurable", data->thisServerID).detail("Version", newOldestVersion);
 


### PR DESCRIPTION
Cherrypick of #4961 of master branch in 7.0 branch. The storage server write path has a number of components that all could be the cause of a write slowdown (e.g.tlog reads, ptree update, disk update, commit). Any of these could be the cause of a storage server’s write path to get behind, but we do not currently have visibility into which component is causing the slowdown.
In this PR, several latency histograms are added into the storage server write path which should help us in understanding/debugging the bottlenecks or performance issues if any. We need these changes in 7.0 to debug the write path issues if any.

Testing:
20210621-120318-neethuhaneeshabingi-05e3666f3dc929ed compressed=True data_size=23556711 duration=4809619 ended=101975 fail=1 fail_fast=10 max_runs=100000 pass=100852 priority=100 remaining=0 runtime=0:27:19 sanity=False started=102498 stopped=20210621-123037 submitted=20210621-120318 timeout=5400 username=neethuhaneeshabingi
Local cluster run logs:
3/log/trace.127.0.0.1.1503.1624277014.LiiYZT.0.2.xml:Event Severity="10" Time="1624279114.853669" DateTime="2021-06-21T12:38:34Z" Type="Histogram" ID="0000000000000000" Group="StorageServer" Op="TLogCursorReadsLatency" Unit="microseconds" LessThan16.384="2" LessThan32.768="1" LessThan65.536="4" LessThan131.072="1" LessThan262.144="3" LessThan524.288="3" LessThan2097.152="34" LessThan4194.304="71" Machine="127.0.0.1:1503" LogGroup="default" Roles="CP,DD,MS,RK,SS" 
3/log/trace.127.0.0.1.1503.1624277014.LiiYZT.0.2.xml:Event Severity="10" Time="1624279114.853669" DateTime="2021-06-21T12:38:34Z" Type="Histogram" ID="0000000000000000" Group="StorageServer" Op="TLogMsgsPTreeUpdatesLatency" Unit="microseconds" LessThan0.002="119" Machine="127.0.0.1:1503" LogGroup="default" Roles="CP,DD,MS,RK,SS" 
3/log/trace.127.0.0.1.1503.1624277014.LiiYZT.0.2.xml:Event Severity="10" Time="1624279414.853682" DateTime="2021-06-21T12:43:34Z" Type="Histogram" ID="0000000000000000" Group="StorageServer" Op="EagerReadsLatency" Unit="microseconds" LessThan0.002="113" Machine="127.0.0.1:1503" LogGroup="default" Roles="CP,DD,MS,RK,SS" 
3/log/trace.127.0.0.1.1503.1624277014.LiiYZT.0.2.xml:Event Severity="10" Time="1624279414.853682" DateTime="2021-06-21T12:43:34Z" Type="Histogram" ID="0000000000000000" Group="StorageServer" Op="FetchKeysPTreeUpdatesLatency" Unit="microseconds" LessThan0.002="113" Machine="127.0.0.1:1503" LogGroup="default" Roles="CP,DD,MS,RK,SS" 
3/log/trace.127.0.0.1.1503.1624277014.LiiYZT.0.2.xml:Event Severity="10" Time="1624279414.853682" DateTime="2021-06-21T12:43:34Z" Type="Histogram" ID="0000000000000000" Group="StorageServer" Op="SSDurableVersionUpdateLatency" Unit="microseconds" LessThan0.002="113" Machine="127.0.0.1:1503" LogGroup="default" Roles="CP,DD,MS,RK,SS" 
3/log/trace.127.0.0.1.1503.1624277014.LiiYZT.0.2.xml:Event Severity="10" Time="1624279414.853682" DateTime="2021-06-21T12:43:34Z" Type="Histogram" ID="0000000000000000" Group="StorageServer" Op="SSVersionLockLatency" Unit="microseconds" LessThan0.002="113" Machine="127.0.0.1:1503" LogGroup="default" Roles="CP,DD,MS,RK,SS"
3/log/trace.127.0.0.1.1503.1624277014.LiiYZT.0.2.xml:Event Severity="10" Time="1624279414.853682" DateTime="2021-06-21T12:43:34Z" Type="Histogram" ID="0000000000000000" Group="StorageServer" Op="StorageCommitLatency" Unit="microseconds" LessThan2.048="108" LessThan4.096="4" LessThan8.192="1" Machine="127.0.0.1:1503" LogGroup="default" Roles="CP,DD,MS,RK,SS"
3/log/trace.127.0.0.1.1503.1624277014.LiiYZT.0.2.xml:Event Severity="10" Time="1624279414.853682" DateTime="2021-06-21T12:43:34Z" Type="Histogram" ID="0000000000000000" Group="StorageServer" Op="StorageUpdatesDurableLatency" Unit="microseconds" LessThan0.002="113" Machine="127.0.0.1:1503" LogGroup="default" Roles="CP,DD,MS,RK,SS" 

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
