### PR TITLE
Refactoring well-known endpoint registration

### DIFF
--- a/documentation/tutorial/tutorial.actor.cpp
+++ b/documentation/tutorial/tutorial.actor.cpp
@@ -33,6 +33,12 @@
 
 NetworkAddress serverAddress;
 
+enum TutorialWellKnownEndpoints {
+	WLTOKEN_SIMPLE_KV_SERVER = WLTOKEN_FIRST_AVAILABLE,
+	WLTOKEN_ECHO_SERVER,
+	WLTOKEN_COUNT_IN_TUTORIAL
+};
+
 // this is a simple actor that will report how long
 // it is already running once a second.
 ACTOR Future<Void> simpleTimer() {
@@ -171,7 +177,7 @@ uint64_t tokenCounter = 1;
 
 ACTOR Future<Void> echoServer() {
 	state EchoServerInterface echoServer;
-	echoServer.getInterface.makeWellKnownEndpoint(UID(-1, ++tokenCounter), TaskPriority::DefaultEndpoint);
+	echoServer.getInterface.makeWellKnownEndpoint(WLTOKEN_ECHO_SERVER, TaskPriority::DefaultEndpoint);
 	loop {
 		try {
 			choose {
@@ -204,7 +210,8 @@ ACTOR Future<Void> echoServer() {
 
 ACTOR Future<Void> echoClient() {
 	state EchoServerInterface server;
-	server.getInterface = RequestStream<GetInterfaceRequest>(Endpoint({ serverAddress }, UID(-1, ++tokenCounter)));
+	server.getInterface =
+	    RequestStream<GetInterfaceRequest>(Endpoint::wellKnown({ serverAddress }, WLTOKEN_ECHO_SERVER));
 	EchoServerInterface s = wait(server.getInterface.getReply(GetInterfaceRequest()));
 	server = s;
 	EchoRequest echoRequest;
@@ -291,7 +298,7 @@ struct ClearRequest {
 ACTOR Future<Void> kvStoreServer() {
 	state SimpleKeyValueStoreInteface inf;
 	state std::map<std::string, std::string> store;
-	inf.connect.makeWellKnownEndpoint(UID(-1, ++tokenCounter), TaskPriority::DefaultEndpoint);
+	inf.connect.makeWellKnownEndpoint(WLTOKEN_SIMPLE_KV_SERVER, TaskPriority::DefaultEndpoint);
 	loop {
 		choose {
 			when(GetKVInterface req = waitNext(inf.connect.getFuture())) {
@@ -328,7 +335,7 @@ ACTOR Future<Void> kvStoreServer() {
 ACTOR Future<SimpleKeyValueStoreInteface> connect() {
 	std::cout << format("%llu: Connect...\n", uint64_t(g_network->now()));
 	SimpleKeyValueStoreInteface c;
-	c.connect = RequestStream<GetKVInterface>(Endpoint({ serverAddress }, UID(-1, ++tokenCounter)));
+	c.connect = RequestStream<GetKVInterface>(Endpoint::wellKnown({ serverAddress }, WLTOKEN_SIMPLE_KV_SERVER));
 	SimpleKeyValueStoreInteface result = wait(c.connect.getReply(GetKVInterface()));
 	std::cout << format("%llu: done..\n", uint64_t(g_network->now()));
 	return result;
@@ -562,7 +569,7 @@ int main(int argc, char* argv[]) {
 	}
 	platformInit();
 	g_network = newNet2(TLSConfig(), false, true);
-	FlowTransport::createInstance(!isServer, 0);
+	FlowTransport::createInstance(!isServer, 0, WLTOKEN_COUNT_IN_TUTORIAL);
 	NetworkAddress publicAddress = NetworkAddress::parse("0.0.0.0:0");
 	if (isServer) {
 		publicAddress = NetworkAddress::parse("0.0.0.0:" + port);

--- a/fdbclient/CMakeLists.txt
+++ b/fdbclient/CMakeLists.txt
@@ -127,6 +127,7 @@ set(FDBCLIENT_SRCS
   VersionedMap.actor.h
   VersionedMap.h
   VersionedMap.cpp
+  WellKnownEndpoints.h
   WriteMap.h
   json_spirit/json_spirit_error_position.h
   json_spirit/json_spirit_reader_template.h

--- a/fdbclient/ConfigTransactionInterface.cpp
+++ b/fdbclient/ConfigTransactionInterface.cpp
@@ -34,10 +34,11 @@ void ConfigTransactionInterface::setupWellKnownEndpoints() {
 }
 
 ConfigTransactionInterface::ConfigTransactionInterface(NetworkAddress const& remote)
-  : getGeneration(Endpoint({ remote }, WLTOKEN_CONFIGTXN_GETGENERATION)),
-    get(Endpoint({ remote }, WLTOKEN_CONFIGTXN_GET)), getClasses(Endpoint({ remote }, WLTOKEN_CONFIGTXN_GETCLASSES)),
-    getKnobs(Endpoint({ remote }, WLTOKEN_CONFIGTXN_GETKNOBS)), commit(Endpoint({ remote }, WLTOKEN_CONFIGTXN_COMMIT)) {
-}
+  : getGeneration(Endpoint::wellKnown({ remote }, WLTOKEN_CONFIGTXN_GETGENERATION)),
+    get(Endpoint::wellKnown({ remote }, WLTOKEN_CONFIGTXN_GET)),
+    getClasses(Endpoint::wellKnown({ remote }, WLTOKEN_CONFIGTXN_GETCLASSES)),
+    getKnobs(Endpoint::wellKnown({ remote }, WLTOKEN_CONFIGTXN_GETKNOBS)),
+    commit(Endpoint::wellKnown({ remote }, WLTOKEN_CONFIGTXN_COMMIT)) {}
 
 bool ConfigTransactionInterface::operator==(ConfigTransactionInterface const& rhs) const {
 	return _id == rhs._id;

--- a/fdbclient/CoordinationInterface.h
+++ b/fdbclient/CoordinationInterface.h
@@ -27,22 +27,9 @@
 #include "fdbrpc/Locality.h"
 #include "fdbclient/CommitProxyInterface.h"
 #include "fdbclient/ClusterInterface.h"
+#include "fdbclient/WellKnownEndpoints.h"
 
 const int MAX_CLUSTER_FILE_BYTES = 60000;
-
-// well known endpoints published to the client.
-constexpr UID WLTOKEN_CLIENTLEADERREG_GETLEADER(-1, 2);
-constexpr UID WLTOKEN_CLIENTLEADERREG_OPENDATABASE(-1, 3);
-
-// the value of this endpoint should be stable and not change.
-constexpr UID WLTOKEN_PROTOCOL_INFO(-1, 10);
-constexpr UID WLTOKEN_CLIENTLEADERREG_DESCRIPTOR_MUTABLE(-1, 11);
-
-constexpr UID WLTOKEN_CONFIGTXN_GETGENERATION(-1, 12);
-constexpr UID WLTOKEN_CONFIGTXN_GET(-1, 13);
-constexpr UID WLTOKEN_CONFIGTXN_GETCLASSES(-1, 14);
-constexpr UID WLTOKEN_CONFIGTXN_GETKNOBS(-1, 15);
-constexpr UID WLTOKEN_CONFIGTXN_COMMIT(-1, 16);
 
 struct ClientLeaderRegInterface {
 	RequestStream<struct GetLeaderRequest> getLeader;

--- a/fdbclient/MonitorLeader.actor.cpp
+++ b/fdbclient/MonitorLeader.actor.cpp
@@ -383,9 +383,9 @@ ClientCoordinators::ClientCoordinators(Key clusterKey, std::vector<NetworkAddres
 }
 
 ClientLeaderRegInterface::ClientLeaderRegInterface(NetworkAddress remote)
-  : getLeader(Endpoint({ remote }, WLTOKEN_CLIENTLEADERREG_GETLEADER)),
-    openDatabase(Endpoint({ remote }, WLTOKEN_CLIENTLEADERREG_OPENDATABASE)),
-    checkDescriptorMutable(Endpoint({ remote }, WLTOKEN_CLIENTLEADERREG_DESCRIPTOR_MUTABLE)) {}
+  : getLeader(Endpoint::wellKnown({ remote }, WLTOKEN_CLIENTLEADERREG_GETLEADER)),
+    openDatabase(Endpoint::wellKnown({ remote }, WLTOKEN_CLIENTLEADERREG_OPENDATABASE)),
+    checkDescriptorMutable(Endpoint::wellKnown({ remote }, WLTOKEN_CLIENTLEADERREG_DESCRIPTOR_MUTABLE)) {}
 
 ClientLeaderRegInterface::ClientLeaderRegInterface(INetwork* local) {
 	getLeader.makeWellKnownEndpoint(WLTOKEN_CLIENTLEADERREG_GETLEADER, TaskPriority::Coordination);

--- a/fdbclient/ProcessInterface.h
+++ b/fdbclient/ProcessInterface.h
@@ -21,8 +21,7 @@
 #include "fdbclient/AnnotateActor.h"
 #include "fdbclient/FDBTypes.h"
 #include "fdbrpc/fdbrpc.h"
-
-constexpr UID WLTOKEN_PROCESS(-1, 21);
+#include "fdbclient/WellKnownEndpoints.h"
 
 struct ProcessInterface {
 	constexpr static FileIdentifier file_identifier = 985636;

--- a/fdbclient/SpecialKeySpace.actor.cpp
+++ b/fdbclient/SpecialKeySpace.actor.cpp
@@ -2092,7 +2092,7 @@ ACTOR static Future<RangeResult> actorLineageGetRangeActor(ReadYourWritesTransac
 	// Open endpoint to target process on each call. This can be optimized at
 	// some point...
 	state ProcessInterface process;
-	process.getInterface = RequestStream<GetProcessInterfaceRequest>(Endpoint({ host }, WLTOKEN_PROCESS));
+	process.getInterface = RequestStream<GetProcessInterfaceRequest>(Endpoint::wellKnown({ host }, WLTOKEN_PROCESS));
 	ProcessInterface p = wait(retryBrokenPromise(process.getInterface, GetProcessInterfaceRequest{}));
 	process = p;
 

--- a/fdbclient/StatusClient.actor.cpp
+++ b/fdbclient/StatusClient.actor.cpp
@@ -319,8 +319,8 @@ ACTOR Future<Optional<StatusObject>> clientCoordinatorsStatusFetcher(Reference<C
 		state std::vector<Future<ProtocolInfoReply>> coordProtocols;
 		coordProtocols.reserve(coord.clientLeaderServers.size());
 		for (int i = 0; i < coord.clientLeaderServers.size(); i++) {
-			RequestStream<ProtocolInfoRequest> requestStream{ Endpoint{
-				{ coord.clientLeaderServers[i].getLeader.getEndpoint().addresses }, WLTOKEN_PROTOCOL_INFO } };
+			RequestStream<ProtocolInfoRequest> requestStream{ Endpoint::wellKnown(
+				{ coord.clientLeaderServers[i].getLeader.getEndpoint().addresses }, WLTOKEN_PROTOCOL_INFO) };
 			coordProtocols.push_back(retryBrokenPromise(requestStream, ProtocolInfoRequest{}));
 		}
 

--- a/fdbclient/WellKnownEndpoints.h
+++ b/fdbclient/WellKnownEndpoints.h
@@ -1,0 +1,54 @@
+/*
+ * WellKnownEndpoints.h
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FDBCLIENT_WELLKNOWNENDPOINTS_H
+#define FDBCLIENT_WELLKNOWNENDPOINTS_H
+#pragma once
+
+#include <fdbrpc/fdbrpc.h>
+
+/*
+ * All well-known endpoints of FDB must be listed here to guarantee their uniqueness
+ */
+enum WellKnownEndpoints {
+	WLTOKEN_CLIENTLEADERREG_GETLEADER = WLTOKEN_FIRST_AVAILABLE, // 2
+	WLTOKEN_CLIENTLEADERREG_OPENDATABASE, // 3
+	WLTOKEN_LEADERELECTIONREG_CANDIDACY, // 4
+	WLTOKEN_LEADERELECTIONREG_ELECTIONRESULT, // 5
+	WLTOKEN_LEADERELECTIONREG_LEADERHEARTBEAT, // 6
+	WLTOKEN_LEADERELECTIONREG_FORWARD, // 7
+	WLTOKEN_GENERATIONREG_READ, // 8
+	WLTOKEN_GENERATIONREG_WRITE, // 9
+	WLTOKEN_PROTOCOL_INFO, // 10 : the value of this endpoint should be stable and not change.
+	WLTOKEN_CLIENTLEADERREG_DESCRIPTOR_MUTABLE, // 11
+	WLTOKEN_CONFIGTXN_GETGENERATION, // 12
+	WLTOKEN_CONFIGTXN_GET, // 13
+	WLTOKEN_CONFIGTXN_GETCLASSES, // 14
+	WLTOKEN_CONFIGTXN_GETKNOBS, // 15
+	WLTOKEN_CONFIGTXN_COMMIT, // 16
+	WLTOKEN_CONFIGFOLLOWER_GETSNAPSHOTANDCHANGES, // 17
+	WLTOKEN_CONFIGFOLLOWER_GETCHANGES, // 18
+	WLTOKEN_CONFIGFOLLOWER_COMPACT, // 19
+	WLTOKEN_CONFIGFOLLOWER_GETCOMMITTEDVERSION, // 20
+	WLTOKEN_PROCESS, // 21
+	WLTOKEN_RESERVED_COUNT // 22
+};
+
+#endif

--- a/fdbrpc/FlowTransport.actor.cpp
+++ b/fdbrpc/FlowTransport.actor.cpp
@@ -45,12 +45,8 @@
 
 static NetworkAddressList g_currentDeliveryPeerAddress = NetworkAddressList();
 
-constexpr UID WLTOKEN_ENDPOINT_NOT_FOUND(-1, 0);
-constexpr UID WLTOKEN_PING_PACKET(-1, 1);
 constexpr int PACKET_LEN_WIDTH = sizeof(uint32_t);
 const uint64_t TOKEN_STREAM_FLAG = 1;
-
-static constexpr int WLTOKEN_COUNTS = 22; // number of wellKnownEndpoints
 
 class EndpointMap : NonCopyable {
 public:
@@ -97,7 +93,7 @@ void EndpointMap::realloc() {
 
 void EndpointMap::insertWellKnown(NetworkMessageReceiver* r, const Endpoint::Token& token, TaskPriority priority) {
 	int index = token.second();
-	ASSERT(index <= WLTOKEN_COUNTS);
+	ASSERT(index <= wellKnownEndpointCount);
 	ASSERT(data[index].receiver == nullptr);
 	data[index].receiver = r;
 	data[index].token() =
@@ -196,7 +192,8 @@ void EndpointMap::remove(Endpoint::Token const& token, NetworkMessageReceiver* r
 
 struct EndpointNotFoundReceiver final : NetworkMessageReceiver {
 	EndpointNotFoundReceiver(EndpointMap& endpoints) {
-		endpoints.insertWellKnown(this, WLTOKEN_ENDPOINT_NOT_FOUND, TaskPriority::DefaultEndpoint);
+		endpoints.insertWellKnown(
+		    this, Endpoint::wellKnownToken(WLTOKEN_ENDPOINT_NOT_FOUND), TaskPriority::DefaultEndpoint);
 	}
 
 	void receive(ArenaObjectReader& reader) override {
@@ -220,7 +217,7 @@ struct PingRequest {
 
 struct PingReceiver final : NetworkMessageReceiver {
 	PingReceiver(EndpointMap& endpoints) {
-		endpoints.insertWellKnown(this, WLTOKEN_PING_PACKET, TaskPriority::ReadSocket);
+		endpoints.insertWellKnown(this, Endpoint::wellKnownToken(WLTOKEN_PING_PACKET), TaskPriority::ReadSocket);
 	}
 	void receive(ArenaObjectReader& reader) override {
 		PingRequest req;
@@ -234,7 +231,7 @@ struct PingReceiver final : NetworkMessageReceiver {
 
 class TransportData {
 public:
-	TransportData(uint64_t transportId);
+	TransportData(uint64_t transportId, int maxWellKnownEndpoints);
 
 	~TransportData();
 
@@ -341,8 +338,8 @@ ACTOR Future<Void> pingLatencyLogger(TransportData* self) {
 	}
 }
 
-TransportData::TransportData(uint64_t transportId)
-  : warnAlwaysForLargePacket(true), endpoints(WLTOKEN_COUNTS), endpointNotFoundReceiver(endpoints),
+TransportData::TransportData(uint64_t transportId, int maxWellKnownEndpoints)
+  : warnAlwaysForLargePacket(true), endpoints(maxWellKnownEndpoints), endpointNotFoundReceiver(endpoints),
     pingReceiver(endpoints), numIncompatibleConnections(0), lastIncompatibleMessage(0), transportId(transportId) {
 	degraded = makeReference<AsyncVar<bool>>(false);
 	pingLogger = pingLatencyLogger(this);
@@ -430,7 +427,7 @@ static ReliablePacket* sendPacket(TransportData* self,
                                   bool reliable);
 
 ACTOR Future<Void> connectionMonitor(Reference<Peer> peer) {
-	state Endpoint remotePingEndpoint({ peer->destination }, WLTOKEN_PING_PACKET);
+	state Endpoint remotePingEndpoint({ peer->destination }, Endpoint::wellKnownToken(WLTOKEN_PING_PACKET));
 	loop {
 		if (!FlowTransport::isClient() && !peer->destination.isPublic() && peer->compatible) {
 			// Don't send ping messages to clients unless necessary. Instead monitor incoming client pings.
@@ -961,13 +958,13 @@ ACTOR static void deliver(TransportData* self,
 			if (self->isLocalAddress(destination.getPrimaryAddress())) {
 				sendLocal(self,
 				          SerializeSource<UID>(destination.token),
-				          Endpoint(destination.addresses, WLTOKEN_ENDPOINT_NOT_FOUND));
+				          Endpoint::wellKnown(destination.addresses, WLTOKEN_ENDPOINT_NOT_FOUND));
 			} else {
 				Reference<Peer> peer = self->getOrOpenPeer(destination.getPrimaryAddress());
 				sendPacket(self,
 				           peer,
 				           SerializeSource<UID>(destination.token),
-				           Endpoint(destination.addresses, WLTOKEN_ENDPOINT_NOT_FOUND),
+				           Endpoint::wellKnown(destination.addresses, WLTOKEN_ENDPOINT_NOT_FOUND),
 				           false);
 			}
 		}
@@ -1421,7 +1418,8 @@ ACTOR static Future<Void> multiVersionCleanupWorker(TransportData* self) {
 	}
 }
 
-FlowTransport::FlowTransport(uint64_t transportId) : self(new TransportData(transportId)) {
+FlowTransport::FlowTransport(uint64_t transportId, int maxWellKnownEndpoints)
+  : self(new TransportData(transportId, maxWellKnownEndpoints)) {
 	self->multiVersionCleanup = multiVersionCleanupWorker(self);
 }
 
@@ -1566,7 +1564,8 @@ static ReliablePacket* sendPacket(TransportData* self,
 
 	// If there isn't an open connection, a public address, or the peer isn't compatible, we can't send
 	if (!peer || (peer->outgoingConnectionIdle && !destination.getPrimaryAddress().isPublic()) ||
-	    (peer->incompatibleProtocolVersionNewer && destination.token != WLTOKEN_PING_PACKET)) {
+	    (peer->incompatibleProtocolVersionNewer &&
+	     destination.token != Endpoint::wellKnownToken(WLTOKEN_PING_PACKET))) {
 		TEST(true); // Can't send to private address without a compatible open connection
 		return nullptr;
 	}
@@ -1651,7 +1650,7 @@ static ReliablePacket* sendPacket(TransportData* self,
 #endif
 
 	peer->send(pb, rp, firstUnsent);
-	if (destination.token != WLTOKEN_PING_PACKET) {
+	if (destination.token != Endpoint::wellKnownToken(WLTOKEN_PING_PACKET)) {
 		peer->lastDataPacketSentTime = now();
 	}
 	return rp;
@@ -1716,8 +1715,9 @@ bool FlowTransport::incompatibleOutgoingConnectionsPresent() {
 	return self->numIncompatibleConnections > 0;
 }
 
-void FlowTransport::createInstance(bool isClient, uint64_t transportId) {
-	g_network->setGlobal(INetwork::enFlowTransport, (flowGlobalType) new FlowTransport(transportId));
+void FlowTransport::createInstance(bool isClient, uint64_t transportId, int maxWellKnownEndpoints) {
+	g_network->setGlobal(INetwork::enFlowTransport,
+	                     (flowGlobalType) new FlowTransport(transportId, maxWellKnownEndpoints));
 	g_network->setGlobal(INetwork::enNetworkAddressFunc, (flowGlobalType)&FlowTransport::getGlobalLocalAddress);
 	g_network->setGlobal(INetwork::enNetworkAddressesFunc, (flowGlobalType)&FlowTransport::getGlobalLocalAddresses);
 	g_network->setGlobal(INetwork::enFailureMonitor, (flowGlobalType) new SimpleFailureMonitor());

--- a/fdbrpc/FlowTransport.h
+++ b/fdbrpc/FlowTransport.h
@@ -31,6 +31,8 @@
 #include "flow/Net2Packet.h"
 #include "fdbrpc/ContinuousSample.h"
 
+enum { WLTOKEN_ENDPOINT_NOT_FOUND = 0, WLTOKEN_PING_PACKET, WLTOKEN_FIRST_AVAILABLE };
+
 #pragma pack(push, 4)
 class Endpoint {
 public:
@@ -44,6 +46,12 @@ public:
 	Endpoint() {}
 	Endpoint(const NetworkAddressList& addresses, Token token) : addresses(addresses), token(token) {
 		choosePrimaryAddress();
+	}
+
+	static Token wellKnownToken(int wlTokenID) { return UID(-1, wlTokenID); }
+
+	static Endpoint wellKnown(const NetworkAddressList& addresses, int wlTokenID) {
+		return Endpoint(addresses, wellKnownToken(wlTokenID));
 	}
 
 	void choosePrimaryAddress() {
@@ -175,12 +183,12 @@ struct Peer : public ReferenceCounted<Peer> {
 
 class FlowTransport {
 public:
-	FlowTransport(uint64_t transportId);
+	FlowTransport(uint64_t transportId, int maxWellKnownEndpoints);
 	~FlowTransport();
 
 	// Creates a new FlowTransport and makes FlowTransport::transport() return it.  This uses g_network->global()
 	// variables, so it will be private to a simulation.
-	static void createInstance(bool isClient, uint64_t transportId);
+	static void createInstance(bool isClient, uint64_t transportId, int maxWellKnownEndpoints);
 
 	static bool isClient() { return g_network->global(INetwork::enClientFailureMonitor) != nullptr; }
 

--- a/fdbrpc/fdbrpc.h
+++ b/fdbrpc/fdbrpc.h
@@ -782,8 +782,9 @@ public:
 	const Endpoint& getEndpoint(TaskPriority taskID = TaskPriority::DefaultEndpoint) const {
 		return queue->getEndpoint(taskID);
 	}
-	void makeWellKnownEndpoint(Endpoint::Token token, TaskPriority taskID) {
-		queue->makeWellKnownEndpoint(token, taskID);
+
+	void makeWellKnownEndpoint(uint64_t wlTokenID, TaskPriority taskID) {
+		queue->makeWellKnownEndpoint(Endpoint::Token(-1, wlTokenID), taskID);
 	}
 
 	bool operator==(const RequestStream<T>& rhs) const { return queue == rhs.queue; }

--- a/fdbserver/ConfigFollowerInterface.cpp
+++ b/fdbserver/ConfigFollowerInterface.cpp
@@ -34,10 +34,10 @@ ConfigFollowerInterface::ConfigFollowerInterface() : _id(deterministicRandom()->
 
 ConfigFollowerInterface::ConfigFollowerInterface(NetworkAddress const& remote)
   : _id(deterministicRandom()->randomUniqueID()),
-    getSnapshotAndChanges(Endpoint({ remote }, WLTOKEN_CONFIGFOLLOWER_GETSNAPSHOTANDCHANGES)),
-    getChanges(Endpoint({ remote }, WLTOKEN_CONFIGFOLLOWER_GETCHANGES)),
-    compact(Endpoint({ remote }, WLTOKEN_CONFIGFOLLOWER_COMPACT)),
-    getCommittedVersion(Endpoint({ remote }, WLTOKEN_CONFIGFOLLOWER_GETCOMMITTEDVERSION)) {}
+    getSnapshotAndChanges(Endpoint::wellKnown({ remote }, WLTOKEN_CONFIGFOLLOWER_GETSNAPSHOTANDCHANGES)),
+    getChanges(Endpoint::wellKnown({ remote }, WLTOKEN_CONFIGFOLLOWER_GETCHANGES)),
+    compact(Endpoint::wellKnown({ remote }, WLTOKEN_CONFIGFOLLOWER_COMPACT)),
+    getCommittedVersion(Endpoint::wellKnown({ remote }, WLTOKEN_CONFIGFOLLOWER_GETCOMMITTEDVERSION)) {}
 
 bool ConfigFollowerInterface::operator==(ConfigFollowerInterface const& rhs) const {
 	return _id == rhs._id;

--- a/fdbserver/Coordination.actor.cpp
+++ b/fdbserver/Coordination.actor.cpp
@@ -74,7 +74,8 @@ struct GenerationRegVal {
 };
 
 GenerationRegInterface::GenerationRegInterface(NetworkAddress remote)
-  : read(Endpoint({ remote }, WLTOKEN_GENERATIONREG_READ)), write(Endpoint({ remote }, WLTOKEN_GENERATIONREG_WRITE)) {}
+  : read(Endpoint::wellKnown({ remote }, WLTOKEN_GENERATIONREG_READ)),
+    write(Endpoint::wellKnown({ remote }, WLTOKEN_GENERATIONREG_WRITE)) {}
 
 GenerationRegInterface::GenerationRegInterface(INetwork* local) {
 	read.makeWellKnownEndpoint(WLTOKEN_GENERATIONREG_READ, TaskPriority::Coordination);
@@ -82,10 +83,10 @@ GenerationRegInterface::GenerationRegInterface(INetwork* local) {
 }
 
 LeaderElectionRegInterface::LeaderElectionRegInterface(NetworkAddress remote)
-  : ClientLeaderRegInterface(remote), candidacy(Endpoint({ remote }, WLTOKEN_LEADERELECTIONREG_CANDIDACY)),
-    electionResult(Endpoint({ remote }, WLTOKEN_LEADERELECTIONREG_ELECTIONRESULT)),
-    leaderHeartbeat(Endpoint({ remote }, WLTOKEN_LEADERELECTIONREG_LEADERHEARTBEAT)),
-    forward(Endpoint({ remote }, WLTOKEN_LEADERELECTIONREG_FORWARD)) {}
+  : ClientLeaderRegInterface(remote), candidacy(Endpoint::wellKnown({ remote }, WLTOKEN_LEADERELECTIONREG_CANDIDACY)),
+    electionResult(Endpoint::wellKnown({ remote }, WLTOKEN_LEADERELECTIONREG_ELECTIONRESULT)),
+    leaderHeartbeat(Endpoint::wellKnown({ remote }, WLTOKEN_LEADERELECTIONREG_LEADERHEARTBEAT)),
+    forward(Endpoint::wellKnown({ remote }, WLTOKEN_LEADERELECTIONREG_FORWARD)) {}
 
 LeaderElectionRegInterface::LeaderElectionRegInterface(INetwork* local) : ClientLeaderRegInterface(local) {
 	candidacy.makeWellKnownEndpoint(WLTOKEN_LEADERELECTIONREG_CANDIDACY, TaskPriority::Coordination);

--- a/fdbserver/CoordinationInterface.h
+++ b/fdbserver/CoordinationInterface.h
@@ -23,19 +23,8 @@
 #pragma once
 
 #include "fdbclient/CoordinationInterface.h"
+#include "fdbclient/WellKnownEndpoints.h"
 #include "fdbserver/ConfigFollowerInterface.h"
-
-constexpr UID WLTOKEN_LEADERELECTIONREG_CANDIDACY(-1, 4);
-constexpr UID WLTOKEN_LEADERELECTIONREG_ELECTIONRESULT(-1, 5);
-constexpr UID WLTOKEN_LEADERELECTIONREG_LEADERHEARTBEAT(-1, 6);
-constexpr UID WLTOKEN_LEADERELECTIONREG_FORWARD(-1, 7);
-constexpr UID WLTOKEN_GENERATIONREG_READ(-1, 8);
-constexpr UID WLTOKEN_GENERATIONREG_WRITE(-1, 9);
-
-constexpr UID WLTOKEN_CONFIGFOLLOWER_GETSNAPSHOTANDCHANGES(-1, 17);
-constexpr UID WLTOKEN_CONFIGFOLLOWER_GETCHANGES(-1, 18);
-constexpr UID WLTOKEN_CONFIGFOLLOWER_COMPACT(-1, 19);
-constexpr UID WLTOKEN_CONFIGFOLLOWER_GETCOMMITTEDVERSION(-1, 20);
 
 struct GenerationRegInterface {
 	constexpr static FileIdentifier file_identifier = 16726744;

--- a/fdbserver/SimulatedCluster.actor.cpp
+++ b/fdbserver/SimulatedCluster.actor.cpp
@@ -38,6 +38,7 @@
 #include "fdbclient/NativeAPI.actor.h"
 #include "fdbclient/BackupAgent.actor.h"
 #include "fdbclient/versions.h"
+#include "fdbclient/WellKnownEndpoints.h"
 #include "flow/ProtocolVersion.h"
 #include "flow/network.h"
 #include "flow/TypeTraits.h"
@@ -533,7 +534,8 @@ ACTOR Future<ISimulator::KillType> simulatedFDBDRebooter(Reference<ClusterConnec
 				// SOMEDAY: test lower memory limits, without making them too small and causing the database to stop
 				// making progress
 				FlowTransport::createInstance(processClass == ProcessClass::TesterClass || runBackupAgents == AgentOnly,
-				                              1);
+				                              1,
+				                              WLTOKEN_RESERVED_COUNT);
 				Sim2FileSystem::newFileSystem();
 
 				std::vector<Future<Void>> futures;
@@ -2221,7 +2223,7 @@ ACTOR void setupAndRun(std::string dataFolder,
 	                           currentProtocolVersion),
 	    TaskPriority::DefaultYield));
 	Sim2FileSystem::newFileSystem();
-	FlowTransport::createInstance(true, 1);
+	FlowTransport::createInstance(true, 1, WLTOKEN_RESERVED_COUNT);
 	TEST(true); // Simulation start
 
 	try {

--- a/fdbserver/fdbserver.actor.cpp
+++ b/fdbserver/fdbserver.actor.cpp
@@ -41,6 +41,7 @@
 #include "fdbclient/SystemData.h"
 #include "fdbclient/versions.h"
 #include "fdbclient/BuildFlags.h"
+#include "fdbclient/WellKnownEndpoints.h"
 #include "fdbmonitor/SimpleIni.h"
 #include "fdbrpc/AsyncFileCached.actor.h"
 #include "fdbrpc/Net2FileSystem.h"
@@ -1780,7 +1781,7 @@ int main(int argc, char* argv[]) {
 		} else {
 			g_network = newNet2(opts.tlsConfig, opts.useThreadPool, true);
 			g_network->addStopCallback(Net2FileSystem::stop);
-			FlowTransport::createInstance(false, 1);
+			FlowTransport::createInstance(false, 1, WLTOKEN_RESERVED_COUNT);
 
 			const bool expectsPublicAddress =
 			    (role == ServerRole::FDBD || role == ServerRole::NetworkTestServer || role == ServerRole::Restore);

--- a/fdbserver/networktest.actor.cpp
+++ b/fdbserver/networktest.actor.cpp
@@ -25,7 +25,7 @@
 #include "flow/UnitTest.h"
 #include <inttypes.h>
 
-UID WLTOKEN_NETWORKTEST(-1, 2);
+constexpr int WLTOKEN_NETWORKTEST = WLTOKEN_FIRST_AVAILABLE;
 
 struct LatencyStats {
 	using sample = double;
@@ -55,7 +55,8 @@ struct LatencyStats {
 	double stddev() { return sqrt(x2 / n - (x / n) * (x / n)); }
 };
 
-NetworkTestInterface::NetworkTestInterface(NetworkAddress remote) : test(Endpoint({ remote }, WLTOKEN_NETWORKTEST)) {}
+NetworkTestInterface::NetworkTestInterface(NetworkAddress remote)
+  : test(Endpoint::wellKnown({ remote }, WLTOKEN_NETWORKTEST)) {}
 
 NetworkTestInterface::NetworkTestInterface(INetwork* local) {
 	test.makeWellKnownEndpoint(WLTOKEN_NETWORKTEST, TaskPriority::DefaultEndpoint);

--- a/fdbserver/workloads/ProtocolVersion.actor.cpp
+++ b/fdbserver/workloads/ProtocolVersion.actor.cpp
@@ -37,8 +37,8 @@ struct ProtocolVersionWorkload : TestWorkload {
 
 		ASSERT(diffVersionProcess != allProcesses.end());
 
-		RequestStream<ProtocolInfoRequest> requestStream{ Endpoint{ { (*diffVersionProcess)->addresses },
-			                                                        WLTOKEN_PROTOCOL_INFO } };
+		RequestStream<ProtocolInfoRequest> requestStream{ Endpoint::wellKnown({ (*diffVersionProcess)->addresses },
+			                                                                  WLTOKEN_PROTOCOL_INFO) };
 		ProtocolInfoReply reply = wait(retryBrokenPromise(requestStream, ProtocolInfoRequest{}));
 
 		ASSERT(reply.version != g_network->protocolVersion());


### PR DESCRIPTION
The identifiers of well-known endpoints must be maintained unique and stable. Also transport must know the maximum possible identifier value in advance. The goal of the refactoring is to maintain the list of all well-known endpoint IDs in a single place.

Changes done:
- List all well-known endpoints of FDB in a single enum
- Identify well-known endpoints by plain IDs

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
