### PR TITLE
When using an external client, report the larger of the primary and external network thread busyness (release-7.0)

### DIFF
--- a/fdbclient/MultiVersionTransaction.actor.cpp
+++ b/fdbclient/MultiVersionTransaction.actor.cpp
@@ -993,12 +993,17 @@ ThreadFuture<Void> MultiVersionDatabase::createSnapshot(const StringRef& uid, co
 }
 
 // Get network thread busyness
+// Return the busyness for the main thread. When using external clients, take the larger of the local client
+// and the external client's busyness.
 double MultiVersionDatabase::getMainThreadBusyness() {
+	ASSERT(g_network);
+
+	double localClientBusyness = g_network->networkInfo.metrics.networkBusyness;
 	if (dbState->db) {
-		return dbState->db->getMainThreadBusyness();
+		return std::max(dbState->db->getMainThreadBusyness(), localClientBusyness);
 	}
 
-	return 0;
+	return localClientBusyness;
 }
 
 // Returns the protocol version reported by the coordinator this client is connected to


### PR DESCRIPTION
This is a cherry-pick of #5484 

The main thread busyness API currently reports the busyness of the network thread corresponding with the database being used. For external clients, we are also impacted by the primary network thread, so this change causes us to report the larger of the two busyness numbers for the two network threads.

Tested manually. Correctness not yet run due to it being in a broken state.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
