### PR TITLE
Limit tenant subspace to the normal key space

### DIFF
--- a/fdbserver/workloads/TenantManagement.actor.cpp
+++ b/fdbserver/workloads/TenantManagement.actor.cpp
@@ -82,7 +82,9 @@ struct TenantManagementWorkload : TestWorkload {
 		state Transaction tr(cx);
 		if (self->clientId == 0) {
 			self->tenantSubspace = makeString(deterministicRandom()->randomInt(0, 10));
-			generateRandomData(mutateString(self->tenantSubspace), self->tenantSubspace.size());
+			while (self->tenantSubspace.startsWith(systemKeys.begin)) {
+				generateRandomData(mutateString(self->tenantSubspace), self->tenantSubspace.size());
+			}
 			loop {
 				try {
 					tr.setOption(FDBTransactionOptions::RAW_ACCESS);

--- a/fdbserver/workloads/TenantManagement.actor.cpp
+++ b/fdbserver/workloads/TenantManagement.actor.cpp
@@ -82,8 +82,11 @@ struct TenantManagementWorkload : TestWorkload {
 		state Transaction tr(cx);
 		if (self->clientId == 0) {
 			self->tenantSubspace = makeString(deterministicRandom()->randomInt(0, 10));
-			while (self->tenantSubspace.startsWith(systemKeys.begin)) {
+			loop {
 				generateRandomData(mutateString(self->tenantSubspace), self->tenantSubspace.size());
+				if (!self->tenantSubspace.startsWith(systemKeys.begin)) {
+					break;
+				}
 			}
 			loop {
 				try {


### PR DESCRIPTION
Setting a tenant subspace in the special keys causes various errors, and having a tenant subspace in the system keys could cause problems with the test depending on the prefix chosen.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
