### PR TITLE
Add the support for using hostname in simulation.

### DIFF
--- a/fdbserver/SimulatedCluster.actor.cpp
+++ b/fdbserver/SimulatedCluster.actor.cpp
@@ -249,6 +249,9 @@ class TestConfig {
 			if (attrib == "disableTss") {
 				disableTss = strcmp(value.c_str(), "true") == 0;
 			}
+			if (attrib == "disableHostname") {
+				disableHostname = strcmp(value.c_str(), "true") == 0;
+			}
 			if (attrib == "restartInfoLocation") {
 				isFirstTestInRestart = true;
 			}
@@ -276,6 +279,8 @@ public:
 	bool isFirstTestInRestart = false;
 	// 7.0 cannot be downgraded to 6.3 after enabling TSS, so disable TSS for 6.3 downgrade tests
 	bool disableTss = false;
+	// 7.1 cannot be downgraded to 7.0 and below after enabling hostname, so disable hostname for 7.0 downgrade tests
+	bool disableHostname = false;
 	// Storage Engine Types: Verify match with SimulationConfig::generateNormalConfig
 	//	0 = "ssd"
 	//	1 = "memory"
@@ -329,6 +334,7 @@ public:
 		    .add("storageEngineExcludeTypes", &storageEngineExcludeTypes)
 		    .add("maxTLogVersion", &maxTLogVersion)
 		    .add("disableTss", &disableTss)
+		    .add("disableHostname", &disableHostname)
 		    .add("simpleConfig", &simpleConfig)
 		    .add("generateFearless", &generateFearless)
 		    .add("datacenters", &datacenters)
@@ -1040,6 +1046,12 @@ ACTOR Future<Void> restartSimulatedSystem(std::vector<Future<Void>>* systemActor
 		ClusterConnectionString conn(ini.GetValue("META", "connectionString"));
 		if (enableExtraDB) {
 			g_simulator.extraDB = new ClusterConnectionString(ini.GetValue("META", "connectionString"));
+		}
+		if (!testConfig.disableHostname) {
+			auto mockDNSStr = ini.GetValue("META", "mockDNS");
+			if (mockDNSStr != nullptr) {
+				INetworkConnections::net()->parseMockDNSFromString(mockDNSStr);
+			}
 		}
 		*pConnString = conn;
 		*pTesterCount = testerCount;
@@ -1883,6 +1895,7 @@ void setupSimulatedSystem(std::vector<Future<Void>>* systemActors,
 	// Use SSL 5% of the time
 	bool sslEnabled = deterministicRandom()->random01() < 0.10;
 	bool sslOnly = sslEnabled && deterministicRandom()->coinflip();
+	bool isTLS = sslEnabled && sslOnly;
 	g_simulator.listenersPerProcess = sslEnabled && !sslOnly ? 2 : 1;
 	TEST(sslEnabled); // SSL enabled
 	TEST(!sslEnabled); // SSL disabled
@@ -1892,8 +1905,18 @@ void setupSimulatedSystem(std::vector<Future<Void>>* systemActors,
 	TEST(useIPv6); // Use IPv6
 	TEST(!useIPv6); // Use IPv4
 
+	// TODO(renxuan): Use hostname 25% of the time, unless it is disabled
+	bool useHostname = false; // !testConfig.disableHostname && deterministicRandom()->random01() < 0.25;
+	TEST(useHostname); // Use hostname
+	TEST(!useHostname); // Use IP address
+	NetworkAddressFromHostname fromHostname =
+	    useHostname ? NetworkAddressFromHostname::True : NetworkAddressFromHostname::False;
+
 	std::vector<NetworkAddress> coordinatorAddresses;
+	std::vector<Hostname> coordinatorHostnames;
 	std::vector<NetworkAddress> extraCoordinatorAddresses; // Used by extra DB if the DR db is a new one
+	std::vector<Hostname> extraCoordinatorHostnames;
+
 	if (testConfig.minimumRegions > 1) {
 		// do not put coordinators in the primary region so that we can kill that region safely
 		int nonPrimaryDcs = dataCenters / 2;
@@ -1901,12 +1924,27 @@ void setupSimulatedSystem(std::vector<Future<Void>>* systemActors,
 			int dcCoordinators = coordinatorCount / nonPrimaryDcs + ((dc - 1) / 2 < coordinatorCount % nonPrimaryDcs);
 			for (int m = 0; m < dcCoordinators; m++) {
 				auto ip = makeIPAddressForSim(useIPv6, { 2, dc, 1, m });
-				coordinatorAddresses.push_back(
-				    NetworkAddress(ip, sslEnabled && !sslOnly ? 2 : 1, true, sslEnabled && sslOnly));
+				uint16_t port = sslEnabled && !sslOnly ? 2 : 1;
+				NetworkAddress coordinator(ip, port, true, isTLS, fromHostname);
+				coordinatorAddresses.push_back(coordinator);
 				auto extraIp = makeIPAddressForSim(useIPv6, { 4, dc, 1, m });
-				extraCoordinatorAddresses.push_back(
-				    NetworkAddress(extraIp, sslEnabled && !sslOnly ? 2 : 1, true, sslEnabled && sslOnly));
-				TraceEvent("SelectedCoordinator").detail("Address", coordinatorAddresses.back());
+				NetworkAddress extraCoordinator(extraIp, port, true, isTLS, fromHostname);
+				extraCoordinatorAddresses.push_back(extraCoordinator);
+
+				if (useHostname) {
+					std::string hostname = "fakeCoordinatorDC" + std::to_string(dc) + "M" + std::to_string(m);
+					Hostname coordinatorHostname(hostname, std::to_string(port), isTLS);
+					coordinatorHostnames.push_back(coordinatorHostname);
+					INetworkConnections::net()->addMockTCPEndpoint(hostname, std::to_string(port), { coordinator });
+					hostname = "fakeExtraCoordinatorDC" + std::to_string(dc) + "M" + std::to_string(m);
+					Hostname extraCoordinatorHostname(hostname, std::to_string(port), isTLS);
+					extraCoordinatorHostnames.push_back(extraCoordinatorHostname);
+					INetworkConnections::net()->addMockTCPEndpoint(
+					    hostname, std::to_string(port), { extraCoordinator });
+				}
+				TraceEvent("SelectedCoordinator")
+				    .detail("Hostname", useHostname ? coordinatorHostnames.back().toString().c_str() : "N/A")
+				    .detail("Address", coordinatorAddresses.back());
 			}
 		}
 	} else {
@@ -1932,12 +1970,25 @@ void setupSimulatedSystem(std::vector<Future<Void>>* systemActors,
 					    .detail("CoordinatorCount", coordinatorCount);
 				} else {
 					auto ip = makeIPAddressForSim(useIPv6, { 2, dc, 1, m });
-					coordinatorAddresses.push_back(
-					    NetworkAddress(ip, sslEnabled && !sslOnly ? 2 : 1, true, sslEnabled && sslOnly));
+					uint16_t port = sslEnabled && !sslOnly ? 2 : 1;
+					NetworkAddress coordinator(ip, port, true, isTLS, fromHostname);
+					coordinatorAddresses.push_back(coordinator);
 					auto extraIp = makeIPAddressForSim(useIPv6, { 4, dc, 1, m });
-					extraCoordinatorAddresses.push_back(
-					    NetworkAddress(extraIp, sslEnabled && !sslOnly ? 2 : 1, true, sslEnabled && sslOnly));
+					NetworkAddress extraCoordinator(extraIp, port, true, isTLS, fromHostname);
+					extraCoordinatorAddresses.push_back(extraCoordinator);
+					if (useHostname) {
+						std::string hostname = "fakeCoordinatorDC" + std::to_string(dc) + "M" + std::to_string(m);
+						Hostname coordinatorHostname(hostname, std::to_string(port), isTLS);
+						coordinatorHostnames.push_back(coordinatorHostname);
+						INetworkConnections::net()->addMockTCPEndpoint(hostname, std::to_string(port), { coordinator });
+						hostname = "fakeExtraCoordinatorDC" + std::to_string(dc) + "M" + std::to_string(m);
+						Hostname extraCoordinatorHostname(hostname, std::to_string(port), isTLS);
+						extraCoordinatorHostnames.push_back(extraCoordinatorHostname);
+						INetworkConnections::net()->addMockTCPEndpoint(
+						    hostname, std::to_string(port), { extraCoordinator });
+					}
 					TraceEvent("SelectedCoordinator")
+					    .detail("Hostname", useHostname ? coordinatorHostnames.back().toString().c_str() : "N/A")
 					    .detail("Address", coordinatorAddresses.back())
 					    .detail("M", m)
 					    .detail("Machines", machines)
@@ -1970,20 +2021,30 @@ void setupSimulatedSystem(std::vector<Future<Void>>* systemActors,
 
 	ASSERT_EQ(coordinatorAddresses.size(), coordinatorCount);
 	ClusterConnectionString conn(coordinatorAddresses, LiteralStringRef("TestCluster:0"));
+	if (useHostname) {
+		conn = ClusterConnectionString(coordinatorHostnames, LiteralStringRef("TestCluster:0"));
+	}
 
 	// If extraDB==0, leave g_simulator.extraDB as null because the test does not use DR.
 	if (testConfig.extraDB == 1) {
 		// The DR database can be either a new database or itself
 		g_simulator.extraDB =
-		    BUGGIFY ? new ClusterConnectionString(coordinatorAddresses, LiteralStringRef("TestCluster:0"))
-		            : new ClusterConnectionString(extraCoordinatorAddresses, LiteralStringRef("ExtraCluster:0"));
+		    BUGGIFY
+		        ? (useHostname ? new ClusterConnectionString(coordinatorHostnames, LiteralStringRef("TestCluster:0"))
+		                       : new ClusterConnectionString(coordinatorAddresses, LiteralStringRef("TestCluster:0")))
+		        : (useHostname
+		               ? new ClusterConnectionString(extraCoordinatorHostnames, LiteralStringRef("ExtraCluster:0"))
+		               : new ClusterConnectionString(extraCoordinatorAddresses, LiteralStringRef("ExtraCluster:0")));
 	} else if (testConfig.extraDB == 2) {
 		// The DR database is a new database
 		g_simulator.extraDB =
-		    new ClusterConnectionString(extraCoordinatorAddresses, LiteralStringRef("ExtraCluster:0"));
+		    useHostname ? new ClusterConnectionString(extraCoordinatorHostnames, LiteralStringRef("ExtraCluster:0"))
+		                : new ClusterConnectionString(extraCoordinatorAddresses, LiteralStringRef("ExtraCluster:0"));
 	} else if (testConfig.extraDB == 3) {
 		// The DR database is the same database
-		g_simulator.extraDB = new ClusterConnectionString(coordinatorAddresses, LiteralStringRef("TestCluster:0"));
+		g_simulator.extraDB =
+		    useHostname ? new ClusterConnectionString(coordinatorHostnames, LiteralStringRef("TestCluster:0"))
+		                : new ClusterConnectionString(coordinatorAddresses, LiteralStringRef("TestCluster:0"));
 	}
 
 	*pConnString = conn;

--- a/fdbserver/tester.actor.cpp
+++ b/fdbserver/tester.actor.cpp
@@ -1083,7 +1083,9 @@ std::map<std::string, std::function<void(const std::string&)>> testSpecGlobalKey
 	  [](const std::string& value) { TraceEvent("TestParserTest").detail("ParsedStorageEngineExcludeTypes", ""); } },
 	{ "maxTLogVersion",
 	  [](const std::string& value) { TraceEvent("TestParserTest").detail("ParsedMaxTLogVersion", ""); } },
-	{ "disableTss", [](const std::string& value) { TraceEvent("TestParserTest").detail("ParsedDisableTSS", ""); } }
+	{ "disableTss", [](const std::string& value) { TraceEvent("TestParserTest").detail("ParsedDisableTSS", ""); } },
+	{ "disableHostname",
+	  [](const std::string& value) { TraceEvent("TestParserTest").detail("ParsedDisableHostname", ""); } }
 };
 
 std::map<std::string, std::function<void(const std::string& value, TestSpec* spec)>> testSpecTestKeys = {

--- a/fdbserver/workloads/SaveAndKill.actor.cpp
+++ b/fdbserver/workloads/SaveAndKill.actor.cpp
@@ -66,6 +66,7 @@ struct SaveAndKillWorkload : TestWorkload {
 		ini.SetValue("META", "connectionString", g_simulator.connectionString.c_str());
 		ini.SetValue("META", "testerCount", format("%d", g_simulator.testerCount).c_str());
 		ini.SetValue("META", "tssMode", format("%d", g_simulator.tssMode).c_str());
+		ini.SetValue("META", "mockDNS", INetworkConnections::net()->convertMockDNSToString().c_str());
 
 		std::vector<ISimulator::ProcessInfo*> processes = g_simulator.getAllProcesses();
 		std::map<NetworkAddress, ISimulator::ProcessInfo*> rebootingProcesses = g_simulator.currentlyRebootingProcesses;

--- a/tests/restarting/to_7.0.0/CycleTestRestart-1.toml
+++ b/tests/restarting/to_7.0.0/CycleTestRestart-1.toml
@@ -2,6 +2,7 @@
 storageEngineExcludeTypes=[-1,-2]
 maxTLogVersion=6
 disableTss=true
+disableHostname=true
 
 [[test]]
 testTitle='Clogged'

--- a/tests/restarting/to_7.0.0/CycleTestRestart-2.toml
+++ b/tests/restarting/to_7.0.0/CycleTestRestart-2.toml
@@ -2,6 +2,7 @@
 storageEngineExcludeTypes=[-1,-2]
 maxTLogVersion=6
 disableTss=true
+disableHostname=true
 
 [[test]]
 testTitle='Clogged'


### PR DESCRIPTION
This PR does NOT turn the feature on. Also, disable hostname in downgrade restarting tests.

20220121-032155-renxuan-40a38d1b3e140002           compressed=True data_size=28128486 duration=5311678 ended=100002 fail_fast=10 max_runs=100000 pass=100002 priority=100 remaining=0 runtime=0:58:53 sanity=False started=100166 stopped=20220121-042048 submitted=20220121-032155 timeout=5400 username=renxuan

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
