### PR TITLE
Fix issue where recoveries could thrash between regions

### DIFF
--- a/fdbserver/masterserver.actor.cpp
+++ b/fdbserver/masterserver.actor.cpp
@@ -1498,11 +1498,6 @@ ACTOR Future<Void> trackTlogRecovery(Reference<MasterData> self,
 			    .trackLatest("MasterRecoveryState");
 		}
 
-		if (newState.oldTLogData.size() && configuration.repopulateRegionAntiQuorum > 0 &&
-		    self->logSystem->remoteStorageRecovered()) {
-			TraceEvent(SevWarnAlways, "RecruitmentStalled_RemoteStorageRecovered", self->dbgid);
-			self->recruitmentStalled->set(true);
-		}
 		self->registrationTrigger.trigger();
 
 		if (finalUpdate) {


### PR DESCRIPTION
Fixes a simulation failure on 79a820fd1161f45e4212336771421b6a3535f9fc:

```
$ ./bin/fdbserver -r simulation -f ../foundationdb/tests/rare/CycleWithKills.toml --seed 427532003 --buggify on
```

The issue is that a remote region could recover before the primary region, causing a recovery. When the primary region recovers, another recovery would occur. This process would repeat.

Passed 35,001 tests off commit 79a820fd1161f45e4212336771421b6a3535f9fc with the fix applied, passed 10,000 tests off of master with the fix applied.

Thanks to @sfc-gh-etschannen for helping to look into the issue.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
