### PR TITLE
Cherry pick #5237 to release-7.0:  Add VSCode workspace file pattern to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,6 +83,7 @@ ipch/
 compile_commands.json
 flow/actorcompiler/obj
 flow/coveragetool/obj
+*.code-workspace
 
 # IDE indexing (commonly used tools)
 /compile_commands.json


### PR DESCRIPTION
Cherry-pick of #5237
Add VSCode workspace file pattern to .gitignore.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
