### PR TITLE
Provide log version information to fdbdr status

### DIFF
--- a/fdbclient/BackupAgent.actor.h
+++ b/fdbclient/BackupAgent.actor.h
@@ -65,6 +65,7 @@ public:
 	static const Key keyConfigStopWhenDoneKey;
 	static const Key keyStateStatus;
 	static const Key keyStateStop;
+	static const Key keyStateLogBeginVersion;
 	static const Key keyLastUid;
 	static const Key keyBeginKey;
 	static const Key keyEndKey;

--- a/fdbclient/BackupAgentBase.actor.cpp
+++ b/fdbclient/BackupAgentBase.actor.cpp
@@ -105,6 +105,7 @@ const Key BackupAgentBase::keyConfigBackupRanges = LiteralStringRef("config_back
 const Key BackupAgentBase::keyConfigStopWhenDoneKey = LiteralStringRef("config_stop_when_done");
 const Key BackupAgentBase::keyStateStop = LiteralStringRef("state_stop");
 const Key BackupAgentBase::keyStateStatus = LiteralStringRef("state_status");
+const Key BackupAgentBase::keyStateLogBeginVersion = LiteralStringRef("last_begin_version");
 const Key BackupAgentBase::keyLastUid = LiteralStringRef("last_uid");
 const Key BackupAgentBase::keyBeginKey = LiteralStringRef("beginKey");
 const Key BackupAgentBase::keyEndKey = LiteralStringRef("endKey");

--- a/fdbclient/DatabaseBackupAgent.actor.cpp
+++ b/fdbclient/DatabaseBackupAgent.actor.cpp
@@ -3106,7 +3106,7 @@ public:
 					state std::string logVersionText
 					    = logVersionKey.present() 
 					    ? ". Last log version is " + format("%lld", BinaryReader::fromStringRef<Version>(logVersionKey.get(), Unversioned())) 
-					    : "";
+					    : "unset";
 					Optional<Key> backupKeysPacked = wait(fBackupKeysPacked);
 
 					state Standalone<VectorRef<KeyRangeRef>> backupRanges;

--- a/fdbclient/DatabaseBackupAgent.actor.cpp
+++ b/fdbclient/DatabaseBackupAgent.actor.cpp
@@ -1321,6 +1321,10 @@ struct CopyDiffLogsTaskFunc : TaskFuncBase {
 			    .detail("LogUID", task->params[BackupAgentBase::keyConfigLogUid]);
 		}
 
+		// set the log version to the state
+		tr->set(StringRef(states.pack(DatabaseBackupAgent::keyStateLogBeginVersion)),
+		        BinaryWriter::toValue(beginVersion, Unversioned()));
+
 		if (!stopWhenDone.present()) {
 			state Reference<TaskFuture> allPartsDone = futureBucket->future(tr);
 			std::vector<Future<Key>> addTaskVector;
@@ -3080,6 +3084,9 @@ public:
 				state Future<Optional<Key>> fBackupKeysPacked =
 				    tr->get(backupAgent->config.get(BinaryWriter::toValue(logUid, Unversioned()))
 				                .pack(BackupAgentBase::keyConfigBackupRanges));
+				state Future<Optional<Value>> flogVersionKey = 
+				    tr->get(backupAgent->states.get(BinaryWriter::toValue(logUid, Unversioned()))
+				                .pack(BackupAgentBase::keyStateLogBeginVersion));
 
 				state EBackupState backupState = wait(backupAgent->getStateValue(tr, logUid));
 
@@ -3095,7 +3102,11 @@ public:
 					}
 
 					state Optional<Value> stopVersionKey = wait(fStopVersionKey);
-
+					Optional<Value> logVersionKey = wait(flogVersionKey);
+					state std::string logVersionText
+					    = logVersionKey.present() 
+					    ? ". Last log version is " + format("%lld", BinaryReader::fromStringRef<Version>(logVersionKey.get(), Unversioned())) 
+					    : "";
 					Optional<Key> backupKeysPacked = wait(fBackupKeysPacked);
 
 					state Standalone<VectorRef<KeyRangeRef>> backupRanges;
@@ -3115,7 +3126,7 @@ public:
 						break;
 					case EBackupState::STATE_RUNNING_DIFFERENTIAL:
 						statusText +=
-						    "The DR on tag `" + tagNameDisplay + "' is a complete copy of the primary database.\n";
+						    "The DR on tag `" + tagNameDisplay + "' is a complete copy of the primary database" + logVersionText + ".\n";
 						break;
 					case EBackupState::STATE_COMPLETED: {
 						Version stopVersion =
@@ -3127,13 +3138,13 @@ public:
 					} break;
 					case EBackupState::STATE_PARTIALLY_ABORTED: {
 						statusText += "The previous DR on tag `" + tagNameDisplay + "' " +
-						              BackupAgentBase::getStateText(backupState) + ".\n";
+						              BackupAgentBase::getStateText(backupState) + logVersionText + ".\n";
 						statusText += "Abort the DR with --cleanup before starting a new DR.\n";
 						break;
 					}
 					default:
 						statusText += "The previous DR on tag `" + tagNameDisplay + "' " +
-						              BackupAgentBase::getStateText(backupState) + ".\n";
+						              BackupAgentBase::getStateText(backupState) + logVersionText + ".\n";
 						break;
 					}
 				}

--- a/fdbclient/DatabaseBackupAgent.actor.cpp
+++ b/fdbclient/DatabaseBackupAgent.actor.cpp
@@ -3104,9 +3104,12 @@ public:
 					state Optional<Value> stopVersionKey = wait(fStopVersionKey);
 					Optional<Value> logVersionKey = wait(flogVersionKey);
 					state std::string logVersionText
-					    = logVersionKey.present() 
-					    ? ". Last log version is " + format("%lld", BinaryReader::fromStringRef<Version>(logVersionKey.get(), Unversioned())) 
-					    : "unset";
+					    = ". Last log version is " 
+					      + (
+						logVersionKey.present()
+					        ? format("%lld", BinaryReader::fromStringRef<Version>(logVersionKey.get(), Unversioned()))
+					        : "unset"
+					      );
 					Optional<Key> backupKeysPacked = wait(fBackupKeysPacked);
 
 					state Standalone<VectorRef<KeyRangeRef>> backupRanges;


### PR DESCRIPTION
# Problem statement

I can make a fast consistent copy of a fdb cluster by stopping a DR site and copy all the files from all DR nodes to a new cluster nodes and detach this copy from the primary site.
I can perform a point-in-time recovery from this copy with fdbrestore start --incremental --begin_version XXXXXXX.
But there is no easy way to get a source db version for using with --begin_version option.

# Findings

When dr agent runs it executes dr_copy_diff_logs tasks for copying version intervals of the mutation log to the DR database, When the task is executing, it has beginVersion: the version all changes before have been copied.

# Proposal

Store beginVersion to the state subspace of system keyspace each time dr_copy_diff_logs executes
Read this version from the state subspace and return as result of fdbdr status
This pull request implements this proposal.

I already proposed this PR several monthes ago #4274 but I declided it because it couldn't be automatically rebased on top of 6.2. Now I'd like to propose it to 7.0.