### PR TITLE
Make sure unit tests are run often enough

### DIFF
--- a/fdbrpc/FlowTests.actor.cpp
+++ b/fdbrpc/FlowTests.actor.cpp
@@ -809,7 +809,7 @@ TEST_CASE("/flow/flow/chooseTwoActor") {
 	return Void();
 }
 
-TEST_CASE("/flow/flow/perf/actor patterns") {
+TEST_CASE("#flow/flow/perf/actor patterns") {
 	double start;
 	int N = 1000000;
 

--- a/fdbserver/OldTLogServer_6_0.actor.cpp
+++ b/fdbserver/OldTLogServer_6_0.actor.cpp
@@ -2886,40 +2886,4 @@ struct DequeAllocator : std::allocator<T> {
 	}
 };
 
-TEST_CASE("/fdbserver/tlogserver/VersionMessagesOverheadFactor") {
-
-	typedef std::pair<Version, LengthPrefixedStringRef> TestType; // type used by versionMessages
-
-	for (int i = 1; i < 9; ++i) {
-		for (int j = 0; j < 20; ++j) {
-			DequeAllocatorStats::allocatedBytes = 0;
-			DequeAllocator<TestType> allocator;
-			std::deque<TestType, DequeAllocator<TestType>> d(allocator);
-
-			int numElements = deterministicRandom()->randomInt(pow(10, i - 1), pow(10, i));
-			for (int k = 0; k < numElements; ++k) {
-				d.push_back(TestType());
-			}
-
-			int removedElements = 0; // deterministicRandom()->randomInt(0, numElements); // FIXME: the overhead factor
-			                         // does not accurately account for removal!
-			for (int k = 0; k < removedElements; ++k) {
-				d.pop_front();
-			}
-
-			int64_t dequeBytes = DequeAllocatorStats::allocatedBytes + sizeof(std::deque<TestType>);
-			int64_t insertedBytes = (numElements - removedElements) * sizeof(TestType);
-			double overheadFactor =
-			    std::max<double>(insertedBytes, dequeBytes - 10000) /
-			    insertedBytes; // We subtract 10K here as an estimated upper bound for the fixed cost of an std::deque
-			// fprintf(stderr, "%d elements (%d inserted, %d removed):\n", numElements-removedElements, numElements,
-			// removedElements); fprintf(stderr, "Allocated %lld bytes to store %lld bytes (%lf overhead factor)\n",
-			// dequeBytes, insertedBytes, overheadFactor);
-			ASSERT(overheadFactor * 1024 <= SERVER_KNOBS->VERSION_MESSAGES_OVERHEAD_FACTOR_1024THS);
-		}
-	}
-
-	return Void();
-}
-
 } // namespace oldTLog_6_0

--- a/fdbserver/OldTLogServer_6_2.actor.cpp
+++ b/fdbserver/OldTLogServer_6_2.actor.cpp
@@ -3374,40 +3374,4 @@ struct DequeAllocator : std::allocator<T> {
 	}
 };
 
-TEST_CASE("/fdbserver/tlogserver/VersionMessagesOverheadFactor") {
-
-	typedef std::pair<Version, LengthPrefixedStringRef> TestType; // type used by versionMessages
-
-	for (int i = 1; i < 9; ++i) {
-		for (int j = 0; j < 20; ++j) {
-			DequeAllocatorStats::allocatedBytes = 0;
-			DequeAllocator<TestType> allocator;
-			std::deque<TestType, DequeAllocator<TestType>> d(allocator);
-
-			int numElements = deterministicRandom()->randomInt(pow(10, i - 1), pow(10, i));
-			for (int k = 0; k < numElements; ++k) {
-				d.push_back(TestType());
-			}
-
-			int removedElements = 0; // deterministicRandom()->randomInt(0, numElements); // FIXME: the overhead factor
-			                         // does not accurately account for removal!
-			for (int k = 0; k < removedElements; ++k) {
-				d.pop_front();
-			}
-
-			int64_t dequeBytes = DequeAllocatorStats::allocatedBytes + sizeof(std::deque<TestType>);
-			int64_t insertedBytes = (numElements - removedElements) * sizeof(TestType);
-			double overheadFactor =
-			    std::max<double>(insertedBytes, dequeBytes - 10000) /
-			    insertedBytes; // We subtract 10K here as an estimated upper bound for the fixed cost of an std::deque
-			// fprintf(stderr, "%d elements (%d inserted, %d removed):\n", numElements-removedElements, numElements,
-			// removedElements); fprintf(stderr, "Allocated %lld bytes to store %lld bytes (%lf overhead factor)\n",
-			// dequeBytes, insertedBytes, overheadFactor);
-			ASSERT(overheadFactor * 1024 <= SERVER_KNOBS->VERSION_MESSAGES_OVERHEAD_FACTOR_1024THS);
-		}
-	}
-
-	return Void();
-}
-
 } // namespace oldTLog_6_2

