### PR TITLE
Fix compatibility issue of s3 backup

### DIFF
--- a/fdbclient/ClientKnobs.cpp
+++ b/fdbclient/ClientKnobs.cpp
@@ -210,6 +210,7 @@ void ClientKnobs::initialize(Randomize randomize) {
 	init( HTTP_VERBOSE_LEVEL,                        0 );
 	init( HTTP_REQUEST_ID_HEADER,                   "" );
 	init( HTTP_REQUEST_AWS_V4_HEADER,             true );
+	init( HTTP_RESPONSE_SKIP_VERIFY_CHECKSUM_FOR_PARTIAL_CONTENT, false );
 	init( BLOBSTORE_ENCRYPTION_TYPE,                "" );
 	init( BLOBSTORE_CONNECT_TRIES,                  10 );
 	init( BLOBSTORE_CONNECT_TIMEOUT,                10 );

--- a/fdbclient/ClientKnobs.h
+++ b/fdbclient/ClientKnobs.h
@@ -221,6 +221,7 @@ public:
 	int HTTP_VERBOSE_LEVEL;
 	std::string HTTP_REQUEST_ID_HEADER;
 	bool HTTP_REQUEST_AWS_V4_HEADER; // setting this knob to true will enable AWS V4 style header.
+	bool HTTP_RESPONSE_SKIP_VERIFY_CHECKSUM_FOR_PARTIAL_CONTENT; // skip verify md5 checksum for 206 response
 	std::string BLOBSTORE_ENCRYPTION_TYPE;
 	int BLOBSTORE_CONNECT_TRIES;
 	int BLOBSTORE_CONNECT_TIMEOUT;

--- a/fdbclient/S3BlobStore.actor.cpp
+++ b/fdbclient/S3BlobStore.actor.cpp
@@ -345,9 +345,9 @@ std::string S3BlobStoreEndpoint::getResourceURL(std::string resource, std::strin
 			params.append("&");
 		}
 		params.append("header=");
-		params.append(HTTP::urlEncode(k));
+		params.append(k);
 		params.append(":");
-		params.append(HTTP::urlEncode(v));
+		params.append(v);
 	}
 
 	if (!params.empty())
@@ -696,6 +696,42 @@ void S3BlobStoreEndpoint::returnConnection(ReusableConnection& rconn) {
 	rconn.conn = Reference<IConnection>();
 }
 
+std::string awsCanonicalURI(const std::string& resource, std::vector<std::string>& queryParameters, bool isV4) {
+	StringRef resourceRef(resource);
+	resourceRef.eat("/");
+	std::string canonicalURI("/" + resourceRef.toString());
+	size_t q = canonicalURI.find_last_of('?');
+	if (q != canonicalURI.npos)
+		canonicalURI.resize(q);
+	if (isV4) {
+		canonicalURI = HTTP::awsV4URIEncode(canonicalURI, false);
+	} else {
+		canonicalURI = HTTP::urlEncode(canonicalURI);
+	}
+
+	// Create the canonical query string
+	std::string queryString;
+	q = resource.find_last_of('?');
+	if (q != queryString.npos)
+		queryString = resource.substr(q + 1);
+
+	StringRef qStr(queryString);
+	StringRef queryParameter;
+	while ((queryParameter = qStr.eat("&")) != StringRef()) {
+		StringRef param = queryParameter.eat("=");
+		StringRef value = queryParameter.eat();
+
+		if (isV4) {
+			queryParameters.push_back(HTTP::awsV4URIEncode(param.toString(), true) + "=" +
+			                          HTTP::awsV4URIEncode(value.toString(), true));
+		} else {
+			queryParameters.push_back(HTTP::urlEncode(param.toString()) + "=" + HTTP::urlEncode(value.toString()));
+		}
+	}
+
+	return canonicalURI;
+}
+
 // Do a request, get a Response.
 // Request content is provided as UnsentPacketQueue *pContent which will be depleted as bytes are sent but the queue
 // itself must live for the life of this actor and be destroyed by the caller
