### PR TITLE
Add the trace_partial_file_suffix option

### DIFF
--- a/bindings/c/CMakeLists.txt
+++ b/bindings/c/CMakeLists.txt
@@ -79,6 +79,7 @@ if(NOT WIN32)
     test/unit/fdb_api.hpp)
 
   set(UNIT_TEST_VERSION_510_SRCS test/unit/unit_tests_version_510.cpp)
+  set(TRACE_PARTIAL_FILE_SUFFIX_TEST_SRCS test/unit/trace_partial_file_suffix_test.cpp)
 
   if(OPEN_FOR_IDE)
     add_library(fdb_c_performance_test OBJECT test/performance_test.c test/test.h)
@@ -88,6 +89,7 @@ if(NOT WIN32)
     add_library(fdb_c_setup_tests OBJECT test/unit/setup_tests.cpp)
     add_library(fdb_c_unit_tests OBJECT ${UNIT_TEST_SRCS})
     add_library(fdb_c_unit_tests_version_510 OBJECT ${UNIT_TEST_VERSION_510_SRCS})
+    add_library(trace_partial_file_suffix_test OBJECT ${TRACE_PARTIAL_FILE_SUFFIX_TEST_SRCS})
   else()
     add_executable(fdb_c_performance_test test/performance_test.c test/test.h)
     add_executable(fdb_c_ryw_benchmark test/ryw_benchmark.c test/test.h)
@@ -96,6 +98,7 @@ if(NOT WIN32)
     add_executable(fdb_c_setup_tests test/unit/setup_tests.cpp)
     add_executable(fdb_c_unit_tests ${UNIT_TEST_SRCS})
     add_executable(fdb_c_unit_tests_version_510 ${UNIT_TEST_VERSION_510_SRCS})
+    add_executable(trace_partial_file_suffix_test ${TRACE_PARTIAL_FILE_SUFFIX_TEST_SRCS})
     strip_debug_symbols(fdb_c_performance_test)
     strip_debug_symbols(fdb_c_ryw_benchmark)
     strip_debug_symbols(fdb_c_txn_size_test)
@@ -106,12 +109,14 @@ if(NOT WIN32)
 
   add_dependencies(fdb_c_setup_tests doctest)
   add_dependencies(fdb_c_unit_tests doctest)
+  add_dependencies(fdb_c_unit_tests_version_510 doctest)
   target_include_directories(fdb_c_setup_tests PUBLIC ${DOCTEST_INCLUDE_DIR})
   target_include_directories(fdb_c_unit_tests PUBLIC ${DOCTEST_INCLUDE_DIR})
   target_include_directories(fdb_c_unit_tests_version_510 PUBLIC ${DOCTEST_INCLUDE_DIR})
   target_link_libraries(fdb_c_setup_tests PRIVATE fdb_c Threads::Threads)
   target_link_libraries(fdb_c_unit_tests PRIVATE fdb_c Threads::Threads)
   target_link_libraries(fdb_c_unit_tests_version_510 PRIVATE fdb_c Threads::Threads)
+  target_link_libraries(trace_partial_file_suffix_test PRIVATE fdb_c Threads::Threads)
 
   # do not set RPATH for mako
   set_property(TARGET mako PROPERTY SKIP_BUILD_RPATH TRUE)
