### PR TITLE
Allows temporarily modify knobs in test TOML files

### DIFF
--- a/fdbclient/ClientKnobCollection.h
+++ b/fdbclient/ClientKnobCollection.h
@@ -49,4 +49,4 @@ public:
 	bool isAtomic(std::string const& knobName) const override;
 };
 
-#endif 	// FDBCLIENT_CLIENTKNOBCCOLLECTION_H
+#endif // FDBCLIENT_CLIENTKNOBCCOLLECTION_H

--- a/fdbclient/ClientKnobCollection.h
+++ b/fdbclient/ClientKnobCollection.h
@@ -18,6 +18,9 @@
  * limitations under the License.
  */
 
+#ifndef FDBCLIENT_CLIENTKNOBCOLLECTION_H
+#define FDBCLIENT_CLIENTKNOBCOLLECTION_H
+
 #pragma once
 
 #include "fdbclient/ClientKnobs.h"
@@ -45,3 +48,5 @@ public:
 	bool trySetKnob(std::string const& knobName, KnobValueRef const& knobValue) override;
 	bool isAtomic(std::string const& knobName) const override;
 };
+
+#endif 	// FDBCLIENT_CLIENTKNOBCCOLLECTION_H

--- a/fdbclient/IKnobCollection.h
+++ b/fdbclient/IKnobCollection.h
@@ -18,6 +18,9 @@
  * limitations under the License.
  */
 
+#ifndef FDBCLIENT_IKNOBCOLLECTION_H
+#define FDBCLIENT_IKNOBCOLLECTION_H
+
 #pragma once
 
 #include <memory>
@@ -69,3 +72,5 @@ public:
 	static ConfigMutationRef createSetMutation(Arena, KeyRef, ValueRef);
 	static ConfigMutationRef createClearMutation(Arena, KeyRef);
 };
+
+#endif	// FDBCLIENT_IKNOBCOLLECTION_H

--- a/fdbclient/IKnobCollection.h
+++ b/fdbclient/IKnobCollection.h
@@ -73,4 +73,4 @@ public:
 	static ConfigMutationRef createClearMutation(Arena, KeyRef);
 };
 
-#endif	// FDBCLIENT_IKNOBCOLLECTION_H
+#endif // FDBCLIENT_IKNOBCOLLECTION_H

--- a/fdbclient/ServerKnobCollection.h
+++ b/fdbclient/ServerKnobCollection.h
@@ -18,6 +18,9 @@
  * limitations under the License.
  */
 
+#ifndef FDBCLIENT_SERVERKNOBCOLLECTION_H
+#define FDBCLIENT_SERVERKNOBCOLLECTION_H
+
 #pragma once
 
 #include "fdbclient/ClientKnobCollection.h"
@@ -43,3 +46,5 @@ public:
 	bool trySetKnob(std::string const& knobName, KnobValueRef const& knobValue) override;
 	bool isAtomic(std::string const& knobName) const override;
 };
+
+#endif // FDBCLIENT_SERVERKNOBCOLLECTION_H

--- a/fdbclient/TestKnobCollection.h
+++ b/fdbclient/TestKnobCollection.h
@@ -18,6 +18,9 @@
  * limitations under the License.
  */
 
+#ifndef FDBCLIENT_TESTKNOBCOLLECTION_H
+#define FDBCLIENT_TESTKNOBCOLLECTION_H
+
 #pragma once
 
 #include "fdbclient/IKnobCollection.h"
@@ -67,3 +70,5 @@ public:
 	bool trySetKnob(std::string const& knobName, KnobValueRef const& knobValue) override;
 	bool isAtomic(std::string const& knobName) const override;
 };
+
+#endif // FDBCLIENT_TESTKNOBCOLLECTION_H

