### PR TITLE
Fixed Codec<Reference<IBackupContainer>> backward compatibility bug from #6705

### DIFF
--- a/fdbclient/BackupAgent.actor.h
+++ b/fdbclient/BackupAgent.actor.h
@@ -744,7 +744,7 @@ inline Tuple Codec<Reference<IBackupContainer>>::pack(Reference<IBackupContainer
 }
 template <>
 inline Reference<IBackupContainer> Codec<Reference<IBackupContainer>>::unpack(Tuple const& val) {
-	ASSERT(val.size() >= 1 || val.size() <= 3);
+	ASSERT(val.size() >= 1 && val.size() <= 3);
 	auto url = val.getString(0).toString();
 
 	Optional<std::string> encryptionKeyFileName;

--- a/fdbclient/BackupAgent.actor.h
+++ b/fdbclient/BackupAgent.actor.h
@@ -727,30 +727,40 @@ template <>
 inline Tuple Codec<Reference<IBackupContainer>>::pack(Reference<IBackupContainer> const& bc) {
 	Tuple tuple;
 	tuple.append(StringRef(bc->getURL()));
-	if (bc->getProxy().present()) {
-		tuple.append(StringRef(bc->getProxy().get()));
-	} else {
-		tuple.append(StringRef());
-	}
+
 	if (bc->getEncryptionKeyFileName().present()) {
 		tuple.append(bc->getEncryptionKeyFileName().get());
 	} else {
 		tuple.append(StringRef());
 	}
+
+	if (bc->getProxy().present()) {
+		tuple.append(StringRef(bc->getProxy().get()));
+	} else {
+		tuple.append(StringRef());
+	}
+
 	return tuple;
 }
 template <>
 inline Reference<IBackupContainer> Codec<Reference<IBackupContainer>>::unpack(Tuple const& val) {
-	ASSERT(val.size() == 3);
+	ASSERT(val.size() >= 1 || val.size() <= 3);
 	auto url = val.getString(0).toString();
-	Optional<std::string> proxy;
-	if (!val.getString(1).empty()) {
-		proxy = val.getString(1).toString();
-	}
+
 	Optional<std::string> encryptionKeyFileName;
-	if (!val.getString(2).empty()) {
-		encryptionKeyFileName = val.getString(2).toString();
+	if (val.size() > 1) {
+		if (!val.getString(1).empty()) {
+			encryptionKeyFileName = val.getString(1).toString();
+		}
 	}
+
+	Optional<std::string> proxy;
+	if (val.size() > 2) {
+		if (!val.getString(2).empty()) {
+			proxy = val.getString(2).toString();
+		};
+	}
+
 	return IBackupContainer::openContainer(url, proxy, encryptionKeyFileName);
 }
 

--- a/fdbclient/BackupAgent.actor.h
+++ b/fdbclient/BackupAgent.actor.h
@@ -755,10 +755,8 @@ inline Reference<IBackupContainer> Codec<Reference<IBackupContainer>>::unpack(Tu
 	}
 
 	Optional<std::string> proxy;
-	if (val.size() > 2) {
-		if (!val.getString(2).empty()) {
-			proxy = val.getString(2).toString();
-		};
+	if (val.size() > 2 && !val.getString(2).empty()) {
+		proxy = val.getString(2).toString();
 	}
 
 	return IBackupContainer::openContainer(url, proxy, encryptionKeyFileName);

--- a/fdbclient/BackupAgent.actor.h
+++ b/fdbclient/BackupAgent.actor.h
@@ -744,7 +744,7 @@ inline Tuple Codec<Reference<IBackupContainer>>::pack(Reference<IBackupContainer
 }
 template <>
 inline Reference<IBackupContainer> Codec<Reference<IBackupContainer>>::unpack(Tuple const& val) {
-	ASSERT(val.size() >= 1 && val.size() <= 3);
+	ASSERT(val.size() >= 1);
 	auto url = val.getString(0).toString();
 
 	Optional<std::string> encryptionKeyFileName;

--- a/fdbclient/BackupAgent.actor.h
+++ b/fdbclient/BackupAgent.actor.h
@@ -748,10 +748,8 @@ inline Reference<IBackupContainer> Codec<Reference<IBackupContainer>>::unpack(Tu
 	auto url = val.getString(0).toString();
 
 	Optional<std::string> encryptionKeyFileName;
-	if (val.size() > 1) {
-		if (!val.getString(1).empty()) {
-			encryptionKeyFileName = val.getString(1).toString();
-		}
+	if (val.size() > 1 && !val.getString(1).empty()) {
+		encryptionKeyFileName = val.getString(1).toString();
 	}
 
 	Optional<std::string> proxy;


### PR DESCRIPTION
The Tuple form of IBackupContainer was changed to be incompatible with prior written data.  This fixes it, the packed form is now
`url [, encryptionKeyFile [, proxy]]`
which is backward compatible.  Even when present in the Tuple, encryptionKeyFile and proxy are treated as omitted when their strings are empty.

This passes 3000 tests of specifically `UpgradeAndBackupRestore`.

Bug introduced in #6705 

#6721 includes this PR

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
