### PR TITLE
Copy transaction state during reset

### DIFF
--- a/fdbclient/NativeAPI.actor.h
+++ b/fdbclient/NativeAPI.actor.h
@@ -258,6 +258,8 @@ struct TransactionState : ReferenceCounted<TransactionState> {
 
 	TransactionState(Database cx, TaskPriority taskID, SpanID spanID, Reference<TransactionLogInfo> trLogInfo)
 	  : cx(cx), trLogInfo(trLogInfo), options(cx), taskID(taskID), spanID(spanID) {}
+
+	Reference<TransactionState> cloneAndReset(Reference<TransactionLogInfo> newTrLogInfo, bool generateNewSpan) const;
 };
 
 class Transaction : NonCopyable {
@@ -440,6 +442,8 @@ private:
 	                                     GetRangeLimits limits,
 	                                     Snapshot snapshot,
 	                                     Reverse reverse);
+
+	void resetImpl(bool generateNewSpan);
 
 	double backoff;
 	CommitTransactionRequest tr;


### PR DESCRIPTION
Previously, resetting a transaction would modify the transaction state reference object. This object could still be in use by operations that were in-flight during the reset. There haven't been any apparent issues with the fields currently in this state, but there are some future fields where this will be a problem.

This change makes it so that we create a new transaction state upon reset and copy relevant values.

Passed 10K correctness with 1 restarting failure that matches the pattern of an unrelated issue.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
