### PR TITLE
Fixed a destruction order bug with parallel stream

### DIFF
--- a/fdbclient/ParallelStream.actor.h
+++ b/fdbclient/ParallelStream.actor.h
@@ -35,7 +35,7 @@
 // in order.
 template <class T>
 class ParallelStream {
-	BoundedFlowLock semaphore;
+	Reference<BoundedFlowLock> semaphore;
 	struct FragmentConstructorTag {
 		explicit FragmentConstructorTag() = default;
 	};
@@ -43,14 +43,14 @@ class ParallelStream {
 public:
 	// A Fragment is a single stream that will get results to be merged back into the main output stream
 	class Fragment : public ReferenceCounted<Fragment> {
-		ParallelStream* parallelStream;
+		Reference<BoundedFlowLock> semaphore;
 		PromiseStream<T> stream;
 		BoundedFlowLock::Releaser releaser;
 		friend class ParallelStream;
 
 	public:
-		Fragment(ParallelStream* parallelStream, int64_t permitNumber, FragmentConstructorTag)
-		  : parallelStream(parallelStream), releaser(&parallelStream->semaphore, permitNumber) {}
+		Fragment(Reference<BoundedFlowLock> semaphore, int64_t permitNumber, FragmentConstructorTag)
+		  : semaphore(semaphore), releaser(semaphore.getPtr(), permitNumber) {}
 		template <class U>
 		void send(U&& value) {
 			stream.send(std::forward<U>(value));
@@ -105,14 +105,15 @@ public:
 		}
 	}
 
-	ParallelStream(PromiseStream<T> results, size_t bufferLimit) : results(results), semaphore(1, bufferLimit) {
+	ParallelStream(PromiseStream<T> results, size_t bufferLimit) : results(results) {
+		semaphore = makeReference<BoundedFlowLock>(1, bufferLimit);
 		flusher = flushToClient(this);
 	}
 
 	// Creates a fragment to get merged into the main output stream
 	ACTOR static Future<Fragment*> createFragmentImpl(ParallelStream<T>* self) {
-		int64_t permitNumber = wait(self->semaphore.take());
-		auto fragment = makeReference<Fragment>(self, permitNumber, FragmentConstructorTag());
+		int64_t permitNumber = wait(self->semaphore->take());
+		auto fragment = makeReference<Fragment>(self->semaphore, permitNumber, FragmentConstructorTag());
 		self->fragments.send(fragment);
 		return fragment.getPtr();
 	}


### PR DESCRIPTION
Cherry pick of #5049 

This needs to be in 7.0 because it breaks correctness.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
