### PR TITLE
fixup! Fix the StorageTeamPeekCursor versioning

### DIFF
--- a/fdbserver/ptxn/MutableTeamPeekCursor.actor.h
+++ b/fdbserver/ptxn/MutableTeamPeekCursor.actor.h
@@ -100,8 +100,7 @@ public:
 	                      const TLogInterfaceByStorageTeamIDFunc& getTLogInterfaceByStorageTeamID_,
 	                      const Version& initialVersion_)
 
-	  : // This minus one in BaseClass is necessary since all new cursor will start with BaseClass::currentVersion + 1
-	    BaseClass(initialVersion_ - 1), serverID(serverID_),
+	  : BaseClass(initialVersion_), serverID(serverID_),
 	    storageServerToTeamIDKey(::storageServerToTeamIdKey(serverID_)),
 	    storageTeamIDsSnapshot(privateMutationStorageTeamID_), storageTeamIDs(privateMutationStorageTeamID_),
 	    newStorageTeamIDs(privateMutationStorageTeamID_),

--- a/fdbserver/ptxn/MutableTeamPeekCursor.actor.h
+++ b/fdbserver/ptxn/MutableTeamPeekCursor.actor.h
@@ -98,7 +98,7 @@ public:
 	MutableTeamPeekCursor(const UID serverID_,
 	                      const StorageTeamID& privateMutationStorageTeamID_,
 	                      const TLogInterfaceByStorageTeamIDFunc& getTLogInterfaceByStorageTeamID_,
-	                      const Version& initialVersion_ = 0)
+	                      const Version& initialVersion_)
 
 	  : // This minus one in BaseClass is necessary since all new cursor will start with BaseClass::currentVersion + 1
 	    BaseClass(initialVersion_ - 1), serverID(serverID_),
@@ -119,7 +119,7 @@ public:
 	MutableTeamPeekCursor(const UID serverID_,
 	                      const StorageServerStorageTeams& storageTeams_,
 	                      const TLogInterfaceByStorageTeamIDFunc& getTLogInterfaceByStorageTeamID_,
-	                      const Version& initialVersion_ = 0)
+	                      const Version& initialVersion_)
 	  : MutableTeamPeekCursor(serverID_,
 	                          storageTeams_.getPrivateMutationsStorageTeamID(),
 	                          getTLogInterfaceByStorageTeamID_,

--- a/fdbserver/ptxn/TLogPeekCursor.actor.h
+++ b/fdbserver/ptxn/TLogPeekCursor.actor.h
@@ -264,9 +264,8 @@ private:
 	// version will be ignored
 	bool reportEmptyVersion;
 
-	// The last version that the cursor have received, the next remote RPC will return versions larger than lastVersion,
-	// if available.
-	Version lastVersion;
+	// The version that the cursor should use for RPC
+	Version rpcVersion;
 
 public:
 	// version_ is the version the cursor begins with
@@ -479,6 +478,7 @@ protected:
 	                                     const Version& version_ = 0)
 	  : pCursorContainer(std::move(pCursorContainer_)),
 	    remoteMoreAvailableSnapshot{ false, version_, std::move(pCursorContainerSnapshot_) }, currentVersion(version_) {
+
 	}
 
 	// Tries to fill the cursor heap, returns true if the cursorContainer is filled with cursors.
@@ -513,9 +513,10 @@ protected:
 	virtual void nextImpl() override;
 
 public:
-	BroadcastedStorageTeamPeekCursor_Ordered()
+	BroadcastedStorageTeamPeekCursor_Ordered(const Version& version_ = 0)
 	  : BroadcastedStorageTeamPeekCursorBase(std::make_unique<details::OrderedCursorContainer>(),
-	                                         std::make_unique<details::OrderedCursorContainer>()) {}
+	                                         std::make_unique<details::OrderedCursorContainer>(),
+											 version_) {}
 };
 
 // Merge multiple storage team peek cursor into one. The version is the barrier, i.e., a version is complete iff all
@@ -527,9 +528,10 @@ protected:
 	virtual void nextImpl() override;
 
 public:
