### PR TITLE
remove network hop by getting previous commit versions in GetCommitVersionRequest

### DIFF
--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -37,6 +37,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( MAX_COMMIT_BATCH_INTERVAL,                             2.0 ); if( randomize && BUGGIFY ) MAX_COMMIT_BATCH_INTERVAL = 0.5; // Each commit proxy generates a CommitTransactionBatchRequest at least this often, so that versions always advance smoothly
 	MAX_COMMIT_BATCH_INTERVAL = std::min(MAX_COMMIT_BATCH_INTERVAL, MAX_READ_TRANSACTION_LIFE_VERSIONS/double(2*VERSIONS_PER_SECOND)); // Ensure that the proxy commits 2 times every MAX_READ_TRANSACTION_LIFE_VERSIONS, otherwise the master will not give out versions fast enough
 	init( ENABLE_VERSION_VECTOR,                               false );
+	init( ENABLE_VERSION_VECTOR_TLOG_UNICAST,                  false );
 
 	// TLogs
 	init( TLOG_TIMEOUT,                                          0.4 ); //cannot buggify because of availability

--- a/fdbclient/ServerKnobs.h
+++ b/fdbclient/ServerKnobs.h
@@ -38,6 +38,7 @@ public:
 	int64_t MAX_READ_TRANSACTION_LIFE_VERSIONS;
 	int64_t MAX_WRITE_TRANSACTION_LIFE_VERSIONS;
 	bool ENABLE_VERSION_VECTOR;
+	bool ENABLE_VERSION_VECTOR_TLOG_UNICAST;
 	double MAX_COMMIT_BATCH_INTERVAL; // Each commit proxy generates a CommitTransactionBatchRequest at least this
 	                                  // often, so that versions always advance smoothly
 

