### PR TITLE
fix compile commands for IDE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -201,9 +201,9 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/fdbclient/BuildFlags.h.in ${CMAKE_CUR
 if (CMAKE_EXPORT_COMPILE_COMMANDS AND WITH_PYTHON)
   add_custom_command(
 	  OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/compile_commands.json
-	  COMMAND $<TARGET_FILE:Python::Interpreter> contrib/gen_compile_db.py
+	  COMMAND $<TARGET_FILE:Python::Interpreter> ${CMAKE_CURRENT_SOURCE_DIR}/contrib/gen_compile_db.py
 	  ARGS -b ${CMAKE_CURRENT_BINARY_DIR} -s ${CMAKE_CURRENT_SOURCE_DIR} -o ${CMAKE_CURRENT_SOURCE_DIR}/compile_commands.json ${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json
-	  DEPENDS contrib/gen_compile_db.py ${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json
+	  DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/contrib/gen_compile_db.py ${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json
 	  COMMENT "Build compile commands for IDE"
 	)
   add_custom_target(processed_compile_commands ALL DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/compile_commands.json ${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json)


### PR DESCRIPTION
Hi :wave: 

Maybe I'm missing something, but since #5162 by @ammolitor, I cannot generate the `compile_commands.json`.

```bash
/tmp
❯ git clone git@github.com:apple/foundationdb.git fdb-src

/tmp
❯ mkdir fdb_build && cd fdb_build

/tmp/fdb_build 
❯ cmake -G Ninja -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ../fdb-src

/tmp/fdb_build
❯ ninja -j1
[1/922] Build compile commands for IDE
FAILED: /tmp/fdb-src/compile_commands.json 
cd /tmp/fdb_build && /usr/host/bin/python3.9 contrib/gen_compile_db.py -b /tmp/fdb_build -s /tmp/fdb-src -o /tmp/fdb-src/compile_commands.json /tmp/fdb_build/compile_commands.json
/usr/host/bin/python3.9: can't open file '/tmp/fdb_build/contrib/gen_compile_db.py': [Errno 2] No such file or directory
ninja: build stopped: subcommand failed.
```

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
