### PR TITLE
Add support for 7.0 and 7.1 in transaction_profiling_analyzer

### DIFF
--- a/contrib/transaction_profiling_analyzer/transaction_profiling_analyzer.py
+++ b/contrib/transaction_profiling_analyzer/transaction_profiling_analyzer.py
@@ -48,8 +48,11 @@ PROTOCOL_VERSION_6_0 = 0x0FDB00A570010001
 PROTOCOL_VERSION_6_1 = 0x0FDB00B061060001
 PROTOCOL_VERSION_6_2 = 0x0FDB00B062010001
 PROTOCOL_VERSION_6_3 = 0x0FDB00B063010001
+PROTOCOL_VERSION_7_0 = 0x0FDB00B070010001
+PROTOCOL_VERSION_7_1 = 0x0FDB00B071010001
 supported_protocol_versions = frozenset([PROTOCOL_VERSION_5_2, PROTOCOL_VERSION_6_0, PROTOCOL_VERSION_6_1,
-                                         PROTOCOL_VERSION_6_2, PROTOCOL_VERSION_6_3])
+                                         PROTOCOL_VERSION_6_2, PROTOCOL_VERSION_6_3, PROTOCOL_VERSION_7_0,
+                                         PROTOCOL_VERSION_7_1])
 
 
 fdb.api_version(520)
@@ -166,6 +169,11 @@ class MutationType(Enum):
     MIN = 13
     SET_VERSION_STAMPED_KEY = 14
     SET_VERSION_STAMPED_VALUE = 15
+    BYTE_MIN = 16
+    BYTE_MAX = 17
+    MIN_V2 = 18
+    AND_V2 = 19
+    COMPARE_AND_CLEAR = 20
 
 
 class Mutation(object):
@@ -176,7 +184,11 @@ class Mutation(object):
 
 
 class BaseInfo(object):
+    """
+    Corresponds to FdbClientLogEvents::Event
+    """
     def __init__(self, bb, protocol_version):
+        # we already read the EventType, so go straight to start_timestamp
         self.start_timestamp = bb.get_double()
         if protocol_version >= PROTOCOL_VERSION_6_3:
             self.dc_id = bb.get_bytes_with_length()
@@ -281,6 +293,7 @@ class ClientTransactionInfo:
         protocol_version = bb.get_long()
         if protocol_version not in supported_protocol_versions:
             raise UnsupportedProtocolVersionError(protocol_version)
+        # keep in sync with subclasses of FdbClientLogEvents::Event in fdbclient/ClientLogEvents.h
         while bb.get_remaining_bytes():
             event = bb.get_int()
             if event == 0:

--- a/fdbclient/ClientLogEvents.h
+++ b/fdbclient/ClientLogEvents.h
@@ -37,7 +37,8 @@ enum class EventType {
 	UNSET
 };
 
-enum class TransactionPriorityType { PRIORITY_DEFAULT = 0, PRIORITY_BATCH = 1, PRIORITY_IMMEDIATE = 2, UNSET };
+enum class TransactionPriorityType : int { PRIORITY_DEFAULT = 0, PRIORITY_BATCH = 1, PRIORITY_IMMEDIATE = 2, UNSET };
+static_assert(sizeof(TransactionPriorityType) == 4, "transaction_profiling_analyzer.py assumes this field has size 4");
 
 struct Event {
 	Event(EventType t, double ts, const Optional<Standalone<StringRef>>& dc) : type(t), startTs(ts) {


### PR DESCRIPTION
I painstakingly went through both transaction_profiling_analyzer.py and
fdbclient/ClientLogEvents.h to make sure that we really can read these
versions. I also tested with a local cluster built from this source tree that I can read the client log event info with transaction_profiling_analyzer.py. I also added some comments I would have found helpful along the way.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
