### PR TITLE
Add testing for Kubernetes sidecar

### DIFF
--- a/packaging/docker/sidecar.py
+++ b/packaging/docker/sidecar.py
@@ -35,6 +35,7 @@ import traceback
 import sys
 import tempfile
 from pathlib import Path
+from functools import partial
 
 from http.server import HTTPServer, ThreadingHTTPServer, BaseHTTPRequestHandler
 
@@ -166,9 +167,7 @@ class Config(object):
         )
         parser.add_argument(
             "--require-not-empty",
-            help=(
-                "A file that must be present and non-empty " "in the input directory"
-            ),
+            help=("A file that must be present and non-empty in the input directory"),
             action="append",
         )
         args = parser.parse_args()
@@ -346,51 +345,23 @@ class ThreadingHTTPServerV6(ThreadingHTTPServer):
     address_family = socket.AF_INET6
 
 
-class Server(BaseHTTPRequestHandler):
-    ssl_context = None
+class SidecarHandler(BaseHTTPRequestHandler):
+    def __init__(self, config, *args, **kwargs):
+        self.config = config
+        self.ssl_context = None
+        # BaseHTTPRequestHandler calls do_GET **inside** __init__ !!!
+        # So we have to call super().__init__ after setting attributes.
+        super().__init__(*args, **kwargs)
 
-    @classmethod
-    def start(cls):
-        """
-        This method starts the server.
-        """
-        config = Config.shared()
-        colon_index = config.bind_address.rindex(":")
-        port_index = colon_index + 1
-        address = config.bind_address[:colon_index]
-        port = config.bind_address[port_index:]
-        log.info(f"Listening on {address}:{port}")
-
-        if address.startswith("[") and address.endswith("]"):
-            server = ThreadingHTTPServerV6((address[1:-1], int(port)), cls)
-        else:
-            server = ThreadingHTTPServer((address, int(port)), cls)
-
-        if config.enable_tls:
-            context = Server.load_ssl_context()
-            server.socket = context.wrap_socket(server.socket, server_side=True)
-            observer = Observer()
-            event_handler = CertificateEventHandler()
-            for path in set(
-                [
-                    Path(config.certificate_file).parent.as_posix(),
-                    Path(config.key_file).parent.as_posix(),
-                ]
-            ):
-                observer.schedule(event_handler, path)
-            observer.start()
-
-        server.serve_forever()
-
-    @classmethod
-    def load_ssl_context(cls):
-        config = Config.shared()
-        if not cls.ssl_context:
-            cls.ssl_context = ssl.create_default_context(cafile=config.ca_file)
-            cls.ssl_context.check_hostname = False
-            cls.ssl_context.verify_mode = ssl.CERT_OPTIONAL
-        cls.ssl_context.load_cert_chain(config.certificate_file, config.key_file)
-        return cls.ssl_context
+    def load_ssl_context(self):
+        if not self.ssl_context:
+            self.ssl_context = ssl.create_default_context(cafile=self.config.ca_file)
+            self.ssl_context.check_hostname = False
+            self.ssl_context.verify_mode = ssl.CERT_OPTIONAL
+        self.ssl_context.load_cert_chain(
+            self.config.certificate_file, self.config.key_file
+        )
+        return self.ssl_context
 
     def send_text(self, text, code=200, content_type="text/plain", add_newline=True):
         """
@@ -407,16 +378,14 @@ class Server(BaseHTTPRequestHandler):
         self.wfile.write(response)
 
     def check_request_cert(self, path):
-        config = Config.shared()
-
         if path == "/ready":
             return True
 
-        if not config.enable_tls:
+        if not self.config.enable_tls:
             return True
 
         approved = self.check_cert(
-            self.connection.getpeercert(), config.peer_verification_rules
+            self.connection.getpeercert(), self.config.peer_verification_rules
         )
         if not approved:
             self.send_error(401, "Client certificate was not approved")
@@ -517,32 +486,32 @@ class Server(BaseHTTPRequestHandler):
             if not self.check_request_cert(self.path):
                 return
             if self.path.startswith("/check_hash/"):
+                file_path = os.path.relpath(self.path, "/check_hash")
                 try:
                     self.send_text(
-                        check_hash(os.path.relpath(self.path, "/check_hash")), add_newline=False
+                        self.check_hash(file_path),
+                        add_newline=False,
                     )
                 except FileNotFoundError:
-                    self.send_error(404, "Path not found")
-                    self.end_headers()
+                    self.send_error(404, f"{file_path} not found")
             if self.path.startswith("/is_present/"):
-                if is_present(os.path.relpath(self.path, "/is_present")):
+                file_path = os.path.relpath(self.path, "/is_present")
+                if self.is_present(file_path):
                     self.send_text("OK")
                 else:
-                    self.send_error(404, "Path not found")
-                    self.end_headers()
+                    self.send_error(404, f"{file_path} not found")
             elif self.path == "/ready":
                 self.send_text(ready())
             elif self.path == "/substitutions":
-                self.send_text(get_substitutions())
+                self.send_text(self.get_substitutions())
             else:
                 self.send_error(404, "Path not found")
-                self.end_headers()
         except RequestException as e:
             self.send_error(400, e.message)
         except Exception as ex:
+            print(ex)
             log.error(f"Error processing request {ex}", exc_info=True)
             self.send_error(500)
-            self.end_headers()
 
     def do_POST(self):
         """
