### PR TITLE
Fix Valgrind error

### DIFF
--- a/fdbclient/CommitTransaction.h
+++ b/fdbclient/CommitTransaction.h
@@ -185,18 +185,20 @@ static inline bool isNonAssociativeOp(MutationRef::Type mutationType) {
 }
 
 struct CommitTransactionRef {
-	CommitTransactionRef() : read_snapshot(0), report_conflicting_keys(false) {}
+	CommitTransactionRef() = default;
 	CommitTransactionRef(Arena& a, const CommitTransactionRef& from)
 	  : read_conflict_ranges(a, from.read_conflict_ranges), write_conflict_ranges(a, from.write_conflict_ranges),
 	    mutations(a, from.mutations), read_snapshot(from.read_snapshot),
-	    report_conflicting_keys(from.report_conflicting_keys) {}
+	    report_conflicting_keys(from.report_conflicting_keys), lock_aware(from.lock_aware),
+	    spanContext(from.spanContext) {}
+
 	VectorRef<KeyRangeRef> read_conflict_ranges;
 	VectorRef<KeyRangeRef> write_conflict_ranges;
 	VectorRef<MutationRef> mutations; // metadata mutations
-	Version read_snapshot;
-	bool report_conflicting_keys;
-	bool lock_aware; // set when metadata mutations are present
-	SpanID spanContext;
+	Version read_snapshot = 0;
+	bool report_conflicting_keys = false;
+	bool lock_aware = false; // set when metadata mutations are present
+	Optional<SpanID> spanContext;
 
 	template <class Ar>
 	force_inline void serialize(Ar& ar) {

--- a/fdbrpc/fdbrpc.h
+++ b/fdbrpc/fdbrpc.h
@@ -124,6 +124,8 @@ public:
 		sav->sendError(exc);
 	}
 
+	void send(Never) { sendError(never_reply()); }
+
 	Future<T> getFuture() const {
 		sav->addFutureRef();
 		return Future<T>(sav);

--- a/fdbrpc/networksender.actor.h
+++ b/fdbrpc/networksender.actor.h
@@ -30,6 +30,7 @@
 #include "flow/flow.h"
 #include "flow/actorcompiler.h" // This must be the last #include.
 
+// This actor is used by FlowTransport to serialize the response to a ReplyPromise across the network
 ACTOR template <class T>
 void networkSender(Future<T> input, Endpoint endpoint) {
 	try {
@@ -37,6 +38,9 @@ void networkSender(Future<T> input, Endpoint endpoint) {
 		FlowTransport::transport().sendUnreliable(SerializeSource<ErrorOr<EnsureTable<T>>>(value), endpoint, false);
 	} catch (Error& err) {
 		// if (err.code() == error_code_broken_promise) return;
+		if (err.code() == error_code_never_reply) {
+			return;
+		}
 		ASSERT(err.code() != error_code_actor_cancelled);
 		FlowTransport::transport().sendUnreliable(SerializeSource<ErrorOr<EnsureTable<T>>>(err), endpoint, false);
 	}

--- a/fdbserver/Resolver.actor.cpp
+++ b/fdbserver/Resolver.actor.cpp
@@ -353,7 +353,10 @@ ACTOR Future<Void> resolveBatch(Reference<Resolver> self, ResolveTransactionBatc
 			// The condition here must match CommitBatch::applyMetadataToCommittedTransactions()
 			if (reply.committed[t] == ConflictBatch::TransactionCommitted && !self->forceRecovery &&
 			    SERVER_KNOBS->PROXY_USE_RESOLVER_PRIVATE_MUTATIONS && (!isLocked || req.transactions[t].lock_aware)) {
-				applyMetadataMutations(req.transactions[t].spanContext, resolverData, req.transactions[t].mutations);
+				SpanID spanContext =
+				    req.transactions[t].spanContext.present() ? req.transactions[t].spanContext.get() : SpanID();
+
+				applyMetadataMutations(spanContext, resolverData, req.transactions[t].mutations);
 			}
 			TEST(self->forceRecovery); // Resolver detects forced recovery
 		}

--- a/fdbserver/ptxn/TLogServer.actor.cpp
+++ b/fdbserver/ptxn/TLogServer.actor.cpp
@@ -501,9 +501,8 @@ struct LogGenerationData : NonCopyable, public ReferenceCounted<LogGenerationDat
 		                bool nothingPersistent,
 		                bool poppedRecently,
 		                bool unpoppedRecovered)
-		  : storageTeamId(storageTeam), tags(tags), poppedTagVersions(tagToVersions),
-		    nothingPersistent(nothingPersistent), poppedRecently(poppedRecently), unpoppedRecovered(unpoppedRecovered) {
-		}
+		  : storageTeamId(storageTeam), tags(tags), poppedTagVersions(tagToVersions), poppedRecently(poppedRecently),
+		    unpoppedRecovered(unpoppedRecovered), nothingPersistent(nothingPersistent) {}
 
 		StorageTeamData(StorageTeamData&& r) noexcept
 		  : storageTeamId(r.storageTeamId), tags(r.tags), versionMessages(std::move(r.versionMessages)),

--- a/flow/error_definitions.h
+++ b/flow/error_definitions.h
@@ -91,6 +91,7 @@ ERROR( broken_promise, 1100, "Broken promise" )
 ERROR( operation_cancelled, 1101, "Asynchronous operation cancelled" )
 ERROR( future_released, 1102, "Future has been released" )
 ERROR( connection_leaked, 1103, "Connection object leaked" )
+ERROR( never_reply, 1104, "Never reply to the request" )
 
 ERROR( recruitment_failed, 1200, "Recruitment of a server failed" )   // Be careful, catching this will delete the data of a storage server or tlog permanently
 ERROR( move_to_removed_server, 1201, "Attempt to move keys to a storage server that was removed" )


### PR DESCRIPTION
Fix Valgrind error of uninitialized data in `CommitTransactionRef`. Cherrypick another fix and fix a tlog initialization order.

I manually ran failed seeds and they now passed.

20220218-234822-jzhou-88ccac247082cd5e passed.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
