### PR TITLE
Fix: Check whether connRecord is null before logging it

### DIFF
--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -1882,8 +1882,8 @@ Database Database::createDatabase(Reference<IClusterConnectionRecord> connRecord
 
 	TraceEvent("ConnectToDatabase", database->dbId)
 	    .detail("Version", FDB_VT_VERSION)
-	    .detail("ClusterFile", connRecord->toString())
-	    .detail("ConnectionString", connRecord->getConnectionString().toString())
+	    .detail("ClusterFile", connRecord ? connRecord->toString() : "None")
+	    .detail("ConnectionString", connRecord ? connRecord->getConnectionString().toString() : "None")
 	    .detail("ClientLibrary", imageInfo.fileName)
 	    .detail("Primary", networkOptions.primaryClient)
 	    .detail("Internal", internal)


### PR DESCRIPTION
PR #6033 introduced a change that logged some details about the connection record when connecting to a database. In practice, it seems as if this connection record is generally present, though it is not actually a contract of the function that it be non-null. This change fixes the use of it to check for null.

Passed 10K correctness and a manual test of this trace event.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
