### PR TITLE
Persist txsTag in TLog

### DIFF
--- a/fdbserver/TLogServer.actor.cpp
+++ b/fdbserver/TLogServer.actor.cpp
@@ -1349,6 +1349,9 @@ ACTOR Future<Void> updateStorage(TLogData* self) {
 		wait(logData->queueCommittedVersion.whenAtLeast(nextVersion));
 		wait(delay(0, TaskPriority::UpdateStorage));
 
+		// nextVersion is the next to be read by SS, that is still on TLog
+		// this if means if there are some version will not be read by SS anymore but still persistent, then pop from
+		// disk queue.
 		if (nextVersion > logData->persistentDataVersion) {
 			wait(self->persistentDataCommitLock.take());
 			commitLockReleaser = FlowLock::Releaser(self->persistentDataCommitLock);

--- a/fdbserver/ptxn/TLogServer.actor.cpp
+++ b/fdbserver/ptxn/TLogServer.actor.cpp
@@ -793,11 +793,6 @@ void commitMessages(Reference<TLogGroupData> self,
                     StorageTeamID storageTeamId) {
 	// SOMEDAY: This method of copying messages is reasonably memory efficient, but it's still a lot of bytes copied.
 	// Find a way to do the memory allocation right as we receive the messages in the network layer.
-	if (storageTeamId == txsTeam) {
-		// TODO: persist txsStateStore data, but ignore for now since we don't
-		// handle recovery yet.
-		return;
-	}
 
 	// The structure of a message is:
 	//   | Protocol Version | Main Header | Message Header | Message |


### PR DESCRIPTION
Not sure if there is a good way to test this, could you please advise @jzhou77 . It seems the read path is from master during a global recovery, is there an easy way to do that in unit test?

joshua: 20211213-165341-haofu-eca436c7d8f0c283 

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
