### PR TITLE
Adding warning on configuring rocksdb storage until production tested.

### DIFF
--- a/fdbcli/ConfigureCommand.actor.cpp
+++ b/fdbcli/ConfigureCommand.actor.cpp
@@ -190,6 +190,11 @@ ACTOR Future<bool> configureCommandActor(Reference<IDatabase> db,
 	case ConfigurationResult::DATABASE_CREATED:
 		printf("Database created\n");
 		break;
+	case ConfigurationResult::DATABASE_CREATED_WARN_ROCKSDB_EXPERIMENTAL:
+		printf("Database created\n");
+		fprintf(stderr,
+		        "WARN: RocksDB storage engine type is still in experimental stage, not yet production tested.\n");
+		break;
 	case ConfigurationResult::DATABASE_UNAVAILABLE:
 		fprintf(stderr, "ERROR: The database is unavailable\n");
 		fprintf(stderr, "Type `configure FORCE <TOKEN...>' to configure without this check\n");
@@ -249,6 +254,11 @@ ACTOR Future<bool> configureCommandActor(Reference<IDatabase> db,
 		        "Type `configure perpetual_storage_wiggle=1' to enable the perpetual wiggle, or `configure "
 		        "storage_migration_type=gradual' to set the gradual migration type.\n");
 		ret = false;
+		break;
+	case ConfigurationResult::SUCCESS_WARN_ROCKSDB_EXPERIMENTAL:
+		printf("Configuration changed\n");
+		fprintf(stderr,
+		        "WARN: RocksDB storage engine type is still in experimental stage, not yet production tested.\n");
 		break;
 	default:
 		ASSERT(false);


### PR DESCRIPTION
Adding warning message on configuring rocksdb storage until production tested. This is basically a warning message for the open source community to be cautious.

Simulation testing passed.
Fdbmonitor testing:
fdb> configure new single ssd-rocksdb-v1
Database created
WARN: RocksDB storage engine type is still in experimental stage, not yet production tested.
fdb> configure ssd
Configuration changed
fdb> configure ssd-rocksdb-v1
Configuration changed
WARN: RocksDB storage engine type is still in experimental stage, not yet production tested.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
