### PR TITLE
Cherrypick "Adding TraceEvent when a worker is removed from cluster controller." to 7.0

### DIFF
--- a/fdbserver/ClusterController.actor.cpp
+++ b/fdbserver/ClusterController.actor.cpp
@@ -3094,9 +3094,9 @@ ACTOR Future<Void> workerAvailabilityWatch(WorkerInterface worker,
 				cluster->id_worker.erase(worker.locality.processId());
 				cluster->updateWorkerList.set(worker.locality.processId(), Optional<ProcessData>());
 				TraceEvent("ClusterControllerWorkerFailed", cluster->id)
-					.detail("WorkerProcessId", worker.locality.processId())
-					.detail("WorkerProcessClass", failedWorkerInfo.details.processClass.toString())
-					.detail("WorkerAddress", worker.address());
+					.detail("ProcessId", worker.locality.processId())
+					.detail("ProcessClass", failedWorkerInfo.details.processClass.toString())
+					.detail("Address", worker.address());
 				return Void();
 			}
 		}

--- a/fdbserver/ClusterController.actor.cpp
+++ b/fdbserver/ClusterController.actor.cpp
@@ -3090,13 +3090,13 @@ ACTOR Future<Void> workerAvailabilityWatch(WorkerInterface worker,
 				if (worker.locality.processId() == cluster->masterProcessId) {
 					cluster->masterProcessId = Optional<Key>();
 				}
-				cluster->removedDBInfoEndpoints.insert(worker.updateServerDBInfo.getEndpoint());
-				cluster->id_worker.erase(worker.locality.processId());
-				cluster->updateWorkerList.set(worker.locality.processId(), Optional<ProcessData>());
 				TraceEvent("ClusterControllerWorkerFailed", cluster->id)
 					.detail("ProcessId", worker.locality.processId())
 					.detail("ProcessClass", failedWorkerInfo.details.processClass.toString())
 					.detail("Address", worker.address());
+				cluster->removedDBInfoEndpoints.insert(worker.updateServerDBInfo.getEndpoint());
+				cluster->id_worker.erase(worker.locality.processId());
+				cluster->updateWorkerList.set(worker.locality.processId(), Optional<ProcessData>());
 				return Void();
 			}
 		}

--- a/fdbserver/ClusterController.actor.cpp
+++ b/fdbserver/ClusterController.actor.cpp
@@ -3093,7 +3093,10 @@ ACTOR Future<Void> workerAvailabilityWatch(WorkerInterface worker,
 				cluster->removedDBInfoEndpoints.insert(worker.updateServerDBInfo.getEndpoint());
 				cluster->id_worker.erase(worker.locality.processId());
 				cluster->updateWorkerList.set(worker.locality.processId(), Optional<ProcessData>());
-				TraceEvent("ClusterFailedWorker", cluster->id).detail("WorkerProcessId", worker.locality.processId());
+				TraceEvent("ClusterControllerWorkerFailed", cluster->id)
+					.detail("WorkerProcessId", worker.locality.processId())
+					.detail("WorkerProcessClass", failedWorkerInfo.details.processClass.toString())
+					.detail("WorkerAddress", worker.address());
 				return Void();
 			}
 		}

--- a/fdbserver/ClusterController.actor.cpp
+++ b/fdbserver/ClusterController.actor.cpp
@@ -3093,6 +3093,7 @@ ACTOR Future<Void> workerAvailabilityWatch(WorkerInterface worker,
 				cluster->removedDBInfoEndpoints.insert(worker.updateServerDBInfo.getEndpoint());
 				cluster->id_worker.erase(worker.locality.processId());
 				cluster->updateWorkerList.set(worker.locality.processId(), Optional<ProcessData>());
+				TraceEvent("ClusterFailedWorker", cluster->id).detail("WorkerProcessId", worker.locality.processId());
 				return Void();
 			}
 		}


### PR DESCRIPTION
Cherrypick of #4730 from master to release-7.0 branch.
Adding TraceEvent when a worker is removed from cluster controller. This log statement helps the SRE's to easily find that a worked is removed form the cluster controller.
As this piece of information is critical to know, it would be beneficial to have it in the release branch.

Testing:
Joshua test run:
20210621-215037-neethuhaneeshabingi-479aa9e8b40028eb compressed=True data_size=23557640 duration=4917490 ended=100614 fail_fast=10 max_runs=100000 pass=100077 priority=100 remaining=0 runtime=0:48:21 sanity=False started=100704 stopped=20210621-223858 submitted=20210621-215037 timeout=5400 username=neethuhaneeshabingi
Simulation Test run:
build_output/bin/fdbserver -r simulation --crash --logsize 1024MB -f src/foundationdb/tests/fast/BackupCorrectness.txt -s 235461 -b on
grep -e ClusterControllerWorkerFailed trace.0.0.0.0.0.1624312430.c2XgUN.0.1.xml 
Log: Event Severity="10" Time="86.201801" DateTime="2021-06-21T21:53:55Z" Type="ClusterControllerWorkerFailed" Machine="[abcd::2:0:1:0]:1" ID="b8c8362ddeac3891" ProcessId="b614168a7259c3c23f9e4bff956625c1" ProcessClass="unset" Address="[abcd::2:3:1:2]:1" LogGroup="default" Roles="BK,CC,CD,GP,SS,TL" 
Event Severity="10" Time="87.655977" DateTime="2021-06-21T21:53:55Z" Type="ClusterControllerWorkerFailed" Machine="[abcd::2:0:1:0]:1" ID="b8c8362ddeac3891" ProcessId="e74eaeb428dc110c3e619149d320d2b8" ProcessClass="unset" Address="[abcd::2:0:1:2]:1" LogGroup="default" Roles="BK,CC,CD,GP,SS,TL" 
Event Severity="10" Time="92.468370" DateTime="2021-06-21T21:53:55Z" Type="ClusterControllerWorkerFailed" Machine="[abcd::2:0:1:0]:1" ID="b8c8362ddeac3891" ProcessId="e74eaeb428dc110c3e619149d320d2b8" ProcessClass="unset" Address="[abcd::2:0:1:2]:1" LogGroup="default" Roles="BK,CC,CD,GP,SS,TL"

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [x] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [x] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [x] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
