### PR TITLE
Remove unused class private variable

### DIFF
--- a/fdbserver/ApplyMetadataMutation.cpp
+++ b/fdbserver/ApplyMetadataMutation.cpp
@@ -93,7 +93,7 @@ public:
 	    storageCache(&proxyCommitData_.storageCache), tag_popped(&proxyCommitData_.tag_popped),
 	    tssMapping(&proxyCommitData_.tssMapping), tLogGroupCollection(proxyCommitData_.tLogGroupCollection),
 	    initialCommit(initialCommit_), tagToServer(&proxyCommitData_.tagToServer),
-	    ssToStorageTeam(&proxyCommitData_.ssToStorageTeam), changedTeams(&proxyCommitData_.changedTeams) {
+	    ssToStorageTeam(&proxyCommitData_.ssToStorageTeam) {
 
 		for (const auto& [ss, teams] : proxyCommitData_.ssToStorageTeam) {
 			TraceEvent(SevDebug, "SSTeam", dbgid).detail("SS", ss).detail("Teams", describe(teams.getStorageTeams()));
@@ -110,8 +110,7 @@ public:
 	    confChange(*resolverData_.confChanges), logSystem(resolverData_.logSystem),
 	    popVersion(resolverData_.popVersion), keyInfo(resolverData_.keyInfo), storageCache(resolverData_.storageCache),
 	    tLogGroupCollection(resolverData_.tLogGroupCollection), initialCommit(resolverData_.initialCommit),
-	    forResolver(true), tagToServer(&resolverData_.tagToServer), ssToStorageTeam(resolverData_.ssToStorageTeam),
-	    changedTeams(&resolverData_.changedTeams) {}
+	    forResolver(true), tagToServer(&resolverData_.tagToServer), ssToStorageTeam(resolverData_.ssToStorageTeam) {}
 
 private:
 	// The following variables are incoming parameters
@@ -171,7 +170,6 @@ private:
 
 	std::map<Tag, UID>* tagToServer = nullptr;
 	std::unordered_map<UID, ptxn::StorageServerStorageTeams>* ssToStorageTeam = nullptr;
-	std::unordered_map<UID, std::vector<std::pair<ptxn::StorageTeamID, bool>>>* changedTeams = nullptr;
 
 	// All SSes' own teams, populated from ssToStorageTeam mapping.
 	std::set<ptxn::StorageTeamID> allTeams;


### PR DESCRIPTION
This is used to remove the following error during compiling:

```
/root/src/fdbserver/ApplyMetadataMutation.cpp:174:78: error: private field 'changedTeams' is not used [-Werror,-Wunused-private-field]
 std::unordered_map<UID, std::vector<std::pair<ptxn::StorageTeamID, bool>>>* changedTeams = nullptr;
```

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
