### PR TITLE
Add new c libs to client package (added to cmake configuration)

### DIFF
--- a/bindings/c/CMakeLists.txt
+++ b/bindings/c/CMakeLists.txt
@@ -335,7 +335,6 @@ fdb_install(
   ${CMAKE_CURRENT_BINARY_DIR}/foundationdb/fdb_c_options.g.h
   ${CMAKE_SOURCE_DIR}/fdbclient/vexillographer/fdb.options
   ${CMAKE_SOURCE_DIR}/bindings/c/foundationdb/fdb_c_types.h
-  ${CMAKE_SOURCE_DIR}/bindings/c/foundationdb/fdb_c_internal.h
   DESTINATION include
   DESTINATION_SUFFIX /foundationdb
   COMPONENT clients)

--- a/bindings/c/CMakeLists.txt
+++ b/bindings/c/CMakeLists.txt
@@ -334,6 +334,8 @@ fdb_install(
   FILES foundationdb/fdb_c.h
   ${CMAKE_CURRENT_BINARY_DIR}/foundationdb/fdb_c_options.g.h
   ${CMAKE_SOURCE_DIR}/fdbclient/vexillographer/fdb.options
+  ${CMAKE_SOURCE_DIR}/bindings/c/foundationdb/fdb_c_types.h
+  ${CMAKE_SOURCE_DIR}/bindings/c/foundationdb/fdb_c_internal.h
   DESTINATION include
   DESTINATION_SUFFIX /foundationdb
   COMPONENT clients)


### PR DESCRIPTION
Fixes: #6822

Looks like rpm/deb specs are generated by cmake/cpack and new libs are ignored due to missing CMakeLists.txt declaration

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
