### PR TITLE
7.1 Cherry-pick: Address seg fault in "storageRecruiter" actor

### DIFF
--- a/fdbserver/DDTeamCollection.h
+++ b/fdbserver/DDTeamCollection.h
@@ -272,6 +272,12 @@ class DDTeamCollection : public ReferenceCounted<DDTeamCollection> {
 
 	LocalityMap<UID> machineLocalityMap; // locality info of machines
 
+	// A mechanism to tell actors that reference a DDTeamCollection object through a direct
+	// pointer (without doing reference counting) that the object is being destroyed.
+	// (Introduced to solve the problem of "self" getting destroyed from underneath the
+	// "storageRecruiter" actor).
+	Promise<Void> shutdown;
+
 	// Randomly choose one machine team that has chosenServer and has the correct size
 	// When configuration is changed, we may have machine teams with old storageTeamSize
 	Reference<TCMachineTeamInfo> findOneRandomMachineTeam(TCServerInfo const& chosenServer) const;


### PR DESCRIPTION
Cherry-pick pull request https://github.com/apple/foundationdb/pull/6924 from "main".

Address the issue of the DDTeamCollection object destroyed from underneath the "storageRecruiter" actor.

Exposed by "SnapCycleRestart-1.txt" failure on release-7.1 branch:
Compiler: gcc
Commit: https://github.com/apple/foundationdb/commit/b7c05eb117bddc109eb8aa879a59573894315a94
build_output/bin/fdbserver -r simulation --crash -f /root/src/foundationdb/tests/restarting/from_7.0.0/SnapCycleRestart-1.txt -b on -s 530094113

Testing:
Simulation tests: 20220422-204941-sre-e2ee4a0e7cc1e0eb (no failures)

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
