### PR TITLE
ApiCorrectness runs outside of simulation

### DIFF
--- a/fdbserver/workloads/ApiWorkload.h
+++ b/fdbserver/workloads/ApiWorkload.h
@@ -238,7 +238,7 @@ struct ApiWorkload : TestWorkload {
 		minValueLength = getOption(options, LiteralStringRef("minValueLength"), 1);
 		maxValueLength = getOption(options, LiteralStringRef("maxValueLength"), 10000);
 
-		useExtraDB = g_simulator.extraDB != nullptr;
+		useExtraDB = g_network->isSimulated() && g_simulator.extraDB != nullptr;
 		if (useExtraDB) {
 			auto extraFile = makeReference<ClusterConnectionMemoryRecord>(*g_simulator.extraDB);
 			extraDB = Database::createDatabase(extraFile, -1);


### PR DESCRIPTION
The `ApiCorrectness` test used to run outside of simulation, IIRC. With the addition of `useExtraDB` it seems that this is no longer true. When run outside of simulation there is an instant segfault in workload construction.

I tested this change with a local (terribly simple) server setup. The only version I could easily compile was 6.1.12, unfortunately. With the patch, the workload `tests/slow/ApiCorrectness.txt` runs to completion.

*Note*: since I don't know well the use of the `extraDB` concept, I would like the reviewer to make sure that evaluating this `false` always outside of simulation is not a bug.

Please check each of the following things and check *all* boxes before accepting a PR.

- [ x ] The PR has a description, explaining both the problem and the solution.
- [ x ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ x ] Every function/class/actor that was touched is reasonably well documented.

