### PR TITLE
Force kill in killDatacenter didn't actually force kill always

### DIFF
--- a/fdbrpc/sim2.actor.cpp
+++ b/fdbrpc/sim2.actor.cpp
@@ -1900,7 +1900,7 @@ public:
 
 		KillType ktResult, ktMin = kt;
 		for (auto& datacenterMachine : datacenterMachines) {
-			if (deterministicRandom()->random01() < 0.99) {
+			if (deterministicRandom()->random01() < 0.99 || forceKill) {
 				killMachine(datacenterMachine.first, kt, true, &ktResult);
 				if (ktResult != kt) {
 					TraceEvent(SevWarn, "KillDCFail")

--- a/fdbserver/workloads/KillRegion.actor.cpp
+++ b/fdbserver/workloads/KillRegion.actor.cpp
@@ -84,6 +84,8 @@ struct KillRegionWorkload : TestWorkload {
 		TraceEvent("ForceRecovery_Wait").log();
 		wait(delay(deterministicRandom()->random01() * self->testDuration));
 
+		// FIXME: killDataCenter breaks simulation if forceKill=false, since some processes can survive and
+		// partially complete a recovery
 		g_simulator.killDataCenter(LiteralStringRef("0"),
 		                           deterministicRandom()->random01() < 0.5 ? ISimulator::KillInstantly
 		                                                                   : ISimulator::RebootAndDelete,


### PR DESCRIPTION
Fixed bug in nightly correctness where killDatacenter with forceKill=true didn't always actually kill the whole datacenter.
In this case, on KillRegionCycle, it skipped killing a tlog in the primary DC that allowed it to get partially through a recovery and take over the cluster controller, but not enough to actually finish the recovery and make the database available.

Passed 100k correctness tests.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
