### PR TITLE
When storing coordinators string, we should concatenate by comma.

### DIFF
--- a/fdbcli/CoordinatorsCommand.actor.cpp
+++ b/fdbcli/CoordinatorsCommand.actor.cpp
@@ -132,7 +132,7 @@ ACTOR Future<bool> changeCoordinators(Reference<IDatabase> db, std::vector<Strin
 						throw;
 					}
 				}
-				std::string new_coordinators_str = boost::algorithm::join(newCoordinatorslist, ", ");
+				std::string new_coordinators_str = boost::algorithm::join(newCoordinatorslist, ",");
 				tr->set(fdb_cli::coordinatorsProcessSpecialKey, new_coordinators_str);
 			}
 			wait(safeThreadFutureToFuture(tr->commit()));


### PR DESCRIPTION
We are splitting by comma https://github.com/apple/foundationdb/blob/402fa4dd9e2151807fc8a89d6471f2da41e41d4a/fdbclient/SpecialKeySpace.actor.cpp#L1686 So when we concatenating, if we use ", ", there will be an extra space, causing hostname parsing error. NetworkAddress happens not to have the same issue because it uses sscanf. https://github.com/apple/foundationdb/blob/402fa4dd9e2151807fc8a89d6471f2da41e41d4a/flow/network.cpp#L119

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
