### PR TITLE
wake waiters when data made durable

### DIFF
--- a/fdbserver/TLogServer.actor.cpp
+++ b/fdbserver/TLogServer.actor.cpp
@@ -1072,6 +1072,11 @@ ACTOR Future<Void> updatePersistentData(TLogData* self, Reference<LogData> logDa
 	for (tagLocality = 0; tagLocality < logData->tag_data.size(); tagLocality++) {
 		for (tagId = 0; tagId < logData->tag_data[tagLocality].size(); tagId++) {
 			if (logData->tag_data[tagLocality][tagId]) {
+				// Currently, when version vector is enabled, peeks wait if there is no data in memory.
+				// In tlog commit, peeks are woken. If there is a restart, there may be data from the previous
+				// run that must be written to the ss. It has already been committed but not reached here.
+				// The conditional below checks such cases. There is a follow up radar to fine-tune this logic.
+				// rdar://84308526 (Version vector / validate logic controlling when to block peeks)
 				if (SERVER_KNOBS->ENABLE_VERSION_VECTOR) {
 					Tag tag(tagLocality, tagId);
 					auto iter = logData->waitingTags.find(tag);


### PR DESCRIPTION
In the tLog, when VERSION_VECTOR is set, peeks will wait when the requested version is greater than the tLog's durable version, i.e. data has not yet been committed at the version so requested.

The conditional is

`if (SERVER_KNOBS->ENABLE_VERSION_VECTOR && reqBegin > logData->persistentDataDurableVersion && !reqOnlySpilled &&   reqTag.locality >= 0 && !reqReturnIfBlocked) {`

But the durable version counter is not increased on tLog commit. It is increased in a separate co-routine, the `updateStorageLoop`. 

- there is a possibility we will "wake" the peek call at commit time, before the DV counter has been increased. Maybe there is a performance impact. 
- The attrition test causes cluster restarts.  When the system comes back up, any data that has been committed but not reached `updateStorageLoop` has not yet bumped the DV. It still needs to be written and only then the DV is bumped. But tLog commit is not called. This causes each tag to wait for the full timeout, eventually resulting in test failure.

Addresses failure
`./build_output/bin/fdbserver -r simulation --logsize=4096MiB -f ./src/foundationdb/tests/fast/SystemRebootTestCycle.toml -b on -s 84318479;`

A follow on radar can consider if VERSION_VECTOR should no longer wake peek calls in tLogCommit. 
rdar://84308526 (Version vector / validate logic controlling when to block peeks)