### PR TITLE
Enhancements for network thread busyness API

### DIFF
--- a/bindings/c/fdb_c.cpp
+++ b/bindings/c/fdb_c.cpp
@@ -362,6 +362,10 @@ extern "C" DLLEXPORT FDBFuture* fdb_database_create_snapshot(FDBDatabase* db,
 // A value of 0 indicates that the client is more or less idle
 // A value of 1 (or more) indicates that the client is saturated
 extern "C" DLLEXPORT double fdb_database_get_main_thread_busyness(FDBDatabase* d) {
+	if (g_api_version < 631) {
+		return 0;
+	}
+
 	return DB(d)->getMainThreadBusyness();
 }
 

--- a/fdbclient/MultiVersionTransaction.actor.cpp
+++ b/fdbclient/MultiVersionTransaction.actor.cpp
@@ -976,13 +976,17 @@ ThreadFuture<Void> MultiVersionDatabase::createSnapshot(const StringRef& uid, co
 	return abortableFuture(f, dbState->dbVar->get().onChange);
 }
 
-// Get network thread busyness
+// Return the busyness for the main thread. When using external clients, take the larger of the local client
+// and the external client's busyness.
 double MultiVersionDatabase::getMainThreadBusyness() {
+	ASSERT(g_network);
+
+	double localClientBusyness = g_network->networkInfo.metrics.networkBusyness;
 	if (dbState->db) {
-		return dbState->db->getMainThreadBusyness();
+		return std::max(dbState->db->getMainThreadBusyness(), localClientBusyness);
 	}
 
-	return 0;
+	return localClientBusyness;
 }
 
 // Returns the protocol version reported by the coordinator this client is connected to

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -1994,8 +1994,10 @@ ACTOR Future<Void> monitorNetworkBusyness() {
 			tracker.windowedTimer = now();
 		}
 
-		g_network->networkInfo.metrics.networkBusyness =
-		    std::min(elapsed, tracker.duration) / elapsed; // average duration spent doing "work"
+		double busyFraction = std::min(elapsed, tracker.duration) / elapsed;
+		double burstiness = std::min(1.0, std::max(0.0, tracker.maxDuration - 0.1) / 0.4);
+
+		g_network->networkInfo.metrics.networkBusyness = std::max(busyFraction, burstiness);
 
 		tracker.duration = 0;
 		tracker.maxDuration = 0;


### PR DESCRIPTION
This includes a few changes to the network thread busyness API to better capture busyness and support backporting:

* Account for bursts smaller than the measurement window in busyness calculations. This helps us identify cases where our saturation state doesn't have us using the CPU fully 100% of the time but in spurts.
* Include the local network thread when using the MVC with an external client. The larger busyness score of the two threads is used.
* "Disallow" use of the new function prior to API version 631. This makes it less likely that someone would be able to run into trouble calling this function against an old patch release. This is currently implemented by making the function return 0 for older API versions, which doesn't technically disable it but does make it useless. Anything more severe might require a different API.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
