### PR TITLE
Add some documentation for the onMainThread functions

### DIFF
--- a/flow/ThreadHelper.actor.h
+++ b/flow/ThreadHelper.actor.h
@@ -55,7 +55,7 @@ void doOnMainThreadVoid(Future<Void> signal, F f, Error* err) {
 // There is no way to wait for the functor run to finish. For cases where you need a result back or simply need
 // to know when the functor has finished running, use `onMainThread`.
 //
-// WARNING: Successive invocations of `onMainThreadVoid` with different task priorities may run out of order.
+// WARNING: Successive invocations of `onMainThreadVoid` with different task priorities may not run in the order they were called.
 //
 // WARNING: The error returned in `err` can only be read on the FDB network thread because there is no way to
 // order the write to `err` with actions on other threads.

--- a/flow/ThreadHelper.actor.h
+++ b/flow/ThreadHelper.actor.h
@@ -52,7 +52,7 @@ void doOnMainThreadVoid(Future<Void> signal, F f, Error* err) {
 } // namespace internal_thread_helper
 
 // onMainThreadVoid runs a functor on the FDB network thread. The value returned by the functor is ignored.
-// There is no way wait for the functor run to finish. For cases where you need a result back or simply need
+// There is no way to wait for the functor run to finish. For cases where you need a result back or simply need
 // to know when the functor has finished running, use `onMainThread`.
 //
 // WARNING: Successive invocations of `onMainThreadVoid` with different task priorities may run out of order.

--- a/flow/ThreadHelper.actor.h
+++ b/flow/ThreadHelper.actor.h
@@ -33,17 +33,38 @@
 #include "flow/flow.h"
 #include "flow/actorcompiler.h" // This must be the last #include.
 
-// template <class F>
-// void onMainThreadVoid( F f ) {
-// 	Promise<Void> signal;
-// 	doOnMainThreadVoid( signal.getFuture(), f );
-// 	g_network->onMainThread( std::move(signal), TaskPriority::DefaultOnMainThread );
-// }
+// Helper actor. Do not use directly!
+namespace internal_thread_helper {
 
+ACTOR template <class F>
+void doOnMainThreadVoid(Future<Void> signal, F f, Error* err) {
+	wait(signal);
+	if (err && err->code() != invalid_error_code)
+		return;
+	try {
+		f();
+	} catch (Error& e) {
+		if (err)
+			*err = e;
+	}
+}
+
+} // namespace internal_thread_helper
+
+// onMainThreadVoid runs a functor on the FDB network thread. The value returned by the functor is ignored.
+// There is no way wait for the functor run to finish. For cases where you need a result back or simply need
+// to know when the functor has finished running, use `onMainThread`.
+//
+// WARNING: Successive invocations of `onMainThreadVoid` with different task priorities may run out of order.
+//
+// WARNING: The error returned in `err` can only be read on the FDB network thread because there is no way to
+// order the write to `err` with actions on other threads.
+//
+// `onMainThreadVoid` is defined here because of the dependency in `ThreadSingleAssignmentVarBase`.
 template <class F>
-void onMainThreadVoid(F f, Error* err, TaskPriority taskID = TaskPriority::DefaultOnMainThread) {
+void onMainThreadVoid(F f, Error* err = nullptr, TaskPriority taskID = TaskPriority::DefaultOnMainThread) {
 	Promise<Void> signal;
-	doOnMainThreadVoid(signal.getFuture(), f, err);
+	internal_thread_helper::doOnMainThreadVoid(signal.getFuture(), f, err);
 	g_network->onMainThread(std::move(signal), taskID);
 }
 
@@ -318,8 +339,7 @@ public:
 		    [this]() {
 			    this->cancelFuture.cancel();
 			    this->delref();
-		    },
-		    nullptr);
+		    });
 	}
 
 	void releaseMemory() {
@@ -582,6 +602,9 @@ Future<T> safeThreadFutureToFuture(ThreadFuture<T> threadFuture) {
 	return threadFuture.get();
 }
 
+// Helper actor. Do not use directly!
+namespace internal_thread_helper {
+
 ACTOR template <class R, class F>
 Future<Void> doOnMainThread(Future<Void> signal, F f, ThreadSingleAssignmentVar<R>* result) {
 	try {
@@ -600,26 +623,24 @@ Future<Void> doOnMainThread(Future<Void> signal, F f, ThreadSingleAssignmentVar<
 	return Void();
 }
 
-ACTOR template <class F>
-void doOnMainThreadVoid(Future<Void> signal, F f, Error* err) {
-	wait(signal);
-	if (err && err->code() != invalid_error_code)
-		return;
-	try {
-		f();
-	} catch (Error& e) {
-		if (err)
-			*err = e;
-	}
-}
+}  // namespace internal_thread_helper
 
+// `onMainThread` runs a functor returning a `Future` on the main thread, waits for the future, and sends either the
+// value returned from the waited `Future` or an error through the `ThreadFuture` returned from the function call.
+//
+// A workaround for cases where your functor returns a non-`Future` value is to wrap the value in an immediately
+// filled `Future`. In cases where the functor returns void, a workaround is to return a `Future<bool>(true)` that
+// can be waited on.
+//
+// TODO: Add SFINAE overloads for functors returning void or a non-Future type.
 template <class F>
 ThreadFuture<decltype(std::declval<F>()().getValue())> onMainThread(F f) {
 	Promise<Void> signal;
 	auto returnValue = new ThreadSingleAssignmentVar<decltype(std::declval<F>()().getValue())>();
 	returnValue->addref(); // For the ThreadFuture we return
-	Future<Void> cancelFuture =
-	    doOnMainThread<decltype(std::declval<F>()().getValue()), F>(signal.getFuture(), f, returnValue);
+	                       // TODO: Is this cancellation logic actually needed?
+	Future<Void> cancelFuture = internal_thread_helper::doOnMainThread<decltype(std::declval<F>()().getValue()), F>(
+	    signal.getFuture(), f, returnValue);
 	returnValue->setCancel(std::move(cancelFuture));
 	g_network->onMainThread(std::move(signal), TaskPriority::DefaultOnMainThread);
 	return ThreadFuture<decltype(std::declval<F>()().getValue())>(returnValue);

--- a/flow/ThreadHelper.actor.h
+++ b/flow/ThreadHelper.actor.h
@@ -638,7 +638,7 @@ ThreadFuture<decltype(std::declval<F>()().getValue())> onMainThread(F f) {
 	Promise<Void> signal;
 	auto returnValue = new ThreadSingleAssignmentVar<decltype(std::declval<F>()().getValue())>();
 	returnValue->addref(); // For the ThreadFuture we return
-	                       // TODO: Is this cancellation logic actually needed?
+	// TODO: Is this cancellation logic actually needed?
 	Future<Void> cancelFuture = internal_thread_helper::doOnMainThread<decltype(std::declval<F>()().getValue()), F>(
 	    signal.getFuture(), f, returnValue);
 	returnValue->setCancel(std::move(cancelFuture));


### PR DESCRIPTION
The `onMainThread` functions are currently under documented and somewhat hard to use. This PR reorganizes the code slightly and adds some documentation. 

The only actual code change is to make the `err` parameter in `onMainThreadVoid` optional. Most uses of it currently already pass in `nullptr`, so those could be made more concise. I did not make those changes simply to make this PR smaller.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
