### PR TITLE
RocksDB increasing background threads to speedup compaction.

### DIFF
--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -339,7 +339,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( REPLACE_CONTENTS_BYTES,                                1e5 );
 
 	// KeyValueStoreRocksDB
-	init( ROCKSDB_BACKGROUND_PARALLELISM,                          0 );
+	init( ROCKSDB_BACKGROUND_PARALLELISM,                          4 );
 	init( ROCKSDB_READ_PARALLELISM,                                4 );
 	// Use a smaller memtable in simulation to avoid OOMs.
 	int64_t memtableBytes = isSimulated ? 32 * 1024 : 512 * 1024 * 1024;
@@ -366,6 +366,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( ROCKSDB_WRITE_RATE_LIMITER_AUTO_TUNE,                 true );
 	init( ROCKSDB_PERFCONTEXT_ENABLE,                          false ); if( randomize && BUGGIFY ) ROCKSDB_PERFCONTEXT_ENABLE = deterministicRandom()->coinflip() ? false : true;
 	init( ROCKSDB_PERFCONTEXT_SAMPLE_RATE, 					  0.0001 );
+	init( ROCKSDB_MAX_SUBCOMPACTIONS,                              2 );
 
 	// Leader election
 	bool longLeaderElection = randomize && BUGGIFY;

--- a/fdbclient/ServerKnobs.h
+++ b/fdbclient/ServerKnobs.h
@@ -297,6 +297,7 @@ public:
 	bool ROCKSDB_WRITE_RATE_LIMITER_AUTO_TUNE;
 	bool ROCKSDB_PERFCONTEXT_ENABLE; // Enable rocks perf context metrics. May cause performance overhead
 	double ROCKSDB_PERFCONTEXT_SAMPLE_RATE;
+	int ROCKSDB_MAX_SUBCOMPACTIONS;
 
 	// Leader election
 	int MAX_NOTIFICATIONS;

--- a/fdbserver/KeyValueStoreRocksDB.actor.cpp
+++ b/fdbserver/KeyValueStoreRocksDB.actor.cpp
@@ -194,6 +194,9 @@ rocksdb::Options getOptions() {
 	if (SERVER_KNOBS->ROCKSDB_BACKGROUND_PARALLELISM > 0) {
 		options.IncreaseParallelism(SERVER_KNOBS->ROCKSDB_BACKGROUND_PARALLELISM);
 	}
+	if (SERVER_KNOBS->ROCKSDB_MAX_SUBCOMPACTIONS > 0) {
+		options.max_subcompactions = SERVER_KNOBS->ROCKSDB_MAX_SUBCOMPACTIONS;
+	}
 
 	options.statistics = rocksdb::CreateDBStatistics();
 	options.statistics->set_stats_level(rocksdb::kExceptHistogramOrTimers);


### PR DESCRIPTION
RocksDB increasing background threads to speedup compaction.
max_background_compactions = 4;  // Maximum number of concurrent background jobs(threads used for flush and compaction)
max_subcompactions = 2;   // Maximum number of threads that will concurrently perform a compaction job by breaking it into multiple smaller ones that are run simultaneously

Why?
1)To give more cpu resources/time for compaction, as compaction is giving low priority and always postponed to do until we reach the thresholds.
2)Observed that a SS having high(>80 billion bytes) pendingCompactionBytes is not using 100% CPU. So, with this we can use the unused CPU for compaction.
3)We see write stalls upto 50 seconds in the case where we have lot of pending compacted data in L0 of LSM. The data in L0 to L1 mostly cannot be compacted parallely, so setting max_subcompactions to 2 would help.

Testing:
-Splunk Stat graphs posted in fab-storage-layer group.
-Correctness test passed.
-Perf Test Output:
LOAD to fill 30% of cluster:
INSERT_AFTER 106628.902512 ops/sec 50th 1 90th 2 99th 11111 99.9th 1505279 99.99th 2854911 (us) 2nd run
INSERT_BEFORE 115697.527355 ops/sec 50th 1 90th 3 99th 4843 99.9th 957951 99.99th 5222399 (us)
Workload CK:
INSERT_AFTER 36163.807261 ops/sec 50th 2 90th 26 99th 147 99.9th 286 99.99th 585 (us)
INSERT_BEFORE 39019.169467 ops/sec 50th 2 90th 26 99th 142 99.9th 271 99.99th 546 (us)
SCAN_AFTER 501808.156087 ops/sec 50th 1217 90th 2105 99th 8415 99.9th 18831 99.99th 41119 (us)
SCAN_BEFORE 541901.519770 ops/sec 50th 1131 90th 2005 99th 7479 99.9th 14407 99.99th 29919 (us)
Throughtout decreased for both insert and scan. This is expected, as we are using comparatively more CPU for compaction and I think this would beneficial if the load continues to run for long hours.

Splunk Observations:
1)Avg(PendingCompactionBytes) is low
2)Better CPU usage of SS
3)Less write stalls
4)Number of parallel running compactions is 3 in atleast 60% of the workload time.



# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
