### PR TITLE
Address 3 issues in PTXN

### DIFF
--- a/fdbserver/ApplyMetadataMutation.cpp
+++ b/fdbserver/ApplyMetadataMutation.cpp
@@ -347,6 +347,7 @@ private:
 		auto teamid = decodeStorageTeamIdKey(m.param1);
 		auto team = decodeStorageTeams(m.param2);
 
+		// TODO(PTXN): decide whether this is the correct place to update tLogGroupCollection.
 		if (tLogGroupCollection->tryAddStorageTeam(teamid, team)) {
 			auto group = tLogGroupCollection->assignStorageTeam(teamid);
 		}

--- a/fdbserver/ClusterController.actor.cpp
+++ b/fdbserver/ClusterController.actor.cpp
@@ -2299,6 +2299,12 @@ public:
 	// This function returns true when the cluster controller determines it is worth forcing
 	// a master recovery in order to change the recruited processes in the transaction subsystem.
 	bool betterMasterExists() {
+		// Disable betterMasterExists when partitioned txn is enabled.
+		// TODO(PTXN): re-enable this once recovery works with PTXN.
+		if (SERVER_KNOBS->ENABLE_PARTITIONED_TRANSACTIONS) {
+			return false;
+		}
+
 		const ServerDBInfo dbi = db.serverInfo->get();
 
 		if (dbi.recoveryState < RecoveryState::ACCEPTING_COMMITS) {

--- a/fdbserver/MoveKeys.actor.cpp
+++ b/fdbserver/MoveKeys.actor.cpp
@@ -1598,6 +1598,11 @@ void seedShardServers(Arena& arena,
 			}
 		}
 
+		// Populate storageTeamIdKey for private teams.
+		for (const auto& [ss, teams] : serverToTeams) {
+			tr.set(arena, storageTeamIdKey(ss), encodeStorageTeams({ ss }));
+		}
+
 		if (!seedTeamSet) {
 			// Two corner case can reach here, serverToTeams.size() is 1 in both cases
 			// 1. the cluster only has 1 SS

--- a/fdbserver/masterserver.actor.cpp
+++ b/fdbserver/masterserver.actor.cpp
@@ -494,11 +494,9 @@ ACTOR Future<Void> newSeedServers(Reference<MasterData> self,
 			tag.id++;
 			idx++;
 
+			// Note that we don't add the private team here. Private team creation is done when system metadata is
+			// created in seedShardServers().
 			servers->emplace_back(newServer.get().interf, seedTeamId);
-
-			if (SERVER_KNOBS->ENABLE_PARTITIONED_TRANSACTIONS) {
-				servers->emplace_back(newServer.get().interf, newServer.get().interf.id());
-			}
 			ssInterfaces.push_back(newServer.get().interf);
 
 			if (SERVER_KNOBS->ENABLE_PARTITIONED_TRANSACTIONS) {


### PR DESCRIPTION
- Currently private team is populated twice in storageServerToTeam. So don't include it in seed server recruitment
- private team's storageTeam is not set up correctly.
- Disable betterMasterExist(), since we don't support recovery yet.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
