### PR TITLE
Use smart pointers to manage `TestWorkload` objects

### DIFF
--- a/fdbserver/workloads/workloads.actor.h
+++ b/fdbserver/workloads/workloads.actor.h
@@ -115,6 +115,7 @@ struct IWorkloadFactory : ReferenceCounted<IWorkloadFactory> {
 		return theFactories;
 	}
 
+	virtual ~IWorkloadFactory() = default;
 	virtual Reference<TestWorkload> create(WorkloadContext const& wcx) = 0;
 };
 


### PR DESCRIPTION
This removes the explicit use of `new` and `delete` and makes the implementation more stable and resilient to memory leaks and invalid memory access in the future.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
