### PR TITLE
Future-proof blob granules with full file size

### DIFF
--- a/fdbclient/BlobGranuleCommon.h
+++ b/fdbclient/BlobGranuleCommon.h
@@ -52,19 +52,20 @@ struct BlobFilePointerRef {
 	StringRef filename;
 	int64_t offset;
 	int64_t length;
+	int64_t fullFileLength;
 
 	BlobFilePointerRef() {}
-	BlobFilePointerRef(Arena& to, const std::string& filename, int64_t offset, int64_t length)
-	  : filename(to, filename), offset(offset), length(length) {}
+	BlobFilePointerRef(Arena& to, const std::string& filename, int64_t offset, int64_t length, int64_t fullFileLength)
+	  : filename(to, filename), offset(offset), length(length), fullFileLength(fullFileLength) {}
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, filename, offset, length);
+		serializer(ar, filename, offset, length, fullFileLength);
 	}
 
 	std::string toString() const {
 		std::stringstream ss;
-		ss << filename.toString() << ":" << offset << ":" << length;
+		ss << filename.toString() << ":" << offset << ":" << length << ":" << fullFileLength;
 		return std::move(ss).str();
 	}
 };

--- a/fdbclient/BlobGranuleFiles.cpp
+++ b/fdbclient/BlobGranuleFiles.cpp
@@ -240,22 +240,27 @@ static void startLoad(const ReadBlobGranuleContext granuleContext,
 	// Start load process for all files in chunk
 	if (chunk.snapshotFile.present()) {
 		std::string snapshotFname = chunk.snapshotFile.get().filename.toString();
-		// FIXME: full file length won't always be length of read
+		// FIXME: remove when we implement file multiplexing
+		ASSERT(chunk.snapshotFile.get().offset == 0);
+		ASSERT(chunk.snapshotFile.get().length == chunk.snapshotFile.get().fullFileLength);
 		loadIds.snapshotId = granuleContext.start_load_f(snapshotFname.c_str(),
 		                                                 snapshotFname.size(),
 		                                                 chunk.snapshotFile.get().offset,
 		                                                 chunk.snapshotFile.get().length,
-		                                                 chunk.snapshotFile.get().length,
+		                                                 chunk.snapshotFile.get().fullFileLength,
 		                                                 granuleContext.userContext);
 	}
 	loadIds.deltaIds.reserve(chunk.deltaFiles.size());
 	for (int deltaFileIdx = 0; deltaFileIdx < chunk.deltaFiles.size(); deltaFileIdx++) {
 		std::string deltaFName = chunk.deltaFiles[deltaFileIdx].filename.toString();
+		// FIXME: remove when we implement file multiplexing
+		ASSERT(chunk.deltaFiles[deltaFileIdx].offset == 0);
+		ASSERT(chunk.deltaFiles[deltaFileIdx].length == chunk.deltaFiles[deltaFileIdx].fullFileLength);
 		int64_t deltaLoadId = granuleContext.start_load_f(deltaFName.c_str(),
 		                                                  deltaFName.size(),
 		                                                  chunk.deltaFiles[deltaFileIdx].offset,
 		                                                  chunk.deltaFiles[deltaFileIdx].length,
-		                                                  chunk.deltaFiles[deltaFileIdx].length,
+		                                                  chunk.deltaFiles[deltaFileIdx].fullFileLength,
 		                                                  granuleContext.userContext);
 		loadIds.deltaIds.push_back(deltaLoadId);
 	}

--- a/fdbclient/SystemData.cpp
+++ b/fdbclient/SystemData.cpp
@@ -1190,23 +1190,26 @@ const KeyRange blobGranuleFileKeyRangeFor(UID granuleID) {
 	return KeyRangeRef(startKey, strinc(startKey));
 }
 
-const Value blobGranuleFileValueFor(StringRef const& filename, int64_t offset, int64_t length) {
+const Value blobGranuleFileValueFor(StringRef const& filename, int64_t offset, int64_t length, int64_t fullFileLength) {
 	BinaryWriter wr(IncludeVersion(ProtocolVersion::withBlobGranule()));
 	wr << filename;
 	wr << offset;
 	wr << length;
+	wr << fullFileLength;
 	return wr.toValue();
 }
 
-std::tuple<Standalone<StringRef>, int64_t, int64_t> decodeBlobGranuleFileValue(ValueRef const& value) {
+std::tuple<Standalone<StringRef>, int64_t, int64_t, int64_t> decodeBlobGranuleFileValue(ValueRef const& value) {
 	StringRef filename;
 	int64_t offset;
 	int64_t length;
+	int64_t fullFileLength;
 	BinaryReader reader(value, IncludeVersion());
 	reader >> filename;
 	reader >> offset;
 	reader >> length;
-	return std::tuple(filename, offset, length);
+	reader >> fullFileLength;
+	return std::tuple(filename, offset, length, fullFileLength);
 }
 
 const Value blobGranulePruneValueFor(Version version, KeyRange range, bool force) {

--- a/fdbclient/SystemData.h
+++ b/fdbclient/SystemData.h
@@ -572,8 +572,8 @@ const Key blobGranuleFileKeyFor(UID granuleID, Version fileVersion, uint8_t file
 std::tuple<UID, Version, uint8_t> decodeBlobGranuleFileKey(KeyRef const& key);
 const KeyRange blobGranuleFileKeyRangeFor(UID granuleID);
 
-const Value blobGranuleFileValueFor(StringRef const& filename, int64_t offset, int64_t length);
-std::tuple<Standalone<StringRef>, int64_t, int64_t> decodeBlobGranuleFileValue(ValueRef const& value);
+const Value blobGranuleFileValueFor(StringRef const& filename, int64_t offset, int64_t length, int64_t fullFileLength);
+std::tuple<Standalone<StringRef>, int64_t, int64_t, int64_t> decodeBlobGranuleFileValue(ValueRef const& value);
 
 const Value blobGranulePruneValueFor(Version version, KeyRange range, bool force);
 std::tuple<Version, KeyRange, bool> decodeBlobGranulePruneValue(ValueRef const& value);

--- a/fdbserver/BlobGranuleServerCommon.actor.h
+++ b/fdbserver/BlobGranuleServerCommon.actor.h
@@ -49,11 +49,12 @@ struct BlobFileIndex {
 	std::string filename;
 	int64_t offset;
 	int64_t length;
+	int64_t fullFileLength;
 
 	BlobFileIndex() {}
 
-	BlobFileIndex(Version version, std::string filename, int64_t offset, int64_t length)
-	  : version(version), filename(filename), offset(offset), length(length) {}
+	BlobFileIndex(Version version, std::string filename, int64_t offset, int64_t length, int64_t fullFileLength)
+	  : version(version), filename(filename), offset(offset), length(length), fullFileLength(fullFileLength) {}
 
 	// compare on version
 	bool operator<(const BlobFileIndex& r) const { return version < r.version; }


### PR DESCRIPTION
Add full file size to bg metadata to be forward-compatible with multiplexing multiple logical files across a single blob storage object.

Passed 1k BlobGranule* correctness.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
