### PR TITLE
Add pkg_tester (release-7.0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,7 @@ packaging/msi/obj
 simfdb
 tests/oldBinaries
 trace.*.xml
+.venv
 
 # Editor files
 *.iml

--- a/cmake/InstallLayout.cmake
+++ b/cmake/InstallLayout.cmake
@@ -155,17 +155,35 @@ list(GET FDB_VERSION_LIST 2 FDB_PATCH)
 # Alternatives config
 ################################################################################
 
+set(mv_packaging_dir ${PROJECT_SOURCE_DIR}/packaging/multiversion)
 math(EXPR ALTERNATIVES_PRIORITY "(${PROJECT_VERSION_MAJOR} * 1000) + (${PROJECT_VERSION_MINOR} * 100) + ${PROJECT_VERSION_PATCH}")
 set(script_dir "${PROJECT_BINARY_DIR}/packaging/multiversion/")
 file(MAKE_DIRECTORY "${script_dir}/server" "${script_dir}/clients")
-configure_file("${PROJECT_SOURCE_DIR}/packaging/multiversion/server/postinst" "${script_dir}/server" @ONLY)
-configure_file("${PROJECT_SOURCE_DIR}/packaging/multiversion/server/prerm" "${script_dir}/server" @ONLY)
-set(LIB_DIR lib)
-configure_file("${PROJECT_SOURCE_DIR}/packaging/multiversion/clients/postinst" "${script_dir}/clients" @ONLY)
-set(LIB_DIR lib64)
-configure_file("${PROJECT_SOURCE_DIR}/packaging/multiversion/clients/postinst" "${script_dir}/clients/postinst-el7" @ONLY)
-configure_file("${PROJECT_SOURCE_DIR}/packaging/multiversion/clients/prerm" "${script_dir}/clients" @ONLY)
 
+# Needs to to be named postinst for debian
+configure_file("${mv_packaging_dir}/server/postinst-deb" "${script_dir}/server/postinst" @ONLY)
+
+configure_file("${mv_packaging_dir}/server/postinst-rpm" "${script_dir}/server" @ONLY)
+configure_file("${mv_packaging_dir}/server/prerm" "${script_dir}/server" @ONLY)
+set(LIB_DIR lib)
+configure_file("${mv_packaging_dir}/clients/postinst" "${script_dir}/clients" @ONLY)
+set(LIB_DIR lib64)
+configure_file("${mv_packaging_dir}/clients/postinst" "${script_dir}/clients/postinst-el7" @ONLY)
+configure_file("${mv_packaging_dir}/clients/prerm" "${script_dir}/clients" @ONLY)
+
+#make sure all directories we need exist
+make_directory("${mv_packaging_dir}/clients/usr/lib/foundationdb")
+install(DIRECTORY "${mv_packaging_dir}/clients/usr/lib/foundationdb"
+  DESTINATION usr/lib
+  COMPONENT clients-versioned)
+make_directory("${mv_packaging_dir}/clients/usr/lib/pkgconfig")
+install(DIRECTORY "${mv_packaging_dir}/clients/usr/lib/pkgconfig"
+  DESTINATION usr/lib
+  COMPONENT clients-versioned)
+make_directory("${mv_packaging_dir}/clients/usr/lib/cmake")
+install(DIRECTORY "${mv_packaging_dir}/clients/usr/lib/cmake"
+  DESTINATION usr/lib
+  COMPONENT clients-versioned)
 
 ################################################################################
 # Move Docker Setup
@@ -196,6 +214,8 @@ set(CPACK_COMPONENT_SERVER-EL7_DEPENDS clients-el7)
 set(CPACK_COMPONENT_SERVER-DEB_DEPENDS clients-deb)
 set(CPACK_COMPONENT_SERVER-TGZ_DEPENDS clients-tgz)
 set(CPACK_COMPONENT_SERVER-VERSIONED_DEPENDS clients-versioned)
+set(CPACK_RPM_SERVER-VERSIONED_PACKAGE_REQUIRES
+  "foundationdb-clients-${FDB_MAJOR}.${FDB_MINOR}.${FDB_PATCH} = ${FDB_MAJOR}.${FDB_MINOR}.${FDB_PATCH}")
 
 set(CPACK_COMPONENT_SERVER-EL7_DISPLAY_NAME "foundationdb-server")
 set(CPACK_COMPONENT_SERVER-DEB_DISPLAY_NAME "foundationdb-server")
@@ -245,6 +265,7 @@ set(CPACK_RPM_PACKAGE_NAME "foundationdb")
 set(CPACK_RPM_CLIENTS-EL7_PACKAGE_NAME "foundationdb-clients")
 set(CPACK_RPM_SERVER-EL7_PACKAGE_NAME "foundationdb-server")
 set(CPACK_RPM_SERVER-VERSIONED_PACKAGE_NAME "foundationdb-server-${PROJECT_VERSION}")
+set(CPACK_RPM_CLIENTS-VERSIONED_PACKAGE_NAME "foundationdb-clients-${PROJECT_VERSION}")
 
 set(CPACK_RPM_CLIENTS-EL7_FILE_NAME "${rpm-clients-filename}.el7.${CMAKE_SYSTEM_PROCESSOR}.rpm")
 set(CPACK_RPM_CLIENTS-VERSIONED_FILE_NAME "${rpm-clients-filename}.versioned.${CMAKE_SYSTEM_PROCESSOR}.rpm")
@@ -281,7 +302,10 @@ set(CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION
   "/lib"
   "/lib/systemd"
   "/lib/systemd/system"
-  "/etc/rc.d/init.d")
+  "/etc/rc.d/init.d"
+  "/usr/lib/pkgconfig"
+  "/usr/lib/foundationdb"
+  "/usr/lib/cmake")
 set(CPACK_RPM_DEBUGINFO_PACKAGE ${GENERATE_DEBUG_PACKAGES})
 #set(CPACK_RPM_BUILD_SOURCE_FDB_INSTALL_DIRS_PREFIX /usr/src)
 set(CPACK_RPM_COMPONENT_INSTALL ON)
