### PR TITLE
Fixes for when getMappedRange cannot parse as tuple

### DIFF
--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -100,6 +100,9 @@ bool canReplyWith(Error e) {
 	case error_code_quick_get_value_miss:
 	case error_code_quick_get_key_values_miss:
 	case error_code_get_mapped_key_values_has_more:
+	case error_code_key_not_tuple:
+	case error_code_value_not_tuple:
+	case error_code_mapper_not_tuple:
 		// case error_code_all_alternatives_failed:
 		return true;
 	default:
@@ -3440,7 +3443,7 @@ Key constructMappedKey(KeyValueRef* keyValue, Tuple& mappedKeyFormatTuple, bool&
 						try {
 							keyTuple = Tuple::unpack(keyValue->key);
 						} catch (Error& e) {
-							TraceEvent(SevError, "KeyNotTuple").detail("Key", keyValue->key.printable());
+							TraceEvent("KeyNotTuple").error(e).detail("Key", keyValue->key.printable());
 							throw key_not_tuple();
 						}
 					}
@@ -3452,7 +3455,7 @@ Key constructMappedKey(KeyValueRef* keyValue, Tuple& mappedKeyFormatTuple, bool&
 						try {
 							valueTuple = Tuple::unpack(keyValue->value);
 						} catch (Error& e) {
-							TraceEvent(SevError, "ValueNotTuple").detail("Value", keyValue->value.printable());
+							TraceEvent("ValueNotTuple").error(e).detail("Value", keyValue->value.printable());
 							throw value_not_tuple();
 						}
 					}
@@ -3592,7 +3595,7 @@ ACTOR Future<GetMappedKeyValuesReply> mapKeyValues(StorageServer* data,
 	try {
 		mappedKeyFormatTuple = Tuple::unpack(mapper);
 	} catch (Error& e) {
-		TraceEvent(SevError, "MapperNotTuple").detail("Mapper", mapper.printable());
+		TraceEvent("MapperNotTuple").error(e).detail("Mapper", mapper.printable());
 		throw mapper_not_tuple();
 	}
 	state KeyValueRef* it = input.data.begin();

--- a/flow/error_definitions.h
+++ b/flow/error_definitions.h
@@ -179,7 +179,7 @@ ERROR( get_mapped_key_values_has_more, 2038, "getMappedRange does not support co
 ERROR( get_mapped_range_reads_your_writes, 2039, "getMappedRange tries to read data that were previously written in the transaction" )
 ERROR( checkpoint_not_found, 2040, "Checkpoint not found" )
 ERROR( key_not_tuple, 2041, "The key cannot be parsed as a tuple" );
-ERROR( value_not_tuple, 2042, "The key cannot be parsed as a tuple" );
+ERROR( value_not_tuple, 2042, "The value cannot be parsed as a tuple" );
 ERROR( mapper_not_tuple, 2043, "The mapper cannot be parsed as a tuple" );
 
 

--- a/flow/error_definitions.h
+++ b/flow/error_definitions.h
@@ -178,6 +178,10 @@ ERROR( blob_granule_not_materialized, 2037, "Blob Granule Read was not materiali
 ERROR( get_mapped_key_values_has_more, 2038, "getMappedRange does not support continuation for now" )
 ERROR( get_mapped_range_reads_your_writes, 2039, "getMappedRange tries to read data that were previously written in the transaction" )
 ERROR( checkpoint_not_found, 2040, "Checkpoint not found" )
+ERROR( key_not_tuple, 2041, "The key cannot be parsed as a tuple" );
+ERROR( value_not_tuple, 2042, "The key cannot be parsed as a tuple" );
+ERROR( mapper_not_tuple, 2043, "The mapper cannot be parsed as a tuple" );
+
 
 ERROR( incompatible_protocol_version, 2100, "Incompatible protocol version" )
 ERROR( transaction_too_large, 2101, "Transaction exceeds byte limit" )


### PR DESCRIPTION
- Throws specific exception instead of a more general error type.

- Log the violating bytes

- Make SS not retry/hang on this kind of errors

- Add and fix tests 

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
