### PR TITLE
Remove redundant RequestStream in ptxn TLogInterface

### DIFF
--- a/fdbserver/ApplyMetadataMutation.cpp
+++ b/fdbserver/ApplyMetadataMutation.cpp
@@ -231,7 +231,7 @@ private:
 		auto groupId = decodeTLogGroupKey(m.param1);
 		auto servers = TLogGroup::fromValue(
 		    groupId, m.param2, std::unordered_map<UID, TLogWorkerDataRef>({ /* TODO: add recruits */ }));
-		tLogGroupCollection->addTLogGroup(servers);
+		tLogGroupCollection->addTLogGroup(dbgid, servers);
 
 		if (!initialCommit) {
 			txnStateStore->set(KeyValueRef(m.param1, m.param2));

--- a/fdbserver/CommitProxyServer.actor.cpp
+++ b/fdbserver/CommitProxyServer.actor.cpp
@@ -2009,7 +2009,7 @@ ACTOR Future<Void> commitProxyServerCore(CommitProxyInterface proxy,
 	const auto& logset = commitData.db->get().logSystemConfig.tLogs[0];
 	for (const auto& gid : logset.tLogGroupIDs) {
 		TLogGroupRef group = makeReference<TLogGroup>(gid);
-		commitData.tLogGroupCollection->addTLogGroup(group);
+		commitData.tLogGroupCollection->addTLogGroup(commitData.dbgid, group);
 	}
 
 	commitData.resolvers = commitData.db->get().resolvers;

--- a/fdbserver/MasterInterface.h
+++ b/fdbserver/MasterInterface.h
@@ -102,12 +102,15 @@ struct TLogRejoinRequest {
 	constexpr static FileIdentifier file_identifier = 15692200;
 	TLogInterface myInterface;
 	ReplyPromise<TLogRejoinReply> reply;
+	ptxn::TLogInterface_PassivelyPull ptxnInterface;
 
 	TLogRejoinRequest() {}
 	explicit TLogRejoinRequest(const TLogInterface& interf) : myInterface(interf) {}
+	explicit TLogRejoinRequest(const ptxn::TLogInterface_PassivelyPull& interf) : ptxnInterface(interf) {}
+
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, myInterface, reply);
+		serializer(ar, myInterface, reply, ptxnInterface);
 	}
 };
 

