### PR TITLE
Stop using solarized theme for pygments (release-6.2)

### DIFF
--- a/documentation/sphinx/conf.py
+++ b/documentation/sphinx/conf.py
@@ -95,9 +95,6 @@ exclude_patterns = []
 # output. They are ignored by default.
 #show_authors = False
 
-# The name of the Pygments (syntax highlighting) style to use.
-pygments_style = 'solarizedlight'
-
 # A list of ignored prefixes for module index sorting.
 #modindex_common_prefix = []
 

--- a/documentation/sphinx/requirements.txt
+++ b/documentation/sphinx/requirements.txt
@@ -3,4 +3,3 @@ setuptools>=20.10.0
 sphinx==1.5.6
 sphinx-bootstrap-theme==0.4.8
 docutils==0.16
-pygments-style-solarized


### PR DESCRIPTION
Cherry pick https://github.com/apple/foundationdb/pull/5473 to release-6.2



It's suddenly unavailable, which is breaking the documentation build.

Before code samples looked like 
<img width="858" alt="image" src="https://user-images.githubusercontent.com/63815641/131016767-0d493c55-5378-4b1f-8c51-31094480828b.png">
and after
<img width="853" alt="image" src="https://user-images.githubusercontent.com/63815641/131016823-188effd5-984e-4379-8ea1-42a3e784ad3b.png">

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
