### PR TITLE
Extend flat_buffer to support unordered_set (de)serialize

### DIFF
--- a/flow/flat_buffers.h
+++ b/flow/flat_buffers.h
@@ -35,6 +35,7 @@
 #include <cstring>
 #include <array>
 #include <unordered_map>
+#include <unordered_set>
 #include <deque>
 #include "flow/FileIdentifier.h"
 #include "flow/ObjectSerializerTraits.h"
@@ -240,6 +241,31 @@ struct vector_like_traits<std::set<Key, Compare, Allocator>> : std::true_type {
 	}
 	template <class Context>
 	static void reserve(Vec&, size_t, Context&) {}
+
+	template <class Context>
+	static insert_iterator insert(Vec& v, Context&) {
+		return std::inserter(v, v.end());
+	}
+	template <class Context>
+	static iterator begin(const Vec& v, Context&) {
+		return v.begin();
+	}
+};
+template <class Key, class Hash, class KeyEqual, class Allocator>
+struct vector_like_traits<std::unordered_set<Key, Hash, KeyEqual, Allocator>> : std::true_type {
+	using Vec = std::unordered_set<Key, Hash, KeyEqual, Allocator>;
+	using value_type = Key;
+	using iterator = typename Vec::const_iterator;
+	using insert_iterator = std::insert_iterator<Vec>;
+
+	template <class Context>
+	static size_t num_entries(const Vec& v, Context&) {
+		return v.size();
+	}
+	template <class Context>
+	static void reserve(Vec& v, size_t size, Context&) {
+		v.reserve(size);
+	}
 
 	template <class Context>
 	static insert_iterator insert(Vec& v, Context&) {

--- a/flow/serialize.h
+++ b/flow/serialize.h
@@ -20,6 +20,7 @@
 
 #ifndef FLOW_SERIALIZE_H
 #define FLOW_SERIALIZE_H
+#include <unordered_set>
 #pragma once
 
 #include <stdint.h>
@@ -171,6 +172,13 @@ struct FileIdentifierFor<std::vector<T, Allocator>> : ComposedIdentifierExternal
 template <class T, class Allocator>
 struct CompositionDepthFor<std::vector<T, Allocator>> : std::integral_constant<int, CompositionDepthFor<T>::value + 1> {
 };
+
+template <class Key, class Hash, class KeyEqual, class Allocator>
+struct FileIdentifierFor<std::unordered_set<Key, Hash, KeyEqual, Allocator>> : ComposedIdentifierExternal<Key, 6> {};
+
+template <class Key, class Hash, class KeyEqual, class Allocator>
+struct CompositionDepthFor<std::unordered_set<Key, Hash, KeyEqual, Allocator>>
+  : std::integral_constant<int, CompositionDepthFor<Key>::value + 1> {};
 
 template <class Archive, class T>
 inline void save(Archive& ar, const std::vector<T>& value) {


### PR DESCRIPTION
Extend flat_buffer to support unordered_set (de)serialize

Description

Extend flat_buffer to support unordered_set (de)serialize

Testing

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
