### PR TITLE
Support building with go 1.16 and higher (release-7.0)

### DIFF
--- a/bindings/go/CMakeLists.txt
+++ b/bindings/go/CMakeLists.txt
@@ -43,7 +43,8 @@ set(go_options_file ${GO_DEST}/src/fdb/generated.go)
 
 set(go_env GOPATH=${GOPATH}
   C_INCLUDE_PATH=${CMAKE_BINARY_DIR}/bindings/c/foundationdb:${CMAKE_SOURCE_DIR}/bindings/c
-  CGO_LDFLAGS=-L${CMAKE_BINARY_DIR}/lib)
+  CGO_LDFLAGS=-L${CMAKE_BINARY_DIR}/lib
+  GO111MODULE=auto)
 
 foreach(src_file IN LISTS SRCS)
   set(dest_file ${GO_DEST}/${src_file})


### PR DESCRIPTION
This is a cherry-pick of #5480.

There is a need to upgrade go in the developer container so we can use the latest version of Ginkgo that fixes several issues in our Kubernetes test suite. A small flag is needed since we do not install within the module FDB for go.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
