### PR TITLE
Upgrade Tests: Avoid race conditions when copying library files from a local repo

### DIFF
--- a/tests/TestRunner/upgrade_test.py
+++ b/tests/TestRunner/upgrade_test.py
@@ -259,10 +259,14 @@ class UpgradeTest:
         dest_lib_file = self.download_dir.joinpath(version, "libfdb_c.so")
         if dest_lib_file.exists():
             return
+        # Avoid race conditions in case of parallel test execution by first copying to a temporary file
+        # and then renaming it atomically
+        dest_file_tmp = Path("{}.{}".format(str(dest_lib_file), random_secret_string(8)))
         src_lib_file = self.local_binary_repo.joinpath(version, "lib", "libfdb_c-{}.so".format(version))
         assert src_lib_file.exists(), "Missing file {} in the local old binaries repository".format(src_lib_file)
         self.download_dir.joinpath(version).mkdir(parents=True, exist_ok=True)
-        shutil.copyfile(src_lib_file, dest_lib_file)
+        shutil.copyfile(src_lib_file, dest_file_tmp)
+        os.rename(dest_file_tmp, dest_lib_file)
         assert dest_lib_file.exists(), "{} does not exist".format(dest_lib_file)
 
     # Download all old binaries required for testing the specified upgrade path


### PR DESCRIPTION
There were sporadical failures of the upgrade tests. The test binaries failed to load the client libraries using dlopen, getting an error that indicates file corruption. The file corruption was likely caused by multiple tests copying the same library file in parallel. The fix addresses this by replacing the file atomically.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
