### PR TITLE
Set `disableHostname=true` in CycleTestRestart downgrade test

### DIFF
--- a/tests/restarting/to_7.0.0/CycleTestRestart-1.txt
+++ b/tests/restarting/to_7.0.0/CycleTestRestart-1.txt
@@ -1,6 +1,8 @@
 storageEngineExcludeTypes=-1,-2
 maxTLogVersion=6
 disableTss=true
+disableHostname=true
+
 testTitle=Clogged
     clearAfterTest=false
     testName=Cycle


### PR DESCRIPTION
This fixes an issue where old binaries are unable to parse connection strings in simulation.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