@@ -305,7 +329,7 @@ set(CPACK_RPM_SERVER-EL7_PACKAGE_REQUIRES
   "foundationdb-clients = ${FDB_MAJOR}.${FDB_MINOR}.${FDB_PATCH}")
 
 set(CPACK_RPM_SERVER-VERSIONED_POST_INSTALL_SCRIPT_FILE
-  ${CMAKE_BINARY_DIR}/packaging/multiversion/server/postinst)
+  ${CMAKE_BINARY_DIR}/packaging/multiversion/server/postinst-rpm)
 
 set(CPACK_RPM_SERVER-VERSIONED_PRE_UNINSTALL_SCRIPT_FILE
   ${CMAKE_BINARY_DIR}/packaging/multiversion/server/prerm)

--- a/contrib/pkg_tester/README.md
+++ b/contrib/pkg_tester/README.md
@@ -1,0 +1,58 @@
+# pkg_tester
+
+This is a test suite that can be used to validate properties of generated package files.
+
+To use it, first build the package files as described in the main [README](https://github.com/apple/foundationdb#linux)
+
+Then setup a virtualenv:
+
+```
+$ python3 -m venv .venv
+$ source .venv/bin/activate
+$ pip install -r requirements.txt
+```
+
+Then you can run the tests with pytest:
+
+```
+$ BUILDDIR=<BUILDDIR> python -m pytest -s -v
+```
+
+These are snapshot tests, so you may need to update the snapshots with
+
+```
+$ BUILDDIR=<BUILDDIR> python -m pytest -s -v --snapshot-update
+```
+
+Use discretion about whether or not the behavior change is acceptable.
+
+A helpful tip for debugging: if you run pytest with `--pdb`, then it will pause
+the tests at the first error which gives you a chance to run some `docker exec`
+commands to try and see what's wrong.
+
+There's a small chance that this will leak an image (especially if you interrupt the test with ctrl-c). Consider running
+
+```
+$ docker image prune
+```
+
+after. If you `kill -9` the test, there might even be leaked containers. You can destroy all existing containers with
+
+```
+$ docker rm -f $(docker ps -a -q) # destroy all docker containers!
+```
+
+# Requirements
+
+docker, python
+
+# Future work?
+
+- [x] Test rpms
+- [x] Test debs
+- [x] Test versioned packages
+- [ ] Test that upgrades preserve data/config
+
+# Development
+
+Please run `black` and `mypy` after making changes

--- a/contrib/pkg_tester/__snapshots__/test_fdb_pkgs.ambr
+++ b/contrib/pkg_tester/__snapshots__/test_fdb_pkgs.ambr
@@ -1,0 +1,244 @@
+# name: test_backup_restore[centos-versioned]
+  '
+  Submitted and now waiting for the backup on tag `default' to complete.
+  
+  '
+---
+# name: test_backup_restore[centos-versioned].1
+  '
+  `x' is `y'
+  
+  '
+---
+# name: test_backup_restore[centos]
+  '
+  Submitted and now waiting for the backup on tag `default' to complete.
+  
+  '
+---
+# name: test_backup_restore[centos].1
+  '
+  `x' is `y'
+  
+  '
+---
+# name: test_backup_restore[ubuntu-versioned]
+  '
+  Submitted and now waiting for the backup on tag `default' to complete.
+  
+  '
+---
+# name: test_backup_restore[ubuntu-versioned].1
+  '
+  `x' is `y'
+  
+  '
+---
+# name: test_backup_restore[ubuntu]
+  '
+  Submitted and now waiting for the backup on tag `default' to complete.
+  
+  '
+---
+# name: test_backup_restore[ubuntu].1
+  '
+  `x' is `y'
+  
+  '
+---
+# name: test_fdbcli_help_text[centos-versioned]
+  '
+  FoundationDB CLI 7.1 (v7.1.0)
+  usage: fdbcli [OPTIONS]
+  
+    -C CONNFILE    The path of a file containing the connection string for the
+                   FoundationDB cluster. The default is first the value of the
+                   FDB_CLUSTER_FILE environment variable, then `./fdb.cluster',
+                   then `/etc/foundationdb/fdb.cluster'.
+    --log          Enables trace file logging for the CLI session.
+    --log-dir PATH Specifes the output directory for trace files. If
+                   unspecified, defaults to the current directory. Has
+                   no effect unless --log is specified.
+    --trace_format FORMAT
+                   Select the format of the log files. xml (the default) and json
+                   are supported. Has no effect unless --log is specified.
+    --exec CMDS    Immediately executes the semicolon separated CLI commands
+                   and then exits.
+    --no-status    Disables the initial status check done when starting
+                   the CLI.
+    --tls_certificate_file CERTFILE
+                   The path of a file containing the TLS certificate and CA
+                   chain.
+    --tls_ca_file CERTAUTHFILE
+                   The path of a file containing the CA certificates chain.
+    --tls_key_file KEYFILE
+                   The path of a file containing the private key corresponding
+                   to the TLS certificate.
+    --tls_password PASSCODE
+                   The passphrase of encrypted private key
+    --tls_verify_peers CONSTRAINTS
+                   The constraints by which to validate TLS peers. The contents
+                   and format of CONSTRAINTS are plugin-specific.
+    --knob_KNOBNAME KNOBVALUE
+                   Changes a knob option. KNOBNAME should be lowercase.
+    --debug-tls    Prints the TLS configuration and certificate chain, then exits.
+                   Useful in reporting and diagnosing TLS issues.
+    --build_flags  Print build information and exit.
+    -v, --version  Print FoundationDB CLI version information and exit.
+    -h, --help     Display this help and exit.
+  
+  '
+---
+# name: test_fdbcli_help_text[centos]
+  '
+  FoundationDB CLI 7.1 (v7.1.0)
+  usage: fdbcli [OPTIONS]
+  
+    -C CONNFILE    The path of a file containing the connection string for the
+                   FoundationDB cluster. The default is first the value of the
+                   FDB_CLUSTER_FILE environment variable, then `./fdb.cluster',
+                   then `/etc/foundationdb/fdb.cluster'.
+    --log          Enables trace file logging for the CLI session.
+    --log-dir PATH Specifes the output directory for trace files. If
+                   unspecified, defaults to the current directory. Has
+                   no effect unless --log is specified.
+    --trace_format FORMAT
+                   Select the format of the log files. xml (the default) and json
+                   are supported. Has no effect unless --log is specified.
+    --exec CMDS    Immediately executes the semicolon separated CLI commands
+                   and then exits.
+    --no-status    Disables the initial status check done when starting
+                   the CLI.
+    --tls_certificate_file CERTFILE
+                   The path of a file containing the TLS certificate and CA
+                   chain.
+    --tls_ca_file CERTAUTHFILE
+                   The path of a file containing the CA certificates chain.
+    --tls_key_file KEYFILE
+                   The path of a file containing the private key corresponding
+                   to the TLS certificate.
+    --tls_password PASSCODE
+                   The passphrase of encrypted private key
+    --tls_verify_peers CONSTRAINTS
+                   The constraints by which to validate TLS peers. The contents
+                   and format of CONSTRAINTS are plugin-specific.
+    --knob_KNOBNAME KNOBVALUE
+                   Changes a knob option. KNOBNAME should be lowercase.
+    --debug-tls    Prints the TLS configuration and certificate chain, then exits.
+                   Useful in reporting and diagnosing TLS issues.
+    --build_flags  Print build information and exit.
+    -v, --version  Print FoundationDB CLI version information and exit.
+    -h, --help     Display this help and exit.
+  
+  '
+---
+# name: test_fdbcli_help_text[ubuntu-versioned]
+  '
+  FoundationDB CLI 7.1 (v7.1.0)
+  usage: fdbcli [OPTIONS]
+  
+    -C CONNFILE    The path of a file containing the connection string for the
+                   FoundationDB cluster. The default is first the value of the
+                   FDB_CLUSTER_FILE environment variable, then `./fdb.cluster',
+                   then `/etc/foundationdb/fdb.cluster'.
+    --log          Enables trace file logging for the CLI session.
+    --log-dir PATH Specifes the output directory for trace files. If
+                   unspecified, defaults to the current directory. Has
+                   no effect unless --log is specified.
+    --trace_format FORMAT
+                   Select the format of the log files. xml (the default) and json
+                   are supported. Has no effect unless --log is specified.
+    --exec CMDS    Immediately executes the semicolon separated CLI commands
+                   and then exits.
+    --no-status    Disables the initial status check done when starting
+                   the CLI.
+    --tls_certificate_file CERTFILE
+                   The path of a file containing the TLS certificate and CA
+                   chain.
+    --tls_ca_file CERTAUTHFILE
+                   The path of a file containing the CA certificates chain.
+    --tls_key_file KEYFILE
+                   The path of a file containing the private key corresponding
+                   to the TLS certificate.
+    --tls_password PASSCODE
+                   The passphrase of encrypted private key
+    --tls_verify_peers CONSTRAINTS
+                   The constraints by which to validate TLS peers. The contents
+                   and format of CONSTRAINTS are plugin-specific.
+    --knob_KNOBNAME KNOBVALUE
+                   Changes a knob option. KNOBNAME should be lowercase.
+    --debug-tls    Prints the TLS configuration and certificate chain, then exits.
+                   Useful in reporting and diagnosing TLS issues.
+    --build_flags  Print build information and exit.
+    -v, --version  Print FoundationDB CLI version information and exit.
+    -h, --help     Display this help and exit.
+  
+  '
+---
+# name: test_fdbcli_help_text[ubuntu]
+  '
+  FoundationDB CLI 7.1 (v7.1.0)
+  usage: fdbcli [OPTIONS]
+  
+    -C CONNFILE    The path of a file containing the connection string for the
+                   FoundationDB cluster. The default is first the value of the
+                   FDB_CLUSTER_FILE environment variable, then `./fdb.cluster',
+                   then `/etc/foundationdb/fdb.cluster'.
+    --log          Enables trace file logging for the CLI session.
+    --log-dir PATH Specifes the output directory for trace files. If
+                   unspecified, defaults to the current directory. Has
+                   no effect unless --log is specified.
+    --trace_format FORMAT
+                   Select the format of the log files. xml (the default) and json
+                   are supported. Has no effect unless --log is specified.
+    --exec CMDS    Immediately executes the semicolon separated CLI commands
+                   and then exits.
+    --no-status    Disables the initial status check done when starting
+                   the CLI.
+    --tls_certificate_file CERTFILE
+                   The path of a file containing the TLS certificate and CA
+                   chain.
+    --tls_ca_file CERTAUTHFILE
+                   The path of a file containing the CA certificates chain.
+    --tls_key_file KEYFILE
+                   The path of a file containing the private key corresponding
+                   to the TLS certificate.
+    --tls_password PASSCODE
+                   The passphrase of encrypted private key
+    --tls_verify_peers CONSTRAINTS
+                   The constraints by which to validate TLS peers. The contents
+                   and format of CONSTRAINTS are plugin-specific.
+    --knob_KNOBNAME KNOBVALUE
+                   Changes a knob option. KNOBNAME should be lowercase.
+    --debug-tls    Prints the TLS configuration and certificate chain, then exits.
+                   Useful in reporting and diagnosing TLS issues.
+    --build_flags  Print build information and exit.
+    -v, --version  Print FoundationDB CLI version information and exit.
+    -h, --help     Display this help and exit.
+  
+  '
+---
+# name: test_write[centos-versioned]
+  '
+  `x' is `y'
+  
+  '
+---
+# name: test_write[centos]
+  '
+  `x' is `y'
+  
+  '
+---
+# name: test_write[ubuntu-versioned]
+  '
+  `x' is `y'
+  
+  '
+---
+# name: test_write[ubuntu]
+  '
+  `x' is `y'
+  
+  '
+---

--- a/contrib/pkg_tester/requirements.txt
+++ b/contrib/pkg_tester/requirements.txt
@@ -1,0 +1,13 @@
+attrs==21.2.0
+colored==1.4.2
+importlib-metadata==4.0.1
+iniconfig==1.1.1
+packaging==20.9
+pluggy==0.13.1
+py==1.10.0
+pyparsing==2.4.7
+pytest==6.2.4
+syrupy==1.2.3
+toml==0.10.2
+typing-extensions==3.10.0.0
+zipp==3.4.1

--- a/contrib/pkg_tester/test_fdb_pkgs.py
+++ b/contrib/pkg_tester/test_fdb_pkgs.py
@@ -1,0 +1,251 @@
+# test_fdb_pkgs.py
+#
+# This source file is part of the FoundationDB open source project
+#
+# Copyright 2013-2021 Apple Inc. and the FoundationDB project authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import glob
+import os
+import pathlib
+import pytest
+import shlex
+import subprocess
+import uuid
+
+from typing import Iterator, List, Optional, Union
+
+
+def run(args: List[str]) -> str:
+    print("$ {}".format(" ".join(map(shlex.quote, args))))
+    result = subprocess.check_output(args).decode("utf-8")
+    print(result, end="")
+    return result
+
+
+class Image:
+    def __init__(self, uid: str):
+        self.uid = uid
+
+    def dispose(self):
+        run(["docker", "image", "rm", self.uid])
+
+
+class Container:
+    def __init__(self, image: Union[str, Image], initd=False):
+        if isinstance(image, Image):
+            image_name = image.uid
+        else:
+            assert isinstance(image, str)
+            image_name = image
+
+        # minimal extra args required to run systemd
+        # https://developers.redhat.com/blog/2016/09/13/running-systemd-in-a-non-privileged-container#the_quest
+        extra_initd_args = []
+        if initd:
+            extra_initd_args = "--tmpfs /tmp --tmpfs /run -v /sys/fs/cgroup:/sys/fs/cgroup:ro".split()
+
+        self.uid = str(uuid.uuid4())
+
+        run(
+            ["docker", "run"]
+            + ["-t", "-d", "--name", self.uid]
+            + extra_initd_args
+            + [image_name]
+            + ["/usr/sbin/init" for _ in range(1) if initd]
+        ).rstrip()
+
+    def run(self, args: List[str]) -> str:
+        return run(["docker", "exec", self.uid] + args)
+
+    def copy_to(self, src_path: str, dst_path: str) -> None:
+        run(["docker", "cp", src_path, "{}:{}".format(self.uid, dst_path)])
+
+    def commit(self) -> Image:
+        output = run(["docker", "commit", self.uid])
+        uid = output.split(":")[1].rstrip()
+        return Image(uid)
+
+    def dispose(self):
+        run(["docker", "rm", "-f", self.uid])
+
+
+def ubuntu_image_with_fdb_helper(versioned: bool) -> Iterator[Optional[Image]]:
+    """
+    Return an image which has just the fdb deb packages installed.
+    """
+    builddir = os.environ.get("BUILDDIR")
+    if builddir is None:
+        assert False, "BUILDDIR environment variable not set"
+    debs = [
+        deb
+        for deb in glob.glob(os.path.join(builddir, "packages", "*.deb"))
+        if ("versioned" in deb) == versioned
+    ]
+    if not debs:
+        yield None
+        return
+
+    container = None
+    image = None
+    try:
+        container = Container("ubuntu")
+        for deb in debs:
+            container.copy_to(deb, "/opt")
+        container.run(["bash", "-c", "dpkg -i /opt/*.deb"])
+        container.run(["bash", "-c", "rm /opt/*.deb"])
+        image = container.commit()
+        yield image
+    finally:
+        if container is not None:
+            container.dispose()
+        if image is not None:
+            image.dispose()
+
+
+@pytest.fixture(scope="session")
+def ubuntu_image_with_fdb() -> Iterator[Optional[Image]]:
+    yield from ubuntu_image_with_fdb_helper(versioned=False)
+
+
+@pytest.fixture(scope="session")
+def ubuntu_image_with_fdb_versioned() -> Iterator[Optional[Image]]:
+    yield from ubuntu_image_with_fdb_helper(versioned=True)
+
+
+def centos_image_with_fdb_helper(versioned: bool) -> Iterator[Optional[Image]]:
+    """
+    Return an image which has just the fdb rpm packages installed.
+    """
+    builddir = os.environ.get("BUILDDIR")
+    if builddir is None:
+        assert False, "BUILDDIR environment variable not set"
+    rpms = [
+        rpm
+        for rpm in glob.glob(os.path.join(builddir, "packages", "*.rpm"))
+        if ("versioned" in rpm) == versioned
+    ]
+    if not rpms:
+        yield None
+        return
+
+    container = None
+    image = None
+    try:
+        container = Container("centos", initd=True)
+        for rpm in rpms:
+            container.copy_to(rpm, "/opt")
+        container.run(["bash", "-c", "yum install -y /opt/*.rpm"])
+        container.run(["bash", "-c", "rm /opt/*.rpm"])
+        image = container.commit()
+        yield image
+    finally:
+        if container is not None:
+            container.dispose()
+        if image is not None:
+            image.dispose()
+
+
+@pytest.fixture(scope="session")
+def centos_image_with_fdb() -> Iterator[Optional[Image]]:
+    yield from centos_image_with_fdb_helper(versioned=False)
+
+
+@pytest.fixture(scope="session")
+def centos_image_with_fdb_versioned() -> Iterator[Optional[Image]]:
+    yield from centos_image_with_fdb_helper(versioned=True)
+
+
+def pytest_generate_tests(metafunc):
+    if "linux_container" in metafunc.fixturenames:
+        metafunc.parametrize(
+            "linux_container",
+            ["ubuntu", "centos", "ubuntu-versioned", "centos-versioned"],
+            indirect=True,
+        )
+
+
+@pytest.fixture()
+def linux_container(
+    request,
+    ubuntu_image_with_fdb,
+    centos_image_with_fdb,
+    ubuntu_image_with_fdb_versioned,
+    centos_image_with_fdb_versioned,
+) -> Iterator[Container]:
+    """
+    Tests which accept this fixture will be run once for each supported platform, for each type of package (versioned or unversioned).
+    """
+    container: Optional[Container] = None
+    try:
+        if request.param == "ubuntu":
+            if ubuntu_image_with_fdb is None:
+                pytest.skip("No debian packages available to test")
+            container = Container(ubuntu_image_with_fdb)
+            container.run(
+                ["/etc/init.d/foundationdb", "start"]
+            )  # outside docker this shouldn't be necessary
+        elif request.param == "centos":
+            if centos_image_with_fdb is None:
+                pytest.skip("No rpm packages available to test")
+            container = Container(centos_image_with_fdb, initd=True)
+        elif request.param == "ubuntu-versioned":
+            if ubuntu_image_with_fdb is None:
+                pytest.skip("No versioned debian packages available to test")
+            container = Container(ubuntu_image_with_fdb_versioned)
+            container.run(
+                ["/etc/init.d/foundationdb", "start"]
+            )  # outside docker this shouldn't be necessary
+        elif request.param == "centos-versioned":
+            if centos_image_with_fdb is None:
+                pytest.skip("No versioned rpm packages available to test")
+            container = Container(centos_image_with_fdb_versioned, initd=True)
+        else:
+            assert False
+        yield container
+    finally:
+        if container is not None:
+            container.dispose()
+
+
+#################### BEGIN ACTUAL TESTS ####################
+
+
+def test_db_available(linux_container: Container):
+    linux_container.run(["fdbcli", "--exec", "get x"])
+
+
+def test_write(linux_container: Container, snapshot):
+    linux_container.run(["fdbcli", "--exec", "writemode on; set x y"])
+    assert snapshot == linux_container.run(["fdbcli", "--exec", "get x"])
+
+
+def test_fdbcli_help_text(linux_container: Container, snapshot):
+    assert snapshot == linux_container.run(["fdbcli", "--help"])
+
+
+def test_backup_restore(linux_container: Container, snapshot, tmp_path: pathlib.Path):
+    linux_container.run(["fdbcli", "--exec", "writemode on; set x y"])
+    assert snapshot == linux_container.run(
+        ["fdbbackup", "start", "-d", "file:///tmp/fdb_backup", "-w"]
+    )
+    linux_container.run(["fdbcli", "--exec", "writemode on; clear x"])
+    linux_container.run(
+        [
+            "bash",
+            "-c",
+            "fdbrestore start -r file://$(echo /tmp/fdb_backup/*) -w --dest_cluster_file /etc/foundationdb/fdb.cluster",
+        ]
+    )
+    assert snapshot == linux_container.run(["fdbcli", "--exec", "get x"])

--- a/packaging/multiversion/clients/postinst
+++ b/packaging/multiversion/clients/postinst
@@ -12,12 +12,17 @@ then
     mkdir ${PKG_CONFIG_DIR}
 fi
 
+getent group foundationdb >/dev/null || addgroup --system foundationdb
+getent passwd foundationdb >/dev/null || adduser --system --disabled-login --ingroup foundationdb --no-create-home --home /var/lib/foundationdb --gecos "FoundationDB" --shell /bin/false foundationdb
+
+mkdir -p /usr/lib/foundationdb/backup_agent
 
 update-alternatives --install /usr/bin/fdbcli fdbclients /usr/lib/foundationdb-@PROJECT_VERSION@/bin/fdbcli @ALTERNATIVES_PRIORITY@ \
     --slave /usr/bin/fdbbackup fdbbackup /usr/lib/foundationdb-@PROJECT_VERSION@/bin/fdbbackup \
     --slave /usr/bin/fdbrestore fdbrestore /usr/lib/foundationdb-@PROJECT_VERSION@/bin/fdbbackup \
     --slave /usr/bin/dr_agent dr_agent /usr/lib/foundationdb-@PROJECT_VERSION@/bin/fdbbackup \
     --slave /usr/bin/fdbdr fdbdr /usr/lib/foundationdb-@PROJECT_VERSION@/bin/fdbbackup \
+    --slave /usr/lib/foundationdb/backup_agent/backup_agent backup_agent /usr/lib/foundationdb-@PROJECT_VERSION@/bin/fdbbackup \
     --slave /usr/@LIB_DIR@/libfdb_c.so libfdb_c /usr/lib/foundationdb-@PROJECT_VERSION@/lib/libfdb_c.so \
     --slave /usr/@LIB_DIR@/pkgconfig/foundationdb-client.pc foundationdb-client.pc /usr/lib/foundationdb-@PROJECT_VERSION@/lib/pkgconfig/foundationdb-client.pc \
     --slave /usr/@LIB_DIR@/cmake/FoundationDB-Client FoundationDB-ClientConfig /usr/lib/foundationdb-@PROJECT_VERSION@/lib/cmake/FoundationDB-Client \

--- a/packaging/multiversion/server/postinst
+++ b/packaging/multiversion/server/postinst
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-
-update-alternatives --install /usr/sbin/fdbserver fdbserver /usr/lib/foundationdb-@PROJECT_VERSION@/sbin/fdbserver @ALTERNATIVES_PRIORITY@ \
-    --slave /usr/sbin/fdbmonitor fdbmonitor /usr/lib/foundationdb-@PROJECT_VERSION@/sbin/fdbmonitor

--- a/packaging/multiversion/server/postinst-deb
+++ b/packaging/multiversion/server/postinst-deb
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+getent group foundationdb >/dev/null || addgroup --system foundationdb
+getent passwd foundationdb >/dev/null || adduser --system --disabled-login --ingroup foundationdb --no-create-home --home /var/lib/foundationdb --gecos "FoundationDB" --shell /bin/false foundationdb
+
+mkdir -p /var/lib/foundationdb/data /var/log/foundationdb
+chown -R foundationdb:foundationdb /var/lib/foundationdb /var/log/foundationdb
+chmod -R 0700 /var/lib/foundationdb/data /var/log/foundationdb
+
+update-alternatives --install /usr/sbin/fdbserver fdbserver /usr/lib/foundationdb-@PROJECT_VERSION@/sbin/fdbserver @ALTERNATIVES_PRIORITY@ \
+    --slave /usr/lib/foundationdb/fdbmonitor fdbmonitor /usr/lib/foundationdb-@PROJECT_VERSION@/sbin/fdbmonitor \
+    --slave /etc/init.d/foundationdb foundationdb.service /usr/lib/foundationdb-@PROJECT_VERSION@/etc/init.d/foundationdb
+
+if mkdir /etc/foundationdb
+then
+    description=`LC_CTYPE=C tr -dc A-Za-z0-9 < /dev/urandom | head -c 8`
+    random_str=`LC_CTYPE=C tr -dc A-Za-z0-9 < /dev/urandom | head -c 8`
+    echo $description:$random_str@127.0.0.1:4500 > /etc/foundationdb/fdb.cluster
+    cp /usr/lib/foundationdb-@PROJECT_VERSION@/etc/foundationdb/foundationdb.conf /etc/foundationdb/foundationdb.conf
+    chown -R foundationdb:foundationdb /etc/foundationdb
+    chmod 775 /etc/foundationdb
+    chmod 0664 /etc/foundationdb/fdb.cluster
+    /etc/init.d/foundationdb start
+    /usr/bin/fdbcli -C /etc/foundationdb/fdb.cluster --exec "configure new single memory; status" --timeout 20
+fi

--- a/packaging/multiversion/server/postinst-rpm
+++ b/packaging/multiversion/server/postinst-rpm
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+getent group foundationdb >/dev/null || groupadd -r foundationdb >/dev/null
+getent passwd foundationdb >/dev/null || useradd -c "FoundationDB" -g foundationdb -s /bin/false -r -d /var/lib/foundationdb foundationdb >/dev/null
+
+mkdir -p /var/lib/foundationdb/data /var/log/foundationdb
+chown -R foundationdb:foundationdb /var/lib/foundationdb /var/log/foundationdb
+chmod -R 0700 /var/lib/foundationdb/data /var/log/foundationdb
+
+mkdir -p /usr/lib/foundationdb
+update-alternatives --install /usr/sbin/fdbserver fdbserver /usr/lib/foundationdb-@PROJECT_VERSION@/sbin/fdbserver @ALTERNATIVES_PRIORITY@ \
+    --slave /usr/lib/foundationdb/fdbmonitor fdbmonitor /usr/lib/foundationdb-@PROJECT_VERSION@/sbin/fdbmonitor \
+    --slave /lib/systemd/system/foundationdb.service foundationdb.service /usr/lib/foundationdb-@PROJECT_VERSION@/lib/systemd/system/foundationdb.service
+
+if mkdir /etc/foundationdb
+then
+    description=`LC_CTYPE=C tr -dc A-Za-z0-9 < /dev/urandom | head -c 8`
+    random_str=`LC_CTYPE=C tr -dc A-Za-z0-9 < /dev/urandom | head -c 8`
+    echo $description:$random_str@127.0.0.1:4500 > /etc/foundationdb/fdb.cluster
+    cp /usr/lib/foundationdb-@PROJECT_VERSION@/etc/foundationdb/foundationdb.conf /etc/foundationdb/foundationdb.conf
+    chown -R foundationdb:foundationdb /etc/foundationdb
+    chmod 775 /etc/foundationdb
+    chmod 0664 /etc/foundationdb/fdb.cluster
+    /usr/bin/systemctl enable foundationdb >/dev/null 2>&1
+    /usr/bin/systemctl start foundationdb >/dev/null 2>&1
+    /usr/bin/fdbcli -C /etc/foundationdb/fdb.cluster --exec "configure new single memory; status" --timeout 20
+fi


### PR DESCRIPTION
Cherry pick https://github.com/apple/foundationdb/pull/4818 to release-7.0



Recently we've been having some problems with our packaging (e.g. #4731 ). This PR adds some basic tests we can run to check that our generated rpm and deb packages behave as expected after making packaging changes.

I tested leaking docker images/containers by running the tests and interrupting them with ctrl-c. These tests do a pretty good job, but I added some instructions to the README about what to do just in case.

This change now also incorporates the fixes from #5391, and adds tests for the versioned packages.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
