### PR TITLE
Add version vector microbenchmark

### DIFF
--- a/flowbench/BenchVersionVector.cpp
+++ b/flowbench/BenchVersionVector.cpp
@@ -1,0 +1,51 @@
+/*
+ * BenchVersionVector.cpp
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2022 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "benchmark/benchmark.h"
+#include "fdbclient/VersionVector.h"
+#include <cstdint>
+
+static void bench_vv_getdelta(benchmark::State& benchState) {
+	int64_t tags = benchState.range(0);
+	Version version = 100000;
+	VersionVector vv(version);
+
+	int i = 0;
+	for (int i = 0; i < tags; i++) {
+		vv.setVersion(Tag(0, i), ++version);
+	}
+
+	i = 0;
+	const int64_t numDeltas = benchState.range(1);
+	while (benchState.KeepRunning()) {
+		vv.setVersion(Tag(0, i++), ++version);
+		i %= tags;
+
+		for (int j = 0; j < numDeltas; j++) {
+			VersionVector delta;
+			vv.getDelta(version - j, delta);
+			benchmark::DoNotOptimize(delta);
+		}
+	}
+	benchState.SetItemsProcessed(numDeltas * static_cast<long>(benchState.iterations()));
+	benchState.counters.insert({ { "Tags", tags }, { "getDeltaTimes", numDeltas } });
+}
+
+BENCHMARK(bench_vv_getdelta)->Ranges({ { 1 << 4, 1 << 10 }, { 1, 1 << 10 } })->ReportAggregatesOnly(true);

--- a/flowbench/CMakeLists.txt
+++ b/flowbench/CMakeLists.txt
@@ -12,6 +12,7 @@ set(FLOWBENCH_SRCS
   BenchRef.cpp
   BenchStream.actor.cpp
   BenchTimer.cpp
+  BenchVersionVector.cpp
   GlobalData.h
   GlobalData.cpp)
 


### PR DESCRIPTION
This one measures cost of "getDelta" calls:

```
./flowbench --benchmark_filter=bench_vv
2022-03-08T22:01:42+00:00
Running ./cbuild_output/bin/flowbench
Run on (32 X 1789.72 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x16)
  L1 Instruction 32 KiB (x16)
  L2 Unified 1024 KiB (x16)
  L3 Unified 36608 KiB (x1)
Load Average: 0.33, 0.51, 1.05
--------------------------------------------------------------------------------------
Benchmark                            Time             CPU   Iterations UserCounters...
--------------------------------------------------------------------------------------
bench_vv_getdelta/16/1            33.9 ns         33.9 ns     20604111 Tags=16 getDeltaTimes=1 items_per_second=29.514M/s
bench_vv_getdelta/64/1            33.5 ns         33.5 ns     20989482 Tags=64 getDeltaTimes=1 items_per_second=29.8637M/s
bench_vv_getdelta/512/1           36.5 ns         36.5 ns     19703013 Tags=512 getDeltaTimes=1 items_per_second=27.3722M/s
bench_vv_getdelta/1024/1          35.2 ns         35.2 ns     19945561 Tags=1024 getDeltaTimes=1 items_per_second=28.4083M/s
bench_vv_getdelta/16/8            6340 ns         6340 ns       110117 Tags=16 getDeltaTimes=8 items_per_second=1.26184M/s
bench_vv_getdelta/64/8            7257 ns         7257 ns        96336 Tags=64 getDeltaTimes=8 items_per_second=1.10235M/s
bench_vv_getdelta/512/8          13844 ns        13844 ns        51522 Tags=512 getDeltaTimes=8 items_per_second=577.871k/s
bench_vv_getdelta/1024/8         34612 ns        34612 ns        20470 Tags=1024 getDeltaTimes=8 items_per_second=231.137k/s
bench_vv_getdelta/16/64         200514 ns       200513 ns         3498 Tags=16 getDeltaTimes=64 items_per_second=319.182k/s
bench_vv_getdelta/64/64         500066 ns       500057 ns         1000 Tags=64 getDeltaTimes=64 items_per_second=127.985k/s
bench_vv_getdelta/512/64        570166 ns       570131 ns         1222 Tags=512 getDeltaTimes=64 items_per_second=112.255k/s
bench_vv_getdelta/1024/64       747168 ns       747156 ns          939 Tags=1024 getDeltaTimes=64 items_per_second=85.6581k/s
bench_vv_getdelta/16/512       1749315 ns      1749305 ns          401 Tags=16 getDeltaTimes=512 items_per_second=292.688k/s
bench_vv_getdelta/64/512       6656289 ns      6656249 ns          105 Tags=64 getDeltaTimes=512 items_per_second=76.9202k/s
bench_vv_getdelta/512/512     36588584 ns     36588013 ns           19 Tags=512 getDeltaTimes=512 items_per_second=13.9937k/s
bench_vv_getdelta/1024/512    37691398 ns     37691154 ns           19 Tags=1024 getDeltaTimes=512 items_per_second=13.5841k/s
bench_vv_getdelta/16/1024      3616253 ns      3616233 ns          193 Tags=16 getDeltaTimes=1024 items_per_second=283.168k/s
bench_vv_getdelta/64/1024     13715322 ns     13715233 ns           51 Tags=64 getDeltaTimes=1024 items_per_second=74.6615k/s
bench_vv_getdelta/512/1024   112346008 ns    112344280 ns            6 Tags=512 getDeltaTimes=1024 items_per_second=9.11484k/s
bench_vv_getdelta/1024/1024  157170467 ns    157169544 ns            4 Tags=1024 getDeltaTimes=1024 items_per_second=6.51526k/s
```

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
