### PR TITLE
Fix tlog group not found error

### DIFF
--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -5087,13 +5087,13 @@ std::vector<ptxn::TLogInterfaceBase*> getTLogInterfaceByStorageTeamID(const Serv
 			}
 		}
 		TraceEvent("PtxnGetTLogInterfaceByStorageTeamID")
-		    .detail("StorageTeamID", storageTeamID.toString())
-		    .detail("TLogGroupID", tLogGroupID.toString())
+		    .detail("StorageTeamID", storageTeamID)
+		    .detail("TLogGroupID", tLogGroupID)
 		    .detail("NumTLogInterfaces", tLogInterfaces.size());
 	}
 
 	TraceEvent("PtxnGetTLogInterfaceByStorageTeamID")
-	    .detail("StorageTeamID", storageTeamID.toString())
+	    .detail("StorageTeamID", storageTeamID)
 	    .detail("TotalNumTLogInterfaces", tLogInterfaces.size());
 	return tLogInterfaces;
 }


### PR DESCRIPTION
When TLog receives a peek request before it's ready, i.e., accepting commits,
the TLog can't find the correct TLog group.


# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
