### PR TITLE
Make fdbmonitor IDs unique per section rather than globally unique

### DIFF
--- a/fdbmonitor/fdbmonitor.cpp
+++ b/fdbmonitor/fdbmonitor.cpp
@@ -137,6 +137,8 @@ int severity_to_priority(Severity severity) {
 	}
 }
 
+typedef std::string ProcessID;
+
 bool daemonize = false;
 std::string logGroup = "default";
 
@@ -390,11 +392,11 @@ public:
 	int pipes[2][2];
 
 	Command() : argv(nullptr) {}
-	Command(const CSimpleIni& ini, std::string _section, uint64_t id, fdb_fd_set fds, int* maxfd)
+	Command(const CSimpleIni& ini, std::string _section, ProcessID id, fdb_fd_set fds, int* maxfd)
 	  : section(_section), argv(nullptr), fork_retry_time(-1), quiet(false), delete_envvars(nullptr), fds(fds),
 	    deconfigured(false), kill_on_configuration_change(true) {
 		char _ssection[strlen(section.c_str()) + 22];
-		snprintf(_ssection, strlen(section.c_str()) + 22, "%s.%" PRIu64, section.c_str(), id);
+		snprintf(_ssection, strlen(section.c_str()) + 22, "%s", id.c_str());
 		ssection = _ssection;
 
 		for (auto p : pipes) {
@@ -593,9 +595,9 @@ public:
 	}
 };
 
-std::unordered_map<uint64_t, std::unique_ptr<Command>> id_command;
-std::unordered_map<pid_t, uint64_t> pid_id;
-std::unordered_map<uint64_t, pid_t> id_pid;
+std::unordered_map<ProcessID, std::unique_ptr<Command>> id_command;
+std::unordered_map<pid_t, ProcessID> pid_id;
+std::unordered_map<ProcessID, pid_t> id_pid;
 
 enum { OPT_CONFFILE, OPT_LOCKFILE, OPT_LOGGROUP, OPT_DAEMONIZE, OPT_HELP };
 
@@ -608,7 +610,7 @@ CSimpleOpt::SOption g_rgOptions[] = { { OPT_CONFFILE, "--conffile", SO_REQ_SEP }
 	                                  { OPT_HELP, "--help", SO_NONE },
 	                                  SO_END_OF_OPTIONS };
 
-void start_process(Command* cmd, uint64_t id, uid_t uid, gid_t gid, int delay, sigset_t* mask) {
+void start_process(Command* cmd, ProcessID id, uid_t uid, gid_t gid, int delay, sigset_t* mask) {
 	if (!cmd->argv)
 		return;
 
@@ -758,7 +760,7 @@ bool argv_equal(const char** a1, const char** a2) {
 	return true;
 }
 
-void kill_process(uint64_t id, bool wait = true) {
+void kill_process(ProcessID id, bool wait = true) {
 	pid_t pid = id_pid[id];
 
 	log_msg(SevInfo, "Killing process %d\n", pid);
@@ -815,7 +817,7 @@ void load_conf(const char* confpath, uid_t& uid, gid_t& gid, sigset_t* mask, fdb
 
 		/* Any change to uid or gid requires the process to be restarted to take effect */
 		if (uid != _uid || gid != _gid) {
-			std::vector<uint64_t> kill_ids;
+			std::vector<ProcessID> kill_ids;
 			for (auto i : id_pid) {
 				if (id_command[i.first]->kill_on_configuration_change) {
 					kill_ids.push_back(i.first);
@@ -831,8 +833,8 @@ void load_conf(const char* confpath, uid_t& uid, gid_t& gid, sigset_t* mask, fdb
 		gid = _gid;
 	}
 
-	std::list<uint64_t> kill_ids;
-	std::list<std::pair<uint64_t, Command*>> start_ids;
+	std::list<ProcessID> kill_ids;
+	std::list<std::pair<ProcessID, Command*>> start_ids;
 
 	for (auto i : id_pid) {
 		if (!loadedConf || ini.GetSectionSize(id_command[i.first]->ssection.c_str()) == -1) {
@@ -881,31 +883,24 @@ void load_conf(const char* confpath, uid_t& uid, gid_t& gid, sigset_t* mask, fdb
 		ini.GetAllSections(sections);
 		for (auto i : sections) {
 			if (auto dot = strrchr(i.pItem, '.')) {
-				char* strtol_end;
+				ProcessID id = i.pItem;
+				if (!id_pid.count(id)) {
+					/* Found something we haven't yet started */
+					Command* cmd;
 
-				uint64_t id = strtoull(dot + 1, &strtol_end, 10);
+					auto itr = id_command.find(id);
+					if (itr != id_command.end()) {
+						cmd = itr->second.get();
+					} else {
+						std::string section(i.pItem, dot - i.pItem);
+						auto p = std::make_unique<Command>(ini, section, id, rfds, maxfd);
+						cmd = p.get();
+						id_command[id] = std::move(p);
+					}
 
-				if (*strtol_end != '\0' || !(id > 0)) {
-					log_msg(SevError, "Found bogus id in %s\n", i.pItem);
-				} else {
-					if (!id_pid.count(id)) {
-						/* Found something we haven't yet started */
-						Command* cmd;
-
-						auto itr = id_command.find(id);
-						if (itr != id_command.end()) {
-							cmd = itr->second.get();
-						} else {
-							std::string section(i.pItem, dot - i.pItem);
-							auto p = std::make_unique<Command>(ini, section, id, rfds, maxfd);
-							cmd = p.get();
-							id_command[id] = std::move(p);
-						}
-
-						if (cmd->fork_retry_time <= timer()) {
-							log_msg(SevInfo, "Starting %s\n", i.pItem);
-							start_process(cmd, id, uid, gid, 0, mask);
-						}
+					if (cmd->fork_retry_time <= timer()) {
+						log_msg(SevInfo, "Starting %s\n", i.pItem);
+						start_process(cmd, id, uid, gid, 0, mask);
 					}
 				}
 			}
@@ -1724,7 +1719,7 @@ int main(int argc, char** argv) {
 					break;
 				}
 
-				uint64_t id = pid_id[pid];
+				ProcessID id = pid_id[pid];
 				Command* cmd = id_command[id].get();
 
 				pid_id.erase(pid);


### PR DESCRIPTION
Resolves #5172

Fdbmonitor had a bug where it would silently fail to start processes that have the same ID, which is possible if you configure something like:

```
[sectionA.1]

...

[sectionB.1]
```

I'm guessing this was mostly not an experienced issue because fdbserver used port numbers as IDs and we generally only ran backup agents as the second binary starting from ID 1, resulting in no collisions.

This change updates it so that IDs are instead section unique.

Tested by manually creating conf files and observing the results.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
