### PR TITLE
Fix data race issue when KVStoreRocksDB using histogram

### DIFF
--- a/fdbclient/FDBTypes.h
+++ b/fdbclient/FDBTypes.h
@@ -1368,12 +1368,12 @@ struct ReadBlobGranuleContext {
 // Store metadata associated with each storage server. Now it only contains data be used in perpetual storage wiggle.
 struct StorageMetadataType {
 	constexpr static FileIdentifier file_identifier = 732123;
-	// when the SS is initialized
-	uint64_t createdTime; // comes from currentTime()
+	// when the SS is initialized, in epoch seconds, comes from currentTime()
+	double createdTime;
 	StorageMetadataType() : createdTime(0) {}
 	StorageMetadataType(uint64_t t) : createdTime(t) {}
 
-	static uint64_t currentTime() { return g_network->timer_int(); }
+	static double currentTime() { return g_network->timer(); }
 
 	// To change this serialization, ProtocolVersion::StorageMetadata must be updated, and downgrades need
 	// to be considered

--- a/fdbclient/Schemas.cpp
+++ b/fdbclient/Schemas.cpp
@@ -24,37 +24,37 @@
 const KeyRef JSONSchemas::statusSchema = LiteralStringRef(R"statusSchema(
 {
    "cluster":{
-       "storage_wiggler": {
-		 "wiggle_server_ids":["0ccb4e0feddb55"],
-		 "wiggle_server_addresses": ["127.0.0.1"],
+      "storage_wiggler": {
+         "wiggle_server_ids":["0ccb4e0feddb55"],
+         "wiggle_server_addresses": ["127.0.0.1"],
          "primary": {
-          	"last_round_start_datetime": "Wed Feb  4 09:36:37 2022 +0000",
-			"last_round_start_timestamp": 63811229797,
-			"last_round_finish_datetime": "Thu Jan  1 00:00:00 1970 +0000",
-			"last_round_finish_timestamp": 0,
-			"smoothed_round_seconds": 1,
-			"finished_round": 1,
-			"last_wiggle_start_datetime": "Wed Feb  4 09:36:37 2022 +0000",
-			"last_wiggle_start_timestamp": 63811229797,
-			"last_wiggle_finish_datetime": "Thu Jan  1 00:00:00 1970 +0000",
-			"last_wiggle_finish_timestamp": 0,
-			"smoothed_wiggle_seconds": 1,
-			"finished_wiggle": 1
-          },
-          "remote": {
-          	"last_round_start_datetime": "Wed Feb  4 09:36:37 2022 +0000",
-			"last_round_start_timestamp": 63811229797,
-			"last_round_finish_datetime": "Thu Jan  1 00:00:00 1970 +0000",
-			"last_round_finish_timestamp": 0,
-			"smoothed_round_seconds": 1,
-			"finished_round": 1,
-			"last_wiggle_start_datetime": "Wed Feb  4 09:36:37 2022 +0000",
-			"last_wiggle_start_timestamp": 63811229797,
-			"last_wiggle_finish_datetime": "Thu Jan  1 00:00:00 1970 +0000",
-			"last_wiggle_finish_timestamp": 0,
-			"smoothed_wiggle_seconds": 1,
-			"finished_wiggle": 1
-          }
+            "last_round_start_datetime": "2022-04-02 00:05:05.123 +0000",
+            "last_round_start_timestamp": 1648857905.123,
+            "last_round_finish_datetime": "1970-01-01 00:00:00.000 +0000",
+            "last_round_finish_timestamp": 0,
+            "smoothed_round_seconds": 1,
+            "finished_round": 1,
+            "last_wiggle_start_datetime": "2022-04-02 00:05:05.123 +0000",
+            "last_wiggle_start_timestamp": 1648857905.123,
+            "last_wiggle_finish_datetime": "1970-01-01 00:00:00.000 +0000",
+            "last_wiggle_finish_timestamp": 0,
+            "smoothed_wiggle_seconds": 1,
+            "finished_wiggle": 1
+         },
+         "remote": {
+            "last_round_start_datetime": "2022-04-02 00:05:05.123 +0000",
+            "last_round_start_timestamp": 1648857905.123,
+            "last_round_finish_datetime": "1970-01-01 00:00:00.000 +0000",
+            "last_round_finish_timestamp": 0,
+            "smoothed_round_seconds": 1,
+            "finished_round": 1,
+            "last_wiggle_start_datetime": "2022-04-02 00:05:05.123 +0000",
+            "last_wiggle_start_timestamp": 1648857905.123,
+            "last_wiggle_finish_datetime": "1970-01-01 00:00:00.000 +0000",
+            "last_wiggle_finish_timestamp": 0,
+            "smoothed_wiggle_seconds": 1,
+            "finished_wiggle": 1
+         }
       },
       "layers":{
          "_valid":true,
@@ -136,7 +136,7 @@ const KeyRef JSONSchemas::statusSchema = LiteralStringRef(R"statusSchema(
                      ]
                   },
                   "storage_metadata":{
-                     "created_time_datetime":"Thu Jan  1 00:00:00 1970 +0000",
+                     "created_time_datetime":"1970-01-01 00:00:00.000 +0000",
                      "created_time_timestamp": 0
                   },
                   "data_version":12341234,

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -296,7 +296,7 @@ Future<Void> StorageWiggler::restoreStats() {
 	return map(readFuture, assignFunc);
 }
 Future<Void> StorageWiggler::startWiggle() {
-	metrics.last_wiggle_start = g_network->timer_int();
+	metrics.last_wiggle_start = StorageMetadataType::currentTime();
 	if (shouldStartNewRound()) {
 		metrics.last_round_start = metrics.last_wiggle_start;
 	}
@@ -304,7 +304,7 @@ Future<Void> StorageWiggler::startWiggle() {
 }
 
 Future<Void> StorageWiggler::finishWiggle() {
-	metrics.last_wiggle_finish = g_network->timer_int();
+	metrics.last_wiggle_finish = StorageMetadataType::currentTime();
 	metrics.finished_wiggle += 1;
 	auto duration = metrics.last_wiggle_finish - metrics.last_wiggle_start;
 	metrics.smoothed_wiggle_duration.setTotal((double)duration);

--- a/fdbserver/DataDistribution.actor.h
+++ b/fdbserver/DataDistribution.actor.h
@@ -299,15 +299,17 @@ struct StorageWiggleMetrics {
 	// round statistics
 	// One StorageServer wiggle round is considered 'complete', when all StorageServers with creationTime < T are
 	// wiggled
-	uint64_t last_round_start = 0; // wall timer: timer_int()
-	uint64_t last_round_finish = 0;
+	// Start and finish are in epoch seconds
+	double last_round_start = 0;
+	double last_round_finish = 0;
 	TimerSmoother smoothed_round_duration;
 	int finished_round = 0; // finished round since storage wiggle is open
 
 	// step statistics
 	// 1 wiggle step as 1 storage server is wiggled in the current round
-	uint64_t last_wiggle_start = 0; // wall timer: timer_int()
-	uint64_t last_wiggle_finish = 0;
+	// Start and finish are in epoch seconds
+	double last_wiggle_start = 0;
+	double last_wiggle_finish = 0;
 	TimerSmoother smoothed_wiggle_duration;
 	int finished_wiggle = 0; // finished step since storage wiggle is open
 
@@ -365,15 +367,15 @@ struct StorageWiggleMetrics {
 
 	StatusObject toJSON() const {
 		StatusObject result;
-		result["last_round_start_datetime"] = timerIntToGmt(last_round_start);
-		result["last_round_finish_datetime"] = timerIntToGmt(last_round_finish);
+		result["last_round_start_datetime"] = epochsToGMTString(last_round_start);
+		result["last_round_finish_datetime"] = epochsToGMTString(last_round_finish);
 		result["last_round_start_timestamp"] = last_round_start;
 		result["last_round_finish_timestamp"] = last_round_finish;
 		result["smoothed_round_seconds"] = smoothed_round_duration.smoothTotal();
 		result["finished_round"] = finished_round;
 
-		result["last_wiggle_start_datetime"] = timerIntToGmt(last_wiggle_start);
-		result["last_wiggle_finish_datetime"] = timerIntToGmt(last_wiggle_finish);
+		result["last_wiggle_start_datetime"] = epochsToGMTString(last_wiggle_start);
+		result["last_wiggle_finish_datetime"] = epochsToGMTString(last_wiggle_finish);
 		result["last_wiggle_start_timestamp"] = last_wiggle_start;
 		result["last_wiggle_finish_timestamp"] = last_wiggle_finish;
 		result["smoothed_wiggle_seconds"] = smoothed_wiggle_duration.smoothTotal();

--- a/fdbserver/Status.actor.cpp
+++ b/fdbserver/Status.actor.cpp
@@ -1934,7 +1934,7 @@ ACTOR static Future<std::vector<std::pair<StorageServerInterface, EventMap>>> ge
 		if (metadata[i].present()) {
 			TraceEventFields metadataField;
 			metadataField.addField("CreatedTimeTimestamp", std::to_string(metadata[i].get().createdTime));
-			metadataField.addField("CreatedTimeDatetime", timerIntToGmt(metadata[i].get().createdTime));
+			metadataField.addField("CreatedTimeDatetime", epochsToGMTString(metadata[i].get().createdTime));
 			results[i].second.emplace("Metadata", metadataField);
 		} else if (!servers[i].isTss()) {
 			TraceEventFields metadataField;

--- a/flow/Histogram.h
+++ b/flow/Histogram.h
@@ -158,8 +158,8 @@ public:
 	}
 
 	void clear() {
-		for (uint32_t& i : buckets) {
-			i = 0;
+		for (std::atomic<uint32_t>& i : buckets) {
+			i.store(0);
 		}
 	}
 	void writeToLog(double elapsed = -1.0);
@@ -172,7 +172,7 @@ public:
 	std::string const op;
 	Unit const unit;
 	Reference<HistogramRegistry> registry;
-	uint32_t buckets[32];
+	std::atomic<uint32_t> buckets[32];
 	uint32_t lowerBound;
 	uint32_t upperBound;
 };

--- a/flow/Platform.actor.cpp
+++ b/flow/Platform.actor.cpp
@@ -1925,16 +1925,20 @@ void getLocalTime(const time_t* timep, struct tm* result) {
 #endif
 }
 
-std::string timerIntToGmt(uint64_t timestamp) {
-	auto time = (time_t)(timestamp / 1e9); // convert to second, see timer_int() implementation
-	return getGmtTimeStr(&time);
-}
+// Outputs a GMT time string for the given epoch seconds, which looks like
+// 2013-04-28 20:57:01.000 +0000
+std::string epochsToGMTString(double epochs) {
+	auto time = (time_t)epochs;
 
-std::string getGmtTimeStr(const time_t* time) {
 	char buff[50];
-	auto size = strftime(buff, 50, "%c %z", gmtime(time));
-	// printf(buff);
-	return std::string(std::begin(buff), std::begin(buff) + size);
+	auto size = strftime(buff, 50, "%Y-%m-%d %H:%M:%S", gmtime(&time));
+	std::string timeString = std::string(std::begin(buff), std::begin(buff) + size);
+
+	// Add fractional seconds and GMT timezone.
+	double integerPart;
+	timeString += format(".%03.3d +0000", (int)(1000 * modf(epochs, &integerPart)));
+
+	return timeString;
 }
 
 void setMemoryQuota(size_t limit) {

--- a/flow/Platform.h
+++ b/flow/Platform.h
@@ -279,10 +279,8 @@ uint64_t timer_int(); // Return timer as uint64_t representing epoch nanoseconds
 
 void getLocalTime(const time_t* timep, struct tm* result);
 
-// convert timestamp returned by timer_int() to Gmt format string
-std::string timerIntToGmt(uint64_t timestamp);
-
-std::string getGmtTimeStr(const time_t* time);
+// get GMT time string from an epoch seconds double
+std::string epochsToGMTString(double epochs);
 
 void setMemoryQuota(size_t limit);
 


### PR DESCRIPTION
Histogram is a useful tool to trace latency of operations.
However, histogram is not thread-safe and data race appears when multiple different read/write threads of KVStoreRocksDB do sampling concurrently.
This PR addresses this issue by making histogram thread-safe.
In particular, we use atomic operations (lock-free) to update and read values in histograms.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
