### PR TITLE
Stop rolling trace events that are associated with a process role when the role terminates

### DIFF
--- a/fdbrpc/Stats.actor.cpp
+++ b/fdbrpc/Stats.actor.cpp
@@ -99,6 +99,11 @@ ACTOR Future<Void> traceCounters(std::string traceEventName,
 	for (ICounter* c : counters->counters)
 		c->resetInterval();
 
+	state Reference<EventCacheHolder> traceEventHolder;
+	if (!trackLatestName.empty()) {
+		traceEventHolder = makeReference<EventCacheHolder>(trackLatestName);
+	}
+
 	state double last_interval = now();
 
 	loop {
@@ -109,7 +114,7 @@ ACTOR Future<Void> traceCounters(std::string traceEventName,
 		decorator(te);
 
 		if (!trackLatestName.empty()) {
-			te.trackLatest(trackLatestName);
+			te.trackLatest(traceEventHolder->trackingKey);
 		}
 
 		last_interval = now();

--- a/fdbrpc/Stats.h
+++ b/fdbrpc/Stats.h
@@ -227,7 +227,8 @@ private:
 class LatencySample {
 public:
 	LatencySample(std::string name, UID id, double loggingInterval, int sampleSize)
-	  : name(name), id(id), sampleStart(now()), sample(sampleSize) {
+	  : name(name), id(id), sampleStart(now()), sample(sampleSize),
+	    latencySampleEventHolder(makeReference<EventCacheHolder>(id.toString() + "/" + name)) {
 		logger = recurring([this]() { logSample(); }, loggingInterval);
 	}
 
@@ -240,6 +241,8 @@ private:
 
 	ContinuousSample<double> sample;
 	Future<Void> logger;
+
+	Reference<EventCacheHolder> latencySampleEventHolder;
 
 	void logSample() {
 		TraceEvent(name.c_str(), id)
@@ -254,7 +257,7 @@ private:
 		    .detail("P95", sample.percentile(0.95))
 		    .detail("P99", sample.percentile(0.99))
 		    .detail("P99.9", sample.percentile(0.999))
-		    .trackLatest(id.toString() + "/" + name);
+		    .trackLatest(latencySampleEventHolder->trackingKey);
 
 		sample.clear();
 		sampleStart = now();

--- a/fdbserver/ClusterController.actor.cpp
+++ b/fdbserver/ClusterController.actor.cpp
@@ -3071,6 +3071,8 @@ public:
 	Counter registerMasterRequests;
 	Counter statusRequests;
 
+	Reference<EventCacheHolder> recruitedMasterWorkerEventHolder;
+
 	ClusterControllerData(ClusterControllerFullInterface const& ccInterface,
 	                      LocalityData const& locality,
 	                      ServerCoordinators const& coordinators)
@@ -3085,7 +3087,8 @@ public:
 	    getWorkersRequests("GetWorkersRequests", clusterControllerMetrics),
 	    getClientWorkersRequests("GetClientWorkersRequests", clusterControllerMetrics),
 	    registerMasterRequests("RegisterMasterRequests", clusterControllerMetrics),
-	    statusRequests("StatusRequests", clusterControllerMetrics) {
+	    statusRequests("StatusRequests", clusterControllerMetrics),
+	    recruitedMasterWorkerEventHolder(makeReference<EventCacheHolder>("RecruitedMasterWorker")) {
 		auto serverInfo = ServerDBInfo();
 		serverInfo.id = deterministicRandom()->randomUniqueID();
 		serverInfo.infoGeneration = ++db.dbInfoCount;
@@ -3201,7 +3204,7 @@ ACTOR Future<Void> clusterWatchDatabase(ClusterControllerData* cluster, ClusterC
 				// for status tool
 				TraceEvent("RecruitedMasterWorker", cluster->id)
 				    .detail("Address", fNewMaster.get().get().address())
-				    .trackLatest("RecruitedMasterWorker");
+				    .trackLatest(cluster->recruitedMasterWorkerEventHolder->trackingKey);
 
 				iMaster = fNewMaster.get().get();
 

--- a/fdbserver/Ratekeeper.actor.cpp
+++ b/fdbserver/Ratekeeper.actor.cpp
@@ -98,6 +98,8 @@ struct StorageQueueInfo {
 	double busiestReadTagFractionalBusyness = 0, busiestWriteTagFractionalBusyness = 0;
 	double busiestReadTagRate = 0, busiestWriteTagRate = 0;
 
+	Reference<EventCacheHolder> busiestWriteTagEventHolder;
+
 	// refresh periodically
 	TransactionTagMap<TransactionCommitCostEstimation> tagCostEst;
 	uint64_t totalWriteCosts = 0;
@@ -108,7 +110,8 @@ struct StorageQueueInfo {
 	    smoothInputBytes(SERVER_KNOBS->SMOOTHING_AMOUNT), verySmoothDurableBytes(SERVER_KNOBS->SLOW_SMOOTHING_AMOUNT),
 	    smoothDurableVersion(SERVER_KNOBS->SMOOTHING_AMOUNT), smoothLatestVersion(SERVER_KNOBS->SMOOTHING_AMOUNT),
 	    smoothFreeSpace(SERVER_KNOBS->SMOOTHING_AMOUNT), smoothTotalSpace(SERVER_KNOBS->SMOOTHING_AMOUNT),
-	    limitReason(limitReason_t::unlimited) {
+	    limitReason(limitReason_t::unlimited),
+	    busiestWriteTagEventHolder(makeReference<EventCacheHolder>(id.toString() + "/BusiestWriteTag")) {
 		// FIXME: this is a tacky workaround for a potential uninitialized use in trackStorageServerQueueInfo
 		lastReply.instanceID = -1;
 	}
@@ -508,6 +511,8 @@ struct RatekeeperLimits {
 	TransactionPriority priority;
 	std::string context;
 
+	Reference<EventCacheHolder> rkUpdateEventCacheHolder;
+
 	RatekeeperLimits(TransactionPriority priority,
 	                 std::string context,
 	                 int64_t storageTargetBytes,
@@ -525,7 +530,7 @@ struct RatekeeperLimits {
 	        SERVER_KNOBS->MAX_READ_TRANSACTION_LIFE_VERSIONS), // The read transaction life versions are expected to not
 	                                                           // be durable on the storage servers
 	    lastDurabilityLag(0), durabilityLagLimit(std::numeric_limits<double>::infinity()), priority(priority),
-	    context(context) {}
+	    context(context), rkUpdateEventCacheHolder(makeReference<EventCacheHolder>("RkUpdate" + context)) {}
 };
 
 namespace RatekeeperActorCpp {
@@ -924,7 +929,7 @@ Future<Void> refreshStorageServerCommitCost(RatekeeperData* self) {
 		    .detail("TagCost", maxCost.getCostSum())
 		    .detail("TotalCost", it->value.totalWriteCosts)
 		    .detail("Reported", it->value.busiestWriteTag.present())
-		    .trackLatest(it->key.toString() + "/BusiestWriteTag");
+		    .trackLatest(it->value.busiestWriteTagEventHolder->trackingKey);
 
 		// reset statistics
 		it->value.tagCostEst.clear();
@@ -1345,7 +1350,7 @@ void updateRate(RatekeeperData* self, RatekeeperLimits* limits) {
 	limits->reasonMetric = limitReason;
 
 	if (deterministicRandom()->random01() < 0.1) {
-		std::string name = "RkUpdate" + limits->context;
+		const std::string& name = limits->rkUpdateEventCacheHolder.getPtr()->trackingKey;
 		TraceEvent(name.c_str(), self->id)
 		    .detail("TPSLimit", limits->tpsLimit)
 		    .detail("Reason", limitReason)

--- a/fdbserver/masterserver.actor.cpp
+++ b/fdbserver/masterserver.actor.cpp
@@ -251,6 +251,12 @@ struct MasterData : NonCopyable, ReferenceCounted<MasterData> {
 
 	Future<Void> logger;
 
+	Reference<EventCacheHolder> masterRecoveryStateEventHolder;
+	Reference<EventCacheHolder> masterRecoveryGenerationsEventHolder;
+	Reference<EventCacheHolder> masterRecoveryDurationEventHolder;
+	Reference<EventCacheHolder> masterRecoveryAvailableEventHolder;
+	Reference<EventCacheHolder> recoveredConfigEventHolder;
+
 	MasterData(Reference<AsyncVar<ServerDBInfo> const> const& dbInfo,
 	           MasterInterface const& myInterface,
 	           ServerCoordinators const& coordinators,
@@ -271,7 +277,12 @@ struct MasterData : NonCopyable, ReferenceCounted<MasterData> {
 	    getCommitVersionRequests("GetCommitVersionRequests", cc),
 	    backupWorkerDoneRequests("BackupWorkerDoneRequests", cc),
 	    getLiveCommittedVersionRequests("GetLiveCommittedVersionRequests", cc),
-	    reportLiveCommittedVersionRequests("ReportLiveCommittedVersionRequests", cc) {
+	    reportLiveCommittedVersionRequests("ReportLiveCommittedVersionRequests", cc),
+	    masterRecoveryStateEventHolder(makeReference<EventCacheHolder>("MasterRecoveryState")),
+	    masterRecoveryGenerationsEventHolder(makeReference<EventCacheHolder>("MasterRecoveryGenerations")),
+	    masterRecoveryDurationEventHolder(makeReference<EventCacheHolder>("MasterRecoveryDuration")),
+	    masterRecoveryAvailableEventHolder(makeReference<EventCacheHolder>("MasterRecoveryAvailable")),
+	    recoveredConfigEventHolder(makeReference<EventCacheHolder>("RecoveredConfig")) {
 		logger = traceCounters("MasterMetrics", dbgid, SERVER_KNOBS->WORKER_LOGGING_INTERVAL, &cc, "MasterMetrics");
 		if (forceRecovery && !myInterface.locality.dcId().present()) {
 			TraceEvent(SevError, "ForcedRecoveryRequiresDcID").log();
@@ -706,7 +717,7 @@ ACTOR Future<std::vector<Standalone<CommitTransactionRef>>> recruitEverything(
 		TraceEvent("MasterRecoveryState", self->dbgid)
 		    .detail("StatusCode", status)
 		    .detail("Status", RecoveryStatus::names[status])
-		    .trackLatest("MasterRecoveryState");
+		    .trackLatest(self->masterRecoveryStateEventHolder->trackingKey);
 		return Never();
 	} else
 		TraceEvent("MasterRecoveryState", self->dbgid)
@@ -716,7 +727,7 @@ ACTOR Future<std::vector<Standalone<CommitTransactionRef>>> recruitEverything(
 		    .detail("RequiredCommitProxies", 1)
 		    .detail("RequiredGrvProxies", 1)
 		    .detail("RequiredResolvers", 1)
-		    .trackLatest("MasterRecoveryState");
+		    .trackLatest(self->masterRecoveryStateEventHolder->trackingKey);
 
 	// FIXME: we only need log routers for the same locality as the master
 	int maxLogRouters = self->cstate.prevDBState.logRouterTags;
@@ -764,7 +775,7 @@ ACTOR Future<std::vector<Standalone<CommitTransactionRef>>> recruitEverything(
 	    .detail("BackupWorkers", self->backupWorkers.size())
 	    .detail("PrimaryDcIds", primaryDcIds)
 	    .detail("RemoteDcIds", remoteDcIds)
-	    .trackLatest("MasterRecoveryState");
+	    .trackLatest(self->masterRecoveryStateEventHolder->trackingKey);
 
 	// Actually, newSeedServers does both the recruiting and initialization of the seed servers; so if this is a brand
 	// new database we are sort of lying that we are past the recruitment phase.  In a perfect world we would split that
@@ -859,7 +870,7 @@ ACTOR Future<Void> readTransactionSystemState(Reference<MasterData> self,
 	    .setMaxEventLength(11000)
 	    .setMaxFieldLength(10000)
 	    .detail("Conf", self->configuration.toString())
-	    .trackLatest("RecoveredConfig");
+	    .trackLatest(self->recoveredConfigEventHolder->trackingKey);
 
 	RangeResult rawLocalities = wait(self->txnStateStore->readRange(tagLocalityListKeys));
 	self->dcId_locality.clear();
@@ -1045,7 +1056,7 @@ ACTOR Future<Void> recoverFrom(Reference<MasterData> self,
 	TraceEvent("MasterRecoveryState", self->dbgid)
 	    .detail("StatusCode", RecoveryStatus::reading_transaction_system_state)
 	    .detail("Status", RecoveryStatus::names[RecoveryStatus::reading_transaction_system_state])
-	    .trackLatest("MasterRecoveryState");
+	    .trackLatest(self->masterRecoveryStateEventHolder->trackingKey);
 	self->hasConfiguration = false;
 
 	if (BUGGIFY)
@@ -1478,7 +1489,7 @@ ACTOR Future<Void> trackTlogRecovery(Reference<MasterData> self,
 			    .detail("StatusCode", RecoveryStatus::fully_recovered)
 			    .detail("Status", RecoveryStatus::names[RecoveryStatus::fully_recovered])
 			    .detail("FullyRecoveredAtVersion", self->version)
-			    .trackLatest("MasterRecoveryState");
+			    .trackLatest(self->masterRecoveryStateEventHolder->trackingKey);
 
 			TraceEvent("MasterRecoveryGenerations", self->dbgid)
 			    .detail("ActiveGenerations", 1)
@@ -1488,13 +1499,13 @@ ACTOR Future<Void> trackTlogRecovery(Reference<MasterData> self,
 			TraceEvent("MasterRecoveryState", self->dbgid)
 			    .detail("StatusCode", RecoveryStatus::storage_recovered)
 			    .detail("Status", RecoveryStatus::names[RecoveryStatus::storage_recovered])
-			    .trackLatest("MasterRecoveryState");
+			    .trackLatest(self->masterRecoveryStateEventHolder->trackingKey);
 		} else if (allLogs && self->recoveryState < RecoveryState::ALL_LOGS_RECRUITED) {
 			self->recoveryState = RecoveryState::ALL_LOGS_RECRUITED;
 			TraceEvent("MasterRecoveryState", self->dbgid)
 			    .detail("StatusCode", RecoveryStatus::all_logs_recruited)
 			    .detail("Status", RecoveryStatus::names[RecoveryStatus::all_logs_recruited])
-			    .trackLatest("MasterRecoveryState");
+			    .trackLatest(self->masterRecoveryStateEventHolder->trackingKey);
 		}
 
 		if (newState.oldTLogData.size() && configuration.repopulateRegionAntiQuorum > 0 &&
@@ -1679,7 +1690,7 @@ ACTOR Future<Void> masterCore(Reference<MasterData> self) {
 	TraceEvent("MasterRecoveryState", self->dbgid)
 	    .detail("StatusCode", RecoveryStatus::reading_coordinated_state)
 	    .detail("Status", RecoveryStatus::names[RecoveryStatus::reading_coordinated_state])
-	    .trackLatest("MasterRecoveryState");
+	    .trackLatest(self->masterRecoveryStateEventHolder->trackingKey);
 
 	wait(self->cstate.read());
 
@@ -1691,14 +1702,14 @@ ACTOR Future<Void> masterCore(Reference<MasterData> self) {
 	    .detail("ActiveGenerations", self->cstate.myDBState.oldTLogData.size() + 1)
 	    .detail("MyRecoveryCount", self->cstate.prevDBState.recoveryCount + 2)
 	    .detail("ForceRecovery", self->forceRecovery)
-	    .trackLatest("MasterRecoveryState");
+	    .trackLatest(self->masterRecoveryStateEventHolder->trackingKey);
 	// for (const auto& old : self->cstate.prevDBState.oldTLogData) {
 	//	TraceEvent("BWReadCoreState", self->dbgid).detail("Epoch", old.epoch).detail("Version", old.epochEnd);
 	//}
 
 	TraceEvent("MasterRecoveryGenerations", self->dbgid)
 	    .detail("ActiveGenerations", self->cstate.myDBState.oldTLogData.size() + 1)
-	    .trackLatest("MasterRecoveryGenerations");
+	    .trackLatest(self->masterRecoveryGenerationsEventHolder->trackingKey);
 
 	if (self->cstate.myDBState.oldTLogData.size() > CLIENT_KNOBS->MAX_GENERATIONS_OVERRIDE) {
 		if (self->cstate.myDBState.oldTLogData.size() >= CLIENT_KNOBS->MAX_GENERATIONS) {
@@ -1791,7 +1802,7 @@ ACTOR Future<Void> masterCore(Reference<MasterData> self) {
 	    .detail("Status", RecoveryStatus::names[RecoveryStatus::recovery_transaction])
 	    .detail("PrimaryLocality", self->primaryLocality)
 	    .detail("DcId", self->myInterface.locality.dcId())
-	    .trackLatest("MasterRecoveryState");
+	    .trackLatest(self->masterRecoveryStateEventHolder->trackingKey);
 
 	// Recovery transaction
 	state bool debugResult = debug_checkMinRestoredVersion(UID(), self->lastEpochEnd, "DBRecovery", SevWarn);
@@ -1910,7 +1921,7 @@ ACTOR Future<Void> masterCore(Reference<MasterData> self) {
 	    .detail("StatusCode", RecoveryStatus::writing_coordinated_state)
 	    .detail("Status", RecoveryStatus::names[RecoveryStatus::writing_coordinated_state])
 	    .detail("TLogList", self->logSystem->describe())
-	    .trackLatest("MasterRecoveryState");
+	    .trackLatest(self->masterRecoveryStateEventHolder->trackingKey);
 
 	// Multiple masters prevent conflicts between themselves via CoordinatedState (self->cstate)
 	//  1. If SetMaster succeeds, then by CS's contract, these "new" Tlogs are the immediate
@@ -1947,18 +1958,18 @@ ACTOR Future<Void> masterCore(Reference<MasterData> self) {
 	           "MasterRecoveryDuration",
 	           self->dbgid)
 	    .detail("RecoveryDuration", recoveryDuration)
-	    .trackLatest("MasterRecoveryDuration");
+	    .trackLatest(self->masterRecoveryDurationEventHolder->trackingKey);
 
 	TraceEvent("MasterRecoveryState", self->dbgid)
 	    .detail("StatusCode", RecoveryStatus::accepting_commits)
 	    .detail("Status", RecoveryStatus::names[RecoveryStatus::accepting_commits])
 	    .detail("StoreType", self->configuration.storageServerStoreType)
 	    .detail("RecoveryDuration", recoveryDuration)
-	    .trackLatest("MasterRecoveryState");
+	    .trackLatest(self->masterRecoveryStateEventHolder->trackingKey);
 
 	TraceEvent("MasterRecoveryAvailable", self->dbgid)
 	    .detail("AvailableAtVersion", self->version)
-	    .trackLatest("MasterRecoveryAvailable");
+	    .trackLatest(self->masterRecoveryAvailableEventHolder->trackingKey);
 
 	if (self->resolvers.size() > 1)
 		self->addActor.send(resolutionBalancing(self));

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -690,8 +690,8 @@ public:
 		Reference<EventCacheHolder> busiestReadTagEventHolder;
 
 		TransactionTagCounter(UID thisServerID)
-		  : thisServerID(thisServerID), busiestReadTagEventHolder(makeReference<EventCacheHolder>(
-		                                    thisServerID.toString() + "/BusiestReadTag")) {}
+		  : thisServerID(thisServerID),
+		    busiestReadTagEventHolder(makeReference<EventCacheHolder>(thisServerID.toString() + "/BusiestReadTag")) {}
 
 		int64_t costFunction(int64_t bytes) { return bytes / SERVER_KNOBS->READ_COST_BYTE_FACTOR + 1; }
 

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -685,6 +685,14 @@ public:
 
 		Optional<TagInfo> previousBusiestTag;
 
+		UID thisServerID;
+
+		Reference<EventCacheHolder> busiestReadTagEventHolder;
+
+		TransactionTagCounter(UID thisServerID)
+		  : thisServerID(thisServerID), busiestReadTagEventHolder(makeReference<EventCacheHolder>(
+		                                    thisServerID.toString() + "/BusiestReadTag")) {}
+
 		int64_t costFunction(int64_t bytes) { return bytes / SERVER_KNOBS->READ_COST_BYTE_FACTOR + 1; }
 
 		void addRequest(Optional<TagSet> const& tags, int64_t bytes) {
@@ -704,7 +712,7 @@ public:
 			}
 		}
 
-		void startNewInterval(UID id) {
+		void startNewInterval() {
 			double elapsed = now() - intervalStart;
 			previousBusiestTag.reset();
 			if (intervalStart > 0 && CLIENT_KNOBS->READ_TAG_SAMPLE_RATE > 0 && elapsed > 0) {
@@ -713,13 +721,13 @@ public:
 					previousBusiestTag = TagInfo(busiestTag, rate, (double)busiestTagCount / intervalTotalSampledCount);
 				}
 
-				TraceEvent("BusiestReadTag", id)
+				TraceEvent("BusiestReadTag", thisServerID)
 				    .detail("Elapsed", elapsed)
 				    .detail("Tag", printable(busiestTag))
 				    .detail("TagCost", busiestTagCount)
 				    .detail("TotalSampledCost", intervalTotalSampledCount)
 				    .detail("Reported", previousBusiestTag.present())
-				    .trackLatest(id.toString() + "/BusiestReadTag");
+				    .trackLatest(busiestReadTagEventHolder->trackingKey);
 			}
 
 			intervalCounts.clear();
@@ -811,6 +819,8 @@ public:
 		}
 	} counters;
 
+	Reference<EventCacheHolder> storageServerSourceTLogIDEventHolder;
+
 	StorageServer(IKeyValueStore* storage,
 	              Reference<AsyncVar<ServerDBInfo> const> const& db,
 	              StorageServerInterface const& ssi)
@@ -848,7 +858,10 @@ public:
 	    fetchKeysParallelismLock(SERVER_KNOBS->FETCH_KEYS_PARALLELISM),
 	    fetchKeysBytesBudget(SERVER_KNOBS->STORAGE_FETCH_BYTES), fetchKeysBudgetUsed(false),
 	    instanceID(deterministicRandom()->randomUniqueID().first()), shuttingDown(false), behind(false),
-	    versionBehind(false), debug_inApplyUpdate(false), debug_lastValidateTime(0), maxQueryQueue(0), counters(this) {
+	    versionBehind(false), debug_inApplyUpdate(false), debug_lastValidateTime(0), maxQueryQueue(0), counters(this),
+	    storageServerSourceTLogIDEventHolder(
+	        makeReference<EventCacheHolder>(ssi.id().toString() + "/StorageServerSourceTLogID")),
+	    transactionTagCounter(ssi.id()) {
 		version.initMetric(LiteralStringRef("StorageServer.Version"), counters.cc.id);
 		oldestVersion.initMetric(LiteralStringRef("StorageServer.OldestVersion"), counters.cc.id);
 		durableVersion.initMetric(LiteralStringRef("StorageServer.DurableVersion"), counters.cc.id);
@@ -3937,7 +3950,7 @@ ACTOR Future<Void> update(StorageServer* data, bool* pReceivedUpdate) {
 				TraceEvent("StorageServerSourceTLogID", data->thisServerID)
 				    .detail("SourceTLogID",
 				            data->sourceTLogID.present() ? data->sourceTLogID.get().toString() : "unknown")
-				    .trackLatest(data->thisServerID.toString() + "/StorageServerSourceTLogID");
+				    .trackLatest(data->storageServerSourceTLogIDEventHolder->trackingKey);
 			}
 
 			data->noRecentUpdates.set(false);
@@ -5008,9 +5021,9 @@ ACTOR Future<Void> storageServerCore(StorageServer* self, StorageServerInterface
 	self->actors.add(traceRole(Role::STORAGE_SERVER, ssi.id()));
 	self->actors.add(reportStorageServerState(self));
 
-	self->transactionTagCounter.startNewInterval(self->thisServerID);
-	self->actors.add(recurring([&]() { self->transactionTagCounter.startNewInterval(self->thisServerID); },
-	                           SERVER_KNOBS->TAG_MEASUREMENT_INTERVAL));
+	self->transactionTagCounter.startNewInterval();
+	self->actors.add(
+	    recurring([&]() { self->transactionTagCounter.startNewInterval(); }, SERVER_KNOBS->TAG_MEASUREMENT_INTERVAL));
 
 	self->coreStarted.send(Void());
 


### PR DESCRIPTION
Various trace events get logged by particular instances and are rolled when the trace file rolls. For example, the MasterRecoveryState is logged by the master and tracks the most recent state of master recovery.

When these instances are terminated, the rolled trace events continue to exist and are repeated in each new trace file for as long as the owning process continues running. With the above example, then, we may have multiple former master processes continuing to log MasterRecoveryState. Another example is with something like TLogMetrics which continues rolling on former transaction log processes, creating the potential for incorrect metrics aggregations unless care is taken.

It would be better if trace events associated with a particular role instance were to stop rolling when the instance dies.
Testing:

issue: #3285 
Correctness test: devRunCorrectness --max-runs 100000

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
