### PR TITLE
replace StringRef with _sr where possible

### DIFF
--- a/bindings/flow/DirectoryLayer.actor.cpp
+++ b/bindings/flow/DirectoryLayer.actor.cpp
@@ -23,17 +23,17 @@
 
 namespace FDB {
 const uint8_t DirectoryLayer::LITTLE_ENDIAN_LONG_ONE[8] = { 1, 0, 0, 0, 0, 0, 0, 0 };
-const StringRef DirectoryLayer::HIGH_CONTENTION_KEY = LiteralStringRef("hca");
-const StringRef DirectoryLayer::LAYER_KEY = LiteralStringRef("layer");
-const StringRef DirectoryLayer::VERSION_KEY = LiteralStringRef("version");
+const StringRef DirectoryLayer::HIGH_CONTENTION_KEY = "hca"_sr;
+const StringRef DirectoryLayer::LAYER_KEY = "layer"_sr;
+const StringRef DirectoryLayer::VERSION_KEY = "version"_sr;
 const int64_t DirectoryLayer::SUB_DIR_KEY = 0;
 
 const uint32_t DirectoryLayer::VERSION[3] = { 1, 0, 0 };
 
-const StringRef DirectoryLayer::DEFAULT_NODE_SUBSPACE_PREFIX = LiteralStringRef("\xfe");
+const StringRef DirectoryLayer::DEFAULT_NODE_SUBSPACE_PREFIX = "\xfe"_sr;
 const Subspace DirectoryLayer::DEFAULT_NODE_SUBSPACE = Subspace(DEFAULT_NODE_SUBSPACE_PREFIX);
 const Subspace DirectoryLayer::DEFAULT_CONTENT_SUBSPACE = Subspace();
-const StringRef DirectoryLayer::PARTITION_LAYER = LiteralStringRef("partition");
+const StringRef DirectoryLayer::PARTITION_LAYER = "partition"_sr;
 
 DirectoryLayer::DirectoryLayer(Subspace nodeSubspace, Subspace contentSubspace, bool allowManualPrefixes)
   : nodeSubspace(nodeSubspace), contentSubspace(contentSubspace), allowManualPrefixes(allowManualPrefixes),

--- a/bindings/flow/FDBLoanerTypes.h
+++ b/bindings/flow/FDBLoanerTypes.h
@@ -31,7 +31,7 @@ typedef Standalone<KeyRef> Key;
 typedef Standalone<ValueRef> Value;
 
 inline Key keyAfter(const KeyRef& key) {
-	if (key == LiteralStringRef("\xff\xff"))
+	if (key == "\xff\xff"_sr)
 		return key;
 
 	Standalone<StringRef> r;
@@ -43,7 +43,7 @@ inline Key keyAfter(const KeyRef& key) {
 }
 
 inline KeyRef keyAfter(const KeyRef& key, Arena& arena) {
-	if (key == LiteralStringRef("\xff\xff"))
+	if (key == "\xff\xff"_sr)
 		return key;
 	uint8_t* t = new (arena) uint8_t[key.size() + 1];
 	memcpy(t, key.begin(), key.size());

--- a/bindings/flow/fdb_flow.actor.cpp
+++ b/bindings/flow/fdb_flow.actor.cpp
@@ -62,15 +62,14 @@ ACTOR Future<Void> _test() {
 	// wait( waitForAllReady( versions ) );
 	printf("Elapsed: %lf\n", timer_monotonic() - starttime);
 
-	tr->set(LiteralStringRef("foo"), LiteralStringRef("bar"));
+	tr->set("foo"_sr, "bar"_sr);
 
-	Optional<FDBStandalone<ValueRef>> v = wait(tr->get(LiteralStringRef("foo")));
+	Optional<FDBStandalone<ValueRef>> v = wait(tr->get("foo"_sr));
 	if (v.present()) {
 		printf("%s\n", v.get().toString().c_str());
 	}
 
-	FDBStandalone<RangeResultRef> r =
-	    wait(tr->getRange(KeyRangeRef(LiteralStringRef("a"), LiteralStringRef("z")), 100));
+	FDBStandalone<RangeResultRef> r = wait(tr->getRange(KeyRangeRef("a"_sr, "z"_sr), 100));
 
 	for (auto kv : r) {
 		printf("%s is %s\n", kv.key.toString().c_str(), kv.value.toString().c_str());

--- a/bindings/flow/tester/DirectoryTester.actor.cpp
+++ b/bindings/flow/tester/DirectoryTester.actor.cpp
@@ -545,11 +545,10 @@ struct DirectoryLogDirectoryFunc : InstructionFunc {
 			pathTuple.append(p, true);
 		}
 
-		instruction->tr->set(logSubspace.pack(LiteralStringRef("path"), true), pathTuple.pack());
-		instruction->tr->set(logSubspace.pack(LiteralStringRef("layer"), true),
-		                     Tuple().append(directory->getLayer()).pack());
-		instruction->tr->set(logSubspace.pack(LiteralStringRef("exists"), true), Tuple().append(exists ? 1 : 0).pack());
-		instruction->tr->set(logSubspace.pack(LiteralStringRef("children"), true), childrenTuple.pack());
+		instruction->tr->set(logSubspace.pack("path"_sr, true), pathTuple.pack());
+		instruction->tr->set(logSubspace.pack("layer"_sr, true), Tuple().append(directory->getLayer()).pack());
+		instruction->tr->set(logSubspace.pack("exists"_sr, true), Tuple().append(exists ? 1 : 0).pack());
+		instruction->tr->set(logSubspace.pack("children"_sr, true), childrenTuple.pack());
 
 		return Void();
 	}

--- a/bindings/flow/tester/Tester.actor.cpp
+++ b/bindings/flow/tester/Tester.actor.cpp
@@ -464,12 +464,12 @@ ACTOR Future<Standalone<StringRef>> waitForVoid(Future<Void> f) {
 	try {
 		wait(f);
 		Tuple t;
-		t.append(LiteralStringRef("RESULT_NOT_PRESENT"));
+		t.append("RESULT_NOT_PRESENT"_sr);
 		return t.pack();
 	} catch (Error& e) {
 		// printf("FDBError1:%d\n", e.code());
 		Tuple t;
-		t.append(LiteralStringRef("ERROR"));
+		t.append("ERROR"_sr);
 		t.append(format("%d", e.code()));
 		// pack above as error string into another tuple
 		Tuple ret;
@@ -487,7 +487,7 @@ ACTOR Future<Standalone<StringRef>> waitForValue(Future<FDBStandalone<KeyRef>> f
 	} catch (Error& e) {
 		// printf("FDBError2:%d\n", e.code());
 		Tuple t;
-		t.append(LiteralStringRef("ERROR"));
+		t.append("ERROR"_sr);
 		t.append(format("%d", e.code()));
 		// pack above as error string into another tuple
 		Tuple ret;
@@ -503,7 +503,7 @@ ACTOR Future<Standalone<StringRef>> waitForValue(Future<Optional<FDBStandalone<V
 		if (value.present())
 			str = value.get();
 		else
-			str = LiteralStringRef("RESULT_NOT_PRESENT");
+			str = "RESULT_NOT_PRESENT"_sr;
 
 		Tuple t;
 		t.append(str);
@@ -511,7 +511,7 @@ ACTOR Future<Standalone<StringRef>> waitForValue(Future<Optional<FDBStandalone<V
 	} catch (Error& e) {
 		// printf("FDBError3:%d\n", e.code());
 		Tuple t;
-		t.append(LiteralStringRef("ERROR"));
+		t.append("ERROR"_sr);
 		t.append(format("%d", e.code()));
 		// pack above as error string into another tuple
 		Tuple ret;
@@ -537,7 +537,7 @@ ACTOR Future<Standalone<StringRef>> getKey(Future<FDBStandalone<KeyRef>> f, Stan
 	} catch (Error& e) {
 		// printf("FDBError4:%d\n", e.code());
 		Tuple t;
-		t.append(LiteralStringRef("ERROR"));
+		t.append("ERROR"_sr);
 		t.append(format("%d", e.code()));
 		// pack above as error string into another tuple
 		Tuple ret;
@@ -664,7 +664,7 @@ struct GetEstimatedRangeSize : InstructionFunc {
 		state Standalone<StringRef> endKey = Tuple::unpack(s2).getString(0);
 		Future<int64_t> fsize = instruction->tr->getEstimatedRangeSizeBytes(KeyRangeRef(beginKey, endKey));
 		int64_t size = wait(fsize);
-		data->stack.pushTuple(LiteralStringRef("GOT_ESTIMATED_RANGE_SIZE"));
+		data->stack.pushTuple("GOT_ESTIMATED_RANGE_SIZE"_sr);
 
 		return Void();
 	}
@@ -692,7 +692,7 @@ struct GetRangeSplitPoints : InstructionFunc {
 		Future<FDBStandalone<VectorRef<KeyRef>>> fsplitPoints =
 		    instruction->tr->getRangeSplitPoints(KeyRangeRef(beginKey, endKey), chunkSize);
 		FDBStandalone<VectorRef<KeyRef>> splitPoints = wait(fsplitPoints);
-		data->stack.pushTuple(LiteralStringRef("GOT_RANGE_SPLIT_POINTS"));
+		data->stack.pushTuple("GOT_RANGE_SPLIT_POINTS"_sr);
 
 		return Void();
 	}
@@ -737,7 +737,7 @@ struct GetReadVersionFunc : InstructionFunc {
 	ACTOR static Future<Void> call(Reference<FlowTesterData> data, Reference<InstructionData> instruction) {
 		Version v = wait(instruction->tr->getReadVersion());
 		data->lastVersion = v;
-		data->stack.pushTuple(LiteralStringRef("GOT_READ_VERSION"));
+		data->stack.pushTuple("GOT_READ_VERSION"_sr);
 		return Void();
 	}
 };
@@ -761,7 +761,7 @@ struct GetCommittedVersionFunc : InstructionFunc {
 
 	static Future<Void> call(Reference<FlowTesterData> const& data, Reference<InstructionData> const& instruction) {
 		data->lastVersion = instruction->tr->getCommittedVersion();
-		data->stack.pushTuple(LiteralStringRef("GOT_COMMITTED_VERSION"));
+		data->stack.pushTuple("GOT_COMMITTED_VERSION"_sr);
 		return Void();
 	}
 };
@@ -775,7 +775,7 @@ struct GetApproximateSizeFunc : InstructionFunc {
 	ACTOR static Future<Void> call(Reference<FlowTesterData> data, Reference<InstructionData> instruction) {
 		int64_t _ = wait(instruction->tr->getApproximateSize());
 		(void)_; // disable unused variable warning
-		data->stack.pushTuple(LiteralStringRef("GOT_APPROXIMATE_SIZE"));
+		data->stack.pushTuple("GOT_APPROXIMATE_SIZE"_sr);
 		return Void();
 	}
 };
@@ -1475,7 +1475,7 @@ struct ReadConflictKeyFunc : InstructionFunc {
 		// printf("=========READ_CONFLICT_KEY:%s\n", printable(key).c_str());
 		instruction->tr->addReadConflictKey(key);
 
-		data->stack.pushTuple(LiteralStringRef("SET_CONFLICT_KEY"));
+		data->stack.pushTuple("SET_CONFLICT_KEY"_sr);
 		return Void();
 	}
 };
@@ -1496,7 +1496,7 @@ struct WriteConflictKeyFunc : InstructionFunc {
 		// printf("=========WRITE_CONFLICT_KEY:%s\n", printable(key).c_str());
 		instruction->tr->addWriteConflictKey(key);
 
-		data->stack.pushTuple(LiteralStringRef("SET_CONFLICT_KEY"));
+		data->stack.pushTuple("SET_CONFLICT_KEY"_sr);
 		return Void();
 	}
 };
@@ -1519,7 +1519,7 @@ struct ReadConflictRangeFunc : InstructionFunc {
 
 		// printf("=========READ_CONFLICT_RANGE:%s:%s\n", printable(begin).c_str(), printable(end).c_str());
 		instruction->tr->addReadConflictRange(KeyRange(KeyRangeRef(begin, end)));
-		data->stack.pushTuple(LiteralStringRef("SET_CONFLICT_RANGE"));
+		data->stack.pushTuple("SET_CONFLICT_RANGE"_sr);
 		return Void();
 	}
 };
@@ -1543,7 +1543,7 @@ struct WriteConflictRangeFunc : InstructionFunc {
 		// printf("=========WRITE_CONFLICT_RANGE:%s:%s\n", printable(begin).c_str(), printable(end).c_str());
 		instruction->tr->addWriteConflictRange(KeyRange(KeyRangeRef(begin, end)));
 
-		data->stack.pushTuple(LiteralStringRef("SET_CONFLICT_RANGE"));
+		data->stack.pushTuple("SET_CONFLICT_RANGE"_sr);
 		return Void();
 	}
 };
@@ -1633,10 +1633,8 @@ struct UnitTestsFunc : InstructionFunc {
 		                            Optional<StringRef>(StringRef((const uint8_t*)&locationCacheSize, 8)));
 		data->db->setDatabaseOption(FDBDatabaseOption::FDB_DB_OPTION_MAX_WATCHES,
 		                            Optional<StringRef>(StringRef((const uint8_t*)&maxWatches, 8)));
-		data->db->setDatabaseOption(FDBDatabaseOption::FDB_DB_OPTION_DATACENTER_ID,
-		                            Optional<StringRef>(LiteralStringRef("dc_id")));
-		data->db->setDatabaseOption(FDBDatabaseOption::FDB_DB_OPTION_MACHINE_ID,
-		                            Optional<StringRef>(LiteralStringRef("machine_id")));
+		data->db->setDatabaseOption(FDBDatabaseOption::FDB_DB_OPTION_DATACENTER_ID, Optional<StringRef>("dc_id"_sr));
+		data->db->setDatabaseOption(FDBDatabaseOption::FDB_DB_OPTION_MACHINE_ID, Optional<StringRef>("machine_id"_sr));
 		data->db->setDatabaseOption(FDBDatabaseOption::FDB_DB_OPTION_SNAPSHOT_RYW_ENABLE);
 		data->db->setDatabaseOption(FDBDatabaseOption::FDB_DB_OPTION_SNAPSHOT_RYW_DISABLE);
 		data->db->setDatabaseOption(FDBDatabaseOption::FDB_DB_OPTION_TRANSACTION_LOGGING_MAX_FIELD_LENGTH,
@@ -1675,13 +1673,13 @@ struct UnitTestsFunc : InstructionFunc {
 		              Optional<StringRef>(StringRef((const uint8_t*)&maxRetryDelay, 8)));
 		tr->setOption(FDBTransactionOption::FDB_TR_OPTION_USED_DURING_COMMIT_PROTECTION_DISABLE);
 		tr->setOption(FDBTransactionOption::FDB_TR_OPTION_TRANSACTION_LOGGING_ENABLE,
-		              Optional<StringRef>(LiteralStringRef("my_transaction")));
+		              Optional<StringRef>("my_transaction"_sr));
 		tr->setOption(FDBTransactionOption::FDB_TR_OPTION_READ_LOCK_AWARE);
 		tr->setOption(FDBTransactionOption::FDB_TR_OPTION_LOCK_AWARE);
 		tr->setOption(FDBTransactionOption::FDB_TR_OPTION_INCLUDE_PORT_IN_ADDRESS);
 		tr->setOption(FDBTransactionOption::FDB_TR_OPTION_REPORT_CONFLICTING_KEYS);
 
-		Optional<FDBStandalone<ValueRef>> _ = wait(tr->get(LiteralStringRef("\xff")));
+		Optional<FDBStandalone<ValueRef>> _ = wait(tr->get("\xff"_sr));
 		tr->cancel();
 
 		return Void();
@@ -1714,13 +1712,13 @@ ACTOR static Future<Void> doInstructions(Reference<FlowTesterData> data) {
 		Tuple opTuple = Tuple::unpack(data->instructions[idx].value);
 		state Standalone<StringRef> op = opTuple.getString(0);
 
-		state bool isDatabase = op.endsWith(LiteralStringRef("_DATABASE"));
-		state bool isSnapshot = op.endsWith(LiteralStringRef("_SNAPSHOT"));
-		state bool isDirectory = op.startsWith(LiteralStringRef("DIRECTORY_"));
+		state bool isDatabase = op.endsWith("_DATABASE"_sr);
+		state bool isSnapshot = op.endsWith("_SNAPSHOT"_sr);
+		state bool isDirectory = op.startsWith("DIRECTORY_"_sr);
 
 		try {
 			if (LOG_INSTRUCTIONS) {
-				if (op != LiteralStringRef("SWAP") && op != LiteralStringRef("PUSH")) {
+				if (op != "SWAP"_sr && op != "PUSH"_sr) {
 					printf("%zu. %s\n", idx, tupleToString(opTuple).c_str());
 					fflush(stdout);
 				}
@@ -1763,7 +1761,7 @@ ACTOR static Future<Void> doInstructions(Reference<FlowTesterData> data) {
 				if (opsThatCreateDirectories.count(op.toString())) {
 					data->directoryData.directoryList.push_back(DirectoryOrSubspace());
 				}
-				data->stack.pushTuple(LiteralStringRef("DIRECTORY_ERROR"));
+				data->stack.pushTuple("DIRECTORY_ERROR"_sr);
 			} else {
 				data->stack.pushError(e.code());
 			}
@@ -1873,15 +1871,14 @@ ACTOR void _test_versionstamp() {
 
 		state Future<FDBStandalone<StringRef>> ftrVersion = tr->getVersionstamp();
 
-		tr->atomicOp(LiteralStringRef("foo"),
-		             LiteralStringRef("blahblahbl\x00\x00\x00\x00"),
-		             FDBMutationType::FDB_MUTATION_TYPE_SET_VERSIONSTAMPED_VALUE);
+		tr->atomicOp(
+		    "foo"_sr, "blahblahbl\x00\x00\x00\x00"_sr, FDBMutationType::FDB_MUTATION_TYPE_SET_VERSIONSTAMPED_VALUE);
 
 		wait(tr->commit()); // should use retry loop
 
 		tr->reset();
 
-		Optional<FDBStandalone<StringRef>> optionalDbVersion = wait(tr->get(LiteralStringRef("foo")));
+		Optional<FDBStandalone<StringRef>> optionalDbVersion = wait(tr->get("foo"_sr));
 		state FDBStandalone<StringRef> dbVersion = optionalDbVersion.get();
 		FDBStandalone<StringRef> trVersion = wait(ftrVersion);
 

--- a/bindings/flow/tester/Tester.actor.h
+++ b/bindings/flow/tester/Tester.actor.h
@@ -71,7 +71,7 @@ struct FlowTesterStack {
 
 	void pushError(int errorCode) {
 		FDB::Tuple t;
-		t.append(LiteralStringRef("ERROR"));
+		t.append("ERROR"_sr);
 		t.append(format("%d", errorCode));
 		// pack above as error string into another tuple
 		pushTuple(t.pack().toString());

--- a/design/special-key-space.md
+++ b/design/special-key-space.md
@@ -32,10 +32,10 @@ public:
     explicit SKRExampleImpl(KeyRangeRef kr): SpecialKeyRangeReadImpl(kr) {
         // Our implementation is quite simple here, the key-value pairs are formatted as:
         // \xff\xff/example/<country_name> : <capital_city_name>
-        CountryToCapitalCity[LiteralStringRef("USA")] = LiteralStringRef("Washington, D.C.");
-        CountryToCapitalCity[LiteralStringRef("UK")] = LiteralStringRef("London");
-        CountryToCapitalCity[LiteralStringRef("Japan")] = LiteralStringRef("Tokyo");
-        CountryToCapitalCity[LiteralStringRef("China")] = LiteralStringRef("Beijing");
+        CountryToCapitalCity["USA"_sr] = "Washington, D.C."_sr;
+        CountryToCapitalCity["UK"_sr] = "London"_sr;
+        CountryToCapitalCity["Japan"_sr] = "Tokyo"_sr;
+        CountryToCapitalCity["China"_sr] = "Beijing"_sr;
     }
     // Implement the getRange interface
     Future<RangeResult> getRange(ReadYourWritesTransaction* ryw,
@@ -58,7 +58,7 @@ private:
 };
 // Instantiate the function object
 // In development, you should have a function object pointer in DatabaseContext(DatabaseContext.h) and initialize in DatabaseContext's constructor(NativeAPI.actor.cpp)
-const KeyRangeRef exampleRange(LiteralStringRef("\xff\xff/example/"), LiteralStringRef("\xff\xff/example/\xff"));
+const KeyRangeRef exampleRange("\xff\xff/example/"_sr, "\xff\xff/example/\xff"_sr);
 SKRExampleImpl exampleImpl(exampleRange);
 // Assuming the database handler is `cx`, register to special-key-space
 // In development, you should register all function objects in the constructor of DatabaseContext(NativeAPI.actor.cpp)
@@ -67,16 +67,16 @@ cx->specialKeySpace->registerKeyRange(exampleRange, &exampleImpl);
 state ReadYourWritesTransaction tr(cx);
 // get
 Optional<Value> res1 = wait(tr.get("\xff\xff/example/Japan"));
-ASSERT(res1.present() && res.getValue() == LiteralStringRef("Tokyo"));
+ASSERT(res1.present() && res.getValue() == "Tokyo"_sr);
 // getRange
 // Note: for getRange(key1, key2), both key1 and key2 should prefixed with \xff\xff
 // something like getRange("normal_key", "\xff\xff/...") is not supported yet
-RangeResult res2 = wait(tr.getRange(LiteralStringRef("\xff\xff/example/U"), LiteralStringRef("\xff\xff/example/U\xff")));
+RangeResult res2 = wait(tr.getRange("\xff\xff/example/U"_sr, "\xff\xff/example/U\xff"_sr));
 // res2 should contain USA and UK
 ASSERT(
     res2.size() == 2 &&
-    res2[0].value == LiteralStringRef("London") &&
-    res2[1].value == LiteralStringRef("Washington, D.C.")
+    res2[0].value == "London"_sr &&
+    res2[1].value == "Washington, D.C."_sr
 );
 ```
 

--- a/documentation/sphinx/source/global-configuration.rst
+++ b/documentation/sphinx/source/global-configuration.rst
@@ -82,7 +82,7 @@ Values must always be encoded according to the :ref:`api-python-tuple-layer`.
    // In GlobalConfig.actor.h
    extern const KeyRef myGlobalConfigKey;
    // In GlobalConfig.actor.cpp
-   const KeyRef myGlobalConfigKey = LiteralStringRef("config/key");
+   const KeyRef myGlobalConfigKey = "config/key"_sr;
    
    // When you want to set the value..
    Tuple value = Tuple().appendDouble(1.5);

--- a/documentation/tutorial/tutorial.actor.cpp
+++ b/documentation/tutorial/tutorial.actor.cpp
@@ -470,7 +470,7 @@ ACTOR Future<Void> fdbClient() {
 	state Transaction tx(db);
 	state std::string keyPrefix = "/tut/";
 	state Key startKey;
-	state KeyRef endKey = LiteralStringRef("/tut0");
+	state KeyRef endKey = "/tut0"_sr;
 	state int beginIdx = 0;
 	loop {
 		try {
@@ -486,7 +486,7 @@ ACTOR Future<Void> fdbClient() {
 			RangeResult range = wait(tx.getRange(KeyRangeRef(startKey, endKey), 100));
 			for (int i = 0; i < 10; ++i) {
 				Key k = Key(keyPrefix + std::to_string(beginIdx + deterministicRandom()->randomInt(0, 100)));
-				tx.set(k, LiteralStringRef("foo"));
+				tx.set(k, "foo"_sr);
 			}
 			wait(tx.commit());
 			std::cout << "Committed\n";

--- a/fdbbackup/backup.actor.cpp
+++ b/fdbbackup/backup.actor.cpp
@@ -893,12 +893,12 @@ CSimpleOpt::SOption g_rgDBPauseOptions[] = {
 	    SO_END_OF_OPTIONS
 };
 
-const KeyRef exeAgent = LiteralStringRef("backup_agent");
-const KeyRef exeBackup = LiteralStringRef("fdbbackup");
-const KeyRef exeRestore = LiteralStringRef("fdbrestore");
-const KeyRef exeFastRestoreTool = LiteralStringRef("fastrestore_tool"); // must be lower case
-const KeyRef exeDatabaseAgent = LiteralStringRef("dr_agent");
-const KeyRef exeDatabaseBackup = LiteralStringRef("fdbdr");
+const KeyRef exeAgent = "backup_agent"_sr;
+const KeyRef exeBackup = "fdbbackup"_sr;
+const KeyRef exeRestore = "fdbrestore"_sr;
+const KeyRef exeFastRestoreTool = "fastrestore_tool"_sr; // must be lower case
+const KeyRef exeDatabaseAgent = "dr_agent"_sr;
+const KeyRef exeDatabaseBackup = "fdbdr"_sr;
 
 extern const char* getSourceVersion();
 
@@ -1347,7 +1347,7 @@ ProgramExe getProgramType(std::string programExe) {
 	}
 #endif
 	// For debugging convenience, remove .debug suffix if present.
-	if (StringRef(programExe).endsWith(LiteralStringRef(".debug")))
+	if (StringRef(programExe).endsWith(".debug"_sr))
 		programExe = programExe.substr(0, programExe.size() - 6);
 
 	// Check if backup agent
@@ -2429,15 +2429,8 @@ ACTOR Future<Void> runFastRestoreTool(Database db,
 			TraceEvent("FastRestoreTool")
 			    .detail("SubmitRestoreRequests", ranges.size())
 			    .detail("RestoreUID", randomUID);
-			wait(backupAgent.submitParallelRestore(db,
-			                                       KeyRef(tagName),
-			                                       ranges,
-			                                       KeyRef(container),
-			                                       dbVersion,
-			                                       LockDB::True,
-			                                       randomUID,
-			                                       LiteralStringRef(""),
-			                                       LiteralStringRef("")));
+			wait(backupAgent.submitParallelRestore(
+			    db, KeyRef(tagName), ranges, KeyRef(container), dbVersion, LockDB::True, randomUID, ""_sr, ""_sr));
 			// TODO: Support addPrefix and removePrefix
 			if (waitForDone) {
 				// Wait for parallel restore to finish and unlock DB after that
@@ -3052,7 +3045,7 @@ static void addKeyRange(std::string optionValue, Standalone<VectorRef<KeyRangeRe
 Version parseVersion(const char* str) {
 	StringRef s((const uint8_t*)str, strlen(str));
 
-	if (s.endsWith(LiteralStringRef("days")) || s.endsWith(LiteralStringRef("d"))) {
+	if (s.endsWith("days"_sr) || s.endsWith("d"_sr)) {
 		float days;
 		if (sscanf(str, "%f", &days) != 1) {
 			fprintf(stderr, "Could not parse version: %s\n", str);
@@ -3405,7 +3398,7 @@ int main(int argc, char* argv[]) {
 				break;
 			case OPT_LOCALITY: {
 				std::string syn = args->OptionSyntax();
-				if (!StringRef(syn).startsWith(LiteralStringRef("--locality_"))) {
+				if (!StringRef(syn).startsWith("--locality_"_sr)) {
 					fprintf(stderr, "ERROR: unable to parse locality key '%s'\n", syn.c_str());
 					return FDB_EXIT_ERROR;
 				}
@@ -3472,7 +3465,7 @@ int main(int argc, char* argv[]) {
 				break;
 			case OPT_KNOB: {
 				std::string syn = args->OptionSyntax();
-				if (!StringRef(syn).startsWith(LiteralStringRef("--knob_"))) {
+				if (!StringRef(syn).startsWith("--knob_"_sr)) {
 					fprintf(stderr, "ERROR: unable to parse knob option '%s'\n", syn.c_str());
 					return FDB_EXIT_ERROR;
 				}
@@ -3499,7 +3492,7 @@ int main(int argc, char* argv[]) {
 			case OPT_DESTCONTAINER:
 				destinationContainer = args->OptionArg();
 				// If the url starts with '/' then prepend "file://" for backwards compatibility
-				if (StringRef(destinationContainer).startsWith(LiteralStringRef("/")))
+				if (StringRef(destinationContainer).startsWith("/"_sr))
 					destinationContainer = std::string("file://") + destinationContainer;
 				modifyOptions.destURL = destinationContainer;
 				break;
@@ -3545,7 +3538,7 @@ int main(int argc, char* argv[]) {
 			case OPT_RESTORECONTAINER:
 				restoreContainer = args->OptionArg();
 				// If the url starts with '/' then prepend "file://" for backwards compatibility
-				if (StringRef(restoreContainer).startsWith(LiteralStringRef("/")))
+				if (StringRef(restoreContainer).startsWith("/"_sr))
 					restoreContainer = std::string("file://") + restoreContainer;
 				break;
 			case OPT_DESCRIBE_DEEP:
@@ -4232,19 +4225,19 @@ int main(int argc, char* argv[]) {
 				char* demangled = abi::__cxa_demangle(i->first, NULL, NULL, NULL);
 				if (demangled) {
 					s = demangled;
-					if (StringRef(s).startsWith(LiteralStringRef("(anonymous namespace)::")))
-						s = s.substr(LiteralStringRef("(anonymous namespace)::").size());
+					if (StringRef(s).startsWith("(anonymous namespace)::"_sr))
+						s = s.substr("(anonymous namespace)::"_sr.size());
 					free(demangled);
 				} else
 					s = i->first;
 #else
 				s = i->first;
-				if (StringRef(s).startsWith(LiteralStringRef("class `anonymous namespace'::")))
-					s = s.substr(LiteralStringRef("class `anonymous namespace'::").size());
-				else if (StringRef(s).startsWith(LiteralStringRef("class ")))
-					s = s.substr(LiteralStringRef("class ").size());
-				else if (StringRef(s).startsWith(LiteralStringRef("struct ")))
-					s = s.substr(LiteralStringRef("struct ").size());
+				if (StringRef(s).startsWith("class `anonymous namespace'::"_sr))
+					s = s.substr("class `anonymous namespace'::"_sr.size());
+				else if (StringRef(s).startsWith("class "_sr))
+					s = s.substr("class "_sr.size());
+				else if (StringRef(s).startsWith("struct "_sr))
+					s = s.substr("struct "_sr.size());
 #endif
 
 				typeNames.emplace_back(s, i->first);

--- a/fdbcli/AdvanceVersionCommand.actor.cpp
+++ b/fdbcli/AdvanceVersionCommand.actor.cpp
@@ -31,7 +31,7 @@
 
 namespace fdb_cli {
 
-const KeyRef advanceVersionSpecialKey = LiteralStringRef("\xff\xff/management/min_required_commit_version");
+const KeyRef advanceVersionSpecialKey = "\xff\xff/management/min_required_commit_version"_sr;
 
 ACTOR Future<bool> advanceVersionCommandActor(Reference<IDatabase> db, std::vector<StringRef> tokens) {
 	if (tokens.size() != 2) {

--- a/fdbcli/ConsistencyCheckCommand.actor.cpp
+++ b/fdbcli/ConsistencyCheckCommand.actor.cpp
@@ -30,7 +30,7 @@
 
 namespace fdb_cli {
 
-const KeyRef consistencyCheckSpecialKey = LiteralStringRef("\xff\xff/management/consistency_check_suspended");
+const KeyRef consistencyCheckSpecialKey = "\xff\xff/management/consistency_check_suspended"_sr;
 
 ACTOR Future<bool> consistencyCheckCommandActor(Reference<ITransaction> tr, std::vector<StringRef> tokens) {
 	// Here we do not proceed in a try-catch loop since the transaction is always supposed to succeed.

--- a/fdbcli/MaintenanceCommand.actor.cpp
+++ b/fdbcli/MaintenanceCommand.actor.cpp
@@ -133,10 +133,10 @@ ACTOR Future<bool> setHealthyZone(Reference<IDatabase> db,
 
 namespace fdb_cli {
 
-const KeyRangeRef maintenanceSpecialKeyRange = KeyRangeRef(LiteralStringRef("\xff\xff/management/maintenance/"),
-                                                           LiteralStringRef("\xff\xff/management/maintenance0"));
+const KeyRangeRef maintenanceSpecialKeyRange =
+    KeyRangeRef("\xff\xff/management/maintenance/"_sr, "\xff\xff/management/maintenance0"_sr);
 // The special key, if present, means data distribution is disabled for storage failures;
-const KeyRef ignoreSSFailureSpecialKey = LiteralStringRef("\xff\xff/management/maintenance/IgnoreSSFailures");
+const KeyRef ignoreSSFailureSpecialKey = "\xff\xff/management/maintenance/IgnoreSSFailures"_sr;
 
 ACTOR Future<bool> maintenanceCommandActor(Reference<IDatabase> db, std::vector<StringRef> tokens) {
 	state bool result = true;

--- a/fdbcli/SnapshotCommand.actor.cpp
+++ b/fdbcli/SnapshotCommand.actor.cpp
@@ -40,7 +40,7 @@ ACTOR Future<bool> snapshotCommandActor(Reference<IDatabase> db, std::vector<Str
 		for (int i = 1; i < tokens.size(); i++) {
 			snap_cmd = snap_cmd.withSuffix(tokens[i]);
 			if (i != tokens.size() - 1) {
-				snap_cmd = snap_cmd.withSuffix(LiteralStringRef(" "));
+				snap_cmd = snap_cmd.withSuffix(" "_sr);
 			}
 		}
 		try {

--- a/fdbclient/BackupAgent.actor.h
+++ b/fdbclient/BackupAgent.actor.h
@@ -611,7 +611,7 @@ class TagUidMap : public KeyBackedMap<std::string, UidAndAbortedFlagT> {
 	                                                           Snapshot snapshot);
 
 public:
-	TagUidMap(const StringRef& prefix) : TagMap(LiteralStringRef("tag->uid/").withPrefix(prefix)), prefix(prefix) {}
+	TagUidMap(const StringRef& prefix) : TagMap("tag->uid/"_sr.withPrefix(prefix)), prefix(prefix) {}
 
 	Future<std::vector<KeyBackedTag>> getAll(Reference<ReadYourWritesTransaction> tr,
 	                                         Snapshot snapshot = Snapshot::False) {
@@ -646,7 +646,7 @@ public:
 	} TaskParams;
 
 	KeyBackedConfig(StringRef prefix, UID uid = UID())
-	  : uid(uid), prefix(prefix), configSpace(uidPrefixKey(LiteralStringRef("uid->config/").withPrefix(prefix), uid)) {}
+	  : uid(uid), prefix(prefix), configSpace(uidPrefixKey("uid->config/"_sr.withPrefix(prefix), uid)) {}
 
 	KeyBackedConfig(StringRef prefix, Reference<Task> task) : KeyBackedConfig(prefix, TaskParams.uid().get(task)) {}
 

--- a/fdbclient/BackupAgentBase.actor.cpp
+++ b/fdbclient/BackupAgentBase.actor.cpp
@@ -958,10 +958,9 @@ ACTOR Future<Void> cleanupLogMutations(Database cx, Value destUidValue, bool del
 					                                                       .get(BackupAgentBase::keySourceStates)
 					                                                       .get(currLogUid)
 					                                                       .pack(DatabaseBackupAgent::keyStateStatus));
-					state Future<Optional<Value>> foundBackupKey =
-					    tr->get(Subspace(currLogUid.withPrefix(LiteralStringRef("uid->config/"))
-					                         .withPrefix(fileBackupPrefixRange.begin))
-					                .pack(LiteralStringRef("stateEnum")));
+					state Future<Optional<Value>> foundBackupKey = tr->get(
+					    Subspace(currLogUid.withPrefix("uid->config/"_sr).withPrefix(fileBackupPrefixRange.begin))
+					        .pack("stateEnum"_sr));
 					wait(success(foundDRKey) && success(foundBackupKey));
 
 					if (foundDRKey.get().present() && foundBackupKey.get().present()) {

--- a/fdbclient/BackupContainerFileSystem.actor.cpp
+++ b/fdbclient/BackupContainerFileSystem.actor.cpp
@@ -1588,16 +1588,16 @@ ACTOR Future<Void> testBackupContainer(std::string url, Optional<std::string> en
 
 	// List of sizes to use to test edge cases on underlying file implementations
 	state std::vector<int> fileSizes = { 0 };
-	if (StringRef(url).startsWith(LiteralStringRef("blob"))) {
- 		fileSizes.push_back(CLIENT_KNOBS->BLOBSTORE_MULTIPART_MIN_PART_SIZE);
+	if (StringRef(url).startsWith("blob"_sr)) {
+		fileSizes.push_back(CLIENT_KNOBS->BLOBSTORE_MULTIPART_MIN_PART_SIZE);
  		fileSizes.push_back(CLIENT_KNOBS->BLOBSTORE_MULTIPART_MIN_PART_SIZE + 10);
- 	}
+	}
 
 	loop {
 		state Version logStart = v;
 		state int kvfiles = deterministicRandom()->randomInt(0, 3);
-		state Key begin = LiteralStringRef("");
-		state Key end = LiteralStringRef("");
+		state Key begin = ""_sr;
+		state Key end = ""_sr;
 		state int blockSize = 3 * sizeof(uint32_t) + begin.size() + end.size() + 8;
 
 		while (kvfiles > 0) {

--- a/fdbclient/BackupContainerLocalDirectory.actor.cpp
+++ b/fdbclient/BackupContainerLocalDirectory.actor.cpp
@@ -102,16 +102,15 @@ ACTOR static Future<BackupContainerFileSystem::FilesAndSizesT> listFiles_impl(st
 	// Remove .lnk files from results, they are a side effect of a backup that was *read* during simulation.  See
 	// openFile() above for more info on why they are created.
 	if (g_network->isSimulated())
-		files.erase(
-		    std::remove_if(files.begin(),
-		                   files.end(),
-		                   [](std::string const& f) { return StringRef(f).endsWith(LiteralStringRef(".lnk")); }),
-		    files.end());
+		files.erase(std::remove_if(files.begin(),
+		                           files.end(),
+		                           [](std::string const& f) { return StringRef(f).endsWith(".lnk"_sr); }),
+		            files.end());
 
 	for (const auto& f : files) {
 		// Hide .part or .temp files.
 		StringRef s(f);
-		if (!s.endsWith(LiteralStringRef(".part")) && !s.endsWith(LiteralStringRef(".temp")))
+		if (!s.endsWith(".part"_sr) && !s.endsWith(".temp"_sr))
 			results.push_back({ f.substr(m_path.size() + 1), ::fileSize(f) });
 	}
 

--- a/fdbclient/ClusterInterface.h
+++ b/fdbclient/ClusterInterface.h
@@ -93,7 +93,7 @@ struct ClientVersionRef {
 	ClientVersionRef(StringRef clientVersion, StringRef sourceVersion, StringRef protocolVersion)
 	  : clientVersion(clientVersion), sourceVersion(sourceVersion), protocolVersion(protocolVersion) {}
 	ClientVersionRef(StringRef versionString) {
-		std::vector<StringRef> parts = versionString.splitAny(LiteralStringRef(","));
+		std::vector<StringRef> parts = versionString.splitAny(","_sr);
 		if (parts.size() != 3) {
 			initUnknown();
 			return;
@@ -104,9 +104,9 @@ struct ClientVersionRef {
 	}
 
 	void initUnknown() {
-		clientVersion = LiteralStringRef("Unknown");
-		sourceVersion = LiteralStringRef("Unknown");
-		protocolVersion = LiteralStringRef("Unknown");
+		clientVersion = "Unknown"_sr;
+		sourceVersion = "Unknown"_sr;
+		protocolVersion = "Unknown"_sr;
 	}
 
 	template <class Ar>

--- a/fdbclient/DatabaseBackupAgent.actor.cpp
+++ b/fdbclient/DatabaseBackupAgent.actor.cpp
@@ -36,11 +36,11 @@
 #include <inttypes.h>
 #include <map>
 
-const Key DatabaseBackupAgent::keyAddPrefix = LiteralStringRef("add_prefix");
-const Key DatabaseBackupAgent::keyRemovePrefix = LiteralStringRef("remove_prefix");
-const Key DatabaseBackupAgent::keyRangeVersions = LiteralStringRef("range_versions");
-const Key DatabaseBackupAgent::keyCopyStop = LiteralStringRef("copy_stop");
-const Key DatabaseBackupAgent::keyDatabasesInSync = LiteralStringRef("databases_in_sync");
+const Key DatabaseBackupAgent::keyAddPrefix = "add_prefix"_sr;
+const Key DatabaseBackupAgent::keyRemovePrefix = "remove_prefix"_sr;
+const Key DatabaseBackupAgent::keyRangeVersions = "range_versions"_sr;
+const Key DatabaseBackupAgent::keyCopyStop = "copy_stop"_sr;
+const Key DatabaseBackupAgent::keyDatabasesInSync = "databases_in_sync"_sr;
 const int DatabaseBackupAgent::LATEST_DR_VERSION = 1;
 
 DatabaseBackupAgent::DatabaseBackupAgent()
@@ -73,8 +73,7 @@ DatabaseBackupAgent::DatabaseBackupAgent(Database src)
 class DRConfig {
 public:
 	DRConfig(UID uid = UID())
-	  : uid(uid),
-	    configSpace(uidPrefixKey(LiteralStringRef("uid->config/").withPrefix(databaseBackupPrefixRange.begin), uid)) {}
+	  : uid(uid), configSpace(uidPrefixKey("uid->config/"_sr.withPrefix(databaseBackupPrefixRange.begin), uid)) {}
 	DRConfig(Reference<Task> task)
 	  : DRConfig(BinaryReader::fromStringRef<UID>(task->params[BackupAgentBase::keyConfigLogUid], Unversioned())) {}
 
@@ -201,7 +200,7 @@ struct BackupRangeTaskFunc : TaskFuncBase {
 		                           task,
 		                           parentTask->params[Task::reservedTaskParamValidKey],
 		                           task->params[BackupAgentBase::keyFolderId]));
-		return LiteralStringRef("OnSetAddTask");
+		return "OnSetAddTask"_sr;
 	}
 
 	ACTOR static Future<Void> _execute(Database cx,
@@ -534,9 +533,9 @@ struct BackupRangeTaskFunc : TaskFuncBase {
 		return Void();
 	}
 };
-StringRef BackupRangeTaskFunc::name = LiteralStringRef("dr_backup_range");
-const Key BackupRangeTaskFunc::keyAddBackupRangeTasks = LiteralStringRef("addBackupRangeTasks");
-const Key BackupRangeTaskFunc::keyBackupRangeBeginKey = LiteralStringRef("backupRangeBeginKey");
+StringRef BackupRangeTaskFunc::name = "dr_backup_range"_sr;
+const Key BackupRangeTaskFunc::keyAddBackupRangeTasks = "addBackupRangeTasks"_sr;
+const Key BackupRangeTaskFunc::keyBackupRangeBeginKey = "backupRangeBeginKey"_sr;
 REGISTER_TASKFUNC(BackupRangeTaskFunc);
 
 struct FinishFullBackupTaskFunc : TaskFuncBase {
@@ -586,7 +585,7 @@ struct FinishFullBackupTaskFunc : TaskFuncBase {
 		                           task,
 		                           parentTask->params[Task::reservedTaskParamValidKey],
 		                           task->params[BackupAgentBase::keyFolderId]));
-		return LiteralStringRef("OnSetAddTask");
+		return "OnSetAddTask"_sr;
 	}
 
 	StringRef getName() const override { return name; };
@@ -604,7 +603,7 @@ struct FinishFullBackupTaskFunc : TaskFuncBase {
 		return _finish(tr, tb, fb, task);
 	};
 };
-StringRef FinishFullBackupTaskFunc::name = LiteralStringRef("dr_finish_full_backup");
+StringRef FinishFullBackupTaskFunc::name = "dr_finish_full_backup"_sr;
 REGISTER_TASKFUNC(FinishFullBackupTaskFunc);
 
 struct EraseLogRangeTaskFunc : TaskFuncBase {
@@ -681,7 +680,7 @@ struct EraseLogRangeTaskFunc : TaskFuncBase {
 		                           task,
 		                           parentTask->params[Task::reservedTaskParamValidKey],
 		                           task->params[BackupAgentBase::keyFolderId]));
-		return LiteralStringRef("OnSetAddTask");
+		return "OnSetAddTask"_sr;
 	}
 
 	ACTOR static Future<Void> _finish(Reference<ReadYourWritesTransaction> tr,
@@ -695,7 +694,7 @@ struct EraseLogRangeTaskFunc : TaskFuncBase {
 		return Void();
 	}
 };
-StringRef EraseLogRangeTaskFunc::name = LiteralStringRef("dr_erase_log_range");
+StringRef EraseLogRangeTaskFunc::name = "dr_erase_log_range"_sr;
 REGISTER_TASKFUNC(EraseLogRangeTaskFunc);
 
 struct CopyLogRangeTaskFunc : TaskFuncBase {
@@ -956,7 +955,7 @@ struct CopyLogRangeTaskFunc : TaskFuncBase {
 		                           task,
 		                           parentTask->params[Task::reservedTaskParamValidKey],
 		                           task->params[BackupAgentBase::keyFolderId]));
-		return LiteralStringRef("OnSetAddTask");
+		return "OnSetAddTask"_sr;
 	}
 
 	ACTOR static Future<Void> _finish(Reference<ReadYourWritesTransaction> tr,
@@ -987,8 +986,8 @@ struct CopyLogRangeTaskFunc : TaskFuncBase {
 		return Void();
 	}
 };
-StringRef CopyLogRangeTaskFunc::name = LiteralStringRef("dr_copy_log_range");
-const Key CopyLogRangeTaskFunc::keyNextBeginVersion = LiteralStringRef("nextBeginVersion");
+StringRef CopyLogRangeTaskFunc::name = "dr_copy_log_range"_sr;
+const Key CopyLogRangeTaskFunc::keyNextBeginVersion = "nextBeginVersion"_sr;
 REGISTER_TASKFUNC(CopyLogRangeTaskFunc);
 
 struct CopyLogsTaskFunc : TaskFuncBase {
@@ -1123,7 +1122,7 @@ struct CopyLogsTaskFunc : TaskFuncBase {
 		                           task,
 		                           parentTask->params[Task::reservedTaskParamValidKey],
 		                           task->params[BackupAgentBase::keyFolderId]));
-		return LiteralStringRef("OnSetAddTask");
+		return "OnSetAddTask"_sr;
 	}
 
 	StringRef getName() const override { return name; };
@@ -1141,7 +1140,7 @@ struct CopyLogsTaskFunc : TaskFuncBase {
 		return _finish(tr, tb, fb, task);
 	};
 };
-StringRef CopyLogsTaskFunc::name = LiteralStringRef("dr_copy_logs");
+StringRef CopyLogsTaskFunc::name = "dr_copy_logs"_sr;
 REGISTER_TASKFUNC(CopyLogsTaskFunc);
 
 struct FinishedFullBackupTaskFunc : TaskFuncBase {
@@ -1233,7 +1232,7 @@ struct FinishedFullBackupTaskFunc : TaskFuncBase {
 		                           task,
 		                           parentTask->params[Task::reservedTaskParamValidKey],
 		                           task->params[BackupAgentBase::keyFolderId]));
-		return LiteralStringRef("OnSetAddTask");
+		return "OnSetAddTask"_sr;
 	}
 
 	ACTOR static Future<Void> _finish(Reference<ReadYourWritesTransaction> tr,
@@ -1281,8 +1280,8 @@ struct FinishedFullBackupTaskFunc : TaskFuncBase {
 		return _finish(tr, tb, fb, task);
 	};
 };
-StringRef FinishedFullBackupTaskFunc::name = LiteralStringRef("dr_finished_full_backup");
-const Key FinishedFullBackupTaskFunc::keyInsertTask = LiteralStringRef("insertTask");
+StringRef FinishedFullBackupTaskFunc::name = "dr_finished_full_backup"_sr;
+const Key FinishedFullBackupTaskFunc::keyInsertTask = "insertTask"_sr;
 REGISTER_TASKFUNC(FinishedFullBackupTaskFunc);
 
 struct CopyDiffLogsTaskFunc : TaskFuncBase {
@@ -1394,7 +1393,7 @@ struct CopyDiffLogsTaskFunc : TaskFuncBase {
 		                           task,
 		                           parentTask->params[Task::reservedTaskParamValidKey],
 		                           task->params[BackupAgentBase::keyFolderId]));
-		return LiteralStringRef("OnSetAddTask");
+		return "OnSetAddTask"_sr;
 	}
 
 	StringRef getName() const override { return name; };
@@ -1412,7 +1411,7 @@ struct CopyDiffLogsTaskFunc : TaskFuncBase {
 		return _finish(tr, tb, fb, task);
 	};
 };
-StringRef CopyDiffLogsTaskFunc::name = LiteralStringRef("dr_copy_diff_logs");
+StringRef CopyDiffLogsTaskFunc::name = "dr_copy_diff_logs"_sr;
 REGISTER_TASKFUNC(CopyDiffLogsTaskFunc);
 
 // Skip unneeded EraseLogRangeTaskFunc in 5.1
@@ -1444,7 +1443,7 @@ struct SkipOldEraseLogRangeTaskFunc : TaskFuncBase {
 		return _finish(tr, tb, fb, task);
 	};
 };
-StringRef SkipOldEraseLogRangeTaskFunc::name = LiteralStringRef("dr_skip_legacy_task");
+StringRef SkipOldEraseLogRangeTaskFunc::name = "dr_skip_legacy_task"_sr;
 REGISTER_TASKFUNC(SkipOldEraseLogRangeTaskFunc);
 REGISTER_TASKFUNC_ALIAS(SkipOldEraseLogRangeTaskFunc, db_erase_log_range);
 
@@ -1650,7 +1649,7 @@ struct OldCopyLogRangeTaskFunc : TaskFuncBase {
 		                           task,
 		                           parentTask->params[Task::reservedTaskParamValidKey],
 		                           task->params[BackupAgentBase::keyFolderId]));
-		return LiteralStringRef("OnSetAddTask");
+		return "OnSetAddTask"_sr;
 	}
 
 	ACTOR static Future<Void> _finish(Reference<ReadYourWritesTransaction> tr,
@@ -1681,8 +1680,8 @@ struct OldCopyLogRangeTaskFunc : TaskFuncBase {
 		return Void();
 	}
 };
-StringRef OldCopyLogRangeTaskFunc::name = LiteralStringRef("db_copy_log_range");
-const Key OldCopyLogRangeTaskFunc::keyNextBeginVersion = LiteralStringRef("nextBeginVersion");
+StringRef OldCopyLogRangeTaskFunc::name = "db_copy_log_range"_sr;
+const Key OldCopyLogRangeTaskFunc::keyNextBeginVersion = "nextBeginVersion"_sr;
 REGISTER_TASKFUNC(OldCopyLogRangeTaskFunc);
 
 struct AbortOldBackupTaskFunc : TaskFuncBase {
@@ -1751,7 +1750,7 @@ struct AbortOldBackupTaskFunc : TaskFuncBase {
 		                           task,
 		                           parentTask->params[Task::reservedTaskParamValidKey],
 		                           task->params[BackupAgentBase::keyFolderId]));
-		return LiteralStringRef("OnSetAddTask");
+		return "OnSetAddTask"_sr;
 	}
 
 	StringRef getName() const override { return name; };
@@ -1769,7 +1768,7 @@ struct AbortOldBackupTaskFunc : TaskFuncBase {
 		return _finish(tr, tb, fb, task);
 	};
 };
-StringRef AbortOldBackupTaskFunc::name = LiteralStringRef("dr_abort_legacy_backup");
+StringRef AbortOldBackupTaskFunc::name = "dr_abort_legacy_backup"_sr;
 REGISTER_TASKFUNC(AbortOldBackupTaskFunc);
 REGISTER_TASKFUNC_ALIAS(AbortOldBackupTaskFunc, db_backup_range);
 REGISTER_TASKFUNC_ALIAS(AbortOldBackupTaskFunc, db_finish_full_backup);
@@ -1916,7 +1915,7 @@ struct CopyDiffLogsUpgradeTaskFunc : TaskFuncBase {
 		return _finish(tr, tb, fb, task);
 	};
 };
-StringRef CopyDiffLogsUpgradeTaskFunc::name = LiteralStringRef("db_copy_diff_logs");
+StringRef CopyDiffLogsUpgradeTaskFunc::name = "db_copy_diff_logs"_sr;
 REGISTER_TASKFUNC(CopyDiffLogsUpgradeTaskFunc);
 
 struct BackupRestorableTaskFunc : TaskFuncBase {
@@ -2029,7 +2028,7 @@ struct BackupRestorableTaskFunc : TaskFuncBase {
 		                           task,
 		                           parentTask->params[Task::reservedTaskParamValidKey],
 		                           task->params[BackupAgentBase::keyFolderId]));
-		return LiteralStringRef("OnSetAddTask");
+		return "OnSetAddTask"_sr;
 	}
 
 	StringRef getName() const override { return name; };
@@ -2047,7 +2046,7 @@ struct BackupRestorableTaskFunc : TaskFuncBase {
 		return _finish(tr, tb, fb, task);
 	};
 };
-StringRef BackupRestorableTaskFunc::name = LiteralStringRef("dr_backup_restorable");
+StringRef BackupRestorableTaskFunc::name = "dr_backup_restorable"_sr;
 REGISTER_TASKFUNC(BackupRestorableTaskFunc);
 
 struct StartFullBackupTaskFunc : TaskFuncBase {
@@ -2279,7 +2278,7 @@ struct StartFullBackupTaskFunc : TaskFuncBase {
 		task->params[BackupAgentBase::keyConfigBackupRanges] = keyConfigBackupRanges;
 		task->params[BackupAgentBase::keyTagName] = tagName;
 		task->params[DatabaseBackupAgent::keyDatabasesInSync] =
-		    backupAction == DatabaseBackupAgent::PreBackupAction::NONE ? LiteralStringRef("t") : LiteralStringRef("f");
+		    backupAction == DatabaseBackupAgent::PreBackupAction::NONE ? "t"_sr : "f"_sr;
 
 		if (!waitFor) {
 			return taskBucket->addTask(tr,
@@ -2299,7 +2298,7 @@ struct StartFullBackupTaskFunc : TaskFuncBase {
 		                               .get(logUid)
 		                               .pack(BackupAgentBase::keyFolderId),
 		                           task->params[BackupAgentBase::keyFolderId]));
-		return LiteralStringRef("OnSetAddTask");
+		return "OnSetAddTask"_sr;
 	}
 
 	StringRef getName() const override { return name; };
@@ -2317,7 +2316,7 @@ struct StartFullBackupTaskFunc : TaskFuncBase {
 		return _finish(tr, tb, fb, task);
 	};
 };
-StringRef StartFullBackupTaskFunc::name = LiteralStringRef("dr_start_full_backup");
+StringRef StartFullBackupTaskFunc::name = "dr_start_full_backup"_sr;
 REGISTER_TASKFUNC(StartFullBackupTaskFunc);
 } // namespace dbBackup
 

--- a/fdbclient/DatabaseConfiguration.cpp
+++ b/fdbclient/DatabaseConfiguration.cpp
@@ -464,34 +464,34 @@ bool DatabaseConfiguration::setInternal(KeyRef key, ValueRef value) {
 	KeyRef ck = key.removePrefix(configKeysPrefix);
 	int type;
 
-	if (ck == LiteralStringRef("initialized")) {
+	if (ck == "initialized"_sr) {
 		initialized = true;
-	} else if (ck == LiteralStringRef("commit_proxies")) {
+	} else if (ck == "commit_proxies"_sr) {
 		parse(&commitProxyCount, value);
-	} else if (ck == LiteralStringRef("grv_proxies")) {
+	} else if (ck == "grv_proxies"_sr) {
 		parse(&grvProxyCount, value);
-	} else if (ck == LiteralStringRef("resolvers")) {
+	} else if (ck == "resolvers"_sr) {
 		parse(&resolverCount, value);
-	} else if (ck == LiteralStringRef("logs")) {
+	} else if (ck == "logs"_sr) {
 		parse(&desiredTLogCount, value);
-	} else if (ck == LiteralStringRef("log_replicas")) {
+	} else if (ck == "log_replicas"_sr) {
 		parse(&tLogReplicationFactor, value);
 		tLogWriteAntiQuorum = std::min(tLogWriteAntiQuorum, tLogReplicationFactor / 2);
-	} else if (ck == LiteralStringRef("log_anti_quorum")) {
+	} else if (ck == "log_anti_quorum"_sr) {
 		parse(&tLogWriteAntiQuorum, value);
 		if (tLogReplicationFactor > 0) {
 			tLogWriteAntiQuorum = std::min(tLogWriteAntiQuorum, tLogReplicationFactor / 2);
 		}
-	} else if (ck == LiteralStringRef("storage_replicas")) {
+	} else if (ck == "storage_replicas"_sr) {
 		parse(&storageTeamSize, value);
-	} else if (ck == LiteralStringRef("tss_count")) {
+	} else if (ck == "tss_count"_sr) {
 		parse(&desiredTSSCount, value);
-	} else if (ck == LiteralStringRef("log_version")) {
+	} else if (ck == "log_version"_sr) {
 		parse((&type), value);
 		type = std::max((int)TLogVersion::MIN_RECRUITABLE, type);
 		type = std::min((int)TLogVersion::MAX_SUPPORTED, type);
 		tLogVersion = (TLogVersion::Version)type;
-	} else if (ck == LiteralStringRef("log_engine")) {
+	} else if (ck == "log_engine"_sr) {
 		parse((&type), value);
 		tLogDataStoreType = (KeyValueStoreType::StoreType)type;
 		// TODO:  Remove this once Redwood works as a log engine
@@ -502,45 +502,45 @@ bool DatabaseConfiguration::setInternal(KeyRef key, ValueRef value) {
 		if (tLogDataStoreType == KeyValueStoreType::MEMORY_RADIXTREE) {
 			tLogDataStoreType = KeyValueStoreType::SSD_BTREE_V2;
 		}
-	} else if (ck == LiteralStringRef("log_spill")) {
+	} else if (ck == "log_spill"_sr) {
 		parse((&type), value);
 		tLogSpillType = (TLogSpillType::SpillType)type;
-	} else if (ck == LiteralStringRef("storage_engine")) {
+	} else if (ck == "storage_engine"_sr) {
 		parse((&type), value);
 		storageServerStoreType = (KeyValueStoreType::StoreType)type;
-	} else if (ck == LiteralStringRef("tss_storage_engine")) {
+	} else if (ck == "tss_storage_engine"_sr) {
 		parse((&type), value);
 		testingStorageServerStoreType = (KeyValueStoreType::StoreType)type;
-	} else if (ck == LiteralStringRef("auto_commit_proxies")) {
+	} else if (ck == "auto_commit_proxies"_sr) {
 		parse(&autoCommitProxyCount, value);
-	} else if (ck == LiteralStringRef("auto_grv_proxies")) {
+	} else if (ck == "auto_grv_proxies"_sr) {
 		parse(&autoGrvProxyCount, value);
-	} else if (ck == LiteralStringRef("auto_resolvers")) {
+	} else if (ck == "auto_resolvers"_sr) {
 		parse(&autoResolverCount, value);
-	} else if (ck == LiteralStringRef("auto_logs")) {
+	} else if (ck == "auto_logs"_sr) {
 		parse(&autoDesiredTLogCount, value);
-	} else if (ck == LiteralStringRef("storage_replication_policy")) {
+	} else if (ck == "storage_replication_policy"_sr) {
 		parseReplicationPolicy(&storagePolicy, value);
-	} else if (ck == LiteralStringRef("log_replication_policy")) {
+	} else if (ck == "log_replication_policy"_sr) {
 		parseReplicationPolicy(&tLogPolicy, value);
-	} else if (ck == LiteralStringRef("log_routers")) {
+	} else if (ck == "log_routers"_sr) {
 		parse(&desiredLogRouterCount, value);
-	} else if (ck == LiteralStringRef("remote_logs")) {
+	} else if (ck == "remote_logs"_sr) {
 		parse(&remoteDesiredTLogCount, value);
-	} else if (ck == LiteralStringRef("remote_log_replicas")) {
+	} else if (ck == "remote_log_replicas"_sr) {
 		parse(&remoteTLogReplicationFactor, value);
-	} else if (ck == LiteralStringRef("remote_log_policy")) {
+	} else if (ck == "remote_log_policy"_sr) {
 		parseReplicationPolicy(&remoteTLogPolicy, value);
-	} else if (ck == LiteralStringRef("backup_worker_enabled")) {
+	} else if (ck == "backup_worker_enabled"_sr) {
 		parse((&type), value);
 		backupWorkerEnabled = (type != 0);
-	} else if (ck == LiteralStringRef("usable_regions")) {
+	} else if (ck == "usable_regions"_sr) {
 		parse(&usableRegions, value);
-	} else if (ck == LiteralStringRef("repopulate_anti_quorum")) {
+	} else if (ck == "repopulate_anti_quorum"_sr) {
 		parse(&repopulateRegionAntiQuorum, value);
-	} else if (ck == LiteralStringRef("regions")) {
+	} else if (ck == "regions"_sr) {
 		parse(&regions, value);
-	} else if (ck == LiteralStringRef("perpetual_storage_wiggle")) {
+	} else if (ck == "perpetual_storage_wiggle"_sr) {
 		parse(&perpetualStorageWiggleSpeed, value);
 	} else {
 		return false;

--- a/fdbclient/FDBTypes.cpp
+++ b/fdbclient/FDBTypes.cpp
@@ -42,12 +42,9 @@ KeyRef keyBetween(const KeyRangeRef& keys) {
 void KeySelectorRef::setKey(KeyRef const& key) {
 	// There are no keys in the database with size greater than KEY_SIZE_LIMIT, so if this key selector has a key
 	// which is large, then we can translate it to an equivalent key selector with a smaller key
-	if (key.size() >
-	    (key.startsWith(LiteralStringRef("\xff")) ? CLIENT_KNOBS->SYSTEM_KEY_SIZE_LIMIT : CLIENT_KNOBS->KEY_SIZE_LIMIT))
-		this->key = key.substr(0,
-		                       (key.startsWith(LiteralStringRef("\xff")) ? CLIENT_KNOBS->SYSTEM_KEY_SIZE_LIMIT
-		                                                                 : CLIENT_KNOBS->KEY_SIZE_LIMIT) +
-		                           1);
+	if (key.size() > (key.startsWith("\xff"_sr) ? CLIENT_KNOBS->SYSTEM_KEY_SIZE_LIMIT : CLIENT_KNOBS->KEY_SIZE_LIMIT))
+		this->key = key.substr(
+		    0, (key.startsWith("\xff"_sr) ? CLIENT_KNOBS->SYSTEM_KEY_SIZE_LIMIT : CLIENT_KNOBS->KEY_SIZE_LIMIT) + 1);
 	else
 		this->key = key;
 }

--- a/fdbclient/FDBTypes.h
+++ b/fdbclient/FDBTypes.h
@@ -483,7 +483,7 @@ using RangeResult = Standalone<struct RangeResultRef>;
 enum { invalidVersion = -1, latestVersion = -2, MAX_VERSION = std::numeric_limits<int64_t>::max() };
 
 inline Key keyAfter(const KeyRef& key) {
-	if (key == LiteralStringRef("\xff\xff"))
+	if (key == "\xff\xff"_sr)
 		return key;
 
 	Standalone<StringRef> r;
@@ -496,7 +496,7 @@ inline Key keyAfter(const KeyRef& key) {
 	return r;
 }
 inline KeyRef keyAfter(const KeyRef& key, Arena& arena) {
-	if (key == LiteralStringRef("\xff\xff"))
+	if (key == "\xff\xff"_sr)
 		return key;
 	uint8_t* t = new (arena) uint8_t[key.size() + 1];
 	memcpy(t, key.begin(), key.size());
@@ -765,15 +765,15 @@ struct TLogVersion {
 	}
 
 	static ErrorOr<TLogVersion> FromStringRef(StringRef s) {
-		if (s == LiteralStringRef("2"))
+		if (s == "2"_sr)
 			return V2;
-		if (s == LiteralStringRef("3"))
+		if (s == "3"_sr)
 			return V3;
-		if (s == LiteralStringRef("4"))
+		if (s == "4"_sr)
 			return V4;
-		if (s == LiteralStringRef("5"))
+		if (s == "5"_sr)
 			return V5;
-		if (s == LiteralStringRef("6"))
+		if (s == "6"_sr)
 			return V6;
 		return default_error_or();
 	}
@@ -823,9 +823,9 @@ struct TLogSpillType {
 	}
 
 	static ErrorOr<TLogSpillType> FromStringRef(StringRef s) {
-		if (s == LiteralStringRef("1"))
+		if (s == "1"_sr)
 			return VALUE;
-		if (s == LiteralStringRef("2"))
+		if (s == "2"_sr)
 			return REFERENCE;
 		return default_error_or();
 	}

--- a/fdbclient/FileBackupAgent.actor.cpp
+++ b/fdbclient/FileBackupAgent.actor.cpp
@@ -89,7 +89,7 @@ std::string secondsToTimeFormat(int64_t seconds) {
 		return format("%ld second(s)", seconds);
 }
 
-const Key FileBackupAgent::keyLastRestorable = LiteralStringRef("last_restorable");
+const Key FileBackupAgent::keyLastRestorable = "last_restorable"_sr;
 
 // For convenience
 typedef FileBackupAgent::ERestoreState ERestoreState;
@@ -97,19 +97,19 @@ typedef FileBackupAgent::ERestoreState ERestoreState;
 StringRef FileBackupAgent::restoreStateText(ERestoreState id) {
 	switch (id) {
 	case ERestoreState::UNITIALIZED:
-		return LiteralStringRef("unitialized");
+		return "unitialized"_sr;
 	case ERestoreState::QUEUED:
-		return LiteralStringRef("queued");
+		return "queued"_sr;
 	case ERestoreState::STARTING:
-		return LiteralStringRef("starting");
+		return "starting"_sr;
 	case ERestoreState::RUNNING:
-		return LiteralStringRef("running");
+		return "running"_sr;
 	case ERestoreState::COMPLETED:
-		return LiteralStringRef("completed");
+		return "completed"_sr;
 	case ERestoreState::ABORTED:
-		return LiteralStringRef("aborted");
+		return "aborted"_sr;
 	default:
-		return LiteralStringRef("Unknown");
+		return "Unknown"_sr;
 	}
 }
 
@@ -161,7 +161,7 @@ public:
 		return configSpace.pack(LiteralStringRef(__FUNCTION__));
 	}
 	// Get the source container as a bare URL, without creating a container instance
-	KeyBackedProperty<Value> sourceContainerURL() { return configSpace.pack(LiteralStringRef("sourceContainer")); }
+	KeyBackedProperty<Value> sourceContainerURL() { return configSpace.pack("sourceContainer"_sr); }
 
 	// Total bytes written by all log and range restore tasks.
 	KeyBackedBinaryValue<int64_t> bytesWritten() { return configSpace.pack(LiteralStringRef(__FUNCTION__)); }
@@ -780,8 +780,7 @@ ACTOR static Future<Void> abortFiveZeroBackup(FileBackupAgent* backupAgent,
 
 	state Subspace statusSpace = backupAgent->subspace.get(BackupAgentBase::keyStates).get(uid.toString());
 	state Subspace globalConfig = backupAgent->subspace.get(BackupAgentBase::keyConfig).get(uid.toString());
-	state Subspace newConfigSpace =
-	    uidPrefixKey(LiteralStringRef("uid->config/").withPrefix(fileBackupPrefixRange.begin), uid);
+	state Subspace newConfigSpace = uidPrefixKey("uid->config/"_sr.withPrefix(fileBackupPrefixRange.begin), uid);
 
 	Optional<Value> statusStr = wait(tr->get(statusSpace.pack(FileBackupAgent::keyStateStatus)));
 	state EBackupState status =
@@ -852,7 +851,7 @@ struct AbortFiveZeroBackupTask : TaskFuncBase {
 		return _finish(tr, tb, fb, task);
 	};
 };
-StringRef AbortFiveZeroBackupTask::name = LiteralStringRef("abort_legacy_backup");
+StringRef AbortFiveZeroBackupTask::name = "abort_legacy_backup"_sr;
 REGISTER_TASKFUNC(AbortFiveZeroBackupTask);
 REGISTER_TASKFUNC_ALIAS(AbortFiveZeroBackupTask, file_backup_diff_logs);
 REGISTER_TASKFUNC_ALIAS(AbortFiveZeroBackupTask, file_backup_log_range);
@@ -938,7 +937,7 @@ struct AbortFiveOneBackupTask : TaskFuncBase {
 		return _finish(tr, tb, fb, task);
 	};
 };
-StringRef AbortFiveOneBackupTask::name = LiteralStringRef("abort_legacy_backup_5.2");
+StringRef AbortFiveOneBackupTask::name = "abort_legacy_backup_5.2"_sr;
 REGISTER_TASKFUNC(AbortFiveOneBackupTask);
 REGISTER_TASKFUNC_ALIAS(AbortFiveOneBackupTask, file_backup_write_range);
 REGISTER_TASKFUNC_ALIAS(AbortFiveOneBackupTask, file_backup_dispatch_ranges);
@@ -977,7 +976,7 @@ ACTOR static Future<Key> addBackupTask(StringRef name,
 	}
 	wait(waitFor->onSetAddTask(tr, taskBucket, task));
 
-	return LiteralStringRef("OnSetAddTask");
+	return "OnSetAddTask"_sr;
 }
 
 // Clears the backup ID from "backupStartedKey" to pause backup workers.
@@ -1394,7 +1393,7 @@ struct BackupRangeTaskFunc : BackupTaskFuncBase {
 		return Void();
 	}
 };
-StringRef BackupRangeTaskFunc::name = LiteralStringRef("file_backup_write_range_5.2");
+StringRef BackupRangeTaskFunc::name = "file_backup_write_range_5.2"_sr;
 REGISTER_TASKFUNC(BackupRangeTaskFunc);
 
 struct BackupSnapshotDispatchTask : BackupTaskFuncBase {
@@ -1961,7 +1960,7 @@ struct BackupSnapshotDispatchTask : BackupTaskFuncBase {
 		return Void();
 	}
 };
-StringRef BackupSnapshotDispatchTask::name = LiteralStringRef("file_backup_dispatch_ranges_5.2");
+StringRef BackupSnapshotDispatchTask::name = "file_backup_dispatch_ranges_5.2"_sr;
 REGISTER_TASKFUNC(BackupSnapshotDispatchTask);
 
 struct BackupLogRangeTaskFunc : BackupTaskFuncBase {
@@ -2200,7 +2199,7 @@ struct BackupLogRangeTaskFunc : BackupTaskFuncBase {
 	}
 };
 
-StringRef BackupLogRangeTaskFunc::name = LiteralStringRef("file_backup_write_logs_5.2");
+StringRef BackupLogRangeTaskFunc::name = "file_backup_write_logs_5.2"_sr;
 REGISTER_TASKFUNC(BackupLogRangeTaskFunc);
 
 // This task stopped being used in 6.2, however the code remains here to handle upgrades.
@@ -2275,7 +2274,7 @@ struct EraseLogRangeTaskFunc : BackupTaskFuncBase {
 		return _finish(tr, tb, fb, task);
 	};
 };
-StringRef EraseLogRangeTaskFunc::name = LiteralStringRef("file_backup_erase_logs_5.2");
+StringRef EraseLogRangeTaskFunc::name = "file_backup_erase_logs_5.2"_sr;
 REGISTER_TASKFUNC(EraseLogRangeTaskFunc);
 
 struct BackupLogsDispatchTask : BackupTaskFuncBase {
@@ -2445,7 +2444,7 @@ struct BackupLogsDispatchTask : BackupTaskFuncBase {
 		return _finish(tr, tb, fb, task);
 	};
 };
-StringRef BackupLogsDispatchTask::name = LiteralStringRef("file_backup_dispatch_logs_5.2");
+StringRef BackupLogsDispatchTask::name = "file_backup_dispatch_logs_5.2"_sr;
 REGISTER_TASKFUNC(BackupLogsDispatchTask);
 
 struct FileBackupFinishedTask : BackupTaskFuncBase {
@@ -2505,7 +2504,7 @@ struct FileBackupFinishedTask : BackupTaskFuncBase {
 		return _finish(tr, tb, fb, task);
 	};
 };
-StringRef FileBackupFinishedTask::name = LiteralStringRef("file_backup_finished_5.2");
+StringRef FileBackupFinishedTask::name = "file_backup_finished_5.2"_sr;
 REGISTER_TASKFUNC(FileBackupFinishedTask);
 
 struct BackupSnapshotManifest : BackupTaskFuncBase {
@@ -2694,7 +2693,7 @@ struct BackupSnapshotManifest : BackupTaskFuncBase {
 		return _finish(tr, tb, fb, task);
 	};
 };
-StringRef BackupSnapshotManifest::name = LiteralStringRef("file_backup_write_snapshot_manifest_5.2");
+StringRef BackupSnapshotManifest::name = "file_backup_write_snapshot_manifest_5.2"_sr;
 REGISTER_TASKFUNC(BackupSnapshotManifest);
 
 Future<Key> BackupSnapshotDispatchTask::addSnapshotManifestTask(Reference<ReadYourWritesTransaction> tr,
@@ -2880,7 +2879,7 @@ struct StartFullBackupTaskFunc : BackupTaskFuncBase {
 		return _finish(tr, tb, fb, task);
 	};
 };
-StringRef StartFullBackupTaskFunc::name = LiteralStringRef("file_backup_start_5.2");
+StringRef StartFullBackupTaskFunc::name = "file_backup_start_5.2"_sr;
 REGISTER_TASKFUNC(StartFullBackupTaskFunc);
 
 struct RestoreCompleteTaskFunc : RestoreTaskFuncBase {
@@ -2927,7 +2926,7 @@ struct RestoreCompleteTaskFunc : RestoreTaskFuncBase {
 		}
 
 		wait(waitFor->onSetAddTask(tr, taskBucket, task));
-		return LiteralStringRef("OnSetAddTask");
+		return "OnSetAddTask"_sr;
 	}
 
 	static StringRef name;
@@ -2947,7 +2946,7 @@ struct RestoreCompleteTaskFunc : RestoreTaskFuncBase {
 		return _finish(tr, tb, fb, task);
 	};
 };
-StringRef RestoreCompleteTaskFunc::name = LiteralStringRef("restore_complete");
+StringRef RestoreCompleteTaskFunc::name = "restore_complete"_sr;
 REGISTER_TASKFUNC(RestoreCompleteTaskFunc);
 
 struct RestoreFileTaskFuncBase : RestoreTaskFuncBase {
@@ -3219,7 +3218,7 @@ struct RestoreRangeTaskFunc : RestoreFileTaskFuncBase {
 		}
 
 		wait(waitFor->onSetAddTask(tr, taskBucket, task));
-		return LiteralStringRef("OnSetAddTask");
+		return "OnSetAddTask"_sr;
 	}
 
 	static StringRef name;
@@ -3239,7 +3238,7 @@ struct RestoreRangeTaskFunc : RestoreFileTaskFuncBase {
 		return _finish(tr, tb, fb, task);
 	};
 };
-StringRef RestoreRangeTaskFunc::name = LiteralStringRef("restore_range_data");
+StringRef RestoreRangeTaskFunc::name = "restore_range_data"_sr;
 REGISTER_TASKFUNC(RestoreRangeTaskFunc);
 
 // Decodes a mutation log key, which contains (hash, commitVersion, chunkNumber) and
@@ -3550,7 +3549,7 @@ struct RestoreLogDataTaskFunc : RestoreFileTaskFuncBase {
 		}
 
 		wait(waitFor->onSetAddTask(tr, taskBucket, task));
-		return LiteralStringRef("OnSetAddTask");
+		return "OnSetAddTask"_sr;
 	}
 
 	Future<Void> execute(Database cx,
@@ -3566,7 +3565,7 @@ struct RestoreLogDataTaskFunc : RestoreFileTaskFuncBase {
 		return _finish(tr, tb, fb, task);
 	};
 };
-StringRef RestoreLogDataTaskFunc::name = LiteralStringRef("restore_log_data");
+StringRef RestoreLogDataTaskFunc::name = "restore_log_data"_sr;
 REGISTER_TASKFUNC(RestoreLogDataTaskFunc);
 
 struct RestoreDispatchTaskFunc : RestoreTaskFuncBase {
@@ -3934,7 +3933,7 @@ struct RestoreDispatchTaskFunc : RestoreTaskFuncBase {
 		}
 
 		wait(waitFor->onSetAddTask(tr, taskBucket, task));
-		return LiteralStringRef("OnSetAddTask");
+		return "OnSetAddTask"_sr;
 	}
 
 	Future<Void> execute(Database cx,
@@ -3950,7 +3949,7 @@ struct RestoreDispatchTaskFunc : RestoreTaskFuncBase {
 		return _finish(tr, tb, fb, task);
 	};
 };
-StringRef RestoreDispatchTaskFunc::name = LiteralStringRef("restore_dispatch");
+StringRef RestoreDispatchTaskFunc::name = "restore_dispatch"_sr;
 REGISTER_TASKFUNC(RestoreDispatchTaskFunc);
 
 ACTOR Future<std::string> restoreStatus(Reference<ReadYourWritesTransaction> tr, Key tagName) {
@@ -4292,7 +4291,7 @@ struct StartFullRestoreTaskFunc : RestoreTaskFuncBase {
 		}
 
 		wait(waitFor->onSetAddTask(tr, taskBucket, task));
-		return LiteralStringRef("OnSetAddTask");
+		return "OnSetAddTask"_sr;
 	}
 
 	StringRef getName() const override { return name; };
@@ -4310,7 +4309,7 @@ struct StartFullRestoreTaskFunc : RestoreTaskFuncBase {
 		return _finish(tr, tb, fb, task);
 	};
 };
-StringRef StartFullRestoreTaskFunc::name = LiteralStringRef("restore_start");
+StringRef StartFullRestoreTaskFunc::name = "restore_start"_sr;
 REGISTER_TASKFUNC(StartFullRestoreTaskFunc);
 } // namespace fileBackup
 
@@ -4898,7 +4897,7 @@ public:
 			tr->setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
 
 			try {
-				tr->set(backupPausedKey, pause ? LiteralStringRef("1") : LiteralStringRef("0"));
+				tr->set(backupPausedKey, pause ? "1"_sr : "0"_sr);
 				wait(tr->commit());
 				break;
 			} catch (Error& e) {

--- a/fdbclient/GlobalConfig.actor.cpp
+++ b/fdbclient/GlobalConfig.actor.cpp
@@ -28,11 +28,11 @@
 
 #include "flow/actorcompiler.h" // This must be the last #include.
 
-const KeyRef fdbClientInfoTxnSampleRate = LiteralStringRef("config/fdb_client_info/client_txn_sample_rate");
-const KeyRef fdbClientInfoTxnSizeLimit = LiteralStringRef("config/fdb_client_info/client_txn_size_limit");
+const KeyRef fdbClientInfoTxnSampleRate = "config/fdb_client_info/client_txn_sample_rate"_sr;
+const KeyRef fdbClientInfoTxnSizeLimit = "config/fdb_client_info/client_txn_size_limit"_sr;
 
-const KeyRef transactionTagSampleRate = LiteralStringRef("config/transaction_tag_sample_rate");
-const KeyRef transactionTagSampleCost = LiteralStringRef("config/transaction_tag_sample_cost");
+const KeyRef transactionTagSampleRate = "config/transaction_tag_sample_rate"_sr;
+const KeyRef transactionTagSampleCost = "config/transaction_tag_sample_cost"_sr;
 
 GlobalConfig::GlobalConfig(Database& cx) : cx(cx), lastUpdate(0) {}
 

--- a/fdbclient/HTTP.actor.cpp
+++ b/fdbclient/HTTP.actor.cpp
@@ -79,14 +79,14 @@ PacketBuffer* writeRequestHeader(std::string const& verb,
 	writer.serializeBytes(verb);
 	writer.serializeBytes(" ", 1);
 	writer.serializeBytes(resource);
-	writer.serializeBytes(LiteralStringRef(" HTTP/1.1\r\n"));
+	writer.serializeBytes(" HTTP/1.1\r\n"_sr);
 	for (auto h : headers) {
 		writer.serializeBytes(h.first);
-		writer.serializeBytes(LiteralStringRef(": "));
+		writer.serializeBytes(": "_sr);
 		writer.serializeBytes(h.second);
-		writer.serializeBytes(LiteralStringRef("\r\n"));
+		writer.serializeBytes("\r\n"_sr);
 	}
-	writer.serializeBytes(LiteralStringRef("\r\n"));
+	writer.serializeBytes("\r\n"_sr);
 	return writer.finish();
 }
 

--- a/fdbclient/KeyRangeMap.actor.cpp
+++ b/fdbclient/KeyRangeMap.actor.cpp
@@ -186,7 +186,7 @@ static Future<Void> krmSetRangeCoalescing_(Transaction* tr,
 	// Determine how far to extend this range at the beginning
 	auto beginRange = keys[0].get();
 	bool hasBegin = beginRange.size() > 0 && beginRange[0].key.startsWith(mapPrefix);
-	Value beginValue = hasBegin ? beginRange[0].value : LiteralStringRef("");
+	Value beginValue = hasBegin ? beginRange[0].value : ""_sr;
 
 	state Key beginKey = withPrefix.begin;
 	if (beginValue == value) {
@@ -199,7 +199,7 @@ static Future<Void> krmSetRangeCoalescing_(Transaction* tr,
 	bool hasEnd = endRange.size() >= 1 && endRange[0].key.startsWith(mapPrefix) && endRange[0].key <= withPrefix.end;
 	bool hasNext = (endRange.size() == 2 && endRange[1].key.startsWith(mapPrefix)) ||
 	               (endRange.size() == 1 && withPrefix.end < endRange[0].key && endRange[0].key.startsWith(mapPrefix));
-	Value existingValue = hasEnd ? endRange[0].value : LiteralStringRef("");
+	Value existingValue = hasEnd ? endRange[0].value : ""_sr;
 	bool valueMatches = value == existingValue;
 
 	KeyRange conflictRange = KeyRangeRef(hasBegin ? beginRange[0].key : mapPrefix, withPrefix.begin);

--- a/fdbclient/ManagementAPI.actor.cpp
+++ b/fdbclient/ManagementAPI.actor.cpp
@@ -414,7 +414,7 @@ ACTOR Future<DatabaseConfiguration> getDatabaseConfiguration(Database cx) {
 }
 
 ACTOR Future<ConfigurationResult> changeConfig(Database cx, std::map<std::string, std::string> m, bool force) {
-	state StringRef initIdKey = LiteralStringRef("\xff/init_id");
+	state StringRef initIdKey = "\xff/init_id"_sr;
 	state Transaction tr(cx);
 
 	if (!m.size()) {
@@ -631,8 +631,8 @@ ACTOR Future<ConfigurationResult> changeConfig(Database cx, std::map<std::string
 				ASSERT(creating);
 				tr.atomicOp(databaseLockedKey,
 				            BinaryWriter::toValue(locked.get(), Unversioned())
-				                .withPrefix(LiteralStringRef("0123456789"))
-				                .withSuffix(LiteralStringRef("\x00\x00\x00\x00")),
+				                .withPrefix("0123456789"_sr)
+				                .withSuffix("\x00\x00\x00\x00"_sr),
 				            MutationRef::SetVersionstampedValue);
 			}
 
@@ -1012,7 +1012,7 @@ Future<ConfigurationResult> changeConfig(Database const& cx,
                                          std::vector<StringRef> const& modes,
                                          Optional<ConfigureAutoResult> const& conf,
                                          bool force) {
-	if (modes.size() && modes[0] == LiteralStringRef("auto") && conf.present()) {
+	if (modes.size() && modes[0] == "auto"_sr && conf.present()) {
 		return autoConfig(cx, conf.get());
 	}
 
@@ -1320,10 +1320,8 @@ struct AutoQuorumChange final : IQuorumChange {
 	}
 
 	ACTOR static Future<int> getRedundancy(AutoQuorumChange* self, Transaction* tr) {
-		state Future<Optional<Value>> fStorageReplicas =
-		    tr->get(LiteralStringRef("storage_replicas").withPrefix(configKeysPrefix));
-		state Future<Optional<Value>> fLogReplicas =
-		    tr->get(LiteralStringRef("log_replicas").withPrefix(configKeysPrefix));
+		state Future<Optional<Value>> fStorageReplicas = tr->get("storage_replicas"_sr.withPrefix(configKeysPrefix));
+		state Future<Optional<Value>> fLogReplicas = tr->get("log_replicas"_sr.withPrefix(configKeysPrefix));
 		wait(success(fStorageReplicas) && success(fLogReplicas));
 		int redundancy = std::min(atoi(fStorageReplicas.get().get().toString().c_str()),
 		                          atoi(fLogReplicas.get().get().toString().c_str()));
@@ -1470,10 +1468,7 @@ struct AutoQuorumChange final : IQuorumChange {
 		std::map<StringRef, std::map<StringRef, int>> currentCounts;
 		std::map<StringRef, int> hardLimits;
 
-		vector<StringRef> fields({ LiteralStringRef("dcid"),
-		                           LiteralStringRef("data_hall"),
-		                           LiteralStringRef("zoneid"),
-		                           LiteralStringRef("machineid") });
+		vector<StringRef> fields({ "dcid"_sr, "data_hall"_sr, "zoneid"_sr, "machineid"_sr });
 
 		for (auto field = fields.begin(); field != fields.end(); field++) {
 			if (field->toString() == "zoneid") {
@@ -1499,7 +1494,7 @@ struct AutoQuorumChange final : IQuorumChange {
 					if (maxCounts[*field] == 0) {
 						maxCounts[*field] = 1;
 					}
-					auto value = worker->locality.get(*field).orDefault(LiteralStringRef(""));
+					auto value = worker->locality.get(*field).orDefault(""_sr);
 					auto currentCount = currentCounts[*field][value];
 					if (currentCount >= maxCounts[*field]) {
 						valid = false;
@@ -1508,7 +1503,7 @@ struct AutoQuorumChange final : IQuorumChange {
 				}
 				if (valid) {
 					for (auto field = fields.begin(); field != fields.end(); field++) {
-						auto value = worker->locality.get(*field).orDefault(LiteralStringRef(""));
+						auto value = worker->locality.get(*field).orDefault(""_sr);
 						currentCounts[*field][value] += 1;
 					}
 					chosen.push_back(worker->address);
@@ -1687,8 +1682,7 @@ ACTOR Future<Void> includeServers(Database cx, vector<AddressExclusion> servers,
 						// This is why we now make two clears: first only of the ip
 						// address, the second will delete all ports.
 						if (s.isWholeMachine())
-							ryw.clear(KeyRangeRef(addr.withSuffix(LiteralStringRef(":")),
-							                      addr.withSuffix(LiteralStringRef(";"))));
+							ryw.clear(KeyRangeRef(addr.withSuffix(":"_sr), addr.withSuffix(";"_sr)));
 					}
 				}
 				TraceEvent("IncludeServersCommit").detail("Servers", describe(servers)).detail("Failed", failed);
@@ -2066,7 +2060,7 @@ ACTOR Future<Void> setDDIgnoreRebalanceSwitch(Database cx, bool ignoreRebalance)
 		try {
 			tr.setOption(FDBTransactionOptions::LOCK_AWARE);
 			if (ignoreRebalance) {
-				tr.set(rebalanceDDIgnoreKey, LiteralStringRef("on"));
+				tr.set(rebalanceDDIgnoreKey, "on"_sr);
 			} else {
 				tr.clear(rebalanceDDIgnoreKey);
 			}
@@ -2280,9 +2274,7 @@ ACTOR Future<Void> lockDatabase(Transaction* tr, UID id) {
 	}
 
 	tr->atomicOp(databaseLockedKey,
-	             BinaryWriter::toValue(id, Unversioned())
-	                 .withPrefix(LiteralStringRef("0123456789"))
-	                 .withSuffix(LiteralStringRef("\x00\x00\x00\x00")),
+	             BinaryWriter::toValue(id, Unversioned()).withPrefix("0123456789"_sr).withSuffix("\x00\x00\x00\x00"_sr),
 	             MutationRef::SetVersionstampedValue);
 	tr->addWriteConflictRange(normalKeys);
 	return Void();
@@ -2303,9 +2295,7 @@ ACTOR Future<Void> lockDatabase(Reference<ReadYourWritesTransaction> tr, UID id)
 	}
 
 	tr->atomicOp(databaseLockedKey,
-	             BinaryWriter::toValue(id, Unversioned())
-	                 .withPrefix(LiteralStringRef("0123456789"))
-	                 .withSuffix(LiteralStringRef("\x00\x00\x00\x00")),
+	             BinaryWriter::toValue(id, Unversioned()).withPrefix("0123456789"_sr).withSuffix("\x00\x00\x00\x00"_sr),
 	             MutationRef::SetVersionstampedValue);
 	tr->addWriteConflictRange(normalKeys);
 	return Void();
@@ -2702,11 +2692,11 @@ TEST_CASE("/ManagementAPI/AutoQuorumChange/checkLocality") {
 		auto dataHall = dataCenter + std::to_string(i / 2 % 2);
 		auto rack = dataHall + std::to_string(i % 2);
 		auto machineId = rack + std::to_string(i);
-		data.locality.set(LiteralStringRef("dcid"), StringRef(dataCenter));
-		data.locality.set(LiteralStringRef("data_hall"), StringRef(dataHall));
-		data.locality.set(LiteralStringRef("rack"), StringRef(rack));
-		data.locality.set(LiteralStringRef("zoneid"), StringRef(rack));
-		data.locality.set(LiteralStringRef("machineid"), StringRef(machineId));
+		data.locality.set("dcid"_sr, StringRef(dataCenter));
+		data.locality.set("data_hall"_sr, StringRef(dataHall));
+		data.locality.set("rack"_sr, StringRef(rack));
+		data.locality.set("zoneid"_sr, StringRef(rack));
+		data.locality.set("machineid"_sr, StringRef(machineId));
 		data.address.ip = IPAddress(i);
 
 		if (g_network->isSimulated()) {
@@ -2732,10 +2722,7 @@ TEST_CASE("/ManagementAPI/AutoQuorumChange/checkLocality") {
 	std::map<StringRef, std::set<StringRef>> chosenValues;
 
 	ASSERT(chosen.size() == 5);
-	std::vector<StringRef> fields({ LiteralStringRef("dcid"),
-	                                LiteralStringRef("data_hall"),
-	                                LiteralStringRef("zoneid"),
-	                                LiteralStringRef("machineid") });
+	std::vector<StringRef> fields({ "dcid"_sr, "data_hall"_sr, "zoneid"_sr, "machineid"_sr });
 	for (auto worker = chosen.begin(); worker != chosen.end(); worker++) {
 		ASSERT(worker->ip.toV4() < workers.size());
 		LocalityData data = workers[worker->ip.toV4()].locality;
@@ -2744,10 +2731,10 @@ TEST_CASE("/ManagementAPI/AutoQuorumChange/checkLocality") {
 		}
 	}
 
-	ASSERT(chosenValues[LiteralStringRef("dcid")].size() == 2);
-	ASSERT(chosenValues[LiteralStringRef("data_hall")].size() == 4);
-	ASSERT(chosenValues[LiteralStringRef("zoneid")].size() == 5);
-	ASSERT(chosenValues[LiteralStringRef("machineid")].size() == 5);
+	ASSERT(chosenValues["dcid"_sr].size() == 2);
+	ASSERT(chosenValues["data_hall"_sr].size() == 4);
+	ASSERT(chosenValues["zoneid"_sr].size() == 5);
+	ASSERT(chosenValues["machineid"_sr].size() == 5);
 	ASSERT(std::find(chosen.begin(), chosen.end(), workers[noAssignIndex].address) != chosen.end());
 
 	return Void();

--- a/fdbclient/MonitorLeader.actor.cpp
+++ b/fdbclient/MonitorLeader.actor.cpp
@@ -303,7 +303,7 @@ TEST_CASE("/fdbclient/MonitorLeader/parseConnectionString/fuzz") {
 		auto c = connectionString.begin();
 		while (c != connectionString.end()) {
 			if (deterministicRandom()->random01() < 0.1) // Add whitespace character
-				output += deterministicRandom()->randomChoice(LiteralStringRef(" \t\n\r"));
+				output += deterministicRandom()->randomChoice(" \t\n\r"_sr);
 			if (deterministicRandom()->random01() < 0.5) { // Add one of the input characters
 				output += *c;
 				++c;
@@ -312,9 +312,9 @@ TEST_CASE("/fdbclient/MonitorLeader/parseConnectionString/fuzz") {
 				output += "#";
 				int charCount = deterministicRandom()->randomInt(0, 20);
 				for (int i = 0; i < charCount; i++) {
-					output += deterministicRandom()->randomChoice(LiteralStringRef("asdfzxcv123345:!@#$#$&()<\"\' \t"));
+					output += deterministicRandom()->randomChoice("asdfzxcv123345:!@#$#$&()<\"\' \t"_sr);
 				}
-				output += deterministicRandom()->randomChoice(LiteralStringRef("\n\r"));
+				output += deterministicRandom()->randomChoice("\n\r"_sr);
 			}
 		}
 
@@ -791,7 +791,7 @@ ACTOR Future<MonitorLeaderInfo> monitorProxiesOneGeneration(
 
 		ClusterConnectionString fileConnectionString;
 		if (connFile && !connFile->fileContentsUpToDate(fileConnectionString)) {
-			req.issues.push_back_deep(req.issues.arena(), LiteralStringRef("incorrect_cluster_file_contents"));
+			req.issues.push_back_deep(req.issues.arena(), "incorrect_cluster_file_contents"_sr);
 			std::string connectionString = connFile->getConnectionString().toString();
 			if (!incorrectTime.present()) {
 				incorrectTime = now();

--- a/fdbclient/RYWIterator.cpp
+++ b/fdbclient/RYWIterator.cpp
@@ -231,28 +231,28 @@ void testSnapshotCache() {
 	WriteMap writes(&arena);
 
 	Standalone<VectorRef<KeyValueRef>> keys;
-	keys.push_back_deep(keys.arena(), KeyValueRef(LiteralStringRef("d"), LiteralStringRef("doo")));
-	keys.push_back_deep(keys.arena(), KeyValueRef(LiteralStringRef("e"), LiteralStringRef("eoo")));
-	keys.push_back_deep(keys.arena(), KeyValueRef(LiteralStringRef("e\x00"), LiteralStringRef("zoo")));
-	keys.push_back_deep(keys.arena(), KeyValueRef(LiteralStringRef("f"), LiteralStringRef("foo")));
-	cache.insert(KeyRangeRef(LiteralStringRef("d"), LiteralStringRef("f\x00")), keys);
+	keys.push_back_deep(keys.arena(), KeyValueRef("d"_sr, "doo"_sr));
+	keys.push_back_deep(keys.arena(), KeyValueRef("e"_sr, "eoo"_sr));
+	keys.push_back_deep(keys.arena(), KeyValueRef("e\x00"_sr, "zoo"_sr));
+	keys.push_back_deep(keys.arena(), KeyValueRef("f"_sr, "foo"_sr));
+	cache.insert(KeyRangeRef("d"_sr, "f\x00"_sr), keys);
 
-	cache.insert(KeyRangeRef(LiteralStringRef("g"), LiteralStringRef("h")), Standalone<VectorRef<KeyValueRef>>());
+	cache.insert(KeyRangeRef("g"_sr, "h"_sr), Standalone<VectorRef<KeyValueRef>>());
 
 	Standalone<VectorRef<KeyValueRef>> keys2;
-	keys2.push_back_deep(keys2.arena(), KeyValueRef(LiteralStringRef("k"), LiteralStringRef("koo")));
-	keys2.push_back_deep(keys2.arena(), KeyValueRef(LiteralStringRef("l"), LiteralStringRef("loo")));
-	cache.insert(KeyRangeRef(LiteralStringRef("j"), LiteralStringRef("m")), keys2);
+	keys2.push_back_deep(keys2.arena(), KeyValueRef("k"_sr, "koo"_sr));
+	keys2.push_back_deep(keys2.arena(), KeyValueRef("l"_sr, "loo"_sr));
+	cache.insert(KeyRangeRef("j"_sr, "m"_sr), keys2);
 
-	writes.mutate(LiteralStringRef("c"), MutationRef::SetValue, LiteralStringRef("c--"), true);
-	writes.clear(KeyRangeRef(LiteralStringRef("c\x00"), LiteralStringRef("e")), true);
-	writes.mutate(LiteralStringRef("c\x00"), MutationRef::SetValue, LiteralStringRef("c00--"), true);
+	writes.mutate("c"_sr, MutationRef::SetValue, "c--"_sr, true);
+	writes.clear(KeyRangeRef("c\x00"_sr, "e"_sr), true);
+	writes.mutate("c\x00"_sr, MutationRef::SetValue, "c00--"_sr, true);
 	WriteMap::iterator it3(&writes);
-	writes.mutate(LiteralStringRef("d"), MutationRef::SetValue, LiteralStringRef("d--"), true);
-	writes.mutate(LiteralStringRef("e"), MutationRef::SetValue, LiteralStringRef("e++"), true);
-	writes.mutate(LiteralStringRef("i"), MutationRef::SetValue, LiteralStringRef("i--"), true);
+	writes.mutate("d"_sr, MutationRef::SetValue, "d--"_sr, true);
+	writes.mutate("e"_sr, MutationRef::SetValue, "e++"_sr, true);
+	writes.mutate("i"_sr, MutationRef::SetValue, "i--"_sr, true);
 
-	KeyRange searchKeys = KeyRangeRef(LiteralStringRef("a"), LiteralStringRef("z"));
+	KeyRange searchKeys = KeyRangeRef("a"_sr, "z"_sr);
 
 	RYWIterator it(&cache, &writes);
 	it.skip(searchKeys.begin);
@@ -425,7 +425,7 @@ TEST_CASE("/fdbclient/WriteMap/emptiness") {
 	Arena arena = Arena();
 	WriteMap writes = WriteMap(&arena);
 	ASSERT(writes.empty());
-	writes.mutate(LiteralStringRef("apple"), MutationRef::SetValue, LiteralStringRef("red"), true);
+	writes.mutate("apple"_sr, MutationRef::SetValue, "red"_sr, true);
 	ASSERT(!writes.empty());
 	return Void();
 }
@@ -436,11 +436,11 @@ TEST_CASE("/fdbclient/WriteMap/clear") {
 	ASSERT(writes.empty());
 	ASSERT(getWriteMapCount(&writes) == 1);
 
-	writes.mutate(LiteralStringRef("apple"), MutationRef::SetValue, LiteralStringRef("red"), true);
+	writes.mutate("apple"_sr, MutationRef::SetValue, "red"_sr, true);
 	ASSERT(!writes.empty());
 	ASSERT(getWriteMapCount(&writes) == 3);
 
-	KeyRangeRef range = KeyRangeRef(LiteralStringRef("a"), LiteralStringRef("j"));
+	KeyRangeRef range = KeyRangeRef("a"_sr, "j"_sr);
 	writes.clear(range, true);
 	ASSERT(getWriteMapCount(&writes) == 3);
 
@@ -453,22 +453,19 @@ TEST_CASE("/fdbclient/WriteMap/setVersionstampedKey") {
 	ASSERT(writes.empty());
 	ASSERT(getWriteMapCount(&writes) == 1);
 
-	writes.mutate(LiteralStringRef("stamp:XXXXXXXX\x06\x00\x00\x00"),
-	              MutationRef::SetVersionstampedKey,
-	              LiteralStringRef("1"),
-	              true);
+	writes.mutate("stamp:XXXXXXXX\x06\x00\x00\x00"_sr, MutationRef::SetVersionstampedKey, "1"_sr, true);
 	ASSERT(!writes.empty());
 	ASSERT(getWriteMapCount(&writes) == 3);
 
-	writes.mutate(LiteralStringRef("stamp:ZZZZZZZZZZ"), MutationRef::AddValue, LiteralStringRef("2"), true);
+	writes.mutate("stamp:ZZZZZZZZZZ"_sr, MutationRef::AddValue, "2"_sr, true);
 	ASSERT(getWriteMapCount(&writes) == 5);
 
 	WriteMap::iterator it(&writes);
 	it.skip(allKeys.begin);
 
 	ASSERT(it.beginKey() < allKeys.end);
-	ASSERT(it.beginKey().compare(LiteralStringRef("")) == 0);
-	ASSERT(it.endKey().compare(LiteralStringRef("stamp:XXXXXXXX\x06\x00\x00\x00")) == 0);
+	ASSERT(it.beginKey().compare(""_sr) == 0);
+	ASSERT(it.endKey().compare("stamp:XXXXXXXX\x06\x00\x00\x00"_sr) == 0);
 	ASSERT(!it.is_cleared_range());
 	ASSERT(!it.is_conflict_range());
 	ASSERT(!it.is_operation());
@@ -477,8 +474,8 @@ TEST_CASE("/fdbclient/WriteMap/setVersionstampedKey") {
 	++it;
 
 	ASSERT(it.beginKey() < allKeys.end);
-	ASSERT(it.beginKey().compare(LiteralStringRef("stamp:XXXXXXXX\x06\x00\x00\x00")) == 0);
-	ASSERT(it.endKey().compare(LiteralStringRef("stamp:XXXXXXXX\x06\x00\x00\x00\x00")) == 0);
+	ASSERT(it.beginKey().compare("stamp:XXXXXXXX\x06\x00\x00\x00"_sr) == 0);
+	ASSERT(it.endKey().compare("stamp:XXXXXXXX\x06\x00\x00\x00\x00"_sr) == 0);
 	ASSERT(!it.is_cleared_range());
 	ASSERT(it.is_conflict_range());
 	ASSERT(it.is_operation());
@@ -488,8 +485,8 @@ TEST_CASE("/fdbclient/WriteMap/setVersionstampedKey") {
 	++it;
 
 	ASSERT(it.beginKey() < allKeys.end);
-	ASSERT(it.beginKey().compare(LiteralStringRef("stamp:XXXXXXXX\x06\x00\x00\x00\x00")) == 0);
-	ASSERT(it.endKey().compare(LiteralStringRef("stamp:ZZZZZZZZZZ")) == 0);
+	ASSERT(it.beginKey().compare("stamp:XXXXXXXX\x06\x00\x00\x00\x00"_sr) == 0);
+	ASSERT(it.endKey().compare("stamp:ZZZZZZZZZZ"_sr) == 0);
 	ASSERT(!it.is_cleared_range());
 	ASSERT(!it.is_conflict_range());
 	ASSERT(!it.is_operation());
@@ -498,8 +495,8 @@ TEST_CASE("/fdbclient/WriteMap/setVersionstampedKey") {
 	++it;
 
 	ASSERT(it.beginKey() < allKeys.end);
-	ASSERT(it.beginKey().compare(LiteralStringRef("stamp:ZZZZZZZZZZ")) == 0);
-	ASSERT(it.endKey().compare(LiteralStringRef("stamp:ZZZZZZZZZZ\x00")) == 0);
+	ASSERT(it.beginKey().compare("stamp:ZZZZZZZZZZ"_sr) == 0);
+	ASSERT(it.endKey().compare("stamp:ZZZZZZZZZZ\x00"_sr) == 0);
 	ASSERT(!it.is_cleared_range());
 	ASSERT(it.is_conflict_range());
 	ASSERT(it.is_operation());
@@ -509,8 +506,8 @@ TEST_CASE("/fdbclient/WriteMap/setVersionstampedKey") {
 	++it;
 
 	ASSERT(it.beginKey() < allKeys.end);
-	ASSERT(it.beginKey().compare(LiteralStringRef("stamp:ZZZZZZZZZZ\x00")) == 0);
-	ASSERT(it.endKey().compare(LiteralStringRef("\xff\xff")) == 0);
+	ASSERT(it.beginKey().compare("stamp:ZZZZZZZZZZ\x00"_sr) == 0);
+	ASSERT(it.endKey().compare("\xff\xff"_sr) == 0);
 	ASSERT(!it.is_cleared_range());
 	ASSERT(!it.is_conflict_range());
 	ASSERT(!it.is_operation());
@@ -529,22 +526,19 @@ TEST_CASE("/fdbclient/WriteMap/setVersionstampedValue") {
 	ASSERT(writes.empty());
 	ASSERT(getWriteMapCount(&writes) == 1);
 
-	writes.mutate(LiteralStringRef("stamp"),
-	              MutationRef::SetVersionstampedValue,
-	              LiteralStringRef("XXXXXXXX\x00\x00\x00\x00\x00\x00"),
-	              true);
+	writes.mutate("stamp"_sr, MutationRef::SetVersionstampedValue, "XXXXXXXX\x00\x00\x00\x00\x00\x00"_sr, true);
 	ASSERT(!writes.empty());
 	ASSERT(getWriteMapCount(&writes) == 3);
 
-	writes.mutate(LiteralStringRef("stamp123"), MutationRef::AddValue, LiteralStringRef("1"), true);
+	writes.mutate("stamp123"_sr, MutationRef::AddValue, "1"_sr, true);
 	ASSERT(getWriteMapCount(&writes) == 5);
 
 	WriteMap::iterator it(&writes);
 	it.skip(allKeys.begin);
 
 	ASSERT(it.beginKey() < allKeys.end);
-	ASSERT(it.beginKey().compare(LiteralStringRef("")) == 0);
-	ASSERT(it.endKey().compare(LiteralStringRef("stamp")) == 0);
+	ASSERT(it.beginKey().compare(""_sr) == 0);
+	ASSERT(it.endKey().compare("stamp"_sr) == 0);
 	ASSERT(!it.is_cleared_range());
 	ASSERT(!it.is_conflict_range());
 	ASSERT(!it.is_operation());
@@ -553,8 +547,8 @@ TEST_CASE("/fdbclient/WriteMap/setVersionstampedValue") {
 	++it;
 
 	ASSERT(it.beginKey() < allKeys.end);
-	ASSERT(it.beginKey().compare(LiteralStringRef("stamp")) == 0);
-	ASSERT(it.endKey().compare(LiteralStringRef("stamp\x00")) == 0);
+	ASSERT(it.beginKey().compare("stamp"_sr) == 0);
+	ASSERT(it.endKey().compare("stamp\x00"_sr) == 0);
 	ASSERT(!it.is_cleared_range());
 	ASSERT(it.is_conflict_range());
 	ASSERT(it.is_operation());
@@ -564,8 +558,8 @@ TEST_CASE("/fdbclient/WriteMap/setVersionstampedValue") {
 	++it;
 
 	ASSERT(it.beginKey() < allKeys.end);
-	ASSERT(it.beginKey().compare(LiteralStringRef("stamp\x00")) == 0);
-	ASSERT(it.endKey().compare(LiteralStringRef("stamp123")) == 0);
+	ASSERT(it.beginKey().compare("stamp\x00"_sr) == 0);
+	ASSERT(it.endKey().compare("stamp123"_sr) == 0);
 	ASSERT(!it.is_cleared_range());
 	ASSERT(!it.is_conflict_range());
 	ASSERT(!it.is_operation());
@@ -574,8 +568,8 @@ TEST_CASE("/fdbclient/WriteMap/setVersionstampedValue") {
 	++it;
 
 	ASSERT(it.beginKey() < allKeys.end);
-	ASSERT(it.beginKey().compare(LiteralStringRef("stamp123")) == 0);
-	ASSERT(it.endKey().compare(LiteralStringRef("stamp123\x00")) == 0);
+	ASSERT(it.beginKey().compare("stamp123"_sr) == 0);
+	ASSERT(it.endKey().compare("stamp123\x00"_sr) == 0);
 	ASSERT(!it.is_cleared_range());
 	ASSERT(it.is_conflict_range());
 	ASSERT(it.is_operation());
@@ -585,8 +579,8 @@ TEST_CASE("/fdbclient/WriteMap/setVersionstampedValue") {
 	++it;
 
 	ASSERT(it.beginKey() < allKeys.end);
-	ASSERT(it.beginKey().compare(LiteralStringRef("stamp123\x00")) == 0);
-	ASSERT(it.endKey().compare(LiteralStringRef("\xff\xff")) == 0);
+	ASSERT(it.beginKey().compare("stamp123\x00"_sr) == 0);
+	ASSERT(it.endKey().compare("\xff\xff"_sr) == 0);
 	ASSERT(!it.is_cleared_range());
 	ASSERT(!it.is_conflict_range());
 	ASSERT(!it.is_operation());
@@ -605,10 +599,10 @@ TEST_CASE("/fdbclient/WriteMap/addValue") {
 	ASSERT(writes.empty());
 	ASSERT(getWriteMapCount(&writes) == 1);
 
-	writes.mutate(LiteralStringRef("apple123"), MutationRef::SetValue, LiteralStringRef("17"), true);
+	writes.mutate("apple123"_sr, MutationRef::SetValue, "17"_sr, true);
 	ASSERT(getWriteMapCount(&writes) == 3);
 
-	writes.mutate(LiteralStringRef("apple123"), MutationRef::AddValue, LiteralStringRef("1"), true);
+	writes.mutate("apple123"_sr, MutationRef::AddValue, "1"_sr, true);
 	ASSERT(getWriteMapCount(&writes) == 3);
 
 	return Void();

--- a/fdbclient/S3BlobStore.actor.cpp
+++ b/fdbclient/S3BlobStore.actor.cpp
@@ -91,7 +91,7 @@ bool S3BlobStoreEndpoint::BlobKnobs::set(StringRef name, int value) {
 	TRY_PARAM(request_tries, rt);
 	TRY_PARAM(request_timeout_min, rtom);
 	// TODO: For backward compatibility because request_timeout was renamed to request_timeout_min
-	if (name == LiteralStringRef("request_timeout") || name == LiteralStringRef("rto")) {
+	if (name == "request_timeout"_sr || name == "rto"_sr) {
 		request_timeout_min = value;
 		return true;
 	}
@@ -162,7 +162,7 @@ Reference<S3BlobStoreEndpoint> S3BlobStoreEndpoint::fromString(std::string const
 	try {
 		StringRef t(url);
 		StringRef prefix = t.eat("://");
-		if (prefix != LiteralStringRef("blobstore"))
+		if (prefix != "blobstore"_sr)
 			throw format("Invalid blobstore URL prefix '%s'", prefix.toString().c_str());
 
 		Optional<StringRef> cred;
@@ -193,7 +193,7 @@ Reference<S3BlobStoreEndpoint> S3BlobStoreEndpoint::fromString(std::string const
 			StringRef value = t.eat("&");
 
 			// Special case for header
-			if (name == LiteralStringRef("header")) {
+			if (name == "header"_sr) {
 				StringRef originalValue = value;
 				StringRef headerFieldName = value.eat(":");
 				StringRef headerFieldValue = value;
@@ -1114,7 +1114,7 @@ void S3BlobStoreEndpoint::setAuthHeaders(std::string const& verb, std::string co
 	msg.append("\n");
 	for (auto h : headers) {
 		StringRef name = h.first;
-		if (name.startsWith(LiteralStringRef("x-amz")) || name.startsWith(LiteralStringRef("x-icloud"))) {
+		if (name.startsWith("x-amz"_sr) || name.startsWith("x-icloud"_sr)) {
 			msg.append(h.first);
 			msg.append(":");
 			msg.append(h.second);

--- a/fdbclient/Schemas.cpp
+++ b/fdbclient/Schemas.cpp
@@ -21,7 +21,7 @@
 #include "fdbclient/Schemas.h"
 
 // NOTE: also change mr-status-json-schemas.rst.inc
-const KeyRef JSONSchemas::statusSchema = LiteralStringRef(R"statusSchema(
+const KeyRef JSONSchemas::statusSchema = R"statusSchema(
 {
    "cluster":{
       "layers":{
@@ -530,7 +530,7 @@ const KeyRef JSONSchemas::statusSchema = LiteralStringRef(R"statusSchema(
          }
       ],
 )statusSchema"
-                                                          R"statusSchema(
+                                         R"statusSchema(
       "recovery_state":{
          "seconds_since_last_recovered":1,
          "required_resolvers":1,
@@ -893,9 +893,9 @@ const KeyRef JSONSchemas::statusSchema = LiteralStringRef(R"statusSchema(
          "up_to_date":true
       }
    }
-})statusSchema");
+})statusSchema"_sr;
 
-const KeyRef JSONSchemas::clusterConfigurationSchema = LiteralStringRef(R"configSchema(
+const KeyRef JSONSchemas::clusterConfigurationSchema = R"configSchema(
 {
     "create":{
     "$enum":[
@@ -965,9 +965,9 @@ const KeyRef JSONSchemas::clusterConfigurationSchema = LiteralStringRef(R"config
     "auto_logs":3,
     "commit_proxies":5,
     "grv_proxies":1
-})configSchema");
+})configSchema"_sr;
 
-const KeyRef JSONSchemas::latencyBandConfigurationSchema = LiteralStringRef(R"configSchema(
+const KeyRef JSONSchemas::latencyBandConfigurationSchema = R"configSchema(
 {
     "get_read_version":{
         "bands":[
@@ -987,30 +987,30 @@ const KeyRef JSONSchemas::latencyBandConfigurationSchema = LiteralStringRef(R"co
         ],
         "max_commit_bytes":0
     }
-})configSchema");
+})configSchema"_sr;
 
-const KeyRef JSONSchemas::dataDistributionStatsSchema = LiteralStringRef(R"""(
+const KeyRef JSONSchemas::dataDistributionStatsSchema = R"""(
 {
   "shard_bytes": 1947000
 }
-)""");
+)"""_sr;
 
-const KeyRef JSONSchemas::logHealthSchema = LiteralStringRef(R"""(
+const KeyRef JSONSchemas::logHealthSchema = R"""(
 {
   "log_queue": 156
 }
-)""");
+)"""_sr;
 
-const KeyRef JSONSchemas::storageHealthSchema = LiteralStringRef(R"""(
+const KeyRef JSONSchemas::storageHealthSchema = R"""(
 {
   "cpu_usage": 3.28629447047675,
   "disk_usage": 0.19997897369207954,
   "storage_durability_lag": 5050809,
   "storage_queue": 2030
 }
-)""");
+)"""_sr;
 
-const KeyRef JSONSchemas::aggregateHealthSchema = LiteralStringRef(R"""(
+const KeyRef JSONSchemas::aggregateHealthSchema = R"""(
 {
   "batch_limited": false,
   "limiting_storage_durability_lag": 5050809,
@@ -1020,12 +1020,12 @@ const KeyRef JSONSchemas::aggregateHealthSchema = LiteralStringRef(R"""(
   "worst_storage_queue": 2030,
   "worst_log_queue": 156
 }
-)""");
+)"""_sr;
 
-const KeyRef JSONSchemas::managementApiErrorSchema = LiteralStringRef(R"""(
+const KeyRef JSONSchemas::managementApiErrorSchema = R"""(
 {
    "retriable": false,
    "command": "exclude",
    "message": "The reason of the error"
 }
-)""");
+)"""_sr;

--- a/fdbclient/SpecialKeySpace.actor.cpp
+++ b/fdbclient/SpecialKeySpace.actor.cpp
@@ -50,57 +50,41 @@ static bool isAlphaNumeric(const std::string& key) {
 } // namespace
 
 std::unordered_map<SpecialKeySpace::MODULE, KeyRange> SpecialKeySpace::moduleToBoundary = {
-	{ SpecialKeySpace::MODULE::TRANSACTION,
-	  KeyRangeRef(LiteralStringRef("\xff\xff/transaction/"), LiteralStringRef("\xff\xff/transaction0")) },
+	{ SpecialKeySpace::MODULE::TRANSACTION, KeyRangeRef("\xff\xff/transaction/"_sr, "\xff\xff/transaction0"_sr) },
 	{ SpecialKeySpace::MODULE::WORKERINTERFACE,
-	  KeyRangeRef(LiteralStringRef("\xff\xff/worker_interfaces/"), LiteralStringRef("\xff\xff/worker_interfaces0")) },
-	{ SpecialKeySpace::MODULE::STATUSJSON, singleKeyRange(LiteralStringRef("\xff\xff/status/json")) },
-	{ SpecialKeySpace::MODULE::CONNECTIONSTRING, singleKeyRange(LiteralStringRef("\xff\xff/connection_string")) },
-	{ SpecialKeySpace::MODULE::CLUSTERFILEPATH, singleKeyRange(LiteralStringRef("\xff\xff/cluster_file_path")) },
-	{ SpecialKeySpace::MODULE::METRICS,
-	  KeyRangeRef(LiteralStringRef("\xff\xff/metrics/"), LiteralStringRef("\xff\xff/metrics0")) },
-	{ SpecialKeySpace::MODULE::MANAGEMENT,
-	  KeyRangeRef(LiteralStringRef("\xff\xff/management/"), LiteralStringRef("\xff\xff/management0")) },
-	{ SpecialKeySpace::MODULE::ERRORMSG, singleKeyRange(LiteralStringRef("\xff\xff/error_message")) },
-	{ SpecialKeySpace::MODULE::CONFIGURATION,
-	  KeyRangeRef(LiteralStringRef("\xff\xff/configuration/"), LiteralStringRef("\xff\xff/configuration0")) },
-	{ SpecialKeySpace::MODULE::GLOBALCONFIG,
-	  KeyRangeRef(LiteralStringRef("\xff\xff/global_config/"), LiteralStringRef("\xff\xff/global_config0")) },
-	{ SpecialKeySpace::MODULE::TRACING,
-	  KeyRangeRef(LiteralStringRef("\xff\xff/tracing/"), LiteralStringRef("\xff\xff/tracing0")) }
+	  KeyRangeRef("\xff\xff/worker_interfaces/"_sr, "\xff\xff/worker_interfaces0"_sr) },
+	{ SpecialKeySpace::MODULE::STATUSJSON, singleKeyRange("\xff\xff/status/json"_sr) },
+	{ SpecialKeySpace::MODULE::CONNECTIONSTRING, singleKeyRange("\xff\xff/connection_string"_sr) },
+	{ SpecialKeySpace::MODULE::CLUSTERFILEPATH, singleKeyRange("\xff\xff/cluster_file_path"_sr) },
+	{ SpecialKeySpace::MODULE::METRICS, KeyRangeRef("\xff\xff/metrics/"_sr, "\xff\xff/metrics0"_sr) },
+	{ SpecialKeySpace::MODULE::MANAGEMENT, KeyRangeRef("\xff\xff/management/"_sr, "\xff\xff/management0"_sr) },
+	{ SpecialKeySpace::MODULE::ERRORMSG, singleKeyRange("\xff\xff/error_message"_sr) },
+	{ SpecialKeySpace::MODULE::CONFIGURATION, KeyRangeRef("\xff\xff/configuration/"_sr, "\xff\xff/configuration0"_sr) },
+	{ SpecialKeySpace::MODULE::GLOBALCONFIG, KeyRangeRef("\xff\xff/global_config/"_sr, "\xff\xff/global_config0"_sr) },
+	{ SpecialKeySpace::MODULE::TRACING, KeyRangeRef("\xff\xff/tracing/"_sr, "\xff\xff/tracing0"_sr) }
 };
 
 std::unordered_map<std::string, KeyRange> SpecialKeySpace::managementApiCommandToRange = {
-	{ "exclude",
-	  KeyRangeRef(LiteralStringRef("excluded/"), LiteralStringRef("excluded0"))
-	      .withPrefix(moduleToBoundary[MODULE::MANAGEMENT].begin) },
-	{ "failed",
-	  KeyRangeRef(LiteralStringRef("failed/"), LiteralStringRef("failed0"))
-	      .withPrefix(moduleToBoundary[MODULE::MANAGEMENT].begin) },
+	{ "exclude", KeyRangeRef("excluded/"_sr, "excluded0"_sr).withPrefix(moduleToBoundary[MODULE::MANAGEMENT].begin) },
+	{ "failed", KeyRangeRef("failed/"_sr, "failed0"_sr).withPrefix(moduleToBoundary[MODULE::MANAGEMENT].begin) },
 	{ "excludedlocality",
-	  KeyRangeRef(LiteralStringRef("excluded_locality/"), LiteralStringRef("excluded_locality0"))
+	  KeyRangeRef("excluded_locality/"_sr, "excluded_locality0"_sr)
 	      .withPrefix(moduleToBoundary[MODULE::MANAGEMENT].begin) },
 	{ "failedlocality",
-	  KeyRangeRef(LiteralStringRef("failed_locality/"), LiteralStringRef("failed_locality0"))
+	  KeyRangeRef("failed_locality/"_sr, "failed_locality0"_sr)
 	      .withPrefix(moduleToBoundary[MODULE::MANAGEMENT].begin) },
-	{ "lock", singleKeyRange(LiteralStringRef("db_locked")).withPrefix(moduleToBoundary[MODULE::MANAGEMENT].begin) },
+	{ "lock", singleKeyRange("db_locked"_sr).withPrefix(moduleToBoundary[MODULE::MANAGEMENT].begin) },
 	{ "consistencycheck",
-	  singleKeyRange(LiteralStringRef("consistency_check_suspended"))
-	      .withPrefix(moduleToBoundary[MODULE::MANAGEMENT].begin) },
+	  singleKeyRange("consistency_check_suspended"_sr).withPrefix(moduleToBoundary[MODULE::MANAGEMENT].begin) },
 	{ "coordinators",
-	  KeyRangeRef(LiteralStringRef("coordinators/"), LiteralStringRef("coordinators0"))
-	      .withPrefix(moduleToBoundary[MODULE::CONFIGURATION].begin) },
+	  KeyRangeRef("coordinators/"_sr, "coordinators0"_sr).withPrefix(moduleToBoundary[MODULE::CONFIGURATION].begin) },
 	{ "advanceversion",
-	  singleKeyRange(LiteralStringRef("min_required_commit_version"))
-	      .withPrefix(moduleToBoundary[MODULE::MANAGEMENT].begin) },
-	{ "profile",
-	  KeyRangeRef(LiteralStringRef("profiling/"), LiteralStringRef("profiling0"))
-	      .withPrefix(moduleToBoundary[MODULE::MANAGEMENT].begin) },
+	  singleKeyRange("min_required_commit_version"_sr).withPrefix(moduleToBoundary[MODULE::MANAGEMENT].begin) },
+	{ "profile", KeyRangeRef("profiling/"_sr, "profiling0"_sr).withPrefix(moduleToBoundary[MODULE::MANAGEMENT].begin) },
 	{ "maintenance",
-	  KeyRangeRef(LiteralStringRef("maintenance/"), LiteralStringRef("maintenance0"))
-	      .withPrefix(moduleToBoundary[MODULE::MANAGEMENT].begin) },
+	  KeyRangeRef("maintenance/"_sr, "maintenance0"_sr).withPrefix(moduleToBoundary[MODULE::MANAGEMENT].begin) },
 	{ "datadistribution",
-	  KeyRangeRef(LiteralStringRef("data_distribution/"), LiteralStringRef("data_distribution0"))
+	  KeyRangeRef("data_distribution/"_sr, "data_distribution0"_sr)
 	      .withPrefix(moduleToBoundary[MODULE::MANAGEMENT].begin) }
 };
 
@@ -501,8 +485,8 @@ bool validateSnakeCaseNaming(const KeyRef& k) {
 	// Suffix can be \xff\xff or \x00 in single key range
 	if (key.endsWith(specialKeys.begin))
 		key = key.removeSuffix(specialKeys.end);
-	else if (key.endsWith(LiteralStringRef("\x00")))
-		key = key.removeSuffix(LiteralStringRef("\x00"));
+	else if (key.endsWith("\x00"_sr))
+		key = key.removeSuffix("\x00"_sr);
 	for (const char& c : key.toString()) {
 		// only small letters, numbers, '/', '_' is allowed
 		ASSERT((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '/' || c == '_');
@@ -683,7 +667,7 @@ Future<RangeResult> DDStatsRangeImpl::getRange(ReadYourWritesTransaction* ryw, K
 }
 
 Key SpecialKeySpace::getManagementApiCommandOptionSpecialKey(const std::string& command, const std::string& option) {
-	Key prefix = LiteralStringRef("options/").withPrefix(moduleToBoundary[MODULE::MANAGEMENT].begin);
+	Key prefix = "options/"_sr.withPrefix(moduleToBoundary[MODULE::MANAGEMENT].begin);
 	auto pair = command + "/" + option;
 	ASSERT(options.find(pair) != options.end());
 	return prefix.withSuffix(pair);
@@ -809,11 +793,11 @@ void ExcludeServersRangeImpl::set(ReadYourWritesTransaction* ryw, const KeyRef& 
 
 Key ExcludeServersRangeImpl::decode(const KeyRef& key) const {
 	return key.removePrefix(SpecialKeySpace::getModuleRange(SpecialKeySpace::MODULE::MANAGEMENT).begin)
-	    .withPrefix(LiteralStringRef("\xff/conf/"));
+	    .withPrefix("\xff/conf/"_sr);
 }
 
 Key ExcludeServersRangeImpl::encode(const KeyRef& key) const {
-	return key.removePrefix(LiteralStringRef("\xff/conf/"))
+	return key.removePrefix("\xff/conf/"_sr)
 	    .withPrefix(SpecialKeySpace::getModuleRange(SpecialKeySpace::MODULE::MANAGEMENT).begin);
 }
 
@@ -1048,11 +1032,11 @@ void FailedServersRangeImpl::set(ReadYourWritesTransaction* ryw, const KeyRef& k
 
 Key FailedServersRangeImpl::decode(const KeyRef& key) const {
 	return key.removePrefix(SpecialKeySpace::getModuleRange(SpecialKeySpace::MODULE::MANAGEMENT).begin)
-	    .withPrefix(LiteralStringRef("\xff/conf/"));
+	    .withPrefix("\xff/conf/"_sr);
 }
 
 Key FailedServersRangeImpl::encode(const KeyRef& key) const {
-	return key.removePrefix(LiteralStringRef("\xff/conf/"))
+	return key.removePrefix("\xff/conf/"_sr)
 	    .withPrefix(SpecialKeySpace::getModuleRange(SpecialKeySpace::MODULE::MANAGEMENT).begin);
 }
 
@@ -1208,8 +1192,7 @@ Future<Optional<std::string>> ProcessClassRangeImpl::commit(ReadYourWritesTransa
 			// validate class type
 			ValueRef processClassType = entry.second.get();
 			ProcessClass processClass(processClassType.toString(), ProcessClass::DBSource);
-			if (processClass.classType() == ProcessClass::InvalidClass &&
-			    processClassType != LiteralStringRef("default")) {
+			if (processClass.classType() == ProcessClass::InvalidClass && processClassType != "default"_sr) {
 				std::string error = "ERROR: \'" + processClassType.toString() + "\' is not a valid process class\n";
 				errorMsg = ManagementAPIError::toJsonString(false, "setclass", error);
 				return errorMsg;
@@ -1302,11 +1285,10 @@ ACTOR Future<Optional<std::string>> lockDatabaseCommitActor(ReadYourWritesTransa
 		msg = ManagementAPIError::toJsonString(false, "lock", "Database has already been locked");
 	} else if (!val.present()) {
 		// lock database
-		ryw->getTransaction().atomicOp(databaseLockedKey,
-		                               BinaryWriter::toValue(uid, Unversioned())
-		                                   .withPrefix(LiteralStringRef("0123456789"))
-		                                   .withSuffix(LiteralStringRef("\x00\x00\x00\x00")),
-		                               MutationRef::SetVersionstampedValue);
+		ryw->getTransaction().atomicOp(
+		    databaseLockedKey,
+		    BinaryWriter::toValue(uid, Unversioned()).withPrefix("0123456789"_sr).withSuffix("\x00\x00\x00\x00"_sr),
+		    MutationRef::SetVersionstampedValue);
 		ryw->getTransaction().addWriteConflictRange(normalKeys);
 	}
 
@@ -1474,7 +1456,7 @@ ACTOR Future<Optional<std::string>> globalConfigCommitActor(GlobalConfigImpl* gl
 
 	// Write version key to trigger update in cluster controller.
 	tr.atomicOp(globalConfigVersionKey,
-	            LiteralStringRef("0123456789\x00\x00\x00\x00"), // versionstamp
+	            "0123456789\x00\x00\x00\x00"_sr, // versionstamp
 	            MutationRef::SetVersionstampedValue);
 
 	return Optional<std::string>();
@@ -1562,7 +1544,7 @@ Future<RangeResult> CoordinatorsImpl::getRange(ReadYourWritesTransaction* ryw, K
 	// the constructor of ClusterConnectionFile already checks whether the file is valid
 	auto cs = ClusterConnectionFile(ryw->getDatabase()->getConnectionFile()->getFilename()).getConnectionString();
 	auto coordinator_processes = cs.coordinators();
-	Key cluster_decription_key = prefix.withSuffix(LiteralStringRef("cluster_description"));
+	Key cluster_decription_key = prefix.withSuffix("cluster_description"_sr);
 	if (kr.contains(cluster_decription_key)) {
 		result.push_back_deep(result.arena(), KeyValueRef(cluster_decription_key, cs.clusterKeyName()));
 	}
@@ -1577,7 +1559,7 @@ Future<RangeResult> CoordinatorsImpl::getRange(ReadYourWritesTransaction* ryw, K
 			processes_str += ",";
 		processes_str += w.toString();
 	}
-	Key processes_key = prefix.withSuffix(LiteralStringRef("processes"));
+	Key processes_key = prefix.withSuffix("processes"_sr);
 	if (kr.contains(processes_key)) {
 		result.push_back_deep(result.arena(), KeyValueRef(processes_key, Value(processes_str)));
 	}
@@ -1593,7 +1575,7 @@ ACTOR static Future<Optional<std::string>> coordinatorsCommitActor(ReadYourWrite
 	state bool parse_error = false;
 
 	// check update for cluster_description
-	Key processes_key = LiteralStringRef("processes").withPrefix(kr.begin);
+	Key processes_key = "processes"_sr.withPrefix(kr.begin);
 	auto processes_entry = ryw->getSpecialKeySpaceWriteMap()[processes_key];
 	if (processes_entry.first) {
 		ASSERT(processes_entry.second.present()); // no clear should be seen here
@@ -1634,7 +1616,7 @@ ACTOR static Future<Optional<std::string>> coordinatorsCommitActor(ReadYourWrite
 		change = noQuorumChange();
 
 	// check update for cluster_description
-	Key cluster_decription_key = LiteralStringRef("cluster_description").withPrefix(kr.begin);
+	Key cluster_decription_key = "cluster_description"_sr.withPrefix(kr.begin);
 	auto entry = ryw->getSpecialKeySpaceWriteMap()[cluster_decription_key];
 	if (entry.first) {
 		// check valid description [a-zA-Z0-9_]+
@@ -1819,7 +1801,7 @@ ACTOR static Future<RangeResult> ClientProfilingGetRangeActor(ReadYourWritesTran
                                                               KeyRangeRef kr) {
 	state RangeResult result;
 	// client_txn_sample_rate
-	state Key sampleRateKey = LiteralStringRef("client_txn_sample_rate").withPrefix(prefix);
+	state Key sampleRateKey = "client_txn_sample_rate"_sr.withPrefix(prefix);
 	if (kr.contains(sampleRateKey)) {
 		auto entry = ryw->getSpecialKeySpaceWriteMap()[sampleRateKey];
 		if (!ryw->readYourWritesDisabled() && entry.first) {
@@ -1838,7 +1820,7 @@ ACTOR static Future<RangeResult> ClientProfilingGetRangeActor(ReadYourWritesTran
 		}
 	}
 	// client_txn_size_limit
-	state Key txnSizeLimitKey = LiteralStringRef("client_txn_size_limit").withPrefix(prefix);
+	state Key txnSizeLimitKey = "client_txn_size_limit"_sr.withPrefix(prefix);
 	if (kr.contains(txnSizeLimitKey)) {
 		auto entry = ryw->getSpecialKeySpaceWriteMap()[txnSizeLimitKey];
 		if (!ryw->readYourWritesDisabled() && entry.first) {
@@ -1866,7 +1848,7 @@ Future<RangeResult> ClientProfilingImpl::getRange(ReadYourWritesTransaction* ryw
 
 Future<Optional<std::string>> ClientProfilingImpl::commit(ReadYourWritesTransaction* ryw) {
 	// client_txn_sample_rate
-	Key sampleRateKey = LiteralStringRef("client_txn_sample_rate").withPrefix(getKeyRange().begin);
+	Key sampleRateKey = "client_txn_sample_rate"_sr.withPrefix(getKeyRange().begin);
 	auto rateEntry = ryw->getSpecialKeySpaceWriteMap()[sampleRateKey];
 
 	if (rateEntry.first && rateEntry.second.present()) {
@@ -1885,7 +1867,7 @@ Future<Optional<std::string>> ClientProfilingImpl::commit(ReadYourWritesTransact
 		ryw->getTransaction().set(fdbClientInfoTxnSampleRate, BinaryWriter::toValue(sampleRate, Unversioned()));
 	}
 	// client_txn_size_limit
-	Key txnSizeLimitKey = LiteralStringRef("client_txn_size_limit").withPrefix(getKeyRange().begin);
+	Key txnSizeLimitKey = "client_txn_size_limit"_sr.withPrefix(getKeyRange().begin);
 	auto sizeLimitEntry = ryw->getSpecialKeySpaceWriteMap()[txnSizeLimitKey];
 	if (sizeLimitEntry.first && sizeLimitEntry.second.present()) {
 		std::string sizeLimitStr = sizeLimitEntry.second.get().toString();
@@ -2023,7 +2005,7 @@ ACTOR static Future<RangeResult> DataDistributionGetRangeActor(ReadYourWritesTra
                                                                KeyRangeRef kr) {
 	state RangeResult result;
 	// dataDistributionModeKey
-	state Key modeKey = LiteralStringRef("mode").withPrefix(prefix);
+	state Key modeKey = "mode"_sr.withPrefix(prefix);
 	if (kr.contains(modeKey)) {
 		auto entry = ryw->getSpecialKeySpaceWriteMap()[modeKey];
 		if (ryw->readYourWritesDisabled() || !entry.first) {
@@ -2036,7 +2018,7 @@ ACTOR static Future<RangeResult> DataDistributionGetRangeActor(ReadYourWritesTra
 		}
 	}
 	// rebalanceDDIgnoreKey
-	state Key rebalanceIgnoredKey = LiteralStringRef("rebalance_ignored").withPrefix(prefix);
+	state Key rebalanceIgnoredKey = "rebalance_ignored"_sr.withPrefix(prefix);
 	if (kr.contains(rebalanceIgnoredKey)) {
 		auto entry = ryw->getSpecialKeySpaceWriteMap()[rebalanceIgnoredKey];
 		if (ryw->readYourWritesDisabled() || !entry.first) {
@@ -2059,8 +2041,8 @@ Future<Optional<std::string>> DataDistributionImpl::commit(ReadYourWritesTransac
 	// <prefix>/rebalance_ignored -> rebalanceDDIgnoreKey, value is unused thus empty
 	Optional<std::string> msg;
 	KeyRangeRef kr = getKeyRange();
-	Key modeKey = LiteralStringRef("mode").withPrefix(kr.begin);
-	Key rebalanceIgnoredKey = LiteralStringRef("rebalance_ignored").withPrefix(kr.begin);
+	Key modeKey = "mode"_sr.withPrefix(kr.begin);
+	Key rebalanceIgnoredKey = "rebalance_ignored"_sr.withPrefix(kr.begin);
 	auto ranges = ryw->getSpecialKeySpaceWriteMap().containedRanges(kr);
 	for (auto iter = ranges.begin(); iter != ranges.end(); ++iter) {
 		if (!iter->value().first)
@@ -2102,7 +2084,7 @@ Future<Optional<std::string>> DataDistributionImpl::commit(ReadYourWritesTransac
 					                                     "Value is unused for the data_distribution/rebalance_ignored "
 					                                     "key, please set it to an empty value");
 				else
-					ryw->getTransaction().set(rebalanceDDIgnoreKey, LiteralStringRef("on"));
+					ryw->getTransaction().set(rebalanceDDIgnoreKey, "on"_sr);
 			} else {
 				msg = ManagementAPIError::toJsonString(
 				    false,
@@ -2236,11 +2218,11 @@ void ExcludedLocalitiesRangeImpl::set(ReadYourWritesTransaction* ryw, const KeyR
 
 Key ExcludedLocalitiesRangeImpl::decode(const KeyRef& key) const {
 	return key.removePrefix(SpecialKeySpace::getModuleRange(SpecialKeySpace::MODULE::MANAGEMENT).begin)
-	    .withPrefix(LiteralStringRef("\xff/conf/"));
+	    .withPrefix("\xff/conf/"_sr);
 }
 
 Key ExcludedLocalitiesRangeImpl::encode(const KeyRef& key) const {
-	return key.removePrefix(LiteralStringRef("\xff/conf/"))
+	return key.removePrefix("\xff/conf/"_sr)
 	    .withPrefix(SpecialKeySpace::getModuleRange(SpecialKeySpace::MODULE::MANAGEMENT).begin);
 }
 
@@ -2262,11 +2244,11 @@ void FailedLocalitiesRangeImpl::set(ReadYourWritesTransaction* ryw, const KeyRef
 
 Key FailedLocalitiesRangeImpl::decode(const KeyRef& key) const {
 	return key.removePrefix(SpecialKeySpace::getModuleRange(SpecialKeySpace::MODULE::MANAGEMENT).begin)
-	    .withPrefix(LiteralStringRef("\xff/conf/"));
+	    .withPrefix("\xff/conf/"_sr);
 }
 
 Key FailedLocalitiesRangeImpl::encode(const KeyRef& key) const {
-	return key.removePrefix(LiteralStringRef("\xff/conf/"))
+	return key.removePrefix("\xff/conf/"_sr)
 	    .withPrefix(SpecialKeySpace::getModuleRange(SpecialKeySpace::MODULE::MANAGEMENT).begin);
 }
 

--- a/fdbclient/SystemData.cpp
+++ b/fdbclient/SystemData.cpp
@@ -27,20 +27,20 @@
 #include "flow/serialize.h"
 #include "flow/UnitTest.h"
 
-const KeyRef systemKeysPrefix = LiteralStringRef("\xff");
+const KeyRef systemKeysPrefix = "\xff"_sr;
 const KeyRangeRef normalKeys(KeyRef(), systemKeysPrefix);
-const KeyRangeRef systemKeys(systemKeysPrefix, LiteralStringRef("\xff\xff"));
-const KeyRangeRef nonMetadataSystemKeys(LiteralStringRef("\xff\x02"), LiteralStringRef("\xff\x03"));
+const KeyRangeRef systemKeys(systemKeysPrefix, "\xff\xff"_sr);
+const KeyRangeRef nonMetadataSystemKeys("\xff\x02"_sr, "\xff\x03"_sr);
 const KeyRangeRef allKeys = KeyRangeRef(normalKeys.begin, systemKeys.end);
-const KeyRef afterAllKeys = LiteralStringRef("\xff\xff\x00");
-const KeyRangeRef specialKeys = KeyRangeRef(LiteralStringRef("\xff\xff"), LiteralStringRef("\xff\xff\xff"));
+const KeyRef afterAllKeys = "\xff\xff\x00"_sr;
+const KeyRangeRef specialKeys = KeyRangeRef("\xff\xff"_sr, "\xff\xff\xff"_sr);
 
 // keyServersKeys.contains(k) iff k.startsWith(keyServersPrefix)
-const KeyRangeRef keyServersKeys(LiteralStringRef("\xff/keyServers/"), LiteralStringRef("\xff/keyServers0"));
+const KeyRangeRef keyServersKeys("\xff/keyServers/"_sr, "\xff/keyServers0"_sr);
 const KeyRef keyServersPrefix = keyServersKeys.begin;
 const KeyRef keyServersEnd = keyServersKeys.end;
-const KeyRangeRef keyServersKeyServersKeys(LiteralStringRef("\xff/keyServers/\xff/keyServers/"),
-                                           LiteralStringRef("\xff/keyServers/\xff/keyServers0"));
+const KeyRangeRef keyServersKeyServersKeys("\xff/keyServers/\xff/keyServers/"_sr,
+                                           "\xff/keyServers/\xff/keyServers0"_sr);
 const KeyRef keyServersKeyServersKey = keyServersKeyServersKeys.begin;
 
 const Key keyServersKey(const KeyRef& k) {
@@ -200,21 +200,18 @@ void decodeKeyServersValue(std::map<Tag, UID> const& tag_uid,
 }
 
 const KeyRangeRef conflictingKeysRange =
-    KeyRangeRef(LiteralStringRef("\xff\xff/transaction/conflicting_keys/"),
-                LiteralStringRef("\xff\xff/transaction/conflicting_keys/\xff\xff"));
-const ValueRef conflictingKeysTrue = LiteralStringRef("1");
-const ValueRef conflictingKeysFalse = LiteralStringRef("0");
+    KeyRangeRef("\xff\xff/transaction/conflicting_keys/"_sr, "\xff\xff/transaction/conflicting_keys/\xff\xff"_sr);
+const ValueRef conflictingKeysTrue = "1"_sr;
+const ValueRef conflictingKeysFalse = "0"_sr;
 
 const KeyRangeRef readConflictRangeKeysRange =
-    KeyRangeRef(LiteralStringRef("\xff\xff/transaction/read_conflict_range/"),
-                LiteralStringRef("\xff\xff/transaction/read_conflict_range/\xff\xff"));
+    KeyRangeRef("\xff\xff/transaction/read_conflict_range/"_sr, "\xff\xff/transaction/read_conflict_range/\xff\xff"_sr);
 
-const KeyRangeRef writeConflictRangeKeysRange =
-    KeyRangeRef(LiteralStringRef("\xff\xff/transaction/write_conflict_range/"),
-                LiteralStringRef("\xff\xff/transaction/write_conflict_range/\xff\xff"));
+const KeyRangeRef writeConflictRangeKeysRange = KeyRangeRef("\xff\xff/transaction/write_conflict_range/"_sr,
+                                                            "\xff\xff/transaction/write_conflict_range/\xff\xff"_sr);
 
 // "\xff/cacheServer/[[UID]] := StorageServerInterface"
-const KeyRangeRef storageCacheServerKeys(LiteralStringRef("\xff/cacheServer/"), LiteralStringRef("\xff/cacheServer0"));
+const KeyRangeRef storageCacheServerKeys("\xff/cacheServer/"_sr, "\xff/cacheServer0"_sr);
 const KeyRef storageCacheServersPrefix = storageCacheServerKeys.begin;
 const KeyRef storageCacheServersEnd = storageCacheServerKeys.end;
 
@@ -231,11 +228,11 @@ const Value storageCacheServerValue(const StorageServerInterface& ssi) {
 	return wr.toValue();
 }
 
-const KeyRangeRef ddStatsRange = KeyRangeRef(LiteralStringRef("\xff\xff/metrics/data_distribution_stats/"),
-                                             LiteralStringRef("\xff\xff/metrics/data_distribution_stats/\xff\xff"));
+const KeyRangeRef ddStatsRange =
+    KeyRangeRef("\xff\xff/metrics/data_distribution_stats/"_sr, "\xff\xff/metrics/data_distribution_stats/\xff\xff"_sr);
 
 //    "\xff/storageCache/[[begin]]" := "[[vector<uint16_t>]]"
-const KeyRangeRef storageCacheKeys(LiteralStringRef("\xff/storageCache/"), LiteralStringRef("\xff/storageCache0"));
+const KeyRangeRef storageCacheKeys("\xff/storageCache/"_sr, "\xff/storageCache0"_sr);
 const KeyRef storageCachePrefix = storageCacheKeys.begin;
 
 const Key storageCacheKey(const KeyRef& k) {
@@ -273,15 +270,15 @@ std::pair<vector<std::pair<UID, NetworkAddress>>, vector<std::pair<UID, NetworkA
 	return std::make_pair(logs, oldLogs);
 }
 
-const KeyRef serverKeysPrefix = LiteralStringRef("\xff/serverKeys/");
-const ValueRef serverKeysTrue = LiteralStringRef("1"), // compatible with what was serverKeysTrue
+const KeyRef serverKeysPrefix = "\xff/serverKeys/"_sr;
+const ValueRef serverKeysTrue = "1"_sr, // compatible with what was serverKeysTrue
     serverKeysFalse;
 
 const Key serverKeysKey(UID serverID, const KeyRef& key) {
 	BinaryWriter wr(Unversioned());
 	wr.serializeBytes(serverKeysPrefix);
 	wr << serverID;
-	wr.serializeBytes(LiteralStringRef("/"));
+	wr.serializeBytes("/"_sr);
 	wr.serializeBytes(key);
 	return wr.toValue();
 }
@@ -289,7 +286,7 @@ const Key serverKeysPrefixFor(UID serverID) {
 	BinaryWriter wr(Unversioned());
 	wr.serializeBytes(serverKeysPrefix);
 	wr << serverID;
-	wr.serializeBytes(LiteralStringRef("/"));
+	wr.serializeBytes("/"_sr);
 	return wr.toValue();
 }
 UID serverKeysDecodeServer(const KeyRef& key) {
@@ -302,13 +299,13 @@ bool serverHasKey(ValueRef storedValue) {
 	return storedValue == serverKeysTrue;
 }
 
-const KeyRef cacheKeysPrefix = LiteralStringRef("\xff\x02/cacheKeys/");
+const KeyRef cacheKeysPrefix = "\xff\x02/cacheKeys/"_sr;
 
 const Key cacheKeysKey(uint16_t idx, const KeyRef& key) {
 	BinaryWriter wr(Unversioned());
 	wr.serializeBytes(cacheKeysPrefix);
 	wr << idx;
-	wr.serializeBytes(LiteralStringRef("/"));
+	wr.serializeBytes("/"_sr);
 	wr.serializeBytes(key);
 	return wr.toValue();
 }
@@ -316,7 +313,7 @@ const Key cacheKeysPrefixFor(uint16_t idx) {
 	BinaryWriter wr(Unversioned());
 	wr.serializeBytes(cacheKeysPrefix);
 	wr << idx;
-	wr.serializeBytes(LiteralStringRef("/"));
+	wr.serializeBytes("/"_sr);
 	return wr.toValue();
 }
 uint16_t cacheKeysDecodeIndex(const KeyRef& key) {
@@ -329,9 +326,8 @@ KeyRef cacheKeysDecodeKey(const KeyRef& key) {
 	return key.substr(cacheKeysPrefix.size() + sizeof(uint16_t) + 1);
 }
 
-const KeyRef cacheChangeKey = LiteralStringRef("\xff\x02/cacheChangeKey");
-const KeyRangeRef cacheChangeKeys(LiteralStringRef("\xff\x02/cacheChangeKeys/"),
-                                  LiteralStringRef("\xff\x02/cacheChangeKeys0"));
+const KeyRef cacheChangeKey = "\xff\x02/cacheChangeKey"_sr;
+const KeyRangeRef cacheChangeKeys("\xff\x02/cacheChangeKeys/"_sr, "\xff\x02/cacheChangeKeys0"_sr);
 const KeyRef cacheChangePrefix = cacheChangeKeys.begin;
 const Key cacheChangeKeyFor(uint16_t idx) {
 	BinaryWriter wr(Unversioned());
@@ -346,9 +342,9 @@ uint16_t cacheChangeKeyDecodeIndex(const KeyRef& key) {
 	return idx;
 }
 
-const KeyRangeRef tssMappingKeys(LiteralStringRef("\xff/tss/"), LiteralStringRef("\xff/tss0"));
+const KeyRangeRef tssMappingKeys("\xff/tss/"_sr, "\xff/tss0"_sr);
 
-const KeyRangeRef tssQuarantineKeys(LiteralStringRef("\xff/tssQ/"), LiteralStringRef("\xff/tssQ0"));
+const KeyRangeRef tssQuarantineKeys("\xff/tssQ/"_sr, "\xff/tssQ0"_sr);
 
 const Key tssQuarantineKeyFor(UID serverID) {
 	BinaryWriter wr(Unversioned());
@@ -364,19 +360,17 @@ UID decodeTssQuarantineKey(KeyRef const& key) {
 	return serverID;
 }
 
-const KeyRangeRef tssMismatchKeys(LiteralStringRef("\xff/tssMismatch/"), LiteralStringRef("\xff/tssMismatch0"));
+const KeyRangeRef tssMismatchKeys("\xff/tssMismatch/"_sr, "\xff/tssMismatch0"_sr);
 
-const KeyRangeRef serverTagKeys(LiteralStringRef("\xff/serverTag/"), LiteralStringRef("\xff/serverTag0"));
+const KeyRangeRef serverTagKeys("\xff/serverTag/"_sr, "\xff/serverTag0"_sr);
 
 const KeyRef serverTagPrefix = serverTagKeys.begin;
-const KeyRangeRef serverTagConflictKeys(LiteralStringRef("\xff/serverTagConflict/"),
-                                        LiteralStringRef("\xff/serverTagConflict0"));
+const KeyRangeRef serverTagConflictKeys("\xff/serverTagConflict/"_sr, "\xff/serverTagConflict0"_sr);
 const KeyRef serverTagConflictPrefix = serverTagConflictKeys.begin;
 // serverTagHistoryKeys is the old tag a storage server uses before it is migrated to a different location.
 // For example, we can copy a SS file to a remote DC and start the SS there;
 //   The new SS will need to consume the last bits of data from the old tag it is responsible for.
-const KeyRangeRef serverTagHistoryKeys(LiteralStringRef("\xff/serverTagHistory/"),
-                                       LiteralStringRef("\xff/serverTagHistory0"));
+const KeyRangeRef serverTagHistoryKeys("\xff/serverTagHistory/"_sr, "\xff/serverTagHistory0"_sr);
 const KeyRef serverTagHistoryPrefix = serverTagHistoryKeys.begin;
 
 const Key serverTagKeyFor(UID serverID) {
@@ -461,8 +455,7 @@ const Key serverTagConflictKeyFor(Tag tag) {
 	return wr.toValue();
 }
 
-const KeyRangeRef tagLocalityListKeys(LiteralStringRef("\xff/tagLocalityList/"),
-                                      LiteralStringRef("\xff/tagLocalityList0"));
+const KeyRangeRef tagLocalityListKeys("\xff/tagLocalityList/"_sr, "\xff/tagLocalityList0"_sr);
 const KeyRef tagLocalityListPrefix = tagLocalityListKeys.begin;
 
 const Key tagLocalityListKeyFor(Optional<Value> dcID) {
@@ -490,8 +483,7 @@ int8_t decodeTagLocalityListValue(ValueRef const& value) {
 	return s;
 }
 
-const KeyRangeRef datacenterReplicasKeys(LiteralStringRef("\xff\x02/datacenterReplicas/"),
-                                         LiteralStringRef("\xff\x02/datacenterReplicas0"));
+const KeyRangeRef datacenterReplicasKeys("\xff\x02/datacenterReplicas/"_sr, "\xff\x02/datacenterReplicas0"_sr);
 const KeyRef datacenterReplicasPrefix = datacenterReplicasKeys.begin;
 
 const Key datacenterReplicasKeyFor(Optional<Value> dcID) {
@@ -524,8 +516,7 @@ extern const KeyRangeRef tLogDatacentersKeys;
 extern const KeyRef tLogDatacentersPrefix;
 const Key tLogDatacentersKeyFor(Optional<Value> dcID);
 
-const KeyRangeRef tLogDatacentersKeys(LiteralStringRef("\xff\x02/tLogDatacenters/"),
-                                      LiteralStringRef("\xff\x02/tLogDatacenters0"));
+const KeyRangeRef tLogDatacentersKeys("\xff\x02/tLogDatacenters/"_sr, "\xff\x02/tLogDatacenters0"_sr);
 const KeyRef tLogDatacentersPrefix = tLogDatacentersKeys.begin;
 
 const Key tLogDatacentersKeyFor(Optional<Value> dcID) {
@@ -541,10 +532,10 @@ Optional<Value> decodeTLogDatacentersKey(KeyRef const& key) {
 	return dcID;
 }
 
-const KeyRef primaryDatacenterKey = LiteralStringRef("\xff/primaryDatacenter");
+const KeyRef primaryDatacenterKey = "\xff/primaryDatacenter"_sr;
 
 // serverListKeys.contains(k) iff k.startsWith( serverListKeys.begin ) because '/'+1 == '0'
-const KeyRangeRef serverListKeys(LiteralStringRef("\xff/serverList/"), LiteralStringRef("\xff/serverList0"));
+const KeyRangeRef serverListKeys("\xff/serverList/"_sr, "\xff/serverList0"_sr);
 const KeyRef serverListPrefix = serverListKeys.begin;
 
 const Key serverListKeyFor(UID serverID) {
@@ -585,11 +576,11 @@ StorageServerInterface decodeServerListValueFB(ValueRef const& value) {
 }
 
 // processClassKeys.contains(k) iff k.startsWith( processClassKeys.begin ) because '/'+1 == '0'
-const KeyRangeRef processClassKeys(LiteralStringRef("\xff/processClass/"), LiteralStringRef("\xff/processClass0"));
+const KeyRangeRef processClassKeys("\xff/processClass/"_sr, "\xff/processClass0"_sr);
 const KeyRef processClassPrefix = processClassKeys.begin;
-const KeyRef processClassChangeKey = LiteralStringRef("\xff/processClassChanges");
-const KeyRef processClassVersionKey = LiteralStringRef("\xff/processClassChangesVersion");
-const ValueRef processClassVersionValue = LiteralStringRef("1");
+const KeyRef processClassChangeKey = "\xff/processClassChanges"_sr;
+const KeyRef processClassVersionKey = "\xff/processClassChangesVersion"_sr;
+const ValueRef processClassVersionValue = "1"_sr;
 
 const Key processClassKeyFor(StringRef processID) {
 	BinaryWriter wr(Unversioned());
@@ -625,17 +616,17 @@ ProcessClass decodeProcessClassValue(ValueRef const& value) {
 	return s;
 }
 
-const KeyRangeRef configKeys(LiteralStringRef("\xff/conf/"), LiteralStringRef("\xff/conf0"));
+const KeyRangeRef configKeys("\xff/conf/"_sr, "\xff/conf0"_sr);
 const KeyRef configKeysPrefix = configKeys.begin;
 
-const KeyRef perpetualStorageWiggleKey(LiteralStringRef("\xff/conf/perpetual_storage_wiggle"));
-const KeyRef wigglingStorageServerKey(LiteralStringRef("\xff/storageWigglePID"));
+const KeyRef perpetualStorageWiggleKey("\xff/conf/perpetual_storage_wiggle"_sr);
+const KeyRef wigglingStorageServerKey("\xff/storageWigglePID"_sr);
 
-const KeyRef triggerDDTeamInfoPrintKey(LiteralStringRef("\xff/triggerDDTeamInfoPrint"));
+const KeyRef triggerDDTeamInfoPrintKey("\xff/triggerDDTeamInfoPrint"_sr);
 
-const KeyRangeRef excludedServersKeys(LiteralStringRef("\xff/conf/excluded/"), LiteralStringRef("\xff/conf/excluded0"));
+const KeyRangeRef excludedServersKeys("\xff/conf/excluded/"_sr, "\xff/conf/excluded0"_sr);
 const KeyRef excludedServersPrefix = excludedServersKeys.begin;
-const KeyRef excludedServersVersionKey = LiteralStringRef("\xff/conf/excluded");
+const KeyRef excludedServersVersionKey = "\xff/conf/excluded"_sr;
 AddressExclusion decodeExcludedServersKey(KeyRef const& key) {
 	ASSERT(key.startsWith(excludedServersPrefix));
 	// Returns an invalid NetworkAddress if given an invalid key (within the prefix)
@@ -650,10 +641,9 @@ std::string encodeExcludedServersKey(AddressExclusion const& addr) {
 	return excludedServersPrefix.toString() + addr.toString();
 }
 
-const KeyRangeRef excludedLocalityKeys(LiteralStringRef("\xff/conf/excluded_locality/"),
-                                       LiteralStringRef("\xff/conf/excluded_locality0"));
+const KeyRangeRef excludedLocalityKeys("\xff/conf/excluded_locality/"_sr, "\xff/conf/excluded_locality0"_sr);
 const KeyRef excludedLocalityPrefix = excludedLocalityKeys.begin;
-const KeyRef excludedLocalityVersionKey = LiteralStringRef("\xff/conf/excluded_locality");
+const KeyRef excludedLocalityVersionKey = "\xff/conf/excluded_locality"_sr;
 std::string decodeExcludedLocalityKey(KeyRef const& key) {
 	ASSERT(key.startsWith(excludedLocalityPrefix));
 	return key.removePrefix(excludedLocalityPrefix).toString();
@@ -662,9 +652,9 @@ std::string encodeExcludedLocalityKey(std::string const& locality) {
 	return excludedLocalityPrefix.toString() + locality;
 }
 
-const KeyRangeRef failedServersKeys(LiteralStringRef("\xff/conf/failed/"), LiteralStringRef("\xff/conf/failed0"));
+const KeyRangeRef failedServersKeys("\xff/conf/failed/"_sr, "\xff/conf/failed0"_sr);
 const KeyRef failedServersPrefix = failedServersKeys.begin;
-const KeyRef failedServersVersionKey = LiteralStringRef("\xff/conf/failed");
+const KeyRef failedServersVersionKey = "\xff/conf/failed"_sr;
 AddressExclusion decodeFailedServersKey(KeyRef const& key) {
 	ASSERT(key.startsWith(failedServersPrefix));
 	// Returns an invalid NetworkAddress if given an invalid key (within the prefix)
@@ -679,10 +669,9 @@ std::string encodeFailedServersKey(AddressExclusion const& addr) {
 	return failedServersPrefix.toString() + addr.toString();
 }
 
-const KeyRangeRef failedLocalityKeys(LiteralStringRef("\xff/conf/failed_locality/"),
-                                     LiteralStringRef("\xff/conf/failed_locality0"));
+const KeyRangeRef failedLocalityKeys("\xff/conf/failed_locality/"_sr, "\xff/conf/failed_locality0"_sr);
 const KeyRef failedLocalityPrefix = failedLocalityKeys.begin;
-const KeyRef failedLocalityVersionKey = LiteralStringRef("\xff/conf/failed_locality");
+const KeyRef failedLocalityVersionKey = "\xff/conf/failed_locality"_sr;
 std::string decodeFailedLocalityKey(KeyRef const& key) {
 	ASSERT(key.startsWith(failedLocalityPrefix));
 	return key.removePrefix(failedLocalityPrefix).toString();
@@ -691,20 +680,18 @@ std::string encodeFailedLocalityKey(std::string const& locality) {
 	return failedLocalityPrefix.toString() + locality;
 }
 
-// const KeyRangeRef globalConfigKeys( LiteralStringRef("\xff/globalConfig/"), LiteralStringRef("\xff/globalConfig0") );
+// const KeyRangeRef globalConfigKeys( "\xff/globalConfig/"_sr, "\xff/globalConfig0"_sr );
 // const KeyRef globalConfigPrefix = globalConfigKeys.begin;
 
-const KeyRangeRef globalConfigDataKeys(LiteralStringRef("\xff/globalConfig/k/"),
-                                       LiteralStringRef("\xff/globalConfig/k0"));
+const KeyRangeRef globalConfigDataKeys("\xff/globalConfig/k/"_sr, "\xff/globalConfig/k0"_sr);
 const KeyRef globalConfigKeysPrefix = globalConfigDataKeys.begin;
 
-const KeyRangeRef globalConfigHistoryKeys(LiteralStringRef("\xff/globalConfig/h/"),
-                                          LiteralStringRef("\xff/globalConfig/h0"));
+const KeyRangeRef globalConfigHistoryKeys("\xff/globalConfig/h/"_sr, "\xff/globalConfig/h0"_sr);
 const KeyRef globalConfigHistoryPrefix = globalConfigHistoryKeys.begin;
 
-const KeyRef globalConfigVersionKey = LiteralStringRef("\xff/globalConfig/v");
+const KeyRef globalConfigVersionKey = "\xff/globalConfig/v"_sr;
 
-const KeyRangeRef workerListKeys(LiteralStringRef("\xff/worker/"), LiteralStringRef("\xff/worker0"));
+const KeyRangeRef workerListKeys("\xff/worker/"_sr, "\xff/worker0"_sr);
 const KeyRef workerListPrefix = workerListKeys.begin;
 
 const Key workerListKeyFor(StringRef processID) {
@@ -734,11 +721,10 @@ ProcessData decodeWorkerListValue(ValueRef const& value) {
 	return s;
 }
 
-const KeyRangeRef backupProgressKeys(LiteralStringRef("\xff\x02/backupProgress/"),
-                                     LiteralStringRef("\xff\x02/backupProgress0"));
+const KeyRangeRef backupProgressKeys("\xff\x02/backupProgress/"_sr, "\xff\x02/backupProgress0"_sr);
 const KeyRef backupProgressPrefix = backupProgressKeys.begin;
-const KeyRef backupStartedKey = LiteralStringRef("\xff\x02/backupStarted");
-extern const KeyRef backupPausedKey = LiteralStringRef("\xff\x02/backupPaused");
+const KeyRef backupStartedKey = "\xff\x02/backupStarted"_sr;
+extern const KeyRef backupPausedKey = "\xff\x02/backupPaused"_sr;
 
 const Key backupProgressKeyFor(UID workerID) {
 	BinaryWriter wr(Unversioned());
@@ -781,97 +767,89 @@ std::vector<std::pair<UID, Version>> decodeBackupStartedValue(const ValueRef& va
 	return ids;
 }
 
-const KeyRef coordinatorsKey = LiteralStringRef("\xff/coordinators");
-const KeyRef logsKey = LiteralStringRef("\xff/logs");
-const KeyRef minRequiredCommitVersionKey = LiteralStringRef("\xff/minRequiredCommitVersion");
+const KeyRef coordinatorsKey = "\xff/coordinators"_sr;
+const KeyRef logsKey = "\xff/logs"_sr;
+const KeyRef minRequiredCommitVersionKey = "\xff/minRequiredCommitVersion"_sr;
 
-const KeyRef globalKeysPrefix = LiteralStringRef("\xff/globals");
-const KeyRef lastEpochEndKey = LiteralStringRef("\xff/globals/lastEpochEnd");
-const KeyRef lastEpochEndPrivateKey = LiteralStringRef("\xff\xff/globals/lastEpochEnd");
-const KeyRef killStorageKey = LiteralStringRef("\xff/globals/killStorage");
-const KeyRef killStoragePrivateKey = LiteralStringRef("\xff\xff/globals/killStorage");
-const KeyRef rebootWhenDurableKey = LiteralStringRef("\xff/globals/rebootWhenDurable");
-const KeyRef rebootWhenDurablePrivateKey = LiteralStringRef("\xff\xff/globals/rebootWhenDurable");
-const KeyRef primaryLocalityKey = LiteralStringRef("\xff/globals/primaryLocality");
-const KeyRef primaryLocalityPrivateKey = LiteralStringRef("\xff\xff/globals/primaryLocality");
-const KeyRef fastLoggingEnabled = LiteralStringRef("\xff/globals/fastLoggingEnabled");
-const KeyRef fastLoggingEnabledPrivateKey = LiteralStringRef("\xff\xff/globals/fastLoggingEnabled");
+const KeyRef globalKeysPrefix = "\xff/globals"_sr;
+const KeyRef lastEpochEndKey = "\xff/globals/lastEpochEnd"_sr;
+const KeyRef lastEpochEndPrivateKey = "\xff\xff/globals/lastEpochEnd"_sr;
+const KeyRef killStorageKey = "\xff/globals/killStorage"_sr;
+const KeyRef killStoragePrivateKey = "\xff\xff/globals/killStorage"_sr;
+const KeyRef rebootWhenDurableKey = "\xff/globals/rebootWhenDurable"_sr;
+const KeyRef rebootWhenDurablePrivateKey = "\xff\xff/globals/rebootWhenDurable"_sr;
+const KeyRef primaryLocalityKey = "\xff/globals/primaryLocality"_sr;
+const KeyRef primaryLocalityPrivateKey = "\xff\xff/globals/primaryLocality"_sr;
+const KeyRef fastLoggingEnabled = "\xff/globals/fastLoggingEnabled"_sr;
+const KeyRef fastLoggingEnabledPrivateKey = "\xff\xff/globals/fastLoggingEnabled"_sr;
 
 // Whenever configuration changes or DD related system keyspace is changed(e.g.., serverList),
 // actor must grab the moveKeysLockOwnerKey and update moveKeysLockWriteKey.
 // This prevents concurrent write to the same system keyspace.
 // When the owner of the DD related system keyspace changes, DD will reboot
-const KeyRef moveKeysLockOwnerKey = LiteralStringRef("\xff/moveKeysLock/Owner");
-const KeyRef moveKeysLockWriteKey = LiteralStringRef("\xff/moveKeysLock/Write");
+const KeyRef moveKeysLockOwnerKey = "\xff/moveKeysLock/Owner"_sr;
+const KeyRef moveKeysLockWriteKey = "\xff/moveKeysLock/Write"_sr;
 
-const KeyRef dataDistributionModeKey = LiteralStringRef("\xff/dataDistributionMode");
+const KeyRef dataDistributionModeKey = "\xff/dataDistributionMode"_sr;
 const UID dataDistributionModeLock = UID(6345, 3425);
 
 // Keys to view and control tag throttling
-const KeyRangeRef tagThrottleKeys =
-    KeyRangeRef(LiteralStringRef("\xff\x02/throttledTags/tag/"), LiteralStringRef("\xff\x02/throttledTags/tag0"));
+const KeyRangeRef tagThrottleKeys = KeyRangeRef("\xff\x02/throttledTags/tag/"_sr, "\xff\x02/throttledTags/tag0"_sr);
 const KeyRef tagThrottleKeysPrefix = tagThrottleKeys.begin;
-const KeyRef tagThrottleAutoKeysPrefix = LiteralStringRef("\xff\x02/throttledTags/tag/\x01");
-const KeyRef tagThrottleSignalKey = LiteralStringRef("\xff\x02/throttledTags/signal");
-const KeyRef tagThrottleAutoEnabledKey = LiteralStringRef("\xff\x02/throttledTags/autoThrottlingEnabled");
-const KeyRef tagThrottleLimitKey = LiteralStringRef("\xff\x02/throttledTags/manualThrottleLimit");
-const KeyRef tagThrottleCountKey = LiteralStringRef("\xff\x02/throttledTags/manualThrottleCount");
+const KeyRef tagThrottleAutoKeysPrefix = "\xff\x02/throttledTags/tag/\x01"_sr;
+const KeyRef tagThrottleSignalKey = "\xff\x02/throttledTags/signal"_sr;
+const KeyRef tagThrottleAutoEnabledKey = "\xff\x02/throttledTags/autoThrottlingEnabled"_sr;
+const KeyRef tagThrottleLimitKey = "\xff\x02/throttledTags/manualThrottleLimit"_sr;
+const KeyRef tagThrottleCountKey = "\xff\x02/throttledTags/manualThrottleCount"_sr;
 
 // Client status info prefix
-const KeyRangeRef fdbClientInfoPrefixRange(LiteralStringRef("\xff\x02/fdbClientInfo/"),
-                                           LiteralStringRef("\xff\x02/fdbClientInfo0"));
+const KeyRangeRef fdbClientInfoPrefixRange("\xff\x02/fdbClientInfo/"_sr, "\xff\x02/fdbClientInfo0"_sr);
 // See remaining fields in GlobalConfig.actor.h
 
 // ConsistencyCheck settings
-const KeyRef fdbShouldConsistencyCheckBeSuspended = LiteralStringRef("\xff\x02/ConsistencyCheck/Suspend");
+const KeyRef fdbShouldConsistencyCheckBeSuspended = "\xff\x02/ConsistencyCheck/Suspend"_sr;
 
 // Request latency measurement key
-const KeyRef latencyBandConfigKey = LiteralStringRef("\xff\x02/latencyBandConfig");
+const KeyRef latencyBandConfigKey = "\xff\x02/latencyBandConfig"_sr;
 
 // Keyspace to maintain wall clock to version map
-const KeyRangeRef timeKeeperPrefixRange(LiteralStringRef("\xff\x02/timeKeeper/map/"),
-                                        LiteralStringRef("\xff\x02/timeKeeper/map0"));
-const KeyRef timeKeeperVersionKey = LiteralStringRef("\xff\x02/timeKeeper/version");
-const KeyRef timeKeeperDisableKey = LiteralStringRef("\xff\x02/timeKeeper/disable");
+const KeyRangeRef timeKeeperPrefixRange("\xff\x02/timeKeeper/map/"_sr, "\xff\x02/timeKeeper/map0"_sr);
+const KeyRef timeKeeperVersionKey = "\xff\x02/timeKeeper/version"_sr;
+const KeyRef timeKeeperDisableKey = "\xff\x02/timeKeeper/disable"_sr;
 
 // Backup Log Mutation constant variables
-const KeyRef backupEnabledKey = LiteralStringRef("\xff/backupEnabled");
-const KeyRangeRef backupLogKeys(LiteralStringRef("\xff\x02/blog/"), LiteralStringRef("\xff\x02/blog0"));
-const KeyRangeRef applyLogKeys(LiteralStringRef("\xff\x02/alog/"), LiteralStringRef("\xff\x02/alog0"));
+const KeyRef backupEnabledKey = "\xff/backupEnabled"_sr;
+const KeyRangeRef backupLogKeys("\xff\x02/blog/"_sr, "\xff\x02/blog0"_sr);
+const KeyRangeRef applyLogKeys("\xff\x02/alog/"_sr, "\xff\x02/alog0"_sr);
 // static_assert( backupLogKeys.begin.size() == backupLogPrefixBytes, "backupLogPrefixBytes incorrect" );
-const KeyRef backupVersionKey = LiteralStringRef("\xff/backupDataFormat");
-const ValueRef backupVersionValue = LiteralStringRef("4");
+const KeyRef backupVersionKey = "\xff/backupDataFormat"_sr;
+const ValueRef backupVersionValue = "4"_sr;
 const int backupVersion = 4;
 
 // Log Range constant variables
 // \xff/logRanges/[16-byte UID][begin key] := serialize( make_pair([end key], [destination key prefix]),
 // IncludeVersion() )
-const KeyRangeRef logRangesRange(LiteralStringRef("\xff/logRanges/"), LiteralStringRef("\xff/logRanges0"));
+const KeyRangeRef logRangesRange("\xff/logRanges/"_sr, "\xff/logRanges0"_sr);
 
 // Layer status metadata prefix
-const KeyRangeRef layerStatusMetaPrefixRange(LiteralStringRef("\xff\x02/status/"),
-                                             LiteralStringRef("\xff\x02/status0"));
+const KeyRangeRef layerStatusMetaPrefixRange("\xff\x02/status/"_sr, "\xff\x02/status0"_sr);
 
 // Backup agent status root
-const KeyRangeRef backupStatusPrefixRange(LiteralStringRef("\xff\x02/backupstatus/"),
-                                          LiteralStringRef("\xff\x02/backupstatus0"));
+const KeyRangeRef backupStatusPrefixRange("\xff\x02/backupstatus/"_sr, "\xff\x02/backupstatus0"_sr);
 
 // Restore configuration constant variables
-const KeyRangeRef fileRestorePrefixRange(LiteralStringRef("\xff\x02/restore-agent/"),
-                                         LiteralStringRef("\xff\x02/restore-agent0"));
+const KeyRangeRef fileRestorePrefixRange("\xff\x02/restore-agent/"_sr, "\xff\x02/restore-agent0"_sr);
 
 // Backup Agent configuration constant variables
-const KeyRangeRef fileBackupPrefixRange(LiteralStringRef("\xff\x02/backup-agent/"),
-                                        LiteralStringRef("\xff\x02/backup-agent0"));
+const KeyRangeRef fileBackupPrefixRange("\xff\x02/backup-agent/"_sr, "\xff\x02/backup-agent0"_sr);
 
 // DR Agent configuration constant variables
-const KeyRangeRef databaseBackupPrefixRange(LiteralStringRef("\xff\x02/db-backup-agent/"),
-                                            LiteralStringRef("\xff\x02/db-backup-agent0"));
+const KeyRangeRef databaseBackupPrefixRange("\xff\x02/db-backup-agent/"_sr, "\xff\x02/db-backup-agent0"_sr);
 
 // \xff\x02/sharedLogRangesConfig/destUidLookup/[keyRange]
-const KeyRef destUidLookupPrefix = LiteralStringRef("\xff\x02/sharedLogRangesConfig/destUidLookup/");
+const KeyRef destUidLookupPrefix = "\xff\x02/sharedLogRangesConfig/destUidLookup/"_sr;
 // \xff\x02/sharedLogRangesConfig/backuplatestVersions/[destUid]/[logUid]
-const KeyRef backupLatestVersionsPrefix = LiteralStringRef("\xff\x02/sharedLogRangesConfig/backupLatestVersions/");
+const KeyRef backupLatestVersionsPrefix = "\xff\x02/sharedLogRangesConfig/backupLatestVersions/"_sr;
 
 // Returns the encoded key comprised of begin key and log uid
 Key logRangesEncodeKey(KeyRef keyBegin, UID logUid) {
@@ -926,31 +904,27 @@ Key uidPrefixKey(KeyRef keyPrefix, UID logUid) {
 // Apply mutations constant variables
 // \xff/applyMutationsEnd/[16-byte UID] := serialize( endVersion, Unversioned() )
 // This indicates what is the highest version the mutation log can be applied
-const KeyRangeRef applyMutationsEndRange(LiteralStringRef("\xff/applyMutationsEnd/"),
-                                         LiteralStringRef("\xff/applyMutationsEnd0"));
+const KeyRangeRef applyMutationsEndRange("\xff/applyMutationsEnd/"_sr, "\xff/applyMutationsEnd0"_sr);
 
 // \xff/applyMutationsBegin/[16-byte UID] := serialize( beginVersion, Unversioned() )
-const KeyRangeRef applyMutationsBeginRange(LiteralStringRef("\xff/applyMutationsBegin/"),
-                                           LiteralStringRef("\xff/applyMutationsBegin0"));
+const KeyRangeRef applyMutationsBeginRange("\xff/applyMutationsBegin/"_sr, "\xff/applyMutationsBegin0"_sr);
 
 // \xff/applyMutationsAddPrefix/[16-byte UID] := addPrefix
-const KeyRangeRef applyMutationsAddPrefixRange(LiteralStringRef("\xff/applyMutationsAddPrefix/"),
-                                               LiteralStringRef("\xff/applyMutationsAddPrefix0"));
+const KeyRangeRef applyMutationsAddPrefixRange("\xff/applyMutationsAddPrefix/"_sr, "\xff/applyMutationsAddPrefix0"_sr);
 
 // \xff/applyMutationsRemovePrefix/[16-byte UID] := removePrefix
-const KeyRangeRef applyMutationsRemovePrefixRange(LiteralStringRef("\xff/applyMutationsRemovePrefix/"),
-                                                  LiteralStringRef("\xff/applyMutationsRemovePrefix0"));
+const KeyRangeRef applyMutationsRemovePrefixRange("\xff/applyMutationsRemovePrefix/"_sr,
+                                                  "\xff/applyMutationsRemovePrefix0"_sr);
 
-const KeyRangeRef applyMutationsKeyVersionMapRange(LiteralStringRef("\xff/applyMutationsKeyVersionMap/"),
-                                                   LiteralStringRef("\xff/applyMutationsKeyVersionMap0"));
-const KeyRangeRef applyMutationsKeyVersionCountRange(LiteralStringRef("\xff\x02/applyMutationsKeyVersionCount/"),
-                                                     LiteralStringRef("\xff\x02/applyMutationsKeyVersionCount0"));
+const KeyRangeRef applyMutationsKeyVersionMapRange("\xff/applyMutationsKeyVersionMap/"_sr,
+                                                   "\xff/applyMutationsKeyVersionMap0"_sr);
+const KeyRangeRef applyMutationsKeyVersionCountRange("\xff\x02/applyMutationsKeyVersionCount/"_sr,
+                                                     "\xff\x02/applyMutationsKeyVersionCount0"_sr);
 
-const KeyRef systemTuplesPrefix = LiteralStringRef("\xff/a/");
-const KeyRef metricConfChangeKey = LiteralStringRef("\x01TDMetricConfChanges\x00");
+const KeyRef systemTuplesPrefix = "\xff/a/"_sr;
+const KeyRef metricConfChangeKey = "\x01TDMetricConfChanges\x00"_sr;
 
-const KeyRangeRef metricConfKeys(LiteralStringRef("\x01TDMetricConf\x00\x01"),
-                                 LiteralStringRef("\x01TDMetricConf\x00\x02"));
+const KeyRangeRef metricConfKeys("\x01TDMetricConf\x00\x01"_sr, "\x01TDMetricConf\x00\x02"_sr);
 const KeyRef metricConfPrefix = metricConfKeys.begin;
 
 /*
@@ -959,15 +933,15 @@ const Key metricConfKey( KeyRef const& prefix, MetricNameRef const& name, KeyRef
     wr.serializeBytes( prefix );
     wr.serializeBytes( metricConfPrefix );
     wr.serializeBytes( name.type );
-    wr.serializeBytes( LiteralStringRef("\x00\x01") );
+    wr.serializeBytes( "\x00\x01"_sr );
     wr.serializeBytes( name.name );
-    wr.serializeBytes( LiteralStringRef("\x00\x01") );
+    wr.serializeBytes( "\x00\x01"_sr );
     wr.serializeBytes( name.address );
-    wr.serializeBytes( LiteralStringRef("\x00\x01") );
+    wr.serializeBytes( "\x00\x01"_sr );
     wr.serializeBytes( name.id );
-    wr.serializeBytes( LiteralStringRef("\x00\x01") );
+    wr.serializeBytes( "\x00\x01"_sr );
     wr.serializeBytes( key );
-    wr.serializeBytes( LiteralStringRef("\x00") );
+    wr.serializeBytes( "\x00"_sr );
     return wr.toValue();
 }
 
@@ -990,23 +964,22 @@ std::pair<MetricNameRef, KeyRef> decodeMetricConfKey( KeyRef const& prefix, KeyR
 }
 */
 
-const KeyRef maxUIDKey = LiteralStringRef("\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff");
+const KeyRef maxUIDKey = "\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff"_sr;
 
-const KeyRef databaseLockedKey = LiteralStringRef("\xff/dbLocked");
-const KeyRef databaseLockedKeyEnd = LiteralStringRef("\xff/dbLocked\x00");
-const KeyRef metadataVersionKey = LiteralStringRef("\xff/metadataVersion");
-const KeyRef metadataVersionKeyEnd = LiteralStringRef("\xff/metadataVersion\x00");
-const KeyRef metadataVersionRequiredValue =
-    LiteralStringRef("\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00");
-const KeyRef mustContainSystemMutationsKey = LiteralStringRef("\xff/mustContainSystemMutations");
+const KeyRef databaseLockedKey = "\xff/dbLocked"_sr;
+const KeyRef databaseLockedKeyEnd = "\xff/dbLocked\x00"_sr;
+const KeyRef metadataVersionKey = "\xff/metadataVersion"_sr;
+const KeyRef metadataVersionKeyEnd = "\xff/metadataVersion\x00"_sr;
+const KeyRef metadataVersionRequiredValue = "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"_sr;
+const KeyRef mustContainSystemMutationsKey = "\xff/mustContainSystemMutations"_sr;
 
-const KeyRangeRef monitorConfKeys(LiteralStringRef("\xff\x02/monitorConf/"), LiteralStringRef("\xff\x02/monitorConf0"));
+const KeyRangeRef monitorConfKeys("\xff\x02/monitorConf/"_sr, "\xff\x02/monitorConf0"_sr);
 
-const KeyRef restoreRequestDoneKey = LiteralStringRef("\xff\x02/restoreRequestDone");
+const KeyRef restoreRequestDoneKey = "\xff\x02/restoreRequestDone"_sr;
 
-const KeyRef healthyZoneKey = LiteralStringRef("\xff\x02/healthyZone");
-const StringRef ignoreSSFailuresZoneString = LiteralStringRef("IgnoreSSFailures");
-const KeyRef rebalanceDDIgnoreKey = LiteralStringRef("\xff\x02/rebalanceDDIgnored");
+const KeyRef healthyZoneKey = "\xff\x02/healthyZone"_sr;
+const StringRef ignoreSSFailuresZoneString = "IgnoreSSFailures"_sr;
+const KeyRef rebalanceDDIgnoreKey = "\xff\x02/rebalanceDDIgnored"_sr;
 
 const Value healthyZoneValue(StringRef const& zoneId, Version version) {
 	BinaryWriter wr(IncludeVersion(ProtocolVersion::withHealthyZoneValue()));
@@ -1023,12 +996,11 @@ std::pair<Key, Version> decodeHealthyZoneValue(ValueRef const& value) {
 	return std::make_pair(zoneId, version);
 }
 
-const KeyRangeRef testOnlyTxnStateStorePrefixRange(LiteralStringRef("\xff/TESTONLYtxnStateStore/"),
-                                                   LiteralStringRef("\xff/TESTONLYtxnStateStore0"));
+const KeyRangeRef testOnlyTxnStateStorePrefixRange("\xff/TESTONLYtxnStateStore/"_sr, "\xff/TESTONLYtxnStateStore0"_sr);
 
-const KeyRef writeRecoveryKey = LiteralStringRef("\xff/writeRecovery");
-const ValueRef writeRecoveryKeyTrue = LiteralStringRef("1");
-const KeyRef snapshotEndVersionKey = LiteralStringRef("\xff/snapshotEndVersion");
+const KeyRef writeRecoveryKey = "\xff/writeRecovery"_sr;
+const ValueRef writeRecoveryKeyTrue = "1"_sr;
+const KeyRef snapshotEndVersionKey = "\xff/snapshotEndVersion"_sr;
 
 const KeyRef configTransactionDescriptionKey = "\xff\xff/description"_sr;
 const KeyRange globalConfigKnobKeys = singleKeyRange("\xff\xff/globalKnobs"_sr);

--- a/fdbclient/TaskBucket.actor.cpp
+++ b/fdbclient/TaskBucket.actor.cpp
@@ -66,7 +66,7 @@ struct UnblockFutureTaskFunc : TaskFuncBase {
 		return Void();
 	}
 };
-StringRef UnblockFutureTaskFunc::name = LiteralStringRef("UnblockFuture");
+StringRef UnblockFutureTaskFunc::name = "UnblockFuture"_sr;
 REGISTER_TASKFUNC(UnblockFutureTaskFunc);
 
 struct AddTaskFunc : TaskFuncBase {
@@ -88,7 +88,7 @@ struct AddTaskFunc : TaskFuncBase {
 		return Void();
 	};
 };
-StringRef AddTaskFunc::name = LiteralStringRef("AddTask");
+StringRef AddTaskFunc::name = "AddTask"_sr;
 REGISTER_TASKFUNC(AddTaskFunc);
 
 struct IdleTaskFunc : TaskFuncBase {
@@ -109,18 +109,18 @@ struct IdleTaskFunc : TaskFuncBase {
 		return tb->finish(tr, task);
 	};
 };
-StringRef IdleTaskFunc::name = LiteralStringRef("idle");
+StringRef IdleTaskFunc::name = "idle"_sr;
 REGISTER_TASKFUNC(IdleTaskFunc);
 
-Key Task::reservedTaskParamKeyType = LiteralStringRef("type");
-Key Task::reservedTaskParamKeyAddTask = LiteralStringRef("_add_task");
-Key Task::reservedTaskParamKeyDone = LiteralStringRef("done");
-Key Task::reservedTaskParamKeyPriority = LiteralStringRef("priority");
-Key Task::reservedTaskParamKeyFuture = LiteralStringRef("future");
-Key Task::reservedTaskParamKeyBlockID = LiteralStringRef("blockid");
-Key Task::reservedTaskParamKeyVersion = LiteralStringRef("version");
-Key Task::reservedTaskParamValidKey = LiteralStringRef("_validkey");
-Key Task::reservedTaskParamValidValue = LiteralStringRef("_validvalue");
+Key Task::reservedTaskParamKeyType = "type"_sr;
+Key Task::reservedTaskParamKeyAddTask = "_add_task"_sr;
+Key Task::reservedTaskParamKeyDone = "done"_sr;
+Key Task::reservedTaskParamKeyPriority = "priority"_sr;
+Key Task::reservedTaskParamKeyFuture = "future"_sr;
+Key Task::reservedTaskParamKeyBlockID = "blockid"_sr;
+Key Task::reservedTaskParamKeyVersion = "version"_sr;
+Key Task::reservedTaskParamValidKey = "_validkey"_sr;
+Key Task::reservedTaskParamValidValue = "_validvalue"_sr;
 
 // IMPORTANT:  Task() must result in an EMPTY parameter set, so params should only
 // be set for non-default constructor arguments.  To change this behavior look at all
@@ -725,7 +725,7 @@ public:
 	                                          Reference<TaskBucket> taskBucket) {
 		taskBucket->setOptions(tr);
 
-		Optional<Value> val = wait(tr->get(taskBucket->prefix.pack(LiteralStringRef("task_count"))));
+		Optional<Value> val = wait(tr->get(taskBucket->prefix.pack("task_count"_sr)));
 
 		if (!val.present())
 			return 0;
@@ -873,13 +873,13 @@ TaskBucket::TaskBucket(const Subspace& subspace,
                        AccessSystemKeys sysAccess,
                        PriorityBatch priorityBatch,
                        LockAware lockAware)
-  : prefix(subspace), active(prefix.get(LiteralStringRef("ac"))), available(prefix.get(LiteralStringRef("av"))),
-    available_prioritized(prefix.get(LiteralStringRef("avp"))), timeouts(prefix.get(LiteralStringRef("to"))),
-    pauseKey(prefix.pack(LiteralStringRef("pause"))), timeout(CLIENT_KNOBS->TASKBUCKET_TIMEOUT_VERSIONS),
-    system_access(sysAccess), priority_batch(priorityBatch), lockAware(lockAware), cc("TaskBucket"),
-    dbgid(deterministicRandom()->randomUniqueID()), dispatchSlotChecksStarted("DispatchSlotChecksStarted", cc),
-    dispatchErrors("DispatchErrors", cc), dispatchDoTasks("DispatchDoTasks", cc),
-    dispatchEmptyTasks("DispatchEmptyTasks", cc), dispatchSlotChecksComplete("DispatchSlotChecksComplete", cc) {}
+  : prefix(subspace), active(prefix.get("ac"_sr)), available(prefix.get("av"_sr)),
+    available_prioritized(prefix.get("avp"_sr)), timeouts(prefix.get("to"_sr)), pauseKey(prefix.pack("pause"_sr)),
+    timeout(CLIENT_KNOBS->TASKBUCKET_TIMEOUT_VERSIONS), system_access(sysAccess), priority_batch(priorityBatch),
+    lockAware(lockAware), cc("TaskBucket"), dbgid(deterministicRandom()->randomUniqueID()),
+    dispatchSlotChecksStarted("DispatchSlotChecksStarted", cc), dispatchErrors("DispatchErrors", cc),
+    dispatchDoTasks("DispatchDoTasks", cc), dispatchEmptyTasks("DispatchEmptyTasks", cc),
+    dispatchSlotChecksComplete("DispatchSlotChecksComplete", cc) {}
 
 TaskBucket::~TaskBucket() {}
 
@@ -922,9 +922,7 @@ Key TaskBucket::addTask(Reference<ReadYourWritesTransaction> tr, Reference<Task>
 	for (auto& param : task->params)
 		tr->set(taskSpace.pack(param.key), param.value);
 
-	tr->atomicOp(prefix.pack(LiteralStringRef("task_count")),
-	             LiteralStringRef("\x01\x00\x00\x00\x00\x00\x00\x00"),
-	             MutationRef::AddValue);
+	tr->atomicOp(prefix.pack("task_count"_sr), "\x01\x00\x00\x00\x00\x00\x00\x00"_sr, MutationRef::AddValue);
 
 	return key;
 }
@@ -1000,9 +998,7 @@ Future<Void> TaskBucket::finish(Reference<ReadYourWritesTransaction> tr, Referen
 	t.append(task->timeoutVersion);
 	t.append(task->key);
 
-	tr->atomicOp(prefix.pack(LiteralStringRef("task_count")),
-	             LiteralStringRef("\xff\xff\xff\xff\xff\xff\xff\xff"),
-	             MutationRef::AddValue);
+	tr->atomicOp(prefix.pack("task_count"_sr), "\xff\xff\xff\xff\xff\xff\xff\xff"_sr, MutationRef::AddValue);
 	tr->clear(timeouts.range(t));
 
 	return Void();
@@ -1033,7 +1029,7 @@ Future<int64_t> TaskBucket::getTaskCount(Reference<ReadYourWritesTransaction> tr
 }
 
 Future<Void> TaskBucket::watchTaskCount(Reference<ReadYourWritesTransaction> tr) {
-	return tr->watch(prefix.pack(LiteralStringRef("task_count")));
+	return tr->watch(prefix.pack("task_count"_sr));
 }
 
 Future<Void> TaskBucket::debugPrintRange(Reference<ReadYourWritesTransaction> tr, Subspace subspace, Key msg) {
@@ -1108,7 +1104,7 @@ public:
 			Key key = StringRef(deterministicRandom()->randomUniqueID().toString());
 			taskFuture->addBlock(tr, key);
 			auto task = makeReference<Task>();
-			task->params[Task::reservedTaskParamKeyType] = LiteralStringRef("UnblockFuture");
+			task->params[Task::reservedTaskParamKeyType] = "UnblockFuture"_sr;
 			task->params[Task::reservedTaskParamKeyFuture] = taskFuture->key;
 			task->params[Task::reservedTaskParamKeyBlockID] = key;
 			onSetFutures.push_back(vectorFuture[i]->onSet(tr, taskBucket, task));
@@ -1222,7 +1218,7 @@ public:
 		taskFuture->futureBucket->setOptions(tr);
 
 		task->params[Task::reservedTaskParamKeyAddTask] = task->params[Task::reservedTaskParamKeyType];
-		task->params[Task::reservedTaskParamKeyType] = LiteralStringRef("AddTask");
+		task->params[Task::reservedTaskParamKeyType] = "AddTask"_sr;
 		wait(onSet(tr, taskBucket, taskFuture, task));
 
 		return Void();
@@ -1287,14 +1283,14 @@ TaskFuture::TaskFuture(const Reference<FutureBucket> bucket, Key k) : futureBuck
 	}
 
 	prefix = futureBucket->prefix.get(key);
-	blocks = prefix.get(LiteralStringRef("bl"));
-	callbacks = prefix.get(LiteralStringRef("cb"));
+	blocks = prefix.get("bl"_sr);
+	callbacks = prefix.get("cb"_sr);
 }
 
 TaskFuture::~TaskFuture() {}
 
 void TaskFuture::addBlock(Reference<ReadYourWritesTransaction> tr, StringRef block_id) {
-	tr->set(blocks.pack(block_id), LiteralStringRef(""));
+	tr->set(blocks.pack(block_id), ""_sr);
 }
 
 Future<Void> TaskFuture::set(Reference<ReadYourWritesTransaction> tr, Reference<TaskBucket> taskBucket) {

--- a/fdbrpc/AsyncFileCached.actor.h
+++ b/fdbrpc/AsyncFileCached.actor.h
@@ -73,7 +73,7 @@ struct EvictablePageCache : ReferenceCounted<EvictablePageCache> {
 	explicit EvictablePageCache(int pageSize, int64_t maxSize)
 	  : pageSize(pageSize), maxPages(maxSize / pageSize),
 	    cacheEvictionType(evictionPolicyStringToEnum(FLOW_KNOBS->CACHE_EVICTION_POLICY)) {
-		cacheEvictions.init(LiteralStringRef("EvictablePageCache.CacheEvictions"));
+		cacheEvictions.init("EvictablePageCache.CacheEvictions"_sr);
 	}
 
 	void allocate(EvictablePage* page) {
@@ -301,25 +301,25 @@ private:
 	  : uncached(uncached), filename(filename), length(length), prevLength(length), pageCache(pageCache),
 	    currentTruncate(Void()), currentTruncateSize(0), rateControl(nullptr) {
 		if (!g_network->isSimulated()) {
-			countFileCacheWrites.init(LiteralStringRef("AsyncFile.CountFileCacheWrites"), filename);
-			countFileCacheReads.init(LiteralStringRef("AsyncFile.CountFileCacheReads"), filename);
-			countFileCacheWritesBlocked.init(LiteralStringRef("AsyncFile.CountFileCacheWritesBlocked"), filename);
-			countFileCacheReadsBlocked.init(LiteralStringRef("AsyncFile.CountFileCacheReadsBlocked"), filename);
-			countFileCachePageReadsHit.init(LiteralStringRef("AsyncFile.CountFileCachePageReadsHit"), filename);
-			countFileCachePageReadsMissed.init(LiteralStringRef("AsyncFile.CountFileCachePageReadsMissed"), filename);
-			countFileCachePageReadsMerged.init(LiteralStringRef("AsyncFile.CountFileCachePageReadsMerged"), filename);
-			countFileCacheFinds.init(LiteralStringRef("AsyncFile.CountFileCacheFinds"), filename);
-			countFileCacheReadBytes.init(LiteralStringRef("AsyncFile.CountFileCacheReadBytes"), filename);
+			countFileCacheWrites.init("AsyncFile.CountFileCacheWrites"_sr, filename);
+			countFileCacheReads.init("AsyncFile.CountFileCacheReads"_sr, filename);
+			countFileCacheWritesBlocked.init("AsyncFile.CountFileCacheWritesBlocked"_sr, filename);
+			countFileCacheReadsBlocked.init("AsyncFile.CountFileCacheReadsBlocked"_sr, filename);
+			countFileCachePageReadsHit.init("AsyncFile.CountFileCachePageReadsHit"_sr, filename);
+			countFileCachePageReadsMissed.init("AsyncFile.CountFileCachePageReadsMissed"_sr, filename);
+			countFileCachePageReadsMerged.init("AsyncFile.CountFileCachePageReadsMerged"_sr, filename);
+			countFileCacheFinds.init("AsyncFile.CountFileCacheFinds"_sr, filename);
+			countFileCacheReadBytes.init("AsyncFile.CountFileCacheReadBytes"_sr, filename);
 
-			countCacheWrites.init(LiteralStringRef("AsyncFile.CountCacheWrites"));
-			countCacheReads.init(LiteralStringRef("AsyncFile.CountCacheReads"));
-			countCacheWritesBlocked.init(LiteralStringRef("AsyncFile.CountCacheWritesBlocked"));
-			countCacheReadsBlocked.init(LiteralStringRef("AsyncFile.CountCacheReadsBlocked"));
-			countCachePageReadsHit.init(LiteralStringRef("AsyncFile.CountCachePageReadsHit"));
-			countCachePageReadsMissed.init(LiteralStringRef("AsyncFile.CountCachePageReadsMissed"));
-			countCachePageReadsMerged.init(LiteralStringRef("AsyncFile.CountCachePageReadsMerged"));
-			countCacheFinds.init(LiteralStringRef("AsyncFile.CountCacheFinds"));
-			countCacheReadBytes.init(LiteralStringRef("AsyncFile.CountCacheReadBytes"));
+			countCacheWrites.init("AsyncFile.CountCacheWrites"_sr);
+			countCacheReads.init("AsyncFile.CountCacheReads"_sr);
+			countCacheWritesBlocked.init("AsyncFile.CountCacheWritesBlocked"_sr);
+			countCacheReadsBlocked.init("AsyncFile.CountCacheReadsBlocked"_sr);
+			countCachePageReadsHit.init("AsyncFile.CountCachePageReadsHit"_sr);
+			countCachePageReadsMissed.init("AsyncFile.CountCachePageReadsMissed"_sr);
+			countCachePageReadsMerged.init("AsyncFile.CountCachePageReadsMerged"_sr);
+			countCacheFinds.init("AsyncFile.CountCacheFinds"_sr);
+			countCacheReadBytes.init("AsyncFile.CountCacheReadBytes"_sr);
 		}
 	}
 

--- a/fdbrpc/AsyncFileEIO.actor.h
+++ b/fdbrpc/AsyncFileEIO.actor.h
@@ -279,11 +279,11 @@ private:
 	AsyncFileEIO(int fd, int flags, std::string const& filename)
 	  : fd(fd), flags(flags), filename(filename), err(new ErrorInfo) {
 		if (!g_network->isSimulated()) {
-			countFileLogicalWrites.init(LiteralStringRef("AsyncFile.CountFileLogicalWrites"), filename);
-			countFileLogicalReads.init(LiteralStringRef("AsyncFile.CountFileLogicalReads"), filename);
+			countFileLogicalWrites.init("AsyncFile.CountFileLogicalWrites"_sr, filename);
+			countFileLogicalReads.init("AsyncFile.CountFileLogicalReads"_sr, filename);
 
-			countLogicalWrites.init(LiteralStringRef("AsyncFile.CountLogicalWrites"));
-			countLogicalReads.init(LiteralStringRef("AsyncFile.CountLogicalReads"));
+			countLogicalWrites.init("AsyncFile.CountLogicalWrites"_sr);
+			countLogicalReads.init("AsyncFile.CountLogicalReads"_sr);
 		}
 	}
 

--- a/fdbrpc/AsyncFileKAIO.actor.h
+++ b/fdbrpc/AsyncFileKAIO.actor.h
@@ -170,12 +170,12 @@ public:
 	static void init(Reference<IEventFD> ev, double ioTimeout) {
 		ASSERT(!FLOW_KNOBS->DISABLE_POSIX_KERNEL_AIO);
 		if (!g_network->isSimulated()) {
-			ctx.countAIOSubmit.init(LiteralStringRef("AsyncFile.CountAIOSubmit"));
-			ctx.countAIOCollect.init(LiteralStringRef("AsyncFile.CountAIOCollect"));
-			ctx.submitMetric.init(LiteralStringRef("AsyncFile.Submit"));
-			ctx.countPreSubmitTruncate.init(LiteralStringRef("AsyncFile.CountPreAIOSubmitTruncate"));
-			ctx.preSubmitTruncateBytes.init(LiteralStringRef("AsyncFile.PreAIOSubmitTruncateBytes"));
-			ctx.slowAioSubmitMetric.init(LiteralStringRef("AsyncFile.SlowAIOSubmit"));
+			ctx.countAIOSubmit.init("AsyncFile.CountAIOSubmit"_sr);
+			ctx.countAIOCollect.init("AsyncFile.CountAIOCollect"_sr);
+			ctx.submitMetric.init("AsyncFile.Submit"_sr);
+			ctx.countPreSubmitTruncate.init("AsyncFile.CountPreAIOSubmitTruncate"_sr);
+			ctx.preSubmitTruncateBytes.init("AsyncFile.PreAIOSubmitTruncateBytes"_sr);
+			ctx.slowAioSubmitMetric.init("AsyncFile.SlowAIOSubmit"_sr);
 		}
 
 		int rc = io_setup(FLOW_KNOBS->MAX_OUTSTANDING, &ctx.iocx);
@@ -622,17 +622,17 @@ private:
 	  : fd(fd), flags(flags), filename(filename), failed(false) {
 		ASSERT(!FLOW_KNOBS->DISABLE_POSIX_KERNEL_AIO);
 		if (!g_network->isSimulated()) {
-			countFileLogicalWrites.init(LiteralStringRef("AsyncFile.CountFileLogicalWrites"), filename);
-			countFileLogicalReads.init(LiteralStringRef("AsyncFile.CountFileLogicalReads"), filename);
-			countLogicalWrites.init(LiteralStringRef("AsyncFile.CountLogicalWrites"));
-			countLogicalReads.init(LiteralStringRef("AsyncFile.CountLogicalReads"));
+			countFileLogicalWrites.init("AsyncFile.CountFileLogicalWrites"_sr, filename);
+			countFileLogicalReads.init("AsyncFile.CountFileLogicalReads"_sr, filename);
+			countLogicalWrites.init("AsyncFile.CountLogicalWrites"_sr);
+			countLogicalReads.init("AsyncFile.CountLogicalReads"_sr);
 		}
 
 #if KAIO_LOGGING
 		logFile = nullptr;
 		// TODO:  Don't do this hacky investigation-specific thing
 		StringRef fname(filename);
-		if (fname.endsWith(LiteralStringRef(".sqlite")) || fname.endsWith(LiteralStringRef(".sqlite-wal"))) {
+		if (fname.endsWith(".sqlite"_sr) || fname.endsWith(".sqlite-wal"_sr)) {
 			std::string logFileName = basename(filename);
 			while (logFileName.find("/") != std::string::npos)
 				logFileName = logFileName.substr(logFileName.find("/") + 1);

--- a/fdbrpc/FlowTests.actor.cpp
+++ b/fdbrpc/FlowTests.actor.cpp
@@ -48,7 +48,7 @@ TEST_CASE("/flow/actorcompiler/lineNumbers") {
 		}
 		break;
 	}
-	ASSERT(LiteralStringRef(__FILE__).endsWith(LiteralStringRef("FlowTests.actor.cpp")));
+	ASSERT(LiteralStringRef(__FILE__).endsWith("FlowTests.actor.cpp"_sr));
 	return Void();
 }
 

--- a/fdbrpc/FlowTransport.actor.cpp
+++ b/fdbrpc/FlowTransport.actor.cpp
@@ -237,12 +237,12 @@ public:
 	~TransportData();
 
 	void initMetrics() {
-		bytesSent.init(LiteralStringRef("Net2.BytesSent"));
-		countPacketsReceived.init(LiteralStringRef("Net2.CountPacketsReceived"));
-		countPacketsGenerated.init(LiteralStringRef("Net2.CountPacketsGenerated"));
-		countConnEstablished.init(LiteralStringRef("Net2.CountConnEstablished"));
-		countConnClosedWithError.init(LiteralStringRef("Net2.CountConnClosedWithError"));
-		countConnClosedWithoutError.init(LiteralStringRef("Net2.CountConnClosedWithoutError"));
+		bytesSent.init("Net2.BytesSent"_sr);
+		countPacketsReceived.init("Net2.CountPacketsReceived"_sr);
+		countPacketsGenerated.init("Net2.CountPacketsGenerated"_sr);
+		countConnEstablished.init("Net2.CountConnEstablished"_sr);
+		countConnClosedWithError.init("Net2.CountConnClosedWithError"_sr);
+		countConnClosedWithoutError.init("Net2.CountConnClosedWithoutError"_sr);
 	}
 
 	Reference<struct Peer> getPeer(NetworkAddress const& address);

--- a/fdbrpc/Locality.cpp
+++ b/fdbrpc/Locality.cpp
@@ -21,13 +21,13 @@
 #include "fdbrpc/Locality.h"
 
 const UID LocalityData::UNSET_ID = UID(0x0ccb4e0feddb5583, 0x010f6b77d9d10ece);
-const StringRef LocalityData::keyProcessId = LiteralStringRef("processid");
-const StringRef LocalityData::keyZoneId = LiteralStringRef("zoneid");
-const StringRef LocalityData::keyDcId = LiteralStringRef("dcid");
-const StringRef LocalityData::keyMachineId = LiteralStringRef("machineid");
-const StringRef LocalityData::keyDataHallId = LiteralStringRef("data_hall");
-const StringRef LocalityData::ExcludeLocalityKeyMachineIdPrefix = LiteralStringRef("locality_machineid:");
-const StringRef LocalityData::ExcludeLocalityPrefix = LiteralStringRef("locality_");
+const StringRef LocalityData::keyProcessId = "processid"_sr;
+const StringRef LocalityData::keyZoneId = "zoneid"_sr;
+const StringRef LocalityData::keyDcId = "dcid"_sr;
+const StringRef LocalityData::keyMachineId = "machineid"_sr;
+const StringRef LocalityData::keyDataHallId = "data_hall"_sr;
+const StringRef LocalityData::ExcludeLocalityKeyMachineIdPrefix = "locality_machineid:"_sr;
+const StringRef LocalityData::ExcludeLocalityPrefix = "locality_"_sr;
 
 ProcessClass::Fitness ProcessClass::machineClassFitness(ClusterRole role) const {
 	switch (role) {

--- a/fdbrpc/ReplicationPolicy.h
+++ b/fdbrpc/ReplicationPolicy.h
@@ -254,19 +254,19 @@ void serializeReplicationPolicy(Ar& ar, Reference<IReplicationPolicy>& policy) {
 		StringRef name;
 		serializer(ar, name);
 
-		if (name == LiteralStringRef("One")) {
+		if (name == "One"_sr) {
 			PolicyOne* pointer = new PolicyOne();
 			pointer->serialize(ar);
 			policy = Reference<IReplicationPolicy>(pointer);
-		} else if (name == LiteralStringRef("Across")) {
+		} else if (name == "Across"_sr) {
 			PolicyAcross* pointer = new PolicyAcross(0, "", Reference<IReplicationPolicy>());
 			pointer->serialize(ar);
 			policy = Reference<IReplicationPolicy>(pointer);
-		} else if (name == LiteralStringRef("And")) {
+		} else if (name == "And"_sr) {
 			PolicyAnd* pointer = new PolicyAnd{};
 			pointer->serialize(ar);
 			policy = Reference<IReplicationPolicy>(pointer);
-		} else if (name == LiteralStringRef("None")) {
+		} else if (name == "None"_sr) {
 			policy = Reference<IReplicationPolicy>();
 		} else {
 			TraceEvent(SevError, "SerializingInvalidPolicyType").detail("PolicyName", name);

--- a/fdbrpc/ReplicationUtils.cpp
+++ b/fdbrpc/ReplicationUtils.cpp
@@ -493,10 +493,10 @@ Reference<LocalitySet> createTestLocalityMap(std::vector<repTestType>& indexes,
 					serverValue = dcLoop + szLoop * 10 + rackLoop * 100 + slotLoop * 1000;
 					slotText = format(".%d", slotLoop);
 					LocalityData data;
-					data.set(LiteralStringRef("dc"), StringRef(dcText));
-					data.set(LiteralStringRef("sz"), StringRef(dcText + szText));
-					data.set(LiteralStringRef("rack"), StringRef(dcText + szText + rackText));
-					data.set(LiteralStringRef("zoneid"), StringRef(dcText + szText + rackText + slotText));
+					data.set("dc"_sr, StringRef(dcText));
+					data.set("sz"_sr, StringRef(dcText + szText));
+					data.set("rack"_sr, StringRef(dcText + szText + rackText));
+					data.set("zoneid"_sr, StringRef(dcText + szText + rackText + slotText));
 					for (int independentLoop = 0; independentLoop < independentItems; independentLoop++) {
 						independentName = format("indiv%02d", independentLoop + 1);
 						for (int totalLoop = 0; totalLoop < independentTotal; totalLoop++) {
@@ -520,10 +520,10 @@ Reference<LocalitySet> createTestLocalityMap(std::vector<repTestType>& indexes,
 					serverValue = (dcLoop + 2) + szLoop * 10 + rackLoop * 100 + slotLoop * 1000;
 					slotText = format(".%d", slotLoop);
 					LocalityData data;
-					data.set(LiteralStringRef("dc"), StringRef(dcText));
-					data.set(LiteralStringRef("az"), StringRef(dcText + szText));
-					data.set(LiteralStringRef("rack"), StringRef(dcText + szText + rackText));
-					data.set(LiteralStringRef("zoneid"), StringRef(dcText + szText + rackText + slotText));
+					data.set("dc"_sr, StringRef(dcText));
+					data.set("az"_sr, StringRef(dcText + szText));
+					data.set("rack"_sr, StringRef(dcText + szText + rackText));
+					data.set("zoneid"_sr, StringRef(dcText + szText + rackText + slotText));
 					for (int independentLoop = 0; independentLoop < independentItems; independentLoop++) {
 						independentName = format("indiv%02d", independentLoop);
 						for (int totalLoop = 0; totalLoop < independentTotal; totalLoop++) {

--- a/fdbrpc/dsltest.actor.cpp
+++ b/fdbrpc/dsltest.actor.cpp
@@ -648,9 +648,9 @@ void arenaTest() {
 	{
 		Arena arena;
 		VectorRef<StringRef> test;
-		test.push_back(arena, StringRef(arena, LiteralStringRef("Hello")));
-		test.push_back(arena, StringRef(arena, LiteralStringRef(", ")));
-		test.push_back(arena, StringRef(arena, LiteralStringRef("World!")));
+		test.push_back(arena, StringRef(arena, "Hello"_sr));
+		test.push_back(arena, StringRef(arena, ", "_sr));
+		test.push_back(arena, StringRef(arena, "World!"_sr));
 
 		for (auto i = test.begin(); i != test.end(); ++i)
 			for (auto j = i->begin(); j != i->end(); ++j)

--- a/fdbrpc/sim2.actor.cpp
+++ b/fdbrpc/sim2.actor.cpp
@@ -2434,8 +2434,8 @@ int sf_open(const char* filename, int flags, int convFlags, int mode) {
 Future<Reference<class IAsyncFile>> Sim2FileSystem::open(const std::string& filename, int64_t flags, int64_t mode) {
 	ASSERT((flags & IAsyncFile::OPEN_ATOMIC_WRITE_AND_CREATE) || !(flags & IAsyncFile::OPEN_CREATE) ||
 	       StringRef(filename).endsWith(
-	           LiteralStringRef(".fdb-lock"))); // We don't use "ordinary" non-atomic file creation right now except for
-	                                            // folder locking, and we don't have code to simulate its unsafeness.
+	           ".fdb-lock"_sr)); // We don't use "ordinary" non-atomic file creation right now except for
+	                             // folder locking, and we don't have code to simulate its unsafeness.
 
 	if ((flags & IAsyncFile::OPEN_EXCLUSIVE))
 		ASSERT(flags & IAsyncFile::OPEN_CREATE);

--- a/fdbserver/ApplyMetadataMutation.cpp
+++ b/fdbserver/ApplyMetadataMutation.cpp
@@ -219,7 +219,7 @@ void applyMetadataMutations(SpanID const& spanContext,
 						auto t = txnStateStore->readValue(m.param1).get();
 						TraceEvent("MutationRequiresRestart", dbgid)
 						    .detail("M", m.toString())
-						    .detail("PrevValue", t.present() ? t.get() : LiteralStringRef("(none)"))
+						    .detail("PrevValue", t.present() ? t.get() : "(none)"_sr)
 						    .detail("ToCommit", toCommit != nullptr);
 						confChange = true;
 					}

--- a/fdbserver/BackupProgress.actor.cpp
+++ b/fdbserver/BackupProgress.actor.cpp
@@ -185,7 +185,7 @@ TEST_CASE("/BackupProgress/Unfinished") {
 	const Tag tag1(tagLocalityLogRouter, 0);
 	epochInfos.insert({ epoch1, ILogSystem::EpochTagsVersionsInfo(1, begin1, end1) });
 	BackupProgress progress(UID(0, 0), epochInfos);
-	progress.setBackupStartedValue(Optional<Value>(LiteralStringRef("1")));
+	progress.setBackupStartedValue(Optional<Value>("1"_sr));
 
 	std::map<std::tuple<LogEpoch, Version, int>, std::map<Tag, Version>> unfinished = progress.getUnfinishedBackup();
 

--- a/fdbserver/BackupWorker.actor.cpp
+++ b/fdbserver/BackupWorker.actor.cpp
@@ -1015,7 +1015,7 @@ ACTOR static Future<Void> monitorWorkerPause(BackupData* self) {
 			tr->setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
 
 			Optional<Value> value = wait(tr->get(backupPausedKey));
-			bool paused = value.present() && value.get() == LiteralStringRef("1");
+			bool paused = value.present() && value.get() == "1"_sr;
 			if (self->paused.get() != paused) {
 				TraceEvent(paused ? "BackupWorkerPaused" : "BackupWorkerResumed", self->myId);
 				self->paused.set(paused);

--- a/fdbserver/ClusterController.actor.cpp
+++ b/fdbserver/ClusterController.actor.cpp
@@ -3394,7 +3394,7 @@ void checkBetterDDOrRK(ClusterControllerData* self) {
 			    .detail("Fitness", ddFitness)
 			    .detail("BestFitness", bestFitnessForDD)
 			    .detail("CurrentRateKeeperProcessId",
-			            currentRKProcessId.present() ? currentRKProcessId.get() : LiteralStringRef("None"))
+			            currentRKProcessId.present() ? currentRKProcessId.get() : "None"_sr)
 			    .detail("CurrentDDProcessId", currentDDProcessId)
 			    .detail("MasterProcessID", self->masterProcessId)
 			    .detail("NewRKWorkers", newRKWorker.interf.locality.processId())
@@ -3889,7 +3889,7 @@ void registerWorker(RegisterWorkerRequest req, ClusterControllerData* self) {
 	}
 }
 
-#define TIME_KEEPER_VERSION LiteralStringRef("1")
+#define TIME_KEEPER_VERSION "1"_sr
 
 ACTOR Future<Void> timeKeeperSetVersion(ClusterControllerData* self) {
 	state Reference<ReadYourWritesTransaction> tr = makeReference<ReadYourWritesTransaction>(self->cx);

--- a/fdbserver/CommitProxyServer.actor.cpp
+++ b/fdbserver/CommitProxyServer.actor.cpp
@@ -280,7 +280,7 @@ void createWhitelistBinPathVec(const std::string& binPath, vector<Standalone<Str
 	TraceEvent(SevDebug, "BinPathConverter").detail("Input", binPath);
 	StringRef input(binPath);
 	while (input != StringRef()) {
-		StringRef token = input.eat(LiteralStringRef(","));
+		StringRef token = input.eat(","_sr);
 		if (token != StringRef()) {
 			const uint8_t* ptr = token.begin();
 			while (ptr != token.end() && *ptr == ' ') {
@@ -549,8 +549,7 @@ bool canReject(const std::vector<CommitTransactionRequest>& trs) {
 	for (const auto& tr : trs) {
 		if (tr.transaction.mutations.empty())
 			continue;
-		if (tr.transaction.mutations[0].param1.startsWith(LiteralStringRef("\xff")) ||
-		    tr.transaction.read_conflict_ranges.empty()) {
+		if (tr.transaction.mutations[0].param1.startsWith("\xff"_sr) || tr.transaction.read_conflict_ranges.empty()) {
 			return false;
 		}
 	}
@@ -1704,9 +1703,7 @@ ACTOR Future<Void> proxySnapCreate(ProxySnapRequest snapReq, ProxyCommitData* co
 			throw snap_not_fully_recovered_unsupported();
 		}
 
-		auto result =
-		    commitData->txnStateStore->readValue(LiteralStringRef("log_anti_quorum").withPrefix(configKeysPrefix))
-		        .get();
+		auto result = commitData->txnStateStore->readValue("log_anti_quorum"_sr.withPrefix(configKeysPrefix)).get();
 		int logAntiQuorum = 0;
 		if (result.present()) {
 			logAntiQuorum = atoi(result.get().toString().c_str());

--- a/fdbserver/CompactMap.cpp
+++ b/fdbserver/CompactMap.cpp
@@ -473,7 +473,7 @@ void compactMapTests(std::vector<std::string> testData,
 	t2 = timer_monotonic();
 	printf("PrefixTree Build time %0.0f us (%0.2f M/sec)\n", (t2 - t1) / nBuild * 1e6, nBuild / (t2 - t1) / 1e6);
 
-	t->lastLessOrEqual(LiteralStringRef("8f9fad2e5e2af980a"));
+	t->lastLessOrEqual("8f9fad2e5e2af980a"_sr);
 
 	{
 		std::string s, s1;

--- a/fdbserver/Coordination.actor.cpp
+++ b/fdbserver/Coordination.actor.cpp
@@ -151,8 +151,8 @@ TEST_CASE("/fdbserver/Coordination/localGenerationReg/simple") {
 	}
 
 	{
-		UniqueGeneration g = wait(
-		    reg.write.getReply(GenerationRegWriteRequest(KeyValueRef(the_key, LiteralStringRef("Value1")), firstGen)));
+		UniqueGeneration g =
+		    wait(reg.write.getReply(GenerationRegWriteRequest(KeyValueRef(the_key, "Value1"_sr), firstGen)));
 		//   (gen1==gen is considered a "successful" write)
 		ASSERT(g == firstGen);
 	}
@@ -161,7 +161,7 @@ TEST_CASE("/fdbserver/Coordination/localGenerationReg/simple") {
 		GenerationRegReadReply r = wait(reg.read.getReply(GenerationRegReadRequest(the_key, UniqueGeneration())));
 		// read(key,gen2) returns (value,gen,rgen).
 		//     There was some earlier or concurrent write(key,value,gen).
-		ASSERT(r.value == LiteralStringRef("Value1"));
+		ASSERT(r.value == "Value1"_sr);
 		ASSERT(r.gen == firstGen);
 		//     There was some earlier or concurrent read(key,rgen).
 		ASSERT(r.rgen == firstGen);

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -3934,7 +3934,7 @@ ACTOR Future<Void> updateNextWigglingStoragePID(DDTeamCollection* teamCollection
 			tr.setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
 			Optional<Value> value = wait(tr.get(wigglingStorageServerKey));
 			if (teamCollection->pid2server_info.empty()) {
-				writeValue = LiteralStringRef("");
+				writeValue = ""_sr;
 			} else {
 				Value pid = teamCollection->pid2server_info.begin()->first;
 				if (value.present()) {
@@ -4098,7 +4098,7 @@ ACTOR Future<Void> perpetualStorageWiggler(AsyncVar<bool>* stopSignal,
 			when(wait(moveFinishFuture)) {
 				ASSERT(self->wigglingPid.present());
 				StringRef pid = self->wigglingPid.get();
-				TEST(pid != LiteralStringRef("")); // finish wiggling this process
+				TEST(pid != ""_sr); // finish wiggling this process
 
 				moveFinishFuture = Never();
 				self->includeStorageServersForWiggle();
@@ -6166,10 +6166,9 @@ ACTOR Future<Void> ddSnapCreateCore(DistributorSnapRequest snapReq, Reference<As
 		std::vector<Future<Void>> storageSnapReqs;
 		storageSnapReqs.reserve(storageWorkers.size());
 		for (const auto& worker : storageWorkers) {
-			storageSnapReqs.push_back(
-			    transformErrors(throwErrorOr(worker.workerSnapReq.tryGetReply(WorkerSnapRequest(
-			                        snapReq.snapPayload, snapReq.snapUID, LiteralStringRef("storage")))),
-			                    snap_storage_failed()));
+			storageSnapReqs.push_back(transformErrors(throwErrorOr(worker.workerSnapReq.tryGetReply(WorkerSnapRequest(
+			                                              snapReq.snapPayload, snapReq.snapUID, "storage"_sr))),
+			                                          snap_storage_failed()));
 		}
 		wait(waitForAll(storageSnapReqs));
 
@@ -6180,10 +6179,9 @@ ACTOR Future<Void> ddSnapCreateCore(DistributorSnapRequest snapReq, Reference<As
 		std::vector<Future<Void>> tLogSnapReqs;
 		tLogSnapReqs.reserve(tlogs.size());
 		for (const auto& tlog : tlogs) {
-			tLogSnapReqs.push_back(
-			    transformErrors(throwErrorOr(tlog.snapRequest.tryGetReply(
-			                        TLogSnapRequest(snapReq.snapPayload, snapReq.snapUID, LiteralStringRef("tlog")))),
-			                    snap_tlog_failed()));
+			tLogSnapReqs.push_back(transformErrors(throwErrorOr(tlog.snapRequest.tryGetReply(TLogSnapRequest(
+			                                           snapReq.snapPayload, snapReq.snapUID, "tlog"_sr))),
+			                                       snap_tlog_failed()));
 		}
 		wait(waitForAll(tLogSnapReqs));
 
@@ -6211,10 +6209,9 @@ ACTOR Future<Void> ddSnapCreateCore(DistributorSnapRequest snapReq, Reference<As
 		std::vector<Future<Void>> coordSnapReqs;
 		coordSnapReqs.reserve(coordWorkers.size());
 		for (const auto& worker : coordWorkers) {
-			coordSnapReqs.push_back(
-			    transformErrors(throwErrorOr(worker.workerSnapReq.tryGetReply(WorkerSnapRequest(
-			                        snapReq.snapPayload, snapReq.snapUID, LiteralStringRef("coord")))),
-			                    snap_coord_failed()));
+			coordSnapReqs.push_back(transformErrors(throwErrorOr(worker.workerSnapReq.tryGetReply(WorkerSnapRequest(
+			                                            snapReq.snapPayload, snapReq.snapUID, "coord"_sr))),
+			                                        snap_coord_failed()));
 		}
 		wait(waitForAll(coordSnapReqs));
 		TraceEvent("SnapDataDistributor_AfterSnapCoords")
@@ -6542,9 +6539,9 @@ std::unique_ptr<DDTeamCollection> testTeamCollection(int teamSize,
 		UID uid(id, 0);
 		StorageServerInterface interface;
 		interface.uniqueID = uid;
-		interface.locality.set(LiteralStringRef("machineid"), Standalone<StringRef>(std::to_string(id)));
-		interface.locality.set(LiteralStringRef("zoneid"), Standalone<StringRef>(std::to_string(id % 5)));
-		interface.locality.set(LiteralStringRef("data_hall"), Standalone<StringRef>(std::to_string(id % 3)));
+		interface.locality.set("machineid"_sr, Standalone<StringRef>(std::to_string(id)));
+		interface.locality.set("zoneid"_sr, Standalone<StringRef>(std::to_string(id % 5)));
+		interface.locality.set("data_hall"_sr, Standalone<StringRef>(std::to_string(id % 3)));
 		collection->server_info[uid] = makeReference<TCServerInfo>(
 		    interface, collection.get(), ProcessClass(), true, collection->storageServerSet);
 		collection->server_status.set(uid, ServerStatus(false, false, false, interface.locality));
@@ -6596,11 +6593,11 @@ std::unique_ptr<DDTeamCollection> testMachineTeamCollection(int teamSize,
 		       zone_id,
 		       machine_id,
 		       interface.address().toString().c_str());
-		interface.locality.set(LiteralStringRef("processid"), Standalone<StringRef>(std::to_string(process_id)));
-		interface.locality.set(LiteralStringRef("machineid"), Standalone<StringRef>(std::to_string(machine_id)));
-		interface.locality.set(LiteralStringRef("zoneid"), Standalone<StringRef>(std::to_string(zone_id)));
-		interface.locality.set(LiteralStringRef("data_hall"), Standalone<StringRef>(std::to_string(data_hall_id)));
-		interface.locality.set(LiteralStringRef("dcid"), Standalone<StringRef>(std::to_string(dc_id)));
+		interface.locality.set("processid"_sr, Standalone<StringRef>(std::to_string(process_id)));
+		interface.locality.set("machineid"_sr, Standalone<StringRef>(std::to_string(machine_id)));
+		interface.locality.set("zoneid"_sr, Standalone<StringRef>(std::to_string(zone_id)));
+		interface.locality.set("data_hall"_sr, Standalone<StringRef>(std::to_string(data_hall_id)));
+		interface.locality.set("dcid"_sr, Standalone<StringRef>(std::to_string(dc_id)));
 		collection->server_info[uid] = makeReference<TCServerInfo>(
 		    interface, collection.get(), ProcessClass(), true, collection->storageServerSet);
 

--- a/fdbserver/DiskQueue.actor.cpp
+++ b/fdbserver/DiskQueue.actor.cpp
@@ -191,7 +191,7 @@ public:
 		memset(firstPages[0], 0xFF, sizeof(Page));
 		firstPages[1] = (Page*)((uintptr_t)firstPages[0] + 4096);
 		memset(firstPages[1], 0xFF, sizeof(Page));
-		stallCount.init(LiteralStringRef("RawDiskQueue.StallCount"));
+		stallCount.init("RawDiskQueue.StallCount"_sr);
 	}
 
 	Future<Void> pushAndCommit(StringRef pageData, StringBuffer* pageMem, uint64_t poppedPages) {

--- a/fdbserver/FDBExecHelper.actor.cpp
+++ b/fdbserver/FDBExecHelper.actor.cpp
@@ -42,7 +42,7 @@ VectorRef<StringRef> ExecCmdValueString::getBinaryArgs() const {
 void ExecCmdValueString::parseCmdValue() {
 	StringRef param = this->cmdValueString;
 	// get the binary path
-	this->binaryPath = param.eat(LiteralStringRef(" "));
+	this->binaryPath = param.eat(" "_sr);
 
 	// no arguments provided
 	if (param == StringRef()) {
@@ -51,7 +51,7 @@ void ExecCmdValueString::parseCmdValue() {
 
 	// extract the arguments
 	while (param != StringRef()) {
-		StringRef token = param.eat(LiteralStringRef(" "));
+		StringRef token = param.eat(" "_sr);
 		this->binaryArgs.push_back(this->binaryArgs.arena(), token);
 	}
 	return;

--- a/fdbserver/KeyValueStoreCompressTestData.actor.cpp
+++ b/fdbserver/KeyValueStoreCompressTestData.actor.cpp
@@ -114,12 +114,12 @@ private:
 
 		// If the value starts with a 0-byte, then we don't compress it
 		if (c == 0)
-			return val.withPrefix(LiteralStringRef("\x00"));
+			return val.withPrefix("\x00"_sr);
 
 		for (int i = 1; i < val.size(); i++) {
 			if (val[i] != c) {
 				// The value is something other than a single repeated character, so not compressible :-)
-				return val.withPrefix(LiteralStringRef("\x00"));
+				return val.withPrefix("\x00"_sr);
 			}
 		}
 

--- a/fdbserver/KeyValueStoreMemory.actor.cpp
+++ b/fdbserver/KeyValueStoreMemory.actor.cpp
@@ -445,7 +445,7 @@ private:
 		log->push(StringRef((const uint8_t*)&h, sizeof(h)));
 		log->push(v1);
 		log->push(v2);
-		return log->push(LiteralStringRef("\x01")); // Changes here should be reflected in OP_DISK_OVERHEAD
+		return log->push("\x01"_sr); // Changes here should be reflected in OP_DISK_OVERHEAD
 	}
 
 	ACTOR static Future<Void> recover(KeyValueStoreMemory* self, bool exactRecovery) {
@@ -723,7 +723,7 @@ private:
 
 					auto thisSnapshotEnd = self->log_op(OpSnapshotEnd, StringRef(), StringRef());
 					//TraceEvent("SnapshotEnd", self->id)
-					//	.detail("LastKey", lastKey.present() ? lastKey.get() : LiteralStringRef("<none>"))
+					//	.detail("LastKey", lastKey.present() ? lastKey.get() : "<none>"_sr)
 					//	.detail("CurrentSnapshotEndLoc", self->currentSnapshotEnd)
 					//	.detail("PreviousSnapshotEndLoc", self->previousSnapshotEnd)
 					//	.detail("ThisSnapshotEnd", thisSnapshotEnd)

--- a/fdbserver/KeyValueStoreRocksDB.actor.cpp
+++ b/fdbserver/KeyValueStoreRocksDB.actor.cpp
@@ -497,11 +497,11 @@ TEST_CASE("noSim/fdbserver/KeyValueStoreRocksDB/Reopen") {
 	state IKeyValueStore* kvStore = new RocksDBKeyValueStore(rocksDBTestDir, deterministicRandom()->randomUniqueID());
 	wait(kvStore->init());
 
-	kvStore->set({ LiteralStringRef("foo"), LiteralStringRef("bar") });
+	kvStore->set({ "foo"_sr, "bar"_sr });
 	wait(kvStore->commit(false));
 
-	Optional<Value> val = wait(kvStore->readValue(LiteralStringRef("foo")));
-	ASSERT(Optional<Value>(LiteralStringRef("bar")) == val);
+	Optional<Value> val = wait(kvStore->readValue("foo"_sr));
+	ASSERT(Optional<Value>("bar"_sr) == val);
 
 	Future<Void> closed = kvStore->onClosed();
 	kvStore->close();
@@ -512,8 +512,8 @@ TEST_CASE("noSim/fdbserver/KeyValueStoreRocksDB/Reopen") {
 	// Confirm that `init()` is idempotent.
 	wait(kvStore->init());
 
-	Optional<Value> val = wait(kvStore->readValue(LiteralStringRef("foo")));
-	ASSERT(Optional<Value>(LiteralStringRef("bar")) == val);
+	Optional<Value> val = wait(kvStore->readValue("foo"_sr));
+	ASSERT(Optional<Value>("bar"_sr) == val);
 
 	Future<Void> closed = kvStore->onClosed();
 	kvStore->close();

--- a/fdbserver/KeyValueStoreSQLite.actor.cpp
+++ b/fdbserver/KeyValueStoreSQLite.actor.cpp
@@ -1321,7 +1321,7 @@ int SQLiteDB::checkAllPageChecksums() {
 	// then we could instead open a read cursor for the same effect, as currently tryReadEveryDbPage() requires it.
 	Statement* jm = new Statement(*this, "PRAGMA journal_mode");
 	ASSERT(jm->nextRow());
-	if (jm->column(0) != LiteralStringRef("wal")) {
+	if (jm->column(0) != "wal"_sr) {
 		TraceEvent(SevError, "JournalModeError").detail("Filename", filename).detail("Mode", jm->column(0));
 		ASSERT(false);
 	}
@@ -1490,7 +1490,7 @@ void SQLiteDB::open(bool writable) {
 
 	Statement jm(*this, "PRAGMA journal_mode");
 	ASSERT(jm.nextRow());
-	if (jm.column(0) != LiteralStringRef("wal")) {
+	if (jm.column(0) != "wal"_sr) {
 		TraceEvent(SevError, "JournalModeError").detail("Filename", filename).detail("Mode", jm.column(0));
 		ASSERT(false);
 	}
@@ -2251,9 +2251,9 @@ ACTOR Future<Void> KVFileCheck(std::string filename, bool integrity) {
 
 	StringRef kvFile(filename);
 	KeyValueStoreType type = KeyValueStoreType::END;
-	if (kvFile.endsWith(LiteralStringRef(".fdb")))
+	if (kvFile.endsWith(".fdb"_sr))
 		type = KeyValueStoreType::SSD_BTREE_V1;
-	else if (kvFile.endsWith(LiteralStringRef(".sqlite")))
+	else if (kvFile.endsWith(".sqlite"_sr))
 		type = KeyValueStoreType::SSD_BTREE_V2;
 	ASSERT(type != KeyValueStoreType::END);
 

--- a/fdbserver/LogRouter.actor.cpp
+++ b/fdbserver/LogRouter.actor.cpp
@@ -141,9 +141,7 @@ struct LogRouterData {
 	    allowPops(false), minKnownCommittedVersion(0), poppedVersion(0), foundEpochEnd(false),
 	    cc("LogRouter", dbgid.toString()), getMoreCount("GetMoreCount", cc),
 	    getMoreBlockedCount("GetMoreBlockedCount", cc),
-	    peekLatencyDist(Histogram::getHistogram(LiteralStringRef("LogRouter"),
-	                                            LiteralStringRef("PeekTLogLatency"),
-	                                            Histogram::Unit::microseconds)) {
+	    peekLatencyDist(Histogram::getHistogram("LogRouter"_sr, "PeekTLogLatency"_sr, Histogram::Unit::microseconds)) {
 		// setup just enough of a logSet to be able to call getPushLocations
 		logSet.logServers.resize(req.tLogLocalities.size());
 		logSet.tLogPolicy = req.tLogPolicy;

--- a/fdbserver/MetricLogger.actor.cpp
+++ b/fdbserver/MetricLogger.actor.cpp
@@ -95,12 +95,10 @@ struct MetricsRule {
 
 struct MetricsConfig {
 	MetricsConfig(Key prefix = KeyRef())
-	  : space(prefix), ruleMap(space.get(LiteralStringRef("Rules")).key()),
-	    addressMap(space.get(LiteralStringRef("Enum")).get(LiteralStringRef("Address")).key()),
-	    nameAndTypeMap(space.get(LiteralStringRef("Enum")).get(LiteralStringRef("NameType")).key()),
-	    ruleChangeKey(space.get(LiteralStringRef("RulesChanged")).key()),
-	    enumsChangeKey(space.get(LiteralStringRef("EnumsChanged")).key()),
-	    fieldChangeKey(space.get(LiteralStringRef("FieldsChanged")).key()) {}
+	  : space(prefix), ruleMap(space.get("Rules"_sr).key()), addressMap(space.get("Enum"_sr).get("Address"_sr).key()),
+	    nameAndTypeMap(space.get("Enum"_sr).get("NameType"_sr).key()),
+	    ruleChangeKey(space.get("RulesChanged"_sr).key()), enumsChangeKey(space.get("EnumsChanged"_sr).key()),
+	    fieldChangeKey(space.get("FieldsChanged"_sr).key()) {}
 
 	Subspace space;
 
@@ -424,7 +422,7 @@ TEST_CASE("/fdbserver/metrics/TraceEvents") {
 	fprintf(stdout, "Using environment variables METRICS_CONNFILE and METRICS_PREFIX.\n");
 
 	state Database metricsDb = Database::createDatabase(metricsConnFile, Database::API_VERSION_LATEST);
-	TDMetricCollection::getTDMetrics()->address = LiteralStringRef("0.0.0.0:0");
+	TDMetricCollection::getTDMetrics()->address = "0.0.0.0:0"_sr;
 	state Future<Void> metrics = runMetrics(metricsDb, KeyRef(metricsPrefix));
 	state int64_t x = 0;
 
@@ -443,9 +441,9 @@ TEST_CASE("/fdbserver/metrics/TraceEvents") {
 	fprintf(stdout, "  d is always present, is a string, and rotates through the values 'one', 'two', and ''.\n");
 	fprintf(stdout, "  Plotting j on the x axis and k on the y axis should look like x=sin(2t), y=sin(3t)\n");
 
-	state Int64MetricHandle intMetric = Int64MetricHandle(LiteralStringRef("DummyInt"));
-	state BoolMetricHandle boolMetric = BoolMetricHandle(LiteralStringRef("DummyBool"));
-	state StringMetricHandle stringMetric = StringMetricHandle(LiteralStringRef("DummyString"));
+	state Int64MetricHandle intMetric = Int64MetricHandle("DummyInt"_sr);
+	state BoolMetricHandle boolMetric = BoolMetricHandle("DummyBool"_sr);
+	state StringMetricHandle stringMetric = StringMetricHandle("DummyString"_sr);
 
 	static const char* dStrings[] = { "one", "two", "" };
 	state const char** d = dStrings;

--- a/fdbserver/MutationTracking.cpp
+++ b/fdbserver/MutationTracking.cpp
@@ -28,8 +28,8 @@
 #endif
 
 // Track up to 2 keys in simulation via enabling MUTATION_TRACKING_ENABLED and setting the keys here.
-StringRef debugKey = LiteralStringRef("");
-StringRef debugKey2 = LiteralStringRef("\xff\xff\xff\xff");
+StringRef debugKey = ""_sr;
+StringRef debugKey2 = "\xff\xff\xff\xff"_sr;
 
 TraceEvent debugMutationEnabled(const char* context, Version version, MutationRef const& mutation) {
 	if ((mutation.type == mutation.ClearRange || mutation.type == mutation.DebugKeyRange) &&

--- a/fdbserver/OldTLogServer_4_6.actor.cpp
+++ b/fdbserver/OldTLogServer_4_6.actor.cpp
@@ -223,17 +223,14 @@ private:
 ////// Persistence format (for self->persistentData)
 
 // Immutable keys
-static const KeyValueRef persistFormat(LiteralStringRef("Format"), LiteralStringRef("FoundationDB/LogServer/2/3"));
-static const KeyRangeRef persistFormatReadableRange(LiteralStringRef("FoundationDB/LogServer/2/3"),
-                                                    LiteralStringRef("FoundationDB/LogServer/2/4"));
-static const KeyRangeRef persistRecoveryCountKeys =
-    KeyRangeRef(LiteralStringRef("DbRecoveryCount/"), LiteralStringRef("DbRecoveryCount0"));
+static const KeyValueRef persistFormat("Format"_sr, "FoundationDB/LogServer/2/3"_sr);
+static const KeyRangeRef persistFormatReadableRange("FoundationDB/LogServer/2/3"_sr, "FoundationDB/LogServer/2/4"_sr);
+static const KeyRangeRef persistRecoveryCountKeys = KeyRangeRef("DbRecoveryCount/"_sr, "DbRecoveryCount0"_sr);
 
 // Updated on updatePersistentData()
-static const KeyRangeRef persistCurrentVersionKeys =
-    KeyRangeRef(LiteralStringRef("version/"), LiteralStringRef("version0"));
-static const KeyRange persistTagMessagesKeys = prefixRange(LiteralStringRef("TagMsg/"));
-static const KeyRange persistTagPoppedKeys = prefixRange(LiteralStringRef("TagPop/"));
+static const KeyRangeRef persistCurrentVersionKeys = KeyRangeRef("version/"_sr, "version0"_sr);
+static const KeyRange persistTagMessagesKeys = prefixRange("TagMsg/"_sr);
+static const KeyRange persistTagPoppedKeys = prefixRange("TagPop/"_sr);
 
 static Key persistTagMessagesKey(UID id, OldTag tag, Version version) {
 	BinaryWriter wr(Unversioned());
@@ -452,10 +449,10 @@ struct LogData : NonCopyable, public ReferenceCounted<LogData> {
 		          "Restored");
 		addActor.send(traceRole(Role::TRANSACTION_LOG, interf.id()));
 
-		persistentDataVersion.init(LiteralStringRef("TLog.PersistentDataVersion"), cc.id);
-		persistentDataDurableVersion.init(LiteralStringRef("TLog.PersistentDataDurableVersion"), cc.id);
-		version.initMetric(LiteralStringRef("TLog.Version"), cc.id);
-		queueCommittedVersion.initMetric(LiteralStringRef("TLog.QueueCommittedVersion"), cc.id);
+		persistentDataVersion.init("TLog.PersistentDataVersion"_sr, cc.id);
+		persistentDataDurableVersion.init("TLog.PersistentDataDurableVersion"_sr, cc.id);
+		version.initMetric("TLog.Version"_sr, cc.id);
+		queueCommittedVersion.initMetric("TLog.QueueCommittedVersion"_sr, cc.id);
 
 		specialCounter(cc, "Version", [this]() { return this->version.get(); });
 		specialCounter(cc, "SharedBytesInput", [tLogData]() { return tLogData->bytesInput; });
@@ -1407,7 +1404,7 @@ ACTOR Future<Void> restorePersistentState(TLogData* self, LocalityData locality)
 	}
 
 	if (!fFormat.get().present()) {
-		RangeResult v = wait(self->persistentData->readRange(KeyRangeRef(StringRef(), LiteralStringRef("\xff")), 1));
+		RangeResult v = wait(self->persistentData->readRange(KeyRangeRef(StringRef(), "\xff"_sr), 1));
 		if (!v.size()) {
 			TEST(true); // The DB is completely empty, so it was never initialized.  Delete it.
 			throw worker_removed();

--- a/fdbserver/OldTLogServer_6_0.actor.cpp
+++ b/fdbserver/OldTLogServer_6_0.actor.cpp
@@ -189,24 +189,18 @@ private:
 ////// Persistence format (for self->persistentData)
 
 // Immutable keys
-static const KeyValueRef persistFormat(LiteralStringRef("Format"), LiteralStringRef("FoundationDB/LogServer/2/4"));
-static const KeyRangeRef persistFormatReadableRange(LiteralStringRef("FoundationDB/LogServer/2/3"),
-                                                    LiteralStringRef("FoundationDB/LogServer/2/5"));
-static const KeyRangeRef persistRecoveryCountKeys =
-    KeyRangeRef(LiteralStringRef("DbRecoveryCount/"), LiteralStringRef("DbRecoveryCount0"));
+static const KeyValueRef persistFormat("Format"_sr, "FoundationDB/LogServer/2/4"_sr);
+static const KeyRangeRef persistFormatReadableRange("FoundationDB/LogServer/2/3"_sr, "FoundationDB/LogServer/2/5"_sr);
+static const KeyRangeRef persistRecoveryCountKeys = KeyRangeRef("DbRecoveryCount/"_sr, "DbRecoveryCount0"_sr);
 
 // Updated on updatePersistentData()
-static const KeyRangeRef persistCurrentVersionKeys =
-    KeyRangeRef(LiteralStringRef("version/"), LiteralStringRef("version0"));
-static const KeyRangeRef persistKnownCommittedVersionKeys =
-    KeyRangeRef(LiteralStringRef("knownCommitted/"), LiteralStringRef("knownCommitted0"));
-static const KeyRangeRef persistLocalityKeys =
-    KeyRangeRef(LiteralStringRef("Locality/"), LiteralStringRef("Locality0"));
-static const KeyRangeRef persistLogRouterTagsKeys =
-    KeyRangeRef(LiteralStringRef("LogRouterTags/"), LiteralStringRef("LogRouterTags0"));
-static const KeyRangeRef persistTxsTagsKeys = KeyRangeRef(LiteralStringRef("TxsTags/"), LiteralStringRef("TxsTags0"));
-static const KeyRange persistTagMessagesKeys = prefixRange(LiteralStringRef("TagMsg/"));
-static const KeyRange persistTagPoppedKeys = prefixRange(LiteralStringRef("TagPop/"));
+static const KeyRangeRef persistCurrentVersionKeys = KeyRangeRef("version/"_sr, "version0"_sr);
+static const KeyRangeRef persistKnownCommittedVersionKeys = KeyRangeRef("knownCommitted/"_sr, "knownCommitted0"_sr);
+static const KeyRangeRef persistLocalityKeys = KeyRangeRef("Locality/"_sr, "Locality0"_sr);
+static const KeyRangeRef persistLogRouterTagsKeys = KeyRangeRef("LogRouterTags/"_sr, "LogRouterTags0"_sr);
+static const KeyRangeRef persistTxsTagsKeys = KeyRangeRef("TxsTags/"_sr, "TxsTags0"_sr);
+static const KeyRange persistTagMessagesKeys = prefixRange("TagMsg/"_sr);
+static const KeyRange persistTagPoppedKeys = prefixRange("TagPop/"_sr);
 
 static Key persistTagMessagesKey(UID id, Tag tag, Version version) {
 	BinaryWriter wr(Unversioned());
@@ -540,10 +534,10 @@ struct LogData : NonCopyable, public ReferenceCounted<LogData> {
 		          context);
 		addActor.send(traceRole(Role::TRANSACTION_LOG, interf.id()));
 
-		persistentDataVersion.init(LiteralStringRef("TLog.PersistentDataVersion"), cc.id);
-		persistentDataDurableVersion.init(LiteralStringRef("TLog.PersistentDataDurableVersion"), cc.id);
-		version.initMetric(LiteralStringRef("TLog.Version"), cc.id);
-		queueCommittedVersion.initMetric(LiteralStringRef("TLog.QueueCommittedVersion"), cc.id);
+		persistentDataVersion.init("TLog.PersistentDataVersion"_sr, cc.id);
+		persistentDataDurableVersion.init("TLog.PersistentDataDurableVersion"_sr, cc.id);
+		version.initMetric("TLog.Version"_sr, cc.id);
+		queueCommittedVersion.initMetric("TLog.QueueCommittedVersion"_sr, cc.id);
 
 		specialCounter(cc, "Version", [this]() { return this->version.get(); });
 		specialCounter(cc, "QueueCommittedVersion", [this]() { return this->queueCommittedVersion.get(); });
@@ -2258,7 +2252,7 @@ ACTOR Future<Void> restorePersistentState(TLogData* self,
 	}
 
 	if (!fFormat.get().present()) {
-		RangeResult v = wait(self->persistentData->readRange(KeyRangeRef(StringRef(), LiteralStringRef("\xff")), 1));
+		RangeResult v = wait(self->persistentData->readRange(KeyRangeRef(StringRef(), "\xff"_sr), 1));
 		if (!v.size()) {
 			TEST(true); // The DB is completely empty, so it was never initialized.  Delete it.
 			throw worker_removed();
@@ -2272,7 +2266,7 @@ ACTOR Future<Void> restorePersistentState(TLogData* self,
 
 	state std::vector<Future<ErrorOr<Void>>> removed;
 
-	if (fFormat.get().get() == LiteralStringRef("FoundationDB/LogServer/2/3")) {
+	if (fFormat.get().get() == "FoundationDB/LogServer/2/3"_sr) {
 		// FIXME: need for upgrades from 5.X to 6.0, remove once this upgrade path is no longer needed
 		if (recovered.canBeSet())
 			recovered.send(Void());

--- a/fdbserver/OldTLogServer_6_2.actor.cpp
+++ b/fdbserver/OldTLogServer_6_2.actor.cpp
@@ -201,28 +201,21 @@ private:
 // Immutable keys
 // persistFormat has been mostly invalidated by TLogVersion, and can probably be removed when
 // 4.6's TLog code is removed.
-static const KeyValueRef persistFormat(LiteralStringRef("Format"), LiteralStringRef("FoundationDB/LogServer/3/0"));
-static const KeyRangeRef persistFormatReadableRange(LiteralStringRef("FoundationDB/LogServer/3/0"),
-                                                    LiteralStringRef("FoundationDB/LogServer/4/0"));
-static const KeyRangeRef persistProtocolVersionKeys(LiteralStringRef("ProtocolVersion/"),
-                                                    LiteralStringRef("ProtocolVersion0"));
-static const KeyRangeRef persistRecoveryCountKeys =
-    KeyRangeRef(LiteralStringRef("DbRecoveryCount/"), LiteralStringRef("DbRecoveryCount0"));
+static const KeyValueRef persistFormat("Format"_sr, "FoundationDB/LogServer/3/0"_sr);
+static const KeyRangeRef persistFormatReadableRange("FoundationDB/LogServer/3/0"_sr, "FoundationDB/LogServer/4/0"_sr);
+static const KeyRangeRef persistProtocolVersionKeys("ProtocolVersion/"_sr, "ProtocolVersion0"_sr);
+static const KeyRangeRef persistRecoveryCountKeys = KeyRangeRef("DbRecoveryCount/"_sr, "DbRecoveryCount0"_sr);
 
 // Updated on updatePersistentData()
-static const KeyRangeRef persistCurrentVersionKeys =
-    KeyRangeRef(LiteralStringRef("version/"), LiteralStringRef("version0"));
-static const KeyRangeRef persistKnownCommittedVersionKeys =
-    KeyRangeRef(LiteralStringRef("knownCommitted/"), LiteralStringRef("knownCommitted0"));
-static const KeyRef persistRecoveryLocationKey = KeyRef(LiteralStringRef("recoveryLocation"));
-static const KeyRangeRef persistLocalityKeys =
-    KeyRangeRef(LiteralStringRef("Locality/"), LiteralStringRef("Locality0"));
-static const KeyRangeRef persistLogRouterTagsKeys =
-    KeyRangeRef(LiteralStringRef("LogRouterTags/"), LiteralStringRef("LogRouterTags0"));
-static const KeyRangeRef persistTxsTagsKeys = KeyRangeRef(LiteralStringRef("TxsTags/"), LiteralStringRef("TxsTags0"));
-static const KeyRange persistTagMessagesKeys = prefixRange(LiteralStringRef("TagMsg/"));
-static const KeyRange persistTagMessageRefsKeys = prefixRange(LiteralStringRef("TagMsgRef/"));
-static const KeyRange persistTagPoppedKeys = prefixRange(LiteralStringRef("TagPop/"));
+static const KeyRangeRef persistCurrentVersionKeys = KeyRangeRef("version/"_sr, "version0"_sr);
+static const KeyRangeRef persistKnownCommittedVersionKeys = KeyRangeRef("knownCommitted/"_sr, "knownCommitted0"_sr);
+static const KeyRef persistRecoveryLocationKey = KeyRef("recoveryLocation"_sr);
+static const KeyRangeRef persistLocalityKeys = KeyRangeRef("Locality/"_sr, "Locality0"_sr);
+static const KeyRangeRef persistLogRouterTagsKeys = KeyRangeRef("LogRouterTags/"_sr, "LogRouterTags0"_sr);
+static const KeyRangeRef persistTxsTagsKeys = KeyRangeRef("TxsTags/"_sr, "TxsTags0"_sr);
+static const KeyRange persistTagMessagesKeys = prefixRange("TagMsg/"_sr);
+static const KeyRange persistTagMessageRefsKeys = prefixRange("TagMsgRef/"_sr);
+static const KeyRange persistTagPoppedKeys = prefixRange("TagPop/"_sr);
 
 static Key persistTagMessagesKey(UID id, Tag tag, Version version) {
 	BinaryWriter wr(Unversioned());
@@ -624,10 +617,10 @@ struct LogData : NonCopyable, public ReferenceCounted<LogData> {
 		          context);
 		addActor.send(traceRole(Role::TRANSACTION_LOG, interf.id()));
 
-		persistentDataVersion.init(LiteralStringRef("TLog.PersistentDataVersion"), cc.id);
-		persistentDataDurableVersion.init(LiteralStringRef("TLog.PersistentDataDurableVersion"), cc.id);
-		version.initMetric(LiteralStringRef("TLog.Version"), cc.id);
-		queueCommittedVersion.initMetric(LiteralStringRef("TLog.QueueCommittedVersion"), cc.id);
+		persistentDataVersion.init("TLog.PersistentDataVersion"_sr, cc.id);
+		persistentDataDurableVersion.init("TLog.PersistentDataDurableVersion"_sr, cc.id);
+		version.initMetric("TLog.Version"_sr, cc.id);
+		queueCommittedVersion.initMetric("TLog.QueueCommittedVersion"_sr, cc.id);
 
 		specialCounter(cc, "Version", [this]() { return this->version.get(); });
 		specialCounter(cc, "QueueCommittedVersion", [this]() { return this->queueCommittedVersion.get(); });
@@ -2724,7 +2717,7 @@ ACTOR Future<Void> restorePersistentState(TLogData* self,
 	}
 
 	if (!fFormat.get().present()) {
-		RangeResult v = wait(self->persistentData->readRange(KeyRangeRef(StringRef(), LiteralStringRef("\xff")), 1));
+		RangeResult v = wait(self->persistentData->readRange(KeyRangeRef(StringRef(), "\xff"_sr), 1));
 		if (!v.size()) {
 			TEST(true); // The DB is completely empty, so it was never initialized.  Delete it.
 			throw worker_removed();
@@ -2738,7 +2731,7 @@ ACTOR Future<Void> restorePersistentState(TLogData* self,
 
 	state std::vector<Future<ErrorOr<Void>>> removed;
 
-	ASSERT(fFormat.get().get() == LiteralStringRef("FoundationDB/LogServer/3/0"));
+	ASSERT(fFormat.get().get() == "FoundationDB/LogServer/3/0"_sr);
 
 	ASSERT(fVers.get().size() == fRecoverCounts.get().size());
 

--- a/fdbserver/ProxyCommitData.actor.h
+++ b/fdbserver/ProxyCommitData.actor.h
@@ -248,7 +248,7 @@ struct ProxyCommitData {
 	    lastCoalesceTime(0), localCommitBatchesStarted(0), locked(false),
 	    commitBatchInterval(SERVER_KNOBS->COMMIT_TRANSACTION_BATCH_INTERVAL_MIN), firstProxy(firstProxy),
 	    cx(openDBOnServer(db, TaskPriority::DefaultEndpoint, LockAware::True)), db(db),
-	    singleKeyMutationEvent(LiteralStringRef("SingleKeyMutation")), commitBatchesMemBytesCount(0), lastTxsPop(0),
+	    singleKeyMutationEvent("SingleKeyMutation"_sr), commitBatchesMemBytesCount(0), lastTxsPop(0),
 	    lastStartCommit(0), lastCommitLatency(SERVER_KNOBS->REQUIRED_MIN_RECOVERY_DURATION), lastCommitTime(0),
 	    lastMasterReset(now()), lastResolverReset(now()) {
 		commitComputePerOperation.resize(SERVER_KNOBS->PROXY_COMPUTE_BUCKETS, 0.0);

--- a/fdbserver/QuietDatabase.actor.cpp
+++ b/fdbserver/QuietDatabase.actor.cpp
@@ -105,8 +105,8 @@ ACTOR Future<WorkerInterface> getDataDistributorWorker(Database cx, Reference<As
 ACTOR Future<int64_t> getDataInFlight(Database cx, WorkerInterface distributorWorker) {
 	try {
 		TraceEvent("DataInFlight").detail("Stage", "ContactingDataDistributor");
-		TraceEventFields md = wait(timeoutError(
-		    distributorWorker.eventLogRequest.getReply(EventLogRequest(LiteralStringRef("TotalDataInFlight"))), 1.0));
+		TraceEventFields md = wait(
+		    timeoutError(distributorWorker.eventLogRequest.getReply(EventLogRequest("TotalDataInFlight"_sr)), 1.0));
 		int64_t dataInFlight = boost::lexical_cast<int64_t>(md.getValue("TotalBytes"));
 		return dataInFlight;
 	} catch (Error& e) {
@@ -258,7 +258,7 @@ ACTOR Future<vector<WorkerInterface>> getStorageWorkers(Database cx,
 	    wait(runRYWTransaction(cx, [=](Reference<ReadYourWritesTransaction> tr) -> Future<Optional<Value>> {
 		    tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
 		    tr->setOption(FDBTransactionOptions::LOCK_AWARE);
-		    return tr->get(LiteralStringRef("usable_regions").withPrefix(configKeysPrefix));
+		    return tr->get("usable_regions"_sr.withPrefix(configKeysPrefix));
 	    }));
 	int usableRegions = 1;
 	if (regionsValue.present()) {
@@ -376,8 +376,8 @@ ACTOR Future<int64_t> getDataDistributionQueueSize(Database cx,
 	try {
 		TraceEvent("DataDistributionQueueSize").detail("Stage", "ContactingDataDistributor");
 
-		TraceEventFields movingDataMessage = wait(timeoutError(
-		    distributorWorker.eventLogRequest.getReply(EventLogRequest(LiteralStringRef("MovingData"))), 1.0));
+		TraceEventFields movingDataMessage =
+		    wait(timeoutError(distributorWorker.eventLogRequest.getReply(EventLogRequest("MovingData"_sr)), 1.0));
 
 		TraceEvent("DataDistributionQueueSize").detail("Stage", "GotString");
 
@@ -419,8 +419,7 @@ ACTOR Future<bool> getTeamCollectionValid(Database cx, WorkerInterface dataDistr
 			TraceEvent("GetTeamCollectionValid").detail("Stage", "ContactingMaster");
 
 			TraceEventFields teamCollectionInfoMessage = wait(timeoutError(
-			    dataDistributorWorker.eventLogRequest.getReply(EventLogRequest(LiteralStringRef("TeamCollectionInfo"))),
-			    1.0));
+			    dataDistributorWorker.eventLogRequest.getReply(EventLogRequest("TeamCollectionInfo"_sr)), 1.0));
 
 			TraceEvent("GetTeamCollectionValid").detail("Stage", "GotString");
 
@@ -527,8 +526,8 @@ ACTOR Future<bool> getDataDistributionActive(Database cx, WorkerInterface distri
 	try {
 		TraceEvent("DataDistributionActive").detail("Stage", "ContactingDataDistributor");
 
-		TraceEventFields activeMessage = wait(timeoutError(
-		    distributorWorker.eventLogRequest.getReply(EventLogRequest(LiteralStringRef("DDTrackerStarting"))), 1.0));
+		TraceEventFields activeMessage = wait(
+		    timeoutError(distributorWorker.eventLogRequest.getReply(EventLogRequest("DDTrackerStarting"_sr)), 1.0));
 
 		return activeMessage.getValue("State") == "Active";
 	} catch (Error& e) {

--- a/fdbserver/Ratekeeper.actor.cpp
+++ b/fdbserver/Ratekeeper.actor.cpp
@@ -575,9 +575,8 @@ struct RatekeeperData {
 	RatekeeperData(UID id, Database db)
 	  : id(id), db(db), smoothReleasedTransactions(SERVER_KNOBS->SMOOTHING_AMOUNT),
 	    smoothBatchReleasedTransactions(SERVER_KNOBS->SMOOTHING_AMOUNT),
-	    smoothTotalDurableBytes(SERVER_KNOBS->SLOW_SMOOTHING_AMOUNT),
-	    actualTpsMetric(LiteralStringRef("Ratekeeper.ActualTPS")), lastWarning(0), lastSSListFetchedTimestamp(now()),
-	    throttledTagChangeId(0), lastBusiestCommitTagPick(0),
+	    smoothTotalDurableBytes(SERVER_KNOBS->SLOW_SMOOTHING_AMOUNT), actualTpsMetric("Ratekeeper.ActualTPS"_sr),
+	    lastWarning(0), lastSSListFetchedTimestamp(now()), throttledTagChangeId(0), lastBusiestCommitTagPick(0),
 	    normalLimits(TransactionPriority::DEFAULT,
 	                 "",
 	                 SERVER_KNOBS->TARGET_BYTES_PER_STORAGE_SERVER,
@@ -797,15 +796,13 @@ ACTOR Future<Void> monitorThrottlingChanges(RatekeeperData* self) {
 
 				wait(success(throttledTagKeys) && success(autoThrottlingEnabled));
 
-				if (autoThrottlingEnabled.get().present() &&
-				    autoThrottlingEnabled.get().get() == LiteralStringRef("0")) {
+				if (autoThrottlingEnabled.get().present() && autoThrottlingEnabled.get().get() == "0"_sr) {
 					TEST(true); // Auto-throttling disabled
 					if (self->autoThrottlingEnabled) {
 						TraceEvent("AutoTagThrottlingDisabled", self->id);
 					}
 					self->autoThrottlingEnabled = false;
-				} else if (autoThrottlingEnabled.get().present() &&
-				           autoThrottlingEnabled.get().get() == LiteralStringRef("1")) {
+				} else if (autoThrottlingEnabled.get().present() && autoThrottlingEnabled.get().get() == "1"_sr) {
 					TEST(true); // Auto-throttling enabled
 					if (!self->autoThrottlingEnabled) {
 						TraceEvent("AutoTagThrottlingEnabled", self->id);

--- a/fdbserver/RestoreApplier.actor.cpp
+++ b/fdbserver/RestoreApplier.actor.cpp
@@ -285,7 +285,7 @@ ACTOR static Future<Void> getAndComputeStagingKeys(
 		ASSERT(!g_network->isSimulated());
 		int i = 0;
 		for (auto& key : incompleteStagingKeys) {
-			MutationRef m(MutationRef::SetValue, key.first, LiteralStringRef("0"));
+			MutationRef m(MutationRef::SetValue, key.first, "0"_sr);
 			key.second->second.add(m, LogMessageVersion(1));
 			key.second->second.precomputeResult("GetAndComputeStagingKeys", applierID, batchIndex);
 			i++;

--- a/fdbserver/RestoreApplier.actor.h
+++ b/fdbserver/RestoreApplier.actor.h
@@ -373,7 +373,7 @@ struct RestoreApplierData : RestoreRoleData, public ReferenceCounted<RestoreAppl
 		nodeIndex = assignedIndex;
 
 		// Q: Why do we need to initMetric?
-		// version.initMetric(LiteralStringRef("RestoreApplier.Version"), cc.id);
+		// version.initMetric("RestoreApplier.Version"_sr, cc.id);
 
 		role = RestoreRole::Applier;
 	}

--- a/fdbserver/RestoreCommon.actor.cpp
+++ b/fdbserver/RestoreCommon.actor.cpp
@@ -68,7 +68,7 @@ KeyBackedProperty<Reference<IBackupContainer>> RestoreConfigFR::sourceContainer(
 }
 // Get the source container as a bare URL, without creating a container instance
 KeyBackedProperty<Value> RestoreConfigFR::sourceContainerURL() {
-	return configSpace.pack(LiteralStringRef("sourceContainer"));
+	return configSpace.pack("sourceContainer"_sr);
 }
 
 // Total bytes written by all log and range restore tasks.

--- a/fdbserver/RestoreUtil.actor.cpp
+++ b/fdbserver/RestoreUtil.actor.cpp
@@ -29,7 +29,7 @@ int numRoles = RestoreRoleStr.size();
 
 // Similar to debugMutation(), we use debugFRMutation to track mutations for fast restore systems only.
 #if CENABLED(0, NOT_IN_CLEAN)
-StringRef debugFRKey = LiteralStringRef("\xff\xff\xff\xff");
+StringRef debugFRKey = "\xff\xff\xff\xff"_sr;
 
 // Track any mutation in fast restore that has overlap with debugFRKey
 bool debugFRMutation(const char* context, Version version, MutationRef const& mutation) {

--- a/fdbserver/SimulatedCluster.actor.cpp
+++ b/fdbserver/SimulatedCluster.actor.cpp
@@ -1060,7 +1060,7 @@ ACTOR Future<Void> restartSimulatedSystem(vector<Future<Void>>* systemActors,
 			}
 
 			LocalityData localities(Optional<Standalone<StringRef>>(), zoneId, machineId, dcUID);
-			localities.set(LiteralStringRef("data_hall"), dcUID);
+			localities.set("data_hall"_sr, dcUID);
 
 			// SOMEDAY: parse backup agent from test file
 			systemActors->push_back(reportErrors(
@@ -1882,21 +1882,19 @@ void setupSimulatedSystem(vector<Future<Void>>* systemActors,
 	deterministicRandom()->randomShuffle(coordinatorAddresses);
 
 	ASSERT_EQ(coordinatorAddresses.size(), coordinatorCount);
-	ClusterConnectionString conn(coordinatorAddresses, LiteralStringRef("TestCluster:0"));
+	ClusterConnectionString conn(coordinatorAddresses, "TestCluster:0"_sr);
 
 	// If extraDB==0, leave g_simulator.extraDB as null because the test does not use DR.
 	if (testConfig.extraDB == 1) {
 		// The DR database can be either a new database or itself
-		g_simulator.extraDB =
-		    BUGGIFY ? new ClusterConnectionString(coordinatorAddresses, LiteralStringRef("TestCluster:0"))
-		            : new ClusterConnectionString(extraCoordinatorAddresses, LiteralStringRef("ExtraCluster:0"));
+		g_simulator.extraDB = BUGGIFY ? new ClusterConnectionString(coordinatorAddresses, "TestCluster:0"_sr)
+		                              : new ClusterConnectionString(extraCoordinatorAddresses, "ExtraCluster:0"_sr);
 	} else if (testConfig.extraDB == 2) {
 		// The DR database is a new database
-		g_simulator.extraDB =
-		    new ClusterConnectionString(extraCoordinatorAddresses, LiteralStringRef("ExtraCluster:0"));
+		g_simulator.extraDB = new ClusterConnectionString(extraCoordinatorAddresses, "ExtraCluster:0"_sr);
 	} else if (testConfig.extraDB == 3) {
 		// The DR database is the same database
-		g_simulator.extraDB = new ClusterConnectionString(coordinatorAddresses, LiteralStringRef("TestCluster:0"));
+		g_simulator.extraDB = new ClusterConnectionString(coordinatorAddresses, "TestCluster:0"_sr);
 	}
 
 	*pConnString = conn;
@@ -1978,7 +1976,7 @@ void setupSimulatedSystem(vector<Future<Void>>* systemActors,
 
 			// check the sslEnablementMap using only one ip
 			LocalityData localities(Optional<Standalone<StringRef>>(), zoneId, machineId, dcUID);
-			localities.set(LiteralStringRef("data_hall"), dcUID);
+			localities.set("data_hall"_sr, dcUID);
 			systemActors->push_back(reportErrors(simulatedMachine(conn,
 			                                                      ips,
 			                                                      sslEnabled,
@@ -2004,7 +2002,7 @@ void setupSimulatedSystem(vector<Future<Void>>* systemActors,
 				Standalone<StringRef> newMachineId(deterministicRandom()->randomUniqueID().toString());
 
 				LocalityData localities(Optional<Standalone<StringRef>>(), newZoneId, newMachineId, dcUID);
-				localities.set(LiteralStringRef("data_hall"), dcUID);
+				localities.set("data_hall"_sr, dcUID);
 				systemActors->push_back(reportErrors(simulatedMachine(*g_simulator.extraDB,
 				                                                      extraIps,
 				                                                      sslEnabled,
@@ -2140,7 +2138,7 @@ ACTOR void setupAndRun(std::string dataFolder,
 			                  100.0));
 			// FIXME: snapshot restore does not support multi-region restore, hence restore it as single region always
 			if (restoring) {
-				startingConfiguration = LiteralStringRef("usable_regions=1");
+				startingConfiguration = "usable_regions=1"_sr;
 			}
 		} else {
 			g_expect_full_pointermap = 1;

--- a/fdbserver/SkipList.cpp
+++ b/fdbserver/SkipList.cpp
@@ -1049,32 +1049,32 @@ void miniConflictSetTest() {
 
 void operatorLessThanTest() {
 	{ // Longer strings before shorter strings.
-		KeyInfo a(LiteralStringRef("hello"), /*begin=*/false, /*write=*/true, 0, nullptr);
-		KeyInfo b(LiteralStringRef("hello\0"), /*begin=*/false, /*write=*/false, 0, nullptr);
+		KeyInfo a("hello"_sr, /*begin=*/false, /*write=*/true, 0, nullptr);
+		KeyInfo b("hello\0"_sr, /*begin=*/false, /*write=*/false, 0, nullptr);
 		ASSERT(a < b);
 		ASSERT(!(b < a));
 		ASSERT(!(a == b));
 	}
 
 	{ // Reads before writes.
-		KeyInfo a(LiteralStringRef("hello"), /*begin=*/false, /*write=*/false, 0, nullptr);
-		KeyInfo b(LiteralStringRef("hello"), /*begin=*/false, /*write=*/true, 0, nullptr);
+		KeyInfo a("hello"_sr, /*begin=*/false, /*write=*/false, 0, nullptr);
+		KeyInfo b("hello"_sr, /*begin=*/false, /*write=*/true, 0, nullptr);
 		ASSERT(a < b);
 		ASSERT(!(b < a));
 		ASSERT(!(a == b));
 	}
 
 	{ // Begin reads after writes.
-		KeyInfo a(LiteralStringRef("hello"), /*begin=*/false, /*write=*/true, 0, nullptr);
-		KeyInfo b(LiteralStringRef("hello"), /*begin=*/true, /*write=*/false, 0, nullptr);
+		KeyInfo a("hello"_sr, /*begin=*/false, /*write=*/true, 0, nullptr);
+		KeyInfo b("hello"_sr, /*begin=*/true, /*write=*/false, 0, nullptr);
 		ASSERT(a < b);
 		ASSERT(!(b < a));
 		ASSERT(!(a == b));
 	}
 
 	{ // Begin writes after writes.
-		KeyInfo a(LiteralStringRef("hello"), /*begin=*/false, /*write=*/true, 0, nullptr);
-		KeyInfo b(LiteralStringRef("hello"), /*begin=*/true, /*write=*/true, 0, nullptr);
+		KeyInfo a("hello"_sr, /*begin=*/false, /*write=*/true, 0, nullptr);
+		KeyInfo b("hello"_sr, /*begin=*/true, /*write=*/true, 0, nullptr);
 		ASSERT(a < b);
 		ASSERT(!(b < a));
 		ASSERT(!(a == b));

--- a/fdbserver/StorageCache.actor.cpp
+++ b/fdbserver/StorageCache.actor.cpp
@@ -244,9 +244,9 @@ public:
 	    lastTLogVersion(0), lastVersionWithData(0), peekVersion(0), compactionInProgress(Void()),
 	    fetchKeysParallelismLock(SERVER_KNOBS->FETCH_KEYS_PARALLELISM_BYTES), debug_inApplyUpdate(false),
 	    debug_lastValidateTime(0), versionLag(0), behind(false), counters(this) {
-		version.initMetric(LiteralStringRef("StorageCacheData.Version"), counters.cc.id);
-		desiredOldestVersion.initMetric(LiteralStringRef("StorageCacheData.DesriedOldestVersion"), counters.cc.id);
-		oldestVersion.initMetric(LiteralStringRef("StorageCacheData.OldestVersion"), counters.cc.id);
+		version.initMetric("StorageCacheData.Version"_sr, counters.cc.id);
+		desiredOldestVersion.initMetric("StorageCacheData.DesriedOldestVersion"_sr, counters.cc.id);
+		oldestVersion.initMetric("StorageCacheData.OldestVersion"_sr, counters.cc.id);
 
 		newestAvailableVersion.insert(allKeys, invalidVersion);
 		newestDirtyVersion.insert(allKeys, invalidVersion);
@@ -514,9 +514,9 @@ ACTOR Future<Void> getValueQ(StorageCacheData* data, GetValueRequest req) {
 		}
 
 		// DEBUG_MUTATION("CacheGetValue", version, MutationRef(MutationRef::DebugKey, req.key,
-		// v.present()?v.get():LiteralStringRef("<null>"))); DEBUG_MUTATION("CacheGetPath", version,
+		// v.present()?v.get():"<null>"_sr)); DEBUG_MUTATION("CacheGetPath", version,
 		// MutationRef(MutationRef::DebugKey, req.key,
-		// path==0?LiteralStringRef("0"):path==1?LiteralStringRef("1"):LiteralStringRef("2")));
+		// path==0?"0"_sr:path==1?"1"_sr:"2"_sr));
 
 		if (v.present()) {
 			++data->counters.rowsQueried;

--- a/fdbserver/StorageMetrics.actor.h
+++ b/fdbserver/StorageMetrics.actor.h
@@ -27,18 +27,18 @@
 #include "fdbserver/Knobs.h"
 #include "flow/actorcompiler.h" // This must be the last #include.
 
-const StringRef STORAGESERVER_HISTOGRAM_GROUP = LiteralStringRef("StorageServer");
-const StringRef FETCH_KEYS_LATENCY_HISTOGRAM = LiteralStringRef("FetchKeysLatency");
-const StringRef FETCH_KEYS_BYTES_HISTOGRAM = LiteralStringRef("FetchKeysSize");
-const StringRef FETCH_KEYS_BYTES_PER_SECOND_HISTOGRAM = LiteralStringRef("FetchKeysBandwidth");
-const StringRef TLOG_CURSOR_READS_LATENCY_HISTOGRAM = LiteralStringRef("TLogCursorReadsLatency");
-const StringRef SS_VERSION_LOCK_LATENCY_HISTOGRAM = LiteralStringRef("SSVersionLockLatency");
-const StringRef EAGER_READS_LATENCY_HISTOGRAM = LiteralStringRef("EagerReadsLatency");
-const StringRef FETCH_KEYS_PTREE_UPDATES_LATENCY_HISTOGRAM = LiteralStringRef("FetchKeysPTreeUpdatesLatency");
-const StringRef TLOG_MSGS_PTREE_UPDATES_LATENCY_HISTOGRAM = LiteralStringRef("TLogMsgsPTreeUpdatesLatency");
-const StringRef STORAGE_UPDATES_DURABLE_LATENCY_HISTOGRAM = LiteralStringRef("StorageUpdatesDurableLatency");
-const StringRef STORAGE_COMMIT_LATENCY_HISTOGRAM = LiteralStringRef("StorageCommitLatency");
-const StringRef SS_DURABLE_VERSION_UPDATE_LATENCY_HISTOGRAM = LiteralStringRef("SSDurableVersionUpdateLatency");
+const StringRef STORAGESERVER_HISTOGRAM_GROUP = "StorageServer"_sr;
+const StringRef FETCH_KEYS_LATENCY_HISTOGRAM = "FetchKeysLatency"_sr;
+const StringRef FETCH_KEYS_BYTES_HISTOGRAM = "FetchKeysSize"_sr;
+const StringRef FETCH_KEYS_BYTES_PER_SECOND_HISTOGRAM = "FetchKeysBandwidth"_sr;
+const StringRef TLOG_CURSOR_READS_LATENCY_HISTOGRAM = "TLogCursorReadsLatency"_sr;
+const StringRef SS_VERSION_LOCK_LATENCY_HISTOGRAM = "SSVersionLockLatency"_sr;
+const StringRef EAGER_READS_LATENCY_HISTOGRAM = "EagerReadsLatency"_sr;
+const StringRef FETCH_KEYS_PTREE_UPDATES_LATENCY_HISTOGRAM = "FetchKeysPTreeUpdatesLatency"_sr;
+const StringRef TLOG_MSGS_PTREE_UPDATES_LATENCY_HISTOGRAM = "TLogMsgsPTreeUpdatesLatency"_sr;
+const StringRef STORAGE_UPDATES_DURABLE_LATENCY_HISTOGRAM = "StorageUpdatesDurableLatency"_sr;
+const StringRef STORAGE_COMMIT_LATENCY_HISTOGRAM = "StorageCommitLatency"_sr;
+const StringRef SS_DURABLE_VERSION_UPDATE_LATENCY_HISTOGRAM = "SSDurableVersionUpdateLatency"_sr;
 
 struct StorageMetricSample {
 	IndexedSet<Key, int64_t> sample;
@@ -95,18 +95,18 @@ struct StorageMetricSample {
 
 TEST_CASE("/fdbserver/StorageMetricSample/simple") {
 	StorageMetricSample s(1000);
-	s.sample.insert(LiteralStringRef("Apple"), 1000);
-	s.sample.insert(LiteralStringRef("Banana"), 2000);
-	s.sample.insert(LiteralStringRef("Cat"), 1000);
-	s.sample.insert(LiteralStringRef("Cathode"), 1000);
-	s.sample.insert(LiteralStringRef("Dog"), 1000);
+	s.sample.insert("Apple"_sr, 1000);
+	s.sample.insert("Banana"_sr, 2000);
+	s.sample.insert("Cat"_sr, 1000);
+	s.sample.insert("Cathode"_sr, 1000);
+	s.sample.insert("Dog"_sr, 1000);
 
-	ASSERT(s.getEstimate(KeyRangeRef(LiteralStringRef("A"), LiteralStringRef("D"))) == 5000);
-	ASSERT(s.getEstimate(KeyRangeRef(LiteralStringRef("A"), LiteralStringRef("E"))) == 6000);
-	ASSERT(s.getEstimate(KeyRangeRef(LiteralStringRef("B"), LiteralStringRef("C"))) == 2000);
+	ASSERT(s.getEstimate(KeyRangeRef("A"_sr, "D"_sr)) == 5000);
+	ASSERT(s.getEstimate(KeyRangeRef("A"_sr, "E"_sr)) == 6000);
+	ASSERT(s.getEstimate(KeyRangeRef("B"_sr, "C"_sr)) == 2000);
 
-	// ASSERT(s.splitEstimate(KeyRangeRef(LiteralStringRef("A"), LiteralStringRef("D")), 3500) ==
-	// LiteralStringRef("Cat"));
+	// ASSERT(s.splitEstimate(KeyRangeRef("A"_sr, "D"_sr), 3500) ==
+	// "Cat"_sr);
 
 	return Void();
 }
@@ -612,18 +612,18 @@ TEST_CASE("/fdbserver/StorageMetricSample/rangeSplitPoints/simple") {
 	int64_t sampleUnit = SERVER_KNOBS->BYTES_READ_UNITS_PER_SAMPLE;
 	StorageServerMetrics ssm;
 
-	ssm.byteSample.sample.insert(LiteralStringRef("A"), 200 * sampleUnit);
-	ssm.byteSample.sample.insert(LiteralStringRef("Absolute"), 800 * sampleUnit);
-	ssm.byteSample.sample.insert(LiteralStringRef("Apple"), 1000 * sampleUnit);
-	ssm.byteSample.sample.insert(LiteralStringRef("Bah"), 20 * sampleUnit);
-	ssm.byteSample.sample.insert(LiteralStringRef("Banana"), 80 * sampleUnit);
-	ssm.byteSample.sample.insert(LiteralStringRef("Bob"), 200 * sampleUnit);
-	ssm.byteSample.sample.insert(LiteralStringRef("But"), 100 * sampleUnit);
-	ssm.byteSample.sample.insert(LiteralStringRef("Cat"), 300 * sampleUnit);
+	ssm.byteSample.sample.insert("A"_sr, 200 * sampleUnit);
+	ssm.byteSample.sample.insert("Absolute"_sr, 800 * sampleUnit);
+	ssm.byteSample.sample.insert("Apple"_sr, 1000 * sampleUnit);
+	ssm.byteSample.sample.insert("Bah"_sr, 20 * sampleUnit);
+	ssm.byteSample.sample.insert("Banana"_sr, 80 * sampleUnit);
+	ssm.byteSample.sample.insert("Bob"_sr, 200 * sampleUnit);
+	ssm.byteSample.sample.insert("But"_sr, 100 * sampleUnit);
+	ssm.byteSample.sample.insert("Cat"_sr, 300 * sampleUnit);
 
-	vector<KeyRef> t = ssm.getSplitPoints(KeyRangeRef(LiteralStringRef("A"), LiteralStringRef("C")), 2000 * sampleUnit);
+	vector<KeyRef> t = ssm.getSplitPoints(KeyRangeRef("A"_sr, "C"_sr), 2000 * sampleUnit);
 
-	ASSERT(t.size() == 1 && t[0] == LiteralStringRef("Bah"));
+	ASSERT(t.size() == 1 && t[0] == "Bah"_sr);
 
 	return Void();
 }
@@ -633,19 +633,18 @@ TEST_CASE("/fdbserver/StorageMetricSample/rangeSplitPoints/multipleReturnedPoint
 	int64_t sampleUnit = SERVER_KNOBS->BYTES_READ_UNITS_PER_SAMPLE;
 	StorageServerMetrics ssm;
 
-	ssm.byteSample.sample.insert(LiteralStringRef("A"), 200 * sampleUnit);
-	ssm.byteSample.sample.insert(LiteralStringRef("Absolute"), 800 * sampleUnit);
-	ssm.byteSample.sample.insert(LiteralStringRef("Apple"), 1000 * sampleUnit);
-	ssm.byteSample.sample.insert(LiteralStringRef("Bah"), 20 * sampleUnit);
-	ssm.byteSample.sample.insert(LiteralStringRef("Banana"), 80 * sampleUnit);
-	ssm.byteSample.sample.insert(LiteralStringRef("Bob"), 200 * sampleUnit);
-	ssm.byteSample.sample.insert(LiteralStringRef("But"), 100 * sampleUnit);
-	ssm.byteSample.sample.insert(LiteralStringRef("Cat"), 300 * sampleUnit);
+	ssm.byteSample.sample.insert("A"_sr, 200 * sampleUnit);
+	ssm.byteSample.sample.insert("Absolute"_sr, 800 * sampleUnit);
+	ssm.byteSample.sample.insert("Apple"_sr, 1000 * sampleUnit);
+	ssm.byteSample.sample.insert("Bah"_sr, 20 * sampleUnit);
+	ssm.byteSample.sample.insert("Banana"_sr, 80 * sampleUnit);
+	ssm.byteSample.sample.insert("Bob"_sr, 200 * sampleUnit);
+	ssm.byteSample.sample.insert("But"_sr, 100 * sampleUnit);
+	ssm.byteSample.sample.insert("Cat"_sr, 300 * sampleUnit);
 
-	vector<KeyRef> t = ssm.getSplitPoints(KeyRangeRef(LiteralStringRef("A"), LiteralStringRef("C")), 600 * sampleUnit);
+	vector<KeyRef> t = ssm.getSplitPoints(KeyRangeRef("A"_sr, "C"_sr), 600 * sampleUnit);
 
-	ASSERT(t.size() == 3 && t[0] == LiteralStringRef("Absolute") && t[1] == LiteralStringRef("Apple") &&
-	       t[2] == LiteralStringRef("Bah"));
+	ASSERT(t.size() == 3 && t[0] == "Absolute"_sr && t[1] == "Apple"_sr && t[2] == "Bah"_sr);
 
 	return Void();
 }
@@ -655,17 +654,16 @@ TEST_CASE("/fdbserver/StorageMetricSample/rangeSplitPoints/noneSplitable") {
 	int64_t sampleUnit = SERVER_KNOBS->BYTES_READ_UNITS_PER_SAMPLE;
 	StorageServerMetrics ssm;
 
-	ssm.byteSample.sample.insert(LiteralStringRef("A"), 200 * sampleUnit);
-	ssm.byteSample.sample.insert(LiteralStringRef("Absolute"), 800 * sampleUnit);
-	ssm.byteSample.sample.insert(LiteralStringRef("Apple"), 1000 * sampleUnit);
-	ssm.byteSample.sample.insert(LiteralStringRef("Bah"), 20 * sampleUnit);
-	ssm.byteSample.sample.insert(LiteralStringRef("Banana"), 80 * sampleUnit);
-	ssm.byteSample.sample.insert(LiteralStringRef("Bob"), 200 * sampleUnit);
-	ssm.byteSample.sample.insert(LiteralStringRef("But"), 100 * sampleUnit);
-	ssm.byteSample.sample.insert(LiteralStringRef("Cat"), 300 * sampleUnit);
+	ssm.byteSample.sample.insert("A"_sr, 200 * sampleUnit);
+	ssm.byteSample.sample.insert("Absolute"_sr, 800 * sampleUnit);
+	ssm.byteSample.sample.insert("Apple"_sr, 1000 * sampleUnit);
+	ssm.byteSample.sample.insert("Bah"_sr, 20 * sampleUnit);
+	ssm.byteSample.sample.insert("Banana"_sr, 80 * sampleUnit);
+	ssm.byteSample.sample.insert("Bob"_sr, 200 * sampleUnit);
+	ssm.byteSample.sample.insert("But"_sr, 100 * sampleUnit);
+	ssm.byteSample.sample.insert("Cat"_sr, 300 * sampleUnit);
 
-	vector<KeyRef> t =
-	    ssm.getSplitPoints(KeyRangeRef(LiteralStringRef("A"), LiteralStringRef("C")), 10000 * sampleUnit);
+	vector<KeyRef> t = ssm.getSplitPoints(KeyRangeRef("A"_sr, "C"_sr), 10000 * sampleUnit);
 
 	ASSERT(t.size() == 0);
 
@@ -677,16 +675,16 @@ TEST_CASE("/fdbserver/StorageMetricSample/rangeSplitPoints/chunkTooLarge") {
 	int64_t sampleUnit = SERVER_KNOBS->BYTES_READ_UNITS_PER_SAMPLE;
 	StorageServerMetrics ssm;
 
-	ssm.byteSample.sample.insert(LiteralStringRef("A"), 20 * sampleUnit);
-	ssm.byteSample.sample.insert(LiteralStringRef("Absolute"), 80 * sampleUnit);
-	ssm.byteSample.sample.insert(LiteralStringRef("Apple"), 10 * sampleUnit);
-	ssm.byteSample.sample.insert(LiteralStringRef("Bah"), 20 * sampleUnit);
-	ssm.byteSample.sample.insert(LiteralStringRef("Banana"), 80 * sampleUnit);
-	ssm.byteSample.sample.insert(LiteralStringRef("Bob"), 20 * sampleUnit);
-	ssm.byteSample.sample.insert(LiteralStringRef("But"), 10 * sampleUnit);
-	ssm.byteSample.sample.insert(LiteralStringRef("Cat"), 30 * sampleUnit);
+	ssm.byteSample.sample.insert("A"_sr, 20 * sampleUnit);
+	ssm.byteSample.sample.insert("Absolute"_sr, 80 * sampleUnit);
+	ssm.byteSample.sample.insert("Apple"_sr, 10 * sampleUnit);
+	ssm.byteSample.sample.insert("Bah"_sr, 20 * sampleUnit);
+	ssm.byteSample.sample.insert("Banana"_sr, 80 * sampleUnit);
+	ssm.byteSample.sample.insert("Bob"_sr, 20 * sampleUnit);
+	ssm.byteSample.sample.insert("But"_sr, 10 * sampleUnit);
+	ssm.byteSample.sample.insert("Cat"_sr, 30 * sampleUnit);
 
-	vector<KeyRef> t = ssm.getSplitPoints(KeyRangeRef(LiteralStringRef("A"), LiteralStringRef("C")), 1000 * sampleUnit);
+	vector<KeyRef> t = ssm.getSplitPoints(KeyRangeRef("A"_sr, "C"_sr), 1000 * sampleUnit);
 
 	ASSERT(t.size() == 0);
 
@@ -698,26 +696,25 @@ TEST_CASE("/fdbserver/StorageMetricSample/readHotDetect/simple") {
 	int64_t sampleUnit = SERVER_KNOBS->BYTES_READ_UNITS_PER_SAMPLE;
 	StorageServerMetrics ssm;
 
-	ssm.bytesReadSample.sample.insert(LiteralStringRef("Apple"), 1000 * sampleUnit);
-	ssm.bytesReadSample.sample.insert(LiteralStringRef("Banana"), 2000 * sampleUnit);
-	ssm.bytesReadSample.sample.insert(LiteralStringRef("Cat"), 1000 * sampleUnit);
-	ssm.bytesReadSample.sample.insert(LiteralStringRef("Cathode"), 1000 * sampleUnit);
-	ssm.bytesReadSample.sample.insert(LiteralStringRef("Dog"), 1000 * sampleUnit);
+	ssm.bytesReadSample.sample.insert("Apple"_sr, 1000 * sampleUnit);
+	ssm.bytesReadSample.sample.insert("Banana"_sr, 2000 * sampleUnit);
+	ssm.bytesReadSample.sample.insert("Cat"_sr, 1000 * sampleUnit);
+	ssm.bytesReadSample.sample.insert("Cathode"_sr, 1000 * sampleUnit);
+	ssm.bytesReadSample.sample.insert("Dog"_sr, 1000 * sampleUnit);
 
-	ssm.byteSample.sample.insert(LiteralStringRef("A"), 20 * sampleUnit);
-	ssm.byteSample.sample.insert(LiteralStringRef("Absolute"), 80 * sampleUnit);
-	ssm.byteSample.sample.insert(LiteralStringRef("Apple"), 1000 * sampleUnit);
-	ssm.byteSample.sample.insert(LiteralStringRef("Bah"), 20 * sampleUnit);
-	ssm.byteSample.sample.insert(LiteralStringRef("Banana"), 80 * sampleUnit);
-	ssm.byteSample.sample.insert(LiteralStringRef("Bob"), 200 * sampleUnit);
-	ssm.byteSample.sample.insert(LiteralStringRef("But"), 100 * sampleUnit);
-	ssm.byteSample.sample.insert(LiteralStringRef("Cat"), 300 * sampleUnit);
+	ssm.byteSample.sample.insert("A"_sr, 20 * sampleUnit);
+	ssm.byteSample.sample.insert("Absolute"_sr, 80 * sampleUnit);
+	ssm.byteSample.sample.insert("Apple"_sr, 1000 * sampleUnit);
+	ssm.byteSample.sample.insert("Bah"_sr, 20 * sampleUnit);
+	ssm.byteSample.sample.insert("Banana"_sr, 80 * sampleUnit);
+	ssm.byteSample.sample.insert("Bob"_sr, 200 * sampleUnit);
+	ssm.byteSample.sample.insert("But"_sr, 100 * sampleUnit);
+	ssm.byteSample.sample.insert("Cat"_sr, 300 * sampleUnit);
 
 	std::vector<ReadHotRangeWithMetrics> t =
-	    ssm.getReadHotRanges(KeyRangeRef(LiteralStringRef("A"), LiteralStringRef("C")), 2.0, 200 * sampleUnit, 0);
+	    ssm.getReadHotRanges(KeyRangeRef("A"_sr, "C"_sr), 2.0, 200 * sampleUnit, 0);
 
-	ASSERT(t.size() == 1 && (*t.begin()).keys.begin == LiteralStringRef("Bah") &&
-	       (*t.begin()).keys.end == LiteralStringRef("Bob"));
+	ASSERT(t.size() == 1 && (*t.begin()).keys.begin == "Bah"_sr && (*t.begin()).keys.end == "Bob"_sr);
 
 	return Void();
 }
@@ -727,29 +724,28 @@ TEST_CASE("/fdbserver/StorageMetricSample/readHotDetect/moreThanOneRange") {
 	int64_t sampleUnit = SERVER_KNOBS->BYTES_READ_UNITS_PER_SAMPLE;
 	StorageServerMetrics ssm;
 
-	ssm.bytesReadSample.sample.insert(LiteralStringRef("Apple"), 1000 * sampleUnit);
-	ssm.bytesReadSample.sample.insert(LiteralStringRef("Banana"), 2000 * sampleUnit);
-	ssm.bytesReadSample.sample.insert(LiteralStringRef("Cat"), 1000 * sampleUnit);
-	ssm.bytesReadSample.sample.insert(LiteralStringRef("Cathode"), 1000 * sampleUnit);
-	ssm.bytesReadSample.sample.insert(LiteralStringRef("Dog"), 1000 * sampleUnit);
-	ssm.bytesReadSample.sample.insert(LiteralStringRef("Final"), 2000 * sampleUnit);
+	ssm.bytesReadSample.sample.insert("Apple"_sr, 1000 * sampleUnit);
+	ssm.bytesReadSample.sample.insert("Banana"_sr, 2000 * sampleUnit);
+	ssm.bytesReadSample.sample.insert("Cat"_sr, 1000 * sampleUnit);
+	ssm.bytesReadSample.sample.insert("Cathode"_sr, 1000 * sampleUnit);
+	ssm.bytesReadSample.sample.insert("Dog"_sr, 1000 * sampleUnit);
+	ssm.bytesReadSample.sample.insert("Final"_sr, 2000 * sampleUnit);
 
-	ssm.byteSample.sample.insert(LiteralStringRef("A"), 20 * sampleUnit);
-	ssm.byteSample.sample.insert(LiteralStringRef("Absolute"), 80 * sampleUnit);
-	ssm.byteSample.sample.insert(LiteralStringRef("Apple"), 1000 * sampleUnit);
-	ssm.byteSample.sample.insert(LiteralStringRef("Bah"), 20 * sampleUnit);
-	ssm.byteSample.sample.insert(LiteralStringRef("Banana"), 80 * sampleUnit);
-	ssm.byteSample.sample.insert(LiteralStringRef("Bob"), 200 * sampleUnit);
-	ssm.byteSample.sample.insert(LiteralStringRef("But"), 100 * sampleUnit);
-	ssm.byteSample.sample.insert(LiteralStringRef("Cat"), 300 * sampleUnit);
-	ssm.byteSample.sample.insert(LiteralStringRef("Dah"), 300 * sampleUnit);
+	ssm.byteSample.sample.insert("A"_sr, 20 * sampleUnit);
+	ssm.byteSample.sample.insert("Absolute"_sr, 80 * sampleUnit);
+	ssm.byteSample.sample.insert("Apple"_sr, 1000 * sampleUnit);
+	ssm.byteSample.sample.insert("Bah"_sr, 20 * sampleUnit);
+	ssm.byteSample.sample.insert("Banana"_sr, 80 * sampleUnit);
+	ssm.byteSample.sample.insert("Bob"_sr, 200 * sampleUnit);
+	ssm.byteSample.sample.insert("But"_sr, 100 * sampleUnit);
+	ssm.byteSample.sample.insert("Cat"_sr, 300 * sampleUnit);
+	ssm.byteSample.sample.insert("Dah"_sr, 300 * sampleUnit);
 
 	std::vector<ReadHotRangeWithMetrics> t =
-	    ssm.getReadHotRanges(KeyRangeRef(LiteralStringRef("A"), LiteralStringRef("D")), 2.0, 200 * sampleUnit, 0);
+	    ssm.getReadHotRanges(KeyRangeRef("A"_sr, "D"_sr), 2.0, 200 * sampleUnit, 0);
 
-	ASSERT(t.size() == 2 && (*t.begin()).keys.begin == LiteralStringRef("Bah") &&
-	       (*t.begin()).keys.end == LiteralStringRef("Bob"));
-	ASSERT(t.at(1).keys.begin == LiteralStringRef("Cat") && t.at(1).keys.end == LiteralStringRef("Dah"));
+	ASSERT(t.size() == 2 && (*t.begin()).keys.begin == "Bah"_sr && (*t.begin()).keys.end == "Bob"_sr);
+	ASSERT(t.at(1).keys.begin == "Cat"_sr && t.at(1).keys.end == "Dah"_sr);
 
 	return Void();
 }
@@ -759,30 +755,29 @@ TEST_CASE("/fdbserver/StorageMetricSample/readHotDetect/consecutiveRanges") {
 	int64_t sampleUnit = SERVER_KNOBS->BYTES_READ_UNITS_PER_SAMPLE;
 	StorageServerMetrics ssm;
 
-	ssm.bytesReadSample.sample.insert(LiteralStringRef("Apple"), 1000 * sampleUnit);
-	ssm.bytesReadSample.sample.insert(LiteralStringRef("Banana"), 2000 * sampleUnit);
-	ssm.bytesReadSample.sample.insert(LiteralStringRef("Bucket"), 2000 * sampleUnit);
-	ssm.bytesReadSample.sample.insert(LiteralStringRef("Cat"), 1000 * sampleUnit);
-	ssm.bytesReadSample.sample.insert(LiteralStringRef("Cathode"), 1000 * sampleUnit);
-	ssm.bytesReadSample.sample.insert(LiteralStringRef("Dog"), 5000 * sampleUnit);
-	ssm.bytesReadSample.sample.insert(LiteralStringRef("Final"), 2000 * sampleUnit);
+	ssm.bytesReadSample.sample.insert("Apple"_sr, 1000 * sampleUnit);
+	ssm.bytesReadSample.sample.insert("Banana"_sr, 2000 * sampleUnit);
+	ssm.bytesReadSample.sample.insert("Bucket"_sr, 2000 * sampleUnit);
+	ssm.bytesReadSample.sample.insert("Cat"_sr, 1000 * sampleUnit);
+	ssm.bytesReadSample.sample.insert("Cathode"_sr, 1000 * sampleUnit);
+	ssm.bytesReadSample.sample.insert("Dog"_sr, 5000 * sampleUnit);
+	ssm.bytesReadSample.sample.insert("Final"_sr, 2000 * sampleUnit);
 
-	ssm.byteSample.sample.insert(LiteralStringRef("A"), 20 * sampleUnit);
-	ssm.byteSample.sample.insert(LiteralStringRef("Absolute"), 80 * sampleUnit);
-	ssm.byteSample.sample.insert(LiteralStringRef("Apple"), 1000 * sampleUnit);
-	ssm.byteSample.sample.insert(LiteralStringRef("Bah"), 20 * sampleUnit);
-	ssm.byteSample.sample.insert(LiteralStringRef("Banana"), 80 * sampleUnit);
-	ssm.byteSample.sample.insert(LiteralStringRef("Bob"), 200 * sampleUnit);
-	ssm.byteSample.sample.insert(LiteralStringRef("But"), 100 * sampleUnit);
-	ssm.byteSample.sample.insert(LiteralStringRef("Cat"), 300 * sampleUnit);
-	ssm.byteSample.sample.insert(LiteralStringRef("Dah"), 300 * sampleUnit);
+	ssm.byteSample.sample.insert("A"_sr, 20 * sampleUnit);
+	ssm.byteSample.sample.insert("Absolute"_sr, 80 * sampleUnit);
+	ssm.byteSample.sample.insert("Apple"_sr, 1000 * sampleUnit);
+	ssm.byteSample.sample.insert("Bah"_sr, 20 * sampleUnit);
+	ssm.byteSample.sample.insert("Banana"_sr, 80 * sampleUnit);
+	ssm.byteSample.sample.insert("Bob"_sr, 200 * sampleUnit);
+	ssm.byteSample.sample.insert("But"_sr, 100 * sampleUnit);
+	ssm.byteSample.sample.insert("Cat"_sr, 300 * sampleUnit);
+	ssm.byteSample.sample.insert("Dah"_sr, 300 * sampleUnit);
 
 	std::vector<ReadHotRangeWithMetrics> t =
-	    ssm.getReadHotRanges(KeyRangeRef(LiteralStringRef("A"), LiteralStringRef("D")), 2.0, 200 * sampleUnit, 0);
+	    ssm.getReadHotRanges(KeyRangeRef("A"_sr, "D"_sr), 2.0, 200 * sampleUnit, 0);
 
-	ASSERT(t.size() == 2 && (*t.begin()).keys.begin == LiteralStringRef("Bah") &&
-	       (*t.begin()).keys.end == LiteralStringRef("But"));
-	ASSERT(t.at(1).keys.begin == LiteralStringRef("Cat") && t.at(1).keys.end == LiteralStringRef("Dah"));
+	ASSERT(t.size() == 2 && (*t.begin()).keys.begin == "Bah"_sr && (*t.begin()).keys.end == "But"_sr);
+	ASSERT(t.at(1).keys.begin == "Cat"_sr && t.at(1).keys.end == "Dah"_sr);
 
 	return Void();
 }

--- a/fdbserver/TLogServer.actor.cpp
+++ b/fdbserver/TLogServer.actor.cpp
@@ -205,30 +205,22 @@ private:
 // Immutable keys
 // persistFormat has been mostly invalidated by TLogVersion, and can probably be removed when
 // 4.6's TLog code is removed.
-static const KeyValueRef persistFormat(LiteralStringRef("Format"), LiteralStringRef("FoundationDB/LogServer/3/0"));
-static const KeyRangeRef persistFormatReadableRange(LiteralStringRef("FoundationDB/LogServer/3/0"),
-                                                    LiteralStringRef("FoundationDB/LogServer/4/0"));
-static const KeyRangeRef persistProtocolVersionKeys(LiteralStringRef("ProtocolVersion/"),
-                                                    LiteralStringRef("ProtocolVersion0"));
-static const KeyRangeRef persistTLogSpillTypeKeys(LiteralStringRef("TLogSpillType/"),
-                                                  LiteralStringRef("TLogSpillType0"));
-static const KeyRangeRef persistRecoveryCountKeys =
-    KeyRangeRef(LiteralStringRef("DbRecoveryCount/"), LiteralStringRef("DbRecoveryCount0"));
+static const KeyValueRef persistFormat("Format"_sr, "FoundationDB/LogServer/3/0"_sr);
+static const KeyRangeRef persistFormatReadableRange("FoundationDB/LogServer/3/0"_sr, "FoundationDB/LogServer/4/0"_sr);
+static const KeyRangeRef persistProtocolVersionKeys("ProtocolVersion/"_sr, "ProtocolVersion0"_sr);
+static const KeyRangeRef persistTLogSpillTypeKeys("TLogSpillType/"_sr, "TLogSpillType0"_sr);
+static const KeyRangeRef persistRecoveryCountKeys = KeyRangeRef("DbRecoveryCount/"_sr, "DbRecoveryCount0"_sr);
 
 // Updated on updatePersistentData()
-static const KeyRangeRef persistCurrentVersionKeys =
-    KeyRangeRef(LiteralStringRef("version/"), LiteralStringRef("version0"));
-static const KeyRangeRef persistKnownCommittedVersionKeys =
-    KeyRangeRef(LiteralStringRef("knownCommitted/"), LiteralStringRef("knownCommitted0"));
-static const KeyRef persistRecoveryLocationKey = KeyRef(LiteralStringRef("recoveryLocation"));
-static const KeyRangeRef persistLocalityKeys =
-    KeyRangeRef(LiteralStringRef("Locality/"), LiteralStringRef("Locality0"));
-static const KeyRangeRef persistLogRouterTagsKeys =
-    KeyRangeRef(LiteralStringRef("LogRouterTags/"), LiteralStringRef("LogRouterTags0"));
-static const KeyRangeRef persistTxsTagsKeys = KeyRangeRef(LiteralStringRef("TxsTags/"), LiteralStringRef("TxsTags0"));
-static const KeyRange persistTagMessagesKeys = prefixRange(LiteralStringRef("TagMsg/"));
-static const KeyRange persistTagMessageRefsKeys = prefixRange(LiteralStringRef("TagMsgRef/"));
-static const KeyRange persistTagPoppedKeys = prefixRange(LiteralStringRef("TagPop/"));
+static const KeyRangeRef persistCurrentVersionKeys = KeyRangeRef("version/"_sr, "version0"_sr);
+static const KeyRangeRef persistKnownCommittedVersionKeys = KeyRangeRef("knownCommitted/"_sr, "knownCommitted0"_sr);
+static const KeyRef persistRecoveryLocationKey = KeyRef("recoveryLocation"_sr);
+static const KeyRangeRef persistLocalityKeys = KeyRangeRef("Locality/"_sr, "Locality0"_sr);
+static const KeyRangeRef persistLogRouterTagsKeys = KeyRangeRef("LogRouterTags/"_sr, "LogRouterTags0"_sr);
+static const KeyRangeRef persistTxsTagsKeys = KeyRangeRef("TxsTags/"_sr, "TxsTags0"_sr);
+static const KeyRange persistTagMessagesKeys = prefixRange("TagMsg/"_sr);
+static const KeyRange persistTagMessageRefsKeys = prefixRange("TagMsgRef/"_sr);
+static const KeyRange persistTagPoppedKeys = prefixRange("TagPop/"_sr);
 
 static Key persistTagMessagesKey(UID id, Tag tag, Version version) {
 	BinaryWriter wr(Unversioned());
@@ -383,9 +375,7 @@ struct TLogData : NonCopyable {
 	    peekMemoryLimiter(SERVER_KNOBS->TLOG_SPILL_REFERENCE_MAX_PEEK_MEMORY_BYTES),
 	    concurrentLogRouterReads(SERVER_KNOBS->CONCURRENT_LOG_ROUTER_READS), ignorePopRequest(false),
 	    ignorePopDeadline(), ignorePopUid(), dataFolder(folder), toBePopped(),
-	    commitLatencyDist(Histogram::getHistogram(LiteralStringRef("tLog"),
-	                                              LiteralStringRef("commit"),
-	                                              Histogram::Unit::microseconds)) {
+	    commitLatencyDist(Histogram::getHistogram("tLog"_sr, "commit"_sr, Histogram::Unit::microseconds)) {
 		cx = openDBOnServer(dbInfo, TaskPriority::DefaultEndpoint, LockAware::True);
 	}
 };
@@ -644,10 +634,10 @@ struct LogData : NonCopyable, public ReferenceCounted<LogData> {
 		          context);
 		addActor.send(traceRole(Role::TRANSACTION_LOG, interf.id()));
 
-		persistentDataVersion.init(LiteralStringRef("TLog.PersistentDataVersion"), cc.id);
-		persistentDataDurableVersion.init(LiteralStringRef("TLog.PersistentDataDurableVersion"), cc.id);
-		version.initMetric(LiteralStringRef("TLog.Version"), cc.id);
-		queueCommittedVersion.initMetric(LiteralStringRef("TLog.QueueCommittedVersion"), cc.id);
+		persistentDataVersion.init("TLog.PersistentDataVersion"_sr, cc.id);
+		persistentDataDurableVersion.init("TLog.PersistentDataDurableVersion"_sr, cc.id);
+		version.initMetric("TLog.Version"_sr, cc.id);
+		queueCommittedVersion.initMetric("TLog.QueueCommittedVersion"_sr, cc.id);
 
 		specialCounter(cc, "Version", [this]() { return this->version.get(); });
 		specialCounter(cc, "QueueCommittedVersion", [this]() { return this->queueCommittedVersion.get(); });
@@ -2787,7 +2777,7 @@ ACTOR Future<Void> restorePersistentState(TLogData* self,
 	}
 
 	if (!fFormat.get().present()) {
-		RangeResult v = wait(self->persistentData->readRange(KeyRangeRef(StringRef(), LiteralStringRef("\xff")), 1));
+		RangeResult v = wait(self->persistentData->readRange(KeyRangeRef(StringRef(), "\xff"_sr), 1));
 		if (!v.size()) {
 			TEST(true); // The DB is completely empty, so it was never initialized.  Delete it.
 			throw worker_removed();
@@ -2801,7 +2791,7 @@ ACTOR Future<Void> restorePersistentState(TLogData* self,
 
 	state std::vector<Future<ErrorOr<Void>>> removed;
 
-	ASSERT(fFormat.get().get() == LiteralStringRef("FoundationDB/LogServer/3/0"));
+	ASSERT(fFormat.get().get() == "FoundationDB/LogServer/3/0"_sr);
 
 	ASSERT(fVers.get().size() == fRecoverCounts.get().size());
 

--- a/fdbserver/VersionedBTree.actor.cpp
+++ b/fdbserver/VersionedBTree.actor.cpp
@@ -1401,24 +1401,24 @@ struct RedwoodMetrics {
 			metrics = {};
 			if (!buildFillPctSketch.isValid() ||
 			    buildFillPctSketch->name() != ("buildFillPct:" + std::to_string(levelCounter))) {
-				buildFillPctSketch = Histogram::getHistogram(LiteralStringRef("buildFillPct"),
+				buildFillPctSketch = Histogram::getHistogram("buildFillPct"_sr,
 				                                             LiteralStringRef(std::to_string(levelCounter).c_str()),
 				                                             Histogram::Unit::percentage);
-				modifyFillPctSketch = Histogram::getHistogram(LiteralStringRef("modifyFillPct"),
+				modifyFillPctSketch = Histogram::getHistogram("modifyFillPct"_sr,
 				                                              LiteralStringRef(std::to_string(levelCounter).c_str()),
 				                                              Histogram::Unit::percentage);
-				buildStoredPctSketch = Histogram::getHistogram(LiteralStringRef("buildStoredPct"),
+				buildStoredPctSketch = Histogram::getHistogram("buildStoredPct"_sr,
 				                                               LiteralStringRef(std::to_string(levelCounter).c_str()),
 				                                               Histogram::Unit::percentage);
-				modifyStoredPctSketch = Histogram::getHistogram(LiteralStringRef("modifyStoredPct"),
+				modifyStoredPctSketch = Histogram::getHistogram("modifyStoredPct"_sr,
 				                                                LiteralStringRef(std::to_string(levelCounter).c_str()),
 				                                                Histogram::Unit::percentage);
-				buildItemCountSketch = Histogram::getHistogram(LiteralStringRef("buildItemCount"),
+				buildItemCountSketch = Histogram::getHistogram("buildItemCount"_sr,
 				                                               LiteralStringRef(std::to_string(levelCounter).c_str()),
 				                                               Histogram::Unit::count,
 				                                               0,
 				                                               maxRecordCount);
-				modifyItemCountSketch = Histogram::getHistogram(LiteralStringRef("modifyItemCount"),
+				modifyItemCountSketch = Histogram::getHistogram("modifyItemCount"_sr,
 				                                                LiteralStringRef(std::to_string(levelCounter).c_str()),
 				                                                Histogram::Unit::count,
 				                                                0,
@@ -1459,12 +1459,9 @@ struct RedwoodMetrics {
 	};
 
 	RedwoodMetrics() {
-		kvSizeWritten =
-		    Histogram::getHistogram(LiteralStringRef("kvSize"), LiteralStringRef("Written"), Histogram::Unit::bytes);
-		kvSizeReadByGet =
-		    Histogram::getHistogram(LiteralStringRef("kvSize"), LiteralStringRef("ReadByGet "), Histogram::Unit::bytes);
-		kvSizeReadByRangeGet = Histogram::getHistogram(
-		    LiteralStringRef("kvSize"), LiteralStringRef("ReadByRangeGet"), Histogram::Unit::bytes);
+		kvSizeWritten = Histogram::getHistogram("kvSize"_sr, "Written"_sr, Histogram::Unit::bytes);
+		kvSizeReadByGet = Histogram::getHistogram("kvSize"_sr, "ReadByGet "_sr, Histogram::Unit::bytes);
+		kvSizeReadByRangeGet = Histogram::getHistogram("kvSize"_sr, "ReadByRangeGet"_sr, Histogram::Unit::bytes);
 		clear();
 	}
 
@@ -6767,8 +6764,8 @@ public:
 
 #include "fdbserver/art_impl.h"
 
-RedwoodRecordRef VersionedBTree::dbBegin(LiteralStringRef(""));
-RedwoodRecordRef VersionedBTree::dbEnd(LiteralStringRef("\xff\xff\xff\xff\xff"));
+RedwoodRecordRef VersionedBTree::dbBegin(""_sr);
+RedwoodRecordRef VersionedBTree::dbEnd("\xff\xff\xff\xff\xff"_sr);
 
 class KeyValueStoreRedwoodUnversioned : public IKeyValueStore {
 public:
@@ -7373,8 +7370,7 @@ ACTOR Future<Void> verify(VersionedBTree* btree,
 			wait(btree->initBTreeCursor(&cur, v));
 
 			debug_printf("Verifying entire key range at version %" PRId64 "\n", v);
-			state Future<int> fRangeAll = verifyRangeBTreeCursor(
-			    btree, LiteralStringRef(""), LiteralStringRef("\xff\xff"), v, written, pErrorCount);
+			state Future<int> fRangeAll = verifyRangeBTreeCursor(btree, ""_sr, "\xff\xff"_sr, v, written, pErrorCount);
 			if (serial) {
 				wait(success(fRangeAll));
 			}
@@ -7582,35 +7578,26 @@ TEST_CASE("/redwood/correctness/unit/RedwoodRecordRef") {
 		ASSERT(r2.getChildPage().begin() != id.begin());
 	}
 
-	deltaTest(RedwoodRecordRef(LiteralStringRef(""), LiteralStringRef("")),
-	          RedwoodRecordRef(LiteralStringRef(""), LiteralStringRef("")));
+	deltaTest(RedwoodRecordRef(""_sr, ""_sr), RedwoodRecordRef(""_sr, ""_sr));
 
-	deltaTest(RedwoodRecordRef(LiteralStringRef("abc"), LiteralStringRef("")),
-	          RedwoodRecordRef(LiteralStringRef("abc"), LiteralStringRef("")));
+	deltaTest(RedwoodRecordRef("abc"_sr, ""_sr), RedwoodRecordRef("abc"_sr, ""_sr));
 
-	deltaTest(RedwoodRecordRef(LiteralStringRef("abc"), LiteralStringRef("")),
-	          RedwoodRecordRef(LiteralStringRef("abcd"), LiteralStringRef("")));
+	deltaTest(RedwoodRecordRef("abc"_sr, ""_sr), RedwoodRecordRef("abcd"_sr, ""_sr));
 
-	deltaTest(RedwoodRecordRef(LiteralStringRef("abcd"), LiteralStringRef("")),
-	          RedwoodRecordRef(LiteralStringRef("abc"), LiteralStringRef("")));
+	deltaTest(RedwoodRecordRef("abcd"_sr, ""_sr), RedwoodRecordRef("abc"_sr, ""_sr));
 
 	deltaTest(RedwoodRecordRef(std::string(300, 'k'), std::string(1e6, 'v')),
-	          RedwoodRecordRef(std::string(300, 'k'), LiteralStringRef("")));
+	          RedwoodRecordRef(std::string(300, 'k'), ""_sr));
 
-	deltaTest(RedwoodRecordRef(LiteralStringRef(""), LiteralStringRef("")),
-	          RedwoodRecordRef(LiteralStringRef(""), LiteralStringRef("")));
+	deltaTest(RedwoodRecordRef(""_sr, ""_sr), RedwoodRecordRef(""_sr, ""_sr));
 
-	deltaTest(RedwoodRecordRef(LiteralStringRef(""), LiteralStringRef("")),
-	          RedwoodRecordRef(LiteralStringRef(""), LiteralStringRef("")));
+	deltaTest(RedwoodRecordRef(""_sr, ""_sr), RedwoodRecordRef(""_sr, ""_sr));
 
-	deltaTest(RedwoodRecordRef(LiteralStringRef(""), LiteralStringRef("")),
-	          RedwoodRecordRef(LiteralStringRef(""), LiteralStringRef("")));
+	deltaTest(RedwoodRecordRef(""_sr, ""_sr), RedwoodRecordRef(""_sr, ""_sr));
 
-	deltaTest(RedwoodRecordRef(LiteralStringRef(""), LiteralStringRef("")),
-	          RedwoodRecordRef(LiteralStringRef(""), LiteralStringRef("")));
+	deltaTest(RedwoodRecordRef(""_sr, ""_sr), RedwoodRecordRef(""_sr, ""_sr));
 
-	deltaTest(RedwoodRecordRef(LiteralStringRef(""), LiteralStringRef("")),
-	          RedwoodRecordRef(LiteralStringRef(""), LiteralStringRef("")));
+	deltaTest(RedwoodRecordRef(""_sr, ""_sr), RedwoodRecordRef(""_sr, ""_sr));
 
 	Arena mem;
 	double start;
@@ -7647,8 +7634,8 @@ TEST_CASE("/redwood/correctness/unit/RedwoodRecordRef") {
 	RedwoodRecordRef rec1;
 	RedwoodRecordRef rec2;
 
-	rec1.key = LiteralStringRef("alksdfjaklsdfjlkasdjflkasdjfklajsdflk;ajsdflkajdsflkjadsf1");
-	rec2.key = LiteralStringRef("alksdfjaklsdfjlkasdjflkasdjfklajsdflk;ajsdflkajdsflkjadsf234");
+	rec1.key = "alksdfjaklsdfjlkasdjflkasdjfklajsdflk;ajsdflkajdsflkjadsf1"_sr;
+	rec2.key = "alksdfjaklsdfjlkasdjflkasdjfklajsdflk;ajsdflkajdsflkjadsf234"_sr;
 
 	start = timer();
 	total = 0;
@@ -7714,7 +7701,7 @@ TEST_CASE("/redwood/correctness/unit/deltaTree/RedwoodRecordRef") {
 	const int N = deterministicRandom()->randomInt(200, 1000);
 
 	RedwoodRecordRef prev;
-	RedwoodRecordRef next(LiteralStringRef("\xff\xff\xff\xff"));
+	RedwoodRecordRef next("\xff\xff\xff\xff"_sr);
 
 	Arena arena;
 	std::set<RedwoodRecordRef> uniqueItems;
@@ -7891,7 +7878,7 @@ TEST_CASE("/redwood/correctness/unit/deltaTree/RedwoodRecordRef2") {
 	const int N = deterministicRandom()->randomInt(200, 1000);
 
 	RedwoodRecordRef prev;
-	RedwoodRecordRef next(LiteralStringRef("\xff\xff\xff\xff"));
+	RedwoodRecordRef next("\xff\xff\xff\xff"_sr);
 
 	Arena arena;
 	std::set<RedwoodRecordRef> uniqueItems;
@@ -9068,7 +9055,7 @@ TEST_CASE(":/redwood/correctness/pager/cow") {
 	Reference<ArenaPage> p = pager->newPageBuffer();
 	memset(p->mutate(), (char)id, p->size());
 	pager->updatePage(PagerEventReasons::MetaData, nonBtreeLevel, id, p);
-	pager->setMetaKey(LiteralStringRef("asdfasdf"));
+	pager->setMetaKey("asdfasdf"_sr);
 	wait(pager->commit());
 	Reference<ArenaPage> p2 = wait(pager->readPage(PagerEventReasons::PointRead, nonBtreeLevel, id, true));
 	printf("%s\n", StringRef(p2->begin(), p2->size()).toHexString().c_str());
@@ -9689,7 +9676,7 @@ ACTOR Future<Void> prefixClusteredInsert(IKeyValueStore* kvs,
 	if (clearAfter) {
 		printf("Clearing all keys\n");
 		intervalStart = timer();
-		kvs->clear(KeyRangeRef(LiteralStringRef(""), LiteralStringRef("\xff")));
+		kvs->clear(KeyRangeRef(""_sr, "\xff"_sr));
 		state StorageBytes sbClear = wait(getStableStorageBytes(kvs));
 		printf("Cleared all keys in %.2f seconds, final storageByte: %s\n",
 		       timer() - intervalStart,
@@ -9931,8 +9918,7 @@ TEST_CASE(":/redwood/performance/histogramThroughput") {
 	{
 		std::cout << "Histogram Unit bytes" << std::endl;
 		auto t_start = std::chrono::high_resolution_clock::now();
-		Reference<Histogram> h = Histogram::getHistogram(
-		    LiteralStringRef("histogramTest"), LiteralStringRef("counts"), Histogram::Unit::bytes);
+		Reference<Histogram> h = Histogram::getHistogram("histogramTest"_sr, "counts"_sr, Histogram::Unit::bytes);
 		ASSERT(uniform.size() == inputSize);
 		for (size_t i = 0; i < uniform.size(); i++) {
 			h->sample(uniform[i]);
@@ -9942,16 +9928,14 @@ TEST_CASE(":/redwood/performance/histogramThroughput") {
 		double elapsed_time_ms = std::chrono::duration<double, std::milli>(t_end - t_start).count();
 		std::cout << "Time in millisecond: " << elapsed_time_ms << std::endl;
 
-		Reference<Histogram> hCopy = Histogram::getHistogram(
-		    LiteralStringRef("histogramTest"), LiteralStringRef("counts"), Histogram::Unit::bytes);
+		Reference<Histogram> hCopy = Histogram::getHistogram("histogramTest"_sr, "counts"_sr, Histogram::Unit::bytes);
 		std::cout << hCopy->drawHistogram();
 		GetHistogramRegistry().logReport();
 	}
 	{
 		std::cout << "Histogram Unit percentage: " << std::endl;
 		auto t_start = std::chrono::high_resolution_clock::now();
-		Reference<Histogram> h = Histogram::getHistogram(
-		    LiteralStringRef("histogramTest"), LiteralStringRef("counts"), Histogram::Unit::percentage);
+		Reference<Histogram> h = Histogram::getHistogram("histogramTest"_sr, "counts"_sr, Histogram::Unit::percentage);
 		ASSERT(uniform.size() == inputSize);
 		for (size_t i = 0; i < uniform.size(); i++) {
 			h->samplePercentage((double)uniform[i] / UINT32_MAX);

--- a/fdbserver/fdbserver.actor.cpp
+++ b/fdbserver/fdbserver.actor.cpp
@@ -348,12 +348,10 @@ void testSerializationSpeed() {
 				CommitTransactionRef& tr = batch[t];
 				tr.read_snapshot = 0;
 				for (int i = 0; i < 2; i++)
-					tr.mutations.push_back_deep(
-					    batchArena,
-					    MutationRef(MutationRef::SetValue, LiteralStringRef("KeyABCDE"), LiteralStringRef("SomeValu")));
-				tr.mutations.push_back_deep(
-				    batchArena,
-				    MutationRef(MutationRef::ClearRange, LiteralStringRef("BeginKey"), LiteralStringRef("EndKeyAB")));
+					tr.mutations.push_back_deep(batchArena,
+					                            MutationRef(MutationRef::SetValue, "KeyABCDE"_sr, "SomeValu"_sr));
+				tr.mutations.push_back_deep(batchArena,
+				                            MutationRef(MutationRef::ClearRange, "BeginKey"_sr, "EndKeyAB"_sr));
 			}
 
 			build += timer() - tstart;
@@ -812,7 +810,7 @@ std::pair<NetworkAddressList, NetworkAddressList> buildNetworkAddresses(const Cl
 
 	for (int ii = 0; ii < publicAddressStrs.size(); ++ii) {
 		const std::string& publicAddressStr = publicAddressStrs[ii];
-		bool autoPublicAddress = StringRef(publicAddressStr).startsWith(LiteralStringRef("auto:"));
+		bool autoPublicAddress = StringRef(publicAddressStr).startsWith("auto:"_sr);
 		NetworkAddress currentPublicAddress;
 		if (autoPublicAddress) {
 			try {
@@ -1051,7 +1049,7 @@ private:
 				break;
 			case OPT_KNOB: {
 				std::string syn = args.OptionSyntax();
-				if (!StringRef(syn).startsWith(LiteralStringRef("--knob_"))) {
+				if (!StringRef(syn).startsWith("--knob_"_sr)) {
 					fprintf(stderr, "ERROR: unable to parse knob option '%s'\n", syn.c_str());
 					flushAndExit(FDB_EXIT_ERROR);
 				}
@@ -1062,7 +1060,7 @@ private:
 			}
 			case OPT_UNITTESTPARAM: {
 				std::string syn = args.OptionSyntax();
-				if (!StringRef(syn).startsWith(LiteralStringRef("--test_"))) {
+				if (!StringRef(syn).startsWith("--test_"_sr)) {
 					fprintf(stderr, "ERROR: unable to parse knob option '%s'\n", syn.c_str());
 					flushAndExit(FDB_EXIT_ERROR);
 				}
@@ -1071,7 +1069,7 @@ private:
 			}
 			case OPT_LOCALITY: {
 				std::string syn = args.OptionSyntax();
-				if (!StringRef(syn).startsWith(LiteralStringRef("--locality_"))) {
+				if (!StringRef(syn).startsWith("--locality_"_sr)) {
 					fprintf(stderr, "ERROR: unable to parse locality key '%s'\n", syn.c_str());
 					flushAndExit(FDB_EXIT_ERROR);
 				}
@@ -1491,7 +1489,7 @@ private:
 
 		bool autoPublicAddress =
 		    std::any_of(publicAddressStrs.begin(), publicAddressStrs.end(), [](const std::string& addr) {
-			    return StringRef(addr).startsWith(LiteralStringRef("auto:"));
+			    return StringRef(addr).startsWith("auto:"_sr);
 		    });
 		if ((role != ServerRole::Simulation && role != ServerRole::CreateTemplateDatabase &&
 		     role != ServerRole::KVFileIntegrityCheck && role != ServerRole::KVFileGenerateIOLogChecksums &&
@@ -2133,19 +2131,19 @@ int main(int argc, char* argv[]) {
 				char* demangled = abi::__cxa_demangle(i->first, nullptr, nullptr, nullptr);
 				if (demangled) {
 					s = demangled;
-					if (StringRef(s).startsWith(LiteralStringRef("(anonymous namespace)::")))
-						s = s.substr(LiteralStringRef("(anonymous namespace)::").size());
+					if (StringRef(s).startsWith("(anonymous namespace)::"_sr))
+						s = s.substr("(anonymous namespace)::"_sr.size());
 					free(demangled);
 				} else
 					s = i->first;
 #else
 				s = i->first;
-				if (StringRef(s).startsWith(LiteralStringRef("class `anonymous namespace'::")))
-					s = s.substr(LiteralStringRef("class `anonymous namespace'::").size());
-				else if (StringRef(s).startsWith(LiteralStringRef("class ")))
-					s = s.substr(LiteralStringRef("class ").size());
-				else if (StringRef(s).startsWith(LiteralStringRef("struct ")))
-					s = s.substr(LiteralStringRef("struct ").size());
+				if (StringRef(s).startsWith("class `anonymous namespace'::"_sr))
+					s = s.substr("class `anonymous namespace'::"_sr.size());
+				else if (StringRef(s).startsWith("class "_sr))
+					s = s.substr("class "_sr.size());
+				else if (StringRef(s).startsWith("struct "_sr))
+					s = s.substr("struct "_sr.size());
 #endif
 
 				typeNames.emplace_back(s, i->first);

--- a/fdbserver/masterserver.actor.cpp
+++ b/fdbserver/masterserver.actor.cpp
@@ -1014,7 +1014,7 @@ void updateConfigForForcedRecovery(Reference<MasterData> self,
 	Standalone<CommitTransactionRef> regionCommit;
 	regionCommit.mutations.push_back_deep(
 	    regionCommit.arena(),
-	    MutationRef(MutationRef::SetValue, configKeysPrefix.toString() + "usable_regions", LiteralStringRef("1")));
+	    MutationRef(MutationRef::SetValue, configKeysPrefix.toString() + "usable_regions", "1"_sr));
 	self->configuration.applyMutation(regionCommit.mutations.back());
 	if (regionsChanged) {
 		std::sort(
@@ -1997,8 +1997,8 @@ ACTOR Future<Void> masterServer(MasterInterface mi,
 
 	state Future<Void> onDBChange = Void();
 	state PromiseStream<Future<Void>> addActor;
-	state Reference<MasterData> self(new MasterData(
-	    db, mi, coordinators, db->get().clusterInterface, LiteralStringRef(""), addActor, forceRecovery));
+	state Reference<MasterData> self(
+	    new MasterData(db, mi, coordinators, db->get().clusterInterface, ""_sr, addActor, forceRecovery));
 	state Future<Void> collection = actorCollection(self->addActor.getFuture());
 	self->addActor.send(traceRole(Role::MASTER, mi.id()));
 

--- a/fdbserver/pubsub.actor.cpp
+++ b/fdbserver/pubsub.actor.cpp
@@ -89,7 +89,7 @@ Key keyForFeedWatcher(uint64_t feed, uint64_t inbox) {
 	return StringRef(format("f/%016llx/watchers/%016llx", feed, inbox));
 }
 
-Standalone<StringRef> messagePrefix(LiteralStringRef("m/"));
+Standalone<StringRef> messagePrefix("m/"_sr);
 
 Key keyForMessage(uint64_t message) {
 	return StringRef(format("m/%016llx", message));

--- a/fdbserver/tester.actor.cpp
+++ b/fdbserver/tester.actor.cpp
@@ -139,7 +139,7 @@ Value getOption(VectorRef<KeyValueRef> options, Key key, Value defaultValue) {
 	for (int i = 0; i < options.size(); i++)
 		if (options[i].key == key) {
 			Value value = options[i].value;
-			options[i].value = LiteralStringRef("");
+			options[i].value = ""_sr;
 			return value;
 		}
 
@@ -151,7 +151,7 @@ int getOption(VectorRef<KeyValueRef> options, Key key, int defaultValue) {
 		if (options[i].key == key) {
 			int r;
 			if (sscanf(options[i].value.toString().c_str(), "%d", &r)) {
-				options[i].value = LiteralStringRef("");
+				options[i].value = ""_sr;
 				return r;
 			} else {
 				TraceEvent(SevError, "InvalidTestOption").detail("OptionName", key);
@@ -167,7 +167,7 @@ uint64_t getOption(VectorRef<KeyValueRef> options, Key key, uint64_t defaultValu
 		if (options[i].key == key) {
 			uint64_t r;
 			if (sscanf(options[i].value.toString().c_str(), "%" SCNd64, &r)) {
-				options[i].value = LiteralStringRef("");
+				options[i].value = ""_sr;
 				return r;
 			} else {
 				TraceEvent(SevError, "InvalidTestOption").detail("OptionName", key);
@@ -183,7 +183,7 @@ int64_t getOption(VectorRef<KeyValueRef> options, Key key, int64_t defaultValue)
 		if (options[i].key == key) {
 			int64_t r;
 			if (sscanf(options[i].value.toString().c_str(), "%" SCNd64, &r)) {
-				options[i].value = LiteralStringRef("");
+				options[i].value = ""_sr;
 				return r;
 			} else {
 				TraceEvent(SevError, "InvalidTestOption").detail("OptionName", key);
@@ -199,7 +199,7 @@ double getOption(VectorRef<KeyValueRef> options, Key key, double defaultValue) {
 		if (options[i].key == key) {
 			float r;
 			if (sscanf(options[i].value.toString().c_str(), "%f", &r)) {
-				options[i].value = LiteralStringRef("");
+				options[i].value = ""_sr;
 				return r;
 			}
 		}
@@ -208,10 +208,10 @@ double getOption(VectorRef<KeyValueRef> options, Key key, double defaultValue) {
 }
 
 bool getOption(VectorRef<KeyValueRef> options, Key key, bool defaultValue) {
-	Value p = getOption(options, key, defaultValue ? LiteralStringRef("true") : LiteralStringRef("false"));
-	if (p == LiteralStringRef("true"))
+	Value p = getOption(options, key, defaultValue ? "true"_sr : "false"_sr);
+	if (p == "true"_sr)
 		return true;
-	if (p == LiteralStringRef("false"))
+	if (p == "false"_sr)
 		return false;
 	ASSERT(false);
 	return false; // Assure that compiler is fine with the function
@@ -228,7 +228,7 @@ vector<std::string> getOption(VectorRef<KeyValueRef> options, Key key, vector<st
 					begin = c + 1;
 				}
 			v.push_back(options[i].value.substr(begin).toString());
-			options[i].value = LiteralStringRef("");
+			options[i].value = ""_sr;
 			return v;
 		}
 	return defaultValue;
@@ -245,7 +245,7 @@ bool hasOption(VectorRef<KeyValueRef> options, Key key) {
 
 // returns unconsumed options
 Standalone<VectorRef<KeyValueRef>> checkAllOptionsConsumed(VectorRef<KeyValueRef> options) {
-	static StringRef nothing = LiteralStringRef("");
+	static StringRef nothing = ""_sr;
 	Standalone<VectorRef<KeyValueRef>> unconsumed;
 	for (int i = 0; i < options.size(); i++)
 		if (!(options[i].value == nothing)) {
@@ -316,7 +316,7 @@ struct CompoundWorkload : TestWorkload {
 TestWorkload* getWorkloadIface(WorkloadRequest work,
                                VectorRef<KeyValueRef> options,
                                Reference<AsyncVar<ServerDBInfo>> dbInfo) {
-	Value testName = getOption(options, LiteralStringRef("testName"), LiteralStringRef("no-test-specified"));
+	Value testName = getOption(options, "testName"_sr, "no-test-specified"_sr);
 	WorkloadContext wcx;
 	wcx.clientId = work.clientId;
 	wcx.clientCount = work.clientCount;
@@ -863,10 +863,9 @@ ACTOR Future<DistributedTestResults> runWorkload(Database cx, std::vector<Tester
 ACTOR Future<Void> changeConfiguration(Database cx, std::vector<TesterInterface> testers, StringRef configMode) {
 	state TestSpec spec;
 	Standalone<VectorRef<KeyValueRef>> options;
-	spec.title = LiteralStringRef("ChangeConfig");
-	options.push_back_deep(options.arena(),
-	                       KeyValueRef(LiteralStringRef("testName"), LiteralStringRef("ChangeConfig")));
-	options.push_back_deep(options.arena(), KeyValueRef(LiteralStringRef("configMode"), configMode));
+	spec.title = "ChangeConfig"_sr;
+	options.push_back_deep(options.arena(), KeyValueRef("testName"_sr, "ChangeConfig"_sr));
+	options.push_back_deep(options.arena(), KeyValueRef("configMode"_sr, configMode));
 	spec.options.push_back_deep(spec.options.arena(), options);
 
 	DistributedTestResults testResults = wait(runWorkload(cx, testers, spec));
@@ -894,31 +893,30 @@ ACTOR Future<Void> checkConsistency(Database cx,
 	}
 
 	Standalone<VectorRef<KeyValueRef>> options;
-	StringRef performQuiescent = LiteralStringRef("false");
-	StringRef performCacheCheck = LiteralStringRef("false");
-	StringRef performTSSCheck = LiteralStringRef("false");
+	StringRef performQuiescent = "false"_sr;
+	StringRef performCacheCheck = "false"_sr;
+	StringRef performTSSCheck = "false"_sr;
 	if (doQuiescentCheck) {
-		performQuiescent = LiteralStringRef("true");
+		performQuiescent = "true"_sr;
 		spec.restorePerpetualWiggleSetting = false;
 	}
 	if (doCacheCheck) {
-		performCacheCheck = LiteralStringRef("true");
+		performCacheCheck = "true"_sr;
 	}
 	if (doTSSCheck) {
-		performTSSCheck = LiteralStringRef("true");
+		performTSSCheck = "true"_sr;
 	}
-	spec.title = LiteralStringRef("ConsistencyCheck");
+	spec.title = "ConsistencyCheck"_sr;
 	spec.databasePingDelay = databasePingDelay;
 	spec.timeout = 32000;
-	options.push_back_deep(options.arena(),
-	                       KeyValueRef(LiteralStringRef("testName"), LiteralStringRef("ConsistencyCheck")));
-	options.push_back_deep(options.arena(), KeyValueRef(LiteralStringRef("performQuiescentChecks"), performQuiescent));
-	options.push_back_deep(options.arena(), KeyValueRef(LiteralStringRef("performCacheCheck"), performCacheCheck));
-	options.push_back_deep(options.arena(), KeyValueRef(LiteralStringRef("performTSSCheck"), performTSSCheck));
-	options.push_back_deep(options.arena(),
-	                       KeyValueRef(LiteralStringRef("quiescentWaitTimeout"),
-	                                   ValueRef(options.arena(), format("%f", quiescentWaitTimeout))));
-	options.push_back_deep(options.arena(), KeyValueRef(LiteralStringRef("distributed"), LiteralStringRef("false")));
+	options.push_back_deep(options.arena(), KeyValueRef("testName"_sr, "ConsistencyCheck"_sr));
+	options.push_back_deep(options.arena(), KeyValueRef("performQuiescentChecks"_sr, performQuiescent));
+	options.push_back_deep(options.arena(), KeyValueRef("performCacheCheck"_sr, performCacheCheck));
+	options.push_back_deep(options.arena(), KeyValueRef("performTSSCheck"_sr, performTSSCheck));
+	options.push_back_deep(
+	    options.arena(),
+	    KeyValueRef("quiescentWaitTimeout"_sr, ValueRef(options.arena(), format("%f", quiescentWaitTimeout))));
+	options.push_back_deep(options.arena(), KeyValueRef("distributed"_sr, "false"_sr));
 	spec.options.push_back_deep(spec.options.arena(), options);
 
 	state double start = now();
@@ -932,8 +930,7 @@ ACTOR Future<Void> checkConsistency(Database cx,
 			return Void();
 		}
 		if (now() - start > softTimeLimit) {
-			spec.options[0].push_back_deep(spec.options.arena(),
-			                               KeyValueRef(LiteralStringRef("failureIsError"), LiteralStringRef("true")));
+			spec.options[0].push_back_deep(spec.options.arena(), KeyValueRef("failureIsError"_sr, "true"_sr));
 			lastRun = true;
 		}
 
@@ -1425,7 +1422,7 @@ ACTOR Future<Void> runTests(Reference<AsyncVar<Optional<struct ClusterController
 		if (iter->simDrAgents != ISimulator::BackupAgentType::NoBackupAgents) {
 			simDrAgents = iter->simDrAgents;
 		}
-		enableDD = enableDD || getOption(iter->options[0], LiteralStringRef("enableDD"), false);
+		enableDD = enableDD || getOption(iter->options[0], "enableDD"_sr, false);
 	}
 
 	if (g_network->isSimulated()) {
@@ -1620,36 +1617,30 @@ ACTOR Future<Void> runTests(Reference<ClusterConnectionFile> connFile,
 	if (whatToRun == TEST_TYPE_CONSISTENCY_CHECK) {
 		TestSpec spec;
 		Standalone<VectorRef<KeyValueRef>> options;
-		spec.title = LiteralStringRef("ConsistencyCheck");
+		spec.title = "ConsistencyCheck"_sr;
 		spec.databasePingDelay = 0;
 		spec.timeout = 0;
 		spec.waitForQuiescenceBegin = false;
 		spec.waitForQuiescenceEnd = false;
 		std::string rateLimitMax = format("%d", CLIENT_KNOBS->CONSISTENCY_CHECK_RATE_LIMIT_MAX);
-		options.push_back_deep(options.arena(),
-		                       KeyValueRef(LiteralStringRef("testName"), LiteralStringRef("ConsistencyCheck")));
-		options.push_back_deep(options.arena(),
-		                       KeyValueRef(LiteralStringRef("performQuiescentChecks"), LiteralStringRef("false")));
-		options.push_back_deep(options.arena(),
-		                       KeyValueRef(LiteralStringRef("distributed"), LiteralStringRef("false")));
-		options.push_back_deep(options.arena(),
-		                       KeyValueRef(LiteralStringRef("failureIsError"), LiteralStringRef("true")));
-		options.push_back_deep(options.arena(), KeyValueRef(LiteralStringRef("indefinite"), LiteralStringRef("true")));
-		options.push_back_deep(options.arena(), KeyValueRef(LiteralStringRef("rateLimitMax"), StringRef(rateLimitMax)));
-		options.push_back_deep(options.arena(),
-		                       KeyValueRef(LiteralStringRef("shuffleShards"), LiteralStringRef("true")));
+		options.push_back_deep(options.arena(), KeyValueRef("testName"_sr, "ConsistencyCheck"_sr));
+		options.push_back_deep(options.arena(), KeyValueRef("performQuiescentChecks"_sr, "false"_sr));
+		options.push_back_deep(options.arena(), KeyValueRef("distributed"_sr, "false"_sr));
+		options.push_back_deep(options.arena(), KeyValueRef("failureIsError"_sr, "true"_sr));
+		options.push_back_deep(options.arena(), KeyValueRef("indefinite"_sr, "true"_sr));
+		options.push_back_deep(options.arena(), KeyValueRef("rateLimitMax"_sr, StringRef(rateLimitMax)));
+		options.push_back_deep(options.arena(), KeyValueRef("shuffleShards"_sr, "true"_sr));
 		spec.options.push_back_deep(spec.options.arena(), options);
 		testSpecs.push_back(spec);
 	} else if (whatToRun == TEST_TYPE_UNIT_TESTS) {
 		TestSpec spec;
 		Standalone<VectorRef<KeyValueRef>> options;
-		spec.title = LiteralStringRef("UnitTests");
+		spec.title = "UnitTests"_sr;
 		spec.startDelay = 0;
 		spec.useDB = false;
 		spec.timeout = 0;
-		options.push_back_deep(options.arena(),
-		                       KeyValueRef(LiteralStringRef("testName"), LiteralStringRef("UnitTests")));
-		options.push_back_deep(options.arena(), KeyValueRef(LiteralStringRef("testsMatching"), fileName));
+		options.push_back_deep(options.arena(), KeyValueRef("testName"_sr, "UnitTests"_sr));
+		options.push_back_deep(options.arena(), KeyValueRef("testsMatching"_sr, fileName));
 		// Add unit test options as test spec options
 		for (auto& kv : testOptions.params) {
 			options.push_back_deep(options.arena(), KeyValueRef(kv.first, kv.second));

--- a/fdbserver/worker.actor.cpp
+++ b/fdbserver/worker.actor.cpp
@@ -269,18 +269,18 @@ ACTOR Future<Void> loadedPonger(FutureStream<LoadedPingRequest> pings) {
 	loop {
 		LoadedPingRequest pong = waitNext(pings);
 		LoadedReply rep;
-		rep.payload = (pong.loadReply ? payloadBack : LiteralStringRef(""));
+		rep.payload = (pong.loadReply ? payloadBack : ""_sr);
 		rep.id = pong.id;
 		pong.reply.send(rep);
 	}
 }
 
-StringRef fileStoragePrefix = LiteralStringRef("storage-");
-StringRef testingStoragePrefix = LiteralStringRef("testingstorage-");
-StringRef fileLogDataPrefix = LiteralStringRef("log-");
-StringRef fileVersionedLogDataPrefix = LiteralStringRef("log2-");
-StringRef fileLogQueuePrefix = LiteralStringRef("logqueue-");
-StringRef tlogQueueExtension = LiteralStringRef("fdq");
+StringRef fileStoragePrefix = "storage-"_sr;
+StringRef testingStoragePrefix = "testingstorage-"_sr;
+StringRef fileLogDataPrefix = "log-"_sr;
+StringRef fileVersionedLogDataPrefix = "log2-"_sr;
+StringRef fileLogQueuePrefix = "logqueue-"_sr;
+StringRef tlogQueueExtension = "fdq"_sr;
 
 enum class FilesystemCheck {
 	FILES_ONLY,
@@ -350,12 +350,12 @@ struct TLogOptions {
 			if (key.size() != 0 && value.size() == 0)
 				return default_error_or();
 
-			if (key == LiteralStringRef("V")) {
+			if (key == "V"_sr) {
 				ErrorOr<TLogVersion> tLogVersion = TLogVersion::FromStringRef(value);
 				if (tLogVersion.isError())
 					return tLogVersion.getError();
 				options.version = tLogVersion.get();
-			} else if (key == LiteralStringRef("LS")) {
+			} else if (key == "LS"_sr) {
 				ErrorOr<TLogSpillType> tLogSpillType = TLogSpillType::FromStringRef(value);
 				if (tLogSpillType.isError())
 					return tLogSpillType.getError();
@@ -535,7 +535,7 @@ ACTOR Future<Void> registrationClient(Reference<AsyncVar<Optional<ClusterControl
 		}
 		ClusterConnectionString fileConnectionString;
 		if (connFile && !connFile->fileContentsUpToDate(fileConnectionString)) {
-			request.issues.push_back_deep(request.issues.arena(), LiteralStringRef("incorrect_cluster_file_contents"));
+			request.issues.push_back_deep(request.issues.arena(), "incorrect_cluster_file_contents"_sr);
 			std::string connectionString = connFile->getConnectionString().toString();
 			if (!incorrectTime.present()) {
 				incorrectTime = now();
@@ -643,7 +643,7 @@ TEST_CASE("/fdbserver/worker/addressInDbAndPrimaryDc") {
 	// Setup a ServerDBInfo for test.
 	ServerDBInfo testDbInfo;
 	LocalityData testLocal;
-	testLocal.set(LiteralStringRef("dcid"), StringRef(std::to_string(1)));
+	testLocal.set("dcid"_sr, StringRef(std::to_string(1)));
 	testDbInfo.master.locality = testLocal;
 
 	// Manually set up a master address.
@@ -654,7 +654,7 @@ TEST_CASE("/fdbserver/worker/addressInDbAndPrimaryDc") {
 	// First, create a remote TLog. Although the remote TLog also uses the local address, it shouldn't be considered as
 	// in primary DC given the remote locality.
 	LocalityData fakeRemote;
-	fakeRemote.set(LiteralStringRef("dcid"), StringRef(std::to_string(2)));
+	fakeRemote.set("dcid"_sr, StringRef(std::to_string(2)));
 	TLogInterface remoteTlog(fakeRemote);
 	remoteTlog.initEndpoints();
 	testDbInfo.logSystemConfig.tLogs.push_back(TLogSet());
@@ -1033,8 +1033,8 @@ void startRole(const Role& role,
 
 	// Update roles map, log Roles metrics
 	g_roles.insert({ role.roleName, roleId.shortString() });
-	StringMetricHandle(LiteralStringRef("Roles")) = roleString(g_roles, false);
-	StringMetricHandle(LiteralStringRef("RolesWithIDs")) = roleString(g_roles, true);
+	StringMetricHandle("Roles"_sr) = roleString(g_roles, false);
+	StringMetricHandle("RolesWithIDs"_sr) = roleString(g_roles, true);
 	if (g_network->isSimulated())
 		g_simulator.addRole(g_network->getLocalAddress(), role.roleName);
 }
@@ -1063,8 +1063,8 @@ void endRole(const Role& role, UID id, std::string reason, bool ok, Error e) {
 
 	// Update roles map, log Roles metrics
 	g_roles.erase({ role.roleName, id.shortString() });
-	StringMetricHandle(LiteralStringRef("Roles")) = roleString(g_roles, false);
-	StringMetricHandle(LiteralStringRef("RolesWithIDs")) = roleString(g_roles, true);
+	StringMetricHandle("Roles"_sr) = roleString(g_roles, false);
+	StringMetricHandle("RolesWithIDs"_sr) = roleString(g_roles, true);
 	if (g_network->isSimulated())
 		g_simulator.removeRole(g_network->getLocalAddress(), role.roleName);
 

--- a/fdbserver/workloads/ApiCorrectness.actor.cpp
+++ b/fdbserver/workloads/ApiCorrectness.actor.cpp
@@ -99,21 +99,21 @@ public:
 
 	ApiCorrectnessWorkload(WorkloadContext const& wcx)
 	  : ApiWorkload(wcx), numRandomOperations("Num Random Operations") {
-		numGets = getOption(options, LiteralStringRef("numGets"), 1000);
-		numGetRanges = getOption(options, LiteralStringRef("numGetRanges"), 100);
-		numGetRangeSelectors = getOption(options, LiteralStringRef("numGetRangeSelectors"), 100);
-		numGetKeys = getOption(options, LiteralStringRef("numGetKeys"), 100);
-		numClears = getOption(options, LiteralStringRef("numClears"), 100);
-		numClearRanges = getOption(options, LiteralStringRef("numClearRanges"), 100);
-		minSizeAfterClear = getOption(options, LiteralStringRef("minSizeAfterClear"), (int)(0.1 * numKeys));
+		numGets = getOption(options, "numGets"_sr, 1000);
+		numGetRanges = getOption(options, "numGetRanges"_sr, 100);
+		numGetRangeSelectors = getOption(options, "numGetRangeSelectors"_sr, 100);
+		numGetKeys = getOption(options, "numGetKeys"_sr, 100);
+		numClears = getOption(options, "numClears"_sr, 100);
+		numClearRanges = getOption(options, "numClearRanges"_sr, 100);
+		minSizeAfterClear = getOption(options, "minSizeAfterClear"_sr, (int)(0.1 * numKeys));
 
-		maxRandomTestKeys = getOption(options, LiteralStringRef("maxRandomTestKeys"), numKeys);
-		randomTestDuration = getOption(options, LiteralStringRef("randomTestDuration"), 60.0);
+		maxRandomTestKeys = getOption(options, "maxRandomTestKeys"_sr, numKeys);
+		randomTestDuration = getOption(options, "randomTestDuration"_sr, 60.0);
 
-		int maxTransactionBytes = getOption(options, LiteralStringRef("maxTransactionBytes"), 500000);
+		int maxTransactionBytes = getOption(options, "maxTransactionBytes"_sr, 500000);
 		maxKeysPerTransaction = std::max(1, maxTransactionBytes / (maxValueLength + maxLongKeyLength));
 
-		resetDBTimeout = getOption(options, LiteralStringRef("resetDBTimeout"), 1800.0);
+		resetDBTimeout = getOption(options, "resetDBTimeout"_sr, 1800.0);
 
 		if (maxTransactionBytes > 500000) {
 			TraceEvent("RemapEventSeverity")
@@ -502,7 +502,7 @@ public:
 
 				if (keys[i].startsWith(StringRef(self->clientPrefix)) ||
 				    (keys[i].size() == 0 && self->clientPrefixInt == 0) ||
-				    (keys[i].startsWith(LiteralStringRef("\xff")) && self->clientPrefixInt == self->clientCount - 1)) {
+				    (keys[i].startsWith("\xff"_sr) && self->clientPrefixInt == self->clientCount - 1)) {
 					break;
 				}
 
@@ -553,7 +553,7 @@ public:
 				if (endKey == self->store.endKey()) {
 					for (int i = 0; i < range.size(); i++) {
 						// Don't include results in the 0xFF key-space
-						if (!range[i].key.startsWith(LiteralStringRef("\xff")))
+						if (!range[i].key.startsWith("\xff"_sr))
 							dbResults.push_back_deep(dbResults.arena(), range[i]);
 					}
 					if (reverse && dbResults.size() < storeResults.size()) {

--- a/fdbserver/workloads/ApiWorkload.h
+++ b/fdbserver/workloads/ApiWorkload.h
@@ -224,18 +224,18 @@ struct ApiWorkload : TestWorkload {
 
 	ApiWorkload(WorkloadContext const& wcx, int maxClients = -1)
 	  : TestWorkload(wcx), success(true), transactionFactory(nullptr), maxClients(maxClients) {
-		clientPrefixInt = getOption(options, LiteralStringRef("clientId"), clientId);
+		clientPrefixInt = getOption(options, "clientId"_sr, clientId);
 		clientPrefix = format("%010d", clientPrefixInt);
 
-		numKeys = getOption(options, LiteralStringRef("numKeys"), 5000);
-		onlyLowerCase = getOption(options, LiteralStringRef("onlyLowerCase"), false);
-		shortKeysRatio = getOption(options, LiteralStringRef("shortKeysRatio"), 0.5);
-		minShortKeyLength = getOption(options, LiteralStringRef("minShortKeyLength"), 1);
-		maxShortKeyLength = getOption(options, LiteralStringRef("maxShortKeyLength"), 3);
-		minLongKeyLength = getOption(options, LiteralStringRef("minLongKeyLength"), 1);
-		maxLongKeyLength = getOption(options, LiteralStringRef("maxLongKeyLength"), 128);
-		minValueLength = getOption(options, LiteralStringRef("minValueLength"), 1);
-		maxValueLength = getOption(options, LiteralStringRef("maxValueLength"), 10000);
+		numKeys = getOption(options, "numKeys"_sr, 5000);
+		onlyLowerCase = getOption(options, "onlyLowerCase"_sr, false);
+		shortKeysRatio = getOption(options, "shortKeysRatio"_sr, 0.5);
+		minShortKeyLength = getOption(options, "minShortKeyLength"_sr, 1);
+		maxShortKeyLength = getOption(options, "maxShortKeyLength"_sr, 3);
+		minLongKeyLength = getOption(options, "minLongKeyLength"_sr, 1);
+		maxLongKeyLength = getOption(options, "maxLongKeyLength"_sr, 128);
+		minValueLength = getOption(options, "minValueLength"_sr, 1);
+		maxValueLength = getOption(options, "maxValueLength"_sr, 10000);
 
 		useExtraDB = g_simulator.extraDB != nullptr;
 		if (useExtraDB) {

--- a/fdbserver/workloads/AsyncFile.cpp
+++ b/fdbserver/workloads/AsyncFile.cpp
@@ -63,11 +63,11 @@ const int AsyncFileWorkload::_PAGE_SIZE = 4096;
 AsyncFileWorkload::AsyncFileWorkload(WorkloadContext const& wcx) : TestWorkload(wcx), fileHandle(nullptr) {
 	// Only run on one client
 	enabled = clientId == 0;
-	testDuration = getOption(options, LiteralStringRef("testDuration"), 10.0);
-	unbufferedIO = getOption(options, LiteralStringRef("unbufferedIO"), false);
-	uncachedIO = getOption(options, LiteralStringRef("uncachedIO"), false);
-	fillRandom = getOption(options, LiteralStringRef("fillRandom"), false);
-	path = getOption(options, LiteralStringRef("fileName"), LiteralStringRef("")).toString();
+	testDuration = getOption(options, "testDuration"_sr, 10.0);
+	unbufferedIO = getOption(options, "unbufferedIO"_sr, false);
+	uncachedIO = getOption(options, "uncachedIO"_sr, false);
+	fillRandom = getOption(options, "fillRandom"_sr, false);
+	path = getOption(options, "fileName"_sr, ""_sr).toString();
 }
 
 Reference<AsyncFileBuffer> AsyncFileWorkload::allocateBuffer(size_t size) {

--- a/fdbserver/workloads/AsyncFileCorrectness.actor.cpp
+++ b/fdbserver/workloads/AsyncFileCorrectness.actor.cpp
@@ -74,9 +74,9 @@ struct AsyncFileCorrectnessWorkload : public AsyncFileWorkload {
 
 	AsyncFileCorrectnessWorkload(WorkloadContext const& wcx)
 	  : AsyncFileWorkload(wcx), success(true), numOperations("Num Operations"), memoryFile(nullptr) {
-		maxOperationSize = getOption(options, LiteralStringRef("maxOperationSize"), 4096);
-		numSimultaneousOperations = getOption(options, LiteralStringRef("numSimultaneousOperations"), 10);
-		targetFileSize = getOption(options, LiteralStringRef("targetFileSize"), (uint64_t)163840);
+		maxOperationSize = getOption(options, "maxOperationSize"_sr, 4096);
+		numSimultaneousOperations = getOption(options, "numSimultaneousOperations"_sr, 10);
+		targetFileSize = getOption(options, "targetFileSize"_sr, (uint64_t)163840);
 
 		if (unbufferedIO)
 			maxOperationSize = std::max(_PAGE_SIZE, maxOperationSize);

--- a/fdbserver/workloads/AsyncFileRead.actor.cpp
+++ b/fdbserver/workloads/AsyncFileRead.actor.cpp
@@ -173,15 +173,14 @@ struct AsyncFileReadWorkload : public AsyncFileWorkload {
 
 	AsyncFileReadWorkload(WorkloadContext const& wcx) : AsyncFileWorkload(wcx), bytesRead("Bytes Read"), ioLog(0) {
 		// Only run on one client
-		numParallelReads = getOption(options, LiteralStringRef("numParallelReads"), 0);
-		readSize = getOption(options, LiteralStringRef("readSize"), _PAGE_SIZE);
-		fileSize =
-		    getOption(options, LiteralStringRef("fileSize"), (int64_t)0); // 0 = use existing, else, change file size
-		unbatched = getOption(options, LiteralStringRef("unbatched"), false);
-		sequential = getOption(options, LiteralStringRef("sequential"), true);
-		writeFraction = getOption(options, LiteralStringRef("writeFraction"), 0.0);
-		randomData = getOption(options, LiteralStringRef("randomData"), true);
-		fixedRate = getOption(options, LiteralStringRef("fixedRate"), 0.0);
+		numParallelReads = getOption(options, "numParallelReads"_sr, 0);
+		readSize = getOption(options, "readSize"_sr, _PAGE_SIZE);
+		fileSize = getOption(options, "fileSize"_sr, (int64_t)0); // 0 = use existing, else, change file size
+		unbatched = getOption(options, "unbatched"_sr, false);
+		sequential = getOption(options, "sequential"_sr, true);
+		writeFraction = getOption(options, "writeFraction"_sr, 0.0);
+		randomData = getOption(options, "randomData"_sr, true);
+		fixedRate = getOption(options, "fixedRate"_sr, 0.0);
 	}
 
 	~AsyncFileReadWorkload() override {}

--- a/fdbserver/workloads/AsyncFileWrite.actor.cpp
+++ b/fdbserver/workloads/AsyncFileWrite.actor.cpp
@@ -47,10 +47,10 @@ struct AsyncFileWriteWorkload : public AsyncFileWorkload {
 
 	AsyncFileWriteWorkload(WorkloadContext const& wcx)
 	  : AsyncFileWorkload(wcx), bytesWritten("Bytes Written"), writeBuffer(nullptr) {
-		numParallelWrites = getOption(options, LiteralStringRef("numParallelWrites"), 0);
-		writeSize = getOption(options, LiteralStringRef("writeSize"), _PAGE_SIZE);
-		fileSize = getOption(options, LiteralStringRef("fileSize"), 10002432);
-		sequential = getOption(options, LiteralStringRef("sequential"), true);
+		numParallelWrites = getOption(options, "numParallelWrites"_sr, 0);
+		writeSize = getOption(options, "writeSize"_sr, _PAGE_SIZE);
+		fileSize = getOption(options, "fileSize"_sr, 10002432);
+		sequential = getOption(options, "sequential"_sr, true);
 	}
 
 	std::string description() const override { return "AsyncFileWrite"; }

--- a/fdbserver/workloads/AtomicOps.actor.cpp
+++ b/fdbserver/workloads/AtomicOps.actor.cpp
@@ -39,11 +39,11 @@ struct AtomicOpsWorkload : TestWorkload {
 	uint64_t lbsum, ubsum; // The lower bound and upper bound sum of operations when opType = AddValue
 
 	AtomicOpsWorkload(WorkloadContext const& wcx) : TestWorkload(wcx), opNum(0) {
-		testDuration = getOption(options, LiteralStringRef("testDuration"), 600.0);
-		transactionsPerSecond = getOption(options, LiteralStringRef("transactionsPerSecond"), 5000.0) / clientCount;
-		actorCount = getOption(options, LiteralStringRef("actorsPerClient"), transactionsPerSecond / 5);
-		opType = getOption(options, LiteralStringRef("opType"), -1);
-		nodeCount = getOption(options, LiteralStringRef("nodeCount"), 1000);
+		testDuration = getOption(options, "testDuration"_sr, 600.0);
+		transactionsPerSecond = getOption(options, "transactionsPerSecond"_sr, 5000.0) / clientCount;
+		actorCount = getOption(options, "actorsPerClient"_sr, transactionsPerSecond / 5);
+		opType = getOption(options, "opType"_sr, -1);
+		nodeCount = getOption(options, "nodeCount"_sr, 1000);
 		// Atomic OPs Min and And have modified behavior from api version 510. Hence allowing testing for older version
 		// (500) with a 10% probability Actual change of api Version happens in setup
 		apiVersion500 = ((sharedRandomNumber % 10) == 0);
@@ -319,7 +319,7 @@ struct AtomicOpsWorkload : TestWorkload {
 		for (auto& kv : log) {
 			uint64_t intValue = 0;
 			memcpy(&intValue, kv.value.begin(), kv.value.size());
-			logVal[kv.key.removePrefix(LiteralStringRef("log")).withPrefix(LiteralStringRef("debug"))] = intValue;
+			logVal[kv.key.removePrefix("log"_sr).withPrefix("debug"_sr)] = intValue;
 		}
 
 		// Get opsKeys and validate if it has correct value
@@ -372,12 +372,11 @@ struct AtomicOpsWorkload : TestWorkload {
 						RangeResult log_ = wait(tr.getRange(KeyRangeRef(begin, strinc(begin)), CLIENT_KNOBS->TOO_MANY));
 						log = log_;
 						uint64_t zeroValue = 0;
-						tr.set(LiteralStringRef("xlogResult"),
-						       StringRef((const uint8_t*)&zeroValue, sizeof(zeroValue)));
+						tr.set("xlogResult"_sr, StringRef((const uint8_t*)&zeroValue, sizeof(zeroValue)));
 						for (auto& kv : log) {
 							uint64_t intValue = 0;
 							memcpy(&intValue, kv.value.begin(), kv.value.size());
-							tr.atomicOp(LiteralStringRef("xlogResult"), kv.value, self->opType);
+							tr.atomicOp("xlogResult"_sr, kv.value, self->opType);
 						}
 					}
 
@@ -386,18 +385,16 @@ struct AtomicOpsWorkload : TestWorkload {
 						Key begin(format("ops%08x", g));
 						RangeResult ops = wait(tr.getRange(KeyRangeRef(begin, strinc(begin)), CLIENT_KNOBS->TOO_MANY));
 						uint64_t zeroValue = 0;
-						tr.set(LiteralStringRef("xopsResult"),
-						       StringRef((const uint8_t*)&zeroValue, sizeof(zeroValue)));
+						tr.set("xopsResult"_sr, StringRef((const uint8_t*)&zeroValue, sizeof(zeroValue)));
 						for (auto& kv : ops) {
 							uint64_t intValue = 0;
 							memcpy(&intValue, kv.value.begin(), kv.value.size());
-							tr.atomicOp(LiteralStringRef("xopsResult"), kv.value, self->opType);
+							tr.atomicOp("xopsResult"_sr, kv.value, self->opType);
 						}
 
-						if (tr.get(LiteralStringRef("xlogResult")).get() !=
-						    tr.get(LiteralStringRef("xopsResult")).get()) {
-							Optional<Standalone<StringRef>> logResult = tr.get(LiteralStringRef("xlogResult")).get();
-							Optional<Standalone<StringRef>> opsResult = tr.get(LiteralStringRef("xopsResult")).get();
+						if (tr.get("xlogResult"_sr).get() != tr.get("xopsResult"_sr).get()) {
+							Optional<Standalone<StringRef>> logResult = tr.get("xlogResult"_sr).get();
+							Optional<Standalone<StringRef>> opsResult = tr.get("xopsResult"_sr).get();
 							ASSERT(logResult.present());
 							ASSERT(opsResult.present());
 							TraceEvent(SevError, "LogMismatch")
@@ -408,7 +405,7 @@ struct AtomicOpsWorkload : TestWorkload {
 
 						if (self->opType == MutationRef::AddValue) {
 							uint64_t opsResult = 0;
-							Key opsResultStr = tr.get(LiteralStringRef("xopsResult")).get().get();
+							Key opsResultStr = tr.get("xopsResult"_sr).get().get();
 							memcpy(&opsResult, opsResultStr.begin(), opsResultStr.size());
 							uint64_t logResult = 0;
 							for (auto& kv : log) {

--- a/fdbserver/workloads/AtomicOpsApiCorrectness.actor.cpp
+++ b/fdbserver/workloads/AtomicOpsApiCorrectness.actor.cpp
@@ -40,7 +40,7 @@ private:
 
 public:
 	AtomicOpsApiCorrectnessWorkload(WorkloadContext const& wcx) : TestWorkload(wcx) {
-		opType = getOption(options, LiteralStringRef("opType"), -1);
+		opType = getOption(options, "opType"_sr, -1);
 	}
 
 	std::string description() const override { return "AtomicOpsApiCorrectness"; }

--- a/fdbserver/workloads/AtomicRestore.actor.cpp
+++ b/fdbserver/workloads/AtomicRestore.actor.cpp
@@ -37,15 +37,15 @@ struct AtomicRestoreWorkload : TestWorkload {
 
 	AtomicRestoreWorkload(WorkloadContext const& wcx) : TestWorkload(wcx) {
 
-		startAfter = getOption(options, LiteralStringRef("startAfter"), 10.0);
-		restoreAfter = getOption(options, LiteralStringRef("restoreAfter"), 20.0);
-		fastRestore = getOption(options, LiteralStringRef("fastRestore"), false);
+		startAfter = getOption(options, "startAfter"_sr, 10.0);
+		restoreAfter = getOption(options, "restoreAfter"_sr, 20.0);
+		fastRestore = getOption(options, "fastRestore"_sr, false);
 		backupRanges.push_back_deep(backupRanges.arena(), normalKeys);
-		usePartitionedLogs.set(getOption(
-		    options, LiteralStringRef("usePartitionedLogs"), deterministicRandom()->random01() < 0.5 ? true : false));
+		usePartitionedLogs.set(
+		    getOption(options, "usePartitionedLogs"_sr, deterministicRandom()->random01() < 0.5 ? true : false));
 
-		addPrefix = getOption(options, LiteralStringRef("addPrefix"), LiteralStringRef(""));
-		removePrefix = getOption(options, LiteralStringRef("removePrefix"), LiteralStringRef(""));
+		addPrefix = getOption(options, "addPrefix"_sr, ""_sr);
+		removePrefix = getOption(options, "removePrefix"_sr, ""_sr);
 
 		// Correctness is not clean for addPrefix feature yet. Uncomment below to enable the test
 		// Generate addPrefix
@@ -81,7 +81,7 @@ struct AtomicRestoreWorkload : TestWorkload {
 
 	void getMetrics(vector<PerfMetric>& m) override {}
 
-	bool hasPrefix() const { return addPrefix != LiteralStringRef("") || removePrefix != LiteralStringRef(""); }
+	bool hasPrefix() const { return addPrefix != ""_sr || removePrefix != ""_sr; }
 
 	ACTOR static Future<Void> _start(Database cx, AtomicRestoreWorkload* self) {
 		state FileBackupAgent backupAgent;

--- a/fdbserver/workloads/AtomicSwitchover.actor.cpp
+++ b/fdbserver/workloads/AtomicSwitchover.actor.cpp
@@ -32,9 +32,9 @@ struct AtomicSwitchoverWorkload : TestWorkload {
 
 	AtomicSwitchoverWorkload(WorkloadContext const& wcx) : TestWorkload(wcx) {
 
-		switch1delay = getOption(options, LiteralStringRef("switch1delay"), 50.0);
-		switch2delay = getOption(options, LiteralStringRef("switch2delay"), 50.0);
-		stopDelay = getOption(options, LiteralStringRef("stopDelay"), 50.0);
+		switch1delay = getOption(options, "switch1delay"_sr, 50.0);
+		switch2delay = getOption(options, "switch2delay"_sr, 50.0);
+		stopDelay = getOption(options, "stopDelay"_sr, 50.0);
 
 		backupRanges.push_back_deep(backupRanges.arena(), normalKeys);
 

--- a/fdbserver/workloads/BackgroundSelectors.actor.cpp
+++ b/fdbserver/workloads/BackgroundSelectors.actor.cpp
@@ -39,13 +39,12 @@ struct BackgroundSelectorWorkload : TestWorkload {
 
 	BackgroundSelectorWorkload(WorkloadContext const& wcx)
 	  : TestWorkload(wcx), operations("Operations"), checks("Checks"), retries("Retries") {
-		testDuration = getOption(options, LiteralStringRef("testDuration"), 10.0);
-		actorsPerClient = std::max(getOption(options, LiteralStringRef("actorsPerClient"), 1), 1);
-		maxDiff = std::max(getOption(options, LiteralStringRef("maxDiff"), 100), 2);
-		minDrift = getOption(options, LiteralStringRef("minDiff"), -10);
-		maxDrift = getOption(options, LiteralStringRef("minDiff"), 100);
-		transactionsPerSecond =
-		    getOption(options, LiteralStringRef("transactionsPerSecond"), 10.0) / (clientCount * actorsPerClient);
+		testDuration = getOption(options, "testDuration"_sr, 10.0);
+		actorsPerClient = std::max(getOption(options, "actorsPerClient"_sr, 1), 1);
+		maxDiff = std::max(getOption(options, "maxDiff"_sr, 100), 2);
+		minDrift = getOption(options, "minDiff"_sr, -10);
+		maxDrift = getOption(options, "minDiff"_sr, 100);
+		transactionsPerSecond = getOption(options, "transactionsPerSecond"_sr, 10.0) / (clientCount * actorsPerClient);
 		resultLimit = 10 * maxDiff;
 	}
 

--- a/fdbserver/workloads/BackupAndParallelRestoreCorrectness.actor.cpp
+++ b/fdbserver/workloads/BackupAndParallelRestoreCorrectness.actor.cpp
@@ -51,34 +51,33 @@ struct BackupAndParallelRestoreCorrectnessWorkload : TestWorkload {
 
 	BackupAndParallelRestoreCorrectnessWorkload(WorkloadContext const& wcx) : TestWorkload(wcx) {
 		locked.set(sharedRandomNumber % 2);
-		backupAfter = getOption(options, LiteralStringRef("backupAfter"), 10.0);
-		restoreAfter = getOption(options, LiteralStringRef("restoreAfter"), 35.0);
-		performRestore = getOption(options, LiteralStringRef("performRestore"), true);
-		backupTag = getOption(options, LiteralStringRef("backupTag"), BackupAgentBase::getDefaultTag());
-		backupRangesCount = getOption(options, LiteralStringRef("backupRangesCount"), 5);
-		backupRangeLengthMax = getOption(options, LiteralStringRef("backupRangeLengthMax"), 1);
+		backupAfter = getOption(options, "backupAfter"_sr, 10.0);
+		restoreAfter = getOption(options, "restoreAfter"_sr, 35.0);
+		performRestore = getOption(options, "performRestore"_sr, true);
+		backupTag = getOption(options, "backupTag"_sr, BackupAgentBase::getDefaultTag());
+		backupRangesCount = getOption(options, "backupRangesCount"_sr, 5);
+		backupRangeLengthMax = getOption(options, "backupRangeLengthMax"_sr, 1);
 		abortAndRestartAfter =
 		    getOption(options,
-		              LiteralStringRef("abortAndRestartAfter"),
+		              "abortAndRestartAfter"_sr,
 		              deterministicRandom()->random01() < 0.5
 		                  ? deterministicRandom()->random01() * (restoreAfter - backupAfter) + backupAfter
 		                  : 0.0);
-		differentialBackup = getOption(
-		    options, LiteralStringRef("differentialBackup"), deterministicRandom()->random01() < 0.5 ? true : false);
+		differentialBackup =
+		    getOption(options, "differentialBackup"_sr, deterministicRandom()->random01() < 0.5 ? true : false);
 		stopDifferentialAfter =
 		    getOption(options,
-		              LiteralStringRef("stopDifferentialAfter"),
+		              "stopDifferentialAfter"_sr,
 		              differentialBackup ? deterministicRandom()->random01() *
 		                                           (restoreAfter - std::max(abortAndRestartAfter, backupAfter)) +
 		                                       std::max(abortAndRestartAfter, backupAfter)
 		                                 : 0.0);
-		agentRequest = getOption(options, LiteralStringRef("simBackupAgents"), true);
-		allowPauses = getOption(options, LiteralStringRef("allowPauses"), true);
-		shareLogRange = getOption(options, LiteralStringRef("shareLogRange"), false);
-		usePartitionedLogs.set(
-		    getOption(options, LiteralStringRef("usePartitionedLogs"), deterministicRandom()->coinflip()));
-		addPrefix = getOption(options, LiteralStringRef("addPrefix"), LiteralStringRef(""));
-		removePrefix = getOption(options, LiteralStringRef("removePrefix"), LiteralStringRef(""));
+		agentRequest = getOption(options, "simBackupAgents"_sr, true);
+		allowPauses = getOption(options, "allowPauses"_sr, true);
+		shareLogRange = getOption(options, "shareLogRange"_sr, false);
+		usePartitionedLogs.set(getOption(options, "usePartitionedLogs"_sr, deterministicRandom()->coinflip()));
+		addPrefix = getOption(options, "addPrefix"_sr, ""_sr);
+		removePrefix = getOption(options, "removePrefix"_sr, ""_sr);
 
 		KeyRef beginRange;
 		KeyRef endRange;
@@ -108,11 +107,10 @@ struct BackupAndParallelRestoreCorrectnessWorkload : TestWorkload {
 		if (shareLogRange) {
 			bool beforePrefix = sharedRandomNumber & 1;
 			if (beforePrefix)
-				backupRanges.push_back_deep(backupRanges.arena(),
-				                            KeyRangeRef(normalKeys.begin, LiteralStringRef("\xfe\xff\xfe")));
+				backupRanges.push_back_deep(backupRanges.arena(), KeyRangeRef(normalKeys.begin, "\xfe\xff\xfe"_sr));
 			else
 				backupRanges.push_back_deep(backupRanges.arena(),
-				                            KeyRangeRef(strinc(LiteralStringRef("\x00\x00\x01")), normalKeys.end));
+				                            KeyRangeRef(strinc("\x00\x00\x01"_sr), normalKeys.end));
 		} else if (backupRangesCount <= 0) {
 			backupRanges.push_back_deep(backupRanges.arena(), normalKeys);
 		} else {
@@ -161,7 +159,7 @@ struct BackupAndParallelRestoreCorrectnessWorkload : TestWorkload {
 		return _start(cx, this);
 	}
 
-	bool hasPrefix() const { return addPrefix != LiteralStringRef("") || removePrefix != LiteralStringRef(""); }
+	bool hasPrefix() const { return addPrefix != ""_sr || removePrefix != ""_sr; }
 
 	Future<bool> check(Database const& cx) override { return true; }
 
@@ -477,7 +475,7 @@ struct BackupAndParallelRestoreCorrectnessWorkload : TestWorkload {
 					// Note the "partitionedLog" must be false, because we change
 					// the configuration to disable backup workers before restore.
 					extraBackup = backupAgent.submitBackup(cx,
-					                                       LiteralStringRef("file://simfdb/backups/"),
+					                                       "file://simfdb/backups/"_sr,
 					                                       deterministicRandom()->randomInt(0, 60),
 					                                       deterministicRandom()->randomInt(0, 100),
 					                                       self->backupTag.toString(),
@@ -760,7 +758,7 @@ struct BackupAndParallelRestoreCorrectnessWorkload : TestWorkload {
 			}
 
 			if (displaySystemKeys) {
-				wait(TaskBucket::debugPrintRange(cx, LiteralStringRef("\xff"), StringRef()));
+				wait(TaskBucket::debugPrintRange(cx, "\xff"_sr, StringRef()));
 			}
 
 			TraceEvent("BARW_Complete", randomID).detail("BackupTag", printable(self->backupTag));

--- a/fdbserver/workloads/BackupToBlob.actor.cpp
+++ b/fdbserver/workloads/BackupToBlob.actor.cpp
@@ -35,15 +35,12 @@ struct BackupToBlobWorkload : TestWorkload {
 	static constexpr const char* DESCRIPTION = "BackupToBlob";
 
 	BackupToBlobWorkload(WorkloadContext const& wcx) : TestWorkload(wcx) {
-		backupAfter = getOption(options, LiteralStringRef("backupAfter"), 10.0);
-		backupTag = getOption(options, LiteralStringRef("backupTag"), BackupAgentBase::getDefaultTag());
-		auto backupURLString =
-		    getOption(options, LiteralStringRef("backupURL"), LiteralStringRef("http://0.0.0.0:10000")).toString();
-		auto accessKeyEnvVar =
-		    getOption(options, LiteralStringRef("accessKeyVar"), LiteralStringRef("BLOB_ACCESS_KEY")).toString();
-		auto secretKeyEnvVar =
-		    getOption(options, LiteralStringRef("secretKeyVar"), LiteralStringRef("BLOB_SECRET_KEY")).toString();
-		bool provideKeys = getOption(options, LiteralStringRef("provideKeys"), false);
+		backupAfter = getOption(options, "backupAfter"_sr, 10.0);
+		backupTag = getOption(options, "backupTag"_sr, BackupAgentBase::getDefaultTag());
+		auto backupURLString = getOption(options, "backupURL"_sr, "http://0.0.0.0:10000"_sr).toString();
+		auto accessKeyEnvVar = getOption(options, "accessKeyVar"_sr, "BLOB_ACCESS_KEY"_sr).toString();
+		auto secretKeyEnvVar = getOption(options, "secretKeyVar"_sr, "BLOB_SECRET_KEY"_sr).toString();
+		bool provideKeys = getOption(options, "provideKeys"_sr, false);
 		if (provideKeys) {
 			updateBackupURL(backupURLString, accessKeyEnvVar, "<access_key>", secretKeyEnvVar, "<secret_key>");
 		}

--- a/fdbserver/workloads/BackupToDBAbort.actor.cpp
+++ b/fdbserver/workloads/BackupToDBAbort.actor.cpp
@@ -31,7 +31,7 @@ struct BackupToDBAbort : TestWorkload {
 	UID lockid;
 
 	explicit BackupToDBAbort(const WorkloadContext& wcx) : TestWorkload(wcx) {
-		abortDelay = getOption(options, LiteralStringRef("abortDelay"), 50.0);
+		abortDelay = getOption(options, "abortDelay"_sr, 50.0);
 
 		backupRanges.push_back_deep(backupRanges.arena(), normalKeys);
 

--- a/fdbserver/workloads/BackupToDBCorrectness.actor.cpp
+++ b/fdbserver/workloads/BackupToDBCorrectness.actor.cpp
@@ -44,44 +44,44 @@ struct BackupToDBCorrectnessWorkload : TestWorkload {
 
 	BackupToDBCorrectnessWorkload(WorkloadContext const& wcx) : TestWorkload(wcx) {
 		locked.set(sharedRandomNumber % 2);
-		backupAfter = getOption(options, LiteralStringRef("backupAfter"), 10.0);
-		restoreAfter = getOption(options, LiteralStringRef("restoreAfter"), 35.0);
-		performRestore = getOption(options, LiteralStringRef("performRestore"), true);
-		backupTag = getOption(options, LiteralStringRef("backupTag"), BackupAgentBase::getDefaultTag());
-		restoreTag = getOption(options, LiteralStringRef("restoreTag"), LiteralStringRef("restore"));
-		backupPrefix = getOption(options, LiteralStringRef("backupPrefix"), StringRef());
+		backupAfter = getOption(options, "backupAfter"_sr, 10.0);
+		restoreAfter = getOption(options, "restoreAfter"_sr, 35.0);
+		performRestore = getOption(options, "performRestore"_sr, true);
+		backupTag = getOption(options, "backupTag"_sr, BackupAgentBase::getDefaultTag());
+		restoreTag = getOption(options, "restoreTag"_sr, "restore"_sr);
+		backupPrefix = getOption(options, "backupPrefix"_sr, StringRef());
 		backupRangesCount = getOption(options,
-		                              LiteralStringRef("backupRangesCount"),
+		                              "backupRangesCount"_sr,
 		                              5); // tests can hangs if set higher than 1 + BACKUP_MAP_KEY_LOWER_LIMIT
-		backupRangeLengthMax = getOption(options, LiteralStringRef("backupRangeLengthMax"), 1);
+		backupRangeLengthMax = getOption(options, "backupRangeLengthMax"_sr, 1);
 		abortAndRestartAfter =
 		    getOption(options,
-		              LiteralStringRef("abortAndRestartAfter"),
+		              "abortAndRestartAfter"_sr,
 		              (!locked && deterministicRandom()->random01() < 0.5)
 		                  ? deterministicRandom()->random01() * (restoreAfter - backupAfter) + backupAfter
 		                  : 0.0);
-		differentialBackup = getOption(
-		    options, LiteralStringRef("differentialBackup"), deterministicRandom()->random01() < 0.5 ? true : false);
+		differentialBackup =
+		    getOption(options, "differentialBackup"_sr, deterministicRandom()->random01() < 0.5 ? true : false);
 		stopDifferentialAfter =
 		    getOption(options,
-		              LiteralStringRef("stopDifferentialAfter"),
+		              "stopDifferentialAfter"_sr,
 		              differentialBackup ? deterministicRandom()->random01() *
 		                                           (restoreAfter - std::max(abortAndRestartAfter, backupAfter)) +
 		                                       std::max(abortAndRestartAfter, backupAfter)
 		                                 : 0.0);
-		agentRequest = getOption(options, LiteralStringRef("simDrAgents"), true);
-		shareLogRange = getOption(options, LiteralStringRef("shareLogRange"), false);
+		agentRequest = getOption(options, "simDrAgents"_sr, true);
+		shareLogRange = getOption(options, "shareLogRange"_sr, false);
 
 		// Use sharedRandomNumber if shareLogRange is true so that we can ensure backup and DR both backup the same
 		// range
 		beforePrefix = shareLogRange ? (sharedRandomNumber & 1) : (deterministicRandom()->random01() < 0.5);
 
 		if (beforePrefix) {
-			extraPrefix = backupPrefix.withPrefix(LiteralStringRef("\xfe\xff\xfe"));
-			backupPrefix = backupPrefix.withPrefix(LiteralStringRef("\xfe\xff\xff"));
+			extraPrefix = backupPrefix.withPrefix("\xfe\xff\xfe"_sr);
+			backupPrefix = backupPrefix.withPrefix("\xfe\xff\xff"_sr);
 		} else {
-			extraPrefix = backupPrefix.withPrefix(LiteralStringRef("\x00\x00\x01"));
-			backupPrefix = backupPrefix.withPrefix(LiteralStringRef("\x00\x00\00"));
+			extraPrefix = backupPrefix.withPrefix("\x00\x00\x01"_sr);
+			backupPrefix = backupPrefix.withPrefix("\x00\x00\00"_sr);
 		}
 
 		ASSERT(backupPrefix != StringRef());
@@ -92,11 +92,10 @@ struct BackupToDBCorrectnessWorkload : TestWorkload {
 
 		if (shareLogRange) {
 			if (beforePrefix)
-				backupRanges.push_back_deep(backupRanges.arena(),
-				                            KeyRangeRef(normalKeys.begin, LiteralStringRef("\xfe\xff\xfe")));
+				backupRanges.push_back_deep(backupRanges.arena(), KeyRangeRef(normalKeys.begin, "\xfe\xff\xfe"_sr));
 			else
 				backupRanges.push_back_deep(backupRanges.arena(),
-				                            KeyRangeRef(strinc(LiteralStringRef("\x00\x00\x01")), normalKeys.end));
+				                            KeyRangeRef(strinc("\x00\x00\x01"_sr), normalKeys.end));
 		} else if (backupRangesCount <= 0) {
 			if (beforePrefix)
 				backupRanges.push_back_deep(backupRanges.arena(),
@@ -436,7 +435,7 @@ struct BackupToDBCorrectnessWorkload : TestWorkload {
 					    .detail("TaskCount", taskCount)
 					    .detail("WaitCycles", waitCycles);
 					printf("EndingNonZeroTasks: %ld\n", (long)taskCount);
-					wait(TaskBucket::debugPrintRange(cx, LiteralStringRef("\xff"), StringRef()));
+					wait(TaskBucket::debugPrintRange(cx, "\xff"_sr, StringRef()));
 				}
 
 				loop {
@@ -544,7 +543,7 @@ struct BackupToDBCorrectnessWorkload : TestWorkload {
 		}
 
 		if (displaySystemKeys) {
-			wait(TaskBucket::debugPrintRange(cx, LiteralStringRef("\xff"), StringRef()));
+			wait(TaskBucket::debugPrintRange(cx, "\xff"_sr, StringRef()));
 		}
 		return Void();
 	}

--- a/fdbserver/workloads/BackupToDBUpgrade.actor.cpp
+++ b/fdbserver/workloads/BackupToDBUpgrade.actor.cpp
@@ -34,15 +34,15 @@ struct BackupToDBUpgradeWorkload : TestWorkload {
 	Database extraDB;
 
 	BackupToDBUpgradeWorkload(WorkloadContext const& wcx) : TestWorkload(wcx) {
-		backupAfter = getOption(options, LiteralStringRef("backupAfter"), deterministicRandom()->random01() * 10.0);
-		backupPrefix = getOption(options, LiteralStringRef("backupPrefix"), StringRef());
-		backupRangeLengthMax = getOption(options, LiteralStringRef("backupRangeLengthMax"), 1);
-		stopDifferentialAfter = getOption(options, LiteralStringRef("stopDifferentialAfter"), 60.0);
-		backupTag = getOption(options, LiteralStringRef("backupTag"), BackupAgentBase::getDefaultTag());
-		restoreTag = getOption(options, LiteralStringRef("restoreTag"), LiteralStringRef("restore"));
-		backupRangesCount = getOption(options, LiteralStringRef("backupRangesCount"), 5);
-		extraPrefix = backupPrefix.withPrefix(LiteralStringRef("\xfe\xff\xfe"));
-		backupPrefix = backupPrefix.withPrefix(LiteralStringRef("\xfe\xff\xff"));
+		backupAfter = getOption(options, "backupAfter"_sr, deterministicRandom()->random01() * 10.0);
+		backupPrefix = getOption(options, "backupPrefix"_sr, StringRef());
+		backupRangeLengthMax = getOption(options, "backupRangeLengthMax"_sr, 1);
+		stopDifferentialAfter = getOption(options, "stopDifferentialAfter"_sr, 60.0);
+		backupTag = getOption(options, "backupTag"_sr, BackupAgentBase::getDefaultTag());
+		restoreTag = getOption(options, "restoreTag"_sr, "restore"_sr);
+		backupRangesCount = getOption(options, "backupRangesCount"_sr, 5);
+		extraPrefix = backupPrefix.withPrefix("\xfe\xff\xfe"_sr);
+		backupPrefix = backupPrefix.withPrefix("\xfe\xff\xff"_sr);
 
 		ASSERT(backupPrefix != StringRef());
 
@@ -174,7 +174,7 @@ struct BackupToDBUpgradeWorkload : TestWorkload {
 					    .detail("TaskCount", taskCount)
 					    .detail("WaitCycles", waitCycles);
 					printf("EndingNonZeroTasks: %ld\n", (long)taskCount);
-					wait(TaskBucket::debugPrintRange(cx, LiteralStringRef("\xff"), StringRef()));
+					wait(TaskBucket::debugPrintRange(cx, "\xff"_sr, StringRef()));
 				}
 
 				loop {
@@ -278,7 +278,7 @@ struct BackupToDBUpgradeWorkload : TestWorkload {
 		}
 
 		if (displaySystemKeys) {
-			wait(TaskBucket::debugPrintRange(cx, LiteralStringRef("\xff"), StringRef()));
+			wait(TaskBucket::debugPrintRange(cx, "\xff"_sr, StringRef()));
 		}
 
 		return Void();

--- a/fdbserver/workloads/BulkLoad.actor.cpp
+++ b/fdbserver/workloads/BulkLoad.actor.cpp
@@ -38,13 +38,13 @@ struct BulkLoadWorkload : TestWorkload {
 	BulkLoadWorkload(WorkloadContext const& wcx)
 	  : TestWorkload(wcx), clientCount(wcx.clientCount), transactions("Transactions"), retries("Retries"),
 	    latencies(2000) {
-		testDuration = getOption(options, LiteralStringRef("testDuration"), 10.0);
-		actorCount = getOption(options, LiteralStringRef("actorCount"), 20);
-		writesPerTransaction = getOption(options, LiteralStringRef("writesPerTransaction"), 10);
-		valueBytes = std::max(getOption(options, LiteralStringRef("valueBytes"), 96), 16);
+		testDuration = getOption(options, "testDuration"_sr, 10.0);
+		actorCount = getOption(options, "actorCount"_sr, 20);
+		writesPerTransaction = getOption(options, "writesPerTransaction"_sr, 10);
+		valueBytes = std::max(getOption(options, "valueBytes"_sr, 96), 16);
 		value = Value(std::string(valueBytes, '.'));
-		targetBytes = getOption(options, LiteralStringRef("targetBytes"), std::numeric_limits<uint64_t>::max());
-		keyPrefix = getOption(options, LiteralStringRef("keyPrefix"), LiteralStringRef(""));
+		targetBytes = getOption(options, "targetBytes"_sr, std::numeric_limits<uint64_t>::max());
+		keyPrefix = getOption(options, "keyPrefix"_sr, ""_sr);
 		keyPrefix = unprintable(keyPrefix.toString());
 	}
 

--- a/fdbserver/workloads/Cache.actor.cpp
+++ b/fdbserver/workloads/Cache.actor.cpp
@@ -7,7 +7,7 @@ struct CacheWorkload : TestWorkload {
 	Key keyPrefix;
 
 	CacheWorkload(WorkloadContext const& wcx) : TestWorkload(wcx) {
-		keyPrefix = unprintable(getOption(options, LiteralStringRef("keyPrefix"), LiteralStringRef("")).toString());
+		keyPrefix = unprintable(getOption(options, "keyPrefix"_sr, ""_sr).toString());
 	}
 
 	std::string description() const override { return "CacheWorkload"; }

--- a/fdbserver/workloads/ChangeConfig.actor.cpp
+++ b/fdbserver/workloads/ChangeConfig.actor.cpp
@@ -33,11 +33,11 @@ struct ChangeConfigWorkload : TestWorkload {
 	std::string networkAddresses; // comma separated list e.g. "127.0.0.1:4000,127.0.0.1:4001"
 
 	ChangeConfigWorkload(WorkloadContext const& wcx) : TestWorkload(wcx) {
-		minDelayBeforeChange = getOption(options, LiteralStringRef("minDelayBeforeChange"), 0);
-		maxDelayBeforeChange = getOption(options, LiteralStringRef("maxDelayBeforeChange"), 0);
+		minDelayBeforeChange = getOption(options, "minDelayBeforeChange"_sr, 0);
+		maxDelayBeforeChange = getOption(options, "maxDelayBeforeChange"_sr, 0);
 		ASSERT(maxDelayBeforeChange >= minDelayBeforeChange);
-		configMode = getOption(options, LiteralStringRef("configMode"), StringRef()).toString();
-		networkAddresses = getOption(options, LiteralStringRef("coordinators"), StringRef()).toString();
+		configMode = getOption(options, "configMode"_sr, StringRef()).toString();
+		networkAddresses = getOption(options, "coordinators"_sr, StringRef()).toString();
 	}
 
 	std::string description() const override { return "ChangeConfig"; }
@@ -128,9 +128,8 @@ struct ChangeConfigWorkload : TestWorkload {
 		if (autoChange) { // if auto, we first get the desired addresses by read \xff\xff/management/auto_coordinators
 			loop {
 				try {
-					Optional<Value> newCoordinatorsKey = wait(tr.get(
-					    LiteralStringRef("auto_coordinators")
-					        .withPrefix(SpecialKeySpace::getModuleRange(SpecialKeySpace::MODULE::MANAGEMENT).begin)));
+					Optional<Value> newCoordinatorsKey = wait(tr.get("auto_coordinators"_sr.withPrefix(
+					    SpecialKeySpace::getModuleRange(SpecialKeySpace::MODULE::MANAGEMENT).begin)));
 					ASSERT(newCoordinatorsKey.present());
 					desiredCoordinatorsKey = newCoordinatorsKey.get().toString();
 					tr.reset();
@@ -167,8 +166,7 @@ struct ChangeConfigWorkload : TestWorkload {
 		loop {
 			try {
 				tr.setOption(FDBTransactionOptions::SPECIAL_KEY_SPACE_ENABLE_WRITES);
-				tr.set(LiteralStringRef("processes")
-				           .withPrefix(SpecialKeySpace::getManagementApiCommandPrefix("coordinators")),
+				tr.set("processes"_sr.withPrefix(SpecialKeySpace::getManagementApiCommandPrefix("coordinators")),
 				       Value(desiredCoordinatorsKey));
 				TraceEvent(SevDebug, "CoordinatorsChangeBeforeCommit")
 				    .detail("Auto", autoChange)

--- a/fdbserver/workloads/ClientTransactionProfileCorrectness.actor.cpp
+++ b/fdbserver/workloads/ClientTransactionProfileCorrectness.actor.cpp
@@ -26,8 +26,8 @@
 #include "fdbclient/Tuple.h"
 #include "flow/actorcompiler.h" // has to be last include
 
-static const Key CLIENT_LATENCY_INFO_PREFIX = LiteralStringRef("client_latency/");
-static const Key CLIENT_LATENCY_INFO_CTR_PREFIX = LiteralStringRef("client_latency_counter/");
+static const Key CLIENT_LATENCY_INFO_PREFIX = "client_latency/"_sr;
+static const Key CLIENT_LATENCY_INFO_CTR_PREFIX = "client_latency_counter/"_sr;
 
 /*
 FF               - 2 bytes \xff\x02
@@ -37,8 +37,7 @@ NNNN             - 4 Bytes Chunk number (Big Endian)
 TTTT             - 4 Bytes Total number of chunks (Big Endian)
 XXXX             - Variable length user provided transaction identifier
 */
-StringRef sampleTrInfoKey =
-    LiteralStringRef("\xff\x02/fdbClientInfo/client_latency/SSSSSSSSSS/RRRRRRRRRRRRRRRR/NNNNTTTT/XXXX/");
+StringRef sampleTrInfoKey = "\xff\x02/fdbClientInfo/client_latency/SSSSSSSSSS/RRRRRRRRRRRRRRRR/NNNNTTTT/XXXX/"_sr;
 static const auto chunkNumStartIndex = sampleTrInfoKey.toString().find('N');
 static const auto numChunksStartIndex = sampleTrInfoKey.toString().find('T');
 static const int chunkFormatSize = 4;
@@ -203,10 +202,10 @@ struct ClientTransactionProfileCorrectnessWorkload : TestWorkload {
 
 	ClientTransactionProfileCorrectnessWorkload(WorkloadContext const& wcx) : TestWorkload(wcx) {
 		samplingProbability = getOption(options,
-		                                LiteralStringRef("samplingProbability"),
+		                                "samplingProbability"_sr,
 		                                deterministicRandom()->random01() / 10); // rand range 0 - 0.1
 		trInfoSizeLimit = getOption(options,
-		                            LiteralStringRef("trInfoSizeLimit"),
+		                            "trInfoSizeLimit"_sr,
 		                            deterministicRandom()->randomInt(100 * 1024, 10 * 1024 * 1024)); // 100 KB - 10 MB
 		TraceEvent(SevInfo, "ClientTransactionProfilingSetup")
 		    .detail("ClientId", clientId)

--- a/fdbserver/workloads/CommitBugCheck.actor.cpp
+++ b/fdbserver/workloads/CommitBugCheck.actor.cpp
@@ -36,8 +36,8 @@ struct CommitBugWorkload : TestWorkload {
 
 	ACTOR Future<Void> bug1(Database cx, CommitBugWorkload* self) {
 		state Key key = StringRef(format("B1Key%d", self->clientId));
-		state Value val1 = LiteralStringRef("Value1");
-		state Value val2 = LiteralStringRef("Value2");
+		state Value val1 = "Value1"_sr;
+		state Value val2 = "Value2"_sr;
 
 		loop {
 			state Transaction tr(cx);

--- a/fdbserver/workloads/ConfigureDatabase.actor.cpp
+++ b/fdbserver/workloads/ConfigureDatabase.actor.cpp
@@ -218,9 +218,9 @@ struct ConfigureDatabaseWorkload : TestWorkload {
 	PerfIntCounter retries;
 
 	ConfigureDatabaseWorkload(WorkloadContext const& wcx) : TestWorkload(wcx), retries("Retries") {
-		testDuration = getOption(options, LiteralStringRef("testDuration"), 200.0);
+		testDuration = getOption(options, "testDuration"_sr, 200.0);
 		allowDescriptorChange =
-		    getOption(options, LiteralStringRef("allowDescriptorChange"), SERVER_KNOBS->ENABLE_CROSS_CLUSTER_SUPPORT);
+		    getOption(options, "allowDescriptorChange"_sr, SERVER_KNOBS->ENABLE_CROSS_CLUSTER_SUPPORT);
 
 		g_simulator.usableRegions = 1;
 	}
@@ -278,7 +278,7 @@ struct ConfigureDatabaseWorkload : TestWorkload {
 			if (randomChoice == 0) {
 				wait(success(
 				    runRYWTransaction(cx, [=](Reference<ReadYourWritesTransaction> tr) -> Future<Optional<Value>> {
-					    return tr->get(LiteralStringRef("This read is only to ensure that the database recovered"));
+					    return tr->get("This read is only to ensure that the database recovered"_sr);
 				    })));
 				wait(delay(20 + 10 * deterministicRandom()->random01()));
 			} else if (randomChoice < 3) {

--- a/fdbserver/workloads/ConflictRange.actor.cpp
+++ b/fdbserver/workloads/ConflictRange.actor.cpp
@@ -39,12 +39,12 @@ struct ConflictRangeWorkload : TestWorkload {
 
 	ConflictRangeWorkload(WorkloadContext const& wcx)
 	  : TestWorkload(wcx), withConflicts("WithConflicts"), withoutConflicts("withoutConflicts"), retries("Retries") {
-		minOperationsPerTransaction = getOption(options, LiteralStringRef("minOperationsPerTransaction"), 2);
-		maxOperationsPerTransaction = getOption(options, LiteralStringRef("minOperationsPerTransaction"), 4);
-		maxKeySpace = getOption(options, LiteralStringRef("maxKeySpace"), 100);
-		maxOffset = getOption(options, LiteralStringRef("maxOffset"), 5);
-		testDuration = getOption(options, LiteralStringRef("testDuration"), 10.0);
-		testReadYourWrites = getOption(options, LiteralStringRef("testReadYourWrites"), false);
+		minOperationsPerTransaction = getOption(options, "minOperationsPerTransaction"_sr, 2);
+		maxOperationsPerTransaction = getOption(options, "minOperationsPerTransaction"_sr, 4);
+		maxKeySpace = getOption(options, "maxKeySpace"_sr, 100);
+		maxOffset = getOption(options, "maxOffset"_sr, 5);
+		testDuration = getOption(options, "testDuration"_sr, 10.0);
+		testReadYourWrites = getOption(options, "testReadYourWrites"_sr, false);
 	}
 
 	std::string description() const override { return "ConflictRange"; }
@@ -262,7 +262,7 @@ struct ConflictRangeWorkload : TestWorkload {
 							throw not_committed();
 						}
 
-						if (originalResults[originalResults.size() - 1].key >= LiteralStringRef("\xff")) {
+						if (originalResults[originalResults.size() - 1].key >= "\xff"_sr) {
 							// Results go into server keyspace, so if a key selector does not fully resolve offset, a
 							// change won't effect results
 							throw not_committed();

--- a/fdbserver/workloads/ConsistencyCheck.actor.cpp
+++ b/fdbserver/workloads/ConsistencyCheck.actor.cpp
@@ -96,16 +96,16 @@ struct ConsistencyCheckWorkload : TestWorkload {
 	Future<Void> monitorConsistencyCheckSettingsActor;
 
 	ConsistencyCheckWorkload(WorkloadContext const& wcx) : TestWorkload(wcx) {
-		performQuiescentChecks = getOption(options, LiteralStringRef("performQuiescentChecks"), false);
-		performCacheCheck = getOption(options, LiteralStringRef("performCacheCheck"), false);
-		performTSSCheck = getOption(options, LiteralStringRef("performTSSCheck"), true);
-		quiescentWaitTimeout = getOption(options, LiteralStringRef("quiescentWaitTimeout"), 600.0);
-		distributed = getOption(options, LiteralStringRef("distributed"), true);
-		shardSampleFactor = std::max(getOption(options, LiteralStringRef("shardSampleFactor"), 1), 1);
-		failureIsError = getOption(options, LiteralStringRef("failureIsError"), false);
-		rateLimitMax = getOption(options, LiteralStringRef("rateLimitMax"), 0);
-		shuffleShards = getOption(options, LiteralStringRef("shuffleShards"), false);
-		indefinite = getOption(options, LiteralStringRef("indefinite"), false);
+		performQuiescentChecks = getOption(options, "performQuiescentChecks"_sr, false);
+		performCacheCheck = getOption(options, "performCacheCheck"_sr, false);
+		performTSSCheck = getOption(options, "performTSSCheck"_sr, true);
+		quiescentWaitTimeout = getOption(options, "quiescentWaitTimeout"_sr, 600.0);
+		distributed = getOption(options, "distributed"_sr, true);
+		shardSampleFactor = std::max(getOption(options, "shardSampleFactor"_sr, 1), 1);
+		failureIsError = getOption(options, "failureIsError"_sr, false);
+		rateLimitMax = getOption(options, "rateLimitMax"_sr, 0);
+		shuffleShards = getOption(options, "shuffleShards"_sr, false);
+		indefinite = getOption(options, "indefinite"_sr, false);
 		suspendConsistencyCheck.set(true);
 
 		success = true;

--- a/fdbserver/workloads/CpuProfiler.actor.cpp
+++ b/fdbserver/workloads/CpuProfiler.actor.cpp
@@ -42,9 +42,9 @@ struct CpuProfilerWorkload : TestWorkload {
 	std::vector<WorkerInterface> profilingWorkers;
 
 	CpuProfilerWorkload(WorkloadContext const& wcx) : TestWorkload(wcx) {
-		initialDelay = getOption(options, LiteralStringRef("initialDelay"), 0.0);
-		duration = getOption(options, LiteralStringRef("duration"), -1.0);
-		roles = getOption(options, LiteralStringRef("roles"), vector<std::string>());
+		initialDelay = getOption(options, "initialDelay"_sr, 0.0);
+		duration = getOption(options, "duration"_sr, -1.0);
+		roles = getOption(options, "roles"_sr, vector<std::string>());
 		success = true;
 	}
 

--- a/fdbserver/workloads/Cycle.actor.cpp
+++ b/fdbserver/workloads/Cycle.actor.cpp
@@ -46,7 +46,7 @@ struct CycleWorkload : TestWorkload {
 		transactionsPerSecond = getOption(options, "transactionsPerSecond"_sr, 5000.0) / clientCount;
 		actorCount = getOption(options, "actorsPerClient"_sr, transactionsPerSecond / 5);
 		nodeCount = getOption(options, "nodeCount"_sr, transactionsPerSecond * clientCount);
-		keyPrefix = unprintable(getOption(options, "keyPrefix"_sr, LiteralStringRef("")).toString());
+		keyPrefix = unprintable(getOption(options, "keyPrefix"_sr, ""_sr).toString());
 		traceParentProbability = getOption(options, "traceParentProbability "_sr, 0.01);
 		minExpectedTransactionsPerSecond = transactionsPerSecond * getOption(options, "expectedRate"_sr, 0.7);
 	}

--- a/fdbserver/workloads/DDBalance.actor.cpp
+++ b/fdbserver/workloads/DDBalance.actor.cpp
@@ -36,17 +36,17 @@ struct DDBalanceWorkload : TestWorkload {
 
 	DDBalanceWorkload(WorkloadContext const& wcx)
 	  : TestWorkload(wcx), latencies(2000), bin_shifts("Bin_Shifts"), operations("Operations"), retries("Retries") {
-		testDuration = getOption(options, LiteralStringRef("testDuration"), 10.0);
-		binCount = getOption(options, LiteralStringRef("binCount"), 1000);
-		writesPerTransaction = getOption(options, LiteralStringRef("writesPerTransaction"), 1);
-		keySpaceDriftFactor = getOption(options, LiteralStringRef("keySpaceDriftFactor"), 1);
-		moversPerClient = std::max(getOption(options, LiteralStringRef("moversPerClient"), 10), 1);
-		actorsPerClient = std::max(getOption(options, LiteralStringRef("actorsPerClient"), 100), 1);
-		int nodes = getOption(options, LiteralStringRef("nodes"), 10000);
-		discardEdgeMeasurements = getOption(options, LiteralStringRef("discardEdgeMeasurements"), true);
-		warmingDelay = getOption(options, LiteralStringRef("warmingDelay"), 0.0);
+		testDuration = getOption(options, "testDuration"_sr, 10.0);
+		binCount = getOption(options, "binCount"_sr, 1000);
+		writesPerTransaction = getOption(options, "writesPerTransaction"_sr, 1);
+		keySpaceDriftFactor = getOption(options, "keySpaceDriftFactor"_sr, 1);
+		moversPerClient = std::max(getOption(options, "moversPerClient"_sr, 10), 1);
+		actorsPerClient = std::max(getOption(options, "actorsPerClient"_sr, 100), 1);
+		int nodes = getOption(options, "nodes"_sr, 10000);
+		discardEdgeMeasurements = getOption(options, "discardEdgeMeasurements"_sr, true);
+		warmingDelay = getOption(options, "warmingDelay"_sr, 0.0);
 		transactionsPerSecond =
-		    getOption(options, LiteralStringRef("transactionsPerSecond"), 5000.0) / (clientCount * moversPerClient);
+		    getOption(options, "transactionsPerSecond"_sr, 5000.0) / (clientCount * moversPerClient);
 
 		nodesPerActor = nodes / (actorsPerClient * clientCount);
 

--- a/fdbserver/workloads/DDMetrics.actor.cpp
+++ b/fdbserver/workloads/DDMetrics.actor.cpp
@@ -30,7 +30,7 @@ struct DDMetricsWorkload : TestWorkload {
 	double startDelay, ddDone;
 
 	DDMetricsWorkload(WorkloadContext const& wcx) : TestWorkload(wcx), ddDone(0.0) {
-		startDelay = getOption(options, LiteralStringRef("beginPoll"), 10.0);
+		startDelay = getOption(options, "beginPoll"_sr, 10.0);
 	}
 
 	std::string description() const override { return "Data Distribution Metrics"; }
@@ -39,8 +39,8 @@ struct DDMetricsWorkload : TestWorkload {
 		WorkerInterface masterWorker = wait(getMasterWorker(cx, self->dbInfo));
 
 		TraceEvent("GetHighPriorityReliocationsInFlight").detail("Stage", "ContactingMaster");
-		TraceEventFields md = wait(
-		    timeoutError(masterWorker.eventLogRequest.getReply(EventLogRequest(LiteralStringRef("MovingData"))), 1.0));
+		TraceEventFields md =
+		    wait(timeoutError(masterWorker.eventLogRequest.getReply(EventLogRequest("MovingData"_sr)), 1.0));
 		int relocations;
 		sscanf(md.getValue("UnhealthyRelocations").c_str(), "%d", &relocations);
 		return relocations;

--- a/fdbserver/workloads/DDMetricsExclude.actor.cpp
+++ b/fdbserver/workloads/DDMetricsExclude.actor.cpp
@@ -38,8 +38,8 @@ struct DDMetricsExcludeWorkload : TestWorkload {
 	DDMetricsExcludeWorkload(WorkloadContext const& wcx)
 	  : TestWorkload(wcx), ddDone(0.0), peakMovingData(0.0), peakInQueue(0.0), peakInFlight(0.0),
 	    movingDataPerSec(0.0) {
-		excludeIp = getOption(options, LiteralStringRef("excludeIp"), Value(LiteralStringRef("127.0.0.1")));
-		excludePort = getOption(options, LiteralStringRef("excludePort"), 4500);
+		excludeIp = getOption(options, "excludeIp"_sr, Value("127.0.0.1"_sr));
+		excludePort = getOption(options, "excludePort"_sr, 4500);
 	}
 
 	static Value getRandomValue() {

--- a/fdbserver/workloads/DataDistributionMetrics.actor.cpp
+++ b/fdbserver/workloads/DataDistributionMetrics.actor.cpp
@@ -37,11 +37,11 @@ struct DataDistributionMetricsWorkload : KVWorkload {
 
 	DataDistributionMetricsWorkload(WorkloadContext const& wcx)
 	  : KVWorkload(wcx), numShards(0), avgBytes(0), commits("Commits"), errors("Errors") {
-		testDuration = getOption(options, LiteralStringRef("testDuration"), 10.0);
-		keyPrefix = getOption(options, LiteralStringRef("keyPrefix"), LiteralStringRef("DDMetrics")).toString();
-		readPerTx = getOption(options, LiteralStringRef("readPerTransaction"), 1);
-		writePerTx = getOption(options, LiteralStringRef("writePerTransaction"), 5 * readPerTx);
-		delayPerLoop = getOption(options, LiteralStringRef("delayPerLoop"), 0.1); // throttling dd rpc calls
+		testDuration = getOption(options, "testDuration"_sr, 10.0);
+		keyPrefix = getOption(options, "keyPrefix"_sr, "DDMetrics"_sr).toString();
+		readPerTx = getOption(options, "readPerTransaction"_sr, 1);
+		writePerTx = getOption(options, "writePerTransaction"_sr, 5 * readPerTx);
+		delayPerLoop = getOption(options, "delayPerLoop"_sr, 0.1); // throttling dd rpc calls
 		ASSERT(nodeCount > 1);
 	}
 

--- a/fdbserver/workloads/DifferentClustersSameRV.actor.cpp
+++ b/fdbserver/workloads/DifferentClustersSameRV.actor.cpp
@@ -39,10 +39,10 @@ struct DifferentClustersSameRVWorkload : TestWorkload {
 		ASSERT(g_simulator.extraDB != nullptr);
 		auto extraFile = makeReference<ClusterConnectionFile>(*g_simulator.extraDB);
 		extraDB = Database::createDatabase(extraFile, -1);
-		testDuration = getOption(options, LiteralStringRef("testDuration"), 100.0);
-		switchAfter = getOption(options, LiteralStringRef("switchAfter"), 50.0);
-		keyToRead = getOption(options, LiteralStringRef("keyToRead"), LiteralStringRef("someKey"));
-		keyToWatch = getOption(options, LiteralStringRef("keyToWatch"), LiteralStringRef("anotherKey"));
+		testDuration = getOption(options, "testDuration"_sr, 100.0);
+		switchAfter = getOption(options, "switchAfter"_sr, 50.0);
+		keyToRead = getOption(options, "keyToRead"_sr, "someKey"_sr);
+		keyToWatch = getOption(options, "keyToWatch"_sr, "anotherKey"_sr);
 	}
 
 	std::string description() const override { return "DifferentClustersSameRV"; }
@@ -162,7 +162,7 @@ struct DifferentClustersSameRVWorkload : TestWorkload {
 		wait(unlockDatabase(self->extraDB, lockUid));
 		TraceEvent("DifferentClusters_UnlockedExtraDB");
 		ASSERT(!watchFuture.isReady() || watchFuture.isError());
-		wait(doWrite(self->extraDB, self->keyToWatch, Optional<Value>{ LiteralStringRef("") }));
+		wait(doWrite(self->extraDB, self->keyToWatch, Optional<Value>{ ""_sr }));
 		TraceEvent("DifferentClusters_WaitingForWatch");
 		try {
 			wait(timeoutError(watchFuture, (self->testDuration - self->switchAfter) / 2));

--- a/fdbserver/workloads/DiskDurability.actor.cpp
+++ b/fdbserver/workloads/DiskDurability.actor.cpp
@@ -87,14 +87,14 @@ struct DiskDurabilityWorkload : public AsyncFileWorkload {
 	double syncInterval;
 
 	DiskDurabilityWorkload(WorkloadContext const& wcx) : AsyncFileWorkload(wcx) {
-		writers = getOption(options, LiteralStringRef("writers"), 1);
-		filePages = getOption(options, LiteralStringRef("filePages"), 1000000);
+		writers = getOption(options, "writers"_sr, 1);
+		filePages = getOption(options, "filePages"_sr, 1000000);
 		fileSize = filePages * _PAGE_SIZE;
 		unbufferedIO = true;
 		uncachedIO = true;
 		fillRandom = false;
-		pagesPerWrite = getOption(options, LiteralStringRef("pagesPerWrite"), 1);
-		syncInterval = (double)(getOption(options, LiteralStringRef("syncIntervalMs"), 2000)) / 1000;
+		pagesPerWrite = getOption(options, "pagesPerWrite"_sr, 1);
+		syncInterval = (double)(getOption(options, "syncIntervalMs"_sr, 2000)) / 1000;
 	}
 
 	~DiskDurabilityWorkload() override {}

--- a/fdbserver/workloads/DiskDurabilityTest.actor.cpp
+++ b/fdbserver/workloads/DiskDurabilityTest.actor.cpp
@@ -31,9 +31,9 @@ struct DiskDurabilityTest : TestWorkload {
 
 	DiskDurabilityTest(WorkloadContext const& wcx) : TestWorkload(wcx) {
 		enabled = !clientId; // only do this on the "first" client
-		filename = getOption(options, LiteralStringRef("filename"), LiteralStringRef("durability_test.bin")).toString();
-		auto prefix = getOption(options, LiteralStringRef("prefix"), LiteralStringRef("/DiskDurabilityTest/"));
-		range = prefixRange(LiteralStringRef("S").withPrefix(prefix));
+		filename = getOption(options, "filename"_sr, "durability_test.bin"_sr).toString();
+		auto prefix = getOption(options, "prefix"_sr, "/DiskDurabilityTest/"_sr);
+		range = prefixRange("S"_sr.withPrefix(prefix));
 		metrics = prefixRange(prefix);
 	}
 
@@ -141,10 +141,10 @@ struct DiskDurabilityTest : TestWorkload {
 						tr.clear(self->encodeKey(targetPages[i]));
 
 					if (!first) {
-						Optional<Value> v = wait(tr.get(LiteralStringRef("syncs").withPrefix(self->metrics.begin)));
+						Optional<Value> v = wait(tr.get("syncs"_sr.withPrefix(self->metrics.begin)));
 						int64_t count = v.present() ? self->decodeValue(v.get()) : 0;
 						count++;
-						tr.set(LiteralStringRef("syncs").withPrefix(self->metrics.begin), self->encodeValue(count));
+						tr.set("syncs"_sr.withPrefix(self->metrics.begin), self->encodeValue(count));
 					}
 
 					wait(tr.commit());

--- a/fdbserver/workloads/Downgrade.actor.cpp
+++ b/fdbserver/workloads/Downgrade.actor.cpp
@@ -31,9 +31,9 @@ struct DowngradeWorkload : TestWorkload {
 	int numObjects;
 
 	DowngradeWorkload(WorkloadContext const& wcx) : TestWorkload(wcx) {
-		oldKey = getOption(options, LiteralStringRef("oldKey"), LiteralStringRef("oldKey"));
-		newKey = getOption(options, LiteralStringRef("newKey"), LiteralStringRef("newKey"));
-		numObjects = getOption(options, LiteralStringRef("numOptions"), deterministicRandom()->randomInt(0, 100));
+		oldKey = getOption(options, "oldKey"_sr, "oldKey"_sr);
+		newKey = getOption(options, "newKey"_sr, "newKey"_sr);
+		numObjects = getOption(options, "numOptions"_sr, deterministicRandom()->randomInt(0, 100));
 	}
 
 	struct _Struct {

--- a/fdbserver/workloads/DummyWorkload.actor.cpp
+++ b/fdbserver/workloads/DummyWorkload.actor.cpp
@@ -27,8 +27,8 @@ struct DummyWorkload : TestWorkload {
 	double displayDelay;
 
 	DummyWorkload(WorkloadContext const& wcx) : TestWorkload(wcx) {
-		displayWorkers = getOption(options, LiteralStringRef("displayWorkers"), true);
-		displayDelay = getOption(options, LiteralStringRef("displayDelay"), 0.0);
+		displayWorkers = getOption(options, "displayWorkers"_sr, true);
+		displayDelay = getOption(options, "displayDelay"_sr, 0.0);
 	}
 
 	std::string description() const override { return "DummyWorkload"; }

--- a/fdbserver/workloads/ExternalWorkload.actor.cpp
+++ b/fdbserver/workloads/ExternalWorkload.actor.cpp
@@ -132,9 +132,9 @@ struct ExternalWorkload : TestWorkload, FDBWorkloadContext {
 	}
 
 	explicit ExternalWorkload(WorkloadContext const& wcx) : TestWorkload(wcx) {
-		libraryName = ::getOption(options, LiteralStringRef("libraryName"), LiteralStringRef("")).toString();
-		libraryPath = ::getOption(options, LiteralStringRef("libraryPath"), Value(getDefaultLibraryPath())).toString();
-		auto wName = ::getOption(options, LiteralStringRef("workloadName"), LiteralStringRef(""));
+		libraryName = ::getOption(options, "libraryName"_sr, ""_sr).toString();
+		libraryPath = ::getOption(options, "libraryPath"_sr, Value(getDefaultLibraryPath())).toString();
+		auto wName = ::getOption(options, "workloadName"_sr, ""_sr);
 		auto fullPath = joinPath(libraryPath, toLibName(libraryName));
 		TraceEvent("ExternalWorkloadLoad")
 		    .detail("LibraryName", libraryName)
@@ -189,7 +189,7 @@ struct ExternalWorkload : TestWorkload, FDBWorkloadContext {
 		keepAlive(f, database);
 		workloadImpl->setup(reinterpret_cast<FDBDatabase*>(database.getPtr()),
 		                    GenericPromise<bool>(new FDBPromiseImpl(promise)));
-		return assertTrue(LiteralStringRef("setup"), f);
+		return assertTrue("setup"_sr, f);
 	}
 
 	Future<Void> start(Database const& cx) override {
@@ -204,7 +204,7 @@ struct ExternalWorkload : TestWorkload, FDBWorkloadContext {
 		keepAlive(f, database);
 		workloadImpl->start(reinterpret_cast<FDBDatabase*>(database.getPtr()),
 		                    GenericPromise<bool>(new FDBPromiseImpl(promise)));
-		return assertTrue(LiteralStringRef("start"), f);
+		return assertTrue("start"_sr, f);
 	}
 	Future<bool> check(Database const& cx) override {
 		if (!success) {

--- a/fdbserver/workloads/FastTriggeredWatches.actor.cpp
+++ b/fdbserver/workloads/FastTriggeredWatches.actor.cpp
@@ -36,10 +36,10 @@ struct FastTriggeredWatchesWorkload : TestWorkload {
 
 	FastTriggeredWatchesWorkload(WorkloadContext const& wcx)
 	  : TestWorkload(wcx), operations("Operations"), retries("Retries") {
-		testDuration = getOption(options, LiteralStringRef("testDuration"), 600.0);
-		nodes = getOption(options, LiteralStringRef("nodes"), 100);
+		testDuration = getOption(options, "testDuration"_sr, 600.0);
+		nodes = getOption(options, "nodes"_sr, 100);
 		defaultValue = StringRef(format("%010d", deterministicRandom()->randomInt(0, 1000)));
-		keyBytes = std::max(getOption(options, LiteralStringRef("keyBytes"), 16), 16);
+		keyBytes = std::max(getOption(options, "keyBytes"_sr, 16), 16);
 	}
 
 	std::string description() const override { return "Watches"; }

--- a/fdbserver/workloads/FileSystem.actor.cpp
+++ b/fdbserver/workloads/FileSystem.actor.cpp
@@ -44,23 +44,21 @@ struct FileSystemWorkload : TestWorkload {
 
 	FileSystemWorkload(WorkloadContext const& wcx)
 	  : TestWorkload(wcx), latencies(2500), writeLatencies(1000), queries("Queries"), writes("Latency") {
-		testDuration = getOption(options, LiteralStringRef("testDuration"), 10.0);
-		transactionsPerSecond = getOption(options, LiteralStringRef("transactionsPerSecond"), 5000.0) / clientCount;
-		double allowedLatency = getOption(options, LiteralStringRef("allowedLatency"), 0.250);
+		testDuration = getOption(options, "testDuration"_sr, 10.0);
+		transactionsPerSecond = getOption(options, "transactionsPerSecond"_sr, 5000.0) / clientCount;
+		double allowedLatency = getOption(options, "allowedLatency"_sr, 0.250);
 		actorCount = transactionsPerSecond * allowedLatency;
-		fileCount = getOption(options, LiteralStringRef("fileCount"), 100000);
-		pathMinChars = std::max(getOption(options, LiteralStringRef("pathMinChars"), 32), 8);
-		pathCharRange =
-		    std::max(getOption(options, LiteralStringRef("pathMaxChars"), 128), pathMinChars) - pathMinChars;
-		discardEdgeMeasurements = getOption(options, LiteralStringRef("discardEdgeMeasurements"), true);
-		deletedFilesRatio = getOption(options, LiteralStringRef("deletedFilesRatio"), 0.01);
-		serverCount = getOption(options, LiteralStringRef("serverCount"), 32);
-		userIDCount = getOption(options, LiteralStringRef("userIDCount"), std::max(100, fileCount / 3000));
-		operationName =
-		    getOption(options, LiteralStringRef("operationName"), LiteralStringRef("modificationQuery")).toString();
-		performingWrites = getOption(options, LiteralStringRef("performingWrites"), false);
-		writeActorCount = getOption(options, LiteralStringRef("writeActorCount"), 4);
-		loggingQueries = getOption(options, LiteralStringRef("loggingQueries"), false);
+		fileCount = getOption(options, "fileCount"_sr, 100000);
+		pathMinChars = std::max(getOption(options, "pathMinChars"_sr, 32), 8);
+		pathCharRange = std::max(getOption(options, "pathMaxChars"_sr, 128), pathMinChars) - pathMinChars;
+		discardEdgeMeasurements = getOption(options, "discardEdgeMeasurements"_sr, true);
+		deletedFilesRatio = getOption(options, "deletedFilesRatio"_sr, 0.01);
+		serverCount = getOption(options, "serverCount"_sr, 32);
+		userIDCount = getOption(options, "userIDCount"_sr, std::max(100, fileCount / 3000));
+		operationName = getOption(options, "operationName"_sr, "modificationQuery"_sr).toString();
+		performingWrites = getOption(options, "performingWrites"_sr, false);
+		writeActorCount = getOption(options, "writeActorCount"_sr, 4);
+		loggingQueries = getOption(options, "loggingQueries"_sr, false);
 	}
 
 	std::string description() const override { return "ReadWrite"; }
@@ -105,7 +103,7 @@ struct FileSystemWorkload : TestWorkload {
 		std::string keyStr(key.toString());
 		tr->set(keyStr + "/size", format("%d", deterministicRandom()->randomInt(0, std::numeric_limits<int>::max())));
 		tr->set(keyStr + "/server", format("%d", deterministicRandom()->randomInt(0, self->serverCount)));
-		tr->set(keyStr + "/deleted", deleted ? LiteralStringRef("1") : LiteralStringRef("0"));
+		tr->set(keyStr + "/deleted", deleted ? "1"_sr : "0"_sr);
 		tr->set(keyStr + "/server", format("%d", serverID));
 		tr->set(keyStr + "/created", doubleToTestKey(time));
 		tr->set(keyStr + "/lastupdated", doubleToTestKey(time));
@@ -250,10 +248,10 @@ struct FileSystemWorkload : TestWorkload {
 						ASSERT(serverStr.present());
 						int serverID = testKeyToInt(serverStr.get());
 						if (deleted.get().toString() == "1") {
-							tr.set(keyStr + "/deleted", LiteralStringRef("0"));
+							tr.set(keyStr + "/deleted", "0"_sr);
 							tr.clear(format("/files/server/%08x/deleted/%016llx", serverID, fileID));
 						} else {
-							tr.set(keyStr + "/deleted", LiteralStringRef("1"));
+							tr.set(keyStr + "/deleted", "1"_sr);
 							tr.set(format("/files/server/%08x/deleted/%016llx", serverID, fileID),
 							       doubleToTestKey(time));
 						}

--- a/fdbserver/workloads/FuzzApiCorrectness.actor.cpp
+++ b/fdbserver/workloads/FuzzApiCorrectness.actor.cpp
@@ -125,11 +125,11 @@ struct FuzzApiCorrectnessWorkload : TestWorkload {
 	FuzzApiCorrectnessWorkload(WorkloadContext const& wcx) : TestWorkload(wcx), operationId(0), success(true) {
 		std::call_once(onceFlag, [&]() { addTestCases(); });
 
-		testDuration = getOption(options, LiteralStringRef("testDuration"), 60.0);
-		numOps = getOption(options, LiteralStringRef("numOps"), 21);
-		rarelyCommit = getOption(options, LiteralStringRef("rarelyCommit"), false);
-		maximumTotalData = getOption(options, LiteralStringRef("maximumTotalData"), 15e6);
-		minNode = getOption(options, LiteralStringRef("minNode"), 0);
+		testDuration = getOption(options, "testDuration"_sr, 60.0);
+		numOps = getOption(options, "numOps"_sr, 21);
+		rarelyCommit = getOption(options, "rarelyCommit"_sr, false);
+		maximumTotalData = getOption(options, "maximumTotalData"_sr, 15e6);
+		minNode = getOption(options, "minNode"_sr, 0);
 		adjacentKeys = deterministicRandom()->coinflip();
 		useSystemKeys = deterministicRandom()->coinflip();
 		initialKeyDensity = deterministicRandom()->random01(); // This fraction of keys are present before the first
@@ -159,7 +159,7 @@ struct FuzzApiCorrectnessWorkload : TestWorkload {
 		}
 
 		maxClearSize = 1 << deterministicRandom()->randomInt(0, 20);
-		conflictRange = KeyRangeRef(LiteralStringRef("\xfe"), LiteralStringRef("\xfe\x00"));
+		conflictRange = KeyRangeRef("\xfe"_sr, "\xfe\x00"_sr);
 		TraceEvent("FuzzApiCorrectnessConfiguration")
 		    .detail("Nodes", nodes)
 		    .detail("InitialKeyDensity", initialKeyDensity)
@@ -633,15 +633,13 @@ struct FuzzApiCorrectnessWorkload : TestWorkload {
 				    error_code_special_keys_no_module_found,
 				    ExceptionContract::possibleIf(specialKeys.contains(key) && !workload->specialKeysRelaxed)),
 				// Read this particular special key may throw timed_out
-				std::make_pair(error_code_timed_out,
-				               ExceptionContract::possibleIf(key == LiteralStringRef("\xff\xff/status/json"))),
+				std::make_pair(error_code_timed_out, ExceptionContract::possibleIf(key == "\xff\xff/status/json"_sr)),
 				// Read this particular special key may throw special_keys_api_failure
 				std::make_pair(
 				    error_code_special_keys_api_failure,
 				    ExceptionContract::possibleIf(
-				        key ==
-				        LiteralStringRef("auto_coordinators")
-				            .withPrefix(SpecialKeySpace::getModuleRange(SpecialKeySpace::MODULE::MANAGEMENT).begin)))
+				        key == "auto_coordinators"_sr.withPrefix(
+				                   SpecialKeySpace::getModuleRange(SpecialKeySpace::MODULE::MANAGEMENT).begin)))
 			};
 		}
 
@@ -796,11 +794,10 @@ struct FuzzApiCorrectnessWorkload : TestWorkload {
 
 			bool isSpecialKeyRange = specialKeys.contains(key1) && specialKeys.begin <= key2 && key2 <= specialKeys.end;
 			// Read this particular special key may throw special_keys_api_failure
-			Key autoCoordinatorSpecialKey =
-			    LiteralStringRef("auto_coordinators")
-			        .withPrefix(SpecialKeySpace::getModuleRange(SpecialKeySpace::MODULE::MANAGEMENT).begin);
+			Key autoCoordinatorSpecialKey = "auto_coordinators"_sr.withPrefix(
+			    SpecialKeySpace::getModuleRange(SpecialKeySpace::MODULE::MANAGEMENT).begin);
 			// Read this particular special key may throw timed_out
-			Key statusJsonSpecialKey = LiteralStringRef("\xff\xff/status/json");
+			Key statusJsonSpecialKey = "\xff\xff/status/json"_sr;
 
 			contract = {
 				std::make_pair(error_code_inverted_range, ExceptionContract::requiredIf(key1 > key2)),
@@ -847,10 +844,9 @@ struct FuzzApiCorrectnessWorkload : TestWorkload {
 			limits = makeRangeLimits();
 
 			bool isSpecialKeyRange = specialKeys.contains(key1) && specialKeys.begin <= key2 && key2 <= specialKeys.end;
-			Key autoCoordinatorSpecialKey =
-			    LiteralStringRef("auto_coordinators")
-			        .withPrefix(SpecialKeySpace::getModuleRange(SpecialKeySpace::MODULE::MANAGEMENT).begin);
-			Key statusJsonSpecialKey = LiteralStringRef("\xff\xff/status/json");
+			Key autoCoordinatorSpecialKey = "auto_coordinators"_sr.withPrefix(
+			    SpecialKeySpace::getModuleRange(SpecialKeySpace::MODULE::MANAGEMENT).begin);
+			Key statusJsonSpecialKey = "\xff\xff/status/json"_sr;
 
 			contract = {
 				std::make_pair(error_code_inverted_range, ExceptionContract::requiredIf(key1 > key2)),

--- a/fdbserver/workloads/GetRangeStream.actor.cpp
+++ b/fdbserver/workloads/GetRangeStream.actor.cpp
@@ -32,10 +32,10 @@ struct GetRangeStream : TestWorkload {
 	bool printKVPairs;
 
 	GetRangeStream(WorkloadContext const& wcx) : TestWorkload(wcx), bytesRead("BytesRead") {
-		useGetRange = getOption(options, LiteralStringRef("useGetRange"), false);
-		begin = getOption(options, LiteralStringRef("begin"), normalKeys.begin);
-		end = getOption(options, LiteralStringRef("end"), normalKeys.end);
-		printKVPairs = getOption(options, LiteralStringRef("printKVPairs"), false);
+		useGetRange = getOption(options, "useGetRange"_sr, false);
+		begin = getOption(options, "begin"_sr, normalKeys.begin);
+		end = getOption(options, "end"_sr, normalKeys.end);
+		printKVPairs = getOption(options, "printKVPairs"_sr, false);
 	}
 
 	std::string description() const override { return "GetRangeStreamWorkload"; }

--- a/fdbserver/workloads/HealthMetricsApi.actor.cpp
+++ b/fdbserver/workloads/HealthMetricsApi.actor.cpp
@@ -49,10 +49,10 @@ struct HealthMetricsApiWorkload : TestWorkload {
 	static constexpr const char* NAME = "HealthMetricsApi";
 
 	HealthMetricsApiWorkload(WorkloadContext const& wcx) : TestWorkload(wcx) {
-		testDuration = getOption(options, LiteralStringRef("testDuration"), 120.0);
-		healthMetricsCheckInterval = getOption(options, LiteralStringRef("healthMetricsCheckInterval"), 1.0);
-		sendDetailedHealthMetrics = getOption(options, LiteralStringRef("sendDetailedHealthMetrics"), true);
-		maxAllowedStaleness = getOption(options, LiteralStringRef("maxAllowedStaleness"), 60.0);
+		testDuration = getOption(options, "testDuration"_sr, 120.0);
+		healthMetricsCheckInterval = getOption(options, "healthMetricsCheckInterval"_sr, 1.0);
+		sendDetailedHealthMetrics = getOption(options, "sendDetailedHealthMetrics"_sr, true);
+		maxAllowedStaleness = getOption(options, "maxAllowedStaleness"_sr, 60.0);
 	}
 
 	std::string description() const override { return HealthMetricsApiWorkload::NAME; }

--- a/fdbserver/workloads/Increment.actor.cpp
+++ b/fdbserver/workloads/Increment.actor.cpp
@@ -35,12 +35,11 @@ struct Increment : TestWorkload {
 	Increment(WorkloadContext const& wcx)
 	  : TestWorkload(wcx), transactions("Transactions"), retries("Retries"), totalLatency("Latency"),
 	    tooOldRetries("Retries.too_old"), commitFailedRetries("Retries.commit_failed") {
-		testDuration = getOption(options, LiteralStringRef("testDuration"), 10.0);
-		transactionsPerSecond = getOption(options, LiteralStringRef("transactionsPerSecond"), 5000.0);
-		actorCount = getOption(options, LiteralStringRef("actorsPerClient"), transactionsPerSecond / 5);
-		nodeCount = getOption(options, LiteralStringRef("nodeCount"), transactionsPerSecond * clientCount);
-		minExpectedTransactionsPerSecond =
-		    transactionsPerSecond * getOption(options, LiteralStringRef("expectedRate"), 0.7);
+		testDuration = getOption(options, "testDuration"_sr, 10.0);
+		transactionsPerSecond = getOption(options, "transactionsPerSecond"_sr, 5000.0);
+		actorCount = getOption(options, "actorsPerClient"_sr, transactionsPerSecond / 5);
+		nodeCount = getOption(options, "nodeCount"_sr, transactionsPerSecond * clientCount);
+		minExpectedTransactionsPerSecond = transactionsPerSecond * getOption(options, "expectedRate"_sr, 0.7);
 	}
 
 	std::string description() const override { return "IncrementWorkload"; }
@@ -84,11 +83,11 @@ struct Increment : TestWorkload {
 				while (true) {
 					try {
 						tr.atomicOp(intToTestKey(deterministicRandom()->randomInt(0, self->nodeCount / 2)),
-						            LiteralStringRef("\x01"),
+						            "\x01"_sr,
 						            MutationRef::AddValue);
 						tr.atomicOp(
 						    intToTestKey(deterministicRandom()->randomInt(self->nodeCount / 2, self->nodeCount)),
-						    LiteralStringRef("\x01"),
+						    "\x01"_sr,
 						    MutationRef::AddValue);
 						wait(tr.commit());
 						break;

--- a/fdbserver/workloads/IncrementalBackup.actor.cpp
+++ b/fdbserver/workloads/IncrementalBackup.actor.cpp
@@ -44,15 +44,15 @@ struct IncrementalBackupWorkload : TestWorkload {
 	bool clearBackupAgentKeys;
 
 	IncrementalBackupWorkload(WorkloadContext const& wcx) : TestWorkload(wcx) {
-		backupDir = getOption(options, LiteralStringRef("backupDir"), LiteralStringRef("file://simfdb/backups/"));
-		tag = getOption(options, LiteralStringRef("tag"), LiteralStringRef("default"));
-		submitOnly = getOption(options, LiteralStringRef("submitOnly"), false);
-		restoreOnly = getOption(options, LiteralStringRef("restoreOnly"), false);
-		waitForBackup = getOption(options, LiteralStringRef("waitForBackup"), false);
-		waitRetries = getOption(options, LiteralStringRef("waitRetries"), -1);
-		stopBackup = getOption(options, LiteralStringRef("stopBackup"), false);
-		checkBeginVersion = getOption(options, LiteralStringRef("checkBeginVersion"), false);
-		clearBackupAgentKeys = getOption(options, LiteralStringRef("clearBackupAgentKeys"), false);
+		backupDir = getOption(options, "backupDir"_sr, "file://simfdb/backups/"_sr);
+		tag = getOption(options, "tag"_sr, "default"_sr);
+		submitOnly = getOption(options, "submitOnly"_sr, false);
+		restoreOnly = getOption(options, "restoreOnly"_sr, false);
+		waitForBackup = getOption(options, "waitForBackup"_sr, false);
+		waitRetries = getOption(options, "waitRetries"_sr, -1);
+		stopBackup = getOption(options, "stopBackup"_sr, false);
+		checkBeginVersion = getOption(options, "checkBeginVersion"_sr, false);
+		clearBackupAgentKeys = getOption(options, "clearBackupAgentKeys"_sr, false);
 	}
 
 	std::string description() const override { return "IncrementalBackup"; }

--- a/fdbserver/workloads/IndexScan.actor.cpp
+++ b/fdbserver/workloads/IndexScan.actor.cpp
@@ -34,11 +34,11 @@ struct IndexScanWorkload : KVWorkload {
 
 	IndexScanWorkload(WorkloadContext const& wcx)
 	  : KVWorkload(wcx), failedTransactions(0), rowsRead(0), chunks(0), scans(0) {
-		testDuration = getOption(options, LiteralStringRef("testDuration"), 10.0);
-		bytesPerRead = getOption(options, LiteralStringRef("bytesPerRead"), 80000);
-		transactionDuration = getOption(options, LiteralStringRef("transactionDuration"), 1.0);
-		singleProcess = getOption(options, LiteralStringRef("singleProcess"), true);
-		readYourWrites = getOption(options, LiteralStringRef("readYourWrites"), true);
+		testDuration = getOption(options, "testDuration"_sr, 10.0);
+		bytesPerRead = getOption(options, "bytesPerRead"_sr, 80000);
+		transactionDuration = getOption(options, "transactionDuration"_sr, 1.0);
+		singleProcess = getOption(options, "singleProcess"_sr, true);
+		readYourWrites = getOption(options, "readYourWrites"_sr, true);
 	}
 
 	std::string description() const override { return "SimpleRead"; }

--- a/fdbserver/workloads/Inventory.actor.cpp
+++ b/fdbserver/workloads/Inventory.actor.cpp
@@ -38,12 +38,12 @@ struct InventoryTestWorkload : TestWorkload {
 
 	InventoryTestWorkload(WorkloadContext const& wcx)
 	  : TestWorkload(wcx), transactions("Transactions"), retries("Retries"), totalLatency("Latency") {
-		actorCount = getOption(options, LiteralStringRef("actorCount"), 500);
-		nProducts = getOption(options, LiteralStringRef("nProducts"), 100000);
-		testDuration = getOption(options, LiteralStringRef("testDuration"), 10.0);
-		transactionsPerSecond = getOption(options, LiteralStringRef("transactionsPerSecond"), 10000);
-		fractionWriteTransactions = getOption(options, LiteralStringRef("fractionWriteTransactions"), 0.01);
-		productsPerWrite = getOption(options, LiteralStringRef("productsPerWrite"), 2);
+		actorCount = getOption(options, "actorCount"_sr, 500);
+		nProducts = getOption(options, "nProducts"_sr, 100000);
+		testDuration = getOption(options, "testDuration"_sr, 10.0);
+		transactionsPerSecond = getOption(options, "transactionsPerSecond"_sr, 10000);
+		fractionWriteTransactions = getOption(options, "fractionWriteTransactions"_sr, 0.01);
+		productsPerWrite = getOption(options, "productsPerWrite"_sr, 2);
 	}
 
 	std::string description() const override { return "InventoryTest"; }

--- a/fdbserver/workloads/KVStoreTest.actor.cpp
+++ b/fdbserver/workloads/KVStoreTest.actor.cpp
@@ -209,19 +209,19 @@ struct KVStoreTestWorkload : TestWorkload {
 	KVStoreTestWorkload(WorkloadContext const& wcx)
 	  : TestWorkload(wcx), reads("Reads"), sets("Sets"), commits("Commits"), setupTook(0) {
 		enabled = !clientId; // only do this on the "first" client
-		testDuration = getOption(options, LiteralStringRef("testDuration"), 10.0);
-		operationsPerSecond = getOption(options, LiteralStringRef("operationsPerSecond"), 100e3);
-		commitFraction = getOption(options, LiteralStringRef("commitFraction"), .001);
-		setFraction = getOption(options, LiteralStringRef("setFraction"), .1);
-		nodeCount = getOption(options, LiteralStringRef("nodeCount"), 100000);
-		keyBytes = getOption(options, LiteralStringRef("keyBytes"), 8);
-		valueBytes = getOption(options, LiteralStringRef("valueBytes"), 8);
-		doSetup = getOption(options, LiteralStringRef("setup"), false);
-		doClear = getOption(options, LiteralStringRef("clear"), false);
-		doCount = getOption(options, LiteralStringRef("count"), false);
-		filename = getOption(options, LiteralStringRef("filename"), Value()).toString();
-		saturation = getOption(options, LiteralStringRef("saturation"), false);
-		storeType = getOption(options, LiteralStringRef("storeType"), LiteralStringRef("ssd")).toString();
+		testDuration = getOption(options, "testDuration"_sr, 10.0);
+		operationsPerSecond = getOption(options, "operationsPerSecond"_sr, 100e3);
+		commitFraction = getOption(options, "commitFraction"_sr, .001);
+		setFraction = getOption(options, "setFraction"_sr, .1);
+		nodeCount = getOption(options, "nodeCount"_sr, 100000);
+		keyBytes = getOption(options, "keyBytes"_sr, 8);
+		valueBytes = getOption(options, "valueBytes"_sr, 8);
+		doSetup = getOption(options, "setup"_sr, false);
+		doClear = getOption(options, "clear"_sr, false);
+		doCount = getOption(options, "count"_sr, false);
+		filename = getOption(options, "filename"_sr, Value()).toString();
+		saturation = getOption(options, "saturation"_sr, false);
+		storeType = getOption(options, "storeType"_sr, "ssd"_sr).toString();
 	}
 	std::string description() const override { return "KVStoreTest"; }
 	Future<Void> setup(Database const& cx) override { return Void(); }
@@ -270,7 +270,7 @@ ACTOR Future<Void> testKVStoreMain(KVStoreTestWorkload* workload, KVTest* ptest)
 		state Key k;
 		state double cst = timer();
 		while (true) {
-			RangeResult kv = wait(test.store->readRange(KeyRangeRef(k, LiteralStringRef("\xff\xff\xff\xff")), 1000));
+			RangeResult kv = wait(test.store->readRange(KeyRangeRef(k, "\xff\xff\xff\xff"_sr), 1000));
 			count += kv.size();
 			if (kv.size() < 1000)
 				break;

--- a/fdbserver/workloads/KillRegion.actor.cpp
+++ b/fdbserver/workloads/KillRegion.actor.cpp
@@ -35,7 +35,7 @@ struct KillRegionWorkload : TestWorkload {
 	KillRegionWorkload(WorkloadContext const& wcx) : TestWorkload(wcx) {
 		enabled =
 		    !clientId && g_network->isSimulated(); // only do this on the "first" client, and only when in simulation
-		testDuration = getOption(options, LiteralStringRef("testDuration"), 10.0);
+		testDuration = getOption(options, "testDuration"_sr, 10.0);
 		g_simulator.usableRegions = 1;
 	}
 
@@ -59,7 +59,7 @@ struct KillRegionWorkload : TestWorkload {
 		TraceEvent("ForceRecovery_DisablePrimaryBegin");
 		wait(success(changeConfig(cx, g_simulator.disablePrimary, true)));
 		TraceEvent("ForceRecovery_WaitForRemote");
-		wait(waitForPrimaryDC(cx, LiteralStringRef("1")));
+		wait(waitForPrimaryDC(cx, "1"_sr));
 		TraceEvent("ForceRecovery_DisablePrimaryComplete");
 		return Void();
 	}
@@ -77,29 +77,29 @@ struct KillRegionWorkload : TestWorkload {
 			TraceEvent("ForceRecovery_DisableRemoteBegin");
 			wait(success(changeConfig(cx, g_simulator.disableRemote, true)));
 			TraceEvent("ForceRecovery_WaitForPrimary");
-			wait(waitForPrimaryDC(cx, LiteralStringRef("0")));
+			wait(waitForPrimaryDC(cx, "0"_sr));
 			TraceEvent("ForceRecovery_DisableRemoteComplete");
 			wait(success(changeConfig(cx, g_simulator.originalRegions, true)));
 		}
 		TraceEvent("ForceRecovery_Wait");
 		wait(delay(deterministicRandom()->random01() * self->testDuration));
 
-		g_simulator.killDataCenter(LiteralStringRef("0"),
+		g_simulator.killDataCenter("0"_sr,
 		                           deterministicRandom()->random01() < 0.5 ? ISimulator::KillInstantly
 		                                                                   : ISimulator::RebootAndDelete,
 		                           true);
-		g_simulator.killDataCenter(LiteralStringRef("2"),
+		g_simulator.killDataCenter("2"_sr,
 		                           deterministicRandom()->random01() < 0.5 ? ISimulator::KillInstantly
 		                                                                   : ISimulator::RebootAndDelete,
 		                           true);
-		g_simulator.killDataCenter(LiteralStringRef("4"),
+		g_simulator.killDataCenter("4"_sr,
 		                           deterministicRandom()->random01() < 0.5 ? ISimulator::KillInstantly
 		                                                                   : ISimulator::RebootAndDelete,
 		                           true);
 
 		TraceEvent("ForceRecovery_Begin");
 
-		wait(forceRecovery(cx->getConnectionFile(), LiteralStringRef("1")));
+		wait(forceRecovery(cx->getConnectionFile(), "1"_sr));
 
 		TraceEvent("ForceRecovery_UsableRegions");
 

--- a/fdbserver/workloads/LocalRatekeeper.actor.cpp
+++ b/fdbserver/workloads/LocalRatekeeper.actor.cpp
@@ -50,10 +50,9 @@ struct LocalRatekeeperWorkload : TestWorkload {
 	bool testFailed = false;
 
 	LocalRatekeeperWorkload(WorkloadContext const& wcx) : TestWorkload(wcx) {
-		startAfter = getOption(options, LiteralStringRef("startAfter"), startAfter);
-		blockWritesFor = getOption(options,
-		                           LiteralStringRef("blockWritesFor"),
-		                           double(SERVER_KNOBS->STORAGE_DURABILITY_LAG_HARD_MAX) / double(1e6));
+		startAfter = getOption(options, "startAfter"_sr, startAfter);
+		blockWritesFor = getOption(
+		    options, "blockWritesFor"_sr, double(SERVER_KNOBS->STORAGE_DURABILITY_LAG_HARD_MAX) / double(1e6));
 	}
 	std::string description() const override { return "LocalRatekeeperWorkload"; }
 
@@ -89,7 +88,7 @@ struct LocalRatekeeperWorkload : TestWorkload {
 				GetValueRequest req;
 				req.version = readVersion;
 				// we don't care about the value
-				req.key = LiteralStringRef("/lkfs");
+				req.key = "/lkfs"_sr;
 				requests.emplace_back(brokenPromiseToNever(ssi.getValue.getReply(req)));
 			}
 			wait(waitForAllReady(requests));

--- a/fdbserver/workloads/LockDatabase.actor.cpp
+++ b/fdbserver/workloads/LockDatabase.actor.cpp
@@ -30,9 +30,9 @@ struct LockDatabaseWorkload : TestWorkload {
 	bool onlyCheckLocked;
 
 	LockDatabaseWorkload(WorkloadContext const& wcx) : TestWorkload(wcx), ok(true) {
-		lockAfter = getOption(options, LiteralStringRef("lockAfter"), 0.0);
-		unlockAfter = getOption(options, LiteralStringRef("unlockAfter"), 10.0);
-		onlyCheckLocked = getOption(options, LiteralStringRef("onlyCheckLocked"), false);
+		lockAfter = getOption(options, "lockAfter"_sr, 0.0);
+		unlockAfter = getOption(options, "unlockAfter"_sr, 10.0);
+		onlyCheckLocked = getOption(options, "onlyCheckLocked"_sr, false);
 		ASSERT(unlockAfter > lockAfter);
 	}
 

--- a/fdbserver/workloads/LockDatabaseFrequently.actor.cpp
+++ b/fdbserver/workloads/LockDatabaseFrequently.actor.cpp
@@ -30,8 +30,8 @@ struct LockDatabaseFrequentlyWorkload : TestWorkload {
 	PerfIntCounter lockCount{ "LockCount" };
 
 	LockDatabaseFrequentlyWorkload(WorkloadContext const& wcx) : TestWorkload(wcx) {
-		delayBetweenLocks = getOption(options, LiteralStringRef("delayBetweenLocks"), 0.1);
-		testDuration = getOption(options, LiteralStringRef("testDuration"), 60);
+		delayBetweenLocks = getOption(options, "delayBetweenLocks"_sr, 0.1);
+		testDuration = getOption(options, "testDuration"_sr, 60);
 	}
 
 	std::string description() const override { return "LockDatabaseFrequently"; }

--- a/fdbserver/workloads/LogMetrics.actor.cpp
+++ b/fdbserver/workloads/LogMetrics.actor.cpp
@@ -35,10 +35,10 @@ struct LogMetricsWorkload : TestWorkload {
 	double logAt, logDuration, logsPerSecond;
 
 	LogMetricsWorkload(WorkloadContext const& wcx) : TestWorkload(wcx) {
-		logAt = getOption(options, LiteralStringRef("logAt"), 0.0);
-		logDuration = getOption(options, LiteralStringRef("logDuration"), 30.0);
-		logsPerSecond = getOption(options, LiteralStringRef("logsPerSecond"), 20);
-		dataFolder = getOption(options, LiteralStringRef("dataFolder"), LiteralStringRef("")).toString();
+		logAt = getOption(options, "logAt"_sr, 0.0);
+		logDuration = getOption(options, "logDuration"_sr, 30.0);
+		logsPerSecond = getOption(options, "logsPerSecond"_sr, 20);
+		dataFolder = getOption(options, "dataFolder"_sr, ""_sr).toString();
 	}
 
 	std::string description() const override { return "LogMetricsWorkload"; }

--- a/fdbserver/workloads/LowLatency.actor.cpp
+++ b/fdbserver/workloads/LowLatency.actor.cpp
@@ -39,12 +39,12 @@ struct LowLatencyWorkload : TestWorkload {
 
 	LowLatencyWorkload(WorkloadContext const& wcx)
 	  : TestWorkload(wcx), operations("Operations"), retries("Retries"), ok(true) {
-		testDuration = getOption(options, LiteralStringRef("testDuration"), 600.0);
-		maxGRVLatency = getOption(options, LiteralStringRef("maxGRVLatency"), 20.0);
-		maxCommitLatency = getOption(options, LiteralStringRef("maxCommitLatency"), 30.0);
-		checkDelay = getOption(options, LiteralStringRef("checkDelay"), 1.0);
-		testWrites = getOption(options, LiteralStringRef("testWrites"), true);
-		testKey = getOption(options, LiteralStringRef("testKey"), LiteralStringRef("testKey"));
+		testDuration = getOption(options, "testDuration"_sr, 600.0);
+		maxGRVLatency = getOption(options, "maxGRVLatency"_sr, 20.0);
+		maxCommitLatency = getOption(options, "maxCommitLatency"_sr, 30.0);
+		checkDelay = getOption(options, "checkDelay"_sr, 1.0);
+		testWrites = getOption(options, "testWrites"_sr, true);
+		testKey = getOption(options, "testKey"_sr, "testKey"_sr);
 	}
 
 	std::string description() const override { return "LowLatency"; }
@@ -81,7 +81,7 @@ struct LowLatencyWorkload : TestWorkload {
 						tr.setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
 						tr.setOption(FDBTransactionOptions::LOCK_AWARE);
 						if (doCommit) {
-							tr.set(self->testKey, LiteralStringRef(""));
+							tr.set(self->testKey, ""_sr);
 							wait(tr.commit());
 						} else {
 							wait(success(tr.getReadVersion()));

--- a/fdbserver/workloads/MachineAttrition.actor.cpp
+++ b/fdbserver/workloads/MachineAttrition.actor.cpp
@@ -80,26 +80,24 @@ struct MachineAttritionWorkload : TestWorkload {
 	MachineAttritionWorkload(WorkloadContext const& wcx) : TestWorkload(wcx) {
 		enabled =
 		    !clientId && g_network->isSimulated(); // only do this on the "first" client, and only when in simulation
-		machinesToKill = getOption(options, LiteralStringRef("machinesToKill"), 2);
-		machinesToLeave = getOption(options, LiteralStringRef("machinesToLeave"), 1);
-		workersToKill = getOption(options, LiteralStringRef("workersToKill"), 2);
-		workersToLeave = getOption(options, LiteralStringRef("workersToLeave"), 1);
-		testDuration = getOption(options, LiteralStringRef("testDuration"), 10.0);
-		suspendDuration = getOption(options, LiteralStringRef("suspendDuration"), 1.0);
-		liveDuration = getOption(options, LiteralStringRef("liveDuration"), 5.0);
-		reboot = getOption(options, LiteralStringRef("reboot"), false);
-		killDc = getOption(
-		    options, LiteralStringRef("killDc"), g_network->isSimulated() && deterministicRandom()->random01() < 0.25);
-		killMachine = getOption(options, LiteralStringRef("killMachine"), false);
-		killDatahall = getOption(options, LiteralStringRef("killDatahall"), false);
-		killProcess = getOption(options, LiteralStringRef("killProcess"), false);
-		killZone = getOption(options, LiteralStringRef("killZone"), false);
-		killSelf = getOption(options, LiteralStringRef("killSelf"), false);
-		targetIds = getOption(options, LiteralStringRef("targetIds"), std::vector<std::string>());
-		replacement =
-		    getOption(options, LiteralStringRef("replacement"), reboot && deterministicRandom()->random01() < 0.5);
-		waitForVersion = getOption(options, LiteralStringRef("waitForVersion"), false);
-		allowFaultInjection = getOption(options, LiteralStringRef("allowFaultInjection"), true);
+		machinesToKill = getOption(options, "machinesToKill"_sr, 2);
+		machinesToLeave = getOption(options, "machinesToLeave"_sr, 1);
+		workersToKill = getOption(options, "workersToKill"_sr, 2);
+		workersToLeave = getOption(options, "workersToLeave"_sr, 1);
+		testDuration = getOption(options, "testDuration"_sr, 10.0);
+		suspendDuration = getOption(options, "suspendDuration"_sr, 1.0);
+		liveDuration = getOption(options, "liveDuration"_sr, 5.0);
+		reboot = getOption(options, "reboot"_sr, false);
+		killDc = getOption(options, "killDc"_sr, g_network->isSimulated() && deterministicRandom()->random01() < 0.25);
+		killMachine = getOption(options, "killMachine"_sr, false);
+		killDatahall = getOption(options, "killDatahall"_sr, false);
+		killProcess = getOption(options, "killProcess"_sr, false);
+		killZone = getOption(options, "killZone"_sr, false);
+		killSelf = getOption(options, "killSelf"_sr, false);
+		targetIds = getOption(options, "targetIds"_sr, std::vector<std::string>());
+		replacement = getOption(options, "replacement"_sr, reboot && deterministicRandom()->random01() < 0.5);
+		waitForVersion = getOption(options, "waitForVersion"_sr, false);
+		allowFaultInjection = getOption(options, "allowFaultInjection"_sr, true);
 		ignoreSSFailures = true;
 	}
 

--- a/fdbserver/workloads/Mako.actor.cpp
+++ b/fdbserver/workloads/Mako.actor.cpp
@@ -56,39 +56,39 @@ struct MakoWorkload : TestWorkload {
 	    totalOps("Operations"), loadTime(0.0) {
 		// init parameters from test file
 		// Number of rows populated
-		rowCount = getOption(options, LiteralStringRef("rows"), 10000);
+		rowCount = getOption(options, "rows"_sr, 10000);
 		// Test duration in seconds
-		testDuration = getOption(options, LiteralStringRef("testDuration"), 30.0);
-		warmingDelay = getOption(options, LiteralStringRef("warmingDelay"), 0.0);
-		maxInsertRate = getOption(options, LiteralStringRef("maxInsertRate"), 1e12);
+		testDuration = getOption(options, "testDuration"_sr, 30.0);
+		warmingDelay = getOption(options, "warmingDelay"_sr, 0.0);
+		maxInsertRate = getOption(options, "maxInsertRate"_sr, 1e12);
 		// Flag to control whether to populate data into database
-		populateData = getOption(options, LiteralStringRef("populateData"), true);
+		populateData = getOption(options, "populateData"_sr, true);
 		// Flag to control whether to run benchmark
-		runBenchmark = getOption(options, LiteralStringRef("runBenchmark"), true);
+		runBenchmark = getOption(options, "runBenchmark"_sr, true);
 		// Flag to control whether to clean data in the database
-		preserveData = getOption(options, LiteralStringRef("preserveData"), true);
+		preserveData = getOption(options, "preserveData"_sr, true);
 		// If true, force commit for read-only transactions
-		commitGet = getOption(options, LiteralStringRef("commitGet"), false);
+		commitGet = getOption(options, "commitGet"_sr, false);
 		// If true, log latency for set, clear and clearrange
-		latencyForLocalOperation = getOption(options, LiteralStringRef("latencyForLocalOperation"), false);
+		latencyForLocalOperation = getOption(options, "latencyForLocalOperation"_sr, false);
 		// Target total transaction-per-second (TPS) of all clients
-		transactionsPerSecond = getOption(options, LiteralStringRef("transactionsPerSecond"), 100000.0) / clientCount;
-		actorCountPerClient = getOption(options, LiteralStringRef("actorCountPerClient"), 16);
+		transactionsPerSecond = getOption(options, "transactionsPerSecond"_sr, 100000.0) / clientCount;
+		actorCountPerClient = getOption(options, "actorCountPerClient"_sr, 16);
 		// Sampling rate (1 sample / <sampleSize> ops) for latency stats
-		sampleSize = getOption(options, LiteralStringRef("sampleSize"), rowCount / 100);
+		sampleSize = getOption(options, "sampleSize"_sr, rowCount / 100);
 		// If true, record latency metrics per periodicLoggingInterval; For details, see tracePeriodically()
-		enableLogging = getOption(options, LiteralStringRef("enableLogging"), false);
-		periodicLoggingInterval = getOption(options, LiteralStringRef("periodicLoggingInterval"), 5.0);
+		enableLogging = getOption(options, "enableLogging"_sr, false);
+		periodicLoggingInterval = getOption(options, "periodicLoggingInterval"_sr, 5.0);
 		// All the generated keys will start with the specified prefix
-		keyPrefix = getOption(options, LiteralStringRef("keyPrefix"), LiteralStringRef("mako")).toString();
+		keyPrefix = getOption(options, "keyPrefix"_sr, "mako"_sr).toString();
 		KEYPREFIXLEN = keyPrefix.size();
 		// If true, the workload will picking up keys which are zipfian distributed
-		zipf = getOption(options, LiteralStringRef("zipf"), false);
-		zipfConstant = getOption(options, LiteralStringRef("zipfConstant"), 0.99);
+		zipf = getOption(options, "zipf"_sr, false);
+		zipfConstant = getOption(options, "zipfConstant"_sr, 0.99);
 		// Specified length of keys and length range of values
-		keyBytes = std::max(getOption(options, LiteralStringRef("keyBytes"), 16), 16);
-		maxValueBytes = getOption(options, LiteralStringRef("valueBytes"), 16);
-		minValueBytes = getOption(options, LiteralStringRef("minValueBytes"), maxValueBytes);
+		keyBytes = std::max(getOption(options, "keyBytes"_sr, 16), 16);
+		maxValueBytes = getOption(options, "valueBytes"_sr, 16);
+		minValueBytes = getOption(options, "minValueBytes"_sr, maxValueBytes);
 		ASSERT(minValueBytes <= maxValueBytes);
 		// The inserted key is formatted as: fixed prefix('mako') + sequential number + padding('x')
 		// assume we want to insert 10000 rows with keyBytes set to 16,
@@ -115,8 +115,7 @@ struct MakoWorkload : TestWorkload {
 		// scr – SET & CLEAR RANGE
 		// grv – GetReadVersion()
 		// Every transaction is committed unless it contains only GET / GET RANGE operations.
-		operationsSpec =
-		    getOption(options, LiteralStringRef("operations"), LiteralStringRef("g100")).contents().toString();
+		operationsSpec = getOption(options, "operations"_sr, "g100"_sr).contents().toString();
 		//  parse the sequence and extract operations to be executed
 		parseOperationsSpec();
 		for (int i = 0; i < MAX_OP; ++i) {
@@ -129,11 +128,11 @@ struct MakoWorkload : TestWorkload {
 			zipfian_generator3(0, (int)rowCount - 1, zipfConstant);
 		}
 		// Added for checksum verification
-		csSize = getOption(options, LiteralStringRef("csSize"), rowCount / 100);
+		csSize = getOption(options, "csSize"_sr, rowCount / 100);
 		ASSERT(csSize <= rowCount);
-		csCount = getOption(options, LiteralStringRef("csCount"), 0);
+		csCount = getOption(options, "csCount"_sr, 0);
 		checksumVerification = (csCount != 0);
-		doChecksumVerificationOnly = getOption(options, LiteralStringRef("doChecksumVerificationOnly"), false);
+		doChecksumVerificationOnly = getOption(options, "doChecksumVerificationOnly"_sr, false);
 		if (doChecksumVerificationOnly)
 			ASSERT(checksumVerification); // csCount should be non-zero when you do checksum verification only
 		if (csCount) {

--- a/fdbserver/workloads/MemoryKeyValueStore.cpp
+++ b/fdbserver/workloads/MemoryKeyValueStore.cpp
@@ -126,12 +126,12 @@ uint64_t MemoryKeyValueStore::size() const {
 
 // The first key in the database; returned by key selectors that choose a key off the front
 Key MemoryKeyValueStore::startKey() const {
-	return LiteralStringRef("");
+	return ""_sr;
 }
 
 // The last key in the database; returned by key selectors that choose a key off the back
 Key MemoryKeyValueStore::endKey() const {
-	return LiteralStringRef("\xff");
+	return "\xff"_sr;
 }
 
 // Debugging function that prints all key-value pairs

--- a/fdbserver/workloads/MemoryLifetime.actor.cpp
+++ b/fdbserver/workloads/MemoryLifetime.actor.cpp
@@ -34,7 +34,7 @@ struct MemoryLifetime : KVWorkload {
 	std::string valueString;
 
 	MemoryLifetime(WorkloadContext const& wcx) : KVWorkload(wcx) {
-		testDuration = getOption(options, LiteralStringRef("testDuration"), 60.0);
+		testDuration = getOption(options, "testDuration"_sr, 60.0);
 		valueString = std::string(maxValueBytes, '.');
 	}
 

--- a/fdbserver/workloads/MetricLogging.actor.cpp
+++ b/fdbserver/workloads/MetricLogging.actor.cpp
@@ -36,17 +36,17 @@ struct MetricLoggingWorkload : TestWorkload {
 	std::vector<Int64MetricHandle> int64Metrics;
 
 	MetricLoggingWorkload(WorkloadContext const& wcx) : TestWorkload(wcx), changes("Changes") {
-		testDuration = getOption(options, LiteralStringRef("testDuration"), 10.0);
-		actorCount = getOption(options, LiteralStringRef("actorCount"), 1);
-		metricCount = getOption(options, LiteralStringRef("metricCount"), 1);
-		testBool = getOption(options, LiteralStringRef("testBool"), true);
-		enabled = getOption(options, LiteralStringRef("enabled"), true);
+		testDuration = getOption(options, "testDuration"_sr, 10.0);
+		actorCount = getOption(options, "actorCount"_sr, 1);
+		metricCount = getOption(options, "metricCount"_sr, 1);
+		testBool = getOption(options, "testBool"_sr, true);
+		enabled = getOption(options, "enabled"_sr, true);
 
 		for (int i = 0; i < metricCount; i++) {
 			if (testBool) {
-				boolMetrics.push_back(BoolMetricHandle(LiteralStringRef("TestBool"), format("%d", i)));
+				boolMetrics.push_back(BoolMetricHandle("TestBool"_sr, format("%d", i)));
 			} else {
-				int64Metrics.push_back(Int64MetricHandle(LiteralStringRef("TestInt"), format("%d", i)));
+				int64Metrics.push_back(Int64MetricHandle("TestInt"_sr, format("%d", i)));
 			}
 		}
 	}

--- a/fdbserver/workloads/Performance.actor.cpp
+++ b/fdbserver/workloads/Performance.actor.cpp
@@ -34,7 +34,7 @@ struct PerformanceWorkload : TestWorkload {
 	PerfMetric maxAchievedTPS;
 
 	PerformanceWorkload(WorkloadContext const& wcx) : TestWorkload(wcx) {
-		probeWorkload = getOption(options, LiteralStringRef("probeWorkload"), LiteralStringRef("ReadWrite"));
+		probeWorkload = getOption(options, "probeWorkload"_sr, "ReadWrite"_sr);
 
 		// "Consume" all options and save for later tests
 		for (int i = 0; i < options.size(); i++) {
@@ -44,7 +44,7 @@ struct PerformanceWorkload : TestWorkload {
 				       i,
 				       printable(options[i].key).c_str(),
 				       printable(options[i].value).c_str());
-				options[i].value = LiteralStringRef("");
+				options[i].value = ""_sr;
 			}
 		}
 		printf("saved %d options\n", savedOptions.size());
@@ -78,10 +78,9 @@ struct PerformanceWorkload : TestWorkload {
 	Standalone<VectorRef<VectorRef<KeyValueRef>>> getOpts(double transactionsPerSecond) {
 		Standalone<VectorRef<KeyValueRef>> options;
 		Standalone<VectorRef<VectorRef<KeyValueRef>>> opts;
-		options.push_back_deep(options.arena(), KeyValueRef(LiteralStringRef("testName"), probeWorkload));
-		options.push_back_deep(
-		    options.arena(),
-		    KeyValueRef(LiteralStringRef("transactionsPerSecond"), format("%f", transactionsPerSecond)));
+		options.push_back_deep(options.arena(), KeyValueRef("testName"_sr, probeWorkload));
+		options.push_back_deep(options.arena(),
+		                       KeyValueRef("transactionsPerSecond"_sr, format("%f", transactionsPerSecond)));
 		for (int i = 0; i < savedOptions.size(); i++) {
 			options.push_back_deep(options.arena(), savedOptions[i]);
 			printf("option [%d]: '%s'='%s'\n",
@@ -134,7 +133,7 @@ struct PerformanceWorkload : TestWorkload {
 		vector<TesterInterface> testers = wait(self->getTesters(self));
 		self->testers = testers;
 
-		TestSpec spec(LiteralStringRef("PerformanceSetup"), false, false);
+		TestSpec spec("PerformanceSetup"_sr, false, false);
 		spec.options = options;
 		spec.phases = TestWorkload::SETUP;
 		DistributedTestResults results = wait(runWorkload(cx, testers, spec));
@@ -169,7 +168,7 @@ struct PerformanceWorkload : TestWorkload {
 			}
 			state DistributedTestResults results;
 			try {
-				TestSpec spec(LiteralStringRef("PerformanceRun"), false, false);
+				TestSpec spec("PerformanceRun"_sr, false, false);
 				spec.phases = TestWorkload::EXECUTION | TestWorkload::METRICS;
 				spec.options = options;
 				DistributedTestResults r = wait(runWorkload(cx, self->testers, spec));

--- a/fdbserver/workloads/Ping.actor.cpp
+++ b/fdbserver/workloads/Ping.actor.cpp
@@ -53,20 +53,20 @@ struct PingWorkload : TestWorkload {
 	PingWorkload(WorkloadContext const& wcx)
 	  : TestWorkload(wcx), messages("Messages"), totalMessageLatency("TotalLatency"),
 	    maxMessageLatency("Max Latency (ms)") {
-		testDuration = getOption(options, LiteralStringRef("testDuration"), 10.0);
-		operationsPerSecond = getOption(options, LiteralStringRef("operationsPerSecondPerClient"), 50.0);
-		usePayload = getOption(options, LiteralStringRef("usePayload"), false);
-		logging = getOption(options, LiteralStringRef("logging"), false);
-		pingWorkers = getOption(options, LiteralStringRef("pingWorkers"), false);
-		registerInterface = getOption(options, LiteralStringRef("registerInterface"), true);
-		broadcastTest = getOption(options, LiteralStringRef("broadcastTest"), false);
-		parallelBroadcast = getOption(options, LiteralStringRef("parallelBroadcast"), false);
-		workerBroadcast = getOption(options, LiteralStringRef("workerBroadcast"), false);
-		int payloadSize = getOption(options, LiteralStringRef("payloadSizeOut"), 1024);
+		testDuration = getOption(options, "testDuration"_sr, 10.0);
+		operationsPerSecond = getOption(options, "operationsPerSecondPerClient"_sr, 50.0);
+		usePayload = getOption(options, "usePayload"_sr, false);
+		logging = getOption(options, "logging"_sr, false);
+		pingWorkers = getOption(options, "pingWorkers"_sr, false);
+		registerInterface = getOption(options, "registerInterface"_sr, true);
+		broadcastTest = getOption(options, "broadcastTest"_sr, false);
+		parallelBroadcast = getOption(options, "parallelBroadcast"_sr, false);
+		workerBroadcast = getOption(options, "workerBroadcast"_sr, false);
+		int payloadSize = getOption(options, "payloadSizeOut"_sr, 1024);
 		payloadOut = std::string(payloadSize, '.');
-		payloadSize = getOption(options, LiteralStringRef("payloadSizeBack"), 1024);
+		payloadSize = getOption(options, "payloadSizeBack"_sr, 1024);
 		payloadBack = std::string(payloadSize, '.');
-		actorCount = getOption(options, LiteralStringRef("actorCount"), 1);
+		actorCount = getOption(options, "actorCount"_sr, 1);
 	}
 
 	std::string description() const override { return "PingWorkload"; }
@@ -155,7 +155,7 @@ struct PingWorkload : TestWorkload {
 
 			LoadedPingRequest req;
 			req.id = deterministicRandom()->randomUniqueID();
-			req.payload = self->usePayload ? self->payloadOut : LiteralStringRef("");
+			req.payload = self->usePayload ? self->payloadOut : ""_sr;
 			req.loadReply = self->usePayload;
 			LoadedReply rep = wait(peer.getReply(req));
 
@@ -273,7 +273,7 @@ struct PingWorkload : TestWorkload {
 
 	// 	LoadedReply rep;
 	// 	rep.id = req.id;
-	// 	rep.payload = req.loadReply ? self->payloadBack : LiteralStringRef("");
+	// 	rep.payload = req.loadReply ? self->payloadBack : ""_sr;
 	// 	req.reply.send( rep );
 
 	// 	return Void();
@@ -294,7 +294,7 @@ struct PingWorkload : TestWorkload {
 
 			LoadedReply rep;
 			rep.id = req.id;
-			rep.payload = req.loadReply ? self->payloadBack : LiteralStringRef("");
+			rep.payload = req.loadReply ? self->payloadBack : ""_sr;
 			req.reply.send(rep);
 
 			// addActor.send( self->packetPonger( self, req ) );

--- a/fdbserver/workloads/PopulateTPCC.actor.cpp
+++ b/fdbserver/workloads/PopulateTPCC.actor.cpp
@@ -53,9 +53,9 @@ struct PopulateTPCC : TestWorkload {
 
 	PopulateTPCC(WorkloadContext const& ctx) : TestWorkload(ctx) {
 		std::string workloadName = DESCRIPTION;
-		actorsPerClient = getOption(options, LiteralStringRef("actorsPerClient"), 10);
-		warehousesPerActor = getOption(options, LiteralStringRef("warehousesPerActor"), 30);
-		clientsUsed = getOption(options, LiteralStringRef("clientsUsed"), 2);
+		actorsPerClient = getOption(options, "actorsPerClient"_sr, 10);
+		warehousesPerActor = getOption(options, "warehousesPerActor"_sr, 30);
+		clientsUsed = getOption(options, "clientsUsed"_sr, 2);
 	}
 
 	int NURand(int C, int A, int x, int y) {
@@ -209,7 +209,7 @@ struct PopulateTPCC : TestWorkload {
 					} else {
 						c.c_last = self->genCLast(c.arena, self->NURand(self->gState.CLoad, 255, 0, 999));
 					}
-					c.c_middle = LiteralStringRef("OE");
+					c.c_middle = "OE"_sr;
 					c.c_first = self->aString(c.arena, 8, 16);
 					c.c_street_1 = self->aString(c.arena, 10, 20);
 					c.c_street_2 = self->aString(c.arena, 10, 20);
@@ -219,9 +219,9 @@ struct PopulateTPCC : TestWorkload {
 					c.c_phone = self->nString(c.arena, 16, 16);
 					c.c_since = g_network->now();
 					if (deterministicRandom()->random01() < 0.1) {
-						c.c_credit = LiteralStringRef("BC");
+						c.c_credit = "BC"_sr;
 					} else {
-						c.c_credit = LiteralStringRef("GC");
+						c.c_credit = "GC"_sr;
 					}
 					c.c_credit_lim = 50000;
 					c.c_discount = deterministicRandom()->random01() / 2.0;
@@ -254,7 +254,7 @@ struct PopulateTPCC : TestWorkload {
 						UID k = deterministicRandom()->randomUniqueID();
 						BinaryWriter kW(Unversioned());
 						serializer(kW, k);
-						auto key = kW.toValue().withPrefix(LiteralStringRef("History/"));
+						auto key = kW.toValue().withPrefix("History/"_sr);
 						tr.set(key, w.toValue(), AddConflictRange::False);
 					}
 				}

--- a/fdbserver/workloads/PubSubMultiples.actor.cpp
+++ b/fdbserver/workloads/PubSubMultiples.actor.cpp
@@ -32,10 +32,10 @@ struct PubSubMultiplesWorkload : TestWorkload {
 	PerfIntCounter messages;
 
 	PubSubMultiplesWorkload(WorkloadContext const& wcx) : TestWorkload(wcx), messages("Messages") {
-		testDuration = getOption(options, LiteralStringRef("testDuration"), 10.0);
-		messagesPerSecond = getOption(options, LiteralStringRef("messagesPerSecond"), 500.0) / clientCount;
-		actorCount = getOption(options, LiteralStringRef("actorsPerClient"), 20);
-		inboxesPerActor = getOption(options, LiteralStringRef("inboxesPerActor"), 20);
+		testDuration = getOption(options, "testDuration"_sr, 10.0);
+		messagesPerSecond = getOption(options, "messagesPerSecond"_sr, 500.0) / clientCount;
+		actorCount = getOption(options, "actorsPerClient"_sr, 20);
+		inboxesPerActor = getOption(options, "inboxesPerActor"_sr, 20);
 	}
 
 	std::string description() const override { return "PubSubMultiplesWorkload"; }

--- a/fdbserver/workloads/QueuePush.actor.cpp
+++ b/fdbserver/workloads/QueuePush.actor.cpp
@@ -40,16 +40,16 @@ struct QueuePushWorkload : TestWorkload {
 
 	QueuePushWorkload(WorkloadContext const& wcx)
 	  : TestWorkload(wcx), commitLatencies(2000), GRVLatencies(2000), transactions("Transactions"), retries("Retries") {
-		testDuration = getOption(options, LiteralStringRef("testDuration"), 10.0);
-		actorCount = getOption(options, LiteralStringRef("actorCount"), 50);
+		testDuration = getOption(options, "testDuration"_sr, 10.0);
+		actorCount = getOption(options, "actorCount"_sr, 50);
 
-		valueBytes = getOption(options, LiteralStringRef("valueBytes"), 96);
+		valueBytes = getOption(options, "valueBytes"_sr, 96);
 		valueString = std::string(valueBytes, 'x');
 
-		forward = getOption(options, LiteralStringRef("forward"), true);
+		forward = getOption(options, "forward"_sr, true);
 
-		endingKey = LiteralStringRef("9999999900000001");
-		startingKey = LiteralStringRef("0000000000000001");
+		endingKey = "9999999900000001"_sr;
+		startingKey = "0000000000000001"_sr;
 	}
 
 	std::string description() const override { return "QueuePush"; }

--- a/fdbserver/workloads/RYWDisable.actor.cpp
+++ b/fdbserver/workloads/RYWDisable.actor.cpp
@@ -31,9 +31,9 @@ struct RYWDisableWorkload : TestWorkload {
 	vector<Future<Void>> clients;
 
 	RYWDisableWorkload(WorkloadContext const& wcx) : TestWorkload(wcx) {
-		testDuration = getOption(options, LiteralStringRef("testDuration"), 600.0);
-		nodes = getOption(options, LiteralStringRef("nodes"), 100);
-		keyBytes = std::max(getOption(options, LiteralStringRef("keyBytes"), 16), 16);
+		testDuration = getOption(options, "testDuration"_sr, 600.0);
+		nodes = getOption(options, "nodes"_sr, 100);
+		keyBytes = std::max(getOption(options, "keyBytes"_sr, 16), 16);
 	}
 
 	std::string description() const override { return "RYWDisable"; }

--- a/fdbserver/workloads/RYWPerformance.actor.cpp
+++ b/fdbserver/workloads/RYWPerformance.actor.cpp
@@ -28,9 +28,9 @@
 struct RYWPerformanceWorkload : TestWorkload {
 	int keyBytes, nodes, ranges;
 	RYWPerformanceWorkload(WorkloadContext const& wcx) : TestWorkload(wcx) {
-		nodes = getOption(options, LiteralStringRef("nodes"), 10000);
-		ranges = getOption(options, LiteralStringRef("ranges"), 10);
-		keyBytes = std::max(getOption(options, LiteralStringRef("keyBytes"), 16), 16);
+		nodes = getOption(options, "nodes"_sr, 10000);
+		ranges = getOption(options, "ranges"_sr, 10);
+		keyBytes = std::max(getOption(options, "keyBytes"_sr, 16), 16);
 	}
 
 	std::string description() const override { return "RYWPerformance"; }
@@ -47,7 +47,7 @@ struct RYWPerformanceWorkload : TestWorkload {
 		loop {
 			try {
 				for (int i = 0; i < self->nodes; i++)
-					tr.set(self->keyForIndex(i), LiteralStringRef("bar"));
+					tr.set(self->keyForIndex(i), "bar"_sr);
 
 				wait(tr.commit());
 				break;
@@ -69,7 +69,7 @@ struct RYWPerformanceWorkload : TestWorkload {
 		state int i;
 		if (type == 0) {
 			for (i = 0; i < self->nodes; i++) {
-				tr->set(self->keyForIndex(i), LiteralStringRef("foo"));
+				tr->set(self->keyForIndex(i), "foo"_sr);
 			}
 		} else if (type == 1) {
 			std::vector<Future<Optional<Value>>> gets;
@@ -84,7 +84,7 @@ struct RYWPerformanceWorkload : TestWorkload {
 			}
 			wait(waitForAll(gets));
 			for (i = 0; i < self->nodes; i++) {
-				tr->set(self->keyForIndex(i), LiteralStringRef("foo"));
+				tr->set(self->keyForIndex(i), "foo"_sr);
 			}
 		} else if (type == 3) {
 			std::vector<Future<Optional<Value>>> gets;
@@ -93,19 +93,19 @@ struct RYWPerformanceWorkload : TestWorkload {
 			}
 			wait(waitForAll(gets));
 			for (i = 1; i < self->nodes; i += 2) {
-				tr->set(self->keyForIndex(i), LiteralStringRef("foo"));
+				tr->set(self->keyForIndex(i), "foo"_sr);
 			}
 		} else if (type == 4) {
 			wait(success(tr->getRange(KeyRangeRef(self->keyForIndex(0), self->keyForIndex(self->nodes)), self->nodes)));
 		} else if (type == 5) {
 			wait(success(tr->getRange(KeyRangeRef(self->keyForIndex(0), self->keyForIndex(self->nodes)), self->nodes)));
 			for (i = 0; i < self->nodes; i++) {
-				tr->set(self->keyForIndex(i), LiteralStringRef("foo"));
+				tr->set(self->keyForIndex(i), "foo"_sr);
 			}
 		} else if (type == 6) {
 			wait(success(tr->getRange(KeyRangeRef(self->keyForIndex(0), self->keyForIndex(self->nodes)), self->nodes)));
 			for (i = 0; i < self->nodes; i += 2) {
-				tr->set(self->keyForIndex(i), LiteralStringRef("foo"));
+				tr->set(self->keyForIndex(i), "foo"_sr);
 			}
 		} else if (type == 7) {
 			wait(success(tr->getRange(KeyRangeRef(self->keyForIndex(0), self->keyForIndex(self->nodes)), self->nodes)));
@@ -130,7 +130,7 @@ struct RYWPerformanceWorkload : TestWorkload {
 			}
 			wait(waitForAll(gets));
 			for (i = 0; i < self->nodes; i++) {
-				tr->set(self->keyForIndex(i), LiteralStringRef("foo"));
+				tr->set(self->keyForIndex(i), "foo"_sr);
 			}
 		} else if (type == 11) {
 			std::vector<Future<RangeResult>> gets;
@@ -139,7 +139,7 @@ struct RYWPerformanceWorkload : TestWorkload {
 			}
 			wait(waitForAll(gets));
 			for (i = 0; i < self->nodes; i += 2) {
-				tr->set(self->keyForIndex(i), LiteralStringRef("foo"));
+				tr->set(self->keyForIndex(i), "foo"_sr);
 			}
 		} else if (type == 12) {
 			std::vector<Future<RangeResult>> gets;

--- a/fdbserver/workloads/RandomClogging.actor.cpp
+++ b/fdbserver/workloads/RandomClogging.actor.cpp
@@ -32,10 +32,10 @@ struct RandomCloggingWorkload : TestWorkload {
 
 	RandomCloggingWorkload(WorkloadContext const& wcx) : TestWorkload(wcx) {
 		enabled = !clientId; // only do this on the "first" client
-		testDuration = getOption(options, LiteralStringRef("testDuration"), 10.0);
-		scale = getOption(options, LiteralStringRef("scale"), 1.0);
-		clogginess = getOption(options, LiteralStringRef("clogginess"), 1.0);
-		swizzleClog = getOption(options, LiteralStringRef("swizzle"), 0);
+		testDuration = getOption(options, "testDuration"_sr, 10.0);
+		scale = getOption(options, "scale"_sr, 1.0);
+		clogginess = getOption(options, "clogginess"_sr, 1.0);
+		swizzleClog = getOption(options, "swizzle"_sr, 0);
 	}
 
 	std::string description() const override {

--- a/fdbserver/workloads/RandomMoveKeys.actor.cpp
+++ b/fdbserver/workloads/RandomMoveKeys.actor.cpp
@@ -36,9 +36,9 @@ struct MoveKeysWorkload : TestWorkload {
 
 	MoveKeysWorkload(WorkloadContext const& wcx) : TestWorkload(wcx) {
 		enabled = !clientId && g_network->isSimulated(); // only do this on the "first" client
-		meanDelay = getOption(options, LiteralStringRef("meanDelay"), 0.05);
-		testDuration = getOption(options, LiteralStringRef("testDuration"), 10.0);
-		maxKeyspace = getOption(options, LiteralStringRef("maxKeyspace"), 0.1);
+		meanDelay = getOption(options, "meanDelay"_sr, 0.05);
+		testDuration = getOption(options, "testDuration"_sr, 10.0);
+		maxKeyspace = getOption(options, "maxKeyspace"_sr, 0.1);
 	}
 
 	std::string description() const override { return "MoveKeysWorkload"; }

--- a/fdbserver/workloads/RandomSelector.actor.cpp
+++ b/fdbserver/workloads/RandomSelector.actor.cpp
@@ -36,13 +36,13 @@ struct RandomSelectorWorkload : TestWorkload {
 	RandomSelectorWorkload(WorkloadContext const& wcx)
 	  : TestWorkload(wcx), transactions("Transactions"), retries("Retries") {
 
-		minOperationsPerTransaction = getOption(options, LiteralStringRef("minOperationsPerTransaction"), 10);
-		maxOperationsPerTransaction = getOption(options, LiteralStringRef("minOperationsPerTransaction"), 50);
-		maxKeySpace = getOption(options, LiteralStringRef("maxKeySpace"), 20);
-		maxOffset = getOption(options, LiteralStringRef("maxOffset"), 5);
-		minInitialAmount = getOption(options, LiteralStringRef("minInitialAmount"), 5);
-		maxInitialAmount = getOption(options, LiteralStringRef("maxInitialAmount"), 10);
-		testDuration = getOption(options, LiteralStringRef("testDuration"), 10.0);
+		minOperationsPerTransaction = getOption(options, "minOperationsPerTransaction"_sr, 10);
+		maxOperationsPerTransaction = getOption(options, "minOperationsPerTransaction"_sr, 50);
+		maxKeySpace = getOption(options, "maxKeySpace"_sr, 20);
+		maxOffset = getOption(options, "maxOffset"_sr, 5);
+		minInitialAmount = getOption(options, "minInitialAmount"_sr, 5);
+		maxInitialAmount = getOption(options, "maxInitialAmount"_sr, 10);
+		testDuration = getOption(options, "testDuration"_sr, 10.0);
 		fail = false;
 	}
 

--- a/fdbserver/workloads/ReadAfterWrite.actor.cpp
+++ b/fdbserver/workloads/ReadAfterWrite.actor.cpp
@@ -53,7 +53,7 @@ struct ReadAfterWriteWorkload : KVWorkload {
 	ContinuousSample<double> propagationLatency;
 
 	ReadAfterWriteWorkload(WorkloadContext const& wcx) : KVWorkload(wcx), propagationLatency(SAMPLE_SIZE) {
-		testDuration = getOption(options, LiteralStringRef("testDuration"), 10.0);
+		testDuration = getOption(options, "testDuration"_sr, 10.0);
 	}
 
 	std::string description() const override { return "ReadAfterWriteWorkload"; }

--- a/fdbserver/workloads/ReadHotDetection.actor.cpp
+++ b/fdbserver/workloads/ReadHotDetection.actor.cpp
@@ -37,10 +37,10 @@ struct ReadHotDetectionWorkload : TestWorkload {
 	bool passed;
 
 	ReadHotDetectionWorkload(WorkloadContext const& wcx) : TestWorkload(wcx) {
-		testDuration = getOption(options, LiteralStringRef("testDuration"), 120.0);
-		transactionsPerSecond = getOption(options, LiteralStringRef("transactionsPerSecond"), 1000.0) / clientCount;
-		actorCount = getOption(options, LiteralStringRef("actorsPerClient"), transactionsPerSecond / 5);
-		keyCount = getOption(options, LiteralStringRef("keyCount"), 100);
+		testDuration = getOption(options, "testDuration"_sr, 120.0);
+		transactionsPerSecond = getOption(options, "transactionsPerSecond"_sr, 1000.0) / clientCount;
+		actorCount = getOption(options, "actorsPerClient"_sr, transactionsPerSecond / 5);
+		keyCount = getOption(options, "keyCount"_sr, 100);
 		readKey = StringRef(format("testkey%08x", deterministicRandom()->randomInt(0, keyCount)));
 	}
 
@@ -89,7 +89,7 @@ struct ReadHotDetectionWorkload : TestWorkload {
 				wait(tr.onError(e));
 			}
 		}
-		self->wholeRange = KeyRangeRef(LiteralStringRef(""), LiteralStringRef("\xff"));
+		self->wholeRange = KeyRangeRef(""_sr, "\xff"_sr);
 		// TraceEvent("RHDLog").detail("Phase", "DoneSetup");
 		return Void();
 	}

--- a/fdbserver/workloads/ReadWrite.actor.cpp
+++ b/fdbserver/workloads/ReadWrite.actor.cpp
@@ -125,62 +125,59 @@ struct ReadWriteWorkload : KVWorkload {
 	    commitLatencies(sampleSize), GRVLatencies(sampleSize), readLatencyTotal(0), readLatencyCount(0), loadTime(0.0),
 	    dependentReads(false), adjacentReads(false), adjacentWrites(false), clientBegin(0),
 	    aTransactions("A Transactions"), bTransactions("B Transactions"), retries("Retries"),
-	    totalReadsMetric(LiteralStringRef("RWWorkload.TotalReads")),
-	    totalRetriesMetric(LiteralStringRef("RWWorkload.TotalRetries")) {
-		transactionSuccessMetric.init(LiteralStringRef("RWWorkload.SuccessfulTransaction"));
-		transactionFailureMetric.init(LiteralStringRef("RWWorkload.FailedTransaction"));
-		readMetric.init(LiteralStringRef("RWWorkload.Read"));
+	    totalReadsMetric("RWWorkload.TotalReads"_sr), totalRetriesMetric("RWWorkload.TotalRetries"_sr) {
+		transactionSuccessMetric.init("RWWorkload.SuccessfulTransaction"_sr);
+		transactionFailureMetric.init("RWWorkload.FailedTransaction"_sr);
+		readMetric.init("RWWorkload.Read"_sr);
 
-		testDuration = getOption(options, LiteralStringRef("testDuration"), 10.0);
-		transactionsPerSecond = getOption(options, LiteralStringRef("transactionsPerSecond"), 5000.0) / clientCount;
-		double allowedLatency = getOption(options, LiteralStringRef("allowedLatency"), 0.250);
+		testDuration = getOption(options, "testDuration"_sr, 10.0);
+		transactionsPerSecond = getOption(options, "transactionsPerSecond"_sr, 5000.0) / clientCount;
+		double allowedLatency = getOption(options, "allowedLatency"_sr, 0.250);
 		actorCount = ceil(transactionsPerSecond * allowedLatency);
-		actorCount = getOption(options, LiteralStringRef("actorCountPerTester"), actorCount);
+		actorCount = getOption(options, "actorCountPerTester"_sr, actorCount);
 
-		readsPerTransactionA = getOption(options, LiteralStringRef("readsPerTransactionA"), 10);
-		writesPerTransactionA = getOption(options, LiteralStringRef("writesPerTransactionA"), 0);
-		readsPerTransactionB = getOption(options, LiteralStringRef("readsPerTransactionB"), 1);
-		writesPerTransactionB = getOption(options, LiteralStringRef("writesPerTransactionB"), 9);
-		alpha = getOption(options, LiteralStringRef("alpha"), 0.1);
+		readsPerTransactionA = getOption(options, "readsPerTransactionA"_sr, 10);
+		writesPerTransactionA = getOption(options, "writesPerTransactionA"_sr, 0);
+		readsPerTransactionB = getOption(options, "readsPerTransactionB"_sr, 1);
+		writesPerTransactionB = getOption(options, "writesPerTransactionB"_sr, 9);
+		alpha = getOption(options, "alpha"_sr, 0.1);
 
-		extraReadConflictRangesPerTransaction =
-		    getOption(options, LiteralStringRef("extraReadConflictRangesPerTransaction"), 0);
-		extraWriteConflictRangesPerTransaction =
-		    getOption(options, LiteralStringRef("extraWriteConflictRangesPerTransaction"), 0);
+		extraReadConflictRangesPerTransaction = getOption(options, "extraReadConflictRangesPerTransaction"_sr, 0);
+		extraWriteConflictRangesPerTransaction = getOption(options, "extraWriteConflictRangesPerTransaction"_sr, 0);
 
 		valueString = std::string(maxValueBytes, '.');
 		if (nodePrefix > 0) {
 			keyBytes += 16;
 		}
 
-		metricsStart = getOption(options, LiteralStringRef("metricsStart"), 0.0);
-		metricsDuration = getOption(options, LiteralStringRef("metricsDuration"), testDuration);
-		if (getOption(options, LiteralStringRef("discardEdgeMeasurements"), true)) {
+		metricsStart = getOption(options, "metricsStart"_sr, 0.0);
+		metricsDuration = getOption(options, "metricsDuration"_sr, testDuration);
+		if (getOption(options, "discardEdgeMeasurements"_sr, true)) {
 			// discardEdgeMeasurements keeps the metrics from the middle 3/4 of the test
 			metricsStart += testDuration * 0.125;
 			metricsDuration *= 0.75;
 		}
 
-		dependentReads = getOption(options, LiteralStringRef("dependentReads"), false);
-		warmingDelay = getOption(options, LiteralStringRef("warmingDelay"), 0.0);
-		maxInsertRate = getOption(options, LiteralStringRef("maxInsertRate"), 1e12);
-		debugInterval = getOption(options, LiteralStringRef("debugInterval"), 0.0);
-		debugTime = getOption(options, LiteralStringRef("debugTime"), 0.0);
-		enableReadLatencyLogging = getOption(options, LiteralStringRef("enableReadLatencyLogging"), false);
-		periodicLoggingInterval = getOption(options, LiteralStringRef("periodicLoggingInterval"), 5.0);
-		cancelWorkersAtDuration = getOption(options, LiteralStringRef("cancelWorkersAtDuration"), true);
-		inconsistentReads = getOption(options, LiteralStringRef("inconsistentReads"), false);
-		adjacentReads = getOption(options, LiteralStringRef("adjacentReads"), false);
-		adjacentWrites = getOption(options, LiteralStringRef("adjacentWrites"), false);
-		rampUpLoad = getOption(options, LiteralStringRef("rampUpLoad"), false);
-		useRYW = getOption(options, LiteralStringRef("useRYW"), false);
-		rampSweepCount = getOption(options, LiteralStringRef("rampSweepCount"), 1);
-		rangeReads = getOption(options, LiteralStringRef("rangeReads"), false);
-		rampTransactionType = getOption(options, LiteralStringRef("rampTransactionType"), false);
-		rampUpConcurrency = getOption(options, LiteralStringRef("rampUpConcurrency"), false);
-		doSetup = getOption(options, LiteralStringRef("setup"), true);
-		batchPriority = getOption(options, LiteralStringRef("batchPriority"), false);
-		descriptionString = getOption(options, LiteralStringRef("description"), LiteralStringRef("ReadWrite"));
+		dependentReads = getOption(options, "dependentReads"_sr, false);
+		warmingDelay = getOption(options, "warmingDelay"_sr, 0.0);
+		maxInsertRate = getOption(options, "maxInsertRate"_sr, 1e12);
+		debugInterval = getOption(options, "debugInterval"_sr, 0.0);
+		debugTime = getOption(options, "debugTime"_sr, 0.0);
+		enableReadLatencyLogging = getOption(options, "enableReadLatencyLogging"_sr, false);
+		periodicLoggingInterval = getOption(options, "periodicLoggingInterval"_sr, 5.0);
+		cancelWorkersAtDuration = getOption(options, "cancelWorkersAtDuration"_sr, true);
+		inconsistentReads = getOption(options, "inconsistentReads"_sr, false);
+		adjacentReads = getOption(options, "adjacentReads"_sr, false);
+		adjacentWrites = getOption(options, "adjacentWrites"_sr, false);
+		rampUpLoad = getOption(options, "rampUpLoad"_sr, false);
+		useRYW = getOption(options, "useRYW"_sr, false);
+		rampSweepCount = getOption(options, "rampSweepCount"_sr, 1);
+		rangeReads = getOption(options, "rangeReads"_sr, false);
+		rampTransactionType = getOption(options, "rampTransactionType"_sr, false);
+		rampUpConcurrency = getOption(options, "rampUpConcurrency"_sr, false);
+		doSetup = getOption(options, "setup"_sr, true);
+		batchPriority = getOption(options, "batchPriority"_sr, false);
+		descriptionString = getOption(options, "description"_sr, "ReadWrite"_sr);
 
 		if (rampUpConcurrency)
 			ASSERT(rampSweepCount == 2); // Implementation is hard coded to ramp up and down
@@ -197,7 +194,7 @@ struct ReadWriteWorkload : KVWorkload {
 		}
 
 		std::vector<std::string> insertionCountsToMeasureString =
-		    getOption(options, LiteralStringRef("insertionCountsToMeasure"), std::vector<std::string>());
+		    getOption(options, "insertionCountsToMeasure"_sr, std::vector<std::string>());
 		for (int i = 0; i < insertionCountsToMeasureString.size(); i++) {
 			try {
 				uint64_t count = boost::lexical_cast<uint64_t>(insertionCountsToMeasureString[i]);
@@ -209,8 +206,8 @@ struct ReadWriteWorkload : KVWorkload {
 		{
 			// with P(hotTrafficFraction) an access is directed to one of a fraction
 			//   of hot keys, else it is directed to a disjoint set of cold keys
-			hotKeyFraction = getOption(options, LiteralStringRef("hotKeyFraction"), 0.0);
-			double hotTrafficFraction = getOption(options, LiteralStringRef("hotTrafficFraction"), 0.0);
+			hotKeyFraction = getOption(options, "hotKeyFraction"_sr, 0.0);
+			double hotTrafficFraction = getOption(options, "hotTrafficFraction"_sr, 0.0);
 			ASSERT(hotKeyFraction >= 0 && hotTrafficFraction <= 1);
 			ASSERT(hotKeyFraction <= hotTrafficFraction); // hot keys should be actually hot!
 			// p(Cold key) = (1-FHP) * (1-hkf)

--- a/fdbserver/workloads/RemoveServersSafely.actor.cpp
+++ b/fdbserver/workloads/RemoveServersSafely.actor.cpp
@@ -44,14 +44,14 @@ struct RemoveServersSafelyWorkload : TestWorkload {
 	RemoveServersSafelyWorkload(WorkloadContext const& wcx) : TestWorkload(wcx) {
 		enabled =
 		    !clientId && g_network->isSimulated(); // only do this on the "first" client, and only when in simulation
-		minMachinesToKill = getOption(options, LiteralStringRef("minMachinesToKill"), 1);
-		maxMachinesToKill = getOption(options, LiteralStringRef("maxMachinesToKill"), 10);
+		minMachinesToKill = getOption(options, "minMachinesToKill"_sr, 1);
+		maxMachinesToKill = getOption(options, "maxMachinesToKill"_sr, 10);
 		maxMachinesToKill = std::max(minMachinesToKill, maxMachinesToKill);
-		maxSafetyCheckRetries = getOption(options, LiteralStringRef("maxSafetyCheckRetries"), 50);
-		minDelay = getOption(options, LiteralStringRef("minDelay"), 0.0);
-		maxDelay = getOption(options, LiteralStringRef("maxDelay"), 60.0);
-		kill1Timeout = getOption(options, LiteralStringRef("kill1Timeout"), 60.0);
-		kill2Timeout = getOption(options, LiteralStringRef("kill2Timeout"), 6000.0);
+		maxSafetyCheckRetries = getOption(options, "maxSafetyCheckRetries"_sr, 50);
+		minDelay = getOption(options, "minDelay"_sr, 0.0);
+		maxDelay = getOption(options, "maxDelay"_sr, 60.0);
+		kill1Timeout = getOption(options, "kill1Timeout"_sr, 60.0);
+		kill2Timeout = getOption(options, "kill2Timeout"_sr, 6000.0);
 		killProcesses = deterministicRandom()->random01() < 0.5;
 		if (g_network->isSimulated()) {
 			g_simulator.allowLogSetKills = false;

--- a/fdbserver/workloads/ReportConflictingKeys.actor.cpp
+++ b/fdbserver/workloads/ReportConflictingKeys.actor.cpp
@@ -40,23 +40,21 @@ struct ReportConflictingKeysWorkload : TestWorkload {
 	ReportConflictingKeysWorkload(WorkloadContext const& wcx)
 	  : TestWorkload(wcx), invalidReports("InvalidReports"), conflicts("Conflicts"), commits("Commits"),
 	    xacts("Transactions") {
-		testDuration = getOption(options, LiteralStringRef("testDuration"), 10.0);
-		// transactionsPerSecond = getOption(options, LiteralStringRef("transactionsPerSecond"), 5000.0) / clientCount;
-		actorCount = getOption(options, LiteralStringRef("actorsPerClient"), 1);
-		keyPrefix = unprintable(
-		    getOption(options, LiteralStringRef("keyPrefix"), LiteralStringRef("ReportConflictingKeysWorkload"))
-		        .toString());
-		keyBytes = getOption(options, LiteralStringRef("keyBytes"), 64);
+		testDuration = getOption(options, "testDuration"_sr, 10.0);
+		// transactionsPerSecond = getOption(options, "transactionsPerSecond"_sr, 5000.0) / clientCount;
+		actorCount = getOption(options, "actorsPerClient"_sr, 1);
+		keyPrefix = unprintable(getOption(options, "keyPrefix"_sr, "ReportConflictingKeysWorkload"_sr).toString());
+		keyBytes = getOption(options, "keyBytes"_sr, 64);
 
-		readConflictRangeCount = getOption(options, LiteralStringRef("readConflictRangeCountPerTx"), 1);
-		writeConflictRangeCount = getOption(options, LiteralStringRef("writeConflictRangeCountPerTx"), 1);
+		readConflictRangeCount = getOption(options, "readConflictRangeCountPerTx"_sr, 1);
+		writeConflictRangeCount = getOption(options, "writeConflictRangeCountPerTx"_sr, 1);
 		ASSERT(readConflictRangeCount >= 1 && writeConflictRangeCount >= 1);
 		// modeled by geometric distribution: (1 - prob) / prob = mean - 1, where we add at least one conflictRange to
 		// each tx
 		addReadConflictRangeProb = (readConflictRangeCount - 1.0) / readConflictRangeCount;
 		addWriteConflictRangeProb = (writeConflictRangeCount - 1.0) / writeConflictRangeCount;
 		ASSERT(keyPrefix.size() + 8 <= keyBytes); // make sure the string format is valid
-		nodeCount = getOption(options, LiteralStringRef("nodeCount"), 100);
+		nodeCount = getOption(options, "nodeCount"_sr, 100);
 	}
 
 	std::string description() const override { return "ReportConflictingKeysWorkload"; }
@@ -187,9 +185,8 @@ struct ReportConflictingKeysWorkload : TestWorkload {
 				// check API correctness
 				if (foundConflict) {
 					// \xff\xff/transaction/conflicting_keys is always initialized to false, skip it here
-					state KeyRange ckr =
-					    KeyRangeRef(keyAfter(LiteralStringRef("").withPrefix(conflictingKeysRange.begin)),
-					                LiteralStringRef("\xff\xff").withPrefix(conflictingKeysRange.begin));
+					state KeyRange ckr = KeyRangeRef(keyAfter(""_sr.withPrefix(conflictingKeysRange.begin)),
+					                                 "\xff\xff"_sr.withPrefix(conflictingKeysRange.begin));
 					// The getRange here using the special key prefix "\xff\xff/transaction/conflicting_keys/" happens
 					// locally Thus, the error handling is not needed here
 					Future<RangeResult> conflictingKeyRangesFuture = tr2->getRange(ckr, CLIENT_KNOBS->TOO_MANY);

--- a/fdbserver/workloads/RestoreBackup.actor.cpp
+++ b/fdbserver/workloads/RestoreBackup.actor.cpp
@@ -37,10 +37,10 @@ struct RestoreBackupWorkload final : TestWorkload {
 	StopWhenDone stopWhenDone{ false };
 
 	RestoreBackupWorkload(WorkloadContext const& wcx) : TestWorkload(wcx) {
-		backupDir = getOption(options, LiteralStringRef("backupDir"), LiteralStringRef("file://simfdb/backups/"));
-		tag = getOption(options, LiteralStringRef("tag"), LiteralStringRef("default"));
-		delayFor = getOption(options, LiteralStringRef("delayFor"), 10.0);
-		stopWhenDone.set(getOption(options, LiteralStringRef("stopWhenDone"), false));
+		backupDir = getOption(options, "backupDir"_sr, "file://simfdb/backups/"_sr);
+		tag = getOption(options, "tag"_sr, "default"_sr);
+		delayFor = getOption(options, "delayFor"_sr, 10.0);
+		stopWhenDone.set(getOption(options, "stopWhenDone"_sr, false));
 	}
 
 	static constexpr const char* DESCRIPTION = "RestoreBackup";

--- a/fdbserver/workloads/RestoreFromBlob.actor.cpp
+++ b/fdbserver/workloads/RestoreFromBlob.actor.cpp
@@ -35,16 +35,13 @@ struct RestoreFromBlobWorkload : TestWorkload {
 	static constexpr const char* DESCRIPTION = "RestoreFromBlob";
 
 	RestoreFromBlobWorkload(WorkloadContext const& wcx) : TestWorkload(wcx) {
-		restoreAfter = getOption(options, LiteralStringRef("restoreAfter"), 10.0);
-		backupTag = getOption(options, LiteralStringRef("backupTag"), BackupAgentBase::getDefaultTag());
-		auto backupURLString =
-		    getOption(options, LiteralStringRef("backupURL"), LiteralStringRef("http://0.0.0.0:10000")).toString();
-		auto accessKeyEnvVar =
-		    getOption(options, LiteralStringRef("accessKeyVar"), LiteralStringRef("BLOB_ACCESS_KEY")).toString();
-		auto secretKeyEnvVar =
-		    getOption(options, LiteralStringRef("secretKeyVar"), LiteralStringRef("BLOB_SECRET_KEY")).toString();
-		bool provideKeys = getOption(options, LiteralStringRef("provideKeys"), false);
-		waitForComplete.set(getOption(options, LiteralStringRef("waitForComplete"), true));
+		restoreAfter = getOption(options, "restoreAfter"_sr, 10.0);
+		backupTag = getOption(options, "backupTag"_sr, BackupAgentBase::getDefaultTag());
+		auto backupURLString = getOption(options, "backupURL"_sr, "http://0.0.0.0:10000"_sr).toString();
+		auto accessKeyEnvVar = getOption(options, "accessKeyVar"_sr, "BLOB_ACCESS_KEY"_sr).toString();
+		auto secretKeyEnvVar = getOption(options, "secretKeyVar"_sr, "BLOB_SECRET_KEY"_sr).toString();
+		bool provideKeys = getOption(options, "provideKeys"_sr, false);
+		waitForComplete.set(getOption(options, "waitForComplete"_sr, true));
 		if (provideKeys) {
 			updateBackupURL(backupURLString, accessKeyEnvVar, "<access_key>", secretKeyEnvVar, "<secret_key>");
 		}

--- a/fdbserver/workloads/Rollback.actor.cpp
+++ b/fdbserver/workloads/Rollback.actor.cpp
@@ -37,11 +37,11 @@ struct RollbackWorkload : TestWorkload {
 
 	RollbackWorkload(WorkloadContext const& wcx) : TestWorkload(wcx) {
 		enabled = !clientId; // only do this on the "first" client
-		meanDelay = getOption(options, LiteralStringRef("meanDelay"), 20.0); // Only matters if multiple==true
-		clogDuration = getOption(options, LiteralStringRef("clogDuration"), 3.0);
-		testDuration = getOption(options, LiteralStringRef("testDuration"), 10.0);
-		enableFailures = getOption(options, LiteralStringRef("enableFailures"), false);
-		multiple = getOption(options, LiteralStringRef("multiple"), true);
+		meanDelay = getOption(options, "meanDelay"_sr, 20.0); // Only matters if multiple==true
+		clogDuration = getOption(options, "clogDuration"_sr, 3.0);
+		testDuration = getOption(options, "testDuration"_sr, 10.0);
+		enableFailures = getOption(options, "enableFailures"_sr, false);
+		multiple = getOption(options, "multiple"_sr, true);
 	}
 
 	std::string description() const override { return "RollbackWorkload"; }

--- a/fdbserver/workloads/RyowCorrectness.actor.cpp
+++ b/fdbserver/workloads/RyowCorrectness.actor.cpp
@@ -29,7 +29,7 @@
 #define TRACE_TRANSACTION 0
 
 #if TRACE_TRANSACTION
-StringRef debugKey = LiteralStringRef("0000000000uldlamzpspf");
+StringRef debugKey = "0000000000uldlamzpspf"_sr;
 #endif
 
 // A struct representing an operation to be performed on a transaction
@@ -62,8 +62,8 @@ struct RyowCorrectnessWorkload : ApiWorkload {
 	int opsPerTransaction;
 
 	RyowCorrectnessWorkload(WorkloadContext const& wcx) : ApiWorkload(wcx, 1) {
-		duration = getOption(options, LiteralStringRef("duration"), 60);
-		opsPerTransaction = getOption(options, LiteralStringRef("opsPerTransaction"), 50);
+		duration = getOption(options, "duration"_sr, 60);
+		opsPerTransaction = getOption(options, "opsPerTransaction"_sr, 50);
 	}
 
 	std::string description() const override { return "RyowCorrectness"; }
@@ -142,7 +142,7 @@ struct RyowCorrectnessWorkload : ApiWorkload {
 	void pushKVPair(std::vector<RangeResult>& results, Key const& key, Optional<Value> const& value) {
 		RangeResult result;
 		if (!value.present())
-			result.push_back_deep(result.arena(), KeyValueRef(key, LiteralStringRef("VALUE_NOT_PRESENT")));
+			result.push_back_deep(result.arena(), KeyValueRef(key, "VALUE_NOT_PRESENT"_sr));
 		else
 			result.push_back_deep(result.arena(), KeyValueRef(key, value.get()));
 

--- a/fdbserver/workloads/SaveAndKill.actor.cpp
+++ b/fdbserver/workloads/SaveAndKill.actor.cpp
@@ -37,11 +37,9 @@ struct SaveAndKillWorkload : TestWorkload {
 	int isRestoring;
 
 	SaveAndKillWorkload(WorkloadContext const& wcx) : TestWorkload(wcx) {
-		restartInfo =
-		    getOption(options, LiteralStringRef("restartInfoLocation"), LiteralStringRef("simfdb/restartInfo.ini"))
-		        .toString();
-		testDuration = getOption(options, LiteralStringRef("testDuration"), 10.0);
-		isRestoring = getOption(options, LiteralStringRef("isRestoring"), 0);
+		restartInfo = getOption(options, "restartInfoLocation"_sr, "simfdb/restartInfo.ini"_sr).toString();
+		testDuration = getOption(options, "testDuration"_sr, 10.0);
+		isRestoring = getOption(options, "isRestoring"_sr, 0);
 	}
 
 	std::string description() const override { return "SaveAndKillWorkload"; }

--- a/fdbserver/workloads/SelectorCorrectness.actor.cpp
+++ b/fdbserver/workloads/SelectorCorrectness.actor.cpp
@@ -35,12 +35,12 @@ struct SelectorCorrectnessWorkload : TestWorkload {
 	SelectorCorrectnessWorkload(WorkloadContext const& wcx)
 	  : TestWorkload(wcx), transactions("Transactions"), retries("Retries") {
 
-		minOperationsPerTransaction = getOption(options, LiteralStringRef("minOperationsPerTransaction"), 10);
-		maxOperationsPerTransaction = getOption(options, LiteralStringRef("minOperationsPerTransaction"), 50);
-		maxKeySpace = getOption(options, LiteralStringRef("maxKeySpace"), 10);
-		maxOffset = getOption(options, LiteralStringRef("maxOffset"), 20);
-		testReadYourWrites = getOption(options, LiteralStringRef("testReadYourWrites"), true);
-		testDuration = getOption(options, LiteralStringRef("testDuration"), 10.0);
+		minOperationsPerTransaction = getOption(options, "minOperationsPerTransaction"_sr, 10);
+		maxOperationsPerTransaction = getOption(options, "minOperationsPerTransaction"_sr, 50);
+		maxKeySpace = getOption(options, "maxKeySpace"_sr, 10);
+		maxOffset = getOption(options, "maxOffset"_sr, 20);
+		testReadYourWrites = getOption(options, "testReadYourWrites"_sr, true);
+		testDuration = getOption(options, "testDuration"_sr, 10.0);
 	}
 
 	std::string description() const override { return "SelectorCorrectness"; }

--- a/fdbserver/workloads/Serializability.actor.cpp
+++ b/fdbserver/workloads/Serializability.actor.cpp
@@ -65,9 +65,9 @@ struct SerializabilityWorkload : TestWorkload {
 	};
 
 	SerializabilityWorkload(WorkloadContext const& wcx) : TestWorkload(wcx), success(true) {
-		testDuration = getOption(options, LiteralStringRef("testDuration"), 30.0);
-		numOps = getOption(options, LiteralStringRef("numOps"), 21);
-		nodes = getOption(options, LiteralStringRef("nodes"), 1000);
+		testDuration = getOption(options, "testDuration"_sr, 30.0);
+		numOps = getOption(options, "numOps"_sr, 21);
+		nodes = getOption(options, "nodes"_sr, 1000);
 
 		adjacentKeys = false; // deterministicRandom()->random01() < 0.5;
 		valueSizeRange = std::make_pair(0, 100);

--- a/fdbserver/workloads/Sideband.actor.cpp
+++ b/fdbserver/workloads/Sideband.actor.cpp
@@ -59,8 +59,8 @@ struct SidebandWorkload : TestWorkload {
 	SidebandWorkload(WorkloadContext const& wcx)
 	  : TestWorkload(wcx), messages("Messages"), consistencyErrors("Causal Consistency Errors"),
 	    keysUnexpectedlyPresent("KeysUnexpectedlyPresent") {
-		testDuration = getOption(options, LiteralStringRef("testDuration"), 10.0);
-		operationsPerSecond = getOption(options, LiteralStringRef("operationsPerSecond"), 50.0);
+		testDuration = getOption(options, "testDuration"_sr, 10.0);
+		operationsPerSecond = getOption(options, "operationsPerSecond"_sr, 50.0);
 	}
 
 	std::string description() const override { return "SidebandWorkload"; }
@@ -151,7 +151,7 @@ struct SidebandWorkload : TestWorkload {
 						++self->keysUnexpectedlyPresent;
 						break;
 					}
-					tr.set(messageKey, LiteralStringRef("deadbeef"));
+					tr.set(messageKey, "deadbeef"_sr);
 					wait(tr.commit());
 					commitVersion = tr.getCommittedVersion();
 					break;

--- a/fdbserver/workloads/SimpleAtomicAdd.actor.cpp
+++ b/fdbserver/workloads/SimpleAtomicAdd.actor.cpp
@@ -35,12 +35,12 @@ struct SimpleAtomicAddWorkload : TestWorkload {
 	vector<Future<Void>> clients;
 
 	SimpleAtomicAddWorkload(WorkloadContext const& wcx) : TestWorkload(wcx) {
-		testDuration = getOption(options, LiteralStringRef("testDuration"), 10.0);
-		addValue = getOption(options, LiteralStringRef("addValue"), 1);
-		iterations = getOption(options, LiteralStringRef("iterations"), 100);
-		initialize = getOption(options, LiteralStringRef("initialize"), false);
-		initialValue = getOption(options, LiteralStringRef("initialValue"), 0);
-		sumKey = getOption(options, LiteralStringRef("sumKey"), LiteralStringRef("sumKey"));
+		testDuration = getOption(options, "testDuration"_sr, 10.0);
+		addValue = getOption(options, "addValue"_sr, 1);
+		iterations = getOption(options, "iterations"_sr, 100);
+		initialize = getOption(options, "initialize"_sr, false);
+		initialValue = getOption(options, "initialValue"_sr, 0);
+		sumKey = getOption(options, "sumKey"_sr, "sumKey"_sr);
 	}
 
 	std::string description() const override { return "SimpleAtomicAdd"; }

--- a/fdbserver/workloads/SnapTest.actor.cpp
+++ b/fdbserver/workloads/SnapTest.actor.cpp
@@ -94,14 +94,12 @@ public: // ctor & dtor
 		std::string workloadName = "SnapTest";
 		maxRetryCntToRetrieveMessage = 10;
 
-		numSnaps = getOption(options, LiteralStringRef("numSnaps"), 0);
-		maxSnapDelay = getOption(options, LiteralStringRef("maxSnapDelay"), 25.0);
-		testID = getOption(options, LiteralStringRef("testID"), 0);
-		restartInfoLocation =
-		    getOption(options, LiteralStringRef("restartInfoLocation"), LiteralStringRef("simfdb/restartInfo.ini"))
-		        .toString();
+		numSnaps = getOption(options, "numSnaps"_sr, 0);
+		maxSnapDelay = getOption(options, "maxSnapDelay"_sr, 25.0);
+		testID = getOption(options, "testID"_sr, 0);
+		restartInfoLocation = getOption(options, "restartInfoLocation"_sr, "simfdb/restartInfo.ini"_sr).toString();
 		skipCheck = false;
-		retryLimit = getOption(options, LiteralStringRef("retryLimit"), 5);
+		retryLimit = getOption(options, "retryLimit"_sr, 5);
 	}
 
 public: // workload functions
@@ -128,7 +126,7 @@ public: // workload functions
 		loop {
 			try {
 				Standalone<StringRef> keyStr =
-				    LiteralStringRef("\xff/SnapTestFailStatus/").withSuffix(StringRef(self->snapUID.toString()));
+				    "\xff/SnapTestFailStatus/"_sr.withSuffix(StringRef(self->snapUID.toString()));
 				TraceEvent("TestKeyStr").detail("Value", keyStr);
 				tr.setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
 				Optional<Value> val = wait(tr.get(keyStr));
@@ -212,7 +210,7 @@ public: // workload functions
 			loop {
 				self->snapUID = deterministicRandom()->randomUniqueID();
 				try {
-					StringRef snapCmdRef = LiteralStringRef("/bin/snap_create.sh");
+					StringRef snapCmdRef = "/bin/snap_create.sh"_sr;
 					Future<Void> status = snapCreate(cx, snapCmdRef, self->snapUID);
 					wait(status);
 					break;
@@ -270,7 +268,7 @@ public: // workload functions
 					}
 
 					for (int i = 0; i < kvRange.size(); i++) {
-						if (kvRange[i].key.startsWith(LiteralStringRef("snapKey"))) {
+						if (kvRange[i].key.startsWith("snapKey"_sr)) {
 							std::string tmp1 = kvRange[i].key.substr(7).toString();
 							int64_t id = strtol(tmp1.c_str(), nullptr, 0);
 							if (id % 2 != 0) {
@@ -301,7 +299,7 @@ public: // workload functions
 			loop {
 				self->snapUID = deterministicRandom()->randomUniqueID();
 				try {
-					StringRef snapCmdRef = LiteralStringRef("/bin/snap_create1.sh");
+					StringRef snapCmdRef = "/bin/snap_create1.sh"_sr;
 					Future<Void> status = snapCreate(cx, snapCmdRef, self->snapUID);
 					wait(status);
 					break;

--- a/fdbserver/workloads/StatusWorkload.actor.cpp
+++ b/fdbserver/workloads/StatusWorkload.actor.cpp
@@ -39,11 +39,10 @@ struct StatusWorkload : TestWorkload {
 	StatusWorkload(WorkloadContext const& wcx)
 	  : TestWorkload(wcx), requests("Status requests issued"), replies("Status replies received"),
 	    errors("Status Errors"), totalSize("Status reply size sum") {
-		testDuration = getOption(options, LiteralStringRef("testDuration"), 10.0);
-		requestsPerSecond = getOption(options, LiteralStringRef("requestsPerSecond"), 0.5);
-		enableLatencyBands =
-		    getOption(options, LiteralStringRef("enableLatencyBands"), deterministicRandom()->random01() < 0.5);
-		auto statusSchemaStr = getOption(options, LiteralStringRef("schema"), JSONSchemas::statusSchema);
+		testDuration = getOption(options, "testDuration"_sr, 10.0);
+		requestsPerSecond = getOption(options, "requestsPerSecond"_sr, 0.5);
+		enableLatencyBands = getOption(options, "enableLatencyBands"_sr, deterministicRandom()->random01() < 0.5);
+		auto statusSchemaStr = getOption(options, "schema"_sr, JSONSchemas::statusSchema);
 		if (statusSchemaStr.size()) {
 			json_spirit::mValue schema = readJSONStrictly(statusSchemaStr.toString());
 			parsedSchema = schema.get_obj();

--- a/fdbserver/workloads/Storefront.actor.cpp
+++ b/fdbserver/workloads/Storefront.actor.cpp
@@ -43,15 +43,12 @@ struct StorefrontWorkload : TestWorkload {
 	StorefrontWorkload(WorkloadContext const& wcx)
 	  : TestWorkload(wcx), transactions("Transactions"), retries("Retries"), totalLatency("Total Latency"),
 	    spuriousCommitFailures("Spurious Commit Failures") {
-		testDuration = getOption(options, LiteralStringRef("testDuration"), 10.0);
-		transactionsPerSecond = getOption(options, LiteralStringRef("transactionsPerSecond"), 1000.0);
-		actorCount =
-		    getOption(options, LiteralStringRef("actorsPerClient"), std::max((int)(transactionsPerSecond / 100), 1));
-		maxOrderSize = getOption(options, LiteralStringRef("maxOrderSize"), 20);
-		itemCount =
-		    getOption(options, LiteralStringRef("itemCount"), transactionsPerSecond * clientCount * maxOrderSize);
-		minExpectedTransactionsPerSecond =
-		    transactionsPerSecond * getOption(options, LiteralStringRef("expectedRate"), 0.9);
+		testDuration = getOption(options, "testDuration"_sr, 10.0);
+		transactionsPerSecond = getOption(options, "transactionsPerSecond"_sr, 1000.0);
+		actorCount = getOption(options, "actorsPerClient"_sr, std::max((int)(transactionsPerSecond / 100), 1));
+		maxOrderSize = getOption(options, "maxOrderSize"_sr, 20);
+		itemCount = getOption(options, "itemCount"_sr, transactionsPerSecond * clientCount * maxOrderSize);
+		minExpectedTransactionsPerSecond = transactionsPerSecond * getOption(options, "expectedRate"_sr, 0.9);
 	}
 
 	std::string description() const override { return "StorefrontWorkload"; }
@@ -202,8 +199,7 @@ struct StorefrontWorkload : TestWorkload {
 
 	ACTOR Future<bool> tableBalancer(Database cx, StorefrontWorkload* self, KeyRangeRef keyRange) {
 		state vector<Future<vector<int>>> accumulators;
-		accumulators.push_back(
-		    self->orderAccumulator(cx, self, KeyRangeRef(LiteralStringRef("/orders/f"), LiteralStringRef("/orders0"))));
+		accumulators.push_back(self->orderAccumulator(cx, self, KeyRangeRef("/orders/f"_sr, "/orders0"_sr)));
 		for (int c = 0; c < 15; c++)
 			accumulators.push_back(self->orderAccumulator(
 			    cx, self, KeyRangeRef(Key(format("/orders/%x", c)), Key(format("/orders/%x", c + 1)))));

--- a/fdbserver/workloads/StreamingRead.actor.cpp
+++ b/fdbserver/workloads/StreamingRead.actor.cpp
@@ -40,17 +40,17 @@ struct StreamingReadWorkload : TestWorkload {
 	StreamingReadWorkload(WorkloadContext const& wcx)
 	  : TestWorkload(wcx), transactions("Transactions"), readKeys("Keys Read"), readValueBytes("Value Bytes Read"),
 	    latencies(2000) {
-		testDuration = getOption(options, LiteralStringRef("testDuration"), 10.0);
-		actorCount = getOption(options, LiteralStringRef("actorCount"), 20);
-		readsPerTransaction = getOption(options, LiteralStringRef("readsPerTransaction"), 10);
-		rangesPerTransaction = getOption(options, LiteralStringRef("rangesPerTransaction"), 1);
-		nodeCount = getOption(options, LiteralStringRef("nodeCount"), 100000);
-		keyBytes = std::max(getOption(options, LiteralStringRef("keyBytes"), 16), 16);
-		valueBytes = std::max(getOption(options, LiteralStringRef("valueBytes"), 96), 16);
+		testDuration = getOption(options, "testDuration"_sr, 10.0);
+		actorCount = getOption(options, "actorCount"_sr, 20);
+		readsPerTransaction = getOption(options, "readsPerTransaction"_sr, 10);
+		rangesPerTransaction = getOption(options, "rangesPerTransaction"_sr, 1);
+		nodeCount = getOption(options, "nodeCount"_sr, 100000);
+		keyBytes = std::max(getOption(options, "keyBytes"_sr, 16), 16);
+		valueBytes = std::max(getOption(options, "valueBytes"_sr, 96), 16);
 		std::string valueFormat = "%016llx" + std::string(valueBytes - 16, '.');
-		warmingDelay = getOption(options, LiteralStringRef("warmingDelay"), 0.0);
+		warmingDelay = getOption(options, "warmingDelay"_sr, 0.0);
 		constantValue = Value(format(valueFormat.c_str(), 42));
-		readSequentially = getOption(options, LiteralStringRef("readSequentially"), false);
+		readSequentially = getOption(options, "readSequentially"_sr, false);
 	}
 
 	std::string description() const override { return "StreamingRead"; }

--- a/fdbserver/workloads/SubmitBackup.actor.cpp
+++ b/fdbserver/workloads/SubmitBackup.actor.cpp
@@ -39,13 +39,13 @@ struct SubmitBackupWorkload final : TestWorkload {
 	IncrementalBackupOnly incremental{ false };
 
 	SubmitBackupWorkload(WorkloadContext const& wcx) : TestWorkload(wcx) {
-		backupDir = getOption(options, LiteralStringRef("backupDir"), LiteralStringRef("file://simfdb/backups/"));
-		tag = getOption(options, LiteralStringRef("tag"), LiteralStringRef("default"));
-		delayFor = getOption(options, LiteralStringRef("delayFor"), 10.0);
-		initSnapshotInterval = getOption(options, LiteralStringRef("initSnapshotInterval"), 0);
-		snapshotInterval = getOption(options, LiteralStringRef("snapshotInterval"), 1e8);
-		stopWhenDone.set(getOption(options, LiteralStringRef("stopWhenDone"), true));
-		incremental.set(getOption(options, LiteralStringRef("incremental"), false));
+		backupDir = getOption(options, "backupDir"_sr, "file://simfdb/backups/"_sr);
+		tag = getOption(options, "tag"_sr, "default"_sr);
+		delayFor = getOption(options, "delayFor"_sr, 10.0);
+		initSnapshotInterval = getOption(options, "initSnapshotInterval"_sr, 0);
+		snapshotInterval = getOption(options, "snapshotInterval"_sr, 1e8);
+		stopWhenDone.set(getOption(options, "stopWhenDone"_sr, true));
+		incremental.set(getOption(options, "incremental"_sr, false));
 	}
 
 	static constexpr const char* DESCRIPTION = "SubmitBackup";

--- a/fdbserver/workloads/SuspendProcesses.actor.cpp
+++ b/fdbserver/workloads/SuspendProcesses.actor.cpp
@@ -14,10 +14,9 @@ struct SuspendProcessesWorkload : TestWorkload {
 	double waitTimeDuration;
 
 	SuspendProcessesWorkload(WorkloadContext const& wcx) : TestWorkload(wcx) {
-		prefixSuspendProcesses =
-		    getOption(options, LiteralStringRef("prefixesSuspendProcesses"), std::vector<std::string>());
-		waitTimeDuration = getOption(options, LiteralStringRef("waitTimeDuration"), 0);
-		suspendTimeDuration = getOption(options, LiteralStringRef("suspendTimeDuration"), 0);
+		prefixSuspendProcesses = getOption(options, "prefixesSuspendProcesses"_sr, std::vector<std::string>());
+		waitTimeDuration = getOption(options, "waitTimeDuration"_sr, 0);
+		suspendTimeDuration = getOption(options, "suspendTimeDuration"_sr, 0);
 	}
 
 	std::string description() const override { return "SuspendProcesses"; }
@@ -31,16 +30,14 @@ struct SuspendProcessesWorkload : TestWorkload {
 			try {
 				tr.setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
 				tr.setOption(FDBTransactionOptions::LOCK_AWARE);
-				RangeResult kvs = wait(tr.getRange(KeyRangeRef(LiteralStringRef("\xff\xff/worker_interfaces/"),
-				                                               LiteralStringRef("\xff\xff/worker_interfaces0")),
-				                                   CLIENT_KNOBS->TOO_MANY));
+				RangeResult kvs =
+				    wait(tr.getRange(KeyRangeRef("\xff\xff/worker_interfaces/"_sr, "\xff\xff/worker_interfaces0"_sr),
+				                     CLIENT_KNOBS->TOO_MANY));
 				ASSERT(!kvs.more);
 				std::vector<Standalone<StringRef>> suspendProcessInterfaces;
 				for (auto it : kvs) {
-					auto ip_port =
-					    (it.key.endsWith(LiteralStringRef(":tls")) ? it.key.removeSuffix(LiteralStringRef(":tls"))
-					                                               : it.key)
-					        .removePrefix(LiteralStringRef("\xff\xff/worker_interfaces/"));
+					auto ip_port = (it.key.endsWith(":tls"_sr) ? it.key.removeSuffix(":tls"_sr) : it.key)
+					                   .removePrefix("\xff\xff/worker_interfaces/"_sr);
 					for (auto& killProcess : self->prefixSuspendProcesses) {
 						if (boost::starts_with(ip_port.toString().c_str(), killProcess.c_str())) {
 							suspendProcessInterfaces.push_back(it.value);

--- a/fdbserver/workloads/TPCC.actor.cpp
+++ b/fdbserver/workloads/TPCC.actor.cpp
@@ -118,11 +118,11 @@ struct TPCC : TestWorkload {
 
 	TPCC(WorkloadContext const& ctx) : TestWorkload(ctx) {
 		std::string workloadName = DESCRIPTION;
-		warehousesPerClient = getOption(options, LiteralStringRef("warehousesPerClient"), 100);
-		expectedTransactionsPerMinute = getOption(options, LiteralStringRef("expectedTransactionsPerMinute"), 1000);
-		testDuration = getOption(options, LiteralStringRef("testDuration"), 600);
-		warmupTime = getOption(options, LiteralStringRef("warmupTime"), 30);
-		getOption(options, LiteralStringRef("clientsUsed"), 40);
+		warehousesPerClient = getOption(options, "warehousesPerClient"_sr, 100);
+		expectedTransactionsPerMinute = getOption(options, "expectedTransactionsPerMinute"_sr, 1000);
+		testDuration = getOption(options, "testDuration"_sr, 600);
+		warmupTime = getOption(options, "warmupTime"_sr, 30);
+		getOption(options, "clientsUsed"_sr, 40);
 	}
 
 	int NURand(int C, int A, int x, int y) {
@@ -416,7 +416,7 @@ struct TPCC : TestWorkload {
 			customer.c_balance -= history.h_amount;
 			customer.c_ytd_payment += history.h_amount;
 			customer.c_payment_cnt += 1;
-			if (customer.c_credit == LiteralStringRef("BC")) {
+			if (customer.c_credit == "BC"_sr) {
 				// we must update c_data
 				std::stringstream ss;
 				ss << customer.c_id << "," << customer.c_d_id << "," << customer.c_w_id << "," << district.d_id << ","
@@ -447,7 +447,7 @@ struct TPCC : TestWorkload {
 				UID k = deterministicRandom()->randomUniqueID();
 				BinaryWriter kW(Unversioned());
 				serializer(kW, k);
-				auto key = kW.toValue().withPrefix(LiteralStringRef("History/"));
+				auto key = kW.toValue().withPrefix("History/"_sr);
 				tr.set(key, w.toValue());
 			}
 			wait(tr.commit());

--- a/fdbserver/workloads/TPCCWorkload.h
+++ b/fdbserver/workloads/TPCCWorkload.h
@@ -309,7 +309,7 @@ struct GlobalState {
 		serializer(ar, CLoad, CRun, CDelta, CId, COlIID);
 	}
 
-	StringRef key() const { return LiteralStringRef("GlobalState"); }
+	StringRef key() const { return "GlobalState"_sr; }
 };
 
 const std::vector<std::string> syllables = {

--- a/fdbserver/workloads/TagThrottleApi.actor.cpp
+++ b/fdbserver/workloads/TagThrottleApi.actor.cpp
@@ -33,7 +33,7 @@ struct TagThrottleApiWorkload : TestWorkload {
 	constexpr static const char* NAME = "TagThrottleApi";
 
 	TagThrottleApiWorkload(WorkloadContext const& wcx) : TestWorkload(wcx) {
-		testDuration = getOption(options, LiteralStringRef("testDuration"), 10.0);
+		testDuration = getOption(options, "testDuration"_sr, 10.0);
 		autoThrottleEnabled = SERVER_KNOBS->AUTO_TAG_THROTTLING_ENABLED;
 	}
 

--- a/fdbserver/workloads/TargetedKill.actor.cpp
+++ b/fdbserver/workloads/TargetedKill.actor.cpp
@@ -36,9 +36,9 @@ struct TargetedKillWorkload : TestWorkload {
 
 	TargetedKillWorkload(WorkloadContext const& wcx) : TestWorkload(wcx) {
 		enabled = !clientId; // only do this on the "first" client
-		killAt = getOption(options, LiteralStringRef("killAt"), 5.0);
-		machineToKill = getOption(options, LiteralStringRef("machineToKill"), LiteralStringRef("master")).toString();
-		killAllMachineProcesses = getOption(options, LiteralStringRef("killWholeMachine"), false);
+		killAt = getOption(options, "killAt"_sr, 5.0);
+		machineToKill = getOption(options, "machineToKill"_sr, "master"_sr).toString();
+		killAllMachineProcesses = getOption(options, "killWholeMachine"_sr, false);
 	}
 
 	std::string description() const override { return "TargetedKillWorkload"; }

--- a/fdbserver/workloads/TaskBucketCorrectness.actor.cpp
+++ b/fdbserver/workloads/TaskBucketCorrectness.actor.cpp
@@ -71,7 +71,7 @@ struct SayHelloTaskFunc : TaskFuncBase {
 
 		state Key key = StringRef("Hello_" + deterministicRandom()->randomUniqueID().toString());
 		state Key value;
-		auto itor = task->params.find(LiteralStringRef("name"));
+		auto itor = task->params.find("name"_sr);
 		if (itor != task->params.end()) {
 			value = itor->value;
 			TraceEvent("TaskBucketCorrectnessSayHello").detail("SayHelloTaskFunc", printable(itor->value));
@@ -79,11 +79,11 @@ struct SayHelloTaskFunc : TaskFuncBase {
 			ASSERT(false);
 		}
 
-		if (!task->params[LiteralStringRef("chained")].compare(LiteralStringRef("false"))) {
+		if (!task->params["chained"_sr].compare("false"_sr)) {
 			wait(done->set(tr, taskBucket));
 		} else {
-			int subtaskCount = atoi(task->params[LiteralStringRef("subtaskCount")].toString().c_str());
-			int currTaskNumber = atoi(value.removePrefix(LiteralStringRef("task_")).toString().c_str());
+			int subtaskCount = atoi(task->params["subtaskCount"_sr].toString().c_str());
+			int currTaskNumber = atoi(value.removePrefix("task_"_sr).toString().c_str());
 			TraceEvent("TaskBucketCorrectnessSayHello")
 			    .detail("SubtaskCount", subtaskCount)
 			    .detail("CurrTaskNumber", currTaskNumber);
@@ -94,9 +94,9 @@ struct SayHelloTaskFunc : TaskFuncBase {
 				                                    SayHelloTaskFunc::version,
 				                                    StringRef(),
 				                                    deterministicRandom()->randomInt(0, 2));
-				new_task->params[LiteralStringRef("name")] = StringRef(format("task_%d", currTaskNumber + 1));
-				new_task->params[LiteralStringRef("chained")] = task->params[LiteralStringRef("chained")];
-				new_task->params[LiteralStringRef("subtaskCount")] = task->params[LiteralStringRef("subtaskCount")];
+				new_task->params["name"_sr] = StringRef(format("task_%d", currTaskNumber + 1));
+				new_task->params["chained"_sr] = task->params["chained"_sr];
+				new_task->params["subtaskCount"_sr] = task->params["subtaskCount"_sr];
 				Reference<TaskFuture> taskDone = futureBucket->future(tr);
 				new_task->params[Task::reservedTaskParamKeyDone] = taskDone->key;
 				taskBucket->addTask(tr, new_task);
@@ -112,7 +112,7 @@ struct SayHelloTaskFunc : TaskFuncBase {
 		return Void();
 	}
 };
-StringRef SayHelloTaskFunc::name = LiteralStringRef("SayHello");
+StringRef SayHelloTaskFunc::name = "SayHello"_sr;
 REGISTER_TASKFUNC(SayHelloTaskFunc);
 
 struct SayHelloToEveryoneTaskFunc : TaskFuncBase {
@@ -141,15 +141,15 @@ struct SayHelloToEveryoneTaskFunc : TaskFuncBase {
 		state std::vector<Reference<TaskFuture>> vectorFuture;
 
 		int subtaskCount = 1;
-		if (!task->params[LiteralStringRef("chained")].compare(LiteralStringRef("false"))) {
-			subtaskCount = atoi(task->params[LiteralStringRef("subtaskCount")].toString().c_str());
+		if (!task->params["chained"_sr].compare("false"_sr)) {
+			subtaskCount = atoi(task->params["subtaskCount"_sr].toString().c_str());
 		}
 		for (int i = 0; i < subtaskCount; ++i) {
 			auto new_task = makeReference<Task>(
 			    SayHelloTaskFunc::name, SayHelloTaskFunc::version, StringRef(), deterministicRandom()->randomInt(0, 2));
-			new_task->params[LiteralStringRef("name")] = StringRef(format("task_%d", i));
-			new_task->params[LiteralStringRef("chained")] = task->params[LiteralStringRef("chained")];
-			new_task->params[LiteralStringRef("subtaskCount")] = task->params[LiteralStringRef("subtaskCount")];
+			new_task->params["name"_sr] = StringRef(format("task_%d", i));
+			new_task->params["chained"_sr] = task->params["chained"_sr];
+			new_task->params["subtaskCount"_sr] = task->params["subtaskCount"_sr];
 			Reference<TaskFuture> taskDone = futureBucket->future(tr);
 			new_task->params[Task::reservedTaskParamKeyDone] = taskDone->key;
 			taskBucket->addTask(tr, new_task);
@@ -160,14 +160,14 @@ struct SayHelloToEveryoneTaskFunc : TaskFuncBase {
 		wait(taskBucket->finish(tr, task));
 
 		Key key = StringRef("Hello_" + deterministicRandom()->randomUniqueID().toString());
-		Value value = LiteralStringRef("Hello, Everyone!");
+		Value value = "Hello, Everyone!"_sr;
 		TraceEvent("TaskBucketCorrectnessSayHello").detail("SayHelloToEveryoneTaskFunc", printable(value));
 		tr->set(key, value);
 
 		return Void();
 	}
 };
-StringRef SayHelloToEveryoneTaskFunc::name = LiteralStringRef("SayHelloToEveryone");
+StringRef SayHelloToEveryoneTaskFunc::name = "SayHelloToEveryone"_sr;
 REGISTER_TASKFUNC(SayHelloToEveryoneTaskFunc);
 
 struct SaidHelloTaskFunc : TaskFuncBase {
@@ -195,14 +195,14 @@ struct SaidHelloTaskFunc : TaskFuncBase {
 		wait(taskBucket->finish(tr, task));
 
 		Key key = StringRef("Hello_" + deterministicRandom()->randomUniqueID().toString());
-		Value value = LiteralStringRef("Said hello to everyone!");
+		Value value = "Said hello to everyone!"_sr;
 		TraceEvent("TaskBucketCorrectnessSayHello").detail("SaidHelloTaskFunc", printable(value));
 		tr->set(key, value);
 
 		return Void();
 	}
 };
-StringRef SaidHelloTaskFunc::name = LiteralStringRef("SaidHello");
+StringRef SaidHelloTaskFunc::name = "SaidHello"_sr;
 REGISTER_TASKFUNC(SaidHelloTaskFunc);
 
 // A workload which test the correctness of TaskBucket
@@ -211,8 +211,8 @@ struct TaskBucketCorrectnessWorkload : TestWorkload {
 	int subtaskCount;
 
 	TaskBucketCorrectnessWorkload(WorkloadContext const& wcx) : TestWorkload(wcx) {
-		chained = getOption(options, LiteralStringRef("chained"), false);
-		subtaskCount = getOption(options, LiteralStringRef("subtaskCount"), 20);
+		chained = getOption(options, "chained"_sr, false);
+		subtaskCount = getOption(options, "subtaskCount"_sr, 20);
 	}
 
 	std::string description() const override { return "TaskBucketCorrectness"; }
@@ -228,11 +228,11 @@ struct TaskBucketCorrectnessWorkload : TestWorkload {
 	                                Reference<FutureBucket> futureBucket,
 	                                bool chained,
 	                                int subtaskCount) {
-		state Key addedInitKey(LiteralStringRef("addedInitTasks"));
+		state Key addedInitKey("addedInitTasks"_sr);
 		Optional<Standalone<StringRef>> res = wait(tr->get(addedInitKey));
 		if (res.present())
 			return Void();
-		tr->set(addedInitKey, LiteralStringRef("true"));
+		tr->set(addedInitKey, "true"_sr);
 
 		Reference<TaskFuture> allDone = futureBucket->future(tr);
 		auto task = makeReference<Task>(SayHelloToEveryoneTaskFunc::name,
@@ -240,8 +240,8 @@ struct TaskBucketCorrectnessWorkload : TestWorkload {
 		                                allDone->key,
 		                                deterministicRandom()->randomInt(0, 2));
 
-		task->params[LiteralStringRef("chained")] = chained ? LiteralStringRef("true") : LiteralStringRef("false");
-		task->params[LiteralStringRef("subtaskCount")] = StringRef(format("%d", subtaskCount));
+		task->params["chained"_sr] = chained ? "true"_sr : "false"_sr;
+		task->params["subtaskCount"_sr] = StringRef(format("%d", subtaskCount));
 		taskBucket->addTask(tr, task);
 		auto taskDone = makeReference<Task>(
 		    SaidHelloTaskFunc::name, SaidHelloTaskFunc::version, StringRef(), deterministicRandom()->randomInt(0, 2));
@@ -251,9 +251,9 @@ struct TaskBucketCorrectnessWorkload : TestWorkload {
 
 	ACTOR Future<Void> _start(Database cx, TaskBucketCorrectnessWorkload* self) {
 		state Reference<ReadYourWritesTransaction> tr(new ReadYourWritesTransaction(cx));
-		state Subspace taskSubspace(LiteralStringRef("backup-agent"));
-		state Reference<TaskBucket> taskBucket(new TaskBucket(taskSubspace.get(LiteralStringRef("tasks"))));
-		state Reference<FutureBucket> futureBucket(new FutureBucket(taskSubspace.get(LiteralStringRef("futures"))));
+		state Subspace taskSubspace("backup-agent"_sr);
+		state Reference<TaskBucket> taskBucket(new TaskBucket(taskSubspace.get("tasks"_sr)));
+		state Reference<FutureBucket> futureBucket(new FutureBucket(taskSubspace.get("futures"_sr)));
 
 		try {
 			if (self->clientId == 0) {
@@ -319,8 +319,7 @@ struct TaskBucketCorrectnessWorkload : TestWorkload {
 			data.insert(format("task_%d", i));
 		}
 
-		RangeResult values = wait(tr->getRange(
-		    KeyRangeRef(LiteralStringRef("Hello_\x00"), LiteralStringRef("Hello_\xff")), CLIENT_KNOBS->TOO_MANY));
+		RangeResult values = wait(tr->getRange(KeyRangeRef("Hello_\x00"_sr, "Hello_\xff"_sr), CLIENT_KNOBS->TOO_MANY));
 		if (values.size() != data.size()) {
 			TraceEvent(SevError, "CheckSayHello")
 			    .detail("CountNotMatchIs", values.size())
@@ -355,56 +354,56 @@ TEST_CASE("/fdbclient/TaskBucket/Subspace") {
 	print_subspace_key(subspace_test, 0);
 	ASSERT(subspace_test.key().toString() == "");
 
-	Subspace subspace_test1(LiteralStringRef("abc"));
+	Subspace subspace_test1("abc"_sr);
 	print_subspace_key(subspace_test1, 1);
-	ASSERT(subspace_test1.key() == LiteralStringRef("abc"));
+	ASSERT(subspace_test1.key() == "abc"_sr);
 
 	Tuple t;
-	t.append(LiteralStringRef("user"));
+	t.append("user"_sr);
 	Subspace subspace_test2(t);
 	print_subspace_key(subspace_test2, 2);
-	ASSERT(subspace_test2.key() == LiteralStringRef("\x01user\x00"));
+	ASSERT(subspace_test2.key() == "\x01user\x00"_sr);
 
-	Subspace subspace_test3(t, LiteralStringRef("abc"));
+	Subspace subspace_test3(t, "abc"_sr);
 	print_subspace_key(subspace_test3, 3);
-	ASSERT(subspace_test3.key() == LiteralStringRef("abc\x01user\x00"));
+	ASSERT(subspace_test3.key() == "abc\x01user\x00"_sr);
 
 	Tuple t1;
 	t1.append(1);
 	Subspace subspace_test4(t1);
 	print_subspace_key(subspace_test4, 4);
-	ASSERT(subspace_test4.key() == LiteralStringRef("\x15\x01"));
+	ASSERT(subspace_test4.key() == "\x15\x01"_sr);
 
 	t.append(123);
-	Subspace subspace_test5(t, LiteralStringRef("abc"));
+	Subspace subspace_test5(t, "abc"_sr);
 	print_subspace_key(subspace_test5, 5);
-	ASSERT(subspace_test5.key() == LiteralStringRef("abc\x01user\x00\x15\x7b"));
+	ASSERT(subspace_test5.key() == "abc\x01user\x00\x15\x7b"_sr);
 
 	// Subspace pack
 	printf("%d==========%s===%d\n", 6, printable(subspace_test5.pack(t)).c_str(), subspace_test5.pack(t).size());
-	ASSERT(subspace_test5.pack(t) == LiteralStringRef("abc\x01user\x00\x15\x7b\x01user\x00\x15\x7b"));
+	ASSERT(subspace_test5.pack(t) == "abc\x01user\x00\x15\x7b\x01user\x00\x15\x7b"_sr);
 
 	printf("%d==========%s===%d\n", 7, printable(subspace_test5.pack(t1)).c_str(), subspace_test5.pack(t1).size());
-	ASSERT(subspace_test5.pack(t1) == LiteralStringRef("abc\x01user\x00\x15\x7b\x15\x01"));
+	ASSERT(subspace_test5.pack(t1) == "abc\x01user\x00\x15\x7b\x15\x01"_sr);
 
 	// Subspace getItem
 	Subspace subspace_test6(t);
-	Subspace subspace_test7 = subspace_test6.get(LiteralStringRef("subitem"));
+	Subspace subspace_test7 = subspace_test6.get("subitem"_sr);
 	print_subspace_key(subspace_test7, 8);
-	ASSERT(subspace_test7.key() == LiteralStringRef("\x01user\x00\x15\x7b\x01subitem\x00"));
+	ASSERT(subspace_test7.key() == "\x01user\x00\x15\x7b\x01subitem\x00"_sr);
 
 	// Subspace unpack
 	Tuple t2 = subspace_test6.unpack(subspace_test7.key());
 	Subspace subspace_test8(t2);
 	print_subspace_key(subspace_test8, 9);
-	ASSERT(subspace_test8.key() == LiteralStringRef("\x01subitem\x00"));
+	ASSERT(subspace_test8.key() == "\x01subitem\x00"_sr);
 
 	// pack
 	Tuple t3;
 	t3.append(StringRef());
 	printf("%d==========%s===%d\n", 10, printable(subspace_test5.pack(t3)).c_str(), subspace_test5.pack(t3).size());
 	ASSERT(subspace_test5.pack(t3) == subspace_test5.pack(StringRef()));
-	ASSERT(subspace_test5.pack(t3) == LiteralStringRef("abc\x01user\x00\x15\x7b\x01\x00"));
+	ASSERT(subspace_test5.pack(t3) == "abc\x01user\x00\x15\x7b\x01\x00"_sr);
 
 	printf("%d==========%s===%d\n",
 	       11,
@@ -417,8 +416,8 @@ TEST_CASE("/fdbclient/TaskBucket/Subspace") {
 	       subspace_test5.range(t3).end.size());
 	ASSERT(subspace_test5.range(t3).end == subspace_test5.get(StringRef()).range().end);
 
-	StringRef def = LiteralStringRef("def");
-	StringRef ghi = LiteralStringRef("ghi");
+	StringRef def = "def"_sr;
+	StringRef ghi = "ghi"_sr;
 	t3.append(def);
 	t3.append(ghi);
 	printf("%d==========%s===%d\n", 13, printable(subspace_test5.pack(t3)).c_str(), subspace_test5.pack(t3).size());

--- a/fdbserver/workloads/ThreadSafety.actor.cpp
+++ b/fdbserver/workloads/ThreadSafety.actor.cpp
@@ -123,9 +123,9 @@ struct ThreadSafetyWorkload : TestWorkload {
 
 	ThreadSafetyWorkload(WorkloadContext const& wcx) : TestWorkload(wcx), tr(nullptr), stopped(false) {
 
-		threadsPerClient = getOption(options, LiteralStringRef("threadsPerClient"), 3);
-		threadDuration = getOption(options, LiteralStringRef("threadDuration"), 60.0);
-		numKeys = getOption(options, LiteralStringRef("numKeys"), 100);
+		threadsPerClient = getOption(options, "threadsPerClient"_sr, 3);
+		threadDuration = getOption(options, "threadDuration"_sr, 60.0);
+		numKeys = getOption(options, "numKeys"_sr, 100);
 
 		commitBarrier.setNumRequired(threadsPerClient);
 

--- a/fdbserver/workloads/Throttling.actor.cpp
+++ b/fdbserver/workloads/Throttling.actor.cpp
@@ -83,12 +83,12 @@ struct ThrottlingWorkload : KVWorkload {
 	static constexpr const char* NAME = "Throttling";
 
 	ThrottlingWorkload(WorkloadContext const& wcx) : KVWorkload(wcx), transactionsCommitted(0) {
-		testDuration = getOption(options, LiteralStringRef("testDuration"), 60.0);
-		actorsPerClient = getOption(options, LiteralStringRef("actorsPerClient"), 10);
-		writesPerTransaction = getOption(options, LiteralStringRef("writesPerTransaction"), 10);
-		readsPerTransaction = getOption(options, LiteralStringRef("readsPerTransaction"), 10);
-		throttlingMultiplier = getOption(options, LiteralStringRef("throttlingMultiplier"), 0.5);
-		int maxBurst = getOption(options, LiteralStringRef("maxBurst"), 1000);
+		testDuration = getOption(options, "testDuration"_sr, 60.0);
+		actorsPerClient = getOption(options, "actorsPerClient"_sr, 10);
+		writesPerTransaction = getOption(options, "writesPerTransaction"_sr, 10);
+		readsPerTransaction = getOption(options, "readsPerTransaction"_sr, 10);
+		throttlingMultiplier = getOption(options, "throttlingMultiplier"_sr, 0.5);
+		int maxBurst = getOption(options, "maxBurst"_sr, 1000);
 		tokenBucket.maxBurst = maxBurst;
 	}
 
@@ -131,13 +131,13 @@ struct ThrottlingWorkload : KVWorkload {
 		state json_spirit::mValue logSchema = readJSONStrictly(JSONSchemas::logHealthSchema.toString()).get_obj();
 		loop {
 			try {
-				RangeResult result = wait(
-				    tr.getRange(prefixRange(LiteralStringRef("\xff\xff/metrics/health/")), CLIENT_KNOBS->TOO_MANY));
+				RangeResult result =
+				    wait(tr.getRange(prefixRange("\xff\xff/metrics/health/"_sr), CLIENT_KNOBS->TOO_MANY));
 				ASSERT(!result.more);
 				for (const auto& [k, v] : result) {
-					ASSERT(k.startsWith(LiteralStringRef("\xff\xff/metrics/health/")));
+					ASSERT(k.startsWith("\xff\xff/metrics/health/"_sr));
 					auto valueObj = readJSONStrictly(v.toString()).get_obj();
-					if (k.removePrefix(LiteralStringRef("\xff\xff/metrics/health/")) == LiteralStringRef("aggregate")) {
+					if (k.removePrefix("\xff\xff/metrics/health/"_sr) == "aggregate"_sr) {
 						TEST(true); // Test aggregate health metrics schema
 						std::string errorStr;
 						if (!schemaMatch(aggregateSchema, valueObj, errorStr, SevError, true)) {
@@ -148,10 +148,9 @@ struct ThrottlingWorkload : KVWorkload {
 						}
 						auto tpsLimit = valueObj.at("tps_limit").get_real();
 						self->tokenBucket.transactionRate = tpsLimit * self->throttlingMultiplier / self->clientCount;
-					} else if (k.removePrefix(LiteralStringRef("\xff\xff/metrics/health/"))
-					               .startsWith(LiteralStringRef("storage/"))) {
+					} else if (k.removePrefix("\xff\xff/metrics/health/"_sr).startsWith("storage/"_sr)) {
 						TEST(true); // Test storage health metrics schema
-						UID::fromString(k.removePrefix(LiteralStringRef("\xff\xff/metrics/health/storage/"))
+						UID::fromString(k.removePrefix("\xff\xff/metrics/health/storage/"_sr)
 						                    .toString()); // Will throw if it's not a valid uid
 						std::string errorStr;
 						if (!schemaMatch(storageSchema, valueObj, errorStr, SevError, true)) {
@@ -160,10 +159,9 @@ struct ThrottlingWorkload : KVWorkload {
 							    .detail("JSON", json_spirit::write_string(json_spirit::mValue(v.toString())));
 							self->correctSpecialKeys = false;
 						}
-					} else if (k.removePrefix(LiteralStringRef("\xff\xff/metrics/health/"))
-					               .startsWith(LiteralStringRef("log/"))) {
+					} else if (k.removePrefix("\xff\xff/metrics/health/"_sr).startsWith("log/"_sr)) {
 						TEST(true); // Test log health metrics schema
-						UID::fromString(k.removePrefix(LiteralStringRef("\xff\xff/metrics/health/log/"))
+						UID::fromString(k.removePrefix("\xff\xff/metrics/health/log/"_sr)
 						                    .toString()); // Will throw if it's not a valid uid
 						std::string errorStr;
 						if (!schemaMatch(logSchema, valueObj, errorStr, SevError, true)) {

--- a/fdbserver/workloads/Throughput.actor.cpp
+++ b/fdbserver/workloads/Throughput.actor.cpp
@@ -310,55 +310,51 @@ struct ThroughputWorkload : TestWorkload {
 		auto multi = makeReference<MeasureMulti>();
 		measurer = multi;
 
-		targetLatency = getOption(options, LiteralStringRef("targetLatency"), 0.05);
+		targetLatency = getOption(options, "targetLatency"_sr, 0.05);
 
-		int keyCount = getOption(options, LiteralStringRef("nodeCount"), (uint64_t)100000);
-		int keyBytes = std::max(getOption(options, LiteralStringRef("keyBytes"), 16), 16);
-		int maxValueBytes = getOption(options, LiteralStringRef("valueBytes"), 100);
-		int minValueBytes = getOption(options, LiteralStringRef("minValueBytes"), maxValueBytes);
-		double sweepDuration = getOption(options, LiteralStringRef("sweepDuration"), 0);
-		double sweepDelay = getOption(options, LiteralStringRef("sweepDelay"), 0);
+		int keyCount = getOption(options, "nodeCount"_sr, (uint64_t)100000);
+		int keyBytes = std::max(getOption(options, "keyBytes"_sr, 16), 16);
+		int maxValueBytes = getOption(options, "valueBytes"_sr, 100);
+		int minValueBytes = getOption(options, "minValueBytes"_sr, maxValueBytes);
+		double sweepDuration = getOption(options, "sweepDuration"_sr, 0);
+		double sweepDelay = getOption(options, "sweepDelay"_sr, 0);
 
-		auto AType =
-		    Reference<ITransactor>(new RWTransactor(getOption(options, LiteralStringRef("readsPerTransactionA"), 10),
-		                                            getOption(options, LiteralStringRef("writesPerTransactionA"), 0),
-		                                            keyCount,
-		                                            keyBytes,
-		                                            minValueBytes,
-		                                            maxValueBytes));
-		auto BType =
-		    Reference<ITransactor>(new RWTransactor(getOption(options, LiteralStringRef("readsPerTransactionB"), 5),
-		                                            getOption(options, LiteralStringRef("writesPerTransactionB"), 5),
-		                                            keyCount,
-		                                            keyBytes,
-		                                            minValueBytes,
-		                                            maxValueBytes));
+		auto AType = Reference<ITransactor>(new RWTransactor(getOption(options, "readsPerTransactionA"_sr, 10),
+		                                                     getOption(options, "writesPerTransactionA"_sr, 0),
+		                                                     keyCount,
+		                                                     keyBytes,
+		                                                     minValueBytes,
+		                                                     maxValueBytes));
+		auto BType = Reference<ITransactor>(new RWTransactor(getOption(options, "readsPerTransactionB"_sr, 5),
+		                                                     getOption(options, "writesPerTransactionB"_sr, 5),
+		                                                     keyCount,
+		                                                     keyBytes,
+		                                                     minValueBytes,
+		                                                     maxValueBytes));
 
 		if (sweepDuration > 0) {
 			op = Reference<ITransactor>(new SweepTransactor(sweepDuration, sweepDelay, AType, BType));
 		} else {
-			op = Reference<ITransactor>(
-			    new ABTransactor(getOption(options, LiteralStringRef("alpha"), 0.1), AType, BType));
+			op = Reference<ITransactor>(new ABTransactor(getOption(options, "alpha"_sr, 0.1), AType, BType));
 		}
 
-		double measureDelay = getOption(options, LiteralStringRef("measureDelay"), 50.0);
-		double measureDuration = getOption(options, LiteralStringRef("measureDuration"), 10.0);
+		double measureDelay = getOption(options, "measureDelay"_sr, 50.0);
+		double measureDuration = getOption(options, "measureDuration"_sr, 10.0);
 		multi->ms.push_back(Reference<IMeasurer>(new MeasureSinglePeriod(measureDelay, measureDuration)));
 
-		double measurePeriod = getOption(options, LiteralStringRef("measurePeriod"), 0.0);
-		vector<std::string> periodicMetrics =
-		    getOption(options, LiteralStringRef("measurePeriodicMetrics"), vector<std::string>());
+		double measurePeriod = getOption(options, "measurePeriod"_sr, 0.0);
+		vector<std::string> periodicMetrics = getOption(options, "measurePeriodicMetrics"_sr, vector<std::string>());
 		if (measurePeriod) {
 			ASSERT(periodicMetrics.size() != 0);
 			multi->ms.push_back(Reference<IMeasurer>(new MeasurePeriodically(
 			    measurePeriod, std::set<std::string>(periodicMetrics.begin(), periodicMetrics.end()))));
 		}
 
-		Pgain = getOption(options, LiteralStringRef("ProportionalGain"), 0.1);
-		Igain = getOption(options, LiteralStringRef("IntegralGain"), 0.005);
+		Pgain = getOption(options, "ProportionalGain"_sr, 0.1);
+		Igain = getOption(options, "IntegralGain"_sr, 0.005);
 
 		testDuration = measureDelay + measureDuration;
-		// testDuration = getOption( options, LiteralStringRef("testDuration"), measureDelay + measureDuration );
+		// testDuration = getOption( options, "testDuration"_sr, measureDelay + measureDuration );
 	}
 
 	std::string description() const override { return "Throughput"; }

--- a/fdbserver/workloads/TimeKeeperCorrectness.actor.cpp
+++ b/fdbserver/workloads/TimeKeeperCorrectness.actor.cpp
@@ -29,7 +29,7 @@ struct TimeKeeperCorrectnessWorkload : TestWorkload {
 	std::map<int64_t, Version> inMemTimeKeeper;
 
 	TimeKeeperCorrectnessWorkload(WorkloadContext const& wcx) : TestWorkload(wcx) {
-		testDuration = getOption(options, LiteralStringRef("testDuration"), 20.0);
+		testDuration = getOption(options, "testDuration"_sr, 20.0);
 	}
 
 	std::string description() const override { return "TimeKeeperCorrectness"; }

--- a/fdbserver/workloads/TriggerRecovery.actor.cpp
+++ b/fdbserver/workloads/TriggerRecovery.actor.cpp
@@ -15,10 +15,10 @@ struct TriggerRecoveryLoopWorkload : TestWorkload {
 	Optional<int32_t> currentNumOfResolvers;
 
 	TriggerRecoveryLoopWorkload(WorkloadContext const& wcx) : TestWorkload(wcx) {
-		startTime = getOption(options, LiteralStringRef("startTime"), 0.0);
-		numRecoveries = getOption(options, LiteralStringRef("numRecoveries"), deterministicRandom()->randomInt(1, 10));
-		delayBetweenRecoveries = getOption(options, LiteralStringRef("delayBetweenRecoveries"), 0.0);
-		killAllProportion = getOption(options, LiteralStringRef("killAllProportion"), 0.1);
+		startTime = getOption(options, "startTime"_sr, 0.0);
+		numRecoveries = getOption(options, "numRecoveries"_sr, deterministicRandom()->randomInt(1, 10));
+		delayBetweenRecoveries = getOption(options, "delayBetweenRecoveries"_sr, 0.0);
+		killAllProportion = getOption(options, "killAllProportion"_sr, 0.1);
 		ASSERT((numRecoveries > 0) && (startTime >= 0) && (delayBetweenRecoveries >= 0));
 		TraceEvent(SevInfo, "TriggerRecoveryLoopSetup")
 		    .detail("StartTime", startTime)
@@ -92,16 +92,14 @@ struct TriggerRecoveryLoopWorkload : TestWorkload {
 			try {
 				tr.setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
 				tr.setOption(FDBTransactionOptions::LOCK_AWARE);
-				RangeResult kvs = wait(tr.getRange(KeyRangeRef(LiteralStringRef("\xff\xff/worker_interfaces/"),
-				                                               LiteralStringRef("\xff\xff/worker_interfaces0")),
-				                                   CLIENT_KNOBS->TOO_MANY));
+				RangeResult kvs =
+				    wait(tr.getRange(KeyRangeRef("\xff\xff/worker_interfaces/"_sr, "\xff\xff/worker_interfaces0"_sr),
+				                     CLIENT_KNOBS->TOO_MANY));
 				ASSERT(!kvs.more);
 				std::map<Key, Value> address_interface;
 				for (auto it : kvs) {
-					auto ip_port =
-					    (it.key.endsWith(LiteralStringRef(":tls")) ? it.key.removeSuffix(LiteralStringRef(":tls"))
-					                                               : it.key)
-					        .removePrefix(LiteralStringRef("\xff\xff/worker_interfaces/"));
+					auto ip_port = (it.key.endsWith(":tls"_sr) ? it.key.removeSuffix(":tls"_sr) : it.key)
+					                   .removePrefix("\xff\xff/worker_interfaces/"_sr);
 					address_interface[ip_port] = it.value;
 				}
 				for (auto it : address_interface) {
@@ -109,7 +107,7 @@ struct TriggerRecoveryLoopWorkload : TestWorkload {
 						BinaryReader::fromStringRef<ClientWorkerInterface>(it.second, IncludeVersion())
 						    .reboot.send(RebootRequest());
 					else
-						tr.set(LiteralStringRef("\xff\xff/reboot_worker"), it.second);
+						tr.set("\xff\xff/reboot_worker"_sr, it.second);
 				}
 				TraceEvent(SevInfo, "TriggerRecoveryLoop_AttempedKillAll");
 				return Void();

--- a/fdbserver/workloads/Unreadable.actor.cpp
+++ b/fdbserver/workloads/Unreadable.actor.cpp
@@ -32,8 +32,8 @@ struct UnreadableWorkload : TestWorkload {
 	vector<Future<Void>> clients;
 
 	UnreadableWorkload(WorkloadContext const& wcx) : TestWorkload(wcx) {
-		testDuration = getOption(options, LiteralStringRef("testDuration"), 600.0);
-		nodeCount = getOption(options, LiteralStringRef("nodeCount"), (uint64_t)100000);
+		testDuration = getOption(options, "testDuration"_sr, 600.0);
+		nodeCount = getOption(options, "nodeCount"_sr, (uint64_t)100000);
 	}
 
 	std::string description() const override { return "Unreadable"; }

--- a/fdbserver/workloads/VersionStamp.actor.cpp
+++ b/fdbserver/workloads/VersionStamp.actor.cpp
@@ -43,16 +43,16 @@ struct VersionStampWorkload : TestWorkload {
 	bool soleOwnerOfMetadataVersionKey;
 
 	VersionStampWorkload(WorkloadContext const& wcx) : TestWorkload(wcx) {
-		testDuration = getOption(options, LiteralStringRef("testDuration"), 60.0);
-		transactionsPerSecond = getOption(options, LiteralStringRef("transactionsPerSecond"), 5000.0);
-		nodeCount = getOption(options, LiteralStringRef("nodeCount"), (uint64_t)10000);
-		keyBytes = std::max(getOption(options, LiteralStringRef("keyBytes"), 16), 4);
-		failIfDataLost = getOption(options, LiteralStringRef("failIfDataLost"), true);
-		const Key prefix = getOption(options, LiteralStringRef("prefix"), LiteralStringRef("VS_"));
-		vsKeyPrefix = LiteralStringRef("K_").withPrefix(prefix);
-		vsValuePrefix = LiteralStringRef("V_").withPrefix(prefix);
-		validateExtraDB = getOption(options, LiteralStringRef("validateExtraDB"), false);
-		soleOwnerOfMetadataVersionKey = getOption(options, LiteralStringRef("soleOwnerOfMetadataVersionKey"), false);
+		testDuration = getOption(options, "testDuration"_sr, 60.0);
+		transactionsPerSecond = getOption(options, "transactionsPerSecond"_sr, 5000.0);
+		nodeCount = getOption(options, "nodeCount"_sr, (uint64_t)10000);
+		keyBytes = std::max(getOption(options, "keyBytes"_sr, 16), 4);
+		failIfDataLost = getOption(options, "failIfDataLost"_sr, true);
+		const Key prefix = getOption(options, "prefix"_sr, "VS_"_sr);
+		vsKeyPrefix = "K_"_sr.withPrefix(prefix);
+		vsValuePrefix = "V_"_sr.withPrefix(prefix);
+		validateExtraDB = getOption(options, "validateExtraDB"_sr, false);
+		soleOwnerOfMetadataVersionKey = getOption(options, "soleOwnerOfMetadataVersionKey"_sr, false);
 	}
 
 	std::string description() const override { return "VersionStamp"; }
@@ -337,7 +337,7 @@ struct VersionStampWorkload : TestWorkload {
 			} else if (oldVSFormat) {
 				versionStampValue = value;
 			} else {
-				versionStampValue = value.withSuffix(LiteralStringRef("\x00\x00\x00\x00"));
+				versionStampValue = value.withSuffix("\x00\x00\x00\x00"_sr);
 			}
 
 			state bool ryw = deterministicRandom()->coinflip();

--- a/fdbserver/workloads/WatchAndWait.actor.cpp
+++ b/fdbserver/workloads/WatchAndWait.actor.cpp
@@ -36,12 +36,12 @@ struct WatchAndWaitWorkload : TestWorkload {
 	PerfIntCounter triggers, retries;
 
 	WatchAndWaitWorkload(WorkloadContext const& wcx) : TestWorkload(wcx), triggers("Triggers"), retries("Retries") {
-		testDuration = getOption(options, LiteralStringRef("testDuration"), 600.0);
-		watchCount = getOption(options, LiteralStringRef("watchCount"), (uint64_t)10000);
-		nodeCount = getOption(options, LiteralStringRef("nodeCount"), (uint64_t)100000);
-		nodePrefix = getOption(options, LiteralStringRef("nodePrefix"), (int64_t)-1);
-		keyBytes = std::max(getOption(options, LiteralStringRef("keyBytes"), 16), 4);
-		triggerWatches = getOption(options, LiteralStringRef("triggerWatches"), false);
+		testDuration = getOption(options, "testDuration"_sr, 600.0);
+		watchCount = getOption(options, "watchCount"_sr, (uint64_t)10000);
+		nodeCount = getOption(options, "nodeCount"_sr, (uint64_t)100000);
+		nodePrefix = getOption(options, "nodePrefix"_sr, (int64_t)-1);
+		keyBytes = std::max(getOption(options, "keyBytes"_sr, 16), 4);
+		triggerWatches = getOption(options, "triggerWatches"_sr, false);
 
 		if (watchCount > nodeCount) {
 			watchCount = nodeCount;

--- a/fdbserver/workloads/Watches.actor.cpp
+++ b/fdbserver/workloads/Watches.actor.cpp
@@ -36,10 +36,10 @@ struct WatchesWorkload : TestWorkload {
 	std::vector<int> nodeOrder;
 
 	WatchesWorkload(WorkloadContext const& wcx) : TestWorkload(wcx), cycles("Cycles"), cycleLatencies(sampleSize) {
-		testDuration = getOption(options, LiteralStringRef("testDuration"), 600.0);
-		nodes = getOption(options, LiteralStringRef("nodeCount"), 100);
-		extraPerNode = getOption(options, LiteralStringRef("extraPerNode"), 1000);
-		keyBytes = std::max(getOption(options, LiteralStringRef("keyBytes"), 16), 16);
+		testDuration = getOption(options, "testDuration"_sr, 600.0);
+		nodes = getOption(options, "nodeCount"_sr, 100);
+		extraPerNode = getOption(options, "extraPerNode"_sr, 1000);
+		keyBytes = std::max(getOption(options, "keyBytes"_sr, 16), 16);
 
 		for (int i = 0; i < nodes + 1; i++)
 			nodeOrder.push_back(i);

--- a/fdbserver/workloads/WatchesSameKeyCorrectness.actor.cpp
+++ b/fdbserver/workloads/WatchesSameKeyCorrectness.actor.cpp
@@ -31,17 +31,17 @@ struct WatchesSameKeyWorkload : TestWorkload {
 	std::vector<Future<Void>> cases;
 
 	WatchesSameKeyWorkload(WorkloadContext const& wcx) : TestWorkload(wcx) {
-		numWatches = getOption(options, LiteralStringRef("numWatches"), 3);
+		numWatches = getOption(options, "numWatches"_sr, 3);
 	}
 
 	std::string description() const override { return "WatchesSameKeyCorrectness"; }
 
 	Future<Void> setup(Database const& cx) override {
-		cases.push_back(case1(cx, LiteralStringRef("foo1"), this));
-		cases.push_back(case2(cx, LiteralStringRef("foo2"), this));
-		cases.push_back(case3(cx, LiteralStringRef("foo3"), this));
-		cases.push_back(case4(cx, LiteralStringRef("foo4"), this));
-		cases.push_back(case5(cx, LiteralStringRef("foo5"), this));
+		cases.push_back(case1(cx, "foo1"_sr, this));
+		cases.push_back(case2(cx, "foo2"_sr, this));
+		cases.push_back(case3(cx, "foo3"_sr, this));
+		cases.push_back(case4(cx, "foo4"_sr, this));
+		cases.push_back(case5(cx, "foo5"_sr, this));
 		return Void();
 	}
 

--- a/fdbserver/workloads/WriteBandwidth.actor.cpp
+++ b/fdbserver/workloads/WriteBandwidth.actor.cpp
@@ -40,12 +40,12 @@ struct WriteBandwidthWorkload : KVWorkload {
 	WriteBandwidthWorkload(WorkloadContext const& wcx)
 	  : KVWorkload(wcx), commitLatencies(2000), GRVLatencies(2000), loadTime(0.0), transactions("Transactions"),
 	    retries("Retries") {
-		testDuration = getOption(options, LiteralStringRef("testDuration"), 10.0);
-		keysPerTransaction = getOption(options, LiteralStringRef("keysPerTransaction"), 100);
+		testDuration = getOption(options, "testDuration"_sr, 10.0);
+		keysPerTransaction = getOption(options, "keysPerTransaction"_sr, 100);
 		valueString = std::string(maxValueBytes, '.');
 
-		warmingDelay = getOption(options, LiteralStringRef("warmingDelay"), 0.0);
-		maxInsertRate = getOption(options, LiteralStringRef("maxInsertRate"), 1e12);
+		warmingDelay = getOption(options, "warmingDelay"_sr, 0.0);
+		maxInsertRate = getOption(options, "maxInsertRate"_sr, 1e12);
 	}
 
 	std::string description() const override { return "WriteBandwidth"; }

--- a/fdbserver/workloads/WriteDuringRead.actor.cpp
+++ b/fdbserver/workloads/WriteDuringRead.actor.cpp
@@ -51,13 +51,13 @@ struct WriteDuringReadWorkload : TestWorkload {
 
 	WriteDuringReadWorkload(WorkloadContext const& wcx)
 	  : TestWorkload(wcx), transactions("Transactions"), retries("Retries"), success(true) {
-		testDuration = getOption(options, LiteralStringRef("testDuration"), 60.0);
-		slowModeStart = getOption(options, LiteralStringRef("slowModeStart"), 1000.0);
-		numOps = getOption(options, LiteralStringRef("numOps"), 21);
-		rarelyCommit = getOption(options, LiteralStringRef("rarelyCommit"), false);
-		maximumTotalData = getOption(options, LiteralStringRef("maximumTotalData"), 3e6);
-		minNode = getOption(options, LiteralStringRef("minNode"), 0);
-		useSystemKeys = getOption(options, LiteralStringRef("useSystemKeys"), deterministicRandom()->random01() < 0.5);
+		testDuration = getOption(options, "testDuration"_sr, 60.0);
+		slowModeStart = getOption(options, "slowModeStart"_sr, 1000.0);
+		numOps = getOption(options, "numOps"_sr, 21);
+		rarelyCommit = getOption(options, "rarelyCommit"_sr, false);
+		maximumTotalData = getOption(options, "maximumTotalData"_sr, 3e6);
+		minNode = getOption(options, "minNode"_sr, 0);
+		useSystemKeys = getOption(options, "useSystemKeys"_sr, deterministicRandom()->random01() < 0.5);
 		adjacentKeys = deterministicRandom()->random01() < 0.5;
 		initialKeyDensity = deterministicRandom()->random01(); // This fraction of keys are present before the first
 		                                                       // transaction (and after an unknown result)
@@ -93,7 +93,7 @@ struct WriteDuringReadWorkload : TestWorkload {
 		}
 
 		maxClearSize = 1 << deterministicRandom()->randomInt(0, 20);
-		conflictRange = KeyRangeRef(LiteralStringRef("\xfe"), LiteralStringRef("\xfe\x00"));
+		conflictRange = KeyRangeRef("\xfe"_sr, "\xfe\x00"_sr);
 		if (clientId == 0)
 			TraceEvent("RYWConfiguration")
 			    .detail("Nodes", nodes)

--- a/fdbserver/workloads/WriteTagThrottling.actor.cpp
+++ b/fdbserver/workloads/WriteTagThrottling.actor.cpp
@@ -66,23 +66,23 @@ struct WriteTagThrottlingWorkload : KVWorkload {
 	WriteTagThrottlingWorkload(WorkloadContext const& wcx)
 	  : KVWorkload(wcx), badActorCommitLatency(SAMPLE_SIZE), badActorReadLatency(SAMPLE_SIZE),
 	    goodActorCommitLatency(SAMPLE_SIZE), goodActorReadLatency(SAMPLE_SIZE) {
-		testDuration = getOption(options, LiteralStringRef("testDuration"), 120.0);
-		badOpRate = getOption(options, LiteralStringRef("badOpRate"), 0.9);
-		numWritePerTr = getOption(options, LiteralStringRef("numWritePerTr"), 1);
-		numReadPerTr = getOption(options, LiteralStringRef("numReadPerTr"), 1);
-		numClearPerTr = getOption(options, LiteralStringRef("numClearPerTr"), 1);
-		hotRangeRate = getOption(options, LiteralStringRef("hotRangeRate"), 0.1);
-		populateData = getOption(options, LiteralStringRef("populateData"), true);
+		testDuration = getOption(options, "testDuration"_sr, 120.0);
+		badOpRate = getOption(options, "badOpRate"_sr, 0.9);
+		numWritePerTr = getOption(options, "numWritePerTr"_sr, 1);
+		numReadPerTr = getOption(options, "numReadPerTr"_sr, 1);
+		numClearPerTr = getOption(options, "numClearPerTr"_sr, 1);
+		hotRangeRate = getOption(options, "hotRangeRate"_sr, 0.1);
+		populateData = getOption(options, "populateData"_sr, true);
 
-		writeThrottle = getOption(options, LiteralStringRef("writeThrottle"), false);
-		badActorPerClient = getOption(options, LiteralStringRef("badActorPerClient"), 1);
-		goodActorPerClient = getOption(options, LiteralStringRef("goodActorPerClient"), 1);
+		writeThrottle = getOption(options, "writeThrottle"_sr, false);
+		badActorPerClient = getOption(options, "badActorPerClient"_sr, 1);
+		goodActorPerClient = getOption(options, "goodActorPerClient"_sr, 1);
 		actorCount = goodActorPerClient + badActorPerClient;
 
 		keyCount = getOption(options,
-		                     LiteralStringRef("keyCount"),
+		                     "keyCount"_sr,
 		                     std::max(3000, clientCount * actorCount * 3)); // enough keys to avoid too many conflicts
-		trInterval = actorCount * 1.0 / getOption(options, LiteralStringRef("trPerSecond"), 1000);
+		trInterval = actorCount * 1.0 / getOption(options, "trPerSecond"_sr, 1000);
 		if (badActorPerClient > 0) {
 			rangeEachBadActor = keyCount / (clientCount * badActorPerClient);
 		}

--- a/fdbserver/workloads/workloads.actor.h
+++ b/fdbserver/workloads/workloads.actor.h
@@ -62,7 +62,7 @@ struct TestWorkload : NonCopyable, WorkloadContext {
 
 	// Subclasses are expected to also have a constructor with this signature (to work with WorkloadFactory<>):
 	explicit TestWorkload(WorkloadContext const& wcx) : WorkloadContext(wcx) {
-		bool runSetup = getOption(options, LiteralStringRef("runSetup"), true);
+		bool runSetup = getOption(options, "runSetup"_sr, true);
 		phases = TestWorkload::EXECUTION | TestWorkload::CHECK | TestWorkload::METRICS;
 		if (runSetup)
 			phases |= TestWorkload::SETUP;
@@ -86,15 +86,15 @@ struct KVWorkload : TestWorkload {
 	double absentFrac;
 
 	explicit KVWorkload(WorkloadContext const& wcx) : TestWorkload(wcx) {
-		nodeCount = getOption(options, LiteralStringRef("nodeCount"), (uint64_t)100000);
-		nodePrefix = getOption(options, LiteralStringRef("nodePrefix"), (int64_t)-1);
-		actorCount = getOption(options, LiteralStringRef("actorCount"), 50);
-		keyBytes = std::max(getOption(options, LiteralStringRef("keyBytes"), 16), 4);
-		maxValueBytes = getOption(options, LiteralStringRef("valueBytes"), 96);
-		minValueBytes = getOption(options, LiteralStringRef("minValueBytes"), maxValueBytes);
+		nodeCount = getOption(options, "nodeCount"_sr, (uint64_t)100000);
+		nodePrefix = getOption(options, "nodePrefix"_sr, (int64_t)-1);
+		actorCount = getOption(options, "actorCount"_sr, 50);
+		keyBytes = std::max(getOption(options, "keyBytes"_sr, 16), 4);
+		maxValueBytes = getOption(options, "valueBytes"_sr, 96);
+		minValueBytes = getOption(options, "minValueBytes"_sr, maxValueBytes);
 		ASSERT(minValueBytes <= maxValueBytes);
 
-		absentFrac = getOption(options, LiteralStringRef("absentFrac"), 0.0);
+		absentFrac = getOption(options, "absentFrac"_sr, 0.0);
 	}
 	Key getRandomKey() const;
 	Key getRandomKey(double absentFrac) const;

--- a/flow/Arena.h
+++ b/flow/Arena.h
@@ -662,6 +662,8 @@ struct Traceable<Standalone<T>> : std::conditional<Traceable<T>::value, std::tru
 	static std::string toString(const Standalone<T>& value) { return Traceable<T>::toString(value); }
 };
 
+// DEPRECATED: We still need this in a few places (like macros) but the usage of this is discouraged.
+// Whenever possible use the string literal _sr instead
 #define LiteralStringRef(str) StringRef((const uint8_t*)(str), sizeof((str)) - 1)
 inline StringRef operator"" _sr(const char* str, size_t size) {
 	return StringRef(reinterpret_cast<const uint8_t*>(str), size);

--- a/flow/CompressedInt.actor.cpp
+++ b/flow/CompressedInt.actor.cpp
@@ -86,12 +86,12 @@ void testCompressedInt(IntType n, StringRef rep = StringRef()) {
 }
 
 TEST_CASE("/flow/compressed_ints") {
-	testCompressedInt<int>(-2, LiteralStringRef("\x7e"));
-	testCompressedInt<int>(-1, LiteralStringRef("\x7f"));
-	testCompressedInt<int>(0, LiteralStringRef("\x80"));
-	testCompressedInt<int>(1, LiteralStringRef("\x81"));
-	testCompressedInt<int>(2, LiteralStringRef("\x82"));
-	testCompressedInt<int64_t>(0x4000000000000000, LiteralStringRef("\xFF\xC0\x40\x00\x00\x00\x00\x00\x00\x00"));
+	testCompressedInt<int>(-2, "\x7e"_sr);
+	testCompressedInt<int>(-1, "\x7f"_sr);
+	testCompressedInt<int>(0, "\x80"_sr);
+	testCompressedInt<int>(1, "\x81"_sr);
+	testCompressedInt<int>(2, "\x82"_sr);
+	testCompressedInt<int64_t>(0x4000000000000000, "\xFF\xC0\x40\x00\x00\x00\x00\x00\x00\x00"_sr);
 
 	int64_t n = 0;
 	for (int i = 0; i < 10000000; ++i) {

--- a/flow/Histogram.cpp
+++ b/flow/Histogram.cpp
@@ -211,8 +211,7 @@ std::string Histogram::drawHistogram() {
 
 TEST_CASE("/flow/histogram/smoke_test") {
 	{
-		Reference<Histogram> h =
-		    Histogram::getHistogram(LiteralStringRef("smoke_test"), LiteralStringRef("counts"), Histogram::Unit::bytes);
+		Reference<Histogram> h = Histogram::getHistogram("smoke_test"_sr, "counts"_sr, Histogram::Unit::bytes);
 
 		h->sample(0);
 		ASSERT(h->buckets[0] == 1);
@@ -227,15 +226,13 @@ TEST_CASE("/flow/histogram/smoke_test") {
 		ASSERT(h->buckets[0] == 0);
 		h->sample(0);
 		ASSERT(h->buckets[0] == 1);
-		h = Histogram::getHistogram(
-		    LiteralStringRef("smoke_test"), LiteralStringRef("counts2"), Histogram::Unit::bytes);
+		h = Histogram::getHistogram("smoke_test"_sr, "counts2"_sr, Histogram::Unit::bytes);
 
 		// confirm that old h was deallocated.
-		h = Histogram::getHistogram(LiteralStringRef("smoke_test"), LiteralStringRef("counts"), Histogram::Unit::bytes);
+		h = Histogram::getHistogram("smoke_test"_sr, "counts"_sr, Histogram::Unit::bytes);
 		ASSERT(h->buckets[0] == 0);
 
-		h = Histogram::getHistogram(
-		    LiteralStringRef("smoke_test"), LiteralStringRef("times"), Histogram::Unit::microseconds);
+		h = Histogram::getHistogram("smoke_test"_sr, "times"_sr, Histogram::Unit::microseconds);
 
 		h->sampleSeconds(0.000000);
 		h->sampleSeconds(0.0000019);

--- a/flow/Knobs.cpp
+++ b/flow/Knobs.cpp
@@ -269,7 +269,7 @@ template <class T>
 static T parseIntegral(std::string const& value) {
 	T v;
 	int n = 0;
-	if (StringRef(value).startsWith(LiteralStringRef("0x"))) {
+	if (StringRef(value).startsWith("0x"_sr)) {
 		if (sscanf(value.c_str(), "0x%" SCNx64 "%n", &v, &n) != 1 || n != value.size())
 			throw invalid_option_value();
 	} else {

--- a/flow/Net2.actor.cpp
+++ b/flow/Net2.actor.cpp
@@ -1354,29 +1354,29 @@ ACTOR Future<Void> Net2::logTimeOffset() {
 }
 
 void Net2::initMetrics() {
-	bytesReceived.init(LiteralStringRef("Net2.BytesReceived"));
-	countWriteProbes.init(LiteralStringRef("Net2.CountWriteProbes"));
-	countReadProbes.init(LiteralStringRef("Net2.CountReadProbes"));
-	countReads.init(LiteralStringRef("Net2.CountReads"));
-	countWouldBlock.init(LiteralStringRef("Net2.CountWouldBlock"));
-	countWrites.init(LiteralStringRef("Net2.CountWrites"));
-	countRunLoop.init(LiteralStringRef("Net2.CountRunLoop"));
-	countCantSleep.init(LiteralStringRef("Net2.CountCantSleep"));
-	countWontSleep.init(LiteralStringRef("Net2.CountWontSleep"));
-	countTimers.init(LiteralStringRef("Net2.CountTimers"));
-	countTasks.init(LiteralStringRef("Net2.CountTasks"));
-	countYields.init(LiteralStringRef("Net2.CountYields"));
-	countYieldBigStack.init(LiteralStringRef("Net2.CountYieldBigStack"));
-	countYieldCalls.init(LiteralStringRef("Net2.CountYieldCalls"));
-	countASIOEvents.init(LiteralStringRef("Net2.CountASIOEvents"));
-	countYieldCallsTrue.init(LiteralStringRef("Net2.CountYieldCallsTrue"));
-	countRunLoopProfilingSignals.init(LiteralStringRef("Net2.CountRunLoopProfilingSignals"));
-	countTLSPolicyFailures.init(LiteralStringRef("Net2.CountTLSPolicyFailures"));
-	priorityMetric.init(LiteralStringRef("Net2.Priority"));
-	awakeMetric.init(LiteralStringRef("Net2.Awake"));
-	slowTaskMetric.init(LiteralStringRef("Net2.SlowTask"));
-	countLaunchTime.init(LiteralStringRef("Net2.CountLaunchTime"));
-	countReactTime.init(LiteralStringRef("Net2.CountReactTime"));
+	bytesReceived.init("Net2.BytesReceived"_sr);
+	countWriteProbes.init("Net2.CountWriteProbes"_sr);
+	countReadProbes.init("Net2.CountReadProbes"_sr);
+	countReads.init("Net2.CountReads"_sr);
+	countWouldBlock.init("Net2.CountWouldBlock"_sr);
+	countWrites.init("Net2.CountWrites"_sr);
+	countRunLoop.init("Net2.CountRunLoop"_sr);
+	countCantSleep.init("Net2.CountCantSleep"_sr);
+	countWontSleep.init("Net2.CountWontSleep"_sr);
+	countTimers.init("Net2.CountTimers"_sr);
+	countTasks.init("Net2.CountTasks"_sr);
+	countYields.init("Net2.CountYields"_sr);
+	countYieldBigStack.init("Net2.CountYieldBigStack"_sr);
+	countYieldCalls.init("Net2.CountYieldCalls"_sr);
+	countASIOEvents.init("Net2.CountASIOEvents"_sr);
+	countYieldCallsTrue.init("Net2.CountYieldCallsTrue"_sr);
+	countRunLoopProfilingSignals.init("Net2.CountRunLoopProfilingSignals"_sr);
+	countTLSPolicyFailures.init("Net2.CountTLSPolicyFailures"_sr);
+	priorityMetric.init("Net2.Priority"_sr);
+	awakeMetric.init("Net2.Awake"_sr);
+	slowTaskMetric.init("Net2.SlowTask"_sr);
+	countLaunchTime.init("Net2.CountLaunchTime"_sr);
+	countReactTime.init("Net2.CountReactTime"_sr);
 }
 
 bool Net2::checkRunnable() {
@@ -2111,7 +2111,7 @@ void net2_test(){
 	    reqs.resize(10000);
 	    for(int i=0; i<10000; i++) {
 	        TestGVR &req = reqs[i];
-	        req.key = LiteralStringRef("Foobar");
+	        req.key = "Foobar"_sr;
 
 	        SerializeSource<TestGVR> what(req);
 

--- a/flow/Net2Packet.h
+++ b/flow/Net2Packet.h
@@ -44,9 +44,8 @@ class UnsentPacketQueue : NonCopyable {
 public:
 	UnsentPacketQueue()
 	  : unsent_first(0), unsent_last(0),
-	    sendQueueLatencyHistogram(Histogram::getHistogram(LiteralStringRef("UnsentPacketQueue"),
-	                                                      LiteralStringRef("QueueWait"),
-	                                                      Histogram::Unit::microseconds)) {}
+	    sendQueueLatencyHistogram(
+	        Histogram::getHistogram("UnsentPacketQueue"_sr, "QueueWait"_sr, Histogram::Unit::microseconds)) {}
 
 	~UnsentPacketQueue() {
 		discardAll();

--- a/flow/Platform.actor.cpp
+++ b/flow/Platform.actor.cpp
@@ -459,24 +459,22 @@ void getMachineRAMInfo(MachineRAMInfo& memInfo) {
 	}
 
 	std::map<StringRef, int64_t> request = {
-		{ LiteralStringRef("MemTotal:"), 0 },       { LiteralStringRef("MemFree:"), 0 },
-		{ LiteralStringRef("MemAvailable:"), -1 },  { LiteralStringRef("Active(file):"), 0 },
-		{ LiteralStringRef("Inactive(file):"), 0 }, { LiteralStringRef("SwapTotal:"), 0 },
-		{ LiteralStringRef("SwapFree:"), 0 },       { LiteralStringRef("SReclaimable:"), 0 },
+		{ "MemTotal:"_sr, 0 },       { "MemFree:"_sr, 0 },   { "MemAvailable:"_sr, -1 }, { "Active(file):"_sr, 0 },
+		{ "Inactive(file):"_sr, 0 }, { "SwapTotal:"_sr, 0 }, { "SwapFree:"_sr, 0 },      { "SReclaimable:"_sr, 0 },
 	};
 
 	std::stringstream memInfoStream;
 	memInfoStream << fileStream.rdbuf();
 	getMemoryInfo(request, memInfoStream);
 
-	int64_t memFree = request[LiteralStringRef("MemFree:")];
-	int64_t pageCache = request[LiteralStringRef("Active(file):")] + request[LiteralStringRef("Inactive(file):")];
-	int64_t slabReclaimable = request[LiteralStringRef("SReclaimable:")];
-	int64_t usedSwap = request[LiteralStringRef("SwapTotal:")] - request[LiteralStringRef("SwapFree:")];
+	int64_t memFree = request["MemFree:"_sr];
+	int64_t pageCache = request["Active(file):"_sr] + request["Inactive(file):"_sr];
+	int64_t slabReclaimable = request["SReclaimable:"_sr];
+	int64_t usedSwap = request["SwapTotal:"_sr] - request["SwapFree:"_sr];
 
-	memInfo.total = 1024 * request[LiteralStringRef("MemTotal:")];
-	if (request[LiteralStringRef("MemAvailable:")] != -1) {
-		memInfo.available = 1024 * (request[LiteralStringRef("MemAvailable:")] - usedSwap);
+	memInfo.total = 1024 * request["MemTotal:"_sr];
+	if (request["MemAvailable:"_sr] != -1) {
+		memInfo.available = 1024 * (request["MemAvailable:"_sr] - usedSwap);
 	} else {
 		memInfo.available =
 		    1024 * (std::max<int64_t>(0,
@@ -2334,7 +2332,7 @@ bool createDirectory(std::string const& directory) {
 
 const uint8_t separatorChar = CANONICAL_PATH_SEPARATOR;
 StringRef separator(&separatorChar, 1);
-StringRef dotdot = LiteralStringRef("..");
+StringRef dotdot = ".."_sr;
 
 std::string cleanPath(std::string const& path) {
 	std::vector<StringRef> finalParts;
@@ -2987,19 +2985,19 @@ void outOfMemory() {
 		char* demangled = abi::__cxa_demangle(i->first, nullptr, nullptr, nullptr);
 		if (demangled) {
 			s = demangled;
-			if (StringRef(s).startsWith(LiteralStringRef("(anonymous namespace)::")))
-				s = s.substr(LiteralStringRef("(anonymous namespace)::").size());
+			if (StringRef(s).startsWith("(anonymous namespace)::"_sr))
+				s = s.substr("(anonymous namespace)::"_sr.size());
 			free(demangled);
 		} else
 			s = i->first;
 #else
 		s = i->first;
-		if (StringRef(s).startsWith(LiteralStringRef("class `anonymous namespace'::")))
-			s = s.substr(LiteralStringRef("class `anonymous namespace'::").size());
-		else if (StringRef(s).startsWith(LiteralStringRef("class ")))
-			s = s.substr(LiteralStringRef("class ").size());
-		else if (StringRef(s).startsWith(LiteralStringRef("struct ")))
-			s = s.substr(LiteralStringRef("struct ").size());
+		if (StringRef(s).startsWith("class `anonymous namespace'::"_sr))
+			s = s.substr("class `anonymous namespace'::"_sr.size());
+		else if (StringRef(s).startsWith("class "_sr))
+			s = s.substr("class "_sr.size());
+		else if (StringRef(s).startsWith("struct "_sr))
+			s = s.substr("struct "_sr.size());
 #endif
 		typeNames.emplace_back(s, i->first);
 	}
@@ -3724,21 +3722,19 @@ TEST_CASE("/flow/Platform/getMemoryInfo") {
 	                        "VmallocUsed:      410576 kB\n";
 
 	std::map<StringRef, int64_t> request = {
-		{ LiteralStringRef("MemTotal:"), 0 },     { LiteralStringRef("MemFree:"), 0 },
-		{ LiteralStringRef("MemAvailable:"), 0 }, { LiteralStringRef("Buffers:"), 0 },
-		{ LiteralStringRef("Cached:"), 0 },       { LiteralStringRef("SwapTotal:"), 0 },
-		{ LiteralStringRef("SwapFree:"), 0 },
+		{ "MemTotal:"_sr, 0 }, { "MemFree:"_sr, 0 },   { "MemAvailable:"_sr, 0 }, { "Buffers:"_sr, 0 },
+		{ "Cached:"_sr, 0 },   { "SwapTotal:"_sr, 0 }, { "SwapFree:"_sr, 0 },
 	};
 
 	std::stringstream memInfoStream(memString);
 	getMemoryInfo(request, memInfoStream);
-	ASSERT(request[LiteralStringRef("MemTotal:")] == 24733228);
-	ASSERT(request[LiteralStringRef("MemFree:")] == 2077580);
-	ASSERT(request[LiteralStringRef("MemAvailable:")] == 0);
-	ASSERT(request[LiteralStringRef("Buffers:")] == 266940);
-	ASSERT(request[LiteralStringRef("Cached:")] == 16798292);
-	ASSERT(request[LiteralStringRef("SwapTotal:")] == 25165820);
-	ASSERT(request[LiteralStringRef("SwapFree:")] == 23680228);
+	ASSERT(request["MemTotal:"_sr] == 24733228);
+	ASSERT(request["MemFree:"_sr] == 2077580);
+	ASSERT(request["MemAvailable:"_sr] == 0);
+	ASSERT(request["Buffers:"_sr] == 266940);
+	ASSERT(request["Cached:"_sr] == 16798292);
+	ASSERT(request["SwapTotal:"_sr] == 25165820);
+	ASSERT(request["SwapFree:"_sr] == 23680228);
 	for (auto& item : request) {
 		printf("%s:%ld\n", item.first.toString().c_str(), item.second);
 	}
@@ -3783,13 +3779,13 @@ TEST_CASE("/flow/Platform/getMemoryInfo") {
 
 	std::stringstream memInfoStream1(memString1);
 	getMemoryInfo(request, memInfoStream1);
-	ASSERT(request[LiteralStringRef("MemTotal:")] == 31856496);
-	ASSERT(request[LiteralStringRef("MemFree:")] == 25492716);
-	ASSERT(request[LiteralStringRef("MemAvailable:")] == 28470756);
-	ASSERT(request[LiteralStringRef("Buffers:")] == 313644);
-	ASSERT(request[LiteralStringRef("Cached:")] == 2956444);
-	ASSERT(request[LiteralStringRef("SwapTotal:")] == 0);
-	ASSERT(request[LiteralStringRef("SwapFree:")] == 0);
+	ASSERT(request["MemTotal:"_sr] == 31856496);
+	ASSERT(request["MemFree:"_sr] == 25492716);
+	ASSERT(request["MemAvailable:"_sr] == 28470756);
+	ASSERT(request["Buffers:"_sr] == 313644);
+	ASSERT(request["Cached:"_sr] == 2956444);
+	ASSERT(request["SwapTotal:"_sr] == 0);
+	ASSERT(request["SwapFree:"_sr] == 0);
 	for (auto& item : request) {
 		printf("%s:%ld\n", item.first.toString().c_str(), item.second);
 	}

--- a/flow/SystemMonitor.cpp
+++ b/flow/SystemMonitor.cpp
@@ -271,19 +271,19 @@ SystemStatistics customSystemMonitor(std::string const& eventName, StatisticsSta
 				char* demangled = abi::__cxa_demangle(i->first, nullptr, nullptr, nullptr);
 				if (demangled) {
 					s = demangled;
-					if (StringRef(s).startsWith(LiteralStringRef("(anonymous namespace)::")))
-						s = s.substr(LiteralStringRef("(anonymous namespace)::").size());
+					if (StringRef(s).startsWith("(anonymous namespace)::"_sr))
+						s = s.substr("(anonymous namespace)::"_sr.size());
 					free(demangled);
 				} else
 					s = i->first;
 #else
 				s = i->first;
-				if (StringRef(s).startsWith(LiteralStringRef("class `anonymous namespace'::")))
-					s = s.substr(LiteralStringRef("class `anonymous namespace'::").size());
-				else if (StringRef(s).startsWith(LiteralStringRef("class ")))
-					s = s.substr(LiteralStringRef("class ").size());
-				else if (StringRef(s).startsWith(LiteralStringRef("struct ")))
-					s = s.substr(LiteralStringRef("struct ").size());
+				if (StringRef(s).startsWith("class `anonymous namespace'::"_sr))
+					s = s.substr("class `anonymous namespace'::"_sr.size());
+				else if (StringRef(s).startsWith("class "_sr))
+					s = s.substr("class "_sr.size());
+				else if (StringRef(s).startsWith("struct "_sr))
+					s = s.substr("struct "_sr.size());
 #endif
 				typeNames.emplace_back(s, i->first);
 			}

--- a/flow/SystemMonitor.h
+++ b/flow/SystemMonitor.h
@@ -89,53 +89,46 @@ struct NetworkData {
 	double countReactTime;
 
 	void init() {
-		bytesSent = Int64Metric::getValueOrDefault(LiteralStringRef("Net2.BytesSent"));
-		countPacketsReceived = Int64Metric::getValueOrDefault(LiteralStringRef("Net2.CountPacketsReceived"));
-		countPacketsGenerated = Int64Metric::getValueOrDefault(LiteralStringRef("Net2.CountPacketsGenerated"));
-		bytesReceived = Int64Metric::getValueOrDefault(LiteralStringRef("Net2.BytesReceived"));
-		countWriteProbes = Int64Metric::getValueOrDefault(LiteralStringRef("Net2.CountWriteProbes"));
-		countReadProbes = Int64Metric::getValueOrDefault(LiteralStringRef("Net2.CountReadProbes"));
-		countReads = Int64Metric::getValueOrDefault(LiteralStringRef("Net2.CountReads"));
-		countWouldBlock = Int64Metric::getValueOrDefault(LiteralStringRef("Net2.CountWouldBlock"));
-		countWrites = Int64Metric::getValueOrDefault(LiteralStringRef("Net2.CountWrites"));
-		countRunLoop = Int64Metric::getValueOrDefault(LiteralStringRef("Net2.CountRunLoop"));
-		countCantSleep = Int64Metric::getValueOrDefault(LiteralStringRef("Net2.CountCantSleep"));
-		countWontSleep = Int64Metric::getValueOrDefault(LiteralStringRef("Net2.CountWontSleep"));
-		countTimers = Int64Metric::getValueOrDefault(LiteralStringRef("Net2.CountTimers"));
-		countTasks = Int64Metric::getValueOrDefault(LiteralStringRef("Net2.CountTasks"));
-		countYields = Int64Metric::getValueOrDefault(LiteralStringRef("Net2.CountYields"));
-		countYieldBigStack = Int64Metric::getValueOrDefault(LiteralStringRef("Net2.CountYieldBigStack"));
-		countYieldCalls = Int64Metric::getValueOrDefault(LiteralStringRef("Net2.CountYieldCalls"));
-		countASIOEvents = Int64Metric::getValueOrDefault(LiteralStringRef("Net2.CountASIOEvents"));
-		countYieldCallsTrue = Int64Metric::getValueOrDefault(LiteralStringRef("Net2.CountYieldCallsTrue"));
-		countRunLoopProfilingSignals =
-		    Int64Metric::getValueOrDefault(LiteralStringRef("Net2.CountRunLoopProfilingSignals"));
-		countConnEstablished = Int64Metric::getValueOrDefault(LiteralStringRef("Net2.CountConnEstablished"));
-		countConnClosedWithError = Int64Metric::getValueOrDefault(LiteralStringRef("Net2.CountConnClosedWithError"));
-		countConnClosedWithoutError =
-		    Int64Metric::getValueOrDefault(LiteralStringRef("Net2.CountConnClosedWithoutError"));
-		countTLSPolicyFailures = Int64Metric::getValueOrDefault(LiteralStringRef("Net2.CountTLSPolicyFailures"));
-		countLaunchTime = DoubleMetric::getValueOrDefault(LiteralStringRef("Net2.CountLaunchTime"));
-		countReactTime = DoubleMetric::getValueOrDefault(LiteralStringRef("Net2.CountReactTime"));
-		countFileLogicalWrites = Int64Metric::getValueOrDefault(LiteralStringRef("AsyncFile.CountLogicalWrites"));
-		countFileLogicalReads = Int64Metric::getValueOrDefault(LiteralStringRef("AsyncFile.CountLogicalReads"));
-		countAIOSubmit = Int64Metric::getValueOrDefault(LiteralStringRef("AsyncFile.CountAIOSubmit"));
-		countAIOCollect = Int64Metric::getValueOrDefault(LiteralStringRef("AsyncFile.CountAIOCollect"));
-		countFileCacheWrites = Int64Metric::getValueOrDefault(LiteralStringRef("AsyncFile.CountCacheWrites"));
-		countFileCacheReads = Int64Metric::getValueOrDefault(LiteralStringRef("AsyncFile.CountCacheReads"));
-		countFileCacheWritesBlocked =
-		    Int64Metric::getValueOrDefault(LiteralStringRef("AsyncFile.CountCacheWritesBlocked"));
-		countFileCacheReadsBlocked =
-		    Int64Metric::getValueOrDefault(LiteralStringRef("AsyncFile.CountCacheReadsBlocked"));
-		countFileCachePageReadsMerged =
-		    Int64Metric::getValueOrDefault(LiteralStringRef("AsyncFile.CountCachePageReadsMerged"));
-		countFileCacheFinds = Int64Metric::getValueOrDefault(LiteralStringRef("AsyncFile.CountCacheFinds"));
-		countFileCacheReadBytes = Int64Metric::getValueOrDefault(LiteralStringRef("AsyncFile.CountCacheReadBytes"));
-		countFilePageCacheHits = Int64Metric::getValueOrDefault(LiteralStringRef("AsyncFile.CountCachePageReadsHit"));
-		countFilePageCacheMisses =
-		    Int64Metric::getValueOrDefault(LiteralStringRef("AsyncFile.CountCachePageReadsMissed"));
-		countFilePageCacheEvictions =
-		    Int64Metric::getValueOrDefault(LiteralStringRef("EvictablePageCache.CacheEvictions"));
+		bytesSent = Int64Metric::getValueOrDefault("Net2.BytesSent"_sr);
+		countPacketsReceived = Int64Metric::getValueOrDefault("Net2.CountPacketsReceived"_sr);
+		countPacketsGenerated = Int64Metric::getValueOrDefault("Net2.CountPacketsGenerated"_sr);
+		bytesReceived = Int64Metric::getValueOrDefault("Net2.BytesReceived"_sr);
+		countWriteProbes = Int64Metric::getValueOrDefault("Net2.CountWriteProbes"_sr);
+		countReadProbes = Int64Metric::getValueOrDefault("Net2.CountReadProbes"_sr);
+		countReads = Int64Metric::getValueOrDefault("Net2.CountReads"_sr);
+		countWouldBlock = Int64Metric::getValueOrDefault("Net2.CountWouldBlock"_sr);
+		countWrites = Int64Metric::getValueOrDefault("Net2.CountWrites"_sr);
+		countRunLoop = Int64Metric::getValueOrDefault("Net2.CountRunLoop"_sr);
+		countCantSleep = Int64Metric::getValueOrDefault("Net2.CountCantSleep"_sr);
+		countWontSleep = Int64Metric::getValueOrDefault("Net2.CountWontSleep"_sr);
+		countTimers = Int64Metric::getValueOrDefault("Net2.CountTimers"_sr);
+		countTasks = Int64Metric::getValueOrDefault("Net2.CountTasks"_sr);
+		countYields = Int64Metric::getValueOrDefault("Net2.CountYields"_sr);
+		countYieldBigStack = Int64Metric::getValueOrDefault("Net2.CountYieldBigStack"_sr);
+		countYieldCalls = Int64Metric::getValueOrDefault("Net2.CountYieldCalls"_sr);
+		countASIOEvents = Int64Metric::getValueOrDefault("Net2.CountASIOEvents"_sr);
+		countYieldCallsTrue = Int64Metric::getValueOrDefault("Net2.CountYieldCallsTrue"_sr);
+		countRunLoopProfilingSignals = Int64Metric::getValueOrDefault("Net2.CountRunLoopProfilingSignals"_sr);
+		countConnEstablished = Int64Metric::getValueOrDefault("Net2.CountConnEstablished"_sr);
+		countConnClosedWithError = Int64Metric::getValueOrDefault("Net2.CountConnClosedWithError"_sr);
+		countConnClosedWithoutError = Int64Metric::getValueOrDefault("Net2.CountConnClosedWithoutError"_sr);
+		countTLSPolicyFailures = Int64Metric::getValueOrDefault("Net2.CountTLSPolicyFailures"_sr);
+		countLaunchTime = DoubleMetric::getValueOrDefault("Net2.CountLaunchTime"_sr);
+		countReactTime = DoubleMetric::getValueOrDefault("Net2.CountReactTime"_sr);
+		countFileLogicalWrites = Int64Metric::getValueOrDefault("AsyncFile.CountLogicalWrites"_sr);
+		countFileLogicalReads = Int64Metric::getValueOrDefault("AsyncFile.CountLogicalReads"_sr);
+		countAIOSubmit = Int64Metric::getValueOrDefault("AsyncFile.CountAIOSubmit"_sr);
+		countAIOCollect = Int64Metric::getValueOrDefault("AsyncFile.CountAIOCollect"_sr);
+		countFileCacheWrites = Int64Metric::getValueOrDefault("AsyncFile.CountCacheWrites"_sr);
+		countFileCacheReads = Int64Metric::getValueOrDefault("AsyncFile.CountCacheReads"_sr);
+		countFileCacheWritesBlocked = Int64Metric::getValueOrDefault("AsyncFile.CountCacheWritesBlocked"_sr);
+		countFileCacheReadsBlocked = Int64Metric::getValueOrDefault("AsyncFile.CountCacheReadsBlocked"_sr);
+		countFileCachePageReadsMerged = Int64Metric::getValueOrDefault("AsyncFile.CountCachePageReadsMerged"_sr);
+		countFileCacheFinds = Int64Metric::getValueOrDefault("AsyncFile.CountCacheFinds"_sr);
+		countFileCacheReadBytes = Int64Metric::getValueOrDefault("AsyncFile.CountCacheReadBytes"_sr);
+		countFilePageCacheHits = Int64Metric::getValueOrDefault("AsyncFile.CountCachePageReadsHit"_sr);
+		countFilePageCacheMisses = Int64Metric::getValueOrDefault("AsyncFile.CountCachePageReadsMissed"_sr);
+		countFilePageCacheEvictions = Int64Metric::getValueOrDefault("EvictablePageCache.CacheEvictions"_sr);
 	}
 };
 

--- a/flow/TDMetric.actor.h
+++ b/flow/TDMetric.actor.h
@@ -358,7 +358,7 @@ struct Descriptor {
 	using fields = std::tuple<>;
 	typedef make_index_sequence_impl<0, index_sequence<>, std::tuple_size<fields>::value>::type field_indexes;
 
-	static StringRef typeName() { return LiteralStringRef(""); }
+	static StringRef typeName() { return ""_sr; }
 #endif
 };
 
@@ -430,9 +430,7 @@ struct FieldValueBlockEncoding<double> {
 
 template <>
 struct FieldValueBlockEncoding<bool> {
-	inline void write(BinaryWriter& w, bool v) {
-		w.serializeBytes(v ? LiteralStringRef("\x01") : LiteralStringRef("\x00"));
-	}
+	inline void write(BinaryWriter& w, bool v) { w.serializeBytes(v ? "\x01"_sr : "\x00"_sr); }
 	bool read(BinaryReader& r) {
 		uint8_t* v = (uint8_t*)r.readBytes(sizeof(uint8_t));
 		return *v != 0;
@@ -716,7 +714,7 @@ struct MakeEventField {
 };
 
 struct TimeDescriptor {
-	static StringRef name() { return LiteralStringRef("Time"); }
+	static StringRef name() { return "Time"_sr; }
 };
 
 struct BaseMetric {

--- a/flow/TDMetric.cpp
+++ b/flow/TDMetric.cpp
@@ -21,15 +21,15 @@
 #include "flow/TDMetric.actor.h"
 #include "flow/flow.h"
 
-const StringRef BaseEventMetric::metricType = LiteralStringRef("Event");
+const StringRef BaseEventMetric::metricType = "Event"_sr;
 template <>
-const StringRef Int64Metric::metricType = LiteralStringRef("Int64");
+const StringRef Int64Metric::metricType = "Int64"_sr;
 template <>
-const StringRef DoubleMetric::metricType = LiteralStringRef("Double");
+const StringRef DoubleMetric::metricType = "Double"_sr;
 template <>
-const StringRef BoolMetric::metricType = LiteralStringRef("Bool");
+const StringRef BoolMetric::metricType = "Bool"_sr;
 template <>
-const StringRef StringMetric::metricType = LiteralStringRef("String");
+const StringRef StringMetric::metricType = "String"_sr;
 
 std::string reduceFilename(std::string const& filename) {
 	std::string r = filename;
@@ -60,29 +60,29 @@ std::string reduceFilename(std::string const& filename) {
 }
 
 void MetricKeyRef::writeField(BinaryWriter& wr) const {
-	wr.serializeBytes(LiteralStringRef("\x01"));
+	wr.serializeBytes("\x01"_sr);
 	wr.serializeBytes(fieldName);
-	wr.serializeBytes(LiteralStringRef("\x00\x01"));
+	wr.serializeBytes("\x00\x01"_sr);
 	wr.serializeBytes(fieldType);
-	wr.serializeBytes(LiteralStringRef("\x00"));
+	wr.serializeBytes("\x00"_sr);
 }
 
 void MetricKeyRef::writeMetricName(BinaryWriter& wr) const {
-	wr.serializeBytes(LiteralStringRef("\x01"));
+	wr.serializeBytes("\x01"_sr);
 	wr.serializeBytes(name.name);
-	wr.serializeBytes(LiteralStringRef("\x00\x01"));
+	wr.serializeBytes("\x00\x01"_sr);
 	wr.serializeBytes(name.type);
-	wr.serializeBytes(LiteralStringRef("\x00\x01"));
+	wr.serializeBytes("\x00\x01"_sr);
 	wr.serializeBytes(address);
-	wr.serializeBytes(LiteralStringRef("\x00\x01"));
+	wr.serializeBytes("\x00\x01"_sr);
 	wr.serializeBytes(name.id);
-	wr.serializeBytes(LiteralStringRef("\x00"));
+	wr.serializeBytes("\x00"_sr);
 }
 
 const Standalone<StringRef> MetricKeyRef::packLatestKey() const {
 	BinaryWriter wr(Unversioned());
 	wr.serializeBytes(prefix);
-	wr.serializeBytes(LiteralStringRef("\x01TDMetricsLastValue\x00"));
+	wr.serializeBytes("\x01TDMetricsLastValue\x00"_sr);
 	writeMetricName(wr);
 	return wr.toValue();
 }
@@ -91,9 +91,9 @@ const Standalone<StringRef> MetricKeyRef::packDataKey(int64_t time) const {
 	BinaryWriter wr(Unversioned());
 	wr.serializeBytes(prefix);
 	if (isField())
-		wr.serializeBytes(LiteralStringRef("\x01TDFieldData\x00"));
+		wr.serializeBytes("\x01TDFieldData\x00"_sr);
 	else
-		wr.serializeBytes(LiteralStringRef("\x01TDMetricData\x00"));
+		wr.serializeBytes("\x01TDMetricData\x00"_sr);
 	writeMetricName(wr);
 	if (isField())
 		writeField(wr);
@@ -107,15 +107,15 @@ const Standalone<StringRef> MetricKeyRef::packFieldRegKey() const {
 	ASSERT(isField());
 	BinaryWriter wr(Unversioned());
 	wr.serializeBytes(prefix);
-	wr.serializeBytes(LiteralStringRef("\x01TDFields\x00\x01"));
+	wr.serializeBytes("\x01TDFields\x00\x01"_sr);
 	wr.serializeBytes(name.name);
-	wr.serializeBytes(LiteralStringRef("\x00\x01"));
+	wr.serializeBytes("\x00\x01"_sr);
 	wr.serializeBytes(name.type);
-	wr.serializeBytes(LiteralStringRef("\x00\x01"));
+	wr.serializeBytes("\x00\x01"_sr);
 	wr.serializeBytes(fieldName);
-	wr.serializeBytes(LiteralStringRef("\x00\x01"));
+	wr.serializeBytes("\x00\x01"_sr);
 	wr.serializeBytes(fieldType);
-	wr.serializeBytes(LiteralStringRef("\x00"));
+	wr.serializeBytes("\x00"_sr);
 	return wr.toValue();
 }
 

--- a/flow/Trace.cpp
+++ b/flow/Trace.cpp
@@ -158,11 +158,11 @@ public:
 	bool logTraceEventMetrics;
 
 	void initMetrics() {
-		SevErrorNames.init(LiteralStringRef("TraceEvents.SevError"));
-		SevWarnAlwaysNames.init(LiteralStringRef("TraceEvents.SevWarnAlways"));
-		SevWarnNames.init(LiteralStringRef("TraceEvents.SevWarn"));
-		SevInfoNames.init(LiteralStringRef("TraceEvents.SevInfo"));
-		SevDebugNames.init(LiteralStringRef("TraceEvents.SevDebug"));
+		SevErrorNames.init("TraceEvents.SevError"_sr);
+		SevWarnAlwaysNames.init("TraceEvents.SevWarnAlways"_sr);
+		SevWarnNames.init("TraceEvents.SevWarn"_sr);
+		SevInfoNames.init("TraceEvents.SevInfo"_sr);
+		SevDebugNames.init("TraceEvents.SevDebug"_sr);
 		logTraceEventMetrics = true;
 	}
 

--- a/flow/actorcompiler/ActorCompiler.cs
+++ b/flow/actorcompiler/ActorCompiler.cs
@@ -249,16 +249,16 @@ namespace actorcompiler
             lines = 0;
 
             writer.WriteLine(memberIndentStr + "template<> struct Descriptor<struct {0}> {{", descr.name);
-            writer.WriteLine(memberIndentStr + "\tstatic StringRef typeName() {{ return LiteralStringRef(\"{0}\"); }}", descr.name);
+            writer.WriteLine(memberIndentStr + "\tstatic StringRef typeName() {{ return \"{0}\"_sr; }}", descr.name);
             writer.WriteLine(memberIndentStr + "\ttypedef {0} type;", descr.name);
             lines += 3;
 
             foreach (var dec in descr.body)
             {
                 writer.WriteLine(memberIndentStr + "\tstruct {0}Descriptor {{", dec.name);
-                writer.WriteLine(memberIndentStr + "\t\tstatic StringRef name() {{ return LiteralStringRef(\"{0}\"); }}", dec.name);
-                writer.WriteLine(memberIndentStr + "\t\tstatic StringRef typeName() {{ return LiteralStringRef(\"{0}\"); }}", dec.type);
-                writer.WriteLine(memberIndentStr + "\t\tstatic StringRef comment() {{ return LiteralStringRef(\"{0}\"); }}", dec.comment);
+                writer.WriteLine(memberIndentStr + "\t\tstatic StringRef name() {{ return \"{0}\"_sr; }}", dec.name);
+                writer.WriteLine(memberIndentStr + "\t\tstatic StringRef typeName() {{ return \"{0}\"_sr; }}", dec.type);
+                writer.WriteLine(memberIndentStr + "\t\tstatic StringRef comment() {{ return \"{0}\"_sr; }}", dec.comment);
                 writer.WriteLine(memberIndentStr + "\t\ttypedef {0} type;", dec.type);
                 writer.WriteLine(memberIndentStr + "\t\tstatic inline type get({0}& from);", descr.name);
                 writer.WriteLine(memberIndentStr + "\t};");

--- a/flow/flow.cpp
+++ b/flow/flow.cpp
@@ -393,7 +393,7 @@ TEST_CASE("/flow/FlatBuffers/Standalone") {
 		ASSERT(in == out);
 	}
 	{
-		StringRef in = LiteralStringRef("foobar");
+		StringRef in = "foobar"_sr;
 		Standalone<StringRef> out;
 		ObjectWriter writer(Unversioned());
 		writer.serialize(in);

--- a/flow/serialize.h
+++ b/flow/serialize.h
@@ -415,17 +415,17 @@ public:
 	void serializeAsTuple(StringRef str) {
 		size_t last_pos = 0;
 
-		serializeBytes(LiteralStringRef("\x01"));
+		serializeBytes("\x01"_sr);
 
 		for (size_t pos = 0; pos < str.size(); ++pos) {
 			if (str[pos] == '\x00') {
 				serializeBytes(str.substr(last_pos, pos - last_pos));
-				serializeBytes(LiteralStringRef("\x00\xff"));
+				serializeBytes("\x00\xff"_sr);
 				last_pos = pos + 1;
 			}
 		}
 		serializeBytes(str.substr(last_pos, str.size() - last_pos));
-		serializeBytes(LiteralStringRef("\x00"));
+		serializeBytes("\x00"_sr);
 	}
 
 	void serializeAsTuple(bool t) {

--- a/flowbench/BenchMetadataCheck.cpp
+++ b/flowbench/BenchMetadataCheck.cpp
@@ -29,12 +29,12 @@
 
 static const std::array<MutationRef, 5> mutations = {
 	MutationRef(MutationRef::Type::ClearRange, normalKeys.begin, normalKeys.end),
-	MutationRef(MutationRef::Type::ClearRange, LiteralStringRef("a"), LiteralStringRef("b")),
-	MutationRef(MutationRef::Type::ClearRange, LiteralStringRef("aaaaaaaaaa"), LiteralStringRef("bbbbbbbbbb")),
+	MutationRef(MutationRef::Type::ClearRange, "a"_sr, "b"_sr),
+	MutationRef(MutationRef::Type::ClearRange, "aaaaaaaaaa"_sr, "bbbbbbbbbb"_sr),
 	MutationRef(MutationRef::Type::ClearRange, normalKeys.begin, systemKeys.end),
 	MutationRef(MutationRef::Type::ClearRange,
-	            LiteralStringRef("a").withPrefix(systemKeys.begin),
-	            LiteralStringRef("b").withPrefix(systemKeys.begin)),
+	            "a"_sr.withPrefix(systemKeys.begin),
+	            "b"_sr.withPrefix(systemKeys.begin)),
 };
 
 static void bench_check_metadata1(benchmark::State& state) {


### PR DESCRIPTION
`LiteralStringRef` is less save than `_sr`. So using that is preferred. This replaces most occurrences of `LiteralStringRef` with `_sr`

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