@@ -739,6 +775,7 @@ ACTOR Future<Reference<HTTP::Response>> doRequest_impl(Reference<S3BlobStoreEndp
 		state Optional<NetworkAddress> remoteAddress;
 		state bool connectionEstablished = false;
 		state Reference<HTTP::Response> r;
+		state std::string canonicalURI = resource;
 
 		try {
 			// Start connecting
@@ -775,15 +812,23 @@ ACTOR Future<Reference<HTTP::Response>> doRequest_impl(Reference<S3BlobStoreEndp
 				bstore->setAuthHeaders(verb, resource, headers);
 			}
 
+			std::vector<std::string> queryParameters;
+			canonicalURI = awsCanonicalURI(resource, queryParameters, CLIENT_KNOBS->HTTP_REQUEST_AWS_V4_HEADER);
+			if (!queryParameters.empty()) {
+				canonicalURI += "?";
+				canonicalURI += boost::algorithm::join(queryParameters, "&");
+			}
+
 			if (bstore->useProxy) {
 				// Has to be in absolute-form.
-				resource = "http://" + bstore->host + ":" + bstore->service + resource;
+				canonicalURI = "http://" + bstore->host + ":" + bstore->service + canonicalURI;
 			}
+
 			remoteAddress = rconn.conn->getPeerAddress();
 			wait(bstore->requestRate->getAllowance(1));
 			Reference<HTTP::Response> _r = wait(timeoutError(HTTP::doRequest(rconn.conn,
 			                                                                 verb,
-			                                                                 resource,
+			                                                                 canonicalURI,
 			                                                                 headers,
 			                                                                 &contentCopy,
 			                                                                 contentLen,
@@ -925,9 +970,9 @@ ACTOR Future<Void> listObjectsStream_impl(Reference<S3BlobStoreEndpoint> bstore,
 	resource.append(bucket);
 	resource.append("/?max-keys=1000");
 	if (prefix.present())
-		resource.append("&prefix=").append(HTTP::urlEncode(prefix.get()));
+		resource.append("&prefix=").append(prefix.get());
 	if (delimiter.present())
-		resource.append("&delimiter=").append(HTTP::urlEncode(std::string(1, delimiter.get())));
+		resource.append("&delimiter=").append(std::string(1, delimiter.get()));
 	resource.append("&marker=");
 	state std::string lastFile;
 	state bool more = true;
@@ -939,7 +984,7 @@ ACTOR Future<Void> listObjectsStream_impl(Reference<S3BlobStoreEndpoint> bstore,
 		state FlowLock::Releaser listReleaser(bstore->concurrentLists, 1);
 
 		HTTP::Headers headers;
-		state std::string fullResource = resource + HTTP::urlEncode(lastFile);
+		state std::string fullResource = resource + lastFile;
 		lastFile.clear();
 		Reference<HTTP::Response> r = wait(bstore->doRequest("GET", fullResource, headers, nullptr, 0, { 200 }));
 		listReleaser.release();
@@ -1117,7 +1162,7 @@ ACTOR Future<std::vector<std::string>> listBuckets_impl(Reference<S3BlobStoreEnd
 		state FlowLock::Releaser listReleaser(bstore->concurrentLists, 1);
 
 		HTTP::Headers headers;
-		state std::string fullResource = resource + HTTP::urlEncode(lastName);
+		state std::string fullResource = resource + lastName;
 		Reference<HTTP::Response> r = wait(bstore->doRequest("GET", fullResource, headers, nullptr, 0, { 200 }));
 		listReleaser.release();
 
@@ -1286,29 +1331,15 @@ void S3BlobStoreEndpoint::setV4AuthHeaders(std::string const& verb,
 
 	// ************* TASK 1: CREATE A CANONICAL REQUEST *************
 	// Create Create canonical URI--the part of the URI from domain to query string (use '/' if no path)
-	StringRef resourceRef(resource);
-	resourceRef.eat("/");
-	std::string canonicalURI("/" + resourceRef.toString());
-	size_t q = canonicalURI.find_last_of('?');
-	if (q != canonicalURI.npos)
-		canonicalURI.resize(q);
-	canonicalURI = HTTP::awsV4URIEncode(canonicalURI, false);
-	// Create the canonical query string
-	std::string queryString;
-	q = resource.find_last_of('?');
-	if (q != queryString.npos)
-		queryString = resource.substr(q + 1);
 	std::vector<std::string> queryParameters;
-	StringRef qStr(queryString);
-	StringRef queryParameter;
-	while ((queryParameter = qStr.eat("&")) != StringRef()) {
-		StringRef param = queryParameter.eat("=");
-		StringRef value = queryParameter.eat();
-		queryParameters.push_back(HTTP::awsV4URIEncode(param.toString(), true) + "=" +
-		                          HTTP::awsV4URIEncode(value.toString(), true));
+	std::string canonicalURI = awsCanonicalURI(resource, queryParameters, true);
+
+	std::string canonicalQueryString;
+	if (!queryParameters.empty()) {
+		std::sort(queryParameters.begin(), queryParameters.end());
+		canonicalQueryString = boost::algorithm::join(queryParameters, "&");
 	}
-	std::sort(queryParameters.begin(), queryParameters.end());
-	std::string canonicalQueryString = boost::algorithm::join(queryParameters, "&");
+
 	using namespace boost::algorithm;
 	// Create the canonical headers and signed headers
 	ASSERT(!headers["Host"].empty());
@@ -1363,11 +1394,10 @@ void S3BlobStoreEndpoint::setAuthHeaders(std::string const& verb, std::string co
 
 	std::string& date = headers["Date"];
 
-	char dateBuf[20];
+	char dateBuf[64];
 	time_t ts;
 	time(&ts);
-	// ISO 8601 format YYYYMMDD'T'HHMMSS'Z'
-	strftime(dateBuf, 20, "%Y%m%dT%H%M%SZ", gmtime(&ts));
+	strftime(dateBuf, 64, "%a, %d %b %Y %H:%M:%S GMT", gmtime(&ts));
 	date = dateBuf;
 
 	std::string msg;

--- a/fdbrpc/HTTP.actor.cpp
+++ b/fdbrpc/HTTP.actor.cpp
@@ -181,6 +181,8 @@ ACTOR Future<Void> read_http_response_headers(Reference<IConnection> conn,
 		int nameEnd = -1, valueStart = -1, valueEnd = -1;
 		int len = -1;
 
+		std::string name, value;
+
 		// Read header of the form "Name: Value\n"
 		// Note that multi line header values are not supported here.
 		// Format string breaks down as follows:
@@ -190,20 +192,28 @@ ACTOR Future<Void> read_http_response_headers(Reference<IConnection> conn,
 		//   %*1[\r]       Exactly one \r
 		//   %*1[\n]       Exactly one \n
 		//   %n            Save final end position
-		if (sscanf(buf->c_str() + *pos,
-		           "%*[^:]%n:%*[ \t]%n%*[^\r]%n%*1[\r]%*1[\n]%n",
-		           &nameEnd,
-		           &valueStart,
-		           &valueEnd,
-		           &len) >= 0 &&
-		    len > 0) {
-			const std::string name(buf->substr(*pos, nameEnd));
-			const std::string value(buf->substr(*pos + valueStart, valueEnd - valueStart));
-			(*headers)[name] = value;
-			*pos += len;
-			len = -1;
-		} else // Malformed header line (at least according to this simple parsing)
+		if (sscanf(buf->c_str() + *pos, "%*[^:]%n:%*[ \t]%n", &nameEnd, &valueStart) >= 0 && valueStart > 0) {
+			// found a header name
+			name = std::string(buf->substr(*pos, nameEnd));
+			*pos += valueStart;
+		} else {
+			// Malformed header line (at least according to this simple parsing)
 			throw http_bad_response();
+		}
+
+		if (sscanf(buf->c_str() + *pos, "%*[^\r]%n%*1[\r]%*1[\n]%n", &valueEnd, &len) >= 0 && len > 0) {
+			// found a header value
+			value = std::string(buf->substr(*pos, valueEnd));
+			*pos += len;
+		} else if (sscanf(buf->c_str() + *pos, "%*1[\r]%*1[\n]%n", &len) >= 0 && len > 0) {
+			// empty header value
+			*pos += len;
+		} else {
+			// Malformed header line (at least according to this simple parsing)
+			throw http_bad_response();
+		}
+
+		(*headers)[name] = value;
 	}
 }
 
@@ -214,7 +224,7 @@ ACTOR Future<Void> read_http_response(Reference<HTTP::Response> r, Reference<ICo
 	state std::string buf;
 	state size_t pos = 0;
 
-	// Read HTTP reponse code and version line
+	// Read HTTP response code and version line
 	size_t lineLen = wait(read_delimited_into_string(conn, "\r\n", &buf, pos));
 
 	int reachedEnd = -1;
@@ -316,9 +326,15 @@ ACTOR Future<Void> read_http_response(Reference<HTTP::Response> r, Reference<ICo
 	}
 
 	// If there is actual response content, check the MD5 sum against the Content-MD5 response header
-	if (r->content.size() > 0)
-		if (!r->verifyMD5(false)) // false arg means do not fail if the Content-MD5 header is missing.
+	if (r->content.size() > 0) {
+		if (r->code == 206 && CLIENT_KNOBS->HTTP_RESPONSE_SKIP_VERIFY_CHECKSUM_FOR_PARTIAL_CONTENT) {
+			return Void();
+		}
+
+		if (!r->verifyMD5(false)) { // false arg means do not fail if the Content-MD5 header is missing.
 			throw http_bad_response();
+		}
+	}
 
 	return Void();
 }


### PR DESCRIPTION
1. For v4 signature, http request path should be encoded, currently only parameters are encoded.
2. For v2 signature, http request date header should be in form of either the http date header or x-amz-date, currently in form of ISO 8601
3. Empty response header value cause http_bad_response error.
4. Skip verifying MD5 for range get request and if http response code 206  is returned.

Since different vendors have different Content-MD5 implementation, eg. Huawei Cloud return object content checksum instead of the checksum of response body. It is difficult to verify checksum at the level of single http response for range get request.  And Content-MD5 header is deprecated in http2.0 for the same reason. In this patch I skip verifying checksum for range get request.

Test:

- [X] AWS s3 v2 & v4 signature
- [X] Tencent Cloud v2 & v4 signature
- [X] QingCloud v2 & v4 signature
- [X] Huawei Cloud v2 & v4 signature, **Huawei Cloud has incorrect service name setting in domain name, v4 signature not work currently**
- [X] Ali Cloud, **Only support virtual hosting style and not working currently.**
- [X] Minio v2 & v4 signature

Remaining issue:
1. Should support virtual hosting style #6382
2. Support pass region info from argument instead of parsing from url #6355


Reference:
1. https://docs.aws.amazon.com/AmazonS3/latest/userguide/RESTAuthentication.html
2. https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-header-based-auth.html
3. https://trac.ietf.org/trac/httpbis/ticket/178


# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
