### PR TITLE
allow build folder as $BUILD_DIR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ bindings/java/foundationdb-client*.jar
 bindings/java/foundationdb-tests*.jar
 bindings/java/fdb-java-*-sources.jar
 packaging/msi/FDBInstaller.msi
-builds/
+build/
 cmake-build-debug/
 # Generated source, build, and packaging files
 *.g.cpp


### PR DESCRIPTION
This PR is adding the `build` folder in the `.gitignore`, allowing IDE to use the standard `$SOURCE_DIR/build`, as discussed in #3098.

I didn't find any reference to a `builds` folder, so I changed it to `build`.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
