### PR TITLE
Double existing FastAlloc limit

### DIFF
--- a/flow/FastAlloc.h
+++ b/flow/FastAlloc.h
@@ -178,7 +178,7 @@ void releaseAllThreadMagazines();
 int64_t getTotalUnusedAllocatedMemory();
 
 inline constexpr int nextFastAllocatedSize(int x) {
-	assert(x > 0 && x <= 8192);
+	assert(x > 0 && x <= 16384);
 	if (x <= 16)
 		return 16;
 	else if (x <= 32)
@@ -199,8 +199,10 @@ inline constexpr int nextFastAllocatedSize(int x) {
 		return 2048;
 	else if (x <= 4096)
 		return 4096;
-	else
+	else if (x <= 8192)
 		return 8192;
+	else
+		return 16384;
 }
 
 template <class Object>


### PR DESCRIPTION
I added a field to the `StorageServer` struct and started seeing the assertion in `nextFastAllocatedSize` fail. It seems there are so many fields in `StorageServer` now that 8192 bytes is not enough to allocate an instance of it. This PR doubles the byte limit.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
