### PR TITLE
RocksDB Performance Metrics

### DIFF
--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -357,16 +357,19 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( ROCKSDB_READ_QUEUE_SOFT_MAX,                           500 );
 	init( ROCKSDB_FETCH_QUEUE_HARD_MAX,                          100 );
 	init( ROCKSDB_FETCH_QUEUE_SOFT_MAX,                           50 );
-	init( ROCKSDB_HISTOGRAMS_SAMPLE_RATE,                      0.001 ); if( randomize && BUGGIFY ) ROCKSDB_HISTOGRAMS_SAMPLE_RATE = 0;
 	init( ROCKSDB_READ_RANGE_ITERATOR_REFRESH_TIME,             30.0 ); if( randomize && BUGGIFY ) ROCKSDB_READ_RANGE_ITERATOR_REFRESH_TIME = 0.1;
 	init( ROCKSDB_READ_RANGE_REUSE_ITERATORS,                   true ); if( randomize && BUGGIFY ) ROCKSDB_READ_RANGE_REUSE_ITERATORS = deterministicRandom()->coinflip() ? true : false;
 	// Set to 0 to disable rocksdb write rate limiting. Rate limiter unit: bytes per second.
 	init( ROCKSDB_WRITE_RATE_LIMITER_BYTES_PER_SEC,                0 );
 	// If true, enables dynamic adjustment of ROCKSDB_WRITE_RATE_LIMITER_BYTES according to the recent demand of background IO.
 	init( ROCKSDB_WRITE_RATE_LIMITER_AUTO_TUNE,                 true );
-	init( ROCKSDB_PERFCONTEXT_ENABLE,                          false ); if( randomize && BUGGIFY ) ROCKSDB_PERFCONTEXT_ENABLE = deterministicRandom()->coinflip() ? false : true;
-	init( ROCKSDB_PERFCONTEXT_SAMPLE_RATE, 					  0.0001 );
-	init(ROCKSDB_ENABLE_SHARDING,								 true);
+	init( ROCKSDB_PERFCONTEXT_ENABLE,                           true ); if( randomize && BUGGIFY ) ROCKSDB_PERFCONTEXT_ENABLE = deterministicRandom()->coinflip() ? false : true;
+	init( ROCKSDB_ENABLE_SHARDING,								true );
+ 	// RocksDB metrics
+ 	init( ROCKSDB_ENABLE_STATISTIC,                           	true ); if( randomize && BUGGIFY ) ROCKSDB_ENABLE_STATISTIC = deterministicRandom()->coinflip() ? false : true;
+ 	init( ROCKSDB_PERFCONTEXT_SAMPLE_RATE, 					    0.01 ); if( randomize && BUGGIFY ) ROCKSDB_PERFCONTEXT_SAMPLE_RATE = 0; //set zero to disable
+ 	init( ROCKSDB_HISTOGRAMS_SAMPLE_RATE,                      0.001 ); if( randomize && BUGGIFY ) ROCKSDB_HISTOGRAMS_SAMPLE_RATE = 0;
+ 	init( ROCKSDB_MEM_USAGE_METRIC_SAMPLE_RATE,               0.0005 ); if( randomize && BUGGIFY ) ROCKSDB_MEM_USAGE_METRIC_SAMPLE_RATE = 0; //set zero to disable
 
 	// Leader election
 	bool longLeaderElection = randomize && BUGGIFY;

--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -363,7 +363,6 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( ROCKSDB_WRITE_RATE_LIMITER_BYTES_PER_SEC,                0 );
 	// If true, enables dynamic adjustment of ROCKSDB_WRITE_RATE_LIMITER_BYTES according to the recent demand of background IO.
 	init( ROCKSDB_WRITE_RATE_LIMITER_AUTO_TUNE,                 true );
-	init( ROCKSDB_PERFCONTEXT_ENABLE,                           true ); if( randomize && BUGGIFY ) ROCKSDB_PERFCONTEXT_ENABLE = deterministicRandom()->coinflip() ? false : true;
 	init( ROCKSDB_ENABLE_SHARDING,								true );
  	// RocksDB metrics
  	init( ROCKSDB_ENABLE_STATISTIC,                           	true ); if( randomize && BUGGIFY ) ROCKSDB_ENABLE_STATISTIC = deterministicRandom()->coinflip() ? false : true;

