### PR TITLE
Fix remote health variables declaration order

### DIFF
--- a/fdbserver/ClusterController.actor.cpp
+++ b/fdbserver/ClusterController.actor.cpp
@@ -3109,14 +3109,15 @@ public:
 	PromiseStream<Future<Void>> addActor;
 	bool versionDifferenceUpdated;
 
+	bool remoteDCMonitorStarted;
+	bool remoteTransactionSystemDegraded;
+
 	// recruitX is used to signal when role X needs to be (re)recruited.
 	// recruitingXID is used to track the ID of X's interface which is being recruited.
 	// We use AsyncVars to kill (i.e. halt) singletons that have been replaced.
 	AsyncVar<bool> recruitDistributor;
 	Optional<UID> recruitingDistributorID;
 
-	bool remoteDCMonitorStarted;
-	bool remoteTransactionSystemDegraded;
 	AsyncVar<bool> recruitRatekeeper;
 	Optional<UID> recruitingRatekeeperID;
 


### PR DESCRIPTION
Didn't know that this was even allowed in some compiler...

20211008-041739-zhewu_5733-4b796c5405235a0d        compressed=True data_size=20742854 duration=3969876 ended=100000 fail=1 fail_fast=10 max_runs=100000 pass=99999 priority=100 remaining=0 runtime=0:24:37 sanity=False started=100269 stopped=20211008-044216 submitted=20211008-041739 timeout=5400 username=zhewu_5733

The only test failure (`fdbserver -r simulation -f src/foundationdb/tests/restarting/from_6.3.13/SnapTestAttrition-1.txt -b on -s 806166330`) was due to a missing tmp file, which was not reproducable.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
