### PR TITLE
Changed FlowTransport to use XXHash instead of CRC32 (release-7.0)

### DIFF
--- a/fdbrpc/FlowTransport.actor.cpp
+++ b/fdbrpc/FlowTransport.actor.cpp
@@ -27,7 +27,6 @@
 #include <memcheck.h>
 #endif
 
-#include "flow/crc32c.h"
 #include "fdbrpc/fdbrpc.h"
 #include "fdbrpc/FailureMonitor.h"
 #include "fdbrpc/HealthMonitor.h"
@@ -41,6 +40,7 @@
 #include "flow/ObjectSerializer.h"
 #include "flow/ProtocolVersion.h"
 #include "flow/UnitTest.h"
+#include "flow/xxhash.h"
 #include "flow/actorcompiler.h" // This must be the last #include.
 
 static NetworkAddressList g_currentDeliveryPeerAddress = NetworkAddressList();
@@ -981,21 +981,22 @@ static void scanPackets(TransportData* transport,
 
 	const bool checksumEnabled = !peerAddress.isTLS();
 	loop {
-		uint32_t packetLen, packetChecksum;
+		uint32_t packetLen;
+		XXH64_hash_t packetChecksum;
 
-		// Retrieve packet length and checksum
+		// Read packet length if size is sufficient or stop
+		if (e - p < PACKET_LEN_WIDTH)
+			break;
+		packetLen = *(uint32_t*)p;
+		p += PACKET_LEN_WIDTH;
+
+		// Read checksum if present
 		if (checksumEnabled) {
-			if (e - p < sizeof(uint32_t) * 2)
+			// Read checksum if size is sufficient or stop
+			if (e - p < sizeof(packetChecksum))
 				break;
-			packetLen = *(uint32_t*)p;
-			p += PACKET_LEN_WIDTH;
-			packetChecksum = *(uint32_t*)p;
-			p += sizeof(uint32_t);
-		} else {
-			if (e - p < sizeof(uint32_t))
-				break;
-			packetLen = *(uint32_t*)p;
-			p += PACKET_LEN_WIDTH;
+			packetChecksum = *(XXH64_hash_t*)p;
+			p += sizeof(packetChecksum);
 		}
 
 		if (packetLen > FLOW_KNOBS->PACKET_LIMIT) {
@@ -1033,23 +1034,23 @@ static void scanPackets(TransportData* transport,
 				}
 			}
 
-			uint32_t calculatedChecksum = crc32c_append(0, p, packetLen);
+			XXH64_hash_t calculatedChecksum = XXH3_64bits(p, packetLen);
 			if (calculatedChecksum != packetChecksum) {
 				if (isBuggifyEnabled) {
 					TraceEvent(SevInfo, "ChecksumMismatchExp")
-					    .detail("PacketChecksum", (int)packetChecksum)
-					    .detail("CalculatedChecksum", (int)calculatedChecksum);
+					    .detail("PacketChecksum", packetChecksum)
+					    .detail("CalculatedChecksum", calculatedChecksum);
 				} else {
 					TraceEvent(SevWarnAlways, "ChecksumMismatchUnexp")
-					    .detail("PacketChecksum", (int)packetChecksum)
-					    .detail("CalculatedChecksum", (int)calculatedChecksum);
+					    .detail("PacketChecksum", packetChecksum)
+					    .detail("CalculatedChecksum", calculatedChecksum);
 				}
 				throw checksum_failed();
 			} else {
 				if (isBuggifyEnabled) {
 					TraceEvent(SevError, "ChecksumMatchUnexp")
-					    .detail("PacketChecksum", (int)packetChecksum)
-					    .detail("CalculatedChecksum", (int)calculatedChecksum);
+					    .detail("PacketChecksum", packetChecksum)
+					    .detail("CalculatedChecksum", calculatedChecksum);
 				}
 			}
 		}
@@ -1579,10 +1580,17 @@ static ReliablePacket* sendPacket(TransportData* self,
 
 	// Reserve some space for packet length and checksum, write them after serializing data
 	SplitBuffer packetInfoBuffer;
-	uint32_t len, checksum = 0;
+	uint32_t len;
+	XXH64_hash_t checksum = 0;
+	XXH3_state_t* checksumState = nullptr;
+
 	int packetInfoSize = PACKET_LEN_WIDTH;
 	if (checksumEnabled) {
 		packetInfoSize += sizeof(checksum);
+		checksumState = XXH3_createState();
+		if (XXH3_64bits_reset(checksumState) != XXH_OK) {
+			throw internal_error();
+		}
 	}
 
 	wr.writeAhead(packetInfoSize, &packetInfoBuffer);
@@ -1604,10 +1612,19 @@ static ReliablePacket* sendPacket(TransportData* self,
 		while (checksumUnprocessedLength > 0) {
 			uint32_t processLength =
 			    std::min(checksumUnprocessedLength, (uint32_t)(checksumPb->bytes_written - prevBytesWritten));
-			checksum = crc32c_append(checksum, checksumPb->data() + prevBytesWritten, processLength);
+			// This won't fail if inputs are non null
+			if (XXH3_64bits_update(checksumState, checksumPb->data() + prevBytesWritten, processLength) != XXH_OK) {
+				throw internal_error();
+			}
 			checksumUnprocessedLength -= processLength;
 			checksumPb = checksumPb->nextPacketBuffer();
 			prevBytesWritten = 0;
+		}
+
+		checksum = XXH3_64bits_digest(checksumState);
+		// This always returns OK
+		if (XXH3_freeState(checksumState) != XXH_OK) {
+			throw internal_error();
 		}
 	}
 


### PR DESCRIPTION
Cherry-pick of #5906
Changed FlowTransport to use XXHash instead of CRC32.

Passes 10k correctness.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
