### PR TITLE
Fix crash when setting invalid value for db/tx option

### DIFF
--- a/bindings/c/test/unit/unit_tests.cpp
+++ b/bindings/c/test/unit/unit_tests.cpp
@@ -2364,17 +2364,9 @@ TEST_CASE("Set transaction size limit too high") {
 	fdb_check(
 	    fdb_database_set_option(tempDb, FDB_DB_OPTION_TRANSACTION_SIZE_LIMIT, (const uint8_t*)&value, sizeof(value)));
 	fdb::Transaction tr(tempDb);
-	while (1) {
-		tr.clear_range(prefix, strinc_str(prefix));
-		for (const auto& [key, val] : std::map<std::string, std::string>{ { "foo", "bar" } }) {
-			tr.set(key, val);
-		}
-
-		fdb::EmptyFuture f1 = tr.commit();
-		fdb_error_t err = wait_future(f1);
-		CHECK(err == 2006 /* Option set with an invalid value */);
-		break;
-	}
+	fdb::EmptyFuture f1 = tr.commit();
+	fdb_error_t err = wait_future(f1);
+	CHECK(err == 2006 /* Option set with an invalid value */);
 	fdb_database_destroy(tempDb);
 }
 

--- a/bindings/c/test/unit/unit_tests.cpp
+++ b/bindings/c/test/unit/unit_tests.cpp
@@ -2364,9 +2364,22 @@ TEST_CASE("Set transaction size limit too high") {
 	fdb_check(
 	    fdb_database_set_option(tempDb, FDB_DB_OPTION_TRANSACTION_SIZE_LIMIT, (const uint8_t*)&value, sizeof(value)));
 	fdb::Transaction tr(tempDb);
-	fdb::EmptyFuture f1 = tr.commit();
-	fdb_error_t err = wait_future(f1);
-	CHECK(err == 2006 /* Option set with an invalid value */);
+	while (1) {
+		tr.clear_range(prefix, strinc_str(prefix));
+		for (const auto& [key, val] : std::map<std::string, std::string>{ { "foo", "bar" } }) {
+			tr.set(key, val);
+		}
+
+		fdb::EmptyFuture f1 = tr.commit();
+		fdb_error_t err = wait_future(f1);
+		if (err == 1039) {
+			fdb::EmptyFuture f2 = tr.on_error(err);
+			fdb_check(wait_future(f2));
+			continue;
+		}
+		CHECK(err == 2006 /* Option set with an invalid value */);
+		break;
+	}
 	fdb_database_destroy(tempDb);
 }
 

--- a/fdbclient/ReadYourWrites.actor.cpp
+++ b/fdbclient/ReadYourWrites.actor.cpp
@@ -1352,7 +1352,14 @@ ReadYourWritesTransaction::ReadYourWritesTransaction(Database const& cx)
     specialKeySpaceWriteMap(std::make_pair(false, Optional<Value>()), specialKeys.end), options(tr) {
 	std::copy(
 	    cx.getTransactionDefaults().begin(), cx.getTransactionDefaults().end(), std::back_inserter(persistentOptions));
-	applyPersistentOptions();
+	if (cx->isError()) {
+		try {
+			applyPersistentOptions();
+		} catch (Error& e) {
+			cx->deferredError = e;
+			deferredError = e;
+		}
+	}
 }
 
 void ReadYourWritesTransaction::setDatabase(Database const& cx) {

--- a/fdbclient/ReadYourWrites.actor.cpp
+++ b/fdbclient/ReadYourWrites.actor.cpp
@@ -1352,7 +1352,7 @@ ReadYourWritesTransaction::ReadYourWritesTransaction(Database const& cx)
     specialKeySpaceWriteMap(std::make_pair(false, Optional<Value>()), specialKeys.end), options(tr) {
 	std::copy(
 	    cx.getTransactionDefaults().begin(), cx.getTransactionDefaults().end(), std::back_inserter(persistentOptions));
-	if (cx->isError()) {
+	if (!cx->isError()) {
 		try {
 			applyPersistentOptions();
 		} catch (Error& e) {


### PR DESCRIPTION
Previously the ReadYourWritesTransaction constructor would throw and later the client probably just probably crashes.

Add a test that fails before and passes after this change.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
