### PR TITLE
make mutablePeekCursor takes a list of storage teams as an input

### DIFF
--- a/fdbserver/ptxn/test/TestTLogPeek.actor.cpp
+++ b/fdbserver/ptxn/test/TestTLogPeek.actor.cpp
@@ -517,8 +517,11 @@ TEST_CASE("/fdbserver/ptxn/test/tLogPeek/cursor/merged/OrderedMutableTeamPeekCur
 	        ptxn::test::TestEnvironment::getTLogGroup())
 	        .privateMutationsStorageTeamID;
 
-	pCursor = std::make_shared<ptxn::merged::OrderedMutableTeamPeekCursor>(
-	    storageServerIDs[0], privateMutationsStorageTeamID, getTLogInterfaceByStorageTeamID, /* version */ 0);
+	pCursor = std::make_shared<ptxn::merged::OrderedMutableTeamPeekCursor>(storageServerIDs[0],
+	                                                                       privateMutationsStorageTeamID,
+	                                                                       Optional<std::set<ptxn::StorageTeamID>>(),
+	                                                                       getTLogInterfaceByStorageTeamID,
+	                                                                       /* version */ 0);
 
 	state Arena storageArena;
 	state std::vector<ptxn::VersionSubsequenceMessage> messagesFromTLogs =

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -5581,12 +5581,13 @@ std::vector<ptxn::TLogInterfaceBase*> getTLogInterfaceByStorageTeamID(const Serv
 }
 
 void initializeUpdateCursor(ptxn::StorageServer& storageServerContext) {
-	auto referencedServerDBInfo = storageServerContext.db;
+	ServerDBInfo copiedServerDbInfo = storageServerContext.db->get();
 	storageServerContext.logCursor = std::make_shared<merged::OrderedMutableTeamPeekCursor>(
 	    storageServerContext.thisServerID,
 	    getStoragePrivateMutationTeam(storageServerContext),
-	    [referencedServerDBInfo](const StorageTeamID& storageTeamID) -> auto {
-		    return getTLogInterfaceByStorageTeamID(referencedServerDBInfo->get(), storageTeamID);
+	    storageServerContext.storageTeamIDs,
+	    [copiedServerDbInfo](const StorageTeamID& storageTeamID) -> auto {
+		    return getTLogInterfaceByStorageTeamID(copiedServerDbInfo, storageTeamID);
 	    },
 	    storageServerContext.version.get() + 1);
 }


### PR DESCRIPTION
make mutablePeekCursor takes a list of storage teams as an input.

This is a hacky version of the change, which has been proven to pass the cycle test. @xis19 is working on the actual fix.

20220413-050736-zhewu_6850-c7e8e5a10e83da6f

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
