### PR TITLE
Fix advanceversion ctest and re-enable it

### DIFF
--- a/bindings/python/tests/fdbcli_tests.py
+++ b/bindings/python/tests/fdbcli_tests.py
@@ -56,7 +56,7 @@ def advanceversion(logger):
     version1 = int(run_fdbcli_command('getversion'))
     logger.debug("Read version: {}".format(version1))
     # advance version to a much larger value compared to the current version
-    version2 = version1 * 10000
+    version2 = version1 * 100
     logger.debug("Advanced to version: " + str(version2))
     run_fdbcli_command('advanceversion', str(version2))
     # after running the advanceversion command,
@@ -71,6 +71,11 @@ def advanceversion(logger):
     version4 = int(run_fdbcli_command('getversion'))
     logger.debug("Read version: {}".format(version4))
     assert version4 >= version3
+    # wait for the recovery to finish
+    # if the database is unavailable, the test will timeout and fail
+    while not get_value_from_status_json(False, 'client', 'database_status', 'available'):
+        logger.debug("Database unavailable after advanceversion, wait for 1 second")
+        time.sleep(1)
 
 @enable_logging()
 def maintenance(logger):
@@ -437,7 +442,7 @@ if __name__ == '__main__':
     process_number = int(sys.argv[3])
     if process_number == 1:
         # TODO: disable for now, the change can cause the database unavailable
-        #advanceversion()
+        advanceversion()
         cache_range()
         consistencycheck()
         datadistribution()

--- a/bindings/python/tests/fdbcli_tests.py
+++ b/bindings/python/tests/fdbcli_tests.py
@@ -441,7 +441,6 @@ if __name__ == '__main__':
     # assertions will fail if fdbcli does not work as expected
     process_number = int(sys.argv[3])
     if process_number == 1:
-        # TODO: disable for now, the change can cause the database unavailable
         advanceversion()
         cache_range()
         consistencycheck()


### PR DESCRIPTION
It seems to be if we `advanceversion` to a much larger version (10000*current_version),
the recovery will take longer to finish.
The test used to be flaky as it continues to run while the database is sometimes unavailable after `advanceversion` is finished.
Add a check in the test to make sure the recovery is finished before running next test.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
