### PR TITLE
Adding Finalizer timing to FDBTransaction.java

### DIFF
--- a/bindings/java/src/main/com/apple/foundationdb/EventKeeper.java
+++ b/bindings/java/src/main/com/apple/foundationdb/EventKeeper.java
@@ -128,7 +128,15 @@ public interface EventKeeper {
 		 * The number of JNI calls that were exercised.
 		 */
 		JNI_CALL,
-
+		/**
+		 * The time spent in the FDBTransaction finalizer
+		 */
+		TRANSACTION_FINALIZER_TIME_NANOS {
+			@Override
+			public boolean isTimeEvent() {
+				return true;
+			}
+		},
 		/**
 		 * The total number of bytes pulled from the native layer, including length delimiters., from
 		 * {@link Transaction#get(byte[])}, {@link Transaction#getKey(KeySelector)},

--- a/bindings/java/src/main/com/apple/foundationdb/FDBTransaction.java
+++ b/bindings/java/src/main/com/apple/foundationdb/FDBTransaction.java
@@ -24,6 +24,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
 import com.apple.foundationdb.EventKeeper.Events;
@@ -756,12 +757,17 @@ class FDBTransaction extends NativeObjectWrapper implements Transaction, OptionC
 
 	@Override
 	protected void finalize() throws Throwable {
+		long start = System.nanoTime();
 		try {
 			checkUnclosed("Transaction");
 			close();
 		}
 		finally {
 			super.finalize();
+			long end = System.nanoTime();
+			if(eventKeeper!=null){
+				eventKeeper.time(EventKeeper.Events.TRANSACTION_FINALIZER_TIME_NANOS, end-start, TimeUnit.NANOSECONDS);
+			}
 		}
 	}
 


### PR DESCRIPTION
This adds a simple latency time measurement to calls made to `FDBTransaction.java#finalize()` so that the time spent in finalization can be measured.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.
