### PR TITLE
Add transaction retry loop for GlobalConfig

### DIFF
--- a/fdbclient/GlobalConfig.actor.cpp
+++ b/fdbclient/GlobalConfig.actor.cpp
@@ -168,11 +168,7 @@ ACTOR Future<Void> GlobalConfig::migrate(GlobalConfig* self) {
 			wait(tr->commit());
 			break;
 		} catch (Error& e) {
-			// If multiple fdbserver processes are started at once, they will all
-			// attempt this migration at the same time, sometimes resulting in
-			// aborts due to conflicts. Purposefully avoid retrying, making this
-			// migration best-effort.
-			TraceEvent(SevInfo, "GlobalConfig_MigrationError").detail("What", e.what());
+			TraceEvent(SevInfo, "GlobalConfig_MigrationError").error(e);
 			wait(tr->onError(e));
 		}
 	}


### PR DESCRIPTION
To catch errors and retry.

100k 20220505-230025-jzhou-e3d22229016c1ae3 passed.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
