### PR TITLE
update build-images.sh to play nice with AWS IMDSv2

### DIFF
--- a/packaging/docker/build-images.sh
+++ b/packaging/docker/build-images.sh
@@ -254,7 +254,8 @@ push_docker_images="false"
 if [ -n "${OKTETO_NAMESPACE+x}" ]; then
     logg "RUNNING IN OKTETO/AWS"
     # these are defaults for the Apple development environment
-    aws_region=$(curl -s "http://169.254.169.254/latest/meta-data/placement/region")
+    imdsv2_token=$(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
+    aws_region=$(curl -H "X-aws-ec2-metadata-token: ${imdsv2_token}" "http://169.254.169.254/latest/meta-data/placement/region")
     aws_account_id=$(aws --output text sts get-caller-identity --query 'Account')
     build_output_directory="${HOME}/build_output"
     fdb_library_versions=( "${fdb_version}" )


### PR DESCRIPTION
build-images.sh requires a token before accessing the Instance MetaData Service in AWS. This change adds that capability. 

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
