### PR TITLE
Fix typo in comment

### DIFF
--- a/fdbcli/ExcludeCommand.actor.cpp
+++ b/fdbcli/ExcludeCommand.actor.cpp
@@ -33,7 +33,7 @@
 
 namespace {
 
-// Exclue the given servers and localities
+// Exclude the given servers and localities
 ACTOR Future<bool> excludeServersAndLocalities(Reference<IDatabase> db,
                                                std::vector<AddressExclusion> servers,
                                                std::unordered_set<std::string> localities,


### PR DESCRIPTION
I was looking into the exclusion internals and stumbled across that typo.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [x] Every function/class/actor that was touched is reasonably well documented.

