### PR TITLE
Version vector prototype: Tweak the logic that populates CommitBatchContext::written_tags

### DIFF
--- a/fdbclient/FDBTypes.h
+++ b/fdbclient/FDBTypes.h
@@ -74,7 +74,7 @@ struct Tag {
 
 	int toTagDataIndex() const { return locality >= 0 ? 2 * locality : 1 - (2 * locality); }
 
-	bool isPseudoTag() const { return locality < 0; }
+	bool isNonPrimaryTLogType() const { return locality < 0; }
 
 	std::string toString() const { return format("%d:%d", locality, id); }
 

--- a/fdbclient/FDBTypes.h
+++ b/fdbclient/FDBTypes.h
@@ -74,6 +74,8 @@ struct Tag {
 
 	int toTagDataIndex() const { return locality >= 0 ? 2 * locality : 1 - (2 * locality); }
 
+	bool isPseudoTag() const { return locality < 0; }
+
 	std::string toString() const { return format("%d:%d", locality, id); }
 
 	template <class Ar>

--- a/fdbserver/CommitProxyServer.actor.cpp
+++ b/fdbserver/CommitProxyServer.actor.cpp
@@ -965,7 +965,6 @@ ACTOR Future<Void> assignMutationsToStorageServers(CommitBatchContext* self) {
 				if (pProxyCommitData->cacheInfo[m.param1]) {
 					self->toCommit.addTag(cacheTag);
 				}
-				self->toCommit.saveTags(self->writtenTags);
 				self->toCommit.writeTypedMessage(m);
 				self->toCommit.saveLocations(self->writtenTLogs);
 			} else if (m.type == MutationRef::ClearRange) {
@@ -1023,7 +1022,6 @@ ACTOR Future<Void> assignMutationsToStorageServers(CommitBatchContext* self) {
 				if (pProxyCommitData->needsCacheTag(clearRange)) {
 					self->toCommit.addTag(cacheTag);
 				}
-				self->toCommit.saveTags(self->writtenTags);
 				self->toCommit.writeTypedMessage(m);
 				self->toCommit.saveLocations(self->writtenTLogs);
 			} else {
@@ -1212,6 +1210,7 @@ ACTOR Future<Void> postResolution(CommitBatchContext* self) {
 	if (SERVER_KNOBS->ENABLE_VERSION_VECTOR) {
 		tpcvMap = self->tpcvMap;
 	}
+	self->toCommit.saveTags(self->writtenTags);
 	self->loggingComplete = pProxyCommitData->logSystem->push(self->prevVersion,
 	                                                          self->commitVersion,
 	                                                          pProxyCommitData->committedVersion.get(),

--- a/fdbserver/CommitProxyServer.actor.cpp
+++ b/fdbserver/CommitProxyServer.actor.cpp
@@ -1113,6 +1113,8 @@ ACTOR Future<Void> postResolution(CommitBatchContext* self) {
 	// Second pass
 	wait(assignMutationsToStorageServers(self));
 
+	self->toCommit.saveTags(self->writtenTags);
+
 	// Obtain previous committed versions for each affected tlog from sequencer
 	if (SERVER_KNOBS->ENABLE_VERSION_VECTOR) {
 		wait(getTPCV(self));
@@ -1210,7 +1212,6 @@ ACTOR Future<Void> postResolution(CommitBatchContext* self) {
 	if (SERVER_KNOBS->ENABLE_VERSION_VECTOR) {
 		tpcvMap = self->tpcvMap;
 	}
-	self->toCommit.saveTags(self->writtenTags);
 	self->loggingComplete = pProxyCommitData->logSystem->push(self->prevVersion,
 	                                                          self->commitVersion,
 	                                                          pProxyCommitData->committedVersion.get(),

--- a/fdbserver/LogSystem.h
+++ b/fdbserver/LogSystem.h
@@ -996,7 +996,7 @@ struct LogPushData : NonCopyable {
 		writtenLocations.clear();
 	}
 
-	// copy next_message_tags into given set
+	// copy written_tags into given set
 	void saveTags(std::set<Tag>& writtenTags, bool filterPseudoTags = true) {
 		for (auto& tag : written_tags) {
 			if (!filterPseudoTags || !tag.isPseudoTag()) {

--- a/fdbserver/LogSystem.h
+++ b/fdbserver/LogSystem.h
@@ -996,11 +996,11 @@ struct LogPushData : NonCopyable {
 		writtenLocations.clear();
 	}
 
-	// copy written_tags into given set
-	void saveTags(std::set<Tag>& writtenTags, bool filterPseudoTags = true) {
-		for (auto& tag : written_tags) {
-			if (!filterPseudoTags || !tag.isPseudoTag()) {
-				writtenTags.insert(tag);
+	// copy written_tags, after filtering, into given set
+	void saveTags(std::set<Tag>& filteredTags) const {
+		for (const auto& tag : written_tags) {
+			if (!tag.isNonPrimaryTLogType()) {
+				filteredTags.insert(tag);
 			}
 		}
 	}
@@ -1021,7 +1021,7 @@ struct LogPushData : NonCopyable {
 			}
 			msg_locations.clear();
 			logSystem->getPushLocations(prev_tags, msg_locations);
-			written_tags.insert(written_tags.end(), next_message_tags.begin(), next_message_tags.end());
+			written_tags.insert(next_message_tags.begin(), next_message_tags.end());
 			next_message_tags.clear();
 		}
 		uint32_t subseq = this->subsequence++;
@@ -1100,7 +1100,7 @@ struct LogPushData : NonCopyable {
 				wr.serializeBytes((uint8_t*)from.getData() + firstOffset, firstLength);
 			}
 		}
-		written_tags.insert(written_tags.end(), next_message_tags.begin(), next_message_tags.end());
+		written_tags.insert(next_message_tags.begin(), next_message_tags.end());
 		next_message_tags.clear();
 	}
 
@@ -1110,7 +1110,7 @@ private:
 	Reference<ILogSystem> logSystem;
 	std::vector<Tag> next_message_tags;
 	std::vector<Tag> prev_tags;
-	std::vector<Tag> written_tags;
+	std::set<Tag> written_tags;
 	std::vector<BinaryWriter> messagesWriter;
 	std::vector<int> msg_locations;
 	// Stores message locations that have had span information written to them

--- a/fdbserver/LogSystem.h
+++ b/fdbserver/LogSystem.h
@@ -997,8 +997,12 @@ struct LogPushData : NonCopyable {
 	}
 
 	// copy next_message_tags into given set
-	void saveTags(std::set<Tag>& writtenTags) {
-		writtenTags.insert(next_message_tags.begin(), next_message_tags.end());
+	void saveTags(std::set<Tag>& writtenTags, bool filterPseudoTags = true) {
+		for (auto& tag : written_tags) {
+			if (!filterPseudoTags || !tag.isPseudoTag()) {
+				writtenTags.insert(tag);
+			}
+		}
 	}
 
 	// store tlogs as represented by index
@@ -1017,6 +1021,7 @@ struct LogPushData : NonCopyable {
 			}
 			msg_locations.clear();
 			logSystem->getPushLocations(prev_tags, msg_locations);
+			written_tags.insert(written_tags.end(), next_message_tags.begin(), next_message_tags.end());
 			next_message_tags.clear();
 		}
 		uint32_t subseq = this->subsequence++;
@@ -1095,6 +1100,7 @@ struct LogPushData : NonCopyable {
 				wr.serializeBytes((uint8_t*)from.getData() + firstOffset, firstLength);
 			}
 		}
+		written_tags.insert(written_tags.end(), next_message_tags.begin(), next_message_tags.end());
 		next_message_tags.clear();
 	}
 
@@ -1104,6 +1110,7 @@ private:
 	Reference<ILogSystem> logSystem;
 	std::vector<Tag> next_message_tags;
 	std::vector<Tag> prev_tags;
+	std::vector<Tag> written_tags;
 	std::vector<BinaryWriter> messagesWriter;
 	std::vector<int> msg_locations;
 	// Stores message locations that have had span information written to them


### PR DESCRIPTION
CommitBatchContext::written_tags captures all tags that have been affected by a transaction batch.  
We were not updating written_tags in applyMetadataToCommittedTransactions() and so we were not capturing all tags affected by a transaction batch. Address this by moving this logic, the logic that populates written_tags, to LogPushData.

Changes:

FDBTypes.h: 

Tag: Add a method to identify whether the tag represents a non-primary tlog type.

LogSystem.h: 

LogPushData: 
- Add a new member, written_tags, which captures all tags affected a transaction batch.
- Update writeMessage() and writeTypedMessage() methods to populate written_tags.
- Modify saveTags() to copy written_tags, after filtering out any pseudo tags.

CommitProxyServer.actor.cpp:
- Remove code that populates written_tags in assignMutationsToStorageServers().
- Capture written_tags right before invoking "getTPCV()"
Put description here...

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
