### PR TITLE
Fix compile errors in Java tutorial code

### DIFF
--- a/documentation/sphinx/source/class-scheduling-java.rst
+++ b/documentation/sphinx/source/class-scheduling-java.rst
@@ -148,7 +148,7 @@ is equivalent to something like:
         tr.set(Tuple.from("class", "class1").pack(), encodeInt(100));
         t.commit().join();
       } catch (RuntimeException e) {
-        t = t.onError(e).get();
+        t = t.onError(e).join();
       }
     }
 
@@ -290,10 +290,10 @@ This is easy -- we simply add a condition to check that the value is non-zero. L
   private static void signup(TransactionContext db, final String s, final String c) {
     db.run((Transaction tr) -> {
       byte[] rec = Tuple.from("attends", s, c).pack();
-      if (tr.get(rec).get() != null)
+      if (tr.get(rec).join() != null)
         return null; // already signed up
 
-      int seatsLeft = decodeInt(tr.get(Tuple.from("class", c).pack()).get());
+      int seatsLeft = decodeInt(tr.get(Tuple.from("class", c).pack()).join());
       if (seatsLeft == 0)
         throw new IllegalStateException("No remaining seats");
 


### PR DESCRIPTION
Use CompletableFuture::join instead of CompletableFuture::get
when blocking on futures in java tutorial snippets. This avoids
the unreported checked exceptions which prevent the snippets from
compiling (and is in line with the full tutorial code).

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
