### PR TITLE
Optimized FlowTransport's use of XXHash

### DIFF
--- a/fdbrpc/FlowTransport.actor.cpp
+++ b/fdbrpc/FlowTransport.actor.cpp
@@ -40,6 +40,7 @@
 #include "flow/ObjectSerializer.h"
 #include "flow/ProtocolVersion.h"
 #include "flow/UnitTest.h"
+#define XXH_INLINE_ALL
 #include "flow/xxhash.h"
 #include "flow/actorcompiler.h" // This must be the last #include.
 
@@ -1589,16 +1590,17 @@ static ReliablePacket* sendPacket(TransportData* self,
 	// Reserve some space for packet length and checksum, write them after serializing data
 	SplitBuffer packetInfoBuffer;
 	uint32_t len;
-	XXH64_hash_t checksum = 0;
-	XXH3_state_t* checksumState = nullptr;
+
+	// This is technically abstraction breaking but avoids XXH3_createState() and XXH3_freeState() which are just
+	// malloc/free
+	XXH3_state_t checksumState;
+	// Checksum will be calculated with buffer API if contiguous, else using stream API.  Mode is tracked here.
+	bool checksumStream = false;
+	XXH64_hash_t checksum;
 
 	int packetInfoSize = PACKET_LEN_WIDTH;
 	if (checksumEnabled) {
 		packetInfoSize += sizeof(checksum);
-		checksumState = XXH3_createState();
-		if (XXH3_64bits_reset(checksumState) != XXH_OK) {
-			throw internal_error();
-		}
 	}
 
 	wr.writeAhead(packetInfoSize, &packetInfoBuffer);
@@ -1620,19 +1622,37 @@ static ReliablePacket* sendPacket(TransportData* self,
 		while (checksumUnprocessedLength > 0) {
 			uint32_t processLength =
 			    std::min(checksumUnprocessedLength, (uint32_t)(checksumPb->bytes_written - prevBytesWritten));
-			// This won't fail if inputs are non null
-			if (XXH3_64bits_update(checksumState, checksumPb->data() + prevBytesWritten, processLength) != XXH_OK) {
-				throw internal_error();
+
+			// If not in checksum stream mode yet
+			if (!checksumStream) {
+				// If there is nothing left to process then calculate checksum directly
+				if (processLength == checksumUnprocessedLength) {
+					checksum = XXH3_64bits(checksumPb->data() + prevBytesWritten, processLength);
+				} else {
+					// Otherwise, initialize checksum state and switch to stream mode
+					if (XXH3_64bits_reset(&checksumState) != XXH_OK) {
+						throw internal_error();
+					}
+					checksumStream = true;
+				}
 			}
+
+			// If in checksum stream mode, update the checksum state
+			if (checksumStream) {
+				if (XXH3_64bits_update(&checksumState, checksumPb->data() + prevBytesWritten, processLength) !=
+				    XXH_OK) {
+					throw internal_error();
+				}
+			}
+
 			checksumUnprocessedLength -= processLength;
 			checksumPb = checksumPb->nextPacketBuffer();
 			prevBytesWritten = 0;
 		}
 
-		checksum = XXH3_64bits_digest(checksumState);
-		// This always returns OK
-		if (XXH3_freeState(checksumState) != XXH_OK) {
-			throw internal_error();
+		// If in checksum stream mode, get the final checksum
+		if (checksumStream) {
+			checksum = XXH3_64bits_digest(&checksumState);
 		}
 	}
 


### PR DESCRIPTION
Optimizations in FlowTransport's use of XXHash to enable inlining, avoid a `malloc()` when using the stream API, and to avoid the stream API when a message being sent is contiguous within a single packet buffer block.  

This is purely a CPU overhead optimization and could be cherry-picked to release-7.0.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
