### PR TITLE
Fix possible Net2 data race

### DIFF
--- a/flow/Net2.actor.cpp
+++ b/flow/Net2.actor.cpp
@@ -199,7 +199,7 @@ public:
 
 	flowGlobalType global(int id) const override { return (globals.size() > id) ? globals[id] : nullptr; }
 	void setGlobal(size_t id, flowGlobalType v) override {
-		globals.resize(std::max(globals.size(), id + 1));
+		ASSERT(id < globals.size());
 		globals[id] = v;
 	}
 
@@ -1187,7 +1187,7 @@ struct PromiseTask final : public Task, public FastAllocated<PromiseTask> {
 // 5MB for loading files into memory
 
 Net2::Net2(const TLSConfig& tlsConfig, bool useThreadPool, bool useMetrics)
-  : useThreadPool(useThreadPool), reactor(this),
+  : globals(enumGlobal::COUNT), useThreadPool(useThreadPool), reactor(this),
 #ifndef TLS_DISABLED
     sslContextVar({ ReferencedObject<boost::asio::ssl::context>::from(
         boost::asio::ssl::context(boost::asio::ssl::context::tls)) }),

--- a/flow/network.h
+++ b/flow/network.h
@@ -540,7 +540,8 @@ public:
 		enGlobalConfig = 14,
 		enChaosMetrics = 15,
 		enDiskFailureInjector = 16,
-		enBitFlipper = 17
+		enBitFlipper = 17,
+		COUNT // Add new fields before this enumerator
 	};
 
 	virtual void longTaskCheck(const char* name) {}


### PR DESCRIPTION
@sfc-gh-anoyes found a data race surfaced by TSAN, where a thread (doing some transaction creation work) tries to resize `globals` at the same time the main thread is reading it. This fix removes the on demand resizing of `globals` and instead initializes it once when `Net2` is constructed.

Passed 10k correctness.


TSAN output:

