### PR TITLE
Fix assignment error in addressInDbAndRemoteDc unittest

### DIFF
--- a/fdbserver/worker.actor.cpp
+++ b/fdbserver/worker.actor.cpp
@@ -792,7 +792,7 @@ TEST_CASE("/fdbserver/worker/addressInDbAndRemoteDc") {
 
 	// Create a satellite tlog, and it shouldn't be considered as in remote DC.
 	testDbInfo.logSystemConfig.tLogs.push_back(TLogSet());
-	testDbInfo.logSystemConfig.tLogs.back().locality == tagLocalitySatellite;
+	testDbInfo.logSystemConfig.tLogs.back().locality = tagLocalitySatellite;
 	NetworkAddress satelliteTLogAddress(IPAddress(0x13131313), 1);
 	TLogInterface satelliteTLog(fakeRemote);
 	satelliteTLog.initEndpoints();


### PR DESCRIPTION
Fix assignment error in addressInDbAndRemoteDc unittest.

Test still passes... Also indicates a poorly written test. Will address it separately.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
