### PR TITLE
Fix bug in conflict range test due to system key changes (7.0)

### DIFF
--- a/fdbserver/workloads/ConflictRange.actor.cpp
+++ b/fdbserver/workloads/ConflictRange.actor.cpp
@@ -328,7 +328,8 @@ struct ConflictRangeWorkload : TestWorkload {
 
 					if (res.size() == originalResults.size()) {
 						for (int i = 0; i < res.size(); i++) {
-							if (res[i] != originalResults[i]) {
+							if (res[i] != originalResults[i] &&
+							    !(res[i].key.startsWith("\xff"_sr) && originalResults[i].key.startsWith("\xff"_sr))) {
 								TraceEvent(SevError, "ConflictRangeError")
 								    .detail("Info", "No conflict returned, however results do not match")
 								    .detail("Original",


### PR DESCRIPTION
Backports https://github.com/apple/foundationdb/pull/6562 and https://github.com/apple/foundationdb/pull/6565 to 7.0

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
