### PR TITLE
Add trace event for role recruitment by CC

### DIFF
--- a/fdbserver/ClusterController.actor.cpp
+++ b/fdbserver/ClusterController.actor.cpp
@@ -3592,6 +3592,8 @@ ACTOR Future<Void> clusterRecruitFromConfiguration(ClusterControllerData* self, 
 				return Void();
 			} else if (e.code() == error_code_operation_failed || e.code() == error_code_no_more_servers) {
 				// recruitment not good enough, try again
+				TraceEvent("RecruitFromConfigurationRetry", self->id).error(e)
+					.detail("GoodRecruitmentTimeReady", self->goodRecruitmentTime.isReady());
 			} else {
 				TraceEvent(SevError, "RecruitFromConfigurationError", self->id).error(e);
 				throw; // goodbye, cluster controller
@@ -3617,6 +3619,8 @@ ACTOR Future<Void> clusterRecruitRemoteFromConfiguration(ClusterControllerData* 
 				return Void();
 			} else if (e.code() == error_code_operation_failed || e.code() == error_code_no_more_servers) {
 				// recruitment not good enough, try again
+				TraceEvent("RecruitRemoteFromConfigurationRetry", self->id).error(e)
+					.detail("GoodRecruitmentTimeReady", self->goodRemoteRecruitmentTime.isReady());
 			} else {
 				TraceEvent(SevError, "RecruitRemoteFromConfigurationError", self->id).error(e);
 				throw; // goodbye, cluster controller


### PR DESCRIPTION
In some long recovery, the recruiting_transaction_servers step takes abnormally long time. 
We want to understand why the recruiting_transaction_servers step takes long time to finish.
A starting point of root cause analysis is to see whether (1) CC repeatedly retry the recruitment; or (2) the recruitment is delay to backend; or (3) some CC error occurs and CC dies.
For case (2) and (3), we already have RecruitFromConfigurationNotAvailable event and RecruitFromConfigurationError event to decide the case. 
For case (1), we add RecruitFromConfigurationRetry event by this PR.
The appearance of this new event should be rare since (1) the event happens when no enough available servers in recruitment and (2) the retry (not in backend) lasts at most 1 second (set by WAIT_FOR_GOOD_RECRUITMENT_DELAY).

Passed Joshua correctness-7.1.0 test: 20210824-013255-zhewang-1f4960baeba2f8f6

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
