### PR TITLE
Decrease default value of `NOTIFICATION_FULL_CLEAR_TIME`

### DIFF
--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -348,7 +348,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	bool longLeaderElection = randomize && BUGGIFY;
 	init( MAX_NOTIFICATIONS,                                  100000 );
 	init( MIN_NOTIFICATIONS,                                     100 );
-	init( NOTIFICATION_FULL_CLEAR_TIME,                      1000.0 );
+	init( NOTIFICATION_FULL_CLEAR_TIME,                       1000.0 );
 	init( CANDIDATE_MIN_DELAY,                                  0.05 );
 	init( CANDIDATE_MAX_DELAY,                                   1.0 );
 	init( CANDIDATE_GROWTH_RATE,                                 1.2 );

--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -348,7 +348,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	bool longLeaderElection = randomize && BUGGIFY;
 	init( MAX_NOTIFICATIONS,                                  100000 );
 	init( MIN_NOTIFICATIONS,                                     100 );
-	init( NOTIFICATION_FULL_CLEAR_TIME,                      10000.0 );
+	init( NOTIFICATION_FULL_CLEAR_TIME,                      1000.0 );
 	init( CANDIDATE_MIN_DELAY,                                  0.05 );
 	init( CANDIDATE_MAX_DELAY,                                   1.0 );
 	init( CANDIDATE_GROWTH_RATE,                                 1.2 );

--- a/fdbserver/Coordination.actor.cpp
+++ b/fdbserver/Coordination.actor.cpp
@@ -440,6 +440,11 @@ ACTOR Future<Void> leaderRegister(LeaderElectionRegInterface interf, Key key) {
 			}
 		}
 		when(wait(notifyCheck)) {
+			TraceEvent te(SevDebug, "CoordinatorNotifyCheck");
+			te.detail("LeaderAvailable", currentNominee.present()).detail("NotifyQueueSize", notify.size());
+			if (!notify.empty()) {
+				te.detail("NotifiedAddress", notify.front().getEndpoint().getPrimaryAddress());
+			}
 			notifyCheck = delay(SERVER_KNOBS->NOTIFICATION_FULL_CLEAR_TIME /
 			                    std::max<double>(SERVER_KNOBS->MIN_NOTIFICATIONS, notify.size()));
 			if (!notify.empty() && currentNominee.present()) {


### PR DESCRIPTION
Having an extremely large default value of `NOTIFICATION_FULL_CLEAR_TIME` caused simulation failures by not allowing workers to receive `CandidacyRequest` replies in time, resulting in `ConsistencyCheck` timeouts.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
