### PR TITLE
Support commit multiple TLog groups with same commit version in TLogC…

### DIFF
--- a/fdbserver/LogSystem.h
+++ b/fdbserver/LogSystem.h
@@ -742,14 +742,14 @@ struct ILogSystem {
 	// Never returns normally, but throws an error if the subsystem stops working
 
 	// Future<Void> push( UID bundle, int64_t seq, VectorRef<TaggedMessageRef> messages );
-	virtual Future<Version> push(Version prevVersion,
+	virtual Future<Version> push(std::vector<Version> prevVersions,
 	                             Version version,
 	                             Version knownCommittedVersion,
 	                             Version minKnownCommittedVersion,
 	                             struct LogPushData& data,
 	                             SpanID const& spanContext,
 	                             Optional<UID> debugID = Optional<UID>(),
-	                             Optional<ptxn::TLogGroupID> tLogGroup = Optional<ptxn::TLogGroupID>()) = 0;
+	                             std::vector<ptxn::TLogGroupID> tLogGroups = std::vector<ptxn::TLogGroupID>()) = 0;
 	// Waits for the version number of the bundle (in this epoch) to be prevVersion (i.e. for all pushes ordered
 	// earlier) Puts the given messages into the bundle, each with the given tags, and with message versions (version,
 	// 0) - (version, N) Changes the version number of the bundle to be version (unblocking the next push) Returns when

--- a/fdbserver/MockLogSystem.cpp
+++ b/fdbserver/MockLogSystem.cpp
@@ -87,14 +87,14 @@ Future<Void> MockLogSystem::onError() {
 	return Future<Void>();
 }
 
-Future<Version> MockLogSystem::push(Version prevVersion,
+Future<Version> MockLogSystem::push(std::vector<Version> prevVersions,
                                     Version version,
                                     Version knownCommittedVersion,
                                     Version minKnownCommittedVersion,
                                     struct LogPushData& data,
                                     const SpanID& spanContext,
                                     Optional<UID> debugID,
-                                    Optional<ptxn::TLogGroupID> tLogGroup) {
+                                    std::vector<ptxn::TLogGroupID> tLogGroups) {
 	logMethodName(__func__);
 	return Future<Version>();
 }

--- a/fdbserver/MockLogSystem.h
+++ b/fdbserver/MockLogSystem.h
@@ -44,14 +44,14 @@ struct MockLogSystem : ILogSystem, ReferenceCounted<MockLogSystem> {
 	Future<Void> onCoreStateChanged() final;
 	void coreStateWritten(const DBCoreState& newState) final;
 	Future<Void> onError() final;
-	Future<Version> push(Version prevVersion,
+	Future<Version> push(std::vector<Version> prevVersions,
 	                     Version version,
 	                     Version knownCommittedVersion,
 	                     Version minKnownCommittedVersion,
 	                     struct LogPushData& data,
 	                     const SpanID& spanContext,
 	                     Optional<UID> debugID,
-	                     Optional<ptxn::TLogGroupID> tLogGroup) final;
+	                     std::vector<ptxn::TLogGroupID> tLogGroups) final;
 	Reference<IPeekCursor> peek(UID dbgid, Version begin, Optional<Version> end, Tag tag, bool parallelGetMore) final;
 	Reference<IPeekCursor> peek(UID dbgid,
 	                            Version begin,

--- a/fdbserver/ptxn/TLogInterface.h
+++ b/fdbserver/ptxn/TLogInterface.h
@@ -56,21 +56,22 @@ struct TLogCommitRequest {
 	// SpanID for tracing
 	SpanID spanID;
 
-	TLogGroupID tLogGroupID;
+	std::vector<TLogGroupID> tLogGroupIDs;
 
 	// TODO:
 	// std::unordered_map<StorageTeamID, StringRef> commits
 	// TLogGroupID group
 
 	// Arena
-	Arena arena;
+	std::vector<Arena> arenas;
 
 	// Serialized messages
-	std::unordered_map<StorageTeamID, StringRef> messages;
+	std::vector<std::unordered_map<StorageTeamID, StringRef>> messages;
 
 	// Versions
-	Version prevVersion;
+	std::vector<Version> prevVersions;
 	Version version;
+
 	Version knownCommittedVersion;
 	Version minKnownCommittedVersion;
 
@@ -82,25 +83,25 @@ struct TLogCommitRequest {
 
 	TLogCommitRequest() = default;
 	TLogCommitRequest(const SpanID& spanID_,
-	                  const TLogGroupID& tLogGroupID_,
-	                  const Arena arena_,
-	                  std::unordered_map<StorageTeamID, StringRef> messages_,
-	                  const Version prevVersion_,
+	                  const std::vector<TLogGroupID> tLogGroupIDs_,
+	                  const std::vector<Arena> arenas_,
+	                  std::vector<std::unordered_map<StorageTeamID, StringRef>> messages_,
+	                  const std::vector<Version> prevVersions_,
 	                  const Version version_,
 	                  const Version knownCommittedVersion_,
 	                  const Version minKnownCommittedVersion_,
 	                  const Optional<UID>& debugID_)
-	  : spanID(spanID_), tLogGroupID(tLogGroupID_), arena(arena_), messages(std::move(messages_)),
-	    prevVersion(prevVersion_), version(version_), knownCommittedVersion(knownCommittedVersion_),
+	  : spanID(spanID_), tLogGroupIDs(tLogGroupIDs_), arenas(arenas_), messages(std::move(messages_)),
+	    prevVersions(prevVersions_), version(version_), knownCommittedVersion(knownCommittedVersion_),
 	    minKnownCommittedVersion(minKnownCommittedVersion_), debugID(debugID_) {}
 
 	template <typename Ar>
 	void serialize(Ar& ar) {
 		serializer(ar,
 		           spanID,
-		           arena,
+		           arenas,
 		           messages,
-		           prevVersion,
+		           prevVersions,
 		           version,
 		           knownCommittedVersion,
 		           minKnownCommittedVersion,

--- a/fdbserver/ptxn/test/FakeProxy.actor.cpp
+++ b/fdbserver/ptxn/test/FakeProxy.actor.cpp
@@ -108,10 +108,10 @@ ACTOR Future<Void> fakeProxy(std::shared_ptr<FakeProxyContext> pFakeProxyContext
 			            << std::endl;
 			auto serialized = serializer->getAllSerialized();
 			TLogCommitRequest request(deterministicRandom()->randomUniqueID(),
-			                          tLogGroupID,
-			                          serialized.first,
-			                          serialized.second,
-			                          commitVersionPair.first,
+			                          std::vector<TLogGroupID>{tLogGroupID},
+			                          std::vector<Arena> {serialized.first},
+			                          std::vector<std::unordered_map<ptxn::StorageTeamID, StringRef>>{serialized.second},
+			                          std::vector<Version>{commitVersionPair.first},
 			                          commitVersionPair.second,
 			                          0,
 			                          0,

--- a/fdbserver/ptxn/test/RealTLog.actor.cpp
+++ b/fdbserver/ptxn/test/RealTLog.actor.cpp
@@ -219,7 +219,7 @@ ACTOR Future<Void> TLogDriverContext::sendPushMessages_impl(TLogDriverContext* p
 			toCommit.writeTypedMessage(m);
 		}
 		Future<Version> loggingComplete =
-		    pTLogDriverContext->ls->push(prev, next, prev, prev, toCommit, deterministicRandom()->randomUniqueID());
+		    pTLogDriverContext->ls->push(std::vector<Version>{prev}, next, prev, prev, toCommit, deterministicRandom()->randomUniqueID());
 		Version ver = wait(loggingComplete);
 		ASSERT_LE(ver, next);
 		prev++;

--- a/fdbserver/ptxn/test/TestTLogServer.actor.cpp
+++ b/fdbserver/ptxn/test/TestTLogServer.actor.cpp
@@ -120,10 +120,10 @@ ACTOR Future<Void> commitPeekAndCheck(std::shared_ptr<ptxn::test::TestDriverCont
 	std::unordered_map<ptxn::StorageTeamID, StringRef> messages = { { storageTeamID, serialized } };
 	// Commit
 	ptxn::TLogCommitRequest commitRequest(ptxn::test::randomUID(),
-	                                      pContext->storageTeamIDTLogGroupIDMapper[storageTeamID],
-	                                      serialized.arena(),
-	                                      messages,
-	                                      prevVersion,
+	                                      std::vector<ptxn::TLogGroupID>{pContext->storageTeamIDTLogGroupIDMapper[storageTeamID]},
+	                                      std::vector<Arena>{serialized.arena()},
+	                                      std::vector<std::unordered_map<ptxn::StorageTeamID, StringRef>>{messages},
+	                                      std::vector<Version>{prevVersion},
 	                                      beginVersion,
 	                                      0,
 	                                      0,
@@ -311,10 +311,10 @@ ACTOR Future<Void> commitInject(std::shared_ptr<ptxn::test::TestDriverContext> p
 		auto serialized = serializeMutations(currVersion, storageTeamID, pContext->commitRecord);
 		std::unordered_map<ptxn::StorageTeamID, StringRef> messages = { { storageTeamID, serialized } };
 		requests.emplace_back(ptxn::test::randomUID(),
-		                      pContext->storageTeamIDTLogGroupIDMapper[storageTeamID],
-		                      serialized.arena(),
-		                      messages,
-		                      prevVersion,
+		                      std::vector<ptxn::TLogGroupID>{pContext->storageTeamIDTLogGroupIDMapper[storageTeamID]},
+		                      std::vector<Arena>{serialized.arena()},
+		                      std::vector<std::unordered_map<ptxn::StorageTeamID, StringRef>>{messages},
+		                      std::vector<Version>{prevVersion},
 		                      currVersion,
 		                      0,
 		                      0,

--- a/fdbserver/ptxn/test/Utils.cpp
+++ b/fdbserver/ptxn/test/Utils.cpp
@@ -95,10 +95,10 @@ void print(const TLogCommitRequest& request) {
 	std::cout << std::endl << ">>> TLogCommitRequest" << std::endl;
 
 	std::cout << formatKVPair("Span ID", request.spanID) << std::endl
-	          << formatKVPair("Log Group ID", request.tLogGroupID) << std::endl
+	          << formatKVPair("Log Group ID length", request.tLogGroupIDs.size()) << std::endl
 	          << formatKVPair("Debug ID", request.debugID) << std::endl
 	          << formatKVPair("Message data length", request.messages.size()) << std::endl
-	          << formatKVPair("Previous version", request.prevVersion) << std::endl
+	          << formatKVPair("Previous version length", request.prevVersions.size()) << std::endl
 	          << formatKVPair("Version", request.version) << std::endl;
 }
 


### PR DESCRIPTION
…ommitRequest

A Tlog can belong to multiple Tlog groups, previously we submit
a TLogCommitRequest for each [TlogGroup, Tlog], thus a Tlog might
receive requests up to (#-of-Tlog groups it belongs to).

This commits allows TLogCommitRequest to contain multiple
Tlog group ids and prevVersions, together with the serialized
data to be persisted.

As a result, for each commit batch, each Tlog will receive at most
1 request.


# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
