### PR TITLE
Master tells cluster controller about TLog groups

### DIFF
--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -104,7 +104,7 @@ void ServerKnobs::initialize(Randomize _randomize, ClientKnobs* clientKnobs, IsS
 	init( PUSH_STATS_SLOW_RATIO,                                 0.5 );
 	init( TLOG_POP_BATCH_SIZE,                                  1000 ); if ( randomize && BUGGIFY ) TLOG_POP_BATCH_SIZE = 10;
 	init( TLOG_SERVER_TEAM_PARTITIONED,                        false );
-	init( TLOG_NEW_INTERFACE,                        true );
+	init( TLOG_NEW_INTERFACE,                        		   false );
 
 	// disk snapshot max timeout, to be put in TLog, storage and coordinator nodes
 	init( MAX_FORKED_PROCESS_OUTPUT,                            1024 );

--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -104,6 +104,7 @@ void ServerKnobs::initialize(Randomize _randomize, ClientKnobs* clientKnobs, IsS
 	init( PUSH_STATS_SLOW_RATIO,                                 0.5 );
 	init( TLOG_POP_BATCH_SIZE,                                  1000 ); if ( randomize && BUGGIFY ) TLOG_POP_BATCH_SIZE = 10;
 	init( TLOG_SERVER_TEAM_PARTITIONED,                        false );
+	init( TLOG_NEW_INTERFACE,                        true );
 
 	// disk snapshot max timeout, to be put in TLog, storage and coordinator nodes
 	init( MAX_FORKED_PROCESS_OUTPUT,                            1024 );

--- a/fdbclient/ServerKnobs.h
+++ b/fdbclient/ServerKnobs.h
@@ -103,7 +103,8 @@ public:
 	double PUSH_STATS_SLOW_RATIO;
 	int TLOG_POP_BATCH_SIZE;
 	bool TLOG_SERVER_TEAM_PARTITIONED;
-
+	bool TLOG_NEW_INTERFACE;
+	
 	// Data distribution queue
 	double HEALTH_POLL_TIME;
 	double BEST_TEAM_STUCK_DELAY;

--- a/fdbserver/ClusterController.actor.cpp
+++ b/fdbserver/ClusterController.actor.cpp
@@ -3408,20 +3408,17 @@ ACTOR Future<Void> clusterRecruitRemoteFromConfiguration(ClusterControllerData* 
 }
 
 void printGroupsToServersMapping(LogSystemConfig logSystemConfig) {
-    std::unordered_map<UID, vector<UID>> tLogGroupIdToServerIds = logSystemConfig.tLogGroupIdToServerIds;
-    for (auto iterator : tLogGroupIdToServerIds) {
+    std::unordered_map<UID, std::vector<Reference<AsyncVar<OptionalInterface<ptxn::TLogInterface_PassivelyPull>>>>> ptxnTLogGroups 
+		= logSystemConfig.tLogs[0].ptxnTLogGroups;
+    for (auto iterator : ptxnTLogGroups) {
         auto serverIds = iterator.first;
-        TraceEvent("tLogGroupToLogServerIds:Group ID: ", serverIds);
-        for (auto id : iterator.second) {
-            TraceEvent("tLogGroupToLogServerIds: server id").detail("server id", id.toString());
-        }
+        TraceEvent("tLogGroupToLogServerIds:Group ID: ", serverIds)
+			.detail("group size : ", iterator.second.size());
     }
 }
 
 void clusterRegisterMaster(ClusterControllerData* self, RegisterMasterRequest const& req) {
 	req.reply.send(Void());
-
-    printGroupsToServersMapping(req.logSystemConfig);
 
 	TraceEvent("MasterRegistrationReceived", self->id)
 	    .detail("MasterId", req.id)

--- a/fdbserver/ClusterController.actor.cpp
+++ b/fdbserver/ClusterController.actor.cpp
@@ -3407,8 +3407,21 @@ ACTOR Future<Void> clusterRecruitRemoteFromConfiguration(ClusterControllerData* 
 	}
 }
 
+void printGroupsToServersMapping(LogSystemConfig logSystemConfig) {
+    std::unordered_map<UID, vector<UID>> tLogGroupIdToServerIds = logSystemConfig.tLogGroupIdToServerIds;
+    for (auto iterator : tLogGroupIdToServerIds) {
+        auto serverIds = iterator.first;
+        TraceEvent("tLogGroupToLogServerIds:Group ID: ", serverIds);
+        for (auto id : iterator.second) {
+            TraceEvent("tLogGroupToLogServerIds: server id").detail("server id", id.toString());
+        }
+    }
+}
+
 void clusterRegisterMaster(ClusterControllerData* self, RegisterMasterRequest const& req) {
 	req.reply.send(Void());
+
+    printGroupsToServersMapping(req.logSystemConfig);
 
 	TraceEvent("MasterRegistrationReceived", self->id)
 	    .detail("MasterId", req.id)

--- a/fdbserver/LogSystem.h
+++ b/fdbserver/LogSystem.h
@@ -241,8 +241,8 @@ public:
 
 		// the following logic supports upgrades from 5.X
 		if (tag == txsTag)
-			return txsTagOld % logServers.size();;
-		return tag.id % logServers.size();;
+			return txsTagOld % logServers.size();
+		return tag.id % logServers.size();
 	}
 
 	void updateLocalitySet(std::vector<LocalityData> const& localities) {

--- a/fdbserver/LogSystem.h
+++ b/fdbserver/LogSystem.h
@@ -23,6 +23,7 @@
 
 #include <set>
 #include <vector>
+#include <unordered_map>
 
 #include "fdbserver/SpanContextMessage.h"
 #include "fdbserver/TLogInterface.h"
@@ -36,6 +37,7 @@
 #include "fdbrpc/ReplicationPolicy.h"
 #include "fdbrpc/Locality.h"
 #include "fdbrpc/Replication.h"
+#include "fdbserver/TLogGroup.actor.h"
 
 struct DBCoreState;
 struct TLogSet;
@@ -54,6 +56,8 @@ struct ConnectionResetInfo : public ReferenceCounted<ConnectionResetInfo> {
 class LogSet : NonCopyable, public ReferenceCounted<LogSet> {
 public:
 	std::vector<Reference<AsyncVar<OptionalInterface<TLogInterface>>>> logServers;
+	// question: why above we use reference -> asyncvar -> optionalinterface? Can I skip them here?
+	std::vector<ptxn::TLogInterface_PassivelyPull> logServersNew;
 	std::vector<Reference<AsyncVar<OptionalInterface<TLogInterface>>>> logRouters;
 	std::vector<Reference<AsyncVar<OptionalInterface<BackupInterface>>>> backupWorkers;
 	std::vector<Reference<ConnectionResetInfo>> connectionResetTrackers;
@@ -237,9 +241,10 @@ public:
 		}
 
 		// the following logic supports upgrades from 5.X
+		int size = SERVER_KNOBS->TLOG_NEW_INTERFACE ? logServersNew.size() : logServers.size();
 		if (tag == txsTag)
-			return txsTagOld % logServers.size();
-		return tag.id % logServers.size();
+			return txsTagOld % size;
+		return tag.id % size;
 	}
 
 	void updateLocalitySet(std::vector<LocalityData> const& localities) {
@@ -292,7 +297,8 @@ public:
 		if (allLocations) {
 			// special handling for allLocations
 			TraceEvent("AllLocationsSet");
-			for (int i = 0; i < logServers.size(); i++) {
+			int size =  SERVER_KNOBS->TLOG_NEW_INTERFACE ? logServersNew.size() : logServers.size();
+			for (int i = 0; i < size; i++) {
 				newLocations.push_back(i);
 			}
 		} else {
@@ -866,7 +872,9 @@ struct ILogSystem {
 	    int8_t primaryLocality,
 	    int8_t remoteLocality,
 	    std::vector<Tag> const& allTags,
-	    Reference<AsyncVar<bool>> const& recruitmentStalled) = 0;
+	    Reference<AsyncVar<bool>> const& recruitmentStalled,
+	    std::unordered_map<UID, std::vector<UID>> tLogGroupIdToServerIds,
+		std::unordered_map<UID, std::vector<TLogGroupRef>> tlogServerIdToTlogGroups) = 0;
 	// Call only on an ILogSystem obtained from recoverAndEndEpoch()
 	// Returns an ILogSystem representing a new epoch immediately following this one.  The new epoch is only provisional
 	// until the caller updates the coordinated DBCoreState
@@ -1091,9 +1099,7 @@ struct LogPushData : NonCopyable {
 		next_message_tags.clear();
 	}
 
-	Standalone<StringRef> getMessages(int loc) {
-		return messagesWriter[loc].toValue();
-	}
+	Standalone<StringRef> getMessages(int loc) { return messagesWriter[loc].toValue(); }
 
 	// Records if a tlog (specified by "loc") will receive an empty version batch message.
 	// "value" is the message returned by getMessages() call.

--- a/fdbserver/LogSystemConfig.h
+++ b/fdbserver/LogSystemConfig.h
@@ -86,11 +86,8 @@ struct TLogSet {
 	constexpr static FileIdentifier file_identifier = 6302317;
 	std::vector<OptionalInterface<TLogInterface>> tLogs;
 
-	// TODO: figure out a way to represent TLog group information needed for a ss to find the corresponding TLog
-	//  interface.
-	// TODO: change other function below to reflect TLogSet
-	std::unordered_map<ptxn::TLogGroupID, std::vector<OptionalInterface<ptxn::TLogInterface_PassivelyPull>>>
-	    ptxnTLogGroups;
+	std::unordered_map<ptxn::TLogGroupID, std::vector<Reference<AsyncVar<OptionalInterface<ptxn::TLogInterface_PassivelyPull>>>>> ptxnTLogGroups;
+
 	std::vector<OptionalInterface<TLogInterface>> logRouters;
 	std::vector<OptionalInterface<BackupInterface>> backupWorkers;
 	int32_t tLogWriteAntiQuorum, tLogReplicationFactor;
@@ -254,8 +251,7 @@ struct LogSystemConfig {
 	std::set<int8_t> pseudoLocalities;
 	LogEpoch epoch;
 	LogEpoch oldestBackupEpoch;
-    std::unordered_map<UID, vector<UID>> tLogGroupIdToServerIds;
-    std::unordered_map<UID, std::vector<ptxn::TLogInterface_PassivelyPull>> tLogGroupIdToInterfaces;
+
 	LogSystemConfig(LogEpoch e = 0)
 	  : logSystemType(LogSystemType::empty), logRouterTags(0), txsTags(0), expectedLogSets(0), stopped(false), epoch(e),
 	    oldestBackupEpoch(e) {}

--- a/fdbserver/LogSystemConfig.h
+++ b/fdbserver/LogSystemConfig.h
@@ -254,7 +254,8 @@ struct LogSystemConfig {
 	std::set<int8_t> pseudoLocalities;
 	LogEpoch epoch;
 	LogEpoch oldestBackupEpoch;
-
+    std::unordered_map<UID, vector<UID>> tLogGroupIdToServerIds;
+    std::unordered_map<UID, std::vector<ptxn::TLogInterface_PassivelyPull>> tLogGroupIdToInterfaces;
 	LogSystemConfig(LogEpoch e = 0)
 	  : logSystemType(LogSystemType::empty), logRouterTags(0), txsTags(0), expectedLogSets(0), stopped(false), epoch(e),
 	    oldestBackupEpoch(e) {}

--- a/fdbserver/MockLogSystem.cpp
+++ b/fdbserver/MockLogSystem.cpp
@@ -196,7 +196,9 @@ Future<Reference<ILogSystem>> MockLogSystem::newEpoch(
     int8_t primaryLocality,
     int8_t remoteLocality,
     const vector<Tag>& allTags,
-    const Reference<AsyncVar<bool>>& recruitmentStalled) {
+    const Reference<AsyncVar<bool>>& recruitmentStalled,
+    std::unordered_map<UID, std::vector<UID>> tLogGroupIdToServerIds,
+	std::unordered_map<UID, std::vector<TLogGroupRef>> tlogServerIdToTlogGroups) {
 	logMethodName(__func__);
 	return Future<Reference<ILogSystem>>();
 }

--- a/fdbserver/MockLogSystem.h
+++ b/fdbserver/MockLogSystem.h
@@ -85,7 +85,9 @@ struct MockLogSystem : ILogSystem, ReferenceCounted<MockLogSystem> {
 	                                       int8_t primaryLocality,
 	                                       int8_t remoteLocality,
 	                                       const vector<Tag>& allTags,
-	                                       const Reference<AsyncVar<bool>>& recruitmentStalled) final;
+	                                       const Reference<AsyncVar<bool>>& recruitmentStalled,
+                                           std::unordered_map<UID, std::vector<UID>> tLogGroupIdToServerIds,
+										   std::unordered_map<UID, std::vector<TLogGroupRef>> tlogServerIdToTlogGroups) final;
 	LogSystemConfig getLogSystemConfig() const final;
 	Standalone<StringRef> getLogsValue() const final;
 	Future<Void> onLogSystemConfigChange() final;

--- a/fdbserver/TagPartitionedLogSystem.actor.cpp
+++ b/fdbserver/TagPartitionedLogSystem.actor.cpp
@@ -2870,7 +2870,6 @@ struct TagPartitionedLogSystem : ILogSystem, ReferenceCounted<TagPartitionedLogS
 		logSystem->tLogs[0]->tLogLocalities.resize(recr.tLogs.size());
 		logSystem->tLogs[0]->logServers.resize(
 		    recr.tLogs.size()); // Dummy interfaces, so that logSystem->getPushLocations() below uses the correct size
-		// assuming tLogs[0] is primary?
 		logSystem->tLogs[0]->updateLocalitySet(localities);
 
 		std::vector<int> locations;
@@ -3063,7 +3062,7 @@ struct TagPartitionedLogSystem : ILogSystem, ReferenceCounted<TagPartitionedLogS
 		for (int i = 0; i < logSystem->tLogs[0]->logServers.size(); i++)
 			recoveryComplete.push_back(transformErrors(
 			    throwErrorOr(
-					// TODO: make recoveryFinished work with new tlog interfaces.
+			        // TODO: make recoveryFinished work with new tlog interfaces.
 			        logSystem->tLogs[0]->logServers[i]->get().interf().recoveryFinished.getReplyUnlessFailedFor(
 			            TLogRecoveryFinishedRequest(),
 			            SERVER_KNOBS->TLOG_TIMEOUT,

--- a/fdbserver/ptxn/test/TestTLogServer.actor.cpp
+++ b/fdbserver/ptxn/test/TestTLogServer.actor.cpp
@@ -172,7 +172,6 @@ ACTOR Future<Void> startStorageServers(std::vector<Future<Void>>* actors,
 	auto& tLogSet = dbInfoBuilder.logSystemConfig.tLogs.back();
 	tLogSet.locality = locality;
 	for (auto tLogGroup : pContext->tLogGroupLeaders) {
-		// I am not sure we want to add leader here, we should have added all interfaces to LogSet in LogSystemConfig, when recruiting.
 		OptionalInterface<ptxn::TLogInterface_PassivelyPull> optionalInterface = 
 			OptionalInterface<ptxn::TLogInterface_PassivelyPull>(*std::dynamic_pointer_cast<ptxn::TLogInterface_PassivelyPull>(tLogGroup.second));
 		tLogSet.ptxnTLogGroups[tLogGroup.first].push_back(makeReference<AsyncVar<OptionalInterface<ptxn::TLogInterface_PassivelyPull>>>(optionalInterface));

--- a/fdbserver/ptxn/test/TestTLogServer.actor.cpp
+++ b/fdbserver/ptxn/test/TestTLogServer.actor.cpp
@@ -172,8 +172,10 @@ ACTOR Future<Void> startStorageServers(std::vector<Future<Void>>* actors,
 	auto& tLogSet = dbInfoBuilder.logSystemConfig.tLogs.back();
 	tLogSet.locality = locality;
 	for (auto tLogGroup : pContext->tLogGroupLeaders) {
-		tLogSet.ptxnTLogGroups[tLogGroup.first].push_back(OptionalInterface<ptxn::TLogInterface_PassivelyPull>(
-		    *std::dynamic_pointer_cast<ptxn::TLogInterface_PassivelyPull>(tLogGroup.second)));
+		// I am not sure we want to add leader here, we should have added all interfaces to LogSet in LogSystemConfig, when recruiting.
+		OptionalInterface<ptxn::TLogInterface_PassivelyPull> optionalInterface = 
+			OptionalInterface<ptxn::TLogInterface_PassivelyPull>(*std::dynamic_pointer_cast<ptxn::TLogInterface_PassivelyPull>(tLogGroup.second));
+		tLogSet.ptxnTLogGroups[tLogGroup.first].push_back(makeReference<AsyncVar<OptionalInterface<ptxn::TLogInterface_PassivelyPull>>>(optionalInterface));
 	}
 	state Reference<AsyncVar<ServerDBInfo>> dbInfo = makeReference<AsyncVar<ServerDBInfo>>(dbInfoBuilder);
 	state Version tssSeedVersion = 0;


### PR DESCRIPTION
    Master tells cluster controller about TLog groups
    
    In TagPartitionedLogSystem(running on master), build the maps:
    * From group id to interfaces of tlog belong to the group
    * From tlog to the TLogGroups id it belongs to
    
    The first map is needed in ServerDBInfo and will be broadcasted.
    The second map is needed when creating a TLog


Joshua 1 failure out of 100000 runs:  20210722-181643-haofu-36797f886a3c3d26 
# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
