### PR TITLE
Update Snowflake Jenkins Node Terminology

### DIFF
--- a/tests/SnowflakeJenkins
+++ b/tests/SnowflakeJenkins
@@ -1,6 +1,6 @@
 def buildScmInfo
 stage("Build") {
-    node('test-dynamic-slave') {
+    node('regular-memory-node') {
         cleanWs()
 
         sfScmInfo = checkout([$class: 'GitSCM',
@@ -38,7 +38,7 @@ stage("Build") {
 
 def makeTestStep(iteration) {
     return {
-        node("test-dynamic-slave") {
+        node("regular-memory-node") {
             cleanWs()
             sfScmInfo = checkout([$class: 'GitSCM',
                 branches: [[name: '*']],
@@ -106,7 +106,7 @@ stage("Test") {
         propagate: false
 }
 stage("Report") {
-    node('test-dynamic-slave') {
+    node('regular-memory-node') {
         cleanWs()
 
         sfScmInfo = checkout([$class: 'GitSCM',


### PR DESCRIPTION
This PR updates the Snowflake Jenkinsfile to use the new jenkins node names.

This change needs to go into the release branch because that is where these jenkins files live (there is not a copy in master).

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [X] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
