### PR TITLE
Fix MVC timeout thread safety issue (release-6.3)

### DIFF
--- a/bindings/c/CMakeLists.txt
+++ b/bindings/c/CMakeLists.txt
@@ -119,7 +119,11 @@ if(NOT WIN32)
     NAME disconnected_timeout_unit_tests
     COMMAND $<TARGET_FILE:disconnected_timeout_unit_tests>
             @CLUSTER_FILE@
-            fdb
+            )
+  add_unavailable_fdbclient_test(
+    NAME disconnected_timeout_external_client_unit_tests
+    COMMAND $<TARGET_FILE:disconnected_timeout_unit_tests>
+            @CLUSTER_FILE@
             ${CMAKE_CURRENT_BINARY_DIR}/libfdb_c.so
             )
 endif()

--- a/bindings/c/CMakeLists.txt
+++ b/bindings/c/CMakeLists.txt
@@ -110,6 +110,19 @@ if(NOT WIN32)
 
   target_link_libraries(trace_partial_file_suffix_test PRIVATE fdb_c Threads::Threads)
 
+  if(OPEN_FOR_IDE)
+    set(FDB_C_TARGET $<TARGET_OBJECTS:fdb_c>)
+  else()
+    set(FDB_C_TARGET $<TARGET_FILE:fdb_c>)
+  endif()
+  add_custom_command(
+    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/libfdb_c.so
+    COMMAND ${CMAKE_COMMAND} -E copy ${FDB_C_TARGET} ${CMAKE_CURRENT_BINARY_DIR}/libfdb_c.so
+    DEPENDS fdb_c
+    COMMENT "Copy libfdb_c to use as external client for test")
+  add_custom_target(external_client DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/libfdb_c.so)
+  add_dependencies(disconnected_timeout_unit_tests external_client)
+
   add_fdbclient_test(
     NAME trace_partial_file_suffix_test
     COMMAND $<TARGET_FILE:trace_partial_file_suffix_test>

--- a/bindings/c/CMakeLists.txt
+++ b/bindings/c/CMakeLists.txt
@@ -72,17 +72,26 @@ if(NOT WIN32)
     test/mako/utils.c
     test/mako/utils.h)
 
+  add_subdirectory(test/unit/third_party)
+  find_package(Threads REQUIRED)
+  set(DISCONNECTED_TIMEOUT_UNIT_TEST_SRCS 
+    test/unit/disconnected_timeout_tests.cpp
+    test/unit/fdb_api.cpp
+    test/unit/fdb_api.hpp)
+
   if(OPEN_FOR_IDE)
     add_library(fdb_c_performance_test OBJECT test/performance_test.c test/test.h)
     add_library(fdb_c_ryw_benchmark OBJECT test/ryw_benchmark.c test/test.h)
     add_library(fdb_c_txn_size_test OBJECT test/txn_size_test.c test/test.h)
     add_library(mako OBJECT ${MAKO_SRCS})
+    add_library(disconnected_timeout_unit_tests OBJECT ${DISCONNECTED_TIMEOUT_UNIT_TEST_SRCS})
   else()
     add_executable(fdb_c_performance_test test/performance_test.c test/test.h)
     add_executable(fdb_c_ryw_benchmark test/ryw_benchmark.c test/test.h)
     add_executable(fdb_c_txn_size_test test/txn_size_test.c test/test.h)
     add_executable(mako ${MAKO_SRCS})
     add_executable(trace_partial_file_suffix_test test/unit/trace_partial_file_suffix_test.cpp)
+    add_executable(disconnected_timeout_unit_tests ${DISCONNECTED_TIMEOUT_UNIT_TEST_SRCS})
     strip_debug_symbols(fdb_c_performance_test)
     strip_debug_symbols(fdb_c_ryw_benchmark)
     strip_debug_symbols(fdb_c_txn_size_test)
@@ -90,6 +99,10 @@ if(NOT WIN32)
   target_link_libraries(fdb_c_performance_test PRIVATE fdb_c)
   target_link_libraries(fdb_c_ryw_benchmark PRIVATE fdb_c)
   target_link_libraries(fdb_c_txn_size_test PRIVATE fdb_c)
+
+  add_dependencies(disconnected_timeout_unit_tests doctest)
+  target_include_directories(disconnected_timeout_unit_tests PUBLIC ${DOCTEST_INCLUDE_DIR})
+  target_link_libraries(disconnected_timeout_unit_tests PRIVATE fdb_c Threads::Threads)
 
   # do not set RPATH for mako
   set_property(TARGET mako PROPERTY SKIP_BUILD_RPATH TRUE)
@@ -102,6 +115,13 @@ if(NOT WIN32)
     COMMAND $<TARGET_FILE:trace_partial_file_suffix_test>
             @CLUSTER_FILE@
             fdb)
