### PR TITLE
Partitioned TLog can peek from disk

### DIFF
--- a/fdbserver/WorkerInterface.actor.h
+++ b/fdbserver/WorkerInterface.actor.h
@@ -1203,6 +1203,7 @@ ACTOR Future<Void> tLog(
     Reference<AsyncVar<UID>> activeSharedTLog);
 
 Key persistStorageTeamMessageRefsKey(UID id, StorageTeamID storageTeamId, Version version);
+Key persistStorageTeamMessagesKey(UID id, StorageTeamID storageTeamId, Version version);
 } // namespace ptxn
 
 typedef decltype(&tLog) TLogFn;

--- a/fdbserver/ptxn/TLogServer.actor.cpp
+++ b/fdbserver/ptxn/TLogServer.actor.cpp
@@ -1509,6 +1509,7 @@ ACTOR Future<Void> servicePeekRequest(
 	reply.maxKnownVersion = logData->version.get();
 	reply.minKnownCommittedVersion = logData->minKnownCommittedVersion;
 	reply.data = replyData;
+	reply.arena.dependsOn(replyData.arena());
 	reply.endVersion = endVersion;
 	reply.beginVersion = beginVersion;
 	reply.onlySpilled = onlySpilled;

--- a/fdbserver/ptxn/TLogServer.actor.cpp
+++ b/fdbserver/ptxn/TLogServer.actor.cpp
@@ -1433,7 +1433,6 @@ ACTOR Future<Void> servicePeekRequest(
 		wait(delay(0, TaskPriority::TLogSpilledPeekReply));
 	}
 
-	state double workStart = now();
 	Version poppedVer = poppedVersion(logData, req.storageTeamID);
 	if (poppedVer > req.beginVersion) {
 		TLogPeekReply rep;

--- a/fdbserver/ptxn/TLogServer.actor.cpp
+++ b/fdbserver/ptxn/TLogServer.actor.cpp
@@ -1508,7 +1508,7 @@ ACTOR Future<Void> servicePeekRequest(
 	TLogPeekReply reply;
 	reply.maxKnownVersion = logData->version.get();
 	reply.minKnownCommittedVersion = logData->minKnownCommittedVersion;
-	reply.data = StringRef(reply.arena, replyData);
+	reply.data = replyData;
 	reply.endVersion = endVersion;
 	reply.beginVersion = beginVersion;
 	reply.onlySpilled = onlySpilled;

--- a/tests/ptxn/TLogServer.toml
+++ b/tests/ptxn/TLogServer.toml
@@ -172,3 +172,17 @@ startDelay = 0
     numTLogGroups = 7
     numCommits = 10
 
+[[test]]
+testTitle = 'Team Partitioned TLog Server Test 12: Read from TLog spilled data by value'
+useDB = false
+startDelay = 0
+
+    [[test.workload]]
+    testName = 'UnitTests'
+    maxTestCases = 1
+    testsMatching = '/fdbserver/ptxn/test/read_tlog_spilled_by_value'
+
+    numTLogs = 3
+    numStorageTeams = 40
+    numTLogGroups = 7
+    numCommits = 10


### PR DESCRIPTION
    Now only support peeking when it is spill-by-value.
    
    Support for spill-by-reference will come in another PR.

20220220-034042-haofu-5bbdc35a35c70f41

latest: 20220224-162602-haofu-9c1af27a48dec20b

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