@@ -552,13 +521,13 @@ class Server(BaseHTTPRequestHandler):
             if not self.check_request_cert(self.path):
                 return
             if self.path == "/copy_files":
-                self.send_text(copy_files())
+                self.send_text(copy_files(self.config))
             elif self.path == "/copy_binaries":
-                self.send_text(copy_binaries())
+                self.send_text(copy_binaries(self.config))
             elif self.path == "/copy_libraries":
-                self.send_text(copy_libraries())
+                self.send_text(copy_libraries(self.config))
             elif self.path == "/copy_monitor_conf":
-                self.send_text(copy_monitor_conf())
+                self.send_text(copy_monitor_conf(self.config))
             elif self.path == "/refresh_certs":
                 self.send_text(refresh_certs())
             elif self.path == "/restart":
@@ -579,8 +548,30 @@ class Server(BaseHTTPRequestHandler):
     def log_message(self, format, *args):
         log.info(format % args)
 
+    def refresh_certs(self):
+        if not self.config.enable_tls:
+            raise RequestException("Server is not using TLS")
+        self.load_ssl_context()
+        return "OK"
+
+    def get_substitutions(self):
+        return json.dumps(self.config.substitutions)
+
+    def check_hash(self, filename):
+        with open(os.path.join(self.config.output_dir, filename), "rb") as contents:
+            m = hashlib.sha256()
+            m.update(contents.read())
+            return m.hexdigest()
+
+    def is_present(self, filename):
+        return os.path.exists(os.path.join(self.config.output_dir, filename))
+
 
 class CertificateEventHandler(FileSystemEventHandler):
+    def __init__(self, handler):
+        self.handler = handler
+        FileSystemEventHandler.__init__(self)
+
     def on_any_event(self, event):
         if event.is_directory:
             return None
@@ -597,27 +588,15 @@ class CertificateEventHandler(FileSystemEventHandler):
         )
         time.sleep(10)
         log.info("Reloading certificates")
-        Server.load_ssl_context()
+        self.handler.load_ssl_context()
 
 
-def check_hash(filename):
-    with open(os.path.join(Config.shared().output_dir, filename), "rb") as contents:
-        m = hashlib.sha256()
-        m.update(contents.read())
-        return m.hexdigest()
-
-
-def is_present(filename):
-    return os.path.exists(os.path.join(Config.shared().output_dir, filename))
-
-
-def copy_files():
-    config = Config.shared()
+def copy_files(config):
     if config.require_not_empty:
         for filename in config.require_not_empty:
             path = os.path.join(config.input_dir, filename)
             if not os.path.isfile(path) or os.path.getsize(path) == 0:
