### PR TITLE
ptxn: Use StorageServerStorageTeams class instead of set

### DIFF
--- a/fdbclient/SystemData.cpp
+++ b/fdbclient/SystemData.cpp
@@ -422,16 +422,21 @@ namespace ptxn {
 
 StorageServerStorageTeams::StorageServerStorageTeams(const StorageTeamID& privateMutationsStorageTeamID_,
                                                      const StorageTeamIDContainer& storageTeamIDs_)
-  : privateMutationsStorageTeamID(privateMutationsStorageTeamID_), storageTeamIDs(storageTeamIDs_) {}
+  : privateMutationsStorageTeamID(privateMutationsStorageTeamID_), storageTeamIDs(storageTeamIDs_) {
+
+	ASSERT_WE_THINK(!storageTeamIDs.count(privateMutationsStorageTeamID));
+}
 
 StorageServerStorageTeams::StorageServerStorageTeams(const ValueRef& serializedValue) {
 	auto [privateMutationsStorageTeamID_, storageTeamIDs_] = decodeStorageServerToTeamIdValue(serializedValue);
 
 	privateMutationsStorageTeamID = privateMutationsStorageTeamID_;
 	storageTeamIDs.swap(storageTeamIDs_);
+	ASSERT_WE_THINK(!storageTeamIDs.count(privateMutationsStorageTeamID));
 }
 
 StorageServerStorageTeams& StorageServerStorageTeams::insert(const StorageTeamID& storageTeamID) {
+	ASSERT_WE_THINK(storageTeamID != privateMutationsStorageTeamID);
 	storageTeamIDs.insert(storageTeamID);
 	return *this;
 }
@@ -447,6 +452,10 @@ const Value StorageServerStorageTeams::toValue() const {
 
 std::string StorageServerStorageTeams::toString() const {
 	return concatToString("{", privateMutationsStorageTeamID, ", {", joinToString(storageTeamIDs), "}}");
+}
+
+int StorageServerStorageTeams::size() const {
+	return storageTeamIDs.size();
 }
 
 } // namespace ptxn

--- a/fdbclient/SystemData.h
+++ b/fdbclient/SystemData.h
@@ -160,11 +160,20 @@ public:
 	// Gets the storage team ID for private mutations
 	const StorageTeamID& getPrivateMutationsStorageTeamID() const { return privateMutationsStorageTeamID; }
 
-	// Gets the set of storage team IDs
+	// Gets the set of storage team IDs, not including the private team.
 	const StorageTeamIDContainer& getStorageTeams() const { return storageTeamIDs; }
 
 	// Add a new storage team ID to list
 	StorageServerStorageTeams& insert(const StorageTeamID& storageTeamID);
+
+	// Adds storage teams from given STL style container.
+	template <class T>
+	void insert(const T& teams) {
+		for (const auto& t : teams) {
+			ASSERT_WE_THINK(t != privateMutationsStorageTeamID);
+			insert(t);
+		}
+	}
 
 	// Removes a storage team ID
 	StorageServerStorageTeams& erase(const StorageTeamID& storageTeamID);
@@ -179,6 +188,9 @@ public:
 
 	// Encodes the object into a std::string object
 	std::string toString() const;
+
+	// Returns the number of teams excluding the private team.
+	int size() const;
 };
 
 } // namespace ptxn

--- a/fdbserver/ApplyMetadataMutation.h
+++ b/fdbserver/ApplyMetadataMutation.h
@@ -51,7 +51,7 @@ struct ResolverData {
 	std::map<UID, Reference<StorageInfo>>* storageCache = nullptr;
 	std::unordered_map<UID, StorageServerInterface>* tssMapping = nullptr;
 	std::map<Tag, UID> tagToServer;
-	std::unordered_map<UID, std::unordered_set<ptxn::StorageTeamID>>* ssToStorageTeam = nullptr;
+	std::unordered_map<UID, ptxn::StorageServerStorageTeams>* ssToStorageTeam = nullptr;
 	std::unordered_map<UID, std::vector<std::pair<ptxn::StorageTeamID, bool>>> changedTeams;
 	Reference<TLogGroupCollection> tLogGroupCollection;
 
@@ -61,7 +61,7 @@ struct ResolverData {
 	             KeyRangeMap<ServerCacheInfo>* info,
 	             bool* forceRecovery,
 	             Reference<TLogGroupCollection> collection,
-	             std::unordered_map<UID, std::unordered_set<ptxn::StorageTeamID>>* pSsToStorageTeam)
+	             std::unordered_map<UID, ptxn::StorageServerStorageTeams>* pSsToStorageTeam)
 	  : dbgid(debugId), txnStateStore(store), keyInfo(info), confChanges(forceRecovery), initialCommit(true),
 	    ssToStorageTeam(pSsToStorageTeam), tLogGroupCollection(collection) {}
 
@@ -77,7 +77,7 @@ struct ResolverData {
 	             std::unordered_map<UID, StorageServerInterface>* tssMapping,
 	             Version commitVersion,
 	             Reference<TLogGroupCollection> collection,
-	             std::unordered_map<UID, std::unordered_set<ptxn::StorageTeamID>>* ssToStorageTeam)
+	             std::unordered_map<UID, ptxn::StorageServerStorageTeams>* ssToStorageTeam)
 	  : dbgid(debugId), txnStateStore(store), keyInfo(info), confChanges(forceRecovery), logSystem(logSystem),
 	    toCommit(toCommit), popVersion(popVersion), storageCache(storageCache), tssMapping(tssMapping),
 	    ssToStorageTeam(ssToStorageTeam), tLogGroupCollection(collection) {

--- a/fdbserver/ProxyCommitData.actor.h
+++ b/fdbserver/ProxyCommitData.actor.h
@@ -223,7 +223,7 @@ struct ProxyCommitData {
 
 	std::map<Tag, UID> tagToServer;
 	// Each storage server's own team.
-	std::unordered_map<UID, std::unordered_set<ptxn::StorageTeamID>> ssToStorageTeam;
+	std::unordered_map<UID, ptxn::StorageServerStorageTeams> ssToStorageTeam;
 
 	// List of added/removed storage teams in given TLogGroup.
 	std::unordered_map<UID, std::vector<std::pair<ptxn::StorageTeamID, bool>>> changedTeams;


### PR DESCRIPTION
Refactor code to use `ptxn::StorageServerStorageTeams` instead of set.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
