### PR TITLE
    Add CycleMultiClientIntegrationTest

### DIFF
--- a/bindings/java/src/integration/com/apple/foundationdb/CycleMultiClientIntegrationTest.java
+++ b/bindings/java/src/integration/com/apple/foundationdb/CycleMultiClientIntegrationTest.java
@@ -1,0 +1,140 @@
+/*
+ * CycleMultiClientIntegrationTest
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2018 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.apple.foundationdb;
+
+import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+import com.apple.foundationdb.tuple.Tuple;
+
+import org.junit.jupiter.api.Assertions;
+
+/**
+ * Setup: Generating a cycle 0 -> 1 -> 2 -> 3 -> 0, its length is 4
+ * Process: randomly choose an element, reverse 2nd and 4rd element, considering the chosen one as the 1st element.
+ * Check: verify no element is lost or added, and they are still a cycle.
+ * 
+ * This test is to verify the atomicity of transactions. 
+ */
+public class CycleMultiClientIntegrationTest {
+	public static final MultiClientHelper clientHelper = new MultiClientHelper();
+
+	private static final int len = 4;
+	private static List<String> expected = new ArrayList<>(Arrays.asList("0", "1", "2", "3"));
+
+	public static void main(String[] args) throws Exception {
+		FDB fdb = FDB.selectAPIVersion(630);
+		setupThreads(fdb);			
+		Collection<Database> dbs = clientHelper.openDatabases(fdb); // the clientHelper will close the databases for us
+		System.out.print("Starting tests\n");
+		setup(dbs);
+		System.out.print("Start processing\n");
+		process(dbs);
+		System.out.print("Start validataing\n");
+		check(dbs);
+		System.out.print("Test finished\n");
+	}
+
+	private static synchronized void setupThreads(FDB fdb) {
+		int clientThreadsPerVersion = clientHelper.readClusterFromEnv().length;
+		fdb.options().setClientThreadsPerVersion(clientThreadsPerVersion);
+		System.out.printf("thread per version is %d\n", clientThreadsPerVersion);
+		fdb.options().setExternalClientDirectory("/var/dynamic-conf/lib");
+		fdb.options().setTraceEnable("/tmp");
+		fdb.options().setKnob("min_trace_severity=5");
+	}
+
+	private static void setup(Collection<Database> dbs) {
+		// 0 -> 1 -> 2 -> 3 -> 0
+		for (int k = 0; k < len; k++) {
+			String key = Integer.toString(k);
+			String value = Integer.toString((k + 1) % len);
+
+			for (Database db : dbs) {
+				db.run(tr -> {
+					tr.set(Tuple.from(key).pack(), Tuple.from(value).pack());
+					return null;
+				});
+			}
+		}
+	}
+
+	private static void process(Collection<Database> dbs) {
+		for (int i = 0; i < len; i++) {
+			int k = ThreadLocalRandom.current().nextInt(len);
+			String key = Integer.toString(k);
+
+			for (Database db : dbs) {
+				db.run(tr -> {
+					byte[] result1 = tr.get(Tuple.from(key).pack()).join();
+					String value1 = Tuple.fromBytes(result1).getString(0);
+
+					byte[] result2 = tr.get(Tuple.from(value1).pack()).join();
+					String value2 = Tuple.fromBytes(result2).getString(0);
+
+					byte[] result3 = tr.get(Tuple.from(value2).pack()).join();
+					String value3 = Tuple.fromBytes(result3).getString(0);
+
+					byte[] result4 = tr.get(Tuple.from(value3).pack()).join();
+					String value4 = Tuple.fromBytes(result4).getString(0);
+
+					tr.set(Tuple.from(key).pack(), Tuple.from(value2).pack());
+					tr.set(Tuple.from(value2).pack(), Tuple.from(value1).pack());
+					tr.set(Tuple.from(value1).pack(), Tuple.from(value3).pack());
+					return null;
+				});
+			}
+		}
+	}
+
+	private static void check(Collection<Database> dbs) {
+		for (int i = 0; i < len + 1; i++) {
+			int k = ThreadLocalRandom.current().nextInt(len);
+			String key = Integer.toString(k);
+
+			for (Database db : dbs) {
+				db.run(tr -> {
+					byte[] result1 = tr.get(Tuple.from(key).pack()).join();
+					String value1 = Tuple.fromBytes(result1).getString(0);
+
+					byte[] result2 = tr.get(Tuple.from(value1).pack()).join();
+					String value2 = Tuple.fromBytes(result2).getString(0);
+
+					byte[] result3 = tr.get(Tuple.from(value2).pack()).join();
+					String value3 = Tuple.fromBytes(result3).getString(0);
+
+					byte[] result4 = tr.get(Tuple.from(value3).pack()).join();
+					String value4 = Tuple.fromBytes(result4).getString(0);
+
+					Assertions.assertEquals(key, value4, "not a cycle anymore");
+					List<String> actual = new ArrayList<>(Arrays.asList(value1, value2, value3, value4));
+
+					Collections.sort(actual);
+					Assertions.assertEquals(expected, actual, "Wrong result!");
+					return null;
+				});
+			}
+		}
+	}
+}

