### PR TITLE
Fix go style issues

### DIFF
--- a/bindings/go/src/_stacktester/directory.go
+++ b/bindings/go/src/_stacktester/directory.go
@@ -22,11 +22,12 @@ package main
 
 import (
 	"bytes"
+	"strings"
+
 	"github.com/apple/foundationdb/bindings/go/src/fdb"
 	"github.com/apple/foundationdb/bindings/go/src/fdb/directory"
 	"github.com/apple/foundationdb/bindings/go/src/fdb/subspace"
 	"github.com/apple/foundationdb/bindings/go/src/fdb/tuple"
-	"strings"
 )
 
 func (sm *StackMachine) popTuples(count int) []tuple.Tuple {

--- a/bindings/go/src/fdb/directory/allocator.go
+++ b/bindings/go/src/fdb/directory/allocator.go
@@ -25,10 +25,11 @@ package directory
 import (
 	"bytes"
 	"encoding/binary"
-	"github.com/apple/foundationdb/bindings/go/src/fdb"
-	"github.com/apple/foundationdb/bindings/go/src/fdb/subspace"
 	"math/rand"
 	"sync"
+
+	"github.com/apple/foundationdb/bindings/go/src/fdb"
+	"github.com/apple/foundationdb/bindings/go/src/fdb/subspace"
 )
 
 var oneBytes = []byte{0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}

--- a/bindings/go/src/fdb/directory/directorySubspace.go
+++ b/bindings/go/src/fdb/directory/directorySubspace.go
@@ -25,6 +25,7 @@ package directory
 import (
 	"fmt"
 	"strings"
+
 	"github.com/apple/foundationdb/bindings/go/src/fdb"
 	"github.com/apple/foundationdb/bindings/go/src/fdb/subspace"
 )

--- a/bindings/go/src/fdb/directory/node.go
+++ b/bindings/go/src/fdb/directory/node.go
@@ -24,6 +24,7 @@ package directory
 
 import (
 	"bytes"
+
 	"github.com/apple/foundationdb/bindings/go/src/fdb"
 	"github.com/apple/foundationdb/bindings/go/src/fdb/subspace"
 )

--- a/bindings/go/src/fdb/subspace/subspace.go
+++ b/bindings/go/src/fdb/subspace/subspace.go
@@ -78,8 +78,8 @@ type Subspace interface {
 	// FoundationDB keys (corresponding to the prefix of this Subspace).
 	fdb.KeyConvertible
 
-	// All Subspaces implement fdb.ExactRange and fdb.Range, and describe all 
-	// keys strictly within the subspace that encode tuples. Specifically, 
+	// All Subspaces implement fdb.ExactRange and fdb.Range, and describe all
+	// keys strictly within the subspace that encode tuples. Specifically,
 	// this will include all keys in [prefix + '\x00', prefix + '\xff').
 	fdb.ExactRange
 }

--- a/bindings/go/src/fdb/tuple/tuple.go
+++ b/bindings/go/src/fdb/tuple/tuple.go
@@ -102,7 +102,7 @@ func printTuple(tuple Tuple, sb *strings.Builder) {
 			fmt.Fprintf(sb, "%v", t)
 		}
 
-		if (i < len(tuple) - 1) {
+		if i < len(tuple)-1 {
 			sb.WriteString(", ")
 		}
 	}

--- a/bindings/go/src/fdb/tuple/tuple_test.go
+++ b/bindings/go/src/fdb/tuple/tuple_test.go
@@ -121,7 +121,7 @@ func BenchmarkTuplePacking(b *testing.B) {
 }
 
 func TestTupleString(t *testing.T) {
-	testCases :=[ ]struct {
+	testCases := []struct {
 		input    Tuple
 		expected string
 	}{

--- a/recipes/go-recipes/blob.go
+++ b/recipes/go-recipes/blob.go
@@ -22,6 +22,7 @@ package main
 
 import (
 	"fmt"
+
 	"github.com/apple/foundationdb/bindings/go/src/fdb"
 	"github.com/apple/foundationdb/bindings/go/src/fdb/directory"
 	"github.com/apple/foundationdb/bindings/go/src/fdb/subspace"

--- a/recipes/go-recipes/doc.go
+++ b/recipes/go-recipes/doc.go
@@ -23,12 +23,13 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"math/rand"
+
 	"github.com/apple/foundationdb/bindings/go/src/fdb"
 	"github.com/apple/foundationdb/bindings/go/src/fdb/directory"
 	"github.com/apple/foundationdb/bindings/go/src/fdb/subspace"
 	"github.com/apple/foundationdb/bindings/go/src/fdb/tuple"
-	"io/ioutil"
-	"math/rand"
 )
 
 func clear_subspace(trtr fdb.Transactor, sub subspace.Subspace) error {
@@ -69,7 +70,7 @@ func ToTuples(item interface{}) []tuple.Tuple {
 	switch i := item.(type) {
 	case []interface{}:
 		if len(i) == 0 {
-			return []tuple.Tuple{tuple.Tuple{EmptyList}}
+			return []tuple.Tuple{{EmptyList}}
 		}
 		tuples := make([]tuple.Tuple, 0)
 		for i, v := range i {
@@ -80,7 +81,7 @@ func ToTuples(item interface{}) []tuple.Tuple {
 		return tuples
 	case map[string]interface{}:
 		if len(i) == 0 {
-			return []tuple.Tuple{tuple.Tuple{EmptyObject}}
+			return []tuple.Tuple{{EmptyObject}}
 		}
 		tuples := make([]tuple.Tuple, 0)
 		for k, v := range i {
@@ -90,7 +91,7 @@ func ToTuples(item interface{}) []tuple.Tuple {
 		}
 		return tuples
 	default:
-		return []tuple.Tuple{tuple.Tuple{i}}
+		return []tuple.Tuple{{i}}
 	}
 	return nil
 }
@@ -119,7 +120,7 @@ func FromTuples(tuples []tuple.Tuple) interface{} {
 		if !ok {
 			group[k] = make([]tuple.Tuple, 0)
 		}
-		group[k] = append(group[k], t[0:len(t)])
+		group[k] = append(group[k], t[0:])
 	}
 
 	switch first[0].(type) {
@@ -128,7 +129,7 @@ func FromTuples(tuples []tuple.Tuple) interface{} {
 		for _, g := range group {
 			subtup := make([]tuple.Tuple, 0)
 			for _, t := range g {
-				subtup = append(subtup, t[1:len(t)])
+				subtup = append(subtup, t[1:])
 			}
 			res = append(res, FromTuples(subtup))
 		}
@@ -138,7 +139,7 @@ func FromTuples(tuples []tuple.Tuple) interface{} {
 		for _, g := range group {
 			subtup := make([]tuple.Tuple, 0)
 			for _, t := range g {
-				subtup = append(subtup, t[1:len(t)])
+				subtup = append(subtup, t[1:])
 			}
 			res[g[0][0].(string)] = FromTuples(subtup)
 		}
@@ -210,7 +211,7 @@ func (doc Doc) GetDoc(trtr fdb.Transactor, doc_id int) interface{} {
 			if err != nil {
 				panic(err)
 			}
-			tuples = append(tuples, append(tup[1:len(tup)], _unpack(v.Value)...))
+			tuples = append(tuples, append(tup[1:], _unpack(v.Value)...))
 		}
 		return nil, nil
 	})

--- a/recipes/go-recipes/graph.go
+++ b/recipes/go-recipes/graph.go
@@ -22,11 +22,12 @@ package main
 
 import (
 	"fmt"
+	"log"
+
 	"github.com/apple/foundationdb/bindings/go/src/fdb"
 	"github.com/apple/foundationdb/bindings/go/src/fdb/directory"
 	"github.com/apple/foundationdb/bindings/go/src/fdb/subspace"
 	"github.com/apple/foundationdb/bindings/go/src/fdb/tuple"
-	"log"
 )
 
 func clear_subspace(trtr fdb.Transactor, sub subspace.Subspace) error {

--- a/recipes/go-recipes/indirect.go
+++ b/recipes/go-recipes/indirect.go
@@ -22,11 +22,12 @@ package main
 
 import (
 	"fmt"
+	"log"
+
 	"github.com/apple/foundationdb/bindings/go/src/fdb"
 	"github.com/apple/foundationdb/bindings/go/src/fdb/directory"
 	"github.com/apple/foundationdb/bindings/go/src/fdb/subspace"
 	"github.com/apple/foundationdb/bindings/go/src/fdb/tuple"
-	"log"
 )
 
 func clear_subspace(trtr fdb.Transactor, sub subspace.Subspace) error {

--- a/recipes/go-recipes/priority.go
+++ b/recipes/go-recipes/priority.go
@@ -22,12 +22,13 @@ package main
 
 import (
 	"fmt"
+	"log"
+	"math/rand"
+
 	"github.com/apple/foundationdb/bindings/go/src/fdb"
 	"github.com/apple/foundationdb/bindings/go/src/fdb/directory"
 	"github.com/apple/foundationdb/bindings/go/src/fdb/subspace"
 	"github.com/apple/foundationdb/bindings/go/src/fdb/tuple"
-	"log"
-	"math/rand"
 )
 
 func clear_subspace(trtr fdb.Transactor, sub subspace.Subspace) error {

--- a/recipes/go-recipes/queue.go
+++ b/recipes/go-recipes/queue.go
@@ -22,11 +22,12 @@ package main
 
 import (
 	"fmt"
+	"log"
+
 	"github.com/apple/foundationdb/bindings/go/src/fdb"
 	"github.com/apple/foundationdb/bindings/go/src/fdb/directory"
 	"github.com/apple/foundationdb/bindings/go/src/fdb/subspace"
 	"github.com/apple/foundationdb/bindings/go/src/fdb/tuple"
-	"log"
 )
 
 type EmptyQueueError struct{}

--- a/recipes/go-recipes/table.go
+++ b/recipes/go-recipes/table.go
@@ -22,11 +22,12 @@ package main
 
 import (
 	"fmt"
+	"log"
+
 	"github.com/apple/foundationdb/bindings/go/src/fdb"
 	"github.com/apple/foundationdb/bindings/go/src/fdb/directory"
 	"github.com/apple/foundationdb/bindings/go/src/fdb/subspace"
 	"github.com/apple/foundationdb/bindings/go/src/fdb/tuple"
-	"log"
 )
 
 func clear_subspace(trtr fdb.Transactor, sub subspace.Subspace) error {


### PR DESCRIPTION
Go is very opinionated about the code style and offers tools to enforce those guidelines like `gofmt` and `goimports`. I ran the following command to get those changes:

```bash
gofmt -s -w  .
goimports -w .
```

We might want to consider to add this to our CI pipeline to enforce this style.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [x] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
