### PR TITLE
Fix error handling when locking database

### DIFF
--- a/fdbserver/workloads/SpecialKeySpaceCorrectness.actor.cpp
+++ b/fdbserver/workloads/SpecialKeySpaceCorrectness.actor.cpp
@@ -829,6 +829,10 @@ struct SpecialKeySpaceCorrectnessWorkload : TestWorkload {
 					ASSERT(schemaMatch(schema, valueObj, errorStr, SevError, true));
 					ASSERT(valueObj["command"].get_str() == "lock" && !valueObj["retriable"].get_bool());
 					break;
+				} else if (e.code() == error_code_database_locked) {
+					// Database is already locked. This can happen if a previous attempt
+					// failed with unknown_result.
+					break;
 				} else {
 					wait(tx->onError(e));
 				}


### PR DESCRIPTION
```
bin/fdbserver -r simulation -f tests/fast/SpecialKeySpaceCorrectness.toml -s 33857219 -b off  --crash --trace_format json
```
at commit `e68b131e4a23d7a780cc3767fc6bd1cd31a21966` failed because of a bug in the special keyspace workload:

1. We attempt to lock the database.
2. The transaction returns the error `commit_unknown_result`.
3. We retry
4. The transaction fails with `database_locked`
5. Goto 3 until we time out

The fix is to simply check the error code and then succeed.

I tested this by introducing the fix and reruning the test. As this only changes the workload, there's no need to rerun a full set of joshua tests.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
