### PR TITLE
Remote kvs error handling

### DIFF
--- a/fdbserver/RemoteIKeyValueStore.actor.cpp
+++ b/fdbserver/RemoteIKeyValueStore.actor.cpp
@@ -91,8 +91,7 @@ ACTOR Future<Void> runIKVS(OpenKVStoreRequest openReq, IKVSInterface ikvsInterfa
 	state AfterReturn guard(kvStore, kvsId);
 	state Promise<Void> onClosed;
 	TraceEvent(SevDebug, "RemoteKVStoreInitializing").detail("UID", kvsId);
-	wait(kvStore->init());
-	openReq.reply.send(ikvsInterface);
+	wait(cancellableForwardPromise(openReq.reply, tag(kvStore->init(), ikvsInterface)));
 	TraceEvent(SevInfo, "RemoteKVStoreInitialized").detail("IKVSInterfaceUID", kvsId);
 
 	loop {

--- a/flow/Error.h
+++ b/flow/Error.h
@@ -53,7 +53,7 @@ public:
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, error_code);
+		serializer(ar, error_code, flags);
 	}
 
 	Error() : error_code(invalid_error_code), flags(0) {}
@@ -73,7 +73,7 @@ public:
 	Error asInjectedFault() const; // Returns an error with the same code() as this but isInjectedFault() is true
 private:
 	uint16_t error_code;
-	uint16_t flags;
+	uint8_t flags;
 
 	enum Flags { FLAG_INJECTED_FAULT = 1 };
 };


### PR DESCRIPTION
This fixes the issue that remote KVS init() would not send failures to the requestor, and also that in simulation injected errors sent back to the storage server would lose the Injected state so the simulation test would be considered a failure.

Fixing this fixed an issue where KVS init() on the remote side would throw and the SS kvs client init() would see broken_promise and then StorageServerTerminated would log non-injected io_timeout so the test would fail.  I do not know what was creating the io_timeout, but the io_error from the remote KVS was not being sent so there was no way for the storage server to get the right error.  With that fixed, Storage Server terminates on io_error but this is still a simulation failure as it was not Injected.  Fixing the Error serialization to retain error flags enables the Storage Server to see that the error was injected.  Note that to prove the fix for this particular failure case required a serialization of Error with the injected bit but without changing determinism which means without changing the message size, which I did, but that implementation is not suitable for checkin.

There are correctness failures with these changes.  The first one is definitely related to remote KVS, the others may not be.

Correctness failures on this PR head:
```
Assertion failure in RemoteKVS:
bin/fdbserver -r simulation -f tests/slow/SwizzledDdBalance.toml -s 864328302 -b on  --crash --trace_format json

Other errors: 
bin/fdbserver -r simulation -f tests/rare/CycleRollbackClogged.toml -s 889678395 -b on  --crash --trace_format json
bin/fdbserver -r simulation -f tests/rare/CycleRollbackClogged.toml -s 889678395 -b on  --crash --trace_format json
bin/fdbserver -r simulation -f tests/slow/SwizzledRollbackTimeLapseIncrement.toml -s 659370194 -b on  --crash --trace_format json
```

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
