### PR TITLE
Improve error reporting in C API tests 

### DIFF
--- a/bindings/c/CMakeLists.txt
+++ b/bindings/c/CMakeLists.txt
@@ -254,6 +254,8 @@ endif()
             ${CMAKE_SOURCE_DIR}/bindings/c/test/apitester/tests
             --tmp-dir
             @TMP_DIR@
+            --log-dir
+            @LOG_DIR@
             )
 
   add_fdbclient_test(
@@ -271,6 +273,10 @@ endif()
             ${CMAKE_SOURCE_DIR}/bindings/c/test/apitester/blobgranuletests
             --blob-granule-local-file-path
             @DATA_DIR@/fdbblob/
+            --tmp-dir
+            @TMP_DIR@
+            --log-dir
+            @LOG_DIR@
             )
 
   if(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64" AND NOT USE_SANITIZER)

--- a/bindings/c/test/apitester/run_c_api_tests.py
+++ b/bindings/c/test/apitester/run_c_api_tests.py
@@ -56,6 +56,7 @@ def run_tester(args, test_file):
         cmd += ["--external-client-library", args.external_client_library]
     if args.tmp_dir is not None:
         cmd += ["--tmp-dir", args.tmp_dir]
+
     if args.blob_granule_local_file_path is not None:
         cmd += ["--blob-granule-local-file-path",
                 args.blob_granule_local_file_path]
@@ -63,6 +64,7 @@ def run_tester(args, test_file):
     get_logger().info('\nRunning tester \'%s\'...' % ' '.join(cmd))
     proc = Popen(cmd, stdout=sys.stdout, stderr=sys.stderr)
     timed_out = False
+    ret_code = 1
     try:
         ret_code = proc.wait(args.timeout)
     except TimeoutExpired:
@@ -72,13 +74,12 @@ def run_tester(args, test_file):
         raise Exception('Unable to run tester (%s)' % e)
 
     if ret_code != 0:
-        if ret_code < 0:
+        if timed_out:
+            reason = 'timed out after %d seconds' % args.timeout
+        elif ret_code < 0:
             reason = signal.Signals(-ret_code).name
         else:
             reason = 'exit code: %d' % ret_code
-        if timed_out:
-            reason = 'timed out after %d seconds' % args.timeout
-            ret_code = 1
         get_logger().error('\n\'%s\' did not complete succesfully (%s)' %
                            (cmd[0], reason))
 


### PR DESCRIPTION
Some improvements in the run_c_api_tests.py script:
- Fix error reporting in case of a time out
- Enable client logs and dump them out in case of an error

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
