### PR TITLE
Fix cmake USE_GPERFTOOLS compiling error

### DIFF
--- a/cmake/FindGperftools.cmake
+++ b/cmake/FindGperftools.cmake
@@ -52,7 +52,6 @@ mark_as_advanced(
 
 if (GPERFTOOLS_FOUND)
   add_library(gperftools UNKNOWN IMPORTED)
-  target_compile_definitions(gperftools PUBLIC USE_GPERFTOOLS)
   set_target_properties(gperftools PROPERTIES
     IMPORTED_LOCATION ${GPERFTOOLS_TCMALLOC_AND_PROFILER}
     INTERFACE_INCLUDE_DIRECTORIES "${GPERFTOOLS_INCLUDE_DIR}")


### PR DESCRIPTION
Otherwise, I got weird errors like pthread library is not found when checking
compilers.


# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
