### PR TITLE
Version vector prototype: propagate latest commit version from client to storage server

### DIFF
--- a/fdbclient/CommitProxyInterface.h
+++ b/fdbclient/CommitProxyInterface.h
@@ -295,6 +295,9 @@ struct GetKeyServerLocationsReply {
 
 	// maps storage server interfaces (captured in "results") to the tags of
 	// their corresponding storage servers
+	// @note this map allows the client to identify the latest commit versions
+	// of storage servers (the version vector, which captures the latest commit
+	// versions of storage servers, identifies storage servers by their tags).
 	std::vector<std::pair<UID, Tag>> resultsTagMapping;
 
 	template <class Ar>

--- a/fdbclient/CommitProxyInterface.h
+++ b/fdbclient/CommitProxyInterface.h
@@ -198,7 +198,7 @@ struct GetReadVersionReply : public BasicLoadBalancedReply {
 
 	TransactionTagMap<ClientTagThrottleLimits> tagThrottleInfo;
 
-	VersionVector ssVersionVector;
+	VersionVector ssVersionVectorDelta;
 
 	GetReadVersionReply() : version(invalidVersion), locked(false) {}
 
@@ -211,7 +211,7 @@ struct GetReadVersionReply : public BasicLoadBalancedReply {
 		           metadataVersion,
 		           tagThrottleInfo,
 		           midShardSize,
-		           ssVersionVector);
+		           ssVersionVectorDelta);
 	}
 };
 
