### PR TITLE
logical fixes to recovery algorithm

### DIFF
--- a/fdbserver/WorkerInterface.actor.h
+++ b/fdbserver/WorkerInterface.actor.h
@@ -569,7 +569,6 @@ struct InitializeTLogRequest {
 	Version startVersion;
 	int logRouterTags;
 	int txsTags;
-	std::map<UID, Version> rvLogs;
 	UID clusterId;
 
 	ReplyPromise<struct TLogInterface> reply;
@@ -596,7 +595,6 @@ struct InitializeTLogRequest {
 		           logVersion,
 		           spillType,
 		           txsTags,
-		           rvLogs,
 		           clusterId);
 	}
 };


### PR DESCRIPTION
On recovery in version vector unicast mode:
* ensure all versions less than or equal to the RV are durable.   The prior algorithm did not guarantee that, which could have created a gap (e.g. sequence v1,v2,v3 ; v1 and v3 recovered, v2 not recovered)
* Replicas must be in the same log group for a version to be considered recovered for that log group. 
* More information [here](https://docs.google.com/document/d/11oR1MOVl6rOhXqaTdLBMzEtsh56en7KAT5wfKRGKM7U/edit)   In section TagPartitionedLogSystem.actor.cpp (recovery path)

Simulation test
20220313-184813-henrylambright-38edfef0e5d536df 