### PR TITLE
Cherry-pick Release-7.0: Add metric to track the ratio of empty messages to tlogs

### DIFF
--- a/fdbserver/CommitProxyServer.actor.cpp
+++ b/fdbserver/CommitProxyServer.actor.cpp
@@ -1185,7 +1185,7 @@ ACTOR Future<Void> postResolution(CommitBatchContext* self) {
 	                                                          span.context,
 	                                                          self->debugID);
 
-	float ratio = self->toCommit.getEmptyLocationRatio();
+	float ratio = self->toCommit.getEmptyMessageRatio();
 	pProxyCommitData->stats.commitBatchingEmptyMessageRatio.addMeasurement(ratio);
 
 	if (!self->forceRecovery) {

--- a/fdbserver/CommitProxyServer.actor.cpp
+++ b/fdbserver/CommitProxyServer.actor.cpp
@@ -1185,6 +1185,9 @@ ACTOR Future<Void> postResolution(CommitBatchContext* self) {
 	                                                          span.context,
 	                                                          self->debugID);
 
+	float ratio = self->toCommit.getEmptyLocationRatio();
+	pProxyCommitData->stats.commitBatchingEmptyMessageRatio.addMeasurement(ratio);
+
 	if (!self->forceRecovery) {
 		ASSERT(pProxyCommitData->latestLocalCommitBatchLogging.get() == self->localBatchNumber - 1);
 		pProxyCommitData->latestLocalCommitBatchLogging.set(self->localBatchNumber);

--- a/fdbserver/LogSystem.h
+++ b/fdbserver/LogSystem.h
@@ -1094,6 +1094,8 @@ struct LogPushData : NonCopyable {
 		return messagesWriter[loc].toValue();
 	}
 
+	// Records if a tlog (specified by "loc") will receive an empty version batch message.
+	// "value" is the message returned by getMessages() call.
 	void recordEmptyMessage(int loc, const Standalone<StringRef>& value) {
 		if (!isEmptyMessage[loc]) {
 			BinaryWriter w(AssumeVersion(g_network->protocolVersion()));
@@ -1104,6 +1106,8 @@ struct LogPushData : NonCopyable {
 		}
 	}
 
+	// Returns the ratio of empty messages in this version batch.
+	// MUST be called after getMessages() and recordEmptyMessage().
 	float getEmptyMessageRatio() const {
 		auto count = std::count(isEmptyMessage.begin(), isEmptyMessage.end(), false);
 		ASSERT_WE_THINK(isEmptyMessage.size() > 0);

--- a/fdbserver/ProxyCommitData.actor.h
+++ b/fdbserver/ProxyCommitData.actor.h
@@ -64,6 +64,9 @@ struct ProxyStats {
 	LatencySample commitLatencySample;
 	LatencyBands commitLatencyBands;
 
+	// Ratio of tlogs receiving empty commit messages.
+	LatencySample commitBatchingEmptyMessageRatio;
+
 	LatencySample commitBatchingWindowSize;
 
 	Future<Void> logger;
@@ -102,6 +105,10 @@ struct ProxyStats {
 	                        SERVER_KNOBS->LATENCY_METRICS_LOGGING_INTERVAL,
 	                        SERVER_KNOBS->LATENCY_SAMPLE_SIZE),
 	    commitLatencyBands("CommitLatencyMetrics", id, SERVER_KNOBS->STORAGE_LOGGING_DELAY),
+	    commitBatchingEmptyMessageRatio("CommitBatchingEmptyMessageRatio",
+	                                    id,
+	                                    SERVER_KNOBS->LATENCY_METRICS_LOGGING_INTERVAL,
+	                                    SERVER_KNOBS->LATENCY_SAMPLE_SIZE),
 	    commitBatchingWindowSize("CommitBatchingWindowSize",
 	                             id,
 	                             SERVER_KNOBS->LATENCY_METRICS_LOGGING_INTERVAL,

--- a/fdbserver/TagPartitionedLogSystem.actor.cpp
+++ b/fdbserver/TagPartitionedLogSystem.actor.cpp
@@ -565,6 +565,7 @@ struct TagPartitionedLogSystem : ILogSystem, ReferenceCounted<TagPartitionedLogS
 				vector<Future<Void>> tLogCommitResults;
 				for (int loc = 0; loc < it->logServers.size(); loc++) {
 					Standalone<StringRef> msg = data.getMessages(location);
+					data.recordEmptyMessage(location, msg);
 					allReplies.push_back(recordPushMetrics(
 					    it->connectionResetTrackers[loc],
 					    it->logServers[loc]->get().interf().address(),


### PR DESCRIPTION
Cherry-pick #5071 

This metric is to understand the impact of batching on empty commit messages.
If the ratio is high, it means proxy sends many empty commit messages, which
can potentially be optimized for better performance. If the ratio is low, which
means the spread factor is large, thus we need to optimize the proxy to reduce
such a factor.

20210628-165245-jzhou-e5554cc567e42ad3             compressed=True data_size=23832694 duration=4823648 ended=100892 fail_fast=10 max_runs=100000 pass=100001 priority=100 remaining=0 runtime=0:56:33 sanity=False started=101391 stopped=20210628-174918 submitted=20210628-165245 timeout=5400 username=jzhou

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
