### PR TITLE
Add Hostname struct, and fromHostname in NetworkAddress struct.

### DIFF
--- a/fdbclient/MonitorLeader.actor.cpp
+++ b/fdbclient/MonitorLeader.actor.cpp
@@ -49,11 +49,11 @@ std::string trim(std::string const& connectionString) {
 }
 
 std::string trimFromHostname(std::string const& networkAddress) {
-	std::string result = networkAddress;
-	if (result.find("(fromHostname)") != std::string::npos) {
-		return result.substr(0, result.find("(fromHostname)"));
+	const auto& pos = networkAddress.find("(fromHostname)");
+	if (pos != std::string::npos) {
+		return networkAddress.substr(0, pos);
 	}
-	return result;
+	return networkAddress;
 }
 
 } // namespace

--- a/fdbclient/MonitorLeader.actor.cpp
+++ b/fdbclient/MonitorLeader.actor.cpp
@@ -48,6 +48,14 @@ std::string trim(std::string const& connectionString) {
 	return trimmed;
 }
 
+std::string trimFromHostname(std::string const& networkAddress) {
+	std::string result = networkAddress;
+	if (result.find("(fromHostname)") != std::string::npos) {
+		return result.substr(0, result.find("(fromHostname)"));
+	}
+	return result;
+}
+
 } // namespace
 
 FDB_DEFINE_BOOLEAN_PARAM(ConnectionStringNeedsPersisted);
@@ -269,9 +277,10 @@ std::string ClusterConnectionString::toString() const {
 	std::string s = key.toString();
 	s += '@';
 	for (int i = 0; i < coord.size(); i++) {
-		if (i)
+		if (i) {
 			s += ',';
-		s += coord[i].toString();
+		}
+		s += trimFromHostname(coord[i].toString());
 	}
 	return s;
 }

--- a/fdbrpc/FlowTransport.actor.cpp
+++ b/fdbrpc/FlowTransport.actor.cpp
@@ -1261,8 +1261,11 @@ ACTOR static Future<Void> connectionReader(TransportData* transport,
 						} else {
 							peerProtocolVersion = protocolVersion;
 							if (pkt.canonicalRemotePort) {
-								peerAddress = NetworkAddress(
-								    pkt.canonicalRemoteIp(), pkt.canonicalRemotePort, true, peerAddress.isTLS());
+								peerAddress = NetworkAddress(pkt.canonicalRemoteIp(),
+								                             pkt.canonicalRemotePort,
+								                             true,
+								                             peerAddress.isTLS(),
+								                             peerAddress.fromHostname);
 							}
 							peer = transport->getOrOpenPeer(peerAddress, false);
 							peer->compatible = compatible;

--- a/flow/ProtocolVersion.h
+++ b/flow/ProtocolVersion.h
@@ -141,6 +141,7 @@ public: // introduced features
 	PROTOCOL_VERSION_FEATURE(0x0FDB00B070010001LL, TSS);
 	PROTOCOL_VERSION_FEATURE(0x0FDB00B070010001LL, ChangeFeed); // FIXME: Change to 7.1 once we cut release
 	PROTOCOL_VERSION_FEATURE(0x0FDB00B070010001LL, BlobGranule); // FIXME: Change to 7.1 once we cut release
+	PROTOCOL_VERSION_FEATURE(0x0FDB00B070010001LL, NetworkAddressHostnameFlag);
 };
 
 template <>

