### PR TITLE
Implement ServerPeekCursor to be compatible with storage server

### DIFF
--- a/fdbserver/LogSystem.h
+++ b/fdbserver/LogSystem.h
@@ -768,6 +768,7 @@ struct ILogSystem {
 	    UID dbgid,
 	    Version begin,
 	    Tag tag,
+	    Optional<ptxn::StorageTeamID> storageTeam = Optional<ptxn::StorageTeamID>(),
 	    std::vector<std::pair<Version, Tag>> history = std::vector<std::pair<Version, Tag>>()) = 0;
 	// Same contract as peek(), but blocks until the preferred log server(s) for the given tag are available (and is
 	// correspondingly less expensive)

--- a/fdbserver/LogSystemConfig.h
+++ b/fdbserver/LogSystemConfig.h
@@ -85,6 +85,12 @@ struct serializable_traits<OptionalInterface<Interface>> : std::true_type {
 struct TLogSet {
 	constexpr static FileIdentifier file_identifier = 6302317;
 	std::vector<OptionalInterface<TLogInterface>> tLogs;
+
+	// TODO: figure out a way to represent TLog group information needed for a ss to find the corresponding TLog
+	//  interface.
+	// TODO: change other function below to reflect TLogSet
+	std::unordered_map<ptxn::TLogGroupID, std::vector<OptionalInterface<ptxn::TLogInterface_PassivelyPull>>>
+	    ptxnTLogGroups;
 	std::vector<OptionalInterface<TLogInterface>> logRouters;
 	std::vector<OptionalInterface<BackupInterface>> backupWorkers;
 	int32_t tLogWriteAntiQuorum, tLogReplicationFactor;

--- a/fdbserver/MockLogSystem.cpp
+++ b/fdbserver/MockLogSystem.cpp
@@ -120,6 +120,7 @@ Reference<ILogSystem::IPeekCursor> MockLogSystem::peek(UID dbgid,
 Reference<ILogSystem::IPeekCursor> MockLogSystem::peekSingle(UID dbgid,
                                                              Version begin,
                                                              Tag tag,
+                                                             Optional<ptxn::StorageTeamID> storageTeam,
                                                              std::vector<std::pair<Version, Tag>> history) {
 	logMethodName(__func__);
 	return cursor;

--- a/fdbserver/MockLogSystem.h
+++ b/fdbserver/MockLogSystem.h
@@ -60,6 +60,7 @@ struct MockLogSystem : ILogSystem, ReferenceCounted<MockLogSystem> {
 	Reference<IPeekCursor> peekSingle(UID dbgid,
 	                                  Version begin,
 	                                  Tag tag,
+	                                  Optional<ptxn::StorageTeamID> storageTeam,
 	                                  std::vector<std::pair<Version, Tag>> history) final;
 	Reference<IPeekCursor> peekLogRouter(UID dbgid, Version begin, Tag tag) final;
 	Reference<IPeekCursor> peekTxs(UID dbgid,

--- a/fdbserver/StorageCache.actor.cpp
+++ b/fdbserver/StorageCache.actor.cpp
@@ -1846,8 +1846,11 @@ ACTOR Future<Void> pullAsyncData(StorageCacheData* data) {
 				when(wait(cursor ? cursor->getMore(TaskPriority::TLogCommit) : Never())) { break; }
 				when(wait(dbInfoChange)) {
 					if (data->logSystem) {
-						cursor = data->logSystem->peekSingle(
-						    data->thisServerID, data->peekVersion, cacheTag, std::vector<std::pair<Version, Tag>>());
+						cursor = data->logSystem->peekSingle(data->thisServerID,
+						                                     data->peekVersion,
+						                                     cacheTag,
+						                                     Optional<ptxn::StorageTeamID>(),
+						                                     std::vector<std::pair<Version, Tag>>());
 					} else
 						cursor = Reference<ILogSystem::IPeekCursor>();
 					dbInfoChange = data->db->onChange();

--- a/fdbserver/WorkerInterface.actor.h
+++ b/fdbserver/WorkerInterface.actor.h
@@ -659,6 +659,7 @@ struct InitializeStorageRequest {
 	Tag seedTag; //< If this server will be passed to seedShardServers, this will be a tag, otherwise it is invalidTag
 	UID reqId;
 	UID interfaceId;
+	Optional<ptxn::StorageTeamID> storageTeamId;
 	KeyValueStoreType storeType;
 	Optional<std::pair<UID, Version>>
 	    tssPairIDAndVersion; // Only set if recruiting a tss. Will be the UID and Version of its SS pair.
@@ -666,7 +667,7 @@ struct InitializeStorageRequest {
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, seedTag, reqId, interfaceId, storeType, reply, tssPairIDAndVersion);
+		serializer(ar, seedTag, reqId, interfaceId, storageTeamId, storeType, reply, tssPairIDAndVersion);
 	}
 };
 
@@ -901,7 +902,9 @@ ACTOR Future<Void> storageServer(
     std::string folder,
     // Only applicable when logSystemType is mock.
     // This has to be a shared_ptr rather than unique_ptr or Reference because MockLogSystem is only forward declared.
-    std::shared_ptr<MockLogSystem> mockLogSystem = nullptr);
+    std::shared_ptr<MockLogSystem> mockLogSystem = nullptr,
+    // Storage team id of a ptxn storage server
+    Optional<ptxn::StorageTeamID> storageTeamId = Optional<ptxn::StorageTeamID>());
 ACTOR Future<Void> storageServer(
     IKeyValueStore* persistentData,
     StorageServerInterface ssi,

--- a/fdbserver/ptxn/TLogInterface.h
+++ b/fdbserver/ptxn/TLogInterface.h
@@ -166,9 +166,12 @@ struct TLogPeekRequest {
 	TLogPeekRequest() = default;
 	TLogPeekRequest(const Optional<UID>& debugID_,
 	                const Version& beginVersion_,
-	                const Version& endVersion_,
+	                const Optional<Version>& endVersion_,
+	                bool returnIfBlocked_,
+	                bool onlySpilled_,
 	                const StorageTeamID& storageTeamID_)
-	  : debugID(debugID_), beginVersion(beginVersion_), endVersion(endVersion_), storageTeamID(storageTeamID_) {}
+	  : debugID(debugID_), beginVersion(beginVersion_), endVersion(endVersion_), returnIfBlocked(returnIfBlocked_),
+	    onlySpilled(onlySpilled_), storageTeamID(storageTeamID_) {}
 
 	template <typename Ar>
 	void serialize(Ar& ar) {

--- a/fdbserver/ptxn/TLogPeekCursor.actor.cpp
+++ b/fdbserver/ptxn/TLogPeekCursor.actor.cpp
@@ -24,6 +24,7 @@
 #include <unordered_set>
 #include <vector>
 
+#include "fdbserver/Knobs.h"
 #include "fdbserver/ptxn/TLogInterface.h"
 #include "flow/Error.h"
 
@@ -224,6 +225,392 @@ const VersionSubsequenceMessage& StorageTeamPeekCursor::getImpl() const {
 
 bool StorageTeamPeekCursor::hasRemainingImpl() const {
 	return deserializerIter != deserializer.end();
+}
+
+ServerPeekCursor::ServerPeekCursor(Reference<AsyncVar<OptionalInterface<TLogInterface_PassivelyPull>>> const& interf,
+                                   Tag tag,
+                                   StorageTeamID storageTeamId,
+                                   Version begin,
+                                   Version end,
+                                   bool returnIfBlocked,
+                                   bool parallelGetMore)
+  : interf(interf), tag(tag), storageTeamId(storageTeamId), messageVersion(begin), end(end), hasMsg(false),
+    rd(results.arena, results.data, Unversioned()), randomID(deterministicRandom()->randomUniqueID()), poppedVersion(0),
+    returnIfBlocked(returnIfBlocked), sequence(0), onlySpilled(false), parallelGetMore(parallelGetMore), lastReset(0),
+    slowReplies(0), fastReplies(0), unknownReplies(0), resetCheck(Void()) {
+	this->results.maxKnownVersion = 0;
+	this->results.minKnownCommittedVersion = 0;
+	//TraceEvent("SPC_Starting", randomID).detail("Tag", tag.toString()).detail("Begin", begin).detail("End", end).backtrace();
+}
+
+ServerPeekCursor::ServerPeekCursor(TLogPeekReply const& results,
+                                   LogMessageVersion const& messageVersion,
+                                   LogMessageVersion const& end,
+                                   TagsAndMessage const& message,
+                                   bool hasMsg,
+                                   Version poppedVersion,
+                                   Tag tag,
+                                   StorageTeamID storageTeamId)
+  : results(results), tag(tag), storageTeamId(storageTeamId), rd(results.arena, results.data, Unversioned()),
+    messageVersion(messageVersion), end(end), messageAndTags(message), hasMsg(hasMsg),
+    randomID(deterministicRandom()->randomUniqueID()), poppedVersion(poppedVersion), returnIfBlocked(false),
+    sequence(0), onlySpilled(false), parallelGetMore(false), lastReset(0), slowReplies(0), fastReplies(0),
+    unknownReplies(0), resetCheck(Void()) {
+	//TraceEvent("SPC_Clone", randomID);
+	this->results.maxKnownVersion = 0;
+	this->results.minKnownCommittedVersion = 0;
+	if (hasMsg)
+		nextMessage();
+
+	advanceTo(messageVersion);
+}
+
+Reference<ILogSystem::IPeekCursor> ServerPeekCursor::cloneNoMore() {
+	return makeReference<ServerPeekCursor>(
+	    results, messageVersion, end, messageAndTags, hasMsg, poppedVersion, tag, storageTeamId);
+}
+
+void ServerPeekCursor::setProtocolVersion(ProtocolVersion version) {
+	rd.setProtocolVersion(version);
+}
+
+Arena& ServerPeekCursor::arena() {
+	return results.arena;
+}
+
+ArenaReader* ServerPeekCursor::reader() {
+	return &rd;
+}
+
+bool ServerPeekCursor::hasMessage() const {
+	//TraceEvent("SPC_HasMessage", randomID).detail("HasMsg", hasMsg);
+	return hasMsg;
+}
+
+void ServerPeekCursor::nextMessage() {
+	//TraceEvent("SPC_NextMessage", randomID).detail("MessageVersion", messageVersion.toString());
+	ASSERT(hasMsg);
+	if (rd.empty()) {
+		messageVersion.reset(std::min(results.endVersion, end.version));
+		hasMsg = false;
+		return;
+	}
+	if (*(int32_t*)rd.peekBytes(4) == VERSION_HEADER) {
+		// A version
+		int32_t dummy;
+		Version ver;
+		rd >> dummy >> ver;
+
+		//TraceEvent("SPC_ProcessSeq", randomID).detail("MessageVersion", messageVersion.toString()).detail("Ver", ver).detail("Tag", tag.toString());
+		// ASSERT( ver >= messageVersion.version );
+
+		messageVersion.reset(ver);
+
+		if (messageVersion >= end) {
+			messageVersion = end;
+			hasMsg = false;
+			return;
+		}
+		ASSERT(!rd.empty());
+	}
+
+	messageAndTags.loadFromArena(&rd, &messageVersion.sub);
+	DEBUG_TAGS_AND_MESSAGE("ServerPeekCursor", messageVersion.version, messageAndTags.getRawMessage())
+	    .detail("CursorID", this->randomID);
+	// Rewind and consume the header so that reader() starts from the message.
+	rd.rewind();
+	rd.readBytes(messageAndTags.getHeaderSize());
+	hasMsg = true;
+	//TraceEvent("SPC_NextMessageB", randomID).detail("MessageVersion", messageVersion.toString());
+}
+
+StringRef ServerPeekCursor::getMessage() {
+	//TraceEvent("SPC_GetMessage", randomID);
+	StringRef message = messageAndTags.getMessageWithoutTags();
+	rd.readBytes(message.size()); // Consumes the message.
+	return message;
+}
+
+StringRef ServerPeekCursor::getMessageWithTags() {
+	StringRef rawMessage = messageAndTags.getRawMessage();
+	rd.readBytes(rawMessage.size() - messageAndTags.getHeaderSize()); // Consumes the message.
+	return rawMessage;
+}
+
+VectorRef<Tag> ServerPeekCursor::getTags() const {
+	return messageAndTags.tags;
+}
+
+void ServerPeekCursor::advanceTo(LogMessageVersion n) {
+	//TraceEvent("SPC_AdvanceTo", randomID).detail("N", n.toString());
+	while (messageVersion < n && hasMessage()) {
+		getMessage();
+		nextMessage();
+	}
+
+	if (hasMessage())
+		return;
+
+	// if( more.isValid() && !more.isReady() ) more.cancel();
+
+	if (messageVersion < n) {
+		messageVersion = n;
+	}
+}
+
+ACTOR Future<Void> resetChecker(ServerPeekCursor* self, NetworkAddress addr) {
+	self->slowReplies = 0;
+	self->unknownReplies = 0;
+	self->fastReplies = 0;
+	wait(delay(SERVER_KNOBS->PEEK_STATS_INTERVAL));
+	TraceEvent("SlowPeekStats", self->randomID)
+	    .detail("PeerAddress", addr)
+	    .detail("SlowReplies", self->slowReplies)
+	    .detail("FastReplies", self->fastReplies)
+	    .detail("UnknownReplies", self->unknownReplies);
+
+	if (self->slowReplies >= SERVER_KNOBS->PEEK_STATS_SLOW_AMOUNT &&
+	    self->slowReplies / double(self->slowReplies + self->fastReplies) >= SERVER_KNOBS->PEEK_STATS_SLOW_RATIO) {
+
+		TraceEvent("ConnectionResetSlowPeek", self->randomID)
+		    .detail("PeerAddress", addr)
+		    .detail("SlowReplies", self->slowReplies)
+		    .detail("FastReplies", self->fastReplies)
+		    .detail("UnknownReplies", self->unknownReplies);
+		FlowTransport::transport().resetConnection(addr);
+		self->lastReset = now();
+	}
+	return Void();
+}
+
+ACTOR Future<TLogPeekReply> recordRequestMetrics(ServerPeekCursor* self,
+                                                 NetworkAddress addr,
+                                                 Future<TLogPeekReply> in) {
+	try {
+		state double startTime = now();
+		TLogPeekReply t = wait(in);
+		if (now() - self->lastReset > SERVER_KNOBS->PEEK_RESET_INTERVAL) {
+			if (now() - startTime > SERVER_KNOBS->PEEK_MAX_LATENCY) {
+				if (t.data.size() >= SERVER_KNOBS->DESIRED_TOTAL_BYTES || SERVER_KNOBS->PEEK_COUNT_SMALL_MESSAGES) {
+					if (self->resetCheck.isReady()) {
+						self->resetCheck = resetChecker(self, addr);
+					}
+					self->slowReplies++;
+				} else {
+					self->unknownReplies++;
+				}
+			} else {
+				self->fastReplies++;
+			}
+		}
+		return t;
+	} catch (Error& e) {
+		if (e.code() != error_code_broken_promise)
+			throw;
+		wait(Never()); // never return
+		throw internal_error(); // does not happen
+	}
+}
+
+ACTOR Future<Void> serverPeekParallelGetMore(ServerPeekCursor* self, TaskPriority taskID) {
+	if (!self->interf || self->messageVersion >= self->end) {
+		if (self->hasMessage())
+			return Void();
+		wait(Future<Void>(Never()));
+		throw internal_error();
+	}
+
+	if (!self->interfaceChanged.isValid()) {
+		self->interfaceChanged = self->interf->onChange();
+	}
+
+	loop {
+		state Version expectedBegin = self->messageVersion.version;
+		try {
+			if (self->parallelGetMore || self->onlySpilled) {
+				while (self->futureResults.size() < SERVER_KNOBS->PARALLEL_GET_MORE_REQUESTS &&
+				       self->interf->get().present()) {
+					self->futureResults.push_back(recordRequestMetrics(
+					    self,
+					    self->interf->get().interf().peekMessages.getEndpoint().getPrimaryAddress(),
+					    self->interf->get().interf().peekMessages.getReply(TLogPeekRequest(self->randomID,
+					                                                                       self->messageVersion.version,
+					                                                                       Optional<Version>(),
+					                                                                       self->returnIfBlocked,
+					                                                                       self->onlySpilled,
+					                                                                       self->storageTeamId),
+					                                                       taskID)));
+				}
+				if (self->sequence == std::numeric_limits<decltype(self->sequence)>::max()) {
+					throw operation_obsolete();
+				}
+			} else if (self->futureResults.size() == 0) {
+				return Void();
+			}
+
+			if (self->hasMessage())
+				return Void();
+
+			choose {
+				when(TLogPeekReply res = wait(self->interf->get().present() ? self->futureResults.front() : Never())) {
+					if (res.beginVersion.get() != expectedBegin) {
+						throw operation_obsolete();
+					}
+					expectedBegin = res.endVersion;
+					self->futureResults.pop_front();
+					self->results = res;
+					self->onlySpilled = res.onlySpilled;
+					if (res.popped.present())
+						self->poppedVersion =
+						    std::min(std::max(self->poppedVersion, res.popped.get()), self->end.version);
+					self->rd = ArenaReader(self->results.arena, self->results.data, Unversioned());
+					LogMessageVersion skipSeq = self->messageVersion;
+					self->hasMsg = true;
+					self->nextMessage();
+					self->advanceTo(skipSeq);
+					//TraceEvent("SPC_GetMoreB", self->randomID).detail("Has", self->hasMessage()).detail("End", res.end).detail("Popped", res.popped.present() ? res.popped.get() : 0);
+					return Void();
+				}
+				when(wait(self->interfaceChanged)) {
+					self->interfaceChanged = self->interf->onChange();
+					self->randomID = deterministicRandom()->randomUniqueID();
+					self->sequence = 0;
+					self->onlySpilled = false;
+					self->futureResults.clear();
+				}
+			}
+		} catch (Error& e) {
+			if (e.code() == error_code_end_of_stream) {
+				self->end.reset(self->messageVersion.version);
+				return Void();
+			} else if (e.code() == error_code_timed_out || e.code() == error_code_operation_obsolete) {
+				TraceEvent("PeekCursorTimedOut", self->randomID).error(e);
+				// We *should* never get timed_out(), as it means the TLog got stuck while handling a parallel peek,
+				// and thus we've likely just wasted 10min.
+				// timed_out() is sent by cleanupPeekTrackers as value PEEK_TRACKER_EXPIRATION_TIME
+				ASSERT_WE_THINK(e.code() == error_code_operation_obsolete ||
+				                SERVER_KNOBS->PEEK_TRACKER_EXPIRATION_TIME < 10);
+				self->interfaceChanged = self->interf->onChange();
+				self->randomID = deterministicRandom()->randomUniqueID();
+				self->sequence = 0;
+				self->futureResults.clear();
+			} else {
+				throw e;
+			}
+		}
+	}
+}
+
+ACTOR Future<Void> serverPeekGetMore(ServerPeekCursor* self, TaskPriority taskID) {
+	if (!self->interf || self->messageVersion >= self->end) {
+		wait(Future<Void>(Never()));
+		throw internal_error();
+	}
+	try {
+		loop {
+			choose {
+				when(TLogPeekReply res =
+				         wait(self->interf->get().present()
+				                  ? brokenPromiseToNever(self->interf->get().interf().peekMessages.getReply(
+				                        TLogPeekRequest(self->randomID,
+				                                        self->messageVersion.version,
+				                                        Optional<Version>(),
+				                                        self->returnIfBlocked,
+				                                        self->onlySpilled,
+				                                        self->storageTeamId),
+				                        taskID))
+				                  : Never())) {
+					self->results = res;
+					self->onlySpilled = res.onlySpilled;
+					if (res.popped.present())
+						self->poppedVersion =
+						    std::min(std::max(self->poppedVersion, res.popped.get()), self->end.version);
+					self->rd = ArenaReader(self->results.arena, self->results.data, Unversioned());
+					LogMessageVersion skipSeq = self->messageVersion;
+					self->hasMsg = true;
+					self->nextMessage();
+					self->advanceTo(skipSeq);
+					//TraceEvent("SPC_GetMoreB", self->randomID).detail("Has", self->hasMessage()).detail("End", res.end).detail("Popped", res.popped.present() ? res.popped.get() : 0);
+					return Void();
+				}
+				when(wait(self->interf->onChange())) { self->onlySpilled = false; }
+			}
+		}
+	} catch (Error& e) {
+		if (e.code() == error_code_end_of_stream) {
+			self->end.reset(self->messageVersion.version);
+			return Void();
+		}
+		throw e;
+	}
+}
+
+Future<Void> ServerPeekCursor::getMore(TaskPriority taskID) {
+	//TraceEvent("SPC_GetMore", randomID).detail("HasMessage", hasMessage()).detail("More", !more.isValid() || more.isReady()).detail("MessageVersion", messageVersion.toString()).detail("End", end.toString());
+	if (hasMessage() && !parallelGetMore)
+		return Void();
+	if (!more.isValid() || more.isReady()) {
+		if (parallelGetMore || onlySpilled || futureResults.size()) {
+			more = serverPeekParallelGetMore(this, taskID);
+		} else {
+			more = serverPeekGetMore(this, taskID);
+		}
+	}
+	return more;
+}
+
+ACTOR Future<Void> serverPeekOnFailed(ServerPeekCursor* self) {
+	loop {
+		choose {
+			when(wait(self->interf->get().present()
+			              ? IFailureMonitor::failureMonitor().onStateEqual(
+			                    self->interf->get().interf().peekMessages.getEndpoint(), FailureStatus())
+			              : Never())) {
+				return Void();
+			}
+			when(wait(self->interf->onChange())) {}
+		}
+	}
+}
+
+Future<Void> ServerPeekCursor::onFailed() {
+	return serverPeekOnFailed(this);
+}
+
+bool ServerPeekCursor::isActive() const {
+	if (!interf->get().present())
+		return false;
+	if (messageVersion >= end)
+		return false;
+	return IFailureMonitor::failureMonitor().getState(interf->get().interf().peekMessages.getEndpoint()).isAvailable();
+}
+
+bool ServerPeekCursor::isExhausted() const {
+	return messageVersion >= end;
+}
+
+const LogMessageVersion& ServerPeekCursor::version() const {
+	return messageVersion;
+} // Call only after nextMessage().  The sequence of the current message, or results.end if nextMessage() has returned
+// false.
+
+Version ServerPeekCursor::getMinKnownCommittedVersion() const {
+	return results.minKnownCommittedVersion;
+}
+
+Optional<UID> ServerPeekCursor::getPrimaryPeekLocation() const {
+	if (interf && interf->get().present()) {
+		return interf->get().id();
+	}
+	return Optional<UID>();
+}
+
+Optional<UID> ServerPeekCursor::getCurrentPeekLocation() const {
+	return ServerPeekCursor::getPrimaryPeekLocation();
+}
+
+Version ServerPeekCursor::popped() const {
+	return poppedVersion;
 }
 
 } // namespace ptxn

--- a/fdbserver/ptxn/test/Driver.h
+++ b/fdbserver/ptxn/test/Driver.h
@@ -109,6 +109,7 @@ struct TestDriverContext {
 	bool useFakeStorageServer;
 	int numStorageServers;
 	std::vector<std::shared_ptr<StorageServerInterfaceBase>> storageServerInterfaces;
+	std::vector<StorageServerInterface> storageServers;
 	std::unordered_map<StorageTeamID, std::shared_ptr<StorageServerInterfaceBase>>
 	    storageTeamIDStorageServerInterfaceMapper;
 	std::shared_ptr<StorageServerInterfaceBase> getStorageServerInterface(const StorageTeamID&);

--- a/fdbserver/ptxn/test/TestTLogPeek.actor.cpp
+++ b/fdbserver/ptxn/test/TestTLogPeek.actor.cpp
@@ -134,7 +134,7 @@ ACTOR Future<Void> peekAndCheck(std::shared_ptr<FakeTLogContext> pContext) {
 
 	printTiming << "AA" << std::endl;
 
-	state TLogPeekRequest request(debugID, beginVersion, endVersion, storageTeamID);
+	state TLogPeekRequest request(debugID, beginVersion, endVersion, false, false, storageTeamID);
 	print::print(request);
 
 	state TLogPeekReply reply = wait(pContext->pTLogInterface->peek.getReply(request));

--- a/fdbserver/worker.actor.cpp
+++ b/fdbserver/worker.actor.cpp
@@ -1700,6 +1700,7 @@ ACTOR Future<Void> workerServer(Reference<ClusterConnectionFile> connFile,
 				                 [&req](const auto& p) { return p.second != req.storeType; }) ||
 				     req.seedTag != invalidTag)) {
 
+					// if req.storageTeamId exists, means it's a new storage server in ptxn
 					bool isTss = req.tssPairIDAndVersion.present();
 
 					StorageServerInterface recruited(req.interfaceId);
@@ -1746,7 +1747,8 @@ ACTOR Future<Void> workerServer(Reference<ClusterConnectionFile> connFile,
 					                               storageReady,
 					                               dbInfo,
 					                               folder,
-					                               nullptr);
+					                               nullptr,
+					                               req.storageTeamId);
 					s = handleIOErrors(s, data, recruited.id(), kvClosed);
 					s = storageCache.removeOnReady(req.reqId, s);
 					s = storageServerRollbackRebooter(&runningStorages,

--- a/tests/ptxn/TLogServer.toml
+++ b/tests/ptxn/TLogServer.toml
@@ -63,3 +63,20 @@ startDelay = 0
     numStorageTeams = 40
     numTLogGroups = 7
     numCommits = 50
+
+[[test]]
+testTitle = 'Team Partitioned TLog Server Test 5: Run storage server'
+useDB = false
+startDelay = 0
+
+    [[test.workload]]
+    testName = 'UnitTests'
+    maxTestCases = 1
+    testsMatching = '/fdbserver/ptxn/test/run_storage_server'
+
+    numProxies = 5
+    numTLogs = 2
+    numStorageTeams = 40
+    numTLogGroups = 7
+    skipCommitValidation = 1
+    numCommits = 50


### PR DESCRIPTION

- Add storage team concept into StorageServer (for now, storage server only manages single storage team)
- Implement ServerPeekCursor to be compatible with storage server which talks to ptxn tlog interfaces.
- Add run_storage_server unit test that runs against new ptxn tlogs

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
