### PR TITLE
Add the trace_partial_file_suffix option (release-6.3)

### DIFF
--- a/bindings/c/CMakeLists.txt
+++ b/bindings/c/CMakeLists.txt
@@ -82,6 +82,7 @@ if(NOT WIN32)
     add_executable(fdb_c_ryw_benchmark test/ryw_benchmark.c test/test.h)
     add_executable(fdb_c_txn_size_test test/txn_size_test.c test/test.h)
     add_executable(mako ${MAKO_SRCS})
+    add_executable(trace_partial_file_suffix_test test/unit/trace_partial_file_suffix_test.cpp)
     strip_debug_symbols(fdb_c_performance_test)
     strip_debug_symbols(fdb_c_ryw_benchmark)
     strip_debug_symbols(fdb_c_txn_size_test)
@@ -89,9 +90,18 @@ if(NOT WIN32)
   target_link_libraries(fdb_c_performance_test PRIVATE fdb_c)
   target_link_libraries(fdb_c_ryw_benchmark PRIVATE fdb_c)
   target_link_libraries(fdb_c_txn_size_test PRIVATE fdb_c)
+
   # do not set RPATH for mako
   set_property(TARGET mako PROPERTY SKIP_BUILD_RPATH TRUE)
   target_link_libraries(mako PRIVATE fdb_c)
