### PR TITLE
Add first stage of rollback and rollforward to ConfigNode

### DIFF
--- a/fdbserver/ConfigFollowerInterface.h
+++ b/fdbserver/ConfigFollowerInterface.h
@@ -150,6 +150,20 @@ struct ConfigFollowerCompactRequest {
 	}
 };
 
+struct ConfigFollowerRollbackRequest {
+	static constexpr FileIdentifier file_identifier = 765456;
+	Version version{ 0 };
+	ReplyPromise<Void> reply;
+
+	ConfigFollowerRollbackRequest() = default;
+	explicit ConfigFollowerRollbackRequest(Version version) : version(version) {}
+
+	template <class Ar>
+	void serialize(Ar& ar) {
+		serializer(ar, version, reply);
+	}
+};
+
 struct ConfigFollowerGetCommittedVersionReply {
 	static constexpr FileIdentifier file_identifier = 9214735;
 	Version version;
@@ -185,6 +199,7 @@ public:
 	RequestStream<ConfigFollowerGetSnapshotAndChangesRequest> getSnapshotAndChanges;
 	RequestStream<ConfigFollowerGetChangesRequest> getChanges;
 	RequestStream<ConfigFollowerCompactRequest> compact;
+	RequestStream<ConfigFollowerRollbackRequest> rollback;
 	RequestStream<ConfigFollowerGetCommittedVersionRequest> getCommittedVersion;
 
 	ConfigFollowerInterface();
@@ -196,6 +211,6 @@ public:
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, _id, getSnapshotAndChanges, getChanges, compact, getCommittedVersion);
+		serializer(ar, _id, getSnapshotAndChanges, getChanges, compact, rollback, getCommittedVersion);
 	}
 };

--- a/fdbserver/ConfigFollowerInterface.h
+++ b/fdbserver/ConfigFollowerInterface.h
@@ -166,18 +166,22 @@ struct ConfigFollowerRollbackRequest {
 
 struct ConfigFollowerRollforwardRequest {
 	static constexpr FileIdentifier file_identifier = 678894;
-	Version version{ 0 };
+	Version beginVersion{ 0 };
+	Version endVersion{ 0 };
 	Standalone<VectorRef<VersionedConfigMutationRef>> mutations;
+	std::map<Version, ConfigCommitAnnotationRef> annotations;
 	ReplyPromise<Void> reply;
 
 	ConfigFollowerRollforwardRequest() = default;
-	explicit ConfigFollowerRollforwardRequest(Version version,
-	                                          Standalone<VectorRef<VersionedConfigMutationRef>> mutations)
-	  : version(version), mutations(mutations) {}
+	explicit ConfigFollowerRollforwardRequest(Version beginVersion,
+	                                          Version endVersion,
+	                                          Standalone<VectorRef<VersionedConfigMutationRef>> mutations,
+	                                          std::map<Version, ConfigCommitAnnotationRef> annotations)
+	  : beginVersion(beginVersion), endVersion(endVersion), mutations(mutations), annotations(annotations) {}
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, version, mutations, reply);
+		serializer(ar, beginVersion, endVersion, mutations, annotations, reply);
 	}
 };
 

--- a/fdbserver/ConfigFollowerInterface.h
+++ b/fdbserver/ConfigFollowerInterface.h
@@ -164,6 +164,23 @@ struct ConfigFollowerRollbackRequest {
 	}
 };
 
+struct ConfigFollowerRollforwardRequest {
+	static constexpr FileIdentifier file_identifier = 678894;
+	Version version{ 0 };
+	Standalone<VectorRef<VersionedConfigMutationRef>> mutations;
+	ReplyPromise<Void> reply;
+
+	ConfigFollowerRollforwardRequest() = default;
+	explicit ConfigFollowerRollforwardRequest(Version version,
+	                                          Standalone<VectorRef<VersionedConfigMutationRef>> mutations)
+	  : version(version), mutations(mutations) {}
+
+	template <class Ar>
+	void serialize(Ar& ar) {
+		serializer(ar, version, mutations, reply);
+	}
+};
+
 struct ConfigFollowerGetCommittedVersionReply {
 	static constexpr FileIdentifier file_identifier = 9214735;
 	Version version;
@@ -200,6 +217,7 @@ public:
 	RequestStream<ConfigFollowerGetChangesRequest> getChanges;
 	RequestStream<ConfigFollowerCompactRequest> compact;
 	RequestStream<ConfigFollowerRollbackRequest> rollback;
+	RequestStream<ConfigFollowerRollforwardRequest> rollforward;
 	RequestStream<ConfigFollowerGetCommittedVersionRequest> getCommittedVersion;
 
 	ConfigFollowerInterface();
@@ -211,6 +229,6 @@ public:
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, _id, getSnapshotAndChanges, getChanges, compact, rollback, getCommittedVersion);
+		serializer(ar, _id, getSnapshotAndChanges, getChanges, compact, rollback, rollforward, getCommittedVersion);
 	}
 };

