### PR TITLE
Disable perpetual_storage_wiggle when no fault injection allowed

### DIFF
--- a/fdbserver/SimulatedCluster.actor.cpp
+++ b/fdbserver/SimulatedCluster.actor.cpp
@@ -1240,7 +1240,7 @@ void SimulationConfig::setRandomConfig() {
 	// 	.detail("GRVProxyCount", db.grvProxyCount)
 	// 	.detail("ResolverCount", db.resolverCount);
 
-	if (deterministicRandom()->random01() < 0.5) {
+	if (deterministicRandom()->random01() < 0.5 || !faultInjectionActivated) {
 		// TraceEvent("SimulatedConfigRandom").detail("PerpetualWiggle", 0);
 		set_config("perpetual_storage_wiggle=0");
 	} else {


### PR DESCRIPTION
This feature will cause recovery by modifying key
"\xff/conf/perpetual_storage_wiggle".

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
