### PR TITLE
Remove TLogGroupID from TLogPeekRequest & ServerPeekCursor

### DIFF
--- a/fdbclient/FDBTypes.h
+++ b/fdbclient/FDBTypes.h
@@ -78,7 +78,8 @@ using StorageTeamID = UID;
 // Transaction subsystem state (txnState) team.
 const StorageTeamID txsTeam = UID(1, 1);
 
-// Map from storage team id to a TLog group.
+// Map from storage team id to a TLog group. Note that the assignment must be consistent across calls/machines.
+// So the "tLogGroups" will be sorted internally.
 TLogGroupID tLogGroupByStorageTeamID(const std::vector<TLogGroupID>& tLogGroups, const StorageTeamID& storageTeamID);
 
 } // namespace ptxn

--- a/fdbserver/TagPartitionedLogSystem.actor.cpp
+++ b/fdbserver/TagPartitionedLogSystem.actor.cpp
@@ -1215,7 +1215,7 @@ Reference<ILogSystem::IPeekCursor> TagPartitionedLogSystem::peekSingle(UID dbgid
 		    .detail("TLog", tlogIf->get().id());
 		ASSERT(tLogGroup.present());
 		return makeReference<ptxn::ServerPeekCursor>(
-		    tlogIf, tag, storageTeam.get(), tLogGroup.get(), begin, getPeekEnd(), false, false);
+		    tlogIf, tag, storageTeam.get(), begin, getPeekEnd(), false, false);
 	}
 
 	while (history.size() && begin >= history.back().first) {

--- a/fdbserver/TagPartitionedLogSystem.actor.cpp
+++ b/fdbserver/TagPartitionedLogSystem.actor.cpp
@@ -1214,8 +1214,7 @@ Reference<ILogSystem::IPeekCursor> TagPartitionedLogSystem::peekSingle(UID dbgid
 		    .detail("Group", tLogGroup.get())
 		    .detail("TLog", tlogIf->get().id());
 		ASSERT(tLogGroup.present());
-		return makeReference<ptxn::ServerPeekCursor>(
-		    tlogIf, tag, storageTeam.get(), begin, getPeekEnd(), false, false);
+		return makeReference<ptxn::ServerPeekCursor>(tlogIf, tag, storageTeam.get(), begin, getPeekEnd(), false, false);
 	}
 
 	while (history.size() && begin >= history.back().first) {

--- a/fdbserver/ptxn/TLogInterface.h
+++ b/fdbserver/ptxn/TLogInterface.h
@@ -206,7 +206,6 @@ struct TLogPeekRequest {
 	Version beginVersion;
 	Optional<Version> endVersion;
 	StorageTeamID storageTeamID;
-	TLogGroupID tLogGroupID;
 
 	Tag tag;
 	bool returnIfBlocked;
@@ -220,10 +219,9 @@ struct TLogPeekRequest {
 	                const Optional<Version>& endVersion_,
 	                bool returnIfBlocked_,
 	                bool onlySpilled_,
-	                const StorageTeamID& storageTeamID_,
-	                const TLogGroupID& tLogGroupID_)
+	                const StorageTeamID& storageTeamID_)
 	  : debugID(debugID_), beginVersion(beginVersion_), endVersion(endVersion_), storageTeamID(storageTeamID_),
-	    tLogGroupID(tLogGroupID_), returnIfBlocked(returnIfBlocked_), onlySpilled(onlySpilled_) {}
+	    returnIfBlocked(returnIfBlocked_), onlySpilled(onlySpilled_) {}
 
 	template <typename Ar>
 	void serialize(Ar& ar) {
@@ -233,7 +231,6 @@ struct TLogPeekRequest {
 		           beginVersion,
 		           endVersion,
 		           storageTeamID,
-		           tLogGroupID,
 		           tag,
 		           returnIfBlocked,
 		           onlySpilled,

--- a/fdbserver/ptxn/TLogPeekCursor.actor.cpp
+++ b/fdbserver/ptxn/TLogPeekCursor.actor.cpp
@@ -711,12 +711,11 @@ ACTOR Future<Void> advanceTo(PeekCursorBase* cursor, Version version, Subsequenc
 ServerPeekCursor::ServerPeekCursor(Reference<AsyncVar<OptionalInterface<TLogInterface_PassivelyPull>>> interf,
                                    Tag tag,
                                    StorageTeamID storageTeamId,
-                                   TLogGroupID tLogGroupID,
                                    Version begin,
                                    Version end,
                                    bool returnIfBlocked,
                                    bool parallelGetMore)
-  : interf(interf), tag(tag), storageTeamId(storageTeamId), tLogGroupID(tLogGroupID),
+  : interf(interf), tag(tag), storageTeamId(storageTeamId),
     results(Optional<UID>(), emptyCursorHeader().arena(), emptyCursorHeader()),
     rd(results.arena, results.data, IncludeVersion(ProtocolVersion::withPartitionTransaction())), messageVersion(begin),
     end(end), dbgid(deterministicRandom()->randomUniqueID()), returnIfBlocked(returnIfBlocked),
@@ -725,7 +724,6 @@ ServerPeekCursor::ServerPeekCursor(Reference<AsyncVar<OptionalInterface<TLogInte
 	this->results.minKnownCommittedVersion = 0;
 	TraceEvent(SevDebug, "SPC_Starting", dbgid)
 	    .detail("Team", storageTeamId)
-	    .detail("Group", tLogGroupID)
 	    .detail("Tag", tag)
 	    .detail("Begin", begin)
 	    .detail("End", end);
@@ -738,9 +736,8 @@ ServerPeekCursor::ServerPeekCursor(TLogPeekReply const& results,
                                    bool hasMsg,
                                    Version poppedVersion,
                                    Tag tag,
-                                   StorageTeamID storageTeamId,
-                                   TLogGroupID tLogGroupID)
-  : tag(tag), storageTeamId(storageTeamId), tLogGroupID(tLogGroupID), results(results),
+                                   StorageTeamID storageTeamId)
+  : tag(tag), storageTeamId(storageTeamId), results(results),
     rd(results.arena, results.data, IncludeVersion(ProtocolVersion::withPartitionTransaction())),
     messageVersion(messageVersion), end(end), poppedVersion(poppedVersion), messageAndTags(message), hasMsg(hasMsg),
     dbgid(deterministicRandom()->randomUniqueID()) {
@@ -760,7 +757,7 @@ ServerPeekCursor::ServerPeekCursor(TLogPeekReply const& results,
 
 Reference<ILogSystem::IPeekCursor> ServerPeekCursor::cloneNoMore() {
 	return makeReference<ServerPeekCursor>(
-	    results, messageVersion, end, messageAndTags, hasMsg, poppedVersion, tag, storageTeamId, tLogGroupID);
+	    results, messageVersion, end, messageAndTags, hasMsg, poppedVersion, tag, storageTeamId);
 }
 
 void ServerPeekCursor::setProtocolVersion(ProtocolVersion version) {

--- a/fdbserver/ptxn/TLogPeekCursor.actor.cpp
+++ b/fdbserver/ptxn/TLogPeekCursor.actor.cpp
@@ -953,8 +953,7 @@ ACTOR Future<Void> serverPeekParallelGetMore(ServerPeekCursor* self, TaskPriorit
 					                                                               Optional<Version>(),
 					                                                               self->returnIfBlocked,
 					                                                               self->onlySpilled,
-					                                                               self->storageTeamId,
-					                                                               self->tLogGroupID),
+					                                                               self->storageTeamId),
 					                                               taskID)));
 				}
 				if (self->sequence == std::numeric_limits<decltype(self->sequence)>::max()) {
@@ -1038,8 +1037,7 @@ ACTOR Future<Void> serverPeekGetMore(ServerPeekCursor* self, TaskPriority taskID
 			                                                        Optional<Version>(),
 			                                                        self->returnIfBlocked,
 			                                                        self->onlySpilled,
-			                                                        self->storageTeamId,
-			                                                        self->tLogGroupID),
+			                                                        self->storageTeamId),
 			                                        taskID))
 			                                  : Never())) {
 				self->results = res;

--- a/fdbserver/ptxn/TLogPeekCursor.actor.h
+++ b/fdbserver/ptxn/TLogPeekCursor.actor.h
@@ -486,7 +486,6 @@ struct ServerPeekCursor final : ILogSystem::IPeekCursor, ReferenceCounted<Server
 	Reference<AsyncVar<OptionalInterface<TLogInterface_PassivelyPull>>> interf;
 	const Tag tag;
 	const StorageTeamID storageTeamId;
-	const TLogGroupID tLogGroupID;
 
 	ptxn::TLogPeekReply results;
 	ArenaReader rd;
@@ -522,7 +521,6 @@ struct ServerPeekCursor final : ILogSystem::IPeekCursor, ReferenceCounted<Server
 	ServerPeekCursor(Reference<AsyncVar<OptionalInterface<TLogInterface_PassivelyPull>>> interf,
 	                 Tag tag,
 	                 StorageTeamID storageTeamID,
-	                 TLogGroupID tLogGroupID,
 	                 Version begin,
 	                 Version end,
 	                 bool returnIfBlocked,
@@ -534,8 +532,7 @@ struct ServerPeekCursor final : ILogSystem::IPeekCursor, ReferenceCounted<Server
 	                 bool hasMsg,
 	                 Version poppedVersion,
 	                 Tag tag,
-	                 StorageTeamID storageTeamID,
-	                 TLogGroupID tLogGroupID);
+	                 StorageTeamID storageTeamID);
 
 	Reference<IPeekCursor> cloneNoMore() override;
 	void setProtocolVersion(ProtocolVersion version) override;

