### PR TITLE
Storage server accepts storage team based cursor

### DIFF
--- a/fdbclient/VersionedMap.h
+++ b/fdbclient/VersionedMap.h
@@ -725,7 +725,7 @@ public:
 			Tree r = getRoot(version);
 			roots.emplace_back(version, r);
 		} else
-			ASSERT(version == latestVersion);
+			ASSERT_EQ(version, latestVersion);
 	}
 
 	// insert() and erase() invalidate atLatest() and all iterators into it

--- a/fdbserver/Timing.h
+++ b/fdbserver/Timing.h
@@ -28,26 +28,34 @@
 #include "flow/flow.h"
 
 class Timing {
-	double m_start;
+public:
+	using time_t = decltype(now());
+
+private:
+	time_t m_start;
 
 public:
 	Timing() : m_start(now()) {}
 
 	// Gets the time the Timing object created
-	double getStart() const { return m_start; }
+	time_t getStart() const { return m_start; }
 
 	// Gets the duration of the timing object
-	double duration() const { return now() - m_start; }
+	time_t duration() const { return now() - m_start; }
 };
 
 class Stopwatch {
-	std::vector<double> m_laps;
+public:
+	using time_t = decltype(now());
+
+private:
+	std::vector<time_t> m_laps;
 
 public:
 	Stopwatch() : m_laps{ now() } {}
 
 	// Laps the watch, stores the current time and return the duration between this lap and the previous one
-	double lap() {
+	time_t lap() {
 		m_laps.push_back(now());
 		return *(m_laps.rbegin()) - *std::next(m_laps.rbegin());
 	}

--- a/fdbserver/ptxn/MutableTeamPeekCursor.actor.h
+++ b/fdbserver/ptxn/MutableTeamPeekCursor.actor.h
@@ -194,6 +194,10 @@ const VersionSubsequenceMessage& MutableTeamPeekCursor<BaseClass>::getImpl() con
 
 template <typename BaseClass>
 bool MutableTeamPeekCursor<BaseClass>::hasRemainingImpl() const {
+	if (BaseClass::getNumCursors() == 0) {
+		return false;
+	}
+
 	bool newCursorsAdded = false;
 	if (shouldUpdateStorageTeamCursor) {
 		// FIXME Rethink this const_cast, perhaps relax the function not to be const??

--- a/fdbserver/ptxn/TLogPeekCursor.actor.cpp
+++ b/fdbserver/ptxn/TLogPeekCursor.actor.cpp
@@ -712,7 +712,6 @@ void BroadcastedStorageTeamPeekCursorBase::resetImpl() {
 			++vsmIter;
 		}
 	}
-
 }
 
 #pragma endregion BroadcastedStorageTeamPeekCursorBase

--- a/fdbserver/ptxn/test/Driver.actor.cpp
+++ b/fdbserver/ptxn/test/Driver.actor.cpp
@@ -338,8 +338,8 @@ void broadcastEmptyVersionMessage(MessageFixture& messageFixture, const TLogGrou
 	auto& commitRecord = messageFixture.commitRecord;
 	const auto& storageTeamIDs = tLogGroupFixture.storageTeamIDs;
 
-	for(auto& [version, storageTeamMessages] : commitRecord.messages) {
-		for(const auto& storageTeamID: storageTeamIDs) {
+	for (auto& [version, storageTeamMessages] : commitRecord.messages) {
+		for (const auto& storageTeamID : storageTeamIDs) {
 			if (storageTeamMessages.count(storageTeamID) == 0) {
 				// Create a VectorRef with 0 messages, imply an empty message
 				storageTeamMessages[storageTeamID];

--- a/fdbserver/ptxn/test/Driver.h
+++ b/fdbserver/ptxn/test/Driver.h
@@ -195,12 +195,6 @@ public:
 // Initializes a set of commits to be sent to TLogs
 struct MessageFixture {
 
-protected:
-	void generateMutationsToStorageTeamIDs(const std::vector<StorageTeamID>& storageTeamIDs,
-	                                       const int initialVersion,
-	                                       const int numVersions,
-	                                       const int numMutationsInVersion);
-
 public:
 	CommitRecord& commitRecord;
 
@@ -213,7 +207,13 @@ public:
 	           const int numMutationsInVersion);
 
 	const decltype(std::declval<CommitRecord>().messages)& getMessages() const { return commitRecord.messages; }
+
+	friend void broadcastEmptyVersionMessage(MessageFixture&, const TLogGroupFixture&);
 };
+
+
+// Broadcasts empty version message to commit record
+void broadcastEmptyVersionMessage(MessageFixture& messageFixture, const TLogGroupFixture&);
 
 // Initializes a set of commits to be sent to TLogs, with a special storage team
 struct MessageWithPrivateMutationsFixture : public MessageFixture {
@@ -371,6 +371,7 @@ public:
 	                                                  const int numVersions,
 	                                                  const int numMutationsInVersion,
 	                                                  Optional<std::vector<UID>> optionalStorageServerIDs);
+	TestEnvironment& broadcastEmptyVersionMessage();
 
 	TestEnvironment& initServerDBInfo();
 

--- a/fdbserver/ptxn/test/Driver.h
+++ b/fdbserver/ptxn/test/Driver.h
@@ -211,7 +211,6 @@ public:
 	friend void broadcastEmptyVersionMessage(MessageFixture&, const TLogGroupFixture&);
 };
 
-
 // Broadcasts empty version message to commit record
 void broadcastEmptyVersionMessage(MessageFixture& messageFixture, const TLogGroupFixture&);
 

--- a/fdbserver/ptxn/test/Driver.h
+++ b/fdbserver/ptxn/test/Driver.h
@@ -293,6 +293,8 @@ protected:
 	const TLogGroupFixture& tLogGroupFixture;
 	const ServerDBInfoFixture& serverDBInfoFixture;
 
+	const std::string folderPrefix;
+
 public:
 	// TODO For test, only support in-memory store type at this stage
 	static const KeyValueStoreType keyValueStoreType;
@@ -300,6 +302,7 @@ public:
 	struct StorageServerResources {
 		static constexpr int MEMORY_LIMIT = 256 * 1024 * 1024; // 256MB per storage server
 
+		const std::string folderPrefix;
 		const StorageTeamID storageTeamID;
 		std::shared_ptr<::StorageServerInterface> interface;
 		const UID clusterID;
@@ -309,7 +312,7 @@ public:
 
 		std::string getFolder() const;
 
-		StorageServerResources(const StorageTeamID& storageTeamID_);
+		StorageServerResources(const StorageTeamID& storageTeamID_, const std::string& folderPrefix_);
 	};
 
 	std::vector<StorageServerResources> storageServerResources;
@@ -317,7 +320,7 @@ public:
 	std::vector<Future<Void>> actors;
 
 	ptxnStorageServerFixture(const TLogGroupFixture& tLogGroupFixture_, const ServerDBInfoFixture& serverDBInfoFixture_)
-	  : tLogGroupFixture(tLogGroupFixture_), serverDBInfoFixture(serverDBInfoFixture_) {}
+	  : tLogGroupFixture(tLogGroupFixture_), serverDBInfoFixture(serverDBInfoFixture_), folderPrefix("./simfdb/") {}
 	~ptxnStorageServerFixture();
 
 	void setUp(const int numStorageServers);

--- a/fdbserver/ptxn/test/FakeTLog.actor.cpp
+++ b/fdbserver/ptxn/test/FakeTLog.actor.cpp
@@ -92,7 +92,6 @@ void processTLogCommitRequestByStorageTeam(std::shared_ptr<FakeTLogContext> pFak
 	auto iter = std::begin(deserializer);
 	auto& arena = iter.arena();
 	for (; iter != std::end(deserializer); ++iter) {
-		std::cout << iter->toString() << std::endl;
 		storageTeamMessages[storageTeamID].push_back(pFakeTLogContext->persistenceArena, *iter);
 	}
 	pFakeTLogContext->persistenceArena.dependsOn(arena);
@@ -146,6 +145,7 @@ ACTOR Future<Void> fakeTLogPeek(TLogPeekRequest request, std::shared_ptr<FakeTLo
 	const auto& storageTeamEpochVersionRange =
 	    pFakeTLogContext->pTestDriverContext->commitRecord.storageTeamEpochVersionRange;
 
+	// FIXME 
 	if (storageTeamEpochVersionRange.find(storageTeamID) == std::end(storageTeamEpochVersionRange)) {
 		printTiming << "No storage team ID " << storageTeamID << " in FakeTLog" << std::endl;
 		fakeTLogPeekReplyEmpty(request, storageTeamID);

--- a/fdbserver/ptxn/test/FakeTLog.actor.cpp
+++ b/fdbserver/ptxn/test/FakeTLog.actor.cpp
@@ -145,7 +145,6 @@ ACTOR Future<Void> fakeTLogPeek(TLogPeekRequest request, std::shared_ptr<FakeTLo
 	const auto& storageTeamEpochVersionRange =
 	    pFakeTLogContext->pTestDriverContext->commitRecord.storageTeamEpochVersionRange;
 
-	// FIXME 
 	if (storageTeamEpochVersionRange.find(storageTeamID) == std::end(storageTeamEpochVersionRange)) {
 		printTiming << "No storage team ID " << storageTeamID << " in FakeTLog" << std::endl;
 		fakeTLogPeekReplyEmpty(request, storageTeamID);

--- a/fdbserver/ptxn/test/RealStorageServer.actor.cpp
+++ b/fdbserver/ptxn/test/RealStorageServer.actor.cpp
@@ -127,7 +127,7 @@ ACTOR Future<Void> runStorageServer(StorageServerTestDriver* self) {
 
 	const auto storeType = self->options.storeType;
 
-	const std::string folder = ".";
+	const std::string folder = "./simfdb/";
 	const std::string fileName = joinPath(folder, "storage-" + ssi.id().toString() + "." + storeType.toString());
 	printTiming << "new Storage Server file name: " << fileName << std::endl;
 	deleteFile(fileName);
@@ -155,6 +155,8 @@ ACTOR Future<Void> runStorageServer(StorageServerTestDriver* self) {
 
 	self->actors.add(ss);
 	wait(ss);
+
+	// FIXME: folder should be RAII cleaned up
 
 	return Void();
 }

--- a/fdbserver/ptxn/test/TestStorageServer.actor.cpp
+++ b/fdbserver/ptxn/test/TestStorageServer.actor.cpp
@@ -59,8 +59,12 @@ TEST_CASE("fdbserver/ptxn/test/StorageServerPull") {
 	    .initPtxnTLog(ptxn::MessageTransferModel::StorageServerActivelyPull, options.numTLogs)
 	    .initServerDBInfo()
 	    .initPtxnStorageServer(1)
-	    .initMessagesWithPrivateMutations(
-	        options.initialVersion, options.numVersions, options.numMutationsPerVersion, Optional<std::vector<UID>>());
+	    .initMessagesWithPrivateMutations(options.initialVersion,
+	                                      options.numVersions,
+	                                      options.numMutationsPerVersion,
+	                                      /* optionalStorageServerIDs= */ {});
+
+	ptxn::test::print::printCommitRecords();
 
 	wait(ptxn::test::messageFeeder());
 

--- a/fdbserver/ptxn/test/TestTLogPeek.actor.cpp
+++ b/fdbserver/ptxn/test/TestTLogPeek.actor.cpp
@@ -365,7 +365,7 @@ TEST_CASE("/fdbserver/ptxn/test/tLogPeek/cursor/advanceTo") {
 	    .initTLogGroup(options.numTLogs, /* numStorageTeams */ options.numTLogs * 3)
 	    .initPtxnTLog(ptxn::MessageTransferModel::StorageServerActivelyPull, options.numTLogs)
 	    .initMessages(options.initialVersion, options.numVersions, options.numMutationsPerVersion)
-		.broadcastEmptyVersionMessage();
+	    .broadcastEmptyVersionMessage();
 
 	for (auto pFakeTLogContext : ptxn::test::TestEnvironment::getTLogs()->tLogContexts) {
 		pFakeTLogContext->latency.enable();

--- a/fdbserver/ptxn/test/TestTLogPeek.actor.cpp
+++ b/fdbserver/ptxn/test/TestTLogPeek.actor.cpp
@@ -165,7 +165,7 @@ ACTOR Future<std::vector<VersionSubsequenceMessage>> getAllMessageFromCursor(std
 				}
 			};
 
-			// Ensure the cursor can be repeatly iterated
+			// Verify the cursor can be repeatedly iterated.
 			getAllMessages(messages);
 			pCursor->reset();
 			getAllMessages(messagesDup);

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -1106,23 +1106,26 @@ public:
 
 	StorageServerStorageTeams storageServerStorageTeams;
 
-	const std::unordered_set<StorageTeamID>& getSubscribedStorageTeamIDs() const;
+	std::unordered_set<StorageTeamID> subscribedStorageTeamIDs;
 
 	StorageServer(IKeyValueStore* pKVStore,
 	              const Reference<const AsyncVar<ServerDBInfo>>& serverDBInfo,
 	              const StorageServerInterface& storageServerInterface,
 	              const StorageTeamID& privateMutationsStorageTeamID_)
 	  : StorageServerBase(pKVStore, serverDBInfo, storageServerInterface),
-	    storageServerStorageTeams(privateMutationsStorageTeamID_) {}
+	    storageServerStorageTeams(privateMutationsStorageTeamID_),
+		subscribedStorageTeamIDs{ privateMutationsStorageTeamID_ } {}
 
 	void updateSubscribedStorageTeamIDs();
 };
 
-const std::unordered_set<StorageTeamID>& StorageServer::getSubscribedStorageTeamIDs() const {
+void StorageServer::updateSubscribedStorageTeamIDs() {
 	ASSERT(logCursor);
+	// NOTE A better choice might be cast it to merged::details::StorageTeamIDCursorMapper, but this breaks the
+	// inheritance structure
 	auto ptr = dynamic_cast<merged::BroadcastedStorageTeamPeekCursorBase*>(logCursor.get());
 	ASSERT(ptr);
-	return ptr->getCursorStorageTeamIDs();
+	subscribedStorageTeamIDs = ptr->getCursorStorageTeamIDs();
 }
 
 } // namespace ptxn

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -1106,26 +1106,23 @@ public:
 
 	StorageServerStorageTeams storageServerStorageTeams;
 
-	std::unordered_set<StorageTeamID> subscribedStorageTeamIDs;
+	const std::unordered_set<StorageTeamID>& getSubscribedStorageTeamIDs() const;
 
 	StorageServer(IKeyValueStore* pKVStore,
 	              const Reference<const AsyncVar<ServerDBInfo>>& serverDBInfo,
 	              const StorageServerInterface& storageServerInterface,
 	              const StorageTeamID& privateMutationsStorageTeamID_)
 	  : StorageServerBase(pKVStore, serverDBInfo, storageServerInterface),
-	    storageServerStorageTeams(privateMutationsStorageTeamID_),
-		subscribedStorageTeamIDs{ privateMutationsStorageTeamID_ } {}
+	    storageServerStorageTeams(privateMutationsStorageTeamID_) {}
 
 	void updateSubscribedStorageTeamIDs();
 };
 
-void StorageServer::updateSubscribedStorageTeamIDs() {
+const std::unordered_set<StorageTeamID>& StorageServer::getSubscribedStorageTeamIDs() const {
 	ASSERT(logCursor);
-	// NOTE A better choice might be cast it to merged::details::StorageTeamIDCursorMapper, but this breaks the
-	// inheritance structure
 	auto ptr = dynamic_cast<merged::BroadcastedStorageTeamPeekCursorBase*>(logCursor.get());
 	ASSERT(ptr);
-	subscribedStorageTeamIDs = ptr->getCursorStorageTeamIDs();
+	return ptr->getCursorStorageTeamIDs();
 }
 
 } // namespace ptxn

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -6012,7 +6012,7 @@ ACTOR Future<Void> update(StorageServer* data, bool* pReceivedUpdate) {
 	try {
 		wait(details::updatePreconditioner(data));
 
-		// NOTE This is anti-intuition. A reference to the cursor is created, but it is an independent cursor -- not
+		// NOTE This is counter-intuitive. A reference to the cursor is created, but it is an independent cursor -- not
 		// impacting the origin cursor. data->logCursor holds no data even cursor->getMore() is called. Later
 		// data->logCursor will advanceTo the newest version.
 		state Reference<ILogSystem::IPeekCursor> cursor = data->logCursor;

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -1106,27 +1106,23 @@ public:
 
 	StorageServerStorageTeams storageServerStorageTeams;
 
-	std::unordered_set<StorageTeamID> subscribedStorageTeamIDs;
+	const std::unordered_set<StorageTeamID>& getSubscribedStorageTeamIDs() const;
 
 	StorageServer(IKeyValueStore* pKVStore,
 	              const Reference<const AsyncVar<ServerDBInfo>>& serverDBInfo,
 	              const StorageServerInterface& storageServerInterface,
 	              const StorageTeamID& privateMutationsStorageTeamID_)
 	  : StorageServerBase(pKVStore, serverDBInfo, storageServerInterface),
-	    storageServerStorageTeams(privateMutationsStorageTeamID_), subscribedStorageTeamIDs{
-		    privateMutationsStorageTeamID_
-	    } {}
+	    storageServerStorageTeams(privateMutationsStorageTeamID_) {}
 
 	void updateSubscribedStorageTeamIDs();
 };
 
-void StorageServer::updateSubscribedStorageTeamIDs() {
+const std::unordered_set<StorageTeamID>& StorageServer::getSubscribedStorageTeamIDs() const {
 	ASSERT(logCursor);
-	// NOTE A better choice might be cast it to merged::details::StorageTeamIDCursorMapper, but this breaks the
-	// inheritance structure
 	auto ptr = dynamic_cast<merged::BroadcastedStorageTeamPeekCursorBase*>(logCursor.get());
 	ASSERT(ptr);
-	subscribedStorageTeamIDs = ptr->getCursorStorageTeamIDs();
+	return ptr->getCursorStorageTeamIDs();
 }
 
 } // namespace ptxn

--- a/tests/ptxn/TLogPeekCursor.toml
+++ b/tests/ptxn/TLogPeekCursor.toml
@@ -61,4 +61,4 @@ startDelay = 0
    testsMatching = '/fdbserver/ptxn/test/tLogPeek/cursor/advanceTo'
 
    numVersions = 10
-  numMutationsPerVersion = 100
+   numMutationsPerVersion = 100

--- a/tests/ptxn/TLogPeekCursor.toml
+++ b/tests/ptxn/TLogPeekCursor.toml
@@ -1,5 +1,5 @@
 [[test]]
-testTitle = 'Test TLog group peek cursor'
+testTitle = 'Test TLog single storage team peek cursor'
 useDB = false
 startDelay = 0
 
@@ -8,7 +8,7 @@ startDelay = 0
    maxTestCases = 1
    testsMatching = '/fdbserver/ptxn/test/tLogPeek/cursor/StorageTeamPeekCursor'
 
-   numVersions = 10
+   numVersions = 50
    numMutationsPerVersion = 100
 
 [[test]]
@@ -22,7 +22,7 @@ startDelay = 0
     testsMatching = '/fdbserver/ptxn/test/tLogPeek/cursor/merged/BroadcastedStorageTeamPeekCursor_Unordered'
 
     numVersions = 10
-    numMutationsPerVersion = 100
+    numMutationsPerVersion = 10
 
 [[test]]
 testTitle = "BroadcastedStorageTeamPeekCursor_Ordered test"


### PR DESCRIPTION
 * Allow ptxn cursors re-iterate messages between each RPC call.
 * Storage server now have code path (enabled by ENABLE_PARTITIONED_TRANSACTIONS knob) that reads from TLogs via ptxn cursor
 * Storage server update code is cleaned up

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
