### PR TITLE
Explicitly initialize thread-local state used in run loop profiler and remove profile deferral.

### DIFF
--- a/fdbserver/workloads/SlowTaskWorkload.actor.cpp
+++ b/fdbserver/workloads/SlowTaskWorkload.actor.cpp
@@ -43,7 +43,7 @@ struct SlowTaskWorkload : TestWorkload {
 	ACTOR static Future<Void> go() {
 		wait(delay(1));
 		int64_t phc = dl_iterate_phdr_calls;
-		int64_t startProfilesDeferred = getNumProfilesDeferred();
+		int64_t startProfilesDisabled = getNumProfilesDisabled();
 		int64_t startProfilesOverflowed = getNumProfilesOverflowed();
 		int64_t startProfilesCaptured = getNumProfilesCaptured();
 		int64_t exc = 0;
@@ -60,7 +60,7 @@ struct SlowTaskWorkload : TestWorkload {
 		        " profiles deferred, %" PRId64 " profiles overflowed, %" PRId64 " profiles captured\n",
 		        exc,
 		        dl_iterate_phdr_calls - phc,
-		        getNumProfilesDeferred() - startProfilesDeferred,
+		        getNumProfilesDisabled() - startProfilesDisabled,
 		        getNumProfilesOverflowed() - startProfilesOverflowed,
 		        getNumProfilesCaptured() - startProfilesCaptured);
 

--- a/flow/Platform.h
+++ b/flow/Platform.h
@@ -718,7 +718,7 @@ inline static int clz(uint32_t value) {
 #endif
 
 // These return thread local counts
-int64_t getNumProfilesDeferred();
+int64_t getNumProfilesDisabled();
 int64_t getNumProfilesOverflowed();
 int64_t getNumProfilesCaptured();
 


### PR DESCRIPTION
This explicitly initializes thread-local state used in the run loop profile when setting it up, which improves the safety of using these variables in the signal handler. It also removes profile deferral, which doesn't work correctly for cases when the run loop is idle.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
