### PR TITLE
Annotate printf-like functions with format attribute

### DIFF
--- a/flow/Arena.h
+++ b/flow/Arena.h
@@ -414,8 +414,6 @@ private:
 	Standalone<T> const& operator=(Standalone<U> const&); // unimplemented
 };
 
-extern std::string format(const char* form, ...);
-
 #pragma pack(push, 4)
 class StringRef {
 public:

--- a/flow/Platform.actor.cpp
+++ b/flow/Platform.actor.cpp
@@ -2936,7 +2936,11 @@ std::string getWorkingDirectory() {
 
 } // namespace platform
 
-extern std::string format(const char* form, ...);
+#if defined(__clang__) || defined(__GNUC__)
+__attribute__((__format__(__printf__, 1, 2)))
+#endif
+extern std::string
+format(const char* form, ...);
 
 namespace platform {
 std::string getDefaultConfigPath() {

--- a/flow/ThreadPrimitives.cpp
+++ b/flow/ThreadPrimitives.cpp
@@ -32,8 +32,6 @@
 #undef max
 #endif
 
-extern std::string format(const char* form, ...);
-
 Event::Event() {
 #ifdef _WIN32
 	ev = CreateEvent(nullptr, FALSE, FALSE, nullptr);

--- a/flow/Trace.cpp
+++ b/flow/Trace.cpp
@@ -1047,6 +1047,7 @@ TraceEvent& TraceEvent::detailf(std::string key, const char* valueFormat, ...) {
 	}
 	return *this;
 }
+
 TraceEvent& TraceEvent::detailfNoMetric(std::string&& key, const char* valueFormat, ...) {
 	if (enabled) {
 		va_list args;

--- a/flow/Trace.h
+++ b/flow/Trace.h
@@ -208,7 +208,11 @@ char base16Char(IntType c) {
 
 // forward declare format from flow.h as we
 // can't include flow.h here
-std::string format(const char* form, ...);
+#if defined(__clang__) || defined(__GNUC__)
+__attribute__((__format__(__printf__, 1, 2)))
+#endif
+std::string
+format(const char* form, ...);
 
 template <class T>
 struct Traceable : std::false_type {};
@@ -411,7 +415,12 @@ struct TraceEvent {
 		}
 		return *this;
 	}
-	TraceEvent& detailf(std::string key, const char* valueFormat, ...);
+
+#if defined(__clang__) || defined(__GNUC__)
+	__attribute__((__format__(__printf__, 3, 4)))
+#endif
+	TraceEvent&
+	detailf(std::string key, const char* valueFormat, ...);
 
 private:
 	template <class T>
@@ -436,7 +445,11 @@ private:
 	TraceEvent& errorImpl(const class Error& e, bool includeCancelled = false);
 	// Private version of detailf that does NOT write to the eventMetric.  This is to be used by other detail methods
 	// which can write field metrics of a more appropriate type than string but use detailf() to add to the TraceEvent.
-	TraceEvent& detailfNoMetric(std::string&& key, const char* valueFormat, ...);
+#if defined(__clang__) || defined(__GNUC__)
+	__attribute__((__format__(__printf__, 3, 4)))
+#endif
+	TraceEvent&
+	detailfNoMetric(std::string&& key, const char* valueFormat, ...);
 	TraceEvent& detailImpl(std::string&& key, std::string&& value, bool writeEventMetricField = true);
 
 public:

--- a/flow/flow.h
+++ b/flow/flow.h
@@ -94,7 +94,12 @@ bool validationIsEnabled(BuggifyType type);
 
 extern Optional<uint64_t> parse_with_suffix(std::string const& toparse, std::string const& default_unit = "");
 extern Optional<uint64_t> parseDuration(std::string const& str, std::string const& defaultUnit = "");
-extern std::string format(const char* form, ...);
+
+#if defined(__clang__) || defined(__GNUC__)
+__attribute__((__format__(__printf__, 1, 2)))
+#endif
+std::string
+format(const char* form, ...);
 
 // On success, returns the number of characters written. On failure, returns a negative number.
 extern int vsformat(std::string& outputString, const char* form, va_list args);


### PR DESCRIPTION
Mismatching print format specifiers and argument types results in undefined behavior. This PR adds the "format" attribute to some helper functions we use that accept printf-like format strings, so that the compiler can check that the format specifiers and argument types match.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
