### PR TITLE
Fix a rare race with version vector cache

### DIFF
--- a/fdbclient/CommitProxyInterface.h
+++ b/fdbclient/CommitProxyInterface.h
@@ -200,6 +200,7 @@ struct GetReadVersionReply : public BasicLoadBalancedReply {
 	TransactionTagMap<ClientTagThrottleLimits> tagThrottleInfo;
 
 	VersionVector ssVersionVectorDelta;
+	UID proxyId; // GRV proxy ID to detect old GRV proxies at client side
 
 	GetReadVersionReply() : version(invalidVersion), locked(false) {}
 
@@ -212,7 +213,8 @@ struct GetReadVersionReply : public BasicLoadBalancedReply {
 		           metadataVersion,
 		           tagThrottleInfo,
 		           midShardSize,
-		           ssVersionVectorDelta);
+		           ssVersionVectorDelta,
+		           proxyId);
 	}
 };
 

--- a/fdbclient/DatabaseContext.h
+++ b/fdbclient/DatabaseContext.h
@@ -465,6 +465,7 @@ public:
 	Counter transactionsExpensiveClearCostEstCount;
 	Counter transactionGrvFullBatches;
 	Counter transactionGrvTimedOutBatches;
+	Counter transactionsStaleVersionVectors;
 
 	ContinuousSample<double> latencies, readLatencies, commitLatencies, GRVLatencies, mutationsPerCommit,
 	    bytesPerCommit;

--- a/fdbclient/DatabaseContext.h
+++ b/fdbclient/DatabaseContext.h
@@ -249,6 +249,7 @@ public:
 	Reference<CommitProxyInfo> getCommitProxies(UseProvisionalProxies useProvisionalProxies);
 	Future<Reference<CommitProxyInfo>> getCommitProxiesFuture(UseProvisionalProxies useProvisionalProxies);
 	Reference<GrvProxyInfo> getGrvProxies(UseProvisionalProxies useProvisionalProxies);
+	bool isCurrentGrvProxy(UID proxyId) const;
 	Future<Void> onProxiesChanged() const;
 	Future<HealthMetrics> getHealthMetrics(bool detailed);
 	// Pass a negative value for `shardLimit` to indicate no limit on the shard number.

--- a/fdbserver/GrvProxyServer.actor.cpp
+++ b/fdbserver/GrvProxyServer.actor.cpp
@@ -639,6 +639,7 @@ ACTOR Future<Void> sendGrvReplies(Future<GetReadVersionReply> replyFuture,
 		reply.tagThrottleInfo.clear();
 		grvProxyData->ssVersionVectorCache.getDelta(request.maxVersion, reply.ssVersionVectorDelta);
 		grvProxyData->versionVectorSizeOnGRVReply.addMeasurement(reply.ssVersionVectorDelta.size());
+		reply.proxyId = grvProxyData->dbgid;
 
 		if (!request.tags.empty()) {
 			auto& priorityThrottledTags = throttledTags[request.priority];

--- a/flow/error_definitions.h
+++ b/flow/error_definitions.h
@@ -84,6 +84,7 @@ ERROR( change_feed_not_registered, 1060, "Change feed not registered" )
 ERROR( granule_assignment_conflict, 1061, "Conflicting attempts to assign blob granules" )
 ERROR( change_feed_cancelled, 1062, "Change feed was cancelled" )
 ERROR( blob_granule_file_load_error, 1063, "Error loading a blob file during granule materialization" )
+ERROR( stale_version_vector, 1064, "Client version vector is stale" )
 
 ERROR( broken_promise, 1100, "Broken promise" )
 ERROR( operation_cancelled, 1101, "Asynchronous operation cancelled" )

--- a/flow/flat_buffers.h
+++ b/flow/flat_buffers.h
@@ -240,7 +240,9 @@ struct vector_like_traits<boost::container::flat_map<Key, T, Compare, Allocator>
 		return v.size();
 	}
 	template <class Context>
-	static void reserve(Vec& v, size_t size, Context&) {}
+	static void reserve(Vec& v, size_t size, Context&) {
+		v.reserve(size);
+	}
 
 	template <class Context>
 	static insert_iterator insert(Vec& v, Context&) {


### PR DESCRIPTION
The events that led to the assertion failure are:
    
1.    Many txn started, some get ReadVersion1, some get ReadVersion2.
1.    Recovery happened.
1.    GRV proxy change detected and the client version cache is cleared.
1.    Old GRV responded with ReadVersion1, and client version cache is updated to ReadVersion1.
1.    A txn starts reading with ReadVersion2, triggering the assertion.

The fix is to throw an error to trigger transaction restart so that a new GRV will update the version cache, validated with previously failed seed: `-f ./foundationdb/tests/slow/DDBalanceAndRemoveStatus.toml -s 559021579 -b on`


# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
