### PR TITLE
Split TLog tests to spilled data read and persisted commit read

### DIFF
--- a/tests/ptxn/TLogServer.toml
+++ b/tests/ptxn/TLogServer.toml
@@ -126,3 +126,18 @@ startDelay = 0
     numStorageTeams = 40
     numTLogGroups = 3
     numCommits = 5
+
+[[test]]
+testTitle = 'Team Partitioned TLog Server Test 9: Read from TLog spilled data'
+useDB = false
+startDelay = 0
+
+    [[test.workload]]
+    testName = 'UnitTests'
+    maxTestCases = 1
+    testsMatching = '/fdbserver/ptxn/test/read_tlog_spilled'
+
+    numTLogs = 3
+    numStorageTeams = 40
+    numTLogGroups = 7
+    numCommits = 20


### PR DESCRIPTION
Previously a single test does 2 things:
* read from spilled data(IKeyValueStore)
* read from persisted commit(IDiskQueue)

now split them into 2 separate tests

Put description here...

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
