### PR TITLE
Add a TestEnvironment for testing

### DIFF
--- a/fdbserver/ptxn/TLogInterface.cpp
+++ b/fdbserver/ptxn/TLogInterface.cpp
@@ -67,4 +67,28 @@ std::shared_ptr<TLogInterfaceBase> getNewTLogInterface(const MessageTransferMode
 	}
 }
 
+namespace details {
+
+namespace {
+template <typename T>
+std::shared_ptr<T> TLogInterfaceCastHelper(std::shared_ptr<TLogInterfaceBase> ptr) {
+	std::shared_ptr<T> result = std::dynamic_pointer_cast<T>(ptr);
+	if (!result) {
+		// std::bad_cast might be a better choice if not using flow
+		throw internal_error_msg("Unable to downcast TLogInterface");
+	}
+	return result;
+}
+} // namespace
+
+TLogInterfaceSharedPtrWrapper::operator std::shared_ptr<TLogInterface_PassivelyPull>() {
+	return TLogInterfaceCastHelper<TLogInterface_PassivelyPull>(ptr);
+}
+
+TLogInterfaceSharedPtrWrapper::operator std::shared_ptr<TLogInterface_ActivelyPush>() {
+	return TLogInterfaceCastHelper<TLogInterface_ActivelyPush>(ptr);
+}
+
+} // namespace details
+
 } // namespace ptxn

--- a/fdbserver/ptxn/TLogInterface.h
+++ b/fdbserver/ptxn/TLogInterface.h
@@ -537,6 +537,20 @@ struct TLogInterface_PassivelyPull : public TLogInterfaceBase {
 	void initEndpoints() override;
 };
 