--- a/fdbserver/ApplyMetadataMutation.cpp
+++ b/fdbserver/ApplyMetadataMutation.cpp
@@ -45,10 +45,6 @@ Reference<StorageInfo> getStorageInfo(UID id,
 }
 namespace {
 
-inline bool isSystemKey(KeyRef key) {
-	return key.size() && key[0] == systemKeys.begin[0];
-}
-
 // It is incredibly important that any modifications to txnStateStore are done in such a way that the same operations
 // will be done on all commit proxies at the same time. Otherwise, the data stored in txnStateStore will become
 // corrupted.
@@ -1046,36 +1042,4 @@ void applyMetadataMutations(SpanID const& spanContext,
                             const VectorRef<MutationRef>& mutations,
                             IKeyValueStore* txnStateStore) {
 	ApplyMetadataMutationsImpl(spanContext, dbgid, arena, mutations, txnStateStore).apply();
-}
-
-bool containsMetadataMutation(const VectorRef<MutationRef>& mutations) {
-	for (auto const& m : mutations) {
-
-		if (m.type == MutationRef::SetValue && isSystemKey(m.param1)) {
-			if (m.param1.startsWith(globalKeysPrefix) || (m.param1.startsWith(cacheKeysPrefix)) ||
-			    (m.param1.startsWith(configKeysPrefix)) || (m.param1.startsWith(serverListPrefix)) ||
-			    (m.param1.startsWith(storageCachePrefix)) || (m.param1.startsWith(serverTagPrefix)) ||
-			    (m.param1.startsWith(tssMappingKeys.begin)) || (m.param1.startsWith(tssQuarantineKeys.begin)) ||
-			    (m.param1.startsWith(applyMutationsEndRange.begin)) ||
-			    (m.param1.startsWith(applyMutationsKeyVersionMapRange.begin)) ||
-			    (m.param1.startsWith(logRangesRange.begin)) || (m.param1.startsWith(serverKeysPrefix)) ||
-			    (m.param1.startsWith(keyServersPrefix)) || (m.param1.startsWith(cacheKeysPrefix))) {
-				return true;
-			}
-		} else if (m.type == MutationRef::ClearRange && isSystemKey(m.param2)) {
-			KeyRangeRef range(m.param1, m.param2);
-			if ((keyServersKeys.intersects(range)) || (configKeys.intersects(range)) ||
-			    (serverListKeys.intersects(range)) || (tagLocalityListKeys.intersects(range)) ||
-			    (serverTagKeys.intersects(range)) || (serverTagHistoryKeys.intersects(range)) ||
-			    (range.intersects(applyMutationsEndRange)) || (range.intersects(applyMutationsKeyVersionMapRange)) ||
-			    (range.intersects(logRangesRange)) || (tssMappingKeys.intersects(range)) ||
-			    (tssQuarantineKeys.intersects(range)) || (range.contains(coordinatorsKey)) ||
-			    (range.contains(databaseLockedKey)) || (range.contains(metadataVersionKey)) ||
-			    (range.contains(mustContainSystemMutationsKey)) || (range.contains(writeRecoveryKey)) ||
-			    (range.intersects(testOnlyTxnStateStorePrefixRange))) {
-				return true;
-			}
-		}
-	}
-	return false;
 }

--- a/fdbserver/ApplyMetadataMutation.cpp
+++ b/fdbserver/ApplyMetadataMutation.cpp
@@ -140,7 +140,7 @@ private:
 		if (!m.param1.startsWith(keyServersPrefix)) {
 			return;
 		}
-		// TraceEvent("checkSetKeyServersPrefix MetadataMutation").detail("ToCommit", toCommit  ? 1 : 0);
+		// TraceEvent("checkSetKeyServersPrefix").detail("ToCommit", toCommit  ? 1 : 0);
 
 		if (!initialCommit)
 			txnStateStore->set(KeyValueRef(m.param1, m.param2));
@@ -189,7 +189,7 @@ private:
 		if (!m.param1.startsWith(serverKeysPrefix)) {
 			return;
 		}
-		// TraceEvent("checkSetServerKeysPrefix MetadataMutation");
+		// TraceEvent("checkSetServerKeysPrefix");
 
 		if (toCommit) {
 			Tag tag = decodeServerTagValue(
@@ -212,7 +212,7 @@ private:
 		if (!m.param1.startsWith(serverTagPrefix)) {
 			return;
 		}
-		// TraceEvent("checkSetServerTagsPrefix MetadataMutation").detail("ToCommit", toCommit  ? 1 : 0);
+		// TraceEvent("checkSetServerTagsPrefix").detail("ToCommit", toCommit  ? 1 : 0);
 
 		UID id = decodeServerTagKey(m.param1);
 		Tag tag = decodeServerTagValue(m.param2);
@@ -279,7 +279,7 @@ private:
 		if (!m.param1.startsWith(cacheKeysPrefix) || toCommit == nullptr) {
 			return;
 		}
-		// TraceEvent("checkSetCacheKeysPrefix MetadataMutation");
+		// TraceEvent("checkSetCacheKeysPrefix");
 		// Create a private mutation for cache servers
 		// This is done to make the cache servers aware of the cached key-ranges
 		MutationRef privatized = m;
@@ -343,7 +343,7 @@ private:
 		if (!m.param1.startsWith(tssMappingKeys.begin)) {
 			return;
 		}
-		// TraceEvent("checkSetTSSMappingKeys MetadataMutation");
+		// TraceEvent("checkSetTSSMappingKeys");
 
 		// Normally uses key backed map, so have to use same unpacking code here.
 		UID ssId = Codec<UID>::unpack(Tuple::unpack(m.param1.removePrefix(tssMappingKeys.begin)));
@@ -377,7 +377,7 @@ private:
 		if (!toCommit) {
 			return;
 		}
-		// TraceEvent("checkSetTSSQuarantineKeys MetadataMutation");
+		// TraceEvent("checkSetTSSQuarantineKeys");
 		UID tssId = decodeTssQuarantineKey(m.param1);
 		Optional<Value> ssiV = txnStateStore->readValue(serverListKeyFor(tssId)).get();
 		if (!ssiV.present()) {
@@ -486,7 +486,7 @@ private:
 		if (!toCommit) {
 			return;
 		}
-		// TraceEvent("checkSetGlobalKeys MetadataMutation");
+		// TraceEvent("checkSetGlobalKeys");
 		// Notifies all servers that a Master's server epoch ends
 		auto allServers = txnStateStore->readRange(serverTagKeys).get();
 		std::set<Tag> allTags;
@@ -618,7 +618,7 @@ private:
 		if (!serverTagKeys.intersects(range)) {
 			return;
 		}
-		// TraceEvent("checkClearServerTagKeys MetadataMutation");
+		// TraceEvent("checkClearServerTagKeys");
 		// Storage server removal always happens in a separate version from any prior writes (or any subsequent
 		// reuse of the tag) so we can safely destroy the tag here without any concern about intra-batch
 		// ordering
@@ -909,7 +909,7 @@ private:
 		if (cachedRangeInfo.size() == 0 || !toCommit) {
 			return;
 		}
-		// TraceEvent("tagStorageServersForCachedKeyRanges MetadataMutation");
+		// TraceEvent("tagStorageServersForCachedKeyRanges");
 
 		std::map<KeyRef, MutationRef>::iterator itr;
 		KeyRef keyBegin, keyEnd;

--- a/fdbserver/ApplyMetadataMutation.h
+++ b/fdbserver/ApplyMetadataMutation.h
@@ -63,5 +63,6 @@ void applyMetadataMutations(SpanID const& spanContext,
                             Arena& arena,
                             const VectorRef<MutationRef>& mutations,
                             IKeyValueStore* txnStateStore);
+bool containsMetadataMutation(const VectorRef<MutationRef>& mutations);
 
 #endif

--- a/fdbserver/CommitProxyServer.actor.cpp
+++ b/fdbserver/CommitProxyServer.actor.cpp
@@ -491,15 +491,79 @@ struct CommitBatchContext {
 
 	std::unordered_map<uint16_t, Version> tpcvMap; // obtained from sequencer
 	std::set<uint16_t> writtenTLogs; // the set of tlog locations written to in the mutation.
-	std::set<Tag> writtenTags; // the set of tags written to in the mutation.
+	std::set<Tag> writtenTags; // final set tags written to in the batch
+	std::set<Tag> writtenTagsPreResolution; // tags written to in the batch not including any changes from the resolver.
+	bool hasMetadataMutation = false;
+	bool metadataMutationFromProxy = false;
 
 	CommitBatchContext(ProxyCommitData*, const std::vector<CommitTransactionRequest>*, const int);
 
 	void setupTraceBatch();
 
+	std::set<Tag> getWrittenTagsPreResolution();
+
 private:
 	void evaluateBatchSize();
 };
+
+std::set<Tag> CommitBatchContext::getWrittenTagsPreResolution() {
+	std::set<Tag> transactionTags;
+	std::vector<Tag> cacheVector = { cacheTag };
+	for (int transactionNum = 0; transactionNum < trs.size(); transactionNum++) {
+		int mutationNum = 0;
+		VectorRef<MutationRef>* pMutations = &trs[transactionNum].transaction.mutations;
+		for (; mutationNum < pMutations->size(); mutationNum++) {
+			auto& m = (*pMutations)[mutationNum];
+			if (m.param1.startsWith(serverTagPrefix)) {
+				std::set<Tag> serverTags;
+				Tag tag = decodeServerTagValue(m.param2);
+				serverTags.insert(tag);
+				transactionTags.insert(tag);
+				toCommit.getLocations(serverTags, writtenTLogs);
+			}
+			if (isSingleKeyMutation((MutationRef::Type)m.type)) {
+				auto& tags = pProxyCommitData->tagsForKey(m.param1);
+				transactionTags.insert(tags.begin(), tags.end());
+				toCommit.getLocations(tags, writtenTLogs);
+				if (pProxyCommitData->cacheInfo[m.param1]) {
+					toCommit.getLocations(cacheVector, writtenTLogs);
+					transactionTags.insert(cacheTag);
+				}
+			} else if (m.type == MutationRef::ClearRange) {
+				KeyRangeRef clearRange(KeyRangeRef(m.param1, m.param2));
+				auto ranges = pProxyCommitData->keyInfo.intersectingRanges(clearRange);
+				auto firstRange = ranges.begin();
+				++firstRange;
+				if (firstRange == ranges.end()) {
+					std::set<Tag> filteredTags;
+					ranges.begin().value().populateTags();
+					filteredTags.insert(ranges.begin().value().tags.begin(), ranges.begin().value().tags.end());
+					transactionTags.insert(ranges.begin().value().tags.begin(), ranges.begin().value().tags.end());
+					toCommit.getLocations(filteredTags, writtenTLogs);
+				} else {
+					std::set<Tag> allSources;
+					for (auto r : ranges) {
+						r.value().populateTags();
+						allSources.insert(r.value().tags.begin(), r.value().tags.end());
+						transactionTags.insert(r.value().tags.begin(), r.value().tags.end());
+					}
+					toCommit.getLocations(allSources, writtenTLogs);
+				}
+				if (pProxyCommitData->needsCacheTag(clearRange)) {
+					toCommit.getLocations(cacheVector, writtenTLogs);
+					transactionTags.insert(cacheTag);
+				}
+			} else {
+				UNREACHABLE();
+			}
+		}
+		if (containsMetadataMutation(trs[transactionNum].transaction.mutations)) {
+			hasMetadataMutation = true;
+		}
+	}
+
+	return transactionTags;
+}
 
 CommitBatchContext::CommitBatchContext(ProxyCommitData* const pProxyCommitData_,
                                        const std::vector<CommitTransactionRequest>* trs_,
@@ -629,13 +693,27 @@ ACTOR Future<Void> preresolutionProcessing(CommitBatchContext* self) {
 		    "CommitDebug", debugID.get().first(), "CommitProxyServer.commitBatch.GettingCommitVersion");
 	}
 
+	if (SERVER_KNOBS->ENABLE_VERSION_VECTOR_TLOG_UNICAST) {
+		self->writtenTagsPreResolution = self->getWrittenTagsPreResolution();
+		if (self->hasMetadataMutation) {
+			int numLogs = pProxyCommitData->db->get().logSystemConfig.numLogs();
+			for (int i = 0; i < numLogs; i++) {
+				self->writtenTLogs.insert(i);
+			}
+		}
+	}
 	GetCommitVersionRequest req(span.context,
 	                            pProxyCommitData->commitVersionRequestNumber++,
 	                            pProxyCommitData->mostRecentProcessedRequestNumber,
-	                            pProxyCommitData->dbgid);
+	                            pProxyCommitData->dbgid,
+	                            self->writtenTLogs);
 	state double beforeGettingCommitVersion = now();
 	GetCommitVersionReply versionReply = wait(brokenPromiseToNever(
 	    pProxyCommitData->master.getCommitVersion.getReply(req, TaskPriority::ProxyMasterVersionReply)));
+
+	if (SERVER_KNOBS->ENABLE_VERSION_VECTOR_TLOG_UNICAST) {
+		self->tpcvMap = versionReply.tpcvMap;
+	}
 
 	pProxyCommitData->mostRecentProcessedRequestNumber = versionReply.requestNum;
 
@@ -764,6 +842,11 @@ void applyMetadataEffect(CommitBatchContext* self) {
 				                       self->forceRecovery,
 				                       /* popVersion= */ 0,
 				                       /* initialCommit */ false);
+				if (SERVER_KNOBS->ENABLE_VERSION_VECTOR_TLOG_UNICAST &&
+				    containsMetadataMutation(
+				        self->resolution[0].stateMutations[versionIndex][transactionIndex].mutations)) {
+					self->metadataMutationFromProxy = true;
+				}
 			}
 			if (self->resolution[0].stateMutations[versionIndex][transactionIndex].mutations.size() &&
 			    self->firstStateMutations) {
@@ -890,15 +973,13 @@ ACTOR Future<Void> applyMetadataToCommittedTransactions(CommitBatchContext* self
 	return Void();
 }
 
-// Message the sequencer to obtain the previous commit version for each tlog to which we are going to send
-// the commit version/ mutations to
-ACTOR Future<Void> getTPCV(CommitBatchContext* self) {
+ACTOR Future<Void> getTPCV(CommitBatchContext* self, std::set<uint16_t> writtenTLogs) {
 	state ProxyCommitData* const pProxyCommitData = self->pProxyCommitData;
 	GetTLogPrevCommitVersionReply rep =
 	    wait(brokenPromiseToNever(pProxyCommitData->master.getTLogPrevCommitVersion.getReply(
-	        GetTLogPrevCommitVersionRequest(self->writtenTLogs, self->commitVersion, self->prevVersion))));
+	        GetTLogPrevCommitVersionRequest(writtenTLogs, self->commitVersion, self->prevVersion))));
 	// TraceEvent("GetTLogPrevCommitVersionRequest");
-	self->tpcvMap = rep.tpcvMap;
+	self->tpcvMap.insert(rep.tpcvMap.begin(), rep.tpcvMap.end());
 	return Void();
 }
 
@@ -976,7 +1057,6 @@ ACTOR Future<Void> assignMutationsToStorageServers(CommitBatchContext* self) {
 					self->toCommit.addTag(cacheTag);
 				}
 				self->toCommit.writeTypedMessage(m);
-				self->toCommit.saveLocations(self->writtenTLogs);
 			} else if (m.type == MutationRef::ClearRange) {
 				KeyRangeRef clearRange(KeyRangeRef(m.param1, m.param2));
 				auto ranges = pProxyCommitData->keyInfo.intersectingRanges(clearRange);
@@ -986,7 +1066,6 @@ ACTOR Future<Void> assignMutationsToStorageServers(CommitBatchContext* self) {
 					// Fast path
 					DEBUG_MUTATION("ProxyCommit", self->commitVersion, m, pProxyCommitData->dbgid)
 					    .detail("To", ranges.begin().value().tags);
-
 					ranges.begin().value().populateTags();
 					self->toCommit.addTags(ranges.begin().value().tags);
 
@@ -1032,7 +1111,6 @@ ACTOR Future<Void> assignMutationsToStorageServers(CommitBatchContext* self) {
 					self->toCommit.addTag(cacheTag);
 				}
 				self->toCommit.writeTypedMessage(m);
-				self->toCommit.saveLocations(self->writtenTLogs);
 			} else {
 				UNREACHABLE();
 			}
@@ -1119,6 +1197,14 @@ ACTOR Future<Void> postResolution(CommitBatchContext* self) {
 		wait(Future<Void>(Never()));
 	}
 
+	if (SERVER_KNOBS->ENABLE_VERSION_VECTOR_TLOG_UNICAST && self->metadataMutationFromProxy &&
+	    !self->hasMetadataMutation) {
+		// TraceEvent("Abort metadataMutationFromProxy");
+		for (int transactionNum = 0; transactionNum < trs.size(); transactionNum++) {
+			self->committed[transactionNum] = ConflictBatch::TransactionConflict;
+		}
+	}
+
 	// First pass
 	wait(applyMetadataToCommittedTransactions(self));
 
@@ -1127,9 +1213,23 @@ ACTOR Future<Void> postResolution(CommitBatchContext* self) {
 
 	self->toCommit.saveTags(self->writtenTags);
 
-	// Obtain previous committed versions for each affected tlog from sequencer
-	if (SERVER_KNOBS->ENABLE_VERSION_VECTOR) {
-		wait(getTPCV(self));
+	if (self->writtenTags.size() && !self->metadataMutationFromProxy &&
+	    SERVER_KNOBS->ENABLE_VERSION_VECTOR_TLOG_UNICAST) {
+		// confirm all serialized tags are sent to a tLog for which the previous commit version was obtained.
+		std::set<uint16_t> postResolutionTLogs;
+		self->toCommit.getLocations(self->writtenTags, postResolutionTLogs);
+		for (auto& t : postResolutionTLogs) {
+			if (self->writtenTLogs.find(t) == self->writtenTLogs.end()) {
+				TraceEvent("Tag in message does not have PCV!")
+				    .detail("tags in batch before resolution", self->writtenTagsPreResolution)
+				    .detail("tags in batch after resolution", self->writtenTags)
+				    .detail("size of TLog set before resolution", self->writtenTLogs.size())
+				    .detail("size of TLog set after resolution", postResolutionTLogs.size())
+				    .detail("Original batch had metadata mutations", self->hasMetadataMutation)
+				    .detail("Recevied metadata mutations from proxy", self->metadataMutationFromProxy);
+				ASSERT(false);
+			}
+		}
 	}
 
 	// Serialize and backup the mutations as a single mutation
@@ -1331,10 +1431,12 @@ ACTOR Future<Void> reply(CommitBatchContext* self) {
 	// self->committedVersion by reporting commit version first before updating self->committedVersion. Otherwise, a
 	// client may get a commit version that the master is not aware of, and next GRV request may get a version less than
 	// self->committedVersion.
+
 	TEST(pProxyCommitData->committedVersion.get() > self->commitVersion); // later version was reported committed first
+
 	if (self->commitVersion >= pProxyCommitData->committedVersion.get()) {
 		state Optional<std::set<Tag>> writtenTags;
-		if (SERVER_KNOBS->ENABLE_VERSION_VECTOR) {
+		if (SERVER_KNOBS->ENABLE_VERSION_VECTOR_TLOG_UNICAST) {
 			writtenTags = self->writtenTags;
 		}
 		wait(pProxyCommitData->master.reportLiveCommittedVersion.getReply(

--- a/fdbserver/LogSystem.h
+++ b/fdbserver/LogSystem.h
@@ -765,10 +765,21 @@ struct LogPushData : NonCopyable {
 	// copy written_tags, after filtering, into given set
 	void saveTags(std::set<Tag>& filteredTags) const {
 		for (const auto& tag : written_tags) {
-			if (!tag.isNonPrimaryTLogType()) {
-				filteredTags.insert(tag);
-			}
+			filteredTags.insert(tag);
 		}
+	}
+
+	void getLocations(const std::set<Tag>& tags, std::set<uint16_t>& writtenTLogs) {
+		std::vector<Tag> vtags(tags.begin(), tags.end());
+		std::vector<int> msg_locations;
+		logSystem->getPushLocations(vtags, msg_locations, false /*allLocations*/);
+		writtenTLogs.insert(msg_locations.begin(), msg_locations.end());
+	}
+
+	void getLocations(const std::vector<Tag>& vtags, std::set<uint16_t>& writtenTLogs) {
+		std::vector<int> msg_locations;
+		logSystem->getPushLocations(vtags, msg_locations, false /*allLocations*/);
+		writtenTLogs.insert(msg_locations.begin(), msg_locations.end());
 	}
 
 	// store tlogs as represented by index

--- a/fdbserver/MasterInterface.h
+++ b/fdbserver/MasterInterface.h
@@ -156,6 +156,7 @@ struct GetCommitVersionReply {
 	Version version;
 	Version prevVersion;
 	uint64_t requestNum;
+	std::unordered_map<uint16_t, Version> tpcvMap;
 
 	GetCommitVersionReply() : resolverChangesVersion(0), version(0), prevVersion(0), requestNum(0) {}
 	explicit GetCommitVersionReply(Version version, Version prevVersion, uint64_t requestNum)
@@ -163,7 +164,7 @@ struct GetCommitVersionReply {
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, resolverChanges, resolverChangesVersion, version, prevVersion, requestNum);
+		serializer(ar, resolverChanges, resolverChangesVersion, version, prevVersion, requestNum, tpcvMap);
 	}
 };
 
@@ -173,19 +174,21 @@ struct GetCommitVersionRequest {
 	uint64_t requestNum;
 	uint64_t mostRecentProcessedRequestNum;
 	UID requestingProxy;
+	std::set<uint16_t> writtenTLogs;
 	ReplyPromise<GetCommitVersionReply> reply;
 
 	GetCommitVersionRequest() {}
 	GetCommitVersionRequest(SpanID spanContext,
 	                        uint64_t requestNum,
 	                        uint64_t mostRecentProcessedRequestNum,
-	                        UID requestingProxy)
+	                        UID requestingProxy,
+	                        std::set<uint16_t>& writtenTLogs)
 	  : spanContext(spanContext), requestNum(requestNum), mostRecentProcessedRequestNum(mostRecentProcessedRequestNum),
-	    requestingProxy(requestingProxy) {}
+	    requestingProxy(requestingProxy), writtenTLogs(writtenTLogs) {}
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, requestNum, mostRecentProcessedRequestNum, requestingProxy, reply, spanContext);
+		serializer(ar, requestNum, mostRecentProcessedRequestNum, requestingProxy, writtenTLogs, reply, spanContext);
 	}
 };
 

--- a/fdbserver/TLogServer.actor.cpp
+++ b/fdbserver/TLogServer.actor.cpp
@@ -1912,10 +1912,10 @@ Future<Void> tLogPeekMessages(PromiseType replyPromise,
 	reply.end = endVersion;
 	reply.onlySpilled = onlySpilled;
 
-	//TraceEvent("TlogPeek", self->dbgid).detail("LogId", logData->logId).detail("Tag", reqTag.toString()).
-	//	detail("BeginVer", reqBegin).detail("EndVer", reply.end).
-	//	detail("MsgBytes", reply.messages.expectedSize()).
-	//	detail("ForAddress", replyPromise.getEndpoint().getPrimaryAddress());
+	// TraceEvent("TlogPeek", self->dbgid).detail("LogId", logData->logId).detail("Tag", reqTag.toString()).
+	// 	detail("BeginVer", reqBegin).detail("EndVer", reply.end).
+	// 	detail("MsgBytes", reply.messages.expectedSize()).
+	// 	detail("ForAddress", replyPromise.getEndpoint().getPrimaryAddress());
 
 	if (reqSequence.present()) {
 		auto& trackerData = logData->peekTracker[peekId];

--- a/fdbserver/TagPartitionedLogSystem.actor.cpp
+++ b/fdbserver/TagPartitionedLogSystem.actor.cpp
@@ -532,7 +532,7 @@ Future<Version> TagPartitionedLogSystem::push(Version prevVersion,
 			}
 			std::vector<Future<Void>> tLogCommitResults;
 			for (int loc = 0; loc < it->logServers.size(); loc++) {
-				if (SERVER_KNOBS->ENABLE_VERSION_VECTOR) {
+				if (SERVER_KNOBS->ENABLE_VERSION_VECTOR_TLOG_UNICAST) {
 					if (tpcvMap.get().find(location) != tpcvMap.get().end()) {
 						prevVersion = tpcvMap.get()[location];
 					} else {


### PR DESCRIPTION
We wish to remove the overhead of sending empty transactions from proxies to tLogs [1]. To do this, the vector: "previous commit version per tLog" (TPCV) must be maintained. 

This was first implemented by maintaining the TPCV on the sequencer. The proxy would call the sequencer to obtain the TPCV for tLogs after the resolve step. This solution generated an extra call in the transaction path. The extra call is expensive and degrades performance.

This PR removes that extra hop, by "piggybacking" how the TPCV is obtained over an existing call (`GetCommitVersionRequest`) from the proxy to the sequencer.  This call is made before the resolve step. 

Prior to the call, all the transactions in the batch are scanned to find the set of tags affected (if any metadata mutations exist, send the batch to all tLogs as done in current FDB). 

Doing it this way introduces a new problem: the resolver may send to the proxy a metadata mutation to modify the transaction's tags or key mappings (e.g. for shard movement). Those new/modified tags may not have a known PCV. See [discussion](https://docs.google.com/document/d/1_3qXu0_MUC10_Ocoqay81unc3f61PKX7VdOngeYGTxE/edit?disco=AAAAPpCIxbw).

To deal with that problem:

1. If any metadata mutations arrive from the resolver, abort the batch by declaring a conflict, unless a metadata mutation arrived in the original batch.
2. Add an assertion validating that any tLogs used in the batch have a previous commit version.

Tested by running inserts and updates with different loads (mako).

[1]
The "partitioned transaction project" is also tackling this issue, but their code will take some time to be completed. This PR allows us to test and explore FDB behavior in the meantime.
