### PR TITLE
Add missing Windows headers for `FileDecoder.actor.cpp`

### DIFF
--- a/fdbbackup/FileDecoder.actor.cpp
+++ b/fdbbackup/FileDecoder.actor.cpp
@@ -25,6 +25,10 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <fcntl.h>
+#ifdef _WIN32
+#include <io.h>
+#endif
 
 #include "fdbbackup/BackupTLSConfig.h"
 #include "fdbclient/BuildFlags.h"


### PR DESCRIPTION
Fix broken Windows build by #6767 