### PR TITLE
Fix crash when DR binaries are invoked without a source cluster file.

### DIFF
--- a/fdbbackup/backup.actor.cpp
+++ b/fdbbackup/backup.actor.cpp
@@ -1209,9 +1209,11 @@ static void printFastRestoreUsage(bool devhelp) {
 static void printDBAgentUsage(bool devhelp) {
 	printf("FoundationDB " FDB_VT_PACKAGE_NAME " (v" FDB_VT_VERSION ")\n");
 	printf("Usage: %s [OPTIONS]\n\n", exeDatabaseAgent.toString().c_str());
-	printf("  -d CONNFILE    The path of a file containing the connection string for the\n"
+	printf("  -d, --destination CONNFILE\n"
+	       "                 The path of a file containing the connection string for the\n"
 	       "                 destination FoundationDB cluster.\n");
-	printf("  -s CONNFILE    The path of a file containing the connection string for the\n"
+	printf("  -s, --source CONNFILE\n"
+	       "                 The path of a file containing the connection string for the\n"
 	       "                 source FoundationDB cluster.\n");
 	printf("  --log          Enables trace file logging for the CLI session.\n"
 	       "  --logdir PATH  Specifes the output directory for trace files. If\n"
@@ -1223,7 +1225,7 @@ static void printDBAgentUsage(bool devhelp) {
 	printf("  --trace_format FORMAT\n"
 	       "                 Select the format of the trace files. xml (the default) and json are supported.\n"
 	       "                 Has no effect unless --log is specified.\n");
-	printf("  -m SIZE, --memory SIZE\n"
+	printf("  -m, --memory SIZE\n"
 	       "                 Memory limit. The default value is 8GiB. When specified\n"
 	       "                 without a unit, MiB is assumed.\n");
 #ifndef TLS_DISABLED
@@ -3073,6 +3075,36 @@ Version parseVersion(const char* str) {
 extern uint8_t* g_extra_memory;
 #endif
 
+// Creates a connection to a cluster. Optionally prints an error if the connection fails.
+Optional<Database> connectToCluster(std::string const& clusterFile,
+                                    LocalityData const& localities,
+                                    bool quiet = false) {
+	auto resolvedClusterFile = ClusterConnectionFile::lookupClusterFileName(clusterFile);
+	Reference<ClusterConnectionFile> ccf;
+
+	Optional<Database> db;
+
+	try {
+		ccf = makeReference<ClusterConnectionFile>(resolvedClusterFile.first);
+	} catch (Error& e) {
+		if (!quiet)
+			fprintf(stderr, "%s\n", ClusterConnectionFile::getErrorString(resolvedClusterFile, e).c_str());
+		return db;
+	}
+
+	try {
+		db = Database::createDatabase(ccf, -1, IsInternal::True, localities);
+	} catch (Error& e) {
+		if (!quiet) {
+			fprintf(stderr, "ERROR: %s\n", e.what());
+			fprintf(stderr, "ERROR: Unable to connect to cluster from `%s'\n", ccf->getFilename().c_str());
+		}
+		return db;
+	}
+
+	return db;
+};
+
 int main(int argc, char* argv[]) {
 	platformInit();
 
@@ -3785,9 +3817,7 @@ int main(int argc, char* argv[]) {
 		std::set_new_handler(&platform::outOfMemory);
 		setMemoryQuota(memLimit);
 
-		Reference<ClusterConnectionFile> ccf;
 		Database db;
-		Reference<ClusterConnectionFile> sourceCcf;
 		Database sourceDb;
 		FileBackupAgent ba;
 		Key tag;
@@ -3830,43 +3860,29 @@ int main(int argc, char* argv[]) {
 		};
 
 		auto initCluster = [&](bool quiet = false) {
-			auto resolvedClusterFile = ClusterConnectionFile::lookupClusterFileName(clusterFile);
-			try {
-				ccf = makeReference<ClusterConnectionFile>(resolvedClusterFile.first);
-			} catch (Error& e) {
-				if (!quiet)
-					fprintf(stderr, "%s\n", ClusterConnectionFile::getErrorString(resolvedClusterFile, e).c_str());
-				return false;
+			Optional<Database> result = connectToCluster(clusterFile, localities, quiet);
+			if (result.present()) {
+				db = result.get();
 			}
 
-			try {
-				db = Database::createDatabase(ccf, -1, IsInternal::True, localities);
-			} catch (Error& e) {
-				fprintf(stderr, "ERROR: %s\n", e.what());
-				fprintf(stderr, "ERROR: Unable to connect to cluster from `%s'\n", ccf->getFilename().c_str());
-				return false;
-			}
-
-			return true;
+			return result.present();
 		};
 
-		if (sourceClusterFile.size()) {
-			auto resolvedSourceClusterFile = ClusterConnectionFile::lookupClusterFileName(sourceClusterFile);
-			try {
-				sourceCcf = makeReference<ClusterConnectionFile>(resolvedSourceClusterFile.first);
-			} catch (Error& e) {
-				fprintf(stderr, "%s\n", ClusterConnectionFile::getErrorString(resolvedSourceClusterFile, e).c_str());
-				return FDB_EXIT_ERROR;
+		auto initSourceCluster = [&](bool required, bool quiet = false) {
+			if (!sourceClusterFile.size() && required) {
+				if (!quiet) {
+					fprintf(stderr, "ERROR: source cluster file is required\n");
+				}
+				return false;
 			}
 
-			try {
-				sourceDb = Database::createDatabase(sourceCcf, -1, IsInternal::True, localities);
-			} catch (Error& e) {
-				fprintf(stderr, "ERROR: %s\n", e.what());
-				fprintf(stderr, "ERROR: Unable to connect to cluster from `%s'\n", sourceCcf->getFilename().c_str());
-				return FDB_EXIT_ERROR;
+			Optional<Database> result = connectToCluster(sourceClusterFile, localities, quiet);
+			if (result.present()) {
+				sourceDb = result.get();
 			}
-		}
+
+			return result.present();
+		};
 
 		switch (programExe) {
 		case ProgramExe::AGENT:
@@ -4166,13 +4182,15 @@ int main(int argc, char* argv[]) {
 			}
 			break;
 		case ProgramExe::DR_AGENT:
-			if (!initCluster())
+			if (!initCluster() || !initSourceCluster(true)) {
 				return FDB_EXIT_ERROR;
+			}
 			f = stopAfter(runDBAgent(sourceDb, db));
 			break;
 		case ProgramExe::DB_BACKUP:
-			if (!initCluster())
+			if (!initCluster() || !initSourceCluster(dbType != DBType::ABORT || !dstOnly)) {
 				return FDB_EXIT_ERROR;
+			}
 			switch (dbType) {
 			case DBType::START:
 				f = stopAfter(submitDBBackup(sourceDb, db, backupKeys, tagName));


### PR DESCRIPTION
Also updates the usage text for dr_agent cluster files to include the long form options.

Tested by running the commands manually and verifying the correct error message appeared and that the usage text looked correct.

Also passed 10K correctness.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.
