### PR TITLE
Fix provisional GRV Proxy ID in GetReadVersionReply

### DIFF
--- a/fdbserver/ClusterRecovery.actor.cpp
+++ b/fdbserver/ClusterRecovery.actor.cpp
@@ -851,6 +851,7 @@ ACTOR Future<Standalone<CommitTransactionRef>> provisionalMaster(Reference<Clust
 				rep.version = parent->lastEpochEnd;
 				rep.locked = locked;
 				rep.metadataVersion = metadataVersion;
+				rep.proxyId = parent->provisionalGrvProxies[0].id();
 				req.reply.send(rep);
 			} else
 				req.reply.send(Never()); // We can't perform causally consistent reads without recovering


### PR DESCRIPTION
This was not set and can cause infinite loop in simulation where the client
calls getConsistentReadVersion(), in which we do "continue" for stale GRV reply
and retry. Then this repeats forever.

Found by @sfc-gh-satherton and @sfc-gh-etschannen .

To reproduce

compiler: clang
commit: 01234720
seed: -r simulation -f ./foundationdb/tests/slow/ParallelRestoreNewBackupCorrectnessAtomicOp.toml -s 504847191 -b on

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
