### PR TITLE
Fix run_storage_server test

### DIFF
--- a/fdbserver/ApplyMetadataMutation.cpp
+++ b/fdbserver/ApplyMetadataMutation.cpp
@@ -132,7 +132,6 @@ private:
 	std::map<UID, Reference<StorageInfo>>* storageCache = nullptr;
 	std::map<Tag, Version>* tag_popped = nullptr;
 	std::unordered_map<UID, StorageServerInterface>* tssMapping = nullptr;
-	std::unordered_map<UID, std::vector<std::pair<ptxn::StorageTeamID, bool>>>* changedTeams = nullptr;
 
 	Reference<TLogGroupCollection> tLogGroupCollection;
 
@@ -156,6 +155,7 @@ private:
 
 	std::map<Tag, UID>* tagToServer = nullptr;
 	std::unordered_map<UID, ptxn::StorageTeamID>* ssToStorageTeam = nullptr;
+	std::unordered_map<UID, std::vector<std::pair<ptxn::StorageTeamID, bool>>>* changedTeams = nullptr;
 
 	// All SSes' own teams, populated from ssToStorageTeam mapping.
 	std::set<ptxn::StorageTeamID> allTeams;

--- a/fdbserver/ptxn/test/Driver.h
+++ b/fdbserver/ptxn/test/Driver.h
@@ -42,7 +42,9 @@ namespace ptxn::test {
 // Driver options for starting mock environment.
 struct TestDriverOptions {
 	static const int DEFAULT_NUM_COMMITS = 3;
-	static const int DEFAULT_NUM_TEAMS = 10;
+	// Default is equal to numStorageTeamIDs so that an assertion in
+	// startStorageServers() won't fail.
+	static const int DEFAULT_NUM_TEAMS = 3;
 	static const int DEFAULT_NUM_PROXIES = 1;
 	static const int DEFAULT_NUM_TLOGS = 3;
 	static const int DEFAULT_NUM_TLOG_GROUPS = 4;

--- a/fdbserver/ptxn/test/TestTLogServer.actor.cpp
+++ b/fdbserver/ptxn/test/TestTLogServer.actor.cpp
@@ -274,7 +274,7 @@ ACTOR Future<Void> startStorageServers(std::vector<Future<Void>>* actors,
 		                                storageInitializations.back().reply,
 		                                dbInfo,
 		                                folder,
-		                                pContext->storageTeamIDs[i]));
+		                                pContext->storageTeamIDs[0]));
 		initializeStorage.send(storageInitializations.back());
 		printTiming << "Recruited storage server " << i
 		            << " : Storage Server Debug ID = " << recruited.id().shortString() << "\n";

--- a/fdbserver/ptxn/test/TestTLogServer.actor.cpp
+++ b/fdbserver/ptxn/test/TestTLogServer.actor.cpp
@@ -302,7 +302,7 @@ TEST_CASE("/fdbserver/ptxn/test/run_tlog_server") {
 	state std::vector<Future<Void>> actors;
 	state std::shared_ptr<ptxn::test::TestDriverContext> pContext = ptxn::test::initTestDriverContext(options);
 
-	state std::string folder = "simdb" + deterministicRandom()->randomAlphaNumeric(10);
+	state std::string folder = "simfdb/" + deterministicRandom()->randomAlphaNumeric(10);
 	platform::createDirectory(folder);
 	// start a real TLog server
 	wait(startTLogServers(&actors, pContext, folder));
@@ -323,7 +323,7 @@ TEST_CASE("/fdbserver/ptxn/test/peek_tlog_server") {
 		ptxn::test::print::print(group);
 	}
 
-	state std::string folder = "simdb/" + deterministicRandom()->randomAlphaNumeric(10);
+	state std::string folder = "simfdb/" + deterministicRandom()->randomAlphaNumeric(10);
 	platform::createDirectory(folder);
 	// start a real TLog server
 	wait(startTLogServers(&actors, pContext, folder));
@@ -560,7 +560,7 @@ TEST_CASE("/fdbserver/ptxn/test/commit_peek") {
 	const ptxn::TLogGroup& group = pContext->tLogGroups[0];
 	state ptxn::StorageTeamID storageTeamID = group.storageTeams.begin()->first;
 
-	state std::string folder = "simdb/" + deterministicRandom()->randomAlphaNumeric(10);
+	state std::string folder = "simfdb/" + deterministicRandom()->randomAlphaNumeric(10);
 	platform::createDirectory(folder);
 
 	wait(startTLogServers(&actors, pContext, folder));
@@ -660,7 +660,7 @@ TEST_CASE("/fdbserver/ptxn/test/read_persisted_disk_on_tlog") {
 	const ptxn::TLogGroup& group = pContext->tLogGroups[0];
 	state ptxn::StorageTeamID storageTeamID = group.storageTeams.begin()->first;
 
-	state std::string folder = "simdb/" + deterministicRandom()->randomAlphaNumeric(10);
+	state std::string folder = "simfdb/" + deterministicRandom()->randomAlphaNumeric(10);
 	platform::createDirectory(folder);
 
 	state std::vector<ptxn::InitializePtxnTLogRequest> tLogInitializations;

--- a/fdbserver/ptxn/test/Utils.cpp
+++ b/fdbserver/ptxn/test/Utils.cpp
@@ -120,7 +120,7 @@ void print(const TLogPeekReply& reply) {
 }
 
 void print(const TestDriverOptions& option) {
-	std::cout << std::endl << ">> ptxn/test//Driver.actor.cpp:DriverTestOptions:" << std::endl;
+	std::cout << std::endl << ">> ptxn/test/Driver.actor.cpp:DriverTestOptions:" << std::endl;
 
 	std::cout << formatKVPair("numCommits", option.numCommits) << std::endl
 	          << formatKVPair("numStorageTeams", option.numStorageTeams) << std::endl
@@ -134,7 +134,7 @@ void print(const TestDriverOptions& option) {
 }
 
 void print(const ptxn::test::TestTLogPeekOptions& option) {
-	std::cout << std::endl << ">> ptxn/test//Driver.actor.cpp:DriverTestOptions:" << std::endl;
+	std::cout << std::endl << ">> ptxn/test/Driver.actor.cpp:DriverTestOptions:" << std::endl;
 
 	std::cout << formatKVPair("Mutations", option.numMutations) << std::endl
 	          << formatKVPair("Teams", option.numStorageTeams) << std::endl


### PR DESCRIPTION
Fix the default so that `numStorageServers == numStorageTeamIDs` when running as specific/random unit test.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
