### PR TITLE
[snowflake/release-7.1] Fix for WriteDuringRead workload key sizes with useSystemKeys=true bu…

### DIFF
--- a/fdbserver/workloads/WriteDuringRead.actor.cpp
+++ b/fdbserver/workloads/WriteDuringRead.actor.cpp
@@ -1003,7 +1003,7 @@ struct WriteDuringReadWorkload : TestWorkload {
 										tr.setOption(FDBTransactionOptions::NEXT_WRITE_NO_WRITE_CONFLICT_RANGE);
 									tr.atomicOp(key, value, opType);
 									//TraceEvent("WDRAtomicOpSuccess").detail("Key", key).detail("Value", value.size());
-									if (!noConflict && key.size() <= getMaxWriteKeySize(key, false)) {
+									if (!noConflict && key.size() <= getMaxWriteKeySize(key, self->useSystemKeys)) {
 										self->addedConflicts.insert(key, true);
 									}
 									Optional<Value> existing = self->memoryGet(&self->memoryDatabase, key);
@@ -1022,7 +1022,7 @@ struct WriteDuringReadWorkload : TestWorkload {
 								if (noConflict)
 									tr.setOption(FDBTransactionOptions::NEXT_WRITE_NO_WRITE_CONFLICT_RANGE);
 								tr.set(key, value);
-								if (!noConflict && key.size() <= getMaxWriteKeySize(key, false)) {
+								if (!noConflict && key.size() <= getMaxWriteKeySize(key, self->useSystemKeys)) {
 									self->addedConflicts.insert(key, true);
 								}
 								//TraceEvent("WDRSetSuccess").detail("Key", key).detail("Value", value.size());


### PR DESCRIPTION
…t writing to normal key space

Cherry-pick #7013 to snowflake/release-7.1.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
