### PR TITLE
fix cmake bug when no link or compile options

### DIFF
--- a/fdbmonitor/CMakeLists.txt
+++ b/fdbmonitor/CMakeLists.txt
@@ -6,7 +6,7 @@ assert_no_version_h(fdbmonitor)
 if(UNIX AND NOT APPLE)
     target_link_libraries(fdbmonitor PRIVATE rt)
 endif()
-# FIXME: This include directory is an ugly hack. We probably want to fix this
+# FIXME: This include directory is an ugly hack. We probably want to fix this.
 # as soon as we get rid of the old build system
 target_link_libraries(fdbmonitor PUBLIC Threads::Threads)
 
@@ -14,11 +14,17 @@ target_link_libraries(fdbmonitor PUBLIC Threads::Threads)
 # appears to change its behavior (it no longer seems to restart killed
 # processes). fdbmonitor is single-threaded anyway.
 get_target_property(fdbmonitor_options fdbmonitor COMPILE_OPTIONS)
-list(REMOVE_ITEM fdbmonitor_options "-fsanitize=thread")
-set_property(TARGET fdbmonitor PROPERTY COMPILE_OPTIONS ${fdbmonitor_options})
+if (NOT "${fdbmonitor_options}" STREQUAL "fdbmonitor_options-NOTFOUND")
+  list(REMOVE_ITEM fdbmonitor_options "-fsanitize=thread")
+  set_property(TARGET fdbmonitor PROPERTY COMPILE_OPTIONS ${fdbmonitor_options})
+endif ()
+
 get_target_property(fdbmonitor_options fdbmonitor LINK_OPTIONS)
-list(REMOVE_ITEM fdbmonitor_options "-fsanitize=thread")
-set_property(TARGET fdbmonitor PROPERTY LINK_OPTIONS ${fdbmonitor_options})
+
+if (NOT "${fdbmonitor_options}" STREQUAL "fdbmonitor_options-NOTFOUND")
+  list(REMOVE_ITEM fdbmonitor_options "-fsanitize=thread")
+  set_property(TARGET fdbmonitor PROPERTY LINK_OPTIONS ${fdbmonitor_options})
+endif ()
 
 if(GENERATE_DEBUG_PACKAGES)
   fdb_install(TARGETS fdbmonitor DESTINATION fdbmonitor COMPONENT server)


### PR DESCRIPTION
If property LINK_OPTIONS or COMPILE_OPTIONS doesn't exist,  `fdbmonitor_options` will be set to `fdbmonitor_options-NOTFOUND`, which result to fdbmonitor link failure.

```
clang: error: no such file or directory: 'fdbmonitor_options-NOTFOUND'
```

Not sure why previous CI didn't find this issue until #6737 .

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
