### PR TITLE
Add sidecar method to check if a file is present

### DIFF
--- a/packaging/docker/sidecar.py
+++ b/packaging/docker/sidecar.py
@@ -518,8 +518,14 @@ class Server(BaseHTTPRequestHandler):
                 return
             if self.path.startswith("/check_hash/"):
                 try:
-                    self.send_text(check_hash(self.path[12:]), add_newline=False)
+                    self.send_text(check_hash(os.path.basename(self.path)), add_newline=False)
                 except FileNotFoundError:
+                    self.send_error(404, "Path not found")
+                    self.end_headers()
+            if self.path.startswith("/is_present/"):
+                if is_present(os.path.basename(self.path))):
+                    self.send_text("OK")
+                else:
                     self.send_error(404, "Path not found")
                     self.end_headers()
             elif self.path == "/ready":
@@ -597,6 +603,10 @@ def check_hash(filename):
         m = hashlib.sha256()
         m.update(contents.read())
         return m.hexdigest()
+
+
+def is_present(filename):
+    return os.path.exists(os.path.join(Config.shared().output_dir, filename))
 
 
 def copy_files():


### PR DESCRIPTION
This allows the operator to query if a file is present without calculation the hash.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [x] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
