### PR TITLE
BlobCipherKeyCache::getLatestCipherKey return empty when there's no key

### DIFF
--- a/flow/BlobCipher.cpp
+++ b/flow/BlobCipher.cpp
@@ -129,6 +129,8 @@ BlobCipherKeyIdCacheKey BlobCipherKeyIdCache::getCacheKey(const EncryptCipherBas
 }
 
 Reference<BlobCipherKey> BlobCipherKeyIdCache::getLatestCipherKey() {
+	// ENCRYPT_INVALID_CIPHER_KEY_ID indicate there was no key inserted. In this case we return empty key instead of
+	// throwing encrypt_invalid_id.
 	if (latestBaseCipherKeyId == ENCRYPT_INVALID_CIPHER_KEY_ID) {
 		return Reference<BlobCipherKey>();
 	}

--- a/flow/BlobCipher.h
+++ b/flow/BlobCipher.h
@@ -257,7 +257,7 @@ public:
 	                                    const EncryptCipherRandomSalt& salt);
 
 	// API returns the last inserted cipherKey.
-	// If none exists, 'encrypt_key_not_found' is thrown.
+	// If none exists, null reference is returned.
 
 	Reference<BlobCipherKey> getLatestCipherKey();
 
@@ -344,7 +344,8 @@ public:
 	                     const EncryptCipherRandomSalt& salt);
 
 	// API returns the last insert cipherKey for a given encryption domain Id.
-	// If none exists, it would throw 'encrypt_key_not_found' exception.
+	// If domain Id is invalid, it would throw 'encrypt_invalid_id' exception,
+	// otherwise, and if none exists, it would return null reference.
 
 	Reference<BlobCipherKey> getLatestCipherKey(const EncryptCipherDomainId& domainId);
 


### PR DESCRIPTION
Instead of throwing error, `BlobCipherKeyCache::getLatestCipherKey()` now returns empty key if the latest key doesn't exists.

The PR also fixes valgrind complaining about `latestRandomSalt` not initialized when `getLatestCipherKey()` try to print the salt if no key is found.

Tested by running the EncryptionOps test with valgrind, and also updating the flow/BlobCipher unit test.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
