### PR TITLE
Don't provide default for requireFunction in loadClientFunction

### DIFF
--- a/fdbclient/MultiVersionTransaction.actor.cpp
+++ b/fdbclient/MultiVersionTransaction.actor.cpp
@@ -426,7 +426,7 @@ ThreadFuture<ProtocolVersion> DLDatabase::getServerProtocol(Optional<ProtocolVer
 // requireFunction - Determines the behavior if the function is not present. If true, an error is thrown. If false,
 //                   the function pointer will be set to nullptr.
 template <class T>
-void loadClientFunction(T* fp, void* lib, std::string libPath, const char* functionName, bool requireFunction = true) {
+void loadClientFunction(T* fp, void* lib, std::string libPath, const char* functionName, bool requireFunction) {
 	*(void**)(fp) = loadFunction(lib, functionName);
 	if (*fp == nullptr && requireFunction) {
 		TraceEvent(SevError, "ErrorLoadingFunction").detail("LibraryPath", libPath).detail("Function", functionName);
@@ -456,16 +456,17 @@ void DLApi::init() {
 		}
 	}
 
-	loadClientFunction(&api->selectApiVersion, lib, fdbCPath, "fdb_select_api_version_impl");
+	loadClientFunction(&api->selectApiVersion, lib, fdbCPath, "fdb_select_api_version_impl", headerVersion >= 0);
 	loadClientFunction(&api->getClientVersion, lib, fdbCPath, "fdb_get_client_version", headerVersion >= 410);
-	loadClientFunction(&api->setNetworkOption, lib, fdbCPath, "fdb_network_set_option");
-	loadClientFunction(&api->setupNetwork, lib, fdbCPath, "fdb_setup_network");
-	loadClientFunction(&api->runNetwork, lib, fdbCPath, "fdb_run_network");
-	loadClientFunction(&api->stopNetwork, lib, fdbCPath, "fdb_stop_network");
+	loadClientFunction(&api->setNetworkOption, lib, fdbCPath, "fdb_network_set_option", headerVersion >= 0);
+	loadClientFunction(&api->setupNetwork, lib, fdbCPath, "fdb_setup_network", headerVersion >= 0);
+	loadClientFunction(&api->runNetwork, lib, fdbCPath, "fdb_run_network", headerVersion >= 0);
+	loadClientFunction(&api->stopNetwork, lib, fdbCPath, "fdb_stop_network", headerVersion >= 0);
 	loadClientFunction(&api->createDatabase, lib, fdbCPath, "fdb_create_database", headerVersion >= 610);
 
-	loadClientFunction(&api->databaseCreateTransaction, lib, fdbCPath, "fdb_database_create_transaction");
-	loadClientFunction(&api->databaseSetOption, lib, fdbCPath, "fdb_database_set_option");
+	loadClientFunction(
+	    &api->databaseCreateTransaction, lib, fdbCPath, "fdb_database_create_transaction", headerVersion >= 0);
+	loadClientFunction(&api->databaseSetOption, lib, fdbCPath, "fdb_database_set_option", headerVersion >= 0);
 	loadClientFunction(&api->databaseGetMainThreadBusyness,
 	                   lib,
 	                   fdbCPath,
@@ -473,7 +474,7 @@ void DLApi::init() {
 	                   headerVersion >= 700);
 	loadClientFunction(
 	    &api->databaseGetServerProtocol, lib, fdbCPath, "fdb_database_get_server_protocol", headerVersion >= 700);
-	loadClientFunction(&api->databaseDestroy, lib, fdbCPath, "fdb_database_destroy");
+	loadClientFunction(&api->databaseDestroy, lib, fdbCPath, "fdb_database_destroy", headerVersion >= 0);
 	loadClientFunction(&api->databaseRebootWorker, lib, fdbCPath, "fdb_database_reboot_worker", headerVersion >= 700);
 	loadClientFunction(&api->databaseForceRecoveryWithDataLoss,
 	                   lib,
@@ -483,14 +484,20 @@ void DLApi::init() {
 	loadClientFunction(
 	    &api->databaseCreateSnapshot, lib, fdbCPath, "fdb_database_create_snapshot", headerVersion >= 700);
 
-	loadClientFunction(&api->transactionSetOption, lib, fdbCPath, "fdb_transaction_set_option");
-	loadClientFunction(&api->transactionDestroy, lib, fdbCPath, "fdb_transaction_destroy");
-	loadClientFunction(&api->transactionSetReadVersion, lib, fdbCPath, "fdb_transaction_set_read_version");
-	loadClientFunction(&api->transactionGetReadVersion, lib, fdbCPath, "fdb_transaction_get_read_version");
-	loadClientFunction(&api->transactionGet, lib, fdbCPath, "fdb_transaction_get");
-	loadClientFunction(&api->transactionGetKey, lib, fdbCPath, "fdb_transaction_get_key");
-	loadClientFunction(&api->transactionGetAddressesForKey, lib, fdbCPath, "fdb_transaction_get_addresses_for_key");
-	loadClientFunction(&api->transactionGetRange, lib, fdbCPath, "fdb_transaction_get_range");
+	loadClientFunction(&api->transactionSetOption, lib, fdbCPath, "fdb_transaction_set_option", headerVersion >= 0);
+	loadClientFunction(&api->transactionDestroy, lib, fdbCPath, "fdb_transaction_destroy", headerVersion >= 0);
+	loadClientFunction(
+	    &api->transactionSetReadVersion, lib, fdbCPath, "fdb_transaction_set_read_version", headerVersion >= 0);
+	loadClientFunction(
+	    &api->transactionGetReadVersion, lib, fdbCPath, "fdb_transaction_get_read_version", headerVersion >= 0);
+	loadClientFunction(&api->transactionGet, lib, fdbCPath, "fdb_transaction_get", headerVersion >= 0);
+	loadClientFunction(&api->transactionGetKey, lib, fdbCPath, "fdb_transaction_get_key", headerVersion >= 0);
+	loadClientFunction(&api->transactionGetAddressesForKey,
+	                   lib,
+	                   fdbCPath,
+	                   "fdb_transaction_get_addresses_for_key",
+	                   headerVersion >= 0);
+	loadClientFunction(&api->transactionGetRange, lib, fdbCPath, "fdb_transaction_get_range", headerVersion >= 0);
 	loadClientFunction(&api->transactionGetRangeAndFlatMap,
 	                   lib,
 	                   fdbCPath,
@@ -498,22 +505,27 @@ void DLApi::init() {
 	                   headerVersion >= 700);
 	loadClientFunction(
 	    &api->transactionGetVersionstamp, lib, fdbCPath, "fdb_transaction_get_versionstamp", headerVersion >= 410);
-	loadClientFunction(&api->transactionSet, lib, fdbCPath, "fdb_transaction_set");
-	loadClientFunction(&api->transactionClear, lib, fdbCPath, "fdb_transaction_clear");
-	loadClientFunction(&api->transactionClearRange, lib, fdbCPath, "fdb_transaction_clear_range");
-	loadClientFunction(&api->transactionAtomicOp, lib, fdbCPath, "fdb_transaction_atomic_op");
-	loadClientFunction(&api->transactionCommit, lib, fdbCPath, "fdb_transaction_commit");
-	loadClientFunction(&api->transactionGetCommittedVersion, lib, fdbCPath, "fdb_transaction_get_committed_version");
+	loadClientFunction(&api->transactionSet, lib, fdbCPath, "fdb_transaction_set", headerVersion >= 0);
+	loadClientFunction(&api->transactionClear, lib, fdbCPath, "fdb_transaction_clear", headerVersion >= 0);
+	loadClientFunction(&api->transactionClearRange, lib, fdbCPath, "fdb_transaction_clear_range", headerVersion >= 0);
+	loadClientFunction(&api->transactionAtomicOp, lib, fdbCPath, "fdb_transaction_atomic_op", headerVersion >= 0);
+	loadClientFunction(&api->transactionCommit, lib, fdbCPath, "fdb_transaction_commit", headerVersion >= 0);
+	loadClientFunction(&api->transactionGetCommittedVersion,
+	                   lib,
+	                   fdbCPath,
+	                   "fdb_transaction_get_committed_version",
+	                   headerVersion >= 0);
 	loadClientFunction(&api->transactionGetApproximateSize,
 	                   lib,
 	                   fdbCPath,
 	                   "fdb_transaction_get_approximate_size",
 	                   headerVersion >= 620);
-	loadClientFunction(&api->transactionWatch, lib, fdbCPath, "fdb_transaction_watch");
-	loadClientFunction(&api->transactionOnError, lib, fdbCPath, "fdb_transaction_on_error");
-	loadClientFunction(&api->transactionReset, lib, fdbCPath, "fdb_transaction_reset");
-	loadClientFunction(&api->transactionCancel, lib, fdbCPath, "fdb_transaction_cancel");
-	loadClientFunction(&api->transactionAddConflictRange, lib, fdbCPath, "fdb_transaction_add_conflict_range");
+	loadClientFunction(&api->transactionWatch, lib, fdbCPath, "fdb_transaction_watch", headerVersion >= 0);
+	loadClientFunction(&api->transactionOnError, lib, fdbCPath, "fdb_transaction_on_error", headerVersion >= 0);
+	loadClientFunction(&api->transactionReset, lib, fdbCPath, "fdb_transaction_reset", headerVersion >= 0);
+	loadClientFunction(&api->transactionCancel, lib, fdbCPath, "fdb_transaction_cancel", headerVersion >= 0);
+	loadClientFunction(
+	    &api->transactionAddConflictRange, lib, fdbCPath, "fdb_transaction_add_conflict_range", headerVersion >= 0);
 	loadClientFunction(&api->transactionGetEstimatedRangeSizeBytes,
 	                   lib,
 	                   fdbCPath,
@@ -525,18 +537,22 @@ void DLApi::init() {
 	                   "fdb_transaction_get_range_split_points",
 	                   headerVersion >= 700);
 
-	loadClientFunction(
-	    &api->futureGetInt64, lib, fdbCPath, headerVersion >= 620 ? "fdb_future_get_int64" : "fdb_future_get_version");
+	loadClientFunction(&api->futureGetInt64,
+	                   lib,
+	                   fdbCPath,
+	                   headerVersion >= 620 ? "fdb_future_get_int64" : "fdb_future_get_version",
+	                   headerVersion >= 0);
 	loadClientFunction(&api->futureGetUInt64, lib, fdbCPath, "fdb_future_get_uint64", headerVersion >= 700);
-	loadClientFunction(&api->futureGetError, lib, fdbCPath, "fdb_future_get_error");
-	loadClientFunction(&api->futureGetKey, lib, fdbCPath, "fdb_future_get_key");
-	loadClientFunction(&api->futureGetValue, lib, fdbCPath, "fdb_future_get_value");
-	loadClientFunction(&api->futureGetStringArray, lib, fdbCPath, "fdb_future_get_string_array");
+	loadClientFunction(&api->futureGetError, lib, fdbCPath, "fdb_future_get_error", headerVersion >= 0);
+	loadClientFunction(&api->futureGetKey, lib, fdbCPath, "fdb_future_get_key", headerVersion >= 0);
+	loadClientFunction(&api->futureGetValue, lib, fdbCPath, "fdb_future_get_value", headerVersion >= 0);
+	loadClientFunction(&api->futureGetStringArray, lib, fdbCPath, "fdb_future_get_string_array", headerVersion >= 0);
 	loadClientFunction(&api->futureGetKeyArray, lib, fdbCPath, "fdb_future_get_key_array", headerVersion >= 700);
-	loadClientFunction(&api->futureGetKeyValueArray, lib, fdbCPath, "fdb_future_get_keyvalue_array");
-	loadClientFunction(&api->futureSetCallback, lib, fdbCPath, "fdb_future_set_callback");
-	loadClientFunction(&api->futureCancel, lib, fdbCPath, "fdb_future_cancel");
-	loadClientFunction(&api->futureDestroy, lib, fdbCPath, "fdb_future_destroy");
+	loadClientFunction(
+	    &api->futureGetKeyValueArray, lib, fdbCPath, "fdb_future_get_keyvalue_array", headerVersion >= 0);
+	loadClientFunction(&api->futureSetCallback, lib, fdbCPath, "fdb_future_set_callback", headerVersion >= 0);
+	loadClientFunction(&api->futureCancel, lib, fdbCPath, "fdb_future_cancel", headerVersion >= 0);
+	loadClientFunction(&api->futureDestroy, lib, fdbCPath, "fdb_future_destroy", headerVersion >= 0);
 
 	loadClientFunction(&api->futureGetDatabase, lib, fdbCPath, "fdb_future_get_database", headerVersion < 610);
 	loadClientFunction(&api->createCluster, lib, fdbCPath, "fdb_create_cluster", headerVersion < 610);


### PR DESCRIPTION
Recently there was an issue where we added a new symbol to the c api and
we did not include the right header version guard to see if it was
required. Let's make this not a default so that we force callers to
think about what the right header versions to require it are.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
