### PR TITLE
Add ClientDescription field for client processes to identify the client logging an event.

### DIFF
--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -1797,6 +1797,8 @@ Database Database::createDatabase(Reference<IClusterConnectionRecord> connRecord
 	if (!g_network)
 		throw network_not_setup();
 
+	ASSERT(TraceEvent::isNetworkThread());
+
 	platform::ImageInfo imageInfo = platform::getImageInfo();
 
 	if (connRecord) {
@@ -1808,6 +1810,12 @@ Database Database::createDatabase(Reference<IClusterConnectionRecord> connRecord
 			auto publicIP = determinePublicIPAutomatically(connRecord->getConnectionString());
 			selectTraceFormatter(networkOptions.traceFormat);
 			selectTraceClockSource(networkOptions.traceClockSource);
+			addUniversalTraceField("ClientDescription",
+			                       format("%s-%s-%" PRIu64,
+			                              networkOptions.primaryClient ? "primary" : "external",
+			                              FDB_VT_VERSION,
+			                              getTraceThreadId()));
+
 			openTraceFile(NetworkAddress(publicIP, ::getpid()),
 			              networkOptions.traceRollSize,
 			              networkOptions.traceMaxLogsSize,

--- a/flow/Trace.cpp
+++ b/flow/Trace.cpp
@@ -367,7 +367,7 @@ public:
 			fields.addField("Roles", r.rolesString);
 		}
 
-		for (auto field : universalFields) {
+		for (auto const& field : universalFields) {
 			fields.addField(field.first, field.second);
 		}
 

--- a/flow/Trace.cpp
+++ b/flow/Trace.cpp
@@ -111,6 +111,7 @@ private:
 	int64_t preopenOverflowCount;
 	std::string basename;
 	std::string logGroup;
+	std::map<std::string, std::string> universalFields;
 
 	std::string directory;
 	std::string processName;
@@ -365,6 +366,11 @@ public:
 		if (r.rolesString.size() > 0) {
 			fields.addField("Roles", r.rolesString);
 		}
+
+		for (auto field : universalFields) {
+			fields.addField(field.first, field.second);
+		}
+
 		fields.setAnnotated();
 	}
 
@@ -543,6 +549,12 @@ public:
 	void setLogGroup(const std::string& logGroup) {
 		MutexHolder holder(mutex);
 		this->logGroup = logGroup;
+	}
+
+	void addUniversalTraceField(const std::string& name, const std::string& value) {
+		MutexHolder holder(mutex);
+		ASSERT(universalFields.count(name) == 0);
+		universalFields[name] = value;
 	}
 
 	Future<Void> pingWriterThread() {
@@ -784,6 +796,10 @@ void removeTraceRole(std::string const& role) {
 
 void setTraceLogGroup(const std::string& logGroup) {
 	g_traceLog.setLogGroup(logGroup);
+}
+
+void addUniversalTraceField(const std::string& name, const std::string& value) {
+	g_traceLog.addUniversalTraceField(name, value);
 }
 
 TraceEvent::TraceEvent() : initialized(true), enabled(false), logged(true) {}
@@ -1141,11 +1157,16 @@ TraceEvent& TraceEvent::setMaxFieldLength(int maxFieldLength) {
 // or multiversion client setups and for multithreaded storage engines.
 thread_local uint64_t threadId = 0;
 
-void TraceEvent::setThreadId() {
+uint64_t getTraceThreadId() {
 	while (threadId == 0) {
 		threadId = deterministicRandom()->randomUInt64();
 	}
-	this->detail("ThreadID", threadId);
+
+	return threadId;
+}
+
+void TraceEvent::setThreadId() {
+	this->detail("ThreadID", getTraceThreadId());
 }
 
 int TraceEvent::getMaxFieldLength() const {

--- a/flow/Trace.h
+++ b/flow/Trace.h
@@ -587,6 +587,9 @@ void addTraceRole(std::string const& role);
 void removeTraceRole(std::string const& role);
 void retrieveTraceLogIssues(std::set<std::string>& out);
 void setTraceLogGroup(const std::string& role);
+void addUniversalTraceField(std::string const& name, std::string const& value);
+uint64_t getTraceThreadId();
+
 template <class T>
 class Future;
 class Void;


### PR DESCRIPTION
This is implemented using new functionality to set a universal trace field that is logged with every event. It serves to enhance the detail provided by `ThreadID` because the `ThreadID` may or may not actually identify the network thread logging an event depending on whether the event was logged on a different thread.

The client description is comprised of three parts: `<primary or external>-<release version>-<network thread ID>`. The network thread ID is the same as the field `ThreadID` that gets logged on trace events logged from the network thread.

Tested manually with a client process configured to use the multi-version client. Also passed 10K correctness.

An example of this field is shown below from a single client process:

```
<Event Severity="10" Time="1639161147.776237" DateTime="2021-12-10T18:32:27Z" Type="SetNetworkOption" ID="0000000000000000" Option="EXTERNAL_CLIENT_DIRECTORY" ThreadID="3616842950979200769" Machine="127.0.0.1:11749" LogGroup="default" ClientDescription="primary-7.1.0-12477486671085416916" />
...
<Event Severity="10" Time="1639161148.263417" DateTime="2021-12-10T18:32:28Z" Type="ClientStart" ID="0000000000000000" SourceVersion="2bee1e40305ca2370ee7cce8385cc0b7ff0687c5" Version="7.1.0" PackageName="7.1" ActualTime="1639161148" ApiVersion="620" ClientLibrary="/lib64/libfdb_c.so" ImageOffset="0x7ff216100000" Primary="1" ThreadID="12477486671085416916" Machine="127.0.0.1:11749" LogGroup="default" ClientDescription="primary-7.1.0-12477486671085416916" TrackLatestType="Original" />
```

The first event above was logged on an application thread and has a non-network thread `ThreadID`. The second event is logged from the network thread and has a thread ID component that matches the `ThreadID` field.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
