### PR TITLE
Some improvements for grey failure failover

### DIFF
--- a/fdbserver/ClusterController.actor.cpp
+++ b/fdbserver/ClusterController.actor.cpp
@@ -2994,8 +2994,15 @@ public:
 		if (machineStartTime() == 0) {
 			return true;
 		}
+
 		if (now() - machineStartTime() < SERVER_KNOBS->INITIAL_UPDATE_CROSS_DC_INFO_DELAY) {
 			return true;
+		}
+
+		// When remote DC health is not monitored, we may not know whether the remote is healthy or not. So return false
+		// here to prevent failover.
+		if (!remoteDCMonitorStarted) {
+			return false;
 		}
 
 		return !remoteTransactionSystemContainsDegradedServers();
@@ -3108,6 +3115,7 @@ public:
 	AsyncVar<bool> recruitDistributor;
 	Optional<UID> recruitingDistributorID;
 
+	bool remoteDCMonitorStarted;
 	bool remoteTransactionSystemDegraded;
 	AsyncVar<bool> recruitRatekeeper;
 	Optional<UID> recruitingRatekeeperID;
@@ -3148,8 +3156,8 @@ public:
 	    clusterControllerDcId(locality.dcId()), id(ccInterface.id()), ac(false), outstandingRequestChecker(Void()),
 	    outstandingRemoteRequestChecker(Void()), startTime(now()), goodRecruitmentTime(Never()),
 	    goodRemoteRecruitmentTime(Never()), datacenterVersionDifference(0), versionDifferenceUpdated(false),
-	    remoteTransactionSystemDegraded(false), recruitDistributor(false), recruitRatekeeper(false),
-	    clusterControllerMetrics("ClusterController", id.toString()),
+	    remoteDCMonitorStarted(false), remoteTransactionSystemDegraded(false), recruitDistributor(false),
+	    recruitRatekeeper(false), clusterControllerMetrics("ClusterController", id.toString()),
 	    openDatabaseRequests("OpenDatabaseRequests", clusterControllerMetrics),
 	    registerWorkerRequests("RegisterWorkerRequests", clusterControllerMetrics),
 	    getWorkersRequests("GetWorkersRequests", clusterControllerMetrics),
@@ -4718,6 +4726,15 @@ ACTOR Future<Void> updateRemoteDCHealth(ClusterControllerData* self) {
 	// The purpose of the initial delay is to wait for the cluster to achieve a steady state before checking remote DC
 	// health, since remote DC healthy may trigger a failover, and we don't want that to happen too frequently.
 	wait(delay(SERVER_KNOBS->INITIAL_UPDATE_CROSS_DC_INFO_DELAY));
+
+	self->remoteDCMonitorStarted = true;
+
+	// When the remote DC health just start, we may just recover from a health degradation. Check if we can failback if
+	// we are currently in the remote DC in the database configuration.
+	if (!self->remoteTransactionSystemDegraded) {
+		checkOutstandingRequests(self);
+	}
+
 	loop {
 		bool oldRemoteTransactionSystemDegraded = self->remoteTransactionSystemDegraded;
 		self->remoteTransactionSystemDegraded = self->remoteTransactionSystemContainsDegradedServers();
@@ -5038,7 +5055,9 @@ ACTOR Future<Void> workerHealthMonitor(ClusterControllerData* self) {
 						TraceEvent("DegradedServerDetectedAndSuggestRecovery").log();
 					}
 				} else if (self->shouldTriggerFailoverDueToDegradedServers()) {
-					if (SERVER_KNOBS->CC_HEALTH_TRIGGER_FAILOVER) {
+					double ccUpTime = now() - machineStartTime();
+					if (SERVER_KNOBS->CC_HEALTH_TRIGGER_FAILOVER &&
+					    ccUpTime > SERVER_KNOBS->INITIAL_UPDATE_CROSS_DC_INFO_DELAY) {
 						TraceEvent("DegradedServerDetectedAndTriggerFailover").log();
 						std::vector<Optional<Key>> dcPriority;
 						auto remoteDcId = self->db.config.regions[0].dcId == self->clusterControllerDcId.get()
@@ -5051,7 +5070,7 @@ ACTOR Future<Void> workerHealthMonitor(ClusterControllerData* self) {
 						dcPriority.push_back(self->clusterControllerDcId);
 						self->desiredDcIds.set(dcPriority);
 					} else {
-						TraceEvent("DegradedServerDetectedAndSuggestFailover").log();
+						TraceEvent("DegradedServerDetectedAndSuggestFailover").detail("CCUpTime", ccUpTime);
 					}
 				}
 			}


### PR DESCRIPTION
Health triggered failover and failback are enabled after waiting for INITIAL_UPDATE_CROSS_DC_INFO_DELAY, to give sometime for health information to propagate to the new cluster controller.

100k joshua tests: 20211008-005225-zhewu_improvements-1ef3112f8f5b7406 compressed=True data_size=25786901 duration=3618475 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=0:38:09 sanity=False started=100421 stopped=20211008-013034 submitted=20211008-005225 timeout=5400 username=zhewu_improvements

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