```
WARNING: ThreadSanitizer: data race (pid=415)
  Write of size 8 at 0x7b6800000758 by thread T2:
    #0 std::__1::vector<void*, std::__1::allocator<void*> >::_ConstructTransaction::~_ConstructTransaction() /usr/local/bin/../include/c++/v1/vector:905:19 (libfdb_c.so+0x10ce795)
    #1 std::__1::vector<void*, std::__1::allocator<void*> >::__construct_at_end(unsigned long) /usr/local/bin/../include/c++/v1/vector:1050:1 (libfdb_c.so+0x10ce795)
    #2 std::__1::vector<void*, std::__1::allocator<void*> >::__append(unsigned long) /usr/local/bin/../include/c++/v1/vector:1092:15 (libfdb_c.so+0x10ce795)
    #3 std::__1::vector<void*, std::__1::allocator<void*> >::resize(unsigned long) /usr/local/bin/../include/c++/v1/vector:2027:15 (libfdb_c.so+0x10cc160)
    #4 N2::Net2::setGlobal(unsigned long, void*) /home/jenkins/fdb/extra/long/path/to/work/around/strange/cpack/debug/rpm/behavior/flow/Net2.actor.cpp:196:11 (libfdb_c.so+0x10cc160)
    #5 void GlobalConfig::create<ClientDBInfo>(Database&, Reference<AsyncVar<ClientDBInfo> const>, ClientDBInfo const*) /home/jenkins/fdb/extra/long/path/to/work/around/strange/cpack/debug/rpm/behavior/fdbclient/GlobalConfig.actor.h:82:15 (libfdb_c.so+0x83a4ef)
    #6 Database::createDatabase(Reference<IClusterConnectionRecord>, int, IsInternal, LocalityData const&, DatabaseContext*) /home/jenkins/fdb/extra/long/path/to/work/around/strange/cpack/debug/rpm/behavior/fdbclient/NativeAPI.actor.cpp:1871:2 (libfdb_c.so+0x61d730)
    #7 ThreadSafeDatabase::ThreadSafeDatabase(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, int)::$_7::operator()() const /home/jenkins/fdb/extra/long/path/to/work/around/strange/cpack/debug/rpm/behavior/_build/../fdbclient/ThreadSafeTransaction.cpp:124:8 (libfdb_c.so+0xf063bc)
    #8 internal_thread_helper::DoOnMainThreadVoidActorState<ThreadSafeDatabase::ThreadSafeDatabase(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, int)::$_7, internal_thread_helper::DoOnMainThreadVoidActor<ThreadSafeDatabase::ThreadSafeDatabase(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, int)::$_7> >::a_body1cont1(Void const&, int) /home/jenkins/fdb/extra/long/path/to/work/around/strange/cpack/debug/rpm/behavior/flow/ThreadHelper.actor.h:45:4 (libfdb_c.so+0xf063bc)
    #9 internal_thread_helper::DoOnMainThreadVoidActorState<ThreadSafeDatabase::ThreadSafeDatabase(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, int)::$_7, internal_thread_helper::DoOnMainThreadVoidActor<ThreadSafeDatabase::ThreadSafeDatabase(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, int)::$_7> >::a_body1when1(Void const&, int) /home/jenkins/fdb/extra/long/path/to/work/around/strange/cpack/debug/rpm/behavior/_build/flow/ThreadHelper.actor.g.h:148:15 (libfdb_c.so+0xf063bc)
    #10 internal_thread_helper::DoOnMainThreadVoidActorState<ThreadSafeDatabase::ThreadSafeDatabase(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, int)::$_7, internal_thread_helper::DoOnMainThreadVoidActor<ThreadSafeDatabase::ThreadSafeDatabase(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, int)::$_7> >::a_callback_fire(ActorCallback<internal_thread_helper::DoOnMainThreadVoidActor<ThreadSafeDatabase::ThreadSafeDatabase(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, int)::$_7>, 0, Void>*, Void const&) /home/jenkins/fdb/extra/long/path/to/work/around/strange/cpack/debug/rpm/behavior/_build/flow/ThreadHelper.actor.g.h:169:4 (libfdb_c.so+0xf0601f)
    #11 ActorCallback<internal_thread_helper::DoOnMainThreadVoidActor<ThreadSafeDatabase::ThreadSafeDatabase(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, int)::$_7>, 0, Void>::fire(Void const&) /home/jenkins/fdb/extra/long/path/to/work/around/strange/cpack/debug/rpm/behavior/_build/../flow/flow.h:1292:34 (libfdb_c.so+0xf0601f)
    #12 void SAV<Void>::send<Void>(Void&&) /home/jenkins/fdb/extra/long/path/to/work/around/strange/cpack/debug/rpm/behavior/_build/../flow/flow.h:659:23 (libfdb_c.so+0x566072)
    #13 void Promise<Void>::send<Void>(Void&&) const /home/jenkins/fdb/extra/long/path/to/work/around/strange/cpack/debug/rpm/behavior/_build/../flow/flow.h:898:8 (libfdb_c.so+0x10dfcde)
    #14 N2::PromiseTask::operator()() /home/jenkins/fdb/extra/long/path/to/work/around/strange/cpack/debug/rpm/behavior/flow/Net2.actor.cpp:1175:11 (libfdb_c.so+0x10dfcde)
    #15 N2::Net2::run() /home/jenkins/fdb/extra/long/path/to/work/around/strange/cpack/debug/rpm/behavior/flow/Net2.actor.cpp:1514:5 (libfdb_c.so+0x10c39a7)
    #16 runNetwork() /home/jenkins/fdb/extra/long/path/to/work/around/strange/cpack/debug/rpm/behavior/fdbclient/NativeAPI.actor.cpp:2169:13 (libfdb_c.so+0x622604)
    #17 ThreadSafeApi::runNetwork() /home/jenkins/fdb/extra/long/path/to/work/around/strange/cpack/debug/rpm/behavior/_build/../fdbclient/ThreadSafeTransaction.cpp:462:3 (libfdb_c.so+0xefe78c)
    #18 MultiVersionApi::runNetwork() /home/jenkins/fdb/extra/long/path/to/work/around/strange/cpack/debug/rpm/behavior/fdbclient/MultiVersionTransaction.actor.cpp:1928:20 (libfdb_c.so+0x589bfd)
    #19 fdb_run_network /home/jenkins/fdb/extra/long/path/to/work/around/strange/cpack/debug/rpm/behavior/_build/../bindings/c/fdb_c.cpp:130:2 (libfdb_c.so+0x557425)
    #20 DLApi::runNetwork() /home/jenkins/fdb/extra/long/path/to/work/around/strange/cpack/debug/rpm/behavior/fdbclient/MultiVersionTransaction.actor.cpp:574:11 (fdbcli+0xc52ba8)
    #21 runNetworkThread(void*) /home/jenkins/fdb/extra/long/path/to/work/around/strange/cpack/debug/rpm/behavior/fdbclient/MultiVersionTransaction.actor.cpp:1897:30 (fdbcli+0xc66e19)

  Previous read of size 8 at 0x7b6800000758 by main thread:
    #0 std::__1::vector<void*, std::__1::allocator<void*> >::size() const /usr/local/bin/../include/c++/v1/vector:658:46 (libfdb_c.so+0x10cdbee)
    #1 N2::Net2::global(int) const /home/jenkins/fdb/extra/long/path/to/work/around/strange/cpack/debug/rpm/behavior/flow/Net2.actor.cpp:194:65 (libfdb_c.so+0x10cdbee)
    #2 FlowTransport::isClient() /home/jenkins/fdb/extra/long/path/to/work/around/strange/cpack/debug/rpm/behavior/_build/../fdbrpc/FlowTransport.h:193:45 (libfdb_c.so+0x83d7f4)
    #3 TimedRequest::TimedRequest() /home/jenkins/fdb/extra/long/path/to/work/around/strange/cpack/debug/rpm/behavior/_build/../fdbrpc/TimedRequest.h:37:8 (libfdb_c.so+0x83d7f4)
    #4 CommitTransactionRequest::CommitTransactionRequest(UID const&) /home/jenkins/fdb/extra/long/path/to/work/around/strange/cpack/debug/rpm/behavior/_build/../fdbclient/CommitProxyInterface.h:174:2 (libfdb_c.so+0x83d7f4)
    #5 CommitTransactionRequest::CommitTransactionRequest() /home/jenkins/fdb/extra/long/path/to/work/around/strange/cpack/debug/rpm/behavior/_build/../fdbclient/CommitProxyInterface.h:173:31 (libfdb_c.so+0x62ec66)
    #6 Transaction::Transaction() /home/jenkins/fdb/extra/long/path/to/work/around/strange/cpack/debug/rpm/behavior/fdbclient/NativeAPI.actor.cpp:4268:14 (libfdb_c.so+0x62ec66)
    #7 ReadYourWritesTransaction::ReadYourWritesTransaction() /home/jenkins/fdb/extra/long/path/to/work/around/strange/cpack/debug/rpm/behavior/_build/../fdbclient/ReadYourWrites.h:140:2 (libfdb_c.so+0x911bf8)
    #8 ISingleThreadTransaction::allocateOnForeignThread(ISingleThreadTransaction::Type) /home/jenkins/fdb/extra/long/path/to/work/around/strange/cpack/debug/rpm/behavior/_build/../fdbclient/ISingleThreadTransaction.cpp:29:17 (libfdb_c.so+0xf1cf7f)
    #9 ThreadSafeTransaction::ThreadSafeTransaction(DatabaseContext*, ISingleThreadTransaction::Type) /home/jenkins/fdb/extra/long/path/to/work/around/strange/cpack/debug/rpm/behavior/_build/../fdbclient/ThreadSafeTransaction.cpp:149:23 (libfdb_c.so+0xeec330)
    #10 ThreadSafeDatabase::createTransaction() /home/jenkins/fdb/extra/long/path/to/work/around/strange/cpack/debug/rpm/behavior/_build/../fdbclient/ThreadSafeTransaction.cpp:50:37 (libfdb_c.so+0xee790c)
    #11 fdb_database_create_transaction /home/jenkins/fdb/extra/long/path/to/work/around/strange/cpack/debug/rpm/behavior/_build/../bindings/c/fdb_c.cpp:332:2 (libfdb_c.so+0x558e4d)
    #12 DLDatabase::createTransaction() /home/jenkins/fdb/extra/long/path/to/work/around/strange/cpack/debug/rpm/behavior/fdbclient/MultiVersionTransaction.actor.cpp:348:2 (fdbcli+0xc4fe9f)
    #13 MultiVersionTransaction::updateTransaction() /home/jenkins/fdb/extra/long/path/to/work/around/strange/cpack/debug/rpm/behavior/fdbclient/MultiVersionTransaction.actor.cpp:666:40 (fdbcli+0xc53f54)
    #14 MultiVersionTransaction::MultiVersionTransaction(Reference<MultiVersionDatabase>, UniqueOrderedOptionList<FDBTransactionOptions>) /home/jenkins/fdb/extra/long/path/to/work/around/strange/cpack/debug/rpm/behavior/fdbclient/MultiVersionTransaction.actor.cpp:653:2 (fdbcli+0xc53a6c)
    #15 MultiVersionDatabase::createTransaction() /home/jenkins/fdb/extra/long/path/to/work/around/strange/cpack/debug/rpm/behavior/fdbclient/MultiVersionTransaction.actor.cpp:1128:10 (fdbcli+0xc5db46)
    #16 getTransaction(Reference<IDatabase>, Reference<ITransaction>&, FdbOptions*, bool) /home/jenkins/fdb/extra/long/path/to/work/around/strange/cpack/debug/rpm/behavior/fdbcli/fdbcli.actor.cpp:1088:12 (fdbcli+0x7e2c10)
    #17 (anonymous namespace)::CliActorState<(anonymous namespace)::CliActor>::a_body1cont4loopBody1(int) /home/jenkins/fdb/extra/long/path/to/work/around/strange/cpack/debug/rpm/behavior/fdbcli/fdbcli.actor.cpp:1619:4 (fdbcli+0x806fc6)
    #18 (anonymous namespace)::CliActorState<(anonymous namespace)::CliActor>::a_body1cont4loopHead1(int) /home/jenkins/fdb/extra/long/path/to/work/around/strange/cpack/debug/rpm/behavior/_build/fdbcli/fdbcli.actor.g.cpp:5675:49 (fdbcli+0x806fc6)
    #19 (anonymous namespace)::CliActorState<(anonymous namespace)::CliActor>::a_body1cont4loopBody1cont1(int) /home/jenkins/fdb/extra/long/path/to/work/around/strange/cpack/debug/rpm/behavior/_build/fdbcli/fdbcli.actor.g.cpp:5721:30 (fdbcli+0x801e1f)
    #20 (anonymous namespace)::CliActorState<(anonymous namespace)::CliActor>::a_body1cont4loopBody1Catch1cont1(int) /home/jenkins/fdb/extra/long/path/to/work/around/strange/cpack/debug/rpm/behavior/_build/fdbcli/fdbcli.actor.g.cpp:5839:15 (fdbcli+0x801e1f)
    #21 (anonymous namespace)::CliActorState<(anonymous namespace)::CliActor>::a_body1cont4loopBody1Catch1cont2(Void const&, int) /home/jenkins/fdb/extra/long/path/to/work/around/strange/cpack/debug/rpm/behavior/_build/fdbcli/fdbcli.actor.g.cpp:5845:15 (fdbcli+0x801e1f)
    #22 (anonymous namespace)::CliActorState<(anonymous namespace)::CliActor>::a_body1cont4loopBody1Catch1when1(Void const&, int) /home/jenkins/fdb/extra/long/path/to/work/around/strange/cpack/debug/rpm/behavior/_build/fdbcli/fdbcli.actor.g.cpp:5857:15 (fdbcli+0x801e1f)
    #23 (anonymous namespace)::CliActorState<(anonymous namespace)::CliActor>::a_callback_fire(ActorCallback<(anonymous namespace)::CliActor, 1, Void>*, Void const&) /home/jenkins/fdb/extra/long/path/to/work/around/strange/cpack/debug/rpm/behavior/_build/fdbcli/fdbcli.actor.g.cpp:5878:4 (fdbcli+0x801e1f)
    #24 ActorCallback<(anonymous namespace)::CliActor, 1, Void>::fire(Void const&) /home/jenkins/fdb/extra/long/path/to/work/around/strange/cpack/debug/rpm/behavior/_build/../flow/flow.h:1292:34 (fdbcli+0x801e1f)
    #25 SAV<Void>::finishSendAndDelPromiseRef() /home/jenkins/fdb/extra/long/path/to/work/around/strange/cpack/debug/rpm/behavior/_build/../flow/flow.h:693:23 (fdbcli+0x7edb92)
    #26 (anonymous namespace)::SafeThreadFutureToFutureActorState<Void, (anonymous namespace)::SafeThreadFutureToFutureActor<Void> >::a_body1cont1(int) /home/jenkins/fdb/extra/long/path/to/work/around/strange/cpack/debug/rpm/behavior/_build/flow/ThreadHelper.actor.g.h:958:54 (fdbcli+0x7edb92)
    #27 (anonymous namespace)::SafeThreadFutureToFutureActorState<Void, (anonymous namespace)::SafeThreadFutureToFutureActor<Void> >::a_body1cont3(int) /home/jenkins/fdb/extra/long/path/to/work/around/strange/cpack/debug/rpm/behavior/_build/flow/ThreadHelper.actor.g.h:1060:16 (fdbcli+0x7edb92)
    #28 (anonymous namespace)::SafeThreadFutureToFutureActorState<Void, (anonymous namespace)::SafeThreadFutureToFutureActor<Void> >::a_body1cont2(Void const&, int) /home/jenkins/fdb/extra/long/path/to/work/around/strange/cpack/debug/rpm/behavior/_build/flow/ThreadHelper.actor.g.h:984:15 (fdbcli+0x7edb92)
    #29 (anonymous namespace)::SafeThreadFutureToFutureActorState<Void, (anonymous namespace)::SafeThreadFutureToFutureActor<Void> >::a_body1when1(Void const&, int) /home/jenkins/fdb/extra/long/path/to/work/around/strange/cpack/debug/rpm/behavior/_build/flow/ThreadHelper.actor.g.h:996:15 (fdbcli+0x7edb92)
    #30 (anonymous namespace)::SafeThreadFutureToFutureActorState<Void, (anonymous namespace)::SafeThreadFutureToFutureActor<Void> >::a_callback_fire(ActorCallback<(anonymous namespace)::SafeThreadFutureToFutureActor<Void>, 0, Void>*, Void const&) /home/jenkins/fdb/extra/long/path/to/work/around/strange/cpack/debug/rpm/behavior/_build/flow/ThreadHelper.actor.g.h:1017:4 (fdbcli+0x7ed70d)
    #31 ActorCallback<(anonymous namespace)::SafeThreadFutureToFutureActor<Void>, 0, Void>::fire(Void const&) /home/jenkins/fdb/extra/long/path/to/work/around/strange/cpack/debug/rpm/behavior/_build/../flow/flow.h:1292:34 (fdbcli+0x7ed70d)
    #32 void SAV<Void>::send<Void>(Void&&) /home/jenkins/fdb/extra/long/path/to/work/around/strange/cpack/debug/rpm/behavior/_build/../flow/flow.h:659:23 (fdbcli+0x8361a2)
    #33 void Promise<Void>::send<Void>(Void&&) const /home/jenkins/fdb/extra/long/path/to/work/around/strange/cpack/debug/rpm/behavior/_build/../flow/flow.h:898:8 (fdbcli+0x14dab4e)
    #34 N2::PromiseTask::operator()() /home/jenkins/fdb/extra/long/path/to/work/around/strange/cpack/debug/rpm/behavior/flow/Net2.actor.cpp:1175:11 (fdbcli+0x14dab4e)
    #35 N2::Net2::run() /home/jenkins/fdb/extra/long/path/to/work/around/strange/cpack/debug/rpm/behavior/flow/Net2.actor.cpp:1514:5 (fdbcli+0x14be837)
    #36 runNetwork() /home/jenkins/fdb/extra/long/path/to/work/around/strange/cpack/debug/rpm/behavior/fdbclient/NativeAPI.actor.cpp:2169:13 (fdbcli+0xcfb6b4)
    #37 ThreadSafeApi::runNetwork() /home/jenkins/fdb/extra/long/path/to/work/around/strange/cpack/debug/rpm/behavior/_build/../fdbclient/ThreadSafeTransaction.cpp:462:3 (fdbcli+0x12f86fc)
    #38 MultiVersionApi::runNetwork() /home/jenkins/fdb/extra/long/path/to/work/around/strange/cpack/debug/rpm/behavior/fdbclient/MultiVersionTransaction.actor.cpp:1928:20 (fdbcli+0xc670fd)
    #39 main /home/jenkins/fdb/extra/long/path/to/work/around/strange/cpack/debug/rpm/behavior/fdbcli/fdbcli.actor.cpp:2540:8 (fdbcli+0x7e90f0)
```

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
