### PR TITLE
Bump default TLogVersion

### DIFF
--- a/fdbclient/FDBTypes.h
+++ b/fdbclient/FDBTypes.h
@@ -748,8 +748,8 @@ struct TLogVersion {
 		V6 = 6, // 7.0
 		MIN_SUPPORTED = V2,
 		MAX_SUPPORTED = V6,
-		MIN_RECRUITABLE = V5,
-		DEFAULT = V5,
+		MIN_RECRUITABLE = V6,
+		DEFAULT = V6,
 	} version;
 
 	TLogVersion() : version(UNSET) {}


### PR DESCRIPTION
The default `TLogVersion` for FDB 7.1 is now `TLogVersion::V6`. 7.0 also supports this version, so downgrades should continue to work.

`TLogVersion::V6` adds support for saving `SpanID`s to disk on tlogs. This allows the transaction tracing feature to propagate data from the transaction subsystem to the storage servers.

More info on tlog compatibility: https://github.com/apple/foundationdb/blob/main/design/tlog-forward-compatibility.md.html

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
