### PR TITLE
Fix /fdbserver/ptxn/test/lock_tlog

### DIFF
--- a/fdbserver/ptxn/test/TestTLogServer.actor.cpp
+++ b/fdbserver/ptxn/test/TestTLogServer.actor.cpp
@@ -612,7 +612,7 @@ TEST_CASE("/fdbserver/ptxn/test/lock_tlog") {
 			break;
 		}
 	}
-
+	ASSERT(index < pContext->numStorageTeamIDs);
 	state bool tlogStopped = false;
 	try {
 		std::vector<Standalone<StringRef>> messages = wait(commitInject(pContext, pContext->storageTeamIDs[index], 1));


### PR DESCRIPTION
Previously asssuming numTlog to be 1, but some test would use a
random number other than 1, thus test failing.

Put description here...

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
