### PR TITLE
Do not sent metadata mutations to all resolvers

### DIFF
--- a/fdbclient/IClientApi.h
+++ b/fdbclient/IClientApi.h
@@ -27,7 +27,7 @@
 
 #include "flow/ThreadHelper.actor.h"
 
-class VersionVector;
+struct VersionVector;
 
 // An interface that represents a transaction created by a client
 class ITransaction {

--- a/fdbclient/NativeAPI.actor.h
+++ b/fdbclient/NativeAPI.actor.h
@@ -237,12 +237,11 @@ struct TransactionState : ReferenceCounted<TransactionState> {
 	Reference<TransactionLogInfo> trLogInfo;
 	TransactionOptions options;
 
-	bool readVersionObtainedFromGrvProxy;
-
 	Optional<UID> debugID;
 	TaskPriority taskID;
 	SpanID spanID;
 	UseProvisionalProxies useProvisionalProxies = UseProvisionalProxies::False;
+	bool readVersionObtainedFromGrvProxy;
 
 	int numErrors = 0;
 	double startTime = 0;

--- a/fdbserver/TagPartitionedLogSystem.actor.h
+++ b/fdbserver/TagPartitionedLogSystem.actor.h
@@ -126,9 +126,9 @@ struct TagPartitionedLogSystem final : ILogSystem, ReferenceCounted<TagPartition
 	                        LogEpoch e,
 	                        Optional<PromiseStream<Future<Void>>> addActor = Optional<PromiseStream<Future<Void>>>())
 	  : dbgid(dbgid), logSystemType(LogSystemType::empty), expectedLogSets(0), logRouterTags(0), txsTags(0),
-	    repopulateRegionAntiQuorum(0), stopped(false), epoch(e), oldestBackupEpoch(0), maxRv(0),
+	    repopulateRegionAntiQuorum(0), stopped(false), epoch(e), oldestBackupEpoch(0),
 	    recoveryCompleteWrittenToCoreState(false), remoteLogsWrittenToCoreState(false), hasRemoteServers(false),
-	    locality(locality), addActor(addActor), popActors(false) {}
+	    maxRv(0), locality(locality), addActor(addActor), popActors(false) {}
 
 	void stopRejoins() final;
 

--- a/fdbserver/TagPartitionedLogSystem.actor.h
+++ b/fdbserver/TagPartitionedLogSystem.actor.h
@@ -105,7 +105,6 @@ struct TagPartitionedLogSystem final : ILogSystem, ReferenceCounted<TagPartition
 	Optional<Version> recoveredAt;
 	Version knownCommittedVersion;
 	Version backupStartVersion = invalidVersion; // max(tLogs[0].startVersion, previous epochEnd).
-	Version maxRv; // (when ENABLE_VERSION_VECTOR_TLOG_UNICAST is on) the maximum DV over all tLogs.
 	std::map<UID, Version> rvLogs; // recovery versions per tlog
 	LocalityData locality;
 	// For each currently running popFromLog actor, outstandingPops is
@@ -128,7 +127,7 @@ struct TagPartitionedLogSystem final : ILogSystem, ReferenceCounted<TagPartition
 	  : dbgid(dbgid), logSystemType(LogSystemType::empty), expectedLogSets(0), logRouterTags(0), txsTags(0),
 	    repopulateRegionAntiQuorum(0), stopped(false), epoch(e), oldestBackupEpoch(0),
 	    recoveryCompleteWrittenToCoreState(false), remoteLogsWrittenToCoreState(false), hasRemoteServers(false),
-	    maxRv(0), locality(locality), addActor(addActor), popActors(false) {}
+	    locality(locality), addActor(addActor), popActors(false) {}
 
 	void stopRejoins() final;
 

--- a/fdbserver/masterserver.actor.cpp
+++ b/fdbserver/masterserver.actor.cpp
@@ -115,7 +115,7 @@ struct MasterData : NonCopyable, ReferenceCounted<MasterData> {
 	    reportLiveCommittedVersionRequests("ReportLiveCommittedVersionRequests", cc),
 	    versionVectorTagUpdates("VersionVectorTagUpdates", cc),
 	    waitForPrevCommitRequests("WaitForPrevCommitRequests", cc),
-	    nonWaitForPrevCommitRequests("NonWaitForPrevCommitRequests", cc), addActor(addActor),
+	    nonWaitForPrevCommitRequests("NonWaitForPrevCommitRequests", cc),
 	    versionVectorSizeOnCVReply("VersionVectorSizeOnCVReply",
 	                               dbgid,
 	                               SERVER_KNOBS->LATENCY_METRICS_LOGGING_INTERVAL,
@@ -123,7 +123,8 @@ struct MasterData : NonCopyable, ReferenceCounted<MasterData> {
 	    waitForPrevLatencies("WaitForPrevLatencies",
 	                         dbgid,
 	                         SERVER_KNOBS->LATENCY_METRICS_LOGGING_INTERVAL,
-	                         SERVER_KNOBS->LATENCY_SAMPLE_SIZE) {
+	                         SERVER_KNOBS->LATENCY_SAMPLE_SIZE),
+	    addActor(addActor) {
 		logger = traceCounters("MasterMetrics", dbgid, SERVER_KNOBS->WORKER_LOGGING_INTERVAL, &cc, "MasterMetrics");
 		if (forceRecovery && !myInterface.locality.dcId().present()) {
 			TraceEvent(SevError, "ForcedRecoveryRequiresDcID").log();


### PR DESCRIPTION
The change is that only Resolver 0 processes metadata mutations and generates private mutations, thus reducing CPU cost for other resolvers.

Also fixed some clang warnings.

20220203-235222-jzhou-c9613b62d93f13ca passed.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
