### PR TITLE
Fix typo from pull request #6698

### DIFF
--- a/fdbmonitor/CMakeLists.txt
+++ b/fdbmonitor/CMakeLists.txt
@@ -15,10 +15,10 @@ target_link_libraries(fdbmonitor PUBLIC Threads::Threads)
 # processes). fdbmonitor is single-threaded anyway.
 get_target_property(fdbmonitor_options fdbmonitor COMPILE_OPTIONS)
 list(REMOVE_ITEM fdbmonitor_options "-fsanitize=thread")
-set_property(TARGET fdbmonitor PROPERTY COMPILE_OPTIONS ${target_options})
+set_property(TARGET fdbmonitor PROPERTY COMPILE_OPTIONS ${fdbmonitor_options})
 get_target_property(fdbmonitor_options fdbmonitor LINK_OPTIONS)
 list(REMOVE_ITEM fdbmonitor_options "-fsanitize=thread")
-set_property(TARGET fdbmonitor PROPERTY LINK_OPTIONS ${target_options})
+set_property(TARGET fdbmonitor PROPERTY LINK_OPTIONS ${fdbmonitor_options})
 
 if(GENERATE_DEBUG_PACKAGES)
   fdb_install(TARGETS fdbmonitor DESTINATION fdbmonitor COMPONENT server)


### PR DESCRIPTION
It looks like #6698 had the effect of removing _all_ compile options from fdbmonitor, not just -fsanitize=thread. Fix that.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
