### PR TITLE
Fix memory issue with client watch metadata

### DIFF
--- a/fdbclient/DatabaseContext.h
+++ b/fdbclient/DatabaseContext.h
@@ -276,7 +276,7 @@ public:
 
 	// watch map operations
 	Reference<WatchMetadata> getWatchMetadata(KeyRef key) const;
-	KeyRef setWatchMetadata(Reference<WatchMetadata> metadata);
+	Key setWatchMetadata(Reference<WatchMetadata> metadata);
 	void deleteWatchMetadata(KeyRef key);
 	void clearWatchMetadata();
 

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -1915,7 +1915,7 @@ Reference<WatchMetadata> DatabaseContext::getWatchMetadata(KeyRef key) const {
 	return it->second;
 }
 
-KeyRef DatabaseContext::setWatchMetadata(Reference<WatchMetadata> metadata) {
+Key DatabaseContext::setWatchMetadata(Reference<WatchMetadata> metadata) {
 	watchMap[metadata->parameters->key] = metadata;
 	return metadata->parameters->key;
 }
@@ -2962,7 +2962,7 @@ ACTOR Future<Version> watchValue(Database cx, Reference<const WatchParameters> p
 	}
 }
 
-ACTOR Future<Void> watchStorageServerResp(KeyRef key, Database cx) {
+ACTOR Future<Void> watchStorageServerResp(Key key, Database cx) {
 	loop {
 		try {
 			state Reference<WatchMetadata> metadata = cx->getWatchMetadata(key);
@@ -3030,9 +3030,9 @@ ACTOR Future<Void> sameVersionDiffValue(Database cx, Reference<WatchParameters> 
 			// val_3 == val_2 (storage server value matches value passed into the function -> new watch)
 			if (valSS == parameters->value) {
 				metadata = makeReference<WatchMetadata>(parameters);
-				KeyRef keyRef = cx->setWatchMetadata(metadata);
+				Key key = cx->setWatchMetadata(metadata);
 
-				metadata->watchFutureSS = watchStorageServerResp(keyRef, cx);
+				metadata->watchFutureSS = watchStorageServerResp(key, cx);
 			}
 
 			// if val_3 != val_2
@@ -3055,9 +3055,9 @@ Future<Void> getWatchFuture(Database cx, Reference<WatchParameters> parameters) 
 	// case 1: key not in map
 	if (!metadata.isValid()) {
 		metadata = makeReference<WatchMetadata>(parameters);
-		KeyRef keyRef = cx->setWatchMetadata(metadata);
+		Key key = cx->setWatchMetadata(metadata);
 
-		metadata->watchFutureSS = watchStorageServerResp(keyRef, cx);
+		metadata->watchFutureSS = watchStorageServerResp(key, cx);
 		return success(metadata->watchPromise.getFuture());
 	}
 	// case 2: val_1 == val_2 (received watch with same value as key already in the map so just update)
@@ -3078,9 +3078,9 @@ Future<Void> getWatchFuture(Database cx, Reference<WatchParameters> parameters) 
 		metadata->watchFutureSS.cancel();
 
 		metadata = makeReference<WatchMetadata>(parameters);
-		KeyRef keyRef = cx->setWatchMetadata(metadata);
+		Key key = cx->setWatchMetadata(metadata);
 
-		metadata->watchFutureSS = watchStorageServerResp(keyRef, cx);
+		metadata->watchFutureSS = watchStorageServerResp(key, cx);
 
 		return success(metadata->watchPromise.getFuture());
 	}


### PR DESCRIPTION
Fixes a memory issue introduced by #6165. The watch map had been changed to hold Keys instead of KeyRefs, but then some usages of the key still held KeyRefs that could be invalidated.

Passed 1K valgrind correctness.
Passed 20K correctness.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
