### PR TITLE
A simple prototype to separate network thread and worker thread

### DIFF
--- a/fdbserver/CMakeLists.txt
+++ b/fdbserver/CMakeLists.txt
@@ -63,6 +63,8 @@ set(FDBSERVER_SRCS
   MutationTracking.cpp
   MoveKeys.actor.h
   MoveKeys.actor.cpp
+  MultiThreadTest.h
+  MultiThreadTest.actor.cpp
   networktest.actor.cpp
   NetworkTest.h
   OldTLogServer_4_6.actor.cpp

--- a/fdbserver/MultiThreadTest.actor.cpp
+++ b/fdbserver/MultiThreadTest.actor.cpp
@@ -1,0 +1,178 @@
+/*
+ * MultiThreadTest.actor.cpp
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "fdbserver/MultiThreadTest.h"
+#include "flow/IRandom.h"
+#include "flow/Knobs.h"
+#include "flow/actorcompiler.h" // This must be the last #include.
+
+UID WLTOKEN_MULTITHREAD_SET(-1, 5);
+UID WLTOKEN_MULTITHREAD_GET(-1, 6);
+UID WLTOKEN_MULTITHREAD_CLEAR(-1, 7);
+
+template <typename Type>
+bool operator<<(ThreadPromiseStream<Type>& stream, const Type& in) {
+	return stream.queue->push(in);
+}
+
+template <typename Type>
+bool operator>>(const Type& in, ThreadPromiseStream<Type>& stream) {
+	return stream.queue->push(in);
+}
+
+template <typename Type>
+bool operator>>(ThreadFutureStream<Type>& stream, Type& out) {
+	return stream.queue->pop(out);
+}
+
+template <typename Type>
+bool operator<<(Type& out, ThreadFutureStream<Type>& stream) {
+	return stream.queue->pop(out);
+}
+
+MultiThreadedFDBInterface::MultiThreadedFDBInterface(NetworkAddress remote)
+  : set(Endpoint({ remote }, WLTOKEN_MULTITHREAD_SET)), get((Endpoint({ remote }, WLTOKEN_MULTITHREAD_GET))),
+    clear((Endpoint({ remote }, WLTOKEN_MULTITHREAD_CLEAR))) {
+	initialize();
+}
+
+MultiThreadedFDBInterface::MultiThreadedFDBInterface(INetwork* local) {
+	initialize();
+	set.makeWellKnownEndpoint(WLTOKEN_MULTITHREAD_SET, TaskPriority::DefaultEndpoint);
+	get.makeWellKnownEndpoint(WLTOKEN_MULTITHREAD_GET, TaskPriority::DefaultEndpoint);
+	clear.makeWellKnownEndpoint(WLTOKEN_MULTITHREAD_CLEAR, TaskPriority::DefaultEndpoint);
+}
+
+ACTOR Future<Void> multiThreadedFDBTestServer() {
+	state MultiThreadedFDBInterface interf(g_network);
+	state std::thread worker(interf.worker);
+	state Future<Void> logging = delay(1.0);
+	state Future<Void> replyInterval = delay(0.01);
+	state double lastTime = now();
+	state int sent = 0;
+	loop {
+		choose {
+			when(wait(logging)) {
+				auto spd = sent / (now() - lastTime);
+				fprintf(stderr, "responses per second: %f\n", spd);
+				lastTime = now();
+				sent = 0;
+				logging = delay(1.0);
+			}
+			when(GetRequest req = waitNext(interf.get.getFuture())) {
+				// fprintf(stderr, "Get request\n");
+				std::shared_ptr<void> reqPtr = std::make_shared<GetRequest>(std::move(req));
+				std::pair<request_type, std::shared_ptr<void>> pair = std::make_pair(request_type::GET, reqPtr);
+				while (!(interf.req << pair)) {
+					// resend until successful
+				};
+			}
+			when(SetRequest req = waitNext(interf.set.getFuture())) {
+				// fprintf(stderr, "Set request\n");
+				std::shared_ptr<void> reqPtr = std::make_shared<SetRequest>(std::move(req));
+				std::pair<request_type, std::shared_ptr<void>> pair = std::make_pair(request_type::SET, reqPtr);
+				while (!(interf.req << pair)) {
+					// resend until successful
+				};
+			}
+			when(ClearRequest req = waitNext(interf.clear.getFuture())) {
+				// fprintf(stderr, "Clear request\n");
+				std::shared_ptr<void> reqPtr = std::make_shared<ClearRequest>(std::move(req));
+				std::pair<request_type, std::shared_ptr<void>> pair = std::make_pair(request_type::CLEAR, reqPtr);
+				while (!(interf.req << pair)) {
+					// resend until successful
+				};
+			}
+			when(wait(replyInterval)) {
+				std::tuple<request_type, std::shared_ptr<void>, std::shared_ptr<void>> tup;
+				while (interf.reply >> tup) {
+					auto& [type, reqPtr, replyPtr] = tup;
+					// fprintf(stderr, "Network thread send reply back\n");
+					switch (type) {
+					case request_type::GET:
+						static_cast<GetRequest*>(reqPtr.get())->reply.send(*static_cast<std::string*>(replyPtr.get()));
+						break;
+					case request_type::SET:
+						static_cast<SetRequest*>(reqPtr.get())->reply.send(*static_cast<Void*>(replyPtr.get()));
+						break;
+					case request_type::CLEAR:
+						static_cast<ClearRequest*>(reqPtr.get())->reply.send(*static_cast<Void*>(replyPtr.get()));
+						break;
+					default:
+						ASSERT(false);
+					}
+					++sent;
+				}
+				replyInterval = delay(0.01);
+			}
+		}
+	}
+}
+
+ACTOR Future<Void> multithreadtestClient(MultiThreadedFDBInterface interf) {
+	state int rangeSize = 100; // 2 << 12;
+	state int op;
+	loop {
+		op = deterministicRandom()->randomInt(0, 3);
+		if (op == 0) {
+			state SetRequest setRequest;
+			setRequest.key = std::to_string(deterministicRandom()->randomInt(0, rangeSize));
+			setRequest.value = std::to_string(deterministicRandom()->coinflip());
+			wait(retryBrokenPromise(interf.set, setRequest));
+			// fprintf(stderr, "Set %s=%s\n", setRequest.key.c_str(), setRequest.value.c_str());
+		} else if (op == 1) {
+			try {
+				state GetRequest getRequest;
+				getRequest.key = std::to_string(deterministicRandom()->randomInt(0, rangeSize));
+				std::string val = wait(retryBrokenPromise(interf.get, getRequest));
+				// if (val.size())
+				//     fprintf(stderr, "%s : %s\n", getRequest.key.c_str(), val.c_str());
+				// else
+				//     fprintf(stderr, "Key %s not found \n", getRequest.key.c_str());
+			} catch (Error& e) {
+				if (e.code() != error_code_io_error) {
+					throw e;
+				}
+			}
+		} else {
+			state int from = deterministicRandom()->randomInt(0, rangeSize);
+			ClearRequest clearRequest;
+			clearRequest.from = std::to_string(from);
+			clearRequest.to = std::to_string(from + 1);
+			wait(retryBrokenPromise(interf.clear, clearRequest));
+			// fprintf(stderr, "Clear key from %d\n", from);
+		}
+		wait(delay(FLOW_KNOBS->PREVENT_FAST_SPIN_DELAY));
+	}
+}
+
+ACTOR Future<Void> multiThreadedFDBTestClient(std::string testServer) {
+
+	state NetworkAddress server = NetworkAddress::parse(testServer);
+	state MultiThreadedFDBInterface interf(server);
+	state std::vector<Future<Void>> clients;
+
+	for (int i = 0; i < 100; i++) {
+		clients.push_back(multithreadtestClient(interf));
+	}
+
+	wait(waitForAll(clients));
+	return Void();
+}

--- a/fdbserver/MultiThreadTest.h
+++ b/fdbserver/MultiThreadTest.h
@@ -1,0 +1,172 @@
+/*
+ * MultiThreadTest.h
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FDBSERVER_MULTITHREADTEST_H
+#define FDBSERVER_MULTITHREADTEST_H
+#include <condition_variable>
+#include <cstdint>
+#include <cstdio>
+#include <memory>
+#include <mutex>
+#include <thread>
+#include <typeinfo>
+#include <utility>
+#pragma once
+
+#include "fdbclient/FDBTypes.h"
+#include "fdbrpc/fdbrpc.h"
+#include "flow/FileIdentifier.h"
+#include "flow/multithread.h"
+
+// copied from tutorial.actor.cpp
+struct GetRequest {
+	constexpr static FileIdentifier file_identifier = 6983506;
+	std::string key;
+	ReplyPromise<std::string> reply;
+
+	template <class Ar>
+	void serialize(Ar& ar) {
+		serializer(ar, key, reply);
+	}
+};
+
+struct SetRequest {
+	constexpr static FileIdentifier file_identifier = 7554186;
+	std::string key;
+	std::string value;
+	ReplyPromise<Void> reply;
+
+	template <class Ar>
+	void serialize(Ar& ar) {
+		serializer(ar, key, value, reply);
+	}
+};
+
+struct ClearRequest {
+	constexpr static FileIdentifier file_identifier = 8500026;
+	std::string from;
+	std::string to;
+	ReplyPromise<Void> reply;
+
+	template <class Ar>
+	void serialize(Ar& ar) {
+		serializer(ar, from, to, reply);
+	}
+};
+
+enum class request_type { GET, SET, CLEAR };
+
+class workerThread {
+public:
+	workerThread() {}
+	workerThread(
+	    const ThreadFutureStream<std::pair<request_type, std::shared_ptr<void>>>& req,
+	    const ThreadPromiseStream<std::tuple<request_type, std::shared_ptr<void>, std::shared_ptr<void>>>& reply)
+	  : req(req), reply(reply) {}
+
+	void operator()() {
+		fprintf(stderr, "Worker thread started!\n");
+		while (true) {
+			std::pair<request_type, std::shared_ptr<void>> pair;
+			while (req >> pair) {
+				// std::ostringstream ss;
+				// ss << std::this_thread::get_id();
+				// std::string idstr = ss.str();
+				// fprintf(stderr, "Worker thread %s get the request\n", idstr.c_str());
+				std::shared_ptr<void> replyPtr;
+				auto& [type, reqPtr] = pair;
+				switch (type) {
+				case request_type::GET: {
+					auto p = static_cast<GetRequest*>(reqPtr.get());
+					auto iter = store.find(p->key);
+					std::string val;
+					if (iter != store.end()) {
+						val = iter->second;
+					}
+					replyPtr = std::make_shared<std::string>(std::move(val));
+					break;
+				}
+				case request_type::SET: {
+					auto p = static_cast<SetRequest*>(reqPtr.get());
+					store[p->key] = p->value;
+					replyPtr = std::make_shared<Void>();
+					break;
+				}
+				case request_type::CLEAR: {
+					auto p = static_cast<ClearRequest*>(reqPtr.get());
+					auto from = store.lower_bound(p->from);
+					auto to = store.lower_bound(p->to);
+					while (from != store.end() && from != to) {
+						auto next = from;
+						++next;
+						store.erase(from);
+						from = next;
+					}
+					replyPtr = std::make_shared<Void>();
+					break;
+				}
+				default:
+					ASSERT(false);
+				}
+				while (!(reply << std::make_tuple(type, reqPtr, replyPtr))) {
+					// false means failed, need to resend
+				}
+				// fprintf(stderr, "Worker thread %s send the reply back\n", idstr.c_str());
+			}
+		}
+	}
+
+private:
+	ThreadFutureStream<std::pair<request_type, std::shared_ptr<void>>> req;
+	ThreadPromiseStream<std::tuple<request_type, std::shared_ptr<void>, std::shared_ptr<void>>> reply;
+	std::map<std::string, std::string> store;
+};
+
+struct MultiThreadedFDBInterface {
+	RequestStream<struct SetRequest> set;
+	RequestStream<struct GetRequest> get;
+	RequestStream<struct ClearRequest> clear;
+	MultiThreadedFDBInterface() { initialize(); }
+	MultiThreadedFDBInterface(NetworkAddress remote);
+	MultiThreadedFDBInterface(INetwork* local);
+
+	void initialize() {
+		req = ThreadPromiseStream<std::pair<request_type, std::shared_ptr<void>>>(10000);
+		ThreadPromiseStream<std::tuple<request_type, std::shared_ptr<void>, std::shared_ptr<void>>> replyPro(10000);
+		worker = workerThread(req.getFutureStream(), replyPro);
+		reply = replyPro.getFutureStream();
+	}
+
+    // worker thread to handle all request and give back replies to the network thread
+	workerThread worker;
+	// request queue where network thread will push a pointer to the coming request with its type to the queue
+    // worker thread then read from the queue and get the requests
+    // worker thread do its work and get the reply ready
+	ThreadPromiseStream<std::pair<request_type, std::shared_ptr<void>>> req;
+    // reply queue where worker thread sends all replies with its request and the type
+    // network thread will periodically read from the queue and send the reply back to clients
+	ThreadFutureStream<std::tuple<request_type, std::shared_ptr<void>, std::shared_ptr<void>>> reply;
+};
+
+Future<Void> multiThreadedFDBTestServer();
+
+Future<Void> multiThreadedFDBTestClient(std::string const& testServer);
+
+#endif

--- a/flow/CMakeLists.txt
+++ b/flow/CMakeLists.txt
@@ -85,6 +85,7 @@ set(FLOW_SRCS
   flow.h
   genericactors.actor.cpp
   genericactors.actor.h
+  multithread.h
   network.cpp
   network.h
   rte_memcpy.h

--- a/flow/multithread.h
+++ b/flow/multithread.h
@@ -1,0 +1,84 @@
+/*
+ * multithread.h
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FLOW_MULTITHREAD_H
+#define FLOW_MULTITHREAD_H
+
+#pragma once
+
+#include <cstdio>
+#include <memory>
+
+#include <vector>
+#include <queue>
+#include <map>
+#include <unordered_map>
+#include <set>
+#include <functional>
+#include <iostream>
+#include <string>
+#include <utility>
+#include <algorithm>
+
+#include "boost/lockfree/spsc_queue.hpp"
+#include "boost/lockfree/policies.hpp"
+
+template <class T>
+class ThreadFutureStream {
+public:
+	explicit ThreadFutureStream(std::shared_ptr<boost::lockfree::spsc_queue<T>> queue) : queue(queue) {}
+
+	ThreadFutureStream() : queue(nullptr) {}
+
+	// to get the message:
+	// message << stream  or stream >> message
+	template <typename Type>
+	friend bool operator>>(ThreadFutureStream<Type>& stream, Type& out);
+
+	template <typename Type>
+	friend bool operator<<(Type& out, ThreadFutureStream<Type>& stream);
+
+private:
+	std::shared_ptr<boost::lockfree::spsc_queue<T>> queue;
+};
+
+template <class T>
+class ThreadPromiseStream {
+public:
+	explicit ThreadPromiseStream(std::size_t capacity)
+	  : queue(std::make_shared<boost::lockfree::spsc_queue<T>>(capacity)) {}
+
+	ThreadPromiseStream() : queue(nullptr) {}
+
+	// to pass the message:
+	// message >> stream  or stream << message
+	template <typename Type>
+	friend bool operator<<(ThreadPromiseStream<Type>& stream, const Type& in);
+
+	template <typename Type>
+	friend bool operator>>(const Type& in, ThreadPromiseStream<Type>& stream);
+
+	ThreadFutureStream<T> getFutureStream() { return ThreadFutureStream<T>(queue); }
+
+private:
+	std::shared_ptr<boost::lockfree::spsc_queue<T>> queue;
+};
+
+#endif


### PR DESCRIPTION
A prototype to show how a multithreaded process(two for now) where we separate into a network thread and a worker thread

A simple test run
```
fdbserver -r multithreadedfdbserver -p 127.0.0.1:4000 (start the server process)
fdbserver -r multithreadedfdbclient --testservers 127.0.0.1:4000(start clients)
```

Added two new roles  `multithreadedfdbserver` and `multithreadedfdbclient` for testing. 
We have a server process with one network thread to communicate with clients and one worker thread to handle requests and generate replies.

There are two structures(_ThreadPromiseStream_  and _ThreadFutureStream_) that are used to communicate between threads.
The sender holds the _ThreadPromiseStream_ and the receiver holds the _ThreadFutureStream_.
As for our case, we have a one-producer/one-consumer case here, thus using the [boost::lockfree::spsc_queue](https://www.boost.org/doc/libs/1_54_0/doc/html/boost/lockfree/spsc_queue.html).
The `pop` and `push` are wait-free, which seems better than writing one with locks and condition variables.

The message flow:
- client sends a request to the server
- the network thread gets the request, wraps the request's pointer with its type, and sends it to the worker thread
- worker thread gets the pair, according to the type it casts the pointer to the request type.
- worker thread does its work and generates the reply
- worker thread wraps the pointer to the reply, the pointer to the request, type (three items) as a tuple and sends back to the network thread
- network thread gets the tuple and casts pointers according to the type and sends the reply back to clients

Discussion/follow-up lists:
- whether to use the locked-based thread-safe queue: may need some performance numbers to decide which is better
- size of the thread-safe queue (A knob for it, needs to find a good value)
- spsc_queue now does not have support for move semantic _pop_ and _push_, so I pass pointers between threads to avoid copy overhead. Maybe better solution here
- now the network thread periodically checks the reply queue to pop replies and send them back to clients. The frequency is manually set now in this test code, but it needs a better solution here.
- the worker thread is now implemented as a busy while loop, needs to improve

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
