### PR TITLE
FlowMutex unit test bug and macOS compilation fix

### DIFF
--- a/fdbrpc/FlowTests.actor.cpp
+++ b/fdbrpc/FlowTests.actor.cpp
@@ -1581,26 +1581,18 @@ TEST_CASE("/flow/flow/FlowMutex") {
 				}
 				error = e;
 
-				// Wait for all actors still running to finish their waits and try to take the mutex
+				// Some actors can still be running, waiting while locked or unlocked,
+				// but all should become ready, some with errors.
+				state int i;
 				if (verbose) {
-					printf("Waiting for completions\n");
+					printf("Waiting for completions.  Future end states:\n");
 				}
-				wait(delay(2 * mutexTestDelay));
-
-				if (verbose) {
-					printf("Future end states:\n");
-				}
-				// All futures should be ready, some with errors.
-				bool allReady = true;
-				for (int i = 0; i < tests.size(); ++i) {
-					auto f = tests[i];
+				for (i = 0; i < tests.size(); ++i) {
+					ErrorOr<Void> f = wait(errorOr(tests[i]));
 					if (verbose) {
-						printf(
-						    "  %d: %s\n", i, f.isReady() ? (f.isError() ? f.getError().what() : "done") : "not ready");
+						printf("  %d: %s\n", i, f.isError() ? f.getError().what() : "done");
 					}
-					allReady = allReady && f.isReady();
 				}
-				ASSERT(allReady);
 			}
 
 			// If an error was caused, one should have been detected.

--- a/fdbserver/SimpleConfigDatabaseNode.actor.cpp
+++ b/fdbserver/SimpleConfigDatabaseNode.actor.cpp
@@ -293,7 +293,7 @@ class SimpleConfigDatabaseNodeImpl {
 		for (const auto& kv : snapshot) {
 			auto configKey =
 			    BinaryReader::fromStringRef<ConfigKey>(kv.key.removePrefix(kvKeys.begin), IncludeVersion());
-			if (configKey.configClass.castTo<Key>() == req.configClass) {
+			if (configKey.configClass.template castTo<Key>() == req.configClass) {
 				knobSet.insert(configKey.knobName);
 			}
 		}
@@ -301,7 +301,7 @@ class SimpleConfigDatabaseNodeImpl {
 		state Standalone<VectorRef<VersionedConfigMutationRef>> mutations =
 		    wait(getMutations(self, lastCompactedVersion + 1, req.version));
 		for (const auto& versionedMutation : mutations) {
-			if (versionedMutation.mutation.getConfigClass().castTo<Key>() == req.configClass) {
+			if (versionedMutation.mutation.getConfigClass().template castTo<Key>() == req.configClass) {
 				if (versionedMutation.mutation.isSet()) {
 					knobSet.insert(versionedMutation.mutation.getKnobName());
 				} else {


### PR DESCRIPTION
FlowMutex test could fail with buggify on due to additional injected delays.  This fix waits for each future to be ready regardless of delay.

Fixed macOS compilation error, for some reason AppleClang is pickier.

I ran the affected unit test with buggify on a few dozen times to prove it works.  It used to fail almost always.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
