### PR TITLE
Synchronize versions with clock

### DIFF
--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -36,6 +36,9 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( MAX_WRITE_TRANSACTION_LIFE_VERSIONS,     5 * VERSIONS_PER_SECOND ); if (randomize && BUGGIFY) MAX_WRITE_TRANSACTION_LIFE_VERSIONS=std::max<int>(1, 1 * VERSIONS_PER_SECOND);
 	init( MAX_COMMIT_BATCH_INTERVAL,                             2.0 ); if( randomize && BUGGIFY ) MAX_COMMIT_BATCH_INTERVAL = 0.5; // Each commit proxy generates a CommitTransactionBatchRequest at least this often, so that versions always advance smoothly
 	MAX_COMMIT_BATCH_INTERVAL = std::min(MAX_COMMIT_BATCH_INTERVAL, MAX_READ_TRANSACTION_LIFE_VERSIONS/double(2*VERSIONS_PER_SECOND)); // Ensure that the proxy commits 2 times every MAX_READ_TRANSACTION_LIFE_VERSIONS, otherwise the master will not give out versions fast enough
+	init( DEFAULT_VERSION_EPOCH,                          1262307600 ); // 2010-01-01T01:00:00+00:00, default version reference epoch (seconds). This value itself is based off the Unix epoch, and is only used when initializing a new cluster. Existing clusters can modify the version epoch through the special key space.
+	init( MAX_VERSION_RATE_MODIFIER,                             0.1 );
+	init( MAX_VERSION_RATE_OFFSET,               VERSIONS_PER_SECOND ); // If the calculated version is more than this amount away from the expected version, it will be clamped to this value. This prevents huge version jumps.
 
 	// TLogs
 	init( TLOG_TIMEOUT,                                          0.4 ); //cannot buggify because of availability

--- a/fdbclient/ServerKnobs.h
+++ b/fdbclient/ServerKnobs.h
@@ -39,6 +39,9 @@ public:
 	int64_t MAX_WRITE_TRANSACTION_LIFE_VERSIONS;
 	double MAX_COMMIT_BATCH_INTERVAL; // Each commit proxy generates a CommitTransactionBatchRequest at least this
 	                                  // often, so that versions always advance smoothly
+	int64_t DEFAULT_VERSION_EPOCH;
+	double MAX_VERSION_RATE_MODIFIER;
+	int64_t MAX_VERSION_RATE_OFFSET;
 
 	// TLogs
 	bool PEEK_USING_STREAMING;

