### PR TITLE
Add fix for KillWorker unit test

### DIFF
--- a/fdbserver/ConfigNode.actor.cpp
+++ b/fdbserver/ConfigNode.actor.cpp
@@ -488,6 +488,10 @@ public:
 	Future<Void> serve(ConfigTransactionInterface const& cti) { return serve(this, &cti); }
 
 	Future<Void> serve(ConfigFollowerInterface const& cfi) { return serve(this, &cfi); }
+
+	void close() { kvStore.close(); }
+
+	Future<Void> onClosed() { return kvStore.onClosed(); }
 };
 
 ConfigNode::ConfigNode(std::string const& folder) : impl(PImpl<ConfigNodeImpl>::create(folder)) {}
@@ -500,4 +504,12 @@ Future<Void> ConfigNode::serve(ConfigTransactionInterface const& cti) {
 
 Future<Void> ConfigNode::serve(ConfigFollowerInterface const& cfi) {
 	return impl->serve(cfi);
+}
+
+void ConfigNode::close() {
+	impl->close();
+}
+
+Future<Void> ConfigNode::onClosed() {
+	return impl->onClosed();
 }

--- a/fdbserver/ConfigNode.h
+++ b/fdbserver/ConfigNode.h
@@ -34,4 +34,8 @@ public:
 	~ConfigNode();
 	Future<Void> serve(ConfigTransactionInterface const&);
 	Future<Void> serve(ConfigFollowerInterface const&);
+
+public: // Testing
+	void close();
+	Future<Void> onClosed();
 };

--- a/fdbserver/LocalConfiguration.actor.cpp
+++ b/fdbserver/LocalConfiguration.actor.cpp
@@ -380,6 +380,10 @@ public:
 		return initFuture;
 	}
 
