### PR TITLE
Minor leader election code improvements.

### DIFF
--- a/fdbclient/MonitorLeader.actor.cpp
+++ b/fdbclient/MonitorLeader.actor.cpp
@@ -394,9 +394,8 @@ ClientLeaderRegInterface::ClientLeaderRegInterface(INetwork* local) {
 	                                             TaskPriority::Coordination);
 }
 
-// Nominee is the worker among all workers that are considered as leader by a coordinator
-// This function contacts a coordinator coord to ask if the worker is considered as a leader (i.e., if the worker
-// is a nominee)
+// Nominee is the worker among all workers that are considered as leader by one coordinator
+// This function contacts a coordinator coord to ask who is its nominee.
 ACTOR Future<Void> monitorNominee(Key key,
                                   ClientLeaderRegInterface coord,
                                   AsyncTrigger* nomineeChange,
@@ -529,18 +528,6 @@ ACTOR Future<MonitorLeaderInfo> monitorLeaderOneGeneration(Reference<ClusterConn
 	}
 }
 
-Future<Void> monitorLeaderRemotelyInternal(Reference<ClusterConnectionFile> const& connFile,
-                                           Reference<AsyncVar<Value>> const& outSerializedLeaderInfo);
-
-template <class LeaderInterface>
-Future<Void> monitorLeaderRemotely(Reference<ClusterConnectionFile> const& connFile,
-                                   Reference<AsyncVar<Optional<LeaderInterface>>> const& outKnownLeader) {
-	LeaderDeserializer<LeaderInterface> deserializer;
-	auto serializedInfo = makeReference<AsyncVar<Value>>();
-	Future<Void> m = monitorLeaderRemotelyInternal(connFile, serializedInfo);
-	return m || deserializer(serializedInfo, outKnownLeader);
-}
-
 ACTOR Future<Void> monitorLeaderInternal(Reference<ClusterConnectionFile> connFile,
                                          Reference<AsyncVar<Value>> outSerializedLeaderInfo) {
 	state MonitorLeaderInfo info(connFile);
@@ -656,7 +643,7 @@ ACTOR Future<Void> getClientInfoFromLeader(Reference<AsyncVar<Optional<ClusterCo
 		choose {
 			when(ClientDBInfo ni =
 			         wait(brokenPromiseToNever(knownLeader->get().get().clientInterface.openDatabase.getReply(req)))) {
-				TraceEvent("MonitorLeaderForProxiesGotClientInfo", knownLeader->get().get().clientInterface.id())
+				TraceEvent("GetClientInfoFromLeaderGotClientInfo", knownLeader->get().get().clientInterface.id())
 				    .detail("CommitProxy0", ni.commitProxies.size() ? ni.commitProxies[0].id() : UID())
 				    .detail("GrvProxy0", ni.grvProxies.size() ? ni.grvProxies[0].id() : UID())
 				    .detail("ClientID", ni.id);
@@ -667,10 +654,10 @@ ACTOR Future<Void> getClientInfoFromLeader(Reference<AsyncVar<Optional<ClusterCo
 	}
 }
 
-ACTOR Future<Void> monitorLeaderForProxies(Key clusterKey,
-                                           vector<NetworkAddress> coordinators,
-                                           ClientData* clientData,
-                                           Reference<AsyncVar<Optional<LeaderInfo>>> leaderInfo) {
+ACTOR Future<Void> monitorLeaderAndGetClientInfo(Key clusterKey,
+                                                 vector<NetworkAddress> coordinators,
+                                                 ClientData* clientData,
+                                                 Reference<AsyncVar<Optional<LeaderInfo>>> leaderInfo) {
 	state vector<ClientLeaderRegInterface> clientLeaderServers;
 	state AsyncTrigger nomineeChange;
 	state std::vector<Optional<LeaderInfo>> nominees;
@@ -695,7 +682,7 @@ ACTOR Future<Void> monitorLeaderForProxies(Key clusterKey,
 
 	loop {
 		Optional<std::pair<LeaderInfo, bool>> leader = getLeader(nominees);
-		TraceEvent("MonitorLeaderForProxiesChange")
+		TraceEvent("MonitorLeaderAndGetClientInfoLeaderChange")
 		    .detail("NewLeader", leader.present() ? leader.get().first.changeID : UID(1, 1))
 		    .detail("Key", clusterKey.printable());
 		if (leader.present()) {
@@ -705,7 +692,7 @@ ACTOR Future<Void> monitorLeaderForProxies(Key clusterKey,
 				outInfo.forward = leader.get().first.serializedInfo;
 				clientData->clientInfo->set(CachedSerialization<ClientDBInfo>(outInfo));
 				leaderInfo->set(leader.get().first);
-				TraceEvent("MonitorLeaderForProxiesForwarding")
+				TraceEvent("MonitorLeaderAndGetClientInfoForwarding")
 				    .detail("NewConnStr", leader.get().first.serializedInfo.toString());
 				return Void();
 			}
@@ -762,7 +749,6 @@ void shrinkProxyList(ClientDBInfo& ni,
 	}
 }
 
-// Leader is the process that will be elected by coordinators as the cluster controller
 ACTOR Future<MonitorLeaderInfo> monitorProxiesOneGeneration(
     Reference<ClusterConnectionFile> connFile,
     Reference<AsyncVar<ClientDBInfo>> clientInfo,
@@ -773,7 +759,7 @@ ACTOR Future<MonitorLeaderInfo> monitorProxiesOneGeneration(
 	state ClusterConnectionString cs = info.intermediateConnFile->getConnectionString();
 	state vector<NetworkAddress> addrs = cs.coordinators();
 	state int idx = 0;
-	state int successIdx = 0;
+	state int successIndex = 0;
 	state Optional<double> incorrectTime;
 	state std::vector<UID> lastCommitProxyUIDs;
 	state std::vector<CommitProxyInterface> lastCommitProxies;
@@ -840,11 +826,11 @@ ACTOR Future<MonitorLeaderInfo> monitorProxiesOneGeneration(
 			auto& ni = rep.get().mutate();
 			shrinkProxyList(ni, lastCommitProxyUIDs, lastCommitProxies, lastGrvProxyUIDs, lastGrvProxies);
 			clientInfo->set(ni);
-			successIdx = idx;
+			successIndex = idx;
 		} else {
 			TEST(rep.getError().code() == error_code_failed_to_progress); // Coordinator cant talk to cluster controller
 			idx = (idx + 1) % addrs.size();
-			if (idx == successIdx) {
+			if (idx == successIndex) {
 				wait(delay(CLIENT_KNOBS->COORDINATOR_RECONNECTION_DELAY));
 			}
 		}

--- a/fdbclient/MonitorLeader.h
+++ b/fdbclient/MonitorLeader.h
@@ -61,17 +61,23 @@ struct MonitorLeaderInfo {
 	  : hasConnected(false), intermediateConnFile(intermediateConnFile) {}
 };
 
-// Monitors the given coordination group's leader election process and provides a best current guess
-// of the current leader.  If a leader is elected for long enough and communication with a quorum of
-// coordinators is possible, eventually outKnownLeader will be that leader's interface.
+Optional<std::pair<LeaderInfo, bool>> getLeader(const vector<Optional<LeaderInfo>>& nominees);
+
+// This is one place where the leader election algorithm is run. The coodinator contacts all coodinators to collect
+// nominees, the nominee with the most nomination is the leader. This function also monitors the change of the leader.
+// If a leader is elected for long enough and communication with a quorum of coordinators is possible, eventually
+// outKnownLeader will be that leader's interface.
 template <class LeaderInterface>
 Future<Void> monitorLeader(Reference<ClusterConnectionFile> const& connFile,
                            Reference<AsyncVar<Optional<LeaderInterface>>> const& outKnownLeader);
 
-Future<Void> monitorLeaderForProxies(Value const& key,
-                                     vector<NetworkAddress> const& coordinators,
-                                     ClientData* const& clientData,
-                                     Reference<AsyncVar<Optional<LeaderInfo>>> const& leaderInfo);
+// This is one place where the leader election algorithm is run. The coodinator contacts all coodinators to collect
+// nominees, the nominee with the most nomination is the leader, and collects client data from the leader. This function
+// also monitors the change of the leader.
+Future<Void> monitorLeaderAndGetClientInfo(Value const& key,
+                                           vector<NetworkAddress> const& coordinators,
+                                           ClientData* const& clientData,
+                                           Reference<AsyncVar<Optional<LeaderInfo>>> const& leaderInfo);
 
 Future<Void> monitorProxies(
     Reference<AsyncVar<Reference<ClusterConnectionFile>>> const& connFile,

--- a/fdbserver/Coordination.actor.cpp
+++ b/fdbserver/Coordination.actor.cpp
@@ -299,8 +299,8 @@ ACTOR Future<Void> leaderRegister(LeaderElectionRegInterface interf, Key key) {
 				req.reply.send(clientData.clientInfo->get());
 			} else {
 				if (!leaderMon.isValid()) {
-					leaderMon =
-					    monitorLeaderForProxies(req.clusterKey, req.coordinators, &clientData, currentElectedLeader);
+					leaderMon = monitorLeaderAndGetClientInfo(
+					    req.clusterKey, req.coordinators, &clientData, currentElectedLeader);
 				}
 				actors.add(
 				    openDatabase(&clientData, &clientCount, hasConnectedClients, req, canConnectToLeader.checkStuck()));
@@ -312,7 +312,8 @@ ACTOR Future<Void> leaderRegister(LeaderElectionRegInterface interf, Key key) {
 				req.reply.send(currentElectedLeader->get());
 			} else {
 				if (!leaderMon.isValid()) {
-					leaderMon = monitorLeaderForProxies(req.key, req.coordinators, &clientData, currentElectedLeader);
+					leaderMon =
+					    monitorLeaderAndGetClientInfo(req.key, req.coordinators, &clientData, currentElectedLeader);
 				}
 				actors.add(remoteMonitorLeader(&clientCount, hasConnectedClients, currentElectedLeader, req));
 			}

--- a/fdbserver/LeaderElection.actor.cpp
+++ b/fdbserver/LeaderElection.actor.cpp
@@ -25,8 +25,6 @@
 #include "fdbclient/MonitorLeader.h"
 #include "flow/actorcompiler.h" // This must be the last #include.
 
-Optional<std::pair<LeaderInfo, bool>> getLeader(const vector<Optional<LeaderInfo>>& nominees);
-
 ACTOR Future<Void> submitCandidacy(Key key,
                                    LeaderElectionRegInterface coord,
                                    LeaderInfo myInfo,

--- a/fdbserver/LeaderElection.h
+++ b/fdbserver/LeaderElection.h
@@ -28,13 +28,6 @@
 
 class ServerCoordinators;
 
-template <class LeaderInterface>
-Future<Void> tryBecomeLeader(ServerCoordinators const& coordinators,
-                             LeaderInterface const& proposedInterface,
-                             Reference<AsyncVar<Optional<LeaderInterface>>> const& outKnownLeader,
-                             bool hasConnected,
-                             Reference<AsyncVar<ClusterControllerPriorityInfo>> const& asyncPriorityInfo);
-
 // Participates in the given coordination group's leader election process, nominating the given
 // LeaderInterface (presumed to be a local interface) as leader.  The leader election process is
 // "sticky" - once a leader becomes leader, as long as its communications with other processes are
@@ -43,9 +36,15 @@ Future<Void> tryBecomeLeader(ServerCoordinators const& coordinators,
 // set to the proposedInterface, and then if it is displaced by another leader, the return value will
 // eventually be set.  If the return value is cancelled, the candidacy or leadership of the proposedInterface
 // will eventually end.
+template <class LeaderInterface>
+Future<Void> tryBecomeLeader(ServerCoordinators const& coordinators,
+                             LeaderInterface const& proposedInterface,
+                             Reference<AsyncVar<Optional<LeaderInterface>>> const& outKnownLeader,
+                             bool hasConnected,
+                             Reference<AsyncVar<ClusterControllerPriorityInfo>> const& asyncPriorityInfo);
 
-Future<Void> changeLeaderCoordinators(ServerCoordinators const& coordinators, Value const& forwardingInfo);
 // Inform all the coordinators that they have been replaced with a new connection string
+Future<Void> changeLeaderCoordinators(ServerCoordinators const& coordinators, Value const& forwardingInfo);
 
 #ifndef __INTEL_COMPILER
 #pragma region Implementation


### PR DESCRIPTION
1. Rename monitorLeaderRemotely* functions to monitorLeaderWithDelayedCandidacy*. "Remote" is not clearly describing what the functions are doing;
2. Rename monitorLeaderForProxies() to monitorLeaderAndGetClientInfo() to better describe the function;
3. Remove monitorLeaderRemotelyInternal() and monitorLeaderRemotely() in MonitorLeader.actor.cpp, to eliminate code duplication. They already exist in worker.actor.cpp;
4. Move the declaration of getLeader() from LeaderElection.actor.cpp to MonitorLeader.h;
5. Update a few comments.

20210914-004908-renxuan-8ff93566406bdf00           compressed=True data_size=25526454 duration=5089580 ended=102088 fail_fast=10 max_runs=100000 pass=100196 priority=100 remaining=0 runtime=0:58:52 sanity=False started=102218 stopped=20210914-014800 submitted=20210914-004908 timeout=5400 username=renxuan

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
