### PR TITLE
Set recovered tLogs' recoverAt to max of all restored tLogs' RV in UNICAST mode

### DIFF
--- a/fdbserver/Resolver.actor.cpp
+++ b/fdbserver/Resolver.actor.cpp
@@ -413,7 +413,7 @@ ACTOR Future<Void> resolveBatch(Reference<Resolver> self, ResolveTransactionBatc
 				reply.tpcvMap.clear();
 			} else {
 				std::set<uint16_t> writtenTLogs;
-				if (shardChanged) {
+				if (shardChanged || reply.privateMutationCount) {
 					for (int i = 0; i < self->numLogs; i++) {
 						writtenTLogs.insert(i);
 					}

--- a/fdbserver/TLogServer.actor.cpp
+++ b/fdbserver/TLogServer.actor.cpp
@@ -3364,9 +3364,7 @@ ACTOR Future<Void> tLogStart(TLogData* self, InitializeTLogRequest req, Locality
 			}
 
 			state Version lastVersionPrevEpoch = req.recoverAt;
-			if (SERVER_KNOBS->ENABLE_VERSION_VECTOR_TLOG_UNICAST) {
-				lastVersionPrevEpoch = req.maxRv;
-			}
+
 			if ((req.isPrimary || req.recoverFrom.logRouterTags == 0) &&
 			    logData->version.get() < lastVersionPrevEpoch && !logData->stopped) {
 				// Log the changes to the persistent queue, to be committed by commitQueue()

--- a/fdbserver/WorkerInterface.actor.h
+++ b/fdbserver/WorkerInterface.actor.h
@@ -486,7 +486,6 @@ struct InitializeTLogRequest {
 	UID recruitmentID;
 	LogSystemConfig recoverFrom;
 	Version recoverAt;
-	Version maxRv;
 	Version knownCommittedVersion;
 	LogEpoch epoch;
 	std::vector<Tag> recoverTags;
@@ -512,7 +511,6 @@ struct InitializeTLogRequest {
 		           recruitmentID,
 		           recoverFrom,
 		           recoverAt,
-		           maxRv,
 		           knownCommittedVersion,
 		           epoch,
 		           recoverTags,


### PR DESCRIPTION
This is incremental work towards passing cycle and upgrade tests in vv's UNICAST mode. Recall "recovered" tLogs crashed and are restarted. "restored" did not crash and can accept peeks during recovery.

- replace maxRv with recoverAt, so recovered tLogs pull data up to the max version rolled forward.
- Do not create invalid (null) versions in recovery.
- Broadcast to all tLogs metadata mutations.

Upgrades tested following [this](https://github.com/apple/foundationdb/wiki/How-to-reproduce-a-restart-test-failure) guide. 

TBD:
- investigate if necessary to manage "gaps" in versions peeked (per offline discussion).
- refactor, e.g. metadata mutations may not need to be broadcast, optimizations can be investigated in later work.

```
-r simulation --logsize=4096MiB -f ./src/foundationdb/tests/fast/ChangeFeeds.toml -b on -s 212138249;
-r simulation --logsize=4096MiB -f ./src/foundationdb/tests/fast/CycleAndLock.toml -b on -s 462200958;
-r simulation --logsize=4096MiB -f ./src/foundationdb/tests/slow/ParallelRestoreNewBackupCorrectnessCycle.toml -b off -s 94432625;
-r simulation --logsize=4096MiB -f ./src/foundationdb/tests/slow/ClogWithRollbacks.toml -b off -s 459430300;
-r simulation --logsize=4096MiB -f ./src/foundationdb/tests/fast/InventoryTestAlmostReadOnly.toml -b off -s 738279447;
-r simulation --logsize=4096MiB -f ./src/foundationdb/tests/slow/SwizzledRollbackTimeLapseIncrement.toml -b on -s 118276796;
-r simulation --logsize=4096MiB -f ./src/foundationdb/tests/slow/ParallelRestoreNewBackupCorrectnessCycle.toml -b off -s 639065319;
-r simulation --logsize=4096MiB -f ./src/foundationdb/tests/rare/CycleWithKills.toml -b on -s 618951457;
-r simulation --logsize=4096MiB -f ./src/foundationdb/tests/restarting/from_6.3.13/ClientTransactionProfilingCorrectness-1.txt -b off -s 28131093;
-r simulation --logsize=4096MiB -f ./src/foundationdb/tests/restarting/from_6.3.13/ClientTransactionProfilingCorrectness-2.txt -b off -s 28131094;
-r simulation --logsize=4096MiB -f ./src/foundationdb/tests/restarting/to_7.0.0/CycleTestRestart-1.txt -b off -s 755818525;
-r simulation --logsize=4096MiB -f ./src/foundationdb/tests/restarting/to_7.0.0/CycleTestRestart-2.txt -b off -s 755818526;
-r simulation --logsize=4096MiB -f ./src/foundationdb/tests/restarting/from_5.0.0_until_6.3.0/StorefrontTestRestart-1.txt -b off -s 76511192;
-r simulation --logsize=4096MiB -f ./src/foundationdb/tests/restarting/from_5.0.0_until_6.3.0/StorefrontTestRestart-2.txt -b off -s 76511193;
-r simulation --logsize=4096MiB -f ./src/foundationdb/tests/restarting/from_5.0.0_until_6.3.0/CycleTestRestart-1.txt -b off -s 49644458;
-r simulation --logsize=4096MiB -f ./src/foundationdb/tests/restarting/from_5.0.0_until_6.3.0/CycleTestRestart-2.txt -b off -s 49644459;
-r simulation --logsize=4096MiB -f ./src/foundationdb/tests/restarting/to_7.0.0/CycleTestRestart-1.txt -b off -s 424906888;
-r simulation --logsize=4096MiB -f ./src/foundationdb/tests/restarting/to_7.0.0/CycleTestRestart-2.txt -b off -s 424906889;


```