### PR TITLE
Move blob granules knob to database config.

### DIFF
--- a/fdbcli/ConfigureCommand.actor.cpp
+++ b/fdbcli/ConfigureCommand.actor.cpp
@@ -264,7 +264,8 @@ CommandFactory configureFactory(
         "<single|double|triple|three_data_hall|three_datacenter|ssd|memory|memory-radixtree-beta|proxies=<PROXIES>|"
         "commit_proxies=<COMMIT_PROXIES>|grv_proxies=<GRV_PROXIES>|logs=<LOGS>|resolvers=<RESOLVERS>>*|"
         "count=<TSS_COUNT>|perpetual_storage_wiggle=<WIGGLE_SPEED>|perpetual_storage_wiggle_locality="
-        "<<LOCALITY_KEY>:<LOCALITY_VALUE>|0>|storage_migration_type={disabled|gradual|aggressive}",
+        "<<LOCALITY_KEY>:<LOCALITY_VALUE>|0>|storage_migration_type={disabled|gradual|aggressive}|"
+        "blob_granules_enabled={0|1}",
         "change the database configuration",
         "The `new' option, if present, initializes a new database with the given configuration rather than changing "
         "the configuration of an existing one. When used, both a redundancy mode and a storage engine must be "

--- a/fdbcli/fdbcli.actor.cpp
+++ b/fdbcli/fdbcli.actor.cpp
@@ -1180,6 +1180,7 @@ void configureGenerator(const char* text, const char* line, std::vector<std::str
 		                   "perpetual_storage_wiggle=",
 		                   "perpetual_storage_wiggle_locality=",
 		                   "storage_migration_type=",
+		                   "blob_granules_enabled=",
 		                   nullptr };
 	arrayGenerator(text, line, opts, lc);
 }

--- a/fdbclient/ClientKnobs.cpp
+++ b/fdbclient/ClientKnobs.cpp
@@ -259,9 +259,6 @@ void ClientKnobs::initialize(Randomize randomize) {
 	init( MVC_CLIENTLIB_CHUNK_SIZE,              8*1024 );
 	init( MVC_CLIENTLIB_CHUNKS_PER_TRANSACTION,      32 );
 
-	// blob granules
-	init( ENABLE_BLOB_GRANULES,                    true );
-
 	// clang-format on
 }
 

--- a/fdbclient/ClientKnobs.h
+++ b/fdbclient/ClientKnobs.h
@@ -250,9 +250,6 @@ public:
 	int MVC_CLIENTLIB_CHUNK_SIZE;
 	int MVC_CLIENTLIB_CHUNKS_PER_TRANSACTION;
 
-	// blob granules
-	bool ENABLE_BLOB_GRANULES;
-
 	ClientKnobs(Randomize randomize);
 	void initialize(Randomize randomize);
 };

