### PR TITLE
Don't adduser in client postinstall (release-7.0)

### DIFF
--- a/packaging/multiversion/clients/postinst
+++ b/packaging/multiversion/clients/postinst
@@ -12,9 +12,6 @@ then
     mkdir ${PKG_CONFIG_DIR}
 fi
 
-getent group foundationdb >/dev/null || addgroup --system foundationdb
-getent passwd foundationdb >/dev/null || adduser --system --disabled-login --ingroup foundationdb --no-create-home --home /var/lib/foundationdb --gecos "FoundationDB" --shell /bin/false foundationdb
-
 mkdir -p /usr/lib/foundationdb/backup_agent
 
 update-alternatives --install /usr/bin/fdbcli fdbclients /usr/lib/foundationdb-@PROJECT_VERSION@/bin/fdbcli @ALTERNATIVES_PRIORITY@ \


### PR DESCRIPTION
Cherry pick https://github.com/apple/foundationdb/pull/6020 to release-7.0



This isn't necessary, and causes spurious error messages on centos.

Tested with pkg_tester

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
