### PR TITLE
Create the logs directory for FDB processes in the correct place in the release Dockerfile (release-7.0)

### DIFF
--- a/packaging/docker/release/Dockerfile
+++ b/packaging/docker/release/Dockerfile
@@ -73,7 +73,7 @@ RUN	/var/fdb/scripts/download_multiversion_libraries.bash $FDB_WEBSITE $FDB_ADDI
 
 RUN	rm -rf /mnt/website
 
-RUN	mkdir -p logs
+RUN	mkdir -p /var/fdb/logs
 
 VOLUME /var/fdb/data
 


### PR DESCRIPTION
This is a cherry pick of #5448.

The working directory for the command that creates the logs directory for FDB server processes was changed from /var/fdb to /, so we need to update the path to the directory we want to create accordingly.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