+	void close() { kvStore.close(); }
+
+	Future<Void> onClosed() { return kvStore.onClosed(); }
+
 	static void testManualKnobOverridesInvalidName() {
 		std::map<std::string, std::string> invalidOverrides;
 		invalidOverrides["knob_name_that_does_not_exist"] = "";
@@ -454,6 +458,14 @@ Future<Void> LocalConfiguration::consume(ConfigBroadcastInterface const& broadca
 Future<Void> LocalConfiguration::addChanges(Standalone<VectorRef<VersionedConfigMutationRef>> changes,
                                             Version mostRecentVersion) {
 	return impl->addChanges(changes, mostRecentVersion);
+}
+
+void LocalConfiguration::close() {
+	impl->close();
+}
+
+Future<Void> LocalConfiguration::onClosed() {
+	return impl->onClosed();
 }
 
 UID LocalConfiguration::getID() const {

--- a/fdbserver/LocalConfiguration.h
+++ b/fdbserver/LocalConfiguration.h
@@ -65,4 +65,6 @@ public:
 public: // Testing
 	Future<Void> addChanges(Standalone<VectorRef<VersionedConfigMutationRef>> versionedMutations,
 	                        Version mostRecentVersion);
+	void close();
+	Future<Void> onClosed();
 };

--- a/fdbserver/OnDemandStore.actor.cpp
+++ b/fdbserver/OnDemandStore.actor.cpp
@@ -37,9 +37,7 @@ OnDemandStore::OnDemandStore(std::string const& folder, UID myID, std::string co
   : folder(folder), myID(myID), store(nullptr), prefix(prefix) {}
 
 OnDemandStore::~OnDemandStore() {
-	if (store) {
-		store->close();
-	}
+	close();
 }
 
 IKeyValueStore* OnDemandStore::get() {
@@ -58,6 +56,23 @@ IKeyValueStore* OnDemandStore::operator->() {
 	return get();
 }
 
-Future<Void> OnDemandStore::getError() const {
+Future<Void> OnDemandStore::getError() {
 	return onErr(err.getFuture());
+}
+
+Future<Void> OnDemandStore::onClosed() {
+	return store->onClosed();
+}
+
+void OnDemandStore::dispose() {
+	if (store) {
+		store->dispose();
+		store = nullptr;
+	}
+}
+void OnDemandStore::close() {
+	if (store) {
+		store->close();
+		store = nullptr;
+	}
 }

--- a/fdbserver/OnDemandStore.h
+++ b/fdbserver/OnDemandStore.h
@@ -41,8 +41,8 @@ public:
 	bool exists() const;
 	IKeyValueStore* operator->();
 
-	Future<Void> getError();
-	Future<Void> onClosed();
-	void dispose();
-	void close();
+	Future<Void> getError() override;
+	Future<Void> onClosed() override;
+	void dispose() override;
+	void close() override;
 };

--- a/fdbserver/OnDemandStore.h
+++ b/fdbserver/OnDemandStore.h
@@ -26,7 +26,7 @@
 #include "fdbserver/IKeyValueStore.h"
 
 // Create a key value store if and only if it is actually used
-class OnDemandStore : NonCopyable {
+class OnDemandStore : public IClosable, NonCopyable {
 	std::string folder;
 	UID myID;
 	IKeyValueStore* store;
@@ -40,5 +40,9 @@ public:
 	IKeyValueStore* get();
 	bool exists() const;
 	IKeyValueStore* operator->();
-	Future<Void> getError() const;
+
+	Future<Void> getError();
+	Future<Void> onClosed();
+	void dispose();
+	void close();
 };


### PR DESCRIPTION
The unit test `/fdbserver/ConfigDB/TransactionToLocalConfig/KillWorker` was causing occasional failures when run using the `RandomUnitTests.toml` test. Initial investigation showed Sev40s in the form:

```
<Event Severity="40" ErrorKind="Unset" Time="6.000321" DateTime="2021-08-27T16:51:27Z" Type="RenameFile" Machine="0.0.0.0:0" ID="0000000000000000" FromPath="simfdb/unittests/globalconf-0.fdq.part" ToPath="simfdb/unittests/globalconf-0.fdq" UnixErrorCode="2" UnixError="No such file or directory" ThreadID="5087479302342525366" Backtrace="addr2line -e fdbserver.debug -p -C -f -i 0x579b467 0x57e21e0 0x57e2472 0x57e2cac 0x5796d39 0x55f5b1b 0x55f56c0 0x55f508d 0x55f4f92 0x55f115b 0x36cb1e4 0x36cb0d3 0x36caf45 0x36ca7af 0x36c5273 0x36c480a 0x36c32d3 0x36c2fde 0x36c320f 0x36c2df3 0x36cc0cb 0x36c2994 0x1e6337f 0x1fbad0d 0x1fbb01b 0x1fbab74 0x1e91472 0x1e90c03 0x55fe142 0x55fdeb8 0x55fda53 0x55fd84f 0x55fd59b 0x55fdee0 0x55fda53 0x55fec9b 0x55fd514 0x1e91472 0x1e90c03 0x5754dca 0x5738087 0x55b2cef 0x2b84322 0x7ffff7105555" LogGroup="default" />
```

`RandomUnitTests.toml` uses the `UnitTests` workload. The `UnitTests` workload creates a temporary directory for persisted files while the unit test is running, then deletes the directory after the unit test completes. After looking into the issue, what appeared to be happening was the `/fdbserver/ConfigDB/TransactionToLocalConfig/KillWorker` unit test would create a `ConfigNode` which in turn creates a key-value store persisted to a file named `globalconf-0.fdq` and `globalconf-1.fdq`. It looks like there is some asynchronous work going on in the background (by the simulator) to atomically create these files. Due to how quickly the unit test was returning, the temporary directory created for these files was erased by the completion of the unit test, and the simulator would then fail with a file not found error.

To fix this issue, ~~I just added some more work to the unit test, so there is more time for initial setup to complete. Perhaps there is an additional hook that can be `wait`ed on, but this quick solution seems to work as well~~. Per the conversation below, I updated `OnDemandStore` to inherit `IClosable` and provide a future which triggers when it is fully closed.

Passed 10k `/fdbserver/ConfigDB/TransactionToLocalConfig/KillWorker` unit tests. Passed 100k `/fdbserver/ConfigDB` unit tests. Passed 10k correctness tests.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
