### PR TITLE
Enforcing 6.22.1 rocksdb version and enabling readRange deadline option.

### DIFF
--- a/cmake/CompileRocksDB.cmake
+++ b/cmake/CompileRocksDB.cmake
@@ -1,6 +1,6 @@
 # FindRocksDB
 
-find_package(RocksDB)
+find_package(RocksDB 6.22.1)
 
 include(ExternalProject)
 

--- a/cmake/FindRocksDB.cmake
+++ b/cmake/FindRocksDB.cmake
@@ -4,5 +4,20 @@ find_path(ROCKSDB_INCLUDE_DIR
   NAMES rocksdb/db.h
   PATH_SUFFIXES include)
 
+if(ROCKSDB_INCLUDE_DIR AND EXISTS "${ROCKSDB_INCLUDE_DIR}/rocksdb/version.h")
+  foreach(ver "MAJOR" "MINOR" "PATCH")
+    file(STRINGS "${ROCKSDB_INCLUDE_DIR}/rocksdb/version.h" ROCKSDB_VER_${ver}_LINE
+      REGEX "^#define[ \t]+ROCKSDB_${ver}[ \t]+[0-9]+$")
+    string(REGEX REPLACE "^#define[ \t]+ROCKSDB_${ver}[ \t]+([0-9]+)$"
+      "\\1" ROCKSDB_VERSION_${ver} "${ROCKSDB_VER_${ver}_LINE}")
+    unset(${ROCKSDB_VER_${ver}_LINE})
+  endforeach()
+  set(ROCKSDB_VERSION_STRING
+    "${ROCKSDB_VERSION_MAJOR}.${ROCKSDB_VERSION_MINOR}.${ROCKSDB_VERSION_PATCH}")
+
+  message(STATUS "Found RocksDB version: ${ROCKSDB_VERSION_STRING}")
+endif()
+
 find_package_handle_standard_args(RocksDB
-  DEFAULT_MSG ROCKSDB_INCLUDE_DIR)
+  REQUIRED_VARS ROCKSDB_INCLUDE_DIR
+  VERSION_VAR ROCKSDB_VERSION_STRING)

--- a/fdbserver/KeyValueStoreRocksDB.actor.cpp
+++ b/fdbserver/KeyValueStoreRocksDB.actor.cpp
@@ -25,11 +25,11 @@
 
 #ifdef SSD_ROCKSDB_EXPERIMENTAL
 
-static_assert(ROCKSDB_MAJOR >= 6
-                  ? (ROCKSDB_MAJOR == 6
-                         ? (ROCKSDB_MINOR >= 22 ? (ROCKSDB_MINOR == 22 ? ROCKSDB_PATCH >= 1 : true) : false)
-                         : true)
-                  : false,
+// Enforcing rocksdb version to be 6.22.1 or greater.
+static_assert(ROCKSDB_MAJOR >= 6, "Unsupported rocksdb version. Update the rocksdb to 6.22.1 version");
+static_assert(ROCKSDB_MAJOR == 6 ? ROCKSDB_MINOR >= 22 : true,
+              "Unsupported rocksdb version. Update the rocksdb to 6.22.1 version");
+static_assert((ROCKSDB_MAJOR == 6 && ROCKSDB_MINOR == 22) ? ROCKSDB_PATCH >= 1 : true,
               "Unsupported rocksdb version. Update the rocksdb to 6.22.1 version");
 
 namespace {


### PR DESCRIPTION
The deadline option for readRange op in rocksdb is supported only from v6.22.1.tar.gz rocksdb version.
We use this deadline option in our fdb code (currently disabled). So,eEnforcing 6.22.1 rocksdb version and enabling readRange deadline option.

Test scenarios tested:
FRESH INSTALL: Removed build_output and /opt/rocksdb directories and checked if 6.22.1 is installed
Backporting: After the fresh install, Changed the version  and url_hash to 6.20.3 and checked if it is overwriting 6.22.1 version and installing 6.20.3
Forward porting: After 6.20.3 is installed, changed the version and url_hash to 6.22.1 and checked if it is overwriting 6.20.3 version and installing 6.22.1

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
