### PR TITLE
Refactor transaction related commands

### DIFF
--- a/fdbcli/CMakeLists.txt
+++ b/fdbcli/CMakeLists.txt
@@ -10,7 +10,7 @@ set(FDBCLI_SRCS
   SetClassCommand.actor.cpp
   SnapshotCommand.actor.cpp
   ThrottleCommand.actor.cpp
-  Util.cpp
+  Util.actor.cpp
   linenoise/linenoise.h)
 
 if(NOT WIN32)

--- a/fdbcli/fdbcli.actor.h
+++ b/fdbcli/fdbcli.actor.h
@@ -67,6 +67,8 @@ extern const KeyRef ignoreSSFailureSpecialKey;
 // setclass
 extern const KeyRangeRef processClassSourceSpecialKeyRange;
 extern const KeyRangeRef processClassTypeSpecialKeyRange;
+// Other special keys
+inline const KeyRef errorMsgSpecialKey = LiteralStringRef("\xff\xff/error_message");
 // help functions (Copied from fdbcli.actor.cpp)
 
 // compare StringRef with the given c string

--- a/fdbcli/fdbcli.actor.h
+++ b/fdbcli/fdbcli.actor.h
@@ -75,6 +75,9 @@ inline const KeyRef errorMsgSpecialKey = LiteralStringRef("\xff\xff/error_messag
 bool tokencmp(StringRef token, const char* command);
 // print the usage of the specified command
 void printUsage(StringRef command);
+// Pre: tr failed with special_keys_api_failure error
+// Read the error message special key and return the message
+ACTOR Future<std::string> getSpecialKeysFailureErrorMessage(Reference<ITransaction> tr);
 
 // All fdbcli commands (alphabetically)
 // advanceversion command


### PR DESCRIPTION
Cherry-pick from #5171 (Part of the pr, it was too large, so we split it and merge one-by-one),
- Print out error message in _setClass_ if get `special_keys_api_failure`
- Refactor transaction related commands like `commit`, `begin`, etc.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
