### PR TITLE
fix: when more tlogs are absent than the replication factor we would access invalid memory

### DIFF
--- a/fdbserver/TagPartitionedLogSystem.actor.cpp
+++ b/fdbserver/TagPartitionedLogSystem.actor.cpp
@@ -1879,7 +1879,7 @@ Optional<std::pair<Version, Version>> TagPartitionedLogSystem::getDurableVersion
 		int absent = logSet->logServers.size() - results.size();
 		int safe_range_begin = logSet->tLogWriteAntiQuorum;
 		int new_safe_range_begin = std::min(logSet->tLogWriteAntiQuorum, (int)(results.size() - 1));
-		int safe_range_end = logSet->tLogReplicationFactor - absent;
+		int safe_range_end = std::max(logSet->tLogReplicationFactor - absent, 1);
 
 		if (!lastEnd.present() || ((safe_range_end > 0) && (safe_range_end - 1 < results.size()) &&
 		                           results[safe_range_end - 1].end < lastEnd.get())) {


### PR DESCRIPTION
cherry pick #6991 

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
