### PR TITLE
Do not partially reset a transaction when it is committed or fails to commit with an error

### DIFF
--- a/bindings/c/test/unit/unit_tests.cpp
+++ b/bindings/c/test/unit/unit_tests.cpp
@@ -2177,6 +2177,81 @@ TEST_CASE("monitor_network_busyness") {
 	CHECK(containsGreaterZero);
 }
 
+// Commit a transaction and confirm it has not been reset
+TEST_CASE("commit_does_not_reset") {
+	fdb::Transaction tr(db);
+	fdb::Transaction tr2(db);
+
+	// Commit two transactions, one that will fail with conflict and the other
+	// that will succeed. Ensure both transactions are not reset at the end.
+	while (1) {
+		fdb::Int64Future tr1GrvFuture = tr.get_read_version();
+		fdb_error_t err = wait_future(tr1GrvFuture);
+		if (err) {
+			fdb::EmptyFuture tr1OnErrorFuture = tr.on_error(err);
+			fdb_check(wait_future(tr1OnErrorFuture));
+			continue;
+		}
+
+		int64_t tr1StartVersion;
+		CHECK(!tr1GrvFuture.get(&tr1StartVersion));
+
+		fdb::Int64Future tr2GrvFuture = tr2.get_read_version();
+		err = wait_future(tr2GrvFuture);
+
+		if (err) {
+			fdb::EmptyFuture tr2OnErrorFuture = tr2.on_error(err);
+			fdb_check(wait_future(tr2OnErrorFuture));
+			continue;
+		}
+
+		int64_t tr2StartVersion;
+		CHECK(!tr2GrvFuture.get(&tr2StartVersion));
+
+		tr.set(key("foo"), "bar");
+		fdb::EmptyFuture tr1CommitFuture = tr.commit();
+		err = wait_future(tr1CommitFuture);
+		if (err) {
+			fdb::EmptyFuture tr1OnErrorFuture = tr.on_error(err);
+			fdb_check(wait_future(tr1OnErrorFuture));
+			continue;
+		}
+
+		fdb_check(tr2.add_conflict_range(key("foo"), strinc(key("foo")), FDB_CONFLICT_RANGE_TYPE_READ));
+		tr2.set(key("foo"), "bar");
+		fdb::EmptyFuture tr2CommitFuture = tr2.commit();
+		err = wait_future(tr2CommitFuture);
+		CHECK(err == 1020); // not_committed
+
+		fdb::Int64Future tr1GrvFuture2 = tr.get_read_version();
+		err = wait_future(tr1GrvFuture2);
+		if (err) {
+			fdb::EmptyFuture tr1OnErrorFuture = tr.on_error(err);
+			fdb_check(wait_future(tr1OnErrorFuture));
+			continue;
+		}
+
+		int64_t tr1EndVersion;
+		CHECK(!tr1GrvFuture2.get(&tr1EndVersion));
+
+		fdb::Int64Future tr2GrvFuture2 = tr2.get_read_version();
+		err = wait_future(tr2GrvFuture2);
+		if (err) {
+			fdb::EmptyFuture tr2OnErrorFuture = tr2.on_error(err);
+			fdb_check(wait_future(tr2OnErrorFuture));
+			continue;
+		}
+
+		int64_t tr2EndVersion;
+		CHECK(!tr2GrvFuture2.get(&tr2EndVersion));
+
+		// If we reset the transaction, then the read version will change
+		CHECK(tr1StartVersion == tr1EndVersion);
+		CHECK(tr2StartVersion == tr2EndVersion);
+		break;
+	}
+}
+
 int main(int argc, char** argv) {
 	if (argc < 3) {
 		std::cout << "Unit tests for the FoundationDB C API.\n"

--- a/documentation/sphinx/source/api-version-upgrade-guide.rst
+++ b/documentation/sphinx/source/api-version-upgrade-guide.rst
@@ -25,6 +25,8 @@ API version 700
 General
 -------
 
+* Committing a transaction will no longer partially reset it. In particular, getting the read version from a transaction that has committed or failed to commit with an error will return the original read version.
+
 Python bindings
 ---------------
 

--- a/documentation/sphinx/source/release-notes/release-notes-700.rst
+++ b/documentation/sphinx/source/release-notes/release-notes-700.rst
@@ -91,6 +91,7 @@ Other Changes
 * The ``foundationdb`` service installed by the RPM packages will now automatically restart ``fdbmonitor`` after 60 seconds when it fails. `(PR #3841) <https://github.com/apple/foundationdb/pull/3841>`_
 * Capture output of forked snapshot processes in trace events. `(PR #4254) <https://github.com/apple/foundationdb/pull/4254/files>`_
 * Add ErrorKind field to Severity 40 trace events. `(PR #4741) <https://github.com/apple/foundationdb/pull/4741/files>`_
+* Committing a transaction will no longer partially reset it as of API version 700. `(PR #) <https://github.com/apple/foundationdb/pull//files>`_
 
 Earlier release notes
 ---------------------

--- a/documentation/sphinx/source/release-notes/release-notes-700.rst
+++ b/documentation/sphinx/source/release-notes/release-notes-700.rst
@@ -91,7 +91,7 @@ Other Changes
 * The ``foundationdb`` service installed by the RPM packages will now automatically restart ``fdbmonitor`` after 60 seconds when it fails. `(PR #3841) <https://github.com/apple/foundationdb/pull/3841>`_
 * Capture output of forked snapshot processes in trace events. `(PR #4254) <https://github.com/apple/foundationdb/pull/4254/files>`_
 * Add ErrorKind field to Severity 40 trace events. `(PR #4741) <https://github.com/apple/foundationdb/pull/4741/files>`_
-* Committing a transaction will no longer partially reset it as of API version 700. `(PR #) <https://github.com/apple/foundationdb/pull//files>`_
+* Committing a transaction will no longer partially reset it as of API version 700. `(PR #5271) <https://github.com/apple/foundationdb/pull/5271/files>`_
 
 Earlier release notes
 ---------------------

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -5244,7 +5244,10 @@ ACTOR Future<Void> commitAndWatch(Transaction* self) {
 			self->setupWatches();
 		}
 
-		self->reset();
+		if (!self->apiVersionAtLeast(700)) {
+			self->reset();
+		}
+
 		return Void();
 	} catch (Error& e) {
 		if (e.code() != error_code_actor_cancelled) {
@@ -5253,7 +5256,10 @@ ACTOR Future<Void> commitAndWatch(Transaction* self) {
 			}
 
 			self->versionstampPromise.sendError(transaction_invalid_version());
-			self->reset();
+
+			if (!self->apiVersionAtLeast(700)) {
+				self->reset();
+			}
 		}
 
 		throw;

--- a/fdbserver/ClusterController.actor.cpp
+++ b/fdbserver/ClusterController.actor.cpp
@@ -195,6 +195,8 @@ public:
 			}
 
 			loop {
+				tr.reset();
+
 				// Wait for some changes
 				while (!self->anyDelta.get())
 					wait(self->anyDelta.onChange());

--- a/fdbserver/StorageCache.actor.cpp
+++ b/fdbserver/StorageCache.actor.cpp
@@ -2156,6 +2156,7 @@ ACTOR Future<Void> watchInterface(StorageCacheData* self, StorageServerInterface
 					tr.set(storageKey, storageCacheServerValue(ssi));
 					wait(tr.commit());
 				}
+				tr.reset();
 				break;
 			} catch (Error& e) {
 				wait(tr.onError(e));

--- a/fdbserver/workloads/CommitBugCheck.actor.cpp
+++ b/fdbserver/workloads/CommitBugCheck.actor.cpp
@@ -45,6 +45,7 @@ struct CommitBugWorkload : TestWorkload {
 				try {
 					tr.set(key, val1);
 					wait(tr.commit());
+					tr.reset();
 					break;
 				} catch (Error& e) {
 					TraceEvent("CommitBugSetVal1Error").error(e);
@@ -57,6 +58,7 @@ struct CommitBugWorkload : TestWorkload {
 				try {
 					tr.set(key, val2);
 					wait(tr.commit());
+					tr.reset();
 					break;
 				} catch (Error& e) {
 					TraceEvent("CommitBugSetVal2Error").error(e);
@@ -85,6 +87,7 @@ struct CommitBugWorkload : TestWorkload {
 				try {
 					tr.clear(key);
 					wait(tr.commit());
+					tr.reset();
 					break;
 				} catch (Error& e) {
 					TraceEvent("CommitBugClearValError").error(e);

--- a/fdbserver/workloads/DifferentClustersSameRV.actor.cpp
+++ b/fdbserver/workloads/DifferentClustersSameRV.actor.cpp
@@ -191,6 +191,7 @@ struct DifferentClustersSameRVWorkload : TestWorkload {
 				serializer(w, x);
 				tr.set(self->keyToRead, w.toValue());
 				wait(tr.commit());
+				tr.reset();
 			} catch (Error& e) {
 				wait(tr.onError(e));
 			}

--- a/fdbserver/workloads/RandomSelector.actor.cpp
+++ b/fdbserver/workloads/RandomSelector.actor.cpp
@@ -125,6 +125,7 @@ struct RandomSelectorWorkload : TestWorkload {
 						//TraceEvent("RYOWInit").detail("Key",myKeyA).detail("Value",myValue);
 					}
 					wait(tr.commit());
+					tr.reset();
 					break;
 				} catch (Error& e) {
 					wait(tr.onError(e));
@@ -149,6 +150,7 @@ struct RandomSelectorWorkload : TestWorkload {
 							try {
 								tr.set(StringRef(clientID + "d/" + myKeyA), myValue);
 								wait(tr.commit());
+								tr.reset();
 								break;
 							} catch (Error& e) {
 								wait(tr.onError(e));
@@ -163,6 +165,7 @@ struct RandomSelectorWorkload : TestWorkload {
 							try {
 								tr.clear(StringRef(clientID + "d/" + myKeyA));
 								wait(tr.commit());
+								tr.reset();
 								break;
 							} catch (Error& e) {
 								wait(tr.onError(e));
@@ -184,6 +187,7 @@ struct RandomSelectorWorkload : TestWorkload {
 								tr.clear(KeyRangeRef(StringRef(clientID + "d/" + myKeyA),
 								                     StringRef(clientID + "d/" + myKeyB)));
 								wait(tr.commit());
+								tr.reset();
 								break;
 							} catch (Error& e) {
 								wait(tr.onError(e));
@@ -231,6 +235,7 @@ struct RandomSelectorWorkload : TestWorkload {
 								tr.set(StringRef(clientID + "z/" + myRandomIDKey), StringRef());
 								tr.atomicOp(StringRef(clientID + "d/" + myKeyA), myValue, MutationRef::AddValue);
 								wait(tr.commit());
+								tr.reset();
 								break;
 							} catch (Error& e) {
 								error = e;
@@ -254,6 +259,7 @@ struct RandomSelectorWorkload : TestWorkload {
 								tr.set(StringRef(clientID + "z/" + myRandomIDKey), StringRef());
 								tr.atomicOp(StringRef(clientID + "d/" + myKeyA), myValue, MutationRef::AppendIfFits);
 								wait(tr.commit());
+								tr.reset();
 								break;
 							} catch (Error& e) {
 								error = e;
@@ -277,6 +283,7 @@ struct RandomSelectorWorkload : TestWorkload {
 								tr.set(StringRef(clientID + "z/" + myRandomIDKey), StringRef());
 								tr.atomicOp(StringRef(clientID + "d/" + myKeyA), myValue, MutationRef::And);
 								wait(tr.commit());
+								tr.reset();
 								break;
 							} catch (Error& e) {
 								error = e;
@@ -300,6 +307,7 @@ struct RandomSelectorWorkload : TestWorkload {
 								tr.set(StringRef(clientID + "z/" + myRandomIDKey), StringRef());
 								tr.atomicOp(StringRef(clientID + "d/" + myKeyA), myValue, MutationRef::Or);
 								wait(tr.commit());
+								tr.reset();
 								break;
 							} catch (Error& e) {
 								error = e;
@@ -323,6 +331,7 @@ struct RandomSelectorWorkload : TestWorkload {
 								tr.set(StringRef(clientID + "z/" + myRandomIDKey), StringRef());
 								tr.atomicOp(StringRef(clientID + "d/" + myKeyA), myValue, MutationRef::Xor);
 								wait(tr.commit());
+								tr.reset();
 								break;
 							} catch (Error& e) {
 								error = e;
@@ -346,6 +355,7 @@ struct RandomSelectorWorkload : TestWorkload {
 								tr.set(StringRef(clientID + "z/" + myRandomIDKey), StringRef());
 								tr.atomicOp(StringRef(clientID + "d/" + myKeyA), myValue, MutationRef::Max);
 								wait(tr.commit());
+								tr.reset();
 								break;
 							} catch (Error& e) {
 								error = e;
@@ -369,6 +379,7 @@ struct RandomSelectorWorkload : TestWorkload {
 								tr.set(StringRef(clientID + "z/" + myRandomIDKey), StringRef());
 								tr.atomicOp(StringRef(clientID + "d/" + myKeyA), myValue, MutationRef::Min);
 								wait(tr.commit());
+								tr.reset();
 								break;
 							} catch (Error& e) {
 								error = e;
@@ -392,6 +403,7 @@ struct RandomSelectorWorkload : TestWorkload {
 								tr.set(StringRef(clientID + "z/" + myRandomIDKey), StringRef());
 								tr.atomicOp(StringRef(clientID + "d/" + myKeyA), myValue, MutationRef::ByteMin);
 								wait(tr.commit());
+								tr.reset();
 								break;
 							} catch (Error& e) {
 								error = e;
@@ -415,6 +427,7 @@ struct RandomSelectorWorkload : TestWorkload {
 								tr.set(StringRef(clientID + "z/" + myRandomIDKey), StringRef());
 								tr.atomicOp(StringRef(clientID + "d/" + myKeyA), myValue, MutationRef::ByteMax);
 								wait(tr.commit());
+								tr.reset();
 								break;
 							} catch (Error& e) {
 								error = e;

--- a/fdbserver/workloads/SpecialKeySpaceCorrectness.actor.cpp
+++ b/fdbserver/workloads/SpecialKeySpaceCorrectness.actor.cpp
@@ -783,6 +783,7 @@ struct SpecialKeySpaceCorrectnessWorkload : TestWorkload {
 					    Value(worker.processClass.toString())); // Set it as the same class type as before, thus only
 					                                            // class source will be changed
 					wait(tx->commit());
+					tx->reset();
 					Optional<Value> class_source = wait(tx->get(
 					    Key("process/class_source/" + address)
 					        .withPrefix(

--- a/fdbserver/workloads/StatusWorkload.actor.cpp
+++ b/fdbserver/workloads/StatusWorkload.actor.cpp
@@ -153,6 +153,7 @@ struct StatusWorkload : TestWorkload {
 
 					tr.set(latencyBandConfigKey, ValueRef(config));
 					wait(tr.commit());
+					tr.reset();
 
 					if (deterministicRandom()->random01() < 0.3) {
 						return Void();


### PR DESCRIPTION
Long ago (API version 4XX), the API was changed so that a transaction would not be reset when it was committed. This change was not fully made however, and so the transaction would be reset in NativeAPI but not ReadYourWrites. The main implication of this seems to be that trying to access the read version after commit would return a new read version rather than the original one, but the transaction could not be used to read any keys or commit outside of the special key-space.

This change makes it so that commit does not reset the transaction in NativeAPI either. It is guarded by API version 700. It also changes many internal usages of NativeAPI transactions to reset after committing if the transaction is reused.

Tested by adding a new unit test to fdb_c_unit_tests. Passed 10K correctness.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.
