### PR TITLE
Fix IKeyValueStore creation during TLog init

### DIFF
--- a/fdbserver/worker.actor.cpp
+++ b/fdbserver/worker.actor.cpp
@@ -1979,7 +1979,8 @@ ACTOR Future<Void> workerServer(Reference<IClusterConnectionRecord> connRecord,
 
 				// create kv and disk queue per TLog group
 				for (auto& group : req.tlogGroups) {
-					IKeyValueStore* data = keyValueStoreMemory(joinPath(folder, "loggroup"), group.logGroupId, 500e6);
+					IKeyValueStore* data =
+					    openKVStore(req.storeType, joinPath(folder, "loggroup"), group.logGroupId, 500e6);
 					IDiskQueue* queue = openDiskQueue(joinPath(folder, "logqueue-" + group.logGroupId.toString() + "-"),
 					                                  "fdq",
 					                                  group.logGroupId,


### PR DESCRIPTION
Put description here...

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
