### PR TITLE
Disable test /fdbserver/ptxn/test/run_storage_server

### DIFF
--- a/fdbserver/ptxn/test/TestTLogServer.actor.cpp
+++ b/fdbserver/ptxn/test/TestTLogServer.actor.cpp
@@ -558,7 +558,7 @@ TEST_CASE("/fdbserver/ptxn/test/commit_peek") {
 	return Void();
 }
 
-TEST_CASE("/fdbserver/ptxn/test/run_storage_server") {
+TEST_CASE(":/fdbserver/ptxn/test/run_storage_server") {
 	state ptxn::test::TestDriverOptions options(params);
 	state std::vector<Future<Void>> actors;
 	state std::shared_ptr<ptxn::test::TestDriverContext> pContext = ptxn::test::initTestDriverContext(options);

--- a/fdbserver/ptxn/test/Utils.cpp
+++ b/fdbserver/ptxn/test/Utils.cpp
@@ -120,7 +120,7 @@ void print(const TLogPeekReply& reply) {
 }
 
 void print(const TestDriverOptions& option) {
-	std::cout << std::endl << ">> ptxn/test//Driver.actor.cpp:DriverTestOptions:" << std::endl;
+	std::cout << std::endl << ">> ptxn/test/Driver.actor.cpp:DriverTestOptions:" << std::endl;
 
 	std::cout << formatKVPair("numCommits", option.numCommits) << std::endl
 	          << formatKVPair("numStorageTeams", option.numStorageTeams) << std::endl
@@ -134,7 +134,7 @@ void print(const TestDriverOptions& option) {
 }
 
 void print(const ptxn::test::TestTLogPeekOptions& option) {
-	std::cout << std::endl << ">> ptxn/test//Driver.actor.cpp:DriverTestOptions:" << std::endl;
+	std::cout << std::endl << ">> ptxn/test/Driver.actor.cpp:DriverTestOptions:" << std::endl;
 
 	std::cout << formatKVPair("Mutations", option.numMutations) << std::endl
 	          << formatKVPair("Teams", option.numStorageTeams) << std::endl


### PR DESCRIPTION
The test should only be invoked from tests/ptxn/TLogServer.toml, where the
number of SS is the same as storage teams. Otherwise, an assertion failure will
be triggered at startStorageServers().

We can't run the unit test from either random unit test `tests/fast/RandomUnitTests.toml`
or specific unit test `tests/rare/SpecificUnitTests.toml`, since we can't set specific test parameters in.

Correctness: failed tests are other unit tests, `/fdbserver/ptxn/test/commit_peek` and `/fdbserver/ptxn/test/lock_tlog`

20211102-041336-jzhou-b37ad2e0ac3dde6c             compressed=True data_size=21601005 duration=4931735 ended=100001 fail=8 fail_fast=10 max_runs=100000 pass=99993 priority=100 remaining=0 runtime=0:46:48 sanity=False started=100199 stopped=20211102-050024 submitted=20211102-041336 timeout=5400 username=jzhou


# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
