### PR TITLE
Make Emergency Transaction only add mutations can change configuration (solve #6715)

### DIFF
--- a/fdbclient/DatabaseConfiguration.cpp
+++ b/fdbclient/DatabaseConfiguration.cpp
@@ -660,6 +660,11 @@ void DatabaseConfiguration::applyMutation(MutationRef m) {
 	}
 }
 
+bool DatabaseConfiguration::involveMutation(MutationRef m) {
+	return (m.type == MutationRef::SetValue && m.param1.startsWith(configKeysPrefix)) ||
+	       (m.type == MutationRef::ClearRange && KeyRangeRef(m.param1, m.param2).intersects(configKeys));
+}
+
 bool DatabaseConfiguration::set(KeyRef key, ValueRef value) {
 	makeConfigurationMutable();
 	mutableConfiguration.get()[key.toString()] = value.toString();

--- a/fdbclient/DatabaseConfiguration.h
+++ b/fdbclient/DatabaseConfiguration.h
@@ -104,6 +104,8 @@ struct DatabaseConfiguration {
 	DatabaseConfiguration();
 
 	void applyMutation(MutationRef mutation);
+	// return true if mutation will cause configuration changes
+	bool involveMutation(MutationRef mutation);
 	bool set(KeyRef key,
 	         ValueRef value); // Returns true if a configuration option that requires recovery to take effect is changed
 	bool clear(KeyRangeRef keys);

--- a/fdbserver/ClusterRecovery.actor.cpp
+++ b/fdbserver/ClusterRecovery.actor.cpp
@@ -869,7 +869,8 @@ ACTOR Future<Standalone<CommitTransactionRef>> provisionalMaster(Reference<Clust
 					    .detail("MType", m->type)
 					    .detail("Param1", m->param1)
 					    .detail("Param2", m->param2);
-					if (isMetadataMutation(*m)) {
+					// emergency transaction only mean to do configuration change
+					if (parent->configuration.involveMutation(*m)) {
 						// We keep the mutations and write conflict ranges from this transaction, but not its read
 						// conflict ranges
 						Standalone<CommitTransactionRef> out;


### PR DESCRIPTION
fix #6715 
pass 100k

The reason why the recruiteStorage is in an endless loop is that it keeps getting AttemptedDoubleRecruitment when it wants to initialize the worker. The worker had been a storage server b10a but this storage server is removed by DD because DD thought b10a is failed. However, even after the removeStorageServer transaction, b10a didn't realize it was removed.

Why b10a doesn't realize it? Because removeStorageServer is an Emergency Transaction, which means it's part of the Recovery Transaction, the commit version of this transaction is the newEpochStartVersion = RecoveryVersion+100M. The b10a first popped it's tag from the oldLogSystem when it realized the recovery happened, note at this time, b10a didn't peek up to newEpochVersion. Then the oldLogSystem is destructed after all SS popped their tag, and the cluster entered fully_recovered state. The new generation of log system wouldn't wait b10a to peek the message at newEpochVersion because the newLogSystem and the whole cluster just think b10a has been removed. So the new log system happened to clear the remove message before b10a can see it.

The fix https://github.com/apple/foundationdb/pull/6760 prevents any transaction except for configuration change to an emergency transaction, which prevent this corner case.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