--- a/fdbclient/SystemData.cpp
+++ b/fdbclient/SystemData.cpp
@@ -821,6 +821,7 @@ std::vector<std::pair<UID, Version>> decodeBackupStartedValue(const ValueRef& va
 const KeyRef coordinatorsKey = LiteralStringRef("\xff/coordinators");
 const KeyRef logsKey = LiteralStringRef("\xff/logs");
 const KeyRef minRequiredCommitVersionKey = LiteralStringRef("\xff/minRequiredCommitVersion");
+const KeyRef referenceVersionKey = LiteralStringRef("\xff/referenceVersion");
 
 const KeyRef globalKeysPrefix = LiteralStringRef("\xff/globals");
 const KeyRef lastEpochEndKey = LiteralStringRef("\xff/globals/lastEpochEnd");

--- a/fdbclient/SystemData.cpp
+++ b/fdbclient/SystemData.cpp
@@ -821,7 +821,7 @@ std::vector<std::pair<UID, Version>> decodeBackupStartedValue(const ValueRef& va
 const KeyRef coordinatorsKey = LiteralStringRef("\xff/coordinators");
 const KeyRef logsKey = LiteralStringRef("\xff/logs");
 const KeyRef minRequiredCommitVersionKey = LiteralStringRef("\xff/minRequiredCommitVersion");
-const KeyRef referenceVersionKey = LiteralStringRef("\xff/referenceVersion");
+const KeyRef versionEpochKey = LiteralStringRef("\xff/versionEpoch");
 
 const KeyRef globalKeysPrefix = LiteralStringRef("\xff/globals");
 const KeyRef lastEpochEndKey = LiteralStringRef("\xff/globals/lastEpochEnd");

--- a/fdbclient/SystemData.h
+++ b/fdbclient/SystemData.h
@@ -349,10 +349,10 @@ extern const KeyRef logsKey;
 extern const KeyRef minRequiredCommitVersionKey;
 
 // TODO: Currently unused
-//	"\xff/referenceVersionKey" = "[[Version]]"
+//	"\xff/versionEpochKey" = "[[uint64_t]]"
 //	Defines the base epoch representing version 0. The value itself is the
-//	number of microseconds since the Unix epoch.
-extern const KeyRef referenceVersionKey;
+//	number of seconds since the Unix epoch.
+extern const KeyRef versionEpochKey;
 
 const Value logsValue(const std::vector<std::pair<UID, NetworkAddress>>& logs,
                       const std::vector<std::pair<UID, NetworkAddress>>& oldLogs);

--- a/fdbclient/SystemData.h
+++ b/fdbclient/SystemData.h
@@ -348,7 +348,6 @@ extern const KeyRef logsKey;
 //	Used during backup/recovery to restrict version requirements
 extern const KeyRef minRequiredCommitVersionKey;
 
-// TODO: Currently unused
 //	"\xff/versionEpochKey" = "[[uint64_t]]"
 //	Defines the base epoch representing version 0. The value itself is the
 //	number of seconds since the Unix epoch.

--- a/fdbclient/SystemData.h
+++ b/fdbclient/SystemData.h
@@ -348,6 +348,12 @@ extern const KeyRef logsKey;
 //	Used during backup/recovery to restrict version requirements
 extern const KeyRef minRequiredCommitVersionKey;
 
+// TODO: Currently unused
+//	"\xff/referenceVersionKey" = "[[Version]]"
+//	Defines the base epoch representing version 0. The value itself is the
+//	number of microseconds since the Unix epoch.
+extern const KeyRef referenceVersionKey;
+
 const Value logsValue(const std::vector<std::pair<UID, NetworkAddress>>& logs,
                       const std::vector<std::pair<UID, NetworkAddress>>& oldLogs);
 std::pair<std::vector<std::pair<UID, NetworkAddress>>, std::vector<std::pair<UID, NetworkAddress>>> decodeLogsValue(

--- a/fdbserver/ClusterRecovery.actor.cpp
+++ b/fdbserver/ClusterRecovery.actor.cpp
@@ -1175,6 +1175,9 @@ ACTOR Future<Void> readTransactionSystemState(Reference<ClusterRecoveryData> sel
 	self->txnStateStore =
 	    keyValueStoreLogSystem(self->txnStateLogAdapter, self->dbgid, self->memoryLimit, false, false, true);
 
+	// TODO: Think about how to handle clusters being upgraded. They should
+	// continue to use the old method of calculating versions until explicitly
+	// upgraded!
 	// Version 0 occurs at the version epoch. The version epoch can be set
 	// through the management API, otherwise a default timestamp is used. The
 	// version epoch is the number of seconds since the Unix epoch.

--- a/fdbserver/ClusterRecovery.actor.cpp
+++ b/fdbserver/ClusterRecovery.actor.cpp
@@ -1208,6 +1208,9 @@ ACTOR Future<Void> readTransactionSystemState(Reference<ClusterRecoveryData> sel
 		self->recoveryTransactionVersion = g_network->timer() * SERVER_KNOBS->VERSIONS_PER_SECOND;
 		if (!g_network->isSimulated()) {
 			self->recoveryTransactionVersion -= SERVER_KNOBS->DEFAULT_VERSION_EPOCH * SERVER_KNOBS->VERSIONS_PER_SECOND;
+		} else {
+			// Since the clock always start at 0 in simulation, add a random offset.
+			self->recoveryTransactionVersion += deterministicRandom()->randomInt64(0, 10000000);
 		}
 	} else {
 		if (self->forceRecovery) {

--- a/fdbserver/ClusterRecovery.actor.h
+++ b/fdbserver/ClusterRecovery.actor.h
@@ -169,7 +169,7 @@ struct ClusterRecoveryData : NonCopyable, ReferenceCounted<ClusterRecoveryData> 
 	AsyncTrigger registrationTrigger;
 	Version lastEpochEnd, // The last version in the old epoch not (to be) rolled back in this recovery
 	    recoveryTransactionVersion; // The first version in this epoch
-	uint64_t versionEpoch; // The epoch which all versions are based off of
+	int64_t versionEpoch = invalidVersion; // The epoch which all versions are based off of
 	double lastCommitTime;
 
 	Version liveCommittedVersion; // The largest live committed version reported by commit proxies.

--- a/fdbserver/ClusterRecovery.actor.h
+++ b/fdbserver/ClusterRecovery.actor.h
@@ -169,7 +169,7 @@ struct ClusterRecoveryData : NonCopyable, ReferenceCounted<ClusterRecoveryData> 
 	AsyncTrigger registrationTrigger;
 	Version lastEpochEnd, // The last version in the old epoch not (to be) rolled back in this recovery
 	    recoveryTransactionVersion; // The first version in this epoch
-	int64_t versionEpoch = invalidVersion; // The epoch which all versions are based off of
+	Optional<int64_t> versionEpoch; // The epoch which all versions are based off of
 	double lastCommitTime;
 
 	Version liveCommittedVersion; // The largest live committed version reported by commit proxies.

--- a/fdbserver/ClusterRecovery.actor.h
+++ b/fdbserver/ClusterRecovery.actor.h
@@ -210,6 +210,7 @@ struct ClusterRecoveryData : NonCopyable, ReferenceCounted<ClusterRecoveryData> 
 	std::map<UID, CommitProxyVersionReplies> lastCommitProxyVersionReplies;
 
 	UID clusterId;
+	Version initialClusterVersion = -1;
 	Standalone<StringRef> dbId;
 
 	MasterInterface masterInterface;

--- a/fdbserver/ClusterRecovery.actor.h
+++ b/fdbserver/ClusterRecovery.actor.h
@@ -169,6 +169,7 @@ struct ClusterRecoveryData : NonCopyable, ReferenceCounted<ClusterRecoveryData> 
 	AsyncTrigger registrationTrigger;
 	Version lastEpochEnd, // The last version in the old epoch not (to be) rolled back in this recovery
 	    recoveryTransactionVersion; // The first version in this epoch
+	uint64_t versionEpoch; // The epoch which all versions are based off of
 	double lastCommitTime;
 
 	Version liveCommittedVersion; // The largest live committed version reported by commit proxies.

--- a/fdbserver/DDTeamCollection.actor.cpp
+++ b/fdbserver/DDTeamCollection.actor.cpp
@@ -2277,7 +2277,6 @@ public:
 			isr.reqId = deterministicRandom()->randomUniqueID();
 			isr.interfaceId = interfaceId;
 			isr.clusterId = clusterId;
-			// TODO: Set initial cluster version in InitializeStorageRequest
 
 			// if tss, wait for pair ss to finish and add its id to isr. If pair fails, don't recruit tss
 			state bool doRecruit = true;

--- a/fdbserver/DDTeamCollection.actor.cpp
+++ b/fdbserver/DDTeamCollection.actor.cpp
@@ -2277,6 +2277,7 @@ public:
 			isr.reqId = deterministicRandom()->randomUniqueID();
 			isr.interfaceId = interfaceId;
 			isr.clusterId = clusterId;
+			// TODO: Set initial cluster version in InitializeStorageRequest
 
 			// if tss, wait for pair ss to finish and add its id to isr. If pair fails, don't recruit tss
 			state bool doRecruit = true;

--- a/fdbserver/MasterInterface.h
+++ b/fdbserver/MasterInterface.h
@@ -155,14 +155,14 @@ struct UpdateRecoveryDataRequest {
 	Version recoveryTransactionVersion;
 	Version lastEpochEnd;
 	std::vector<CommitProxyInterface> commitProxies;
-	int64_t versionEpoch;
+	Optional<int64_t> versionEpoch;
 	ReplyPromise<Void> reply;
 
 	UpdateRecoveryDataRequest() {}
 	UpdateRecoveryDataRequest(Version recoveryTransactionVersion,
 	                          Version lastEpochEnd,
 	                          std::vector<CommitProxyInterface> commitProxies,
-	                          Version versionEpoch)
+	                          Optional<Version> versionEpoch)
 	  : recoveryTransactionVersion(recoveryTransactionVersion), lastEpochEnd(lastEpochEnd),
 	    commitProxies(commitProxies), versionEpoch(versionEpoch) {}
 

--- a/fdbserver/MasterInterface.h
+++ b/fdbserver/MasterInterface.h
@@ -155,18 +155,20 @@ struct UpdateRecoveryDataRequest {
 	Version recoveryTransactionVersion;
 	Version lastEpochEnd;
 	std::vector<CommitProxyInterface> commitProxies;
+	uint64_t versionEpoch;
 	ReplyPromise<Void> reply;
 
 	UpdateRecoveryDataRequest() {}
 	UpdateRecoveryDataRequest(Version recoveryTransactionVersion,
 	                          Version lastEpochEnd,
-	                          std::vector<CommitProxyInterface> commitProxies)
+	                          std::vector<CommitProxyInterface> commitProxies,
+	                          Version versionEpoch)
 	  : recoveryTransactionVersion(recoveryTransactionVersion), lastEpochEnd(lastEpochEnd),
-	    commitProxies(commitProxies) {}
+	    commitProxies(commitProxies), versionEpoch(versionEpoch) {}
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, recoveryTransactionVersion, lastEpochEnd, commitProxies, reply);
+		serializer(ar, recoveryTransactionVersion, lastEpochEnd, commitProxies, reply, versionEpoch);
 	}
 };
 

--- a/fdbserver/MasterInterface.h
+++ b/fdbserver/MasterInterface.h
@@ -155,7 +155,7 @@ struct UpdateRecoveryDataRequest {
 	Version recoveryTransactionVersion;
 	Version lastEpochEnd;
 	std::vector<CommitProxyInterface> commitProxies;
-	uint64_t versionEpoch;
+	int64_t versionEpoch;
 	ReplyPromise<Void> reply;
 
 	UpdateRecoveryDataRequest() {}

--- a/fdbserver/QuietDatabase.actor.cpp
+++ b/fdbserver/QuietDatabase.actor.cpp
@@ -596,6 +596,31 @@ ACTOR Future<bool> getStorageServersRecruiting(Database cx, WorkerInterface dist
 	}
 }
 
+// Gets the difference between the expected version (based on the version
+// epoch) and the actual version.
+ACTOR Future<int64_t> getVersionOffset(Database cx,
+                                       WorkerInterface distributorWorker,
+                                       Reference<AsyncVar<ServerDBInfo> const> dbInfo) {
+	loop {
+		state Transaction tr(cx);
+		try {
+			TraceEvent("GetVersionOffset").detail("Stage", "ReadingVersionEpoch");
+
+			tr.setOption(FDBTransactionOptions::LOCK_AWARE);
+			state Version rv = wait(tr.getReadVersion());
+			Optional<Standalone<StringRef>> versionEpochValue = wait(tr.get(versionEpochKey));
+			if (!versionEpochValue.present()) {
+				return 0;
+			}
+			int64_t versionEpoch = BinaryReader::fromStringRef<Version>(versionEpochValue.get(), Unversioned());
+			int64_t versionOffset = abs(rv - (g_network->timer() - versionEpoch) * SERVER_KNOBS->VERSIONS_PER_SECOND);
+			return versionOffset;
+		} catch (Error& e) {
+			wait(tr.onError(e));
+		}
+	}
+}
+
 ACTOR Future<Void> repairDeadDatacenter(Database cx,
                                         Reference<AsyncVar<ServerDBInfo> const> dbInfo,
                                         std::string context) {
@@ -650,7 +675,8 @@ ACTOR Future<Void> waitForQuietDatabase(Database cx,
                                         int64_t maxTLogQueueGate = 5e6,
                                         int64_t maxStorageServerQueueGate = 5e6,
                                         int64_t maxDataDistributionQueueSize = 0,
-                                        int64_t maxPoppedVersionLag = 30e6) {
+                                        int64_t maxPoppedVersionLag = 30e6,
+                                        int64_t maxVersionOffset = 1e6) {
 	state Future<Void> reconfig =
 	    reconfigureAfter(cx, 100 + (deterministicRandom()->random01() * 100), dbInfo, "QuietDatabase");
 	state Future<int64_t> dataInFlight;
@@ -660,6 +686,7 @@ ACTOR Future<Void> waitForQuietDatabase(Database cx,
 	state Future<int64_t> storageQueueSize;
 	state Future<bool> dataDistributionActive;
 	state Future<bool> storageServersRecruiting;
+	state Future<int64_t> versionOffset;
 	auto traceMessage = "QuietDatabase" + phase + "Begin";
 	TraceEvent(traceMessage.c_str()).log();
 
@@ -696,10 +723,11 @@ ACTOR Future<Void> waitForQuietDatabase(Database cx,
 			storageQueueSize = getMaxStorageServerQueueSize(cx, dbInfo);
 			dataDistributionActive = getDataDistributionActive(cx, distributorWorker);
 			storageServersRecruiting = getStorageServersRecruiting(cx, distributorWorker, distributorUID);
+			versionOffset = getVersionOffset(cx, distributorWorker, dbInfo);
 
 			wait(success(dataInFlight) && success(tLogQueueInfo) && success(dataDistributionQueueSize) &&
 			     success(teamCollectionValid) && success(storageQueueSize) && success(dataDistributionActive) &&
-			     success(storageServersRecruiting));
+			     success(storageServersRecruiting) && success(versionOffset));
 
 			TraceEvent(("QuietDatabase" + phase).c_str())
 			    .detail("DataInFlight", dataInFlight.get())
@@ -715,13 +743,17 @@ ACTOR Future<Void> waitForQuietDatabase(Database cx,
 			    .detail("MaxStorageServerQueueGate", maxStorageServerQueueGate)
 			    .detail("DataDistributionActive", dataDistributionActive.get())
 			    .detail("StorageServersRecruiting", storageServersRecruiting.get())
+			    .detail("RecoveryCount", dbInfo->get().recoveryCount)
+			    .detail("VersionOffset", versionOffset.get())
 			    .detail("NumSuccesses", numSuccesses);
 
+			maxVersionOffset += dbInfo->get().recoveryCount * SERVER_KNOBS->MAX_VERSIONS_IN_FLIGHT;
 			if (dataInFlight.get() > dataInFlightGate || tLogQueueInfo.get().first > maxTLogQueueGate ||
 			    tLogQueueInfo.get().second > maxPoppedVersionLag ||
 			    dataDistributionQueueSize.get() > maxDataDistributionQueueSize ||
 			    storageQueueSize.get() > maxStorageServerQueueGate || !dataDistributionActive.get() ||
-			    storageServersRecruiting.get() || !teamCollectionValid.get()) {
+			    storageServersRecruiting.get() || versionOffset.get() > maxVersionOffset ||
+			    !teamCollectionValid.get()) {
 
 				wait(delay(1.0));
 				numSuccesses = 0;
@@ -777,6 +809,10 @@ ACTOR Future<Void> waitForQuietDatabase(Database cx,
 				auto key = "NotReady" + std::to_string(notReadyCount++);
 				evt.detail(key.c_str(), "storageServersRecruiting");
 			}
+			if (versionOffset.isReady() && versionOffset.isError()) {
+				auto key = "NotReady" + std::to_string(notReadyCount++);
+				evt.detail(key.c_str(), "versionOffset");
+			}
 			wait(delay(1.0));
 			numSuccesses = 0;
 		}
@@ -792,7 +828,8 @@ Future<Void> quietDatabase(Database const& cx,
                            int64_t maxTLogQueueGate,
                            int64_t maxStorageServerQueueGate,
                            int64_t maxDataDistributionQueueSize,
-                           int64_t maxPoppedVersionLag) {
+                           int64_t maxPoppedVersionLag,
+                           int64_t maxVersionOffset) {
 	return waitForQuietDatabase(cx,
 	                            dbInfo,
 	                            phase,
@@ -800,5 +837,6 @@ Future<Void> quietDatabase(Database const& cx,
 	                            maxTLogQueueGate,
 	                            maxStorageServerQueueGate,
 	                            maxDataDistributionQueueSize,
-	                            maxPoppedVersionLag);
+	                            maxPoppedVersionLag,
+	                            maxVersionOffset);
 }

--- a/fdbserver/WorkerInterface.actor.h
+++ b/fdbserver/WorkerInterface.actor.h
@@ -767,11 +767,13 @@ struct InitializeStorageRequest {
 	Optional<std::pair<UID, Version>>
 	    tssPairIDAndVersion; // Only set if recruiting a tss. Will be the UID and Version of its SS pair.
 	UID clusterId; // Unique cluster identifier. Only needed at recruitment, will be read from txnStateStore on recovery
+	Version initialClusterVersion;
 	ReplyPromise<InitializeStorageReply> reply;
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, seedTag, reqId, interfaceId, storeType, reply, tssPairIDAndVersion, clusterId);
+		serializer(
+		    ar, seedTag, reqId, interfaceId, storeType, reply, tssPairIDAndVersion, clusterId, initialClusterVersion);
 	}
 };
 
@@ -1086,6 +1088,7 @@ ACTOR Future<Void> storageServer(IKeyValueStore* persistentData,
                                  StorageServerInterface ssi,
                                  Tag seedTag,
                                  UID clusterId,
+                                 Version startVersion,
                                  Version tssSeedVersion,
                                  ReplyPromise<InitializeStorageReply> recruitReply,
                                  Reference<AsyncVar<ServerDBInfo> const> db,

--- a/fdbserver/masterserver.actor.cpp
+++ b/fdbserver/masterserver.actor.cpp
@@ -175,9 +175,7 @@ ACTOR Future<Void> getVersion(Reference<MasterData> self, GetCommitVersionReques
 				// 1,000,000]) to a value in the range [0.9, 1.1]). Note that these
 				// values are examples, and are based on the
 				// MAX_VERSION_RATE_OFFSET and MAX_VERSION_RATE_MODIFIER knobs.
-				double modifier = ((1.0 + SERVER_KNOBS->MAX_VERSION_RATE_MODIFIER) -
-				                   (1.0 - SERVER_KNOBS->MAX_VERSION_RATE_MODIFIER)) /
-				                  (2 * SERVER_KNOBS->MAX_VERSION_RATE_OFFSET);
+				double modifier = SERVER_KNOBS->MAX_VERSION_RATE_MODIFIER / SERVER_KNOBS->MAX_VERSION_RATE_OFFSET;
 				// Use std::pow to apply a more aggressive curve to version
 				// corrections. Versions further from the expected version will
 				// receive a larger multiplier.
@@ -188,7 +186,7 @@ ACTOR Future<Void> getVersion(Reference<MasterData> self, GetCommitVersionReques
 				               1.0 - SERVER_KNOBS->MAX_VERSION_RATE_MODIFIER,
 				               1.0 + SERVER_KNOBS->MAX_VERSION_RATE_MODIFIER);
 				;
-				toAdd = std::max((Version)1, (Version)(toAdd * versionCorrection));
+				toAdd = std::max(static_cast<Version>(1), static_cast<Version>(toAdd * versionCorrection));
 			}
 
 			rep.prevVersion = self->version;

--- a/fdbserver/masterserver.actor.cpp
+++ b/fdbserver/masterserver.actor.cpp
@@ -173,6 +173,7 @@ ACTOR Future<Void> getVersion(Reference<MasterData> self, GetCommitVersionReques
 				                             SERVER_KNOBS->MAX_VERSION_RATE_OFFSET);
 				self->version =
 				    std::clamp(expected, self->version + toAdd - maxOffset, self->version + toAdd + maxOffset);
+				ASSERT_GT(self->version, rep.prevVersion);
 			} else {
 				self->version = self->version + toAdd;
 			}

--- a/fdbserver/masterserver.actor.cpp
+++ b/fdbserver/masterserver.actor.cpp
@@ -294,8 +294,7 @@ ACTOR Future<Void> updateRecoveryData(Reference<MasterData> self) {
 					}
 				}
 				if (req.versionEpoch.present()) {
-					self->referenceVersion =
-					    !g_network->isSimulated() ? req.versionEpoch.get() * SERVER_KNOBS->VERSIONS_PER_SECOND : 0;
+					self->referenceVersion = req.versionEpoch.get() * SERVER_KNOBS->VERSIONS_PER_SECOND;
 				}
 				req.reply.send(Void());
 			}

--- a/fdbserver/masterserver.actor.cpp
+++ b/fdbserver/masterserver.actor.cpp
@@ -292,8 +292,10 @@ ACTOR Future<Void> updateRecoveryData(Reference<MasterData> self) {
 						self->lastCommitProxyVersionReplies[p.id()] = CommitProxyVersionReplies();
 					}
 				}
-				self->referenceVersion =
-				    !g_network->isSimulated() ? req.versionEpoch * SERVER_KNOBS->VERSIONS_PER_SECOND : 0;
+				if (req.versionEpoch >= 0) {
+					self->referenceVersion =
+					    !g_network->isSimulated() ? req.versionEpoch * SERVER_KNOBS->VERSIONS_PER_SECOND : 0;
+				}
 				req.reply.send(Void());
 			}
 		}

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -738,7 +738,7 @@ public:
 	Promise<UID> clusterId;
 	// The version the cluster starts on. This value is not persisted and may
 	// not be valid after a recovery.
