### PR TITLE
Disallow anonymous standalone thread futures in safeThreadFutureToFuture

### DIFF
--- a/fdbclient/NativeAPI.actor.h
+++ b/fdbclient/NativeAPI.actor.h
@@ -459,6 +459,10 @@ public:
 	std::vector<Reference<Watch>> watches;
 	Span span;
 
+	// used in template functions as returned Future type
+	template <typename Type>
+	using FutureT = Future<Type>;
+
 private:
 	Future<Version> getReadVersion(uint32_t flags);
 

--- a/flow/ThreadHelper.actor.h
+++ b/flow/ThreadHelper.actor.h
@@ -614,7 +614,7 @@ private:
 // If instead, this actor is cancelled, we will also cancel the underlying "threadFuture"
 // Note: we are required to have unique ownership of the "threadFuture"
 ACTOR template <class T>
-Future<T> safeThreadFutureToFuture(ThreadFuture<T> threadFuture) {
+Future<T> safeThreadFutureToFutureImpl(ThreadFuture<T> threadFuture) {
 	Promise<Void> ready;
 	Future<Void> onReady = ready.getFuture();
 	UtilCallback<T>* callback = new UtilCallback<T>(threadFuture, ready.extractRawPointer());
@@ -635,10 +635,45 @@ Future<T> safeThreadFutureToFuture(ThreadFuture<T> threadFuture) {
 	return threadFuture.get();
 }
 
-// do nothing, just for template functions' calls
+// The allow anonymous_future type is used to prevent misuse of ThreadFutures.
+// For Standalone types, the memory in some cases is actually stored in the ThreadFuture object,
+// in which case we expect the caller to keep that ThreadFuture around until the result is no
+// longer needed.
+//
+// We can provide some compile-time detection of this misuse by disallowing anonymous thread futures
+// being passed in for certain types.
+template <typename T>
+struct allow_anonymous_future : std::true_type {};
+
+template <typename T>
+struct allow_anonymous_future<Standalone<T>> : std::false_type {};
+
+template <typename T>
+struct allow_anonymous_future<Optional<Standalone<T>>> : std::false_type {};
+
 template <class T>
-Future<T> safeThreadFutureToFuture(Future<T> future) {
-	// do nothing
+typename std::enable_if<allow_anonymous_future<T>::value, Future<T>>::type safeThreadFutureToFuture(
+    const ThreadFuture<T>& threadFuture) {
+	return safeThreadFutureToFutureImpl(threadFuture);
+}
+
+template <class T>
+typename std::enable_if<!allow_anonymous_future<T>::value, Future<T>>::type safeThreadFutureToFuture(
+    ThreadFuture<T>& threadFuture) {
+	return safeThreadFutureToFutureImpl(threadFuture);
+}
+
+template <class T>
+typename std::enable_if<allow_anonymous_future<T>::value, Future<T>>::type safeThreadFutureToFuture(
+    const Future<T>& future) {
+	// Do nothing
+	return future;
+}
+
+template <class T>
+typename std::enable_if<!allow_anonymous_future<T>::value, Future<T>>::type safeThreadFutureToFuture(
+    Future<T>& future) {
+	// Do nothing
 	return future;
 }
 


### PR DESCRIPTION
When wrapping a standalone type, the memory for some ThreadFutures may be held by the ThreadFuture itself rather than the standalone. While we should aim to fix this, for the time being I've added some protection that makes it a compiler error to pass an anonymous thread future to `safeThreadFutureToFuture` when that thread future wraps a standalone type. For example, the following is now an error:

```
safeThreadFutureToFuture(tr.getRange(...)); 
```

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
