### PR TITLE
Fix a race condition with updating the coordinated state and updating the master registration

### DIFF
--- a/fdbserver/masterserver.actor.cpp
+++ b/fdbserver/masterserver.actor.cpp
@@ -224,6 +224,7 @@ struct MasterData : NonCopyable, ReferenceCounted<MasterData> {
 	    clusterController; // If the cluster controller changes, this master will die, so this is immutable.
 
 	ReusableCoordinatedState cstate;
+	Promise<Void> recoveryReadyForCommits;
 	Promise<Void> cstateUpdated;
 	Reference<AsyncVar<ServerDBInfo> const> dbInfo;
 	int64_t registrationCount; // Number of different MasterRegistrationRequests sent to clusterController
@@ -605,7 +606,9 @@ ACTOR Future<Void> updateRegistration(Reference<MasterData> self, Reference<ILog
 		TraceEvent("MasterUpdateRegistration", self->dbgid)
 		    .detail("RecoveryCount", self->cstate.myDBState.recoveryCount)
 		    .detail("OldestBackupEpoch", logSystemConfig.oldestBackupEpoch)
-		    .detail("Logs", describe(logSystemConfig.tLogs));
+		    .detail("Logs", describe(logSystemConfig.tLogs))
+		    .detail("CStateUpdated", self->cstateUpdated.isSet())
+		    .detail("RecoveryState", self->recoveryState);
 
 		if (!self->cstateUpdated.isSet()) {
 			wait(sendMasterRegistration(self.getPtr(),
@@ -615,7 +618,7 @@ ACTOR Future<Void> updateRegistration(Reference<MasterData> self, Reference<ILog
 			                            self->resolvers,
 			                            self->cstate.myDBState.recoveryCount,
 			                            self->cstate.prevDBState.getPriorCommittedLogServers()));
-		} else {
+		} else if (self->recoveryState >= RecoveryState::ACCEPTING_COMMITS) {
 			updateLogsKey = updateLogsValue(self, cx);
 			wait(sendMasterRegistration(self.getPtr(),
 			                            logSystemConfig,
@@ -624,6 +627,9 @@ ACTOR Future<Void> updateRegistration(Reference<MasterData> self, Reference<ILog
 			                            self->resolvers,
 			                            self->cstate.myDBState.recoveryCount,
 			                            std::vector<UID>()));
+		} else {
+			// The master should enter the accepting commits phase soon, and then we will register again
+			TEST(true); // cstate is updated but we aren't accepting commits yet
 		}
 	}
 }
@@ -1494,10 +1500,15 @@ ACTOR Future<Void> trackTlogRecovery(Reference<MasterData> self,
 		    configuration.expectedLogSets(self->primaryDcId.size() ? self->primaryDcId[0] : Optional<Key>());
 		state bool finalUpdate = !newState.oldTLogData.size() && allLogs;
 		wait(self->cstate.write(newState, finalUpdate));
-		wait(minRecoveryDuration);
-		self->logSystem->coreStateWritten(newState);
 		if (self->cstateUpdated.canBeSet()) {
 			self->cstateUpdated.send(Void());
+		}
+
+		wait(minRecoveryDuration);
+		self->logSystem->coreStateWritten(newState);
+
+		if (self->recoveryReadyForCommits.canBeSet()) {
+			self->recoveryReadyForCommits.send(Void());
 		}
 
 		if (finalUpdate) {
@@ -1965,7 +1976,7 @@ ACTOR Future<Void> masterCore(Reference<MasterData> self) {
 
 	self->addActor.send(trackTlogRecovery(self, oldLogSystems, minRecoveryDuration));
 	debug_advanceMaxCommittedVersion(UID(), self->recoveryTransactionVersion);
-	wait(self->cstateUpdated.getFuture());
+	wait(self->recoveryReadyForCommits.getFuture());
 	debug_advanceMinCommittedVersion(UID(), self->recoveryTransactionVersion);
 
 	if (debugResult) {


### PR DESCRIPTION
During master recovery, it was possible for the master to write the cstate but get blocked waiting for the minimum recovery duration. If this happened, it could send an invalid master registration that updated the recovery count but reported no proxies. This would cause the current proxies to terminate and start the recovery over.

This PR changes the logic to disallow updating the master registration between the point when the cstate is updated and the recovery enters the accepting commits phase.

This bug was detected by the ConfigureTest.

Passed 10K correctness.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
