### PR TITLE
Fix some code that was valid but confusing to IDEs because of flow

### DIFF
--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -1855,7 +1855,7 @@ ACTOR Future<Void> fetchCheckpointQ(StorageServer* self, FetchCheckpointRequest 
 		return Void();
 	}
 
-	state ICheckpointReader* reader;
+	state ICheckpointReader* reader = nullptr;
 
 	try {
 		reader = newCheckpointReader(it->second, deterministicRandom()->randomUniqueID());


### PR DESCRIPTION
My IDE was confused about some code in storageserver.actor.cpp because it declared the same variable name on two sides of a `wait`, declared a state variable inside of a scope and used it outside that scope, or shadowed a parameter name.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
