### PR TITLE
7.1 Cherry-pick: Address GRV cache and version vector incompatibility

### DIFF
--- a/fdbclient/DatabaseContext.h
+++ b/fdbclient/DatabaseContext.h
@@ -524,7 +524,6 @@ public:
 	Counter transactionsExpensiveClearCostEstCount;
 	Counter transactionGrvFullBatches;
 	Counter transactionGrvTimedOutBatches;
-	Counter transactionsStaleVersionVectors;
 
 	ContinuousSample<double> latencies, readLatencies, commitLatencies, GRVLatencies, mutationsPerCommit,
 	    bytesPerCommit, bgLatencies, bgGranulesPerRequest;

--- a/flow/error_definitions.h
+++ b/flow/error_definitions.h
@@ -95,7 +95,6 @@ ERROR( page_encoding_not_supported, 1071, "Page encoding type is not supported o
 ERROR( page_decoding_failed, 1072, "Page content decoding failed" )
 ERROR( unexpected_encoding_type, 1073, "Page content decoding failed" )
 ERROR( encryption_key_not_found, 1074, "Encryption key not found" )
-ERROR( stale_version_vector, 1075, "Client version vector is stale" )
 
 ERROR( broken_promise, 1100, "Broken promise" )
 ERROR( operation_cancelled, 1101, "Asynchronous operation cancelled" )


### PR DESCRIPTION
Cherry-pick pull request https://github.com/apple/foundationdb/pull/7057 from "main".

Do not consult version vector if the client has obtained the read version from its GRV cache.

Test that detected this issue:
Branch: release-7.1 (with version vector enabled)
Compiler: gcc
Commit: https://github.com/apple/foundationdb/commit/f120b3f1a07b5804fee3d57a019df1a6ae410119
Test: build_output/bin/fdbserver -r simulation --crash -f /root/src/foundationdb/tests/fast/SidebandSingle.toml -b on -s 1651247938

Simulation tests:
Release-7.1 (with version vector enabled): 20220503-153015-sre-d45cb1e1fbf7c4e5 (no failures)
Release-7.1 (with version vector disabled): 20220503-170118-sre-a89fc0efc6f71ac1 (no failures)

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
