### PR TITLE
Fix TenantManagement correctness timeout

### DIFF
--- a/fdbserver/workloads/TenantManagement.actor.cpp
+++ b/fdbserver/workloads/TenantManagement.actor.cpp
@@ -287,6 +287,7 @@ struct TenantManagementWorkload : TestWorkload {
 
 		loop {
 			try {
+				tr->reset();
 				if (operationType == OperationType::SPECIAL_KEYS) {
 					tr->setOption(FDBTransactionOptions::SPECIAL_KEY_SPACE_ENABLE_WRITES);
 					Key key = self->specialKeysTenantMapPrefix.withSuffix(tenant);


### PR DESCRIPTION
The nightly surfaced a timeout in `TenantManagement.toml`. The issue appears to be that a call to `deleteTenant` never completes and instead gets stuck in an infinite loop. This is because after the transaction fails the first couple times, future transactions start getting `transaction_too_old` errors, ensuring future attempts will never succeed. The solution is to reset the transaction at the beginning of each retry.

Reproduces with the following command on 29cf5f1fbf986668b978eabff846f15a907d0da0:

```
bin/fdbserver -r simulation -f tests/slow/TenantManagement.toml --seed 331856885 --buggify on --logsize 1GB --trace_format json --crash
```

Running correctness.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
