### PR TITLE
Single TLog can recover from disks

### DIFF
--- a/fdbserver/ptxn/test/Driver.h
+++ b/fdbserver/ptxn/test/Driver.h
@@ -100,6 +100,7 @@ struct TestDriverContext {
 	std::vector<TLogGroup> tLogGroups;
 	std::vector<std::vector<ptxn::TLogGroup>> groupsPerTLog;
 	std::unordered_map<TLogGroupID, std::shared_ptr<TLogInterfaceBase>> tLogGroupLeaders;
+	std::unordered_map<ptxn::TLogGroupID, int> groupToLeaderId;
 	std::unordered_map<TLogGroupID, Version> tLogGroupVersion;
 	std::vector<std::shared_ptr<TLogInterfaceBase>> tLogInterfaces;
 	std::unordered_map<StorageTeamID, TLogGroupID> storageTeamIDTLogGroupIDMapper;

--- a/fdbserver/worker.actor.cpp
+++ b/fdbserver/worker.actor.cpp
@@ -1428,7 +1428,6 @@ ACTOR Future<Void> workerServer(Reference<ClusterConnectionFile> connFile,
 				auto& logData = sharedLogs[SharedLogsKey(s.tLogOptions, s.storeType)];
 				// FIXME: Shouldn't if logData.first isValid && !isReady, shouldn't we
 				// be sending a fake InitializeTLogRequest rather than calling tLog() ?
-				// here is where recovery happens
 				Future<Void> tl =
 				    tLogFn(persistentDataAndQueues,
 				           dbInfo,

--- a/fdbserver/worker.actor.cpp
+++ b/fdbserver/worker.actor.cpp
@@ -1428,6 +1428,7 @@ ACTOR Future<Void> workerServer(Reference<ClusterConnectionFile> connFile,
 				auto& logData = sharedLogs[SharedLogsKey(s.tLogOptions, s.storeType)];
 				// FIXME: Shouldn't if logData.first isValid && !isReady, shouldn't we
 				// be sending a fake InitializeTLogRequest rather than calling tLog() ?
+				// here is where recovery happens
 				Future<Void> tl =
 				    tLogFn(persistentDataAndQueues,
 				           dbInfo,

--- a/tests/ptxn/TLogServer.toml
+++ b/tests/ptxn/TLogServer.toml
@@ -111,3 +111,18 @@ startDelay = 0
     numTLogs = 3
     numStorageTeams = 40
     numTLogGroups = 7
+
+[[test]]
+testTitle = 'Team Partitioned TLog Server Test 8: Single tlog recovers'
+useDB = false
+startDelay = 0
+
+    [[test.workload]]
+    testName = 'UnitTests'
+    maxTestCases = 1
+    testsMatching = '/fdbserver/ptxn/test/single_tlog_recovery'
+    
+    numTLogs = 3
+    numStorageTeams = 40
+    numTLogGroups = 3
+    numCommits = 5


### PR DESCRIPTION
    Single TLog can recover from disks
    
    This PR makes it possible for single TLog server to recover from disk.
    It assumes tlog was serving the same set of groups before the recovery,
    which is not ideal. It can be fixed by persisting TLog groups metadata
    onto TLog disk and only recover groups who sit in the overlap
    of (old_from_disk, new_from_request).
    
    Each interface serves a certain epoch that might include multiple groups,
    but recovery must happen per group because data is stored per group.
    
    Thus the recovery process is:
    1. recover each group from disk
    2. aggregate by epoch and group in TLogServer level
    3. sstart previous and current epoch if necessary


joshua: 20211207-223418-haofu-4686b6c3973227dc
# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
