### PR TITLE
Add target to build unversioned correctness pkgs

### DIFF
--- a/cmake/AddFdbTest.cmake
+++ b/cmake/AddFdbTest.cmake
@@ -261,6 +261,14 @@ function(create_correctness_package)
     )
   add_custom_target(package_tests ALL DEPENDS ${tar_file})
   add_dependencies(package_tests strip_only_fdbserver TestHarness)
+  set(unversioned_tar_file "${CMAKE_BINARY_DIR}/packages/correctness.tar.gz")
+  add_custom_command(
+    OUTPUT "${unversioned_tar_file}"
+    DEPENDS "${tar_file}"
+    COMMAND ${CMAKE_COMMAND} -E copy "${tar_file}" "${unversioned_tar_file}"
+    COMMENT "Copy correctness package to ${unversioned_tar_file}")
+  add_custom_target(package_tests_u DEPENDS "${unversioned_tar_file}")
+  add_dependencies(package_tests_u package_tests)
 endfunction()
 
 function(create_valgrind_correctness_package)
@@ -288,6 +296,14 @@ function(create_valgrind_correctness_package)
       )
     add_custom_target(package_valgrind_tests ALL DEPENDS ${tar_file})
     add_dependencies(package_valgrind_tests strip_only_fdbserver TestHarness)
+    set(unversioned_tar_file "${CMAKE_BINARY_DIR}/packages/valgrind.tar.gz")
+    add_custom_command(
+      OUTPUT "${unversioned_tar_file}"
+      DEPENDS "${tar_file}"
+      COMMAND ${CMAKE_COMMAND} -E copy "${tar_file}" "${unversioned_tar_file}"
+      COMMENT "Copy valgrind package to ${unversioned_tar_file}")
+    add_custom_target(package_valgrind_tests_u DEPENDS "${unversioned_tar_file}")
+    add_dependencies(package_valgrind_tests_u package_valgrind_tests)
   endif()
 endfunction()
 


### PR DESCRIPTION
By default the correctness package will be built to `packages/correctness-${FDB_MAJOR_VERSION}.${FDB_MINOR_VERSION}.${FDB_PATCH_VERSION}.tar.gz` (and similar for valgrind package).

This is inconvenient for scripting. This PR simply adds two new cmake targets that will copy the correctness and valgrind packages to a new file that doesn't contain the version (`packages/correctness.tar.gz`).

I tested this just by running it locally. As currently no automation exists that runs these target (and these targets don't depend on `all`), this should be very high risk.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
