### PR TITLE
Transactions would not honor the transaction timeout option if the MVC did not have an active database

### DIFF
--- a/documentation/sphinx/source/release-notes/release-notes-630.rst
+++ b/documentation/sphinx/source/release-notes/release-notes-630.rst
@@ -4,7 +4,8 @@ Release Notes
 
 6.3.20
 ======
-* Several minor problems with the versioned packages have been fixed `(PR 5607) <https://github.com/apple/foundationdb/pull/5607>`_
+* Several minor problems with the versioned packages have been fixed. `(PR 5607) <https://github.com/apple/foundationdb/pull/5607>`_
+* A client might not honor transaction timeouts when using the multi-version client if it cannot connect to the cluster. `(Issue #5595) <https://github.com/apple/foundationdb/issues/5595>`_
 
 6.3.19
 ======

--- a/documentation/sphinx/source/release-notes/release-notes-700.rst
+++ b/documentation/sphinx/source/release-notes/release-notes-700.rst
@@ -64,6 +64,7 @@ Fixes
 * If a restore is done using a prefix to remove and specific key ranges to restore, the key range boundaries must begin with the prefix to remove. `(PR #4684) <https://github.com/apple/foundationdb/pull/4684>`_
 * The multi-version client API would not propagate errors that occurred when creating databases on external clients. This could result in a invalid memory accesses. `(PR #5220) <https://github.com/apple/foundationdb/pull/5220>`_
 * Fixed a race between the multi-version client connecting to a cluster and destroying the database that could cause an assertion failure. `(PR #5220) <https://github.com/apple/foundationdb/pull/5220>`_
+* A client might not honor transaction timeouts when using the multi-version client if it cannot connect to the cluster. `(Issue #5595) <https://github.com/apple/foundationdb/issues/5595>`_
 
 Status
 ------

