### PR TITLE
Redwood inline same-size value updates

### DIFF
--- a/fdbserver/DeltaTree.h
+++ b/fdbserver/DeltaTree.h
@@ -1226,7 +1226,11 @@ public:
 			return item.get();
 		}
 
-		void switchTree(DeltaTree2* newTree) { tree = newTree; }
+		void switchTree(DeltaTree2* newTree) {
+			tree = newTree;
+			// Reset item because it may point into tree memory
+			item.reset();
+		}
 
 		// If the cursor is valid, return a reference to the cursor's internal T.
 		// Otherwise, returns a reference to the cache's upper boundary.


### PR DESCRIPTION
Refactored mutation application in leaf nodes to handle existing mutation boundary keys more efficiently and do in-place value string updates when an existing value is being replaced with a new value of the same length.

Passed 200k correctness only choosing Redwood storage.  

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