--- a/fdbserver/TLogGroup.actor.cpp
+++ b/fdbserver/TLogGroup.actor.cpp
@@ -144,6 +144,8 @@ void TLogGroupCollection::recruitEverything() {
 
 			recruitedGroups.push_back(group);
 			TraceEvent("TLogGroupAdd")
+			    .setMaxEventLength(-1)
+			    .setMaxFieldLength(10000)
 			    .detail("GroupID", group->id())
 			    .detail("Servers", describe(group->servers()))
 			    .detail("TotalGroups", recruitedGroups.size());
@@ -167,8 +169,10 @@ LocalityMap<TLogWorkerData> TLogGroupCollection::buildLocalityMap(const std::uno
 	return localityMap;
 }
 
-void TLogGroupCollection::addTLogGroup(TLogGroupRef group) {
-	TraceEvent("TLogGroupAdd")
+void TLogGroupCollection::addTLogGroup(UID debugID, TLogGroupRef group) {
+	TraceEvent("TLogGroupAdd", debugID)
+	    .setMaxEventLength(-1)
+	    .setMaxFieldLength(10000)
 	    .detail("GroupID", group->id())
 	    .detail("Size", group->size())
 	    .detail("Group", group->toString());

--- a/fdbserver/TLogGroup.actor.h
+++ b/fdbserver/TLogGroup.actor.h
@@ -101,7 +101,7 @@ public:
 	void recruitEverything();
 
 	// Add a TLogGroup
-	void addTLogGroup(TLogGroupRef group);
+	void addTLogGroup(UID debugID, TLogGroupRef group);
 
 	// Find a TLogGroup for assigning a storage team.
 	TLogGroupRef selectFreeGroup(int seed = 0);

--- a/fdbserver/ptxn/TLogInterface.cpp
+++ b/fdbserver/ptxn/TLogInterface.cpp
@@ -50,9 +50,7 @@ void TLogInterface_ActivelyPush::initEndpoints() {
 
 void TLogInterface_PassivelyPull::initEndpoints() {
 	// RequestSteam order must be the same as declared in TLogInterface_PassivelyPull
-	TLogInterfaceBase::initEndpointsImpl({ peekMessages.getReceiver(TaskPriority::TLogPeek),
-	                                       popMessages.getReceiver(TaskPriority::TLogPop),
-	                                       disablePopRequest.getReceiver(),
+	TLogInterfaceBase::initEndpointsImpl({ disablePopRequest.getReceiver(),
 	                                       enablePopRequest.getReceiver() });
 }
 

--- a/fdbserver/ptxn/TLogInterface.h
+++ b/fdbserver/ptxn/TLogInterface.h
@@ -452,8 +452,6 @@ struct TLogInterface_ActivelyPush : public TLogInterfaceBase {
 struct TLogInterface_PassivelyPull : public TLogInterfaceBase {
 	constexpr static FileIdentifier file_identifier = 748550;
 
-	RequestStream<TLogPeekRequest> peekMessages;
-	RequestStream<TLogPopRequest> popMessages;
 	RequestStream<TLogDisablePopRequest> disablePopRequest;
 	RequestStream<TLogEnablePopRequest> enablePopRequest;
 
@@ -461,10 +459,8 @@ struct TLogInterface_PassivelyPull : public TLogInterfaceBase {
 	void serialize(Ar& ar) {
 		TLogInterfaceBase::serializeImpl(ar);
 		if (Ar::isDeserializing) {
-			popMessages = RequestStream<TLogPopRequest>(commit.getEndpoint().getAdjustedEndpoint(9));
-			popMessages = RequestStream<TLogPopRequest>(commit.getEndpoint().getAdjustedEndpoint(10));
-			disablePopRequest = RequestStream<TLogDisablePopRequest>(commit.getEndpoint().getAdjustedEndpoint(11));
-			enablePopRequest = RequestStream<TLogEnablePopRequest>(commit.getEndpoint().getAdjustedEndpoint(12));
+			disablePopRequest = RequestStream<TLogDisablePopRequest>(commit.getEndpoint().getAdjustedEndpoint(9));
+			enablePopRequest = RequestStream<TLogEnablePopRequest>(commit.getEndpoint().getAdjustedEndpoint(10));
 		}
 	}
 

--- a/fdbserver/ptxn/TLogPeekCursor.actor.cpp
+++ b/fdbserver/ptxn/TLogPeekCursor.actor.cpp
@@ -438,15 +438,15 @@ ACTOR Future<Void> serverPeekParallelGetMore(ServerPeekCursor* self, TaskPriorit
 				       self->interf->get().present()) {
 					self->futureResults.push_back(recordRequestMetrics(
 					    self,
-					    self->interf->get().interf().peekMessages.getEndpoint().getPrimaryAddress(),
-					    self->interf->get().interf().peekMessages.getReply(TLogPeekRequest(self->dbgid,
-					                                                                       self->messageVersion.version,
-					                                                                       Optional<Version>(),
-					                                                                       self->returnIfBlocked,
-					                                                                       self->onlySpilled,
-					                                                                       self->storageTeamId,
-					                                                                       self->tLogGroupID),
-					                                                       taskID)));
+					    self->interf->get().interf().peek.getEndpoint().getPrimaryAddress(),
+					    self->interf->get().interf().peek.getReply(TLogPeekRequest(self->dbgid,
+					                                                               self->messageVersion.version,
+					                                                               Optional<Version>(),
+					                                                               self->returnIfBlocked,
+					                                                               self->onlySpilled,
+					                                                               self->storageTeamId,
+					                                                               self->tLogGroupID),
+					                                               taskID)));
 				}
 				if (self->sequence == std::numeric_limits<decltype(self->sequence)>::max()) {
 					throw operation_obsolete();
@@ -516,7 +516,7 @@ ACTOR Future<Void> serverPeekGetMore(ServerPeekCursor* self, TaskPriority taskID
 	try {
 		loop choose {
 			when(TLogPeekReply res = wait(self->interf->get().present()
-			                                  ? brokenPromiseToNever(self->interf->get().interf().peekMessages.getReply(
+			                                  ? brokenPromiseToNever(self->interf->get().interf().peek.getReply(
 			                                        TLogPeekRequest(self->dbgid,
 			                                                        self->messageVersion.version,
 			                                                        Optional<Version>(),
@@ -576,7 +576,7 @@ ACTOR Future<Void> serverPeekOnFailed(ServerPeekCursor* self) {
 		choose {
 			when(wait(self->interf->get().present()
 			              ? IFailureMonitor::failureMonitor().onStateEqual(
-			                    self->interf->get().interf().peekMessages.getEndpoint(), FailureStatus())
+			                    self->interf->get().interf().peek.getEndpoint(), FailureStatus())
 			              : Never())) {
 				return Void();
 			}
@@ -594,7 +594,7 @@ bool ServerPeekCursor::isActive() const {
 		return false;
 	if (messageVersion >= end)
 		return false;
-	return IFailureMonitor::failureMonitor().getState(interf->get().interf().peekMessages.getEndpoint()).isAvailable();
+	return IFailureMonitor::failureMonitor().getState(interf->get().interf().peek.getEndpoint()).isAvailable();
 }
 
 bool ServerPeekCursor::isExhausted() const {

--- a/fdbserver/ptxn/TLogPeekCursor.actor.h
+++ b/fdbserver/ptxn/TLogPeekCursor.actor.h
@@ -183,20 +183,20 @@ struct ServerPeekCursor final : ILogSystem::IPeekCursor, ReferenceCounted<Server
 	TagsAndMessage messageAndTags; // TODO: do we still have tag concept in a message
 	bool hasMsg;
 	Future<Void> more;
-	UID randomID; // TODO: figure out what's this
+	UID dbgid; // i.e., unique debugID of this cursor.
 	bool returnIfBlocked;
 
-	bool onlySpilled;
+	bool onlySpilled = false;
 	bool parallelGetMore;
-	int sequence;
+	int sequence = 0;
 	Deque<Future<TLogPeekReply>> futureResults;
 	Future<Void> interfaceChanged;
 
-	double lastReset;
-	Future<Void> resetCheck;
-	int slowReplies;
-	int fastReplies;
-	int unknownReplies;
+	double lastReset = 0;
+	Future<Void> resetCheck = Void();
+	int slowReplies = 0;
+	int fastReplies = 0;
+	int unknownReplies = 0;
 
 	ServerPeekCursor(Reference<AsyncVar<OptionalInterface<TLogInterface_PassivelyPull>>> const& interf,
 	                 Tag tag,

--- a/fdbserver/ptxn/TLogServer.actor.cpp
+++ b/fdbserver/ptxn/TLogServer.actor.cpp
@@ -1428,8 +1428,6 @@ ACTOR Future<Void> tLogStart(Reference<TLogServerData> self, InitializePtxnTLogR
 	DUMPTOKEN(recruited.recoveryFinished);
 	DUMPTOKEN(recruited.snapRequest);
 
-	DUMPTOKEN(recruited.peekMessages);
-	DUMPTOKEN(recruited.popMessages);
 	DUMPTOKEN(recruited.disablePopRequest);
 	DUMPTOKEN(recruited.enablePopRequest);
 

--- a/fdbserver/ptxn/TLogServer.actor.cpp
+++ b/fdbserver/ptxn/TLogServer.actor.cpp
@@ -1127,7 +1127,7 @@ ACTOR Future<Void> rejoinMasters(Reference<TLogServerData> self,
 			if (self->dbInfo->get().master.id() != lastMasterID) {
 				// The TLogRejoinRequest is needed to establish communications with a new master, which doesn't have our
 				// TLogInterface
-				TLogRejoinRequest req;
+				TLogRejoinRequest req(tli);
 				TraceEvent("TLogRejoining", tli.id()).detail("Master", self->dbInfo->get().master.id());
 				choose {
 					when(TLogRejoinReply rep =


### PR DESCRIPTION
This was was causing undeliverable messages: sender uses `peekMessages` and receiver expects `peek`.

20210914-163012-jzhou-7c9c9ea207181aa0             compressed=True data_size=20959730 duration=4855892 ended=100866 fail_fast=10 max_runs=100000 pass=100129 priority=100 remaining=0 runtime=0:28:06 sanity=False started=102153 stopped=20210914-165818 submitted=20210914-163012 timeout=5400 username=jzhou

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