--- a/fdbserver/ptxn/test/Driver.actor.cpp
+++ b/fdbserver/ptxn/test/Driver.actor.cpp
@@ -70,6 +70,23 @@ TestDriverOptions::TestDriverOptions(const UnitTestParameters& params)
     transferModel(static_cast<MessageTransferModel>(
         params.getInt("messageTransferModel").orDefault(static_cast<int>(DEFAULT_MESSAGE_TRANSFER_MODEL)))) {}
 
+void TestDriverContext::updateServerDBInfo(Reference<AsyncVar<ServerDBInfo>> dbInfo) {
+	ServerDBInfo info;
+	LogSystemConfig& lsConfig = info.logSystemConfig;
+	lsConfig.logSystemType = LogSystemType::teamPartitioned;
+
+	// For now, assume we only have primary TLog set
+	lsConfig.tLogs.clear();
+	lsConfig.tLogs.emplace_back(TLogSet());
+	TLogSet& logset = lsConfig.tLogs[0];
+	for (const auto& group : tLogGroups) {
+		logset.tLogGroupIDs.push_back(group.logGroupId);
+	}
+	// TODO: fill in tLogsPtxn and ptxnTLogGroups fields
+
+	dbInfo->setUnconditional(info);
+}
+
 std::shared_ptr<TestDriverContext> initTestDriverContext(const TestDriverOptions& options) {
 	print::PrintTiming printTiming(__FUNCTION__);
 	print::print(options);

--- a/fdbserver/ptxn/test/Driver.h
+++ b/fdbserver/ptxn/test/Driver.h
@@ -124,6 +124,9 @@ struct TestDriverContext {
 
 	// Generated commits
 	CommitRecord commitRecord;
+
+	// Updates a ServerDBInfo object with this context.
+	void updateServerDBInfo(Reference<AsyncVar<ServerDBInfo>> dbInfo);
 };
 
 // Returns an initialized TestDriverContext with default values specified in "options".

--- a/fdbserver/ptxn/test/Driver.h
+++ b/fdbserver/ptxn/test/Driver.h
@@ -127,6 +127,8 @@ struct TestDriverContext {
 
 	// Updates a ServerDBInfo object with this context.
 	void updateServerDBInfo(Reference<AsyncVar<ServerDBInfo>> dbInfo);
+
+	TLogGroup& getTLogGroup(TLogGroupID gid);
 };
 
 // Returns an initialized TestDriverContext with default values specified in "options".

--- a/fdbserver/ptxn/test/TestTLogServer.actor.cpp
+++ b/fdbserver/ptxn/test/TestTLogServer.actor.cpp
@@ -729,8 +729,7 @@ TEST_CASE("/fdbserver/ptxn/test/read_persisted_disk_on_tlog") {
 	for (const auto& group : pContext->tLogGroups) {
 		ptxn::test::print::print(group);
 	}
-	const ptxn::TLogGroup& group = pContext->tLogGroups[0];
-	state ptxn::StorageTeamID storageTeamID = group.storageTeams.begin()->first;
+	state ptxn::StorageTeamID storageTeamID = pContext->storageTeamIDs[0];
 
 	state std::string folder = "simfdb/" + deterministicRandom()->randomAlphaNumeric(10);
 	platform::createDirectory(folder);
@@ -780,8 +779,7 @@ TEST_CASE("/fdbserver/ptxn/test/read_tlog_spilled") {
 	for (const auto& group : pContext->tLogGroups) {
 		ptxn::test::print::print(group);
 	}
-	const ptxn::TLogGroup& group = pContext->tLogGroups[0];
-	state ptxn::StorageTeamID storageTeamID = group.storageTeams.begin()->first;
+	state ptxn::StorageTeamID storageTeamID = pContext->storageTeamIDs[0];
 
 	state std::string folder = "simfdb/" + deterministicRandom()->randomAlphaNumeric(10);
 	platform::createDirectory(folder);
@@ -829,8 +827,7 @@ TEST_CASE("/fdbserver/ptxn/test/read_tlog_not_spilled_with_default_threshold") {
 	for (const auto& group : pContext->tLogGroups) {
 		ptxn::test::print::print(group);
 	}
-	const ptxn::TLogGroup& group = pContext->tLogGroups[0];
-	state ptxn::StorageTeamID storageTeamID = group.storageTeams.begin()->first;
+	state ptxn::StorageTeamID storageTeamID = pContext->storageTeamIDs[0];
 
 	state std::string folder = "simfdb/" + deterministicRandom()->randomAlphaNumeric(10);
 	platform::createDirectory(folder);
@@ -870,8 +867,7 @@ TEST_CASE("/fdbserver/ptxn/test/single_tlog_recovery") {
 	for (const auto& group : pContext->tLogGroups) {
 		ptxn::test::print::print(group);
 	}
-	const ptxn::TLogGroup& group = pContext->tLogGroups[0];
-	state ptxn::StorageTeamID storageTeamID = group.storageTeams.begin()->first;
+	state ptxn::StorageTeamID storageTeamID = pContext->storageTeamIDs[0];
 
 	state std::string folder = "simfdb/" + deterministicRandom()->randomAlphaNumeric(10);
 	platform::createDirectory(folder);

--- a/fdbserver/ptxn/test/TestTLogServer.actor.cpp
+++ b/fdbserver/ptxn/test/TestTLogServer.actor.cpp
@@ -213,8 +213,7 @@ ACTOR Future<Void> commitPeekAndCheck(std::shared_ptr<ptxn::test::TestDriverCont
 	                                  endVersion,
 	                                  false,
 	                                  false,
-	                                  storageTeamID,
-	                                  pContext->storageTeamIDTLogGroupIDMapper[storageTeamID]);
+	                                  storageTeamID);
 	ptxn::test::print::print(peekRequest);
 
 	ptxn::TLogPeekReply peekReply = wait(tli->peek.getReply(peekRequest));
@@ -444,7 +443,7 @@ ACTOR Future<Void> verifyPeek(std::shared_ptr<ptxn::test::TestDriverContext> pCo
 
 	state int receivedVersions = 0;
 	loop {
-		ptxn::TLogPeekRequest request(Optional<UID>(), version, 0, false, false, storageTeamID, tLogGroupID);
+		ptxn::TLogPeekRequest request(Optional<UID>(), version, 0, false, false, storageTeamID);
 		request.endVersion.reset();
 		ptxn::TLogPeekReply reply = wait(pInterface->peek.getReply(request));
 

--- a/fdbserver/ptxn/test/TestTLogServer.actor.cpp
+++ b/fdbserver/ptxn/test/TestTLogServer.actor.cpp
@@ -211,12 +211,7 @@ ACTOR Future<Void> commitPeekAndCheck(std::shared_ptr<ptxn::test::TestDriverCont
 	ptxn::test::print::print(commitReply);
 
 	// Peek
-	ptxn::TLogPeekRequest peekRequest(debugID,
-	                                  beginVersion,
-	                                  endVersion,
-	                                  false,
-	                                  false,
-	                                  storageTeamID);
+	ptxn::TLogPeekRequest peekRequest(debugID, beginVersion, endVersion, false, false, storageTeamID);
 	ptxn::test::print::print(peekRequest);
 
 	ptxn::TLogPeekReply peekReply = wait(tli->peek.getReply(peekRequest));

--- a/fdbserver/ptxn/test/TestTLogServer.actor.cpp
+++ b/fdbserver/ptxn/test/TestTLogServer.actor.cpp
@@ -172,9 +172,7 @@ const int COMMIT_PEEK_CHECK_MUTATIONS = 20;
 ACTOR Future<Void> commitPeekAndCheck(std::shared_ptr<ptxn::test::TestDriverContext> pContext) {
 	state ptxn::test::print::PrintTiming printTiming("tlog/commitPeekAndCheck");
 
-	const ptxn::TLogGroup& group = pContext->tLogGroups[0];
-	ASSERT(!group.storageTeams.empty());
-	state ptxn::StorageTeamID storageTeamID = group.storageTeams.begin()->first;
+	state ptxn::StorageTeamID storageTeamID = pContext->storageTeamIDs[0];
 	printTiming << "Storage Team ID: " << storageTeamID.toString() << std::endl;
 
 	state std::shared_ptr<ptxn::TLogInterfaceBase> tli = pContext->getTLogLeaderByStorageTeamID(storageTeamID);
@@ -570,13 +568,12 @@ TEST_CASE("/fdbserver/ptxn/test/commit_peek") {
 		ptxn::test::print::print(group);
 	}
 
-	const ptxn::TLogGroup& group = pContext->tLogGroups[0];
-	state ptxn::StorageTeamID storageTeamID = group.storageTeams.begin()->first;
-
 	state std::string folder = "simfdb/" + deterministicRandom()->randomAlphaNumeric(10);
 	platform::createDirectory(folder);
 
 	wait(startTLogServers(&actors, pContext, folder));
+
+	state ptxn::StorageTeamID storageTeamID = pContext->storageTeamIDs[0];
 	std::vector<Standalone<StringRef>> messages = wait(commitInject(pContext, storageTeamID, NUM_COMMITS));
 	wait(verifyPeek(pContext, storageTeamID, NUM_COMMITS));
 	platform::eraseDirectoryRecursive(folder);

--- a/fdbserver/ptxn/test/Utils.cpp
+++ b/fdbserver/ptxn/test/Utils.cpp
@@ -214,7 +214,7 @@ void printCommitRecords() {
 }
 
 void print(const TLogGroup& tLogGroup) {
-	std::cout << ">> WorkInterface.actor.h:TLogGroup:" << std::endl;
+	std::cout << ">> WorkInterface.actor.h:TLogGroup: " << tLogGroup.logGroupId << std::endl;
 	for (const auto& [storageTeamID, tags] : tLogGroup.storageTeams) {
 		std::cout << concatToString("\tStorage Team ID: ", storageTeamID, "\n");
 		std::cout << "\tTags:" << std::endl;

--- a/fdbserver/ptxn/test/Utils.cpp
+++ b/fdbserver/ptxn/test/Utils.cpp
@@ -108,8 +108,7 @@ void print(const TLogPeekRequest& request) {
 	std::cout << formatKVPair("Debug ID", request.debugID) << std::endl
 	          << formatKVPair("Begin version", request.beginVersion) << std::endl
 	          << formatKVPair("End version", request.endVersion) << std::endl
-	          << formatKVPair("Team ID", request.storageTeamID) << std::endl
-	          << formatKVPair("Log Group ID", request.tLogGroupID) << std::endl;
+	          << formatKVPair("Team ID", request.storageTeamID) << std::endl;
 }
 
 void print(const TLogPeekReply& reply) {


### PR DESCRIPTION
Fixed invalid tlog group at TLog by looking up the group ID at the TLog receiving the TLogPeekRequest. Also fixed test driver to use the consistent team to group mapping.

Correctness `20220122-000750-jzhou-876a5b352f538db4` has 2 unit tests failed at `FailedAssertion="fVers.get().size() == fRecoverCounts.get().size()" File="/root/src/foundationdb/fdbserver/ptxn/TLogServer.actor.cpp" Line="1543"`, which seems not related to this change.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
