### PR TITLE
Allow CC health monitor to handle Actor cancellation

### DIFF
--- a/fdbserver/ClusterController.actor.cpp
+++ b/fdbserver/ClusterController.actor.cpp
@@ -4780,6 +4780,9 @@ ACTOR Future<Void> workerHealthMonitor(ClusterControllerData* self) {
 			wait(delay(SERVER_KNOBS->CC_WORKER_HEALTH_CHECKING_INTERVAL));
 		} catch (Error& e) {
 			TraceEvent(SevWarnAlways, "ClusterControllerHealthMonitorError").error(e);
+			if (e.code() == error_code_actor_cancelled) {
+				throw;
+			}
 		}
 	}
 }


### PR DESCRIPTION
Previously, the health monitor in Cluster controller runs a loop despite of any errors encountered. When the actor is cancelled, the loop drops the cancellation error and still running, which causes the health monitor to stuck. To fix the issue, we need to return the cancellation error, which is also suggested [here](https://github.com/apple/foundationdb/tree/master/flow#actor-cancellation).

100k joshua test: 20210819-235625-zhewu_5381-c40c02fc8f0678cb

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
