### PR TITLE
Refactor our PRIVATE_EXCEPT_FOR_TLSCONFIG_CPP macro to be compatible with clang-format

### DIFF
--- a/flow/TLSConfig.actor.cpp
+++ b/flow/TLSConfig.actor.cpp
@@ -18,7 +18,7 @@
  * limitations under the License.
  */
 
-#define PRIVATE_EXCEPT_FOR_TLSCONFIG_CPP public
+#define PRIVATE_EXCEPT_FOR_TLSCONFIG_CPP
 #include "flow/TLSConfig.actor.h"
 #undef PRIVATE_EXCEPT_FOR_TLSCONFIG_CPP
 

--- a/flow/TLSConfig.actor.h
+++ b/flow/TLSConfig.actor.h
@@ -94,10 +94,6 @@ enum class TLSEndpointType { UNSET = 0, CLIENT, SERVER };
 class TLSConfig;
 template <typename T>
 class LoadAsyncActorState;
-// TODO: Remove this once this code is merged with master/to-be 7.0 and actors can access private variables.
-#ifndef PRIVATE_EXCEPT_FOR_TLSCONFIG_CPP
-#define PRIVATE_EXCEPT_FOR_TLSCONFIG_CPP private
-#endif
 
 class LoadedTLSConfig {
 public:
@@ -123,7 +119,10 @@ public:
 
 	void print(FILE* fp);
 
-PRIVATE_EXCEPT_FOR_TLSCONFIG_CPP:
+#ifndef PRIVATE_EXCEPT_FOR_TLSCONFIG_CPP
+private:
+#endif
+
 	std::string tlsCertBytes, tlsKeyBytes, tlsCABytes;
 	std::string tlsPassword;
 	std::vector<std::string> tlsVerifyPeers;
@@ -206,8 +205,8 @@ public:
 	std::string getKeyPathSync() const;
 	std::string getCAPathSync() const;
 
-PRIVATE_EXCEPT_FOR_TLSCONFIG_CPP:
-    ACTOR static Future<LoadedTLSConfig> loadAsync(const TLSConfig* self);
+private:
+	ACTOR static Future<LoadedTLSConfig> loadAsync(const TLSConfig* self);
 	template <typename T>
 	friend class LoadAsyncActorState;
 


### PR DESCRIPTION
This also removes one use of the macro that is no longer needed now that actors can access private members.

Passed 10K correctness with 1 seemingly unrelated redwood failure.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.