--- a/fdbserver/ConfigFollowerInterface.h
+++ b/fdbserver/ConfigFollowerInterface.h
@@ -166,22 +166,22 @@ struct ConfigFollowerRollbackRequest {
 
 struct ConfigFollowerRollforwardRequest {
 	static constexpr FileIdentifier file_identifier = 678894;
-	Version beginVersion{ 0 };
-	Version endVersion{ 0 };
+	Version lastKnownCommitted{ 0 };
+	Version target{ 0 };
 	Standalone<VectorRef<VersionedConfigMutationRef>> mutations;
-	std::map<Version, ConfigCommitAnnotationRef> annotations;
+	Standalone<VectorRef<VersionedConfigCommitAnnotationRef>> annotations;
 	ReplyPromise<Void> reply;
 
 	ConfigFollowerRollforwardRequest() = default;
-	explicit ConfigFollowerRollforwardRequest(Version beginVersion,
-	                                          Version endVersion,
+	explicit ConfigFollowerRollforwardRequest(Version lastKnownCommitted,
+	                                          Version target,
 	                                          Standalone<VectorRef<VersionedConfigMutationRef>> mutations,
-	                                          std::map<Version, ConfigCommitAnnotationRef> annotations)
-	  : beginVersion(beginVersion), endVersion(endVersion), mutations(mutations), annotations(annotations) {}
+	                                          Standalone<VectorRef<VersionedConfigCommitAnnotationRef>> annotations)
+	  : lastKnownCommitted(lastKnownCommitted), target(target), mutations(mutations), annotations(annotations) {}
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, beginVersion, endVersion, mutations, annotations, reply);
+		serializer(ar, lastKnownCommitted, target, mutations, annotations, reply);
 	}
 };
 

--- a/fdbserver/ConfigNode.actor.cpp
+++ b/fdbserver/ConfigNode.actor.cpp
@@ -327,7 +327,7 @@ class ConfigNodeImpl {
 				continue;
 			}
 			// Mutations should be in ascending version order.
-			ASSERT(mutation.version >= latestVersion);
+			ASSERT_GE(mutation.version, latestVersion);
 			if (mutation.version > latestVersion) {
 				latestVersion = mutation.version;
 				index = 0;

--- a/fdbserver/ConfigNode.actor.cpp
+++ b/fdbserver/ConfigNode.actor.cpp
@@ -496,7 +496,7 @@ class ConfigNodeImpl {
 			req.reply.sendError(not_committed());
 			return Void();
 		}
-		ASSERT(req.mutations[0].version > currentGeneration.committedVersion);
+		ASSERT_GT(req.mutations[0].version, currentGeneration.committedVersion);
 		wait(commitMutations(self, req.mutations, req.annotations, req.target));
 		req.reply.send(Void());
 		return Void();

--- a/fdbserver/ConfigNode.actor.cpp
+++ b/fdbserver/ConfigNode.actor.cpp
@@ -461,7 +461,7 @@ class ConfigNodeImpl {
 	}
 
 	ACTOR static Future<Void> rollback(ConfigNodeImpl* self, ConfigFollowerRollbackRequest req) {
-		// TODO: Actaully delete mutations from kvstore (similar to compact)
+		// TODO: Actually delete mutations from kvstore (similar to compact)
 		state ConfigGeneration generation = wait(getGeneration(self));
 		if (req.version < generation.committedVersion) {
 			generation.committedVersion = req.version;


### PR DESCRIPTION
Add rollback and rollforward functionality to `ConfigNode`s, which run on each coordinator. This allows the `ConfigBroadcaster` to update an out of date `ConfigNode` (rollforward) or to tell it to rollback any changes it may have mistakenly made.

Ran `ConfigDB` unit tests a bunch and didn't see any failures. Also passed 10k correctness.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
