### PR TITLE
ssToStorageTeam: Use unordered_set instead of set

### DIFF
--- a/fdbserver/ApplyMetadataMutation.cpp
+++ b/fdbserver/ApplyMetadataMutation.cpp
@@ -70,7 +70,7 @@ public:
 	                           IKeyValueStore* txnStateStore_,
 	                           Reference<TLogGroupCollection> tLogGroupCollection_,
 	                           std::map<Tag, UID>* tagToServer_,
-	                           std::unordered_map<UID, std::set<ptxn::StorageTeamID>>* ssToStorageTeam_)
+	                           std::unordered_map<UID, std::unordered_set<ptxn::StorageTeamID>>* ssToStorageTeam_)
 	  : spanContext(spanContext_), dbgid(dbgid_), arena(arena_), mutations(mutations_), txnStateStore(txnStateStore_),
 	    confChange(dummyConfChange), tLogGroupCollection(tLogGroupCollection_), tagToServer(tagToServer_),
 	    ssToStorageTeam(ssToStorageTeam_) {}
@@ -96,7 +96,7 @@ public:
 	    ssToStorageTeam(&proxyCommitData_.ssToStorageTeam), changedTeams(&proxyCommitData_.changedTeams) {
 
 		for (const auto& [ss, teams] : proxyCommitData_.ssToStorageTeam) {
-			TraceEvent(SevDebug, "SSTeam", dbgid).detail("SS", ss).detail("Team", teams);
+			TraceEvent(SevDebug, "SSTeam", dbgid).detail("SS", ss).detail("Teams", describe(teams));
 			allTeams.insert(teams.begin(), teams.end());
 		}
 	}
@@ -169,7 +169,7 @@ private:
 	std::vector<std::pair<UID, UID>> tssMappingToAdd;
 
 	std::map<Tag, UID>* tagToServer = nullptr;
-	std::unordered_map<UID, std::set<ptxn::StorageTeamID>>* ssToStorageTeam = nullptr;
+	std::unordered_map<UID, std::unordered_set<ptxn::StorageTeamID>>* ssToStorageTeam = nullptr;
 	std::unordered_map<UID, std::vector<std::pair<ptxn::StorageTeamID, bool>>>* changedTeams = nullptr;
 
 	// All SSes' own teams, populated from ssToStorageTeam mapping.
@@ -1312,7 +1312,7 @@ void applyMetadataMutations(SpanID const& spanContext,
                             IKeyValueStore* txnStateStore,
                             TLogGroupCollectionRef tLogGroupCollection) {
 	std::map<Tag, UID> tagToServer;
-	std::unordered_map<UID, std::set<ptxn::StorageTeamID>> ssToStorageTeam;
+	std::unordered_map<UID, std::unordered_set<ptxn::StorageTeamID>> ssToStorageTeam;
 	ApplyMetadataMutationsImpl(
 	    spanContext, dbgid, arena, mutations, txnStateStore, tLogGroupCollection, &tagToServer, &ssToStorageTeam)
 	    .apply();

--- a/fdbserver/ApplyMetadataMutation.h
+++ b/fdbserver/ApplyMetadataMutation.h
@@ -51,7 +51,7 @@ struct ResolverData {
 	std::map<UID, Reference<StorageInfo>>* storageCache = nullptr;
 	std::unordered_map<UID, StorageServerInterface>* tssMapping = nullptr;
 	std::map<Tag, UID> tagToServer;
-	std::unordered_map<UID, std::set<ptxn::StorageTeamID>>* ssToStorageTeam = nullptr;
+	std::unordered_map<UID, std::unordered_set<ptxn::StorageTeamID>>* ssToStorageTeam = nullptr;
 	std::unordered_map<UID, std::vector<std::pair<ptxn::StorageTeamID, bool>>> changedTeams;
 	Reference<TLogGroupCollection> tLogGroupCollection;
 
@@ -61,7 +61,7 @@ struct ResolverData {
 	             KeyRangeMap<ServerCacheInfo>* info,
 	             bool* forceRecovery,
 	             Reference<TLogGroupCollection> collection,
-	             std::unordered_map<UID, std::set<ptxn::StorageTeamID>>* pSsToStorageTeam)
+	             std::unordered_map<UID, std::unordered_set<ptxn::StorageTeamID>>* pSsToStorageTeam)
 	  : dbgid(debugId), txnStateStore(store), keyInfo(info), confChanges(forceRecovery), initialCommit(true),
 	    ssToStorageTeam(pSsToStorageTeam), tLogGroupCollection(collection) {}
 
@@ -77,7 +77,7 @@ struct ResolverData {
 	             std::unordered_map<UID, StorageServerInterface>* tssMapping,
 	             Version commitVersion,
 	             Reference<TLogGroupCollection> collection,
-	             std::unordered_map<UID, std::set<ptxn::StorageTeamID>>* ssToStorageTeam)
+	             std::unordered_map<UID, std::unordered_set<ptxn::StorageTeamID>>* ssToStorageTeam)
 	  : dbgid(debugId), txnStateStore(store), keyInfo(info), confChanges(forceRecovery), logSystem(logSystem),
 	    toCommit(toCommit), popVersion(popVersion), storageCache(storageCache), tssMapping(tssMapping),
 	    ssToStorageTeam(ssToStorageTeam), tLogGroupCollection(collection) {

--- a/fdbserver/ProxyCommitData.actor.h
+++ b/fdbserver/ProxyCommitData.actor.h
@@ -223,7 +223,7 @@ struct ProxyCommitData {
 
 	std::map<Tag, UID> tagToServer;
 	// Each storage server's own team.
-	std::unordered_map<UID, std::set<ptxn::StorageTeamID>> ssToStorageTeam;
+	std::unordered_map<UID, std::unordered_set<ptxn::StorageTeamID>> ssToStorageTeam;
 
 	// List of added/removed storage teams in given TLogGroup.
 	std::unordered_map<UID, std::vector<std::pair<ptxn::StorageTeamID, bool>>> changedTeams;

--- a/fdbserver/Resolver.actor.cpp
+++ b/fdbserver/Resolver.actor.cpp
@@ -150,7 +150,7 @@ struct Resolver : ReferenceCounted<Resolver> {
 	Reference<TLogGroupCollection> tLogGroupCollection = Reference<TLogGroupCollection>(nullptr);
 
 	// Each storage server's teams.
-	std::unordered_map<UID, std::set<ptxn::StorageTeamID>> ssToStorageTeam;
+	std::unordered_map<UID, std::unordered_set<ptxn::StorageTeamID>> ssToStorageTeam;
 
 	Version debugMinRecentStateVersion = 0;
 


### PR DESCRIPTION
Just refactor set to unordered_set.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