-	BroadcastedStorageTeamPeekCursor_Unordered()
+	BroadcastedStorageTeamPeekCursor_Unordered(const Version& version_ = 0)
 	  : BroadcastedStorageTeamPeekCursorBase(std::make_unique<details::UnorderedCursorContainer>(),
-	                                         std::make_unique<details::UnorderedCursorContainer>()) {}
+	                                         std::make_unique<details::UnorderedCursorContainer>(),
+											 version_) {}
 };
 
 } // namespace merged

--- a/fdbserver/ptxn/TLogPeekCursor.actor.h
+++ b/fdbserver/ptxn/TLogPeekCursor.actor.h
@@ -475,11 +475,10 @@ protected:
 protected:
 	BroadcastedStorageTeamPeekCursorBase(std::unique_ptr<details::CursorContainerBase>&& pCursorContainer_,
 	                                     std::unique_ptr<details::CursorContainerBase>&& pCursorContainerSnapshot_,
-	                                     const Version& version_ = 0)
+	                                     const Version& version_ = -1)
 	  : pCursorContainer(std::move(pCursorContainer_)),
-	    remoteMoreAvailableSnapshot{ false, version_, std::move(pCursorContainerSnapshot_) }, currentVersion(version_) {
-
-	}
+	    remoteMoreAvailableSnapshot{ false, version_, std::move(pCursorContainerSnapshot_) },
+	    currentVersion(version_ + 1) {}
 
 	// Tries to fill the cursor heap, returns true if the cursorContainer is filled with cursors.
 	// If cursorContainer is not empty, the behavior is undefined.
@@ -513,7 +512,7 @@ protected:
 	virtual void nextImpl() override;
 
 public:
-	BroadcastedStorageTeamPeekCursor_Ordered(const Version& version_ = 0)
+	BroadcastedStorageTeamPeekCursor_Ordered(const Version& version_ = -1)
 	  : BroadcastedStorageTeamPeekCursorBase(std::make_unique<details::OrderedCursorContainer>(),
 	                                         std::make_unique<details::OrderedCursorContainer>(),
 	                                         version_) {}
@@ -528,7 +527,7 @@ protected:
 	virtual void nextImpl() override;
 
 public:
-	BroadcastedStorageTeamPeekCursor_Unordered(const Version& version_ = 0)
+	BroadcastedStorageTeamPeekCursor_Unordered(const Version& version_ = -1)
 	  : BroadcastedStorageTeamPeekCursorBase(std::make_unique<details::UnorderedCursorContainer>(),
 	                                         std::make_unique<details::UnorderedCursorContainer>(),
 	                                         version_) {}

--- a/fdbserver/ptxn/TLogPeekCursor.actor.h
+++ b/fdbserver/ptxn/TLogPeekCursor.actor.h
@@ -516,7 +516,7 @@ public:
 	BroadcastedStorageTeamPeekCursor_Ordered(const Version& version_ = 0)
 	  : BroadcastedStorageTeamPeekCursorBase(std::make_unique<details::OrderedCursorContainer>(),
 	                                         std::make_unique<details::OrderedCursorContainer>(),
-											 version_) {}
+	                                         version_) {}
 };
 
 // Merge multiple storage team peek cursor into one. The version is the barrier, i.e., a version is complete iff all
@@ -531,7 +531,7 @@ public:
 	BroadcastedStorageTeamPeekCursor_Unordered(const Version& version_ = 0)
 	  : BroadcastedStorageTeamPeekCursorBase(std::make_unique<details::UnorderedCursorContainer>(),
 	                                         std::make_unique<details::UnorderedCursorContainer>(),
-											 version_) {}
+	                                         version_) {}
 };
 
 } // namespace merged

