### PR TITLE
Restricted getRangeAndFlatMap to snapshot

### DIFF
--- a/bindings/c/test/unit/fdb_api.hpp
+++ b/bindings/c/test/unit/fdb_api.hpp
@@ -219,7 +219,8 @@ public:
 	                              fdb_bool_t snapshot,
 	                              fdb_bool_t reverse);
 
-	// Returns a future which will be set to an FDBKeyValue array.
+	// WARNING: This feature is considered experimental at this time. It is only allowed when using snapshot isolation
+	// AND disabling read-your-writes. Returns a future which will be set to an FDBKeyValue array.
 	KeyValueArrayFuture get_range_and_flat_map(const uint8_t* begin_key_name,
 	                                           int begin_key_name_length,
 	                                           fdb_bool_t begin_or_equal,

--- a/bindings/c/test/unit/unit_tests.cpp
+++ b/bindings/c/test/unit/unit_tests.cpp
@@ -922,7 +922,7 @@ TEST_CASE("fdb_transaction_get_range_and_flat_map") {
 		    /* target_bytes */ 0,
 		    /* FDBStreamingMode */ FDB_STREAMING_MODE_WANT_ALL,
 		    /* iteration */ 0,
-		    /* snapshot */ false,
+		    /* snapshot */ true,
 		    /* reverse */ 0);
 
 		if (result.err) {

--- a/bindings/java/src/integration/com/apple/foundationdb/RangeAndFlatMapQueryIntegrationTest.java
+++ b/bindings/java/src/integration/com/apple/foundationdb/RangeAndFlatMapQueryIntegrationTest.java
@@ -180,9 +180,10 @@ class RangeAndFlatMapQueryIntegrationTest {
 		try {
 			tr.options().setReadYourWritesDisable();
 			List<KeyValue> kvs =
-			    tr.getRangeAndFlatMap(KeySelector.firstGreaterOrEqual(indexEntryKey(begin)),
-			                          KeySelector.firstGreaterOrEqual(indexEntryKey(end)), MAPPER,
-			                          ReadTransaction.ROW_LIMIT_UNLIMITED, false, StreamingMode.WANT_ALL)
+			    tr.snapshot()
+			        .getRangeAndFlatMap(KeySelector.firstGreaterOrEqual(indexEntryKey(begin)),
+			                            KeySelector.firstGreaterOrEqual(indexEntryKey(end)), MAPPER,
+			                            ReadTransaction.ROW_LIMIT_UNLIMITED, false, StreamingMode.WANT_ALL)
 			        .asList()
 			        .get();
 			Assertions.assertEquals(end - begin, kvs.size());
@@ -219,10 +220,12 @@ class RangeAndFlatMapQueryIntegrationTest {
 				// getRangeAndFlatMap is only support without RYW. This is a must!!!
 				tr.options().setReadYourWritesDisable();
 
+				// getRangeAndFlatMap is only supported with snapshot.
 				Iterator<KeyValue> kvs =
-				    tr.getRangeAndFlatMap(KeySelector.firstGreaterOrEqual(indexEntryKey(0)),
-				                          KeySelector.firstGreaterThan(indexEntryKey(1)), MAPPER,
-				                          ReadTransaction.ROW_LIMIT_UNLIMITED, false, StreamingMode.WANT_ALL)
+				    tr.snapshot()
+				        .getRangeAndFlatMap(KeySelector.firstGreaterOrEqual(indexEntryKey(0)),
+				                            KeySelector.firstGreaterThan(indexEntryKey(1)), MAPPER,
+				                            ReadTransaction.ROW_LIMIT_UNLIMITED, false, StreamingMode.WANT_ALL)
 				        .iterator();
 				Iterator<byte[]> expected_data_of_records_iter = expected_data_of_records.iterator();
 				while (expected_data_of_records_iter.hasNext()) {

--- a/bindings/java/src/main/com/apple/foundationdb/FDBTransaction.java
+++ b/bindings/java/src/main/com/apple/foundationdb/FDBTransaction.java
@@ -350,10 +350,7 @@ class FDBTransaction extends NativeObjectWrapper implements Transaction, OptionC
 	@Override
 	public AsyncIterable<KeyValue> getRangeAndFlatMap(KeySelector begin, KeySelector end, byte[] mapper, int limit,
 	                                                  boolean reverse, StreamingMode mode) {
-		if (mapper == null) {
-			throw new IllegalArgumentException("Mapper must be non-null");
-		}
-		return new RangeQuery(this, false, begin, end, mapper, limit, reverse, mode, eventKeeper);
+		throw new UnsupportedOperationException("getRangeAndFlatMap is only supported in snapshot");
 	}
 
 	///////////////////

--- a/bindings/java/src/main/com/apple/foundationdb/ReadTransaction.java
+++ b/bindings/java/src/main/com/apple/foundationdb/ReadTransaction.java
@@ -425,9 +425,8 @@ public interface ReadTransaction extends ReadTransactionContext {
 			int limit, boolean reverse, StreamingMode mode);
 
 	/**
-	 * Gets an ordered range of keys and values from the database. The begin
-	 *  and end keys are specified by {@code KeySelector}s, with the begin
-	 *  {@code KeySelector} inclusive and the end {@code KeySelector} exclusive.
+	 * WARNING: This feature is considered experimental at this time. It is only allowed when using snapshot isolation
+	 * AND disabling read-your-writes.
 	 *
 	 * @see KeySelector
 	 * @see AsyncIterator

--- a/fdbclient/ReadYourWrites.actor.cpp
+++ b/fdbclient/ReadYourWrites.actor.cpp
@@ -397,11 +397,10 @@ public:
 	static inline Future<typename Req::Result> readWithConflictRangeAndFlatMap(ReadYourWritesTransaction* ryw,
 	                                                                           Req const& req,
 	                                                                           Snapshot snapshot) {
-		if (ryw->options.readYourWritesDisabled) {
+		// For now, getRangeAndFlatMap is only supported if transaction use snapshot isolation AND read-your-writes is
+		// disabled.
+		if (snapshot && ryw->options.readYourWritesDisabled) {
 			return readWithConflictRangeThroughAndFlatMap(ryw, req, snapshot);
-		} else if (snapshot && ryw->options.snapshotRywEnabled <= 0) {
-			TEST(true); // readWithConflictRangeSnapshot not supported for getRangeAndFlatMap
-			throw client_invalid_operation();
 		}
 		TEST(true); // readWithConflictRangeRYW not supported for getRangeAndFlatMap
 		throw client_invalid_operation();

--- a/fdbserver/workloads/IndexPrefetchDemo.actor.cpp
+++ b/fdbserver/workloads/IndexPrefetchDemo.actor.cpp
@@ -108,7 +108,8 @@ struct IndexPrefetchDemoWorkload : TestWorkload {
 			    wait(tr.getRangeAndFlatMap(KeySelector(firstGreaterOrEqual(range.begin), range.arena()),
 			                               KeySelector(firstGreaterOrEqual(range.end), range.arena()),
 			                               mapper,
-			                               GetRangeLimits(CLIENT_KNOBS->TOO_MANY)));
+			                               GetRangeLimits(CLIENT_KNOBS->TOO_MANY),
+			                               Snapshot::True));
 			showResult(result);
 			if (self->BAD_MAPPER) {
 				TraceEvent("IndexPrefetchDemoWorkloadShouldNotReachable").detail("ResultSize", result.size());


### PR DESCRIPTION
We can only support snapshot because the current implementation doesn't update the conflict ranges perfectly (It will add the scanned range to read conflicts, but won’t add the keys in the secondary requests to read conflicts). This PR tries to add this restriction both systematically and verbally, so that users wont have incorrect result unexpectedly.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
