### PR TITLE
Version vector prototype: Pull changes related to tlog-peek from the version indexer branch and address some bugs

### DIFF
--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -3004,7 +3004,7 @@ ACTOR Future<RangeResult> getExactRange(Database cx,
 			req.begin = firstGreaterOrEqual(range.begin);
 			req.end = firstGreaterOrEqual(range.end);
 			req.spanContext = span.context;
-			cx->getLatestCommitVersions(locations[shard].second, version, req.ssLatestCommitVersions);
+			cx->getLatestCommitVersions(locations[shard].second, req.version, req.ssLatestCommitVersions);
 
 			// keep shard's arena around in case of async tss comparison
 			req.arena.dependsOn(locations[shard].first.arena());
@@ -3325,7 +3325,7 @@ ACTOR Future<RangeResult> getRange(Database cx,
 			req.isFetchKeys = (info.taskID == TaskPriority::FetchKeys);
 			req.version = readVersion;
 
-                        cx->getLatestCommitVersions(beginServer.second, version, req.ssLatestCommitVersions);
+                        cx->getLatestCommitVersions(beginServer.second, req.version, req.ssLatestCommitVersions);
 
 			// In case of async tss comparison, also make req arena depend on begin, end, and/or shard's arena depending
 			// on which  is used
@@ -3762,7 +3762,7 @@ ACTOR Future<Void> getRangeStreamFragment(ParallelStream<RangeResult>::Fragment*
 			req.spanContext = spanContext;
 			req.limit = reverse ? -CLIENT_KNOBS->REPLY_BYTE_LIMIT : CLIENT_KNOBS->REPLY_BYTE_LIMIT;
 			req.limitBytes = std::numeric_limits<int>::max();
-			cx->getLatestCommitVersions(locations[shard].second, version, req.ssLatestCommitVersions);
+			cx->getLatestCommitVersions(locations[shard].second, req.version, req.ssLatestCommitVersions);
 
 			// keep shard's arena around in case of async tss comparison
 			req.arena.dependsOn(range.arena());

--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -103,6 +103,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( TLOG_POP_BATCH_SIZE,                                  1000 ); if ( randomize && BUGGIFY ) TLOG_POP_BATCH_SIZE = 10;
 	init( TLOG_POPPED_VER_LAG_THRESHOLD_FOR_TLOGPOP_TRACE,     250e6 );
 	init( ENABLE_DETAILED_TLOG_POP_TRACE,                       true );
+	init( BLOCKING_PEEK_TIMEOUT,                                 1.0 );
 
 	// disk snapshot max timeout, to be put in TLog, storage and coordinator nodes
 	init( MAX_FORKED_PROCESS_OUTPUT,                            1024 );

--- a/fdbclient/ServerKnobs.h
+++ b/fdbclient/ServerKnobs.h
@@ -106,6 +106,7 @@ public:
 	double PUSH_STATS_SLOW_AMOUNT;
 	double PUSH_STATS_SLOW_RATIO;
 	int TLOG_POP_BATCH_SIZE;
+	double BLOCKING_PEEK_TIMEOUT;
 
 	// Data distribution queue
 	double HEALTH_POLL_TIME;

--- a/fdbserver/masterserver.actor.cpp
+++ b/fdbserver/masterserver.actor.cpp
@@ -1229,11 +1229,11 @@ ACTOR Future<Void> provideVersions(Reference<MasterData> self) {
 
 void updateLiveCommittedVersion(Reference<MasterData> self, ReportRawCommittedVersionRequest req) {
 	self->minKnownCommittedVersion = std::max(self->minKnownCommittedVersion, req.minKnownCommittedVersion);
-	if (SERVER_KNOBS->ENABLE_VERSION_VECTOR && req.writtenTags.present()) {
-		// TraceEvent("Received ReportRawCommittedVersionRequest").detail("Version",req.version);
-		self->ssVersionVector.setVersion(req.writtenTags.get(), req.version);
-	}
 	if (req.version > self->liveCommittedVersion.get()) {
+		if (SERVER_KNOBS->ENABLE_VERSION_VECTOR && req.writtenTags.present()) {
+			// TraceEvent("Received ReportRawCommittedVersionRequest").detail("Version",req.version);
+			self->ssVersionVector.setVersion(req.writtenTags.get(), req.version);
+		}
 		self->databaseLocked = req.locked;
 		self->proxyMetadataVersion = req.metadataVersion;
 		// Note the set call switches context to any waiters on liveCommittedVersion before continuing.


### PR DESCRIPTION
Changes:

TLogServer.actor.cpp:

- Pull commits 5e37bc37a07ea54136865d1933758d9769ef8a94 and
95e85aaffba7e7ad8dad85774ac7370f23a1e769 from the version indexer branch.

- Do not enable the blocking-peek logic if ENABLE_VERSION_VECTOR flag is set to false.

masterserver.actor.cpp:

- Sequencer should update the version vector once for a given commit version (irrespective of the number of times that it receives and processes the ReportRawCommittedVersionRequest message for that commit version). Issue found by simulation tests.

storageserver.actor.cpp:

- Storage server should take both its latest commit version and the read version into account while processing a read request. This is to address "transaction too old" error that we saw while testing with mako (and also in YCSB tests).

NativeAPI.actor.cpp:

- Specify the correct "readVersion" when finding the latest commit versions of storage server replicas (which will serve the read request). Issue found by simulation tests.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
