### PR TITLE
Use ObjectWriter to write storage cache data (fixes CycleTestRestart downgrade test)

### DIFF
--- a/fdbclient/SystemData.cpp
+++ b/fdbclient/SystemData.cpp
@@ -228,9 +228,11 @@ const Key storageCacheServerKey(UID id) {
 }
 
 const Value storageCacheServerValue(const StorageServerInterface& ssi) {
-	BinaryWriter wr(IncludeVersion());
-	wr << ssi;
-	return wr.toValue();
+	auto protocolVersion = currentProtocolVersion;
+	protocolVersion.addObjectSerializerFlag();
+	ObjectWriter writer(IncludeVersion(protocolVersion));
+	writer.serialize(ssi);
+	return writer.toStringRef();
 }
 
 const KeyRangeRef ddStatsRange = KeyRangeRef(LiteralStringRef("\xff\xff/metrics/data_distribution_stats/"),


### PR DESCRIPTION
Using `ObjectWriter` to serialize the `StorageServerInterface`, allowing FDB 7.0 to continue to deserialize it even as fields are added (#6053 adds a new field to `NetworkAddress`, which is contained as a nested field within an object in `StorageServerInterface`).

Passed 10k `CycleTestRestart` main -> 7.0 downgrade tests.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
