### PR TITLE
Added new endpoints in Cluster Controller interface.

### DIFF
--- a/fdbclient/ClusterInterface.h
+++ b/fdbclient/ClusterInterface.h
@@ -314,7 +314,7 @@ struct MoveShardRequest {
 
 	MoveShardRequest() {}
 	MoveShardRequest(KeyRange shard, std::vector<NetworkAddress> addresses)
-	  : shard{std::move(shard)}, addresses{std::move(addresses)} {}
+	  : shard{ std::move(shard) }, addresses{ std::move(addresses) } {}
 
 	template <class Ar>
 	void serialize(Ar& ar) {


### PR DESCRIPTION
moveShard is for manual data move;
repairSystemData is for repairing system metadata when some or all of
storage servers hosting system metadata are lost.

This PR doesn't have any behavior changes, only the interfaces, to make sure it can be included in 7.1 for compatibility.

The complete implementation can be fund in #5718.

Put description here...

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
