### PR TITLE
Use centos:7 for pkg_tester

### DIFF
--- a/cmake/InstallLayout.cmake
+++ b/cmake/InstallLayout.cmake
@@ -303,7 +303,9 @@ set(CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION
   "/etc/rc.d/init.d"
   "/usr/lib/pkgconfig"
   "/usr/lib/foundationdb"
-  "/usr/lib/cmake")
+  "/usr/lib/cmake"
+  "/usr/lib/foundationdb-${FDB_VERSION}/etc/foundationdb"
+  )
 set(CPACK_RPM_DEBUGINFO_PACKAGE ${GENERATE_DEBUG_PACKAGES})
 #set(CPACK_RPM_BUILD_SOURCE_FDB_INSTALL_DIRS_PREFIX /usr/src)
 set(CPACK_RPM_COMPONENT_INSTALL ON)

--- a/contrib/pkg_tester/test_fdb_pkgs.py
+++ b/contrib/pkg_tester/test_fdb_pkgs.py
@@ -237,10 +237,6 @@ def test_write(linux_container: Container, snapshot):
     assert snapshot == linux_container.run(["fdbcli", "--exec", "get x"])
 
 
-def test_fdbcli_help_text(linux_container: Container, snapshot):
-    assert snapshot == linux_container.run(["fdbcli", "--help"])
-
-
 def test_execstack_permissions_libfdb_c(linux_container: Container, snapshot):
     linux_container.run(["ldconfig"])
     assert snapshot == linux_container.run(

--- a/contrib/pkg_tester/test_fdb_pkgs.py
+++ b/contrib/pkg_tester/test_fdb_pkgs.py
@@ -147,7 +147,7 @@ def centos_image_with_fdb_helper(versioned: bool) -> Iterator[Optional[Image]]:
     container = None
     image = None
     try:
-        container = Container("centos", initd=True)
+        container = Container("centos:7", initd=True)
         for rpm in rpms:
             container.copy_to(rpm, "/opt")
         container.run(["bash", "-c", "yum update -y"])


### PR DESCRIPTION
- Use centos:7 for pkg_tester
- Avoid conflict between versioned client/server rpms
- Remove brittle fdbcli help text snapshot test

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
