### PR TITLE
Fix operation_failed thrown incorrectly from transactions

### DIFF
--- a/fdbclient/WriteMap.h
+++ b/fdbclient/WriteMap.h
@@ -231,7 +231,8 @@ public:
 				                                is_unreadable));
 			}
 		} else {
-			if (!it.is_unreadable() && operation == MutationRef::SetValue) {
+			if (!it.is_unreadable() &&
+			    (operation == MutationRef::SetValue || operation == MutationRef::SetVersionstampedValue)) {
 				it.tree.clear();
 				PTreeImpl::remove(writes, ver, key);
 				PTreeImpl::insert(writes,
@@ -523,9 +524,10 @@ public:
 	static RYWMutation coalesce(RYWMutation existingEntry, RYWMutation newEntry, Arena& arena) {
 		ASSERT(newEntry.value.present());
 
-		if (newEntry.type == MutationRef::SetValue)
+		if (newEntry.type == MutationRef::SetValue || newEntry.type == MutationRef::SetVersionstampedValue) {
+			// independent mutations
 			return newEntry;
-		else if (newEntry.type == MutationRef::AddValue) {
+		} else if (newEntry.type == MutationRef::AddValue) {
 			switch (existingEntry.type) {
 			case MutationRef::SetValue:
 				return RYWMutation(doLittleEndianAdd(existingEntry.value, newEntry.value.get(), arena),


### PR DESCRIPTION
- Add a test demonstrating the issue
- Treat SetVersionstampedValue as independent in coalesce and mutate

Previously the following sequence of operations would cause operation_failed to get thrown incorrectly.

1. Set the bypass_unreadable transaction option
2. Set a key k to a value
3. Set k to a versionstamped value
4. Read k

AFAICT FuzzApiCorrectness is capable of catching this, but the probability seems to be too low.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
