### PR TITLE
Make overwriteProxiesCount a function of conf keys

### DIFF
--- a/fdbclient/DatabaseConfiguration.cpp
+++ b/fdbclient/DatabaseConfiguration.cpp
@@ -488,9 +488,9 @@ void DatabaseConfiguration::overwriteProxiesCount() {
 	Optional<ValueRef> optGrvProxies = DatabaseConfiguration::get(grvProxiesKey);
 	Optional<ValueRef> optProxies = DatabaseConfiguration::get(proxiesKey);
 
-	const int mutableGrvProxyCount = optGrvProxies.present() ? toInt(optGrvProxies.get()) : 0;
-	const int mutableCommitProxyCount = optCommitProxies.present() ? toInt(optCommitProxies.get()) : 0;
-	const int mutableProxiesCount = optProxies.present() ? toInt(optProxies.get()) : 0;
+	const int mutableGrvProxyCount = optGrvProxies.present() ? toInt(optGrvProxies.get()) : -1;
+	const int mutableCommitProxyCount = optCommitProxies.present() ? toInt(optCommitProxies.get()) : -1;
+	const int mutableProxiesCount = optProxies.present() ? toInt(optProxies.get()) : -1;
 
 	if (mutableProxiesCount > 1) {
 		TraceEvent(SevDebug, "OverwriteProxiesCount")
@@ -500,23 +500,23 @@ void DatabaseConfiguration::overwriteProxiesCount() {
 		    .detail("MutableGrvCPCount", mutableGrvProxyCount)
 		    .detail("MutableProxiesCount", mutableProxiesCount);
 
-		if (grvProxyCount == -1 && commitProxyCount > 0) {
-			if (mutableProxiesCount > commitProxyCount) {
-				grvProxyCount = mutableProxiesCount - commitProxyCount;
+		if (mutableGrvProxyCount == -1 && mutableCommitProxyCount > 0) {
+			if (mutableProxiesCount > mutableCommitProxyCount) {
+				grvProxyCount = mutableProxiesCount - mutableCommitProxyCount;
 			} else {
 				// invalid configuration; provision min GrvProxies
 				grvProxyCount = 1;
 				commitProxyCount = mutableProxiesCount - 1;
 			}
-		} else if (grvProxyCount > 0 && commitProxyCount == -1) {
-			if (mutableProxiesCount > grvProxyCount) {
+		} else if (mutableGrvProxyCount > 0 && mutableCommitProxyCount == -1) {
+			if (mutableProxiesCount > mutableGrvProxyCount) {
 				commitProxyCount = mutableProxiesCount - grvProxyCount;
 			} else {
 				// invalid configuration; provision min CommitProxies
 				commitProxyCount = 1;
 				grvProxyCount = mutableProxiesCount - 1;
 			}
-		} else if (grvProxyCount == -1 && commitProxyCount == -1) {
+		} else if (mutableGrvProxyCount == -1 && mutableCommitProxyCount == -1) {
 			// Use DEFAULT_COMMIT_GRV_PROXIES_RATIO to split proxies between Grv & Commit proxies
 			const int derivedGrvProxyCount =
 			    std::max(1,

--- a/fdbclient/DatabaseConfiguration.cpp
+++ b/fdbclient/DatabaseConfiguration.cpp
@@ -23,6 +23,7 @@
 #include "flow/ITrace.h"
 #include "flow/Trace.h"
 #include "flow/genericactors.actor.h"
+#include "flow/UnitTest.h"
 
 DatabaseConfiguration::DatabaseConfiguration() {
 	resetInternal();
@@ -819,4 +820,22 @@ bool DatabaseConfiguration::isOverridden(std::string key) const {
 	}
 
 	return false;
+}
+
+TEST_CASE("/fdbclient/databaseConfiguration/overwriteCommitProxy") {
+	DatabaseConfiguration conf1;
+	conf1.applyMutation(MutationRef(MutationRef::SetValue, "\xff/conf/grv_proxies"_sr, "5"_sr));
+	conf1.applyMutation(MutationRef(MutationRef::SetValue, "\xff/conf/proxies"_sr, "10"_sr));
+	conf1.applyMutation(MutationRef(MutationRef::SetValue, "\xff/conf/grv_proxies"_sr, "-1"_sr));
+	conf1.applyMutation(MutationRef(MutationRef::SetValue, "\xff/conf/commit_proxies"_sr, "-1"_sr));
+
+	DatabaseConfiguration conf2;
+	conf2.applyMutation(MutationRef(MutationRef::SetValue, "\xff/conf/proxies"_sr, "10"_sr));
+	conf2.applyMutation(MutationRef(MutationRef::SetValue, "\xff/conf/grv_proxies"_sr, "-1"_sr));
+	conf2.applyMutation(MutationRef(MutationRef::SetValue, "\xff/conf/commit_proxies"_sr, "-1"_sr));
+
+	ASSERT(conf1 == conf2);
+	ASSERT(conf1.getDesiredCommitProxies() == conf2.getDesiredCommitProxies());
+
+	return Void();
 }

--- a/fdbserver/ClusterRecovery.actor.cpp
+++ b/fdbserver/ClusterRecovery.actor.cpp
@@ -1616,12 +1616,12 @@ ACTOR Future<Void> clusterRecoveryCore(Reference<ClusterRecoveryData> self) {
 
 	recoverAndEndEpoch.cancel();
 
-	ASSERT(self->commitProxies.size() <= self->configuration.getDesiredCommitProxies());
-	ASSERT(self->commitProxies.size() >= 1);
-	ASSERT(self->grvProxies.size() <= self->configuration.getDesiredGrvProxies());
-	ASSERT(self->grvProxies.size() >= 1);
-	ASSERT(self->resolvers.size() <= self->configuration.getDesiredResolvers());
-	ASSERT(self->resolvers.size() >= 1);
+	ASSERT_LE(self->commitProxies.size(), self->configuration.getDesiredCommitProxies());
+	ASSERT_GE(self->commitProxies.size(), 1);
+	ASSERT_LE(self->grvProxies.size(), self->configuration.getDesiredGrvProxies());
+	ASSERT_GE(self->grvProxies.size(), 1);
+	ASSERT_LE(self->resolvers.size(), self->configuration.getDesiredResolvers());
+	ASSERT_GE(self->resolvers.size(), 1);
 
 	self->recoveryState = RecoveryState::RECOVERY_TRANSACTION;
 	TraceEvent(getRecoveryEventName(ClusterRecoveryEventType::CLUSTER_RECOVERY_STATE_EVENT_NAME).c_str(), self->dbgid)


### PR DESCRIPTION
- Improve assert diagnostics
- Make overwriteProxiesCount a deterministic function of conf keys

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
