### PR TITLE
Use MLR to read restore range

### DIFF
--- a/fdbclient/FileBackupAgent.actor.cpp
+++ b/fdbclient/FileBackupAgent.actor.cpp
@@ -3842,7 +3842,7 @@ struct RestoreDispatchTaskFunc : RestoreTaskFuncBase {
 
 		// If more blocks need to be dispatched in this batch then add a follow-on task that is part of the allPartsDone
 		// group which will won't wait to run and will add more block tasks.
-		if (remainingInBatch > 0)
+		if (remainingInBatch > 0) {
 			addTaskFutures.push_back(RestoreDispatchTaskFunc::addTask(tr,
 			                                                          taskBucket,
 			                                                          task,
@@ -3852,7 +3852,7 @@ struct RestoreDispatchTaskFunc : RestoreTaskFuncBase {
 			                                                          batchSize,
 			                                                          remainingInBatch,
 			                                                          TaskCompletionKey::joinWith(allPartsDone)));
-		else // Otherwise, add a follow-on task to continue after all previously dispatched blocks are done
+		} else { // Otherwise, add a follow-on task to continue after all previously dispatched blocks are done
 			addTaskFutures.push_back(RestoreDispatchTaskFunc::addTask(tr,
 			                                                          taskBucket,
 			                                                          task,
@@ -3863,6 +3863,7 @@ struct RestoreDispatchTaskFunc : RestoreTaskFuncBase {
 			                                                          0,
 			                                                          TaskCompletionKey::noSignal(),
 			                                                          allPartsDone));
+		}
 
 		wait(waitForAll(addTaskFutures));
 


### PR DESCRIPTION
The current database restore process, restoring from files, looks like:
1. Read saved mutation data from backup files.
2. Write the data into the FDB-internal range `\xff\xff02/alog/<ApplyLogUID>/<HashByte><ChunkVersion><ChunkNumber>`. The data is sharded evenly based on the hash byte, allowing even load on FDB.
3. Read the data from `\xff\xff02/alog/<ApplyLogUID>/` and write back as original key value pairs. This works by splitting the restore range (specified by a start and end version) into small chunks, then reading each range and restoring the data in it.

Step 3 is problematic when a restore is being done over a large version range that is sparsely populated. The existing approach will try to read all version ranges within the range [begin version, end version), even if the range doesn't contain any data. @RenxuanW implemented a more efficient, pipelined reading mechanism in #5359.

This PR integrates the `MutationLogReader` into the restore path, allowing fast file restores over large, sparse version ranges.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
