### PR TITLE
Add libatomic for building FDB using Clang

### DIFF
--- a/flow/CMakeLists.txt
+++ b/flow/CMakeLists.txt
@@ -137,6 +137,12 @@ if(CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
     target_link_libraries(flow PUBLIC ${EIO})
   endif()
 endif()
+
+# For Clang in Linux environment, libatomic is required
+if (UNIX AND CMAKE_CXX_COMPILER_ID MATCHES "Clang$")
+	set (FLOW_LIBS ${FLOW_LIBS} atomic)
+endif ()
+
 target_link_libraries(flow PRIVATE ${FLOW_LIBS})
 if(USE_VALGRIND)
   target_link_libraries(flow PUBLIC Valgrind)


### PR DESCRIPTION
To build FDB using Linux/Clang, an additional library,libatomic, is needed.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [x] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
