### PR TITLE
Fail simulation if the trace log buffer gets large

### DIFF
--- a/flow/Trace.cpp
+++ b/flow/Trace.cpp
@@ -388,6 +388,17 @@ public:
 		eventBuffer.push_back(fields);
 		bufferLength += fields.sizeBytes();
 
+		// If we have queued up a large number of events in simulation, then flush the trace file and throw an error.
+		// This makes it easier to diagnose cases where we get stuck in a loop logging trace events that eventually
+		// runs out of memory. Without this we would never see any trace events from that loop, and it would be more
+		// difficult to identify where the process is actually stuck.
+		if (g_network && g_network->isSimulated() && bufferLength > 1e8) {
+			// Setting this to 0 avoids a recurse from the assertion trace event and also prevents a situation where
+			// we roll the trace log only to log the single assertion event when using --crash.
+			bufferLength = 0;
+			ASSERT(false);
+		}
+
 		if (trackError) {
 			latestEventCache.setLatestError(fields);
 		}

--- a/flow/Trace.cpp
+++ b/flow/Trace.cpp
@@ -388,10 +388,10 @@ public:
 		eventBuffer.push_back(fields);
 		bufferLength += fields.sizeBytes();
 
-		// If we have queued up a large number of events in simulation, then flush the trace file and throw an error.
-		// This makes it easier to diagnose cases where we get stuck in a loop logging trace events that eventually
-		// runs out of memory. Without this we would never see any trace events from that loop, and it would be more
-		// difficult to identify where the process is actually stuck.
+		// If we have queued up a large number of events in simulation, then throw an error. This makes it easier to
+		// diagnose cases where we get stuck in a loop logging trace events that eventually runs out of memory.
+		// Without this we would never see any trace events from that loop, and it would be more difficult to identify
+		// where the process is actually stuck.
 		if (g_network && g_network->isSimulated() && bufferLength > 1e8) {
 			// Setting this to 0 avoids a recurse from the assertion trace event and also prevents a situation where
 			// we roll the trace log only to log the single assertion event when using --crash.


### PR DESCRIPTION
We recently had a correctness failure (see #5650) where a test got stuck in a loop that did not advance time. It was logging trace events in this loop, which eventually caused the process to run out of memory. However, because we weren't advancing time we did not actually flush the trace log, and this made it unclear what was happening.

To diagnose the problem initially, I increased the memory of the process and observed no change in the output logs. From this I surmised we were stuck in a loop and used gdb to figure out where.

With this change, it should be possible from the trace logs to tell that we were stuck in a loop that involves trace events, and the trace events should make it clear where.

Passed 100K correctness with one unrelated failure.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.
