### PR TITLE
Modify parameters of ApiCorrectnessSwitchover test to avoid out of memory errors (release-7.0)

### DIFF
--- a/tests/slow/ApiCorrectnessSwitchover.toml
+++ b/tests/slow/ApiCorrectnessSwitchover.toml
@@ -9,15 +9,15 @@ runSetup = true
 
     [[test.workload]]
     testName = 'ApiCorrectness'
-    numKeys = 5000
+    numKeys = 2500
     onlyLowerCase = true
     shortKeysRatio = 0.5
     minShortKeyLength = 1
     maxShortKeyLength = 3
     minLongKeyLength = 1
-    maxLongKeyLength = 128
+    maxLongKeyLength = 64
     minValueLength = 1
-    maxValueLength = 1000
+    maxValueLength = 200
     numGets = 1000
     numGetRanges = 100
     numGetRangeSelectors = 100


### PR DESCRIPTION
This is a cherry-pick of #6102.

The ApiCorrectnessSwitchover test would very rarely (1/100K for just this test) run out of memory. This reduces some of the parameters in the test to try to use less memory.

Passed 10K targeted correctness of modified test.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