--- a/fdbclient/DatabaseConfiguration.cpp
+++ b/fdbclient/DatabaseConfiguration.cpp
@@ -50,7 +50,7 @@ void DatabaseConfiguration::resetInternal() {
 	perpetualStorageWiggleSpeed = 0;
 	perpetualStorageWiggleLocality = "0";
 	storageMigrationType = StorageMigrationType::DEFAULT;
-	blobGranulesEnabled = true; // TODO: default to false if merging to master
+	blobGranulesEnabled = false;
 }
 
 int toInt(ValueRef const& v) {

--- a/fdbclient/DatabaseConfiguration.cpp
+++ b/fdbclient/DatabaseConfiguration.cpp
@@ -50,7 +50,7 @@ void DatabaseConfiguration::resetInternal() {
 	perpetualStorageWiggleSpeed = 0;
 	perpetualStorageWiggleLocality = "0";
 	storageMigrationType = StorageMigrationType::DEFAULT;
-	blobGranulesEnabled = true;
+	blobGranulesEnabled = false;
 }
 
 int toInt(ValueRef const& v) {

--- a/fdbclient/DatabaseConfiguration.cpp
+++ b/fdbclient/DatabaseConfiguration.cpp
@@ -629,21 +629,6 @@ bool DatabaseConfiguration::setInternal(KeyRef key, ValueRef value) {
 		storageMigrationType = (StorageMigrationType::MigrationType)type;
 	} else if (ck == LiteralStringRef("proxies")) {
 		overwriteProxiesCount();
-		int proxiesCount;
-		parse(&proxiesCount, value);
-		if (proxiesCount > 1) {
-			int derivedGrvProxyCount =
-			    std::max(1,
-			             std::min(CLIENT_KNOBS->DEFAULT_MAX_GRV_PROXIES,
-			                      proxiesCount / (CLIENT_KNOBS->DEFAULT_COMMIT_GRV_PROXIES_RATIO + 1)));
-			int derivedCommitProxyCount = proxiesCount - derivedGrvProxyCount;
-			if (grvProxyCount == -1) {
-				grvProxyCount = derivedGrvProxyCount;
-			}
-			if (commitProxyCount == -1) {
-				commitProxyCount = derivedCommitProxyCount;
-			}
-		}
 	} else if (ck == LiteralStringRef("blob_granules_enabled")) {
 		parse((&type), value);
 		blobGranulesEnabled = (type != 0);

--- a/fdbclient/DatabaseConfiguration.cpp
+++ b/fdbclient/DatabaseConfiguration.cpp
@@ -50,7 +50,7 @@ void DatabaseConfiguration::resetInternal() {
 	perpetualStorageWiggleSpeed = 0;
 	perpetualStorageWiggleLocality = "0";
 	storageMigrationType = StorageMigrationType::DEFAULT;
-	blobGranulesEnabled = false;
+	blobGranulesEnabled = true; // TODO: default to false if merging to master
 }
 
 int toInt(ValueRef const& v) {

--- a/fdbclient/DatabaseConfiguration.h
+++ b/fdbclient/DatabaseConfiguration.h
@@ -250,6 +250,9 @@ struct DatabaseConfiguration {
 	// Storage Migration Type
 	StorageMigrationType storageMigrationType;
 
+	// Blob Granules
+	bool blobGranulesEnabled;
+
 	// Excluded servers (no state should be here)
 	bool isExcludedServer(NetworkAddressList) const;
 	bool isExcludedLocality(const LocalityData& locality) const;

--- a/fdbclient/ManagementAPI.actor.cpp
+++ b/fdbclient/ManagementAPI.actor.cpp
@@ -174,6 +174,16 @@ std::map<std::string, std::string> configForToken(std::string const& mode) {
 			}
 			out[p + key] = format("%d", type);
 		}
+
+		if (key == "blob_granules_enabled") {
+			int enabled = std::stoi(value);
+			if (enabled != 0 && enabled != 1) {
+				printf("Error: Only 0 or 1 are valid values for blob_granules_enabled. "
+				       "1 enables blob granules and 0 disables them.\n");
+				return out;
+			}
+			out[p + key] = value;
+		}
 		return out;
 	}
 

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -6543,9 +6543,11 @@ ACTOR Future<Standalone<VectorRef<KeyRangeRef>>> getBlobGranuleRangesActor(Trans
 
 Future<Standalone<VectorRef<KeyRangeRef>>> Transaction::getBlobGranuleRanges(const KeyRange& range) {
 	// TODO: change to use db config
+	/*
 	if (!CLIENT_KNOBS->ENABLE_BLOB_GRANULES) {
-		throw client_invalid_operation();
+	    throw client_invalid_operation();
 	}
+	*/
 	return ::getBlobGranuleRangesActor(this, range);
 }
 
@@ -6722,9 +6724,11 @@ Future<Standalone<VectorRef<BlobGranuleChunkRef>>> Transaction::readBlobGranules
                                                                                  Optional<Version> readVersion,
                                                                                  Version* readVersionOut) {
 	// TODO: change to use db config
+	/*
 	if (!CLIENT_KNOBS->ENABLE_BLOB_GRANULES) {
-		throw client_invalid_operation();
+	    throw client_invalid_operation();
 	}
+	*/
 	return readBlobGranulesActor(cx, this, range, begin, readVersion, readVersionOut);
 }
 

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -6542,12 +6542,6 @@ ACTOR Future<Standalone<VectorRef<KeyRangeRef>>> getBlobGranuleRangesActor(Trans
 }
 
 Future<Standalone<VectorRef<KeyRangeRef>>> Transaction::getBlobGranuleRanges(const KeyRange& range) {
-	// TODO: change to use db config
-	/*
-	if (!CLIENT_KNOBS->ENABLE_BLOB_GRANULES) {
-	    throw client_invalid_operation();
-	}
-	*/
 	return ::getBlobGranuleRangesActor(this, range);
 }
 
@@ -6723,12 +6717,6 @@ Future<Standalone<VectorRef<BlobGranuleChunkRef>>> Transaction::readBlobGranules
                                                                                  Version begin,
                                                                                  Optional<Version> readVersion,
                                                                                  Version* readVersionOut) {
-	// TODO: change to use db config
-	/*
-	if (!CLIENT_KNOBS->ENABLE_BLOB_GRANULES) {
-	    throw client_invalid_operation();
-	}
-	*/
 	return readBlobGranulesActor(cx, this, range, begin, readVersion, readVersionOut);
 }
 

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -6542,6 +6542,7 @@ ACTOR Future<Standalone<VectorRef<KeyRangeRef>>> getBlobGranuleRangesActor(Trans
 }
 
 Future<Standalone<VectorRef<KeyRangeRef>>> Transaction::getBlobGranuleRanges(const KeyRange& range) {
+	// TODO: change to use db config
 	if (!CLIENT_KNOBS->ENABLE_BLOB_GRANULES) {
 		throw client_invalid_operation();
 	}
@@ -6720,6 +6721,7 @@ Future<Standalone<VectorRef<BlobGranuleChunkRef>>> Transaction::readBlobGranules
                                                                                  Version begin,
                                                                                  Optional<Version> readVersion,
                                                                                  Version* readVersionOut) {
+	// TODO: change to use db config
 	if (!CLIENT_KNOBS->ENABLE_BLOB_GRANULES) {
 		throw client_invalid_operation();
 	}

--- a/fdbclient/Schemas.cpp
+++ b/fdbclient/Schemas.cpp
@@ -771,7 +771,7 @@ const KeyRef JSONSchemas::statusSchema = LiteralStringRef(R"statusSchema(
              "aggressive",
              "gradual"
          ]},
-         "blob_granules_enabled":1,
+         "blob_granules_enabled":0
       },
       "data":{
          "least_operating_space_bytes_log_server":0,

--- a/fdbclient/Schemas.cpp
+++ b/fdbclient/Schemas.cpp
@@ -770,7 +770,8 @@ const KeyRef JSONSchemas::statusSchema = LiteralStringRef(R"statusSchema(
              "disabled",
              "aggressive",
              "gradual"
-         ]}
+         ]},
+         "blob_granules_enabled":1,
       },
       "data":{
          "least_operating_space_bytes_log_server":0,

--- a/fdbserver/BlobManager.actor.cpp
+++ b/fdbserver/BlobManager.actor.cpp
@@ -1352,6 +1352,21 @@ ACTOR Future<Void> blobWorkerRecruiter(
 	}
 }
 
