### PR TITLE
Use CC_ENABLE_WORKER_HEALTH_MONITOR knob to guard remoteDCIsHealthy logic

### DIFF
--- a/fdbserver/ClusterController.actor.cpp
+++ b/fdbserver/ClusterController.actor.cpp
@@ -3068,6 +3068,11 @@ public:
 
 	// Returns true if remote DC is healthy and can failover to.
 	bool remoteDCIsHealthy() {
+		// Ignore remote DC health if worker health monitor is disabled.
+		if (!SERVER_KNOBS->CC_ENABLE_WORKER_HEALTH_MONITOR) {
+			return true;
+		}
+
 		// When we just start, we ignore any remote DC health info since the current CC may be elected at wrong DC due
 		// to that all the processes are still starting.
 		if (machineStartTime() == 0) {


### PR DESCRIPTION
remoteDCIsHealthy() currently doesn't take CC_ENABLE_WORKER_HEALTH_MONITOR into account. When this knob is turned off, CC doesn't run any health monitoring logic. So when a failover happens due to primary region unhealthy, it may not be able to failback due to that the remote worker health monitoring is never started.

This fix is validated in kubernetes test. I'm also working on a simulation test to reproduce the behavior.

Put description here...

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
