### PR TITLE
Track metadata mutations' group version at Resolvers

### DIFF
--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -105,7 +105,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( TLOG_POP_BATCH_SIZE,                                  1000 ); if ( randomize && BUGGIFY ) TLOG_POP_BATCH_SIZE = 10;
 	init( TLOG_SERVER_TEAM_PARTITIONED,                        false );
 	init( TLOG_NEW_INTERFACE,                                  false );
-	init( BROADCAST_TLOG_GROUPS,                                true );
+	init( BROADCAST_TLOG_GROUPS,                                true ); //BROADCAST_TLOG_GROUPS = !PROXY_USE_RESOLVER_PRIVATE_MUTATIONS;
 	init( PTXN_DISABLE_DD,                                     false ); if (TLOG_NEW_INTERFACE) PTXN_DISABLE_DD = true;
 	init( TLOG_POPPED_VER_LAG_THRESHOLD_FOR_TLOGPOP_TRACE,     250e6 );
 	init( ENABLE_DETAILED_TLOG_POP_TRACE,                       true );
@@ -414,7 +414,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( TXN_STATE_SEND_AMOUNT,                                    4 );
 	init( REPORT_TRANSACTION_COST_ESTIMATION_DELAY,               0.1 );
 	init( PROXY_REJECT_BATCH_QUEUED_TOO_LONG,                    true );
-	init( PROXY_USE_RESOLVER_PRIVATE_MUTATIONS,                 false ); if( randomize && BUGGIFY ) PROXY_USE_RESOLVER_PRIVATE_MUTATIONS = deterministicRandom()->coinflip();
+	init( PROXY_USE_RESOLVER_PRIVATE_MUTATIONS,                 false ); PROXY_USE_RESOLVER_PRIVATE_MUTATIONS = TLOG_NEW_INTERFACE || (randomize && BUGGIFY && deterministicRandom()->coinflip());
 
 	init( RESET_MASTER_BATCHES,                                   200 );
 	init( RESET_RESOLVER_BATCHES,                                 200 );

