### PR TITLE
Fix worker segfault by reference counting LocalConfiguration

### DIFF
--- a/fdbserver/LocalConfiguration.actor.cpp
+++ b/fdbserver/LocalConfiguration.actor.cpp
@@ -414,10 +414,6 @@ LocalConfiguration::LocalConfiguration(std::string const& dataFolder,
                                        IsTest isTest)
   : impl(PImpl<LocalConfigurationImpl>::create(dataFolder, configPath, manualKnobOverrides, isTest)) {}
 
-LocalConfiguration::LocalConfiguration(LocalConfiguration&&) = default;
-
-LocalConfiguration& LocalConfiguration::operator=(LocalConfiguration&&) = default;
-
 LocalConfiguration::~LocalConfiguration() = default;
 
 Future<Void> LocalConfiguration::initialize() {

--- a/fdbserver/LocalConfiguration.h
+++ b/fdbserver/LocalConfiguration.h
@@ -43,7 +43,7 @@ FDB_DECLARE_BOOLEAN_PARAM(IsTest);
  *    - Register with the broadcaster to receive new updates for the relevant configuration classes
  *      - Persist these updates when received, and restart if necessary
  */
-class LocalConfiguration {
+class LocalConfiguration : public ReferenceCounted<LocalConfiguration> {
 	PImpl<class LocalConfigurationImpl> impl;
 
 public:
@@ -51,8 +51,6 @@ public:
 	                   std::string const& configPath,
 	                   std::map<std::string, std::string> const& manualKnobOverrides,
 	                   IsTest = IsTest::False);
-	LocalConfiguration(LocalConfiguration&&);
-	LocalConfiguration& operator=(LocalConfiguration&&);
 	~LocalConfiguration();
 	Future<Void> initialize();
 	FlowKnobs const& getFlowKnobs() const;


### PR DESCRIPTION
After discussing reference counting vs yielding, I decided to go with reference counting since it would fix this issue if it ever came up elsewhere, and avoids yielding in a response from the network thread, which evan mentioned could cause performance problems.

Passed 10k correctness tests. It's essentially a no-op with the config initialize step disabled.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
