### PR TITLE
Backported mako from master to release-6.3

### DIFF
--- a/bindings/c/test/mako/utils.c
+++ b/bindings/c/test/mako/utils.c
@@ -3,6 +3,7 @@
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 /* uniform-distribution random */
 int urand(int low, int high) {
@@ -67,13 +68,69 @@ int digits(int num) {
 }
 
 /* generate a key for a given key number */
+/* prefix is "mako" by default, prefixpadding = 1 means 'x' will be in front rather than trailing the keyname */
 /* len is the buffer size, key length + null */
-void genkey(char* str, int num, int rows, int len) {
-	int i;
-	int rowdigit = digits(rows);
-	sprintf(str, KEYPREFIX "%0.*d", rowdigit, num);
-	for (i = (KEYPREFIXLEN + rowdigit); i < len - 1; i++) {
-		str[i] = 'x';
+void genkey(char* str, char* prefix, int prefixlen, int prefixpadding, int num, int rows, int len) {
+        const int rowdigit = digits(rows);
+        const int prefixoffset = prefixpadding ? len - (prefixlen + rowdigit) - 1 : 0;
+        char* prefixstr = (char*)alloca(sizeof(char) * (prefixlen + rowdigit + 1));
+        snprintf(prefixstr, prefixlen + rowdigit + 1, "%s%0.*d", prefix, rowdigit, num);
+        memset(str, 'x', len);
+        memcpy(str + prefixoffset, prefixstr, prefixlen + rowdigit);
+        str[len - 1] = '\0';
+}
+
+/* This is another sorting algorithm used to calculate latency parameters */
+/* We moved from radix sort to quick sort to avoid extra space used in radix sort */
+
+#if 0
+uint64_t get_max(uint64_t arr[], int n) {
+	uint64_t mx = arr[0];
+	for (int i = 1; i < n; i++) {
+		if (arr[i] > mx) {
+			mx = arr[i];
+		}
 	}
-	str[len - 1] = '\0';
+	return mx;
+}
+
+void bucket_data(uint64_t arr[], int n, uint64_t exp) {
+	// uint64_t output[n];
+	int i, count[10] = { 0 };
+	uint64_t* output = (uint64_t*)malloc(sizeof(uint64_t) * n);
+
+	for (i = 0; i < n; i++) {
+		count[(arr[i] / exp) % 10]++;
+	}
+	for (i = 1; i < 10; i++) {
+		count[i] += count[i - 1];
+	}
+	for (i = n - 1; i >= 0; i--) {
+		output[count[(arr[i] / exp) % 10] - 1] = arr[i];
+		count[(arr[i] / exp) % 10]--;
+	}
+	for (i = 0; i < n; i++) {
+		arr[i] = output[i];
+	}
+	free(output);
+}
+
+// The main function is to sort arr[] of size n using Radix Sort
+void radix_sort(uint64_t* arr, int n) {
+	// Find the maximum number to know number of digits
+	uint64_t m = get_max(arr, n);
+	for (uint64_t exp = 1; m / exp > 0; exp *= 10) bucket_data(arr, n, exp);
+}
+#endif
+
+int compare(const void* a, const void* b) {
+	const uint64_t* da = (const uint64_t*)a;
+	const uint64_t* db = (const uint64_t*)b;
+
+	return (*da > *db) - (*da < *db);
+}
+
+// The main function is to sort arr[] of size n using Quick Sort
+void quick_sort(uint64_t* arr, int n) {
+	qsort(arr, n, sizeof(uint64_t), compare);
 }

--- a/bindings/c/test/mako/utils.h
+++ b/bindings/c/test/mako/utils.h
@@ -2,6 +2,8 @@
 #define UTILS_H
 #pragma once
 
+#include <stdint.h>
+
 /* uniform-distribution random */
 /* return a uniform random number between low and high, both inclusive */
 int urand(int low, int high);
@@ -45,7 +47,19 @@ int compute_thread_portion(int val, int p_idx, int t_idx, int total_p, int total
 int digits(int num);
 
 /* generate a key for a given key number */
+/* prefix is "mako" by default, prefixpadding = 1 means 'x' will be in front rather than trailing the keyname */
 /* len is the buffer size, key length + null */
-void genkey(char* str, int num, int rows, int len);
+void genkey(char* str, char* prefix, int prefixlen, int prefixpadding, int num, int rows, int len);
+
+#if 0
+// The main function is to sort arr[] of size n using Radix Sort
+void radix_sort(uint64_t arr[], int n);
+void bucket_data(uint64_t arr[], int n, uint64_t exp);
+uint64_t get_max(uint64_t arr[], int n);
+#endif
+
+// The main function is to sort arr[] of size n using Quick Sort
+void quick_sort(uint64_t arr[], int n);
+int compare(const void* a, const void* b);
 
 #endif /* UTILS_H */


### PR DESCRIPTION
This PR backports mako latency measurements from master to release-6.3 branch. This is so we'd have latency data for mako workloads with 6.3 clusters. 

This is a copy and paste of the current mako files in master branch. The only edit I made was to hard-code `FDB_API_VERSION=630` since this is for `release-6.3` branch.

**Test**
- I built and ran a performance test using mako and confirmed that latency stats are now there.

**How to Review?**
@sfc-gh-anoyes @sfc-gh-kmakino could you please double check that the current mako doesn't contain any incompatible changes to 6.3?

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
