### PR TITLE
Features/version vector - Initial proxy changes

### DIFF
--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -38,7 +38,7 @@ void ServerKnobs::initialize(Randomize _randomize, ClientKnobs* clientKnobs, IsS
 	init( MAX_WRITE_TRANSACTION_LIFE_VERSIONS,     5 * VERSIONS_PER_SECOND ); if (randomize && BUGGIFY) MAX_WRITE_TRANSACTION_LIFE_VERSIONS=std::max<int>(1, 1 * VERSIONS_PER_SECOND);
 	init( MAX_COMMIT_BATCH_INTERVAL,                             2.0 ); if( randomize && BUGGIFY ) MAX_COMMIT_BATCH_INTERVAL = 0.5; // Each commit proxy generates a CommitTransactionBatchRequest at least this often, so that versions always advance smoothly
 	MAX_COMMIT_BATCH_INTERVAL = std::min(MAX_COMMIT_BATCH_INTERVAL, MAX_READ_TRANSACTION_LIFE_VERSIONS/double(2*VERSIONS_PER_SECOND)); // Ensure that the proxy commits 2 times every MAX_READ_TRANSACTION_LIFE_VERSIONS, otherwise the master will not give out versions fast enough
-	init( ENABLE_VERSION_VECTOR,                                true );
+	init( ENABLE_VERSION_VECTOR,                               false );
 
 	// TLogs
 	init( TLOG_TIMEOUT,                                          0.4 ); //cannot buggify because of availability

--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -38,6 +38,7 @@ void ServerKnobs::initialize(Randomize _randomize, ClientKnobs* clientKnobs, IsS
 	init( MAX_WRITE_TRANSACTION_LIFE_VERSIONS,     5 * VERSIONS_PER_SECOND ); if (randomize && BUGGIFY) MAX_WRITE_TRANSACTION_LIFE_VERSIONS=std::max<int>(1, 1 * VERSIONS_PER_SECOND);
 	init( MAX_COMMIT_BATCH_INTERVAL,                             2.0 ); if( randomize && BUGGIFY ) MAX_COMMIT_BATCH_INTERVAL = 0.5; // Each commit proxy generates a CommitTransactionBatchRequest at least this often, so that versions always advance smoothly
 	MAX_COMMIT_BATCH_INTERVAL = std::min(MAX_COMMIT_BATCH_INTERVAL, MAX_READ_TRANSACTION_LIFE_VERSIONS/double(2*VERSIONS_PER_SECOND)); // Ensure that the proxy commits 2 times every MAX_READ_TRANSACTION_LIFE_VERSIONS, otherwise the master will not give out versions fast enough
+	init( ENABLE_VERSION_VECTOR,                                true );
 
 	// TLogs
 	init( TLOG_TIMEOUT,                                          0.4 ); //cannot buggify because of availability

--- a/fdbclient/ServerKnobs.h
+++ b/fdbclient/ServerKnobs.h
@@ -36,6 +36,7 @@ public:
 	int64_t MAX_VERSIONS_IN_FLIGHT_FORCED;
 	int64_t MAX_READ_TRANSACTION_LIFE_VERSIONS;
 	int64_t MAX_WRITE_TRANSACTION_LIFE_VERSIONS;
+	bool ENABLE_VERSION_VECTOR;
 	double MAX_COMMIT_BATCH_INTERVAL; // Each commit proxy generates a CommitTransactionBatchRequest at least this
 	                                  // often, so that versions always advance smoothly
 

--- a/fdbclient/VersionVector.h
+++ b/fdbclient/VersionVector.h
@@ -43,6 +43,14 @@ struct VersionVector {
 		maxVersion = version;
 	}
 
+	void setVersions(const std::set<Tag>& tags, Version version) {
+		ASSERT(version > maxVersion);
+		for (auto& tag : tags) {
+			ASSERT(tag != invalidTag);
+			versions[tag] = version;
+		}
+	}
+
 	bool hasVersion(const Tag& tag) const {
 		ASSERT(tag != invalidTag);
 		return versions.find(tag) != versions.end();

--- a/fdbserver/CommitProxyServer.actor.cpp
+++ b/fdbserver/CommitProxyServer.actor.cpp
@@ -879,9 +879,9 @@ ACTOR Future<Void> applyMetadataToCommittedTransactions(CommitBatchContext* self
 // Message the sequencer to obtain the previous commit version for each storage server's tag
 ACTOR Future<Void> getTPCV(CommitBatchContext* self) {
 	state ProxyCommitData* const pProxyCommitData = self->pProxyCommitData;
-	GetTlogPrevCommitVersionReply rep = wait(brokenPromiseToNever(
-	    pProxyCommitData->master.getTlogPrevCommitVersion.getReply(GetTlogPrevCommitVersionRequest(self->writtenTLogs))));
-	// TraceEvent("GetTlogPrevCommitVersionRequest");
+	GetTLogPrevCommitVersionReply rep = wait(brokenPromiseToNever(
+	    pProxyCommitData->master.getTLogPrevCommitVersion.getReply(GetTLogPrevCommitVersionRequest(self->writtenTLogs))));
+	// TraceEvent("GetTLogPrevCommitVersionRequest");
 	return Void();
 }
 

--- a/fdbserver/CommitProxyServer.actor.cpp
+++ b/fdbserver/CommitProxyServer.actor.cpp
@@ -480,8 +480,8 @@ struct CommitBatchContext {
 
 	double commitStartTime;
 
-	std::set<uint16_t> locSet; // the set of tlog locations written to in the mutation.
-	std::set<Tag> tagSet; // the set of tags written to in the mutation.
+	std::set<uint16_t> writtenTLogs; // the set of tlog locations written to in the mutation.
+	std::set<Tag> writtenTags; // the set of tags written to in the mutation.
 
 	CommitBatchContext(ProxyCommitData*, const std::vector<CommitTransactionRequest>*, const int);
 
@@ -880,7 +880,7 @@ ACTOR Future<Void> applyMetadataToCommittedTransactions(CommitBatchContext* self
 ACTOR Future<Void> getTPCV(CommitBatchContext* self) {
 	state ProxyCommitData* const pProxyCommitData = self->pProxyCommitData;
 	GetTlogPrevCommitVersionReply rep = wait(brokenPromiseToNever(
-	    pProxyCommitData->master.getTlogPrevCommitVersion.getReply(GetTlogPrevCommitVersionRequest(self->locSet))));
+	    pProxyCommitData->master.getTlogPrevCommitVersion.getReply(GetTlogPrevCommitVersionRequest(self->writtenTLogs))));
 	// TraceEvent("GetTlogPrevCommitVersionRequest");
 	return Void();
 }
@@ -961,9 +961,9 @@ ACTOR Future<Void> assignMutationsToStorageServers(CommitBatchContext* self) {
 				if (pProxyCommitData->cacheInfo[m.param1]) {
 					self->toCommit.addTag(cacheTag);
 				}
-				self->toCommit.saveTags(self->tagSet);
+				self->toCommit.saveTags(self->writtenTags);
 				self->toCommit.writeTypedMessage(m);
-				self->toCommit.saveLocations(self->locSet, self->tagSet);
+				self->toCommit.saveLocations(self->writtenTLogs);
 			} else if (m.type == MutationRef::ClearRange) {
 				KeyRangeRef clearRange(KeyRangeRef(m.param1, m.param2));
 				auto ranges = pProxyCommitData->keyInfo.intersectingRanges(clearRange);
@@ -1019,9 +1019,9 @@ ACTOR Future<Void> assignMutationsToStorageServers(CommitBatchContext* self) {
 				if (pProxyCommitData->needsCacheTag(clearRange)) {
 					self->toCommit.addTag(cacheTag);
 				}
-				self->toCommit.saveTags(self->tagSet);
+				self->toCommit.saveTags(self->writtenTags);
 				self->toCommit.writeTypedMessage(m);
-				self->toCommit.saveLocations(self->locSet, self->tagSet);
+				self->toCommit.saveLocations(self->writtenTLogs);
 			} else {
 				UNREACHABLE();
 			}
@@ -1298,16 +1298,16 @@ ACTOR Future<Void> reply(CommitBatchContext* self) {
 	// self->committedVersion.
 	TEST(pProxyCommitData->committedVersion.get() > self->commitVersion); // A later version was reported committed first
 	if (self->commitVersion >= pProxyCommitData->committedVersion.get()) {
-		state Optional<std::set<Tag>> tagSet;
+		state Optional<std::set<Tag>> writtenTags;
 		if (SERVER_KNOBS->ENABLE_VERSION_VECTOR) {
-			tagSet = self->tagSet;
+			writtenTags = self->writtenTags;
 		}
 		wait(pProxyCommitData->master.reportLiveCommittedVersion.getReply(
 		    ReportRawCommittedVersionRequest(self->commitVersion,
 		                                     self->lockedAfter,
 		                                     self->metadataVersionAfter,
 		                                     pProxyCommitData->minKnownCommittedVersion,
-		                                     tagSet),
+		                                     writtenTags),
 		    TaskPriority::ProxyMasterVersionReply));
 	}
 	if (self->commitVersion > pProxyCommitData->committedVersion.get()) {

--- a/fdbserver/CommitProxyServer.actor.cpp
+++ b/fdbserver/CommitProxyServer.actor.cpp
@@ -480,6 +480,9 @@ struct CommitBatchContext {
 
 	double commitStartTime;
 
+	std::set<uint16_t> locSet; // the set of tlog locations written to in the mutation.
+	std::set<Tag> tagSet; // the set of tags written to in the mutation.
+
 	CommitBatchContext(ProxyCommitData*, const std::vector<CommitTransactionRequest>*, const int);
 
 	void setupTraceBatch();
@@ -873,6 +876,15 @@ ACTOR Future<Void> applyMetadataToCommittedTransactions(CommitBatchContext* self
 	return Void();
 }
 
+// Message the sequencer to obtain the previous commit version for each storage server's tag
+ACTOR Future<Void> getTPCV(CommitBatchContext* self) {
+	state ProxyCommitData* const pProxyCommitData = self->pProxyCommitData;
+	GetTlogPrevCommitVersionReply rep = wait(brokenPromiseToNever(
+	    pProxyCommitData->master.getTlogPrevCommitVersion.getReply(GetTlogPrevCommitVersionRequest(self->locSet))));
+	// TraceEvent("GetTlogPrevCommitVersionRequest");
+	return Void();
+}
+
 /// This second pass through committed transactions assigns the actual mutations to the appropriate storage servers'
 /// tags
 ACTOR Future<Void> assignMutationsToStorageServers(CommitBatchContext* self) {
@@ -949,7 +961,9 @@ ACTOR Future<Void> assignMutationsToStorageServers(CommitBatchContext* self) {
 				if (pProxyCommitData->cacheInfo[m.param1]) {
 					self->toCommit.addTag(cacheTag);
 				}
+				self->toCommit.saveTags(self->tagSet);
 				self->toCommit.writeTypedMessage(m);
+				self->toCommit.saveLocations(self->locSet, self->tagSet);
 			} else if (m.type == MutationRef::ClearRange) {
 				KeyRangeRef clearRange(KeyRangeRef(m.param1, m.param2));
 				auto ranges = pProxyCommitData->keyInfo.intersectingRanges(clearRange);
@@ -999,14 +1013,15 @@ ACTOR Future<Void> assignMutationsToStorageServers(CommitBatchContext* self) {
 					    .detail("Dbgid", pProxyCommitData->dbgid)
 					    .detail("To", allSources)
 					    .detail("Mutation", m);
-
 					self->toCommit.addTags(allSources);
 				}
 
 				if (pProxyCommitData->needsCacheTag(clearRange)) {
 					self->toCommit.addTag(cacheTag);
 				}
+				self->toCommit.saveTags(self->tagSet);
 				self->toCommit.writeTypedMessage(m);
+				self->toCommit.saveLocations(self->locSet, self->tagSet);
 			} else {
 				UNREACHABLE();
 			}
@@ -1095,6 +1110,11 @@ ACTOR Future<Void> postResolution(CommitBatchContext* self) {
 
 	// Second pass
 	wait(assignMutationsToStorageServers(self));
+
+	// Obtain previous committed versions for each affected tlog from sequencer
+	if (SERVER_KNOBS->ENABLE_VERSION_VECTOR) {
+		wait(getTPCV(self));
+	}
 
 	// Serialize and backup the mutations as a single mutation
 	if ((pProxyCommitData->vecBackupKeys.size() > 1) && self->logRangeMutations.size()) {
@@ -1278,11 +1298,16 @@ ACTOR Future<Void> reply(CommitBatchContext* self) {
 	// self->committedVersion.
 	TEST(pProxyCommitData->committedVersion.get() > self->commitVersion); // A later version was reported committed first
 	if (self->commitVersion >= pProxyCommitData->committedVersion.get()) {
+		state Optional<std::set<Tag>> tagSet;
+		if (SERVER_KNOBS->ENABLE_VERSION_VECTOR) {
+			tagSet = self->tagSet;
+		}
 		wait(pProxyCommitData->master.reportLiveCommittedVersion.getReply(
 		    ReportRawCommittedVersionRequest(self->commitVersion,
 		                                     self->lockedAfter,
 		                                     self->metadataVersionAfter,
-		                                     pProxyCommitData->minKnownCommittedVersion),
+		                                     pProxyCommitData->minKnownCommittedVersion,
+		                                     tagSet),
 		    TaskPriority::ProxyMasterVersionReply));
 	}
 	if (self->commitVersion > pProxyCommitData->committedVersion.get()) {

--- a/fdbserver/LogSystem.h
+++ b/fdbserver/LogSystem.h
@@ -995,6 +995,22 @@ struct LogPushData : NonCopyable {
 		writtenLocations.clear();
 	}
 
+	// copy next_message_tags into given set
+	void saveTags(std::set<Tag>& tagSet) {
+		tagSet.insert(next_message_tags.begin(), next_message_tags.end());
+		return;
+	}
+
+	// store tlogs as represented by index
+	// also store in tag set all replicas
+	void saveLocations(std::set<uint16_t>& locSet, std::set<Tag>& tagSet) {
+		locSet.insert(msg_locations.begin(), msg_locations.end());
+		for (auto loc: msg_locations) {
+			tagSet.insert(Tag(0, loc));  // TODO POST DEMO support DC other than primary
+		}
+		return;
+	}
+
 	void writeMessage(StringRef rawMessageWithoutLength, bool usePreviousLocations) {
 		if (!usePreviousLocations) {
 			prev_tags.clear();

--- a/fdbserver/LogSystem.h
+++ b/fdbserver/LogSystem.h
@@ -996,19 +996,13 @@ struct LogPushData : NonCopyable {
 	}
 
 	// copy next_message_tags into given set
-	void saveTags(std::set<Tag>& tagSet) {
-		tagSet.insert(next_message_tags.begin(), next_message_tags.end());
-		return;
+	void saveTags(std::set<Tag>& writtenTags) {
+		writtenTags.insert(next_message_tags.begin(), next_message_tags.end());
 	}
 
 	// store tlogs as represented by index
-	// also store in tag set all replicas
-	void saveLocations(std::set<uint16_t>& locSet, std::set<Tag>& tagSet) {
-		locSet.insert(msg_locations.begin(), msg_locations.end());
-		for (auto loc: msg_locations) {
-			tagSet.insert(Tag(0, loc));  // TODO POST DEMO support DC other than primary
-		}
-		return;
+	void saveLocations(std::set<uint16_t>& writtenTLogs) {
+		writtenTLogs.insert(msg_locations.begin(), msg_locations.end());
 	}
 
 	void writeMessage(StringRef rawMessageWithoutLength, bool usePreviousLocations) {

--- a/fdbserver/LogSystemConfig.h
+++ b/fdbserver/LogSystemConfig.h
@@ -295,7 +295,9 @@ struct LogSystemConfig {
 	int numLogs() const {
 		int numLogs=0;
 		for (auto& tLogSet : tLogs) {
-			numLogs += tLogSet.tLogs.size();
+			if (tLogSet.isLocal == true) {
+				numLogs += tLogSet.tLogs.size();
+			}
 		}
 		return numLogs;
 	}

--- a/fdbserver/LogSystemConfig.h
+++ b/fdbserver/LogSystemConfig.h
@@ -292,6 +292,14 @@ struct LogSystemConfig {
 		return results;
 	}
 
+	int numLogs() const {
+		int numLogs=0;
+		for (auto& tLogSet : tLogs) {
+			numLogs += tLogSet.tLogs.size();
+		}
+		return numLogs;
+	}
+
 	std::vector<TLogInterface> allPresentLogs() const {
 		std::vector<TLogInterface> results;
 		for (int i = 0; i < tLogs.size(); i++) {

--- a/fdbserver/MasterInterface.h
+++ b/fdbserver/MasterInterface.h
@@ -201,13 +201,13 @@ struct GetTlogPrevCommitVersionReply {
 
 struct GetTlogPrevCommitVersionRequest {
 	constexpr static FileIdentifier file_identifier = 16683184;
-	std::set<uint16_t> locSet;
+	std::set<uint16_t> writtenTLogs;
 	ReplyPromise<GetTlogPrevCommitVersionReply> reply;
 	GetTlogPrevCommitVersionRequest() {}
-	GetTlogPrevCommitVersionRequest(std::set<uint16_t>& locSet) : locSet(locSet) {}
+	GetTlogPrevCommitVersionRequest(std::set<uint16_t>& writtenTLogs) : writtenTLogs(writtenTLogs) {}
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, locSet, reply);
+		serializer(ar, writtenTLogs, reply);
 	}
 };
 
@@ -217,7 +217,7 @@ struct ReportRawCommittedVersionRequest {
 	bool locked;
 	Optional<Value> metadataVersion;
 	Version minKnownCommittedVersion;
-	Optional<std::set<Tag>> tagSet;
+	Optional<std::set<Tag>> writtenTags;
 	ReplyPromise<Void> reply;
 
 	ReportRawCommittedVersionRequest() : version(invalidVersion), locked(false), minKnownCommittedVersion(0) {}
@@ -225,13 +225,13 @@ struct ReportRawCommittedVersionRequest {
 	                                 bool locked,
 	                                 Optional<Value> metadataVersion,
 	                                 Version minKnownCommittedVersion,
-	                                 Optional<std::set<Tag>> tagSet = Optional<std::set<Tag>>())
+	                                 Optional<std::set<Tag>> writtenTags = Optional<std::set<Tag>>())
 	  : version(version), locked(locked), metadataVersion(metadataVersion),
-	    minKnownCommittedVersion(minKnownCommittedVersion), tagSet(tagSet) {}
+	    minKnownCommittedVersion(minKnownCommittedVersion), writtenTags(writtenTags) {}
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, version, locked, metadataVersion, minKnownCommittedVersion, tagSet, reply);
+		serializer(ar, version, locked, metadataVersion, minKnownCommittedVersion, writtenTags, reply);
 	}
 };
 

--- a/fdbserver/MasterInterface.h
+++ b/fdbserver/MasterInterface.h
@@ -44,7 +44,7 @@ struct MasterInterface {
 	RequestStream<struct GetRawCommittedVersionRequest> getLiveCommittedVersion;
 	// Report a proxy's committed version.
 	RequestStream<struct ReportRawCommittedVersionRequest> reportLiveCommittedVersion;
-	RequestStream<struct GetTlogPrevCommitVersionRequest> getTlogPrevCommitVersion;
+	RequestStream<struct GetTLogPrevCommitVersionRequest> getTLogPrevCommitVersion;
 
 	NetworkAddress address() const { return changeCoordinators.getEndpoint().getPrimaryAddress(); }
 	NetworkAddressList addresses() const { return changeCoordinators.getEndpoint().addresses; }
@@ -68,8 +68,8 @@ struct MasterInterface {
 			    RequestStream<struct GetRawCommittedVersionRequest>(waitFailure.getEndpoint().getAdjustedEndpoint(5));
 			reportLiveCommittedVersion = RequestStream<struct ReportRawCommittedVersionRequest>(
 			    waitFailure.getEndpoint().getAdjustedEndpoint(6));
-			getTlogPrevCommitVersion =
-			    RequestStream<struct GetTlogPrevCommitVersionRequest>(waitFailure.getEndpoint().getAdjustedEndpoint(7));
+			getTLogPrevCommitVersion =
+			    RequestStream<struct GetTLogPrevCommitVersionRequest>(waitFailure.getEndpoint().getAdjustedEndpoint(7));
 		}
 	}
 
@@ -82,7 +82,7 @@ struct MasterInterface {
 		streams.push_back(notifyBackupWorkerDone.getReceiver());
 		streams.push_back(getLiveCommittedVersion.getReceiver(TaskPriority::GetLiveCommittedVersion));
 		streams.push_back(reportLiveCommittedVersion.getReceiver(TaskPriority::ReportLiveCommittedVersion));
-		streams.push_back(getTlogPrevCommitVersion.getReceiver(TaskPriority::GetTlogPrevCommitVersion));
+		streams.push_back(getTLogPrevCommitVersion.getReceiver(TaskPriority::GetTLogPrevCommitVersion));
 		FlowTransport::transport().addEndpoints(streams);
 	}
 };
@@ -189,22 +189,22 @@ struct GetCommitVersionRequest {
 	}
 };
 
-struct GetTlogPrevCommitVersionReply {
+struct GetTLogPrevCommitVersionReply {
 	constexpr static FileIdentifier file_identifier = 16683183;
 	std::unordered_map<uint16_t, Version> tpcvMap;
-	GetTlogPrevCommitVersionReply() {}
+	GetTLogPrevCommitVersionReply() {}
 	template <class Ar>
 	void serialize(Ar& ar) {
 		serializer(ar, tpcvMap);
 	}
 };
 
-struct GetTlogPrevCommitVersionRequest {
+struct GetTLogPrevCommitVersionRequest {
 	constexpr static FileIdentifier file_identifier = 16683184;
 	std::set<uint16_t> writtenTLogs;
-	ReplyPromise<GetTlogPrevCommitVersionReply> reply;
-	GetTlogPrevCommitVersionRequest() {}
-	GetTlogPrevCommitVersionRequest(std::set<uint16_t>& writtenTLogs) : writtenTLogs(writtenTLogs) {}
+	ReplyPromise<GetTLogPrevCommitVersionReply> reply;
+	GetTLogPrevCommitVersionRequest() {}
+	GetTLogPrevCommitVersionRequest(std::set<uint16_t>& writtenTLogs) : writtenTLogs(writtenTLogs) {}
 	template <class Ar>
 	void serialize(Ar& ar) {
 		serializer(ar, writtenTLogs, reply);

--- a/fdbserver/masterserver.actor.cpp
+++ b/fdbserver/masterserver.actor.cpp
@@ -251,8 +251,7 @@ struct MasterData : NonCopyable, ReferenceCounted<MasterData> {
 	VersionVector ssVersionVector;
 
 	// The previous commit versions per tlog
-	std::map<uint16_t, Version> tpcvMap;
-
+	std::vector<Version> tpcvVector;
 	CounterCollection cc;
 	Counter changeCoordinatorsRequests;
 	Counter getCommitVersionRequests;
@@ -1247,6 +1246,7 @@ ACTOR Future<Void> serveLiveCommittedVersion(Reference<MasterData> self) {
 			         waitNext(self->myInterface.reportLiveCommittedVersion.getFuture())) {
 				self->minKnownCommittedVersion = std::max(self->minKnownCommittedVersion, req.minKnownCommittedVersion);
 				if (SERVER_KNOBS->ENABLE_VERSION_VECTOR && req.writtenTags.present()) {
+					// NB: this if-condition is not needed after wait-for-prev is ported to this branch
 					if (req.version > self->ssVersionVector.maxVersion) {
 						// TraceEvent("Received ReportRawCommittedVersionRequest").detail("Version",req.version);
 						self->ssVersionVector.setVersions(req.writtenTags.get(), req.version);
@@ -1260,14 +1260,11 @@ ACTOR Future<Void> serveLiveCommittedVersion(Reference<MasterData> self) {
 				++self->reportLiveCommittedVersionRequests;
 				req.reply.send(Void());
 			}
-			when(GetTlogPrevCommitVersionRequest req =
-			         waitNext(self->myInterface.getTlogPrevCommitVersion.getFuture())) {
-				GetTlogPrevCommitVersionReply reply;
+			when(GetTLogPrevCommitVersionRequest req =
+			         waitNext(self->myInterface.getTLogPrevCommitVersion.getFuture())) {
+				GetTLogPrevCommitVersionReply reply;
 				for (uint16_t tLog : req.writtenTLogs) {
-					// TraceEvent("Received GetTlogPrevCommitVersionRequest").detail("Loc", loc);
-					if (self->tpcvMap.find(tLog) != self->tpcvMap.end()) {
-						reply.tpcvMap[tLog] = self->tpcvMap[tLog];
-					}
+					reply.tpcvMap[tLog] = self->tpcvVector[tLog]; // TODO (placeholder)
 				}
 				req.reply.send(reply);
 			}
@@ -1907,6 +1904,10 @@ ACTOR Future<Void> masterCore(Reference<MasterData> self) {
 	tr.read_snapshot = self->recoveryTransactionVersion; // lastEpochEnd would make more sense, but isn't in the initial
 	                                                     // window of the resolver(s)
 
+	// resize the previous commit version vector to the number of tlogs.
+	int numLogs = self->dbInfo->get().logSystemConfig.numLogs();
+	self->tpcvVector.resize(1 + numLogs, invalidVersion);
+
 	TraceEvent("MasterRecoveryCommit", self->dbgid);
 	state Future<ErrorOr<CommitID>> recoveryCommit = self->commitProxies[0].commit.tryGetReply(recoveryCommitRequest);
 	self->addActor.send(self->logSystem->onError());
@@ -2046,6 +2047,9 @@ ACTOR Future<Void> masterServer(MasterInterface mi,
 						wait(delay(5));
 					throw worker_removed();
 				}
+				// resize the previous commit version vector to the number of tlogs.
+				int numLogs = self->dbInfo->get().logSystemConfig.numLogs();
+				self->tpcvVector.resize(1 + numLogs, invalidVersion);
 			}
 			when(BackupWorkerDoneRequest req = waitNext(mi.notifyBackupWorkerDone.getFuture())) {
 				if (self->logSystem.isValid() && self->logSystem->removeBackupWorker(req)) {

--- a/fdbserver/masterserver.actor.cpp
+++ b/fdbserver/masterserver.actor.cpp
@@ -1264,6 +1264,7 @@ ACTOR Future<Void> serveLiveCommittedVersion(Reference<MasterData> self) {
 			         waitNext(self->myInterface.getTLogPrevCommitVersion.getFuture())) {
 				GetTLogPrevCommitVersionReply reply;
 				for (uint16_t tLog : req.writtenTLogs) {
+					// TODO the reply needs to be ordered by commit version.
 					reply.tpcvMap[tLog] = self->tpcvVector[tLog]; // TODO (placeholder)
 				}
 				req.reply.send(reply);

--- a/fdbserver/masterserver.actor.cpp
+++ b/fdbserver/masterserver.actor.cpp
@@ -250,6 +250,9 @@ struct MasterData : NonCopyable, ReferenceCounted<MasterData> {
 	// Captures the latest commit version targeted for each storage server in the cluster.
 	VersionVector ssVersionVector;
 
+	// The previous commit versions per tlog
+	std::map<uint16_t, Version> tpcvMap;
+
 	CounterCollection cc;
 	Counter changeCoordinatorsRequests;
 	Counter getCommitVersionRequests;
@@ -299,8 +302,8 @@ ACTOR Future<Void> newCommitProxies(Reference<MasterData> self, RecruitFromConfi
 		req.recoveryTransactionVersion = self->recoveryTransactionVersion;
 		req.firstProxy = i == 0;
 		TraceEvent("CommitProxyReplies", self->dbgid)
-			.detail("WorkerID", recr.commitProxies[i].id())
-			.detail("FirstProxy", req.firstProxy ? "True" : "False");
+		    .detail("WorkerID", recr.commitProxies[i].id())
+		    .detail("FirstProxy", req.firstProxy ? "True" : "False");
 		initializationReplies.push_back(
 		    transformErrors(throwErrorOr(recr.commitProxies[i].commitProxy.getReplyUnlessFailedFor(
 		                        req, SERVER_KNOBS->TLOG_TIMEOUT, SERVER_KNOBS->MASTER_FAILURE_SLOPE_DURING_RECOVERY)),
@@ -960,9 +963,9 @@ ACTOR Future<Void> sendInitialCommitToResolvers(Reference<MasterData> self) {
 	}
 	wait(waitForAll(txnReplies));
 	TraceEvent("RecoveryInternal", self->dbgid)
-		.detail("StatusCode", RecoveryStatus::recovery_transaction)
-		.detail("Status", RecoveryStatus::names[RecoveryStatus::recovery_transaction])
-		.detail("Step", "SentTxnStateStoreToCommitProxies");
+	    .detail("StatusCode", RecoveryStatus::recovery_transaction)
+	    .detail("Status", RecoveryStatus::names[RecoveryStatus::recovery_transaction])
+	    .detail("Step", "SentTxnStateStoreToCommitProxies");
 
 	vector<Future<ResolveTransactionBatchReply>> replies;
 	for (auto& r : self->resolvers) {
@@ -976,9 +979,9 @@ ACTOR Future<Void> sendInitialCommitToResolvers(Reference<MasterData> self) {
 
 	wait(waitForAll(replies));
 	TraceEvent("RecoveryInternal", self->dbgid)
-		.detail("StatusCode", RecoveryStatus::recovery_transaction)
-		.detail("Status", RecoveryStatus::names[RecoveryStatus::recovery_transaction])
-		.detail("Step", "InitializedAllResolvers");
+	    .detail("StatusCode", RecoveryStatus::recovery_transaction)
+	    .detail("Status", RecoveryStatus::names[RecoveryStatus::recovery_transaction])
+	    .detail("Step", "InitializedAllResolvers");
 	return Void();
 }
 
@@ -1243,6 +1246,12 @@ ACTOR Future<Void> serveLiveCommittedVersion(Reference<MasterData> self) {
 			when(ReportRawCommittedVersionRequest req =
 			         waitNext(self->myInterface.reportLiveCommittedVersion.getFuture())) {
 				self->minKnownCommittedVersion = std::max(self->minKnownCommittedVersion, req.minKnownCommittedVersion);
+				if (SERVER_KNOBS->ENABLE_VERSION_VECTOR && req.tagSet.present()) {
+					if (req.version > self->ssVersionVector.maxVersion) {
+						// TraceEvent("Received ReportRawCommittedVersionRequest").detail("Version",req.version);
+						self->ssVersionVector.setVersions(req.tagSet.get(), req.version);
+					}
+				}
 				if (req.version > self->liveCommittedVersion) {
 					self->liveCommittedVersion = req.version;
 					self->databaseLocked = req.locked;
@@ -1250,6 +1259,17 @@ ACTOR Future<Void> serveLiveCommittedVersion(Reference<MasterData> self) {
 				}
 				++self->reportLiveCommittedVersionRequests;
 				req.reply.send(Void());
+			}
+			when(GetTlogPrevCommitVersionRequest req =
+			         waitNext(self->myInterface.getTlogPrevCommitVersion.getFuture())) {
+				GetTlogPrevCommitVersionReply reply;
+				for (uint16_t loc : req.locSet) {
+					// TraceEvent("Received GetTlogPrevCommitVersionRequest").detail("Loc", loc);
+					if (self->tpcvMap.find(loc) != self->tpcvMap.end()) {
+						reply.tpcvMap[loc] = self->tpcvMap[loc];
+					}
+				}
+				req.reply.send(reply);
 			}
 		}
 	}

--- a/fdbserver/masterserver.actor.cpp
+++ b/fdbserver/masterserver.actor.cpp
@@ -1246,10 +1246,10 @@ ACTOR Future<Void> serveLiveCommittedVersion(Reference<MasterData> self) {
 			when(ReportRawCommittedVersionRequest req =
 			         waitNext(self->myInterface.reportLiveCommittedVersion.getFuture())) {
 				self->minKnownCommittedVersion = std::max(self->minKnownCommittedVersion, req.minKnownCommittedVersion);
-				if (SERVER_KNOBS->ENABLE_VERSION_VECTOR && req.tagSet.present()) {
+				if (SERVER_KNOBS->ENABLE_VERSION_VECTOR && req.writtenTags.present()) {
 					if (req.version > self->ssVersionVector.maxVersion) {
 						// TraceEvent("Received ReportRawCommittedVersionRequest").detail("Version",req.version);
-						self->ssVersionVector.setVersions(req.tagSet.get(), req.version);
+						self->ssVersionVector.setVersions(req.writtenTags.get(), req.version);
 					}
 				}
 				if (req.version > self->liveCommittedVersion) {
@@ -1263,10 +1263,10 @@ ACTOR Future<Void> serveLiveCommittedVersion(Reference<MasterData> self) {
 			when(GetTlogPrevCommitVersionRequest req =
 			         waitNext(self->myInterface.getTlogPrevCommitVersion.getFuture())) {
 				GetTlogPrevCommitVersionReply reply;
-				for (uint16_t loc : req.locSet) {
+				for (uint16_t tLog : req.writtenTLogs) {
 					// TraceEvent("Received GetTlogPrevCommitVersionRequest").detail("Loc", loc);
-					if (self->tpcvMap.find(loc) != self->tpcvMap.end()) {
-						reply.tpcvMap[loc] = self->tpcvMap[loc];
+					if (self->tpcvMap.find(tLog) != self->tpcvMap.end()) {
+						reply.tpcvMap[tLog] = self->tpcvMap[tLog];
 					}
 				}
 				req.reply.send(reply);

--- a/flow/network.h
+++ b/flow/network.h
@@ -81,7 +81,7 @@ enum class TaskPriority {
 	GetConsistentReadVersion = 8500,
 	GetLiveCommittedVersionReply = 8490,
 	GetLiveCommittedVersion = 8480,
-	GetTlogPrevCommitVersion = 8400,
+	GetTLogPrevCommitVersion = 8400,
 	DefaultPromiseEndpoint = 8000,
 	DefaultOnMainThread = 7500,
 	DefaultDelay = 7010,

--- a/flow/network.h
+++ b/flow/network.h
@@ -81,6 +81,7 @@ enum class TaskPriority {
 	GetConsistentReadVersion = 8500,
 	GetLiveCommittedVersionReply = 8490,
 	GetLiveCommittedVersion = 8480,
+	GetTlogPrevCommitVersion = 8400,
 	DefaultPromiseEndpoint = 8000,
 	DefaultOnMainThread = 7500,
 	DefaultDelay = 7010,


### PR DESCRIPTION
- after commit resolve: The Proxy sends the sets of affected tlogs (index format) to the sequencer;
- the Sequencer returns each tlog’s previous commit version (TPCV) 
- The TPCV has dummy values for now. A subsequent PR will use the TPCV.
- after tlogs persist data: the Proxy notifies the Sequencer that the transaction with CV has committed with the sets of affected storage tags (including replicas in team)
- created knob for the feature

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
