### PR TITLE
    Add pop API for TLog

### DIFF
--- a/fdbserver/TLogServer.actor.cpp
+++ b/fdbserver/TLogServer.actor.cpp
@@ -943,10 +943,8 @@ ACTOR Future<Void> popDiskQueue(TLogData* self, Reference<LogData> logData) {
 		IDiskQueue::location lastCommittedLocation = minLocation;
 		auto locationIter = logData->versionLocation.lower_bound(lastCommittedVersion);
 		if (locationIter != logData->versionLocation.end()) {
-			// why do we need this? committed data should always be bigger than smallest un-poped location
 			lastCommittedLocation = locationIter->value.first;
 		}
-		// actually pop from disk
 		self->persistentQueue->pop(std::min(minLocation, lastCommittedLocation));
 		logData->queuePoppedVersion = std::max(logData->queuePoppedVersion, minVersion);
 	}

--- a/fdbserver/ptxn/TLogInterface.h
+++ b/fdbserver/ptxn/TLogInterface.h
@@ -250,8 +250,9 @@ struct TLogPopRequest {
 
 	ReplyPromise<Void> reply;
 
-	TLogPopRequest(Version version, Version durableKnownCommittedVersion, Tag tag)
-	  : version(version), durableKnownCommittedVersion(durableKnownCommittedVersion), tag(tag) {}
+	TLogPopRequest(Version version, Version durableKnownCommittedVersion, Tag tag, StorageTeamID storageTeamID)
+	  : version(version), durableKnownCommittedVersion(durableKnownCommittedVersion), tag(tag),
+	    storageTeamID(storageTeamID) {}
 	TLogPopRequest() {}
 
 	template <typename Ar>

--- a/fdbserver/ptxn/TLogServer.actor.cpp
+++ b/fdbserver/ptxn/TLogServer.actor.cpp
@@ -1429,12 +1429,12 @@ ACTOR Future<Void> tLogPopCore(Reference<TLogGroupData> self,
 		}
 
 		storageTeamData->popped = minVersionInTeam;
-		// pop from in-memory object: TagData::versionMessages
+		// pop from in-memory object: StorageTeamData::versionMessages
 		// only when minVersionInTeam > logData->persistentDataDurableVersion, there are data
 		// need to be popped from in memory data structure(i.e. versionMessages) that has not been persisted.
 		// if minVersionInTeam < logData->persistentDataDurableVersion, it means all the data needs to be popped has
 		// been persisted into disk, so they are already erased from in memory data structure in updatePersistentData(),
-		// thus we only need to erase them from disk.
+		// thus we only need to erase them from disk (in popDiskQueue actor)
 		if (minVersionInTeam > logData->persistentDataDurableVersion)
 			wait(storageTeamData->eraseMessagesBefore(minVersionInTeam, self, logData, TaskPriority::TLogPop));
 		//TraceEvent("TLogPop", logData->logId).detail("Tag", tag.toString()).detail("To", upTo);

--- a/fdbserver/ptxn/test/Driver.actor.cpp
+++ b/fdbserver/ptxn/test/Driver.actor.cpp
@@ -181,7 +181,8 @@ std::shared_ptr<TestDriverContext> initTestDriverContext(const TestDriverOptions
 		TLogGroup& tLogGroup = context->getTLogGroup(groupId);
 		context->storageTeamIDTLogGroupIDMapper[storageTeamID] = groupId;
 		// TODO: support tags when implementing pop
-		tLogGroup.storageTeams[storageTeamID] = {};
+		tLogGroup.storageTeams[storageTeamID] =
+		    std::vector<Tag>{ Tag(1, deterministicRandom()->randomInt(1, 1 << 16)) };
 	}
 	return context;
 }

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -6828,7 +6828,8 @@ ACTOR Future<Void> storageServerCore(std::shared_ptr<StorageServerBase> self_, S
 							ASSERT(std::dynamic_pointer_cast<ptxn::StorageServer>(self_));
 							ptxn::initializeUpdateCursor(*std::dynamic_pointer_cast<ptxn::StorageServer>(self_));
 						}
-						self->popVersion(self->durableVersion.get() + 1, true);
+						self->popVersion(self->durableVersion.get() + 1,
+						                 true); // why do we need to pop all tags in this case?
 					}
 					// If update() is waiting for results from the tlog, it might never get them, so needs to be
 					// cancelled.  But if it is waiting later, cancelling it could cause problems (e.g. fetchKeys that

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -6828,8 +6828,7 @@ ACTOR Future<Void> storageServerCore(std::shared_ptr<StorageServerBase> self_, S
 							ASSERT(std::dynamic_pointer_cast<ptxn::StorageServer>(self_));
 							ptxn::initializeUpdateCursor(*std::dynamic_pointer_cast<ptxn::StorageServer>(self_));
 						}
-						self->popVersion(self->durableVersion.get() + 1,
-						                 true); // why do we need to pop all tags in this case?
+						self->popVersion(self->durableVersion.get() + 1, true);
 					}
 					// If update() is waiting for results from the tlog, it might never get them, so needs to be
 					// cancelled.  But if it is waiting later, cancelling it could cause problems (e.g. fetchKeys that

--- a/tests/ptxn/TLogServer.toml
+++ b/tests/ptxn/TLogServer.toml
@@ -157,3 +157,18 @@ startDelay = 0
     numTLogGroups = 7
     numCommits = 10
 
+[[test]]
+testTitle = 'Team Partitioned TLog Server Test 11: test popping TLog'
+useDB = false
+startDelay = 0
+
+    [[test.workload]]
+    testName = 'UnitTests'
+    maxTestCases = 1
+    testsMatching = '/fdbserver/ptxn/test/pop_data'
+
+    numTLogs = 3
+    numStorageTeams = 40
+    numTLogGroups = 7
+    numCommits = 10
+


### PR DESCRIPTION
Previously TLog does not support pop, it is needed because
otherwise we cannot trim data on memory/disk.

This commit only changes the memory part, disk part will be a separate PR


# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
