### PR TITLE
Add missing namespace qualifier to vector.

### DIFF
--- a/fdbserver/ClusterController.actor.cpp
+++ b/fdbserver/ClusterController.actor.cpp
@@ -3451,7 +3451,8 @@ bool isHealthySingleton(ClusterControllerData* self,
 }
 
 // Returns a mapping from pid->pidCount for pids
-std::map<Optional<Standalone<StringRef>>, int> getColocCounts(const vector<Optional<Standalone<StringRef>>>& pids) {
+std::map<Optional<Standalone<StringRef>>, int> getColocCounts(
+    const std::vector<Optional<Standalone<StringRef>>>& pids) {
 	std::map<Optional<Standalone<StringRef>>, int> counts;
 	for (const auto& pid : pids) {
 		++counts[pid];


### PR DESCRIPTION
Missed a namespace (`std`, specifically) qualifier in #5601.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
