### PR TITLE
Fix invalid read

### DIFF
--- a/fdbclient/ManagementAPI.actor.cpp
+++ b/fdbclient/ManagementAPI.actor.cpp
@@ -1956,7 +1956,8 @@ ACTOR Future<vector<std::string>> getExcludedLocalities(Database cx) {
 // Decodes the locality string to a pair of locality prefix and its value.
 // The prefix could be dcid, processid, machineid, processid.
 std::pair<std::string, std::string> decodeLocality(const std::string& locality) {
-	StringRef localityRef(locality.c_str());
+	StringRef localityRef((const uint8_t*)(locality.c_str()), locality.size());
+
 	std::string localityKeyValue = localityRef.removePrefix(LocalityData::ExcludeLocalityPrefix).toString();
 	int split = localityKeyValue.find(':');
 	if (split != std::string::npos) {


### PR DESCRIPTION
Valgrind surfaced an invalid read on commit de898cd8abe448cbbb70197cc697602ffc7c4848:

```
./bin/fdbserver -r simulation -f ../foundationdb/tests/fast/SwizzledRollbackSideband.toml --seed 462862274 --buggify on
```

Relevant backtrace from valgrind log:

```
==1030== Invalid read of size 16
==1030==    at 0x331A5BC: _mm_loadu_si128 (emmintrin.h:703)
==1030==    by 0x331A5BC: rte_mov16 (rte_memcpy.h:306)
==1030==    by 0x331A5BC: rte_memcpy_generic (rte_memcpy.h:404)
==1030==    by 0x331A5BC: rte_memcpy (rte_memcpy.h:870)
==1030==    by 0x331A5BC: memcpy (flow.cpp:38)
==1030==    by 0x4204F7: std::char_traits<char>::copy(char*, char const*, unsigned long) (char_traits.h:352)
==1030==    by 0x4320F6: std::string::_M_copy(char*, char const*, unsigned long) (basic_string.h:3382)
==1030==    by 0x452D66: std::string::_S_copy_chars(char*, char const*, char const*) (basic_string.h:3429)
==1030==    by 0x449C72: char* std::string::_S_construct<char const*>(char const*, char const*, std::allocator<char> const&, std::forward_iterator_tag) (basic_string.tcc:580)
==1030==    by 0x43D96F: char* std::string::_S_construct_aux<char const*>(char const*, char const*, std::allocator<char> const&, std::__false_type) (basic_string.h:5052)
==1030==    by 0x431E97: char* std::string::_S_construct<char const*>(char const*, char const*, std::allocator<char> const&) (basic_string.h:5073)
==1030==    by 0x428A07: std::basic_string<char, std::char_traits<char>, std::allocator<char> >::basic_string(char const*, unsigned long, std::allocator<char> const&) (basic_string.tcc:657)
==1030==    by 0x421471: StringRef::toString() const (Arena.h:508)
==1030==    by 0x25FEDD3: decodeLocality(std::string const&) (ManagementAPI.actor.cpp:1960)
==1030==    by 0x25FEF43: getAddressesByLocality(std::vector<ProcessData, std::allocator<ProcessData> > const&, std::string const&) (ManagementAPI.actor.cpp:1973)
==1030==    by 0x296217B: parseLocalitiesFromKeys(ReadYourWritesTransaction*, bool, std::unordered_set<std::string, std::hash<std::string>, std::equal_to<std::string>, std::allocator<std::string> >&, s
td::vector<AddressExclusion, std::allocator<AddressExclusion> >&, std::set<AddressExclusion, std::less<AddressExclusion>, std::allocator<AddressExclusion> >&, std::vector<ProcessData, std::allocator<Pr
ocessData> >&, Optional<std::string>&) (SpecialKeySpace.actor.cpp:2181)
```

I think the issue is that the `const char*` value from calling `c_str()` is getting implicitly converted back into `std::string` and using the `StringRef(const std::string& s)` constructor, which then uses `s.c_str()` as the data for the `StringRef`. But this is a temporarily constructed `std::string`, so any uses after the `StringRef` is created are invalid.

https://github.com/apple/foundationdb/blob/6c84594e2f9c33975bd23ce1f66d24a9c1ca5a81/flow/Arena.h#L618 should be catching this, except it seems the implicit conversion rules favor the `const std::string&` constructor instead of the `char*` constructor when doing an implicit conversion from `const char*`. Maybe we should add another private `StringRef` constructor for `const char*`.

Passed 10,000 correctness tests.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
