### PR TITLE
Return if no available old binary in the given range

### DIFF
--- a/contrib/TestHarness/Program.cs.cmake
+++ b/contrib/TestHarness/Program.cs.cmake
@@ -336,7 +336,9 @@ namespace SummarizeTest
                     }
                     List<string> oldBinariesList = oldBinaries.ToList<string>();
                     if (oldBinariesList.Count == 0) {
-                        Console.WriteLine("No available binary version from {0} to {1}", oldBinaryVersionLowerBound, oldBinaryVersionUpperBound);
+                        // In theory, restarting tests are named to have at least one old binary version to run
+                        // But if none of the provided old binaries fall in the range, we just skip the test
+                        Console.WriteLine("No available old binary version from {0} to {1}", oldBinaryVersionLowerBound, oldBinaryVersionUpperBound);
                         return 0;
                     } else {
                         oldServerName = random.Choice(oldBinariesList);

--- a/contrib/TestHarness/Program.cs.cmake
+++ b/contrib/TestHarness/Program.cs.cmake
@@ -334,7 +334,13 @@ namespace SummarizeTest
                         // thus, by definition, if "until_" appears, we do not want to run with the current binary version
                         oldBinaries = oldBinaries.Concat(currentBinary);
                     }
-                    oldServerName = random.Choice(oldBinaries.ToList<string>());
+                    List<string> oldBinariesList = oldBinaries.ToList<string>();
+                    if (oldBinariesList.Count == 0) {
+                        Console.WriteLine("No available binary version from {0} to {1}", oldBinaryVersionLowerBound, oldBinaryVersionUpperBound);
+                        return 0;
+                    } else {
+                        oldServerName = random.Choice(oldBinariesList);
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
The CI does not have `6.2.33` and also if in any environment,
no binary version in the expected range,
print out a message and return to skip the test.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
