### PR TITLE
[release-7.1] Optimize LogPushData to avoid constructing LogSystemConfig

### DIFF
--- a/fdbserver/CommitProxyServer.actor.cpp
+++ b/fdbserver/CommitProxyServer.actor.cpp
@@ -624,7 +624,7 @@ CommitBatchContext::CommitBatchContext(ProxyCommitData* const pProxyCommitData_,
   : pProxyCommitData(pProxyCommitData_), trs(std::move(*const_cast<std::vector<CommitTransactionRequest>*>(trs_))),
     currentBatchMemBytesCount(currentBatchMemBytesCount), startTime(g_network->now()),
     localBatchNumber(++pProxyCommitData->localCommitBatchesStarted),
-    toCommit(pProxyCommitData->logSystem, pProxyCommitData->localTLogs), span("MP:commitBatch"_loc),
+    toCommit(pProxyCommitData->logSystem, pProxyCommitData->localTLogCount), span("MP:commitBatch"_loc),
     committed(trs.size()) {
 
 	evaluateBatchSize();
@@ -2327,7 +2327,7 @@ ACTOR Future<Void> commitProxyServerCore(CommitProxyInterface proxy,
 	//TraceEvent("ProxyInit3", proxy.id());
 
 	commitData.resolvers = commitData.db->get().resolvers;
-	commitData.localTLogs = commitData.db->get().logSystemConfig.numLogs();
+	commitData.localTLogCount = commitData.db->get().logSystemConfig.numLogs();
 	ASSERT(commitData.resolvers.size() != 0);
 	for (int i = 0; i < commitData.resolvers.size(); ++i) {
 		commitData.stats.resolverDist.push_back(

--- a/fdbserver/CommitProxyServer.actor.cpp
+++ b/fdbserver/CommitProxyServer.actor.cpp
@@ -621,16 +621,11 @@ std::set<Tag> CommitBatchContext::getWrittenTagsPreResolution() {
 CommitBatchContext::CommitBatchContext(ProxyCommitData* const pProxyCommitData_,
                                        const std::vector<CommitTransactionRequest>* trs_,
                                        const int currentBatchMemBytesCount)
-  :
-
-    pProxyCommitData(pProxyCommitData_), trs(std::move(*const_cast<std::vector<CommitTransactionRequest>*>(trs_))),
-    currentBatchMemBytesCount(currentBatchMemBytesCount),
-
-    startTime(g_network->now()),
-
-    localBatchNumber(++pProxyCommitData->localCommitBatchesStarted), toCommit(pProxyCommitData->logSystem),
-
-    span("MP:commitBatch"_loc), committed(trs.size()) {
+  : pProxyCommitData(pProxyCommitData_), trs(std::move(*const_cast<std::vector<CommitTransactionRequest>*>(trs_))),
+    currentBatchMemBytesCount(currentBatchMemBytesCount), startTime(g_network->now()),
+    localBatchNumber(++pProxyCommitData->localCommitBatchesStarted),
+    toCommit(pProxyCommitData->logSystem, pProxyCommitData->localTLogs), span("MP:commitBatch"_loc),
+    committed(trs.size()) {
 
 	evaluateBatchSize();
 
@@ -2332,6 +2327,7 @@ ACTOR Future<Void> commitProxyServerCore(CommitProxyInterface proxy,
 	//TraceEvent("ProxyInit3", proxy.id());
 
 	commitData.resolvers = commitData.db->get().resolvers;
+	commitData.localTLogs = commitData.db->get().logSystemConfig.numLogs();
 	ASSERT(commitData.resolvers.size() != 0);
 	for (int i = 0; i < commitData.resolvers.size(); ++i) {
 		commitData.stats.resolverDist.push_back(

--- a/fdbserver/LogSystem.cpp
+++ b/fdbserver/LogSystem.cpp
@@ -269,6 +269,15 @@ void LogSet::getPushLocations(VectorRef<Tag> tags, std::vector<int>& locations, 
 	//	.detail("Included", alsoServers.size()).detail("Duration", timer() - t);
 }
 
+LogPushData::LogPushData(Reference<ILogSystem> logSystem, int tlogCount) : logSystem(logSystem), subsequence(1) {
+	ASSERT(tlogCount > 0);
+	messagesWriter.reserve(tlogCount);
+	for (int i = 0; i < tlogCount; i++) {
+		messagesWriter.emplace_back(AssumeVersion(g_network->protocolVersion()));
+	}
+	messagesWritten = std::vector<bool>(tlogCount, false);
+}
+
 void LogPushData::addTxsTag() {
 	if (logSystem->getTLogVersion() >= TLogVersion::V4) {
 		next_message_tags.push_back(logSystem->getRandomTxsTag());

--- a/fdbserver/LogSystem.h
+++ b/fdbserver/LogSystem.h
@@ -651,14 +651,14 @@ struct ILogSystem {
 	// Returns an ILogSystem representing a new epoch immediately following this one.  The new epoch is only provisional
 	// until the caller updates the coordinated DBCoreState
 
-	virtual LogSystemConfig getLogSystemConfig() const = 0;
 	// Returns the physical configuration of this LogSystem, that could be used to construct an equivalent LogSystem
 	// using fromLogSystemConfig()
+	virtual LogSystemConfig getLogSystemConfig() const = 0;
 
 	virtual Standalone<StringRef> getLogsValue() const = 0;
 
-	virtual Future<Void> onLogSystemConfigChange() = 0;
 	// Returns when the log system configuration has changed due to a tlog rejoin.
+	virtual Future<Void> onLogSystemConfigChange() = 0;
 
 	virtual void getPushLocations(VectorRef<Tag> tags,
 	                              std::vector<int>& locations,
@@ -740,16 +740,7 @@ struct LogPushData : NonCopyable {
 	// Log subsequences have to start at 1 (the MergedPeekCursor relies on this to make sure we never have !hasMessage()
 	// in the middle of data for a version
 
-	explicit LogPushData(Reference<ILogSystem> logSystem) : logSystem(logSystem), subsequence(1) {
-		for (auto& log : logSystem->getLogSystemConfig().tLogs) {
-			if (log.isLocal) {
-				for (int i = 0; i < log.tLogs.size(); i++) {
-					messagesWriter.push_back(BinaryWriter(AssumeVersion(g_network->protocolVersion())));
-				}
-			}
-		}
-		messagesWritten = std::vector<bool>(messagesWriter.size(), false);
-	}
+	explicit LogPushData(Reference<ILogSystem> logSystem, int tlogCount);
 
 	void addTxsTag();
 

--- a/fdbserver/ProxyCommitData.actor.h
+++ b/fdbserver/ProxyCommitData.actor.h
@@ -225,6 +225,7 @@ struct ProxyCommitData {
 	double lastResolverReset;
 
 	std::map<TenantName, TenantMapEntry> tenantMap;
+	int localTLogs = -1;
 
 	// The tag related to a storage server rarely change, so we keep a vector of tags for each key range to be slightly
 	// more CPU efficient. When a tag related to a storage server does change, we empty out all of these vectors to

--- a/fdbserver/ProxyCommitData.actor.h
+++ b/fdbserver/ProxyCommitData.actor.h
@@ -225,7 +225,7 @@ struct ProxyCommitData {
 	double lastResolverReset;
 
 	std::map<TenantName, TenantMapEntry> tenantMap;
-	int localTLogs = -1;
+	int localTLogCount = -1;
 
 	// The tag related to a storage server rarely change, so we keep a vector of tags for each key range to be slightly
 	// more CPU efficient. When a tag related to a storage server does change, we empty out all of these vectors to

--- a/fdbserver/Resolver.actor.cpp
+++ b/fdbserver/Resolver.actor.cpp
@@ -138,6 +138,7 @@ struct Resolver : ReferenceCounted<Resolver> {
 	LogSystemDiskQueueAdapter* logAdapter = nullptr;
 	Reference<ILogSystem> logSystem;
 	IKeyValueStore* txnStateStore = nullptr;
+	int localTLogs = -1;
 
 	std::map<UID, Reference<StorageInfo>> storageCache;
 	KeyRangeMap<ServerCacheInfo> keyInfo; // keyrange -> all storage servers in all DCs for the keyrange
@@ -318,7 +319,7 @@ ACTOR Future<Void> resolveBatch(Reference<Resolver> self, ResolveTransactionBatc
 		if (SERVER_KNOBS->PROXY_USE_RESOLVER_PRIVATE_MUTATIONS) {
 			auto lockedKey = self->txnStateStore->readValue(databaseLockedKey).get();
 			isLocked = lockedKey.present() && lockedKey.get().size();
-			toCommit.reset(new LogPushData(self->logSystem));
+			toCommit.reset(new LogPushData(self->logSystem, self->localTLogs));
 			resolverData.reset(new ResolverData(self->dbgid,
 			                                    self->logSystem,
 			                                    self->txnStateStore,
@@ -647,6 +648,7 @@ ACTOR Future<Void> resolverCore(ResolverInterface resolver,
 
 	// Initialize txnStateStore
 	self->logSystem = ILogSystem::fromServerDBInfo(resolver.id(), db->get(), false, addActor);
+	self->localTLogs = db->get().logSystemConfig.numLogs();
 	state PromiseStream<Future<Void>> addActor;
 	state Future<Void> onError =
 	    transformError(actorCollection(addActor.getFuture()), broken_promise(), resolver_failed());

--- a/fdbserver/Resolver.actor.cpp
+++ b/fdbserver/Resolver.actor.cpp
@@ -138,7 +138,7 @@ struct Resolver : ReferenceCounted<Resolver> {
 	LogSystemDiskQueueAdapter* logAdapter = nullptr;
 	Reference<ILogSystem> logSystem;
 	IKeyValueStore* txnStateStore = nullptr;
-	int localTLogs = -1;
+	int localTLogCount = -1;
 
 	std::map<UID, Reference<StorageInfo>> storageCache;
 	KeyRangeMap<ServerCacheInfo> keyInfo; // keyrange -> all storage servers in all DCs for the keyrange
@@ -319,7 +319,7 @@ ACTOR Future<Void> resolveBatch(Reference<Resolver> self, ResolveTransactionBatc
 		if (SERVER_KNOBS->PROXY_USE_RESOLVER_PRIVATE_MUTATIONS) {
 			auto lockedKey = self->txnStateStore->readValue(databaseLockedKey).get();
 			isLocked = lockedKey.present() && lockedKey.get().size();
-			toCommit.reset(new LogPushData(self->logSystem, self->localTLogs));
+			toCommit.reset(new LogPushData(self->logSystem, self->localTLogCount));
 			resolverData.reset(new ResolverData(self->dbgid,
 			                                    self->logSystem,
 			                                    self->txnStateStore,
@@ -648,7 +648,7 @@ ACTOR Future<Void> resolverCore(ResolverInterface resolver,
 
 	// Initialize txnStateStore
 	self->logSystem = ILogSystem::fromServerDBInfo(resolver.id(), db->get(), false, addActor);
-	self->localTLogs = db->get().logSystemConfig.numLogs();
+	self->localTLogCount = db->get().logSystemConfig.numLogs();
 	state PromiseStream<Future<Void>> addActor;
 	state Future<Void> onError =
 	    transformError(actorCollection(addActor.getFuture()), broken_promise(), resolver_failed());


### PR DESCRIPTION
Cherrypick #7070 

Which seems to be a CPU hot spot in our testing.

100k 20220505-215659-jzhou-c1f22b99d946b5be has one `BlobGranuleVerifyLarge.toml` timeout failure (many BlobGranuleInitialSnapshotRetry with transaction_too_old error), probably not related.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
