### PR TITLE
Excluding DiskFailureCycle test for rocksdb storage engine.

### DIFF
--- a/tests/slow/DiskFailureCycle.toml
+++ b/tests/slow/DiskFailureCycle.toml
@@ -3,6 +3,7 @@ buggify = false
 minimumReplication = 3
 minimumRegions = 3
 logAntiQuorum = 0
+storageEngineExcludeTypes = [4]
 
 [[test]]
 testTitle = 'DiskFailureCycle'


### PR DESCRIPTION
Excluding DiskFailureCycle test for rocksdb storage engine. DiskFailureCycle injects chaos faults in AsyncFile layer, so this test is not valid for rocksdb storage engine as it does not used AsynFile.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
