### PR TITLE
Disable recruitment determinism check for configurations with remote satellites (release-7.0)

### DIFF
--- a/fdbserver/ClusterController.actor.cpp
+++ b/fdbserver/ClusterController.actor.cpp
@@ -1438,7 +1438,7 @@ public:
 	}
 
 	// Given datacenter ID, returns the primary and remote regions.
-	std::pair<RegionInfo, RegionInfo> getPrimaryAndRemoteRegion(std::vector<RegionInfo> regions, Key dcId) {
+	std::pair<RegionInfo, RegionInfo> getPrimaryAndRemoteRegion(const std::vector<RegionInfo>& regions, Key dcId) {
 		RegionInfo region;
 		RegionInfo remoteRegion;
 		for (const auto& r : regions) {

--- a/fdbserver/ClusterController.actor.cpp
+++ b/fdbserver/ClusterController.actor.cpp
@@ -1437,6 +1437,20 @@ public:
 		return result;
 	}
 
+	// Given datacenter ID, returns the primary and remote regions.
+	std::pair<RegionInfo, RegionInfo> getPrimaryAndRemoteRegion(std::vector<RegionInfo> regions, Key dcId) {
+		RegionInfo region;
+		RegionInfo remoteRegion;
+		for (const auto& r : regions) {
+			if (r.dcId == dcId) {
+				region = r;
+			} else {
+				remoteRegion = r;
+			}
+		}
+		return std::make_pair(region, remoteRegion);
+	}
+
 	ErrorOr<RecruitFromConfigurationReply> findWorkersForConfigurationFromDC(RecruitFromConfigurationRequest const& req,
 	                                                                         Optional<Key> dcId) {
 		RecruitFromConfigurationReply result;
@@ -1449,15 +1463,7 @@ public:
 		primaryDC.insert(dcId);
 		result.dcId = dcId;
 
-		RegionInfo region;
-		RegionInfo remoteRegion;
-		for (auto& r : req.configuration.regions) {
-			if (r.dcId == dcId.get()) {
-				region = r;
-			} else {
-				remoteRegion = r;
-			}
-		}
+		auto [region, remoteRegion] = getPrimaryAndRemoteRegion(req.configuration.regions, dcId.get());
 
 		if (req.recruitSeedServers) {
 			auto primaryStorageServers =
@@ -1879,67 +1885,82 @@ public:
 	RecruitFromConfigurationReply findWorkersForConfiguration(RecruitFromConfigurationRequest const& req) {
 		RecruitFromConfigurationReply rep = findWorkersForConfigurationDispatch(req);
 		if (g_network->isSimulated()) {
-			RecruitFromConfigurationReply compare = findWorkersForConfigurationDispatch(req);
+			// FIXME: The logic to pick a satellite in a remote region is not
+			// deterministic and can therefore break this nondeterminism check.
+			// Since satellites will generally be in the primary region,
+			// disable the determinism check for remote region satellites.
+			bool remoteDCUsedAsSatellite = false;
+			if (req.configuration.regions.size() > 1) {
+				auto [region, remoteRegion] = getPrimaryAndRemoteRegion(req.configuration.regions, req.configuration.regions[0].dcId);
+				for (const auto& satellite : region.satellites) {
+					if (satellite.dcId == remoteRegion.dcId) {
+						remoteDCUsedAsSatellite = true;
+					}
+				}
+			}
+			if (!remoteDCUsedAsSatellite) {
+				RecruitFromConfigurationReply compare = findWorkersForConfigurationDispatch(req);
 
-			std::map<Optional<Standalone<StringRef>>, int> firstUsed;
-			std::map<Optional<Standalone<StringRef>>, int> secondUsed;
-			updateKnownIds(&firstUsed);
-			updateKnownIds(&secondUsed);
+				std::map<Optional<Standalone<StringRef>>, int> firstUsed;
+				std::map<Optional<Standalone<StringRef>>, int> secondUsed;
+				updateKnownIds(&firstUsed);
+				updateKnownIds(&secondUsed);
 
-			// auto mworker = id_worker.find(masterProcessId);
-			//TraceEvent("CompareAddressesMaster")
-			//    .detail("Master",
-			//            mworker != id_worker.end() ? mworker->second.details.interf.address() : NetworkAddress());
+				// auto mworker = id_worker.find(masterProcessId);
+				//TraceEvent("CompareAddressesMaster")
+				//    .detail("Master",
+				//            mworker != id_worker.end() ? mworker->second.details.interf.address() : NetworkAddress());
 
-			updateIdUsed(rep.tLogs, firstUsed);
-			updateIdUsed(compare.tLogs, secondUsed);
-			compareWorkers(
-			    req.configuration, rep.tLogs, firstUsed, compare.tLogs, secondUsed, ProcessClass::TLog, "TLog");
-			updateIdUsed(rep.satelliteTLogs, firstUsed);
-			updateIdUsed(compare.satelliteTLogs, secondUsed);
-			compareWorkers(req.configuration,
-			               rep.satelliteTLogs,
-			               firstUsed,
-			               compare.satelliteTLogs,
-			               secondUsed,
-			               ProcessClass::TLog,
-			               "Satellite");
-			updateIdUsed(rep.commitProxies, firstUsed);
-			updateIdUsed(compare.commitProxies, secondUsed);
-			updateIdUsed(rep.grvProxies, firstUsed);
-			updateIdUsed(compare.grvProxies, secondUsed);
-			updateIdUsed(rep.resolvers, firstUsed);
-			updateIdUsed(compare.resolvers, secondUsed);
-			compareWorkers(req.configuration,
-			               rep.commitProxies,
-			               firstUsed,
-			               compare.commitProxies,
-			               secondUsed,
-			               ProcessClass::CommitProxy,
-			               "CommitProxy");
-			compareWorkers(req.configuration,
-			               rep.grvProxies,
-			               firstUsed,
-			               compare.grvProxies,
-			               secondUsed,
-			               ProcessClass::GrvProxy,
-			               "GrvProxy");
-			compareWorkers(req.configuration,
-			               rep.resolvers,
-			               firstUsed,
-			               compare.resolvers,
-			               secondUsed,
-			               ProcessClass::Resolver,
-			               "Resolver");
-			updateIdUsed(rep.backupWorkers, firstUsed);
-			updateIdUsed(compare.backupWorkers, secondUsed);
-			compareWorkers(req.configuration,
-			               rep.backupWorkers,
-			               firstUsed,
-			               compare.backupWorkers,
-			               secondUsed,
-			               ProcessClass::Backup,
-			               "Backup");
+				updateIdUsed(rep.tLogs, firstUsed);
+				updateIdUsed(compare.tLogs, secondUsed);
+				compareWorkers(
+				    req.configuration, rep.tLogs, firstUsed, compare.tLogs, secondUsed, ProcessClass::TLog, "TLog");
+				updateIdUsed(rep.satelliteTLogs, firstUsed);
+				updateIdUsed(compare.satelliteTLogs, secondUsed);
+				compareWorkers(req.configuration,
+				               rep.satelliteTLogs,
+				               firstUsed,
+				               compare.satelliteTLogs,
+				               secondUsed,
+				               ProcessClass::TLog,
+				               "Satellite");
+				updateIdUsed(rep.commitProxies, firstUsed);
+				updateIdUsed(compare.commitProxies, secondUsed);
+				updateIdUsed(rep.grvProxies, firstUsed);
+				updateIdUsed(compare.grvProxies, secondUsed);
+				updateIdUsed(rep.resolvers, firstUsed);
+				updateIdUsed(compare.resolvers, secondUsed);
+				compareWorkers(req.configuration,
+				               rep.commitProxies,
+				               firstUsed,
+				               compare.commitProxies,
+				               secondUsed,
+				               ProcessClass::CommitProxy,
+				               "CommitProxy");
+				compareWorkers(req.configuration,
+				               rep.grvProxies,
+				               firstUsed,
+				               compare.grvProxies,
+				               secondUsed,
+				               ProcessClass::GrvProxy,
+				               "GrvProxy");
+				compareWorkers(req.configuration,
+				               rep.resolvers,
+				               firstUsed,
+				               compare.resolvers,
+				               secondUsed,
+				               ProcessClass::Resolver,
+				               "Resolver");
+				updateIdUsed(rep.backupWorkers, firstUsed);
+				updateIdUsed(compare.backupWorkers, secondUsed);
+				compareWorkers(req.configuration,
+				               rep.backupWorkers,
+				               firstUsed,
+				               compare.backupWorkers,
+				               secondUsed,
+				               ProcessClass::Backup,
+				               "Backup");
+			}
 		}
 		return rep;
 	}


### PR DESCRIPTION
Cherry pick of #5104.

This fixes a simulation failure originally surfaced on the `release-7.0` branch (commit 540da1e4abd78165ab4423735ad00c7f3f8739aa):

```
./bin/fdbserver -r simulation -f ../foundationdb/tests/slow/CommitBug.toml --seed 322853697 --buggify on
```

Passed 100,000 correctness tests on Joshua.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