--- a/fdbserver/OldTLogServer_6_2.actor.cpp
+++ b/fdbserver/OldTLogServer_6_2.actor.cpp
@@ -3374,4 +3374,40 @@ struct DequeAllocator : std::allocator<T> {
 	}
 };
 
+TEST_CASE("Lfdbserver/tlogserver/VersionMessagesOverheadFactor") {
+
+	typedef std::pair<Version, LengthPrefixedStringRef> TestType; // type used by versionMessages
+
+	for (int i = 1; i < 9; ++i) {
+		for (int j = 0; j < 20; ++j) {
+			DequeAllocatorStats::allocatedBytes = 0;
+			DequeAllocator<TestType> allocator;
+			std::deque<TestType, DequeAllocator<TestType>> d(allocator);
+
+			int numElements = deterministicRandom()->randomInt(pow(10, i - 1), pow(10, i));
+			for (int k = 0; k < numElements; ++k) {
+				d.push_back(TestType());
+			}
+
+			int removedElements = 0; // deterministicRandom()->randomInt(0, numElements); // FIXME: the overhead factor
+			                         // does not accurately account for removal!
+			for (int k = 0; k < removedElements; ++k) {
+				d.pop_front();
+			}
+
+			int64_t dequeBytes = DequeAllocatorStats::allocatedBytes + sizeof(std::deque<TestType>);
+			int64_t insertedBytes = (numElements - removedElements) * sizeof(TestType);
+			double overheadFactor =
+			    std::max<double>(insertedBytes, dequeBytes - 10000) /
+			    insertedBytes; // We subtract 10K here as an estimated upper bound for the fixed cost of an std::deque
+			// fprintf(stderr, "%d elements (%d inserted, %d removed):\n", numElements-removedElements, numElements,
+			// removedElements); fprintf(stderr, "Allocated %lld bytes to store %lld bytes (%lf overhead factor)\n",
+			// dequeBytes, insertedBytes, overheadFactor);
+			ASSERT(overheadFactor * 1024 <= SERVER_KNOBS->VERSION_MESSAGES_OVERHEAD_FACTOR_1024THS);
+		}
+	}
+
+	return Void();
+}
+
 } // namespace oldTLog_6_2

--- a/fdbserver/Status.actor.cpp
+++ b/fdbserver/Status.actor.cpp
@@ -3308,7 +3308,7 @@ JsonBuilderObject randomDocument(const std::vector<std::string>& strings, int& l
 	return r;
 }
 
