### PR TITLE
use version vector in GetRange

### DIFF
--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -3301,6 +3301,8 @@ ACTOR Future<RangeResult> getRange(Database cx,
 			req.isFetchKeys = (info.taskID == TaskPriority::FetchKeys);
 			req.version = readVersion;
 
+                        cx->getLatestCommitVersions(beginServer.second, version, req.ssLatestCommitVersions);
+
 			// In case of async tss comparison, also make req arena depend on begin, end, and/or shard's arena depending
 			// on which  is used
 			bool dependOnShard = false;

--- a/fdbclient/VersionVector.h
+++ b/fdbclient/VersionVector.h
@@ -121,6 +121,15 @@ struct VersionVector {
 			setVersion(tags, version);
 		}
 	}
+	std::string toString() const {
+		std::stringstream vector;
+		vector << "[";
+		for (const auto& [tag, version] : versions) {
+			vector << '{' << tag.toString() << "," << version << '}';
+		}
+		vector << " maxversion: " << maxVersion << "]";
+		return vector.str();
+	}
 
 	bool operator==(const VersionVector& vv) const { return maxVersion == vv.maxVersion; }
 	bool operator!=(const VersionVector& vv) const { return maxVersion != vv.maxVersion; }

--- a/fdbserver/CommitProxyServer.actor.cpp
+++ b/fdbserver/CommitProxyServer.actor.cpp
@@ -1313,8 +1313,7 @@ ACTOR Future<Void> reply(CommitBatchContext* self) {
 	// self->committedVersion by reporting commit version first before updating self->committedVersion. Otherwise, a
 	// client may get a commit version that the master is not aware of, and next GRV request may get a version less than
 	// self->committedVersion.
-	TEST(pProxyCommitData->committedVersion.get() >
-	     self->commitVersion); // A later version was reported committed first
+	TEST(pProxyCommitData->committedVersion.get() >  self->commitVersion); // A later version was reported committed first
 	if (self->commitVersion >= pProxyCommitData->committedVersion.get()) {
 		state Optional<std::set<Tag>> writtenTags;
 		if (SERVER_KNOBS->ENABLE_VERSION_VECTOR) {

--- a/fdbserver/masterserver.actor.cpp
+++ b/fdbserver/masterserver.actor.cpp
@@ -1230,7 +1230,7 @@ void updateLiveCommittedVersion(Reference<MasterData> self, ReportRawCommittedVe
 	self->minKnownCommittedVersion = std::max(self->minKnownCommittedVersion, req.minKnownCommittedVersion);
 	if (SERVER_KNOBS->ENABLE_VERSION_VECTOR && req.writtenTags.present()) {
 		// TraceEvent("Received ReportRawCommittedVersionRequest").detail("Version",req.version);
-		self->ssVersionVector.setVersions(req.writtenTags.get(), req.version);
+		self->ssVersionVector.setVersion(req.writtenTags.get(), req.version);
 	}
 	if (req.version > self->liveCommittedVersion.get()) {
 		self->databaseLocked = req.locked;


### PR DESCRIPTION
- use version vector in GetRange
- add toString in version vector
- two minor fixes preventing compilation

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
