### PR TITLE
Merge cursor

### DIFF
--- a/fdbclient/CommitTransaction.h
+++ b/fdbclient/CommitTransaction.h
@@ -50,6 +50,7 @@ static const char* typeString[] = { "SetValue",
 	                                "AndV2",
 	                                "CompareAndClear",
 	                                "Reserved_For_SpanContextMessage",
+	                                "Reserved_For_EmptyCommit",
 	                                "MAX_ATOMIC_OP" };
 
 struct MutationRef {
@@ -77,6 +78,7 @@ struct MutationRef {
 		AndV2,
 		CompareAndClear,
 		Reserved_For_SpanContextMessage /* See fdbserver/SpanContextMessage.h */,
+		Reserved_For_EmptyCommit /* See fdbserver/EmptyCommit.h */,
 		MAX_ATOMIC_OP
 	};
 	// This is stored this way for serialization purposes.

--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -641,6 +641,8 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( MAX_STORAGE_COMMIT_TIME,                             120.0 ); //The max fsync stall time on the storage server and tlog before marking a disk as failed
 	init( RANGESTREAM_LIMIT_BYTES,                               2e6 ); if( randomize && BUGGIFY ) RANGESTREAM_LIMIT_BYTES = 1;
 	init( ENABLE_CLEAR_RANGE_EAGER_READS,                       true );
+	init( MERGE_CURSOR_RETRY_TIMES,                               10 );
+	init( MERGE_CURSOR_RETRY_DELAY,                             1e-2 );
 
 	//Wait Failure
 	init( MAX_OUTSTANDING_WAIT_FAILURE_REQUESTS,                 250 ); if( randomize && BUGGIFY ) MAX_OUTSTANDING_WAIT_FAILURE_REQUESTS = 2;

--- a/fdbclient/ServerKnobs.h
+++ b/fdbclient/ServerKnobs.h
@@ -579,6 +579,11 @@ public:
 	double MAX_STORAGE_COMMIT_TIME;
 	int64_t RANGESTREAM_LIMIT_BYTES;
 	bool ENABLE_CLEAR_RANGE_EAGER_READS;
+	// When using merge cursor, some of the cursors might not have messages available. This knob determines the number
+	// of times the cursor peeks before claiming failure.
+	int MERGE_CURSOR_RETRY_TIMES;
+	// Time between each retries of peeks when using merge cursor
+	double MERGE_CURSOR_RETRY_DELAY;
 
 	// Wait Failure
 	int MAX_OUTSTANDING_WAIT_FAILURE_REQUESTS;

--- a/fdbserver/ptxn/MessageSerializer.cpp
+++ b/fdbserver/ptxn/MessageSerializer.cpp
@@ -183,8 +183,16 @@ size_t TLogSubsequencedMessageSerializer::getTotalBytes() const {
 
 ProxySubsequencedMessageSerializer::ProxySubsequencedMessageSerializer(const Version& version_) : version(version_) {}
 
+const Subsequence& ProxySubsequencedMessageSerializer::getSubsequence() const {
+	return subsequence;
+}
+
 const Version& ProxySubsequencedMessageSerializer::getVersion() const {
 	return version;
+}
+
+void ProxySubsequencedMessageSerializer::setSubsequence(const Subsequence& newSubsequence) {
+	subsequence = newSubsequence;
 }
 
 void ProxySubsequencedMessageSerializer::prepareWriteMessage(const StorageTeamID& storageTeamID) {

--- a/fdbserver/ptxn/MessageSerializer.cpp
+++ b/fdbserver/ptxn/MessageSerializer.cpp
@@ -187,7 +187,8 @@ size_t TLogSubsequencedMessageSerializer::getTotalBytes() const {
 
 #pragma region ProxySubsequencedMessageSerializer
 
-ProxySubsequencedMessageSerializer::ProxySubsequencedMessageSerializer(const Version& version_) : storageTeamVersion(version_) {}
+ProxySubsequencedMessageSerializer::ProxySubsequencedMessageSerializer(const Version& version_)
+  : storageTeamVersion(version_) {}
 
 const Subsequence& ProxySubsequencedMessageSerializer::getSubsequence() const {
 	return subsequence;

--- a/fdbserver/ptxn/MessageSerializer.h
+++ b/fdbserver/ptxn/MessageSerializer.h
@@ -301,6 +301,18 @@ public:
 	SerializedTeamData getAllSerialized();
 };
 
+class BroadcastedSubsequencedMessageSerializer : public ProxySubsequencedMessageSerializer {
+public:
+	template <typename Container_t>
+	BroadcastedSubsequencedMessageSerializer(const Version& storageTeamVersion, const Container_t& storageTeamIDs)
+	  : ProxySubsequencedMessageSerializer(storageTeamVersion) {
+
+		for (const auto& storageTeamID : storageTeamIDs) {
+			prepareWriteMessage(storageTeamID);
+		}
+	}
+};
+
 template <typename T>
 using ConstInputIteratorBase = std::iterator<std::input_iterator_tag, T, size_t, const T* const, const T&>;
 

--- a/fdbserver/ptxn/MessageSerializer.h
+++ b/fdbserver/ptxn/MessageSerializer.h
@@ -259,6 +259,12 @@ public:
 	// Gets the version the serializer is currently using
 	const Version& getVersion() const;
 
+	// Gets the current subsequence
+	const Subsequence& getSubsequence() const;
+
+	// Sets the subsequence. It is the caller's obligation to ensure the subsequence is ordered properly.
+	void setSubsequence(const Subsequence& subsequence);
+
 	// Broadcasts the span context to all storage teams. After this function is called, for any storage team, the first
 	// write will always prepend this SpanContextMessage before the mutation.
 	void broadcastSpanContext(const SpanContextMessage&);

--- a/fdbserver/ptxn/MessageTypes.cpp
+++ b/fdbserver/ptxn/MessageTypes.cpp
@@ -39,6 +39,9 @@ std::string Message::toString() const {
 	case Type::LOG_PROTOCOL_MESSAGE:
 		result = concatToString(result, "Log Protocol ", std::get<LogProtocolMessage>(*this));
 		break;
+	case Type::EMPTY_VERSION_MESSAGE:
+		result = concatToString(result, "Empty version ", std::get<EmptyMessage>(*this));
+		break;
 	case Type::UNDEFINED:
 		result = concatToString(result, "Undefined value");
 	default:
@@ -59,6 +62,8 @@ bool Message::operator==(const Message& another) const {
 		return std::get<SpanContextMessage>(*this) == std::get<SpanContextMessage>(another);
 	case Type::LOG_PROTOCOL_MESSAGE:
 		return std::get<LogProtocolMessage>(*this) == std::get<LogProtocolMessage>(another);
+	case Type::EMPTY_VERSION_MESSAGE:
+		return std::get<EmptyMessage>(*this) == std::get<EmptyMessage>(another);
 	case Type::UNDEFINED:
 		return true;
 	default:

--- a/fdbserver/ptxn/MessageTypes.cpp
+++ b/fdbserver/ptxn/MessageTypes.cpp
@@ -89,15 +89,51 @@ std::string VersionSubsequenceMessage::toString() const {
 }
 
 bool VersionSubsequenceMessage::operator==(const VersionSubsequenceMessage& another) const {
-	if (!(version == another.version && subsequence == another.subsequence &&
-	      message.getType() == another.message.getType())) {
-		return false;
-	}
-	return message == another.message;
+	return operatorSpaceship(another) == 0;
 }
 
 bool VersionSubsequenceMessage::operator!=(const VersionSubsequenceMessage& another) const {
-	return !(*this == another);
+	return operatorSpaceship(another) != 0;
+}
+
+bool VersionSubsequenceMessage::operator<(const VersionSubsequenceMessage& another) const {
+	return operatorSpaceship(another) == -1;
+}
+
+bool VersionSubsequenceMessage::operator>(const VersionSubsequenceMessage& another) const {
+	return operatorSpaceship(another) == 1;
+}
+
+bool VersionSubsequenceMessage::operator<=(const VersionSubsequenceMessage& another) const {
+	return operatorSpaceship(another) <= 0;
+}
+
+bool VersionSubsequenceMessage::operator>=(const VersionSubsequenceMessage& another) const {
+	return operatorSpaceship(another) >= 0;
+}
+
+int VersionSubsequenceMessage::operatorSpaceship(const VersionSubsequenceMessage& another) const {
+	if (version < another.version) {
+		return -1;
+	} else if (version > another.version) {
+		return 1;
+	}
+
+	if (subsequence < another.subsequence) {
+		return -1;
+	} else if (subsequence > another.subsequence) {
+		return 1;
+	}
+
+	if (message.getType() == another.message.getType() && message == another.message) {
+		return 0;
+	}
+
+	// Two different messages cannot share one single (version, subsequnece) pair.
+	ASSERT(false);
+
+	// This return will not be reachable, but to mute the non-void function does not return a value warning.
+	return 0;
 }
 
 std::ostream& operator<<(std::ostream& stream, const Message& message) {

--- a/fdbserver/ptxn/MessageTypes.h
+++ b/fdbserver/ptxn/MessageTypes.h
@@ -139,8 +139,15 @@ struct VersionSubsequenceMessage {
 
 	std::string toString() const;
 
+	// FIXME use operator spaceship when we use C++20
+	int operatorSpaceship(const VersionSubsequenceMessage& another) const;
+
 	bool operator==(const VersionSubsequenceMessage&) const;
 	bool operator!=(const VersionSubsequenceMessage&) const;
+	bool operator<(const VersionSubsequenceMessage&) const;
+	bool operator<=(const VersionSubsequenceMessage&) const;
+	bool operator>(const VersionSubsequenceMessage&) const;
+	bool operator>=(const VersionSubsequenceMessage&) const;
 };
 
 std::ostream& operator<<(std::ostream&, const VersionSubsequenceMessage&);

--- a/fdbserver/ptxn/MessageTypes.h
+++ b/fdbserver/ptxn/MessageTypes.h
@@ -84,17 +84,30 @@ struct SubsequenceSerializedMessageItem {
 	}
 };
 
+// Placeholder message, used to notify an version w/o any messages inside it
+struct EmptyMessage {
+	// All empty messages are the same, the version difference is checked at VersionSubsequenceMessage
+	bool operator==(const EmptyMessage&) const { return true; }
+
+	// All empty messages are the same, the version difference is checked at VersionSubsequenceMessage
+	bool operator!=(const EmptyMessage&) const { return false; }
+
+	std::string toString() const { return std::string("<EmptyMessage>"); }
+};
+
 // Stores one of the following:
 //    * MutationRef
 //    * SpanContextMessage
 //    * LogProtocolMessage
-struct Message : public std::variant<MutationRef, SpanContextMessage, LogProtocolMessage> {
-	using variant_t = std::variant<MutationRef, SpanContextMessage, LogProtocolMessage>;
+// .  * EmptyMessage
+struct Message : public std::variant<MutationRef, SpanContextMessage, LogProtocolMessage, EmptyMessage> {
+	using variant_t = std::variant<MutationRef, SpanContextMessage, LogProtocolMessage, EmptyMessage>;
 
 	enum class Type : std::size_t {
 		MUTATION_REF,
 		SPAN_CONTEXT_MESSAGE,
 		LOG_PROTOCOL_MESSAGE,
+		EMPTY_VERSION_MESSAGE,
 		UNDEFINED = std::variant_npos
 	};
 

--- a/fdbserver/ptxn/TLogGroupVersionTracker.actor.cpp
+++ b/fdbserver/ptxn/TLogGroupVersionTracker.actor.cpp
@@ -114,7 +114,6 @@ TEST_CASE("fdbserver/ptxn/test/versiontracker") {
 		return Void();
 	}
 
-
 	for (auto beginVersion : std::vector<Version>{ -1, 0, 3 }) {
 		printTiming << "Testing version: " << beginVersion << "\n";
 

--- a/fdbserver/ptxn/TLogInterface.cpp
+++ b/fdbserver/ptxn/TLogInterface.cpp
@@ -73,10 +73,7 @@ namespace {
 template <typename T>
 std::shared_ptr<T> TLogInterfaceCastHelper(std::shared_ptr<TLogInterfaceBase> ptr) {
 	std::shared_ptr<T> result = std::dynamic_pointer_cast<T>(ptr);
-	if (!result) {
-		// std::bad_cast might be a better choice if not using flow
-		throw internal_error_msg("Unable to downcast TLogInterface");
-	}
+	ASSERT(result);
 	return result;
 }
 } // namespace

--- a/fdbserver/ptxn/TLogPeekCursor.actor.cpp
+++ b/fdbserver/ptxn/TLogPeekCursor.actor.cpp
@@ -20,12 +20,14 @@
 
 #include "fdbserver/ptxn/TLogPeekCursor.actor.h"
 
+#include <algorithm>
 #include <iterator>
 #include <unordered_set>
 #include <vector>
 
 #include "fdbserver/Knobs.h"
 #include "fdbserver/ptxn/TLogInterface.h"
+#include "fdbserver/ptxn/test/Delay.h"
 #include "fdbserver/ptxn/test/Utils.h"
 #include "flow/Error.h"
 #include "flow/Trace.h"
@@ -49,6 +51,10 @@ const Standalone<StringRef>& emptyCursorHeader() {
 	return empty;
 };
 
+} // anonymous namespace
+
+namespace details::StorageTeamPeekCursor {
+
 struct PeekRemoteContext {
 	const Optional<UID> debugID;
 	const StorageTeamID storageTeamID;
@@ -60,34 +66,34 @@ struct PeekRemoteContext {
 	const std::vector<TLogInterfaceBase*>& pTLogInterfaces;
 
 	// Deserializer
-	SubsequencedMessageDeserializer* pDeserializer;
+	SubsequencedMessageDeserializer& deserializer;
 
 	// Deserializer iterator
-	SubsequencedMessageDeserializer::iterator* pDeserializerIterator;
+	ptxn::details::ArenaWrapper<SubsequencedMessageDeserializer::iterator>& wrappedDeserializerIter;
+
+	// The pointer to the work arena. The work arena stores the data from TLogPeekReply
+	Arena* pWorkArena;
 
 	// If not null, attach the arena in the reply to this arena, so the mutations will still be
 	// accessible even the deserializer gets destructed.
 	Arena* pAttachArena;
 
-	Arena* pWorkArena;
-
 	PeekRemoteContext(const Optional<UID>& debugID_,
 	                  const StorageTeamID& storageTeamID_,
 	                  Version* pLastVersion_,
 	                  const std::vector<TLogInterfaceBase*>& pInterfaces_,
-	                  SubsequencedMessageDeserializer* pDeserializer_,
-	                  SubsequencedMessageDeserializer::iterator* pDeserializerIterator_,
+	                  SubsequencedMessageDeserializer& deserializer_,
+	                  details::ArenaWrapper<SubsequencedMessageDeserializer::iterator>& wrappedDeserializerIterator_,
 	                  Arena* pWorkArena_,
 	                  Arena* pAttachArena_ = nullptr)
 	  : debugID(debugID_), storageTeamID(storageTeamID_), pLastVersion(pLastVersion_), pTLogInterfaces(pInterfaces_),
-	    pDeserializer(pDeserializer_), pDeserializerIterator(pDeserializerIterator_), pAttachArena(pAttachArena_),
-	    pWorkArena(pWorkArena_) {
+	    deserializer(deserializer_), wrappedDeserializerIter(wrappedDeserializerIterator_), pWorkArena(pWorkArena_),
+	    pAttachArena(pAttachArena_) {
 
 		for (const auto pTLogInterface : pTLogInterfaces) {
 			ASSERT(pTLogInterface != nullptr);
 		}
-
-		ASSERT(pDeserializer != nullptr && pDeserializerIterator != nullptr);
+		ASSERT(pWorkArena_);
 	}
 };
 
@@ -103,32 +109,27 @@ ACTOR Future<bool> peekRemote(PeekRemoteContext peekRemoteContext) {
 	request.endVersion = invalidVersion; // we *ALWAYS* try to extract *ALL* data
 	request.storageTeamID = peekRemoteContext.storageTeamID;
 
-	try {
-		state TLogPeekReply reply = wait(pTLogInterface->peek.getReply(request));
+	state TLogPeekReply reply = wait(pTLogInterface->peek.getReply(request));
 
-		peekRemoteContext.pDeserializer->reset(reply.data);
-		*peekRemoteContext.pLastVersion = peekRemoteContext.pDeserializer->getLastVersion();
-		*peekRemoteContext.pDeserializerIterator = peekRemoteContext.pDeserializer->begin();
+	// In case the remote epoch ended, an end_of_stream exception will be thrown and it is the caller's responsible
+	// to catch.
 
-		if (*peekRemoteContext.pDeserializerIterator == peekRemoteContext.pDeserializer->end()) {
-			// No new mutations incoming, and there is no new mutations responded from TLog in this request
-			return false;
-		}
-
-		if (peekRemoteContext.pAttachArena != nullptr) {
-			peekRemoteContext.pAttachArena->dependsOn(reply.arena);
-		}
-
-		(*peekRemoteContext.pWorkArena) = reply.arena;
-
-		return true;
-	} catch (Error& error) {
-		// FIXME deal with possible errors
+	peekRemoteContext.deserializer.reset(reply.data);
+	peekRemoteContext.wrappedDeserializerIter = peekRemoteContext.deserializer.begin();
+	if (peekRemoteContext.wrappedDeserializerIter.get() == peekRemoteContext.deserializer.end()) {
+		// No new mutations incoming, and there is no new mutations responded from TLog in this request
 		return false;
 	}
+
+	*peekRemoteContext.pLastVersion = reply.endVersion;
+	*peekRemoteContext.pWorkArena = reply.arena;
+
+	return true;
 }
 
-} // anonymous namespace
+} // namespace details::StorageTeamPeekCursor
+
+#pragma region PeekCursorBase
 
 PeekCursorBase::iterator::iterator(PeekCursorBase* pCursor_, bool isEndIterator_)
   : pCursor(pCursor_), isEndIterator(isEndIterator_) {}
@@ -173,19 +174,70 @@ bool PeekCursorBase::hasRemaining() const {
 	return hasRemainingImpl();
 }
 
-StorageTeamPeekCursor::StorageTeamPeekCursor(const Version& beginVersion_,
+#pragma endregion PeekCursorBase
+
+namespace details {
+
+#pragma region VersionSubsequencePeekCursorBase
+
+VersionSubsequencePeekCursorBase::VersionSubsequencePeekCursorBase(const Version version_,
+                                                                   const Subsequence subsequence_)
+  : PeekCursorBase() {}
+
+const Version& VersionSubsequencePeekCursorBase::getVersion() const {
+	return get().version;
+}
+
+const Subsequence& VersionSubsequencePeekCursorBase::getSubsequence() const {
+	return get().subsequence;
+}
+
+int VersionSubsequencePeekCursorBase::operatorSpaceship(const VersionSubsequencePeekCursorBase& other) const {
+	const Version& thisVersion = getVersion();
+	const Version& otherVersion = other.getVersion();
+	if (thisVersion < otherVersion) {
+		return -1;
+	} else if (thisVersion > otherVersion) {
+		return 1;
+	}
+
+	const Subsequence& thisSubsequence = getSubsequence();
+	const Subsequence& otherSubsequence = other.getSubsequence();
+	if (thisSubsequence < otherSubsequence) {
+		return -1;
+	} else if (thisSubsequence > otherSubsequence) {
+		return 1;
+	}
+
+	return 0;
+}
+
+#pragma endregion VersionSubsequencePeekCursorBase
+
+} // namespace details
+
+#pragma region StorageTeamPeekCursor
+
+StorageTeamPeekCursor::StorageTeamPeekCursor(const Version& startingVersion_,
                                              const StorageTeamID& storageTeamID_,
                                              TLogInterfaceBase* pTLogInterface_,
-                                             Arena* pArena_)
-  : StorageTeamPeekCursor(beginVersion_, storageTeamID_, std::vector<TLogInterfaceBase*>{ pTLogInterface_ }, pArena_) {}
+                                             Arena* pArena_,
+                                             const bool reportEmptyVersion_)
+  : StorageTeamPeekCursor(startingVersion_,
+                          storageTeamID_,
+                          std::vector<TLogInterfaceBase*>{ pTLogInterface_ },
+                          pArena_,
+                          reportEmptyVersion_) {}
 
-StorageTeamPeekCursor::StorageTeamPeekCursor(const Version& beginVersion_,
+StorageTeamPeekCursor::StorageTeamPeekCursor(const Version& startingVersion_,
                                              const StorageTeamID& storageTeamID_,
                                              const std::vector<TLogInterfaceBase*>& pTLogInterfaces_,
-                                             Arena* pArena_)
-  : storageTeamID(storageTeamID_), pTLogInterfaces(pTLogInterfaces_), pAttachArena(pArena_),
-    deserializer(emptyCursorHeader()), deserializerIter(deserializer.begin()), beginVersion(beginVersion_),
-    lastVersion(beginVersion_ - 1) {
+                                             Arena* pArena_,
+                                             const bool reportEmptyVersion_)
+  : VersionSubsequencePeekCursorBase(), storageTeamID(storageTeamID_), pTLogInterfaces(pTLogInterfaces_),
+    pAttachArena(pArena_), deserializer(emptyCursorHeader(), /* reportEmptyVersion_ */ true),
+    wrappedDeserializerIter(deserializer.begin(), pArena_), startingVersion(startingVersion_),
+    reportEmptyVersion(reportEmptyVersion_), lastVersion(startingVersion_ - 1) {
 
 	for (const auto pTLogInterface : pTLogInterfaces) {
 		ASSERT(pTLogInterface != nullptr);
@@ -196,38 +248,411 @@ const StorageTeamID& StorageTeamPeekCursor::getStorageTeamID() const {
 	return storageTeamID;
 }
 
-const Version& StorageTeamPeekCursor::getLastVersion() const {
-	return lastVersion;
-}
-
-const Version& StorageTeamPeekCursor::getBeginVersion() const {
-	return beginVersion;
+const Version& StorageTeamPeekCursor::getStartingVersion() const {
+	return startingVersion;
 }
 
 Future<bool> StorageTeamPeekCursor::remoteMoreAvailableImpl() {
 	// FIXME Put debugID if necessary
-	PeekRemoteContext context(Optional<UID>(),
-	                          getStorageTeamID(),
-	                          &lastVersion,
-	                          pTLogInterfaces,
-	                          &deserializer,
-	                          &deserializerIter,
-	                          &workArena,
-	                          pAttachArena);
+	details::StorageTeamPeekCursor::PeekRemoteContext context(Optional<UID>(),
+	                                                          getStorageTeamID(),
+	                                                          &lastVersion,
+	                                                          pTLogInterfaces,
+	                                                          deserializer,
+	                                                          wrappedDeserializerIter,
+	                                                          &workArena,
+	                                                          pAttachArena);
 
-	return peekRemote(context);
+	return details::StorageTeamPeekCursor::peekRemote(context);
 }
 
 void StorageTeamPeekCursor::nextImpl() {
-	++deserializerIter;
+	++(wrappedDeserializerIter.get());
 }
 
 const VersionSubsequenceMessage& StorageTeamPeekCursor::getImpl() const {
-	return *deserializerIter;
+	return *wrappedDeserializerIter.get();
 }
 
 bool StorageTeamPeekCursor::hasRemainingImpl() const {
-	return deserializerIter != deserializer.end();
+	if (!reportEmptyVersion) {
+		while (wrappedDeserializerIter.get() != deserializer.end() &&
+		       wrappedDeserializerIter.get()->message.getType() == Message::Type::EMPTY_VERSION_MESSAGE) {
+			++(wrappedDeserializerIter.get());
+		}
+	}
+	return wrappedDeserializerIter.get() != deserializer.end();
+}
+
+#pragma endregion StorageTeamPeekCursor
+
+namespace merged {
+
+namespace details {
+
+#pragma region OrderedCursorContainer
+
+bool OrderedCursorContainer::heapElementComparator(OrderedCursorContainer::element_t e1,
+                                                   OrderedCursorContainer::element_t e2) {
+	return *e1 > *e2;
+}
+
+OrderedCursorContainer::OrderedCursorContainer() {
+	std::make_heap(std::begin(container), std::end(container), heapElementComparator);
+}
+
+void OrderedCursorContainer::pushImpl(const OrderedCursorContainer::element_t& pCursor) {
+	container.push_back(pCursor);
+	std::push_heap(std::begin(container), std::end(container), heapElementComparator);
+}
+
+void OrderedCursorContainer::popImpl() {
+	std::pop_heap(std::begin(container), std::end(container), heapElementComparator);
+	container.pop_back();
+}
+
+#pragma endregion OrderedCursorContainer
+
+#pragma region UnorderedCursorContainer
+
+void UnorderedCursorContainer::pushImpl(const UnorderedCursorContainer::element_t& pCursor) {
+	container.push_back(pCursor);
+}
+
+void UnorderedCursorContainer::popImpl() {
+	container.pop_front();
+}
+
+#pragma endregion UnorderedCursorContainer
+
+#pragma region StorageTeamIDCursorMapperMixin
+
+void StorageTeamIDCursorMapperMixin::addCursor(std::shared_ptr<StorageTeamPeekCursor>&& cursor) {
+	addCursorImpl(std::move(cursor));
+}
+
+void StorageTeamIDCursorMapperMixin::addCursorImpl(std::shared_ptr<StorageTeamPeekCursor>&& cursor) {
+	const StorageTeamID& storageTeamID = cursor->getStorageTeamID();
+	ASSERT(!isCursorExists(storageTeamID));
+	mapper[storageTeamID] = std::shared_ptr<StorageTeamPeekCursor>(std::move(cursor));
+}
+
+std::shared_ptr<StorageTeamPeekCursor> StorageTeamIDCursorMapperMixin::removeCursor(
+    const StorageTeamID& storageTeamID) {
+
+	ASSERT(isCursorExists(storageTeamID));
+	return removeCursorImpl(storageTeamID);
+}
+
+std::shared_ptr<StorageTeamPeekCursor> StorageTeamIDCursorMapperMixin::removeCursorImpl(
+    const StorageTeamID& storageTeamID) {
+
+	std::shared_ptr<StorageTeamPeekCursor> result = mapper[storageTeamID];
+	mapper.erase(storageTeamID);
+	return result;
+}
+
+bool StorageTeamIDCursorMapperMixin::isCursorExists(const StorageTeamID& storageTeamID) const {
+	return mapper.find(storageTeamID) != mapper.end();
+}
+
+StorageTeamPeekCursor& StorageTeamIDCursorMapperMixin::getCursor(const StorageTeamID& storageTeamID) {
+	ASSERT(isCursorExists(storageTeamID));
+	return *mapper[storageTeamID];
+}
+
+const StorageTeamPeekCursor& StorageTeamIDCursorMapperMixin::getCursor(const StorageTeamID& storageTeamID) const {
+	ASSERT(isCursorExists(storageTeamID));
+	return *mapper.at(storageTeamID);
+}
+
+std::shared_ptr<StorageTeamPeekCursor> StorageTeamIDCursorMapperMixin::getCursorPtr(
+    const StorageTeamID& storageTeamID) {
+
+	ASSERT(isCursorExists(storageTeamID));
+	return mapper.at(storageTeamID);
+}
+
+int StorageTeamIDCursorMapperMixin::getNumCursors() const {
+	return mapper.size();
+}
+
+StorageTeamIDCursorMapperMixin::StorageTeamIDCursorMapper::iterator StorageTeamIDCursorMapperMixin::cursorsBegin() {
+	return std::begin(mapper);
+}
+
+StorageTeamIDCursorMapperMixin::StorageTeamIDCursorMapper::iterator StorageTeamIDCursorMapperMixin::cursorsEnd() {
+	return std::end(mapper);
+}
+
+#pragma endregion StorageTeamIDCursorMapperMixin
+
+namespace BroadcastedStorageTeamPeekCursor {
+
+struct PeekRemoteContext {
+	using GetCursorPtrFunc_t = std::function<std::shared_ptr<StorageTeamPeekCursor>(const StorageTeamID&)>;
+
+	// Cursors that are empty
+	std::list<StorageTeamID>& emptyCursorStorageTeamIDs;
+
+	// Cursors that meets end-of-stream when querying the TLog server
+	std::list<StorageTeamID>& retiredCursorStorageTeamIDs;
+
+	// Function that called to get the corresponding cursor by storage team id
+	GetCursorPtrFunc_t getCursorPtr;
+
+	PeekRemoteContext(std::list<StorageTeamID>& emptyCursorStorageTeamIDs_,
+	                  std::list<StorageTeamID>& retiredCursorStorageTeamIDs_,
+	                  GetCursorPtrFunc_t getCursorPtr_)
+	  : emptyCursorStorageTeamIDs(emptyCursorStorageTeamIDs_),
+	    retiredCursorStorageTeamIDs(retiredCursorStorageTeamIDs_), getCursorPtr(getCursorPtr_) {}
+};
+
+struct PeekSingleCursorResult {
+	bool retrievedData = false;
+	bool endOfStream = false;
+};
+
+ACTOR Future<PeekSingleCursorResult> peekSingleCursor(std::shared_ptr<StorageTeamPeekCursor> pCursor) {
+	state int i = 0;
+	state ptxn::test::ExponentalBackoffDelay exponentalBackoff(SERVER_KNOBS->MERGE_CURSOR_RETRY_DELAY);
+	exponentalBackoff.enable();
+
+	while (i < SERVER_KNOBS->MERGE_CURSOR_RETRY_TIMES) {
+		try {
+			state bool receivedData = wait(pCursor->remoteMoreAvailable());
+		} catch (Error& error) {
+			if (error.code() == error_code_end_of_stream) {
+				return PeekSingleCursorResult{ false, true };
+			}
+			throw;
+		}
+		if (receivedData) {
+			exponentalBackoff.resetBackoffs();
+			return PeekSingleCursorResult{ true, false };
+		}
+		if (++i == SERVER_KNOBS->MERGE_CURSOR_RETRY_TIMES) {
+			break;
+		}
+		wait(exponentalBackoff());
+	}
+
+	return PeekSingleCursorResult{ false, false };
+}
+
+// Returns the number of cursors reported that has received messages from TLogs
+ACTOR Future<bool> peekRemote(std::shared_ptr<PeekRemoteContext> pPeekRemoteContext) {
+	if (pPeekRemoteContext->emptyCursorStorageTeamIDs.empty()) {
+		throw end_of_stream();
+	}
+
+	std::vector<Future<PeekSingleCursorResult>> cursorFutures;
+	std::transform(
+	    std::begin(pPeekRemoteContext->emptyCursorStorageTeamIDs),
+	    std::end(pPeekRemoteContext->emptyCursorStorageTeamIDs),
+	    std::back_inserter(cursorFutures),
+	    /* NOTE ACTORs are compiled into classes */
+	    [this](const auto& storageTeamID) -> auto {
+		    return peekSingleCursor(pPeekRemoteContext->getCursorPtr(storageTeamID));
+	    });
+	state std::vector<PeekSingleCursorResult> cursorResults = wait(getAll(cursorFutures));
+
+	auto cursorResultsIter = std::begin(cursorResults);
+	auto emptyCursorStorageTeamIDsIter = std::begin(pPeekRemoteContext->emptyCursorStorageTeamIDs);
+	// For any cursors need to be refilled, if the final state is either filled or end_of_stream, the cursors will
+	// be ready; otherwise, not ready.
+	bool cursorsReady = true;
+	while (cursorResultsIter != std::end(cursorResults)) {
+		const auto& peekResult = *cursorResultsIter++;
+		const StorageTeamID& storageTeamID = *emptyCursorStorageTeamIDsIter;
+
+		// Timeout
+		if (!peekResult.endOfStream && !peekResult.retrievedData) {
+			TraceEvent(SevWarn, "CursorTimeOutError").detail("StorageTeamID", storageTeamID);
+			cursorsReady = false;
+			++emptyCursorStorageTeamIDsIter;
+			continue;
+		}
+
+		if (peekResult.endOfStream) {
+			TraceEvent(SevInfo, "CursorEndOfStream").detail("StorageTeamID", storageTeamID);
+			pPeekRemoteContext->retiredCursorStorageTeamIDs.push_back(storageTeamID);
+		}
+
+		pPeekRemoteContext->emptyCursorStorageTeamIDs.erase(emptyCursorStorageTeamIDsIter++);
+	}
+
+	return cursorsReady;
+}
+
+} // namespace BroadcastedStorageTeamPeekCursor
+
+} // namespace details
+
+#pragma region BroadcastedStorageTeamPeekCursorBase
+
+bool BroadcastedStorageTeamPeekCursorBase::tryFillCursorContainer() {
+	ASSERT(getNumCursors() != 0);
+	ASSERT(pCursorContainer && pCursorContainer->empty());
+
+	for (const auto& storageTeamID : retiredCursorStorageTeamIDs) {
+		removeCursor(storageTeamID);
+	}
+
+	if (getNumCursors() == 0) {
+		// We have no active cursors, fail the cursor filling process
+		// In this case, the caller should do the RPC, and peekRemote should throw end_of_stream to indicate the cursor
+		// is expired.
+		return false;
+	}
+
+	// Find the current version all the cursors are sharing
+	currentVersion = invalidVersion;
+	bool isFirstElement = true;
+	for (auto iter = cursorsBegin(); iter != cursorsEnd(); ++iter) {
+		auto pCursor = iter->second;
+		if (!pCursor->hasRemaining()) {
+			emptyCursorStorageTeamIDs.push_back(pCursor->getStorageTeamID());
+			continue;
+		}
+
+		Version cursorVersion = iter->second->getVersion();
+		if (isFirstElement) {
+			currentVersion = cursorVersion;
+			isFirstElement = false;
+		} else {
+			// In the broadcast model, the cursors must be in state of:
+			//   * For cursors that have messages, they share the same version.
+			// . * Otherwise, the cursor must have no remaining data, i.e. needs RPC to get refilled.
+			// The cursors cannot be lagged behind, or the subsequence constraint cannot be fulfilled.
+			UNSTOPPABLE_ASSERT(currentVersion == cursorVersion);
+		}
+	}
+
+	if (!emptyCursorStorageTeamIDs.empty()) {
+		// There are cursors locally consumed. Requires RPC to get a refill.
+		return false;
+	}
+
+	// No cursor should report its version invalidVersion
+	ASSERT(currentVersion != invalidVersion);
+
+	// Now the cursors are all sharing the same version, fill the cursor container for consumption
+	for (auto iter = cursorsBegin(); iter != cursorsEnd(); ++iter) {
+		pCursorContainer->push(
+		    std::dynamic_pointer_cast<ptxn::details::VersionSubsequencePeekCursorBase>(iter->second));
+	}
+
+	return true;
+}
+
+Future<bool> BroadcastedStorageTeamPeekCursorBase::remoteMoreAvailableImpl() {
+	using PeekRemoteContext = details::BroadcastedStorageTeamPeekCursor::PeekRemoteContext;
+	std::shared_ptr<PeekRemoteContext> pContext = std::make_shared<PeekRemoteContext>(
+	    emptyCursorStorageTeamIDs, retiredCursorStorageTeamIDs, [this](const StorageTeamID& storageTeamID) -> auto {
+		    return getCursorPtr(storageTeamID);
+	    });
+	return details::BroadcastedStorageTeamPeekCursor::peekRemote(pContext);
+}
+
+const VersionSubsequenceMessage& BroadcastedStorageTeamPeekCursorBase::getImpl() const {
+	return pCursorContainer->front()->get();
+}
+
+void BroadcastedStorageTeamPeekCursorBase::addCursorImpl(std::shared_ptr<StorageTeamPeekCursor>&& cursor) {
+	ASSERT(!cursor->isEmptyVersionsIgnored());
+	emptyCursorStorageTeamIDs.push_back(cursor->getStorageTeamID());
+	details::StorageTeamIDCursorMapperMixin::addCursorImpl(std::move(cursor));
+}
+
+bool BroadcastedStorageTeamPeekCursorBase::hasRemainingImpl() const {
+	while (true) {
+		// Remove all empty version message
+		while (!pCursorContainer->empty() &&
+		       pCursorContainer->front()->get().message.getType() == Message::Type::EMPTY_VERSION_MESSAGE) {
+			auto& pCursorContainer = const_cast<BroadcastedStorageTeamPeekCursorBase*>(this)->pCursorContainer;
+			auto pConsumedCursor = pCursorContainer->front();
+			pConsumedCursor->next();
+			pCursorContainer->pop();
+		}
+
+		if (!pCursorContainer->empty()) {
+			return true;
+		} else {
+			// FIXME Rethink this... const_cast is bitter yet setting hasRemainingImpl non-const is also painful
+			bool tryFillResult = const_cast<BroadcastedStorageTeamPeekCursorBase*>(this)->tryFillCursorContainer();
+			if (!tryFillResult) {
+				return false;
+			}
+			return true;
+		}
+	}
+}
+
+#pragma endregion BroadcastedStorageTeamPeekCursorBase
+
+void BroadcastedStorageTeamPeekCursor_Ordered::nextImpl() {
+	if (pCursorContainer->empty() && !tryFillCursorContainer()) {
+		// Calling BroadcastedStorageTeamPeekCursor::next while hasRemaining is fals
+		ASSERT(false);
+	}
+
+	details::OrderedCursorContainer::element_t pConsumedCursor = pCursorContainer->front();
+	pCursorContainer->pop();
+	pConsumedCursor->next();
+	if (pConsumedCursor->hasRemaining() && pConsumedCursor->getVersion() == currentVersion) {
+		// The current version is not completely consumed, push it back for consumption
+		pCursorContainer->push(
+		    std::dynamic_pointer_cast<ptxn::details::VersionSubsequencePeekCursorBase>(pConsumedCursor));
+	}
+}
+
+void BroadcastedStorageTeamPeekCursor_Unordered::nextImpl() {
+	if (pCursorContainer->empty() && !tryFillCursorContainer()) {
+		// Calling BroadcastedStorageTeamPeekCursor::next while hasRemaining is fals
+		ASSERT(false);
+	}
+
+	details::OrderedCursorContainer::element_t pConsumedCursor = pCursorContainer->front();
+	pConsumedCursor->next();
+	if (!pConsumedCursor->hasRemaining() || pConsumedCursor->getVersion() != currentVersion) {
+		pCursorContainer->pop();
+	}
+}
+
+} // namespace merged
+
+// Moves the cursor so it locates to the given version/subsequence. If the version/subsequence does not exist, moves the
+// cursor to the closest next mutation. If the version/subsequence is earlier than the current version/subsequence the
+// cursor is located, then the code will do nothing.
+ACTOR Future<Void> advanceTo(PeekCursorBase* cursor, Version version, Subsequence subsequence) {
+	state PeekCursorBase::iterator iter = cursor->begin();
+
+	loop {
+		while (iter != cursor->end()) {
+			// Is iter already past the version?
+			if (iter->version > version) {
+				return Void();
+			}
+			// Is iter current at the given version?
+			if (iter->version == version) {
+				while (iter != cursor->end() && iter->version == version && iter->subsequence < subsequence)
+					++iter;
+				if (iter->version > version || iter->subsequence >= subsequence) {
+					return Void();
+				}
+			}
+			++iter;
+		}
+
+		// Consumed local data, need to check remote TLog
+		bool remoteAvailable = wait(cursor->remoteMoreAvailable());
+		if (!remoteAvailable) {
+			// The version/subsequence should be in the future
+			// Throw error?
+			return Void();
+		}
+	}
 }
 
 //////////////////////////////////////////////////////////////////////////////////

--- a/fdbserver/ptxn/TLogPeekCursor.actor.h
+++ b/fdbserver/ptxn/TLogPeekCursor.actor.h
@@ -392,7 +392,7 @@ protected:
 
 } // namespace details
 
-// Base class for peeking data from multiple storage teams, when all storage teams are notified when a commit is done.
+// Base class for peeking data from multiple storage teams, where all storage teams are notified when a commit version is done, i.e., the proxy broadcasts to all teams.
 // In this case, even different teams might have different team versions, they will be informed when the commit version
 // has changed.
 class BroadcastedStorageTeamPeekCursorBase : public ptxn::details::VersionSubsequencePeekCursorBase,

--- a/fdbserver/ptxn/TLogPeekCursor.actor.h
+++ b/fdbserver/ptxn/TLogPeekCursor.actor.h
@@ -350,7 +350,7 @@ protected:
 };
 
 // Provides a Storage Team ID to StorageTeamPeekCursor mapping functionality
-class StorageTeamIDCursorMapper{
+class StorageTeamIDCursorMapper {
 public:
 	using StorageTeamIDCursorMapper_t = std::unordered_map<StorageTeamID, std::shared_ptr<StorageTeamPeekCursor>>;
 
@@ -396,7 +396,7 @@ protected:
 // In this case, even different teams might have different team versions, they will be informed when the commit version
 // has changed.
 class BroadcastedStorageTeamPeekCursorBase : public ptxn::details::VersionSubsequencePeekCursorBase,
-                                             protected details::StorageTeamIDCursorMapper{
+                                             protected details::StorageTeamIDCursorMapper {
 protected:
 	std::unique_ptr<details::CursorContainerBase> pCursorContainer;
 

--- a/fdbserver/ptxn/test/CommitUtils.cpp
+++ b/fdbserver/ptxn/test/CommitUtils.cpp
@@ -37,54 +37,107 @@ int CommitRecord::getNumTotalMessages() const {
 	return sum;
 }
 
+std::vector<VersionSubsequenceMessage> CommitRecord::getMessagesFromStorageTeams(
+    const std::unordered_set<StorageTeamID>& storageTeamIDs) const {
+
+	std::vector<VersionSubsequenceMessage> vsm;
+	for (const auto& [version, _1] : this->messages) {
+		for (const auto& [storageTeamID, _2] : _1) {
+			if (!storageTeamIDs.empty() && storageTeamIDs.find(storageTeamID) == std::end(storageTeamIDs)) {
+				continue;
+			}
+			for (const auto& [subsequence, message] : _2) {
+				vsm.emplace_back(version, subsequence, message);
+			}
+		}
+	}
+	std::sort(std::begin(vsm), std::end(vsm));
+	return vsm;
+}
+
+const std::pair<int, int> DEFAULT_KEY_LENGTH_RANGE = { 10, 20 };
+const std::pair<int, int> DEFAULT_VALUE_LENGTH_RANGE = { 100, 200 };
+
+MutationRef generateRandomSetValue(Arena& arena,
+                                   const std::pair<int, int>& keyLengthRange,
+                                   const std::pair<int, int>& valueLengthRange) {
+	StringRef key = StringRef(arena, getRandomAlnum(keyLengthRange.first, keyLengthRange.second));
+	StringRef value = StringRef(arena, getRandomAlnum(valueLengthRange.first, valueLengthRange.second));
+	return MutationRef(MutationRef::SetValue, key, value);
+}
+
 void generateMutationRefs(const int numMutations,
                           Arena& arena,
                           VectorRef<MutationRef>& mutationRefs,
                           const std::pair<int, int>& keyLengthRange,
                           const std::pair<int, int>& valueLengthRange) {
 	for (int i = 0; i < numMutations; ++i) {
-		StringRef key = StringRef(arena, getRandomAlnum(keyLengthRange.first, keyLengthRange.second));
-		StringRef value = StringRef(arena, getRandomAlnum(valueLengthRange.first, valueLengthRange.second));
-		mutationRefs.emplace_back(arena, MutationRef(MutationRef::SetValue, key, value));
+		mutationRefs.push_back(arena, generateRandomSetValue(arena, keyLengthRange, valueLengthRange));
 	}
 }
 
 void distributeMutationRefs(VectorRef<MutationRef>& mutationRefs,
-                            const Version& version,
-                            const std::vector<StorageTeamID>& storageTeamIDs,
+                            const Version& commitVersion,
+                            const Version& storageTeamVersion,
+                            const std::vector<StorageTeamID>& allStorageTeamIDs,
                             CommitRecord& commitRecord) {
-	auto& storageTeamMessageMap = commitRecord.messages[version];
 
-	// Find the maximum subsequence used in the commitRecord for the given version
-	Subsequence subsequence = invalidSubsequence;
-	for (const auto& [_, messages] : storageTeamMessageMap) {
-		subsequence = std::max(messages.back().first, subsequence);
+	for (auto storageTeamID : allStorageTeamIDs) {
+		if (commitRecord.storageTeamEpochVersionRange.count(storageTeamID) == 0) {
+			commitRecord.storageTeamEpochVersionRange[storageTeamID] = { commitVersion, commitVersion + 1 };
+		} else {
+			commitRecord.storageTeamEpochVersionRange.at(storageTeamID).second = commitVersion + 1;
+		}
 	}
+
+	auto& storageTeamMessageMap = commitRecord.messages[commitVersion];
+	auto storageTeamIDs = randomlyPick<std::vector<StorageTeamID>>(
+	    allStorageTeamIDs, deterministicRandom()->randomInt(1, allStorageTeamIDs.size() + 1));
 
 	// Distribute the mutations
+	Subsequence subsequence = 0;
 	for (const auto& mutationRef : mutationRefs) {
 		const StorageTeamID storageTeamID = randomlyPick(storageTeamIDs);
-		storageTeamMessageMap[storageTeamID].push_back(commitRecord.messageArena, { ++subsequence, mutationRef });
+		storageTeamMessageMap[storageTeamID].push_back(
+		    commitRecord.messageArena, { ++subsequence, MutationRef(commitRecord.messageArena, mutationRef) });
 	}
+
+	// Update commit version range
+	commitRecord.firstVersion = std::min(commitRecord.firstVersion, commitVersion);
+	commitRecord.lastVersion = std::max(commitRecord.lastVersion, commitVersion);
+
+	commitRecord.commitVersionStorageTeamVersionMapper[commitVersion] = storageTeamVersion;
 }
 
 void prepareProxySerializedMessages(
     const CommitRecord& commitRecord,
-    const Version& version,
-    std::function<std::shared_ptr<ProxySubsequencedMessageSerializer>(StorageTeamID)> serializer) {
+    const Version& commitVersion,
+    std::function<std::shared_ptr<ProxySubsequencedMessageSerializer>(const StorageTeamID&)> serializerGen) {
 
-	if (commitRecord.messages.find(version) == commitRecord.messages.end()) {
+	if (commitRecord.messages.find(commitVersion) == commitRecord.messages.end()) {
 		// Version not found, skips the serialization
 		return;
 	}
-	for (const auto& [storageTeamID, messages] : commitRecord.messages.at(version)) {
-		for (const auto& [subsequence, message] : messages) {
+
+	for (const auto& [storageTeamID, _1] : commitRecord.messages.at(commitVersion)) {
+		for (const auto& [subsequence, message] : _1) {
+			auto pSerializer = serializerGen(storageTeamID);
+			// setSubsequence requires subsequence increasing, but for the first message, the subsequence is 1 and the
+			// initial subsequence for the serializer is 1 too, this causes an ASSERT failure
+			if (pSerializer->getSubsequence() != subsequence) {
+				pSerializer->setSubsequence(subsequence);
+			}
 			switch (message.getType()) {
 			case Message::Type::MUTATION_REF:
-				serializer(storageTeamID)->write(std::get<MutationRef>(message), storageTeamID);
+				pSerializer->write(std::get<MutationRef>(message), storageTeamID);
 				break;
 			case Message::Type::SPAN_CONTEXT_MESSAGE:
-				serializer(storageTeamID)->broadcastSpanContext(std::get<SpanContextMessage>(message));
+				// This might be nasty, as SPAN_CONTEXT_MESSAGE is broadcasted once, and then all new StorageTeamIDs
+				// will have it later. Do not support this at this stage.
+				ASSERT(false);
+				break;
+			case Message::Type::LOG_PROTOCOL_MESSAGE:
+				pSerializer->write(std::get<LogProtocolMessage>(message), storageTeamID);
 				break;
 			default:
 				throw internal_error_msg("Unsupported type");
@@ -93,15 +146,7 @@ void prepareProxySerializedMessages(
 	}
 }
 
-void distributeMutationRefs(VectorRef<MutationRef>& mutationRefs,
-                            const Version& version,
-                            const StorageTeamID& storageTeamID,
-                            CommitRecord& commitRecord) {
-	distributeMutationRefs(mutationRefs, version, std::vector<StorageTeamID>{ storageTeamID }, commitRecord);
-}
-
 bool isAllRecordsValidated(const CommitRecord& commitRecord) {
-	std::cout << " Check validation " << std::endl;
 	for (const auto& [_1, storageTeamTagMap] : commitRecord.tags) {
 		for (const auto& [_2, commitRecordTag] : storageTeamTagMap) {
 			if (!commitRecordTag.allValidated()) {

--- a/fdbserver/ptxn/test/CommitUtils.h
+++ b/fdbserver/ptxn/test/CommitUtils.h
@@ -103,7 +103,7 @@ void distributeMutationRefs(VectorRef<MutationRef>& mutationRefs,
                             CommitRecord& commitRecord);
 
 // For a given version, serialize the messages from CommitRecord for Proxy use
-// The lambda function will receive a StorageTeamID, and return the serializer for its corresponding TLogGroupID
+// The function will receive a StorageTeamID, and return the serializer for its corresponding TLogGroupID
 // FIXME: use TestEnvironment for the mapping
 void prepareProxySerializedMessages(
     const CommitRecord& commitRecord,

--- a/fdbserver/ptxn/test/CommitUtils.h
+++ b/fdbserver/ptxn/test/CommitUtils.h
@@ -21,8 +21,9 @@
 #ifndef FDBSERVER_PTXN_TEST_GENERATEDCOMMITS_H
 #define FDBSERVER_PTXN_TEST_GENERATEDCOMMITS_H
 
-#include <functional>
+#include <map>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -39,33 +40,75 @@ struct CommitRecordTag {
 	bool allValidated() const;
 };
 
-// Record generated commits
+// Record generated commits in the current epoch
 struct CommitRecord {
+	// Format:
+	// Commit Version ---+ Storage Team ID -- <Subsequence, Message>
+	//                   | Storage Team ID -- <Subsequence, Message>
+	//                   | Storage Team ID -- <Subsequence, Message>
+	//                     ...
+	// Commit Version ---+ Storage Team ID -- <Subsequence, Message>
+	//                   | Storage Team ID -- <Subsequence, Message>
+	//                     ...
+	using RecordType = std::map<Version, std::unordered_map<StorageTeamID, VectorRef<std::pair<Subsequence, Message>>>>;
+
+	// The arena contains the messages
 	Arena messageArena;
-	std::map<Version, std::unordered_map<StorageTeamID, VectorRef<std::pair<Subsequence, Message>>>> messages;
+
+	RecordType messages;
+
+	// Maps commit version to corresponding storage team version
+	std::map<Version, Version> commitVersionStorageTeamVersionMapper;
+
+	// Maps StorageTeamID to corresponding epoch
+	std::unordered_map<StorageTeamID, std::pair<Version, Version>> storageTeamEpochVersionRange;
+
+	// Add tag for each Commit version -- Storage Team ID pair. The tag is used for verifying the data.
 	std::map<Version, std::unordered_map<StorageTeamID, CommitRecordTag>> tags;
 
+	// Get messages from a given set of storage teams, in format
+	//     CommitVersion -- Subsequence -- Messag
+	// If the set is empty, return *all* messages in CommitRecord
+	std::vector<VersionSubsequenceMessage> getMessagesFromStorageTeams(
+	    const std::unordered_set<StorageTeamID>& storageTeamIDs = std::unordered_set<StorageTeamID>()) const;
 	int getNumTotalMessages() const;
+
+	// The first commit version
+	Version firstVersion = MAX_VERSION;
+
+	// The last commit version
+	Version lastVersion = invalidVersion;
 };
+
+extern const std::pair<int, int> DEFAULT_KEY_LENGTH_RANGE;
+extern const std::pair<int, int> DEFAULT_VALUE_LENGTH_RANGE;
+
+// Generate a random SetValue MutationRef
+MutationRef generateRandomSetValue(Arena& arena,
+                                   const std::pair<int, int>& keyLengthRange = DEFAULT_KEY_LENGTH_RANGE,
+                                   const std::pair<int, int>& valueLengthRange = DEFAULT_VALUE_LENGTH_RANGE);
 
 // Generates a series of random mutations
 void generateMutationRefs(const int numMutations,
                           Arena& arena,
                           VectorRef<MutationRef>& mutationRefs,
-                          const std::pair<int, int>& keyLengthRange = { 10, 15 },
-                          const std::pair<int, int>& valueLengthRange = { 10, 1000 });
+                          const std::pair<int, int>& keyLengthRange = DEFAULT_KEY_LENGTH_RANGE,
+                          const std::pair<int, int>& valueLengthRange = DEFAULT_VALUE_LENGTH_RANGE);
 
-// Distribute MutationRefs to StorageTeamIDs in CommitRecord
+// Distribute MutationRefs to StorageTeamIDs in CommitRecord.
 void distributeMutationRefs(VectorRef<MutationRef>& mutationRefs,
-                            const Version& version,
+                            const Version& commitVersion,
+                            const Version& storageTeamVersion,
                             const std::vector<StorageTeamID>& storageTeamIDs,
                             CommitRecord& commitRecord);
 
 // For a given version, serialize the messages from CommitRecord for Proxy use
+// The lambda function will receive a StorageTeamID, and return the serializer for its corresponding TLogGroupID
+// FIXME: use TestEnvironment for the mapping
 void prepareProxySerializedMessages(
     const CommitRecord& commitRecord,
-    const Version& version,
-    std::function<std::shared_ptr<ProxySubsequencedMessageSerializer>(StorageTeamID)> serializer);
+    const Version& commitVersion,
+    std::function<std::shared_ptr<ProxySubsequencedMessageSerializer>(const StorageTeamID&)> serializerGen);
 
 // Check if all records are validated
 bool isAllRecordsValidated(const CommitRecord& commitRecord);

--- a/fdbserver/ptxn/test/Delay.h
+++ b/fdbserver/ptxn/test/Delay.h
@@ -28,6 +28,7 @@
 
 namespace ptxn::test {
 
+// Base class for a configurable delay
 class Delay {
 	bool m_enabled = false;
 
@@ -48,6 +49,7 @@ public:
 	}
 };
 
+// Provides a fixed time delay
 class FixedTimeDelay : public Delay {
 	double m_delayTime;
 
@@ -61,6 +63,7 @@ public:
 	void setDelayTime(const double delayTime) { m_delayTime = delayTime; }
 };
 
+// Provides a delay of random time in a given range
 class RandomDelay : public Delay {
 	double m_delayLower;
 	double m_delayUpper;
@@ -80,6 +83,7 @@ public:
 	void setDelayUpper(const double upper) { m_delayUpper = upper; }
 };
 
+// Provides an exponental backoff delay with possible jitter time
 class ExponentalBackoffDelay : public Delay {
 	double m_initialBackoff;
 	bool m_useJitter = true;

--- a/fdbserver/ptxn/test/Delay.h
+++ b/fdbserver/ptxn/test/Delay.h
@@ -1,0 +1,133 @@
+/*
+ * Delay.h
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FDBSERVER_PTXN_TEST_DELAY_H
+#define FDBSERVER_PTXN_TEST_DELAY_H
+
+#pragma once
+
+#include "flow/flow.h"
+#include "flow/IRandom.h"
+
+namespace ptxn::test {
+
+class Delay {
+	bool m_enabled = false;
+
+protected:
+	virtual double getDelayTime() = 0;
+
+public:
+	bool enabled() const { return m_enabled; }
+	void setEnable(const bool flag) { m_enabled = flag; }
+	void enable() { setEnable(true); }
+	void disable() { setEnable(false); }
+
+	Future<Void> operator()() {
+		if (enabled()) {
+			return delay(getDelayTime());
+		}
+		return Void();
+	}
+};
+
+class FixedTimeDelay : public Delay {
+	double m_delayTime;
+
+protected:
+	virtual double getDelayTime() { return m_delayTime; }
+
+public:
+	FixedTimeDelay(const double delayTime_ = 1.0) : m_delayTime(delayTime_) {}
+
+	double delayTime() const { return const_cast<FixedTimeDelay*>(this)->getDelayTime(); }
+	void setDelayTime(const double delayTime) { m_delayTime = delayTime; }
+};
+
+class RandomDelay : public Delay {
+	double m_delayLower;
+	double m_delayUpper;
+
+protected:
+	virtual double getDelayTime() {
+		return m_delayLower + (m_delayUpper - m_delayLower) * deterministicRandom()->random01();
+	}
+
+public:
+	RandomDelay(const double delayLower_ = 0.0005, const double delayUpper_ = 0.001)
+	  : m_delayLower(delayLower_), m_delayUpper(delayUpper_) {}
+
+	double delayLower() const { return m_delayLower; }
+	double delayUpper() const { return m_delayUpper; }
+	void setDelayLower(const double lower) { m_delayLower = lower; }
+	void setDelayUpper(const double upper) { m_delayUpper = upper; }
+};
+
+class ExponentalBackoffDelay : public Delay {
+	double m_initialBackoff;
+	bool m_useJitter = true;
+	double m_jitterLower;
+	double m_jitterUpper;
+	double m_backoff;
+	int m_numBackoffs = 0;
+
+	double getJitterTime() const {
+		static const int RANGE = 10000;
+		return (m_jitterUpper - m_jitterLower) * deterministicRandom()->randomInt(0, RANGE) / RANGE + m_jitterLower;
+	}
+
+	virtual double getDelayTime() {
+		double delayTime = m_backoff + (m_useJitter ? getJitterTime() : 0);
+		m_backoff *= 2;
+		++m_numBackoffs;
+		return delayTime;
+	}
+
+public:
+	ExponentalBackoffDelay(const double initialBackoff_ = 0.01,
+	                       const bool useJitter_ = true,
+	                       const double jitterLower_ = 0.0001,
+	                       const double jitterUpper_ = 0.0002)
+	  : m_initialBackoff(initialBackoff_), m_useJitter(useJitter_), m_jitterLower(jitterLower_),
+	    m_jitterUpper(jitterUpper_), m_backoff(initialBackoff_), m_numBackoffs(0) {}
+
+	double initialBackoff() const { return m_initialBackoff; }
+	void setInitialBackoff(const double initialBackoff) { m_initialBackoff = initialBackoff; }
+
+	bool useJitter() const { return m_useJitter; }
+	void setUseJitter(const bool useJitter) { m_useJitter = useJitter; }
+
+	double jitterLower() const { return m_jitterLower; }
+	void setJitterLower(const double jitterLower) { m_jitterLower = jitterLower; }
+
+	double jitterUpper() const { return m_jitterUpper; }
+	void setJitterUpper(const double jitterUpper) { m_jitterUpper = jitterUpper; }
+
+	int numBackoffs() const { return m_numBackoffs; }
+	// Resets the backoffs to 0
+	void resetBackoffs() {
+		m_numBackoffs = 0;
+		m_backoff = m_initialBackoff;
+	}
+};
+
+} // namespace ptxn::test
+
+#endif // FDBSERVER_PTXN_TEST_DELAY_H

--- a/fdbserver/ptxn/test/Driver.actor.cpp
+++ b/fdbserver/ptxn/test/Driver.actor.cpp
@@ -275,6 +275,12 @@ void MessageFixture::setUp(const TLogGroupFixture& tLogGroupStorageTeamMapping,
 
 #pragma region ptxnTLogFixture
 
+ptxnTLogFixture::~ptxnTLogFixture() {
+	for (auto& actor : actors) {
+	    actor.cancel();
+	}
+}
+
 void ptxnTLogFixture::setUp(const int numTLogs) {
 	int tLogGroupIndex = 0;
 	auto assignTLogGroup = [this](const TLogGroupID& tLogGroupID, std::shared_ptr<FakeTLogContext> pTLogContext) {

--- a/fdbserver/ptxn/test/Driver.actor.cpp
+++ b/fdbserver/ptxn/test/Driver.actor.cpp
@@ -277,7 +277,7 @@ void MessageFixture::setUp(const TLogGroupFixture& tLogGroupStorageTeamMapping,
 
 ptxnTLogFixture::~ptxnTLogFixture() {
 	for (auto& actor : actors) {
-	    actor.cancel();
+		actor.cancel();
 	}
 }
 

--- a/fdbserver/ptxn/test/Driver.actor.cpp
+++ b/fdbserver/ptxn/test/Driver.actor.cpp
@@ -262,14 +262,14 @@ void MessageFixture::setUp(const TLogGroupFixture& tLogGroupStorageTeamMapping,
                            const int numVersions,
                            const int numMutationsInVersion) {
 	const std::vector<StorageTeamID>& storageTeamIDs = tLogGroupStorageTeamMapping.storageTeamIDs;
-
-	Version version = initialVersion;
+	Version storageTeamVersion = 0;
+	Version commitVersion = initialVersion;
 	for (int _ = 0; _ < numVersions; ++_) {
 		Arena mutationArena;
 		VectorRef<MutationRef> mutationRefs;
 		generateMutationRefs(numMutationsInVersion, mutationArena, mutationRefs);
-		distributeMutationRefs(mutationRefs, version, storageTeamIDs, commitRecord);
-		version += deterministicRandom()->randomInt(5, 11);
+		distributeMutationRefs(mutationRefs, commitVersion, ++storageTeamVersion, storageTeamIDs, commitRecord);
+		commitVersion += deterministicRandom()->randomInt(5, 11);
 	}
 }
 

--- a/fdbserver/ptxn/test/Driver.h
+++ b/fdbserver/ptxn/test/Driver.h
@@ -197,6 +197,8 @@ struct ptxnTLogFixture {
 	  : tLogGroupFixture(tLogGroupFixture_), pTestDriverContext(pTestDriverContext_),
 	    tLogGroupLeaders(pTestDriverContext->tLogGroupLeaders), tLogInterfaces(pTestDriverContext->tLogInterfaces) {}
 
+	~ptxnTLogFixture();
+
 	// Returns the shared_ptr of the TLog interface for the given TLogGroupID
 	// The user must explicitly cast/provide the interface type.
 	ptxn::details::TLogInterfaceSharedPtrWrapper getTLogLeaderByTLogGroupID(const TLogGroupID& tLogGroupID) const;

--- a/fdbserver/ptxn/test/FakeTLog.actor.h
+++ b/fdbserver/ptxn/test/FakeTLog.actor.h
@@ -24,6 +24,7 @@
 #elif !defined(FDBSERVER_PTXN_TEST_FAKETLOG_ACTOR_H)
 #define FDBSERVER_PTXN_TEST_FAKETLOG_ACTOR_H
 
+#include <limits>
 #include <memory>
 #include <unordered_map>
 
@@ -31,6 +32,7 @@
 #include "fdbserver/ptxn/MessageSerializer.h"
 #include "fdbserver/ptxn/MessageTypes.h"
 #include "fdbserver/ptxn/StorageServerInterface.h"
+#include "fdbserver/ptxn/test/Delay.h"
 #include "fdbserver/ptxn/TLogInterface.h"
 #include "flow/flow.h"
 
@@ -43,10 +45,16 @@ namespace ptxn::test {
 struct TestDriverContext;
 
 struct FakeTLogContext {
+	// FIXME FakeTLogContext should *not* depend on TestDriverContext, should use TestEnvironment
 	std::shared_ptr<TestDriverContext> pTestDriverContext;
 	std::shared_ptr<TLogInterfaceBase> pTLogInterface;
 
+	// Maximum bytes a peek would return
+	// The actual bytes might be different since
 	size_t maxBytesPerPeek = 1024 * 1024;
+
+	// Maximum versions a peek would return
+	int maxVersionsPerPeek = std::numeric_limits<int>::max();
 
 	// Team IDs
 	std::vector<StorageTeamID> storageTeamIDs;
@@ -58,8 +66,20 @@ struct FakeTLogContext {
 	// keep its own version of data, to simulate the "persistence" behavior.
 	Arena persistenceArena;
 
-	// Deseriqlized messages grouped by teams
-	std::unordered_map<StorageTeamID, VectorRef<VersionSubsequenceMessage>> storageTeamMessages;
+	using StorageTeamMessages = std::unordered_map<StorageTeamID, VectorRef<VersionSubsequenceMessage>>;
+	// Stores the messages per commit version, in format
+	// Commit version -- ( Storage Team ID -- (Storage Team Version, Subsequence, Message) )
+	//                   ( Storage Team ID -- (Storage Team Version, Subsequence, Message) )
+	//                   ...
+	// Commit version -- ( Storage Team ID -- (Storage Team Version, Subsequence, Message) )
+	//                   ...
+	std::map<Version, StorageTeamMessages> epochVersionMessages;
+
+	// Stores the version range per epoch
+	std::vector<std::pair<Version, Version>> epochVersionRange;
+
+	// Delay to simulate network latency
+	RandomDelay latency = RandomDelay(0.01, 0.02);
 };
 
 ACTOR Future<Void> fakeTLog_ActivelyPush(std::shared_ptr<FakeTLogContext> pFakeTLogContext);

--- a/fdbserver/ptxn/test/TestSerialization.cpp
+++ b/fdbserver/ptxn/test/TestSerialization.cpp
@@ -301,9 +301,7 @@ void generateMutations(std::vector<ptxn::VersionSubsequenceMessage>& mutations, 
 			subsequence = 0;
 		}
 
-		mutations.emplace_back(version,
-		                       ++subsequence,
-		                       ptxn::test::generateRandomSetValue(arena));
+		mutations.emplace_back(version, ++subsequence, ptxn::test::generateRandomSetValue(arena));
 	}
 }
 
@@ -719,14 +717,14 @@ bool testDeserializerReset() {
 
 	SubsequencedMessageDeserializer deserializer(serialized1);
 	auto iter1 = deserializer.begin();
-	for(int i = 0; i < NUM_MUTATIONS; ++i, ++iter1) {
+	for (int i = 0; i < NUM_MUTATIONS; ++i, ++iter1) {
 		ASSERT(*iter1 == data1[i]);
 	}
 	ASSERT(iter1 == deserializer.end());
 
 	deserializer.reset(serialized2);
 	auto iter2 = deserializer.begin();
-	for(int i = 0; i < NUM_MUTATIONS; ++i, ++iter2) {
+	for (int i = 0; i < NUM_MUTATIONS; ++i, ++iter2) {
 		ASSERT(*iter2 == data2[i]);
 	}
 	ASSERT(iter2 == deserializer.end());

--- a/fdbserver/ptxn/test/TestTLogPeek.actor.cpp
+++ b/fdbserver/ptxn/test/TestTLogPeek.actor.cpp
@@ -20,6 +20,8 @@
 
 #include "fdbserver/ptxn/test/TestTLogPeek.h"
 
+#include <numeric>
+
 #include "fdbserver/ptxn/MessageTypes.h"
 #include "fdbserver/ptxn/test/Driver.h"
 #include "fdbserver/ptxn/test/FakeTLog.actor.h"
@@ -31,166 +33,361 @@
 namespace ptxn::test {
 
 TestTLogPeekOptions::TestTLogPeekOptions(const UnitTestParameters& params)
-  : numMutations(params.getInt("numMutations").orDefault(DEFAULT_NUM_MUTATIONS)),
+  : numVersions(params.getInt("numVersions").orDefault(DEFAULT_NUM_VERSIONS)),
+    numMutationsPerVersion(params.getInt("numMutationsPerVersion").orDefault(DEFAULT_NUM_MUTATIONS_PER_VERSION)),
     numStorageTeams(params.getInt("numStorageTeams").orDefault(DEFAULT_NUM_TEAMS)),
     initialVersion(params.getInt("initialVersion").orDefault(DEFAULT_INITIAL_VERSION)),
     peekTimes(params.getInt("peekTimes").orDefault(DEFAULT_PEEK_TIMES)) {}
 
+TestTLogPeekMergeCursorOptions::TestTLogPeekMergeCursorOptions(const UnitTestParameters& params)
+  : numTLogs(params.getInt("numTLogs").orDefault(DEFAULT_NUM_TLOGS)),
+    numMutationsPerVersion(params.getInt("numMutationsPerVersion").orDefault(DEFAULT_NUM_MUTATIONS_PER_VERSION)),
+    initialVersion(params.getInt("initialVersion").orDefault(DEFAULT_INITIAL_VERSION)),
+    numVersions(params.getInt("numVersions").orDefault(DEFAULT_NUM_VERSIONS)) {}
+
 namespace {
+// FIXME this should be moved to a more generic place
+// Feed the message generated in CommitRecord to TLog servers
+ACTOR Future<Void> messageFeeder() {
+	state print::PrintTiming printTiming("messageFeeder");
+	state RandomDelay randomDelay(0.0, 0.1);
+	state CommitRecord::RecordType& committedMessages = TestEnvironment::getCommitRecords().messages;
+	randomDelay.enable();
 
-Future<Void> initializeTLogForPeekTest(MessageTransferModel transferModel,
-                                       const int numStorageTeams,
-                                       std::shared_ptr<FakeTLogContext>& pContext) {
-	// We use the CommitRecord in the context -- no other parts needed, so no need to call initTestDriverContext
-	if (!pContext->pTestDriverContext)
-		pContext->pTestDriverContext.reset(new TestDriverContext());
+	// Need to use an explicit iterator since there is a wait statement in the loop
+	state CommitRecord::RecordType::const_iterator iter;
+	iter = std::cbegin(committedMessages);
+	state std::vector<Future<TLogCommitReply>> replies;
+	for (; iter != std::cend(committedMessages); ++iter) {
+		const Version& commitVersion = iter->first;
+		const Version& storageTeamVersion =
+		    TestEnvironment::getCommitRecords().commitVersionStorageTeamVersionMapper.at(commitVersion);
+		printTiming << "Injecting version " << commitVersion << "(Storage Team Version = " << storageTeamVersion
+		            << ") to TLogs" << std::endl;
 
-	pContext->pTLogInterface = getNewTLogInterface(transferModel);
-	pContext->pTLogInterface->initEndpoints();
+		// Serialize the version
+		std::unordered_map<TLogGroupID, std::shared_ptr<ProxySubsequencedMessageSerializer>> tLogGroupSerializers;
+		prepareProxySerializedMessages(
+		    TestEnvironment::getCommitRecords(),
+		    commitVersion,
+		    [&tLogGroupSerializers, &storageTeamVersion ](const auto& storageTeamID) -> auto {
+			    const auto& mapping = TestEnvironment::getTLogGroup().storageTeamTLogGroupMapping;
+			    const auto i = mapping.find(storageTeamID);
+			    ASSERT(i != std::end(mapping));
+			    const auto tLogGroupID = i->second;
+			    if (!tLogGroupSerializers.count(tLogGroupID)) {
+				    const auto& storageTeamIDs = TestEnvironment::getTLogGroup().storageTeamIDs;
+				    tLogGroupSerializers.emplace(
+				        tLogGroupID,
+				        std::make_shared<BroadcastedSubsequencedMessageSerializer>(storageTeamVersion, storageTeamIDs));
+			    }
+			    return tLogGroupSerializers[tLogGroupID];
+		    });
 
-	// We do NOT use the storageTeamID in the TestDriverContext
-	for (auto _ = 0; _ < numStorageTeams; ++_) {
-		pContext->storageTeamIDs.push_back(getNewStorageTeamID());
-	}
-
-	return getFakeTLogActor(transferModel, pContext);
-}
-
-void fillTLogWithRandomMutations(std::shared_ptr<FakeTLogContext> pFakeTLogContext,
-                                 const Version& initialVersion,
-                                 const int numMutations) {
-	ASSERT(pFakeTLogContext);
-	ASSERT(pFakeTLogContext->pTestDriverContext);
-
-	print::PrintTiming printTiming(__FUNCTION__);
-
-	Arena& arena = pFakeTLogContext->persistenceArena;
-	VectorRef<MutationRef> mutationRefs;
-	generateMutationRefs(numMutations, arena, mutationRefs);
-
-	CommitRecord& commitRecord = pFakeTLogContext->pTestDriverContext->commitRecord;
-	if (!commitRecord.messageArena.sameArena(arena)) {
-		commitRecord.messageArena.dependsOn(arena);
-	}
-
-	auto& epochVersionMessages = pFakeTLogContext->epochVersionMessages;
-	Version version = initialVersion;
-	Subsequence subsequence = 0;
-
-	pFakeTLogContext->versions.push_back(version);
-	for (int i = 0; i < numMutations; ++i) {
-		// 20% chance version change
-		if (deterministicRandom()->randomInt(0, 10) <= 2) {
-			version += deterministicRandom()->randomInt(5, 10);
-			subsequence = 0;
-			pFakeTLogContext->versions.push_back(version);
+		// Send to TLogInterfaces
+		for (auto& [tLogGroupID, serializer] : tLogGroupSerializers) {
+			auto serialized = serializer->getAllSerialized();
+			// NOTE In this test, there is only one storage team per TLog group
+			for (const auto& [storageTeamID, serializedData] : serialized.second) {
+				printTiming << "TLog Group ID " << tLogGroupID << "  Storage Team ID: " << storageTeamID << std::endl;
+				TLogCommitRequest request(deterministicRandom()->randomUniqueID(),
+				                          tLogGroupID,
+				                          serialized.first,
+				                          { { storageTeamID, serializedData } },
+				                          0, // FakeTLog does not care previous version yet
+				                          commitVersion,
+				                          /* knownCommittedVersion */ 0,
+				                          /* minKnownCommittedVersion */ 0,
+				                          /* addedTeams */ {},
+				                          /* removedTeams */ {},
+				                          /* teamToTags */ {},
+				                          Optional<UID>());
+				std::shared_ptr<TLogInterface_PassivelyPull> pInterface =
+				    TestEnvironment::getTLogs()->getTLogLeaderByStorageTeamID(storageTeamID);
+				replies.push_back(pInterface->commit.getReply(request));
+			}
 		}
-		const StorageTeamID& storageTeamID = randomlyPick(pFakeTLogContext->storageTeamIDs);
-		epochVersionMessages[version][storageTeamID].push_back(arena, { version, ++subsequence, mutationRefs[i] });
+
+		wait(randomDelay());
 	}
+
+	return Void();
 }
 
-std::vector<ptxn::VersionSubsequenceMessage> collectAllMessagesFromCommitRecord(const CommitRecord& commitRecord) {
-	std::vector<ptxn::VersionSubsequenceMessage> allMessages;
+ACTOR Future<std::vector<VersionSubsequenceMessage>> getAllMessageFromCursor(std::shared_ptr<PeekCursorBase> pCursor,
+                                                                             Arena* arena) {
+	state std::vector<VersionSubsequenceMessage> messages;
+	state RandomDelay randomDelay(0.01, 0.02);
+	state int i = 0;
+	loop {
+		try {
+			state bool remoteAvailable = wait(pCursor->remoteMoreAvailable());
+		} catch (Error& err) {
+			if (err.code() != error_code_end_of_stream) {
+				throw;
+			}
+			break;
+		}
 
-	for (const auto& [version, teamedMessages] : commitRecord.messages) {
-		for (const auto& [storageTeamID, subsequencedMessages] : teamedMessages) {
-			for (int i = 0; i < subsequencedMessages.size(); ++i) {
-				allMessages.emplace_back(version, subsequencedMessages[i].first, subsequencedMessages[i].second);
+		if (!remoteAvailable) {
+			// In serious work this should be exponental backoff with jitter
+			wait(randomDelay());
+		} else {
+			for (const VersionSubsequenceMessage& vsm : *pCursor) {
+				// Empty version message type is not stored in CommitRecord
+				if (vsm.message.getType() == Message::Type::EMPTY_VERSION_MESSAGE) {
+					continue;
+				}
+				if (vsm.message.getType() == Message::Type::MUTATION_REF) {
+					messages.emplace_back(
+					    vsm.version, vsm.subsequence, MutationRef(*arena, std::get<MutationRef>(vsm.message)));
+				} else {
+					messages.emplace_back(vsm);
+				}
 			}
 		}
 	}
-	std::sort(std::begin(allMessages), std::end(allMessages));
-
-	return allMessages;
-}
-
-// Randomly peek data from FakeTLog and verify if the data is consistent
-ACTOR Future<Void> peekAndCheck(std::shared_ptr<FakeTLogContext> pContext) {
-	state print::PrintTiming printTiming("peekAndCheck");
-
-	state std::vector<StorageTeamID>& storageTeamIDs = pContext->storageTeamIDs;
-	state std::vector<Version>& versions = pContext->versions;
-
-	state Optional<UID> debugID(randomUID());
-	state StorageTeamID storageTeamID(randomlyPick(storageTeamIDs));
-
-	state Version beginVersion(randomlyPick(versions));
-	state Version endVersion(beginVersion + deterministicRandom()->randomInt(5, 20));
-
-	state TLogPeekRequest request(debugID, beginVersion, endVersion, false, false, storageTeamID, TLogGroupID());
-	print::print(request);
-
-	state TLogPeekReply reply = wait(pContext->pTLogInterface->peek.getReply(request));
-	print::print(reply);
-
-	return Void();
+	return messages;
 }
 
 } // anonymous namespace
 
 } // namespace ptxn::test
 
-TEST_CASE("/fdbserver/ptxn/test/tLogPeek/readFromSerialization") {
+TEST_CASE("/fdbserver/ptxn/test/tLogPeek/cursor/StorageTeamPeekCursor") {
 	state ptxn::test::TestTLogPeekOptions options(params);
-	state std::shared_ptr<ptxn::test::FakeTLogContext> pContext = std::make_shared<ptxn::test::FakeTLogContext>();
-	state int numPeeks = 0;
-	state Future<Void> tLog;
+	state ptxn::test::TestEnvironment testEnvironment;
+	state ptxn::test::print::PrintTiming printTiming("TestStorageTeamPeekCursor");
+	state std::vector<Future<Void>> actors;
 
-	tLog = ptxn::test::initializeTLogForPeekTest(
-	    ptxn::MessageTransferModel::TLogActivelyPush, options.numStorageTeams, pContext);
-	ptxn::test::fillTLogWithRandomMutations(pContext, options.initialVersion, options.numMutations);
+	testEnvironment.initDriverContext()
+	    .initTLogGroup(1, options.numStorageTeams)
+	    .initPtxnTLog(ptxn::MessageTransferModel::StorageServerActivelyPull, 1)
+	    .initMessages(options.initialVersion, options.numVersions, options.numMutationsPerVersion);
 
-	loop {
-		wait(ptxn::test::peekAndCheck(pContext));
+	for (auto& pTLogContext : ptxn::test::TestEnvironment::getTLogs()->tLogContexts) {
+		// Limit the versions per reply, to force multiple peeks
+		pTLogContext->maxVersionsPerPeek = 5;
+		pTLogContext->latency.enable();
+	}
 
-		if (++numPeeks == options.peekTimes) {
-			break;
-		}
+	// Inject the messages
+	actors.push_back(ptxn::test::messageFeeder());
+
+	const auto& storageTeamID = ptxn::test::randomlyPick(ptxn::test::TestEnvironment::getTLogGroup().storageTeamIDs);
+	state std::vector<ptxn::VersionSubsequenceMessage> messagesGenerated =
+	    ptxn::test::TestEnvironment::getCommitRecords().getMessagesFromStorageTeams({ storageTeamID });
+
+	// Peek from one TLog server
+	state Arena messageArena;
+	std::shared_ptr<ptxn::TLogInterface_PassivelyPull> pInterface =
+	    ptxn::test::TestEnvironment::getTLogs()->getTLogLeaderByStorageTeamID(storageTeamID);
+
+	// FIXME reportEmptyVersion should reflect the value of (SERVER_KNOBS->INSERT_EMPTY_TRANSACTION ||
+	// SERVER_KNOBS->BROADCAST_TLOG_GROUPS)
+	state std::shared_ptr<ptxn::StorageTeamPeekCursor> pCursor = std::make_shared<ptxn::StorageTeamPeekCursor>(
+	    options.initialVersion, storageTeamID, pInterface.get(), &messageArena);
+
+	state Arena arena;
+	state std::vector<ptxn::VersionSubsequenceMessage> messagesFromTLog =
+	    wait(ptxn::test::getAllMessageFromCursor(pCursor, &arena));
+
+	// Verify
+	ASSERT(messagesFromTLog.size() == messagesGenerated.size());
+	for (int i = 0; i < static_cast<int>(messagesFromTLog.size()); ++i) {
+		ASSERT(messagesFromTLog[i] == messagesGenerated[i]);
 	}
 
 	return Void();
 }
 
-TEST_CASE("/fdbserver/ptxn/test/tLogPeek/cursor/StorageTeamPeekCursor") {
-	state ptxn::test::TestTLogPeekOptions options(params);
-	state std::shared_ptr<ptxn::test::FakeTLogContext> pContext = std::make_shared<ptxn::test::FakeTLogContext>();
-	state Future<Void> tLog;
-	state std::shared_ptr<ptxn::StorageTeamPeekCursor> pCursor;
-	state ptxn::StorageTeamID storageTeamID;
-	state ptxn::test::print::PrintTiming printTiming("TestStorageTeamPeekCursor");
+namespace {
 
-	// Limit the size of reply, to force multiple peeks
-	pContext->maxBytesPerPeek = params.getInt("maxBytesPerPeek").orDefault(32 * 1024);
-	tLog = ptxn::test::initializeTLogForPeekTest(
-	    ptxn::MessageTransferModel::TLogActivelyPush, options.numStorageTeams, pContext);
-	ptxn::test::fillTLogWithRandomMutations(pContext, options.initialVersion, options.numMutations);
+void verifyMergedCursorResult_Ordered(const std::vector<ptxn::VersionSubsequenceMessage>& messagesFromTLogs) {
+	auto messagesGenerated = ptxn::test::TestEnvironment::getCommitRecords().getMessagesFromStorageTeams();
+	ASSERT(messagesFromTLogs.size() == messagesGenerated.size());
+	for (int i = 0; i < static_cast<int>(messagesFromTLogs.size()); ++i) {
+		ASSERT(messagesFromTLogs[i] == messagesGenerated[i]);
+	}
+}
 
-	storageTeamID = ptxn::test::randomlyPick(pContext->storageTeamIDs);
-	pCursor = std::make_shared<ptxn::StorageTeamPeekCursor>(
-	    options.initialVersion, storageTeamID, pContext->pTLogInterface.get());
-	state size_t index = 0;
-	loop {
-		printTiming << "Querying team " << storageTeamID.toString() << " from version: " << pCursor->getLastVersion()
-		            << std::endl;
-		state bool remoteDataAvailable = wait(pCursor->remoteMoreAvailable());
-		if (!remoteDataAvailable) {
-			printTiming << "TLog reported no more messages available." << std::endl;
-			break;
+void verifyMergedCursorResult_Unordered(const std::vector<ptxn::VersionSubsequenceMessage>& messagesFromTLogs) {
+	auto& commitRecords = ptxn::test::TestEnvironment::getCommitRecords();
+	auto messagesGenerated = commitRecords.getMessagesFromStorageTeams();
+	ASSERT(messagesFromTLogs.size() == messagesGenerated.size());
+
+	Version currentVersion = invalidVersion;
+	ptxn::StorageTeamID currentStorageTeamID;
+	int storageTeamMessageIndex = 0;
+	bool versionStorageTeamTerminated = true;
+	for (const auto& vsm : messagesFromTLogs) {
+		if (vsm.version != currentVersion) {
+			currentVersion = vsm.version;
+		}
+		const auto& storageTeamMessage = commitRecords.messages.at(currentVersion);
+
+		if (versionStorageTeamTerminated) {
+			// Find the storage team for the current message
+			bool found = false;
+			for (const auto& [storageTeamID, subsequenceMessages] : storageTeamMessage) {
+				if (storageTeamMessage.size() == 0) {
+					continue;
+				}
+				if (subsequenceMessages[0].first == vsm.subsequence && subsequenceMessages[0].second == vsm.message) {
+					currentStorageTeamID = storageTeamID;
+					storageTeamMessageIndex = 0;
+					found = true;
+					break;
+				}
+			}
+			ASSERT(found);
+			versionStorageTeamTerminated = false;
 		}
 
-		// There are two ways iterating local data in pCursor, one is using
-		//    hasRemaining
-		//    get
-		//    next
-		// e.g.
-		// while (pCursor->hasRemaining()) {
-		//     ASSERT(pCursor->get() == pContext->storageTeamMessages[storageTeamID][index++]);
-		//     pCursor->next();
-		// }
-		// the other way is to use iterators. Yet the iterator here is *NOT* standard input iterator, see comments in
-		// PeekCursorBase::iterator. In this implementation we use iterators since iterators are implemented using the
-		// methods above.
+		const auto& messages = storageTeamMessage.at(currentStorageTeamID);
+		ASSERT_EQ(messages[storageTeamMessageIndex].first, vsm.subsequence);
+		ASSERT(messages[storageTeamMessageIndex].second == vsm.message);
+
+		if (++storageTeamMessageIndex >= messages.size()) {
+			versionStorageTeamTerminated = true;
+		}
+	}
+}
+
+ACTOR template <typename CursorType>
+Future<Void> runMergedCursorTest(ptxn::test::TestTLogPeekMergeCursorOptions options) {
+	state ptxn::test::TestEnvironment testEnvironment;
+	state std::vector<Future<Void>> actors;
+
+	testEnvironment.initDriverContext()
+	    .initTLogGroup(options.numTLogs, options.numTLogs)
+	    .initPtxnTLog(ptxn::MessageTransferModel::StorageServerActivelyPull, options.numTLogs)
+	    .initMessages(options.initialVersion, options.numVersions, options.numMutationsPerVersion);
+
+	// Force multiple time peek, and peek causes latency
+	for (auto pFakeTLogContext : ptxn::test::TestEnvironment::getTLogs()->tLogContexts) {
+		pFakeTLogContext->maxVersionsPerPeek = 10;
+		pFakeTLogContext->latency.enable();
+	}
+
+	// Inject the commits to TLogs
+	actors.push_back(ptxn::test::messageFeeder());
+
+	// Initialize the cursor
+	state Arena messageArena;
+	state std::shared_ptr<CursorType> mergedCursor = std::make_shared<CursorType>();
+	const std::vector<ptxn::StorageTeamID>& storageTeamIDs = ptxn::test::TestEnvironment::getTLogGroup().storageTeamIDs;
+	for (const auto& storageTeamID : storageTeamIDs) {
+		std::shared_ptr<ptxn::TLogInterface_PassivelyPull> pInterface =
+		    ptxn::test::TestEnvironment::getTLogs()->getTLogLeaderByStorageTeamID(storageTeamID);
+		mergedCursor->addCursor(std::make_shared<ptxn::StorageTeamPeekCursor>(options.initialVersion,
+		                                                                      storageTeamID,
+		                                                                      pInterface.get(),
+		                                                                      &messageArena,
+		                                                                      /* reportEmptyVersion = */ true));
+	}
+
+	// Query all messages using a merged cursor
+	state Arena arena;
+	state std::vector<ptxn::VersionSubsequenceMessage> messagesFromTLogs =
+	    wait(ptxn::test::getAllMessageFromCursor(mergedCursor, &arena));
+
+	wait(waitForAll(actors));
+
+	// FIXME: Use constexpr when actor compiler supports this
+	if (std::is_same<CursorType, ptxn::merged::BroadcastedStorageTeamPeekCursor_Ordered>::value) {
+		verifyMergedCursorResult_Ordered(messagesFromTLogs);
+	} else if (std::is_same<CursorType, ptxn::merged::BroadcastedStorageTeamPeekCursor_Unordered>::value) {
+		verifyMergedCursorResult_Unordered(messagesFromTLogs);
+	} else {
+		// Unsupported cursor type
+		ASSERT(false);
+	}
+
+	return Void();
+}
+
+} // anonymous namespace
+
+TEST_CASE("/fdbserver/ptxn/test/tLogPeek/cursor/merged/BroadcastedStorageTeamPeekCursor_Ordered") {
+	state ptxn::test::TestTLogPeekMergeCursorOptions options(params);
+
+	wait(runMergedCursorTest<ptxn::merged::BroadcastedStorageTeamPeekCursor_Ordered>(options));
+
+	return Void();
+}
+
+TEST_CASE("/fdbserver/ptxn/test/tLogPeek/cursor/merged/BroadcastedStorageTeamPeekCursor_Unordered") {
+	state ptxn::test::TestTLogPeekMergeCursorOptions options(params);
+
+	wait(runMergedCursorTest<ptxn::merged::BroadcastedStorageTeamPeekCursor_Unordered>(options));
+
+	return Void();
+}
+
+TEST_CASE("/fdbserver/ptxn/test/tLogPeek/cursor/advanceTo") {
+	state ptxn::test::TestTLogPeekMergeCursorOptions options(params);
+	state ptxn::test::TestEnvironment testEnvironment;
+	state ptxn::test::print::PrintTiming printTiming("TestAdvanceTo");
+	state std::vector<Future<Void>> actors;
+
+	testEnvironment.initDriverContext()
+	    .initTLogGroup(options.numTLogs, /* numStorageTeams */ options.numTLogs * 3)
+	    .initPtxnTLog(ptxn::MessageTransferModel::StorageServerActivelyPull, options.numTLogs)
+	    .initMessages(options.initialVersion, options.numVersions, options.numMutationsPerVersion);
+
+	for (auto pFakeTLogContext : ptxn::test::TestEnvironment::getTLogs()->tLogContexts) {
+		pFakeTLogContext->latency.enable();
+	}
+
+	// Inject the commits to TLogs
+	actors.push_back(ptxn::test::messageFeeder());
+
+	// Initialize the cursor
+	state Arena messageArena;
+	// Unordered cursor cannot correctly advanceTo
+	state std::shared_ptr<ptxn::merged::BroadcastedStorageTeamPeekCursor_Ordered> mergedCursor =
+	    std::make_shared<ptxn::merged::BroadcastedStorageTeamPeekCursor_Ordered>();
+	const std::vector<ptxn::StorageTeamID>& storageTeamIDs = ptxn::test::TestEnvironment::getTLogGroup().storageTeamIDs;
+	for (const auto& storageTeamID : storageTeamIDs) {
+		std::shared_ptr<ptxn::TLogInterface_PassivelyPull> pInterface =
+		    ptxn::test::TestEnvironment::getTLogs()->getTLogLeaderByStorageTeamID(storageTeamID);
+		mergedCursor->addCursor(std::make_shared<ptxn::StorageTeamPeekCursor>(options.initialVersion,
+		                                                                      storageTeamID,
+		                                                                      pInterface.get(),
+		                                                                      &messageArena,
+		                                                                      /* reportEmptyVersion = */ true));
+	}
+
+	const auto& commitRecords = ptxn::test::TestEnvironment::getCommitRecords().messages;
+
+	// Find a random version/subsequence/message
+	{
+		std::vector<Version> versions;
+		for (const auto& [version, _] : commitRecords) {
+			versions.push_back(version);
+		}
+		state Version advanceToVersion = ptxn::test::randomlyPick(versions);
+
+		std::vector<ptxn::StorageTeamID> storageTeamIDs;
+		for (const auto& [storageTeamID, _] : commitRecords.at(advanceToVersion)) {
+			storageTeamIDs.push_back(storageTeamID);
+		}
+		state ptxn::StorageTeamID advanceToUseStorageTeamID = ptxn::test::randomlyPick(storageTeamIDs);
+
+		std::vector<Subsequence> subsequences;
+		for (const auto& [subsequence, _] : commitRecords.at(advanceToVersion).at(advanceToUseStorageTeamID)) {
+			subsequences.push_back(subsequence);
+		}
+		state Subsequence advanceToSubsequence = ptxn::test::randomlyPick(subsequences);
+
+		printTiming << "Advancing to " << advanceToVersion << ", " << advanceToSubsequence << std::endl;
+
+		wait(ptxn::advanceTo(mergedCursor.get(), advanceToVersion, advanceToSubsequence));
+		auto vsm = mergedCursor->get();
+		printTiming << "Cursor reached " << vsm.version << ", " << vsm.subsequence << std::endl;
+		ASSERT_EQ(vsm.version, advanceToVersion);
+		ASSERT_EQ(vsm.subsequence, advanceToSubsequence);
 	}
 
 	return Void();

--- a/fdbserver/ptxn/test/TestTLogPeek.h
+++ b/fdbserver/ptxn/test/TestTLogPeek.h
@@ -27,14 +27,18 @@
 #include "flow/UnitTest.h"
 
 namespace ptxn::test {
+
 struct TestTLogPeekOptions {
-	static const int DEFAULT_NUM_MUTATIONS = 10000;
+	static const int DEFAULT_NUM_VERSIONS = 100;
+	static const int DEFAULT_NUM_MUTATIONS_PER_VERSION = 100;
 	static const int DEFAULT_NUM_TEAMS = 3;
 	static const int DEFAULT_INITIAL_VERSION = 1000;
 	static const int DEFAULT_PEEK_TIMES = 1000;
 
-	// The number of mutations stored in the TLog before peek
-	int numMutations;
+	// The number of versions for peek
+	int numVersions;
+	// The number of mutations per version
+	int numMutationsPerVersion;
 	// The number of teams in the TLog. Mutations are randomly distributed into teams.
 	int numStorageTeams;
 	// The initial version
@@ -43,6 +47,23 @@ struct TestTLogPeekOptions {
 	int peekTimes;
 
 	explicit TestTLogPeekOptions(const UnitTestParameters&);
+};
+
+struct TestTLogPeekMergeCursorOptions {
+	static const int DEFAULT_INITIAL_VERSION = 1000;
+	static const int DEFAULT_NUM_VERSIONS = 10;
+	static const int DEFAULT_NUM_MUTATIONS_PER_VERSION = 100;
+	static const int DEFAULT_NUM_TLOGS = 5;
+
+	// The number of TLogGroup/StorageTeam/TLog
+	// One TLogGroup has one StorageTeam and one TLog server
+	int numTLogs;
+	// Number mutations per version
+	int numMutationsPerVersion;
+	Version initialVersion;
+	int numVersions;
+
+	explicit TestTLogPeekMergeCursorOptions(const UnitTestParameters&);
 };
 
 } // namespace ptxn::test

--- a/fdbserver/ptxn/test/Utils.cpp
+++ b/fdbserver/ptxn/test/Utils.cpp
@@ -136,7 +136,8 @@ void print(const TestDriverOptions& option) {
 void print(const ptxn::test::TestTLogPeekOptions& option) {
 	std::cout << std::endl << ">> ptxn/test/Driver.actor.cpp:DriverTestOptions:" << std::endl;
 
-	std::cout << formatKVPair("Mutations", option.numMutations) << std::endl
+	std::cout << formatKVPair("Versions", option.numVersions) << std::endl
+	          << formatKVPair("Mutations per versions", option.numMutationsPerVersion) << std::endl
 	          << formatKVPair("Teams", option.numStorageTeams) << std::endl
 	          << formatKVPair("Intial version", option.initialVersion) << std::endl;
 }

--- a/fdbserver/ptxn/test/Utils.cpp
+++ b/fdbserver/ptxn/test/Utils.cpp
@@ -146,7 +146,8 @@ void printCommitRecords(const CommitRecord& record) {
 	std::cout << ">> ptxn/test/CommitUtils.h:CommitRecord:" << std::endl;
 	for (const auto& [version, storageTeamIDMessageMap] : record.messages) {
 		std::cout << "\n\tCommit version: " << std::setw(10) << version
-		          << "\tStorage Team Version: " << record.commitVersionStorageTeamVersionMapper.at(version) << std::endl;
+		          << "\tStorage Team Version: " << record.commitVersionStorageTeamVersionMapper.at(version)
+		          << std::endl;
 		for (const auto& [storageTeamID, sms] : storageTeamIDMessageMap) {
 			std::cout << "\t\tStorage Team ID: " << storageTeamID.toString() << std::endl;
 			for (const auto& [subsequence, message] : sms) {

--- a/fdbserver/ptxn/test/Utils.cpp
+++ b/fdbserver/ptxn/test/Utils.cpp
@@ -144,11 +144,12 @@ void print(const ptxn::test::TestTLogPeekOptions& option) {
 void printCommitRecords(const CommitRecord& record) {
 	std::cout << ">> ptxn/test/CommitUtils.h:CommitRecord:" << std::endl;
 	for (const auto& [version, storageTeamIDMessageMap] : record.messages) {
-		std::cout << "\n\tVersion: " << version << std::endl;
-		for (const auto& [storageTeamID, subsequenceMessage] : storageTeamIDMessageMap) {
+		std::cout << "\n\tCommit version: " << std::setw(10) << version
+		          << "\tStorage Team Version: " << record.commitVersionStorageTeamVersionMapper.at(version) << std::endl;
+		for (const auto& [storageTeamID, sms] : storageTeamIDMessageMap) {
 			std::cout << "\t\tStorage Team ID: " << storageTeamID.toString() << std::endl;
-			for (const auto& [subsequence, message] : subsequenceMessage) {
-				std::cout << "\t\t\t" << message << std::endl;
+			for (const auto& [subsequence, message] : sms) {
+				std::cout << "\t\t\t" << std::setw(10) << subsequence << '\t' << message.toString() << std::endl;
 			}
 		}
 	}

--- a/flow/Arena.h
+++ b/flow/Arena.h
@@ -101,7 +101,8 @@ public:
 	Arena& operator=(const Arena&);
 	Arena& operator=(Arena&&) noexcept;
 
-	// If additional ArenaBlock is added to p, dependsOn will need to be re-called in order to include the new blocks.
+	// Adds a reference to memory blocks held by "p" so that they are accessible after "p" is destructed. Note future
+	// blocks allocated by "p" are not referenced.
 	void dependsOn(const Arena& p);
 	void* allocate4kAlignedBuffer(uint32_t size);
 	size_t getSize() const;

--- a/flow/Arena.h
+++ b/flow/Arena.h
@@ -101,6 +101,7 @@ public:
 	Arena& operator=(const Arena&);
 	Arena& operator=(Arena&&) noexcept;
 
+	// If additional ArenaBlock is added to p, dependsOn will need to be re-called in order to include the new blocks.
 	void dependsOn(const Arena& p);
 	void* allocate4kAlignedBuffer(uint32_t size);
 	size_t getSize() const;

--- a/tests/ptxn/TLogPeekCursor.toml
+++ b/tests/ptxn/TLogPeekCursor.toml
@@ -1,16 +1,4 @@
 [[test]]
-testTitle = 'Test FakeTLog serialize data to FakeStorageServer'
-useDB = false
-startDelay = 0
-
-    [[test.workload]]
-    testName = 'UnitTests'
-    maxTestCases = 1
-    testsMatching = '/fdbserver/ptxn/test/tLogPeek/readFromSerialization'
-
-    peekTimes = 10
-
-[[test]]
 testTitle = 'Test TLog group peek cursor'
 useDB = false
 startDelay = 0
@@ -20,4 +8,44 @@ startDelay = 0
     maxTestCases = 1
     testsMatching = '/fdbserver/ptxn/test/tLogPeek/cursor/StorageTeamPeekCursor'
 
-    maxBytesPerPeek = 65536
+    numVersions = 10
+    numMutationsPerVersion = 100
+
+[[test]]
+testTitle = "BroadcastedStorageTeamPeekCursor_Unordered test"
+useDB = false
+startDelay = 0
+
+    [[test.workload]]
+    testName = "UnitTests"
+    maxTestCases = 1
+    testsMatching = '/fdbserver/ptxn/test/tLogPeek/cursor/merged/BroadcastedStorageTeamPeekCursor_Unordered'
+
+    numVersions = 10
+    numMutationsPerVersion = 100
+
+[[test]]
+testTitle = "BroadcastedStorageTeamPeekCursor_Ordered test"
+useDB = false
+startDelay = 0
+
+    [[test.workload]]
+    testName = "UnitTests"
+    maxTestCases = 1
+    testsMatching = '/fdbserver/ptxn/test/tLogPeek/cursor/merged/BroadcastedStorageTeamPeekCursor_Ordered'
+
+    numVersions = 10
+    numMutationsPerVersion = 100
+
+[[test]]
+testTitle = "Advance To"
+useDB = false
+startDelay = 0
+
+    [[test.workload]]
+    testName = "UnitTests"
+    maxTestCases = 1
+    testsMatching = '/fdbserver/ptxn/test/tLogPeek/cursor/advanceTo'
+
+    numVersions = 10
+    numMutationsPerVersion = 100


### PR DESCRIPTION

This set of commits provides the following features:
 * Provide an implementation of merged cursor for the broadcast model. The broadcast model assumes for each commit, all storage teams are informed.
 * Provide a test for the merged cursors
 * Update the ptxn tests to differentiate commit versions and storage team versions.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [x] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
