### PR TITLE
Use boost::flat_map and optimize getDelta/applyDelta

### DIFF
--- a/fdbclient/VersionVector.h
+++ b/fdbclient/VersionVector.h
@@ -40,9 +40,9 @@ struct VersionVector {
 	VersionVector(Version version) : maxVersion(version) {}
 
 private:
-	inline void setVersionNoCheck(const Tag& tag, Version version) {
-		versions[tag] = version;
-	}
+	// Only invoked by getDelta() and applyDelta(), where tag has been validated
+	// and version is guaranteed to be larger than the existing value.
+	inline void setVersionNoCheck(const Tag& tag, Version version) { versions[tag] = version; }
 
 public:
 	Version getMaxVersion() const { return maxVersion; }
@@ -122,17 +122,11 @@ public:
 		if (CLIENT_KNOBS->SEND_ENTIRE_VERSION_VECTOR) {
 			*this = delta;
 		} else {
-			std::map<Version, std::set<Tag>> tmpVersionMap; // order versions
 			for (const auto& [tag, version] : delta.versions) {
 				if (version > maxVersion) {
-					tmpVersionMap[version].insert(tag);
+					setVersionNoCheck(tag, version);
 				}
 			}
-
-			for (auto& [version, tags] : tmpVersionMap) {
-				setVersion(tags, version);
-			}
-
 			maxVersion = delta.maxVersion;
 		}
 	}

--- a/fdbclient/VersionVector.h
+++ b/fdbclient/VersionVector.h
@@ -23,15 +23,14 @@
 
 #pragma once
 
-#include <map>
+#include <boost/container/flat_map.hpp>
 #include <set>
-#include <unordered_map>
 
 #include "fdbclient/FDBTypes.h"
 #include "fdbclient/Knobs.h"
 
 struct VersionVector {
-	std::map<Tag, Version> versions;
+	boost::container::flat_map<Tag, Version> versions;
 	Version maxVersion; // Specifies the max version in this version vector. (Note:
 	                    // there may or may not be a corresponding entry for this
 	                    // version in the "versions" map.)

--- a/flow/flat_buffers.h
+++ b/flow/flat_buffers.h
@@ -21,6 +21,7 @@
 #pragma once
 
 #include <algorithm>
+#include <boost/container/flat_map.hpp>
 #include <iterator>
 #include <cstring>
 #include <functional>
@@ -206,6 +207,30 @@ struct vector_like_traits<std::map<Key, T, Compare, Allocator>> : std::true_type
 template <class Key, class T, class Hash, class Pred, class Allocator>
 struct vector_like_traits<std::unordered_map<Key, T, Hash, Pred, Allocator>> : std::true_type {
 	using Vec = std::unordered_map<Key, T, Hash, Pred, Allocator>;
+	using value_type = std::pair<Key, T>;
+	using iterator = typename Vec::const_iterator;
+	using insert_iterator = std::insert_iterator<Vec>;
+
+	template <class Context>
+	static size_t num_entries(const Vec& v, Context&) {
+		return v.size();
+	}
+	template <class Context>
+	static void reserve(Vec& v, size_t size, Context&) {}
+
+	template <class Context>
+	static insert_iterator insert(Vec& v, Context&) {
+		return std::inserter(v, v.end());
+	}
+	template <class Context>
+	static iterator begin(const Vec& v, Context&) {
+		return v.begin();
+	}
+};
+
+template <class Key, class T, class Compare, class Allocator>
+struct vector_like_traits<boost::container::flat_map<Key, T, Compare, Allocator>> : std::true_type {
+	using Vec = boost::container::flat_map<Key, T, Compare, Allocator>;
 	using value_type = std::pair<Key, T>;
 	using iterator = typename Vec::const_iterator;
 	using insert_iterator = std::insert_iterator<Vec>;

--- a/flow/serialize.h
+++ b/flow/serialize.h
@@ -22,17 +22,19 @@
 #define FLOW_SERIALIZE_H
 #pragma once
 
-#include <stdint.h>
+#include <algorithm>
 #include <array>
+#include <boost/container/flat_map.hpp>
+#include <deque>
 #include <set>
-#include "flow/ProtocolVersion.h"
-#include "flow/Error.h"
+#include <stdint.h>
+
 #include "flow/Arena.h"
+#include "flow/Error.h"
 #include "flow/FileIdentifier.h"
 #include "flow/ObjectSerializer.h"
+#include "flow/ProtocolVersion.h"
 #include "flow/network.h"
-#include <algorithm>
-#include <deque>
 
 // Though similar, is_binary_serializable cannot be replaced by std::is_pod, as doing so would prefer
 // memcpy over a defined serialize() method on a POD struct.  As not all of our structs are packed,
@@ -257,6 +259,27 @@ inline void save(Archive& ar, const std::map<K, V>& value) {
 }
 template <class Archive, class K, class V>
 inline void load(Archive& ar, std::map<K, V>& value) {
+	int s;
+	ar >> s;
+	value.clear();
+	for (int i = 0; i < s; ++i) {
+		std::pair<K, V> p;
+		ar >> p.first >> p.second;
+		value.emplace(p);
+	}
+	ASSERT(ar.protocolVersion().isValid());
+}
+
+template <class Archive, class K, class V>
+inline void save(Archive& ar, const boost::container::flat_map<K, V>& value) {
+	ar << (int)value.size();
+	for (const auto& it : value) {
+		ar << it.first << it.second;
+	}
+	ASSERT(ar.protocolVersion().isValid());
+}
+template <class Archive, class K, class V>
+inline void load(Archive& ar, boost::container::flat_map<K, V>& value) {
 	int s;
 	ar >> s;
 	value.clear();


### PR DESCRIPTION
Introduce setVersionNoCheck() to avoid building a temporary map.
`std::map` is faster than `std::unordered_map` in benchmarks, while `boost::flat_map` beats both.

boost::flat_map is the fastest
bench_vv_getdelta/512/1024     8768606 ns      8768555 ns           80 Tags=512 getDeltaTimes=1024 items_per_second=116.781k/s
bench_vv_getdelta/1024/1024   12051740 ns     12051549 ns           58 Tags=1024 getDeltaTimes=1024 items_per_second=84.9683k/s

std::unordered_map
bench_vv_getdelta/512/1024    43800487 ns     43799915 ns           16 Tags=512 getDeltaTimes=1024 items_per_second=23.379k/s
bench_vv_getdelta/1024/1024   64894719 ns     64893852 ns           11 Tags=1024 getDeltaTimes=1024 items_per_second=15.7796k/s

std::map
bench_vv_getdelta/512/1024    34068779 ns     34068233 ns           21 Tags=512 getDeltaTimes=1024 items_per_second=30.0573k/s
bench_vv_getdelta/1024/1024   49867913 ns     49852281 ns           14 Tags=1024 getDeltaTimes=1024 items_per_second=20.5407k/s

Correctness found 2 timeout failures and 1 assertion failure (NativeAPI.actor.cpp 230), which reproduced at fe0c13797, i.e., without this PR:
```
-r simulation --crash --logsize 1024MB -f ./foundationdb/tests/rare/SwizzledLargeApiCorrectness.toml -s 220943799 -b on
-r simulation --crash --logsize 1024MB -f ./foundationdb/tests/fast/KillRegionCycle.toml -s 343565765 -b on
-r simulation --crash --logsize 1024MB -f ./foundationdb/tests/slow/DDBalanceAndRemoveStatus.toml -s 559021579 -b on
```
So these failures are unrelated to this PR.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
