### PR TITLE
Add resolveHostnamesBlocking() and resolveTCPEndpointBlocking() to resolve hostnames where async resolving is impossible.

### DIFF
--- a/fdbclient/AutoPublicAddress.cpp
+++ b/fdbclient/AutoPublicAddress.cpp
@@ -28,7 +28,7 @@
 
 #include "fdbclient/CoordinationInterface.h"
 
-IPAddress determinePublicIPAutomatically(ClusterConnectionString const& ccs) {
+IPAddress determinePublicIPAutomatically(ClusterConnectionString& ccs) {
 	try {
 		using namespace boost::asio;
 

--- a/fdbclient/ClusterConnectionFile.actor.cpp
+++ b/fdbclient/ClusterConnectionFile.actor.cpp
@@ -41,7 +41,7 @@ ClusterConnectionFile::ClusterConnectionFile(std::string const& filename, Cluste
 }
 
 // Sets the connections string held by this object and persists it.
-Future<Void> ClusterConnectionFile::setConnectionString(ClusterConnectionString const& conn) {
+Future<Void> ClusterConnectionFile::setAndPersistConnectionString(ClusterConnectionString const& conn) {
 	ASSERT(filename.size());
 	cs = conn;
 	return success(persist());

--- a/fdbclient/ClusterConnectionFile.h
+++ b/fdbclient/ClusterConnectionFile.h
@@ -35,7 +35,7 @@ public:
 	explicit ClusterConnectionFile(std::string const& filename, ClusterConnectionString const& contents);
 
 	// Sets the connections string held by this object and persists it.
-	Future<Void> setConnectionString(ClusterConnectionString const&) override;
+	Future<Void> setAndPersistConnectionString(ClusterConnectionString const&) override;
 
 	// Get the connection string stored in the file.
 	Future<ClusterConnectionString> getStoredConnectionString() override;

--- a/fdbclient/ClusterConnectionKey.actor.cpp
+++ b/fdbclient/ClusterConnectionKey.actor.cpp
@@ -57,7 +57,7 @@ ACTOR Future<Reference<ClusterConnectionKey>> ClusterConnectionKey::loadClusterC
 }
 
 // Sets the connections string held by this object and persists it.
-Future<Void> ClusterConnectionKey::setConnectionString(ClusterConnectionString const& connectionString) {
+Future<Void> ClusterConnectionKey::setAndPersistConnectionString(ClusterConnectionString const& connectionString) {
 	cs = connectionString;
 	return success(persist());
 }

--- a/fdbclient/ClusterConnectionKey.actor.h
+++ b/fdbclient/ClusterConnectionKey.actor.h
@@ -48,7 +48,7 @@ public:
 	ACTOR static Future<Reference<ClusterConnectionKey>> loadClusterConnectionKey(Database db, Key connectionStringKey);
 
 	// Sets the connections string held by this object and persists it.
-	Future<Void> setConnectionString(ClusterConnectionString const&) override;
+	Future<Void> setAndPersistConnectionString(ClusterConnectionString const&) override;
 
 	// Get the connection string stored in the database.
 	Future<ClusterConnectionString> getStoredConnectionString() override;

--- a/fdbclient/ClusterConnectionMemoryRecord.actor.cpp
+++ b/fdbclient/ClusterConnectionMemoryRecord.actor.cpp
@@ -23,7 +23,7 @@
 #include "flow/actorcompiler.h" // has to be last include
 
 // Sets the connections string held by this object.
-Future<Void> ClusterConnectionMemoryRecord::setConnectionString(ClusterConnectionString const& conn) {
+Future<Void> ClusterConnectionMemoryRecord::setAndPersistConnectionString(ClusterConnectionString const& conn) {
 	cs = conn;
 	return Void();
 }

--- a/fdbclient/ClusterConnectionMemoryRecord.h
+++ b/fdbclient/ClusterConnectionMemoryRecord.h
@@ -36,7 +36,7 @@ public:
 	}
 
 	// Sets the connections string held by this object.
-	Future<Void> setConnectionString(ClusterConnectionString const&) override;
+	Future<Void> setAndPersistConnectionString(ClusterConnectionString const&) override;
 
 	// Returns the connection string currently held in this object (there is no persistent storage).
 	Future<ClusterConnectionString> getStoredConnectionString() override;

--- a/fdbclient/CoordinationInterface.h
+++ b/fdbclient/CoordinationInterface.h
@@ -75,6 +75,9 @@ public:
 	std::string toString() const;
 	static std::string getErrorString(std::string const& source, Error const& e);
 	Future<Void> resolveHostnames();
+	// This one should only be used when resolving asynchronously is impossible. For all other cases, resolveHostnames()
+	// should be preferred.
+	void resolveHostnamesBlocking();
 	void resetToUnresolved();
 
 	bool hasUnresolvedHostnames = false;
@@ -105,12 +108,10 @@ public:
 
 	// Returns the connection string currently held in this object. This may not match the stored record if it hasn't
 	// been persisted or if the persistent storage for the record has been modified externally.
-	ClusterConnectionString const& getConnectionString() const;
-
-	ClusterConnectionString* getMutableConnectionString();
+	ClusterConnectionString& getConnectionString();
 
 	// Sets the connections string held by this object and persists it.
-	virtual Future<Void> setConnectionString(ClusterConnectionString const&) = 0;
+	virtual Future<Void> setAndPersistConnectionString(ClusterConnectionString const&) = 0;
 
 	// If this record is backed by persistent storage, get the connection string from that storage. Otherwise, return
 	// the connection string stored in memory.
@@ -140,6 +141,9 @@ public:
 
 	bool hasUnresolvedHostnames() const;
 	Future<Void> resolveHostnames();
+	// This one should only be used when resolving asynchronously is impossible. For all other cases, resolveHostnames()
+	// should be preferred.
+	void resolveHostnamesBlocking();
 
 	virtual void addref() = 0;
 	virtual void delref() = 0;

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -1791,7 +1791,7 @@ void DatabaseContext::expireThrottles() {
 	}
 }
 
-extern IPAddress determinePublicIPAutomatically(ClusterConnectionString const& ccs);
+extern IPAddress determinePublicIPAutomatically(ClusterConnectionString& ccs);
 
 // Creates a database object that represents a connection to a cluster
 // This constructor uses a preallocated DatabaseContext that may have been created

--- a/fdbrpc/SimExternalConnection.actor.cpp
+++ b/fdbrpc/SimExternalConnection.actor.cpp
@@ -221,8 +221,8 @@ UID SimExternalConnection::getDebugID() const {
 	return dbgid;
 }
 
-ACTOR static Future<std::vector<NetworkAddress>> resolveTCPEndpointImpl(std::string host, std::string service) {
-	wait(delayJittered(0.1));
+std::vector<NetworkAddress> SimExternalConnection::resolveTCPEndpointBlocking(const std::string& host,
+                                                                              const std::string& service) {
 	ip::tcp::resolver resolver(ios);
 	ip::tcp::resolver::query query(host, service);
 	auto iter = resolver.resolve(query);
@@ -239,6 +239,11 @@ ACTOR static Future<std::vector<NetworkAddress>> resolveTCPEndpointImpl(std::str
 		++iter;
 	}
 	return addrs;
+}
+
+ACTOR static Future<std::vector<NetworkAddress>> resolveTCPEndpointImpl(std::string host, std::string service) {
+	wait(delayJittered(0.1));
+	return SimExternalConnection::resolveTCPEndpointBlocking(host, service);
 }
 
 Future<std::vector<NetworkAddress>> SimExternalConnection::resolveTCPEndpoint(const std::string& host,

--- a/fdbrpc/SimExternalConnection.h
+++ b/fdbrpc/SimExternalConnection.h
@@ -77,6 +77,7 @@ public:
 	NetworkAddress getPeerAddress() const override;
 	UID getDebugID() const override;
 	static Future<std::vector<NetworkAddress>> resolveTCPEndpoint(const std::string& host, const std::string& service);
+	static std::vector<NetworkAddress> resolveTCPEndpointBlocking(const std::string& host, const std::string& service);
 	static Future<Reference<IConnection>> connect(NetworkAddress toAddr);
 };
 

--- a/fdbrpc/sim2.actor.cpp
+++ b/fdbrpc/sim2.actor.cpp
@@ -960,6 +960,14 @@ public:
 		}
 		return SimExternalConnection::resolveTCPEndpoint(host, service);
 	}
+	std::vector<NetworkAddress> resolveTCPEndpointBlocking(const std::string& host,
+	                                                       const std::string& service) override {
+		// If a <hostname, vector<NetworkAddress>> pair was injected to mock DNS, use it.
+		if (mockDNS.findMockTCPEndpoint(host, service)) {
+			return mockDNS.getTCPEndpoint(host, service);
+		}
+		return SimExternalConnection::resolveTCPEndpointBlocking(host, service);
+	}
 	ACTOR static Future<Reference<IConnection>> onConnect(Future<Void> ready, Reference<Sim2Conn> conn) {
 		wait(ready);
 		if (conn->isPeerGone()) {

--- a/fdbserver/LeaderElection.actor.cpp
+++ b/fdbserver/LeaderElection.actor.cpp
@@ -141,7 +141,7 @@ ACTOR Future<Void> tryBecomeLeaderInternal(ServerCoordinators coordinators,
 					    .detail("StoredConnectionString", coordinators.ccr->getConnectionString().toString())
 					    .detail("CurrentConnectionString", leader.get().first.serializedInfo.toString());
 				}
-				coordinators.ccr->setConnectionString(
+				coordinators.ccr->setAndPersistConnectionString(
 				    ClusterConnectionString(leader.get().first.serializedInfo.toString()));
 				TraceEvent("LeaderForwarding")
 				    .detail("ConnStr", coordinators.ccr->getConnectionString().toString())

--- a/fdbserver/fdbserver.actor.cpp
+++ b/fdbserver/fdbserver.actor.cpp
@@ -205,7 +205,7 @@ extern void copyTest();
 extern void versionedMapTest();
 extern void createTemplateDatabase();
 // FIXME: this really belongs in a header somewhere since it is actually used.
-extern IPAddress determinePublicIPAutomatically(ClusterConnectionString const& ccs);
+extern IPAddress determinePublicIPAutomatically(ClusterConnectionString& ccs);
 
 extern const char* getSourceVersion();
 
@@ -808,7 +808,7 @@ Optional<bool> checkBuggifyOverride(const char* testFile) {
 // Takes a vector of public and listen address strings given via command line, and returns vector of NetworkAddress
 // objects.
 std::pair<NetworkAddressList, NetworkAddressList> buildNetworkAddresses(
-    const IClusterConnectionRecord& connectionRecord,
+    IClusterConnectionRecord& connectionRecord,
     const std::vector<std::string>& publicAddressStrs,
     std::vector<std::string>& listenAddressStrs) {
 	if (listenAddressStrs.size() > 0 && publicAddressStrs.size() != listenAddressStrs.size()) {

--- a/fdbserver/worker.actor.cpp
+++ b/fdbserver/worker.actor.cpp
@@ -2476,7 +2476,7 @@ ACTOR Future<MonitorLeaderInfo> monitorLeaderWithDelayedCandidacyImplOneGenerati
 						    .detail("CurrentConnectionString",
 						            info.intermediateConnRecord->getConnectionString().toString());
 					}
-					connRecord->setConnectionString(info.intermediateConnRecord->getConnectionString());
+					connRecord->setAndPersistConnectionString(info.intermediateConnRecord->getConnectionString());
 					info.intermediateConnRecord = connRecord;
 				}
 

--- a/flow/Net2.actor.cpp
+++ b/flow/Net2.actor.cpp
@@ -166,6 +166,8 @@ public:
 
 	Future<std::vector<NetworkAddress>> resolveTCPEndpoint(const std::string& host,
 	                                                       const std::string& service) override;
+	std::vector<NetworkAddress> resolveTCPEndpointBlocking(const std::string& host,
+	                                                       const std::string& service) override;
 	Reference<IListener> listen(NetworkAddress localAddr) override;
 
 	// INetwork interface
@@ -1870,6 +1872,25 @@ Future<Reference<IUDPSocket>> Net2::createUDPSocket(bool isV6) {
 
 Future<std::vector<NetworkAddress>> Net2::resolveTCPEndpoint(const std::string& host, const std::string& service) {
 	return resolveTCPEndpoint_impl(this, host, service);
+}
+
+std::vector<NetworkAddress> Net2::resolveTCPEndpointBlocking(const std::string& host, const std::string& service) {
+	tcp::resolver tcpResolver(reactor.ios);
+	tcp::resolver::query query(host, service);
+	auto iter = tcpResolver.resolve(query);
+	decltype(iter) end;
+	std::vector<NetworkAddress> addrs;
+	while (iter != end) {
+		auto endpoint = iter->endpoint();
+		auto addr = endpoint.address();
+		if (addr.is_v6()) {
+			addrs.emplace_back(IPAddress(addr.to_v6().to_bytes()), endpoint.port());
+		} else {
+			addrs.emplace_back(addr.to_v4().to_ulong(), endpoint.port());
+		}
+		++iter;
+	}
+	return addrs;
 }
 
 bool Net2::isAddressOnThisHost(NetworkAddress const& addr) const {

--- a/flow/network.h
+++ b/flow/network.h
@@ -703,6 +703,10 @@ public:
 	// NetworkAddresses
 	virtual Future<std::vector<NetworkAddress>> resolveTCPEndpoint(const std::string& host,
 	                                                               const std::string& service) = 0;
+	// Resolve host name and service name. This one should only be used when resolving asynchronously is impossible. For
+	// all other cases, resolveTCPEndpoint() should be preferred.
+	virtual std::vector<NetworkAddress> resolveTCPEndpointBlocking(const std::string& host,
+	                                                               const std::string& service) = 0;
 
 	// Convenience function to resolve host/service and connect to one of its NetworkAddresses randomly
 	// isTLS has to be a parameter here because it is passed to connect() as part of the toAddr object.


### PR DESCRIPTION
When connection string contains hostname, there are places (e.g., `determinePublicIPAutomatically()`) where async resolving is impossible. The new added functions will and should only be used in those cases. For all other cases, the regular async `resolveHostnames()` and `resolveTCPEndpoint()` should be preferred.

Also, combine `IClusterConnectionRecord::getConnectionString()` and `IClusterConnectionRecord::getMutableConnectionString()` to `IClusterConnectionRecord::getConnectionString()`, and rename `setConnectionString()` to `setAndPersistConnectionString()`.

20220128-014412-renxuan-5e1c616c1b75b5c8           compressed=True data_size=28344993 duration=5093169 ended=100000 fail=1 fail_fast=10 max_runs=100000 pass=99999 priority=100 remaining=0 runtime=0:56:48 sanity=False started=100412 stopped=20220128-024100 submitted=20220128-014412 timeout=5400 username=renxuan

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
