### PR TITLE
fixed a trace event which used fetchVersion before it was defined in the actor 

### DIFF
--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -2833,10 +2833,6 @@ ACTOR Future<Void> fetchKeys(StorageServer* data, AddingShard* shard) {
 
 		wait(delay(0));
 
-		TraceEvent(SevDebug, "FetchKeysUnblocked", data->thisServerID)
-		    .detail("FKID", interval.pairID)
-		    .detail("Version", fetchVersion);
-
 		// Get the history
 		state int debug_getRangeRetries = 0;
 		state int debug_nextRetryToLog = 1;
@@ -2849,6 +2845,11 @@ ACTOR Future<Void> fetchKeys(StorageServer* data, AddingShard* shard) {
 		loop {
 			state Transaction tr(data->cx);
 			state Version fetchVersion = data->version.get();
+
+			TraceEvent(SevDebug, "FetchKeysUnblocked", data->thisServerID)
+			    .detail("FKID", interval.pairID)
+			    .detail("Version", fetchVersion);
+
 			while (!shard->updates.empty() && shard->updates[0].version <= fetchVersion)
 				shard->updates.pop_front();
 			tr.setVersion(fetchVersion);


### PR DESCRIPTION
cherry pick of #5073

needs to be in 7.0 because it is a correctness problem

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
