### PR TITLE
Fix written_tags not propagated to commit proxies

### DIFF
--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -414,7 +414,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( TXN_STATE_SEND_AMOUNT,                                    4 );
 	init( REPORT_TRANSACTION_COST_ESTIMATION_DELAY,               0.1 );
 	init( PROXY_REJECT_BATCH_QUEUED_TOO_LONG,                    true );
-	init( PROXY_USE_RESOLVER_PRIVATE_MUTATIONS,                 false ); //if( randomize && BUGGIFY ) PROXY_USE_RESOLVER_PRIVATE_MUTATIONS = deterministicRandom()->coinflip();
+	init( PROXY_USE_RESOLVER_PRIVATE_MUTATIONS,                  true ); if( randomize && BUGGIFY ) PROXY_USE_RESOLVER_PRIVATE_MUTATIONS = deterministicRandom()->coinflip();
 
 	init( RESET_MASTER_BATCHES,                                   200 );
 	init( RESET_RESOLVER_BATCHES,                                 200 );

--- a/fdbserver/CommitProxyServer.actor.cpp
+++ b/fdbserver/CommitProxyServer.actor.cpp
@@ -980,6 +980,7 @@ ACTOR Future<Void> applyMetadataToCommittedTransactions(CommitBatchContext* self
 			// TraceEvent("ResolverReturn").detail("ReturnTags",reply.writtenTags).detail("TPCVsize",reply.tpcvMap.size()).detail("ReqTags",self->writtenTagsPreResolution);
 			self->tpcvMap = reply.tpcvMap;
 		}
+		self->toCommit.addWrittenTags(reply.writtenTags);
 	}
 
 	self->lockedKey = pProxyCommitData->txnStateStore->readValue(databaseLockedKey).get();

--- a/fdbserver/LogSystem.h
+++ b/fdbserver/LogSystem.h
@@ -770,6 +770,8 @@ struct LogPushData : NonCopyable {
 		}
 	}
 
+	void addWrittenTags(const std::set<Tag>& tags) { written_tags.insert(tags.begin(), tags.end()); }
+
 	void getLocations(const std::set<Tag>& tags, std::set<uint16_t>& writtenTLogs) {
 		std::vector<Tag> vtags(tags.begin(), tags.end());
 		std::vector<int> msg_locations;

--- a/fdbserver/Resolver.actor.cpp
+++ b/fdbserver/Resolver.actor.cpp
@@ -286,10 +286,8 @@ ACTOR Future<Void> resolveBatch(Reference<Resolver> self, ResolveTransactionBatc
 				reply.privateMutations.push_back(reply.arena, mutations);
 				reply.arena.dependsOn(mutations.arena());
 			}
-			if (SERVER_KNOBS->ENABLE_VERSION_VECTOR_TLOG_UNICAST) {
-				// merge mutation tags with sent client tags
-				toCommit.saveTags(reply.writtenTags);
-			}
+			// merge mutation tags with sent client tags
+			toCommit.saveTags(reply.writtenTags);
 			reply.privateMutationCount = toCommit.getMutationCount();
 		}
 


### PR DESCRIPTION
This is needed so that private mutation tags are propagated from Resolvers to
commit proxies. Otherwise, the master's VV won't be correct and can cause data
corruptions.

I ran correctness with `init( PROXY_USE_RESOLVER_PRIVATE_MUTATIONS,                  true );`:

20211111-182905-jzhou-fa403806e62d4e98             compressed=True data_size=21968423 duration=5445268 ended=100001 fail_fast=10 max_runs=100000 pass=100001 priority=100 remaining=0 runtime=0:49:40 sanity=False started=100482 stopped=20211111-191845 submitted=20211111-182905 timeout=5400 username=jzhou

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
