### PR TITLE
7.1 Cherry-pick: Address readVersion related bug in getRange actor

### DIFF
--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -4369,11 +4369,10 @@ Future<RangeResultFamily> getRange(Reference<TransactionState> trState,
 					TEST(true); // !GetKeyValuesFamilyReply.more and modifiedSelectors in getRange
 
 					if (!rep.data.size()) {
-						// VERSION_VECTOR change version to readVersion in getRangeFallback
 						RangeResultFamily result = wait(
 						    getRangeFallback<GetKeyValuesFamilyRequest, GetKeyValuesFamilyReply, RangeResultFamily>(
 						        trState,
-						        version,
+						        readVersion,
 						        originalBegin,
 						        originalEnd,
 						        mapper,


### PR DESCRIPTION
Cherry-pick pull request https://github.com/apple/foundationdb/pull/7092 from "main".

If getRange() is called with "latestVersion" as the read version then both GetKeyValuesFamilyRequest and getRangeFallback should do reads at the same version.

NOTE: Found this issue on the version vector branch but I don't think this issue is specific to version vector logic.

Testing:

Simulation tests:
Release-7.1 (with version vector disabled): 20220509-142228-sre-f20b969240383dee (no failures)
Release-7.1 (with version vector enabled): 20220509-151532-sre-c34087a7c7827946 (no failures)

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
