### PR TITLE
Log protocol version as a hex string rather than a uint64_t

### DIFF
--- a/fdbrpc/FlowTransport.actor.cpp
+++ b/fdbrpc/FlowTransport.actor.cpp
@@ -1205,8 +1205,8 @@ ACTOR static Future<Void> connectionReader(TransportData* transport,
 								    FLOW_KNOBS->CONNECTION_REJECTED_MESSAGE_DELAY) {
 									TraceEvent(SevWarn, "ConnectionRejected", conn->getDebugID())
 									    .detail("Reason", "IncompatibleProtocolVersion")
-									    .detail("LocalVersion", g_network->protocolVersion().version())
-									    .detail("RejectedVersion", pkt.protocolVersion.version())
+									    .detail("LocalVersion", g_network->protocolVersion())
+									    .detail("RejectedVersion", pkt.protocolVersion)
 									    .detail("Peer",
 									            pkt.canonicalRemotePort
 									                ? NetworkAddress(pkt.canonicalRemoteIp(), pkt.canonicalRemotePort)


### PR DESCRIPTION
Logging a protocol version object directly gives a human readable version of the protocol version. Update the `ConnectionRejected` event to do this rather than logging the integer form of the protocol version.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
