### PR TITLE
Improve YCSB image logging; remove logic to support partial restarts

### DIFF
--- a/packaging/docker/run_ycsb.sh
+++ b/packaging/docker/run_ycsb.sh
@@ -1,23 +1,16 @@
 #!/usr/bin/env bash
-set -Eeuo pipefail
+set -Eeuxo pipefail
 
 namespace=$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace)
 POD_NUM=$(echo $POD_NAME | cut -d - -f3)
 KEY="ycsb_load_${POD_NUM}_of_${NUM_PODS}_complete"
 CLI=$(ls /var/dynamic-conf/bin/*/fdbcli | head -n1)
-if [ ${MODE} != "load" ]; then
-    echo "WAITING FOR ALL PODS TO COME UP"
-    while [[ $(kubectl get pods -n ${namespace} -l name=ycsb,run=${RUN_ID} --field-selector=status.phase=Running | grep -cv NAME) -lt ${NUM_PODS} ]]; do
-        sleep 0.1
-    done
-    echo "ALL PODS ARE UP"
-else
-    if ${CLI} --exec "get ${KEY}" | grep is ;
-    then
-        # load already completed
-        exit 0
-    fi
-fi;
+
+echo "WAITING FOR ALL PODS TO COME UP"
+while [[ $(kubectl get pods -n ${namespace} -l name=ycsb,run=${RUN_ID} --field-selector=status.phase=Running | grep -cv NAME) -lt ${NUM_PODS} ]]; do
+    sleep 1
+done
+echo "ALL PODS ARE UP"
 
 echo "RUNNING YCSB"
 ./bin/ycsb.sh ${MODE} foundationdb -s -P workloads/${WORKLOAD} ${YCSB_ARGS}
@@ -27,7 +20,3 @@ echo "COPYING HISTOGRAMS TO S3"
 aws s3 sync --sse aws:kms --exclude "*" --include "histogram.*" /tmp s3://${BUCKET}/ycsb_histograms/${namespace}/${POD_NAME}
 echo "COPYING HISTOGRAMS TO S3 FINISHED"
 
-if [ ${MODE} == "load" ]; then
-    ${CLI} --exec "writemode on; set ${KEY} 1"
-    echo "WROTE LOAD COMPLETION KEY"
-fi


### PR DESCRIPTION
The partial restart logic for the YCSB images doesn't work with the preload phase.  This deletes that, and also passes `-x` to bash so that the logs produced by the YCSB container are more useful.

I tested by backporting to release-6.3 (which is a clean backport), building the image, and using the resulting YCSB image to benchmark foundationdb-7.0.0-rc1.

I'm considering removing the .so's, etc from the YCSB image.  It'll make it much smaller, and also intentionally break misconfigured environments that try to use the YCSB image's version of the FDB drivers instead of getting matching drivers from the running version of fdbserver.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
