### PR TITLE
Add new package_all_tests target

### DIFF
--- a/cmake/AddFdbTest.cmake
+++ b/cmake/AddFdbTest.cmake
@@ -14,6 +14,7 @@ function(configure_testing)
   set(multiValueArgs IGNORE_PATTERNS)
   cmake_parse_arguments(CONFIGURE_TESTING "${options}" "${oneValueArgs}" "${multiValueArgs}" "${ARGN}")
   set(no_tests YES)
+  add_custom_target(package_all_tests ALL)
   if(CONFIGURE_TESTING_ERROR_ON_ADDITIONAL_FILES)
     file(GLOB_RECURSE candidates "${CONFIGURE_TESTING_TEST_DIRECTORY}/*.txt")
     file(GLOB_RECURSE toml_candidates "${CONFIGURE_TESTING_TEST_DIRECTORY}/*.toml")
@@ -260,7 +261,7 @@ function(create_correctness_package)
     WORKING_DIRECTORY ${out_dir}
     COMMENT "Package correctness archive"
     )
-  add_custom_target(package_tests ALL DEPENDS ${tar_file})
+  add_custom_target(package_tests DEPENDS ${tar_file})
   add_dependencies(package_tests strip_only_fdbserver TestHarness)
   set(unversioned_tar_file "${CMAKE_BINARY_DIR}/packages/correctness.tar.gz")
   add_custom_command(
@@ -270,6 +271,7 @@ function(create_correctness_package)
     COMMENT "Copy correctness package to ${unversioned_tar_file}")
   add_custom_target(package_tests_u DEPENDS "${unversioned_tar_file}")
   add_dependencies(package_tests_u package_tests)
+  add_dependencies(package_all_tests package_tests_u)
 endfunction()
 
 function(create_valgrind_correctness_package)
@@ -295,7 +297,7 @@ function(create_valgrind_correctness_package)
       WORKING_DIRECTORY ${out_dir}
       COMMENT "Package valgrind correctness archive"
       )
-    add_custom_target(package_valgrind_tests ALL DEPENDS ${tar_file})
+    add_custom_target(package_valgrind_tests DEPENDS ${tar_file})
     add_dependencies(package_valgrind_tests strip_only_fdbserver TestHarness)
     set(unversioned_tar_file "${CMAKE_BINARY_DIR}/packages/valgrind.tar.gz")
     add_custom_command(
@@ -305,6 +307,7 @@ function(create_valgrind_correctness_package)
       COMMENT "Copy valgrind package to ${unversioned_tar_file}")
     add_custom_target(package_valgrind_tests_u DEPENDS "${unversioned_tar_file}")
     add_dependencies(package_valgrind_tests_u package_valgrind_tests)
+    add_dependencies(package_all_tests package_valgrind_tests_u)
   endif()
 endfunction()
 


### PR DESCRIPTION
For automation it is easier to have a target that builds all correctness packages that we currently have (correctness and, if applicable, valgrind).

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
