### PR TITLE
Enable support for integers in environment variable network options(release 7.0)

### DIFF
--- a/fdbclient/FDBOptions.h
+++ b/fdbclient/FDBOptions.h
@@ -42,15 +42,25 @@ struct FDBOptionInfo {
 	// be no cumulative effects from calling multiple times).
 	int defaultFor;
 
+	enum FDBOptionParamType{
+		None,
+		String,
+		Int,
+		Bytes
+	};
+
+	FDBOptionParamType paramType;
+
 	FDBOptionInfo(std::string name,
 	              std::string comment,
 	              std::string parameterComment,
 	              bool hasParameter,
 	              bool hidden,
 	              bool persistent,
-	              int defaultFor)
+	              int defaultFor,
+				  FDBOptionParamType paramType)
 	  : name(name), comment(comment), parameterComment(parameterComment), hasParameter(hasParameter), hidden(hidden),
-	    persistent(persistent), defaultFor(defaultFor) {}
+	    persistent(persistent), defaultFor(defaultFor), paramType(paramType) {}
 
 	FDBOptionInfo() {}
 };
@@ -103,8 +113,8 @@ public:
 	typename OptionList::const_iterator end() const { return options.cend(); }
 };
 
-#define ADD_OPTION_INFO(type, var, name, comment, parameterComment, hasParameter, hidden, persistent, defaultFor)      \
+#define ADD_OPTION_INFO(type, var, name, comment, parameterComment, hasParameter, hidden, persistent, defaultFor, paramType)      \
 	type::optionInfo.insert(                                                                                           \
-	    var, FDBOptionInfo(name, comment, parameterComment, hasParameter, hidden, persistent, defaultFor));
+	    var, FDBOptionInfo(name, comment, parameterComment, hasParameter, hidden, persistent, defaultFor, paramType));
 
 #endif

--- a/fdbclient/FDBOptions.h
+++ b/fdbclient/FDBOptions.h
@@ -42,12 +42,7 @@ struct FDBOptionInfo {
 	// be no cumulative effects from calling multiple times).
 	int defaultFor;
 
-	enum FDBOptionParamType{
-		None,
-		String,
-		Int,
-		Bytes
-	};
+	enum class FDBOptionParamType { None, String, Int, Bytes };
 
 	FDBOptionParamType paramType;
 
@@ -58,7 +53,7 @@ struct FDBOptionInfo {
 	              bool hidden,
 	              bool persistent,
 	              int defaultFor,
-				  FDBOptionParamType paramType)
+	              FDBOptionParamType paramType)
 	  : name(name), comment(comment), parameterComment(parameterComment), hasParameter(hasParameter), hidden(hidden),
 	    persistent(persistent), defaultFor(defaultFor), paramType(paramType) {}
 
@@ -113,7 +108,8 @@ public:
 	typename OptionList::const_iterator end() const { return options.cend(); }
 };
 
-#define ADD_OPTION_INFO(type, var, name, comment, parameterComment, hasParameter, hidden, persistent, defaultFor, paramType)      \
+#define ADD_OPTION_INFO(                                                                                               \
+    type, var, name, comment, parameterComment, hasParameter, hidden, persistent, defaultFor, paramType)               \
 	type::optionInfo.insert(                                                                                           \
 	    var, FDBOptionInfo(name, comment, parameterComment, hasParameter, hidden, persistent, defaultFor, paramType));
 

