### PR TITLE
Use a storageTeamCursor wide arena to hold the data

### DIFF
--- a/fdbserver/ptxn/TLogPeekCursor.actor.cpp
+++ b/fdbserver/ptxn/TLogPeekCursor.actor.cpp
@@ -250,7 +250,7 @@ StorageTeamPeekCursor::StorageTeamPeekCursor(const Version& beginVersion_,
                                              const bool reportEmptyVersion_)
   : VersionSubsequencePeekCursorBase(), storageTeamID(storageTeamID_), pTLogInterfaces(pTLogInterfaces_),
     pAttachArena(pArena_), deserializer(emptyCursorHeader(), /* reportEmptyVersion_ */ true),
-    wrappedDeserializerIter(deserializer.begin(), pArena_), beginVersion(beginVersion_),
+    wrappedDeserializerIter(deserializer.begin(), &localArena), beginVersion(beginVersion_),
     reportEmptyVersion(reportEmptyVersion_), rpcVersion(beginVersion_) {
 
 	for (const auto pTLogInterface : pTLogInterfaces) {

--- a/fdbserver/ptxn/TLogPeekCursor.actor.h
+++ b/fdbserver/ptxn/TLogPeekCursor.actor.h
@@ -257,6 +257,11 @@ private:
 	// it will not be GCed after the ACTOR terminates.
 	Arena workArena;
 
+	// This is the cursor-wide arena that has the same lifetime as the cursor. This arena is used to depend on all the
+	// parsed mutationRef to make sure that the data is still around before the next iteration.
+	// TODO(PTXN): remove this arena once we switch to use ArenaReader.
+	Arena localArena;
+
 	// The version the cursor begins, all versions that are smaller than beginVersion will be ignored by remote TLog
 	const Version beginVersion;
 


### PR DESCRIPTION
This is a temporary solution to make StorageTeamPeekCursor to not lose data after Reset().

This will be replaced once we switch to use ArenaReader in `TwoLevelHeaderedItemsDeserializer`.

20220412-052437-zhewu_6835-4dada5e168429949        compressed=True data_size=30653842 duration=5592294 ended=100000 fail=1 fail_fast=10 max_runs=100000 pass=99999 priority=100 remaining=0 runtime=0:54:15 sanity=False started=100095 stopped=20220412-061852 submitted=20220412-052437 timeout=5400 username=zhewu_6835

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
