### PR TITLE
Put guard pages next to fast alloc memory

### DIFF
--- a/flow/FastAlloc.cpp
+++ b/flow/FastAlloc.cpp
@@ -519,7 +519,7 @@ void FastAllocator<Size>::getMagazine() {
 		--g_allocation_tracing_disabled;
 	}
 #endif
-	block = (void**)::allocate(magazine_size * Size, false);
+	block = (void**)::allocate(magazine_size * Size, /*allowLargePages*/ false, /*includeGuardPages*/ true);
 #endif
 
 	// void** block = new void*[ magazine_size * PSize ];

--- a/flow/Platform.actor.cpp
+++ b/flow/Platform.actor.cpp
@@ -2037,7 +2037,20 @@ static void enableLargePages() {
 #endif
 }
 
-static void* allocateInternal(size_t length, bool largePages) {
+static void* mmapInternal(size_t length, int flags, bool guardPages) {
+	if (guardPages) {
+		constexpr size_t pageSize = 4096;
+		length += 2 * 4096; // Map enough for the guard pages
+		void* resultWithGuardPages = mmap(nullptr, length, PROT_READ | PROT_WRITE, flags, -1, 0);
+		mprotect(resultWithGuardPages, pageSize, PROT_NONE); // left guard page
+		mprotect((void*)(uintptr_t(resultWithGuardPages) + length - pageSize), pageSize, PROT_NONE); // right guard page
+		return (void*)(uintptr_t(resultWithGuardPages) + pageSize);
+	} else {
+		return mmap(nullptr, length, PROT_READ | PROT_WRITE, flags, -1, 0);
+	}
+}
+
+static void* allocateInternal(size_t length, bool largePages, bool guardPages) {
 
 #ifdef _WIN32
 	DWORD allocType = MEM_COMMIT | MEM_RESERVE;
@@ -2052,31 +2065,31 @@ static void* allocateInternal(size_t length, bool largePages) {
 	if (largePages)
 		flags |= MAP_HUGETLB;
 
-	return mmap(nullptr, length, PROT_READ | PROT_WRITE, flags, -1, 0);
+	return mmapInternal(length, flags, guardPages);
 #elif defined(__APPLE__) || defined(__FreeBSD__)
 	int flags = MAP_PRIVATE | MAP_ANON;
 
-	return mmap(nullptr, length, PROT_READ | PROT_WRITE, flags, -1, 0);
+	return mmapInternal(length, flags, guardPages);
 #else
 #error Port me!
 #endif
 }
 
 static bool largeBlockFail = false;
-void* allocate(size_t length, bool allowLargePages) {
+void* allocate(size_t length, bool allowLargePages, bool includeGuardPages) {
 	if (allowLargePages)
 		enableLargePages();
 
 	void* block = ALLOC_FAIL;
 
 	if (allowLargePages && !largeBlockFail) {
-		block = allocateInternal(length, true);
+		block = allocateInternal(length, true, includeGuardPages);
 		if (block == ALLOC_FAIL)
 			largeBlockFail = true;
 	}
 
 	if (block == ALLOC_FAIL)
-		block = allocateInternal(length, false);
+		block = allocateInternal(length, false, includeGuardPages);
 
 	// FIXME: SevWarnAlways trace if "close" to out of memory
 

--- a/flow/Platform.h
+++ b/flow/Platform.h
@@ -284,7 +284,7 @@ std::string epochsToGMTString(double epochs);
 
 void setMemoryQuota(size_t limit);
 
-void* allocate(size_t length, bool allowLargePages);
+void* allocate(size_t length, bool allowLargePages, bool includeGuardPages);
 
 void setAffinity(int proc);
 


### PR DESCRIPTION
I verified that we can now detect #6753 without creating tons of
threads.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
