### PR TITLE
Eliminate warnings in macOS and Windows CI builds.

### DIFF
--- a/bindings/c/test/mako/mako.c
+++ b/bindings/c/test/mako/mako.c
@@ -616,7 +616,7 @@ int64_t granule_start_load(const char* filename,
 	// don't seek if offset == 0
 	if (offset && fseek(fp, offset, SEEK_SET)) {
 		// if fseek was non-zero, it failed
-		fprintf(stderr, "ERROR: BG could not seek to %ld in file %s\n", offset, full_fname);
+		fprintf(stderr, "ERROR: BG could not seek to %lld in file %s\n", offset, full_fname);
 		fclose(fp);
 		return -1;
 	}
@@ -626,7 +626,7 @@ int64_t granule_start_load(const char* filename,
 	fclose(fp);
 
 	if (readSize != length) {
-		fprintf(stderr, "ERROR: BG could not read %ld bytes from file: %s\n", length, full_fname);
+		fprintf(stderr, "ERROR: BG could not read %lld bytes from file: %s\n", length, full_fname);
 		return -1;
 	}
 
@@ -637,7 +637,7 @@ int64_t granule_start_load(const char* filename,
 uint8_t* granule_get_load(int64_t loadId, void* userContext) {
 	BGLocalFileContext* context = (BGLocalFileContext*)userContext;
 	if (context->data_by_id[loadId] == 0) {
-		fprintf(stderr, "ERROR: BG loadId invalid for get_load: %ld\n", loadId);
+		fprintf(stderr, "ERROR: BG loadId invalid for get_load: %lld\n", loadId);
 		return 0;
 	}
 	return context->data_by_id[loadId];
@@ -646,7 +646,7 @@ uint8_t* granule_get_load(int64_t loadId, void* userContext) {
 void granule_free_load(int64_t loadId, void* userContext) {
 	BGLocalFileContext* context = (BGLocalFileContext*)userContext;
 	if (context->data_by_id[loadId] == 0) {
-		fprintf(stderr, "ERROR: BG loadId invalid for free_load: %ld\n", loadId);
+		fprintf(stderr, "ERROR: BG loadId invalid for free_load: %lld\n", loadId);
 	}
 	free(context->data_by_id[loadId]);
 	context->data_by_id[loadId] = 0;
@@ -1120,7 +1120,7 @@ int run_workload(FDBTransaction* transaction,
 					if (tracetimer == dotrace) {
 						fdb_error_t err;
 						tracetimer = 0;
-						snprintf(traceid, 32, "makotrace%019ld", total_xacts);
+						snprintf(traceid, 32, "makotrace%019lld", total_xacts);
 						fprintf(debugme, "DEBUG: txn tracing %s\n", traceid);
 						err = fdb_transaction_set_option(transaction,
 						                                 FDB_TR_OPTION_DEBUG_TRANSACTION_IDENTIFIER,
@@ -1284,7 +1284,7 @@ void* worker_thread(void* thread_args) {
 	}
 
 	fprintf(debugme,
-	        "DEBUG: worker_id:%d (%d) thread_id:%d (%d) database_index:%lu (tid:%lu)\n",
+	        "DEBUG: worker_id:%d (%d) thread_id:%d (%d) database_index:%lu (tid:%llu)\n",
 	        worker_id,
 	        args->num_processes,
 	        thread_id,
@@ -2251,9 +2251,9 @@ void print_stats(mako_args_t* args, mako_stats_t* stats, struct timespec* now, s
 	for (op = 0; op < MAX_OP; op++) {
 		if (args->txnspec.ops[op][OP_COUNT] > 0) {
 			uint64_t ops_total_diff = ops_total[op] - ops_total_prev[op];
-			printf("%" STR(STATS_FIELD_WIDTH) "lu ", ops_total_diff);
+			printf("%" STR(STATS_FIELD_WIDTH) "llu ", ops_total_diff);
 			if (fp) {
-				fprintf(fp, "\"%s\": %lu,", get_ops_name(op), ops_total_diff);
+				fprintf(fp, "\"%s\": %llu,", get_ops_name(op), ops_total_diff);
 			}
 			errors_diff[op] = errors_total[op] - errors_total_prev[op];
 			print_err = (errors_diff[op] > 0);
@@ -2281,7 +2281,7 @@ void print_stats(mako_args_t* args, mako_stats_t* stats, struct timespec* now, s
 		printf("%" STR(STATS_TITLE_WIDTH) "s ", "Errors");
 		for (op = 0; op < MAX_OP; op++) {
 			if (args->txnspec.ops[op][OP_COUNT] > 0) {
-				printf("%" STR(STATS_FIELD_WIDTH) "lu ", errors_diff[op]);
+				printf("%" STR(STATS_FIELD_WIDTH) "llu ", errors_diff[op]);
 				if (fp) {
 					fprintf(fp, ",\"errors\": %.2f", conflicts_diff);
 				}
@@ -2430,10 +2430,10 @@ void print_report(mako_args_t* args,
 			break;
 		}
 	}
-	printf("Total Xacts:      %8lu\n", totalxacts);
-	printf("Total Conflicts:  %8lu\n", conflicts);
-	printf("Total Errors:     %8lu\n", totalerrors);
-	printf("Overall TPS:      %8lu\n\n", totalxacts * 1000000000 / duration_nsec);
+	printf("Total Xacts:      %8llu\n", totalxacts);
+	printf("Total Conflicts:  %8llu\n", conflicts);
+	printf("Total Errors:     %8llu\n", totalerrors);
+	printf("Overall TPS:      %8llu\n\n", totalxacts * 1000000000 / duration_nsec);
 
 	if (fp) {
 		fprintf(fp, "\"results\": {");
@@ -2441,10 +2441,10 @@ void print_report(mako_args_t* args,
 		fprintf(fp, "\"totalProcesses\": %d,", args->num_processes);
 		fprintf(fp, "\"totalThreads\": %d,", args->num_threads);
 		fprintf(fp, "\"targetTPS\": %d,", args->tpsmax);
-		fprintf(fp, "\"totalXacts\": %lu,", totalxacts);
-		fprintf(fp, "\"totalConflicts\": %lu,", conflicts);
-		fprintf(fp, "\"totalErrors\": %lu,", totalerrors);
-		fprintf(fp, "\"overallTPS\": %lu,", totalxacts * 1000000000 / duration_nsec);
+		fprintf(fp, "\"totalXacts\": %llu,", totalxacts);
+		fprintf(fp, "\"totalConflicts\": %llu,", conflicts);
+		fprintf(fp, "\"totalErrors\": %llu,", totalerrors);
+		fprintf(fp, "\"overallTPS\": %llu,", totalxacts * 1000000000 / duration_nsec);
 	}
 
 	/* per-op stats */
@@ -2457,14 +2457,14 @@ void print_report(mako_args_t* args,
 	}
 	for (op = 0; op < MAX_OP; op++) {
 		if ((args->txnspec.ops[op][OP_COUNT] > 0 && op != OP_TRANSACTION) || op == OP_COMMIT) {
-			printf("%" STR(STATS_FIELD_WIDTH) "lu ", ops_total[op]);
+			printf("%" STR(STATS_FIELD_WIDTH) "llu ", ops_total[op]);
 			if (fp) {
 				if (first_op) {
 					first_op = 0;
 				} else {
 					fprintf(fp, ",");
 				}
-				fprintf(fp, "\"%s\": %lu", get_ops_name(op), ops_total[op]);
+				fprintf(fp, "\"%s\": %llu", get_ops_name(op), ops_total[op]);
 			}
 		}
 	}
@@ -2486,14 +2486,14 @@ void print_report(mako_args_t* args,
 	first_op = 1;
 	for (op = 0; op < MAX_OP; op++) {
 		if (args->txnspec.ops[op][OP_COUNT] > 0 && op != OP_TRANSACTION) {
-			printf("%" STR(STATS_FIELD_WIDTH) "lu ", errors_total[op]);
+			printf("%" STR(STATS_FIELD_WIDTH) "llu ", errors_total[op]);
 			if (fp) {
 				if (first_op) {
 					first_op = 0;
 				} else {
 					fprintf(fp, ",");
 				}
-				fprintf(fp, "\"%s\": %lu", get_ops_name(op), errors_total[op]);
+				fprintf(fp, "\"%s\": %llu", get_ops_name(op), errors_total[op]);
 			}
 		}
 	}
@@ -2511,7 +2511,7 @@ void print_report(mako_args_t* args,
 	for (op = 0; op < MAX_OP; op++) {
 		if (args->txnspec.ops[op][OP_COUNT] > 0 || op == OP_TRANSACTION || op == OP_COMMIT) {
 			if (lat_total[op]) {
-				printf("%" STR(STATS_FIELD_WIDTH) "lu ", lat_samples[op]);
+				printf("%" STR(STATS_FIELD_WIDTH) "llu ", lat_samples[op]);
 			} else {
 				printf("%" STR(STATS_FIELD_WIDTH) "s ", "N/A");
 			}
@@ -2521,7 +2521,7 @@ void print_report(mako_args_t* args,
 				} else {
 					fprintf(fp, ",");
 				}
-				fprintf(fp, "\"%s\": %lu", get_ops_name(op), lat_samples[op]);
+				fprintf(fp, "\"%s\": %llu", get_ops_name(op), lat_samples[op]);
 			}
 		}
 	}
@@ -2538,14 +2538,14 @@ void print_report(mako_args_t* args,
 			if (lat_min[op] == -1) {
 				printf("%" STR(STATS_FIELD_WIDTH) "s ", "N/A");
 			} else {
-				printf("%" STR(STATS_FIELD_WIDTH) "lu ", lat_min[op]);
+				printf("%" STR(STATS_FIELD_WIDTH) "llu ", lat_min[op]);
 				if (fp) {
 					if (first_op) {
 						first_op = 0;
 					} else {
 						fprintf(fp, ",");
 					}
-					fprintf(fp, "\"%s\": %lu", get_ops_name(op), lat_min[op]);
+					fprintf(fp, "\"%s\": %llu", get_ops_name(op), lat_min[op]);
 				}
 			}
 		}
@@ -2561,14 +2561,14 @@ void print_report(mako_args_t* args,
 	for (op = 0; op < MAX_OP; op++) {
 		if (args->txnspec.ops[op][OP_COUNT] > 0 || op == OP_TRANSACTION || op == OP_COMMIT) {
 			if (lat_total[op]) {
-				printf("%" STR(STATS_FIELD_WIDTH) "lu ", lat_total[op] / lat_samples[op]);
+				printf("%" STR(STATS_FIELD_WIDTH) "llu ", lat_total[op] / lat_samples[op]);
 				if (fp) {
 					if (first_op) {
 						first_op = 0;
 					} else {
 						fprintf(fp, ",");
 					}
-					fprintf(fp, "\"%s\": %lu", get_ops_name(op), lat_total[op] / lat_samples[op]);
+					fprintf(fp, "\"%s\": %llu", get_ops_name(op), lat_total[op] / lat_samples[op]);
 				}
 			} else {
 				printf("%" STR(STATS_FIELD_WIDTH) "s ", "N/A");
@@ -2588,14 +2588,14 @@ void print_report(mako_args_t* args,
 			if (lat_max[op] == 0) {
 				printf("%" STR(STATS_FIELD_WIDTH) "s ", "N/A");
 			} else {
-				printf("%" STR(STATS_FIELD_WIDTH) "lu ", lat_max[op]);
+				printf("%" STR(STATS_FIELD_WIDTH) "llu ", lat_max[op]);
 				if (fp) {
 					if (first_op) {
 						first_op = 0;
 					} else {
 						fprintf(fp, ",");
 					}
-					fprintf(fp, "\"%s\": %lu", get_ops_name(op), lat_max[op]);
+					fprintf(fp, "\"%s\": %llu", get_ops_name(op), lat_max[op]);
 				}
 			}
 		}
@@ -2646,14 +2646,14 @@ void print_report(mako_args_t* args,
 				} else {
 					median = (dataPoints[op][num_points[op] / 2] + dataPoints[op][num_points[op] / 2 - 1]) >> 1;
 				}
-				printf("%" STR(STATS_FIELD_WIDTH) "lu ", median);
+				printf("%" STR(STATS_FIELD_WIDTH) "llu ", median);
 				if (fp) {
 					if (first_op) {
 						first_op = 0;
 					} else {
 						fprintf(fp, ",");
 					}
-					fprintf(fp, "\"%s\": %lu", get_ops_name(op), median);
+					fprintf(fp, "\"%s\": %llu", get_ops_name(op), median);
 				}
 			} else {
 				printf("%" STR(STATS_FIELD_WIDTH) "s ", "N/A");
@@ -2676,14 +2676,14 @@ void print_report(mako_args_t* args,
 			}
 			if (lat_total[op]) {
 				point_95pct = ((float)(num_points[op]) * 0.95) - 1;
-				printf("%" STR(STATS_FIELD_WIDTH) "lu ", dataPoints[op][point_95pct]);
+				printf("%" STR(STATS_FIELD_WIDTH) "llu ", dataPoints[op][point_95pct]);
 				if (fp) {
 					if (first_op) {
 						first_op = 0;
 					} else {
 						fprintf(fp, ",");
 					}
-					fprintf(fp, "\"%s\": %lu", get_ops_name(op), dataPoints[op][point_95pct]);
+					fprintf(fp, "\"%s\": %llu", get_ops_name(op), dataPoints[op][point_95pct]);
 				}
 			} else {
 				printf("%" STR(STATS_FIELD_WIDTH) "s ", "N/A");
@@ -2706,14 +2706,14 @@ void print_report(mako_args_t* args,
 			}
 			if (lat_total[op]) {
 				point_99pct = ((float)(num_points[op]) * 0.99) - 1;
-				printf("%" STR(STATS_FIELD_WIDTH) "lu ", dataPoints[op][point_99pct]);
+				printf("%" STR(STATS_FIELD_WIDTH) "llu ", dataPoints[op][point_99pct]);
 				if (fp) {
 					if (first_op) {
 						first_op = 0;
 					} else {
 						fprintf(fp, ",");
 					}
-					fprintf(fp, "\"%s\": %lu", get_ops_name(op), dataPoints[op][point_99pct]);
+					fprintf(fp, "\"%s\": %llu", get_ops_name(op), dataPoints[op][point_99pct]);
 				}
 			} else {
 				printf("%" STR(STATS_FIELD_WIDTH) "s ", "N/A");
@@ -2736,14 +2736,14 @@ void print_report(mako_args_t* args,
 			}
 			if (lat_total[op]) {
 				point_99_9pct = ((float)(num_points[op]) * 0.999) - 1;
-				printf("%" STR(STATS_FIELD_WIDTH) "lu ", dataPoints[op][point_99_9pct]);
+				printf("%" STR(STATS_FIELD_WIDTH) "llu ", dataPoints[op][point_99_9pct]);
 				if (fp) {
 					if (first_op) {
 						first_op = 0;
 					} else {
 						fprintf(fp, ",");
 					}
-					fprintf(fp, "\"%s\": %lu", get_ops_name(op), dataPoints[op][point_99_9pct]);
+					fprintf(fp, "\"%s\": %llu", get_ops_name(op), dataPoints[op][point_99_9pct]);
 				}
 			} else {
 				printf("%" STR(STATS_FIELD_WIDTH) "s ", "N/A");

--- a/bindings/c/test/txn_size_test.c
+++ b/bindings/c/test/txn_size_test.c
@@ -67,25 +67,25 @@ void runTests(struct ResultSet* rs) {
 	fdb_transaction_set(tr, keys[i], KEY_SIZE, valueStr, VALUE_SIZE);
 	e = getSize(rs, tr, sizes + i);
 	checkError(e, "transaction get size", rs);
-	printf("size %d: %ld\n", i, sizes[i]);
+	printf("size %d: %lld\n", i, sizes[i]);
 	i++;
 
 	fdb_transaction_set(tr, keys[i], KEY_SIZE, valueStr, VALUE_SIZE);
 	e = getSize(rs, tr, sizes + i);
 	checkError(e, "transaction get size", rs);
-	printf("size %d: %ld\n", i, sizes[i]);
+	printf("size %d: %lld\n", i, sizes[i]);
 	i++;
 
 	fdb_transaction_clear(tr, keys[i], KEY_SIZE);
 	e = getSize(rs, tr, sizes + i);
 	checkError(e, "transaction get size", rs);
-	printf("size %d: %ld\n", i, sizes[i]);
+	printf("size %d: %lld\n", i, sizes[i]);
 	i++;
 
 	fdb_transaction_clear_range(tr, keys[i], KEY_SIZE, keys[i + 1], KEY_SIZE);
 	e = getSize(rs, tr, sizes + i);
 	checkError(e, "transaction get size", rs);
-	printf("size %d: %ld\n", i, sizes[i]);
+	printf("size %d: %lld\n", i, sizes[i]);
 	i++;
 
 	for (j = 0; j + 1 < i; j++) {

--- a/documentation/tutorial/tutorial.actor.cpp
+++ b/documentation/tutorial/tutorial.actor.cpp
@@ -413,7 +413,7 @@ ACTOR Future<Void> logThroughput(int64_t* v, Key* next) {
 	loop {
 		state int64_t last = *v;
 		wait(delay(1));
-		printf("throughput: %ld bytes/s, next: %s\n", *v - last, printable(*next).c_str());
+		printf("throughput: %lld bytes/s, next: %s\n", *v - last, printable(*next).c_str());
 	}
 }
 

--- a/documentation/tutorial/tutorial.actor.cpp
+++ b/documentation/tutorial/tutorial.actor.cpp
@@ -19,6 +19,7 @@
 * limitations under the License.
 */
 
+#include "contrib/fmt-8.0.1/include/fmt/format.h"
 #include "flow/flow.h"
 #include "flow/Platform.h"
 #include "flow/DeterministicRandom.h"
@@ -413,7 +414,7 @@ ACTOR Future<Void> logThroughput(int64_t* v, Key* next) {
 	loop {
 		state int64_t last = *v;
 		wait(delay(1));
-		printf("throughput: %lld bytes/s, next: %s\n", *v - last, printable(*next).c_str());
+		fmt::print("throughput: {} bytes/s, next: {}\n", *v - last, printable(*next).c_str());
 	}
 }
 

--- a/fdbbackup/backup.actor.cpp
+++ b/fdbbackup/backup.actor.cpp
@@ -3081,7 +3081,7 @@ static void addKeyRange(std::string optionValue, Standalone<VectorRef<KeyRangeRe
 
 			// Too many keys
 		default:
-			fprintf(stderr, "ERROR: Invalid key range identified with %ld keys", tokens.size());
+			fmt::print(stderr, "ERROR: Invalid key range identified with {} keys", tokens.size());
 			throw invalid_option_value();
 			break;
 		}

--- a/fdbbackup/backup.actor.cpp
+++ b/fdbbackup/backup.actor.cpp
@@ -2754,7 +2754,7 @@ ACTOR Future<Void> queryBackup(const char* name,
 			reportBackupQueryError(operationId,
 			                       result,
 			                       errorMessage =
-			                           format("the specified restorable version %ld is not valid", restoreVersion));
+			                           format("the specified restorable version %lld is not valid", restoreVersion));
 			return Void();
 		}
 		Optional<RestorableFileSet> fileSet = wait(bc->getRestoreSet(restoreVersion, keyRangesFilter));

--- a/fdbcli/AdvanceVersionCommand.actor.cpp
+++ b/fdbcli/AdvanceVersionCommand.actor.cpp
@@ -19,7 +19,7 @@
  */
 
 #include "boost/lexical_cast.hpp"
-
+#include "contrib/fmt-8.0.1/include/fmt/format.h"
 #include "fdbcli/fdbcli.actor.h"
 
 #include "fdbclient/IClientApi.h"
@@ -53,7 +53,7 @@ ACTOR Future<bool> advanceVersionCommandActor(Reference<IDatabase> db, std::vect
 						tr->set(advanceVersionSpecialKey, boost::lexical_cast<std::string>(v));
 						wait(safeThreadFutureToFuture(tr->commit()));
 					} else {
-						printf("Current read version is %lld\n", rv);
+						fmt::print("Current read version is {}\n", rv);
 						return true;
 					}
 				} catch (Error& e) {

--- a/fdbcli/AdvanceVersionCommand.actor.cpp
+++ b/fdbcli/AdvanceVersionCommand.actor.cpp
@@ -40,7 +40,7 @@ ACTOR Future<bool> advanceVersionCommandActor(Reference<IDatabase> db, std::vect
 	} else {
 		state Version v;
 		int n = 0;
-		if (sscanf(tokens[1].toString().c_str(), "%ld%n", &v, &n) != 1 || n != tokens[1].size()) {
+		if (sscanf(tokens[1].toString().c_str(), "%lld%n", &v, &n) != 1 || n != tokens[1].size()) {
 			printUsage(tokens[0]);
 			return false;
 		} else {
@@ -53,7 +53,7 @@ ACTOR Future<bool> advanceVersionCommandActor(Reference<IDatabase> db, std::vect
 						tr->set(advanceVersionSpecialKey, boost::lexical_cast<std::string>(v));
 						wait(safeThreadFutureToFuture(tr->commit()));
 					} else {
-						printf("Current read version is %ld\n", rv);
+						printf("Current read version is %lld\n", rv);
 						return true;
 					}
 				} catch (Error& e) {

--- a/fdbcli/ChangeFeedCommand.actor.cpp
+++ b/fdbcli/ChangeFeedCommand.actor.cpp
@@ -115,7 +115,7 @@ ACTOR Future<bool> changeFeedCommandActor(Database localDb, std::vector<StringRe
 		Version end = std::numeric_limits<Version>::max();
 		if (tokens.size() > 3) {
 			int n = 0;
-			if (sscanf(tokens[3].toString().c_str(), "%ld%n", &begin, &n) != 1 || n != tokens[3].size()) {
+			if (sscanf(tokens[3].toString().c_str(), "%lld%n", &begin, &n) != 1 || n != tokens[3].size()) {
 				printUsage(tokens[0]);
 				return false;
 			}
@@ -168,7 +168,7 @@ ACTOR Future<bool> changeFeedCommandActor(Database localDb, std::vector<StringRe
 		}
 		Version v;
 		int n = 0;
-		if (sscanf(tokens[3].toString().c_str(), "%ld%n", &v, &n) != 1 || n != tokens[3].size()) {
+		if (sscanf(tokens[3].toString().c_str(), "%lld%n", &v, &n) != 1 || n != tokens[3].size()) {
 			printUsage(tokens[0]);
 			return false;
 		} else {

--- a/fdbcli/StatusCommand.actor.cpp
+++ b/fdbcli/StatusCommand.actor.cpp
@@ -705,12 +705,12 @@ void printStatus(StatusObjectReader statusObj,
 										}
 									}
 									outputString += format(
-									    "  %s log epoch: %ld begin: %ld end: %s, missing "
+									    "  %s log epoch: %lld begin: %lld end: %s, missing "
 									    "log interfaces(id,address): %s\n",
 									    current ? "Current" : "Old",
 									    epoch,
 									    beginVersion,
-									    endVersion == invalidVersion ? "(unknown)" : format("%ld", endVersion).c_str(),
+									    endVersion == invalidVersion ? "(unknown)" : format("%lld", endVersion).c_str(),
 									    missing_log_interfaces.c_str());
 								}
 							}

--- a/fdbcli/fdbcli.actor.cpp
+++ b/fdbcli/fdbcli.actor.cpp
@@ -1615,7 +1615,7 @@ ACTOR Future<int> cli(CLIOptions opt, LineNoise* plinenoise) {
 					} else {
 						Version v = wait(makeInterruptable(
 						    safeThreadFutureToFuture(getTransaction(db, tr, options, intrans)->getReadVersion())));
-						printf("%ld\n", v);
+						printf("%lld\n", v);
 					}
 					continue;
 				}

--- a/fdbcli/fdbcli.actor.cpp
+++ b/fdbcli/fdbcli.actor.cpp
@@ -1615,7 +1615,7 @@ ACTOR Future<int> cli(CLIOptions opt, LineNoise* plinenoise) {
 					} else {
 						Version v = wait(makeInterruptable(
 						    safeThreadFutureToFuture(getTransaction(db, tr, options, intrans)->getReadVersion())));
-						printf("%lld\n", v);
+						fmt::print("{}\n", v);
 					}
 					continue;
 				}

--- a/fdbclient/ConfigKnobs.cpp
+++ b/fdbclient/ConfigKnobs.cpp
@@ -96,7 +96,7 @@ public:
 
 struct ToStringFunc {
 	std::string operator()(int v) const { return format("int:%d", v); }
-	std::string operator()(int64_t v) const { return format("int64_t:%ld", v); }
+	std::string operator()(int64_t v) const { return format("int64_t:%lld", v); }
 	std::string operator()(bool v) const { return format("bool:%d", v); }
 	std::string operator()(ValueRef v) const { return "string:" + v.toString(); }
 	std::string operator()(double v) const { return format("double:%lf", v); }

--- a/fdbclient/FileBackupAgent.actor.cpp
+++ b/fdbclient/FileBackupAgent.actor.cpp
@@ -87,7 +87,7 @@ std::string secondsToTimeFormat(int64_t seconds) {
 	else if (seconds >= 60)
 		return format("%.2f minute(s)", seconds / 60.0);
 	else
-		return format("%ld second(s)", seconds);
+		return format("%lld second(s)", seconds);
 }
 
 const Key FileBackupAgent::keyLastRestorable = LiteralStringRef("last_restorable");
@@ -5183,7 +5183,7 @@ public:
 						else
 							statusText += "The initial snapshot is still running.\n";
 
-						statusText += format("\nDetails:\n LogBytes written - %ld\n RangeBytes written - %ld\n "
+						statusText += format("\nDetails:\n LogBytes written - %lld\n RangeBytes written - %lld\n "
 						                     "Last complete log version and timestamp        - %s, %s\n "
 						                     "Last complete snapshot version and timestamp   - %s, %s\n "
 						                     "Current Snapshot start version and timestamp   - %s, %s\n "

--- a/fdbclient/ManagementAPI.actor.cpp
+++ b/fdbclient/ManagementAPI.actor.cpp
@@ -2201,7 +2201,7 @@ ACTOR Future<Void> advanceVersion(Database cx, Version v) {
 				tr.set(minRequiredCommitVersionKey, BinaryWriter::toValue(v + 1, Unversioned()));
 				wait(tr.commit());
 			} else {
-				printf("Current read version is %ld\n", rv);
+				printf("Current read version is %lld\n", rv);
 				return Void();
 			}
 		} catch (Error& e) {

--- a/fdbclient/ManagementAPI.actor.cpp
+++ b/fdbclient/ManagementAPI.actor.cpp
@@ -2201,7 +2201,7 @@ ACTOR Future<Void> advanceVersion(Database cx, Version v) {
 				tr.set(minRequiredCommitVersionKey, BinaryWriter::toValue(v + 1, Unversioned()));
 				wait(tr.commit());
 			} else {
-				printf("Current read version is %lld\n", rv);
+				fmt::print("Current read version is {}\n", rv);
 				return Void();
 			}
 		} catch (Error& e) {

--- a/fdbserver/ConfigDatabaseUnitTests.actor.cpp
+++ b/fdbserver/ConfigDatabaseUnitTests.actor.cpp
@@ -61,7 +61,7 @@ class WriteToTransactionEnvironment {
 	Version lastWrittenVersion{ 0 };
 
 	static Value longToValue(int64_t v) {
-		auto s = format("%ld", v);
+		auto s = format("%lld", v);
 		return StringRef(reinterpret_cast<uint8_t const*>(s.c_str()), s.size());
 	}
 

--- a/fdbserver/DDTeamCollection.actor.cpp
+++ b/fdbserver/DDTeamCollection.actor.cpp
@@ -5209,13 +5209,13 @@ public:
 		return Void();
 	}
 
-	ACTOR static Future<Void> AddAllTeams_isExhaustive() {
+	static void AddAllTeams_isExhaustive() {
 		Reference<IReplicationPolicy> policy = Reference<IReplicationPolicy>(
 		    new PolicyAcross(3, "zoneid", Reference<IReplicationPolicy>(new PolicyOne())));
-		state int processSize = 10;
-		state int desiredTeams = SERVER_KNOBS->DESIRED_TEAMS_PER_SERVER * processSize;
-		state int maxTeams = SERVER_KNOBS->MAX_TEAMS_PER_SERVER * processSize;
-		state std::unique_ptr<DDTeamCollection> collection = testTeamCollection(3, policy, processSize);
+		int processSize = 10;
+		int desiredTeams = SERVER_KNOBS->DESIRED_TEAMS_PER_SERVER * processSize;
+		int maxTeams = SERVER_KNOBS->MAX_TEAMS_PER_SERVER * processSize;
+		std::unique_ptr<DDTeamCollection> collection = testTeamCollection(3, policy, processSize);
 
 		int result = collection->addTeamsBestOf(200, desiredTeams, maxTeams);
 
@@ -5223,24 +5223,20 @@ public:
 		// The maximum number of available server teams with machine locality constraint is 120 - 40, because
 		// the 40 (5*4*2) server teams whose servers come from the same machine are invalid.
 		ASSERT(result == 80);
-
-		return Void();
 	}
 
-	ACTOR static Future<Void> AddAllTeams_withLimit() {
+	static void AddAllTeams_withLimit() {
 		Reference<IReplicationPolicy> policy = Reference<IReplicationPolicy>(
 		    new PolicyAcross(3, "zoneid", Reference<IReplicationPolicy>(new PolicyOne())));
-		state int processSize = 10;
-		state int desiredTeams = SERVER_KNOBS->DESIRED_TEAMS_PER_SERVER * processSize;
-		state int maxTeams = SERVER_KNOBS->MAX_TEAMS_PER_SERVER * processSize;
+		int processSize = 10;
+		int desiredTeams = SERVER_KNOBS->DESIRED_TEAMS_PER_SERVER * processSize;
+		int maxTeams = SERVER_KNOBS->MAX_TEAMS_PER_SERVER * processSize;
 
-		state std::unique_ptr<DDTeamCollection> collection = testTeamCollection(3, policy, processSize);
+		std::unique_ptr<DDTeamCollection> collection = testTeamCollection(3, policy, processSize);
 
 		int result = collection->addTeamsBestOf(10, desiredTeams, maxTeams);
 
 		ASSERT(result >= 10);
-
-		return Void();
 	}
 
 	ACTOR static Future<Void> AddTeamsBestOf_SkippingBusyServers() {
@@ -5665,12 +5661,12 @@ TEST_CASE("DataDistribution/AddTeamsBestOf/NotUseMachineID") {
 }
 
 TEST_CASE("DataDistribution/AddAllTeams/isExhaustive") {
-	wait(DDTeamCollectionUnitTest::AddAllTeams_isExhaustive());
+	DDTeamCollectionUnitTest::AddAllTeams_isExhaustive();
 	return Void();
 }
 
 TEST_CASE("/DataDistribution/AddAllTeams/withLimit") {
-	wait(DDTeamCollectionUnitTest::AddAllTeams_withLimit());
+	DDTeamCollectionUnitTest::AddAllTeams_withLimit();
 	return Void();
 }
 

--- a/fdbserver/KeyValueStoreSQLite.actor.cpp
+++ b/fdbserver/KeyValueStoreSQLite.actor.cpp
@@ -2359,7 +2359,7 @@ ACTOR Future<Void> KVFileDump(std::string filename) {
 		k = keyAfter(kv[kv.size() - 1].key);
 	}
 	fflush(stdout);
-	fprintf(stderr, "Counted: %ld\n", count);
+	fprintf(stderr, "Counted: %lld\n", count);
 
 	if (store->getError().isError())
 		wait(store->getError());

--- a/fdbserver/KeyValueStoreSQLite.actor.cpp
+++ b/fdbserver/KeyValueStoreSQLite.actor.cpp
@@ -19,6 +19,7 @@
  */
 
 #define SQLITE_THREADSAFE 0 // also in sqlite3.amalgamation.c!
+#include "contrib/fmt-8.0.1/include/fmt/format.h"
 #include "flow/crc32c.h"
 #include "fdbserver/IKeyValueStore.h"
 #include "fdbserver/CoroFlow.h"
@@ -2359,7 +2360,7 @@ ACTOR Future<Void> KVFileDump(std::string filename) {
 		k = keyAfter(kv[kv.size() - 1].key);
 	}
 	fflush(stdout);
-	fprintf(stderr, "Counted: %lld\n", count);
+	fmt::print(stderr, "Counted: {}\n", count);
 
 	if (store->getError().isError())
 		wait(store->getError());

--- a/fdbserver/Status.actor.cpp
+++ b/fdbserver/Status.actor.cpp
@@ -1038,7 +1038,7 @@ ACTOR static Future<JsonBuilderObject> processStatusFetcher(
 			if (ssLag[address] >= 60) {
 				messages.push_back(JsonString::makeMessage(
 				    "storage_server_lagging",
-				    format("Storage server lagging by %ld seconds.", (int64_t)ssLag[address]).c_str()));
+				    format("Storage server lagging by %lld seconds.", (int64_t)ssLag[address]).c_str()));
 			}
 
 			// Store the message array into the status object that represents the worker process

--- a/fdbserver/fdbserver.actor.cpp
+++ b/fdbserver/fdbserver.actor.cpp
@@ -1432,8 +1432,8 @@ private:
 				// parameter
 				knobs.emplace_back(
 				    "page_cache_4k",
-				    format("%ld", ti.get() / 4096 * 4096)); // The cache holds 4K pages, so we can truncate this to the
-				                                            // next smaller multiple of 4K.
+				    format("%lld", ti.get() / 4096 * 4096)); // The cache holds 4K pages, so we can truncate this to the
+				                                             // next smaller multiple of 4K.
 				break;
 			case OPT_BUGGIFY:
 				if (!strcmp(args.OptionArg(), "on"))

--- a/fdbserver/workloads/Mako.actor.cpp
+++ b/fdbserver/workloads/Mako.actor.cpp
@@ -183,7 +183,7 @@ struct MakoWorkload : TestWorkload {
 			auto ratesItr = ratesAtKeyCounts.begin();
 			for (; ratesItr != ratesAtKeyCounts.end(); ratesItr++) {
 				m.emplace_back(
-				    format("%ld keys imported bytes/sec", ratesItr->first), ratesItr->second, Averaged::False);
+				    format("%lld keys imported bytes/sec", ratesItr->first), ratesItr->second, Averaged::False);
 			}
 		}
 		// benchmark

--- a/fdbserver/workloads/ReadWrite.actor.cpp
+++ b/fdbserver/workloads/ReadWrite.actor.cpp
@@ -317,7 +317,7 @@ struct ReadWriteWorkload : KVWorkload {
 
 		std::vector<std::pair<uint64_t, double>>::iterator ratesItr = ratesAtKeyCounts.begin();
 		for (; ratesItr != ratesAtKeyCounts.end(); ratesItr++)
-			m.emplace_back(format("%ld keys imported bytes/sec", ratesItr->first), ratesItr->second, Averaged::False);
+			m.emplace_back(format("%lld keys imported bytes/sec", ratesItr->first), ratesItr->second, Averaged::False);
 	}
 
 	Value randomValue() {

--- a/flow/Platform.actor.cpp
+++ b/flow/Platform.actor.cpp
@@ -3826,7 +3826,7 @@ TEST_CASE("/flow/Platform/getMemoryInfo") {
 	ASSERT(request[LiteralStringRef("SwapTotal:")] == 25165820);
 	ASSERT(request[LiteralStringRef("SwapFree:")] == 23680228);
 	for (auto& item : request) {
-		printf("%s:%ld\n", item.first.toString().c_str(), item.second);
+		printf("%s:%lld\n", item.first.toString().c_str(), item.second);
 	}
 
 	printf("UnitTest flow/Platform/getMemoryInfo 2\n");
@@ -3877,7 +3877,7 @@ TEST_CASE("/flow/Platform/getMemoryInfo") {
 	ASSERT(request[LiteralStringRef("SwapTotal:")] == 0);
 	ASSERT(request[LiteralStringRef("SwapFree:")] == 0);
 	for (auto& item : request) {
-		printf("%s:%ld\n", item.first.toString().c_str(), item.second);
+		printf("%s:%lld\n", item.first.toString().c_str(), item.second);
 	}
 
 	return Void();

--- a/flow/Platform.actor.cpp
+++ b/flow/Platform.actor.cpp
@@ -26,6 +26,7 @@
 #endif
 
 #include <errno.h>
+#include "contrib/fmt-8.0.1/include/fmt/format.h"
 #include "flow/Platform.h"
 #include "flow/Platform.actor.h"
 #include "flow/Arena.h"
@@ -3826,7 +3827,7 @@ TEST_CASE("/flow/Platform/getMemoryInfo") {
 	ASSERT(request[LiteralStringRef("SwapTotal:")] == 25165820);
 	ASSERT(request[LiteralStringRef("SwapFree:")] == 23680228);
 	for (auto& item : request) {
-		printf("%s:%lld\n", item.first.toString().c_str(), item.second);
+		fmt::print("{}:{}\n", item.first.toString().c_str(), item.second);
 	}
 
 	printf("UnitTest flow/Platform/getMemoryInfo 2\n");
@@ -3877,7 +3878,7 @@ TEST_CASE("/flow/Platform/getMemoryInfo") {
 	ASSERT(request[LiteralStringRef("SwapTotal:")] == 0);
 	ASSERT(request[LiteralStringRef("SwapFree:")] == 0);
 	for (auto& item : request) {
-		printf("%s:%lld\n", item.first.toString().c_str(), item.second);
+		fmt::print("{}:{}\n", item.first.toString().c_str(), item.second);
 	}
 
 	return Void();


### PR DESCRIPTION
MacOS warnings are format warnings, e.g., `format specifies type 'long' but the argument has type 'Version' (aka 'long long')`.
Windows warnings are `ACTOR does not contain a wait() statement`.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
