### PR TITLE
Fix TLog push in partitioned txns

### DIFF
--- a/fdbserver/CommitProxyServer.actor.cpp
+++ b/fdbserver/CommitProxyServer.actor.cpp
@@ -1296,15 +1296,15 @@ ACTOR Future<Void> postResolution(CommitBatchContext* self) {
 		self->toCommit.pGroupMessageBuilders = &self->pGroupMessageBuilders;
 		std::vector<Future<Version>> pushResults;
 		pushResults.reserve(self->pGroupMessageBuilders.size());
-		for (auto& groupMessageBuilder : self->pGroupMessageBuilders) {
-			pushResults.push_back(
-			    pProxyCommitData->logSystem->push(self->previousCommitVersionByGroup[groupMessageBuilder.first],
-			                                      self->commitVersion,
-			                                      pProxyCommitData->committedVersion.get(),
-			                                      pProxyCommitData->minKnownCommittedVersion,
-			                                      self->toCommit,
-			                                      span.context,
-			                                      self->debugID));
+		for (auto& [groupId, _] : self->pGroupMessageBuilders) {
+			pushResults.push_back(pProxyCommitData->logSystem->push(self->previousCommitVersionByGroup[groupId],
+			                                                        self->commitVersion,
+			                                                        pProxyCommitData->committedVersion.get(),
+			                                                        pProxyCommitData->minKnownCommittedVersion,
+			                                                        self->toCommit,
+			                                                        span.context,
+			                                                        self->debugID,
+			                                                        groupId));
 		}
 
 		std::function<Version(const std::vector<Version>&)> reduce =

--- a/fdbserver/CommitProxyServer.actor.cpp
+++ b/fdbserver/CommitProxyServer.actor.cpp
@@ -605,6 +605,15 @@ void CommitBatchContext::findOverlappingTLogGroups() {
 			}
 		}
 	}
+	if (pGroupMessageBuilders.empty()) {
+		TraceEvent("EmptyCommits", pProxyCommitData->dbgid);
+		// This is an empty commit controlled by MAX_COMMIT_BATCH_INTERVAL.
+		// We force writing to all groups.
+		for (const auto& groupRef : pProxyCommitData->tLogGroupCollection->groups()) {
+			pGroupMessageBuilders.emplace(groupRef->id(),
+			                              std::make_shared<ptxn::ProxySubsequencedMessageSerializer>(commitVersion));
+		}
+	}
 }
 
 void CommitBatchContext::writeToStorageTeams(const std::set<ptxn::StorageTeamID>& storageTeams, MutationRef m) {

--- a/fdbserver/TLogGroup.actor.h
+++ b/fdbserver/TLogGroup.actor.h
@@ -22,9 +22,6 @@
 
 // When actually compiled (NO_INTELLISENSE), include the generated version of
 // this file. In intellisense use the source version.
-#include "fdbserver/TesterInterface.actor.h"
-#include "fdbserver/ptxn/TLogInterface.h"
-#include "flow/Trace.h"
 #if defined(NO_INTELLISENSE) && !defined(FDBSERVER_TLOGROUP_ACTOR_G_H)
 #define FDBSERVER_TLOGROUP_ACTOR_G_H
 #include "fdbserver/TLogGroup.actor.g.h"
@@ -37,11 +34,14 @@
 #include "fdbclient/CommitProxyInterface.h"
 #include "fdbclient/NativeAPI.actor.h"
 #include "fdbserver/IKeyValueStore.h"
+#include "fdbserver/TesterInterface.actor.h"
+#include "fdbserver/ptxn/TLogInterface.h"
 #include "fdbrpc/Locality.h"
 #include "fdbrpc/Replication.h"
 #include "fdbserver/WorkerInterface.actor.h"
 #include "flow/FastRef.h"
 #include "flow/IRandom.h"
+#include "flow/Trace.h"
 #include "flow/network.h"
 
 #include "flow/actorcompiler.h" // This must be the last #include.


### PR DESCRIPTION
Was not using PTXN tlog before.

This PR also fixed serialization bug/inefficiency in TLog push.

Force empty writes to all tlog groups:
    When a proxy generate an empty commit, we force such a write to all groups.
    This won't generate a lot of traffic, since empty commit is created if there
    are no commits in a few seconds, i.e., MAX_COMMIT_BATCH_INTERVAL (2s).

  20210908-163436-jzhou-49cce751f7ac079f             compressed=True data_size=20943480 duration=4678849 ended=102739 fail=1 fail_fast=10 max_runs=100000 pass=100031 priority=100 remaining=0 runtime=0:26:46 sanity=False started=103271 stopped=20210908-170122 submitted=20210908-163436 timeout=5400 username=jzhou

There is a failure that is probably not related:
```
-r simulation -f src/foundationdb/tests/fast/AtomicBackupToDBCorrectness.toml -b on -s 865444666

Assertion !vfsAsyncIsOpen(filename) failed @ /root/src/foundationdb/fdbserver/KeyValueStoreSQLite.actor.cpp 2128:
```

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
