### PR TITLE
Fix the self-assign warning in Atomic.h

### DIFF
--- a/flow/Platform.h
+++ b/flow/Platform.h
@@ -594,9 +594,9 @@ inline static int64_t flowInterlockedAnd64(int64_t* p, int64_t a) {
 #error Missing byte swap methods
 #endif
 
-#define littleEndian16(value) value
-#define littleEndian32(value) value
-#define littleEndian64(value) value
+#define littleEndian16(value) uint16_t(value)
+#define littleEndian32(value) uint32_t(value)
+#define littleEndian64(value) uint64_t(value)
 
 #if defined(_WIN32)
 inline static void flushOutputStreams() {


### PR DESCRIPTION
When compiling FDB using clang++, self-assign warning appears due to the
code

	pos = littleEndian32(pos);

in Atomic.h, which expands to

	pos = pos;

as littleEndian32 is defined as

        #define littleEndian32(value) value

This warning is not interesting, but annoying, by adding a
no-side-effect casting, the warning is suppressed.

Tested by 100000 correctness runs.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
