### PR TITLE
use setUnconditional in worker's health monitor

### DIFF
--- a/fdbserver/worker.actor.cpp
+++ b/fdbserver/worker.actor.cpp
@@ -766,7 +766,7 @@ ACTOR Future<Void> healthMonitor(Reference<AsyncVar<Optional<ClusterControllerFu
 			}
 
 			if (!currentDegradedPeers.empty()) {
-				degradedPeers->set(currentDegradedPeers);
+				degradedPeers->setUnconditional(currentDegradedPeers);
 			}
 		}
 		choose {


### PR DESCRIPTION
So that even the degraded peers don't change, worker will still send the degraded peers to CC. Otherwise, if CC doesn't hear from a worker about a bad peer, it'll consider it is recovered.

This problem doesn't exist in master branch since the master branch doesn't use async var to trigger a reporting to CC.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
