### PR TITLE
Re-enable the test for TLog peek

### DIFF
--- a/fdbserver/ptxn/MessageSerializer.cpp
+++ b/fdbserver/ptxn/MessageSerializer.cpp
@@ -343,6 +343,10 @@ SubsequencedMessageDeserializer::iterator SubsequencedMessageDeserializer::itera
 	return prev;
 }
 
+Arena& SubsequencedMessageDeserializer::iterator::arena() {
+	return deserializer.arena();
+}
+
 SubsequencedMessageDeserializer::SubsequencedMessageDeserializer(const StringRef serialized_)
   : endIterator(serialized_, true) {
 

--- a/fdbserver/ptxn/MessageSerializer.h
+++ b/fdbserver/ptxn/MessageSerializer.h
@@ -359,6 +359,12 @@ public:
 
 		// Postfix operator++, this is more expensive and should be avoided.
 		iterator operator++(int);
+
+		// Returns the arena used by the deserializer. Any objects deserialized and required an arena, e.g. StringRefs,
+		// will depend on this arena. If the arena destructed when the iterator destructs, those objects would be
+		// invalidated, i.e. the life cycle will be the same to the iterator. To extend the life cycle, this arena
+		// should be dependent on other arenas.
+		Arena& arena();
 	};
 
 private:
@@ -370,9 +376,10 @@ public:
 	// serialized_ refers to the serialized data
 	SubsequencedMessageDeserializer(const StringRef serialized_);
 
-	// Reset the deserializer, this will invalidate all iterators
+	// Resets the deserializer, this will invalidate all iterators
 	void reset(const StringRef serialized_);
 
+	// Returns an iterator.
 	iterator begin() const;
 	// end() is called multiple times in typical for loop:
 	//    for(auto iter = deserializer.begin(); iter != deserializer.end(); ++iter)

--- a/fdbserver/ptxn/Serializer.h
+++ b/fdbserver/ptxn/Serializer.h
@@ -376,6 +376,11 @@ public:
 
 	// Peeks raw bytes, but doesn't consume the bytes
 	const uint8_t* peekBytes(int nBytes) const { return reinterpret_cast<const uint8_t*>(reader.peekBytes(nBytes)); }
+
+	// Returns the arena the deserialized data uses.
+	Arena& arena() {
+		return reader.arena();
+	}
 };
 
 } // namespace ptxn

