### PR TITLE
Mark `Smoother::smooth*` methods `const`

### DIFF
--- a/fdbclient/DatabaseContext.h
+++ b/fdbclient/DatabaseContext.h
@@ -107,13 +107,13 @@ public:
 
 	void addReleased(int released) { smoothReleased.addDelta(released); }
 
-	bool expired() { return expiration <= now(); }
+	bool expired() const { return expiration <= now(); }
 
 	void updateChecked() { lastCheck = now(); }
 
-	bool canRecheck() { return lastCheck < now() - CLIENT_KNOBS->TAG_THROTTLE_RECHECK_INTERVAL; }
+	bool canRecheck() const { return lastCheck < now() - CLIENT_KNOBS->TAG_THROTTLE_RECHECK_INTERVAL; }
 
-	double throttleDuration() {
+	double throttleDuration() const {
 		if (expiration <= now()) {
 			return 0.0;
 		}

--- a/fdbrpc/LoadBalance.actor.h
+++ b/fdbrpc/LoadBalance.actor.h
@@ -490,7 +490,7 @@ Future<REPLY_TYPE(Request)> loadBalance(
 
 			RequestStream<Request> const* thisStream = &alternatives->get(i, channel);
 			if (!IFailureMonitor::failureMonitor().getState(thisStream->getEndpoint()).failed) {
-				auto& qd = model->getMeasurement(thisStream->getEndpoint().token.first());
+				auto const& qd = model->getMeasurement(thisStream->getEndpoint().token.first());
 				if (now() > qd.failedUntil) {
 					double thisMetric = qd.smoothOutstanding.smoothTotal();
 					double thisTime = qd.latency;
@@ -529,7 +529,7 @@ Future<REPLY_TYPE(Request)> loadBalance(
 			for (int i = alternatives->countBest(); i < alternatives->size(); i++) {
 				RequestStream<Request> const* thisStream = &alternatives->get(i, channel);
 				if (!IFailureMonitor::failureMonitor().getState(thisStream->getEndpoint()).failed) {
-					auto& qd = model->getMeasurement(thisStream->getEndpoint().token.first());
+					auto const& qd = model->getMeasurement(thisStream->getEndpoint().token.first());
 					if (now() > qd.failedUntil) {
 						double thisMetric = qd.smoothOutstanding.smoothTotal();
 						double thisTime = qd.latency;

--- a/fdbrpc/QueueModel.cpp
+++ b/fdbrpc/QueueModel.cpp
@@ -50,7 +50,7 @@ void QueueModel::endRequest(uint64_t id, double latency, double penalty, double 
 	}
 }
 
-QueueData& QueueModel::getMeasurement(uint64_t id) {
+QueueData const& QueueModel::getMeasurement(uint64_t id) {
 	return data[id]; // return smoothed penalty
 }
 

--- a/fdbrpc/QueueModel.h
+++ b/fdbrpc/QueueModel.h
@@ -93,7 +93,7 @@ public:
 	// 	 - futureVersion: indicates whether there was "future version" error or
 	//					  not.
 	void endRequest(uint64_t id, double latency, double penalty, double delta, bool clean, bool futureVersion);
-	QueueData& getMeasurement(uint64_t id);
+	QueueData const& getMeasurement(uint64_t id);
 
 	// Starts a new request to storage server with `id`. If the storage
 	// server contains a penalty, add it to the queue size, and return the

--- a/fdbrpc/Smoother.h
+++ b/fdbrpc/Smoother.h
@@ -65,10 +65,20 @@ public:
 	}
 };
 
-// TODO: Improve encapsulation
-struct TimerSmoother {
+class TimerSmoother {
 	// Times (t) are expected to be nondecreasing
 
+	double eFoldingTime;
+	double total;
+	mutable double time, estimate;
+
+	void update(double t) const {
+		double elapsed = t - time;
+		time = t;
+		estimate += (total - estimate) * (1 - exp(-elapsed / eFoldingTime));
+	}
+
+public:
 	explicit TimerSmoother(double eFoldingTime) : eFoldingTime(eFoldingTime) { reset(0); }
 	void reset(double value) {
 		time = 0;
@@ -82,24 +92,17 @@ struct TimerSmoother {
 		total += delta;
 	}
 	// smoothTotal() is a continuous (under)estimate of the sum of all addDeltas()
-	double smoothTotal(double t = timer()) {
+	double smoothTotal(double t = timer()) const {
 		update(t);
 		return estimate;
 	}
 	// smoothRate() is d/dt[smoothTotal], and is NOT continuous
-	double smoothRate(double t = timer()) {
+	double smoothRate(double t = timer()) const {
 		update(t);
 		return (total - estimate) / eFoldingTime;
 	}
 
-	void update(double t) {
-		double elapsed = t - time;
-		time = t;
-		estimate += (total - estimate) * (1 - exp(-elapsed / eFoldingTime));
-	}
-
-	double eFoldingTime;
-	double time, total, estimate;
+	double getTotal() const { return total; }
 };
 
 #endif

--- a/fdbserver/DataDistribution.actor.h
+++ b/fdbserver/DataDistribution.actor.h
@@ -315,29 +315,23 @@ struct StorageWiggleMetrics {
 
 	template <class Ar>
 	void serialize(Ar& ar) {
+		double step_total, round_total;
+		if (!ar.isDeserializing) {
+			step_total = smoothed_wiggle_duration.getTotal();
+			round_total = smoothed_round_duration.getTotal();
+		}
+		serializer(ar,
+		           last_wiggle_start,
+		           last_wiggle_finish,
+		           step_total,
+		           finished_wiggle,
+		           last_round_start,
+		           last_round_finish,
+		           round_total,
+		           finished_round);
 		if (ar.isDeserializing) {
-			double step_total, round_total;
-			serializer(ar,
-			           last_wiggle_start,
-			           last_wiggle_finish,
-			           step_total,
-			           finished_wiggle,
-			           last_round_start,
-			           last_round_finish,
-			           round_total,
-			           finished_round);
 			smoothed_round_duration.reset(round_total);
 			smoothed_wiggle_duration.reset(step_total);
-		} else {
-			serializer(ar,
-			           last_wiggle_start,
-			           last_wiggle_finish,
-			           smoothed_wiggle_duration.total,
-			           finished_wiggle,
-			           last_round_start,
-			           last_round_finish,
-			           smoothed_round_duration.total,
-			           finished_round);
 		}
 	}
 
@@ -375,14 +369,14 @@ struct StorageWiggleMetrics {
 		result["last_round_finish_datetime"] = timerIntToGmt(last_round_finish);
 		result["last_round_start_timestamp"] = last_round_start;
 		result["last_round_finish_timestamp"] = last_round_finish;
-		result["smoothed_round_seconds"] = smoothed_round_duration.estimate;
+		result["smoothed_round_seconds"] = smoothed_round_duration.smoothTotal();
 		result["finished_round"] = finished_round;
 
 		result["last_wiggle_start_datetime"] = timerIntToGmt(last_wiggle_start);
 		result["last_wiggle_finish_datetime"] = timerIntToGmt(last_wiggle_finish);
 		result["last_wiggle_start_timestamp"] = last_wiggle_start;
 		result["last_wiggle_finish_timestamp"] = last_wiggle_finish;
-		result["smoothed_wiggle_seconds"] = smoothed_wiggle_duration.estimate;
+		result["smoothed_wiggle_seconds"] = smoothed_wiggle_duration.smoothTotal();
 		result["finished_wiggle"] = finished_wiggle;
 		return result;
 	}

--- a/fdbserver/DataDistribution.actor.h
+++ b/fdbserver/DataDistribution.actor.h
@@ -170,7 +170,7 @@ public:
 	//       intersecting shards.
 
 	int getNumberOfShards(UID ssID) const;
-	std::vector<KeyRange> getShardsFor(Team team);
+	std::vector<KeyRange> getShardsFor(Team team) const;
 	bool hasShards(Team team) const;
 
 	// The first element of the pair is either the source for non-moving shards or the destination team for in-flight
@@ -180,7 +180,7 @@ public:
 	void defineShard(KeyRangeRef keys);
 	void moveShard(KeyRangeRef keys, std::vector<Team> destinationTeam);
 	void finishMove(KeyRangeRef keys);
-	void check();
+	void check() const;
 
 private:
 	struct OrderByTeamKey {
@@ -363,7 +363,7 @@ struct StorageWiggleMetrics {
 		});
 	}
 
-	StatusObject toJSON() {
+	StatusObject toJSON() const {
 		StatusObject result;
 		result["last_round_start_datetime"] = timerIntToGmt(last_round_start);
 		result["last_round_finish_datetime"] = timerIntToGmt(last_round_finish);
@@ -383,7 +383,7 @@ struct StorageWiggleMetrics {
 };
 
 struct StorageWiggler : ReferenceCounted<StorageWiggler> {
-	DDTeamCollection* teamCollection;
+	DDTeamCollection const* teamCollection;
 	StorageWiggleMetrics metrics;
 
 	// data structures
@@ -410,8 +410,8 @@ struct StorageWiggler : ReferenceCounted<StorageWiggler> {
 	void removeServer(const UID& serverId);
 	// update metadata and adjust priority_queue
 	void updateMetadata(const UID& serverId, const StorageMetadataType& metadata);
-	bool contains(const UID& serverId) { return pq_handles.count(serverId) > 0; }
-	bool empty() { return wiggle_pq.empty(); }
+	bool contains(const UID& serverId) const { return pq_handles.count(serverId) > 0; }
+	bool empty() const { return wiggle_pq.empty(); }
 	Optional<UID> getNextServerId();
 
 	// -- statistic update
@@ -423,8 +423,8 @@ struct StorageWiggler : ReferenceCounted<StorageWiggler> {
 	// called when start wiggling a SS
 	Future<Void> startWiggle();
 	Future<Void> finishWiggle();
-	bool shouldStartNewRound() { return metrics.last_round_finish >= metrics.last_round_start; }
-	bool shouldFinishRound() {
+	bool shouldStartNewRound() const { return metrics.last_round_finish >= metrics.last_round_start; }
+	bool shouldFinishRound() const {
 		if (wiggle_pq.empty())
 			return true;
 		return (wiggle_pq.top().first.createdTime >= metrics.last_round_start);

--- a/fdbserver/DataDistributionTracker.actor.cpp
+++ b/fdbserver/DataDistributionTracker.actor.cpp
@@ -973,7 +973,7 @@ ACTOR Future<Void> dataDistributionTracker(Reference<InitialDataDistribution> in
 	}
 }
 
-std::vector<KeyRange> ShardsAffectedByTeamFailure::getShardsFor(Team team) {
+std::vector<KeyRange> ShardsAffectedByTeamFailure::getShardsFor(Team team) const {
 	std::vector<KeyRange> r;
 	for (auto it = team_shards.lower_bound(std::pair<Team, KeyRange>(team, KeyRangeRef()));
 	     it != team_shards.end() && it->first == team;
@@ -1106,7 +1106,7 @@ void ShardsAffectedByTeamFailure::finishMove(KeyRangeRef keys) {
 	}
 }
 
-void ShardsAffectedByTeamFailure::check() {
+void ShardsAffectedByTeamFailure::check() const {
 	if (EXPENSIVE_VALIDATION) {
 		for (auto t = team_shards.begin(); t != team_shards.end(); ++t) {
 			auto i = shard_teams.rangeContaining(t->second.begin);
@@ -1115,8 +1115,8 @@ void ShardsAffectedByTeamFailure::check() {
 			}
 		}
 		auto rs = shard_teams.ranges();
-		for (auto i = rs.begin(); i != rs.end(); ++i)
-			for (std::vector<Team>::iterator t = i->value().first.begin(); t != i->value().first.end(); ++t)
+		for (auto i = rs.begin(); i != rs.end(); ++i) {
+			for (auto t = i->value().first.begin(); t != i->value().first.end(); ++t) {
 				if (!team_shards.count(std::make_pair(*t, i->range()))) {
 					std::string teamDesc, shards;
 					for (int k = 0; k < t->servers.size(); k++)
@@ -1132,5 +1132,7 @@ void ShardsAffectedByTeamFailure::check() {
 					    .detail("Shards", shards);
 					ASSERT(false);
 				}
+			}
+		}
 	}
 }

--- a/fdbserver/Ratekeeper.actor.cpp
+++ b/fdbserver/Ratekeeper.actor.cpp
@@ -511,8 +511,8 @@ void Ratekeeper::updateRate(RatekeeperLimits* limits) {
 	int64_t limitingStorageQueueStorageServer = 0;
 	int64_t worstDurabilityLag = 0;
 
-	std::multimap<double, StorageQueueInfo*> storageTpsLimitReverseIndex;
-	std::multimap<int64_t, StorageQueueInfo*> storageDurabilityLagReverseIndex;
+	std::multimap<double, StorageQueueInfo const*> storageTpsLimitReverseIndex;
+	std::multimap<int64_t, StorageQueueInfo const*> storageDurabilityLagReverseIndex;
 
 	std::map<UID, limitReason_t> ssReasons;
 
@@ -522,7 +522,7 @@ void Ratekeeper::updateRate(RatekeeperLimits* limits) {
 
 	// Look at each storage server's write queue and local rate, compute and store the desired rate ratio
 	for (auto i = storageQueueInfo.begin(); i != storageQueueInfo.end(); ++i) {
-		auto& ss = i->value;
+		auto const& ss = i->value;
 		if (!ss.valid || (remoteDC.present() && ss.locality.dcId() == remoteDC))
 			continue;
 		++sscount;
@@ -779,7 +779,7 @@ void Ratekeeper::updateRate(RatekeeperLimits* limits) {
 	int64_t worstStorageQueueTLog = 0;
 	int tlcount = 0;
 	for (auto& it : tlogQueueInfo) {
-		auto& tl = it.value;
+		auto const& tl = it.value;
 		if (!tl.valid)
 			continue;
 		++tlcount;

--- a/fdbserver/TagThrottler.actor.cpp
+++ b/fdbserver/TagThrottler.actor.cpp
@@ -538,7 +538,7 @@ public:
 	int64_t manualThrottleCount() const { return throttledTags.manualThrottleCount(); }
 	bool isAutoThrottlingEnabled() const { return autoThrottlingEnabled; }
 
-	Future<Void> tryAutoThrottleTag(StorageQueueInfo& ss, int64_t storageQueue, int64_t storageDurabilityLag) {
+	Future<Void> tryAutoThrottleTag(StorageQueueInfo const& ss, int64_t storageQueue, int64_t storageDurabilityLag) {
 		// NOTE: we just keep it simple and don't differentiate write-saturation and read-saturation at the moment. In
 		// most of situation, this works. More indicators besides queue size and durability lag could be investigated in
 		// the future
@@ -591,7 +591,7 @@ int64_t TagThrottler::manualThrottleCount() const {
 bool TagThrottler::isAutoThrottlingEnabled() const {
 	return impl->isAutoThrottlingEnabled();
 }
-Future<Void> TagThrottler::tryAutoThrottleTag(StorageQueueInfo& ss,
+Future<Void> TagThrottler::tryAutoThrottleTag(StorageQueueInfo const& ss,
                                               int64_t storageQueue,
                                               int64_t storageDurabilityLag) {
 	return impl->tryAutoThrottleTag(ss, storageQueue, storageDurabilityLag);

--- a/fdbserver/TagThrottler.actor.cpp
+++ b/fdbserver/TagThrottler.actor.cpp
@@ -38,7 +38,7 @@ class RkTagThrottleCollection : NonCopyable {
 
 		RkTagThrottleData() : clientRate(CLIENT_KNOBS->TAG_THROTTLE_SMOOTHING_WINDOW) {}
 
-		double getTargetRate(Optional<double> requestRate) {
+		double getTargetRate(Optional<double> requestRate) const {
 			if (limits.tpsRate == 0.0 || !requestRate.present() || requestRate.get() == 0.0 || !rateSet) {
 				return limits.tpsRate;
 			} else {

--- a/fdbserver/TagThrottler.h
+++ b/fdbserver/TagThrottler.h
@@ -38,5 +38,5 @@ public:
 	uint32_t busyWriteTagCount() const;
 	int64_t manualThrottleCount() const;
 	bool isAutoThrottlingEnabled() const;
-	Future<Void> tryAutoThrottleTag(StorageQueueInfo&, int64_t storageQueue, int64_t storageDurabilityLag);
+	Future<Void> tryAutoThrottleTag(StorageQueueInfo const&, int64_t storageQueue, int64_t storageDurabilityLag);
 };


### PR DESCRIPTION
The `Smoother::estimate` and `Smoother::time` fields are marked mutable, because updating these fields in `Smoother::update` does not affect the underlying state of the `Smoother` object. This allows `Smoother::smoothTotal`, `Smoother::smoothRate`, and many other methods and object references to be marked `const`.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
