### PR TITLE
TSS Metrics improvements

### DIFF
--- a/fdbclient/ClientKnobs.cpp
+++ b/fdbclient/ClientKnobs.cpp
@@ -36,6 +36,7 @@ void ClientKnobs::initialize(Randomize randomize) {
 
 	init( SYSTEM_MONITOR_INTERVAL,                 5.0 );
 	init( NETWORK_BUSYNESS_MONITOR_INTERVAL,       1.0 );
+	init( TSS_METRICS_LOGGING_INTERVAL,          120.0 ); // 2 minutes by default
 
 	init( FAILURE_MAX_DELAY,                       5.0 );
 	init( FAILURE_MIN_DELAY,                       4.0 ); if( randomize && BUGGIFY ) FAILURE_MIN_DELAY = 1.0;

--- a/fdbclient/ClientKnobs.h
+++ b/fdbclient/ClientKnobs.h
@@ -35,6 +35,7 @@ public:
 
 	double SYSTEM_MONITOR_INTERVAL;
 	double NETWORK_BUSYNESS_MONITOR_INTERVAL; // The interval in which we should update the network busyness metric
+	double TSS_METRICS_LOGGING_INTERVAL;
 
 	double FAILURE_MAX_DELAY;
 	double FAILURE_MIN_DELAY;

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -382,6 +382,82 @@ void traceTSSErrors(const char* name, UID tssId, const std::unordered_map<int, u
 	}
 }
 
