### PR TITLE
Improve robustness of upgrade tests

### DIFF
--- a/tests/TestRunner/upgrade_test.py
+++ b/tests/TestRunner/upgrade_test.py
@@ -261,6 +261,7 @@ class UpgradeTest:
             return
         src_lib_file = self.local_binary_repo.joinpath(version, "lib", "libfdb_c-{}.so".format(version))
         assert src_lib_file.exists(), "Missing file {} in the local old binaries repository".format(src_lib_file)
+        self.download_dir.joinpath(version).mkdir(parents=True, exist_ok=True)
         shutil.copyfile(src_lib_file, dest_lib_file)
         assert dest_lib_file.exists(), "{} does not exist".format(dest_lib_file)
 

--- a/tests/TestRunner/upgrade_test.py
+++ b/tests/TestRunner/upgrade_test.py
@@ -192,7 +192,7 @@ class UpgradeTest:
         if version == CURRENT_VERSION:
             return self.build_dir.joinpath("bin", bin_name)
         elif self.version_in_local_repo(version):
-            return self.local_binary_repo.joinpath(version, "{}-{}".format(bin_name, version))
+            return self.local_binary_repo.joinpath(version, "bin", "{}-{}".format(bin_name, version))
         else:
             return self.download_dir.joinpath(version, bin_name)
 
@@ -259,7 +259,7 @@ class UpgradeTest:
         dest_lib_file = self.download_dir.joinpath(version, "libfdb_c.so")
         if dest_lib_file.exists():
             return
-        src_lib_file = self.local_binary_repo.joinpath(version, "libfdb_c-{}.so".format(version))
+        src_lib_file = self.local_binary_repo.joinpath(version, "lib", "libfdb_c-{}.so".format(version))
         assert src_lib_file.exists(), "Missing file {} in the local old binaries repository".format(src_lib_file)
         shutil.copyfile(src_lib_file, dest_lib_file)
         assert dest_lib_file.exists(), "{} does not exist".format(dest_lib_file)


### PR DESCRIPTION
Various improvements to the robustness of the upgrade tests
* Download old FDB binaries only if they are not available in the Docker build image
* Retry on download errors
* Avoid tests getting stuck waiting for the named pipes to be opened, in the case when test binary fails to initialize, because of errors in the configuration or similar

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