--- a/fdbserver/ptxn/TLogPeekCursor.actor.h
+++ b/fdbserver/ptxn/TLogPeekCursor.actor.h
@@ -475,10 +475,10 @@ protected:
 protected:
 	BroadcastedStorageTeamPeekCursorBase(std::unique_ptr<details::CursorContainerBase>&& pCursorContainer_,
 	                                     std::unique_ptr<details::CursorContainerBase>&& pCursorContainerSnapshot_,
-	                                     const Version& version_ = -1)
+	                                     const Version& version_)
 	  : pCursorContainer(std::move(pCursorContainer_)),
 	    remoteMoreAvailableSnapshot{ false, version_, std::move(pCursorContainerSnapshot_) },
-	    currentVersion(version_ + 1) {}
+	    currentVersion(version_) {}
 
 	// Tries to fill the cursor heap, returns true if the cursorContainer is filled with cursors.
 	// If cursorContainer is not empty, the behavior is undefined.
@@ -512,7 +512,7 @@ protected:
 	virtual void nextImpl() override;
 
 public:
-	BroadcastedStorageTeamPeekCursor_Ordered(const Version& version_ = -1)
+	BroadcastedStorageTeamPeekCursor_Ordered(const Version& version_)
 	  : BroadcastedStorageTeamPeekCursorBase(std::make_unique<details::OrderedCursorContainer>(),
 	                                         std::make_unique<details::OrderedCursorContainer>(),
 	                                         version_) {}
@@ -527,7 +527,7 @@ protected:
 	virtual void nextImpl() override;
 
 public:
-	BroadcastedStorageTeamPeekCursor_Unordered(const Version& version_ = -1)
+	BroadcastedStorageTeamPeekCursor_Unordered(const Version& version_)
 	  : BroadcastedStorageTeamPeekCursorBase(std::make_unique<details::UnorderedCursorContainer>(),
 	                                         std::make_unique<details::UnorderedCursorContainer>(),
 	                                         version_) {}

--- a/fdbserver/ptxn/TLogPeekCursor.actor.h
+++ b/fdbserver/ptxn/TLogPeekCursor.actor.h
@@ -478,7 +478,7 @@ protected:
 	                                     const Version& version_)
 	  : pCursorContainer(std::move(pCursorContainer_)),
 	    remoteMoreAvailableSnapshot{ false, version_, std::move(pCursorContainerSnapshot_) },
-	    currentVersion(version_) {}
+	    currentVersion(version_ - 1) {}
 
 	// Tries to fill the cursor heap, returns true if the cursorContainer is filled with cursors.
 	// If cursorContainer is not empty, the behavior is undefined.

