### PR TITLE
Add a ThreadID field to eachTraceEvent.  This is needed for multithre…(release 6.3)

### DIFF
--- a/flow/DeterministicRandom.cpp
+++ b/flow/DeterministicRandom.cpp
@@ -84,6 +84,10 @@ uint32_t DeterministicRandom::randomUInt32() {
 	return gen64();
 }
 
+uint64_t DeterministicRandom::randomUInt64() {
+	return gen64();
+}
+
 uint32_t DeterministicRandom::randomSkewedUInt32(uint32_t min, uint32_t maxPlusOne) {
 	std::uniform_real_distribution<double> distribution(std::log(min), std::log(maxPlusOne - 1));
 	double logpower = distribution(random);

--- a/flow/DeterministicRandom.h
+++ b/flow/DeterministicRandom.h
@@ -44,6 +44,7 @@ public:
 	int randomInt(int min, int maxPlusOne) override;
 	int64_t randomInt64(int64_t min, int64_t maxPlusOne) override;
 	uint32_t randomUInt32() override;
+	uint64_t randomUInt64() override;
 	uint32_t randomSkewedUInt32(uint32_t min, uint32_t maxPlusOne) override;
 	UID randomUniqueID() override;
 	char randomAlphaNumeric() override;

--- a/flow/IRandom.h
+++ b/flow/IRandom.h
@@ -138,6 +138,7 @@ public:
 	virtual int randomInt(int min, int maxPlusOne) = 0;
 	virtual int64_t randomInt64(int64_t min, int64_t maxPlusOne) = 0;
 	virtual uint32_t randomUInt32() = 0;
+	virtual uint64_t randomUInt64() = 0;
 	virtual UID randomUniqueID() = 0;
 	virtual char randomAlphaNumeric() = 0;
 	virtual std::string randomAlphaNumeric(int length) = 0;

--- a/flow/Trace.h
+++ b/flow/Trace.h
@@ -426,6 +426,7 @@ private:
 	void setField(const char* key, int64_t value);
 	void setField(const char* key, double value);
 	void setField(const char* key, const std::string& value);
+	void setThreadId();
 
 	TraceEvent& errorImpl(const class Error& e, bool includeCancelled = false);
 	// Private version of detailf that does NOT write to the eventMetric.  This is to be used by other detail methods


### PR DESCRIPTION
…aded client debugging, and should also be helpful for multithreaded storage engines, SSL handshake threadpools, and so on


Backports https://github.com/apple/foundationdb/pull/5108 to 6.3. Also added the definition of DeterministicRandom::randomUInt64 to make it work.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
