### PR TITLE
Refactor TRACING_UDP_LISTENER_PORT to TRACING_UDP_LISTENER_ADDR.

### DIFF
--- a/flow/Knobs.cpp
+++ b/flow/Knobs.cpp
@@ -74,7 +74,8 @@ void FlowKnobs::initialize(Randomize randomize, IsSimulated isSimulated) {
 
 	init( WRITE_TRACING_ENABLED,                              true ); if( randomize && BUGGIFY ) WRITE_TRACING_ENABLED = false;
 	init( TRACING_SAMPLE_RATE,                                 0.0 ); // Fraction of distributed traces (not spans) to sample (0 means ignore all traces)
-	init( TRACING_UDP_LISTENER_ADDR,                          "127.0.0.1:8889"); // Only applicable if TracerType is set to a network option
+	init( TRACING_UDP_LISTENER_ADDR,                          "127.0.0.1"); // Only applicable if TracerType is set to a network option
+	init( TRACING_UDP_LISTENER_PORT,                          8889); // Only applicable if TracerType is set to a network option
 
 	//connectionMonitor
 	init( CONNECTION_MONITOR_LOOP_TIME,   isSimulated ? 0.75 : 1.0 ); if( randomize && BUGGIFY ) CONNECTION_MONITOR_LOOP_TIME = 6.0;

--- a/flow/Knobs.cpp
+++ b/flow/Knobs.cpp
@@ -74,7 +74,7 @@ void FlowKnobs::initialize(Randomize randomize, IsSimulated isSimulated) {
 
 	init( WRITE_TRACING_ENABLED,                              true ); if( randomize && BUGGIFY ) WRITE_TRACING_ENABLED = false;
 	init( TRACING_SAMPLE_RATE,                                 0.0 ); // Fraction of distributed traces (not spans) to sample (0 means ignore all traces)
-	init( TRACING_UDP_LISTENER_PORT,                          8889 ); // Only applicable if TracerType is set to a network option
+	init( TRACING_UDP_LISTENER_ADDR,                          "127.0.0.1:8889"); // Only applicable if TracerType is set to a network option
 
 	//connectionMonitor
 	init( CONNECTION_MONITOR_LOOP_TIME,   isSimulated ? 0.75 : 1.0 ); if( randomize && BUGGIFY ) CONNECTION_MONITOR_LOOP_TIME = 6.0;

--- a/flow/Knobs.cpp
+++ b/flow/Knobs.cpp
@@ -74,7 +74,7 @@ void FlowKnobs::initialize(Randomize randomize, IsSimulated isSimulated) {
 
 	init( WRITE_TRACING_ENABLED,                              true ); if( randomize && BUGGIFY ) WRITE_TRACING_ENABLED = false;
 	init( TRACING_SAMPLE_RATE,                                 0.0 ); // Fraction of distributed traces (not spans) to sample (0 means ignore all traces)
-	init( TRACING_UDP_LISTENER_ADDR,                          "127.0.0.1" ); // Only applicable if TracerType is set to a network option
+	init( TRACING_UDP_LISTENER_ADDR,                   "127.0.0.1" ); // Only applicable if TracerType is set to a network option
 	init( TRACING_UDP_LISTENER_PORT,                          8889 ); // Only applicable if TracerType is set to a network option
 
 	//connectionMonitor

--- a/flow/Knobs.cpp
+++ b/flow/Knobs.cpp
@@ -74,8 +74,8 @@ void FlowKnobs::initialize(Randomize randomize, IsSimulated isSimulated) {
 
 	init( WRITE_TRACING_ENABLED,                              true ); if( randomize && BUGGIFY ) WRITE_TRACING_ENABLED = false;
 	init( TRACING_SAMPLE_RATE,                                 0.0 ); // Fraction of distributed traces (not spans) to sample (0 means ignore all traces)
-	init( TRACING_UDP_LISTENER_ADDR,                          "127.0.0.1"); // Only applicable if TracerType is set to a network option
-	init( TRACING_UDP_LISTENER_PORT,                          8889); // Only applicable if TracerType is set to a network option
+	init( TRACING_UDP_LISTENER_ADDR,                          "127.0.0.1" ); // Only applicable if TracerType is set to a network option
+	init( TRACING_UDP_LISTENER_PORT,                          8889 ); // Only applicable if TracerType is set to a network option
 
 	//connectionMonitor
 	init( CONNECTION_MONITOR_LOOP_TIME,   isSimulated ? 0.75 : 1.0 ); if( randomize && BUGGIFY ) CONNECTION_MONITOR_LOOP_TIME = 6.0;

--- a/flow/Knobs.h
+++ b/flow/Knobs.h
@@ -122,7 +122,7 @@ public:
 
 	bool WRITE_TRACING_ENABLED;
 	double TRACING_SAMPLE_RATE;
-	int TRACING_UDP_LISTENER_PORT;
+	std::string TRACING_UDP_LISTENER_ADDR;
 
 	// run loop profiling
 	double RUN_LOOP_PROFILING_INTERVAL;

--- a/flow/Knobs.h
+++ b/flow/Knobs.h
@@ -123,6 +123,7 @@ public:
 	bool WRITE_TRACING_ENABLED;
 	double TRACING_SAMPLE_RATE;
 	std::string TRACING_UDP_LISTENER_ADDR;
+	int TRACING_UDP_LISTENER_PORT;
 
 	// run loop profiling
 	double RUN_LOOP_PROFILING_INTERVAL;

--- a/flow/Tracing.actor.cpp
+++ b/flow/Tracing.actor.cpp
@@ -102,8 +102,7 @@ struct TraceRequest {
 // A server listening for UDP trace messages, run only in simulation.
 ACTOR Future<Void> simulationStartServer() {
 	TraceEvent(SevInfo, "UDPServerStarted").detail("Port", FLOW_KNOBS->TRACING_UDP_LISTENER_ADDR);
-	state NetworkAddress localAddress =
-	    NetworkAddress::parse(FLOW_KNOBS->TRACING_UDP_LISTENER_ADDR);
+	state NetworkAddress localAddress = NetworkAddress::parse(FLOW_KNOBS->TRACING_UDP_LISTENER_ADDR);
 	state Reference<IUDPSocket> serverSocket = wait(INetworkConnections::net()->createUDPSocket(localAddress));
 	serverSocket->bind(localAddress);
 
@@ -294,8 +293,7 @@ struct FastUDPTracer : public UDPTracer {
 				udp_server_actor_ = simulationStartServer();
 			}
 
-			NetworkAddress localAddress =
-			    NetworkAddress::parse(FLOW_KNOBS->TRACING_UDP_LISTENER_ADDR);
+			NetworkAddress localAddress = NetworkAddress::parse(FLOW_KNOBS->TRACING_UDP_LISTENER_ADDR);
 			socket_ = INetworkConnections::net()->createUDPSocket(localAddress);
 		});
 

--- a/flow/Tracing.actor.cpp
+++ b/flow/Tracing.actor.cpp
@@ -101,9 +101,9 @@ struct TraceRequest {
 
 // A server listening for UDP trace messages, run only in simulation.
 ACTOR Future<Void> simulationStartServer() {
-	TraceEvent(SevInfo, "UDPServerStarted").detail("Port", FLOW_KNOBS->TRACING_UDP_LISTENER_PORT);
+	TraceEvent(SevInfo, "UDPServerStarted").detail("Port", FLOW_KNOBS->TRACING_UDP_LISTENER_ADDR);
 	state NetworkAddress localAddress =
-	    NetworkAddress::parse("127.0.0.1:" + std::to_string(FLOW_KNOBS->TRACING_UDP_LISTENER_PORT));
+	    NetworkAddress::parse(FLOW_KNOBS->TRACING_UDP_LISTENER_ADDR);
 	state Reference<IUDPSocket> serverSocket = wait(INetworkConnections::net()->createUDPSocket(localAddress));
 	serverSocket->bind(localAddress);
 
@@ -295,7 +295,7 @@ struct FastUDPTracer : public UDPTracer {
 			}
 
 			NetworkAddress localAddress =
-			    NetworkAddress::parse("127.0.0.1:" + std::to_string(FLOW_KNOBS->TRACING_UDP_LISTENER_PORT));
+			    NetworkAddress::parse(FLOW_KNOBS->TRACING_UDP_LISTENER_ADDR);
 			socket_ = INetworkConnections::net()->createUDPSocket(localAddress);
 		});
 

--- a/flow/Tracing.actor.cpp
+++ b/flow/Tracing.actor.cpp
@@ -20,6 +20,7 @@
 
 #include "flow/Tracing.h"
 
+#include "flow/Knobs.h"
 #include "flow/network.h"
 
 #include <functional>
@@ -101,8 +102,11 @@ struct TraceRequest {
 
 // A server listening for UDP trace messages, run only in simulation.
 ACTOR Future<Void> simulationStartServer() {
-	TraceEvent(SevInfo, "UDPServerStarted").detail("Port", FLOW_KNOBS->TRACING_UDP_LISTENER_ADDR);
-	state NetworkAddress localAddress = NetworkAddress::parse(FLOW_KNOBS->TRACING_UDP_LISTENER_ADDR);
+	TraceEvent(SevInfo, "UDPServerStarted")
+	    .detail("Address", FLOW_KNOBS->TRACING_UDP_LISTENER_ADDR)
+	    .detail("Port", FLOW_KNOBS->TRACING_UDP_LISTENER_PORT);
+	state NetworkAddress localAddress = NetworkAddress::parse(FLOW_KNOBS->TRACING_UDP_LISTENER_ADDR + ":" +
+	                                                          std::to_string(FLOW_KNOBS->TRACING_UDP_LISTENER_PORT));
 	state Reference<IUDPSocket> serverSocket = wait(INetworkConnections::net()->createUDPSocket(localAddress));
 	serverSocket->bind(localAddress);
 
@@ -293,7 +297,8 @@ struct FastUDPTracer : public UDPTracer {
 				udp_server_actor_ = simulationStartServer();
 			}
 
-			NetworkAddress localAddress = NetworkAddress::parse(FLOW_KNOBS->TRACING_UDP_LISTENER_ADDR);
+			NetworkAddress localAddress = NetworkAddress::parse(FLOW_KNOBS->TRACING_UDP_LISTENER_ADDR + ":" +
+			                                                    std::to_string(FLOW_KNOBS->TRACING_UDP_LISTENER_PORT));
 			socket_ = INetworkConnections::net()->createUDPSocket(localAddress);
 		});
 

--- a/flow/Tracing.actor.cpp
+++ b/flow/Tracing.actor.cpp
@@ -102,11 +102,13 @@ struct TraceRequest {
 
 // A server listening for UDP trace messages, run only in simulation.
 ACTOR Future<Void> simulationStartServer() {
+	// We're going to force the address to be loopback regardless of FLOW_KNOBS->TRACING_UDP_LISTENER_ADDR
+	// because we're in simulation testing mode.
 	TraceEvent(SevInfo, "UDPServerStarted")
-	    .detail("Address", FLOW_KNOBS->TRACING_UDP_LISTENER_ADDR)
+	    .detail("Address", "127.0.0.1")
 	    .detail("Port", FLOW_KNOBS->TRACING_UDP_LISTENER_PORT);
-	state NetworkAddress localAddress = NetworkAddress::parse(FLOW_KNOBS->TRACING_UDP_LISTENER_ADDR + ":" +
-	                                                          std::to_string(FLOW_KNOBS->TRACING_UDP_LISTENER_PORT));
+	state NetworkAddress localAddress =
+	    NetworkAddress::parse("127.0.0.1:" + std::to_string(FLOW_KNOBS->TRACING_UDP_LISTENER_PORT));
 	state Reference<IUDPSocket> serverSocket = wait(INetworkConnections::net()->createUDPSocket(localAddress));
 	serverSocket->bind(localAddress);
 


### PR DESCRIPTION
This PR introduces a change to allow a user to configure a destination addr/port pair, rather than simply a port when enabling the `network_lossy` tracer.

Previously the address of the tracing receiver was hardcoded to `127.0.0.1`. It will be quite common for users to provision tracing collector agents as sidecars or on separate hosts. In many cases sidecars will use various networking configurations with bridge or overlay style networks that will require sending traces to a specific IP other than localhost. The same of course is applicable to collectors provisioned on other hosts.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
