### PR TITLE
New ycsb launcher

### DIFF
--- a/packaging/docker/run_ycsb.sh
+++ b/packaging/docker/run_ycsb.sh
@@ -2,12 +2,22 @@
 set -Eeuo pipefail
 
 namespace=$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace)
-
-echo "WAITING FOR ALL PODS TO COME UP"
-while [[ $(kubectl get pods -n ${namespace} -l name=ycsb,run=${RUN_ID} --field-selector=status.phase=Running | grep -cv NAME) -lt ${NUM_PODS} ]]; do
-    sleep 0.1
-done
-echo "ALL PODS ARE UP"
+POD_NUM=$(echo $POD_NAME | cut -d - -f3)
+KEY="ycsb_load_${POD_NUM}_of_${NUM_PODS}_complete"
+CLI=$(ls /var/dynamic-conf/bin/*/fdbcli | head -n1)
+if [ ${MODE} != "load" ]; then
+    echo "WAITING FOR ALL PODS TO COME UP"
+    while [[ $(kubectl get pods -n ${namespace} -l name=ycsb,run=${RUN_ID} --field-selector=status.phase=Running | grep -cv NAME) -lt ${NUM_PODS} ]]; do
+        sleep 0.1
+    done
+    echo "ALL PODS ARE UP"
+else
+    if ${CLI} --exec "get ${KEY}" | grep is ;
+    then
+        # load already completed
+        exit 0
+    fi
+fi;
 
 echo "RUNNING YCSB"
 ./bin/ycsb.sh ${MODE} foundationdb -s -P workloads/${WORKLOAD} ${YCSB_ARGS}
@@ -16,3 +26,8 @@ echo "YCSB FINISHED"
 echo "COPYING HISTOGRAMS TO S3"
 aws s3 sync --sse aws:kms --exclude "*" --include "histogram.*" /tmp s3://${BUCKET}/ycsb_histograms/${namespace}/${POD_NAME}
 echo "COPYING HISTOGRAMS TO S3 FINISHED"
+
+if [ ${MODE} == "load" ]; then
+    ${CLI} --exec "writemode on; set ${KEY} 1"
+    echo "WROTE LOAD COMPLETION KEY"
+fi


### PR DESCRIPTION
This updates the YCSB launcher so that load will succeed even if the thing monitoring its progress fails.  It also adds support for building YCSB from checked out source (the build defaults to the old behavior).

The launcher script changes break compatibility with existing fdb-kubernetes-tests (since they require fdbcli to be injected into the YCSB container at runtime; currently it is not).  A companion PR for that repo should be merged before this one (will send link out-of-band).

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
