### PR TITLE
Fix TraceEvent usages to avoid clang-tidy bugprone-unused-raii warning.

### DIFF
--- a/fdbbackup/FileDecoder.actor.cpp
+++ b/fdbbackup/FileDecoder.actor.cpp
@@ -571,7 +571,7 @@ int main(int argc, char** argv) {
 		}
 
 		if (!param.tlsConfig.setupTLS()) {
-			TraceEvent(SevError, "TLSError");
+			TraceEvent(SevError, "TLSError").log();
 			throw tls_error();
 		}
 

--- a/fdbclient/BackupContainerLocalDirectory.actor.cpp
+++ b/fdbclient/BackupContainerLocalDirectory.actor.cpp
@@ -227,7 +227,7 @@ Future<Reference<IAsyncFile>> BackupContainerLocalDirectory::readFile(const std:
 		}
 
 		if (g_simulator.getCurrentProcess()->uid == UID()) {
-			TraceEvent(SevError, "BackupContainerReadFileOnUnsetProcessID");
+			TraceEvent(SevError, "BackupContainerReadFileOnUnsetProcessID").log();
 		}
 		std::string uniquePath = fullPath + "." + g_simulator.getCurrentProcess()->uid.toString() + ".lnk";
 		unlink(uniquePath.c_str());

