### PR TITLE
Fix invalid read in TagPartitionedLogSystem

### DIFF
--- a/fdbserver/TagPartitionedLogSystem.actor.cpp
+++ b/fdbserver/TagPartitionedLogSystem.actor.cpp
@@ -1529,11 +1529,12 @@ struct TagPartitionedLogSystem : ILogSystem, ReferenceCounted<TagPartitionedLogS
 			}
 		}
 
+		state UID dbgid = self->dbgid;
 		state Future<Void> maxGetPoppedDuration = delay(SERVER_KNOBS->TXS_POPPED_MAX_DELAY);
 		wait(waitForAll(poppedReady) || maxGetPoppedDuration);
 
 		if (maxGetPoppedDuration.isReady()) {
-			TraceEvent(SevWarnAlways, "PoppedTxsNotReady", self->dbgid);
+			TraceEvent(SevWarnAlways, "PoppedTxsNotReady", dbgid);
 		}
 
 		Version maxPopped = 1;


### PR DESCRIPTION
An invalid read was surfaced by Joshua on commit 74e1f49512016c5e613750c6a4f637ade664012d (on the `release-7.0` branch). The same bug appears to be in master.

```
valgrind --log-file=valg8.log ./bin/fdbserver -r simulation -f ../foundationdb/tests/fast/FuzzApiCorrectness.toml --seed 671659932 --buggify off
```

