### PR TITLE
Version vector prototype: Propagate written tags from proxy to sequencer

### DIFF
--- a/fdbserver/CommitProxyServer.actor.cpp
+++ b/fdbserver/CommitProxyServer.actor.cpp
@@ -1481,7 +1481,7 @@ ACTOR Future<Void> reply(CommitBatchContext* self) {
 
 	if (self->commitVersion >= pProxyCommitData->committedVersion.get()) {
 		state Optional<std::set<Tag>> writtenTags;
-		if (SERVER_KNOBS->ENABLE_VERSION_VECTOR_TLOG_UNICAST) {
+		if (SERVER_KNOBS->ENABLE_VERSION_VECTOR) {
 			writtenTags = self->writtenTags;
 		}
 		wait(pProxyCommitData->master.reportLiveCommittedVersion.getReply(


### PR DESCRIPTION
Propagate written tags from proxy to sequencer when ENABLE_VERSION_VECTOR
is enabled, not when ENABLE_VERSION_VECTOR_TLOG_UNICAST is enabled.

Testing:

The following tests fail without this change, and succeed after this change:

build_output/bin/fdbserver -r simulation --crash -f /root/src/foundationdb/tests/fast/AtomicOps.toml -b on -s 913548526

build_output/bin/fdbserver -r simulation --crash -f /root/src/foundationdb/tests/fast/FuzzApiCorrectness.toml -b on -s 459270791

build_output/bin/fdbserver -r simulation --crash -f /root/src/foundationdb/tests/fast/MutationLogReaderCorrectness.toml  -b on -s 256948054

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
