### PR TITLE
Fix conflict between two recent merges by using the new errorUnsuppressed function

### DIFF
--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -1058,7 +1058,7 @@ ACTOR static Future<Void> backgroundGrvUpdater(DatabaseContext* cx) {
 					    .detail("CachedReadVersion", cx->getCachedReadVersion())
 					    .detail("CachedTime", cx->getLastGrvTime());
 				} catch (Error& e) {
-					TraceEvent(SevInfo, "BackgroundGrvUpdaterTxnError").error(e, true);
+					TraceEvent(SevInfo, "BackgroundGrvUpdaterTxnError").errorUnsuppressed(e);
 					wait(tr.onError(e));
 				}
 			} else {
@@ -1069,7 +1069,7 @@ ACTOR static Future<Void> backgroundGrvUpdater(DatabaseContext* cx) {
 			}
 		}
 	} catch (Error& e) {
-		TraceEvent(SevInfo, "BackgroundGrvUpdaterFailed").error(e, true);
+		TraceEvent(SevInfo, "BackgroundGrvUpdaterFailed").errorUnsuppressed(e);
 		throw;
 	}
 }

--- a/fdbserver/workloads/SidebandSingle.actor.cpp
+++ b/fdbserver/workloads/SidebandSingle.actor.cpp
@@ -161,7 +161,7 @@ struct SidebandSingleWorkload : TestWorkload {
 								wait(store(val2, tr2.get(messageKey)));
 								break;
 							} catch (Error& e) {
-								TraceEvent("DebugSidebandNoCacheError").error(e, true);
+								TraceEvent("DebugSidebandNoCacheError").errorUnsuppressed(e);
 								wait(tr2.onError(e));
 							}
 						}
@@ -178,7 +178,7 @@ struct SidebandSingleWorkload : TestWorkload {
 					}
 					break;
 				} catch (Error& e) {
-					TraceEvent("DebugSidebandCheckError").error(e, true);
+					TraceEvent("DebugSidebandCheckError").errorUnsuppressed(e);
 					wait(tr.onError(e));
 				}
 			}


### PR DESCRIPTION
The GRV caching PR used `TraceEvent().error(e, true)`, which was removed in another recent commit. This updates those calls to use the new `errorUnsuppressed` function and fixes the build.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
