### PR TITLE
version vector / maintain tLog previous commit version vector

### DIFF
--- a/fdbserver/CommitProxyServer.actor.cpp
+++ b/fdbserver/CommitProxyServer.actor.cpp
@@ -480,6 +480,7 @@ struct CommitBatchContext {
 
 	double commitStartTime;
 
+	std::unordered_map<uint16_t, Version> tpcvMap; // obtained from sequencer
 	std::set<uint16_t> writtenTLogs; // the set of tlog locations written to in the mutation.
 	std::set<Tag> writtenTags; // the set of tags written to in the mutation.
 
@@ -881,8 +882,9 @@ ACTOR Future<Void> getTPCV(CommitBatchContext* self) {
 	state ProxyCommitData* const pProxyCommitData = self->pProxyCommitData;
 	GetTLogPrevCommitVersionReply rep =
 	    wait(brokenPromiseToNever(pProxyCommitData->master.getTLogPrevCommitVersion.getReply(
-	        GetTLogPrevCommitVersionRequest(self->writtenTLogs))));
+	        GetTLogPrevCommitVersionRequest(self->writtenTLogs, self->commitVersion, self->prevVersion))));
 	// TraceEvent("GetTLogPrevCommitVersionRequest");
+	self->tpcvMap = rep.tpcvMap;
 	return Void();
 }
 
@@ -1202,13 +1204,18 @@ ACTOR Future<Void> postResolution(CommitBatchContext* self) {
 
 	self->commitStartTime = now();
 	pProxyCommitData->lastStartCommit = self->commitStartTime;
+	std::unordered_map<uint16_t, Version> tpcvMap;
+	if (SERVER_KNOBS->ENABLE_VERSION_VECTOR) {
+		tpcvMap = self->tpcvMap;
+	}
 	self->loggingComplete = pProxyCommitData->logSystem->push(self->prevVersion,
 	                                                          self->commitVersion,
 	                                                          pProxyCommitData->committedVersion.get(),
 	                                                          pProxyCommitData->minKnownCommittedVersion,
 	                                                          self->toCommit,
 	                                                          span.context,
-	                                                          self->debugID);
+	                                                          self->debugID,
+	                                                          self->tpcvMap);
 
 	if (!self->forceRecovery) {
 		ASSERT(pProxyCommitData->latestLocalCommitBatchLogging.get() == self->localBatchNumber - 1);

--- a/fdbserver/CommitProxyServer.actor.cpp
+++ b/fdbserver/CommitProxyServer.actor.cpp
@@ -879,8 +879,9 @@ ACTOR Future<Void> applyMetadataToCommittedTransactions(CommitBatchContext* self
 // Message the sequencer to obtain the previous commit version for each storage server's tag
 ACTOR Future<Void> getTPCV(CommitBatchContext* self) {
 	state ProxyCommitData* const pProxyCommitData = self->pProxyCommitData;
-	GetTLogPrevCommitVersionReply rep = wait(brokenPromiseToNever(
-	    pProxyCommitData->master.getTLogPrevCommitVersion.getReply(GetTLogPrevCommitVersionRequest(self->writtenTLogs))));
+	GetTLogPrevCommitVersionReply rep =
+	    wait(brokenPromiseToNever(pProxyCommitData->master.getTLogPrevCommitVersion.getReply(
+	        GetTLogPrevCommitVersionRequest(self->writtenTLogs))));
 	// TraceEvent("GetTLogPrevCommitVersionRequest");
 	return Void();
 }
@@ -1189,9 +1190,12 @@ ACTOR Future<Void> postResolution(CommitBatchContext* self) {
 	if (self->prevVersion && self->commitVersion - self->prevVersion < SERVER_KNOBS->MAX_VERSIONS_IN_FLIGHT / 2)
 		debug_advanceMaxCommittedVersion(UID(), self->commitVersion); //< Is this valid?
 
-	//TraceEvent("ProxyPush", pProxyCommitData->dbgid).detail("PrevVersion", prevVersion).detail("Version", commitVersion)
-	//	.detail("TransactionsSubmitted", trs.size()).detail("TransactionsCommitted", commitCount).detail("TxsPopTo",
-	// msg.popTo);
+	// TraceEvent("ProxyPush", pProxyCommitData->dbgid)
+	//     .detail("PrevVersion", self->prevVersion)
+	//     .detail("Version", self->commitVersion)
+	//     .detail("TransactionsSubmitted", trs.size())
+	//     .detail("TransactionsCommitted", self->commitCount)
+	//     .detail("TxsPopTo", self->msg.popTo);
 
 	if (self->prevVersion && self->commitVersion - self->prevVersion < SERVER_KNOBS->MAX_VERSIONS_IN_FLIGHT / 2)
 		debug_advanceMaxCommittedVersion(UID(), self->commitVersion);
@@ -1281,7 +1285,9 @@ ACTOR Future<Void> reply(CommitBatchContext* self) {
 	if (self->prevVersion && self->commitVersion - self->prevVersion < SERVER_KNOBS->MAX_VERSIONS_IN_FLIGHT / 2)
 		debug_advanceMinCommittedVersion(UID(), self->commitVersion);
 
-	//TraceEvent("ProxyPushed", pProxyCommitData->dbgid).detail("PrevVersion", prevVersion).detail("Version", commitVersion);
+	// TraceEvent("ProxyPushed", pProxyCommitData->dbgid)
+	//     .detail("PrevVersion", self->prevVersion)
+	//     .detail("Version", self->commitVersion);
 	if (debugID.present())
 		g_traceBatch.addEvent("CommitDebug", debugID.get().first(), "CommitProxyServer.commitBatch.AfterLogPush");
 
@@ -1307,6 +1313,7 @@ ACTOR Future<Void> reply(CommitBatchContext* self) {
 		                                     self->lockedAfter,
 		                                     self->metadataVersionAfter,
 		                                     pProxyCommitData->minKnownCommittedVersion,
+		                                     self->prevVersion,
 		                                     writtenTags),
 		    TaskPriority::ProxyMasterVersionReply));
 	}

--- a/fdbserver/LogSystem.h
+++ b/fdbserver/LogSystem.h
@@ -738,7 +738,8 @@ struct ILogSystem {
 	                             Version minKnownCommittedVersion,
 	                             struct LogPushData& data,
 	                             SpanID const& spanContext,
-	                             Optional<UID> debugID = Optional<UID>()) = 0;
+	                             Optional<UID> debugID = Optional<UID>(),
+                                 Optional<std::unordered_map<uint16_t, Version>> = Optional<std::unordered_map<uint16_t, Version>>()) = 0;
 	// Waits for the version number of the bundle (in this epoch) to be prevVersion (i.e. for all pushes ordered
 	// earlier) Puts the given messages into the bundle, each with the given tags, and with message versions (version,
 	// 0) - (version, N) Changes the version number of the bundle to be version (unblocking the next push) Returns when

