### PR TITLE
Blob Granules Multi-Version-Client ASAN fixes

### DIFF
--- a/bindings/c/test/apitester/TesterApiWrapper.cpp
+++ b/bindings/c/test/apitester/TesterApiWrapper.cpp
@@ -169,7 +169,7 @@ public:
 		// if there was an error or not all loads finished, delete data
 		for (auto& it : loadsInProgress) {
 			uint8_t* dataToFree = it.second;
-			delete dataToFree;
+			delete[] dataToFree;
 		}
 	}
 };
@@ -203,7 +203,7 @@ static void granule_free_load(int64_t loadId, void* context) {
 	TesterGranuleContext* ctx = (TesterGranuleContext*)context;
 	auto it = ctx->loadsInProgress.find(loadId);
 	uint8_t* dataToFree = it->second;
-	delete dataToFree;
+	delete[] dataToFree;
 
 	ctx->loadsInProgress.erase(it);
 }

--- a/fdbclient/MultiVersionTransaction.actor.cpp
+++ b/fdbclient/MultiVersionTransaction.actor.cpp
@@ -296,17 +296,7 @@ ThreadResult<RangeResult> DLTransaction::readBlobGranules(const KeyRangeRef& key
 	                                                         beginVersion,
 	                                                         rv,
 	                                                         context);
-	const FdbCApi::FDBKeyValue* kvs;
-	int count;
-	FdbCApi::fdb_bool_t more;
-	FdbCApi::fdb_error_t error = api->resultGetKeyValueArray(r, &kvs, &count, &more);
-	if (error) {
-		return ThreadResult<RangeResult>(Error(error));
-	}
-
-	// The memory for this is stored in the FDBResult and is released when the result gets destroyed
-	return ThreadResult<RangeResult>(
-	    RangeResult(RangeResultRef(VectorRef<KeyValueRef>((KeyValueRef*)kvs, count), more), Arena()));
+	return ThreadResult<RangeResult>((ThreadSingleAssignmentVar<RangeResult>*)(r));
 }
 
 void DLTransaction::addReadConflictRange(const KeyRangeRef& keys) {


### PR DESCRIPTION
Fixes ASAN issues (incorrect delete and memory leak) in fdb_c_api_tests_blob_granule.

Passes ASAN and valgrind with "ctest -R fdb_c_api_tests"

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
