### PR TITLE
Add the functions to convert mock DNS to and from string.

### DIFF
--- a/fdbrpc/SimExternalConnection.actor.cpp
+++ b/fdbrpc/SimExternalConnection.actor.cpp
@@ -110,18 +110,17 @@ void MockDNS::clearMockTCPEndpoints() {
 
 std::string MockDNS::toString() {
 	std::string ret;
-	int i = 0;
-	for (auto it = hostnameToAddresses.begin(); it != hostnameToAddresses.end(); ++it, ++i) {
+	for (auto it = hostnameToAddresses.begin(); it != hostnameToAddresses.end(); ++it) {
+		if (it != hostnameToAddresses.begin()) {
+			ret += ';';
+		}
 		ret += it->first + ',';
-		std::vector<NetworkAddress> addresses = it->second;
-		for (int j = 0; j < addresses.size(); ++j) {
-			ret += addresses[j].toString();
-			if (j != addresses.size() - 1) {
+		const std::vector<NetworkAddress>& addresses = it->second;
+		for (int i = 0; i < addresses.size(); ++i) {
+			ret += addresses[i].toString();
+			if (i != addresses.size() - 1) {
 				ret += ',';
 			}
-		}
-		if (i != hostnameToAddresses.size() - 1) {
-			ret += ';';
 		}
 	}
 	return ret;

--- a/fdbrpc/SimExternalConnection.h
+++ b/fdbrpc/SimExternalConnection.h
@@ -41,6 +41,10 @@ public:
 	void removeMockTCPEndpoint(const std::string& host, const std::string& service);
 	void clearMockTCPEndpoints();
 	std::vector<NetworkAddress> getTCPEndpoint(const std::string& host, const std::string& service);
+	const std::map<std::string, std::vector<NetworkAddress>> getMockDNS() const { return hostnameToAddresses; }
+	void setMockDNS(const std::map<std::string, std::vector<NetworkAddress>>& mockDNS) {
+		hostnameToAddresses = mockDNS;
+	}
 
 private:
 	std::map<std::string, std::vector<NetworkAddress>> hostnameToAddresses;

--- a/fdbrpc/SimExternalConnection.h
+++ b/fdbrpc/SimExternalConnection.h
@@ -31,6 +31,10 @@
 // MockDNS is a class maintaining a <hostname, vector<NetworkAddress>> mapping, mocking a DNS in simulation.
 class MockDNS {
 public:
+	MockDNS() {}
+	explicit MockDNS(const std::map<std::string, std::vector<NetworkAddress>>& mockDNS)
+	  : hostnameToAddresses(mockDNS) {}
+
 	bool findMockTCPEndpoint(const std::string& host, const std::string& service);
 	void addMockTCPEndpoint(const std::string& host,
 	                        const std::string& service,
@@ -41,10 +45,12 @@ public:
 	void removeMockTCPEndpoint(const std::string& host, const std::string& service);
 	void clearMockTCPEndpoints();
 	std::vector<NetworkAddress> getTCPEndpoint(const std::string& host, const std::string& service);
-	const std::map<std::string, std::vector<NetworkAddress>> getMockDNS() const { return hostnameToAddresses; }
-	void setMockDNS(const std::map<std::string, std::vector<NetworkAddress>>& mockDNS) {
-		hostnameToAddresses = mockDNS;
-	}
+
+	void operator=(MockDNS const& rhs) { hostnameToAddresses = rhs.hostnameToAddresses; }
+	// Convert hostnameToAddresses to string. The format is:
+	// hostname1,host1Address1,host1Address2;hostname2,host2Address1,host2Address2...
+	std::string toString();
+	static MockDNS parseFromString(const std::string& s);
 
 private:
 	std::map<std::string, std::vector<NetworkAddress>> hostnameToAddresses;

--- a/fdbrpc/sim2.actor.cpp
+++ b/fdbrpc/sim2.actor.cpp
@@ -948,10 +948,10 @@ public:
 	void removeMockTCPEndpoint(const std::string& host, const std::string& service) override {
 		mockDNS.removeMockTCPEndpoint(host, service);
 	}
-	const std::map<std::string, std::vector<NetworkAddress>> getMockDNS() override { return mockDNS.getMockDNS(); }
-	void setMockDNS(std::map<std::string, std::vector<NetworkAddress>> otherMockDNS) override {
-		mockDNS.setMockDNS(otherMockDNS);
-	}
+	// Convert hostnameToAddresses from/to string. The format is:
+	// hostname1,host1Address1,host1Address2;hostname2,host2Address1,host2Address2...
+	void parseMockDNSFromString(const std::string& s) override { mockDNS = MockDNS::parseFromString(s); }
+	std::string convertMockDNSToString() override { return mockDNS.toString(); }
 	Future<std::vector<NetworkAddress>> resolveTCPEndpoint(const std::string& host,
 	                                                       const std::string& service) override {
 		// If a <hostname, vector<NetworkAddress>> pair was injected to mock DNS, use it.

--- a/fdbrpc/sim2.actor.cpp
+++ b/fdbrpc/sim2.actor.cpp
@@ -945,6 +945,13 @@ public:
 	                        const std::vector<NetworkAddress>& addresses) override {
 		mockDNS.addMockTCPEndpoint(host, service, addresses);
 	}
+	void removeMockTCPEndpoint(const std::string& host, const std::string& service) override {
+		mockDNS.removeMockTCPEndpoint(host, service);
+	}
+	const std::map<std::string, std::vector<NetworkAddress>> getMockDNS() override { return mockDNS.getMockDNS(); }
+	void setMockDNS(std::map<std::string, std::vector<NetworkAddress>> otherMockDNS) override {
+		mockDNS.setMockDNS(otherMockDNS);
+	}
 	Future<std::vector<NetworkAddress>> resolveTCPEndpoint(const std::string& host,
 	                                                       const std::string& service) override {
 		// If a <hostname, vector<NetworkAddress>> pair was injected to mock DNS, use it.

--- a/flow/Net2.actor.cpp
+++ b/flow/Net2.actor.cpp
@@ -151,12 +151,21 @@ public:
 	Future<Reference<IConnection>> connectExternal(NetworkAddress toAddr, const std::string& host) override;
 	Future<Reference<IUDPSocket>> createUDPSocket(NetworkAddress toAddr) override;
 	Future<Reference<IUDPSocket>> createUDPSocket(bool isV6) override;
-	// This method should only be used in simulation.
+	// The mock DNS methods should only be used in simulation.
 	void addMockTCPEndpoint(const std::string& host,
 	                        const std::string& service,
 	                        const std::vector<NetworkAddress>& addresses) override {
 		throw operation_failed();
 	}
+	// The mock DNS methods should only be used in simulation.
+	void removeMockTCPEndpoint(const std::string& host, const std::string& service) override {
+		throw operation_failed();
+	}
+	const std::map<std::string, std::vector<NetworkAddress>> getMockDNS() override { throw operation_failed(); }
+	void setMockDNS(std::map<std::string, std::vector<NetworkAddress>> otherMockDNS) override {
+		throw operation_failed();
+	}
+
 	Future<std::vector<NetworkAddress>> resolveTCPEndpoint(const std::string& host,
 	                                                       const std::string& service) override;
 	Reference<IListener> listen(NetworkAddress localAddr) override;

--- a/flow/Net2.actor.cpp
+++ b/flow/Net2.actor.cpp
@@ -161,10 +161,8 @@ public:
 	void removeMockTCPEndpoint(const std::string& host, const std::string& service) override {
 		throw operation_failed();
 	}
-	const std::map<std::string, std::vector<NetworkAddress>> getMockDNS() override { throw operation_failed(); }
-	void setMockDNS(std::map<std::string, std::vector<NetworkAddress>> otherMockDNS) override {
-		throw operation_failed();
-	}
+	void parseMockDNSFromString(const std::string& s) override { throw operation_failed(); }
+	std::string convertMockDNSToString() override { throw operation_failed(); }
 
 	Future<std::vector<NetworkAddress>> resolveTCPEndpoint(const std::string& host,
 	                                                       const std::string& service) override;

--- a/flow/network.cpp
+++ b/flow/network.cpp
@@ -134,12 +134,12 @@ Optional<NetworkAddress> NetworkAddress::parseOptional(std::string const& s) {
 std::vector<NetworkAddress> NetworkAddress::parseList(std::string const& addrs) {
 	// Split addrs on ',' and parse them individually
 	std::vector<NetworkAddress> coord;
-	for (int p = 0; p <= addrs.size();) {
+	for (int p = 0; p < addrs.length();) {
 		int pComma = addrs.find_first_of(',', p);
-		if (pComma == addrs.npos)
-			pComma = addrs.size();
-		NetworkAddress parsedAddress = NetworkAddress::parse(addrs.substr(p, pComma - p));
-		coord.push_back(parsedAddress);
+		if (pComma == addrs.npos) {
+			pComma = addrs.length();
+		}
+		coord.push_back(NetworkAddress::parse(addrs.substr(p, pComma - p)));
 		p = pComma + 1;
 	}
 	return coord;

--- a/flow/network.h
+++ b/flow/network.h
@@ -696,8 +696,8 @@ public:
 	                                const std::string& service,
 	                                const std::vector<NetworkAddress>& addresses) = 0;
 	virtual void removeMockTCPEndpoint(const std::string& host, const std::string& service) = 0;
-	virtual const std::map<std::string, std::vector<NetworkAddress>> getMockDNS() = 0;
-	virtual void setMockDNS(std::map<std::string, std::vector<NetworkAddress>> otherMockDNS) = 0;
+	virtual void parseMockDNSFromString(const std::string& s) = 0;
+	virtual std::string convertMockDNSToString() = 0;
 	// Resolve host name and service name (such as "http" or can be a plain number like "80") to a list of 1 or more
 	// NetworkAddresses
 	virtual Future<std::vector<NetworkAddress>> resolveTCPEndpoint(const std::string& host,

--- a/flow/network.h
+++ b/flow/network.h
@@ -695,6 +695,9 @@ public:
 	virtual void addMockTCPEndpoint(const std::string& host,
 	                                const std::string& service,
 	                                const std::vector<NetworkAddress>& addresses) = 0;
+	virtual void removeMockTCPEndpoint(const std::string& host, const std::string& service) = 0;
+	virtual const std::map<std::string, std::vector<NetworkAddress>> getMockDNS() = 0;
+	virtual void setMockDNS(std::map<std::string, std::vector<NetworkAddress>> otherMockDNS) = 0;
 	// Resolve host name and service name (such as "http" or can be a plain number like "80") to a list of 1 or more
 	// NetworkAddresses
 	virtual Future<std::vector<NetworkAddress>> resolveTCPEndpoint(const std::string& host,


### PR DESCRIPTION
These functions will be used in restarting tests, where mock DNS needs to be saved to and read from files.

20220115-032454-renxuan-5abb2d445a658c60           compressed=True data_size=28103027 duration=5590149 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=0:50:16 sanity=False started=100252 stopped=20220115-041510 submitted=20220115-032454 timeout=5400 username=renxuan

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
