### PR TITLE
Enable xxhash checksum for TLog

### DIFF
--- a/fdbclient/include/fdbclient/FDBTypes.h
+++ b/fdbclient/include/fdbclient/FDBTypes.h
@@ -915,7 +915,7 @@ struct TLogVersion {
 		MIN_SUPPORTED = V2,
 		MAX_SUPPORTED = V7,
 		MIN_RECRUITABLE = V6,
-		DEFAULT = V6,
+		DEFAULT = V7,
 	} version;
 
 	TLogVersion() : version(UNSET) {}

--- a/fdbclient/include/fdbclient/FDBTypes.h
+++ b/fdbclient/include/fdbclient/FDBTypes.h
@@ -914,7 +914,7 @@ struct TLogVersion {
 		V7 = 7, // 7.2
 		MIN_SUPPORTED = V2,
 		MAX_SUPPORTED = V7,
-		MIN_RECRUITABLE = V6,
+		MIN_RECRUITABLE = V7,
 		DEFAULT = V7,
 	} version;
 

--- a/fdbserver/KeyValueStoreMemory.actor.cpp
+++ b/fdbserver/KeyValueStoreMemory.actor.cpp
@@ -1007,8 +1007,7 @@ IKeyValueStore* keyValueStoreMemory(std::string const& basename,
 	    .detail("MemoryLimit", memoryLimit)
 	    .detail("StoreType", storeType);
 
-	// SOMEDAY: update to use DiskQueueVersion::V2 with xxhash3 checksum for FDB >= 7.2
-	IDiskQueue* log = openDiskQueue(basename, ext, logID, DiskQueueVersion::V1);
+	IDiskQueue* log = openDiskQueue(basename, ext, logID, DiskQueueVersion::V2);
 	if (storeType == KeyValueStoreType::MEMORY_RADIXTREE) {
 		return new KeyValueStoreMemory<radix_tree>(
 		    log, Reference<AsyncVar<ServerDBInfo> const>(), logID, memoryLimit, storeType, false, false, false, false);

--- a/tests/restarting/to_7.1.0/ConfigureStorageMigrationTestRestart-1.toml
+++ b/tests/restarting/to_7.1.0/ConfigureStorageMigrationTestRestart-1.toml
@@ -1,6 +1,6 @@
 [configuration]
 extraMachineCountDC = 2
-maxTLogVersion=6
+maxTLogVersion=7
 disableHostname=true
 disableEncryption=true
 storageEngineExcludeTypes=[4]

--- a/tests/restarting/to_7.1.0/CycleTestRestart-1.txt
+++ b/tests/restarting/to_7.1.0/CycleTestRestart-1.txt
@@ -1,5 +1,5 @@
 storageEngineExcludeTypes=-1,-2,3
-maxTLogVersion=6
+maxTLogVersion=7
 disableTss=true
 disableHostname=true
 disableEncryption=true

--- a/tests/restarting/to_7.1.0/CycleTestRestart-2.txt
+++ b/tests/restarting/to_7.1.0/CycleTestRestart-2.txt
@@ -1,5 +1,5 @@
 storageEngineExcludeTypes=-1,-2
-maxTLogVersion=6
+maxTLogVersion=7
 disableTss=true
 testTitle=Clogged
     runSetup=false


### PR DESCRIPTION
xxhash checksum support for TLog was added in #6335. Enable it for 7.2.

Closes #5141 

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
