### PR TITLE
Disable using rocksdb in valgrind builds.

### DIFF
--- a/fdbserver/SimulatedCluster.actor.cpp
+++ b/fdbserver/SimulatedCluster.actor.cpp
@@ -2097,7 +2097,7 @@ void setupSimulatedSystem(vector<Future<Void>>* systemActors,
 
 using namespace std::literals;
 
-#ifdef SSD_ROCKSDB_EXPERIMENTAL
+#if defined(SSD_ROCKSDB_EXPERIMENTAL) && !VALGRIND
 bool rocksDBEnabled = true;
 #else
 bool rocksDBEnabled = false;


### PR DESCRIPTION
For valgrind builds, if rocksdb is chosen for the storage engine then simulation tests often timeout, even when they are not run under valgrind.  At least some of the tests hang indefinitely and stop writing TraceEvents to the log.

Although these tests aren't deterministic once the cluster starts, many choices prior to that are deterministic, so this commit hash and command should be able to reproduce the problem even if not every time.

```
0ce468198db3c4daf755cd1c17e2c02cdda755b9
bin/fdbserver -r simulation -f tests/slow/FastTriggeredWatches.toml -s 356712494 -b on  --crash
```

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
