### PR TITLE
Add DNS mock in SimExternalConnection.

### DIFF
--- a/fdbrpc/SimExternalConnection.h
+++ b/fdbrpc/SimExternalConnection.h
@@ -28,6 +28,24 @@
 
 #include <boost/asio.hpp>
 
+// MockDNS is a class maintaining a <hostname, vector<NetworkAddress>> mapping, mocking a DNS in simulation.
+class MockDNS {
+public:
+	bool findMockTCPEndpoint(const std::string& host, const std::string& service);
+	void addMockTCPEndpoint(const std::string& host,
+	                        const std::string& service,
+	                        const std::vector<NetworkAddress>& addresses);
+	void updateMockTCPEndpoint(const std::string& host,
+	                           const std::string& service,
+	                           const std::vector<NetworkAddress>& addresses);
+	void removeMockTCPEndpoint(const std::string& host, const std::string& service);
+	void clearMockTCPEndpoints();
+	std::vector<NetworkAddress> getTCPEndpoint(const std::string& host, const std::string& service);
+
+private:
+	std::map<std::string, std::vector<NetworkAddress>> hostnameToAddresses;
+};
+
 class SimExternalConnection final : public IConnection, public ReferenceCounted<SimExternalConnection> {
 	boost::asio::ip::tcp::socket socket;
 	SimExternalConnection(boost::asio::ip::tcp::socket&& socket);
@@ -50,6 +68,9 @@ public:
 	UID getDebugID() const override;
 	static Future<std::vector<NetworkAddress>> resolveTCPEndpoint(const std::string& host, const std::string& service);
 	static Future<Reference<IConnection>> connect(NetworkAddress toAddr);
+
+private:
+	static MockDNS mockDNS;
 };
 
 #endif


### PR DESCRIPTION
This is a substep in supporting hostnames in cluster files. So that in simulation, we can add <hostname, ip addresses> mappings to mock DNS.

20211109-010322-renxuan-33a909a7b07173e1           compressed=True data_size=27446727 duration=5607621 ended=100001 fail_fast=10 max_runs=100000 pass=100001 priority=100 remaining=0 runtime=0:57:14 sanity=False started=100499 stopped=20211109-020036 submitted=20211109-010322 timeout=5400 username=renxuan

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
