### PR TITLE
Fix incorrect prefix in storageServerListToTeamIdKey

### DIFF
--- a/fdbclient/SystemData.cpp
+++ b/fdbclient/SystemData.cpp
@@ -465,7 +465,7 @@ const KeyRef storageServerListToTeamIdKeyPrefix = "\xff/storageServerListToTeamI
 const Key storageServerListToTeamIdKey(std::vector<UID> servers) {
 	BinaryWriter wr(Unversioned());
 	std::sort(servers.begin(), servers.end());
-	wr.serializeBytes(storageServerToTeamIdKeyPrefix);
+	wr.serializeBytes(storageServerListToTeamIdKeyPrefix);
 	wr << static_cast<int>(servers.size());
 	for (auto& s : servers) {
 		wr << s;


### PR DESCRIPTION
This is a typo from https://github.com/apple/foundationdb/commit/83fa2e2c626bb27ddddaa68fe12fe014a416188a#diff-48d9eb52a8b2837c32fa75fe526faff0949d52a0ca9170276e5731016081e3a5R337

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
