### PR TITLE
Fix 2 SS peek bugs

### DIFF
--- a/fdbclient/FDBTypes.cpp
+++ b/fdbclient/FDBTypes.cpp
@@ -68,7 +68,8 @@ std::string KeySelectorRef::toString() const {
 
 namespace ptxn {
 
-TLogGroupID tLogGroupByStorageTeamID(const std::vector<TLogGroupID>& tLogGroups, const StorageTeamID& storageTeamID) {
+TLogGroupID tLogGroupByStorageTeamID(std::vector<TLogGroupID>& tLogGroups, const StorageTeamID& storageTeamID) {
+	std::sort(tLogGroups.begin(), tLogGroups.end());
 	return tLogGroups[storageTeamID.hash() % tLogGroups.size()];
 }
 

--- a/fdbclient/FDBTypes.h
+++ b/fdbclient/FDBTypes.h
@@ -74,8 +74,9 @@ using StorageTeamID = UID;
 // Transaction subsystem state (txnState) team.
 const StorageTeamID txsTeam = UID(1, 1);
 
-// Map from storage team id to a TLog group
-TLogGroupID tLogGroupByStorageTeamID(const std::vector<TLogGroupID>& tLogGroups, const StorageTeamID& storageTeamID);
+// Map from storage team id to a TLog group. "tLogGroups" will be sorted so
+// that the assignment is consistent across calls/machines.
+TLogGroupID tLogGroupByStorageTeamID(std::vector<TLogGroupID>& tLogGroups, const StorageTeamID& storageTeamID);
 
 } // namespace ptxn
 

--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -555,8 +555,6 @@ void ServerKnobs::initialize(Randomize _randomize, ClientKnobs* clientKnobs, IsS
 	init( DURABILITY_LAG_INCREASE_RATE,                        1.001 );
 	init( STORAGE_SERVER_LIST_FETCH_TIMEOUT,                    20.0 );
 
-	init( TLOG_GROUP_COLLECTION_TARGET_SIZE,                      10 );
-
 	init( MAX_AUTO_THROTTLED_TRANSACTION_TAGS,                     5 ); if(randomize && BUGGIFY) MAX_AUTO_THROTTLED_TRANSACTION_TAGS = 1;
 	init( MAX_MANUAL_THROTTLED_TRANSACTION_TAGS,                  40 ); if(randomize && BUGGIFY) MAX_MANUAL_THROTTLED_TRANSACTION_TAGS = 1;
 	init( MIN_TAG_COST,                                          200 ); if(randomize && BUGGIFY) MIN_TAG_COST = 0.0;

--- a/fdbserver/ApplyMetadataMutation.cpp
+++ b/fdbserver/ApplyMetadataMutation.cpp
@@ -247,10 +247,9 @@ private:
 
 		if (SERVER_KNOBS->TLOG_NEW_INTERFACE &&
 		    tLogGroupCollection->tryAddStorageTeam(teamid, decodeStorageTeams(m.param2))) {
-			auto group = tLogGroupCollection->selectFreeGroup(teamid.hash());
+			auto group = tLogGroupCollection->assignStorageTeam(teamid);
 			// TODO: This may be unnessary, as ApplyMetadataMutation case for this key-range
 			//     should do the assignment.
-			tLogGroupCollection->assignStorageTeam(teamid, group);
 			txnStateStore->set(
 			    KeyValueRef(storageTeamIdToTLogGroupKey(teamid), BinaryWriter::toValue(group->id(), Unversioned())));
 		}

--- a/fdbserver/TLogGroup.actor.h
+++ b/fdbserver/TLogGroup.actor.h
@@ -103,9 +103,6 @@ public:
 	// Add a TLogGroup
 	void addTLogGroup(UID debugID, TLogGroupRef group);
 
-	// Find a TLogGroup for assigning a storage team.
-	TLogGroupRef selectFreeGroup(int seed = 0);
-
 	// Return storage team to list of storage server map.
 	const std::map<ptxn::StorageTeamID, vector<UID>>& getStorageTeams() const { return storageTeams; }
 
@@ -113,11 +110,12 @@ public:
 	// already exists, else return `true`.
 	bool tryAddStorageTeam(ptxn::StorageTeamID teamId, vector<UID> servers);
 
-	// Assigns a storage team to given group
-	bool assignStorageTeam(ptxn::StorageTeamID teamId, UID groupId);
+	// Assigns a storage team to given group. This is only called when we know
+	// the group for the team, i.e., in applyMetadataMutations().
+	TLogGroupRef assignStorageTeam(ptxn::StorageTeamID teamId, UID groupId);
 
-	// Assigns a storage team to given group
-	bool assignStorageTeam(ptxn::StorageTeamID teamId, TLogGroupRef group);
+	// Returns the group the storage team is assigned to.
+	TLogGroupRef assignStorageTeam(ptxn::StorageTeamID teamId);
 
 	// Add mutations to store state to given txnStoreState transaction request 'recoveryCommitReq'.
 	void storeState(CommitTransactionRequest* recoveryCommitReq);
@@ -163,7 +161,7 @@ private:
 	std::unordered_map<UID, TLogWorkerDataRef> recruitMap;
 
 	// Map from storage TeamID to list of list of storage servers in that team.
-	std::map<ptxn::StorageTeamID, vector<UID>> storageTeams;
+	std::map<ptxn::StorageTeamID, std::vector<UID>> storageTeams;
 
 	// Map from storage TeamID to the TLogGroup managing that team.
 	std::map<ptxn::StorageTeamID, TLogGroupRef> storageTeamToTLogGroupMap;

--- a/fdbserver/ptxn/TLogInterface.h
+++ b/fdbserver/ptxn/TLogInterface.h
@@ -58,10 +58,6 @@ struct TLogCommitRequest {
 
 	TLogGroupID tLogGroupID;
 
-	// TODO:
-	// std::unordered_map<StorageTeamID, StringRef> commits
-	// TLogGroupID group
-
 	// Arena
 	Arena arena;
 
@@ -120,7 +116,9 @@ struct TLogPeekReply {
 	// StringRef referring the serialized mutation data
 	StringRef data;
 
+	// The first version of this reply. May be non-present if reply is empty.
 	Optional<Version> beginVersion;
+	// Non-inclusive end version of this reply.
 	Version endVersion;
 
 	Optional<Version> popped;
@@ -382,6 +380,7 @@ struct TLogInterfaceBase {
 	NetworkAddress address() const { return commit.getEndpoint().getPrimaryAddress(); }
 	Optional<NetworkAddress> secondaryAddress() const { return commit.getEndpoint().addresses.secondaryAddress; }
 	const LocalityData& getLocality() const { return filteredLocality; }
+	LocalityData& getFilteredLocality() { return filteredLocality; }
 
 	MessageTransferModel getMessageTransferModel() const;
 


### PR DESCRIPTION
SS can choose TLog groups randomly, instead of deterministically, due to the unordered list of group IDs.
TLog is not updating end version in PeekReply for empty message.

20210918-165714-jzhou-923899f1f7901006             compressed=True data_size=26539941 duration=5143330 ended=101295 fail_fast=10 max_runs=100000 pass=100121 priority=100 remaining=0 runtime=0:22:07 sanity=False started=102254 stopped=20210918-171921 submitted=20210918-165714 timeout=5400 username=jzhou

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [x] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
