### PR TITLE
Add option --api-version for fdbcli

### DIFF
--- a/bindings/python/tests/fdbcli_tests.py
+++ b/bindings/python/tests/fdbcli_tests.py
@@ -385,7 +385,7 @@ def coordinators(logger):
     # verify now we have 5 coordinators and the description is updated
     output2 = run_fdbcli_command('coordinators')
     assert output2.split('\n')[0].split(': ')[-1] == new_cluster_description
-    assert output2.split('\n')[1] == 'Cluster coordinators ({}): {}'.format(5, ','.join(addresses))
+    assert output2.split('\n')[1] == 'Cluster coordinators ({}): {}'.format(args.process_number, ','.join(addresses))
     # auto change should go back to 1 coordinator
     run_fdbcli_command('coordinators', 'auto')
     assert len(get_value_from_status_json(True, 'client', 'coordinators', 'coordinators')) == 1

--- a/fdbcli/fdbcli.actor.cpp
+++ b/fdbcli/fdbcli.actor.cpp
@@ -90,7 +90,8 @@ enum {
 	OPT_BUILD_FLAGS,
 	OPT_TRACE_FORMAT,
 	OPT_KNOB,
-	OPT_DEBUG_TLS
+	OPT_DEBUG_TLS,
+	OPT_API_VERSION,
 };
 
 CSimpleOpt::SOption g_rgOptions[] = { { OPT_CONNFILE, "-C", SO_REQ_SEP },
@@ -112,6 +113,7 @@ CSimpleOpt::SOption g_rgOptions[] = { { OPT_CONNFILE, "-C", SO_REQ_SEP },
 	                                  { OPT_TRACE_FORMAT, "--trace_format", SO_REQ_SEP },
 	                                  { OPT_KNOB, "--knob_", SO_REQ_SEP },
 	                                  { OPT_DEBUG_TLS, "--debug-tls", SO_NONE },
+	                                  { OPT_API_VERSION, "--api-version", SO_REQ_SEP },
 
 #ifndef TLS_DISABLED
 	                                  TLS_OPTION_FLAGS
@@ -428,6 +430,8 @@ static void printProgramUsage(const char* name) {
 	       "                 and then exits.\n"
 	       "  --no-status    Disables the initial status check done when starting\n"
 	       "                 the CLI.\n"
+	       "  --api-version  APIVERSION\n"
+	       "                 Specifies the version of the API for the CLI to use.\n"
 #ifndef TLS_DISABLED
 	       TLS_HELP
 #endif
@@ -1371,6 +1375,9 @@ struct CLIOptions {
 
 	std::vector<std::pair<std::string, std::string>> knobs;
 
+	// api version, using the latest version by default
+	int api_version = FDB_API_VERSION;
+
 	CLIOptions(int argc, char* argv[]) {
 		program_name = argv[0];
 		for (int a = 0; a < argc; a++) {
@@ -1433,6 +1440,22 @@ struct CLIOptions {
 		case OPT_CONNFILE:
 			clusterFile = args.OptionArg();
 			break;
+		case OPT_API_VERSION: {
+			char* endptr;
+			api_version = strtoul((char*)args.OptionArg(), &endptr, 10);
+			if (*endptr != '\0') {
+				fprintf(stderr, "ERROR: invalid client version %s\n", args.OptionArg());
+				return 1;
+			} else if (api_version < 700 || api_version > FDB_API_VERSION) {
+				// multi-version fdbcli only available after 7.0
+				fprintf(stderr,
+				        "ERROR: api version %s is not supported. (Min: 700, Max: %d)\n",
+				        args.OptionArg(),
+				        FDB_API_VERSION);
+				return 1;
+			}
+			break;
+		}
 		case OPT_TRACE:
 			trace = true;
 			break;
@@ -1559,7 +1582,7 @@ ACTOR Future<int> cli(CLIOptions opt, LineNoise* plinenoise) {
 	TraceEvent::setNetworkThread();
 
 	try {
-		localDb = Database::createDatabase(ccf, -1, IsInternal::False);
+		localDb = Database::createDatabase(ccf, opt.api_version, IsInternal::False);
 		if (!opt.exec.present()) {
 			printf("Using cluster file `%s'.\n", ccf->getFilename().c_str());
 		}
@@ -2492,8 +2515,7 @@ int main(int argc, char** argv) {
 	}
 
 	try {
-		// Note: refactoring fdbcli, in progress
-		API->selectApiVersion(FDB_API_VERSION);
+		API->selectApiVersion(opt.api_version);
 		API->setupNetwork();
 		Future<int> cliFuture = runCli(opt);
 		Future<Void> timeoutFuture = opt.exit_timeout ? timeExit(opt.exit_timeout) : Never();


### PR DESCRIPTION
As now we have multi-version fdbcli
we add the option `--api-version` to specify the API version to use.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