-TEST_CASE("/status/json/builderPerf") {
+TEST_CASE("Lstatus/json/builderPerf") {
 	std::vector<std::string> strings;
 	int c = 1000000;
 	printf("Generating random strings\n");

--- a/fdbserver/TLogServer.actor.cpp
+++ b/fdbserver/TLogServer.actor.cpp
@@ -3453,7 +3453,7 @@ struct DequeAllocator : std::allocator<T> {
 	}
 };
 
-TEST_CASE("/fdbserver/tlogserver/VersionMessagesOverheadFactor") {
+TEST_CASE("Lfdbserver/tlogserver/VersionMessagesOverheadFactor") {
 
 	typedef std::pair<Version, LengthPrefixedStringRef> TestType; // type used by versionMessages
 

--- a/fdbserver/VersionedBTree.actor.cpp
+++ b/fdbserver/VersionedBTree.actor.cpp
@@ -8065,7 +8065,7 @@ TEST_CASE("/redwood/correctness/unit/RedwoodRecordRef") {
 	return Void();
 }
 
-TEST_CASE("/redwood/correctness/unit/deltaTree/RedwoodRecordRef") {
+TEST_CASE("Lredwood/correctness/unit/deltaTree/RedwoodRecordRef") {
 	// Sanity check on delta tree node format
 	ASSERT(DeltaTree2<RedwoodRecordRef>::Node::headerSize(false) == 4);
 	ASSERT(DeltaTree2<RedwoodRecordRef>::Node::headerSize(true) == 8);
@@ -8241,7 +8241,7 @@ TEST_CASE("/redwood/correctness/unit/deltaTree/RedwoodRecordRef") {
 	return Void();
 }
 
-TEST_CASE("/redwood/correctness/unit/deltaTree/RedwoodRecordRef2") {
+TEST_CASE("Lredwood/correctness/unit/deltaTree/RedwoodRecordRef2") {
 	// Sanity check on delta tree node format
 	ASSERT(DeltaTree2<RedwoodRecordRef>::Node::headerSize(false) == 4);
 	ASSERT(DeltaTree2<RedwoodRecordRef>::Node::headerSize(true) == 8);
@@ -8420,7 +8420,7 @@ TEST_CASE("/redwood/correctness/unit/deltaTree/RedwoodRecordRef2") {
 	return Void();
 }
 
-TEST_CASE("/redwood/correctness/unit/deltaTree/IntIntPair") {
+TEST_CASE("Lredwood/correctness/unit/deltaTree/IntIntPair") {
 	const int N = 200;
 	IntIntPair lowerBound = { 0, 0 };
 	IntIntPair upperBound = { 1000, 1000 };
@@ -9017,7 +9017,7 @@ TEST_CASE(":/redwood/pager/ArenaPage") {
 	return Void();
 }
 
-TEST_CASE("/redwood/correctness/btree") {
+TEST_CASE("Lredwood/correctness/btree") {
 	g_redwoodMetricsActor = Void(); // Prevent trace event metrics from starting
 	g_redwoodMetrics.clear();
 

--- a/tests/PerfUnitTests.toml
+++ b/tests/PerfUnitTests.toml
@@ -1,0 +1,9 @@
+[[test]]
+testTitle = 'PerfUnitTests'
+useDB = false
+startDelay = 0
+
+    [[test.workload]]
+    testName = 'UnitTests'
+    #maxTestCases = 1
+    testsMatching = '#'

--- a/tests/rare/AllSimUnitTests.toml
+++ b/tests/rare/AllSimUnitTests.toml
@@ -5,5 +5,5 @@ startDelay = 0
 
     [[test.workload]]
     testName = 'UnitTests'
-    maxTestCases = 1
-    testsMatching = 'Lredwood/correctness/btree'
+    #maxTestCases = 1
+    testsMatching = '/'

--- a/tests/rare/RedwoodDeltaTree.toml
+++ b/tests/rare/RedwoodDeltaTree.toml
@@ -1,0 +1,16 @@
+[[test]]
+testTitle = 'RedwoodDeltaTree'
+useDB = false
+startDelay = 0
+
+    [[test.workload]]
+    testName = 'UnitTests'
+    maxTestCases = 1
+    testsMatching = 'Lredwood/correctness/unit/deltaTree/IntIntPair'
+
+[[test]]
+testTitle = "RedwoodRecordRef"
+
+    [[test.workload]]
+    testName = 'Lredwood/correctness/unit/deltaTree/RedwoodRecordRef'
+    maxTestCases = 2 # there are two of those

--- a/tests/rare/RedwoodDeltaTree.toml
+++ b/tests/rare/RedwoodDeltaTree.toml
@@ -12,5 +12,6 @@ startDelay = 0
 testTitle = "RedwoodRecordRef"
 
     [[test.workload]]
-    testName = 'Lredwood/correctness/unit/deltaTree/RedwoodRecordRef'
+    testName = 'UnitTests'
     maxTestCases = 2 # there are two of those
+    testsMatching = 'Lredwood/correctness/unit/deltaTree/RedwoodRecordRef'

--- a/tests/rare/StatusBuilderPerf.toml
+++ b/tests/rare/StatusBuilderPerf.toml
@@ -1,9 +1,9 @@
 [[test]]
-testTitle = 'UnitTests'
+testTitle = 'StatusBuilderPerf'
 useDB = false
 startDelay = 0
 
     [[test.workload]]
     testName = 'UnitTests'
     maxTestCases = 1
-    testsMatching = 'Lredwood/correctness/btree'
+    testsMatching = 'Lstatus/json/builderPerf'

--- a/tests/rare/TLogVersionMessagesOverheadFactor.toml
+++ b/tests/rare/TLogVersionMessagesOverheadFactor.toml
@@ -1,0 +1,9 @@
+[[test]]
+testTitle = 'TLogVersionMessagesOverheadFactor'
+useDB = false
+startDelay = 0
+
+    [[test.workload]]
+    testName = 'UnitTests'
+    maxTestCases = 1
+    testsMatching = 'Lfdbserver/tlogserver/VersionMessagesOverheadFactor'

--- a/tests/rare/TLogVersionMessagesOverheadFactor.toml
+++ b/tests/rare/TLogVersionMessagesOverheadFactor.toml
@@ -5,5 +5,4 @@ startDelay = 0
 
     [[test.workload]]
     testName = 'UnitTests'
-    maxTestCases = 1
     testsMatching = 'Lfdbserver/tlogserver/VersionMessagesOverheadFactor'


### PR DESCRIPTION
This applied the following policy to our unit tests:

1. `/`: (current default) means that this test is meant to run in simulation and will finish very quickly. These tests will be executed often (I will add them to CI)
1. `L`: (for long-running) means the test shouldn’t be included with the rest but instead the author created a separate toml-file (for example in rare).
1. `#`: (for “number”): The purpose of this unit test is to measure the performance of something and therefore it doesn’t make sense to run it in simulation and we won’t ever run it.

Additionally this adds a test `AllSimUnitTests.toml` to `rare` to make sure we execute unit tests often enough

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
