### PR TITLE
FDB compiles on Apple Sillicon

### DIFF
--- a/bindings/c/CMakeLists.txt
+++ b/bindings/c/CMakeLists.txt
@@ -7,18 +7,26 @@ file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/foundationdb)
 
 set(asm_file ${CMAKE_CURRENT_BINARY_DIR}/fdb_c.g.S)
 
-set(platform "linux")
+set(os "linux")
+set(cpu "intel")
 if(APPLE)
-  set(platform "osx")
+  set(os "osx")
 elseif(WIN32)
-  set(platform "windows")
+  set(os "windows")
   set(asm_file ${CMAKE_CURRENT_BINARY_DIR}/fdb_c.g.asm)
-elseif(CMAKE_SYSTEM_NAME MATCHES "Linux" AND CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
-  set(platform "linux-aarch64")
+endif()
+
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64" OR CMAKE_SYSTEM_PROCESSOR MATCHES "arm64")
+  set(cpu "aarch64")
+endif()
+
+set(IS_ARM_MAC NO)
+if(APPLE AND CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64")
+  set(IS_ARM_MAC YES)
 endif()
 
 add_custom_command(OUTPUT ${asm_file} ${CMAKE_CURRENT_BINARY_DIR}/fdb_c_function_pointers.g.h
-  COMMAND $<TARGET_FILE:Python::Interpreter> ${CMAKE_CURRENT_SOURCE_DIR}/generate_asm.py ${platform}
+  COMMAND $<TARGET_FILE:Python::Interpreter> ${CMAKE_CURRENT_SOURCE_DIR}/generate_asm.py ${os} ${cpu}
       ${CMAKE_CURRENT_SOURCE_DIR}/fdb_c.cpp
       ${asm_file}
       ${CMAKE_CURRENT_BINARY_DIR}/fdb_c_function_pointers.g.h
@@ -66,8 +74,10 @@ if(WIN32)
   set_property(SOURCE ${asm_file} PROPERTY LANGUAGE ASM_MASM)
 endif()
 
-# The tests don't build on windows
-if(NOT WIN32)
+# The tests don't build on windows and ARM macs
+# doctest doesn't seem to compile on ARM macs, we should
+# check later whether this works
+if(NOT WIN32 AND NOT IS_ARM_MAC)
   set(MAKO_SRCS
     test/mako/mako.c
     test/mako/mako.h

--- a/bindings/c/generate_asm.py
+++ b/bindings/c/generate_asm.py
@@ -23,7 +23,7 @@
 import re
 import sys
 
-(platform, source, asm, h) = sys.argv[1:]
+(os, cpu, source, asm, h) = sys.argv[1:]
 
 functions = {}
 
@@ -59,17 +59,18 @@ def write_windows_asm(asmfile, functions):
 
 
 def write_unix_asm(asmfile, functions, prefix):
-    if platform != "linux-aarch64":
+    if cpu != "aarch64":
         asmfile.write(".intel_syntax noprefix\n")
 
-    if platform.startswith('linux') or platform == "freebsd":
+    if cpu == 'aarch64' or os == 'linux' or os == 'freebsd':
         asmfile.write("\n.data\n")
         for f in functions:
             asmfile.write("\t.extern fdb_api_ptr_%s\n" % f)
-
-        asmfile.write("\n.text\n")
-        for f in functions:
-            asmfile.write("\t.global %s\n\t.type %s, @function\n" % (f, f))
+        
+        if os == 'linux' or os == 'freebsd':
+            asmfile.write("\n.text\n")
+            for f in functions:
+                asmfile.write("\t.global %s\n\t.type %s, @function\n" % (f, f))
 
     for f in functions:
         asmfile.write("\n.globl %s%s\n" % (prefix, f))
@@ -104,10 +105,16 @@ def write_unix_asm(asmfile, functions, prefix):
         # 	.size	g, .-g
         # 	.ident	"GCC: (GNU) 8.3.1 20190311 (Red Hat 8.3.1-3)"
 
-        if platform == "linux-aarch64":
-            asmfile.write("\tadrp x8, :got:fdb_api_ptr_%s\n" % (f))
-            asmfile.write("\tldr x8, [x8, #:got_lo12:fdb_api_ptr_%s]\n" % (f))
-            asmfile.write("\tldr x8, [x8]\n")
+        p = ''
+        if os == 'osx':
+            p = '_'
+        if cpu == "aarch64":
+            asmfile.write("\tldr x16, =%sfdb_api_ptr_%s\n" % (p, f))
+            if os == 'osx':
+                asmfile.write("\tldr x16, [x16]\n")
+            else:
+                asmfile.write("\tldr x8, [x8, #:got_lo12:fdb_api_ptr_%s]\n" % (f))
+                asmfile.write("\tldr x8, [x8]\n")
             asmfile.write("\tbr x8\n")
         else:
             asmfile.write(
@@ -123,15 +130,15 @@ with open(asm, 'w') as asmfile:
         hfile.write(
             "void fdb_api_ptr_removed() { fprintf(stderr, \"REMOVED FDB API FUNCTION\\n\"); abort(); }\n\n")
 
-        if platform.startswith('linux'):
+        if os == 'linux':
             write_unix_asm(asmfile, functions, '')
-        elif platform == "osx":
+        elif os == "osx":
             write_unix_asm(asmfile, functions, '_')
-        elif platform == "windows":
+        elif os == "windows":
             write_windows_asm(asmfile, functions)
 
         for f in functions:
-            if platform == "windows":
+            if os == "windows":
                 hfile.write("extern \"C\" ")
             hfile.write("void* fdb_api_ptr_%s = (void*)&fdb_api_ptr_unimpl;\n" % f)
             for v in functions[f]:

--- a/cmake/CompileBoost.cmake
+++ b/cmake/CompileBoost.cmake
@@ -49,8 +49,8 @@ function(compile_boost)
   include(ExternalProject)
   set(BOOST_INSTALL_DIR "${CMAKE_BINARY_DIR}/boost_install")
   ExternalProject_add("${COMPILE_BOOST_TARGET}Project"
-    URL "https://boostorg.jfrog.io/artifactory/main/release/1.72.0/source/boost_1_72_0.tar.bz2"
-    URL_HASH SHA256=59c9b274bc451cf91a9ba1dd2c7fdcaf5d60b1b3aa83f2c9fa143417cc660722
+    URL "https://boostorg.jfrog.io/artifactory/main/release/1.77.0/source/boost_1_77_0.tar.bz2"
+    URL_HASH SHA256=fc9f85fc030e233142908241af7a846e60630aa7388de9a5fafb1f3a26840854
     CONFIGURE_COMMAND ${BOOTSTRAP_COMMAND} ${BOOTSTRAP_ARGS} --with-libraries=${BOOTSTRAP_LIBRARIES} --with-toolset=${BOOST_TOOLSET}
     BUILD_COMMAND ${B2_COMMAND} link=static ${COMPILE_BOOST_BUILD_ARGS} --prefix=${BOOST_INSTALL_DIR} ${USER_CONFIG_FLAG} install
     BUILD_IN_SOURCE ON
@@ -113,7 +113,7 @@ if(WIN32)
   return()
 endif()
 
-find_package(Boost 1.72.0 EXACT QUIET COMPONENTS context CONFIG PATHS ${BOOST_HINT_PATHS})
+find_package(Boost 1.77.0 EXACT QUIET COMPONENTS context CONFIG PATHS ${BOOST_HINT_PATHS})
 set(FORCE_BOOST_BUILD OFF CACHE BOOL "Forces cmake to build boost and ignores any installed boost")
 
 if(Boost_FOUND AND NOT FORCE_BOOST_BUILD)

--- a/fdbclient/IKnobCollection.cpp
+++ b/fdbclient/IKnobCollection.cpp
@@ -73,20 +73,25 @@ KnobValue IKnobCollection::parseKnobValue(std::string const& knobName, std::stri
 	UNSTOPPABLE_ASSERT(false);
 }
 
-std::unique_ptr<IKnobCollection> IKnobCollection::globalKnobCollection =
-    IKnobCollection::create(IKnobCollection::Type::CLIENT, Randomize::False, IsSimulated::False);
+std::unique_ptr<IKnobCollection>& IKnobCollection::globalKnobCollection() {
+	static std::unique_ptr<IKnobCollection> res;
+	if (!res) {
+		res = IKnobCollection::create(IKnobCollection::Type::CLIENT, Randomize::False, IsSimulated::False);
+	}
+	return res;
+}
 
 void IKnobCollection::setGlobalKnobCollection(Type type, Randomize randomize, IsSimulated isSimulated) {
-	globalKnobCollection = create(type, randomize, isSimulated);
-	FLOW_KNOBS = &globalKnobCollection->getFlowKnobs();
+	globalKnobCollection() = create(type, randomize, isSimulated);
+	FLOW_KNOBS = &globalKnobCollection()->getFlowKnobs();
 }
 
 IKnobCollection const& IKnobCollection::getGlobalKnobCollection() {
-	return *globalKnobCollection;
+	return *globalKnobCollection();
 }
 
 IKnobCollection& IKnobCollection::getMutableGlobalKnobCollection() {
-	return *globalKnobCollection;
+	return *globalKnobCollection();
 }
 
 ConfigMutationRef IKnobCollection::createSetMutation(Arena arena, KeyRef key, ValueRef value) {

--- a/fdbclient/IKnobCollection.h
+++ b/fdbclient/IKnobCollection.h
@@ -36,7 +36,7 @@
  *  - TestKnobs
  */
 class IKnobCollection {
-	static std::unique_ptr<IKnobCollection> globalKnobCollection;
+	static std::unique_ptr<IKnobCollection>& globalKnobCollection();
 
 public:
 	virtual ~IKnobCollection() = default;

--- a/flow/IndexedSet.actor.h
+++ b/flow/IndexedSet.actor.h
@@ -47,7 +47,7 @@ ACTOR template <class Node>
 	while (!prefetchQueue.empty() || !toFree.empty()) {
 
 		while (prefetchQueue.size() < 10 && !toFree.empty()) {
-			_mm_prefetch((const char*)toFree.back(), _MM_HINT_T0);
+			__builtin_prefetch((const char*)toFree.back(), _MM_HINT_T0);
 			prefetchQueue.push_back(toFree.back());
 			toFree.pop_back();
 		}

--- a/flow/Platform.h
+++ b/flow/Platform.h
@@ -416,28 +416,8 @@ typedef struct {
 dev_t getDeviceId(std::string path);
 #endif
 
-#ifdef __linux__
-#ifndef __aarch64__
-#include <x86intrin.h>
-#else
+#if defined(__aarch64__)
 #include "sse2neon.h"
-#endif
-#include <features.h>
-#include <sys/stat.h>
-#endif
-
-#if defined(__APPLE__)
-// Version of CLang bundled with XCode doesn't yet include ia32intrin.h.
-#if !(__has_builtin(__rdtsc))
-inline static uint64_t timestampCounter() {
-	uint64_t lo, hi;
-	asm("rdtsc" : "=a"(lo), "=d"(hi));
-	return (lo | (hi << 32));
-}
-#else
-#define timestampCounter() __rdtsc()
-#endif
-#elif defined(__aarch64__)
 // aarch64 does not have rdtsc counter
 // Use cntvct_el0 virtual counter instead
 inline static uint64_t timestampCounter() {
@@ -445,8 +425,21 @@ inline static uint64_t timestampCounter() {
 	asm volatile("mrs %0, cntvct_el0" : "=r"(timer));
 	return timer;
 }
+#elif defined(__linux__)
+#include <x86intrin.h>
+#define timestampCounter() __rdtsc()
+#elif defined(__APPLE__) // macOS on Intel
+// Version of CLang bundled with XCode doesn't yet include ia32intrin.h.
+#if !(__has_builtin(__rdtsc))
+inline static uint64_t timestampCounter() {
+	uint64_t lo, hi;
+	asm( "rdtsc" : "=a" (lo), "=d" (hi) );
+	return( lo | (hi << 32) );
+}
 #else
-// all other platforms including Linux x86_64
+#define timestampCounter() __rdtsc()
+#endif
+#else
 #define timestampCounter() __rdtsc()
 #endif
 
@@ -459,6 +452,11 @@ inline static uint64_t __rdtsc() {
 }
 #endif
 #endif
+
+#if defined(__linux__)
+#include <features.h>
+#endif
+#include <sys/stat.h>
 
 #ifdef _WIN32
 #include <intrin.h>


### PR DESCRIPTION
This is my third try...

This makes FDB compile on Apple Silicon with minimal code-changes. I did minimal testing so expect stuff to be still broken. Changes necessary:

1. Weird static initialization problem with knobs (`fdbserver` did immediately segfault)
2. Generate asm files
3. Use `__bultin_prefetch` instead of `_mm_prefetch`
4. Fix clock to work on Mac arm in `flow/Platform.h`

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
