### PR TITLE
Fix flaky ctest tests

### DIFF
--- a/bindings/c/test/unit/trace_partial_file_suffix_test.cpp
+++ b/bindings/c/test/unit/trace_partial_file_suffix_test.cpp
@@ -72,7 +72,7 @@ int main(int argc, char** argv) {
 
 	// Apparently you need to open a database to initialize logging
 	FDBDatabase* out;
-	fdb_check(fdb_create_database(nullptr, &out));
+	fdb_check(fdb_create_database(argv[1], &out));
 	fdb_database_destroy(out);
 
 	// Eventually there's a new trace file for this test ending in .tmp

--- a/bindings/python/tests/fdbcli_tests.py
+++ b/bindings/python/tests/fdbcli_tests.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+import shutil
 import os
 import subprocess
 import logging
@@ -216,6 +217,9 @@ def kill(logger):
 
 @enable_logging()
 def suspend(logger):
+    if not shutil.which("pidof"):
+        logger.debug("Skipping suspend test. Pidof not available")
+        return
     output1 = run_fdbcli_command('suspend')
     lines = output1.split('\n')
     assert len(lines) == 2

--- a/flow/FileTraceLogWriter.cpp
+++ b/flow/FileTraceLogWriter.cpp
@@ -122,6 +122,9 @@ void FileTraceLogWriter::write(const StringRef& str) {
 }
 
 void FileTraceLogWriter::write(const char* str, size_t len) {
+	if (traceFileFD < 0) {
+		return;
+	}
 	auto ptr = str;
 	int remaining = len;
 	bool needsResolve = false;

--- a/tests/TestRunner/local_cluster.py
+++ b/tests/TestRunner/local_cluster.py
@@ -7,10 +7,22 @@ import sys
 import socket
 
 
-def get_free_port():
+def _get_free_port_internal():
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
         s.bind(('0.0.0.0', 0))
         return s.getsockname()[1]
+
+
+_used_ports = set()
+
+
+def get_free_port():
+    global _used_ports
+    port = _get_free_port_internal()
+    while port in _used_ports:
+        port = _get_free_port_internal()
+    _used_ports.add(port)
+    return port
 
 
 class LocalCluster:

--- a/tests/TestRunner/tmp_cluster.py
+++ b/tests/TestRunner/tmp_cluster.py
@@ -129,6 +129,10 @@ if __name__ == "__main__":
             break
 
         if errcode:
+            for etc_file in glob.glob(os.path.join(cluster.etc, "*")):
+                print(">>>>>>>>>>>>>>>>>>>> Contents of {}:".format(etc_file))
+                with open(etc_file, "r") as f:
+                    print(f.read())
             for log_file in glob.glob(os.path.join(cluster.log, "*")):
                 print(">>>>>>>>>>>>>>>>>>>> Contents of {}:".format(log_file))
                 with open(log_file, "r") as f:


### PR DESCRIPTION
Fix a few sources of flakiness in our "ctest" tests. Flakiness found by running the tests many times in Joshua, using #6237 
# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
