### PR TITLE
Fix failover logic in checkRecoveryStalled

### DIFF
--- a/fdbserver/ClusterController.actor.cpp
+++ b/fdbserver/ClusterController.actor.cpp
@@ -2197,10 +2197,10 @@ public:
 		    db.recoveryStalled) {
 			if (db.config.regions.size() > 1) {
 				auto regions = db.config.regions;
-				if (clusterControllerDcId.get() == regions[0].dcId) {
+				if (clusterControllerDcId.get() == regions[0].dcId && regions[1].priority >= 0) {
 					std::swap(regions[0], regions[1]);
 				}
-				ASSERT(clusterControllerDcId.get() == regions[1].dcId);
+				ASSERT(regions[1].priority < 0 || clusterControllerDcId.get() == regions[1].dcId);
 				checkRegions(regions);
 			}
 		}


### PR DESCRIPTION
checkRecoveryStalled should perform failover only when remote is enabled (priority >= 0). Otherwise, forcing failover will cause constant primary DC flip. Issue found in Snowflake nightly runs.

Since the issue doesn't cause test to fail directly (only generate non-zero exit code), I've manually verified the fix. With the new change, release-6.3 with commit 482b3cd5a69a186716cfa3c73d577540fae5886c and seed 718072587 no longer generate any Sev40 errors, and exit successfully.

100K joshua: 20210923-212452-zhewu_5659-9e6707ad01d7e682        compressed=True data_size=20708483 duration=4098214 ended=100041 fail_fast=10 max_runs=100000 pass=100041 priority=100 remaining=0 runtime=1:22:35 sanity=False started=100052 stopped=20210923-224727 submitted=20210923-212452 timeout=5400 username=zhewu_5659

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
