### PR TITLE
Revert "Disable test /fdbserver/ptxn/test/run_storage_server"

### DIFF
--- a/fdbserver/ptxn/test/TestTLogServer.actor.cpp
+++ b/fdbserver/ptxn/test/TestTLogServer.actor.cpp
@@ -558,7 +558,7 @@ TEST_CASE("/fdbserver/ptxn/test/commit_peek") {
 	return Void();
 }
 
-TEST_CASE(":/fdbserver/ptxn/test/run_storage_server") {
+TEST_CASE("/fdbserver/ptxn/test/run_storage_server") {
 	state ptxn::test::TestDriverOptions options(params);
 	state std::vector<Future<Void>> actors;
 	state std::shared_ptr<ptxn::test::TestDriverContext> pContext = ptxn::test::initTestDriverContext(options);

--- a/fdbserver/ptxn/test/Utils.cpp
+++ b/fdbserver/ptxn/test/Utils.cpp
@@ -120,7 +120,7 @@ void print(const TLogPeekReply& reply) {
 }
 
 void print(const TestDriverOptions& option) {
-	std::cout << std::endl << ">> ptxn/test/Driver.actor.cpp:DriverTestOptions:" << std::endl;
+	std::cout << std::endl << ">> ptxn/test//Driver.actor.cpp:DriverTestOptions:" << std::endl;
 
 	std::cout << formatKVPair("numCommits", option.numCommits) << std::endl
 	          << formatKVPair("numStorageTeams", option.numStorageTeams) << std::endl
@@ -134,7 +134,7 @@ void print(const TestDriverOptions& option) {
 }
 
 void print(const ptxn::test::TestTLogPeekOptions& option) {
-	std::cout << std::endl << ">> ptxn/test/Driver.actor.cpp:DriverTestOptions:" << std::endl;
+	std::cout << std::endl << ">> ptxn/test//Driver.actor.cpp:DriverTestOptions:" << std::endl;
 
 	std::cout << formatKVPair("Mutations", option.numMutations) << std::endl
 	          << formatKVPair("Teams", option.numStorageTeams) << std::endl


### PR DESCRIPTION
Reverts apple/foundationdb#5895

The fix makes that test no longer runnable.