+
+  target_link_libraries(trace_partial_file_suffix_test PRIVATE fdb_c Threads::Threads)
+
+  add_fdbclient_test(
+    NAME trace_partial_file_suffix_test
+    COMMAND $<TARGET_FILE:trace_partial_file_suffix_test>
+            @CLUSTER_FILE@
+            fdb)
 endif()
 
 set(c_workloads_srcs

--- a/bindings/c/test/unit/trace_partial_file_suffix_test.cpp
+++ b/bindings/c/test/unit/trace_partial_file_suffix_test.cpp
@@ -1,0 +1,111 @@
+/*
+ * trace_partial_file_suffix_test.cpp
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <fstream>
+#include <iostream>
+#include <random>
+#include <string>
+#include <thread>
+
+#include "flow/Platform.h"
+
+#define FDB_API_VERSION 630
+#include "foundationdb/fdb_c.h"
+
+#undef NDEBUG
+#include <cassert>
+
+void fdb_check(fdb_error_t e) {
+	if (e) {
+		std::cerr << fdb_get_error(e) << std::endl;
+		std::abort();
+	}
+}
+
+void set_net_opt(FDBNetworkOption option, const std::string& value) {
+	fdb_check(fdb_network_set_option(option, reinterpret_cast<const uint8_t*>(value.c_str()), value.size()));
+}
+
+bool file_exists(const char* path) {
+	FILE* f = fopen(path, "r");
+	if (f) {
+		fclose(f);
+		return true;
+	}
+	return false;
+}
+
+int main(int argc, char** argv) {
+	fdb_check(fdb_select_api_version(630));
+
+	std::string file_identifier = "trace_partial_file_suffix_test" + std::to_string(std::random_device{}());
+	std::string trace_partial_file_suffix = ".tmp";
+	std::string simulated_stray_partial_file =
+	    "trace.127.0.0.1." + file_identifier + ".simulated.xml" + trace_partial_file_suffix;
+
+	// Simulate this process crashing previously by creating a ".tmp" file
+	{ std::ofstream file{ simulated_stray_partial_file }; }
+
+	set_net_opt(FDBNetworkOption::FDB_NET_OPTION_TRACE_ENABLE, "");
+	set_net_opt(FDBNetworkOption::FDB_NET_OPTION_TRACE_FILE_IDENTIFIER, file_identifier);
+	set_net_opt(FDBNetworkOption::FDB_NET_OPTION_TRACE_PARTIAL_FILE_SUFFIX, trace_partial_file_suffix);
+
+	fdb_check(fdb_setup_network());
+	std::thread network_thread{ &fdb_run_network };
+
+	// Apparently you need to open a database to initialize logging
+	FDBDatabase* out;
+	fdb_check(fdb_create_database(nullptr, &out));
+	fdb_database_destroy(out);
+
+	// Eventually there's a new trace file for this test ending in .tmp
+	std::string name;
+	for (;;) {
+		for (const auto& path : platform::listFiles(".")) {
+			if (path.find(file_identifier) != std::string::npos && path.find(".simulated.") == std::string::npos) {
+				assert(path.substr(path.size() - trace_partial_file_suffix.size()) == trace_partial_file_suffix);
+				name = path;
+				break;
+			}
+		}
+		if (!name.empty()) {
+			break;
+		}
+	}
+
+	fdb_check(fdb_stop_network());
+	network_thread.join();
+
+	// After shutting down, the suffix is removed for both the simulated stray file and our new file
+	if (!trace_partial_file_suffix.empty()) {
+		assert(!file_exists(name.c_str()));
+		assert(!file_exists(simulated_stray_partial_file.c_str()));
+	}
+
+	auto new_name = name.substr(0, name.size() - trace_partial_file_suffix.size());
+	auto new_stray_name =
+	    simulated_stray_partial_file.substr(0, simulated_stray_partial_file.size() - trace_partial_file_suffix.size());
+	assert(file_exists(new_name.c_str()));
+	assert(file_exists(new_stray_name.c_str()));
+	remove(new_name.c_str());
+	remove(new_stray_name.c_str());
+	assert(!file_exists(new_name.c_str()));
+	assert(!file_exists(new_stray_name.c_str()));
+}

--- a/cmake/ConfigureCompiler.cmake
+++ b/cmake/ConfigureCompiler.cmake
@@ -41,7 +41,9 @@ endif()
 add_compile_options(-DCMAKE_BUILD)
 add_compile_definitions(BOOST_ERROR_CODE_HEADER_ONLY BOOST_SYSTEM_NO_DEPRECATED)
 
+set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
+
 if(ALLOC_INSTRUMENTATION)
   add_compile_options(-DALLOC_INSTRUMENTATION)
 endif()

--- a/documentation/sphinx/source/release-notes/release-notes-630.rst
+++ b/documentation/sphinx/source/release-notes/release-notes-630.rst
@@ -4,6 +4,10 @@
 Release Notes
 #############
 
+6.3.19
+======
+* Add the ``trace_partial_file_suffix`` network option. This option will give unfinished trace files a special suffix to indicate they're not complete yet. When the trace file is complete, it is renamed to remove the suffix. `(PR #5330) <https://github.com/apple/foundationdb/pull/5330>`_
+
 6.3.18
 ======
 * The multi-version client API would not propagate errors that occurred when creating databases on external clients. This could result in a invalid memory accesses. `(PR #5221) <https://github.com/apple/foundationdb/pull/5221>`_

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -1277,7 +1277,7 @@ void setNetworkOption(FDBNetworkOptions::Option option, Optional<StringRef> valu
 		}
 		break;
 	case FDBNetworkOptions::TRACE_PARTIAL_FILE_SUFFIX:
-		validateOptionValuePresent(value);
+		validateOptionValue(value, true);
 		networkOptions.tracePartialFileSuffix = value.get().toString();
 		break;
 	case FDBNetworkOptions::KNOB: {

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -1144,7 +1144,8 @@ Database Database::createDatabase(Reference<ClusterConnectionFile> connFile,
 			              networkOptions.traceDirectory.get(),
 			              "trace",
 			              networkOptions.traceLogGroup,
-			              networkOptions.traceFileIdentifier);
+			              networkOptions.traceFileIdentifier,
+			              networkOptions.tracePartialFileSuffix);
 
 			TraceEvent("ClientStart")
 			    .detail("SourceVersion", getSourceVersion())
@@ -1274,6 +1275,10 @@ void setNetworkOption(FDBNetworkOptions::Option option, Optional<StringRef> valu
 			fprintf(stderr, "Unrecognized trace clock source: `%s'\n", networkOptions.traceClockSource.c_str());
 			throw invalid_option_value();
 		}
+		break;
+	case FDBNetworkOptions::TRACE_PARTIAL_FILE_SUFFIX:
+		validateOptionValuePresent(value);
+		networkOptions.tracePartialFileSuffix = value.get().toString();
 		break;
 	case FDBNetworkOptions::KNOB: {
 		validateOptionValue(value, true);

--- a/fdbclient/NativeAPI.actor.h
+++ b/fdbclient/NativeAPI.actor.h
@@ -63,6 +63,7 @@ struct NetworkOptions {
 	std::string traceFormat;
 	std::string traceClockSource;
 	std::string traceFileIdentifier;
+	std::string tracePartialFileSuffix;
 	Optional<bool> logClientInfo;
 	Reference<ReferencedObject<Standalone<VectorRef<ClientVersionRef>>>> supportedVersions;
 	bool runLoopProfilingEnabled;

--- a/fdbclient/vexillographer/fdb.options
+++ b/fdbclient/vexillographer/fdb.options
@@ -57,6 +57,9 @@ description is not currently required but encouraged.
     <Option name="trace_file_identifier" code="36"
             paramType="String" paramDescription="The identifier that will be part of all trace file names"
             description="Once provided, this string will be used to replace the port/PID in the log file names." />
+    <Option name="trace_partial_file_suffix" code="39"
+            paramType="String" paramDesciption="Append this suffix to partially written log files. When a log file is complete, it is renamed to remove the suffix. No separator is added between the file and the suffix. If you want to add a file extension, you should include the separator - e.g. '.tmp' instead of 'tmp' to add the 'tmp' extension."
+            description="" />
     <Option name="knob" code="40"
             paramType="String" paramDescription="knob_name=knob_value"
             description="Set internal tuning or debugging knobs"/>

--- a/flow/FileTraceLogWriter.h
+++ b/flow/FileTraceLogWriter.h
@@ -33,6 +33,8 @@ private:
 	std::string processName;
 	std::string basename;
 	std::string extension;
+	std::string finalname;
+	std::string tracePartialFileSuffix;
 
 	uint64_t maxLogsSize;
 	int traceFileFD;
@@ -46,6 +48,7 @@ public:
 	                   std::string processName,
 	                   std::string basename,
 	                   std::string extension,
+	                   std::string tracePartialFileSuffix,
 	                   uint64_t maxLogsSize,
 	                   std::function<void()> onError,
 	                   Reference<ITraceLogIssuesReporter> issues);

--- a/flow/Trace.cpp
+++ b/flow/Trace.cpp
@@ -138,6 +138,7 @@ private:
 	std::string directory;
 	std::string processName;
 	Optional<NetworkAddress> localAddress;
+	std::string tracePartialFileSuffix;
 
 	Reference<IThreadPool> writer;
 	uint64_t rollsize;
@@ -338,13 +339,15 @@ public:
 	          std::string const& timestamp,
 	          uint64_t rs,
 	          uint64_t maxLogsSize,
-	          Optional<NetworkAddress> na) {
+	          Optional<NetworkAddress> na,
+	          std::string const& tracePartialFileSuffix) {
 		ASSERT(!writer && !opened);
 
 		this->directory = directory;
 		this->processName = processName;
 		this->logGroup = logGroup;
 		this->localAddress = na;
+		this->tracePartialFileSuffix = tracePartialFileSuffix;
 
 		basename = format("%s/%s.%s.%s",
 		                  directory.c_str(),
@@ -356,6 +359,7 @@ public:
 		    processName,
 		    basename,
 		    formatter->getExtension(),
+		    tracePartialFileSuffix,
 		    maxLogsSize,
 		    [this]() { barriers->triggerAll(); },
 		    issues));
@@ -765,7 +769,8 @@ void openTraceFile(const NetworkAddress& na,
                    std::string directory,
                    std::string baseOfBase,
                    std::string logGroup,
-                   std::string identifier) {
+                   std::string identifier,
+                   std::string tracePartialFileSuffix) {
 	if (g_traceLog.isOpen())
 		return;
 
@@ -789,7 +794,8 @@ void openTraceFile(const NetworkAddress& na,
 	                format("%lld", time(NULL)),
 	                rollsize,
 	                maxLogsSize,
-	                !g_network->isSimulated() ? na : Optional<NetworkAddress>());
+	                !g_network->isSimulated() ? na : Optional<NetworkAddress>(),
+	                tracePartialFileSuffix);
 
 	uncancellable(recurring(&flushTraceFile, FLOW_KNOBS->TRACE_FLUSH_INTERVAL, TaskPriority::FlushTrace));
 	g_traceBatch.dump();

--- a/flow/Trace.h
+++ b/flow/Trace.h
@@ -577,7 +577,8 @@ void openTraceFile(const NetworkAddress& na,
                    std::string directory = ".",
                    std::string baseOfBase = "trace",
                    std::string logGroup = "default",
-                   std::string identifier = "");
+                   std::string identifier = "",
+                   std::string tracePartialFileSuffix = "");
 void initTraceEventMetrics();
 void closeTraceFile();
 bool traceFileIsOpen();


### PR DESCRIPTION
Cherry pick https://github.com/apple/foundationdb/pull/5325 to release-6.3



This option configures a suffix for partial trace files that gets removed once the trace file is complete. This is useful for cases where your trace log ingestion infrastructure on the client expects files matching a certain pattern to be complete - you can use the suffix to "hide" incomplete trace files from being ingested prematurely.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
