### PR TITLE
Fix size calculation in spill by reference

### DIFF
--- a/fdbserver/ptxn/TLogServer.actor.cpp
+++ b/fdbserver/ptxn/TLogServer.actor.cpp
@@ -2570,9 +2570,7 @@ ACTOR Future<Void> updatePersistentData(Reference<TLogGroupData> self,
 					uint32_t size = 0;
 					for (; msg != teamData->versionMessages.end() && msg->first == currentVersion; ++msg) {
 						// Fast forward until we find a new version.
-						// TOFIX: how to calculate the size of stringref?
-						// size += msg->second->first.expectedSize();
-						size += 0;
+						size += msg->second.size();
 					}
 
 					SpilledData spilledData(currentVersion, begin, length, size);


### PR DESCRIPTION
Put description here...

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
