### PR TITLE
Flush all output streams in flushAndExit

### DIFF
--- a/contrib/debug_determinism/debug_determinism.cpp
+++ b/contrib/debug_determinism/debug_determinism.cpp
@@ -40,11 +40,11 @@ extern "C" void __sanitizer_cov_trace_pc_guard(uint32_t* guard) {
 	if (!guard) {
 		return;
 	}
-	fwrite(guard, 1, sizeof(*guard), out);
+	fwrite(guard, sizeof(*guard), 1, out);
 	if (in) {
 		uint32_t theirs;
-		fread(&theirs, 1, sizeof(theirs), in);
-		if (*guard != theirs) {
+		auto read = fread(&theirs, sizeof(theirs), 1, in);
+		if (read != 1 || *guard != theirs) {
 			printf("Non-determinism detected\n");
 			loop_forever();
 		}

--- a/flow/Platform.actor.cpp
+++ b/flow/Platform.actor.cpp
@@ -3231,6 +3231,10 @@ extern "C" void flushAndExit(int exitCode) {
 	flushTraceFileVoid();
 	fflush(stdout);
 	closeTraceFile();
+
+	// Flush all output streams. The original intent is to flush the outfile for contrib/debug_determinism.
+	fflush(nullptr);
+
 #ifdef USE_GCOV
 	__gcov_flush();
 #endif


### PR DESCRIPTION
Also detect reading past the end of the infile for debug_determinism tracing

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
