### PR TITLE
Log SubCode and Severity for RocksDB erros. 

### DIFF
--- a/fdbserver/KeyValueStoreRocksDB.actor.cpp
+++ b/fdbserver/KeyValueStoreRocksDB.actor.cpp
@@ -181,6 +181,14 @@ ACTOR Future<Void> rocksDBMetricLogger(std::shared_ptr<rocksdb::Statistics> stat
 	}
 }
 
+void logRocksDBError(const rocksdb::Status& status, const std::string& method) {
+	TraceEvent e(SevError, "RocksDBError");
+	e.detail("Error", status.ToString()).detail("Method", method).detail("RocksDBSeverity", status.severity());
+	if (status.IsIOError()) {
+		e.detail("SubCode", status.subcode());
+	}
+}
+
 Error statusToError(const rocksdb::Status& s) {
 	if (s.IsIOError()) {
 		return io_error();
@@ -224,7 +232,7 @@ struct RocksDBKeyValueStore : IKeyValueStore {
 			auto options = getOptions();
 			auto status = rocksdb::DB::Open(options, a.path, defaultCF, &handle, &db);
 			if (!status.ok()) {
-				TraceEvent(SevError, "RocksDBError").detail("Error", status.ToString()).detail("Method", "Open");
+				logRocksDBError(status, "Open");
 				a.done.sendError(statusToError(status));
 			} else {
 				TraceEvent(SevInfo, "RocksDB").detail("Path", a.path).detail("Method", "Open");
@@ -266,7 +274,7 @@ struct RocksDBKeyValueStore : IKeyValueStore {
 			options.sync = !SERVER_KNOBS->ROCKSDB_UNSAFE_AUTO_FSYNC;
 			auto s = db->Write(options, a.batchToCommit.get());
 			if (!s.ok()) {
-				TraceEvent(SevError, "RocksDBError").detail("Error", s.ToString()).detail("Method", "Commit");
+				logRocksDBError(s, "Commit");
 				a.done.sendError(statusToError(s));
 			} else {
 				a.done.send(Void());
@@ -292,14 +300,14 @@ struct RocksDBKeyValueStore : IKeyValueStore {
 			}
 			auto s = db->Close();
 			if (!s.ok()) {
-				TraceEvent(SevError, "RocksDBError").detail("Error", s.ToString()).detail("Method", "Close");
+				logRocksDBError(s, "Close");
 			}
 			if (a.deleteOnClose) {
 				std::vector<rocksdb::ColumnFamilyDescriptor> defaultCF = { rocksdb::ColumnFamilyDescriptor{
 					"default", getCFOptions() } };
 				s = rocksdb::DestroyDB(a.path, getOptions(), defaultCF);
 				if (!s.ok()) {
-					TraceEvent(SevError, "RocksDBError").detail("Error", s.ToString()).detail("Method", "Destroy");
+					logRocksDBError(s, "Destroy");
 				} else {
 					TraceEvent(SevInfo, "RocksDB").detail("Path", a.path).detail("Method", "Destroy");
 				}
@@ -420,7 +428,7 @@ struct RocksDBKeyValueStore : IKeyValueStore {
 			} else if (s.IsNotFound()) {
 				a.result.send(Optional<Value>());
 			} else {
-				TraceEvent(SevError, "RocksDBError").detail("Error", s.ToString()).detail("Method", "ReadValuePrefix");
+				logRocksDBError(s, "ReadValuePrefix");
 				a.result.sendError(statusToError(s));
 			}
 		}
@@ -512,7 +520,7 @@ struct RocksDBKeyValueStore : IKeyValueStore {
 			}
 
 			if (!s.ok()) {
-				TraceEvent(SevError, "RocksDBError").detail("Error", s.ToString()).detail("Method", "ReadRange");
+				logRocksDBError(s, "ReadRange");
 				a.result.sendError(statusToError(s));
 				return;
 			}


### PR DESCRIPTION
Example 
`trace.127.0.0.1.4503.1630440279.a5Q2jo.0.1.xml:<Event Severity="40" ErrorKind="Unset" Time="1630440291.196540" DateTime="2021-08-31T20:04:51Z" Type="RocksDBError" ID="0000000000000000" Error="IO error: No space left on device" Method="Commit" RocksDBSeverity="0" SubCode="4" ThreadID="16869869807533468410" Backtrace="addr2line -e fdbserver.debug -p -C -f -i 0x2becf2c 0x2bec0f0 0x2bec4d1 0xf29787 0xf2b7e2 0x2b68d46 0x2b6a285 0x7fb2598fbea5" Machine="127.0.0.1:4503" LogGroup="default" Roles="CC,CP,DD,GP,MS,RK,RV,SS,TL" />`
# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
