### PR TITLE
Support xxhash3 for checksuming DiskQueue for TLogs

### DIFF
--- a/fdbclient/FDBTypes.h
+++ b/fdbclient/FDBTypes.h
@@ -740,16 +740,18 @@ struct TLogVersion {
 		// V4 changed how data gets written to satellite TLogs so that we can peek from them;
 		// V5 merged reference and value spilling
 		// V6 added span context to list of serialized mutations sent from proxy to tlogs
+		// V7 use xxhash3 for TLog checksum
 		// V1 = 1,  // 4.6 is dispatched to via 6.0
 		V2 = 2, // 6.0
 		V3 = 3, // 6.1
 		V4 = 4, // 6.2
 		V5 = 5, // 6.3
 		V6 = 6, // 7.0
+		V7 = 7, // 7.2
 		MIN_SUPPORTED = V2,
-		MAX_SUPPORTED = V6,
-		MIN_RECRUITABLE = V5,
-		DEFAULT = V5,
+		MAX_SUPPORTED = V7,
+		MIN_RECRUITABLE = V6,
+		DEFAULT = V6,
 	} version;
 
 	TLogVersion() : version(UNSET) {}
@@ -775,6 +777,8 @@ struct TLogVersion {
 			return V5;
 		if (s == LiteralStringRef("6"))
 			return V6;
+		if (s == LiteralStringRef("7"))
+			return V7;
 		return default_error_or();
 	}
 };

--- a/fdbserver/DiskQueue.actor.cpp
+++ b/fdbserver/DiskQueue.actor.cpp
@@ -25,6 +25,7 @@
 #include "flow/crc32c.h"
 #include "flow/genericactors.actor.h"
 #include "flow/actorcompiler.h" // This must be the last #include.
+#include "flow/xxhash.h"
 
 typedef bool (*compare_pages)(void*, void*);
 typedef int64_t loc_t;
