### PR TITLE
Resolver saves shardChanged in recent state transactions

### DIFF
--- a/fdbserver/CommitProxyServer.actor.cpp
+++ b/fdbserver/CommitProxyServer.actor.cpp
@@ -1524,7 +1524,7 @@ ACTOR Future<Void> reply(CommitBatchContext* self) {
 	// client may get a commit version that the master is not aware of, and next GRV request may get a version less than
 	// self->committedVersion.
 	TEST(pProxyCommitData->committedVersion.get() > self->commitVersion); // later version was reported committed first
-	if (self->commitVersion >= pProxyCommitData->committedVersion.get()) {
+	if (self->commitVersion >= pProxyCommitData->committedVersion.get() || SERVER_KNOBS->TLOG_NEW_INTERFACE) {
 		wait(pProxyCommitData->master.reportLiveCommittedVersion.getReply(
 		    ReportRawCommittedVersionRequest(self->commitVersion,
 		                                     self->lockedAfter,

--- a/fdbserver/Resolver.actor.cpp
+++ b/fdbserver/Resolver.actor.cpp
@@ -18,6 +18,8 @@
  * limitations under the License.
  */
 
+#include <stdint.h>
+
 #include "fdbclient/FDBTypes.h"
 #include "fdbclient/NativeAPI.actor.h"
 #include "fdbclient/Notified.h"
@@ -50,6 +52,61 @@ struct ProxyRequestsInfo {
 	ProxyRequestsInfo() = default;
 };
 
+class RecentStateTransactionsInfo {
+public:
+	RecentStateTransactionsInfo() = default;
+
+	// Erases state transactions up to the given version (inclusive) and returns
+	// the number of bytes for the erased mutations.
+	int64_t eraseUpTo(Version oldestVersion) {
+		recentStateTransactions.erase(recentStateTransactions.begin(),
+		                              recentStateTransactions.upper_bound(oldestVersion));
+
+		int64_t stateBytes = 0;
+		while (recentStateTransactionSizes.size() && recentStateTransactionSizes.front().first <= oldestVersion) {
+			stateBytes += recentStateTransactionSizes.front().second;
+			recentStateTransactionSizes.pop_front();
+		}
+		return stateBytes;
+	}
+
+	// Adds state transactions between two versions to the reply message.
+	// Returns if shardChanged has ever happened for these versions.
+	bool addStateTransactions(ResolveTransactionBatchReply* reply, Version firstUnseenVersion, Version commitVersion) {
+		bool shardChanged = false;
+		auto stateTransactionItr = recentStateTransactions.lower_bound(firstUnseenVersion);
+		auto endItr = recentStateTransactions.lower_bound(commitVersion);
+		for (; stateTransactionItr != endItr; ++stateTransactionItr) {
+			shardChanged = shardChanged || stateTransactionItr->value.first;
+			reply->stateMutations.push_back(reply->arena, stateTransactionItr->value.second);
+			reply->arena.dependsOn(stateTransactionItr->value.second.arena());
+		}
+		return shardChanged;
+	}
+
+	bool empty() const { return recentStateTransactionSizes.empty(); }
+	uint32_t size() const { return recentStateTransactionSizes.size(); }
+
+	// Returns the first/smallest version of the state transactions.
+	Version firstVersion() const { return recentStateTransactionSizes.front().first; }
+
+	void addVersionBytes(Version commitVersion, int64_t stateBytes) {
+		recentStateTransactionSizes.emplace_back(commitVersion, stateBytes);
+	}
+
+	// Returns the reference to the pair of (shardChanged, stateMutations) for the given version
+	std::pair<bool, Standalone<VectorRef<StateTransactionRef>>>& getStateTransactionsRef(Version commitVersion) {
+		return recentStateTransactions[commitVersion];
+	}
+
+private:
+	// Commit version to a pair of (shardChanged, stateMutations).
+	Map<Version, std::pair<bool, Standalone<VectorRef<StateTransactionRef>>>> recentStateTransactions;
+
+	// Only keep versions with non-zero size state transactions.
+	Deque<std::pair<Version, int64_t>> recentStateTransactionSizes;
+};
+
 struct Resolver : ReferenceCounted<Resolver> {
 	const UID dbgid;
 	const int commitProxyCount, resolverCount;
@@ -60,8 +117,7 @@ struct Resolver : ReferenceCounted<Resolver> {
 	// very first ResolveTransactionBatchRequest.
 	ptxn::TLogGroupVersionTracker versionTracker;
 
-	Map<Version, Standalone<VectorRef<StateTransactionRef>>> recentStateTransactions;
-	Deque<std::pair<Version, int64_t>> recentStateTransactionSizes;
+	RecentStateTransactionsInfo recentStateTransactionsInfo;
 	AsyncVar<int64_t> totalStateBytes;
 	AsyncTrigger checkNeededVersion;
 	std::map<NetworkAddress, ProxyRequestsInfo> proxyInfoMap;
@@ -149,17 +205,17 @@ ACTOR Future<Void> resolveBatch(Reference<Resolver> self, ResolveTransactionBatc
 	}
 
 	/*TraceEvent("ResolveBatchStart", self->dbgid).detail("From", proxyAddress).detail("Version", req.version).detail("PrevVersion", req.prevVersion).detail("StateTransactions", req.txnStateTransactions.size())
-	    .detail("RecentStateTransactions", self->recentStateTransactionSizes.size()).detail("LastVersion",
-	   proxyInfo.lastVersion).detail("FirstVersion", self->recentStateTransactionSizes.empty() ? -1 :
-	   self->recentStateTransactionSizes.front().first) .detail("ResolverVersion", self->version.get());*/
+	    .detail("RecentStateTransactions", self->recentStateTransactionsInfo.size()).detail("LastVersion",
+	   proxyInfo.lastVersion).detail("FirstVersion", self->recentStateTransactionsInfo.empty() ? -1 :
+	   self->recentStateTransactionsInfo.firstVersion()) .detail("ResolverVersion", self->version.get());*/
 
 	while (self->totalStateBytes.get() > SERVER_KNOBS->RESOLVER_STATE_MEMORY_LIMIT &&
-	       self->recentStateTransactionSizes.size() &&
-	       proxyInfo.lastVersion > self->recentStateTransactionSizes.front().first &&
+	       self->recentStateTransactionsInfo.size() &&
+	       proxyInfo.lastVersion > self->recentStateTransactionsInfo.firstVersion() &&
 	       req.version > self->neededVersion.get()) {
-		/*TraceEvent("ResolveBatchDelay").detail("From", proxyAddress).detail("StateBytes", self->totalStateBytes.get()).detail("RecentStateTransactionSize", self->recentStateTransactionSizes.size())
+		/*TraceEvent("ResolveBatchDelay").detail("From", proxyAddress).detail("StateBytes", self->totalStateBytes.get()).detail("RecentStateTransactionSize", self->recentStateTransactionsInfo.size())
 		    .detail("LastVersion", proxyInfo.lastVersion).detail("RequestVersion", req.version).detail("NeededVersion",
-		   self->neededVersion.get()) .detail("RecentStateVer", self->recentStateTransactions.begin()->key);*/
+		   self->neededVersion.get()) .detail("RecentStateVer", self->recentStateTransactionsInfo.firstVersion());*/
 
 		wait(self->totalStateBytes.onChange() || self->neededVersion.onChange());
 	}
@@ -169,8 +225,8 @@ ACTOR Future<Void> resolveBatch(Reference<Resolver> self, ResolveTransactionBatc
 	}
 
 	loop {
-		if (self->recentStateTransactionSizes.size() &&
-		    proxyInfo.lastVersion <= self->recentStateTransactionSizes.front().first) {
+		if (self->recentStateTransactionsInfo.size() &&
+		    proxyInfo.lastVersion <= self->recentStateTransactionsInfo.firstVersion()) {
 			self->neededVersion.set(std::max(self->neededVersion.get(), req.prevVersion));
 		}
 
@@ -244,7 +300,8 @@ ACTOR Future<Void> resolveBatch(Reference<Resolver> self, ResolveTransactionBatc
 		ASSERT(req.prevVersion >= 0 ||
 		       req.txnStateTransactions.size() == 0); // The master's request should not have any state transactions
 
-		auto& stateTransactions = self->recentStateTransactions[req.version];
+		auto& stateTransactionsPair = self->recentStateTransactionsInfo.getStateTransactionsRef(req.version);
+		auto& stateTransactions = stateTransactionsPair.second;
 		int64_t stateMutations = 0;
 		int64_t stateBytes = 0;
 		LogPushData toCommit(self->logSystem); // For accumulating private mutations
@@ -288,17 +345,31 @@ ACTOR Future<Void> resolveBatch(Reference<Resolver> self, ResolveTransactionBatc
 			TEST(self->forceRecovery); // Resolver detects forced recovery
 		}
 
+		self->resolvedStateTransactions += req.txnStateTransactions.size();
+		self->resolvedStateMutations += stateMutations;
+		self->resolvedStateBytes += stateBytes;
+
+		if (stateBytes > 0)
+			self->recentStateTransactionsInfo.addVersionBytes(req.version, stateBytes);
+
+		ASSERT(req.version >= firstUnseenVersion);
+		ASSERT(firstUnseenVersion >= self->debugMinRecentStateVersion);
+
+		TEST(firstUnseenVersion == req.version); // Resolver first unseen version is current version
+
+		bool shardChanged =
+		    self->recentStateTransactionsInfo.addStateTransactions(&reply, firstUnseenVersion, req.version);
+
 		// Update group versions
 		std::set<ptxn::TLogGroupID> writtenGroups; // TLog groups been written
 		if (SERVER_KNOBS->TLOG_NEW_INTERFACE && req.prevVersion >= 0) { // Not first request
 			writtenGroups.insert(req.updatedGroups.begin(), req.updatedGroups.end());
 			auto& more = toCommit.getWrittenTLogGroups();
 			writtenGroups.insert(more.begin(), more.end());
-			// TODO(jingyu): shardChange could happen in the txnStateTransactions from
-			// earlier versions, so need to take those into account--scanning through
-			// any previous versions that are sent back in txnStateTransactions.
+			stateTransactionsPair.first = toCommit.isShardChanged();
+			shardChanged = shardChanged || toCommit.isShardChanged();
 			reply.previousCommitVersions = self->versionTracker.updateGroups(
-			    writtenGroups, req.version, toCommit.isShardChanged() ? UpdateAllGroups::True : UpdateAllGroups::False);
+			    writtenGroups, req.version, shardChanged ? UpdateAllGroups::True : UpdateAllGroups::False);
 		}
 
 		// Adds private mutation messages to the reply message.
@@ -319,26 +390,7 @@ ACTOR Future<Void> resolveBatch(Reference<Resolver> self, ResolveTransactionBatc
 			}
 		}
 
-		self->resolvedStateTransactions += req.txnStateTransactions.size();
-		self->resolvedStateMutations += stateMutations;
-		self->resolvedStateBytes += stateBytes;
-
-		if (stateBytes > 0)
-			self->recentStateTransactionSizes.emplace_back(req.version, stateBytes);
-
-		ASSERT(req.version >= firstUnseenVersion);
-		ASSERT(firstUnseenVersion >= self->debugMinRecentStateVersion);
-
-		TEST(firstUnseenVersion == req.version); // Resolver first unseen version is current version
-
-		auto stateTransactionItr = self->recentStateTransactions.lower_bound(firstUnseenVersion);
-		auto endItr = self->recentStateTransactions.lower_bound(req.version);
-		for (; stateTransactionItr != endItr; ++stateTransactionItr) {
-			reply.stateMutations.push_back(reply.arena, stateTransactionItr->value);
-			reply.arena.dependsOn(stateTransactionItr->value.arena());
-		}
-
-		//TraceEvent("ResolveBatch", self->dbgid).detail("PrevVersion", req.prevVersion).detail("Version", req.version).detail("StateTransactionVersions", self->recentStateTransactionSizes.size()).detail("StateBytes", stateBytes).detail("FirstVersion", self->recentStateTransactionSizes.empty() ? -1 : self->recentStateTransactionSizes.front().first).detail("StateMutationsIn", req.txnStateTransactions.size()).detail("StateMutationsOut", reply.stateMutations.size()).detail("From", proxyAddress);
+		//TraceEvent("ResolveBatch", self->dbgid).detail("PrevVersion", req.prevVersion).detail("Version", req.version).detail("StateTransactionVersions", self->recentStateTransactionsInfo.size()).detail("StateBytes", stateBytes).detail("FirstVersion", self->recentStateTransactionsInfo.empty() ? -1 : self->recentStateTransactionsInfo.firstVersion()).detail("StateMutationsIn", req.txnStateTransactions.size()).detail("StateMutationsOut", reply.stateMutations.size()).detail("From", proxyAddress);
 
 		ASSERT(!proxyInfo.outstandingBatches.empty());
 		ASSERT(self->proxyInfoMap.size() <= self->commitProxyCount + 1);
@@ -363,16 +415,11 @@ ACTOR Future<Void> resolveBatch(Reference<Resolver> self, ResolveTransactionBatc
 		bool anyPopped = false;
 		if (firstUnseenVersion <= oldestProxyVersion && self->proxyInfoMap.size() == self->commitProxyCount + 1) {
 			TEST(true); // Deleting old state transactions
-			self->recentStateTransactions.erase(self->recentStateTransactions.begin(),
-			                                    self->recentStateTransactions.upper_bound(oldestProxyVersion));
+			int64_t erasedBytes = self->recentStateTransactionsInfo.eraseUpTo(oldestProxyVersion);
 			self->debugMinRecentStateVersion = oldestProxyVersion + 1;
 
-			while (self->recentStateTransactionSizes.size() &&
-			       self->recentStateTransactionSizes.front().first <= oldestProxyVersion) {
-				anyPopped = true;
-				stateBytes -= self->recentStateTransactionSizes.front().second;
-				self->recentStateTransactionSizes.pop_front();
-			}
+			anyPopped = erasedBytes == 0;
+			stateBytes -= erasedBytes;
 		}
 
 		self->version.set(req.version);

--- a/fdbserver/Resolver.actor.cpp
+++ b/fdbserver/Resolver.actor.cpp
@@ -80,6 +80,9 @@ public:
 		bool shardChanged = initialShardChanged;
 		auto stateTransactionItr = recentStateTransactions.lower_bound(firstUnseenVersion);
 		auto endItr = recentStateTransactions.lower_bound(commitVersion);
+		// Resolver only sends back prior state txns back, because the proxy
+		// sends this request has them and will apply them via applyMetadataToCommittedTransactions();
+		// and other proxies will get this version's state txns as a prior version.
 		for (; stateTransactionItr != endItr; ++stateTransactionItr) {
 			shardChanged = shardChanged || stateTransactionItr->value.first;
 			reply->stateMutations.push_back(reply->arena, stateTransactionItr->value.second);

--- a/fdbserver/TLogGroup.actor.cpp
+++ b/fdbserver/TLogGroup.actor.cpp
@@ -195,7 +195,7 @@ TLogGroupRef TLogGroupCollection::assignStorageTeam(ptxn::StorageTeamID teamId, 
 	ASSERT(group.isValid());
 	storageTeamToTLogGroupMap[teamId] = group;
 	group->assignStorageTeam(teamId);
-	TraceEvent(SevDebug, "TLogGroupAssignTeam").detail("StorageTeamId", teamId).detail("TLogGroupId", groupId);
+	// TraceEvent(SevDebug, "TLogGroupAssignTeam").detail("StorageTeamId", teamId).detail("TLogGroupId", groupId);
 	return group;
 }
 


### PR DESCRIPTION
Before setting private mutations in the reply, addStateTransactions() tells us
if shard change happened in previous versions. In this way, the detection of
shard change becomes accurate.

### Tests

non-PTXN correctness passed:

20211209-013138-jzhou-292915832167e63c             compressed=True data_size=20382368 duration=5371700 ended=100004 fail_fast=10 max_runs=100000 pass=100004 priority=100 remaining=0 runtime=1:09:49 sanity=False started=100114 stopped=20211209-024127 submitted=20211209-013138 timeout=5400 username=jzhou

PTXN test passed (with/without proxy-to-tlog group broadcast):

-r simulation --crash --logsize 1024MB --knob_tlog_new_interface 1 -fi off -f src/foundationdb/tests/ptxn/CycleTest.toml -b off -s 101

-r simulation --crash --logsize 1024MB --knob_tlog_new_interface 1 -fi off -f src/foundationdb/tests/ptxn/CycleTest.toml -b off -s 101 --knob_broadcast_tlog_groups 0


# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
