### PR TITLE
Fix an ASSERT when an fdbcli command times out (snowflake/release-7.1)

### DIFF
--- a/fdbcli/fdbcli.actor.cpp
+++ b/fdbcli/fdbcli.actor.cpp
@@ -1191,6 +1191,9 @@ ACTOR Future<int> cli(CLIOptions opt, LineNoise* plinenoise) {
 		ccf = makeReference<ClusterConnectionFile>(resolvedClusterFile.first);
 		wait(ccf->resolveHostnames());
 	} catch (Error& e) {
+		if (e.code() == error_code_operation_cancelled) {
+			throw;
+		}
 		fprintf(stderr, "%s\n", ClusterConnectionFile::getErrorString(resolvedClusterFile, e).c_str());
 		return 1;
 	}
@@ -1236,6 +1239,9 @@ ACTOR Future<int> cli(CLIOptions opt, LineNoise* plinenoise) {
 			wait(delay(3.0) || success(safeThreadFutureToFuture(tr->getReadVersion())));
 			break;
 		} catch (Error& e) {
+			if (e.code() == error_code_operation_cancelled) {
+				throw;
+			}
 			if (e.code() == error_code_cluster_version_changed) {
 				wait(safeThreadFutureToFuture(tr->onError(e)));
 			} else {
@@ -2023,6 +2029,9 @@ ACTOR Future<int> cli(CLIOptions opt, LineNoise* plinenoise) {
 			TraceEvent(SevInfo, "CLICommandLog", randomID).detail("Command", line).detail("IsError", is_error);
 
 		} catch (Error& e) {
+			if (e.code() == error_code_operation_cancelled) {
+				throw;
+			}
 			if (e.code() == error_code_tenant_name_required) {
 				printAtCol("ERROR: tenant name required. Use the `usetenant' command to select a tenant or enable the "
 				           "`RAW_ACCESS' option to read raw keys.",

--- a/flow/ThreadHelper.actor.h
+++ b/flow/ThreadHelper.actor.h
@@ -698,9 +698,12 @@ Future<T> safeThreadFutureToFutureImpl(ThreadFuture<T> threadFuture) {
 	try {
 		wait(onReady);
 	} catch (Error& e) {
-		ASSERT(e.code() == error_code_actor_cancelled);
+		// broken_promise can be thrown if the network is already shut down
+		ASSERT(e.code() == error_code_operation_cancelled || e.code() == error_code_broken_promise);
 		// prerequisite: we have exclusive ownership of the threadFuture
-		threadFuture.cancel();
+		if (e.code() == error_code_operation_cancelled) {
+			threadFuture.cancel();
+		}
 		throw e;
 	}
 	// threadFuture should be ready


### PR DESCRIPTION
Cherry pick https://github.com/apple/foundationdb/pull/6857 to snowflake/release-7.1



Previously a few catch blocks did not properly propagate operation_cancelled, which caused some code to run after the network had stopped. Also allow broken_promise in the ASSERT for `safeThreadFutureToFutureImpl` since it's not necessarily an error to call safeThreadFutureToFutureImpl after the network is stopped (although it's certainly not useful to do so)

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
