### PR TITLE
Allow worker health monitor to report recent destroyed peers

### DIFF
--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -719,6 +719,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( PEER_LATENCY_DEGRADATION_THRESHOLD,                   0.05 );
 	init( PEER_TIMEOUT_PERCENTAGE_DEGRADATION_THRESHOLD,         0.1 );
 	init( PEER_DEGRADATION_CONNECTION_FAILURE_COUNT,               1 );
+	init( WORKER_HEALTH_REPORT_RECENT_DESTROYED_PEER,           true );
 
 	// Test harness
 	init( WORKER_POLL_DELAY,                                     1.0 );

--- a/fdbclient/ServerKnobs.h
+++ b/fdbclient/ServerKnobs.h
@@ -662,6 +662,9 @@ public:
 	double PEER_TIMEOUT_PERCENTAGE_DEGRADATION_THRESHOLD; // The percentage of timeout to consider a peer degraded.
 	int PEER_DEGRADATION_CONNECTION_FAILURE_COUNT; // The number of connection failures experienced during measurement
 	                                               // period to consider a peer degraded.
+	bool WORKER_HEALTH_REPORT_RECENT_DESTROYED_PEER; // When enabled, the worker's health monitor also report any recent
+	                                                 // destroyed peers who are part of the transaction system to
+	                                                 // cluster controller.
 
 	// Test harness
 	double WORKER_POLL_DELAY;

--- a/fdbrpc/HealthMonitor.actor.cpp
+++ b/fdbrpc/HealthMonitor.actor.cpp
@@ -36,6 +36,10 @@ void HealthMonitor::purgeOutdatedHistory() {
 			--count;
 			ASSERT(count >= 0);
 			peerClosedHistory.pop_front();
+
+			if (count == 0) {
+				peerClosedNum.erase(p.second);
+			}
 		} else {
 			break;
 		}
@@ -44,10 +48,27 @@ void HealthMonitor::purgeOutdatedHistory() {
 
 bool HealthMonitor::tooManyConnectionsClosed(const NetworkAddress& peerAddress) {
 	purgeOutdatedHistory();
+	if (peerClosedNum.find(peerAddress) == peerClosedNum.end()) {
+		return false;
+	}
 	return peerClosedNum[peerAddress] > FLOW_KNOBS->HEALTH_MONITOR_CONNECTION_MAX_CLOSED;
 }
 
 int HealthMonitor::closedConnectionsCount(const NetworkAddress& peerAddress) {
 	purgeOutdatedHistory();
+	if (peerClosedNum.find(peerAddress) == peerClosedNum.end()) {
+		return 0;
+	}
 	return peerClosedNum[peerAddress];
+}
+
+std::unordered_set<NetworkAddress> HealthMonitor::getRecentClosedPeers() {
+	purgeOutdatedHistory();
+	std::unordered_set<NetworkAddress> closedPeers;
+	for (const auto& [peerAddr, count] : peerClosedNum) {
+		if (count > 0) {
+			closedPeers.insert(peerAddr);
+		}
+	}
+	return closedPeers;
 }

--- a/fdbrpc/HealthMonitor.h
+++ b/fdbrpc/HealthMonitor.h
@@ -31,6 +31,7 @@ public:
 	void reportPeerClosed(const NetworkAddress& peerAddress);
 	bool tooManyConnectionsClosed(const NetworkAddress& peerAddress);
 	int closedConnectionsCount(const NetworkAddress& peerAddress);
+	std::unordered_set<NetworkAddress> getRecentClosedPeers();
 
 private:
 	void purgeOutdatedHistory();


### PR DESCRIPTION
As observed in real cluster testing, when a worker is having trouble connecting to another worker, sometimes it destroys the worker (remove the corresponding `peer` object from its network). In such case, the worker's health monitor will miss such connection failure.

Therefore, this PR also examines all the recent closed peers and find out those that are destroyed. If any of them are in the cluster's transaction sub system, report it to the cluster controller.

This feature is guarded by a knob and can be easily disabled.

20220406-054035-zhewu_6774-9143bba0921a9f60        compressed=True data_size=30771268 duration=5921307 ended=100000 fail=1 fail_fast=10 max_runs=100000 pass=99999 priority=100 remaining=0 runtime=1:11:06 sanity=False started=100130 stopped=20220406-065141 submitted=20220406-054035 timeout=5400 username=zhewu_6774

Error is a unit test in tracing

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
