### PR TITLE
Capture deep copy of `machine_info` in `printSnapshotTeamsInfo`

### DIFF
--- a/fdbrpc/fdbrpc.h
+++ b/fdbrpc/fdbrpc.h
@@ -783,6 +783,7 @@ public:
 	}
 
 	bool operator==(const RequestStream<T>& rhs) const { return queue == rhs.queue; }
+	bool operator!=(const RequestStream<T>& rhs) const { return !(*this == rhs); }
 	bool isEmpty() const { return !queue->isReady(); }
 	uint32_t size() const { return queue->size(); }
 

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -604,7 +604,6 @@ Future<Void> teamTracker(struct DDTeamCollection* const& self,
 
 struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 	// clang-format off
-	enum { REQUESTING_WORKER = 0, GETTING_WORKER = 1, GETTING_STORAGE = 2 };
 	enum class Status { NONE = 0, WIGGLING = 1, EXCLUDED = 2, FAILED = 3};
 
 	// addActor: add to actorCollection so that when an actor has error, the ActorCollection can catch the error.

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -396,7 +396,7 @@ struct ServerStatus {
 	// If a process has reappeared without the storage server that was on it (isFailed == true), we don't need to
 	// exclude it We also don't need to exclude processes who are in the wrong configuration (since those servers will
 	// be removed)
-	bool excludeOnRecruit() { return !isFailed && !isWrongConfiguration; }
+	bool excludeOnRecruit() const { return !isFailed && !isWrongConfiguration; }
 };
 typedef AsyncMap<UID, ServerStatus> ServerStatusMap;
 

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -40,6 +40,7 @@
 #include "fdbserver/WaitFailure.h"
 #include "flow/ActorCollection.h"
 #include "flow/Arena.h"
+#include "flow/BooleanParam.h"
 #include "flow/Trace.h"
 #include "flow/UnitTest.h"
 #include "flow/actorcompiler.h" // This must be the last #include.
@@ -48,6 +49,8 @@
 class TCTeamInfo;
 struct TCMachineInfo;
 class TCMachineTeamInfo;
+
+FDB_BOOLEAN_PARAM(IsPrimary);
 
 ACTOR Future<Void> checkAndRemoveInvalidLocalityAddr(DDTeamCollection* self);
 ACTOR Future<Void> removeWrongStoreType(DDTeamCollection* self);
@@ -732,7 +735,7 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 	                 Optional<std::vector<Optional<Key>>> otherTrackedDCs,
 	                 Future<Void> readyToStart,
 	                 Reference<AsyncVar<bool>> zeroHealthyTeams,
-	                 bool primary,
+	                 IsPrimary primary,
 	                 Reference<AsyncVar<bool>> processingUnhealthy,
 	                 PromiseStream<GetMetricsRequest> getShardMetrics,
 	                 Promise<UID> removeFailedServer,
@@ -6031,7 +6034,7 @@ ACTOR Future<Void> dataDistribution(Reference<DataDistributorData> self,
 			    configuration.usableRegions > 1 ? remoteDcIds : std::vector<Optional<Key>>(),
 			    readyToStart.getFuture(),
 			    zeroHealthyTeams[0],
-			    true,
+			    IsPrimary::True,
 			    processingUnhealthy,
 			    getShardMetrics,
 			    removeFailedServer,
@@ -6049,7 +6052,7 @@ ACTOR Future<Void> dataDistribution(Reference<DataDistributorData> self,
 				                                    Optional<std::vector<Optional<Key>>>(),
 				                                    readyToStart.getFuture() && remoteRecovered(self->dbInfo),
 				                                    zeroHealthyTeams[1],
-				                                    false,
+				                                    IsPrimary::False,
 				                                    processingUnhealthy,
 				                                    getShardMetrics,
 				                                    removeFailedServer,
@@ -6529,7 +6532,7 @@ std::unique_ptr<DDTeamCollection> testTeamCollection(int teamSize,
 	                                                           {},
 	                                                           Future<Void>(Void()),
 	                                                           makeReference<AsyncVar<bool>>(true),
-	                                                           true,
+	                                                           IsPrimary::True,
 	                                                           makeReference<AsyncVar<bool>>(false),
 	                                                           PromiseStream<GetMetricsRequest>(),
 	                                                           Promise<UID>(),
@@ -6572,7 +6575,7 @@ std::unique_ptr<DDTeamCollection> testMachineTeamCollection(int teamSize,
 	                                                           {},
 	                                                           Future<Void>(Void()),
 	                                                           makeReference<AsyncVar<bool>>(true),
-	                                                           true,
+	                                                           IsPrimary::True,
 	                                                           makeReference<AsyncVar<bool>>(false),
 	                                                           PromiseStream<GetMetricsRequest>(),
 	                                                           Promise<UID>(),

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -100,7 +100,7 @@ struct TCServerInfo : public ReferenceCounted<TCServerInfo> {
 		}
 	}
 
-	bool isCorrectStoreType(KeyValueStoreType configStoreType) {
+	bool isCorrectStoreType(KeyValueStoreType configStoreType) const {
 		// A new storage server's store type may not be set immediately.
 		// If a storage server does not reply its storeType, it will be tracked by failure monitor and removed.
 		return (storeType == configStoreType || storeType == KeyValueStoreType::END);

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -1318,8 +1318,10 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 		}
 
 		int maxMatchingServers = 0;
-		auto const& serverID = team[0];
-		for (auto const& usedTeam : machine_info.at(serverID)->machineTeams) {
+		auto it = machine_info.find(team[0]);
+		ASSERT(it != machine_info.end());
+		auto const& machineTeams = it->second->machineTeams;
+		for (auto const& usedTeam : machineTeams) {
 			auto used = usedTeam->machineIDs;
 			int teamIdx = 0;
 			int usedIdx = 0;

--- a/flow/genericactors.actor.h
+++ b/flow/genericactors.actor.h
@@ -1973,6 +1973,8 @@ public:
 	virtual Output const& get() const = 0;
 	virtual Future<Void> onChange() const = 0;
 	template <class Input, class F>
+	static Reference<IAsyncListener> create(Reference<AsyncVar<Input> const> const& input, F const& f);
+	template <class Input, class F>
 	static Reference<IAsyncListener> create(Reference<AsyncVar<Input>> const& input, F const& f);
 	static Reference<IAsyncListener> create(Reference<AsyncVar<Output>> const& output);
 };
@@ -2002,8 +2004,15 @@ public:
 
 template <class Output>
 template <class Input, class F>
-Reference<IAsyncListener<Output>> IAsyncListener<Output>::create(Reference<AsyncVar<Input>> const& input, F const& f) {
+Reference<IAsyncListener<Output>> IAsyncListener<Output>::create(Reference<AsyncVar<Input> const> const& input,
+                                                                 F const& f) {
 	return makeReference<IAsyncListenerImpl::AsyncListener<Input, Output, F>>(input, f);
+}
+
+template <class Output>
+template <class Input, class F>
+Reference<IAsyncListener<Output>> IAsyncListener<Output>::create(Reference<AsyncVar<Input>> const& input, F const& f) {
+	return create(Reference<AsyncVar<Input> const>(input), f);
 }
 
 template <class Output>

--- a/flow/genericactors.actor.h
+++ b/flow/genericactors.actor.h
@@ -547,14 +547,14 @@ public:
 		}
 	}
 	void clear(K const& k) { set(k, V()); }
-	V const& get(K const& k) {
+	V const& get(K const& k) const {
 		auto it = items.find(k);
 		if (it != items.end())
 			return it->second.value;
 		else
 			return defaultValue;
 	}
-	int count(K const& k) {
+	int count(K const& k) const {
 		auto it = items.find(k);
 		if (it != items.end())
 			return 1;
@@ -566,7 +566,7 @@ public:
 			return destroyOnCancel(this, k, item.change.getFuture());
 		return item.change.getFuture();
 	}
-	std::vector<K> getKeys() {
+	std::vector<K> getKeys() const {
 		std::vector<K> keys;
 		keys.reserve(items.size());
 		for (auto i = items.begin(); i != items.end(); ++i)


### PR DESCRIPTION
When `printSnapshotTeamsInfo` yields, the referenced objects in `machine_info` can change causing the snapshot to become invalid. This resulted in simulation failures on the 7.0 branch. This PR also includes several changes cherry-picked from https://github.com/apple/foundationdb/pull/4289 to improve the const-correctness of `DataDistribution.actor.cpp`.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
