### PR TITLE
Add a ThreadID field to each TraceEvent.  This is needed for multithr…

### DIFF
--- a/flow/Trace.h
+++ b/flow/Trace.h
@@ -431,6 +431,7 @@ private:
 	void setField(const char* key, int64_t value);
 	void setField(const char* key, double value);
 	void setField(const char* key, const std::string& value);
+	void setThreadId();
 
 	TraceEvent& errorImpl(const class Error& e, bool includeCancelled = false);
 	// Private version of detailf that does NOT write to the eventMetric.  This is to be used by other detail methods


### PR DESCRIPTION
…eaded client debugging, and should also be helpful for multithreaded storage engines, SSL handshake threadpools, and so on.

I'd rather use more human-readable numbers (0, 1, 2, ...) by incrementing a static int once per thread, but that won't work for client code, which uses linker tricks to create one copy of all the global variables per client thread.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
