### PR TITLE
Make FdbCApi functions private and add [[nodiscard]] wrappers

### DIFF
--- a/fdbclient/MultiVersionAssignmentVars.h
+++ b/fdbclient/MultiVersionAssignmentVars.h
@@ -130,7 +130,10 @@ public:
 	                            std::function<T(FdbCApi::FDBFuture*, FdbCApi*)> extractValue)
 	  : api(api), f(f), extractValue(extractValue), futureRefCount(1) {
 		ThreadSingleAssignmentVar<T>::addref();
-		api->futureSetCallback(f, &futureCallback, this);
+		FdbCApi::fdb_error_t e = api->futureSetCallback(f, &futureCallback, this);
+		if (e) {
+			throw Error(e);
+		}
 	}
 
 	~DLThreadSingleAssignmentVar() override {

--- a/fdbclient/MultiVersionTransaction.actor.cpp
+++ b/fdbclient/MultiVersionTransaction.actor.cpp
@@ -550,7 +550,8 @@ Reference<IDatabase> DLApi::createDatabase609(const char* clusterFilePath) {
 
 	auto clusterFuture = toThreadFuture<FdbCApi::FDBCluster*>(api, f, [](FdbCApi::FDBFuture* f, FdbCApi* api) {
 		FdbCApi::FDBCluster* cluster;
-		throwIfError(api->futureGetCluster(f, &cluster));
+		auto err = api->futureGetCluster(f, &cluster);
+		ASSERT(!err);
 		return cluster;
 	});
 

--- a/fdbclient/MultiVersionTransaction.actor.cpp
+++ b/fdbclient/MultiVersionTransaction.actor.cpp
@@ -177,7 +177,6 @@ ThreadFuture<Standalone<StringRef>> DLTransaction::getVersionstamp() {
 ThreadFuture<int64_t> DLTransaction::getEstimatedRangeSizeBytes(const KeyRangeRef& keys) {
 	FdbCApi::FDBFuture* f;
 	try {
-
 		f = api->transactionGetEstimatedRangeSizeBytes(
 		    tr, keys.begin.begin(), keys.begin.size(), keys.end.begin(), keys.end.size());
 	} catch (Error& e) {

--- a/fdbclient/MultiVersionTransaction.actor.cpp
+++ b/fdbclient/MultiVersionTransaction.actor.cpp
@@ -565,7 +565,8 @@ Reference<IDatabase> DLApi::createDatabase609(const char* clusterFilePath) {
 		                                              innerApi->clusterCreateDatabase(cluster.get(), (uint8_t*)"DB", 2),
 		                                              [](FdbCApi::FDBFuture* f, FdbCApi* api) {
 			                                              FdbCApi::FDBDatabase* db;
-			                                              throwIfError(api->futureGetDatabase(f, &db));
+			                                              auto err = (api->futureGetDatabase(f, &db));
+			                                              ASSERT(!err);
 			                                              return db;
 		                                              });
 

--- a/fdbclient/MultiVersionTransaction.actor.cpp
+++ b/fdbclient/MultiVersionTransaction.actor.cpp
@@ -195,7 +195,6 @@ ThreadFuture<Standalone<VectorRef<KeyRef>>> DLTransaction::getRangeSplitPoints(c
                                                                                int64_t chunkSize) {
 	FdbCApi::FDBFuture* f;
 	try {
-
 		f = api->transactionGetRangeSplitPoints(
 		    tr, range.begin.begin(), range.begin.size(), range.end.begin(), range.end.size(), chunkSize);
 	} catch (Error& e) {

--- a/fdbclient/MultiVersionTransaction.actor.cpp
+++ b/fdbclient/MultiVersionTransaction.actor.cpp
@@ -363,7 +363,7 @@ ThreadFuture<Void> DLDatabase::createSnapshot(const StringRef& uid, const String
 
 // Get network thread busyness
 double DLDatabase::getMainThreadBusyness() {
-	return 0;
+	return api->databaseGetMainThreadBusyness(db);
 }
 
 // Returns the protocol version reported by the coordinator this client is connected to

--- a/fdbclient/MultiVersionTransaction.actor.cpp
+++ b/fdbclient/MultiVersionTransaction.actor.cpp
@@ -565,7 +565,7 @@ Reference<IDatabase> DLApi::createDatabase609(const char* clusterFilePath) {
 		                                              innerApi->clusterCreateDatabase(cluster.get(), (uint8_t*)"DB", 2),
 		                                              [](FdbCApi::FDBFuture* f, FdbCApi* api) {
 			                                              FdbCApi::FDBDatabase* db;
-			                                              auto err = (api->futureGetDatabase(f, &db));
+			                                              auto err = api->futureGetDatabase(f, &db);
 			                                              ASSERT(!err);
 			                                              return db;
 		                                              });


### PR DESCRIPTION
We recently had a bug where the result of an FdbCApi function was
incorrectly discarded. We can't make function pointers [[nodiscard]], so
instead we'll wrap them in functions and make them private.

This change also fixes the ensuing [[nodiscard]] warnings, and moves
existing checks for whether or not the function pointer is set inside
the new wrapper functions.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
