### PR TITLE
Add split points and pass to database configuration

### DIFF
--- a/fdbclient/DatabaseConfiguration.cpp
+++ b/fdbclient/DatabaseConfiguration.cpp
@@ -405,7 +405,9 @@ StatusObject DatabaseConfiguration::toJSON(bool noPolicies) const {
 
 	result["backup_worker_enabled"] = (int32_t)backupWorkerEnabled;
 	result["perpetual_storage_wiggle"] = perpetualStorageWiggleSpeed;
-	result["splits"] = getSplitJSON();
+	if (!splits.empty()) {
+		result["splits"] = getSplitJSON();
+	}
 	return result;
 }
 

--- a/fdbclient/DatabaseConfiguration.cpp
+++ b/fdbclient/DatabaseConfiguration.cpp
@@ -158,6 +158,10 @@ void parse(std::vector<RegionInfo>* regions, ValueRef const& v) {
 	}
 }
 
+void parse(std::vector<StringRef>* splits, ValueRef const& v) {
+	*splits = v.splitAny(":"_sr);
+}
+
 void DatabaseConfiguration::setDefaultReplicationPolicy() {
 	if (!storagePolicy) {
 		storagePolicy = Reference<IReplicationPolicy>(
@@ -389,6 +393,7 @@ StatusObject DatabaseConfiguration::toJSON(bool noPolicies) const {
 
 	result["backup_worker_enabled"] = (int32_t)backupWorkerEnabled;
 	result["perpetual_storage_wiggle"] = perpetualStorageWiggleSpeed;
+	result["splits"] = getSplitJSON();
 	return result;
 }
 
@@ -454,6 +459,14 @@ StatusArray DatabaseConfiguration::getRegionJSON() const {
 		regionArr.push_back(regionObj);
 	}
 	return regionArr;
+}
+
+StatusArray DatabaseConfiguration::getSplitJSON() const {
+	StatusArray splitsArr;
+	for (const StringRef& s : splits) {
+		splitsArr.push_back(s.toString());
+	}
+	return splitsArr;
 }
 
 std::string DatabaseConfiguration::toString() const {
@@ -542,6 +555,8 @@ bool DatabaseConfiguration::setInternal(KeyRef key, ValueRef value) {
 		parse(&regions, value);
 	} else if (ck == LiteralStringRef("perpetual_storage_wiggle")) {
 		parse(&perpetualStorageWiggleSpeed, value);
+	} else if (ck == "splits"_sr) {
+		parse(&splits, value);
 	} else {
 		return false;
 	}

--- a/fdbclient/DatabaseConfiguration.h
+++ b/fdbclient/DatabaseConfiguration.h
@@ -104,8 +104,8 @@ struct DatabaseConfiguration {
 	DatabaseConfiguration();
 
 	void applyMutation(MutationRef mutation);
-	bool set(KeyRef key,
-	         ValueRef value); // Returns true if a configuration option that requires recovery to take effect is changed
+	// Returns true if a configuration option that requires recovery to take effect is changed
+	bool set(KeyRef key, ValueRef value);
 	bool clear(KeyRangeRef keys);
 	Optional<ValueRef> get(KeyRef key) const;
 
@@ -116,6 +116,7 @@ struct DatabaseConfiguration {
 	std::string toString() const;
 	StatusObject toJSON(bool noPolicies = false) const;
 	StatusArray getRegionJSON() const;
+	StatusArray getSplitJSON() const;
 
 	RegionInfo getRegion(Optional<Key> dcId) const {
 		if (!dcId.present()) {
@@ -245,6 +246,9 @@ struct DatabaseConfiguration {
 
 	// Perpetual Storage Setting
 	int32_t perpetualStorageWiggleSpeed;
+
+	// Initial shard split boundaries
+	std::vector<StringRef> splits;
 
 	// Excluded servers (no state should be here)
 	bool isExcludedServer(NetworkAddressList) const;

--- a/fdbclient/ManagementAPI.actor.cpp
+++ b/fdbclient/ManagementAPI.actor.cpp
@@ -23,6 +23,9 @@
 #include <vector>
 
 #include "fdbclient/Knobs.h"
+#include "fdbclient/Status.h"
+#include "fdbclient/json_spirit/json_spirit_reader_template.h"
+#include "fdbclient/json_spirit/json_spirit_value.h"
 #include "flow/Arena.h"
 #include "fdbclient/FDBOptions.g.h"
 #include "fdbclient/FDBTypes.h"
@@ -35,12 +38,14 @@
 #include "fdbclient/DatabaseContext.h"
 #include "fdbrpc/simulator.h"
 #include "fdbclient/StatusClient.h"
+#include "flow/ProtocolVersion.h"
 #include "flow/Trace.h"
 #include "flow/UnitTest.h"
 #include "fdbrpc/ReplicationPolicy.h"
 #include "fdbrpc/Replication.h"
 #include "flow/actorcompiler.h" // This must be the last #include.
 #include "fdbclient/Schemas.h"
+#include "flow/serialize.h"
 
 bool isInteger(const std::string& s) {
 	if (s.empty())
@@ -140,6 +145,16 @@ std::map<std::string, std::string> configForToken(std::string const& mode) {
 			regionObj["regions"] = mv;
 			out[p + key] =
 			    BinaryWriter::toValue(regionObj, IncludeVersion(ProtocolVersion::withRegionConfiguration())).toString();
+		}
+
+		if (key == "splits") {
+			json_spirit::mValue mv;
+			json_spirit::read_string(value, mv);
+
+			StatusObject splitsObj;
+			splitsObj["splits"] = mv;
+			out[p + key] = BinaryWriter::toValue(splitsObj, IncludeVersion(ProtocolVersion::withPartitionTransaction())).toString();
+			//out[p + key] = value;
 		}
 
 		if (key == "perpetual_storage_wiggle" && isInteger(value)) {

--- a/fdbclient/ManagementAPI.actor.cpp
+++ b/fdbclient/ManagementAPI.actor.cpp
@@ -148,13 +148,7 @@ std::map<std::string, std::string> configForToken(std::string const& mode) {
 		}
 
 		if (key == "splits") {
-			json_spirit::mValue mv;
-			json_spirit::read_string(value, mv);
-
-			StatusObject splitsObj;
-			splitsObj["splits"] = mv;
-			out[p + key] = BinaryWriter::toValue(splitsObj, IncludeVersion(ProtocolVersion::withPartitionTransaction())).toString();
-			//out[p + key] = value;
+			out[p + key] = value;
 		}
 
 		if (key == "perpetual_storage_wiggle" && isInteger(value)) {

--- a/fdbserver/SimulatedCluster.actor.cpp
+++ b/fdbserver/SimulatedCluster.actor.cpp
@@ -1211,6 +1211,7 @@ void SimulationConfig::set_config(std::string config) {
 void SimulationConfig::setSplits(const TestConfig& testConfig) {
 	if (!testConfig.splits.empty()) {
 		splitsStr = toJSONString(testConfig.splits);
+		std::cout << "set splits: " << splitsStr << "\n";
 		db.set(configKeysPrefix.withSuffix("splits"_sr), StringRef(splitsStr));
 	}
 }

--- a/fdbserver/SimulatedCluster.actor.cpp
+++ b/fdbserver/SimulatedCluster.actor.cpp
@@ -244,6 +244,7 @@ public:
 	Optional<int> datacenters, desiredTLogCount, commitProxyCount, grvProxyCount, resolverCount, storageEngineType,
 	    stderrSeverity, machineCount, processesPerMachine, coordinators;
 	Optional<std::string> config;
+	Optional<std::string> splits; // pre-defined shard split boundaries
 
 	bool tomlKeyPresent(const toml::value& data, std::string key) {
 		if (data.is_table()) {
@@ -286,6 +287,7 @@ public:
 		    .add("resolverCount", &resolverCount)
 		    .add("storageEngineType", &storageEngineType)
 		    .add("config", &config)
+		    .add("splits", &splits)
 		    .add("buggify", &buggify)
 		    .add("StderrSeverity", &stderrSeverity)
 		    .add("machineCount", &machineCount)
@@ -1155,6 +1157,7 @@ private:
 	void setProcessesPerMachine(const TestConfig& testConfig);
 	void setTss(const TestConfig& testConfig);
 	void generateNormalConfig(const TestConfig& testConfig);
+	void setSplits(const TestConfig& testConfig);
 };
 
 SimulationConfig::SimulationConfig(const TestConfig& testConfig) : extraDB(testConfig.extraDB) {
@@ -1168,6 +1171,12 @@ void SimulationConfig::set_config(std::string config) {
 	ASSERT(buildConfiguration(config, hack_map) != ConfigurationResult::NO_OPTIONS_PROVIDED);
 	for (auto kv : hack_map)
 		db.set(kv.first, kv.second);
+}
+
+void SimulationConfig::setSplits(const TestConfig& testConfig) {
+	if (testConfig.splits.present()) {
+		db.set(configKeysPrefix.withSuffix("splits"_sr), testConfig.splits.get());
+	}
 }
 
 StringRef StringRefOf(const char* s) {
@@ -1688,6 +1697,7 @@ void SimulationConfig::generateNormalConfig(const TestConfig& testConfig) {
 
 	setProcessesPerMachine(testConfig);
 	setTss(testConfig);
+	setSplits(testConfig);
 }
 
 // Configures the system according to the given specifications in order to run

--- a/fdbserver/TLogGroup.actor.cpp
+++ b/fdbserver/TLogGroup.actor.cpp
@@ -109,7 +109,7 @@ void TLogGroupCollection::addWorkers(
 
 void TLogGroupCollection::addWorkers(const std::vector<ptxn::TLogInterface_PassivelyPull>& logWorkers) {
 	for (const auto& worker : logWorkers) {
-		TraceEvent("TLogGroupAddWorker").detail("ID", worker.id()).detail("Address", worker.address());
+		TraceEvent("TLogGroupAddWorker").detail("WorkerID", worker.id()).detail("Address", worker.address());
 		recruitMap.emplace(worker.id(), TLogWorkerData::fromInterface(worker));
 	}
 }

--- a/fdbserver/masterserver.actor.cpp
+++ b/fdbserver/masterserver.actor.cpp
@@ -1922,6 +1922,9 @@ ACTOR Future<Void> masterCore(Reference<MasterData> self) {
 	} else {
 		// Recruit and seed initial shard servers
 		// This transaction must be the very first one in the database (version 1)
+		for (const auto& s : self->configuration.splits) {
+			TraceEvent("InitialSplitPoint", self->dbgid).detail("Point", s.toString());
+		}
 		seedShardServers(recoveryCommitRequest.arena, tr, seedServers);
 
 		if (SERVER_KNOBS->TLOG_NEW_INTERFACE) {

--- a/tests/ptxn/CycleTest.toml
+++ b/tests/ptxn/CycleTest.toml
@@ -1,5 +1,5 @@
 [configuration]
-splits = "a:b:c"
+splits = ["a","b","c"]
 
 [[test]]
 testTitle = 'Cycle'

--- a/tests/ptxn/CycleTest.toml
+++ b/tests/ptxn/CycleTest.toml
@@ -1,3 +1,6 @@
+[configuration]
+splits = "a:b:c"
+
 [[test]]
 testTitle = 'Cycle'
 


### PR DESCRIPTION
This is done for the first time DB is created. The split points are specified
in the TOML file and persisted into the database configuration.

I tested that `InitialSplitPoint` matches the splits defined in TOML file.

Correctness has a random unit test failure that can't be reproduced.

20210806-044301-jzhou-f317276c80168837             compressed=True data_size=26379470 duration=5230705 ended=104974 fail=1 fail_fast=10 max_runs=100000 pass=99999 priority=100 remaining=0 runtime=0:21:30 sanity=False started=105036 stopped=20210806-050431 submitted=20210806-044301 timeout=5400 username=jzhou


# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
