### PR TITLE
Fix ignoring test exit codes

### DIFF
--- a/tests/TestRunner/TestRunner.py
+++ b/tests/TestRunner/TestRunner.py
@@ -409,7 +409,7 @@ def run_simulation_test(basedir, options):
     if len(os.listdir(wd)) == 0:
         print("Delete {} - empty".format(wd))
         os.rmdir(wd)
-    return res
+    return res and proc.returncode == 0
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Take into account test exit codes.
Actually, if a test fails without logging an error with severity = 40, it may still pass