### PR TITLE
Add test to assert spilling not happen with a higher threshold

### DIFF
--- a/fdbserver/ptxn/test/TestTLogServer.actor.cpp
+++ b/fdbserver/ptxn/test/TestTLogServer.actor.cpp
@@ -803,7 +803,9 @@ TEST_CASE("/fdbserver/ptxn/test/read_tlog_spilled") {
 	// only wrote to a single storageTeamId, thus only 1 tlogGroup, while each tlogGroup has their own disk queue.
 	state bool exist = false;
 	state int i = 0;
-	// commit to IKeyValueStore might happen in any version of our commits(might happen more than time)
+
+	ASSERT(!res.second.empty());
+	// commit to IKeyValueStore might happen in any version of our commits(multiple versions might be combined)
 	for (i = 0; i < res.second.size(); i++) {
 		state Key k = ptxn::persistStorageTeamMessageRefsKey(
 		    pContext->getTLogLeaderByStorageTeamID(storageTeamID)->id(), storageTeamID, res.second[i]);
@@ -849,7 +851,7 @@ TEST_CASE("/fdbserver/ptxn/test/read_tlog_not_spilled_with_default_threshold") {
 
 	// only wrote to a single storageTeamId, thus only 1 tlogGroup, while each tlogGroup has their own disk queue.
 	state int i = 0;
-	// commit to IKeyValueStore might happen in any version of our commits(might happen more than time)
+	ASSERT(!res.second.empty());
 	for (i = 0; i < res.second.size(); i++) {
 		state Key k = ptxn::persistStorageTeamMessageRefsKey(
 		    pContext->getTLogLeaderByStorageTeamID(storageTeamID)->id(), storageTeamID, res.second[i]);

--- a/fdbserver/ptxn/test/TestTLogServer.actor.cpp
+++ b/fdbserver/ptxn/test/TestTLogServer.actor.cpp
@@ -819,6 +819,48 @@ TEST_CASE("/fdbserver/ptxn/test/read_tlog_spilled") {
 	return Void();
 }
 
+TEST_CASE("/fdbserver/ptxn/test/read_tlog_not_spilled_with_default_threshold") {
+	state ptxn::test::TestDriverOptions options(params);
+	state std::vector<Future<Void>> actors;
+	(const_cast<ServerKnobs*> SERVER_KNOBS)->TLOG_SPILL_THRESHOLD =
+	    1500e6; // set it as default, in case other tests change it since it is global
+	(const_cast<ServerKnobs*> SERVER_KNOBS)->BUGGIFY_TLOG_STORAGE_MIN_UPDATE_INTERVAL = 0.5;
+	state std::shared_ptr<ptxn::test::TestDriverContext> pContext = ptxn::test::initTestDriverContext(options);
+
+	for (const auto& group : pContext->tLogGroups) {
+		ptxn::test::print::print(group);
+	}
+	const ptxn::TLogGroup& group = pContext->tLogGroups[0];
+	state ptxn::StorageTeamID storageTeamID = group.storageTeams.begin()->first;
+
+	state std::string folder = "simfdb/" + deterministicRandom()->randomAlphaNumeric(10);
+	platform::createDirectory(folder);
+
+	wait(startTLogServers(&actors, pContext, folder, true));
+	state IKeyValueStore* d = pContext->kvStores[pContext->storageTeamIDTLogGroupIDMapper[storageTeamID]];
+
+	state std::pair<std::vector<Standalone<StringRef>>, std::vector<Version>> res =
+	    wait(commitInjectReturnVersions(pContext, storageTeamID, pContext->numCommits));
+	state std::vector<Standalone<StringRef>> expectedMessages = res.first;
+	wait(verifyPeek(pContext, storageTeamID, pContext->numCommits));
+
+	// wait 1s so that actors who update persistent data can do their job.
+	wait(delay(1.5));
+
+	// only wrote to a single storageTeamId, thus only 1 tlogGroup, while each tlogGroup has their own disk queue.
+	state int i = 0;
+	// commit to IKeyValueStore might happen in any version of our commits(might happen more than time)
+	for (i = 0; i < res.second.size(); i++) {
+		state Key k = ptxn::persistStorageTeamMessageRefsKey(
+		    pContext->getTLogLeaderByStorageTeamID(storageTeamID)->id(), storageTeamID, res.second[i]);
+		state Optional<Value> v = wait(d->readValue(k));
+		ASSERT(!v.present());
+	}
+
+	platform::eraseDirectoryRecursive(folder);
+	return Void();
+}
+
 TEST_CASE("/fdbserver/ptxn/test/single_tlog_recovery") {
 	state ptxn::test::TestDriverOptions options(params);
 	state std::vector<Future<Void>> actors;

--- a/tests/ptxn/TLogServer.toml
+++ b/tests/ptxn/TLogServer.toml
@@ -141,3 +141,19 @@ startDelay = 0
     numStorageTeams = 40
     numTLogGroups = 7
     numCommits = 20
+
+[[test]]
+testTitle = 'Team Partitioned TLog Server Test 10: Spilling not happen with default threshold'
+useDB = false
+startDelay = 0
+
+    [[test.workload]]
+    testName = 'UnitTests'
+    maxTestCases = 1
+    testsMatching = '/fdbserver/ptxn/test/read_tlog_not_spilled_with_default_threshold'
+
+    numTLogs = 3
+    numStorageTeams = 40
+    numTLogGroups = 7
+    numCommits = 10
+


### PR DESCRIPTION
Previously only had a test to verify spilling happens with 0 threshold, not the other way.
Now adding it.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
