### PR TITLE
Non-simulated test harness runs don't check the unseed

### DIFF
--- a/contrib/TestHarness/Program.cs
+++ b/contrib/TestHarness/Program.cs
@@ -359,7 +359,7 @@ namespace SummarizeTest
             }
 
             int result = 0;
-            bool unseedCheck = random.NextDouble() < unseedRatio;
+            bool unseedCheck = !noSim && random.NextDouble() < unseedRatio;
             for (int i = 0; i < maxTries; ++i)
             {
                 bool logOnRetryableError = i == maxTries - 1;


### PR DESCRIPTION
I think these tests are responsible for the frequent unseed mismatch CI failures recently.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
