### PR TITLE
Version vector / remove network hop by getting previous commit versions in GetCommitVe…

### DIFF
--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -36,7 +36,8 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( MAX_WRITE_TRANSACTION_LIFE_VERSIONS,     5 * VERSIONS_PER_SECOND ); if (randomize && BUGGIFY) MAX_WRITE_TRANSACTION_LIFE_VERSIONS=std::max<int>(1, 1 * VERSIONS_PER_SECOND);
 	init( MAX_COMMIT_BATCH_INTERVAL,                             2.0 ); if( randomize && BUGGIFY ) MAX_COMMIT_BATCH_INTERVAL = 0.5; // Each commit proxy generates a CommitTransactionBatchRequest at least this often, so that versions always advance smoothly
 	MAX_COMMIT_BATCH_INTERVAL = std::min(MAX_COMMIT_BATCH_INTERVAL, MAX_READ_TRANSACTION_LIFE_VERSIONS/double(2*VERSIONS_PER_SECOND)); // Ensure that the proxy commits 2 times every MAX_READ_TRANSACTION_LIFE_VERSIONS, otherwise the master will not give out versions fast enough
-	init( ENABLE_VERSION_VECTOR,                               false );
+	init( ENABLE_VERSION_VECTOR,                               true );
+ 	init( ENABLE_VERSION_VECTOR_TLOG_UNICAST,                  true );
 
 	// TLogs
 	init( TLOG_TIMEOUT,                                          0.4 ); //cannot buggify because of availability

--- a/fdbclient/ServerKnobs.h
+++ b/fdbclient/ServerKnobs.h
@@ -38,6 +38,7 @@ public:
 	int64_t MAX_READ_TRANSACTION_LIFE_VERSIONS;
 	int64_t MAX_WRITE_TRANSACTION_LIFE_VERSIONS;
 	bool ENABLE_VERSION_VECTOR;
+	bool ENABLE_VERSION_VECTOR_TLOG_UNICAST;
 	double MAX_COMMIT_BATCH_INTERVAL; // Each commit proxy generates a CommitTransactionBatchRequest at least this
 	                                  // often, so that versions always advance smoothly
 

--- a/fdbserver/ApplyMetadataMutation.h
+++ b/fdbserver/ApplyMetadataMutation.h
@@ -63,5 +63,6 @@ void applyMetadataMutations(SpanID const& spanContext,
                             Arena& arena,
                             const VectorRef<MutationRef>& mutations,
                             IKeyValueStore* txnStateStore);
+bool containsMetadataMutation(const VectorRef<MutationRef>& mutations);
 
 #endif

--- a/fdbserver/LogSystem.h
+++ b/fdbserver/LogSystem.h
@@ -765,10 +765,21 @@ struct LogPushData : NonCopyable {
 	// copy written_tags, after filtering, into given set
 	void saveTags(std::set<Tag>& filteredTags) const {
 		for (const auto& tag : written_tags) {
-			if (!tag.isNonPrimaryTLogType()) {
-				filteredTags.insert(tag);
-			}
+			filteredTags.insert(tag);
 		}
+	}
+
+	void getLocations(const std::set<Tag>& tags, std::set<uint16_t>& writtenTLogs) {
+		std::vector<Tag> vtags(tags.begin(), tags.end());
+		std::vector<int> msg_locations;
+		logSystem->getPushLocations(vtags, msg_locations, false /*allLocations*/);
+		writtenTLogs.insert(msg_locations.begin(), msg_locations.end());
+	}
+
+	void getLocations(const std::vector<Tag>& vtags, std::set<uint16_t>& writtenTLogs) {
+		std::vector<int> msg_locations;
+		logSystem->getPushLocations(vtags, msg_locations, false /*allLocations*/);
+		writtenTLogs.insert(msg_locations.begin(), msg_locations.end());
 	}
 
 	// store tlogs as represented by index

--- a/fdbserver/MasterInterface.h
+++ b/fdbserver/MasterInterface.h
@@ -156,6 +156,7 @@ struct GetCommitVersionReply {
 	Version version;
 	Version prevVersion;
 	uint64_t requestNum;
+	std::unordered_map<uint16_t, Version> tpcvMap;
 
 	GetCommitVersionReply() : resolverChangesVersion(0), version(0), prevVersion(0), requestNum(0) {}
 	explicit GetCommitVersionReply(Version version, Version prevVersion, uint64_t requestNum)
@@ -163,7 +164,7 @@ struct GetCommitVersionReply {
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, resolverChanges, resolverChangesVersion, version, prevVersion, requestNum);
+		serializer(ar, resolverChanges, resolverChangesVersion, version, prevVersion, requestNum, tpcvMap);
 	}
 };
 
