### PR TITLE
Allowing for blob granules to initialize at start of TesterBlobGranul…

### DIFF
--- a/bindings/c/test/apitester/TesterBlobGranuleCorrectnessWorkload.cpp
+++ b/bindings/c/test/apitester/TesterBlobGranuleCorrectnessWorkload.cpp
@@ -61,8 +61,7 @@ private:
 				    ASSERT(!seenReadSuccess);
 				    *tooOld = true;
 				    ctx->done();
-			    }
-			    if (res.getError() != error_code_success) {
+			    } else if (res.getError() != error_code_success) {
 				    ctx->onError(res.getError());
 			    } else {
 				    if (!seenReadSuccess) {


### PR DESCRIPTION
…eCorrectness

Fixes flaky test that has been causing CI failures.

Testing:  ctest -R fdb_c_api_tests_blob_granule

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
