### PR TITLE
Allow temporarily changing the knobs during test

### DIFF
--- a/fdbclient/ClientKnobCollection.h
+++ b/fdbclient/ClientKnobCollection.h
@@ -49,4 +49,4 @@ public:
 	bool isAtomic(std::string const& knobName) const override;
 };
 
-#endif 	// FDBCLIENT_CLIENTKNOBCCOLLECTION_H
+#endif // FDBCLIENT_CLIENTKNOBCCOLLECTION_H

--- a/fdbclient/ClientKnobCollection.h
+++ b/fdbclient/ClientKnobCollection.h
@@ -18,6 +18,9 @@
  * limitations under the License.
  */
 
+#ifndef FDBCLIENT_CLIENTKNOBCOLLECTION_H
+#define FDBCLIENT_CLIENTKNOBCOLLECTION_H
+
 #pragma once
 
 #include "fdbclient/ClientKnobs.h"
@@ -45,3 +48,5 @@ public:
 	bool trySetKnob(std::string const& knobName, KnobValueRef const& knobValue) override;
 	bool isAtomic(std::string const& knobName) const override;
 };
+
+#endif 	// FDBCLIENT_CLIENTKNOBCCOLLECTION_H

--- a/fdbclient/IKnobCollection.h
+++ b/fdbclient/IKnobCollection.h
@@ -18,6 +18,9 @@
  * limitations under the License.
  */
 
+#ifndef FDBCLIENT_IKNOBCOLLECTION_H
+#define FDBCLIENT_IKNOBCOLLECTION_H
+
 #pragma once
 
 #include <memory>
@@ -69,3 +72,5 @@ public:
 	static ConfigMutationRef createSetMutation(Arena, KeyRef, ValueRef);
 	static ConfigMutationRef createClearMutation(Arena, KeyRef);
 };
+
+#endif	// FDBCLIENT_IKNOBCOLLECTION_H

--- a/fdbclient/IKnobCollection.h
+++ b/fdbclient/IKnobCollection.h
@@ -73,4 +73,4 @@ public:
 	static ConfigMutationRef createClearMutation(Arena, KeyRef);
 };
 
-#endif	// FDBCLIENT_IKNOBCOLLECTION_H
+#endif // FDBCLIENT_IKNOBCOLLECTION_H

--- a/fdbclient/ServerKnobCollection.h
+++ b/fdbclient/ServerKnobCollection.h
@@ -18,6 +18,9 @@
  * limitations under the License.
  */
 
+#ifndef FDBCLIENT_SERVERKNOBCOLLECTION_H
+#define FDBCLIENT_SERVERKNOBCOLLECTION_H
+
 #pragma once
 
 #include "fdbclient/ClientKnobCollection.h"
@@ -43,3 +46,5 @@ public:
 	bool trySetKnob(std::string const& knobName, KnobValueRef const& knobValue) override;
 	bool isAtomic(std::string const& knobName) const override;
 };
+
+#endif // FDBCLIENT_SERVERKNOBCOLLECTION_H

--- a/fdbclient/TestKnobCollection.h
+++ b/fdbclient/TestKnobCollection.h
@@ -18,6 +18,9 @@
  * limitations under the License.
  */
 
+#ifndef FDBCLIENT_TESTKNOBCOLLECTION_H
+#define FDBCLIENT_TESTKNOBCOLLECTION_H
+
 #pragma once
 
 #include "fdbclient/IKnobCollection.h"
@@ -67,3 +70,5 @@ public:
 	bool trySetKnob(std::string const& knobName, KnobValueRef const& knobValue) override;
 	bool isAtomic(std::string const& knobName) const override;
 };
+
+#endif // FDBCLIENT_TESTKNOBCOLLECTION_H

