### PR TITLE
Fix several Valgrind errors of uninitialized memory

### DIFF
--- a/fdbserver/ptxn/TLogInterface.h
+++ b/fdbserver/ptxn/TLogInterface.h
@@ -527,6 +527,7 @@ protected:
 			waitFailure = RequestStream<ReplyPromise<Void>>(commit.getEndpoint().getAdjustedEndpoint(6));
 			recoveryFinished = RequestStream<TLogRecoveryFinishedRequest>(commit.getEndpoint().getAdjustedEndpoint(7));
 			snapRequest = RequestStream<TLogSnapRequest>(commit.getEndpoint().getAdjustedEndpoint(8));
+			testInfo = RequestStream<TLogTestInfoRequest>(commit.getEndpoint().getAdjustedEndpoint(9));
 		}
 	}
 };
@@ -554,8 +555,8 @@ struct TLogInterface_PassivelyPull : public TLogInterfaceBase {
 	void serialize(Ar& ar) {
 		TLogInterfaceBase::serializeImpl(ar);
 		if (Ar::isDeserializing) {
-			disablePopRequest = RequestStream<TLogDisablePopRequest>(commit.getEndpoint().getAdjustedEndpoint(9));
-			enablePopRequest = RequestStream<TLogEnablePopRequest>(commit.getEndpoint().getAdjustedEndpoint(10));
+			disablePopRequest = RequestStream<TLogDisablePopRequest>(commit.getEndpoint().getAdjustedEndpoint(10));
+			enablePopRequest = RequestStream<TLogEnablePopRequest>(commit.getEndpoint().getAdjustedEndpoint(11));
 		}
 	}
 

--- a/fdbserver/ptxn/TLogServer.actor.cpp
+++ b/fdbserver/ptxn/TLogServer.actor.cpp
@@ -1798,11 +1798,14 @@ ACTOR Future<Void> serveTLogInterface_PassivelyPull(
 
 			// Update storage teams.
 			for (auto t : req.addedTeams) {
+				auto tags = req.teamToTags.find(t)->second;
+				TraceEvent("TLogAddTeam", self->dbgid).detail("Team", t).detail("Tags", describe(tags));
 				logData->storageTeams.emplace(t, req.teamToTags.find(t)->second);
 				logData->createStorageTeamData(t, logData->storageTeams[t], true, true, false);
 			}
 
 			for (auto& t : req.removedTeams) {
+				TraceEvent("TLogRemoveTeam", self->dbgid).detail("Team", t);
 				logData->removeStorageTeam(t);
 			}
 

--- a/fdbserver/ptxn/test/Driver.actor.cpp
+++ b/fdbserver/ptxn/test/Driver.actor.cpp
@@ -73,11 +73,13 @@ TestDriverOptions::TestDriverOptions(const UnitTestParameters& params)
         params.getInt("messageTransferModel").orDefault(static_cast<int>(DEFAULT_MESSAGE_TRANSFER_MODEL)))) {}
 
 void TestDriverContext::updateServerDBInfo(Reference<AsyncVar<ServerDBInfo>> dbInfo,
+                                           LogEpoch epoch,
                                            const std::vector<ptxn::TLogInterface_PassivelyPull>& interfaces) {
 	ServerDBInfo info;
 	LogSystemConfig& lsConfig = info.logSystemConfig;
 	lsConfig.logSystemType = LogSystemType::teamPartitioned;
 	info.recoveryState = RecoveryState::FULLY_RECOVERED;
+	info.recoveryCount = epoch;
 
 	// For now, assume we only have primary TLog set
 	lsConfig.tLogs.clear();

--- a/fdbserver/ptxn/test/Driver.h
+++ b/fdbserver/ptxn/test/Driver.h
@@ -127,6 +127,7 @@ struct TestDriverContext {
 
 	// Updates a ServerDBInfo object with this context.
 	void updateServerDBInfo(Reference<AsyncVar<ServerDBInfo>> dbInfo,
+	                        LogEpoch epoch,
 	                        const std::vector<ptxn::TLogInterface_PassivelyPull>& interfaces);
 
 	TLogGroup& getTLogGroup(TLogGroupID gid);

--- a/fdbserver/ptxn/test/FakeTLog.actor.cpp
+++ b/fdbserver/ptxn/test/FakeTLog.actor.cpp
@@ -231,6 +231,7 @@ ACTOR Future<Void> fakeTLogPeek(TLogPeekRequest request, std::shared_ptr<FakeTLo
 	state TLogPeekReply reply(request.debugID, serialized.arena(), serialized);
 	reply.beginVersion = firstVersion;
 	reply.endVersion = lastVersion;
+	reply.minKnownCommittedVersion = firstVersion;
 
 	wait(pFakeTLogContext->latency());
 	request.reply.send(reply);

--- a/fdbserver/ptxn/test/RealTLog.actor.cpp
+++ b/fdbserver/ptxn/test/RealTLog.actor.cpp
@@ -136,6 +136,8 @@ ACTOR Future<Void> getTLogCreateActor(std::shared_ptr<TLogDriverContext> pTLogDr
 		}
 	}
 
+	wait(delay(1.0));
+
 	// delete old disk queue files
 	deleteFile(diskQueueFilename + "0." + tLogOptions.diskQueueExtension);
 	deleteFile(diskQueueFilename + "1." + tLogOptions.diskQueueExtension);

--- a/fdbserver/ptxn/test/TestTLogServer.actor.cpp
+++ b/fdbserver/ptxn/test/TestTLogServer.actor.cpp
@@ -363,7 +363,6 @@ ACTOR Future<Void> commitTeams(std::shared_ptr<ptxn::test::TestDriverContext> pC
 	ASSERT_EQ(newTeamCount, oldTeamCount + 1);
 
 	prevVersion = currVersion;
-	currVersion = rep.version;
 	increaseVersion(currVersion);
 	generateMutations(currVersion, ++storageTeamVersion, 1, { storageTeamID }, pContext->commitRecord);
 	auto serialized = serializeMutations(currVersion, storageTeamID, pContext->commitRecord);

--- a/fdbserver/ptxn/test/TestTLogServer.actor.cpp
+++ b/fdbserver/ptxn/test/TestTLogServer.actor.cpp
@@ -342,7 +342,7 @@ ACTOR Future<Void> commitTeams(std::shared_ptr<ptxn::test::TestDriverContext> pC
 	generateMutations(currVersion, ++storageTeamVersion, 1, { storageTeamID }, pContext->commitRecord);
 	auto serialized = serializeMutations(currVersion, storageTeamID, pContext->commitRecord);
 	std::unordered_map<ptxn::StorageTeamID, StringRef> messages = { { storageTeamID, serialized } };
-	state UID newTeam = pContext->storageTeamIDs[2];
+	state UID newTeam = ptxn::test::getNewStorageTeamID(); // Avoid existing teams
 	state std::map<ptxn::StorageTeamID, std::vector<Tag>> teamToTagMap;
 	teamToTagMap.insert(std::make_pair(newTeam, std::vector<Tag>{ Tag(-1, -1) }));
 	ptxn::TLogCommitRequest request(ptxn::test::randomUID(),
@@ -414,7 +414,6 @@ TEST_CASE("/fdbserver/ptxn/test/tlog_server_group_teams") {
 	// Commit validation in real TLog is not supported for now
 	options.skipCommitValidation = true;
 	state std::vector<Future<Void>> actors;
-	state std::vector<Future<Void>> proxies;
 	state std::shared_ptr<ptxn::test::TestDriverContext> pContext = ptxn::test::initTestDriverContext(options);
 
 	state std::string folder = "simfdb/" + deterministicRandom()->randomAlphaNumeric(10);


### PR DESCRIPTION
Manually verified the fixes work.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