--- a/fdbserver/MasterInterface.h
+++ b/fdbserver/MasterInterface.h
@@ -202,12 +202,14 @@ struct GetTLogPrevCommitVersionReply {
 struct GetTLogPrevCommitVersionRequest {
 	constexpr static FileIdentifier file_identifier = 16683184;
 	std::set<uint16_t> writtenTLogs;
+	Version commitVersion;
+	Version prev;
 	ReplyPromise<GetTLogPrevCommitVersionReply> reply;
 	GetTLogPrevCommitVersionRequest() {}
-	GetTLogPrevCommitVersionRequest(std::set<uint16_t>& writtenTLogs) : writtenTLogs(writtenTLogs) {}
+	GetTLogPrevCommitVersionRequest(std::set<uint16_t>& writtenTLogs, Version commitVersion, Version prev) : writtenTLogs(writtenTLogs), commitVersion(commitVersion), prev(prev) {}
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, writtenTLogs, reply);
+		serializer(ar, writtenTLogs, commitVersion, prev, reply);
 	}
 };
 

--- a/fdbserver/MasterInterface.h
+++ b/fdbserver/MasterInterface.h
@@ -217,6 +217,7 @@ struct ReportRawCommittedVersionRequest {
 	bool locked;
 	Optional<Value> metadataVersion;
 	Version minKnownCommittedVersion;
+	Optional<Version> prevVersion; // if present, wait for prevVersion to be committed before replying
 	Optional<std::set<Tag>> writtenTags;
 	ReplyPromise<Void> reply;
 
@@ -225,13 +226,14 @@ struct ReportRawCommittedVersionRequest {
 	                                 bool locked,
 	                                 Optional<Value> metadataVersion,
 	                                 Version minKnownCommittedVersion,
+	                                 Optional<Version> prevVersion,
 	                                 Optional<std::set<Tag>> writtenTags = Optional<std::set<Tag>>())
 	  : version(version), locked(locked), metadataVersion(metadataVersion),
-	    minKnownCommittedVersion(minKnownCommittedVersion), writtenTags(writtenTags) {}
+	    minKnownCommittedVersion(minKnownCommittedVersion), writtenTags(writtenTags), prevVersion(prevVersion) {}
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, version, locked, metadataVersion, minKnownCommittedVersion, writtenTags, reply);
+		serializer(ar, version, locked, metadataVersion, minKnownCommittedVersion, prevVersion, writtenTags, reply);
 	}
 };
 

