### PR TITLE
Disable advanceversion ctest

### DIFF
--- a/bindings/python/tests/fdbcli_tests.py
+++ b/bindings/python/tests/fdbcli_tests.py
@@ -436,7 +436,8 @@ if __name__ == '__main__':
     # assertions will fail if fdbcli does not work as expected
     process_number = int(sys.argv[3])
     if process_number == 1:
-        advanceversion()
+        # TODO: disable for now, the change can cause the database unavailable
+        #advanceversion()
         cache_range()
         consistencycheck()
         datadistribution()


### PR DESCRIPTION
The current test setting can cause the database unavailable afterward.
It used to be good so need to find out what logic is changed here and redesign the test.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