@@ -1044,8 +1045,13 @@ private:
 		union {
 			UID hash;
 			struct {
-				uint32_t hash32;
-				uint32_t _unused;
+				union {
+					uint64_t hash64;
+					struct {
+						uint32_t hash32;
+						uint32_t _unused;
+					};
+				};
 				uint16_t magic;
 				uint16_t implementationVersion;
 			};
@@ -1073,15 +1079,22 @@ private:
 		uint32_t checksum_crc32c() const {
 			return crc32c_append(0xfdbeefdb, (uint8_t*)&_unused, sizeof(Page) - sizeof(uint32_t));
 		}
+		uint64_t checksum_xxhash3() const {
+			return XXH3_64bits(static_cast<const void*>(&magic), sizeof(Page) - sizeof(uint32_t));
+		}
 		void updateHash() {
 			switch (diskQueueVersion()) {
 			case DiskQueueVersion::V0: {
 				hash = checksum_hashlittle2();
 				return;
 			}
-			case DiskQueueVersion::V1:
-			default: {
+			case DiskQueueVersion::V1: {
 				hash32 = checksum_crc32c();
+				return;
+			}
+			case DiskQueueVersion::V2:
+			default: {
+				hash64 = checksum_xxhash3();
 				return;
 			}
 			}
@@ -1093,6 +1106,9 @@ private:
 			}
 			case DiskQueueVersion::V1: {
 				return hash32 == checksum_crc32c();
+			}
+			case DiskQueueVersion::V2: {
+				return hash64 == checksum_xxhash3();
 			}
 			default:
 				return false;

--- a/fdbserver/DiskQueue.actor.cpp
+++ b/fdbserver/DiskQueue.actor.cpp
@@ -1145,6 +1145,9 @@ private:
 		case DiskQueueVersion::V1:
 			p.implementationVersion = 1;
 			break;
+		case DiskQueueVersion::V2:
+			p.implementationVersion = 2;
+			break;
 		}
 		p.payloadSize = 0;
 		p.seq = nextPageSeq;

--- a/fdbserver/DiskQueue.actor.cpp
+++ b/fdbserver/DiskQueue.actor.cpp
@@ -1080,7 +1080,7 @@ private:
 			return crc32c_append(0xfdbeefdb, (uint8_t*)&_unused, sizeof(Page) - sizeof(uint32_t));
 		}
 		uint64_t checksum_xxhash3() const {
-			return XXH3_64bits(static_cast<const void*>(&magic), sizeof(Page) - sizeof(uint32_t));
+			return XXH3_64bits(static_cast<const void*>(&magic), sizeof(Page) - sizeof(uint64_t));
 		}
 		void updateHash() {
 			switch (diskQueueVersion()) {

--- a/fdbserver/IDiskQueue.h
+++ b/fdbserver/IDiskQueue.h
@@ -125,6 +125,7 @@ struct numeric_limits<IDiskQueue::location> {
 enum class DiskQueueVersion : uint16_t {
 	V0 = 0, // Use hashlittle
 	V1 = 1, // Use crc32, which is faster than hashlittle
+	V2 = 2, // Use xxhash3
 };
 
 IDiskQueue* openDiskQueue(std::string basename,

--- a/fdbserver/KeyValueStoreMemory.actor.cpp
+++ b/fdbserver/KeyValueStoreMemory.actor.cpp
@@ -887,6 +887,7 @@ IKeyValueStore* keyValueStoreMemory(std::string const& basename,
 	    .detail("MemoryLimit", memoryLimit)
 	    .detail("StoreType", storeType);
 
+	// SOMEDAY: Maybe update to use DiskQueueVersion::V2 with xxhash3 checksum.
 	IDiskQueue* log = openDiskQueue(basename, ext, logID, DiskQueueVersion::V1);
 	if (storeType == KeyValueStoreType::MEMORY_RADIXTREE) {
 		return new KeyValueStoreMemory<radix_tree>(log, logID, memoryLimit, storeType, false, false, false);

--- a/fdbserver/KeyValueStoreMemory.actor.cpp
+++ b/fdbserver/KeyValueStoreMemory.actor.cpp
@@ -887,7 +887,7 @@ IKeyValueStore* keyValueStoreMemory(std::string const& basename,
 	    .detail("MemoryLimit", memoryLimit)
 	    .detail("StoreType", storeType);
 
-	// SOMEDAY: Maybe update to use DiskQueueVersion::V2 with xxhash3 checksum.
+	// SOMEDAY: update to use DiskQueueVersion::V2 with xxhash3 checksum for FDB >= 7.2
 	IDiskQueue* log = openDiskQueue(basename, ext, logID, DiskQueueVersion::V1);
 	if (storeType == KeyValueStoreType::MEMORY_RADIXTREE) {
 		return new KeyValueStoreMemory<radix_tree>(log, logID, memoryLimit, storeType, false, false, false);

--- a/fdbserver/KeyValueStoreMemory.actor.cpp
+++ b/fdbserver/KeyValueStoreMemory.actor.cpp
@@ -887,8 +887,7 @@ IKeyValueStore* keyValueStoreMemory(std::string const& basename,
 	    .detail("MemoryLimit", memoryLimit)
 	    .detail("StoreType", storeType);
 
-	// SOMEDAY: Maybe update to use DiskQueueVersion::V2 with xxhash3 checksum.
-	IDiskQueue* log = openDiskQueue(basename, ext, logID, DiskQueueVersion::V1);
+	IDiskQueue* log = openDiskQueue(basename, ext, logID, DiskQueueVersion::V2);
 	if (storeType == KeyValueStoreType::MEMORY_RADIXTREE) {
 		return new KeyValueStoreMemory<radix_tree>(log, logID, memoryLimit, storeType, false, false, false);
 	} else {

--- a/fdbserver/KeyValueStoreMemory.actor.cpp
+++ b/fdbserver/KeyValueStoreMemory.actor.cpp
@@ -887,7 +887,8 @@ IKeyValueStore* keyValueStoreMemory(std::string const& basename,
 	    .detail("MemoryLimit", memoryLimit)
 	    .detail("StoreType", storeType);
 
-	IDiskQueue* log = openDiskQueue(basename, ext, logID, DiskQueueVersion::V2);
+	// SOMEDAY: Maybe update to use DiskQueueVersion::V2 with xxhash3 checksum.
+	IDiskQueue* log = openDiskQueue(basename, ext, logID, DiskQueueVersion::V1);
 	if (storeType == KeyValueStoreType::MEMORY_RADIXTREE) {
 		return new KeyValueStoreMemory<radix_tree>(log, logID, memoryLimit, storeType, false, false, false);
 	} else {

--- a/fdbserver/workloads/ConfigureDatabase.actor.cpp
+++ b/fdbserver/workloads/ConfigureDatabase.actor.cpp
@@ -36,9 +36,9 @@ static const char* storageMigrationTypes[] = { "perpetual_storage_wiggle=0 stora
 	                                           "perpetual_storage_wiggle=1",
 	                                           "perpetual_storage_wiggle=1 storage_migration_type=gradual",
 	                                           "storage_migration_type=aggressive" };
-static const char* logTypes[] = { "log_engine:=1",  "log_engine:=2",  "log_spill:=1",
-	                              "log_spill:=2",   "log_version:=2", "log_version:=3",
-	                              "log_version:=4", "log_version:=5", "log_version:=6" };
+static const char* logTypes[] = { "log_engine:=1",  "log_engine:=2",  "log_spill:=1",   "log_spill:=2",
+	                              "log_version:=2", "log_version:=3", "log_version:=4", "log_version:=5",
+	                              "log_version:=6", "log_version:=7" };
 static const char* redundancies[] = { "single", "double", "triple" };
 static const char* backupTypes[] = { "backup_worker_enabled:=0", "backup_worker_enabled:=1" };
 


### PR DESCRIPTION
The PR addresses #5141 

Support using xxhash3 to checksum DiskQueue blocks, when TLogVersion >= 7. Also changing default TLogVersion to V6 for FDB 7.1.

For now KeyValueStoreMemory will still be using crc32 checksum for the underlying DiskQueue.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
