### PR TITLE
Eliminate vector string during mapped key processing

### DIFF
--- a/packaging/docker/sidecar.py
+++ b/packaging/docker/sidecar.py
@@ -523,7 +523,7 @@ class Server(BaseHTTPRequestHandler):
                     self.send_error(404, "Path not found")
                     self.end_headers()
             if self.path.startswith("/is_present/"):
-                if is_present(os.path.basename(self.path))):
+                if is_present(os.path.basename(self.path)):
                     self.send_text("OK")
                 else:
                     self.send_error(404, "Path not found")


### PR DESCRIPTION
There was OOM if we pre-process all the strings.

Put description here...

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
