### PR TITLE
Use Standalone rather than pair of StringRef and Arena

### DIFF
--- a/fdbserver/ptxn/TLogServer.actor.cpp
+++ b/fdbserver/ptxn/TLogServer.actor.cpp
@@ -886,7 +886,7 @@ void commitMessages(Reference<TLogGroupData> self,
 	StringRef storedMessage(block.end() - msgSize, msgSize);
 	const auto expectedStoredMessageSize = storedMessage.expectedSize();
 
-	storageTeamData->versionMessages[version] = Standalone(storedMessage); // do memcpy to copy contents from block
+	storageTeamData->versionMessages[version] = Standalone(storedMessage, block.arena());
 
 	if (expectedStoredMessageSize > SERVER_KNOBS->MAX_MESSAGE_SIZE) {
 		TraceEvent(SevWarnAlways, "LargeMessage").detail("Size", expectedStoredMessageSize);


### PR DESCRIPTION
This is a follow-up PR for 6404

20220225-213408-haofu-3c1f61d536ce2d55
Put description here...

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
