### PR TITLE
Use XXHash in Redwood

### DIFF
--- a/fdbserver/IPager.h
+++ b/fdbserver/IPager.h
@@ -26,7 +26,7 @@
 
 #include "flow/flow.h"
 #include "fdbclient/FDBTypes.h"
-#include "flow/crc32c.h"
+#include "flow/xxhash.h"
 
 #ifndef VALGRIND
 #define VALGRIND_MAKE_MEM_UNDEFINED(x, y)
@@ -101,7 +101,7 @@ public:
 
 	uint8_t* mutate() { return (uint8_t*)buffer; }
 
-	typedef uint32_t Checksum;
+	typedef XXH64_hash_t Checksum;
 
 	// Usable size, without checksum
 	int size() const { return logicalSize - sizeof(Checksum); }
@@ -143,7 +143,7 @@ public:
 
 	Checksum& getChecksum() { return *(Checksum*)(buffer + size()); }
 
-	Checksum calculateChecksum(LogicalPageID pageID) { return crc32c_append(pageID, buffer, size()); }
+	Checksum calculateChecksum(LogicalPageID pageID) { return XXH3_64bits_withSeed(buffer, size(), pageID); }
 
 	void updateChecksum(LogicalPageID pageID) { getChecksum() = calculateChecksum(pageID); }
 

--- a/fdbserver/VersionedBTree.actor.cpp
+++ b/fdbserver/VersionedBTree.actor.cpp
@@ -3629,7 +3629,7 @@ private:
 #pragma pack(push, 1)
 	// Header is the format of page 0 of the database
 	struct Header {
-		static constexpr int FORMAT_VERSION = 7;
+		static constexpr int FORMAT_VERSION = 8;
 		uint16_t formatVersion;
 		uint32_t queueCount;
 		uint32_t pageSize;
@@ -4601,7 +4601,7 @@ public:
 
 #pragma pack(push, 1)
 	struct MetaKey {
-		static constexpr int FORMAT_VERSION = 14;
+		static constexpr int FORMAT_VERSION = 15;
 		// This serves as the format version for the entire tree, individual pages will not be versioned
 		uint16_t formatVersion;
 		uint8_t height;

--- a/fdbserver/VersionedBTree.actor.cpp
+++ b/fdbserver/VersionedBTree.actor.cpp
@@ -4447,15 +4447,17 @@ struct BTreePage {
 				c.moveFirst();
 				ASSERT(c.valid());
 
-				bool anyOutOfRange = false;
 				do {
 					r += "  ";
 					r += c.get().toString(height == 1);
 
+					// Out of range entries are annotated but can actually be valid, as they can be the result of
+					// subtree deletion followed by incremental insertions of records in the deleted range being added
+					// to an adjacent subtree which is logically expanded encompass the deleted range but still is using
+					// the original subtree boundaries as DeltaTree2 boundaries.
 					bool tooLow = c.get().withoutValue() < lowerBound.withoutValue();
 					bool tooHigh = c.get().withoutValue() >= upperBound.withoutValue();
 					if (tooLow || tooHigh) {
-						anyOutOfRange = true;
 						if (tooLow) {
 							r += " (below decode lower bound)";
 						}
@@ -4466,12 +4468,6 @@ struct BTreePage {
 					r += "\n";
 
 				} while (c.moveNext());
-
-				// Out of range entries are actually okay now and the result of subtree deletion followed by
-				// incremental insertions of records in the deleted range being added to an adjacent subtree
-				// which is logically expanded encompass the deleted range but still is using the original
-				// subtree boundaries as DeltaTree2 boundaries.
-				// ASSERT(!anyOutOfRange);
 			}
 		} catch (Error& e) {
 			debug_printf("BTreePage::toString ERROR: %s\n", e.what());


### PR DESCRIPTION
Changed hash function from CRC32 to XXHash.

Passes 10k correctness (it's a simple change).

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
