### PR TITLE
 [release 6.3] Fix get key location overloading proxies

### DIFF
--- a/fdbclient/Knobs.cpp
+++ b/fdbclient/Knobs.cpp
@@ -83,6 +83,8 @@ void ClientKnobs::initialize(bool randomize) {
 
 	init( LOCATION_CACHE_EVICTION_SIZE,         600000 );
 	init( LOCATION_CACHE_EVICTION_SIZE_SIM,         10 ); if( randomize && BUGGIFY ) LOCATION_CACHE_EVICTION_SIZE_SIM = 3;
+	init( LOCATION_CACHE_ENDPOINT_FAILURE_GRACE_PERIOD,     60 );
+	init( LOCATION_CACHE_FAILED_ENDPOINT_RETRY_INTERVAL,    60 );
 
 	init( GET_RANGE_SHARD_LIMIT,                     2 );
 	init( WARM_RANGE_SHARD_LIMIT,                  100 );

--- a/fdbclient/Knobs.h
+++ b/fdbclient/Knobs.h
@@ -77,6 +77,8 @@ public:
 	// When locationCache in DatabaseContext gets to be this size, items will be evicted
 	int LOCATION_CACHE_EVICTION_SIZE;
 	int LOCATION_CACHE_EVICTION_SIZE_SIM;
+	double LOCATION_CACHE_ENDPOINT_FAILURE_GRACE_PERIOD;
+	double LOCATION_CACHE_FAILED_ENDPOINT_RETRY_INTERVAL;
 
 	int GET_RANGE_SHARD_LIMIT;
 	int WARM_RANGE_SHARD_LIMIT;

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -953,7 +953,7 @@ void DatabaseContext::invalidateCache(const KeyRangeRef& keys) {
 
 void DatabaseContext::setFailedEndpointOnHealthyServer(const Endpoint& endpoint) {
 	if (failedEndpointsOnHealthyServersInfo.find(endpoint) == failedEndpointsOnHealthyServersInfo.end()) {
-		failedEndpointsOnHealthyServersInfo[endpoint] = { /*startTime=*/now(), /*lastRefreshTime=*/now() };
+		failedEndpointsOnHealthyServersInfo[endpoint] = EndpointFailureInfo { startTime:now(), lastRefreshTime:now() };
 	}
 }
 

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -951,6 +951,32 @@ void DatabaseContext::invalidateCache(const KeyRangeRef& keys) {
 	locationCache.insert(KeyRangeRef(begin, end), Reference<LocationInfo>());
 }
 
+void DatabaseContext::setFailedEndpointOnHealthyServer(const Endpoint& endpoint) {
+	if (failedEndpointsOnHealthyServersInfo.find(endpoint) == failedEndpointsOnHealthyServersInfo.end()) {
+		failedEndpointsOnHealthyServersInfo[endpoint] = { /*startTime=*/now(), /*lastRefreshTime=*/now() };
+	}
+}
+
+void DatabaseContext::updateFailedEndpointRefreshTime(const Endpoint& endpoint) {
+	if (failedEndpointsOnHealthyServersInfo.find(endpoint) == failedEndpointsOnHealthyServersInfo.end()) {
+		// The endpoint is not failed. Nothing to update.
+		return;
+	}
+
+	failedEndpointsOnHealthyServersInfo[endpoint].lastRefreshTime = now();
+}
+
+Optional<EndpointFailureInfo> DatabaseContext::getEndpointFailureInfo(const Endpoint& endpoint) {
+	if (failedEndpointsOnHealthyServersInfo.find(endpoint) == failedEndpointsOnHealthyServersInfo.end()) {
+		return Optional<EndpointFailureInfo>();
+	}
+	return failedEndpointsOnHealthyServersInfo[endpoint];
+}
+
+void DatabaseContext::clearFailedEndpointOnHealthyServer(const Endpoint& endpoint) {
+	failedEndpointsOnHealthyServersInfo.erase(endpoint);
+}
+
 Future<Void> DatabaseContext::onMasterProxiesChanged() {
 	return this->masterProxiesChangeTrigger.onTrigger();
 }
@@ -1639,12 +1665,40 @@ Future<pair<KeyRange, Reference<LocationInfo>>> getKeyLocation(Database const& c
 		return getKeyLocation_internal(cx, key, info, isBackward);
 	}
 
+	bool onlyEndpointFailedAndNeedRefresh = false;
 	for (int i = 0; i < ssi.second->size(); i++) {
-		if (IFailureMonitor::failureMonitor().onlyEndpointFailed(ssi.second->get(i, member).getEndpoint())) {
-			cx->invalidateCache(key);
-			ssi.second.clear();
-			return getKeyLocation_internal(cx, key, info, isBackward);
+		const Endpoint& endpoint = ssi.second->get(i, member).getEndpoint();
+		if (IFailureMonitor::failureMonitor().onlyEndpointFailed(endpoint)) {
+			// This endpoint is failed, but the server is still healthy. There are two cases this can happen:
+			//    - There is a recent bounce in the cluster where the endpoints in SSes get updated.
+			//    - The SS is failed and terminated on a server, but the server is kept running.
+			// To account for the first case, we invalidate the cache and issue GetKeyLocation requests to the proxy to
+			// update the cache with the new SS points. However, if the failure is caused by the second case, the
+			// requested key location will continue to be the failed endpoint until the data movement is finished. But
+			// every read will generate a GetKeyLocation request to the proxies (and still getting the failed endpoint
+			// back), which may overload the proxy and affect data movement speed. Therefore, we only refresh the
+			// location cache for short period of time, and after the initial grace period that we keep retrying
+			// resolving key location, we will slow it down to resolve it only once every
+			// `LOCATION_CACHE_FAILED_ENDPOINT_RETRY_INTERVAL`.
+			cx->setFailedEndpointOnHealthyServer(endpoint);
+			const auto& failureInfo = cx->getEndpointFailureInfo(endpoint);
+			ASSERT(failureInfo.present());
+			if (now() - failureInfo.get().startTime < CLIENT_KNOBS->LOCATION_CACHE_ENDPOINT_FAILURE_GRACE_PERIOD ||
+			    now() - failureInfo.get().lastRefreshTime >
+			        CLIENT_KNOBS->LOCATION_CACHE_FAILED_ENDPOINT_RETRY_INTERVAL) {
+				onlyEndpointFailedAndNeedRefresh = true;
+				cx->updateFailedEndpointRefreshTime(endpoint);
+			}
+		} else {
+			cx->clearFailedEndpointOnHealthyServer(endpoint);
 		}
+	}
+
+	if (onlyEndpointFailedAndNeedRefresh) {
+		cx->invalidateCache(key);
+
+		// Refresh the cache with a new getKeyLocations made to proxies.
+		return getKeyLocation_internal(cx, key, info, isBackward);
 	}
 
 	return ssi;
@@ -1712,21 +1766,34 @@ Future<vector<pair<KeyRange, Reference<LocationInfo>>>> getKeyRangeLocations(Dat
 
 	bool foundFailed = false;
 	for (auto& it : locations) {
-		bool onlyEndpointFailed = false;
+		bool onlyEndpointFailedAndNeedRefresh = false;
 		for (int i = 0; i < it.second->size(); i++) {
-			if (IFailureMonitor::failureMonitor().onlyEndpointFailed(it.second->get(i, member).getEndpoint())) {
-				onlyEndpointFailed = true;
-				break;
+			const Endpoint& endpoint = it.second->get(i, member).getEndpoint();
+			if (IFailureMonitor::failureMonitor().onlyEndpointFailed(endpoint)) {
+				// Please refer to `getKeyLocation` about why we keep track of endpoint failure starting and refreshing
+				// time.
+				cx->setFailedEndpointOnHealthyServer(endpoint);
+				const auto& failureInfo = cx->getEndpointFailureInfo(endpoint);
+				ASSERT(failureInfo.present());
+				if (now() - failureInfo.get().startTime < CLIENT_KNOBS->LOCATION_CACHE_ENDPOINT_FAILURE_GRACE_PERIOD ||
+				    now() - failureInfo.get().lastRefreshTime >
+				        CLIENT_KNOBS->LOCATION_CACHE_FAILED_ENDPOINT_RETRY_INTERVAL) {
+					onlyEndpointFailedAndNeedRefresh = true;
+					cx->updateFailedEndpointRefreshTime(endpoint);
+				}
+			} else {
+				cx->clearFailedEndpointOnHealthyServer(endpoint);
 			}
 		}
 
-		if (onlyEndpointFailed) {
+		if (onlyEndpointFailedAndNeedRefresh) {
 			cx->invalidateCache(it.first.begin);
 			foundFailed = true;
 		}
 	}
 
 	if (foundFailed) {
+		// Refresh the cache with a new getKeyRangeLocations made to proxies.
 		return getKeyRangeLocations_internal(cx, keys, limit, reverse, info);
 	}
 

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -953,7 +953,8 @@ void DatabaseContext::invalidateCache(const KeyRangeRef& keys) {
 
 void DatabaseContext::setFailedEndpointOnHealthyServer(const Endpoint& endpoint) {
 	if (failedEndpointsOnHealthyServersInfo.find(endpoint) == failedEndpointsOnHealthyServersInfo.end()) {
-		failedEndpointsOnHealthyServersInfo[endpoint] = EndpointFailureInfo { startTime:now(), lastRefreshTime:now() };
+		failedEndpointsOnHealthyServersInfo[endpoint] =
+		EndpointFailureInfo{ startTime : now(), lastRefreshTime : now() };
 	}
 }
 
@@ -1653,6 +1654,35 @@ ACTOR Future<pair<KeyRange, Reference<LocationInfo>>> getKeyLocation_internal(Da
 	}
 }
 
+// Checks if `endpoint` is failed on a healthy server or not. Returns true if we need to refresh the location cache for
+// the endpoint.
+bool checkOnlyEndpointFailed(const Database& cx, const Endpoint& endpoint) {
+	if (IFailureMonitor::failureMonitor().onlyEndpointFailed(endpoint)) {
+		// This endpoint is failed, but the server is still healthy. There are two cases this can happen:
+		//    - There is a recent bounce in the cluster where the endpoints in SSes get updated.
+		//    - The SS is failed and terminated on a server, but the server is kept running.
+		// To account for the first case, we invalidate the cache and issue GetKeyLocation requests to the proxy to
+		// update the cache with the new SS points. However, if the failure is caused by the second case, the
+		// requested key location will continue to be the failed endpoint until the data movement is finished. But
+		// every read will generate a GetKeyLocation request to the proxies (and still getting the failed endpoint
+		// back), which may overload the proxy and affect data movement speed. Therefore, we only refresh the
+		// location cache for short period of time, and after the initial grace period that we keep retrying
+		// resolving key location, we will slow it down to resolve it only once every
+		// `LOCATION_CACHE_FAILED_ENDPOINT_RETRY_INTERVAL`.
+		cx->setFailedEndpointOnHealthyServer(endpoint);
+		const auto& failureInfo = cx->getEndpointFailureInfo(endpoint);
+		ASSERT(failureInfo.present());
+		if (now() - failureInfo.get().startTime < CLIENT_KNOBS->LOCATION_CACHE_ENDPOINT_FAILURE_GRACE_PERIOD ||
+		    now() - failureInfo.get().lastRefreshTime > CLIENT_KNOBS->LOCATION_CACHE_FAILED_ENDPOINT_RETRY_INTERVAL) {
+			cx->updateFailedEndpointRefreshTime(endpoint);
+			return true;
+		}
+	} else {
+		cx->clearFailedEndpointOnHealthyServer(endpoint);
+	}
+	return false;
+}
+
 template <class F>
 Future<pair<KeyRange, Reference<LocationInfo>>> getKeyLocation(Database const& cx,
                                                                Key const& key,
@@ -1666,30 +1696,8 @@ Future<pair<KeyRange, Reference<LocationInfo>>> getKeyLocation(Database const& c
 
 	bool onlyEndpointFailedAndNeedRefresh = false;
 	for (int i = 0; i < ssi.second->size(); i++) {
-		const Endpoint& endpoint = ssi.second->get(i, member).getEndpoint();
-		if (IFailureMonitor::failureMonitor().onlyEndpointFailed(endpoint)) {
-			// This endpoint is failed, but the server is still healthy. There are two cases this can happen:
-			//    - There is a recent bounce in the cluster where the endpoints in SSes get updated.
-			//    - The SS is failed and terminated on a server, but the server is kept running.
-			// To account for the first case, we invalidate the cache and issue GetKeyLocation requests to the proxy to
-			// update the cache with the new SS points. However, if the failure is caused by the second case, the
-			// requested key location will continue to be the failed endpoint until the data movement is finished. But
-			// every read will generate a GetKeyLocation request to the proxies (and still getting the failed endpoint
-			// back), which may overload the proxy and affect data movement speed. Therefore, we only refresh the
-			// location cache for short period of time, and after the initial grace period that we keep retrying
-			// resolving key location, we will slow it down to resolve it only once every
-			// `LOCATION_CACHE_FAILED_ENDPOINT_RETRY_INTERVAL`.
-			cx->setFailedEndpointOnHealthyServer(endpoint);
-			const auto& failureInfo = cx->getEndpointFailureInfo(endpoint);
-			ASSERT(failureInfo.present());
-			if (now() - failureInfo.get().startTime < CLIENT_KNOBS->LOCATION_CACHE_ENDPOINT_FAILURE_GRACE_PERIOD ||
-			    now() - failureInfo.get().lastRefreshTime >
-			        CLIENT_KNOBS->LOCATION_CACHE_FAILED_ENDPOINT_RETRY_INTERVAL) {
-				onlyEndpointFailedAndNeedRefresh = true;
-				cx->updateFailedEndpointRefreshTime(endpoint);
-			}
-		} else {
-			cx->clearFailedEndpointOnHealthyServer(endpoint);
+		if (checkOnlyEndpointFailed(cx, ssi.second->get(i, member).getEndpoint())) {
+			onlyEndpointFailedAndNeedRefresh = true;
 		}
 	}
 
@@ -1766,21 +1774,8 @@ Future<vector<pair<KeyRange, Reference<LocationInfo>>>> getKeyRangeLocations(Dat
 	for (auto& it : locations) {
 		bool onlyEndpointFailedAndNeedRefresh = false;
 		for (int i = 0; i < it.second->size(); i++) {
-			const Endpoint& endpoint = it.second->get(i, member).getEndpoint();
-			if (IFailureMonitor::failureMonitor().onlyEndpointFailed(endpoint)) {
-				// Please refer to `getKeyLocation` about why we keep track of endpoint failure starting and refreshing
-				// time.
-				cx->setFailedEndpointOnHealthyServer(endpoint);
-				const auto& failureInfo = cx->getEndpointFailureInfo(endpoint);
-				ASSERT(failureInfo.present());
-				if (now() - failureInfo.get().startTime < CLIENT_KNOBS->LOCATION_CACHE_ENDPOINT_FAILURE_GRACE_PERIOD ||
-				    now() - failureInfo.get().lastRefreshTime >
-				        CLIENT_KNOBS->LOCATION_CACHE_FAILED_ENDPOINT_RETRY_INTERVAL) {
-					onlyEndpointFailedAndNeedRefresh = true;
-					cx->updateFailedEndpointRefreshTime(endpoint);
-				}
-			} else {
-				cx->clearFailedEndpointOnHealthyServer(endpoint);
+			if (checkOnlyEndpointFailed(cx, it.second->get(i, member).getEndpoint())) {
+				onlyEndpointFailedAndNeedRefresh = true;
 			}
 		}
 

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -1695,7 +1695,6 @@ Future<pair<KeyRange, Reference<LocationInfo>>> getKeyLocation(Database const& c
 
 	if (onlyEndpointFailedAndNeedRefresh) {
 		cx->invalidateCache(key);
-
 		// Refresh the cache with a new getKeyLocations made to proxies.
 		return getKeyLocation_internal(cx, key, info, isBackward);
 	}

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -962,7 +962,6 @@ void DatabaseContext::updateFailedEndpointRefreshTime(const Endpoint& endpoint) 
 		// The endpoint is not failed. Nothing to update.
 		return;
 	}
-
 	failedEndpointsOnHealthyServersInfo[endpoint].lastRefreshTime = now();
 }
 


### PR DESCRIPTION
Cherry-pick #6446 to release 6.3

20220225-201358-zhe-6.3-8127bf61dbe5ffe0           compressed=True data_size=22141129 duration=5380432 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=1:20:17 sanity=False started=100077 stopped=20220225-213415 submitted=20220225-201358 timeout=5400 username=zhe-6.3

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
