### PR TITLE
Redwood small memory usage reductions and a small CPU reduction

### DIFF
--- a/fdbserver/VersionedBTree.actor.cpp
+++ b/fdbserver/VersionedBTree.actor.cpp
@@ -2705,7 +2705,7 @@ public:
 		// future reads of the version are not allowed) and the write of the next newest version over top
 		// of the original page begins.
 		if (!cacheEntry.initialized()) {
-			cacheEntry.writeFuture = writePhysicalPage(reason, level, pageIDs, data);
+			cacheEntry.writeFuture = detach(writePhysicalPage(reason, level, pageIDs, data));
 		} else if (cacheEntry.reading()) {
 			// Wait for the read to finish, then start the write.
 			cacheEntry.writeFuture = map(success(cacheEntry.readFuture), [=](Void) {
@@ -2721,7 +2721,7 @@ public:
 				return Void();
 			});
 		} else {
-			cacheEntry.writeFuture = writePhysicalPage(reason, level, pageIDs, data);
+			cacheEntry.writeFuture = detach(writePhysicalPage(reason, level, pageIDs, data));
 		}
 
 		// Always update the page contents immediately regardless of what happened above.

--- a/flow/genericactors.actor.h
+++ b/flow/genericactors.actor.h
@@ -1119,6 +1119,12 @@ Future<T> tagError(Future<Void> future, Error e) {
 	throw e;
 }
 
+ACTOR template <class T>
+Future<T> detach(Future<T> f) {
+	T x = wait(f);
+	return x;
+}
+
 // If the future is ready, yields and returns. Otherwise, returns when future is set.
 template <class T>
 Future<T> orYield(Future<T> f) {


### PR DESCRIPTION
Changed a `SignallableActorCollection` to a simple `vector<Future<Void>>` as the semantics of the actor collection aren't needed anymore.

Added generic `Future<T> detach(Future<T>)` which allows futures that will exist for a long time hold a smaller actor that contains the result of a much larger actor to save the larger actor's memory footprint from being held alive long after its actor has finished.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
