### PR TITLE
Encryption header authentication tokens

### DIFF
--- a/fdbserver/workloads/EncryptionOps.actor.cpp
+++ b/fdbserver/workloads/EncryptionOps.actor.cpp
@@ -178,7 +178,7 @@ struct EncryptionOpsWorkload : TestWorkload {
 			ASSERT(cipherLen > 0 && cipherLen <= AES_256_KEY_LENGTH);
 
 			cipherKeys = cipherKeyCache.getAllCiphers(id);
-			ASSERT(cipherKeys.size() == 1);
+			ASSERT_EQ(cipherKeys.size(), 1);
 		}
 
 		// insert the Encrypt Header cipherKey
@@ -224,9 +224,9 @@ struct EncryptionOpsWorkload : TestWorkload {
 		auto end = std::chrono::high_resolution_clock::now();
 
 		// validate encrypted buffer size and contents (not matching with plaintext)
-		ASSERT(encrypted->getLogicalSize() == len);
-		ASSERT(memcmp(encrypted->begin(), payload, len) != 0);
-		ASSERT(header->flags.headerVersion == EncryptBlobCipherAes265Ctr::ENCRYPT_HEADER_VERSION);
+		ASSERT_EQ(encrypted->getLogicalSize(), len);
+		ASSERT_NE(memcmp(encrypted->begin(), payload, len), 0);
+		ASSERT_EQ(header->flags.headerVersion, EncryptBlobCipherAes265Ctr::ENCRYPT_HEADER_VERSION);
 
 		metrics->updateEncryptionTime(std::chrono::duration<double, std::nano>(end - start).count());
 		return encrypted;
@@ -237,8 +237,8 @@ struct EncryptionOpsWorkload : TestWorkload {
 	                  const BlobCipherEncryptHeader& header,
 	                  uint8_t* originalPayload,
 	                  Reference<BlobCipherKey> orgCipherKey) {
-		ASSERT(header.flags.headerVersion == EncryptBlobCipherAes265Ctr::ENCRYPT_HEADER_VERSION);
-		ASSERT(header.flags.encryptMode == ENCRYPT_CIPHER_MODE_AES_256_CTR);
+		ASSERT_EQ(header.flags.headerVersion, EncryptBlobCipherAes265Ctr::ENCRYPT_HEADER_VERSION);
+		ASSERT_EQ(header.flags.encryptMode, ENCRYPT_CIPHER_MODE_AES_256_CTR);
 
 		auto& cipherKeyCache = BlobCipherKeyCache::getInstance();
 		Reference<BlobCipherKey> cipherKey = cipherKeyCache.getCipherKey(header.cipherTextDetails.encryptDomainId,
@@ -259,8 +259,8 @@ struct EncryptionOpsWorkload : TestWorkload {
 		auto end = std::chrono::high_resolution_clock::now();
 
 		// validate decrypted buffer size and contents (matching with original plaintext)
-		ASSERT(decrypted->getLogicalSize() == len);
-		ASSERT(memcmp(decrypted->begin(), originalPayload, len) == 0);
+		ASSERT_EQ(decrypted->getLogicalSize(), len);
+		ASSERT_EQ(memcmp(decrypted->begin(), originalPayload, len), 0);
 
 		metrics->updateDecryptionTime(std::chrono::duration<double, std::nano>(end - start).count());
 	}
@@ -303,9 +303,9 @@ struct EncryptionOpsWorkload : TestWorkload {
 
 			// Validate sanity of "getLatestCipher", especially when baseCipher gets updated
 			if (updateBaseCipher) {
-				ASSERT(cipherKey->getBaseCipherId() == nextBaseCipherId);
-				ASSERT(cipherKey->getBaseCipherLen() == baseCipherLen);
-				ASSERT(memcmp(cipherKey->rawBaseCipher(), baseCipher, baseCipherLen) == 0);
+				ASSERT_EQ(cipherKey->getBaseCipherId(), nextBaseCipherId);
+				ASSERT_EQ(cipherKey->getBaseCipherLen(), baseCipherLen);
+				ASSERT_EQ(memcmp(cipherKey->rawBaseCipher(), baseCipher, baseCipherLen), 0);
 			}
 
 			int dataLen = isFixedSizePayload() ? pageSize : deterministicRandom()->randomInt(100, maxBufSize);

--- a/flow/BlobCipher.cpp
+++ b/flow/BlobCipher.cpp
@@ -424,7 +424,7 @@ void DecryptBlobCipherAes256Ctr::verifyHeaderAuthToken(const BlobCipherEncryptHe
 		TraceEvent("VerifyEncryptBlobHeader_AuthTokenMismatch")
 		    .detail("HeaderVersion", header.flags.headerVersion)
 		    .detail("HeaderMode", header.flags.encryptMode)
-		    .detail("MultiAuthToken_HeaderAuthToken",
+		    .detail("MultiAuthHeaderAuthToken",
 		            StringRef(arena, &header.multiAuthTokens.headerAuthToken[0], AUTH_TOKEN_SIZE).toString())
 		    .detail("ComputedHeaderAuthToken", computedHeaderAuthToken.toString());
 		throw encrypt_header_authtoken_mismatch();
@@ -480,7 +480,7 @@ void DecryptBlobCipherAes256Ctr::verifyHeaderMultiAuthToken(const uint8_t* ciphe
 		TraceEvent("VerifyEncryptBlobHeader_AuthTokenMismatch")
 		    .detail("HeaderVersion", header.flags.headerVersion)
 		    .detail("HeaderMode", header.flags.encryptMode)
-		    .detail("MultiAuthToken_CipherTextAuthToken",
+		    .detail("MultiAuthCipherTextAuthToken",
 		            StringRef(arena, &header.multiAuthTokens.cipherTextAuthToken[0], AUTH_TOKEN_SIZE).toString())
 		    .detail("ComputedCipherTextAuthToken", computedCipherTextAuthToken.toString());
 		throw encrypt_header_authtoken_mismatch();

--- a/flow/BlobCipher.cpp
+++ b/flow/BlobCipher.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "flow/BlobCipher.h"
+#include "flow/EncryptUtils.h"
 #include "flow/Error.h"
 #include "flow/FastRef.h"
 #include "flow/IRandom.h"
@@ -29,21 +30,28 @@
 
 #include <cstring>
 #include <memory>
+#include <string>
 
 #if ENCRYPTION_ENABLED
 
+namespace {
+bool isEncryptHeaderAuthTokenModeValid(const EncryptAuthTokenMode mode) {
+	return mode == ENCRYPT_HEADER_AUTH_TOKEN_MODE_SINGLE || mode == ENCRYPT_HEADER_AUTH_TOKEN_MODE_MULTI ? true : false;
+}
+} // namespace
+
 // BlobCipherEncryptHeader
 BlobCipherEncryptHeader::BlobCipherEncryptHeader() {
-	flags.encryptMode = BLOB_CIPHER_ENCRYPT_MODE_NONE;
+	flags.encryptMode = ENCRYPT_CIPHER_MODE_NONE;
 }
 
 // BlobCipherKey class methods
 
-BlobCipherKey::BlobCipherKey(const BlobCipherDomainId& domainId,
-                             const BlobCipherBaseKeyId& baseCiphId,
+BlobCipherKey::BlobCipherKey(const EncryptCipherDomainId& domainId,
+                             const EncryptCipherBaseKeyId& baseCiphId,
                              const uint8_t* baseCiph,
                              int baseCiphLen) {
-	BlobCipherRandomSalt salt;
+	EncryptCipherRandomSalt salt;
 	if (g_network->isSimulated()) {
 		salt = deterministicRandom()->randomUInt64();
 	} else {
@@ -58,11 +66,11 @@ BlobCipherKey::BlobCipherKey(const BlobCipherDomainId& domainId,
 	    .detail("CreationTime", creationTime);*/
 }
 
-void BlobCipherKey::initKey(const BlobCipherDomainId& domainId,
+void BlobCipherKey::initKey(const EncryptCipherDomainId& domainId,
                             const uint8_t* baseCiph,
                             int baseCiphLen,
-                            const BlobCipherBaseKeyId& baseCiphId,
-                            const BlobCipherRandomSalt& salt) {
+                            const EncryptCipherBaseKeyId& baseCiphId,
+                            const EncryptCipherRandomSalt& salt) {
 	// Set the base encryption key properties
 	baseCipher = std::make_unique<uint8_t[]>(AES_256_KEY_LENGTH);
 	memset(baseCipher.get(), 0, AES_256_KEY_LENGTH);
@@ -82,11 +90,11 @@ void BlobCipherKey::initKey(const BlobCipherDomainId& domainId,
 
 void BlobCipherKey::applyHmacSha256Derivation() {
 	Arena arena;
-	uint8_t buf[baseCipherLen + sizeof(BlobCipherRandomSalt)];
+	uint8_t buf[baseCipherLen + sizeof(EncryptCipherRandomSalt)];
 	memcpy(&buf[0], baseCipher.get(), baseCipherLen);
-	memcpy(&buf[0] + baseCipherLen, &randomSalt, sizeof(BlobCipherRandomSalt));
+	memcpy(&buf[0] + baseCipherLen, &randomSalt, sizeof(EncryptCipherRandomSalt));
 	HmacSha256DigestGen hmacGen(baseCipher.get(), baseCipherLen);
-	StringRef digest = hmacGen.digest(&buf[0], baseCipherLen + sizeof(BlobCipherRandomSalt), arena);
+	StringRef digest = hmacGen.digest(&buf[0], baseCipherLen + sizeof(EncryptCipherRandomSalt), arena);
 	std::copy(digest.begin(), digest.end(), cipher.get());
 	if (digest.size() < AES_256_KEY_LENGTH) {
 		memcpy(cipher.get() + digest.size(), buf, AES_256_KEY_LENGTH - digest.size());
@@ -101,10 +109,10 @@ void BlobCipherKey::reset() {
 // BlobKeyIdCache class methods
 
 BlobCipherKeyIdCache::BlobCipherKeyIdCache()
-  : domainId(INVALID_DOMAIN_ID), latestBaseCipherKeyId(INVALID_CIPHER_KEY_ID) {}
+  : domainId(ENCRYPT_INVALID_DOMAIN_ID), latestBaseCipherKeyId(ENCRYPT_INVALID_CIPHER_KEY_ID) {}
 
-BlobCipherKeyIdCache::BlobCipherKeyIdCache(BlobCipherDomainId dId)
-  : domainId(dId), latestBaseCipherKeyId(INVALID_CIPHER_KEY_ID) {
+BlobCipherKeyIdCache::BlobCipherKeyIdCache(EncryptCipherDomainId dId)
+  : domainId(dId), latestBaseCipherKeyId(ENCRYPT_INVALID_CIPHER_KEY_ID) {
 	TraceEvent("Init_BlobCipherKeyIdCache").detail("DomainId", domainId);
 }
 
@@ -112,7 +120,7 @@ Reference<BlobCipherKey> BlobCipherKeyIdCache::getLatestCipherKey() {
 	return getCipherByBaseCipherId(latestBaseCipherKeyId);
 }
 
-Reference<BlobCipherKey> BlobCipherKeyIdCache::getCipherByBaseCipherId(BlobCipherBaseKeyId baseCipherKeyId) {
+Reference<BlobCipherKey> BlobCipherKeyIdCache::getCipherByBaseCipherId(EncryptCipherBaseKeyId baseCipherKeyId) {
 	BlobCipherKeyIdCacheMapCItr itr = keyIdCache.find(baseCipherKeyId);
 	if (itr == keyIdCache.end()) {
 		throw encrypt_key_not_found();
@@ -120,10 +128,10 @@ Reference<BlobCipherKey> BlobCipherKeyIdCache::getCipherByBaseCipherId(BlobCiphe
 	return itr->second;
 }
 
-void BlobCipherKeyIdCache::insertBaseCipherKey(BlobCipherBaseKeyId baseCipherId,
+void BlobCipherKeyIdCache::insertBaseCipherKey(EncryptCipherBaseKeyId baseCipherId,
                                                const uint8_t* baseCipher,
                                                int baseCipherLen) {
-	ASSERT(baseCipherId > INVALID_CIPHER_KEY_ID);
+	ASSERT_GT(baseCipherId, ENCRYPT_INVALID_CIPHER_KEY_ID);
 
 	// BaseCipherKeys are immutable, ensure that cached value doesn't get updated.
 	BlobCipherKeyIdCacheMapCItr itr = keyIdCache.find(baseCipherId);
@@ -165,11 +173,11 @@ std::vector<Reference<BlobCipherKey>> BlobCipherKeyIdCache::getAllCipherKeys() {
 
 // BlobCipherKeyCache class methods
 
-void BlobCipherKeyCache::insertCipherKey(const BlobCipherDomainId& domainId,
-                                         const BlobCipherBaseKeyId& baseCipherId,
+void BlobCipherKeyCache::insertCipherKey(const EncryptCipherDomainId& domainId,
+                                         const EncryptCipherBaseKeyId& baseCipherId,
                                          const uint8_t* baseCipher,
                                          int baseCipherLen) {
-	if (domainId == INVALID_DOMAIN_ID || baseCipherId == INVALID_CIPHER_KEY_ID) {
+	if (domainId == ENCRYPT_INVALID_DOMAIN_ID || baseCipherId == ENCRYPT_INVALID_CIPHER_KEY_ID) {
 		throw encrypt_invalid_id();
 	}
 
@@ -193,7 +201,7 @@ void BlobCipherKeyCache::insertCipherKey(const BlobCipherDomainId& domainId,
 	}
 }
 
-Reference<BlobCipherKey> BlobCipherKeyCache::getLatestCipherKey(const BlobCipherDomainId& domainId) {
+Reference<BlobCipherKey> BlobCipherKeyCache::getLatestCipherKey(const EncryptCipherDomainId& domainId) {
 	auto domainItr = domainCacheMap.find(domainId);
 	if (domainItr == domainCacheMap.end()) {
 		TraceEvent("GetLatestCipherKey_DomainNotFound").detail("DomainId", domainId);
@@ -212,8 +220,8 @@ Reference<BlobCipherKey> BlobCipherKeyCache::getLatestCipherKey(const BlobCipher
 	return cipherKey;
 }
 
-Reference<BlobCipherKey> BlobCipherKeyCache::getCipherKey(const BlobCipherDomainId& domainId,
-                                                          const BlobCipherBaseKeyId& baseCipherId) {
+Reference<BlobCipherKey> BlobCipherKeyCache::getCipherKey(const EncryptCipherDomainId& domainId,
+                                                          const EncryptCipherBaseKeyId& baseCipherId) {
 	auto domainItr = domainCacheMap.find(domainId);
 	if (domainItr == domainCacheMap.end()) {
 		throw encrypt_key_not_found();
@@ -223,7 +231,7 @@ Reference<BlobCipherKey> BlobCipherKeyCache::getCipherKey(const BlobCipherDomain
 	return keyIdCache->getCipherByBaseCipherId(baseCipherId);
 }
 
-void BlobCipherKeyCache::resetEncyrptDomainId(const BlobCipherDomainId domainId) {
+void BlobCipherKeyCache::resetEncyrptDomainId(const EncryptCipherDomainId domainId) {
 	auto domainItr = domainCacheMap.find(domainId);
 	if (domainItr == domainCacheMap.end()) {
 		throw encrypt_key_not_found();
@@ -245,7 +253,7 @@ void BlobCipherKeyCache::cleanup() noexcept {
 	instance.domainCacheMap.clear();
 }
 
-std::vector<Reference<BlobCipherKey>> BlobCipherKeyCache::getAllCiphers(const BlobCipherDomainId& domainId) {
+std::vector<Reference<BlobCipherKey>> BlobCipherKeyCache::getAllCiphers(const EncryptCipherDomainId& domainId) {
 	auto domainItr = domainCacheMap.find(domainId);
 	if (domainItr == domainCacheMap.end()) {
 		return {};
@@ -255,13 +263,17 @@ std::vector<Reference<BlobCipherKey>> BlobCipherKeyCache::getAllCiphers(const Bl
 	return keyIdCache->getAllCipherKeys();
 }
 
-// EncryptBlobCipher class methods
+// EncryptBlobCipherAes265Ctr class methods
 
-EncryptBlobCipherAes265Ctr::EncryptBlobCipherAes265Ctr(Reference<BlobCipherKey> key,
+EncryptBlobCipherAes265Ctr::EncryptBlobCipherAes265Ctr(Reference<BlobCipherKey> tCipherKey,
+                                                       Reference<BlobCipherKey> hCipherKey,
                                                        const uint8_t* cipherIV,
-                                                       const int ivLen)
-  : ctx(EVP_CIPHER_CTX_new()), cipherKey(key) {
-	ASSERT(ivLen == AES_256_IV_LENGTH);
+                                                       const int ivLen,
+                                                       const EncryptAuthTokenMode mode)
+  : ctx(EVP_CIPHER_CTX_new()), textCipherKey(tCipherKey), headerCipherKey(hCipherKey), authTokenMode(mode) {
+	ASSERT(isEncryptHeaderAuthTokenModeValid(mode));
+	ASSERT_EQ(ivLen, AES_256_IV_LENGTH);
+
 	memcpy(&iv[0], cipherIV, ivLen);
 
 	if (ctx == nullptr) {
@@ -270,7 +282,7 @@ EncryptBlobCipherAes265Ctr::EncryptBlobCipherAes265Ctr(Reference<BlobCipherKey> 
 	if (EVP_EncryptInit_ex(ctx, EVP_aes_256_ctr(), nullptr, nullptr, nullptr) != 1) {
 		throw encrypt_ops_error();
 	}
-	if (EVP_EncryptInit_ex(ctx, nullptr, nullptr, key.getPtr()->data(), cipherIV) != 1) {
+	if (EVP_EncryptInit_ex(ctx, nullptr, nullptr, textCipherKey.getPtr()->data(), cipherIV) != 1) {
 		throw encrypt_ops_error();
 	}
 }
@@ -281,21 +293,29 @@ Reference<EncryptBuf> EncryptBlobCipherAes265Ctr::encrypt(const uint8_t* plainte
                                                           Arena& arena) {
 	TEST(true); // Encrypting data with BlobCipher
 
-	Reference<EncryptBuf> encryptBuf = makeReference<EncryptBuf>(plaintextLen + AES_BLOCK_SIZE, arena);
+	memset(reinterpret_cast<uint8_t*>(header), 0, sizeof(BlobCipherEncryptHeader));
+
+	// Alloc buffer computation accounts for 'header authentication' generation scheme. If single-auth-token needs to be
+	// generated, allocate buffer sufficient to append header to the cipherText optimizing memcpy cost.
+
+	const int allocSize = authTokenMode == ENCRYPT_HEADER_AUTH_TOKEN_MODE_SINGLE
+	                          ? plaintextLen + AES_BLOCK_SIZE + sizeof(BlobCipherEncryptHeader)
+	                          : plaintextLen + AES_BLOCK_SIZE;
+	Reference<EncryptBuf> encryptBuf = makeReference<EncryptBuf>(allocSize, arena);
 	uint8_t* ciphertext = encryptBuf->begin();
 	int bytes{ 0 };
 	if (EVP_EncryptUpdate(ctx, ciphertext, &bytes, plaintext, plaintextLen) != 1) {
 		TraceEvent("Encrypt_UpdateFailed")
-		    .detail("BaseCipherId", cipherKey->getBaseCipherId())
-		    .detail("EncryptDomainId", cipherKey->getDomainId());
+		    .detail("BaseCipherId", textCipherKey->getBaseCipherId())
+		    .detail("EncryptDomainId", textCipherKey->getDomainId());
 		throw encrypt_ops_error();
 	}
 
 	int finalBytes{ 0 };
 	if (EVP_EncryptFinal_ex(ctx, ciphertext + bytes, &finalBytes) != 1) {
 		TraceEvent("Encrypt_FinalFailed")
-		    .detail("BaseCipherId", cipherKey->getBaseCipherId())
-		    .detail("EncryptDomainId", cipherKey->getDomainId());
+		    .detail("BaseCipherId", textCipherKey->getBaseCipherId())
+		    .detail("EncryptDomainId", textCipherKey->getDomainId());
 		throw encrypt_ops_error();
 	}
 
@@ -306,19 +326,50 @@ Reference<EncryptBuf> EncryptBlobCipherAes265Ctr::encrypt(const uint8_t* plainte
 		throw encrypt_ops_error();
 	}
 
-	// populate header details for the encrypted blob.
+	// Populate encryption header flags details
 	header->flags.size = sizeof(BlobCipherEncryptHeader);
 	header->flags.headerVersion = EncryptBlobCipherAes265Ctr::ENCRYPT_HEADER_VERSION;
-	header->flags.encryptMode = BLOB_CIPHER_ENCRYPT_MODE_AES_256_CTR;
-	header->baseCipherId = cipherKey->getBaseCipherId();
-	header->encryptDomainId = cipherKey->getDomainId();
-	header->salt = cipherKey->getSalt();
-	memcpy(&header->iv[0], &iv[0], AES_256_IV_LENGTH);
+	header->flags.encryptMode = ENCRYPT_CIPHER_MODE_AES_256_CTR;
+	header->flags.authTokenMode = authTokenMode;
 
-	// Preserve checksum of encrypted bytes in the header; approach protects against disk induced bit-rot/flip
-	// scenarios. AES CTR mode doesn't generate 'tag' by default as with schemes such as: AES 256 GCM.
+	// Populate cipherText encryption-key details
+	header->cipherTextDetails.baseCipherId = textCipherKey->getBaseCipherId();
+	header->cipherTextDetails.encryptDomainId = textCipherKey->getDomainId();
+	header->cipherTextDetails.salt = textCipherKey->getSalt();
+	memcpy(&header->cipherTextDetails.iv[0], &iv[0], AES_256_IV_LENGTH);
 
-	header->ciphertextChecksum = computeEncryptChecksum(ciphertext, bytes + finalBytes, cipherKey->getSalt(), arena);
+	// Populate header encryption-key details
+	header->cipherHeaderDetails.encryptDomainId = headerCipherKey->getDomainId();
+	header->cipherHeaderDetails.baseCipherId = headerCipherKey->getBaseCipherId();
+
+	// Populate header authToken details
+	if (header->flags.authTokenMode == ENCRYPT_HEADER_AUTH_TOKEN_MODE_SINGLE) {
+		ASSERT_GE(allocSize, (bytes + finalBytes + sizeof(BlobCipherEncryptHeader)));
+		ASSERT_GE(encryptBuf->getLogicalSize(), (bytes + finalBytes + sizeof(BlobCipherEncryptHeader)));
+
+		memcpy(
+		    &ciphertext[bytes + finalBytes], reinterpret_cast<const uint8_t*>(header), sizeof(BlobCipherEncryptHeader));
+		StringRef authToken = computeAuthToken(ciphertext,
+		                                       bytes + finalBytes + sizeof(BlobCipherEncryptHeader),
+		                                       headerCipherKey->rawCipher(),
+		                                       AES_256_KEY_LENGTH,
+		                                       arena);
+		memcpy(&header->singleAuthToken.authToken[0], authToken.begin(), AUTH_TOKEN_SIZE);
+	} else {
+		StringRef cipherTextAuthToken =
+		    computeAuthToken(ciphertext,
+		                     bytes + finalBytes,
+		                     reinterpret_cast<const uint8_t*>(&header->cipherTextDetails.salt),
+		                     sizeof(EncryptCipherRandomSalt),
+		                     arena);
+		memcpy(&header->multiAuthTokens.cipherTextAuthToken[0], cipherTextAuthToken.begin(), AUTH_TOKEN_SIZE);
+		StringRef headerAuthToken = computeAuthToken(reinterpret_cast<const uint8_t*>(header),
+		                                             sizeof(BlobCipherEncryptHeader),
+		                                             headerCipherKey->rawCipher(),
+		                                             AES_256_KEY_LENGTH,
+		                                             arena);
+		memcpy(&header->multiAuthTokens.headerAuthToken[0], headerAuthToken.begin(), AUTH_TOKEN_SIZE);
+	}
 
 	encryptBuf->setLogicalSize(plaintextLen);
 	return encryptBuf;
@@ -330,46 +381,136 @@ EncryptBlobCipherAes265Ctr::~EncryptBlobCipherAes265Ctr() {
 	}
 }
 
-// DecryptBlobCipher class methods
+// DecryptBlobCipherAes256Ctr class methods
 
-DecryptBlobCipherAes256Ctr::DecryptBlobCipherAes256Ctr(Reference<BlobCipherKey> key, const uint8_t* iv)
-  : ctx(EVP_CIPHER_CTX_new()) {
+DecryptBlobCipherAes256Ctr::DecryptBlobCipherAes256Ctr(Reference<BlobCipherKey> tCipherKey,
+                                                       Reference<BlobCipherKey> hCipherKey,
+                                                       const uint8_t* iv)
+  : ctx(EVP_CIPHER_CTX_new()), textCipherKey(tCipherKey), headerCipherKey(hCipherKey),
+    headerAuthTokenValidationDone(false), authTokensValidationDone(false) {
 	if (ctx == nullptr) {
 		throw encrypt_ops_error();
 	}
 	if (!EVP_DecryptInit_ex(ctx, EVP_aes_256_ctr(), nullptr, nullptr, nullptr)) {
 		throw encrypt_ops_error();
 	}
-	if (!EVP_DecryptInit_ex(ctx, nullptr, nullptr, key.getPtr()->data(), iv)) {
+	if (!EVP_DecryptInit_ex(ctx, nullptr, nullptr, tCipherKey.getPtr()->data(), iv)) {
 		throw encrypt_ops_error();
 	}
 }
 
-void DecryptBlobCipherAes256Ctr::verifyEncryptBlobHeader(const uint8_t* ciphertext,
-                                                         const int ciphertextLen,
-                                                         const BlobCipherEncryptHeader& header,
-                                                         Arena& arena) {
+void DecryptBlobCipherAes256Ctr::verifyHeaderAuthToken(const BlobCipherEncryptHeader& header, Arena& arena) {
+	if (header.flags.authTokenMode == ENCRYPT_HEADER_AUTH_TOKEN_MODE_SINGLE) {
+		// SingleAuthToken mode; verification will happen as part of decryption.
+		return;
+	}
+
+	ASSERT_EQ(header.flags.authTokenMode, ENCRYPT_HEADER_AUTH_TOKEN_MODE_MULTI);
+
+	BlobCipherEncryptHeader headerCopy;
+	memcpy(reinterpret_cast<uint8_t*>(&headerCopy),
+	       reinterpret_cast<const uint8_t*>(&header),
+	       sizeof(BlobCipherEncryptHeader));
+	memset(reinterpret_cast<uint8_t*>(&headerCopy.multiAuthTokens.headerAuthToken), 0, AUTH_TOKEN_SIZE);
+	StringRef computedHeaderAuthToken = computeAuthToken(reinterpret_cast<const uint8_t*>(&headerCopy),
+	                                                     sizeof(BlobCipherEncryptHeader),
+	                                                     headerCipherKey->rawCipher(),
+	                                                     AES_256_KEY_LENGTH,
+	                                                     arena);
+	if (memcmp(&header.multiAuthTokens.headerAuthToken[0], computedHeaderAuthToken.begin(), AUTH_TOKEN_SIZE) != 0) {
+		TraceEvent("VerifyEncryptBlobHeader_AuthTokenMismatch")
+		    .detail("HeaderVersion", header.flags.headerVersion)
+		    .detail("HeaderMode", header.flags.encryptMode)
+		    .detail("MultiAuthToken_HeaderAuthToken",
+		            StringRef(arena, &header.multiAuthTokens.headerAuthToken[0], AUTH_TOKEN_SIZE).toString())
+		    .detail("ComputedHeaderAuthToken", computedHeaderAuthToken.toString());
+		throw encrypt_header_authtoken_mismatch();
+	}
+
+	headerAuthTokenValidationDone = true;
+}
+
+void DecryptBlobCipherAes256Ctr::verifyHeaderSingleAuthToken(const uint8_t* ciphertext,
+                                                             const int ciphertextLen,
+                                                             const BlobCipherEncryptHeader& header,
+                                                             uint8_t* buff,
+                                                             Arena& arena) {
+	// Header authToken not set for single auth-token mode.
+	ASSERT(!headerAuthTokenValidationDone);
+
+	// prepare the payload {cipherText + encryptionHeader}
+	memcpy(&buff[0], ciphertext, ciphertextLen);
+	memcpy(&buff[ciphertextLen], reinterpret_cast<const uint8_t*>(&header), sizeof(BlobCipherEncryptHeader));
+	// ensure the 'authToken' is reset before computing the 'authentication token'
+	BlobCipherEncryptHeader* eHeader = (BlobCipherEncryptHeader*)(&buff[ciphertextLen]);
+	memset(reinterpret_cast<uint8_t*>(&eHeader->singleAuthToken), 0, 2 * AUTH_TOKEN_SIZE);
+
+	StringRef computed = computeAuthToken(
+	    buff, ciphertextLen + sizeof(BlobCipherEncryptHeader), headerCipherKey->rawCipher(), AES_256_KEY_LENGTH, arena);
+	if (memcmp(&header.singleAuthToken.authToken[0], computed.begin(), AUTH_TOKEN_SIZE) != 0) {
+		TraceEvent("VerifyEncryptBlobHeader_AuthTokenMismatch")
+		    .detail("HeaderVersion", header.flags.headerVersion)
+		    .detail("HeaderMode", header.flags.encryptMode)
+		    .detail("SingleAuthToken",
+		            StringRef(arena, &header.singleAuthToken.authToken[0], AUTH_TOKEN_SIZE).toString())
+		    .detail("ComputedSingleAuthToken", computed.toString());
+		throw encrypt_header_authtoken_mismatch();
+	}
+}
+
+void DecryptBlobCipherAes256Ctr::verifyHeaderMultiAuthToken(const uint8_t* ciphertext,
+                                                            const int ciphertextLen,
+                                                            const BlobCipherEncryptHeader& header,
+                                                            uint8_t* buff,
+                                                            Arena& arena) {
+	if (!headerAuthTokenValidationDone) {
+		verifyHeaderAuthToken(header, arena);
+	}
+	StringRef computedCipherTextAuthToken =
+	    computeAuthToken(ciphertext,
+	                     ciphertextLen,
+	                     reinterpret_cast<const uint8_t*>(&header.cipherTextDetails.salt),
+	                     sizeof(EncryptCipherRandomSalt),
+	                     arena);
+	if (memcmp(&header.singleAuthToken.authToken[0], computedCipherTextAuthToken.begin(), AUTH_TOKEN_SIZE) != 0) {
+		TraceEvent("VerifyEncryptBlobHeader_AuthTokenMismatch")
+		    .detail("HeaderVersion", header.flags.headerVersion)
+		    .detail("HeaderMode", header.flags.encryptMode)
+		    .detail("MultiAuthToken_CipherTextAuthToken",
+		            StringRef(arena, &header.multiAuthTokens.cipherTextAuthToken[0], AUTH_TOKEN_SIZE).toString())
+		    .detail("ComputedCiptherTextAuthToken", computedCipherTextAuthToken.toString());
+		throw encrypt_header_authtoken_mismatch();
+	}
+}
+
+void DecryptBlobCipherAes256Ctr::verifyAuthTokens(const uint8_t* ciphertext,
+                                                  const int ciphertextLen,
+                                                  const BlobCipherEncryptHeader& header,
+                                                  uint8_t* buff,
+                                                  Arena& arena) {
 	// validate header flag sanity
 	if (header.flags.headerVersion != EncryptBlobCipherAes265Ctr::ENCRYPT_HEADER_VERSION ||
-	    header.flags.encryptMode != BLOB_CIPHER_ENCRYPT_MODE_AES_256_CTR) {
+	    header.flags.encryptMode != ENCRYPT_CIPHER_MODE_AES_256_CTR ||
+	    !(header.flags.authTokenMode == ENCRYPT_HEADER_AUTH_TOKEN_MODE_SINGLE ||
+	      header.flags.authTokenMode == ENCRYPT_HEADER_AUTH_TOKEN_MODE_MULTI)) {
 		TraceEvent("VerifyEncryptBlobHeader")
 		    .detail("HeaderVersion", header.flags.headerVersion)
 		    .detail("HeaderMode", header.flags.encryptMode)
 		    .detail("ExpectedVersion", EncryptBlobCipherAes265Ctr::ENCRYPT_HEADER_VERSION)
-		    .detail("ExpectedMode", BLOB_CIPHER_ENCRYPT_MODE_AES_256_CTR);
+		    .detail("EncryptCipherMode", header.flags.encryptMode)
+		    .detail("ExpectedCipherMode", ENCRYPT_CIPHER_MODE_AES_256_CTR)
+		    .detail("EncryptHeaderAuthTokenMode", header.flags.authTokenMode);
 		throw encrypt_header_metadata_mismatch();
 	}
 
-	// encrypted byte checksum sanity; protection against data bit-rot/flip.
-	BlobCipherChecksum computed = computeEncryptChecksum(ciphertext, ciphertextLen, header.salt, arena);
-	if (computed != header.ciphertextChecksum) {
-		TraceEvent("VerifyEncryptBlobHeader_ChecksumMismatch")
-		    .detail("HeaderVersion", header.flags.headerVersion)
-		    .detail("HeaderMode", header.flags.encryptMode)
-		    .detail("CiphertextChecksum", header.ciphertextChecksum)
-		    .detail("ComputedCiphertextChecksum", computed);
-		throw encrypt_header_checksum_mismatch();
+	if (header.flags.authTokenMode == ENCRYPT_HEADER_AUTH_TOKEN_MODE_SINGLE) {
+		verifyHeaderSingleAuthToken(ciphertext, ciphertextLen, header, buff, arena);
+	} else {
+		ASSERT_EQ(header.flags.authTokenMode, ENCRYPT_HEADER_AUTH_TOKEN_MODE_MULTI);
+		verifyHeaderMultiAuthToken(ciphertext, ciphertextLen, header, buff, arena);
 	}
+
+	authTokensValidationDone = true;
 }
 
 Reference<EncryptBuf> DecryptBlobCipherAes256Ctr::decrypt(const uint8_t* ciphertext,
@@ -378,23 +519,29 @@ Reference<EncryptBuf> DecryptBlobCipherAes256Ctr::decrypt(const uint8_t* ciphert
                                                           Arena& arena) {
 	TEST(true); // Decrypting data with BlobCipher
 
-	verifyEncryptBlobHeader(ciphertext, ciphertextLen, header, arena);
+	const int allocSize = header.flags.authTokenMode == ENCRYPT_HEADER_AUTH_TOKEN_MODE_SINGLE
+	                          ? ciphertextLen + AES_BLOCK_SIZE + sizeof(BlobCipherEncryptHeader)
+	                          : ciphertextLen + AES_BLOCK_SIZE;
+	Reference<EncryptBuf> decrypted = makeReference<EncryptBuf>(allocSize, arena);
 
-	Reference<EncryptBuf> decrypted = makeReference<EncryptBuf>(ciphertextLen + AES_BLOCK_SIZE, arena);
+	verifyAuthTokens(ciphertext, ciphertextLen, header, decrypted->begin(), arena);
+
+	ASSERT(authTokensValidationDone);
+
 	uint8_t* plaintext = decrypted->begin();
 	int bytesDecrypted{ 0 };
 	if (!EVP_DecryptUpdate(ctx, plaintext, &bytesDecrypted, ciphertext, ciphertextLen)) {
 		TraceEvent("Decrypt_UpdateFailed")
-		    .detail("BaseCipherId", header.baseCipherId)
-		    .detail("EncryptDomainId", header.encryptDomainId);
+		    .detail("BaseCipherId", header.cipherTextDetails.baseCipherId)
+		    .detail("EncryptDomainId", header.cipherTextDetails.encryptDomainId);
 		throw encrypt_ops_error();
 	}
 
 	int finalBlobBytes{ 0 };
 	if (EVP_DecryptFinal_ex(ctx, plaintext + bytesDecrypted, &finalBlobBytes) <= 0) {
 		TraceEvent("Decrypt_FinalFailed")
-		    .detail("BaseCipherId", header.baseCipherId)
-		    .detail("EncryptDomainId", header.encryptDomainId);
+		    .detail("BaseCipherId", header.cipherTextDetails.baseCipherId)
+		    .detail("EncryptDomainId", header.cipherTextDetails.encryptDomainId);
 		throw encrypt_ops_error();
 	}
 
@@ -462,32 +609,32 @@ TEST_CASE("flow/BlobCipher") {
 	// Construct a dummy External Key Manager representation and populate with some keys
 	class BaseCipher : public ReferenceCounted<BaseCipher>, NonCopyable {
 	public:
-		BlobCipherDomainId domainId;
+		EncryptCipherDomainId domainId;
 		int len;
-		BlobCipherBaseKeyId keyId;
+		EncryptCipherBaseKeyId keyId;
 		std::unique_ptr<uint8_t[]> key;
 
-		BaseCipher(const BlobCipherDomainId& dId, const BlobCipherBaseKeyId& kId)
+		BaseCipher(const EncryptCipherDomainId& dId, const EncryptCipherBaseKeyId& kId)
 		  : domainId(dId), len(deterministicRandom()->randomInt(AES_256_KEY_LENGTH / 2, AES_256_KEY_LENGTH + 1)),
 		    keyId(kId), key(std::make_unique<uint8_t[]>(len)) {
 			generateRandomData(key.get(), len);
 		}
 	};
 
-	using BaseKeyMap = std::unordered_map<BlobCipherBaseKeyId, Reference<BaseCipher>>;
-	using DomainKeyMap = std::unordered_map<BlobCipherDomainId, BaseKeyMap>;
+	using BaseKeyMap = std::unordered_map<EncryptCipherBaseKeyId, Reference<BaseCipher>>;
+	using DomainKeyMap = std::unordered_map<EncryptCipherDomainId, BaseKeyMap>;
 	DomainKeyMap domainKeyMap;
-	const BlobCipherDomainId minDomainId = 1;
-	const BlobCipherDomainId maxDomainId = deterministicRandom()->randomInt(minDomainId, minDomainId + 10) + 5;
-	const BlobCipherBaseKeyId minBaseCipherKeyId = 100;
-	const BlobCipherBaseKeyId maxBaseCipherKeyId =
+	const EncryptCipherDomainId minDomainId = 1;
+	const EncryptCipherDomainId maxDomainId = deterministicRandom()->randomInt(minDomainId, minDomainId + 10) + 5;
+	const EncryptCipherBaseKeyId minBaseCipherKeyId = 100;
+	const EncryptCipherBaseKeyId maxBaseCipherKeyId =
 	    deterministicRandom()->randomInt(minBaseCipherKeyId, minBaseCipherKeyId + 50) + 15;
 	for (int dId = minDomainId; dId <= maxDomainId; dId++) {
 		for (int kId = minBaseCipherKeyId; kId <= maxBaseCipherKeyId; kId++) {
 			domainKeyMap[dId].emplace(kId, makeReference<BaseCipher>(dId, kId));
 		}
 	}
-	ASSERT(domainKeyMap.size() == maxDomainId);
+	ASSERT_EQ(domainKeyMap.size(), maxDomainId);
 
 	// insert BlobCipher keys into BlobCipherKeyCache map and validate
 	TraceEvent("BlobCipherTest_InsertKeys").log();
@@ -500,6 +647,11 @@ TEST_CASE("flow/BlobCipher") {
 			    baseCipher->domainId, baseCipher->keyId, baseCipher->key.get(), baseCipher->len);
 		}
 	}
+	// insert EncryptHeader BlobCipher key
+	Reference<BaseCipher> headerBaseCipher = makeReference<BaseCipher>(ENCRYPT_HEADER_DOMAIN_ID, 1);
+	cipherKeyCache.insertCipherKey(
+	    headerBaseCipher->domainId, headerBaseCipher->keyId, headerBaseCipher->key.get(), headerBaseCipher->len);
+
 	TraceEvent("BlobCipherTest_InsertKeysDone").log();
 
 	// validate the cipherKey lookups work as desired
@@ -509,13 +661,13 @@ TEST_CASE("flow/BlobCipher") {
 			Reference<BlobCipherKey> cipherKey = cipherKeyCache.getCipherKey(baseCipher->domainId, baseCipher->keyId);
 			ASSERT(cipherKey.isValid());
 			// validate common cipher properties - domainId, baseCipherId, baseCipherLen, rawBaseCipher
-			ASSERT(cipherKey->getBaseCipherId() == baseCipher->keyId);
-			ASSERT(cipherKey->getDomainId() == baseCipher->domainId);
-			ASSERT(cipherKey->getBaseCipherLen() == baseCipher->len);
+			ASSERT_EQ(cipherKey->getBaseCipherId(), baseCipher->keyId);
+			ASSERT_EQ(cipherKey->getDomainId(), baseCipher->domainId);
+			ASSERT_EQ(cipherKey->getBaseCipherLen(), baseCipher->len);
 			// ensure that baseCipher matches with the cached information
-			ASSERT(std::memcmp(cipherKey->rawBaseCipher(), baseCipher->key.get(), cipherKey->getBaseCipherLen()) == 0);
+			ASSERT_EQ(std::memcmp(cipherKey->rawBaseCipher(), baseCipher->key.get(), cipherKey->getBaseCipherLen()), 0);
 			// validate the encryption derivation
-			ASSERT(std::memcmp(cipherKey->rawCipher(), baseCipher->key.get(), cipherKey->getBaseCipherLen()) != 0);
+			ASSERT_NE(std::memcmp(cipherKey->rawCipher(), baseCipher->key.get(), cipherKey->getBaseCipherLen()), 0);
 		}
 	}
 	TraceEvent("BlobCipherTest_LooksupDone").log();
@@ -548,6 +700,7 @@ TEST_CASE("flow/BlobCipher") {
 
 	// Validate Encyrption ops
 	Reference<BlobCipherKey> cipherKey = cipherKeyCache.getLatestCipherKey(minDomainId);
+	Reference<BlobCipherKey> headerCipherKey = cipherKeyCache.getLatestCipherKey(ENCRYPT_HEADER_DOMAIN_ID);
 	const int bufLen = deterministicRandom()->randomInt(786, 2127) + 512;
 	uint8_t orgData[bufLen];
 	generateRandomData(&orgData[0], bufLen);
@@ -556,68 +709,165 @@ TEST_CASE("flow/BlobCipher") {
 	uint8_t iv[AES_256_IV_LENGTH];
 	generateRandomData(&iv[0], AES_256_IV_LENGTH);
 
-	// validate basic encrypt followed by decrypt operation
-	EncryptBlobCipherAes265Ctr encryptor(cipherKey, iv, AES_256_IV_LENGTH);
-	BlobCipherEncryptHeader header;
-	Reference<EncryptBuf> encrypted = encryptor.encrypt(&orgData[0], bufLen, &header, arena);
+	// validate basic encrypt followed by decrypt operation for SINGLE_AUTH_TOKEN_MODE
+	{
+		EncryptBlobCipherAes265Ctr encryptor(
+		    cipherKey, headerCipherKey, iv, AES_256_IV_LENGTH, ENCRYPT_HEADER_AUTH_TOKEN_MODE_SINGLE);
+		BlobCipherEncryptHeader header;
+		Reference<EncryptBuf> encrypted = encryptor.encrypt(&orgData[0], bufLen, &header, arena);
 
-	ASSERT(encrypted->getLogicalSize() == bufLen);
-	ASSERT(memcmp(&orgData[0], encrypted->begin(), bufLen) != 0);
-	ASSERT(header.flags.headerVersion == EncryptBlobCipherAes265Ctr::ENCRYPT_HEADER_VERSION);
-	ASSERT(header.flags.encryptMode == BLOB_CIPHER_ENCRYPT_MODE_AES_256_CTR);
+		ASSERT_EQ(encrypted->getLogicalSize(), bufLen);
+		ASSERT_NE(memcmp(&orgData[0], encrypted->begin(), bufLen), 0);
+		ASSERT_EQ(header.flags.headerVersion, EncryptBlobCipherAes265Ctr::ENCRYPT_HEADER_VERSION);
+		ASSERT_EQ(header.flags.encryptMode, ENCRYPT_CIPHER_MODE_AES_256_CTR);
 
-	TraceEvent("BlobCipherTest_EncryptDone")
-	    .detail("HeaderVersion", header.flags.headerVersion)
-	    .detail("HeaderEncryptMode", header.flags.encryptMode)
-	    .detail("DomainId", header.encryptDomainId)
-	    .detail("BaseCipherId", header.baseCipherId)
-	    .detail("HeaderChecksum", header.ciphertextChecksum);
+		TraceEvent("BlobCipherTest_EncryptDone")
+		    .detail("HeaderVersion", header.flags.headerVersion)
+		    .detail("HeaderEncryptMode", header.flags.encryptMode)
+		    .detail("DomainId", header.cipherTextDetails.encryptDomainId)
+		    .detail("BaseCipherId", header.cipherTextDetails.baseCipherId)
+		    .detail("HeaderAuthToken",
+		            StringRef(arena, &header.singleAuthToken.authToken[0], AUTH_TOKEN_SIZE).toString());
 
-	Reference<BlobCipherKey> encyrptKey = cipherKeyCache.getCipherKey(header.encryptDomainId, header.baseCipherId);
-	ASSERT(encyrptKey->isEqual(cipherKey));
-	DecryptBlobCipherAes256Ctr decryptor(encyrptKey, &header.iv[0]);
-	Reference<EncryptBuf> decrypted = decryptor.decrypt(encrypted->begin(), bufLen, header, arena);
+		Reference<BlobCipherKey> tCipherKeyKey = cipherKeyCache.getCipherKey(header.cipherTextDetails.encryptDomainId,
+		                                                                     header.cipherTextDetails.baseCipherId);
+		Reference<BlobCipherKey> hCipherKey = cipherKeyCache.getCipherKey(header.cipherHeaderDetails.encryptDomainId,
+		                                                                  header.cipherHeaderDetails.baseCipherId);
+		ASSERT(tCipherKeyKey->isEqual(cipherKey));
+		DecryptBlobCipherAes256Ctr decryptor(tCipherKeyKey, hCipherKey, &header.cipherTextDetails.iv[0]);
+		Reference<EncryptBuf> decrypted = decryptor.decrypt(encrypted->begin(), bufLen, header, arena);
 
-	ASSERT(decrypted->getLogicalSize() == bufLen);
-	ASSERT(memcmp(decrypted->begin(), &orgData[0], bufLen) == 0);
+		ASSERT_EQ(decrypted->getLogicalSize(), bufLen);
+		ASSERT_EQ(memcmp(decrypted->begin(), &orgData[0], bufLen), 0);
 
-	TraceEvent("BlobCipherTest_DecryptDone").log();
+		TraceEvent("BlobCipherTest_DecryptDone").log();
 
-	// induce encryption header corruption - headerVersion corrupted
-	header.flags.headerVersion += 1;
-	try {
-		decrypted = decryptor.decrypt(encrypted->begin(), bufLen, header, arena);
-	} catch (Error& e) {
-		if (e.code() != error_code_encrypt_header_metadata_mismatch) {
-			throw;
+		// induce encryption header corruption - headerVersion corrupted
+		header.flags.headerVersion += 1;
+		try {
+			decrypted = decryptor.decrypt(encrypted->begin(), bufLen, header, arena);
+		} catch (Error& e) {
+			if (e.code() != error_code_encrypt_header_metadata_mismatch) {
+				throw;
+			}
+			header.flags.headerVersion -= 1;
 		}
-		header.flags.headerVersion -= 1;
+
+		// induce encryption header corruption - encryptionMode corrupted
+		header.flags.encryptMode += 1;
+		try {
+			decrypted = decryptor.decrypt(encrypted->begin(), bufLen, header, arena);
+		} catch (Error& e) {
+			if (e.code() != error_code_encrypt_header_metadata_mismatch) {
+				throw;
+			}
+			header.flags.encryptMode -= 1;
+		}
+
+		// induce encryption header corruption - authToken mismatch
+		BlobCipherEncryptHeader headerCopy;
+		memcpy(reinterpret_cast<uint8_t*>(&headerCopy),
+		       reinterpret_cast<const uint8_t*>(&header),
+		       sizeof(BlobCipherEncryptHeader));
+		int hIdx = deterministicRandom()->randomInt(0, AUTH_TOKEN_SIZE - 1);
+		headerCopy.singleAuthToken.authToken[hIdx] += 1;
+		try {
+			decrypted = decryptor.decrypt(encrypted->begin(), bufLen, header, arena);
+		} catch (Error& e) {
+			if (e.code() != error_code_encrypt_header_authtoken_mismatch) {
+				throw;
+			}
+		}
 	}
 
-	// induce encryption header corruption - encryptionMode corrupted
-	header.flags.encryptMode += 1;
-	try {
-		decrypted = decryptor.decrypt(encrypted->begin(), bufLen, header, arena);
-	} catch (Error& e) {
-		if (e.code() != error_code_encrypt_header_metadata_mismatch) {
-			throw;
-		}
-		header.flags.encryptMode -= 1;
-	}
+	// validate basic encrypt followed by decrypt operation for MULTI_AUTH_TOKEN_MODE
+	{
+		EncryptBlobCipherAes265Ctr encryptor(
+		    cipherKey, headerCipherKey, iv, AES_256_IV_LENGTH, ENCRYPT_HEADER_AUTH_TOKEN_MODE_MULTI);
+		BlobCipherEncryptHeader header;
+		Reference<EncryptBuf> encrypted = encryptor.encrypt(&orgData[0], bufLen, &header, arena);
 
-	// induce encryption header corruption - checksum mismatch
-	header.ciphertextChecksum += 1;
-	try {
-		decrypted = decryptor.decrypt(encrypted->begin(), bufLen, header, arena);
-	} catch (Error& e) {
-		if (e.code() != error_code_encrypt_header_checksum_mismatch) {
-			throw;
+		ASSERT_EQ(encrypted->getLogicalSize(), bufLen);
+		ASSERT_NE(memcmp(&orgData[0], encrypted->begin(), bufLen), 0);
+		ASSERT_EQ(header.flags.headerVersion, EncryptBlobCipherAes265Ctr::ENCRYPT_HEADER_VERSION);
+		ASSERT_EQ(header.flags.encryptMode, ENCRYPT_CIPHER_MODE_AES_256_CTR);
+
+		TraceEvent("BlobCipherTest_EncryptDone")
+		    .detail("HeaderVersion", header.flags.headerVersion)
+		    .detail("HeaderEncryptMode", header.flags.encryptMode)
+		    .detail("DomainId", header.cipherTextDetails.encryptDomainId)
+		    .detail("BaseCipherId", header.cipherTextDetails.baseCipherId)
+		    .detail("HeaderAuthToken",
+		            StringRef(arena, &header.singleAuthToken.authToken[0], AUTH_TOKEN_SIZE).toString());
+
+		Reference<BlobCipherKey> tCipherKey = cipherKeyCache.getCipherKey(header.cipherTextDetails.encryptDomainId,
+		                                                                  header.cipherTextDetails.baseCipherId);
+		Reference<BlobCipherKey> hCipherKey = cipherKeyCache.getCipherKey(header.cipherHeaderDetails.encryptDomainId,
+		                                                                  header.cipherHeaderDetails.baseCipherId);
+
+		ASSERT(tCipherKey->isEqual(cipherKey));
+		DecryptBlobCipherAes256Ctr decryptor(tCipherKey, hCipherKey, &header.cipherTextDetails.iv[0]);
+		Reference<EncryptBuf> decrypted = decryptor.decrypt(encrypted->begin(), bufLen, header, arena);
+
+		ASSERT_EQ(decrypted->getLogicalSize(), bufLen);
+		ASSERT_EQ(memcmp(decrypted->begin(), &orgData[0], bufLen), 0);
+
+		TraceEvent("BlobCipherTest_DecryptDone").log();
+
+		// induce encryption header corruption - headerVersion corrupted
+		header.flags.headerVersion += 1;
+		try {
+			decrypted = decryptor.decrypt(encrypted->begin(), bufLen, header, arena);
+		} catch (Error& e) {
+			if (e.code() != error_code_encrypt_header_metadata_mismatch) {
+				throw;
+			}
+			header.flags.headerVersion -= 1;
 		}
-		header.ciphertextChecksum -= 1;
+
+		// induce encryption header corruption - encryptionMode corrupted
+		header.flags.encryptMode += 1;
+		try {
+			decrypted = decryptor.decrypt(encrypted->begin(), bufLen, header, arena);
+		} catch (Error& e) {
+			if (e.code() != error_code_encrypt_header_metadata_mismatch) {
+				throw;
+			}
+			header.flags.encryptMode -= 1;
+		}
+
+		// induce encryption header corruption - cipherText authToken mismatch
+		BlobCipherEncryptHeader headerCopy;
+		memcpy(reinterpret_cast<uint8_t*>(&headerCopy),
+		       reinterpret_cast<const uint8_t*>(&header),
+		       sizeof(BlobCipherEncryptHeader));
+		int hIdx = deterministicRandom()->randomInt(0, AUTH_TOKEN_SIZE - 1);
+		headerCopy.multiAuthTokens.cipherTextAuthToken[hIdx] += 1;
+		try {
+			decrypted = decryptor.decrypt(encrypted->begin(), bufLen, headerCopy, arena);
+		} catch (Error& e) {
+			if (e.code() != error_code_encrypt_header_authtoken_mismatch) {
+				throw;
+			}
+		}
+
+		// induce encryption header corruption - header authToken mismatch
+		memcpy(reinterpret_cast<uint8_t*>(&headerCopy),
+		       reinterpret_cast<const uint8_t*>(&header),
+		       sizeof(BlobCipherEncryptHeader));
+		hIdx = deterministicRandom()->randomInt(0, AUTH_TOKEN_SIZE - 1);
+		headerCopy.multiAuthTokens.headerAuthToken[hIdx] += 1;
+		try {
+			decrypted = decryptor.decrypt(encrypted->begin(), bufLen, headerCopy, arena);
+		} catch (Error& e) {
+			if (e.code() != error_code_encrypt_header_authtoken_mismatch) {
+				throw;
+			}
+		}
 	}
 
 	// Validate dropping encyrptDomainId cached keys
-	const BlobCipherDomainId candidate = deterministicRandom()->randomInt(minDomainId, maxDomainId);
+	const EncryptCipherDomainId candidate = deterministicRandom()->randomInt(minDomainId, maxDomainId);
 	cipherKeyCache.resetEncyrptDomainId(candidate);
 	std::vector<Reference<BlobCipherKey>> cachedKeys = cipherKeyCache.getAllCiphers(candidate);
 	ASSERT(cachedKeys.empty());
@@ -633,20 +883,16 @@ TEST_CASE("flow/BlobCipher") {
 	return Void();
 }
 
-BlobCipherChecksum computeEncryptChecksum(const uint8_t* payload,
-                                          const int payloadLen,
-                                          const BlobCipherRandomSalt& salt,
-                                          Arena& arena) {
-	// FIPS compliance recommendation is to leverage cryptographic digest mechanism to generate checksum
-	// Leverage HMAC_SHA256 using header.randomSalt as the initialization 'key' for the hmac digest.
-
-	HmacSha256DigestGen hmacGenerator((const uint8_t*)&salt, sizeof(salt));
+StringRef computeAuthToken(const uint8_t* payload,
+                           const int payloadLen,
+                           const uint8_t* key,
+                           const int keyLen,
+                           Arena& arena) {
+	HmacSha256DigestGen hmacGenerator(key, keyLen);
 	StringRef digest = hmacGenerator.digest(payload, payloadLen, arena);
-	ASSERT(digest.size() >= sizeof(BlobCipherChecksum));
 
-	BlobCipherChecksum checksum;
-	memcpy((uint8_t*)&checksum, digest.begin(), sizeof(BlobCipherChecksum));
-	return checksum;
+	ASSERT_GE(digest.size(), AUTH_TOKEN_SIZE);
+	return digest;
 }
 
 #endif // ENCRYPTION_ENABLED

--- a/flow/BlobCipher.h
+++ b/flow/BlobCipher.h
@@ -33,6 +33,7 @@
 #if ENCRYPTION_ENABLED
 
 #include "flow/Arena.h"
+#include "flow/EncryptUtils.h"
 #include "flow/FastRef.h"
 #include "flow/flow.h"
 #include "flow/xxhash.h"
@@ -45,15 +46,6 @@
 
 #define AES_256_KEY_LENGTH 32
 #define AES_256_IV_LENGTH 16
-#define INVALID_DOMAIN_ID 0
-#define INVALID_CIPHER_KEY_ID 0
-
-using BlobCipherDomainId = uint64_t;
-using BlobCipherRandomSalt = uint64_t;
-using BlobCipherBaseKeyId = uint64_t;
-using BlobCipherChecksum = uint64_t;
-
-typedef enum { BLOB_CIPHER_ENCRYPT_MODE_NONE = 0, BLOB_CIPHER_ENCRYPT_MODE_AES_256_CTR = 1 } BlockCipherEncryptMode;
 
 // Encryption operations buffer management
 // Approach limits number of copies needed during encryption or decryption operations.
@@ -99,24 +91,64 @@ typedef struct BlobCipherEncryptHeader {
 			              // length. ALWAYS THE FIRST HEADER ELEMENT.
 			uint8_t headerVersion{};
 			uint8_t encryptMode{};
-			uint8_t _reserved[5]{};
+			EncryptAuthTokenMode authTokenMode{};
+			uint8_t _reserved[4]{};
 		} flags;
 		uint64_t _padding{};
 	};
-	// Encyrption domain boundary identifier.
-	BlobCipherDomainId encryptDomainId{};
-	// BaseCipher encryption key identifier
-	BlobCipherBaseKeyId baseCipherId{};
-	// Random salt
-	BlobCipherRandomSalt salt{};
-	// Checksum of the encrypted buffer. It protects against 'tampering' of ciphertext as well 'bit rots/flips'.
-	BlobCipherChecksum ciphertextChecksum{};
-	// Initialization vector used to encrypt the payload.
-	uint8_t iv[AES_256_IV_LENGTH];
+
+	struct {
+		// Encryption domainId for the header
+		EncryptCipherDomainId encryptDomainId{};
+		// BaseCipher encryption key identifier.
+		EncryptCipherBaseKeyId baseCipherId{};
+	} cipherHeaderDetails;
+
+	// Cipher text encryption information
+	struct {
+		// Encyrption domain boundary identifier.
+		EncryptCipherDomainId encryptDomainId{};
+		// BaseCipher encryption key identifier
+		EncryptCipherBaseKeyId baseCipherId{};
+		// Random salt
+		EncryptCipherRandomSalt salt{};
+		// Initialization vector used to encrypt the payload.
+		uint8_t iv[AES_256_IV_LENGTH];
+	} cipherTextDetails;
+
+	// Encryption header is stored as plaintext on a persistent storage to assist reconstruction of cipher-key(s) for
+	// reads. FIPS compliance recommendation is to leverage cryptographic digest mechanism to generate 'authentication
+	// token' (crypto-secure) to protect against malicious tampering and/or bit rot/flip scenarios.
+
+	union {
+		// Encryption header support two modes of generation 'authentication tokens':
+		// 1) SingleAuthTokenMode: the scheme generates single crypto-secrure auth token to protect {cipherText +
+		// header} payload. Scheme is geared towards optimizing cost due to crypto-secure auth-token generation,
+		// however, on decryption client needs to be read 'header' + 'encrypted-buffer' to validate the 'auth-token'.
+		// The scheme is ideal for usecases where payload represented by the encryptionHeader is not large and it is
+		// desirable to minimize CPU/latency penalty due to crypto-secure ops, such as: CommitProxies encrypted inline
+		// transactions, StorageServer encrypting pages etc. 2) MultiAuthTokenMode: Scheme generates separate authTokens
+		// for 'encrypted buffer' & 'encryption-header'. The scheme is ideal where payload represented by
+		// encryptionHeader is large enough such that it is desirable to optimize cost of upfront reading full
+		// 'encrypted buffer', compared to reading only encryptionHeader and ensuring its sanity; for instance:
+		// backup-files.
+
+		struct {
+			// Cipher text authentication token
+			uint8_t cipherTextAuthToken[AUTH_TOKEN_SIZE]{};
+			uint8_t headerAuthToken[AUTH_TOKEN_SIZE]{};
+		} multiAuthTokens;
+		struct {
+			uint8_t authToken[AUTH_TOKEN_SIZE]{};
+			uint8_t _reserved[AUTH_TOKEN_SIZE]{};
+		} singleAuthToken;
+	};
 
 	BlobCipherEncryptHeader();
 } BlobCipherEncryptHeader;
 #pragma pack(pop)
+
+// static_assert(sizeof(BlobCipherEncryptHeader) == sizeof(uint64_t) + , "FDBKeyValue / KeyValueRef size mismatch");
 
 // This interface is in-memory representation of CipherKey used for encryption/decryption information.
 // It caches base encryption key properties as well as caches the 'derived encryption' key obtained by applying
@@ -124,16 +156,16 @@ typedef struct BlobCipherEncryptHeader {
 
 class BlobCipherKey : public ReferenceCounted<BlobCipherKey>, NonCopyable {
 public:
-	BlobCipherKey(const BlobCipherDomainId& domainId,
-	              const BlobCipherBaseKeyId& baseCiphId,
+	BlobCipherKey(const EncryptCipherDomainId& domainId,
+	              const EncryptCipherBaseKeyId& baseCiphId,
 	              const uint8_t* baseCiph,
 	              int baseCiphLen);
 
 	uint8_t* data() const { return cipher.get(); }
 	uint64_t getCreationTime() const { return creationTime; }
-	BlobCipherDomainId getDomainId() const { return encryptDomainId; }
-	BlobCipherRandomSalt getSalt() const { return randomSalt; }
-	BlobCipherBaseKeyId getBaseCipherId() const { return baseCipherId; }
+	EncryptCipherDomainId getDomainId() const { return encryptDomainId; }
+	EncryptCipherRandomSalt getSalt() const { return randomSalt; }
+	EncryptCipherBaseKeyId getBaseCipherId() const { return baseCipherId; }
 	int getBaseCipherLen() const { return baseCipherLen; }
 	uint8_t* rawCipher() const { return cipher.get(); }
 	uint8_t* rawBaseCipher() const { return baseCipher.get(); }
@@ -147,23 +179,23 @@ public:
 
 private:
 	// Encryption domain boundary identifier
-	BlobCipherDomainId encryptDomainId;
+	EncryptCipherDomainId encryptDomainId;
 	// Base encryption cipher key properties
 	std::unique_ptr<uint8_t[]> baseCipher;
 	int baseCipherLen;
-	BlobCipherBaseKeyId baseCipherId;
+	EncryptCipherBaseKeyId baseCipherId;
 	// Random salt used for encryption cipher key derivation
-	BlobCipherRandomSalt randomSalt;
+	EncryptCipherRandomSalt randomSalt;
 	// Creation timestamp for the derived encryption cipher key
 	uint64_t creationTime;
 	// Derived encryption cipher key
 	std::unique_ptr<uint8_t[]> cipher;
 
-	void initKey(const BlobCipherDomainId& domainId,
+	void initKey(const EncryptCipherDomainId& domainId,
 	             const uint8_t* baseCiph,
 	             int baseCiphLen,
-	             const BlobCipherBaseKeyId& baseCiphId,
-	             const BlobCipherRandomSalt& salt);
+	             const EncryptCipherBaseKeyId& baseCiphId,
+	             const EncryptCipherRandomSalt& salt);
 	void applyHmacSha256Derivation();
 };
 
@@ -190,37 +222,45 @@ private:
 // required encryption key, however, CPs/SSs cache-miss would result in RPC to
 // EncryptKeyServer to refresh the desired encryption key.
 
-using BlobCipherKeyIdCacheMap = std::unordered_map<BlobCipherBaseKeyId, Reference<BlobCipherKey>>;
-using BlobCipherKeyIdCacheMapCItr = std::unordered_map<BlobCipherBaseKeyId, Reference<BlobCipherKey>>::const_iterator;
+using BlobCipherKeyIdCacheMap = std::unordered_map<EncryptCipherBaseKeyId, Reference<BlobCipherKey>>;
+using BlobCipherKeyIdCacheMapCItr =
+    std::unordered_map<EncryptCipherBaseKeyId, Reference<BlobCipherKey>>::const_iterator;
 
 struct BlobCipherKeyIdCache : ReferenceCounted<BlobCipherKeyIdCache> {
 public:
 	BlobCipherKeyIdCache();
-	explicit BlobCipherKeyIdCache(BlobCipherDomainId dId);
+	explicit BlobCipherKeyIdCache(EncryptCipherDomainId dId);
 
 	// API returns the last inserted cipherKey.
 	// If none exists, 'encrypt_key_not_found' is thrown.
+
 	Reference<BlobCipherKey> getLatestCipherKey();
+
 	// API returns cipherKey corresponding to input 'baseCipherKeyId'.
 	// If none exists, 'encrypt_key_not_found' is thrown.
-	Reference<BlobCipherKey> getCipherByBaseCipherId(BlobCipherBaseKeyId baseCipherKeyId);
+
+	Reference<BlobCipherKey> getCipherByBaseCipherId(EncryptCipherBaseKeyId baseCipherKeyId);
+
 	// API enables inserting base encryption cipher details to the BlobCipherKeyIdCache.
 	// Given cipherKeys are immutable, attempting to re-insert same 'identical' cipherKey
 	// is treated as a NOP (success), however, an attempt to update cipherKey would throw
 	// 'encrypt_update_cipher' exception.
-	void insertBaseCipherKey(BlobCipherBaseKeyId baseCipherId, const uint8_t* baseCipher, int baseCipherLen);
+
+	void insertBaseCipherKey(EncryptCipherBaseKeyId baseCipherId, const uint8_t* baseCipher, int baseCipherLen);
+
 	// API cleanup the cache by dropping all cached cipherKeys
 	void cleanup();
+
 	// API returns list of all 'cached' cipherKeys
 	std::vector<Reference<BlobCipherKey>> getAllCipherKeys();
 
 private:
-	BlobCipherDomainId domainId;
+	EncryptCipherDomainId domainId;
 	BlobCipherKeyIdCacheMap keyIdCache;
-	BlobCipherBaseKeyId latestBaseCipherKeyId;
+	EncryptCipherBaseKeyId latestBaseCipherKeyId;
 };
 
-using BlobCipherDomainCacheMap = std::unordered_map<BlobCipherDomainId, Reference<BlobCipherKeyIdCache>>;
+using BlobCipherDomainCacheMap = std::unordered_map<EncryptCipherDomainId, Reference<BlobCipherKeyIdCache>>;
 
 class BlobCipherKeyCache : NonCopyable {
 public:
@@ -228,21 +268,28 @@ public:
 	// The cipherKeys are indexed using 'baseCipherId', given cipherKeys are immutable,
 	// attempting to re-insert same 'identical' cipherKey is treated as a NOP (success),
 	// however, an attempt to update cipherKey would throw 'encrypt_update_cipher' exception.
-	void insertCipherKey(const BlobCipherDomainId& domainId,
-	                     const BlobCipherBaseKeyId& baseCipherId,
+
+	void insertCipherKey(const EncryptCipherDomainId& domainId,
+	                     const EncryptCipherBaseKeyId& baseCipherId,
 	                     const uint8_t* baseCipher,
 	                     int baseCipherLen);
 	// API returns the last insert cipherKey for a given encyryption domain Id.
 	// If none exists, it would throw 'encrypt_key_not_found' exception.
-	Reference<BlobCipherKey> getLatestCipherKey(const BlobCipherDomainId& domainId);
+
+	Reference<BlobCipherKey> getLatestCipherKey(const EncryptCipherDomainId& domainId);
+
 	// API returns cipherKey corresponding to {encryptionDomainId, baseCipherId} tuple.
 	// If none exists, it would throw 'encrypt_key_not_found' exception.
-	Reference<BlobCipherKey> getCipherKey(const BlobCipherDomainId& domainId, const BlobCipherBaseKeyId& baseCipherId);
+
+	Reference<BlobCipherKey> getCipherKey(const EncryptCipherDomainId& domainId,
+	                                      const EncryptCipherBaseKeyId& baseCipherId);
 	// API returns point in time list of all 'cached' cipherKeys for a given encryption domainId.
-	std::vector<Reference<BlobCipherKey>> getAllCiphers(const BlobCipherDomainId& domainId);
+	std::vector<Reference<BlobCipherKey>> getAllCiphers(const EncryptCipherDomainId& domainId);
+
 	// API enables dropping all 'cached' cipherKeys for a given encryption domain Id.
 	// Useful to cleanup cache if an encryption domain gets removed/destroyed etc.
-	void resetEncyrptDomainId(const BlobCipherDomainId domainId);
+
+	void resetEncyrptDomainId(const EncryptCipherDomainId domainId);
 
 	static BlobCipherKeyCache& getInstance() {
 		static BlobCipherKeyCache instance;
@@ -262,14 +309,19 @@ private:
 // This interface enables data block encryption. An invocation to encrypt() will
 // do two things:
 // 1) generate encrypted ciphertext for given plaintext input.
-// 2) generate BlobCipherEncryptHeader (including the 'header checksum') and persit for decryption on reads.
+// 2) generate BlobCipherEncryptHeader (including the 'header authTokens') and persit for decryption on reads.
 
 class EncryptBlobCipherAes265Ctr final : NonCopyable, public ReferenceCounted<EncryptBlobCipherAes265Ctr> {
 public:
 	static constexpr uint8_t ENCRYPT_HEADER_VERSION = 1;
 
-	EncryptBlobCipherAes265Ctr(Reference<BlobCipherKey> key, const uint8_t* iv, const int ivLen);
+	EncryptBlobCipherAes265Ctr(Reference<BlobCipherKey> tCipherKey,
+	                           Reference<BlobCipherKey> hCipherKey,
+	                           const uint8_t* iv,
+	                           const int ivLen,
+	                           const EncryptAuthTokenMode mode);
 	~EncryptBlobCipherAes265Ctr();
+
 	Reference<EncryptBuf> encrypt(const uint8_t* plaintext,
 	                              const int plaintextLen,
 	                              BlobCipherEncryptHeader* header,
@@ -277,7 +329,9 @@ public:
 
 private:
 	EVP_CIPHER_CTX* ctx;
-	Reference<BlobCipherKey> cipherKey;
+	Reference<BlobCipherKey> textCipherKey;
+	Reference<BlobCipherKey> headerCipherKey;
+	EncryptAuthTokenMode authTokenMode;
 	uint8_t iv[AES_256_IV_LENGTH];
 };
 
@@ -286,20 +340,43 @@ private:
 
 class DecryptBlobCipherAes256Ctr final : NonCopyable, public ReferenceCounted<DecryptBlobCipherAes256Ctr> {
 public:
-	DecryptBlobCipherAes256Ctr(Reference<BlobCipherKey> key, const uint8_t* iv);
+	DecryptBlobCipherAes256Ctr(Reference<BlobCipherKey> tCipherKey,
+	                           Reference<BlobCipherKey> hCipherKey,
+	                           const uint8_t* iv);
 	~DecryptBlobCipherAes256Ctr();
+
 	Reference<EncryptBuf> decrypt(const uint8_t* ciphertext,
 	                              const int ciphertextLen,
 	                              const BlobCipherEncryptHeader& header,
 	                              Arena&);
 
+	// Enable caller to validate encryption header auth-token (if available) without needing to read the full encyrpted
+	// payload. The call is NOP unless header.flags.authTokenMode == ENCRYPT_HEADER_AUTH_TOKEN_MODE_MULTI.
+
+	void verifyHeaderAuthToken(const BlobCipherEncryptHeader& header, Arena& arena);
+
 private:
 	EVP_CIPHER_CTX* ctx;
+	Reference<BlobCipherKey> textCipherKey;
+	Reference<BlobCipherKey> headerCipherKey;
+	bool headerAuthTokenValidationDone;
+	bool authTokensValidationDone;
 
-	void verifyEncryptBlobHeader(const uint8_t* cipherText,
-	                             const int ciphertextLen,
-	                             const BlobCipherEncryptHeader& header,
-	                             Arena& arena);
+	void verifyAuthTokens(const uint8_t* ciphertext,
+	                      const int ciphertextLen,
+	                      const BlobCipherEncryptHeader& header,
+	                      uint8_t* buff,
+	                      Arena& arena);
+	void verifyHeaderSingleAuthToken(const uint8_t* ciphertext,
+	                                 const int ciphertextLen,
+	                                 const BlobCipherEncryptHeader& header,
+	                                 uint8_t* buff,
+	                                 Arena& arena);
+	void verifyHeaderMultiAuthToken(const uint8_t* ciphertext,
+	                                const int ciphertextLen,
+	                                const BlobCipherEncryptHeader& header,
+	                                uint8_t* buff,
+	                                Arena& arena);
 };
 
 class HmacSha256DigestGen final : NonCopyable {
@@ -313,9 +390,10 @@ private:
 	HMAC_CTX* ctx;
 };
 
-BlobCipherChecksum computeEncryptChecksum(const uint8_t* payload,
-                                          const int payloadLen,
-                                          const BlobCipherRandomSalt& salt,
-                                          Arena& arena);
+StringRef computeAuthToken(const uint8_t* payload,
+                           const int payloadLen,
+                           const uint8_t* key,
+                           const int keyLen,
+                           Arena& arena);
 
 #endif // ENCRYPTION_ENABLED

--- a/flow/BlobCipher.h
+++ b/flow/BlobCipher.h
@@ -365,6 +365,7 @@ private:
 	bool headerAuthTokenValidationDone;
 	bool authTokensValidationDone;
 
+	void verifyEncryptHeaderMetadata(const BlobCipherEncryptHeader& header);
 	void verifyAuthTokens(const uint8_t* ciphertext,
 	                      const int ciphertextLen,
 	                      const BlobCipherEncryptHeader& header,

--- a/flow/EncryptUtils.h
+++ b/flow/EncryptUtils.h
@@ -23,6 +23,7 @@
 #pragma once
 
 #include <cstdint>
+#include <limits>
 
 #define ENCRYPT_INVALID_DOMAIN_ID 0
 #define ENCRYPT_INVALID_CIPHER_KEY_ID 0
@@ -33,14 +34,26 @@
 #define ENCRYPT_HEADER_DOMAIN_ID -2
 
 using EncryptCipherDomainId = int64_t;
-using EncryptCipherRandomSalt = uint64_t;
 using EncryptCipherBaseKeyId = uint64_t;
+using EncryptCipherRandomSalt = uint64_t;
 
-typedef enum { ENCRYPT_CIPHER_MODE_NONE = 0, ENCRYPT_CIPHER_MODE_AES_256_CTR = 1 } EncryptCipherMode;
+typedef enum {
+	ENCRYPT_CIPHER_MODE_NONE = 0,
+	ENCRYPT_CIPHER_MODE_AES_256_CTR = 1,
+	ENCRYPT_CIPHER_MODE_LAST = 2
+} EncryptCipherMode;
+
+static_assert(EncryptCipherMode::ENCRYPT_CIPHER_MODE_LAST <= std::numeric_limits<uint8_t>::max(),
+              "EncryptCipherMode value overflow");
+
 typedef enum {
 	ENCRYPT_HEADER_AUTH_TOKEN_MODE_NONE = 0,
 	ENCRYPT_HEADER_AUTH_TOKEN_MODE_SINGLE = 1,
-	ENCRYPT_HEADER_AUTH_TOKEN_MODE_MULTI = 2
+	ENCRYPT_HEADER_AUTH_TOKEN_MODE_MULTI = 2,
+	ENCRYPT_HEADER_AUTH_TOKEN_LAST = 3 // Always the last element
 } EncryptAuthTokenMode;
+
+static_assert(EncryptAuthTokenMode::ENCRYPT_HEADER_AUTH_TOKEN_LAST <= std::numeric_limits<uint8_t>::max(),
+              "EncryptHeaderAuthToken value overflow");
 
 #endif

--- a/flow/EncryptUtils.h
+++ b/flow/EncryptUtils.h
@@ -46,6 +46,13 @@ typedef enum {
 static_assert(EncryptCipherMode::ENCRYPT_CIPHER_MODE_LAST <= std::numeric_limits<uint8_t>::max(),
               "EncryptCipherMode value overflow");
 
+// EncryptionHeader authentication modes
+// 1. NONE - No 'authentication token' generation needed for EncryptionHeader i.e. no protection against header OR
+// cipherText 'tampering' and/or bit rot/flip corruptions.
+// 2. Single/Multi - Encyrption header would generate one or more 'authentication tokens' to protect the header against
+// 'tempering' and/or bit rot/flip corruptions. Refer to BlobCipher.h for detailed usage recommendations.
+// 3. LAST - Invalid mode, used for static asserts.
+
 typedef enum {
 	ENCRYPT_HEADER_AUTH_TOKEN_MODE_NONE = 0,
 	ENCRYPT_HEADER_AUTH_TOKEN_MODE_SINGLE = 1,

--- a/flow/EncryptUtils.h
+++ b/flow/EncryptUtils.h
@@ -1,0 +1,46 @@
+/*
+ * EncryptUtils.h
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2022 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef ENCRYPT_UTILS_H
+#define ENCRYPT_UTILS_H
+#pragma once
+
+#include <cstdint>
+
+#define ENCRYPT_INVALID_DOMAIN_ID 0
+#define ENCRYPT_INVALID_CIPHER_KEY_ID 0
+
+#define AUTH_TOKEN_SIZE 16
+
+#define SYSTEM_KEYSPACE_ENCRYPT_DOMAIN_ID -1
+#define ENCRYPT_HEADER_DOMAIN_ID -2
+
+using EncryptCipherDomainId = int64_t;
+using EncryptCipherRandomSalt = uint64_t;
+using EncryptCipherBaseKeyId = uint64_t;
+
+typedef enum { ENCRYPT_CIPHER_MODE_NONE = 0, ENCRYPT_CIPHER_MODE_AES_256_CTR = 1 } EncryptCipherMode;
+typedef enum {
+	ENCRYPT_HEADER_AUTH_TOKEN_MODE_NONE = 0,
+	ENCRYPT_HEADER_AUTH_TOKEN_MODE_SINGLE = 1,
+	ENCRYPT_HEADER_AUTH_TOKEN_MODE_MULTI = 2
+} EncryptAuthTokenMode;
+
+#endif

--- a/flow/error_definitions.h
+++ b/flow/error_definitions.h
@@ -295,7 +295,7 @@ ERROR( encrypt_ops_error, 3000, "Encryption operation error")
 ERROR( encrypt_header_metadata_mismatch, 3001, "Encryption header metadata mismatch")
 ERROR( encrypt_key_not_found, 3002, "Expected encryption key is missing")
 ERROR( encrypt_key_ttl_expired, 3003, "Expected encryption key TTL has expired")
-ERROR( encrypt_header_checksum_mismatch, 3004, "Encryption header checksum mismatch")
+ERROR( encrypt_header_authtoken_mismatch, 3004, "Encryption header authentication token mismatch")
 ERROR( encrypt_update_cipher, 3005, "Attempt to update encryption cipher key")
 ERROR( encrypt_invalid_id, 3006, "Invalid encryption domainId or encryption cipher key id")
 

--- a/flow/error_definitions.h
+++ b/flow/error_definitions.h
@@ -290,14 +290,14 @@ ERROR( snap_log_anti_quorum_unsupported, 2507, "Unsupported when log anti quorum
 ERROR( snap_with_recovery_unsupported, 2508, "Cluster recovery during snapshot operation not supported")
 ERROR( snap_invalid_uid_string, 2509, "The given uid string is not a 32-length hex string")
 
-// 3XXX - Encryption operations errors
-ERROR( encrypt_ops_error, 3000, "Encryption operation error")
-ERROR( encrypt_header_metadata_mismatch, 3001, "Encryption header metadata mismatch")
-ERROR( encrypt_key_not_found, 3002, "Expected encryption key is missing")
-ERROR( encrypt_key_ttl_expired, 3003, "Expected encryption key TTL has expired")
-ERROR( encrypt_header_authtoken_mismatch, 3004, "Encryption header authentication token mismatch")
-ERROR( encrypt_update_cipher, 3005, "Attempt to update encryption cipher key")
-ERROR( encrypt_invalid_id, 3006, "Invalid encryption domainId or encryption cipher key id")
+// 27XX - Encryption operations errors
+ERROR( encrypt_ops_error, 2700, "Encryption operation error")
+ERROR( encrypt_header_metadata_mismatch, 2701, "Encryption header metadata mismatch")
+ERROR( encrypt_key_not_found, 2702, "Expected encryption key is missing")
+ERROR( encrypt_key_ttl_expired, 2703, "Expected encryption key TTL has expired")
+ERROR( encrypt_header_authtoken_mismatch, 2704, "Encryption header authentication token mismatch")
+ERROR( encrypt_update_cipher, 2705, "Attempt to update encryption cipher key")
+ERROR( encrypt_invalid_id, 2706, "Invalid encryption domainId or encryption cipher key id")
 
 // 4xxx Internal errors (those that should be generated only by bugs) are decimal 4xxx
 ERROR( unknown_error, 4000, "An unknown error occurred" )  // C++ exception not of type Error


### PR DESCRIPTION
Description

Major changes proposed are:
1.Encryption header support two modes of generation 'authentication tokens':
  a) SingleAuthTokenMode: the scheme generates single crypto-secure auth
     token to protect {cipherText + header} payload. Scheme is geared towards
     optimizing cost due to crypto-secure auth-token generation, however,
     on decryption client needs to be read 'header' + 'encrypted-buffer'
     to validate the 'auth-token'. The scheme is ideal for usecases where
     payload represented by the encryptionHeader is not large and it is
     desirable to minimize CPU/latency penalty due to crypto-secure ops,
     such as: CommitProxies encrypted inline transactions,
     StorageServer encrypting pages etc.
  b) MultiAuthTokenMode: Scheme generates separate authTokens for
     'encrypted buffer' & 'encryption-header'. The scheme is ideal where
     payload represented by encryptionHeader is large enough such that it
     is desirable to optimize cost of upfront reading full 'encrypted buffer',
     compared to reading only encryptionHeader and ensuring its sanity;
     for instance: backup-files
2. Leverage full crypto-secure digest as 'authentication token'

Testing

Update EncryptionOps simulation test
Update BlobCipher unit test
20220408-073434-ahusain-foundationdb-6816f5f1513d3a92

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
