### PR TITLE
Support other output streams in fdbcli printAtCol

### DIFF
--- a/fdbcli/fdbcli.actor.cpp
+++ b/fdbcli/fdbcli.actor.cpp
@@ -125,7 +125,7 @@ CSimpleOpt::SOption g_rgOptions[] = { { OPT_CONNFILE, "-C", SO_REQ_SEP },
 
 	                                      SO_END_OF_OPTIONS };
 
-void printAtCol(const char* text, int col) {
+void printAtCol(const char* text, int col, FILE* stream = stdout) {
 	const char* iter = text;
 	const char* start = text;
 	const char* space = nullptr;
@@ -137,7 +137,7 @@ void printAtCol(const char* text, int col) {
 		if (*iter == '\n' || *iter == '\0' || (iter - start == col)) {
 			if (!space)
 				space = iter;
-			printf("%.*s\n", (int)(space - start), start);
+			fprintf(stream, "%.*s\n", (int)(space - start), start);
 			start = space;
 			if (*start == ' ' || *start == '\n')
 				start++;


### PR DESCRIPTION
The `printAtCol` function does some helpful wrapping, etc. for printing in `fdbcli`. Update this function to allow printing to other streams, such as `stderr`.

Tested manually in fdbcli:

```
fdb> help getrange

getrange <BEGINKEY> [ENDKEY] [LIMIT]

Fetch key/value pairs in a range of keys.

Displays up to LIMIT keys and values for keys between BEGINKEY (inclusive) and
ENDKEY (exclusive). If ENDKEY is omitted, then the range will include all keys
starting with BEGINKEY. LIMIT defaults to 25 if omitted.

For information on escaping keys, type `help escaping'.
```

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