-                raise Exception("No contents for file %s" % path)
+                raise Exception(f"No contents for file {path}")
 
     for filename in config.copy_files:
         tmp_file = tempfile.NamedTemporaryFile(
@@ -629,8 +608,7 @@ def copy_files():
     return "OK"
 
 
-def copy_binaries():
-    config = Config.shared()
+def copy_binaries(config):
     if config.main_container_version != config.primary_version:
         for binary in config.copy_binaries:
             path = Path(f"/usr/bin/{binary}")
@@ -650,8 +628,7 @@ def copy_binaries():
     return "OK"
 
 
-def copy_libraries():
-    config = Config.shared()
+def copy_libraries(config):
     for version in config.copy_libraries:
         path = Path(f"/var/fdb/lib/libfdb_c_{version}.so")
         if version == config.copy_libraries[0]:
@@ -670,8 +647,7 @@ def copy_libraries():
     return "OK"
 
 
-def copy_monitor_conf():
-    config = Config.shared()
+def copy_monitor_conf(config):
     if config.input_monitor_conf:
         with open(
             os.path.join(config.input_dir, config.input_monitor_conf)
@@ -695,18 +671,7 @@ def copy_monitor_conf():
     return "OK"
 
 
-def get_substitutions():
-    return json.dumps(Config.shared().substitutions)
-
-
 def ready():
-    return "OK"
-
-
-def refresh_certs():
-    if not Config.shared().enable_tls:
-        raise RequestException("Server is not using TLS")
-    Server.load_ssl_context()
     return "OK"
 
 
@@ -716,14 +681,52 @@ class RequestException(Exception):
         self.message = message
 
 
+def start_sidecar_server(config):
+    """
+    This method starts the HTTP server with the sidecar handler.
+    """
+    colon_index = config.bind_address.rindex(":")
+    port_index = colon_index + 1
+    address = config.bind_address[:colon_index]
+    port = config.bind_address[port_index:]
+    log.info(f"Listening on {address}:{port}")
+
+    handler = partial(
+        SidecarHandler,
+        config,
+    )
+
+    if address.startswith("[") and address.endswith("]"):
+        server = ThreadingHTTPServerV6((address[1:-1], int(port)), handler)
+    else:
+        server = ThreadingHTTPServer((address, int(port)), handler)
+
+    if config.enable_tls:
+        context = handler.load_ssl_context()
+        server.socket = context.wrap_socket(server.socket, server_side=True)
+        observer = Observer()
+        event_handler = CertificateEventHandler(handler)
+        for path in set(
+            [
+                Path(config.certificate_file).parent.as_posix(),
+                Path(config.key_file).parent.as_posix(),
+            ]
+        ):
+            observer.schedule(event_handler, path)
+        observer.start()
+
+    server.serve_forever()
+
+
 if __name__ == "__main__":
     logging.basicConfig(format="%(asctime)-15s %(levelname)s %(message)s")
-    copy_files()
-    copy_binaries()
-    copy_libraries()
-    copy_monitor_conf()
+    config = Config.shared()
+    copy_files(config)
+    copy_binaries(config)
+    copy_libraries(config)
+    copy_monitor_conf(config)
 
-    if Config.shared().init_mode:
+    if config.init_mode:
         sys.exit(0)
 
-    Server.start()
+    start_sidecar_server(config)

--- a/packaging/docker/sidecar.py
+++ b/packaging/docker/sidecar.py
@@ -353,8 +353,8 @@ class SidecarHandler(BaseHTTPRequestHandler):
     # This method allows to trigger a reload of the ssl context and updates the static variable.
     @classmethod
     def load_ssl_context(cls):
+        config = Config.shared()
         if not cls.ssl_context:
-            config = Config.shared()
             cls.ssl_context = ssl.create_default_context(cafile=config.ca_file)
             cls.ssl_context.check_hostname = False
             cls.ssl_context.verify_mode = ssl.CERT_OPTIONAL

--- a/packaging/docker/sidecar.py
+++ b/packaging/docker/sidecar.py
@@ -501,15 +501,16 @@ class SidecarHandler(BaseHTTPRequestHandler):
                 else:
                     self.send_error(404, f"{file_path} not found")
             elif self.path == "/ready":
-                self.send_text(ready())
+                self.send_text("OK")
             elif self.path == "/substitutions":
                 self.send_text(self.get_substitutions())
             else:
                 self.send_error(404, "Path not found")
         except RequestException as e:
             self.send_error(400, e.message)
+        except (ConnectionResetError, BrokenPipeError) as ex:
+            log.error(f"connection was reset {ex}")
         except Exception as ex:
-            print(ex)
             log.error(f"Error processing request {ex}", exc_info=True)
             self.send_error(500)
 
@@ -668,10 +669,6 @@ def copy_monitor_conf(config):
 
         os.replace(tmp_file.name, target_file)
 
-    return "OK"
-
-
-def ready():
     return "OK"
 
 

--- a/packaging/docker/sidecar_test.py
+++ b/packaging/docker/sidecar_test.py
@@ -61,6 +61,7 @@ class TestSidecar(unittest.TestCase):
     def test_get_check_hash_no_found(self):
         r = requests.get(f"{self.server_url }/check_hash/foobar")
         self.assertEqual(r.status_code, 404)
+        self.assertRegex(r.text, "foobar not found")
 
     def test_get_check_hash(self):
         with open(os.path.join(self.mock_config.output_dir, "foobar"), "w") as f:
@@ -85,6 +86,7 @@ class TestSidecar(unittest.TestCase):
     def test_get_is_present_no_found(self):
         r = requests.get(f"{self.server_url }/is_present/foobar")
         self.assertEqual(r.status_code, 404)
+        self.assertRegex(r.text, "foobar not found")
 
     def test_get_is_present(self):
         with open(os.path.join(self.mock_config.output_dir, "foobar"), "w") as f:
@@ -102,7 +104,10 @@ class TestSidecar(unittest.TestCase):
         self.assertEqual(r.status_code, 200)
         self.assertEqual(r.text, "OK\n")
 
-    # TODO (johscheuer): test case default case.
+    def test_get_not_found(self):
+        r = requests.get(f"{self.server_url }/foobar")
+        self.assertEqual(r.status_code, 404)
+        self.assertRegex(r.text, "Path not found")
 
 
 # TODO(johscheuer): Add test cases for post requests

--- a/packaging/docker/sidecar_test.py
+++ b/packaging/docker/sidecar_test.py
@@ -1,0 +1,111 @@
+import unittest
+from unittest.mock import MagicMock
+import socket
+from sidecar import SidecarHandler
+from http.server import HTTPServer, BaseHTTPRequestHandler
+import shutil, tempfile
+from functools import partial
+import os
+import requests
+from threading import Thread
+import time
+
+# This test suite starts a real server with a mocked configuration and will do some requests against it.
+class TestSidecar(unittest.TestCase):
+    def setUp(self):
+        super(TestSidecar, self).setUp()
+        self.get_free_port()
+        self.server_url = f"http://localhost:{self.test_server_port}"
+        self.mock_config = MagicMock()
+        # We don't want to use TLS for the local tests for now.
+        self.mock_config.enable_tls = False
+        self.mock_config.output_dir = tempfile.mkdtemp()
+
+        handler = partial(
+            SidecarHandler,
+            self.mock_config,
+        )
+        self.mock_server = HTTPServer(("localhost", self.test_server_port), handler)
+
+        # Start running mock server in a separate thread.
+        # Daemon threads automatically shut down when the main process exits.
+        self.mock_server_thread = Thread(target=self.mock_server.serve_forever)
+        self.mock_server_thread.setDaemon(True)
+        self.mock_server_thread.start()
+        # time.sleep(1)
+
+    def tearDown(self):
+        shutil.rmtree(self.mock_config.output_dir)
+        super(TestSidecar, self).tearDown()
+
+    # Helper method to get a free port
+    def get_free_port(self):
+        s = socket.socket(socket.AF_INET, type=socket.SOCK_STREAM)
+        s.bind(("localhost", 0))
+        __, port = s.getsockname()
+        s.close()
+        self.test_server_port = port
+
+    def test_get_ready(self):
+        r = requests.get(f"{self.server_url }/ready")
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.text, "OK\n")
+
+    def test_get_substitutions(self):
+        expected = {"key": "value"}
+        self.mock_config.substitutions = expected
+        r = requests.get(f"{self.server_url }/substitutions")
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.json(), expected)
+
+    def test_get_check_hash_no_found(self):
+        r = requests.get(f"{self.server_url }/check_hash/foobar")
+        self.assertEqual(r.status_code, 404)
+
+    def test_get_check_hash(self):
+        with open(os.path.join(self.mock_config.output_dir, "foobar"), "w") as f:
+            f.write("hello world")
+        r = requests.get(f"{self.server_url }/check_hash/foobar")
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(
+            r.text, "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9"
+        )
+
+    def test_get_check_hash_nested(self):
+        test_path = os.path.join(self.mock_config.output_dir, "nested/foobar")
+        os.makedirs(os.path.dirname(test_path), exist_ok=True)
+        with open(test_path, "w") as f:
+            f.write("hello world")
+        r = requests.get(f"{self.server_url }/check_hash/nested/foobar")
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(
+            r.text, "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9"
+        )
+
+    def test_get_is_present_no_found(self):
+        r = requests.get(f"{self.server_url }/is_present/foobar")
+        self.assertEqual(r.status_code, 404)
+
+    def test_get_is_present(self):
+        with open(os.path.join(self.mock_config.output_dir, "foobar"), "w") as f:
+            f.write("hello world")
+        r = requests.get(f"{self.server_url }/is_present/foobar")
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.text, "OK\n")
+
+    def test_get_is_present_nested(self):
+        test_path = os.path.join(self.mock_config.output_dir, "nested/foobar")
+        os.makedirs(os.path.dirname(test_path), exist_ok=True)
+        with open(test_path, "w") as f:
+            f.write("hello world")
+        r = requests.get(f"{self.server_url }/is_present/nested/foobar")
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.text, "OK\n")
+
+    # TODO (johscheuer): test case default case.
+
+
+# TODO(johscheuer): Add test cases for post requests
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packaging/docker/sidecar_test.py
+++ b/packaging/docker/sidecar_test.py
@@ -1,14 +1,38 @@
-import unittest
-from unittest.mock import MagicMock
-import socket
-from sidecar import SidecarHandler
-from http.server import HTTPServer, BaseHTTPRequestHandler
-import shutil, tempfile
-from functools import partial
+#!/usr/bin/env python3
+
+# sidecar_test.py
+#
+# This source file is part of the FoundationDB open source project
+#
+# Copyright 2018-2022 Apple Inc. and the FoundationDB project authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 import os
-import requests
+import shutil
+import socket
+import tempfile
+import unittest
+from functools import partial
+from http.server import HTTPServer
 from threading import Thread
