### PR TITLE
Bug fix: CommitQuorum::addRequestActor() accesses self after destruction

### DIFF
--- a/fdbclient/PaxosConfigTransaction.actor.cpp
+++ b/fdbclient/PaxosConfigTransaction.actor.cpp
@@ -58,6 +58,11 @@ class CommitQuorum {
 			wait(retryBrokenPromise(cti.commit, self->getCommitRequest(generation)));
 			++self->successful;
 		} catch (Error& e) {
+			// self might be destroyed if this actor is canceled
+			if (e.code() == error_code_actor_cancelled) {
+				throw;
+			}
+
 			if (e.code() == error_code_not_committed) {
 				++self->failed;
 			} else {


### PR DESCRIPTION
Catch block was ignoring actor_cancelled error.

Original repro:
```
13e6ac7c53f725d4dcf07956ac51f3b907c17181
valgrind bin/fdbserver -r simulation -f tests/rare/ConfigIncrement.toml -s 165618570 -b on  --crash --trace_format json
```

Passed 100k correctness.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
