### PR TITLE
Tss improvement

### DIFF
--- a/fdbclient/StorageServerInterface.cpp
+++ b/fdbclient/StorageServerInterface.cpp
@@ -28,7 +28,7 @@
 
 // if size + hex of checksum is shorter than value, record that instead of actual value. break-even point is 12
 // characters
-std::string traceChecksumValue(ValueRef s) {
+std::string traceChecksumValue(const ValueRef& s) {
 	return s.size() > 12 ? format("(%d)%08x", s.size(), crc32c_append(0, s.begin(), s.size())) : s.toString();
 }
 
@@ -49,6 +49,7 @@ void TSS_traceMismatch(TraceEvent& event,
                        const GetValueReply& src,
                        const GetValueReply& tss) {
 	event.detail("Key", req.key.printable())
+	    .detail("Tenant", req.tenantInfo.name)
 	    .detail("Version", req.version)
 	    .detail("SSReply", src.value.present() ? traceChecksumValue(src.value.get()) : "missing")
 	    .detail("TSSReply", tss.value.present() ? traceChecksumValue(tss.value.get()) : "missing");
@@ -125,33 +126,77 @@ const char* TSS_mismatchTraceName(const GetKeyValuesRequest& req) {
 	return "TSSMismatchGetKeyValues";
 }
 
+static void traceKeyValuesSummary(TraceEvent& event,
+                                  const KeySelectorRef& begin,
+                                  const KeySelectorRef& end,
+                                  Optional<TenantName> tenant,
+                                  Version version,
+                                  int limit,
+                                  int limitBytes,
+                                  size_t ssSize,
+                                  bool ssMore,
+                                  size_t tssSize,
+                                  bool tssMore) {
+	std::string ssSummaryString = format("(%d)%s", ssSize, ssMore ? "+" : "");
+	std::string tssSummaryString = format("(%d)%s", tssSize, tssMore ? "+" : "");
+	event.detail("Begin", format("%s%s:%d", begin.orEqual ? "=" : "", begin.getKey().printable().c_str(), begin.offset))
+	    .detail("End", format("%s%s:%d", end.orEqual ? "=" : "", end.getKey().printable().c_str(), end.offset))
+	    .detail("Tenant", tenant)
+	    .detail("Version", version)
+	    .detail("Limit", limit)
+	    .detail("LimitBytes", limitBytes)
+	    .detail("SSReplySummary", ssSummaryString)
+	    .detail("TSSReplySummary", tssSummaryString);
+}
+
+static void traceKeyValuesDiff(TraceEvent& event,
+                               const KeySelectorRef& begin,
+                               const KeySelectorRef& end,
+                               Optional<TenantName> tenant,
+                               Version version,
+                               int limit,
+                               int limitBytes,
+                               const VectorRef<KeyValueRef>& ssKV,
+                               bool ssMore,
+                               const VectorRef<KeyValueRef>& tssKV,
+                               bool tssMore) {
+	traceKeyValuesSummary(
+	    event, begin, end, tenant, version, limit, limitBytes, ssKV.size(), ssMore, tssKV.size(), tssMore);
+	bool mismatchFound = false;
+	for (int i = 0; i < std::max(ssKV.size(), tssKV.size()); i++) {
+		if (i >= ssKV.size() || i >= tssKV.size() || ssKV[i] != tssKV[i]) {
+			event.detail("MismatchIndex", i);
+			if (i >= ssKV.size() || i >= tssKV.size() || ssKV[i].key != tssKV[i].key) {
+				event.detail("MismatchSSKey", i < ssKV.size() ? ssKV[i].key.printable() : "missing");
+				event.detail("MismatchTSSKey", i < tssKV.size() ? tssKV[i].key.printable() : "missing");
+			} else {
+				event.detail("MismatchKey", ssKV[i].key.printable());
+				event.detail("MismatchSSValue", traceChecksumValue(ssKV[i].value));
+				event.detail("MismatchTSSValue", traceChecksumValue(tssKV[i].value));
+			}
+			mismatchFound = true;
+			break;
+		}
+	}
+	ASSERT(mismatchFound);
+}
+
 template <>
 void TSS_traceMismatch(TraceEvent& event,
                        const GetKeyValuesRequest& req,
                        const GetKeyValuesReply& src,
                        const GetKeyValuesReply& tss) {
-	std::string ssResultsString = format("(%d)%s:\n", src.data.size(), src.more ? "+" : "");
-	for (auto& it : src.data) {
-		ssResultsString += "\n" + it.key.printable() + "=" + traceChecksumValue(it.value);
-	}
-
-	std::string tssResultsString = format("(%d)%s:\n", tss.data.size(), tss.more ? "+" : "");
-	for (auto& it : tss.data) {
-		tssResultsString += "\n" + it.key.printable() + "=" + traceChecksumValue(it.value);
-	}
-	event
-	    .detail(
-	        "Begin",
-	        format("%s%s:%d", req.begin.orEqual ? "=" : "", req.begin.getKey().printable().c_str(), req.begin.offset))
-	    .detail("End",
-	            format("%s%s:%d", req.end.orEqual ? "=" : "", req.end.getKey().printable().c_str(), req.end.offset))
-	    .detail("Tenant", req.tenantInfo.name)
-	    .detail("Version", req.version)
-	    .detail("Limit", req.limit)
-	    .detail("LimitBytes", req.limitBytes)
-	    .setMaxFieldLength(FLOW_KNOBS->TSS_LARGE_TRACE_SIZE * 4 / 10)
-	    .detail("SSReply", ssResultsString)
-	    .detail("TSSReply", tssResultsString);
+	traceKeyValuesDiff(event,
+	                   req.begin,
+	                   req.end,
+	                   req.tenantInfo.name,
+	                   req.version,
+	                   req.limit,
+	                   req.limitBytes,
+	                   src.data,
+	                   src.more,
+	                   tss.data,
+	                   tss.more);
 }
 
 // range reads and flat map
@@ -170,28 +215,18 @@ void TSS_traceMismatch(TraceEvent& event,
                        const GetMappedKeyValuesRequest& req,
                        const GetMappedKeyValuesReply& src,
                        const GetMappedKeyValuesReply& tss) {
-	std::string ssResultsString = format("(%d)%s:\n", src.data.size(), src.more ? "+" : "");
-	for (auto& it : src.data) {
-		ssResultsString += "\n" + it.key.printable() + "=" + traceChecksumValue(it.value);
-	}
-
-	std::string tssResultsString = format("(%d)%s:\n", tss.data.size(), tss.more ? "+" : "");
-	for (auto& it : tss.data) {
-		tssResultsString += "\n" + it.key.printable() + "=" + traceChecksumValue(it.value);
-	}
-	event
-	    .detail(
-	        "Begin",
-	        format("%s%s:%d", req.begin.orEqual ? "=" : "", req.begin.getKey().printable().c_str(), req.begin.offset))
-	    .detail("End",
-	            format("%s%s:%d", req.end.orEqual ? "=" : "", req.end.getKey().printable().c_str(), req.end.offset))
-	    .detail("Tenant", req.tenantInfo.name)
-	    .detail("Version", req.version)
-	    .detail("Limit", req.limit)
-	    .detail("LimitBytes", req.limitBytes)
-	    .setMaxFieldLength(FLOW_KNOBS->TSS_LARGE_TRACE_SIZE * 4 / 10)
-	    .detail("SSReply", ssResultsString)
-	    .detail("TSSReply", tssResultsString);
+	traceKeyValuesSummary(event,
+	                      req.begin,
+	                      req.end,
+	                      req.tenantInfo.name,
+	                      req.version,
+	                      req.limit,
+	                      req.limitBytes,
+	                      src.data.size(),
+	                      src.more,
+	                      tss.data.size(),
+	                      tss.more);
+	// FIXME: trace details for TSS mismatch of mapped data
 }
 
 // streaming range reads
@@ -211,28 +246,17 @@ void TSS_traceMismatch(TraceEvent& event,
                        const GetKeyValuesStreamRequest& req,
                        const GetKeyValuesStreamReply& src,
                        const GetKeyValuesStreamReply& tss) {
-	std::string ssResultsString = format("(%d)%s:\n", src.data.size(), src.more ? "+" : "");
-	for (auto& it : src.data) {
-		ssResultsString += "\n" + it.key.printable() + "=" + traceChecksumValue(it.value);
-	}
-
-	std::string tssResultsString = format("(%d)%s:\n", tss.data.size(), tss.more ? "+" : "");
-	for (auto& it : tss.data) {
-		tssResultsString += "\n" + it.key.printable() + "=" + traceChecksumValue(it.value);
-	}
-	event
-	    .detail(
-	        "Begin",
-	        format("%s%s:%d", req.begin.orEqual ? "=" : "", req.begin.getKey().printable().c_str(), req.begin.offset))
-	    .detail("End",
-	            format("%s%s:%d", req.end.orEqual ? "=" : "", req.end.getKey().printable().c_str(), req.end.offset))
-	    .detail("Tenant", req.tenantInfo.name)
-	    .detail("Version", req.version)
-	    .detail("Limit", req.limit)
-	    .detail("LimitBytes", req.limitBytes)
-	    .setMaxFieldLength(FLOW_KNOBS->TSS_LARGE_TRACE_SIZE * 4 / 10)
-	    .detail("SSReply", ssResultsString)
-	    .detail("TSSReply", tssResultsString);
+	traceKeyValuesDiff(event,
+	                   req.begin,
+	                   req.end,
+	                   req.tenantInfo.name,
+	                   req.version,
+	                   req.limit,
+	                   req.limitBytes,
+	                   src.data,
+	                   src.more,
+	                   tss.data,
+	                   tss.more);
 }
 
 template <>


### PR DESCRIPTION
Fix for TSS nightly failure and metrics (SS forgets about its TSS pair on restart) and improvement to debug tracing
Failed 1 test out of 50k, but it's the same as another unrelated failure from the nightly where this failure occurred.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
