### PR TITLE
Replace <boost/bind.hpp> with <boost/bind/bind.hpp> (release-7.0).

### DIFF
--- a/fdbclient/json_spirit/json_spirit_reader_template.h
+++ b/fdbclient/json_spirit/json_spirit_reader_template.h
@@ -15,7 +15,7 @@
 
 //#define BOOST_SPIRIT_THREADSAFE  // uncomment for multithreaded use, requires linking to boost.thread
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/function.hpp>
 #include <boost/version.hpp>
 
@@ -366,18 +366,25 @@ public:
 			typedef boost::function<void(boost::int64_t)> Int_action;
 			typedef boost::function<void(boost::uint64_t)> Uint64_action;
 
-			Char_action begin_obj(boost::bind(&Semantic_actions_t::begin_obj, &self.actions_, _1));
-			Char_action end_obj(boost::bind(&Semantic_actions_t::end_obj, &self.actions_, _1));
-			Char_action begin_array(boost::bind(&Semantic_actions_t::begin_array, &self.actions_, _1));
-			Char_action end_array(boost::bind(&Semantic_actions_t::end_array, &self.actions_, _1));
-			Str_action new_name(boost::bind(&Semantic_actions_t::new_name, &self.actions_, _1, _2));
-			Str_action new_str(boost::bind(&Semantic_actions_t::new_str, &self.actions_, _1, _2));
-			Str_action new_true(boost::bind(&Semantic_actions_t::new_true, &self.actions_, _1, _2));
-			Str_action new_false(boost::bind(&Semantic_actions_t::new_false, &self.actions_, _1, _2));
-			Str_action new_null(boost::bind(&Semantic_actions_t::new_null, &self.actions_, _1, _2));
-			Real_action new_real(boost::bind(&Semantic_actions_t::new_real, &self.actions_, _1));
-			Int_action new_int(boost::bind(&Semantic_actions_t::new_int, &self.actions_, _1));
-			Uint64_action new_uint64(boost::bind(&Semantic_actions_t::new_uint64, &self.actions_, _1));
+			Char_action begin_obj(boost::bind(&Semantic_actions_t::begin_obj, &self.actions_, boost::placeholders::_1));
+			Char_action end_obj(boost::bind(&Semantic_actions_t::end_obj, &self.actions_, boost::placeholders::_1));
+			Char_action begin_array(
+			    boost::bind(&Semantic_actions_t::begin_array, &self.actions_, boost::placeholders::_1));
+			Char_action end_array(boost::bind(&Semantic_actions_t::end_array, &self.actions_, boost::placeholders::_1));
+			Str_action new_name(boost::bind(
+			    &Semantic_actions_t::new_name, &self.actions_, boost::placeholders::_1, boost::placeholders::_2));
+			Str_action new_str(boost::bind(
+			    &Semantic_actions_t::new_str, &self.actions_, boost::placeholders::_1, boost::placeholders::_2));
+			Str_action new_true(boost::bind(
+			    &Semantic_actions_t::new_true, &self.actions_, boost::placeholders::_1, boost::placeholders::_2));
+			Str_action new_false(boost::bind(
+			    &Semantic_actions_t::new_false, &self.actions_, boost::placeholders::_1, boost::placeholders::_2));
+			Str_action new_null(boost::bind(
+			    &Semantic_actions_t::new_null, &self.actions_, boost::placeholders::_1, boost::placeholders::_2));
+			Real_action new_real(boost::bind(&Semantic_actions_t::new_real, &self.actions_, boost::placeholders::_1));
+			Int_action new_int(boost::bind(&Semantic_actions_t::new_int, &self.actions_, boost::placeholders::_1));
+			Uint64_action new_uint64(
+			    boost::bind(&Semantic_actions_t::new_uint64, &self.actions_, boost::placeholders::_1));
 
 			// actual grammer
 

--- a/fdbrpc/Net2FileSystem.cpp
+++ b/fdbrpc/Net2FileSystem.cpp
@@ -26,7 +26,6 @@
 #define BOOST_DATE_TIME_NO_LIB
 #define BOOST_REGEX_NO_LIB
 #include <boost/asio.hpp>
-#include <boost/bind.hpp>
 
 #define FILESYSTEM_IMPL 1
 

--- a/flow/AsioReactor.h
+++ b/flow/AsioReactor.h
@@ -23,7 +23,7 @@
 #pragma once
 
 #include <boost/asio.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 #include "flow/flow.h"
 

--- a/flow/Net2.actor.cpp
+++ b/flow/Net2.actor.cpp
@@ -29,7 +29,6 @@
 #define BOOST_DATE_TIME_NO_LIB
 #define BOOST_REGEX_NO_LIB
 #include <boost/asio.hpp>
-#include <boost/bind.hpp>
 #include <boost/date_time/posix_time/posix_time_types.hpp>
 #include <boost/range.hpp>
 #include <boost/algorithm/string/join.hpp>


### PR DESCRIPTION
Backporting #6023.
This eliminates many useless warnings when compiling.
`#pragma message: The practice of declaring the Bind placeholders (_1, _2, ...) in the global namespace is deprecated. Please use <boost/bind/bind.hpp> + using namespace boost::placeholders, or define BOOST_BIND_GLOBAL_PLACEHOLDERS to retain the current behavior.`

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
