### PR TITLE
Move DNS mock from SimExternalConnection to Sim2.

### DIFF
--- a/fdbrpc/SimExternalConnection.actor.cpp
+++ b/fdbrpc/SimExternalConnection.actor.cpp
@@ -108,8 +108,6 @@ void MockDNS::clearMockTCPEndpoints() {
 	hostnameToAddresses.clear();
 }
 
-MockDNS SimExternalConnection::mockDNS;
-
 void SimExternalConnection::close() {
 	socket.close();
 }
@@ -195,9 +193,6 @@ ACTOR static Future<std::vector<NetworkAddress>> resolveTCPEndpointImpl(std::str
 
 Future<std::vector<NetworkAddress>> SimExternalConnection::resolveTCPEndpoint(const std::string& host,
                                                                               const std::string& service) {
-	if (mockDNS.findMockTCPEndpoint(host, service)) {
-		return mockDNS.getTCPEndpoint(host, service);
-	}
 	return resolveTCPEndpointImpl(host, service);
 }
 

--- a/fdbrpc/SimExternalConnection.h
+++ b/fdbrpc/SimExternalConnection.h
@@ -68,9 +68,6 @@ public:
 	UID getDebugID() const override;
 	static Future<std::vector<NetworkAddress>> resolveTCPEndpoint(const std::string& host, const std::string& service);
 	static Future<Reference<IConnection>> connect(NetworkAddress toAddr);
-
-private:
-	static MockDNS mockDNS;
 };
 
 #endif

--- a/fdbrpc/sim2.actor.cpp
+++ b/fdbrpc/sim2.actor.cpp
@@ -945,8 +945,18 @@ public:
 	Future<Reference<IUDPSocket>> createUDPSocket(NetworkAddress toAddr) override;
 	Future<Reference<IUDPSocket>> createUDPSocket(bool isV6 = false) override;
 
+	// Add a <hostname, vector<NetworkAddress>> pair to mock DNS in simulation.
+	void addMockTCPEndpoint(const std::string& host,
+	                        const std::string& service,
+	                        const std::vector<NetworkAddress>& addresses) override {
+		mockDNS.addMockTCPEndpoint(host, service, addresses);
+	}
 	Future<std::vector<NetworkAddress>> resolveTCPEndpoint(const std::string& host,
 	                                                       const std::string& service) override {
+		// If a <hostname, vector<NetworkAddress>> pair was injected to mock DNS, use it.
+		if (mockDNS.findMockTCPEndpoint(host, service)) {
+			return mockDNS.getTCPEndpoint(host, service);
+		}
 		return SimExternalConnection::resolveTCPEndpoint(host, service);
 	}
 	ACTOR static Future<Reference<IConnection>> onConnect(Future<Void> ready, Reference<Sim2Conn> conn) {
@@ -2131,6 +2141,9 @@ public:
 	// Whether or not yield has returned true during the current iteration of the run loop
 	bool yielded;
 	int yield_limit; // how many more times yield may return false before next returning true
+
+private:
+	MockDNS mockDNS;
 
 #ifdef ENABLE_SAMPLING
 	ActorLineageSet actorLineageSet;

--- a/flow/Net2.actor.cpp
+++ b/flow/Net2.actor.cpp
@@ -152,6 +152,12 @@ public:
 	Future<Reference<IConnection>> connectExternal(NetworkAddress toAddr, const std::string& host) override;
 	Future<Reference<IUDPSocket>> createUDPSocket(NetworkAddress toAddr) override;
 	Future<Reference<IUDPSocket>> createUDPSocket(bool isV6) override;
+	// This method should only be used in simulation.
+	void addMockTCPEndpoint(const std::string& host,
+	                        const std::string& service,
+	                        const std::vector<NetworkAddress>& addresses) override {
+		throw operation_failed();
+	}
 	Future<std::vector<NetworkAddress>> resolveTCPEndpoint(const std::string& host,
 	                                                       const std::string& service) override;
 	Reference<IListener> listen(NetworkAddress localAddr) override;

--- a/flow/network.h
+++ b/flow/network.h
@@ -689,6 +689,9 @@ public:
 	// Make an outgoing udp connection without establishing a connection
 	virtual Future<Reference<IUDPSocket>> createUDPSocket(bool isV6 = false) = 0;
 
+	virtual void addMockTCPEndpoint(const std::string& host,
+	                                const std::string& service,
+	                                const std::vector<NetworkAddress>& addresses) = 0;
 	// Resolve host name and service name (such as "http" or can be a plain number like "80") to a list of 1 or more
 	// NetworkAddresses
 	virtual Future<std::vector<NetworkAddress>> resolveTCPEndpoint(const std::string& host,


### PR DESCRIPTION
This is a revise PR of #5934. In simulation, we don't have direct access to SimExternalConnection.

20211115-230109-renxuan-916bc186f0ad6df6

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
