### PR TITLE
Fix leak due to missing virtual destructor

### DIFF
--- a/fdbclient/IKnobCollection.h
+++ b/fdbclient/IKnobCollection.h
@@ -39,6 +39,8 @@ class IKnobCollection {
 	static std::unique_ptr<IKnobCollection> globalKnobCollection;
 
 public:
+	virtual ~IKnobCollection() = default;
+
 	enum class Type {
 		CLIENT,
 		SERVER,


### PR DESCRIPTION
Deletes are done through a pointer to the base class, so a virtual destructor is needed.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
