### PR TITLE
add appendRaw and subTupleRawString for Tuple(release-7.1)

### DIFF
--- a/fdbclient/Tuple.cpp
+++ b/fdbclient/Tuple.cpp
@@ -121,6 +121,13 @@ Tuple& Tuple::append(StringRef const& str, bool utf8) {
 	return *this;
 }
 
+Tuple& Tuple::appendRaw(StringRef const& str) {
+	offsets.push_back(data.size());
+
+	data.append(data.arena(), str.begin(), str.size());
+	return *this;
+}
+
 Tuple& Tuple::append(int64_t value) {
 	uint64_t swap = value;
 	bool neg = false;
@@ -382,4 +389,13 @@ Tuple Tuple::subTuple(size_t start, size_t end) const {
 
 	size_t endPos = end < offsets.size() ? offsets[end] : data.size();
 	return Tuple(StringRef(data.begin() + offsets[start], endPos - offsets[start]));
+}
+
+StringRef Tuple::subTupleRawString(size_t index) const {
+	if (index >= offsets.size()) {
+		return StringRef();
+	}
+	size_t end = index + 1;
+	size_t endPos = end < offsets.size() ? offsets[end] : data.size();
+	return StringRef(data.begin() + offsets[index], endPos - offsets[index]);
 }

--- a/fdbclient/Tuple.h
+++ b/fdbclient/Tuple.h
@@ -36,6 +36,7 @@ struct Tuple {
 	static Tuple unpack(StringRef const& str, bool exclude_incomplete = false);
 
 	Tuple& append(Tuple const& tuple);
+	Tuple& appendRaw(StringRef const& str);
 	Tuple& append(StringRef const& str, bool utf8 = false);
 	Tuple& append(int64_t);
 	// There are some ambiguous append calls in fdbclient, so to make it easier
@@ -61,7 +62,7 @@ struct Tuple {
 		data.clear();
 		offsets.clear();
 	}
-
+	StringRef subTupleRawString(size_t index) const;
 	ElementType getType(size_t index) const;
 	Standalone<StringRef> getString(size_t index) const;
 	int64_t getInt(size_t index, bool allow_incomplete = false) const;

--- a/fdbclient/Tuple.h
+++ b/fdbclient/Tuple.h
@@ -36,6 +36,8 @@ struct Tuple {
 	static Tuple unpack(StringRef const& str, bool exclude_incomplete = false);
 
 	Tuple& append(Tuple const& tuple);
+
+	// the str needs to be a Tuple encoded string.
 	Tuple& appendRaw(StringRef const& str);
 	Tuple& append(StringRef const& str, bool utf8 = false);
 	Tuple& append(int64_t);
@@ -62,6 +64,7 @@ struct Tuple {
 		data.clear();
 		offsets.clear();
 	}
+	// Return a Tuple encoded raw string.
 	StringRef subTupleRawString(size_t index) const;
 	ElementType getType(size_t index) const;
 	Standalone<StringRef> getString(size_t index) const;

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -3552,10 +3552,14 @@ void preprocessMappedKey(Tuple& mappedKeyFormatTuple,
 				vt.push_back(Optional<Tuple>());
 				isRangeQuery = true;
 			} else {
-				vt.push_back(Optional<Tuple>(mappedKeyFormatTuple.subTuple(i, i + 1)));
+				Tuple t;
+				t.appendRaw(mappedKeyFormatTuple.subTupleRawString(i));
+				vt.push_back(Optional<Tuple>(t));
 			}
 		} else {
-			vt.push_back(Optional<Tuple>(mappedKeyFormatTuple.subTuple(i, i + 1)));
+			Tuple t;
+			t.appendRaw(mappedKeyFormatTuple.subTupleRawString(i));
+			vt.push_back(Optional<Tuple>(t));
 		}
 	}
 }
@@ -3599,7 +3603,7 @@ Key constructMappedKey(KeyValueRef* keyValue,
 			if (idx < 0 || idx >= referenceTuple->size()) {
 				throw mapper_bad_index();
 			}
-			mappedKeyTuple.append(referenceTuple->subTuple(idx, idx + 1));
+			mappedKeyTuple.appendRaw(referenceTuple->subTupleRawString(idx));
 		}
 	}
 

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -3539,27 +3539,27 @@ void preprocessMappedKey(Tuple& mappedKeyFormatTuple,
 			if (escaped) {
 				Tuple escapedTuple;
 				escapedTuple.append(s);
-				vt.push_back(Optional<Tuple>(escapedTuple));
+				vt.emplace_back(escapedTuple);
 			} else if (singleKeyOrValue(s, sz)) {
 				// when it is SingleKeyOrValue, insert an empty Tuple to vector as placeholder
-				vt.push_back(Optional<Tuple>(Tuple()));
+				vt.emplace_back(Tuple());
 			} else if (rangeQuery(s)) {
 				if (i != mappedKeyFormatTuple.size() - 1) {
 					// It must be the last element of the mapper tuple
 					throw mapper_bad_range_decriptor();
 				}
 				// when it is rangeQuery, insert Optional.empty as placeholder
-				vt.push_back(Optional<Tuple>());
+				vt.emplace_back(Optional<Tuple>());
 				isRangeQuery = true;
 			} else {
 				Tuple t;
 				t.appendRaw(mappedKeyFormatTuple.subTupleRawString(i));
-				vt.push_back(Optional<Tuple>(t));
+				vt.emplace_back(t);
 			}
 		} else {
 			Tuple t;
 			t.appendRaw(mappedKeyFormatTuple.subTupleRawString(i));
-			vt.push_back(Optional<Tuple>(t));
+			vt.emplace_back(t);
 		}
 	}
 }


### PR DESCRIPTION
backporting https://github.com/apple/foundationdb/pull/7077

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