+namespace details {
+
+class TLogInterfaceSharedPtrWrapper {
+	std::shared_ptr<TLogInterfaceBase> ptr;
+
+public:
+	TLogInterfaceSharedPtrWrapper(std::shared_ptr<TLogInterfaceBase> ptr_ = nullptr) : ptr(ptr_) {}
+
+	operator std::shared_ptr<TLogInterface_PassivelyPull>();
+	operator std::shared_ptr<TLogInterface_ActivelyPush>();
+};
+
+} // namespace details
+
 std::shared_ptr<TLogInterfaceBase> getNewTLogInterface(const MessageTransferModel model,
                                                        UID id_ = deterministicRandom()->randomUniqueID(),
                                                        UID sharedTLogID_ = deterministicRandom()->randomUniqueID(),

--- a/fdbserver/ptxn/test/Driver.actor.cpp
+++ b/fdbserver/ptxn/test/Driver.actor.cpp
@@ -216,15 +216,13 @@ void startFakeStorageServer(std::vector<Future<Void>>& actors, std::shared_ptr<T
 
 namespace details {
 
-#pragma region TLogGroupFixture
-
 void TLogGroupFixture::setUp(TestDriverContext& testDriverContext,
                              const int numTLogGroups,
                              const int numStorageTeamIDs) {
 
-	ASSERT(numTLogGroups >= numStorageTeamIDs);
+	ASSERT(numTLogGroups <= numStorageTeamIDs);
 
-	test::print::PrintTiming printTIming("TLogGroupFixture::setUp");
+	test::print::PrintTiming printTiming("TLogGroupFixture::setUp");
 
 	for (int i = 0; i < numTLogGroups; ++i) {
 		tLogGroupIDs.push_back(randomUID());
@@ -257,10 +255,6 @@ void TLogGroupFixture::setUp(TestDriverContext& testDriverContext,
 	}
 }
 
-#pragma endregion TLogGroupFixture
-
-#pragma region MessageFixture
-
 void MessageFixture::setUp(const TLogGroupFixture& tLogGroupStorageTeamMapping,
                            const int initialVersion,
                            const int numVersions,
@@ -276,8 +270,6 @@ void MessageFixture::setUp(const TLogGroupFixture& tLogGroupStorageTeamMapping,
 		version += deterministicRandom()->randomInt(5, 11);
 	}
 }
-
-#pragma endregion MessageFixture
 
 #pragma region ptxnTLogFixture
 
@@ -344,16 +336,11 @@ ptxn::details::TLogInterfaceSharedPtrWrapper ptxnTLogFixture::getTLogLeaderBySto
 
 #pragma endregion ptxnTLogFixture
 
-#pragma region ptxnFakeTLogFixture
-
-
 std::shared_ptr<FakeTLogContext> ptxnFakeTLogFixture::getTLogContextByIndex(const int index) {
 	ASSERT(index >= 0 && index < static_cast<int>(tLogContexts.size()));
 
 	return tLogContexts[index];
 }
-
-#pragma endregion ptxnFakeTLogFixture
 
 #pragma region ptxnTLogPassivelyPullFixture
 
@@ -427,7 +414,7 @@ TestEnvironment& TestEnvironment::initMessages(const int initialVersion,
 	return *this;
 }
 
-const CommitRecord& TestEnvironment::getCommitRecords() {
+CommitRecord& TestEnvironment::getCommitRecords() {
 	ASSERT(pImpl);
 	ASSERT(pImpl->testDriverContextImpl);
 

--- a/fdbserver/ptxn/test/Driver.h
+++ b/fdbserver/ptxn/test/Driver.h
@@ -31,10 +31,11 @@
 #include "fdbserver/ptxn/MessageSerializer.h"
 #include "fdbserver/ptxn/MessageTypes.h"
 #include "fdbserver/ptxn/StorageServerInterface.h"
+#include "fdbserver/ptxn/test/CommitUtils.h"
 #include "fdbserver/ptxn/TLogInterface.h"
+#include "fdbserver/ptxn/test/FakeTLog.actor.h"
 #include "fdbserver/ResolverInterface.h"
 #include "fdbserver/WorkerInterface.actor.h"
-#include "fdbserver/ptxn/test/CommitUtils.h"
 #include "flow/UnitTest.h"
 
 namespace ptxn::test {
@@ -94,7 +95,6 @@ struct TestDriverContext {
 	std::vector<std::shared_ptr<ResolverInterface>> resolverInterfaces;
 
 	// TLog
-	bool useFakeTLog;
 	int numTLogs;
 	int numTLogGroups;
 	std::vector<TLogGroup> tLogGroups;
@@ -137,6 +137,140 @@ void startFakeStorageServer(std::vector<Future<Void>>& actors, std::shared_ptr<T
 
 // Starts all fake sequencers specified in the pTestDriverContext.
 void startFakeSequencer(std::vector<Future<Void>>& actors, std::shared_ptr<TestDriverContext> pTestDriverContext);
+
+namespace details {
+
+// FIXME: change the struct to class, hide all member variables
+struct TLogGroupFixture {
+	std::vector<TLogGroup>& tLogGroups;
+
+	// Handy variable for accessing all TLog group IDs
+	std::vector<TLogGroupID> tLogGroupIDs;
+
+	// Handy variable for accessing all storage team IDs
+	std::vector<StorageTeamID> storageTeamIDs;
+
+	// Handy variable for accessing mapping information
+	std::unordered_map<TLogGroupID, std::unordered_set<StorageTeamID>> tLogGroupStorageTeamMapping;
+
+	// Handy variable for reverse mapping information
+	std::unordered_map<StorageTeamID, TLogGroupID>& storageTeamTLogGroupMapping;
+
+public:
+	TLogGroupFixture(TestDriverContext& testDriverContext)
+	  : tLogGroups(testDriverContext.tLogGroups),
+	    storageTeamTLogGroupMapping(testDriverContext.storageTeamIDTLogGroupIDMapper) {}
+
+	int getNumTLogGroups() const { return tLogGroups.size(); }
+
+	void setUp(TestDriverContext& testDriverContext, const int numTLogGroups, const int numStorageTeamIDs);
+};
+
+// FIXME: change the struct to class, hide all member variables
+struct MessageFixture {
+	CommitRecord& commitRecord;
+
+	MessageFixture(CommitRecord& commitRecord_) : commitRecord(commitRecord_) {}
+
+	void setUp(const TLogGroupFixture& tLogGroupStorageTeamMapping,
+	           const int initialVersion,
+	           const int numVersions,
+	           const int numMutationsInVersion);
+
+	const decltype(std::declval<CommitRecord>().messages)& getMessages() const { return commitRecord.messages; }
+};
+
+// FIXME: Hide member varaible access
+struct ptxnTLogFixture {
+	// FIXME make this configurable
+	static const int NUM_TLOG_PER_GROUP = 3;
+
+	const TLogGroupFixture& tLogGroupFixture;
+	std::shared_ptr<TestDriverContext> pTestDriverContext;
+	std::vector<Future<Void>> actors;
+	std::unordered_map<TLogGroupID, std::shared_ptr<TLogInterfaceBase>>& tLogGroupLeaders;
+	std::vector<std::shared_ptr<TLogInterfaceBase>>& tLogInterfaces;
+	std::vector<std::shared_ptr<FakeTLogContext>> tLogContexts;
+
+	// FIXME Implement without using TestDriverContext
+	ptxnTLogFixture(std::shared_ptr<TestDriverContext> pTestDriverContext_, const TLogGroupFixture& tLogGroupFixture_)
+	  : tLogGroupFixture(tLogGroupFixture_), pTestDriverContext(pTestDriverContext_),
+	    tLogGroupLeaders(pTestDriverContext->tLogGroupLeaders), tLogInterfaces(pTestDriverContext->tLogInterfaces) {}
+
+	// Returns the shared_ptr of the TLog interface for the given TLogGroupID
+	// The user must explicitly cast/provide the interface type.
+	ptxn::details::TLogInterfaceSharedPtrWrapper getTLogLeaderByTLogGroupID(const TLogGroupID& tLogGroupID) const;
+	// Returns the shared_ptr of the TLog interface for the given StorageTeamID
+	// The user must explicitly cast/provide the interface type.
+	ptxn::details::TLogInterfaceSharedPtrWrapper getTLogLeaderByStorageTeamID(const StorageTeamID& storageTeamID) const;
+
+	int getNumTLogActors() const { return actors.size(); }
+	virtual void setUp(const int numTLogs);
+
+protected:
+	virtual std::shared_ptr<TLogInterfaceBase> createTLogInterface() = 0;
+	virtual Future<Void> createTLogActor(std::shared_ptr<FakeTLogContext>) = 0;
+};
+
+struct ptxnFakeTLogFixture : public ptxnTLogFixture {
+	ptxnFakeTLogFixture(std::shared_ptr<TestDriverContext> pTestDriverContext_,
+	                    const TLogGroupFixture& tLogGroupFixture_)
+	  : ptxnTLogFixture(pTestDriverContext_, tLogGroupFixture_) {}
+
+	std::shared_ptr<FakeTLogContext> getTLogContextByIndex(const int index);
+};
+
+struct ptxnFakeTLogPassivelyPullFixture : public ptxnFakeTLogFixture {
+
+	ptxnFakeTLogPassivelyPullFixture(std::shared_ptr<TestDriverContext> pTestDriverContext_,
+	                                 const TLogGroupFixture& tLogGroupFixture_)
+	  : ptxnFakeTLogFixture(pTestDriverContext_, tLogGroupFixture_) {}
+
+protected:
+	virtual std::shared_ptr<TLogInterfaceBase> createTLogInterface() override;
+	virtual Future<Void> createTLogActor(std::shared_ptr<FakeTLogContext>) override;
+};
+
+struct TestEnvironmentImpl {
+	// FIXME At this stage, we use testDriverContextImpl to implement the fixtures, in the future each fixture should
+	// have its own class.
+	std::shared_ptr<TestDriverContext> testDriverContextImpl;
+	std::unique_ptr<TLogGroupFixture> tLogGroup;
+	std::shared_ptr<ptxnTLogFixture> tLogs;
+	std::unique_ptr<MessageFixture> messages;
+};
+
+} // namespace details
+
+class TestEnvironment {
+
+private:
+	static std::unique_ptr<details::TestEnvironmentImpl> pImpl;
+
+public:
+	TestEnvironment() {
+		ASSERT(!pImpl);
+		pImpl = std::make_unique<details::TestEnvironmentImpl>();
+	}
+
+	void tearDownAll() { pImpl.reset(nullptr); }
+
+	~TestEnvironment() { tearDownAll(); }
+
+	TestEnvironment(TestEnvironment&&) = delete;
+	TestEnvironment(const TestEnvironment&) = delete;
+	TestEnvironment& operator=(const TestEnvironment&) = delete;
+	TestEnvironment& operator=(TestEnvironment&&) = delete;
+
+	TestEnvironment& initDriverContext();
+	TestEnvironment& initTLogGroup(const int numTLogGroupIDs, const int numStorageTeamIDs);
+	TestEnvironment& initPtxnTLog(const MessageTransferModel model, const int numTLogs, bool useFake = true);
+	TestEnvironment& initMessages(const int initialVersion, const int numVersions, const int numMutationsInVersion);
+
+	static const CommitRecord& getCommitRecords();
+	static const details::TLogGroupFixture& getTLogGroup();
+	static std::shared_ptr<details::ptxnTLogFixture> getTLogs();
+};
 
 } // namespace ptxn::test
 

--- a/fdbserver/ptxn/test/Driver.h
+++ b/fdbserver/ptxn/test/Driver.h
@@ -267,7 +267,7 @@ public:
 	TestEnvironment& initPtxnTLog(const MessageTransferModel model, const int numTLogs, bool useFake = true);
 	TestEnvironment& initMessages(const int initialVersion, const int numVersions, const int numMutationsInVersion);
 
-	static const CommitRecord& getCommitRecords();
+	static CommitRecord& getCommitRecords();
 	static const details::TLogGroupFixture& getTLogGroup();
 	static std::shared_ptr<details::ptxnTLogFixture> getTLogs();
 };

--- a/fdbserver/ptxn/test/FakeTLog.actor.h
+++ b/fdbserver/ptxn/test/FakeTLog.actor.h
@@ -31,7 +31,6 @@
 #include "fdbserver/ptxn/MessageSerializer.h"
 #include "fdbserver/ptxn/MessageTypes.h"
 #include "fdbserver/ptxn/StorageServerInterface.h"
-#include "fdbserver/ptxn/test/Driver.h"
 #include "fdbserver/ptxn/TLogInterface.h"
 #include "flow/flow.h"
 
@@ -40,6 +39,8 @@
 #pragma once
 
 namespace ptxn::test {
+
+struct TestDriverContext;
 
 struct FakeTLogContext {
 	std::shared_ptr<TestDriverContext> pTestDriverContext;

--- a/fdbserver/ptxn/test/Utils.h
+++ b/fdbserver/ptxn/test/Utils.h
@@ -81,7 +81,7 @@ ResultContainer randomlyPick(const Container& container, const int numSamples) {
 	}
 
 	for (int i = numSamples; i < containerSize; ++i) {
-		int j = deterministicRandom()->randomInt(1, i + 1);
+		int j = deterministicRandom()->randomInt(0, i + 1);
 		if (j < numSamples) {
 			result[j] = container[i];
 		}


### PR DESCRIPTION
Earlier the plan was to use TestDriverContext for *all* roles and
ACTORs. This is obviously brining more complexity than benefits. In this
patch, TestEnvironment is introduced as a global singleton. By accessing
TestEnvironment, one could construct fixtures and access the test
environment easier.

The example will be given in following commits. 


# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
