### PR TITLE
Static assert that LiteralStringRef arg is literal string

### DIFF
--- a/fdbserver/VersionedBTree.actor.cpp
+++ b/fdbserver/VersionedBTree.actor.cpp
@@ -1401,25 +1401,22 @@ struct RedwoodMetrics {
 			metrics = {};
 			if (!buildFillPctSketch.isValid() ||
 			    buildFillPctSketch->name() != ("buildFillPct:" + std::to_string(levelCounter))) {
-				buildFillPctSketch = Histogram::getHistogram(LiteralStringRef("buildFillPct"),
-				                                             LiteralStringRef(std::to_string(levelCounter).c_str()),
-				                                             Histogram::Unit::percentage);
-				modifyFillPctSketch = Histogram::getHistogram(LiteralStringRef("modifyFillPct"),
-				                                              LiteralStringRef(std::to_string(levelCounter).c_str()),
-				                                              Histogram::Unit::percentage);
-				buildStoredPctSketch = Histogram::getHistogram(LiteralStringRef("buildStoredPct"),
-				                                               LiteralStringRef(std::to_string(levelCounter).c_str()),
-				                                               Histogram::Unit::percentage);
-				modifyStoredPctSketch = Histogram::getHistogram(LiteralStringRef("modifyStoredPct"),
-				                                                LiteralStringRef(std::to_string(levelCounter).c_str()),
-				                                                Histogram::Unit::percentage);
+				std::string levelCounterStr = std::to_string(levelCounter);
+				buildFillPctSketch = Histogram::getHistogram(
+				    LiteralStringRef("buildFillPct"), StringRef(levelCounterStr), Histogram::Unit::percentage);
+				modifyFillPctSketch = Histogram::getHistogram(
+				    LiteralStringRef("modifyFillPct"), StringRef(levelCounterStr), Histogram::Unit::percentage);
+				buildStoredPctSketch = Histogram::getHistogram(
+				    LiteralStringRef("buildStoredPct"), StringRef(levelCounterStr), Histogram::Unit::percentage);
+				modifyStoredPctSketch = Histogram::getHistogram(
+				    LiteralStringRef("modifyStoredPct"), StringRef(levelCounterStr), Histogram::Unit::percentage);
 				buildItemCountSketch = Histogram::getHistogram(LiteralStringRef("buildItemCount"),
-				                                               LiteralStringRef(std::to_string(levelCounter).c_str()),
+				                                               StringRef(levelCounterStr),
 				                                               Histogram::Unit::count,
 				                                               0,
 				                                               maxRecordCount);
 				modifyItemCountSketch = Histogram::getHistogram(LiteralStringRef("modifyItemCount"),
-				                                                LiteralStringRef(std::to_string(levelCounter).c_str()),
+				                                                StringRef(levelCounterStr),
 				                                                Histogram::Unit::count,
 				                                                0,
 				                                                maxRecordCount);

--- a/flow/Arena.h
+++ b/flow/Arena.h
@@ -662,7 +662,15 @@ struct Traceable<Standalone<T>> : std::conditional<Traceable<T>::value, std::tru
 	static std::string toString(const Standalone<T>& value) { return Traceable<T>::toString(value); }
 };
 
-#define LiteralStringRef(str) StringRef((const uint8_t*)(str), sizeof((str)) - 1)
+namespace literal_string_ref {
+template <class T, int Size>
+StringRef LiteralStringRefHelper(const char* str) {
+	static_assert(std::is_same_v<T, const char(&)[Size]>, "Argument to LiteralStringRef must be a literal string");
+	return StringRef(reinterpret_cast<const uint8_t*>(str), Size);
+}
+} // namespace literal_string_ref
+#define LiteralStringRef(str) literal_string_ref::LiteralStringRefHelper<decltype(str), sizeof(str)>(str)
+
 inline StringRef operator"" _sr(const char* str, size_t size) {
 	return StringRef(reinterpret_cast<const uint8_t*>(str), size);
 }

--- a/flow/Arena.h
+++ b/flow/Arena.h
@@ -666,7 +666,7 @@ namespace literal_string_ref {
 template <class T, int Size>
 StringRef LiteralStringRefHelper(const char* str) {
 	static_assert(std::is_same_v<T, const char(&)[Size]>, "Argument to LiteralStringRef must be a literal string");
-	return StringRef(reinterpret_cast<const uint8_t*>(str), Size);
+	return StringRef(reinterpret_cast<const uint8_t*>(str), Size - 1);
 }
 } // namespace literal_string_ref
 #define LiteralStringRef(str) literal_string_ref::LiteralStringRefHelper<decltype(str), sizeof(str)>(str)


### PR DESCRIPTION
Tested that `LiteralStringRef(std::to_string(levelCounter).c_str())` no longer compiles

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
