### PR TITLE
Added Redwood knob to reserve part of configured page cache size for other structures

### DIFF
--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -793,6 +793,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( REDWOOD_METRICS_INTERVAL,                              5.0 );
 	init( REDWOOD_HISTOGRAM_INTERVAL,                           30.0 );
 	init( REDWOOD_EVICT_UPDATED_PAGES,                          true ); if( randomize && BUGGIFY ) { REDWOOD_EVICT_UPDATED_PAGES = false; }
+	init( REDWOOD_DECODE_CACHE_RESERVATION,                     0.30 );
 
 	// Server request latency measurement
 	init( LATENCY_SAMPLE_SIZE,                                100000 );

--- a/fdbclient/ServerKnobs.h
+++ b/fdbclient/ServerKnobs.h
@@ -744,6 +744,10 @@ public:
 	double REDWOOD_METRICS_INTERVAL;
 	double REDWOOD_HISTOGRAM_INTERVAL;
 	bool REDWOOD_EVICT_UPDATED_PAGES; // Whether to prioritize eviction of updated pages from cache.
+	double REDWOOD_DECODE_CACHE_RESERVATION; // Fraction of the configured page cache memory that should be reserved
+	                                         // for use by DecodeCache instances.  This is a soft reservation for this
+	                                         // purpose and not a hard limit on memory usage by these structures.  This
+	                                         // value may need to be tuned for a particular workload.
 
 	// Server request latency measurement
 	int LATENCY_SAMPLE_SIZE;

--- a/fdbserver/VersionedBTree.actor.cpp
+++ b/fdbserver/VersionedBTree.actor.cpp
@@ -2144,9 +2144,10 @@ public:
 	          bool memoryOnly = false,
 	          Promise<Void> errorPromise = {})
 	  : ioLock(FLOW_KNOBS->MAX_OUTSTANDING, ioMaxPriority, FLOW_KNOBS->MAX_OUTSTANDING / 2),
-	    pageCacheBytes(pageCacheSizeBytes), pHeader(nullptr), desiredPageSize(desiredPageSize),
-	    desiredExtentSize(desiredExtentSize), filename(filename), memoryOnly(memoryOnly), errorPromise(errorPromise),
-	    remapCleanupWindow(remapCleanupWindow), concurrentExtentReads(new FlowLock(concurrentExtentReads)) {
+	    pageCacheBytes(pageCacheSizeBytes * (1.0 - SERVER_KNOBS->REDWOOD_DECODE_CACHE_RESERVATION)), pHeader(nullptr),
+	    desiredPageSize(desiredPageSize), desiredExtentSize(desiredExtentSize), filename(filename),
+	    memoryOnly(memoryOnly), errorPromise(errorPromise), remapCleanupWindow(remapCleanupWindow),
+	    concurrentExtentReads(new FlowLock(concurrentExtentReads)) {
 
 		if (!g_redwoodMetricsActor.isValid()) {
 			g_redwoodMetricsActor = redwoodMetricsLogger();


### PR DESCRIPTION
Redwood uses significant additional memory beyond the configured page cache size so it is far more likely to run out of memory with a configuration that otherwise works for the `ssd` storage engine.   The precise amount of additional memory needed is workload dependent (on key size, compressibility, and key access locality) but the default value of 0.3 should cover a lot of scenarios.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
