### PR TITLE
Not warn on constant-logical-operand when compile with clang

### DIFF
--- a/cmake/ConfigureCompiler.cmake
+++ b/cmake/ConfigureCompiler.cmake
@@ -288,6 +288,7 @@ else()
       -Wno-undefined-var-template
       -Wno-unknown-warning-option
       -Wno-unused-parameter
+      -Wno-constant-logical-operand
       )
     if (USE_CCACHE)
       add_compile_options(


### PR DESCRIPTION
explicitly disable to compile warning-free with clang

```
In file included from /root/src/foundationdb/fdbrpc/FlowTransport.actor.cpp:44:
/root/src/foundationdb/flow/xxhash.h:1743:8: error: use of logical '||' with constant operand [-Werror,-Wconstant-logical-operand]
 if (0 || 0) {
       ^  ~
/root/src/foundationdb/flow/xxhash.h:1743:8: note: use '|' for a bitwise operation
 if (0 || 0) {
       ^~
       |
1 error generated.
```


# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
