### PR TITLE
Unset the last bit of the protocol version

### DIFF
--- a/flow/ProtocolVersion.h
+++ b/flow/ProtocolVersion.h
@@ -22,7 +22,24 @@
 #include <cstdint>
 #include "flow/Trace.h"
 
+// This version impacts both communications and the deserialization of certain database and IKeyValueStore keys.
+//
+// The convention is that 'x' and 'y' should match the major and minor version of the software, and 'z' should be 0.
+// To make a change without a corresponding increase to the x.y version, increment the 'dev' digit.
+//
+// The last 2 bytes (4 digits) of the protocol version do not affect compatibility. These two bytes are not currently
+// used and should not be changed from 0.
+//                                                         xyzdev
+//                                                         vvvv
+constexpr uint64_t currentProtocolVersionValue = 0x0FDB00B071010000LL;
+
+// The first protocol version that cannot be downgraded from. Ordinarily, this will be two release versions larger
+// than the current version, meaning that we only support downgrades between consecutive release versions.
+constexpr uint64_t minInvalidProtocolVersionValue = 0x0FDB00B073000000LL;
+
 #define PROTOCOL_VERSION_FEATURE(v, x)                                                                                 \
+	static_assert((v & 0xF0FFFFLL) == 0 || v < 0x0FDB00B071000000LL, "Unexpected feature protocol version");           \
+	static_assert(v <= currentProtocolVersionValue, "Feature protocol version too large");                             \
 	struct x {                                                                                                         \
 		static constexpr uint64_t protocolVersion = v;                                                                 \
 	};                                                                                                                 \
@@ -151,17 +168,24 @@ struct Traceable<ProtocolVersion> : std::true_type {
 	}
 };
 
-// These impact both communications and the deserialization of certain database and IKeyValueStore keys.
-//
-// The convention is that 'x' and 'y' should match the major and minor version of the software, and 'z' should be 0.
-// To make a change without a corresponding increase to the x.y version, increment the 'dev' digit.
-//
-//                                                         xyzdev
-//                                                         vvvv
-constexpr ProtocolVersion currentProtocolVersion(0x0FDB00B071010000LL);
+constexpr ProtocolVersion currentProtocolVersion(currentProtocolVersionValue);
+constexpr ProtocolVersion minInvalidProtocolVersion(minInvalidProtocolVersionValue);
+
 // This assert is intended to help prevent incrementing the leftmost digits accidentally. It will probably need to
 // change when we reach version 10.
 static_assert(currentProtocolVersion.version() < 0x0FDB00B100000000LL, "Unexpected protocol version");
 
-// Downgrades are only supported for one minor version
-constexpr ProtocolVersion minInvalidProtocolVersion(0x0FDB00B073000000LL);
+// The last two bytes of the protocol version are currently masked out in compatibility checks. We do not use them,
+// so prevent them from being inadvertently changed.
+//
+// We also do not modify the protocol version for patch releases, so prevent modifying the patch version digit.
+static_assert((currentProtocolVersion.version() & 0xF0FFFFLL) == 0, "Unexpected protocol version");
+
+// Downgrades must support at least one minor version.
+static_assert(minInvalidProtocolVersion.version() >=
+                  (currentProtocolVersion.version() & 0xFFFFFFFFFF000000LL) + 0x0000000002000000,
+              "Downgrades must support one minor version");
+
+// The min invalid protocol version should be the smallest possible protocol version associated with a minor release
+// version.
+static_assert((minInvalidProtocolVersion.version() & 0xFFFFFFLL) == 0, "Unexpected min invalid protocol version");

--- a/flow/ProtocolVersion.h
+++ b/flow/ProtocolVersion.h
@@ -121,7 +121,6 @@ public: // introduced features
 	PROTOCOL_VERSION_FEATURE(0x0FDB00B062010001LL, CloseUnusedConnection);
 	PROTOCOL_VERSION_FEATURE(0x0FDB00B063010000LL, DBCoreState);
 	PROTOCOL_VERSION_FEATURE(0x0FDB00B063010000LL, TagThrottleValue);
-	PROTOCOL_VERSION_FEATURE(0x0FDB00B070010001LL, ServerListValue);
 	PROTOCOL_VERSION_FEATURE(0x0FDB00B063010000LL, StorageCacheValue);
 	PROTOCOL_VERSION_FEATURE(0x0FDB00B063010000LL, RestoreStatusValue);
 	PROTOCOL_VERSION_FEATURE(0x0FDB00B063010000LL, RestoreRequestValue);
@@ -136,12 +135,13 @@ public: // introduced features
 	PROTOCOL_VERSION_FEATURE(0x0FDB00B063010000LL, SmallEndpoints);
 	PROTOCOL_VERSION_FEATURE(0x0FDB00B063010000LL, CacheRole);
 	PROTOCOL_VERSION_FEATURE(0x0FDB00B070010000LL, StableInterfaces);
+	PROTOCOL_VERSION_FEATURE(0x0FDB00B070010001LL, ServerListValue);
 	PROTOCOL_VERSION_FEATURE(0x0FDB00B070010001LL, TagThrottleValueReason);
 	PROTOCOL_VERSION_FEATURE(0x0FDB00B070010001LL, SpanContext);
 	PROTOCOL_VERSION_FEATURE(0x0FDB00B070010001LL, TSS);
-	PROTOCOL_VERSION_FEATURE(0x0FDB00B071010001LL, ChangeFeed);
-	PROTOCOL_VERSION_FEATURE(0x0FDB00B071010001LL, BlobGranule);
-	PROTOCOL_VERSION_FEATURE(0x0FDB00B071010001LL, NetworkAddressHostnameFlag);
+	PROTOCOL_VERSION_FEATURE(0x0FDB00B071010000LL, ChangeFeed);
+	PROTOCOL_VERSION_FEATURE(0x0FDB00B071010000LL, BlobGranule);
+	PROTOCOL_VERSION_FEATURE(0x0FDB00B071010000LL, NetworkAddressHostnameFlag);
 };
 
 template <>
@@ -158,7 +158,7 @@ struct Traceable<ProtocolVersion> : std::true_type {
 //
 //                                                         xyzdev
 //                                                         vvvv
-constexpr ProtocolVersion currentProtocolVersion(0x0FDB00B071010001LL);
+constexpr ProtocolVersion currentProtocolVersion(0x0FDB00B071010000LL);
 // This assert is intended to help prevent incrementing the leftmost digits accidentally. It will probably need to
 // change when we reach version 10.
 static_assert(currentProtocolVersion.version() < 0x0FDB00B100000000LL, "Unexpected protocol version");

--- a/flow/serialize.h
+++ b/flow/serialize.h
@@ -314,7 +314,7 @@ struct _IncludeVersion {
 			throw err;
 		}
 		if (v >= minInvalidProtocolVersion) {
-			// Downgrades are only supported for one minor version
+			// The version v is too large to be downgraded from.
 			auto err = incompatible_protocol_version();
 			TraceEvent(SevError, "FutureProtocolVersion").error(err).detailf("Version", "%llx", v.versionWithFlags());
 			throw err;


### PR DESCRIPTION
The last bit of the protocol version has been set, though this bit is typically masked out and I don't think has a need to be used here. I've unset it and also reordered the various protocol version feature declarations to match their version order.

This adds some comments documenting the expectations for the protocol version and the min invalid protocol version, and it also adds some static assertions to ensure that those expectations are being met.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
