### PR TITLE
When inserting multiple streams into an EndpointMap, don't assign them to the well-known endpoint space

### DIFF
--- a/fdbrpc/FlowTransport.actor.cpp
+++ b/fdbrpc/FlowTransport.actor.cpp
@@ -117,7 +117,7 @@ const Endpoint& EndpointMap::insert(NetworkAddressList localAddresses,
 	int adjacentFree = 0;
 	int adjacentStart = -1;
 	firstFree = -1;
-	for (int i = 0; i < data.size(); i++) {
+	for (int i = wellKnownEndpointCount; i < data.size(); i++) {
 		if (data[i].receiver) {
 			adjacentFree = 0;
 		} else {


### PR DESCRIPTION
It was previously possible (at least in simulation) that registering an interface in the endpoint map would assign it endpoints from the spaces reserved for well-known endpoints. This changes the assignment logic to skip the well-known section when allocating these endpoints.

Passed 100K correctness.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
