### PR TITLE
Fix valgrind failure where FutureStream is destroyed accidentally

### DIFF
--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -8642,6 +8642,7 @@ ACTOR Future<Void> singleChangeFeedStreamInternal(KeyRange range,
 
 	state Promise<Void> refresh = results->refresh;
 	ASSERT(results->streams.size() == 1);
+	state FutureStream<ChangeFeedStreamReply> feedReplyStream = results->streams[0].getFuture();
 	ASSERT(results->storageData.size() == 1);
 	state bool atLatest = false;
 
@@ -8656,7 +8657,7 @@ ACTOR Future<Void> singleChangeFeedStreamInternal(KeyRange range,
 
 	loop {
 
-		state ChangeFeedStreamReply feedReply = waitNext(results->streams[0].getFuture());
+		state ChangeFeedStreamReply feedReply = waitNext(feedReplyStream);
 		*begin = feedReply.mutations.back().version + 1;
 
 		if (feedReply.popVersion > results->popVersion) {


### PR DESCRIPTION
A straightforward fix.
Otherwise, every loop will destroy the temporary _FutureStream_ and may even cancel the promise.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
