### PR TITLE
Use --enable-prof switch when building jemalloc.

### DIFF
--- a/cmake/Jemalloc.cmake
+++ b/cmake/Jemalloc.cmake
@@ -35,7 +35,7 @@ else()
     BUILD_BYPRODUCTS "${JEMALLOC_DIR}/include/jemalloc/jemalloc.h"
     "${JEMALLOC_DIR}/lib/libjemalloc.a"
     "${JEMALLOC_DIR}/lib/libjemalloc_pic.a"
-    CONFIGURE_COMMAND ./configure --prefix=${JEMALLOC_DIR} --enable-static --disable-cxx
+    CONFIGURE_COMMAND ./configure --prefix=${JEMALLOC_DIR} --enable-static --disable-cxx --enable-prof
     BUILD_IN_SOURCE ON
     BUILD_COMMAND make
     INSTALL_DIR "${JEMALLOC_DIR}"


### PR DESCRIPTION
I got errors like `<jemalloc>: Invalid conf pair: prof:true` when trying to use jemalloc. Referring to https://stackoverflow.com/questions/27422508/heap-dump-fails-with-jemalloc-mcllctl, seems that we are missing out this flag. https://github.com/jeffgriffith/native-jvm-leaks#building.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
