### PR TITLE
Change dbinfo broadcast to be explicitly requested by the worker registration message

### DIFF
--- a/fdbserver/ClusterController.actor.cpp
+++ b/fdbserver/ClusterController.actor.cpp
@@ -3876,8 +3876,6 @@ ACTOR Future<Void> workerAvailabilityWatch(WorkerInterface worker,
 	        : waitFailureClient(worker.waitFailure, SERVER_KNOBS->WORKER_FAILURE_TIME);
 	cluster->updateWorkerList.set(worker.locality.processId(),
 	                              ProcessData(worker.locality, startingClass, worker.stableAddress()));
-	cluster->updateDBInfoEndpoints.insert(worker.updateServerDBInfo.getEndpoint());
-	cluster->updateDBInfo.trigger();
 	// This switching avoids a race where the worker can be added to id_worker map after the workerAvailabilityWatch
 	// fails for the worker.
 	wait(delay(0));
@@ -4295,6 +4293,10 @@ void registerWorker(RegisterWorkerRequest req, ClusterControllerData* self, Conf
 			    self->id_worker[w.locality.processId()].watcher,
 			    self->id_worker[w.locality.processId()].details.interf.configBroadcastInterface));
 		}
+		if (req.requestDbInfo) {
+			self->updateDBInfoEndpoints.insert(w.updateServerDBInfo.getEndpoint());
+			self->updateDBInfo.trigger();
+		}
 		checkOutstandingRequests(self);
 	} else if (info->second.details.interf.id() != w.id() || req.generation >= info->second.gen) {
 		if (!info->second.reply.isSet()) {
@@ -4309,9 +4311,12 @@ void registerWorker(RegisterWorkerRequest req, ClusterControllerData* self, Conf
 		info->second.issues = req.issues;
 
 		if (info->second.details.interf.id() != w.id()) {
-			self->removedDBInfoEndpoints.insert(info->second.details.interf.updateServerDBInfo.getEndpoint());
 			info->second.details.interf = w;
 			info->second.watcher = workerAvailabilityWatch(w, newProcessClass, self);
+		}
+		if (req.requestDbInfo) {
+			self->updateDBInfoEndpoints.insert(w.updateServerDBInfo.getEndpoint());
+			self->updateDBInfo.trigger();
 		}
 		if (configBroadcaster != nullptr) {
 			self->addActor.send(

--- a/fdbserver/ClusterController.actor.cpp
+++ b/fdbserver/ClusterController.actor.cpp
@@ -3876,8 +3876,6 @@ ACTOR Future<Void> workerAvailabilityWatch(WorkerInterface worker,
 	        : waitFailureClient(worker.waitFailure, SERVER_KNOBS->WORKER_FAILURE_TIME);
 	cluster->updateWorkerList.set(worker.locality.processId(),
 	                              ProcessData(worker.locality, startingClass, worker.stableAddress()));
-	cluster->updateDBInfoEndpoints.insert(worker.updateServerDBInfo.getEndpoint());
-	cluster->updateDBInfo.trigger();
 	// This switching avoids a race where the worker can be added to id_worker map after the workerAvailabilityWatch
 	// fails for the worker.
 	wait(delay(0));
@@ -4295,10 +4293,8 @@ void registerWorker(RegisterWorkerRequest req, ClusterControllerData* self, Conf
 			    self->id_worker[w.locality.processId()].watcher,
 			    self->id_worker[w.locality.processId()].details.interf.configBroadcastInterface));
 		}
-		if (req.requestDbInfo) {
-			self->updateDBInfoEndpoints.insert(w.updateServerDBInfo.getEndpoint());
-			self->updateDBInfo.trigger();
-		}
+		self->updateDBInfoEndpoints.insert(w.updateServerDBInfo.getEndpoint());
+		self->updateDBInfo.trigger();
 		checkOutstandingRequests(self);
 	} else if (info->second.details.interf.id() != w.id() || req.generation >= info->second.gen) {
 		if (!info->second.reply.isSet()) {

--- a/fdbserver/WorkerInterface.actor.h
+++ b/fdbserver/WorkerInterface.actor.h
@@ -413,6 +413,7 @@ struct RegisterWorkerRequest {
 	bool degraded;
 	Version lastSeenKnobVersion;
 	ConfigClassSet knobConfigClassSet;
+	bool requestDbInfo;
 
 	RegisterWorkerRequest()
 	  : priorityInfo(ProcessClass::UnsetFit, false, ClusterControllerPriorityInfo::FitnessUnknown), degraded(false) {}
@@ -429,7 +430,8 @@ struct RegisterWorkerRequest {
 	                      ConfigClassSet knobConfigClassSet)
 	  : wi(wi), initialClass(initialClass), processClass(processClass), priorityInfo(priorityInfo),
 	    generation(generation), distributorInterf(ddInterf), ratekeeperInterf(rkInterf), blobManagerInterf(bmInterf),
-	    degraded(degraded), lastSeenKnobVersion(lastSeenKnobVersion), knobConfigClassSet(knobConfigClassSet) {}
+	    degraded(degraded), lastSeenKnobVersion(lastSeenKnobVersion), knobConfigClassSet(knobConfigClassSet),
+	    requestDbInfo(false) {}
 
 	template <class Ar>
 	void serialize(Ar& ar) {
@@ -447,7 +449,8 @@ struct RegisterWorkerRequest {
 		           reply,
 		           degraded,
 		           lastSeenKnobVersion,
-		           knobConfigClassSet);
+		           knobConfigClassSet,
+		           requestDbInfo);
 	}
 };
 

--- a/fdbserver/worker.actor.cpp
+++ b/fdbserver/worker.actor.cpp
@@ -522,7 +522,8 @@ ACTOR Future<Void> registrationClient(Reference<AsyncVar<Optional<ClusterControl
                                       Reference<AsyncVar<bool> const> degraded,
                                       Reference<IClusterConnectionRecord> connRecord,
                                       Reference<AsyncVar<std::set<std::string>> const> issues,
-                                      Reference<LocalConfiguration> localConfig) {
+                                      Reference<LocalConfiguration> localConfig,
+                                      Reference<AsyncVar<ServerDBInfo>> dbInfo) {
 	// Keeps the cluster controller (as it may be re-elected) informed that this worker exists
 	// The cluster controller uses waitFailureClient to find out if we die, and returns from registrationReply
 	// (requiring us to re-register) The registration request piggybacks optional distributor interface if it exists.
@@ -533,7 +534,6 @@ ACTOR Future<Void> registrationClient(Reference<AsyncVar<Optional<ClusterControl
 	state Future<Void> cacheProcessFuture;
 	state Future<Void> cacheErrorsFuture;
 	state Optional<double> incorrectTime;
-	state UID lastCCInterfaceId = UID();
 	loop {
 		state ClusterConnectionString storedConnectionString;
 		state bool upToDate = true;
@@ -587,13 +587,12 @@ ACTOR Future<Void> registrationClient(Reference<AsyncVar<Optional<ClusterControl
 
 		state bool ccInterfacePresent = ccInterface->get().present();
 		if (ccInterfacePresent) {
-			request.requestDbInfo = (ccInterface->get().get().id() != lastCCInterfaceId);
+			request.requestDbInfo = (ccInterface->get().get().id() != dbInfo->get().clusterInterface.id());
 		}
 		state Future<RegisterWorkerReply> registrationReply =
 		    ccInterfacePresent ? brokenPromiseToNever(ccInterface->get().get().registerWorker.getReply(request))
 		                       : Never();
 		state double startTime = now();
-		lastCCInterfaceId = ccInterface->get().present() ? ccInterface->get().get().id() : UID();
 		loop choose {
 			when(RegisterWorkerReply reply = wait(registrationReply)) {
 				processClass = reply.processClass;
@@ -1614,7 +1613,8 @@ ACTOR Future<Void> workerServer(Reference<IClusterConnectionRecord> connRecord,
 		                                       degraded,
 		                                       connRecord,
 		                                       issues,
-		                                       localConfig));
+		                                       localConfig,
+		                                       dbInfo));
 
 		if (configDBType != ConfigDBType::DISABLED) {
 			errorForwarders.add(localConfig->consume(interf.configBroadcastInterface));

--- a/fdbserver/worker.actor.cpp
+++ b/fdbserver/worker.actor.cpp
@@ -534,6 +534,7 @@ ACTOR Future<Void> registrationClient(Reference<AsyncVar<Optional<ClusterControl
 	state Future<Void> cacheProcessFuture;
 	state Future<Void> cacheErrorsFuture;
 	state Optional<double> incorrectTime;
+	state bool firstReg = true;
 	loop {
 		state ClusterConnectionString storedConnectionString;
 		state bool upToDate = true;
@@ -588,6 +589,10 @@ ACTOR Future<Void> registrationClient(Reference<AsyncVar<Optional<ClusterControl
 		state bool ccInterfacePresent = ccInterface->get().present();
 		if (ccInterfacePresent) {
 			request.requestDbInfo = (ccInterface->get().get().id() != dbInfo->get().clusterInterface.id());
+			if (firstReg) {
+				request.requestDbInfo = true;
+				firstReg = false;
+			}
 		}
 		state Future<RegisterWorkerReply> registrationReply =
 		    ccInterfacePresent ? brokenPromiseToNever(ccInterface->get().get().registerWorker.getReply(request))


### PR DESCRIPTION
This issue first appeared in nightly correctness runs on master commit `020b02ea4c2af1e28d6087d36c84316d817fb5f8`.
Test: `tests/slow/ConfigureTest.toml`
Seed: `29463510`
Buggify: `off`

This test timed out due to Master Recovery getting stuck while attempting to recruit TLogs. The root of the issue was that a DBInfo broadcast to the worker was arriving very late, while at the same time the worker's CC interface also reverted to that of an older generation. Because of that, the stale generation's DBInfo was accepted and updated. The worker's CC interface eventually got updated back to the correct one, but it did not trigger the cluster controller to rebroadcast the DBInfo because it was receiving a worker registration request from a machine it had already seen before. This change makes it so that the client worker explicitly requests a rebroadcast of the DBInfo if the CC interface does not match the CC interface in the ServerDBInfo object held by the worker.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