-	Version initialClusterVersion = -1;
+	Version initialClusterVersion = invalidVersion;
 	UID thisServerID;
 	Optional<UID> tssPairID; // if this server is a tss, this is the id of its (ss) pair
 	Optional<UID> ssPairID; // if this server is an ss, this is the id of its (tss) pair

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -5957,6 +5957,7 @@ ACTOR Future<Void> update(StorageServer* data, bool* pReceivedUpdate) {
 			proposedOldestVersion = std::min(proposedOldestVersion, data->version.get() - 1);
 			proposedOldestVersion = std::max(proposedOldestVersion, data->oldestVersion.get());
 			proposedOldestVersion = std::max(proposedOldestVersion, data->desiredOldestVersion.get());
+			proposedOldestVersion = std::max(proposedOldestVersion, data->initialClusterVersion);
 
 			//TraceEvent("StorageServerUpdated", data->thisServerID).detail("Ver", ver).detail("DataVersion", data->version.get())
 			//	.detail("LastTLogVersion", data->lastTLogVersion).detail("NewOldest",

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -5049,8 +5049,8 @@ void changeServerKeys(StorageServer* data,
 			data->watches.triggerRange(range.begin, range.end);
 		} else if (!dataAvailable) {
 			// SOMEDAY: Avoid restarting adding/transferred shards
-			if (version ==
-			    data->initialClusterVersion - 1) { // bypass fetchkeys; shard is known empty at initial cluster version
+			// bypass fetchkeys; shard is known empty at initial cluster version
+			if (version == data->initialClusterVersion - 1) {
 				TraceEvent("ChangeServerKeysInitialRange", data->thisServerID)
 				    .detail("Begin", range.begin)
 				    .detail("End", range.end);
@@ -5841,8 +5841,7 @@ ACTOR Future<Void> update(StorageServer* data, bool* pReceivedUpdate) {
 					    .detail("Version", cloneCursor2->version().toString());
 				} else if (ver != invalidVersion) { // This change belongs to a version < minVersion
 					DEBUG_MUTATION("SSPeek", ver, msg, data->thisServerID);
-					if (ver == data->initialClusterVersion) { // TODO: Change to log based on current version, not
-						                                      // always set to 1
+					if (ver == data->initialClusterVersion) {
 						//TraceEvent("SSPeekMutation", data->thisServerID).log();
 						// The following trace event may produce a value with special characters
 						TraceEvent("SSPeekMutation", data->thisServerID)

--- a/fdbserver/worker.actor.cpp
+++ b/fdbserver/worker.actor.cpp
@@ -2011,6 +2011,7 @@ ACTOR Future<Void> workerServer(Reference<IClusterConnectionRecord> connRecord,
 				                 [&req](const auto& p) { return p.second != req.storeType; }) ||
 				     req.seedTag != invalidTag)) {
 					ASSERT(req.clusterId.isValid());
+					ASSERT(req.initialClusterVersion >= 0);
 					LocalLineage _;
 					getCurrentLineage()->modify(&RoleLineage::role) = ProcessClass::ClusterRole::Storage;
 					bool isTss = req.tssPairIDAndVersion.present();
@@ -2056,6 +2057,7 @@ ACTOR Future<Void> workerServer(Reference<IClusterConnectionRecord> connRecord,
 					                               recruited,
 					                               req.seedTag,
 					                               req.clusterId,
+					                               req.initialClusterVersion,
 					                               isTss ? req.tssPairIDAndVersion.get().second : 0,
 					                               storageReady,
 					                               dbInfo,

--- a/fdbserver/workloads/workloads.actor.h
+++ b/fdbserver/workloads/workloads.actor.h
@@ -235,7 +235,8 @@ Future<Void> quietDatabase(Database const& cx,
                            int64_t maxTLogQueueGate = 5e6,
                            int64_t maxStorageServerQueueGate = 5e6,
                            int64_t maxDataDistributionQueueSize = 0,
-                           int64_t maxPoppedVersionLag = 30e6);
+                           int64_t maxPoppedVersionLag = 30e6,
+                           int64_t maxVersionOffset = 1e6);
 
 /**
  * A utility function for testing error situations. It succeeds if the given test


### PR DESCRIPTION
Previously, new clusters would begin at version 0. After this change, clusters will initialize at a version matching wall-clock time. Instead of using the Unix epoch (or Windows epoch), FDB clusters will use a new epoch, defaulting to January 1, 2010, 01:00:00+00:00. In the future, this base epoch will be modifiable through `fdbcli`, allowing administrators to advance the cluster version.

Basing the version off of time allows different FDB clusters to share data without running into version issues.

The cluster will also attempt to keep versions consistent with the clock. Typically, versions are incremented by ~1,000,000 per second. Now, if the cluster version is behind the clock, it can h and out versions at a faster rate, or vice versa if the cluster version is ahead of the clock.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
