### PR TITLE
Move getConnectionString() to IClusterConnectionRecord.

### DIFF
--- a/fdbclient/ClusterConnectionFile.actor.cpp
+++ b/fdbclient/ClusterConnectionFile.actor.cpp
@@ -40,12 +40,6 @@ ClusterConnectionFile::ClusterConnectionFile(std::string const& filename, Cluste
 	cs = contents;
 }
 
-// Returns the connection string currently held in this object. This may not match the string on disk if it hasn't
-// been persisted or if the file has been modified externally.
-ClusterConnectionString const& ClusterConnectionFile::getConnectionString() const {
-	return cs;
-}
-
 // Sets the connections string held by this object and persists it.
 Future<Void> ClusterConnectionFile::setConnectionString(ClusterConnectionString const& conn) {
 	ASSERT(filename.size());

--- a/fdbclient/ClusterConnectionFile.h
+++ b/fdbclient/ClusterConnectionFile.h
@@ -34,10 +34,6 @@ public:
 	// Creates a cluster file with a given connection string and saves it to the specified file.
 	explicit ClusterConnectionFile(std::string const& filename, ClusterConnectionString const& contents);
 
-	// Returns the connection string currently held in this object. This may not match the string on disk if it hasn't
-	// been persisted or if the file has been modified externally.
-	ClusterConnectionString const& getConnectionString() const override;
-
 	// Sets the connections string held by this object and persists it.
 	Future<Void> setConnectionString(ClusterConnectionString const&) override;
 

--- a/fdbclient/ClusterConnectionKey.actor.cpp
+++ b/fdbclient/ClusterConnectionKey.actor.cpp
@@ -56,12 +56,6 @@ ACTOR Future<Reference<ClusterConnectionKey>> ClusterConnectionKey::loadClusterC
 	}
 }
 
-// Returns the connection string currently held in this object. This may not match the string in the database if it
-// hasn't been persisted or if the key has been modified externally.
-ClusterConnectionString const& ClusterConnectionKey::getConnectionString() const {
-	return cs;
-}
-
 // Sets the connections string held by this object and persists it.
 Future<Void> ClusterConnectionKey::setConnectionString(ClusterConnectionString const& connectionString) {
 	cs = connectionString;

--- a/fdbclient/ClusterConnectionKey.actor.h
+++ b/fdbclient/ClusterConnectionKey.actor.h
@@ -47,10 +47,6 @@ public:
 	// format is invalid.
 	ACTOR static Future<Reference<ClusterConnectionKey>> loadClusterConnectionKey(Database db, Key connectionStringKey);
 
-	// Returns the connection string currently held in this object. This may not match the string in the database if it
-	// hasn't been persisted or if the key has been modified externally.
-	ClusterConnectionString const& getConnectionString() const override;
-
 	// Sets the connections string held by this object and persists it.
 	Future<Void> setConnectionString(ClusterConnectionString const&) override;
 

--- a/fdbclient/ClusterConnectionMemoryRecord.actor.cpp
+++ b/fdbclient/ClusterConnectionMemoryRecord.actor.cpp
@@ -22,11 +22,6 @@
 #include "fdbclient/MonitorLeader.h"
 #include "flow/actorcompiler.h" // has to be last include
 
-// Returns the connection string currently held in this object.
-ClusterConnectionString const& ClusterConnectionMemoryRecord::getConnectionString() const {
-	return cs;
-}
-
 // Sets the connections string held by this object.
 Future<Void> ClusterConnectionMemoryRecord::setConnectionString(ClusterConnectionString const& conn) {
 	cs = conn;

--- a/fdbclient/ClusterConnectionMemoryRecord.h
+++ b/fdbclient/ClusterConnectionMemoryRecord.h
@@ -35,9 +35,6 @@ public:
 		cs = contents;
 	}
 
-	// Returns the connection string currently held in this object.
-	ClusterConnectionString const& getConnectionString() const override;
-
 	// Sets the connections string held by this object.
 	Future<Void> setConnectionString(ClusterConnectionString const&) override;
 

--- a/fdbclient/CoordinationInterface.h
+++ b/fdbclient/CoordinationInterface.h
@@ -93,7 +93,7 @@ public:
 
 	// Returns the connection string currently held in this object. This may not match the stored record if it hasn't
 	// been persisted or if the persistent storage for the record has been modified externally.
-	virtual ClusterConnectionString const& getConnectionString() const = 0;
+	ClusterConnectionString const& getConnectionString() const;
 
 	// Sets the connections string held by this object and persists it.
 	virtual Future<Void> setConnectionString(ClusterConnectionString const&) = 0;

--- a/fdbclient/MonitorLeader.actor.cpp
+++ b/fdbclient/MonitorLeader.actor.cpp
@@ -52,6 +52,12 @@ std::string trim(std::string const& connectionString) {
 
 FDB_DEFINE_BOOLEAN_PARAM(ConnectionStringNeedsPersisted);
 
+// Returns the connection string currently held in this object. This may not match the stored record if it hasn't
+// been persisted or if the persistent storage for the record has been modified externally.
+ClusterConnectionString const& IClusterConnectionRecord::getConnectionString() const {
+	return cs;
+}
+
 Future<bool> IClusterConnectionRecord::upToDate() {
 	ClusterConnectionString temp;
 	return upToDate(temp);


### PR DESCRIPTION
ClusterConnectionString was moved to IClusterConnectionRecord in PR #5853.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
