### PR TITLE
Fix bug in tenant map range reads when the end key is outside of the tenant map range

### DIFF
--- a/bindings/c/test/unit/unit_tests.cpp
+++ b/bindings/c/test/unit/unit_tests.cpp
@@ -2436,8 +2436,8 @@ TEST_CASE("Tenant create, access, and delete") {
 		StringRef end = "\xff\xff/management/tenant_map0"_sr;
 
 		fdb_check(tr.set_option(FDB_TR_OPTION_SPECIAL_KEY_SPACE_ENABLE_WRITES, nullptr, 0));
-		fdb::KeyValueArrayFuture f = tr.get_range(FDB_KEYSEL_FIRST_GREATER_OR_EQUAL(begin.data(), begin.size()),
-		                                          FDB_KEYSEL_FIRST_GREATER_OR_EQUAL(end.data(), end.size()),
+		fdb::KeyValueArrayFuture f = tr.get_range(FDB_KEYSEL_FIRST_GREATER_OR_EQUAL(begin.begin(), begin.size()),
+		                                          FDB_KEYSEL_FIRST_GREATER_OR_EQUAL(end.begin(), end.size()),
 		                                          /* limit */ 0,
 		                                          /* target_bytes */ 0,
 		                                          /* FDBStreamingMode */ FDB_STREAMING_MODE_WANT_ALL,
@@ -2455,9 +2455,9 @@ TEST_CASE("Tenant create, access, and delete") {
 		FDBKeyValue const* outKv;
 		int outCount;
 		int outMore;
-		fdb_check(f1.get(&outKv, &outCount, &outMore));
+		fdb_check(f.get(&outKv, &outCount, &outMore));
 		CHECK(outCount == 1);
-		CHECK(StringRef(outKv->key, outKv->key_length) == StringRef(tenantName).withPrefix(tenantMapKeys.begin));
+		CHECK(StringRef(outKv->key, outKv->key_length) == StringRef(tenantName).withPrefix(begin));
 
 		tr.reset();
 		break;

--- a/fdbclient/SpecialKeySpace.actor.cpp
+++ b/fdbclient/SpecialKeySpace.actor.cpp
@@ -2704,16 +2704,23 @@ Future<Optional<std::string>> FailedLocalitiesRangeImpl::commit(ReadYourWritesTr
 }
 
 ACTOR Future<RangeResult> getTenantList(ReadYourWritesTransaction* ryw, KeyRangeRef kr, GetRangeLimits limitsHint) {
-	KeyRangeRef tenantRange =
-	    kr.removePrefix(SpecialKeySpace::getModuleRange(SpecialKeySpace::MODULE::MANAGEMENT).begin)
-	        .removePrefix(TenantMapRangeImpl::submoduleRange.begin);
 	state KeyRef managementPrefix =
 	    kr.begin.substr(0,
 	                    SpecialKeySpace::getModuleRange(SpecialKeySpace::MODULE::MANAGEMENT).begin.size() +
 	                        TenantMapRangeImpl::submoduleRange.begin.size());
 
-	std::map<TenantName, TenantMapEntry> tenants = wait(ManagementAPI::listTenantsTransaction(
-	    &ryw->getTransaction(), tenantRange.begin, tenantRange.end, limitsHint.rows));
+	kr = kr.removePrefix(SpecialKeySpace::getModuleRange(SpecialKeySpace::MODULE::MANAGEMENT).begin);
+	TenantNameRef beginTenant = kr.begin.removePrefix(TenantMapRangeImpl::submoduleRange.begin);
+
+	TenantNameRef endTenant = kr.end;
+	if (endTenant.startsWith(TenantMapRangeImpl::submoduleRange.begin)) {
+		endTenant = endTenant.removePrefix(TenantMapRangeImpl::submoduleRange.begin);
+	} else {
+		endTenant = "\xff"_sr;
+	}
+
+	std::map<TenantName, TenantMapEntry> tenants =
+	    wait(ManagementAPI::listTenantsTransaction(&ryw->getTransaction(), beginTenant, endTenant, limitsHint.rows));
 
 	RangeResult results;
 	for (auto tenant : tenants) {
@@ -2783,7 +2790,7 @@ Future<Optional<std::string>> TenantMapRangeImpl::commit(ReadYourWritesTransacti
 				TenantNameRef endTenant = range.end().removePrefix(
 				    SpecialKeySpace::getModuleRange(SpecialKeySpace::MODULE::MANAGEMENT).begin);
 				if (endTenant.startsWith(submoduleRange.begin)) {
-					endTenant = endTenant.removePrefix(submoduleRange.end);
+					endTenant = endTenant.removePrefix(submoduleRange.begin);
 				} else {
 					endTenant = "\xff"_sr;
 				}


### PR DESCRIPTION
When the end key of a tenant map range read was \xff\xff/management/tenant_map0, the operation would incorrectly return no results. This also adds a unit test that covers this behavior.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
