### PR TITLE
Fix get key location overloading proxies

### DIFF
--- a/fdbclient/ClientKnobs.cpp
+++ b/fdbclient/ClientKnobs.cpp
@@ -86,6 +86,8 @@ void ClientKnobs::initialize(Randomize randomize) {
 
 	init( LOCATION_CACHE_EVICTION_SIZE,         600000 );
 	init( LOCATION_CACHE_EVICTION_SIZE_SIM,         10 ); if( randomize && BUGGIFY ) LOCATION_CACHE_EVICTION_SIZE_SIM = 3;
+	init( LOCATION_CACHE_ENDPOINT_FAILURE_GRACE_PERIOD,     60 );
+	init( LOCATION_CACHE_FAILED_ENDPOINT_RETRY_INTERVAL,    60 );
 
 	init( GET_RANGE_SHARD_LIMIT,                     2 );
 	init( WARM_RANGE_SHARD_LIMIT,                  100 );

--- a/fdbclient/ClientKnobs.h
+++ b/fdbclient/ClientKnobs.h
@@ -86,6 +86,8 @@ public:
 	// When locationCache in DatabaseContext gets to be this size, items will be evicted
 	int LOCATION_CACHE_EVICTION_SIZE;
 	int LOCATION_CACHE_EVICTION_SIZE_SIM;
+	double LOCATION_CACHE_ENDPOINT_FAILURE_GRACE_PERIOD;
+	double LOCATION_CACHE_FAILED_ENDPOINT_RETRY_INTERVAL;
 
 	int GET_RANGE_SHARD_LIMIT;
 	int WARM_RANGE_SHARD_LIMIT;

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -1596,6 +1596,32 @@ void DatabaseContext::invalidateCache(const KeyRangeRef& keys) {
 	locationCache.insert(KeyRangeRef(begin, end), Reference<LocationInfo>());
 }
 
+void DatabaseContext::setFailedEndpointOnHealthyServer(const Endpoint& endpoint) {
+	if (failedEndpointsOnHealthyServersInfo.find(endpoint) == failedEndpointsOnHealthyServersInfo.end()) {
+		failedEndpointsOnHealthyServersInfo[endpoint] = { /*startTime=*/now(), /*lastRefreshTime=*/now() };
+	}
+}
+
+void DatabaseContext::updateFailedEndpointRefreshTime(const Endpoint& endpoint) {
+	if (failedEndpointsOnHealthyServersInfo.find(endpoint) == failedEndpointsOnHealthyServersInfo.end()) {
+		// The endpoint is not failed. Nothing to update.
+		return;
+	}
+
+	failedEndpointsOnHealthyServersInfo[endpoint].lastRefreshTime = now();
+}
+
+Optional<EndpointFailureInfo> DatabaseContext::getEndpointFailureInfo(const Endpoint& endpoint) {
+	if (failedEndpointsOnHealthyServersInfo.find(endpoint) == failedEndpointsOnHealthyServersInfo.end()) {
+		return Optional<EndpointFailureInfo>();
+	}
+	return failedEndpointsOnHealthyServersInfo[endpoint];
+}
+
+void DatabaseContext::clearFailedEndpointOnHealthyServer(const Endpoint& endpoint) {
+	failedEndpointsOnHealthyServersInfo.erase(endpoint);
+}
+
 Future<Void> DatabaseContext::onProxiesChanged() const {
 	return this->proxiesChangeTrigger.onTrigger();
 }
@@ -2463,12 +2489,40 @@ Future<std::pair<KeyRange, Reference<LocationInfo>>> getKeyLocation(Database con
 		return getKeyLocation_internal(cx, key, spanID, debugID, useProvisionalProxies, isBackward);
 	}
 
+	bool onlyEndpointFailedAndNeedRefresh = false;
 	for (int i = 0; i < ssi.second->size(); i++) {
-		if (IFailureMonitor::failureMonitor().onlyEndpointFailed(ssi.second->get(i, member).getEndpoint())) {
-			cx->invalidateCache(key);
-			ssi.second.clear();
-			return getKeyLocation_internal(cx, key, spanID, debugID, useProvisionalProxies, isBackward);
+		const Endpoint& endpoint = ssi.second->get(i, member).getEndpoint();
+		if (IFailureMonitor::failureMonitor().onlyEndpointFailed(endpoint)) {
+			// This endpoint is failed, but the server is still healthy. There are two cases this can happen:
+			//    - There is a recent bounce in the cluster where the endpoints in SSes get updated.
+			//    - The SS is failed and terminated on a server, but the server is kept running.
+			// To account for the first case, we invalidate the cache and issue GetKeyLocation requests to the proxy to
+			// update the cache with the new SS points. However, if the failure is caused by the second case, the
+			// requested key location will continue to be the failed endpoint until the data movement is finished. But
+			// every read will generate a GetKeyLocation request to the proxies (and still getting the failed endpoint
+			// back), which may overload the proxy and affect data movement speed. Therefore, we only refresh the
+			// location cache for short period of time, and after the initial grace period that we keep retrying
+			// resolving key location, we will slow it down to resolve it only once every
+			// `LOCATION_CACHE_FAILED_ENDPOINT_RETRY_INTERVAL`.
+			cx->setFailedEndpointOnHealthyServer(endpoint);
+			const auto& failureInfo = cx->getEndpointFailureInfo(endpoint);
+			ASSERT(failureInfo.present());
+			if (now() - failureInfo.get().startTime < CLIENT_KNOBS->LOCATION_CACHE_ENDPOINT_FAILURE_GRACE_PERIOD ||
+			    now() - failureInfo.get().lastRefreshTime >
+			        CLIENT_KNOBS->LOCATION_CACHE_FAILED_ENDPOINT_RETRY_INTERVAL) {
+				onlyEndpointFailedAndNeedRefresh = true;
+			}
+		} else {
+			cx->clearFailedEndpointOnHealthyServer(endpoint);
 		}
+	}
+
+	if (onlyEndpointFailedAndNeedRefresh) {
+		cx->invalidateCache(key);
+		for (int i = 0; i < ssi.second->size(); i++) {
+			cx->updateFailedEndpointRefreshTime(ssi.second->get(i, member).getEndpoint());
+		}
+		return getKeyLocation_internal(cx, key, spanID, debugID, useProvisionalProxies, isBackward);
 	}
 
 	return ssi;
@@ -2553,21 +2607,37 @@ Future<std::vector<std::pair<KeyRange, Reference<LocationInfo>>>> getKeyRangeLoc
 
 	bool foundFailed = false;
 	for (const auto& [range, locInfo] : locations) {
-		bool onlyEndpointFailed = false;
+		bool onlyEndpointFailedAndNeedRefresh = false;
 		for (int i = 0; i < locInfo->size(); i++) {
-			if (IFailureMonitor::failureMonitor().onlyEndpointFailed(locInfo->get(i, member).getEndpoint())) {
-				onlyEndpointFailed = true;
-				break;
+			const Endpoint& endpoint = locInfo->get(i, member).getEndpoint();
+			if (IFailureMonitor::failureMonitor().onlyEndpointFailed(endpoint)) {
+				// Please refer to `getKeyLocation` about why we keep track of endpoint failure starting and refreshing
+				// time.
+				cx->setFailedEndpointOnHealthyServer(endpoint);
+				const auto& failureInfo = cx->getEndpointFailureInfo(endpoint);
+				ASSERT(failureInfo.present());
+				if (now() - failureInfo.get().startTime < CLIENT_KNOBS->LOCATION_CACHE_ENDPOINT_FAILURE_GRACE_PERIOD ||
+				    now() - failureInfo.get().lastRefreshTime >
+				        CLIENT_KNOBS->LOCATION_CACHE_FAILED_ENDPOINT_RETRY_INTERVAL) {
+					onlyEndpointFailedAndNeedRefresh = true;
+				}
+			} else {
+				cx->clearFailedEndpointOnHealthyServer(endpoint);
 			}
 		}
 
-		if (onlyEndpointFailed) {
+		if (onlyEndpointFailedAndNeedRefresh) {
 			cx->invalidateCache(range.begin);
 			foundFailed = true;
 		}
 	}
 
 	if (foundFailed) {
+		for (const auto& [range, locInfo] : locations) {
+			for (int i = 0; i < locInfo->size(); i++) {
+				cx->updateFailedEndpointRefreshTime(locInfo->get(i, member).getEndpoint());
+			}
+		}
 		return getKeyRangeLocations_internal(cx, keys, limit, reverse, spanID, debugID, useProvisionalProxies);
 	}
 


### PR DESCRIPTION
This PR tries to fix a case where proxies are overloaded by GetKeyLocation when a SS is failed.

The situation this can happen is when a SS is terminated (e.g. experience an IO failure), but the worker is still up and running. After this time, client GetKeyLocation returns a failed endpoint. There is a logic that when the endpoint is failed, but the worker is healthy, the client will invalidate the cache. This is to account for the case when we bounce the cluster, all SSes' endpoints will get updated. However, in this case, the proxies will still return the failed enpoint until the data movement is finished, and this period can last for a quite sometime (hours). During this period, all read requests will result in GetKeyLocation requests to the proxy, including the reads performed by the data movement. This can result in proxies getting overloaded, which further slows down reads, data movements, as well as commits.

To fix this issue, we implement a time based mechanism. When we first see a failed endpoint on a heathy server, we still invalidate the cache for short period of time to account for the bounce case. If we continue see this failed endpoint, we will only invalidate the cache once very so often (controlled by a knob, currently 1 min).

20220223-223310-zhewu-6446-340df0e11b6422f2        compressed=True data_size=28969610 duration=4922620 ended=100001 fail_fast=10 max_runs=100000 pass=100001 priority=100 remaining=0 runtime=0:55:11 sanity=False started=100154 stopped=20220223-232821 submitted=20220223-223310 timeout=5400 username=zhewu-6446

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
