### PR TITLE
Refactor decoder for better handling KV blocks

### DIFF
--- a/fdbbackup/FileDecoder.actor.cpp
+++ b/fdbbackup/FileDecoder.actor.cpp
@@ -370,7 +370,9 @@ public:
 		}
 
 		// No complete versions
-		TraceEvent(SevWarn, "UnfishedBlocks").detail("NumberOfVersions", mutationBlocksByVersion.size());
+		if (!mutationBlocksByVersion.empty()) {
+			TraceEvent(SevWarn, "UnfishedBlocks").detail("NumberOfVersions", mutationBlocksByVersion.size());
+		}
 		done = true;
 		return vms;
 	}

--- a/fdbbackup/FileDecoder.actor.cpp
+++ b/fdbbackup/FileDecoder.actor.cpp
@@ -681,7 +681,6 @@ public:
 
 ACTOR Future<Void> process_file(Reference<IBackupContainer> container, LogFile file, UID uid, DecodeParams params) {
 	TraceEvent("ProcessFile").detail("Name", file.fileName);
-	std::cout << "ProcessFile " << file.fileName << "\n";
 	if (file.fileSize == 0) {
 		TraceEvent("SkipEmptyFile").detail("Name", file.fileName);
 		return Void();
@@ -721,7 +720,6 @@ ACTOR Future<Void> process_file(Reference<IBackupContainer> container, LogFile f
 		}
 	}
 	TraceEvent("ProcessFileDone").detail("File", file.fileName);
-	std::cout << "ProcessFileDone " << file.fileName << "\n";
 	return Void();
 }
 
@@ -752,12 +750,10 @@ ACTOR Future<Void> decode_logs(DecodeParams params) {
 	state int idx = 0;
 	while (idx < logs.size()) {
 		TraceEvent("ProcessFileI").detail("Name", logs[idx].fileName).detail("I", idx);
-		std::cout << "ProcessFileI " << logs[idx].fileName << " " << idx << "\n";
 
 		wait(process_file(container, logs[idx], uid, params));
 
 		TraceEvent("ProcessFileIDone").detail("I", idx);
-		std::cout << "ProcessFileIDone " << idx << "\n";
 		idx++;
 	}
 	TraceEvent("DecodeDone", uid);

--- a/fdbbackup/FileDecoder.actor.cpp
+++ b/fdbbackup/FileDecoder.actor.cpp
@@ -592,7 +592,7 @@ public:
 			if (m.isComplete()) {
 				vms.version = version;
 				std::vector<MutationRef> mutations = decodeLogValue(m.serializedMutations);
-				TraceEvent("Decode").detail("version", vms.version).detail("N", mutations.size());
+				TraceEvent("Decode").detail("Version", vms.version).detail("N", mutations.size());
 				vms.mutations.insert(vms.mutations.end(), mutations.begin(), mutations.end());
 				vms.arena = blocks.arena();
 				vms.serializedMutations = m.serializedMutations;
@@ -711,7 +711,7 @@ ACTOR Future<Void> process_file(Reference<IBackupContainer> container, LogFile f
 				}
 			}
 			if (print) {
-				TraceEvent(format("Mutation_%d_%d", vms.version, sub).c_str(), uid)
+				TraceEvent(format("Mutation_%llu_%d", vms.version, sub).c_str(), uid)
 					.detail("Version", vms.version)
 					.setMaxFieldLength(10000)
 					.detail("M", m.toString());

--- a/fdbbackup/FileDecoder.actor.cpp
+++ b/fdbbackup/FileDecoder.actor.cpp
@@ -640,9 +640,9 @@ ACTOR Future<Void> decode_logs(DecodeParams params) {
 				continue;
 			}
 
-			int i = 0;
+			int sub = 0;
 			for (const auto& m : vms.mutations) {
-				i++; // sub sequence number starts at 1
+				sub++; // sub sequence number starts at 1
 				bool print = params.prefix.empty(); // no filtering
 
 				if (!print) {
@@ -656,7 +656,7 @@ ACTOR Future<Void> decode_logs(DecodeParams params) {
 					}
 				}
 				if (print) {
-					TraceEvent(format("Mutation_%d_%d", vms.version, i).c_str(), uid)
+					TraceEvent(format("Mutation_%d_%d", vms.version, sub).c_str(), uid)
 					    .detail("Version", vms.version)
 					    .setMaxFieldLength(10000)
 					    .detail("M", m.toString());

--- a/fdbclient/BackupAgent.actor.h
+++ b/fdbclient/BackupAgent.actor.h
@@ -970,6 +970,11 @@ ACTOR Future<Standalone<VectorRef<KeyValueRef>>> decodeRangeFileBlock(Reference<
                                                                       int64_t offset,
                                                                       int len);
 
+// Reads a mutation log block from file and parses into batch mutation blocks for further parsing.
+ACTOR Future<Standalone<VectorRef<KeyValueRef>>> decodeMutationLogFileBlock(Reference<IAsyncFile> file,
+                                                                            int64_t offset,
+                                                                            int len);
+
 // Return a block of contiguous padding bytes "\0xff" for backup files, growing if needed.
 Value makePadding(int size);
 } // namespace fileBackup

--- a/fdbclient/BackupContainer.h
+++ b/fdbclient/BackupContainer.h
@@ -306,4 +306,43 @@ private:
 	std::string URL;
 };
 
+namespace fileBackup {
+// Accumulates mutation log value chunks, as both a vector of chunks and as a combined chunk,
+// in chunk order, and can check the chunk set for completion or intersection with a set
+// of ranges.
+struct AccumulatedMutations {
+	AccumulatedMutations() : lastChunkNumber(-1) {}
+
+	// Add a KV pair for this mutation chunk set
+	// It will be accumulated onto serializedMutations if the chunk number is
+	// the next expected value.
+	void addChunk(int chunkNumber, const KeyValueRef& kv);
+
+	// Returns true if both
+	//   - 1 or more chunks were added to this set
+	//   - The header of the first chunk contains a valid protocol version and a length
+	//     that matches the bytes after the header in the combined value in serializedMutations
+	bool isComplete() const;
+
+	// Returns true if a complete chunk contains any MutationRefs which intersect with any
+	// range in ranges.
+	// It is undefined behavior to run this if isComplete() does not return true.
+	bool matchesAnyRange(const std::vector<KeyRange>& ranges) const;
+
+	std::vector<KeyValueRef> kvs;
+	std::string serializedMutations;
+	int lastChunkNumber;
+};
+
+// Decodes a mutation log key, which contains (hash, commitVersion, chunkNumber) and
+// returns (commitVersion, chunkNumber)
+std::pair<Version, int32_t> decodeMutationLogKey(const StringRef& key);
+
+// Decodes an encoded list of mutations in the format of:
+//   [includeVersion:uint64_t][val_length:uint32_t][mutation_1][mutation_2]...[mutation_k],
+// where a mutation is encoded as:
+//   [type:uint32_t][keyLength:uint32_t][valueLength:uint32_t][param1][param2]
+std::vector<MutationRef> decodeMutationLogValue(const StringRef& value);
+} // namespace fileBackup
+
 #endif


### PR DESCRIPTION
Refactor `fdbdecoder` to reuse `AccumulatedMutations` and mutation log decoding functions for restores. Because KV chunks can be out-of-order, now the process is to load the whole file into memory and to emit one version's data at a time. The out-of-order chunks are handled by `AccumulatedMutations` to avoid the original complicated logic.

The `fdbdecoder` has been manually tested to work as intended.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
