### PR TITLE
Better cancelling logic that reflects whether move has actually started

### DIFF
--- a/fdbserver/DataDistributionQueue.actor.cpp
+++ b/fdbserver/DataDistributionQueue.actor.cpp
@@ -50,11 +50,12 @@ struct RelocateData {
 	std::vector<UID> completeSources;
 	std::vector<UID> completeDests;
 	bool wantsNewServers;
+	bool cancellable;
 	TraceInterval interval;
 
 	RelocateData()
 	  : priority(-1), boundaryPriority(-1), healthPriority(-1), startTime(-1), workFactor(0), wantsNewServers(false),
-	    interval("QueuedRelocation") {}
+	    cancellable(false), interval("QueuedRelocation") {}
 	explicit RelocateData(RelocateShard const& rs)
 	  : keys(rs.keys), priority(rs.priority), boundaryPriority(isBoundaryPriority(rs.priority) ? rs.priority : -1),
 	    healthPriority(isHealthPriority(rs.priority) ? rs.priority : -1), startTime(now()),
@@ -63,7 +64,7 @@ struct RelocateData {
 	                    rs.priority == SERVER_KNOBS->PRIORITY_REBALANCE_UNDERUTILIZED_TEAM ||
 	                    rs.priority == SERVER_KNOBS->PRIORITY_SPLIT_SHARD ||
 	                    rs.priority == SERVER_KNOBS->PRIORITY_TEAM_REDUNDANT),
-	    interval("QueuedRelocation") {}
+	    cancellable(true), interval("QueuedRelocation") {}
 
 	static bool isHealthPriority(int priority) {
 		return priority == SERVER_KNOBS->PRIORITY_POPULATE_REGION ||
@@ -610,19 +611,23 @@ struct DDQueueData {
 						    .detail(
 						        "Problem",
 						        "the key range in the inFlight map matches the key range in the RelocateData message");
+				} else if (it->value().cancellable) {
+					TraceEvent(SevError, "DDQueueValidateError13")
+					    .detail("Problem", "key range is cancellable but not in flight!")
+					    .detail("Range", it->range());
 				}
 			}
 
 			for (auto it = busymap.begin(); it != busymap.end(); ++it) {
 				for (int i = 0; i < it->second.ledger.size() - 1; i++) {
 					if (it->second.ledger[i] < it->second.ledger[i + 1])
-						TraceEvent(SevError, "DDQueueValidateError13")
+						TraceEvent(SevError, "DDQueueValidateError14")
 						    .detail("Problem", "ascending ledger problem")
 						    .detail("LedgerLevel", i)
 						    .detail("LedgerValueA", it->second.ledger[i])
 						    .detail("LedgerValueB", it->second.ledger[i + 1]);
 					if (it->second.ledger[i] < 0.0)
-						TraceEvent(SevError, "DDQueueValidateError14")
+						TraceEvent(SevError, "DDQueueValidateError15")
 						    .detail("Problem", "negative ascending problem")
 						    .detail("LedgerLevel", i)
 						    .detail("LedgerValue", it->second.ledger[i]);
@@ -632,13 +637,13 @@ struct DDQueueData {
 			for (auto it = destBusymap.begin(); it != destBusymap.end(); ++it) {
 				for (int i = 0; i < it->second.ledger.size() - 1; i++) {
 					if (it->second.ledger[i] < it->second.ledger[i + 1])
-						TraceEvent(SevError, "DDQueueValidateError15")
+						TraceEvent(SevError, "DDQueueValidateError16")
 						    .detail("Problem", "ascending ledger problem")
 						    .detail("LedgerLevel", i)
 						    .detail("LedgerValueA", it->second.ledger[i])
 						    .detail("LedgerValueB", it->second.ledger[i + 1]);
 					if (it->second.ledger[i] < 0.0)
-						TraceEvent(SevError, "DDQueueValidateError16")
+						TraceEvent(SevError, "DDQueueValidateError17")
 						    .detail("Problem", "negative ascending problem")
 						    .detail("LedgerLevel", i)
 						    .detail("LedgerValue", it->second.ledger[i]);
@@ -954,7 +959,7 @@ struct DDQueueData {
 			auto containedRanges = inFlight.containedRanges(rd.keys);
 			std::vector<RelocateData> cancellableRelocations;
 			for (auto it = containedRanges.begin(); it != containedRanges.end(); ++it) {
-				if (inFlightActors.liveActorAt(it->range().begin)) {
+				if (it.value().cancellable) {
 					cancellableRelocations.push_back(it->value());
 				}
 			}
@@ -1179,6 +1184,12 @@ ACTOR Future<Void> dataDistributionRelocator(DDQueueData* self, RelocateData rd,
 
 				// TODO different trace event + knob for overloaded? Could wait on an async var for done moves
 			}
+
+			// set cancellable to false on inFlight's entry for this key range
+			auto inFlightRange = self->inFlight.rangeContaining(rd.keys.begin);
+			ASSERT(inFlightRange.range() == rd.keys);
+			ASSERT(inFlightRange.value().randomId == rd.randomId);
+			inFlightRange.value().cancellable = false;
 
 			destIds.clear();
 			state std::vector<UID> healthyIds;


### PR DESCRIPTION
Follow-on PR to #6178 
Improve cancelling logic in DDQueue to more accurately reflect when a move has started.
This behavior was desired before the previous PR, but is now much more desirable, since the destination limiting causes significantly more moves to spend time in the state where the dataDistributionRelocator actor is started, but startMoveKeys has not yet been called.

Passed 100k correctness.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
