### PR TITLE
Fix `-Wunused-but-set-variable` warnings

### DIFF
--- a/fdbbackup/backup.actor.cpp
+++ b/fdbbackup/backup.actor.cpp
@@ -2996,15 +2996,15 @@ static std::vector<std::vector<StringRef>> parseLine(std::string& line, bool& er
 
 static void addKeyRange(std::string optionValue, Standalone<VectorRef<KeyRangeRef>>& keyRanges) {
 	bool err = false, partial = false;
-	int tokenArray = 0, tokenIndex = 0;
+	int tokenArray = 0;
 
 	auto parsed = parseLine(optionValue, err, partial);
 
 	for (auto tokens : parsed) {
 		tokenArray++;
-		tokenIndex = 0;
 
 		/*
+		int tokenIndex = 0;
 		for (auto token : tokens)
 		{
 		    tokenIndex++;

--- a/fdbclient/ManagementAPI.actor.cpp
+++ b/fdbclient/ManagementAPI.actor.cpp
@@ -453,7 +453,7 @@ ConfigureAutoResult parseConfig(StatusObject const& status) {
 
 	result.auto_replication = result.old_replication;
 
-	int storage_replication;
+	[[maybe_unused]] int storage_replication;
 	int log_replication;
 	if (result.old_replication == "single") {
 		result.auto_replication = "double";

--- a/fdbmonitor/fdbmonitor.cpp
+++ b/fdbmonitor/fdbmonitor.cpp
@@ -1151,7 +1151,7 @@ void testPathOps() {
 	std::string cwd = abspath(".", true);
 
 	// Create some symlinks and test resolution (or non-resolution) of them
-	int rc;
+	[[maybe_unused]] int rc;
 	// Ignoring return codes, if symlinks fail tests below will fail
 	rc = unlink("simfdb/backups/four");
 	rc = unlink("simfdb/backups/five");

--- a/fdbserver/BlobWorker.actor.cpp
+++ b/fdbserver/BlobWorker.actor.cpp
@@ -1951,7 +1951,7 @@ ACTOR Future<Void> handleBlobGranuleFileRequest(Reference<BlobWorkerData> bwData
 				j--;
 			}
 			j++;
-			Version latestDeltaVersion = invalidVersion;
+			[[maybe_unused]] Version latestDeltaVersion = invalidVersion;
 			while (j <= i) {
 				BlobFileIndex deltaF = chunkFiles.deltaFiles[j];
 				chunk.deltaFiles.emplace_back_deep(rep.arena, deltaF.filename, deltaF.offset, deltaF.length);

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -2195,7 +2195,6 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 		ASSERT_WE_THINK(machine_info.size() > 0 || server_info.size() == 0);
 		ASSERT_WE_THINK(SERVER_KNOBS->DESIRED_TEAMS_PER_SERVER >= 1 && configuration.storageTeamSize >= 1);
 
-		int addedMachineTeams = 0;
 		int addedTeams = 0;
 
 		// Exclude machine teams who have members in the wrong configuration.
@@ -2210,15 +2209,18 @@ struct DDTeamCollection : ReferenceCounted<DDTeamCollection> {
 		int machineTeamsToBuild = std::max(
 		    0, std::min(desiredMachineTeams - healthyMachineTeamCount, maxMachineTeams - totalMachineTeamCount));
 
-		TraceEvent("BuildMachineTeams")
-		    .detail("TotalHealthyMachine", totalHealthyMachineCount)
-		    .detail("HealthyMachineTeamCount", healthyMachineTeamCount)
-		    .detail("DesiredMachineTeams", desiredMachineTeams)
-		    .detail("MaxMachineTeams", maxMachineTeams)
-		    .detail("MachineTeamsToBuild", machineTeamsToBuild);
-		// Pre-build all machine teams until we have the desired number of machine teams
-		if (machineTeamsToBuild > 0 || notEnoughMachineTeamsForAMachine()) {
-			addedMachineTeams = addBestMachineTeams(machineTeamsToBuild);
+		{
+			TraceEvent te("BuildMachineTeams");
+			te.detail("TotalHealthyMachine", totalHealthyMachineCount)
+			    .detail("HealthyMachineTeamCount", healthyMachineTeamCount)
+			    .detail("DesiredMachineTeams", desiredMachineTeams)
+			    .detail("MaxMachineTeams", maxMachineTeams)
+			    .detail("MachineTeamsToBuild", machineTeamsToBuild);
+			// Pre-build all machine teams until we have the desired number of machine teams
+			if (machineTeamsToBuild > 0 || notEnoughMachineTeamsForAMachine()) {
+				auto addedMachineTeams = addBestMachineTeams(machineTeamsToBuild);
+				te.detail("MachineTeamsAdded", addedMachineTeams);
+			}
 		}
 
 		while (addedTeams < teamsToBuild || notEnoughTeamsForAServer()) {

--- a/fdbserver/Resolver.actor.cpp
+++ b/fdbserver/Resolver.actor.cpp
@@ -180,13 +180,10 @@ ACTOR Future<Void> resolveBatch(Reference<Resolver> self, ResolveTransactionBatc
 		// Detect conflicts
 		double expire = now() + SERVER_KNOBS->SAMPLE_EXPIRATION_TIME;
 		ConflictBatch conflictBatch(self->conflictSet, &reply.conflictingKeyRangeMap, &reply.arena);
-		int keys = 0;
 		for (int t = 0; t < req.transactions.size(); t++) {
 			conflictBatch.addTransaction(req.transactions[t]);
 			self->resolvedReadConflictRanges += req.transactions[t].read_conflict_ranges.size();
 			self->resolvedWriteConflictRanges += req.transactions[t].write_conflict_ranges.size();
-			keys += req.transactions[t].write_conflict_ranges.size() * 2 +
-			        req.transactions[t].read_conflict_ranges.size() * 2;
 
 			if (self->resolverCount > 1) {
 				for (auto it : req.transactions[t].write_conflict_ranges)

--- a/fdbserver/art_impl.h
+++ b/fdbserver/art_impl.h
@@ -166,7 +166,7 @@ void art_tree::art_bound_iterative(art_node* n, const KeyRef& k, int depth, art_
 
 	static stack_entry arena[ART_MAX_KEY_LEN]; // Single threaded implementation.
 
-	stack_entry *head = nullptr, *tmp, *curr_arena = arena;
+	stack_entry *head = nullptr, *curr_arena = arena;
 	int ret;
 	art_node** child;
 	unsigned char* key = (unsigned char*)k.begin();
@@ -198,7 +198,6 @@ void art_tree::art_bound_iterative(art_node* n, const KeyRef& k, int depth, art_
 			*result = minimum(next);
 			break;
 		} else {
-			tmp = head;
 			head = head->prev;
 		}
 	}

--- a/fdbserver/workloads/ConsistencyCheck.actor.cpp
+++ b/fdbserver/workloads/ConsistencyCheck.actor.cpp
@@ -1598,7 +1598,8 @@ struct ConsistencyCheckWorkload : TestWorkload {
 					for (int j = 0; j < storageServers.size(); j++)
 						storageServerSizes[storageServers[j]] += shardBytes;
 
-				bool hasValidEstimate = estimatedBytes.size() > 0;
+				// FIXME: Where is this intended to be used?
+				[[maybe_unused]] bool hasValidEstimate = estimatedBytes.size() > 0;
 
 				// If the storage servers' sampled estimate of shard size is different from ours
 				if (self->performQuiescentChecks) {

--- a/fdbserver/workloads/SnapTest.actor.cpp
+++ b/fdbserver/workloads/SnapTest.actor.cpp
@@ -21,10 +21,10 @@ void getVersionAndnumTags(TraceEventFields md, Version& version, int& numTags) {
 }
 
 void getTagAndDurableVersion(TraceEventFields md, Version version, Tag& tag, Version& durableVersion) {
-	Version verifyVersion;
 	durableVersion = -1;
 
-	verifyVersion = boost::lexical_cast<int64_t>(md.getValue("Version"));
+	// verify version:
+	boost::lexical_cast<int64_t>(md.getValue("Version"));
 	std::string tagString = md.getValue("Tag");
 	int colon = tagString.find_first_of(':');
 	std::string localityString = tagString.substr(0, colon);
@@ -40,11 +40,11 @@ void getMinAndMaxTLogVersions(TraceEventFields md,
                               Tag tag,
                               Version& minTLogVersion,
                               Version& maxTLogVersion) {
-	Version verifyVersion;
 	Tag verifyTag;
 	minTLogVersion = maxTLogVersion = -1;
 
-	verifyVersion = boost::lexical_cast<int64_t>(md.getValue("Version"));
+	// verify version:
+	boost::lexical_cast<int64_t>(md.getValue("Version"));
 	std::string tagString = md.getValue("Tag");
 	int colon = tagString.find_first_of(':');
 	std::string localityString = tagString.substr(0, colon);

--- a/flow/Net2.actor.cpp
+++ b/flow/Net2.actor.cpp
@@ -1509,7 +1509,7 @@ void Net2::run() {
 		taskBegin = timer_monotonic();
 		numYields = 0;
 		TaskPriority minTaskID = TaskPriority::Max;
-		int queueSize = ready.size();
+		[[maybe_unused]] int queueSize = ready.size();
 
 		FDB_TRACE_PROBE(run_loop_tasks_start, queueSize);
 		while (!ready.empty()) {


### PR DESCRIPTION
These warnings started showing up once we upgraded to `clang` version 13.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
