### PR TITLE
Improve distributed trace sample collection

### DIFF
--- a/bindings/c/test/unit/unit_tests.cpp
+++ b/bindings/c/test/unit/unit_tests.cpp
@@ -1828,50 +1828,40 @@ TEST_CASE("special-key-space set transaction ID after write") {
 	}
 }
 
-TEST_CASE("special-key-space set token after write") {
-	int64_t trace_sample_rate = 1000000;
-	fdb_check(fdb_database_set_option(db,
-	                                  FDB_DB_OPTION_DISTRIBUTED_TRANSACTION_TRACE_SAMPLE_RATE,
-	                                  (const uint8_t*)&trace_sample_rate,
-	                                  sizeof(trace_sample_rate)));
-	fdb::Transaction tr(db);
-	fdb_check(tr.set_option(FDB_TR_OPTION_SPECIAL_KEY_SPACE_ENABLE_WRITES, nullptr, 0));
-	while (1) {
-		tr.set(key("foo"), "bar");
-		tr.set("\xff\xff/tracing/token", "false");
-		fdb::ValueFuture f1 = tr.get("\xff\xff/tracing/token",
-		                             /* snapshot */ false);
+// TEST_CASE("special-key-space set token after write") {
+// 	fdb::Transaction tr(db);
+// 	fdb_check(tr.set_option(FDB_TR_OPTION_SPECIAL_KEY_SPACE_ENABLE_WRITES, nullptr, 0));
+// 	while (1) {
+// 		tr.set(key("foo"), "bar");
+// 		tr.set("\xff\xff/tracing/token", "false");
+// 		fdb::ValueFuture f1 = tr.get("\xff\xff/tracing/token",
+// 		                             /* snapshot */ false);
+//
+// 		fdb_error_t err = wait_future(f1);
+// 		if (err) {
+// 			fdb::EmptyFuture f2 = tr.on_error(err);
+// 			fdb_check(wait_future(f2));
+// 			continue;
+// 		}
+//
+// 		int out_present;
+// 		char* val;
+// 		int vallen;
+// 		fdb_check(f1.get(&out_present, (const uint8_t**)&val, &vallen));
+//
+// 		REQUIRE(out_present);
+// 		uint64_t token = std::stoul(std::string(val, vallen));
+// 		CHECK(token != 0);
+// 		break;
+// 	}
+// }
 
-		fdb_error_t err = wait_future(f1);
-		if (err) {
-			fdb::EmptyFuture f2 = tr.on_error(err);
-			fdb_check(wait_future(f2));
-			continue;
-		}
-
-		int out_present;
-		char* val;
-		int vallen;
-		fdb_check(f1.get(&out_present, (const uint8_t**)&val, &vallen));
-
-		REQUIRE(out_present);
-		uint64_t token = std::stoul(std::string(val, vallen));
-		CHECK(token != 0);
-		break;
-	}
-}
-
-TEST_CASE("special-key-space valid token") {
-	int64_t trace_sample_rate = 1000000;
-	fdb_check(fdb_database_set_option(db,
-	                                  FDB_DB_OPTION_DISTRIBUTED_TRANSACTION_TRACE_SAMPLE_RATE,
-	                                  (const uint8_t*)&trace_sample_rate,
-	                                  sizeof(trace_sample_rate)));
-	auto value = get_value("\xff\xff/tracing/token", /* snapshot */ false, {});
-	REQUIRE(value.has_value());
-	uint64_t token = std::stoul(value.value());
-	CHECK(token > 0);
-}
+// TEST_CASE("special-key-space valid token") {
+// 	auto value = get_value("\xff\xff/tracing/token", /* snapshot */ false, {});
+// 	REQUIRE(value.has_value());
+// 	uint64_t token = std::stoul(value.value());
+// 	CHECK(token > 0);
+// }
 
 TEST_CASE("special-key-space disable tracing") {
 	fdb::Transaction tr(db);
@@ -1900,71 +1890,49 @@ TEST_CASE("special-key-space disable tracing") {
 	}
 }
 
