### PR TITLE
Locality filter support to perpetual storage wiggler feature.

### DIFF
--- a/documentation/sphinx/source/command-line-interface.rst
+++ b/documentation/sphinx/source/command-line-interface.rst
@@ -64,7 +64,7 @@ The ``commit`` command commits the current transaction. Any sets or clears execu
 configure
 ---------
 
-The ``configure`` command changes the database configuration. Its syntax is ``configure [new|tss] [single|double|triple|three_data_hall|three_datacenter] [ssd|memory] [grv_proxies=<N>] [commit_proxies=<N>] [resolvers=<N>] [logs=<N>] [count=<TSS_COUNT>] [perpetual_storage_wiggle=<WIGGLE_SPEED>] [storage_migration_type={disabled|aggressive|gradual}]``.
+The ``configure`` command changes the database configuration. Its syntax is ``configure [new|tss] [single|double|triple|three_data_hall|three_datacenter] [ssd|memory] [grv_proxies=<N>] [commit_proxies=<N>] [resolvers=<N>] [logs=<N>] [count=<TSS_COUNT>] [perpetual_storage_wiggle=<WIGGLE_SPEED>] [perpetual_storage_wiggle_locality=<<LOCALITY_KEY>:<LOCALITY_VALUE>|0>] [storage_migration_type={disabled|aggressive|gradual}]``.
 
 The ``new`` option, if present, initializes a new database with the given configuration rather than changing the configuration of an existing one. When ``new`` is used, both a redundancy mode and a storage engine must be specified.
 
@@ -112,7 +112,10 @@ For recommendations on appropriate values for process types in large clusters, s
 perpetual storage wiggle
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-Set the value speed (a.k.a., the number of processes that the Data Distributor should wiggle at a time). Currently, only 0 and 1 are supported. The value 0 means to disable the perpetual storage wiggle. For more details, see :ref:`perpetual-storage-wiggle`.
+``perpetual_storage_wiggle`` sets the value speed (a.k.a., the number of processes that the Data Distributor should wiggle at a time). Currently, only 0 and 1 are supported. The value 0 means to disable the perpetual storage wiggle.
+``perpetual_storage_wiggle_locality`` sets the process filter for wiggling. The processes that match the given locality key and locality value are only wiggled. The value 0 will disable the locality filter and matches all the processes for wiggling.
+
+For more details, see :ref:`perpetual-storage-wiggle`.
 
 storage migration type
 ^^^^^^^^^^^^^^^^^^^^^^

--- a/documentation/sphinx/source/mr-status-json-schemas.rst.inc
+++ b/documentation/sphinx/source/mr-status-json-schemas.rst.inc
@@ -736,7 +736,7 @@
          "proxies":6, // this field will be absent if a value has not been explicitly set
          "backup_worker_enabled":1,
          "perpetual_storage_wiggle": 0,