+  add_unavailable_fdbclient_test(
+    NAME disconnected_timeout_unit_tests
+    COMMAND $<TARGET_FILE:disconnected_timeout_unit_tests>
+            @CLUSTER_FILE@
+            fdb
+            ${CMAKE_CURRENT_BINARY_DIR}/libfdb_c.so
+            )
 endif()
 
 set(c_workloads_srcs

--- a/bindings/c/test/unit/disconnected_timeout_tests.cpp
+++ b/bindings/c/test/unit/disconnected_timeout_tests.cpp
@@ -1,0 +1,292 @@
+/*
+ * disconnected_timeout_tests.cpp
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Unit tests that test the timeouts for a disconnected cluster
+
+#define FDB_API_VERSION 710
+#include <foundationdb/fdb_c.h>
+
+#include <chrono>
+#include <iostream>
+#include <string.h>
+#include <thread>
+
+#define DOCTEST_CONFIG_IMPLEMENT
+#include "doctest.h"
+#include "fdb_api.hpp"
+
+void fdb_check(fdb_error_t e) {
+	if (e) {
+		std::cerr << fdb_get_error(e) << std::endl;
+		std::abort();
+	}
+}
+
+FDBDatabase* fdb_open_database(const char* clusterFile) {
+	FDBDatabase* db;
+	fdb_check(fdb_create_database(clusterFile, &db));
+	return db;
+}
+
+static FDBDatabase* db = nullptr;
+static FDBDatabase* timeoutDb = nullptr;
+
+// Blocks until the given future is ready, returning an error code if there was
+// an issue.
+fdb_error_t wait_future(fdb::Future& f) {
+	fdb_check(f.block_until_ready());
+	return f.get_error();
+}
+
+void validateTimeoutDuration(double expectedSeconds, std::chrono::time_point<std::chrono::steady_clock> start) {
+	std::chrono::duration<double> duration = std::chrono::steady_clock::now() - start;
+	double actualSeconds = duration.count();
+	CHECK(actualSeconds >= expectedSeconds - 1e-6);
+	CHECK(actualSeconds < expectedSeconds * 2);
+}
+
+TEST_CASE("500ms_transaction_timeout") {
+	auto start = std::chrono::steady_clock::now();
+
+	fdb::Transaction tr(db);
+
+	int64_t timeout = 500;
+	fdb_check(tr.set_option(FDB_TR_OPTION_TIMEOUT, reinterpret_cast<const uint8_t*>(&timeout), sizeof(timeout)));
+
+	fdb::Int64Future grvFuture = tr.get_read_version();
+	fdb_error_t err = wait_future(grvFuture);
+
+	CHECK(err == 1031);
+	validateTimeoutDuration(timeout / 1000.0, start);
+}
+
+TEST_CASE("500ms_transaction_timeout_after_op") {
+	auto start = std::chrono::steady_clock::now();
+
+	fdb::Transaction tr(db);
+	fdb::Int64Future grvFuture = tr.get_read_version();
+
+	int64_t timeout = 500;
+	fdb_check(tr.set_option(FDB_TR_OPTION_TIMEOUT, reinterpret_cast<const uint8_t*>(&timeout), sizeof(timeout)));
+
+	fdb_error_t err = wait_future(grvFuture);
+
+	CHECK(err == 1031);
+	validateTimeoutDuration(timeout / 1000.0, start);
+}
+
+TEST_CASE("500ms_transaction_timeout_before_op_2000ms_after") {
+	auto start = std::chrono::steady_clock::now();
+
+	fdb::Transaction tr(db);
+
+	int64_t timeout = 500;
+	fdb_check(tr.set_option(FDB_TR_OPTION_TIMEOUT, reinterpret_cast<const uint8_t*>(&timeout), sizeof(timeout)));
+
+	fdb::Int64Future grvFuture = tr.get_read_version();
+
+	timeout = 2000;
+	fdb_check(tr.set_option(FDB_TR_OPTION_TIMEOUT, reinterpret_cast<const uint8_t*>(&timeout), sizeof(timeout)));
+
+	fdb_error_t err = wait_future(grvFuture);
+
+	CHECK(err == 1031);
+	validateTimeoutDuration(timeout / 1000.0, start);
+}
+
+TEST_CASE("2000ms_transaction_timeout_before_op_500ms_after") {
+	auto start = std::chrono::steady_clock::now();
+
+	fdb::Transaction tr(db);
+
+	int64_t timeout = 2000;
+	fdb_check(tr.set_option(FDB_TR_OPTION_TIMEOUT, reinterpret_cast<const uint8_t*>(&timeout), sizeof(timeout)));
+
+	fdb::Int64Future grvFuture = tr.get_read_version();
+
+	timeout = 500;
+	fdb_check(tr.set_option(FDB_TR_OPTION_TIMEOUT, reinterpret_cast<const uint8_t*>(&timeout), sizeof(timeout)));
+
+	fdb_error_t err = wait_future(grvFuture);
+
+	CHECK(err == 1031);
+	validateTimeoutDuration(timeout / 1000.0, start);
+}
+
+TEST_CASE("500ms_database_timeout") {
+	auto start = std::chrono::steady_clock::now();
+
+	int64_t timeout = 500;
+	fdb_check(fdb_database_set_option(
+	    timeoutDb, FDB_DB_OPTION_TRANSACTION_TIMEOUT, reinterpret_cast<const uint8_t*>(&timeout), sizeof(timeout)));
+
+	fdb::Transaction tr(timeoutDb);
+
+	fdb::Int64Future grvFuture = tr.get_read_version();
+	fdb_error_t err = wait_future(grvFuture);
+
+	CHECK(err == 1031);
+	validateTimeoutDuration(timeout / 1000.0, start);
+}
+
+TEST_CASE("2000ms_database_timeout_500ms_transaction_timeout") {
+	auto start = std::chrono::steady_clock::now();
+
+	int64_t timeout = 2000;
+	fdb_check(fdb_database_set_option(
+	    timeoutDb, FDB_DB_OPTION_TRANSACTION_TIMEOUT, reinterpret_cast<const uint8_t*>(&timeout), sizeof(timeout)));
+
+	fdb::Transaction tr(timeoutDb);
+
+	timeout = 500;
+	fdb_check(tr.set_option(FDB_TR_OPTION_TIMEOUT, reinterpret_cast<const uint8_t*>(&timeout), sizeof(timeout)));
+
+	fdb::Int64Future grvFuture = tr.get_read_version();
+	fdb_error_t err = wait_future(grvFuture);
+
+	CHECK(err == 1031);
+	validateTimeoutDuration(timeout / 1000.0, start);
+}
+
+TEST_CASE("500ms_database_timeout_2000ms_transaction_timeout_with_reset") {
+	auto start = std::chrono::steady_clock::now();
+
+	int64_t dbTimeout = 500;
+	fdb_check(fdb_database_set_option(
+	    timeoutDb, FDB_DB_OPTION_TRANSACTION_TIMEOUT, reinterpret_cast<const uint8_t*>(&dbTimeout), sizeof(dbTimeout)));
+
+	fdb::Transaction tr(timeoutDb);
+
+	int64_t trTimeout = 2000;
+	fdb_check(tr.set_option(FDB_TR_OPTION_TIMEOUT, reinterpret_cast<const uint8_t*>(&trTimeout), sizeof(trTimeout)));
+
+	tr.reset();
+
+	fdb::Int64Future grvFuture = tr.get_read_version();
+	fdb_error_t err = wait_future(grvFuture);
+
+	CHECK(err == 1031);
+	validateTimeoutDuration(dbTimeout / 1000.0, start);
+}
+
+TEST_CASE("transaction_reset_cancels_without_timeout") {
+	fdb::Transaction tr(db);
+	fdb::Int64Future grvFuture = tr.get_read_version();
+	tr.reset();
+
+	fdb_error_t err = wait_future(grvFuture);
+	CHECK(err == 1025);
+}
+
+TEST_CASE("transaction_reset_cancels_with_timeout") {
+	fdb::Transaction tr(db);
+
+	int64_t timeout = 500;
+	fdb_check(tr.set_option(FDB_TR_OPTION_TIMEOUT, reinterpret_cast<const uint8_t*>(&timeout), sizeof(timeout)));
+
+	fdb::Int64Future grvFuture = tr.get_read_version();
+	tr.reset();
+
+	fdb_error_t err = wait_future(grvFuture);
+	CHECK(err == 1025);
+}
+
+TEST_CASE("transaction_destruction_cancels_without_timeout") {
+	FDBTransaction* tr;
+	fdb_check(fdb_database_create_transaction(db, &tr));
+
+	FDBFuture* grvFuture = fdb_transaction_get_read_version(tr);
+	fdb_transaction_destroy(tr);
+
+	fdb_check(fdb_future_block_until_ready(grvFuture));
+	fdb_error_t err = fdb_future_get_error(grvFuture);
+	CHECK(err == 1025);
+
+	fdb_future_destroy(grvFuture);
+}
+
+TEST_CASE("transaction_destruction_cancels_with_timeout") {
+	FDBTransaction* tr;
+	fdb_check(fdb_database_create_transaction(db, &tr));
+
+	int64_t timeout = 500;
+	fdb_check(fdb_transaction_set_option(
+	    tr, FDB_TR_OPTION_TIMEOUT, reinterpret_cast<const uint8_t*>(&timeout), sizeof(timeout)));
+
+	FDBFuture* grvFuture = fdb_transaction_get_read_version(tr);
+	fdb_transaction_destroy(tr);
+
+	fdb_check(fdb_future_block_until_ready(grvFuture));
+	fdb_error_t err = fdb_future_get_error(grvFuture);
+	CHECK(err == 1025);
+
+	fdb_future_destroy(grvFuture);
+}
+
+TEST_CASE("transaction_set_timeout_and_destroy_repeatedly") {
+	for (int i = 0; i < 1000; ++i) {
+		fdb::Transaction tr(db);
+		int64_t timeout = 500;
+		fdb_check(tr.set_option(FDB_TR_OPTION_TIMEOUT, reinterpret_cast<const uint8_t*>(&timeout), sizeof(timeout)));
+	}
+}
+
+int main(int argc, char** argv) {
+	if (argc < 2) {
+		std::cout << "Disconnected timeout unit tests for the FoundationDB C API.\n"
+		          << "Usage: disconnected_timeout_tests <unavailableClusterFile> [externalClient] [doctest args]"
+		          << std::endl;
+		return 1;
+	}
+	fdb_check(fdb_select_api_version(710));
+	if (argc >= 3) {
+		std::string externalClientLibrary = argv[2];
+		if (externalClientLibrary.substr(0, 2) != "--") {
+			fdb_check(fdb_network_set_option(
+			    FDBNetworkOption::FDB_NET_OPTION_DISABLE_LOCAL_CLIENT, reinterpret_cast<const uint8_t*>(""), 0));
+			fdb_check(fdb_network_set_option(FDBNetworkOption::FDB_NET_OPTION_EXTERNAL_CLIENT_LIBRARY,
+			                                 reinterpret_cast<const uint8_t*>(externalClientLibrary.c_str()),
+			                                 externalClientLibrary.size()));
+		}
+	}
+
+	doctest::Context context;
+	context.applyCommandLine(argc, argv);
+
+	fdb_check(fdb_setup_network());
+	std::thread network_thread{ &fdb_run_network };
+
+	db = fdb_open_database(argv[1]);
+	timeoutDb = fdb_open_database(argv[1]);
+
+	int res = context.run();
+	fdb_database_destroy(db);
+	fdb_database_destroy(timeoutDb);
+
+	if (context.shouldExit()) {
+		fdb_check(fdb_stop_network());
+		network_thread.join();
+		return res;
+	}
+	fdb_check(fdb_stop_network());
+	network_thread.join();
+
+	return res;
+}

--- a/bindings/c/test/unit/disconnected_timeout_tests.cpp
+++ b/bindings/c/test/unit/disconnected_timeout_tests.cpp
@@ -20,7 +20,7 @@
 
 // Unit tests that test the timeouts for a disconnected cluster
 
-#define FDB_API_VERSION 710
+#define FDB_API_VERSION 630
 #include <foundationdb/fdb_c.h>
 
 #include <chrono>
@@ -255,7 +255,7 @@ int main(int argc, char** argv) {
 		          << std::endl;
 		return 1;
 	}
-	fdb_check(fdb_select_api_version(710));
+	fdb_check(fdb_select_api_version(630));
 	if (argc >= 3) {
 		std::string externalClientLibrary = argv[2];
 		if (externalClientLibrary.substr(0, 2) != "--") {

--- a/bindings/c/test/unit/fdb_api.cpp
+++ b/bindings/c/test/unit/fdb_api.cpp
@@ -1,0 +1,218 @@
+/*
+ * fdb_api.cpp
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2020 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "fdb_api.hpp"
+
+#include <iostream>
+
+namespace fdb {
+
+// Future
+
+Future::~Future() {
+	fdb_future_destroy(future_);
+}
+
+bool Future::is_ready() {
+	return fdb_future_is_ready(future_);
+}
+
+[[nodiscard]] fdb_error_t Future::block_until_ready() {
+	return fdb_future_block_until_ready(future_);
+}
+
+[[nodiscard]] fdb_error_t Future::set_callback(FDBCallback callback, void* callback_parameter) {
+	return fdb_future_set_callback(future_, callback, callback_parameter);
+}
+
+[[nodiscard]] fdb_error_t Future::get_error() {
+	return fdb_future_get_error(future_);
+}
+
+void Future::release_memory() {
+	fdb_future_release_memory(future_);
+}
+
+void Future::cancel() {
+	fdb_future_cancel(future_);
+}
+
+// Int64Future
+
+[[nodiscard]] fdb_error_t Int64Future::get(int64_t* out) {
+	return fdb_future_get_int64(future_, out);
+}
+
+// ValueFuture
+
+[[nodiscard]] fdb_error_t ValueFuture::get(fdb_bool_t* out_present, const uint8_t** out_value, int* out_value_length) {
+	return fdb_future_get_value(future_, out_present, out_value, out_value_length);
+}
+
+// KeyFuture
+
+[[nodiscard]] fdb_error_t KeyFuture::get(const uint8_t** out_key, int* out_key_length) {
+	return fdb_future_get_key(future_, out_key, out_key_length);
+}
+
+// StringArrayFuture
+
+[[nodiscard]] fdb_error_t StringArrayFuture::get(const char*** out_strings, int* out_count) {
+	return fdb_future_get_string_array(future_, out_strings, out_count);
+}
+
+// KeyValueArrayFuture
+
+[[nodiscard]] fdb_error_t KeyValueArrayFuture::get(const FDBKeyValue** out_kv, int* out_count, fdb_bool_t* out_more) {
+	return fdb_future_get_keyvalue_array(future_, out_kv, out_count, out_more);
+}
+
+// Transaction
+
+Transaction::Transaction(FDBDatabase* db) {
+	if (fdb_error_t err = fdb_database_create_transaction(db, &tr_)) {
+		std::cerr << fdb_get_error(err) << std::endl;
+		std::abort();
+	}
+}
+
+Transaction::~Transaction() {
+	fdb_transaction_destroy(tr_);
+}
+
+void Transaction::reset() {
+	fdb_transaction_reset(tr_);
+}
+
+void Transaction::cancel() {
+	fdb_transaction_cancel(tr_);
+}
+
+[[nodiscard]] fdb_error_t Transaction::set_option(FDBTransactionOption option, const uint8_t* value, int value_length) {
+	return fdb_transaction_set_option(tr_, option, value, value_length);
+}
+
+void Transaction::set_read_version(int64_t version) {
+	fdb_transaction_set_read_version(tr_, version);
+}
+
+Int64Future Transaction::get_read_version() {
+	return Int64Future(fdb_transaction_get_read_version(tr_));
+}
+
+Int64Future Transaction::get_approximate_size() {
+	return Int64Future(fdb_transaction_get_approximate_size(tr_));
+}
+
+KeyFuture Transaction::get_versionstamp() {
+	return KeyFuture(fdb_transaction_get_versionstamp(tr_));
+}
+
+ValueFuture Transaction::get(std::string_view key, fdb_bool_t snapshot) {
+	return ValueFuture(fdb_transaction_get(tr_, (const uint8_t*)key.data(), key.size(), snapshot));
+}
+
+KeyFuture Transaction::get_key(const uint8_t* key_name,
+                               int key_name_length,
+                               fdb_bool_t or_equal,
+                               int offset,
+                               fdb_bool_t snapshot) {
+	return KeyFuture(fdb_transaction_get_key(tr_, key_name, key_name_length, or_equal, offset, snapshot));
+}
+
+StringArrayFuture Transaction::get_addresses_for_key(std::string_view key) {
+	return StringArrayFuture(fdb_transaction_get_addresses_for_key(tr_, (const uint8_t*)key.data(), key.size()));
+}
+
+KeyValueArrayFuture Transaction::get_range(const uint8_t* begin_key_name,
+                                           int begin_key_name_length,
+                                           fdb_bool_t begin_or_equal,
+                                           int begin_offset,
+                                           const uint8_t* end_key_name,
+                                           int end_key_name_length,
+                                           fdb_bool_t end_or_equal,
+                                           int end_offset,
+                                           int limit,
+                                           int target_bytes,
+                                           FDBStreamingMode mode,
+                                           int iteration,
+                                           fdb_bool_t snapshot,
+                                           fdb_bool_t reverse) {
+	return KeyValueArrayFuture(fdb_transaction_get_range(tr_,
+	                                                     begin_key_name,
+	                                                     begin_key_name_length,
+	                                                     begin_or_equal,
+	                                                     begin_offset,
+	                                                     end_key_name,
+	                                                     end_key_name_length,
+	                                                     end_or_equal,
+	                                                     end_offset,
+	                                                     limit,
+	                                                     target_bytes,
+	                                                     mode,
+	                                                     iteration,
+	                                                     snapshot,
+	                                                     reverse));
+}
+
+EmptyFuture Transaction::watch(std::string_view key) {
+	return EmptyFuture(fdb_transaction_watch(tr_, (const uint8_t*)key.data(), key.size()));
+}
+
+EmptyFuture Transaction::commit() {
+	return EmptyFuture(fdb_transaction_commit(tr_));
+}
+
+EmptyFuture Transaction::on_error(fdb_error_t err) {
+	return EmptyFuture(fdb_transaction_on_error(tr_, err));
+}
+
+void Transaction::clear(std::string_view key) {
+	return fdb_transaction_clear(tr_, (const uint8_t*)key.data(), key.size());
+}
+
+void Transaction::clear_range(std::string_view begin_key, std::string_view end_key) {
+	fdb_transaction_clear_range(
+	    tr_, (const uint8_t*)begin_key.data(), begin_key.size(), (const uint8_t*)end_key.data(), end_key.size());
+}
+
+void Transaction::set(std::string_view key, std::string_view value) {
+	fdb_transaction_set(tr_, (const uint8_t*)key.data(), key.size(), (const uint8_t*)value.data(), value.size());
+}
+
+void Transaction::atomic_op(std::string_view key,
+                            const uint8_t* param,
+                            int param_length,
+                            FDBMutationType operationType) {
+	return fdb_transaction_atomic_op(tr_, (const uint8_t*)key.data(), key.size(), param, param_length, operationType);
+}
+
+[[nodiscard]] fdb_error_t Transaction::get_committed_version(int64_t* out_version) {
+	return fdb_transaction_get_committed_version(tr_, out_version);
+}
+
+fdb_error_t Transaction::add_conflict_range(std::string_view begin_key,
+                                            std::string_view end_key,
+                                            FDBConflictRangeType type) {
+	return fdb_transaction_add_conflict_range(
+	    tr_, (const uint8_t*)begin_key.data(), begin_key.size(), (const uint8_t*)end_key.data(), end_key.size(), type);
+}
+
+} // namespace fdb

--- a/bindings/c/test/unit/fdb_api.hpp
+++ b/bindings/c/test/unit/fdb_api.hpp
@@ -1,0 +1,240 @@
+/*
+ * fdb_api.hpp
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2020 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// A collection of C++ classes to wrap the C API to improve memory management
+// and add types to futures. Using the old C API may look something like:
+//
+//   FDBTransaction *tr;
+//   fdb_database_create_transaction(db, &tr);
+//   FDBFuture *f = fdb_transaction_get(tr, (const uint8_t*)"foo", 3, true);
+//   fdb_future_block_until_ready(f);
+//   fdb_future_get_value(f, ...);
+//   fdb_future_destroy(f);
+//   fdb_transaction_destroy(tr);
+//
+// Using the wrapper classes defined here, it will instead look like:
+//
+//   fdb::Transaction tr(db);
+//   fdb::ValueFuture f = tr.get((const uint8_t*)"foo", 3, true);
+//   f.block_until_ready();
+//   f.get_value(f, ...);
+//
+
+#pragma once
+
+#define FDB_API_VERSION 630
+#include <foundationdb/fdb_c.h>
+
+#include <string>
+#include <string_view>
+
+namespace fdb {
+
+// Wrapper parent class to manage memory of an FDBFuture pointer. Cleans up
+// FDBFuture when this instance goes out of scope.
+class Future {
+public:
+	virtual ~Future() = 0;
+
+	// Wrapper around fdb_future_is_ready.
+	bool is_ready();
+	// Wrapper around fdb_future_block_until_ready.
+	fdb_error_t block_until_ready();
+	// Wrapper around fdb_future_set_callback.
+	fdb_error_t set_callback(FDBCallback callback, void* callback_parameter);
+	// Wrapper around fdb_future_get_error.
+	fdb_error_t get_error();
+	// Wrapper around fdb_future_release_memory.
+	void release_memory();
+	// Wrapper around fdb_future_cancel.
+	void cancel();
+
+	// Conversion operator to allow Future instances to work interchangeably as
+	// an FDBFuture object.
+	// operator FDBFuture* () const {
+	//   return future_;
+	// }
+
+protected:
+	Future(FDBFuture* f) : future_(f) {}
+	FDBFuture* future_;
+};
+
+class Int64Future : public Future {
+public:
+	// Call this function instead of fdb_future_get_int64 when using the
+	// Int64Future type. It's behavior is identical to fdb_future_get_int64.
+	fdb_error_t get(int64_t* out);
+
+private:
+	friend class Transaction;
+	friend class Database;
+	Int64Future(FDBFuture* f) : Future(f) {}
+};
+
+class KeyFuture : public Future {
+public:
+	// Call this function instead of fdb_future_get_key when using the KeyFuture
+	// type. It's behavior is identical to fdb_future_get_key.
+	fdb_error_t get(const uint8_t** out_key, int* out_key_length);
+
+private:
+	friend class Transaction;
+	KeyFuture(FDBFuture* f) : Future(f) {}
+};
+
+class ValueFuture : public Future {
+public:
+	// Call this function instead of fdb_future_get_value when using the
+	// ValueFuture type. It's behavior is identical to fdb_future_get_value.
+	fdb_error_t get(fdb_bool_t* out_present, const uint8_t** out_value, int* out_value_length);
+
+private:
+	friend class Transaction;
+	ValueFuture(FDBFuture* f) : Future(f) {}
+};
+
+class StringArrayFuture : public Future {
+public:
+	// Call this function instead of fdb_future_get_string_array when using the
+	// StringArrayFuture type. It's behavior is identical to
+	// fdb_future_get_string_array.
+	fdb_error_t get(const char*** out_strings, int* out_count);
+
+private:
+	friend class Transaction;
+	StringArrayFuture(FDBFuture* f) : Future(f) {}
+};
+
+class KeyValueArrayFuture : public Future {
+public:
+	// Call this function instead of fdb_future_get_keyvalue_array when using
+	// the KeyValueArrayFuture type. It's behavior is identical to
+	// fdb_future_get_keyvalue_array.
+	fdb_error_t get(const FDBKeyValue** out_kv, int* out_count, fdb_bool_t* out_more);
+
+private:
+	friend class Transaction;
+	KeyValueArrayFuture(FDBFuture* f) : Future(f) {}
+};
+
+class EmptyFuture : public Future {
+private:
+	friend class Transaction;
+	friend class Database;
+	EmptyFuture(FDBFuture* f) : Future(f) {}
+};
+
+// Wrapper around FDBTransaction, providing the same set of calls as the C API.
+// Handles cleanup of memory, removing the need to call
+// fdb_transaction_destroy.
+class Transaction final {
+public:
+	// Given an FDBDatabase, initializes a new transaction.
+	Transaction(FDBDatabase* db);
+	~Transaction();
+
+	// Wrapper around fdb_transaction_reset.
+	void reset();
+
+	// Wrapper around fdb_transaction_cancel.
+	void cancel();
+
+	// Wrapper around fdb_transaction_set_option.
+	fdb_error_t set_option(FDBTransactionOption option, const uint8_t* value, int value_length);
+
+	// Wrapper around fdb_transaction_set_read_version.
+	void set_read_version(int64_t version);
+
+	// Returns a future which will be set to the transaction read version.
+	Int64Future get_read_version();
+
+	// Returns a future which will be set to the approximate transaction size so far.
+	Int64Future get_approximate_size();
+
+	// Returns a future which will be set to the versionstamp which was used by
+	// any versionstamp operations in the transaction.
+	KeyFuture get_versionstamp();
+
+	// Returns a future which will be set to the value of `key` in the database.
+	ValueFuture get(std::string_view key, fdb_bool_t snapshot);
+
+	// Returns a future which will be set to the key in the database matching the
+	// passed key selector.
+	KeyFuture get_key(const uint8_t* key_name,
+	                  int key_name_length,
+	                  fdb_bool_t or_equal,
+	                  int offset,
+	                  fdb_bool_t snapshot);
+
+	// Returns a future which will be set to an array of strings.
+	StringArrayFuture get_addresses_for_key(std::string_view key);
+
+	// Returns a future which will be set to an FDBKeyValue array.
+	KeyValueArrayFuture get_range(const uint8_t* begin_key_name,
+	                              int begin_key_name_length,
+	                              fdb_bool_t begin_or_equal,
+	                              int begin_offset,
+	                              const uint8_t* end_key_name,
+	                              int end_key_name_length,
+	                              fdb_bool_t end_or_equal,
+	                              int end_offset,
+	                              int limit,
+	                              int target_bytes,
+	                              FDBStreamingMode mode,
+	                              int iteration,
+	                              fdb_bool_t snapshot,
+	                              fdb_bool_t reverse);
+
+	// Wrapper around fdb_transaction_watch. Returns a future representing an
+	// empty value.
+	EmptyFuture watch(std::string_view key);
+
+	// Wrapper around fdb_transaction_commit. Returns a future representing an
+	// empty value.
+	EmptyFuture commit();
+
+	// Wrapper around fdb_transaction_on_error. Returns a future representing an
+	// empty value.
+	EmptyFuture on_error(fdb_error_t err);
+
+	// Wrapper around fdb_transaction_clear.
+	void clear(std::string_view key);
+
+	// Wrapper around fdb_transaction_clear_range.
+	void clear_range(std::string_view begin_key, std::string_view end_key);
+
+	// Wrapper around fdb_transaction_set.
+	void set(std::string_view key, std::string_view value);
+
+	// Wrapper around fdb_transaction_atomic_op.
+	void atomic_op(std::string_view key, const uint8_t* param, int param_length, FDBMutationType operationType);
+
+	// Wrapper around fdb_transaction_get_committed_version.
+	fdb_error_t get_committed_version(int64_t* out_version);
+
+	// Wrapper around fdb_transaction_add_conflict_range.
+	fdb_error_t add_conflict_range(std::string_view begin_key, std::string_view end_key, FDBConflictRangeType type);
+
+private:
+	FDBTransaction* tr_;
+};
+
+} // namespace fdb

--- a/bindings/c/test/unit/third_party/CMakeLists.txt
+++ b/bindings/c/test/unit/third_party/CMakeLists.txt
@@ -1,0 +1,18 @@
+# Download doctest repo.
+include(ExternalProject)
+find_package(Git REQUIRED)
+
+ExternalProject_Add(
+    doctest
+    PREFIX ${CMAKE_BINARY_DIR}/doctest
+    GIT_REPOSITORY https://github.com/onqtam/doctest.git
+    GIT_TAG 1c8da00c978c19e00a434b2b1f854fcffc9fba35 # v2.4.0
+    TIMEOUT 10
+    CONFIGURE_COMMAND ""
+    BUILD_COMMAND ""
+    INSTALL_COMMAND ""
+    LOG_DOWNLOAD ON
+)
+
+ExternalProject_Get_Property(doctest source_dir)
+set(DOCTEST_INCLUDE_DIR ${source_dir}/doctest CACHE INTERNAL "Path to include folder for doctest")

--- a/cmake/AddFdbTest.cmake
+++ b/cmake/AddFdbTest.cmake
@@ -403,6 +403,40 @@ function(add_fdbclient_test)
   set_tests_properties("${T_NAME}" PROPERTIES TIMEOUT 60) 
 endfunction()
 
+# Creates a cluster file for a nonexistent cluster before running the specified command 
+# (usually a ctest test)
+function(add_unavailable_fdbclient_test)
+  set(options DISABLED ENABLED)
+  set(oneValueArgs NAME TEST_TIMEOUT)
+  set(multiValueArgs COMMAND)
+  cmake_parse_arguments(T "${options}" "${oneValueArgs}" "${multiValueArgs}" "${ARGN}")
+  if(OPEN_FOR_IDE)
+    return()
+  endif()
+  if(NOT T_ENABLED AND T_DISABLED)
+    return()
+  endif()
+  if(NOT T_NAME)
+    message(FATAL_ERROR "NAME is a required argument for add_unavailable_fdbclient_test")
+  endif()
+  if(NOT T_COMMAND)
+    message(FATAL_ERROR "COMMAND is a required argument for add_unavailable_fdbclient_test")
+  endif()
+  message(STATUS "Adding unavailable client test ${T_NAME}")
+  add_test(NAME "${T_NAME}"
+  COMMAND ${Python_EXECUTABLE} ${CMAKE_SOURCE_DIR}/tests/TestRunner/fake_cluster.py
+          --output-dir ${CMAKE_BINARY_DIR}
+          --
+          ${T_COMMAND})
+  if (T_TEST_TIMEOUT)
+    set_tests_properties("${T_NAME}" PROPERTIES TIMEOUT ${T_TEST_TIMEOUT})
+  else()
+    # default timeout
+    set_tests_properties("${T_NAME}" PROPERTIES TIMEOUT 60)
+  endif()
+  set_tests_properties("${T_NAME}" PROPERTIES ENVIRONMENT UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1)
+endfunction()
+
 # Creates 3 distinct clusters before running the specified command.
 # This is useful for testing features that require multiple clusters (like the
 # multi-cluster FDB client)

--- a/tests/TestRunner/fake_cluster.py
+++ b/tests/TestRunner/fake_cluster.py
@@ -7,6 +7,7 @@ import sys
 from local_cluster import LocalCluster
 from argparse import ArgumentParser, RawDescriptionHelpFormatter
 from pathlib import Path
+from random import choice
 
 class ClusterFileGenerator:
     def __init__(self, output_dir: str):
@@ -16,14 +17,14 @@ class ClusterFileGenerator:
         self.tmp_dir = self.output_dir.joinpath(
             'tmp',
             ''.join(choice(LocalCluster.valid_letters_for_secret) for i in range(16)))
-        tmp_dir.mkdir(parents=True)
+        self.tmp_dir.mkdir(parents=True)
         self.cluster_file_path = self.tmp_dir.joinpath('fdb.cluster')
 
     def __enter__(self):
-       with open(self.cluster_file_path, 'x') as f:
-           f.write('foo:bar@1.1.1.1:5678')
+        with open(self.cluster_file_path, 'x') as f:
+            f.write('foo:bar@1.1.1.1:5678\n')
 
-       return self
+        return self
 
     def __exit__(self, xc_type, exc_value, traceback):
         shutil.rmtree(self.tmp_dir)

--- a/tests/TestRunner/fake_cluster.py
+++ b/tests/TestRunner/fake_cluster.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+
+import os
+import shutil
+import subprocess
+import sys
+from local_cluster import LocalCluster
+from argparse import ArgumentParser, RawDescriptionHelpFormatter
+from pathlib import Path
+
+class ClusterFileGenerator:
+    def __init__(self, output_dir: str):
+        self.output_dir = Path(output_dir).resolve()
+        assert self.output_dir.exists(), "{} does not exist".format(output_dir)
+        assert self.output_dir.is_dir(), "{} is not a directory".format(output_dir)
+        self.tmp_dir = self.output_dir.joinpath(
+            'tmp',
+            ''.join(choice(LocalCluster.valid_letters_for_secret) for i in range(16)))
+        tmp_dir.mkdir(parents=True)
+        self.cluster_file_path = self.tmp_dir.joinpath('fdb.cluster')
+
+    def __enter__(self):
+       with open(self.cluster_file_path, 'x') as f:
+           f.write('foo:bar@1.1.1.1:5678')
+
+       return self
+
+    def __exit__(self, xc_type, exc_value, traceback):
+        shutil.rmtree(self.tmp_dir)
+
+    def close(self):
+        shutil.rmtree(self.tmp_dir)
+
+
+if __name__ == '__main__':
+    parser = ArgumentParser(formatter_class=RawDescriptionHelpFormatter,
+                            description="""
+    This script generates a cluster file that can be used to run a test and that will
+    be cleaned up when the test is over. The cluster file will not correspond to a real
+    cluster.
+
+    Before the command is executed, the following arguments will be preprocessed:
+    - All occurrences of @CLUSTER_FILE@ will be replaced with the path to the generated cluster file.
+
+    The environment variable FDB_CLUSTER_FILE is set to the generated cluster file for the command if 
+    it is not set already.
+    """)
+    parser.add_argument('--output-dir', '-o', metavar='OUTPUT_DIRECTORY', help='Directory where output files are written', required=True)
+    parser.add_argument('cmd', metavar="COMMAND", nargs="+", help="The command to run")
+    args = parser.parse_args()
+    errcode = 1
+
+    with ClusterFileGenerator(args.output_dir) as generator:
+        print("cluster-file: {}".format(generator.cluster_file_path))
+        cmd_args = []
+        for cmd in args.cmd:
+            if cmd == '@CLUSTER_FILE@':
+                cmd_args.append(str(generator.cluster_file_path))
+            else:
+                cmd_args.append(cmd)
+
+        env = dict(**os.environ)
+        env['FDB_CLUSTER_FILE'] = env.get('FDB_CLUSTER_FILE', generator.cluster_file_path)
+        errcode = subprocess.run(cmd_args, stdout=sys.stdout, stderr=sys.stderr, env=env).returncode
+
+    sys.exit(errcode)


### PR DESCRIPTION
This is a backport of #5690 and #5692. It also includes some other changes from master to support running the unit tests and the fix in #5697.

The timeoutTsav variable was accessed unsafely when setting a timeout or returning a future on a transaction that is not connected to a database.

Most of the changes here are for testing, only `fdbclient/MultiVersionTransaction.actor.cpp` has changes that should affect the behavior of the client.

This has passed the new unit tests introduced in this change.

This has also passed the following, which likely don't exercise these changes:
- 10K correctness
- 10K bindingtester

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
