### PR TITLE
Add role 'kvfiledump' to dump key-values from storage file

### DIFF
--- a/fdbserver/IKeyValueStore.h
+++ b/fdbserver/IKeyValueStore.h
@@ -164,5 +164,6 @@ inline IKeyValueStore* openKVStore(KeyValueStoreType storeType,
 
 void GenerateIOLogChecksumFile(std::string filename);
 Future<Void> KVFileCheck(std::string const& filename, bool const& integrity);
+Future<Void> KVFileDump(std::string const& filename);
 
 #endif

--- a/fdbserver/KeyValueStoreSQLite.actor.cpp
+++ b/fdbserver/KeyValueStoreSQLite.actor.cpp
@@ -2303,7 +2303,7 @@ ACTOR Future<Void> KVFileDump(std::string filename) {
 	// dump
 	state int64_t count = 0;
 	state Key k;
-	state Key endk = LiteralStringRef("\xff\xff\xff\xff");
+	state Key endk = allKeys.end;
 	state bool debug = false;
 
 	const char *startKey = getenv("FDB_DUMP_STARTKEY");

--- a/fdbserver/KeyValueStoreSQLite.actor.cpp
+++ b/fdbserver/KeyValueStoreSQLite.actor.cpp
@@ -2291,9 +2291,9 @@ ACTOR Future<Void> KVFileDump(std::string filename) {
 
 	StringRef kvFile(filename);
 	KeyValueStoreType type = KeyValueStoreType::END;
-	if (kvFile.endsWith(LiteralStringRef(".fdb")))
+	if (kvFile.endsWith(".fdb"_sr))
 		type = KeyValueStoreType::SSD_BTREE_V1;
-	else if (kvFile.endsWith(LiteralStringRef(".sqlite")))
+	else if (kvFile.endsWith(".sqlite"_sr))
 		type = KeyValueStoreType::SSD_BTREE_V2;
 	ASSERT(type != KeyValueStoreType::END);
 

--- a/fdbserver/KeyValueStoreSQLite.actor.cpp
+++ b/fdbserver/KeyValueStoreSQLite.actor.cpp
@@ -26,6 +26,9 @@
 #include "flow/Hash3.h"
 #include "flow/xxhash.h"
 
+// for unprintable
+#include "fdbclient/NativeAPI.actor.h"
+
 extern "C" {
 #include "fdbserver/sqlite/sqliteInt.h"
 u32 sqlite3VdbeSerialGet(const unsigned char*, u32, Mem*);
@@ -2272,6 +2275,79 @@ ACTOR Future<Void> KVFileCheck(std::string filename, bool integrity) {
 
 	// Wait for integry check to finish
 	wait(success(store->readValue(StringRef())));
+
+	if (store->getError().isError())
+		wait(store->getError());
+	Future<Void> c = store->onClosed();
+	store->close();
+	wait(c);
+
+	return Void();
+}
+
+ACTOR Future<Void> KVFileDump(std::string filename) {
+	if (!fileExists(filename))
+		throw file_not_found();
+
+	StringRef kvFile(filename);
+	KeyValueStoreType type = KeyValueStoreType::END;
+	if (kvFile.endsWith(LiteralStringRef(".fdb")))
+		type = KeyValueStoreType::SSD_BTREE_V1;
+	else if (kvFile.endsWith(LiteralStringRef(".sqlite")))
+		type = KeyValueStoreType::SSD_BTREE_V2;
+	ASSERT(type != KeyValueStoreType::END);
+
+	state IKeyValueStore* store = keyValueStoreSQLite(filename, UID(0, 0), type);
+	ASSERT(store != nullptr);
+
+	// dump
+	state int64_t count = 0;
+	state Key k;
+	state Key endk = LiteralStringRef("\xff\xff\xff\xff");
+	state bool debug = false;
+
+	const char *startKey = getenv("FDB_DUMP_STARTKEY");
+	const char *endKey = getenv("FDB_DUMP_ENDKEY");
+	const char *debugS = getenv("FDB_DUMP_DEBUG");
+	if (startKey != NULL)
+		k = StringRef(unprintable(std::string(startKey)));
+	if (endKey != NULL)
+		endk = StringRef(unprintable(std::string(endKey)));
+	if (debugS != NULL)
+		debug = true;
+
+	fprintf(stderr, "Dump start: %s, end: %s, debug: %s\n",
+			printable(k).c_str(), printable(endk).c_str(),
+			debug ? "true" : "false");
+
+	while (true) {
+		RangeResult kv = wait( store->readRange( KeyRangeRef(k, endk), 1000 ) );
+		for (auto &one : kv) {
+			int size = 0;
+			const uint8_t* data = NULL;
+
+			size = one.key.size();
+			data = one.key.begin();
+			fwrite(&size, sizeof(int), 1, stdout);
+			fwrite(data, sizeof(uint8_t), size, stdout);
+
+			size = one.value.size();
+			data = one.value.begin();
+			fwrite(&size, sizeof(int), 1, stdout);
+			fwrite(data, sizeof(uint8_t), size, stdout);
+
+			if (debug) {
+				fprintf(stderr, "key: %s\n", printable(one.key).c_str());
+				fprintf(stderr, "val: %s\n", printable(one.value).c_str());
+			}
+		}
+
+		count += kv.size();
+		if (kv.size() <= 0) break;
+		k = keyAfter( kv[ kv.size()-1 ].key );
+	}
+	fflush(stdout);
+	fprintf(stderr, "Counted: %ld\n", count);
 
 	if (store->getError().isError())
 		wait(store->getError());

--- a/fdbserver/KeyValueStoreSQLite.actor.cpp
+++ b/fdbserver/KeyValueStoreSQLite.actor.cpp
@@ -2306,9 +2306,9 @@ ACTOR Future<Void> KVFileDump(std::string filename) {
 	state Key endk = allKeys.end;
 	state bool debug = false;
 
-	const char *startKey = getenv("FDB_DUMP_STARTKEY");
-	const char *endKey = getenv("FDB_DUMP_ENDKEY");
-	const char *debugS = getenv("FDB_DUMP_DEBUG");
+	const char* startKey = getenv("FDB_DUMP_STARTKEY");
+	const char* endKey = getenv("FDB_DUMP_ENDKEY");
+	const char* debugS = getenv("FDB_DUMP_DEBUG");
 	if (startKey != NULL)
 		k = StringRef(unprintable(std::string(startKey)));
 	if (endKey != NULL)
@@ -2316,13 +2316,15 @@ ACTOR Future<Void> KVFileDump(std::string filename) {
 	if (debugS != NULL)
 		debug = true;
 
-	fprintf(stderr, "Dump start: %s, end: %s, debug: %s\n",
-			printable(k).c_str(), printable(endk).c_str(),
-			debug ? "true" : "false");
+	fprintf(stderr,
+	        "Dump start: %s, end: %s, debug: %s\n",
+	        printable(k).c_str(),
+	        printable(endk).c_str(),
+	        debug ? "true" : "false");
 
 	while (true) {
-		RangeResult kv = wait( store->readRange( KeyRangeRef(k, endk), 1000 ) );
-		for (auto &one : kv) {
+		RangeResult kv = wait(store->readRange(KeyRangeRef(k, endk), 1000));
+		for (auto& one : kv) {
 			int size = 0;
 			const uint8_t* data = NULL;
 
@@ -2343,8 +2345,9 @@ ACTOR Future<Void> KVFileDump(std::string filename) {
 		}
 
 		count += kv.size();
-		if (kv.size() <= 0) break;
-		k = keyAfter( kv[ kv.size()-1 ].key );
+		if (kv.size() <= 0)
+			break;
+		k = keyAfter(kv[kv.size() - 1].key);
 	}
 	fflush(stdout);
 	fprintf(stderr, "Counted: %ld\n", count);

--- a/fdbserver/fdbserver.actor.cpp
+++ b/fdbserver/fdbserver.actor.cpp
@@ -706,6 +706,13 @@ static void printUsage(const char* name, bool devhelp) {
 		printOptionUsage("--io-trust-warn-only",
 		                 " Instead of failing when an I/O operation exceeds io_trust_seconds, just"
 		                 " log a warning to the trace log. Has no effect if io_trust_seconds is unspecified.");
+		printf("\n"
+		       "The 'kvfiledump' role dump all key-values from kvfile to stdout in binary format:\n"
+		       "{key length}{key binary}{value length}{value binary}, length is 4 bytes int\n"
+		       "(little endianness). This role takes 3 environment variables as parameter:\n"
+		       " - FDB_DUMP_STARTKEY: start key for the dump, default is empty\n"
+		       " - FDB_DUMP_ENDKEY: end key for the dump, default is \"\\xff\\xff\"\n"
+		       " - FDB_DUMP_DEBUG: print key-values to stderr in escaped format\n");
 	} else {
 		printOptionUsage("--dev-help", "Display developer-specific help and exit.");
 	}

--- a/fdbserver/fdbserver.actor.cpp
+++ b/fdbserver/fdbserver.actor.cpp
@@ -707,7 +707,7 @@ static void printUsage(const char* name, bool devhelp) {
 		printf("\n"
 		       "The 'kvfiledump' role dump all key-values from kvfile to stdout in binary format:\n"
 		       "{key length}{key binary}{value length}{value binary}, length is 4 bytes int\n"
-		       "(little endianness). This role takes 3 environment variables as parameter:\n"
+		       "(little endianness). This role takes 3 environment variables as parameters:\n"
 		       " - FDB_DUMP_STARTKEY: start key for the dump, default is empty\n"
 		       " - FDB_DUMP_ENDKEY: end key for the dump, default is \"\\xff\\xff\"\n"
 		       " - FDB_DUMP_DEBUG: print key-values to stderr in escaped format\n");

--- a/fdbserver/fdbserver.actor.cpp
+++ b/fdbserver/fdbserver.actor.cpp
@@ -643,12 +643,11 @@ static void printUsage(const char* name, bool devhelp) {
 	printOptionUsage("-h, -?, --help", "Display this help and exit.");
 	if (devhelp) {
 		printf("  --build-flags  Print build information and exit.\n");
-		printOptionUsage(
-		    "-r ROLE, --role ROLE",
-		    " Server role (valid options are fdbd, test, multitest,"
-		    " simulation, networktestclient, networktestserver, restore"
-		    " consistencycheck, kvfileintegritycheck, kvfilegeneratesums, kvfiledump, unittests)."
-		    " The default is `fdbd'.");
+		printOptionUsage("-r ROLE, --role ROLE",
+		                 " Server role (valid options are fdbd, test, multitest,"
+		                 " simulation, networktestclient, networktestserver, restore"
+		                 " consistencycheck, kvfileintegritycheck, kvfilegeneratesums, kvfiledump, unittests)."
+		                 " The default is `fdbd'.");
 #ifdef _WIN32
 		printOptionUsage("-n, --newconsole", " Create a new console.");
 		printOptionUsage("-q, --no-dialog", " Disable error dialog on crash.");
@@ -660,10 +659,9 @@ static void printUsage(const char* name, bool devhelp) {
 		printOptionUsage("-R, --restarting", " Restart a previous simulation that was cleanly shut down.");
 		printOptionUsage("-s SEED, --seed SEED", " Random seed.");
 		printOptionUsage("-k KEY, --key KEY", "Target key for search role.");
-		printOptionUsage(
-		    "--kvfile FILE",
-		    "Input file (SQLite database file) for use by the 'kvfilegeneratesums', "
-		    "'kvfileintegritycheck' and 'kvfiledump' roles.");
+		printOptionUsage("--kvfile FILE",
+		                 "Input file (SQLite database file) for use by the 'kvfilegeneratesums', "
+		                 "'kvfileintegritycheck' and 'kvfiledump' roles.");
 		printOptionUsage("-b [on,off], --buggify [on,off]", " Sets Buggify system state, defaults to `off'.");
 		printOptionUsage("-fi [on,off], --fault-injection [on,off]", " Sets fault injection, defaults to `on'.");
 		printOptionUsage("--crash", "Crash on serious errors instead of continuing.");


### PR DESCRIPTION
To recover data from a broken cluster, we could use this new 'kvfiledump'
role to dump key-values from storage file(sqlite) directly.

Dumped key-values will print to stdout in binary format:
`[4-bytes key len][key binary][4-bytes value len][value binary]`
(len is in little endianness)

Users can use environment var to control the dump:
* `FDB_DUMP_STARTKEY`: start key for the dump, default is empty
* `FDB_DUMP_ENDKEY`: end key for the dump, default is \xff\xff\xff\xff
* `FDB_DUMP_DEBUG`: print key-values to stderr in escaped format

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
