### PR TITLE
TLog pop works for on-disk data

### DIFF
--- a/fdbserver/DiskQueue.actor.cpp
+++ b/fdbserver/DiskQueue.actor.cpp
@@ -1614,6 +1614,8 @@ public:
 
 	StorageBytes getStorageBytes() const override { return queue->getStorageBytes(); }
 
+	location getPoppedLocationForTest() override { return popped; }
+
 private:
 	DiskQueue* queue;
 	location pushed;

--- a/fdbserver/DiskQueue.actor.cpp
+++ b/fdbserver/DiskQueue.actor.cpp
@@ -1614,7 +1614,7 @@ public:
 
 	StorageBytes getStorageBytes() const override { return queue->getStorageBytes(); }
 
-	location getPoppedLocationForTest() override { return popped; }
+	location TEST_getPoppedLocation() override { return popped; }
 
 private:
 	DiskQueue* queue;

--- a/fdbserver/IDiskQueue.h
+++ b/fdbserver/IDiskQueue.h
@@ -93,6 +93,8 @@ public:
 	                                           // that immediately followed this call
 
 	virtual StorageBytes getStorageBytes() const = 0;
+
+	virtual location getPoppedLocationForTest() { throw unsupported_operation(); };
 };
 
 // InMemoryDiskQueue

--- a/fdbserver/IDiskQueue.h
+++ b/fdbserver/IDiskQueue.h
@@ -94,7 +94,7 @@ public:
 
 	virtual StorageBytes getStorageBytes() const = 0;
 
-	virtual location getPoppedLocationForTest() { throw unsupported_operation(); };
+	virtual location TEST_getPoppedLocation() { throw unsupported_operation(); };
 };
 
 // InMemoryDiskQueue

--- a/fdbserver/TLogServer.actor.cpp
+++ b/fdbserver/TLogServer.actor.cpp
@@ -1365,8 +1365,6 @@ ACTOR Future<Void> updateStorage(TLogData* self) {
 		// this if means if there are some version will not be read by SS anymore but still persistent, then pop from
 		// disk queue.
 
-		// nextVersion var is closely related to spilling, popDiskQueue should not be only called under cerain condition
-		// of nextVersion
 		if (nextVersion > logData->persistentDataVersion) {
 			wait(self->persistentDataCommitLock.take());
 			commitLockReleaser = FlowLock::Releaser(self->persistentDataCommitLock);

--- a/fdbserver/TLogServer.actor.cpp
+++ b/fdbserver/TLogServer.actor.cpp
@@ -1364,6 +1364,9 @@ ACTOR Future<Void> updateStorage(TLogData* self) {
 		// nextVersion is the next to be read by SS, that is still on TLog
 		// this if means if there are some version will not be read by SS anymore but still persistent, then pop from
 		// disk queue.
+
+		// nextVersion var is closely related to spilling, popDiskQueue should not be only called under cerain condition
+		// of nextVersion
 		if (nextVersion > logData->persistentDataVersion) {
 			wait(self->persistentDataCommitLock.take());
 			commitLockReleaser = FlowLock::Releaser(self->persistentDataCommitLock);

--- a/fdbserver/ptxn/TLogServer.actor.cpp
+++ b/fdbserver/ptxn/TLogServer.actor.cpp
@@ -547,7 +547,6 @@ struct LogGenerationData : NonCopyable, public ReferenceCounted<LogGenerationDat
 					} else {
 						sizes.second -= m->second.first.size();
 					}
-
 					self->versionMessages.erase(it);
 				}
 
@@ -800,7 +799,6 @@ void TLogQueue::forgetBefore(Version upToVersion, Reference<LogGenerationData> l
 	} else {
 		v.decrementNonEnd();
 	}
-
 	logData->versionLocation.erase(logData->versionLocation.begin(),
 	                               v); // ... and then we erase that previous version and all prior versions
 }
@@ -1434,8 +1432,8 @@ ACTOR Future<Void> tLogPopCore(Reference<TLogGroupData> self,
 			    .detail("PoppedVersionLag", PoppedVersionLag)
 			    .detail("MinPoppedStorageTeamVersion", logData->minPoppedStorageTeamVersion)
 			    .detail("QueuePoppedVersion", logData->queuePoppedVersion)
-			    .detail("UnpoppedRecovered", storageTeamData->unpoppedRecovered ? "True" : "False")
-			    .detail("NothingPersistent", storageTeamData->nothingPersistent ? "True" : "False");
+			    .detail("UnpoppedRecovered", storageTeamData->unpoppedRecovered)
+			    .detail("NothingPersistent", storageTeamData->nothingPersistent);
 		}
 
 		Version minVersionInTeam = upTo; // storageTeams
@@ -2137,6 +2135,8 @@ void updatePersistentPopped(Reference<TLogGroupData> self,
 	}
 }
 