-         "perpetual_storage_wiggle_locality":"0"
+         "perpetual_storage_wiggle_locality":"0",
          "storage_migration_type":{
          "$enum":[
              "disabled",

--- a/documentation/sphinx/source/mr-status-json-schemas.rst.inc
+++ b/documentation/sphinx/source/mr-status-json-schemas.rst.inc
@@ -736,6 +736,7 @@
          "proxies":6, // this field will be absent if a value has not been explicitly set
          "backup_worker_enabled":1,
          "perpetual_storage_wiggle": 0,
+         "perpetual_storage_wiggle_locality":"0"
          "storage_migration_type":{
          "$enum":[
              "disabled",

--- a/documentation/sphinx/source/perpetual-storage-wiggle.rst
+++ b/documentation/sphinx/source/perpetual-storage-wiggle.rst
@@ -40,6 +40,10 @@ Open perpetual storage wiggle: ``configure perpetual_storage_wiggle=1``.
 
 Disable perpetual storage wiggle on the cluster: ``configure perpetual_storage_wiggle=0``.
 
+Open perpetual storage wiggle for only processes matching the given locality key and value: ``configure perpetual_storage_wiggle=1 perpetual_storage_wiggle_locality=<LOCALITY_KEY>:<LOCALITY_VALUE>``.
+
+Disable perpetual storage wiggle locality matching filter, which wiggles all the processes: ``configure perpetual_storage_wiggle_locality=0``.
+
 Monitor
 =======
 

--- a/fdbcli/ConfigureCommand.actor.cpp
+++ b/fdbcli/ConfigureCommand.actor.cpp
@@ -262,9 +262,9 @@ CommandFactory configureFactory(
     CommandHelp(
         "configure [new|tss]"
         "<single|double|triple|three_data_hall|three_datacenter|ssd|memory|memory-radixtree-beta|proxies=<PROXIES>|"
-        "commit_proxies=<COMMIT_PROXIES>|grv_proxies=<GRV_PROXIES>|logs=<LOGS>|resolvers=<RESOLVERS>>*|count=<TSS_COUNT>|"
-        "perpetual_storage_wiggle=<WIGGLE_SPEED>|perpetual_storage_wiggle_locality=<<LOCALITY_KEY>:<LOCALITY_VALUE>|0>|"
-		"storage_migration_type={disabled|gradual|aggressive}",
+        "commit_proxies=<COMMIT_PROXIES>|grv_proxies=<GRV_PROXIES>|logs=<LOGS>|resolvers=<RESOLVERS>>*|"
+        "count=<TSS_COUNT>|perpetual_storage_wiggle=<WIGGLE_SPEED>|perpetual_storage_wiggle_locality="
+        "<<LOCALITY_KEY>:<LOCALITY_VALUE>|0>|storage_migration_type={disabled|gradual|aggressive}",
         "change the database configuration",
         "The `new' option, if present, initializes a new database with the given configuration rather than changing "
         "the configuration of an existing one. When used, both a redundancy mode and a storage engine must be "

--- a/fdbcli/ConfigureCommand.actor.cpp
+++ b/fdbcli/ConfigureCommand.actor.cpp
@@ -262,9 +262,9 @@ CommandFactory configureFactory(
     CommandHelp(
         "configure [new|tss]"
         "<single|double|triple|three_data_hall|three_datacenter|ssd|memory|memory-radixtree-beta|proxies=<PROXIES>|"
-        "commit_proxies=<COMMIT_PROXIES>|grv_proxies=<GRV_PROXIES>|logs=<LOGS>|resolvers=<RESOLVERS>>*|"
-        "count=<TSS_COUNT>|perpetual_storage_wiggle=<WIGGLE_SPEED>|storage_migration_type={disabled|gradual|"
-        "aggressive}",
+        "commit_proxies=<COMMIT_PROXIES>|grv_proxies=<GRV_PROXIES>|logs=<LOGS>|resolvers=<RESOLVERS>>*|count=<TSS_COUNT>|"
+        "perpetual_storage_wiggle=<WIGGLE_SPEED>|perpetual_storage_wiggle_locality=<<LOCALITY_KEY>:<LOCALITY_VALUE>|0>|"
+		"storage_migration_type={disabled|gradual|aggressive}",
         "change the database configuration",
         "The `new' option, if present, initializes a new database with the given configuration rather than changing "
         "the configuration of an existing one. When used, both a redundancy mode and a storage engine must be "
@@ -292,6 +292,9 @@ CommandFactory configureFactory(
         "perpetual_storage_wiggle=<WIGGLE_SPEED>: Set the value speed (a.k.a., the number of processes that the Data "
         "Distributor should wiggle at a time). Currently, only 0 and 1 are supported. The value 0 means to disable the "
         "perpetual storage wiggle.\n\n"
+        "perpetual_storage_wiggle_locality=<<LOCALITY_KEY>:<LOCALITY_VALUE>|0>: Set the process filter for wiggling. "
+        "The processes that match the given locality key and locality value are only wiggled. The value 0 will disable "
+        "the locality filter and matches all the processes for wiggling.\n\n"
         "See the FoundationDB Administration Guide for more information."));
 
 } // namespace fdb_cli

--- a/fdbcli/fdbcli.actor.cpp
+++ b/fdbcli/fdbcli.actor.cpp
@@ -1171,6 +1171,7 @@ void configureGenerator(const char* text, const char* line, std::vector<std::str
 		                   "logs=",
 		                   "resolvers=",
 		                   "perpetual_storage_wiggle=",
+		                   "perpetual_storage_wiggle_locality=",
 		                   "storage_migration_type=",
 		                   nullptr };
 	arrayGenerator(text, line, opts, lc);

--- a/fdbclient/DatabaseConfiguration.cpp
+++ b/fdbclient/DatabaseConfiguration.cpp
@@ -201,8 +201,7 @@ bool DatabaseConfiguration::isValid() const {
 	      (regions.size() == 0 || tLogPolicy->info() != "dcid^2 x zoneid^2 x 1") &&
 	      // We cannot specify regions with three_datacenter replication
 	      (perpetualStorageWiggleSpeed == 0 || perpetualStorageWiggleSpeed == 1) &&
-	      (perpetualStorageWiggleLocality.find(':') != std::string::npos ||
-	       !perpetualStorageWiggleLocality.compare("0")) &&
+	      isValidPerpetualStorageWiggleLocality(perpetualStorageWiggleLocality) &&
 	      storageMigrationType != StorageMigrationType::UNSET)) {
 		return false;
 	}
@@ -550,7 +549,7 @@ bool DatabaseConfiguration::setInternal(KeyRef key, ValueRef value) {
 	} else if (ck == LiteralStringRef("perpetual_storage_wiggle")) {
 		parse(&perpetualStorageWiggleSpeed, value);
 	} else if (ck == LiteralStringRef("perpetual_storage_wiggle_locality")) {
-		if (value.toString().find(':') == std::string::npos && value.toString().compare("0")) {
+		if (!isValidPerpetualStorageWiggleLocality(value.toString())) {
 			return false;
 		}
 		perpetualStorageWiggleLocality = value.toString();

--- a/fdbclient/DatabaseConfiguration.cpp
+++ b/fdbclient/DatabaseConfiguration.cpp
@@ -45,6 +45,7 @@ void DatabaseConfiguration::resetInternal() {
 	remoteTLogReplicationFactor = repopulateRegionAntiQuorum = 0;
 	backupWorkerEnabled = false;
 	perpetualStorageWiggleSpeed = 0;
+	perpetualStorageWiggleLocality = "0";
 	storageMigrationType = StorageMigrationType::DEFAULT;
 }
 
@@ -200,6 +201,8 @@ bool DatabaseConfiguration::isValid() const {
 	      (regions.size() == 0 || tLogPolicy->info() != "dcid^2 x zoneid^2 x 1") &&
 	      // We cannot specify regions with three_datacenter replication
 	      (perpetualStorageWiggleSpeed == 0 || perpetualStorageWiggleSpeed == 1) &&
+	      (perpetualStorageWiggleLocality.find(':') != std::string::npos ||
+	       !perpetualStorageWiggleLocality.compare("0")) &&
 	      storageMigrationType != StorageMigrationType::UNSET)) {
 		return false;
 	}
@@ -391,6 +394,7 @@ StatusObject DatabaseConfiguration::toJSON(bool noPolicies) const {
 
 	result["backup_worker_enabled"] = (int32_t)backupWorkerEnabled;
 	result["perpetual_storage_wiggle"] = perpetualStorageWiggleSpeed;
+	result["perpetual_storage_wiggle_locality"] = perpetualStorageWiggleLocality;
 	result["storage_migration_type"] = storageMigrationType.toString();
 	return result;
 }
@@ -545,6 +549,11 @@ bool DatabaseConfiguration::setInternal(KeyRef key, ValueRef value) {
 		parse(&regions, value);
 	} else if (ck == LiteralStringRef("perpetual_storage_wiggle")) {
 		parse(&perpetualStorageWiggleSpeed, value);
+	} else if (ck == LiteralStringRef("perpetual_storage_wiggle_locality")) {
+		if (value.toString().find(':') == std::string::npos && value.toString().compare("0")) {
+			return false;
+		}
+		perpetualStorageWiggleLocality = value.toString();
 	} else if (ck == LiteralStringRef("storage_migration_type")) {
 		parse((&type), value);
 		storageMigrationType = (StorageMigrationType::MigrationType)type;

--- a/fdbclient/DatabaseConfiguration.h
+++ b/fdbclient/DatabaseConfiguration.h
@@ -245,6 +245,7 @@ struct DatabaseConfiguration {
 
 	// Perpetual Storage Setting
 	int32_t perpetualStorageWiggleSpeed;
+	std::string perpetualStorageWiggleLocality;
 
 	// Storage Migration Type
 	StorageMigrationType storageMigrationType;

--- a/fdbclient/FDBTypes.h
+++ b/fdbclient/FDBTypes.h
@@ -1163,4 +1163,14 @@ struct StorageMigrationType {
 	uint32_t type;
 };
 
+inline bool isValidPerpetualStorageWiggleLocality(std::string locality) {
+	int pos = locality.find(':');
+	// locality should be either 0 or in the format '<non_empty_string>:<non_empty_string>'
+	if ((pos > 0 && pos < locality.size() - 1) || locality == "0") {
+		return true;
+	}
+
+	return false;
+}
+
 #endif

--- a/fdbclient/FDBTypes.h
+++ b/fdbclient/FDBTypes.h
@@ -1166,11 +1166,7 @@ struct StorageMigrationType {
 inline bool isValidPerpetualStorageWiggleLocality(std::string locality) {
 	int pos = locality.find(':');
 	// locality should be either 0 or in the format '<non_empty_string>:<non_empty_string>'
-	if ((pos > 0 && pos < locality.size() - 1) || locality == "0") {
-		return true;
-	}
-
-	return false;
+	return ((pos > 0 && pos < locality.size() - 1) || locality == "0");
 }
 
 #endif

--- a/fdbclient/ManagementAPI.actor.cpp
+++ b/fdbclient/ManagementAPI.actor.cpp
@@ -151,7 +151,7 @@ std::map<std::string, std::string> configForToken(std::string const& mode) {
 			out[p + key] = value;
 		}
 		if (key == "perpetual_storage_wiggle_locality") {
-			if (value.find(':') == std::string::npos && value.compare("0")) {
+			if (!isValidPerpetualStorageWiggleLocality(value)) {
 				printf("Error: perpetual_storage_wiggle_locality should be in <locality_key>:<locality_value> "
 				       "format or enter 0 to disable the locality match for wiggling.\n");
 				return out;

--- a/fdbclient/ManagementAPI.actor.cpp
+++ b/fdbclient/ManagementAPI.actor.cpp
@@ -150,6 +150,14 @@ std::map<std::string, std::string> configForToken(std::string const& mode) {
 			}
 			out[p + key] = value;
 		}
+		if (key == "perpetual_storage_wiggle_locality") {
+			if (value.find(':') == std::string::npos && value.compare("0")) {
+				printf("Error: perpetual_storage_wiggle_locality should be in <locality_key>:<locality_value> "
+				       "format or enter 0 to disable the locality match for wiggling.\n");
+				return out;
+			}
+			out[p + key] = value;
+		}
 		if (key == "storage_migration_type") {
 			StorageMigrationType type;
 			if (value == "disabled") {

--- a/fdbclient/Schemas.cpp
+++ b/fdbclient/Schemas.cpp
@@ -760,6 +760,7 @@ const KeyRef JSONSchemas::statusSchema = LiteralStringRef(R"statusSchema(
          "proxies":6,
          "backup_worker_enabled":1,
          "perpetual_storage_wiggle":0,
+         "perpetual_storage_wiggle_locality":"0",
          "storage_migration_type": {
              "$enum":[
              "disabled",

--- a/fdbclient/SystemData.cpp
+++ b/fdbclient/SystemData.cpp
@@ -630,6 +630,7 @@ const KeyRangeRef configKeys(LiteralStringRef("\xff/conf/"), LiteralStringRef("\
 const KeyRef configKeysPrefix = configKeys.begin;
 
 const KeyRef perpetualStorageWiggleKey(LiteralStringRef("\xff/conf/perpetual_storage_wiggle"));
+const KeyRef perpetualStorageWiggleLocalityKey(LiteralStringRef("\xff/conf/perpetual_storage_wiggle_locality"));
 const KeyRef wigglingStorageServerKey(LiteralStringRef("\xff/storageWigglePID"));
 
 const KeyRef triggerDDTeamInfoPrintKey(LiteralStringRef("\xff/triggerDDTeamInfoPrint"));

--- a/fdbclient/SystemData.h
+++ b/fdbclient/SystemData.h
@@ -210,6 +210,7 @@ extern const KeyRangeRef configKeys;
 extern const KeyRef configKeysPrefix;
 
 extern const KeyRef perpetualStorageWiggleKey;
+extern const KeyRef perpetualStorageWiggleLocalityKey;
 extern const KeyRef wigglingStorageServerKey;
 // Change the value of this key to anything and that will trigger detailed data distribution team info log.
 extern const KeyRef triggerDDTeamInfoPrintKey;

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -4009,7 +4009,7 @@ ACTOR Future<std::vector<std::pair<StorageServerInterface, ProcessClass>>> getSe
 // to a sorted PID set maintained by the data distributor. If now no storage server exists, the new Process ID is 0.
 ACTOR Future<Void> updateNextWigglingStoragePID(DDTeamCollection* teamCollection) {
 	state ReadYourWritesTransaction tr(teamCollection->cx);
-	state Value writeValue = LiteralStringRef("");
+	state Value writeValue = ""_sr;
 	state const Key writeKey =
 	    wigglingStorageServerKey.withSuffix(teamCollection->primary ? "/primary"_sr : "/remote"_sr);
 	loop {
@@ -4018,14 +4018,14 @@ ACTOR Future<Void> updateNextWigglingStoragePID(DDTeamCollection* teamCollection
 			Optional<Value> locality = wait(tr.get(perpetualStorageWiggleLocalityKey));
 
 			if (teamCollection->pid2server_info.empty()) {
-				writeValue = LiteralStringRef("");
+				writeValue = ""_sr;
 			} else if (locality.present() && locality.get().toString().compare("0")) {
 				// if perpetual_storage_wiggle_locality has value and not 0(disabled).
 				state std::string localityKeyValue = locality.get().toString();
-				int split = localityKeyValue.find(':');
-				ASSERT(split != std::string::npos);
+				ASSERT(isValidPerpetualStorageWiggleLocality(localityKeyValue));
 
 				// get key and value from perpetual_storage_wiggle_locality.
+				int split = localityKeyValue.find(':');
 				state std::string localityKey = localityKeyValue.substr(0, split);
 				state std::string localityValue = localityKeyValue.substr(split + 1);
 				state Value prevValue;
@@ -4047,8 +4047,8 @@ ACTOR Future<Void> updateNextWigglingStoragePID(DDTeamCollection* teamCollection
 
 				// If first entry of pid2server_info, did not match the locality.
 				if (!(writeValue.compare(LiteralStringRef("")))) {
+					auto nextIt = teamCollection->pid2server_info.upper_bound(prevValue);
 					while (true) {
-						auto nextIt = teamCollection->pid2server_info.upper_bound(prevValue);
 						if (nextIt == teamCollection->pid2server_info.end()) {
 							nextIt = teamCollection->pid2server_info.begin();
 						}
@@ -4067,7 +4067,7 @@ ACTOR Future<Void> updateNextWigglingStoragePID(DDTeamCollection* teamCollection
 							    .detail("PerpetualStorageWiggleLocality", localityKeyValue);
 							break;
 						}
-						prevValue = nextIt->first;
+						nextIt++;
 					}
 				}
 			} else {

--- a/fdbserver/SimulatedCluster.actor.cpp
+++ b/fdbserver/SimulatedCluster.actor.cpp
@@ -1781,7 +1781,14 @@ void setupSimulatedSystem(std::vector<Future<Void>>* systemActors,
 	}
 	auto configDBType = testConfig.getConfigDBType();
 	for (auto kv : startingConfigJSON) {
-		if ("tss_storage_engine" == kv.first || "perpetual_storage_wiggle_locality" == kv.first) {
+		if ("tss_storage_engine" == kv.first) {
+			continue;
+		}
+		if ("perpetual_storage_wiggle_locality" == kv.first) {
+			if (deterministicRandom()->random01() < 0.25) {
+				int dcId = deterministicRandom()->randomInt(0, simconfig.datacenters);
+				startingConfigString += " " + kv.first + "=" + "data_hall:" + std::to_string(dcId);
+			}
 			continue;
 		}
 		startingConfigString += " ";

--- a/fdbserver/SimulatedCluster.actor.cpp
+++ b/fdbserver/SimulatedCluster.actor.cpp
@@ -1781,7 +1781,7 @@ void setupSimulatedSystem(std::vector<Future<Void>>* systemActors,
 	}
 	auto configDBType = testConfig.getConfigDBType();
 	for (auto kv : startingConfigJSON) {
-		if ("tss_storage_engine" == kv.first) {
+		if ("tss_storage_engine" == kv.first || "perpetual_storage_wiggle_locality" == kv.first) {
 			continue;
 		}
 		startingConfigString += " ";

--- a/fdbserver/workloads/ConfigureDatabase.actor.cpp
+++ b/fdbserver/workloads/ConfigureDatabase.actor.cpp
@@ -276,13 +276,24 @@ struct ConfigureDatabaseWorkload : TestWorkload {
 		if (self->allowTestStorageMigration) {
 			state DatabaseConfiguration conf = wait(getDatabaseConfiguration(cx));
 			state int i;
+			state std::string wiggleLocalityKeyValue = conf.perpetualStorageWiggleLocality;
+			state std::string wiggleLocalityKey;
+			state std::string wiggleLocalityValue;
+			if (wiggleLocalityKeyValue != "0") {
+				int split = wiggleLocalityKeyValue.find(':');
+				wiggleLocalityKey = wiggleLocalityKeyValue.substr(0, split);
+				wiggleLocalityValue = wiggleLocalityKeyValue.substr(split + 1);
+			}
 			loop {
 				state bool pass = true;
 				state std::vector<StorageServerInterface> storageServers = wait(getStorageServers(cx));
 
 				for (i = 0; i < storageServers.size(); i++) {
 					// Check that each storage server has the correct key value store type
-					if (!storageServers[i].isTss()) {
+					if (!storageServers[i].isTss() &&
+					    (wiggleLocalityKeyValue == "0" ||
+					     (storageServers[i].locality.get(wiggleLocalityKey).present() &&
+					      storageServers[i].locality.get(wiggleLocalityKey).get().toString() == wiggleLocalityValue))) {
 						ReplyPromise<KeyValueStoreType> typeReply;
 						ErrorOr<KeyValueStoreType> keyValueStoreType =
 						    wait(storageServers[i].getKeyValueStoreType.getReplyUnlessFailedFor(typeReply, 2, 0));
@@ -397,10 +408,32 @@ struct ConfigureDatabaseWorkload : TestWorkload {
 			} else if (randomChoice == 8) {
 				if (self->allowTestStorageMigration) {
 					TEST(true); // storage migration type change
+
+					// randomly configuring perpetual_storage_wiggle_locality
+					state std::string randomPerpetualWiggleLocality;
+					if (deterministicRandom()->random01() < 0.25) {
+						state std::vector<StorageServerInterface> storageServers = wait(getStorageServers(cx));
+						StorageServerInterface randomSS =
+						    storageServers[deterministicRandom()->randomInt(0, storageServers.size())];
+						std::vector<StringRef> localityKeys = { LocalityData::keyDcId,
+							                                    LocalityData::keyDataHallId,
+							                                    LocalityData::keyZoneId,
+							                                    LocalityData::keyMachineId,
+							                                    LocalityData::keyProcessId };
+						StringRef randomLocalityKey =
+						    localityKeys[deterministicRandom()->randomInt(0, localityKeys.size())];
+						if (randomSS.locality.isPresent(randomLocalityKey)) {
+							randomPerpetualWiggleLocality =
+							    " perpetual_storage_wiggle_locality=" + randomLocalityKey.toString() + ":" +
+							    randomSS.locality.get(randomLocalityKey).get().toString();
+						}
+					}
+
 					wait(success(IssueConfigurationChange(
 					    cx,
 					    storageMigrationTypes[deterministicRandom()->randomInt(
-					        0, sizeof(storageMigrationTypes) / sizeof(storageMigrationTypes[0]))],
+					        0, sizeof(storageMigrationTypes) / sizeof(storageMigrationTypes[0]))] +
+					        randomPerpetualWiggleLocality,
 					    false)));
 				}
 			} else {


### PR DESCRIPTION
Locality filter support to perpetual storage wiggler feature. 
By configuring perpetual_storage_wiggle_locality, the processes which match the given locality will only be wiggled.

perpetual_storage_wiggle_locality=<<LOCALITY_KEY>:<LOCALITY_VALUE>|0>: Set the process filter for wiggling. The processes that match the given locality key and locality value are only wiggled. The value 0 will disable the locality filter and matches all the processes for wiggling.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
