### PR TITLE
Change Histogram Unit::Count output format

### DIFF
--- a/flow/Histogram.cpp
+++ b/flow/Histogram.cpp
@@ -135,7 +135,7 @@ void Histogram::writeToLog() {
 				e.detail(format("LessThan%f", (i + 1) * 0.04), buckets[i]);
 				break;
 			case Unit::count:
-				e.detail(format("LessThan%f", (i + 1) * ((upperBound - lowerBound) / 31.0)), buckets[i]);
+				e.detail(format("LessThan%.2f", (i + 1) * ((upperBound - lowerBound) / 31.0)), buckets[i]);
 				break;
 			default:
 				ASSERT(false);


### PR DESCRIPTION
Update the Histogram Unit::Count output format to keep two decimals which reduce the output size and make the metrics more readable.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
