### PR TITLE
Fix macOS CI broken by #6449.

### DIFF
--- a/fdbserver/CoroFlow.actor.cpp
+++ b/fdbserver/CoroFlow.actor.cpp
@@ -256,10 +256,10 @@ public:
 
 		pool->queueLock.enter();
 		TraceEvent("WorkPool_Stop")
+		    .errorUnsuppressed(e)
 		    .detail("Workers", pool->workers.size())
 		    .detail("Idle", pool->idle.size())
-		    .detail("Work", pool->work.size())
-		    .errorUnsuppressed(e);
+		    .detail("Work", pool->work.size());
 
 		for (uint32_t i = 0; i < pool->work.size(); i++)
 			pool->work[i]->cancel(); // What if cancel() does something to this?


### PR DESCRIPTION
foundationdb/fdbserver/CoroFlow.actor.cpp:262:8: error: no member named 'errorUnsuppressed' in 'BaseTraceEvent'

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
