### PR TITLE
Bug fixes in IAsyncEncryptedFile

### DIFF
--- a/fdbclient/BackupContainerFileSystem.actor.cpp
+++ b/fdbclient/BackupContainerFileSystem.actor.cpp
@@ -163,7 +163,6 @@ public:
 		state Version maxVer = 0;
 		state RangeFile rf;
 		state json_spirit::mArray fileArray;
-		state int i;
 
 		// Validate each filename, update version range
 		for (const auto& f : fileNames) {
@@ -1488,7 +1487,7 @@ void BackupContainerFileSystem::setEncryptionKey(Optional<std::string> const& en
 #endif
 	}
 }
-Future<Void> BackupContainerFileSystem::createTestEncryptionKeyFile(std::string const &filename) {
+Future<Void> BackupContainerFileSystem::createTestEncryptionKeyFile(std::string const& filename) {
 #if ENCRYPTION_ENABLED
 	return BackupContainerFileSystemImpl::createTestEncryptionKeyFile(filename);
 #else
@@ -1507,13 +1506,16 @@ int chooseFileSize(std::vector<int>& sizes) {
 	return deterministicRandom()->randomInt(0, 2e6);
 }
 
-ACTOR Future<Void> writeAndVerifyFile(Reference<IBackupContainer> c, Reference<IBackupFile> f, int size, FlowLock* lock) {
+ACTOR Future<Void> writeAndVerifyFile(Reference<IBackupContainer> c,
+                                      Reference<IBackupFile> f,
+                                      int size,
+                                      FlowLock* lock) {
 	state Standalone<VectorRef<uint8_t>> content;
 
 	wait(lock->take(TaskPriority::DefaultYield, size));
- 	state FlowLock::Releaser releaser(*lock, size);
+	state FlowLock::Releaser releaser(*lock, size);
 
- 	printf("writeAndVerify size=%d file=%s\n", size, f->getFileName().c_str());
+	printf("writeAndVerify size=%d file=%s\n", size, f->getFileName().c_str());
 	content.resize(content.arena(), size);
 	for (int i = 0; i < content.size(); ++i) {
 		content[i] = (uint8_t)deterministicRandom()->randomInt(0, 256);
@@ -1601,9 +1603,9 @@ ACTOR Future<Void> testBackupContainer(std::string url, Optional<std::string> en
 	// List of sizes to use to test edge cases on underlying file implementations
 	state std::vector<int> fileSizes = { 0 };
 	if (StringRef(url).startsWith(LiteralStringRef("blob"))) {
- 		fileSizes.push_back(CLIENT_KNOBS->BLOBSTORE_MULTIPART_MIN_PART_SIZE);
- 		fileSizes.push_back(CLIENT_KNOBS->BLOBSTORE_MULTIPART_MIN_PART_SIZE + 10);
- 	}
+		fileSizes.push_back(CLIENT_KNOBS->BLOBSTORE_MULTIPART_MIN_PART_SIZE);
+		fileSizes.push_back(CLIENT_KNOBS->BLOBSTORE_MULTIPART_MIN_PART_SIZE + 10);
+	}
 
 	loop {
 		state Version logStart = v;

--- a/fdbrpc/AsyncFileEncrypted.actor.cpp
+++ b/fdbrpc/AsyncFileEncrypted.actor.cpp
@@ -262,6 +262,7 @@ TEST_CASE("fdbrpc/AsyncFileEncrypted") {
 	state Reference<IAsyncFile> file =
 	    wait(IAsyncFileSystem::filesystem()->open(joinPath(params.getDataDir(), "test-encrypted-file"), flags, 0600));
 	state int bytesWritten = 0;
+	state int chunkSize;
 	while (bytesWritten < bytes) {
 		chunkSize = std::min(deterministicRandom()->randomInt(0, 100), bytes - bytesWritten);
 		wait(file->write(&writeBuffer[bytesWritten], chunkSize, bytesWritten));
@@ -269,7 +270,6 @@ TEST_CASE("fdbrpc/AsyncFileEncrypted") {
 	}
 	wait(file->sync());
 	state int bytesRead = 0;
-	state int chunkSize;
 	while (bytesRead < bytes) {
 		chunkSize = std::min(deterministicRandom()->randomInt(0, 100), bytes - bytesRead);
 		int bytesReadInChunk = wait(file->read(&readBuffer[bytesRead], chunkSize, bytesRead));

--- a/fdbrpc/AsyncFileEncrypted.h
+++ b/fdbrpc/AsyncFileEncrypted.h
@@ -40,7 +40,7 @@ public:
 private:
 	Reference<IAsyncFile> file;
 	StreamCipher::IV firstBlockIV;
-	StreamCipher::IV getIV(uint16_t block) const;
+	StreamCipher::IV getIV(uint32_t block) const;
 	Mode mode;
 	Future<Void> writeLastBlockToFile();
 	friend class AsyncFileEncryptedImpl;
@@ -48,19 +48,19 @@ private:
 	// Reading:
 	class RandomCache {
 		size_t maxSize;
-		std::vector<uint16_t> vec;
-		std::unordered_map<uint16_t, Standalone<StringRef>> hashMap;
+		std::vector<uint32_t> vec;
+		std::unordered_map<uint32_t, Standalone<StringRef>> hashMap;
 		size_t evict();
 
 	public:
 		RandomCache(size_t maxSize);
-		void insert(uint16_t block, const Standalone<StringRef>& value);
-		Optional<Standalone<StringRef>> get(uint16_t block) const;
+		void insert(uint32_t block, const Standalone<StringRef>& value);
+		Optional<Standalone<StringRef>> get(uint32_t block) const;
 	} readBuffers;
 
 	// Writing (append only):
 	std::unique_ptr<EncryptionStreamCipher> encryptor;
-	uint16_t currentBlock{ 0 };
+	uint32_t currentBlock{ 0 };
 	int offsetInBlock{ 0 };
 	std::vector<unsigned char> writeBuffer;
 	Future<Void> initialize();


### PR DESCRIPTION
Fixed issues with reads crossing file end, block memory lifetime, and file size limit.

Also, fixed IDE / clangd warnings and clang-formatted code.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
