### PR TITLE
Set recovery state in updateServerDBInfo

### DIFF
--- a/fdbserver/ptxn/TLogServer.actor.cpp
+++ b/fdbserver/ptxn/TLogServer.actor.cpp
@@ -1271,13 +1271,11 @@ ACTOR Future<Void> servicePeekRequest(
 	}
 
 	auto tLogGroupID =
-		tLogGroupByStorageTeamID(self->dbInfo->get().logSystemConfig.tLogs[0].tLogGroupIDs, req.storageTeamID);
+	    tLogGroupByStorageTeamID(self->dbInfo->get().logSystemConfig.tLogs[0].tLogGroupIDs, req.storageTeamID);
 	auto tlogGroup = activeGeneration->find(tLogGroupID);
 	TEST(tlogGroup == activeGeneration->end()); // TLog peek: group not found
 	if (tlogGroup == activeGeneration->end()) {
-		TraceEvent("TLogPeekGroupNotFound", self->dbgid)
-			.detail("Group", tLogGroupID)
-			.detail("Team", req.storageTeamID);
+		TraceEvent("TLogPeekGroupNotFound", self->dbgid).detail("Group", tLogGroupID).detail("Team", req.storageTeamID);
 		req.reply.sendError(tlog_group_not_found());
 		return Void();
 	}

