### PR TITLE
Fixing Trace Event Names

### DIFF
--- a/fdbserver/ClusterController.actor.cpp
+++ b/fdbserver/ClusterController.actor.cpp
@@ -1770,7 +1770,7 @@ public:
 		for (auto& [workerAddress, health] : workerHealth) {
 			for (auto it = health.degradedPeers.begin(); it != health.degradedPeers.end();) {
 				if (currentTime - it->second.lastRefreshTime > SERVER_KNOBS->CC_DEGRADED_LINK_EXPIRATION_INTERVAL) {
-					TraceEvent("WorkerPeerHealthRecovered").detail("Worker", workerAddress).detail("peer", it->first);
+					TraceEvent("WorkerPeerHealthRecovered").detail("Worker", workerAddress).detail("Peer", it->first);
 					health.degradedPeers.erase(it++);
 				} else {
 					++it;
@@ -1780,7 +1780,7 @@ public:
 
 		for (auto it = workerHealth.begin(); it != workerHealth.end();) {
 			if (it->second.degradedPeers.empty()) {
-				TraceEvent("WorkerAllPeerHealthRecovered").detail("worker", it->first);
+				TraceEvent("WorkerAllPeerHealthRecovered").detail("Worker", it->first);
 				workerHealth.erase(it++);
 			} else {
 				++it;


### PR DESCRIPTION
Last night's snowflake 6.3 nightly had 7/100k correctness failures and 1/1k valgrind failures in `RandomUnitTests.txt` because the trace event detail names weren't capitalized here.
It appears this was introduced in https://github.com/apple/foundationdb/pull/5249.

`<StdErrOutput Severity="40" Output="Trace event detail name `peer' is invalid in:"/>`

  `<"Severity"="10", "Time"="6.985623", "DateTime"="2021-08-20T09:26:34Z", "Type"="WorkerPeerHealthRecovered", "Machine"="3.4.3.3:1", "ID"="0000000000000000", "Worker"="17.17.17.17:1", "peer"="3.3.3.3:1", "LogGroup"="default", "Roles"="TS""/>`

`<StdErrOutput Severity="40" Output="Trace event detail name `worker' is invalid in:"/>`

`<"Severity"="10", "Time"="6.033279", "DateTime"="2021-08-20T05:42:52Z", "Type"="WorkerAllPeerHealthRecovered", "Machine"="3.4.3.7:1", "ID"="0000000000000000", "worker"="17.17.17.17:1", "LogGroup"="default", "Roles"="TS""/>`

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
