### PR TITLE
Fix Valgrind error where Promise is already destroyed when actors are being cancelled

### DIFF
--- a/fdbserver/PaxosConfigConsumer.actor.cpp
+++ b/fdbserver/PaxosConfigConsumer.actor.cpp
@@ -40,6 +40,9 @@ struct QuorumVersion {
 };
 
 class GetCommittedVersionQuorum {
+	// Set to the <secondToLastCommitted, lastCommitted> versions a quorum of
+	// ConfigNodes agree on, otherwise unset.
+	Promise<QuorumVersion> quorumVersion;
 	std::vector<Future<Void>> actors;
 	std::vector<ConfigFollowerInterface> cfis;
 	std::map<Version, std::vector<ConfigFollowerInterface>> replies;
@@ -52,9 +55,6 @@ class GetCommittedVersionQuorum {
 	Version lastSeenVersion;
 	size_t totalRepliesReceived{ 0 };
 	size_t maxAgreement{ 0 };
-	// Set to the <secondToLastCommitted, lastCommitted> versions a quorum of
-	// ConfigNodes agree on, otherwise unset.
-	Promise<QuorumVersion> quorumVersion;
 	// Stores the largest committed version out of all responses.
 	Version largestCommitted{ 0 };
 


### PR DESCRIPTION
Move the Promise<QuorumVersion> before the Future vector to let it be destroyed after the vector.

Passed the 1k Valgrind test and 10K correctness

-----------

From nightly Valgrind result

```
Results for test ensemble: 20220322-053356-nightly_valgrind_main-502b143cd34ecf22
Ensemble stopped
devRetryCorrectnessTest valgrind bin/fdbserver -r simulation -f tests/rare/ConfigIncrementWithKills.toml -s 10235636 -b on  --crash --trace_format json
{
   "BuggifyEnabled" : "1",
   "Command" : "devRetryCorrectnessTest valgrind bin/fdbserver -r simulation -f tests/rare/ConfigIncrementWithKills.toml -s 10235636 -b on  --crash --trace_format json",
   "DeterminismCheck" : "0",
   "Errors" : [
      {
         "Severity" : "40",
         "Type" : "ValgrindError",
         "What" : "Invalid read of size 2"
      },
      {
         "Severity" : "40",
         "Type" : "ValgrindError",
         "What" : "Invalid read of size 8"
      },
      {
         "Severity" : "40",
         "Type" : "ValgrindError",
         "What" : "Invalid write of size 4"
      }
   ],
   "Failed" : "0",
   "FaultInjectionEnabled" : "1",
   "JoshuaRun" : "20220322-053356-nightly_valgrind_main-502b143cd34ecf22",
   "OK" : "false",
   "OldBinary" : "",
   "Passed" : "1",
   "PeakMemory" : "716431360",
   "RandomSeed" : "10235636",
   "RandomUnseed" : "37440",
   "RealElapsedTime" : "238.942",
   "SimElapsedTime" : "180.43",
   "SourceVersion" : "6390d93efdecd0d52cb91d88c0068befa9dea51f",
   "TestFile" : "tests/rare/ConfigIncrementWithKills.toml",
   "TestUID" : "aa0b91a9-39f0-4369-977f-b0b8f66f3412",
   "Time" : "1647927264"
}
```

The detailed trace
```
==44== Invalid read of size 2
==44==    at 0x165A6FE: GetCommittedVersionQuorum::GetCommittedVersionActorActorState<GetCommittedVersionQuorum::GetCommittedVersionActorActor>::a_body1Catch2(Error const&, int) (PaxosConfigConsumer.actor.cpp:191)
==44==    by 0x165AA10: a_callback_error (PaxosConfigConsumer.actor.g.cpp:922)
==44==    by 0x165AA10: cancel (PaxosConfigConsumer.actor.g.cpp:1505)
==44==    by 0x165AA10: GetCommittedVersionQuorum::GetCommittedVersionActorActor::cancel() (PaxosConfigConsumer.actor.g.cpp:1500)
==44==    by 0x165A402: delFutureRef (flow.h:742)
==44==    by 0x165A402: delFutureRef (flow.h:739)
==44==    by 0x165A402: ~Future (flow.h:829)
==44==    by 0x165A402: _Destroy<Future<Void> > (stl_construct.h:98)
==44==    by 0x165A402: __destroy<Future<Void>*> (stl_construct.h:108)
==44==    by 0x165A402: _Destroy<Future<Void>*> (stl_construct.h:137)
==44==    by 0x165A402: _Destroy<Future<Void>*, Future<Void> > (stl_construct.h:206)
==44==    by 0x165A402: ~vector (stl_vector.h:567)
==44==    by 0x165A402: GetCommittedVersionQuorum::~GetCommittedVersionQuorum() (PaxosConfigConsumer.actor.cpp:42)
==44==    by 0x16509F9: ~PaxosConfigConsumerImpl (PaxosConfigConsumer.actor.cpp:252)
==44==    by 0x16509F9: operator() (unique_ptr.h:81)
==44==    by 0x16509F9: ~unique_ptr (unique_ptr.h:274)
==44==    by 0x16509F9: ~PImpl (PImpl.h:26)
==44==    by 0x16509F9: ~PaxosConfigConsumer (PaxosConfigConsumer.h:29)
==44==    by 0x16509F9: PaxosConfigConsumer::~PaxosConfigConsumer() (PaxosConfigConsumer.h:29)
==44==    by 0x101D6FD: operator() (unique_ptr.h:81)
==44==    by 0x101D6FD: ~unique_ptr (unique_ptr.h:274)
==44==    by 0x101D6FD: ConfigBroadcasterImpl::~ConfigBroadcasterImpl() (ConfigBroadcaster.actor.cpp:51)
==44==    by 0x10145D8: operator() (unique_ptr.h:81)
==44==    by 0x10145D8: operator() (unique_ptr.h:75)
==44==    by 0x10145D8: ~unique_ptr (unique_ptr.h:274)
==44==    by 0x10145D8: ~PImpl (PImpl.h:26)
==44==    by 0x10145D8: ConfigBroadcaster::~ConfigBroadcaster() (ConfigBroadcaster.h:38)
==44==    by 0xE16791: (anonymous namespace)::ClusterControllerCoreActorState<(anonymous namespace)::ClusterControllerCoreActor>::~ClusterControllerCoreActorState() (ClusterController.actor.g.cpp:18339)
==44==    by 0xE16E86: (anonymous namespace)::ClusterControllerCoreActorState<(anonymous namespace)::ClusterControllerCoreActor>::a_body1loopBody1when1(ErrorOr<Void> const&, int) [clone .isra.5182] (ClusterController.actor.g.cpp:18537)
==44==    by 0xE16F9D: a_callback_fire (ClusterController.actor.g.cpp:18905)
==44==    by 0xE16F9D: ActorCallback<(anonymous namespace)::ClusterControllerCoreActor, 0, ErrorOr<Void> >::fire(ErrorOr<Void> const&) (flow.h:1302)
==44==    by 0xE113DF: finishSendAndDelPromiseRef (flow.h:694)
==44==    by 0xE113DF: (anonymous namespace)::ErrorOrActorState<Void, (anonymous namespace)::ErrorOrActor<Void> >::a_body1Catch2(Error const&, int) [clone .isra.4715] (genericactors.actor.g.h:912)
==44==    by 0xE114AD: (anonymous namespace)::ErrorOrActorState<Void, (anonymous namespace)::ErrorOrActor<Void> >::a_callback_error(ActorCallback<(anonymous namespace)::ErrorOrActor<Void>, 0, Void>*, Error) [clone .isra.4716] (genericactors.actor.g.h:1000)
==44==    by 0x32C0818: SAV<Void>::sendErrorAndDelPromiseRef(Error) [clone .constprop.385] (flow.h:717)
==44==  Address 0xce364f8 is 8 bytes before a recently re-allocated block of size 64 alloc'd
==44==    at 0x32E1896: FastAllocator<64>::allocate() (FastAlloc.cpp:352)
==44==    by 0x2A81960: operator new (FastAlloc.h:213)
==44==    by 0x2A81960: PromiseStream<Future<Void> >::PromiseStream() (flow.h:1195)
==44==    by 0x2A72EFD: ActorCollection (ActorCollection.h:70)
==44==    by 0x2A72EFD: MonitorClientDBInfoChangeActorState (NativeAPI.actor.cpp:794)
==44==    by 0x2A72EFD: MonitorClientDBInfoChangeActor (NativeAPI.actor.g.cpp:4025)
==44==    by 0x2A72EFD: monitorClientDBInfoChange (NativeAPI.actor.cpp:788)
==44==    by 0x2A72EFD: DatabaseContext::DatabaseContext(Reference<AsyncVar<Reference<IClusterConnectionRecord> > >, Reference<AsyncVar<ClientDBInfo> >, Reference<AsyncVar<Optional<ClientLeaderRegInterface> > const>, Future<Void>, TaskPriority, LocalityData const&, EnableLocalityLoadBalance, LockAware, IsInternal, int, IsSwitchable, Optional<Standalone<StringRef> >) (NativeAPI.actor.cpp:1378)
==44==    by 0x2A75B96: DatabaseContext::create(Reference<AsyncVar<ClientDBInfo> >, Future<Void>, LocalityData, EnableLocalityLoadBalance, TaskPriority, LockAware, int, IsSwitchable) (NativeAPI.actor.cpp:1641)
==44==    by 0x1D6691A: openDBOnServer(Reference<AsyncVar<ServerDBInfo> const> const&, TaskPriority, LockAware, EnableLocalityLoadBalance) (worker.actor.cpp:159)
==44==    by 0x119A62E: DataDistributorActorState (DataDistribution.actor.cpp:1218)
==44==    by 0x119A62E: DataDistributorActor (DataDistribution.actor.g.cpp:11012)
==44==    by 0x119A62E: dataDistributor(DataDistributorInterface const&, Reference<AsyncVar<ServerDBInfo> const> const&) (DataDistribution.actor.cpp:1212)
==44==    by 0x1D7FF27: (anonymous namespace)::WorkerServerActorState<(anonymous namespace)::WorkerServerActor>::a_body1cont11loopBody1when6(InitializeDataDistributorRequest&&, int) (worker.actor.cpp:1829)
==44==    by 0x1D801DD: a_callback_fire (worker.actor.g.cpp:10806)
==44==    by 0x1D801DD: ActorSingleCallback<(anonymous namespace)::WorkerServerActor, 6, InitializeDataDistributorRequest>::fire(InitializeDataDistributorRequest&&) (flow.h:1324)
==44==    by 0xBE111E: send<InitializeDataDistributorRequest> (flow.h:1006)
==44==    by 0xBE111E: send<InitializeDataDistributorRequest> (flow.h:1001)
==44==    by 0xBE111E: NetNotifiedQueue<InitializeDataDistributorRequest>::receive(ArenaObjectReader&) (fdbrpc.h:619)
==44==    by 0x31A22C7: (anonymous namespace)::DeliverActorState<(anonymous namespace)::DeliverActor>::a_body1cont1(int) [clone .isra.1050] (FlowTransport.actor.cpp:943)
==44==    by 0x31A266A: a_body1cont2 (FlowTransport.actor.g.cpp:4204)
==44==    by 0x31A266A: a_body1when1 (FlowTransport.actor.g.cpp:4216)
==44==    by 0x31A266A: a_callback_fire (FlowTransport.actor.g.cpp:4237)
==44==    by 0x31A266A: ActorCallback<(anonymous namespace)::DeliverActor, 0, Void>::fire(Void const&) (flow.h:1302)
==44==    by 0x323FF47: send<Void> (flow.h:660)
==44==    by 0x323FF47: send<Void> (flow.h:906)
==44==    by 0x323FF47: execTask (sim2.actor.cpp:2087)
==44==    by 0x323FF47: runLoop (sim2.actor.cpp:1141)
==44==    by 0x323FF47: Sim2::run() (sim2.actor.cpp:1151)
```

When `getCommittedVersionActor` is cancelled due to the `std::vector<Future<Void>>  actors` is destroyed,
`Promise<QuorumVersion> quorumVersion` is already destroyed;


# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