--- a/fdbserver/ptxn/test/Driver.actor.cpp
+++ b/fdbserver/ptxn/test/Driver.actor.cpp
@@ -76,6 +76,7 @@ void TestDriverContext::updateServerDBInfo(Reference<AsyncVar<ServerDBInfo>> dbI
 	ServerDBInfo info;
 	LogSystemConfig& lsConfig = info.logSystemConfig;
 	lsConfig.logSystemType = LogSystemType::teamPartitioned;
+	info.recoveryState = RecoveryState::FULLY_RECOVERED;
 
 	// For now, assume we only have primary TLog set
 	lsConfig.tLogs.clear();

--- a/fdbserver/ptxn/test/Driver.actor.cpp
+++ b/fdbserver/ptxn/test/Driver.actor.cpp
@@ -72,7 +72,8 @@ TestDriverOptions::TestDriverOptions(const UnitTestParameters& params)
     transferModel(static_cast<MessageTransferModel>(
         params.getInt("messageTransferModel").orDefault(static_cast<int>(DEFAULT_MESSAGE_TRANSFER_MODEL)))) {}
 
-void TestDriverContext::updateServerDBInfo(Reference<AsyncVar<ServerDBInfo>> dbInfo) {
+void TestDriverContext::updateServerDBInfo(Reference<AsyncVar<ServerDBInfo>> dbInfo,
+                                           const std::vector<ptxn::TLogInterface_PassivelyPull>& interfaces) {
 	ServerDBInfo info;
 	LogSystemConfig& lsConfig = info.logSystemConfig;
 	lsConfig.logSystemType = LogSystemType::teamPartitioned;
@@ -85,7 +86,10 @@ void TestDriverContext::updateServerDBInfo(Reference<AsyncVar<ServerDBInfo>> dbI
 	for (const auto& group : tLogGroups) {
 		logset.tLogGroupIDs.push_back(group.logGroupId);
 	}
-	// TODO: fill in tLogsPtxn and ptxnTLogGroups fields
+	for (const auto& tlogIf : interfaces) {
+		logset.tLogsPtxn.emplace_back(tlogIf);
+	}
+	// TODO: fill in ptxnTLogGroups fields
 
 	dbInfo->setUnconditional(info);
 }

--- a/fdbserver/ptxn/test/Driver.h
+++ b/fdbserver/ptxn/test/Driver.h
@@ -126,7 +126,8 @@ struct TestDriverContext {
 	CommitRecord commitRecord;
 
 	// Updates a ServerDBInfo object with this context.
-	void updateServerDBInfo(Reference<AsyncVar<ServerDBInfo>> dbInfo);
+	void updateServerDBInfo(Reference<AsyncVar<ServerDBInfo>> dbInfo,
+	                        const std::vector<ptxn::TLogInterface_PassivelyPull>& interfaces);
 
 	TLogGroup& getTLogGroup(TLogGroupID gid);
 };

--- a/fdbserver/ptxn/test/TestTLogServer.actor.cpp
+++ b/fdbserver/ptxn/test/TestTLogServer.actor.cpp
@@ -138,7 +138,7 @@ ACTOR Future<Void> startTLogServers(std::vector<Future<Void>>* actors,
 		tLogGroupLeader = pContext->tLogInterfaces[pContext->groupToLeaderId[tLogGroupID]];
 	}
 	// Update TLogGroups & TLogInterfaces in ServerDBInfo
-	pContext->updateServerDBInfo(dbInfo);
+	pContext->updateServerDBInfo(dbInfo, interfaces);
 	return Void();
 }
 

--- a/fdbserver/ptxn/test/TestTLogServer.actor.cpp
+++ b/fdbserver/ptxn/test/TestTLogServer.actor.cpp
@@ -393,7 +393,7 @@ ACTOR Future<std::vector<Standalone<StringRef>>> commitInject(std::shared_ptr<pt
 		auto serialized = serializeMutations(currVersion, storageTeamID, pContext->commitRecord);
 		std::unordered_map<ptxn::StorageTeamID, StringRef> messages = { { storageTeamID, serialized } };
 		requests.emplace_back(ptxn::test::randomUID(),
-		                      pContext->storageTeamIDTLogGroupIDMapper[storageTeamID],
+		                      tLogGroupID,
 		                      serialized.arena(),
 		                      messages,
 		                      prevVersion,
@@ -408,7 +408,7 @@ ACTOR Future<std::vector<Standalone<StringRef>>> commitInject(std::shared_ptr<pt
 		prevVersion = currVersion;
 		increaseVersion(currVersion);
 	}
-	printTiming << "Generated " << numCommits << " commit requests" << std::endl;
+	printTiming << "Generated " << numCommits << " commit requests to group " << tLogGroupID.shortString() << std::endl;
 	{
 		std::mt19937 g(deterministicRandom()->randomUInt32());
 		std::shuffle(std::begin(requests), std::end(requests), g);
@@ -432,7 +432,6 @@ ACTOR Future<Void> verifyPeek(std::shared_ptr<ptxn::test::TestDriverContext> pCo
                               int numCommits) {
 	state ptxn::test::print::PrintTiming printTiming("tlog/verifyPeek");
 
-	state const ptxn::TLogGroupID tLogGroupID = pContext->storageTeamIDTLogGroupIDMapper.at(storageTeamID);
 	state std::shared_ptr<ptxn::TLogInterfaceBase> pInterface = pContext->getTLogLeaderByStorageTeamID(storageTeamID);
 	ASSERT(pInterface);
 
@@ -692,7 +691,7 @@ ACTOR Future<std::pair<std::vector<Standalone<StringRef>>, std::vector<Version>>
 		auto serialized = serializeMutations(currVersion, storageTeamID, pContext->commitRecord);
 		std::unordered_map<ptxn::StorageTeamID, StringRef> messages = { { storageTeamID, serialized } };
 		requests.emplace_back(ptxn::test::randomUID(),
-		                      pContext->storageTeamIDTLogGroupIDMapper[storageTeamID],
+		                      tLogGroupID,
 		                      serialized.arena(),
 		                      messages,
 		                      prevVersion,
@@ -708,7 +707,7 @@ ACTOR Future<std::pair<std::vector<Standalone<StringRef>>, std::vector<Version>>
 		prevVersion = currVersion;
 		increaseVersion(currVersion);
 	}
-	printTiming << "Generated " << numCommits << " commit requests" << std::endl;
+	printTiming << "Generated " << numCommits << " commit requests to group " << tLogGroupID.shortString() << std::endl;
 	{
 		std::mt19937 g(deterministicRandom()->randomUInt32());
 		std::shuffle(std::begin(requests), std::end(requests), g);


### PR DESCRIPTION
This is to ensure in unit test, TLogServer won't be blocked when receiving peek requests.

I manually run ptxn/TLogServer.toml and it passed.

Correctness 20220128-042806-jzhou-19fda37d5a28aa57 passed

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
