### PR TITLE
put upper bound on setuptools version

### DIFF
--- a/documentation/sphinx/requirements.txt
+++ b/documentation/sphinx/requirements.txt
@@ -1,5 +1,5 @@
 --index-url https://pypi.python.org/simple
-setuptools>=20.10.0
+setuptools>=20.10.0,<=57.4.0
 sphinx==1.5.6
 sphinx-bootstrap-theme==0.4.8
 docutils==0.16


### PR DESCRIPTION
Attempt to repair documentation build so PR builds complete as needed

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
