### PR TITLE
Cherrypick Release 6.3: Add metric to track the ratio of empty messages to tlogs

### DIFF
--- a/fdbserver/LogSystem.h
+++ b/fdbserver/LogSystem.h
@@ -28,6 +28,7 @@
 #include "fdbserver/WorkerInterface.actor.h"
 #include "fdbclient/DatabaseConfiguration.h"
 #include "flow/IndexedSet.h"
+#include "flow/ProtocolVersion.h"
 #include "fdbrpc/ReplicationPolicy.h"
 #include "fdbrpc/Locality.h"
 #include "fdbrpc/Replication.h"
@@ -952,6 +953,7 @@ struct LogPushData : NonCopyable {
 				}
 			}
 		}
+		isEmptyMessage = std::vector<bool>(messagesWriter.size(), false);
 	}
 
 	void addTxsTag() {
@@ -1022,11 +1024,32 @@ struct LogPushData : NonCopyable {
 
 	Standalone<StringRef> getMessages(int loc) { return messagesWriter[loc].toValue(); }
 
+	// Records if a tlog (specified by "loc") will receive an empty version batch message.
+	// "value" is the message returned by getMessages() call.
+	void recordEmptyMessage(int loc, const Standalone<StringRef>& value) {
+		if (!isEmptyMessage[loc]) {
+			BinaryWriter w(AssumeVersion(currentProtocolVersion));
+			Standalone<StringRef> v = w.toValue();
+			if (value.size() > v.size()) {
+				isEmptyMessage[loc] = true;
+			}
+		}
+	}
+
+	// Returns the ratio of empty messages in this version batch.
+	// MUST be called after getMessages() and recordEmptyMessage().
+	float getEmptyMessageRatio() const {
+		auto count = std::count(isEmptyMessage.begin(), isEmptyMessage.end(), false);
+		ASSERT_WE_THINK(isEmptyMessage.size() > 0);
+		return 1.0 * count / isEmptyMessage.size();
+	}
+
 private:
 	Reference<ILogSystem> logSystem;
 	std::vector<Tag> next_message_tags;
 	std::vector<Tag> prev_tags;
 	std::vector<BinaryWriter> messagesWriter;
+	std::vector<bool> isEmptyMessage; // if messagesWriter has written anything
 	std::vector<int> msg_locations;
 	uint32_t subsequence;
 };

--- a/fdbserver/TagPartitionedLogSystem.actor.cpp
+++ b/fdbserver/TagPartitionedLogSystem.actor.cpp
@@ -563,6 +563,7 @@ struct TagPartitionedLogSystem : ILogSystem, ReferenceCounted<TagPartitionedLogS
 				vector<Future<Void>> tLogCommitResults;
 				for (int loc = 0; loc < it->logServers.size(); loc++) {
 					Standalone<StringRef> msg = data.getMessages(location);
+					data.recordEmptyMessage(location, msg);
 					allReplies.push_back(recordPushMetrics(
 					    it->connectionResetTrackers[loc],
 					    it->logServers[loc]->get().interf().address(),


### PR DESCRIPTION
Cherry-pick #5071

This metric is to understand the impact of batching on empty commit messages.
If the ratio is high, it means proxy sends many empty commit messages, which
can potentially be optimized for better performance. If the ratio is low, which
means the spread factor is large, thus we need to optimize the proxy to reduce
such a factor.

20210629-002733-jzhou-fea1469beaa2a5e1             compressed=True data_size=21408446 duration=5882385 ended=102187 fail=1 fail_fast=10 max_runs=100000 pass=100094 priority=100 remaining=0 runtime=1:01:35 sanity=False started=102305 stopped=20210629-012908 submitted=20210629-002733 timeout=5400 username=jzhou

`DDBalanceAndRemoveStatus.txt` has timeout error of "Unable to perform consistency check", which is unrelated to this PR.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
