### PR TITLE
Upgrade google benchmark to v1.6.0

### DIFF
--- a/flowbench/benchmark.cmake
+++ b/flowbench/benchmark.cmake
@@ -4,7 +4,7 @@ project(googlebenchmark-download NONE)
 include(ExternalProject)
 ExternalProject_Add(googlebenchmark
   GIT_REPOSITORY    https://github.com/google/benchmark.git
-  GIT_TAG           8039b4030795b1c9b8cedb78e3a2a6fb89574b6e # v1.5.1
+  GIT_TAG           f91b6b42b1b9854772a90ae9501464a161707d1e # v1.6.0
   GIT_SHALLOW       ON
   GIT_CONFIG        advice.detachedHead=false
   SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googlebenchmark-src"


### PR DESCRIPTION
This fixes a compile error with clang 13. For some reason this only seems to come up on Arm.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
