### PR TITLE
Convert the ScopeEventFieldTypeMismatch event to a Sev40 in simulation.

### DIFF
--- a/flow/TDMetric.actor.h
+++ b/flow/TDMetric.actor.h
@@ -963,7 +963,7 @@ struct DynamicFieldBase {
 		if (getDerivedTypeName() == metricTypeName<T>())
 			return (DynamicField<T>*)this;
 
-		TraceEvent(SevWarnAlways, "ScopeEventFieldTypeMismatch")
+		TraceEvent(g_network->isSimulated() ? SevError :SevWarnAlways, "ScopeEventFieldTypeMismatch")
 		    .detail("EventType", eventType.toString())
 		    .detail("FieldName", fieldName().toString())
 		    .detail("OldType", getDerivedTypeName().toString())

--- a/flow/TDMetric.actor.h
+++ b/flow/TDMetric.actor.h
@@ -963,7 +963,7 @@ struct DynamicFieldBase {
 		if (getDerivedTypeName() == metricTypeName<T>())
 			return (DynamicField<T>*)this;
 
-		TraceEvent(g_network->isSimulated() ? SevError :SevWarnAlways, "ScopeEventFieldTypeMismatch")
+		TraceEvent(g_network->isSimulated() ? SevError : SevWarnAlways, "ScopeEventFieldTypeMismatch")
 		    .detail("EventType", eventType.toString())
 		    .detail("FieldName", fieldName().toString())
 		    .detail("OldType", getDerivedTypeName().toString())


### PR DESCRIPTION
ScopeEventFieldTypeMismatch trace event occurs when the detail field gets duplicates. Making it a Sev40 for simulation only runs to catch such duplicates in simulation.

Ran 100K simulation tests.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
