### PR TITLE
Remove hot TraceEvents from GlobalConfig

### DIFF
--- a/fdbclient/GlobalConfig.actor.cpp
+++ b/fdbclient/GlobalConfig.actor.cpp
@@ -77,7 +77,7 @@ void GlobalConfig::trigger(KeyRef key, std::function<void(std::optional<std::any
 }
 
 void GlobalConfig::insert(KeyRef key, ValueRef value) {
-	TraceEvent(SevInfo, "GlobalConfig_Insert").detail("Key", key).detail("Value", value);
+	// TraceEvent(SevInfo, "GlobalConfig_Insert").detail("Key", key).detail("Value", value);
 	data.erase(key);
 
 	Arena arena(key.expectedSize() + value.expectedSize());
@@ -113,7 +113,7 @@ void GlobalConfig::erase(Key key) {
 }
 
 void GlobalConfig::erase(KeyRangeRef range) {
-	TraceEvent(SevInfo, "GlobalConfig_Erase").detail("Range", range);
+	// TraceEvent(SevInfo, "GlobalConfig_Erase").detail("Range", range);
 	auto it = data.begin();
 	while (it != data.end()) {
 		if (range.contains(it->first)) {
@@ -167,7 +167,7 @@ ACTOR Future<Void> GlobalConfig::migrate(GlobalConfig* self) {
 		// attempt this migration at the same time, sometimes resulting in
 		// aborts due to conflicts. Purposefully avoid retrying, making this
 		// migration best-effort.
-		TraceEvent(SevInfo, "GlobalConfigMigrationError").detail("What", e.what());
+		TraceEvent(SevInfo, "GlobalConfig_MigrationError").detail("What", e.what());
 	}
 
 	return Void();
@@ -176,7 +176,7 @@ ACTOR Future<Void> GlobalConfig::migrate(GlobalConfig* self) {
 // Updates local copy of global configuration by reading the entire key-range
 // from storage.
 ACTOR Future<Void> GlobalConfig::refresh(GlobalConfig* self) {
-	TraceEvent trace(SevInfo, "GlobalConfig_Refresh");
+	// TraceEvent trace(SevInfo, "GlobalConfig_Refresh");
 	self->erase(KeyRangeRef(""_sr, "\xff"_sr));
 
 	Transaction tr(self->cx);

--- a/fdbclient/GlobalConfig.actor.h
+++ b/fdbclient/GlobalConfig.actor.h
@@ -108,7 +108,6 @@ public:
 	// the key.
 	template <typename T, typename std::enable_if<std::is_arithmetic<T>{}, bool>::type = true>
 	const T get(KeyRef name, T defaultVal) {
-		TraceEvent(SevInfo, "GlobalConfig_Get").detail("Key", name);
 		try {
 			auto configValue = get(name);
 			if (configValue.isValid()) {


### PR DESCRIPTION
#5291 added a `TraceEvent` on a hot code path (called every time a `Transaction` is created). Steve let me know that it was causing >50% of all `TraceEvent`s in the logs for most simulation tests. The date #5291 also lines up with a big dip in grv performance as reported by our nightly performance testing. This trace could be involved in the performance regression as well.

This PR removes all info-level `TraceEvent`s associated with GlobalConfig. The hot trace was `GlobalConfig_Get`, being called at https://github.com/apple/foundationdb/blob/cf7b42e65289e7f9ade481cb0a45aecd35c0bb90/fdbclient/NativeAPI.actor.cpp#L6314 which is in turn called from the `Transaction` constructor.

Passed 10k correctness tests.

Currently running performance testing.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
