### PR TITLE
Jemalloc integration fixes

### DIFF
--- a/cmake/ConfigureCompiler.cmake
+++ b/cmake/ConfigureCompiler.cmake
@@ -5,7 +5,6 @@ env_set(USE_DTRACE ON BOOL "Enable dtrace probes on supported platforms")
 env_set(USE_VALGRIND OFF BOOL "Compile for valgrind usage")
 env_set(USE_VALGRIND_FOR_CTEST ${USE_VALGRIND} BOOL "Use valgrind for ctest")
 env_set(ALLOC_INSTRUMENTATION OFF BOOL "Instrument alloc")
-env_set(USE_JEMALLOC ON BOOL "Link with jemalloc")
 env_set(USE_ASAN OFF BOOL "Compile with address sanitizer")
 env_set(USE_GCOV OFF BOOL "Compile with gcov instrumentation")
 env_set(USE_MSAN OFF BOOL "Compile with memory sanitizer. To avoid false positives you need to dynamically link to a msan-instrumented libc++ and libc++abi, which you must compile separately. See https://github.com/google/sanitizers/wiki/MemorySanitizerLibcxxHowTo#instrumented-libc.")
@@ -31,6 +30,14 @@ set(USE_SANITIZER OFF)
 if(USE_ASAN OR USE_VALGRIND OR USE_MSAN OR USE_TSAN OR USE_UBSAN)
   set(USE_SANITIZER ON)
 endif()
+
+set(jemalloc_default ON)
+# We don't want to use jemalloc on Windows
+# Nor on FreeBSD, where jemalloc is the default system allocator
+if(USE_SANITIZER OR WIN32 OR (CMAKE_SYSTEM_NAME STREQUAL "FreeBSD") OR APPLE)
+  set(jemalloc_default OFF)
+endif()
+env_set(USE_JEMALLOC ${jemalloc_default} BOOL "Link with jemalloc")
 
 if(USE_LIBCXX AND STATIC_LINK_LIBCXX AND NOT USE_LD STREQUAL "LLD")
   message(FATAL_ERROR "Unsupported configuration: STATIC_LINK_LIBCXX with libc++ only works if USE_LD=LLD")

--- a/cmake/Jemalloc.cmake
+++ b/cmake/Jemalloc.cmake
@@ -1,12 +1,5 @@
 add_library(jemalloc INTERFACE)
 
-# We don't want to use jemalloc on Windows
-# Nor on FreeBSD, where jemalloc is the default system allocator
-if(USE_SANITIZER OR WIN32 OR (CMAKE_SYSTEM_NAME STREQUAL "FreeBSD") OR APPLE)
-  set(USE_JEMALLOC OFF)
-  return()
-endif()
-
 if(NOT USE_JEMALLOC)
   return()
 endif()

--- a/contrib/TestHarness/Program.cs
+++ b/contrib/TestHarness/Program.cs
@@ -829,7 +829,7 @@ namespace SummarizeTest
                                 if (ev.DDetails.ContainsKey("FaultInjectionEnabled"))
                                     xout.Add(new XAttribute("FaultInjectionEnabled", ev.Details.FaultInjectionEnabled));
                             }
-                            if (ev.Type == "Simulation")
+                            if (ev.Type == "Simulation" || ev.Type == "NonSimulationTest")
                             {
                                 xout.Add(
                                     new XAttribute("TestFile", ev.Details.TestFile));

--- a/contrib/TestHarness/Program.cs
+++ b/contrib/TestHarness/Program.cs
@@ -835,11 +835,6 @@ namespace SummarizeTest
                                     new XAttribute("TestFile", ev.Details.TestFile));
                                 testFile = ev.Details.TestFile.Substring(ev.Details.TestFile.IndexOf("tests"));
                             }
