### PR TITLE
Update RYWIterator test to match #6993 (snowflake/release-7.1)

### DIFF
--- a/fdbclient/RYWIterator.cpp
+++ b/fdbclient/RYWIterator.cpp
@@ -655,7 +655,10 @@ TEST_CASE("/fdbclient/WriteMap/random") {
 			KeyRef key = RandomTestImpl::getRandomKey(arena);
 			ValueRef value = RandomTestImpl::getRandomValue(arena);
 			writes.mutate(key, MutationRef::SetVersionstampedValue, value, addConflict);
-			setMap[key].push(RYWMutation(value, MutationRef::SetVersionstampedValue));
+			if (unreadableMap[key])
+				setMap[key].push(RYWMutation(value, MutationRef::SetVersionstampedValue));
+			else
+				setMap[key] = OperationStack(RYWMutation(value, MutationRef::SetVersionstampedValue));
 			if (addConflict)
 				conflictMap.insert(key, true);
 			clearMap.insert(key, false);


### PR DESCRIPTION
Cherry pick https://github.com/apple/foundationdb/pull/7046 to snowflake/release-7.1



There's a test which checks behavior against a reference implementation,
and so the reference implementation needs to be updated as well.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
