### PR TITLE
Fix exclude test and re-enable it in ctest

### DIFF
--- a/bindings/python/tests/fdbcli_tests.py
+++ b/bindings/python/tests/fdbcli_tests.py
@@ -382,7 +382,7 @@ def exclude(logger):
         logger.debug("Excluding process: {}".format(excluded_address))
         error_message = run_fdbcli_command_and_get_error('exclude', excluded_address)
         if error_message == 'WARNING: {} is a coordinator!'.format(excluded_address):
-            # exclude coordinator will fail, verify the randomly selected process is the coordinator
+            # exclude coordinator will print the warning, verify the randomly selected process is the coordinator
             coordinator_list = get_value_from_status_json(True, 'client', 'coordinators', 'coordinators')
             assert len(coordinator_list) == 1
             assert coordinator_list[0]['address'] == excluded_address

--- a/bindings/python/tests/fdbcli_tests.py
+++ b/bindings/python/tests/fdbcli_tests.py
@@ -381,12 +381,19 @@ def exclude(logger):
     while True:
         logger.debug("Excluding process: {}".format(excluded_address))
         error_message = run_fdbcli_command_and_get_error('exclude', excluded_address)
-        if not error_message:
+        if error_message == 'WARNING: {} is a coordinator!'.format(excluded_address):
+            # exclude coordinator will fail, verify the randomly selected process is the coordinator
+            coordinator_list = get_value_from_status_json(True, 'client', 'coordinators', 'coordinators')
+            assert len(coordinator_list) == 1
+            assert coordinator_list[0]['address'] == excluded_address
             break
+        elif not error_message:
+            break
+        else:
+            logger.debug("Error message: {}\n".format(error_message))
         logger.debug("Retry exclude after 1 second")
         time.sleep(1)
     output2 = run_fdbcli_command('exclude')
-    # logger.debug(output3)
     assert 'There are currently 1 servers or localities being excluded from the database' in output2
     assert excluded_address in output2
     run_fdbcli_command('include', excluded_address)
@@ -416,6 +423,6 @@ if __name__ == '__main__':
     else:
         assert process_number > 1, "Process number should be positive"
         coordinators()
-        # exclude()
+        exclude()
 
     


### PR DESCRIPTION
The original test did not catch the warnings when a coordinator is excluded.
The pr fixed it and reenable the test.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
