### PR TITLE
Bugfix/nosim tests

### DIFF
--- a/flow/flow.cpp
+++ b/flow/flow.cpp
@@ -447,3 +447,9 @@ TEST_CASE("/flow/FlatBuffers/Standalone") {
 	}
 	return Void();
 }
+
+// we need to make sure at least one test of each prefix exists, otherwise
+// the noSim test fails if we compile without RocksDB
+TEST_CASE("noSim/noopTest") {
+	return Void();
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -179,7 +179,9 @@ if(WITH_PYTHON)
   add_fdb_test(TEST_FILES fast/WriteDuringRead.toml)
   add_fdb_test(TEST_FILES fast/WriteDuringReadClean.toml)
   add_fdb_test(TEST_FILES noSim/RandomUnitTests.toml UNIT)
-  add_fdb_test(TEST_FILES noSim/KeyValueStoreRocksDBTest.toml IGNORE) # re-enable as needed for RocksDB. Breaks correctness tests if RocksDB is disabled.
+  if (SSD_ROCKSDB_EXPERIMENTAL)
+    add_fdb_test(TEST_FILES noSim/KeyValueStoreRocksDBTest.toml IGNORE) # re-enable as needed for RocksDB. Breaks correctness tests if RocksDB is disabled.
+  endif()
   add_fdb_test(TEST_FILES rare/CheckRelocation.toml)
   add_fdb_test(TEST_FILES rare/ClogUnclog.toml)
   add_fdb_test(TEST_FILES rare/CloggedCycleWithKills.toml)


### PR DESCRIPTION
noSim tests would fail if compiled without rocks because no noSim tests exist if we don't compile the rocksdb tests. This adds a simple mock-test to make sure this test never fails.

If we compile with rocks we now always run the rocksdb unit tests

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
