### PR TITLE
DO NOT MERGE! Reproduction of rocksdb::Iterator::Refresh bug 

### DIFF
--- a/fdbclient/MultiVersionTransaction.actor.cpp
+++ b/fdbclient/MultiVersionTransaction.actor.cpp
@@ -1884,8 +1884,6 @@ bool ClientInfo::canReplace(Reference<ClientInfo> other) const {
 }
 
 // UNIT TESTS
-extern bool noUnseed;
-
 TEST_CASE("/fdbclient/multiversionclient/EnvironmentVariableParsing") {
 	auto vals = parseOptionValues("a");
 	ASSERT(vals.size() == 1 && vals[0] == "a");

--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -335,7 +335,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( ROCKSDB_BACKGROUND_PARALLELISM,                          0 );
 	init( ROCKSDB_READ_PARALLELISM,                                4 );
 	// Use a smaller memtable in simulation to avoid OOMs.
-	int64_t memtableBytes = isSimulated ? 64 * 1014 : 512 * 1024 * 1024;
+	int64_t memtableBytes = isSimulated ? 32 * 1024 : 512 * 1024 * 1024;
 	init( ROCKSDB_MEMTABLE_BYTES,                      memtableBytes );
 	init( ROCKSDB_UNSAFE_AUTO_FSYNC,                           false );
 	init( ROCKSDB_PERIODIC_COMPACTION_SECONDS,                     0 );

--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -334,7 +334,9 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	// KeyValueStoreRocksDB
 	init( ROCKSDB_BACKGROUND_PARALLELISM,                          0 );
 	init( ROCKSDB_READ_PARALLELISM,                                4 );
-	init( ROCKSDB_MEMTABLE_BYTES,                  512 * 1024 * 1024 );
+	// Use a smaller memtable in simulation to avoid OOMs.
+	int64_t memtableBytes = isSimulated ? 64 * 1014 : 512 * 1024 * 1024;
+	init( ROCKSDB_MEMTABLE_BYTES,                      memtableBytes );
 	init( ROCKSDB_UNSAFE_AUTO_FSYNC,                           false );
 	init( ROCKSDB_PERIODIC_COMPACTION_SECONDS,                     0 );
 	init( ROCKSDB_PREFIX_LEN,                                      0 );

--- a/fdbrpc/FlowTests.actor.cpp
+++ b/fdbrpc/FlowTests.actor.cpp
@@ -262,8 +262,8 @@ struct YieldMockNetwork final : INetwork, ReferenceCounted<YieldMockNetwork> {
 		return baseNetwork->onMainThread(std::move(signal), taskID);
 	}
 	bool isOnMainThread() const override { return baseNetwork->isOnMainThread(); }
-	THREAD_HANDLE startThread(THREAD_FUNC_RETURN (*func)(void*), void* arg) override {
-		return baseNetwork->startThread(func, arg);
+	THREAD_HANDLE startThread(THREAD_FUNC_RETURN (*func)(void*), void* arg, int stackSize, const char* name) override {
+		return baseNetwork->startThread(func, arg, stackSize, name);
 	}
 	Future<Reference<class IAsyncFile>> open(std::string filename, int64_t flags, int64_t mode) {
 		return IAsyncFileSystem::filesystem()->open(filename, flags, mode);

--- a/fdbrpc/sim2.actor.cpp
+++ b/fdbrpc/sim2.actor.cpp
@@ -1007,9 +1007,9 @@ public:
 		THREAD_RETURN;
 	}
 
-	THREAD_HANDLE startThread(THREAD_FUNC_RETURN (*func)(void*), void* arg) override {
+	THREAD_HANDLE startThread(THREAD_FUNC_RETURN (*func)(void*), void* arg, int stackSize, const char* name) override {
 		SimThreadArgs* simArgs = new SimThreadArgs(func, arg);
-		return ::startThread(simStartThread, simArgs);
+		return ::startThread(simStartThread, simArgs, stackSize, name);
 	}
 
 	void getDiskBytes(std::string const& directory, int64_t& free, int64_t& total) override {

--- a/fdbserver/DataDistributionQueue.actor.cpp
+++ b/fdbserver/DataDistributionQueue.actor.cpp
@@ -941,8 +941,6 @@ struct DDQueueData {
 	}
 };
 
-extern bool noUnseed;
-
 // This actor relocates the specified keys to a good place.
 // The inFlightActor key range map stores the actor for each RelocateData
 ACTOR Future<Void> dataDistributionRelocator(DDQueueData* self, RelocateData rd, const DDEnabledState* ddEnabledState) {

--- a/fdbserver/KeyValueStoreMemory.actor.cpp
+++ b/fdbserver/KeyValueStoreMemory.actor.cpp
@@ -31,8 +31,6 @@
 
 #define OP_DISK_OVERHEAD (sizeof(OpHeader) + 1)
 
-extern bool noUnseed;
-
 template <typename Container>
 class KeyValueStoreMemory final : public IKeyValueStore, NonCopyable {
 public:

--- a/fdbserver/SimulatedCluster.actor.cpp
+++ b/fdbserver/SimulatedCluster.actor.cpp
@@ -232,6 +232,7 @@ public:
 	//	1 = "memory"
 	//	2 = "memory-radixtree-beta"
 	//	3 = "ssd-redwood-experimental"
+	//	4 = "ssd-rocksdb-experimental"
 	// Requires a comma-separated list of numbers WITHOUT whitespaces
 	std::vector<int> storageEngineExcludeTypes;
 	// Set the maximum TLog version that can be selected for a test
@@ -1252,7 +1253,7 @@ void SimulationConfig::setDatacenters(const TestConfig& testConfig) {
 
 // Sets storage engine based on testConfig details
 void SimulationConfig::setStorageEngine(const TestConfig& testConfig) {
-	int storage_engine_type = deterministicRandom()->randomInt(0, 4);
+	int storage_engine_type = deterministicRandom()->randomInt(0, 5);
 	if (testConfig.storageEngineType.present()) {
 		storage_engine_type = testConfig.storageEngineType.get();
 	} else {
@@ -1260,7 +1261,7 @@ void SimulationConfig::setStorageEngine(const TestConfig& testConfig) {
 		while (std::find(testConfig.storageEngineExcludeTypes.begin(),
 		                 testConfig.storageEngineExcludeTypes.end(),
 		                 storage_engine_type) != testConfig.storageEngineExcludeTypes.end()) {
-			storage_engine_type = deterministicRandom()->randomInt(0, 4);
+			storage_engine_type = deterministicRandom()->randomInt(0, 5);
 		}
 	}
 
@@ -1283,6 +1284,14 @@ void SimulationConfig::setStorageEngine(const TestConfig& testConfig) {
 	case 3: {
 		TEST(true); // Simulated cluster using redwood storage engine
 		set_config("ssd-redwood-experimental");
+		break;
+	}
+	case 4: {
+		TEST(true); // Simulated cluster using RocksDB storage engine
+		set_config("ssd-rocksdb-experimental");
+		// Tests using the RocksDB engine are necessarily non-deterministic because of RocksDB
+		// background threads.
+		noUnseed = true;
 		break;
 	}
 	default:

--- a/fdbserver/fdbserver.actor.cpp
+++ b/fdbserver/fdbserver.actor.cpp
@@ -199,7 +199,6 @@ extern const char* getSourceVersion();
 
 extern void flushTraceFileVoid();
 
-extern bool noUnseed;
 extern const int MAX_CLUSTER_FILE_BYTES;
 
 #ifdef ALLOC_INSTRUMENTATION

--- a/fdbserver/workloads/ThreadSafety.actor.cpp
+++ b/fdbserver/workloads/ThreadSafety.actor.cpp
@@ -100,8 +100,6 @@ private:
 	}
 };
 
-extern bool noUnseed;
-
 // A workload which uses the thread safe API from multiple threads
 struct ThreadSafetyWorkload : TestWorkload {
 	int threadsPerClient;

--- a/flow/IThreadPool.cpp
+++ b/flow/IThreadPool.cpp
@@ -109,7 +109,7 @@ public:
 	}
 	void addThread(IThreadPoolReceiver* userData, const char* name) override {
 		threads.push_back(new Thread(this, userData));
-		threads.back()->handle = startThread(start, threads.back(), stackSize, name);
+		threads.back()->handle = g_network->startThread(start, threads.back(), stackSize, name);
 	}
 	void post(PThreadAction action) override { ios.post(ActionWrapper(action)); }
 };

--- a/flow/IThreadPoolTest.actor.cpp
+++ b/flow/IThreadPoolTest.actor.cpp
@@ -35,7 +35,7 @@ struct ThreadNameReceiver : IThreadPoolReceiver {
 	}
 };
 
-TEST_CASE("noSim/IThreadPool/NamedThread") {
+TEST_CASE("/flow/IThreadPool/NamedThread") {
 	state Reference<IThreadPool> pool = createGenericThreadPool();
 	pool->addThread(new ThreadNameReceiver(), "thread-foo");
 

--- a/flow/IThreadPoolTest.actor.cpp
+++ b/flow/IThreadPoolTest.actor.cpp
@@ -36,6 +36,8 @@ struct ThreadNameReceiver : IThreadPoolReceiver {
 };
 
 TEST_CASE("/flow/IThreadPool/NamedThread") {
+	noUnseed = true;
+
 	state Reference<IThreadPool> pool = createGenericThreadPool();
 	pool->addThread(new ThreadNameReceiver(), "thread-foo");
 

--- a/flow/Net2.actor.cpp
+++ b/flow/Net2.actor.cpp
@@ -184,7 +184,7 @@ public:
 	}
 
 	bool isSimulated() const override { return false; }
-	THREAD_HANDLE startThread(THREAD_FUNC_RETURN (*func)(void*), void* arg) override;
+	THREAD_HANDLE startThread(THREAD_FUNC_RETURN (*func)(void*), void* arg, int stackSize, const char* name) override;
 
 	void getDiskBytes(std::string const& directory, int64_t& free, int64_t& total) override;
 	bool isAddressOnThisHost(NetworkAddress const& addr) const override;
@@ -1513,7 +1513,7 @@ void Net2::run() {
 			double newTaskBegin = timer_monotonic();
 			if (check_yield(TaskPriority::Max, tscNow)) {
 				checkForSlowTask(tscBegin, tscNow, newTaskBegin - taskBegin, currentTaskID);
-				taskBegin = newTaskBegin;	
+				taskBegin = newTaskBegin;
 				FDB_TRACE_PROBE(run_loop_yield);
 				++countYields;
 				break;
@@ -1765,8 +1765,8 @@ void Net2::onMainThread(Promise<Void>&& signal, TaskPriority taskID) {
 	}
 }
 
-THREAD_HANDLE Net2::startThread(THREAD_FUNC_RETURN (*func)(void*), void* arg) {
-	return ::startThread(func, arg);
+THREAD_HANDLE Net2::startThread(THREAD_FUNC_RETURN (*func)(void*), void* arg, int stackSize, const char* name) {
+	return ::startThread(func, arg, stackSize, name);
 }
 
 Future<Reference<IConnection>> Net2::connect(NetworkAddress toAddr, const std::string& host) {

--- a/flow/UnitTest.h
+++ b/flow/UnitTest.h
@@ -99,6 +99,9 @@ struct UnitTestCollection {
 
 extern UnitTestCollection g_unittests;
 
+// Set this to `true` to disable RNG state checking after simulation runs.
+ extern bool noUnseed;
+
 #define APPEND(a, b) a##b
 
 // FILE_UNIQUE_NAME(basename) expands to a name like basename456 if on line 456

--- a/flow/network.h
+++ b/flow/network.h
@@ -347,7 +347,8 @@ struct NetworkMetrics {
 
 	std::unordered_map<TaskPriority, struct PriorityStats> activeTrackers;
 	double lastRunLoopBusyness; // network thread busyness (measured every 5s by default)
-	std::atomic<double> networkBusyness; // network thread busyness which is returned to the the client (measured every 1s by default)
+	std::atomic<double>
+	    networkBusyness; // network thread busyness which is returned to the the client (measured every 1s by default)
 
 	// starvation trackers which keeps track of different task priorities
 	std::vector<struct PriorityStats> starvationTrackers;
@@ -536,7 +537,10 @@ public:
 	virtual void onMainThread(Promise<Void>&& signal, TaskPriority taskID) = 0;
 	// Executes signal.send(Void()) on a/the thread belonging to this network
 
-	virtual THREAD_HANDLE startThread(THREAD_FUNC_RETURN (*func)(void*), void* arg) = 0;
+	virtual THREAD_HANDLE startThread(THREAD_FUNC_RETURN (*func)(void*),
+	                                  void* arg,
+	                                  int stackSize = 0,
+	                                  const char* name = nullptr) = 0;
 	// Starts a thread and returns a handle to it
 
 	virtual void run() = 0;

--- a/tests/restarting/from_6.2.33/SnapCycleRestart-1.txt
+++ b/tests/restarting/from_6.2.33/SnapCycleRestart-1.txt
@@ -1,3 +1,5 @@
+storageEngineExcludeTypes=4
+
 ;Take snap and do cycle test
 testTitle=SnapCyclePre
 clearAfterTest=false

--- a/tests/restarting/from_6.2.33/SnapCycleRestart-2.txt
+++ b/tests/restarting/from_6.2.33/SnapCycleRestart-2.txt
@@ -1,4 +1,5 @@
 buggify=off
+storageEngineExcludeTypes=4
 
 testTitle=SnapCycleRestore
 runSetup=false

--- a/tests/restarting/from_6.2.33/SnapTestAttrition-1.txt
+++ b/tests/restarting/from_6.2.33/SnapTestAttrition-1.txt
@@ -1,3 +1,5 @@
+storageEngineExcludeTypes=4
+
 ;write 1000 Keys ending with even numbers
 testTitle=SnapTestPre
 clearAfterTest=false

--- a/tests/restarting/from_6.2.33/SnapTestAttrition-2.txt
+++ b/tests/restarting/from_6.2.33/SnapTestAttrition-2.txt
@@ -1,4 +1,5 @@
 buggify=off
+storageEngineExcludeTypes=4
 
 ; verify all keys are even numbered
 testTitle=SnapTestVerify

--- a/tests/restarting/from_6.2.33/SnapTestRestart-1.txt
+++ b/tests/restarting/from_6.2.33/SnapTestRestart-1.txt
@@ -1,3 +1,5 @@
+storageEngineExcludeTypes=4
+
 ;write 1000 Keys ending with even numbers
 testTitle=SnapTestPre
 clearAfterTest=false

--- a/tests/restarting/from_6.2.33/SnapTestRestart-2.txt
+++ b/tests/restarting/from_6.2.33/SnapTestRestart-2.txt
@@ -1,4 +1,5 @@
 buggify=off
+storageEngineExcludeTypes=4
 
 ; verify all keys are even numbered
 testTitle=SnapTestVerify

--- a/tests/restarting/from_6.2.33/SnapTestSimpleRestart-1.txt
+++ b/tests/restarting/from_6.2.33/SnapTestSimpleRestart-1.txt
@@ -1,3 +1,5 @@
+storageEngineExcludeTypes=4
+
 ;write 1000 Keys ending with even number
 testTitle=SnapSimplePre
 clearAfterTest=false

--- a/tests/restarting/from_6.2.33/SnapTestSimpleRestart-2.txt
+++ b/tests/restarting/from_6.2.33/SnapTestSimpleRestart-2.txt
@@ -1,4 +1,5 @@
 buggify=off
+storageEngineExcludeTypes=4
 
 ; verify all keys are even numbered
 testTitle=SnapSimpleVerify

--- a/tests/restarting/from_7.0.0/SnapIncrementalRestore-1.toml
+++ b/tests/restarting/from_7.0.0/SnapIncrementalRestore-1.toml
@@ -1,7 +1,8 @@
 [configuration]
 logAntiQuorum = 0
+storageEngineExcludeTypes = [4]
 
-[[test]] 
+[[test]]
 testTitle = 'SubmitBackup'
 simBackupAgents = 'BackupToFile'
 clearAfterTest = false

--- a/tests/restarting/from_7.0.0/SnapIncrementalRestore-2.toml
+++ b/tests/restarting/from_7.0.0/SnapIncrementalRestore-2.toml
@@ -1,3 +1,6 @@
+[configuration]
+storageEngineExcludeTypes = [4]
+
 [[test]]
 testTitle = 'RestoreBackup'
 simBackupAgents = 'BackupToFile'


### PR DESCRIPTION
This branch can reproduce https://github.com/facebook/rocksdb/issues/7212. Unfortunately, the failures are non-deterministic, so I do not have consistent reproduction instructions.

This is the assert that fails: https://github.com/apple/foundationdb/blob/ad9ee9739e567a55e7f9d135154a8c947c723a61/fdbserver/MoveKeys.actor.cpp#L1228

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
