### PR TITLE
Add the trace_partial_file_suffix option (release-6.2)

### DIFF
--- a/bindings/c/CMakeLists.txt
+++ b/bindings/c/CMakeLists.txt
@@ -82,6 +82,7 @@ if(NOT WIN32)
     add_executable(fdb_c_ryw_benchmark test/ryw_benchmark.c test/test.h)
     add_executable(fdb_c_txn_size_test test/txn_size_test.c test/test.h)
     add_executable(mako ${MAKO_SRCS})
+    add_executable(trace_partial_file_suffix_test test/unit/trace_partial_file_suffix_test.cpp)
     strip_debug_symbols(fdb_c_performance_test)
     strip_debug_symbols(fdb_c_ryw_benchmark)
     strip_debug_symbols(fdb_c_txn_size_test)
@@ -89,9 +90,12 @@ if(NOT WIN32)
   target_link_libraries(fdb_c_performance_test PRIVATE fdb_c)
   target_link_libraries(fdb_c_ryw_benchmark PRIVATE fdb_c)
   target_link_libraries(fdb_c_txn_size_test PRIVATE fdb_c)
+
   # do not set RPATH for mako
   set_property(TARGET mako PROPERTY SKIP_BUILD_RPATH TRUE)
   target_link_libraries(mako PRIVATE fdb_c)