--- a/fdbserver/ptxn/test/TestTLogPeek.actor.cpp
+++ b/fdbserver/ptxn/test/TestTLogPeek.actor.cpp
@@ -305,7 +305,7 @@ Future<Void> runMergedCursorTest(ptxn::test::TestTLogPeekMergeCursorOptions opti
 
 	// Initialize the cursor
 	state Arena messageArena;
-	state std::shared_ptr<CursorType> mergedCursor = std::make_shared<CursorType>();
+	state std::shared_ptr<CursorType> mergedCursor = std::make_shared<CursorType>(/* version */ 0);
 	const std::vector<ptxn::StorageTeamID>& storageTeamIDs = ptxn::test::TestEnvironment::getTLogGroup().storageTeamIDs;
 	for (const auto& storageTeamID : storageTeamIDs) {
 		std::shared_ptr<ptxn::TLogInterface_PassivelyPull> pInterface =
@@ -378,7 +378,7 @@ TEST_CASE("/fdbserver/ptxn/test/tLogPeek/cursor/advanceTo") {
 	state Arena messageArena;
 	// Unordered cursor cannot correctly advanceTo
 	state std::shared_ptr<ptxn::merged::BroadcastedStorageTeamPeekCursor_Ordered> mergedCursor =
-	    std::make_shared<ptxn::merged::BroadcastedStorageTeamPeekCursor_Ordered>();
+	    std::make_shared<ptxn::merged::BroadcastedStorageTeamPeekCursor_Ordered>(/* version */ 0);
 	const std::vector<ptxn::StorageTeamID>& storageTeamIDs = ptxn::test::TestEnvironment::getTLogGroup().storageTeamIDs;
 	for (const auto& storageTeamID : storageTeamIDs) {
 		std::shared_ptr<ptxn::TLogInterface_PassivelyPull> pInterface =
@@ -518,7 +518,7 @@ TEST_CASE("/fdbserver/ptxn/test/tLogPeek/cursor/merged/OrderedMutableTeamPeekCur
 	        .privateMutationsStorageTeamID;
 
 	pCursor = std::make_shared<ptxn::merged::OrderedMutableTeamPeekCursor>(
-	    storageServerIDs[0], privateMutationsStorageTeamID, getTLogInterfaceByStorageTeamID);
+	    storageServerIDs[0], privateMutationsStorageTeamID, getTLogInterfaceByStorageTeamID, /* version */ 0);
 
 	state Arena storageArena;
 	state std::vector<ptxn::VersionSubsequenceMessage> messagesFromTLogs =

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -5592,7 +5592,8 @@ void initializeUpdateCursor(ptxn::StorageServer& storageServerContext) {
 	    getStoragePrivateMutationTeam(storageServerContext),
 	    [referencedServerDBInfo](const StorageTeamID& storageTeamID) -> auto {
 		    return getTLogInterfaceByStorageTeamID(referencedServerDBInfo->get(), storageTeamID);
-	    });
+	    },
+	    storageServerContext.version.get() + 1);
 }
 
 ACTOR Future<Void> peekFromRemote(std::shared_ptr<ptxn::StorageServer> storageServerContext,

--- a/tests/ptxn/TLogPeekCursor.toml
+++ b/tests/ptxn/TLogPeekCursor.toml
@@ -12,30 +12,30 @@ startDelay = 0
    numMutationsPerVersion = 100
 
 [[test]]
-    testTitle = "BroadcastedStorageTeamPeekCursor_Unordered test"
-    useDB = false
-    startDelay = 0
+   testTitle = "BroadcastedStorageTeamPeekCursor_Unordered test"
+   useDB = false
+   startDelay = 0
 
-    [[test.workload]]
-    testName = "UnitTests"
-    maxTestCases = 1
-    testsMatching = '/fdbserver/ptxn/test/tLogPeek/cursor/merged/BroadcastedStorageTeamPeekCursor_Unordered'
+   [[test.workload]]
+   testName = "UnitTests"
+   maxTestCases = 1
+   testsMatching = '/fdbserver/ptxn/test/tLogPeek/cursor/merged/BroadcastedStorageTeamPeekCursor_Unordered'
 
-    numVersions = 10
-    numMutationsPerVersion = 10
+   numVersions = 50
+   numMutationsPerVersion = 100
 
 [[test]]
 testTitle = "BroadcastedStorageTeamPeekCursor_Ordered test"
 useDB = false
 startDelay = 0
 
-    [[test.workload]]
-    testName = "UnitTests"
-    maxTestCases = 1
-    testsMatching = '/fdbserver/ptxn/test/tLogPeek/cursor/merged/BroadcastedStorageTeamPeekCursor_Ordered'
+   [[test.workload]]
+   testName = "UnitTests"
+   maxTestCases = 1
+   testsMatching = '/fdbserver/ptxn/test/tLogPeek/cursor/merged/BroadcastedStorageTeamPeekCursor_Ordered'
 
-    numVersions = 10
-    numMutationsPerVersion = 100
+   numVersions = 50
+   numMutationsPerVersion = 100
 
 [[test]]
 testTitle = "OrderedMutableTeamPeekCursor test"
@@ -47,8 +47,8 @@ startDelay = 0
    maxTestCases = 1
    testsMatching = '/fdbserver/ptxn/test/tLogPeek/cursor/merged/OrderedMutableTeamPeekCursor'
 
-   numVersions = 10
-   numMutationsPerVersion = 10
+   numVersions = 50
+   numMutationsPerVersion = 100
 
 [[test]]
 testTitle = "Advance To"


### PR DESCRIPTION
This is a fix to let recent cursor code change passes the unit test.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