--- a/fdbserver/ptxn/TLogPeekCursor.actor.cpp
+++ b/fdbserver/ptxn/TLogPeekCursor.actor.cpp
@@ -96,7 +96,7 @@ ACTOR Future<bool> peekRemote(PeekRemoteContext peekRemoteContext) {
 
 	request.debugID = peekRemoteContext.debugID;
 	request.beginVersion = *peekRemoteContext.pLastVersion + 1;
-	request.endVersion = -1; // we *ALWAYS* try to extract *ALL* data
+	request.endVersion = invalidVersion; // we *ALWAYS* try to extract *ALL* data
 	request.storageTeamID = peekRemoteContext.storageTeamID;
 
 	try {

--- a/fdbserver/ptxn/test/CommitUtils.cpp
+++ b/fdbserver/ptxn/test/CommitUtils.cpp
@@ -51,7 +51,7 @@ void generateMutationRefs(const int numMutations,
 
 void distributeMutationRefs(VectorRef<MutationRef>& mutationRefs,
                             const Version& version,
-                            const std::vector<StorageTeamID> storageTeamIDs,
+                            const std::vector<StorageTeamID>& storageTeamIDs,
                             CommitRecord& commitRecord) {
 	auto& storageTeamMessageMap = commitRecord.messages[version];
 
@@ -89,6 +89,13 @@ void prepareProxySerializedMessages(const CommitRecord& commitRecord,
 			}
 		}
 	}
+}
+
+void distributeMutationRefs(VectorRef<MutationRef>& mutationRefs,
+                            const Version& version,
+                            const StorageTeamID& storageTeamID,
+                            CommitRecord& commitRecord) {
+	distributeMutationRefs(mutationRefs, version, { storageTeamID }, commitRecord);
 }
 
 bool isAllRecordsValidated(const CommitRecord& commitRecord) {

--- a/fdbserver/ptxn/test/CommitUtils.h
+++ b/fdbserver/ptxn/test/CommitUtils.h
@@ -57,7 +57,12 @@ void generateMutationRefs(const int numMutations,
 // Distribute MutationRefs to StorageTeamIDs in CommitRecord
 void distributeMutationRefs(VectorRef<MutationRef>& mutationRefs,
                             const Version& version,
-                            const std::vector<StorageTeamID> storageTeamIDs,
+                            const std::vector<StorageTeamID>& storageTeamIDs,
+                            CommitRecord& commitRecord);
+
+void distributeMutationRefs(VectorRef<MutationRef>& mutationRefs,
+                            const Version& version,
+                            const StorageTeamID& storageTeamIDs,
                             CommitRecord& commitRecord);
 
 // For a given version, serialize the messages from CommitRecord for Proxy use

--- a/fdbserver/ptxn/test/TestTLogServer.actor.cpp
+++ b/fdbserver/ptxn/test/TestTLogServer.actor.cpp
@@ -218,7 +218,7 @@ ACTOR Future<Void> commitInject(std::shared_ptr<ptxn::test::TestDriverContext> p
 
 	state std::vector<ptxn::TLogCommitRequest> requests;
 	for (auto i = 0; i < numCommits; ++i) {
-		generateMutations(currVersion, 1, { storageTeamID }, pContext->commitRecord);
+		generateMutations(currVersion, 16, { storageTeamID }, pContext->commitRecord);
 		auto serialized = serializeMutations(currVersion, storageTeamID, pContext->commitRecord);
 
 		requests.emplace_back(ptxn::test::randomUID(),

--- a/fdbserver/ptxn/test/Utils.cpp
+++ b/fdbserver/ptxn/test/Utils.cpp
@@ -140,7 +140,7 @@ void print(const ptxn::test::TestTLogPeekOptions& option) {
 	          << formatKVPair("Intial version", option.initialVersion) << std::endl;
 }
 
-void printCommitRecords(const CommitRecord& record) {
+void print(const CommitRecord& record) {
 	std::cout << ">> ptxn/test/CommitUtils.h:CommitRecord:" << std::endl;
 	for (const auto& [version, storageTeamIDMessageMap] : record.messages) {
 		std::cout << "\n\tVersion: " << version << std::endl;
@@ -149,6 +149,17 @@ void printCommitRecords(const CommitRecord& record) {
 			for (const auto& [subsequence, message] : subsequenceMessage) {
 				std::cout << "\t\t\t" << message << std::endl;
 			}
+		}
+	}
+}
+
+void print(const TLogGroup& tLogGroup) {
+	std::cout << ">> WorkInterface.actor.h:TLogGroup:"<<std::endl;
+	for(const auto& [storageTeamID, tags] : tLogGroup.storageTeams) {
+		std::cout << concatToString("\tStorage Team ID: ", storageTeamID, "\n");
+		std::cout << "\tTags:" << std::endl;
+		for(const auto& tag : tags) {
+			std::cout << concatToString("\t\t", tag, "\n");
 		}
 	}
 }

--- a/fdbserver/ptxn/test/Utils.h
+++ b/fdbserver/ptxn/test/Utils.h
@@ -30,6 +30,7 @@
 #include "fdbserver/ptxn/test/CommitUtils.h"
 #include "fdbserver/ptxn/test/TestTLogPeek.h"
 #include "fdbserver/ptxn/TLogInterface.h"
+#include "fdbserver/WorkerInterface.actor.h"
 
 namespace ptxn::test {
 
@@ -70,8 +71,7 @@ void print(const TLogPeekReply&);
 void print(const TestDriverOptions&);
 void print(const CommitRecord&);
 void print(const ptxn::test::TestTLogPeekOptions&);
-
-void printCommitRecords(const std::vector<CommitRecord>&);
+void print(const TLogGroup&);
 
 // Prints timing per step
 class PrintTiming {

--- a/tests/ptxn/TLogServer.toml
+++ b/tests/ptxn/TLogServer.toml
@@ -48,3 +48,18 @@ startDelay = 0
     numTLogGroups = 7
     skipCommitValidation = 1
     numCommits = 50
+
+[[test]]
+testTitle = 'Team Partitioned TLog Server Test 4: Multiple Commit and Peek'
+useDB = false
+startDelay = 0
+
+    [[test.workload]]
+    testName = 'UnitTests'
+    maxTestCases = 1
+    testsMatching = '/fdbserver/ptxn/test/commit_peek'
+
+    numTLogs = 1
+    numStorageTeams = 40
+    numTLogGroups = 7
+    numCommits = 50


### PR DESCRIPTION
 * Enable the peek TLog server test
 * Add a test that interlaces commit and peek for TLog
 * Add a note on the deserializer related to the use of the internal arena

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
