### PR TITLE
Override commit/grv proxies_count if mutation supplied new value is -1 (cherry-pick)

### DIFF
--- a/fdbclient/DatabaseConfiguration.cpp
+++ b/fdbclient/DatabaseConfiguration.cpp
@@ -20,6 +20,9 @@
 
 #include "fdbclient/DatabaseConfiguration.h"
 #include "fdbclient/SystemData.h"
+#include "flow/ITrace.h"
+#include "flow/Trace.h"
+#include "flow/genericactors.actor.h"
 
 DatabaseConfiguration::DatabaseConfiguration() {
 	resetInternal();
@@ -46,6 +49,10 @@ void DatabaseConfiguration::resetInternal() {
 	backupWorkerEnabled = false;
 	perpetualStorageWiggleSpeed = 0;
 	storageMigrationType = StorageMigrationType::DEFAULT;
+}
+
+int toInt(ValueRef const& v) {
+	return atoi(v.toString().c_str());
 }
 
 void parse(int* i, ValueRef const& v) {
@@ -463,6 +470,64 @@ std::string DatabaseConfiguration::toString() const {
 	return json_spirit::write_string(json_spirit::mValue(toJSON()), json_spirit::Output_options::none);
 }
 
+Key getKeyWithPrefix(std::string const& k) {
+	return StringRef(k).withPrefix(configKeysPrefix);
+}
+
+void DatabaseConfiguration::overwriteProxiesCount() {
+	Key commitProxiesKey = getKeyWithPrefix("commit_proxies");
+	Key grvProxiesKey = getKeyWithPrefix("grv_proxies");
+	Key proxiesKey = getKeyWithPrefix("proxies");
+	Optional<ValueRef> optCommitProxies = DatabaseConfiguration::get(commitProxiesKey);
+	Optional<ValueRef> optGrvProxies = DatabaseConfiguration::get(grvProxiesKey);
+	Optional<ValueRef> optProxies = DatabaseConfiguration::get(proxiesKey);
+
+	const int mutableGrvProxyCount = optGrvProxies.present() ? toInt(optGrvProxies.get()) : 0;
+	const int mutableCommitProxyCount = optCommitProxies.present() ? toInt(optCommitProxies.get()) : 0;
+	const int mutableProxiesCount = optProxies.present() ? toInt(optProxies.get()) : 0;
+
+	if (mutableProxiesCount > 1) {
+		TraceEvent(SevDebug, "OverwriteProxiesCount")
+		    .detail("CPCount", commitProxyCount)
+		    .detail("MutableCPCount", mutableCommitProxyCount)
+		    .detail("GrvCount", grvProxyCount)
+		    .detail("MutableGrvCPCount", mutableGrvProxyCount)
+		    .detail("MutableProxiesCount", mutableProxiesCount);
+
+		if (grvProxyCount == -1 && commitProxyCount > 0) {
+			if (mutableProxiesCount > commitProxyCount) {
+				grvProxyCount = mutableProxiesCount - commitProxyCount;
+			} else {
+				// invalid configuration; provision min GrvProxies
+				grvProxyCount = 1;
+				commitProxyCount = mutableProxiesCount - 1;
+			}
+		} else if (grvProxyCount > 0 && commitProxyCount == -1) {
+			if (mutableProxiesCount > grvProxyCount) {
+				commitProxyCount = mutableProxiesCount - grvProxyCount;
+			} else {
+				// invalid configuration; provision min CommitProxies
+				commitProxyCount = 1;
+				grvProxyCount = mutableProxiesCount - 1;
+			}
+		} else if (grvProxyCount == -1 && commitProxyCount == -1) {
+			// Use DEFAULT_COMMIT_GRV_PROXIES_RATIO to split proxies between Grv & Commit proxies
+			const int derivedGrvProxyCount =
+			    std::max(1,
+			             std::min(CLIENT_KNOBS->DEFAULT_MAX_GRV_PROXIES,
+			                      mutableProxiesCount / (CLIENT_KNOBS->DEFAULT_COMMIT_GRV_PROXIES_RATIO + 1)));
+
+			grvProxyCount = derivedGrvProxyCount;
+			commitProxyCount = mutableProxiesCount - grvProxyCount;
+		}
+
+		TraceEvent(SevDebug, "OverwriteProxiesCountResult")
+		    .detail("CommitProxyCount", commitProxyCount)
+		    .detail("GrvProxyCount", grvProxyCount)
+		    .detail("ProxyCount", mutableProxiesCount);
+	}
+}
+
 bool DatabaseConfiguration::setInternal(KeyRef key, ValueRef value) {
 	KeyRef ck = key.removePrefix(configKeysPrefix);
 	int type;
@@ -470,9 +535,13 @@ bool DatabaseConfiguration::setInternal(KeyRef key, ValueRef value) {
 	if (ck == LiteralStringRef("initialized")) {
 		initialized = true;
 	} else if (ck == LiteralStringRef("commit_proxies")) {
-		parse(&commitProxyCount, value);
+		commitProxyCount = toInt(value);
+		if (commitProxyCount == -1)
+			overwriteProxiesCount();
 	} else if (ck == LiteralStringRef("grv_proxies")) {
-		parse(&grvProxyCount, value);
+		grvProxyCount = toInt(value);
+		if (grvProxyCount == -1)
+			overwriteProxiesCount();
 	} else if (ck == LiteralStringRef("resolvers")) {
 		parse(&resolverCount, value);
 	} else if (ck == LiteralStringRef("logs")) {
@@ -549,21 +618,7 @@ bool DatabaseConfiguration::setInternal(KeyRef key, ValueRef value) {
 		parse((&type), value);
 		storageMigrationType = (StorageMigrationType::MigrationType)type;
 	} else if (ck == LiteralStringRef("proxies")) {
-		int proxiesCount;
-		parse(&proxiesCount, value);
-		if (proxiesCount > 1) {
-			int derivedGrvProxyCount =
-			    std::max(1,
-			             std::min(CLIENT_KNOBS->DEFAULT_MAX_GRV_PROXIES,
-			                      proxiesCount / (CLIENT_KNOBS->DEFAULT_COMMIT_GRV_PROXIES_RATIO + 1)));
-			int derivedCommitProxyCount = proxiesCount - derivedGrvProxyCount;
-			if (grvProxyCount == -1) {
-				grvProxyCount = derivedGrvProxyCount;
-			}
-			if (commitProxyCount == -1) {
-				commitProxyCount = derivedCommitProxyCount;
-			}
-		}
+		overwriteProxiesCount();
 	} else {
 		return false;
 	}

--- a/fdbclient/DatabaseConfiguration.h
+++ b/fdbclient/DatabaseConfiguration.h
@@ -332,6 +332,8 @@ private:
 
 	/// Check if the key is overridden by either mutableConfiguration or rawConfiguration
 	bool isOverridden(std::string key) const;
+	// Overwrite commitProxyCount and/or grvProxyCount if set to -1
+	void overwriteProxiesCount();
 };
 
 #endif

--- a/flow/Arena.h
+++ b/flow/Arena.h
@@ -439,6 +439,7 @@ public:
 	const uint8_t* begin() const { return data; }
 	const uint8_t* end() const { return data + length; }
 	int size() const { return length; }
+	bool empty() const { return length == 0; }
 
 	uint8_t operator[](int i) const { return data[i]; }
 


### PR DESCRIPTION
Patch improves on handling scenarios where either commit or grv proxies
value is update to -1 OR `proxies_count` is being reset.
The code splits the proxies between two proxies by ensuring for invalid
input configuration, the min (read as 1) proxies gets provisioned, otherwise,
the split is done based on input values

Patch handles the scenario where mutation supplied values to update grv_proxies
and/or commit_proxies is -1, however, the total proxy count > 1,
uses DEFAULT_COMMIT_GRV_PROXIES_RATIO to split proxies between
grv_proxies & commit_proxies.

Put description here...

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
