### PR TITLE
Added an option to fdbdecode for saving processed files and fixed a memory corruption issue in clang build

### DIFF
--- a/fdbbackup/FileConverter.h
+++ b/fdbbackup/FileConverter.h
@@ -47,6 +47,7 @@ enum {
 	OPT_BEGIN_VERSION_FILTER,
 	OPT_END_VERSION_FILTER,
 	OPT_KNOB,
+	OPT_SAVE_FILE,
 	OPT_HELP
 };
 
@@ -74,6 +75,8 @@ CSimpleOpt::SOption gConverterOptions[] = { { OPT_CONTAINER, "-r", SO_REQ_SEP },
 	                                        { OPT_BEGIN_VERSION_FILTER, "--begin-version-filter", SO_REQ_SEP },
 	                                        { OPT_END_VERSION_FILTER, "--end-version-filter", SO_REQ_SEP },
 	                                        { OPT_KNOB, "--knob-", SO_REQ_SEP },
+	                                        { OPT_SAVE_FILE, "-s", SO_NONE },
+	                                        { OPT_SAVE_FILE, "--save", SO_NONE },
 	                                        { OPT_HELP, "-?", SO_NONE },
 	                                        { OPT_HELP, "-h", SO_NONE },
 	                                        { OPT_HELP, "--help", SO_NONE },

--- a/fdbbackup/FileDecoder.actor.cpp
+++ b/fdbbackup/FileDecoder.actor.cpp
@@ -22,6 +22,7 @@
 #include <cstdlib>
 #include <iostream>
 #include <limits>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -600,10 +601,10 @@ ACTOR Future<Void> decode_logs(DecodeParams params) {
 
 int main(int argc, char** argv) {
 	try {
-		CSimpleOpt* args =
-		    new CSimpleOpt(argc, argv, file_converter::gConverterOptions, SO_O_EXACT | SO_O_HYPHEN_TO_UNDERSCORE);
+		std::unique_ptr<CSimpleOpt> args(
+		    new CSimpleOpt(argc, argv, file_converter::gConverterOptions, SO_O_EXACT | SO_O_HYPHEN_TO_UNDERSCORE));
 		file_converter::DecodeParams param;
-		int status = file_converter::parseDecodeCommandLine(&param, args);
+		int status = file_converter::parseDecodeCommandLine(&param, args.get());
 		std::cout << "Params: " << param.toString() << "\n";
 		if (status != FDB_EXIT_SUCCESS) {
 			file_converter::printDecodeUsage();


### PR DESCRIPTION
`fdbdecode` changes only. I've manually tested the backup files can be saved.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