+// Each storage team tries to update its poppedLocation by reading data from persistentData
+// persistentData got updated in updatePersistentData actor.
 ACTOR Future<Void> updatePoppedLocation(Reference<TLogGroupData> self,
                                         Reference<LogGenerationData> logData,
                                         Reference<LogGenerationData::StorageTeamData> data) {
@@ -2144,8 +2144,7 @@ ACTOR Future<Void> updatePoppedLocation(Reference<TLogGroupData> self,
 	if (logData->shouldSpillByValue(data->storageTeamId)) {
 		return Void();
 	}
-
-	if (data->versionForPoppedLocation >= data->persistentPopped) // both are 0 here, thus not continuing.
+	if (data->versionForPoppedLocation >= data->persistentPopped)
 		return Void();
 	data->versionForPoppedLocation = data->persistentPopped;
 

--- a/fdbserver/ptxn/TLogServer.actor.cpp
+++ b/fdbserver/ptxn/TLogServer.actor.cpp
@@ -486,7 +486,8 @@ struct LogGenerationData : NonCopyable, public ReferenceCounted<LogGenerationDat
 		bool nothingPersistent =
 		    false; // true means tag is *known* to have no messages in persistentData.  false means nothing.
 
-		StorageTeamData(StorageTeamID storageTeam, std::vector<Tag> tags) : storageTeamId(storageTeam), tags(tags) {
+		StorageTeamData(StorageTeamID storageTeam, const std::vector<Tag>& tags)
+		  : storageTeamId(storageTeam), tags(tags) {
 			popped = invalidVersion;
 			persistentPopped = invalidVersion;
 			for (auto& tag : tags) {
@@ -495,8 +496,8 @@ struct LogGenerationData : NonCopyable, public ReferenceCounted<LogGenerationDat
 		}
 
 		StorageTeamData(StorageTeamID storageTeam,
-		                std::vector<Tag> tags,
-		                std::map<Tag, Version> tagToVersions,
+		                const std::vector<Tag>& tags,
+		                const std::map<Tag, Version>& tagToVersions,
 		                bool nothingPersistent,
 		                bool poppedRecently,
 		                bool unpoppedRecovered)
@@ -539,7 +540,7 @@ struct LogGenerationData : NonCopyable, public ReferenceCounted<LogGenerationDat
 					auto const& m = self->versionMessages.begin();
 					++messagesErased;
 
-					// TODO: understand what this means and make it work for txsTeam
+					// TODO: understand why we need to subtract the size for normal/txs team
 					if (self->storageTeamId != txsTeam) {
 						sizes.first -= m->second.first.size();
 					} else {
@@ -674,11 +675,11 @@ struct LogGenerationData : NonCopyable, public ReferenceCounted<LogGenerationDat
 
 	// only callable after getStorageTeamData returns a null reference
 	Reference<StorageTeamData> createStorageTeamData(StorageTeamID team,
-	                                                 std::vector<Tag>& tags,
+	                                                 const std::vector<Tag>& tags,
 	                                                 bool nothingPersistent,
 	                                                 bool poppedRecently,
 	                                                 bool unpoppedRecovered,
-	                                                 std::map<Tag, Version> tagToVersions = {}) {
+	                                                 const std::map<Tag, Version>& tagToVersions = {}) {
 		return storageTeamData[team] = makeReference<StorageTeamData>(
 		           team, tags, tagToVersions, nothingPersistent, poppedRecently, unpoppedRecovered);
 	}

--- a/fdbserver/ptxn/test/Driver.actor.cpp
+++ b/fdbserver/ptxn/test/Driver.actor.cpp
@@ -180,7 +180,6 @@ std::shared_ptr<TestDriverContext> initTestDriverContext(const TestDriverOptions
 		TLogGroupID groupId = tLogGroupByStorageTeamID(groups, storageTeamID);
 		TLogGroup& tLogGroup = context->getTLogGroup(groupId);
 		context->storageTeamIDTLogGroupIDMapper[storageTeamID] = groupId;
-		// TODO: support tags when implementing pop
 		tLogGroup.storageTeams[storageTeamID] =
 		    std::vector<Tag>{ Tag(1, deterministicRandom()->randomInt(1, 1 << 16)) };
 	}

--- a/fdbserver/ptxn/test/TestTLogServer.actor.cpp
+++ b/fdbserver/ptxn/test/TestTLogServer.actor.cpp
@@ -571,8 +571,8 @@ ACTOR Future<Void> verifyReadStorageServer(std::shared_ptr<ptxn::test::TestDrive
 TEST_CASE("/fdbserver/ptxn/test/commit_peek") {
 	state ptxn::test::TestDriverOptions options(params);
 	state std::vector<Future<Void>> actors;
+	(const_cast<ServerKnobs*> SERVER_KNOBS)->TLOG_SPILL_THRESHOLD = 1500e6; // remove after implementing peek from disk
 	state std::shared_ptr<ptxn::test::TestDriverContext> pContext = ptxn::test::initTestDriverContext(options);
-	state const int NUM_COMMITS = 10;
 
 	for (const auto& group : pContext->tLogGroups) {
 		ptxn::test::print::print(group);
@@ -584,8 +584,8 @@ TEST_CASE("/fdbserver/ptxn/test/commit_peek") {
 	wait(startTLogServers(&actors, pContext, folder));
 
 	state ptxn::StorageTeamID storageTeamID = pContext->storageTeamIDs[0];
-	std::vector<Standalone<StringRef>> messages = wait(commitInject(pContext, storageTeamID, NUM_COMMITS));
-	wait(verifyPeek(pContext, storageTeamID, NUM_COMMITS));
+	std::vector<Standalone<StringRef>> messages = wait(commitInject(pContext, storageTeamID, pContext->numCommits));
+	wait(verifyPeek(pContext, storageTeamID, pContext->numCommits));
 	platform::eraseDirectoryRecursive(folder);
 	return Void();
 }
@@ -593,6 +593,7 @@ TEST_CASE("/fdbserver/ptxn/test/commit_peek") {
 TEST_CASE("/fdbserver/ptxn/test/run_storage_server") {
 	state ptxn::test::TestDriverOptions options(params);
 	state std::vector<Future<Void>> actors;
+	(const_cast<ServerKnobs*> SERVER_KNOBS)->TLOG_SPILL_THRESHOLD = 1500e6; // remove after implementing peek from disk
 	state std::shared_ptr<ptxn::test::TestDriverContext> pContext = ptxn::test::initTestDriverContext(options);
 
 	for (const auto& group : pContext->tLogGroups) {
@@ -680,14 +681,15 @@ TEST_CASE("/fdbserver/ptxn/test/lock_tlog") {
 ACTOR Future<std::pair<std::vector<Standalone<StringRef>>, std::vector<Version>>> commitInjectReturnVersions(
     std::shared_ptr<ptxn::test::TestDriverContext> pContext,
     ptxn::StorageTeamID storageTeamID,
-    int numCommits) {
+    int numCommits,
+    Version cur = 0) {
 	state ptxn::test::print::PrintTiming printTiming("tlog/commitInject");
 
 	state const ptxn::TLogGroupID tLogGroupID = pContext->storageTeamIDTLogGroupIDMapper.at(storageTeamID);
 	state std::shared_ptr<ptxn::TLogInterfaceBase> pInterface = pContext->getTLogLeaderByStorageTeamID(storageTeamID);
 	ASSERT(pInterface);
 
-	state Version currVersion = 0;
+	state Version currVersion = cur;
 	state Version prevVersion = currVersion;
 	state Version storageTeamVersion = -1;
 	increaseVersion(currVersion);
@@ -740,6 +742,7 @@ TEST_CASE("/fdbserver/ptxn/test/read_persisted_disk_on_tlog") {
 	state ptxn::test::TestDriverOptions options(params);
 	state std::vector<Future<Void>> actors;
 	(const_cast<ServerKnobs*> SERVER_KNOBS)->BUGGIFY_TLOG_STORAGE_MIN_UPDATE_INTERVAL = 0.5;
+	(const_cast<ServerKnobs*> SERVER_KNOBS)->TLOG_SPILL_THRESHOLD = 1500e6; // remove after implementing peek from disk
 	state std::shared_ptr<ptxn::test::TestDriverContext> pContext = ptxn::test::initTestDriverContext(options);
 
 	for (const auto& group : pContext->tLogGroups) {
@@ -789,29 +792,50 @@ TEST_CASE("/fdbserver/ptxn/test/pop_data") {
 	state ptxn::test::TestDriverOptions options(params);
 	state std::vector<Future<Void>> actors;
 	(const_cast<ServerKnobs*> SERVER_KNOBS)->BUGGIFY_TLOG_STORAGE_MIN_UPDATE_INTERVAL = 0.5;
+	(const_cast<ServerKnobs*> SERVER_KNOBS)->TLOG_SPILL_THRESHOLD = 0;
+
 	state std::shared_ptr<ptxn::test::TestDriverContext> pContext = ptxn::test::initTestDriverContext(options);
 
 	for (const auto& group : pContext->tLogGroups) {
 		ptxn::test::print::print(group);
 	}
 	state ptxn::StorageTeamID storageTeamID = pContext->storageTeamIDs[0];
-
 	state std::string folder = "simfdb/" + deterministicRandom()->randomAlphaNumeric(10);
 	platform::createDirectory(folder);
 
-	wait(startTLogServers(&actors, pContext, folder, true));
+	wait(startTLogServers(&actors, pContext, folder));
 	state IKeyValueStore* d = pContext->kvStores[pContext->storageTeamIDTLogGroupIDMapper[storageTeamID]];
+	state IDiskQueue* q = pContext->diskQueues[pContext->storageTeamIDTLogGroupIDMapper[storageTeamID]];
 
 	state std::pair<std::vector<Standalone<StringRef>>, std::vector<Version>> res =
 	    wait(commitInjectReturnVersions(pContext, storageTeamID, pContext->numCommits));
 	state std::vector<Standalone<StringRef>> expectedMessages = res.first;
-	wait(verifyPeek(pContext, storageTeamID, pContext->numCommits));
+	// wait(verifyPeek(pContext, storageTeamID, pContext->numCommits));
 
 	wait(pop(pContext,
 	         res.second.back(),
 	         storageTeamID,
 	         pContext->getTLogGroup(pContext->storageTeamIDTLogGroupIDMapper[storageTeamID])
 	             .storageTeams[storageTeamID][0]));
+
+	// commit 1 more time, to give TLog a chance to pop disk
+	state std::pair<std::vector<Standalone<StringRef>>, std::vector<Version>> resIgnore =
+	    wait(commitInjectReturnVersions(pContext, storageTeamID, 1, res.second.back()));
+
+	wait(delay(5.0)); // give some time for the updateStorageLoop to run
+	int totalSizeExcludeHeader = 0;
+	for (const auto& written : res.first) {
+		totalSizeExcludeHeader += written.size();
+	}
+	totalSizeExcludeHeader -= res.first.back().size(); // because poppedLocation record the start location
+
+	// the final popped location is the total sizes of written messages + page headers
+	// it is hard to calculate page headers size here, thus using '>'
+	// (note that the last message needs to be excluded because pop location use the start instead of end of a location)
+	// ref: https://github.com/apple/foundationdb/blob/4bf14e6/fdbserver/TLogServer.actor.cpp#L919
+	ASSERT(q->getPoppedLocationForTest() > totalSizeExcludeHeader);
+
+	(const_cast<ServerKnobs*> SERVER_KNOBS)->TLOG_SPILL_THRESHOLD = 1500e6;
 	platform::eraseDirectoryRecursive(folder);
 	return Void();
 }
@@ -831,7 +855,7 @@ TEST_CASE("/fdbserver/ptxn/test/read_tlog_spilled") {
 	state std::string folder = "simfdb/" + deterministicRandom()->randomAlphaNumeric(10);
 	platform::createDirectory(folder);
 
-	wait(startTLogServers(&actors, pContext, folder, true));
+	wait(startTLogServers(&actors, pContext, folder));
 	state IKeyValueStore* d = pContext->kvStores[pContext->storageTeamIDTLogGroupIDMapper[storageTeamID]];
 
 	state std::pair<std::vector<Standalone<StringRef>>, std::vector<Version>> res =
@@ -882,7 +906,7 @@ TEST_CASE("/fdbserver/ptxn/test/read_tlog_not_spilled_with_default_threshold") {
 	state std::string folder = "simfdb/" + deterministicRandom()->randomAlphaNumeric(10);
 	platform::createDirectory(folder);
 
-	wait(startTLogServers(&actors, pContext, folder, true));
+	wait(startTLogServers(&actors, pContext, folder));
 	state IKeyValueStore* d = pContext->kvStores[pContext->storageTeamIDTLogGroupIDMapper[storageTeamID]];
 
 	state std::pair<std::vector<Standalone<StringRef>>, std::vector<Version>> res =


### PR DESCRIPTION
    TLog pop works for on-disk data
    
    Previously only in-memory data is popped, this commit makes
    on-disk data work with pop API.
    
    This PR also tests for spilling data, because when popping
    we need to consider both spilling and disk queue.
    Due to the way the code is written, I find no easy way to
    disable spill while still popping, so they are tested together.
    
    This commit also sets the spill threshold to default value
    for tests who needs to peek, to avoid spilling because peek
    does not work for on-disk data now, need fo fix it before
    uncomment them.

20220204-032133-haofu-b98c5e0b37b2b2a9  (3 failures, fixed)
20220204-042420-haofu-c371efc0424eaa86
3rd commit: 20220208-022341-haofu-7e048f4907113fb3

This PR is based on https://github.com/apple/foundationdb/pull/6299 (merge 6299 first)
# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