--- a/fdbserver/TagPartitionedLogSystem.actor.cpp
+++ b/fdbserver/TagPartitionedLogSystem.actor.cpp
@@ -550,7 +550,8 @@ struct TagPartitionedLogSystem : ILogSystem, ReferenceCounted<TagPartitionedLogS
 	                     Version minKnownCommittedVersion,
 	                     LogPushData& data,
 	                     SpanID const& spanContext,
-	                     Optional<UID> debugID) final {
+	                     Optional<UID> debugID,
+	                     Optional<std::unordered_map<uint16_t, Version>> tpcvMap) final {
 		// FIXME: Randomize request order as in LegacyLogSystem?
 		vector<Future<Void>> quorumResults;
 		vector<Future<TLogCommitReply>> allReplies;
@@ -565,6 +566,15 @@ struct TagPartitionedLogSystem : ILogSystem, ReferenceCounted<TagPartitionedLogS
 				}
 				vector<Future<Void>> tLogCommitResults;
 				for (int loc = 0; loc < it->logServers.size(); loc++) {
+					if (SERVER_KNOBS->ENABLE_VERSION_VECTOR) {
+						if (tpcvMap.get().find(location) != tpcvMap.get().end()) {
+							prevVersion = tpcvMap.get()[location];
+						} else {
+							// Do not send empty commit to tLog if its not a destination of the transaction
+							location++;
+							continue;
+						}
+					}
 					Standalone<StringRef> msg = data.getMessages(location);
 					allReplies.push_back(recordPushMetrics(
 					    it->connectionResetTrackers[loc],

--- a/fdbserver/masterserver.actor.cpp
+++ b/fdbserver/masterserver.actor.cpp
@@ -1248,8 +1248,10 @@ ACTOR Future<Void> waitForPrev(Reference<MasterData> self, ReportRawCommittedVer
 
 ACTOR Future<Void> waitForTLogPrev(Reference<MasterData> self, GetTLogPrevCommitVersionRequest req) {
 	// TraceEvent("WaitForTLogPrev").detail("Prev",req.prev).detail("CommitVersion",req.commitVersion).detail("PrevTLogVersion",self->prevTLogVersion.get());
-	if (self->prevTLogVersion.get() != -1) {
+	if (self->prevTLogVersion.get() != invalidVersion) {
 		wait(self->prevTLogVersion.whenAtLeast(req.prev));
+	} else {
+		std::fill(self->tpcvVector.begin(), self->tpcvVector.end(), self->lastEpochEnd);
 	}
 
 	GetTLogPrevCommitVersionReply reply;
@@ -1257,9 +1259,7 @@ ACTOR Future<Void> waitForTLogPrev(Reference<MasterData> self, GetTLogPrevCommit
 		reply.tpcvMap[tLog] = self->tpcvVector[tLog];
 		self->tpcvVector[tLog] = req.commitVersion;
 	}
-	if (req.commitVersion > self->prevTLogVersion.get()) {
-		self->prevTLogVersion.set(req.commitVersion);
-	}
+	self->prevTLogVersion.set(req.commitVersion);
 	req.reply.send(reply);
 	return Void();
 }

--- a/fdbserver/masterserver.actor.cpp
+++ b/fdbserver/masterserver.actor.cpp
@@ -183,7 +183,7 @@ struct MasterData : NonCopyable, ReferenceCounted<MasterData> {
 	    recoveryTransactionVersion; // The first version in this epoch
 	double lastCommitTime;
 
-	Version liveCommittedVersion; // The largest live committed version reported by commit proxies.
+	NotifiedVersion liveCommittedVersion; // The largest live committed version reported by commit proxies.
 	bool databaseLocked;
 	Optional<Value> proxyMetadataVersion;
 	Version minKnownCommittedVersion;
@@ -1221,6 +1221,31 @@ ACTOR Future<Void> provideVersions(Reference<MasterData> self) {
 	}
 }
 
+void updateLiveCommittedVersion(Reference<MasterData> self, ReportRawCommittedVersionRequest req) {
+	self->minKnownCommittedVersion = std::max(self->minKnownCommittedVersion, req.minKnownCommittedVersion);
+	if (req.version > self->liveCommittedVersion.get()) {
+		self->databaseLocked = req.locked;
+		self->proxyMetadataVersion = req.metadataVersion;
+		// Note the set call switches context to any waiters on liveCommittedVersion before continuing.
+		self->liveCommittedVersion.set(req.version);
+	}
+	++self->reportLiveCommittedVersionRequests;
+	if (SERVER_KNOBS->ENABLE_VERSION_VECTOR && req.writtenTags.present()) {
+		// NB: this if-condition is not needed after wait-for-prev is ported to this branch
+		if (req.version > self->ssVersionVector.maxVersion) {
+			// TraceEvent("Received ReportRawCommittedVersionRequest").detail("Version",req.version);
+			self->ssVersionVector.setVersions(req.writtenTags.get(), req.version);
+		}
+	}
+}
+
+ACTOR Future<Void> waitForPrev(Reference<MasterData> self, ReportRawCommittedVersionRequest req) {
+	wait(self->liveCommittedVersion.whenAtLeast(req.prevVersion.get()));
+	updateLiveCommittedVersion(self, req);
+	req.reply.send(Void());
+	return Void();
+}
+
 ACTOR Future<Void> serveLiveCommittedVersion(Reference<MasterData> self) {
 	loop {
 		choose {
@@ -1230,12 +1255,12 @@ ACTOR Future<Void> serveLiveCommittedVersion(Reference<MasterData> self) {
 					                      req.debugID.get().first(),
 					                      "MasterServer.serveLiveCommittedVersion.GetRawCommittedVersion");
 
-				if (self->liveCommittedVersion == invalidVersion) {
-					self->liveCommittedVersion = self->recoveryTransactionVersion;
+				if (self->liveCommittedVersion.get() == invalidVersion) {
+					self->liveCommittedVersion.set(self->recoveryTransactionVersion);
 				}
 				++self->getLiveCommittedVersionRequests;
 				GetRawCommittedVersionReply reply;
-				reply.version = self->liveCommittedVersion;
+				reply.version = self->liveCommittedVersion.get();
 				reply.locked = self->databaseLocked;
 				reply.metadataVersion = self->proxyMetadataVersion;
 				reply.minKnownCommittedVersion = self->minKnownCommittedVersion;
@@ -1244,21 +1269,14 @@ ACTOR Future<Void> serveLiveCommittedVersion(Reference<MasterData> self) {
 			}
 			when(ReportRawCommittedVersionRequest req =
 			         waitNext(self->myInterface.reportLiveCommittedVersion.getFuture())) {
-				self->minKnownCommittedVersion = std::max(self->minKnownCommittedVersion, req.minKnownCommittedVersion);
-				if (SERVER_KNOBS->ENABLE_VERSION_VECTOR && req.writtenTags.present()) {
-					// NB: this if-condition is not needed after wait-for-prev is ported to this branch
-					if (req.version > self->ssVersionVector.maxVersion) {
-						// TraceEvent("Received ReportRawCommittedVersionRequest").detail("Version",req.version);
-						self->ssVersionVector.setVersions(req.writtenTags.get(), req.version);
-					}
+				if (SERVER_KNOBS->ENABLE_VERSION_VECTOR && req.prevVersion.present() &&
+				    (self->liveCommittedVersion.get() != invalidVersion) &&
+				    (self->liveCommittedVersion.get() < req.prevVersion.get())) {
+					self->addActor.send(waitForPrev(self, req));
+				} else {
+					updateLiveCommittedVersion(self, req);
+					req.reply.send(Void());
 				}
-				if (req.version > self->liveCommittedVersion) {
-					self->liveCommittedVersion = req.version;
-					self->databaseLocked = req.locked;
-					self->proxyMetadataVersion = req.metadataVersion;
-				}
-				++self->reportLiveCommittedVersionRequests;
-				req.reply.send(Void());
 			}
 			when(GetTLogPrevCommitVersionRequest req =
 			         waitNext(self->myInterface.getTLogPrevCommitVersion.getFuture())) {


### PR DESCRIPTION
version vector support, enabled with knob:
- Maintain the previous commit version per tLog (the `TPCV` vector) in the sequencer.
- Update the TPCV vector only once the previous transaction (at cluster level) has updated it.
- Do not reply to the client out of order.
- process transactions in "per-tLog order" in the tLog

This must be integrated with [PR5161](https://github.com/apple/foundationdb/pull/5161), else, reads stall as transactions are no longer written to all tLogs. note reads are internally generated, (e.g. `getServerListAndProcessClasses` generates transactions to read the system keyspace)

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
