### PR TITLE
Rename libfdb_c in bindings/c

### DIFF
--- a/bindings/c/CMakeLists.txt
+++ b/bindings/c/CMakeLists.txt
@@ -157,6 +157,9 @@ if(NOT WIN32 AND NOT IS_ARM_MAC)
     set(FDB_C_TARGET $<TARGET_FILE:fdb_c>)
   endif()
   add_custom_command(
+    TARGET fdb_c POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy ${FDB_C_TARGET} ${CMAKE_BINARY_DIR}/lib/libfdb_c_external.so)
+  add_custom_command(
     OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/libfdb_c.so
     COMMAND ${CMAKE_COMMAND} -E copy ${FDB_C_TARGET} ${CMAKE_CURRENT_BINARY_DIR}/libfdb_c.so
     DEPENDS fdb_c

--- a/bindings/c/CMakeLists.txt
+++ b/bindings/c/CMakeLists.txt
@@ -157,14 +157,11 @@ if(NOT WIN32 AND NOT IS_ARM_MAC)
     set(FDB_C_TARGET $<TARGET_FILE:fdb_c>)
   endif()
   add_custom_command(
-    TARGET fdb_c POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy ${FDB_C_TARGET} ${CMAKE_BINARY_DIR}/lib/libfdb_c_external.so)
-  add_custom_command(
-    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/libfdb_c.so
-    COMMAND ${CMAKE_COMMAND} -E copy ${FDB_C_TARGET} ${CMAKE_CURRENT_BINARY_DIR}/libfdb_c.so
+    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/libfdb_c_external.so
+    COMMAND ${CMAKE_COMMAND} -E copy ${FDB_C_TARGET} ${CMAKE_CURRENT_BINARY_DIR}/libfdb_c_external.so
     DEPENDS fdb_c
     COMMENT "Copy libfdb_c to use as external client for test")
-  add_custom_target(external_client DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/libfdb_c.so)
+  add_custom_target(external_client DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/libfdb_c_external.so)
   add_dependencies(fdb_c_unit_tests external_client)
   add_dependencies(disconnected_timeout_unit_tests external_client)
 
@@ -191,7 +188,7 @@ if(NOT WIN32 AND NOT IS_ARM_MAC)
     COMMAND $<TARGET_FILE:fdb_c_unit_tests>
             @CLUSTER_FILE@
             fdb
-            ${CMAKE_CURRENT_BINARY_DIR}/libfdb_c.so
+            ${CMAKE_CURRENT_BINARY_DIR}/libfdb_c_external.so
             )
   add_unavailable_fdbclient_test(
     NAME disconnected_timeout_unit_tests
@@ -202,7 +199,7 @@ if(NOT WIN32 AND NOT IS_ARM_MAC)
     NAME disconnected_timeout_external_client_unit_tests
     COMMAND $<TARGET_FILE:disconnected_timeout_unit_tests>
             @CLUSTER_FILE@
-            ${CMAKE_CURRENT_BINARY_DIR}/libfdb_c.so
+            ${CMAKE_CURRENT_BINARY_DIR}/libfdb_c_external.so
             )
 endif()
 

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -90,13 +90,13 @@ if (NOT WIN32 AND NOT OPEN_FOR_IDE)
             @CLUSTER_FILE@
             5
             )
-  if (TARGET external_client) # external_client copies fdb_c to bindings/c/libfdb_c.so
+  if (TARGET external_client) # external_client copies fdb_c to bindings/c/libfdb_c_external.so
     add_fdbclient_test(
     NAME single_process_external_client_fdbcli_tests
     COMMAND ${CMAKE_SOURCE_DIR}/bindings/python/tests/fdbcli_tests.py
             ${CMAKE_BINARY_DIR}
             @CLUSTER_FILE@
-            --external-client-library ${CMAKE_BINARY_DIR}/bindings/c/libfdb_c.so
+            --external-client-library ${CMAKE_BINARY_DIR}/bindings/c/libfdb_c_external.so
             )
     add_fdbclient_test(
     NAME multi_process_external_client_fdbcli_tests
@@ -105,7 +105,7 @@ if (NOT WIN32 AND NOT OPEN_FOR_IDE)
             ${CMAKE_BINARY_DIR}
             @CLUSTER_FILE@
             5
-            --external-client-library ${CMAKE_BINARY_DIR}/bindings/c/libfdb_c.so
+            --external-client-library ${CMAKE_BINARY_DIR}/bindings/c/libfdb_c_external.so
             )
   endif()
 endif()


### PR DESCRIPTION
Issues can occur when loading a file named `libfdb_c.so` as an external client. We have various dependencies that load the `libfdb_c.so` generated as part of a build, as an external client. This PR renames the copy of `libfdb_c.so`at `bindings/c/` to `libfdb_c_external.so`.

Passed `ctest`.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
