### PR TITLE
Variable clientsUsed in TPC-C workload is not initialized correctly.

### DIFF
--- a/fdbserver/workloads/TPCC.actor.cpp
+++ b/fdbserver/workloads/TPCC.actor.cpp
@@ -122,7 +122,7 @@ struct TPCC : TestWorkload {
 		expectedTransactionsPerMinute = getOption(options, LiteralStringRef("expectedTransactionsPerMinute"), 1000);
 		testDuration = getOption(options, LiteralStringRef("testDuration"), 600);
 		warmupTime = getOption(options, LiteralStringRef("warmupTime"), 30);
-		getOption(options, LiteralStringRef("clientsUsed"), 40);
+		clientsUsed = getOption(options, LiteralStringRef("clientsUsed"), 40);
 	}
 
 	int NURand(int C, int A, int x, int y) {


### PR DESCRIPTION
Variable `clientsUsed` is not initialized correctly.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
