### PR TITLE
Don't test requests that don't initialize properly

### DIFF
--- a/fdbserver/workloads/PrivateEndpoints.actor.cpp
+++ b/fdbserver/workloads/PrivateEndpoints.actor.cpp
@@ -90,17 +90,19 @@ struct PrivateEndpoints : TestWorkload {
 	}
 
 	explicit PrivateEndpoints(WorkloadContext const& wcx) : TestWorkload(wcx) {
+		// The commented out request streams below can't be default initialized properly
+		// as they won't initialize all of their memory which causes valgrind to complain.
 		startAfter = getOption(options, "startAfter"_sr, 10.0);
 		runFor = getOption(options, "runFor"_sr, 10.0);
 		addTestFor(&GrvProxyInterface::waitFailure);
 		addTestFor(&GrvProxyInterface::getHealthMetrics);
-		addTestFor(&CommitProxyInterface::getStorageServerRejoinInfo);
+		//addTestFor(&CommitProxyInterface::getStorageServerRejoinInfo);
 		addTestFor(&CommitProxyInterface::waitFailure);
-		addTestFor(&CommitProxyInterface::txnState);
-		addTestFor(&CommitProxyInterface::getHealthMetrics);
-		addTestFor(&CommitProxyInterface::proxySnapReq);
+		//addTestFor(&CommitProxyInterface::txnState);
+		//addTestFor(&CommitProxyInterface::getHealthMetrics);
+		//addTestFor(&CommitProxyInterface::proxySnapReq);
 		addTestFor(&CommitProxyInterface::exclusionSafetyCheckReq);
-		addTestFor(&CommitProxyInterface::getDDMetrics);
+		//addTestFor(&CommitProxyInterface::getDDMetrics);
 	}
 	std::string description() const override { return WorkloadName; }
 	Future<Void> start(Database const& cx) override { return _start(this, cx); }

--- a/fdbserver/workloads/PrivateEndpoints.actor.cpp
+++ b/fdbserver/workloads/PrivateEndpoints.actor.cpp
@@ -96,13 +96,13 @@ struct PrivateEndpoints : TestWorkload {
 		runFor = getOption(options, "runFor"_sr, 10.0);
 		addTestFor(&GrvProxyInterface::waitFailure);
 		addTestFor(&GrvProxyInterface::getHealthMetrics);
-		//addTestFor(&CommitProxyInterface::getStorageServerRejoinInfo);
+		// addTestFor(&CommitProxyInterface::getStorageServerRejoinInfo);
 		addTestFor(&CommitProxyInterface::waitFailure);
-		//addTestFor(&CommitProxyInterface::txnState);
-		//addTestFor(&CommitProxyInterface::getHealthMetrics);
-		//addTestFor(&CommitProxyInterface::proxySnapReq);
+		// addTestFor(&CommitProxyInterface::txnState);
+		// addTestFor(&CommitProxyInterface::getHealthMetrics);
+		// addTestFor(&CommitProxyInterface::proxySnapReq);
 		addTestFor(&CommitProxyInterface::exclusionSafetyCheckReq);
-		//addTestFor(&CommitProxyInterface::getDDMetrics);
+		// addTestFor(&CommitProxyInterface::getDDMetrics);
 	}
 	std::string description() const override { return WorkloadName; }
 	Future<Void> start(Database const& cx) override { return _start(this, cx); }


### PR DESCRIPTION
Some request objects don't initialize their members properly when being constructed using the default constructor. This makes valgrind unhappy.

Testing these request streams probably doesn't give us too much anyways (this test does the same thing for all private endpoints that are added), so for now I just commented those out.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
