### PR TITLE
Bring back optimization that avoids hop to network thread (release-6.3)

### DIFF
--- a/flow/ThreadHelper.actor.h
+++ b/flow/ThreadHelper.actor.h
@@ -321,10 +321,12 @@ public:
 		if (isReadyUnsafe()) {
 			delref();
 		} else {
-			onMainThreadVoid([this]() {
-				this->cancelFuture.cancel();
-				this->delref();
-			});
+			onMainThreadVoid(
+			    [this]() {
+				    this->cancelFuture.cancel();
+				    this->delref();
+			    },
+			    nullptr);
 		}
 	}
 

--- a/flow/ThreadHelper.actor.h
+++ b/flow/ThreadHelper.actor.h
@@ -150,7 +150,7 @@ public:
 	enum Status { Unset, NeverSet, Set, ErrorSet }; // order is important
 	// volatile long referenceCount;
 	ThreadSpinLock mutex;
-	Status status;
+	std::atomic<Status> status;
 	Error error;
 	ThreadCallback* callback;
 
@@ -314,12 +314,18 @@ public:
 	void setCancel(Future<Void>&& cf) { cancelFuture = std::move(cf); }
 
 	virtual void cancel() {
-		onMainThreadVoid(
-		    [this]() {
-			    this->cancelFuture.cancel();
-			    this->delref();
-		    },
-		    nullptr);
+		// Cancels the action and decrements the reference count by 1. The if statement is just an optimization. It's ok
+		// if we take the "wrong path" if we call this while someone else holds |mutex|. We can't take |mutex| since
+		// this is called from releaseMemory. Trying to avoid going to the network thread here is important - without
+		// this we see lower throughput on the client for e.g. GRV workloads.
+		if (isReadyUnsafe()) {
+			delref();
+		} else {
+			onMainThreadVoid([this]() {
+				this->cancelFuture.cancel();
+				this->delref();
+			});
+		}
 	}
 
 	void releaseMemory() {
@@ -334,6 +340,24 @@ private:
 
 protected:
 	// The caller of any of these *Unsafe functions should be holding |mutex|
+	//
+	// |status| is an atomic, so these are not unsafe in the "data race"
+	// sense. It appears that there are some class invariants (e.g. that
+	// callback should be null if the future is ready), so we should still
+	// hold |mutex| when calling these functions. One exception is for
+	// cancel, which mustn't try to acquire |mutex| since it's called from
+	// releaseMemory while holding the |mutex|. In cancel, we only need to
+	// know if there's possibly work to cancel on the main thread, so it's safe to
+	// call without holding |mutex|.
+	//
+	// A bit of history: the original implementation of cancel was not
+	// thread safe (in practice it behaved as intended, but TSAN didn't like
+	// it, and it was definitely a data race.) The first attempt to fix this[1]
+	// was simply to cancel on the main thread, but this turns out to cause
+	// a performance regression on the client. Now we simply make |status|
+	// atomic so that it behaves (legally) how the original author intended.
+	//
+	// [1]: https://github.com/apple/foundationdb/pull/3750
 	bool isReadyUnsafe() const { return status >= Set; }
 	bool isErrorUnsafe() const { return status == ErrorSet; }
 	bool canBeSetUnsafe() const { return status == Unset; }


### PR DESCRIPTION
This is a cherry-pick of #5290.

Bring back optimization removed in #3750. 

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
