### PR TITLE
Fix arena size test failure on GCC

### DIFF
--- a/flow/Arena.cpp
+++ b/flow/Arena.cpp
@@ -676,6 +676,7 @@ TEST_CASE("/flow/Arena/DefaultBoostHash") {
 
 TEST_CASE("/flow/Arena/Size") {
 	Arena a;
+	int fastSize, slowSize;
 
 	// Size estimates are accurate unless dependencies are added to an Arena via another Arena
 	// handle which points to a non-root node.
@@ -683,10 +684,14 @@ TEST_CASE("/flow/Arena/Size") {
 	// Note that the ASSERT argument order matters, the estimate must be calculated first as
 	// the full accurate calculation will update the estimate
 	makeString(40, a);
-	ASSERT_EQ(a.getSize(true), a.getSize());
+	fastSize = a.getSize(true);
+	slowSize = a.getSize();
+	ASSERT_EQ(fastSize, slowSize);
 
 	makeString(700, a);
-	ASSERT_EQ(a.getSize(true), a.getSize());
+	fastSize = a.getSize(true);
+	slowSize = a.getSize();
+	ASSERT_EQ(fastSize, slowSize);
 
 	// Copy a at a point where it points to a large block with room for block references
 	Arena b = a;
@@ -697,35 +702,51 @@ TEST_CASE("/flow/Arena/Size") {
 
 	makeString(1000, a);
 	makeString(1000, a);
-	ASSERT_EQ(a.getSize(true), a.getSize());
+	fastSize = a.getSize(true);
+	slowSize = a.getSize();
+	ASSERT_EQ(fastSize, slowSize);
 
 	Standalone<StringRef> s = makeString(500);
 	a.dependsOn(s.arena());
-	ASSERT_EQ(a.getSize(true), a.getSize());
+	fastSize = a.getSize(true);
+	slowSize = a.getSize();
+	ASSERT_EQ(fastSize, slowSize);
 
 	Standalone<StringRef> s2 = makeString(500);
 	a.dependsOn(s2.arena());
-	ASSERT_EQ(a.getSize(true), a.getSize());
+	fastSize = a.getSize(true);
+	slowSize = a.getSize();
+	ASSERT_EQ(fastSize, slowSize);
 
 	// Add a dependency to b, which will fit in b's root and update b's size estimate
 	Standalone<StringRef> s3 = makeString(100);
 	b.dependsOn(s3.arena());
-	ASSERT_EQ(b.getSize(true), b.getSize());
+	fastSize = b.getSize(true);
+	slowSize = b.getSize();
+	ASSERT_EQ(fastSize, slowSize);
 
 	// But now a's size estimate is out of date because the new reference in b's root is still
 	// in a's tree
-	ASSERT_LT(a.getSize(true), a.getSize());
+	fastSize = a.getSize(true);
+	slowSize = a.getSize();
+	ASSERT_LT(fastSize, slowSize);
 
 	// Now that a full size calc has been done on a, the estimate is up to date.
-	ASSERT_EQ(a.getSize(true), a.getSize());
+	fastSize = a.getSize(true);
+	slowSize = a.getSize();
+	ASSERT_EQ(fastSize, slowSize);
 
 	// Add a dependency to c, which will NOT fit in c's root, so it will be added to a new
 	// root for c and that root will not be in a's tree so a's size and estimate remain
 	// unchanged and the same.  The size and estimate of c will also match.
 	Standalone<StringRef> s4 = makeString(100);
 	c.dependsOn(s4.arena());
-	ASSERT_EQ(c.getSize(true), c.getSize());
-	ASSERT_EQ(a.getSize(true), a.getSize());
+	fastSize = c.getSize(true);
+	slowSize = c.getSize();
+	ASSERT_EQ(fastSize, slowSize);
+	fastSize = a.getSize(true);
+	slowSize = a.getSize();
+	ASSERT_EQ(fastSize, slowSize);
 
 	return Void();
 }


### PR DESCRIPTION
Change assertions to not rely on the first argument being evaluated before the second.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
