### PR TITLE
Make Standalone's returned from DLTransaction actually own their memory

### DIFF
--- a/fdbcli/ConfigureCommand.actor.cpp
+++ b/fdbcli/ConfigureCommand.actor.cpp
@@ -57,8 +57,7 @@ ACTOR Future<bool> configureCommandActor(Reference<IDatabase> db,
 				StatusObject _s = wait(StatusClient::statusFetcher(localDb));
 				s = _s;
 			} else {
-				state ThreadFuture<Optional<Value>> statusValueF = tr->get("\xff\xff/status/json"_sr);
-				Optional<Value> statusValue = wait(safeThreadFutureToFuture(statusValueF));
+				Optional<Value> statusValue = wait(safeThreadFutureToFuture(tr->get("\xff\xff/status/json"_sr)));
 				if (!statusValue.present()) {
 					fprintf(stderr, "ERROR: Failed to get status json from the cluster\n");
 					return false;

--- a/fdbcli/ConsistencyCheckCommand.actor.cpp
+++ b/fdbcli/ConsistencyCheckCommand.actor.cpp
@@ -39,9 +39,7 @@ ACTOR Future<bool> consistencyCheckCommandActor(Reference<ITransaction> tr,
 	// If not, the outer loop catch block(fdbcli.actor.cpp) will handle the error and print out the error message
 	tr->setOption(FDBTransactionOptions::SPECIAL_KEY_SPACE_ENABLE_WRITES);
 	if (tokens.size() == 1) {
-		// hold the returned standalone object's memory
-		state ThreadFuture<Optional<Value>> suspendedF = tr->get(consistencyCheckSpecialKey);
-		Optional<Value> suspended = wait(safeThreadFutureToFuture(suspendedF));
+		Optional<Value> suspended = wait(safeThreadFutureToFuture(tr->get(consistencyCheckSpecialKey)));
 		printf("ConsistencyCheck is %s\n", suspended.present() ? "off" : "on");
 	} else if (tokens.size() == 2 && tokencmp(tokens[1], "off")) {
 		tr->set(consistencyCheckSpecialKey, Value());

--- a/fdbcli/DataDistributionCommand.actor.cpp
+++ b/fdbcli/DataDistributionCommand.actor.cpp
@@ -41,10 +41,8 @@ ACTOR Future<Void> setDDMode(Reference<IDatabase> db, int mode) {
 			tr->set(fdb_cli::ddModeSpecialKey, boost::lexical_cast<std::string>(mode));
 			if (mode) {
 				// set DDMode to 1 will enable all disabled parts, for instance the SS failure monitors.
-				// hold the returned standalone object's memory
-				state ThreadFuture<RangeResult> resultFuture =
-				    tr->getRange(fdb_cli::maintenanceSpecialKeyRange, CLIENT_KNOBS->TOO_MANY);
-				RangeResult res = wait(safeThreadFutureToFuture(resultFuture));
+				RangeResult res = wait(safeThreadFutureToFuture(
+				    tr->getRange(fdb_cli::maintenanceSpecialKeyRange, CLIENT_KNOBS->TOO_MANY)));
 				ASSERT(res.size() <= 1);
 				if (res.size() == 1 && res[0].key == fdb_cli::ignoreSSFailureSpecialKey) {
 					// only clear the key if it is currently being used to disable all SS failure data movement

--- a/fdbcli/ExcludeCommand.actor.cpp
+++ b/fdbcli/ExcludeCommand.actor.cpp
@@ -87,13 +87,11 @@ ACTOR Future<std::vector<std::string>> getExcludedServers(Reference<IDatabase> d
 	state Reference<ITransaction> tr = db->createTransaction();
 	loop {
 		try {
-			state ThreadFuture<RangeResult> resultFuture =
-			    tr->getRange(fdb_cli::excludedServersSpecialKeyRange, CLIENT_KNOBS->TOO_MANY);
-			state RangeResult r = wait(safeThreadFutureToFuture(resultFuture));
+			state RangeResult r = wait(safeThreadFutureToFuture(
+			    tr->getRange(fdb_cli::excludedServersSpecialKeyRange, CLIENT_KNOBS->TOO_MANY)));
 			ASSERT(!r.more && r.size() < CLIENT_KNOBS->TOO_MANY);
-			state ThreadFuture<RangeResult> resultFuture2 =
-			    tr->getRange(fdb_cli::failedServersSpecialKeyRange, CLIENT_KNOBS->TOO_MANY);
-			state RangeResult r2 = wait(safeThreadFutureToFuture(resultFuture2));
+			state RangeResult r2 = wait(
+			    safeThreadFutureToFuture(tr->getRange(fdb_cli::failedServersSpecialKeyRange, CLIENT_KNOBS->TOO_MANY)));
 			ASSERT(!r2.more && r2.size() < CLIENT_KNOBS->TOO_MANY);
 
 			std::vector<std::string> exclusions;
@@ -117,13 +115,11 @@ ACTOR Future<std::vector<std::string>> getExcludedLocalities(Reference<IDatabase
 	state Reference<ITransaction> tr = db->createTransaction();
 	loop {
 		try {
-			state ThreadFuture<RangeResult> resultFuture =
-			    tr->getRange(fdb_cli::excludedLocalitySpecialKeyRange, CLIENT_KNOBS->TOO_MANY);
-			state RangeResult r = wait(safeThreadFutureToFuture(resultFuture));
+			state RangeResult r = wait(safeThreadFutureToFuture(
+			    tr->getRange(fdb_cli::excludedLocalitySpecialKeyRange, CLIENT_KNOBS->TOO_MANY)));
 			ASSERT(!r.more && r.size() < CLIENT_KNOBS->TOO_MANY);
-			state ThreadFuture<RangeResult> resultFuture2 =
-			    tr->getRange(fdb_cli::failedLocalitySpecialKeyRange, CLIENT_KNOBS->TOO_MANY);
-			state RangeResult r2 = wait(safeThreadFutureToFuture(resultFuture2));
+			state RangeResult r2 = wait(
+			    safeThreadFutureToFuture(tr->getRange(fdb_cli::failedLocalitySpecialKeyRange, CLIENT_KNOBS->TOO_MANY)));
 			ASSERT(!r2.more && r2.size() < CLIENT_KNOBS->TOO_MANY);
 
 			std::vector<std::string> excludedLocalities;
@@ -151,9 +147,8 @@ ACTOR Future<std::set<NetworkAddress>> checkForExcludingServers(Reference<IDatab
 	loop {
 		inProgressExclusion.clear();
 		try {
-			state ThreadFuture<RangeResult> resultFuture =
-			    tr->getRange(fdb_cli::exclusionInProgressSpecialKeyRange, CLIENT_KNOBS->TOO_MANY);
-			RangeResult exclusionInProgress = wait(safeThreadFutureToFuture(resultFuture));
+			RangeResult exclusionInProgress = wait(safeThreadFutureToFuture(
+			    tr->getRange(fdb_cli::exclusionInProgressSpecialKeyRange, CLIENT_KNOBS->TOO_MANY)));
 			ASSERT(!exclusionInProgress.more && exclusionInProgress.size() < CLIENT_KNOBS->TOO_MANY);
 			if (exclusionInProgress.empty())
 				return inProgressExclusion;
@@ -200,9 +195,8 @@ ACTOR Future<Void> checkForCoordinators(Reference<IDatabase> db, std::vector<Add
 	state Reference<ITransaction> tr = db->createTransaction();
 	loop {
 		try {
-			// Hold the reference to the standalone's memory
-			state ThreadFuture<Optional<Value>> coordinatorsF = tr->get(fdb_cli::coordinatorsProcessSpecialKey);
-			Optional<Value> coordinators = wait(safeThreadFutureToFuture(coordinatorsF));
+			Optional<Value> coordinators =
+			    wait(safeThreadFutureToFuture(tr->get(fdb_cli::coordinatorsProcessSpecialKey)));
 			ASSERT(coordinators.present());
 			coordinatorList = NetworkAddress::parseList(coordinators.get().toString());
 			break;

--- a/fdbcli/LockCommand.actor.cpp
+++ b/fdbcli/LockCommand.actor.cpp
@@ -78,8 +78,7 @@ ACTOR Future<bool> unlockDatabaseActor(Reference<IDatabase> db, UID uid) {
 	loop {
 		tr->setOption(FDBTransactionOptions::SPECIAL_KEY_SPACE_ENABLE_WRITES);
 		try {
-			state ThreadFuture<Optional<Value>> valF = tr->get(fdb_cli::lockSpecialKey);
-			Optional<Value> val = wait(safeThreadFutureToFuture(valF));
+			Optional<Value> val = wait(safeThreadFutureToFuture(tr->get(fdb_cli::lockSpecialKey)));
 
 			if (!val.present())
 				return true;

--- a/fdbcli/MaintenanceCommand.actor.cpp
+++ b/fdbcli/MaintenanceCommand.actor.cpp
@@ -42,11 +42,8 @@ ACTOR Future<Void> printHealthyZone(Reference<IDatabase> db) {
 	loop {
 		tr->setOption(FDBTransactionOptions::SPECIAL_KEY_SPACE_ENABLE_WRITES);
 		try {
-			// We need to keep the future as the returned standalone is not guaranteed to manage its memory when
-			// using an external client, but the ThreadFuture holds a reference to the memory
-			state ThreadFuture<RangeResult> resultFuture =
-			    tr->getRange(fdb_cli::maintenanceSpecialKeyRange, CLIENT_KNOBS->TOO_MANY);
-			RangeResult res = wait(safeThreadFutureToFuture(resultFuture));
+			RangeResult res = wait(
+			    safeThreadFutureToFuture(tr->getRange(fdb_cli::maintenanceSpecialKeyRange, CLIENT_KNOBS->TOO_MANY)));
 			ASSERT(res.size() <= 1);
 			if (res.size() == 1 && res[0].key == fdb_cli::ignoreSSFailureSpecialKey) {
 				printf("Data distribution has been disabled for all storage server failures in this cluster and thus "
@@ -81,10 +78,8 @@ ACTOR Future<bool> setHealthyZone(Reference<IDatabase> db, StringRef zoneId, dou
 	loop {
 		tr->setOption(FDBTransactionOptions::SPECIAL_KEY_SPACE_ENABLE_WRITES);
 		try {
-			// hold the returned standalone object's memory
-			state ThreadFuture<RangeResult> resultFuture =
-			    tr->getRange(fdb_cli::maintenanceSpecialKeyRange, CLIENT_KNOBS->TOO_MANY);
-			RangeResult res = wait(safeThreadFutureToFuture(resultFuture));
+			RangeResult res = wait(
+			    safeThreadFutureToFuture(tr->getRange(fdb_cli::maintenanceSpecialKeyRange, CLIENT_KNOBS->TOO_MANY)));
 			ASSERT(res.size() <= 1);
 			if (res.size() == 1 && res[0].key == fdb_cli::ignoreSSFailureSpecialKey) {
 				if (printWarning) {
@@ -111,10 +106,8 @@ ACTOR Future<bool> clearHealthyZone(Reference<IDatabase> db, bool printWarning, 
 	loop {
 		tr->setOption(FDBTransactionOptions::SPECIAL_KEY_SPACE_ENABLE_WRITES);
 		try {
-			// hold the returned standalone object's memory
-			state ThreadFuture<RangeResult> resultFuture =
-			    tr->getRange(fdb_cli::maintenanceSpecialKeyRange, CLIENT_KNOBS->TOO_MANY);
-			RangeResult res = wait(safeThreadFutureToFuture(resultFuture));
+			RangeResult res = wait(
+			    safeThreadFutureToFuture(tr->getRange(fdb_cli::maintenanceSpecialKeyRange, CLIENT_KNOBS->TOO_MANY)));
 			ASSERT(res.size() <= 1);
 			if (!clearSSFailureZoneString && res.size() == 1 && res[0].key == fdb_cli::ignoreSSFailureSpecialKey) {
 				if (printWarning) {

--- a/fdbcli/ProfileCommand.actor.cpp
+++ b/fdbcli/ProfileCommand.actor.cpp
@@ -114,10 +114,8 @@ ACTOR Future<bool> profileCommandActor(Database db,
 			fprintf(stderr, "ERROR: Usage: profile list\n");
 			return false;
 		}
-		// Hold the reference to the standalone's memory
-		state ThreadFuture<RangeResult> kvsFuture = tr->getRange(
-		    KeyRangeRef("\xff\xff/worker_interfaces/"_sr, "\xff\xff/worker_interfaces0"_sr), CLIENT_KNOBS->TOO_MANY);
-		RangeResult kvs = wait(safeThreadFutureToFuture(kvsFuture));
+		RangeResult kvs = wait(safeThreadFutureToFuture(tr->getRange(
+		    KeyRangeRef("\xff\xff/worker_interfaces/"_sr, "\xff\xff/worker_interfaces0"_sr), CLIENT_KNOBS->TOO_MANY)));
 		ASSERT(!kvs.more);
 		for (const auto& pair : kvs) {
 			auto ip_port = (pair.key.endsWith(":tls"_sr) ? pair.key.removeSuffix(":tls"_sr) : pair.key)

--- a/fdbcli/SetClassCommand.actor.cpp
+++ b/fdbcli/SetClassCommand.actor.cpp
@@ -38,7 +38,6 @@ ACTOR Future<Void> printProcessClass(Reference<IDatabase> db) {
 	loop {
 		tr->setOption(FDBTransactionOptions::SPECIAL_KEY_SPACE_ENABLE_WRITES);
 		try {
-			// Hold the reference to the memory
 			state ThreadFuture<RangeResult> classTypeFuture =
 			    tr->getRange(fdb_cli::processClassTypeSpecialKeyRange, CLIENT_KNOBS->TOO_MANY);
 			state ThreadFuture<RangeResult> classSourceFuture =
@@ -77,9 +76,8 @@ ACTOR Future<bool> setProcessClass(Reference<IDatabase> db, KeyRef network_addre
 	loop {
 		tr->setOption(FDBTransactionOptions::SPECIAL_KEY_SPACE_ENABLE_WRITES);
 		try {
-			state ThreadFuture<Optional<Value>> result =
-			    tr->get(network_address.withPrefix(fdb_cli::processClassTypeSpecialKeyRange.begin));
-			Optional<Value> val = wait(safeThreadFutureToFuture(result));
+			Optional<Value> val = wait(safeThreadFutureToFuture(
+			    tr->get(network_address.withPrefix(fdb_cli::processClassTypeSpecialKeyRange.begin))));
 			if (!val.present()) {
 				printf("No matching addresses found\n");
 				return false;

--- a/fdbcli/StatusCommand.actor.cpp
+++ b/fdbcli/StatusCommand.actor.cpp
@@ -1265,8 +1265,7 @@ ACTOR Future<bool> statusCommandActor(Reference<IDatabase> db,
 		StatusObject _s = wait(StatusClient::statusFetcher(localDb));
 		s = _s;
 	} else {
-		state ThreadFuture<Optional<Value>> statusValueF = tr->get("\xff\xff/status/json"_sr);
-		Optional<Value> statusValue = wait(safeThreadFutureToFuture(statusValueF));
+		Optional<Value> statusValue = wait(safeThreadFutureToFuture(tr->get("\xff\xff/status/json"_sr)));
 		if (!statusValue.present()) {
 			fprintf(stderr, "ERROR: Failed to get status json from the cluster\n");
 		}

--- a/fdbcli/TenantCommands.actor.cpp
+++ b/fdbcli/TenantCommands.actor.cpp
@@ -192,9 +192,7 @@ ACTOR Future<bool> tenantCreateCommand(Reference<IDatabase> db, std::vector<Stri
 				wait(MetaclusterAPI::createTenant(db, tokens[2], tenantEntry));
 			} else {
 				if (!doneExistenceCheck) {
-					// Hold the reference to the standalone's memory
-					state ThreadFuture<Optional<Value>> existingTenantFuture = tr->get(tenantNameKey);
-					Optional<Value> existingTenant = wait(safeThreadFutureToFuture(existingTenantFuture));
+					Optional<Value> existingTenant = wait(safeThreadFutureToFuture(tr->get(tenantNameKey)));
 					if (existingTenant.present()) {
 						throw tenant_already_exists();
 					}
@@ -244,9 +242,7 @@ ACTOR Future<bool> tenantDeleteCommand(Reference<IDatabase> db, std::vector<Stri
 				wait(MetaclusterAPI::deleteTenant(db, tokens[2]));
 			} else {
 				if (!doneExistenceCheck) {
-					// Hold the reference to the standalone's memory
-					state ThreadFuture<Optional<Value>> existingTenantFuture = tr->get(tenantNameKey);
-					Optional<Value> existingTenant = wait(safeThreadFutureToFuture(existingTenantFuture));
+					Optional<Value> existingTenant = wait(safeThreadFutureToFuture(tr->get(tenantNameKey)));
 					if (!existingTenant.present()) {
 						throw tenant_not_found();
 					}
@@ -323,10 +319,8 @@ ACTOR Future<bool> tenantListCommand(Reference<IDatabase> db, std::vector<String
 					tenantNames.push_back(tenant.first);
 				}
 			} else {
-				// Hold the reference to the standalone's memory
-				state ThreadFuture<RangeResult> kvsFuture =
-				    tr->getRange(firstGreaterOrEqual(beginTenantKey), firstGreaterOrEqual(endTenantKey), limit);
-				RangeResult tenants = wait(safeThreadFutureToFuture(kvsFuture));
+				RangeResult tenants = wait(safeThreadFutureToFuture(
+				    tr->getRange(firstGreaterOrEqual(beginTenantKey), firstGreaterOrEqual(endTenantKey), limit)));
 				for (auto tenant : tenants) {
 					tenantNames.push_back(tenant.key.removePrefix(tenantMapSpecialKeyRange.begin));
 				}
@@ -380,9 +374,7 @@ ACTOR Future<bool> tenantGetCommand(Reference<IDatabase> db, std::vector<StringR
 				TenantMapEntry entry = wait(MetaclusterAPI::getTenantTransaction(tr, tokens[2]));
 				tenantJson = entry.toJson();
 			} else {
-				// Hold the reference to the standalone's memory
-				state ThreadFuture<Optional<Value>> tenantFuture = tr->get(tenantNameKey);
-				Optional<Value> tenant = wait(safeThreadFutureToFuture(tenantFuture));
+				Optional<Value> tenant = wait(safeThreadFutureToFuture(tr->get(tenantNameKey)));
 				if (!tenant.present()) {
 					throw tenant_not_found();
 				}

--- a/fdbcli/Util.actor.cpp
+++ b/fdbcli/Util.actor.cpp
@@ -47,9 +47,7 @@ void printUsage(StringRef command) {
 }
 
 ACTOR Future<std::string> getSpecialKeysFailureErrorMessage(Reference<ITransaction> tr) {
-	// hold the returned standalone object's memory
-	state ThreadFuture<Optional<Value>> errorMsgF = tr->get(fdb_cli::errorMsgSpecialKey);
-	Optional<Value> errorMsg = wait(safeThreadFutureToFuture(errorMsgF));
+	Optional<Value> errorMsg = wait(safeThreadFutureToFuture(tr->get(fdb_cli::errorMsgSpecialKey)));
 	// Error message should be present
 	ASSERT(errorMsg.present());
 	// Read the json string
@@ -95,10 +93,8 @@ ACTOR Future<Void> getWorkerInterfaces(Reference<ITransaction> tr,
 		tr->setOption(FDBTransactionOptions::SPECIAL_KEY_SPACE_ENABLE_WRITES);
 		tr->set(workerInterfacesVerifyOptionSpecialKey, ValueRef());
 	}
-	// Hold the reference to the standalone's memory
-	state ThreadFuture<RangeResult> kvsFuture = tr->getRange(
-	    KeyRangeRef("\xff\xff/worker_interfaces/"_sr, "\xff\xff/worker_interfaces0"_sr), CLIENT_KNOBS->TOO_MANY);
-	state RangeResult kvs = wait(safeThreadFutureToFuture(kvsFuture));
+	state RangeResult kvs = wait(safeThreadFutureToFuture(tr->getRange(
+	    KeyRangeRef("\xff\xff/worker_interfaces/"_sr, "\xff\xff/worker_interfaces0"_sr), CLIENT_KNOBS->TOO_MANY)));
 	ASSERT(!kvs.more);
 	if (verify) {
 		// remove the option if set

--- a/fdbcli/VersionEpochCommand.actor.cpp
+++ b/fdbcli/VersionEpochCommand.actor.cpp
@@ -45,8 +45,7 @@ ACTOR static Future<Optional<VersionInfo>> getVersionInfo(Reference<IDatabase> d
 		try {
 			tr->setOption(FDBTransactionOptions::READ_SYSTEM_KEYS);
 			state Version rv = wait(safeThreadFutureToFuture(tr->getReadVersion()));
-			state ThreadFuture<Optional<Value>> versionEpochValFuture = tr->get(versionEpochKey);
-			Optional<Value> versionEpochVal = wait(safeThreadFutureToFuture(versionEpochValFuture));
+			Optional<Value> versionEpochVal = wait(safeThreadFutureToFuture(tr->get(versionEpochKey)));
 			if (!versionEpochVal.present()) {
 				return Optional<VersionInfo>();
 			}
@@ -62,8 +61,7 @@ ACTOR static Future<Optional<VersionInfo>> getVersionInfo(Reference<IDatabase> d
 ACTOR static Future<Optional<int64_t>> getVersionEpoch(Reference<ITransaction> tr) {
 	loop {
 		try {
-			state ThreadFuture<Optional<Value>> versionEpochValFuture = tr->get(versionEpochSpecialKey);
-			Optional<Value> versionEpochVal = wait(safeThreadFutureToFuture(versionEpochValFuture));
+			Optional<Value> versionEpochVal = wait(safeThreadFutureToFuture(tr->get(versionEpochSpecialKey)));
 			return versionEpochVal.present() ? boost::lexical_cast<int64_t>(versionEpochVal.get().toString())
 			                                 : Optional<int64_t>();
 		} catch (Error& e) {

--- a/fdbcli/fdbcli.actor.cpp
+++ b/fdbcli/fdbcli.actor.cpp
@@ -665,8 +665,7 @@ ACTOR Future<Void> checkStatus(Future<Void> f,
 		StatusObject _s = wait(StatusClient::statusFetcher(localDb));
 		s = _s;
 	} else {
-		state ThreadFuture<Optional<Value>> statusValueF = tr->get("\xff\xff/status/json"_sr);
-		Optional<Value> statusValue = wait(safeThreadFutureToFuture(statusValueF));
+		Optional<Value> statusValue = wait(safeThreadFutureToFuture(tr->get("\xff\xff/status/json"_sr)));
 		if (!statusValue.present()) {
 			fprintf(stderr, "ERROR: Failed to get status json from the cluster\n");
 			return Void();
@@ -1577,9 +1576,8 @@ ACTOR Future<int> cli(CLIOptions opt, LineNoise* plinenoise, Reference<ClusterCo
 								continue;
 							}
 						}
-						state ThreadFuture<Optional<Value>> valueF =
-						    getTransaction(db, tenant, tr, options, intrans)->get(tokens[1]);
-						Optional<Standalone<StringRef>> v = wait(makeInterruptable(safeThreadFutureToFuture(valueF)));
+						Optional<Standalone<StringRef>> v = wait(makeInterruptable(safeThreadFutureToFuture(
+						    getTransaction(db, tenant, tr, options, intrans)->get(tokens[1]))));
 
 						if (v.present())
 							printf("`%s' is `%s'\n", printable(tokens[1]).c_str(), printable(v.get()).c_str());
@@ -1740,8 +1738,8 @@ ACTOR Future<int> cli(CLIOptions opt, LineNoise* plinenoise, Reference<ClusterCo
 						}
 
 						getTransaction(db, tenant, tr, options, intrans);
-						state ThreadFuture<RangeResult> kvsF = tr->getRange(KeyRangeRef(tokens[1], endKey), limit);
-						RangeResult kvs = wait(makeInterruptable(safeThreadFutureToFuture(kvsF)));
+						RangeResult kvs = wait(makeInterruptable(
+						    safeThreadFutureToFuture(tr->getRange(KeyRangeRef(tokens[1], endKey), limit))));
 
 						printf("\nRange limited to %d keys\n", limit);
 						for (auto iter = kvs.begin(); iter < kvs.end(); iter++) {

--- a/fdbclient/MultiVersionTransaction.actor.cpp
+++ b/fdbclient/MultiVersionTransaction.actor.cpp
@@ -62,7 +62,7 @@ void DLTransaction::setVersion(Version v) {
 ThreadFuture<Version> DLTransaction::getReadVersion() {
 	FdbCApi::FDBFuture* f = api->transactionGetReadVersion(tr);
 
-	return toThreadFuture<Version>(api, f, [](FdbCApi::FDBFuture* f, FdbCApi* api) {
+	return toThreadFuture<Version>(api, f, [](FdbCApi::FDBFuture* f, Arena& arena, FdbCApi* api) {
 		int64_t version;
 		FdbCApi::fdb_error_t error = api->futureGetInt64(f, &version);
 		ASSERT(!error);
@@ -73,15 +73,14 @@ ThreadFuture<Version> DLTransaction::getReadVersion() {
 ThreadFuture<Optional<Value>> DLTransaction::get(const KeyRef& key, bool snapshot) {
 	FdbCApi::FDBFuture* f = api->transactionGet(tr, key.begin(), key.size(), snapshot);
 
-	return toThreadFuture<Optional<Value>>(api, f, [](FdbCApi::FDBFuture* f, FdbCApi* api) {
+	return toThreadFuture<Optional<Value>>(api, f, [](FdbCApi::FDBFuture* f, Arena& arena, FdbCApi* api) {
 		FdbCApi::fdb_bool_t present;
 		const uint8_t* value;
 		int valueLength;
 		FdbCApi::fdb_error_t error = api->futureGetValue(f, &present, &value, &valueLength);
 		ASSERT(!error);
 		if (present) {
-			// The memory for this is stored in the FDBFuture and is released when the future gets destroyed
-			return Optional<Value>(Value(ValueRef(value, valueLength), Arena()));
+			return Optional<Value>(Value(ValueRef(value, valueLength), arena));
 		} else {
 			return Optional<Value>();
 		}
@@ -92,14 +91,13 @@ ThreadFuture<Key> DLTransaction::getKey(const KeySelectorRef& key, bool snapshot
 	FdbCApi::FDBFuture* f =
 	    api->transactionGetKey(tr, key.getKey().begin(), key.getKey().size(), key.orEqual, key.offset, snapshot);
 
-	return toThreadFuture<Key>(api, f, [](FdbCApi::FDBFuture* f, FdbCApi* api) {
+	return toThreadFuture<Key>(api, f, [](FdbCApi::FDBFuture* f, Arena& arena, FdbCApi* api) {
 		const uint8_t* key;
 		int keyLength;
 		FdbCApi::fdb_error_t error = api->futureGetKey(f, &key, &keyLength);
 		ASSERT(!error);
 
-		// The memory for this is stored in the FDBFuture and is released when the future gets destroyed
-		return Key(KeyRef(key, keyLength), Arena());
+		return Key(KeyRef(key, keyLength), arena);
 	});
 }
 
@@ -131,15 +129,14 @@ ThreadFuture<RangeResult> DLTransaction::getRange(const KeySelectorRef& begin,
 	                                                 0,
 	                                                 snapshot,
 	                                                 reverse);
-	return toThreadFuture<RangeResult>(api, f, [](FdbCApi::FDBFuture* f, FdbCApi* api) {
+	return toThreadFuture<RangeResult>(api, f, [](FdbCApi::FDBFuture* f, Arena& arena, FdbCApi* api) {
 		const FdbCApi::FDBKeyValue* kvs;
 		int count;
 		FdbCApi::fdb_bool_t more;
 		FdbCApi::fdb_error_t error = api->futureGetKeyValueArray(f, &kvs, &count, &more);
 		ASSERT(!error);
 
-		// The memory for this is stored in the FDBFuture and is released when the future gets destroyed
-		return RangeResult(RangeResultRef(VectorRef<KeyValueRef>((KeyValueRef*)kvs, count), more), Arena());
+		return RangeResult(RangeResultRef(VectorRef<KeyValueRef>((KeyValueRef*)kvs, count), more), arena);
 	});
 }
 
@@ -180,31 +177,30 @@ ThreadFuture<MappedRangeResult> DLTransaction::getMappedRange(const KeySelectorR
 	                                                       matchIndex,
 	                                                       snapshot,
 	                                                       reverse);
-	return toThreadFuture<MappedRangeResult>(api, f, [](FdbCApi::FDBFuture* f, FdbCApi* api) {
+	return toThreadFuture<MappedRangeResult>(api, f, [](FdbCApi::FDBFuture* f, Arena& arena, FdbCApi* api) {
 		const FdbCApi::FDBMappedKeyValue* kvms;
 		int count;
 		FdbCApi::fdb_bool_t more;
 		FdbCApi::fdb_error_t error = api->futureGetMappedKeyValueArray(f, &kvms, &count, &more);
 		ASSERT(!error);
 
-		// The memory for this is stored in the FDBFuture and is released when the future gets destroyed
 		return MappedRangeResult(
-		    MappedRangeResultRef(VectorRef<MappedKeyValueRef>((MappedKeyValueRef*)kvms, count), more), Arena());
+		    MappedRangeResultRef(VectorRef<MappedKeyValueRef>((MappedKeyValueRef*)kvms, count), more), arena);
 	});
 }
 
 ThreadFuture<Standalone<VectorRef<const char*>>> DLTransaction::getAddressesForKey(const KeyRef& key) {
 	FdbCApi::FDBFuture* f = api->transactionGetAddressesForKey(tr, key.begin(), key.size());
 
-	return toThreadFuture<Standalone<VectorRef<const char*>>>(api, f, [](FdbCApi::FDBFuture* f, FdbCApi* api) {
-		const char** addresses;
-		int count;
-		FdbCApi::fdb_error_t error = api->futureGetStringArray(f, &addresses, &count);
-		ASSERT(!error);
+	return toThreadFuture<Standalone<VectorRef<const char*>>>(
+	    api, f, [](FdbCApi::FDBFuture* f, Arena& arena, FdbCApi* api) {
+		    const char** addresses;
+		    int count;
+		    FdbCApi::fdb_error_t error = api->futureGetStringArray(f, &addresses, &count);
+		    ASSERT(!error);
 
-		// The memory for this is stored in the FDBFuture and is released when the future gets destroyed
-		return Standalone<VectorRef<const char*>>(VectorRef<const char*>(addresses, count), Arena());
-	});
+		    return Standalone<VectorRef<const char*>>(VectorRef<const char*>(addresses, count), arena);
+	    });
 }
 
 ThreadFuture<Standalone<StringRef>> DLTransaction::getVersionstamp() {
@@ -214,14 +210,13 @@ ThreadFuture<Standalone<StringRef>> DLTransaction::getVersionstamp() {
 
 	FdbCApi::FDBFuture* f = api->transactionGetVersionstamp(tr);
 
-	return toThreadFuture<Standalone<StringRef>>(api, f, [](FdbCApi::FDBFuture* f, FdbCApi* api) {
+	return toThreadFuture<Standalone<StringRef>>(api, f, [](FdbCApi::FDBFuture* f, Arena& arena, FdbCApi* api) {
 		const uint8_t* str;
 		int strLength;
 		FdbCApi::fdb_error_t error = api->futureGetKey(f, &str, &strLength);
 		ASSERT(!error);
 
-		// The memory for this is stored in the FDBFuture and is released when the future gets destroyed
-		return Standalone<StringRef>(StringRef(str, strLength), Arena());
+		return Standalone<StringRef>(StringRef(str, strLength), arena);
 	});
 }
 
@@ -232,7 +227,7 @@ ThreadFuture<int64_t> DLTransaction::getEstimatedRangeSizeBytes(const KeyRangeRe
 	FdbCApi::FDBFuture* f = api->transactionGetEstimatedRangeSizeBytes(
 	    tr, keys.begin.begin(), keys.begin.size(), keys.end.begin(), keys.end.size());
 
-	return toThreadFuture<int64_t>(api, f, [](FdbCApi::FDBFuture* f, FdbCApi* api) {
+	return toThreadFuture<int64_t>(api, f, [](FdbCApi::FDBFuture* f, Arena& arena, FdbCApi* api) {
 		int64_t sampledSize;
 		FdbCApi::fdb_error_t error = api->futureGetInt64(f, &sampledSize);
 		ASSERT(!error);
@@ -248,13 +243,12 @@ ThreadFuture<Standalone<VectorRef<KeyRef>>> DLTransaction::getRangeSplitPoints(c
 	FdbCApi::FDBFuture* f = api->transactionGetRangeSplitPoints(
 	    tr, range.begin.begin(), range.begin.size(), range.end.begin(), range.end.size(), chunkSize);
 
-	return toThreadFuture<Standalone<VectorRef<KeyRef>>>(api, f, [](FdbCApi::FDBFuture* f, FdbCApi* api) {
+	return toThreadFuture<Standalone<VectorRef<KeyRef>>>(api, f, [](FdbCApi::FDBFuture* f, Arena& arena, FdbCApi* api) {
 		const FdbCApi::FDBKey* splitKeys;
 		int keysArrayLength;
 		FdbCApi::fdb_error_t error = api->futureGetKeyArray(f, &splitKeys, &keysArrayLength);
 		ASSERT(!error);
-		// The memory for this is stored in the FDBFuture and is released when the future gets destroyed
-		return Standalone<VectorRef<KeyRef>>(VectorRef<KeyRef>((KeyRef*)splitKeys, keysArrayLength), Arena());
+		return Standalone<VectorRef<KeyRef>>(VectorRef<KeyRef>((KeyRef*)splitKeys, keysArrayLength), arena);
 	});
 }
 
@@ -266,15 +260,15 @@ ThreadFuture<Standalone<VectorRef<KeyRangeRef>>> DLTransaction::getBlobGranuleRa
 
 	FdbCApi::FDBFuture* f = api->transactionGetBlobGranuleRanges(
 	    tr, keyRange.begin.begin(), keyRange.begin.size(), keyRange.end.begin(), keyRange.end.size(), rangeLimit);
-	return toThreadFuture<Standalone<VectorRef<KeyRangeRef>>>(api, f, [](FdbCApi::FDBFuture* f, FdbCApi* api) {
-		const FdbCApi::FDBKeyRange* keyRanges;
-		int keyRangesLength;
-		FdbCApi::fdb_error_t error = api->futureGetKeyRangeArray(f, &keyRanges, &keyRangesLength);
-		ASSERT(!error);
-		// The memory for this is stored in the FDBFuture and is released when the future gets destroyed
-		return Standalone<VectorRef<KeyRangeRef>>(VectorRef<KeyRangeRef>((KeyRangeRef*)keyRanges, keyRangesLength),
-		                                          Arena());
-	});
+	return toThreadFuture<Standalone<VectorRef<KeyRangeRef>>>(
+	    api, f, [](FdbCApi::FDBFuture* f, Arena& arena, FdbCApi* api) {
+		    const FdbCApi::FDBKeyRange* keyRanges;
+		    int keyRangesLength;
+		    FdbCApi::fdb_error_t error = api->futureGetKeyRangeArray(f, &keyRanges, &keyRangesLength);
+		    ASSERT(!error);
+		    return Standalone<VectorRef<KeyRangeRef>>(VectorRef<KeyRangeRef>((KeyRangeRef*)keyRanges, keyRangesLength),
+		                                              arena);
+	    });
 }
 
 ThreadResult<RangeResult> DLTransaction::readBlobGranules(const KeyRangeRef& keyRange,
@@ -340,6 +334,39 @@ ThreadResult<RangeResult> DLTransaction::readBlobGranulesFinish(
 	                                                               readVersion,
 	                                                               &context);
 
+	// DO NOT SUBMIT
+	/*
+	FdbCApi::FDBResult* r = api->transactionReadBlobGranules(tr,
+	                                                         keyRange.begin.begin(),
+	                                                         keyRange.begin.size(),
+	                                                         keyRange.end.begin(),
+	                                                         keyRange.end.size(),
+	                                                         beginVersion,
+	                                                         rv,
+	                                                         context);
+	const FdbCApi::FDBKeyValue* kvs;
+	int count;
+	FdbCApi::fdb_bool_t more;
+	FdbCApi::fdb_error_t error = api->resultGetKeyValueArray(r, &kvs, &count, &more);
+	if (error) {
+	    api->resultDestroy(r);
+	    return ThreadResult<RangeResult>(Error(error));
+	}
+
+	Arena arena;
+	typedef void (*destructor)(void*);
+	arena.addResourceWithDestructor(r, (destructor)api->resultDestroy);
+
+	// If we want to avoid copying by casting FdbCApi::FDBKeyValue* to KeyValueRef*, then we need to be sure that the
+	// corresponding fields share offsets.
+	static_assert(offsetof(KeyValueRef, key.data) == offsetof(FdbCApi::FDBKeyValue, key));
+	static_assert(offsetof(KeyValueRef, key.length) == offsetof(FdbCApi::FDBKeyValue, keyLength));
+	static_assert(offsetof(KeyValueRef, value.data) == offsetof(FdbCApi::FDBKeyValue, value));
+	static_assert(offsetof(KeyValueRef, value.length) == offsetof(FdbCApi::FDBKeyValue, valueLength));
+
+	return ThreadResult<RangeResult>(
+	    RangeResult(RangeResultRef(VectorRef<KeyValueRef>((KeyValueRef*)kvs, count), more), arena));
+	*/
 	return ThreadResult<RangeResult>((ThreadSingleAssignmentVar<RangeResult>*)(r));
 };
 
@@ -355,14 +382,13 @@ DLTransaction::summarizeBlobGranules(const KeyRangeRef& keyRange, Optional<Versi
 	    tr, keyRange.begin.begin(), keyRange.begin.size(), keyRange.end.begin(), keyRange.end.size(), sv, rangeLimit);
 
 	return toThreadFuture<Standalone<VectorRef<BlobGranuleSummaryRef>>>(
-	    api, f, [](FdbCApi::FDBFuture* f, FdbCApi* api) {
+	    api, f, [](FdbCApi::FDBFuture* f, Arena& arena, FdbCApi* api) {
 		    const FdbCApi::FDBGranuleSummary* summaries;
 		    int summariesLength;
 		    FdbCApi::fdb_error_t error = api->futureGetGranuleSummaryArray(f, &summaries, &summariesLength);
 		    ASSERT(!error);
-		    // The memory for this is stored in the FDBFuture and is released when the future gets destroyed
 		    return Standalone<VectorRef<BlobGranuleSummaryRef>>(
-		        VectorRef<BlobGranuleSummaryRef>((BlobGranuleSummaryRef*)summaries, summariesLength), Arena());
+		        VectorRef<BlobGranuleSummaryRef>((BlobGranuleSummaryRef*)summaries, summariesLength), arena);
 	    });
 }
 
@@ -395,7 +421,7 @@ void DLTransaction::clear(const KeyRef& key) {
 ThreadFuture<Void> DLTransaction::watch(const KeyRef& key) {
 	FdbCApi::FDBFuture* f = api->transactionWatch(tr, key.begin(), key.size());
 
-	return toThreadFuture<Void>(api, f, [](FdbCApi::FDBFuture* f, FdbCApi* api) { return Void(); });
+	return toThreadFuture<Void>(api, f, [](FdbCApi::FDBFuture* f, Arena& arena, FdbCApi* api) { return Void(); });
 }
 
 void DLTransaction::addWriteConflictRange(const KeyRangeRef& keys) {
@@ -406,7 +432,7 @@ void DLTransaction::addWriteConflictRange(const KeyRangeRef& keys) {
 ThreadFuture<Void> DLTransaction::commit() {
 	FdbCApi::FDBFuture* f = api->transactionCommit(tr);
 
-	return toThreadFuture<Void>(api, f, [](FdbCApi::FDBFuture* f, FdbCApi* api) { return Void(); });
+	return toThreadFuture<Void>(api, f, [](FdbCApi::FDBFuture* f, Arena& arena, FdbCApi* api) { return Void(); });
 }
 
 Version DLTransaction::getCommittedVersion() {
@@ -421,7 +447,7 @@ ThreadFuture<int64_t> DLTransaction::getTotalCost() {
 	}
 
 	FdbCApi::FDBFuture* f = api->transactionGetTotalCost(tr);
-	return toThreadFuture<int64_t>(api, f, [](FdbCApi::FDBFuture* f, FdbCApi* api) {
+	return toThreadFuture<int64_t>(api, f, [](FdbCApi::FDBFuture* f, Arena&, FdbCApi* api) {
 		int64_t size = 0;
 		FdbCApi::fdb_error_t error = api->futureGetInt64(f, &size);
 		ASSERT(!error);
@@ -435,7 +461,7 @@ ThreadFuture<int64_t> DLTransaction::getApproximateSize() {
 	}
 
 	FdbCApi::FDBFuture* f = api->transactionGetApproximateSize(tr);
-	return toThreadFuture<int64_t>(api, f, [](FdbCApi::FDBFuture* f, FdbCApi* api) {
+	return toThreadFuture<int64_t>(api, f, [](FdbCApi::FDBFuture* f, Arena& arena, FdbCApi* api) {
 		int64_t size = 0;
 		FdbCApi::fdb_error_t error = api->futureGetInt64(f, &size);
 		ASSERT(!error);
@@ -453,7 +479,7 @@ void DLTransaction::setOption(FDBTransactionOptions::Option option, Optional<Str
 ThreadFuture<Void> DLTransaction::onError(Error const& e) {
 	FdbCApi::FDBFuture* f = api->transactionOnError(tr, e.code());
 
-	return toThreadFuture<Void>(api, f, [](FdbCApi::FDBFuture* f, FdbCApi* api) { return Void(); });
+	return toThreadFuture<Void>(api, f, [](FdbCApi::FDBFuture* f, Arena& arena, FdbCApi* api) { return Void(); });
 }
 
 void DLTransaction::reset() {
@@ -485,14 +511,13 @@ ThreadFuture<Key> DLTenant::purgeBlobGranules(const KeyRangeRef& keyRange, Versi
 	                                                     purgeVersion,
 	                                                     force);
 
-	return toThreadFuture<Key>(api, f, [](FdbCApi::FDBFuture* f, FdbCApi* api) {
+	return toThreadFuture<Key>(api, f, [](FdbCApi::FDBFuture* f, Arena& arena, FdbCApi* api) {
 		const uint8_t* key;
 		int keyLength;
 		FdbCApi::fdb_error_t error = api->futureGetKey(f, &key, &keyLength);
 		ASSERT(!error);
 
-		// The memory for this is stored in the FDBFuture and is released when the future gets destroyed
-		return Key(KeyRef(key, keyLength), Arena());
+		return Key(KeyRef(key, keyLength), arena);
 	});
 }
 
@@ -502,7 +527,7 @@ ThreadFuture<Void> DLTenant::waitPurgeGranulesComplete(const KeyRef& purgeKey) {
 	}
 
 	FdbCApi::FDBFuture* f = api->tenantWaitPurgeGranulesComplete(tenant, purgeKey.begin(), purgeKey.size());
-	return toThreadFuture<Void>(api, f, [](FdbCApi::FDBFuture* f, FdbCApi* api) { return Void(); });
+	return toThreadFuture<Void>(api, f, [](FdbCApi::FDBFuture* f, Arena&, FdbCApi* api) { return Void(); });
 }
 
 ThreadFuture<bool> DLTenant::blobbifyRange(const KeyRangeRef& keyRange) {
@@ -513,7 +538,7 @@ ThreadFuture<bool> DLTenant::blobbifyRange(const KeyRangeRef& keyRange) {
 	FdbCApi::FDBFuture* f = api->tenantBlobbifyRange(
 	    tenant, keyRange.begin.begin(), keyRange.begin.size(), keyRange.end.begin(), keyRange.end.size());
 
-	return toThreadFuture<bool>(api, f, [](FdbCApi::FDBFuture* f, FdbCApi* api) {
+	return toThreadFuture<bool>(api, f, [](FdbCApi::FDBFuture* f, Arena&, FdbCApi* api) {
 		FdbCApi::fdb_bool_t ret = false;
 		ASSERT(!api->futureGetBool(f, &ret));
 		return ret;
@@ -528,7 +553,7 @@ ThreadFuture<bool> DLTenant::unblobbifyRange(const KeyRangeRef& keyRange) {
 	FdbCApi::FDBFuture* f = api->tenantUnblobbifyRange(
 	    tenant, keyRange.begin.begin(), keyRange.begin.size(), keyRange.end.begin(), keyRange.end.size());
 
-	return toThreadFuture<bool>(api, f, [](FdbCApi::FDBFuture* f, FdbCApi* api) {
+	return toThreadFuture<bool>(api, f, [](FdbCApi::FDBFuture* f, Arena&, FdbCApi* api) {
 		FdbCApi::fdb_bool_t ret = false;
 		ASSERT(!api->futureGetBool(f, &ret));
 		return ret;
@@ -544,15 +569,15 @@ ThreadFuture<Standalone<VectorRef<KeyRangeRef>>> DLTenant::listBlobbifiedRanges(
 	FdbCApi::FDBFuture* f = api->tenantListBlobbifiedRanges(
 	    tenant, keyRange.begin.begin(), keyRange.begin.size(), keyRange.end.begin(), keyRange.end.size(), rangeLimit);
 
-	return toThreadFuture<Standalone<VectorRef<KeyRangeRef>>>(api, f, [](FdbCApi::FDBFuture* f, FdbCApi* api) {
-		const FdbCApi::FDBKeyRange* keyRanges;
-		int keyRangesLength;
-		FdbCApi::fdb_error_t error = api->futureGetKeyRangeArray(f, &keyRanges, &keyRangesLength);
-		ASSERT(!error);
-		// The memory for this is stored in the FDBFuture and is released when the future gets destroyed.
-		return Standalone<VectorRef<KeyRangeRef>>(VectorRef<KeyRangeRef>((KeyRangeRef*)keyRanges, keyRangesLength),
-		                                          Arena());
-	});
+	return toThreadFuture<Standalone<VectorRef<KeyRangeRef>>>(
+	    api, f, [](FdbCApi::FDBFuture* f, Arena& arena, FdbCApi* api) {
+		    const FdbCApi::FDBKeyRange* keyRanges;
+		    int keyRangesLength;
+		    FdbCApi::fdb_error_t error = api->futureGetKeyRangeArray(f, &keyRanges, &keyRangesLength);
+		    ASSERT(!error);
+		    return Standalone<VectorRef<KeyRangeRef>>(VectorRef<KeyRangeRef>((KeyRangeRef*)keyRanges, keyRangesLength),
+		                                              arena);
+	    });
 }
 
 ThreadFuture<Version> DLTenant::verifyBlobRange(const KeyRangeRef& keyRange, Optional<Version> version) {
@@ -565,7 +590,7 @@ ThreadFuture<Version> DLTenant::verifyBlobRange(const KeyRangeRef& keyRange, Opt
 	FdbCApi::FDBFuture* f = api->tenantVerifyBlobRange(
 	    tenant, keyRange.begin.begin(), keyRange.begin.size(), keyRange.end.begin(), keyRange.end.size(), readVersion);
 
-	return toThreadFuture<Version>(api, f, [](FdbCApi::FDBFuture* f, FdbCApi* api) {
+	return toThreadFuture<Version>(api, f, [](FdbCApi::FDBFuture* f, Arena&, FdbCApi* api) {
 		Version version = invalidVersion;
 		ASSERT(!api->futureGetInt64(f, &version));
 		return version;
@@ -620,7 +645,7 @@ ThreadFuture<int64_t> DLDatabase::rebootWorker(const StringRef& address, bool ch
 	}
 
 	FdbCApi::FDBFuture* f = api->databaseRebootWorker(db, address.begin(), address.size(), check, duration);
-	return toThreadFuture<int64_t>(api, f, [](FdbCApi::FDBFuture* f, FdbCApi* api) {
+	return toThreadFuture<int64_t>(api, f, [](FdbCApi::FDBFuture* f, Arena& arena, FdbCApi* api) {
 		int64_t res;
 		FdbCApi::fdb_error_t error = api->futureGetInt64(f, &res);
 		ASSERT(!error);
@@ -634,7 +659,7 @@ ThreadFuture<Void> DLDatabase::forceRecoveryWithDataLoss(const StringRef& dcid) 
 	}
 
 	FdbCApi::FDBFuture* f = api->databaseForceRecoveryWithDataLoss(db, dcid.begin(), dcid.size());
-	return toThreadFuture<Void>(api, f, [](FdbCApi::FDBFuture* f, FdbCApi* api) { return Void(); });
+	return toThreadFuture<Void>(api, f, [](FdbCApi::FDBFuture* f, Arena& arena, FdbCApi* api) { return Void(); });
 }
 
 ThreadFuture<Void> DLDatabase::createSnapshot(const StringRef& uid, const StringRef& snapshot_command) {
@@ -644,7 +669,7 @@ ThreadFuture<Void> DLDatabase::createSnapshot(const StringRef& uid, const String
 
 	FdbCApi::FDBFuture* f =
 	    api->databaseCreateSnapshot(db, uid.begin(), uid.size(), snapshot_command.begin(), snapshot_command.size());
-	return toThreadFuture<Void>(api, f, [](FdbCApi::FDBFuture* f, FdbCApi* api) { return Void(); });
+	return toThreadFuture<Void>(api, f, [](FdbCApi::FDBFuture* f, Arena& arena, FdbCApi* api) { return Void(); });
 }
 
 ThreadFuture<DatabaseSharedState*> DLDatabase::createSharedState() {
@@ -652,7 +677,7 @@ ThreadFuture<DatabaseSharedState*> DLDatabase::createSharedState() {
 		return unsupported_operation();
 	}
 	FdbCApi::FDBFuture* f = api->databaseCreateSharedState(db);
-	return toThreadFuture<DatabaseSharedState*>(api, f, [](FdbCApi::FDBFuture* f, FdbCApi* api) {
+	return toThreadFuture<DatabaseSharedState*>(api, f, [](FdbCApi::FDBFuture* f, Arena& arena, FdbCApi* api) {
 		DatabaseSharedState* res;
 		FdbCApi::fdb_error_t error = api->futureGetSharedState(f, &res);
 		ASSERT(!error);
@@ -685,7 +710,7 @@ ThreadFuture<ProtocolVersion> DLDatabase::getServerProtocol(Optional<ProtocolVer
 	uint64_t expected =
 	    expectedVersion.map<uint64_t>([](const ProtocolVersion& v) { return v.version(); }).orDefault(0);
 	FdbCApi::FDBFuture* f = api->databaseGetServerProtocol(db, expected);
-	return toThreadFuture<ProtocolVersion>(api, f, [](FdbCApi::FDBFuture* f, FdbCApi* api) {
+	return toThreadFuture<ProtocolVersion>(api, f, [](FdbCApi::FDBFuture* f, Arena& arena, FdbCApi* api) {
 		uint64_t pv;
 		FdbCApi::fdb_error_t error = api->futureGetUInt64(f, &pv);
 		ASSERT(!error);
@@ -705,14 +730,13 @@ ThreadFuture<Key> DLDatabase::purgeBlobGranules(const KeyRangeRef& keyRange, Ver
 	                                                       purgeVersion,
 	                                                       force);
 
-	return toThreadFuture<Key>(api, f, [](FdbCApi::FDBFuture* f, FdbCApi* api) {
+	return toThreadFuture<Key>(api, f, [](FdbCApi::FDBFuture* f, Arena& arena, FdbCApi* api) {
 		const uint8_t* key;
 		int keyLength;
 		FdbCApi::fdb_error_t error = api->futureGetKey(f, &key, &keyLength);
 		ASSERT(!error);
 
-		// The memory for this is stored in the FDBFuture and is released when the future gets destroyed
-		return Key(KeyRef(key, keyLength), Arena());
+		return Key(KeyRef(key, keyLength), arena);
 	});
 }
 
@@ -722,7 +746,7 @@ ThreadFuture<Void> DLDatabase::waitPurgeGranulesComplete(const KeyRef& purgeKey)
 	}
 
 	FdbCApi::FDBFuture* f = api->databaseWaitPurgeGranulesComplete(db, purgeKey.begin(), purgeKey.size());
-	return toThreadFuture<Void>(api, f, [](FdbCApi::FDBFuture* f, FdbCApi* api) { return Void(); });
+	return toThreadFuture<Void>(api, f, [](FdbCApi::FDBFuture* f, Arena& arena, FdbCApi* api) { return Void(); });
 }
 
 ThreadFuture<bool> DLDatabase::blobbifyRange(const KeyRangeRef& keyRange) {
@@ -733,7 +757,7 @@ ThreadFuture<bool> DLDatabase::blobbifyRange(const KeyRangeRef& keyRange) {
 	FdbCApi::FDBFuture* f = api->databaseBlobbifyRange(
 	    db, keyRange.begin.begin(), keyRange.begin.size(), keyRange.end.begin(), keyRange.end.size());
 
-	return toThreadFuture<bool>(api, f, [](FdbCApi::FDBFuture* f, FdbCApi* api) {
+	return toThreadFuture<bool>(api, f, [](FdbCApi::FDBFuture* f, Arena&, FdbCApi* api) {
 		FdbCApi::fdb_bool_t ret = false;
 		ASSERT(!api->futureGetBool(f, &ret));
 		return ret;
@@ -748,7 +772,7 @@ ThreadFuture<bool> DLDatabase::unblobbifyRange(const KeyRangeRef& keyRange) {
 	FdbCApi::FDBFuture* f = api->databaseUnblobbifyRange(
 	    db, keyRange.begin.begin(), keyRange.begin.size(), keyRange.end.begin(), keyRange.end.size());
 
-	return toThreadFuture<bool>(api, f, [](FdbCApi::FDBFuture* f, FdbCApi* api) {
+	return toThreadFuture<bool>(api, f, [](FdbCApi::FDBFuture* f, Arena&, FdbCApi* api) {
 		FdbCApi::fdb_bool_t ret = false;
 		ASSERT(!api->futureGetBool(f, &ret));
 		return ret;
@@ -764,15 +788,15 @@ ThreadFuture<Standalone<VectorRef<KeyRangeRef>>> DLDatabase::listBlobbifiedRange
 	FdbCApi::FDBFuture* f = api->databaseListBlobbifiedRanges(
 	    db, keyRange.begin.begin(), keyRange.begin.size(), keyRange.end.begin(), keyRange.end.size(), rangeLimit);
 
-	return toThreadFuture<Standalone<VectorRef<KeyRangeRef>>>(api, f, [](FdbCApi::FDBFuture* f, FdbCApi* api) {
-		const FdbCApi::FDBKeyRange* keyRanges;
-		int keyRangesLength;
-		FdbCApi::fdb_error_t error = api->futureGetKeyRangeArray(f, &keyRanges, &keyRangesLength);
-		ASSERT(!error);
-		// The memory for this is stored in the FDBFuture and is released when the future gets destroyed.
-		return Standalone<VectorRef<KeyRangeRef>>(VectorRef<KeyRangeRef>((KeyRangeRef*)keyRanges, keyRangesLength),
-		                                          Arena());
-	});
+	return toThreadFuture<Standalone<VectorRef<KeyRangeRef>>>(
+	    api, f, [](FdbCApi::FDBFuture* f, Arena& arena, FdbCApi* api) {
+		    const FdbCApi::FDBKeyRange* keyRanges;
+		    int keyRangesLength;
+		    FdbCApi::fdb_error_t error = api->futureGetKeyRangeArray(f, &keyRanges, &keyRangesLength);
+		    ASSERT(!error);
+		    return Standalone<VectorRef<KeyRangeRef>>(VectorRef<KeyRangeRef>((KeyRangeRef*)keyRanges, keyRangesLength),
+		                                              arena);
+	    });
 }
 
 ThreadFuture<Version> DLDatabase::verifyBlobRange(const KeyRangeRef& keyRange, Optional<Version> version) {
@@ -785,7 +809,7 @@ ThreadFuture<Version> DLDatabase::verifyBlobRange(const KeyRangeRef& keyRange, O
 	FdbCApi::FDBFuture* f = api->databaseVerifyBlobRange(
 	    db, keyRange.begin.begin(), keyRange.begin.size(), keyRange.end.begin(), keyRange.end.size(), readVersion);
 
-	return toThreadFuture<Version>(api, f, [](FdbCApi::FDBFuture* f, FdbCApi* api) {
+	return toThreadFuture<Version>(api, f, [](FdbCApi::FDBFuture* f, Arena&, FdbCApi* api) {
 		Version version = invalidVersion;
 		ASSERT(!api->futureGetInt64(f, &version));
 		return version;
@@ -1121,11 +1145,12 @@ void DLApi::stopNetwork() {
 Reference<IDatabase> DLApi::createDatabase609(const char* clusterFilePath) {
 	FdbCApi::FDBFuture* f = api->createCluster(clusterFilePath);
 
-	auto clusterFuture = toThreadFuture<FdbCApi::FDBCluster*>(api, f, [](FdbCApi::FDBFuture* f, FdbCApi* api) {
-		FdbCApi::FDBCluster* cluster;
-		api->futureGetCluster(f, &cluster);
-		return cluster;
-	});
+	auto clusterFuture =
+	    toThreadFuture<FdbCApi::FDBCluster*>(api, f, [](FdbCApi::FDBFuture* f, Arena& arena, FdbCApi* api) {
+		    FdbCApi::FDBCluster* cluster;
+		    api->futureGetCluster(f, &cluster);
+		    return cluster;
+	    });
 
 	Reference<FdbCApi> innerApi = api;
 	auto dbFuture = flatMapThreadFuture<FdbCApi::FDBCluster*, FdbCApi::FDBDatabase*>(
@@ -1137,7 +1162,7 @@ Reference<IDatabase> DLApi::createDatabase609(const char* clusterFilePath) {
 		    auto innerDbFuture =
 		        toThreadFuture<FdbCApi::FDBDatabase*>(innerApi,
 		                                              innerApi->clusterCreateDatabase(cluster.get(), (uint8_t*)"DB", 2),
-		                                              [](FdbCApi::FDBFuture* f, FdbCApi* api) {
+		                                              [](FdbCApi::FDBFuture* f, Arena& arena, FdbCApi* api) {
 			                                              FdbCApi::FDBDatabase* db;
 			                                              api->futureGetDatabase(f, &db);
 			                                              return db;
@@ -3513,7 +3538,7 @@ struct DLTest {
 		return FutureInfo(
 		    toThreadFuture<int>(getApi(),
 		                        (FdbCApi::FDBFuture*)f.future.extractPtr(),
-		                        [](FdbCApi::FDBFuture* f, FdbCApi* api) {
+		                        [](FdbCApi::FDBFuture* f, Arena& arena, FdbCApi* api) {
 			                        ASSERT_GE(((ThreadSingleAssignmentVar<int>*)f)->debugGetReferenceCount(), 1);
 			                        return ((ThreadSingleAssignmentVar<int>*)f)->get();
 		                        }),

--- a/fdbclient/MultiVersionTransaction.actor.cpp
+++ b/fdbclient/MultiVersionTransaction.actor.cpp
@@ -334,16 +334,6 @@ ThreadResult<RangeResult> DLTransaction::readBlobGranulesFinish(
 	                                                               readVersion,
 	                                                               &context);
 
-	// DO NOT SUBMIT
-	/*
-	FdbCApi::FDBResult* r = api->transactionReadBlobGranules(tr,
-	                                                         keyRange.begin.begin(),
-	                                                         keyRange.begin.size(),
-	                                                         keyRange.end.begin(),
-	                                                         keyRange.end.size(),
-	                                                         beginVersion,
-	                                                         rv,
-	                                                         context);
 	const FdbCApi::FDBKeyValue* kvs;
 	int count;
 	FdbCApi::fdb_bool_t more;
@@ -366,8 +356,6 @@ ThreadResult<RangeResult> DLTransaction::readBlobGranulesFinish(
 
 	return ThreadResult<RangeResult>(
 	    RangeResult(RangeResultRef(VectorRef<KeyValueRef>((KeyValueRef*)kvs, count), more), arena));
-	*/
-	return ThreadResult<RangeResult>((ThreadSingleAssignmentVar<RangeResult>*)(r));
 };
 
 ThreadFuture<Standalone<VectorRef<BlobGranuleSummaryRef>>>

--- a/fdbclient/include/fdbclient/HighContentionPrefixAllocator.actor.h
+++ b/fdbclient/include/fdbclient/HighContentionPrefixAllocator.actor.h
@@ -65,9 +65,8 @@ private:
 		state int64_t window = 0;
 
 		loop {
-			state typename TransactionT::template FutureT<RangeResult> rangeFuture =
-			    tr->getRange(self->counters.range(), 1, Snapshot::True, Reverse::True);
-			RangeResult range = wait(safeThreadFutureToFuture(rangeFuture));
+			RangeResult range =
+			    wait(safeThreadFutureToFuture(tr->getRange(self->counters.range(), 1, Snapshot::True, Reverse::True)));
 
 			if (range.size() > 0) {
 				start = self->counters.unpack(range[0].key).getInt(0);
@@ -85,11 +84,10 @@ private:
 				int64_t inc = 1;
 				tr->atomicOp(self->counters.get(start).key(), StringRef((uint8_t*)&inc, 8), MutationRef::AddValue);
 
-				state typename TransactionT::template FutureT<Optional<Value>> countFuture =
-				    tr->get(self->counters.get(start).key(), Snapshot::True);
 				// }
 
-				Optional<Value> countValue = wait(safeThreadFutureToFuture(countFuture));
+				Optional<Value> countValue =
+				    wait(safeThreadFutureToFuture(tr->get(self->counters.get(start).key(), Snapshot::True)));
 
 				int64_t count = 0;
 				if (countValue.present()) {

--- a/fdbrpc/dsltest.actor.cpp
+++ b/fdbrpc/dsltest.actor.cpp
@@ -627,10 +627,15 @@ void showArena(ArenaBlock* a, ArenaBlock* parent) {
 			ArenaBlockRef* r = (ArenaBlockRef*)((char*)a->getData() + o);
 
 			// If alignedBuffer is valid then print its pointer and size, else recurse
-			if (r->aligned4kBufferSize != 0) {
-				printf("AlignedBuffer %p (<-%p) %u bytes\n", r->aligned4kBuffer, a, r->aligned4kBufferSize);
+			if (r->type == ArenaBlockRef::Type::kAligned4kBuffer) {
+				auto* b = static_cast<Aligned4kBufferRef*>(r);
+				printf("AlignedBuffer %p (<-%p) %u bytes\n", b->aligned4kBuffer, a, b->aligned4kBufferSize);
+			} else if (r->type == ArenaBlockRef::Type::kResourceWithDestructor) {
+				auto* b = static_cast<ResourceWithDestructorRef*>(r);
+				printf("Resource %p (<-%p), destructor %p\n", b->resource, a, b->destructor);
 			} else {
-				showArena(r->next, a);
+				auto* b = static_cast<BlockRef*>(r);
+				showArena(b->next, a);
 			}
 
 			o = r->nextBlockOffset;

--- a/flow/include/flow/Arena.h
+++ b/flow/include/flow/Arena.h
@@ -111,6 +111,9 @@ public:
 
 	void dependsOn(const Arena& p);
 	void* allocate4kAlignedBuffer(uint32_t size);
+	// Take ownership of |resource|. destructor(resource) will be called when the lifetime of this Arena (and all
+	// Arena's depending on this Arena) ends.
+	void addResourceWithDestructor(void* resource, void (*destructor)(void*));
 
 	// If fastInaccurateEstimate is true this operation is O(1) but it is inaccurate in that it
 	// will omit memory added to this Arena's block tree using Arena handles which reference
@@ -143,18 +146,45 @@ struct scalar_traits<Arena> : std::true_type {
 	}
 };
 
+// Pragma pack 1 is usually a bad idea, so I will try to justify why it makes sense here.
+// 1. We already ignore alignment since this is placed in an Arena
+// 2. This is not part of any stable ABI
+//
+// The upside is that we save bytes in the ArenaBlock.
+//
+// This is a reference to a resource within an ArenaBlock. That resource may be
+// another ArenaBlock, or it may be a 4k aligned buffer, or it may be an
+// arbitrary pointer + destructor.
+#pragma pack(push, 1)
 struct ArenaBlockRef {
-	union {
-		ArenaBlock* next;
-		void* aligned4kBuffer;
-	};
-
-	// Only one of (next, aligned4kBuffer) is valid at any one time, as they occupy the same space.
-	// If aligned4kBufferSize is not 0, aligned4kBuffer is valid, otherwise next is valid.
-	uint32_t aligned4kBufferSize;
-
+	// An ArenaBlock may have many ArenaBlockRef's within its buffer. These
+	// ArenaBlockRef's form a null-terminated singly linked list, with
+	// nextBlockOffset serving logically as a pointer to
+	// (ArenaBlockRef*)((char*)b->getData() + o), for an ArenaBlock b, and
+	// nextBlockOffset == 0 serving as null.
 	uint32_t nextBlockOffset;
+
+	enum class Type : uint8_t {
+		kBlock,
+		kAligned4kBuffer,
+		kResourceWithDestructor,
+	};
+	// Indicates which of the subclass of ArenaBlockRef this is.
+	Type type;
 };
+
+struct BlockRef : ArenaBlockRef {
+	ArenaBlock* next;
+};
+struct Aligned4kBufferRef : ArenaBlockRef {
+	void* aligned4kBuffer;
+	uint32_t aligned4kBufferSize;
+};
+struct ResourceWithDestructorRef : ArenaBlockRef {
+	void* resource;
+	void (*destructor)(void*);
+};
+#pragma pack(pop)
 
 struct ArenaBlock : NonCopyable, ThreadSafeReferenceCounted<ArenaBlock> {
 	enum {
@@ -185,9 +215,13 @@ struct ArenaBlock : NonCopyable, ThreadSafeReferenceCounted<ArenaBlock> {
 	void getUniqueBlocks(std::set<ArenaBlock*>& a);
 	int addUsed(int bytes);
 	void makeReference(ArenaBlock* next);
+	void addResourceWithDestructor(void* resource, void (*destructor)(void*));
 	void* make4kAlignedBuffer(uint32_t size);
 	static void dependOn(Reference<ArenaBlock>& self, ArenaBlock* other);
-	static void* dependOn4kAlignedBuffer(Reference<ArenaBlock>& self, uint32_t size);
+	static void* makeDependent4kAlignedBuffer(Reference<ArenaBlock>& self, uint32_t size);
+	static void addDependentResourceWithDestructor(Reference<ArenaBlock>& self,
+	                                               void* resource,
+	                                               void (*destructor)(void*));
 	static void* allocate(Reference<ArenaBlock>& self, int bytes);
 	// Return an appropriately-sized ArenaBlock to store the given data
 	static ArenaBlock* create(int dataSize, Reference<ArenaBlock>& next);
@@ -672,6 +706,11 @@ public:
 private:
 	// Unimplemented; blocks conversion through std::string
 	StringRef(char*);
+
+	// This friend class is so that we can static_assert that it's not
+	// completely invalid to cast something to KeyValueRef in the multiversion
+	// client. Overall motivation is to save a copy.
+	friend class DLTransaction;
 
 	const uint8_t* data;
 	int length;


### PR DESCRIPTION
Make standalone's with external clients work as expected.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
