### PR TITLE
Restore missing variable initialization in proxy (release-6.3)

### DIFF
--- a/fdbserver/MasterProxyServer.actor.cpp
+++ b/fdbserver/MasterProxyServer.actor.cpp
@@ -241,6 +241,7 @@ struct ProxyStats {
 	                           SERVER_KNOBS->LATENCY_SAMPLE_SIZE),
 	    systemGRVQueueSize(0), defaultGRVQueueSize(0), batchGRVQueueSize(0), transactionRateAllowed(0),
 	    batchTransactionRateAllowed(0), transactionLimit(0), batchTransactionLimit(0),
+	    percentageOfDefaultGRVQueueProcessed(0), percentageOfBatchGRVQueueProcessed(0),
 	    grvConfirmEpochLiveDist(Histogram::getHistogram(LiteralStringRef("MasterProxy"),
 	                                                    LiteralStringRef("GrvConfirmEpochLive"),
 	                                                    Histogram::Unit::microseconds)),


### PR DESCRIPTION
A [recent PR](https://github.com/apple/foundationdb/pull/5689/files) accidentally removed the initialization of a couple variables. This adds back this initialization.

These variables look to still be correctly initialized on release-7.0 and master:

release-7.0: https://github.com/apple/foundationdb/blob/72bedfeb530c0ed92e5e777bafc6c698f7a308ee/fdbserver/GrvProxyServer.actor.cpp#L98
master: https://github.com/apple/foundationdb/blob/f27c6ef57cb65d63031e07ae69e0e7005b8079a6/fdbserver/GrvProxyServer.actor.cpp#L99

This was detected with valgrind correctness. The failing test worked correctly with this change. Also passed 1000 valgrind correctness.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