--- a/fdbclient/FDBOptions.h
+++ b/fdbclient/FDBOptions.h
@@ -42,9 +42,9 @@ struct FDBOptionInfo {
 	// be no cumulative effects from calling multiple times).
 	int defaultFor;
 
-	enum class FDBOptionParamType { None, String, Int, Bytes };
+	enum class ParamType { None, String, Int, Bytes };
 
-	FDBOptionParamType paramType;
+	ParamType paramType;
 
 	FDBOptionInfo(std::string name,
 	              std::string comment,
@@ -53,7 +53,7 @@ struct FDBOptionInfo {
 	              bool hidden,
 	              bool persistent,
 	              int defaultFor,
-	              FDBOptionParamType paramType)
+	              ParamType paramType)
 	  : name(name), comment(comment), parameterComment(parameterComment), hasParameter(hasParameter), hidden(hidden),
 	    persistent(persistent), defaultFor(defaultFor), paramType(paramType) {}
 

--- a/fdbclient/MultiVersionTransaction.actor.cpp
+++ b/fdbclient/MultiVersionTransaction.actor.cpp
@@ -29,6 +29,7 @@
 #include "flow/UnitTest.h"
 
 #include "flow/actorcompiler.h" // This must be the last #include.
+#include <cstddef>
 
 void throwIfError(FdbCApi::fdb_error_t e) {
 	if (e) {
@@ -1978,7 +1979,11 @@ void MultiVersionApi::loadEnvironmentVariableNetworkOptions() {
 						int64_t intParamVal;
 						if (curParamType == FDBOptionInfo::ParamType::Int) {
 							try {
-								intParamVal = std::stoll(value, nullptr, 10);
+								size_t nextIdx = -1;
+								intParamVal = std::stoll(value, &nextIdx);
+								if (nextIdx != value.length()) {
+									throw invalid_option_value();
+								}
 							} catch (std::exception e) {
 								TraceEvent(SevError, "EnvironmentVariableParseIntegerFailed")
 								    .detail("Option", option.second.name)

--- a/fdbclient/MultiVersionTransaction.actor.cpp
+++ b/fdbclient/MultiVersionTransaction.actor.cpp
@@ -29,7 +29,6 @@
 #include "flow/UnitTest.h"
 
 #include "flow/actorcompiler.h" // This must be the last #include.
-#include <cstddef>
 
 void throwIfError(FdbCApi::fdb_error_t e) {
 	if (e) {

--- a/fdbclient/MultiVersionTransaction.actor.cpp
+++ b/fdbclient/MultiVersionTransaction.actor.cpp
@@ -1976,11 +1976,10 @@ void MultiVersionApi::loadEnvironmentVariableNetworkOptions() {
 					int64_t intParamVal;
 					for (auto value : parseOptionValues(valueStr)) {
 						Standalone<StringRef> currentValue;
-						if (curParamType == FDBOptionInfo::Int) {
-							intParamVal = std::stoll(value.c_str(),nullptr,10);
-							currentValue = StringRef(reinterpret_cast<uint8_t*>(&intParamVal),8);
-						}
-						else{
+						if (curParamType == FDBOptionInfo::FDBOptionParamType::Int) {
+							intParamVal = std::stoll(value.c_str(), nullptr, 10);
+							currentValue = StringRef(reinterpret_cast<uint8_t*>(&intParamVal), 8);
+						} else {
 							currentValue = StringRef(value);
 						}
 						{ // lock scope

--- a/fdbclient/MultiVersionTransaction.actor.cpp
+++ b/fdbclient/MultiVersionTransaction.actor.cpp
@@ -1979,7 +1979,7 @@ void MultiVersionApi::loadEnvironmentVariableNetworkOptions() {
 						int64_t intParamVal;
 						if (curParamType == FDBOptionInfo::ParamType::Int) {
 							try {
-								size_t nextIdx = -1;
+								size_t nextIdx;
 								intParamVal = std::stoll(value, &nextIdx);
 								if (nextIdx != value.length()) {
 									throw invalid_option_value();

--- a/fdbclient/MultiVersionTransaction.actor.cpp
+++ b/fdbclient/MultiVersionTransaction.actor.cpp
@@ -1972,11 +1972,20 @@ void MultiVersionApi::loadEnvironmentVariableNetworkOptions() {
 			std::string valueStr;
 			try {
 				if (platform::getEnvironmentVar(("FDB_NETWORK_OPTION_" + option.second.name).c_str(), valueStr)) {
-					FDBOptionInfo::FDBOptionParamType curParamType = option.second.paramType;
+					FDBOptionInfo::ParamType curParamType = option.second.paramType;
 					for (auto value : parseOptionValues(valueStr)) {
 						Standalone<StringRef> currentValue;
-						if (curParamType == FDBOptionInfo::FDBOptionParamType::Int) {
-							int64_t intParamVal = std::stoll(value.c_str(), nullptr, 10);
+						int64_t intParamVal;
+						if (curParamType == FDBOptionInfo::ParamType::Int) {
+							try {
+								intParamVal = std::stoll(value, nullptr, 10);
+							} catch (std::exception e) {
+								TraceEvent(SevError, "EnvironmentVariableParseIntegerFailed")
+								    .detail("Option", option.second.name)
+								    .detail("Value", valueStr)
+								    .detail("Error", e.what());
+								throw invalid_option_value();
+							}
 							currentValue = StringRef(reinterpret_cast<uint8_t*>(&intParamVal), 8);
 						} else {
 							currentValue = StringRef(value);

--- a/fdbclient/MultiVersionTransaction.actor.cpp
+++ b/fdbclient/MultiVersionTransaction.actor.cpp
@@ -1972,8 +1972,17 @@ void MultiVersionApi::loadEnvironmentVariableNetworkOptions() {
 			std::string valueStr;
 			try {
 				if (platform::getEnvironmentVar(("FDB_NETWORK_OPTION_" + option.second.name).c_str(), valueStr)) {
+					FDBOptionInfo::FDBOptionParamType curParamType = option.second.paramType;
+					int64_t intParamVal;
 					for (auto value : parseOptionValues(valueStr)) {
-						Standalone<StringRef> currentValue = StringRef(value);
+						Standalone<StringRef> currentValue;
+						if (curParamType == FDBOptionInfo::Int) {
+							intParamVal = std::stoll(value.c_str(),nullptr,10);
+							currentValue = StringRef(reinterpret_cast<uint8_t*>(&intParamVal),8);
+						}
+						else{
+							currentValue = StringRef(value);
+						}
 						{ // lock scope
 							MutexHolder holder(lock);
 							if (setEnvOptions[option.first].count(currentValue) == 0) {

--- a/fdbclient/MultiVersionTransaction.actor.cpp
+++ b/fdbclient/MultiVersionTransaction.actor.cpp
@@ -1973,11 +1973,10 @@ void MultiVersionApi::loadEnvironmentVariableNetworkOptions() {
 			try {
 				if (platform::getEnvironmentVar(("FDB_NETWORK_OPTION_" + option.second.name).c_str(), valueStr)) {
 					FDBOptionInfo::FDBOptionParamType curParamType = option.second.paramType;
-					int64_t intParamVal;
 					for (auto value : parseOptionValues(valueStr)) {
 						Standalone<StringRef> currentValue;
 						if (curParamType == FDBOptionInfo::FDBOptionParamType::Int) {
-							intParamVal = std::stoll(value.c_str(), nullptr, 10);
+							int64_t intParamVal = std::stoll(value.c_str(), nullptr, 10);
 							currentValue = StringRef(reinterpret_cast<uint8_t*>(&intParamVal), 8);
 						} else {
 							currentValue = StringRef(value);

--- a/fdbclient/vexillographer/cpp.cs
+++ b/fdbclient/vexillographer/cpp.cs
@@ -47,7 +47,7 @@ namespace vexillographer
 
         private static string getCInfoLine(Option o, string indent, string structName)
         {
-            return String.Format("{0}ADD_OPTION_INFO({1}, {2}, \"{2}\", \"{3}\", \"{4}\", {5}, {6}, {7}, {8}, {9})",
+            return String.Format("{0}ADD_OPTION_INFO({1}, {2}, \"{2}\", \"{3}\", \"{4}\", {5}, {6}, {7}, {8}, FDBOptionInfo::ParamType::{9})",
                 indent, structName, o.name.ToUpper(), o.comment, o.getParameterComment(), (o.paramDesc != null).ToString().ToLower(), 
                 o.hidden.ToString().ToLower(), o.persistent.ToString().ToLower(), o.defaultFor, o.paramType);
         }

--- a/fdbclient/vexillographer/cpp.cs
+++ b/fdbclient/vexillographer/cpp.cs
@@ -47,8 +47,9 @@ namespace vexillographer
 
         private static string getCInfoLine(Option o, string indent, string structName)
         {
-            return String.Format("{0}ADD_OPTION_INFO({1}, {2}, \"{2}\", \"{3}\", \"{4}\", {5}, {6}, {7}, {8})",
-                indent, structName, o.name.ToUpper(), o.comment, o.getParameterComment(), (o.paramDesc != null).ToString().ToLower(), o.hidden.ToString().ToLower(), o.persistent.ToString().ToLower(), o.defaultFor);
+            return String.Format("{0}ADD_OPTION_INFO({1}, {2}, \"{2}\", \"{3}\", \"{4}\", {5}, {6}, {7}, {8}, {9})",
+                indent, structName, o.name.ToUpper(), o.comment, o.getParameterComment(), (o.paramDesc != null).ToString().ToLower(), 
+                o.hidden.ToString().ToLower(), o.persistent.ToString().ToLower(), o.defaultFor, o.paramType);
         }
 
         private static void writeCppInfo(TextWriter outFile, Scope scope, IEnumerable<Option> options)


### PR DESCRIPTION
Previously, the environment setting via shell cannot be extracted correctly, due to the code is't able to determine input parameter type.
Now the logic to determine parameter and give it different processing is added.

backport #5616

Testing
    1. Pass an invalid env var:
            FDB_NETWORK_OPTION_TRACE_ROLL_SIZE=xyz - error
            FDB_NETWORK_OPTION_TRACE_ROLL_SIZE=123xyz) - error
    2. Pass an out-of-ranged env var:
            FDB_NETWORK_OPTION_TRACE_ROLL_SIZE=9999999999999999999999999999 -error
            FDB_NETWORK_OPTION_TRACE_ROLL_SIZE=-9999999999999999999999999999 -error
    3. Pass a valid env var
            FDB_NETWORK_OPTION_TRACE_ROLL_SIZE=1000 -ok
    4. Pass a float env var(not support)
            FDB_NETWORK_OPTION_TRACE_ROLL_SIZE=3.1415926535 - error
    5. Pass string as env var for places where string type var is required
            FDB_NETWORK_OPTION_TRACE_ENABLE="" - ok
            FDB_NETWORK_OPTION_EXTERNAL_CLIENT_DIRECTORY=/home/xxx/snowflakedb/temp  -ok
    
# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
