### PR TITLE
Add trace event to tLog pop

### DIFF
--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -102,6 +102,8 @@ void ServerKnobs::initialize(Randomize _randomize, ClientKnobs* clientKnobs, IsS
 	init( PUSH_STATS_SLOW_AMOUNT,                                  2 );
 	init( PUSH_STATS_SLOW_RATIO,                                 0.5 );
 	init( TLOG_POP_BATCH_SIZE,                                  1000 ); if ( randomize && BUGGIFY ) TLOG_POP_BATCH_SIZE = 10;
+	init( TLOG_POPPED_VER_LAG_THRESHOLD_FOR_TLOGPOP_TRACE,     100e6 );
+	init( ENABLE_DETAILED_TLOG_POP_TRACE,                          1 );
 
 	// disk snapshot max timeout, to be put in TLog, storage and coordinator nodes
 	init( MAX_FORKED_PROCESS_OUTPUT,                            1024 );

--- a/fdbclient/ServerKnobs.h
+++ b/fdbclient/ServerKnobs.h
@@ -64,6 +64,8 @@ public:
 	                                              // message (measured in 1/1024ths, e.g. a value of 2048 yields a
 	                                              // factor of 2).
 	int64_t VERSION_MESSAGES_ENTRY_BYTES_WITH_OVERHEAD;
+	int64_t TLOG_POPPED_VER_LAG_THRESHOLD_FOR_TLOGPOP_TRACE;
+	bool ENABLE_DETAILED_TLOG_POP_TRACE;
 	double TLOG_MESSAGE_BLOCK_OVERHEAD_FACTOR;
 	int64_t TLOG_MESSAGE_BLOCK_BYTES;
 	int64_t MAX_MESSAGE_SIZE;

--- a/fdbserver/OldTLogServer_6_2.actor.cpp
+++ b/fdbserver/OldTLogServer_6_2.actor.cpp
@@ -1440,6 +1440,18 @@ ACTOR Future<Void> tLogPopCore(TLogData* self, Tag inputTag, Version to, Referen
 			}
 		}
 
+		uint64_t PoppedVersionLag = logData->persistentDataDurableVersion - logData->queuePoppedVersion;
+		if ( SERVER_KNOBS->ENABLE_DETAILED_TLOG_POP_TRACE && //trace is open
+			(tagData->unpoppedRecovered || PoppedVersionLag >= SERVER_KNOBS->TLOG_POPPED_VER_LAG_THRESHOLD_FOR_TLOGPOP_TRACE)) { //when recovery or long lag
+			TraceEvent("TLogPopDetails", logData->logId)
+				.detail("Tag", tagData->tag.toString())
+				.detail("UpTo", upTo)
+				.detail("PoppedVersionLag", PoppedVersionLag)
+				.detail("MinPoppedTag", logData->minPoppedTag.toString())
+				.detail("QueuePoppedVersion", logData->queuePoppedVersion)
+				.detail("UnpoppedRecovered", tagData->unpoppedRecovered ? "True" : "False")
+				.detail("NothingPersistent", tagData->nothingPersistent ? "True" : "False");
+		}
 		if (upTo > logData->persistentDataDurableVersion)
 			wait(tagData->eraseMessagesBefore(upTo, self, logData, TaskPriority::TLogPop));
 		//TraceEvent("TLogPop", self->dbgid).detail("Tag", tag.toString()).detail("To", upTo);

--- a/fdbserver/TLogServer.actor.cpp
+++ b/fdbserver/TLogServer.actor.cpp
@@ -1166,6 +1166,18 @@ ACTOR Future<Void> tLogPopCore(TLogData* self, Tag inputTag, Version to, Referen
 			}
 		}
 
+		uint64_t PoppedVersionLag = logData->persistentDataDurableVersion - logData->queuePoppedVersion;
+		if ( SERVER_KNOBS->ENABLE_DETAILED_TLOG_POP_TRACE && //trace is open
+			(tagData->unpoppedRecovered || PoppedVersionLag >= SERVER_KNOBS->TLOG_POPPED_VER_LAG_THRESHOLD_FOR_TLOGPOP_TRACE)) { //when recovery or long lag
+			TraceEvent("TLogPopDetails", logData->logId)
+				.detail("Tag", tagData->tag.toString())
+				.detail("UpTo", upTo)
+				.detail("PoppedVersionLag", PoppedVersionLag)
+				.detail("MinPoppedTag", logData->minPoppedTag.toString())
+				.detail("QueuePoppedVersion", logData->queuePoppedVersion)
+				.detail("UnpoppedRecovered", tagData->unpoppedRecovered ? "True" : "False")
+				.detail("NothingPersistent", tagData->nothingPersistent ? "True" : "False");
+		}
 		if (upTo > logData->persistentDataDurableVersion)
 			wait(tagData->eraseMessagesBefore(upTo, self, logData, TaskPriority::TLogPop));
 		//TraceEvent("TLogPop", logData->logId).detail("Tag", tag.toString()).detail("To", upTo);


### PR DESCRIPTION
Problem:
There are two incidents where disk occupancy of TLogs can abnormally large: (1) the recovery gets stuck between accepting_commits step and full_recovery step; (2) SS falls far behind the TLog.

In both incidents, we want to know whether existing a TLog which disk occupancy is abnormally large? If yes, which tag blocks discarding the tail of DiskQueue of the tLog? Since the tail of the DiskQueue can be discarded only if all the tags have been popped from the oldest commit in the DiskQueue. 

Solution:
logData->queuePoppedVersion is the oldest version that is still useful.
logData->persistentDataDurableVersion is the latest version spilled on disk.
Then the field PoppedVersionLag (= logData->persistentDataDurableVersion - logData->queuePoppedVersion) indicates us how many versions are kept on the TLog DiskQueue.
When PoppedVersionLag is large, we want to know which tag blocks the tLog from discarding old data.
logData->MinPoppedTag is the tag that makes tLog hold its data and cause tLog's disk queue increasing.

Respecting to the overhead, this event message appears only in recovery (before the tLog pop passes recoveryAt) or when the version scope on tLog disk queue  is larger than 2/5 * STORAGE_DURABILITY_LAG_SOFT_MAX.

Verified functionality via simulation and aws env.
Passed Joshua 100k test: 20210707-162215-zhewang-d35bee965022a270





# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
