### PR TITLE
Version vector prototype: unblock waiting peeks

### DIFF
--- a/fdbserver/TLogServer.actor.cpp
+++ b/fdbserver/TLogServer.actor.cpp
@@ -734,6 +734,9 @@ struct LogData : NonCopyable, public ReferenceCounted<LogData> {
 	void unblockWaitingPeeks() {
 		if (SERVER_KNOBS->ENABLE_VERSION_VECTOR) {
 			for (auto& iter : waitingTags) {
+				TraceEvent("UnblockWaitingPeeks", tLogData->dbgid)
+				    .detail("LogId", logId)
+				    .detail("Tag", iter.first.toString());
 				iter.second.send(Void());
 			}
 			waitingTags.clear();


### PR DESCRIPTION
Unblock waiting peek requests, if any, before stopping a tlog instance. (This allows the waiting storage server to make progress by requesting/receiving mutations from the new "committing" tlog instance.)

NOTE: We were doing this "unblocking" in "updatePersistentData()" which is not very efficient. This PR removes that code, and does the "unblocking" before an instance gets stopped.

Testing:
- Ran simulation tests. Job 20211109-153401-sre-0deb84d998bf107c completed without any failures. Job 20211109-003616-sre-0deb84d998bf107c shows failures in the following tests: ConstrainedRandomSelector.toml and MutationLogReaderCorrectness.toml. These tests don't cause any tlog failures/restarts so these failures might not be related to this issue.

- Mako testing: Ran an insert workload (provided by Dan) over a 24 node loopback cluster. Here are the peek-related tlog metrics:

> BlockingPeeks="6.39998 7.00165 360" BlockingPeekTimeouts="6.39998 7.19817 344" EmptyPeeks="6.39998 7.19817 344" NonEmptyPeeks="0 -1 8"
> 
> BlockingPeeks="7.99998 9.00206 1068" BlockingPeekTimeouts="7.99998 9.25242 389" EmptyPeeks="7.99998 9.25242 389" NonEmptyPeeks="0 -1 669"
> 
> BlockingPeeks="6.39998 7.00159 361" BlockingPeekTimeouts="6.39998 7.19777 342" EmptyPeeks="6.39998 7.19777 342" NonEmptyPeeks="0 -1 11"

In the above results, empty peek count matches the blocking peek timeout count, which shows that the blocking peek logic is working the way it is supposed to.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
