### PR TITLE
Disable upgrade tests in sanitizer builds

### DIFF
--- a/bindings/c/CMakeLists.txt
+++ b/bindings/c/CMakeLists.txt
@@ -253,6 +253,7 @@ endif()
             ${CMAKE_SOURCE_DIR}/bindings/c/test/apitester/tests
             )
 
+if(NOT USE_SANITIZER)
   add_test(NAME fdb_c_upgrade_single_threaded
       COMMAND ${CMAKE_SOURCE_DIR}/tests/TestRunner/upgrade_test.py
             --build-dir ${CMAKE_BINARY_DIR}
@@ -262,7 +263,7 @@ endif()
             --process-number 1
     )
 
-    add_test(NAME fdb_c_upgrade_multi_threaded
+  add_test(NAME fdb_c_upgrade_multi_threaded
     COMMAND ${CMAKE_SOURCE_DIR}/tests/TestRunner/upgrade_test.py
           --build-dir ${CMAKE_BINARY_DIR}
           --disable-log-dump
@@ -270,6 +271,7 @@ endif()
           --upgrade-path "6.3.23" "7.0.0" "6.3.23"
           --process-number 3
     )
+endif()
 
 endif()
 


### PR DESCRIPTION
Upgrade tests are using binaries of old FDB versions. These binaries are downloaded from the release repository and are thus not instrumented by the sanitizer, and thus cannot be used in sanitizer builds.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
