### PR TITLE
Added missing 16k magazine size to memory stats.

### DIFF
--- a/flow/SystemMonitor.cpp
+++ b/flow/SystemMonitor.cpp
@@ -160,6 +160,7 @@ SystemStatistics customSystemMonitor(std::string const& eventName, StatisticsSta
 			    .DETAILALLOCATORMEMUSAGE(2048)
 			    .DETAILALLOCATORMEMUSAGE(4096)
 			    .DETAILALLOCATORMEMUSAGE(8192)
+			    .DETAILALLOCATORMEMUSAGE(16384)
 			    .detail("HugeArenaMemory", g_hugeArenaMemory.load())
 			    .detail("DCID", machineState.dcId)
 			    .detail("ZoneID", machineState.zoneId)
@@ -177,6 +178,7 @@ SystemStatistics customSystemMonitor(std::string const& eventName, StatisticsSta
 			total_memory += FastAllocator<2048>::getTotalMemory();
 			total_memory += FastAllocator<4096>::getTotalMemory();
 			total_memory += FastAllocator<8192>::getTotalMemory();
+			total_memory += FastAllocator<16384>::getTotalMemory();
 
 			uint64_t unused_memory = 0;
 			unused_memory += FastAllocator<16>::getApproximateMemoryUnused();
@@ -190,6 +192,7 @@ SystemStatistics customSystemMonitor(std::string const& eventName, StatisticsSta
 			unused_memory += FastAllocator<2048>::getApproximateMemoryUnused();
 			unused_memory += FastAllocator<4096>::getApproximateMemoryUnused();
 			unused_memory += FastAllocator<8192>::getApproximateMemoryUnused();
+			unused_memory += FastAllocator<16384>::getApproximateMemoryUnused();
 
 			if (total_memory > 0) {
 				TraceEvent("FastAllocMemoryUsage")


### PR DESCRIPTION
This size was missing in three places reporting FastAlloc memory stats.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
