### PR TITLE
Apply `clang-format` (version 13.0)

### DIFF
--- a/fdbclient/rapidjson/rapidjson.h
+++ b/fdbclient/rapidjson/rapidjson.h
@@ -449,7 +449,7 @@ RAPIDJSON_NAMESPACE_END
  */
 #define RAPIDJSON_STATIC_ASSERT(x)                                                                                     \
 	typedef ::RAPIDJSON_NAMESPACE::StaticAssertTest<sizeof(::RAPIDJSON_NAMESPACE::STATIC_ASSERTION_FAILURE<bool(x)>)>  \
-	    RAPIDJSON_JOIN(StaticAssertTypedef, __LINE__) RAPIDJSON_STATIC_ASSERT_UNUSED_ATTRIBUTE
+	RAPIDJSON_JOIN(StaticAssertTypedef, __LINE__) RAPIDJSON_STATIC_ASSERT_UNUSED_ATTRIBUTE
 #endif
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/flow/TDMetric.actor.h
+++ b/flow/TDMetric.actor.h
@@ -343,11 +343,11 @@ auto tuple_map_impl(F f, index_sequence<Is...>, const Tuples&... ts)
 
 // tuple_map( f(a,b), (a1,a2,a3), (b1,b2,b3) ) = (f(a1,b1), f(a2,b2), f(a3,b3))
 template <typename F, typename Tuple, typename... Tuples>
-auto tuple_map(F f, const Tuple& t, const Tuples&... ts) -> decltype(
-    tuple_map_impl(f,
-                   typename make_index_sequence_impl<0, index_sequence<>, std::tuple_size<Tuple>::value>::type(),
-                   t,
-                   ts...)) {
+auto tuple_map(F f, const Tuple& t, const Tuples&... ts) -> decltype(tuple_map_impl(
+    f,
+    typename make_index_sequence_impl<0, index_sequence<>, std::tuple_size<Tuple>::value>::type(),
+    t,
+    ts...)) {
 	return tuple_map_impl(
 	    f, typename make_index_sequence_impl<0, index_sequence<>, std::tuple_size<Tuple>::value>::type(), t, ts...);
 }


### PR DESCRIPTION
Two files were previously formatted with an older version of `clang-format`, causing CI to fail.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
