### PR TITLE
Enforce storage migration compatible config in restarting test

### DIFF
--- a/fdbserver/workloads/ConfigureDatabase.actor.cpp
+++ b/fdbserver/workloads/ConfigureDatabase.actor.cpp
@@ -227,7 +227,8 @@ struct ConfigureDatabaseWorkload : TestWorkload {
 	double testDuration;
 	int additionalDBs;
 	bool allowDescriptorChange;
-	bool allowTestStorageMigration;
+	bool allowTestStorageMigration; // allow change storage migration and perpetual wiggle conf
+	bool storageMigrationCompatibleConf; // only allow generating configuration suitable for storage migration test
 	bool waitStoreTypeCheck;
 	bool downgradeTest1; // if this is true, don't pick up downgrade incompatible config
 	std::vector<Future<Void>> clients;
@@ -239,6 +240,7 @@ struct ConfigureDatabaseWorkload : TestWorkload {
 		    getOption(options, LiteralStringRef("allowDescriptorChange"), SERVER_KNOBS->ENABLE_CROSS_CLUSTER_SUPPORT);
 		allowTestStorageMigration =
 		    getOption(options, "allowTestStorageMigration"_sr, false) && g_simulator.allowStorageMigrationTypeChange;
+		storageMigrationCompatibleConf = getOption(options, "storageMigrationCompatibleConf"_sr, false);
 		waitStoreTypeCheck = getOption(options, "waitStoreTypeCheck"_sr, false);
 		downgradeTest1 = getOption(options, "downgradeTest1"_sr, false);
 		g_simulator.usableRegions = 1;
@@ -349,7 +351,11 @@ struct ConfigureDatabaseWorkload : TestWorkload {
 			}
 			state int randomChoice;
 			if (self->allowTestStorageMigration) {
-				randomChoice = deterministicRandom()->randomInt(4, 9);
+				randomChoice = (deterministicRandom()->random01() < 0.375) ? deterministicRandom()->randomInt(0, 3)
+				                                                           : deterministicRandom()->randomInt(4, 9);
+			} else if (self->storageMigrationCompatibleConf) {
+				randomChoice = (deterministicRandom()->random01() < 3.0 / 7) ? deterministicRandom()->randomInt(0, 3)
+				                                                             : deterministicRandom()->randomInt(5, 9);
 			} else {
 				randomChoice = deterministicRandom()->randomInt(0, 8);
 			}

--- a/tests/restarting/from_7.1.0/ConfigureStorageMigrationTestRestart-2.toml
+++ b/tests/restarting/from_7.1.0/ConfigureStorageMigrationTestRestart-2.toml
@@ -10,6 +10,7 @@ waitForQuiescenceBegin=false
     testName = 'ConfigureDatabase'
     testDuration = 300.0
     waitStoreTypeCheck = true
+    storageMigrationCompatibleConf = true
 
     [[test.workload]]
     testName = 'RandomClogging'

--- a/tests/restarting/to_7.1.0/ConfigureStorageMigrationTestRestart-2.toml
+++ b/tests/restarting/to_7.1.0/ConfigureStorageMigrationTestRestart-2.toml
@@ -10,6 +10,7 @@ waitForQuiescenceBegin=false
     testName = 'ConfigureDatabase'
     testDuration = 300.0
     waitStoreTypeCheck = true
+    storageMigrationCompatibleConf = true
 
     [[test.workload]]
     testName = 'RandomClogging'


### PR DESCRIPTION
Fix: 
Commit: `465ff712b63eb78f13044a3dc68e2d63fd6c487c`
The restart-2 change the storage engine and replica which cannot be achieved without adding more SS and enabling perpetual wiggle. 
The fix is just changing the test to make it always simulate the reasonable configuration change.

```
| C | restarting/from_7.1.0/ConfigureStorageMigrationTestResta | F | 883463378 |
| C | restarting/from_7.1.0/ConfigureStorageMigrationTestResta | F | 883463379 |
```

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
