### PR TITLE
Transactions would not honor the transaction timeout option if the MVC did not have an active database (release 6.3)

### DIFF
--- a/documentation/sphinx/source/release-notes/release-notes-630.rst
+++ b/documentation/sphinx/source/release-notes/release-notes-630.rst
@@ -6,7 +6,8 @@ Release Notes
 
 6.3.20
 ======
-* Several minor problems with the versioned packages have been fixed `(PR 5607) <https://github.com/apple/foundationdb/pull/5607>`_
+* Several minor problems with the versioned packages have been fixed. `(PR 5607) <https://github.com/apple/foundationdb/pull/5607>`_
+* A client might not honor transaction timeouts when using the multi-version client if it cannot connect to the cluster. `(Issue #5595) <https://github.com/apple/foundationdb/issues/5595>`_
 
 6.3.19
 ======

--- a/fdbclient/MultiVersionTransaction.actor.cpp
+++ b/fdbclient/MultiVersionTransaction.actor.cpp
@@ -625,7 +625,8 @@ ThreadFuture<Standalone<RangeResultRef>> MultiVersionTransaction::getRange(const
                                                                            bool snapshot,
                                                                            bool reverse) {
 	auto tr = getTransaction();
-	auto f = tr.transaction ? tr.transaction->getRange(keys, limits, snapshot, reverse) : makeTimeout<Standalone<RangeResultRef>>();
+	auto f = tr.transaction ? tr.transaction->getRange(keys, limits, snapshot, reverse)
+	                        : makeTimeout<Standalone<RangeResultRef>>();
 	return abortableFuture(f, tr.onChange);
 }
 
@@ -835,7 +836,7 @@ void MultiVersionTransaction::reset() {
 		ThreadSpinLockHolder holder(timeoutLock);
 
 		prevTimeoutTsav = timeoutTsav;
-		timeoutTsav = makeReference<ThreadSingleAssignmentVar<Void>>();
+		timeoutTsav = Reference<ThreadSingleAssignmentVar<Void>>(new ThreadSingleAssignmentVar<Void>());
 
 		prevTimeout = currentTimeout;
 		currentTimeout = ThreadFuture<Void>();

--- a/fdbclient/MultiVersionTransaction.h
+++ b/fdbclient/MultiVersionTransaction.h
@@ -349,6 +349,15 @@ private:
 		ThreadFuture<Void> onChange;
 	};
 
+	double startTime;
+	ThreadSpinLock timeoutLock;
+	ThreadFuture<Void> timeoutFuture;
+	ThreadFuture<Void> currentTimeout;
+	void setTimeout(Optional<StringRef> value);
+
+	template <class T>
+	ThreadFuture<T> makeTimeout();
+
 	TransactionInfo transaction;
 
 	TransactionInfo getTransaction();

--- a/fdbclient/MultiVersionTransaction.h
+++ b/fdbclient/MultiVersionTransaction.h
@@ -288,6 +288,8 @@ public:
 	MultiVersionTransaction(Reference<MultiVersionDatabase> db,
 	                        UniqueOrderedOptionList<FDBTransactionOptions> defaultOptions);
 
+	~MultiVersionTransaction() override;
+
 	void cancel() override;
 	void setVersion(Version v) override;
 	ThreadFuture<Version> getReadVersion() override;
@@ -349,12 +351,26 @@ private:
 		ThreadFuture<Void> onChange;
 	};
 
-	double startTime;
+	// Timeout related variables for MultiVersionTransaction objects that do not have an underlying ITransaction
+
+	// The time when the MultiVersionTransaction was last created or reset
+	std::atomic<double> startTime;
+
+	// A lock that needs to be held if using timeoutTsav or currentTimeout
 	ThreadSpinLock timeoutLock;
-	ThreadFuture<Void> timeoutFuture;
+
+	// A single assignment var (i.e. promise) that gets set with an error when the timeout elapses or the transaction
+	// is reset or destroyed.
+	Reference<ThreadSingleAssignmentVar<Void>> timeoutTsav;
+
+	// A reference to the current actor waiting for the timeout. This actor will set the timeoutTsav promise.
 	ThreadFuture<Void> currentTimeout;
+
+	// Configure a timeout based on the options set for this transaction. This timeout only applies
+	// if we don't have an underlying database object to connect with.
 	void setTimeout(Optional<StringRef> value);
 
+	// Creates a ThreadFuture<T> that will signal an error if the transaction times out.
 	template <class T>
 	ThreadFuture<T> makeTimeout();
 


### PR DESCRIPTION
This could happen if, for example, the client has never been able to connect to the cluster or if the version of the cluster change to one not supported by the client.

This is a cherry-pick of #5598.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
