### PR TITLE
Unit test ConfigBroadcaster detection of worker death

### DIFF
--- a/fdbserver/ConfigBroadcaster.actor.cpp
+++ b/fdbserver/ConfigBroadcaster.actor.cpp
@@ -81,6 +81,7 @@ class ConfigBroadcasterImpl {
 	Future<Void> consumerFuture;
 	ActorCollection actors{ false };
 	std::map<UID, BroadcastClientDetails> clients;
+	std::map<UID, Future<Void>> clientFailures;
 
 	UID id;
 	CounterCollection cc;
@@ -203,6 +204,7 @@ class ConfigBroadcasterImpl {
 		wait(watcher);
 		TraceEvent(SevDebug, "ConfigBroadcastClientDied", self->id).detail("ClientID", clientUID);
 		self->clients.erase(clientUID);
+		// TODO: Erase clientUID from clientFailures at some point
 		return Void();
 	}
 
@@ -230,7 +232,7 @@ class ConfigBroadcasterImpl {
 		// Push full snapshot to worker if it isn't up to date.
 		wait(impl->pushSnapshot(impl->mostRecentVersion, client));
 		impl->clients[broadcastInterface.id()] = client;
-		impl->actors.add(waitForFailure(impl, watcher, broadcastInterface.id()));
+		impl->clientFailures[broadcastInterface.id()] = waitForFailure(impl, watcher, broadcastInterface.id());
 		return Void();
 	}
 
@@ -345,6 +347,8 @@ public:
 
 	Future<Void> getError() const { return consumerFuture || actors.getResult(); }
 
+	Future<Void> getClientFailure(UID clientUID) const { return clientFailures.find(clientUID)->second; }
+
 	UID getID() const { return id; }
 
 	static void runPendingRequestStoreTest(bool includeGlobalMutation, int expectedMatches);
@@ -395,6 +399,10 @@ void ConfigBroadcaster::applySnapshotAndChanges(
 
 Future<Void> ConfigBroadcaster::getError() const {
 	return impl->getError();
+}
+
+Future<Void> ConfigBroadcaster::getClientFailure(UID clientUID) const {
+	return impl->getClientFailure(clientUID);
 }
 
 UID ConfigBroadcaster::getID() const {

--- a/fdbserver/ConfigBroadcaster.actor.cpp
+++ b/fdbserver/ConfigBroadcaster.actor.cpp
@@ -201,21 +201,10 @@ class ConfigBroadcasterImpl {
 	}
 
 	ACTOR static Future<Void> waitForFailure(ConfigBroadcasterImpl* self, Future<Void> watcher, UID clientUID) {
-		// Clean up clientFailures futures. The values in this map should only
-		// be used for testing, and cleaning them up here ensures tests still
-		// have enough time to read the future while making sure the map
-		// doesn't grow unbounded.
-		for (auto it = self->clientFailures.begin(); it != self->clientFailures.end();) {
-			if (it->second.isReady()) {
-				it = self->clientFailures.erase(it);
-			} else {
-				++it;
-			}
-		}
-
 		wait(watcher);
 		TraceEvent(SevDebug, "ConfigBroadcastClientDied", self->id).detail("ClientID", clientUID);
 		self->clients.erase(clientUID);
+		self->clientFailures.erase(clientUID);
 		return Void();
 	}
 

--- a/fdbserver/ConfigBroadcaster.actor.cpp
+++ b/fdbserver/ConfigBroadcaster.actor.cpp
@@ -201,6 +201,18 @@ class ConfigBroadcasterImpl {
 	}
 
 	ACTOR static Future<Void> waitForFailure(ConfigBroadcasterImpl* self, Future<Void> watcher, UID clientUID) {
+		// Clean up clientFailures futures. The values in this map should only
+		// be used for testing, and cleaning them up here ensures tests still
+		// have enough time to read the future while making sure the map
+		// doesn't grow unbounded.
+		for (auto it = self->clientFailures.begin(); it != self->clientFailures.end();) {
+			if (it->second.isReady()) {
+				it = self->clientFailures.erase(it);
+			} else {
+				++it;
+			}
+		}
+
 		wait(watcher);
 		TraceEvent(SevDebug, "ConfigBroadcastClientDied", self->id).detail("ClientID", clientUID);
 		self->clients.erase(clientUID);
@@ -222,18 +234,6 @@ class ConfigBroadcasterImpl {
 		if (impl->clients.count(broadcastInterface.id())) {
 			// Client already registered
 			return Void();
-		}
-
-		// Clean up clientFailures futures. The values in this map should only
-		// be used for testing, and cleaning them up here ensures tests still
-		// have enough time to read the future while making sure the map
-		// doesn't grow unbounded.
-		for (auto it = impl->clientFailures.begin(); it != impl->clientFailures.end();) {
-			if (it->second.isReady()) {
-				it = impl->clientFailures.erase(it);
-			} else {
-				++it;
-			}
 		}
 
 		TraceEvent(SevDebug, "ConfigBroadcasterRegisteringWorker", impl->id)

--- a/fdbserver/ConfigBroadcaster.h
+++ b/fdbserver/ConfigBroadcaster.h
@@ -67,4 +67,5 @@ public:
 
 public: // Testing
 	explicit ConfigBroadcaster(ConfigFollowerInterface const&);
+	Future<Void> getClientFailure(UID clientUID) const;
 };

--- a/fdbserver/ConfigDatabaseUnitTests.actor.cpp
+++ b/fdbserver/ConfigDatabaseUnitTests.actor.cpp
@@ -401,7 +401,8 @@ class TransactionToLocalConfigEnvironment {
 		wait(self->readFrom.setup());
 		self->cbi = makeReference<AsyncVar<ConfigBroadcastInterface>>();
 		self->readFrom.connectToBroadcaster(self->cbi);
-		self->broadcastServer = self->broadcaster.registerWorker(0, configClassSet, Never(), self->cbi->get());
+		self->broadcastServer =
+		    self->broadcaster.registerWorker(0, configClassSet, self->workerFailure.getFuture(), self->cbi->get());
 		return Void();
 	}
 

--- a/fdbserver/ConfigDatabaseUnitTests.actor.cpp
+++ b/fdbserver/ConfigDatabaseUnitTests.actor.cpp
@@ -910,5 +910,3 @@ TEST_CASE("/fdbserver/ConfigDB/Transaction/BadRangeRead") {
 	}
 	return Void();
 }
-
-// TODO: Test worker failure detection on ConfigBroadcaster

--- a/fdbserver/ConfigDatabaseUnitTests.actor.cpp
+++ b/fdbserver/ConfigDatabaseUnitTests.actor.cpp
@@ -831,7 +831,7 @@ TEST_CASE("/fdbserver/ConfigDB/TransactionToLocalConfig/RestartLocalConfiguratio
 	return Void();
 }
 
-TEST_CASE("/fdbserver/ConfigDB/TransactionToLocalconfig/KillWorker") {
+TEST_CASE("/fdbserver/ConfigDB/TransactionToLocalConfig/KillWorker") {
 	wait(testKillWorker<TransactionToLocalConfigEnvironment>(params));
 	return Void();
 }

--- a/fdbserver/ConfigDatabaseUnitTests.actor.cpp
+++ b/fdbserver/ConfigDatabaseUnitTests.actor.cpp
@@ -247,6 +247,7 @@ class BroadcasterToLocalConfigEnvironment {
 	Version lastWrittenVersion{ 0 };
 	Future<Void> broadcastServer;
 	Promise<Void> workerFailure;
+	Future<Void> workerFailed_;
 
 	ACTOR static Future<Void> setup(BroadcasterToLocalConfigEnvironment* self, ConfigClassSet configClassSet) {
 		wait(self->readFrom.setup());
@@ -294,9 +295,15 @@ public:
 		return readFrom.restartLocalConfig(newConfigPath);
 	}
 
-	void killLocalConfig() { workerFailure.send(Void()); }
+	void killLocalConfig() {
+		workerFailed_ = broadcaster.getClientFailure(cbi->get().id());
+		workerFailure.send(Void());
+	}
 
-	Future<Void> workerFailed() { return broadcaster.getClientFailure(cbi->get().id()); }
+	Future<Void> workerFailed() {
+		ASSERT(workerFailed_.isValid());
+		return workerFailed_;
+	}
 
 	void compact() { broadcaster.compact(lastWrittenVersion); }
 
@@ -396,6 +403,7 @@ class TransactionToLocalConfigEnvironment {
 	ConfigBroadcaster broadcaster;
 	Future<Void> broadcastServer;
 	Promise<Void> workerFailure;
+	Future<Void> workerFailed_;
 
 	ACTOR static Future<Void> setup(TransactionToLocalConfigEnvironment* self, ConfigClassSet configClassSet) {
 		wait(self->readFrom.setup());
@@ -427,9 +435,15 @@ public:
 		return readFrom.restartLocalConfig(newConfigPath);
 	}
 
-	void killLocalConfig() { workerFailure.send(Void()); }
+	void killLocalConfig() {
+		workerFailed_ = broadcaster.getClientFailure(cbi->get().id());
+		workerFailure.send(Void());
+	}
 
-	Future<Void> workerFailed() { return broadcaster.getClientFailure(cbi->get().id()); }
+	Future<Void> workerFailed() {
+		ASSERT(workerFailed_.isValid());
+		return workerFailed_;
+	}
 
 	Future<Void> compact() { return writeTo.compact(); }
 


### PR DESCRIPTION
Adds a unit test to test whether the `ConfigBroadcaster` correctly catches the death of a worker.

Passed 10k correctness.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
