### PR TITLE
Make use of the log group in fdbcli

### DIFF
--- a/fdbcli/fdbcli.actor.cpp
+++ b/fdbcli/fdbcli.actor.cpp
@@ -64,6 +64,7 @@ enum {
 	OPT_HELP,
 	OPT_TRACE,
 	OPT_TRACE_DIR,
+	OPT_LOGGROUP,
 	OPT_TIMEOUT,
 	OPT_EXEC,
 	OPT_NO_STATUS,
@@ -80,6 +81,7 @@ CSimpleOpt::SOption g_rgOptions[] = { { OPT_CONNFILE, "-C", SO_REQ_SEP },
 	                                  { OPT_DATABASE, "-d", SO_REQ_SEP },
 	                                  { OPT_TRACE, "--log", SO_NONE },
 	                                  { OPT_TRACE_DIR, "--log-dir", SO_REQ_SEP },
+	                                  { OPT_LOGGROUP, "--log-group", SO_REQ_SEP },
 	                                  { OPT_TIMEOUT, "--timeout", SO_REQ_SEP },
 	                                  { OPT_EXEC, "--exec", SO_REQ_SEP },
 	                                  { OPT_NO_STATUS, "--no-status", SO_NONE },
@@ -429,6 +431,9 @@ static void printProgramUsage(const char* name) {
 	       "  --log-dir PATH Specifes the output directory for trace files. If\n"
 	       "                 unspecified, defaults to the current directory. Has\n"
 	       "                 no effect unless --log is specified.\n"
+	       "  --log-group LOG_GROUP\n"
+	       "                 Sets the LogGroup field with the specified value for all\n"
+	       "                 events in the trace output (defaults to `default').\n"
 	       "  --trace_format FORMAT\n"
 	       "                 Select the format of the log files. xml (the default) and json\n"
 	       "                 are supported. Has no effect unless --log is specified.\n"
@@ -2869,6 +2874,7 @@ struct CLIOptions {
 	bool trace = false;
 	std::string traceDir;
 	std::string traceFormat;
+	std::string logGroup;
 	int exit_timeout = 0;
 	Optional<std::string> exec;
 	bool initialStatusCheck = true;
@@ -2959,6 +2965,9 @@ struct CLIOptions {
 			break;
 		case OPT_TRACE_DIR:
 			traceDir = args.OptionArg();
+			break;
+		case OPT_LOGGROUP:
+			logGroup = args.OptionArg();
 			break;
 		case OPT_TIMEOUT: {
 			char* endptr;
@@ -4696,6 +4705,10 @@ int main(int argc, char** argv) {
 			setNetworkOption(FDBNetworkOptions::TRACE_FORMAT, StringRef(opt.traceFormat));
 		}
 		setNetworkOption(FDBNetworkOptions::ENABLE_SLOW_TASK_PROFILING);
+
+		if (!opt.logGroup.empty()) {
+			setNetworkOption(FDBNetworkOptions::TRACE_LOG_GROUP, StringRef(opt.logGroup));
+		}
 	}
 	initHelp();
 


### PR DESCRIPTION
This change adds an additional flag to `fdbcli` to set the log group otherwise the log group will be `default`.

I did a local test to show that the `LogGroup` will be used:

```xml
<Event Severity="10" Type="ClientStart" ID="0000000000000000" SourceVersion="e942fb9cb55b3da2e5ce6789683e5f0a9460a11f" Version="6.3.24" mageOffset="(nil)"  LogGroup="test" TrackLatestType="Original" />
```

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [x] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