--- a/fdbclient/ServerKnobs.h
+++ b/fdbclient/ServerKnobs.h
@@ -297,7 +297,6 @@ public:
 	int64_t ROCKSDB_WRITE_RATE_LIMITER_BYTES_PER_SEC;
 	bool ROCKSDB_WRITE_RATE_LIMITER_AUTO_TUNE;
 	bool ROCKSDB_ENABLE_STATISTIC; // Enable rocks statistic
-	bool ROCKSDB_PERFCONTEXT_ENABLE;
 	double ROCKSDB_PERFCONTEXT_SAMPLE_RATE; // Enable rocks perf context metrics. May cause performance overhead
 	double ROCKSDB_MEM_USAGE_METRIC_SAMPLE_RATE;
 

--- a/fdbclient/ServerKnobs.h
+++ b/fdbclient/ServerKnobs.h
@@ -296,8 +296,10 @@ public:
 	bool ROCKSDB_READ_RANGE_REUSE_ITERATORS;
 	int64_t ROCKSDB_WRITE_RATE_LIMITER_BYTES_PER_SEC;
 	bool ROCKSDB_WRITE_RATE_LIMITER_AUTO_TUNE;
-	bool ROCKSDB_PERFCONTEXT_ENABLE; // Enable rocks perf context metrics. May cause performance overhead
-	double ROCKSDB_PERFCONTEXT_SAMPLE_RATE;
+	bool ROCKSDB_ENABLE_STATISTIC; // Enable rocks statistic
+	bool ROCKSDB_PERFCONTEXT_ENABLE;
+	double ROCKSDB_PERFCONTEXT_SAMPLE_RATE; // Enable rocks perf context metrics. May cause performance overhead
+	double ROCKSDB_MEM_USAGE_METRIC_SAMPLE_RATE;
 
 	// Leader election
 	int MAX_NOTIFICATIONS;


### PR DESCRIPTION
Previously, performance metrics related to RocksDB is everywhere in the code, which is not well organized and makes the metrics hard to manage.
This PR refactors performance metrics related to RocksDB:
(1) Create an object `RocksDBMetrics` dedicated to any performance metric of RocksDB, including: RocksDB Statistics, RocksDB Property, Read/Write Iterator Pool Statistics, RocksDB PerfContext, Latency Histogram.
(2) Add a new function which collects memory usage by each RocksDB instance. As a result, we could know the memory usage for each shard, given that different active shard uses different RocksDB instance.

| Metric Type  | Scope | TraceEvent | How to open | 
| ------------- | ------------- | ------------- | ------------- |
| RocksDB Statistics  | Aggregation of all DB shards | RocksDBMetrics | ROCKSDB_ENABLE_STATISTIC | 
| RocksDB Property  | Aggregation of all DB shards (TODO)  | RocksDBMetrics | ROCKSDB_ENABLE_STATISTIC | 
| Read/Write Iterator Pool Statistics | Aggregation of all DB shards | RocksDBMetrics | ROCKSDB_ENABLE_STATISTIC | 
| RocksDB PerfContext | Per DB operation  | RocksDBPerfContextMetrics | ROCKSDB_PERFCONTEXT_SAMPLE_RATE>0 | 
| Latency Histogram | Per DB operation  | Histogram | ROCKSDB_HISTOGRAMS_SAMPLE_RATE>0 | 
| MemUsage | Per DB shard | RocksDBShardMemMetrics | ROCKSDB_MEM_USAGE_METRIC_SAMPLE_RATE>0 | 

Note: we assume each shard has its own DB instance.

This PR includes two commits:
- The first commit adds new metrics which output exactly the same as the old metrics.
- The second commit removes the old metrics.

Simulation with 500 tests passed with 492 tests.
20220401-180207-zhewang-11d649868b2ee295           compressed=True data_size=29136667 duration=20169 ended=500 fail=8 fail_fast=10 max_runs=500 pass=492 priority=100 remaining=0 runtime=0:10:55 sanity=False started=510 stopped=20220401-181302 submitted=20220401-180207 timeout=5400 username=zhewang

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
