### PR TITLE
Increase default timeout to 5 minutes for add_fdbclient_test

### DIFF
--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -85,7 +85,6 @@ if (NOT WIN32 AND NOT OPEN_FOR_IDE)
   add_fdbclient_test(
     NAME multi_process_fdbcli_tests
     PROCESS_NUMBER 5
-    TEST_TIMEOUT 120 # The test can take near to 1 minutes sometime, set timeout to 2 minutes to be safe
     COMMAND ${CMAKE_SOURCE_DIR}/bindings/python/tests/fdbcli_tests.py
             ${CMAKE_BINARY_DIR}
             @CLUSTER_FILE@
@@ -102,7 +101,6 @@ if (NOT WIN32 AND NOT OPEN_FOR_IDE)
     add_fdbclient_test(
     NAME multi_process_external_client_fdbcli_tests
     PROCESS_NUMBER 5
-    TEST_TIMEOUT 120 # The test can take near to 1 minutes sometime, set timeout to 2 minutes to be safe
     COMMAND ${CMAKE_SOURCE_DIR}/bindings/python/tests/fdbcli_tests.py
             ${CMAKE_BINARY_DIR}
             @CLUSTER_FILE@

--- a/bindings/python/tests/fdbcli_tests.py
+++ b/bindings/python/tests/fdbcli_tests.py
@@ -504,6 +504,18 @@ def profile(logger):
 
 
 @enable_logging()
+def test_available(logger):
+    duration = 0  # seconds we already wait
+    while not get_value_from_status_json(False, 'client', 'database_status', 'available') and duration < 10:
+        logger.debug("Sleep for 1 second to wait cluster recovery")
+        time.sleep(1)
+        duration += 1
+    if duration >= 10:
+        logger.debug(run_fdbcli_command('status', 'json'))
+        assert False
+
+
+@enable_logging()
 def triggerddteaminfolog(logger):
     # this command is straightforward and only has one code path
     output = run_fdbcli_command('triggerddteaminfolog')
@@ -538,6 +550,7 @@ if __name__ == '__main__':
     command_template = [args.build_dir + '/bin/fdbcli', '-C', args.cluster_file, '--exec']
     # tests for fdbcli commands
     # assertions will fail if fdbcli does not work as expected
+    test_available()
     if args.process_number == 1:
         # TODO: disable for now, the change can cause the database unavailable
         # advanceversion()

--- a/cmake/AddFdbTest.cmake
+++ b/cmake/AddFdbTest.cmake
@@ -438,7 +438,7 @@ function(add_fdbclient_test)
     set_tests_properties("${T_NAME}" PROPERTIES TIMEOUT ${T_TEST_TIMEOUT})
   else()
     # default timeout
-    set_tests_properties("${T_NAME}" PROPERTIES TIMEOUT 60)
+    set_tests_properties("${T_NAME}" PROPERTIES TIMEOUT 300)
   endif()
   set_tests_properties("${T_NAME}" PROPERTIES ENVIRONMENT UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1)
 endfunction()


### PR DESCRIPTION
We've been seeing some timeouts for add_fdbclient_test in CI. Maybe we need a longer timeout set.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
