### PR TITLE
Link libfdb_c with `-z noexecstack` (release-7.0)

### DIFF
--- a/bindings/c/CMakeLists.txt
+++ b/bindings/c/CMakeLists.txt
@@ -53,7 +53,7 @@ if(APPLE)
   target_link_options(fdb_c PRIVATE "LINKER:-no_weak_exports,-exported_symbols_list,${symbols}")
 elseif(WIN32)
 else()
-  target_link_options(fdb_c PRIVATE "LINKER:--version-script=${CMAKE_CURRENT_SOURCE_DIR}/fdb_c.map,-z,nodelete")
+  target_link_options(fdb_c PRIVATE "LINKER:--version-script=${CMAKE_CURRENT_SOURCE_DIR}/fdb_c.map,-z,nodelete,-z,noexecstack")
 endif()
 target_include_directories(fdb_c PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>

--- a/contrib/pkg_tester/__snapshots__/test_fdb_pkgs.ambr
+++ b/contrib/pkg_tester/__snapshots__/test_fdb_pkgs.ambr
@@ -46,6 +46,34 @@
   
   '
 ---
+# name: test_execstack_permissions_libfdb_c[centos-versioned]
+  '
+    GNU_STACK      0x0000000000000000 0x0000000000000000 0x0000000000000000
+                   0x0000000000000000 0x0000000000000000  RW     0x0
+  
+  '
+---
+# name: test_execstack_permissions_libfdb_c[centos]
+  '
+    GNU_STACK      0x0000000000000000 0x0000000000000000 0x0000000000000000
+                   0x0000000000000000 0x0000000000000000  RW     0x0
+  
+  '
+---
+# name: test_execstack_permissions_libfdb_c[ubuntu-versioned]
+  '
+    GNU_STACK      0x0000000000000000 0x0000000000000000 0x0000000000000000
+                   0x0000000000000000 0x0000000000000000  RW     0x0
+  
+  '
+---
+# name: test_execstack_permissions_libfdb_c[ubuntu]
+  '
+    GNU_STACK      0x0000000000000000 0x0000000000000000 0x0000000000000000
+                   0x0000000000000000 0x0000000000000000  RW     0x0
+  
+  '
+---
 # name: test_fdbcli_help_text[centos-versioned]
   '
   FoundationDB CLI 7.0 (v7.0.0)

--- a/contrib/pkg_tester/test_fdb_pkgs.py
+++ b/contrib/pkg_tester/test_fdb_pkgs.py
@@ -54,7 +54,9 @@ class Container:
         # https://developers.redhat.com/blog/2016/09/13/running-systemd-in-a-non-privileged-container#the_quest
         extra_initd_args = []
         if initd:
-            extra_initd_args = "--tmpfs /tmp --tmpfs /run -v /sys/fs/cgroup:/sys/fs/cgroup:ro".split()
+            extra_initd_args = (
+                "--tmpfs /tmp --tmpfs /run -v /sys/fs/cgroup:/sys/fs/cgroup:ro".split()
+            )
 
         self.uid = str(uuid.uuid4())
 
@@ -103,6 +105,8 @@ def ubuntu_image_with_fdb_helper(versioned: bool) -> Iterator[Optional[Image]]:
         container = Container("ubuntu")
         for deb in debs:
             container.copy_to(deb, "/opt")
+        container.run(["bash", "-c", "apt-get update"])
+        container.run(["bash", "-c", "apt-get install --yes binutils"]) # this is for testing libfdb_c execstack permissions
         container.run(["bash", "-c", "dpkg -i /opt/*.deb"])
         container.run(["bash", "-c", "rm /opt/*.deb"])
         image = container.commit()
@@ -146,6 +150,8 @@ def centos_image_with_fdb_helper(versioned: bool) -> Iterator[Optional[Image]]:
         container = Container("centos", initd=True)
         for rpm in rpms:
             container.copy_to(rpm, "/opt")
+        container.run(["bash", "-c", "yum update -y"])
+        container.run(["bash", "-c", "yum install -y binutils"]) # this is for testing libfdb_c execstack permissions
         container.run(["bash", "-c", "yum install -y /opt/*.rpm"])
         container.run(["bash", "-c", "rm /opt/*.rpm"])
         image = container.commit()
@@ -233,6 +239,17 @@ def test_write(linux_container: Container, snapshot):
 
 def test_fdbcli_help_text(linux_container: Container, snapshot):
     assert snapshot == linux_container.run(["fdbcli", "--help"])
+
+
+def test_execstack_permissions_libfdb_c(linux_container: Container, snapshot):
+    linux_container.run(["ldconfig"])
+    assert snapshot == linux_container.run(
+        [
+            "bash",
+            "-c",
+            "readelf -l $(ldconfig -p | grep libfdb_c | awk '{print $(NF)}') | grep -A1 GNU_STACK",
+        ]
+    )
 
 
 def test_backup_restore(linux_container: Container, snapshot, tmp_path: pathlib.Path):


### PR DESCRIPTION
Cherry pick https://github.com/apple/foundationdb/pull/6120 to release-7.0



Tested by compiling and then using `execstack -q` to see if the stack is executable or not

Closes #6119 

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
