### PR TITLE
Fix several instances where trace events were double-escaping strings

### DIFF
--- a/fdbclient/FDBTypes.h
+++ b/fdbclient/FDBTypes.h
@@ -593,6 +593,11 @@ inline bool selectorInRange(KeySelectorRef const& sel, KeyRangeRef const& range)
 	return sel.getKey() >= range.begin && (sel.isBackward() ? sel.getKey() <= range.end : sel.getKey() < range.end);
 }
 
+template <>
+struct Traceable<KeySelectorRef> : std::true_type {
+	static std::string toString(const KeySelectorRef& value) { return value.toString(); }
+};
+
 template <class Val>
 struct KeyRangeWith : KeyRange {
 	Val value;

--- a/fdbclient/SpecialKeySpace.actor.cpp
+++ b/fdbclient/SpecialKeySpace.actor.cpp
@@ -340,8 +340,8 @@ ACTOR Future<RangeResult> SpecialKeySpace::getRangeAggregationActor(SpecialKeySp
 				moduleBoundary = beginIter->range();
 		} else {
 			TraceEvent(SevInfo, "SpecialKeyCrossModuleRead")
-			    .detail("Begin", begin.toString())
-			    .detail("End", end.toString())
+			    .detail("Begin", begin)
+			    .detail("End", end)
 			    .detail("BoundaryBegin", beginIter->begin())
 			    .detail("BoundaryEnd", beginIter->end());
 			throw special_keys_cross_module_read();

--- a/fdbserver/workloads/ConsistencyCheck.actor.cpp
+++ b/fdbserver/workloads/ConsistencyCheck.actor.cpp
@@ -430,9 +430,7 @@ struct ConsistencyCheckWorkload : TestWorkload {
 			if (serverIndices.size()) {
 				KeyRangeRef range(cacheKey[k].key, (k < cacheKey.size() - 1) ? cacheKey[k + 1].key : allKeys.end);
 				cachedKeysLocationMap.insert(range, cacheServerInterfaces);
-				TraceEvent(SevDebug, "CheckCacheConsistency")
-				    .detail("CachedRange", range.toString())
-				    .detail("Index", k);
+				TraceEvent(SevDebug, "CheckCacheConsistency").detail("CachedRange", range).detail("Index", k);
 			}
 		}
 		// Second, insert corresponding storage servers into the list
@@ -545,8 +543,8 @@ struct ConsistencyCheckWorkload : TestWorkload {
 
 					wait(waitForAll(keyValueFutures));
 					TraceEvent(SevDebug, "CheckCacheConsistencyComparison")
-					    .detail("Begin", req.begin.toString())
-					    .detail("End", req.end.toString())
+					    .detail("Begin", req.begin)
+					    .detail("End", req.end)
 					    .detail("SSInterfaces", describe(iter_ss));
 
 					// Read the resulting entries
@@ -712,7 +710,7 @@ struct ConsistencyCheckWorkload : TestWorkload {
 						begin = firstGreaterThan(result[result.size() - 1].key);
 						ASSERT(begin.getKey() != allKeys.end);
 						lastStartSampleKey = lastSampleKey;
-						TraceEvent(SevDebug, "CacheConsistencyCheckNextBeginKey").detail("Key", begin.toString());
+						TraceEvent(SevDebug, "CacheConsistencyCheckNextBeginKey").detail("Key", begin);
 					} else
 						break;
 				} catch (Error& e) {

--- a/fdbserver/workloads/DataDistributionMetrics.actor.cpp
+++ b/fdbserver/workloads/DataDistributionMetrics.actor.cpp
@@ -96,30 +96,30 @@ struct DataDistributionMetricsWorkload : KVWorkload {
 						TraceEvent(SevError, "TestFailure")
 						    .detail("Reason", "Result mismatches the given begin selector")
 						    .detail("Size", result.size())
-						    .detail("FirstKey", result[0].key.toString())
-						    .detail("SecondKey", result[1].key.toString())
-						    .detail("BeginKeySelector", begin.toString());
+						    .detail("FirstKey", result[0].key)
+						    .detail("SecondKey", result[1].key)
+						    .detail("BeginKeySelector", begin);
 					}
 					if (result[result.size() - 1].key < end.getKey() || result[result.size() - 2].key >= end.getKey()) {
 						++self->errors;
 						TraceEvent(SevError, "TestFailure")
 						    .detail("Reason", "Result mismatches the given end selector")
 						    .detail("Size", result.size())
-						    .detail("FirstKey", result[result.size() - 1].key.toString())
-						    .detail("SecondKey", result[result.size() - 2].key.toString())
-						    .detail("EndKeySelector", end.toString());
+						    .detail("FirstKey", result[result.size() - 1].key)
+						    .detail("SecondKey", result[result.size() - 2].key)
+						    .detail("EndKeySelector", end);
 					}
 					// Debugging traces
 					// TraceEvent(SevDebug, "DDMetricsConsistencyTest")
 					// 	    .detail("Size", result.size())
-					// 	    .detail("FirstKey", result[0].key.toString())
-					// 	    .detail("SecondKey", result[1].key.toString())
-					// 	    .detail("BeginKeySelector", begin.toString());
+					// 	    .detail("FirstKey", result[0].key)
+					// 	    .detail("SecondKey", result[1].key)
+					// 	    .detail("BeginKeySelector", begin);
 					// TraceEvent(SevDebug, "DDMetricsConsistencyTest")
 					// 	    .detail("Size", result.size())
-					// 	    .detail("LastKey", result[result.size() - 1].key.toString())
-					// 	    .detail("SecondLastKey", result[result.size() - 2].key.toString())
-					// 	    .detail("EndKeySelector", end.toString());
+					// 	    .detail("LastKey", result[result.size() - 1].key)
+					// 	    .detail("SecondLastKey", result[result.size() - 2].key)
+					// 	    .detail("EndKeySelector", end);
 				}
 			} catch (Error& e) {
 				// Ignore timed_out error and cross_module_read, the end key selector may read through the end

--- a/fdbserver/workloads/FuzzApiCorrectness.actor.cpp
+++ b/fdbserver/workloads/FuzzApiCorrectness.actor.cpp
@@ -675,7 +675,7 @@ struct FuzzApiCorrectnessWorkload : TestWorkload {
 
 		void augmentTrace(TraceEvent& e) const override {
 			base_type::augmentTrace(e);
-			e.detail("KeySel", keysel.toString());
+			e.detail("KeySel", keysel);
 		}
 	};
 
@@ -726,7 +726,7 @@ struct FuzzApiCorrectnessWorkload : TestWorkload {
 
 		void augmentTrace(TraceEvent& e) const override {
 			base_type::augmentTrace(e);
-			e.detail("KeySel1", keysel1.toString()).detail("KeySel2", keysel2.toString()).detail("Limit", limit);
+			e.detail("KeySel1", keysel1).detail("KeySel2", keysel2).detail("Limit", limit);
 		}
 	};
 
@@ -769,7 +769,7 @@ struct FuzzApiCorrectnessWorkload : TestWorkload {
 
 		void augmentTrace(TraceEvent& e) const override {
 			base_type::augmentTrace(e);
-			e.detail("KeySel1", keysel1.toString()).detail("KeySel2", keysel2.toString());
+			e.detail("KeySel1", keysel1).detail("KeySel2", keysel2);
 			std::stringstream ss;
 			ss << "(" << limits.rows << ", " << limits.minRows << ", " << limits.bytes << ")";
 			e.detail("Limits", ss.str());

--- a/fdbserver/workloads/SpecialKeySpaceCorrectness.actor.cpp
+++ b/fdbserver/workloads/SpecialKeySpaceCorrectness.actor.cpp
@@ -144,8 +144,8 @@ struct SpecialKeySpaceCorrectnessWorkload : TestWorkload {
 			if (!self->compareRangeResult(correctResult, testResult)) {
 				TraceEvent(SevError, "TestFailure")
 				    .detail("Reason", "Results from getRange are inconsistent")
-				    .detail("Begin", begin.toString())
-				    .detail("End", end.toString())
+				    .detail("Begin", begin)
+				    .detail("End", end)
 				    .detail("LimitRows", limit.rows)
 				    .detail("LimitBytes", limit.bytes)
 				    .detail("Reverse", reverse);
@@ -185,8 +185,8 @@ struct SpecialKeySpaceCorrectnessWorkload : TestWorkload {
 			if (!self->compareRangeResult(correctRywResult, testRywResult)) {
 				TraceEvent(SevError, "TestFailure")
 				    .detail("Reason", "Results from getRange(ryw) are inconsistent")
-				    .detail("Begin", begin.toString())
-				    .detail("End", end.toString())
+				    .detail("Begin", begin)
+				    .detail("End", end)
 				    .detail("LimitRows", limit.rows)
 				    .detail("LimitBytes", limit.bytes)
 				    .detail("Reverse", reverse);
@@ -569,8 +569,8 @@ struct SpecialKeySpaceCorrectnessWorkload : TestWorkload {
 					    .detail("TestKey", test_iter->key)
 					    .detail("CorrectValue", correct_iter->value)
 					    .detail("TestValue", test_iter->value)
-					    .detail("Begin", begin.toString())
-					    .detail("End", end.toString())
+					    .detail("Begin", begin)
+					    .detail("End", end)
 					    .detail("Ryw", ryw);
 					had_error = true;
 					++self->wrongResults;
@@ -584,8 +584,8 @@ struct SpecialKeySpaceCorrectnessWorkload : TestWorkload {
 				    .detail("ConflictType", read ? "read" : "write")
 				    .detail("CorrectKey", correct_iter->key)
 				    .detail("CorrectValue", correct_iter->value)
-				    .detail("Begin", begin.toString())
-				    .detail("End", end.toString())
+				    .detail("Begin", begin)
+				    .detail("End", end)
 				    .detail("Ryw", ryw);
 				++correct_iter;
 				had_error = true;
@@ -597,8 +597,8 @@ struct SpecialKeySpaceCorrectnessWorkload : TestWorkload {
 				    .detail("ConflictType", read ? "read" : "write")
 				    .detail("TestKey", test_iter->key)
 				    .detail("TestValue", test_iter->value)
-				    .detail("Begin", begin.toString())
-				    .detail("End", end.toString())
+				    .detail("Begin", begin)
+				    .detail("End", end)
 				    .detail("Ryw", ryw);
 				++test_iter;
 				had_error = true;

--- a/fdbserver/workloads/WriteDuringRead.actor.cpp
+++ b/fdbserver/workloads/WriteDuringRead.actor.cpp
@@ -170,12 +170,12 @@ struct WriteDuringReadWorkload : TestWorkload {
 				res = allKeys.end;
 			if (res != memRes) {
 				TraceEvent(SevError, "WDRGetKeyWrongResult", randomID)
-				    .detail("Key", printable(key.getKey()))
+				    .detail("Key", key.getKey())
 				    .detail("Offset", key.offset)
 				    .detail("OrEqual", key.orEqual)
 				    .detail("Snapshot", snapshot)
-				    .detail("MemoryResult", printable(memRes))
-				    .detail("DbResult", printable(res));
+				    .detail("MemoryResult", memRes)
+				    .detail("DbResult", res);
 				self->success = false;
 			}
 			return Void();
@@ -197,7 +197,7 @@ struct WriteDuringReadWorkload : TestWorkload {
 	                                                  Reverse reverse) {
 		Key beginKey = memoryGetKey(db, begin);
 		Key endKey = memoryGetKey(db, end);
-		//TraceEvent("WDRGetRange").detail("Begin", printable(beginKey)).detail("End", printable(endKey));
+		//TraceEvent("WDRGetRange").detail("Begin", beginKey).detail("End", endKey);
 		if (beginKey >= endKey)
 			return Standalone<VectorRef<KeyValueRef>>();
 
@@ -232,8 +232,8 @@ struct WriteDuringReadWorkload : TestWorkload {
 	                                      bool* doingCommit,
 	                                      int64_t* memLimit) {
 		state UID randomID = nondeterministicRandom()->randomUniqueID();
-		/*TraceEvent("WDRGetRange", randomID).detail("BeginKey", printable(begin.getKey())).detail("BeginOffset", begin.offset).detail("BeginOrEqual", begin.orEqual)
-		    .detail("EndKey", printable(end.getKey())).detail("EndOffset", end.offset).detail("EndOrEqual", end.orEqual)
+		/*TraceEvent("WDRGetRange", randomID).detail("BeginKey", begin.getKey()).detail("BeginOffset", begin.offset).detail("BeginOrEqual", begin.orEqual)
+		    .detail("EndKey", end.getKey()).detail("EndOffset", end.offset).detail("EndOrEqual", end.orEqual)
 		    .detail("Limit", limit.rows).detail("Snapshot", snapshot).detail("Reverse",
 		   reverse).detail("ReadYourWritesDisabled", readYourWritesDisabled);*/
 
@@ -277,10 +277,10 @@ struct WriteDuringReadWorkload : TestWorkload {
 			if (!limit.hasByteLimit() && systemKeyCount == 0) {
 				if (res.size() != memRes.size()) {
 					TraceEvent(SevError, "WDRGetRangeWrongResult", randomID)
-					    .detail("BeginKey", printable(begin.getKey()))
+					    .detail("BeginKey", begin.getKey())
 					    .detail("BeginOffset", begin.offset)
 					    .detail("BeginOrEqual", begin.orEqual)
-					    .detail("EndKey", printable(end.getKey()))
+					    .detail("EndKey", end.getKey())
 					    .detail("EndOffset", end.offset)
 					    .detail("EndOrEqual", end.orEqual)
 					    .detail("LimitRows", limit.rows)
@@ -298,10 +298,10 @@ struct WriteDuringReadWorkload : TestWorkload {
 				for (int i = 0; i < res.size(); i++) {
 					if (res[i] != memRes[i]) {
 						TraceEvent(SevError, "WDRGetRangeWrongResult", randomID)
-						    .detail("BeginKey", printable(begin.getKey()))
+						    .detail("BeginKey", begin.getKey())
 						    .detail("BeginOffset", begin.offset)
 						    .detail("BeginOrEqual", begin.orEqual)
-						    .detail("EndKey", printable(end.getKey()))
+						    .detail("EndKey", end.getKey())
 						    .detail("EndOffset", end.offset)
 						    .detail("EndOrEqual", end.orEqual)
 						    .detail("LimitRows", limit.rows)
@@ -310,8 +310,8 @@ struct WriteDuringReadWorkload : TestWorkload {
 						    .detail("Reverse", reverse)
 						    .detail("Size", memRes.size())
 						    .detail("WrongLocation", i)
-						    .detail("MemoryResultKey", printable(memRes[i].key))
-						    .detail("DbResultKey", printable(res[i].key))
+						    .detail("MemoryResultKey", memRes[i].key)
+						    .detail("DbResultKey", res[i].key)
 						    .detail("MemoryResultValueSize", memRes[i].value.size())
 						    .detail("DbResultValueSize", res[i].value.size())
 						    .detail("ReadYourWritesDisabled", readYourWritesDisabled);
@@ -323,10 +323,10 @@ struct WriteDuringReadWorkload : TestWorkload {
 				if (res.size() > memRes.size() || (res.size() < memRes.size() && !res.more) ||
 				    (res.size() == 0 && res.more && !resized)) {
 					TraceEvent(SevError, "WDRGetRangeWrongResult", randomID)
-					    .detail("BeginKey", printable(begin.getKey()))
+					    .detail("BeginKey", begin.getKey())
 					    .detail("BeginOffset", begin.offset)
 					    .detail("BeginOrEqual", begin.orEqual)
-					    .detail("EndKey", printable(end.getKey()))
+					    .detail("EndKey", end.getKey())
 					    .detail("EndOffset", end.offset)
 					    .detail("EndOrEqual", end.orEqual)
 					    .detail("LimitRows", limit.rows)
@@ -346,10 +346,10 @@ struct WriteDuringReadWorkload : TestWorkload {
 				for (int i = 0; i < res.size(); i++) {
 					if (res[i] != memRes[i]) {
 						TraceEvent(SevError, "WDRGetRangeWrongResult", randomID)
-						    .detail("BeginKey", printable(begin.getKey()))
+						    .detail("BeginKey", begin.getKey())
 						    .detail("BeginOffset", begin.offset)
 						    .detail("BeginOrEqual", begin.orEqual)
-						    .detail("EndKey", printable(end.getKey()))
+						    .detail("EndKey", end.getKey())
 						    .detail("EndOffset", end.offset)
 						    .detail("EndOrEqual", end.orEqual)
 						    .detail("LimitRows", limit.rows)
@@ -358,8 +358,8 @@ struct WriteDuringReadWorkload : TestWorkload {
 						    .detail("Reverse", reverse)
 						    .detail("Size", memRes.size())
 						    .detail("WrongLocation", i)
-						    .detail("MemoryResultKey", printable(memRes[i].key))
-						    .detail("DbResultKey", printable(res[i].key))
+						    .detail("MemoryResultKey", memRes[i].key)
+						    .detail("DbResultKey", res[i].key)
 						    .detail("MemoryResultValueSize", memRes[i].value.size())
 						    .detail("DbResultValueSize", res[i].value.size())
 						    .detail("ReadYourWritesDisabled", readYourWritesDisabled)
@@ -409,7 +409,7 @@ struct WriteDuringReadWorkload : TestWorkload {
 			*memLimit += memRes.expectedSize();
 			if (res != memRes) {
 				TraceEvent(SevError, "WDRGetWrongResult", randomID)
-				    .detail("Key", printable(key))
+				    .detail("Key", key)
 				    .detail("Snapshot", snapshot)
 				    .detail("MemoryResult", memRes.present() ? memRes.get().size() : -1)
 				    .detail("DbResult", res.present() ? res.get().size() : -1)
@@ -439,7 +439,7 @@ struct WriteDuringReadWorkload : TestWorkload {
 		if (readYourWritesDisabled) // Only tests RYW activated watches
 			return Void();
 
-		//TraceEvent("WDRWatch", randomID).detail("Key", printable(key));
+		//TraceEvent("WDRWatch", randomID).detail("Key", key);
 		try {
 			state int changeNum = self->changeCount[key];
 			state Optional<Value> memRes = self->memoryGet(&self->memoryDatabase, key);
@@ -452,7 +452,7 @@ struct WriteDuringReadWorkload : TestWorkload {
 						if (changeNum == self->changeCount[key]) {
 							TraceEvent(SevError, "WDRWatchWrongResult", randomID)
 							    .detail("Reason", "Triggered without changing")
-							    .detail("Key", printable(key))
+							    .detail("Key", key)
 							    .detail("Value", changeNum)
 							    .detail("DuringCommit", *doingCommit);
 						}
@@ -462,9 +462,9 @@ struct WriteDuringReadWorkload : TestWorkload {
 						if (memRes != memRes2) {
 							TraceEvent(SevError, "WDRWatchWrongResult", randomID)
 							    .detail("Reason", "Changed without triggering")
-							    .detail("Key", printable(key))
-							    .detail("Value1", printable(memRes))
-							    .detail("Value2", printable(memRes2));
+							    .detail("Key", key)
+							    .detail("Value1", memRes)
+							    .detail("Value2", memRes2);
 						}
 					}
 				}
@@ -511,8 +511,8 @@ struct WriteDuringReadWorkload : TestWorkload {
 					if (transactionIter->begin() != addedIter->begin() ||
 					    transactionIter->value() != addedIter->value()) {
 						TraceEvent(SevError, "WriteConflictError")
-						    .detail("TransactionKey", printable(transactionIter->begin()))
-						    .detail("AddedKey", printable(addedIter->begin()))
+						    .detail("TransactionKey", transactionIter->begin())
+						    .detail("AddedKey", addedIter->begin())
 						    .detail("TransactionVal", transactionIter->value())
 						    .detail("AddedVal", addedIter->value());
 						failed = true;
@@ -530,12 +530,12 @@ struct WriteDuringReadWorkload : TestWorkload {
 					for (transactionIter = transactionRanges.begin(); transactionIter != transactionRanges.end();
 					     ++transactionIter) {
 						TraceEvent("WCRTransaction")
-						    .detail("Range", printable(transactionIter.range()))
+						    .detail("Range", transactionIter.range())
 						    .detail("Value", transactionIter.value());
 					}
 					for (addedIter = addedRanges.begin(); addedIter != addedRanges.end(); ++addedIter) {
 						TraceEvent("WCRAdded")
-						    .detail("Range", printable(addedIter.range()))
+						    .detail("Range", addedIter.range())
 						    .detail("Value", addedIter.value());
 					}
 				}
@@ -854,7 +854,7 @@ struct WriteDuringReadWorkload : TestWorkload {
 								KeyRange range = self->getRandomRange(self->maxClearSize);
 								self->changeCount.insert(range, changeNum++);
 								bool noConflict = deterministicRandom()->random01() < 0.5;
-								//TraceEvent("WDRClearRange").detail("Begin", printable(range)).detail("NoConflict", noConflict);
+								//TraceEvent("WDRClearRange").detail("Begin", range).detail("NoConflict", noConflict);
 								if (noConflict)
 									tr.setOption(FDBTransactionOptions::NEXT_WRITE_NO_WRITE_CONFLICT_RANGE);
 								tr.clear(range);
@@ -880,7 +880,7 @@ struct WriteDuringReadWorkload : TestWorkload {
 								Key key = self->getRandomKey();
 								self->changeCount.insert(key, changeNum++);
 								bool noConflict = deterministicRandom()->random01() < 0.5;
-								//TraceEvent("WDRClear").detail("Key", printable(key)).detail("NoConflict", noConflict);
+								//TraceEvent("WDRClear").detail("Key", key).detail("NoConflict", noConflict);
 								if (noConflict)
 									tr.setOption(FDBTransactionOptions::NEXT_WRITE_NO_WRITE_CONFLICT_RANGE);
 								tr.clear(key);
@@ -895,7 +895,7 @@ struct WriteDuringReadWorkload : TestWorkload {
 								    &tr, self->getRandomKey(), readYourWritesDisabled, self, &doingCommit, &memLimit));
 							} else if (operationType == 7 && !disableWriteConflictRange) {
 								KeyRange range = self->getRandomRange(self->nodes);
-								//TraceEvent("WDRAddWriteConflict").detail("Range", printable(range));
+								//TraceEvent("WDRAddWriteConflict").detail("Range", range);
 								tr.addWriteConflictRange(range);
 								KeyRangeRef conflict(
 								    range.begin.substr(0,
@@ -949,7 +949,7 @@ struct WriteDuringReadWorkload : TestWorkload {
 									                                            tr.getCachedReadVersion().orDefault(0),
 									                                            normalKeys.end);
 									self->changeCount.insert(range, changeNum++);
-									//TraceEvent("WDRVersionStamp").detail("VersionStampKey", printable(versionStampKey)).detail("Range", printable(range));
+									//TraceEvent("WDRVersionStamp").detail("VersionStampKey", versionStampKey).detail("Range", range);
 									tr.atomicOp(versionStampKey, value, MutationRef::SetVersionstampedKey);
 									tr.clear(range);
 									KeyRangeRef conflict(
@@ -1000,11 +1000,11 @@ struct WriteDuringReadWorkload : TestWorkload {
 									}
 									self->changeCount.insert(key, changeNum++);
 									bool noConflict = deterministicRandom()->random01() < 0.5;
-									//TraceEvent("WDRAtomicOp").detail("Key", printable(key)).detail("Value", value.size()).detail("NoConflict", noConflict);
+									//TraceEvent("WDRAtomicOp").detail("Key", key).detail("Value", value.size()).detail("NoConflict", noConflict);
 									if (noConflict)
 										tr.setOption(FDBTransactionOptions::NEXT_WRITE_NO_WRITE_CONFLICT_RANGE);
 									tr.atomicOp(key, value, opType);
-									//TraceEvent("WDRAtomicOpSuccess").detail("Key", printable(key)).detail("Value", value.size());
+									//TraceEvent("WDRAtomicOpSuccess").detail("Key", key).detail("Value", value.size());
 									if (!noConflict && key.size() <= (key.startsWith(systemKeys.begin)
 									                                      ? CLIENT_KNOBS->SYSTEM_KEY_SIZE_LIMIT
 									                                      : CLIENT_KNOBS->KEY_SIZE_LIMIT))
@@ -1021,7 +1021,7 @@ struct WriteDuringReadWorkload : TestWorkload {
 								Value value = self->getRandomValue();
 								self->changeCount.insert(key, changeNum++);
 								bool noConflict = deterministicRandom()->random01() < 0.5;
-								//TraceEvent("WDRSet").detail("Key", printable(key)).detail("Value", value.size()).detail("NoConflict", noConflict);
+								//TraceEvent("WDRSet").detail("Key", key).detail("Value", value.size()).detail("NoConflict", noConflict);
 								if (noConflict)
 									tr.setOption(FDBTransactionOptions::NEXT_WRITE_NO_WRITE_CONFLICT_RANGE);
 								tr.set(key, value);
@@ -1029,7 +1029,7 @@ struct WriteDuringReadWorkload : TestWorkload {
 								                                      ? CLIENT_KNOBS->SYSTEM_KEY_SIZE_LIMIT
 								                                      : CLIENT_KNOBS->KEY_SIZE_LIMIT))
 									self->addedConflicts.insert(key, true);
-								//TraceEvent("WDRSetSuccess").detail("Key", printable(key)).detail("Value", value.size());
+								//TraceEvent("WDRSetSuccess").detail("Key", key).detail("Value", value.size());
 								self->memoryDatabase[key] = value;
 							}
 						} catch (Error& e) {

--- a/fdbserver/workloads/WriteDuringRead.actor.cpp
+++ b/fdbserver/workloads/WriteDuringRead.actor.cpp
@@ -534,9 +534,7 @@ struct WriteDuringReadWorkload : TestWorkload {
 						    .detail("Value", transactionIter.value());
 					}
 					for (addedIter = addedRanges.begin(); addedIter != addedRanges.end(); ++addedIter) {
-						TraceEvent("WCRAdded")
-						    .detail("Range", addedIter.range())
-						    .detail("Value", addedIter.value());
+						TraceEvent("WCRAdded").detail("Range", addedIter.range()).detail("Value", addedIter.value());
 					}
 				}
 			}


### PR DESCRIPTION
We were converting keys, ranges, and selectors into strings before passing them into trace events in numerous places. This had the effect of causing those strings to be escaped by `printable` twice.

This PR fixes some of the locations where this was occurring.

Passed 10K correctness.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
