### PR TITLE
Let FakeTLogs uses tLogGroupByStorageTeamID

### DIFF
--- a/fdbserver/ptxn/test/TestStorageServer.actor.cpp
+++ b/fdbserver/ptxn/test/TestStorageServer.actor.cpp
@@ -64,8 +64,6 @@ TEST_CASE("fdbserver/ptxn/test/StorageServerPull") {
 
 	wait(ptxn::test::messageFeeder());
 
-	ptxn::test::print::printCommitRecords();
-
 	std::vector<Future<InitializeStorageReply>> initializeStoreReplyFutures;
 	std::transform(std::begin(ptxn::test::TestEnvironment::getStorageServers()->initializeStorageReplies),
 	               std::end(ptxn::test::TestEnvironment::getStorageServers()->initializeStorageReplies),
@@ -75,7 +73,7 @@ TEST_CASE("fdbserver/ptxn/test/StorageServerPull") {
 
 	printTiming << "All storage servers are ready" << std::endl;
 
-	wait(delay(100));
+	wait(delay(10));
 
 	return Void();
 }


### PR DESCRIPTION
FakeTLogs was using its own LogGroupID<->StorageTeamID mapping mechanism
With this patch, it uses tLogGroupByStorageTeamID
Letting FakeTLogs behaves better.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
