### PR TITLE
Reject preprocessor directives in ACTORs

### DIFF
--- a/flow/actorcompiler/ActorParser.cs
+++ b/flow/actorcompiler/ActorParser.cs
@@ -929,6 +929,8 @@ namespace actorcompiler
                         Add(ParseStateDeclaration(toks));
                     else if (toks.First().Value == "switch" && toks.Any(t => t.Value == "return"))
                         throw new Error(toks.First().SourceLine, "Unsupported compound statement containing return.");
+                    else if (toks.First().Value.StartsWith("#"))
+                        throw new Error(toks.First().SourceLine, "Found \"{0}\". Preprocessor directives are not supported within ACTORs", toks.First().Value);
                     else if (toks.RevSkipWhile(t => t.Value == ";").Any(NonWhitespace))
                         Add(new PlainOldCodeStatement
                         {
@@ -1131,7 +1133,8 @@ namespace actorcompiler
             @"\n",
             @"::",
             @":",
-            @"."
+            @"#[a-z]*", // Recognize preprocessor directives so that we can reject them
+            @".",
         }).Select( x=>new Regex(@"\G"+x, RegexOptions.Singleline) ).ToArray();
 
         IEnumerable<string> Tokenize(string text)


### PR DESCRIPTION
The actor compiler does surprising things (and may even compile "successfully") if there's a preprocessor directive in an ACTOR. Disallow that. Tested by adding `#warning` inside an actor and seeing that it no longer compiles.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