--- a/fdbserver/CMakeLists.txt
+++ b/fdbserver/CMakeLists.txt
@@ -43,6 +43,8 @@ set(FDBSERVER_SRCS
   KeyValueStoreMemory.actor.cpp
   KeyValueStoreRocksDB.actor.cpp
   KeyValueStoreSQLite.actor.cpp
+  KnobProtectiveGroups.cpp
+  KnobProtectiveGroups.h
   Knobs.h
   LatencyBandConfig.cpp
   LatencyBandConfig.h

--- a/fdbserver/KnobProtectiveGroups.cpp
+++ b/fdbserver/KnobProtectiveGroups.cpp
@@ -1,0 +1,73 @@
+/*
+ * KnobProtectiveGroups.cpp
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2022 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "fdbserver/KnobProtectiveGroups.h"
+
+#include <array>
+
+#include "fdbclient/Knobs.h"
+#include "fdbclient/ServerKnobCollection.h"
+#include "fdbserver/Knobs.h"
+
+void KnobKeyValuePairs::set(const std::string& name, const ParsedKnobValue value) {
+	ASSERT(knobs.count(name) == 0);
+
+	knobs[name] = value;
+}
+
+const KnobKeyValuePairs::container_t& KnobKeyValuePairs::getKnobs() const {
+	return knobs;
+}
+
+KnobProtectiveGroup::KnobProtectiveGroup(const KnobKeyValuePairs& overriddenKnobKeyValuePairs_)
+  : overriddenKnobs(overriddenKnobKeyValuePairs_) {
+	snapshotOriginalKnobs();
+	assignKnobs(overriddenKnobs);
+}
+
+KnobProtectiveGroup::~KnobProtectiveGroup() {
+	assignKnobs(originalKnobs);
+}
+
+void KnobProtectiveGroup::snapshotOriginalKnobs() {
+	for (const auto& [name, _] : overriddenKnobs.getKnobs()) {
+		ParsedKnobValue value = CLIENT_KNOBS->getKnob(name);
+		if (std::get_if<NoKnobFound>(&value)) {
+			value = SERVER_KNOBS->getKnob(name);
+		}
+		if (std::get_if<NoKnobFound>(&value)) {
+			ASSERT(false);
+		}
+		originalKnobs.set(name, value);
+		TraceEvent("SnapshotKnobValue")
+		    .detail("KnobName", name)
+		    .detail("KnobValue", KnobValueRef::create(value).toString());
+	}
+}
+
+void KnobProtectiveGroup::assignKnobs(const KnobKeyValuePairs& overrideKnobs) {
+	auto& mutableServerKnobs = dynamic_cast<ServerKnobCollection&>(IKnobCollection::getMutableGlobalKnobCollection());
+
+	for (const auto& [name, value] : overrideKnobs.getKnobs()) {
+		Standalone<KnobValueRef> valueRef = KnobValueRef::create(value);
+		ASSERT(mutableServerKnobs.trySetKnob(name, valueRef));
+		TraceEvent("AssignKnobValue").detail("KnobName", name).detail("KnobValue", valueRef.toString());
+	}
+}

--- a/fdbserver/KnobProtectiveGroups.cpp
+++ b/fdbserver/KnobProtectiveGroups.cpp
@@ -56,7 +56,7 @@ void KnobProtectiveGroup::snapshotOriginalKnobs() {
 			ASSERT(false);
 		}
 		originalKnobs.set(name, value);
-		TraceEvent("SnapshotKnobValue")
+		TraceEvent(SevInfo, "SnapshotKnobValue")
 		    .detail("KnobName", name)
 		    .detail("KnobValue", KnobValueRef::create(value).toString());
 	}
@@ -68,6 +68,6 @@ void KnobProtectiveGroup::assignKnobs(const KnobKeyValuePairs& overrideKnobs) {
 	for (const auto& [name, value] : overrideKnobs.getKnobs()) {
 		Standalone<KnobValueRef> valueRef = KnobValueRef::create(value);
 		ASSERT(mutableServerKnobs.trySetKnob(name, valueRef));
-		TraceEvent("AssignKnobValue").detail("KnobName", name).detail("KnobValue", valueRef.toString());
+		TraceEvent(SevInfo, "AssignKnobValue").detail("KnobName", name).detail("KnobValue", valueRef.toString());
 	}
 }

--- a/fdbserver/KnobProtectiveGroups.h
+++ b/fdbserver/KnobProtectiveGroups.h
@@ -29,31 +29,33 @@
 // A list of knob key value pairs
 class KnobKeyValuePairs {
 public:
-    using container_t = std::unordered_map<std::string, ParsedKnobValue>;
+	using container_t = std::unordered_map<std::string, ParsedKnobValue>;
+
 private:
-    // Here the knob value is directly stored, unlike KnobValue, for simplicity
-    container_t knobs;
+	// Here the knob value is directly stored, unlike KnobValue, for simplicity
+	container_t knobs;
 
 public:
-    // Sets a value for a given knob
-    void set(const std::string& name, const ParsedKnobValue value);
+	// Sets a value for a given knob
+	void set(const std::string& name, const ParsedKnobValue value);
 
-    // Gets a list of knobs for given type
-    const container_t& getKnobs() const;
+	// Gets a list of knobs for given type
+	const container_t& getKnobs() const;
 };
 
-// For knobs, temporarily change the values, the original values will be recovered 
+// For knobs, temporarily change the values, the original values will be recovered
 class KnobProtectiveGroup {
-    KnobKeyValuePairs overriddenKnobs;
-    KnobKeyValuePairs originalKnobs;
+	KnobKeyValuePairs overriddenKnobs;
+	KnobKeyValuePairs originalKnobs;
 
-    // Snapshots the current knob values base on those knob keys in overriddenKnobs
-    void snapshotOriginalKnobs();
+	// Snapshots the current knob values base on those knob keys in overriddenKnobs
+	void snapshotOriginalKnobs();
 
-    void assignKnobs(const KnobKeyValuePairs& overrideKnobs);
+	void assignKnobs(const KnobKeyValuePairs& overrideKnobs);
+
 public:
-    KnobProtectiveGroup(const KnobKeyValuePairs& overridenKnobs_);
-    ~KnobProtectiveGroup();
+	KnobProtectiveGroup(const KnobKeyValuePairs& overridenKnobs_);
+	~KnobProtectiveGroup();
 };
 
-#endif  // FDBSERVER_KNOBPROTECTIVEGROUPS_H
+#endif // FDBSERVER_KNOBPROTECTIVEGROUPS_H

--- a/fdbserver/KnobProtectiveGroups.h
+++ b/fdbserver/KnobProtectiveGroups.h
@@ -1,0 +1,59 @@
+/*
+ * KnobProtectiveGroups.h
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2022 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FDBSERVER_KNOBPROTECTIVEGROUPS_H
+#define FDBSERVER_KNOBPROTECTIVEGROUPS_H
+
+#include <array>
+#include <unordered_map>
+
+#include "fdbclient/IKnobCollection.h"
+
+// A list of knob key value pairs
+class KnobKeyValuePairs {
+public:
+    using container_t = std::unordered_map<std::string, ParsedKnobValue>;
+private:
+    // Here the knob value is directly stored, unlike KnobValue, for simplicity
+    container_t knobs;
+
+public:
+    // Sets a value for a given knob
+    void set(const std::string& name, const ParsedKnobValue value);
+
+    // Gets a list of knobs for given type
+    const container_t& getKnobs() const;
+};
+
+// For knobs, temporarily change the values, the original values will be recovered 
+class KnobProtectiveGroup {
+    KnobKeyValuePairs overriddenKnobs;
+    KnobKeyValuePairs originalKnobs;
+
+    // Snapshots the current knob values base on those knob keys in overriddenKnobs
+    void snapshotOriginalKnobs();
+
+    void assignKnobs(const KnobKeyValuePairs& overrideKnobs);
+public:
+    KnobProtectiveGroup(const KnobKeyValuePairs& overridenKnobs_);
+    ~KnobProtectiveGroup();
+};
+
+#endif  // FDBSERVER_KNOBPROTECTIVEGROUPS_H

--- a/fdbserver/Knobs.h
+++ b/fdbserver/Knobs.h
@@ -27,4 +27,4 @@
 
 #define SERVER_KNOBS (&IKnobCollection::getGlobalKnobCollection().getServerKnobs())
 
-#endif  // FDBSERVER_KNOBS_H
+#endif // FDBSERVER_KNOBS_H

--- a/fdbserver/Knobs.h
+++ b/fdbserver/Knobs.h
@@ -18,8 +18,13 @@
  * limitations under the License.
  */
 
+#ifndef FDBSERVER_KNOBS_H
+#define FDBSERVER_KNOBS_H
+
 #pragma once
 
 #include "fdbclient/IKnobCollection.h"
 
 #define SERVER_KNOBS (&IKnobCollection::getGlobalKnobCollection().getServerKnobs())
+
+#endif  // FDBSERVER_KNOBS_H

--- a/fdbserver/tester.actor.cpp
+++ b/fdbserver/tester.actor.cpp
@@ -1355,9 +1355,9 @@ std::vector<TestSpec> readTOMLTests_(std::string fileName) {
 						parsedValue = SERVER_KNOBS->parseKnobValue(key, value);
 					}
 					if (std::get_if<NoKnobFound>(&parsedValue)) {
-						TraceEvent(SevErrro, "TestSpecUnrecognizedKnob")
-							.detail("KnobName", key)
-							.detail("OverrideValue", value);
+						TraceEvent(SevError, "TestSpecUnrecognizedKnob")
+						    .detail("KnobName", key)
+						    .detail("OverrideValue", value);
 						continue;
 					}
 					spec.overrideKnobs.set(key, parsedValue);

--- a/fdbserver/tester.actor.cpp
+++ b/fdbserver/tester.actor.cpp
@@ -1549,7 +1549,7 @@ ACTOR Future<Void> runTests(Reference<AsyncVar<Optional<struct ClusterController
 	for (; idx < tests.size(); idx++) {
 		printf("%f Run test:%s start\n", now(), tests[idx].title.toString().c_str());
 		knobProtectiveGroup = std::make_unique<KnobProtectiveGroup>(tests[idx].overrideKnobs);
-		wait(success(runTest(cx, testers, tests[idx], dbInfo, defaultTenant)));
+		wait(success(runTest(cx, testers, tests[idx], dbInfo)));
 		knobProtectiveGroup.reset(nullptr);
 		printf("%f Run test:%s Done.\n", now(), tests[idx].title.toString().c_str());
 		// do we handle a failure here?

--- a/fdbserver/tester.actor.cpp
+++ b/fdbserver/tester.actor.cpp
@@ -1775,8 +1775,8 @@ ACTOR Future<Void> runTests(Reference<IClusterConnectionRecord> connRecord,
 		actors.push_back(reportErrors(testerServerCore(iTesters[0], connRecord, db, locality), "TesterServerCore"));
 		tests = runTests(cc, ci, iTesters, testSet.testSpecs, startingConfiguration, locality);
 	} else {
-		tests = reportErrors(runTests(cc, ci, testSet.testSpecs, at, minTestersExpected, startingConfiguration, locality),
-		                     "RunTests");
+		tests = reportErrors(
+		    runTests(cc, ci, testSet.testSpecs, at, minTestersExpected, startingConfiguration, locality), "RunTests");
 	}
 
 	choose {

--- a/fdbserver/tester.actor.cpp
+++ b/fdbserver/tester.actor.cpp
@@ -1773,9 +1773,9 @@ ACTOR Future<Void> runTests(Reference<IClusterConnectionRecord> connRecord,
 		actors.push_back(
 		    reportErrors(monitorServerDBInfo(cc, LocalityData(), db), "MonitorServerDBInfo")); // FIXME: Locality
 		actors.push_back(reportErrors(testerServerCore(iTesters[0], connRecord, db, locality), "TesterServerCore"));
-		tests = runTests(cc, ci, iTesters, testSpecs, startingConfiguration, locality);
+		tests = runTests(cc, ci, iTesters, testSet.testSpecs, startingConfiguration, locality);
 	} else {
-		tests = reportErrors(runTests(cc, ci, testSpecs, at, minTestersExpected, startingConfiguration, locality),
+		tests = reportErrors(runTests(cc, ci, testSet.testSpecs, at, minTestersExpected, startingConfiguration, locality),
 		                     "RunTests");
 	}
 

--- a/fdbserver/workloads/workloads.actor.h
+++ b/fdbserver/workloads/workloads.actor.h
@@ -27,6 +27,7 @@
 
 #include "fdbclient/NativeAPI.actor.h"
 #include "fdbclient/DatabaseContext.h" // for clone()
+#include "fdbserver/KnobProtectiveGroups.h"
 #include "fdbserver/TesterInterface.actor.h"
 #include "fdbrpc/simulator.h"
 #include "flow/actorcompiler.h"
@@ -204,6 +205,8 @@ public:
 	ISimulator::BackupAgentType simBackupAgents; // If set to true, then the simulation runs backup agents on the
 	                                             // workers. Can only be used in simulation.
 	ISimulator::BackupAgentType simDrAgents;
+
+	KnobKeyValuePairs overrideKnobs;
 };
 
 ACTOR Future<DistributedTestResults> runWorkload(Database cx, std::vector<TesterInterface> testers, TestSpec spec);

--- a/flow/Knobs.cpp
+++ b/flow/Knobs.cpp
@@ -343,6 +343,26 @@ bool Knobs::setKnob(std::string const& knob, std::string const& value) {
 	return true;
 }
 
+ParsedKnobValue Knobs::getKnob(const std::string& name) const {
+	if (double_knobs.count(name) > 0) {
+		return ParsedKnobValue{ *double_knobs.at(name).value };
+	}
+	if (int64_knobs.count(name) > 0) {
+		return ParsedKnobValue{ *int64_knobs.at(name).value };
+	}
+	if (int_knobs.count(name) > 0) {
+		return ParsedKnobValue{ *int_knobs.at(name).value };
+	}
+	if (string_knobs.count(name) > 0) {
+		return ParsedKnobValue{ *string_knobs.at(name).value };
+	}
+	if (bool_knobs.count(name) > 0) {
+		return ParsedKnobValue{ *bool_knobs.at(name).value };
+	}
+
+	return ParsedKnobValue{ NoKnobFound() };
+}
+
 bool Knobs::isAtomic(std::string const& knob) const {
 	if (double_knobs.count(knob)) {
 		return double_knobs.find(knob)->second.atomic == Atomic::YES;

--- a/flow/Knobs.h
+++ b/flow/Knobs.h
@@ -76,11 +76,24 @@ protected:
 	std::set<std::string> explicitlySetKnobs;
 
 public:
+	// Sets an integer value to an integer knob, returns false if the knob does not exist or type mismatch
 	bool setKnob(std::string const& name, int value);
+
+	// Sets a boolean value to a bool knob, returns false if the knob does not exist or type mismatch
 	bool setKnob(std::string const& name, bool value);
+
+	// Sets an int64_t value to an int64_t knob, returns false if the knob does not exist or type mismatch
 	bool setKnob(std::string const& name, int64_t value);
+
+	// Sets a double value to a double knob, returns false if the knob does not exist or type mismatch
 	bool setKnob(std::string const& name, double value);
+
+	// Sets a string value to a string knob, returns false if the knob does not exist or type mismatch
 	bool setKnob(std::string const& name, std::string const& value);
+
+	// Gets the value of knob
+	ParsedKnobValue getKnob(const std::string& name) const;
+
 	ParsedKnobValue parseKnobValue(std::string const& name, std::string const& value) const;
 	bool isAtomic(std::string const& knob) const;
 	void trace() const;


### PR DESCRIPTION
This patch allows manually override knob values in TOML files.

See
 - https://github.com/apple/foundationdb/pull/6597
 - https://github.com/apple/foundationdb/pull/6751

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