-import time
+from unittest.mock import MagicMock
+
+import requests
+
+from sidecar import SidecarHandler
+
 
 # This test suite starts a real server with a mocked configuration and will do some requests against it.
 class TestSidecar(unittest.TestCase):
@@ -32,7 +56,6 @@ class TestSidecar(unittest.TestCase):
         self.mock_server_thread = Thread(target=self.mock_server.serve_forever)
         self.mock_server_thread.setDaemon(True)
         self.mock_server_thread.start()
-        # time.sleep(1)
 
     def tearDown(self):
         shutil.rmtree(self.mock_config.output_dir)
@@ -110,7 +133,7 @@ class TestSidecar(unittest.TestCase):
         self.assertRegex(r.text, "Path not found")
 
 
-# TODO(johscheuer): Add test cases for post requests
-
+# TODO(johscheuer): Add test cases for post requests.
+# TODO(johscheuer): Add test cases for TLS.
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This is an initial attempt to make the Sidecar testable and add unit tests for it to test it without the requirement to spin up a cluster. In the long term this should give us more confidence in making changes in this script. I'm not an expert with the CI setup in this repository so I will probably consult @ammolitor how to integrate this in the CI runs.

Current run:

```bash
$ python3 sidecar_test.py
........
----------------------------------------------------------------------
Ran 8 tests in 0.050s

OK
```

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [x] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
