### PR TITLE
SeedTeam Storage Server can get mutations in version 1 txn

### DIFF
--- a/documentation/sphinx/requirements.txt
+++ b/documentation/sphinx/requirements.txt
@@ -3,3 +3,4 @@ setuptools>=20.10.0,<=57.4.0
 sphinx==1.5.6
 sphinx-bootstrap-theme==0.4.8
 docutils==0.16
+Jinja2==3.0.3

--- a/fdbserver/CommitProxyServer.actor.cpp
+++ b/fdbserver/CommitProxyServer.actor.cpp
@@ -777,7 +777,7 @@ ACTOR Future<Void> preresolutionProcessing(CommitBatchContext* self) {
 	pProxyCommitData->stats.lastCommitVersionAssigned = versionReply.version;
 	pProxyCommitData->stats.getCommitVersionDist->sampleSeconds(now() - beforeGettingCommitVersion);
 
-	self->commitVersion = versionReply.version; // hfu : get commit version here
+	self->commitVersion = versionReply.version;
 	self->prevVersion = versionReply.prevVersion;
 
 	if (SERVER_KNOBS->ENABLE_PARTITIONED_TRANSACTIONS) {
@@ -2305,7 +2305,6 @@ ACTOR Future<Void> commitProxyServerCore(CommitProxyInterface proxy,
                                          Version recoveryTransactionVersion,
                                          bool firstProxy,
                                          std::string whitelistBinPaths) {
-	// hfu : recovery version is stored in commit proxy
 	state ProxyCommitData commitData(
 	    proxy.id(), master, proxy.getConsistentReadVersion, recoveryTransactionVersion, proxy.commit, db, firstProxy);
 

--- a/fdbserver/masterserver.actor.cpp
+++ b/fdbserver/masterserver.actor.cpp
@@ -1330,7 +1330,7 @@ ACTOR Future<Void> getVersion(Reference<MasterData> self, GetCommitVersionReques
 			}
 		}
 
-		rep.version = self->version; // hfu : reply.version is master's self->version
+		rep.version = self->version;
 		rep.requestNum = req.requestNum;
 
 		proxyItr->second.replies.erase(proxyItr->second.replies.begin(),

--- a/fdbserver/masterserver.actor.cpp
+++ b/fdbserver/masterserver.actor.cpp
@@ -909,7 +909,7 @@ ACTOR Future<Void> readTransactionSystemState(Reference<MasterData> self,
 	// Recover version info
 	self->lastEpochEnd = oldLogSystem->getEnd() - 1;
 	if (self->lastEpochEnd == 0) {
-		self->recoveryTransactionVersion = 1; // recoveryTransactionVersion is set here
+		self->recoveryTransactionVersion = 1;
 	} else {
 		if (self->forceRecovery) {
 			self->recoveryTransactionVersion = self->lastEpochEnd + SERVER_KNOBS->MAX_VERSIONS_IN_FLIGHT_FORCED;


### PR DESCRIPTION
SeedTeam SS need to get all mutations in txn whose version is 1,
otherwise these mutations are lost, because SeedTeam SS would not
know they need to fetch the data from this version until after this
version.

Fixing it by manually adding all mutations in txn V1 to private teams
of SeedTeam SS.

Note: some temporary comments are added for now, to facilitate code review, and will be removed
# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
