### PR TITLE
version vector / Proxy changes- wait for previous commit before responding to client

### DIFF
--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -38,6 +38,7 @@ void ServerKnobs::initialize(Randomize _randomize, ClientKnobs* clientKnobs, IsS
 	init( MAX_WRITE_TRANSACTION_LIFE_VERSIONS,     5 * VERSIONS_PER_SECOND ); if (randomize && BUGGIFY) MAX_WRITE_TRANSACTION_LIFE_VERSIONS=std::max<int>(1, 1 * VERSIONS_PER_SECOND);
 	init( MAX_COMMIT_BATCH_INTERVAL,                             2.0 ); if( randomize && BUGGIFY ) MAX_COMMIT_BATCH_INTERVAL = 0.5; // Each commit proxy generates a CommitTransactionBatchRequest at least this often, so that versions always advance smoothly
 	MAX_COMMIT_BATCH_INTERVAL = std::min(MAX_COMMIT_BATCH_INTERVAL, MAX_READ_TRANSACTION_LIFE_VERSIONS/double(2*VERSIONS_PER_SECOND)); // Ensure that the proxy commits 2 times every MAX_READ_TRANSACTION_LIFE_VERSIONS, otherwise the master will not give out versions fast enough
+	init( ENABLE_VERSION_VECTOR,                                true );
 
 	// TLogs
 	init( TLOG_TIMEOUT,                                          0.4 ); //cannot buggify because of availability

--- a/fdbclient/ServerKnobs.h
+++ b/fdbclient/ServerKnobs.h
@@ -36,6 +36,7 @@ public:
 	int64_t MAX_VERSIONS_IN_FLIGHT_FORCED;
 	int64_t MAX_READ_TRANSACTION_LIFE_VERSIONS;
 	int64_t MAX_WRITE_TRANSACTION_LIFE_VERSIONS;
+	bool ENABLE_VERSION_VECTOR;
 	double MAX_COMMIT_BATCH_INTERVAL; // Each commit proxy generates a CommitTransactionBatchRequest at least this
 	                                  // often, so that versions always advance smoothly
 

--- a/fdbclient/VersionVector.h
+++ b/fdbclient/VersionVector.h
@@ -43,6 +43,14 @@ struct VersionVector {
 		maxVersion = version;
 	}
 
+	void setVersions(const std::set<Tag>& tags, Version version) {
+		ASSERT(version > maxVersion);
+		for (auto& tag : tags) {
+			ASSERT(tag != invalidTag);
+			versions[tag] = version;
+		}
+	}
+
 	bool hasVersion(const Tag& tag) const {
 		ASSERT(tag != invalidTag);
 		return versions.find(tag) != versions.end();

--- a/fdbclient/VersionVector.h
+++ b/fdbclient/VersionVector.h
@@ -45,6 +45,7 @@ struct VersionVector {
 
 	void setVersions(const std::set<Tag>& tags, Version version) {
 		ASSERT(version > maxVersion);
+		maxVersion = version;
 		for (auto& tag : tags) {
 			ASSERT(tag != invalidTag);
 			versions[tag] = version;

--- a/fdbserver/CommitProxyServer.actor.cpp
+++ b/fdbserver/CommitProxyServer.actor.cpp
@@ -480,8 +480,8 @@ struct CommitBatchContext {
 
 	double commitStartTime;
 
-	std::set<uint16_t> locSet; // the set of tlog locations written to in the mutation.
-	std::set<Tag> tagSet; // the set of tags written to in the mutation.
+	std::set<uint16_t> writtenTLogs; // the set of tlog locations written to in the mutation.
+	std::set<Tag> writtenTags; // the set of tags written to in the mutation.
 
 	CommitBatchContext(ProxyCommitData*, const std::vector<CommitTransactionRequest>*, const int);
 
@@ -880,7 +880,7 @@ ACTOR Future<Void> applyMetadataToCommittedTransactions(CommitBatchContext* self
 ACTOR Future<Void> getTPCV(CommitBatchContext* self) {
 	state ProxyCommitData* const pProxyCommitData = self->pProxyCommitData;
 	GetTlogPrevCommitVersionReply rep = wait(brokenPromiseToNever(
-	    pProxyCommitData->master.getTlogPrevCommitVersion.getReply(GetTlogPrevCommitVersionRequest(self->locSet))));
+	    pProxyCommitData->master.getTlogPrevCommitVersion.getReply(GetTlogPrevCommitVersionRequest(self->writtenTLogs))));
 	// TraceEvent("GetTlogPrevCommitVersionRequest");
 	return Void();
 }
@@ -961,9 +961,9 @@ ACTOR Future<Void> assignMutationsToStorageServers(CommitBatchContext* self) {
 				if (pProxyCommitData->cacheInfo[m.param1]) {
 					self->toCommit.addTag(cacheTag);
 				}
-				self->toCommit.saveTags(self->tagSet);
+				self->toCommit.saveTags(self->writtenTags);
 				self->toCommit.writeTypedMessage(m);
-				self->toCommit.saveLocations(self->locSet, self->tagSet);
+				self->toCommit.saveLocations(self->writtenTLogs);
 			} else if (m.type == MutationRef::ClearRange) {
 				KeyRangeRef clearRange(KeyRangeRef(m.param1, m.param2));
 				auto ranges = pProxyCommitData->keyInfo.intersectingRanges(clearRange);
@@ -1019,9 +1019,9 @@ ACTOR Future<Void> assignMutationsToStorageServers(CommitBatchContext* self) {
 				if (pProxyCommitData->needsCacheTag(clearRange)) {
 					self->toCommit.addTag(cacheTag);
 				}
-				self->toCommit.saveTags(self->tagSet);
+				self->toCommit.saveTags(self->writtenTags);
 				self->toCommit.writeTypedMessage(m);
-				self->toCommit.saveLocations(self->locSet, self->tagSet);
+				self->toCommit.saveLocations(self->writtenTLogs);
 			} else {
 				UNREACHABLE();
 			}
@@ -1298,16 +1298,16 @@ ACTOR Future<Void> reply(CommitBatchContext* self) {
 	// self->committedVersion.
 	TEST(pProxyCommitData->committedVersion.get() > self->commitVersion); // A later version was reported committed first
 	if (self->commitVersion >= pProxyCommitData->committedVersion.get()) {
-		state Optional<std::set<Tag>> tagSet;
+		state Optional<std::set<Tag>> writtenTags;
 		if (SERVER_KNOBS->ENABLE_VERSION_VECTOR) {
-			tagSet = self->tagSet;
+			writtenTags = self->writtenTags;
 		}
 		wait(pProxyCommitData->master.reportLiveCommittedVersion.getReply(
 		    ReportRawCommittedVersionRequest(self->commitVersion,
 		                                     self->lockedAfter,
 		                                     self->metadataVersionAfter,
 		                                     pProxyCommitData->minKnownCommittedVersion,
-		                                     tagSet),
+		                                     writtenTags),
 		    TaskPriority::ProxyMasterVersionReply));
 	}
 	if (self->commitVersion > pProxyCommitData->committedVersion.get()) {

--- a/fdbserver/CommitProxyServer.actor.cpp
+++ b/fdbserver/CommitProxyServer.actor.cpp
@@ -480,6 +480,9 @@ struct CommitBatchContext {
 
 	double commitStartTime;
 
+	std::set<uint16_t> locSet; // the set of tlog locations written to in the mutation.
+	std::set<Tag> tagSet; // the set of tags written to in the mutation.
+
 	CommitBatchContext(ProxyCommitData*, const std::vector<CommitTransactionRequest>*, const int);
 
 	void setupTraceBatch();
@@ -873,6 +876,15 @@ ACTOR Future<Void> applyMetadataToCommittedTransactions(CommitBatchContext* self
 	return Void();
 }
 
+// Message the sequencer to obtain the previous commit version for each storage server's tag
+ACTOR Future<Void> getTPCV(CommitBatchContext* self) {
+	state ProxyCommitData* const pProxyCommitData = self->pProxyCommitData;
+	GetTlogPrevCommitVersionReply rep = wait(brokenPromiseToNever(
+	    pProxyCommitData->master.getTlogPrevCommitVersion.getReply(GetTlogPrevCommitVersionRequest(self->locSet))));
+	// TraceEvent("GetTlogPrevCommitVersionRequest");
+	return Void();
+}
+
 /// This second pass through committed transactions assigns the actual mutations to the appropriate storage servers'
 /// tags
 ACTOR Future<Void> assignMutationsToStorageServers(CommitBatchContext* self) {
@@ -949,7 +961,9 @@ ACTOR Future<Void> assignMutationsToStorageServers(CommitBatchContext* self) {
 				if (pProxyCommitData->cacheInfo[m.param1]) {
 					self->toCommit.addTag(cacheTag);
 				}
+				self->toCommit.saveTags(self->tagSet);
 				self->toCommit.writeTypedMessage(m);
+				self->toCommit.saveLocations(self->locSet, self->tagSet);
 			} else if (m.type == MutationRef::ClearRange) {
 				KeyRangeRef clearRange(KeyRangeRef(m.param1, m.param2));
 				auto ranges = pProxyCommitData->keyInfo.intersectingRanges(clearRange);
@@ -999,14 +1013,15 @@ ACTOR Future<Void> assignMutationsToStorageServers(CommitBatchContext* self) {
 					    .detail("Dbgid", pProxyCommitData->dbgid)
 					    .detail("To", allSources)
 					    .detail("Mutation", m);
-
 					self->toCommit.addTags(allSources);
 				}
 
 				if (pProxyCommitData->needsCacheTag(clearRange)) {
 					self->toCommit.addTag(cacheTag);
 				}
+				self->toCommit.saveTags(self->tagSet);
 				self->toCommit.writeTypedMessage(m);
+				self->toCommit.saveLocations(self->locSet, self->tagSet);
 			} else {
 				UNREACHABLE();
 			}
@@ -1095,6 +1110,11 @@ ACTOR Future<Void> postResolution(CommitBatchContext* self) {
 
 	// Second pass
 	wait(assignMutationsToStorageServers(self));
+
+	// Obtain previous committed versions for each affected tlog from sequencer
+	if (SERVER_KNOBS->ENABLE_VERSION_VECTOR) {
+		wait(getTPCV(self));
+	}
 
 	// Serialize and backup the mutations as a single mutation
 	if ((pProxyCommitData->vecBackupKeys.size() > 1) && self->logRangeMutations.size()) {
@@ -1278,11 +1298,16 @@ ACTOR Future<Void> reply(CommitBatchContext* self) {
 	// self->committedVersion.
 	TEST(pProxyCommitData->committedVersion.get() > self->commitVersion); // A later version was reported committed first
 	if (self->commitVersion >= pProxyCommitData->committedVersion.get()) {
+		state Optional<std::set<Tag>> tagSet;
+		if (SERVER_KNOBS->ENABLE_VERSION_VECTOR) {
+			tagSet = self->tagSet;
+		}
 		wait(pProxyCommitData->master.reportLiveCommittedVersion.getReply(
 		    ReportRawCommittedVersionRequest(self->commitVersion,
 		                                     self->lockedAfter,
 		                                     self->metadataVersionAfter,
-		                                     pProxyCommitData->minKnownCommittedVersion),
+		                                     pProxyCommitData->minKnownCommittedVersion,
+		                                     tagSet),
 		    TaskPriority::ProxyMasterVersionReply));
 	}
 	if (self->commitVersion > pProxyCommitData->committedVersion.get()) {

--- a/fdbserver/LogSystem.h
+++ b/fdbserver/LogSystem.h
@@ -995,6 +995,22 @@ struct LogPushData : NonCopyable {
 		writtenLocations.clear();
 	}
 
+	// copy next_message_tags into given set
+	void saveTags(std::set<Tag>& tagSet) {
+		tagSet.insert(next_message_tags.begin(), next_message_tags.end());
+		return;
+	}
+
+	// store tlogs as represented by index
+	// also store in tag set all replicas
+	void saveLocations(std::set<uint16_t>& locSet, std::set<Tag>& tagSet) {
+		locSet.insert(msg_locations.begin(), msg_locations.end());
+		for (auto loc: msg_locations) {
+			tagSet.insert(Tag(0, loc));  // TODO POST DEMO support DC other than primary
+		}
+		return;
+	}
+
 	void writeMessage(StringRef rawMessageWithoutLength, bool usePreviousLocations) {
 		if (!usePreviousLocations) {
 			prev_tags.clear();

--- a/fdbserver/LogSystem.h
+++ b/fdbserver/LogSystem.h
@@ -738,7 +738,8 @@ struct ILogSystem {
 	                             Version minKnownCommittedVersion,
 	                             struct LogPushData& data,
 	                             SpanID const& spanContext,
-	                             Optional<UID> debugID = Optional<UID>()) = 0;
+	                             Optional<UID> debugID = Optional<UID>(),
+								 Optional<std::unordered_map<uint16_t, Version>> tpcvMap = Optional<std::unordered_map<uint16_t, Version>>()) = 0;
 	// Waits for the version number of the bundle (in this epoch) to be prevVersion (i.e. for all pushes ordered
 	// earlier) Puts the given messages into the bundle, each with the given tags, and with message versions (version,
 	// 0) - (version, N) Changes the version number of the bundle to be version (unblocking the next push) Returns when

--- a/fdbserver/LogSystem.h
+++ b/fdbserver/LogSystem.h
@@ -996,19 +996,13 @@ struct LogPushData : NonCopyable {
 	}
 
 	// copy next_message_tags into given set
-	void saveTags(std::set<Tag>& tagSet) {
-		tagSet.insert(next_message_tags.begin(), next_message_tags.end());
-		return;
+	void saveTags(std::set<Tag>& writtenTags) {
+		writtenTags.insert(next_message_tags.begin(), next_message_tags.end());
 	}
 
 	// store tlogs as represented by index
-	// also store in tag set all replicas
-	void saveLocations(std::set<uint16_t>& locSet, std::set<Tag>& tagSet) {
-		locSet.insert(msg_locations.begin(), msg_locations.end());
-		for (auto loc: msg_locations) {
-			tagSet.insert(Tag(0, loc));  // TODO POST DEMO support DC other than primary
-		}
-		return;
+	void saveLocations(std::set<uint16_t>& writtenTLogs) {
+		writtenTLogs.insert(msg_locations.begin(), msg_locations.end());
 	}
 
 	void writeMessage(StringRef rawMessageWithoutLength, bool usePreviousLocations) {

--- a/fdbserver/MasterInterface.h
+++ b/fdbserver/MasterInterface.h
@@ -201,13 +201,13 @@ struct GetTlogPrevCommitVersionReply {
 
 struct GetTlogPrevCommitVersionRequest {
 	constexpr static FileIdentifier file_identifier = 16683184;
-	std::set<uint16_t> locSet;
+	std::set<uint16_t> writtenTLogs;
 	ReplyPromise<GetTlogPrevCommitVersionReply> reply;
 	GetTlogPrevCommitVersionRequest() {}
-	GetTlogPrevCommitVersionRequest(std::set<uint16_t>& locSet) : locSet(locSet) {}
+	GetTlogPrevCommitVersionRequest(std::set<uint16_t>& writtenTLogs) : writtenTLogs(writtenTLogs) {}
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, locSet, reply);
+		serializer(ar, writtenTLogs, reply);
 	}
 };
 
@@ -217,7 +217,7 @@ struct ReportRawCommittedVersionRequest {
 	bool locked;
 	Optional<Value> metadataVersion;
 	Version minKnownCommittedVersion;
-	Optional<std::set<Tag>> tagSet;
+	Optional<std::set<Tag>> writtenTags;
 	ReplyPromise<Void> reply;
 
 	ReportRawCommittedVersionRequest() : version(invalidVersion), locked(false), minKnownCommittedVersion(0) {}
@@ -225,13 +225,13 @@ struct ReportRawCommittedVersionRequest {
 	                                 bool locked,
 	                                 Optional<Value> metadataVersion,
 	                                 Version minKnownCommittedVersion,
-	                                 Optional<std::set<Tag>> tagSet = Optional<std::set<Tag>>())
+	                                 Optional<std::set<Tag>> writtenTags = Optional<std::set<Tag>>())
 	  : version(version), locked(locked), metadataVersion(metadataVersion),
-	    minKnownCommittedVersion(minKnownCommittedVersion), tagSet(tagSet) {}
+	    minKnownCommittedVersion(minKnownCommittedVersion), writtenTags(writtenTags) {}
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, version, locked, metadataVersion, minKnownCommittedVersion, tagSet, reply);
+		serializer(ar, version, locked, metadataVersion, minKnownCommittedVersion, writtenTags, reply);
 	}
 };
 

--- a/fdbserver/MasterInterface.h
+++ b/fdbserver/MasterInterface.h
@@ -202,12 +202,13 @@ struct GetTlogPrevCommitVersionReply {
 struct GetTlogPrevCommitVersionRequest {
 	constexpr static FileIdentifier file_identifier = 16683184;
 	std::set<uint16_t> writtenTLogs;
+	Version commitVersion;
 	ReplyPromise<GetTlogPrevCommitVersionReply> reply;
 	GetTlogPrevCommitVersionRequest() {}
-	GetTlogPrevCommitVersionRequest(std::set<uint16_t>& writtenTLogs) : writtenTLogs(writtenTLogs) {}
+	GetTlogPrevCommitVersionRequest(std::set<uint16_t>& writtenTLogs, Version commitVersion) : writtenTLogs(writtenTLogs), commitVersion(commitVersion) {}
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, writtenTLogs, reply);
+		serializer(ar, writtenTLogs, commitVersion, reply);
 	}
 };
 
@@ -218,6 +219,7 @@ struct ReportRawCommittedVersionRequest {
 	Optional<Value> metadataVersion;
 	Version minKnownCommittedVersion;
 	Optional<std::set<Tag>> writtenTags;
+	Optional<Version> prevVersion; // if present, wait for prevVersion to be committed before replying
 	ReplyPromise<Void> reply;
 
 	ReportRawCommittedVersionRequest() : version(invalidVersion), locked(false), minKnownCommittedVersion(0) {}
@@ -225,13 +227,14 @@ struct ReportRawCommittedVersionRequest {
 	                                 bool locked,
 	                                 Optional<Value> metadataVersion,
 	                                 Version minKnownCommittedVersion,
+	                                 Optional<Version> prevVersion,
 	                                 Optional<std::set<Tag>> writtenTags = Optional<std::set<Tag>>())
 	  : version(version), locked(locked), metadataVersion(metadataVersion),
-	    minKnownCommittedVersion(minKnownCommittedVersion), writtenTags(writtenTags) {}
+	    minKnownCommittedVersion(minKnownCommittedVersion), writtenTags(writtenTags), prevVersion(prevVersion) {}
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, version, locked, metadataVersion, minKnownCommittedVersion, writtenTags, reply);
+		serializer(ar, version, locked, metadataVersion, minKnownCommittedVersion, writtenTags, prevVersion, reply);
 	}
 };
 

--- a/fdbserver/masterserver.actor.cpp
+++ b/fdbserver/masterserver.actor.cpp
@@ -250,6 +250,9 @@ struct MasterData : NonCopyable, ReferenceCounted<MasterData> {
 	// Captures the latest commit version targeted for each storage server in the cluster.
 	VersionVector ssVersionVector;
 
+	// The previous commit versions per tlog
+	std::map<uint16_t, Version> tpcvMap;
+
 	CounterCollection cc;
 	Counter changeCoordinatorsRequests;
 	Counter getCommitVersionRequests;
@@ -299,8 +302,8 @@ ACTOR Future<Void> newCommitProxies(Reference<MasterData> self, RecruitFromConfi
 		req.recoveryTransactionVersion = self->recoveryTransactionVersion;
 		req.firstProxy = i == 0;
 		TraceEvent("CommitProxyReplies", self->dbgid)
-			.detail("WorkerID", recr.commitProxies[i].id())
-			.detail("FirstProxy", req.firstProxy ? "True" : "False");
+		    .detail("WorkerID", recr.commitProxies[i].id())
+		    .detail("FirstProxy", req.firstProxy ? "True" : "False");
 		initializationReplies.push_back(
 		    transformErrors(throwErrorOr(recr.commitProxies[i].commitProxy.getReplyUnlessFailedFor(
 		                        req, SERVER_KNOBS->TLOG_TIMEOUT, SERVER_KNOBS->MASTER_FAILURE_SLOPE_DURING_RECOVERY)),
@@ -960,9 +963,9 @@ ACTOR Future<Void> sendInitialCommitToResolvers(Reference<MasterData> self) {
 	}
 	wait(waitForAll(txnReplies));
 	TraceEvent("RecoveryInternal", self->dbgid)
-		.detail("StatusCode", RecoveryStatus::recovery_transaction)
-		.detail("Status", RecoveryStatus::names[RecoveryStatus::recovery_transaction])
-		.detail("Step", "SentTxnStateStoreToCommitProxies");
+	    .detail("StatusCode", RecoveryStatus::recovery_transaction)
+	    .detail("Status", RecoveryStatus::names[RecoveryStatus::recovery_transaction])
+	    .detail("Step", "SentTxnStateStoreToCommitProxies");
 
 	vector<Future<ResolveTransactionBatchReply>> replies;
 	for (auto& r : self->resolvers) {
@@ -976,9 +979,9 @@ ACTOR Future<Void> sendInitialCommitToResolvers(Reference<MasterData> self) {
 
 	wait(waitForAll(replies));
 	TraceEvent("RecoveryInternal", self->dbgid)
-		.detail("StatusCode", RecoveryStatus::recovery_transaction)
-		.detail("Status", RecoveryStatus::names[RecoveryStatus::recovery_transaction])
-		.detail("Step", "InitializedAllResolvers");
+	    .detail("StatusCode", RecoveryStatus::recovery_transaction)
+	    .detail("Status", RecoveryStatus::names[RecoveryStatus::recovery_transaction])
+	    .detail("Step", "InitializedAllResolvers");
 	return Void();
 }
 
@@ -1243,6 +1246,12 @@ ACTOR Future<Void> serveLiveCommittedVersion(Reference<MasterData> self) {
 			when(ReportRawCommittedVersionRequest req =
 			         waitNext(self->myInterface.reportLiveCommittedVersion.getFuture())) {
 				self->minKnownCommittedVersion = std::max(self->minKnownCommittedVersion, req.minKnownCommittedVersion);
+				if (SERVER_KNOBS->ENABLE_VERSION_VECTOR && req.tagSet.present()) {
+					if (req.version > self->ssVersionVector.maxVersion) {
+						// TraceEvent("Received ReportRawCommittedVersionRequest").detail("Version",req.version);
+						self->ssVersionVector.setVersions(req.tagSet.get(), req.version);
+					}
+				}
 				if (req.version > self->liveCommittedVersion) {
 					self->liveCommittedVersion = req.version;
 					self->databaseLocked = req.locked;
@@ -1250,6 +1259,17 @@ ACTOR Future<Void> serveLiveCommittedVersion(Reference<MasterData> self) {
 				}
 				++self->reportLiveCommittedVersionRequests;
 				req.reply.send(Void());
+			}
+			when(GetTlogPrevCommitVersionRequest req =
+			         waitNext(self->myInterface.getTlogPrevCommitVersion.getFuture())) {
+				GetTlogPrevCommitVersionReply reply;
+				for (uint16_t loc : req.locSet) {
+					// TraceEvent("Received GetTlogPrevCommitVersionRequest").detail("Loc", loc);
+					if (self->tpcvMap.find(loc) != self->tpcvMap.end()) {
+						reply.tpcvMap[loc] = self->tpcvMap[loc];
+					}
+				}
+				req.reply.send(reply);
 			}
 		}
 	}

--- a/fdbserver/masterserver.actor.cpp
+++ b/fdbserver/masterserver.actor.cpp
@@ -1246,10 +1246,10 @@ ACTOR Future<Void> serveLiveCommittedVersion(Reference<MasterData> self) {
 			when(ReportRawCommittedVersionRequest req =
 			         waitNext(self->myInterface.reportLiveCommittedVersion.getFuture())) {
 				self->minKnownCommittedVersion = std::max(self->minKnownCommittedVersion, req.minKnownCommittedVersion);
-				if (SERVER_KNOBS->ENABLE_VERSION_VECTOR && req.tagSet.present()) {
+				if (SERVER_KNOBS->ENABLE_VERSION_VECTOR && req.writtenTags.present()) {
 					if (req.version > self->ssVersionVector.maxVersion) {
 						// TraceEvent("Received ReportRawCommittedVersionRequest").detail("Version",req.version);
-						self->ssVersionVector.setVersions(req.tagSet.get(), req.version);
+						self->ssVersionVector.setVersions(req.writtenTags.get(), req.version);
 					}
 				}
 				if (req.version > self->liveCommittedVersion) {
@@ -1263,10 +1263,10 @@ ACTOR Future<Void> serveLiveCommittedVersion(Reference<MasterData> self) {
 			when(GetTlogPrevCommitVersionRequest req =
 			         waitNext(self->myInterface.getTlogPrevCommitVersion.getFuture())) {
 				GetTlogPrevCommitVersionReply reply;
-				for (uint16_t loc : req.locSet) {
+				for (uint16_t tLog : req.writtenTLogs) {
 					// TraceEvent("Received GetTlogPrevCommitVersionRequest").detail("Loc", loc);
-					if (self->tpcvMap.find(loc) != self->tpcvMap.end()) {
-						reply.tpcvMap[loc] = self->tpcvMap[loc];
+					if (self->tpcvMap.find(tLog) != self->tpcvMap.end()) {
+						reply.tpcvMap[tLog] = self->tpcvMap[tLog];
 					}
 				}
 				req.reply.send(reply);

--- a/fdbserver/masterserver.actor.cpp
+++ b/fdbserver/masterserver.actor.cpp
@@ -183,7 +183,7 @@ struct MasterData : NonCopyable, ReferenceCounted<MasterData> {
 	    recoveryTransactionVersion; // The first version in this epoch
 	double lastCommitTime;
 
-	Version liveCommittedVersion; // The largest live committed version reported by commit proxies.
+	NotifiedVersion liveCommittedVersion; // The largest live committed version reported by commit proxies.
 	bool databaseLocked;
 	Optional<Value> proxyMetadataVersion;
 	Version minKnownCommittedVersion;
@@ -1222,6 +1222,43 @@ ACTOR Future<Void> provideVersions(Reference<MasterData> self) {
 	}
 }
 
+void updateLiveCommittedVersion(Reference<MasterData> self, ReportRawCommittedVersionRequest req) {
+	self->minKnownCommittedVersion = std::max(self->minKnownCommittedVersion, req.minKnownCommittedVersion);
+	if (req.version > self->liveCommittedVersion.get()) {
+		self->databaseLocked = req.locked;
+		self->proxyMetadataVersion = req.metadataVersion;
+		// Note the set call switches context to any waiters on liveCommittedVersion before continuing.
+		self->liveCommittedVersion.set(req.version);
+	}
+	++self->reportLiveCommittedVersionRequests;
+}
+
+ACTOR Future<Void> waitForTLogPrev(Reference<MasterData> self, GetTlogPrevCommitVersionRequest req) {
+	state Version maxVersion = invalidVersion;
+	for (uint16_t tLog : req.writtenTLogs) {
+		if (self->tpcvMap.find(tLog) != self->tpcvMap.end()) {
+			maxVersion=std::max<Version>(maxVersion, self->tpcvMap[tLog]);
+		}
+	}
+	// TraceEvent("waitForTLogPrev").detail("maxVersion",maxVersion).detail("req.commitVersion",req.commitVersion).detail("liveCommittedVersion",self->liveCommittedVersion.get());
+	if (req.commitVersion > maxVersion) {
+		wait(self->liveCommittedVersion.whenAtLeast(maxVersion));
+	}
+	GetTlogPrevCommitVersionReply reply;
+	for (uint16_t tLog : req.writtenTLogs) {
+		self->tpcvMap[tLog] = reply.tpcvMap[tLog] = req.commitVersion;
+	}
+	req.reply.send(reply);
+	return Void();
+}
+
+ACTOR Future<Void> waitForPrev(Reference<MasterData> self, ReportRawCommittedVersionRequest req) {
+	wait(self->liveCommittedVersion.whenAtLeast(req.prevVersion.get()));
+	updateLiveCommittedVersion(self, req);
+	req.reply.send(Void());
+	return Void();
+}
+
 ACTOR Future<Void> serveLiveCommittedVersion(Reference<MasterData> self) {
 	loop {
 		choose {
@@ -1231,12 +1268,12 @@ ACTOR Future<Void> serveLiveCommittedVersion(Reference<MasterData> self) {
 					                      req.debugID.get().first(),
 					                      "MasterServer.serveLiveCommittedVersion.GetRawCommittedVersion");
 
-				if (self->liveCommittedVersion == invalidVersion) {
-					self->liveCommittedVersion = self->recoveryTransactionVersion;
+				if (self->liveCommittedVersion.get() == invalidVersion) {
+					self->liveCommittedVersion.set(self->recoveryTransactionVersion);
 				}
 				++self->getLiveCommittedVersionRequests;
 				GetRawCommittedVersionReply reply;
-				reply.version = self->liveCommittedVersion;
+				reply.version = self->liveCommittedVersion.get();
 				reply.locked = self->databaseLocked;
 				reply.metadataVersion = self->proxyMetadataVersion;
 				reply.minKnownCommittedVersion = self->minKnownCommittedVersion;
@@ -1245,31 +1282,23 @@ ACTOR Future<Void> serveLiveCommittedVersion(Reference<MasterData> self) {
 			}
 			when(ReportRawCommittedVersionRequest req =
 			         waitNext(self->myInterface.reportLiveCommittedVersion.getFuture())) {
-				self->minKnownCommittedVersion = std::max(self->minKnownCommittedVersion, req.minKnownCommittedVersion);
+				// TraceEvent("ReportRawCommittedVersionRequest").detail("req.version",req.version).detail("liveComittedVersion",self->liveCommittedVersion.get()).detail("prevVersion",req.prevVersion.get());
+				if (SERVER_KNOBS->ENABLE_VERSION_VECTOR && req.prevVersion.present() && (self->liveCommittedVersion.get() != invalidVersion) &&
+					(self->liveCommittedVersion.get() < req.prevVersion.get())) {
+					self->addActor.send(waitForPrev(self, req));
+				} else {
+					updateLiveCommittedVersion(self, req);
+					req.reply.send(Void());
+				}
 				if (SERVER_KNOBS->ENABLE_VERSION_VECTOR && req.writtenTags.present()) {
 					if (req.version > self->ssVersionVector.maxVersion) {
-						// TraceEvent("Received ReportRawCommittedVersionRequest").detail("Version",req.version);
 						self->ssVersionVector.setVersions(req.writtenTags.get(), req.version);
 					}
 				}
-				if (req.version > self->liveCommittedVersion) {
-					self->liveCommittedVersion = req.version;
-					self->databaseLocked = req.locked;
-					self->proxyMetadataVersion = req.metadataVersion;
-				}
-				++self->reportLiveCommittedVersionRequests;
-				req.reply.send(Void());
 			}
 			when(GetTlogPrevCommitVersionRequest req =
 			         waitNext(self->myInterface.getTlogPrevCommitVersion.getFuture())) {
-				GetTlogPrevCommitVersionReply reply;
-				for (uint16_t tLog : req.writtenTLogs) {
-					// TraceEvent("Received GetTlogPrevCommitVersionRequest").detail("Loc", loc);
-					if (self->tpcvMap.find(tLog) != self->tpcvMap.end()) {
-						reply.tpcvMap[tLog] = self->tpcvMap[tLog];
-					}
-				}
-				req.reply.send(reply);
+				self->addActor.send(waitForTLogPrev(self, req));
 			}
 		}
 	}

--- a/flow/network.h
+++ b/flow/network.h
@@ -81,6 +81,7 @@ enum class TaskPriority {
 	GetConsistentReadVersion = 8500,
 	GetLiveCommittedVersionReply = 8490,
 	GetLiveCommittedVersion = 8480,
+	GetTlogPrevCommitVersion = 8400,
 	DefaultPromiseEndpoint = 8000,
 	DefaultOnMainThread = 7500,
 	DefaultDelay = 7010,


### PR DESCRIPTION
Posting for discussion only, *not ready for review.*
 
- wait for previous transaction to commit before returning commit to client or processing
- scaffolding to send tpcv vector entry to tlog , and do not send empty messages to tlogs

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
