### PR TITLE
Do not sent metadata mutations to all resolvers

### DIFF
--- a/fdbserver/CommitProxyServer.actor.cpp
+++ b/fdbserver/CommitProxyServer.actor.cpp
@@ -204,13 +204,6 @@ struct ResolutionRequestBuilder {
 				auto& tr = getOutTransaction(0, trIn.read_snapshot);
 				tr.mutations.push_back(requests[0].arena, m);
 				tr.lock_aware = trRequest.isLockAware();
-
-				for (int r = 1; r < self->resolvers.size() && SERVER_KNOBS->PROXY_USE_RESOLVER_PRIVATE_MUTATIONS; r++) {
-					// Keep metadata in sync on all resolvers
-					auto& outTransaction = getOutTransaction(r, trIn.read_snapshot);
-					outTransaction.mutations.push_back(requests[r].arena, m);
-					outTransaction.lock_aware = trRequest.isLockAware();
-				}
 			}
 		}
 		if (isTXNStateTransaction && !trRequest.isLockAware()) {
@@ -879,13 +872,8 @@ ACTOR Future<Void> getResolution(CommitBatchContext* self) {
 }
 
 void assertResolutionStateMutationsSizeConsistent(const std::vector<ResolveTransactionBatchReply>& resolution) {
-
 	for (int r = 1; r < resolution.size(); r++) {
 		ASSERT(resolution[r].stateMutations.size() == resolution[0].stateMutations.size());
-		// The resolution[r].privateMutationCount can be different due to random log router tags:
-		// two consecutive mutations may have the same or different locations. If they share the
-		// same locations, then no new SpanContextMessage is written. Otherwise, a new one is written.
-		ASSERT_EQ(resolution[0].privateMutations.size(), resolution[r].privateMutations.size());
 		for (int s = 0; s < resolution[r].stateMutations.size(); s++) {
 			ASSERT(resolution[r].stateMutations[s].size() == resolution[0].stateMutations[s].size());
 		}

--- a/fdbserver/ptxn/TLogServer.actor.cpp
+++ b/fdbserver/ptxn/TLogServer.actor.cpp
@@ -644,7 +644,7 @@ struct LogGenerationData : NonCopyable, public ReferenceCounted<LogGenerationDat
 	UID recruitmentID;
 	TLogSpillType logSpillType;
 	PromiseStream<Void> warningCollectorInput;
-	int unpoppedRecoveredStorageTeams;
+	int unpoppedRecoveredStorageTeams = 0;
 
 	Reference<StorageTeamData> getStorageTeamData(const StorageTeamID& storageTeamID) {
 		for (const auto& [id, data] : storageTeamData) {
@@ -680,7 +680,7 @@ struct LogGenerationData : NonCopyable, public ReferenceCounted<LogGenerationDat
 	                           const std::string& context)
 	  : tlogGroupData(tlogGroupData), logId(interf.id()), cc("TLog", interf.id().toString()),
 	    bytesInput("BytesInput", cc), bytesDurable("BytesDurable", cc), protocolVersion(protocolVersion),
-	    unpoppedRecoveredStorageTeams(0), storageTeams(storageTeams), terminated(tlogGroupData->terminated.getFuture()),
+	    storageTeams(storageTeams), terminated(tlogGroupData->terminated.getFuture()),
 	    logSystem(new AsyncVar<Reference<ILogSystem>>()),
 	    // These are initialized differently on init() or recovery
 	    locality(locality), recruitmentID(recruitmentID), logSpillType(logSpillType) {


### PR DESCRIPTION
Let only resolver 0 to process metadata mutations and generate private mutations.

20220207-173004-jzhou-ab775e34e5ba041b has one failure (timeout) of unit test `read_persisted_disk_on_tlog`, which is unrelated.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