```
﻿==33317== Invalid read of size 8
==33317==    at 0x16C7EF6: TagPartitionedLogSystem::GetPoppedTxsActorState<TagPartitionedLogSystem::GetPoppedTxsActor>::a_body1cont1(Void const&, int) (TagPartitionedLogSystem.actor.cpp:1535)
==33317==    by 0x16BD8E2: TagPartitionedLogSystem::GetPoppedTxsActorState<TagPartitionedLogSystem::GetPoppedTxsActor>::a_body1when1(Void const&, int) (TagPartitionedLogSystem.actor.g.cpp:3182)
==33317==    by 0x16F2F2A: TagPartitionedLogSystem::GetPoppedTxsActorState<TagPartitionedLogSystem::GetPoppedTxsActor>::a_callback_fire(ActorCallback<TagPartitionedLogSystem::GetPoppedTxsActor, 0, Void
>*, Void const&) (TagPartitionedLogSystem.actor.g.cpp:3203)
==33317==    by 0x16F1070: ActorCallback<TagPartitionedLogSystem::GetPoppedTxsActor, 0, Void>::fire(Void const&) (flow.h:1077)
==33317==    by 0x43367A: SAV<Void>::finishSendAndDelPromiseRef() (flow.h:497)
==33317==    by 0x51CAF2: (anonymous namespace)::ChooseActorActorState<Void, (anonymous namespace)::ChooseActorActor<Void> >::a_body1when2(Void const&, int) (genericactors.actor.g.h:14284)
==33317==    by 0x52F89A: (anonymous namespace)::ChooseActorActorState<Void, (anonymous namespace)::ChooseActorActor<Void> >::a_callback_fire(ActorCallback<(anonymous namespace)::ChooseActorActor<Void>
, 1, Void>*, Void const&) (genericactors.actor.g.h:14358)
==33317==    by 0x52B2F4: ActorCallback<(anonymous namespace)::ChooseActorActor<Void>, 1, Void>::fire(Void const&) (flow.h:1077)
==33317==    by 0x433474: void SAV<Void>::send<Void>(Void&&) (flow.h:465)
==33317==    by 0x42A140: void Promise<Void>::send<Void>(Void&&) const (flow.h:702)
==33317==    by 0x2F01F54: Sim2::execTask(Sim2::Task&) (sim2.actor.cpp:2057)
==33317==    by 0x2F3182D: Sim2::RunLoopActorState<Sim2::RunLoopActor>::a_body1loopBody1cont1(Void const&, int) (sim2.actor.cpp:1114)
==33317==  Address 0xd410760 is 16 bytes inside a block of size 537 free'd
==33317==    at 0x5F7C40D: operator delete(void*) (vg_replace_malloc.c:586)
==33317==    by 0x44990F: __gnu_cxx::new_allocator<char>::deallocate(char*, unsigned long) (new_allocator.h:125)
==33317==    by 0x43D7D1: std::string::_Rep::_M_destroy(std::allocator<char> const&) (basic_string.tcc:899)
==33317==    by 0x3375A3F: std::basic_stringbuf<char, std::char_traits<char>, std::allocator<char> >::overflow(int) (in /mnt/ephemeral/ljoswiak/build-gcc/bin/fdbserver)
==33317==    by 0x3353EDA: std::basic_streambuf<char, std::char_traits<char> >::xsputn(char const*, long) (in /mnt/ephemeral/ljoswiak/build-gcc/bin/fdbserver)
==33317==    by 0x337F273: std::basic_ostream<char, std::char_traits<char> >& std::__ostream_insert<char, std::char_traits<char> >(std::basic_ostream<char, std::char_traits<char> >&, char const*, long)
 (in /mnt/ephemeral/ljoswiak/build-gcc/bin/fdbserver)
==33317==    by 0x30E226E: XmlTraceLogFormatter::escape(std::basic_stringstream<char, std::char_traits<char>, std::allocator<char> >&, std::string) (XmlTraceLogFormatter.cpp:75)
==33317==    by 0x30E249E: XmlTraceLogFormatter::formatEvent(TraceEventFields const&) (XmlTraceLogFormatter.cpp:85)
==33317==    by 0x30C4E6F: TraceLog::WriterThread::action(TraceLog::WriterThread::WriteBuffer&) (Trace.cpp:255)
==33317==    by 0x30D6B28: TypedAction<TraceLog::WriterThread, TraceLog::WriterThread::WriteBuffer>::operator()(IThreadPoolReceiver*) (IThreadPool.h:76)
==33317==    by 0x30C398C: DummyThreadPool::post(ThreadAction*) (IThreadPool.h:127)
==33317==    by 0x30C6A17: TraceLog::flush() (Trace.cpp:441)
==33317==  Block was alloc'd at
==33317==    at 0x5F7B483: operator new(unsigned long) (vg_replace_malloc.c:344)
==33317==    by 0x449D57: __gnu_cxx::new_allocator<char>::allocate(unsigned long, void const*) (new_allocator.h:111)
==33317==    by 0x43D985: std::string::_Rep::_S_create(unsigned long, unsigned long, std::allocator<char> const&) (basic_string.tcc:1057)
==33317==    by 0x431F6B: std::string::_Rep::_M_clone(std::allocator<char> const&, unsigned long) (basic_string.tcc:1078)
==33317==    by 0x428DF5: std::string::reserve(unsigned long) (basic_string.tcc:960)
==33317==    by 0x3375972: std::basic_stringbuf<char, std::char_traits<char>, std::allocator<char> >::overflow(int) (in /mnt/ephemeral/ljoswiak/build-gcc/bin/fdbserver)
==33317==    by 0x3353EDA: std::basic_streambuf<char, std::char_traits<char> >::xsputn(char const*, long) (in /mnt/ephemeral/ljoswiak/build-gcc/bin/fdbserver)
==33317==    by 0x337F273: std::basic_ostream<char, std::char_traits<char> >& std::__ostream_insert<char, std::char_traits<char> >(std::basic_ostream<char, std::char_traits<char> >&, char const*, long)
 (in /mnt/ephemeral/ljoswiak/build-gcc/bin/fdbserver)
==33317==    by 0x337F5E6: std::basic_ostream<char, std::char_traits<char> >& std::operator<< <std::char_traits<char> >(std::basic_ostream<char, std::char_traits<char> >&, char const*) (in /mnt/ephemer
al/ljoswiak/build-gcc/bin/fdbserver)
==33317==    by 0x30E2398: XmlTraceLogFormatter::formatEvent(TraceEventFields const&) (XmlTraceLogFormatter.cpp:80)
==33317==    by 0x30C4E6F: TraceLog::WriterThread::action(TraceLog::WriterThread::WriteBuffer&) (Trace.cpp:255)
==33317==    by 0x30D6B28: TypedAction<TraceLog::WriterThread, TraceLog::WriterThread::WriteBuffer>::operator()(IThreadPoolReceiver*) (IThreadPool.h:76)
```

Fix was proposed in ticket #5165.

I verified the fix makes the invalid read go away (for the same seed). Passed 10,000 correctness tests on Joshua.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
