### PR TITLE
Busyness API incorporates a burstiness score based on the max busyness interval in a measurement period (release-7.0)

### DIFF
--- a/fdbclient/Knobs.cpp
+++ b/fdbclient/Knobs.cpp
@@ -249,6 +249,10 @@ void ClientKnobs::initialize(bool randomize) {
 	init( TAG_THROTTLE_RECHECK_INTERVAL,            5.0 ); if( randomize && BUGGIFY ) TAG_THROTTLE_RECHECK_INTERVAL = 0.0;
 	init( TAG_THROTTLE_EXPIRATION_INTERVAL,        60.0 ); if( randomize && BUGGIFY ) TAG_THROTTLE_EXPIRATION_INTERVAL = 1.0;
 
+	// busyness reporting
+	init( BUSYNESS_SPIKE_START_THRESHOLD,         0.100 );
+	init( BUSYNESS_SPIKE_SATURATED_THRESHOLD,     0.500 );
+
 	// clang-format on
 }
 

--- a/fdbclient/Knobs.h
+++ b/fdbclient/Knobs.h
@@ -233,6 +233,10 @@ public:
 	double TAG_THROTTLE_RECHECK_INTERVAL;
 	double TAG_THROTTLE_EXPIRATION_INTERVAL;
 
+	// busyness reporting
+	double BUSYNESS_SPIKE_START_THRESHOLD;
+	double BUSYNESS_SPIKE_SATURATED_THRESHOLD;
+
 	ClientKnobs();
 	void initialize(bool randomize = false);
 };

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -2004,8 +2004,25 @@ ACTOR Future<Void> monitorNetworkBusyness() {
 			tracker.windowedTimer = now();
 		}
 
-		g_network->networkInfo.metrics.networkBusyness =
-		    std::min(elapsed, tracker.duration) / elapsed; // average duration spent doing "work"
+		double busyFraction = std::min(elapsed, tracker.duration) / elapsed;
+
+		// The burstiness score is an indicator of the maximum busyness spike over the measurement interval.
+		// It scales linearly from 0 to 1 as the largest burst goes from the start to the saturation threshold.
+		// This allows us to account for saturation that happens in smaller bursts than the measurement interval.
+		//
+		// Burstyness will not be calculated if the saturation threshold is smaller than the start threshold or
+		// if either value is negative.
+		double burstiness = 0;
+		if (CLIENT_KNOBS->BUSYNESS_SPIKE_START_THRESHOLD >= 0 &&
+		    CLIENT_KNOBS->BUSYNESS_SPIKE_SATURATED_THRESHOLD >= CLIENT_KNOBS->BUSYNESS_SPIKE_START_THRESHOLD) {
+			burstiness = std::min(1.0,
+			                      std::max(0.0, tracker.maxDuration - CLIENT_KNOBS->BUSYNESS_SPIKE_START_THRESHOLD) /
+			                          std::max(1e-6,
+			                                   CLIENT_KNOBS->BUSYNESS_SPIKE_SATURATED_THRESHOLD -
+			                                       CLIENT_KNOBS->BUSYNESS_SPIKE_START_THRESHOLD));
+		}
+
+		g_network->networkInfo.metrics.networkBusyness = std::max(busyFraction, burstiness);
 
 		tracker.duration = 0;
 		tracker.maxDuration = 0;

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -2010,7 +2010,7 @@ ACTOR Future<Void> monitorNetworkBusyness() {
 		// It scales linearly from 0 to 1 as the largest burst goes from the start to the saturation threshold.
 		// This allows us to account for saturation that happens in smaller bursts than the measurement interval.
 		//
-		// Burstyness will not be calculated if the saturation threshold is smaller than the start threshold or
+		// Burstiness will not be calculated if the saturation threshold is smaller than the start threshold or
 		// if either value is negative.
 		double burstiness = 0;
 		if (CLIENT_KNOBS->BUSYNESS_SPIKE_START_THRESHOLD >= 0 &&


### PR DESCRIPTION
This is a cherry-pick of #5495.

This allows us to detect situations where the network thread is busy at smaller time intervals than our measurement period in a way that would impact performance.

The score is computed based on the value of the maximum non-idle time in the measurement interval, and converts that duration to a 0-1 scale. This is done linearly from the configured range (right now 100ms - 500ms), so 100ms corresponds to 0 and 500ms corresponds to 1. These values were intended to be somewhat conservative, but they can be configured differently via knob and we could also change the defaults.

Tested manually using a client that generated bursts of work.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