--- a/fdbserver/CMakeLists.txt
+++ b/fdbserver/CMakeLists.txt
@@ -1,6 +1,6 @@
 set(FDBSERVER_SRCS
-  ApplyMetadataMutation.h
   ApplyMetadataMutation.cpp
+  ApplyMetadataMutation.h
   BackupInterface.h
   BackupProgress.actor.cpp
   BackupProgress.actor.h
@@ -8,10 +8,11 @@ set(FDBSERVER_SRCS
   BlobManager.actor.cpp
   BlobManagerInterface.h
   BlobWorker.actor.cpp
-  ClusterController.actor.h
   ClusterController.actor.cpp
-  ClusterRecovery.actor.h
+  ClusterController.actor.h
   ClusterRecovery.actor.cpp
+  ClusterRecovery.actor.h
+  CommitProxyServer.actor.cpp
   ConfigBroadcaster.actor.cpp
   ConfigBroadcaster.h
   ConfigDatabaseUnitTests.actor.cpp
@@ -34,11 +35,11 @@ set(FDBSERVER_SRCS
   DDTeamCollection.actor.cpp
   DDTeamCollection.h
   DiskQueue.actor.cpp
-  EncryptKeyProxyInterface.h
   EncryptKeyProxy.actor.cpp
-  fdbserver.actor.cpp
+  EncryptKeyProxyInterface.h
   FDBExecHelper.actor.cpp
   FDBExecHelper.actor.h
+  fdbserver.actor.cpp
   GrvProxyServer.actor.cpp
   IConfigConsumer.cpp
   IConfigConsumer.h
@@ -69,14 +70,13 @@ set(FDBSERVER_SRCS
   LogSystemDiskQueueAdapter.h
   LogSystemPeekCursor.actor.cpp
   MasterInterface.h
+  masterserver.actor.cpp
   MetricLogger.actor.cpp
   MetricLogger.actor.h
-  CommitProxyServer.actor.cpp
-  masterserver.actor.cpp
-  MutationTracking.h
-  MutationTracking.cpp
-  MoveKeys.actor.h
   MoveKeys.actor.cpp
+  MoveKeys.actor.h
+  MutationTracking.cpp
+  MutationTracking.h
   networktest.actor.cpp
   NetworkTest.h
   OldTLogServer_4_6.actor.cpp
@@ -92,35 +92,39 @@ set(FDBSERVER_SRCS
   QuietDatabase.actor.cpp
   QuietDatabase.h
   RadixTree.h
-  Ratekeeper.h
   Ratekeeper.actor.cpp
+  Ratekeeper.h
   RatekeeperInterface.h
   RecoveryState.h
-  RestoreCommon.actor.h
-  RestoreCommon.actor.cpp
-  RestoreUtil.h
-  RestoreUtil.actor.cpp
-  RestoreRoleCommon.actor.h
-  RestoreRoleCommon.actor.cpp
-  RestoreController.actor.h
-  RestoreController.actor.cpp
-  RestoreApplier.actor.h
-  RestoreApplier.actor.cpp
-  RestoreLoader.actor.h
-  RestoreLoader.actor.cpp
-  RestoreWorker.actor.h
-  RestoreWorker.actor.cpp
-  RestoreWorkerInterface.actor.cpp
-  RestoreWorkerInterface.actor.h
   Resolver.actor.cpp
   ResolverInterface.h
-  RoleLineage.actor.h
+  RestoreApplier.actor.cpp
+  RestoreApplier.actor.h
+  RestoreCommon.actor.cpp
+  RestoreCommon.actor.h
+  RestoreController.actor.cpp
+  RestoreController.actor.h
+  RestoreLoader.actor.cpp
+  RestoreLoader.actor.h
+  RestoreRoleCommon.actor.cpp
+  RestoreRoleCommon.actor.h
+  RestoreUtil.actor.cpp
+  RestoreUtil.h
+  RestoreWorker.actor.cpp
+  RestoreWorker.actor.h
+  RestoreWorkerInterface.actor.cpp
+  RestoreWorkerInterface.actor.h
+  RocksDBCheckpointUtils.actor.cpp
+  RocksDBCheckpointUtils.actor.h
   RoleLineage.actor.cpp
+  RoleLineage.actor.h
+  ServerCheckpoint.actor.cpp
+  ServerCheckpoint.actor.h
   ServerDBInfo.actor.h
   ServerDBInfo.h
   SigStack.cpp
-  SimEncryptVaultProxy.actor.h
   SimEncryptVaultProxy.actor.cpp
+  SimEncryptVaultProxy.actor.h
   SimpleConfigConsumer.actor.cpp
   SimpleConfigConsumer.h
   SimulatedCluster.actor.cpp
@@ -137,18 +141,18 @@ set(FDBSERVER_SRCS
   TagPartitionedLogSystem.actor.h
   TagThrottler.actor.cpp
   TagThrottler.h
-  template_fdb.h
   TCInfo.actor.cpp
   TCInfo.h
+  template_fdb.h
   tester.actor.cpp
   TesterInterface.actor.h
   TLogInterface.h
   TLogServer.actor.cpp
-  TSSMappingUtil.actor.h
   TSSMappingUtil.actor.cpp
+  TSSMappingUtil.actor.h
   VersionedBTree.actor.cpp
-  VFSAsync.h
   VFSAsync.cpp
+  VFSAsync.h
   WaitFailure.actor.cpp
   WaitFailure.h
   worker.actor.cpp
@@ -166,37 +170,35 @@ set(FDBSERVER_SRCS
   workloads/AtomicRestore.actor.cpp
   workloads/AtomicSwitchover.actor.cpp
   workloads/BackgroundSelectors.actor.cpp
-  workloads/BackupCorrectness.actor.cpp
   workloads/BackupAndParallelRestoreCorrectness.actor.cpp
-  workloads/ClogSingleConnection.actor.cpp
-  workloads/ConfigIncrement.actor.cpp
+  workloads/BackupCorrectness.actor.cpp
   workloads/BackupToBlob.actor.cpp
   workloads/BackupToDBAbort.actor.cpp
   workloads/BackupToDBCorrectness.actor.cpp
   workloads/BackupToDBUpgrade.actor.cpp
-  workloads/BlobStoreWorkload.h
   workloads/BlobGranuleVerifier.actor.cpp
+  workloads/BlobStoreWorkload.h
   workloads/BulkLoad.actor.cpp
   workloads/BulkSetup.actor.h
   workloads/Cache.actor.cpp
   workloads/ChangeConfig.actor.cpp
+  workloads/ChangeFeeds.actor.cpp
   workloads/ClearSingleRange.actor.cpp
   workloads/ClientTransactionProfileCorrectness.actor.cpp
-  workloads/TriggerRecovery.actor.cpp
-  workloads/SuspendProcesses.actor.cpp
+  workloads/ClogSingleConnection.actor.cpp
   workloads/CommitBugCheck.actor.cpp
+  workloads/ConfigIncrement.actor.cpp
   workloads/ConfigureDatabase.actor.cpp
   workloads/ConflictRange.actor.cpp
   workloads/ConsistencyCheck.actor.cpp
   workloads/CpuProfiler.actor.cpp
   workloads/Cycle.actor.cpp
-  workloads/ChangeFeeds.actor.cpp
   workloads/DataDistributionMetrics.actor.cpp
   workloads/DataLossRecovery.actor.cpp
-  workloads/PhysicalShardMove.actor.cpp
   workloads/DDBalance.actor.cpp
   workloads/DDMetrics.actor.cpp
   workloads/DDMetricsExclude.actor.cpp
+  workloads/DifferentClustersSameRV.actor.cpp
   workloads/DiskDurability.actor.cpp
   workloads/DiskDurabilityTest.actor.cpp
   workloads/DiskFailureInjection.actor.cpp
@@ -207,18 +209,19 @@ set(FDBSERVER_SRCS
   workloads/FileSystem.actor.cpp
   workloads/Fuzz.cpp
   workloads/FuzzApiCorrectness.actor.cpp
+  workloads/GetMappedRange.actor.cpp
   workloads/GetRangeStream.actor.cpp
   workloads/HealthMetricsApi.actor.cpp
   workloads/HighContentionPrefixAllocatorWorkload.actor.cpp
-  workloads/IncrementalBackup.actor.cpp
   workloads/Increment.actor.cpp
+  workloads/IncrementalBackup.actor.cpp
   workloads/IndexScan.actor.cpp
   workloads/Inventory.actor.cpp
-  workloads/KVStoreTest.actor.cpp
   workloads/KillRegion.actor.cpp
+  workloads/KVStoreTest.actor.cpp
+  workloads/LocalRatekeeper.actor.cpp
   workloads/LockDatabase.actor.cpp
   workloads/LockDatabaseFrequently.actor.cpp
-  workloads/LocalRatekeeper.actor.cpp
   workloads/LogMetrics.actor.cpp
   workloads/LowLatency.actor.cpp
   workloads/MachineAttrition.actor.cpp
@@ -229,9 +232,9 @@ set(FDBSERVER_SRCS
   workloads/MetricLogging.actor.cpp
   workloads/MiniCycle.actor.cpp
   workloads/MutationLogReaderCorrectness.actor.cpp
-  workloads/GetMappedRange.actor.cpp
   workloads/ParallelRestore.actor.cpp
   workloads/Performance.actor.cpp
+  workloads/PhysicalShardMove.actor.cpp
   workloads/Ping.actor.cpp
   workloads/PopulateTPCC.actor.cpp
   workloads/ProtocolVersion.actor.cpp
@@ -260,11 +263,12 @@ set(FDBSERVER_SRCS
   workloads/SlowTaskWorkload.actor.cpp
   workloads/SnapTest.actor.cpp
   workloads/SpecialKeySpaceCorrectness.actor.cpp
-  workloads/StreamingRangeRead.actor.cpp
   workloads/StatusWorkload.actor.cpp
   workloads/Storefront.actor.cpp
+  workloads/StreamingRangeRead.actor.cpp
   workloads/StreamingRead.actor.cpp
   workloads/SubmitBackup.actor.cpp
+  workloads/SuspendProcesses.actor.cpp
   workloads/TagThrottleApi.actor.cpp
   workloads/TargetedKill.actor.cpp
   workloads/TaskBucketCorrectness.actor.cpp
@@ -275,11 +279,11 @@ set(FDBSERVER_SRCS
   workloads/TimeKeeperCorrectness.actor.cpp
   workloads/TPCC.actor.cpp
   workloads/TPCCWorkload.h
-  workloads/DifferentClustersSameRV.actor.cpp
+  workloads/TriggerRecovery.actor.cpp
+  workloads/UDPWorkload.actor.cpp
   workloads/UnitPerf.actor.cpp
   workloads/UnitTests.actor.cpp
   workloads/Unreadable.actor.cpp
-  workloads/UDPWorkload.actor.cpp
   workloads/VersionStamp.actor.cpp
   workloads/WatchAndWait.actor.cpp
   workloads/Watches.actor.cpp

--- a/fdbserver/CMakeLists.txt
+++ b/fdbserver/CMakeLists.txt
@@ -50,10 +50,8 @@ set(FDBSERVER_SRCS
   KeyValueStoreMemory.actor.cpp
   KeyValueStoreRocksDB.actor.cpp
   KeyValueStoreSQLite.actor.cpp
-  ServerCheckpoint.actor.cpp
-  ServerCheckpoint.actor.h
-  RocksDBCheckpointUtils.actor.cpp
-  RocksDBCheckpointUtils.actor.h
+  KnobProtectiveGroups.cpp
+  KnobProtectiveGroups.h
   Knobs.h
   LatencyBandConfig.cpp
   LatencyBandConfig.h

--- a/fdbserver/KnobProtectiveGroups.cpp
+++ b/fdbserver/KnobProtectiveGroups.cpp
@@ -1,0 +1,73 @@
+/*
+ * KnobProtectiveGroups.cpp
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2022 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "fdbserver/KnobProtectiveGroups.h"
+
+#include <array>
+
+#include "fdbclient/Knobs.h"
+#include "fdbclient/ServerKnobCollection.h"
+#include "fdbserver/Knobs.h"
+
+void KnobKeyValuePairs::set(const std::string& name, const ParsedKnobValue value) {
+	ASSERT(knobs.count(name) == 0);
+
+	knobs[name] = value;
+}
+
+const KnobKeyValuePairs::container_t& KnobKeyValuePairs::getKnobs() const {
+	return knobs;
+}
+
+KnobProtectiveGroup::KnobProtectiveGroup(const KnobKeyValuePairs& overriddenKnobKeyValuePairs_)
+  : overriddenKnobs(overriddenKnobKeyValuePairs_) {
+	snapshotOriginalKnobs();
+	assignKnobs(overriddenKnobs);
+}
+
+KnobProtectiveGroup::~KnobProtectiveGroup() {
+	assignKnobs(originalKnobs);
+}
+
+void KnobProtectiveGroup::snapshotOriginalKnobs() {
+	for (const auto& [name, _] : overriddenKnobs.getKnobs()) {
+		ParsedKnobValue value = CLIENT_KNOBS->getKnob(name);
+		if (std::get_if<NoKnobFound>(&value)) {
+			value = SERVER_KNOBS->getKnob(name);
+		}
+		if (std::get_if<NoKnobFound>(&value)) {
+			ASSERT(false);
+		}
+		originalKnobs.set(name, value);
+		TraceEvent("SnapshotKnobValue")
+		    .detail("KnobName", name)
+		    .detail("KnobValue", KnobValueRef::create(value).toString());
+	}
+}
+
+void KnobProtectiveGroup::assignKnobs(const KnobKeyValuePairs& overrideKnobs) {
+	auto& mutableServerKnobs = dynamic_cast<ServerKnobCollection&>(IKnobCollection::getMutableGlobalKnobCollection());
+
+	for (const auto& [name, value] : overrideKnobs.getKnobs()) {
+		Standalone<KnobValueRef> valueRef = KnobValueRef::create(value);
+		ASSERT(mutableServerKnobs.trySetKnob(name, valueRef));
+		TraceEvent("AssignKnobValue").detail("KnobName", name).detail("KnobValue", valueRef.toString());
+	}
+}

--- a/fdbserver/KnobProtectiveGroups.cpp
+++ b/fdbserver/KnobProtectiveGroups.cpp
@@ -56,7 +56,7 @@ void KnobProtectiveGroup::snapshotOriginalKnobs() {
 			ASSERT(false);
 		}
 		originalKnobs.set(name, value);
-		TraceEvent("SnapshotKnobValue")
+		TraceEvent(SevInfo, "SnapshotKnobValue")
 		    .detail("KnobName", name)
 		    .detail("KnobValue", KnobValueRef::create(value).toString());
 	}
@@ -68,6 +68,6 @@ void KnobProtectiveGroup::assignKnobs(const KnobKeyValuePairs& overrideKnobs) {
 	for (const auto& [name, value] : overrideKnobs.getKnobs()) {
 		Standalone<KnobValueRef> valueRef = KnobValueRef::create(value);
 		ASSERT(mutableServerKnobs.trySetKnob(name, valueRef));
-		TraceEvent("AssignKnobValue").detail("KnobName", name).detail("KnobValue", valueRef.toString());
+		TraceEvent(SevInfo, "AssignKnobValue").detail("KnobName", name).detail("KnobValue", valueRef.toString());
 	}
 }

--- a/fdbserver/KnobProtectiveGroups.h
+++ b/fdbserver/KnobProtectiveGroups.h
@@ -29,31 +29,33 @@
 // A list of knob key value pairs
 class KnobKeyValuePairs {
 public:
-    using container_t = std::unordered_map<std::string, ParsedKnobValue>;
+	using container_t = std::unordered_map<std::string, ParsedKnobValue>;
+
 private:
-    // Here the knob value is directly stored, unlike KnobValue, for simplicity
-    container_t knobs;
+	// Here the knob value is directly stored, unlike KnobValue, for simplicity
+	container_t knobs;
 
 public:
-    // Sets a value for a given knob
-    void set(const std::string& name, const ParsedKnobValue value);
+	// Sets a value for a given knob
+	void set(const std::string& name, const ParsedKnobValue value);
 
-    // Gets a list of knobs for given type
-    const container_t& getKnobs() const;
+	// Gets a list of knobs for given type
+	const container_t& getKnobs() const;
 };
 
-// For knobs, temporarily change the values, the original values will be recovered 
+// For knobs, temporarily change the values, the original values will be recovered
 class KnobProtectiveGroup {
-    KnobKeyValuePairs overriddenKnobs;
-    KnobKeyValuePairs originalKnobs;
+	KnobKeyValuePairs overriddenKnobs;
+	KnobKeyValuePairs originalKnobs;
 
-    // Snapshots the current knob values base on those knob keys in overriddenKnobs
-    void snapshotOriginalKnobs();
+	// Snapshots the current knob values base on those knob keys in overriddenKnobs
+	void snapshotOriginalKnobs();
 
-    void assignKnobs(const KnobKeyValuePairs& overrideKnobs);
+	void assignKnobs(const KnobKeyValuePairs& overrideKnobs);
+
 public:
-    KnobProtectiveGroup(const KnobKeyValuePairs& overridenKnobs_);
-    ~KnobProtectiveGroup();
+	KnobProtectiveGroup(const KnobKeyValuePairs& overridenKnobs_);
+	~KnobProtectiveGroup();
 };
 
-#endif  // FDBSERVER_KNOBPROTECTIVEGROUPS_H
+#endif // FDBSERVER_KNOBPROTECTIVEGROUPS_H

--- a/fdbserver/KnobProtectiveGroups.h
+++ b/fdbserver/KnobProtectiveGroups.h
@@ -1,0 +1,59 @@
+/*
+ * KnobProtectiveGroups.h
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2022 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FDBSERVER_KNOBPROTECTIVEGROUPS_H
+#define FDBSERVER_KNOBPROTECTIVEGROUPS_H
+
+#include <array>
+#include <unordered_map>
+
+#include "fdbclient/IKnobCollection.h"
+
+// A list of knob key value pairs
+class KnobKeyValuePairs {
+public:
+    using container_t = std::unordered_map<std::string, ParsedKnobValue>;
+private:
+    // Here the knob value is directly stored, unlike KnobValue, for simplicity
+    container_t knobs;
+
+public:
+    // Sets a value for a given knob
+    void set(const std::string& name, const ParsedKnobValue value);
+
+    // Gets a list of knobs for given type
+    const container_t& getKnobs() const;
+};
+
+// For knobs, temporarily change the values, the original values will be recovered 
+class KnobProtectiveGroup {
+    KnobKeyValuePairs overriddenKnobs;
+    KnobKeyValuePairs originalKnobs;
+
+    // Snapshots the current knob values base on those knob keys in overriddenKnobs
+    void snapshotOriginalKnobs();
+
+    void assignKnobs(const KnobKeyValuePairs& overrideKnobs);
+public:
+    KnobProtectiveGroup(const KnobKeyValuePairs& overridenKnobs_);
+    ~KnobProtectiveGroup();
+};
+
+#endif  // FDBSERVER_KNOBPROTECTIVEGROUPS_H

--- a/fdbserver/Knobs.h
+++ b/fdbserver/Knobs.h
@@ -27,4 +27,4 @@
 
 #define SERVER_KNOBS (&IKnobCollection::getGlobalKnobCollection().getServerKnobs())
 
-#endif  // FDBSERVER_KNOBS_H
+#endif // FDBSERVER_KNOBS_H

--- a/fdbserver/Knobs.h
+++ b/fdbserver/Knobs.h
@@ -18,8 +18,13 @@
  * limitations under the License.
  */
 
+#ifndef FDBSERVER_KNOBS_H
+#define FDBSERVER_KNOBS_H
+
 #pragma once
 
 #include "fdbclient/IKnobCollection.h"
 
 #define SERVER_KNOBS (&IKnobCollection::getGlobalKnobCollection().getServerKnobs())
+
+#endif  // FDBSERVER_KNOBS_H

--- a/fdbserver/tester.actor.cpp
+++ b/fdbserver/tester.actor.cpp
@@ -1349,15 +1349,17 @@ std::vector<TestSpec> readTOMLTests_(std::string fileName) {
 		try {
 			const toml::array& overrideKnobs = toml::find(test, "knobs").as_array();
 			for (const toml::value& knob : overrideKnobs) {
-				for (const auto& [key_, value_] : knob.as_table()) {
-					const std::string key = key_;
+				for (const auto& [key, value_] : knob.as_table()) {
 					const std::string& value = toml_to_string(value_);
 					ParsedKnobValue parsedValue = CLIENT_KNOBS->parseKnobValue(key, value);
 					if (std::get_if<NoKnobFound>(&parsedValue)) {
 						parsedValue = SERVER_KNOBS->parseKnobValue(key, value);
 					}
 					if (std::get_if<NoKnobFound>(&parsedValue)) {
-						ASSERT(false);
+						TraceEvent(SevErrro, "TestSpecUnrecognizedKnob")
+							.detail("KnobName", key)
+							.detail("OverrideValue", value);
+						continue;
 					}
 					spec.overrideKnobs.set(key, parsedValue);
 				}

--- a/fdbserver/tester.actor.cpp
+++ b/fdbserver/tester.actor.cpp
@@ -31,6 +31,7 @@
 #include "fdbclient/ClusterInterface.h"
 #include "fdbclient/NativeAPI.actor.h"
 #include "fdbclient/SystemData.h"
+#include "fdbserver/KnobProtectiveGroups.h"
 #include "fdbserver/TesterInterface.actor.h"
 #include "fdbserver/WorkerInterface.actor.h"
 #include "fdbserver/workloads/workloads.actor.h"
@@ -1318,7 +1319,7 @@ std::vector<TestSpec> readTOMLTests_(std::string fileName) {
 
 		// First handle all test-level settings
 		for (const auto& [k, v] : test.as_table()) {
-			if (k == "workload") {
+			if (k == "workload" || k == "knobs") {
 				continue;
 			}
 			if (testSpecTestKeys.find(k) != testSpecTestKeys.end()) {
@@ -1342,6 +1343,27 @@ std::vector<TestSpec> readTOMLTests_(std::string fileName) {
 				TraceEvent("TestParserOption").detail("ParsedKey", attrib).detail("ParsedValue", value);
 			}
 			spec.options.push_back_deep(spec.options.arena(), workloadOptions);
+		}
+
+		// And then copy the knob attributes to spec.overrideKnobs
+		try {
+			const toml::array& overrideKnobs = toml::find(test, "knobs").as_array();
+			for (const toml::value& knob : overrideKnobs) {
+				for (const auto& [key_, value_] : knob.as_table()) {
+					const std::string key = key_;
+					const std::string& value = toml_to_string(value_);
+					ParsedKnobValue parsedValue = CLIENT_KNOBS->parseKnobValue(key, value);
+					if (std::get_if<NoKnobFound>(&parsedValue)) {
+						parsedValue = SERVER_KNOBS->parseKnobValue(key, value);
+					}
+					if (std::get_if<NoKnobFound>(&parsedValue)) {
+						ASSERT(false);
+					}
+					spec.overrideKnobs.set(key, parsedValue);
+				}
+			}
+		} catch (const std::out_of_range&) {
+			// no knob overridden
 		}
 
 		result.push_back(spec);
@@ -1529,9 +1551,12 @@ ACTOR Future<Void> runTests(Reference<AsyncVar<Optional<struct ClusterController
 
 	TraceEvent("TestsExpectedToPass").detail("Count", tests.size());
 	state int idx = 0;
+	state std::unique_ptr<KnobProtectiveGroup> knobProtectiveGroup;
 	for (; idx < tests.size(); idx++) {
 		printf("Run test:%s start\n", tests[idx].title.toString().c_str());
+		knobProtectiveGroup = std::make_unique<KnobProtectiveGroup>(tests[idx].overrideKnobs);
 		wait(success(runTest(cx, testers, tests[idx], dbInfo, defaultTenant)));
+		knobProtectiveGroup.reset(nullptr);
 		printf("Run test:%s Done.\n", tests[idx].title.toString().c_str());
 		// do we handle a failure here?
 	}

--- a/fdbserver/tester.actor.cpp
+++ b/fdbserver/tester.actor.cpp
@@ -1356,9 +1356,9 @@ std::vector<TestSpec> readTOMLTests_(std::string fileName) {
 						parsedValue = SERVER_KNOBS->parseKnobValue(key, value);
 					}
 					if (std::get_if<NoKnobFound>(&parsedValue)) {
-						TraceEvent(SevErrro, "TestSpecUnrecognizedKnob")
-							.detail("KnobName", key)
-							.detail("OverrideValue", value);
+						TraceEvent(SevError, "TestSpecUnrecognizedKnob")
+						    .detail("KnobName", key)
+						    .detail("OverrideValue", value);
 						continue;
 					}
 					spec.overrideKnobs.set(key, parsedValue);

--- a/fdbserver/workloads/workloads.actor.h
+++ b/fdbserver/workloads/workloads.actor.h
@@ -27,6 +27,7 @@
 
 #include "fdbclient/NativeAPI.actor.h"
 #include "fdbclient/DatabaseContext.h" // for clone()
+#include "fdbserver/KnobProtectiveGroups.h"
 #include "fdbserver/TesterInterface.actor.h"
 #include "fdbrpc/simulator.h"
 #include "flow/actorcompiler.h"
@@ -205,6 +206,8 @@ public:
 	ISimulator::BackupAgentType simBackupAgents; // If set to true, then the simulation runs backup agents on the
 	                                             // workers. Can only be used in simulation.
 	ISimulator::BackupAgentType simDrAgents;
+
+	KnobKeyValuePairs overrideKnobs;
 };
 
 ACTOR Future<DistributedTestResults> runWorkload(Database cx,

--- a/flow/Knobs.cpp
+++ b/flow/Knobs.cpp
@@ -346,6 +346,26 @@ bool Knobs::setKnob(std::string const& knob, std::string const& value) {
 	return true;
 }
 
+ParsedKnobValue Knobs::getKnob(const std::string& name) const {
+	if (double_knobs.count(name) > 0) {
+		return ParsedKnobValue{ *double_knobs.at(name).value };
+	}
+	if (int64_knobs.count(name) > 0) {
+		return ParsedKnobValue{ *int64_knobs.at(name).value };
+	}
+	if (int_knobs.count(name) > 0) {
+		return ParsedKnobValue{ *int_knobs.at(name).value };
+	}
+	if (string_knobs.count(name) > 0) {
+		return ParsedKnobValue{ *string_knobs.at(name).value };
+	}
+	if (bool_knobs.count(name) > 0) {
+		return ParsedKnobValue{ *bool_knobs.at(name).value };
+	}
+
+	return ParsedKnobValue{ NoKnobFound() };
+}
+
 bool Knobs::isAtomic(std::string const& knob) const {
 	if (double_knobs.count(knob)) {
 		return double_knobs.find(knob)->second.atomic == Atomic::YES;

--- a/flow/Knobs.h
+++ b/flow/Knobs.h
@@ -76,11 +76,24 @@ protected:
 	std::set<std::string> explicitlySetKnobs;
 
 public:
+	// Sets an integer value to an integer knob, returns false if the knob does not exist or type mismatch
 	bool setKnob(std::string const& name, int value);
+
+	// Sets a boolean value to a bool knob, returns false if the knob does not exist or type mismatch
 	bool setKnob(std::string const& name, bool value);
+
+	// Sets an int64_t value to an int64_t knob, returns false if the knob does not exist or type mismatch
 	bool setKnob(std::string const& name, int64_t value);
+
+	// Sets a double value to a double knob, returns false if the knob does not exist or type mismatch
 	bool setKnob(std::string const& name, double value);
+
+	// Sets a string value to a string knob, returns false if the knob does not exist or type mismatch
 	bool setKnob(std::string const& name, std::string const& value);
+
+	// Gets the value of knob
+	ParsedKnobValue getKnob(const std::string& name) const;
+
 	ParsedKnobValue parseKnobValue(std::string const& name, std::string const& value) const;
 	bool isAtomic(std::string const& knob) const;
 	void trace() const;


### PR DESCRIPTION
With this patch, for a given test, it is possible to override the knob values, e.g.

```
    [[test]]

        [[test.knobs]]
        watch_timeout = 999
```

will set CLIENT_KNOBS->WATCH_TIMEOUT in the current test to 999. After the test completes, the knob value will be reverted. 


# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