--- a/fdbserver/ApplyMetadataMutation.cpp
+++ b/fdbserver/ApplyMetadataMutation.cpp
@@ -1247,6 +1247,9 @@ public:
 } // anonymous namespace
 
 void ResolverData::initGroupMessageBuilders(Version commitVersion) {
+	if (!SERVER_KNOBS->PROXY_USE_RESOLVER_PRIVATE_MUTATIONS)
+		return;
+
 	const auto& groups = tLogGroupCollection->groups();
 	ASSERT_WE_THINK(toCommit && toCommit->pGroupMessageBuilders->empty());
 	toCommit->addTLogGroups(groups, commitVersion);

--- a/fdbserver/ApplyMetadataMutation.cpp
+++ b/fdbserver/ApplyMetadataMutation.cpp
@@ -109,7 +109,7 @@ public:
 	    confChange(*resolverData_.confChanges), logSystem(resolverData_.logSystem),
 	    popVersion(resolverData_.popVersion), keyInfo(resolverData_.keyInfo), storageCache(resolverData_.storageCache),
 	    tLogGroupCollection(resolverData_.tLogGroupCollection), initialCommit(resolverData_.initialCommit),
-	    forResolver(true), tagToServer(&resolverData_.tagToServer), ssToStorageTeam(&resolverData_.ssToStorageTeam),
+	    forResolver(true), tagToServer(&resolverData_.tagToServer), ssToStorageTeam(resolverData_.ssToStorageTeam),
 	    changedTeams(&resolverData_.changedTeams) {}
 
 private:

--- a/fdbserver/ApplyMetadataMutation.cpp
+++ b/fdbserver/ApplyMetadataMutation.cpp
@@ -1250,6 +1250,9 @@ void ResolverData::initGroupMessageBuilders(Version commitVersion) {
 	if (!SERVER_KNOBS->PROXY_USE_RESOLVER_PRIVATE_MUTATIONS)
 		return;
 
+	// Initialize all groups' serializers, because we don't know which group will have private mutations.
+	// Resolver calls toCommit.getGroupMutations(writtenGroups) later to only
+	// extract private mutations for the writtenGroups, not all groups.
 	const auto& groups = tLogGroupCollection->groups();
 	ASSERT_WE_THINK(toCommit && toCommit->pGroupMessageBuilders->empty());
 	toCommit->addTLogGroups(groups, commitVersion);

--- a/fdbserver/ApplyMetadataMutation.h
+++ b/fdbserver/ApplyMetadataMutation.h
@@ -51,7 +51,7 @@ struct ResolverData {
 	std::map<UID, Reference<StorageInfo>>* storageCache = nullptr;
 	std::unordered_map<UID, StorageServerInterface>* tssMapping = nullptr;
 	std::map<Tag, UID> tagToServer;
-	std::unordered_map<UID, ptxn::StorageTeamID> ssToStorageTeam;
+	std::unordered_map<UID, ptxn::StorageTeamID>* ssToStorageTeam = nullptr;
 	std::unordered_map<UID, std::vector<std::pair<ptxn::StorageTeamID, bool>>> changedTeams;
 	Reference<TLogGroupCollection> tLogGroupCollection;
 
@@ -60,9 +60,10 @@ struct ResolverData {
 	             IKeyValueStore* store,
 	             KeyRangeMap<ServerCacheInfo>* info,
 	             bool* forceRecovery,
-	             Reference<TLogGroupCollection> collection)
+	             Reference<TLogGroupCollection> collection,
+	             std::unordered_map<UID, ptxn::StorageTeamID>* pSsToStorageTeam)
 	  : dbgid(debugId), txnStateStore(store), keyInfo(info), confChanges(forceRecovery), initialCommit(true),
-	    tLogGroupCollection(collection) {}
+	    ssToStorageTeam(pSsToStorageTeam), tLogGroupCollection(collection) {}
 
 	// For transaction batches that contain metadata mutations
 	ResolverData(UID debugId,
@@ -75,10 +76,11 @@ struct ResolverData {
 	             std::map<UID, Reference<StorageInfo>>* storageCache,
 	             std::unordered_map<UID, StorageServerInterface>* tssMapping,
 	             Version commitVersion,
-	             Reference<TLogGroupCollection> collection)
+	             Reference<TLogGroupCollection> collection,
+	             std::unordered_map<UID, ptxn::StorageTeamID>* ssToStorageTeam)
 	  : dbgid(debugId), txnStateStore(store), keyInfo(info), confChanges(forceRecovery), logSystem(logSystem),
 	    toCommit(toCommit), popVersion(popVersion), storageCache(storageCache), tssMapping(tssMapping),
-	    tLogGroupCollection(collection) {
+	    ssToStorageTeam(ssToStorageTeam), tLogGroupCollection(collection) {
 		initGroupMessageBuilders(commitVersion);
 	}
 

--- a/fdbserver/CommitProxyServer.actor.cpp
+++ b/fdbserver/CommitProxyServer.actor.cpp
@@ -2132,14 +2132,13 @@ ACTOR Future<Void> processCompleteTransactionStateRequest(TransactionStateResolv
 		std::vector<std::pair<MapPair<Key, ServerCacheInfo>, int>> keyInfoData;
 		// NOTE: An ACTOR will be compiled into several classes, the this pointer is from one of them.
 		auto updateTagInfo = [this](const std::vector<UID>& uids,
-		                            std::vector<Tag>& tags,
 		                            ServerCacheInfo& info,
 		                            const std::vector<ptxn::StorageTeamID>& srcDstTeams,
 		                            std::vector<Reference<StorageInfo>>& storageInfoItems) {
 			for (const auto& id : uids) {
 				auto storageInfo = getStorageInfo(id, &pContext->pCommitData->storageCache, pContext->pTxnStateStore);
 				ASSERT(storageInfo->tag != invalidTag);
-				tags.push_back(storageInfo->tag);
+				info.tags.push_back(storageInfo->tag);
 				storageInfoItems.push_back(storageInfo);
 
 				if (SERVER_KNOBS->TLOG_NEW_INTERFACE) {
@@ -2177,8 +2176,8 @@ ACTOR Future<Void> processCompleteTransactionStateRequest(TransactionStateResolv
 			ServerCacheInfo info;
 			std::vector<ptxn::StorageTeamID> srcDstTeams = decodeKeyServersValue(tag_uid, kv.value, src, dest);
 
-			updateTagInfo(src, info.tags, info, srcDstTeams, info.src_info);
-			updateTagInfo(dest, info.tags, info, srcDstTeams, info.dest_info);
+			updateTagInfo(src, info, srcDstTeams, info.src_info);
+			updateTagInfo(dest, info, srcDstTeams, info.dest_info);
 			uniquify(info.tags);
 			if (SERVER_KNOBS->TLOG_NEW_INTERFACE) {
 				// A shard can only correspond to single storage team in the primary DC for now

--- a/fdbserver/LogSystem.cpp
+++ b/fdbserver/LogSystem.cpp
@@ -398,11 +398,13 @@ void LogPushData::setGroupMutations(
     const std::map<ptxn::TLogGroupID, std::unordered_map<ptxn::StorageTeamID, StringRef>>& groupMutations,
     Version commitVersion) {
 	for (const auto& [group, teamData] : groupMutations) {
-		if (pGroupMessageBuilders->count(group) == 0) {
-			pGroupMessageBuilders->emplace(group,
-			                               std::make_shared<ptxn::ProxySubsequencedMessageSerializer>(commitVersion));
+		auto it = pGroupMessageBuilders->find(group);
+		if (it == pGroupMessageBuilders->end()) {
+			it = pGroupMessageBuilders
+			         ->emplace(group, std::make_shared<ptxn::ProxySubsequencedMessageSerializer>(commitVersion))
+			         .first;
 		}
-		auto& writer = (*pGroupMessageBuilders)[group];
+		auto& writer = it->second;
 		for (const auto& [team, mutations] : teamData) {
 			ptxn::SubsequencedMessageDeserializer deserializer(mutations);
 			for (const auto& item : deserializer) {

--- a/fdbserver/LogSystem.cpp
+++ b/fdbserver/LogSystem.cpp
@@ -395,7 +395,8 @@ std::map<ptxn::TLogGroupID, ptxn::SerializedTeamData> LogPushData::getGroupMutat
 // It would be nice that ProxySubsequencedMessageSerializer can be set with
 // serialized data.
 void LogPushData::setGroupMutations(
-    const std::map<ptxn::TLogGroupID, std::unordered_map<ptxn::StorageTeamID, StringRef>>& groupMutations, Version commitVersion) {
+    const std::map<ptxn::TLogGroupID, std::unordered_map<ptxn::StorageTeamID, StringRef>>& groupMutations,
+    Version commitVersion) {
 	for (const auto& [group, teamData] : groupMutations) {
 		if (pGroupMessageBuilders->count(group) == 0) {
 			pGroupMessageBuilders->emplace(group,

--- a/fdbserver/LogSystem.cpp
+++ b/fdbserver/LogSystem.cpp
@@ -381,9 +381,9 @@ void LogPushData::addTLogGroups(const std::vector<TLogGroupRef>& groups, Version
 	}
 }
 
-std::map<ptxn::TLogGroupID, ptxn::SerializedTeamData> LogPushData::getGroupMutations(
+std::unordered_map<ptxn::TLogGroupID, ptxn::SerializedTeamData> LogPushData::getGroupMutations(
     const std::set<ptxn::TLogGroupID>& groups) {
-	std::map<ptxn::TLogGroupID, ptxn::SerializedTeamData> results;
+	std::unordered_map<ptxn::TLogGroupID, ptxn::SerializedTeamData> results;
 	for (const auto& [group, serializer] : *pGroupMessageBuilders) {
 		auto teamData = serializer->getAllSerialized();
 		results.emplace(group, teamData);

--- a/fdbserver/LogSystem.cpp
+++ b/fdbserver/LogSystem.cpp
@@ -369,6 +369,13 @@ bool LogPushData::writeTransactionInfo(int location, uint32_t subseq) {
 	return true;
 }
 
+void LogPushData::addTLogGroups(const std::vector<TLogGroupRef>& groups, Version commitVersion) {
+	for (const auto& group : groups) {
+		pGroupMessageBuilders->emplace(group->id(),
+		                               std::make_shared<ptxn::ProxySubsequencedMessageSerializer>(commitVersion));
+	}
+}
+
 #ifndef __INTEL_COMPILER
 #pragma endregion
 #endif

--- a/fdbserver/LogSystem.h
+++ b/fdbserver/LogSystem.h
@@ -782,7 +782,6 @@ struct LogPushData : NonCopyable {
 	void writeToStorageTeams(TLogGroupCollectionRef tLogGroupCollection,
 	                         const std::set<ptxn::StorageTeamID>& storageTeams,
 	                         T m) {
-		TraceEvent("GroupMessageBuilder").detail("Size", pGroupMessageBuilders->size());
 		for (const auto& team : storageTeams) {
 			auto groupID = tLogGroupCollection->assignStorageTeam(team)->id();
 			ASSERT(pGroupMessageBuilders->count(groupID));

--- a/fdbserver/LogSystem.h
+++ b/fdbserver/LogSystem.h
@@ -827,7 +827,8 @@ struct LogPushData : NonCopyable {
 	void setMutations(uint32_t totalMutations, VectorRef<StringRef> mutations);
 
 	// Returns messages for specified groups
-	std::map<ptxn::TLogGroupID, ptxn::SerializedTeamData> getGroupMutations(const std::set<ptxn::TLogGroupID>& groups);
+	std::unordered_map<ptxn::TLogGroupID, ptxn::SerializedTeamData> getGroupMutations(
+	    const std::set<ptxn::TLogGroupID>& groups);
 
 	// Sets mutations for internal group writers. "groupMutations" is the output from
 	// getGroupMutations() and is used before writing any other mutations.

--- a/fdbserver/LogSystem.h
+++ b/fdbserver/LogSystem.h
@@ -852,7 +852,7 @@ private:
 	SpanID spanContext;
 	// Stores TLog groups updated by the transactions.
 	std::set<ptxn::TLogGroupID> writtenTLogGroups;
-	bool shardChanged; // if keyServers has any changes, i.e., shard boundary modifications.
+	bool shardChanged = false; // if keyServers has any changes, i.e., shard boundary modifications.
 
 	// Writes transaction info to the message stream at the given location if
 	// it has not already been written (for the current transaction). Returns

--- a/fdbserver/LogSystem.h
+++ b/fdbserver/LogSystem.h
@@ -754,10 +754,7 @@ struct CompareFirst {
 // uniquely identified by its first byte -- a value from MutationRef::Type.
 //
 struct LogPushData : NonCopyable {
-	// Log subsequences have to start at 1 (the MergedPeekCursor relies on this to make sure we never have !hasMessage()
-	// in the middle of data for a version
-
-	explicit LogPushData(Reference<ILogSystem> logSystem) : logSystem(logSystem), subsequence(1) {
+	explicit LogPushData(Reference<ILogSystem> logSystem) : logSystem(logSystem) {
 		for (auto& log : logSystem->getLogSystemConfig().tLogs) {
 			if (log.isLocal) {
 				for (int i = 0; i < log.tLogs.size(); i++) {
@@ -786,12 +783,19 @@ struct LogPushData : NonCopyable {
 	void writeToStorageTeams(TLogGroupCollectionRef tLogGroupCollection,
 	                         const std::set<ptxn::StorageTeamID>& storageTeams,
 	                         T m) {
+		TraceEvent("GroupMessageBuilder").detail("Size", pGroupMessageBuilders->size());
 		for (const auto& team : storageTeams) {
 			auto groupID = tLogGroupCollection->assignStorageTeam(team)->id();
 			ASSERT(pGroupMessageBuilders->count(groupID));
 			(*pGroupMessageBuilders)[groupID]->write(m, team);
+			writtenTLogGroups.insert(groupID);
 		}
 	}
+
+	const std::set<ptxn::TLogGroupID>& getWrittenTLogGroups() const { return writtenTLogGroups; }
+
+	void setShardChanged() { shardChanged = true; }
+	bool isShardChanged() const { return shardChanged; }
 
 	void writeMessage(StringRef rawMessageWithoutLength, bool usePreviousLocations);
 
@@ -812,7 +816,10 @@ struct LogPushData : NonCopyable {
 	float getEmptyMessageRatio() const;
 
 	std::unordered_map<ptxn::TLogGroupID, std::shared_ptr<ptxn::ProxySubsequencedMessageSerializer>>*
-	    pGroupMessageBuilders;
+	    pGroupMessageBuilders = nullptr;
+
+	// Add TLog groups to initialize "pGroupMessageBuilders".
+	void addTLogGroups(const std::vector<TLogGroupRef>& groups, Version commitVersion);
 
 	// Returns the total number of mutations.
 	uint32_t getMutationCount() const { return subsequence; }
@@ -832,8 +839,13 @@ private:
 	// for the current transaction. Adding transaction info will reset this
 	// field.
 	std::unordered_set<int> writtenLocations;
-	uint32_t subsequence;
+	// Log subsequences have to start at 1 (the MergedPeekCursor relies on this to make sure we never have !hasMessage()
+	// in the middle of data for a version
+	uint32_t subsequence = 1;
 	SpanID spanContext;
+	// Stores TLog groups updated by the transactions.
+	std::set<ptxn::TLogGroupID> writtenTLogGroups;
+	bool shardChanged; // if keyServers has any changes, i.e., shard boundary modifications.
 
 	// Writes transaction info to the message stream at the given location if
 	// it has not already been written (for the current transaction). Returns

--- a/fdbserver/LogSystem.h
+++ b/fdbserver/LogSystem.h
@@ -35,7 +35,6 @@
 #include "fdbserver/ptxn/MessageSerializer.h"
 #include "fdbserver/SpanContextMessage.h"
 #include "fdbserver/TLogGroup.actor.h"
-#include "fdbserver/TLogGroup.actor.h"
 #include "fdbserver/TLogInterface.h"
 #include "fdbserver/WorkerInterface.actor.h"
 #include "flow/Arena.h"
@@ -827,6 +826,15 @@ struct LogPushData : NonCopyable {
 	// Sets mutations for all internal writers. "mutations" is the output from
 	// getAllMessages() and is used before writing any other mutations.
 	void setMutations(uint32_t totalMutations, VectorRef<StringRef> mutations);
+
+	// Returns messages for specified groups
+	std::map<ptxn::TLogGroupID, ptxn::SerializedTeamData> getGroupMutations(const std::set<ptxn::TLogGroupID>& groups);
+
+	// Sets mutations for internal group writers. "groupMutations" is the output from
+	// getGroupMutations() and is used before writing any other mutations.
+	void setGroupMutations(
+	    const std::map<ptxn::TLogGroupID, std::unordered_map<ptxn::StorageTeamID, StringRef>>& groupMutations,
+	    Version commitVersion);
 
 private:
 	Reference<ILogSystem> logSystem;

--- a/fdbserver/Resolver.actor.cpp
+++ b/fdbserver/Resolver.actor.cpp
@@ -55,7 +55,10 @@ struct Resolver : ReferenceCounted<Resolver> {
 	const int commitProxyCount, resolverCount;
 	NotifiedVersion version;
 	AsyncVar<Version> neededVersion;
-	ptxn::TLogGroupVersionTracker versionTracker; // tracks per group commit version
+	// Tracks per group commit version. It is initialized by the master, which
+	// sends all TLogGroup info to all resolvers during initialization, i.e., the
+	// very first ResolveTransactionBatchRequest.
+	ptxn::TLogGroupVersionTracker versionTracker;
 
 	Map<Version, Standalone<VectorRef<StateTransactionRef>>> recentStateTransactions;
 	Deque<std::pair<Version, int64_t>> recentStateTransactionSizes;

--- a/fdbserver/Resolver.actor.cpp
+++ b/fdbserver/Resolver.actor.cpp
@@ -77,7 +77,7 @@ struct Resolver : ReferenceCounted<Resolver> {
 	std::unordered_map<UID, StorageServerInterface> tssMapping;
 	bool forceRecovery = false;
 
-	Reference<TLogGroupCollection> tLogGroupCollection;
+	Reference<TLogGroupCollection> tLogGroupCollection = Reference<TLogGroupCollection>(nullptr);
 	// Each storage server's own team.
 	std::unordered_map<UID, ptxn::StorageTeamID> ssToStorageTeam;
 

--- a/fdbserver/ResolverInterface.h
+++ b/fdbserver/ResolverInterface.h
@@ -102,6 +102,9 @@ struct ResolveTransactionBatchReply {
 	// Each group's previous commit version
 	std::map<ptxn::TLogGroupID, Version> previousCommitVersions;
 
+	// Each group's private mutations, serialized by ProxySubsequencedMessageSerializer
+	std::map<ptxn::TLogGroupID, std::unordered_map<ptxn::StorageTeamID, StringRef>> groupPrivateMutations;
+
 	// Privatized mutations with tags, one for each TLog location
 	VectorRef<StringRef> privateMutations;
 	uint32_t privateMutationCount;
@@ -114,6 +117,7 @@ struct ResolveTransactionBatchReply {
 		           debugID,
 		           conflictingKeyRangeMap,
 		           previousCommitVersions,
+		           groupPrivateMutations,
 		           privateMutations,
 		           privateMutationCount,
 		           arena);

--- a/fdbserver/ptxn/MessageSerializer.cpp
+++ b/fdbserver/ptxn/MessageSerializer.cpp
@@ -203,6 +203,12 @@ void ProxySubsequencedMessageSerializer::broadcastSpanContext(const SpanContextM
 	storageTeamInjectedSpanContext.clear();
 }
 
+void ProxySubsequencedMessageSerializer::writeTeamSpanContext(const SpanContextMessage& spanContext,
+                                                              const StorageTeamID& team) {
+	prepareWriteMessage(team);
+	serializers.at(team).write(SubsequenceSpanContextItem{ subsequence++, spanContext });
+}
+
 void ProxySubsequencedMessageSerializer::write(const MutationRef& mutation, const StorageTeamID& storageTeamID) {
 	prepareWriteMessage(storageTeamID);
 	serializers.at(storageTeamID).write(subsequence++, mutation);

--- a/fdbserver/ptxn/MessageSerializer.h
+++ b/fdbserver/ptxn/MessageSerializer.h
@@ -18,9 +18,11 @@
  * limitations under the License.
  */
 
-#ifndef FDBSERVER_PTXN_TLOGSTORAGESERVERPEEKMESSAGESERIALIZER_H
-#define FDBSERVER_PTXN_TLOGSTORAGESERVERPEEKMESSAGESERIALIZER_H
+#ifndef FDBSERVER_PTXN_MESSAGESERIALIZER_H
+#define FDBSERVER_PTXN_MESSAGESERIALIZER_H
 
+#include "fdbclient/FDBTypes.h"
+#include "fdbserver/SpanContextMessage.h"
 #pragma once
 
 #include <cstdint>
@@ -34,6 +36,7 @@
 
 namespace ptxn {
 
+using SerializedTeamData = std::pair<Arena, std::unordered_map<StorageTeamID, StringRef>>;
 const SerializationProtocolVersion MessageSerializationProtocolVersion = 1;
 
 namespace details {
@@ -259,6 +262,9 @@ public:
 	// write will always prepend this SpanContextMessage before the mutation.
 	void broadcastSpanContext(const SpanContextMessage&);
 
+	// Writes a SpanContextMessage for the specified team.
+	void writeTeamSpanContext(const SpanContextMessage&, const StorageTeamID&);
+
 	// Writes a mutation to a given stoarge team.
 	void write(const MutationRef&, const StorageTeamID&);
 
@@ -281,8 +287,8 @@ public:
 	// Get serialized data for a given storage team ID
 	Standalone<StringRef> getSerialized(const StorageTeamID& storageTeamID);
 
-	// Get all serialized data
-	std::pair<Arena, std::unordered_map<StorageTeamID, StringRef>> getAllSerialized();
+	// Returns all teams' serialized data
+	SerializedTeamData getAllSerialized();
 };
 
 template <typename T>
@@ -398,4 +404,4 @@ public:
 
 } // namespace ptxn
 
-#endif // FDBSERVER_PTXN_TLOGSTORAGESERVERPEEKMESSAGESERIALIZER_H
+#endif // FDBSERVER_PTXN_MESSAGESERIALIZER_H

--- a/fdbserver/ptxn/TLogGroupVersionTracker.h
+++ b/fdbserver/ptxn/TLogGroupVersionTracker.h
@@ -27,6 +27,9 @@
 #include <vector>
 
 #include "fdbclient/FDBTypes.h"
+#include "flow/BooleanParam.h"
+
+FDB_DECLARE_BOOLEAN_PARAM(UpdateAllGroups);
 
 namespace ptxn {
 
@@ -46,7 +49,15 @@ public:
 	void removeGroups(const std::vector<TLogGroupID>& groups);
 
 	// Updates "groups" with new commitVersion. Returns each group's PCV in a map.
-	std::map<TLogGroupID, Version> updateGroups(const std::vector<TLogGroupID>& groups, Version commitVersion);
+	// Whenever shard boundary changes, we need to return all groups in the results,
+	// i.e., the commit proxy needs to broadcast to all TLog groups so that the Resolver
+	// may correctly track commit versions of TLog groups.
+	std::map<TLogGroupID, Version> updateGroups(const std::vector<TLogGroupID>& groups,
+	                                            Version commitVersion,
+	                                            UpdateAllGroups returnAllGroups);
+	std::map<TLogGroupID, Version> updateGroups(const std::set<TLogGroupID>& groups,
+	                                            Version commitVersion,
+	                                            UpdateAllGroups returnAllGroups);
 
 	// Returns the most lagging group and its CV.
 	std::pair<TLogGroupID, Version> mostLaggingGroup() const;

--- a/fdbserver/ptxn/TLogServer.actor.cpp
+++ b/fdbserver/ptxn/TLogServer.actor.cpp
@@ -509,8 +509,7 @@ struct LogGenerationData : NonCopyable, public ReferenceCounted<LogGenerationDat
 		  : storageTeamId(r.storageTeamId), tags(r.tags), versionMessages(std::move(r.versionMessages)),
 		    nothingPersistent(r.nothingPersistent), poppedRecently(r.poppedRecently), popped(r.popped),
 		    persistentPopped(r.persistentPopped), versionForPoppedLocation(r.versionForPoppedLocation),
-		    poppedLocation(r.poppedLocation),
-		    unpoppedRecovered(r.unpoppedRecovered) {}
+		    poppedLocation(r.poppedLocation), unpoppedRecovered(r.unpoppedRecovered) {}
 		void operator=(StorageTeamData&& r) noexcept {
 			storageTeamId = r.storageTeamId;
 			nothingPersistent = r.nothingPersistent;

--- a/fdbserver/ptxn/test/TestResolver.actor.cpp
+++ b/fdbserver/ptxn/test/TestResolver.actor.cpp
@@ -102,7 +102,7 @@ bool trackerTest() {
 		removedGroups.emplace_back(0, totalGroups - i - 1);
 	}
 	const Version cv1 = 200, cv2 = 200;
-	tracker.updateGroups(updatedGroups, cv1);
+	tracker.updateGroups(updatedGroups, cv1, UpdateAllGroups::False);
 	tracker.addGroups(newGroups, cv2);
 	tracker.removeGroups(removedGroups);
 


### PR DESCRIPTION
When private mutations are generated at Resolvers, accumulate them and assign them to corresponding TLog groups for version tracking. However, if any shard change is detected, the transaction batch has to switch back to broadcast.

The version tracker at Resolvers now accounts both groups from commit proxies and TLog groups for private mutations. Use "LogPushData" to accumulate private mutations.

The serialized private mutations are sent for each TLog group. After receiving them, the commit proxy deserializes all mutations and then writes to its internal buffer, before processing the rest of transaction data.

## Testing

One unit test failure is unrelated (`-f ./tests/fast/RandomUnitTests.toml -s 755382714 -b on`, unit test `/fdbserver/ConfigDB/TransactionToLocalConfig/KillWorker`):
20211118-181600-jzhou-211ee172628a63d5             compressed=True data_size=21691898 duration=4824321 ended=100000 fail=1 fail_fast=10 max_runs=100000 pass=99999 priority=100 remaining=0 runtime=1:09:20 sanity=False started=100501 stopped=20211118-192520 submitted=20211118-181600 timeout=5400 username=jzhou

PTXN test passed (with/without proxy-to-tlog group broadcast):

-r simulation --crash --logsize 1024MB --knob_tlog_new_interface 1 -fi off -f src/foundationdb/tests/ptxn/CycleTest.toml -b off -s 101

-r simulation --crash --logsize 1024MB --knob_tlog_new_interface 1 -fi off -f src/foundationdb/tests/ptxn/CycleTest.toml -b off -s 101 --knob_broadcast_tlog_groups 0

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
