### PR TITLE
Fix recovery restarts in vv UNICAST mode

### DIFF
--- a/fdbserver/TLogServer.actor.cpp
+++ b/fdbserver/TLogServer.actor.cpp
@@ -3311,12 +3311,6 @@ ACTOR Future<Void> tLogStart(TLogData* self, InitializeTLogRequest req, Locality
 		if (recovering) {
 			logData->unrecoveredBefore = req.startVersion;
 			state Version recoverAt = req.recoverAt;
-			if (SERVER_KNOBS->ENABLE_VERSION_VECTOR_TLOG_UNICAST) {
-				if (req.rvLogs.find(self->dbgid) != req.rvLogs.end()) {
-					recoverAt = req.rvLogs[self->dbgid];
-					// TraceEvent("TLogUnicastRecovered").detail("U", recoverAt);
-				}
-			}
 			logData->recoveredAt = recoverAt;
 			logData->knownCommittedVersion = req.startVersion - 1;
 			logData->persistentDataVersion = logData->unrecoveredBefore - 1;

--- a/fdbserver/TagPartitionedLogSystem.actor.cpp
+++ b/fdbserver/TagPartitionedLogSystem.actor.cpp
@@ -2256,9 +2256,9 @@ ACTOR Future<Void> TagPartitionedLogSystem::epochEnd(Reference<AsyncVar<Referenc
 					logSystem->recoverAt = std::max(val, logSystem->recoverAt.get());
 				}
 				// TraceEvent("RecoveryVersionInfo").detail("RecoverAt", logSystem->recoverAt);
-			} else {
-				lastEnd = minEnd;
 			}
+
+			lastEnd = minEnd;
 
 			logSystem->rvLogs = rvLogs;
 			logSystem->tLogs = logServers;


### PR DESCRIPTION
Fixes simulation failures below. 

1.

In vv UNICAST mode, recovery restarted too frequently, resulting in 20-30 second periods between the master's reading coordinated state and the set of recovered tLogs settling to a new epoch. 

To prevent this long cycle of convergence, the logic should be the same as existing fdb. In other words, only restart recovery when the set of recovered tLogs changes such that the recovery version is calculated to be less than what was derived in the previous set.

2.

Prior to the PR, a separate RV was computed for each tLog. This led to a situation where an RV for one tLog was less than another. If tLog A and B are in the same replica set, the latest key's versions must be stored on both A and B. Otherwise, a read to the SS peeked from A would different from that by B, leading to data loss. The solution is to use the same RV for all tLogs.    

```
-r simulation --logsize=4096MiB -f ./src/foundationdb/tests/fast/BackupToDBCorrectness.toml -b on -s 338332592;
-r simulation --logsize=4096MiB -f ./src/foundationdb/tests/slow/VersionStampBackupToDB.toml -b on -s 166177587;
-r simulation --logsize=4096MiB -f ./src/foundationdb/tests/slow/SwizzledDdBalance.toml -b on -s 451876487;
-r simulation --logsize=4096MiB -f ./src/foundationdb/tests/fast/KillRegionCycle.toml -b on -s 560001991;
-r simulation --logsize=4096MiB -f ./src/foundationdb/tests/fast/BackupToDBCorrectnessClean.toml -b on -s 38517146;
-r simulation --logsize=4096MiB -f ./src/foundationdb/tests/slow/SwizzledDdBalance.toml -b on -s 160484542;
-r simulation --logsize=4096MiB -f ./src/foundationdb/tests/slow/SwizzledRollbackTimeLapse.toml -b on -s 614903728;
-r simulation --logsize=4096MiB -f ./src/foundationdb/tests/slow/SwizzledDdBalance.toml -b on -s 82157467;
-r simulation --logsize=4096MiB -f ./src/foundationdb/tests/slow/SwizzledRollbackTimeLapse.toml -b off -s 908447618;
-r simulation --logsize=4096MiB -f ./src/foundationdb/tests/slow/SwizzledRollbackTimeLapse.toml -b off -s 516360797;
-r simulation --logsize=4096MiB -f ./src/foundationdb/tests/slow/ParallelRestoreOldBackupCorrectnessCycle.toml -b on -s 618203041;
-r simulation --logsize=4096MiB -f ./src/foundationdb/tests/slow/SwizzledRollbackTimeLapse.toml -b off -s 929873030;
-r simulation --logsize=4096MiB -f ./src/foundationdb/tests/slow/SwizzledRollbackTimeLapseIncrement.toml -b off -s 579404732;
-r simulation --logsize=4096MiB -f ./src/foundationdb/tests/slow/SwizzledDdBalance.toml -b off -s 575324113;
-r simulation --logsize=4096MiB -f ./src/foundationdb/tests/fast/WriteDuringReadClean.toml -b off -s 945544274;
-r simulation --logsize=4096MiB -f ./src/foundationdb/tests/slow/SwizzledCycleTest.toml -b on -s 115244367;
-r simulation --logsize=4096MiB -f ./src/foundationdb/tests/slow/SwizzledCycleTest.toml -b on -s 115244367;
-r simulation --logsize=4096MiB -f ./src/foundationdb/tests/fast/BackupCorrectness.toml -b off -s 853473739;
-r simulation --logsize=4096MiB -f ./src/foundationdb/tests/fast/BackupCorrectness.toml -b on -s 163101;
Ensemble stopped
-r simulation --logsize=4096MiB -f ./src/foundationdb/tests/slow/SwizzledRollbackTimeLapse.toml -b off -s 210153717;
```
A follow up PR will refactor the recovery code.