-                            if (ev.Type == "ActualRun")
-                            {
-                                xout.Add(
-                                    new XAttribute("TestFile", ev.Details.RunID));
-                            }
                             if (ev.Type == "ElapsedTime" && !testEndFound)
                             {
                                 testEndFound = true;

--- a/fdbrpc/AsyncFileCached.actor.h
+++ b/fdbrpc/AsyncFileCached.actor.h
@@ -84,6 +84,9 @@ struct EvictablePageCache : ReferenceCounted<EvictablePageCache> {
 #else
 		page->data = pageSize == 4096 ? FastAllocator<4096>::allocate() : aligned_alloc(4096, pageSize);
 #endif
+		if (page->data == nullptr) {
+			platform::outOfMemory();
+		}
 		if (RANDOM == cacheEvictionType) {
 			page->index = pages.size();
 			pages.push_back(page);
@@ -396,6 +399,9 @@ struct AFCPage : public EvictablePage, public FastAllocated<AFCPage> {
 #else
 		data = pageCache->pageSize == 4096 ? FastAllocator<4096>::allocate() : aligned_alloc(4096, pageCache->pageSize);
 #endif
+		if (data == nullptr) {
+			platform::outOfMemory();
+		}
 	}
 
 	Future<Void> write(void const* data, int length, int offset) {

--- a/fdbserver/fdbserver.actor.cpp
+++ b/fdbserver/fdbserver.actor.cpp
@@ -2085,6 +2085,7 @@ int main(int argc, char* argv[]) {
 			                       opts.localities));
 			g_network->run();
 		} else if (role == ServerRole::Test) {
+			TraceEvent("NonSimulationTest").detail("TestFile", opts.testFile);
 			setupRunLoopProfiler();
 			auto m = startSystemMonitor(opts.dataFolder, opts.dcId, opts.zoneId, opts.zoneId);
 			f = stopAfter(runTests(

--- a/flow/Deque.h
+++ b/flow/Deque.h
@@ -44,7 +44,9 @@ public:
 	Deque(Deque const& r) : arr(nullptr), begin(0), end(r.size()), mask(r.mask) {
 		if (r.capacity() > 0) {
 			arr = (T*)aligned_alloc(std::max(__alignof(T), sizeof(void*)), capacity() * sizeof(T));
-			ASSERT(arr != nullptr);
+			if (arr == nullptr) {
+				platform::outOfMemory();
+			}
 		}
 		ASSERT(capacity() >= end || end == 0);
 		if (r.end < r.capacity()) {
@@ -67,7 +69,9 @@ public:
 		mask = r.mask;
 		if (r.capacity() > 0) {
 			arr = (T*)aligned_alloc(std::max(__alignof(T), sizeof(void*)), capacity() * sizeof(T));
-			ASSERT(arr != nullptr);
+			if (arr == nullptr) {
+				platform::outOfMemory();
+			}
 		}
 		ASSERT(capacity() >= end || end == 0);
 		if (r.end < r.capacity()) {
@@ -193,7 +197,9 @@ private:
 		// printf("Growing to %lld (%u-%u mask %u)\n", (long long)newSize, begin, end, mask);
 		T* newArr = (T*)aligned_alloc(std::max(__alignof(T), sizeof(void*)),
 		                              newSize * sizeof(T)); // SOMEDAY: FastAllocator
-		ASSERT(newArr != nullptr);
+		if (newArr == nullptr) {
+			platform::outOfMemory();
+		}
 		for (int i = begin; i != end; i++) {
 			try {
 				new (&newArr[i - begin]) T(std::move_if_noexcept(arr[i & mask]));

--- a/flow/FastAlloc.h
+++ b/flow/FastAlloc.h
@@ -103,6 +103,8 @@ void recordAllocation(void* ptr, size_t size);
 void recordDeallocation(void* ptr);
 #endif
 
+inline constexpr auto kFastAllocMagazineBytes = 128 << 10;
+
 template <int Size>
 class FastAllocator {
 public:
@@ -125,7 +127,7 @@ private:
 	static unsigned long vLock;
 #endif
 
-	static const int magazine_size = (128 << 10) / Size;
+	static const int magazine_size = kFastAllocMagazineBytes / Size;
 	static const int PSize = Size / sizeof(void*);
 	struct GlobalData;
 	struct ThreadData {

--- a/flow/FastAlloc.h
+++ b/flow/FastAlloc.h
@@ -287,7 +287,11 @@ inline void freeFast(int size, void* ptr) {
 	if (size <= 16384)
 		return FastAllocator<16384>::allocate();
 #endif
-	return aligned_alloc(4096, size);
+	auto* result = aligned_alloc(4096, size);
+	if (result == nullptr) {
+		platform::outOfMemory();
+	}
+	return result;
 }
 
 inline void freeFast4kAligned(int size, void* ptr) {


### PR DESCRIPTION
Fix the cmake logic that decides whether or not to link to jemalloc. It was incorrectly linking to jemalloc for sanitizer builds previously.

Also include the filename in the test harness output for tests in the noSim directory.

Also check aligned_alloc for nullptr, and make sure that jemalloc does not have internal fragmentation when requesting fast alloc magazines (since I think we want to make use of that later)

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
