### PR TITLE
Fix the compile error on NativeAPI.actor.cpp

### DIFF
--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -1601,7 +1601,7 @@ void DatabaseContext::invalidateCache(const KeyRangeRef& keys) {
 void DatabaseContext::setFailedEndpointOnHealthyServer(const Endpoint& endpoint) {
 	if (failedEndpointsOnHealthyServersInfo.find(endpoint) == failedEndpointsOnHealthyServersInfo.end()) {
 		failedEndpointsOnHealthyServersInfo[endpoint] =
-		EndpointFailureInfo{ startTime : now(), lastRefreshTime : now() };
+		EndpointFailureInfo{ .startTime = now(), .lastRefreshTime = now() };
 	}
 }
 


### PR DESCRIPTION
`{ fieldName : value } ` struct initialization is GNU only, causing clang++ complain

```
/root/src/fdbclient/NativeAPI.actor.cpp:1604:24: error: use of GNU old-style field designator extension [-Werror,-Wgnu-designator]
  EndpointFailureInfo{ startTime : now(), lastRefreshTime : now() };
                       ^~~~~~~~~~~
                       .startTime =
/root/src/fdbclient/NativeAPI.actor.cpp:1604:43: error: use of GNU old-style field designator extension [-Werror,-Wgnu-designator]
  EndpointFailureInfo{ startTime : now(), lastRefreshTime : now() };
                                          ^~~~~~~~~~~~~~~~~
                                          .lastRefreshTime =
```

This patch fixes the compile error using standard C struct initialization

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