--- a/bindings/java/src/integration/com/apple/foundationdb/CycleMultiClientIntegrationTest.java
+++ b/bindings/java/src/integration/com/apple/foundationdb/CycleMultiClientIntegrationTest.java
@@ -3,7 +3,7 @@
  *
  * This source file is part of the FoundationDB open source project
  *
- * Copyright 2013-2018 Apple Inc. and the FoundationDB project authors
+ * Copyright 2013-2021 Apple Inc. and the FoundationDB project authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,9 @@ import java.util.ArrayList;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
 import com.apple.foundationdb.tuple.Tuple;
 
@@ -38,103 +40,163 @@ import org.junit.jupiter.api.Assertions;
  * This test is to verify the atomicity of transactions. 
  */
 public class CycleMultiClientIntegrationTest {
-	public static final MultiClientHelper clientHelper = new MultiClientHelper();
+    public static final MultiClientHelper clientHelper = new MultiClientHelper();
 
-	private static final int len = 4;
-	private static List<String> expected = new ArrayList<>(Arrays.asList("0", "1", "2", "3"));
+    // more write txn than validate txn, as parent thread waits only for validate txn.
+    private static final int writeTxnCnt = 2000;
+    private static final int validateTxnCnt = 1000;
+    private static final int threadPerDB = 5;
 
-	public static void main(String[] args) throws Exception {
-		FDB fdb = FDB.selectAPIVersion(630);
-		setupThreads(fdb);			
-		Collection<Database> dbs = clientHelper.openDatabases(fdb); // the clientHelper will close the databases for us
-		System.out.print("Starting tests\n");
-		setup(dbs);
-		System.out.print("Start processing\n");
-		process(dbs);
-		System.out.print("Start validataing\n");
-		check(dbs);
-		System.out.print("Test finished\n");
-	}
+    private static final int cycleLength = 4;
+    private static List<String> expected = new ArrayList<>(Arrays.asList("0", "1", "2", "3"));
 
-	private static synchronized void setupThreads(FDB fdb) {
-		int clientThreadsPerVersion = clientHelper.readClusterFromEnv().length;
-		fdb.options().setClientThreadsPerVersion(clientThreadsPerVersion);
-		System.out.printf("thread per version is %d\n", clientThreadsPerVersion);
-		fdb.options().setExternalClientDirectory("/var/dynamic-conf/lib");
-		fdb.options().setTraceEnable("/tmp");
-		fdb.options().setKnob("min_trace_severity=5");
-	}
+    public static void main(String[] args) throws Exception {
+        FDB fdb = FDB.selectAPIVersion(630);
+        setupThreads(fdb);
+        Collection<Database> dbs = clientHelper.openDatabases(fdb); // the clientHelper will close the databases for us
+        System.out.println("Starting tests");
+        setup(dbs);
+        System.out.println("Start processing and validating");
+        process(dbs);
+        check(dbs);
+        System.out.println("Test finished");
+    }
 
-	private static void setup(Collection<Database> dbs) {
-		// 0 -> 1 -> 2 -> 3 -> 0
-		for (int k = 0; k < len; k++) {
-			String key = Integer.toString(k);
-			String value = Integer.toString((k + 1) % len);
+    private static synchronized void setupThreads(FDB fdb) {
+        int clientThreadsPerVersion = clientHelper.readClusterFromEnv().length;
+        fdb.options().setClientThreadsPerVersion(clientThreadsPerVersion);
+        System.out.printf("thread per version is %d\n", clientThreadsPerVersion);
+        fdb.options().setExternalClientDirectory("/var/dynamic-conf/lib");
+        fdb.options().setTraceEnable("/tmp");
+        fdb.options().setKnob("min_trace_severity=5");
+    }
 
-			for (Database db : dbs) {
-				db.run(tr -> {
-					tr.set(Tuple.from(key).pack(), Tuple.from(value).pack());
-					return null;
-				});
-			}
-		}
-	}
+    private static void setup(Collection<Database> dbs) {
+        // 0 -> 1 -> 2 -> 3 -> 0
+        for (int k = 0; k < cycleLength; k++) {
+            String key = Integer.toString(k);
+            String value = Integer.toString((k + 1) % cycleLength);
 
-	private static void process(Collection<Database> dbs) {
-		for (int i = 0; i < len; i++) {
-			int k = ThreadLocalRandom.current().nextInt(len);
-			String key = Integer.toString(k);
+            for (Database db : dbs) {
+                db.run(tr -> {
+                    tr.set(Tuple.from(key).pack(), Tuple.from(value).pack());
+                    return null;
+                });
+            }
+        }
+    }
 
-			for (Database db : dbs) {
-				db.run(tr -> {
-					byte[] result1 = tr.get(Tuple.from(key).pack()).join();
-					String value1 = Tuple.fromBytes(result1).getString(0);
+    private static void process(Collection<Database> dbs) {
+        for (Database db : dbs) {
+            for (int i = 0; i < threadPerDB; i++) {
+                final Thread thread = new Thread(CycleWorkload.create(db));
+                thread.start();
+            }
+        }
+    }
 
-					byte[] result2 = tr.get(Tuple.from(value1).pack()).join();
-					String value2 = Tuple.fromBytes(result2).getString(0);
+    private static void check(Collection<Database> dbs) throws InterruptedException {
+        final Map<Thread, CycleChecker> threadsToCheckers = new HashMap<>();
+        for (Database db : dbs) {
+            for (int i = 0; i < threadPerDB; i++) {
+                final CycleChecker checker = new CycleChecker(db);
+                final Thread thread = new Thread(checker);
+                thread.start();
+                threadsToCheckers.put(thread, checker);
+            }
+        }
 
-					byte[] result3 = tr.get(Tuple.from(value2).pack()).join();
-					String value3 = Tuple.fromBytes(result3).getString(0);
+        for (Map.Entry<Thread, CycleChecker> entry : threadsToCheckers.entrySet()) {
+            entry.getKey().join();
+            final boolean succeed = entry.getValue().succeed();
+            Assertions.assertTrue(succeed, "Cycle test failed");
+        }
+    }
 
-					byte[] result4 = tr.get(Tuple.from(value3).pack()).join();
-					String value4 = Tuple.fromBytes(result4).getString(0);
+    public static class CycleWorkload implements Runnable {
 
-					tr.set(Tuple.from(key).pack(), Tuple.from(value2).pack());
-					tr.set(Tuple.from(value2).pack(), Tuple.from(value1).pack());
-					tr.set(Tuple.from(value1).pack(), Tuple.from(value3).pack());
-					return null;
-				});
-			}
-		}
-	}
+        private final Database db;
 
-	private static void check(Collection<Database> dbs) {
-		for (int i = 0; i < len + 1; i++) {
-			int k = ThreadLocalRandom.current().nextInt(len);
-			String key = Integer.toString(k);
+        private CycleWorkload(Database db) {
+            this.db = db;
+        }
 
-			for (Database db : dbs) {
-				db.run(tr -> {
-					byte[] result1 = tr.get(Tuple.from(key).pack()).join();
-					String value1 = Tuple.fromBytes(result1).getString(0);
+        public static CycleWorkload create(Database db) {
+            return new CycleWorkload(db);
+        }
 
-					byte[] result2 = tr.get(Tuple.from(value1).pack()).join();
-					String value2 = Tuple.fromBytes(result2).getString(0);
+        @Override
+        public void run() {
+            for (int i = 0; i < writeTxnCnt; i++) {
+                db.run(tr -> {
+                    final int k = ThreadLocalRandom.current().nextInt(cycleLength);
+                    final String key = Integer.toString(k);
+                    byte[] result1 = tr.get(Tuple.from(key).pack()).join();
+                    String value1 = Tuple.fromBytes(result1).getString(0);
 
-					byte[] result3 = tr.get(Tuple.from(value2).pack()).join();
-					String value3 = Tuple.fromBytes(result3).getString(0);
+                    byte[] result2 = tr.get(Tuple.from(value1).pack()).join();
+                    String value2 = Tuple.fromBytes(result2).getString(0);
 
-					byte[] result4 = tr.get(Tuple.from(value3).pack()).join();
-					String value4 = Tuple.fromBytes(result4).getString(0);
+                    byte[] result3 = tr.get(Tuple.from(value2).pack()).join();
+                    String value3 = Tuple.fromBytes(result3).getString(0);
 
-					Assertions.assertEquals(key, value4, "not a cycle anymore");
-					List<String> actual = new ArrayList<>(Arrays.asList(value1, value2, value3, value4));
+                    byte[] result4 = tr.get(Tuple.from(value3).pack()).join();
 
-					Collections.sort(actual);
-					Assertions.assertEquals(expected, actual, "Wrong result!");
-					return null;
-				});
-			}
-		}
-	}
+                    tr.set(Tuple.from(key).pack(), Tuple.from(value2).pack());
+                    tr.set(Tuple.from(value2).pack(), Tuple.from(value1).pack());
+                    tr.set(Tuple.from(value1).pack(), Tuple.from(value3).pack());
+                    return null;
+                });
+            }
+        }
+    }
+
+    public static class CycleChecker implements Runnable {
+        private final Database db;
+        private boolean succeed;
+
+        public CycleChecker(Database db) {
+            this.db = db;
+            this.succeed = true;
+        }
+
+        public static CycleChecker create(Database db) {
+            return new CycleChecker(db);
+        }
+
+        @Override
+        public void run() {
+            for (int i = 0; i < validateTxnCnt; i++) {
+                db.run(tr -> {
+                    final int k = ThreadLocalRandom.current().nextInt(cycleLength);
+                    final String key = Integer.toString(k);
+                    byte[] result1 = tr.get(Tuple.from(key).pack()).join();
+                    String value1 = Tuple.fromBytes(result1).getString(0);
+
+                    byte[] result2 = tr.get(Tuple.from(value1).pack()).join();
+                    String value2 = Tuple.fromBytes(result2).getString(0);
+
+                    byte[] result3 = tr.get(Tuple.from(value2).pack()).join();
+                    String value3 = Tuple.fromBytes(result3).getString(0);
+
+                    byte[] result4 = tr.get(Tuple.from(value3).pack()).join();
+                    String value4 = Tuple.fromBytes(result4).getString(0);
+
+                    if (!key.equals(value4)) {
+                        succeed = false;
+                    }
+                    List<String> actual = new ArrayList<>(Arrays.asList(value1, value2, value3, value4));
+                    Collections.sort(actual);
+                    if (!expected.equals(actual)) {
+                        succeed = false;
+                    }
+                    return null;
+                });
+            }
+        }
+
+        public boolean succeed() {
+            return succeed;
+        }
+    }
 }

