### PR TITLE
Introduced ThreadReturnPromiseStream

### DIFF
--- a/flow/IThreadPool.h
+++ b/flow/IThreadPool.h
@@ -115,12 +115,9 @@ template <class T>
 class ThreadReturnPromiseStream : NonCopyable {
 public:
 	ThreadReturnPromiseStream() {}
-	~ThreadReturnPromiseStream() {
-		if (!promiseStream.isValid())
-			sendError(broken_promise());
-	}
+	~ThreadReturnPromiseStream() {}
 
-	Future<T> getFuture() { // Call only on the originating thread!
+	FutureStream<T> getFuture() { // Call only on the originating thread!
 		return promiseStream.getFuture();
 	}
 

--- a/flow/IThreadPoolTest.actor.cpp
+++ b/flow/IThreadPoolTest.actor.cpp
@@ -11,10 +11,9 @@
 
 void forceLinkIThreadPoolTests() {}
 
-static ThreadReturnPromiseStream<std::string> notifications;
 
 struct ThreadNameReceiver final : IThreadPoolReceiver {
-	ThreadNameReceiver(const bool stream_signal = false) : stream_signal(stream_signal) {}
+	ThreadNameReceiver(){};
 
 	void init() override {}
 
@@ -32,20 +31,13 @@ struct ThreadNameReceiver final : IThreadPoolReceiver {
 		if (err != 0) {
 			std::cout << "Get name failed with error code: " << err << std::endl;
 			a.name.sendError(platform_error());
-			if (stream_signal) {
-				notifications.sendError(platform_error());
-			}
 			return;
 		}
 		std::string s = name;
-		if (stream_signal) {
-			notifications.send(s);
-		}
 		a.name.send(std::move(s));
 	}
-
-	bool stream_signal; 
 };
+
 
 TEST_CASE("/flow/IThreadPool/NamedThread") {
 	noUnseed = true;
@@ -72,11 +64,41 @@ TEST_CASE("/flow/IThreadPool/NamedThread") {
 	return Void();
 }
 
+struct ThreadSafePromiseStreamSender final : IThreadPoolReceiver {
+	ThreadSafePromiseStreamSender(
+		ThreadReturnPromiseStream<std::string>* notifications)
+		 : notifications(notifications) {}
+	void init() override {}
+
+	struct GetNameAction final : TypedAction<ThreadSafePromiseStreamSender, GetNameAction> {
+		double getTimeEstimate() const override { return 3.; }
+	};
+
+	void action(GetNameAction& a) {
+		pthread_t t = pthread_self();
+		const size_t arrayLen = 16;
+		char name[arrayLen];
+		int err = pthread_getname_np(t, name, arrayLen);
+		if (err != 0) {
+			std::cout << "Get name failed with error code: " << err << std::endl;
+			notifications->sendError(platform_error());
+			return;
+		}
+		notifications->send(std::move(name));
+	}
+
+private:
+	ThreadReturnPromiseStream<std::string>* notifications;
+};
+
 TEST_CASE("/flow/IThreadPool/ThreadReturnPromiseStream") {
 	noUnseed = true;
 
+	state std::unique_ptr<ThreadReturnPromiseStream<std::string>> 
+		notifications(new ThreadReturnPromiseStream<std::string>());
+
 	state Reference<IThreadPool> pool = createGenericThreadPool();
-	pool->addThread(new ThreadNameReceiver(/*stream_signal=*/true), "thread-foo");
+	pool->addThread(new ThreadSafePromiseStreamSender(notifications.get()), "thread-foo");
 
 	// Warning: this action is a little racy with the call to `pthread_setname_np`. In practice,
 	// ~nothing should depend on the thread name being set instantaneously. If this test ever
@@ -84,11 +106,11 @@ TEST_CASE("/flow/IThreadPool/ThreadReturnPromiseStream") {
 	// the actions.
 	state int num = 3;
 	for (int i = 0; i < num; ++i) {
-		auto* a = new ThreadNameReceiver::GetNameAction();
+		auto* a = new ThreadSafePromiseStreamSender::GetNameAction();
 		pool->post(a);
 	}
 
-	state FutureStream<std::string> futs = notifications.getFuture();
+	state FutureStream<std::string> futs = notifications->getFuture();
 
 	state int n = 0;
 	while (n < num) {

--- a/flow/IThreadPoolTest.actor.cpp
+++ b/flow/IThreadPoolTest.actor.cpp
@@ -79,7 +79,7 @@ struct ThreadSafePromiseStreamSender final : IThreadPoolReceiver {
 			notifications->sendError(platform_error());
 			return;
 		}
-		notifications->send(std::move(name));
+		notifications->send(name);
 	}
 
 	struct FaultyAction final : TypedAction<ThreadSafePromiseStreamSender, FaultyAction> {

--- a/flow/IThreadPoolTest.actor.cpp
+++ b/flow/IThreadPoolTest.actor.cpp
@@ -35,7 +35,6 @@ struct ThreadNameReceiver final : IThreadPoolReceiver {
 	}
 };
 
-
 TEST_CASE("/flow/IThreadPool/NamedThread") {
 	noUnseed = true;
 
@@ -62,9 +61,8 @@ TEST_CASE("/flow/IThreadPool/NamedThread") {
 }
 
 struct ThreadSafePromiseStreamSender final : IThreadPoolReceiver {
-	ThreadSafePromiseStreamSender(
-		ThreadReturnPromiseStream<std::string>* notifications)
-		 : notifications(notifications) {}
+	ThreadSafePromiseStreamSender(ThreadReturnPromiseStream<std::string>* notifications)
+	  : notifications(notifications) {}
 	void init() override {}
 
 	struct GetNameAction final : TypedAction<ThreadSafePromiseStreamSender, GetNameAction> {
@@ -88,9 +86,7 @@ struct ThreadSafePromiseStreamSender final : IThreadPoolReceiver {
 		double getTimeEstimate() const override { return 3.; }
 	};
 
-	void action(FaultyAction& a) {
-		notifications->sendError(platform_error().asInjectedFault());
-	}
+	void action(FaultyAction& a) { notifications->sendError(platform_error().asInjectedFault()); }
 
 private:
 	ThreadReturnPromiseStream<std::string>* notifications;
@@ -99,8 +95,8 @@ private:
 TEST_CASE("/flow/IThreadPool/ThreadReturnPromiseStream") {
 	noUnseed = true;
 
-	state std::unique_ptr<ThreadReturnPromiseStream<std::string>> 
-		notifications(new ThreadReturnPromiseStream<std::string>());
+	state std::unique_ptr<ThreadReturnPromiseStream<std::string>> notifications(
+	    new ThreadReturnPromiseStream<std::string>());
 
 	state Reference<IThreadPool> pool = createGenericThreadPool();
 	pool->addThread(new ThreadSafePromiseStreamSender(notifications.get()), "thread-foo");
@@ -135,7 +131,7 @@ TEST_CASE("/flow/IThreadPool/ThreadReturnPromiseStream") {
 	try {
 		std::string name = waitNext(futs);
 		ASSERT(false);
-	} catch(Error& e) {
+	} catch (Error& e) {
 		ASSERT(e.isInjectedFault());
 	}
 

--- a/flow/genericactors.actor.h
+++ b/flow/genericactors.actor.h
@@ -1254,10 +1254,22 @@ void tagAndForward(Promise<T>* pOutputPromise, T value, Future<Void> signal) {
 }
 
 ACTOR template <class T>
+void tagAndForward(PromiseStream<T>* pOutput, T value, Future<Void> signal) {
+	wait(signal);
+	pOutput->send(value);
+}
+
+ACTOR template <class T>
 void tagAndForwardError(Promise<T>* pOutputPromise, Error value, Future<Void> signal) {
 	state Promise<T> out(std::move(*pOutputPromise));
 	wait(signal);
 	out.sendError(value);
+}
+
+ACTOR template <class T>
+void tagAndForwardError(PromiseStream<T>* pOutput, Error value, Future<Void> signal) {
+	wait(signal);
+	pOutput.sendError(value);
 }
 
 ACTOR template <class T>

--- a/flow/genericactors.actor.h
+++ b/flow/genericactors.actor.h
@@ -1269,7 +1269,7 @@ void tagAndForwardError(Promise<T>* pOutputPromise, Error value, Future<Void> si
 ACTOR template <class T>
 void tagAndForwardError(PromiseStream<T>* pOutput, Error value, Future<Void> signal) {
 	wait(signal);
-	pOutput.sendError(value);
+	pOutput->sendError(value);
 }
 
 ACTOR template <class T>

--- a/tests/IThreadPool.txt
+++ b/tests/IThreadPool.txt
@@ -1,0 +1,7 @@
+testTitle=UnitTests
+startDelay=0
+useDB=false
+
+    testName=UnitTests
+    maxTestCases=0
+    testsMatching=/flow/IThreadPool/

--- a/tests/WorkerTests.txt
+++ b/tests/WorkerTests.txt
@@ -4,4 +4,4 @@ useDB=false
 
     testName=UnitTests
     maxTestCases=0
-    testsMatching=/flow/IThreadPool/
+    testsMatching=/fdbserver/worker/

--- a/tests/WorkerTests.txt
+++ b/tests/WorkerTests.txt
@@ -4,4 +4,4 @@ useDB=false
 
     testName=UnitTests
     maxTestCases=0
-    testsMatching=/fdbserver/worker/
+    testsMatching=/flow/IThreadPool/


### PR DESCRIPTION
It is the stream version of [ThreadReturnPromise](https://github.com/apple/foundationdb/blob/857d5704dace1ed4e1c43908710da9900132bb03/flow/IThreadPool.h#L83), enabling us to send signals back safely to the main thread from a [TypedAction](https://github.com/apple/foundationdb/blob/857d5704dace1ed4e1c43908710da9900132bb03/flow/IThreadPool.h#L72)(possibly on another thread).

Its first use case is passing notifications back to SS from RocksDB, on [completion of memlayer flushes](https://github.com/facebook/rocksdb/blob/052c24a6680c7de4aabf42c9efe24b345dcb18fd/include/rocksdb/listener.h#L377).

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
