### PR TITLE
Handle the edge case correctly when the upper bound version is less than the binary version

### DIFF
--- a/contrib/TestHarness/Program.cs.cmake
+++ b/contrib/TestHarness/Program.cs.cmake
@@ -328,7 +328,7 @@ namespace SummarizeTest
                                                          x => versionGreaterThanOrEqual(Path.GetFileName(x).Split('-').Last(), oldBinaryVersionLowerBound)
                                                            && versionLessThan(Path.GetFileName(x).Split('-').Last(), oldBinaryVersionUpperBound));
                     if (versionGreaterThanOrEqual(oldBinaryVersionUpperBound, getFdbserverVersion(fdbserverName))) {
-                        // only add current binary if it's allowed
+                        // only add current binary to list of old binaries if its version is less than or equal to the upperbound version
                         oldBinaries = oldBinaries.Concat(currentBinary);
                     }
                     oldServerName = random.Choice(oldBinaries.ToList<string>());

--- a/contrib/TestHarness/Program.cs.cmake
+++ b/contrib/TestHarness/Program.cs.cmake
@@ -327,7 +327,10 @@ namespace SummarizeTest
                                                          Directory.GetFiles(oldBinaryFolder),
                                                          x => versionGreaterThanOrEqual(Path.GetFileName(x).Split('-').Last(), oldBinaryVersionLowerBound)
                                                            && versionLessThan(Path.GetFileName(x).Split('-').Last(), oldBinaryVersionUpperBound));
-                    oldBinaries = oldBinaries.Concat(currentBinary);
+                    if (versionGreaterThanOrEqual(oldBinaryVersionUpperBound, getFdbserverVersion(fdbserverName))) {
+                        // only add current binary if it's allowed
+                        oldBinaries = oldBinaries.Concat(currentBinary);
+                    }
                     oldServerName = random.Choice(oldBinaries.ToList<string>());
                 }
                 else

--- a/contrib/TestHarness/Program.cs.cmake
+++ b/contrib/TestHarness/Program.cs.cmake
@@ -327,8 +327,11 @@ namespace SummarizeTest
                                                          Directory.GetFiles(oldBinaryFolder),
                                                          x => versionGreaterThanOrEqual(Path.GetFileName(x).Split('-').Last(), oldBinaryVersionLowerBound)
                                                            && versionLessThan(Path.GetFileName(x).Split('-').Last(), oldBinaryVersionUpperBound));
-                    if (versionGreaterThanOrEqual(oldBinaryVersionUpperBound, getFdbserverVersion(fdbserverName))) {
-                        // only add current binary to list of old binaries if its version is less than or equal to the upperbound version
+                    if (!lastFolderName.Contains("until_")) {
+                        // only add current binary to the list of old binaries if "until_" is not specified in the folder name
+                        // <version> in until_<version> should be less or equal to the current binary version
+                        // otherwise, using "until_" makes no sense
+                        // thus, by definition, if "until_" appears, we do not want to run with the current binary version
                         oldBinaries = oldBinaries.Concat(currentBinary);
                     }
                     oldServerName = random.Choice(oldBinaries.ToList<string>());


### PR DESCRIPTION
A follow-up on #5529,
~~if the allowed upper bound version is smaller than the server version,
then do not add it to the old binary list~~

----------

Update:
We only add the current binary to the list of old binaries if "until_" is not specified in the folder name
The reason is as below:
<version> in until_<version> should be less or equal to the current binary version
otherwise, using "until_" makes no sense
thus, by definition, if "until_" appears, we do not want to run with the current binary version

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
