### PR TITLE
Fix flow build issues on Windows

### DIFF
--- a/flow/IThreadPoolTest.actor.cpp
+++ b/flow/IThreadPoolTest.actor.cpp
@@ -1,3 +1,6 @@
+// Thread naming only works on Linux.
+#if defined(__linux__)
+
 #include "flow/IThreadPool.h"
 
 #include <pthread.h>
@@ -5,9 +8,6 @@
 
 #include "flow/UnitTest.h"
 #include "flow/actorcompiler.h" // has to be last include
-
-// Thread naming only works on Linux.
-#if defined(__linux__)
 
 void forceLinkIThreadPoolTests() {}
 

--- a/flow/flat_buffers.h
+++ b/flow/flat_buffers.h
@@ -21,6 +21,7 @@
 #pragma once
 
 #include <algorithm>
+#include <iterator>
 #include <cstring>
 #include <functional>
 #include <map>


### PR DESCRIPTION
This PR fixes flow build issues on Windows :
- flow/IThreadPoolTest.actor.cpp : needs to include <iterator> (which included by another dependency on Linux)
- flow/flat_buffers.h : pthread.h is not under linux section

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
