### PR TITLE
Mark a team as unhealthy when it is removed (backport #7020 to release-7.1)

### DIFF
--- a/fdbserver/DDTeamCollection.actor.cpp
+++ b/fdbserver/DDTeamCollection.actor.cpp
@@ -4758,6 +4758,7 @@ bool DDTeamCollection::removeTeam(Reference<TCTeamInfo> team) {
 
 	ASSERT_WE_THINK(foundInMachineTeam);
 	team->tracker.cancel();
+	team->setHealthy(false);
 	if (g_network->isSimulated()) {
 		// Update server team information for consistency check in simulation
 		traceTeamCollectionInfo();

--- a/fdbserver/DataDistribution.actor.h
+++ b/fdbserver/DataDistribution.actor.h
@@ -65,7 +65,7 @@ struct IDataDistributionTeam {
 
 	std::string getDesc() const {
 		const auto& servers = getLastKnownServerInterfaces();
-		std::string s = format("TeamID:%s", getTeamID().c_str());
+		std::string s = format("TeamID %s; ", getTeamID().c_str());
 		s += format("Size %d; ", servers.size());
 		for (int i = 0; i < servers.size(); i++) {
 			if (i)


### PR DESCRIPTION
This is a backport of https://github.com/apple/foundationdb/pull/7020.

It was previously possible for a team to be removed but for a relocate shard task to still have a reference to it. If that happened, the task would not detect when the team became unhealthy and could no longer be moved to.

Marking the team unhealthy signals to the relocate shard task that it should stop trying to relocate it.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
