### PR TITLE
Fix missing group ID in serializing ptxn::TLogCommitRequest

### DIFF
--- a/fdbserver/OldTLogServer_6_0.actor.cpp
+++ b/fdbserver/OldTLogServer_6_0.actor.cpp
@@ -1158,7 +1158,7 @@ Version poppedVersion(Reference<LogData> self, Tag tag) {
 		if (tag == txsTag || tag.locality == tagLocalityTxs) {
 			return 0;
 		}
-		return self->recoveredAt;
+		return self->recoveredAt + 1;
 	}
 	return tagData->popped;
 }

--- a/fdbserver/OldTLogServer_6_2.actor.cpp
+++ b/fdbserver/OldTLogServer_6_2.actor.cpp
@@ -1377,7 +1377,7 @@ Version poppedVersion(Reference<LogData> self, Tag tag) {
 		if (tag == txsTag || tag.locality == tagLocalityTxs) {
 			return 0;
 		}
-		return self->recoveredAt;
+		return self->recoveredAt + 1;
 	}
 	return tagData->popped;
 }

--- a/fdbserver/TLogServer.actor.cpp
+++ b/fdbserver/TLogServer.actor.cpp
@@ -1492,7 +1492,7 @@ Version poppedVersion(Reference<LogData> self, Tag tag) {
 		if (tag == txsTag || tag.locality == tagLocalityTxs) {
 			return 0;
 		}
-		return self->recoveredAt;
+		return self->recoveredAt + 1;
 	}
 	return tagData->popped;
 }

--- a/fdbserver/ptxn/TLogGroupVersionTracker.actor.cpp
+++ b/fdbserver/ptxn/TLogGroupVersionTracker.actor.cpp
@@ -22,6 +22,7 @@
 #include "fdbserver/ptxn/TLogGroupVersionTracker.h"
 
 #include "fdbclient/FDBTypes.h"
+#include "flow/Trace.h"
 #include "flow/UnitTest.h"
 
 namespace ptxn {
@@ -60,11 +61,10 @@ std::map<TLogGroupID, Version> TLogGroupVersionTracker::updateGroups(const std::
 	}
 
 	if (SERVER_KNOBS->INSERT_EMPTY_TRANSACTION) {
-		for (auto& it : versions) {
-			if (results.count(it.first) == 0 &&
-			    commitVersion - it.second >= SERVER_KNOBS->LAGGING_TLOG_GROUP_VERSION_LIMIT) {
-				it.second = commitVersion;
-				results.emplace(it.first, it.second);
+		for (auto& [gid, version] : versions) {
+			if (results.count(gid) == 0 && commitVersion - version >= SERVER_KNOBS->LAGGING_TLOG_GROUP_VERSION_LIMIT) {
+				results.emplace(gid, version);
+				version = commitVersion;
 			}
 		}
 	}

--- a/fdbserver/ptxn/TLogInterface.h
+++ b/fdbserver/ptxn/TLogInterface.h
@@ -98,6 +98,7 @@ struct TLogCommitRequest {
 	void serialize(Ar& ar) {
 		serializer(ar,
 		           spanID,
+		           tLogGroupID,
 		           arena,
 		           messages,
 		           prevVersion,

--- a/fdbserver/ptxn/TLogServer.actor.cpp
+++ b/fdbserver/ptxn/TLogServer.actor.cpp
@@ -1180,6 +1180,7 @@ ACTOR Future<Void> serveTLogInterface_PassivelyPull(
 			auto tlogGroup = activeGeneration->find(req.tLogGroupID);
 			TEST(tlogGroup == activeGeneration->end()); // TLog group not found
 			if (tlogGroup == activeGeneration->end()) {
+				TraceEvent(SevWarn, "TLogCommitUnknownGroup", self->dbgid).detail("Group", req.tLogGroupID);
 				req.reply.sendError(tlog_group_not_found());
 				continue;
 			}


### PR DESCRIPTION
Fix missing group ID in serializing ptxn::TLogCommitRequest

20210909-171712-jzhou-9095b7ee08d1f87d             compressed=True data_size=20943723 duration=4796355 ended=101975 fail_fast=10 max_runs=100000 pass=100197 priority=100 remaining=0 runtime=0:32:23 sanity=False started=101975 stopped=20210909-174935 submitted=20210909-171712 timeout=5400 username=jzhou


# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
