### PR TITLE
 Use ArenaReader in TwoLevelHeaderedItemsDeserializer

### DIFF
--- a/fdbserver/CommitProxyServer.actor.cpp
+++ b/fdbserver/CommitProxyServer.actor.cpp
@@ -1022,7 +1022,7 @@ ACTOR Future<Void> applyMetadataToCommittedTransactions(CommitBatchContext* self
 		// in the same set of transactions as this proxy.
 		ResolveTransactionBatchReply& reply = self->resolution[0];
 		if (SERVER_KNOBS->ENABLE_PARTITIONED_TRANSACTIONS) {
-			self->toCommit.setGroupMutations(reply.groupPrivateMutations, self->commitVersion);
+			self->toCommit.setGroupMutations(reply.arena, reply.groupPrivateMutations, self->commitVersion);
 		} else {
 			self->toCommit.setMutations(reply.privateMutationCount, reply.privateMutations);
 		}

--- a/fdbserver/LogSystem.cpp
+++ b/fdbserver/LogSystem.cpp
@@ -397,6 +397,7 @@ std::unordered_map<ptxn::TLogGroupID, ptxn::SerializedTeamData> LogPushData::get
 // It would be nice that ProxySubsequencedMessageSerializer can be set with
 // serialized data.
 void LogPushData::setGroupMutations(
+    const Arena& arena,
     const std::map<ptxn::TLogGroupID, std::unordered_map<ptxn::StorageTeamID, StringRef>>& groupMutations,
     Version commitVersion) {
 	for (const auto& [group, teamData] : groupMutations) {
@@ -408,7 +409,7 @@ void LogPushData::setGroupMutations(
 		}
 		auto& writer = it->second;
 		for (const auto& [team, mutations] : teamData) {
-			ptxn::SubsequencedMessageDeserializer deserializer(mutations);
+			ptxn::SubsequencedMessageDeserializer deserializer(arena, mutations);
 			for (const auto& item : deserializer) {
 				if (item.message.getType() == ptxn::Message::Type::SPAN_CONTEXT_MESSAGE) {
 					writer->writeTeamSpanContext(std::get<SpanContextMessage>(item.message), team);

--- a/fdbserver/LogSystem.h
+++ b/fdbserver/LogSystem.h
@@ -831,6 +831,7 @@ struct LogPushData : NonCopyable {
 	// Sets mutations for internal group writers. "groupMutations" is the output from
 	// getGroupMutations() and is used before writing any other mutations.
 	void setGroupMutations(
+	    const Arena& arena,
 	    const std::map<ptxn::TLogGroupID, std::unordered_map<ptxn::StorageTeamID, StringRef>>& groupMutations,
 	    Version commitVersion);
 

--- a/fdbserver/ptxn/MessageSerializer.h
+++ b/fdbserver/ptxn/MessageSerializer.h
@@ -320,10 +320,11 @@ namespace details {
 class SubsequencedMessageDeserializerBase {
 protected:
 	StringRef serialized;
+	Arena arena;
 	MessageHeader header;
 
 	// Reset the deserializer, start with new serialized data
-	void resetImpl(const StringRef);
+	void resetImpl(const Arena, const StringRef);
 
 public:
 	// Gets the team ID
@@ -379,7 +380,10 @@ public:
 		// serialized_ refers to the serialized data
 		// If isEndIterator, then the iterator indicates the end of the serialized data. The behavior of dereferencing
 		// the iterator is undefined.
-		iterator(StringRef serialized_, const bool isEndIterator = false, const bool iterateOverEmptyVersions_ = false);
+		iterator(Arena arena_,
+		         StringRef serialized_,
+		         const bool isEndIterator = false,
+		         const bool iterateOverEmptyVersions_ = false);
 
 	public:
 		bool operator==(const iterator& another) const;
@@ -416,13 +420,15 @@ public:
 	// serialized_ refers to the serialized data
 	// If iterateOverEmptyVersions_ is set to true, the iterator will yield a VersionSubsequencedMessage with message
 	// type EmptyMessage when meet a version that has no messages, instead of skipping it.
-	SubsequencedMessageDeserializer(const StringRef serialized_, const bool iterateOverEmptyVersions_ = false);
+	SubsequencedMessageDeserializer(const Arena arena_,
+	                                const StringRef serialized_,
+	                                const bool iterateOverEmptyVersions_ = false);
 
 	// Returns true if a version without messages will be skipped.
 	bool isEmptyVersionsIgnored() const;
 
 	// Resets the deserializer, this will invalidate all iterators
-	void reset(const StringRef serialized_);
+	void reset(const Arena, const StringRef);
 
 	// Returns an iterator.
 	iterator begin() const;

--- a/fdbserver/ptxn/Serializer.h
+++ b/fdbserver/ptxn/Serializer.h
@@ -326,15 +326,15 @@ bool headeredItemDeserializerBase(const Arena& arena, StringRef serialized, Head
 // Deserializes the TwoLevelHeaderedItemsSerializer
 template <typename MainHeader, typename SectionHeader>
 class TwoLevelHeaderedItemsDeserializer {
-	BinaryReader reader;
+	ArenaReader reader;
 
 public:
 	using main_header_t = MainHeader;
 	using section_header_t = SectionHeader;
 
 	// serialized is the StringRef points to the serialied data
-	TwoLevelHeaderedItemsDeserializer(StringRef serialized)
-	  : reader(serialized, IncludeVersion(ProtocolVersion::withPartitionTransaction())) {
+	TwoLevelHeaderedItemsDeserializer(Arena arena, StringRef serialized)
+	  : reader(arena, serialized, IncludeVersion(ProtocolVersion::withPartitionTransaction())) {
 		// The serialized data *MUST* have a header
 		ASSERT(!allConsumed());
 	}

--- a/fdbserver/ptxn/TLogPeekCursor.actor.cpp
+++ b/fdbserver/ptxn/TLogPeekCursor.actor.cpp
@@ -123,7 +123,7 @@ ACTOR Future<bool> peekRemote(PeekRemoteContext peekRemoteContext) {
 	// In case the remote epoch ended, an end_of_stream exception will be thrown and it is the caller's responsible
 	// to catch.
 
-	peekRemoteContext.deserializer.reset(reply.data);
+	peekRemoteContext.deserializer.reset(reply.arena, reply.data);
 	peekRemoteContext.wrappedDeserializerIter = peekRemoteContext.deserializer.begin();
 	if (peekRemoteContext.wrappedDeserializerIter.get() == peekRemoteContext.deserializer.end()) {
 		// No new mutations incoming, and there is no new mutations responded from TLog in this request
@@ -249,7 +249,8 @@ StorageTeamPeekCursor::StorageTeamPeekCursor(const Version& beginVersion_,
                                              Arena* pArena_,
                                              const bool reportEmptyVersion_)
   : VersionSubsequencePeekCursorBase(), storageTeamID(storageTeamID_), pTLogInterfaces(pTLogInterfaces_),
-    pAttachArena(pArena_), deserializer(emptyCursorHeader(), /* reportEmptyVersion_ */ true),
+    pAttachArena(pArena_),
+    deserializer(emptyCursorHeader().arena(), emptyCursorHeader(), /* reportEmptyVersion_ */ true),
     wrappedDeserializerIter(deserializer.begin(), pArena_), beginVersion(beginVersion_),
     reportEmptyVersion(reportEmptyVersion_), lastVersion(beginVersion_ - 1) {
 

--- a/fdbserver/ptxn/test/FakeStorageServer.actor.cpp
+++ b/fdbserver/ptxn/test/FakeStorageServer.actor.cpp
@@ -42,7 +42,7 @@ ACTOR Future<Void> fakeStorageServer_PassivelyReceive(
 		when(StorageServerPushRequest request = waitNext(pStorageServerInterface->pushRequests.getFuture())) {
 			const Version version = request.version;
 			const StorageTeamID storageTeamID = request.storageTeamID;
-			SubsequencedMessageDeserializer deserializer(request.messages);
+			SubsequencedMessageDeserializer deserializer(request.arena, request.messages);
 			int index = 0;
 			for (auto vsm : deserializer) {
 				const auto& message = vsm.message;

--- a/fdbserver/ptxn/test/FakeTLog.actor.cpp
+++ b/fdbserver/ptxn/test/FakeTLog.actor.cpp
@@ -37,10 +37,11 @@ namespace ptxn::test {
 void processTLogCommitRequestByStorageTeam(std::shared_ptr<FakeTLogContext> pFakeTLogContext,
                                            const Version& commitVersion,
                                            const StorageTeamID& storageTeamID,
+                                           const Arena arenaFromReq,
                                            const StringRef& messages) {
 	print::PrintTiming printTiming("processTLogCommitRequest");
 	printTiming << "Processing commit " << commitVersion << " for storage team " << storageTeamID << std::endl;
-	SubsequencedMessageDeserializer deserializer(messages, true);
+	SubsequencedMessageDeserializer deserializer(arenaFromReq, messages, true);
 	auto& commitRecord = pFakeTLogContext->pTestDriverContext->commitRecord;
 
 	// Check the committed data matches the record
@@ -101,7 +102,8 @@ ACTOR Future<Void> processTLogCommitRequest(std::shared_ptr<FakeTLogContext> pFa
                                             TLogCommitRequest commitRequest) {
 	wait(pFakeTLogContext->latency());
 	for (const auto& [storageTeamID, message] : commitRequest.messages) {
-		processTLogCommitRequestByStorageTeam(pFakeTLogContext, commitRequest.version, storageTeamID, message);
+		processTLogCommitRequestByStorageTeam(
+		    pFakeTLogContext, commitRequest.version, storageTeamID, commitRequest.arena, message);
 	}
 	commitRequest.reply.send(TLogCommitReply{ commitRequest.version });
 	return Void();

--- a/fdbserver/ptxn/test/TestTLogServer.actor.cpp
+++ b/fdbserver/ptxn/test/TestTLogServer.actor.cpp
@@ -227,7 +227,7 @@ ACTOR Future<Void> commitPeekAndCheck(std::shared_ptr<ptxn::test::TestDriverCont
 	ptxn::test::print::print(peekReply);
 
 	// Verify
-	ptxn::SubsequencedMessageDeserializer deserializer(peekReply.data);
+	ptxn::SubsequencedMessageDeserializer deserializer(peekReply.arena, peekReply.data);
 	ASSERT(storageTeamID == deserializer.getStorageTeamID());
 	ASSERT_EQ(beginVersion, deserializer.getFirstVersion());
 	ASSERT_EQ(beginVersion, deserializer.getLastVersion());
@@ -554,7 +554,7 @@ ACTOR Future<Void> verifyPeek(std::shared_ptr<ptxn::test::TestDriverContext> pCo
 		request.endVersion.reset();
 		ptxn::TLogPeekReply reply = wait(pInterface->peek.getReply(request));
 
-		ptxn::SubsequencedMessageDeserializer deserializer(reply.data);
+		ptxn::SubsequencedMessageDeserializer deserializer(reply.arena, reply.data);
 		Version v = deserializer.getFirstVersion();
 
 		if (v == invalidVersion) {


### PR DESCRIPTION
Replace BinaryReader with ArenaReader, to avoid unnecessary
    memory copy.


20220330-001819-haofu-671820cba65d6ef4

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
