### PR TITLE
Increase watch trigger time limit in FastTriggeredWatches (release-6.3)

### DIFF
--- a/fdbserver/workloads/FastTriggeredWatches.actor.cpp
+++ b/fdbserver/workloads/FastTriggeredWatches.actor.cpp
@@ -27,6 +27,7 @@
 #include "flow/actorcompiler.h" // This must be the last #include.
 
 struct FastTriggeredWatchesWorkload : TestWorkload {
+	// Tests the time it takes for a watch to be fired after the value has changed in the storage server
 	int nodes, keyBytes;
 	double testDuration;
 	vector<Future<Void>> clients;
@@ -75,6 +76,7 @@ struct FastTriggeredWatchesWorkload : TestWorkload {
 
 	ACTOR Future<Version> setter(Database cx, Key key, Optional<Value> value) {
 		state ReadYourWritesTransaction tr(cx);
+		// set the value of key and return the commit version
 		wait(delay(deterministicRandom()->random01()));
 		loop {
 			try {
@@ -105,22 +107,26 @@ struct FastTriggeredWatchesWorkload : TestWorkload {
 				state Optional<Value> setValue;
 				if (deterministicRandom()->random01() > 0.5)
 					setValue = StringRef(format("%010d", deterministicRandom()->randomInt(0, 1000)));
+				// Set the value at setKey to something random
 				state Future<Version> setFuture = self->setter(cx, setKey, setValue);
 				wait(delay(deterministicRandom()->random01()));
 				loop {
 					state ReadYourWritesTransaction tr(cx);
 
 					try {
-
+						
+						// read the value at setKey
 						Optional<Value> val = wait(tr.get(setKey));
 						if (!first) {
 							getDuration = now() - watchEnd;
 						}
 						lastReadVersion = tr.getReadVersion().get();
 						//TraceEvent("FTWGet").detail("Key", printable(setKey)).detail("Value", printable(val)).detail("Ver", tr.getReadVersion().get());
+						// if the value is already setValue then there is no point setting a watch so break out of the loop
 						if (val == setValue)
 							break;
 						ASSERT(first);
+						// set a watch and wait for it to be triggered (i.e for self->setter to set the value)
 						state Future<Void> watchFuture = tr.watch(setKey);
 						wait(tr.commit());
 						//TraceEvent("FTWStartWatch").detail("Key", printable(setKey));
@@ -134,8 +140,10 @@ struct FastTriggeredWatchesWorkload : TestWorkload {
 				}
 				Version ver = wait(setFuture);
 				//TraceEvent("FTWWatchDone").detail("Key", printable(setKey));
+				// Assert that the time from setting the key to triggering the watch is no greater than 25s
+				// TODO: This assertion can cause flaky behaviour since sometimes a watch can take longer to fire
 				ASSERT(lastReadVersion - ver >= SERVER_KNOBS->MAX_VERSIONS_IN_FLIGHT ||
-				       lastReadVersion - ver < SERVER_KNOBS->VERSIONS_PER_SECOND * (12 + getDuration));
+				       lastReadVersion - ver < SERVER_KNOBS->VERSIONS_PER_SECOND * (25 + getDuration));
 
 				if (now() - testStart > self->testDuration)
 					break;

--- a/fdbserver/workloads/FastTriggeredWatches.actor.cpp
+++ b/fdbserver/workloads/FastTriggeredWatches.actor.cpp
@@ -114,7 +114,6 @@ struct FastTriggeredWatchesWorkload : TestWorkload {
 					state ReadYourWritesTransaction tr(cx);
 
 					try {
-						// read the value at setKey
 						Optional<Value> val = wait(tr.get(setKey));
 						if (!first) {
 							getDuration = now() - watchEnd;

--- a/fdbserver/workloads/FastTriggeredWatches.actor.cpp
+++ b/fdbserver/workloads/FastTriggeredWatches.actor.cpp
@@ -114,7 +114,6 @@ struct FastTriggeredWatchesWorkload : TestWorkload {
 					state ReadYourWritesTransaction tr(cx);
 
 					try {
-						
 						// read the value at setKey
 						Optional<Value> val = wait(tr.get(setKey));
 						if (!first) {


### PR DESCRIPTION
This is a backport of #4539.

Currently the FastTriggeredWatches test in simulation fails because a watch takes longer to fire than the expected limit (12s). This PR increases the limit to 25s in hopes of reducing the flakiness of the test.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