@@ -240,15 +240,18 @@ struct GetReadVersionRequest : TimedRequest {
 	Optional<UID> debugID;
 	ReplyPromise<GetReadVersionReply> reply;
 
-	GetReadVersionRequest() : transactionCount(1), flags(0) {}
+	Version maxVersion; // max version in the client's version vector cache
+
+	GetReadVersionRequest() : transactionCount(1), flags(0), maxVersion(invalidVersion) {}
 	GetReadVersionRequest(SpanID spanContext,
 	                      uint32_t transactionCount,
 	                      TransactionPriority priority,
+	                      Version maxVersion,
 	                      uint32_t flags = 0,
 	                      TransactionTagMap<uint32_t> tags = TransactionTagMap<uint32_t>(),
 	                      Optional<UID> debugID = Optional<UID>())
 	  : spanContext(spanContext), transactionCount(transactionCount), priority(priority), flags(flags), tags(tags),
-	    debugID(debugID) {
+	    debugID(debugID), maxVersion(maxVersion) {
 		flags = flags & ~FLAG_PRIORITY_MASK;
 		switch (priority) {
 		case TransactionPriority::BATCH:
@@ -269,7 +272,7 @@ struct GetReadVersionRequest : TimedRequest {
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, transactionCount, flags, tags, debugID, reply, spanContext);
+		serializer(ar, transactionCount, flags, tags, debugID, reply, spanContext, maxVersion);
 
 		if (ar.isDeserializing) {
 			if ((flags & PRIORITY_SYSTEM_IMMEDIATE) == PRIORITY_SYSTEM_IMMEDIATE) {
@@ -338,7 +341,7 @@ struct GetRawCommittedVersionReply {
 	bool locked;
 	Optional<Value> metadataVersion;
 	Version minKnownCommittedVersion;
-	VersionVector ssVersionVector;
+	VersionVector ssVersionVectorDelta;
 
 	GetRawCommittedVersionReply()
 	  : debugID(Optional<UID>()), version(invalidVersion), locked(false), metadataVersion(Optional<Value>()),
@@ -346,7 +349,7 @@ struct GetRawCommittedVersionReply {
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, debugID, version, locked, metadataVersion, minKnownCommittedVersion, ssVersionVector);
+		serializer(ar, debugID, version, locked, metadataVersion, minKnownCommittedVersion, ssVersionVectorDelta);
 	}
 };
 
@@ -355,14 +358,17 @@ struct GetRawCommittedVersionRequest {
 	SpanID spanContext;
 	Optional<UID> debugID;
 	ReplyPromise<GetRawCommittedVersionReply> reply;
+	Version maxVersion; // max version in the grv proxy's version vector cache
 
-	explicit GetRawCommittedVersionRequest(SpanID spanContext, Optional<UID> const& debugID = Optional<UID>())
-	  : spanContext(spanContext), debugID(debugID) {}
-	explicit GetRawCommittedVersionRequest() : spanContext(), debugID() {}
+	explicit GetRawCommittedVersionRequest(SpanID spanContext,
+	                                       Optional<UID> const& debugID = Optional<UID>(),
+	                                       Version maxVersion = invalidVersion)
+	  : spanContext(spanContext), debugID(debugID), maxVersion(maxVersion) {}
+	explicit GetRawCommittedVersionRequest() : spanContext(), debugID(), maxVersion(invalidVersion) {}
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, debugID, reply, spanContext);
+		serializer(ar, debugID, reply, spanContext, maxVersion);
 	}
 };
 

--- a/fdbclient/CommitProxyInterface.h
+++ b/fdbclient/CommitProxyInterface.h
@@ -293,9 +293,13 @@ struct GetKeyServerLocationsReply {
 	// if any storage servers in results have a TSS pair, that mapping is in here
 	std::vector<std::pair<UID, StorageServerInterface>> resultsTssMapping;
 
+	// maps storage server interfaces (captured in "results") to the tags of
+	// their corresponding storage servers
+	std::vector<std::pair<UID, Tag>> resultsTagMapping;
+
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, results, resultsTssMapping, arena);
+		serializer(ar, results, resultsTssMapping, arena, resultsTagMapping);
 	}
 };
 

--- a/fdbclient/DatabaseContext.h
+++ b/fdbclient/DatabaseContext.h
@@ -330,6 +330,9 @@ public:
 	std::unordered_map<UID, Reference<TSSMetrics>> tssMetrics;
 
 	// map from ssid -> ss tag
+	// @note this map allows the client to identify the latest commit versions
+	// of storage servers (note that "ssVersionVectorCache" identifies storage
+	// servers by their tags).
 	std::unordered_map<UID, Tag> ssidTagMapping;
 
 	UID dbId;

--- a/fdbclient/DatabaseContext.h
+++ b/fdbclient/DatabaseContext.h
@@ -32,13 +32,13 @@
 #include "fdbclient/KeyRangeMap.h"
 #include "fdbclient/CommitProxyInterface.h"
 #include "fdbclient/SpecialKeySpace.actor.h"
+#include "fdbclient/VersionVector.h"
 #include "fdbrpc/QueueModel.h"
 #include "fdbrpc/MultiInterface.h"
 #include "flow/TDMetric.actor.h"
 #include "fdbclient/EventTypes.actor.h"
 #include "fdbrpc/ContinuousSample.h"
 #include "fdbrpc/Smoother.h"
-#include "fdbclient/VersionVector.h"
 
 class StorageServerInfo : public ReferencedInterface<StorageServerInterface> {
 public:
@@ -329,6 +329,9 @@ public:
 	// map from tssid -> metrics for that tss pair
 	std::unordered_map<UID, Reference<TSSMetrics>> tssMetrics;
 
+	// map from ssid -> ss tag
+	std::unordered_map<UID, Tag> ssidTagMapping;
+
 	UID dbId;
 	bool internal; // Only contexts created through the C client and fdbcli are non-internal
 
@@ -434,13 +437,23 @@ public:
 	// Cache of the latest commit versions of storage servers.
 	VersionVector ssVersionVectorCache;
 
-        // Adds or updates the specified (SS, TSS) pair in the TSS mapping (if not already present).
-        // Requests to the storage server will be duplicated to the TSS.
+	// Adds or updates the specified (SS, TSS) pair in the TSS mapping (if not already present).
+	// Requests to the storage server will be duplicated to the TSS.
 	void addTssMapping(StorageServerInterface const& ssi, StorageServerInterface const& tssi);
 
-        // Removes the storage server and its TSS pair from the TSS mapping (if present).
-        // Requests to the storage server will no longer be duplicated to its pair TSS.
+	// Removes the storage server and its TSS pair from the TSS mapping (if present).
+	// Requests to the storage server will no longer be duplicated to its pair TSS.
 	void removeTssMapping(StorageServerInterface const& ssi);
+
+	// Adds or updates the specified (UID, Tag) pair in the tag mapping.
+	void addSSIdTagMapping(const UID& uid, const Tag& tag);
+
+	// Returns the latest commit versions that mutated the specified storage servers
+	/// @note returns the latest commit version for a storage server only if the latest
+	// commit version of that storage server is below the specified "readVersion".
+	void getLatestCommitVersions(const Reference<LocationInfo>& locationInfo,
+	                             Version readVersion,
+	                             VersionVector& latestCommitVersions);
 };
 
 #endif

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -2660,11 +2660,12 @@ ACTOR Future<Version> waitForCommittedVersion(Database cx, Version version, Span
 		loop {
 			choose {
 				when(wait(cx->onProxiesChanged())) {}
-				when(GetReadVersionReply v =
-				         wait(basicLoadBalance(cx->getGrvProxies(false),
-				                               &GrvProxyInterface::getConsistentReadVersion,
-				                               GetReadVersionRequest(span.context, 0, TransactionPriority::IMMEDIATE),
-				                               cx->taskID))) {
+				when(GetReadVersionReply v = wait(basicLoadBalance(
+				         cx->getGrvProxies(false),
+				         &GrvProxyInterface::getConsistentReadVersion,
+				         GetReadVersionRequest(
+				             span.context, 0, TransactionPriority::IMMEDIATE, cx->ssVersionVectorCache.getMaxVersion()),
+				         cx->taskID))) {
 					cx->minAcceptableReadVersion = std::min(cx->minAcceptableReadVersion, v.version);
 					if (v.midShardSize > 0)
 						cx->smoothMidShardSize.setTotal(v.midShardSize);
@@ -2687,11 +2688,12 @@ ACTOR Future<Version> getRawVersion(Database cx, SpanID spanContext) {
 	loop {
 		choose {
 			when(wait(cx->onProxiesChanged())) {}
-			when(GetReadVersionReply v =
-			         wait(basicLoadBalance(cx->getGrvProxies(false),
-			                               &GrvProxyInterface::getConsistentReadVersion,
-			                               GetReadVersionRequest(spanContext, 0, TransactionPriority::IMMEDIATE),
-			                               cx->taskID))) {
+			when(GetReadVersionReply v = wait(basicLoadBalance(
+			         cx->getGrvProxies(false),
+			         &GrvProxyInterface::getConsistentReadVersion,
+			         GetReadVersionRequest(
+			             spanContext, 0, TransactionPriority::IMMEDIATE, cx->ssVersionVectorCache.getMaxVersion()),
+			         cx->taskID))) {
 				return v.version;
 			}
 		}
@@ -5285,7 +5287,13 @@ ACTOR Future<GetReadVersionReply> getConsistentReadVersion(SpanID parentSpan,
 		g_traceBatch.addEvent("TransactionDebug", debugID.get().first(), "NativeAPI.getConsistentReadVersion.Before");
 	loop {
 		try {
-			state GetReadVersionRequest req(span.context, transactionCount, priority, flags, tags, debugID);
+			state GetReadVersionRequest req(span.context,
+			                                transactionCount,
+			                                priority,
+			                                cx->ssVersionVectorCache.getMaxVersion(),
+			                                flags,
+			                                tags,
+			                                debugID);
 
 			choose {
 				when(wait(cx->onProxiesChanged())) {}
@@ -5466,7 +5474,7 @@ ACTOR Future<Version> extractReadVersion(Location location,
 	}
 
 	metadataVersion.send(rep.metadataVersion);
-	cx->ssVersionVectorCache = rep.ssVersionVector;
+	cx->ssVersionVectorCache.applyDelta(rep.ssVersionVectorDelta);
 	return rep.version;
 }
 

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -169,6 +169,34 @@ void DatabaseContext::removeTssMapping(StorageServerInterface const& ssi) {
 	}
 }
 
+void DatabaseContext::addSSIdTagMapping(const UID& uid, const Tag& tag) {
+	ssidTagMapping[uid] = tag;
+}
+
+void DatabaseContext::getLatestCommitVersions(const Reference<LocationInfo>& locationInfo,
+                                              Version readVersion,
+                                              VersionVector& latestCommitVersions) {
+	std::map<Version, std::set<Tag>> versionMap; // order the versions to be returned
+	for (int i = 0; i < locationInfo->locations()->size(); i++) {
+		UID uid = locationInfo->locations()->getId(i);
+		if (ssidTagMapping.find(uid) != ssidTagMapping.end()) {
+			Tag tag = ssidTagMapping[uid];
+			if (ssVersionVectorCache.hasVersion(tag)) {
+				Version commitVersion = ssVersionVectorCache.getVersion(tag); // latest commit version
+				if (commitVersion < readVersion) {
+					versionMap[commitVersion].insert(tag);
+				}
+			}
+		}
+	}
+
+	// insert the commit versions in the version vector.
+	latestCommitVersions.clear();
+	for (auto& iter : versionMap) {
+		latestCommitVersions.setVersion(iter.second, iter.first);
+	}
+}
+
 Reference<StorageServerInfo> StorageServerInfo::getInterface(DatabaseContext* cx,
                                                              StorageServerInterface const& ssi,
                                                              LocalityData const& locality) {
@@ -2224,6 +2252,12 @@ void updateTssMappings(Database cx, const GetKeyServerLocationsReply& reply) {
 	}
 }
 
+void updateTagMappings(Database cx, const GetKeyServerLocationsReply& reply) {
+	for (const auto& mapping : reply.resultsTagMapping) {
+		cx->addSSIdTagMapping(mapping.first, mapping.second);
+	}
+}
+
 // If isBackward == true, returns the shard containing the key before 'key' (an infinitely long, inexpressible key).
 // Otherwise returns the shard containing key
 ACTOR Future<pair<KeyRange, Reference<LocationInfo>>> getKeyLocation_internal(Database cx,
@@ -2257,6 +2291,7 @@ ACTOR Future<pair<KeyRange, Reference<LocationInfo>>> getKeyLocation_internal(Da
 
 				auto locationInfo = cx->setCachedLocation(rep.results[0].first, rep.results[0].second);
 				updateTssMappings(cx, rep);
+				updateTagMappings(cx, rep);
 				return std::make_pair(KeyRange(rep.results[0].first, rep.arena), locationInfo);
 			}
 		}
@@ -2321,6 +2356,7 @@ ACTOR Future<vector<pair<KeyRange, Reference<LocationInfo>>>> getKeyRangeLocatio
 					wait(yield());
 				}
 				updateTssMappings(cx, rep);
+				updateTagMappings(cx, rep);
 
 				return results;
 			}
@@ -2425,6 +2461,8 @@ ACTOR Future<Optional<Value>> getValue(Future<Version> version,
 		state Optional<UID> getValueID = Optional<UID>();
 		state uint64_t startTime;
 		state double startTimeD;
+		state VersionVector ssLatestCommitVersions;
+		cx->getLatestCommitVersions(ssi.second, ver, ssLatestCommitVersions);
 		try {
 			if (info.debugID.present()) {
 				getValueID = nondeterministicRandom()->randomUniqueID();
@@ -2452,15 +2490,19 @@ ACTOR Future<Optional<Value>> getValue(Future<Version> version,
 				}
 				choose {
 					when(wait(cx->connectionFileChanged())) { throw transaction_too_old(); }
-					when(GetValueReply _reply = wait(loadBalance(
-					         cx.getPtr(),
-					         ssi.second,
-					         &StorageServerInterface::getValue,
-					         GetValueRequest(
-					             span.context, key, ver, cx->sampleReadTags() ? tags : Optional<TagSet>(), getValueID),
-					         TaskPriority::DefaultPromiseEndpoint,
-					         false,
-					         cx->enableLocalityLoadBalance ? &cx->queueModel : nullptr))) {
+					when(GetValueReply _reply =
+					         wait(loadBalance(cx.getPtr(),
+					                          ssi.second,
+					                          &StorageServerInterface::getValue,
+					                          GetValueRequest(span.context,
+					                                          key,
+					                                          ver,
+					                                          cx->sampleReadTags() ? tags : Optional<TagSet>(),
+					                                          getValueID,
+					                                          ssLatestCommitVersions),
+					                          TaskPriority::DefaultPromiseEndpoint,
+					                          false,
+					                          cx->enableLocalityLoadBalance ? &cx->queueModel : nullptr))) {
 						reply = _reply;
 					}
 				}
@@ -2548,6 +2590,9 @@ ACTOR Future<Key> getKey(Database cx, KeySelector k, Future<Version> version, Tr
 		state pair<KeyRange, Reference<LocationInfo>> ssi =
 		    wait(getKeyLocation(cx, locationKey, &StorageServerInterface::getKey, info, k.isBackward()));
 
+		state VersionVector ssLatestCommitVersions;
+		cx->getLatestCommitVersions(ssi.second, version.get(), ssLatestCommitVersions);
+
 		try {
 			if (info.debugID.present())
 				g_traceBatch.addEvent(
@@ -2557,8 +2602,12 @@ ACTOR Future<Key> getKey(Database cx, KeySelector k, Future<Version> version, Tr
 				                                // k.getKey()).detail("Offset",k.offset).detail("OrEqual",k.orEqual);
 			++cx->transactionPhysicalReads;
 
-			GetKeyRequest req(
-			    span.context, k, version.get(), cx->sampleReadTags() ? tags : Optional<TagSet>(), getKeyID);
+			GetKeyRequest req(span.context,
+			                  k,
+			                  version.get(),
+			                  cx->sampleReadTags() ? tags : Optional<TagSet>(),
+			                  getKeyID,
+			                  ssLatestCommitVersions);
 			req.arena.dependsOn(k.arena());
 
 			state GetKeyReply reply;
@@ -2929,6 +2978,7 @@ ACTOR Future<RangeResult> getExactRange(Database cx,
 			req.begin = firstGreaterOrEqual(range.begin);
 			req.end = firstGreaterOrEqual(range.end);
 			req.spanContext = span.context;
+			cx->getLatestCommitVersions(locations[shard].second, version, req.ssLatestCommitVersions);
 
 			// keep shard's arena around in case of async tss comparison
 			req.arena.dependsOn(locations[shard].first.arena());
@@ -3515,6 +3565,7 @@ ACTOR Future<Void> getRangeStreamFragment(ParallelStream<RangeResult>::Fragment*
 			req.spanContext = spanContext;
 			req.limit = reverse ? -CLIENT_KNOBS->REPLY_BYTE_LIMIT : CLIENT_KNOBS->REPLY_BYTE_LIMIT;
 			req.limitBytes = std::numeric_limits<int>::max();
+			cx->getLatestCommitVersions(locations[shard].second, version, req.ssLatestCommitVersions);
 
 			ASSERT(req.limitBytes > 0 && req.limit != 0 && req.limit < 0 == reverse);
 

--- a/fdbclient/VersionVector.h
+++ b/fdbclient/VersionVector.h
@@ -43,7 +43,7 @@ struct VersionVector {
 		maxVersion = version;
 	}
 
-	void setVersions(const std::set<Tag>& tags, Version version) {
+	void setVersion(const std::set<Tag>& tags, Version version) {
 		ASSERT(version > maxVersion);
 		for (auto& tag : tags) {
 			ASSERT(tag != invalidTag);
@@ -62,6 +62,11 @@ struct VersionVector {
 		auto iter = versions.find(tag);
 		ASSERT(iter != versions.end());
 		return iter->second;
+	}
+
+	void clear() {
+		versions.clear();
+		maxVersion = invalidVersion;
 	}
 
 	bool operator==(const VersionVector& vv) const { return maxVersion == vv.maxVersion; }

--- a/fdbclient/VersionVector.h
+++ b/fdbclient/VersionVector.h
@@ -53,6 +53,7 @@ struct VersionVector {
 			ASSERT(tag != invalidTag);
 			versions[tag] = version;
 		}
+		maxVersion = version;
 	}
 
 	bool hasVersion(const Tag& tag) const {
@@ -73,24 +74,24 @@ struct VersionVector {
 		maxVersion = invalidVersion;
 	}
 
-	void getDelta(Version version, VersionVector& delta) const {
-		ASSERT(version <= maxVersion);
+	void getDelta(Version refVersion, VersionVector& delta) const {
+		ASSERT(refVersion <= maxVersion);
 
 		delta.clear();
 
-		if (version == maxVersion) {
+		if (refVersion == maxVersion) {
 			return; // rerurn an invalid version vector
 		}
 
-		std::map<Version, std::set<Tag>> versionMap;
-		for (auto& iter : versions) {
-			if (iter.second > version) {
-				versionMap[iter.second].insert(iter.first);
+		std::map<Version, std::set<Tag>> versionMap; // order versions
+		for (const auto& [tag, version] : versions) {
+			if (version > refVersion) {
+				versionMap[version].insert(tag);
 			}
 		}
 
-		for (auto& iter : versionMap) {
-			delta.setVersion(iter.second, iter.first);
+		for (auto& [version, tags] : versionMap) {
+			delta.setVersion(tags, version);
 		}
 	}
 
@@ -101,15 +102,15 @@ struct VersionVector {
 
 		ASSERT(maxVersion < delta.maxVersion);
 
-		std::map<Version, std::set<Tag>> versionMap; // order the versions
-		for (auto& iter : delta.versions) {
+		std::map<Version, std::set<Tag>> versionMap; // order versions
+		for (const auto& [tag, version] : delta.versions) {
 			// @todo remove this assert later
-			ASSERT(iter.second > maxVersion);
-			versionMap[iter.second].insert(iter.first);
+			ASSERT(version > maxVersion);
+			versionMap[version].insert(tag);
 		}
 
-		for (auto& iter : versionMap) {
-			setVersion(iter.second, iter.first);
+		for (auto& [version, tags] : versionMap) {
+			setVersion(tags, version);
 		}
 	}
 

--- a/fdbserver/BackupWorker.actor.cpp
+++ b/fdbserver/BackupWorker.actor.cpp
@@ -431,6 +431,7 @@ struct BackupData {
 			GetReadVersionRequest request(span.context,
 			                              0,
 			                              TransactionPriority::DEFAULT,
+			                              invalidVersion,
 			                              GetReadVersionRequest::FLAG_USE_MIN_KNOWN_COMMITTED_VERSION);
 			choose {
 				when(wait(self->cx->onProxiesChanged())) {}

--- a/fdbserver/CommitProxyServer.actor.cpp
+++ b/fdbserver/CommitProxyServer.actor.cpp
@@ -1470,6 +1470,17 @@ void maybeAddTssMapping(GetKeyServerLocationsReply& reply,
 	}
 }
 
+void addTagMapping(GetKeyServerLocationsReply& reply, ProxyCommitData* commitData) {
+	for (const auto& [_, shard] : reply.results) {
+		for (auto& ssi : shard) {
+			auto iter = commitData->storageCache.find(ssi.id());
+			if (iter != commitData->storageCache.end()) {
+				reply.resultsTagMapping.emplace_back(ssi.id(), iter->second->tag);
+			}
+		}
+	}
+}
+
 ACTOR static Future<Void> doKeyServerLocationRequest(GetKeyServerLocationsRequest req, ProxyCommitData* commitData) {
 	// We can't respond to these requests until we have valid txnStateStore
 	wait(commitData->validState.getFuture());
@@ -1519,6 +1530,7 @@ ACTOR static Future<Void> doKeyServerLocationRequest(GetKeyServerLocationsReques
 			--r;
 		}
 	}
+	addTagMapping(rep, commitData);
 	req.reply.send(rep);
 	++commitData->stats.keyServerLocationOut;
 	return Void();

--- a/fdbserver/CommitProxyServer.actor.cpp
+++ b/fdbserver/CommitProxyServer.actor.cpp
@@ -1152,7 +1152,7 @@ ACTOR Future<Void> postResolution(CommitBatchContext* self) {
 				}
 				when(wait(pProxyCommitData->cx->onProxiesChanged())) {}
 				when(GetRawCommittedVersionReply v = wait(pProxyCommitData->master.getLiveCommittedVersion.getReply(
-				         GetRawCommittedVersionRequest(waitVersionSpan.context, debugID),
+				         GetRawCommittedVersionRequest(waitVersionSpan.context, debugID, invalidVersion),
 				         TaskPriority::GetLiveCommittedVersionReply))) {
 					if (v.version > pProxyCommitData->committedVersion.get()) {
 						pProxyCommitData->locked = v.locked;
@@ -1474,9 +1474,8 @@ void addTagMapping(GetKeyServerLocationsReply& reply, ProxyCommitData* commitDat
 	for (const auto& [_, shard] : reply.results) {
 		for (auto& ssi : shard) {
 			auto iter = commitData->storageCache.find(ssi.id());
-			if (iter != commitData->storageCache.end()) {
-				reply.resultsTagMapping.emplace_back(ssi.id(), iter->second->tag);
-			}
+			ASSERT_WE_THINK(iter != commitData->storageCache.end());
+			reply.resultsTagMapping.emplace_back(ssi.id(), iter->second->tag);
 		}
 	}
 }

--- a/fdbserver/CommitProxyServer.actor.cpp
+++ b/fdbserver/CommitProxyServer.actor.cpp
@@ -879,8 +879,9 @@ ACTOR Future<Void> applyMetadataToCommittedTransactions(CommitBatchContext* self
 // Message the sequencer to obtain the previous commit version for each storage server's tag
 ACTOR Future<Void> getTPCV(CommitBatchContext* self) {
 	state ProxyCommitData* const pProxyCommitData = self->pProxyCommitData;
-	GetTLogPrevCommitVersionReply rep = wait(brokenPromiseToNever(
-	    pProxyCommitData->master.getTLogPrevCommitVersion.getReply(GetTLogPrevCommitVersionRequest(self->writtenTLogs))));
+	GetTLogPrevCommitVersionReply rep =
+	    wait(brokenPromiseToNever(pProxyCommitData->master.getTLogPrevCommitVersion.getReply(
+	        GetTLogPrevCommitVersionRequest(self->writtenTLogs))));
 	// TraceEvent("GetTLogPrevCommitVersionRequest");
 	return Void();
 }
@@ -1151,6 +1152,9 @@ ACTOR Future<Void> postResolution(CommitBatchContext* self) {
 					break;
 				}
 				when(wait(pProxyCommitData->cx->onProxiesChanged())) {}
+				// @todo probably there is no need to get the (entire) version vector from the sequencer
+				// in this case, and if so, consider adding a flag to the request to tell the sequencer
+				// to not send the version vector information.
 				when(GetRawCommittedVersionReply v = wait(pProxyCommitData->master.getLiveCommittedVersion.getReply(
 				         GetRawCommittedVersionRequest(waitVersionSpan.context, debugID, invalidVersion),
 				         TaskPriority::GetLiveCommittedVersionReply))) {
@@ -1296,7 +1300,8 @@ ACTOR Future<Void> reply(CommitBatchContext* self) {
 	// self->committedVersion by reporting commit version first before updating self->committedVersion. Otherwise, a
 	// client may get a commit version that the master is not aware of, and next GRV request may get a version less than
 	// self->committedVersion.
-	TEST(pProxyCommitData->committedVersion.get() > self->commitVersion); // A later version was reported committed first
+	TEST(pProxyCommitData->committedVersion.get() >
+	     self->commitVersion); // A later version was reported committed first
 	if (self->commitVersion >= pProxyCommitData->committedVersion.get()) {
 		state Optional<std::set<Tag>> writtenTags;
 		if (SERVER_KNOBS->ENABLE_VERSION_VECTOR) {

--- a/fdbserver/GrvProxyServer.actor.cpp
+++ b/fdbserver/GrvProxyServer.actor.cpp
@@ -23,10 +23,10 @@
 #include "fdbserver/LogSystemDiskQueueAdapter.h"
 #include "fdbclient/CommitProxyInterface.h"
 #include "fdbclient/GrvProxyInterface.h"
+#include "fdbclient/VersionVector.h"
 #include "fdbserver/WaitFailure.h"
 #include "fdbserver/WorkerInterface.actor.h"
 #include "flow/flow.h"
-#include "fdbclient/VersionVector.h"
 #include "flow/actorcompiler.h" // This must be the last #include.
 
 struct GrvProxyStats {

--- a/fdbserver/TLogServer.actor.cpp
+++ b/fdbserver/TLogServer.actor.cpp
@@ -516,6 +516,7 @@ struct LogData : NonCopyable, public ReferenceCounted<LogData> {
 	Deque<std::pair<Version, Standalone<VectorRef<uint8_t>>>> messageBlocks;
 	std::vector<std::vector<Reference<TagData>>> tag_data; // tag.locality | tag.id
 	int unpoppedRecoveredTags;
+	std::map<Tag, Promise<Void>> waitingTags;
 
 	Reference<TagData> getTagData(Tag tag) {
 		int idx = tag.toTagDataIndex();
@@ -1452,6 +1453,13 @@ void commitMessages(TLogData* self,
 					txsBytes += tagData->versionMessages.back().second.expectedSize();
 				}
 
+				auto iter = logData->waitingTags.find(tag);
+				if (iter != logData->waitingTags.end()) {
+					auto promise = iter->second;
+					logData->waitingTags.erase(iter);
+					promise.send(Void());
+				}
+
 				// The factor of VERSION_MESSAGES_OVERHEAD is intended to be an overestimate of the actual memory used
 				// to store this data in a std::deque. In practice, this number is probably something like 528/512
 				// ~= 1.03, but this could vary based on the implementation. There will also be a fixed overhead per
@@ -1505,6 +1513,17 @@ std::deque<std::pair<Version, LengthPrefixedStringRef>>& getVersionMessages(Refe
 	}
 	return tagData->versionMessages;
 };
+
+ACTOR Future<Void> waitForMessagesForTag(Reference<LogData> self, TLogPeekRequest* req) {
+	auto tagData = self->getTagData(req->tag);
+	if (tagData.isValid()) {
+		return Void();
+	}
+	wait(self->waitingTags[req->tag].getFuture());
+	// we want the caller to finish first, otherwise the data structure it is building might not be complete
+	wait(delay(0.0));
+	return Void();
+}
 
 void peekMessagesFromMemory(Reference<LogData> self,
                             TLogPeekRequest const& req,
@@ -1835,6 +1854,10 @@ ACTOR Future<Void> tLogPeekMessages(TLogData* self, TLogPeekRequest req, Referen
 		if (req.onlySpilled) {
 			endVersion = logData->persistentDataDurableVersion + 1;
 		} else {
+			if (req.tag.locality >= 0 && !req.returnIfBlocked) {
+				// wait for at most 1 second
+				wait(waitForMessagesForTag(logData, &req) || delay(1.0));
+			}
 			peekMessagesFromMemory(logData, req, messages, endVersion);
 		}
 
@@ -2655,7 +2678,7 @@ ACTOR Future<Void> tLogCore(TLogData* self,
 	                                     SERVER_KNOBS->STORAGE_LOGGING_DELAY,
 	                                     &logData->cc,
 	                                     logData->logId.toString() + "/TLogMetrics",
-	                                     [self=self](TraceEvent& te) {
+	                                     [self = self](TraceEvent& te) {
 		                                     StorageBytes sbTlog = self->persistentData->getStorageBytes();
 		                                     te.detail("KvstoreBytesUsed", sbTlog.used);
 		                                     te.detail("KvstoreBytesFree", sbTlog.free);
@@ -2885,9 +2908,9 @@ ACTOR Future<Void> restorePersistentState(TLogData* self,
 		logsByVersion.emplace_back(ver, id1);
 
 		TraceEvent("TLogPersistentStateRestore", self->dbgid)
-			.detail("LogId", logData->logId)
-			.detail("Ver", ver)
-			.detail("RecoveryCount", logData->recoveryCount);
+		    .detail("LogId", logData->logId)
+		    .detail("Ver", ver)
+		    .detail("RecoveryCount", logData->recoveryCount);
 		// Restore popped keys.  Pop operations that took place after the last (committed) updatePersistentDataVersion
 		// might be lost, but that is fine because we will get the corresponding data back, too.
 		tagKeys = prefixRange(rawId.withPrefix(persistTagPoppedKeys.begin));

--- a/fdbserver/masterserver.actor.cpp
+++ b/fdbserver/masterserver.actor.cpp
@@ -248,6 +248,8 @@ struct MasterData : NonCopyable, ReferenceCounted<MasterData> {
 	std::vector<WorkerInterface> backupWorkers; // Recruited backup workers from cluster controller.
 
 	// Captures the latest commit version targeted for each storage server in the cluster.
+	// @todo We need to ensure that the latest commit versions of storage servers stay 
+	// up-to-date in the presence of key range splits/merges.
 	VersionVector ssVersionVector;
 
 	// The previous commit versions per tlog

--- a/fdbserver/masterserver.actor.cpp
+++ b/fdbserver/masterserver.actor.cpp
@@ -248,7 +248,7 @@ struct MasterData : NonCopyable, ReferenceCounted<MasterData> {
 	std::vector<WorkerInterface> backupWorkers; // Recruited backup workers from cluster controller.
 
 	// Captures the latest commit version targeted for each storage server in the cluster.
-	// @todo We need to ensure that the latest commit versions of storage servers stay 
+	// @todo We need to ensure that the latest commit versions of storage servers stay
 	// up-to-date in the presence of key range splits/merges.
 	VersionVector ssVersionVector;
 
@@ -1241,7 +1241,7 @@ ACTOR Future<Void> serveLiveCommittedVersion(Reference<MasterData> self) {
 				reply.locked = self->databaseLocked;
 				reply.metadataVersion = self->proxyMetadataVersion;
 				reply.minKnownCommittedVersion = self->minKnownCommittedVersion;
-				reply.ssVersionVector = self->ssVersionVector;
+				self->ssVersionVector.getDelta(req.maxVersion, reply.ssVersionVectorDelta);
 				req.reply.send(reply);
 			}
 			when(ReportRawCommittedVersionRequest req =

--- a/fdbserver/masterserver.actor.cpp
+++ b/fdbserver/masterserver.actor.cpp
@@ -1251,7 +1251,7 @@ ACTOR Future<Void> serveLiveCommittedVersion(Reference<MasterData> self) {
 					// NB: this if-condition is not needed after wait-for-prev is ported to this branch
 					if (req.version > self->ssVersionVector.maxVersion) {
 						// TraceEvent("Received ReportRawCommittedVersionRequest").detail("Version",req.version);
-						self->ssVersionVector.setVersions(req.writtenTags.get(), req.version);
+						self->ssVersionVector.setVersion(req.writtenTags.get(), req.version);
 					}
 				}
 				if (req.version > self->liveCommittedVersion) {

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -1178,8 +1178,8 @@ ACTOR Future<Version> waitForVersionActor(StorageServer* data, Version version, 
 // of the storage server.
 Version getRealReadVersion(VersionVector& ssLatestCommitVersions, Tag& tag, Version specifiedReadVersion)
 {
-	Version realReadVersion = ssLatestcommitVersions.hasVersion(tag) ? ssLatestCommitVersions.getVersion(tag) : readVersion;
-	ASSERT(readlReadVersion <= specifiedReadVersion);
+	Version realReadVersion = ssLatestCommitVersions.hasVersion(tag) ? ssLatestCommitVersions.getVersion(tag) : specifiedReadVersion;
+	ASSERT(realReadVersion <= specifiedReadVersion);
 	return realReadVersion;
 }
 


### PR DESCRIPTION
Main changes:
- Propagate latest commit version from client to storage server
- Make a storage server read at the latest commit version (instead of the actual read version)
- Make a peek request block on a tlog until the tlog has a commit that is relevant to the requester (code changes to accomplish this have been extracted from https://github.com/apple/foundationdb/pull/5058)
- Propagate version vector deltas between processes

Changes related to the propagation of the latest commit version from client to storage server and to make a storage server read at the latest commit version:

CommitProxyInterface.h:
- Let the proxy return the tags of storage servers (along with the storage server interfaces) as part of GetKeyServerLocationsReply.

DatabaseContext.h:
- Map the tags of storage servers to their corresponding storage server interfaces.
- APIs to update the tag mapping and to fetch the tags of a given set storage server replicas.

NativeAPI.cpp:
- Update tag mappings in GetKeyServerLocationsReply() and getKeyRangeLocations_internal().
- Propagate the late commit versions of storage server replicas when making the following requests: 					                          GetValueRequest, GetKeyRequest, GetKeyValuesRequest, GetKeyValuesStreamRequest.

StorageServerInterface.h:
- Extend the following RPCs to also propagate the latest commit versions of all storage server replicas that serve the given key/key range: GetValueRequest, GetKeyRequest, GetKeyValuesRequest, GetKeyValuesStreamRequest.

VersionVector.h:
- Add APIs to set the versions for a given set of storage servers and to clear the vector.

CommitProxyServer.actor.cpp:
- Populate the storage server tag info in GetKeyServerLocationsReply.

GrvProxyServer.actor.cpp:
- Order the includes.

storageserver.actor.cpp:
- Make the server read at the specified latest commit version while serving the following types of requests: GetValueRequest, GetKeyRequest, GetKeyValuesRequest, GetKeyValuesStreamRequest.

Changes to make a peek request block on a tlog until the tlog has a commit that is relevant to the requester:

TLogServer.actor.cpp:
- Code changes extracted from https://github.com/apple/foundationdb/pull/5058

Changes related to the propagation of version vector deltas:

VersionVector.h:

- Add APIs to get and apply version vector deltas.

CommitProxyInterface.h:
- Extend GetReadVersionRequest and GetRawCommittedVersionRequest data structures so the client and the grv proxy can inform the maximum version in their version vectors.

NativeAPI.actor.cpp and GrvProxyServer.actor.cpp:
- Modify code so the client/grv proxy will include the maximum version in its version vector cache in GetReadVersionRequest/GetRawCommittedVersionRequest and then apply the version vector delta (that it receives from the grv proxy/sequenver) to its version vector cache.

CommitProxyServer.actor.cpp:
- Set "maxVersion = invalidVersion" in the GetReadVersionRequest that it makes.

masterserver.actor.cpp:
- Return version vector delta to the grv proxy.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
