### PR TITLE
Fix some common sampling crashes at high sampling frequencies

### DIFF
--- a/fdbclient/ActorLineageProfiler.cpp
+++ b/fdbclient/ActorLineageProfiler.cpp
@@ -242,6 +242,9 @@ void sample(LineageReference* lineagePtr) {
 	if (!lineagePtr->isValid()) {
 		return;
 	}
+	if (!lineagePtr->isAllocated()) {
+		lineagePtr->allocate();
+	}
 	(*lineagePtr)->modify(&NameLineage::actorName) = lineagePtr->actorName();
 	boost::asio::post(ActorLineageProfiler::instance().context(),
 	                  [lineage = LineageReference::addRef(lineagePtr->getPtr())]() {

--- a/fdbclient/FluentDSampleIngestor.cpp
+++ b/fdbclient/FluentDSampleIngestor.cpp
@@ -73,13 +73,14 @@ class SampleSender : public std::enable_shared_from_this<SampleSender<Protocol, 
 	}
 
 	void send(boost::asio::ip::tcp::socket& socket, std::shared_ptr<Buf> const& buf) {
-		boost::asio::async_write(socket,
-		                         boost::asio::const_buffer(buf->data, buf->size),
-		                         [buf, this](auto const& ec, size_t) { this->sendCompletionHandler(ec); });
+		boost::system::error_code ec;
+		socket.send(boost::asio::const_buffer(buf->data, buf->size), 0, ec);
+		this->sendCompletionHandler(ec);
 	}
 	void send(boost::asio::ip::udp::socket& socket, std::shared_ptr<Buf> const& buf) {
-		socket.async_send(boost::asio::const_buffer(buf->data, buf->size),
-		                  [buf, this](auto const& ec, size_t) { this->sendCompletionHandler(ec); });
+		boost::system::error_code ec;
+		socket.send(boost::asio::const_buffer(buf->data, buf->size), 0, ec);
+		this->sendCompletionHandler(ec);
 	}
 
 	void sendNext() {

--- a/flow/flow.cpp
+++ b/flow/flow.cpp
@@ -51,9 +51,7 @@ LineageReference getCurrentLineage() {
 	}
 	return *currentLineage;
 }
-#endif
 
-#ifdef ENABLE_SAMPLING
 void sample(LineageReference* lineagePtr);
 
 void replaceLineage(LineageReference* lineage) {

--- a/flow/flow.h
+++ b/flow/flow.h
@@ -545,6 +545,11 @@ public:
 	LineageReference() : Reference<ActorLineage>(nullptr), actorName_(""), allocated_(false) {}
 	explicit LineageReference(ActorLineage* ptr) : Reference<ActorLineage>(ptr), actorName_(""), allocated_(false) {}
 	LineageReference(const LineageReference& r) : Reference<ActorLineage>(r), actorName_(""), allocated_(false) {}
+	LineageReference(LineageReference&& r)
+	  : Reference<ActorLineage>(std::forward<LineageReference>(r)), actorName_(r.actorName_), allocated_(r.allocated_) {
+		r.actorName_ = "";
+		r.allocated_ = false;
+	}
 
 	void setActorName(const char* name) { actorName_ = name; }
 	const char* actorName() { return actorName_; }


### PR DESCRIPTION
Sampling at a high frequency (1000Hz+) was causing pretty frequent crashes. This attempts to fix those issues.

1. The first "fix" is related to the ALP not being allocated when a sample is taken. The issue I was seeing here is that the reference count of a sample when `sample` was called was 0 -- but it should never be 0 here, since the actor should be running when `sample` is called. I think the issue was related to the current `LineageReference` not being allocated and so only containing a pointer to a parent ALP instead of its own (although the parent ALP shouldn't have a ref count of zero either... this is a fix but I think there are more issues here).
2. The second fix is related to how samples are sent out as UDP packets. The constructor of `SampleSender` initiates sending a sample, but if multiple wait states exist for the sample (say the sample has data for the currently running actor and an actor waiting on disk), after sending the first bit of data, there was an asynchronous send to send the rest of the data. This was causing the constructor to return, and nothing was storing the newly created `SampleSender` object, causing it to go out of scope by the time the asynchronous send completed and tried to send the next bit of data.

Passed 10k correctness (everything here is disabled behind a compile time flag).

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
