### PR TITLE
Fix missing blob access key in credentials

### DIFF
--- a/fdbbackup/FileConverter.h
+++ b/fdbbackup/FileConverter.h
@@ -46,6 +46,7 @@ enum {
 	OPT_HEX_KEY_PREFIX,
 	OPT_BEGIN_VERSION_FILTER,
 	OPT_END_VERSION_FILTER,
+	OPT_KNOB,
 	OPT_HELP
 };
 
@@ -72,6 +73,7 @@ CSimpleOpt::SOption gConverterOptions[] = { { OPT_CONTAINER, "-r", SO_REQ_SEP },
 	                                        { OPT_HEX_KEY_PREFIX, "--hex-prefix", SO_REQ_SEP },
 	                                        { OPT_BEGIN_VERSION_FILTER, "--begin-version-filter", SO_REQ_SEP },
 	                                        { OPT_END_VERSION_FILTER, "--end-version-filter", SO_REQ_SEP },
+	                                        { OPT_KNOB, "--knob-", SO_REQ_SEP },
 	                                        { OPT_HELP, "-?", SO_NONE },
 	                                        { OPT_HELP, "-h", SO_NONE },
 	                                        { OPT_HELP, "--help", SO_NONE },

--- a/fdbbackup/FileDecoder.actor.cpp
+++ b/fdbbackup/FileDecoder.actor.cpp
@@ -26,17 +26,21 @@
 #include <vector>
 
 #include "fdbbackup/BackupTLSConfig.h"
+#include "fdbclient/BuildFlags.h"
+#include "fdbbackup/FileConverter.h"
 #include "fdbclient/BackupAgent.actor.h"
 #include "fdbclient/BackupContainer.h"
-#include "fdbbackup/FileConverter.h"
 #include "fdbclient/CommitTransaction.h"
 #include "fdbclient/FDBTypes.h"
+#include "fdbclient/IKnobCollection.h"
+#include "fdbclient/Knobs.h"
 #include "fdbclient/MutationList.h"
+#include "flow/ArgParseUtil.h"
 #include "flow/IRandom.h"
 #include "flow/Trace.h"
 #include "flow/flow.h"
 #include "flow/serialize.h"
-#include "fdbclient/BuildFlags.h"
+
 #include "flow/actorcompiler.h" // has to be last include
 
 #define SevDecodeInfo SevVerbose
@@ -73,11 +77,13 @@ void printDecodeUsage() {
 	             "  --list-only    Print file list and exit.\n"
 	             "  -k KEY_PREFIX  Use the prefix for filtering mutations\n"
 	             "  --hex-prefix   HEX_PREFIX\n"
-	             "                 The prefix specified in HEX format, e.g., \\x05\\x01.\n"
+	             "                 The prefix specified in HEX format, e.g., \"\\\\x05\\\\x01\".\n"
 	             "  --begin-version-filter BEGIN_VERSION\n"
 	             "                 The version range's begin version (inclusive) for filtering.\n"
 	             "  --end-version-filter END_VERSION\n"
 	             "                 The version range's end version (exclusive) for filtering.\n"
+	             "  --knob-KNOBNAME KNOBVALUE\n"
+	             "                 Changes a knob value. KNOBNAME should be lowercase."
 	             "\n";
 	return;
 }
@@ -96,6 +102,8 @@ struct DecodeParams {
 	std::string prefix; // Key prefix for filtering
 	Version beginVersionFilter = 0;
 	Version endVersionFilter = std::numeric_limits<Version>::max();
+
+	std::vector<std::pair<std::string, std::string>> knobs;
 
 	// Returns if [begin, end) overlap with the filter range
 	bool overlap(Version begin, Version end) const {
@@ -130,7 +138,38 @@ struct DecodeParams {
 		if (!prefix.empty()) {
 			s.append(", KeyPrefix: ").append(printable(KeyRef(prefix)));
 		}
+		for (const auto& [knob, value] : knobs) {
+			s.append(", KNOB-").append(knob).append(" = ").append(value);
+		}
 		return s;
+	}
+
+	void updateKnobs() {
+		auto& g_knobs = IKnobCollection::getMutableGlobalKnobCollection();
+		for (const auto& [knobName, knobValueString] : knobs) {
+			try {
+				auto knobValue = g_knobs.parseKnobValue(knobName, knobValueString);
+				g_knobs.setKnob(knobName, knobValue);
+			} catch (Error& e) {
+				if (e.code() == error_code_invalid_option_value) {
+					std::cerr << "WARNING: Invalid value '" << knobValueString << "' for knob option '" << knobName
+					          << "'\n";
+					TraceEvent(SevWarnAlways, "InvalidKnobValue")
+					    .detail("Knob", printable(knobName))
+					    .detail("Value", printable(knobValueString));
+				} else {
+					std::cerr << "ERROR: Failed to set knob option '" << knobName << "': " << e.what() << "\n";
+					TraceEvent(SevError, "FailedToSetKnob")
+					    .errorUnsuppressed(e)
+					    .detail("Knob", printable(knobName))
+					    .detail("Value", printable(knobValueString));
+					throw;
+				}
+			}
+		}
+
+		// Reinitialize knobs in order to update knobs that are dependent on explicitly set knobs
+		g_knobs.initialize(Randomize::True, IsSimulated::False);
 	}
 };
 
@@ -255,6 +294,16 @@ int parseDecodeCommandLine(DecodeParams* param, CSimpleOpt* args) {
 		case OPT_BLOB_CREDENTIALS:
 			param->tlsConfig.blobCredentials.push_back(args->OptionArg());
 			break;
+
+		case OPT_KNOB: {
+			Optional<std::string> knobName = extractPrefixedArgument("--knob", args->OptionSyntax());
+			if (!knobName.present()) {
+				std::cerr << "ERROR: unable to parse knob option '" << args->OptionSyntax() << "'\n";
+				return FDB_EXIT_ERROR;
+			}
+			param->knobs.emplace_back(knobName.get(), args->OptionArg());
+			break;
+		}
 
 #ifndef TLS_DISABLED
 		case TLSConfig::OPT_TLS_PLUGIN:
@@ -551,6 +600,9 @@ int main(int argc, char** argv) {
 
 		StringRef url(param.container_url);
 		setupNetwork(0, UseMetrics::True);
+
+		// Must be called after setupNetwork() to be effective
+		param.updateKnobs();
 
 		TraceEvent::setNetworkThread();
 		openTraceFile(NetworkAddress(), 10 << 20, 500 << 20, param.log_dir, "decode", param.trace_log_group);

--- a/fdbclient/JSONDoc.h
+++ b/fdbclient/JSONDoc.h
@@ -22,6 +22,7 @@
 
 #include "fdbclient/json_spirit/json_spirit_writer_template.h"
 #include "fdbclient/json_spirit/json_spirit_reader_template.h"
+#include "flow/Error.h"
 
 // JSONDoc is a convenient reader/writer class for manipulating JSON documents using "paths".
 // Access is done using a "path", which is a string of dot-separated

--- a/fdbclient/S3BlobStore.actor.cpp
+++ b/fdbclient/S3BlobStore.actor.cpp
@@ -538,7 +538,7 @@ ACTOR Future<Void> updateSecret_impl(Reference<S3BlobStoreEndpoint> b) {
 			JSONDoc accounts(doc.last().get_obj());
 			if (accounts.has(credentialsFileKey, false) && accounts.last().type() == json_spirit::obj_type) {
 				JSONDoc account(accounts.last());
-				S3BlobStoreEndpoint::Credentials creds;
+				S3BlobStoreEndpoint::Credentials creds = b->credentials.get();
 				if (b->lookupKey) {
 					std::string apiKey;
 					if (account.tryGet("api_key", apiKey))


### PR DESCRIPTION
This causes failures of backup_auth_missing: ErrorDescription="Cannot find
authentication details (such as a password or secret key) for the specified
Backup Container URL"

Correct header with the fix:
```
Request Header: Authorization: AWS XXXSECRET_KEYXXX:+F/GfXKLqd4x1Cb75yux7chK1Co=
```

Wrong header without the fix:
```
Request Header: Authorization: AWS :n4Zuwh75fptP3furmlPVDbwo3VI=
```
    
This is found by manually running "fdbdecode". I verified the fix works as intended.

Also added `--knob-` option to `fdbdecode` to allow easier debugging, i.e., `--knob_http_request_aws_v4_header 0 --knob_http_verbose_level 4`.
# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
