### PR TITLE
Fail simulation if the trace log buffer gets large (release-7.0)

### DIFF
--- a/flow/Trace.cpp
+++ b/flow/Trace.cpp
@@ -388,6 +388,17 @@ public:
 		eventBuffer.push_back(fields);
 		bufferLength += fields.sizeBytes();
 
+		// If we have queued up a large number of events in simulation, then flush the trace file and throw an error.
+		// This makes it easier to diagnose cases where we get stuck in a loop logging trace events that eventually
+		// runs out of memory. Without this we would never see any trace events from that loop, and it would be more
+		// difficult to identify where the process is actually stuck.
+		if (g_network && g_network->isSimulated() && bufferLength > 1e8) {
+			// Setting this to 0 avoids a recurse from the assertion trace event and also prevents a situation where
+			// we roll the trace log only to log the single assertion event when using --crash.
+			bufferLength = 0;
+			ASSERT(false);
+		}
+
 		if (trackError) {
 			latestEventCache.setLatestError(fields);
 		}

--- a/flow/Trace.cpp
+++ b/flow/Trace.cpp
@@ -388,10 +388,10 @@ public:
 		eventBuffer.push_back(fields);
 		bufferLength += fields.sizeBytes();
 
-		// If we have queued up a large number of events in simulation, then flush the trace file and throw an error.
-		// This makes it easier to diagnose cases where we get stuck in a loop logging trace events that eventually
-		// runs out of memory. Without this we would never see any trace events from that loop, and it would be more
-		// difficult to identify where the process is actually stuck.
+		// If we have queued up a large number of events in simulation, then throw an error. This makes it easier to
+		// diagnose cases where we get stuck in a loop logging trace events that eventually runs out of memory.
+		// Without this we would never see any trace events from that loop, and it would be more difficult to identify
+		// where the process is actually stuck.
 		if (g_network && g_network->isSimulated() && bufferLength > 1e8) {
 			// Setting this to 0 avoids a recurse from the assertion trace event and also prevents a situation where
 			// we roll the trace log only to log the single assertion event when using --crash.


### PR DESCRIPTION
This is a backport of #5668.

This makes it an error in simulation for the trace log buffer to get too large.

Passed 100K correctness.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
