### PR TITLE
TLogServer popped version calculation was off-by-one for retired tags after master recovery (release-6.2)

### DIFF
--- a/bindings/c/test/mako/mako.c
+++ b/bindings/c/test/mako/mako.c
@@ -830,7 +830,8 @@ int worker_process_main(mako_args_t* args, int worker_id, mako_shmhdr_t* shm) {
 
 	/* Set client Log group */
 	if (strlen(args->log_group) != 0) {
-		err = fdb_network_set_option(FDB_NET_OPTION_TRACE_LOG_GROUP, (uint8_t*)args->log_group, strlen(args->log_group));
+		err =
+		    fdb_network_set_option(FDB_NET_OPTION_TRACE_LOG_GROUP, (uint8_t*)args->log_group, strlen(args->log_group));
 		if (err) {
 			fprintf(stderr, "ERROR: fdb_network_set_option(FDB_NET_OPTION_TRACE_LOG_GROUP): %s\n", fdb_get_error(err));
 		}

--- a/fdbclient/CommitTransaction.h
+++ b/fdbclient/CommitTransaction.h
@@ -157,7 +157,7 @@ struct CommitTransactionRef {
 	force_inline void serialize(Ar& ar) {
 		serializer(ar, read_conflict_ranges, write_conflict_ranges, mutations, read_snapshot);
 		// 6.3 Specific fields
-		if( ar.protocolVersion() == supportDowngradeProtocolVersion && ar.isDeserializing ) {
+		if (ar.protocolVersion() == supportDowngradeProtocolVersion && ar.isDeserializing) {
 			bool report_conflicting_keys;
 			serializer(ar, report_conflicting_keys);
 		}

--- a/fdbclient/FDBTypes.h
+++ b/fdbclient/FDBTypes.h
@@ -261,7 +261,7 @@ struct KeyRangeRef {
 			const_cast<KeyRef&>(begin) = end.substr(0, end.size() - 1);
 		}
 
-		if( begin > end ) {
+		if (begin > end) {
 			TraceEvent("InvertedRange").detail("Begin", begin).detail("End", end);
 			throw inverted_range();
 		};

--- a/fdbclient/StorageServerInterface.h
+++ b/fdbclient/StorageServerInterface.h
@@ -77,9 +77,9 @@ struct StorageServerInterface {
 	NetworkAddress address() const { return getVersion.getEndpoint().getPrimaryAddress(); }
 	UID id() const { return uniqueID; }
 	std::string toString() const { return id().shortString(); }
-	template <class Ar> 
-	void serialize( Ar& ar ) {
-		if ( ar.protocolVersion() == supportDowngradeProtocolVersion && ar.isDeserializing ) {
+	template <class Ar>
+	void serialize(Ar& ar) {
+		if (ar.protocolVersion() == supportDowngradeProtocolVersion && ar.isDeserializing) {
 			serializer(ar, uniqueID, locality, getValue);
 			getKey = RequestStream<struct GetKeyRequest>(getValue.getEndpoint());
 			getKeyValues = RequestStream<struct GetKeyValuesRequest>(getValue.getEndpoint());

--- a/fdbclient/rapidjson/document.h
+++ b/fdbclient/rapidjson/document.h
@@ -2041,7 +2041,7 @@ private:
 #elif RAPIDJSON_64BIT
 		char payload[sizeof(SizeType) * 2 + sizeof(void*) + 6]; // 6 padding bytes
 #else
-		char payload[sizeof(SizeType) * 2 + sizeof(void*) + 2]; // 2 padding bytes
+		  char payload[sizeof(SizeType) * 2 + sizeof(void*) + 2]; // 2 padding bytes
 #endif
 		uint16_t flags;
 	};

--- a/fdbserver/DBCoreState.h
+++ b/fdbserver/DBCoreState.h
@@ -107,7 +107,7 @@ struct OldTLogCoreData {
 
 	template <class Archive>
 	void serialize(Archive& ar) {
-		if( ar.protocolVersion() == supportDowngradeProtocolVersion && ar.isDeserializing ) {
+		if (ar.protocolVersion() == supportDowngradeProtocolVersion && ar.isDeserializing) {
 			serializer(ar, tLogs, logRouterTags, epochEnd, pseudoLocalities, txsTags);
 			// 6.3 specific fields
 			Version epochBegin;

--- a/fdbserver/KeyValueStoreMemory.actor.cpp
+++ b/fdbserver/KeyValueStoreMemory.actor.cpp
@@ -304,8 +304,8 @@ private:
 		OpSnapshotItem,
 		OpSnapshotEnd,
 		OpSnapshotAbort, // terminate an in progress snapshot in order to start a full snapshot
-		OpCommit,        // only in log, not in queue
-		OpRollback,       // only in log, not in queue
+		OpCommit, // only in log, not in queue
+		OpRollback, // only in log, not in queue
 		OpSnapshotItemDelta
 	};
 
@@ -532,15 +532,15 @@ private:
 							        .detail("Nextlocation", self->log->getNextReadLocation());
 							}
 							ASSERT( p1 >= uncommittedNextKey );*/
-							if(h.op == OpSnapshotItemDelta) {
+							if (h.op == OpSnapshotItemDelta) {
 								ASSERT(p1.size() > 1);
 								// Get number of bytes borrowed from previous item key
-								int borrowed = *(uint8_t *)p1.begin();
+								int borrowed = *(uint8_t*)p1.begin();
 								ASSERT(borrowed <= lastSnapshotKey.size());
 								// Trim p1 to just the suffix
 								StringRef suffix = p1.substr(1);
 								// Allocate a new string in data arena to hold prefix + suffix
-								Arena &dataArena = *(Arena *)&data.arena();
+								Arena& dataArena = *(Arena*)&data.arena();
 								p1 = makeString(borrowed + suffix.size(), dataArena);
 								// Copy the prefix into the new reconstituted key
 								memcpy(mutateString(p1), lastSnapshotKey.begin(), borrowed);

--- a/fdbserver/OldTLogServer_6_0.actor.cpp
+++ b/fdbserver/OldTLogServer_6_0.actor.cpp
@@ -1062,7 +1062,7 @@ Version poppedVersion(Reference<LogData> self, Tag tag) {
 		if (tag == txsTag || tag.locality == tagLocalityTxs) {
 			return 0;
 		}
-		return self->recoveredAt;
+		return self->recoveredAt + 1;
 	}
 	return tagData->popped;
 }

--- a/fdbserver/TLogServer.actor.cpp
+++ b/fdbserver/TLogServer.actor.cpp
@@ -1371,7 +1371,7 @@ Version poppedVersion(Reference<LogData> self, Tag tag) {
 		if (tag == txsTag || tag.locality == tagLocalityTxs) {
 			return 0;
 		}
-		return self->recoveredAt;
+		return self->recoveredAt + 1;
 	}
 	return tagData->popped;
 }

--- a/fdbserver/masterserver.actor.cpp
+++ b/fdbserver/masterserver.actor.cpp
@@ -119,7 +119,8 @@ private:
 		self->addActor.send(onConflict);
 
 		if (prevDBStateRaw.size()) {
-			self->prevDBState = BinaryReader::fromStringRef<DBCoreState>(prevDBStateRaw, IncludeVersion(supportDowngradeProtocolVersion));
+			self->prevDBState = BinaryReader::fromStringRef<DBCoreState>(
+			    prevDBStateRaw, IncludeVersion(supportDowngradeProtocolVersion));
 			self->myDBState = self->prevDBState;
 		}
 
@@ -150,7 +151,8 @@ private:
 			Value rereadDBStateRaw = wait(self->cstate.read());
 			DBCoreState readState;
 			if (rereadDBStateRaw.size()) {
-				readState = BinaryReader::fromStringRef<DBCoreState>(rereadDBStateRaw, IncludeVersion(supportDowngradeProtocolVersion));
+				readState = BinaryReader::fromStringRef<DBCoreState>(rereadDBStateRaw,
+				                                                     IncludeVersion(supportDowngradeProtocolVersion));
 			}
 
 			if (readState != newState) {

--- a/flow/TLSConfig.actor.h
+++ b/flow/TLSConfig.actor.h
@@ -123,8 +123,7 @@ public:
 
 	void print(FILE* fp);
 
-PRIVATE_EXCEPT_FOR_TLSCONFIG_CPP:
-	std::string tlsCertBytes, tlsKeyBytes, tlsCABytes;
+	PRIVATE_EXCEPT_FOR_TLSCONFIG_CPP : std::string tlsCertBytes, tlsKeyBytes, tlsCABytes;
 	std::string tlsPassword;
 	std::vector<std::string> tlsVerifyPeers;
 	TLSEndpointType endpointType = TLSEndpointType::UNSET;
@@ -206,8 +205,7 @@ public:
 	std::string getKeyPathSync() const;
 	std::string getCAPathSync() const;
 
-PRIVATE_EXCEPT_FOR_TLSCONFIG_CPP:
-	ACTOR static Future<LoadedTLSConfig> loadAsync(const TLSConfig* self);
+	PRIVATE_EXCEPT_FOR_TLSCONFIG_CPP : ACTOR static Future<LoadedTLSConfig> loadAsync(const TLSConfig* self);
 	template <typename T>
 	friend class LoadAsyncActorState;
 

--- a/flow/serialize.h
+++ b/flow/serialize.h
@@ -278,7 +278,7 @@ static inline bool valgrindCheck(const void* data, int bytes, const char* contex
 struct _IncludeVersion {
 	ProtocolVersion v;
 	ProtocolVersion futureDowngradev;
-	explicit _IncludeVersion( ProtocolVersion defaultVersion ) : v(defaultVersion), futureDowngradev(defaultVersion) {
+	explicit _IncludeVersion(ProtocolVersion defaultVersion) : v(defaultVersion), futureDowngradev(defaultVersion) {
 		ASSERT(defaultVersion.isValid());
 	}
 	template <class Ar>


### PR DESCRIPTION
#5461

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
