### PR TITLE
Fix build with DISABLE_TLS=ON

### DIFF
--- a/fdbclient/BackupContainerAzureBlobStore.actor.cpp
+++ b/fdbclient/BackupContainerAzureBlobStore.actor.cpp
@@ -170,7 +170,7 @@ public:
 		}
 		Reference<IAsyncFile> f =
 		    makeReference<ReadFile>(self->asyncTaskThread, self->containerName, fileName, self->client.get());
-#if (!defined(TLS_DISABLED) && !defined(_WIN32))
+#if ENCRYPTION_ENABLED
 		if (self->usesEncryption()) {
 			f = makeReference<AsyncFileEncrypted>(f, false);
 		}
@@ -185,7 +185,7 @@ public:
 			    return Void();
 		    }));
 		auto f = makeReference<WriteFile>(self->asyncTaskThread, self->containerName, fileName, self->client.get());
-#if (!defined(TLS_DISABLED) && !defined(_WIN32))
+#if ENCRYPTED_ENABLED
 		if (self->usesEncryption()) {
 			f = makeReference<AsyncFileEncrypted>(f, true);
 		}

--- a/fdbclient/BackupContainerAzureBlobStore.actor.cpp
+++ b/fdbclient/BackupContainerAzureBlobStore.actor.cpp
@@ -170,9 +170,11 @@ public:
 		}
 		Reference<IAsyncFile> f =
 		    makeReference<ReadFile>(self->asyncTaskThread, self->containerName, fileName, self->client.get());
+#if (!defined(TLS_DISABLED) && !defined(_WIN32))
 		if (self->usesEncryption()) {
 			f = makeReference<AsyncFileEncrypted>(f, false);
 		}
+#endif
 		return f;
 	}
 
@@ -183,9 +185,11 @@ public:
 			    return Void();
 		    }));
 		auto f = makeReference<WriteFile>(self->asyncTaskThread, self->containerName, fileName, self->client.get());
+#if (!defined(TLS_DISABLED) && !defined(_WIN32))
 		if (self->usesEncryption()) {
 			f = makeReference<AsyncFileEncrypted>(f, true);
 		}
+#endif
 		return makeReference<BackupFile>(fileName, f);
 	}
 

--- a/fdbclient/BackupContainerAzureBlobStore.actor.cpp
+++ b/fdbclient/BackupContainerAzureBlobStore.actor.cpp
@@ -185,7 +185,7 @@ public:
 			    return Void();
 		    }));
 		auto f = makeReference<WriteFile>(self->asyncTaskThread, self->containerName, fileName, self->client.get());
-#if ENCRYPTED_ENABLED
+#if ENCRYPTION_ENABLED
 		if (self->usesEncryption()) {
 			f = makeReference<AsyncFileEncrypted>(f, true);
 		}

--- a/fdbclient/BackupContainerFileSystem.actor.cpp
+++ b/fdbclient/BackupContainerFileSystem.actor.cpp
@@ -1127,7 +1127,7 @@ public:
 		return false;
 	}
 
