### PR TITLE
Remove anonymous namespace in PaxosConfigTransaction.actor.cpp

### DIFF
--- a/fdbclient/PaxosConfigTransaction.actor.cpp
+++ b/fdbclient/PaxosConfigTransaction.actor.cpp
@@ -22,8 +22,6 @@
 #include "fdbclient/PaxosConfigTransaction.h"
 #include "flow/actorcompiler.h" // must be last include
 
-namespace {
-
 // TODO: Some replicas may reply after quorum has already been achieved, and we may want to add them to the readReplicas
 // list
 class GetGenerationQuorum {
@@ -71,8 +69,6 @@ public:
 	Future<Result> getResult() const { return result.getFuture(); }
 	Optional<Version> getLastSeenLiveVersion() const { return lastSeenLiveVersion; }
 };
-
-} // namespace
 
 class PaxosConfigTransactionImpl {
 	ConfigTransactionCommitRequest toCommit;


### PR DESCRIPTION
This fixes `subobject-linkage` warning from `gcc`.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
