### PR TITLE
Fix fdbcli cache_range command

### DIFF
--- a/bindings/python/tests/fdbcli_tests.py
+++ b/bindings/python/tests/fdbcli_tests.py
@@ -249,8 +249,9 @@ def consistencycheck(logger):
 def cache_range(logger):
     # this command is currently experimental
     # just test we can set and clear the cached range
-    run_fdbcli_command('cache_range', 'set', 'a', 'b')
-    run_fdbcli_command('cache_range', 'clear', 'a', 'b')
+    run_fdbcli_command('cache_range', 'set', 'a', 'd')
+    run_fdbcli_command('cache_range', 'clear', 'b', 'c')
+    run_fdbcli_command('cache_range', 'clear', 'a', 'd')
 
 @enable_logging()
 def datadistribution(logger):

--- a/fdbclient/ManagementAPI.actor.cpp
+++ b/fdbclient/ManagementAPI.actor.cpp
@@ -2472,7 +2472,7 @@ ACTOR Future<Void> changeCachedRange(Database cx, KeyRangeRef range, bool add) {
 			tr.clear(sysRangeClear);
 			tr.clear(privateRange);
 			tr.addReadConflictRange(privateRange);
-			RangeResult previous = wait(tr.getRange(KeyRangeRef(storageCachePrefix, sysRange.begin), 1, true));
+			RangeResult previous = wait(tr.getRange(KeyRangeRef(storageCachePrefix, sysRange.begin), 1, false, true));
 			bool prevIsCached = false;
 			if (!previous.empty()) {
 				std::vector<uint16_t> prevVal;
@@ -2488,7 +2488,7 @@ ACTOR Future<Void> changeCachedRange(Database cx, KeyRangeRef range, bool add) {
 				tr.set(sysRange.begin, trueValue);
 				tr.set(privateRange.begin, serverKeysTrue);
 			}
-			RangeResult after = wait(tr.getRange(KeyRangeRef(sysRange.end, storageCacheKeys.end), 1, false));
+			RangeResult after = wait(tr.getRange(KeyRangeRef(sysRange.end, storageCacheKeys.end), 1, false, false));
 			bool afterIsCached = false;
 			if (!after.empty()) {
 				std::vector<uint16_t> afterVal;

--- a/fdbserver/ApplyMetadataMutation.cpp
+++ b/fdbserver/ApplyMetadataMutation.cpp
@@ -755,16 +755,8 @@ void applyMetadataMutations(SpanID const& spanContext,
 					break;
 				}
 			} else {
-				keyEnd = itr->first;
-				mutationEnd = itr->second;
-				++itr;
-				if (itr != cachedRangeInfo.end()) {
-					keyBegin = itr->first;
-					mutationBegin = itr->second;
-				} else {
-					//TraceEvent(SevDebug, "BeginKeyNotFound", dbgid).detail("KeyEnd", keyEnd.toString());
-					break;
-				}
+				// skip the ending keys
+				continue;
 			}
 
 			// Now get all the storage server tags for the cached key-ranges


### PR DESCRIPTION
The follow commands will fail 
```
cache_range set a d
cache_range clear b c
```
will throw `inverted_range` error.

While debugging, it was found that the parameters used to call `getRange` were not correct.
In particular, we want to set `reverse=true` but it applied as `snapshot=true`.

The `inverted_range` error was thrown in _ApplyMetadataMutation.actor.cpp_ where we constructing begin keys and end keys.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
