### PR TITLE
Reserve the version and the storage team infomration when ServerDBInfo changes

### DIFF
--- a/fdbserver/ptxn/MutableTeamPeekCursor.actor.h
+++ b/fdbserver/ptxn/MutableTeamPeekCursor.actor.h
@@ -129,8 +129,6 @@ public:
 	}
 
 	const StorageServerStorageTeams getStorageTeamIDs() const { return storageTeamIDs; }
-
-	const KeyRef getStorageServerToTeamIDKey() const { return storageServerToTeamIDKey; }
 };
 
 template <typename BaseClass>

--- a/fdbserver/ptxn/MutableTeamPeekCursor.actor.h
+++ b/fdbserver/ptxn/MutableTeamPeekCursor.actor.h
@@ -130,6 +130,8 @@ public:
 	}
 
 	const StorageServerStorageTeams getStorageTeamIDs() const { return storageTeamIDs; }
+
+	const KeyRef getStorageServerToTeamIDKey() const { return storageServerToTeamIDKey; }
 };
 
 template <typename BaseClass>

--- a/fdbserver/ptxn/MutableTeamPeekCursor.actor.h
+++ b/fdbserver/ptxn/MutableTeamPeekCursor.actor.h
@@ -99,7 +99,6 @@ public:
 	                      const StorageTeamID& privateMutationStorageTeamID_,
 	                      const TLogInterfaceByStorageTeamIDFunc& getTLogInterfaceByStorageTeamID_,
 	                      const Version& initialVersion_)
-
 	  : BaseClass(initialVersion_), serverID(serverID_),
 	    storageServerToTeamIDKey(::storageServerToTeamIdKey(serverID_)),
 	    storageTeamIDsSnapshot(privateMutationStorageTeamID_), storageTeamIDs(privateMutationStorageTeamID_),

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -5607,7 +5607,8 @@ void initializeUpdateCursor(ptxn::StorageServer& storageServerContext) {
 	    storageServerContext.storageServerStorageTeams,
 	    [referencedServerDBInfo](const StorageTeamID& storageTeamID) -> auto {
 		    return getTLogInterfaceByStorageTeamID(referencedServerDBInfo->get(), storageTeamID);
-	    });
+	    },
+		storageServerContext.version.get() + 1);
 
 	storageServerContext.storageServerToTeamIDKey =
 	    std::dynamic_pointer_cast<merged::OrderedMutableTeamPeekCursor>(storageServerContext.logCursor)

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -1119,7 +1119,7 @@ public:
 	std::shared_ptr<ptxn::PeekCursorBase> logCursor;
 
 	// The key used to inform this storage server the new list of storage teams.
-	KeyRef storageServerToTeamIDKey;
+	Key storageServerToTeamIDKey;
 
 	// The storage teams the storage server has subscribed
 	StorageServerStorageTeams storageServerStorageTeams;
@@ -1132,6 +1132,7 @@ public:
 	              const StorageServerInterface& storageServerInterface,
 	              const StorageTeamID& privateMutationsStorageTeamID_)
 	  : StorageServerBase(pKVStore, serverDBInfo, storageServerInterface),
+	    storageServerToTeamIDKey(::storageServerToTeamIdKey(thisServerID)),
 	    storageServerStorageTeams(privateMutationsStorageTeamID_) {}
 };
 
@@ -5608,11 +5609,7 @@ void initializeUpdateCursor(ptxn::StorageServer& storageServerContext) {
 	    [referencedServerDBInfo](const StorageTeamID& storageTeamID) -> auto {
 		    return getTLogInterfaceByStorageTeamID(referencedServerDBInfo->get(), storageTeamID);
 	    },
-		storageServerContext.version.get() + 1);
-
-	storageServerContext.storageServerToTeamIDKey =
-	    std::dynamic_pointer_cast<merged::OrderedMutableTeamPeekCursor>(storageServerContext.logCursor)
-	        ->getStorageServerToTeamIDKey();
+	    storageServerContext.version.get() + 1);
 }
 
 ACTOR Future<Void> peekFromRemote(std::shared_ptr<ptxn::StorageServer> storageServerContext,


### PR DESCRIPTION

In storage server, when ServerDBInfo changes, the cursor will be
re-constructed. With this patch, the subscribed storage team and version
will be preserved.


# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
