### PR TITLE
Enforce comment with static assert

### DIFF
--- a/fdbclient/WellKnownEndpoints.h
+++ b/fdbclient/WellKnownEndpoints.h
@@ -52,4 +52,7 @@ enum WellKnownEndpoints {
 	WLTOKEN_RESERVED_COUNT // 23
 };
 
+static_assert(WLTOKEN_PROTOCOL_INFO ==
+              10); // Enforce that the value of this endpoint does not change per comment above.
+
 #endif


### PR DESCRIPTION
Enforce that WLTOKEN_PROTOCOL_INFO does not change with a static_assert. It's more robust than a comment.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