--- a/bindings/java/src/tests.cmake
+++ b/bindings/java/src/tests.cmake
@@ -48,6 +48,7 @@ set(JAVA_INTEGRATION_TESTS
   src/integration/com/apple/foundationdb/DirectoryTest.java
   src/integration/com/apple/foundationdb/RangeQueryIntegrationTest.java
   src/integration/com/apple/foundationdb/BasicMultiClientIntegrationTest.java
+  src/integration/com/apple/foundationdb/CycleMultiClientIntegrationTest.java
 )
 
 # Resources that are used in integration testing, but are not explicitly test files (JUnit rules,


### PR DESCRIPTION
    FDB clients are multi-threaded and connecting to multiple clusters,
    this commit adds a test to validate the multi-threaded client can
    achieve atomicity.

See https://github.com/FoundationDB/fdb-kubernetes-tests/pull/229 for k8s part.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [x] Every function/class/actor that was touched is reasonably well documented.



log proof:
log 
```

<Event Severity="10" Time="1625847081.711147" DateTime="2021-07-09T16:11:21Z" Type="CopyingExternalClient" ID="0000000000000000" FileName="libfdb_c.so" LibraryPath="/var/dynamic-conf/lib/libfdb_c.so" TempPath="/tmp/libfdb_c.so-M2p7Z8\x00\x96\xed\xcaCI\x7f\x00\x00p\xc4\x09\x00\x01\x00\x00\x00\xb0#2CI\x7f\x00\x00\x00\xe7\xa6AI\x7f\x00\x00\x00\xa8\x00&lt;I\x7f\x00\x00\x00\xe7\xa6AI\x7f\x00\x00\x00\xa8\x00&lt;I\x7f\x00\x00\xe0#2CI\x7f\x00\x00`(2CI\x7f\x00\x00\xf0\xe4\xa6AI\x7f\x00\x00\x00\xa8\x00&lt;I\x7f\x00\x00\x00\xa8\x00&lt;I\x7f\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00`$2CI\x7f\x00\x00\x8aJ\xb2CI\x7f\x00\x00\xf0\xe4\xa6AI\x7f\x00\x00\x00\xa8\x00&lt;I\x7f\x00\x00\xf0\xe4\xa6AI\x7f\x00\x00\x00\xa8\x00&lt;I\x7f\x00\x..." Machine="100.82.6.138:7" LogGroup="default" />
<Event Severity="10" Time="1625847081.852835" DateTime="2021-07-09T16:11:21Z" Type="CopyingExternalClient" ID="0000000000000000" FileName="libfdb_c.so" LibraryPath="/var/dynamic-conf/lib/libfdb_c.so" TempPath="/tmp/libfdb_c.so-JtvxWj\x00\x96\xed\xcaCI\x7f\x00\x00p\xc4\x09\x00\x01\x00\x00\x00\xb0#2CI\x7f\x00\x00\x00\xe7\xa6AI\x7f\x00\x00\x00\xa8\x00&lt;I\x7f\x00\x00\x00\xe7\xa6AI\x7f\x00\x00\x00\xa8\x00&lt;I\x7f\x00\x00\xe0#2CI\x7f\x00\x00`(2CI\x7f\x00\x00\xf0\xe4\xa6AI\x7f\x00\x00\x00\xa8\x00&lt;I\x7f\x00\x00\x00\xa8\x00&lt;I\x7f\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00`$2CI\x7f\x00\x00\x8aJ\xb2CI\x7f\x00\x00\xf0\xe4\xa6AI\x7f\x00\x00\x00\xa8\x00&lt;I\x7f\x00\x00\xf0\xe4\xa6AI\x7f\x00\x00\x00\xa8\x00&lt;I\x7f\x00\x..." Machine="100.82.6.138:7" LogGroup="default" />
<Event Severity="10" Time="1625847081.999593" DateTime="2021-07-09T16:11:21Z" Type="CopyingExternalClient" ID="0000000000000000" FileName="libfdb_c.so" LibraryPath="/var/dynamic-conf/lib/libfdb_c.so" TempPath="/tmp/libfdb_c.so-el1Mhv\x00\x96\xed\xcaCI\x7f\x00\x00p\xc4\x09\x00\x01\x00\x00\x00\xb0#2CI\x7f\x00\x00\x00\xe7\xa6AI\x7f\x00\x00\x00\xa8\x00&lt;I\x7f\x00\x00\x00\xe7\xa6AI\x7f\x00\x00\x00\xa8\x00&lt;I\x7f\x00\x00\xe0#2CI\x7f\x00\x00`(2CI\x7f\x00\x00\xf0\xe4\xa6AI\x7f\x00\x00\x00\xa8\x00&lt;I\x7f\x00\x00\x00\xa8\x00&lt;I\x7f\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00`$2CI\x7f\x00\x00\x8aJ\xb2CI\x7f\x00\x00\xf0\xe4\xa6AI\x7f\x00\x00\x00

<Event Severity="10" Time="1625847082.141708" DateTime="2021-07-09T16:11:22Z" Type="InitializingExternalClient" ID="0000000000000000" LibraryPath="/var/dynamic-conf/lib/libfdb_c.so" Machine="100.82.6.138:7" LogGroup="default" />
<Event Severity="10" Time="1625847082.143234" DateTime="2021-07-09T16:11:22Z" Type="InitializingExternalClient" ID="0000000000000000" LibraryPath="/var/dynamic-conf/lib/libfdb_c.so" Machine="100.82.6.138:7" LogGroup="default" />
<Event Severity="10" Time="1625847082.144667" DateTime="2021-07-09T16:11:22Z" Type="InitializingExternalClient" ID="0000000000000000" LibraryPath="/var/dynamic-conf/lib/libfdb_c.so" Machine="100.82.6.138:7" LogGroup="default" />
```