### PR TITLE
Fix formatting in cherry-picked change

### DIFF
--- a/flow/aarch64/asmdefs.h
+++ b/flow/aarch64/asmdefs.h
@@ -11,11 +11,15 @@
 #if defined(__aarch64__)
 
 /* Branch Target Identitication support.  */
-#define BTI_C		hint	34
-#define BTI_J		hint	36
+#define BTI_C hint 34
+#define BTI_J hint 36
 /* Return address signing support (pac-ret).  */
-#define PACIASP		hint	25; .cfi_window_save
-#define AUTIASP		hint	29; .cfi_window_save
+#define PACIASP                                                                                                        \
+	hint 25;                                                                                                           \
+	.cfi_window_save
+#define AUTIASP                                                                                                        \
+	hint 29;                                                                                                           \
+	.cfi_window_save
 
 /* GNU_PROPERTY_AARCH64_* macros from elf.h.  */
 #define FEATURE_1_AND 0xc0000000
@@ -23,18 +27,18 @@
 #define FEATURE_1_PAC 2
 
 /* Add a NT_GNU_PROPERTY_TYPE_0 note.  */
-#define GNU_PROPERTY(type, value)	\
-  .section .note.gnu.property, "a";	\
-  .p2align 3;				\
-  .word 4;				\
-  .word 16;				\
-  .word 5;				\
-  .asciz "GNU";				\
-  .word type;				\
-  .word 4;				\
-  .word value;				\
-  .word 0;				\
-  .text
+#define GNU_PROPERTY(type, value)                                                                                      \
+	.section.note.gnu.property, "a";                                                                                   \
+	.p2align 3;                                                                                                        \
+	.word 4;                                                                                                           \
+	.word 16;                                                                                                          \
+	.word 5;                                                                                                           \
+	.asciz "GNU";                                                                                                      \
+	.word type;                                                                                                        \
+	.word 4;                                                                                                           \
+	.word value;                                                                                                       \
+	.word 0;                                                                                                           \
+	.text
 
 /* If set then the GNU Property Note section will be added to
    mark objects to support BTI and PAC-RET.  */
@@ -44,53 +48,53 @@
 
 #if WANT_GNU_PROPERTY
 /* Add property note with supported features to all asm files.  */
-GNU_PROPERTY (FEATURE_1_AND, FEATURE_1_BTI|FEATURE_1_PAC)
+GNU_PROPERTY(FEATURE_1_AND, FEATURE_1_BTI | FEATURE_1_PAC)
 #endif
 
-#define ENTRY_ALIGN(name, alignment)	\
-  .global name;		\
-  .type name,%function;	\
-  .align alignment;		\
-  name:			\
-  .cfi_startproc;	\
-  BTI_C;
+#define ENTRY_ALIGN(name, alignment)                                                                                   \
+	.global name;                                                                                                      \
+	.type name, % function;                                                                                            \
+	.align alignment;                                                                                                  \
+	name:                                                                                                              \
+	.cfi_startproc;                                                                                                    \
+	BTI_C;
 
 #else
 
 #define END_FILE
 
-#define ENTRY_ALIGN(name, alignment)	\
-  .global name;		\
-  .type name,%function;	\
-  .align alignment;		\
-  name:			\
-  .cfi_startproc;
+#define ENTRY_ALIGN(name, alignment)                                                                                   \
+	.global name;                                                                                                      \
+	.type name, % function;                                                                                            \
+	.align alignment;                                                                                                  \
+	name:                                                                                                              \
+	.cfi_startproc;
 
 #endif
 
-#define ENTRY(name)	ENTRY_ALIGN(name, 6)
+#define ENTRY(name) ENTRY_ALIGN(name, 6)
 
-#define ENTRY_ALIAS(name)	\
-  .global name;		\
-  .type name,%function;	\
-  name:
+#define ENTRY_ALIAS(name)                                                                                              \
+	.global name;                                                                                                      \
+	.type name, % function;                                                                                            \
+	name:
 
-#define END(name)	\
-  .cfi_endproc;		\
-  .size name, .-name;
+#define END(name)                                                                                                      \
+	.cfi_endproc;                                                                                                      \
+	.size name, .- name;
 
-#define L(l) .L ## l
+#define L(l) .L##l
 
 #ifdef __ILP32__
-  /* Sanitize padding bits of pointer arguments as per aapcs64 */
-#define PTR_ARG(n)  mov w##n, w##n
+/* Sanitize padding bits of pointer arguments as per aapcs64 */
+#define PTR_ARG(n) mov w##n, w##n
 #else
 #define PTR_ARG(n)
 #endif
 
 #ifdef __ILP32__
-  /* Sanitize padding bits of size arguments as per aapcs64 */
-#define SIZE_ARG(n)  mov w##n, w##n
+/* Sanitize padding bits of size arguments as per aapcs64 */
+#define SIZE_ARG(n) mov w##n, w##n
 #else
 #define SIZE_ARG(n)
 #endif


### PR DESCRIPTION
A [recent change](https://github.com/apple/foundationdb/pull/5478) was cherry-picked to release-7.0 at around the same time we applied clang-format to the entire repo. The result was that this file was formatted on master but not on release-7.0, and that now impacts CI.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
