### PR TITLE
Use printable when formatting change feed ranges in fdbcli

### DIFF
--- a/fdbcli/ChangeFeedCommand.actor.cpp
+++ b/fdbcli/ChangeFeedCommand.actor.cpp
@@ -48,10 +48,10 @@ ACTOR Future<Void> changeFeedList(Database db) {
 			printf("Found %d range feeds%s\n", result.size(), result.size() == 0 ? "." : ":");
 			for (auto& it : result) {
 				auto range = std::get<0>(decodeChangeFeedValue(it.value));
-				printf("  %s: %s - %s\n",
+				printf("  %s: `%s' - `%s'\n",
 				       it.key.removePrefix(changeFeedPrefix).toString().c_str(),
-				       range.begin.toString().c_str(),
-				       range.end.toString().c_str());
+				       printable(range.begin).c_str(),
+				       printable(range.end).c_str());
 			}
 			return Void();
 		} catch (Error& e) {


### PR DESCRIPTION
Change feed ranges can include unprintable characters, so they should use printable when displaying them. Tested manually using fdbcli, an example output is the following:

```
fdb> changefeed list
Found 1 range feeds:
  myfeed: `\x15 a' - `\x15 z'
```

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
