### PR TITLE
Update code documentation for cluster recovery

### DIFF
--- a/fdbclient/SystemData.h
+++ b/fdbclient/SystemData.h
@@ -326,7 +326,7 @@ extern const KeyRef backupPausedKey;
 extern const KeyRef coordinatorsKey;
 
 //	"\xff/logs" = "[[LogsValue]]"
-//	Used during master recovery in order to communicate
+//	Used during cluster recovery in order to communicate
 //	and store info about the logs system.
 extern const KeyRef logsKey;
 

--- a/fdbserver/ClusterController.actor.cpp
+++ b/fdbserver/ClusterController.actor.cpp
@@ -207,7 +207,7 @@ ACTOR Future<Void> clusterWatchDatabase(ClusterControllerData* cluster,
 
 			state Future<Void> spinDelay = delay(
 			    SERVER_KNOBS
-			        ->MASTER_SPIN_DELAY); // Don't retry master recovery more than once per second, but don't delay
+			        ->MASTER_SPIN_DELAY); // Don't retry cluster recovery more than once per second, but don't delay
 			                              // the "first" recovery after more than a second of normal operation
 
 			TraceEvent("CCWDB", cluster->id).detail("Watching", iMaster.id());

--- a/fdbserver/ClusterController.actor.h
+++ b/fdbserver/ClusterController.actor.h
@@ -2304,7 +2304,7 @@ public:
 	// FIXME: determine when to fail the cluster controller when a primaryDC has not been set
 
 	// This function returns true when the cluster controller determines it is worth forcing
-	// a master recovery in order to change the recruited processes in the transaction subsystem.
+	// a cluster recovery in order to change the recruited processes in the transaction subsystem.
 	bool betterMasterExists() {
 		const ServerDBInfo dbi = db.serverInfo->get();
 

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -4552,7 +4552,7 @@ ACTOR Future<Void> waitForAllDataRemoved(Database cx, UID serverID, Version adde
 			tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
 			Version ver = wait(tr->getReadVersion());
 
-			// we cannot remove a server immediately after adding it, because a perfectly timed master recovery could
+			// we cannot remove a server immediately after adding it, because a perfectly timed cluster recovery could
 			// cause us to not store the mutations sent to the short lived storage server.
 			if (ver > addedVersion + SERVER_KNOBS->MAX_READ_TRANSACTION_LIFE_VERSIONS) {
 				bool canRemove = wait(canRemoveStorageServer(tr, serverID));

--- a/fdbserver/ServerDBInfo.actor.h
+++ b/fdbserver/ServerDBInfo.actor.h
@@ -51,7 +51,7 @@ struct ServerDBInfo {
 	Optional<BlobManagerInterface> blobManager;
 	std::vector<ResolverInterface> resolvers;
 	DBRecoveryCount
-	    recoveryCount; // A recovery count from DBCoreState.  A successful master recovery increments it twice;
+	    recoveryCount; // A recovery count from DBCoreState.  A successful cluster recovery increments it twice;
 	                   // unsuccessful recoveries may increment it once. Depending on where the current master is in its
 	                   // recovery process, this might not have been written by the current master.
 	RecoveryState recoveryState;


### PR DESCRIPTION
Patch updates code documentation to reflect the recent code
refactoring where ClusterController process drives recovery
instead of sequencer/master process.

Put description here...

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
