### PR TITLE
Add support for the reboot command in go bindings

### DIFF
--- a/bindings/go/README.md
+++ b/bindings/go/README.md
@@ -25,7 +25,6 @@ You can also build this package, in the top level of this repository run:
 
 This will create binary packages for the appropriate platform within the "build" subdirectory of this folder.
 
-
 Documentation
 -------------
 

--- a/bindings/go/src/fdb/database.go
+++ b/bindings/go/src/fdb/database.go
@@ -27,6 +27,7 @@ package fdb
 import "C"
 
 import (
+	"errors"
 	"runtime"
 
 	"golang.org/x/xerrors"
@@ -80,6 +81,32 @@ func (d Database) CreateTransaction() (Transaction, error) {
 	runtime.SetFinalizer(t, (*transaction).destroy)
 
 	return Transaction{t}, nil
+}
+
+// RebootWorker is a wrapper around fdb_database_reboot_worker and allows to reboot processes
+// from the go bindings. If a suspendDuration > 0 is provided the rebooted process will be
+// suspended for suspendDuration seconds. If checkFile is set to true the process will check
+// if the data directory is writeable by creating a validation file. The address must be a
+// process address is the form of IP:Port pair.
+func (d Database) RebootWorker(address string, checkFile bool, suspendDuration int) error {
+	t := &futureInt64{
+		future: newFuture(C.fdb_database_reboot_worker(
+			d.ptr,
+			byteSliceToPtr([]byte(address)),
+			C.int(len(address)),
+			C.fdb_bool_t(boolToInt(checkFile)),
+			C.int(suspendDuration),
+		),
+		),
+	}
+
+	dbVersion, err := t.Get()
+
+	if dbVersion == 0 {
+		return errors.New("failed to send reboot process request")
+	}
+
+	return err
 }
 
 func retryable(wrapped func() (interface{}, error), onError func(Error) FutureNil) (ret interface{}, e error) {

--- a/bindings/go/src/fdb/fdb_test.go
+++ b/bindings/go/src/fdb/fdb_test.go
@@ -101,14 +101,13 @@ func TestReadTransactionOptions(t *testing.T) {
 	fdb.MustAPIVersion(710)
 	db := fdb.MustOpenDefault()
 	_, e := db.ReadTransact(func(rtr fdb.ReadTransaction) (interface{}, error) {
-		rtr.Options().SetAccessSystemKeys();
+		rtr.Options().SetAccessSystemKeys()
 		return rtr.Get(fdb.Key("\xff/")).MustGet(), nil
 	})
 	if e != nil {
 		t.Errorf("Failed to read system key: %s", e)
 	}
 }
-
 
 func ExampleTransactor() {
 	fdb.MustAPIVersion(710)


### PR DESCRIPTION
Add support for the `fdb_database_reboot_worker` method in the go bindings. I did some testing with the [fdb-kubernetes-operator](https://github.com/FoundationDB/fdb-kubernetes-operator) to ensure everything works.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [x] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
