### PR TITLE
Enable rocksdb storage in simulation with some simulation fixes.

### DIFF
--- a/fdbserver/SimulatedCluster.actor.cpp
+++ b/fdbserver/SimulatedCluster.actor.cpp
@@ -1297,9 +1297,7 @@ void SimulationConfig::setDatacenters(const TestConfig& testConfig) {
 
 // Sets storage engine based on testConfig details
 void SimulationConfig::setStorageEngine(const TestConfig& testConfig) {
-	// Using [0, 4) to disable the RocksDB storage engine.
-	// TODO: Figure out what is broken with the RocksDB engine in simulation.
-	int storage_engine_type = deterministicRandom()->randomInt(0, 4);
+	int storage_engine_type = deterministicRandom()->randomInt(0, 5);
 	if (testConfig.storageEngineType.present()) {
 		storage_engine_type = testConfig.storageEngineType.get();
 	} else {
@@ -1337,7 +1335,7 @@ void SimulationConfig::setStorageEngine(const TestConfig& testConfig) {
 		set_config("ssd-rocksdb-experimental");
 		// Tests using the RocksDB engine are necessarily non-deterministic because of RocksDB
 		// background threads.
-		TraceEvent(SevWarn, "RocksDBNonDeterminism")
+		TraceEvent(SevWarnAlways, "RocksDBNonDeterminism")
 		    .detail("Explanation", "The RocksDB storage engine is threaded and non-deterministic");
 		noUnseed = true;
 		break;
@@ -2176,6 +2174,13 @@ ACTOR void setupAndRun(std::string dataFolder,
 	// snapshot of the storage engine without a snapshotting file system.
 	// https://github.com/apple/foundationdb/issues/5155
 	if (std::string_view(testFile).find("restarting") != std::string_view::npos) {
+		testConfig.storageEngineExcludeTypes.push_back(4);
+	}
+
+	// TODO: Currently backup and restore related simulation tests are failing when run with rocksDB storage engine
+	// possibly due to running the rocksdb in single thread in simulation.
+	// Re-enable the backup and restore related simulation tests when the tests are passing again.
+	if (std::string_view(testFile).find("Backup") != std::string_view::npos) {
 		testConfig.storageEngineExcludeTypes.push_back(4);
 	}
 


### PR DESCRIPTION
Enable rocksdb storage in simulation with some simulation fixes.

Joshua runs with setting storage_engine_type = rocksdb, so that it runs all the tests with rocksdb.
  20210902-154815-neethuhaneeshabingi-c9a73d3cec65a203 compressed=True data_size=25173336 duration=8196797 ended=105309 fail=3 fail_fast=10 max_runs=100000 pass=100001 priority=100 remaining=0 runtime=0:42:19 sanity=False started=105509 stopped=20210902-163034 submitted=20210902-154815 timeout=5400 username=neethuhaneeshabingi
  20210902-164230-neethuhaneeshabingi-c9a73d3cec65a203 compressed=True data_size=25173336 duration=7375889 ended=104200 fail=1 fail_fast=10 max_runs=100000 pass=100064 priority=100 remaining=0 runtime=0:39:42 sanity=False started=105454 stopped=20210902-172212 submitted=20210902-164230 timeout=5400 username=neethuhaneeshabingi
  20210902-175726-neethuhaneeshabingi-c9a73d3cec65a203 compressed=True data_size=25173336 duration=7250057 ended=102691 fail=2 fail_fast=10 max_runs=100000 pass=100112 priority=100 remaining=0 runtime=0:36:26 sanity=False started=102741 stopped=20210902-183352 submitted=20210902-175726 timeout=5400 username=neethuhaneeshabingi
  20210902-194758-neethuhaneeshabingi-c9a73d3cec65a203 compressed=True data_size=25173336 duration=7220207 ended=102164 fail=1 fail_fast=10 max_runs=100000 pass=100311 priority=100 remaining=0 runtime=0:37:24 sanity=False started=102924 stopped=20210902-202522 submitted=20210902-194758 timeout=5400 username=neethuhaneeshabingi

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
