### PR TITLE
7.1 Cherry-pick: Do not invoke version vector related code when the feature is disabled

### DIFF
--- a/fdbserver/masterserver.actor.cpp
+++ b/fdbserver/masterserver.actor.cpp
@@ -275,8 +275,10 @@ ACTOR Future<Void> serveLiveCommittedVersion(Reference<MasterData> self) {
 				reply.locked = self->databaseLocked;
 				reply.metadataVersion = self->proxyMetadataVersion;
 				reply.minKnownCommittedVersion = self->minKnownCommittedVersion;
-				self->ssVersionVector.getDelta(req.maxVersion, reply.ssVersionVectorDelta);
-				self->versionVectorSizeOnCVReply.addMeasurement(reply.ssVersionVectorDelta.size());
+				if (SERVER_KNOBS->ENABLE_VERSION_VECTOR) {
+					self->ssVersionVector.getDelta(req.maxVersion, reply.ssVersionVectorDelta);
+					self->versionVectorSizeOnCVReply.addMeasurement(reply.ssVersionVectorDelta.size());
+				}
 				req.reply.send(reply);
 			}
 			when(ReportRawCommittedVersionRequest req =


### PR DESCRIPTION
Cherry-pick pull request #6843 from "main".

Do not invoke version vector related code when the feature is disabled.

Simulation tests: 20220419-160319-sre-361f00fde5064959 (no failures).

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
