### PR TITLE
Add a hash function for Optional and a default boost hash function

### DIFF
--- a/flow/Arena.cpp
+++ b/flow/Arena.cpp
@@ -613,3 +613,40 @@ TEST_CASE("/flow/Arena/SmallVectorRef10") {
 	testVectorLike<SmallVectorRef10Proxy>();
 	return Void();
 }
+
+TEST_CASE("/flow/Arena/OptionalHash") {
+	std::hash<Optional<int>> hashFunc{};
+	Optional<int> a;
+	Optional<int> b;
+	Optional<int> c = 1;
+	Optional<int> d = 1;
+	Optional<int> e = 2;
+
+	ASSERT(hashFunc(a) == hashFunc(b));
+	ASSERT(hashFunc(a) != hashFunc(c));
+	ASSERT(hashFunc(c) == hashFunc(d));
+	ASSERT(hashFunc(c) != hashFunc(e));
+	ASSERT(hashFunc(a) == hashFunc(a));
+	ASSERT(hashFunc(c) == hashFunc(c));
+
+	return Void();
+}
+
+TEST_CASE("/flow/Arena/DefaultBoostHash") {
+	boost::hash<std::pair<Optional<int>, StringRef>> hashFunc;
+
+	auto a = std::make_pair(Optional<int>(), "foo"_sr);
+	auto b = std::make_pair(Optional<int>(), "foo"_sr);
+	auto c = std::make_pair(Optional<int>(), "bar"_sr);
+	auto d = std::make_pair(Optional<int>(1), "foo"_sr);
+	auto e = std::make_pair(Optional<int>(1), "foo"_sr);
+
+	ASSERT(hashFunc(a) == hashFunc(b));
+	ASSERT(hashFunc(a) != hashFunc(c));
+	ASSERT(hashFunc(a) != hashFunc(d));
+	ASSERT(hashFunc(d) == hashFunc(e));
+	ASSERT(hashFunc(a) == hashFunc(a));
+	ASSERT(hashFunc(d) == hashFunc(d));
+
+	return Void();
+}


### PR DESCRIPTION
This adds a hash function that can be used for `Optional`. It also introduces a default boost hash function for types that cannot be hashed using boost but can be hashed using `std::hash`. This is useful if we want to take advantage of boost's ability to hash certain types, like `std::pair`, that are not hashable by `std::hash` but that have members that are.

These hash functions are not currently used anywhere on main (they will be in https://github.com/apple/foundationdb/pull/6274), so simulation will not exercise them. The newly added unit tests pass

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
