### PR TITLE
Make use of relpath instead of basepath

### DIFF
--- a/packaging/docker/sidecar.py
+++ b/packaging/docker/sidecar.py
@@ -519,13 +519,13 @@ class Server(BaseHTTPRequestHandler):
             if self.path.startswith("/check_hash/"):
                 try:
                     self.send_text(
-                        check_hash(os.path.basename(self.path)), add_newline=False
+                        check_hash(os.path.relpath(self.path, "/check_hash")), add_newline=False
                     )
                 except FileNotFoundError:
                     self.send_error(404, "Path not found")
                     self.end_headers()
             if self.path.startswith("/is_present/"):
-                if is_present(os.path.basename(self.path)):
+                if is_present(os.path.relpath(self.path, "/is_present")):
                     self.send_text("OK")
                 else:
                     self.send_error(404, "Path not found")


### PR DESCRIPTION
We have to use `relpath` instead of the base path if a file is in a sub folder example:

```bash
2022-05-07 08:19:46,541 INFO path: /is_present/bin/7.1.3/fdbserver
2022-05-07 08:19:46,541 INFO real: bin/7.1.3/fdbserver
2022-05-07 08:19:46,541 INFO base: fdbserver
2022-05-07 08:19:46,541 INFO file is_present on disk
2022-05-07 08:19:46,541 INFO "GET /is_present/bin/7.1.3/fdbserver HTTP/1.1" 200 -
```

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [x] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
