### PR TITLE
Make AsyncFileNonDurable to also listen to shutdown signal

### DIFF
--- a/fdbrpc/AsyncFileNonDurable.actor.h
+++ b/fdbrpc/AsyncFileNonDurable.actor.h
@@ -829,6 +829,7 @@ private:
 		state ISimulator::ProcessInfo* currentProcess = g_simulator.getCurrentProcess();
 		state TaskPriority currentTaskID = g_network->getCurrentTask();
 		state std::string filename = self->filename;
+		state Future<Void> shutdown = success(currentProcess->shutdownSignal.getFuture());
 
 		wait(g_simulator.onMachine(currentProcess));
 		try {
@@ -846,7 +847,7 @@ private:
 					outstandingModifications.push_back(itr->value());
 
 			// Ignore errors here so that all modifications can finish
-			wait(waitForAllReady(outstandingModifications));
+			wait(waitForAllReady(outstandingModifications) || shutdown);
 
 			// Make sure we aren't in the process of killing the file
 			if (self->killed.isSet())


### PR DESCRIPTION
This is to fix a simulation hang. It appears that when shutting down a machine, the underlying file will be removed only after any pending `write` or `truncate` has finished. In this simulation, the deleting file never succeed due to pending writes haven't finished (but has gone due to machine shutdown). Therefore, any future file open is blocked by the file [deletion](https://github.com/apple/foundationdb/blob/9730f670e1ec18a153c9ca2eb940e81f678ca1b8/fdbrpc/AsyncFileNonDurable.actor.h#L236).

When a machine is shut down, it sends a shutdown signal. So in deleteFile, we also listen to shutdown signal to delete files.

The issue can be reproduced by:

commit: 87f46ccb00d1cfd432808d57ba386f216834e148
./build_output/bin/fdbserver -r simulation -f src/foundationdb/tests/slow/SwizzledRollbackTimeLapseIncrement.txt -s 962010032 -b on

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
