### PR TITLE
Minor leader election code improvements (release-7.0).

### DIFF
--- a/fdbclient/MonitorLeader.actor.cpp
+++ b/fdbclient/MonitorLeader.actor.cpp
@@ -387,9 +387,8 @@ ClientLeaderRegInterface::ClientLeaderRegInterface(INetwork* local) {
 	openDatabase.makeWellKnownEndpoint(WLTOKEN_CLIENTLEADERREG_OPENDATABASE, TaskPriority::Coordination);
 }
 
-// Nominee is the worker among all workers that are considered as leader by a coordinator
-// This function contacts a coordinator coord to ask if the worker is considered as a leader (i.e., if the worker
-// is a nominee)
+// Nominee is the worker among all workers that are considered as leader by one coordinator
+// This function contacts a coordinator coord to ask who is its nominee.
 ACTOR Future<Void> monitorNominee(Key key,
                                   ClientLeaderRegInterface coord,
                                   AsyncTrigger* nomineeChange,
@@ -522,18 +521,6 @@ ACTOR Future<MonitorLeaderInfo> monitorLeaderOneGeneration(Reference<ClusterConn
 	}
 }
 
-Future<Void> monitorLeaderRemotelyInternal(Reference<ClusterConnectionFile> const& connFile,
-                                           Reference<AsyncVar<Value>> const& outSerializedLeaderInfo);
-
-template <class LeaderInterface>
-Future<Void> monitorLeaderRemotely(Reference<ClusterConnectionFile> const& connFile,
-                                   Reference<AsyncVar<Optional<LeaderInterface>>> const& outKnownLeader) {
-	LeaderDeserializer<LeaderInterface> deserializer;
-	auto serializedInfo = makeReference<AsyncVar<Value>>();
-	Future<Void> m = monitorLeaderRemotelyInternal(connFile, serializedInfo);
-	return m || deserializer(serializedInfo, outKnownLeader);
-}
-
 ACTOR Future<Void> monitorLeaderInternal(Reference<ClusterConnectionFile> connFile,
                                          Reference<AsyncVar<Value>> outSerializedLeaderInfo) {
 	state MonitorLeaderInfo info(connFile);
@@ -649,7 +636,7 @@ ACTOR Future<Void> getClientInfoFromLeader(Reference<AsyncVar<Optional<ClusterCo
 		choose {
 			when(ClientDBInfo ni =
 			         wait(brokenPromiseToNever(knownLeader->get().get().clientInterface.openDatabase.getReply(req)))) {
-				TraceEvent("MonitorLeaderForProxiesGotClientInfo", knownLeader->get().get().clientInterface.id())
+				TraceEvent("GetClientInfoFromLeaderGotClientInfo", knownLeader->get().get().clientInterface.id())
 				    .detail("CommitProxy0", ni.commitProxies.size() ? ni.commitProxies[0].id() : UID())
 				    .detail("GrvProxy0", ni.grvProxies.size() ? ni.grvProxies[0].id() : UID())
 				    .detail("ClientID", ni.id);
@@ -660,10 +647,10 @@ ACTOR Future<Void> getClientInfoFromLeader(Reference<AsyncVar<Optional<ClusterCo
 	}
 }
 
-ACTOR Future<Void> monitorLeaderForProxies(Key clusterKey,
-                                           vector<NetworkAddress> coordinators,
-                                           ClientData* clientData,
-                                           Reference<AsyncVar<Optional<LeaderInfo>>> leaderInfo) {
+ACTOR Future<Void> monitorLeaderAndGetClientInfo(Key clusterKey,
+                                                 vector<NetworkAddress> coordinators,
+                                                 ClientData* clientData,
+                                                 Reference<AsyncVar<Optional<LeaderInfo>>> leaderInfo) {
 	state vector<ClientLeaderRegInterface> clientLeaderServers;
 	state AsyncTrigger nomineeChange;
 	state std::vector<Optional<LeaderInfo>> nominees;
@@ -688,7 +675,7 @@ ACTOR Future<Void> monitorLeaderForProxies(Key clusterKey,
 
 	loop {
 		Optional<std::pair<LeaderInfo, bool>> leader = getLeader(nominees);
-		TraceEvent("MonitorLeaderForProxiesChange")
+		TraceEvent("MonitorLeaderAndGetClientInfoLeaderChange")
 		    .detail("NewLeader", leader.present() ? leader.get().first.changeID : UID(1, 1))
 		    .detail("Key", clusterKey.printable());
 		if (leader.present()) {
@@ -698,7 +685,7 @@ ACTOR Future<Void> monitorLeaderForProxies(Key clusterKey,
 				outInfo.forward = leader.get().first.serializedInfo;
 				clientData->clientInfo->set(CachedSerialization<ClientDBInfo>(outInfo));
 				leaderInfo->set(leader.get().first);
-				TraceEvent("MonitorLeaderForProxiesForwarding")
+				TraceEvent("MonitorLeaderAndGetClientInfoForwarding")
 				    .detail("NewConnStr", leader.get().first.serializedInfo.toString());
 				return Void();
 			}
@@ -755,7 +742,6 @@ void shrinkProxyList(ClientDBInfo& ni,
 	}
 }
 
-// Leader is the process that will be elected by coordinators as the cluster controller
 ACTOR Future<MonitorLeaderInfo> monitorProxiesOneGeneration(
     Reference<ClusterConnectionFile> connFile,
     Reference<AsyncVar<ClientDBInfo>> clientInfo,
@@ -766,7 +752,7 @@ ACTOR Future<MonitorLeaderInfo> monitorProxiesOneGeneration(
 	state ClusterConnectionString cs = info.intermediateConnFile->getConnectionString();
 	state vector<NetworkAddress> addrs = cs.coordinators();
 	state int idx = 0;
-	state int successIdx = 0;
+	state int successIndex = 0;
 	state Optional<double> incorrectTime;
 	state std::vector<UID> lastCommitProxyUIDs;
 	state std::vector<CommitProxyInterface> lastCommitProxies;
@@ -833,10 +819,10 @@ ACTOR Future<MonitorLeaderInfo> monitorProxiesOneGeneration(
 			auto& ni = rep.get().mutate();
 			shrinkProxyList(ni, lastCommitProxyUIDs, lastCommitProxies, lastGrvProxyUIDs, lastGrvProxies);
 			clientInfo->set(ni);
-			successIdx = idx;
+			successIndex = idx;
 		} else {
 			idx = (idx + 1) % addrs.size();
-			if (idx == successIdx) {
+			if (idx == successIndex) {
 				wait(delay(CLIENT_KNOBS->COORDINATOR_RECONNECTION_DELAY));
 			}
 		}

--- a/fdbclient/MonitorLeader.h
+++ b/fdbclient/MonitorLeader.h
@@ -61,17 +61,23 @@ struct MonitorLeaderInfo {
 	  : intermediateConnFile(intermediateConnFile), hasConnected(false) {}
 };
 
-// Monitors the given coordination group's leader election process and provides a best current guess
-// of the current leader.  If a leader is elected for long enough and communication with a quorum of
-// coordinators is possible, eventually outKnownLeader will be that leader's interface.
+Optional<std::pair<LeaderInfo, bool>> getLeader(const vector<Optional<LeaderInfo>>& nominees);
+
+// This is one place where the leader election algorithm is run. The coodinator contacts all coodinators to collect
+// nominees, the nominee with the most nomination is the leader. This function also monitors the change of the leader.
+// If a leader is elected for long enough and communication with a quorum of coordinators is possible, eventually
+// outKnownLeader will be that leader's interface.
 template <class LeaderInterface>
 Future<Void> monitorLeader(Reference<ClusterConnectionFile> const& connFile,
                            Reference<AsyncVar<Optional<LeaderInterface>>> const& outKnownLeader);
 
-Future<Void> monitorLeaderForProxies(Value const& key,
-                                     vector<NetworkAddress> const& coordinators,
-                                     ClientData* const& clientData,
-                                     Reference<AsyncVar<Optional<LeaderInfo>>> const& leaderInfo);
+// This is one place where the leader election algorithm is run. The coodinator contacts all coodinators to collect
+// nominees, the nominee with the most nomination is the leader, and collects client data from the leader. This function
+// also monitors the change of the leader.
+Future<Void> monitorLeaderAndGetClientInfo(Value const& key,
+                                           vector<NetworkAddress> const& coordinators,
+                                           ClientData* const& clientData,
+                                           Reference<AsyncVar<Optional<LeaderInfo>>> const& leaderInfo);
 
 Future<Void> monitorProxies(
     Reference<AsyncVar<Reference<ClusterConnectionFile>>> const& connFile,

--- a/fdbserver/Coordination.actor.cpp
+++ b/fdbserver/Coordination.actor.cpp
@@ -305,8 +305,8 @@ ACTOR Future<Void> leaderRegister(LeaderElectionRegInterface interf, Key key) {
 				req.reply.send(clientData.clientInfo->get());
 			} else {
 				if (!leaderMon.isValid()) {
-					leaderMon =
-					    monitorLeaderForProxies(req.clusterKey, req.coordinators, &clientData, currentElectedLeader);
+					leaderMon = monitorLeaderAndGetClientInfo(
+					    req.clusterKey, req.coordinators, &clientData, currentElectedLeader);
 				}
 				actors.add(openDatabase(&clientData, &clientCount, hasConnectedClients, req));
 			}
@@ -317,7 +317,8 @@ ACTOR Future<Void> leaderRegister(LeaderElectionRegInterface interf, Key key) {
 				req.reply.send(currentElectedLeader->get());
 			} else {
 				if (!leaderMon.isValid()) {
-					leaderMon = monitorLeaderForProxies(req.key, req.coordinators, &clientData, currentElectedLeader);
+					leaderMon =
+					    monitorLeaderAndGetClientInfo(req.key, req.coordinators, &clientData, currentElectedLeader);
 				}
 				actors.add(remoteMonitorLeader(&clientCount, hasConnectedClients, currentElectedLeader, req));
 			}

--- a/fdbserver/LeaderElection.actor.cpp
+++ b/fdbserver/LeaderElection.actor.cpp
@@ -24,8 +24,6 @@
 #include "fdbclient/MonitorLeader.h"
 #include "flow/actorcompiler.h" // This must be the last #include.
 
-Optional<std::pair<LeaderInfo, bool>> getLeader(const vector<Optional<LeaderInfo>>& nominees);
-
 ACTOR Future<Void> submitCandidacy(Key key,
                                    LeaderElectionRegInterface coord,
                                    LeaderInfo myInfo,

--- a/fdbserver/LeaderElection.h
+++ b/fdbserver/LeaderElection.h
@@ -28,13 +28,6 @@
 
 class ServerCoordinators;
 
-template <class LeaderInterface>
-Future<Void> tryBecomeLeader(ServerCoordinators const& coordinators,
-                             LeaderInterface const& proposedInterface,
-                             Reference<AsyncVar<Optional<LeaderInterface>>> const& outKnownLeader,
-                             bool hasConnected,
-                             Reference<AsyncVar<ClusterControllerPriorityInfo>> const& asyncPriorityInfo);
-
 // Participates in the given coordination group's leader election process, nominating the given
 // LeaderInterface (presumed to be a local interface) as leader.  The leader election process is
 // "sticky" - once a leader becomes leader, as long as its communications with other processes are
@@ -43,9 +36,15 @@ Future<Void> tryBecomeLeader(ServerCoordinators const& coordinators,
 // set to the proposedInterface, and then if it is displaced by another leader, the return value will
 // eventually be set.  If the return value is cancelled, the candidacy or leadership of the proposedInterface
 // will eventually end.
+template <class LeaderInterface>
+Future<Void> tryBecomeLeader(ServerCoordinators const& coordinators,
+                             LeaderInterface const& proposedInterface,
+                             Reference<AsyncVar<Optional<LeaderInterface>>> const& outKnownLeader,
+                             bool hasConnected,
+                             Reference<AsyncVar<ClusterControllerPriorityInfo>> const& asyncPriorityInfo);
 
-Future<Void> changeLeaderCoordinators(ServerCoordinators const& coordinators, Value const& forwardingInfo);
 // Inform all the coordinators that they have been replaced with a new connection string
+Future<Void> changeLeaderCoordinators(ServerCoordinators const& coordinators, Value const& forwardingInfo);
 
 #ifndef __INTEL_COMPILER
 #pragma region Implementation

--- a/fdbserver/worker.actor.cpp
+++ b/fdbserver/worker.actor.cpp
@@ -2122,9 +2122,10 @@ ACTOR Future<UID> createAndLockProcessIdFile(std::string folder) {
 	}
 }
 
-ACTOR Future<MonitorLeaderInfo> monitorLeaderRemotelyOneGeneration(Reference<ClusterConnectionFile> connFile,
-                                                                   Reference<AsyncVar<Value>> result,
-                                                                   MonitorLeaderInfo info) {
+ACTOR Future<MonitorLeaderInfo> monitorLeaderWithDelayedCandidacyImplOneGeneration(
+    Reference<ClusterConnectionFile> connFile,
+    Reference<AsyncVar<Value>> result,
+    MonitorLeaderInfo info) {
 	state ClusterConnectionString ccf = info.intermediateConnFile->getConnectionString();
 	state vector<NetworkAddress> addrs = ccf.coordinators();
 	state ElectionResultRequest request;
@@ -2183,32 +2184,34 @@ ACTOR Future<MonitorLeaderInfo> monitorLeaderRemotelyOneGeneration(Reference<Clu
 	}
 }
 
-ACTOR Future<Void> monitorLeaderRemotelyInternal(Reference<ClusterConnectionFile> connFile,
-                                                 Reference<AsyncVar<Value>> outSerializedLeaderInfo) {
+ACTOR Future<Void> monitorLeaderWithDelayedCandidacyImplInternal(Reference<ClusterConnectionFile> connFile,
+                                                                 Reference<AsyncVar<Value>> outSerializedLeaderInfo) {
 	state MonitorLeaderInfo info(connFile);
 	loop {
-		MonitorLeaderInfo _info = wait(monitorLeaderRemotelyOneGeneration(connFile, outSerializedLeaderInfo, info));
+		MonitorLeaderInfo _info =
+		    wait(monitorLeaderWithDelayedCandidacyImplOneGeneration(connFile, outSerializedLeaderInfo, info));
 		info = _info;
 	}
 }
 
 template <class LeaderInterface>
-Future<Void> monitorLeaderRemotely(Reference<ClusterConnectionFile> const& connFile,
-                                   Reference<AsyncVar<Optional<LeaderInterface>>> const& outKnownLeader) {
+Future<Void> monitorLeaderWithDelayedCandidacyImpl(
+    Reference<ClusterConnectionFile> const& connFile,
+    Reference<AsyncVar<Optional<LeaderInterface>>> const& outKnownLeader) {
 	LeaderDeserializer<LeaderInterface> deserializer;
 	auto serializedInfo = makeReference<AsyncVar<Value>>();
-	Future<Void> m = monitorLeaderRemotelyInternal(connFile, serializedInfo);
+	Future<Void> m = monitorLeaderWithDelayedCandidacyImplInternal(connFile, serializedInfo);
 	return m || deserializer(serializedInfo, outKnownLeader);
 }
 
-ACTOR Future<Void> monitorLeaderRemotelyWithDelayedCandidacy(
+ACTOR Future<Void> monitorLeaderWithDelayedCandidacy(
     Reference<ClusterConnectionFile> connFile,
     Reference<AsyncVar<Optional<ClusterControllerFullInterface>>> currentCC,
     Reference<AsyncVar<ClusterControllerPriorityInfo>> asyncPriorityInfo,
     Future<Void> recoveredDiskFiles,
     LocalityData locality,
     Reference<AsyncVar<ServerDBInfo>> dbInfo) {
-	state Future<Void> monitor = monitorLeaderRemotely(connFile, currentCC);
+	state Future<Void> monitor = monitorLeaderWithDelayedCandidacyImpl(connFile, currentCC);
 	state Future<Void> timeout;
 
 	wait(recoveredDiskFiles);
@@ -2304,7 +2307,7 @@ ACTOR Future<Void> fdbd(Reference<ClusterConnectionFile> connFile,
 		} else if (processClass.machineClassFitness(ProcessClass::ClusterController) == ProcessClass::WorstFit &&
 		           SERVER_KNOBS->MAX_DELAY_CC_WORST_FIT_CANDIDACY_SECONDS > 0) {
 			actors.push_back(
-			    reportErrors(monitorLeaderRemotelyWithDelayedCandidacy(
+			    reportErrors(monitorLeaderWithDelayedCandidacy(
 			                     connFile, cc, asyncPriorityInfo, recoveredDiskFiles.getFuture(), localities, dbInfo),
 			                 "ClusterController"));
 		} else {


### PR DESCRIPTION
Backporting #5592.

1. Rename monitorLeaderRemotely* functions to monitorLeaderWithDelayedCandidacy*. "Remote" is not clearly describing what the functions are doing;
2. Rename monitorLeaderForProxies() to monitorLeaderAndGetClientInfo() to better describe the function;
3. Remove monitorLeaderRemotelyInternal() and monitorLeaderRemotely() in MonitorLeader.actor.cpp, to eliminate code duplication. They already exist in worker.actor.cpp;
4. Move the declaration of getLeader() from LeaderElection.actor.cpp to MonitorLeader.h;
5. Update a few comments.

20210916-232016-renxuan-29621ca9d5b92d8b

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