--- a/fdbclient/MultiVersionTransaction.actor.cpp
+++ b/fdbclient/MultiVersionTransaction.actor.cpp
@@ -606,7 +606,7 @@ void DLApi::addNetworkThreadCompletionHook(void (*hook)(void*), void* hookParame
 // MultiVersionTransaction
 MultiVersionTransaction::MultiVersionTransaction(Reference<MultiVersionDatabase> db,
                                                  UniqueOrderedOptionList<FDBTransactionOptions> defaultOptions)
-  : db(db), startTime(timer_monotonic()), timeoutFuture(new ThreadSingleAssignmentVar<Void>()) {
+  : db(db), startTime(timer_monotonic()), timeoutTsav(new ThreadSingleAssignmentVar<Void>()) {
 	setDefaultOptions(defaultOptions);
 	updateTransaction();
 }
@@ -877,50 +877,90 @@ ThreadFuture<Void> MultiVersionTransaction::onError(Error const& e) {
 	}
 }
 
-ACTOR Future<Void> timeoutImpl(Reference<ThreadSingleAssignmentVarBase> tsav, double duration) {
+// Waits for the specified duration and signals the assignment variable with a timed out error
+// This will be canceled if a new timeout is set, in which case the tsav will not be signaled.
+ACTOR Future<Void> timeoutImpl(Reference<ThreadSingleAssignmentVar<Void>> tsav, double duration) {
 	wait(delay(duration));
-	if (!tsav->isReady()) {
-		tsav->sendError(transaction_timed_out());
-	}
 
+	tsav->trySendError(transaction_timed_out());
 	return Void();
 }
 
+// Configure a timeout based on the options set for this transaction. This timeout only applies
+// if we don't have an underlying database object to connect with.
 void MultiVersionTransaction::setTimeout(Optional<StringRef> value) {
 	double timeoutDuration = extractIntOption(value, 0, std::numeric_limits<int>::max()) / 1000.0;
 
 	ThreadFuture<Void> prevTimeout;
-	{
+	ThreadFuture<Void> newTimeout = onMainThread([this, timeoutDuration]() {
+		return timeoutImpl(timeoutTsav, timeoutDuration - std::max(0.0, now() - startTime));
+	});
+
+	{ // lock scope
 		ThreadSpinLockHolder holder(timeoutLock);
 
 		prevTimeout = currentTimeout;
-		currentTimeout = onMainThread([this, timeoutDuration]() {
-			return timeoutImpl(Reference<ThreadSingleAssignmentVarBase>::addRef(timeoutFuture.getPtr()),
-			                   timeoutDuration - std::max(0.0, now() - startTime));
-		});
+		currentTimeout = newTimeout;
 	}
 
+	// Cancel the previous timeout now that we have a new one. This means that changing the timeout
+	// affects in-flight operations, which is consistent with the behavior in RYW.
 	if (prevTimeout.isValid()) {
 		prevTimeout.cancel();
 	}
 }
 
+// Creates a ThreadFuture<T> that will signal an error if the transaction times out.
 template <class T>
 ThreadFuture<T> MultiVersionTransaction::makeTimeout() {
-	return mapThreadFuture<Void, T>(timeoutFuture, [](ErrorOr<Void> v) {
+	ThreadFuture<Void> f;
+
+	// We create a ThreadFuture that holds a reference to this below,
+	// but the ThreadFuture does not increment the ref count
+	timeoutTsav->addref();
+
+	{ // lock scope
+		ThreadSpinLockHolder holder(timeoutLock);
+		f = ThreadFuture<Void>(timeoutTsav.getPtr());
+	}
+
+	// When our timeoutTsav gets set, map it to the appropriate type
+	return mapThreadFuture<Void, T>(f, [](ErrorOr<Void> v) {
 		ASSERT(v.isError());
-		if (v.getError().code() == error_code_transaction_timed_out) {
-			return ErrorOr<T>(v.getError());
-		} else {
-			return ErrorOr<T>(transaction_cancelled());
-		}
+		return ErrorOr<T>(v.getError());
 	});
 }
 
 void MultiVersionTransaction::reset() {
 	persistentOptions.clear();
+
+	// Reset the timeout state
+	Reference<ThreadSingleAssignmentVar<Void>> prevTimeoutTsav;
+	ThreadFuture<Void> prevTimeout;
+	startTime = timer_monotonic();
+
+	{ // lock scope
+		ThreadSpinLockHolder holder(timeoutLock);
+
+		prevTimeoutTsav = timeoutTsav;
+		timeoutTsav = makeReference<ThreadSingleAssignmentVar<Void>>();
+
+		prevTimeout = currentTimeout;
+		currentTimeout = ThreadFuture<Void>();
+	}
+
+	// Cancel any outstanding operations if they don't have an underlying transaction object to cancel them
+	prevTimeoutTsav->trySendError(transaction_cancelled());
+	if (prevTimeout.isValid()) {
+		prevTimeout.cancel();
+	}
+
 	setDefaultOptions(db->dbState->transactionDefaultOptions);
 	updateTransaction();
+}
+
+MultiVersionTransaction::~MultiVersionTransaction() {
+	timeoutTsav->trySendError(transaction_cancelled());
 }
 
 bool MultiVersionTransaction::isValid() {

--- a/fdbclient/MultiVersionTransaction.h
+++ b/fdbclient/MultiVersionTransaction.h
@@ -400,6 +400,15 @@ private:
 		ThreadFuture<Void> onChange;
 	};
 
+	double startTime;
+	ThreadSpinLock timeoutLock;
+	ThreadFuture<Void> timeoutFuture;
+	ThreadFuture<Void> currentTimeout;
+	void setTimeout(Optional<StringRef> value);
+
+	template <class T>
+	ThreadFuture<T> makeTimeout();
+
 	TransactionInfo transaction;
 
 	TransactionInfo getTransaction();

--- a/fdbclient/MultiVersionTransaction.h
+++ b/fdbclient/MultiVersionTransaction.h
@@ -334,6 +334,8 @@ public:
 	MultiVersionTransaction(Reference<MultiVersionDatabase> db,
 	                        UniqueOrderedOptionList<FDBTransactionOptions> defaultOptions);
 
+	~MultiVersionTransaction() override;
+
 	void cancel() override;
 	void setVersion(Version v) override;
 	ThreadFuture<Version> getReadVersion() override;
@@ -400,12 +402,26 @@ private:
 		ThreadFuture<Void> onChange;
 	};
 
-	double startTime;
+	// Timeout related variables for MultiVersionTransaction objects that do not have an underlying ITransaction
+
+	// The time when the MultiVersionTransaction was last created or reset
+	std::atomic<double> startTime;
+
+	// A lock that needs to be held if using timeoutTsav or currentTimeout
 	ThreadSpinLock timeoutLock;
-	ThreadFuture<Void> timeoutFuture;
+
+	// A single assignment var (i.e. promise) that gets set with an error when the timeout elapses or the transaction
+	// is reset or destroyed.
+	Reference<ThreadSingleAssignmentVar<Void>> timeoutTsav;
+
+	// A reference to the current actor waiting for the timeout. This actor will set the timeoutTsav promise.
 	ThreadFuture<Void> currentTimeout;
+
+	// Configure a timeout based on the options set for this transaction. This timeout only applies
+	// if we don't have an underlying database object to connect with.
 	void setTimeout(Optional<StringRef> value);
 
+	// Creates a ThreadFuture<T> that will signal an error if the transaction times out.
 	template <class T>
 	ThreadFuture<T> makeTimeout();
 

--- a/flow/ThreadHelper.actor.h
+++ b/flow/ThreadHelper.actor.h
@@ -250,19 +250,21 @@ public:
 		this->status = NeverSet;
 	}
 
-	void sendError(const Error& err) {
+	// Sends an error through the assignment var if it is not already set. Otherwise does nothing.
+	// Returns true if the assignment var was not already set; otherwise returns false.
+	bool trySendError(const Error& err) {
 		if (TRACE_SAMPLE())
 			TraceEvent(SevSample, "Promise_sendError").detail("ErrorCode", err.code());
 		this->mutex.enter();
 		if (!canBeSetUnsafe()) {
 			this->mutex.leave();
-			ASSERT(false); // Promise fulfilled twice
+			return false;
 		}
 		error = err;
 		status = ErrorSet;
 		if (!callback) {
 			this->mutex.leave();
-			return;
+			return true;
 		}
 		auto func = callback;
 		if (!callback->isMultiCallback())
@@ -277,7 +279,12 @@ public:
 			int userParam = 0;
 			func->error(err, userParam);
 		}
+
+		return true;
 	}
+
+	// Like trySendError, except that it is assumed the assignment var is not already set.
+	void sendError(const Error& err) { ASSERT(trySendError(err)); }
 
 	SetCallbackResult::Result callOrSetAsCallback(ThreadCallback* callback, int& userParam1, int notMadeActive) {
 		this->mutex.enter();


### PR DESCRIPTION
This could happen if, for example, the client has never been able to connect to the cluster or if the version of the cluster change to one not supported by the client.

Resolves #5595.

Passed correctness, bindingtester, and some TSAN tests.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
