### PR TITLE
Add a ThreadID field to each TraceEvent.

### DIFF
--- a/flow/Trace.cpp
+++ b/flow/Trace.cpp
@@ -1121,6 +1121,17 @@ TraceEvent& TraceEvent::setMaxFieldLength(int maxFieldLength) {
 	return *this;
 }
 
+// A unique, per-thread ID.  This is particularly important for multithreaded
+// or multiversion client setups and for multithreaded storage engines.
+thread_local uint64_t threadId = 0;
+
+void TraceEvent::setThreadId() {
+	while (threadId == 0) {
+		threadId = deterministicRandom()->randomUInt64();
+	}
+	this->detail("ThreadID", threadId);
+}
+
 int TraceEvent::getMaxFieldLength() const {
 	return maxFieldLength;
 }
@@ -1173,6 +1184,8 @@ void TraceEvent::log() {
 				if (FLOW_KNOBS && FLOW_KNOBS->TRACE_DATETIME_ENABLED) {
 					fields.mutate(timeIndex + 1).second = TraceEvent::printRealTime(time);
 				}
+
+				setThreadId();
 
 				if (this->severity == SevError) {
 					severity = SevInfo;

--- a/flow/Trace.h
+++ b/flow/Trace.h
@@ -431,6 +431,7 @@ private:
 	void setField(const char* key, int64_t value);
 	void setField(const char* key, double value);
 	void setField(const char* key, const std::string& value);
+	void setThreadId();
 
 	TraceEvent& errorImpl(const class Error& e, bool includeCancelled = false);
 	// Private version of detailf that does NOT write to the eventMetric.  This is to be used by other detail methods


### PR DESCRIPTION
This is needed for multithreaded client debugging, and should also be helpful for multithreaded storage engines, SSL handshake threadpools, and so on

I'd rather use more human-readable numbers (0, 1, 2, ...) by incrementing a static int once per thread, but that won't work for client code, which uses linker tricks to create one copy of all the global variables per client thread.

I tested this by running:

```
~/src/foundationdb/tests/loopback_cluster/run_cluster.sh . 3 '/root/src/foundationdb/tests/python_tests/multithreaded_client.py loopback-cluster-*/fdb.cluster --threads 3 '
```
and then:
```
for i in client-logs/* ; do echo $i; perl -ne 's/^.+(ThreadID\S+).+$/$1/ && print;'< $i | uniq -c  ;done
client-logs/trace.127.0.0.1.24723.1625088374.3EabNv.0.1.xml
     25 ThreadID="6606692112544116287"
     17 ThreadID="710970412960973612"
client-logs/trace.127.0.0.1.24723.1625088374.awNHk7.0.1.xml
      8 ThreadID="220911987543889332"
     11 ThreadID="2902076149887619111"
client-logs/trace.127.0.0.1.24723.1625088374.K7hswE.0.1.xml
      8 ThreadID="10158245817242645701"
     11 ThreadID="2327224285922824598"
client-logs/trace.127.0.0.1.24723.1625088374.Mj19QA.0.1.xml
      8 ThreadID="7546905367506037422"
     11 ThreadID="4393189544932179542"
```
It emits a different ThreadID for things that run on the main thread than on the Net2 thread.  When it adds a client thread, it first adds a main thread (which will be idle soon), and that thread spawns the actual client thread.  You can see this in the above output because each file switches thread ID after emitting a dozen or so lines.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
