### PR TITLE
Fix fallback logic for getting pod IPs in the sidecar

### DIFF
--- a/packaging/docker/sidecar/sidecar.py
+++ b/packaging/docker/sidecar/sidecar.py
@@ -236,7 +236,7 @@ class Config(object):
             # As long as the public IP is not set fallback to the
             # Pod IP address.
             pod_ip = os.getenv("FDB_POD_IP")
-            if pod_ip is none:
+            if pod_ip is None:
                 pod_ip = socket.gethostbyname(socket.gethostname())
             self.substitutions["FDB_PUBLIC_IP"] = pod_ip
 


### PR DESCRIPTION
This fixes a bug where we used the non-existent constant `none` rather than `None`. This caused the sidecar to crash loop when the `FDB_PUBLIC_IP` environment variable was not provided.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
