### PR TITLE
Add StorageTeams into ServerCacheInfo

### DIFF
--- a/fdbserver/CommitProxyServer.actor.cpp
+++ b/fdbserver/CommitProxyServer.actor.cpp
@@ -2098,7 +2098,7 @@ ACTOR Future<Void> commitProxyServerCore(CommitProxyInterface proxy,
 					RangeResult UIDtoTagMap = commitData.txnStateStore->readRange(serverTagKeys).get();
 					state std::map<Tag, UID> tag_uid;
 					state std::unordered_map<UID, ptxn::StorageTeamID> storageServerToStorageTeam;
-					state std::unordered_map<KeyRef, ValueRef> keyServers;
+					state std::vector<std::pair<KeyRef, ValueRef>> keyServers;
 					for (const KeyValueRef kv : UIDtoTagMap) {
 						tag_uid[decodeServerTagValue(kv.value)] = decodeServerTagKey(kv.key);
 					}
@@ -2116,7 +2116,7 @@ ACTOR Future<Void> commitProxyServerCore(CommitProxyInterface proxy,
 						MutationsVec mutations;
 						for (auto& kv : data) {
 							if (kv.key.startsWith(keyServersPrefix)) {
-								keyServers.emplace(kv.key.removePrefix(keyServersPrefix), kv.value);
+								keyServers.emplace_back(kv.key.removePrefix(keyServersPrefix), kv.value);
 							} else if (kv.key.startsWith(storageServerToTeamIdKeyPrefix)) {
 								KeyRef k = kv.key.removePrefix(keyServersPrefix);
 								std::set<ptxn::StorageTeamID> storageTeamIDs =

--- a/fdbserver/CommitProxyServer.actor.cpp
+++ b/fdbserver/CommitProxyServer.actor.cpp
@@ -2170,6 +2170,8 @@ ACTOR Future<Void> commitProxyServerCore(CommitProxyInterface proxy,
 					// insert keyTag data separately from metadata mutations so that we can do one bulk insert which
 					// avoids a lot of map lookups.
 					commitData.keyInfo.rawInsert(keyInfoData);
+					storageServerToStorageTeam.clear();
+					keyServers.clear();
 
 					auto lockedKey = commitData.txnStateStore->readValue(databaseLockedKey).get();
 					commitData.locked = lockedKey.present() && lockedKey.get().size();

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -6464,11 +6464,6 @@ ACTOR Future<Void> dataDistributor(DataDistributorInterface di, Reference<AsyncV
 	self->addActor.send(actors.getResult());
 	self->addActor.send(traceRole(Role::DATA_DISTRIBUTOR, di.id()));
 
-	loop {
-		wait(delay(1.0));
-	}
-
-/*
 	try {
 		TraceEvent("DataDistributorRunning", di.id());
 		self->addActor.send(waitFailureServer(di.waitFailure.getFuture()));
@@ -6508,7 +6503,6 @@ ACTOR Future<Void> dataDistributor(DataDistributorInterface di, Reference<AsyncV
 		TraceEvent("DataDistributorDied", di.id()).error(err, true);
 	}
 	return Void();
-*/
 }
 
 std::unique_ptr<DDTeamCollection> testTeamCollection(int teamSize,


### PR DESCRIPTION
Add StorageTeams into ServerCacheInfo so that proxy can look up storage teams by key ranges.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [x] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