+ACTOR Future<Void> haltBlobGranules(BlobManagerData* bmData) {
+	std::vector<BlobWorkerInterface> blobWorkers = wait(getBlobWorkers(bmData->db));
+	std::vector<Future<Void>> deregisterBlobWorkers;
+	for (auto& worker : blobWorkers) {
+		printf("BM: sending halt to BW %s\n", worker.myId.toString().c_str());
+		// TODO: send a special req to blob workers so they clean up granules/CFs
+		bmData->addActor.send(
+		    brokenPromiseToNever(worker.haltBlobWorker.getReply(HaltBlobWorkerRequest(bmData->epoch, bmData->id))));
+		deregisterBlobWorkers.emplace_back(deregisterBlobWorker(bmData, worker));
+	}
+	waitForAll(deregisterBlobWorkers);
+
+	return Void();
+}
+
 ACTOR Future<Void> blobManager(BlobManagerInterface bmInterf,
                                Reference<AsyncVar<ServerDBInfo> const> dbInfo,
                                int64_t epoch) {
@@ -1413,6 +1428,13 @@ ACTOR Future<Void> blobManager(BlobManagerInterface bmInterf,
 			when(HaltBlobManagerRequest req = waitNext(bmInterf.haltBlobManager.getFuture())) {
 				req.reply.send(Void());
 				TraceEvent("BlobManagerHalted", bmInterf.id()).detail("ReqID", req.requesterID);
+				break;
+			}
+			when(state HaltBlobGranulesRequest req = waitNext(bmInterf.haltBlobGranules.getFuture())) {
+				printf("BM: got haltBlobGranules\n");
+				wait(haltBlobGranules(&self));
+				req.reply.send(Void());
+				TraceEvent("BlobGranulesHalted", bmInterf.id()).detail("ReqID", req.requesterID);
 				break;
 			}
 			when(wait(collection)) {

--- a/fdbserver/BlobManager.actor.cpp
+++ b/fdbserver/BlobManager.actor.cpp
@@ -1356,7 +1356,6 @@ ACTOR Future<Void> haltBlobGranules(BlobManagerData* bmData) {
 	std::vector<BlobWorkerInterface> blobWorkers = wait(getBlobWorkers(bmData->db));
 	std::vector<Future<Void>> deregisterBlobWorkers;
 	for (auto& worker : blobWorkers) {
-		printf("BM: sending halt to BW %s\n", worker.myId.toString().c_str());
 		// TODO: send a special req to blob workers so they clean up granules/CFs
 		bmData->addActor.send(
 		    brokenPromiseToNever(worker.haltBlobWorker.getReply(HaltBlobWorkerRequest(bmData->epoch, bmData->id))));
@@ -1431,7 +1430,6 @@ ACTOR Future<Void> blobManager(BlobManagerInterface bmInterf,
 				break;
 			}
 			when(state HaltBlobGranulesRequest req = waitNext(bmInterf.haltBlobGranules.getFuture())) {
-				printf("BM: got haltBlobGranules\n");
 				wait(haltBlobGranules(&self));
 				req.reply.send(Void());
 				TraceEvent("BlobGranulesHalted", bmInterf.id()).detail("ReqID", req.requesterID);

--- a/fdbserver/BlobManagerInterface.h
+++ b/fdbserver/BlobManagerInterface.h
@@ -53,15 +53,13 @@ struct HaltBlobManagerRequest {
 	constexpr static FileIdentifier file_identifier = 4149140;
 	UID requesterID;
 	ReplyPromise<Void> reply;
-	bool haltBlobGranules;
 
 	HaltBlobManagerRequest() {}
-	explicit HaltBlobManagerRequest(UID uid, bool haltBlobGranules = false)
-	  : requesterID(uid), haltBlobGranules(haltBlobGranules) {}
+	explicit HaltBlobManagerRequest(UID uid) : requesterID(uid) {}
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, requesterID, reply, haltBlobGranules);
+		serializer(ar, requesterID, reply);
 	}
 };
 

--- a/fdbserver/BlobManagerInterface.h
+++ b/fdbserver/BlobManagerInterface.h
@@ -30,6 +30,7 @@ struct BlobManagerInterface {
 	constexpr static FileIdentifier file_identifier = 369169;
 	RequestStream<ReplyPromise<Void>> waitFailure;
 	RequestStream<struct HaltBlobManagerRequest> haltBlobManager;
+	RequestStream<struct HaltBlobGranulesRequest> haltBlobGranules;
 	struct LocalityData locality;
 	UID myId;
 
@@ -44,7 +45,7 @@ struct BlobManagerInterface {
 
 	template <class Archive>
 	void serialize(Archive& ar) {
-		serializer(ar, waitFailure, haltBlobManager, locality, myId);
+		serializer(ar, waitFailure, haltBlobManager, haltBlobGranules, locality, myId);
 	}
 };
 
@@ -52,9 +53,25 @@ struct HaltBlobManagerRequest {
 	constexpr static FileIdentifier file_identifier = 4149140;
 	UID requesterID;
 	ReplyPromise<Void> reply;
+	bool haltBlobGranules;
 
 	HaltBlobManagerRequest() {}
-	explicit HaltBlobManagerRequest(UID uid) : requesterID(uid) {}
+	explicit HaltBlobManagerRequest(UID uid, bool haltBlobGranules = false)
+	  : requesterID(uid), haltBlobGranules(haltBlobGranules) {}
+
+	template <class Ar>
+	void serialize(Ar& ar) {
+		serializer(ar, requesterID, reply, haltBlobGranules);
+	}
+};
+
+struct HaltBlobGranulesRequest {
+	constexpr static FileIdentifier file_identifier = 904267;
+	UID requesterID;
+	ReplyPromise<Void> reply;
+
+	HaltBlobGranulesRequest() {}
+	explicit HaltBlobGranulesRequest(UID uid) : requesterID(uid) {}
 
 	template <class Ar>
 	void serialize(Ar& ar) {

--- a/fdbserver/BlobWorker.actor.cpp
+++ b/fdbserver/BlobWorker.actor.cpp
@@ -2890,6 +2890,8 @@ ACTOR Future<Void> blobWorker(BlobWorkerInterface bwInterf,
 				self->addActor.send(handleRangeAssign(self, granuleToReassign, true));
 			}
 			when(HaltBlobWorkerRequest req = waitNext(bwInterf.haltBlobWorker.getFuture())) {
+				printf("BW %s got halt request\n", self->id.toString().c_str());
+
 				req.reply.send(Void());
 				if (self->managerEpochOk(req.managerEpoch)) {
 					TraceEvent("BlobWorkerHalted", self->id)

--- a/fdbserver/BlobWorker.actor.cpp
+++ b/fdbserver/BlobWorker.actor.cpp
@@ -2890,8 +2890,6 @@ ACTOR Future<Void> blobWorker(BlobWorkerInterface bwInterf,
 				self->addActor.send(handleRangeAssign(self, granuleToReassign, true));
 			}
 			when(HaltBlobWorkerRequest req = waitNext(bwInterf.haltBlobWorker.getFuture())) {
-				printf("BW %s got halt request\n", self->id.toString().c_str());
-
 				req.reply.send(Void());
 				if (self->managerEpochOk(req.managerEpoch)) {
 					TraceEvent("BlobWorkerHalted", self->id)

--- a/fdbserver/ClusterController.actor.cpp
+++ b/fdbserver/ClusterController.actor.cpp
@@ -5364,16 +5364,18 @@ ACTOR Future<Void> watchBlobGranulesConfigKey(ClusterControllerData* self) {
 
 	loop {
 		try {
+			tr->reset();
 			tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
 			tr->setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
+
 			state Future<Void> watch = tr->watch(blobGranuleConfigKey);
 			wait(tr->commit());
 			wait(watch);
 
 			tr->reset();
-
 			tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
 			tr->setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
+
 			Optional<Value> blobConfig = wait(tr->get(blobGranuleConfigKey));
 			if (blobConfig.present()) {
 				self->db.blobGranulesEnabled.set(blobConfig.get() == LiteralStringRef("1"));

--- a/fdbserver/ClusterController.actor.cpp
+++ b/fdbserver/ClusterController.actor.cpp
@@ -5399,12 +5399,12 @@ ACTOR Future<Void> monitorBlobManager(ClusterControllerData* self) {
 					}
 				}
 			}
-		} else {
-			wait(watchConfigChange);
+		} else if (self->db.config.blobGranulesEnabled) {
 			// if there is no blob manager present but blob granules are now enabled, recruit a BM
-			if (self->db.config.blobGranulesEnabled) {
-				wait(startBlobManager(self));
-			}
+			wait(startBlobManager(self));
+		} else {
+			// if there is no blob manager present and blob granules are disabled, wait for a config change
+			wait(watchConfigChange);
 		}
 	}
 }

--- a/fdbserver/SimulatedCluster.actor.cpp
+++ b/fdbserver/SimulatedCluster.actor.cpp
@@ -2021,7 +2021,7 @@ void setupSimulatedSystem(std::vector<Future<Void>>* systemActors,
 		// TODO: caching disabled for this merge
 		int storageCacheMachines = dc == 0 ? 1 : 0;
 		int blobWorkerMachines = 0;
-		if (CLIENT_KNOBS->ENABLE_BLOB_GRANULES) {
+		if (simconfig.db.blobGranulesEnabled) {
 			int blobWorkerProcesses = 1 + deterministicRandom()->randomInt(0, NUM_EXTRA_BW_MACHINES + 1);
 			blobWorkerMachines = std::max(1, blobWorkerProcesses / processesPerMachine);
 		}

--- a/fdbserver/SimulatedCluster.actor.cpp
+++ b/fdbserver/SimulatedCluster.actor.cpp
@@ -263,6 +263,9 @@ class TestConfig {
 					configDBType = configDBTypeFromString(value);
 				}
 			}
+			if (attrib == "blobGranulesEnabled") {
+				blobGranulesEnabled = strcmp(value.c_str(), "true") == 0;
+			}
 		}
 
 		ifs.close();
@@ -297,6 +300,7 @@ public:
 	Optional<bool> generateFearless, buggify;
 	Optional<int> datacenters, desiredTLogCount, commitProxyCount, grvProxyCount, resolverCount, storageEngineType,
 	    stderrSeverity, machineCount, processesPerMachine, coordinators;
+	bool blobGranulesEnabled = false;
 	Optional<std::string> config;
 
 	ConfigDBType getConfigDBType() const { return configDBType; }
@@ -348,7 +352,8 @@ public:
 		    .add("processesPerMachine", &processesPerMachine)
 		    .add("coordinators", &coordinators)
 		    .add("configDB", &configDBType)
-		    .add("extraMachineCountDC", &extraMachineCountDC);
+		    .add("extraMachineCountDC", &extraMachineCountDC)
+		    .add("blobGranulesEnabled", &blobGranulesEnabled);
 		try {
 			auto file = toml::parse(testFile);
 			if (file.contains("configuration") && toml::find(file, "configuration").is_table()) {
@@ -2021,7 +2026,7 @@ void setupSimulatedSystem(std::vector<Future<Void>>* systemActors,
 		// TODO: caching disabled for this merge
 		int storageCacheMachines = dc == 0 ? 1 : 0;
 		int blobWorkerMachines = 0;
-		if (simconfig.db.blobGranulesEnabled) {
+		if (testConfig.blobGranulesEnabled) {
 			int blobWorkerProcesses = 1 + deterministicRandom()->randomInt(0, NUM_EXTRA_BW_MACHINES + 1);
 			blobWorkerMachines = std::max(1, blobWorkerProcesses / processesPerMachine);
 		}

--- a/fdbserver/Status.actor.cpp
+++ b/fdbserver/Status.actor.cpp
@@ -797,7 +797,7 @@ ACTOR static Future<JsonBuilderObject> processStatusFetcher(
 		roles.addRole("ratekeeper", db->get().ratekeeper.get());
 	}
 
-	if (CLIENT_KNOBS->ENABLE_BLOB_GRANULES && db->get().blobManager.present()) {
+	if (configuration.present() && configuration.get().blobGranulesEnabled && db->get().blobManager.present()) {
 		roles.addRole("blob_manager", db->get().blobManager.get());
 	}
 
@@ -864,7 +864,7 @@ ACTOR static Future<JsonBuilderObject> processStatusFetcher(
 		wait(yield());
 	}
 
-	if (CLIENT_KNOBS->ENABLE_BLOB_GRANULES) {
+	if (configuration.present() && configuration.get().blobGranulesEnabled) {
 		for (auto blobWorker : blobWorkers) {
 			roles.addRole("blob_worker", blobWorker);
 			wait(yield());
@@ -2890,7 +2890,7 @@ ACTOR Future<StatusReply> clusterGetStatus(
 			    errorOr(getGrvProxiesAndMetrics(db, address_workers));
 			state Future<ErrorOr<std::vector<BlobWorkerInterface>>> blobWorkersFuture;
 
-			if (CLIENT_KNOBS->ENABLE_BLOB_GRANULES) {
+			if (configuration.present() && configuration.get().blobGranulesEnabled) {
 				blobWorkersFuture = errorOr(timeoutError(getBlobWorkers(cx, true), 5.0));
 			}
 
@@ -3011,7 +3011,7 @@ ACTOR Future<StatusReply> clusterGetStatus(
 			}
 
 			// ...also blob workers
-			if (CLIENT_KNOBS->ENABLE_BLOB_GRANULES) {
+			if (configuration.present() && configuration.get().blobGranulesEnabled) {
 				ErrorOr<std::vector<BlobWorkerInterface>> _blobWorkers = wait(blobWorkersFuture);
 				if (_blobWorkers.present()) {
 					blobWorkers = _blobWorkers.get();

--- a/fdbserver/workloads/ConsistencyCheck.actor.cpp
+++ b/fdbserver/workloads/ConsistencyCheck.actor.cpp
@@ -296,7 +296,7 @@ struct ConsistencyCheckWorkload : TestWorkload {
 					wait(::success(self->checkForExtraDataStores(cx, self)));
 
 					// Check blob workers are operating as expected
-					if (CLIENT_KNOBS->ENABLE_BLOB_GRANULES) {
+					if (configuration.blobGranulesEnabled) {
 						bool blobWorkersCorrect = wait(self->checkBlobWorkers(cx, configuration, self));
 						if (!blobWorkersCorrect)
 							self->testFailure("Blob workers incorrect");
@@ -2352,7 +2352,7 @@ struct ConsistencyCheckWorkload : TestWorkload {
 		}
 
 		// Check BlobManager
-		if (CLIENT_KNOBS->ENABLE_BLOB_GRANULES && db.blobManager.present() &&
+		if (configuration.&& db.blobManager.present() &&
 		    (!nonExcludedWorkerProcessMap.count(db.blobManager.get().address()) ||
 		     nonExcludedWorkerProcessMap[db.blobManager.get().address()].processClass.machineClassFitness(
 		         ProcessClass::BlobManager) > fitnessLowerBound)) {

--- a/fdbserver/workloads/ConsistencyCheck.actor.cpp
+++ b/fdbserver/workloads/ConsistencyCheck.actor.cpp
@@ -2352,7 +2352,7 @@ struct ConsistencyCheckWorkload : TestWorkload {
 		}
 
 		// Check BlobManager
-		if (configuration.&& db.blobManager.present() &&
+		if (config.blobGranulesEnabled && db.blobManager.present() &&
 		    (!nonExcludedWorkerProcessMap.count(db.blobManager.get().address()) ||
 		     nonExcludedWorkerProcessMap[db.blobManager.get().address()].processClass.machineClassFitness(
 		         ProcessClass::BlobManager) > fitnessLowerBound)) {

--- a/tests/fast/BlobGranuleCorrectness.toml
+++ b/tests/fast/BlobGranuleCorrectness.toml
@@ -1,3 +1,6 @@
+[configuration]
+blobGranulesEnabled = true 
+
 [[test]]
 testTitle = 'BlobGranuleCorrectnessTest'
 

--- a/tests/fast/BlobGranuleCorrectnessClean.toml
+++ b/tests/fast/BlobGranuleCorrectnessClean.toml
@@ -1,3 +1,6 @@
+[configuration]
+blobGranulesEnabled = true
+
 [[test]]
 testTitle = 'BlobGranuleCorrectnessCleanTest'
 

--- a/tests/fast/BlobGranuleCycle.toml
+++ b/tests/fast/BlobGranuleCycle.toml
@@ -1,3 +1,6 @@
+[configuration]
+blobGranulesEnabled = true 
+
 [[test]]
 testTitle = 'BlobGranuleCycle'
 

--- a/tests/fast/BlobGranuleCycleClean.toml
+++ b/tests/fast/BlobGranuleCycleClean.toml
@@ -1,3 +1,6 @@
+[configuration]
+blobGranulesEnabled = true 
+
 [[test]]
 testTitle = 'BlobGranuleCycleClean'
 

--- a/tests/slow/BlobGranuleCorrectnessLarge.toml
+++ b/tests/slow/BlobGranuleCorrectnessLarge.toml
@@ -1,3 +1,6 @@
+[configuration]
+blobGranulesEnabled = true 
+
 [[test]]
 testTitle = 'BlobGranuleCorrectnessLargeTest'
 

--- a/tests/slow/BlobGranuleCorrectnessLargeClean.toml
+++ b/tests/slow/BlobGranuleCorrectnessLargeClean.toml
@@ -1,3 +1,6 @@
+[configuration]
+blobGranulesEnabled = true 
+
 [[test]]
 testTitle = 'BlobGranuleCorrectnessLargeCleanTest'
 


### PR DESCRIPTION
# Summary
This change allows us to use the CLI to dynamically turn on/off blob granules. Specifically, the configure command is
```
configure blob_granules_enabled=1
```
By default, blob granules are **disabled**.

# Testing
## Simulation
Non-blob tests (w/ config turned off): 50k tests passed
Blob tests (w/ config turned on): approximately same passing rate as `blob_integration`

## Locally
Verified that when the config is disabled by default, blob processes won't be recruited until the configure command is issued. Also verified that you can teardown easily by disabling the option.

Verified that when the config is enabled by default, blob processes are recruited when the database is started.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