--- a/flow/network.cpp
+++ b/flow/network.cpp
@@ -90,9 +90,10 @@ NetworkAddress NetworkAddress::parse(std::string const& s) {
 	bool isTLS = false;
 	NetworkAddressFromHostname fromHostname = NetworkAddressFromHostname::False;
 	std::string f = s;
-	if (f.find("(fromHostname)") != std::string::npos) {
+	const auto& pos = f.find("(fromHostname)");
+	if (pos != std::string::npos) {
 		fromHostname = NetworkAddressFromHostname::True;
-		f = f.substr(0, f.find("(fromHostname)"));
+		f = f.substr(0, pos);
 	}
 	if (f.size() > 4 && strcmp(f.c_str() + f.size() - 4, ":tls") == 0) {
 		isTLS = true;

--- a/flow/network.cpp
+++ b/flow/network.cpp
@@ -63,7 +63,7 @@ bool IPAddress::isValid() const {
 	return std::get<uint32_t>(addr) != 0;
 }
 
-NetworkAddress NetworkAddress::parse(std::string const& s) {
+Hostname Hostname::parse(std::string const& s) {
 	if (s.empty()) {
 		throw connection_string_invalid();
 	}
@@ -75,6 +75,28 @@ NetworkAddress NetworkAddress::parse(std::string const& s) {
 		f = s.substr(0, s.size() - 4);
 	} else {
 		f = s;
+	}
+	auto colonPos = f.find_first_of(":");
+	return Hostname(f.substr(0, colonPos), f.substr(colonPos + 1), isTLS);
+}
+
+FDB_DEFINE_BOOLEAN_PARAM(NetworkAddressFromHostname);
+
+NetworkAddress NetworkAddress::parse(std::string const& s) {
+	if (s.empty()) {
+		throw connection_string_invalid();
+	}
+
+	bool isTLS = false;
+	NetworkAddressFromHostname fromHostname = NetworkAddressFromHostname::False;
+	std::string f = s;
+	if (f.find("(fromHostname)") != std::string::npos) {
+		fromHostname = NetworkAddressFromHostname::True;
+		f = f.substr(0, f.find("(fromHostname)"));
+	}
+	if (f.size() > 4 && strcmp(f.c_str() + f.size() - 4, ":tls") == 0) {
+		isTLS = true;
+		f = f.substr(0, f.size() - 4);
 	}
 
 	if (f[0] == '[') {
@@ -89,13 +111,13 @@ NetworkAddress NetworkAddress::parse(std::string const& s) {
 		if (!addr.present()) {
 			throw connection_string_invalid();
 		}
-		return NetworkAddress(addr.get(), port, true, isTLS);
+		return NetworkAddress(addr.get(), port, true, isTLS, fromHostname);
 	} else {
 		// TODO: Use IPAddress::parse
 		int a, b, c, d, port, count = -1;
 		if (sscanf(f.c_str(), "%d.%d.%d.%d:%d%n", &a, &b, &c, &d, &port, &count) < 5 || count != f.size())
 			throw connection_string_invalid();
-		return NetworkAddress((a << 24) + (b << 16) + (c << 8) + d, port, true, isTLS);
+		return NetworkAddress((a << 24) + (b << 16) + (c << 8) + d, port, true, isTLS, fromHostname);
 	}
 }
 
@@ -123,7 +145,11 @@ std::vector<NetworkAddress> NetworkAddress::parseList(std::string const& addrs) 
 }
 
 std::string NetworkAddress::toString() const {
-	return formatIpPort(ip, port) + (isTLS() ? ":tls" : "");
+	std::string ipString = formatIpPort(ip, port) + (isTLS() ? ":tls" : "");
+	if (fromHostname) {
+		return ipString + "(fromHostname)";
+	}
+	return ipString;
 }
 
 std::string toIPVectorString(const std::vector<uint32_t>& ips) {
@@ -158,8 +184,10 @@ Future<Reference<IConnection>> INetworkConnections::connect(const std::string& h
 	Future<NetworkAddress> pickEndpoint =
 	    map(resolveTCPEndpoint(host, service), [=](std::vector<NetworkAddress> const& addresses) -> NetworkAddress {
 		    NetworkAddress addr = addresses[deterministicRandom()->randomInt(0, addresses.size())];
-		    if (useTLS)
+		    addr.fromHostname = NetworkAddressFromHostname::True;
+		    if (useTLS) {
 			    addr.flags = NetworkAddress::FLAG_TLS;
+		    }
 		    return addr;
 	    });
 
@@ -185,15 +213,18 @@ TEST_CASE("/flow/network/ipaddress") {
 		auto addrCompressed = "[2001:db8:85a3::8a2e:370:7334]:4800";
 		ASSERT(addrParsed.isV6());
 		ASSERT(!addrParsed.isTLS());
+		ASSERT(addrParsed.fromHostname == NetworkAddressFromHostname::False);
+		ASSERT(addrParsed.toString() == addrCompressed);
 		ASSERT(addrParsed.toString() == addrCompressed);
 	}
 
 	{
-		auto addr = "[2001:0db8:85a3:0000:0000:8a2e:0370:7334]:4800:tls";
+		auto addr = "[2001:0db8:85a3:0000:0000:8a2e:0370:7334]:4800:tls(fromHostname)";
 		auto addrParsed = NetworkAddress::parse(addr);
-		auto addrCompressed = "[2001:db8:85a3::8a2e:370:7334]:4800:tls";
+		auto addrCompressed = "[2001:db8:85a3::8a2e:370:7334]:4800:tls(fromHostname)";
 		ASSERT(addrParsed.isV6());
 		ASSERT(addrParsed.isTLS());
+		ASSERT(addrParsed.fromHostname == NetworkAddressFromHostname::True);
 		ASSERT(addrParsed.toString() == addrCompressed);
 	}
 
@@ -216,6 +247,64 @@ TEST_CASE("/flow/network/ipaddress") {
 		auto addrParsed = IPAddress::parse(addr);
 		ASSERT(!addrParsed.present());
 	}
+
+	return Void();
+}
+
+TEST_CASE("/flow/network/hostname") {
+	std::string hn1s = "localhost:1234";
+	std::string hn2s = "host-name:1234";
+	std::string hn3s = "host.name:1234";
+	std::string hn4s = "host-name_part1.host-name_part2:1234:tls";
+
+	std::string hn5s = "127.0.0.1:1234";
+	std::string hn6s = "127.0.0.1:1234:tls";
+	std::string hn7s = "[2001:0db8:85a3:0000:0000:8a2e:0370:7334]:4800";
+	std::string hn8s = "[2001:0db8:85a3:0000:0000:8a2e:0370:7334]:4800:tls";
+	std::string hn9s = "2001:0db8:85a3:0000:0000:8a2e:0370:7334";
+	std::string hn10s = "2001:0db8:85a3:0000:0000:8a2e:0370:7334:tls";
+	std::string hn11s = "[::1]:4800";
+	std::string hn12s = "[::1]:4800:tls";
+	std::string hn13s = "1234";
+
+	auto hn1 = Hostname::parse(hn1s);
+	ASSERT(hn1.toString() == hn1s);
+	ASSERT(hn1.host == "localhost");
+	ASSERT(hn1.service == "1234");
+	ASSERT(!hn1.useTLS);
+
+	auto hn2 = Hostname::parse(hn2s);
+	ASSERT(hn2.toString() == hn2s);
+	ASSERT(hn2.host == "host-name");
+	ASSERT(hn2.service == "1234");
+	ASSERT(!hn2.useTLS);
+
+	auto hn3 = Hostname::parse(hn3s);
+	ASSERT(hn3.toString() == hn3s);
+	ASSERT(hn3.host == "host.name");
+	ASSERT(hn3.service == "1234");
+	ASSERT(!hn3.useTLS);
+
+	auto hn4 = Hostname::parse(hn4s);
+	ASSERT(hn4.toString() == hn4s);
+	ASSERT(hn4.host == "host-name_part1.host-name_part2");
+	ASSERT(hn4.service == "1234");
+	ASSERT(hn4.useTLS);
+
+	ASSERT(Hostname::isHostname(hn1s));
+	ASSERT(Hostname::isHostname(hn2s));
+	ASSERT(Hostname::isHostname(hn3s));
+	ASSERT(Hostname::isHostname(hn4s));
+
+	ASSERT(!Hostname::isHostname(hn5s));
+	ASSERT(!Hostname::isHostname(hn6s));
+	ASSERT(!Hostname::isHostname(hn7s));
+	ASSERT(!Hostname::isHostname(hn8s));
+	ASSERT(!Hostname::isHostname(hn9s));
+	ASSERT(!Hostname::isHostname(hn10s));
+	ASSERT(!Hostname::isHostname(hn11s));
+	ASSERT(!Hostname::isHostname(hn12s));
+	ASSERT(!Hostname::isHostname(hn13s));
 
 	return Void();
 }


### PR DESCRIPTION
This is a substep in supporting hostnames in cluster files. So that in fdbcli, `coordinator` command will print out whether the coordinators' network addresses are resolved from hostnames, e.g., `127.0.0.1:4501(fromHostname)`.

20211103-181211-renxuan-a8b9b501483ff61c           compressed=True data_size=27440027 duration=5716161 ended=100000 fail=1 fail_fast=10 max_runs=100000 pass=99999 priority=100 remaining=0 runtime=0:51:46 sanity=False started=100181 stopped=20211103-190357 submitted=20211103-181211 timeout=5400 username=renxuan
The failed test is an unrelated KillRegionCycle test.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
