### PR TITLE
re-use same arena when construct mapped key

### DIFF
--- a/fdbclient/Tuple.h
+++ b/fdbclient/Tuple.h
@@ -56,6 +56,11 @@ struct Tuple {
 
 	// this is number of elements, not length of data
 	size_t size() const { return offsets.size(); }
+	void reserve(size_t cap) { offsets.reserve(cap); }
+	void clear() {
+		data.clear();
+		offsets.clear();
+	}
 
 	ElementType getType(size_t index) const;
 	Standalone<StringRef> getString(size_t index) const;

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -3548,6 +3548,10 @@ void preprocessMappedKey(Tuple& mappedKeyFormatTuple,
 				// when it is SingleKeyOrValue, insert an empty Tuple to vector as placeholder
 				vt.push_back(Optional<Tuple>(Tuple()));
 			} else if (rangeQuery(s)) {
+				if (i != mappedKeyFormatTuple.size() - 1) {
+					// It must be the last element of the mapper tuple
+					throw mapper_bad_range_decriptor();
+				}
 				// when it is rangeQuery, insert Optional.empty as placeholder
 				vt.push_back(Optional<Tuple>());
 				isRangeQuery = true;


### PR DESCRIPTION
    ConstructMappedKey seems to be a hotspot, try eliminate unnecessary
    operations by
    * re-using the same Tuple
    * preprocess the formatTuple to get a list of Tuples and strings

20220505-003405-haofu-e943db3c75f10cc0: commit 1
20220505-174645-haofu-3d80901ef6df31fa : commit 2
# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
