### PR TITLE
Remove unneeded Arena in Requests/Replies

### DIFF
--- a/fdbserver/TLogInterface.h
+++ b/fdbserver/TLogInterface.h
@@ -193,7 +193,6 @@ struct TLogPeekReply {
 
 struct TLogPeekRequest {
 	constexpr static FileIdentifier file_identifier = 11001131;
-	Arena arena;
 	Version begin;
 	Tag tag;
 	bool returnIfBlocked;
@@ -211,7 +210,7 @@ struct TLogPeekRequest {
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, arena, begin, tag, returnIfBlocked, onlySpilled, sequence, reply);
+		serializer(ar, begin, tag, returnIfBlocked, onlySpilled, sequence, reply);
 	}
 };
 
@@ -232,7 +231,6 @@ struct TLogPeekStreamReply : public ReplyPromiseStreamReply {
 
 struct TLogPeekStreamRequest {
 	constexpr static FileIdentifier file_identifier = 10072821;
-	Arena arena;
 	Version begin;
 	Tag tag;
 	bool returnIfBlocked;
@@ -245,13 +243,12 @@ struct TLogPeekStreamRequest {
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, arena, begin, tag, returnIfBlocked, limitBytes, reply);
+		serializer(ar, begin, tag, returnIfBlocked, limitBytes, reply);
 	}
 };
 
 struct TLogPopRequest {
 	constexpr static FileIdentifier file_identifier = 5556423;
-	Arena arena;
 	Version to;
 	Version durableKnownCommittedVersion;
 	Tag tag;
@@ -263,7 +260,7 @@ struct TLogPopRequest {
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, arena, to, durableKnownCommittedVersion, tag, reply);
+		serializer(ar, to, durableKnownCommittedVersion, tag, reply);
 	}
 };
 
@@ -359,7 +356,6 @@ struct TLogQueuingMetricsRequest {
 
 struct TLogDisablePopRequest {
 	constexpr static FileIdentifier file_identifier = 4022806;
-	Arena arena;
 	UID snapUID;
 	ReplyPromise<Void> reply;
 	Optional<UID> debugID;
@@ -369,13 +365,12 @@ struct TLogDisablePopRequest {
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, snapUID, reply, arena, debugID);
+		serializer(ar, snapUID, reply, debugID);
 	}
 };
 
 struct TLogEnablePopRequest {
 	constexpr static FileIdentifier file_identifier = 4022809;
-	Arena arena;
 	UID snapUID;
 	ReplyPromise<Void> reply;
 	Optional<UID> debugID;
@@ -385,7 +380,7 @@ struct TLogEnablePopRequest {
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, snapUID, reply, arena, debugID);
+		serializer(ar, snapUID, reply, debugID);
 	}
 };
 

--- a/fdbserver/WorkerInterface.actor.h
+++ b/fdbserver/WorkerInterface.actor.h
@@ -647,7 +647,6 @@ struct InitializeBackupRequest {
 // FIXME: Rename to InitializeMasterRequest, etc
 struct RecruitMasterRequest {
 	constexpr static FileIdentifier file_identifier = 12684574;
-	Arena arena;
 	LifetimeToken lifetime;
 	bool forceRecovery;
 	ReplyPromise<struct MasterInterface> reply;
@@ -657,7 +656,7 @@ struct RecruitMasterRequest {
 		if constexpr (!is_fb_function<Ar>) {
 			ASSERT(ar.protocolVersion().isValid());
 		}
-		serializer(ar, lifetime, forceRecovery, reply, arena);
+		serializer(ar, lifetime, forceRecovery, reply);
 	}
 };
 


### PR DESCRIPTION
If the Request/Reply doesn't have *Ref types, we typically don't need to have an Arena.

Correctness passed:
20220107-222327-jzhou-5bb7456ab1585db9             compressed=True data_size=21063430 duration=5646565 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=0:50:43 sanity=False started=100103 stopped=20220107-231410 submitted=20220107-222327 timeout=5400 username=jzhou

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
