### PR TITLE
Cherry pick 7.0 sim fix

### DIFF
--- a/fdbclient/ManagementAPI.actor.cpp
+++ b/fdbclient/ManagementAPI.actor.cpp
@@ -1166,14 +1166,24 @@ ACTOR Future<Optional<CoordinatorsResult>> changeQuorumChecker(Transaction* tr,
 	                                   StringRef(newName + ':' + deterministicRandom()->randomAlphaNumeric(32)));
 
 	if (g_network->isSimulated()) {
-		for (int i = 0; i < (desiredCoordinators->size() / 2) + 1; i++) {
-			auto addresses = g_simulator.getProcessByAddress((*desiredCoordinators)[i])->addresses;
+		int i = 0;
+		int protectedCount = 0;
+		while ((protectedCount <  ((desiredCoordinators->size() / 2) + 1)) && (i < desiredCoordinators->size())) {
+			auto process = g_simulator.getProcessByAddress((*desiredCoordinators)[i]);
+			auto addresses = process->addresses;
 
-			g_simulator.protectedAddresses.insert(addresses.address);
+			if (!process->isReliable()) {
+				i++;
+				continue;
+			}
+
+			g_simulator.protectedAddresses.insert(process->addresses.address);
 			if (addresses.secondaryAddress.present()) {
-				g_simulator.protectedAddresses.insert(addresses.secondaryAddress.get());
+				g_simulator.protectedAddresses.insert(process->addresses.secondaryAddress.get());
 			}
 			TraceEvent("ProtectCoordinator").detail("Address", (*desiredCoordinators)[i]).backtrace();
+			protectedCount++;
+			i++;
 		}
 	}
 

--- a/fdbclient/ManagementAPI.actor.cpp
+++ b/fdbclient/ManagementAPI.actor.cpp
@@ -1168,7 +1168,7 @@ ACTOR Future<Optional<CoordinatorsResult>> changeQuorumChecker(Transaction* tr,
 	if (g_network->isSimulated()) {
 		int i = 0;
 		int protectedCount = 0;
-		while ((protectedCount <  ((desiredCoordinators->size() / 2) + 1)) && (i < desiredCoordinators->size())) {
+		while ((protectedCount < ((desiredCoordinators->size() / 2) + 1)) && (i < desiredCoordinators->size())) {
 			auto process = g_simulator.getProcessByAddress((*desiredCoordinators)[i]);
 			auto addresses = process->addresses;
 

--- a/fdbclient/rapidjson/rapidjson.h
+++ b/fdbclient/rapidjson/rapidjson.h
@@ -449,7 +449,7 @@ RAPIDJSON_NAMESPACE_END
  */
 #define RAPIDJSON_STATIC_ASSERT(x)                                                                                     \
 	typedef ::RAPIDJSON_NAMESPACE::StaticAssertTest<sizeof(::RAPIDJSON_NAMESPACE::STATIC_ASSERTION_FAILURE<bool(x)>)>  \
-	    RAPIDJSON_JOIN(StaticAssertTypedef, __LINE__) RAPIDJSON_STATIC_ASSERT_UNUSED_ATTRIBUTE
+	RAPIDJSON_JOIN(StaticAssertTypedef, __LINE__) RAPIDJSON_STATIC_ASSERT_UNUSED_ATTRIBUTE
 #endif
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/fdbserver/worker.actor.cpp
+++ b/fdbserver/worker.actor.cpp
@@ -1358,7 +1358,7 @@ ACTOR Future<Void> workerServer(Reference<ClusterConnectionFile> connFile,
 	state Reference<AsyncVar<std::set<std::string>>> issues(new AsyncVar<std::set<std::string>>());
 
 	if (FLOW_KNOBS->ENABLE_CHAOS_FEATURES) {
-		TraceEvent(SevWarnAlways, "ChaosFeaturesEnabled");
+		TraceEvent(SevInfo, "ChaosFeaturesEnabled");
 		chaosMetricsActor = chaosMetricsLogger();
 	}
 

--- a/fdbserver/workloads/HealthMetricsApi.actor.cpp
+++ b/fdbserver/workloads/HealthMetricsApi.actor.cpp
@@ -172,7 +172,7 @@ struct HealthMetricsApiWorkload : TestWorkload {
 			//TraceEvent traceTLogQueue("TLogQueue");
 			for (const auto& ss : healthMetrics.tLogQueue) {
 				self->detailedWorstTLogQueue = std::max(self->detailedWorstTLogQueue, ss.second);
-				//traceTLogQueue.detail(format("TLog-%s", ss.first.toString().c_str()), ss.second);
+				// traceTLogQueue.detail(format("TLog-%s", ss.first.toString().c_str()), ss.second);
 			}
 		};
 	}

--- a/fdbserver/workloads/HealthMetricsApi.actor.cpp
+++ b/fdbserver/workloads/HealthMetricsApi.actor.cpp
@@ -167,10 +167,12 @@ struct HealthMetricsApiWorkload : TestWorkload {
 				self->detailedWorstDiskUsage = std::max(self->detailedWorstDiskUsage, storageStats.diskUsage);
 				traceDiskUsage.detail(format("Storage-%s", ss.first.toString().c_str()), storageStats.diskUsage);
 			}
-			TraceEvent traceTLogQueue("TLogQueue");
+
+			// This trace event can cause TraceEventOverflow. Only enable when debugging an issue
+			//TraceEvent traceTLogQueue("TLogQueue");
 			for (const auto& ss : healthMetrics.tLogQueue) {
 				self->detailedWorstTLogQueue = std::max(self->detailedWorstTLogQueue, ss.second);
-				traceTLogQueue.detail(format("TLog-%s", ss.first.toString().c_str()), ss.second);
+				//traceTLogQueue.detail(format("TLog-%s", ss.first.toString().c_str()), ss.second);
 			}
 		};
 	}

--- a/flow/TDMetric.actor.h
+++ b/flow/TDMetric.actor.h
@@ -343,11 +343,11 @@ auto tuple_map_impl(F f, index_sequence<Is...>, const Tuples&... ts)
 
 // tuple_map( f(a,b), (a1,a2,a3), (b1,b2,b3) ) = (f(a1,b1), f(a2,b2), f(a3,b3))
 template <typename F, typename Tuple, typename... Tuples>
-auto tuple_map(F f, const Tuple& t, const Tuples&... ts) -> decltype(
-    tuple_map_impl(f,
-                   typename make_index_sequence_impl<0, index_sequence<>, std::tuple_size<Tuple>::value>::type(),
-                   t,
-                   ts...)) {
+auto tuple_map(F f, const Tuple& t, const Tuples&... ts) -> decltype(tuple_map_impl(
+    f,
+    typename make_index_sequence_impl<0, index_sequence<>, std::tuple_size<Tuple>::value>::type(),
+    t,
+    ts...)) {
 	return tuple_map_impl(
 	    f, typename make_index_sequence_impl<0, index_sequence<>, std::tuple_size<Tuple>::value>::type(), t, ts...);
 }


### PR DESCRIPTION
Cherry-picck of #6095

A process can be marked unreliable (due to fault injection) after it has been added to the protected list. Recheck for reliability during quorum change and exclude the unreliable processes.

This fix surfaced another trace overflow issue which is also fixed in this PR why disabling the event for normal cases.



# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
