### PR TITLE
Cherrypick "Adding TraceEvent when a worker is removed from cluster controller." to 6.3

### DIFF
--- a/fdbserver/ClusterController.actor.cpp
+++ b/fdbserver/ClusterController.actor.cpp
@@ -2216,7 +2216,10 @@ ACTOR Future<Void> workerAvailabilityWatch(WorkerInterface worker,
 				cluster->removedDBInfoEndpoints.insert(worker.updateServerDBInfo.getEndpoint());
 				cluster->id_worker.erase(worker.locality.processId());
 				cluster->updateWorkerList.set(worker.locality.processId(), Optional<ProcessData>());
-				TraceEvent("ClusterFailedWorker", cluster->id).detail("WorkerProcessId", worker.locality.processId());
+				TraceEvent("ClusterControllerWorkerFailed", cluster->id)
+					.detail("WorkerProcessId", worker.locality.processId())
+					.detail("WorkerProcessClass", failedWorkerInfo.details.processClass.toString())
+					.detail("WorkerAddress", worker.address());
 				return Void();
 			}
 		}

--- a/fdbserver/ClusterController.actor.cpp
+++ b/fdbserver/ClusterController.actor.cpp
@@ -2217,9 +2217,9 @@ ACTOR Future<Void> workerAvailabilityWatch(WorkerInterface worker,
 				cluster->id_worker.erase(worker.locality.processId());
 				cluster->updateWorkerList.set(worker.locality.processId(), Optional<ProcessData>());
 				TraceEvent("ClusterControllerWorkerFailed", cluster->id)
-					.detail("WorkerProcessId", worker.locality.processId())
-					.detail("WorkerProcessClass", failedWorkerInfo.details.processClass.toString())
-					.detail("WorkerAddress", worker.address());
+					.detail("ProcessId", worker.locality.processId())
+					.detail("ProcessClass", failedWorkerInfo.details.processClass.toString())
+					.detail("Address", worker.address());
 				return Void();
 			}
 		}

--- a/fdbserver/ClusterController.actor.cpp
+++ b/fdbserver/ClusterController.actor.cpp
@@ -2213,13 +2213,13 @@ ACTOR Future<Void> workerAvailabilityWatch(WorkerInterface worker,
 				if (worker.locality.processId() == cluster->masterProcessId) {
 					cluster->masterProcessId = Optional<Key>();
 				}
-				cluster->removedDBInfoEndpoints.insert(worker.updateServerDBInfo.getEndpoint());
-				cluster->id_worker.erase(worker.locality.processId());
-				cluster->updateWorkerList.set(worker.locality.processId(), Optional<ProcessData>());
 				TraceEvent("ClusterControllerWorkerFailed", cluster->id)
 					.detail("ProcessId", worker.locality.processId())
 					.detail("ProcessClass", failedWorkerInfo.details.processClass.toString())
 					.detail("Address", worker.address());
+				cluster->removedDBInfoEndpoints.insert(worker.updateServerDBInfo.getEndpoint());
+				cluster->id_worker.erase(worker.locality.processId());
+				cluster->updateWorkerList.set(worker.locality.processId(), Optional<ProcessData>());
 				return Void();
 			}
 		}

--- a/fdbserver/ClusterController.actor.cpp
+++ b/fdbserver/ClusterController.actor.cpp
@@ -2216,6 +2216,7 @@ ACTOR Future<Void> workerAvailabilityWatch(WorkerInterface worker,
 				cluster->removedDBInfoEndpoints.insert(worker.updateServerDBInfo.getEndpoint());
 				cluster->id_worker.erase(worker.locality.processId());
 				cluster->updateWorkerList.set(worker.locality.processId(), Optional<ProcessData>());
+				TraceEvent("ClusterFailedWorker", cluster->id).detail("WorkerProcessId", worker.locality.processId());
 				return Void();
 			}
 		}


### PR DESCRIPTION
Cherrypick of #4730 from master to release-6.3 branch. 
Adding TraceEvent when a worker is removed from cluster controller. This log statement helps the SRE's to easily find that a worked is removed form the cluster controller.
As this piece of information is critical to know, it would be beneficial to have it in the release branch.

Testing:
Joshua test run:
20210621-200941-neethuhaneeshabingi-144f310e2f3d01eb compressed=True data_size=21416937 duration=6062686 ended=100268 fail=1 fail_fast=10 max_runs=100000 pass=100115 priority=100 remaining=0 runtime=0:23:08 sanity=False started=100728 stopped=20210621-203249 submitted=20210621-200941 timeout=5400 username=neethuhaneeshabingi
1 test failure seems unrelated to this change and passes when run locally.
Simulation Test run:
build_output/bin/fdbserver -r simulation --crash --logsize 1024MB -f src/foundationdb/tests/fast/BackupCorrectness.txt -s 235461 -b on
grep -e ClusterControllerWorkerFailed trace.0.0.0.0.0.1624309571.MGngBL.0.1.xml 
Log: Event Severity="10" Time="123.099334" DateTime="2021-06-21T21:06:31Z" Type="ClusterControllerWorkerFailed" Machine="[abcd::2:0:1:1]:1" ID="7860fd2effe81605" ProcessId="bcc7be38c85631e16571fcaef95c0836" ProcessClass="storage" Address="[abcd::2:5:1:1]:1" LogGroup="default" Roles="CC,DD,MP,MS,RK,RV,SS,TL"

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
