### PR TITLE
Revert "added median and 99.9 percentile latency measurement"

### DIFF
--- a/bindings/c/test/mako/mako.h
+++ b/bindings/c/test/mako/mako.h
@@ -32,8 +32,6 @@
 #define FDB_ERROR_ABORT -2
 #define FDB_ERROR_CONFLICT -3
 
-#define INIT_STORE 0
-
 /* transaction specification */
 enum Operations {
 	OP_GETREADVERSION,
@@ -134,7 +132,6 @@ typedef struct {
 	int signal;
 	int readycount;
 	double throttle_factor;
-	int stopcount;
 } mako_shmhdr_t;
 
 typedef struct {
@@ -159,8 +156,6 @@ typedef struct {
 /* args for threads */
 typedef struct {
 	int thread_id;
-	int elem_size[MAX_OP];
-	uint64_t* data[MAX_OP];
 	process_info_t* process;
 } thread_args_t;
 

--- a/bindings/c/test/mako/utils.c
+++ b/bindings/c/test/mako/utils.c
@@ -4,8 +4,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-
-
 /* uniform-distribution random */
 int urand(int low, int high) {
 	double r = rand() / (1.0 + RAND_MAX);
@@ -78,45 +76,4 @@ void genkey(char* str, int num, int rows, int len) {
 		str[i] = 'x';
 	}
 	str[len - 1] = '\0';
-}
-
-
-uint64_t getMax(uint64_t arr[], int n) 
-{ 
-    uint64_t mx = arr[0]; 
-    for (int i = 1; i < n; i++) 
-        if (arr[i] > mx) 
-            mx = arr[i]; 
-    return mx; 
-}
-
-void countSort(uint64_t arr[], int n, uint64_t exp) 
-{ 
-    uint64_t output[n]; 
-    int i, count[10] = {0}; 
-  
-    for (i = 0; i < n; i++) 
-        count[ (arr[i]/exp)%10 ]++; 
-  
-    for (i = 1; i < 10; i++) 
-        count[i] += count[i - 1]; 
-  
-    for (i = n - 1; i >= 0; i--) 
-    { 
-        output[count[ (arr[i]/exp)%10 ] - 1] = arr[i]; 
-        count[ (arr[i]/exp)%10 ]--; 
-    } 
-    for (i = 0; i < n; i++) 
-        arr[i] = output[i]; 
-} 
-
-
-
-// The main function to that sorts arr[] of size n using  
-// Radix Sort 
-void radix_sort(uint64_t arr[], int n)  { 
-    // Find the maximum number to know number of digits 
-    uint64_t m = getMax(arr, n); 
-    for (uint64_t exp = 1; m/exp > 0; exp *= 10) 
-        countSort(arr, n, exp); 
 }

--- a/bindings/c/test/mako/utils.h
+++ b/bindings/c/test/mako/utils.h
@@ -2,8 +2,6 @@
 #define UTILS_H
 #pragma once
 
-#include <stdint.h>
-
 /* uniform-distribution random */
 /* return a uniform random number between low and high, both inclusive */
 int urand(int low, int high);
@@ -49,12 +47,5 @@ int digits(int num);
 /* generate a key for a given key number */
 /* len is the buffer size, key length + null */
 void genkey(char* str, int num, int rows, int len);
-
-
-// The main function to that sorts arr[] of size n using  
-// Radix Sort 
-void radix_sort(uint64_t arr[], int n);
-void countSort(uint64_t arr[], int n, uint64_t exp) ;
-uint64_t getMax(uint64_t arr[], int n) ;
 
 #endif /* UTILS_H */


### PR DESCRIPTION
This reverts commit 6e97e8e30e4a054d99928e60d05087cae6e8d735.

Unfortunately there are a few issues with mako that need to be resolved. E.g.

```*** Error in `mako': double free or corruption (top): 0x0000000000bbaf00 ***```

Reverting this backport for now. I will work on a fix and make another attempt later.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
