### PR TITLE
Version vector prototype: cache version vector on grv proxy and client

### DIFF
--- a/fdbclient/CommitProxyInterface.h
+++ b/fdbclient/CommitProxyInterface.h
@@ -30,6 +30,7 @@
 #include "fdbclient/CommitTransaction.h"
 #include "fdbclient/TagThrottle.h"
 #include "fdbclient/GlobalConfig.h"
+#include "fdbclient/VersionVector.h"
 
 #include "fdbrpc/Stats.h"
 #include "fdbrpc/TimedRequest.h"
@@ -197,6 +198,8 @@ struct GetReadVersionReply : public BasicLoadBalancedReply {
 
 	TransactionTagMap<ClientTagThrottleLimits> tagThrottleInfo;
 
+	VersionVector ssVersionVector;
+
 	GetReadVersionReply() : version(invalidVersion), locked(false) {}
 
 	template <class Ar>
@@ -207,7 +210,8 @@ struct GetReadVersionReply : public BasicLoadBalancedReply {
 		           locked,
 		           metadataVersion,
 		           tagThrottleInfo,
-		           midShardSize);
+		           midShardSize,
+		           ssVersionVector);
 	}
 };
 
@@ -327,6 +331,7 @@ struct GetRawCommittedVersionReply {
 	bool locked;
 	Optional<Value> metadataVersion;
 	Version minKnownCommittedVersion;
+	VersionVector ssVersionVector;
 
 	GetRawCommittedVersionReply()
 	  : debugID(Optional<UID>()), version(invalidVersion), locked(false), metadataVersion(Optional<Value>()),
@@ -334,7 +339,7 @@ struct GetRawCommittedVersionReply {
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, debugID, version, locked, metadataVersion, minKnownCommittedVersion);
+		serializer(ar, debugID, version, locked, metadataVersion, minKnownCommittedVersion, ssVersionVector);
 	}
 };
 

--- a/fdbclient/DatabaseContext.h
+++ b/fdbclient/DatabaseContext.h
@@ -38,6 +38,7 @@
 #include "fdbclient/EventTypes.actor.h"
 #include "fdbrpc/ContinuousSample.h"
 #include "fdbrpc/Smoother.h"
+#include "fdbclient/VersionVector.h"
 
 class StorageServerInfo : public ReferencedInterface<StorageServerInterface> {
 public:
@@ -429,6 +430,9 @@ public:
 	static bool debugUseTags;
 	static const std::vector<std::string> debugTransactionTagChoices;
 	std::unordered_map<KeyRef, Reference<WatchMetadata>> watchMap;
+
+	// Cache of the latest commit versions of storage servers.
+	VersionVector ssVersionVectorCache;
 
         // Adds or updates the specified (SS, TSS) pair in the TSS mapping (if not already present).
         // Requests to the storage server will be duplicated to the TSS.

--- a/fdbclient/FDBTypes.h
+++ b/fdbclient/FDBTypes.h
@@ -26,6 +26,7 @@
 #include <string>
 #include <vector>
 #include <unordered_set>
+#include <boost/functional/hash.hpp>
 
 #include "flow/Arena.h"
 #include "flow/flow.h"

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -5415,6 +5415,7 @@ ACTOR Future<Version> extractReadVersion(Location location,
 	}
 
 	metadataVersion.send(rep.metadataVersion);
+	cx->ssVersionVectorCache = rep.ssVersionVector;
 	return rep.version;
 }
 

--- a/fdbserver/GrvProxyServer.actor.cpp
+++ b/fdbserver/GrvProxyServer.actor.cpp
@@ -26,6 +26,7 @@
 #include "fdbserver/WaitFailure.h"
 #include "fdbserver/WorkerInterface.actor.h"
 #include "flow/flow.h"
+#include "fdbclient/VersionVector.h"
 #include "flow/actorcompiler.h" // This must be the last #include.
 
 struct GrvProxyStats {
@@ -231,6 +232,9 @@ struct GrvProxyData {
 	NotifiedDouble lastCommitTime;
 
 	Version minKnownCommittedVersion; // we should ask master for this version.
+
+	// Cache of the latest commit versions of storage servers.
+	VersionVector ssVersionVectorCache;
 
 	void updateLatencyBandConfig(Optional<LatencyBandConfig> newLatencyBandConfig) {
 		if (newLatencyBandConfig.present() != latencyBandConfig.present() ||
@@ -543,6 +547,7 @@ ACTOR Future<GetReadVersionReply> getLiveCommittedVersion(SpanID parentSpan,
 	GetRawCommittedVersionReply repFromMaster = wait(replyFromMasterFuture);
 	grvProxyData->minKnownCommittedVersion =
 	    std::max(grvProxyData->minKnownCommittedVersion, repFromMaster.minKnownCommittedVersion);
+	grvProxyData->ssVersionVectorCache = repFromMaster.ssVersionVector;
 
 	GetReadVersionReply rep;
 	rep.version = repFromMaster.version;
@@ -555,6 +560,7 @@ ACTOR Future<GetReadVersionReply> getLiveCommittedVersion(SpanID parentSpan,
 	rep.processBusyTime += FLOW_KNOBS->BASIC_LOAD_BALANCE_COMPUTE_PRECISION *
 	                       (g_network->isSimulated() ? deterministicRandom()->random01()
 	                                                 : g_network->networkInfo.metrics.lastRunLoopBusyness);
+	rep.ssVersionVector = grvProxyData->ssVersionVectorCache;
 
 	if (debugID.present()) {
 		g_traceBatch.addEvent(

--- a/fdbserver/masterserver.actor.cpp
+++ b/fdbserver/masterserver.actor.cpp
@@ -1237,6 +1237,7 @@ ACTOR Future<Void> serveLiveCommittedVersion(Reference<MasterData> self) {
 				reply.locked = self->databaseLocked;
 				reply.metadataVersion = self->proxyMetadataVersion;
 				reply.minKnownCommittedVersion = self->minKnownCommittedVersion;
+				reply.ssVersionVector = self->ssVersionVector;
 				req.reply.send(reply);
 			}
 			when(ReportRawCommittedVersionRequest req =


### PR DESCRIPTION
Changes:

GrvProxyServer.actor.cpp:
- Cache the version vector on the grv proxy
- Update the local version vector cache on receiving the latest version vector (from the sequencer)
as part of the GetRawCommittedVersionReply message.
- Provide the latest version vector to the client as part of the GetReadVersionReply message.

masterserver.actor.cpp:
- Provide the latest version vector to the grv proxy as part of the GetRawCommittedVersionReply
message.

DatabaseContext.h:
- Cache the version vector to be made available to the client.

NativeAPI.actor.cpp:
- Update the local version vector cache on receiving the latest version vector (from the grv proxy)
as part of the GetReadVersionReply message.

CommitProxyInterface.h:
- Extend GetReadVersionReply and GetRawCommittedVersionReply so as to be able to propagate
the version vector from the sequencer (to the grv proxy) and the grv proxy (to the client).

FDBTypes.h:
- Include boost header (to address a compilation/linker error).

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
