### PR TITLE
Fix TokenSign copying and using uninitialized arena

### DIFF
--- a/fdbrpc/TokenSign.cpp
+++ b/fdbrpc/TokenSign.cpp
@@ -114,7 +114,7 @@ Standalone<KeyPairRef> generateEcdsaKeyPair() {
 
 Standalone<SignedAuthTokenRef> signToken(AuthTokenRef token, StringRef keyName, StringRef privateKeyDer) {
 	auto ret = Standalone<SignedAuthTokenRef>{};
-	auto arena = ret.arena();
+	auto& arena = ret.arena();
 	auto writer = ObjectWriter([&arena](size_t len) { return new (arena) uint8_t[len]; }, IncludeVersion());
 	writer.serialize(token);
 	auto tokenStr = writer.toStringRef();
@@ -181,7 +181,7 @@ TEST_CASE("/fdbrpc/TokenSign") {
 	for (auto i = 0; i < numIters; i++) {
 		auto keyPair = generateEcdsaKeyPair();
 		auto token = Standalone<AuthTokenRef>{};
-		auto arena = token.arena();
+		auto& arena = token.arena();
 		auto& rng = *deterministicRandom();
 		token.expiresAt = timer_monotonic() * (0.5 + rng.random01());
 		if (auto setIp = rng.randomInt(0, 3)) {


### PR DESCRIPTION
TokenSign was copying unused Arena held by _Standalone_ instead of referring to it.
Copied Arenas aren't guaranteed to share with the original the lifecycle of the objects allocated post-copy.
Thus, when the copied arena went out of scope,
the memory supposed to be held by returned _Standalone_ also got released.

Fix: instead of copying, refer to _Standalone_'s arena.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
