### PR TITLE
Fix failing upgrades due to non-persisted initial cluster version

### DIFF
--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -806,7 +806,7 @@ public:
 	Promise<UID> clusterId;
 	// The version the cluster starts on. This value is not persisted and may
 	// not be valid after a recovery.
-	Version initialClusterVersion = invalidVersion;
+	Version initialClusterVersion = 1;
 	UID thisServerID;
 	Optional<UID> tssPairID; // if this server is a tss, this is the id of its (ss) pair
 	Optional<UID> ssPairID; // if this server is an ss, this is the id of its (tss) pair


### PR DESCRIPTION
The real cluster upgrade tests added by @vikasgupta8 in #6651 were surfacing an upgrade failure when upgrading from FDB 7.0 -> 7.1 (or 7.2). It was due to a storage server not remembering its initial cluster version after the upgrade (it is not persisted durably).

Since the initial cluster version is always (for now) 1, we can always start at this version. In the future, this may no longer be the case, in which case we will need to instead persist the initial cluster version for upgrades. The appropriate logic can be added if/when all FDB clusters start at a version relative to time instead of at version 1.

Passed 10k `restarting/*` tests and 10k `*` tests.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
