### PR TITLE
Fix endpoint ordering by moving the new updateWorkerHealth to the end of ClusterControllerFullInterface

### DIFF
--- a/fdbserver/WorkerInterface.actor.h
+++ b/fdbserver/WorkerInterface.actor.h
@@ -149,9 +149,9 @@ struct ClusterControllerFullInterface {
 	RequestStream<struct RegisterWorkerRequest> registerWorker;
 	RequestStream<struct GetWorkersRequest> getWorkers;
 	RequestStream<struct RegisterMasterRequest> registerMaster;
-	RequestStream<struct UpdateWorkerHealthRequest> updateWorkerHealth;
 	RequestStream<struct GetServerDBInfoRequest>
 	    getServerDBInfo; // only used by testers; the cluster controller will send the serverDBInfo to workers
+	RequestStream<struct UpdateWorkerHealthRequest> updateWorkerHealth;
 
 	UID id() const { return clientInterface.id(); }
 	bool operator==(ClusterControllerFullInterface const& r) const { return id() == r.id(); }
@@ -161,8 +161,8 @@ struct ClusterControllerFullInterface {
 		return clientInterface.hasMessage() || recruitFromConfiguration.getFuture().isReady() ||
 		       recruitRemoteFromConfiguration.getFuture().isReady() || recruitStorage.getFuture().isReady() ||
 		       registerWorker.getFuture().isReady() || getWorkers.getFuture().isReady() ||
-		       registerMaster.getFuture().isReady() || updateWorkerHealth.getFuture().isReady() ||
-		       getServerDBInfo.getFuture().isReady();
+		       registerMaster.getFuture().isReady() || getServerDBInfo.getFuture().isReady() ||
+		       updateWorkerHealth.getFuture().isReady();
 	}
 
 	void initEndpoints() {
@@ -173,8 +173,8 @@ struct ClusterControllerFullInterface {
 		registerWorker.getEndpoint(TaskPriority::ClusterControllerWorker);
 		getWorkers.getEndpoint(TaskPriority::ClusterController);
 		registerMaster.getEndpoint(TaskPriority::ClusterControllerRegister);
-		updateWorkerHealth.getEndpoint(TaskPriority::ClusterController);
 		getServerDBInfo.getEndpoint(TaskPriority::ClusterController);
+		updateWorkerHealth.getEndpoint(TaskPriority::ClusterController);
 	}
 
 	template <class Ar>
@@ -190,8 +190,8 @@ struct ClusterControllerFullInterface {
 		           registerWorker,
 		           getWorkers,
 		           registerMaster,
-				   updateWorkerHealth,
-		           getServerDBInfo);
+		           getServerDBInfo,
+		           updateWorkerHealth);
 	}
 };
 


### PR DESCRIPTION
As pointed out by @xumengpanda [here](https://github.com/apple/foundationdb/pull/5062#discussion_r659467481), we can only append new endpoints in an existing interface.

This PR moves the new updateWorkerHealth endpoint to the end of ClusterControllerFullInterface.

100K Joshua tests: 20210628-185650-zhewu-5081-20de31bc069ead53

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
