### PR TITLE
Added Label field for keys and ranges in MutationTracking.

### DIFF
--- a/fdbserver/RestoreApplier.actor.h
+++ b/fdbserver/RestoreApplier.actor.h
@@ -62,8 +62,8 @@ struct StagingKey {
 	void add(const MutationRef& m, LogMessageVersion newVersion) {
 		ASSERT(m.type != MutationRef::SetVersionstampedKey && m.type != MutationRef::SetVersionstampedValue);
 		DEBUG_MUTATION("StagingKeyAdd", newVersion.version, m)
-		    .detail("Version", version.toString())
-		    .detail("NewVersion", newVersion.toString());
+		    .detail("SubVersion", version.toString())
+		    .detail("NewSubVersion", newVersion.toString());
 		if (version == newVersion) {
 			// This could happen because the same mutation can be present in
 			// overlapping mutation logs, because new TLogs can copy mutations
@@ -83,8 +83,8 @@ struct StagingKey {
 			}
 			if (version < newVersion) {
 				DEBUG_MUTATION("StagingKeyAdd", newVersion.version, m)
-				    .detail("Version", version.toString())
-				    .detail("NewVersion", newVersion.toString())
+				    .detail("SubVersion", version.toString())
+				    .detail("NewSubVersion", newVersion.toString())
 				    .detail("MType", getTypeString(type))
 				    .detail("Key", key)
 				    .detail("Val", val)

--- a/fdbserver/RestoreLoader.actor.cpp
+++ b/fdbserver/RestoreLoader.actor.cpp
@@ -910,7 +910,7 @@ ACTOR Future<Void> sendMutationsToApplier(
 
 				DEBUG_MUTATION("RestoreLoaderSendMutation", commitVersion.version, kvm)
 				    .detail("Applier", applierID)
-				    .detail("Version", commitVersion.toString());
+				    .detail("SubVersion", commitVersion.toString());
 				// kvm data is saved in pkvOps in batchData, so shallow copy is ok here.
 				applierVersionedMutationsBuffer[applierID].push_back(applierVersionedMutationsBuffer[applierID].arena(),
 				                                                     VersionedMutation(kvm, commitVersion));

--- a/fdbserver/RestoreLoader.actor.cpp
+++ b/fdbserver/RestoreLoader.actor.cpp
@@ -910,8 +910,7 @@ ACTOR Future<Void> sendMutationsToApplier(
 
 				DEBUG_MUTATION("RestoreLoaderSendMutation", commitVersion.version, kvm)
 				    .detail("Applier", applierID)
-				    .detail("Version", commitVersion.toString())
-				    .detail("Mutation", kvm);
+				    .detail("Version", commitVersion.toString());
 				// kvm data is saved in pkvOps in batchData, so shallow copy is ok here.
 				applierVersionedMutationsBuffer[applierID].push_back(applierVersionedMutationsBuffer[applierID].arena(),
 				                                                     VersionedMutation(kvm, commitVersion));


### PR DESCRIPTION
MutationTracking events will now contain a Label field which references the first tracked key or range that matched the mutation.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
