### PR TITLE
Fix Build: use boost::hash to compute hash for std::pair

### DIFF
--- a/fdbserver/EncryptKeyProxy.actor.cpp
+++ b/fdbserver/EncryptKeyProxy.actor.cpp
@@ -154,17 +154,6 @@ public:
 	}
 };
 
-struct pair_hash {
-	template <class T1, class T2>
-	std::size_t operator()(const std::pair<T1, T2>& pair) const {
-		auto hash1 = std::hash<T1>{}(pair.first);
-		auto hash2 = std::hash<T2>{}(pair.second);
-
-		// Equal hashes XOR would be ZERO.
-		return hash1 == hash2 ? hash1 : hash1 ^ hash2;
-	}
-};
-
 ACTOR Future<Void> getCipherKeysByBaseCipherKeyIds(Reference<EncryptKeyProxyData> ekpProxyData,
                                                    KmsConnectorInterface kmsConnectorInf,
                                                    EKPGetBaseCipherKeysByIdsRequest req) {
@@ -179,7 +168,9 @@ ACTOR Future<Void> getCipherKeysByBaseCipherKeyIds(Reference<EncryptKeyProxyData
 
 	// Dedup the requested pair<baseCipherId, encryptDomainId>
 	// TODO: endpoint serialization of std::unordered_set isn't working at the moment
-	std::unordered_set<std::pair<EncryptCipherBaseKeyId, EncryptCipherDomainId>, pair_hash> dedupedCipherIds;
+	std::unordered_set<std::pair<EncryptCipherBaseKeyId, EncryptCipherDomainId>,
+	                   boost::hash<std::pair<EncryptCipherBaseKeyId, EncryptCipherDomainId>>>
+	    dedupedCipherIds;
 	for (const auto& item : req.baseCipherIds) {
 		dedupedCipherIds.emplace(item);
 	}

--- a/flow/BlobCipher.h
+++ b/flow/BlobCipher.h
@@ -233,20 +233,12 @@ private:
 // required encryption key, however, CPs/SSs cache-miss would result in RPC to
 // EncryptKeyServer to refresh the desired encryption key.
 
-struct pair_hash {
-	template <class T1, class T2>
-	std::size_t operator()(const std::pair<T1, T2>& pair) const {
-		auto hash1 = std::hash<T1>{}(pair.first);
-		auto hash2 = std::hash<T2>{}(pair.second);
-
-		// Equal hashes XOR would be ZERO.
-		return hash1 == hash2 ? hash1 : hash1 ^ hash2;
-	}
-};
 using BlobCipherKeyIdCacheKey = std::pair<EncryptCipherBaseKeyId, EncryptCipherRandomSalt>;
-using BlobCipherKeyIdCacheMap = std::unordered_map<BlobCipherKeyIdCacheKey, Reference<BlobCipherKey>, pair_hash>;
+using BlobCipherKeyIdCacheKeyHash = boost::hash<BlobCipherKeyIdCacheKey>;
+using BlobCipherKeyIdCacheMap =
+    std::unordered_map<BlobCipherKeyIdCacheKey, Reference<BlobCipherKey>, BlobCipherKeyIdCacheKeyHash>;
 using BlobCipherKeyIdCacheMapCItr =
-    std::unordered_map<BlobCipherKeyIdCacheKey, Reference<BlobCipherKey>, pair_hash>::const_iterator;
+    std::unordered_map<BlobCipherKeyIdCacheKey, Reference<BlobCipherKey>, BlobCipherKeyIdCacheKeyHash>::const_iterator;
 
 struct BlobCipherKeyIdCache : ReferenceCounted<BlobCipherKeyIdCache> {
 public:


### PR DESCRIPTION
Description

Fix Build: use boost::hash to compute hash for std::pair

Testing

1. Build - gcc/clang
2. Simulation test: EncryptKeyProxyTest, EncryptionOps
3. Unit test: flow/BlobCipher
4. Running 10k correctness Joshua run

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
