### PR TITLE
Add static_assert to serializeBinaryItem

### DIFF
--- a/flow/serialize.h
+++ b/flow/serialize.h
@@ -369,6 +369,8 @@ public:
 	}
 	template <class T>
 	void serializeBinaryItem(const T& t) {
+		static_assert(is_binary_serializable<T>::value,
+		              "Object must be binary serializable, see BINARY_SERIALIZABLE macro");
 		*(T*)writeBytes(sizeof(T)) = t;
 	}
 	void* getData() { return data; }
@@ -543,6 +545,8 @@ public:
 	}
 	template <class T>
 	void serializeBinaryItem(const T& t) {
+		static_assert(is_binary_serializable<T>::value,
+		              "Object must be binary serializable, see BINARY_SERIALIZABLE macro");
 		writeBytes(&t, sizeof(T));
 	}
 
@@ -577,6 +581,8 @@ public:
 
 	template <class T>
 	void serializeBinaryItem(T& t) {
+		static_assert(is_binary_serializable<T>::value,
+		              "Object must be binary serializable, see BINARY_SERIALIZABLE macro");
 		t = *(T*)(static_cast<Impl*>(this)->readBytes(sizeof(T)));
 	}
 
@@ -808,6 +814,8 @@ struct PacketWriter {
 	void serializeBytes(StringRef bytes) { serializeBytes(bytes.begin(), bytes.size()); }
 	template <class T>
 	void serializeBinaryItem(const T& t) {
+		static_assert(is_binary_serializable<T>::value,
+		              "Object must be binary serializable, see BINARY_SERIALIZABLE macro");
 		if (sizeof(T) <= buffer->bytes_unwritten()) {
 			*(T*)(buffer->data() + buffer->bytes_written) = t;
 			buffer->bytes_written += sizeof(T);


### PR DESCRIPTION
BinaryWriter::serializeBinaryItem will accept *any* objects and
serialize them by memory copy. If the object is a struct, padding bytes
will also be copied, which is not expected (at this stage, the
serializer will NOT include any padding). If padding exists, the caller
is required to use _Reader::serializeBinaryItem when reading.

Due to this inconsistency, it is helpful to restrict
serializedBinaryItem calls to limited types. Base on the current
implementation, one reasonable approach is allowing only those types
are BINARY_SERIALIZABLE. This patch addresses such restriction.

The restriction is also applied to other classes:

 * OverWriter
 * _Reader
 * PacketWriter

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
