### PR TITLE
Fixes #6793: Upgrade from 7.0.0 to 7.1.0 fails because of missing function fdb_transaction_get_mapped_range

### DIFF
--- a/bindings/c/fdb_c.cpp
+++ b/bindings/c/fdb_c.cpp
@@ -619,23 +619,23 @@ FDBFuture* fdb_transaction_get_range_impl(FDBTransaction* tr,
 	                    .extractPtr());
 }
 
-FDBFuture* fdb_transaction_get_mapped_range_impl(FDBTransaction* tr,
-                                                 uint8_t const* begin_key_name,
-                                                 int begin_key_name_length,
-                                                 fdb_bool_t begin_or_equal,
-                                                 int begin_offset,
-                                                 uint8_t const* end_key_name,
-                                                 int end_key_name_length,
-                                                 fdb_bool_t end_or_equal,
-                                                 int end_offset,
-                                                 uint8_t const* mapper_name,
-                                                 int mapper_name_length,
-                                                 int limit,
-                                                 int target_bytes,
-                                                 FDBStreamingMode mode,
-                                                 int iteration,
-                                                 fdb_bool_t snapshot,
-                                                 fdb_bool_t reverse) {
+extern "C" DLLEXPORT FDBFuture* fdb_transaction_get_mapped_range(FDBTransaction* tr,
+                                                                 uint8_t const* begin_key_name,
+                                                                 int begin_key_name_length,
+                                                                 fdb_bool_t begin_or_equal,
+                                                                 int begin_offset,
+                                                                 uint8_t const* end_key_name,
+                                                                 int end_key_name_length,
+                                                                 fdb_bool_t end_or_equal,
+                                                                 int end_offset,
+                                                                 uint8_t const* mapper_name,
+                                                                 int mapper_name_length,
+                                                                 int limit,
+                                                                 int target_bytes,
+                                                                 FDBStreamingMode mode,
+                                                                 int iteration,
+                                                                 fdb_bool_t snapshot,
+                                                                 fdb_bool_t reverse) {
 	FDBFuture* r = validate_and_update_parameters(limit, target_bytes, mode, iteration, reverse);
 	if (r != nullptr)
 		return r;
@@ -649,49 +649,6 @@ FDBFuture* fdb_transaction_get_mapped_range_impl(FDBTransaction* tr,
 	                        snapshot,
 	                        reverse)
 	                    .extractPtr());
-}
-
-// TODO: Support FDB_API_ADDED in generate_asm.py and then this can be replaced with fdb_api_ptr_unimpl.
-FDBFuture* fdb_transaction_get_range_and_flat_map_v699(FDBTransaction* tr,
-                                                       uint8_t const* begin_key_name,
-                                                       int begin_key_name_length,
-                                                       fdb_bool_t begin_or_equal,
-                                                       int begin_offset,
-                                                       uint8_t const* end_key_name,
-                                                       int end_key_name_length,
-                                                       fdb_bool_t end_or_equal,
-                                                       int end_offset,
-                                                       uint8_t const* mapper_name,
-                                                       int mapper_name_length,
-                                                       int limit,
-                                                       int target_bytes,
-                                                       FDBStreamingMode mode,
-                                                       int iteration,
-                                                       fdb_bool_t snapshot,
-                                                       fdb_bool_t reverse) {
-	fprintf(stderr, "UNIMPLEMENTED FDB API FUNCTION\n");
-	abort();
-}
-
-FDBFuture* fdb_transaction_get_range_and_flat_map_impl(FDBTransaction* tr,
-                                                       uint8_t const* begin_key_name,
-                                                       int begin_key_name_length,
-                                                       fdb_bool_t begin_or_equal,
-                                                       int begin_offset,
-                                                       uint8_t const* end_key_name,
-                                                       int end_key_name_length,
-                                                       fdb_bool_t end_or_equal,
-                                                       int end_offset,
-                                                       uint8_t const* mapper_name,
-                                                       int mapper_name_length,
-                                                       int limit,
-                                                       int target_bytes,
-                                                       FDBStreamingMode mode,
-                                                       int iteration,
-                                                       fdb_bool_t snapshot,
-                                                       fdb_bool_t reverse) {
-	fprintf(stderr, "GetRangeAndFlatMap is removed from 7.0. Please upgrade to 7.1 and use GetMappedRange\n");
-	abort();
 }
 
 FDBFuture* fdb_transaction_get_range_and_flat_map_v709(FDBTransaction* tr,
@@ -712,27 +669,6 @@ FDBFuture* fdb_transaction_get_range_and_flat_map_v709(FDBTransaction* tr,
                                                        fdb_bool_t snapshot,
                                                        fdb_bool_t reverse) {
 	fprintf(stderr, "GetRangeAndFlatMap is removed from 7.0. Please upgrade to 7.1 and use GetMappedRange\n");
-	abort();
-}
-
-FDBFuture* fdb_transaction_get_mapped_range_v709(FDBTransaction* tr,
-                                                 uint8_t const* begin_key_name,
-                                                 int begin_key_name_length,
-                                                 fdb_bool_t begin_or_equal,
-                                                 int begin_offset,
-                                                 uint8_t const* end_key_name,
-                                                 int end_key_name_length,
-                                                 fdb_bool_t end_or_equal,
-                                                 int end_offset,
-                                                 uint8_t const* mapper_name,
-                                                 int mapper_name_length,
-                                                 int limit,
-                                                 int target_bytes,
-                                                 FDBStreamingMode mode,
-                                                 int iteration,
-                                                 fdb_bool_t snapshot,
-                                                 fdb_bool_t reverse) {
-	fprintf(stderr, "UNIMPLEMENTED FDB API FUNCTION\n");
 	abort();
 }
 
@@ -969,9 +905,7 @@ extern "C" DLLEXPORT fdb_error_t fdb_select_api_version_impl(int runtime_version
 	// WARNING: use caution when implementing removed functions by calling public API functions. This can lead to
 	// undesired behavior when using the multi-version API. Instead, it is better to have both the removed and public
 	// functions call an internal implementation function. See fdb_create_database_impl for an example.
-	FDB_API_CHANGED(fdb_transaction_get_mapped_range, 710);
 	FDB_API_REMOVED(fdb_transaction_get_range_and_flat_map, 710);
-	FDB_API_CHANGED(fdb_transaction_get_range_and_flat_map, 700);
 	FDB_API_REMOVED(fdb_future_get_version, 620);
 	FDB_API_REMOVED(fdb_create_cluster, 610);
 	FDB_API_REMOVED(fdb_cluster_create_database, 610);

--- a/bindings/c/fdb_c.cpp
+++ b/bindings/c/fdb_c.cpp
@@ -652,7 +652,70 @@ FDBFuture* fdb_transaction_get_mapped_range_impl(FDBTransaction* tr,
 }
 
 // TODO: Support FDB_API_ADDED in generate_asm.py and then this can be replaced with fdb_api_ptr_unimpl.
-FDBFuture* fdb_transaction_get_mapped_range_v699(FDBTransaction* tr,
+FDBFuture* fdb_transaction_get_range_and_flat_map_v699(FDBTransaction* tr,
+                                                       uint8_t const* begin_key_name,
+                                                       int begin_key_name_length,
+                                                       fdb_bool_t begin_or_equal,
+                                                       int begin_offset,
+                                                       uint8_t const* end_key_name,
+                                                       int end_key_name_length,
+                                                       fdb_bool_t end_or_equal,
+                                                       int end_offset,
+                                                       uint8_t const* mapper_name,
+                                                       int mapper_name_length,
+                                                       int limit,
+                                                       int target_bytes,
+                                                       FDBStreamingMode mode,
+                                                       int iteration,
+                                                       fdb_bool_t snapshot,
+                                                       fdb_bool_t reverse) {
+	fprintf(stderr, "UNIMPLEMENTED FDB API FUNCTION\n");
+	abort();
+}
+
+FDBFuture* fdb_transaction_get_range_and_flat_map_impl(FDBTransaction* tr,
+                                                       uint8_t const* begin_key_name,
+                                                       int begin_key_name_length,
+                                                       fdb_bool_t begin_or_equal,
+                                                       int begin_offset,
+                                                       uint8_t const* end_key_name,
+                                                       int end_key_name_length,
+                                                       fdb_bool_t end_or_equal,
+                                                       int end_offset,
+                                                       uint8_t const* mapper_name,
+                                                       int mapper_name_length,
+                                                       int limit,
+                                                       int target_bytes,
+                                                       FDBStreamingMode mode,
+                                                       int iteration,
+                                                       fdb_bool_t snapshot,
+                                                       fdb_bool_t reverse) {
+	fprintf(stderr, "GetRangeAndFlatMap is removed from 7.0. Please upgrade to 7.1 and use GetMappedRange\n");
+	abort();
+}
+
+FDBFuture* fdb_transaction_get_range_and_flat_map_v709(FDBTransaction* tr,
+                                                       uint8_t const* begin_key_name,
+                                                       int begin_key_name_length,
+                                                       fdb_bool_t begin_or_equal,
+                                                       int begin_offset,
+                                                       uint8_t const* end_key_name,
+                                                       int end_key_name_length,
+                                                       fdb_bool_t end_or_equal,
+                                                       int end_offset,
+                                                       uint8_t const* mapper_name,
+                                                       int mapper_name_length,
+                                                       int limit,
+                                                       int target_bytes,
+                                                       FDBStreamingMode mode,
+                                                       int iteration,
+                                                       fdb_bool_t snapshot,
+                                                       fdb_bool_t reverse) {
+	fprintf(stderr, "GetRangeAndFlatMap is removed from 7.0. Please upgrade to 7.1 and use GetMappedRange\n");
+	abort();
+}
+
+FDBFuture* fdb_transaction_get_mapped_range_v709(FDBTransaction* tr,
                                                  uint8_t const* begin_key_name,
                                                  int begin_key_name_length,
                                                  fdb_bool_t begin_or_equal,
@@ -900,13 +963,15 @@ extern "C" DLLEXPORT fdb_error_t fdb_select_api_version_impl(int runtime_version
 
 	// Versioned API changes -- descending order by version (new changes at top)
 	// FDB_API_CHANGED( function, ver ) means there is a new implementation as of ver, and a function function_(ver-1)
-	// is the old implementation FDB_API_REMOVED( function, ver ) means the function was removed as of ver, and
+	// is the old implementation. FDB_API_REMOVED( function, ver ) means the function was removed as of ver, and
 	// function_(ver-1) is the old implementation
 	//
 	// WARNING: use caution when implementing removed functions by calling public API functions. This can lead to
 	// undesired behavior when using the multi-version API. Instead, it is better to have both the removed and public
 	// functions call an internal implementation function. See fdb_create_database_impl for an example.
-	FDB_API_CHANGED(fdb_transaction_get_mapped_range, 700);
+	FDB_API_CHANGED(fdb_transaction_get_mapped_range, 710);
+	FDB_API_REMOVED(fdb_transaction_get_range_and_flat_map, 710);
+	FDB_API_CHANGED(fdb_transaction_get_range_and_flat_map, 700);
 	FDB_API_REMOVED(fdb_future_get_version, 620);
 	FDB_API_REMOVED(fdb_create_cluster, 610);
 	FDB_API_REMOVED(fdb_cluster_create_database, 610);

--- a/documentation/sphinx/source/release-notes/release-notes-700.rst
+++ b/documentation/sphinx/source/release-notes/release-notes-700.rst
@@ -28,7 +28,6 @@ Features
 * Improved the efficiency with which storage servers replicate data between themselves. `(PR #5017) <https://github.com/apple/foundationdb/pull/5017>`_
 * Added support to ``exclude command`` to exclude based on locality match. `(PR #5113) <https://github.com/apple/foundationdb/pull/5113>`_
 * Add the ``trace_partial_file_suffix`` network option. This option will give unfinished trace files a special suffix to indicate they're not complete yet. When the trace file is complete, it is renamed to remove the suffix. `(PR #5328) <https://github.com/apple/foundationdb/pull/5328>`_
-* Added "get range and flat map" feature with new APIs (see Bindings section). Storage servers are able to generate the keys in the queries based on another query. With this, upper layer can push some computations down to FDB, to improve latency and bandwidth when read. `(PR #5609) <https://github.com/apple/foundationdb/pull/5609>`_
 
 Performance
 -----------
@@ -85,8 +84,6 @@ Bindings
 * C: Added a function, ``fdb_database_create_snapshot``, to create a snapshot of the database. `(PR #4241) <https://github.com/apple/foundationdb/pull/4241/files>`_
 * C: Added ``fdb_database_get_main_thread_busyness`` function to report how busy a client's main thread is. `(PR #4504) <https://github.com/apple/foundationdb/pull/4504>`_
 * Java: Added ``Database.getMainThreadBusyness`` function to report how busy a client's main thread is. `(PR #4564) <https://github.com/apple/foundationdb/pull/4564>`_
-* C: Added ``fdb_transaction_get_range_and_flat_map`` function to support running queries based on another query in one request. `(PR #5609) <https://github.com/apple/foundationdb/pull/5609>`_
-* Java: Added ``Transaction.getRangeAndFlatMap`` function to support running queries based on another query in one request. `(PR #5609) <https://github.com/apple/foundationdb/pull/5609>`_
 
 Other Changes
 -------------

--- a/documentation/sphinx/source/release-notes/release-notes-710.rst
+++ b/documentation/sphinx/source/release-notes/release-notes-710.rst
@@ -10,6 +10,7 @@ Release Notes
 Features
 --------
 * Added ``USE_GRV_CACHE`` transaction option to allow read versions to be locally cached on the client side for latency optimizations. `(PR #5725) <https://github.com/apple/foundationdb/pull/5725>`_ `(PR #6664) <https://github.com/apple/foundationdb/pull/6664>`_
+* Added "get range and flat map" feature with new APIs (see Bindings section). Storage servers are able to generate the keys in the queries based on another query. With this, upper layer can push some computations down to FDB, to improve latency and bandwidth when read. `(PR #5609) <https://github.com/apple/foundationdb/pull/5609>`_, `(PR #6181) <https://github.com/apple/foundationdb/pull/6181>`_, etc..
 
 Performance
 -----------
@@ -25,6 +26,8 @@ Status
 
 Bindings
 --------
+* C: Added ``fdb_transaction_get_range_and_flat_map`` function to support running queries based on another query in one request. `(PR #5609) <https://github.com/apple/foundationdb/pull/5609>`_
+* Java: Added ``Transaction.getRangeAndFlatMap`` function to support running queries based on another query in one request. `(PR #5609) <https://github.com/apple/foundationdb/pull/5609>`_
 
 Other Changes
 -------------

--- a/fdbclient/MultiVersionTransaction.actor.cpp
+++ b/fdbclient/MultiVersionTransaction.actor.cpp
@@ -609,7 +609,7 @@ void DLApi::init() {
 	                   headerVersion >= 0);
 	loadClientFunction(&api->transactionGetRange, lib, fdbCPath, "fdb_transaction_get_range", headerVersion >= 0);
 	loadClientFunction(
-	    &api->transactionGetMappedRange, lib, fdbCPath, "fdb_transaction_get_mapped_range", headerVersion >= 700);
+	    &api->transactionGetMappedRange, lib, fdbCPath, "fdb_transaction_get_mapped_range", headerVersion >= 710);
 	loadClientFunction(
 	    &api->transactionGetVersionstamp, lib, fdbCPath, "fdb_transaction_get_versionstamp", headerVersion >= 410);
 	loadClientFunction(&api->transactionSet, lib, fdbCPath, "fdb_transaction_set", headerVersion >= 0);
@@ -667,7 +667,7 @@ void DLApi::init() {
 	loadClientFunction(
 	    &api->futureGetKeyValueArray, lib, fdbCPath, "fdb_future_get_keyvalue_array", headerVersion >= 0);
 	loadClientFunction(
-	    &api->futureGetMappedKeyValueArray, lib, fdbCPath, "fdb_future_get_mappedkeyvalue_array", headerVersion >= 700);
+	    &api->futureGetMappedKeyValueArray, lib, fdbCPath, "fdb_future_get_mappedkeyvalue_array", headerVersion >= 710);
 	loadClientFunction(&api->futureGetSharedState, lib, fdbCPath, "fdb_future_get_shared_state", headerVersion >= 710);
 	loadClientFunction(&api->futureSetCallback, lib, fdbCPath, "fdb_future_set_callback", headerVersion >= 0);
 	loadClientFunction(&api->futureCancel, lib, fdbCPath, "fdb_future_cancel", headerVersion >= 0);


### PR DESCRIPTION
Deprecate `fdb_transaction_get_range_and_flat_map` which was introduced prematurely in 7.0, in preference of `fdb_transaction_get_mapped_range` in 7.1.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
