### PR TITLE
Fix Valgrind error of uninitialized data in CommitTransactionRef

### DIFF
--- a/fdbclient/CommitTransaction.h
+++ b/fdbclient/CommitTransaction.h
@@ -177,18 +177,20 @@ static inline bool isNonAssociativeOp(MutationRef::Type mutationType) {
 }
 
 struct CommitTransactionRef {
-	CommitTransactionRef() : read_snapshot(0), report_conflicting_keys(false) {}
+	CommitTransactionRef() = default;
 	CommitTransactionRef(Arena& a, const CommitTransactionRef& from)
 	  : read_conflict_ranges(a, from.read_conflict_ranges), write_conflict_ranges(a, from.write_conflict_ranges),
 	    mutations(a, from.mutations), read_snapshot(from.read_snapshot),
-	    report_conflicting_keys(from.report_conflicting_keys) {}
+	    report_conflicting_keys(from.report_conflicting_keys), lock_aware(from.lock_aware),
+	    spanContext(from.spanContext) {}
+
 	VectorRef<KeyRangeRef> read_conflict_ranges;
 	VectorRef<KeyRangeRef> write_conflict_ranges;
 	VectorRef<MutationRef> mutations; // metadata mutations
-	Version read_snapshot;
-	bool report_conflicting_keys;
-	bool lock_aware; // set when metadata mutations are present
-	SpanID spanContext;
+	Version read_snapshot = 0;
+	bool report_conflicting_keys = false;
+	bool lock_aware = false; // set when metadata mutations are present
+	Optional<SpanID> spanContext;
 
 	template <class Ar>
 	force_inline void serialize(Ar& ar) {

--- a/fdbserver/Resolver.actor.cpp
+++ b/fdbserver/Resolver.actor.cpp
@@ -340,7 +340,10 @@ ACTOR Future<Void> resolveBatch(Reference<Resolver> self, ResolveTransactionBatc
 			// The condition here must match CommitBatch::applyMetadataToCommittedTransactions()
 			if (reply.committed[t] == ConflictBatch::TransactionCommitted && !self->forceRecovery &&
 			    SERVER_KNOBS->PROXY_USE_RESOLVER_PRIVATE_MUTATIONS && (!isLocked || req.transactions[t].lock_aware)) {
-				applyMetadataMutations(req.transactions[t].spanContext, resolverData, req.transactions[t].mutations);
+				SpanID spanContext =
+				    req.transactions[t].spanContext.present() ? req.transactions[t].spanContext.get() : SpanID();
+
+				applyMetadataMutations(spanContext, resolverData, req.transactions[t].mutations);
 			}
 			TEST(self->forceRecovery); // Resolver detects forced recovery
 		}


### PR DESCRIPTION
I manually verified the failed seeds now pass.

20220219-004736-jzhou-908ce3b7dbcb9a60 has one unrelated timeout failure in `ConsistencyCheck`.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
