### PR TITLE
TLogGroup: Use new ptxn::TLogInterface not old TLogInterface

### DIFF
--- a/fdbserver/ApplyMetadataMutation.cpp
+++ b/fdbserver/ApplyMetadataMutation.cpp
@@ -25,6 +25,7 @@
 #include "fdbclient/Notified.h"
 #include "fdbserver/ApplyMetadataMutation.h"
 #include "fdbserver/IKeyValueStore.h"
+#include "fdbserver/Knobs.h"
 #include "fdbserver/LogSystem.h"
 #include "fdbserver/LogProtocolMessage.h"
 
@@ -192,7 +193,9 @@ void applyMetadataMutations(
 			} else if (m.param1.startsWith(storageTeamIdKeyPrefix)) {
 				ASSERT_WE_THINK(tLogGroupCollection.isValid());
 				auto teamid = storageTeamIdKeyDecode(m.param1);
-				if (tLogGroupCollection->tryAddStorageTeam(teamid, decodeStorageTeams(m.param2))) {
+
+				if (SERVER_KNOBS->TLOG_NEW_INTERFACE &&
+				    tLogGroupCollection->tryAddStorageTeam(teamid, decodeStorageTeams(m.param2))) {
 					auto group = tLogGroupCollection->selectFreeGroup(teamid.hash());
 					// TODO: This may be unnessary, as ApplyMetadataMutation case for this key-range
 					//     should do the assignment.

--- a/fdbserver/LogSystem.h
+++ b/fdbserver/LogSystem.h
@@ -26,6 +26,7 @@
 
 #include "fdbserver/SpanContextMessage.h"
 #include "fdbserver/TLogInterface.h"
+#include "fdbserver/TLogGroup.actor.h"
 #include "fdbserver/WorkerInterface.actor.h"
 #include "fdbclient/DatabaseConfiguration.h"
 #include "fdbserver/MutationTracking.h"
@@ -866,6 +867,7 @@ struct ILogSystem {
 	    int8_t primaryLocality,
 	    int8_t remoteLocality,
 	    std::vector<Tag> const& allTags,
+	    TLogGroupCollectionRef tLogGroupCollection,
 	    Reference<AsyncVar<bool>> const& recruitmentStalled) = 0;
 	// Call only on an ILogSystem obtained from recoverAndEndEpoch()
 	// Returns an ILogSystem representing a new epoch immediately following this one.  The new epoch is only provisional
@@ -1091,9 +1093,7 @@ struct LogPushData : NonCopyable {
 		next_message_tags.clear();
 	}
 
-	Standalone<StringRef> getMessages(int loc) {
-		return messagesWriter[loc].toValue();
-	}
+	Standalone<StringRef> getMessages(int loc) { return messagesWriter[loc].toValue(); }
 
 	// Records if a tlog (specified by "loc") will receive an empty version batch message.
 	// "value" is the message returned by getMessages() call.

--- a/fdbserver/LogSystem.h
+++ b/fdbserver/LogSystem.h
@@ -57,6 +57,7 @@ struct ConnectionResetInfo : public ReferenceCounted<ConnectionResetInfo> {
 class LogSet : NonCopyable, public ReferenceCounted<LogSet> {
 public:
 	std::vector<Reference<AsyncVar<OptionalInterface<TLogInterface>>>> logServers;
+	std::vector<Reference<AsyncVar<OptionalInterface<ptxn::TLogInterface_PassivelyPull>>>> logServersPtxn;
 	std::unordered_map<UID, std::vector<Reference<AsyncVar<OptionalInterface<ptxn::TLogInterface_PassivelyPull>>>>>
 	    groupIdToInterfaces;
 	std::vector<Reference<AsyncVar<OptionalInterface<TLogInterface>>>> logRouters;

--- a/fdbserver/LogSystemConfig.h
+++ b/fdbserver/LogSystemConfig.h
@@ -146,11 +146,6 @@ struct TLogSet {
 			}
 		}
 
-		for (int j = 0; j < tLogGroupIDs.size(); j++) {
-			if (tLogGroupIDs[j] != rhs.tLogGroupIDs[j]) {
-				return false;
-			}
-		}
 		for (int j = 0; j < logRouters.size(); j++) {
 			if (logRouters[j].id() != rhs.logRouters[j].id() ||
 			    logRouters[j].present() != rhs.logRouters[j].present() ||
@@ -197,6 +192,7 @@ struct TLogSet {
 	void serialize(Ar& ar) {
 		serializer(ar,
 		           tLogs,
+		           tLogsPtxn,
 		           tLogGroupIDs,
 		           ptxnTLogGroups,
 		           logRouters,

--- a/fdbserver/MockLogSystem.cpp
+++ b/fdbserver/MockLogSystem.cpp
@@ -196,6 +196,7 @@ Future<Reference<ILogSystem>> MockLogSystem::newEpoch(
     int8_t primaryLocality,
     int8_t remoteLocality,
     const vector<Tag>& allTags,
+    TLogGroupCollectionRef tLogGroupCollection,
     const Reference<AsyncVar<bool>>& recruitmentStalled) {
 	logMethodName(__func__);
 	return Future<Reference<ILogSystem>>();

--- a/fdbserver/MockLogSystem.h
+++ b/fdbserver/MockLogSystem.h
@@ -85,6 +85,7 @@ struct MockLogSystem : ILogSystem, ReferenceCounted<MockLogSystem> {
 	                                       int8_t primaryLocality,
 	                                       int8_t remoteLocality,
 	                                       const vector<Tag>& allTags,
+	                                       TLogGroupCollectionRef tLogGroupCollection,
 	                                       const Reference<AsyncVar<bool>>& recruitmentStalled) final;
 	LogSystemConfig getLogSystemConfig() const final;
 	Standalone<StringRef> getLogsValue() const final;

--- a/fdbserver/ProxyCommitData.actor.h
+++ b/fdbserver/ProxyCommitData.actor.h
@@ -255,7 +255,7 @@ struct ProxyCommitData {
 	    cx(openDBOnServer(db, TaskPriority::DefaultEndpoint, true, true)), db(db),
 	    singleKeyMutationEvent(LiteralStringRef("SingleKeyMutation")), commitBatchesMemBytesCount(0), lastTxsPop(0),
 	    lastStartCommit(0), lastCommitLatency(SERVER_KNOBS->REQUIRED_MIN_RECOVERY_DURATION), lastCommitTime(0),
-	    lastMasterReset(now()), lastResolverReset(now()), tLogGroupCollection(makeReference<TLogGroupCollection>()) {
+	    lastMasterReset(now()), lastResolverReset(now()), tLogGroupCollection(makeReference<TLogGroupCollection>(db)) {
 		commitComputePerOperation.resize(SERVER_KNOBS->PROXY_COMPUTE_BUCKETS, 0.0);
 	}
 };

--- a/fdbserver/TLogGroup.actor.cpp
+++ b/fdbserver/TLogGroup.actor.cpp
@@ -102,12 +102,14 @@ TLogGroupRef TLogGroupCollection::getGroup(UID groupId, bool create) {
 void TLogGroupCollection::addWorkers(
     const std::vector<OptionalInterface<ptxn::TLogInterface_PassivelyPull>>& logWorkers) {
 	for (const auto& worker : logWorkers) {
+		TraceEvent("TLogGroupAddWorker").detail("ID", worker.id());
 		recruitMap.emplace(worker.id(), TLogWorkerData::fromInterface(worker));
 	}
 }
 
 void TLogGroupCollection::addWorkers(const std::vector<ptxn::TLogInterface_PassivelyPull>& logWorkers) {
 	for (const auto& worker : logWorkers) {
+		TraceEvent("TLogGroupAddWorker").detail("ID", worker.id()).detail("Address", worker.address());
 		recruitMap.emplace(worker.id(), TLogWorkerData::fromInterface(worker));
 	}
 }
@@ -182,7 +184,7 @@ bool TLogGroupCollection::tryAddStorageTeam(ptxn::StorageTeamID teamId, vector<U
 		return false;
 	}
 	storageTeams[teamId] = servers;
-	TraceEvent("TLogGroupAddStorageTeam").detail("StorageTeamIdW", teamId).detail("Servers", describe(servers));
+	TraceEvent("TLogGroupAddStorageTeam").detail("StorageTeamId", teamId).detail("Servers", describe(servers));
 	return true;
 }
 

--- a/fdbserver/TLogGroup.actor.cpp
+++ b/fdbserver/TLogGroup.actor.cpp
@@ -65,6 +65,12 @@ TLogGroupCollection::TLogGroupCollection(Reference<AsyncVar<ServerDBInfo>> dbInf
 	}
 }
 
+void TLogGroupCollection::setPolicy(const Reference<IReplicationPolicy>& policy, int numGroups, int groupSize) {
+	this->policy = policy;
+	this->GROUP_SIZE = groupSize;
+	this->targetNumGroups = numGroups;
+}
+
 const std::vector<TLogGroupRef>& TLogGroupCollection::groups() const {
 	return recruitedGroups;
 }
@@ -165,6 +171,7 @@ void TLogGroupCollection::addTLogGroup(TLogGroupRef group) {
 }
 
 TLogGroupRef TLogGroupCollection::selectFreeGroup(int seed) {
+	ASSERT(recruitedGroups.size() > 0);
 	return recruitedGroups[seed % recruitedGroups.size()];
 }
 

--- a/fdbserver/TLogGroup.actor.h
+++ b/fdbserver/TLogGroup.actor.h
@@ -37,6 +37,7 @@
 #include "fdbclient/NativeAPI.actor.h"
 #include "fdbserver/IKeyValueStore.h"
 #include "fdbrpc/Locality.h"
+#include "fdbrpc/Replication.h"
 #include "fdbserver/WorkerInterface.actor.h"
 #include "flow/FastRef.h"
 #include "flow/IRandom.h"
@@ -87,7 +88,7 @@ public:
 	int targetGroupSize() const;
 
 	// Add 'logWorkers' to current collection of workers that can be recruited into a TLogGroup.
-	void addWorkers(const std::vector<WorkerInterface>& logWorkers);
+	void addWorkers(const std::vector<TLogInterface>& logWorkers);
 	void addWorkers(const std::vector<OptionalInterface<TLogInterface>>& logWorkers);
 
 	// Build a collection of groups and recruit workers into each group as per the ReplicationPolicy
@@ -220,9 +221,9 @@ struct TLogWorkerData : public ReferenceCounted<TLogWorkerData> {
 	TLogWorkerData(const UID& id, const NetworkAddress& addr, const LocalityData& locality)
 	  : id(id), address(addr), locality(locality) {}
 
-	// Converts a WorkerInterface to TLogWorkerData.
-	static TLogWorkerDataRef fromInterface(const WorkerInterface& interf) {
-		return makeReference<TLogWorkerData>(interf.id(), interf.address(), interf.locality);
+	// Converts a TLogInterface to TLogWorkerData.
+	static TLogWorkerDataRef fromInterface(const TLogInterface& interf) {
+		return makeReference<TLogWorkerData>(interf.id(), interf.address(), interf.filteredLocality);
 	}
 	// Converts a WorkerInterface to TLogWorkerData.
 	static TLogWorkerDataRef fromInterface(const OptionalInterface<TLogInterface>& interf) {

--- a/fdbserver/TLogGroup.actor.h
+++ b/fdbserver/TLogGroup.actor.h
@@ -71,6 +71,9 @@ public:
 	// intended to  be used by CommitProxy.
 	explicit TLogGroupCollection(Reference<AsyncVar<ServerDBInfo>> serverDbInfo);
 
+	// Sets the policy for TLogGroupCollection.
+	void setPolicy(const Reference<IReplicationPolicy>& policy, int numGroups, int groupSize);
+
 	// Returns list of groups recruited by this collection.
 	const std::vector<TLogGroupRef>& groups() const;
 

--- a/fdbserver/TLogGroup.actor.h
+++ b/fdbserver/TLogGroup.actor.h
@@ -23,6 +23,7 @@
 // When actually compiled (NO_INTELLISENSE), include the generated version of
 // this file. In intellisense use the source version.
 #include "fdbserver/TesterInterface.actor.h"
+#include "fdbserver/ptxn/TLogInterface.h"
 #include "flow/Trace.h"
 #if defined(NO_INTELLISENSE) && !defined(FDBSERVER_TLOGROUP_ACTOR_G_H)
 #define FDBSERVER_TLOGROUP_ACTOR_G_H
@@ -66,12 +67,9 @@ public:
 	// the contraints set by ReplicaitonPolicy 'policy'
 	explicit TLogGroupCollection(const Reference<IReplicationPolicy>& policy, int numGroups, int groupSize);
 
-	// Construct a TLogGroupCollection, where each group has 'groupSize' servers and satifies
-	// the contraints set by ReplicaitonPolicy 'policy'
-	explicit TLogGroupCollection(const Reference<IReplicationPolicy>& policy,
-	                             int numGroups,
-	                             int groupSize,
-	                             Reference<AsyncVar<ServerDBInfo>> serverDbInfo);
+	// Construct a TLogGroupCollection from `serverDbInfo`. This object would not be able to recruit TLogGroup, and is
+	// intended to  be used by CommitProxy.
+	explicit TLogGroupCollection(Reference<AsyncVar<ServerDBInfo>> serverDbInfo);
 
 	// Returns list of groups recruited by this collection.
 	const std::vector<TLogGroupRef>& groups() const;
@@ -88,8 +86,8 @@ public:
 	int targetGroupSize() const;
 
 	// Add 'logWorkers' to current collection of workers that can be recruited into a TLogGroup.
-	void addWorkers(const std::vector<TLogInterface>& logWorkers);
-	void addWorkers(const std::vector<OptionalInterface<TLogInterface>>& logWorkers);
+	void addWorkers(const std::vector<ptxn::TLogInterface_PassivelyPull>& logWorkers);
+	void addWorkers(const std::vector<OptionalInterface<ptxn::TLogInterface_PassivelyPull>>& logWorkers);
 
 	// Build a collection of groups and recruit workers into each group as per the ReplicationPolicy
 	// and group size set in the parent class.
@@ -139,10 +137,10 @@ private:
 
 	// ReplicationPolicy defined for this collection. The members of group must satisfy
 	// this replication policy, or else will not be part of a group.
-	const Reference<IReplicationPolicy> policy;
+	Reference<IReplicationPolicy> policy;
 
 	// Size of each group, set once during intialization.
-	const int GROUP_SIZE;
+	int GROUP_SIZE;
 
 	// Number of groups the collection is configured to recruit.
 	int targetNumGroups;
@@ -222,14 +220,14 @@ struct TLogWorkerData : public ReferenceCounted<TLogWorkerData> {
 	  : id(id), address(addr), locality(locality) {}
 
 	// Converts a TLogInterface to TLogWorkerData.
-	static TLogWorkerDataRef fromInterface(const TLogInterface& interf) {
-		return makeReference<TLogWorkerData>(interf.id(), interf.address(), interf.filteredLocality);
+	static TLogWorkerDataRef fromInterface(const ptxn::TLogInterface_PassivelyPull& interf) {
+		return makeReference<TLogWorkerData>(interf.id(), interf.address(), interf.getLocality());
 	}
 	// Converts a WorkerInterface to TLogWorkerData.
-	static TLogWorkerDataRef fromInterface(const OptionalInterface<TLogInterface>& interf) {
+	static TLogWorkerDataRef fromInterface(const OptionalInterface<ptxn::TLogInterface_PassivelyPull>& interf) {
 		if (interf.present()) {
 			auto inf = interf.interf();
-			return makeReference<TLogWorkerData>(inf.id(), inf.address(), inf.filteredLocality);
+			return makeReference<TLogWorkerData>(inf.id(), inf.address(), inf.getLocality());
 		} else {
 			// TODO (Vishesh) Figure out how to find out locality later?
 			return makeReference<TLogWorkerData>(interf.id());

--- a/fdbserver/TagPartitionedLogSystem.actor.cpp
+++ b/fdbserver/TagPartitionedLogSystem.actor.cpp
@@ -85,6 +85,9 @@ LogSet::LogSet(const TLogSet& tLogSet)
 	for (const auto& log : tLogSet.tLogs) {
 		logServers.push_back(makeReference<AsyncVar<OptionalInterface<TLogInterface>>>(log));
 	}
+	for (const auto& log : tLogSet.tLogsPtxn) {
+		logServersPtxn.push_back(makeReference<AsyncVar<OptionalInterface<ptxn::TLogInterface_PassivelyPull>>>(log));
+	}
 	tLogGroupIDs = tLogSet.tLogGroupIDs;
 	for (int i = 0; tLogGroupIDs.size(); i++) {
 		for (const OptionalInterface<ptxn::TLogInterface_PassivelyPull>& interface : tLogSet.ptxnTLogGroups[i]) {

--- a/fdbserver/masterserver.actor.cpp
+++ b/fdbserver/masterserver.actor.cpp
@@ -785,7 +785,9 @@ ACTOR Future<vector<Standalone<CommitTransactionRef>>> recruitEverything(Referen
 	     newTLogServers(self, recruits, oldLogSystem, &confChanges));
 
 	// Recruit TLog groups
-	self->tLogGroupCollection->recruitEverything();
+	if (SERVER_KNOBS->TLOG_NEW_INTERFACE) {
+		self->tLogGroupCollection->recruitEverything();
+	}
 
 	// Assign storage teams to tLogGroups.
 	for (const auto& [teamId, _] : self->tLogGroupCollection->getStorageTeams()) {

--- a/fdbserver/masterserver.actor.cpp
+++ b/fdbserver/masterserver.actor.cpp
@@ -791,12 +791,12 @@ ACTOR Future<vector<Standalone<CommitTransactionRef>>> recruitEverything(Referen
 		                                     SERVER_KNOBS->TLOG_GROUP_COLLECTION_TARGET_SIZE,
 		                                     self->configuration.tLogReplicationFactor);
 		self->tLogGroupCollection->recruitEverything();
-	}
 
-	// Assign storage teams to tLogGroups.
-	for (const auto& [teamId, _] : self->tLogGroupCollection->getStorageTeams()) {
-		auto group = self->tLogGroupCollection->selectFreeGroup();
-		self->tLogGroupCollection->assignStorageTeam(teamId, group);
+		// Assign storage teams to tLogGroups.
+		for (const auto& [teamId, _] : self->tLogGroupCollection->getStorageTeams()) {
+			auto group = self->tLogGroupCollection->selectFreeGroup();
+			self->tLogGroupCollection->assignStorageTeam(teamId, group);
+		}
 	}
 
 	return confChanges;

--- a/fdbserver/masterserver.actor.cpp
+++ b/fdbserver/masterserver.actor.cpp
@@ -279,7 +279,8 @@ struct MasterData : NonCopyable, ReferenceCounted<MasterData> {
 	    getCommitVersionRequests("GetCommitVersionRequests", cc),
 	    backupWorkerDoneRequests("BackupWorkerDoneRequests", cc),
 	    getLiveCommittedVersionRequests("GetLiveCommittedVersionRequests", cc),
-	    reportLiveCommittedVersionRequests("ReportLiveCommittedVersionRequests", cc) {
+	    reportLiveCommittedVersionRequests("ReportLiveCommittedVersionRequests", cc),
+	    tLogGroupCollection(makeReference<TLogGroupCollection>()) {
 		logger = traceCounters("MasterMetrics", dbgid, SERVER_KNOBS->WORKER_LOGGING_INTERVAL, &cc, "MasterMetrics");
 		if (forceRecovery && !myInterface.locality.dcId().present()) {
 			TraceEvent(SevError, "ForcedRecoveryRequiresDcID");
@@ -786,6 +787,9 @@ ACTOR Future<vector<Standalone<CommitTransactionRef>>> recruitEverything(Referen
 
 	// Recruit TLog groups
 	if (SERVER_KNOBS->TLOG_NEW_INTERFACE) {
+		self->tLogGroupCollection->setPolicy(self->configuration.tLogPolicy,
+		                                     SERVER_KNOBS->TLOG_GROUP_COLLECTION_TARGET_SIZE,
+		                                     self->configuration.tLogReplicationFactor);
 		self->tLogGroupCollection->recruitEverything();
 	}
 
@@ -922,10 +926,6 @@ ACTOR Future<Void> readTransactionSystemState(Reference<MasterData> self,
 	// Clear previous TLogGroupCollection state
 	self->txnStateStore->clear(tLogGroupKeys);
 	self->txnStateStore->clear(storageTeamIdToTLogGroupRange);
-
-	self->tLogGroupCollection = makeReference<TLogGroupCollection>(self->configuration.tLogPolicy,
-	                                                               SERVER_KNOBS->TLOG_GROUP_COLLECTION_TARGET_SIZE,
-	                                                               self->configuration.tLogReplicationFactor);
 
 	// Load storage teams from \xff keyspace to tLogGroupCollection.
 	RangeResult ssTeams = wait(self->txnStateStore->readRange(storageTeamIdKeyRange));
@@ -1911,7 +1911,10 @@ ACTOR Future<Void> masterCore(Reference<MasterData> self) {
 		// Recruit and seed initial shard servers
 		// This transaction must be the very first one in the database (version 1)
 		seedShardServers(recoveryCommitRequest.arena, tr, seedServers);
-		self->tLogGroupCollection->seedTLogGroupAssignment(recoveryCommitRequest.arena, tr, seedServers);
+
+		if (SERVER_KNOBS->TLOG_NEW_INTERFACE) {
+			self->tLogGroupCollection->seedTLogGroupAssignment(recoveryCommitRequest.arena, tr, seedServers);
+		}
 	}
 	// initialConfChanges have not been conflict checked against any earlier writes in the recovery transaction, so do
 	// this as early as possible in the recovery transaction but see above comments as to why it can't be absolutely

--- a/fdbserver/ptxn/TLogInterface.h
+++ b/fdbserver/ptxn/TLogInterface.h
@@ -378,6 +378,7 @@ struct TLogInterfaceBase {
 	bool operator!=(const TLogInterfaceBase& r) const { return !this->operator==(r); }
 	NetworkAddress address() const { return commit.getEndpoint().getPrimaryAddress(); }
 	Optional<NetworkAddress> secondaryAddress() const { return commit.getEndpoint().addresses.secondaryAddress; }
+	const LocalityData& getLocality() const { return filteredLocality; }
 
 	MessageTransferModel getMessageTransferModel() const;
 


### PR DESCRIPTION
- We were using WorkerInterface ID which isn't useful as just using TLogInterface ID directly. 
- Use new ptxn::TLogInterface instead of older one.
- Add vector<ptxn::TLogInterface> to LogSystemConfig: We have tLog groups to tLog mapping in there, but       tLogGroupCollection needs to know the list of available tLogs first, which is available only via LogSystemConfig. Alternatively, we can also do tLogGroupCollection recruitment as part of
LogSystem, and possibly also add tLogGroupCollection to LogSystem itself, as it
is infact part of LogSystem.

 
# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR. However, getting tLog IDs needs us to wait during recovery until we get the TLogInterface.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
