### PR TITLE
GetKeyValuesAndFlatMap should return error if not retriable

### DIFF
--- a/fdbserver/workloads/IndexPrefetchDemo.actor.cpp
+++ b/fdbserver/workloads/IndexPrefetchDemo.actor.cpp
@@ -35,6 +35,7 @@ const KeyRef INDEX = "INDEX"_sr;
 
 struct IndexPrefetchDemoWorkload : TestWorkload {
 	bool enabled;
+	const bool BAD_MAPPER = deterministicRandom()->random01() < 0.1;
 
 	IndexPrefetchDemoWorkload(WorkloadContext const& wcx) : TestWorkload(wcx) {
 		enabled = !clientId; // only do this on the "first" client
@@ -97,7 +98,7 @@ struct IndexPrefetchDemoWorkload : TestWorkload {
 		return Void();
 	}
 
-	ACTOR Future<Void> scanRangeAndFlatMap(Database cx, KeyRange range, Key mapper) {
+	ACTOR Future<Void> scanRangeAndFlatMap(Database cx, KeyRange range, Key mapper, IndexPrefetchDemoWorkload* self) {
 		std::cout << "start scanRangeAndFlatMap " << range.toString() << std::endl;
 		// TODO: When n is large, split into multiple transactions.
 		state Transaction tr(cx);
@@ -109,17 +110,26 @@ struct IndexPrefetchDemoWorkload : TestWorkload {
 			                               mapper,
 			                               GetRangeLimits(CLIENT_KNOBS->TOO_MANY)));
 			showResult(result);
+			if (self->BAD_MAPPER) {
+				TraceEvent("IndexPrefetchDemoWorkloadShouldNotReachable").detail("ResultSize", result.size());
+			}
 			// result size: 2
 			// key=\x01prefix\x00\x01RECORD\x00\x01primary-key-of-record-2\x00, value=\x01data-of-record-2\x00
 			// key=\x01prefix\x00\x01RECORD\x00\x01primary-key-of-record-3\x00, value=\x01data-of-record-3\x00
 		} catch (Error& e) {
-			wait(tr.onError(e));
+			if (self->BAD_MAPPER && e.code() == error_code_mapper_bad_index) {
+				TraceEvent("IndexPrefetchDemoWorkloadBadMapperDetected").error(e);
+			} else {
+				wait(tr.onError(e));
+			}
 		}
 		std::cout << "finished scanRangeAndFlatMap" << std::endl;
 		return Void();
 	}
 
 	ACTOR Future<Void> _start(Database cx, IndexPrefetchDemoWorkload* self) {
+		TraceEvent("IndexPrefetchDemoWorkloadConfig").detail("BadMapper", self->BAD_MAPPER);
+
 		// TODO: Use toml to config
 		wait(self->fillInRecords(cx, 5));
 
@@ -131,9 +141,13 @@ struct IndexPrefetchDemoWorkload : TestWorkload {
 		wait(self->scanRange(cx, someIndexes));
 
 		Tuple mapperTuple;
-		mapperTuple << prefix << RECORD << "{K[3]}"_sr;
+		if (self->BAD_MAPPER) {
+			mapperTuple << prefix << RECORD << "{K[xxx]}"_sr;
+		} else {
+			mapperTuple << prefix << RECORD << "{K[3]}"_sr;
+		}
 		Key mapper = mapperTuple.getDataAsStandalone();
-		wait(self->scanRangeAndFlatMap(cx, someIndexes, mapper));
+		wait(self->scanRangeAndFlatMap(cx, someIndexes, mapper, self));
 		return Void();
 	}
 


### PR DESCRIPTION
I recently find out that the `GetKeyValuesAndFlatMap` endpoint will retry forever for a non-retriable error (e.g. the "mapper" in user's request is invalid). We need this fix in 7.0 to make the new feature useful. 

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
