### PR TITLE
Redwood IO Concurrent Read Locking Optimization

### DIFF
--- a/fdbserver/VersionedBTree.actor.cpp
+++ b/fdbserver/VersionedBTree.actor.cpp
@@ -7053,7 +7053,7 @@ public:
 		    self->m_tree->initBTreeCursor(&cur, self->m_tree->getLastCommittedVersion(), PagerEventReasons::RangeRead));
 
 		state PriorityMultiLock::Lock lock;
-		state bool inLock = false;
+		state bool isLocked = false;
 		++g_redwoodMetrics.metric.opGetRange;
 
 		state RangeResult result;
@@ -7066,11 +7066,11 @@ public:
 
 		if (rowLimit > 0) {
 			Future<Void> f = cur.seekGTE(keys.begin);
-			if (!inLock && !f.isReady()) {
-				inLock = true;
+			if (!isLocked && !f.isReady()) {
+				isLocked = true;
 				wait(store(lock, self->m_concurrentReads.lock()));
 			}
-			
+
 			if (self->prefetch) {
 				cur.prefetch(keys.end, true, rowLimit, byteLimit);
 			}
@@ -7117,8 +7117,8 @@ public:
 			}
 		} else {
 			Future<Void> f = cur.seekLT(keys.end);
-			if (!inLock && !f.isReady()) {
-				inLock = true;
+			if (!isLocked && !f.isReady()) {
+				isLocked = true;
 				wait(store(lock, self->m_concurrentReads.lock()));
 			}
 


### PR DESCRIPTION
Instead of lock and then retrieve data, first check if it in cache and if is then return the data. Otherwise, lock it. This change reduces the read latency by avoiding the case that data is cached but it needs to wait for other previous reads to finish retrieving data from disk.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