--- a/fdbclient/DatabaseBackupAgent.actor.cpp
+++ b/fdbclient/DatabaseBackupAgent.actor.cpp
@@ -364,7 +364,7 @@ struct BackupRangeTaskFunc : TaskFuncBase {
 						TEST(true); // range insert delayed because too versionMap is too large
 
 						if (rangeCount > CLIENT_KNOBS->BACKUP_MAP_KEY_UPPER_LIMIT)
-							TraceEvent(SevWarnAlways, "DBA_KeyRangeMapTooLarge");
+							TraceEvent(SevWarnAlways, "DBA_KeyRangeMapTooLarge").log();
 
 						wait(delay(1));
 						task->params[BackupRangeTaskFunc::keyBackupRangeBeginKey] = rangeBegin;
@@ -1882,7 +1882,7 @@ struct CopyDiffLogsUpgradeTaskFunc : TaskFuncBase {
 		state Reference<TaskFuture> onDone = futureBucket->unpack(task->params[Task::reservedTaskParamKeyDone]);
 
 		if (task->params[BackupAgentBase::destUid].size() == 0) {
-			TraceEvent("DBA_CopyDiffLogsUpgradeTaskFuncAbortInUpgrade");
+			TraceEvent("DBA_CopyDiffLogsUpgradeTaskFuncAbortInUpgrade").log();
 			wait(success(AbortOldBackupTaskFunc::addTask(tr, taskBucket, task, TaskCompletionKey::signal(onDone))));
 		} else {
 			Version beginVersion =
@@ -2377,11 +2377,11 @@ void checkAtomicSwitchOverConfig(StatusObjectReader srcStatus, StatusObjectReade
 	try {
 		// Check if src is unlocked and dest is locked
 		if (getLockedStatus(srcStatus) != false) {
-			TraceEvent(SevWarn, "DBA_AtomicSwitchOverSrcLocked");
+			TraceEvent(SevWarn, "DBA_AtomicSwitchOverSrcLocked").log();
 			throw backup_error();
 		}
 		if (getLockedStatus(destStatus) != true) {
-			TraceEvent(SevWarn, "DBA_AtomicSwitchOverDestUnlocked");
+			TraceEvent(SevWarn, "DBA_AtomicSwitchOverDestUnlocked").log();
 			throw backup_error();
 		}
 		// Check if mutation-stream-id matches
@@ -2402,7 +2402,7 @@ void checkAtomicSwitchOverConfig(StatusObjectReader srcStatus, StatusObjectReade
 		                      destDRAgents.end(),
 		                      std::inserter(intersectingAgents, intersectingAgents.begin()));
 		if (intersectingAgents.empty()) {
-			TraceEvent(SevWarn, "DBA_SwitchOverPossibleDRAgentsIncorrectSetup");
+			TraceEvent(SevWarn, "DBA_SwitchOverPossibleDRAgentsIncorrectSetup").log();
 			throw backup_error();
 		}
 	} catch (std::runtime_error& e) {
@@ -2757,7 +2757,7 @@ public:
 			}
 		}
 
-		TraceEvent("DBA_SwitchoverReady");
+		TraceEvent("DBA_SwitchoverReady").log();
 
 		try {
 			wait(backupAgent->discontinueBackup(dest, tagName));
@@ -2768,7 +2768,7 @@ public:
 
 		wait(success(backupAgent->waitBackup(dest, tagName, StopWhenDone::True)));
 
-		TraceEvent("DBA_SwitchoverStopped");
+		TraceEvent("DBA_SwitchoverStopped").log();
 
 		state ReadYourWritesTransaction tr3(dest);
 		loop {
@@ -2789,7 +2789,7 @@ public:
 			}
 		}
 
-		TraceEvent("DBA_SwitchoverVersionUpgraded");
+		TraceEvent("DBA_SwitchoverVersionUpgraded").log();
 
 		try {
 			wait(drAgent.submitBackup(backupAgent->taskBucket->src,
@@ -2805,15 +2805,15 @@ public:
 				throw;
 		}
 
-		TraceEvent("DBA_SwitchoverSubmitted");
+		TraceEvent("DBA_SwitchoverSubmitted").log();
 
 		wait(success(drAgent.waitSubmitted(backupAgent->taskBucket->src, tagName)));
 
-		TraceEvent("DBA_SwitchoverStarted");
+		TraceEvent("DBA_SwitchoverStarted").log();
 
 		wait(backupAgent->unlockBackup(dest, tagName));
 
-		TraceEvent("DBA_SwitchoverUnlocked");
+		TraceEvent("DBA_SwitchoverUnlocked").log();
 
 		return Void();
 	}

--- a/fdbclient/FileBackupAgent.actor.cpp
+++ b/fdbclient/FileBackupAgent.actor.cpp
@@ -5478,7 +5478,7 @@ public:
 			try {
 				wait(discontinueBackup(backupAgent, ryw_tr, tagName));
 				wait(ryw_tr->commit());
-				TraceEvent("AS_DiscontinuedBackup");
+				TraceEvent("AS_DiscontinuedBackup").log();
 				break;
 			} catch (Error& e) {
 				if (e.code() == error_code_backup_unneeded || e.code() == error_code_backup_duplicate) {
@@ -5489,7 +5489,7 @@ public:
 		}
 
 		wait(success(waitBackup(backupAgent, cx, tagName.toString(), StopWhenDone::True)));
-		TraceEvent("AS_BackupStopped");
+		TraceEvent("AS_BackupStopped").log();
 
 		ryw_tr->reset();
 		loop {
@@ -5502,7 +5502,7 @@ public:
 					ryw_tr->clear(range);
 				}
 				wait(ryw_tr->commit());
-				TraceEvent("AS_ClearedRange");
+				TraceEvent("AS_ClearedRange").log();
 				break;
 			} catch (Error& e) {
 				wait(ryw_tr->onError(e));
@@ -5512,7 +5512,7 @@ public:
 		Reference<IBackupContainer> bc = wait(backupConfig.backupContainer().getOrThrow(cx));
 
 		if (fastRestore) {
-			TraceEvent("AtomicParallelRestoreStartRestore");
+			TraceEvent("AtomicParallelRestoreStartRestore").log();
 			Version targetVersion = ::invalidVersion;
 			wait(submitParallelRestore(cx,
 			                           tagName,
@@ -5533,7 +5533,7 @@ public:
 			}
 			return -1;
 		} else {
-			TraceEvent("AS_StartRestore");
+			TraceEvent("AS_StartRestore").log();
 			Version ver = wait(restore(backupAgent,
 			                           cx,
 			                           cx,

--- a/fdbclient/MultiVersionTransaction.actor.cpp
+++ b/fdbclient/MultiVersionTransaction.actor.cpp
@@ -1521,7 +1521,7 @@ std::vector<std::pair<std::string, bool>> MultiVersionApi::copyExternalLibraryPe
 #else
 std::vector<std::pair<std::string, bool>> MultiVersionApi::copyExternalLibraryPerThread(std::string path) {
 	if (threadCount > 1) {
-		TraceEvent(SevError, "MultipleClientThreadsUnsupportedOnWindows");
+		TraceEvent(SevError, "MultipleClientThreadsUnsupportedOnWindows").log();
 		throw unsupported_operation();
 	}
 	std::vector<std::pair<std::string, bool>> paths;

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -488,7 +488,7 @@ ACTOR static Future<Void> transactionInfoCommitActor(Transaction* tr, std::vecto
 ACTOR static Future<Void> delExcessClntTxnEntriesActor(Transaction* tr, int64_t clientTxInfoSizeLimit) {
 	state const Key clientLatencyName = CLIENT_LATENCY_INFO_PREFIX.withPrefix(fdbClientInfoPrefixRange.begin);
 	state const Key clientLatencyAtomicCtr = CLIENT_LATENCY_INFO_CTR_PREFIX.withPrefix(fdbClientInfoPrefixRange.begin);
-	TraceEvent(SevInfo, "DelExcessClntTxnEntriesCalled");
+	TraceEvent(SevInfo, "DelExcessClntTxnEntriesCalled").log();
 	loop {
 		try {
 			tr->reset();
@@ -496,7 +496,7 @@ ACTOR static Future<Void> delExcessClntTxnEntriesActor(Transaction* tr, int64_t 
 			tr->setOption(FDBTransactionOptions::LOCK_AWARE);
 			Optional<Value> ctrValue = wait(tr->get(KeyRef(clientLatencyAtomicCtr), Snapshot::True));
 			if (!ctrValue.present()) {
-				TraceEvent(SevInfo, "NumClntTxnEntriesNotFound");
+				TraceEvent(SevInfo, "NumClntTxnEntriesNotFound").log();
 				return Void();
 			}
 			state int64_t txInfoSize = 0;
@@ -1627,7 +1627,7 @@ ACTOR static Future<Void> switchConnectionFileImpl(Reference<ClusterConnectionFi
 	loop {
 		tr.setOption(FDBTransactionOptions::READ_LOCK_AWARE);
 		try {
-			TraceEvent("SwitchConnectionFileAttemptingGRV");
+			TraceEvent("SwitchConnectionFileAttemptingGRV").log();
 			Version v = wait(tr.getReadVersion());
 			TraceEvent("SwitchConnectionFileGotRV")
 			    .detail("ReadVersion", v)
@@ -5199,7 +5199,7 @@ Future<Void> Transaction::commitMutations() {
 
 		if (options.debugDump) {
 			UID u = nondeterministicRandom()->randomUniqueID();
-			TraceEvent("TransactionDump", u);
+			TraceEvent("TransactionDump", u).log();
 			for (auto i = tr.transaction.mutations.begin(); i != tr.transaction.mutations.end(); ++i)
 				TraceEvent("TransactionMutation", u)
 				    .detail("T", i->type)
@@ -6326,7 +6326,7 @@ void Transaction::setToken(uint64_t token) {
 void enableClientInfoLogging() {
 	ASSERT(networkOptions.logClientInfo.present() == false);
 	networkOptions.logClientInfo = true;
-	TraceEvent(SevInfo, "ClientInfoLoggingEnabled");
+	TraceEvent(SevInfo, "ClientInfoLoggingEnabled").log();
 }
 
 ACTOR Future<Void> snapCreate(Database cx, Standalone<StringRef> snapCmd, UID snapUID) {
@@ -6380,7 +6380,7 @@ ACTOR Future<bool> checkSafeExclusions(Database cx, vector<AddressExclusion> exc
 		}
 		throw;
 	}
-	TraceEvent("ExclusionSafetyCheckCoordinators");
+	TraceEvent("ExclusionSafetyCheckCoordinators").log();
 	state ClientCoordinators coordinatorList(cx->getConnectionFile());
 	state vector<Future<Optional<LeaderInfo>>> leaderServers;
 	leaderServers.reserve(coordinatorList.clientLeaderServers.size());
@@ -6393,7 +6393,7 @@ ACTOR Future<bool> checkSafeExclusions(Database cx, vector<AddressExclusion> exc
 	choose {
 		when(wait(smartQuorum(leaderServers, leaderServers.size() / 2 + 1, 1.0))) {}
 		when(wait(delay(3.0))) {
-			TraceEvent("ExclusionSafetyCheckNoCoordinatorQuorum");
+			TraceEvent("ExclusionSafetyCheckNoCoordinatorQuorum").log();
 			return false;
 		}
 	}

--- a/fdbclient/ReadYourWrites.actor.cpp
+++ b/fdbclient/ReadYourWrites.actor.cpp
@@ -1164,7 +1164,7 @@ public:
 		if (!ryw->resetPromise.isSet())
 			ryw->resetPromise.sendError(transaction_timed_out());
 		wait(delay(deterministicRandom()->random01() * 5));
-		TraceEvent("ClientBuggifyInFlightCommit");
+		TraceEvent("ClientBuggifyInFlightCommit").log();
 		wait(ryw->tr.commit());
 	}
 

--- a/fdbclient/SystemData.cpp
+++ b/fdbclient/SystemData.cpp
@@ -129,7 +129,7 @@ void decodeKeyServersValue(RangeResult result,
 	std::sort(src.begin(), src.end());
 	std::sort(dest.begin(), dest.end());
 	if (missingIsError && (src.size() != srcTag.size() || dest.size() != destTag.size())) {
-		TraceEvent(SevError, "AttemptedToDecodeMissingTag");
+		TraceEvent(SevError, "AttemptedToDecodeMissingTag").log();
 		for (const KeyValueRef& kv : result) {
 			Tag tag = decodeServerTagValue(kv.value);
 			UID serverID = decodeServerTagKey(kv.key);

--- a/fdbrpc/FlowTransport.actor.cpp
+++ b/fdbrpc/FlowTransport.actor.cpp
@@ -1019,7 +1019,7 @@ static void scanPackets(TransportData* transport,
 			    BUGGIFY_WITH_PROB(0.0001)) {
 				g_simulator.lastConnectionFailure = g_network->now();
 				isBuggifyEnabled = true;
-				TraceEvent(SevInfo, "BitsFlip");
+				TraceEvent(SevInfo, "BitsFlip").log();
 				int flipBits = 32 - (int)floor(log2(deterministicRandom()->randomUInt32()));
 
 				uint32_t firstFlipByteLocation = deterministicRandom()->randomUInt32() % packetLen;

--- a/fdbrpc/sim2.actor.cpp
+++ b/fdbrpc/sim2.actor.cpp
@@ -470,12 +470,12 @@ public:
 		state TaskPriority currentTaskID = g_network->getCurrentTask();
 
 		if (++openCount >= 3000) {
-			TraceEvent(SevError, "TooManyFiles");
+			TraceEvent(SevError, "TooManyFiles").log();
 			ASSERT(false);
 		}
 
 		if (openCount == 2000) {
-			TraceEvent(SevWarnAlways, "DisableConnectionFailures_TooManyFiles");
+			TraceEvent(SevWarnAlways, "DisableConnectionFailures_TooManyFiles").log();
 			g_simulator.speedUpSimulation = true;
 			g_simulator.connectionFailuresDisableDuration = 1e6;
 		}

--- a/fdbserver/ApplyMetadataMutation.cpp
+++ b/fdbserver/ApplyMetadataMutation.cpp
@@ -404,7 +404,7 @@ void applyMetadataMutations(SpanID const& spanContext,
 				confChange = true;
 				TEST(true); // Recovering at a higher version.
 			} else if (m.param1 == writeRecoveryKey) {
-				TraceEvent("WriteRecoveryKeySet", dbgid);
+				TraceEvent("WriteRecoveryKeySet", dbgid).log();
 				if (!initialCommit)
 					txnStateStore->set(KeyValueRef(m.param1, m.param2));
 				TEST(true); // Snapshot created, setting writeRecoveryKey in txnStateStore

--- a/fdbserver/BackupWorker.actor.cpp
+++ b/fdbserver/BackupWorker.actor.cpp
@@ -477,7 +477,7 @@ ACTOR Future<bool> monitorBackupStartedKeyChanges(BackupData* self, bool present
 					if (present || !watch)
 						return true;
 				} else {
-					TraceEvent("BackupWorkerEmptyStartKey", self->myId);
+					TraceEvent("BackupWorkerEmptyStartKey", self->myId).log();
 					self->onBackupChanges(uidVersions);
 
 					self->exitEarly = shouldExit;
@@ -887,7 +887,7 @@ ACTOR Future<Void> pullAsyncData(BackupData* self) {
 	state Version tagAt = std::max(self->pulledVersion.get(), std::max(self->startVersion, self->savedVersion));
 	state Arena prev;
 
-	TraceEvent("BackupWorkerPull", self->myId);
+	TraceEvent("BackupWorkerPull", self->myId).log();
 	loop {
 		while (self->paused.get()) {
 			wait(self->paused.onChange());
@@ -1017,7 +1017,7 @@ ACTOR static Future<Void> monitorWorkerPause(BackupData* self) {
 			Optional<Value> value = wait(tr->get(backupPausedKey));
 			bool paused = value.present() && value.get() == LiteralStringRef("1");
 			if (self->paused.get() != paused) {
-				TraceEvent(paused ? "BackupWorkerPaused" : "BackupWorkerResumed", self->myId);
+				TraceEvent(paused ? "BackupWorkerPaused" : "BackupWorkerResumed", self->myId).log();
 				self->paused.set(paused);
 			}
 

--- a/fdbserver/ClusterController.actor.cpp
+++ b/fdbserver/ClusterController.actor.cpp
@@ -1962,7 +1962,7 @@ public:
 			}
 
 			if (bestDC != clusterControllerDcId) {
-				TraceEvent("BestDCIsNotClusterDC");
+				TraceEvent("BestDCIsNotClusterDC").log();
 				vector<Optional<Key>> dcPriority;
 				dcPriority.push_back(bestDC);
 				desiredDcIds.set(dcPriority);
@@ -3094,7 +3094,7 @@ ACTOR Future<Void> clusterWatchDatabase(ClusterControllerData* cluster, ClusterC
 	// When this someday is implemented, make sure forced failures still cause the master to be recruited again
 
 	loop {
-		TraceEvent("CCWDB", cluster->id);
+		TraceEvent("CCWDB", cluster->id).log();
 		try {
 			state double recoveryStart = now();
 			TraceEvent("CCWDB", cluster->id).detail("Recruiting", "Master");
@@ -3915,7 +3915,7 @@ ACTOR Future<Void> timeKeeperSetVersion(ClusterControllerData* self) {
 ACTOR Future<Void> timeKeeper(ClusterControllerData* self) {
 	state KeyBackedMap<int64_t, Version> versionMap(timeKeeperPrefixRange.begin);
 
-	TraceEvent("TimeKeeperStarted");
+	TraceEvent("TimeKeeperStarted").log();
 
 	wait(timeKeeperSetVersion(self));
 
@@ -3929,7 +3929,7 @@ ACTOR Future<Void> timeKeeper(ClusterControllerData* self) {
 					//       how long it is taking to hear responses from each other component.
 
 					UID debugID = deterministicRandom()->randomUniqueID();
-					TraceEvent("TimeKeeperCommit", debugID);
+					TraceEvent("TimeKeeperCommit", debugID).log();
 					tr->debugTransaction(debugID);
 				}
 				tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
@@ -4080,7 +4080,7 @@ ACTOR Future<Void> monitorProcessClasses(ClusterControllerData* self) {
 			}
 
 			wait(trVer.commit());
-			TraceEvent("ProcessClassUpgrade");
+			TraceEvent("ProcessClassUpgrade").log();
 			break;
 		} catch (Error& e) {
 			wait(trVer.onError(e));
@@ -4509,7 +4509,7 @@ ACTOR Future<Void> handleForcedRecoveries(ClusterControllerData* self, ClusterCo
 			}
 			wait(fCommit);
 		}
-		TraceEvent("ForcedRecoveryFinish", self->id);
+		TraceEvent("ForcedRecoveryFinish", self->id).log();
 		self->db.forceRecovery = false;
 		req.reply.send(Void());
 	}
@@ -4518,7 +4518,7 @@ ACTOR Future<Void> handleForcedRecoveries(ClusterControllerData* self, ClusterCo
 ACTOR Future<DataDistributorInterface> startDataDistributor(ClusterControllerData* self) {
 	wait(delay(0.0)); // If master fails at the same time, give it a chance to clear master PID.
 
-	TraceEvent("CCStartDataDistributor", self->id);
+	TraceEvent("CCStartDataDistributor", self->id).log();
 	loop {
 		try {
 			state bool no_distributor = !self->db.serverInfo->get().distributor.present();
@@ -4585,7 +4585,7 @@ ACTOR Future<Void> monitorDataDistributor(ClusterControllerData* self) {
 ACTOR Future<Void> startRatekeeper(ClusterControllerData* self) {
 	wait(delay(0.0)); // If master fails at the same time, give it a chance to clear master PID.
 
-	TraceEvent("CCStartRatekeeper", self->id);
+	TraceEvent("CCStartRatekeeper", self->id).log();
 	loop {
 		try {
 			state bool no_ratekeeper = !self->db.serverInfo->get().ratekeeper.present();
@@ -4702,7 +4702,7 @@ ACTOR Future<Void> dbInfoUpdater(ClusterControllerData* self) {
 		req.serializedDbInfo =
 		    BinaryWriter::toValue(self->db.serverInfo->get(), AssumeVersion(g_network->protocolVersion()));
 
-		TraceEvent("DBInfoStartBroadcast", self->id);
+		TraceEvent("DBInfoStartBroadcast", self->id).log();
 		choose {
 			when(std::vector<Endpoint> notUpdated =
 			         wait(broadcastDBInfoRequest(req, SERVER_KNOBS->DBINFO_SEND_AMOUNT, Optional<Endpoint>(), false))) {
@@ -4757,7 +4757,7 @@ ACTOR Future<Void> workerHealthMonitor(ClusterControllerData* self) {
 						}
 					} else {
 						self->excludedDegradedServers.clear();
-						TraceEvent("DegradedServerDetectedAndSuggestRecovery");
+						TraceEvent("DegradedServerDetectedAndSuggestRecovery").log();
 					}
 				}
 			}

--- a/fdbserver/CommitProxyServer.actor.cpp
+++ b/fdbserver/CommitProxyServer.actor.cpp
@@ -1756,7 +1756,7 @@ ACTOR Future<Void> proxySnapCreate(ProxySnapRequest snapReq, ProxyCommitData* co
 
 ACTOR Future<Void> proxyCheckSafeExclusion(Reference<AsyncVar<ServerDBInfo> const> db,
                                            ExclusionSafetyCheckRequest req) {
-	TraceEvent("SafetyCheckCommitProxyBegin");
+	TraceEvent("SafetyCheckCommitProxyBegin").log();
 	state ExclusionSafetyCheckReply reply(false);
 	if (!db->get().distributor.present()) {
 		TraceEvent(SevWarnAlways, "DataDistributorNotPresent").detail("Operation", "ExclusionSafetyCheck");
@@ -1778,7 +1778,7 @@ ACTOR Future<Void> proxyCheckSafeExclusion(Reference<AsyncVar<ServerDBInfo> cons
 			throw e;
 		}
 	}
-	TraceEvent("SafetyCheckCommitProxyFinish");
+	TraceEvent("SafetyCheckCommitProxyFinish").log();
 	req.reply.send(reply);
 	return Void();
 }
@@ -1796,7 +1796,7 @@ ACTOR Future<Void> reportTxnTagCommitCost(UID myID,
 				TraceEvent("ProxyRatekeeperChanged", myID).detail("RKID", db->get().ratekeeper.get().id());
 				nextRequestTimer = Void();
 			} else {
-				TraceEvent("ProxyRatekeeperDied", myID);
+				TraceEvent("ProxyRatekeeperDied", myID).log();
 				nextRequestTimer = Never();
 			}
 		}
@@ -1936,7 +1936,7 @@ ACTOR Future<Void> commitProxyServerCore(CommitProxyInterface proxy,
 			}
 		}
 		when(ProxySnapRequest snapReq = waitNext(proxy.proxySnapReq.getFuture())) {
-			TraceEvent(SevDebug, "SnapMasterEnqueue");
+			TraceEvent(SevDebug, "SnapMasterEnqueue").log();
 			addActor.send(proxySnapCreate(snapReq, &commitData));
 		}
 		when(ExclusionSafetyCheckRequest exclCheckReq = waitNext(proxy.exclusionSafetyCheckReq.getFuture())) {

--- a/fdbserver/CoordinatedState.actor.cpp
+++ b/fdbserver/CoordinatedState.actor.cpp
@@ -316,7 +316,7 @@ struct MovableCoordinatedStateImpl {
 		Value oldQuorumState = wait(cs.read());
 		if (oldQuorumState != self->lastCSValue.get()) {
 			TEST(true); // Quorum change aborted by concurrent write to old coordination state
-			TraceEvent("QuorumChangeAbortedByConcurrency");
+			TraceEvent("QuorumChangeAbortedByConcurrency").log();
 			throw coordinated_state_conflict();
 		}
 

--- a/fdbserver/CoroFlow.actor.cpp
+++ b/fdbserver/CoroFlow.actor.cpp
@@ -173,7 +173,7 @@ class WorkPool final : public IThreadPool, public ReferenceCounted<WorkPool<Thre
 					}
 				}
 
-				TraceEvent("CoroStop");
+				TraceEvent("CoroStop").log();
 				delete userData;
 				stopped.send(Void());
 				return;
@@ -181,14 +181,14 @@ class WorkPool final : public IThreadPool, public ReferenceCounted<WorkPool<Thre
 				TraceEvent("WorkPoolError").error(e, true);
 				error.sendError(e);
 			} catch (...) {
-				TraceEvent("WorkPoolError");
+				TraceEvent("WorkPoolError").log();
 				error.sendError(unknown_error());
 			}
 
 			try {
 				delete userData;
 			} catch (...) {
-				TraceEvent(SevError, "WorkPoolErrorShutdownError");
+				TraceEvent(SevError, "WorkPoolErrorShutdownError").log();
 			}
 			stopped.send(Void());
 		}

--- a/fdbserver/CoroFlowCoro.actor.cpp
+++ b/fdbserver/CoroFlowCoro.actor.cpp
@@ -149,7 +149,7 @@ class WorkPool final : public IThreadPool, public ReferenceCounted<WorkPool<Thre
 					}
 				}
 
-				TraceEvent("CoroStop");
+				TraceEvent("CoroStop").log();
 				delete userData;
 				stopped.send(Void());
 				return;
@@ -157,14 +157,14 @@ class WorkPool final : public IThreadPool, public ReferenceCounted<WorkPool<Thre
 				TraceEvent("WorkPoolError").error(e, true);
 				error.sendError(e);
 			} catch (...) {
-				TraceEvent("WorkPoolError");
+				TraceEvent("WorkPoolError").log();
 				error.sendError(unknown_error());
 			}
 
 			try {
 				delete userData;
 			} catch (...) {
-				TraceEvent(SevError, "WorkPoolErrorShutdownError");
+				TraceEvent(SevError, "WorkPoolErrorShutdownError").log();
 			}
 			stopped.send(Void());
 		}

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -190,7 +190,7 @@ public:
 	  : servers(servers), healthy(true), priority(SERVER_KNOBS->PRIORITY_TEAM_HEALTHY), wrongConfiguration(false),
 	    id(deterministicRandom()->randomUniqueID()) {
 		if (servers.empty()) {
-			TraceEvent(SevInfo, "ConstructTCTeamFromEmptyServers");
+			TraceEvent(SevInfo, "ConstructTCTeamFromEmptyServers").log();
 		}
 		serverIDs.reserve(servers.size());
 		for (int i = 0; i < servers.size(); i++) {
@@ -445,7 +445,7 @@ ACTOR Future<Reference<InitialDataDistribution>> getInitialDataDistribution(Data
 			}
 			if (!result->mode || !ddEnabledState->isDDEnabled()) {
 				// DD can be disabled persistently (result->mode = 0) or transiently (isDDEnabled() = 0)
-				TraceEvent(SevDebug, "GetInitialDataDistribution_DisabledDD");
+				TraceEvent(SevDebug, "GetInitialDataDistribution_DisabledDD").log();
 				return result;
 			}
 
@@ -475,7 +475,7 @@ ACTOR Future<Reference<InitialDataDistribution>> getInitialDataDistribution(Data
 			wait(tr.onError(e));
 
 			ASSERT(!succeeded); // We shouldn't be retrying if we have already started modifying result in this loop
-			TraceEvent("GetInitialTeamsRetry", distributorId);
+			TraceEvent("GetInitialTeamsRetry", distributorId).log();
 		}
 	}
 
@@ -4160,14 +4160,14 @@ ACTOR Future<Void> monitorPerpetualStorageWiggle(DDTeamCollection* teamCollectio
 					    &stopWiggleSignal, finishStorageWiggleSignal.getFuture(), teamCollection));
 					collection.add(perpetualStorageWiggler(
 					    &stopWiggleSignal, finishStorageWiggleSignal, teamCollection, ddEnabledState));
-					TraceEvent("PerpetualStorageWiggleOpen", teamCollection->distributorId);
+					TraceEvent("PerpetualStorageWiggleOpen", teamCollection->distributorId).log();
 				} else if (speed == 0) {
 					if (!stopWiggleSignal.get()) {
 						stopWiggleSignal.set(true);
 						wait(collection.signalAndReset());
 						teamCollection->pauseWiggle->set(true);
 					}
-					TraceEvent("PerpetualStorageWiggleClose", teamCollection->distributorId);
+					TraceEvent("PerpetualStorageWiggleClose", teamCollection->distributorId).log();
 				}
 				wait(watchFuture);
 				break;
@@ -4262,7 +4262,7 @@ ACTOR Future<Void> waitHealthyZoneChange(DDTeamCollection* self) {
 				auto p = decodeHealthyZoneValue(val.get());
 				if (p.first == ignoreSSFailuresZoneString) {
 					// healthyZone is now overloaded for DD diabling purpose, which does not timeout
-					TraceEvent("DataDistributionDisabledForStorageServerFailuresStart", self->distributorId);
+					TraceEvent("DataDistributionDisabledForStorageServerFailuresStart", self->distributorId).log();
 					healthyZoneTimeout = Never();
 				} else if (p.second > tr.getReadVersion().get()) {
 					double timeoutSeconds =
@@ -4277,15 +4277,15 @@ ACTOR Future<Void> waitHealthyZoneChange(DDTeamCollection* self) {
 					}
 				} else if (self->healthyZone.get().present()) {
 					// maintenance hits timeout
-					TraceEvent("MaintenanceZoneEndTimeout", self->distributorId);
+					TraceEvent("MaintenanceZoneEndTimeout", self->distributorId).log();
 					self->healthyZone.set(Optional<Key>());
 				}
 			} else if (self->healthyZone.get().present()) {
 				// `healthyZone` has been cleared
 				if (self->healthyZone.get().get() == ignoreSSFailuresZoneString) {
-					TraceEvent("DataDistributionDisabledForStorageServerFailuresEnd", self->distributorId);
+					TraceEvent("DataDistributionDisabledForStorageServerFailuresEnd", self->distributorId).log();
 				} else {
-					TraceEvent("MaintenanceZoneEndManualClear", self->distributorId);
+					TraceEvent("MaintenanceZoneEndManualClear", self->distributorId).log();
 				}
 				self->healthyZone.set(Optional<Key>());
 			}
@@ -4432,7 +4432,7 @@ ACTOR Future<Void> storageServerFailureTracker(DDTeamCollection* self,
 						status->isFailed = false;
 					} else if (self->clearHealthyZoneFuture.isReady()) {
 						self->clearHealthyZoneFuture = clearHealthyZone(self->cx);
-						TraceEvent("MaintenanceZoneCleared", self->distributorId);
+						TraceEvent("MaintenanceZoneCleared", self->distributorId).log();
 						self->healthyZone.set(Optional<Key>());
 					}
 				}
@@ -5491,7 +5491,7 @@ ACTOR Future<Void> serverGetTeamRequests(TeamCollectionInterface tci, DDTeamColl
 }
 
 ACTOR Future<Void> remoteRecovered(Reference<AsyncVar<ServerDBInfo> const> db) {
-	TraceEvent("DDTrackerStarting");
+	TraceEvent("DDTrackerStarting").log();
 	while (db->get().recoveryState < RecoveryState::ALL_LOGS_RECRUITED) {
 		TraceEvent("DDTrackerStarting").detail("RecoveryState", (int)db->get().recoveryState);
 		wait(db->onChange());
@@ -5625,7 +5625,7 @@ ACTOR Future<Void> waitForDataDistributionEnabled(Database cx, const DDEnabledSt
 		try {
 			Optional<Value> mode = wait(tr.get(dataDistributionModeKey));
 			if (!mode.present() && ddEnabledState->isDDEnabled()) {
-				TraceEvent("WaitForDDEnabledSucceeded");
+				TraceEvent("WaitForDDEnabledSucceeded").log();
 				return Void();
 			}
 			if (mode.present()) {
@@ -5636,7 +5636,7 @@ ACTOR Future<Void> waitForDataDistributionEnabled(Database cx, const DDEnabledSt
 				    .detail("Mode", m)
 				    .detail("IsDDEnabled", ddEnabledState->isDDEnabled());
 				if (m && ddEnabledState->isDDEnabled()) {
-					TraceEvent("WaitForDDEnabledSucceeded");
+					TraceEvent("WaitForDDEnabledSucceeded").log();
 					return Void();
 				}
 			}
@@ -5711,7 +5711,7 @@ ACTOR Future<Void> debugCheckCoalescing(Database cx) {
 						    .detail("Value", ranges[j].value);
 			}
 
-			TraceEvent("DoneCheckingCoalescing");
+			TraceEvent("DoneCheckingCoalescing").log();
 			return Void();
 		} catch (Error& e) {
 			wait(tr.onError(e));
@@ -5807,10 +5807,10 @@ ACTOR Future<Void> dataDistribution(Reference<DataDistributorData> self,
 		state Promise<UID> removeFailedServer;
 		try {
 			loop {
-				TraceEvent("DDInitTakingMoveKeysLock", self->ddId);
+				TraceEvent("DDInitTakingMoveKeysLock", self->ddId).log();
 				MoveKeysLock lock_ = wait(takeMoveKeysLock(cx, self->ddId));
 				lock = lock_;
-				TraceEvent("DDInitTookMoveKeysLock", self->ddId);
+				TraceEvent("DDInitTookMoveKeysLock", self->ddId).log();
 
 				DatabaseConfiguration configuration_ = wait(getDatabaseConfiguration(cx));
 				configuration = configuration_;
@@ -5854,7 +5854,7 @@ ACTOR Future<Void> dataDistribution(Reference<DataDistributorData> self,
 					}
 				}
 
-				TraceEvent("DDInitUpdatedReplicaKeys", self->ddId);
+				TraceEvent("DDInitUpdatedReplicaKeys", self->ddId).log();
 				Reference<InitialDataDistribution> initData_ = wait(getInitialDataDistribution(
 				    cx,
 				    self->ddId,
@@ -5882,7 +5882,7 @@ ACTOR Future<Void> dataDistribution(Reference<DataDistributorData> self,
 					// mode may be set true by system operator using fdbcli and isDDEnabled() set to true
 					break;
 				}
-				TraceEvent("DataDistributionDisabled", self->ddId);
+				TraceEvent("DataDistributionDisabled", self->ddId).log();
 
 				TraceEvent("MovingData", self->ddId)
 				    .detail("InFlight", 0)
@@ -5919,7 +5919,7 @@ ACTOR Future<Void> dataDistribution(Reference<DataDistributorData> self,
 				    .trackLatest("TotalDataInFlightRemote");
 
 				wait(waitForDataDistributionEnabled(cx, ddEnabledState));
-				TraceEvent("DataDistributionEnabled");
+				TraceEvent("DataDistributionEnabled").log();
 			}
 
 			// When/If this assertion fails, Evan owes Ben a pat on the back for his foresight
@@ -6256,7 +6256,7 @@ ACTOR Future<Void> ddSnapCreateCore(DistributorSnapRequest snapReq, Reference<As
 				}
 				wait(waitForAll(enablePops));
 			} catch (Error& error) {
-				TraceEvent(SevDebug, "IgnoreEnableTLogPopFailure");
+				TraceEvent(SevDebug, "IgnoreEnableTLogPopFailure").log();
 			}
 		}
 		throw e;
@@ -6271,7 +6271,7 @@ ACTOR Future<Void> ddSnapCreate(DistributorSnapRequest snapReq,
 	if (!ddEnabledState->setDDEnabled(false, snapReq.snapUID)) {
 		// disable DD before doing snapCreate, if previous snap req has already disabled DD then this operation fails
 		// here
-		TraceEvent("SnapDDSetDDEnabledFailedInMemoryCheck");
+		TraceEvent("SnapDDSetDDEnabledFailedInMemoryCheck").log();
 		snapReq.reply.sendError(operation_failed());
 		return Void();
 	}
@@ -6344,18 +6344,18 @@ bool _exclusionSafetyCheck(vector<UID>& excludeServerIDs, DDTeamCollection* team
 ACTOR Future<Void> ddExclusionSafetyCheck(DistributorExclusionSafetyCheckRequest req,
                                           Reference<DataDistributorData> self,
                                           Database cx) {
-	TraceEvent("DDExclusionSafetyCheckBegin", self->ddId);
+	TraceEvent("DDExclusionSafetyCheckBegin", self->ddId).log();
 	vector<StorageServerInterface> ssis = wait(getStorageServers(cx));
 	DistributorExclusionSafetyCheckReply reply(true);
 	if (!self->teamCollection) {
-		TraceEvent("DDExclusionSafetyCheckTeamCollectionInvalid", self->ddId);
+		TraceEvent("DDExclusionSafetyCheckTeamCollectionInvalid", self->ddId).log();
 		reply.safe = false;
 		req.reply.send(reply);
 		return Void();
 	}
 	// If there is only 1 team, unsafe to mark failed: team building can get stuck due to lack of servers left
 	if (self->teamCollection->teams.size() <= 1) {
-		TraceEvent("DDExclusionSafetyCheckNotEnoughTeams", self->ddId);
+		TraceEvent("DDExclusionSafetyCheckNotEnoughTeams", self->ddId).log();
 		reply.safe = false;
 		req.reply.send(reply);
 		return Void();
@@ -6371,7 +6371,7 @@ ACTOR Future<Void> ddExclusionSafetyCheck(DistributorExclusionSafetyCheckRequest
 		}
 	}
 	reply.safe = _exclusionSafetyCheck(excludeServerIDs, self->teamCollection);
-	TraceEvent("DDExclusionSafetyCheckFinish", self->ddId);
+	TraceEvent("DDExclusionSafetyCheckFinish", self->ddId).log();
 	req.reply.send(reply);
 	return Void();
 }

--- a/fdbserver/GrvProxyServer.actor.cpp
+++ b/fdbserver/GrvProxyServer.actor.cpp
@@ -300,7 +300,7 @@ ACTOR Future<Void> getRate(UID myID,
 				TraceEvent("ProxyRatekeeperChanged", myID).detail("RKID", db->get().ratekeeper.get().id());
 				nextRequestTimer = Void(); // trigger GetRate request
 			} else {
-				TraceEvent("ProxyRatekeeperDied", myID);
+				TraceEvent("ProxyRatekeeperDied", myID).log();
 				nextRequestTimer = Never();
 				reply = Never();
 			}

--- a/fdbserver/KeyValueStoreMemory.actor.cpp
+++ b/fdbserver/KeyValueStoreMemory.actor.cpp
@@ -141,7 +141,7 @@ public:
 
 	Future<Void> commit(bool sequential) override {
 		if (getAvailableSize() <= 0) {
-			TraceEvent(SevError, "KeyValueStoreMemory_OutOfSpace", id);
+			TraceEvent(SevError, "KeyValueStoreMemory_OutOfSpace", id).log();
 			return Never();
 		}
 
@@ -605,7 +605,7 @@ private:
 
 				if (zeroFillSize) {
 					if (exactRecovery) {
-						TraceEvent(SevError, "KVSMemExpectedExact", self->id);
+						TraceEvent(SevError, "KVSMemExpectedExact", self->id).log();
 						ASSERT(false);
 					}
 

--- a/fdbserver/KeyValueStoreSQLite.actor.cpp
+++ b/fdbserver/KeyValueStoreSQLite.actor.cpp
@@ -727,7 +727,7 @@ struct RawCursor {
 			try {
 				db.checkError("BtreeCloseCursor", sqlite3BtreeCloseCursor(cursor));
 			} catch (...) {
-				TraceEvent(SevError, "RawCursorDestructionError");
+				TraceEvent(SevError, "RawCursorDestructionError").log();
 			}
 			delete[](char*) cursor;
 		}
@@ -1737,9 +1737,9 @@ private:
 		    freeListPages(freeListPages), cursor(nullptr), dbgid(dbgid), readThreads(*pReadThreads),
 		    checkAllChecksumsOnOpen(checkAllChecksumsOnOpen), checkIntegrityOnOpen(checkIntegrityOnOpen) {}
 		~Writer() override {
-			TraceEvent("KVWriterDestroying", dbgid);
+			TraceEvent("KVWriterDestroying", dbgid).log();
 			delete cursor;
-			TraceEvent("KVWriterDestroyed", dbgid);
+			TraceEvent("KVWriterDestroyed", dbgid).log();
 		}
 		void init() override {
 			if (checkAllChecksumsOnOpen) {

--- a/fdbserver/LeaderElection.actor.cpp
+++ b/fdbserver/LeaderElection.actor.cpp
@@ -156,7 +156,7 @@ ACTOR Future<Void> tryBecomeLeaderInternal(ServerCoordinators coordinators,
 			}
 
 			if (leader.present() && leader.get().second && leader.get().first.equalInternalId(myInfo)) {
-				TraceEvent("BecomingLeader", myInfo.changeID);
+				TraceEvent("BecomingLeader", myInfo.changeID).log();
 				ASSERT(leader.get().first.serializedInfo == proposedSerializedInterface);
 				outSerializedLeader->set(leader.get().first.serializedInfo);
 				iAmLeader = true;
@@ -184,7 +184,7 @@ ACTOR Future<Void> tryBecomeLeaderInternal(ServerCoordinators coordinators,
 				when(wait(nominees->onChange())) {}
 				when(wait(badCandidateTimeout.isValid() ? badCandidateTimeout : Never())) {
 					TEST(true); // Bad candidate timeout
-					TraceEvent("LeaderBadCandidateTimeout", myInfo.changeID);
+					TraceEvent("LeaderBadCandidateTimeout", myInfo.changeID).log();
 					break;
 				}
 				when(wait(candidacies)) { ASSERT(false); }
@@ -225,7 +225,7 @@ ACTOR Future<Void> tryBecomeLeaderInternal(ServerCoordinators coordinators,
 				//TraceEvent("StillLeader", myInfo.changeID);
 			} // We are still leader
 			when(wait(quorum(false_heartbeats, false_heartbeats.size() / 2 + 1))) {
-				TraceEvent("ReplacedAsLeader", myInfo.changeID);
+				TraceEvent("ReplacedAsLeader", myInfo.changeID).log();
 				break;
 			} // We are definitely not leader
 			when(wait(delay(SERVER_KNOBS->POLLING_FREQUENCY))) {
@@ -243,7 +243,7 @@ ACTOR Future<Void> tryBecomeLeaderInternal(ServerCoordinators coordinators,
 						    .detail("Coordinator",
 						            coordinators.leaderElectionServers[i].candidacy.getEndpoint().getPrimaryAddress());
 				}
-				TraceEvent("ReleasingLeadership", myInfo.changeID);
+				TraceEvent("ReleasingLeadership", myInfo.changeID).log();
 				break;
 			} // Give up on being leader, because we apparently have poor communications
 			when(wait(asyncPriorityInfo->onChange())) {}

--- a/fdbserver/LogSystem.h
+++ b/fdbserver/LogSystem.h
@@ -291,7 +291,7 @@ public:
 
 		if (allLocations) {
 			// special handling for allLocations
-			TraceEvent("AllLocationsSet");
+			TraceEvent("AllLocationsSet").log();
 			for (int i = 0; i < logServers.size(); i++) {
 				newLocations.push_back(i);
 			}

--- a/fdbserver/MetricLogger.actor.cpp
+++ b/fdbserver/MetricLogger.actor.cpp
@@ -374,7 +374,7 @@ ACTOR Future<Void> updateMetricRegistration(Database cx, MetricsConfig* config, 
 ACTOR Future<Void> runMetrics(Future<Database> fcx, Key prefix) {
 	// Never log to an empty prefix, it's pretty much always a bad idea.
 	if (prefix.size() == 0) {
-		TraceEvent(SevWarnAlways, "TDMetricsRefusingEmptyPrefix");
+		TraceEvent(SevWarnAlways, "TDMetricsRefusingEmptyPrefix").log();
 		return Void();
 	}
 

--- a/fdbserver/MoveKeys.actor.cpp
+++ b/fdbserver/MoveKeys.actor.cpp
@@ -100,7 +100,7 @@ ACTOR static Future<Void> checkMoveKeysLock(Transaction* tr,
                                             const DDEnabledState* ddEnabledState,
                                             bool isWrite = true) {
 	if (!ddEnabledState->isDDEnabled()) {
-		TraceEvent(SevDebug, "DDDisabledByInMemoryCheck");
+		TraceEvent(SevDebug, "DDDisabledByInMemoryCheck").log();
 		throw movekeys_conflict();
 	}
 	Optional<Value> readVal = wait(tr->get(moveKeysLockOwnerKey));
@@ -1143,7 +1143,7 @@ ACTOR Future<std::pair<Version, Tag>> addStorageServer(Database cx, StorageServe
 
 				if (SERVER_KNOBS->TSS_HACK_IDENTITY_MAPPING) {
 					// THIS SHOULD NEVER BE ENABLED IN ANY NON-TESTING ENVIRONMENT
-					TraceEvent(SevError, "TSSIdentityMappingEnabled");
+					TraceEvent(SevError, "TSSIdentityMappingEnabled").log();
 					tssMapDB.set(tr, server.id(), server.id());
 				}
 			}
@@ -1268,7 +1268,7 @@ ACTOR Future<Void> removeStorageServer(Database cx,
 
 				if (SERVER_KNOBS->TSS_HACK_IDENTITY_MAPPING) {
 					// THIS SHOULD NEVER BE ENABLED IN ANY NON-TESTING ENVIRONMENT
-					TraceEvent(SevError, "TSSIdentityMappingEnabled");
+					TraceEvent(SevError, "TSSIdentityMappingEnabled").log();
 					tssMapDB.erase(tr, serverID);
 				} else if (tssPairID.present()) {
 					// remove the TSS from the mapping
@@ -1440,7 +1440,7 @@ void seedShardServers(Arena& arena, CommitTransactionRef& tr, vector<StorageServ
 		tr.set(arena, serverListKeyFor(s.id()), serverListValue(s));
 		if (SERVER_KNOBS->TSS_HACK_IDENTITY_MAPPING) {
 			// THIS SHOULD NEVER BE ENABLED IN ANY NON-TESTING ENVIRONMENT
-			TraceEvent(SevError, "TSSIdentityMappingEnabled");
+			TraceEvent(SevError, "TSSIdentityMappingEnabled").log();
 			// hack key-backed map here since we can't really change CommitTransactionRef to a RYW transaction
 			Key uidRef = Codec<UID>::pack(s.id()).pack();
 			tr.set(arena, uidRef.withPrefix(tssMappingKeys.begin), uidRef);

--- a/fdbserver/OldTLogServer_4_6.actor.cpp
+++ b/fdbserver/OldTLogServer_4_6.actor.cpp
@@ -1387,7 +1387,7 @@ ACTOR Future<Void> restorePersistentState(TLogData* self, LocalityData locality)
 	state KeyRange tagKeys;
 	// PERSIST: Read basic state from persistentData; replay persistentQueue but don't erase it
 
-	TraceEvent("TLogRestorePersistentState", self->dbgid);
+	TraceEvent("TLogRestorePersistentState", self->dbgid).log();
 
 	IKeyValueStore* storage = self->persistentData;
 	state Future<Optional<Value>> fFormat = storage->readValue(persistFormat.key);
@@ -1575,7 +1575,7 @@ ACTOR Future<Void> tLog(IKeyValueStore* persistentData,
 	state TLogData self(tlogId, workerID, persistentData, persistentQueue, db);
 	state Future<Void> error = actorCollection(self.sharedActors.getFuture());
 
-	TraceEvent("SharedTlog", tlogId);
+	TraceEvent("SharedTlog", tlogId).log();
 
 	try {
 		wait(restorePersistentState(&self, locality));

--- a/fdbserver/OldTLogServer_6_0.actor.cpp
+++ b/fdbserver/OldTLogServer_6_0.actor.cpp
@@ -876,7 +876,7 @@ ACTOR Future<Void> tLogPop(TLogData* self, TLogPopRequest req, Reference<LogData
 	// timeout check for ignorePopRequest
 	if (self->ignorePopRequest && (g_network->now() > self->ignorePopDeadline)) {
 
-		TraceEvent("EnableTLogPlayAllIgnoredPops");
+		TraceEvent("EnableTLogPlayAllIgnoredPops").log();
 		// use toBePopped and issue all the pops
 		state std::map<Tag, Version>::iterator it;
 		state vector<Future<Void>> ignoredPops;
@@ -1666,7 +1666,7 @@ ACTOR Future<Void> initPersistentState(TLogData* self, Reference<LogData> logDat
 		updatePersistentPopped(self, logData, logData->getTagData(tag));
 	}
 
-	TraceEvent("TLogInitCommit", logData->logId);
+	TraceEvent("TLogInitCommit", logData->logId).log();
 	wait(ioTimeoutError(self->persistentData->commit(), SERVER_KNOBS->TLOG_MAX_CREATE_DURATION));
 	return Void();
 }
@@ -1869,7 +1869,7 @@ ACTOR Future<Void> tLogEnablePopReq(TLogEnablePopRequest enablePopReq, TLogData*
 		enablePopReq.reply.sendError(operation_failed());
 		return Void();
 	}
-	TraceEvent("EnableTLogPlayAllIgnoredPops2");
+	TraceEvent("EnableTLogPlayAllIgnoredPops2").log();
 	// use toBePopped and issue all the pops
 	std::map<Tag, Version>::iterator it;
 	vector<Future<Void>> ignoredPops;
@@ -1923,7 +1923,7 @@ ACTOR Future<Void> serveTLogInterface(TLogData* self,
 				}
 
 				if (!logData->isPrimary && logData->stopped) {
-					TraceEvent("TLogAlreadyStopped", self->dbgid);
+					TraceEvent("TLogAlreadyStopped", self->dbgid).log();
 					logData->removed = logData->removed && logData->logSystem->get()->endEpoch();
 				}
 			} else {
@@ -2198,22 +2198,22 @@ ACTOR Future<Void> tLogCore(TLogData* self,
 }
 
 ACTOR Future<Void> checkEmptyQueue(TLogData* self) {
-	TraceEvent("TLogCheckEmptyQueueBegin", self->dbgid);
+	TraceEvent("TLogCheckEmptyQueueBegin", self->dbgid).log();
 	try {
 		TLogQueueEntry r = wait(self->persistentQueue->readNext(self));
 		throw internal_error();
 	} catch (Error& e) {
 		if (e.code() != error_code_end_of_stream)
 			throw;
-		TraceEvent("TLogCheckEmptyQueueEnd", self->dbgid);
+		TraceEvent("TLogCheckEmptyQueueEnd", self->dbgid).log();
 		return Void();
 	}
 }
 
 ACTOR Future<Void> checkRecovered(TLogData* self) {
-	TraceEvent("TLogCheckRecoveredBegin", self->dbgid);
+	TraceEvent("TLogCheckRecoveredBegin", self->dbgid).log();
 	Optional<Value> v = wait(self->persistentData->readValue(StringRef()));
-	TraceEvent("TLogCheckRecoveredEnd", self->dbgid);
+	TraceEvent("TLogCheckRecoveredEnd", self->dbgid).log();
 	return Void();
 }
 
@@ -2227,7 +2227,7 @@ ACTOR Future<Void> restorePersistentState(TLogData* self,
 	state KeyRange tagKeys;
 	// PERSIST: Read basic state from persistentData; replay persistentQueue but don't erase it
 
-	TraceEvent("TLogRestorePersistentState", self->dbgid);
+	TraceEvent("TLogRestorePersistentState", self->dbgid).log();
 
 	state IKeyValueStore* storage = self->persistentData;
 	wait(storage->init());
@@ -2585,7 +2585,7 @@ ACTOR Future<Void> tLogStart(TLogData* self, InitializeTLogRequest req, Locality
 	logData->removed = rejoinMasters(self, recruited, req.epoch, Future<Void>(Void()), req.isPrimary);
 	self->queueOrder.push_back(recruited.id());
 
-	TraceEvent("TLogStart", logData->logId);
+	TraceEvent("TLogStart", logData->logId).log();
 	state Future<Void> updater;
 	state bool pulledRecoveryVersions = false;
 	try {
@@ -2730,7 +2730,7 @@ ACTOR Future<Void> tLog(IKeyValueStore* persistentData,
 	state TLogData self(tlogId, workerID, persistentData, persistentQueue, db, degraded, folder);
 	state Future<Void> error = actorCollection(self.sharedActors.getFuture());
 
-	TraceEvent("SharedTlog", tlogId);
+	TraceEvent("SharedTlog", tlogId).log();
 	try {
 		if (restoreFromDisk) {
 			wait(restorePersistentState(&self, locality, oldLog, recovered, tlogRequests));

--- a/fdbserver/OldTLogServer_6_2.actor.cpp
+++ b/fdbserver/OldTLogServer_6_2.actor.cpp
@@ -1464,7 +1464,7 @@ ACTOR Future<Void> tLogPop(TLogData* self, TLogPopRequest req, Reference<LogData
 	// timeout check for ignorePopRequest
 	if (self->ignorePopRequest && (g_network->now() > self->ignorePopDeadline)) {
 
-		TraceEvent("EnableTLogPlayAllIgnoredPops");
+		TraceEvent("EnableTLogPlayAllIgnoredPops").log();
 		// use toBePopped and issue all the pops
 		std::map<Tag, Version>::iterator it;
 		vector<Future<Void>> ignoredPops;
@@ -1871,7 +1871,7 @@ ACTOR Future<Void> watchDegraded(TLogData* self) {
 
 	wait(lowPriorityDelay(SERVER_KNOBS->TLOG_DEGRADED_DURATION));
 
-	TraceEvent(SevWarnAlways, "TLogDegraded", self->dbgid);
+	TraceEvent(SevWarnAlways, "TLogDegraded", self->dbgid).log();
 	TEST(true); // TLog degraded
 	self->degraded->set(true);
 	return Void();
@@ -2109,7 +2109,7 @@ ACTOR Future<Void> initPersistentState(TLogData* self, Reference<LogData> logDat
 		updatePersistentPopped(self, logData, logData->getTagData(tag));
 	}
 
-	TraceEvent("TLogInitCommit", logData->logId);
+	TraceEvent("TLogInitCommit", logData->logId).log();
 	wait(self->persistentData->commit());
 	return Void();
 }
@@ -2312,7 +2312,7 @@ ACTOR Future<Void> tLogEnablePopReq(TLogEnablePopRequest enablePopReq, TLogData*
 		enablePopReq.reply.sendError(operation_failed());
 		return Void();
 	}
-	TraceEvent("EnableTLogPlayAllIgnoredPops2");
+	TraceEvent("EnableTLogPlayAllIgnoredPops2").log();
 	// use toBePopped and issue all the pops
 	std::map<Tag, Version>::iterator it;
 	state vector<Future<Void>> ignoredPops;
@@ -2657,7 +2657,7 @@ ACTOR Future<Void> tLogCore(TLogData* self,
 }
 
 ACTOR Future<Void> checkEmptyQueue(TLogData* self) {
-	TraceEvent("TLogCheckEmptyQueueBegin", self->dbgid);
+	TraceEvent("TLogCheckEmptyQueueBegin", self->dbgid).log();
 	try {
 		bool recoveryFinished = wait(self->persistentQueue->initializeRecovery(0));
 		if (recoveryFinished)
@@ -2667,15 +2667,15 @@ ACTOR Future<Void> checkEmptyQueue(TLogData* self) {
 	} catch (Error& e) {
 		if (e.code() != error_code_end_of_stream)
 			throw;
-		TraceEvent("TLogCheckEmptyQueueEnd", self->dbgid);
+		TraceEvent("TLogCheckEmptyQueueEnd", self->dbgid).log();
 		return Void();
 	}
 }
 
 ACTOR Future<Void> checkRecovered(TLogData* self) {
-	TraceEvent("TLogCheckRecoveredBegin", self->dbgid);
+	TraceEvent("TLogCheckRecoveredBegin", self->dbgid).log();
 	Optional<Value> v = wait(self->persistentData->readValue(StringRef()));
-	TraceEvent("TLogCheckRecoveredEnd", self->dbgid);
+	TraceEvent("TLogCheckRecoveredEnd", self->dbgid).log();
 	return Void();
 }
 
@@ -2690,7 +2690,7 @@ ACTOR Future<Void> restorePersistentState(TLogData* self,
 	state KeyRange tagKeys;
 	// PERSIST: Read basic state from persistentData; replay persistentQueue but don't erase it
 
-	TraceEvent("TLogRestorePersistentState", self->dbgid);
+	TraceEvent("TLogRestorePersistentState", self->dbgid).log();
 
 	state IKeyValueStore* storage = self->persistentData;
 	wait(storage->init());
@@ -3219,7 +3219,7 @@ ACTOR Future<Void> tLog(IKeyValueStore* persistentData,
 	state TLogData self(tlogId, workerID, persistentData, persistentQueue, db, degraded, folder);
 	state Future<Void> error = actorCollection(self.sharedActors.getFuture());
 
-	TraceEvent("SharedTlog", tlogId);
+	TraceEvent("SharedTlog", tlogId).log();
 	try {
 		if (restoreFromDisk) {
 			wait(restorePersistentState(&self, locality, oldLog, recovered, tlogRequests));

--- a/fdbserver/QuietDatabase.actor.cpp
+++ b/fdbserver/QuietDatabase.actor.cpp
@@ -576,7 +576,7 @@ ACTOR Future<Void> repairDeadDatacenter(Database cx,
 		// FIXME: the primary and remote can both be considered dead because excludes are not handled properly by the
 		// datacenterDead function
 		if (primaryDead && remoteDead) {
-			TraceEvent(SevWarnAlways, "CannotDisableFearlessConfiguration");
+			TraceEvent(SevWarnAlways, "CannotDisableFearlessConfiguration").log();
 			return Void();
 		}
 		if (primaryDead || remoteDead) {
@@ -647,7 +647,7 @@ ACTOR Future<Void> waitForQuietDatabase(Database cx,
 
 	loop {
 		try {
-			TraceEvent("QuietDatabaseWaitingOnDataDistributor");
+			TraceEvent("QuietDatabaseWaitingOnDataDistributor").log();
 			WorkerInterface distributorWorker = wait(getDataDistributorWorker(cx, dbInfo));
 			UID distributorUID = dbInfo->get().distributor.get().id();
 			TraceEvent("QuietDatabaseGotDataDistributor", distributorUID)

--- a/fdbserver/Ratekeeper.actor.cpp
+++ b/fdbserver/Ratekeeper.actor.cpp
@@ -801,14 +801,14 @@ ACTOR Future<Void> monitorThrottlingChanges(RatekeeperData* self) {
 				    autoThrottlingEnabled.get().get() == LiteralStringRef("0")) {
 					TEST(true); // Auto-throttling disabled
 					if (self->autoThrottlingEnabled) {
-						TraceEvent("AutoTagThrottlingDisabled", self->id);
+						TraceEvent("AutoTagThrottlingDisabled", self->id).log();
 					}
 					self->autoThrottlingEnabled = false;
 				} else if (autoThrottlingEnabled.get().present() &&
 				           autoThrottlingEnabled.get().get() == LiteralStringRef("1")) {
 					TEST(true); // Auto-throttling enabled
 					if (!self->autoThrottlingEnabled) {
-						TraceEvent("AutoTagThrottlingEnabled", self->id);
+						TraceEvent("AutoTagThrottlingEnabled", self->id).log();
 					}
 					self->autoThrottlingEnabled = true;
 				} else {
@@ -870,7 +870,7 @@ ACTOR Future<Void> monitorThrottlingChanges(RatekeeperData* self) {
 				committed = true;
 
 				wait(watchFuture);
-				TraceEvent("RatekeeperThrottleSignaled", self->id);
+				TraceEvent("RatekeeperThrottleSignaled", self->id).log();
 				TEST(true); // Tag throttle changes detected
 				break;
 			} catch (Error& e) {

--- a/fdbserver/RestoreApplier.actor.cpp
+++ b/fdbserver/RestoreApplier.actor.cpp
@@ -473,7 +473,7 @@ ACTOR static Future<Void> precomputeMutationsResult(Reference<ApplierBatchData> 
 		}
 	}
 
-	TraceEvent("FastRestoreApplierGetAndComputeStagingKeysWaitOn", applierID);
+	TraceEvent("FastRestoreApplierGetAndComputeStagingKeysWaitOn", applierID).log();
 	wait(waitForAll(fGetAndComputeKeys));
 
 	// Sanity check all stagingKeys have been precomputed

--- a/fdbserver/RestoreApplier.actor.h
+++ b/fdbserver/RestoreApplier.actor.h
@@ -317,7 +317,7 @@ struct ApplierBatchData : public ReferenceCounted<ApplierBatchData> {
 				return false;
 			}
 		}
-		TraceEvent("FastRestoreApplierAllKeysPrecomputed");
+		TraceEvent("FastRestoreApplierAllKeysPrecomputed").log();
 		return true;
 	}
 

--- a/fdbserver/RestoreController.actor.cpp
+++ b/fdbserver/RestoreController.actor.cpp
@@ -714,7 +714,7 @@ ACTOR static Future<std::vector<RestoreRequest>> collectRestoreRequests(Database
 	// restoreRequestTriggerKey should already been set
 	loop {
 		try {
-			TraceEvent("FastRestoreControllerPhaseCollectRestoreRequestsWait");
+			TraceEvent("FastRestoreControllerPhaseCollectRestoreRequestsWait").log();
 			tr.setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
 			tr.setOption(FDBTransactionOptions::LOCK_AWARE);
 
@@ -732,7 +732,7 @@ ACTOR static Future<std::vector<RestoreRequest>> collectRestoreRequests(Database
 				}
 				break;
 			} else {
-				TraceEvent(SevError, "FastRestoreControllerPhaseCollectRestoreRequestsEmptyRequests");
+				TraceEvent(SevError, "FastRestoreControllerPhaseCollectRestoreRequestsEmptyRequests").log();
 				wait(delay(5.0));
 			}
 		} catch (Error& e) {
@@ -1079,7 +1079,7 @@ ACTOR static Future<Void> notifyLoadersVersionBatchFinished(std::map<UID, Restor
 // Terminate those roles if terminate = true
 ACTOR static Future<Void> notifyRestoreCompleted(Reference<RestoreControllerData> self, bool terminate = false) {
 	std::vector<std::pair<UID, RestoreFinishRequest>> requests;
-	TraceEvent("FastRestoreControllerPhaseNotifyRestoreCompletedStart");
+	TraceEvent("FastRestoreControllerPhaseNotifyRestoreCompletedStart").log();
 	for (auto& loader : self->loadersInterf) {
 		requests.emplace_back(loader.first, RestoreFinishRequest(terminate));
 	}
@@ -1099,7 +1099,7 @@ ACTOR static Future<Void> notifyRestoreCompleted(Reference<RestoreControllerData
 		wait(endLoaders && endAppliers);
 	}
 
-	TraceEvent("FastRestoreControllerPhaseNotifyRestoreCompletedDone");
+	TraceEvent("FastRestoreControllerPhaseNotifyRestoreCompletedDone").log();
 
 	return Void();
 }
@@ -1128,7 +1128,7 @@ ACTOR static Future<Void> signalRestoreCompleted(Reference<RestoreControllerData
 		}
 	}
 
-	TraceEvent("FastRestoreControllerAllRestoreCompleted");
+	TraceEvent("FastRestoreControllerAllRestoreCompleted").log();
 
 	return Void();
 }

--- a/fdbserver/RestoreWorker.actor.cpp
+++ b/fdbserver/RestoreWorker.actor.cpp
@@ -277,7 +277,7 @@ ACTOR static Future<Void> waitOnRestoreRequests(Database cx, UID nodeID = UID())
 	state Optional<Value> numRequests;
 
 	// wait for the restoreRequestTriggerKey to be set by the client/test workload
-	TraceEvent("FastRestoreWaitOnRestoreRequest", nodeID);
+	TraceEvent("FastRestoreWaitOnRestoreRequest", nodeID).log();
 	loop {
 		try {
 			tr.reset();
@@ -288,9 +288,9 @@ ACTOR static Future<Void> waitOnRestoreRequests(Database cx, UID nodeID = UID())
 			if (!numRequests.present()) {
 				state Future<Void> watchForRestoreRequest = tr.watch(restoreRequestTriggerKey);
 				wait(tr.commit());
-				TraceEvent(SevInfo, "FastRestoreWaitOnRestoreRequestTriggerKey", nodeID);
+				TraceEvent(SevInfo, "FastRestoreWaitOnRestoreRequestTriggerKey", nodeID).log();
 				wait(watchForRestoreRequest);
-				TraceEvent(SevInfo, "FastRestoreDetectRestoreRequestTriggerKeyChanged", nodeID);
+				TraceEvent(SevInfo, "FastRestoreDetectRestoreRequestTriggerKeyChanged", nodeID).log();
 			} else {
 				TraceEvent(SevInfo, "FastRestoreRestoreRequestTriggerKey", nodeID)
 				    .detail("TriggerKey", numRequests.get().toString());

--- a/fdbserver/SimulatedCluster.actor.cpp
+++ b/fdbserver/SimulatedCluster.actor.cpp
@@ -408,7 +408,7 @@ ACTOR Future<Void> runDr(Reference<ClusterConnectionFile> connFile) {
 			wait(delay(1.0));
 		}
 
-		TraceEvent("StoppingDrAgents");
+		TraceEvent("StoppingDrAgents").log();
 
 		for (auto it : agentFutures) {
 			it.cancel();
@@ -2205,7 +2205,7 @@ ACTOR void setupAndRun(std::string dataFolder,
 		TraceEvent(SevError, "SetupAndRunError").error(e);
 	}
 
-	TraceEvent("SimulatedSystemDestruct");
+	TraceEvent("SimulatedSystemDestruct").log();
 	g_simulator.stop();
 	destructed = true;
 	wait(Never());

--- a/fdbserver/StorageCache.actor.cpp
+++ b/fdbserver/StorageCache.actor.cpp
@@ -425,7 +425,7 @@ ACTOR Future<Version> waitForVersion(StorageCacheData* data, Version version) {
 	}
 
 	if (deterministicRandom()->random01() < 0.001)
-		TraceEvent("WaitForVersion1000x");
+		TraceEvent("WaitForVersion1000x").log();
 	choose {
 		when(wait(data->version.whenAtLeast(version))) {
 			// FIXME: A bunch of these can block with or without the following delay 0.
@@ -1363,7 +1363,7 @@ ACTOR Future<Void> fetchKeys(StorageCacheData* data, AddingCacheRange* cacheRang
 				// doesn't fit on this cache. For now, we can just fail this cache role. In future, we should think
 				// about evicting some data to make room for the remaining keys
 				if (this_block.more) {
-					TraceEvent(SevDebug, "CacheWarmupMoreDataThanLimit", data->thisServerID);
+					TraceEvent(SevDebug, "CacheWarmupMoreDataThanLimit", data->thisServerID).log();
 					throw please_reboot();
 				}
 
@@ -1780,7 +1780,7 @@ private:
 				rollback(data, rollbackVersion, currentVersion);
 			}
 		} else {
-			TraceEvent(SevWarn, "SCPrivateCacheMutation: Unknown private mutation");
+			TraceEvent(SevWarn, "SCPrivateCacheMutation: Unknown private mutation").log();
 			// ASSERT(false);  // Unknown private mutation
 		}
 	}

--- a/fdbserver/TLogServer.actor.cpp
+++ b/fdbserver/TLogServer.actor.cpp
@@ -2160,7 +2160,7 @@ ACTOR Future<Void> initPersistentState(TLogData* self, Reference<LogData> logDat
 		updatePersistentPopped(self, logData, logData->getTagData(tag));
 	}
 
-	TraceEvent("TLogInitCommit", logData->logId);
+	TraceEvent("TLogInitCommit", logData->logId).log();
 	wait(ioTimeoutError(self->persistentData->commit(), SERVER_KNOBS->TLOG_MAX_CREATE_DURATION));
 	return Void();
 }
@@ -2713,7 +2713,7 @@ ACTOR Future<Void> tLogCore(TLogData* self,
 }
 
 ACTOR Future<Void> checkEmptyQueue(TLogData* self) {
-	TraceEvent("TLogCheckEmptyQueueBegin", self->dbgid);
+	TraceEvent("TLogCheckEmptyQueueBegin", self->dbgid).log();
 	try {
 		bool recoveryFinished = wait(self->persistentQueue->initializeRecovery(0));
 		if (recoveryFinished)
@@ -2723,15 +2723,15 @@ ACTOR Future<Void> checkEmptyQueue(TLogData* self) {
 	} catch (Error& e) {
 		if (e.code() != error_code_end_of_stream)
 			throw;
-		TraceEvent("TLogCheckEmptyQueueEnd", self->dbgid);
+		TraceEvent("TLogCheckEmptyQueueEnd", self->dbgid).log();
 		return Void();
 	}
 }
 
 ACTOR Future<Void> checkRecovered(TLogData* self) {
-	TraceEvent("TLogCheckRecoveredBegin", self->dbgid);
+	TraceEvent("TLogCheckRecoveredBegin", self->dbgid).log();
 	Optional<Value> v = wait(self->persistentData->readValue(StringRef()));
-	TraceEvent("TLogCheckRecoveredEnd", self->dbgid);
+	TraceEvent("TLogCheckRecoveredEnd", self->dbgid).log();
 	return Void();
 }
 
@@ -2746,7 +2746,7 @@ ACTOR Future<Void> restorePersistentState(TLogData* self,
 	state KeyRange tagKeys;
 	// PERSIST: Read basic state from persistentData; replay persistentQueue but don't erase it
 
-	TraceEvent("TLogRestorePersistentState", self->dbgid);
+	TraceEvent("TLogRestorePersistentState", self->dbgid).log();
 
 	state IKeyValueStore* storage = self->persistentData;
 	wait(storage->init());
@@ -3294,7 +3294,7 @@ ACTOR Future<Void> tLog(IKeyValueStore* persistentData,
 	state TLogData self(tlogId, workerID, persistentData, persistentQueue, db, degraded, folder);
 	state Future<Void> error = actorCollection(self.sharedActors.getFuture());
 
-	TraceEvent("SharedTlog", tlogId);
+	TraceEvent("SharedTlog", tlogId).log();
 	try {
 		if (restoreFromDisk) {
 			wait(restorePersistentState(&self, locality, oldLog, recovered, tlogRequests));

--- a/fdbserver/TagPartitionedLogSystem.actor.cpp
+++ b/fdbserver/TagPartitionedLogSystem.actor.cpp
@@ -415,7 +415,7 @@ struct TagPartitionedLogSystem : ILogSystem, ReferenceCounted<TagPartitionedLogS
 		}
 		for (auto& t : newState.tLogs) {
 			if (!t.isLocal) {
-				TraceEvent("RemoteLogsWritten", dbgid);
+				TraceEvent("RemoteLogsWritten", dbgid).log();
 				remoteLogsWrittenToCoreState = true;
 				break;
 			}
@@ -1101,7 +1101,7 @@ struct TagPartitionedLogSystem : ILogSystem, ReferenceCounted<TagPartitionedLogS
 	                               bool canDiscardPopped) final {
 		Version end = getEnd();
 		if (!tLogs.size()) {
-			TraceEvent("TLogPeekTxsNoLogs", dbgid);
+			TraceEvent("TLogPeekTxsNoLogs", dbgid).log();
 			return makeReference<ILogSystem::ServerPeekCursor>(
 			    Reference<AsyncVar<OptionalInterface<TLogInterface>>>(), txsTag, begin, end, false, false);
 		}
@@ -1534,7 +1534,7 @@ struct TagPartitionedLogSystem : ILogSystem, ReferenceCounted<TagPartitionedLogS
 		wait(waitForAll(poppedReady) || maxGetPoppedDuration);
 
 		if (maxGetPoppedDuration.isReady()) {
-			TraceEvent(SevWarnAlways, "PoppedTxsNotReady", dbgid);
+			TraceEvent(SevWarnAlways, "PoppedTxsNotReady", dbgid).log();
 		}
 
 		Version maxPopped = 1;
@@ -2480,7 +2480,7 @@ struct TagPartitionedLogSystem : ILogSystem, ReferenceCounted<TagPartitionedLogS
 	                                         LogEpoch recoveryCount,
 	                                         int8_t remoteLocality,
 	                                         std::vector<Tag> allTags) {
-		TraceEvent("RemoteLogRecruitment_WaitingForWorkers");
+		TraceEvent("RemoteLogRecruitment_WaitingForWorkers").log();
 		state RecruitRemoteFromConfigurationReply remoteWorkers = wait(fRemoteWorkers);
 
 		state Reference<LogSet> logSet(new LogSet());
@@ -2655,7 +2655,7 @@ struct TagPartitionedLogSystem : ILogSystem, ReferenceCounted<TagPartitionedLogS
 
 		self->remoteRecoveryComplete = waitForAll(recoveryComplete);
 		self->tLogs.push_back(logSet);
-		TraceEvent("RemoteLogRecruitment_CompletingRecovery");
+		TraceEvent("RemoteLogRecruitment_CompletingRecovery").log();
 		return Void();
 	}
 
@@ -3149,7 +3149,7 @@ struct TagPartitionedLogSystem : ILogSystem, ReferenceCounted<TagPartitionedLogS
 
 	    // Step 1: Verify that if all the failed TLogs come back, they can't form a quorum.
 	    if (can_obtain_quorum(locking_failed)) {
-	        TraceEvent(SevInfo, "MasterRecoveryTLogLockingImpossible", dbgid);
+	        TraceEvent(SevInfo, "MasterRecoveryTLogLockingImpossible", dbgid).log();
 	        return;
 	    }
 

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -1189,7 +1189,7 @@ Future<Version> waitForVersion(StorageServer* data, Version version, SpanID span
 	}
 
 	if (deterministicRandom()->random01() < 0.001) {
-		TraceEvent("WaitForVersion1000x");
+		TraceEvent("WaitForVersion1000x").log();
 	}
 	return waitForVersionActor(data, version, spanContext);
 }
@@ -3542,10 +3542,10 @@ private:
 				ASSERT(ssId == data->thisServerID);
 				if (m.type == MutationRef::SetValue) {
 					TEST(true); // Putting TSS in quarantine
-					TraceEvent(SevWarn, "TSSQuarantineStart", data->thisServerID);
+					TraceEvent(SevWarn, "TSSQuarantineStart", data->thisServerID).log();
 					data->startTssQuarantine();
 				} else {
-					TraceEvent(SevWarn, "TSSQuarantineStop", data->thisServerID);
+					TraceEvent(SevWarn, "TSSQuarantineStop", data->thisServerID).log();
 					// dipose of this TSS
 					throw worker_removed();
 				}
@@ -3620,7 +3620,7 @@ ACTOR Future<Void> update(StorageServer* data, bool* pReceivedUpdate) {
 		    !g_simulator.speedUpSimulation && data->tssFaultInjectTime.present() &&
 		    data->tssFaultInjectTime.get() < now()) {
 			if (deterministicRandom()->random01() < 0.01) {
-				TraceEvent(SevWarnAlways, "TSSInjectDelayForever", data->thisServerID);
+				TraceEvent(SevWarnAlways, "TSSInjectDelayForever", data->thisServerID).log();
 				// small random chance to just completely get stuck here, each tss should eventually hit this in this
 				// mode
 				wait(tssDelayForever());
@@ -3835,7 +3835,7 @@ ACTOR Future<Void> update(StorageServer* data, bool* pReceivedUpdate) {
 				} else if (ver != invalidVersion) { // This change belongs to a version < minVersion
 					DEBUG_MUTATION("SSPeek", ver, msg).detail("ServerID", data->thisServerID);
 					if (ver == 1) {
-						TraceEvent("SSPeekMutation", data->thisServerID);
+						TraceEvent("SSPeekMutation", data->thisServerID).log();
 						// The following trace event may produce a value with special characters
 						//TraceEvent("SSPeekMutation", data->thisServerID).detail("Mutation", msg.toString()).detail("Version", cloneCursor2->version().toString());
 					}
@@ -4333,15 +4333,15 @@ ACTOR Future<bool> restoreDurableState(StorageServer* data, IKeyValueStore* stor
 	data->byteSampleRecovery =
 	    restoreByteSample(data, storage, byteSampleSampleRecovered, startByteSampleRestore.getFuture());
 
-	TraceEvent("ReadingDurableState", data->thisServerID);
+	TraceEvent("ReadingDurableState", data->thisServerID).log();
 	wait(waitForAll(std::vector{ fFormat, fID, ftssPairID, fTssQuarantine, fVersion, fLogProtocol, fPrimaryLocality }));
 	wait(waitForAll(std::vector{ fShardAssigned, fShardAvailable }));
 	wait(byteSampleSampleRecovered.getFuture());
-	TraceEvent("RestoringDurableState", data->thisServerID);
+	TraceEvent("RestoringDurableState", data->thisServerID).log();
 
 	if (!fFormat.get().present()) {
 		// The DB was never initialized
-		TraceEvent("DBNeverInitialized", data->thisServerID);
+		TraceEvent("DBNeverInitialized", data->thisServerID).log();
 		storage->dispose();
 		data->thisServerID = UID();
 		data->sk = Key();
@@ -5262,7 +5262,7 @@ ACTOR Future<Void> replaceInterface(StorageServer* self, StorageServerInterface 
 							}
 
 							if (self->history.size() && BUGGIFY) {
-								TraceEvent("SSHistoryReboot", self->thisServerID);
+								TraceEvent("SSHistoryReboot", self->thisServerID).log();
 								throw please_reboot();
 							}
 
@@ -5337,7 +5337,7 @@ ACTOR Future<Void> storageServer(IKeyValueStore* persistentData,
 
 	try {
 		state double start = now();
-		TraceEvent("StorageServerRebootStart", self.thisServerID);
+		TraceEvent("StorageServerRebootStart", self.thisServerID).log();
 
 		wait(self.storage.init());
 		choose {
@@ -5346,7 +5346,7 @@ ACTOR Future<Void> storageServer(IKeyValueStore* persistentData,
 			when(wait(self.storage.commit())) {}
 
 			when(wait(memoryStoreRecover(persistentData, connFile, self.thisServerID))) {
-				TraceEvent("DisposeStorageServer", self.thisServerID);
+				TraceEvent("DisposeStorageServer", self.thisServerID).log();
 				throw worker_removed();
 			}
 		}

--- a/fdbserver/tester.actor.cpp
+++ b/fdbserver/tester.actor.cpp
@@ -817,7 +817,7 @@ ACTOR Future<DistributedTestResults> runWorkload(Database cx, std::vector<Tester
 		}
 
 		state std::vector<Future<ErrorOr<CheckReply>>> checks;
-		TraceEvent("CheckingResults");
+		TraceEvent("CheckingResults").log();
 
 		printf("checking test (%s)...\n", printable(spec.title).c_str());
 
@@ -1016,7 +1016,7 @@ ACTOR Future<bool> runTest(Database cx,
 
 	if (spec.useDB && spec.clearAfterTest) {
 		try {
-			TraceEvent("TesterClearingDatabase");
+			TraceEvent("TesterClearingDatabase").log();
 			wait(timeoutError(clearData(cx), 1000.0));
 		} catch (Error& e) {
 			TraceEvent(SevError, "ErrorClearingDatabaseAfterTest").error(e);
@@ -1559,7 +1559,7 @@ ACTOR Future<Void> runTests(Reference<AsyncVar<Optional<struct ClusterController
 			}
 			when(wait(cc->onChange())) {}
 			when(wait(testerTimeout)) {
-				TraceEvent(SevError, "TesterRecruitmentTimeout");
+				TraceEvent(SevError, "TesterRecruitmentTimeout").log();
 				throw timed_out();
 			}
 		}

--- a/fdbserver/worker.actor.cpp
+++ b/fdbserver/worker.actor.cpp
@@ -848,7 +848,7 @@ bool checkHighMemory(int64_t threshold, bool* error) {
 	uint64_t page_size = sysconf(_SC_PAGESIZE);
 	int fd = open("/proc/self/statm", O_RDONLY | O_CLOEXEC);
 	if (fd < 0) {
-		TraceEvent("OpenStatmFileFailure");
+		TraceEvent("OpenStatmFileFailure").log();
 		*error = true;
 		return false;
 	}
@@ -857,7 +857,7 @@ bool checkHighMemory(int64_t threshold, bool* error) {
 	char stat_buf[buf_sz];
 	ssize_t stat_nread = read(fd, stat_buf, buf_sz);
 	if (stat_nread < 0) {
-		TraceEvent("ReadStatmFileFailure");
+		TraceEvent("ReadStatmFileFailure").log();
 		*error = true;
 		return false;
 	}
@@ -869,7 +869,7 @@ bool checkHighMemory(int64_t threshold, bool* error) {
 		return true;
 	}
 #else
-	TraceEvent("CheckHighMemoryUnsupported");
+	TraceEvent("CheckHighMemoryUnsupported").log();
 	*error = true;
 #endif
 	return false;
@@ -926,7 +926,7 @@ ACTOR Future<Void> storageServerRollbackRebooter(std::set<std::pair<UID, KeyValu
 		else if (e.getError().code() != error_code_please_reboot)
 			throw e.getError();
 
-		TraceEvent("StorageServerRequestedReboot", id);
+		TraceEvent("StorageServerRequestedReboot", id).log();
 
 		StorageServerInterface recruited;
 		recruited.uniqueID = id;
@@ -964,7 +964,7 @@ ACTOR Future<Void> storageCacheRollbackRebooter(Future<Void> prevStorageCache,
 	loop {
 		ErrorOr<Void> e = wait(errorOr(prevStorageCache));
 		if (!e.isError()) {
-			TraceEvent("StorageCacheRequestedReboot1", id);
+			TraceEvent("StorageCacheRequestedReboot1", id).log();
 			return Void();
 		} else if (e.getError().code() != error_code_please_reboot &&
 		           e.getError().code() != error_code_worker_removed) {
@@ -972,7 +972,7 @@ ACTOR Future<Void> storageCacheRollbackRebooter(Future<Void> prevStorageCache,
 			throw e.getError();
 		}
 
-		TraceEvent("StorageCacheRequestedReboot", id);
+		TraceEvent("StorageCacheRequestedReboot", id).log();
 
 		StorageServerInterface recruited;
 		recruited.uniqueID = deterministicRandom()->randomUniqueID(); // id;
@@ -1504,7 +1504,7 @@ ACTOR Future<Void> workerServer(Reference<ClusterConnectionFile> connFile,
 					}
 					throw please_reboot();
 				} else {
-					TraceEvent("ProcessReboot");
+					TraceEvent("ProcessReboot").log();
 					ASSERT(!rebootReq.deleteData);
 					flushAndExit(0);
 				}
@@ -2017,7 +2017,7 @@ ACTOR Future<Void> printOnFirstConnected(Reference<AsyncVar<Optional<ClusterInte
 			                                    ci->get().get().openDatabase.getEndpoint(), FailureStatus(false))
 			                              : Never())) {
 				printf("FDBD joined cluster.\n");
-				TraceEvent("FDBDConnected");
+				TraceEvent("FDBDConnected").log();
 				return Void();
 			}
 			when(wait(ci->onChange())) {}

--- a/fdbserver/workloads/AtomicOpsApiCorrectness.actor.cpp
+++ b/fdbserver/workloads/AtomicOpsApiCorrectness.actor.cpp
@@ -480,7 +480,7 @@ public:
 		TraceEvent("AtomicOpCorrectnessApiWorkload").detail("OpType", "MIN");
 		// API Version 500
 		setApiVersion(&cx, 500);
-		TraceEvent(SevInfo, "Running Atomic Op Min Correctness Test Api Version 500");
+		TraceEvent(SevInfo, "Running Atomic Op Min Correctness Test Api Version 500").log();
 		wait(self->testAtomicOpUnsetOnNonExistingKey(cx, self, MutationRef::Min, key));
 		wait(self->testAtomicOpApi(
 		    cx, self, MutationRef::Min, key, [](uint64_t val1, uint64_t val2) { return val1 < val2 ? val1 : val2; }));
@@ -513,7 +513,7 @@ public:
 	ACTOR Future<Void> testMax(Database cx, AtomicOpsApiCorrectnessWorkload* self) {
 		state Key key = self->getTestKey("test_key_max_");
 
-		TraceEvent(SevInfo, "Running Atomic Op MAX Correctness Current Api Version");
+		TraceEvent(SevInfo, "Running Atomic Op MAX Correctness Current Api Version").log();
 		wait(self->testAtomicOpSetOnNonExistingKey(cx, self, MutationRef::Max, key));
 		wait(self->testAtomicOpApi(
 		    cx, self, MutationRef::Max, key, [](uint64_t val1, uint64_t val2) { return val1 > val2 ? val1 : val2; }));
@@ -530,7 +530,7 @@ public:
 		TraceEvent("AtomicOpCorrectnessApiWorkload").detail("OpType", "AND");
 		// API Version 500
 		setApiVersion(&cx, 500);
-		TraceEvent(SevInfo, "Running Atomic Op AND Correctness Test Api Version 500");
+		TraceEvent(SevInfo, "Running Atomic Op AND Correctness Test Api Version 500").log();
 		wait(self->testAtomicOpUnsetOnNonExistingKey(cx, self, MutationRef::And, key));
 		wait(self->testAtomicOpApi(
 		    cx, self, MutationRef::And, key, [](uint64_t val1, uint64_t val2) { return val1 & val2; }));
@@ -563,7 +563,7 @@ public:
 	ACTOR Future<Void> testOr(Database cx, AtomicOpsApiCorrectnessWorkload* self) {
 		state Key key = self->getTestKey("test_key_or_");
 
-		TraceEvent(SevInfo, "Running Atomic Op OR Correctness Current Api Version");
+		TraceEvent(SevInfo, "Running Atomic Op OR Correctness Current Api Version").log();
 		wait(self->testAtomicOpSetOnNonExistingKey(cx, self, MutationRef::Or, key));
 		wait(self->testAtomicOpApi(
 		    cx, self, MutationRef::Or, key, [](uint64_t val1, uint64_t val2) { return val1 | val2; }));
@@ -576,7 +576,7 @@ public:
 	ACTOR Future<Void> testXor(Database cx, AtomicOpsApiCorrectnessWorkload* self) {
 		state Key key = self->getTestKey("test_key_xor_");
 
-		TraceEvent(SevInfo, "Running Atomic Op XOR Correctness Current Api Version");
+		TraceEvent(SevInfo, "Running Atomic Op XOR Correctness Current Api Version").log();
 		wait(self->testAtomicOpSetOnNonExistingKey(cx, self, MutationRef::Xor, key));
 		wait(self->testAtomicOpApi(
 		    cx, self, MutationRef::Xor, key, [](uint64_t val1, uint64_t val2) { return val1 ^ val2; }));
@@ -588,7 +588,7 @@ public:
 
 	ACTOR Future<Void> testAdd(Database cx, AtomicOpsApiCorrectnessWorkload* self) {
 		state Key key = self->getTestKey("test_key_add_");
-		TraceEvent(SevInfo, "Running Atomic Op ADD Correctness Current Api Version");
+		TraceEvent(SevInfo, "Running Atomic Op ADD Correctness Current Api Version").log();
 		wait(self->testAtomicOpSetOnNonExistingKey(cx, self, MutationRef::AddValue, key));
 		wait(self->testAtomicOpApi(
 		    cx, self, MutationRef::AddValue, key, [](uint64_t val1, uint64_t val2) { return val1 + val2; }));
@@ -601,7 +601,7 @@ public:
 
 	ACTOR Future<Void> testCompareAndClear(Database cx, AtomicOpsApiCorrectnessWorkload* self) {
 		state Key key = self->getTestKey("test_key_compare_and_clear_");
-		TraceEvent(SevInfo, "Running Atomic Op COMPARE_AND_CLEAR Correctness Current Api Version");
+		TraceEvent(SevInfo, "Running Atomic Op COMPARE_AND_CLEAR Correctness Current Api Version").log();
 		wait(self->testCompareAndClearAtomicOpApi(cx, self, key, true));
 		wait(self->testCompareAndClearAtomicOpApi(cx, self, key, false));
 		return Void();
@@ -610,7 +610,7 @@ public:
 	ACTOR Future<Void> testByteMin(Database cx, AtomicOpsApiCorrectnessWorkload* self) {
 		state Key key = self->getTestKey("test_key_byte_min_");
 
-		TraceEvent(SevInfo, "Running Atomic Op BYTE_MIN Correctness Current Api Version");
+		TraceEvent(SevInfo, "Running Atomic Op BYTE_MIN Correctness Current Api Version").log();
 		wait(self->testAtomicOpSetOnNonExistingKey(cx, self, MutationRef::ByteMin, key));
 		wait(self->testAtomicOpApi(cx, self, MutationRef::ByteMin, key, [](uint64_t val1, uint64_t val2) {
 			return StringRef((const uint8_t*)&val1, sizeof(val1)) < StringRef((const uint8_t*)&val2, sizeof(val2))
@@ -626,7 +626,7 @@ public:
 	ACTOR Future<Void> testByteMax(Database cx, AtomicOpsApiCorrectnessWorkload* self) {
 		state Key key = self->getTestKey("test_key_byte_max_");
 
-		TraceEvent(SevInfo, "Running Atomic Op BYTE_MAX Correctness Current Api Version");
+		TraceEvent(SevInfo, "Running Atomic Op BYTE_MAX Correctness Current Api Version").log();
 		wait(self->testAtomicOpSetOnNonExistingKey(cx, self, MutationRef::ByteMax, key));
 		wait(self->testAtomicOpApi(cx, self, MutationRef::ByteMax, key, [](uint64_t val1, uint64_t val2) {
 			return StringRef((const uint8_t*)&val1, sizeof(val1)) > StringRef((const uint8_t*)&val2, sizeof(val2))

--- a/fdbserver/workloads/AtomicRestore.actor.cpp
+++ b/fdbserver/workloads/AtomicRestore.actor.cpp
@@ -104,14 +104,14 @@ struct AtomicRestoreWorkload : TestWorkload {
 				throw;
 		}
 
-		TraceEvent("AtomicRestore_Wait");
+		TraceEvent("AtomicRestore_Wait").log();
 		wait(success(backupAgent.waitBackup(cx, BackupAgentBase::getDefaultTagName(), StopWhenDone::False)));
-		TraceEvent("AtomicRestore_BackupStart");
+		TraceEvent("AtomicRestore_BackupStart").log();
 		wait(delay(self->restoreAfter * deterministicRandom()->random01()));
-		TraceEvent("AtomicRestore_RestoreStart");
+		TraceEvent("AtomicRestore_RestoreStart").log();
 
 		if (self->fastRestore) { // New fast parallel restore
-			TraceEvent(SevInfo, "AtomicParallelRestore");
+			TraceEvent(SevInfo, "AtomicParallelRestore").log();
 			wait(backupAgent.atomicParallelRestore(
 			    cx, BackupAgentBase::getDefaultTag(), self->backupRanges, self->addPrefix, self->removePrefix));
 		} else { // Old style restore
@@ -141,7 +141,7 @@ struct AtomicRestoreWorkload : TestWorkload {
 			g_simulator.backupAgents = ISimulator::BackupAgentType::NoBackupAgents;
 		}
 
-		TraceEvent("AtomicRestore_Done");
+		TraceEvent("AtomicRestore_Done").log();
 		return Void();
 	}
 };

--- a/fdbserver/workloads/AtomicSwitchover.actor.cpp
+++ b/fdbserver/workloads/AtomicSwitchover.actor.cpp
@@ -53,7 +53,7 @@ struct AtomicSwitchoverWorkload : TestWorkload {
 	ACTOR static Future<Void> _setup(Database cx, AtomicSwitchoverWorkload* self) {
 		state DatabaseBackupAgent backupAgent(cx);
 		try {
-			TraceEvent("AS_Submit1");
+			TraceEvent("AS_Submit1").log();
 			wait(backupAgent.submitBackup(self->extraDB,
 			                              BackupAgentBase::getDefaultTag(),
 			                              self->backupRanges,
@@ -61,7 +61,7 @@ struct AtomicSwitchoverWorkload : TestWorkload {
 			                              StringRef(),
 			                              StringRef(),
 			                              LockDB::True));
-			TraceEvent("AS_Submit2");
+			TraceEvent("AS_Submit2").log();
 		} catch (Error& e) {
 			if (e.code() != error_code_backup_duplicate)
 				throw;
@@ -167,27 +167,27 @@ struct AtomicSwitchoverWorkload : TestWorkload {
 		state DatabaseBackupAgent backupAgent(cx);
 		state DatabaseBackupAgent restoreTool(self->extraDB);
 
-		TraceEvent("AS_Wait1");
+		TraceEvent("AS_Wait1").log();
 		wait(success(backupAgent.waitBackup(self->extraDB, BackupAgentBase::getDefaultTag(), StopWhenDone::False)));
-		TraceEvent("AS_Ready1");
+		TraceEvent("AS_Ready1").log();
 		wait(delay(deterministicRandom()->random01() * self->switch1delay));
-		TraceEvent("AS_Switch1");
+		TraceEvent("AS_Switch1").log();
 		wait(backupAgent.atomicSwitchover(
 		    self->extraDB, BackupAgentBase::getDefaultTag(), self->backupRanges, StringRef(), StringRef()));
-		TraceEvent("AS_Wait2");
+		TraceEvent("AS_Wait2").log();
 		wait(success(restoreTool.waitBackup(cx, BackupAgentBase::getDefaultTag(), StopWhenDone::False)));
-		TraceEvent("AS_Ready2");
+		TraceEvent("AS_Ready2").log();
 		wait(delay(deterministicRandom()->random01() * self->switch2delay));
-		TraceEvent("AS_Switch2");
+		TraceEvent("AS_Switch2").log();
 		wait(restoreTool.atomicSwitchover(
 		    cx, BackupAgentBase::getDefaultTag(), self->backupRanges, StringRef(), StringRef()));
-		TraceEvent("AS_Wait3");
+		TraceEvent("AS_Wait3").log();
 		wait(success(backupAgent.waitBackup(self->extraDB, BackupAgentBase::getDefaultTag(), StopWhenDone::False)));
-		TraceEvent("AS_Ready3");
+		TraceEvent("AS_Ready3").log();
 		wait(delay(deterministicRandom()->random01() * self->stopDelay));
-		TraceEvent("AS_Abort");
+		TraceEvent("AS_Abort").log();
 		wait(backupAgent.abortBackup(self->extraDB, BackupAgentBase::getDefaultTag()));
-		TraceEvent("AS_Done");
+		TraceEvent("AS_Done").log();
 
 		// SOMEDAY: Remove after backup agents can exist quiescently
 		if (g_simulator.drAgents == ISimulator::BackupAgentType::BackupToDB) {

--- a/fdbserver/workloads/BackupAndParallelRestoreCorrectness.actor.cpp
+++ b/fdbserver/workloads/BackupAndParallelRestoreCorrectness.actor.cpp
@@ -384,7 +384,7 @@ struct BackupAndParallelRestoreCorrectnessWorkload : TestWorkload {
 				                                  Key(),
 				                                  Key(),
 				                                  self->locked)));
-				TraceEvent(SevError, "BARW_RestoreAllowedOverwrittingDatabase", randomID);
+				TraceEvent(SevError, "BARW_RestoreAllowedOverwrittingDatabase", randomID).log();
 				ASSERT(false);
 			} catch (Error& e) {
 				if (e.code() != error_code_restore_destination_not_empty) {

--- a/fdbserver/workloads/BackupCorrectness.actor.cpp
+++ b/fdbserver/workloads/BackupCorrectness.actor.cpp
@@ -430,7 +430,7 @@ struct BackupAndRestoreCorrectnessWorkload : TestWorkload {
 				                                  Key(),
 				                                  Key(),
 				                                  self->locked)));
-				TraceEvent(SevError, "BARW_RestoreAllowedOverwrittingDatabase", randomID);
+				TraceEvent(SevError, "BARW_RestoreAllowedOverwrittingDatabase", randomID).log();
 				ASSERT(false);
 			} catch (Error& e) {
 				if (e.code() != error_code_restore_destination_not_empty) {

--- a/fdbserver/workloads/BackupToDBAbort.actor.cpp
+++ b/fdbserver/workloads/BackupToDBAbort.actor.cpp
@@ -52,7 +52,7 @@ struct BackupToDBAbort : TestWorkload {
 	ACTOR static Future<Void> _setup(BackupToDBAbort* self, Database cx) {
 		state DatabaseBackupAgent backupAgent(cx);
 		try {
-			TraceEvent("BDBA_Submit1");
+			TraceEvent("BDBA_Submit1").log();
 			wait(backupAgent.submitBackup(self->extraDB,
 			                              BackupAgentBase::getDefaultTag(),
 			                              self->backupRanges,
@@ -60,7 +60,7 @@ struct BackupToDBAbort : TestWorkload {
 			                              StringRef(),
 			                              StringRef(),
 			                              LockDB::True));
-			TraceEvent("BDBA_Submit2");
+			TraceEvent("BDBA_Submit2").log();
 		} catch (Error& e) {
 			if (e.code() != error_code_backup_duplicate)
 				throw;
@@ -79,15 +79,15 @@ struct BackupToDBAbort : TestWorkload {
 
 		TraceEvent("BDBA_Start").detail("Delay", self->abortDelay);
 		wait(delay(self->abortDelay));
-		TraceEvent("BDBA_Wait");
+		TraceEvent("BDBA_Wait").log();
 		wait(success(backupAgent.waitBackup(self->extraDB, BackupAgentBase::getDefaultTag(), StopWhenDone::False)));
-		TraceEvent("BDBA_Lock");
+		TraceEvent("BDBA_Lock").log();
 		wait(lockDatabase(cx, self->lockid));
-		TraceEvent("BDBA_Abort");
+		TraceEvent("BDBA_Abort").log();
 		wait(backupAgent.abortBackup(self->extraDB, BackupAgentBase::getDefaultTag()));
-		TraceEvent("BDBA_Unlock");
+		TraceEvent("BDBA_Unlock").log();
 		wait(backupAgent.unlockBackup(self->extraDB, BackupAgentBase::getDefaultTag()));
-		TraceEvent("BDBA_End");
+		TraceEvent("BDBA_End").log();
 
 		// SOMEDAY: Remove after backup agents can exist quiescently
 		if (g_simulator.drAgents == ISimulator::BackupAgentType::BackupToDB) {
@@ -98,7 +98,7 @@ struct BackupToDBAbort : TestWorkload {
 	}
 
 	ACTOR static Future<bool> _check(BackupToDBAbort* self, Database cx) {
-		TraceEvent("BDBA_UnlockPrimary");
+		TraceEvent("BDBA_UnlockPrimary").log();
 		// Too much of the tester framework expects the primary database to be unlocked, so we unlock it
 		// once all of the workloads have finished.
 		wait(unlockDatabase(cx, self->lockid));

--- a/fdbserver/workloads/BackupToDBUpgrade.actor.cpp
+++ b/fdbserver/workloads/BackupToDBUpgrade.actor.cpp
@@ -78,7 +78,7 @@ struct BackupToDBUpgradeWorkload : TestWorkload {
 		auto extraFile = makeReference<ClusterConnectionFile>(*g_simulator.extraDB);
 		extraDB = Database::createDatabase(extraFile, -1);
 
-		TraceEvent("DRU_Start");
+		TraceEvent("DRU_Start").log();
 	}
 
 	std::string description() const override { return "BackupToDBUpgrade"; }
@@ -459,7 +459,7 @@ struct BackupToDBUpgradeWorkload : TestWorkload {
 				}
 			}
 
-			TraceEvent("DRU_DiffRanges");
+			TraceEvent("DRU_DiffRanges").log();
 			wait(diffRanges(prevBackupRanges, self->backupPrefix, cx, self->extraDB));
 
 			// abort backup

--- a/fdbserver/workloads/BulkSetup.actor.h
+++ b/fdbserver/workloads/BulkSetup.actor.h
@@ -284,7 +284,7 @@ Future<Void> bulkSetup(Database cx,
 					wait(delay(1.0));
 				} else {
 					wait(delay(1.0));
-					TraceEvent("DynamicWarmingDone");
+					TraceEvent("DynamicWarmingDone").log();
 					break;
 				}
 			}

--- a/fdbserver/workloads/ChangeConfig.actor.cpp
+++ b/fdbserver/workloads/ChangeConfig.actor.cpp
@@ -65,9 +65,9 @@ struct ChangeConfigWorkload : TestWorkload {
 					// It is not safe to allow automatic failover to a region which is not fully replicated,
 					// so wait for both regions to be fully replicated before enabling failover
 					wait(success(changeConfig(extraDB, g_simulator.startingDisabledConfiguration, true)));
-					TraceEvent("WaitForReplicasExtra");
+					TraceEvent("WaitForReplicasExtra").log();
 					wait(waitForFullReplication(extraDB));
-					TraceEvent("WaitForReplicasExtraEnd");
+					TraceEvent("WaitForReplicasExtraEnd").log();
 				}
 				wait(success(changeConfig(extraDB, self->configMode, true)));
 			}
@@ -99,9 +99,9 @@ struct ChangeConfigWorkload : TestWorkload {
 				// It is not safe to allow automatic failover to a region which is not fully replicated,
 				// so wait for both regions to be fully replicated before enabling failover
 				wait(success(changeConfig(cx, g_simulator.startingDisabledConfiguration, true)));
-				TraceEvent("WaitForReplicas");
+				TraceEvent("WaitForReplicas").log();
 				wait(waitForFullReplication(cx));
-				TraceEvent("WaitForReplicasEnd");
+				TraceEvent("WaitForReplicasEnd").log();
 			}
 			wait(success(changeConfig(cx, self->configMode, true)));
 		}

--- a/fdbserver/workloads/ConflictRange.actor.cpp
+++ b/fdbserver/workloads/ConflictRange.actor.cpp
@@ -100,7 +100,7 @@ struct ConflictRangeWorkload : TestWorkload {
 			loop {
 				state Transaction tr0(cx);
 				try {
-					TraceEvent("ConflictRangeReset");
+					TraceEvent("ConflictRangeReset").log();
 					insertedSet.clear();
 
 					if (self->testReadYourWrites) {

--- a/fdbserver/workloads/ConsistencyCheck.actor.cpp
+++ b/fdbserver/workloads/ConsistencyCheck.actor.cpp
@@ -142,7 +142,7 @@ struct ConsistencyCheckWorkload : TestWorkload {
 	}
 
 	Future<Void> start(Database const& cx) override {
-		TraceEvent("ConsistencyCheck");
+		TraceEvent("ConsistencyCheck").log();
 		return _start(cx, this);
 	}
 
@@ -186,10 +186,10 @@ struct ConsistencyCheckWorkload : TestWorkload {
 	ACTOR Future<Void> _start(Database cx, ConsistencyCheckWorkload* self) {
 		loop {
 			while (self->suspendConsistencyCheck.get()) {
-				TraceEvent("ConsistencyCheck_Suspended");
+				TraceEvent("ConsistencyCheck_Suspended").log();
 				wait(self->suspendConsistencyCheck.onChange());
 			}
-			TraceEvent("ConsistencyCheck_StartingOrResuming");
+			TraceEvent("ConsistencyCheck_StartingOrResuming").log();
 			choose {
 				when(wait(self->runCheck(cx, self))) {
 					if (!self->indefinite)
@@ -222,7 +222,7 @@ struct ConsistencyCheckWorkload : TestWorkload {
 						}
 						RangeResult res = wait(tr.getRange(configKeys, 1000));
 						if (res.size() == 1000) {
-							TraceEvent("ConsistencyCheck_TooManyConfigOptions");
+							TraceEvent("ConsistencyCheck_TooManyConfigOptions").log();
 							self->testFailure("Read too many configuration options");
 						}
 						for (int i = 0; i < res.size(); i++)
@@ -251,7 +251,7 @@ struct ConsistencyCheckWorkload : TestWorkload {
 					// the allowed maximum number of teams
 					bool teamCollectionValid = wait(getTeamCollectionValid(cx, self->dbInfo));
 					if (!teamCollectionValid) {
-						TraceEvent(SevError, "ConsistencyCheck_TooManyTeams");
+						TraceEvent(SevError, "ConsistencyCheck_TooManyTeams").log();
 						self->testFailure("The number of process or machine teams is larger than the allowed maximum "
 						                  "number of teams");
 					}
@@ -1817,7 +1817,7 @@ struct ConsistencyCheckWorkload : TestWorkload {
 				self->testFailure("No storage server on worker");
 				return false;
 			} else {
-				TraceEvent(SevWarn, "ConsistencyCheck_TSSMissing");
+				TraceEvent(SevWarn, "ConsistencyCheck_TSSMissing").log();
 			}
 		}
 
@@ -1992,7 +1992,7 @@ struct ConsistencyCheckWorkload : TestWorkload {
 				Optional<Value> currentKey = wait(tr.get(coordinatorsKey));
 
 				if (!currentKey.present()) {
-					TraceEvent("ConsistencyCheck_NoCoordinatorKey");
+					TraceEvent("ConsistencyCheck_NoCoordinatorKey").log();
 					return false;
 				}
 

--- a/fdbserver/workloads/CpuProfiler.actor.cpp
+++ b/fdbserver/workloads/CpuProfiler.actor.cpp
@@ -93,7 +93,7 @@ struct CpuProfilerWorkload : TestWorkload {
 					if (!replies[i].get().present())
 						self->success = false;
 
-			TraceEvent("DoneSignalingProfiler");
+			TraceEvent("DoneSignalingProfiler").log();
 		}
 
 		return Void();
@@ -104,14 +104,14 @@ struct CpuProfilerWorkload : TestWorkload {
 	ACTOR Future<Void> _start(Database cx, CpuProfilerWorkload* self) {
 		wait(delay(self->initialDelay));
 		if (self->clientId == 0)
-			TraceEvent("SignalProfilerOn");
+			TraceEvent("SignalProfilerOn").log();
 		wait(timeoutError(self->updateProfiler(true, cx, self), 60.0));
 
 		// If a duration was given, let the duration elapse and then shut the profiler off
 		if (self->duration > 0) {
 			wait(delay(self->duration));
 			if (self->clientId == 0)
-				TraceEvent("SignalProfilerOff");
+				TraceEvent("SignalProfilerOff").log();
 			wait(timeoutError(self->updateProfiler(false, cx, self), 60.0));
 		}
 
@@ -124,7 +124,7 @@ struct CpuProfilerWorkload : TestWorkload {
 		// If no duration was given, then shut the profiler off now
 		if (self->duration <= 0) {
 			if (self->clientId == 0)
-				TraceEvent("SignalProfilerOff");
+				TraceEvent("SignalProfilerOff").log();
 			wait(timeoutError(self->updateProfiler(false, cx, self), 60.0));
 		}
 

--- a/fdbserver/workloads/Cycle.actor.cpp
+++ b/fdbserver/workloads/Cycle.actor.cpp
@@ -104,7 +104,7 @@ struct CycleWorkload : TestWorkload {
 				state Transaction tr(cx);
 				if (deterministicRandom()->random01() >= self->traceParentProbability) {
 					state Span span("CycleClient"_loc);
-					TraceEvent("CycleTracingTransaction", span.context);
+					TraceEvent("CycleTracingTransaction", span.context).log();
 					tr.setOption(FDBTransactionOptions::SPAN_PARENT,
 					             BinaryWriter::toValue(span.context, Unversioned()));
 				}
@@ -154,7 +154,7 @@ struct CycleWorkload : TestWorkload {
 	}
 
 	void logTestData(const VectorRef<KeyValueRef>& data) {
-		TraceEvent("TestFailureDetail");
+		TraceEvent("TestFailureDetail").log();
 		int index = 0;
 		for (auto& entry : data) {
 			TraceEvent("CurrentDataEntry")

--- a/fdbserver/workloads/DDMetrics.actor.cpp
+++ b/fdbserver/workloads/DDMetrics.actor.cpp
@@ -50,7 +50,7 @@ struct DDMetricsWorkload : TestWorkload {
 		try {
 			TraceEvent("DDMetricsWaiting").detail("StartDelay", self->startDelay);
 			wait(delay(self->startDelay));
-			TraceEvent("DDMetricsStarting");
+			TraceEvent("DDMetricsStarting").log();
 			state double startTime = now();
 			loop {
 				wait(delay(2.5));

--- a/fdbserver/workloads/ExternalWorkload.actor.cpp
+++ b/fdbserver/workloads/ExternalWorkload.actor.cpp
@@ -142,19 +142,19 @@ struct ExternalWorkload : TestWorkload, FDBWorkloadContext {
 		    .detail("WorkloadName", wName);
 		library = loadLibrary(fullPath.c_str());
 		if (library == nullptr) {
-			TraceEvent(SevError, "ExternalWorkloadLoadError");
+			TraceEvent(SevError, "ExternalWorkloadLoadError").log();
 			success = false;
 			return;
 		}
 		workloadFactory = reinterpret_cast<decltype(workloadFactory)>(loadFunction(library, "workloadFactory"));
 		if (workloadFactory == nullptr) {
-			TraceEvent(SevError, "ExternalFactoryNotFound");
+			TraceEvent(SevError, "ExternalFactoryNotFound").log();
 			success = false;
 			return;
 		}
 		workloadImpl = (*workloadFactory)(FDBLoggerImpl::instance())->create(wName.toString());
 		if (!workloadImpl) {
-			TraceEvent(SevError, "WorkloadNotFound");
+			TraceEvent(SevError, "WorkloadNotFound").log();
 			success = false;
 		}
 		workloadImpl->init(this);

--- a/fdbserver/workloads/HealthMetricsApi.actor.cpp
+++ b/fdbserver/workloads/HealthMetricsApi.actor.cpp
@@ -75,7 +75,7 @@ struct HealthMetricsApiWorkload : TestWorkload {
 
 	Future<bool> check(Database const& cx) override {
 		if (healthMetricsStoppedUpdating) {
-			TraceEvent(SevError, "HealthMetricsStoppedUpdating");
+			TraceEvent(SevError, "HealthMetricsStoppedUpdating").log();
 			return false;
 		}
 		bool correctHealthMetricsState = true;

--- a/fdbserver/workloads/IncrementalBackup.actor.cpp
+++ b/fdbserver/workloads/IncrementalBackup.actor.cpp
@@ -92,11 +92,11 @@ struct IncrementalBackupWorkload : TestWorkload {
 			}
 			loop {
 				// Wait for backup container to be created and avoid race condition
-				TraceEvent("IBackupWaitContainer");
+				TraceEvent("IBackupWaitContainer").log();
 				wait(success(self->backupAgent.waitBackup(
 				    cx, self->tag.toString(), StopWhenDone::False, &backupContainer, &backupUID)));
 				if (!backupContainer.isValid()) {
-					TraceEvent("IBackupCheckListContainersAttempt");
+					TraceEvent("IBackupCheckListContainersAttempt").log();
 					state std::vector<std::string> containers =
 					    wait(IBackupContainer::listContainers(self->backupDir.toString()));
 					TraceEvent("IBackupCheckListContainersSuccess")
@@ -132,7 +132,7 @@ struct IncrementalBackupWorkload : TestWorkload {
 		}
 		if (self->stopBackup) {
 			try {
-				TraceEvent("IBackupDiscontinueBackup");
+				TraceEvent("IBackupDiscontinueBackup").log();
 				wait(self->backupAgent.discontinueBackup(cx, self->tag));
 			} catch (Error& e) {
 				TraceEvent("IBackupDiscontinueBackupException").error(e);
@@ -148,7 +148,7 @@ struct IncrementalBackupWorkload : TestWorkload {
 		if (self->submitOnly) {
 			Standalone<VectorRef<KeyRangeRef>> backupRanges;
 			backupRanges.push_back_deep(backupRanges.arena(), normalKeys);
-			TraceEvent("IBackupSubmitAttempt");
+			TraceEvent("IBackupSubmitAttempt").log();
 			try {
 				wait(self->backupAgent.submitBackup(cx,
 				                                    self->backupDir,
@@ -165,7 +165,7 @@ struct IncrementalBackupWorkload : TestWorkload {
 					throw;
 				}
 			}
-			TraceEvent("IBackupSubmitSuccess");
+			TraceEvent("IBackupSubmitSuccess").log();
 		}
 		if (self->restoreOnly) {
 			if (self->clearBackupAgentKeys) {
@@ -189,7 +189,7 @@ struct IncrementalBackupWorkload : TestWorkload {
 			wait(success(self->backupAgent.waitBackup(
 			    cx, self->tag.toString(), StopWhenDone::False, &backupContainer, &backupUID)));
 			if (self->checkBeginVersion) {
-				TraceEvent("IBackupReadSystemKeys");
+				TraceEvent("IBackupReadSystemKeys").log();
 				state Reference<ReadYourWritesTransaction> tr(new ReadYourWritesTransaction(cx));
 				loop {
 					try {
@@ -201,7 +201,7 @@ struct IncrementalBackupWorkload : TestWorkload {
 						    .detail("WriteRecoveryValue", writeFlag.present() ? writeFlag.get().toString() : "N/A")
 						    .detail("EndVersionValue", versionValue.present() ? versionValue.get().toString() : "N/A");
 						if (!versionValue.present()) {
-							TraceEvent("IBackupCheckSpecialKeysFailure");
+							TraceEvent("IBackupCheckSpecialKeysFailure").log();
 							// Snapshot failed to write to special keys, possibly due to snapshot itself failing
 							throw key_not_found();
 						}
@@ -217,7 +217,7 @@ struct IncrementalBackupWorkload : TestWorkload {
 					}
 				}
 			}
-			TraceEvent("IBackupStartListContainersAttempt");
+			TraceEvent("IBackupStartListContainersAttempt").log();
 			state std::vector<std::string> containers =
 			    wait(IBackupContainer::listContainers(self->backupDir.toString()));
 			TraceEvent("IBackupStartListContainersSuccess")
@@ -239,7 +239,7 @@ struct IncrementalBackupWorkload : TestWorkload {
 			                                       OnlyApplyMutationLogs::True,
 			                                       InconsistentSnapshotOnly::False,
 			                                       beginVersion)));
-			TraceEvent("IBackupRestoreSuccess");
+			TraceEvent("IBackupRestoreSuccess").log();
 		}
 		return Void();
 	}

--- a/fdbserver/workloads/KVStoreTest.actor.cpp
+++ b/fdbserver/workloads/KVStoreTest.actor.cpp
@@ -115,7 +115,7 @@ struct KVTest {
 	~KVTest() { close(); }
 	void close() {
 		if (store) {
-			TraceEvent("KVTestDestroy");
+			TraceEvent("KVTestDestroy").log();
 			if (dispose)
 				store->dispose();
 			else
@@ -373,7 +373,7 @@ ACTOR Future<Void> testKVStore(KVStoreTestWorkload* workload) {
 	state Error err;
 
 	// wait( delay(1) );
-	TraceEvent("GO");
+	TraceEvent("GO").log();
 
 	UID id = deterministicRandom()->randomUniqueID();
 	std::string fn = workload->filename.size() ? workload->filename : id.toString();

--- a/fdbserver/workloads/KillRegion.actor.cpp
+++ b/fdbserver/workloads/KillRegion.actor.cpp
@@ -56,11 +56,11 @@ struct KillRegionWorkload : TestWorkload {
 	void getMetrics(vector<PerfMetric>& m) override {}
 
 	ACTOR static Future<Void> _setup(KillRegionWorkload* self, Database cx) {
-		TraceEvent("ForceRecovery_DisablePrimaryBegin");
+		TraceEvent("ForceRecovery_DisablePrimaryBegin").log();
 		wait(success(changeConfig(cx, g_simulator.disablePrimary, true)));
-		TraceEvent("ForceRecovery_WaitForRemote");
+		TraceEvent("ForceRecovery_WaitForRemote").log();
 		wait(waitForPrimaryDC(cx, LiteralStringRef("1")));
-		TraceEvent("ForceRecovery_DisablePrimaryComplete");
+		TraceEvent("ForceRecovery_DisablePrimaryComplete").log();
 		return Void();
 	}
 
@@ -74,14 +74,14 @@ struct KillRegionWorkload : TestWorkload {
 	ACTOR static Future<Void> killRegion(KillRegionWorkload* self, Database cx) {
 		ASSERT(g_network->isSimulated());
 		if (deterministicRandom()->random01() < 0.5) {
-			TraceEvent("ForceRecovery_DisableRemoteBegin");
+			TraceEvent("ForceRecovery_DisableRemoteBegin").log();
 			wait(success(changeConfig(cx, g_simulator.disableRemote, true)));
-			TraceEvent("ForceRecovery_WaitForPrimary");
+			TraceEvent("ForceRecovery_WaitForPrimary").log();
 			wait(waitForPrimaryDC(cx, LiteralStringRef("0")));
-			TraceEvent("ForceRecovery_DisableRemoteComplete");
+			TraceEvent("ForceRecovery_DisableRemoteComplete").log();
 			wait(success(changeConfig(cx, g_simulator.originalRegions, true)));
 		}
-		TraceEvent("ForceRecovery_Wait");
+		TraceEvent("ForceRecovery_Wait").log();
 		wait(delay(deterministicRandom()->random01() * self->testDuration));
 
 		g_simulator.killDataCenter(LiteralStringRef("0"),
@@ -97,11 +97,11 @@ struct KillRegionWorkload : TestWorkload {
 		                                                                   : ISimulator::RebootAndDelete,
 		                           true);
 
-		TraceEvent("ForceRecovery_Begin");
+		TraceEvent("ForceRecovery_Begin").log();
 
 		wait(forceRecovery(cx->getConnectionFile(), LiteralStringRef("1")));
 
-		TraceEvent("ForceRecovery_UsableRegions");
+		TraceEvent("ForceRecovery_UsableRegions").log();
 
 		DatabaseConfiguration conf = wait(getDatabaseConfiguration(cx));
 
@@ -119,7 +119,7 @@ struct KillRegionWorkload : TestWorkload {
 			wait(success(changeConfig(cx, "usable_regions=1", true)));
 		}
 
-		TraceEvent("ForceRecovery_Complete");
+		TraceEvent("ForceRecovery_Complete").log();
 
 		return Void();
 	}

--- a/fdbserver/workloads/LogMetrics.actor.cpp
+++ b/fdbserver/workloads/LogMetrics.actor.cpp
@@ -54,7 +54,7 @@ struct LogMetricsWorkload : TestWorkload {
 		state BinaryWriter br(Unversioned());
 		vector<WorkerDetails> workers = wait(getWorkers(self->dbInfo));
 		// vector<Future<Void>> replies;
-		TraceEvent("RateChangeTrigger");
+		TraceEvent("RateChangeTrigger").log();
 		SetMetricsLogRateRequest req(rate);
 		for (int i = 0; i < workers.size(); i++) {
 			workers[i].interf.setMetricsRate.send(req);

--- a/fdbserver/workloads/LowLatency.actor.cpp
+++ b/fdbserver/workloads/LowLatency.actor.cpp
@@ -77,7 +77,7 @@ struct LowLatencyWorkload : TestWorkload {
 				++self->operations;
 				loop {
 					try {
-						TraceEvent("StartLowLatencyTransaction");
+						TraceEvent("StartLowLatencyTransaction").log();
 						tr.setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
 						tr.setOption(FDBTransactionOptions::LOCK_AWARE);
 						if (doCommit) {

--- a/fdbserver/workloads/MachineAttrition.actor.cpp
+++ b/fdbserver/workloads/MachineAttrition.actor.cpp
@@ -39,18 +39,18 @@ static std::set<int> const& normalAttritionErrors() {
 
 ACTOR Future<bool> ignoreSSFailuresForDuration(Database cx, double duration) {
 	// duration doesn't matter since this won't timeout
-	TraceEvent("IgnoreSSFailureStart");
+	TraceEvent("IgnoreSSFailureStart").log();
 	wait(success(setHealthyZone(cx, ignoreSSFailuresZoneString, 0)));
-	TraceEvent("IgnoreSSFailureWait");
+	TraceEvent("IgnoreSSFailureWait").log();
 	wait(delay(duration));
-	TraceEvent("IgnoreSSFailureClear");
+	TraceEvent("IgnoreSSFailureClear").log();
 	state Transaction tr(cx);
 	loop {
 		try {
 			tr.setOption(FDBTransactionOptions::LOCK_AWARE);
 			tr.clear(healthyZoneKey);
 			wait(tr.commit());
-			TraceEvent("IgnoreSSFailureComplete");
+			TraceEvent("IgnoreSSFailureComplete").log();
 			return true;
 		} catch (Error& e) {
 			wait(tr.onError(e));
@@ -311,7 +311,7 @@ struct MachineAttritionWorkload : TestWorkload {
 				TEST(true); // Killing a machine
 
 				wait(delay(delayBeforeKill));
-				TraceEvent("WorkerKillAfterDelay");
+				TraceEvent("WorkerKillAfterDelay").log();
 
 				if (self->waitForVersion) {
 					state Transaction tr(cx);

--- a/fdbserver/workloads/ParallelRestore.actor.cpp
+++ b/fdbserver/workloads/ParallelRestore.actor.cpp
@@ -30,7 +30,7 @@
 struct RunRestoreWorkerWorkload : TestWorkload {
 	Future<Void> worker;
 	RunRestoreWorkerWorkload(WorkloadContext const& wcx) : TestWorkload(wcx) {
-		TraceEvent("RunRestoreWorkerWorkloadMX");
+		TraceEvent("RunRestoreWorkerWorkloadMX").log();
 	}
 
 	std::string description() const override { return "RunRestoreWorkerWorkload"; }

--- a/fdbserver/workloads/Ping.actor.cpp
+++ b/fdbserver/workloads/Ping.actor.cpp
@@ -259,7 +259,7 @@ struct PingWorkload : TestWorkload {
 			// peers[i].payloadPing.getEndpoint().getPrimaryAddress(), pingId ) ); peers[i].payloadPing.send( req );
 			// replies.push_back( self->payloadDelayer( req, peers[i].payloadPing ) );
 		}
-		TraceEvent("PayloadPingSent", pingId);
+		TraceEvent("PayloadPingSent", pingId).log();
 		wait(waitForAll(replies));
 		double elapsed = now() - start;
 		TraceEvent("PayloadPingDone", pingId).detail("Elapsed", elapsed);

--- a/fdbserver/workloads/PopulateTPCC.actor.cpp
+++ b/fdbserver/workloads/PopulateTPCC.actor.cpp
@@ -184,7 +184,7 @@ struct PopulateTPCC : TestWorkload {
 				}
 			}
 		}
-		TraceEvent("PopulateItemsDone");
+		TraceEvent("PopulateItemsDone").log();
 		return Void();
 	}
 

--- a/fdbserver/workloads/RandomMoveKeys.actor.cpp
+++ b/fdbserver/workloads/RandomMoveKeys.actor.cpp
@@ -62,13 +62,13 @@ struct MoveKeysWorkload : TestWorkload {
 			}
 
 			state int oldMode = wait(setDDMode(cx, 0));
-			TraceEvent("RMKStartModeSetting");
+			TraceEvent("RMKStartModeSetting").log();
 			wait(timeout(
 			    reportErrors(self->worker(cx, self), "MoveKeysWorkloadWorkerError"), self->testDuration, Void()));
 			// Always set the DD mode back, even if we die with an error
-			TraceEvent("RMKDoneMoving");
+			TraceEvent("RMKDoneMoving").log();
 			wait(success(setDDMode(cx, oldMode)));
-			TraceEvent("RMKDoneModeSetting");
+			TraceEvent("RMKDoneModeSetting").log();
 		}
 		return Void();
 	}
@@ -87,7 +87,7 @@ struct MoveKeysWorkload : TestWorkload {
 
 	vector<StorageServerInterface> getRandomTeam(vector<StorageServerInterface> storageServers, int teamSize) {
 		if (storageServers.size() < teamSize) {
-			TraceEvent(SevWarnAlways, "LessThanThreeStorageServers");
+			TraceEvent(SevWarnAlways, "LessThanThreeStorageServers").log();
 			throw operation_failed();
 		}
 
@@ -105,7 +105,7 @@ struct MoveKeysWorkload : TestWorkload {
 		}
 
 		if (t.size() < teamSize) {
-			TraceEvent(SevWarnAlways, "LessThanThreeUniqueMachines");
+			TraceEvent(SevWarnAlways, "LessThanThreeUniqueMachines").log();
 			throw operation_failed();
 		}
 

--- a/fdbserver/workloads/RestoreBackup.actor.cpp
+++ b/fdbserver/workloads/RestoreBackup.actor.cpp
@@ -73,7 +73,7 @@ struct RestoreBackupWorkload final : TestWorkload {
 				    .detail("TargetVersion", waitForVersion);
 				if (desc.contiguousLogEnd.present() && desc.contiguousLogEnd.get() >= waitForVersion) {
 					try {
-						TraceEvent("DiscontinuingBackup");
+						TraceEvent("DiscontinuingBackup").log();
 						wait(self->backupAgent.discontinueBackup(cx, self->tag));
 					} catch (Error& e) {
 						TraceEvent("ErrorDiscontinuingBackup").error(e);

--- a/fdbserver/workloads/SimpleAtomicAdd.actor.cpp
+++ b/fdbserver/workloads/SimpleAtomicAdd.actor.cpp
@@ -114,7 +114,7 @@ struct SimpleAtomicAddWorkload : TestWorkload {
 		}
 		loop {
 			try {
-				TraceEvent("SAACheckKey");
+				TraceEvent("SAACheckKey").log();
 				Optional<Value> actualValue = wait(tr.get(self->sumKey));
 				uint64_t actualValueInt = 0;
 				if (actualValue.present()) {

--- a/fdbserver/workloads/SnapTest.actor.cpp
+++ b/fdbserver/workloads/SnapTest.actor.cpp
@@ -90,7 +90,7 @@ public: // variables
 public: // ctor & dtor
 	SnapTestWorkload(WorkloadContext const& wcx)
 	  : TestWorkload(wcx), numSnaps(0), maxSnapDelay(0.0), testID(0), snapUID() {
-		TraceEvent("SnapTestWorkloadConstructor");
+		TraceEvent("SnapTestWorkloadConstructor").log();
 		std::string workloadName = "SnapTest";
 		maxRetryCntToRetrieveMessage = 10;
 
@@ -107,11 +107,11 @@ public: // ctor & dtor
 public: // workload functions
 	std::string description() const override { return "SnapTest"; }
 	Future<Void> setup(Database const& cx) override {
-		TraceEvent("SnapTestWorkloadSetup");
+		TraceEvent("SnapTestWorkloadSetup").log();
 		return Void();
 	}
 	Future<Void> start(Database const& cx) override {
-		TraceEvent("SnapTestWorkloadStart");
+		TraceEvent("SnapTestWorkloadStart").log();
 		if (clientId == 0) {
 			return _start(cx, this);
 		}
@@ -120,7 +120,7 @@ public: // workload functions
 
 	ACTOR Future<bool> _check(Database cx, SnapTestWorkload* self) {
 		if (self->skipCheck) {
-			TraceEvent(SevWarnAlways, "SnapCheckIgnored");
+			TraceEvent(SevWarnAlways, "SnapCheckIgnored").log();
 			return true;
 		}
 		state Transaction tr(cx);
@@ -250,7 +250,7 @@ public: // workload functions
 			bool backupFailed = atoi(ini.GetValue("RESTORE", "BackupFailed"));
 			if (backupFailed) {
 				// since backup failed, skip the restore checking
-				TraceEvent(SevWarnAlways, "BackupFailedSkippingRestoreCheck");
+				TraceEvent(SevWarnAlways, "BackupFailedSkippingRestoreCheck").log();
 				return Void();
 			}
 			state KeySelector begin = firstGreaterOrEqual(normalKeys.begin);
@@ -265,7 +265,7 @@ public: // workload functions
 				try {
 					RangeResult kvRange = wait(tr.getRange(begin, end, 1000));
 					if (!kvRange.more && kvRange.size() == 0) {
-						TraceEvent("SnapTestNoMoreEntries");
+						TraceEvent("SnapTestNoMoreEntries").log();
 						break;
 					}
 

--- a/fdbserver/workloads/SpecialKeySpaceCorrectness.actor.cpp
+++ b/fdbserver/workloads/SpecialKeySpaceCorrectness.actor.cpp
@@ -721,7 +721,7 @@ struct SpecialKeySpaceCorrectnessWorkload : TestWorkload {
 					ASSERT(false);
 				} else {
 					// If no worker process returned, skip the test
-					TraceEvent(SevDebug, "EmptyWorkerListInSetClassTest");
+					TraceEvent(SevDebug, "EmptyWorkerListInSetClassTest").log();
 				}
 			} catch (Error& e) {
 				if (e.code() == error_code_actor_cancelled)
@@ -796,7 +796,7 @@ struct SpecialKeySpaceCorrectnessWorkload : TestWorkload {
 					tx->reset();
 				} else {
 					// If no worker process returned, skip the test
-					TraceEvent(SevDebug, "EmptyWorkerListInSetClassTest");
+					TraceEvent(SevDebug, "EmptyWorkerListInSetClassTest").log();
 				}
 			} catch (Error& e) {
 				wait(tx->onError(e));
@@ -832,7 +832,7 @@ struct SpecialKeySpaceCorrectnessWorkload : TestWorkload {
 				}
 			}
 		}
-		TraceEvent(SevDebug, "DatabaseLocked");
+		TraceEvent(SevDebug, "DatabaseLocked").log();
 		// if database locked, fdb read should get database_locked error
 		try {
 			tx->reset();
@@ -851,7 +851,7 @@ struct SpecialKeySpaceCorrectnessWorkload : TestWorkload {
 				// unlock the database
 				tx->clear(SpecialKeySpace::getManagementApiCommandPrefix("lock"));
 				wait(tx->commit());
-				TraceEvent(SevDebug, "DatabaseUnlocked");
+				TraceEvent(SevDebug, "DatabaseUnlocked").log();
 				tx->reset();
 				// read should be successful
 				RangeResult res = wait(tx->getRange(normalKeys, 1));

--- a/fdbserver/workloads/StatusWorkload.actor.cpp
+++ b/fdbserver/workloads/StatusWorkload.actor.cpp
@@ -101,7 +101,7 @@ struct StatusWorkload : TestWorkload {
 			TraceEvent(SevError, "SchemaCoverageRequirementsException").detail("What", e.what());
 			throw unknown_error();
 		} catch (...) {
-			TraceEvent(SevError, "SchemaCoverageRequirementsException");
+			TraceEvent(SevError, "SchemaCoverageRequirementsException").log();
 			throw unknown_error();
 		}
 	}

--- a/fdbserver/workloads/Throttling.actor.cpp
+++ b/fdbserver/workloads/Throttling.actor.cpp
@@ -112,7 +112,7 @@ struct ThrottlingWorkload : KVWorkload {
 				}
 				wait(tr.commit());
 				if (deterministicRandom()->randomInt(0, 1000) == 0)
-					TraceEvent("TransactionCommittedx1000");
+					TraceEvent("TransactionCommittedx1000").log();
 				++self->transactionsCommitted;
 			} catch (Error& e) {
 				if (e.code() == error_code_actor_cancelled)

--- a/fdbserver/workloads/TimeKeeperCorrectness.actor.cpp
+++ b/fdbserver/workloads/TimeKeeperCorrectness.actor.cpp
@@ -39,7 +39,7 @@ struct TimeKeeperCorrectnessWorkload : TestWorkload {
 	void getMetrics(vector<PerfMetric>& m) override {}
 
 	ACTOR static Future<Void> _start(Database cx, TimeKeeperCorrectnessWorkload* self) {
-		TraceEvent(SevInfo, "TKCorrectness_Start");
+		TraceEvent(SevInfo, "TKCorrectness_Start").log();
 
 		state double start = now();
 		while (now() - start > self->testDuration) {
@@ -60,7 +60,7 @@ struct TimeKeeperCorrectnessWorkload : TestWorkload {
 			wait(delay(std::min(SERVER_KNOBS->TIME_KEEPER_DELAY / 10, (int64_t)1L)));
 		}
 
-		TraceEvent(SevInfo, "TKCorrectness_Completed");
+		TraceEvent(SevInfo, "TKCorrectness_Completed").log();
 		return Void();
 	}
 
@@ -111,7 +111,7 @@ struct TimeKeeperCorrectnessWorkload : TestWorkload {
 					}
 				}
 
-				TraceEvent(SevInfo, "TKCorrectness_Passed");
+				TraceEvent(SevInfo, "TKCorrectness_Passed").log();
 				return true;
 			} catch (Error& e) {
 				wait(tr->onError(e));

--- a/fdbserver/workloads/TriggerRecovery.actor.cpp
+++ b/fdbserver/workloads/TriggerRecovery.actor.cpp
@@ -111,7 +111,7 @@ struct TriggerRecoveryLoopWorkload : TestWorkload {
 					else
 						tr.set(LiteralStringRef("\xff\xff/reboot_worker"), it.second);
 				}
-				TraceEvent(SevInfo, "TriggerRecoveryLoop_AttempedKillAll");
+				TraceEvent(SevInfo, "TriggerRecoveryLoop_AttempedKillAll").log();
 				return Void();
 			} catch (Error& e) {
 				wait(tr.onError(e));

--- a/fdbserver/workloads/VersionStamp.actor.cpp
+++ b/fdbserver/workloads/VersionStamp.actor.cpp
@@ -297,7 +297,7 @@ struct VersionStampWorkload : TestWorkload {
 				wait(tr.onError(e));
 			}
 		}
-		TraceEvent("VST_CheckEnd");
+		TraceEvent("VST_CheckEnd").log();
 		return true;
 	}
 

--- a/fdbserver/workloads/WriteDuringRead.actor.cpp
+++ b/fdbserver/workloads/WriteDuringRead.actor.cpp
@@ -518,7 +518,7 @@ ACTOR Future<Void> commitAndUpdateMemory(ReadYourWritesTransaction* tr,
 			}
 
 			if (failed) {
-				TraceEvent(SevError, "WriteConflictRangeError");
+				TraceEvent(SevError, "WriteConflictRangeError").log();
 				for (transactionIter = transactionRanges.begin(); transactionIter != transactionRanges.end();
 				     ++transactionIter) {
 					TraceEvent("WCRTransaction")

--- a/fdbserver/workloads/WriteTagThrottling.actor.cpp
+++ b/fdbserver/workloads/WriteTagThrottling.actor.cpp
@@ -135,7 +135,7 @@ struct WriteTagThrottlingWorkload : KVWorkload {
 			return true;
 		if (writeThrottle) {
 			if (!badActorThrottleRetries && !goodActorThrottleRetries) {
-				TraceEvent(SevWarn, "NoThrottleTriggered");
+				TraceEvent(SevWarn, "NoThrottleTriggered").log();
 			}
 			if (badActorThrottleRetries < goodActorThrottleRetries) {
 				TraceEvent(SevWarnAlways, "IncorrectThrottle")

--- a/flow/DeterministicRandom.cpp
+++ b/flow/DeterministicRandom.cpp
@@ -26,7 +26,7 @@ uint64_t DeterministicRandom::gen64() {
 	uint64_t curr = next;
 	next = (uint64_t(random()) << 32) ^ random();
 	if (TRACE_SAMPLE())
-		TraceEvent(SevSample, "Random");
+		TraceEvent(SevSample, "Random").log();
 	return curr;
 }
 

--- a/flow/Net2.actor.cpp
+++ b/flow/Net2.actor.cpp
@@ -1182,7 +1182,7 @@ Net2::Net2(const TLSConfig& tlsConfig, bool useThreadPool, bool useMetrics)
 #endif
 
 {
-	TraceEvent("Net2Starting");
+	TraceEvent("Net2Starting").log();
 
 	// Set the global members
 	if (useMetrics) {
@@ -1257,13 +1257,13 @@ ACTOR static Future<Void> reloadCertificatesOnChange(
 	lifetimes.push_back(watchFileForChanges(config.getCAPathSync(), &fileChanged));
 	loop {
 		wait(fileChanged.onTrigger());
-		TraceEvent("TLSCertificateRefreshBegin");
+		TraceEvent("TLSCertificateRefreshBegin").log();
 
 		try {
 			LoadedTLSConfig loaded = wait(config.loadAsync());
 			boost::asio::ssl::context context(boost::asio::ssl::context::tls);
 			ConfigureSSLContext(loaded, &context, onPolicyFailure);
-			TraceEvent(SevInfo, "TLSCertificateRefreshSucceeded");
+			TraceEvent(SevInfo, "TLSCertificateRefreshSucceeded").log();
 			mismatches = 0;
 			contextVar->set(ReferencedObject<boost::asio::ssl::context>::from(std::move(context)));
 		} catch (Error& e) {
@@ -1385,13 +1385,13 @@ bool Net2::checkRunnable() {
 
 void Net2::run() {
 	TraceEvent::setNetworkThread();
-	TraceEvent("Net2Running");
+	TraceEvent("Net2Running").log();
 
 	thread_network = this;
 
 #ifdef WIN32
 	if (timeBeginPeriod(1) != TIMERR_NOERROR)
-		TraceEvent(SevError, "TimeBeginPeriodError");
+		TraceEvent(SevError, "TimeBeginPeriodError").log();
 #endif
 
 	timeOffsetLogger = logTimeOffset();

--- a/flow/Platform.actor.cpp
+++ b/flow/Platform.actor.cpp
@@ -1227,19 +1227,19 @@ void getDiskStatistics(std::string const& directory,
 	CFMutableDictionaryRef match = IOBSDNameMatching(kIOMasterPortDefault, kNilOptions, dev);
 
 	if (!match) {
-		TraceEvent(SevError, "IOBSDNameMatching");
+		TraceEvent(SevError, "IOBSDNameMatching").log();
 		throw platform_error();
 	}
 
 	if (IOServiceGetMatchingServices(kIOMasterPortDefault, match, &disk_list) != kIOReturnSuccess) {
-		TraceEvent(SevError, "IOServiceGetMatchingServices");
+		TraceEvent(SevError, "IOServiceGetMatchingServices").log();
 		throw platform_error();
 	}
 
 	io_registry_entry_t disk = IOIteratorNext(disk_list);
 	if (!disk) {
 		IOObjectRelease(disk_list);
-		TraceEvent(SevError, "IOIteratorNext");
+		TraceEvent(SevError, "IOIteratorNext").log();
 		throw platform_error();
 	}
 
@@ -1255,7 +1255,7 @@ void getDiskStatistics(std::string const& directory,
 	        disk, (CFMutableDictionaryRef*)&disk_dict, kCFAllocatorDefault, kNilOptions) != kIOReturnSuccess) {
 		IOObjectRelease(disk);
 		IOObjectRelease(disk_list);
-		TraceEvent(SevError, "IORegistryEntryCreateCFProperties");
+		TraceEvent(SevError, "IORegistryEntryCreateCFProperties").log();
 		throw platform_error();
 	}
 
@@ -1268,7 +1268,7 @@ void getDiskStatistics(std::string const& directory,
 		CFRelease(disk_dict);
 		IOObjectRelease(disk);
 		IOObjectRelease(disk_list);
-		TraceEvent(SevError, "CFDictionaryGetValue");
+		TraceEvent(SevError, "CFDictionaryGetValue").log();
 		throw platform_error();
 	}
 
@@ -1524,7 +1524,7 @@ SystemStatistics getSystemStatistics(std::string const& dataFolder,
 	if ((*statState)->Query == nullptr) {
 		initPdhStrings(*statState, dataFolder);
 
-		TraceEvent("SetupQuery");
+		TraceEvent("SetupQuery").log();
 		handlePdhStatus(PdhOpenQuery(nullptr, NULL, &(*statState)->Query), "PdhOpenQuery");
 
 		if (!(*statState)->pdhStrings.diskDevice.empty()) {
@@ -2073,7 +2073,7 @@ int getRandomSeed() {
 	do {
 		retryCount++;
 		if (rand_s((unsigned int*)&randomSeed) != 0) {
-			TraceEvent(SevError, "WindowsRandomSeedError");
+			TraceEvent(SevError, "WindowsRandomSeedError").log();
 			throw platform_error();
 		}
 	} while (randomSeed == 0 &&
@@ -2093,7 +2093,7 @@ int getRandomSeed() {
 #endif
 
 	if (randomSeed == 0) {
-		TraceEvent(SevError, "RandomSeedZeroError");
+		TraceEvent(SevError, "RandomSeedZeroError").log();
 		throw platform_error();
 	}
 	return randomSeed;

--- a/flow/ThreadHelper.actor.h
+++ b/flow/ThreadHelper.actor.h
@@ -242,7 +242,7 @@ public:
 
 	void send(Never) {
 		if (TRACE_SAMPLE())
-			TraceEvent(SevSample, "Promise_sendNever");
+			TraceEvent(SevSample, "Promise_sendNever").log();
 		ThreadSpinLockHolder holder(mutex);
 		if (!canBeSetUnsafe())
 			ASSERT(false); // Promise fulfilled twice
@@ -399,7 +399,7 @@ public:
 
 	void send(const T& value) {
 		if (TRACE_SAMPLE())
-			TraceEvent(SevSample, "Promise_send");
+			TraceEvent(SevSample, "Promise_send").log();
 		this->mutex.enter();
 		if (!canBeSetUnsafe()) {
 			this->mutex.leave();

--- a/flow/Trace.cpp
+++ b/flow/Trace.cpp
@@ -70,7 +70,7 @@ struct SuppressionMap {
 	int64_t checkAndInsertSuppression(std::string type, double duration) {
 		ASSERT(g_network);
 		if (suppressionMap.size() >= FLOW_KNOBS->MAX_TRACE_SUPPRESSIONS) {
-			TraceEvent(SevWarnAlways, "ClearingTraceSuppressionMap");
+			TraceEvent(SevWarnAlways, "ClearingTraceSuppressionMap").log();
 			suppressionMap.clear();
 		}
 

--- a/flow/genericactors.actor.h
+++ b/flow/genericactors.actor.h
@@ -868,7 +868,7 @@ Future<T> ioDegradedOrTimeoutError(Future<T> what,
 			when(T t = wait(what)) { return t; }
 			when(wait(degradedEnd)) {
 				TEST(true); // TLog degraded
-				TraceEvent(SevWarnAlways, "IoDegraded");
+				TraceEvent(SevWarnAlways, "IoDegraded").log();
 				degraded->set(true);
 			}
 		}


### PR DESCRIPTION
Add .log() to bare TraceEvent() invocations without any .detail()s to avoid clang-tidy warning about immediate destruction of object without use.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
