### PR TITLE
Introduce Version Vector

### DIFF
--- a/fdbclient/CMakeLists.txt
+++ b/fdbclient/CMakeLists.txt
@@ -114,6 +114,7 @@ set(FDBCLIENT_SRCS
   VersionedMap.actor.h
   VersionedMap.h
   VersionedMap.cpp
+  VersionVector.h
   WriteMap.h
   json_spirit/json_spirit_error_position.h
   json_spirit/json_spirit_reader_template.h

--- a/fdbclient/FDBTypes.h
+++ b/fdbclient/FDBTypes.h
@@ -1126,4 +1126,27 @@ inline const char* transactionPriorityToString(TransactionPriority priority, boo
 	throw internal_error();
 }
 
+struct VersionVector {
+	std::map<Tag, Version> versions;
+
+	VersionVector() {}
+
+	void setVersion(const Tag& tag, Version version) {
+		versions[tag] = version;
+	}
+
+	bool hasVersion(const Tag& tag) const {
+		return versions.find(tag) != versions.end();
+	}
+
+	Version getVersion(const Tag& tag) const {
+		return versions.at(tag);
+	}
+
+	template <class Ar>
+	void serialize(Ar& ar) {
+		serializer(ar, versions);
+	}
+};
+
 #endif

--- a/fdbclient/FDBTypes.h
+++ b/fdbclient/FDBTypes.h
@@ -126,6 +126,18 @@ struct Traceable<Tag> : std::true_type {
 	static std::string toString(const Tag& value) { return value.toString(); }
 };
 
+namespace std {
+template <>
+struct hash<Tag> {
+	std::size_t operator() (const Tag& tag) const {
+		std::size_t seed = 0;
+		boost::hash_combine(seed, std::hash<int8_t>{}(tag.locality));
+		boost::hash_combine(seed, std::hash<uint16_t>{}(tag.id));
+		return seed;
+	}
+};
+} // namespace std
+
 static const Tag invalidTag{ tagLocalitySpecial, 0 };
 static const Tag txsTag{ tagLocalitySpecial, 1 };
 static const Tag cacheTag{ tagLocalitySpecial, 2 };
@@ -1125,28 +1137,5 @@ inline const char* transactionPriorityToString(TransactionPriority priority, boo
 	ASSERT(false);
 	throw internal_error();
 }
-
-struct VersionVector {
-	std::map<Tag, Version> versions;
-
-	VersionVector() {}
-
-	void setVersion(const Tag& tag, Version version) {
-		versions[tag] = version;
-	}
-
-	bool hasVersion(const Tag& tag) const {
-		return versions.find(tag) != versions.end();
-	}
-
-	Version getVersion(const Tag& tag) const {
-		return versions.at(tag);
-	}
-
-	template <class Ar>
-	void serialize(Ar& ar) {
-		serializer(ar, versions);
-	}
-};
 
 #endif

--- a/fdbclient/VersionVector.h
+++ b/fdbclient/VersionVector.h
@@ -35,7 +35,7 @@ struct VersionVector {
 
 
 	VersionVector() : maxVersion(invalidVersion) {}
-	VersionVector(Version maxVer) : maxVersion(maxVer) {}
+	VersionVector(Version version) : maxVersion(version) {}
 
 	void setVersion(const Tag& tag, Version version) {
         ASSERT(tag != invalidTag);
@@ -63,7 +63,7 @@ struct VersionVector {
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, versions);
+		serializer(ar, versions, maxVersion);
 	}
 };
 

--- a/fdbclient/VersionVector.h
+++ b/fdbclient/VersionVector.h
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2013-2018 Apple Inc. and the FoundationDB project authors
+ * Copyright 2013-2021 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fdbclient/VersionVector.h
+++ b/fdbclient/VersionVector.h
@@ -30,15 +30,14 @@
 struct VersionVector {
 	std::unordered_map<Tag, Version> versions;
 	Version maxVersion; // Specifies the max version in this version vector. (Note:
-                        // there may or may not be a corresponding entry for this
-                        // version in the "versions" map.)
-
+	                    // there may or may not be a corresponding entry for this
+	                    // version in the "versions" map.)
 
 	VersionVector() : maxVersion(invalidVersion) {}
 	VersionVector(Version version) : maxVersion(version) {}
 
 	void setVersion(const Tag& tag, Version version) {
-        ASSERT(tag != invalidTag);
+		ASSERT(tag != invalidTag);
 		ASSERT(version > maxVersion);
 		versions[tag] = version;
 		maxVersion = version;
@@ -49,12 +48,12 @@ struct VersionVector {
 		return versions.find(tag) != versions.end();
 	}
 
-	// @pre assumes that the given tag has an entry in the "versions" map.
+	// @pre assumes that the given tag has an entry in the version vector.
 	Version getVersion(const Tag& tag) const {
 		ASSERT(tag != invalidTag);
-        auto iter = versions.find(tag);
-        ASSERT(iter != versions.end());
-        return iter->second;
+		auto iter = versions.find(tag);
+		ASSERT(iter != versions.end());
+		return iter->second;
 	}
 
 	bool operator==(const VersionVector& vv) const { return maxVersion == vv.maxVersion; }
@@ -67,8 +66,8 @@ struct VersionVector {
 	}
 };
 
-static const VersionVector minVersionVector{0};
-static const VersionVector maxVersionVector{MAX_VERSION};
-static const VersionVector invalidVersionVector{invalidVersion};
+static const VersionVector minVersionVector{ 0 };
+static const VersionVector maxVersionVector{ MAX_VERSION };
+static const VersionVector invalidVersionVector{ invalidVersion };
 
 #endif /* FDBCLIENT_VERSION_VECTOR_H */

--- a/fdbclient/VersionVector.h
+++ b/fdbclient/VersionVector.h
@@ -1,0 +1,74 @@
+/*
+ * VersionVector.h
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2018 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FDBCLIENT_VERSION_VECTOR_H
+#define FDBCLIENT_VERSION_VECTOR_H
+
+#pragma once
+
+#include <unordered_map>
+
+#include "fdbclient/FDBTypes.h"
+
+struct VersionVector {
+	std::unordered_map<Tag, Version> versions;
+	Version maxVersion; // Specifies the max version in this version vector. (Note:
+                        // there may or may not be a corresponding entry for this
+                        // version in the "versions" map.)
+
+
+	VersionVector() : maxVersion(invalidVersion) {}
+	VersionVector(Version maxVer) : maxVersion(maxVer) {}
+
+	void setVersion(const Tag& tag, Version version) {
+        ASSERT(tag != invalidTag);
+		ASSERT(version > maxVersion);
+		versions[tag] = version;
+		maxVersion = version;
+	}
+
+	bool hasVersion(const Tag& tag) const {
+		ASSERT(tag != invalidTag);
+		return versions.find(tag) != versions.end();
+	}
+
+	// @pre assumes that the given tag has an entry in the "versions" map.
+	Version getVersion(const Tag& tag) const {
+		ASSERT(tag != invalidTag);
+        auto iter = versions.find(tag);
+        ASSERT(iter != versions.end());
+        return iter->second;
+	}
+
+	bool operator==(const VersionVector& vv) const { return maxVersion == vv.maxVersion; }
+	bool operator!=(const VersionVector& vv) const { return maxVersion != vv.maxVersion; }
+	bool operator<(const VersionVector& vv) const { return maxVersion < vv.maxVersion; }
+
+	template <class Ar>
+	void serialize(Ar& ar) {
+		serializer(ar, versions);
+	}
+};
+
+static const VersionVector minVersionVector{0};
+static const VersionVector maxVersionVector{MAX_VERSION};
+static const VersionVector invalidVersionVector{invalidVersion};
+
+#endif /* FDBCLIENT_VERSION_VECTOR_H */

--- a/fdbserver/masterserver.actor.cpp
+++ b/fdbserver/masterserver.actor.cpp
@@ -246,6 +246,9 @@ struct MasterData : NonCopyable, ReferenceCounted<MasterData> {
 
 	std::vector<WorkerInterface> backupWorkers; // Recruited backup workers from cluster controller.
 
+	// Captures the latest commit version for each storage server in the cluster.
+	VersionVector ssVersionVector;
+
 	CounterCollection cc;
 	Counter changeCoordinatorsRequests;
 	Counter getCommitVersionRequests;

--- a/fdbserver/masterserver.actor.cpp
+++ b/fdbserver/masterserver.actor.cpp
@@ -247,7 +247,7 @@ struct MasterData : NonCopyable, ReferenceCounted<MasterData> {
 
 	std::vector<WorkerInterface> backupWorkers; // Recruited backup workers from cluster controller.
 
-	// Captures the latest commit version for each storage server in the cluster.
+	// Captures the latest commit version targeted for each storage server in the cluster.
 	VersionVector ssVersionVector;
 
 	CounterCollection cc;

--- a/fdbserver/masterserver.actor.cpp
+++ b/fdbserver/masterserver.actor.cpp
@@ -46,6 +46,7 @@
 #include "fdbserver/WorkerInterface.actor.h"
 #include "flow/ActorCollection.h"
 #include "flow/Trace.h"
+#include "fdbclient/VersionVector.h"
 
 #include "flow/actorcompiler.h" // This must be the last #include.
 


### PR DESCRIPTION
Changes:

VersionVector.h: Create a data structure to hold the version vector. 

FDBTypes.h: Customize hash so we can use Tag as the key for an unordered_map.

masterserver.actor.cpp: Create an instance of the version vector in "MasterData".

Notes:
- I imagine more fields will be added to the version vector (and improvements will be made to its "serialize()" method) as we add various suggested optimizations to the version vector.
- I hope to use the version vector to also hold the previous commit versions of logs (TPCVs) on the sequencer. If we do decide to do that then we can templatize the version vector to be a map of Tag/UUID to a Version.

Testing:

- Started simulation tests (ID: 20210629-194901-sre-3273684ea475d6bd)

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
