### PR TITLE
sidecar: use full version in library files for release candidates

### DIFF
--- a/packaging/docker/sidecar.py
+++ b/packaging/docker/sidecar.py
@@ -189,6 +189,10 @@ class Config(object):
         with open("/var/fdb/version") as version_file:
             self.primary_version = version_file.read().strip()
 
+        self.primary_version_is_rc = False
+        if self.primary_version.find("rc") > 0:
+            self.primary_version_is_rc = True
+
         version_split = self.primary_version.split(".")
         self.minor_version = [int(version_split[0]), int(version_split[1])]
 
@@ -645,9 +649,14 @@ def copy_libraries():
         if version == config.copy_libraries[0]:
             target_path = Path(f"{config.output_dir}/lib/libfdb_c.so")
         else:
-            target_path = Path(
-                f"{config.output_dir}/lib/multiversion/libfdb_c_{version}.so"
-            )
+            if config.primary_version_is_rc:
+                target_path = Path(
+                    f"{config.output_dir}/lib/multiversion/libfdb_c_{config.primary_version}.so"
+                )
+            else:
+                target_path = Path(
+                    f"{config.output_dir}/lib/multiversion/libfdb_c_{config.version}.so"
+                )
         if not target_path.exists():
             target_path.parent.mkdir(parents=True, exist_ok=True)
             tmp_file = tempfile.NamedTemporaryFile(


### PR DESCRIPTION
This change ensures that when we release RC versions of FDB, the sidecar will use the full version in the `multiversion/libfdb_c_$VERSION.so` files to avoid clobbering the files if we define or use multiple RC versions in the multiversion directory.

# Code-Reviewer Section
- [X] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches
- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
