### PR TITLE
Disabling frequently failing tests until they can be fixed

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -132,7 +132,7 @@ if(WITH_PYTHON)
   add_fdb_test(TEST_FILES fast/CycleAndLock.toml)
   add_fdb_test(TEST_FILES fast/CycleTest.toml)
   add_fdb_test(TEST_FILES fast/ChangeFeeds.toml)
-  add_fdb_test(TEST_FILES fast/DataLossRecovery.toml)
+  add_fdb_test(TEST_FILES fast/DataLossRecovery.toml IGNORE) # TODO Re-enable once failures are fixed
   add_fdb_test(TEST_FILES fast/FuzzApiCorrectness.toml)
   add_fdb_test(TEST_FILES fast/FuzzApiCorrectnessClean.toml)
   add_fdb_test(TEST_FILES fast/IncrementalBackup.toml)
@@ -207,7 +207,7 @@ if(WITH_PYTHON)
                restarting/from_5.0.0_until_6.3.0/StorefrontTestRestart-2.txt)
   add_fdb_test(
     TEST_FILES restarting/from_6.2.33_until_6.3.0/SnapTestAttrition-1.txt
-               restarting/from_6.2.33_until_6.3.0/SnapTestAttrition-2.txt)
+               restarting/from_6.2.33_until_6.3.0/SnapTestAttrition-2.txt IGNORE) # TODO re-enable once snap test failures are fixed!
   add_fdb_test(
     TEST_FILES restarting/from_6.2.33_until_6.3.0/SnapTestSimpleRestart-1.txt
                restarting/from_6.2.33_until_6.3.0/SnapTestSimpleRestart-2.txt)
@@ -234,10 +234,10 @@ if(WITH_PYTHON)
                restarting/from_6.3.13/DrUpgradeRestart-2.txt)
   add_fdb_test(
     TEST_FILES restarting/from_6.3.13/SnapCycleRestart-1.txt
-               restarting/from_6.3.13/SnapCycleRestart-2.txt)
-  add_fdb_test(
+               restarting/from_6.3.13/SnapCycleRestart-2.txt IGNORE) # TODO re-enable once snap test failures are fixed!
+  add_fdb_test( 
     TEST_FILES restarting/from_6.3.13/SnapTestAttrition-1.txt
-               restarting/from_6.3.13/SnapTestAttrition-2.txt)
+               restarting/from_6.3.13/SnapTestAttrition-2.txt IGNORE) # TODO re-enable once snap test failures are fixed!
   add_fdb_test(
     TEST_FILES restarting/from_6.3.13/SnapTestRestart-1.txt
                restarting/from_6.3.13/SnapTestRestart-2.txt)


### PR DESCRIPTION
Disabled all of the snapshot tests that failed recently, as well as the DataLossRecovery test. Addresses https://github.com/apple/foundationdb/issues/5847.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
