### PR TITLE
Demonstrate that fast alloc thread cleanup doesn't work on osx

### DIFF
--- a/flow/CMakeLists.txt
+++ b/flow/CMakeLists.txt
@@ -188,3 +188,6 @@ if(APPLE)
   target_link_libraries(flow PRIVATE ${IO_KIT} ${CORE_FOUNDATION})
   target_link_libraries(flow_sampling PRIVATE ${IO_KIT} ${CORE_FOUNDATION})
 endif()
+
+add_executable(fast_alloc_test fast_alloc_test.cpp ${CMAKE_SOURCE_DIR}/bindings/c/ThreadCleanup.cpp)
+target_link_libraries(fast_alloc_test PRIVATE flow)

--- a/flow/FastAlloc.h
+++ b/flow/FastAlloc.h
@@ -103,6 +103,8 @@ void recordAllocation(void* ptr, size_t size);
 void recordDeallocation(void* ptr);
 #endif
 
+uint64_t get_high_water_mark();
+
 template <int Size>
 class FastAllocator {
 public:

--- a/flow/fast_alloc_test.cpp
+++ b/flow/fast_alloc_test.cpp
@@ -1,0 +1,24 @@
+#include "FastAlloc.h"
+#include <vector>
+#include <mutex>
+#include <thread>
+#include <iostream>
+
+int main() {
+	constexpr auto Size = 16;
+	for (int i = 0; i < 1000; ++i) {
+		// Create a thread, allocate, free, and join
+		auto thread = std::thread([]() {
+			std::vector<void*> allocations;
+			for (int i = 0; i < 1; ++i) {
+				allocations.push_back(FastAllocator<Size>::allocate());
+			}
+			for (auto* p : allocations) {
+				FastAllocator<Size>::release(p);
+			}
+		});
+		thread.join();
+	}
+	std::cout << "Total Memory\t" << FastAllocator<Size>::getTotalMemory() << std::endl;
+	std::cout << "High water\t" << get_high_water_mark() << std::endl;
+}


### PR DESCRIPTION
Put description here...

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
