### PR TITLE
Fix static initialization order for maxAllowedVersion (release-7.0)

### DIFF
--- a/fdbclient/SpecialKeySpace.actor.cpp
+++ b/fdbclient/SpecialKeySpace.actor.cpp
@@ -32,10 +32,6 @@
 namespace {
 const std::string kTracingTransactionIdKey = "transaction_id";
 const std::string kTracingTokenKey = "token";
-// Max version we can set for minRequiredCommitVersionKey,
-// making sure the cluster can still be alive for 1000 years after the recovery
-const Version maxAllowedVerion =
-    std::numeric_limits<int64_t>::max() - 1 - CLIENT_KNOBS->VERSIONS_PER_SECOND * 3600 * 24 * 365 * 1000;
 
 static bool isAlphaNumeric(const std::string& key) {
 	// [A-Za-z0-9_]+
@@ -1784,6 +1780,11 @@ Future<RangeResult> AdvanceVersionImpl::getRange(ReadYourWritesTransaction* ryw,
 }
 
 ACTOR static Future<Optional<std::string>> advanceVersionCommitActor(ReadYourWritesTransaction* ryw, Version v) {
+	// Max version we can set for minRequiredCommitVersionKey,
+	// making sure the cluster can still be alive for 1000 years after the recovery
+	static const Version maxAllowedVerion =
+	    std::numeric_limits<int64_t>::max() - 1 - CLIENT_KNOBS->VERSIONS_PER_SECOND * 3600 * 24 * 365 * 1000;
+
 	ryw->getTransaction().setOption(FDBTransactionOptions::LOCK_AWARE);
 	TraceEvent(SevDebug, "AdvanceVersion").detail("MaxAllowedVersion", maxAllowedVerion);
 	if (v > maxAllowedVerion) {


### PR DESCRIPTION
Cherry pick https://github.com/apple/foundationdb/pull/6570 to release-7.0



`maxAllowedVerion` was statically initialized with a dependency on `CLIENT_KNOBS`, which is also statically initialized. In some cases these two were constructed in the wrong order and led to a segfault on startup. Fix by deferring initialization of `maxAllowedVerion` into the first call to `advanceVersionCommitActor()`.

Tested by compiling and running fdbcli and fdbserver. Previously both crashed instantly. Now both run normally and print the expected first message. A sample simulation test runs as well. Extensive simulation was not run on this change.
