### PR TITLE
Change default data directory for unit tests outside simulation

### DIFF
--- a/fdbserver/workloads/UnitTests.actor.cpp
+++ b/fdbserver/workloads/UnitTests.actor.cpp
@@ -55,7 +55,7 @@ struct UnitTestWorkload : TestWorkload {
 		if (g_network->isSimulated()) {
 			testParams.setDataDir(getOption(options, "dataDir"_sr, "simfdb/unittests/"_sr).toString());
 		} else {
-			testParams.setDataDir(getOption(options, "dataDir"_sr, "/private/tmp/"_sr).toString());
+			testParams.setDataDir(getOption(options, "dataDir"_sr, "unittests/"_sr).toString());
 		}
 		cleanupAfterTests = getOption(options, "cleanupAfterTests"_sr, true);
 


### PR DESCRIPTION
It is not always possible to create the `/private` directory.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
