### PR TITLE
Storage server should have storage team ID accessible

### DIFF
--- a/fdbserver/ptxn/TLogPeekCursor.actor.cpp
+++ b/fdbserver/ptxn/TLogPeekCursor.actor.cpp
@@ -350,6 +350,7 @@ void StorageTeamIDCursorMapper::addCursorImpl(const std::shared_ptr<StorageTeamP
 	const StorageTeamID& storageTeamID = cursor->getStorageTeamID();
 	ASSERT(!isCursorExists(storageTeamID));
 	mapper[storageTeamID] = std::shared_ptr<StorageTeamPeekCursor>(cursor);
+	storageTeamIDs.insert(storageTeamID);
 }
 
 std::shared_ptr<StorageTeamPeekCursor> StorageTeamIDCursorMapper::removeCursor(const StorageTeamID& storageTeamID) {
@@ -359,6 +360,7 @@ std::shared_ptr<StorageTeamPeekCursor> StorageTeamIDCursorMapper::removeCursor(c
 
 std::shared_ptr<StorageTeamPeekCursor> StorageTeamIDCursorMapper::removeCursorImpl(const StorageTeamID& storageTeamID) {
 	std::shared_ptr<StorageTeamPeekCursor> result = mapper[storageTeamID];
+	storageTeamIDs.erase(storageTeamID);
 	mapper.erase(storageTeamID);
 	return result;
 }

--- a/fdbserver/ptxn/TLogPeekCursor.actor.h
+++ b/fdbserver/ptxn/TLogPeekCursor.actor.h
@@ -28,6 +28,7 @@
 #include <functional>
 #include <memory>
 #include <unordered_map>
+#include <unordered_set>
 #include <set>
 #include <vector>
 
@@ -373,6 +374,7 @@ public:
 
 private:
 	StorageTeamIDCursorMapper_t mapper;
+	std::unordered_set<StorageTeamID> storageTeamIDs;
 
 public:
 	// Moves a cursor to the mapping system, the original cursor is invalidated
@@ -392,6 +394,9 @@ public:
 
 	// Gets the number of storage teams
 	int getNumCursors() const;
+
+	// Get currently active storage team IDs
+	const auto& getCursorStorageTeamIDs() const { return storageTeamIDs; }
 
 	// Returns the iterator points at the beginning of the (Storage Team ID, cursor) pair list.
 	StorageTeamIDCursorMapper_t::iterator cursorsBegin();
@@ -444,6 +449,7 @@ protected:
 
 public:
 	using details::StorageTeamIDCursorMapper::addCursor;
+	using details::StorageTeamIDCursorMapper::getCursorStorageTeamIDs;
 	using details::StorageTeamIDCursorMapper::getNumCursors;
 	using details::StorageTeamIDCursorMapper::isCursorExists;
 };

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -1113,8 +1113,9 @@ public:
 	              const StorageServerInterface& storageServerInterface,
 	              const StorageTeamID& privateMutationsStorageTeamID_)
 	  : StorageServerBase(pKVStore, serverDBInfo, storageServerInterface),
-	    storageServerStorageTeams(privateMutationsStorageTeamID_),
-		subscribedStorageTeamIDs{ privateMutationsStorageTeamID_ } {}
+	    storageServerStorageTeams(privateMutationsStorageTeamID_), subscribedStorageTeamIDs{
+		    privateMutationsStorageTeamID_
+	    } {}
 
 	void updateSubscribedStorageTeamIDs();
 };


### PR DESCRIPTION
This adds subscribedStorageTeamIDs to ptxn::StorageServer class, contains storage team ID the storage server is using.


# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
