### PR TITLE
remove BUILD_ALWAYS from awssdk.cmake

### DIFF
--- a/cmake/awssdk.cmake
+++ b/cmake/awssdk.cmake
@@ -27,7 +27,6 @@ ExternalProject_Add(awssdk_project
                     -DCMAKE_EXE_LINKER_FLAGS=${AWSSDK_COMPILER_FLAGS}
                     -DCMAKE_CXX_FLAGS=${AWSSDK_LINK_FLAGS}
   TEST_COMMAND      ""
-  BUILD_ALWAYS      TRUE
   # the sdk build produces a ton of artifacts, with their own dependency tree, so there is a very specific dependency order they must be linked in
   BUILD_BYPRODUCTS  "${CMAKE_CURRENT_BINARY_DIR}/awssdk-build/install/lib64/libaws-cpp-sdk-core.a"
                     "${CMAKE_CURRENT_BINARY_DIR}/awssdk-build/install/lib64/libaws-crt-cpp.a"


### PR DESCRIPTION
The BUILD_ALWAYS was unecessary here and caused extra compilation work

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
