### PR TITLE
Make resolver to track version by tlog group

### DIFF
--- a/fdbclient/FDBTypes.cpp
+++ b/fdbclient/FDBTypes.cpp
@@ -65,3 +65,11 @@ std::string KeySelectorRef::toString() const {
 			return format("%d+lastLessThan(%s)", offset, printable(key).c_str());
 	}
 }
+
+namespace ptxn {
+
+TLogGroupID tLogGroupByStorageTeamID(std::vector<TLogGroupID> tLogGroups, StorageTeamID storageTeamID) {
+	return tLogGroups[std::hash<StorageTeamID>{}(storageTeamID) % tLogGroups.size()];
+}
+
+} // namespace ptxn

--- a/fdbclient/FDBTypes.cpp
+++ b/fdbclient/FDBTypes.cpp
@@ -68,7 +68,7 @@ std::string KeySelectorRef::toString() const {
 
 namespace ptxn {
 
-TLogGroupID tLogGroupByStorageTeamID(std::vector<TLogGroupID> tLogGroups, StorageTeamID storageTeamID) {
+TLogGroupID tLogGroupByStorageTeamID(const std::vector<TLogGroupID>& tLogGroups, const StorageTeamID& storageTeamID) {
 	return tLogGroups[std::hash<StorageTeamID>{}(storageTeamID) % tLogGroups.size()];
 }
 

--- a/fdbclient/FDBTypes.h
+++ b/fdbclient/FDBTypes.h
@@ -75,9 +75,7 @@ using StorageTeamID = UID;
 const StorageTeamID txsTeam = UID(1, 1);
 
 // Map from storage team id to a TLog group
-TLogGroupID tLogGroupByStorageTeamID(std::vector<TLogGroupID> tLogGroups, StorageTeamID storageTeamID) {
-	return tLogGroups[std::hash<StorageTeamID>{}(storageTeamID) % tLogGroups.size()];
-}
+TLogGroupID tLogGroupByStorageTeamID(std::vector<TLogGroupID> tLogGroups, StorageTeamID storageTeamID);
 
 } // namespace ptxn
 

--- a/fdbclient/FDBTypes.h
+++ b/fdbclient/FDBTypes.h
@@ -74,6 +74,11 @@ using StorageTeamID = UID;
 // Transaction subsystem state (txnState) team.
 const StorageTeamID txsTeam = UID(1, 1);
 
+// Map from storage team id to a TLog group
+TLogGroupID tLogGroupByStorageTeamID(std::vector<TLogGroupID> tLogGroups, StorageTeamID storageTeamID) {
+	return tLogGroups[std::hash<StorageTeamID>{}(storageTeamID) % tLogGroups.size()];
+}
+
 } // namespace ptxn
 
 #pragma pack(push, 1)

--- a/fdbclient/FDBTypes.h
+++ b/fdbclient/FDBTypes.h
@@ -75,7 +75,7 @@ using StorageTeamID = UID;
 const StorageTeamID txsTeam = UID(1, 1);
 
 // Map from storage team id to a TLog group
-TLogGroupID tLogGroupByStorageTeamID(std::vector<TLogGroupID> tLogGroups, StorageTeamID storageTeamID);
+TLogGroupID tLogGroupByStorageTeamID(const std::vector<TLogGroupID>& tLogGroups, const StorageTeamID& storageTeamID);
 
 } // namespace ptxn
 

