### PR TITLE
docs: Clarify that `"ERROR"` is a byte string

### DIFF
--- a/bindings/bindingtester/spec/bindingApiTester.md
+++ b/bindings/bindingtester/spec/bindingApiTester.md
@@ -117,8 +117,8 @@ should simulate it using an anonymous transaction. Remember that set and clear
 operations must immediately commit (with appropriate retry behavior!).
 
 Any error that bubbles out of these operations must be caught. In the event of
-an error, you must push the packed tuple of the string `"ERROR"` and the error
-code (as a string, not an integer).
+an error, you must push the packed tuple of the byte string `"ERROR"` and the
+error code (as a byte string, not an integer).
 
 Some operations may allow you to push future values onto the stack. When popping
 objects from the stack, the future MUST BE waited on and errors caught before


### PR DESCRIPTION
`string` can be ambiguous as `Tuple` layer supports both `byte string`
and unicode `string`.

Further links to relevant part of [Go](https://github.com/apple/foundationdb/blob/22e34bd6b93bd556539219414aff5235069fa37d/bindings/go/src/_stacktester/stacktester.go#L97) and [Java](https://github.com/apple/foundationdb/blob/22e34bd6b93bd556539219414aff5235069fa37d/bindings/java/src/test/com/apple/foundationdb/test/StackUtils.java#L42-L44) code.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
