### PR TITLE
Don't use -latomic with clang

### DIFF
--- a/cmake/ConfigureCompiler.cmake
+++ b/cmake/ConfigureCompiler.cmake
@@ -261,10 +261,6 @@ else()
 
   if (CLANG)
     add_compile_options()
-    # Clang has link errors unless `atomic` is specifically requested.
-    if(NOT APPLE)
-      add_link_options(-latomic)
-    endif()
     if (APPLE OR USE_LIBCXX)
       add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-stdlib=libc++>)
       if (NOT APPLE)


### PR DESCRIPTION
Attempting to link with `-latomic` will make the build fail with clang and the official docker image. I tested this by compiling on our teamserver using the official docker image

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
