### PR TITLE
Fix ctest under ASAN

### DIFF
--- a/fdbrpc/fdbrpc.h
+++ b/fdbrpc/fdbrpc.h
@@ -124,6 +124,8 @@ public:
 		sav->sendError(exc);
 	}
 
+	void send(Never) { sendError(never_reply()); }
+
 	Future<T> getFuture() const {
 		sav->addFutureRef();
 		return Future<T>(sav);

--- a/fdbrpc/networksender.actor.h
+++ b/fdbrpc/networksender.actor.h
@@ -30,6 +30,7 @@
 #include "flow/flow.h"
 #include "flow/actorcompiler.h" // This must be the last #include.
 
+// This actor is used by FlowTransport to serialize the response to a ReplyPromise across the network
 ACTOR template <class T>
 void networkSender(Future<T> input, Endpoint endpoint) {
 	try {
@@ -37,6 +38,9 @@ void networkSender(Future<T> input, Endpoint endpoint) {
 		FlowTransport::transport().sendUnreliable(SerializeSource<ErrorOr<EnsureTable<T>>>(value), endpoint, false);
 	} catch (Error& err) {
 		// if (err.code() == error_code_broken_promise) return;
+		if (err.code() == error_code_never_reply) {
+			return;
+		}
 		ASSERT(err.code() != error_code_actor_cancelled);
 		FlowTransport::transport().sendUnreliable(SerializeSource<ErrorOr<EnsureTable<T>>>(err), endpoint, false);
 	}

--- a/flow/error_definitions.h
+++ b/flow/error_definitions.h
@@ -89,6 +89,7 @@ ERROR( broken_promise, 1100, "Broken promise" )
 ERROR( operation_cancelled, 1101, "Asynchronous operation cancelled" )
 ERROR( future_released, 1102, "Future has been released" )
 ERROR( connection_leaked, 1103, "Connection object leaked" )
+ERROR( never_reply, 1104, "Never reply to the request" )
 
 ERROR( recruitment_failed, 1200, "Recruitment of a server failed" )   // Be careful, catching this will delete the data of a storage server or tlog permanently
 ERROR( move_to_removed_server, 1201, "Attempt to move keys to a storage server that was removed" )

--- a/tests/TestRunner/tmp_cluster.py
+++ b/tests/TestRunner/tmp_cluster.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 
+import glob
 import os
 import shutil
 import subprocess
 import sys
-import socket
 from local_cluster import LocalCluster
 from argparse import ArgumentParser, RawDescriptionHelpFormatter
 from random import choice
@@ -109,4 +109,21 @@ if __name__ == "__main__":
         errcode = subprocess.run(
             cmd_args, stdout=sys.stdout, stderr=sys.stderr, env=env
         ).returncode
+        sev40s = (
+            subprocess.run(
+                ["grep", 'Severity="40"', os.path.join(cluster.log)],
+                stdout=sys.stdout,
+                stderr=sys.stderr,
+            ).returncode
+            != 0
+        )
+        if sev40s:
+            print(">>>>>>>>>>>>>>>>>>>> Found severity 40 events - the test fails")
+            errcode = 1
+        if errcode:
+            for log_file in glob.glob(os.path.join(cluster.log, "*")):
+                print(">>>>>>>>>>>>>>>>>>>> Contents of {}:".format(log_file))
+                with open(log_file, "r") as f:
+                    print(f.read())
+
     sys.exit(errcode)


### PR DESCRIPTION
~Ctest now runs cleanly on linux for ASAN builds.~ Ok there's still memory leaks but it's better

Previously, a memory leak detected by ASAN was causing "actual cluster" tests to fail with an exceptionally unhelpful error message, when the answer was in the logs along. To improve that, also output the logs if a test fails and look for sev40s.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