@@ -144,6 +149,11 @@ if(NOT WIN32)
   add_fdbclient_test(
     NAME fdb_c_unit_tests_version_510
     COMMAND $<TARGET_FILE:fdb_c_unit_tests_version_510>
+            @CLUSTER_FILE@
+            fdb)
+  add_fdbclient_test(
+    NAME trace_partial_file_suffix_test
+    COMMAND $<TARGET_FILE:trace_partial_file_suffix_test>
             @CLUSTER_FILE@
             fdb)
   add_fdbclient_test(

--- a/bindings/c/test/unit/trace_partial_file_suffix_test.cpp
+++ b/bindings/c/test/unit/trace_partial_file_suffix_test.cpp
@@ -18,12 +18,13 @@
  * limitations under the License.
  */
 
-#include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <random>
 #include <string>
 #include <thread>
+
+#include "flow/Platform.h"
 
 #define FDB_API_VERSION 710
 #include "foundationdb/fdb_c.h"
@@ -77,8 +78,7 @@ int main(int argc, char** argv) {
 	// Eventually there's a new trace file for this test ending in .tmp
 	std::string name;
 	for (;;) {
-		for (const auto& entry : std::filesystem::directory_iterator(".")) {
-			auto path = entry.path().string();
+		for (const auto& path : platform::listFiles(".")) {
 			if (path.find(file_identifier) != std::string::npos && path.find(".simulated.") == std::string::npos) {
 				assert(path.substr(path.size() - trace_partial_file_suffix.size()) == trace_partial_file_suffix);
 				name = path;

--- a/bindings/c/test/unit/trace_partial_file_suffix_test.cpp
+++ b/bindings/c/test/unit/trace_partial_file_suffix_test.cpp
@@ -53,12 +53,11 @@ int main(int argc, char** argv) {
 	fdb_check(fdb_select_api_version(710));
 
 	std::string file_identifier = "trace_partial_file_suffix_test" + std::to_string(std::random_device{}());
-	// std::string trace_partial_file_suffix = ".tmp";
-	std::string trace_partial_file_suffix = "";
+	std::string trace_partial_file_suffix = ".tmp";
 
 	set_net_opt(FDBNetworkOption::FDB_NET_OPTION_TRACE_ENABLE, "");
 	set_net_opt(FDBNetworkOption::FDB_NET_OPTION_TRACE_FILE_IDENTIFIER, file_identifier);
-	// set_net_opt(FDBNetworkOption::FDB_NET_OPTION_TRACE_PARTIAL_FILE_SUFFIX, trace_partial_file_suffix);
+	set_net_opt(FDBNetworkOption::FDB_NET_OPTION_TRACE_PARTIAL_FILE_SUFFIX, trace_partial_file_suffix);
 
 	fdb_check(fdb_setup_network());
 	std::thread network_thread{ &fdb_run_network };

--- a/bindings/c/test/unit/trace_partial_file_suffix_test.cpp
+++ b/bindings/c/test/unit/trace_partial_file_suffix_test.cpp
@@ -1,0 +1,101 @@
+/*
+ * trace_partial_file_suffix_test.cpp
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <iostream>
+#include <random>
+#include <thread>
+#include <filesystem>
+
+#define FDB_API_VERSION 710
+#include "foundationdb/fdb_c.h"
+
+#undef NDEBUG
+#include <cassert>
+
+void fdb_check(fdb_error_t e) {
+	if (e) {
+		std::cerr << fdb_get_error(e) << std::endl;
+		std::abort();
+	}
+}
+
+void set_net_opt(FDBNetworkOption option, const std::string& value) {
+	fdb_check(fdb_network_set_option(option, reinterpret_cast<const uint8_t*>(value.c_str()), value.size()));
+}
+
+bool file_exists(const char* path) {
+	FILE* f = fopen(path, "r");
+	if (f) {
+		fclose(f);
+		return true;
+	}
+	return false;
+}
+
+int main(int argc, char** argv) {
+	fdb_check(fdb_select_api_version(710));
+
+	std::string file_identifier = "trace_partial_file_suffix_test" + std::to_string(std::random_device{}());
+	// std::string trace_partial_file_suffix = ".tmp";
+	std::string trace_partial_file_suffix = "";
+
+	set_net_opt(FDBNetworkOption::FDB_NET_OPTION_TRACE_ENABLE, "");
+	set_net_opt(FDBNetworkOption::FDB_NET_OPTION_TRACE_FILE_IDENTIFIER, file_identifier);
+	// set_net_opt(FDBNetworkOption::FDB_NET_OPTION_TRACE_PARTIAL_FILE_SUFFIX, trace_partial_file_suffix);
+
+	fdb_check(fdb_setup_network());
+	std::thread network_thread{ &fdb_run_network };
+
+	// Apparently you need to open a database to initialize logging
+	FDBDatabase* out;
+	fdb_check(fdb_create_database(nullptr, &out));
+	fdb_database_destroy(out);
+
+	// Eventually there's a trace file for this test ending in .tmp
+	std::string name;
+	for (;;) {
+		for (const auto& entry : std::filesystem::directory_iterator(".")) {
+			auto path = entry.path().string();
+			if (path.find(file_identifier) != std::string::npos) {
+				assert(path.substr(path.size() - trace_partial_file_suffix.size()) == trace_partial_file_suffix);
+				name = path;
+				break;
+			}
+		}
+		if (!name.empty()) {
+			break;
+		}
+	}
+
+	// Need to do one round trip to the network thread to make sure the trace file gets opened
+
+	fdb_check(fdb_stop_network());
+	network_thread.join();
+
+	// After shutting down, the trace file's suffix is (eventually) removed
+	if (!trace_partial_file_suffix.empty()) {
+		while (file_exists(name.c_str())) {
+		}
+	}
+
+	auto new_name = name.substr(0, name.size() - trace_partial_file_suffix.size());
+	assert(file_exists(new_name.c_str()));
+	remove(new_name.c_str());
+}

--- a/bindings/c/test/unit/trace_partial_file_suffix_test.cpp
+++ b/bindings/c/test/unit/trace_partial_file_suffix_test.cpp
@@ -83,8 +83,6 @@ int main(int argc, char** argv) {
 		}
 	}
 
-	// Need to do one round trip to the network thread to make sure the trace file gets opened
-
 	fdb_check(fdb_stop_network());
 	network_thread.join();
 

--- a/bindings/c/test/unit/trace_partial_file_suffix_test.cpp
+++ b/bindings/c/test/unit/trace_partial_file_suffix_test.cpp
@@ -86,10 +86,9 @@ int main(int argc, char** argv) {
 	fdb_check(fdb_stop_network());
 	network_thread.join();
 
-	// After shutting down, the trace file's suffix is (eventually) removed
+	// After shutting down, the trace file's suffix is removed
 	if (!trace_partial_file_suffix.empty()) {
-		while (file_exists(name.c_str())) {
-		}
+		assert(!file_exists(name.c_str()));
 	}
 
 	auto new_name = name.substr(0, name.size() - trace_partial_file_suffix.size());

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -1698,7 +1698,8 @@ Database Database::createDatabase(Reference<ClusterConnectionFile> connFile,
 			              networkOptions.traceDirectory.get(),
 			              "trace",
 			              networkOptions.traceLogGroup,
-			              networkOptions.traceFileIdentifier);
+			              networkOptions.traceFileIdentifier,
+			              networkOptions.tracePartialFileSuffix);
 
 			TraceEvent("ClientStart")
 			    .detail("SourceVersion", getSourceVersion())
@@ -1855,6 +1856,10 @@ void setNetworkOption(FDBNetworkOptions::Option option, Optional<StringRef> valu
 			fprintf(stderr, "Unrecognized trace clock source: `%s'\n", networkOptions.traceClockSource.c_str());
 			throw invalid_option_value();
 		}
+		break;
+	case FDBNetworkOptions::TRACE_PARTIAL_FILE_SUFFIX:
+		validateOptionValuePresent(value);
+		networkOptions.tracePartialFileSuffix = value.get().toString();
 		break;
 	case FDBNetworkOptions::KNOB: {
 		validateOptionValuePresent(value);

--- a/fdbclient/NativeAPI.actor.h
+++ b/fdbclient/NativeAPI.actor.h
@@ -68,6 +68,7 @@ struct NetworkOptions {
 	std::string traceFormat;
 	std::string traceClockSource;
 	std::string traceFileIdentifier;
+	std::string tracePartialFileSuffix;
 	Optional<bool> logClientInfo;
 	Reference<ReferencedObject<Standalone<VectorRef<ClientVersionRef>>>> supportedVersions;
 	bool runLoopProfilingEnabled;

--- a/fdbclient/vexillographer/fdb.options
+++ b/fdbclient/vexillographer/fdb.options
@@ -57,6 +57,9 @@ description is not currently required but encouraged.
     <Option name="trace_file_identifier" code="36"
             paramType="String" paramDescription="The identifier that will be part of all trace file names"
             description="Once provided, this string will be used to replace the port/PID in the log file names." />
+    <Option name="trace_partial_file_suffix" code="39"
+            paramType="String" paramDesciption="Append this suffix to partially written log files. When a log file is complete, rename it to remove the suffix."
+            description="" />
     <Option name="knob" code="40"
             paramType="String" paramDescription="knob_name=knob_value"
             description="Set internal tuning or debugging knobs"/>

--- a/fdbclient/vexillographer/fdb.options
+++ b/fdbclient/vexillographer/fdb.options
@@ -58,7 +58,7 @@ description is not currently required but encouraged.
             paramType="String" paramDescription="The identifier that will be part of all trace file names"
             description="Once provided, this string will be used to replace the port/PID in the log file names." />
     <Option name="trace_partial_file_suffix" code="39"
-            paramType="String" paramDesciption="Append this suffix to partially written log files. When a log file is complete, it is renamed to remove the suffix."
+            paramType="String" paramDesciption="Append this suffix to partially written log files. When a log file is complete, it is renamed to remove the suffix. No separator is added between the file and the suffix. If you want to add a file extension, you should include the separator - e.g. '.tmp' instead of 'tmp' to add the 'tmp' extension."
             description="" />
     <Option name="knob" code="40"
             paramType="String" paramDescription="knob_name=knob_value"

--- a/fdbclient/vexillographer/fdb.options
+++ b/fdbclient/vexillographer/fdb.options
@@ -58,7 +58,7 @@ description is not currently required but encouraged.
             paramType="String" paramDescription="The identifier that will be part of all trace file names"
             description="Once provided, this string will be used to replace the port/PID in the log file names." />
     <Option name="trace_partial_file_suffix" code="39"
-            paramType="String" paramDesciption="Append this suffix to partially written log files. When a log file is complete, rename it to remove the suffix."
+            paramType="String" paramDesciption="Append this suffix to partially written log files. When a log file is complete, it is renamed to remove the suffix."
             description="" />
     <Option name="knob" code="40"
             paramType="String" paramDescription="knob_name=knob_value"

--- a/flow/FileTraceLogWriter.cpp
+++ b/flow/FileTraceLogWriter.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "flow/FileTraceLogWriter.h"
+#include "flow/Platform.h"
 #include "flow/flow.h"
 #include "flow/ThreadHelper.actor.h"
 
@@ -229,6 +230,15 @@ void FileTraceLogWriter::cleanupTraceFiles() {
 	// Setting maxLogsSize=0 disables trace file cleanup based on dir size
 	if (!g_network->isSimulated() && maxLogsSize > 0) {
 		try {
+			// Rename/finalize any stray files ending in tracePartialFileSuffix for this process.
+			if (!tracePartialFileSuffix.empty()) {
+				for (const auto& f : platform::listFiles(directory, tracePartialFileSuffix)) {
+					if (f.substr(0, processName.length()) == processName) {
+						renameFile(f, f.substr(0, f.size() - tracePartialFileSuffix.size()));
+					}
+				}
+			}
+
 			std::vector<std::string> existingFiles = platform::listFiles(directory, extension);
 			std::vector<std::string> existingTraceFiles;
 

--- a/flow/FileTraceLogWriter.h
+++ b/flow/FileTraceLogWriter.h
@@ -51,6 +51,8 @@ private:
 	std::string processName;
 	std::string basename;
 	std::string extension;
+	std::string finalname;
+	std::string tracePartialFileSuffix;
 
 	uint64_t maxLogsSize;
 	int traceFileFD;
@@ -66,6 +68,7 @@ public:
 	                   std::string const& processName,
 	                   std::string const& basename,
 	                   std::string const& extension,
+	                   std::string const& tracePartialFileSuffix,
 	                   uint64_t maxLogsSize,
 	                   std::function<void()> const& onError,
 	                   Reference<ITraceLogIssuesReporter> const& issues);

--- a/flow/Trace.cpp
+++ b/flow/Trace.cpp
@@ -115,6 +115,7 @@ private:
 	std::string directory;
 	std::string processName;
 	Optional<NetworkAddress> localAddress;
+	std::string tracePartialFileSuffix;
 
 	Reference<IThreadPool> writer;
 	uint64_t rollsize;
@@ -288,13 +289,15 @@ public:
 	          std::string const& timestamp,
 	          uint64_t rs,
 	          uint64_t maxLogsSize,
-	          Optional<NetworkAddress> na) {
+	          Optional<NetworkAddress> na,
+	          std::string const& tracePartialFileSuffix) {
 		ASSERT(!writer && !opened);
 
 		this->directory = directory;
 		this->processName = processName;
 		this->logGroup = logGroup;
 		this->localAddress = na;
+		this->tracePartialFileSuffix = tracePartialFileSuffix;
 
 		basename = format("%s/%s.%s.%s",
 		                  directory.c_str(),
@@ -306,6 +309,7 @@ public:
 		    processName,
 		    basename,
 		    formatter->getExtension(),
+		    tracePartialFileSuffix,
 		    maxLogsSize,
 		    [this]() { barriers->triggerAll(); },
 		    issues));
@@ -715,7 +719,8 @@ void openTraceFile(const NetworkAddress& na,
                    std::string directory,
                    std::string baseOfBase,
                    std::string logGroup,
-                   std::string identifier) {
+                   std::string identifier,
+                   std::string tracePartialFileSuffix) {
 	if (g_traceLog.isOpen())
 		return;
 
@@ -739,7 +744,8 @@ void openTraceFile(const NetworkAddress& na,
 	                format("%lld", time(nullptr)),
 	                rollsize,
 	                maxLogsSize,
-	                !g_network->isSimulated() ? na : Optional<NetworkAddress>());
+	                !g_network->isSimulated() ? na : Optional<NetworkAddress>(),
+	                tracePartialFileSuffix);
 
 	uncancellable(recurring(&flushTraceFile, FLOW_KNOBS->TRACE_FLUSH_INTERVAL, TaskPriority::FlushTrace));
 	g_traceBatch.dump();

--- a/flow/Trace.h
+++ b/flow/Trace.h
@@ -564,7 +564,8 @@ void openTraceFile(const NetworkAddress& na,
                    std::string directory = ".",
                    std::string baseOfBase = "trace",
                    std::string logGroup = "default",
-                   std::string identifier = "");
+                   std::string identifier = "",
+                   std::string tracePartialFileSuffix = "");
 void initTraceEventMetrics();
 void closeTraceFile();
 bool traceFileIsOpen();


### PR DESCRIPTION
This option configures a suffix for partial trace files that gets removed once the trace file is complete. This is useful for cases where your trace log ingestion infrastructure on the client expects files matching a certain pattern to be complete - you can use the suffix to "hide" incomplete trace files from being ingested prematurely.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
