### PR TITLE
Clamp end of system keys down to normal keys.

### DIFF
--- a/fdbserver/BlobManager.actor.cpp
+++ b/fdbserver/BlobManager.actor.cpp
@@ -1019,6 +1019,7 @@ ACTOR Future<Void> recoverBlobManager(BlobManagerData* bmData) {
 	//    If the worker already had the range, this is a no-op. If the worker didn't have it, it will
 	//    begin persisting it. The worker that had the same range before will now be at a lower seqno.
 
+	state KeyRangeMap<Optional<UID>> workerAssignments;
 	state Reference<ReadYourWritesTransaction> tr = makeReference<ReadYourWritesTransaction>(bmData->db);
 
 	// Step 1. Get the latest known mapping of granules to blob workers (i.e. assignments)
@@ -1041,7 +1042,7 @@ ACTOR Future<Void> recoverBlobManager(BlobManagerData* bmData) {
 				if (results[rangeIdx].value.size()) {
 					// note: if the old owner is dead, we handle this in rangeAssigner
 					UID existingOwner = decodeBlobGranuleMappingValue(results[rangeIdx].value);
-					bmData->workerAssignments.insert(KeyRangeRef(granuleStartKey, granuleEndKey), existingOwner);
+					workerAssignments.insert(KeyRangeRef(granuleStartKey, granuleEndKey), existingOwner);
 				}
 			}
 
@@ -1079,7 +1080,7 @@ ACTOR Future<Void> recoverBlobManager(BlobManagerData* bmData) {
 				std::tie(splitState, version) = decodeBlobGranuleSplitValue(split.value);
 				const KeyRange range = blobGranuleSplitKeyRangeFor(parentGranuleID);
 				if (splitState <= BlobGranuleSplitState::Initialized) {
-					bmData->workerAssignments.insert(range, UID());
+					workerAssignments.insert(range, UID());
 				}
 			}
 
@@ -1093,16 +1094,19 @@ ACTOR Future<Void> recoverBlobManager(BlobManagerData* bmData) {
 		}
 	}
 
-	// Step 3. Send assign requests for all the granules
-	for (auto& range : bmData->workerAssignments.intersectingRanges(normalKeys)) {
-		// a second manager started before the first manager assigned any ranges so the
-		// the only range is [ - \xff\xff), so we clamp it to [ - \xff)
-		Key end = range.end() == allKeys.end ? normalKeys.end : range.end();
+	// Step 3. Send assign requests for all the granules and transfer assignments
+	// from local workerAssignments to bmData
+	for (auto& range : workerAssignments.intersectingRanges(normalKeys)) {
+		if (!range.value().present()) {
+			continue;
+		}
+
+		bmData->workerAssignments.insert(range.range(), range.value().get());
 
 		RangeAssignment raAssign;
 		raAssign.isAssign = true;
-		raAssign.worker = range.value();
-		raAssign.keyRange = KeyRangeRef(range.begin(), end);
+		raAssign.worker = range.value().get();
+		raAssign.keyRange = range.range();
 		raAssign.assign = RangeAssignmentData(AssignRequestType::Reassign);
 		bmData->rangesToAssign.send(raAssign);
 	}

--- a/fdbserver/BlobManager.actor.cpp
+++ b/fdbserver/BlobManager.actor.cpp
@@ -1080,6 +1080,7 @@ ACTOR Future<Void> recoverBlobManager(BlobManagerData* bmData) {
 				std::tie(splitState, version) = decodeBlobGranuleSplitValue(split.value);
 				const KeyRange range = blobGranuleSplitKeyRangeFor(parentGranuleID);
 				if (splitState <= BlobGranuleSplitState::Initialized) {
+					// the empty UID signifies that we need to find an owner (worker) for this range
 					workerAssignments.insert(range, UID());
 				}
 			}


### PR DESCRIPTION
When we have an empty key range map, the default range is `allKeys`. In the case of a BM failure before any ranges were assigned, the new BM will try to assign the range `['', \xff\xff)`, so we clamp this down to the normal key space `['', \xff)`.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
