### PR TITLE
Exclude redwood from part 1 of restarting tests that are from versions < 6.3 (release-7.0)

### DIFF
--- a/tests/restarting/from_5.0.0/CycleTestRestart-1.txt
+++ b/tests/restarting/from_5.0.0/CycleTestRestart-1.txt
@@ -1,3 +1,5 @@
+storageEngineExcludeTypes=3
+
 testTitle=Clogged
 clearAfterTest=false 
 

--- a/tests/restarting/from_5.0.0/StorefrontTestRestart-1.txt
+++ b/tests/restarting/from_5.0.0/StorefrontTestRestart-1.txt
@@ -1,3 +1,5 @@
+storageEngineExcludeTypes=3
+
 testTitle=StorefrontTest
 clearAfterTest=false 
 testName=Storefront

--- a/tests/restarting/from_5.1.7/DrUpgradeRestart-1.txt
+++ b/tests/restarting/from_5.1.7/DrUpgradeRestart-1.txt
@@ -1,3 +1,5 @@
+storageEngineExcludeTypes=3
+
 extraDB=3
 
 testTitle=DrUpgrade

--- a/tests/restarting/from_5.2.0/ClientTransactionProfilingCorrectness-1.txt
+++ b/tests/restarting/from_5.2.0/ClientTransactionProfilingCorrectness-1.txt
@@ -1,3 +1,5 @@
+storageEngineExcludeTypes=3
+
 testTitle=ClientTransactionProfilingCorrectness
 clearAfterTest=false
 runSetup=true

--- a/tests/restarting/from_6.2.33/SnapCycleRestart-1.txt
+++ b/tests/restarting/from_6.2.33/SnapCycleRestart-1.txt
@@ -1,3 +1,5 @@
+storageEngineExcludeTypes=3
+
 ;Take snap and do cycle test
 testTitle=SnapCyclePre
 clearAfterTest=false

--- a/tests/restarting/from_6.2.33/SnapTestAttrition-1.txt
+++ b/tests/restarting/from_6.2.33/SnapTestAttrition-1.txt
@@ -1,3 +1,5 @@
+storageEngineExcludeTypes=3
+
 ;write 1000 Keys ending with even numbers
 testTitle=SnapTestPre
 clearAfterTest=false

--- a/tests/restarting/from_6.2.33/SnapTestRestart-1.txt
+++ b/tests/restarting/from_6.2.33/SnapTestRestart-1.txt
@@ -1,3 +1,5 @@
+storageEngineExcludeTypes=3
+
 ;write 1000 Keys ending with even numbers
 testTitle=SnapTestPre
 clearAfterTest=false

--- a/tests/restarting/from_6.2.33/SnapTestSimpleRestart-1.txt
+++ b/tests/restarting/from_6.2.33/SnapTestSimpleRestart-1.txt
@@ -1,3 +1,5 @@
+storageEngineExcludeTypes=3
+
 ;write 1000 Keys ending with even number
 testTitle=SnapSimplePre
 clearAfterTest=false

--- a/tests/restarting/to_6.3.10/CycleTestRestart-1.txt
+++ b/tests/restarting/to_6.3.10/CycleTestRestart-1.txt
@@ -1,4 +1,4 @@
-storageEngineExcludeTypes=-1,-2
+storageEngineExcludeTypes=3
 maxTLogVersion=6
 disableTss=true
 testTitle=Clogged


### PR DESCRIPTION
This is a cherry-pick of https://github.com/apple/foundationdb/pull/5508 onto `release-7.0` with the additional change to the test file of `tests/restarting/to_6.3.10/CycleTestRestart-1.txt` since a 7.0 downgrade will be to 6.3

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
