### PR TITLE
Initialize tlog group collection at commit proxy

### DIFF
--- a/fdbserver/CommitProxyServer.actor.cpp
+++ b/fdbserver/CommitProxyServer.actor.cpp
@@ -1994,6 +1994,7 @@ ACTOR Future<Void> commitProxyServerCore(CommitProxyInterface proxy,
 	//TraceEvent("ProxyInit3", proxy.id());
 
 	// Add TLog groups to collection
+	// TODO: also add list of workers for groups
 	const auto& logset = commitData.db->get().logSystemConfig.tLogs[0];
 	for (const auto& gid : logset.tLogGroupIDs) {
 		TLogGroupRef group = makeReference<TLogGroup>(gid);

--- a/fdbserver/LogSystemConfig.h
+++ b/fdbserver/LogSystemConfig.h
@@ -482,10 +482,16 @@ struct LogSystemConfig {
 			if (std::count(log.tLogs.begin(), log.tLogs.end(), tid) > 0) {
 				return true;
 			}
+			if (std::count(log.tLogsPtxn.begin(), log.tLogsPtxn.end(), tid) > 0) {
+				return true;
+			}
 		}
 		for (const auto& old : oldTLogs) {
 			for (const auto& log : old.tLogs) {
 				if (std::count(log.tLogs.begin(), log.tLogs.end(), tid) > 0) {
+					return true;
+				}
+				if (std::count(log.tLogsPtxn.begin(), log.tLogsPtxn.end(), tid) > 0) {
 					return true;
 				}
 			}

--- a/fdbserver/TLogGroup.actor.h
+++ b/fdbserver/TLogGroup.actor.h
@@ -53,9 +53,9 @@ struct TLogWorkerData;
 class TLogGroup;
 class TLogGroupCollection;
 
-typedef Reference<TLogWorkerData> TLogWorkerDataRef;
-typedef Reference<TLogGroup> TLogGroupRef;
-typedef Reference<TLogGroupCollection> TLogGroupCollectionRef;
+using TLogWorkerDataRef = Reference<TLogWorkerData>;
+using TLogGroupRef = Reference<TLogGroup>;
+using TLogGroupCollectionRef = Reference<TLogGroupCollection>;
 
 // `TLogGroupCollection` manages, recruits and tracks all the TLogGroups in the system.
 // TODO: TLogGroupCollection for HA (satellite and remote), either same class or separate.


### PR DESCRIPTION
Also fix crash in empty message calculation.

20210903-175936-jzhou-6a824505eeb3669d             compressed=True data_size=20936960 duration=4951106 ended=102201 fail_fast=10 max_runs=100000 pass=100050 priority=100 remaining=0 runtime=0:34:29 sanity=False started=102394 stopped=20210903-183405 submitted=20210903-175936 timeout=5400 username=jzhou

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
