### PR TITLE
Fix the case where we access the memory after cleaning

### DIFF
--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -8690,11 +8690,24 @@ ACTOR Future<Void> singleChangeFeedStreamInternal(KeyRange range,
 			results->lastReturnedVersion.set(feedReply.mutations.back().version);
 		}
 
-		if (refresh.canBeSet() && !atLatest && feedReply.atLatestVersion) {
+		if (!refresh.canBeSet()) {
+			try {
+				// refresh is set if and only if this actor is cancelled
+				wait(Future<Void>(Void()));
+				// Catch any unexpected behavior if the above contract is broken
+				ASSERT(false);
+			} catch (Error& e) {
+				ASSERT(e.code() == error_code_actor_cancelled);
+				throw;
+			}
+		}
+
+		if (!atLatest && feedReply.atLatestVersion) {
 			atLatest = true;
 			results->notAtLatest.set(0);
 		}
-		if (refresh.canBeSet() && feedReply.minStreamVersion > results->storageData[0]->version.get()) {
+
+		if (feedReply.minStreamVersion > results->storageData[0]->version.get()) {
 			results->storageData[0]->version.set(feedReply.minStreamVersion);
 		}
 	}


### PR DESCRIPTION
There's a code jump that can happen after
```
results->lastReturnedVersion.set(feedReply.mutations.back().version);
```
when the child actor goes to the parent actor's(_getChangeFeedStreamActor_) catch block.
in particular, where it clears the `results->streams` vector. 

However, as there's no _wait_ there until the next
```state ChangeFeedStreamReply feedReply = waitNext(results->streams[0].getFuture());```
We will have a segfault here.

The fix is to add a _wait_ in this rare case and also add ASSERTIONs to catch unexpected behavior.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
