### PR TITLE
Fix backup mutation tags not counted in version vector

### DIFF
--- a/fdbserver/CommitProxyServer.actor.cpp
+++ b/fdbserver/CommitProxyServer.actor.cpp
@@ -1120,8 +1120,7 @@ ACTOR Future<Void> assignMutationsToStorageServers(CommitBatchContext* self) {
 
 					DEBUG_MUTATION("ProxyCommit", self->commitVersion, m)
 					    .detail("Dbgid", pProxyCommitData->dbgid)
-					    .detail("To", allSources)
-					    .detail("Mutation", m);
+					    .detail("To", allSources);
 					self->toCommit.addTags(allSources);
 				}
 
@@ -1221,8 +1220,6 @@ ACTOR Future<Void> postResolution(CommitBatchContext* self) {
 	// Second pass
 	wait(assignMutationsToStorageServers(self));
 
-	self->toCommit.saveTags(self->writtenTags);
-
 	// Serialize and backup the mutations as a single mutation
 	if ((pProxyCommitData->vecBackupKeys.size() > 1) && self->logRangeMutations.size()) {
 		wait(addBackupMutations(pProxyCommitData,
@@ -1232,6 +1229,8 @@ ACTOR Future<Void> postResolution(CommitBatchContext* self) {
 		                        &self->computeDuration,
 		                        &self->computeStart));
 	}
+
+	self->toCommit.saveTags(self->writtenTags);
 
 	pProxyCommitData->stats.mutations += self->mutationCount;
 	pProxyCommitData->stats.mutationBytes += self->mutationBytes;


### PR DESCRIPTION


20211022-154904-jzhou-028b5ef3762c7bae             compressed=True data_size=20842715 duration=3080156 ended=69360 fail=10 fail_fast=10 max_runs=100000 pass=69350 priority=100 remaining=0 runtime=0:14:25 sanity=False started=73758 stopped=20211022-160329 submitted=20211022-154904 timeout=5400 username=jzhou

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
