### PR TITLE
First pass at using ChangeFeedData in blob worker

### DIFF
--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -6787,7 +6787,7 @@ Reference<ChangeFeedStorageData> DatabaseContext::getStorageData(StorageServerIn
 }
 
 Version ChangeFeedData::getVersion() {
-	if (notAtLatest.get() == 0 && mutations.isEmpty()) {
+	if (notAtLatest.get() == 0 && mutations.isEmpty() && storageData.size() > 0) {
 		Version v = storageData[0]->version.get();
 		for (int i = 1; i < storageData.size(); i++) {
 			if (storageData[i]->version.get() < v) {

--- a/fdbserver/BlobWorker.actor.cpp
+++ b/fdbserver/BlobWorker.actor.cpp
@@ -97,14 +97,12 @@ struct GranuleMetadata : NonCopyable, ReferenceCounted<GranuleMetadata> {
 	uint64_t bufferedDeltaBytes = 0;
 
 	// for client to know when it is safe to read a certain version and from where (check waitForVersion)
-	NotifiedVersion bufferedDeltaVersion; // largest delta version in currentDeltas (including empty versions)
+	Version bufferedDeltaVersion; // largest delta version in currentDeltas (including empty versions)
 	Version pendingDeltaVersion = 0; // largest version in progress writing to s3/fdb
 	NotifiedVersion durableDeltaVersion; // largest version persisted in s3/fdb
 	NotifiedVersion durableSnapshotVersion; // same as delta vars, except for snapshots
 	Version pendingSnapshotVersion = 0;
 	Version initialSnapshotVersion = invalidVersion;
-
-	AsyncVar<int> rollbackCount;
 
 	int64_t originalEpoch;
 	int64_t originalSeqno;
@@ -116,6 +114,8 @@ struct GranuleMetadata : NonCopyable, ReferenceCounted<GranuleMetadata> {
 	Promise<Void> historyLoaded;
 
 	Promise<Void> resumeSnapshot;
+
+	AsyncVar<Reference<ChangeFeedData>> activeCFData;
 
 	AssignBlobRangeRequest originalReq;
 
@@ -1009,6 +1009,13 @@ struct InFlightFile {
 	  : future(future), version(version), bytes(bytes), snapshot(snapshot) {}
 };
 
+static Reference<ChangeFeedData> newChangeFeedData(Version startVersion) {
+	// FIXME: should changeFeedStream guarantee that this is always set to begin-1 instead?
+	Reference<ChangeFeedData> r = makeReference<ChangeFeedData>();
+	r->lastReturnedVersion.set(startVersion);
+	return r;
+}
+
 static Version doGranuleRollback(Reference<GranuleMetadata> metadata,
                                  Version mutationVersion,
                                  Version rollbackVersion,
@@ -1072,9 +1079,7 @@ static Version doGranuleRollback(Reference<GranuleMetadata> metadata,
 		metadata->deltaArena = Arena();
 		metadata->currentDeltas = GranuleDeltas();
 		metadata->bufferedDeltaBytes = 0;
-		// Create new notified version so it doesn't go backwards. Do this before signaling the rollback counter so that
-		// the callers pick this new one up for the next waitForVersion
-		metadata->bufferedDeltaVersion = NotifiedVersion(cfRollbackVersion);
+		metadata->bufferedDeltaVersion = cfRollbackVersion;
 
 		// Track that this rollback happened, since we have to re-read mutations up to the rollback
 		// Add this rollback to in progress, and put all completed ones back in progress
@@ -1113,9 +1118,7 @@ static Version doGranuleRollback(Reference<GranuleMetadata> metadata,
 		// delete all deltas in rollback range, but we can optimize here to just skip the uncommitted mutations
 		// directly and immediately pop the rollback out of inProgress
 
-		// Create new notified version so it doesn't go backwards. Do this before signaling the rollback counter so that
-		// the callers pick this new one up for the next waitForVersion
-		metadata->bufferedDeltaVersion = NotifiedVersion(rollbackVersion);
+		metadata->bufferedDeltaVersion = rollbackVersion;
 		cfRollbackVersion = mutationVersion;
 	}
 
@@ -1126,8 +1129,6 @@ static Version doGranuleRollback(Reference<GranuleMetadata> metadata,
 		       cfRollbackVersion);
 	}
 
-	metadata->rollbackCount.set(metadata->rollbackCount.get() + 1);
-
 	return cfRollbackVersion;
 }
 
@@ -1137,8 +1138,6 @@ static Version doGranuleRollback(Reference<GranuleMetadata> metadata,
 ACTOR Future<Void> blobGranuleUpdateFiles(Reference<BlobWorkerData> bwData,
                                           Reference<GranuleMetadata> metadata,
                                           Future<GranuleStartState> assignFuture) {
-	state Reference<ChangeFeedData> oldChangeFeedStream = makeReference<ChangeFeedData>();
-	state Reference<ChangeFeedData> changeFeedStream = makeReference<ChangeFeedData>();
 	state std::deque<InFlightFile> inFlightFiles;
 	state Future<Void> oldChangeFeedFuture;
 	state Future<Void> changeFeedFuture;
@@ -1234,25 +1233,28 @@ ACTOR Future<Void> blobGranuleUpdateFiles(Reference<BlobWorkerData> bwData,
 
 		metadata->durableDeltaVersion.set(startVersion);
 		metadata->pendingDeltaVersion = startVersion;
-		metadata->bufferedDeltaVersion.set(startVersion);
+		metadata->bufferedDeltaVersion = startVersion;
 		committedVersion.set(startVersion);
 
-		ASSERT(metadata->readable.canBeSet());
-		metadata->readable.send(Void());
-
+		metadata->activeCFData.set(newChangeFeedData(startVersion));
 		if (startState.parentGranule.present() && startVersion < startState.changeFeedStartVersion) {
 			// read from parent change feed up until our new change feed is started
 			readOldChangeFeed = true;
-			oldChangeFeedFuture = bwData->db->getChangeFeedStream(oldChangeFeedStream,
+
+			oldChangeFeedFuture = bwData->db->getChangeFeedStream(metadata->activeCFData.get(),
 			                                                      oldCFKey.get(),
 			                                                      startVersion + 1,
 			                                                      startState.changeFeedStartVersion,
 			                                                      metadata->keyRange);
+
 		} else {
 			readOldChangeFeed = false;
 			changeFeedFuture = bwData->db->getChangeFeedStream(
-			    changeFeedStream, cfKey, startVersion + 1, MAX_VERSION, metadata->keyRange);
+			    metadata->activeCFData.get(), cfKey, startVersion + 1, MAX_VERSION, metadata->keyRange);
 		}
+
+		ASSERT(metadata->readable.canBeSet());
+		metadata->readable.send(Void());
 
 		loop {
 			// check outstanding snapshot/delta files for completion
@@ -1295,16 +1297,12 @@ ACTOR Future<Void> blobGranuleUpdateFiles(Reference<BlobWorkerData> bwData,
 
 			state Standalone<VectorRef<MutationsAndVersionRef>> mutations;
 			try {
+				state Standalone<VectorRef<MutationsAndVersionRef>> _mutations =
+				    waitNext(metadata->activeCFData.get()->mutations.getFuture());
+				mutations = _mutations;
 				if (readOldChangeFeed) {
-					// TODO efficient way to store next in mutations?
-					Standalone<VectorRef<MutationsAndVersionRef>> oldMutations =
-					    waitNext(oldChangeFeedStream->mutations.getFuture());
-					mutations = oldMutations;
 					ASSERT(mutations.back().version < startState.changeFeedStartVersion);
 				} else {
-					Standalone<VectorRef<MutationsAndVersionRef>> newMutations =
-					    waitNext(changeFeedStream->mutations.getFuture());
-					mutations = newMutations;
 					ASSERT(mutations.front().version >= startState.changeFeedStartVersion);
 				}
 			} catch (Error& e) {
@@ -1323,11 +1321,15 @@ ACTOR Future<Void> blobGranuleUpdateFiles(Reference<BlobWorkerData> bwData,
 					       metadata->keyRange.begin.printable().c_str(),
 					       metadata->keyRange.end.printable().c_str(),
 					       startState.granuleID.toString().c_str(),
-					       metadata->bufferedDeltaVersion.get());
+					       metadata->bufferedDeltaVersion);
 				}
 
-				changeFeedFuture = bwData->db->getChangeFeedStream(
-				    changeFeedStream, cfKey, startState.changeFeedStartVersion, MAX_VERSION, metadata->keyRange);
+				metadata->activeCFData.set(newChangeFeedData(startState.changeFeedStartVersion - 1));
+				changeFeedFuture = bwData->db->getChangeFeedStream(metadata->activeCFData.get(),
+				                                                   cfKey,
+				                                                   startState.changeFeedStartVersion,
+				                                                   MAX_VERSION,
+				                                                   metadata->keyRange);
 			}
 
 			// process mutations
@@ -1336,7 +1338,7 @@ ACTOR Future<Void> blobGranuleUpdateFiles(Reference<BlobWorkerData> bwData,
 
 				// buffer mutations at this version. There should not be multiple MutationsAndVersionRef with the same
 				// version
-				ASSERT(deltas.version > metadata->bufferedDeltaVersion.get());
+				ASSERT(deltas.version > metadata->bufferedDeltaVersion);
 				if (!deltas.mutations.empty()) {
 					if (deltas.mutations.size() == 1 && deltas.mutations.back().param1 == lastEpochEndPrivateKey) {
 						// Note rollbackVerision is durable, [rollbackVersion+1 - deltas.version] needs to be tossed
@@ -1383,6 +1385,7 @@ ACTOR Future<Void> blobGranuleUpdateFiles(Reference<BlobWorkerData> bwData,
 									    .detail("Version", deltas.version)
 									    .detail("RollbackVersion", rollbackVersion);
 								}
+
 								Version cfRollbackVersion = doGranuleRollback(metadata,
 								                                              deltas.version,
 								                                              rollbackVersion,
@@ -1391,27 +1394,29 @@ ACTOR Future<Void> blobGranuleUpdateFiles(Reference<BlobWorkerData> bwData,
 								                                              rollbacksCompleted);
 
 								// Reset change feeds to cfRollbackVersion
+								metadata->activeCFData.set(newChangeFeedData(cfRollbackVersion));
 								if (readOldChangeFeed) {
 									// It shouldn't be possible to roll back across the parent/child feed boundary,
 									// because the transaction creating the child change feed had to commit before we
 									// got here.
 									ASSERT(cfRollbackVersion < startState.changeFeedStartVersion);
-									oldChangeFeedStream = makeReference<ChangeFeedData>();
 									oldChangeFeedFuture =
-									    bwData->db->getChangeFeedStream(oldChangeFeedStream,
+									    bwData->db->getChangeFeedStream(metadata->activeCFData.get(),
 									                                    oldCFKey.get(),
 									                                    cfRollbackVersion + 1,
 									                                    startState.changeFeedStartVersion,
 									                                    metadata->keyRange);
+
 								} else {
 									ASSERT(cfRollbackVersion > startState.changeFeedStartVersion);
-									changeFeedStream = makeReference<ChangeFeedData>();
-									changeFeedFuture = bwData->db->getChangeFeedStream(changeFeedStream,
+
+									changeFeedFuture = bwData->db->getChangeFeedStream(metadata->activeCFData.get(),
 									                                                   cfKey,
 									                                                   cfRollbackVersion + 1,
 									                                                   MAX_VERSION,
 									                                                   metadata->keyRange);
 								}
+
 								justDidRollback = true;
 								break;
 							}
@@ -1440,7 +1445,7 @@ ACTOR Future<Void> blobGranuleUpdateFiles(Reference<BlobWorkerData> bwData,
 				}
 
 				// update buffered version and committed version
-				metadata->bufferedDeltaVersion.set(deltas.version);
+				metadata->bufferedDeltaVersion = deltas.version;
 				Version knownNoRollbacksPast = std::min(deltas.version, deltas.knownCommittedVersion);
 				if (knownNoRollbacksPast > committedVersion.get()) {
 					// This is the only place it is safe to set committedVersion, as it has to come from the mutation
@@ -1621,6 +1626,9 @@ ACTOR Future<Void> blobGranuleUpdateFiles(Reference<BlobWorkerData> bwData,
 		if (BW_DEBUG) {
 			printf("BGUF got error %s\n", e.name());
 		}
+		// Free last change feed data
+		metadata->activeCFData.set(Reference<ChangeFeedData>());
+
 		if (e.code() == error_code_operation_cancelled) {
 			throw;
 		}
@@ -1785,13 +1793,15 @@ ACTOR Future<Void> waitForVersion(Reference<GranuleMetadata> metadata, Version v
 	       metadata->keyRange.end.printable().c_str(),
 	       v,
 	       metadata->readable.isSet() ? "T" : "F",
-	       metadata->bufferedDeltaVersion.get(),
+	       metadata->activeCFData.get()->getVersion(),
 	       metadata->pendingDeltaVersion,
 	       metadata->durableDeltaVersion.get(),
 	       metadata->pendingSnapshotVersion,
 	       metadata->durableSnapshotVersion.get());*/
 
-	if (v <= metadata->bufferedDeltaVersion.get() &&
+	ASSERT(metadata->activeCFData.get().isValid());
+
+	if (v <= metadata->activeCFData.get()->getVersion() &&
 	    (v <= metadata->durableDeltaVersion.get() ||
 	     metadata->durableDeltaVersion.get() == metadata->pendingDeltaVersion) &&
 	    (v <= metadata->durableSnapshotVersion.get() ||
@@ -1800,15 +1810,15 @@ ACTOR Future<Void> waitForVersion(Reference<GranuleMetadata> metadata, Version v
 	}
 
 	// wait for change feed version to catch up to ensure we have all data
-	if (metadata->bufferedDeltaVersion.get() < v) {
-		wait(metadata->bufferedDeltaVersion.whenAtLeast(v));
+	if (metadata->activeCFData.get()->getVersion() < v) {
+		wait(metadata->activeCFData.get()->whenAtLeast(v));
 	}
 
 	// wait for any pending delta and snapshot files as of the moment the change feed version caught up.
 	state Version pendingDeltaV = metadata->pendingDeltaVersion;
 	state Version pendingSnapshotV = metadata->pendingSnapshotVersion;
 
-	ASSERT(pendingDeltaV <= metadata->bufferedDeltaVersion.get());
+	// ASSERT(pendingDeltaV <= metadata->activeCFData.get()->getVersion());
 	if (pendingDeltaV > metadata->durableDeltaVersion.get()) {
 		wait(metadata->durableDeltaVersion.whenAtLeast(pendingDeltaV));
 	}
@@ -1970,6 +1980,9 @@ ACTOR Future<Void> handleBlobGranuleFileRequest(Reference<BlobWorkerData> bwData
 			} else {
 				// this is an active granule query
 				loop {
+					if (!metadata->activeCFData.get().isValid()) {
+						throw wrong_shard_server();
+					}
 					Future<Void> waitForVersionFuture = waitForVersion(metadata, req.readVersion);
 					if (waitForVersionFuture.isReady()) {
 						// didn't wait, so no need to check rollback stuff
@@ -1977,17 +1990,13 @@ ACTOR Future<Void> handleBlobGranuleFileRequest(Reference<BlobWorkerData> bwData
 					}
 					// rollback resets all of the version information, so we have to redo wait for
 					// version on rollback
-					state int rollbackCount = metadata->rollbackCount.get();
 					choose {
-						when(wait(waitForVersionFuture)) {}
-						when(wait(metadata->rollbackCount.onChange())) {}
+						when(wait(waitForVersionFuture)) { break; }
+						when(wait(metadata->activeCFData.onChange())) {}
 						when(wait(metadata->cancelled.getFuture())) { throw wrong_shard_server(); }
 					}
-
-					if (rollbackCount == metadata->rollbackCount.get()) {
-						break;
-					} else if (BW_REQUEST_DEBUG) {
-						printf("[%s - %s) @ %lld hit rollback, restarting waitForVersion\n",
+					if (BW_REQUEST_DEBUG && metadata->activeCFData.get().isValid()) {
+						printf("[%s - %s) @ %lld hit CF change, restarting waitForVersion\n",
 						       req.keyRange.begin.printable().c_str(),
 						       req.keyRange.end.printable().c_str(),
 						       req.readVersion);


### PR DESCRIPTION
It's not correctness clean (currently some segfault happens in the storage server i have yet to debug), but I figured i'd at least make sure i'm using the API as intended before diving into that further.
Using the ChangeFeedData also cleaned up several aspects of the BlobWorker code, which is nice too.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
