### PR TITLE
Revert "Update 'salt' details for EncryptHeader AuthToken details (#6…

### DIFF
--- a/fdbserver/workloads/EncryptionOps.actor.cpp
+++ b/fdbserver/workloads/EncryptionOps.actor.cpp
@@ -121,7 +121,6 @@ struct EncryptionOpsWorkload : TestWorkload {
 	EncryptCipherDomainId maxDomainId;
 	EncryptCipherBaseKeyId minBaseCipherId;
 	EncryptCipherBaseKeyId headerBaseCipherId;
-	EncryptCipherRandomSalt headerRandomSalt;
 
 	EncryptionOpsWorkload(WorkloadContext const& wcx) : TestWorkload(wcx) {
 		mode = getOption(options, LiteralStringRef("fixedSize"), 1);
@@ -135,7 +134,6 @@ struct EncryptionOpsWorkload : TestWorkload {
 		maxDomainId = deterministicRandom()->randomInt(minDomainId, minDomainId + 10) + 5;
 		minBaseCipherId = 100;
 		headerBaseCipherId = wcx.clientId * 100 + 1;
-		headerRandomSalt = wcx.clientId * 100 + 1;
 
 		metrics = std::make_unique<WorkloadMetrics>();
 
@@ -185,8 +183,7 @@ struct EncryptionOpsWorkload : TestWorkload {
 
 		// insert the Encrypt Header cipherKey
 		generateRandomBaseCipher(AES_256_KEY_LENGTH, &buff[0], &cipherLen);
-		cipherKeyCache->insertCipherKey(
-		    ENCRYPT_HEADER_DOMAIN_ID, headerBaseCipherId, buff, cipherLen, headerRandomSalt);
+		cipherKeyCache->insertCipherKey(ENCRYPT_HEADER_DOMAIN_ID, headerBaseCipherId, buff, cipherLen);
 
 		TraceEvent("SetupCipherEssentials_Done").detail("MinDomainId", minDomainId).detail("MaxDomainId", maxDomainId);
 	}
@@ -210,29 +207,6 @@ struct EncryptionOpsWorkload : TestWorkload {
 
 		ASSERT(*baseCipherLen > 0 && *baseCipherLen <= AES_256_KEY_LENGTH);
 		TraceEvent("UpdateBaseCipher").detail("DomainId", encryptDomainId).detail("BaseCipherId", *nextBaseCipherId);
-	}
-
-	Reference<BlobCipherKey> getEncryptionKey(const EncryptCipherDomainId& domainId,
-	                                          const EncryptCipherBaseKeyId& baseCipherId,
-	                                          const EncryptCipherRandomSalt& salt) {
-		const bool simCacheMiss = deterministicRandom()->randomInt(1, 100) < 15;
-
-		Reference<BlobCipherKeyCache> cipherKeyCache = BlobCipherKeyCache::getInstance();
-		Reference<BlobCipherKey> cipherKey = cipherKeyCache->getCipherKey(domainId, baseCipherId, salt);
-
-		if (simCacheMiss) {
-			TraceEvent("SimKeyCacheMiss").detail("EncyrptDomainId", domainId).detail("BaseCipherId", baseCipherId);
-			// simulate KeyCache miss that may happen during decryption; insert a CipherKey with known 'salt'
-			cipherKeyCache->insertCipherKey(domainId,
-			                                baseCipherId,
-			                                cipherKey->rawBaseCipher(),
-			                                cipherKey->getBaseCipherLen(),
-			                                cipherKey->getSalt());
-			// Ensure the update was a NOP
-			Reference<BlobCipherKey> cKey = cipherKeyCache->getCipherKey(domainId, baseCipherId, salt);
-			ASSERT(cKey->isEqual(cipherKey));
-		}
-		return cipherKey;
 	}
 
 	Reference<EncryptBuf> doEncryption(Reference<BlobCipherKey> textCipherKey,
@@ -266,12 +240,11 @@ struct EncryptionOpsWorkload : TestWorkload {
 		ASSERT_EQ(header.flags.headerVersion, EncryptBlobCipherAes265Ctr::ENCRYPT_HEADER_VERSION);
 		ASSERT_EQ(header.flags.encryptMode, ENCRYPT_CIPHER_MODE_AES_256_CTR);
 
-		Reference<BlobCipherKey> cipherKey = getEncryptionKey(header.cipherTextDetails.encryptDomainId,
-		                                                      header.cipherTextDetails.baseCipherId,
-		                                                      header.cipherTextDetails.salt);
-		Reference<BlobCipherKey> headerCipherKey = getEncryptionKey(header.cipherHeaderDetails.encryptDomainId,
-		                                                            header.cipherHeaderDetails.baseCipherId,
-		                                                            header.cipherHeaderDetails.salt);
+		Reference<BlobCipherKeyCache> cipherKeyCache = BlobCipherKeyCache::getInstance();
+		Reference<BlobCipherKey> cipherKey = cipherKeyCache->getCipherKey(header.cipherTextDetails.encryptDomainId,
+		                                                                  header.cipherTextDetails.baseCipherId);
+		Reference<BlobCipherKey> headerCipherKey = cipherKeyCache->getCipherKey(
+		    header.cipherHeaderDetails.encryptDomainId, header.cipherHeaderDetails.baseCipherId);
 		ASSERT(cipherKey.isValid());
 		ASSERT(cipherKey->isEqual(orgCipherKey));
 
@@ -324,7 +297,7 @@ struct EncryptionOpsWorkload : TestWorkload {
 			Reference<BlobCipherKey> cipherKey = cipherKeyCache->getLatestCipherKey(encryptDomainId);
 			// Each client working with their own version of encryptHeaderCipherKey, avoid using getLatest()
 			Reference<BlobCipherKey> headerCipherKey =
-			    cipherKeyCache->getCipherKey(ENCRYPT_HEADER_DOMAIN_ID, headerBaseCipherId, headerRandomSalt);
+			    cipherKeyCache->getCipherKey(ENCRYPT_HEADER_DOMAIN_ID, headerBaseCipherId);
 			auto end = std::chrono::high_resolution_clock::now();
 			metrics->updateKeyDerivationTime(std::chrono::duration<double, std::nano>(end - start).count());
 

--- a/flow/BlobCipher.h
+++ b/flow/BlobCipher.h
@@ -82,11 +82,11 @@ private:
 // This header is persisted along with encrypted buffer, it contains information necessary
 // to assist decrypting the buffers to serve read requests.
 //
-// The total space overhead is 104 bytes.
+// The total space overhead is 96 bytes.
 
 #pragma pack(push, 1) // exact fit - no padding
 typedef struct BlobCipherEncryptHeader {
-	static constexpr int headerSize = 104;
+	static constexpr int headerSize = 96;
 	union {
 		struct {
 			uint8_t size; // reading first byte is sufficient to determine header
@@ -101,7 +101,7 @@ typedef struct BlobCipherEncryptHeader {
 
 	// Cipher text encryption information
 	struct {
-		// Encryption domain boundary identifier.
+		// Encyrption domain boundary identifier.
 		EncryptCipherDomainId encryptDomainId{};
 		// BaseCipher encryption key identifier
 		EncryptCipherBaseKeyId baseCipherId{};
@@ -116,8 +116,6 @@ typedef struct BlobCipherEncryptHeader {
 		EncryptCipherDomainId encryptDomainId{};
 		// BaseCipher encryption key identifier.
 		EncryptCipherBaseKeyId baseCipherId{};
-		// Random salt
-		EncryptCipherRandomSalt salt{};
 	} cipherHeaderDetails;
 
 	// Encryption header is stored as plaintext on a persistent storage to assist reconstruction of cipher-key(s) for
@@ -166,11 +164,6 @@ public:
 	              const EncryptCipherBaseKeyId& baseCiphId,
 	              const uint8_t* baseCiph,
 	              int baseCiphLen);
-	BlobCipherKey(const EncryptCipherDomainId& domainId,
-	              const EncryptCipherBaseKeyId& baseCiphId,
-	              const uint8_t* baseCiph,
-	              int baseCiphLen,
-	              const EncryptCipherRandomSalt& salt);
 
 	uint8_t* data() const { return cipher.get(); }
 	uint64_t getCreationTime() const { return creationTime; }
@@ -213,7 +206,7 @@ private:
 // This interface allows FDB processes participating in encryption to store and
 // index recently used encyption cipher keys. FDB encryption has two dimensions:
 // 1. Mapping on cipher encryption keys per "encryption domains"
-// 2. Per encryption domain, the cipher keys are index using {baseCipherKeyId, salt} tuple.
+// 2. Per encryption domain, the cipher keys are index using "baseCipherKeyId".
 //
 // The design supports NIST recommendation of limiting lifetime of an encryption
 // key. For details refer to:
@@ -221,10 +214,10 @@ private:
 //
 // Below gives a pictoral representation of in-memory datastructure implemented
 // to index encryption keys:
-//                  { encryptionDomain -> { {baseCipherId, salt} -> cipherKey } }
+//                  { encryptionDomain -> { baseCipherId -> cipherKey } }
 //
 // Supported cache lookups schemes:
-// 1. Lookup cipher based on { encryptionDomainId, baseCipherKeyId, salt } triplet.
+// 1. Lookup cipher based on { encryptionDomainId, baseCipherKeyId } tuple.
 // 2. Lookup latest cipher key for a given encryptionDomainId.
 //
 // Client is responsible to handle cache-miss usecase, the corrective operation
@@ -233,28 +226,14 @@ private:
 // required encryption key, however, CPs/SSs cache-miss would result in RPC to
 // EncryptKeyServer to refresh the desired encryption key.
 
-struct pair_hash {
-	template <class T1, class T2>
-	std::size_t operator()(const std::pair<T1, T2>& pair) const {
-		auto hash1 = std::hash<T1>{}(pair.first);
-		auto hash2 = std::hash<T2>{}(pair.second);
-
-		// Equal hashes XOR would be ZERO.
-		return hash1 == hash2 ? hash1 : hash1 ^ hash2;
-	}
-};
-using BlobCipherKeyIdCacheKey = std::pair<EncryptCipherBaseKeyId, EncryptCipherRandomSalt>;
-using BlobCipherKeyIdCacheMap = std::unordered_map<BlobCipherKeyIdCacheKey, Reference<BlobCipherKey>, pair_hash>;
+using BlobCipherKeyIdCacheMap = std::unordered_map<EncryptCipherBaseKeyId, Reference<BlobCipherKey>>;
 using BlobCipherKeyIdCacheMapCItr =
-    std::unordered_map<BlobCipherKeyIdCacheKey, Reference<BlobCipherKey>, pair_hash>::const_iterator;
+    std::unordered_map<EncryptCipherBaseKeyId, Reference<BlobCipherKey>>::const_iterator;
 
 struct BlobCipherKeyIdCache : ReferenceCounted<BlobCipherKeyIdCache> {
 public:
 	BlobCipherKeyIdCache();
 	explicit BlobCipherKeyIdCache(EncryptCipherDomainId dId);
-
-	BlobCipherKeyIdCacheKey getCacheKey(const EncryptCipherBaseKeyId& baseCipherId,
-	                                    const EncryptCipherRandomSalt& salt);
 
 	// API returns the last inserted cipherKey.
 	// If none exists, 'encrypt_key_not_found' is thrown.
@@ -264,33 +243,14 @@ public:
 	// API returns cipherKey corresponding to input 'baseCipherKeyId'.
 	// If none exists, 'encrypt_key_not_found' is thrown.
 
-	Reference<BlobCipherKey> getCipherByBaseCipherId(const EncryptCipherBaseKeyId& baseCipherKeyId,
-	                                                 const EncryptCipherRandomSalt& salt);
+	Reference<BlobCipherKey> getCipherByBaseCipherId(EncryptCipherBaseKeyId baseCipherKeyId);
 
 	// API enables inserting base encryption cipher details to the BlobCipherKeyIdCache.
 	// Given cipherKeys are immutable, attempting to re-insert same 'identical' cipherKey
 	// is treated as a NOP (success), however, an attempt to update cipherKey would throw
 	// 'encrypt_update_cipher' exception.
-	//
-	// API NOTE: Recommended usecase is to update encryption cipher-key is updated the external
-	// keyManagementSolution to limit an encryption key lifetime
 
-	void insertBaseCipherKey(const EncryptCipherBaseKeyId& baseCipherId, const uint8_t* baseCipher, int baseCipherLen);
-
-	// API enables inserting base encryption cipher details to the BlobCipherKeyIdCache
-	// Given cipherKeys are immutable, attempting to re-insert same 'identical' cipherKey
-	// is treated as a NOP (success), however, an attempt to update cipherKey would throw
-	// 'encrypt_update_cipher' exception.
-	//
-	// API NOTE: Recommended usecase is to update encryption cipher-key regeneration while performing
-	// decryption. The encryptionheader would contain relevant details including: 'encryptDomainId',
-	// 'baseCipherId' & 'salt'. The caller needs to fetch 'baseCipherKey' detail and re-populate KeyCache.
-	// Also, the invocation will NOT update the latest cipher-key details.
-
-	void insertBaseCipherKey(const EncryptCipherBaseKeyId& baseCipherId,
-	                         const uint8_t* baseCipher,
-	                         int baseCipherLen,
-	                         const EncryptCipherRandomSalt& salt);
+	void insertBaseCipherKey(EncryptCipherBaseKeyId baseCipherId, const uint8_t* baseCipher, int baseCipherLen);
 
 	// API cleanup the cache by dropping all cached cipherKeys
 	void cleanup();
@@ -302,7 +262,6 @@ private:
 	EncryptCipherDomainId domainId;
 	BlobCipherKeyIdCacheMap keyIdCache;
 	EncryptCipherBaseKeyId latestBaseCipherKeyId;
-	EncryptCipherRandomSalt latestRandomSalt;
 };
 
 using BlobCipherDomainCacheMap = std::unordered_map<EncryptCipherDomainId, Reference<BlobCipherKeyIdCache>>;
@@ -318,32 +277,12 @@ public:
 	// The cipherKeys are indexed using 'baseCipherId', given cipherKeys are immutable,
 	// attempting to re-insert same 'identical' cipherKey is treated as a NOP (success),
 	// however, an attempt to update cipherKey would throw 'encrypt_update_cipher' exception.
-	//
-	// API NOTE: Recommended usecase is to update encryption cipher-key is updated the external
-	// keyManagementSolution to limit an encryption key lifetime
 
 	void insertCipherKey(const EncryptCipherDomainId& domainId,
 	                     const EncryptCipherBaseKeyId& baseCipherId,
 	                     const uint8_t* baseCipher,
 	                     int baseCipherLen);
-
-	// Enable clients to insert base encryption cipher details to the BlobCipherKeyCache.
-	// The cipherKeys are indexed using 'baseCipherId', given cipherKeys are immutable,
-	// attempting to re-insert same 'identical' cipherKey is treated as a NOP (success),
-	// however, an attempt to update cipherKey would throw 'encrypt_update_cipher' exception.
-	//
-	// API NOTE: Recommended usecase is to update encryption cipher-key regeneration while performing
-	// decryption. The encryptionheader would contain relevant details including: 'encryptDomainId',
-	// 'baseCipherId' & 'salt'. The caller needs to fetch 'baseCipherKey' detail and re-populate KeyCache.
-	// Also, the invocation will NOT update the latest cipher-key details.
-
-	void insertCipherKey(const EncryptCipherDomainId& domainId,
-	                     const EncryptCipherBaseKeyId& baseCipherId,
-	                     const uint8_t* baseCipher,
-	                     int baseCipherLen,
-	                     const EncryptCipherRandomSalt& salt);
-
-	// API returns the last insert cipherKey for a given encryption domain Id.
+	// API returns the last insert cipherKey for a given encyryption domain Id.
 	// If none exists, it would throw 'encrypt_key_not_found' exception.
 
 	Reference<BlobCipherKey> getLatestCipherKey(const EncryptCipherDomainId& domainId);
@@ -352,16 +291,14 @@ public:
 	// If none exists, it would throw 'encrypt_key_not_found' exception.
 
 	Reference<BlobCipherKey> getCipherKey(const EncryptCipherDomainId& domainId,
-	                                      const EncryptCipherBaseKeyId& baseCipherId,
-	                                      const EncryptCipherRandomSalt& salt);
-
+	                                      const EncryptCipherBaseKeyId& baseCipherId);
 	// API returns point in time list of all 'cached' cipherKeys for a given encryption domainId.
 	std::vector<Reference<BlobCipherKey>> getAllCiphers(const EncryptCipherDomainId& domainId);
 
 	// API enables dropping all 'cached' cipherKeys for a given encryption domain Id.
 	// Useful to cleanup cache if an encryption domain gets removed/destroyed etc.
 
-	void resetEncryptDomainId(const EncryptCipherDomainId domainId);
+	void resetEncyrptDomainId(const EncryptCipherDomainId domainId);
 
 	static Reference<BlobCipherKeyCache> getInstance() {
 		if (g_network->isSimulated()) {
@@ -427,7 +364,7 @@ public:
 	                              const BlobCipherEncryptHeader& header,
 	                              Arena&);
 
-	// Enable caller to validate encryption header auth-token (if available) without needing to read the full encrypted
+	// Enable caller to validate encryption header auth-token (if available) without needing to read the full encyrpted
 	// payload. The call is NOP unless header.flags.authTokenMode == ENCRYPT_HEADER_AUTH_TOKEN_MODE_MULTI.
 
 	void verifyHeaderAuthToken(const BlobCipherEncryptHeader& header, Arena& arena);


### PR DESCRIPTION
This reverts commit a38318a6acc1ef71ebcc5ea4af6bb2ea0edf0887.

The above commit introduced a memory bug which causes many valgrind failures in the nightlies. This either needs to be fixed quickly or we should revert the change for now.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