--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -104,6 +104,7 @@ void ServerKnobs::initialize(Randomize _randomize, ClientKnobs* clientKnobs, IsS
 	init( PUSH_STATS_SLOW_RATIO,                                 0.5 );
 	init( TLOG_POP_BATCH_SIZE,                                  1000 ); if ( randomize && BUGGIFY ) TLOG_POP_BATCH_SIZE = 10;
 	init( TLOG_SERVER_TEAM_PARTITIONED,                        false );
+	init( TLOG_NEW_INTERFACE,                        		   false );
 
 	// disk snapshot max timeout, to be put in TLog, storage and coordinator nodes
 	init( MAX_FORKED_PROCESS_OUTPUT,                            1024 );

--- a/fdbclient/ServerKnobs.h
+++ b/fdbclient/ServerKnobs.h
@@ -103,6 +103,7 @@ public:
 	double PUSH_STATS_SLOW_RATIO;
 	int TLOG_POP_BATCH_SIZE;
 	bool TLOG_SERVER_TEAM_PARTITIONED;
+	bool TLOG_NEW_INTERFACE;
 
 	// Data distribution queue
 	double HEALTH_POLL_TIME;

--- a/fdbclient/StorageServerInterface.h
+++ b/fdbclient/StorageServerInterface.h
@@ -177,7 +177,7 @@ struct ServerCacheInfo {
 	std::vector<Reference<StorageInfo>> dest_info;
 	// Primary and remote DC teams for the key range. For now, ptxn is only enabled for primary DC so
 	// size of teams is always 1
-	std::set<ptxn::StorageTeamID> teams;
+	std::set<ptxn::StorageTeamID> storageTeams;
 
 	void populateTags() {
 		if (tags.size())

--- a/fdbclient/StorageServerInterface.h
+++ b/fdbclient/StorageServerInterface.h
@@ -175,7 +175,9 @@ struct ServerCacheInfo {
 	std::vector<Tag> tags; // all tags in both primary and remote DC for the key-range
 	std::vector<Reference<StorageInfo>> src_info;
 	std::vector<Reference<StorageInfo>> dest_info;
-	std::set<ptxn::StorageTeamID> teams; // primary and remote DC teams for the key range
+	// Primary and remote DC teams for the key range. For now, ptxn is only enabled for primary DC so
+	// size of teams is always 1
+	std::set<ptxn::StorageTeamID> teams;
 
 	void populateTags() {
 		if (tags.size())

--- a/fdbserver/CMakeLists.txt
+++ b/fdbserver/CMakeLists.txt
@@ -131,8 +131,8 @@ set(FDBSERVER_SRCS
   ptxn/Serializer.h
   ptxn/StorageServerInterface.cpp
   ptxn/StorageServerInterface.h
-  ptxn/TeamVersionTracker.actor.cpp
-  ptxn/TeamVersionTracker.h
+  ptxn/TLogGroupVersionTracker.actor.cpp
+  ptxn/TLogGroupVersionTracker.h
   ptxn/TLogInterface.cpp
   ptxn/TLogInterface.h
   ptxn/TLogPeekCursor.actor.cpp

--- a/fdbserver/ClusterController.actor.cpp
+++ b/fdbserver/ClusterController.actor.cpp
@@ -3407,6 +3407,15 @@ ACTOR Future<Void> clusterRecruitRemoteFromConfiguration(ClusterControllerData* 
 	}
 }
 
+void printGroupsToServersMapping(LogSystemConfig logSystemConfig) {
+	std::unordered_map<UID, std::vector<Reference<AsyncVar<OptionalInterface<ptxn::TLogInterface_PassivelyPull>>>>>
+	    ptxnTLogGroups = logSystemConfig.tLogs[0].ptxnTLogGroups;
+	for (auto iterator : ptxnTLogGroups) {
+		auto serverIds = iterator.first;
+		TraceEvent("tLogGroupToLogServerIds:Group ID: ", serverIds).detail("group size : ", iterator.second.size());
+	}
+}
+
 void clusterRegisterMaster(ClusterControllerData* self, RegisterMasterRequest const& req) {
 	req.reply.send(Void());
 

--- a/fdbserver/LogSystem.h
+++ b/fdbserver/LogSystem.h
@@ -23,6 +23,7 @@
 
 #include <set>
 #include <vector>
+#include <unordered_map>
 
 #include "fdbserver/SpanContextMessage.h"
 #include "fdbserver/TLogInterface.h"
@@ -36,6 +37,7 @@
 #include "fdbrpc/ReplicationPolicy.h"
 #include "fdbrpc/Locality.h"
 #include "fdbrpc/Replication.h"
+#include "fdbserver/TLogGroup.actor.h"
 
 struct DBCoreState;
 struct TLogSet;
@@ -54,6 +56,8 @@ struct ConnectionResetInfo : public ReferenceCounted<ConnectionResetInfo> {
 class LogSet : NonCopyable, public ReferenceCounted<LogSet> {
 public:
 	std::vector<Reference<AsyncVar<OptionalInterface<TLogInterface>>>> logServers;
+	std::unordered_map<UID, std::vector<Reference<AsyncVar<OptionalInterface<ptxn::TLogInterface_PassivelyPull>>>>>
+	    groupIdToInterfaces;
 	std::vector<Reference<AsyncVar<OptionalInterface<TLogInterface>>>> logRouters;
 	std::vector<Reference<AsyncVar<OptionalInterface<BackupInterface>>>> backupWorkers;
 	std::vector<Reference<ConnectionResetInfo>> connectionResetTrackers;
@@ -866,7 +870,9 @@ struct ILogSystem {
 	    int8_t primaryLocality,
 	    int8_t remoteLocality,
 	    std::vector<Tag> const& allTags,
-	    Reference<AsyncVar<bool>> const& recruitmentStalled) = 0;
+	    Reference<AsyncVar<bool>> const& recruitmentStalled,
+	    std::unordered_map<UID, std::vector<UID>> tLogGroupIdToServerIds,
+	    std::unordered_map<UID, std::vector<TLogGroupRef>> tlogServerIdToTlogGroups) = 0;
 	// Call only on an ILogSystem obtained from recoverAndEndEpoch()
 	// Returns an ILogSystem representing a new epoch immediately following this one.  The new epoch is only provisional
 	// until the caller updates the coordinated DBCoreState
@@ -1091,9 +1097,7 @@ struct LogPushData : NonCopyable {
 		next_message_tags.clear();
 	}
 
-	Standalone<StringRef> getMessages(int loc) {
-		return messagesWriter[loc].toValue();
-	}
+	Standalone<StringRef> getMessages(int loc) { return messagesWriter[loc].toValue(); }
 
 	// Records if a tlog (specified by "loc") will receive an empty version batch message.
 	// "value" is the message returned by getMessages() call.

--- a/fdbserver/LogSystemConfig.h
+++ b/fdbserver/LogSystemConfig.h
@@ -85,14 +85,11 @@ struct serializable_traits<OptionalInterface<Interface>> : std::true_type {
 struct TLogSet {
 	constexpr static FileIdentifier file_identifier = 6302317;
 	std::vector<OptionalInterface<TLogInterface>> tLogs;
-
-	// TODO: figure out a way to represent TLog group information needed for a ss to find the corresponding TLog
-	//  interface.
-	// TODO: change other function below to reflect TLogSet
-	// Same order as in the recruitment, will only be set when 'isLocal' is true.
 	std::vector<ptxn::TLogGroupID> tLogGroups;
-	std::unordered_map<ptxn::TLogGroupID, std::vector<OptionalInterface<ptxn::TLogInterface_PassivelyPull>>>
+	std::unordered_map<ptxn::TLogGroupID,
+	                   std::vector<Reference<AsyncVar<OptionalInterface<ptxn::TLogInterface_PassivelyPull>>>>>
 	    ptxnTLogGroups;
+
 	std::vector<OptionalInterface<TLogInterface>> logRouters;
 	std::vector<OptionalInterface<BackupInterface>> backupWorkers;
 	int32_t tLogWriteAntiQuorum, tLogReplicationFactor;

--- a/fdbserver/LogSystemConfig.h
+++ b/fdbserver/LogSystemConfig.h
@@ -89,6 +89,8 @@ struct TLogSet {
 	// TODO: figure out a way to represent TLog group information needed for a ss to find the corresponding TLog
 	//  interface.
 	// TODO: change other function below to reflect TLogSet
+	// Same order as in the recruitment, will only be set when 'isLocal' is true.
+	std::vector<ptxn::TLogGroupID> tLogGroups;
 	std::unordered_map<ptxn::TLogGroupID, std::vector<OptionalInterface<ptxn::TLogInterface_PassivelyPull>>>
 	    ptxnTLogGroups;
 	std::vector<OptionalInterface<TLogInterface>> logRouters;

--- a/fdbserver/MockLogSystem.cpp
+++ b/fdbserver/MockLogSystem.cpp
@@ -196,7 +196,9 @@ Future<Reference<ILogSystem>> MockLogSystem::newEpoch(
     int8_t primaryLocality,
     int8_t remoteLocality,
     const vector<Tag>& allTags,
-    const Reference<AsyncVar<bool>>& recruitmentStalled) {
+    const Reference<AsyncVar<bool>>& recruitmentStalled,
+    std::unordered_map<UID, std::vector<UID>> tLogGroupIdToServerIds,
+    std::unordered_map<UID, std::vector<TLogGroupRef>> tlogServerIdToTlogGroups) {
 	logMethodName(__func__);
 	return Future<Reference<ILogSystem>>();
 }

--- a/fdbserver/MockLogSystem.h
+++ b/fdbserver/MockLogSystem.h
@@ -78,14 +78,17 @@ struct MockLogSystem : ILogSystem, ReferenceCounted<MockLogSystem> {
 	Version getEnd() const final;
 	Version getBackupStartVersion() const final;
 	std::map<LogEpoch, EpochTagsVersionsInfo> getOldEpochTagsVersionsInfo() const final;
-	Future<Reference<ILogSystem>> newEpoch(const RecruitFromConfigurationReply& recr,
-	                                       const Future<struct RecruitRemoteFromConfigurationReply>& fRemoteWorkers,
-	                                       const DatabaseConfiguration& config,
-	                                       LogEpoch recoveryCount,
-	                                       int8_t primaryLocality,
-	                                       int8_t remoteLocality,
-	                                       const vector<Tag>& allTags,
-	                                       const Reference<AsyncVar<bool>>& recruitmentStalled) final;
+	Future<Reference<ILogSystem>> newEpoch(
+	    const RecruitFromConfigurationReply& recr,
+	    const Future<struct RecruitRemoteFromConfigurationReply>& fRemoteWorkers,
+	    const DatabaseConfiguration& config,
+	    LogEpoch recoveryCount,
+	    int8_t primaryLocality,
+	    int8_t remoteLocality,
+	    const vector<Tag>& allTags,
+	    const Reference<AsyncVar<bool>>& recruitmentStalled,
+	    std::unordered_map<UID, std::vector<UID>> tLogGroupIdToServerIds,
+	    std::unordered_map<UID, std::vector<TLogGroupRef>> tlogServerIdToTlogGroups) final;
 	LogSystemConfig getLogSystemConfig() const final;
 	Standalone<StringRef> getLogsValue() const final;
 	Future<Void> onLogSystemConfigChange() final;

--- a/fdbserver/ProxyCommitData.actor.h
+++ b/fdbserver/ProxyCommitData.actor.h
@@ -133,6 +133,7 @@ struct ProxyCommitData {
 	vector<ResolverInterface> resolvers;
 	LogSystemDiskQueueAdapter* logAdapter;
 	Reference<ILogSystem> logSystem;
+	std::vector<ptxn::TLogGroupID> tLogGroups;
 	IKeyValueStore* txnStateStore;
 	NotifiedVersion committedVersion; // Provided that this recovery has succeeded or will succeed, this version is
 	                                  // fully committed (durable)

--- a/fdbserver/ResolverInterface.h
+++ b/fdbserver/ResolverInterface.h
@@ -90,8 +90,8 @@ struct ResolveTransactionBatchReply {
 	// transaction index -> conflicting read_conflict_range ids given by the resolver
 	std::map<int, VectorRef<int>> conflictingKeyRangeMap;
 
-	// Each team's previous commit version
-	std::map<ptxn::StorageTeamID, Version> previousCommitVersions;
+	// Each group's previous commit version
+	std::map<ptxn::TLogGroupID, Version> previousCommitVersions;
 
 	template <class Archive>
 	void serialize(Archive& ar) {
@@ -112,9 +112,9 @@ struct ResolveTransactionBatchRequest {
 	VectorRef<int> txnStateTransactions;
 	ReplyPromise<ResolveTransactionBatchReply> reply;
 	Optional<UID> debugID;
-	std::vector<ptxn::StorageTeamID> updatedTeams; // Teams updated in this batch
-	std::vector<ptxn::StorageTeamID> newTeams; // New teams added in this batch
-	std::vector<ptxn::StorageTeamID> staleTeams; // Teams that become stale in this batch
+	std::vector<ptxn::TLogGroupID> updatedGroups; // Groups updated in this batch
+	std::vector<ptxn::TLogGroupID> newGroups; // New groups added in this batch
+	std::vector<ptxn::TLogGroupID> staleGroups; // Groups that become stale in this batch
 
 	template <class Archive>
 	void serialize(Archive& ar) {
@@ -128,9 +128,9 @@ struct ResolveTransactionBatchRequest {
 		           arena,
 		           debugID,
 		           spanContext,
-		           updatedTeams,
-		           newTeams,
-		           staleTeams);
+		           updatedGroups,
+		           newGroups,
+		           staleGroups);
 	}
 };
 

--- a/fdbserver/TagPartitionedLogSystem.actor.cpp
+++ b/fdbserver/TagPartitionedLogSystem.actor.cpp
@@ -85,6 +85,11 @@ LogSet::LogSet(const TLogSet& tLogSet)
 	for (const auto& log : tLogSet.tLogs) {
 		logServers.push_back(makeReference<AsyncVar<OptionalInterface<TLogInterface>>>(log));
 	}
+	for (const auto& log : tLogSet.ptxnTLogGroups) {
+		for (const Reference<AsyncVar<OptionalInterface<ptxn::TLogInterface_PassivelyPull>>>& interface : log.second) {
+			groupIdToInterfaces[log.first].push_back(interface);
+		}
+	}
 	for (const auto& log : tLogSet.logRouters) {
 		logRouters.push_back(makeReference<AsyncVar<OptionalInterface<TLogInterface>>>(log));
 	}
@@ -115,6 +120,11 @@ TLogSet::TLogSet(const LogSet& rhs)
     locality(rhs.locality), startVersion(rhs.startVersion), satelliteTagLocations(rhs.satelliteTagLocations) {
 	for (const auto& tlog : rhs.logServers) {
 		tLogs.push_back(tlog->get());
+	}
+	for (const auto& log : rhs.groupIdToInterfaces) {
+		for (const Reference<AsyncVar<OptionalInterface<ptxn::TLogInterface_PassivelyPull>>>& interface : log.second) {
+			ptxnTLogGroups[log.first].push_back(interface);
+		}
 	}
 	for (const auto& logRouter : rhs.logRouters) {
 		logRouters.push_back(logRouter->get());
@@ -1636,14 +1646,17 @@ struct TagPartitionedLogSystem : ILogSystem, ReferenceCounted<TagPartitionedLogS
 
 	// Call only after end_epoch() has successfully completed.  Returns a new epoch immediately following this one.
 	// The new epoch is only provisional until the caller updates the coordinated DBCoreState.
-	Future<Reference<ILogSystem>> newEpoch(RecruitFromConfigurationReply const& recr,
-	                                       Future<RecruitRemoteFromConfigurationReply> const& fRemoteWorkers,
-	                                       DatabaseConfiguration const& config,
-	                                       LogEpoch recoveryCount,
-	                                       int8_t primaryLocality,
-	                                       int8_t remoteLocality,
-	                                       std::vector<Tag> const& allTags,
-	                                       Reference<AsyncVar<bool>> const& recruitmentStalled) final {
+	Future<Reference<ILogSystem>> newEpoch(
+	    RecruitFromConfigurationReply const& recr,
+	    Future<RecruitRemoteFromConfigurationReply> const& fRemoteWorkers,
+	    DatabaseConfiguration const& config,
+	    LogEpoch recoveryCount,
+	    int8_t primaryLocality,
+	    int8_t remoteLocality,
+	    std::vector<Tag> const& allTags,
+	    Reference<AsyncVar<bool>> const& recruitmentStalled,
+	    std::unordered_map<UID, std::vector<UID>> tLogGroupIdToServerIds,
+	    std::unordered_map<UID, std::vector<TLogGroupRef>> tlogServerIdToTlogGroups) final {
 		return newEpoch(Reference<TagPartitionedLogSystem>::addRef(this),
 		                recr,
 		                fRemoteWorkers,
@@ -1652,7 +1665,9 @@ struct TagPartitionedLogSystem : ILogSystem, ReferenceCounted<TagPartitionedLogS
 		                primaryLocality,
 		                remoteLocality,
 		                allTags,
-		                recruitmentStalled);
+		                recruitmentStalled,
+		                tLogGroupIdToServerIds,
+		                tlogServerIdToTlogGroups);
 	}
 
 	LogSystemConfig getLogSystemConfig() const final {
@@ -2677,15 +2692,18 @@ struct TagPartitionedLogSystem : ILogSystem, ReferenceCounted<TagPartitionedLogS
 		return Void();
 	}
 
-	ACTOR static Future<Reference<ILogSystem>> newEpoch(Reference<TagPartitionedLogSystem> oldLogSystem,
-	                                                    RecruitFromConfigurationReply recr,
-	                                                    Future<RecruitRemoteFromConfigurationReply> fRemoteWorkers,
-	                                                    DatabaseConfiguration configuration,
-	                                                    LogEpoch recoveryCount,
-	                                                    int8_t primaryLocality,
-	                                                    int8_t remoteLocality,
-	                                                    std::vector<Tag> allTags,
-	                                                    Reference<AsyncVar<bool>> recruitmentStalled) {
+	ACTOR static Future<Reference<ILogSystem>> newEpoch(
+	    Reference<TagPartitionedLogSystem> oldLogSystem,
+	    RecruitFromConfigurationReply recr,
+	    Future<RecruitRemoteFromConfigurationReply> fRemoteWorkers,
+	    DatabaseConfiguration configuration,
+	    LogEpoch recoveryCount,
+	    int8_t primaryLocality,
+	    int8_t remoteLocality,
+	    std::vector<Tag> allTags,
+	    Reference<AsyncVar<bool>> recruitmentStalled,
+	    std::unordered_map<UID, std::vector<UID>> tLogGroupIdToServerIds,
+	    std::unordered_map<UID, std::vector<TLogGroupRef>> tlogServerIdToTlogGroups) {
 		state double startTime = now();
 		state Reference<TagPartitionedLogSystem> logSystem(
 		    new TagPartitionedLogSystem(oldLogSystem->getDebugID(), oldLogSystem->locality, recoveryCount));
@@ -2848,7 +2866,8 @@ struct TagPartitionedLogSystem : ILogSystem, ReferenceCounted<TagPartitionedLogS
 		state LogSystemConfig oldLogSystemConfig = oldLogSystem->getLogSystemConfig();
 
 		state vector<Future<TLogInterface>> initializationReplies;
-		vector<InitializeTLogRequest> reqs(recr.tLogs.size());
+		state vector<Future<ptxn::TLogInterface_PassivelyPull>> initializationRepliesPtxn;
+		state vector<InitializeTLogRequest> reqs = vector<InitializeTLogRequest>(recr.tLogs.size());
 
 		logSystem->tLogs[0]->tLogLocalities.resize(recr.tLogs.size());
 		logSystem->tLogs[0]->logServers.resize(
@@ -2902,14 +2921,26 @@ struct TagPartitionedLogSystem : ILogSystem, ReferenceCounted<TagPartitionedLogS
 			req.startVersion = logSystem->tLogs[0]->startVersion;
 			req.logRouterTags = logSystem->logRouterTags;
 			req.txsTags = logSystem->txsTags;
+
+			// Add TLogGroup here
+			if (SERVER_KNOBS->TLOG_NEW_INTERFACE) {
+				UID serverId = recr.tLogs[i].id();
+				std::vector<ptxn::TLogGroup> groups;
+				for (TLogGroupRef tlogGroup : tlogServerIdToTlogGroups[serverId]) {
+					groups.push_back(ptxn::TLogGroup(tlogGroup->id()));
+				}
+				req.tlogGroups = groups;
+			}
 		}
 
-		initializationReplies.reserve(recr.tLogs.size());
-		for (int i = 0; i < recr.tLogs.size(); i++)
-			initializationReplies.push_back(transformErrors(
-			    throwErrorOr(recr.tLogs[i].tLog.getReplyUnlessFailedFor(
-			        reqs[i], SERVER_KNOBS->TLOG_TIMEOUT, SERVER_KNOBS->MASTER_FAILURE_SLOPE_DURING_RECOVERY)),
-			    master_recovery_failed()));
+		if (!SERVER_KNOBS->TLOG_NEW_INTERFACE) {
+			initializationReplies.reserve(recr.tLogs.size());
+			for (int i = 0; i < recr.tLogs.size(); i++)
+				initializationReplies.push_back(transformErrors(
+				    throwErrorOr(recr.tLogs[i].tLog.getReplyUnlessFailedFor(
+				        reqs[i], SERVER_KNOBS->TLOG_TIMEOUT, SERVER_KNOBS->MASTER_FAILURE_SLOPE_DURING_RECOVERY)),
+				    master_recovery_failed()));
+		}
 
 		state std::vector<Future<Void>> recoveryComplete;
 
@@ -2996,11 +3027,35 @@ struct TagPartitionedLogSystem : ILogSystem, ReferenceCounted<TagPartitionedLogS
 
 		wait(waitForAll(initializationReplies) || oldRouterRecruitment);
 
-		for (int i = 0; i < initializationReplies.size(); i++) {
-			logSystem->tLogs[0]->logServers[i] = makeReference<AsyncVar<OptionalInterface<TLogInterface>>>(
-			    OptionalInterface<TLogInterface>(initializationReplies[i].get()));
-			logSystem->tLogs[0]->tLogLocalities[i] = recr.tLogs[i].locality;
+		if (SERVER_KNOBS->TLOG_NEW_INTERFACE) {
+			state std::unordered_map<UID, ptxn::TLogInterface_PassivelyPull> id2Interface;
+			state int i = 0;
+			for (i = 0; i < reqs.size(); i++) {
+				ASSERT(reqs[i].isPrimary);
+				// wait for interfaces being built from TLogServer, then construct id -> interface mapping
+				// cannot use more standard `getReplyUnlessFailedFor`, because it is waiting on `reply` field, here we
+				// have ptxn.reply
+				state ptxn::TLogInterface_PassivelyPull serverNew = wait(reqs[i].ptxnReply.getFuture());
+				id2Interface[recr.tLogs[i].id()] = serverNew;
+			}
+
+			for (auto it : tLogGroupIdToServerIds) {
+				for (UID serverId : it.second) {
+					UID groupId = it.first;
+					// from group_id -> list of server_id, to group_id -> list of interfaces
+					logSystem->tLogs[0]->groupIdToInterfaces[groupId].push_back(
+					    makeReference<AsyncVar<OptionalInterface<ptxn::TLogInterface_PassivelyPull>>>(
+					        OptionalInterface<ptxn::TLogInterface_PassivelyPull>(id2Interface[serverId])));
+				}
+			}
+		} else {
+			for (int i = 0; i < initializationReplies.size(); i++) {
+				logSystem->tLogs[0]->logServers[i] = makeReference<AsyncVar<OptionalInterface<TLogInterface>>>(
+				    OptionalInterface<TLogInterface>(initializationReplies[i].get()));
+				logSystem->tLogs[0]->tLogLocalities[i] = recr.tLogs[i].locality;
+			}
 		}
+
 		filterLocalityDataForPolicy(logSystem->tLogs[0]->tLogPolicy, &logSystem->tLogs[0]->tLogLocalities);
 
 		// Don't force failure of recovery if it took us a long time to recover. This avoids multiple long running
@@ -3011,6 +3066,7 @@ struct TagPartitionedLogSystem : ILogSystem, ReferenceCounted<TagPartitionedLogS
 		for (int i = 0; i < logSystem->tLogs[0]->logServers.size(); i++)
 			recoveryComplete.push_back(transformErrors(
 			    throwErrorOr(
+			        // TODO: make recoveryFinished work with new tlog interfaces.
 			        logSystem->tLogs[0]->logServers[i]->get().interf().recoveryFinished.getReplyUnlessFailedFor(
 			            TLogRecoveryFinishedRequest(),
 			            SERVER_KNOBS->TLOG_TIMEOUT,

--- a/fdbserver/masterserver.actor.cpp
+++ b/fdbserver/masterserver.actor.cpp
@@ -993,7 +993,7 @@ ACTOR static Future<Void> sendInitialCommitToResolvers(Reference<MasterData> sel
 		req.version = self->lastEpochEnd;
 		req.lastReceivedVersion = -1;
 		req.newGroups.reserve(self->tLogGroupCollection->groups().size());
-		for (auto& tLogGroup : self->tLogGroupCollection->groups()) {
+		for (const auto& tLogGroup : self->tLogGroupCollection->groups()) {
 			req.newGroups.push_back(tLogGroup->id());
 		}
 		replies.push_back(brokenPromiseToNever(r.resolve.getReply(req)));

--- a/fdbserver/masterserver.actor.cpp
+++ b/fdbserver/masterserver.actor.cpp
@@ -992,8 +992,10 @@ ACTOR static Future<Void> sendInitialCommitToResolvers(Reference<MasterData> sel
 		req.prevVersion = -1;
 		req.version = self->lastEpochEnd;
 		req.lastReceivedVersion = -1;
-		// TODO: add all team IDs to the request
-
+		req.newGroups.reserve(self->tLogGroupCollection->groups().size());
+		for (auto& tLogGroup : self->tLogGroupCollection->groups()) {
+			req.newGroups.push_back(tLogGroup->id());
+		}
 		replies.push_back(brokenPromiseToNever(r.resolve.getReply(req)));
 	}
 

--- a/fdbserver/ptxn/MessageSerializer.cpp
+++ b/fdbserver/ptxn/MessageSerializer.cpp
@@ -180,6 +180,10 @@ const Version& ProxySubsequencedMessageSerializer::getVersion() const {
 	return version;
 }
 
+void ProxySubsequencedMessageSerializer::setVersion(const Version& version) {
+	this->version = version;
+}
+
 void ProxySubsequencedMessageSerializer::prepareWriteMessage(const StorageTeamID& storageTeamID) {
 	// If the storage team ID is unseen, create a serializer for it.
 	if (serializers.find(storageTeamID) == serializers.end()) {

--- a/fdbserver/ptxn/MessageSerializer.cpp
+++ b/fdbserver/ptxn/MessageSerializer.cpp
@@ -180,10 +180,6 @@ const Version& ProxySubsequencedMessageSerializer::getVersion() const {
 	return version;
 }
 
-void ProxySubsequencedMessageSerializer::setVersion(const Version& version) {
-	this->version = version;
-}
-
 void ProxySubsequencedMessageSerializer::prepareWriteMessage(const StorageTeamID& storageTeamID) {
 	// If the storage team ID is unseen, create a serializer for it.
 	if (serializers.find(storageTeamID) == serializers.end()) {

--- a/fdbserver/ptxn/MessageSerializer.h
+++ b/fdbserver/ptxn/MessageSerializer.h
@@ -209,6 +209,9 @@ public:
 // Each serializer servers a single storage team ID. The serializer will only seriaize one version
 // (SubsequencedMessageSerializer supports serializing multiple versions).
 // This is useful for CommitProxies to serialize one commit into multiple storage team IDs.
+// TODO: introduce TLogGroupID into serializer for a two level serialization:
+// 		tloggroup1 : version, [team 1 header], team 1 mutations, [team 2 header], team 2 mutations
+//      tloggroup2 : version, [team 1 header], team 1 mutations, [team 3 header], team 3 mutations
 class ProxySubsequencedMessageSerializer {
 private:
 	// Mapper between StorageTeamID and SubsequencedMessageSerializer

--- a/fdbserver/ptxn/TLogGroupVersionTracker.h
+++ b/fdbserver/ptxn/TLogGroupVersionTracker.h
@@ -1,5 +1,5 @@
 /*
- * TeamVersionTracker.h
+ * TLogGroupVersionTracker.h
  *
  * This source file is part of the FoundationDB open source project
  *
@@ -31,37 +31,38 @@
 namespace ptxn {
 
 // Tracks the previous commit version (PCV) and commit version (CV) for each
-// team so that teams can progress at different rate, while down stream
+// group so that groups can progress at different rate, while down stream
 // components, e.g., TLogs or Storage Servers, can have ordered mutation
 // streams.
-class TeamVersionTracker {
+class TLogGroupVersionTracker {
 public:
-	TeamVersionTracker();
+	TLogGroupVersionTracker();
 
-	// Adds "teams" to the tracker with their "beginVersion", i.e., first PCV.
-	void addTeams(const std::vector<StorageTeamID>& teams, Version beginVersion);
+	// Adds "groups" to the tracker with their "beginVersion", i.e., first PCV.
+	void addGroups(const std::vector<TLogGroupID>& groups, Version beginVersion);
 
-	// Removes stale "teams" from this tracker.
-	void removeTeams(const std::vector<StorageTeamID>& teams);
+	// TODO: remove this function as TLog groups only gets updated at the beginning of an epoch
+	// Removes stale "groups" from this tracker.
+	void removeGroups(const std::vector<TLogGroupID>& groups);
 
-	// Updates "teams" with new commitVersion. Returns each team's PCV in a map.
-	std::map<StorageTeamID, Version> updateTeams(const std::vector<StorageTeamID>& teams, Version commitVersion);
+	// Updates "groups" with new commitVersion. Returns each group's PCV in a map.
+	std::map<TLogGroupID, Version> updateGroups(const std::vector<TLogGroupID>& groups, Version commitVersion);
 
-	// Returns the most lagging team and its CV.
-	std::pair<StorageTeamID, Version> mostLaggingTeam() const;
+	// Returns the most lagging group and its CV.
+	std::pair<TLogGroupID, Version> mostLaggingGroup() const;
 
-	// Returns the maximum commit version of all teams
+	// Returns the maximum commit version of all groups
 	Version getMaxCommitVersion() const { return maxCV; }
 
-	// Returns the CV of a team, or invalidVersion if not found.
-	Version getCommitVersion(StorageTeamID tid) const {
+	// Returns the CV of a group, or invalidVersion if not found.
+	Version getCommitVersion(TLogGroupID tid) const {
 		auto it = versions.find(tid);
 		return it == versions.end() ? invalidVersion : it->second;
 	}
 
 private:
-	std::map<StorageTeamID, Version> versions; // a map of StorageTeamID -> CV
-	Version maxCV = invalidVersion; // the maximum commit version of all teams
+	std::map<TLogGroupID, Version> versions; // a map of TLogGroupID -> CV
+	Version maxCV = invalidVersion; // the maximum commit version of all groups
 };
 
 } // namespace ptxn

--- a/fdbserver/ptxn/TLogInterface.h
+++ b/fdbserver/ptxn/TLogInterface.h
@@ -59,6 +59,10 @@ struct TLogCommitRequest {
 	// Team ID
 	StorageTeamID storageTeamID;
 
+	// TODO:
+	// std::unordered_map<StorageTeamID, StringRef> commits
+	// TLogGroupID group
+
 	// Arena
 	Arena arena;
 

--- a/fdbserver/ptxn/TLogServer.actor.cpp
+++ b/fdbserver/ptxn/TLogServer.actor.cpp
@@ -687,6 +687,7 @@ void TLogQueue::updateVersionSizes(const TLogQueueEntry& result,
 	}
 }
 
+// TODO: should deserialize messages to pairs of storage team -> message
 void commitMessages(Reference<TLogGroupData> self,
                     Reference<LogGenerationData> logData,
                     Version version,

--- a/fdbserver/ptxn/test/TestTLogServer.actor.cpp
+++ b/fdbserver/ptxn/test/TestTLogServer.actor.cpp
@@ -172,8 +172,11 @@ ACTOR Future<Void> startStorageServers(std::vector<Future<Void>>* actors,
 	auto& tLogSet = dbInfoBuilder.logSystemConfig.tLogs.back();
 	tLogSet.locality = locality;
 	for (auto tLogGroup : pContext->tLogGroupLeaders) {
-		tLogSet.ptxnTLogGroups[tLogGroup.first].push_back(OptionalInterface<ptxn::TLogInterface_PassivelyPull>(
-		    *std::dynamic_pointer_cast<ptxn::TLogInterface_PassivelyPull>(tLogGroup.second)));
+		OptionalInterface<ptxn::TLogInterface_PassivelyPull> optionalInterface =
+		    OptionalInterface<ptxn::TLogInterface_PassivelyPull>(
+		        *std::dynamic_pointer_cast<ptxn::TLogInterface_PassivelyPull>(tLogGroup.second));
+		tLogSet.ptxnTLogGroups[tLogGroup.first].push_back(
+		    makeReference<AsyncVar<OptionalInterface<ptxn::TLogInterface_PassivelyPull>>>(optionalInterface));
 	}
 	state Reference<AsyncVar<ServerDBInfo>> dbInfo = makeReference<AsyncVar<ServerDBInfo>>(dbInfoBuilder);
 	state Version tssSeedVersion = 0;


### PR DESCRIPTION
- Change resolver interface to take tlog groups instead of storage teams
- Change TeamVersionTracker to TLogGroupVersionTracker

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
