### PR TITLE
Reduce workload in CycleMultiClientIntegrationTest

### DIFF
--- a/bindings/java/src/integration/com/apple/foundationdb/CycleMultiClientIntegrationTest.java
+++ b/bindings/java/src/integration/com/apple/foundationdb/CycleMultiClientIntegrationTest.java
@@ -43,8 +43,8 @@ public class CycleMultiClientIntegrationTest {
     public static final MultiClientHelper clientHelper = new MultiClientHelper();
 
     // more write txn than validate txn, as parent thread waits only for validate txn.
-    private static final int writeTxnCnt = 2000;
-    private static final int validateTxnCnt = 1000;
+    private static final int writeTxnCnt = 200;
+    private static final int validateTxnCnt = 100;
     private static final int threadPerDB = 5;
 
     private static final int cycleLength = 4;


### PR DESCRIPTION
By default we have 3 clusters, each have 5 threads running the same
workload, this PR reduces workload from 2k write txn to 200 because
2k txn takes too long to execute and 200 is enough for correcetness.

Put description here...

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
