### PR TITLE
Add RocksDB Memory Usage Metrics

### DIFF
--- a/fdbserver/KeyValueStoreRocksDB.actor.cpp
+++ b/fdbserver/KeyValueStoreRocksDB.actor.cpp
@@ -784,6 +784,8 @@ ACTOR Future<Void> rocksDBMetricLogger(std::shared_ptr<rocksdb::Statistics> stat
 		{ "EstimateLiveDataSize", rocksdb::DB::Properties::kEstimateLiveDataSize },
 		{ "BaseLevel", rocksdb::DB::Properties::kBaseLevel },
 		{ "EstPendCompactBytes", rocksdb::DB::Properties::kEstimatePendingCompactionBytes },
+		{ "BlockCacheUsage", rocksdb::DB::Properties::kBlockCacheUsage },
+		{ "BlockCachePinnedUsage", rocksdb::DB::Properties::kBlockCachePinnedUsage },
 	};
 
 	state std::unordered_map<std::string, uint64_t> readIteratorPoolStats = {


### PR DESCRIPTION
To understand RocksDB memory usage, we should collect counters from RocksDB instance, as described in [https://github.com/facebook/rocksdb/wiki/Memory-usage-in-RocksDB](https://github.com/facebook/rocksdb/wiki/Memory-usage-in-RocksDB)

Some of the counter we already have. Some of them we need to add.
For block cache, we can add `kBlockCacheUsage` to our propertyStats.
For indexes and filter blocks, we have already monitored it --- `EstimateSstReaderBytes` in our propertyStats.
For memtable, we have it as `AllMemtablesBytes` in our propertyStats.
For blocks pinned by iterators, we could add `kBlockCachePinnedUsage` to our propertyStats.

**Passed Joshua test**
20220323-200456-zhewang-99aa6ca2a65e8a71           compressed=True data_size=29939315 duration=5702184 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=1:01:46 sanity=False started=100109 stopped=20220323-210642 submitted=20220323-200456 timeout=5400 username=zhewang

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
