### PR TITLE
Fix image links in read-write-path documentation

### DIFF
--- a/documentation/sphinx/source/cap-theorem.rst
+++ b/documentation/sphinx/source/cap-theorem.rst
@@ -24,7 +24,7 @@ Let's consider an **AP** database. In such a database, reads and writes would al
 
 However, the downside is stark. Imagine a simple distributed database consisting of two nodes and a network partition making them unable to communicate. To be Available, each of the two nodes must continue to accept writes from clients.
 
-.. figure:: /images/AP_Partition.png
+.. figure:: images/AP_Partition.png
 
    Data divergence in an AP system during partition
 
@@ -62,7 +62,7 @@ Imagine that a rack-top switch fails, and A is partitioned from the network. A w
 
 However, for all other clients, the database servers can reach a majority of coordination servers, B and C. The replication configuration has ensured there is a full copy of the data available even without A. For these clients, the database will remain available for reads and writes and the web servers will continue to serve traffic.
 
-.. figure:: /images/FDB_Partition.png
+.. figure:: images/FDB_Partition.png
 
     Maintenance of availability during partition
     

--- a/documentation/sphinx/source/ha-write-path.rst
+++ b/documentation/sphinx/source/ha-write-path.rst
@@ -176,7 +176,7 @@ The *LogPushData* class is used to hold serialized mutations on a per transactio
 
 *LogPushData.writeTypedMessage* is the function that serializes each mutation and writes it to the correct binary stream to be sent to the corresponding transaction log. Each serialized mutation contains additional metadata about the message, with the format:
 
-.. image:: /images/serialized_mutation_metadata_format.png
+.. image:: images/serialized_mutation_metadata_format.png
 
 * Message size: size of the message, in bytes, excluding the four bytes used for the message size
 

--- a/documentation/sphinx/source/performance.rst
+++ b/documentation/sphinx/source/performance.rst
@@ -9,7 +9,7 @@ Scaling
 
 FoundationDB scales linearly with the number of cores in a cluster over a wide range of sizes.
 
-.. image:: /images/scaling.png
+.. image:: images/scaling.png
 
 Here, a cluster of commodity hardware scales to **8.2 million** operations/sec doing a 90% read and 10% write workload with 16 byte keys and values between 8 and 100 bytes.
 
@@ -24,7 +24,7 @@ Latency
 
 FoundationDB has low latencies over a broad range of workloads that only increase modestly as the cluster approaches saturation.
 
-.. image:: /images/latency.png
+.. image:: images/latency.png
 
 When run at less than **75% load**, FoundationDB typically has the following latencies:
 
@@ -53,7 +53,7 @@ Throughput (per core)
 
 FoundationDB provides good throughput for the full range of read and write workloads, with two fully durable storage engine options.
 
-.. image:: /images/throughput.png
+.. image:: images/throughput.png
 
 FoundationDB offers two :ref:`storage engines <configuration-storage-engine>`, optimized for distinct use cases, both of which write to disk before reporting transactions committed. For each storage engine, the graph shows throughput of a single FoundationDB process running on a **single core** with saturating read/write workloads ranging from 100% reads to 100% writes, all with 16 byte keys and values between 8 and 100 bytes. Throughput for the unmixed workloads is about:
 
@@ -79,7 +79,7 @@ Concurrency
 
 FoundationDB is designed to achieve great performance under high concurrency from a large number of clients.
 
-.. image:: /images/concurrency.png
+.. image:: images/concurrency.png
 
 Its asynchronous design allows it to handle very high concurrency, and for a typical workload with 90% reads and 10% writes, maximum throughput is reached at about 200 concurrent operations. This number of operations was achieved with **20** concurrent transactions per FoundationDB process each running 10 operations with 16 byte keys and values between 8 and 100 bytes.
 

--- a/documentation/sphinx/source/read-write-path.rst
+++ b/documentation/sphinx/source/read-write-path.rst
@@ -16,7 +16,7 @@ The processing order of multiple transactions is important because it affects th
 The content is based on FDB 6.2 and is true for FDB 6.3.  A new timestamp proxy role is introduced in post FDB 6.3,
 which affects the read path. We will discuss the timestamp proxy role in the future version of this document.
 
-.. image:: /images/FDB_read_path.png
+.. image:: images/FDB_read_path.png
 
 Components
 =================
@@ -198,7 +198,7 @@ Write path of a transaction
 Suppose a client has a write-only transaction. Fig. 2 below shows the write path in a non-HA cluster.
 We will discuss how a transaction with both read and write works in the next section.
 
-.. image:: /images/FDB_write_path.png
+.. image:: images/FDB_write_path.png
 
 To simplify the explanation, the steps below do not include transaction batching on proxy,
 which is a typical database technique to increase transaction throughput.
@@ -461,7 +461,7 @@ The ordering is enforced in the timestamp generator, the concurrency control com
 We use the following example and draw its swimlane diagram to illustrate how two write transactions are ordered in FDB.
 The diagram with notes can be viewed at `here <https://lucid.app/lucidchart/6336dbe3-cff4-4c46-995a-4ca3d9260696/view?page=0_0#?folder_id=home&browser=icon>`_.
 
-.. image:: /images/FDB_multiple_txn_swimlane_diagram.png
+.. image:: images/FDB_multiple_txn_swimlane_diagram.png
 
 Reference
 ============


### PR DESCRIPTION
The images in the website are fine, but broken on github. Fix these links on github.

See results at https://github.com/jzhou77/foundationdb/blob/master/documentation/sphinx/source/read-write-path.rst and https://github.com/jzhou77/foundationdb/blob/master/documentation/sphinx/source/ha-write-path.rst, which correctly shows images.

Verified the `docpreview` target displays images for these pages.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
