### PR TITLE
Lower max TLogVersion to V5 during 6.3 downgrade tests

### DIFF
--- a/tests/restarting/to_6.3.13_until_7.0.0/CycleTestRestart-1.txt
+++ b/tests/restarting/to_6.3.13_until_7.0.0/CycleTestRestart-1.txt
@@ -1,5 +1,5 @@
 storageEngineExcludeTypes=3
-maxTLogVersion=6
+maxTLogVersion=5
 disableTss=true
 testTitle=Clogged
     clearAfterTest=false

--- a/tests/restarting/to_6.3.13_until_7.0.0/CycleTestRestart-2.txt
+++ b/tests/restarting/to_6.3.13_until_7.0.0/CycleTestRestart-2.txt
@@ -1,5 +1,5 @@
 storageEngineExcludeTypes=3
-maxTLogVersion=6
+maxTLogVersion=5
 testTitle=Clogged
     runSetup=false
     testName=Cycle


### PR DESCRIPTION
The nightlies were surfacing restart test failures in the 7.0 -> 6.3 downgrade tests. At least some of these failures appear to be because the `TLogVersion` being selected by the first cycle test was `TLogVersion::V6`, which is not supported on 6.3. We just need to bump the max TLogVersion down to fix these issues.

This change does not need to go into master because there are no downgrade tests to 6.3 in versions of FDB greater than 7.0 (only single version downgrades are supported).

Passed 10k `restarting/to_6.3.13_until_7.0.0/*`, 10k `restarting/*`, and 100k `*` correctness tests.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
