### PR TITLE
Add destination team to ServerCacheInfo

### DIFF
--- a/fdbserver/ApplyMetadataMutation.cpp
+++ b/fdbserver/ApplyMetadataMutation.cpp
@@ -95,7 +95,7 @@ void applyMetadataMutations(
 					if (k != allKeys.end) {
 						KeyRef end = keyInfo->rangeContaining(k).end();
 						KeyRangeRef insertRange(k, end);
-						vector<UID> src, dest;
+						std::vector<UID> src, dest;
 						// txnStateStore is always an in-memory KVS, and must always be recovered before
 						// applyMetadataMutations is called, so a wait here should never be needed.
 						Future<RangeResult> fResult = txnStateStore->readRange(serverTagKeys);

--- a/fdbserver/ApplyMetadataMutation.h
+++ b/fdbserver/ApplyMetadataMutation.h
@@ -44,6 +44,8 @@ Reference<StorageInfo> getStorageInfo(UID id,
                                       std::map<UID, Reference<StorageInfo>>* storageCache,
                                       IKeyValueStore* txnStateStore);
 
+// Commit proxy calls this function to apply metadata mutations to transaction
+// state store.
 void applyMetadataMutations(SpanID const& spanContext,
                             ProxyCommitData& proxyCommitData,
                             Arena& arena,
@@ -53,6 +55,9 @@ void applyMetadataMutations(SpanID const& spanContext,
                             bool& confChange,
                             Version popVersion,
                             bool initialCommit);
+
+// Master calls this function during recovery to apply recovery transaction and
+// initialize TLog groups.
 void applyMetadataMutations(SpanID const& spanContext,
                             const UID& dbgid,
                             Arena& arena,

--- a/fdbserver/CommitProxyServer.actor.cpp
+++ b/fdbserver/CommitProxyServer.actor.cpp
@@ -2180,6 +2180,11 @@ ACTOR Future<Void> commitProxyServerCore(CommitProxyInterface proxy,
 								ASSERT(storageInfo->tag != invalidTag);
 								info.tags.push_back(storageInfo->tag);
 								info.dest_info.push_back(storageInfo);
+								if (SERVER_KNOBS->TLOG_NEW_INTERFACE) {
+									// Add storage teams of storage servers
+									ASSERT(storageServerToStorageTeam.count(id));
+									info.storageTeams.insert(storageServerToStorageTeam[id]);
+								}
 							}
 							uniquify(info.tags);
 							keyInfoData.emplace_back(MapPair<Key, ServerCacheInfo>(k, info), 1);

--- a/fdbserver/ptxn/test/TestTLogServer.actor.cpp
+++ b/fdbserver/ptxn/test/TestTLogServer.actor.cpp
@@ -326,8 +326,7 @@ ACTOR Future<Void> commitInject(std::shared_ptr<ptxn::test::TestDriverContext> p
 	printTiming << "Generated " << numCommits << " commit requests" << std::endl;
 
 	{
-		std::random_device rd;
-		std::mt19937 g(rd());
+		std::mt19937 g(deterministicRandom()->randomUInt32());
 		std::shuffle(std::begin(requests), std::end(requests), g);
 	}
 


### PR DESCRIPTION
This was missed in the PR #5399. Also added some comments.

20210818-230909-jzhou-6dbf4ceda72525df             compressed=True data_size=26378427 duration=4760661 ended=101236 fail=1 fail_fast=10 max_runs=100000 pass=100223 priority=100 remaining=0 runtime=0:29:25 sanity=False started=101567 stopped=20210818-233834 submitted=20210818-230909 timeout=5400 username=jzhou

The failed test is a non-deterministic unit test `/fdbserver/ptxn/test/commit_peek`, as unseed values are different. I fixed in the second commit.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
