### PR TITLE
Change how to wait for goodRecruitmentTime and populate default PEER_LATENCY_CHECK_MIN_POPULATION

### DIFF
--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -644,6 +644,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( DBINFO_FAILED_DELAY,                                   1.0 );
 	init( ENABLE_WORKER_HEALTH_MONITOR,                        false );
 	init( WORKER_HEALTH_MONITOR_INTERVAL,                       60.0 );
+	init( PEER_LATENCY_CHECK_MIN_POPULATION,                      30 );
 	init( PEER_LATENCY_DEGRADATION_PERCENTILE,                  0.90 );
 	init( PEER_LATENCY_DEGRADATION_THRESHOLD,                   0.05 );
 	init( PEER_TIMEOUT_PERCENTAGE_DEGRADATION_THRESHOLD,         0.1 );

--- a/fdbserver/ClusterController.actor.cpp
+++ b/fdbserver/ClusterController.actor.cpp
@@ -4722,7 +4722,7 @@ ACTOR Future<Void> workerHealthMonitor(ClusterControllerData* self) {
 	loop {
 		try {
 			while (!self->goodRecruitmentTime.isReady()) {
-				wait(self->goodRecruitmentTime);
+				wait(lowPriorityDelay(SERVER_KNOBS->CC_WORKER_HEALTH_CHECKING_INTERVAL));
 			}
 
 			self->degradedServers = self->getServersWithDegradedLink();


### PR DESCRIPTION
goodRecruitmentTime is initially set to Never() until the first worker joins the cluster controller.

If the workerHealthMonitor waits on goodRecruitmentTime, there is a race that it may wait for indefinitely.

100K joshua run 20210726-054823-zhe-5268-4d3060be5443cfd2: 20210726-054823-zhe-5268-4d3060be5443cfd2          compressed=True data_size=25963564 duration=5702933 ended=101264 fail=3 fail_fast=10 max_runs=100000 pass=99998 priority=100 remaining=0 runtime=0:59:23 sanity=False started=101324 stopped=20210726-064746 submitted=20210726-054823 timeout=5400 username=zhe-5268 (3 failures are out of memory)

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
