### PR TITLE
Unit tests require a match from the test pattern in order to be successful

### DIFF
--- a/fdbserver/workloads/UnitTests.actor.cpp
+++ b/fdbserver/workloads/UnitTests.actor.cpp
@@ -110,7 +110,15 @@ struct UnitTestWorkload : TestWorkload {
 				tests.push_back(test);
 			}
 		}
+
 		fprintf(stdout, "Found %zu tests\n", tests.size());
+
+		if (tests.size() == 0) {
+			TraceEvent(SevError, "NoMatchingUnitTests").detail("TestPattern", self->testPattern);
+			++self->testsFailed;
+			return Void();
+		}
+
 		deterministicRandom()->randomShuffle(tests);
 		if (self->testRunLimit > 0 && tests.size() > self->testRunLimit)
 			tests.resize(self->testRunLimit);


### PR DESCRIPTION
This avoids cases where a typo in the pattern might lead one to believe that their tests were all successful.

Tested by running correctness with an invalid pattern to see that the tests failed and a valid pattern to see that they succeeded.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

