### PR TITLE
Various fixes in ptxn

### DIFF
--- a/fdbserver/TLogGroup.actor.cpp
+++ b/fdbserver/TLogGroup.actor.cpp
@@ -138,7 +138,7 @@ void TLogGroupCollection::recruitEverything() {
 
 			Reference<TLogGroup> group(new TLogGroup());
 			for (auto& entry : bestSet) {
-				group->addServer(Reference<TLogWorkerData>(entry));
+				group->addServer(Reference<TLogWorkerData>::addRef(entry));
 			}
 
 			recruitedGroups.push_back(group);

--- a/fdbserver/worker.actor.cpp
+++ b/fdbserver/worker.actor.cpp
@@ -242,7 +242,8 @@ ACTOR Future<Void> workerHandleErrors(FutureStream<ErrorInfo> errors) {
 			bool ok = err.error.code() == error_code_success || err.error.code() == error_code_please_reboot ||
 			          err.error.code() == error_code_actor_cancelled ||
 			          err.error.code() == error_code_coordinators_changed || // The worker server was cancelled
-			          err.error.code() == error_code_shutdown_in_progress;
+			          err.error.code() == error_code_shutdown_in_progress ||
+			          err.error.code() == error_code_storage_team_id_not_found;
 
 			if (!ok) {
 				err.error = checkIOTimeout(err.error); // Possibly convert error to io_timeout
@@ -1979,7 +1980,8 @@ ACTOR Future<Void> workerServer(Reference<IClusterConnectionRecord> connRecord,
 
 				// create kv and disk queue per TLog group
 				for (auto& group : req.tlogGroups) {
-					IKeyValueStore* data = keyValueStoreMemory(joinPath(folder, "loggroup"), group.logGroupId, 500e6);
+					IKeyValueStore* data = keyValueStoreMemory(
+					    joinPath(folder, "loggroup-" + group.logGroupId.toString() + "-"), group.logGroupId, 500e6);
 					IDiskQueue* queue = openDiskQueue(joinPath(folder, "logqueue-" + group.logGroupId.toString() + "-"),
 					                                  "fdq",
 					                                  group.logGroupId,


### PR DESCRIPTION
- Fix missing TLogWorkerData reference counting
- getStorageTeamData() needs to make sure not creating new StorageTeamData(). This is an assertion in the code.
- Move endRole from LogGenerationData to where tlogCore return, which matches beginRole. Otherwise, endRole maybe called before beginRole is called.
- Fix tlog keyvalue store file name.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