@@ -173,19 +174,21 @@ struct GetCommitVersionRequest {
 	uint64_t requestNum;
 	uint64_t mostRecentProcessedRequestNum;
 	UID requestingProxy;
+	std::set<uint16_t> writtenTLogs;
 	ReplyPromise<GetCommitVersionReply> reply;
 
 	GetCommitVersionRequest() {}
 	GetCommitVersionRequest(SpanID spanContext,
 	                        uint64_t requestNum,
 	                        uint64_t mostRecentProcessedRequestNum,
-	                        UID requestingProxy)
+	                        UID requestingProxy,
+	                        std::set<uint16_t>& writtenTLogs)
 	  : spanContext(spanContext), requestNum(requestNum), mostRecentProcessedRequestNum(mostRecentProcessedRequestNum),
-	    requestingProxy(requestingProxy) {}
+	    requestingProxy(requestingProxy), writtenTLogs(writtenTLogs) {}
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, requestNum, mostRecentProcessedRequestNum, requestingProxy, reply, spanContext);
+		serializer(ar, requestNum, mostRecentProcessedRequestNum, requestingProxy, writtenTLogs, reply, spanContext);
 	}
 };
 

--- a/fdbserver/TLogServer.actor.cpp
+++ b/fdbserver/TLogServer.actor.cpp
@@ -1912,10 +1912,10 @@ Future<Void> tLogPeekMessages(PromiseType replyPromise,
 	reply.end = endVersion;
 	reply.onlySpilled = onlySpilled;
 
-	//TraceEvent("TlogPeek", self->dbgid).detail("LogId", logData->logId).detail("Tag", reqTag.toString()).
-	//	detail("BeginVer", reqBegin).detail("EndVer", reply.end).
-	//	detail("MsgBytes", reply.messages.expectedSize()).
-	//	detail("ForAddress", replyPromise.getEndpoint().getPrimaryAddress());
+	// TraceEvent("TlogPeek", self->dbgid).detail("LogId", logData->logId).detail("Tag", req.tag.toString()).
+	// 	detail("BeginVer", req.begin).detail("EndVer", reply.end).
+	// 	detail("MsgBytes", reply.messages.expectedSize()).
+	// 	detail("ForAddress", req.reply.getEndpoint().getPrimaryAddress());
 
 	if (reqSequence.present()) {
 		auto& trackerData = logData->peekTracker[peekId];
@@ -2135,9 +2135,7 @@ ACTOR Future<Void> tLogCommit(TLogData* self,
 	}
 
 	logData->minKnownCommittedVersion = std::max(logData->minKnownCommittedVersion, req.minKnownCommittedVersion);
-
 	wait(logData->version.whenAtLeast(req.prevVersion));
-
 	// Calling check_yield instead of yield to avoid a destruction ordering problem in simulation
 	if (g_network->check_yield(g_network->getCurrentTask())) {
 		wait(delay(0, g_network->getCurrentTask()));
@@ -2168,7 +2166,7 @@ ACTOR Future<Void> tLogCommit(TLogData* self,
 		if (req.debugID.present())
 			g_traceBatch.addEvent("CommitDebug", tlogDebugID.get().first(), "TLog.tLogCommit.Before");
 
-		//TraceEvent("TLogCommit", logData->logId).detail("Version", req.version);
+		// TraceEvent("TLogCommit", logData->logId).detail("Version", req.version);
 		commitMessages(self, logData, req.version, req.arena, req.messages);
 
 		logData->knownCommittedVersion = std::max(logData->knownCommittedVersion, req.knownCommittedVersion);

--- a/fdbserver/TagPartitionedLogSystem.actor.cpp
+++ b/fdbserver/TagPartitionedLogSystem.actor.cpp
@@ -532,7 +532,7 @@ Future<Version> TagPartitionedLogSystem::push(Version prevVersion,
 			}
 			std::vector<Future<Void>> tLogCommitResults;
 			for (int loc = 0; loc < it->logServers.size(); loc++) {
-				if (SERVER_KNOBS->ENABLE_VERSION_VECTOR) {
+				if (SERVER_KNOBS->ENABLE_VERSION_VECTOR_TLOG_UNICAST) {
 					if (tpcvMap.get().find(location) != tpcvMap.get().end()) {
 						prevVersion = tpcvMap.get()[location];
 					} else {

--- a/fdbserver/masterserver.actor.cpp
+++ b/fdbserver/masterserver.actor.cpp
@@ -1165,6 +1165,9 @@ ACTOR Future<Void> getVersion(Reference<MasterData> self, GetCommitVersionReques
 			self->lastVersionTime = now();
 			self->version = self->recoveryTransactionVersion;
 			rep.prevVersion = self->lastEpochEnd;
+
+			std::fill(self->tpcvVector.begin(), self->tpcvVector.end(), self->lastEpochEnd);
+
 		} else {
 			double t1 = now();
 			if (BUGGIFY) {
@@ -1199,6 +1202,14 @@ ACTOR Future<Void> getVersion(Reference<MasterData> self, GetCommitVersionReques
 		                               proxyItr->second.replies.upper_bound(req.mostRecentProcessedRequestNum));
 		proxyItr->second.replies[req.requestNum] = rep;
 		ASSERT(rep.prevVersion >= 0);
+
+		if (SERVER_KNOBS->ENABLE_VERSION_VECTOR_TLOG_UNICAST) {
+			for (uint16_t tLog : req.writtenTLogs) {
+				rep.tpcvMap[tLog] = self->tpcvVector[tLog];
+				self->tpcvVector[tLog] = rep.version;
+			}
+		}
+
 		req.reply.send(rep);
 
 		ASSERT(proxyItr->second.latestRequestNum.get() == req.requestNum - 1);
@@ -1287,7 +1298,7 @@ ACTOR Future<Void> serveLiveCommittedVersion(Reference<MasterData> self) {
 			}
 			when(ReportRawCommittedVersionRequest req =
 			         waitNext(self->myInterface.reportLiveCommittedVersion.getFuture())) {
-				if (SERVER_KNOBS->ENABLE_VERSION_VECTOR && req.prevVersion.present() &&
+				if (SERVER_KNOBS->ENABLE_VERSION_VECTOR_TLOG_UNICAST && req.prevVersion.present() &&
 				    (self->liveCommittedVersion.get() != invalidVersion) &&
 				    (self->liveCommittedVersion.get() < req.prevVersion.get())) {
 					self->addActor.send(waitForPrev(self, req));


### PR DESCRIPTION
Previously the previous commit version vector was obtained at the cost of a separate network hop. This PR removes that extra hop and piggybacks getting the "per tLog previous commit versions" when we get the commit version. 

To do that, the transactions are parsed to obtain which tLogs will be used (the 'locations') prior to resolve stage. 

Added knob ENABLE_VERSION_VECTOR_TLOG_UNICAST = false. The vv branch should be capable of prototyping / measuring the effects of removing multicast between the commit proxy and tLogs. Experiments help to remove doubt and develop a better understanding of how to scale. 

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)