+
+  target_link_libraries(trace_partial_file_suffix_test PRIVATE fdb_c Threads::Threads)
 endif()
 
 set(c_workloads_srcs

--- a/bindings/c/test/unit/trace_partial_file_suffix_test.cpp
+++ b/bindings/c/test/unit/trace_partial_file_suffix_test.cpp
@@ -1,0 +1,100 @@
+/*
+ * trace_partial_file_suffix_test.cpp
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <fstream>
+#include <iostream>
+#include <random>
+#include <string>
+#include <thread>
+
+#include "flow/Platform.h"
+
+#define FDB_API_VERSION 620
+#include "foundationdb/fdb_c.h"
+
+#undef NDEBUG
+#include <cassert>
+
+void fdb_check(fdb_error_t e) {
+	if (e) {
+		std::cerr << fdb_get_error(e) << std::endl;
+		std::abort();
+	}
+}
+
+void set_net_opt(FDBNetworkOption option, const std::string& value) {
+	fdb_check(fdb_network_set_option(option, reinterpret_cast<const uint8_t*>(value.c_str()), value.size()));
+}
+
+bool file_exists(const char* path) {
+	FILE* f = fopen(path, "r");
+	if (f) {
+		fclose(f);
+		return true;
+	}
+	return false;
+}
+
+int main(int argc, char** argv) {
+	fdb_check(fdb_select_api_version(620));
+
+	// We don't have the file_identifier network option in 6.2, so this test will be less robust.
+	std::string file_identifier = "trace.127.0.0.1";
+	std::string trace_partial_file_suffix = ".tmp";
+
+	set_net_opt(FDBNetworkOption::FDB_NET_OPTION_TRACE_ENABLE, "");
+	set_net_opt(FDBNetworkOption::FDB_NET_OPTION_TRACE_PARTIAL_FILE_SUFFIX, trace_partial_file_suffix);
+
+	fdb_check(fdb_setup_network());
+	std::thread network_thread{ &fdb_run_network };
+
+	// Apparently you need to open a database to initialize logging
+	FDBDatabase* out;
+	fdb_check(fdb_create_database(nullptr, &out));
+	fdb_database_destroy(out);
+
+	// Eventually there's a new trace file for this test ending in .tmp
+	std::string name;
+	for (;;) {
+		for (const auto& path : platform::listFiles(".")) {
+			if (path.find(file_identifier) != std::string::npos) {
+				assert(path.substr(path.size() - trace_partial_file_suffix.size()) == trace_partial_file_suffix);
+				name = path;
+				break;
+			}
+		}
+		if (!name.empty()) {
+			break;
+		}
+	}
+
+	fdb_check(fdb_stop_network());
+	network_thread.join();
+
+	// After shutting down, the suffix is removed for both our new file
+	if (!trace_partial_file_suffix.empty()) {
+		assert(!file_exists(name.c_str()));
+	}
+
+	auto new_name = name.substr(0, name.size() - trace_partial_file_suffix.size());
+	assert(file_exists(new_name.c_str()));
+	remove(new_name.c_str());
+	assert(!file_exists(new_name.c_str()));
+}

--- a/cmake/ConfigureCompiler.cmake
+++ b/cmake/ConfigureCompiler.cmake
@@ -24,7 +24,9 @@ endif()
 add_compile_options(-DCMAKE_BUILD)
 add_compile_definitions(BOOST_ERROR_CODE_HEADER_ONLY BOOST_SYSTEM_NO_DEPRECATED)
 
+set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
+
 if(ALLOC_INSTRUMENTATION)
   add_compile_options(-DALLOC_INSTRUMENTATION)
 endif()

--- a/documentation/sphinx/source/release-notes/release-notes-620.rst
+++ b/documentation/sphinx/source/release-notes/release-notes-620.rst
@@ -4,6 +4,10 @@
 Release Notes
 #############
 
+6.2.34
+======
+* Add the ``trace_partial_file_suffix`` network option. This option will give unfinished trace files a special suffix to indicate they're not complete yet. When the trace file is complete, it is renamed to remove the suffix. `(PR #5330) <https://github.com/apple/foundationdb/pull/5330>`_
+
 6.2.33
 ======
 * Fixed an issue where storage servers could shutdown with ``unknown_error``. `(PR #4437) <https://github.com/apple/foundationdb/pull/4437>`_

--- a/documentation/sphinx/source/release-notes/release-notes-620.rst
+++ b/documentation/sphinx/source/release-notes/release-notes-620.rst
@@ -6,7 +6,7 @@ Release Notes
 
 6.2.34
 ======
-* Add the ``trace_partial_file_suffix`` network option. This option will give unfinished trace files a special suffix to indicate they're not complete yet. When the trace file is complete, it is renamed to remove the suffix. `(PR #5330) <https://github.com/apple/foundationdb/pull/5330>`_
+* Add the ``trace_partial_file_suffix`` network option. This option will give unfinished trace files a special suffix to indicate they're not complete yet. When the trace file is complete, it is renamed to remove the suffix. `(PR #5349) <https://github.com/apple/foundationdb/pull/5349>`_
 
 6.2.33
 ======

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -901,7 +901,8 @@ Database Database::createDatabase(Reference<ClusterConnectionFile> connFile,
 			              networkOptions.traceMaxLogsSize,
 			              networkOptions.traceDirectory.get(),
 			              "trace",
-			              networkOptions.traceLogGroup);
+			              networkOptions.traceLogGroup,
+			              networkOptions.tracePartialFileSuffix);
 
 			TraceEvent("ClientStart")
 			    .detail("SourceVersion", getHGVersion())
@@ -997,6 +998,10 @@ void setNetworkOption(FDBNetworkOptions::Option option, Optional<StringRef> valu
 			fprintf(stderr, "Unrecognized trace format: `%s'\n", networkOptions.traceFormat.c_str());
 			throw invalid_option_value();
 		}
+		break;
+	case FDBNetworkOptions::TRACE_PARTIAL_FILE_SUFFIX:
+		validateOptionValue(value, true);
+		networkOptions.tracePartialFileSuffix = value.get().toString();
 		break;
 	case FDBNetworkOptions::KNOB: {
 		validateOptionValue(value, true);

--- a/fdbclient/NativeAPI.actor.h
+++ b/fdbclient/NativeAPI.actor.h
@@ -60,6 +60,7 @@ struct NetworkOptions {
 	uint64_t traceMaxLogsSize;
 	std::string traceLogGroup;
 	std::string traceFormat;
+	std::string tracePartialFileSuffix;
 	Optional<bool> logClientInfo;
 	Reference<ReferencedObject<Standalone<VectorRef<ClientVersionRef>>>> supportedVersions;
 	bool slowTaskProfilingEnabled;

--- a/fdbclient/vexillographer/fdb.options
+++ b/fdbclient/vexillographer/fdb.options
@@ -51,6 +51,9 @@ description is not currently required but encouraged.
     <Option name="trace_format" code="34"
             paramType="String" paramDescription="Format of trace files"
             description="Select the format of the log files. xml (the default) and json are supported."/>
+    <Option name="trace_partial_file_suffix" code="39"
+            paramType="String" paramDesciption="Append this suffix to partially written log files. When a log file is complete, it is renamed to remove the suffix. No separator is added between the file and the suffix. If you want to add a file extension, you should include the separator - e.g. '.tmp' instead of 'tmp' to add the 'tmp' extension."
+            description="" />
     <Option name="knob" code="40"
             paramType="String" paramDescription="knob_name=knob_value"
             description="Set internal tuning or debugging knobs"/>

--- a/flow/FileTraceLogWriter.cpp
+++ b/flow/FileTraceLogWriter.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "flow/FileTraceLogWriter.h"
+#include "flow/Platform.h"
 #include "flow/flow.h"
 #include "flow/ThreadHelper.actor.h"
 
@@ -51,10 +52,12 @@ FileTraceLogWriter::FileTraceLogWriter(std::string directory,
                                        std::string processName,
                                        std::string basename,
                                        std::string extension,
+                                       std::string tracePartialFileSuffix,
                                        uint64_t maxLogsSize,
                                        std::function<void()> onError)
-  : directory(directory), processName(processName), basename(basename), extension(extension), maxLogsSize(maxLogsSize),
-    traceFileFD(-1), index(0), onError(onError) {}
+  : directory(directory), processName(processName), basename(basename), extension(extension),
+    tracePartialFileSuffix(tracePartialFileSuffix), maxLogsSize(maxLogsSize), traceFileFD(-1), index(0),
+    onError(onError) {}
 
 void FileTraceLogWriter::addref() {
 	ReferenceCounted<FileTraceLogWriter>::addref();
@@ -104,7 +107,8 @@ void FileTraceLogWriter::open() {
 	// log10(index) < 10
 	UNSTOPPABLE_ASSERT(indexWidth < 10);
 
-	auto finalname = format("%s.%d.%d.%s", basename.c_str(), indexWidth, index, extension.c_str());
+	finalname =
+	    format("%s.%d.%d.%s%s", basename.c_str(), indexWidth, index, extension.c_str(), tracePartialFileSuffix.c_str());
 	while ((traceFileFD = __open(finalname.c_str(), TRACEFILE_FLAGS, TRACEFILE_MODE)) == -1) {
 		lastError(errno);
 		if (errno == EEXIST) {
@@ -112,7 +116,12 @@ void FileTraceLogWriter::open() {
 			indexWidth = unsigned(::floor(log10f(float(index))));
 
 			UNSTOPPABLE_ASSERT(indexWidth < 10);
-			finalname = format("%s.%d.%d.%s", basename.c_str(), indexWidth, index, extension.c_str());
+			finalname = format("%s.%d.%d.%s%s",
+			                   basename.c_str(),
+			                   indexWidth,
+			                   index,
+			                   extension.c_str(),
+			                   tracePartialFileSuffix.c_str());
 		} else {
 			fprintf(stderr,
 			        "ERROR: could not create trace log file `%s' (%d: %s)\n",
@@ -122,7 +131,7 @@ void FileTraceLogWriter::open() {
 
 			int errorNum = errno;
 			onMainThreadVoid(
-			    [finalname, errorNum] {
+			    [finalname = finalname, errorNum] {
 				    TraceEvent(SevWarnAlways, "TraceFileOpenError")
 				        .detail("Filename", finalname)
 				        .detail("ErrorCode", errorNum)
@@ -142,6 +151,11 @@ void FileTraceLogWriter::close() {
 		while (__close(traceFileFD))
 			threadSleep(0.1);
 	}
+	traceFileFD = -1;
+	if (!tracePartialFileSuffix.empty()) {
+		renameFile(finalname, finalname.substr(0, finalname.size() - tracePartialFileSuffix.size()));
+	}
+	finalname = "";
 }
 
 void FileTraceLogWriter::roll() {
@@ -157,6 +171,15 @@ void FileTraceLogWriter::cleanupTraceFiles() {
 	// Setting maxLogsSize=0 disables trace file cleanup based on dir size
 	if (!g_network->isSimulated() && maxLogsSize > 0) {
 		try {
+			// Rename/finalize any stray files ending in tracePartialFileSuffix for this process.
+			if (!tracePartialFileSuffix.empty()) {
+				for (const auto& f : platform::listFiles(directory, tracePartialFileSuffix)) {
+					if (f.substr(0, processName.length()) == processName) {
+						renameFile(f, f.substr(0, f.size() - tracePartialFileSuffix.size()));
+					}
+				}
+			}
+
 			std::vector<std::string> existingFiles = platform::listFiles(directory, extension);
 			std::vector<std::string> existingTraceFiles;
 

--- a/flow/FileTraceLogWriter.h
+++ b/flow/FileTraceLogWriter.h
@@ -33,6 +33,8 @@ private:
 	std::string processName;
 	std::string basename;
 	std::string extension;
+	std::string finalname;
+	std::string tracePartialFileSuffix;
 
 	uint64_t maxLogsSize;
 	int traceFileFD;
@@ -45,6 +47,7 @@ public:
 	                   std::string processName,
 	                   std::string basename,
 	                   std::string extension,
+	                   std::string tracePartialFileSuffix,
 	                   uint64_t maxLogsSize,
 	                   std::function<void()> onError);
 

--- a/flow/Trace.h
+++ b/flow/Trace.h
@@ -550,7 +550,8 @@ void openTraceFile(const NetworkAddress& na,
                    uint64_t maxLogsSize,
                    std::string directory = ".",
                    std::string baseOfBase = "trace",
-                   std::string logGroup = "default");
+                   std::string logGroup = "default",
+                   std::string tracePartialFileSuffix = "");
 void initTraceEventMetrics();
 void closeTraceFile();
 bool traceFileIsOpen();


### PR DESCRIPTION
Cherry pick https://github.com/apple/foundationdb/pull/5330 to release-6.2

This option configures a suffix for partial trace files that gets removed once the trace file is complete. This is useful for cases where your trace log ingestion infrastructure on the client expects files matching a certain pattern to be complete - you can use the suffix to "hide" incomplete trace files from being ingested prematurely.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
