### PR TITLE
Update the status documentation to include missing fields

### DIFF
--- a/documentation/sphinx/source/mr-status-json-schemas.rst.inc
+++ b/documentation/sphinx/source/mr-status-json-schemas.rst.inc
@@ -50,6 +50,9 @@
                   "kvstore_available_bytes":12341234,
                   "kvstore_free_bytes":12341234,
                   "kvstore_total_bytes":12341234,
+                  "kvstore_total_size":12341234,
+                  "kvstore_total_nodes":12341234,
+                  "kvstore_inline_keys":12341234,
                   "durable_bytes":{
                      "hz":0.0,
                      "counter":0,
@@ -208,6 +211,13 @@
                      "estimated_cost":{
                         "hz":0.0
                      }
+                  },
+                  "busiest_write_tag":{
+                     "tag": "",
+                     "fractional_cost": 0.0,
+                     "estimated_cost":{
+                        "hz":0.0
+                     }
                   }
                }
             ],
@@ -226,6 +236,9 @@
                      "$enum":[
                         "file_open_error",
                         "incorrect_cluster_file_contents",
+                        "trace_log_file_write_error",
+                        "trace_log_could_not_create_file",
+                        "trace_log_writer_thread_unresponsive",
                         "process_error",
                         "io_error",
                         "io_timeout",
@@ -285,15 +298,20 @@
             "run_loop_busy":0.2 // fraction of time the run loop was busy
          }
       },
-      "old_logs":[
+      "logs":[
          {
-            "logs":[ // this field will be absent if a value has not been explicitly set
+            "log_interfaces":[ // this field will be absent if a value has not been explicitly set
                {
                   "id":"7f8d623d0cb9966e",
                   "healthy":true,
                   "address":"1.2.3.4:1234"
                }
             ],
+            "epoch":1,
+            "current":false,
+            "begin_version":23,
+            "end_version":112315141,
+            "possibly_losing_data":true,
             "log_replication_factor":3,
             "log_write_anti_quorum":0,
             "log_fault_tolerance":2,
@@ -325,7 +343,8 @@
                   "storage_server_min_free_space_ratio",
                   "log_server_min_free_space",
                   "log_server_min_free_space_ratio",
-                  "storage_server_durability_lag"
+                  "storage_server_durability_lag",
+                  "storage_server_list_fetch_failed"
                ]
             },
             "description":"The database is not being saturated by the workload."
@@ -345,7 +364,8 @@
                   "storage_server_min_free_space_ratio",
                   "log_server_min_free_space",
                   "log_server_min_free_space_ratio",
-                  "storage_server_durability_lag"
+                  "storage_server_durability_lag",
+                  "storage_server_list_fetch_failed"
                ]
             },
             "description":"The database is not being saturated by the workload."
@@ -358,14 +378,10 @@
             "auto" : {
                 "busy_read" : 0,
                 "busy_write" : 0,
-                "count" : 0
+                "count" : 0,
+                "recommended_only":0
             },
             "manual" : {
-                "count" : 0
-            },
-            "recommend" : {
-                "busy_read" : 0,
-                "busy_write" : 0,
                 "count" : 0
             }
          },
@@ -394,12 +410,13 @@
          "seconds":1.0,
          "versions":1000000
       },
+      "active_tss_count":0,
       "degraded_processes":0,
       "database_available":true,
       "database_lock_state":{
          "locked":true,
          "lock_uid":"00000000000000000000000000000000" // Only present when database is locked
-      }
+      },
       "generation":2,
       "latency_probe":{ // all measurements are based on running sample transactions
          "read_seconds":7, // time to perform a single read
@@ -468,6 +485,8 @@
                   "database_availability_timeout",
                   "consistencycheck_suspendkey_fetch_timeout",
                   "consistencycheck_disabled",
+                  "duplicate_mutation_streams",
+                  "duplicate_mutation_fetch_timeout",
                   "primary_dc_missing",
                   "fetch_primary_dc_timeout"
                ]
@@ -476,7 +495,10 @@
                {
                   "name":{ // when not limiting
                      "$enum":[
-                        "incorrect_cluster_file_contents"
+                        "incorrect_cluster_file_contents",
+                        "trace_log_file_write_error",
+                        "trace_log_could_not_create_file",
+                        "trace_log_writer_thread_unresponsive"
                      ]
                   },
                   "description":"Cluster file contents do not match current cluster connection string. Verify cluster file is writable and has not been overwritten externally."
@@ -680,7 +702,10 @@
              "ssd-2",
              "ssd-redwood-experimental",
              "ssd-rocksdb-experimental",
-             "memory"
+             "memory",
+             "memory-1",
+             "memory-2",
+             "memory-radixtree-beta"
          ]},
          "tss_count":1,
          "tss_storage_engine":{
@@ -690,7 +715,10 @@
              "ssd-2",
              "ssd-redwood-experimental",
              "ssd-rocksdb-experimental",
-             "memory"
+             "memory",
+             "memory-1",
+             "memory-2",
+             "memory-radixtree-beta"
          ]},
          "coordinators_count":1,
          "excluded_servers":[
@@ -700,11 +728,13 @@
             }
          ],
          "auto_commit_proxies":3,
+         "auto_grv_proxies":1,
          "auto_resolvers":1,
          "auto_logs":3,
-         "backup_worker_enabled":1,
          "commit_proxies":5, // this field will be absent if a value has not been explicitly set
+         "grv_proxies":1, // this field will be absent if a value has not been explicitly set
          "proxies":6, // this field will be absent if a value has not been explicitly set
+         "backup_worker_enabled":1,
          "perpetual_storage_wiggle": 0
       },
       "data":{
@@ -805,7 +835,8 @@
          "coordinators":[
             {
                "reachable":true,
-               "address":"127.0.0.1:4701"
+               "address":"127.0.0.1:4701",
+               "protocol":"0fdb00b070010001"
             }
          ],
          "quorum_reachable":true


### PR DESCRIPTION
The status schema included many fields that weren't present in the documentation. This adds those fields and also fixes one missing comma.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.
