### PR TITLE
Fix bug where spans were not being properly constructed (release-7.0)

### DIFF
--- a/flow/Tracing.h
+++ b/flow/Tracing.h
@@ -44,12 +44,13 @@ struct Span {
 			this->context = SpanID((*parents.begin()).first(), traceId);
 		}
 	}
-	Span(Location location, std::initializer_list<SpanID> const& parents = {}) {
-		uint64_t tokenId = deterministicRandom()->random01() < FLOW_KNOBS->TRACING_SAMPLE_RATE
-		                       ? deterministicRandom()->randomUInt64()
-		                       : 0;
-		Span(UID(deterministicRandom()->randomUInt64(), tokenId), location, parents);
-	}
+	Span(Location location, std::initializer_list<SpanID> const& parents = {})
+	  : Span(UID(deterministicRandom()->randomUInt64(),
+	             deterministicRandom()->random01() < FLOW_KNOBS->TRACING_SAMPLE_RATE
+	                 ? deterministicRandom()->randomUInt64()
+	                 : 0),
+	         location,
+	         parents) {}
 	Span(Location location, SpanID context) : Span(location, { context }) {}
 	Span(const Span&) = delete;
 	Span(Span&& o) {
@@ -78,13 +79,12 @@ struct Span {
 
 	void addParent(SpanID span) {
 		if (parents.size() == 0) {
-			uint64_t traceId = (*parents.begin()).second() > 0 ? context.second() : 0;
 			// Use first parent to set trace ID. This is non-ideal for spans
 			// with multiple parents, because the trace ID will associate the
 			// span with only one trace. A workaround is to look at the parent
 			// relationships instead of the trace ID. Another option in the
 			// future is to keep a list of trace IDs.
-			context = SpanID(span.first(), traceId);
+			context = SpanID(span.first(), context.second());
 		}
 		parents.push_back(arena, span);
 	}


### PR DESCRIPTION
Cherry pick of #5851. Fixes an issue with span construction where no state was actually being saved.

Passed 20k correctness.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
