### PR TITLE
Enable -Wdelete-non-virtual-dtor for clang build

### DIFF
--- a/bindings/c/test/workloads/SimpleWorkload.cpp
+++ b/bindings/c/test/workloads/SimpleWorkload.cpp
@@ -30,7 +30,7 @@
 
 namespace {
 
-struct SimpleWorkload : FDBWorkload {
+struct SimpleWorkload final : FDBWorkload {
 	static const std::string name;
 	static const std::string KEY_PREFIX;
 	std::mt19937 random;

--- a/cmake/ConfigureCompiler.cmake
+++ b/cmake/ConfigureCompiler.cmake
@@ -283,7 +283,6 @@ else()
       -Woverloaded-virtual
       -Wshift-sign-overflow
       # Here's the current set of warnings we need to explicitly disable to compile warning-free with clang 11
-      -Wno-delete-non-virtual-dtor
       -Wno-sign-compare
       -Wno-undefined-var-template
       -Wno-unknown-warning-option

--- a/fdbserver/CoroFlowCoro.actor.cpp
+++ b/fdbserver/CoroFlowCoro.actor.cpp
@@ -119,7 +119,7 @@ class WorkPool final : public IThreadPool, public ReferenceCounted<WorkPool<Thre
 		}
 	};
 
-	struct Worker : Threadlike {
+	struct Worker final : Threadlike {
 		Pool* pool;
 		IThreadPoolReceiver* userData;
 		bool stop;

--- a/fdbserver/DiskQueue.actor.cpp
+++ b/fdbserver/DiskQueue.actor.cpp
@@ -869,7 +869,7 @@ public:
 	}
 };
 
-class DiskQueue : public IDiskQueue, public Tracked<DiskQueue> {
+class DiskQueue final : public IDiskQueue, public Tracked<DiskQueue> {
 public:
 	// FIXME: Is setting lastCommittedSeq to -1 instead of 0 necessary?
 	DiskQueue(std::string basename,
@@ -1539,7 +1539,7 @@ private:
 // This works by performing two commits when uncommitted data is popped:
 //	Commit 1 - pop only previously committed data and push new data (i.e., commit uncommitted data)
 //  Commit 2 - finish pop into uncommitted data
-class DiskQueue_PopUncommitted : public IDiskQueue {
+class DiskQueue_PopUncommitted final : public IDiskQueue {
 
 public:
 	DiskQueue_PopUncommitted(std::string basename,

--- a/fdbserver/LogSystemDiskQueueAdapter.h
+++ b/fdbserver/LogSystemDiskQueueAdapter.h
@@ -41,7 +41,7 @@ struct PeekTxsInfo {
 	    knownCommittedVersion(knownCommittedVersion) {}
 };
 
-class LogSystemDiskQueueAdapter : public IDiskQueue {
+class LogSystemDiskQueueAdapter final : public IDiskQueue {
 public:
 	// This adapter is designed to let KeyValueStoreMemory use ILogSystem
 	// as a backing store, so that the transaction subsystem can in

--- a/flow/DeterministicRandom.h
+++ b/flow/DeterministicRandom.h
@@ -30,7 +30,7 @@
 
 #include <random>
 
-class DeterministicRandom : public IRandom, public ReferenceCounted<DeterministicRandom> {
+class DeterministicRandom final : public IRandom, public ReferenceCounted<DeterministicRandom> {
 private:
 	std::mt19937 random;
 	uint64_t next;

--- a/flow/actorcompiler/ActorCompiler.cs
+++ b/flow/actorcompiler/ActorCompiler.cs
@@ -431,10 +431,15 @@ namespace actorcompiler
             writer.WriteLine("public:");
             writer.WriteLine("\tusing FastAllocated<{0}>::operator new;", fullClassName);
             writer.WriteLine("\tusing FastAllocated<{0}>::operator delete;", fullClassName);
+
+            writer.WriteLine("#pragma clang diagnostic push");
+            writer.WriteLine("#pragma clang diagnostic ignored \"-Wdelete-non-virtual-dtor\"");
             if (actor.returnType != null)
                 writer.WriteLine("\tvoid destroy() override {{ ((Actor<{0}>*)this)->~Actor(); operator delete(this); }}", actor.returnType);
             else
                 writer.WriteLine("\tvoid destroy() {{ ((Actor<void>*)this)->~Actor(); operator delete(this); }}");
+            writer.WriteLine("#pragma clang diagnostic pop");
+
             foreach (var cb in callbacks)
                 writer.WriteLine("friend struct {0};", cb.type);
 

--- a/flow/genericactors.actor.h
+++ b/flow/genericactors.actor.h
@@ -870,7 +870,7 @@ template <class T>
 class QuorumCallback;
 
 template <class T>
-struct Quorum : SAV<Void> {
+struct Quorum final : SAV<Void> {
 	int antiQuorum;
 	int count;
 
@@ -1558,7 +1558,9 @@ Future<Void> yieldPromiseStream(FutureStream<T> input,
 	}
 }
 
-struct YieldedFutureActor : SAV<Void>, ActorCallback<YieldedFutureActor, 1, Void>, FastAllocated<YieldedFutureActor> {
+struct YieldedFutureActor final : SAV<Void>,
+                                  ActorCallback<YieldedFutureActor, 1, Void>,
+                                  FastAllocated<YieldedFutureActor> {
 	Error in_error_state;
 
 	typedef ActorCallback<YieldedFutureActor, 1, Void> CB1;


### PR DESCRIPTION
We had been disabling -Wdelete-non-virtual-dtor, because this seems to be done intentionally in the generated code of the actor compiler. I spent some time trying to rewrite it in a way that doesn't literally delete/destroy through a pointer to a base class without a virtual destructor, but I was unable to come up with something that passes correctness. My best guess is that we do this so that we can destroy actor state classes, call callbacks registered on the actor SAV, and then destroy the SAV. 

Anyway now we'll detect new usages of deleting through a pointer to a base class without a virtual destructor.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