-TEST_CASE("FDB_DB_OPTION_DISTRIBUTED_TRANSACTION_TRACE_DISABLE") {
-	int64_t trace_sample_rate = 0;
-	fdb_check(fdb_database_set_option(db,
-	                                  FDB_DB_OPTION_DISTRIBUTED_TRANSACTION_TRACE_SAMPLE_RATE,
-	                                  (const uint8_t*)&trace_sample_rate,
-	                                  sizeof(trace_sample_rate)));
+// TEST_CASE("FDB_DB_OPTION_DISTRIBUTED_TRANSACTION_TRACE_DISABLE") {
+// 	fdb_check(fdb_database_set_option(db, FDB_DB_OPTION_DISTRIBUTED_TRANSACTION_TRACE_DISABLE, nullptr, 0));
+//
+// 	auto value = get_value("\xff\xff/tracing/token", /* snapshot */ false, {});
+// 	REQUIRE(value.has_value());
+// 	uint64_t token = std::stoul(value.value());
+// 	CHECK(token == 0);
+//
+// 	fdb_check(fdb_database_set_option(db, FDB_DB_OPTION_DISTRIBUTED_TRANSACTION_TRACE_ENABLE, nullptr, 0));
+// }
 
-	auto value = get_value("\xff\xff/tracing/token", /* snapshot */ false, {});
-	REQUIRE(value.has_value());
-	uint64_t token = std::stoul(value.value());
-	CHECK(token == 0);
-
-	trace_sample_rate = 1000000;
-	fdb_check(fdb_database_set_option(db,
-	                                  FDB_DB_OPTION_DISTRIBUTED_TRANSACTION_TRACE_SAMPLE_RATE,
-	                                  (const uint8_t*)&trace_sample_rate,
-	                                  sizeof(trace_sample_rate)));
-}
-
-TEST_CASE("FDB_DB_OPTION_DISTRIBUTED_TRANSACTION_TRACE_DISABLE enable tracing for transaction") {
-	int64_t trace_sample_rate = 0;
-	fdb_check(fdb_database_set_option(db,
-	                                  FDB_DB_OPTION_DISTRIBUTED_TRANSACTION_TRACE_SAMPLE_RATE,
-	                                  (const uint8_t*)&trace_sample_rate,
-	                                  sizeof(trace_sample_rate)));
-
-	fdb::Transaction tr(db);
-	fdb_check(tr.set_option(FDB_TR_OPTION_SPECIAL_KEY_SPACE_ENABLE_WRITES, nullptr, 0));
-	while (1) {
-		tr.set("\xff\xff/tracing/token", "true");
-		fdb::ValueFuture f1 = tr.get("\xff\xff/tracing/token",
-		                             /* snapshot */ false);
-
-		fdb_error_t err = wait_future(f1);
-		if (err) {
-			fdb::EmptyFuture f2 = tr.on_error(err);
-			fdb_check(wait_future(f2));
-			continue;
-		}
-
-		int out_present;
-		char* val;
-		int vallen;
-		fdb_check(f1.get(&out_present, (const uint8_t**)&val, &vallen));
-
-		REQUIRE(out_present);
-		uint64_t token = std::stoul(std::string(val, vallen));
-		CHECK(token > 0);
-		break;
-	}
-
-	trace_sample_rate = 1000000;
-	fdb_check(fdb_database_set_option(db,
-	                                  FDB_DB_OPTION_DISTRIBUTED_TRANSACTION_TRACE_SAMPLE_RATE,
-	                                  (const uint8_t*)&trace_sample_rate,
-	                                  sizeof(trace_sample_rate)));
-}
+// TEST_CASE("FDB_DB_OPTION_DISTRIBUTED_TRANSACTION_TRACE_DISABLE enable tracing for transaction") {
+// 	fdb_check(fdb_database_set_option(db, FDB_DB_OPTION_DISTRIBUTED_TRANSACTION_TRACE_DISABLE, nullptr, 0));
+//
+// 	fdb::Transaction tr(db);
+// 	fdb_check(tr.set_option(FDB_TR_OPTION_SPECIAL_KEY_SPACE_ENABLE_WRITES, nullptr, 0));
+// 	while (1) {
+// 		tr.set("\xff\xff/tracing/token", "true");
+// 		fdb::ValueFuture f1 = tr.get("\xff\xff/tracing/token",
+// 		                             /* snapshot */ false);
+//
+// 		fdb_error_t err = wait_future(f1);
+// 		if (err) {
+// 			fdb::EmptyFuture f2 = tr.on_error(err);
+// 			fdb_check(wait_future(f2));
+// 			continue;
+// 		}
+//
+// 		int out_present;
+// 		char* val;
+// 		int vallen;
+// 		fdb_check(f1.get(&out_present, (const uint8_t**)&val, &vallen));
+//
+// 		REQUIRE(out_present);
+// 		uint64_t token = std::stoul(std::string(val, vallen));
+// 		CHECK(token > 0);
+// 		break;
+// 	}
+//
+// 	fdb_check(fdb_database_set_option(db, FDB_DB_OPTION_DISTRIBUTED_TRANSACTION_TRACE_ENABLE, nullptr, 0));
+// }
 
 TEST_CASE("special-key-space tracing get range") {
-	int64_t trace_sample_rate = 1000000;
-	fdb_check(fdb_database_set_option(db,
-	                                  FDB_DB_OPTION_DISTRIBUTED_TRANSACTION_TRACE_SAMPLE_RATE,
-	                                  (const uint8_t*)&trace_sample_rate,
-	                                  sizeof(trace_sample_rate)));
-
 	std::string tracingBegin = "\xff\xff/tracing/";
 	std::string tracingEnd = "\xff\xff/tracing0";
 
@@ -1997,7 +1965,7 @@ TEST_CASE("special-key-space tracing get range") {
 		CHECK(out_count == 2);
 
 		CHECK(std::string((char*)out_kv[0].key, out_kv[0].key_length) == tracingBegin + "token");
-		CHECK(std::stoul(std::string((char*)out_kv[0].value, out_kv[0].value_length)) > 0);
+		// CHECK(std::stoul(std::string((char*)out_kv[0].value, out_kv[0].value_length)) > 0);
 		CHECK(std::string((char*)out_kv[1].key, out_kv[1].key_length) == tracingBegin + "transaction_id");
 		CHECK(std::stoul(std::string((char*)out_kv[1].value, out_kv[1].value_length)) > 0);
 		break;

--- a/bindings/c/test/unit/unit_tests.cpp
+++ b/bindings/c/test/unit/unit_tests.cpp
@@ -1828,40 +1828,40 @@ TEST_CASE("special-key-space set transaction ID after write") {
 	}
 }
 
-TEST_CASE("special-key-space set token after write") {
-	fdb::Transaction tr(db);
-	fdb_check(tr.set_option(FDB_TR_OPTION_SPECIAL_KEY_SPACE_ENABLE_WRITES, nullptr, 0));
-	while (1) {
-		tr.set(key("foo"), "bar");
-		tr.set("\xff\xff/tracing/token", "false");
-		fdb::ValueFuture f1 = tr.get("\xff\xff/tracing/token",
-		                             /* snapshot */ false);
+// TEST_CASE("special-key-space set token after write") {
+// 	fdb::Transaction tr(db);
+// 	fdb_check(tr.set_option(FDB_TR_OPTION_SPECIAL_KEY_SPACE_ENABLE_WRITES, nullptr, 0));
+// 	while (1) {
+// 		tr.set(key("foo"), "bar");
+// 		tr.set("\xff\xff/tracing/token", "false");
+// 		fdb::ValueFuture f1 = tr.get("\xff\xff/tracing/token",
+// 		                             /* snapshot */ false);
+//
+// 		fdb_error_t err = wait_future(f1);
+// 		if (err) {
+// 			fdb::EmptyFuture f2 = tr.on_error(err);
+// 			fdb_check(wait_future(f2));
+// 			continue;
+// 		}
+//
+// 		int out_present;
+// 		char* val;
+// 		int vallen;
+// 		fdb_check(f1.get(&out_present, (const uint8_t**)&val, &vallen));
+//
+// 		REQUIRE(out_present);
+// 		uint64_t token = std::stoul(std::string(val, vallen));
+// 		CHECK(token != 0);
+// 		break;
+// 	}
+// }
 
-		fdb_error_t err = wait_future(f1);
-		if (err) {
-			fdb::EmptyFuture f2 = tr.on_error(err);
-			fdb_check(wait_future(f2));
-			continue;
-		}
-
-		int out_present;
-		char* val;
-		int vallen;
-		fdb_check(f1.get(&out_present, (const uint8_t**)&val, &vallen));
-
-		REQUIRE(out_present);
-		uint64_t token = std::stoul(std::string(val, vallen));
-		CHECK(token != 0);
-		break;
-	}
-}
-
-TEST_CASE("special-key-space valid token") {
-	auto value = get_value("\xff\xff/tracing/token", /* snapshot */ false, {});
-	REQUIRE(value.has_value());
-	uint64_t token = std::stoul(value.value());
-	CHECK(token > 0);
-}
+// TEST_CASE("special-key-space valid token") {
+// 	auto value = get_value("\xff\xff/tracing/token", /* snapshot */ false, {});
+// 	REQUIRE(value.has_value());
+// 	uint64_t token = std::stoul(value.value());
+// 	CHECK(token > 0);
+// }
 
 TEST_CASE("special-key-space disable tracing") {
 	fdb::Transaction tr(db);
@@ -1965,7 +1965,7 @@ TEST_CASE("special-key-space tracing get range") {
 		CHECK(out_count == 2);
 
 		CHECK(std::string((char*)out_kv[0].key, out_kv[0].key_length) == tracingBegin + "token");
-		CHECK(std::stoul(std::string((char*)out_kv[0].value, out_kv[0].value_length)) > 0);
+		// CHECK(std::stoul(std::string((char*)out_kv[0].value, out_kv[0].value_length)) > 0);
 		CHECK(std::string((char*)out_kv[1].key, out_kv[1].key_length) == tracingBegin + "transaction_id");
 		CHECK(std::stoul(std::string((char*)out_kv[1].value, out_kv[1].value_length)) > 0);
 		break;

--- a/bindings/c/test/unit/unit_tests.cpp
+++ b/bindings/c/test/unit/unit_tests.cpp
@@ -1828,40 +1828,50 @@ TEST_CASE("special-key-space set transaction ID after write") {
 	}
 }
 
-// TEST_CASE("special-key-space set token after write") {
-// 	fdb::Transaction tr(db);
-// 	fdb_check(tr.set_option(FDB_TR_OPTION_SPECIAL_KEY_SPACE_ENABLE_WRITES, nullptr, 0));
-// 	while (1) {
-// 		tr.set(key("foo"), "bar");
-// 		tr.set("\xff\xff/tracing/token", "false");
-// 		fdb::ValueFuture f1 = tr.get("\xff\xff/tracing/token",
-// 		                             /* snapshot */ false);
-//
-// 		fdb_error_t err = wait_future(f1);
-// 		if (err) {
-// 			fdb::EmptyFuture f2 = tr.on_error(err);
-// 			fdb_check(wait_future(f2));
-// 			continue;
-// 		}
-//
-// 		int out_present;
-// 		char* val;
-// 		int vallen;
-// 		fdb_check(f1.get(&out_present, (const uint8_t**)&val, &vallen));
-//
-// 		REQUIRE(out_present);
-// 		uint64_t token = std::stoul(std::string(val, vallen));
-// 		CHECK(token != 0);
-// 		break;
-// 	}
-// }
+TEST_CASE("special-key-space set token after write") {
+	int64_t trace_sample_rate = 1000000;
+	fdb_check(fdb_database_set_option(db,
+	                                  FDB_DB_OPTION_DISTRIBUTED_TRANSACTION_TRACE_SAMPLE_RATE,
+	                                  (const uint8_t*)&trace_sample_rate,
+	                                  sizeof(trace_sample_rate)));
+	fdb::Transaction tr(db);
+	fdb_check(tr.set_option(FDB_TR_OPTION_SPECIAL_KEY_SPACE_ENABLE_WRITES, nullptr, 0));
+	while (1) {
+		tr.set(key("foo"), "bar");
+		tr.set("\xff\xff/tracing/token", "false");
+		fdb::ValueFuture f1 = tr.get("\xff\xff/tracing/token",
+		                             /* snapshot */ false);
 
-// TEST_CASE("special-key-space valid token") {
-// 	auto value = get_value("\xff\xff/tracing/token", /* snapshot */ false, {});
-// 	REQUIRE(value.has_value());
-// 	uint64_t token = std::stoul(value.value());
-// 	CHECK(token > 0);
-// }
+		fdb_error_t err = wait_future(f1);
+		if (err) {
+			fdb::EmptyFuture f2 = tr.on_error(err);
+			fdb_check(wait_future(f2));
+			continue;
+		}
+
+		int out_present;
+		char* val;
+		int vallen;
+		fdb_check(f1.get(&out_present, (const uint8_t**)&val, &vallen));
+
+		REQUIRE(out_present);
+		uint64_t token = std::stoul(std::string(val, vallen));
+		CHECK(token != 0);
+		break;
+	}
+}
+
+TEST_CASE("special-key-space valid token") {
+	int64_t trace_sample_rate = 1000000;
+	fdb_check(fdb_database_set_option(db,
+	                                  FDB_DB_OPTION_DISTRIBUTED_TRANSACTION_TRACE_SAMPLE_RATE,
+	                                  (const uint8_t*)&trace_sample_rate,
+	                                  sizeof(trace_sample_rate)));
+	auto value = get_value("\xff\xff/tracing/token", /* snapshot */ false, {});
+	REQUIRE(value.has_value());
+	uint64_t token = std::stoul(value.value());
+	CHECK(token > 0);
+}
 
 TEST_CASE("special-key-space disable tracing") {
 	fdb::Transaction tr(db);
@@ -1891,18 +1901,30 @@ TEST_CASE("special-key-space disable tracing") {
 }
 
 TEST_CASE("FDB_DB_OPTION_DISTRIBUTED_TRANSACTION_TRACE_DISABLE") {
-	fdb_check(fdb_database_set_option(db, FDB_DB_OPTION_DISTRIBUTED_TRANSACTION_TRACE_DISABLE, nullptr, 0));
+	int64_t trace_sample_rate = 0;
+	fdb_check(fdb_database_set_option(db,
+	                                  FDB_DB_OPTION_DISTRIBUTED_TRANSACTION_TRACE_SAMPLE_RATE,
+	                                  (const uint8_t*)&trace_sample_rate,
+	                                  sizeof(trace_sample_rate)));
 
 	auto value = get_value("\xff\xff/tracing/token", /* snapshot */ false, {});
 	REQUIRE(value.has_value());
 	uint64_t token = std::stoul(value.value());
 	CHECK(token == 0);
 
-	fdb_check(fdb_database_set_option(db, FDB_DB_OPTION_DISTRIBUTED_TRANSACTION_TRACE_ENABLE, nullptr, 0));
+	trace_sample_rate = 1000000;
+	fdb_check(fdb_database_set_option(db,
+	                                  FDB_DB_OPTION_DISTRIBUTED_TRANSACTION_TRACE_SAMPLE_RATE,
+	                                  (const uint8_t*)&trace_sample_rate,
+	                                  sizeof(trace_sample_rate)));
 }
 
 TEST_CASE("FDB_DB_OPTION_DISTRIBUTED_TRANSACTION_TRACE_DISABLE enable tracing for transaction") {
-	fdb_check(fdb_database_set_option(db, FDB_DB_OPTION_DISTRIBUTED_TRANSACTION_TRACE_DISABLE, nullptr, 0));
+	int64_t trace_sample_rate = 0;
+	fdb_check(fdb_database_set_option(db,
+	                                  FDB_DB_OPTION_DISTRIBUTED_TRANSACTION_TRACE_SAMPLE_RATE,
+	                                  (const uint8_t*)&trace_sample_rate,
+	                                  sizeof(trace_sample_rate)));
 
 	fdb::Transaction tr(db);
 	fdb_check(tr.set_option(FDB_TR_OPTION_SPECIAL_KEY_SPACE_ENABLE_WRITES, nullptr, 0));
@@ -1929,10 +1951,20 @@ TEST_CASE("FDB_DB_OPTION_DISTRIBUTED_TRANSACTION_TRACE_DISABLE enable tracing fo
 		break;
 	}
 
-	fdb_check(fdb_database_set_option(db, FDB_DB_OPTION_DISTRIBUTED_TRANSACTION_TRACE_ENABLE, nullptr, 0));
+	trace_sample_rate = 1000000;
+	fdb_check(fdb_database_set_option(db,
+	                                  FDB_DB_OPTION_DISTRIBUTED_TRANSACTION_TRACE_SAMPLE_RATE,
+	                                  (const uint8_t*)&trace_sample_rate,
+	                                  sizeof(trace_sample_rate)));
 }
 
 TEST_CASE("special-key-space tracing get range") {
+	int64_t trace_sample_rate = 1000000;
+	fdb_check(fdb_database_set_option(db,
+	                                  FDB_DB_OPTION_DISTRIBUTED_TRANSACTION_TRACE_SAMPLE_RATE,
+	                                  (const uint8_t*)&trace_sample_rate,
+	                                  sizeof(trace_sample_rate)));
+
 	std::string tracingBegin = "\xff\xff/tracing/";
 	std::string tracingEnd = "\xff\xff/tracing0";
 
@@ -1965,7 +1997,7 @@ TEST_CASE("special-key-space tracing get range") {
 		CHECK(out_count == 2);
 
 		CHECK(std::string((char*)out_kv[0].key, out_kv[0].key_length) == tracingBegin + "token");
-		// CHECK(std::stoul(std::string((char*)out_kv[0].value, out_kv[0].value_length)) > 0);
+		CHECK(std::stoul(std::string((char*)out_kv[0].value, out_kv[0].value_length)) > 0);
 		CHECK(std::string((char*)out_kv[1].key, out_kv[1].key_length) == tracingBegin + "transaction_id");
 		CHECK(std::stoul(std::string((char*)out_kv[1].value, out_kv[1].value_length)) > 0);
 		break;

--- a/bindings/c/test/unit/unit_tests.cpp
+++ b/bindings/c/test/unit/unit_tests.cpp
@@ -1828,41 +1828,6 @@ TEST_CASE("special-key-space set transaction ID after write") {
 	}
 }
 
-// TEST_CASE("special-key-space set token after write") {
-// 	fdb::Transaction tr(db);
-// 	fdb_check(tr.set_option(FDB_TR_OPTION_SPECIAL_KEY_SPACE_ENABLE_WRITES, nullptr, 0));
-// 	while (1) {
-// 		tr.set(key("foo"), "bar");
-// 		tr.set("\xff\xff/tracing/token", "false");
-// 		fdb::ValueFuture f1 = tr.get("\xff\xff/tracing/token",
-// 		                             /* snapshot */ false);
-//
-// 		fdb_error_t err = wait_future(f1);
-// 		if (err) {
-// 			fdb::EmptyFuture f2 = tr.on_error(err);
-// 			fdb_check(wait_future(f2));
-// 			continue;
-// 		}
-//
-// 		int out_present;
-// 		char* val;
-// 		int vallen;
-// 		fdb_check(f1.get(&out_present, (const uint8_t**)&val, &vallen));
-//
-// 		REQUIRE(out_present);
-// 		uint64_t token = std::stoul(std::string(val, vallen));
-// 		CHECK(token != 0);
-// 		break;
-// 	}
-// }
-
-// TEST_CASE("special-key-space valid token") {
-// 	auto value = get_value("\xff\xff/tracing/token", /* snapshot */ false, {});
-// 	REQUIRE(value.has_value());
-// 	uint64_t token = std::stoul(value.value());
-// 	CHECK(token > 0);
-// }
-
 TEST_CASE("special-key-space disable tracing") {
 	fdb::Transaction tr(db);
 	fdb_check(tr.set_option(FDB_TR_OPTION_SPECIAL_KEY_SPACE_ENABLE_WRITES, nullptr, 0));
@@ -1889,48 +1854,6 @@ TEST_CASE("special-key-space disable tracing") {
 		break;
 	}
 }
-
-// TEST_CASE("FDB_DB_OPTION_DISTRIBUTED_TRANSACTION_TRACE_DISABLE") {
-// 	fdb_check(fdb_database_set_option(db, FDB_DB_OPTION_DISTRIBUTED_TRANSACTION_TRACE_DISABLE, nullptr, 0));
-//
-// 	auto value = get_value("\xff\xff/tracing/token", /* snapshot */ false, {});
-// 	REQUIRE(value.has_value());
-// 	uint64_t token = std::stoul(value.value());
-// 	CHECK(token == 0);
-//
-// 	fdb_check(fdb_database_set_option(db, FDB_DB_OPTION_DISTRIBUTED_TRANSACTION_TRACE_ENABLE, nullptr, 0));
-// }
-
-// TEST_CASE("FDB_DB_OPTION_DISTRIBUTED_TRANSACTION_TRACE_DISABLE enable tracing for transaction") {
-// 	fdb_check(fdb_database_set_option(db, FDB_DB_OPTION_DISTRIBUTED_TRANSACTION_TRACE_DISABLE, nullptr, 0));
-//
-// 	fdb::Transaction tr(db);
-// 	fdb_check(tr.set_option(FDB_TR_OPTION_SPECIAL_KEY_SPACE_ENABLE_WRITES, nullptr, 0));
-// 	while (1) {
-// 		tr.set("\xff\xff/tracing/token", "true");
-// 		fdb::ValueFuture f1 = tr.get("\xff\xff/tracing/token",
-// 		                             /* snapshot */ false);
-//
-// 		fdb_error_t err = wait_future(f1);
-// 		if (err) {
-// 			fdb::EmptyFuture f2 = tr.on_error(err);
-// 			fdb_check(wait_future(f2));
-// 			continue;
-// 		}
-//
-// 		int out_present;
-// 		char* val;
-// 		int vallen;
-// 		fdb_check(f1.get(&out_present, (const uint8_t**)&val, &vallen));
-//
-// 		REQUIRE(out_present);
-// 		uint64_t token = std::stoul(std::string(val, vallen));
-// 		CHECK(token > 0);
-// 		break;
-// 	}
-//
-// 	fdb_check(fdb_database_set_option(db, FDB_DB_OPTION_DISTRIBUTED_TRANSACTION_TRACE_ENABLE, nullptr, 0));
-// }
 
 TEST_CASE("special-key-space tracing get range") {
 	std::string tracingBegin = "\xff\xff/tracing/";
@@ -1964,8 +1887,6 @@ TEST_CASE("special-key-space tracing get range") {
 		CHECK(!out_more);
 		CHECK(out_count == 2);
 
-		CHECK(std::string((char*)out_kv[0].key, out_kv[0].key_length) == tracingBegin + "token");
-		// CHECK(std::stoul(std::string((char*)out_kv[0].value, out_kv[0].value_length)) > 0);
 		CHECK(std::string((char*)out_kv[1].key, out_kv[1].key_length) == tracingBegin + "transaction_id");
 		CHECK(std::stoul(std::string((char*)out_kv[1].value, out_kv[1].value_length)) > 0);
 		break;

--- a/documentation/sphinx/source/request-tracing.rst
+++ b/documentation/sphinx/source/request-tracing.rst
@@ -85,25 +85,12 @@ Control options
 In addition to the command line parameter described above, tracing can be set
 at a database and transaction level.
 
-Tracing can be controlled by setting the
-``distributed_transaction_trace_sample_rate`` database option. Set this option
-to a value between 0 and 1,000,000, representing a fraction of traces to
-record. For example, to completely disable distributed tracing, set the value
-to 0. To trace half of all transactions, set the value to 500,000. Note that
-the value must be an integer. The initial distributed trace sample fraction is
-set by the knob ``TRACING_SAMPLE_RATE``.
+Tracing can be controlled on a global level by setting the
+``TRACING_SAMPLE_RATE`` knob. Set the knob to 0.0 to record no traces, to 1.0
+to record all traces, or somewhere in the middle. Traces are sampled as a unit.
+All individual spans in the trace will be included in the sample.
 
 Tracing can be enabled or disabled for individual transactions. The special key
 space exposes an API to set a custom trace ID for a transaction, or to disable
 tracing for the transaction. See the special key space :ref:`tracing module
 documentation <special-key-space-tracing-module>` to learn more.
-
-^^^^^^^^^^^^^^
-Trace sampling
-^^^^^^^^^^^^^^
-
-By default, all traces are recorded. If tracing is producing too much data,
-adjust the trace sample rate with the ``TRACING_SAMPLE_RATE`` knob. Set the
-knob to 0.0 to record no traces, to 1.0 to record all traces, or somewhere in
-the middle. Traces are sampled as a unit. All individual spans in the trace
-will be included in the sample.

--- a/documentation/sphinx/source/request-tracing.rst
+++ b/documentation/sphinx/source/request-tracing.rst
@@ -85,11 +85,13 @@ Control options
 In addition to the command line parameter described above, tracing can be set
 at a database and transaction level.
 
-Tracing can be globally disabled by setting the
-``distributed_transaction_trace_disable`` database option. It can be enabled by
-setting the ``distributed_transaction_trace_enable`` database option. If
-neither option is specified but a tracer option is set as described above,
-tracing will be enabled.
+Tracing can be controlled by setting the
+``distributed_transaction_trace_sample_rate`` database option. Set this option
+to a value between 0 and 1,000,000, representing a fraction of traces to
+record. For example, to completely disable distributed tracing, set the value
+to 0. To trace half of all transactions, set the value to 500,000. Note that
+the value must be an integer. The initial distributed trace sample fraction is
+set by the knob ``TRACING_SAMPLE_RATE``.
 
 Tracing can be enabled or disabled for individual transactions. The special key
 space exposes an API to set a custom trace ID for a transaction, or to disable

--- a/fdbclient/DatabaseContext.h
+++ b/fdbclient/DatabaseContext.h
@@ -404,7 +404,8 @@ public:
 
 	int snapshotRywEnabled;
 
-	int transactionTracingEnabled;
+	double transactionTracingSampleRate;
+	bool transactionTracingSample;
 	double verifyCausalReadsProp = 0.0;
 
 	Future<Void> logger;

--- a/fdbclient/DatabaseContext.h
+++ b/fdbclient/DatabaseContext.h
@@ -404,7 +404,6 @@ public:
 
 	int snapshotRywEnabled;
 
-	double transactionTracingSampleRate;
 	bool transactionTracingSample;
 	double verifyCausalReadsProp = 0.0;
 

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -1212,10 +1212,10 @@ DatabaseContext::DatabaseContext(Reference<AsyncVar<Reference<IClusterConnection
     transactionsExpensiveClearCostEstCount("ExpensiveClearCostEstCount", cc),
     transactionGrvFullBatches("NumGrvFullBatches", cc), transactionGrvTimedOutBatches("NumGrvTimedOutBatches", cc),
     latencies(1000), readLatencies(1000), commitLatencies(1000), GRVLatencies(1000), mutationsPerCommit(1000),
-    bytesPerCommit(1000), outstandingWatches(0), transactionTracingSampleRate(FLOW_KNOBS->TRACING_SAMPLE_RATE),
-    transactionTracingSample(false), taskID(taskID), clientInfo(clientInfo), clientInfoMonitor(clientInfoMonitor),
-    coordinator(coordinator), apiVersion(apiVersion), mvCacheInsertLocation(0), healthMetricsLastUpdated(0),
-    detailedHealthMetricsLastUpdated(0), smoothMidShardSize(CLIENT_KNOBS->SHARD_STAT_SMOOTH_AMOUNT),
+    bytesPerCommit(1000), outstandingWatches(0), transactionTracingSample(false), taskID(taskID),
+    clientInfo(clientInfo), clientInfoMonitor(clientInfoMonitor), coordinator(coordinator), apiVersion(apiVersion),
+    mvCacheInsertLocation(0), healthMetricsLastUpdated(0), detailedHealthMetricsLastUpdated(0),
+    smoothMidShardSize(CLIENT_KNOBS->SHARD_STAT_SMOOTH_AMOUNT),
     specialKeySpace(std::make_unique<SpecialKeySpace>(specialKeys.begin, specialKeys.end, /* test */ false)) {
 	dbId = deterministicRandom()->randomUniqueID();
 	connected = (clientInfo->get().commitProxies.size() && clientInfo->get().grvProxies.size())
@@ -1467,8 +1467,7 @@ DatabaseContext::DatabaseContext(const Error& err)
     transactionsExpensiveClearCostEstCount("ExpensiveClearCostEstCount", cc),
     transactionGrvFullBatches("NumGrvFullBatches", cc), transactionGrvTimedOutBatches("NumGrvTimedOutBatches", cc),
     latencies(1000), readLatencies(1000), commitLatencies(1000), GRVLatencies(1000), mutationsPerCommit(1000),
-    bytesPerCommit(1000), transactionTracingSampleRate(FLOW_KNOBS->TRACING_SAMPLE_RATE),
-    transactionTracingSample(false), smoothMidShardSize(CLIENT_KNOBS->SHARD_STAT_SMOOTH_AMOUNT) {}
+    bytesPerCommit(1000), transactionTracingSample(false), smoothMidShardSize(CLIENT_KNOBS->SHARD_STAT_SMOOTH_AMOUNT) {}
 
 // Static constructor used by server processes to create a DatabaseContext
 // For internal (fdbserver) use only
@@ -1666,10 +1665,6 @@ void DatabaseContext::setOption(FDBDatabaseOptions::Option option, Optional<Stri
 		case FDBDatabaseOptions::SNAPSHOT_RYW_DISABLE:
 			validateOptionValueNotPresent(value);
 			snapshotRywEnabled--;
-			break;
-		case FDBDatabaseOptions::DISTRIBUTED_TRANSACTION_TRACE_SAMPLE_RATE:
-			transactionTracingSampleRate = double(extractIntOption(value, 0, 1000000)) / 1000000.0;
-			setDistributedTraceSampleRate(transactionTracingSampleRate);
 			break;
 		case FDBDatabaseOptions::USE_CONFIG_DATABASE:
 			validateOptionValueNotPresent(value);
@@ -4202,7 +4197,7 @@ void debugAddTags(Transaction* tr) {
 	}
 }
 
-SpanID generateSpanID(Database const& cx, SpanID parentContext = SpanID()) {
+SpanID generateSpanID(bool transactionTracingSample, SpanID parentContext = SpanID()) {
 	uint64_t txnId = deterministicRandom()->randomUInt64();
 	if (parentContext.isValid()) {
 		if (parentContext.first() > 0) {
@@ -4210,8 +4205,8 @@ SpanID generateSpanID(Database const& cx, SpanID parentContext = SpanID()) {
 		}
 		uint64_t tokenId = parentContext.second() > 0 ? deterministicRandom()->randomUInt64() : 0;
 		return SpanID(txnId, tokenId);
-	} else if (cx.getPtr() != nullptr && cx->transactionTracingSample) {
-		uint64_t tokenId = deterministicRandom()->random01() <= cx->transactionTracingSampleRate
+	} else if (transactionTracingSample) {
+		uint64_t tokenId = deterministicRandom()->random01() <= FLOW_KNOBS->TRACING_SAMPLE_RATE
 		                       ? deterministicRandom()->randomUInt64()
 		                       : 0;
 		return SpanID(txnId, tokenId);
@@ -4220,12 +4215,12 @@ SpanID generateSpanID(Database const& cx, SpanID parentContext = SpanID()) {
 	}
 }
 
-Transaction::Transaction() : info(TaskPriority::DefaultEndpoint, generateSpanID(Database())) {}
+Transaction::Transaction() : info(TaskPriority::DefaultEndpoint, generateSpanID(false)) {}
 
 Transaction::Transaction(Database const& cx)
-  : info(cx->taskID, generateSpanID(cx)), numErrors(0), options(cx), span(info.spanID, "Transaction"_loc),
-    trLogInfo(createTrLogInfoProbabilistically(cx)), cx(cx), backoff(CLIENT_KNOBS->DEFAULT_BACKOFF),
-    committedVersion(invalidVersion), tr(info.spanID) {
+  : info(cx->taskID, generateSpanID(cx->transactionTracingSample)), numErrors(0), options(cx),
+    span(info.spanID, "Transaction"_loc), trLogInfo(createTrLogInfoProbabilistically(cx)), cx(cx),
+    backoff(CLIENT_KNOBS->DEFAULT_BACKOFF), committedVersion(invalidVersion), tr(info.spanID) {
 	if (DatabaseContext::debugUseTags) {
 		debugAddTags(this);
 	}
@@ -4848,7 +4843,7 @@ void Transaction::reset() {
 
 void Transaction::fullReset() {
 	reset();
-	info.spanID = generateSpanID(cx);
+	info.spanID = generateSpanID(cx->transactionTracingSample);
 	span = Span(info.spanID, "Transaction"_loc);
 	backoff = CLIENT_KNOBS->DEFAULT_BACKOFF;
 }
@@ -5372,7 +5367,7 @@ ACTOR Future<Void> commitAndWatch(Transaction* self) {
 		wait(self->commitMutations());
 
 		self->getDatabase()->transactionTracingSample =
-		    (self->getCommittedVersion() % 60000000) < (60000000 * self->getDatabase()->transactionTracingSampleRate);
+		    (self->getCommittedVersion() % 60000000) < (60000000 * FLOW_KNOBS->TRACING_SAMPLE_RATE);
 
 		if (!self->watches.empty()) {
 			self->setupWatches();
@@ -5877,7 +5872,7 @@ Future<Version> Transaction::getReadVersion(uint32_t flags) {
 		}
 
 		Location location = "NAPI:getReadVersion"_loc;
-		UID spanContext = generateSpanID(cx, info.spanID);
+		UID spanContext = generateSpanID(cx->transactionTracingSample, info.spanID);
 		auto const req = DatabaseContext::VersionRequest(spanContext, options.tags, info.debugID);
 		batcher.stream.send(req);
 		startTime = now();
@@ -6240,7 +6235,7 @@ ACTOR Future<std::pair<Optional<StorageMetrics>, int>> waitStorageMetrics(Databa
                                                                           StorageMetrics permittedError,
                                                                           int shardLimit,
                                                                           int expectedShardCount) {
-	state Span span("NAPI:WaitStorageMetrics"_loc, generateSpanID(cx));
+	state Span span("NAPI:WaitStorageMetrics"_loc, generateSpanID(cx->transactionTracingSample));
 	loop {
 		std::vector<std::pair<KeyRange, Reference<LocationInfo>>> locations =
 		    wait(getKeyRangeLocations(cx,

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -93,9 +93,6 @@ namespace {
 TransactionLineageCollector transactionLineageCollector;
 NameLineageCollector nameLineageCollector;
 
-// Set to true when new transactions should enable distributed trace recording.
-bool transactionTracingSample = false;
-
 template <class Interface, class Request>
 Future<REPLY_TYPE(Request)> loadBalance(
     DatabaseContext* ctx,
@@ -1215,10 +1212,10 @@ DatabaseContext::DatabaseContext(Reference<AsyncVar<Reference<IClusterConnection
     transactionsExpensiveClearCostEstCount("ExpensiveClearCostEstCount", cc),
     transactionGrvFullBatches("NumGrvFullBatches", cc), transactionGrvTimedOutBatches("NumGrvTimedOutBatches", cc),
     latencies(1000), readLatencies(1000), commitLatencies(1000), GRVLatencies(1000), mutationsPerCommit(1000),
-    bytesPerCommit(1000), outstandingWatches(0), transactionTracingEnabled(true), taskID(taskID),
-    clientInfo(clientInfo), clientInfoMonitor(clientInfoMonitor), coordinator(coordinator), apiVersion(apiVersion),
-    mvCacheInsertLocation(0), healthMetricsLastUpdated(0), detailedHealthMetricsLastUpdated(0),
-    smoothMidShardSize(CLIENT_KNOBS->SHARD_STAT_SMOOTH_AMOUNT),
+    bytesPerCommit(1000), outstandingWatches(0), transactionTracingSampleRate(FLOW_KNOBS->TRACING_SAMPLE_RATE),
+    transactionTracingSample(false), taskID(taskID), clientInfo(clientInfo), clientInfoMonitor(clientInfoMonitor),
+    coordinator(coordinator), apiVersion(apiVersion), mvCacheInsertLocation(0), healthMetricsLastUpdated(0),
+    detailedHealthMetricsLastUpdated(0), smoothMidShardSize(CLIENT_KNOBS->SHARD_STAT_SMOOTH_AMOUNT),
     specialKeySpace(std::make_unique<SpecialKeySpace>(specialKeys.begin, specialKeys.end, /* test */ false)) {
 	dbId = deterministicRandom()->randomUniqueID();
 	connected = (clientInfo->get().commitProxies.size() && clientInfo->get().grvProxies.size())
@@ -1470,7 +1467,8 @@ DatabaseContext::DatabaseContext(const Error& err)
     transactionsExpensiveClearCostEstCount("ExpensiveClearCostEstCount", cc),
     transactionGrvFullBatches("NumGrvFullBatches", cc), transactionGrvTimedOutBatches("NumGrvTimedOutBatches", cc),
     latencies(1000), readLatencies(1000), commitLatencies(1000), GRVLatencies(1000), mutationsPerCommit(1000),
-    bytesPerCommit(1000), transactionTracingEnabled(true), smoothMidShardSize(CLIENT_KNOBS->SHARD_STAT_SMOOTH_AMOUNT) {}
+    bytesPerCommit(1000), transactionTracingSampleRate(FLOW_KNOBS->TRACING_SAMPLE_RATE),
+    transactionTracingSample(false), smoothMidShardSize(CLIENT_KNOBS->SHARD_STAT_SMOOTH_AMOUNT) {}
 
 // Static constructor used by server processes to create a DatabaseContext
 // For internal (fdbserver) use only
@@ -1669,13 +1667,9 @@ void DatabaseContext::setOption(FDBDatabaseOptions::Option option, Optional<Stri
 			validateOptionValueNotPresent(value);
 			snapshotRywEnabled--;
 			break;
-		case FDBDatabaseOptions::DISTRIBUTED_TRANSACTION_TRACE_ENABLE:
-			validateOptionValueNotPresent(value);
-			transactionTracingEnabled++;
-			break;
-		case FDBDatabaseOptions::DISTRIBUTED_TRANSACTION_TRACE_DISABLE:
-			validateOptionValueNotPresent(value);
-			transactionTracingEnabled--;
+		case FDBDatabaseOptions::DISTRIBUTED_TRANSACTION_TRACE_SAMPLE_RATE:
+			transactionTracingSampleRate = double(extractIntOption(value, 0, 1000000)) / 1000000.0;
+			setDistributedTraceSampleRate(transactionTracingSampleRate);
 			break;
 		case FDBDatabaseOptions::USE_CONFIG_DATABASE:
 			validateOptionValueNotPresent(value);
@@ -4208,7 +4202,7 @@ void debugAddTags(Transaction* tr) {
 	}
 }
 
-SpanID generateSpanID(bool transactionTracingEnabled, SpanID parentContext = SpanID()) {
+SpanID generateSpanID(Database const& cx, SpanID parentContext = SpanID()) {
 	uint64_t txnId = deterministicRandom()->randomUInt64();
 	if (parentContext.isValid()) {
 		if (parentContext.first() > 0) {
@@ -4216,8 +4210,8 @@ SpanID generateSpanID(bool transactionTracingEnabled, SpanID parentContext = Spa
 		}
 		uint64_t tokenId = parentContext.second() > 0 ? deterministicRandom()->randomUInt64() : 0;
 		return SpanID(txnId, tokenId);
-	} else if (transactionTracingEnabled && transactionTracingSample) {
-		uint64_t tokenId = deterministicRandom()->random01() <= FLOW_KNOBS->TRACING_SAMPLE_RATE
+	} else if (cx.getPtr() != nullptr && cx->transactionTracingSample) {
+		uint64_t tokenId = deterministicRandom()->random01() <= cx->transactionTracingSampleRate
 		                       ? deterministicRandom()->randomUInt64()
 		                       : 0;
 		return SpanID(txnId, tokenId);
@@ -4226,12 +4220,12 @@ SpanID generateSpanID(bool transactionTracingEnabled, SpanID parentContext = Spa
 	}
 }
 
-Transaction::Transaction() : info(TaskPriority::DefaultEndpoint, generateSpanID(false)) {}
+Transaction::Transaction() : info(TaskPriority::DefaultEndpoint, generateSpanID(Database())) {}
 
 Transaction::Transaction(Database const& cx)
-  : info(cx->taskID, generateSpanID(cx->transactionTracingEnabled)), numErrors(0), options(cx),
-    span(info.spanID, "Transaction"_loc), trLogInfo(createTrLogInfoProbabilistically(cx)), cx(cx),
-    backoff(CLIENT_KNOBS->DEFAULT_BACKOFF), committedVersion(invalidVersion), tr(info.spanID) {
+  : info(cx->taskID, generateSpanID(cx)), numErrors(0), options(cx), span(info.spanID, "Transaction"_loc),
+    trLogInfo(createTrLogInfoProbabilistically(cx)), cx(cx), backoff(CLIENT_KNOBS->DEFAULT_BACKOFF),
+    committedVersion(invalidVersion), tr(info.spanID) {
 	if (DatabaseContext::debugUseTags) {
 		debugAddTags(this);
 	}
@@ -4854,7 +4848,7 @@ void Transaction::reset() {
 
 void Transaction::fullReset() {
 	reset();
-	info.spanID = generateSpanID(cx->transactionTracingEnabled);
+	info.spanID = generateSpanID(cx);
 	span = Span(info.spanID, "Transaction"_loc);
 	backoff = CLIENT_KNOBS->DEFAULT_BACKOFF;
 }
@@ -5166,7 +5160,6 @@ ACTOR static Future<Void> tryCommit(Database cx,
 			}
 			when(CommitID ci = wait(reply)) {
 				Version v = ci.version;
-				transactionTracingSample = (v % 60000000) < (60000000 * FLOW_KNOBS->TRACING_SAMPLE_RATE);
 				if (v != invalidVersion) {
 					if (CLIENT_BUGGIFY) {
 						throw commit_unknown_result();
@@ -5377,6 +5370,9 @@ Future<Void> Transaction::commitMutations() {
 ACTOR Future<Void> commitAndWatch(Transaction* self) {
 	try {
 		wait(self->commitMutations());
+
+		self->getDatabase()->transactionTracingSample =
+		    (self->getCommittedVersion() % 60000000) < (60000000 * self->getDatabase()->transactionTracingSampleRate);
 
 		if (!self->watches.empty()) {
 			self->setupWatches();
@@ -5881,7 +5877,7 @@ Future<Version> Transaction::getReadVersion(uint32_t flags) {
 		}
 
 		Location location = "NAPI:getReadVersion"_loc;
-		UID spanContext = generateSpanID(cx->transactionTracingEnabled, info.spanID);
+		UID spanContext = generateSpanID(cx, info.spanID);
 		auto const req = DatabaseContext::VersionRequest(spanContext, options.tags, info.debugID);
 		batcher.stream.send(req);
 		startTime = now();
@@ -6244,7 +6240,7 @@ ACTOR Future<std::pair<Optional<StorageMetrics>, int>> waitStorageMetrics(Databa
                                                                           StorageMetrics permittedError,
                                                                           int shardLimit,
                                                                           int expectedShardCount) {
-	state Span span("NAPI:WaitStorageMetrics"_loc, generateSpanID(cx->transactionTracingEnabled));
+	state Span span("NAPI:WaitStorageMetrics"_loc, generateSpanID(cx));
 	loop {
 		std::vector<std::pair<KeyRange, Reference<LocationInfo>>> locations =
 		    wait(getKeyRangeLocations(cx,

--- a/fdbclient/vexillographer/fdb.options
+++ b/fdbclient/vexillographer/fdb.options
@@ -191,9 +191,6 @@ description is not currently required but encouraged.
     <Option name="transaction_include_port_in_address" code="505"
             description="Addresses returned by get_addresses_for_key include the port when enabled. As of api version 630, this option is enabled by default and setting this has no effect."
             defaultFor="23"/>
-    <Option name="distributed_transaction_trace_sample_rate" code="600"
-            paramType="Int" paramDescription="value representing the fraction of distributed traces to record"
-            description="An integer between 0 and 1,000,000 (default is 0) expressing the fraction of distributed traces to record." />
     <Option name="transaction_bypass_unreadable" code="700"
             description="Allows ``get`` operations to read from sections of keyspace that have become unreadable because of versionstamp operations. This sets the ``bypass_unreadable`` option of each transaction created by this database. See the transaction option description for more information."
             defaultFor="1100"/>

--- a/fdbclient/vexillographer/fdb.options
+++ b/fdbclient/vexillographer/fdb.options
@@ -191,10 +191,9 @@ description is not currently required but encouraged.
     <Option name="transaction_include_port_in_address" code="505"
             description="Addresses returned by get_addresses_for_key include the port when enabled. As of api version 630, this option is enabled by default and setting this has no effect."
             defaultFor="23"/>
-    <Option name="distributed_transaction_trace_enable" code="600"
-            description="Enable tracing for all transactions. This is the default." />
-    <Option name="distributed_transaction_trace_disable" code="601"
-            description="Disable tracing for all transactions." />
+    <Option name="distributed_transaction_trace_sample_rate" code="600"
+            paramType="Int" paramDescription="value representing the fraction of distributed traces to record"
+            description="An integer between 0 and 1,000,000 (default is 0) expressing the fraction of distributed traces to record." />
     <Option name="transaction_bypass_unreadable" code="700"
             description="Allows ``get`` operations to read from sections of keyspace that have become unreadable because of versionstamp operations. This sets the ``bypass_unreadable`` option of each transaction created by this database. See the transaction option description for more information."
             defaultFor="1100"/>

--- a/fdbserver/GrvProxyServer.actor.cpp
+++ b/fdbserver/GrvProxyServer.actor.cpp
@@ -722,7 +722,7 @@ ACTOR static Future<Void> transactionStarter(GrvProxyInterface proxy,
 	state PrioritizedTransactionTagMap<ClientTagThrottleLimits> throttledTags;
 
 	state PromiseStream<double> normalGRVLatency;
-	state Span span;
+	// state Span span;
 
 	state int64_t midShardSize = SERVER_KNOBS->MIN_SHARD_BYTES;
 	getCurrentLineage()->modify(&TransactionLineage::operation) =
@@ -805,7 +805,7 @@ ACTOR static Future<Void> transactionStarter(GrvProxyInterface proxy,
 			} else {
 				break;
 			}
-			transactionQueue->span.swap(span);
+			// transactionQueue->span.swap(span);
 
 			auto& req = transactionQueue->front();
 			int tc = req.transactionCount;
@@ -886,7 +886,7 @@ ACTOR static Future<Void> transactionStarter(GrvProxyInterface proxy,
 		int batchGRVProcessed = 0;
 		for (int i = 0; i < start.size(); i++) {
 			if (start[i].size()) {
-				Future<GetReadVersionReply> readVersionReply = getLiveCommittedVersion(span.context,
+				Future<GetReadVersionReply> readVersionReply = getLiveCommittedVersion(UID() /*span.context*/,
 				                                                                       grvProxyData,
 				                                                                       i,
 				                                                                       debugID,
@@ -909,7 +909,7 @@ ACTOR static Future<Void> transactionStarter(GrvProxyInterface proxy,
 				batchGRVProcessed += batchPriTransactionsStarted[i];
 			}
 		}
-		span = Span(span.location);
+		// span = Span(span.location);
 
 		grvProxyData->stats.percentageOfDefaultGRVQueueProcessed =
 		    defaultQueueSize ? (double)defaultGRVProcessed / defaultQueueSize : 1;

--- a/fdbserver/GrvProxyServer.actor.cpp
+++ b/fdbserver/GrvProxyServer.actor.cpp
@@ -456,14 +456,14 @@ ACTOR Future<Void> queueGetReadVersionRequests(Reference<AsyncVar<ServerDBInfo> 
 					stats->txnSystemPriorityStartIn += req.transactionCount;
 					++stats->systemGRVQueueSize;
 					systemQueue->push_back(req);
-					systemQueue->span.addParent(req.spanContext);
+					// systemQueue->span.addParent(req.spanContext);
 				} else if (req.priority >= TransactionPriority::DEFAULT) {
 					++stats->txnRequestIn;
 					stats->txnStartIn += req.transactionCount;
 					stats->txnDefaultPriorityStartIn += req.transactionCount;
 					++stats->defaultGRVQueueSize;
 					defaultQueue->push_back(req);
-					defaultQueue->span.addParent(req.spanContext);
+					// defaultQueue->span.addParent(req.spanContext);
 				} else {
 					// Return error for batch_priority GRV requests
 					int64_t proxiesCount = std::max((int)db->get().client.grvProxies.size(), 1);
@@ -476,7 +476,7 @@ ACTOR Future<Void> queueGetReadVersionRequests(Reference<AsyncVar<ServerDBInfo> 
 						stats->txnBatchPriorityStartIn += req.transactionCount;
 						++stats->batchGRVQueueSize;
 						batchQueue->push_back(req);
-						batchQueue->span.addParent(req.spanContext);
+						// batchQueue->span.addParent(req.spanContext);
 					}
 				}
 			}

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -4617,6 +4617,7 @@ ACTOR Future<Void> update(StorageServer* data, bool* pReceivedUpdate) {
 				data->logProtocol = rd.protocolVersion();
 				data->storage.changeLogProtocol(ver, data->logProtocol);
 				cloneCursor2->setProtocolVersion(rd.protocolVersion());
+				spanContext = UID();
 			} else if (rd.protocolVersion().hasSpanContext() && SpanContextMessage::isNextIn(rd)) {
 				SpanContextMessage scm;
 				rd >> scm;

--- a/flow/Knobs.cpp
+++ b/flow/Knobs.cpp
@@ -68,7 +68,7 @@ void FlowKnobs::initialize(Randomize randomize, IsSimulated isSimulated) {
 	init( HUGE_ARENA_LOGGING_INTERVAL,                         5.0 );
 
 	init( WRITE_TRACING_ENABLED,                              true ); if( randomize && BUGGIFY ) WRITE_TRACING_ENABLED = false;
-	init( TRACING_SAMPLE_RATE,                                 1.0 ); // Fraction of traces (not spans) to sample (0 means ignore all traces)
+	init( TRACING_SAMPLE_RATE,                                 0.0 ); // Fraction of distributed traces (not spans) to sample (0 means ignore all traces)
 	init( TRACING_UDP_LISTENER_PORT,                          8889 ); // Only applicable if TracerType is set to a network option
 
 	//connectionMonitor

--- a/flow/Tracing.actor.cpp
+++ b/flow/Tracing.actor.cpp
@@ -349,6 +349,12 @@ ITracer* g_tracer = new NoopTracer();
 } // namespace
 #endif
 
+double distributedTraceSampleRate = 0;
+
+void setDistributedTraceSampleRate(double rate) {
+	distributedTraceSampleRate = rate;
+}
+
 void openTracer(TracerType type) {
 	if (g_tracer->type() == type) {
 		return;

--- a/flow/Tracing.actor.cpp
+++ b/flow/Tracing.actor.cpp
@@ -349,12 +349,6 @@ ITracer* g_tracer = new NoopTracer();
 } // namespace
 #endif
 
-double distributedTraceSampleRate = 0;
-
-void setDistributedTraceSampleRate(double rate) {
-	distributedTraceSampleRate = rate;
-}
-
 void openTracer(TracerType type) {
 	if (g_tracer->type() == type) {
 		return;

--- a/flow/Tracing.h
+++ b/flow/Tracing.h
@@ -25,6 +25,8 @@
 #include <unordered_set>
 #include <atomic>
 
+extern double distributedTraceSampleRate;
+
 struct Location {
 	StringRef name;
 };
@@ -49,9 +51,8 @@ struct Span {
 	}
 	Span(Location location, std::initializer_list<SpanID> const& parents = {})
 	  : Span(UID(deterministicRandom()->randomUInt64(),
-	             deterministicRandom()->random01() < FLOW_KNOBS->TRACING_SAMPLE_RATE
-	                 ? deterministicRandom()->randomUInt64()
-	                 : 0),
+	             deterministicRandom()->random01() < distributedTraceSampleRate ? deterministicRandom()->randomUInt64()
+	                                                                            : 0),
 	         location,
 	         parents) {}
 	Span(Location location, SpanID context) : Span(location, { context }) {}
@@ -105,6 +106,8 @@ struct Span {
 	SmallVectorRef<SpanID> parents;
 	std::unordered_map<StringRef, StringRef> tags;
 };
+
+void setDistributedTraceSampleRate(double rate);
 
 // The user selects a tracer using a string passed to fdbserver on boot.
 // Clients should not refer to TracerType directly, and mappings of names to

--- a/flow/Tracing.h
+++ b/flow/Tracing.h
@@ -106,8 +106,6 @@ struct Span {
 	std::unordered_map<StringRef, StringRef> tags;
 };
 
-void setDistributedTraceSampleRate(double rate);
-
 // The user selects a tracer using a string passed to fdbserver on boot.
 // Clients should not refer to TracerType directly, and mappings of names to
 // values in this enum can change without notice.

--- a/flow/Tracing.h
+++ b/flow/Tracing.h
@@ -44,12 +44,13 @@ struct Span {
 			this->context = SpanID((*parents.begin()).first(), traceId);
 		}
 	}
-	Span(Location location, std::initializer_list<SpanID> const& parents = {}) {
-		uint64_t tokenId = deterministicRandom()->random01() < FLOW_KNOBS->TRACING_SAMPLE_RATE
-		                       ? deterministicRandom()->randomUInt64()
-		                       : 0;
-		Span(UID(deterministicRandom()->randomUInt64(), tokenId), location, parents);
-	}
+	Span(Location location, std::initializer_list<SpanID> const& parents = {})
+	  : Span(UID(deterministicRandom()->randomUInt64(),
+	             deterministicRandom()->random01() < FLOW_KNOBS->TRACING_SAMPLE_RATE
+	                 ? deterministicRandom()->randomUInt64()
+	                 : 0),
+	         location,
+	         parents) {}
 	Span(Location location, SpanID context) : Span(location, { context }) {}
 	Span(const Span&) = delete;
 	Span(Span&& o) {
@@ -78,13 +79,12 @@ struct Span {
 
 	void addParent(SpanID span) {
 		if (parents.size() == 0) {
-			uint64_t traceId = (*parents.begin()).second() > 0 ? context.second() : 0;
 			// Use first parent to set trace ID. This is non-ideal for spans
 			// with multiple parents, because the trace ID will associate the
 			// span with only one trace. A workaround is to look at the parent
 			// relationships instead of the trace ID. Another option in the
 			// future is to keep a list of trace IDs.
-			context = SpanID(span.first(), traceId);
+			context = SpanID(span.first(), context.second());
 		}
 		parents.push_back(arena, span);
 	}

--- a/flow/Tracing.h
+++ b/flow/Tracing.h
@@ -25,8 +25,6 @@
 #include <unordered_set>
 #include <atomic>
 
-extern double distributedTraceSampleRate;
-
 struct Location {
 	StringRef name;
 };
@@ -51,8 +49,9 @@ struct Span {
 	}
 	Span(Location location, std::initializer_list<SpanID> const& parents = {})
 	  : Span(UID(deterministicRandom()->randomUInt64(),
-	             deterministicRandom()->random01() < distributedTraceSampleRate ? deterministicRandom()->randomUInt64()
-	                                                                            : 0),
+	             deterministicRandom()->random01() < FLOW_KNOBS->TRACING_SAMPLE_RATE
+	                 ? deterministicRandom()->randomUInt64()
+	                 : 0),
 	         location,
 	         parents) {}
 	Span(Location location, SpanID context) : Span(location, { context }) {}


### PR DESCRIPTION
Fixes some issues with spans not being recorded correctly. Also fixes some of the logic around distributed trace sampling. Now, traces are sampled in bunches. For example, if you want to sample 10 percent of distributed traces, all samples will be taken in the first six seconds of every minute, instead of evenly spreading the sampling out throughout the minute.

I gathered some data on the distribution of recorded spans and the breakdown of each span type. I ran

```
./bin/mako --cluster fdb.cluster --mode run --rows 1000000 --procs 8 --threads 256 --keylen 32 --vallen 16 --transaction "i8" --seconds 120 --trace
```

on a single FDB server binary with the `network_lossy` tracer type and `TRACING_SAMPLE_RATE` set to 0.25 (meaning there should be a 15 second continious window each minute where spans are recorded).

Here's the count of each type of span:

```
SRC:NAME	COUNT(*)
"SS:update"	36003
"NAPI:getReadVersion"	4824
"Transaction"	4685
"NAPI:tryCommit"	4368
"NAPI:readVersionBatcher"	295
"NAPI:getConsistentReadVersion"	277
"TPLS:push"	182
"MP:postResolution"	179
"MP:getResolution"	176
"R:resolveBatch"	174
"M:getVersion"	159
"MP:preresolutionProcessing"	154
"MP:commitBatch"	135
"TLog:tLogCommit"	133
"MP:reply"	133
"MP:transactionLogging"	128
"SS:getValue"	15
"NAPI:getValue"	11
"NAPI:getRange"	10
"SS:getKeyValues"	10
"SS:readRange"	10
"NAPI:WaitStorageMetrics"	8
"SS:watchWaitForValueChange"	7
"SS:watchValueWaitForVersion"	4
"SS:serveWatchValueRequestsImpl"	4
"NAPI:getRawVersion"	3
"SS:watchValue"	3
"NAPI:getKeyLocation"	1
```

And here is a graph of the distribution of the begin time of the collected spans:

<img width="1905" alt="Screen Shot 2021-11-02 at 5 16 48 PM" src="https://user-images.githubusercontent.com/68252610/139968857-4e8c19d1-f725-4a6f-9a42-f307a4dcd1f2.png">

We can see the distribution of span start times matches up with the `TRACING_SAMPLE_RATE` value.

Note that for now, `TRACING_SAMPLE_RATE` has been set to 0. We will selectively enable it when rolling out distributed trace collection.

Passed 10k correctness.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
