### PR TITLE
Fix the slow task profiler when used with the multi-version client

### DIFF
--- a/fdbserver/workloads/SlowTaskWorkload.actor.cpp
+++ b/fdbserver/workloads/SlowTaskWorkload.actor.cpp
@@ -43,7 +43,7 @@ struct SlowTaskWorkload : TestWorkload {
 	ACTOR static Future<Void> go() {
 		wait(delay(1));
 		int64_t phc = dl_iterate_phdr_calls;
-		int64_t startProfilesDeferred = getNumProfilesDeferred();
+		int64_t startProfilesDisabled = getNumProfilesDisabled();
 		int64_t startProfilesOverflowed = getNumProfilesOverflowed();
 		int64_t startProfilesCaptured = getNumProfilesCaptured();
 		int64_t exc = 0;
@@ -57,10 +57,10 @@ struct SlowTaskWorkload : TestWorkload {
 		}
 		fmt::print(stderr,
 		           "Slow task complete: {0} exceptions; {1} calls to dl_iterate_phdr, {2}"
-		           " profiles deferred, {3} profiles overflowed, {4} profiles captured\n",
+		           " profiles disabled, {3} profiles overflowed, {4} profiles captured\n",
 		           exc,
 		           dl_iterate_phdr_calls - phc,
-		           getNumProfilesDeferred() - startProfilesDeferred,
+		           getNumProfilesDisabled() - startProfilesDisabled,
 		           getNumProfilesOverflowed() - startProfilesOverflowed,
 		           getNumProfilesCaptured() - startProfilesCaptured);
 

--- a/flow/Platform.actor.cpp
+++ b/flow/Platform.actor.cpp
@@ -3799,7 +3799,7 @@ void profileHandler(int sig) {
 
 	// This is not documented in the POSIX list of signal-safe functions, but numbered syscalls are reported to be
 	// async safe in Linux.
-	if (profileThreadId != syscall(SYS_gettid)) {
+	if (profileThreadId != syscall(__NR_gettid)) {
 		return;
 	} else if (!profilingEnabled) {
 		++numProfilesDisabled;

--- a/flow/Platform.actor.cpp
+++ b/flow/Platform.actor.cpp
@@ -3756,6 +3756,7 @@ volatile bool profileThread = false;
 volatile int64_t profileThreadId = -1;
 void (*chainedSignalHandler)(int) = nullptr;
 volatile bool profilingEnabled = 1;
+volatile thread_local bool flowProfilingEnabled = 1;
 
 volatile int64_t numProfilesDisabled = 0;
 volatile int64_t numProfilesOverflowed = 0;
@@ -3833,6 +3834,7 @@ void setProfilingEnabled(int enabled) {
 	if (profileThread) {
 		profilingEnabled = enabled;
 	}
+	flowProfilingEnabled = enabled;
 #else
 	// No profiling for other platforms!
 #endif

--- a/flow/Platform.actor.cpp
+++ b/flow/Platform.actor.cpp
@@ -3752,8 +3752,13 @@ extern void initProfiling();
 std::atomic<double> checkThreadTime;
 #endif
 
-volatile bool profileThread = false;
+// True if this thread is the thread being profiled. Not to be used from the signal handler.
+thread_local bool profileThread = false;
+
+// The thread ID of the profiled thread. This can be compared against the current thread ID
+// to see if we are on the profiled thread. Can be used in the signal handler.
 volatile int64_t profileThreadId = -1;
+
 void (*chainedSignalHandler)(int) = nullptr;
 volatile bool profilingEnabled = 1;
 volatile thread_local bool flowProfilingEnabled = 1;
@@ -3792,6 +3797,8 @@ void profileHandler(int sig) {
 		chainedSignalHandler(sig);
 	}
 
+	// This is not documented in the POSIX list of signal-safe functions, but numbered syscalls are reported to be
+	// async safe in Linux.
 	if (profileThreadId != syscall(SYS_gettid)) {
 		return;
 	} else if (!profilingEnabled) {
@@ -3983,21 +3990,31 @@ void setupRunLoopProfiler() {
 #ifdef __linux__
 	if (profileThreadId == -1 && FLOW_KNOBS->RUN_LOOP_PROFILING_INTERVAL > 0) {
 		TraceEvent("StartingRunLoopProfilingThread").detail("Interval", FLOW_KNOBS->RUN_LOOP_PROFILING_INTERVAL);
-		initProfiling();
 
 		profileThread = true;
 		profileThreadId = syscall(__NR_gettid);
-		;
+		if (profileThreadId < 0) {
+			TraceEvent(SevWarnAlways, "RunLoopProfilingSetupFailed")
+			    .detail("Reason", "Error getting thread ID")
+			    .GetLastError();
+			return;
+		}
+
+		initProfiling();
 
 		struct sigaction oldAction;
 		struct sigaction action;
 		action.sa_handler = profileHandler;
 		sigfillset(&action.sa_mask);
 		action.sa_flags = 0;
-		sigaction(SIGPROF, &action, &oldAction);
+		if (sigaction(SIGPROF, &action, &oldAction)) {
+			TraceEvent(SevWarnAlways, "RunLoopProfilingSetupFailed")
+			    .detail("Reason", "Error configuring signal handler")
+			    .GetLastError();
+			return;
+		}
 
-		if (oldAction.sa_handler != SIG_DFL && oldAction.sa_handler != SIG_ERR && oldAction.sa_handler != SIG_IGN &&
-		    oldAction.sa_handler != NULL) {
+		if (oldAction.sa_handler != SIG_DFL && oldAction.sa_handler != SIG_IGN && oldAction.sa_handler != NULL) {
 			chainedSignalHandler = oldAction.sa_handler;
 		} else {
 			chainedSignalHandler = nullptr;

--- a/flow/Profiler.actor.cpp
+++ b/flow/Profiler.actor.cpp
@@ -33,7 +33,7 @@
 #include "flow/Platform.h"
 #include "flow/actorcompiler.h" // This must be the last include.
 
-extern volatile thread_local int profilingEnabled;
+extern volatile int profilingEnabled;
 
 static uint64_t sys_gettid() {
 	return syscall(__NR_gettid);

--- a/flow/Profiler.actor.cpp
+++ b/flow/Profiler.actor.cpp
@@ -33,7 +33,7 @@
 #include "flow/Platform.h"
 #include "flow/actorcompiler.h" // This must be the last include.
 
-extern volatile int profilingEnabled;
+extern volatile thread_local int flowProfilingEnabled;
 
 static uint64_t sys_gettid() {
 	return syscall(__NR_gettid);
@@ -146,7 +146,7 @@ struct Profiler {
 		if (inSigHandler.exchange(true)) {
 			return;
 		}
-		if (profilingEnabled) {
+		if (flowProfilingEnabled) {
 			double t = timer();
 			output_buffer->push(*(void**)&t);
 			size_t n = platform::raw_backtrace(addresses, 256);

--- a/flow/include/flow/Platform.h
+++ b/flow/include/flow/Platform.h
@@ -779,8 +779,8 @@ inline static int clz(uint32_t value) {
 #define clz __builtin_clz
 #endif
 
-// These return thread local counts
-int64_t getNumProfilesDeferred();
+// These return 0 unless run on the network thread
+int64_t getNumProfilesDisabled();
 int64_t getNumProfilesOverflowed();
 int64_t getNumProfilesCaptured();
 


### PR DESCRIPTION
The slow task profiler had two problems when used with the multi-version client:

1. Each external client sets a signal handler for the process, but these overwrite each other. In the end, one signal handler would be called from one of the libraries.
2. It used thread local variables to handle some of its logic. For externally loaded clients (loaded using dlopen), the memory for these variables was allocated dynamically the first time they were used, and if we called into another client's signal handler then this allocation would occur in the signal handler. It is not safe to call malloc in a signal handler, and this led to deadlocks.

This changes the signal handler to not use thread local variables but to instead compare the thread ID of the network thread with the thread id in the signal handler, obtained using a syscall. It also updates the signal handler to chain with the prior signal handlers so that we would call this function on each external client. In theory, the external client with a thread ID that matches the network thread being signaled would be the one to actually run.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
