### PR TITLE
Remove unordered_map of pointers from ThreadMultiCallback

### DIFF
--- a/fdbclient/BackupAgent.actor.h
+++ b/fdbclient/BackupAgent.actor.h
@@ -727,30 +727,40 @@ template <>
 inline Tuple Codec<Reference<IBackupContainer>>::pack(Reference<IBackupContainer> const& bc) {
 	Tuple tuple;
 	tuple.append(StringRef(bc->getURL()));
-	if (bc->getProxy().present()) {
-		tuple.append(StringRef(bc->getProxy().get()));
-	} else {
-		tuple.append(StringRef());
-	}
+
 	if (bc->getEncryptionKeyFileName().present()) {
 		tuple.append(bc->getEncryptionKeyFileName().get());
 	} else {
 		tuple.append(StringRef());
 	}
+
+	if (bc->getProxy().present()) {
+		tuple.append(StringRef(bc->getProxy().get()));
+	} else {
+		tuple.append(StringRef());
+	}
+
 	return tuple;
 }
 template <>
 inline Reference<IBackupContainer> Codec<Reference<IBackupContainer>>::unpack(Tuple const& val) {
-	ASSERT(val.size() == 3);
+	ASSERT(val.size() >= 1 || val.size() <= 3);
 	auto url = val.getString(0).toString();
-	Optional<std::string> proxy;
-	if (!val.getString(1).empty()) {
-		proxy = val.getString(1).toString();
-	}
+
 	Optional<std::string> encryptionKeyFileName;
-	if (!val.getString(2).empty()) {
-		encryptionKeyFileName = val.getString(2).toString();
+	if (val.size() > 1) {
+		if (!val.getString(1).empty()) {
+			encryptionKeyFileName = val.getString(1).toString();
+		}
 	}
+
+	Optional<std::string> proxy;
+	if (val.size() > 2) {
+		if (!val.getString(2).empty()) {
+			proxy = val.getString(2).toString();
+		};
+	}
+
 	return IBackupContainer::openContainer(url, proxy, encryptionKeyFileName);
 }
 

--- a/flow/ThreadHelper.actor.h
+++ b/flow/ThreadHelper.actor.h
@@ -98,14 +98,14 @@ struct ThreadCallback {
 	// MultiCallbackHolder objects can form a doubly linked list.
 	struct MultiCallbackHolder : public FastAllocated<MultiCallbackHolder> {
 		// Construction requires no arguments or all the arguments
-		MultiCallbackHolder() : holder(nullptr), index(0), previous(nullptr), next(nullptr) {}
+		MultiCallbackHolder() : multiCallback(nullptr), index(0), previous(nullptr), next(nullptr) {}
 		MultiCallbackHolder(ThreadMultiCallback* multiCallback,
 		                    int index,
 		                    MultiCallbackHolder* prev,
 		                    MultiCallbackHolder* next)
-		  : holder(multiCallback), index(0), previous(prev), next(next) {}
+		  : multiCallback(multiCallback), index(0), previous(prev), next(next) {}
 
-		ThreadMultiCallback* holder;
+		ThreadMultiCallback* multiCallback;
 		int index;
 		MultiCallbackHolder* previous;
 		MultiCallbackHolder* next;
@@ -118,8 +118,8 @@ struct ThreadCallback {
 	// Return a MultiCallbackHolder for the given holder, using the firstHolder if free or allocating
 	// a new one.  No check for an existing record for holder is done.
 	MultiCallbackHolder* addHolder(ThreadMultiCallback* multiCallback, int index) {
-		if (firstHolder.holder == nullptr) {
-			firstHolder.holder = multiCallback;
+		if (firstHolder.multiCallback == nullptr) {
+			firstHolder.multiCallback = multiCallback;
 			firstHolder.index = index;
 			return &firstHolder;
 		}
@@ -130,7 +130,7 @@ struct ThreadCallback {
 	// Get the MultiCallbackHolder for holder if it exists, or nullptr.
 	MultiCallbackHolder* getHolder(ThreadMultiCallback* multiCallback) {
 		MultiCallbackHolder* h = &firstHolder;
-		while (h != nullptr && h->holder != multiCallback) {
+		while (h != nullptr && h->multiCallback != multiCallback) {
 			h = h->next;
 		}
 		return h;
@@ -142,7 +142,7 @@ struct ThreadCallback {
 
 		// If h is the firstHolder just clear its holder pointer to indicate unusedness
 		if (h == &firstHolder) {
-			h->holder = nullptr;
+			h->multiCallback = nullptr;
 		} else {
 			// Otherwise unlink h from the doubly linked list and free it
 			// h->previous is definitely valid


### PR DESCRIPTION
When using `DEBUG_DETERMINISM` to investigate unseed mismatches it is problematic to have an unordered_map of pointers as the iteration order of the logical objects pointed to will vary across executions.

This refactor removes the unordered map and replaces it with a doubly linked fast allocated list of MultiCallbackHolder objects which provide a place to store the per-MultiCallback index of the callback in each ThreadMultiCallback that holds it.  The first entry of the list is included in ThreadCallback inline.

Experimentally via correctness testing it seems that the common case is at most 1 ThreadMultiCallback holder for a given ThreadCallback.  For this, or up to a several holders this new implementation should be faster.

I ran 20 executions of the `AbortableSingleAssignmentVar` unit test and measured CPU usage, and while the test is not deterministic the parent commit and this PR each measured within separate narrow and non-overlapping time bands.  The parent average was 4.92s, the new version is 4.61s, for about a 6.3% reduction.

I have not done any multi version client testing with this PR.  If for some reason these changes do not work, they should at least be used when DEBUG_DETERMINISM is set and the old behavior could be restore for when it is not.

This PR is included in #6574 so it is a blocker for that PR.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