-#if (!defined(TLS_DISABLED) && !defined(_WIN32))
+#if ENCRYPTION_ENABLED
 	ACTOR static Future<Void> createTestEncryptionKeyFile(std::string filename) {
 		state Reference<IAsyncFile> keyFile = wait(IAsyncFileSystem::filesystem()->open(
 		    filename,
@@ -1164,7 +1164,8 @@ public:
 		StreamCipher::Key::initializeKey(std::move(key));
 		return Void();
 	}
-#endif // encryption enabled
+#endif // ENCRYPTION_ENABLED
+
 }; // class BackupContainerFileSystemImpl
 
 Future<Reference<IBackupFile>> BackupContainerFileSystem::writeLogFile(Version beginVersion,
@@ -1479,7 +1480,7 @@ Future<Void> BackupContainerFileSystem::encryptionSetupComplete() const {
 }
 void BackupContainerFileSystem::setEncryptionKey(Optional<std::string> const& encryptionKeyFileName) {
 	if (encryptionKeyFileName.present()) {
-#if (!defined(TLS_DISABLED) && !defined(_WIN32))
+#if ENCRYPTION_ENABLED
 		encryptionSetupFuture = BackupContainerFileSystemImpl::readEncryptionKey(encryptionKeyFileName.get());
 #else
 		encryptionSetupFuture = Void();
@@ -1487,7 +1488,7 @@ void BackupContainerFileSystem::setEncryptionKey(Optional<std::string> const& en
 	}
 }
 Future<Void> BackupContainerFileSystem::createTestEncryptionKeyFile(std::string const &filename) {
-#if (!defined(TLS_DISABLED) && !defined(_WIN32))
+#if ENCRYPTION_ENABLED
 	return BackupContainerFileSystemImpl::createTestEncryptionKeyFile(filename);
 #else
 	return Void();

--- a/fdbclient/BackupContainerFileSystem.actor.cpp
+++ b/fdbclient/BackupContainerFileSystem.actor.cpp
@@ -1127,6 +1127,7 @@ public:
 		return false;
 	}
 
+#if (!defined(TLS_DISABLED) && !defined(_WIN32))
 	ACTOR static Future<Void> createTestEncryptionKeyFile(std::string filename) {
 		state Reference<IAsyncFile> keyFile = wait(IAsyncFileSystem::filesystem()->open(
 		    filename,
@@ -1163,6 +1164,7 @@ public:
 		StreamCipher::Key::initializeKey(std::move(key));
 		return Void();
 	}
+#endif // encryption enabled
 }; // class BackupContainerFileSystemImpl
 
 Future<Reference<IBackupFile>> BackupContainerFileSystem::writeLogFile(Version beginVersion,
@@ -1477,11 +1479,19 @@ Future<Void> BackupContainerFileSystem::encryptionSetupComplete() const {
 }
 void BackupContainerFileSystem::setEncryptionKey(Optional<std::string> const& encryptionKeyFileName) {
 	if (encryptionKeyFileName.present()) {
+#if (!defined(TLS_DISABLED) && !defined(_WIN32))
 		encryptionSetupFuture = BackupContainerFileSystemImpl::readEncryptionKey(encryptionKeyFileName.get());
+#else
+		encryptionSetupFuture = Void();
+#endif
 	}
 }
 Future<Void> BackupContainerFileSystem::createTestEncryptionKeyFile(std::string const &filename) {
+#if (!defined(TLS_DISABLED) && !defined(_WIN32))
 	return BackupContainerFileSystemImpl::createTestEncryptionKeyFile(filename);
+#else
+	return Void();
+#endif
 }
 
 namespace backup_test {

--- a/fdbclient/BackupContainerS3BlobStore.actor.cpp
+++ b/fdbclient/BackupContainerS3BlobStore.actor.cpp
@@ -171,9 +171,11 @@ std::string BackupContainerS3BlobStore::getURLFormat() {
 
 Future<Reference<IAsyncFile>> BackupContainerS3BlobStore::readFile(const std::string& path) {
 	Reference<IAsyncFile> f = makeReference<AsyncFileS3BlobStoreRead>(m_bstore, m_bucket, dataPath(path));
+#if (!defined(TLS_DISABLED) && !defined(_WIN32))
 	if (usesEncryption()) {
 		f = makeReference<AsyncFileEncrypted>(f, AsyncFileEncrypted::Mode::READ_ONLY);
 	}
+#endif
 	f = makeReference<AsyncFileReadAheadCache>(f,
 	                                           m_bstore->knobs.read_block_size,
 	                                           m_bstore->knobs.read_ahead_blocks,
@@ -189,9 +191,11 @@ Future<std::vector<std::string>> BackupContainerS3BlobStore::listURLs(Reference<
 
 Future<Reference<IBackupFile>> BackupContainerS3BlobStore::writeFile(const std::string& path) {
 	Reference<IAsyncFile> f = makeReference<AsyncFileS3BlobStoreWrite>(m_bstore, m_bucket, dataPath(path));
+#if (!defined(TLS_DISABLED) && !defined(_WIN32))
 	if (usesEncryption()) {
 		f = makeReference<AsyncFileEncrypted>(f, AsyncFileEncrypted::Mode::APPEND_ONLY);
 	}
+#endif
 	return Future<Reference<IBackupFile>>(makeReference<BackupContainerS3BlobStoreImpl::BackupFile>(path, f));
 }
 

--- a/fdbclient/BackupContainerS3BlobStore.actor.cpp
+++ b/fdbclient/BackupContainerS3BlobStore.actor.cpp
@@ -171,7 +171,7 @@ std::string BackupContainerS3BlobStore::getURLFormat() {
 
 Future<Reference<IAsyncFile>> BackupContainerS3BlobStore::readFile(const std::string& path) {
 	Reference<IAsyncFile> f = makeReference<AsyncFileS3BlobStoreRead>(m_bstore, m_bucket, dataPath(path));
-#if ENCRYPTED_ENABLED
+#if ENCRYPTION_ENABLED
 	if (usesEncryption()) {
 		f = makeReference<AsyncFileEncrypted>(f, AsyncFileEncrypted::Mode::READ_ONLY);
 	}

--- a/fdbclient/BackupContainerS3BlobStore.actor.cpp
+++ b/fdbclient/BackupContainerS3BlobStore.actor.cpp
@@ -171,7 +171,7 @@ std::string BackupContainerS3BlobStore::getURLFormat() {
 
 Future<Reference<IAsyncFile>> BackupContainerS3BlobStore::readFile(const std::string& path) {
 	Reference<IAsyncFile> f = makeReference<AsyncFileS3BlobStoreRead>(m_bstore, m_bucket, dataPath(path));
-#if (!defined(TLS_DISABLED) && !defined(_WIN32))
+#if ENCRYPTED_ENABLED
 	if (usesEncryption()) {
 		f = makeReference<AsyncFileEncrypted>(f, AsyncFileEncrypted::Mode::READ_ONLY);
 	}
@@ -191,7 +191,7 @@ Future<std::vector<std::string>> BackupContainerS3BlobStore::listURLs(Reference<
 
 Future<Reference<IBackupFile>> BackupContainerS3BlobStore::writeFile(const std::string& path) {
 	Reference<IAsyncFile> f = makeReference<AsyncFileS3BlobStoreWrite>(m_bstore, m_bucket, dataPath(path));
-#if (!defined(TLS_DISABLED) && !defined(_WIN32))
+#if ENCRYPTION_ENABLED
 	if (usesEncryption()) {
 		f = makeReference<AsyncFileEncrypted>(f, AsyncFileEncrypted::Mode::APPEND_ONLY);
 	}

--- a/fdbrpc/AsyncFileEncrypted.h
+++ b/fdbrpc/AsyncFileEncrypted.h
@@ -20,7 +20,7 @@
 
 #pragma once
 
-#if (!defined(TLS_DISABLED) && !defined(_WIN32))
+#if ENCRYPTION_ENABLED
 
 #include "fdbrpc/IAsyncFile.h"
 #include "flow/FastRef.h"
@@ -82,4 +82,4 @@ public:
 	int64_t debugFD() const override;
 };
 
-#endif // Encryption enabled
+#endif // ENCRYPTION_ENABLED

--- a/fdbrpc/AsyncFileEncrypted.h
+++ b/fdbrpc/AsyncFileEncrypted.h
@@ -20,6 +20,8 @@
 
 #pragma once
 
+#if (!defined(TLS_DISABLED) && !defined(_WIN32))
+
 #include "fdbrpc/IAsyncFile.h"
 #include "flow/FastRef.h"
 #include "flow/flow.h"
@@ -79,3 +81,5 @@ public:
 	void releaseZeroCopy(void* data, int length, int64_t offset) override;
 	int64_t debugFD() const override;
 };
+
+#endif // Encryption enabled

--- a/fdbrpc/AsyncFileEncrypted.h
+++ b/fdbrpc/AsyncFileEncrypted.h
@@ -20,13 +20,13 @@
 
 #pragma once
 
-#if ENCRYPTION_ENABLED
-
 #include "fdbrpc/IAsyncFile.h"
 #include "flow/FastRef.h"
 #include "flow/flow.h"
 #include "flow/IRandom.h"
 #include "flow/StreamCipher.h"
+
+#if ENCRYPTION_ENABLED
 
 #include <array>
 

--- a/fdbrpc/CMakeLists.txt
+++ b/fdbrpc/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(FDBRPC_SRCS
   AsyncFileCached.actor.h
   AsyncFileEIO.actor.h
+  AsyncFileEncrypted.h
   AsyncFileKAIO.actor.h
   AsyncFileNonDurable.actor.h
   AsyncFileReadAhead.actor.h
@@ -36,7 +37,6 @@ set(FDBRPC_SRCS
 if(WITH_TLS AND NOT WIN32)
   set(FDBRPC_SRCS
     ${FDBRPC_SRCS}
-    AsyncFileEncrypted.h
     AsyncFileEncrypted.actor.cpp)
 endif()
 

--- a/fdbrpc/Net2FileSystem.cpp
+++ b/fdbrpc/Net2FileSystem.cpp
@@ -77,14 +77,14 @@ Future<Reference<class IAsyncFile>> Net2FileSystem::open(const std::string& file
 		    static_cast<boost::asio::io_service*>((void*)g_network->global(INetwork::enASIOService)));
 	if (FLOW_KNOBS->PAGE_WRITE_CHECKSUM_HISTORY > 0)
 		f = map(f, [=](Reference<IAsyncFile> r) { return Reference<IAsyncFile>(new AsyncFileWriteChecker(r)); });
-#if (!defined(TLS_DISABLED) && !defined(_WIN32))
+#if ENCRYPTION_ENABLED
 	if (flags & IAsyncFile::OPEN_ENCRYPTED)
 		f = map(f, [flags](Reference<IAsyncFile> r) {
 			auto mode = flags & IAsyncFile::OPEN_READWRITE ? AsyncFileEncrypted::Mode::APPEND_ONLY
 			                                               : AsyncFileEncrypted::Mode::READ_ONLY;
 			return Reference<IAsyncFile>(new AsyncFileEncrypted(r, mode));
 		});
-#endif
+#endif // ENCRYPTION_ENABLED
 	return f;
 }
 

--- a/fdbrpc/Net2FileSystem.cpp
+++ b/fdbrpc/Net2FileSystem.cpp
@@ -32,9 +32,7 @@
 
 #include "fdbrpc/AsyncFileCached.actor.h"
 #include "fdbrpc/AsyncFileEIO.actor.h"
-#if (!defined(TLS_DISABLED) && !defined(_WIN32))
 #include "fdbrpc/AsyncFileEncrypted.h"
-#endif
 #include "fdbrpc/AsyncFileWinASIO.actor.h"
 #include "fdbrpc/AsyncFileKAIO.actor.h"
 #include "flow/AsioReactor.h"

--- a/fdbrpc/sim2.actor.cpp
+++ b/fdbrpc/sim2.actor.cpp
@@ -33,9 +33,7 @@
 #include "flow/Util.h"
 #include "fdbrpc/IAsyncFile.h"
 #include "fdbrpc/AsyncFileCached.actor.h"
-#if (!defined(TLS_DISABLED) && !defined(_WIN32))
 #include "fdbrpc/AsyncFileEncrypted.h"
-#endif
 #include "fdbrpc/AsyncFileNonDurable.actor.h"
 #include "flow/crc32c.h"
 #include "fdbrpc/TraceFileIO.h"

--- a/fdbrpc/sim2.actor.cpp
+++ b/fdbrpc/sim2.actor.cpp
@@ -2474,14 +2474,14 @@ Future<Reference<class IAsyncFile>> Sim2FileSystem::open(const std::string& file
 		f = AsyncFileDetachable::open(f);
 		if (FLOW_KNOBS->PAGE_WRITE_CHECKSUM_HISTORY > 0)
 			f = map(f, [=](Reference<IAsyncFile> r) { return Reference<IAsyncFile>(new AsyncFileWriteChecker(r)); });
-#if (!defined(TLS_DISABLED) && !defined(_WIN32))
+#if ENCRYPTION_ENABLED
 		if (flags & IAsyncFile::OPEN_ENCRYPTED)
 			f = map(f, [flags](Reference<IAsyncFile> r) {
 				auto mode = flags & IAsyncFile::OPEN_READWRITE ? AsyncFileEncrypted::Mode::APPEND_ONLY
 				                                               : AsyncFileEncrypted::Mode::READ_ONLY;
 				return Reference<IAsyncFile>(new AsyncFileEncrypted(r, mode));
 			});
-#endif
+#endif // ENCRYPTION_ENABLED
 		return f;
 	} else
 		return AsyncFileCached::open(filename, flags, mode);

--- a/flow/CMakeLists.txt
+++ b/flow/CMakeLists.txt
@@ -53,6 +53,7 @@ set(FLOW_SRCS
   SignalSafeUnwind.cpp
   SignalSafeUnwind.h
   SimpleOpt.h
+  StreamCipher.h
   SystemMonitor.cpp
   SystemMonitor.h
   TDMetric.actor.h
@@ -100,8 +101,7 @@ set(FLOW_SRCS
 if(WITH_TLS AND NOT WIN32)
   set(FLOW_SRCS
     ${FLOW_SRCS}
-    StreamCipher.cpp
-    StreamCipher.h)
+    StreamCipher.cpp)
 endif()
 
 add_library(stacktrace stacktrace.amalgamation.cpp stacktrace.h)

--- a/flow/StreamCipher.h
+++ b/flow/StreamCipher.h
@@ -20,6 +20,8 @@
 
 #pragma once
 
+#if (!defined(TLS_DISABLED) && !defined(_WIN32))
+
 #include "flow/Arena.h"
 #include "flow/FastRef.h"
 #include "flow/flow.h"
@@ -78,3 +80,5 @@ public:
 	StringRef decrypt(unsigned char const* ciphertext, int len, Arena&);
 	StringRef finish(Arena&);
 };
+
+#endif // encryption enabled

--- a/flow/StreamCipher.h
+++ b/flow/StreamCipher.h
@@ -21,6 +21,12 @@
 #pragma once
 
 #if (!defined(TLS_DISABLED) && !defined(_WIN32))
+#define ENCRYPTION_ENABLED 1
+#else
+#define ENCRYPTION_ENABLED 0
+#endif
+
+#if ENCRYPTION_ENABLED
 
 #include "flow/Arena.h"
 #include "flow/FastRef.h"
@@ -81,4 +87,4 @@ public:
 	StringRef finish(Arena&);
 };
 
-#endif // encryption enabled
+#endif // ENCRYPTION_ENABLED


### PR DESCRIPTION
This resolves https://github.com/apple/foundationdb/issues/5148 by using an `ENCRYPTION_ENABLED` macro to disable usages of `openssl` when they won't compile.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
