### PR TITLE
Version vector prototype: Address simulation test failures

### DIFF
--- a/fdbclient/DatabaseContext.h
+++ b/fdbclient/DatabaseContext.h
@@ -455,6 +455,7 @@ public:
 	// commit version of that storage server is below the specified "readVersion".
 	void getLatestCommitVersions(const Reference<LocationInfo>& locationInfo,
 	                             Version readVersion,
+	                             const TransactionInfo& info,
 	                             VersionVector& latestCommitVersions);
 
 	// used in template functions to create a transaction

--- a/fdbclient/FDBTypes.h
+++ b/fdbclient/FDBTypes.h
@@ -132,7 +132,7 @@ struct Traceable<Tag> : std::true_type {
 namespace std {
 template <>
 struct hash<Tag> {
-	std::size_t operator() (const Tag& tag) const {
+	std::size_t operator()(const Tag& tag) const {
 		std::size_t seed = 0;
 		boost::hash_combine(seed, std::hash<int8_t>{}(tag.locality));
 		boost::hash_combine(seed, std::hash<uint16_t>{}(tag.id));

--- a/fdbclient/IClientApi.h
+++ b/fdbclient/IClientApi.h
@@ -27,6 +27,8 @@
 
 #include "flow/ThreadHelper.actor.h"
 
+class VersionVector;
+
 // An interface that represents a transaction created by a client
 class ITransaction {
 public:
@@ -79,7 +81,7 @@ public:
 
 	virtual ThreadFuture<Void> commit() = 0;
 	virtual Version getCommittedVersion() = 0;
-	virtual std::string getVersionVector() = 0;
+	virtual VersionVector getVersionVector() = 0;
 	virtual UID getSpanID() = 0;
 	virtual ThreadFuture<int64_t> getApproximateSize() = 0;
 

--- a/fdbclient/IClientApi.h
+++ b/fdbclient/IClientApi.h
@@ -79,6 +79,8 @@ public:
 
 	virtual ThreadFuture<Void> commit() = 0;
 	virtual Version getCommittedVersion() = 0;
+	virtual std::string getVersionVector() = 0;
+	virtual UID getSpanID() = 0;
 	virtual ThreadFuture<int64_t> getApproximateSize() = 0;
 
 	virtual void setOption(FDBTransactionOptions::Option option, Optional<StringRef> value = Optional<StringRef>()) = 0;

--- a/fdbclient/IClientApi.h
+++ b/fdbclient/IClientApi.h
@@ -81,6 +81,9 @@ public:
 
 	virtual ThreadFuture<Void> commit() = 0;
 	virtual Version getCommittedVersion() = 0;
+	// @todo This API and the "getSpanID()" API may help with debugging simulation
+	// test failures. (These APIs are not currently invoked anywhere.) Remove them
+	// later if they are not really needed.
 	virtual VersionVector getVersionVector() = 0;
 	virtual UID getSpanID() = 0;
 	virtual ThreadFuture<int64_t> getApproximateSize() = 0;

--- a/fdbclient/IConfigTransaction.h
+++ b/fdbclient/IConfigTransaction.h
@@ -44,6 +44,8 @@ public:
 
 	// Not implemented:
 	void setVersion(Version) override { throw client_invalid_operation(); }
+	std::string getVersionVector() const override { throw client_invalid_operation(); }
+	UID getSpanID() const override { throw client_invalid_operation(); }
 	Future<Key> getKey(KeySelector const& key, Snapshot snapshot = Snapshot::False) override {
 		throw client_invalid_operation();
 	}

--- a/fdbclient/IConfigTransaction.h
+++ b/fdbclient/IConfigTransaction.h
@@ -44,7 +44,7 @@ public:
 
 	// Not implemented:
 	void setVersion(Version) override { throw client_invalid_operation(); }
-	std::string getVersionVector() const override { throw client_invalid_operation(); }
+	VersionVector getVersionVector() const override { throw client_invalid_operation(); }
 	UID getSpanID() const override { throw client_invalid_operation(); }
 	Future<Key> getKey(KeySelector const& key, Snapshot snapshot = Snapshot::False) override {
 		throw client_invalid_operation();

--- a/fdbclient/ISingleThreadTransaction.h
+++ b/fdbclient/ISingleThreadTransaction.h
@@ -76,7 +76,7 @@ public:
 	virtual void addWriteConflictRange(KeyRangeRef const& keys) = 0;
 	virtual Future<Void> commit() = 0;
 	virtual Version getCommittedVersion() const = 0;
-	virtual std::string getVersionVector() const = 0;
+	virtual VersionVector getVersionVector() const = 0;
 	virtual UID getSpanID() const = 0;
 	virtual int64_t getApproximateSize() const = 0;
 	virtual Future<Standalone<StringRef>> getVersionstamp() = 0;

--- a/fdbclient/ISingleThreadTransaction.h
+++ b/fdbclient/ISingleThreadTransaction.h
@@ -76,6 +76,8 @@ public:
 	virtual void addWriteConflictRange(KeyRangeRef const& keys) = 0;
 	virtual Future<Void> commit() = 0;
 	virtual Version getCommittedVersion() const = 0;
+	virtual std::string getVersionVector() const = 0;
+	virtual UID getSpanID() const = 0;
 	virtual int64_t getApproximateSize() const = 0;
 	virtual Future<Standalone<StringRef>> getVersionstamp() = 0;
 	virtual void setOption(FDBTransactionOptions::Option option, Optional<StringRef> value = Optional<StringRef>()) = 0;

--- a/fdbclient/MultiVersionTransaction.actor.cpp
+++ b/fdbclient/MultiVersionTransaction.actor.cpp
@@ -285,6 +285,10 @@ void DLTransaction::reset() {
 	api->transactionReset(tr);
 }
 
+VersionVector DLTransaction::getVersionVector() {
+	return VersionVector(); // not implemented
+}
+
 // DLDatabase
 DLDatabase::DLDatabase(Reference<FdbCApi> api, ThreadFuture<FdbCApi::FDBDatabase*> dbFuture) : api(api), db(nullptr) {
 	addref();
@@ -826,13 +830,13 @@ Version MultiVersionTransaction::getCommittedVersion() {
 	return invalidVersion;
 }
 
-std::string MultiVersionTransaction::getVersionVector() {
+VersionVector MultiVersionTransaction::getVersionVector() {
 	auto tr = getTransaction();
 	if (tr.transaction) {
 		return tr.transaction->getVersionVector();
 	}
 
-	return std::string("transaction not found");
+	return VersionVector();
 }
 
 UID MultiVersionTransaction::getSpanID() {

--- a/fdbclient/MultiVersionTransaction.actor.cpp
+++ b/fdbclient/MultiVersionTransaction.actor.cpp
@@ -668,6 +668,7 @@ void MultiVersionTransaction::setVersion(Version v) {
 		tr.transaction->setVersion(v);
 	}
 }
+
 ThreadFuture<Version> MultiVersionTransaction::getReadVersion() {
 	auto tr = getTransaction();
 	auto f = tr.transaction ? tr.transaction->getReadVersion() : ThreadFuture<Version>(Never());
@@ -823,6 +824,24 @@ Version MultiVersionTransaction::getCommittedVersion() {
 	}
 
 	return invalidVersion;
+}
+
+std::string MultiVersionTransaction::getVersionVector() {
+	auto tr = getTransaction();
+	if (tr.transaction) {
+		return tr.transaction->getVersionVector();
+	}
+
+	return std::string("transaction not found");
+}
+
+UID MultiVersionTransaction::getSpanID() {
+	auto tr = getTransaction();
+	if (tr.transaction) {
+		return tr.transaction->getSpanID();
+	}
+
+	return UID();
 }
 
 ThreadFuture<int64_t> MultiVersionTransaction::getApproximateSize() {

--- a/fdbclient/MultiVersionTransaction.h
+++ b/fdbclient/MultiVersionTransaction.h
@@ -239,6 +239,8 @@ public:
 
 	ThreadFuture<Void> commit() override;
 	Version getCommittedVersion() override;
+	std::string getVersionVector() override { return std::string("DLTransaction::Not implemented"); }
+	UID getSpanID() override { return UID(); };
 	ThreadFuture<int64_t> getApproximateSize() override;
 
 	void setOption(FDBTransactionOptions::Option option, Optional<StringRef> value = Optional<StringRef>()) override;
@@ -378,6 +380,8 @@ public:
 
 	ThreadFuture<Void> commit() override;
 	Version getCommittedVersion() override;
+	std::string getVersionVector() override;
+	UID getSpanID() override;
 	ThreadFuture<int64_t> getApproximateSize() override;
 
 	void setOption(FDBTransactionOptions::Option option, Optional<StringRef> value = Optional<StringRef>()) override;

--- a/fdbclient/MultiVersionTransaction.h
+++ b/fdbclient/MultiVersionTransaction.h
@@ -239,7 +239,7 @@ public:
 
 	ThreadFuture<Void> commit() override;
 	Version getCommittedVersion() override;
-	std::string getVersionVector() override { return std::string("DLTransaction::Not implemented"); }
+	VersionVector getVersionVector() override;
 	UID getSpanID() override { return UID(); };
 	ThreadFuture<int64_t> getApproximateSize() override;
 
@@ -380,7 +380,7 @@ public:
 
 	ThreadFuture<Void> commit() override;
 	Version getCommittedVersion() override;
-	std::string getVersionVector() override;
+	VersionVector getVersionVector() override;
 	UID getSpanID() override;
 	ThreadFuture<int64_t> getApproximateSize() override;
 

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -212,8 +212,7 @@ void DatabaseContext::getLatestCommitVersions(const Reference<LocationInfo>& loc
 	}
 
 	if (readVersion > ssVersionVectorCache.getMaxVersion()) {
-		// @todo Use SevError here (and drop "ASSERT(false)").
-		TraceEvent("GetLatestCommitVersions")
+		TraceEvent(SevError, "GetLatestCommitVersions")
 		    .detail("ReadVersion", readVersion)
 		    .detail("Version vector", ssVersionVectorCache.toString());
 		ASSERT(false);

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -203,11 +203,16 @@ void DatabaseContext::getLatestCommitVersions(const Reference<LocationInfo>& loc
                                               VersionVector& latestCommitVersions) {
 	latestCommitVersions.clear();
 
+	if (info.debugID.present()) {
+		g_traceBatch.addEvent("TransactionDebug", info.debugID.get().first(), "NativeAPI.getLatestCommitVersions");
+	}
+
 	if (!info.readVersionObtainedFromGrvProxy) {
 		return;
 	}
 
 	if (readVersion > ssVersionVectorCache.getMaxVersion()) {
+		// @todo Use SevError here (and drop "ASSERT(false)").
 		TraceEvent("GetLatestCommitVersions")
 		    .detail("ReadVersion", readVersion)
 		    .detail("Version vector", ssVersionVectorCache.toString());
@@ -4245,8 +4250,8 @@ void Transaction::flushTrLogsIfEnabled() {
 	}
 }
 
-std::string Transaction::getVersionVector() const {
-	return cx->ssVersionVectorCache.toString();
+VersionVector Transaction::getVersionVector() const {
+	return cx->ssVersionVectorCache;
 }
 
 void Transaction::setVersion(Version v) {

--- a/fdbclient/NativeAPI.actor.h
+++ b/fdbclient/NativeAPI.actor.h
@@ -388,7 +388,7 @@ public:
 	void fullReset();
 	double getBackoff(int errCode);
 	void debugTransaction(UID dID) { info.debugID = dID; }
-	std::string getVersionVector() const;
+	VersionVector getVersionVector() const;
 	UID getSpanID() const { return info.spanID; }
 
 	Future<Void> commitMutations();

--- a/fdbclient/NativeAPI.actor.h
+++ b/fdbclient/NativeAPI.actor.h
@@ -180,12 +180,13 @@ struct TransactionInfo {
 	// prefix/<key1> : '1' - any keys equal or larger than this key are (probably) conflicting keys
 	// prefix/<key2> : '0' - any keys equal or larger than this key are (definitely) not conflicting keys
 	std::shared_ptr<CoalescedKeyRangeMap<Value>> conflictingKeys;
+	bool readVersionObtainedFromGrvProxy;
 
 	// Only available so that Transaction can have a default constructor, for use in state variables
 	TransactionInfo() : taskID(), spanID(), useProvisionalProxies() {}
 
 	explicit TransactionInfo(TaskPriority taskID, SpanID spanID)
-	  : taskID(taskID), spanID(spanID), useProvisionalProxies(false) {}
+	  : taskID(taskID), spanID(spanID), useProvisionalProxies(false), readVersionObtainedFromGrvProxy(true) {}
 };
 
 struct TransactionLogInfo : public ReferenceCounted<TransactionLogInfo>, NonCopyable {
@@ -387,6 +388,8 @@ public:
 	void fullReset();
 	double getBackoff(int errCode);
 	void debugTransaction(UID dID) { info.debugID = dID; }
+	std::string getVersionVector() const;
+	UID getSpanID() const { return info.spanID; }
 
 	Future<Void> commitMutations();
 	void setupWatches();

--- a/fdbclient/ReadYourWrites.h
+++ b/fdbclient/ReadYourWrites.h
@@ -123,6 +123,9 @@ public:
 
 	[[nodiscard]] Future<Void> commit() override;
 	Version getCommittedVersion() const override { return tr.getCommittedVersion(); }
+	std::string getVersionVector() const override { return tr.getVersionVector(); }
+	UID getSpanID() const override { return tr.getSpanID(); }
+
 	int64_t getApproximateSize() const override { return approximateSize; }
 	[[nodiscard]] Future<Standalone<StringRef>> getVersionstamp() override;
 

--- a/fdbclient/ReadYourWrites.h
+++ b/fdbclient/ReadYourWrites.h
@@ -123,7 +123,7 @@ public:
 
 	[[nodiscard]] Future<Void> commit() override;
 	Version getCommittedVersion() const override { return tr.getCommittedVersion(); }
-	std::string getVersionVector() const override { return tr.getVersionVector(); }
+	VersionVector getVersionVector() const override { return tr.getVersionVector(); }
 	UID getSpanID() const override { return tr.getSpanID(); }
 
 	int64_t getApproximateSize() const override { return approximateSize; }

--- a/fdbclient/ThreadSafeTransaction.cpp
+++ b/fdbclient/ThreadSafeTransaction.cpp
@@ -353,6 +353,14 @@ Version ThreadSafeTransaction::getCommittedVersion() {
 	return tr->getCommittedVersion();
 }
 
+std::string ThreadSafeTransaction::getVersionVector() {
+	return tr->getVersionVector();
+}
+
+UID ThreadSafeTransaction::getSpanID() {
+	return tr->getSpanID();
+}
+
 ThreadFuture<int64_t> ThreadSafeTransaction::getApproximateSize() {
 	ISingleThreadTransaction* tr = this->tr;
 	return onMainThread([tr]() -> Future<int64_t> { return tr->getApproximateSize(); });

--- a/fdbclient/ThreadSafeTransaction.cpp
+++ b/fdbclient/ThreadSafeTransaction.cpp
@@ -353,7 +353,7 @@ Version ThreadSafeTransaction::getCommittedVersion() {
 	return tr->getCommittedVersion();
 }
 
-std::string ThreadSafeTransaction::getVersionVector() {
+VersionVector ThreadSafeTransaction::getVersionVector() {
 	return tr->getVersionVector();
 }
 

--- a/fdbclient/ThreadSafeTransaction.h
+++ b/fdbclient/ThreadSafeTransaction.h
@@ -127,7 +127,7 @@ public:
 
 	ThreadFuture<Void> commit() override;
 	Version getCommittedVersion() override;
-	std::string getVersionVector() override;
+	VersionVector getVersionVector() override;
 	UID getSpanID() override;
 	ThreadFuture<int64_t> getApproximateSize() override;
 

--- a/fdbclient/ThreadSafeTransaction.h
+++ b/fdbclient/ThreadSafeTransaction.h
@@ -127,6 +127,8 @@ public:
 
 	ThreadFuture<Void> commit() override;
 	Version getCommittedVersion() override;
+	std::string getVersionVector() override;
+	UID getSpanID() override;
 	ThreadFuture<int64_t> getApproximateSize() override;
 
 	ThreadFuture<uint64_t> getProtocolVersion();

--- a/fdbclient/VersionVector.h
+++ b/fdbclient/VersionVector.h
@@ -108,7 +108,7 @@ struct VersionVector {
 			return;
 		}
 
-		if (maxVersion == delta.maxVersion) {
+		if (maxVersion >= delta.maxVersion) {
 			return;
 		}
 

--- a/fdbclient/VersionVector.h
+++ b/fdbclient/VersionVector.h
@@ -96,6 +96,8 @@ struct VersionVector {
 		for (auto& [version, tags] : tmpVersionMap) {
 			delta.setVersion(tags, version);
 		}
+
+		delta.maxVersion = maxVersion;
 	}
 
 	// @note this method, together with method getDelta(), helps minimize
@@ -120,7 +122,10 @@ struct VersionVector {
 		for (auto& [version, tags] : tmpVersionMap) {
 			setVersion(tags, version);
 		}
+
+		maxVersion = delta.maxVersion;
 	}
+
 	std::string toString() const {
 		std::stringstream vector;
 		vector << "[";

--- a/fdbserver/BackupWorker.actor.cpp
+++ b/fdbserver/BackupWorker.actor.cpp
@@ -439,6 +439,7 @@ struct BackupData {
 				                                                       &GrvProxyInterface::getConsistentReadVersion,
 				                                                       request,
 				                                                       self->cx->taskID))) {
+					self->cx->ssVersionVectorCache.applyDelta(reply.ssVersionVectorDelta);
 					return reply.version;
 				}
 			}

--- a/fdbserver/LogSystem.h
+++ b/fdbserver/LogSystem.h
@@ -739,14 +739,15 @@ struct ILogSystem {
 	// Never returns normally, but throws an error if the subsystem stops working
 
 	// Future<Void> push( UID bundle, int64_t seq, VectorRef<TaggedMessageRef> messages );
-	virtual Future<Version> push(Version prevVersion,
-	                             Version version,
-	                             Version knownCommittedVersion,
-	                             Version minKnownCommittedVersion,
-	                             struct LogPushData& data,
-	                             SpanID const& spanContext,
-	                             Optional<UID> debugID = Optional<UID>(),
-                                 Optional<std::unordered_map<uint16_t, Version>> = Optional<std::unordered_map<uint16_t, Version>>()) = 0;
+	virtual Future<Version> push(
+	    Version prevVersion,
+	    Version version,
+	    Version knownCommittedVersion,
+	    Version minKnownCommittedVersion,
+	    struct LogPushData& data,
+	    SpanID const& spanContext,
+	    Optional<UID> debugID = Optional<UID>(),
+	    Optional<std::unordered_map<uint16_t, Version>> = Optional<std::unordered_map<uint16_t, Version>>()) = 0;
 	// Waits for the version number of the bundle (in this epoch) to be prevVersion (i.e. for all pushes ordered
 	// earlier) Puts the given messages into the bundle, each with the given tags, and with message versions (version,
 	// 0) - (version, N) Changes the version number of the bundle to be version (unblocking the next push) Returns when

--- a/fdbserver/LogSystemConfig.h
+++ b/fdbserver/LogSystemConfig.h
@@ -293,7 +293,7 @@ struct LogSystemConfig {
 	}
 
 	int numLogs() const {
-		int numLogs=0;
+		int numLogs = 0;
 		for (auto& tLogSet : tLogs) {
 			if (tLogSet.isLocal == true) {
 				numLogs += tLogSet.tLogs.size();

--- a/fdbserver/MasterInterface.h
+++ b/fdbserver/MasterInterface.h
@@ -206,7 +206,8 @@ struct GetTLogPrevCommitVersionRequest {
 	Version prev;
 	ReplyPromise<GetTLogPrevCommitVersionReply> reply;
 	GetTLogPrevCommitVersionRequest() {}
-	GetTLogPrevCommitVersionRequest(std::set<uint16_t>& writtenTLogs, Version commitVersion, Version prev) : writtenTLogs(writtenTLogs), commitVersion(commitVersion), prev(prev) {}
+	GetTLogPrevCommitVersionRequest(std::set<uint16_t>& writtenTLogs, Version commitVersion, Version prev)
+	  : writtenTLogs(writtenTLogs), commitVersion(commitVersion), prev(prev) {}
 	template <class Ar>
 	void serialize(Ar& ar) {
 		serializer(ar, writtenTLogs, commitVersion, prev, reply);

--- a/fdbserver/Status.actor.cpp
+++ b/fdbserver/Status.actor.cpp
@@ -1264,6 +1264,8 @@ ACTOR static Future<double> doCommitProbe(Future<double> grvProbe, Transaction* 
 
 	ASSERT(sourceTr->getReadVersion().isReady());
 	tr->setVersion(sourceTr->getReadVersion().get());
+	tr->getDatabase()->ssVersionVectorCache = sourceTr->getDatabase()->ssVersionVectorCache;
+	tr->info.readVersionObtainedFromGrvProxy = sourceTr->info.readVersionObtainedFromGrvProxy;
 
 	state double start = g_network->timer_monotonic();
 

--- a/fdbserver/workloads/ApiWorkload.h
+++ b/fdbserver/workloads/ApiWorkload.h
@@ -69,6 +69,12 @@ struct TransactionWrapper : public ReferenceCounted<TransactionWrapper> {
 	// Gets the committed version of a transaction
 	virtual Version getCommittedVersion() = 0;
 
+	// Gets the version vector cached in a transaction
+	virtual std::string getVersionVector() = 0;
+
+	// Gets the spanID of a transaction
+	virtual UID getSpanID() = 0;
+
 	// Prints debugging messages for a transaction; not implemented for all transaction types
 	virtual void debugTransaction(UID debugId) {}
 
@@ -135,6 +141,12 @@ struct FlowTransactionWrapper : public TransactionWrapper {
 	// Gets the committed version of a transaction
 	Version getCommittedVersion() override { return transaction.getCommittedVersion(); }
 
+	// Gets the version vector cached in a transaction
+	std::string getVersionVector() override { return transaction.getVersionVector(); }
+
+	// Gets the spanID of a transaction
+	UID getSpanID() override { return transaction.getSpanID(); }
+
 	// Prints debugging messages for a transaction
 	void debugTransaction(UID debugId) override { transaction.debugTransaction(debugId); }
 
@@ -187,6 +199,10 @@ struct ThreadTransactionWrapper : public TransactionWrapper {
 
 	// Gets the committed version of a transaction
 	Version getCommittedVersion() override { return transaction->getCommittedVersion(); }
+
+	std::string getVersionVector() override { return transaction->getVersionVector(); }
+
+	UID getSpanID() override { return transaction->getSpanID(); }
 
 	void addReadConflictRange(KeyRangeRef const& keys) override { transaction->addReadConflictRange(keys); }
 };

--- a/fdbserver/workloads/ApiWorkload.h
+++ b/fdbserver/workloads/ApiWorkload.h
@@ -70,7 +70,7 @@ struct TransactionWrapper : public ReferenceCounted<TransactionWrapper> {
 	virtual Version getCommittedVersion() = 0;
 
 	// Gets the version vector cached in a transaction
-	virtual std::string getVersionVector() = 0;
+	virtual VersionVector getVersionVector() = 0;
 
 	// Gets the spanID of a transaction
 	virtual UID getSpanID() = 0;
@@ -142,7 +142,7 @@ struct FlowTransactionWrapper : public TransactionWrapper {
 	Version getCommittedVersion() override { return transaction.getCommittedVersion(); }
 
 	// Gets the version vector cached in a transaction
-	std::string getVersionVector() override { return transaction.getVersionVector(); }
+	VersionVector getVersionVector() override { return transaction.getVersionVector(); }
 
 	// Gets the spanID of a transaction
 	UID getSpanID() override { return transaction.getSpanID(); }
@@ -200,8 +200,10 @@ struct ThreadTransactionWrapper : public TransactionWrapper {
 	// Gets the committed version of a transaction
 	Version getCommittedVersion() override { return transaction->getCommittedVersion(); }
 
-	std::string getVersionVector() override { return transaction->getVersionVector(); }
+	// Gets the version vector cached in a transaction
+	VersionVector getVersionVector() override { return transaction->getVersionVector(); }
 
+	// Gets the spanID of a transaction
 	UID getSpanID() override { return transaction->getSpanID(); }
 
 	void addReadConflictRange(KeyRangeRef const& keys) override { transaction->addReadConflictRange(keys); }


### PR DESCRIPTION
Address simulation test failures caused by:

- Assertion failures in MoveKeys.actor.cpp
- Wrong results returned by getRange()
- Assertion failure in DatabaseContext::getLatestCommitVersions(()

Changes:

DatabaseContext.h, NativeAPI.actor.[h,cpp]:
- Introduce a new flag, TransactionInfo::readVersionObtainedFromGrvProxy.
- Set this flag to true by default, and clear it when the read version of a
transaction is explicitly set (by using setVersion()).
- Modify getLatestCommitVersions() to not populate "latestCommitVersions" if
this flag is not set. (This will cause storage server to read at the specified
read version.)

- Modify getRange() actor to always use the specified version as the read
version (except when the specified version is latestVersion).

- Modify waitForCommittedVersion(), getRawVersion(), and getConsistentReadVersion()
to update local version vector cache after receiving GetReadVersionReply.

IClientApi.h, IConfigTransaction.h, ISingleThreadTransaction.h,
MultiVersionTransaction[.actor].[h,cpp], ThreadSafeTransaction.[h,cpp],
ApiWorkload.h:
- Add methods to get the spanID of a transaction and also the version vector
cached in a transaction. (Likely to be useful for debugging simulation test
failures.)

VersionVector.h:
- Update "maxVersion" when populating/applying a delta. (Note that empty
mutation messages only update VersionVector::maxVersion.)
- Apply the delta version vector only if the max version of the local version
vector cache is below the max version of the delta version vector.

BackupWorker.actor.cpp:
- Update local version vector cache after receiving GetReadVersionReply message.

Status.actor.cpp:
- Update local version vector cache and
TransactionInfo::info.readVersionObtainedFromGrvProxy after setting the
read version.

Tests that fail without this change:

- This test fails on assertion "!dest.empty()" in MoveKeys.actor.cpp:
../../build_output/bin/fdbserver -r simulation -f tests/slow/VersionStampBackupToDB.toml -b on -s 408274400

- This test fails with error "Clear resulted in incorrect database"/"Clear (range) resulted in incorrect database":
../../build_output/bin/fdbserver -r simulation --crash -f tests/slow/SwizzledApiCorrectness.toml -b on -s 705951580

Test that fails on ASSERT(false) in DatabaseContext::getLatestCommitVersions() without commit 59bed61:
../../build_output/bin/fdbserver -r simulation --crash -f tests/fast/ConstrainedRandomSelector.toml -b on -s 879654813

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
