### PR TITLE
Remove checkRegions in shouldTriggerRecoveryDueToDegradedServers

### DIFF
--- a/fdbserver/ClusterController.actor.cpp
+++ b/fdbserver/ClusterController.actor.cpp
@@ -2934,12 +2934,6 @@ public:
 			return false;
 		}
 
-		if (db.config.regions.size() > 1 && db.config.regions[0].priority > db.config.regions[1].priority &&
-		    db.config.regions[0].dcId != clusterControllerDcId.get() && versionDifferenceUpdated &&
-		    datacenterVersionDifference < SERVER_KNOBS->MAX_VERSION_DIFFERENCE) {
-			checkRegions(db.config.regions);
-		}
-
 		for (const auto& excludedServer : degradedServers) {
 			if (dbi.master.addresses().contains(excludedServer)) {
 				return true;


### PR DESCRIPTION
checkRegions may cause DC priority change, which shouldn't be done in CC health monitor.

20210827-205304-zhewu_5489-39c30994bd57aa10        compressed=True data_size=25177840 duration=5651374 ended=101579 fail=1 fail_fast=10 max_runs=100000 pass=100105 priority=100 remaining=0 runtime=1:26:17 sanity=False started=101592 stopped=20210827-221921 submitted=20210827-205304 timeout=5400 username=zhewu_5489 (failed one is a tmp file non exist error, and not reproducable).

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
