### PR TITLE
refactor unicast recovery

### DIFF
--- a/fdbserver/ClusterRecovery.actor.cpp
+++ b/fdbserver/ClusterRecovery.actor.cpp
@@ -1142,6 +1142,12 @@ ACTOR Future<Void> updateLocalityForDcId(Optional<Key> dcId,
 		if (ver == invalidVersion) {
 			ver = oldLogSystem->getKnownCommittedVersion();
 		}
+		if (SERVER_KNOBS->ENABLE_VERSION_VECTOR_TLOG_UNICAST) {
+			// Do not try to split peeks between data centers in peekTxns() to recover mem kvstore.
+			// This recovery optimization won't work in UNICAST mode.
+			loc.first = -1;
+		}
+
 		locality->set(PeekTxsInfo(loc.first, loc.second, ver));
 		TraceEvent("UpdatedLocalityForDcId")
 		    .detail("DcId", dcId)

--- a/fdbserver/TagPartitionedLogSystem.actor.cpp
+++ b/fdbserver/TagPartitionedLogSystem.actor.cpp
@@ -522,7 +522,7 @@ Future<Version> TagPartitionedLogSystem::push(Version prevVersion,
 		for (auto& it : tLogs) {
 			for (int loc = 0; loc < it->logServers.size(); loc++) {
 				if (tpcvMap.get().find(location) != tpcvMap.get().end()) {
-					tLogCount[loc]++;
+					tLogCount[location];
 				}
 				location++;
 			}
@@ -566,7 +566,7 @@ Future<Version> TagPartitionedLogSystem::push(Version prevVersion,
 				                                                                          knownCommittedVersion,
 				                                                                          minKnownCommittedVersion,
 				                                                                          msg,
-				                                                                          tLogCount[loc],
+				                                                                          tLogCount[location],
 				                                                                          debugID),
 				                                                        TaskPriority::ProxyTLogCommitReply)));
 				Future<Void> commitSuccess = success(allReplies.back());


### PR DESCRIPTION
- Refactor for readability. 
- Add bug fix lost in previous rebase - do not limit transaction store recovery to a single DC
- Consult number of tLogs per log group affected by transaction for recovery.