+/*
+    For each request type, this will produce
+    <Type>Count
+    <Type>{SS,TSS}{Mean,P50,P90,P99}
+    Example:
+    GetValueLatencySSMean
+*/
+void traceSSOrTSSPercentiles(TraceEvent& ev, const std::string name, ContinuousSample<double>& sample) {
+	ev.detail(name + "Mean", sample.mean());
+	ev.detail(name + "P50", sample.median());
+	// don't log the larger percentiles unless we actually have enough samples to log the accurate percentile instead of
+	// the largest sample in this window
+	if (sample.getPopulationSize() > 10) {
+		ev.detail(name + "P90", sample.percentile(0.90));
+	}
+	if (sample.getPopulationSize() > 100) {
+		ev.detail(name + "P99", sample.percentile(0.99));
+	}
+}
+
+void traceTSSPercentiles(TraceEvent& ev,
+                         const std::string name,
+                         ContinuousSample<double>& ssSample,
+                         ContinuousSample<double>& tssSample) {
+	ASSERT(ssSample.getPopulationSize() == tssSample.getPopulationSize());
+	ev.detail(name + "Count", ssSample.getPopulationSize());
+	if (ssSample.getPopulationSize() > 0) {
+		traceSSOrTSSPercentiles(ev, name + "SS", ssSample);
+		traceSSOrTSSPercentiles(ev, name + "TSS", tssSample);
+	}
+}
+
+ACTOR Future<Void> tssLogger(DatabaseContext* cx) {
+	state double lastLogged = 0;
+	loop {
+		wait(delay(CLIENT_KNOBS->TSS_METRICS_LOGGING_INTERVAL, TaskPriority::FlushTrace));
+
+		// Log each TSS pair separately
+		for (const auto& it : cx->tssMetrics) {
+			if (it.second->mismatches.getIntervalDelta()) {
+				cx->tssMismatchStream.send(
+				    std::pair<UID, std::vector<DetailedTSSMismatch>>(it.first, it.second->detailedMismatches));
+			}
+
+			// Do error histograms as separate event
+			if (it.second->ssErrorsByCode.size()) {
+				traceTSSErrors("TSS_SSErrors", it.first, it.second->ssErrorsByCode);
+			}
+
+			if (it.second->tssErrorsByCode.size()) {
+				traceTSSErrors("TSS_TSSErrors", it.first, it.second->tssErrorsByCode);
+			}
+
+			TraceEvent tssEv("TSSClientMetrics", cx->dbId);
+			tssEv.detail("TSSID", it.first)
+			    .detail("Elapsed", (lastLogged == 0) ? 0 : now() - lastLogged)
+			    .detail("Internal", cx->internal);
+
+			it.second->cc.logToTraceEvent(tssEv);
+
+			traceTSSPercentiles(tssEv, "GetValueLatency", it.second->SSgetValueLatency, it.second->TSSgetValueLatency);
+			traceTSSPercentiles(
+			    tssEv, "GetKeyValuesLatency", it.second->SSgetKeyValuesLatency, it.second->TSSgetKeyValuesLatency);
+			traceTSSPercentiles(tssEv, "GetKeyLatency", it.second->SSgetKeyLatency, it.second->TSSgetKeyLatency);
+			traceTSSPercentiles(tssEv,
+			                    "GetKeyValuesAndFlatMapLatency",
+			                    it.second->SSgetKeyValuesAndFlatMapLatency,
+			                    it.second->TSSgetKeyValuesAndFlatMapLatency);
+
+			it.second->clear();
+		}
+
+		lastLogged = now();
+	}
+}
+
 ACTOR Future<Void> databaseLogger(DatabaseContext* cx) {
 	state double lastLogged = 0;
 	loop {
@@ -427,63 +503,6 @@ ACTOR Future<Void> databaseLogger(DatabaseContext* cx) {
 		cx->commitLatencies.clear();
 		cx->mutationsPerCommit.clear();
 		cx->bytesPerCommit.clear();
-
-		for (const auto& it : cx->tssMetrics) {
-			// TODO could skip this whole thing if tss if request counter is zero?
-			// That would potentially complicate elapsed calculation though
-			if (it.second->mismatches.getIntervalDelta()) {
-				cx->tssMismatchStream.send(
-				    std::pair<UID, std::vector<DetailedTSSMismatch>>(it.first, it.second->detailedMismatches));
-			}
-
-			// do error histograms as separate event
-			if (it.second->ssErrorsByCode.size()) {
-				traceTSSErrors("TSS_SSErrors", it.first, it.second->ssErrorsByCode);
-			}
-
-			if (it.second->tssErrorsByCode.size()) {
-				traceTSSErrors("TSS_TSSErrors", it.first, it.second->tssErrorsByCode);
-			}
-
-			TraceEvent tssEv("TSSClientMetrics", cx->dbId);
-			tssEv.detail("TSSID", it.first)
-			    .detail("Elapsed", (lastLogged == 0) ? 0 : now() - lastLogged)
-			    .detail("Internal", cx->internal);
-
-			it.second->cc.logToTraceEvent(tssEv);
-
-			tssEv.detail("MeanSSGetValueLatency", it.second->SSgetValueLatency.mean())
-			    .detail("MedianSSGetValueLatency", it.second->SSgetValueLatency.median())
-			    .detail("SSGetValueLatency90", it.second->SSgetValueLatency.percentile(0.90))
-			    .detail("SSGetValueLatency99", it.second->SSgetValueLatency.percentile(0.99));
-
-			tssEv.detail("MeanTSSGetValueLatency", it.second->TSSgetValueLatency.mean())
-			    .detail("MedianTSSGetValueLatency", it.second->TSSgetValueLatency.median())
-			    .detail("TSSGetValueLatency90", it.second->TSSgetValueLatency.percentile(0.90))
-			    .detail("TSSGetValueLatency99", it.second->TSSgetValueLatency.percentile(0.99));
-
-			tssEv.detail("MeanSSGetKeyLatency", it.second->SSgetKeyLatency.mean())
-			    .detail("MedianSSGetKeyLatency", it.second->SSgetKeyLatency.median())
-			    .detail("SSGetKeyLatency90", it.second->SSgetKeyLatency.percentile(0.90))
-			    .detail("SSGetKeyLatency99", it.second->SSgetKeyLatency.percentile(0.99));
-
-			tssEv.detail("MeanTSSGetKeyLatency", it.second->TSSgetKeyLatency.mean())
-			    .detail("MedianTSSGetKeyLatency", it.second->TSSgetKeyLatency.median())
-			    .detail("TSSGetKeyLatency90", it.second->TSSgetKeyLatency.percentile(0.90))
-			    .detail("TSSGetKeyLatency99", it.second->TSSgetKeyLatency.percentile(0.99));
-
-			tssEv.detail("MeanSSGetKeyValuesLatency", it.second->SSgetKeyValuesLatency.mean())
-			    .detail("MedianSSGetKeyValuesLatency", it.second->SSgetKeyValuesLatency.median())
-			    .detail("SSGetKeyValuesLatency90", it.second->SSgetKeyValuesLatency.percentile(0.90))
-			    .detail("SSGetKeyValuesLatency99", it.second->SSgetKeyValuesLatency.percentile(0.99));
-
-			tssEv.detail("MeanTSSGetKeyValuesLatency", it.second->TSSgetKeyValuesLatency.mean())
-			    .detail("MedianTSSGetKeyValuesLatency", it.second->TSSgetKeyValuesLatency.median())
-			    .detail("TSSGetKeyValuesLatency90", it.second->TSSgetKeyValuesLatency.percentile(0.90))
-			    .detail("TSSGetKeyValuesLatency99", it.second->TSSgetKeyValuesLatency.percentile(0.99));
-
-			it.second->clear();
-		}
 
 		lastLogged = now();
 	}
@@ -1242,7 +1261,7 @@ DatabaseContext::DatabaseContext(Reference<AsyncVar<Reference<IClusterConnection
 
 	snapshotRywEnabled = apiVersionAtLeast(300) ? 1 : 0;
 
-	logger = databaseLogger(this);
+	logger = databaseLogger(this) && tssLogger(this);
 	locationCacheSize = g_network->isSimulated() ? CLIENT_KNOBS->LOCATION_CACHE_EVICTION_SIZE_SIM
 	                                             : CLIENT_KNOBS->LOCATION_CACHE_EVICTION_SIZE;
 

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -391,13 +391,15 @@ void traceTSSErrors(const char* name, UID tssId, const std::unordered_map<int, u
 */
 void traceSSOrTSSPercentiles(TraceEvent& ev, const std::string name, ContinuousSample<double>& sample) {
 	ev.detail(name + "Mean", sample.mean());
-	ev.detail(name + "P50", sample.median());
 	// don't log the larger percentiles unless we actually have enough samples to log the accurate percentile instead of
 	// the largest sample in this window
-	if (sample.getPopulationSize() > 10) {
+	if (sample.getPopulationSize() >= 2) {
+		ev.detail(name + "P50", sample.median());
+	}
+	if (sample.getPopulationSize() >= 10) {
 		ev.detail(name + "P90", sample.percentile(0.90));
 	}
-	if (sample.getPopulationSize() > 100) {
+	if (sample.getPopulationSize() >= 100) {
 		ev.detail(name + "P99", sample.percentile(0.99));
 	}
 }

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -393,7 +393,7 @@ void traceSSOrTSSPercentiles(TraceEvent& ev, const std::string name, ContinuousS
 	ev.detail(name + "Mean", sample.mean());
 	// don't log the larger percentiles unless we actually have enough samples to log the accurate percentile instead of
 	// the largest sample in this window
-	if (sample.getPopulationSize() >= 2) {
+	if (sample.getPopulationSize() >= 3) {
 		ev.detail(name + "P50", sample.median());
 	}
 	if (sample.getPopulationSize() >= 10) {

--- a/fdbrpc/ContinuousSample.h
+++ b/fdbrpc/ContinuousSample.h
@@ -62,13 +62,12 @@ public:
 
 	T median() { return percentile(0.5); }
 
+	// Percentile (X) is the smallest element in the sample set at least as large as X% of the samples.
 	T percentile(double percentile) {
 		if (!samples.size() || percentile < 0.0 || percentile > 1.0)
 			return T();
 		sort();
-		// Percentile (X) is the smallest element in the sample set at least as large as X% of the samples.
-		// Min with last idx to ensure no out of bounds for percentile=1.0
-		int idx = std::min((int)std::ceil(samples.size() - 1 * percentile), (int)samples.size() - 1);
+		int idx = std::max<int>(0, std::ceil(samples.size() * percentile) - 1);
 		return samples[idx];
 	}
 

--- a/fdbrpc/ContinuousSample.h
+++ b/fdbrpc/ContinuousSample.h
@@ -66,7 +66,9 @@ public:
 		if (!samples.size() || percentile < 0.0 || percentile > 1.0)
 			return T();
 		sort();
-		int idx = std::floor((samples.size() - 1) * percentile);
+		// Percentile (X) is the smallest element in the sample set at least as large as X% of the samples.
+		// Min with last idx to ensure no out of bounds for percentile=1.0
+		int idx = std::min((int)std::ceil(samples.size() - 1 * percentile), (int)samples.size() - 1);
 		return samples[idx];
 	}
 

--- a/fdbrpc/TSSComparison.h
+++ b/fdbrpc/TSSComparison.h
@@ -40,7 +40,7 @@ struct DetailedTSSMismatch {
 
 struct TSSMetrics : ReferenceCounted<TSSMetrics>, NonCopyable {
 	CounterCollection cc;
-	Counter requests;
+	Counter requests; // requests is the number of requests attempted, successful or not
 	Counter streamComparisons;
 	Counter ssErrors;
 	Counter tssErrors;
@@ -90,10 +90,12 @@ struct TSSMetrics : ReferenceCounted<TSSMetrics>, NonCopyable {
 		SSgetValueLatency.clear();
 		SSgetKeyLatency.clear();
 		SSgetKeyValuesLatency.clear();
+		SSgetKeyValuesAndFlatMapLatency.clear();
 
 		TSSgetValueLatency.clear();
 		TSSgetKeyLatency.clear();
 		TSSgetKeyValuesLatency.clear();
+		TSSgetKeyValuesAndFlatMapLatency.clear();
 
 		tssErrorsByCode.clear();
 		ssErrorsByCode.clear();


### PR DESCRIPTION
TSS Metrics Improvements for 7.1
- Cleaned up tss metrics code
- Fixed ContinuousSample's percentiles to be statistically correct
- Configurable and default larger interval for logging tss metrics
- separate out counts by request type, and only logging latencies if any requests of that type happened
- only logging high percentile latency metrics when enough samples are present for it to be useful in aggregate

Passed 10k simulation tests
Ran local testing to verify behavior. Example new trace log, when only point reads were done:

`<Event Severity="10" Time="1645025119.592454" DateTime="2022-02-16T15:25:19Z" Type="TSSClientMetrics" ID="037402dae0309635" TSSID="c174bfb8d2fe9728" Elapsed="120.005" Internal="1" Requests="692.987 40935.1 86562" StreamComparisons="0 -1 0" SSErrors="0 -1 0" TSSErrors="0 -1 1" TSSTimeouts="0 -1 0" Mismatches="0 -1 0" GetValueLatencyCount="83162" GetValueLatencySSMean="0.000792228" GetValueLatencySSP50="0.0522025" GetValueLatencySSP90="0.0522025" GetValueLatencySSP99="0.0522025" GetValueLatencyTSSMean="0.000737258" GetValueLatencyTSSP50="0.0125926" GetValueLatencyTSSP90="0.0125926" GetValueLatencyTSSP99="0.0125926" GetKeyValuesLatencyCount="0" GetKeyLatencyCount="0" GetKeyValuesAndFlatMapLatencyCount="0" ThreadID="1250967684847437691" Machine="127.0.0.1:4004" LogGroup="default" />`

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
