### PR TITLE
Fix IThreadPool thread naming (release 7.0)

### DIFF
--- a/fdbserver/workloads/UnitTests.actor.cpp
+++ b/fdbserver/workloads/UnitTests.actor.cpp
@@ -30,6 +30,7 @@ void forceLinkMemcpyTests();
 void forceLinkMemcpyPerfTests();
 void forceLinkParallelStreamTests();
 void forceLinkSimExternalConnectionTests();
+void forceLinkIThreadPoolTests();
 
 struct UnitTestWorkload : TestWorkload {
 	bool enabled;
@@ -63,6 +64,7 @@ struct UnitTestWorkload : TestWorkload {
 		forceLinkMemcpyPerfTests();
 		forceLinkParallelStreamTests();
 		forceLinkSimExternalConnectionTests();
+		forceLinkIThreadPoolTests();
 	}
 
 	std::string description() const override { return "UnitTests"; }

--- a/flow/CMakeLists.txt
+++ b/flow/CMakeLists.txt
@@ -28,6 +28,7 @@ set(FLOW_SRCS
   Histogram.h
   IDispatched.h
   IRandom.h
+  IThreadPoolTest.actor.cpp
   IThreadPool.cpp
   IThreadPool.h
   ITrace.h

--- a/flow/IThreadPool.cpp
+++ b/flow/IThreadPool.cpp
@@ -109,7 +109,7 @@ public:
 	}
 	void addThread(IThreadPoolReceiver* userData, const char* name) override {
 		threads.push_back(new Thread(this, userData));
-		threads.back()->handle = startThread(start, threads.back(), stackSize);
+		threads.back()->handle = startThread(start, threads.back(), stackSize, name);
 	}
 	void post(PThreadAction action) override { ios.post(ActionWrapper(action)); }
 };

--- a/flow/IThreadPoolTest.actor.cpp
+++ b/flow/IThreadPoolTest.actor.cpp
@@ -35,7 +35,7 @@ struct ThreadNameReceiver : IThreadPoolReceiver {
 	}
 };
 
-TEST_CASE("/flow/IThreadPool/NamedThread") {
+TEST_CASE("noSim/IThreadPool/NamedThread") {
 	state Reference<IThreadPool> pool = createGenericThreadPool();
 	pool->addThread(new ThreadNameReceiver(), "thread-foo");
 

--- a/flow/IThreadPoolTest.actor.cpp
+++ b/flow/IThreadPoolTest.actor.cpp
@@ -1,0 +1,61 @@
+#include "flow/IThreadPool.h"
+
+#include <pthread.h>
+#include <ostream>
+
+#include "flow/UnitTest.h"
+#include "flow/actorcompiler.h" // has to be last include
+
+// Thread naming only works on Linux.
+#if defined(__linux__)
+
+void forceLinkIThreadPoolTests() {}
+
+struct ThreadNameReceiver : IThreadPoolReceiver {
+	void init() override {}
+
+	struct GetNameAction : TypedAction<ThreadNameReceiver, GetNameAction> {
+		ThreadReturnPromise<std::string> name;
+
+		double getTimeEstimate() const override { return 3.; }
+	};
+
+	void action(GetNameAction& a) {
+		pthread_t t = pthread_self();
+		const size_t arrayLen = 16;
+		char name[arrayLen];
+		int err = pthread_getname_np(t, name, arrayLen);
+		if (err != 0) {
+			std::cout << "Get name failed with error code: " << err << std::endl;
+			a.name.sendError(platform_error());
+			return;
+		}
+		std::string s = name;
+		a.name.send(std::move(s));
+	}
+};
+
+TEST_CASE("/flow/IThreadPool/NamedThread") {
+	state Reference<IThreadPool> pool = createGenericThreadPool();
+	pool->addThread(new ThreadNameReceiver(), "thread-foo");
+
+	// Warning: this action is a little racy with the call to `pthread_setname_np`. In practice,
+	// ~nothing should depend on the thread name being set instantaneously. If this test ever
+	// flakes, we can make `startThread` in platform a little bit more complex to clearly order
+	// the actions.
+	auto* a = new ThreadNameReceiver::GetNameAction();
+	auto fut = a->name.getFuture();
+	pool->post(a);
+
+	std::string name = wait(fut);
+	if (name != "thread-foo") {
+		std::cout << "Incorrect thread name: " << name << std::endl;
+		ASSERT(false);
+	}
+
+	wait(pool->stop());
+
+	return Void();
+}
+
+#endif


### PR DESCRIPTION
Cherry pick of https://github.com/apple/foundationdb/pull/5092 and https://github.com/apple/foundationdb/pull/5097 (the latter fixes the test)

A refactoring accidentally deleted passing the name parameter along to startThread. This both fixes that error and adds a test to ensure that future changes don't break the feature.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
