### PR TITLE
Fix /fdbserver/ptxn/test/lock_tlog

### DIFF
--- a/fdbserver/ptxn/test/Driver.h
+++ b/fdbserver/ptxn/test/Driver.h
@@ -96,6 +96,7 @@ struct TestDriverContext {
 	int numTLogs;
 	int numTLogGroups;
 	std::vector<TLogGroup> tLogGroups;
+	std::vector<std::vector<ptxn::TLogGroup>> groupsPerTLog;
 	std::unordered_map<TLogGroupID, std::shared_ptr<TLogInterfaceBase>> tLogGroupLeaders;
 	std::unordered_map<TLogGroupID, Version> tLogGroupVersion;
 	std::vector<std::shared_ptr<TLogInterfaceBase>> tLogInterfaces;

--- a/tests/ptxn/TLogServer.toml
+++ b/tests/ptxn/TLogServer.toml
@@ -108,6 +108,6 @@ startDelay = 0
     maxTestCases = 1
     testsMatching = '/fdbserver/ptxn/test/lock_tlog'
 
-    numTLogs = 1
+    numTLogs = 3
     numStorageTeams = 40
     numTLogGroups = 7


### PR DESCRIPTION
Previously all tlogs are sent to all tlog servers, in PR 5869 it was
fixed by assigning non-overlapping subsets of groups to each tlog server.

Now this test must respect that so that it still passes in the case
of multiple tlog servers.

Put description here...

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
