### PR TITLE
Fix printable bytes that may be escaped incorrectly

### DIFF
--- a/flow/Trace.h
+++ b/flow/Trace.h
@@ -333,7 +333,6 @@ struct TraceableStringImpl : std::true_type {
 				result.push_back(base16Char(byte));
 			}
 		}
-        ASSERT_WE_THINK(result.size() == result.capacity());
 		return result;
 	}
 };

--- a/flow/Trace.h
+++ b/flow/Trace.h
@@ -333,7 +333,7 @@ struct TraceableStringImpl : std::true_type {
 				result.push_back(base16Char(byte));
 			}
 		}
-		ASSERT(result.size() == result.capacity());
+        ASSERT_WE_THINK(result.size() == result.capacity());
 		return result;
 	}
 };

--- a/flow/Trace.h
+++ b/flow/Trace.h
@@ -320,11 +320,11 @@ struct TraceableStringImpl : std::true_type {
 		std::string result;
 		result.reserve(size - nonPrintables + (nonPrintables * 4) + numBackslashes);
 		for (auto iter = TraceableString<T>::begin(value); !TraceableString<T>::atEnd(value, iter); ++iter) {
-			if (isPrintable(*iter)) {
+			if (*iter == '\\') {
+				result.push_back('\\');
+				result.push_back('\\');
+			} else if (isPrintable(*iter)) {
 				result.push_back(*iter);
-			} else if (*iter == '\\') {
-				result.push_back('\\');
-				result.push_back('\\');
 			} else {
 				const uint8_t byte = *iter;
 				result.push_back('\\');
@@ -333,6 +333,7 @@ struct TraceableStringImpl : std::true_type {
 				result.push_back(base16Char(byte));
 			}
 		}
+		ASSERT(result.size() == result.capacity());
 		return result;
 	}
 };


### PR DESCRIPTION
0x5C `'\'` should not be counted as normal printables

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
