### PR TITLE
Add some extra print debugging if we overflow the trace buffer

### DIFF
--- a/flow/Trace.cpp
+++ b/flow/Trace.cpp
@@ -399,6 +399,8 @@ public:
 		// Without this we would never see any trace events from that loop, and it would be more difficult to identify
 		// where the process is actually stuck.
 		if (g_network && g_network->isSimulated() && bufferLength > 1e8) {
+			fprintf(stderr, "Trace log buffer overflow\n");
+			fprintf(stderr, "Last event: %s\n", fields.toString().c_str());
 			// Setting this to 0 avoids a recurse from the assertion trace event and also prevents a situation where
 			// we roll the trace log only to log the single assertion event when using --crash.
 			bufferLength = 0;


### PR DESCRIPTION
This prints the string for the last event that would have been logged.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
