### PR TITLE
Remove mako temp shared memory file

### DIFF
--- a/bindings/c/test/mako/mako.c
+++ b/bindings/c/test/mako/mako.c
@@ -2818,6 +2818,7 @@ failExit:
 	if (shmfd) {
 		close(shmfd);
 		shm_unlink(shmpath);
+		unlink(shmpath);
 	}
 
 	return 0;


### PR DESCRIPTION
This PR fixes `mako` to clean up its temporary file under `/dev/shm` properly

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
