### PR TITLE
Disallow usage of `wait` outside of ACTORs

### DIFF
--- a/flow/actorcompiler.h
+++ b/flow/actorcompiler.h
@@ -18,6 +18,23 @@
  * limitations under the License.
  */
 
+#ifdef POST_ACTOR_COMPILER
+#ifndef FLOW_DEFINED_WAIT_AND_WAIT_NEXT
+#define FLOW_DEFINED_WAIT_AND_WAIT_NEXT
+
+// These should all be re-written by the actor compiler. We don't want to
+// accidentally call them from something that's not an actor. `wait` is such a
+// common identifier that `wait` calls outside ACTORs might accidentally
+// compile.
+template <class T>
+T wait(const Future<T>&) = delete;
+void wait(const Never&) = delete;
+template <class T>
+T waitNext(const FutureStream<T>&) = delete;
+
+#endif
+#endif
+
 #ifndef POST_ACTOR_COMPILER
 
 template <typename T>


### PR DESCRIPTION
Before this change, calling `wait` outside of an ACTOR would compile (!!)

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
