### PR TITLE
RFC1123 datetime format for Date header

### DIFF
--- a/fdbclient/BlobStore.actor.cpp
+++ b/fdbclient/BlobStore.actor.cpp
@@ -1165,11 +1165,11 @@ void BlobStoreEndpoint::setV4AuthHeaders(std::string const& verb,
 	if (date.empty() || datestamp.empty()) {
 		time_t ts;
 		time(&ts);
-		char dateBuf[20];
-		// ISO 8601 format YYYYMMDD'T'HHMMSS'Z'
-		strftime(dateBuf, 20, "%Y%m%dT%H%M%SZ", gmtime(&ts));
+		char dateBuf[40];
+		// RFC 1123 format
+		strftime(dateBuf, 40, "%a, %d %b %Y %T GMT", gmtime(&ts));
 		amzDate = dateBuf;
-		strftime(dateBuf, 20, "%Y%m%d", gmtime(&ts));
+		strftime(dateBuf, 40, "%Y%m%d", gmtime(&ts));
 		dateStamp = dateBuf;
 	} else {
 		amzDate = date;
@@ -1254,11 +1254,11 @@ void BlobStoreEndpoint::setV4AuthHeaders(std::string const& verb,
 void BlobStoreEndpoint::setAuthHeaders(std::string const& verb, std::string const& resource, HTTP::Headers& headers) {
 	std::string& date = headers["Date"];
 
-	char dateBuf[20];
+	char dateBuf[40];
 	time_t ts;
 	time(&ts);
-	// ISO 8601 format YYYYMMDD'T'HHMMSS'Z'
-	strftime(dateBuf, 20, "%Y%m%dT%H%M%SZ", gmtime(&ts));
+	// RFC 1123 format
+	strftime(dateBuf, 40, "%a, %d %b %Y %T GMT", gmtime(&ts));
 	date = dateBuf;
 
 	std::string msg;


### PR DESCRIPTION
A valid time stamp (using either the HTTP Date header or an x-amz-date alternative) is mandatory for authenticated requests.
The value of the Date header must be in one of the RFC 2616 formats (RFC 1123, RFC 1060 or ANSI C's asctime() format)
The RFC 1123 format is preferred as an Internet standard (RFC 2616)

Signed-off-by: Dmitry Kvashnin <dm.kvashnin@gmail.com>

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
