### PR TITLE
fix configure workload typo

### DIFF
--- a/fdbserver/workloads/ConfigureDatabase.actor.cpp
+++ b/fdbserver/workloads/ConfigureDatabase.actor.cpp
@@ -355,7 +355,7 @@ struct ConfigureDatabaseWorkload : TestWorkload {
 				                                                           : deterministicRandom()->randomInt(4, 9);
 			} else if (self->storageMigrationCompatibleConf) {
 				randomChoice = (deterministicRandom()->random01() < 3.0 / 7) ? deterministicRandom()->randomInt(0, 3)
-				                                                             : deterministicRandom()->randomInt(5, 9);
+				                                                             : deterministicRandom()->randomInt(4, 8);
 			} else {
 				randomChoice = deterministicRandom()->randomInt(0, 8);
 			}


### PR DESCRIPTION
#6806 follow up.

For `self->storageMigrationCompatibleConf`, [0,3) and [4,8) are valid because it's use for restarting test, in `restart-2` test the perpetual wiggle and storage migration setting are expected to be the same as `restart-1`.
# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
