### PR TITLE
Enable debugId tracing for encryption requests

### DIFF
--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -857,6 +857,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
     init( ENABLE_ENCRYPTION,                                   false );
     init( ENCRYPTION_MODE,                              "AES-256-CTR");
     init( SIM_KMS_MAX_KEYS,                                      4096);
+    init( ENCRYPT_PROXY_MAX_DBG_TRACE_LENGTH,                  100000);
 
     // KMS connector type
     init( KMS_CONNECTOR_TYPE,                      "RESTKmsConnector");

--- a/fdbclient/ServerKnobs.h
+++ b/fdbclient/ServerKnobs.h
@@ -824,6 +824,7 @@ public:
 	bool ENABLE_ENCRYPTION;
 	std::string ENCRYPTION_MODE;
 	int SIM_KMS_MAX_KEYS;
+	int ENCRYPT_PROXY_MAX_DBG_TRACE_LENGTH;
 
 	// Key Management Service (KMS) Connector
 	std::string KMS_CONNECTOR_TYPE;

--- a/fdbserver/CMakeLists.txt
+++ b/fdbserver/CMakeLists.txt
@@ -105,7 +105,7 @@ set(FDBSERVER_SRCS
   RecoveryState.h
   RemoteIKeyValueStore.actor.h
   RemoteIKeyValueStore.actor.cpp
-  RESTKmsConnector.actor.h
+  RESTKmsConnector.h
   RESTKmsConnector.actor.cpp
   ResolutionBalancer.actor.cpp
   ResolutionBalancer.actor.h
@@ -138,7 +138,7 @@ set(FDBSERVER_SRCS
   ServerDBInfo.actor.h
   ServerDBInfo.h
   SigStack.cpp
-  SimKmsConnector.actor.h
+  SimKmsConnector.h
   SimKmsConnector.actor.cpp
   SimpleConfigConsumer.actor.cpp
   SimpleConfigConsumer.h

--- a/fdbserver/EncryptKeyProxy.actor.cpp
+++ b/fdbserver/EncryptKeyProxy.actor.cpp
@@ -182,8 +182,11 @@ ACTOR Future<Void> getCipherKeysByBaseCipherKeyIds(Reference<EncryptKeyProxyData
 	    dedupedCipherIds;
 	for (const auto& item : req.baseCipherIds) {
 		dedupedCipherIds.emplace(item);
+	}
 
-		if (dbgTrace.present()) {
+	if (dbgTrace.present()) {
+		dbgTrace.get().detail("NKeys", dedupedCipherIds.size());
+		for (const auto& item : dedupedCipherIds) {
 			// Record {encryptDomainId, baseCipherId} queried
 			dbgTrace.get().detail(getEncryptDbgTraceKey(ENCRYPT_DBG_TRACE_QUERY_PREFIX, item.second, item.first), "");
 		}
@@ -278,8 +281,11 @@ ACTOR Future<Void> getLatestCipherKeys(Reference<EncryptKeyProxyData> ekpProxyDa
 	std::unordered_set<EncryptCipherDomainId> dedupedDomainIds;
 	for (EncryptCipherDomainId id : req.encryptDomainIds) {
 		dedupedDomainIds.emplace(id);
+	}
 
-		if (dbgTrace.present()) {
+	if (dbgTrace.present()) {
+		dbgTrace.get().detail("NKeys", dedupedDomainIds.size());
+		for (EncryptCipherDomainId id : dedupedDomainIds) {
 			// log encryptDomainIds queried
 			dbgTrace.get().detail(getEncryptDbgTraceKey(ENCRYPT_DBG_TRACE_QUERY_PREFIX, id), "");
 		}

--- a/fdbserver/EncryptKeyProxy.actor.cpp
+++ b/fdbserver/EncryptKeyProxy.actor.cpp
@@ -24,9 +24,9 @@
 #include "fdbserver/KmsConnector.h"
 #include "fdbserver/KmsConnectorInterface.h"
 #include "fdbserver/Knobs.h"
-#include "fdbserver/RESTKmsConnector.actor.h"
+#include "fdbserver/RESTKmsConnector.h"
 #include "fdbserver/ServerDBInfo.actor.h"
-#include "fdbserver/SimKmsConnector.actor.h"
+#include "fdbserver/SimKmsConnector.h"
 #include "fdbserver/WorkerInterface.actor.h"
 #include "fdbserver/ServerDBInfo.h"
 #include "flow/Arena.h"
@@ -42,6 +42,7 @@
 #include "flow/network.h"
 
 #include <boost/mpl/not.hpp>
+#include <string>
 #include <utility>
 #include <memory>
 
@@ -162,10 +163,17 @@ ACTOR Future<Void> getCipherKeysByBaseCipherKeyIds(Reference<EncryptKeyProxyData
 	// for the rest, reachout to KMS to fetch the required details
 
 	std::vector<std::pair<EncryptCipherBaseKeyId, EncryptCipherDomainId>> lookupCipherIds;
-	state std::vector<EKPBaseCipherDetails> cachedCipherDetails;
 
+	state std::vector<EKPBaseCipherDetails> cachedCipherDetails;
 	state EKPGetBaseCipherKeysByIdsRequest keysByIds = req;
 	state EKPGetBaseCipherKeysByIdsReply keyIdsReply;
+	state Optional<TraceEvent> dbgTrace =
+	    keysByIds.debugId.present() ? TraceEvent("GetByKeyIds", ekpProxyData->myId) : Optional<TraceEvent>();
+
+	if (dbgTrace.present()) {
+		dbgTrace.get().setMaxEventLength(SERVER_KNOBS->ENCRYPT_PROXY_MAX_DBG_TRACE_LENGTH);
+		dbgTrace.get().detail("DbgId", keysByIds.debugId.get());
+	}
 
 	// Dedup the requested pair<baseCipherId, encryptDomainId>
 	// TODO: endpoint serialization of std::unordered_set isn't working at the moment
@@ -174,6 +182,11 @@ ACTOR Future<Void> getCipherKeysByBaseCipherKeyIds(Reference<EncryptKeyProxyData
 	    dedupedCipherIds;
 	for (const auto& item : req.baseCipherIds) {
 		dedupedCipherIds.emplace(item);
+
+		if (dbgTrace.present()) {
+			// Record {encryptDomainId, baseCipherId} queried
+			dbgTrace.get().detail(getEncryptDbgTraceKey(ENCRYPT_DBG_TRACE_QUERY_PREFIX, item.second, item.first), "");
+		}
 	}
 
 	for (const auto& item : dedupedCipherIds) {
@@ -182,6 +195,14 @@ ACTOR Future<Void> getCipherKeysByBaseCipherKeyIds(Reference<EncryptKeyProxyData
 			ASSERT(itr->second.isValid());
 			cachedCipherDetails.emplace_back(
 			    itr->second.domainId, itr->second.baseCipherId, itr->second.baseCipherKey, keyIdsReply.arena);
+
+			if (dbgTrace.present()) {
+				// {encryptId, baseCipherId} forms a unique tuple across encryption domains
+				dbgTrace.get().detail(getEncryptDbgTraceKey(ENCRYPT_DBG_TRACE_CACHED_PREFIX,
+				                                            itr->second.domainId,
+				                                            itr->second.baseCipherId),
+				                      "");
+			}
 		} else {
 			lookupCipherIds.emplace_back(std::make_pair(item.first, item.second));
 		}
@@ -192,7 +213,7 @@ ACTOR Future<Void> getCipherKeysByBaseCipherKeyIds(Reference<EncryptKeyProxyData
 
 	if (!lookupCipherIds.empty()) {
 		try {
-			KmsConnLookupEKsByKeyIdsReq keysByIdsReq(lookupCipherIds);
+			KmsConnLookupEKsByKeyIdsReq keysByIdsReq(lookupCipherIds, keysByIds.debugId);
 			KmsConnLookupEKsByKeyIdsRep keysByIdsRep = wait(kmsConnectorInf.ekLookupByIds.getReply(keysByIdsReq));
 
 			for (const auto& item : keysByIdsRep.cipherKeyDetails) {
@@ -206,13 +227,20 @@ ACTOR Future<Void> getCipherKeysByBaseCipherKeyIds(Reference<EncryptKeyProxyData
 			for (auto& item : keysByIdsRep.cipherKeyDetails) {
 				// DomainId isn't available here, the caller must know the encryption domainId
 				ekpProxyData->insertIntoBaseCipherIdCache(item.encryptDomainId, item.encryptKeyId, item.encryptKey);
+
+				if (dbgTrace.present()) {
+					// {encryptId, baseCipherId} forms a unique tuple across encryption domains
+					dbgTrace.get().detail(
+					    getEncryptDbgTraceKey(ENCRYPT_DBG_TRACE_INSERT_PREFIX, item.encryptDomainId, item.encryptKeyId),
+					    "");
+				}
 			}
 		} catch (Error& e) {
 			if (!canReplyWith(e)) {
-				TraceEvent("GetCipherKeysByIds", ekpProxyData->myId).error(e);
+				TraceEvent("GetCipherKeysByKeyIds", ekpProxyData->myId).error(e);
 				throw;
 			}
-			TraceEvent("GetCipherKeysByIds", ekpProxyData->myId).detail("ErrorCode", e.code());
+			TraceEvent("GetCipherKeysByKeyIds", ekpProxyData->myId).detail("ErrorCode", e.code());
 			ekpProxyData->sendErrorResponse(keysByIds.reply, e);
 			return Void();
 		}
@@ -237,12 +265,24 @@ ACTOR Future<Void> getLatestCipherKeys(Reference<EncryptKeyProxyData> ekpProxyDa
 	state EKPGetLatestBaseCipherKeysRequest latestKeysReq = req;
 	state EKPGetLatestBaseCipherKeysReply latestCipherReply;
 	state Arena& arena = latestCipherReply.arena;
+	state Optional<TraceEvent> dbgTrace =
+	    latestKeysReq.debugId.present() ? TraceEvent("GetByDomIds", ekpProxyData->myId) : Optional<TraceEvent>();
+
+	if (dbgTrace.present()) {
+		dbgTrace.get().setMaxEventLength(SERVER_KNOBS->ENCRYPT_PROXY_MAX_DBG_TRACE_LENGTH);
+		dbgTrace.get().detail("DbgId", latestKeysReq.debugId.get());
+	}
 
 	// Dedup the requested domainIds.
 	// TODO: endpoint serialization of std::unordered_set isn't working at the moment
 	std::unordered_set<EncryptCipherDomainId> dedupedDomainIds;
 	for (EncryptCipherDomainId id : req.encryptDomainIds) {
 		dedupedDomainIds.emplace(id);
+
+		if (dbgTrace.present()) {
+			// log encryptDomainIds queried
+			dbgTrace.get().detail(getEncryptDbgTraceKey(ENCRYPT_DBG_TRACE_QUERY_PREFIX, id), "");
+		}
 	}
 
 	// First, check if the requested information is already cached by the server.
@@ -253,6 +293,12 @@ ACTOR Future<Void> getLatestCipherKeys(Reference<EncryptKeyProxyData> ekpProxyDa
 		const auto itr = ekpProxyData->baseCipherDomainIdCache.find(id);
 		if (itr != ekpProxyData->baseCipherDomainIdCache.end() && itr->second.isValid()) {
 			cachedCipherDetails.emplace_back(id, itr->second.baseCipherId, itr->second.baseCipherKey, arena);
+
+			if (dbgTrace.present()) {
+				// {encryptDomainId, baseCipherId} forms a unique tuple across encryption domains
+				dbgTrace.get().detail(
+				    getEncryptDbgTraceKey(ENCRYPT_DBG_TRACE_CACHED_PREFIX, id, itr->second.baseCipherId), "");
+			}
 		} else {
 			lookupCipherDomains.emplace_back(id);
 		}
@@ -263,7 +309,7 @@ ACTOR Future<Void> getLatestCipherKeys(Reference<EncryptKeyProxyData> ekpProxyDa
 
 	if (!lookupCipherDomains.empty()) {
 		try {
-			KmsConnLookupEKsByDomainIdsReq keysByDomainIdReq(lookupCipherDomains);
+			KmsConnLookupEKsByDomainIdsReq keysByDomainIdReq(lookupCipherDomains, latestKeysReq.debugId);
 			KmsConnLookupEKsByDomainIdsRep keysByDomainIdRep =
 			    wait(kmsConnectorInf.ekLookupByDomainIds.getReply(keysByDomainIdReq));
 
@@ -273,6 +319,13 @@ ACTOR Future<Void> getLatestCipherKeys(Reference<EncryptKeyProxyData> ekpProxyDa
 
 				// Record the fetched cipher details to the local cache for the future references
 				ekpProxyData->insertIntoBaseDomainIdCache(item.encryptDomainId, item.encryptKeyId, item.encryptKey);
+
+				if (dbgTrace.present()) {
+					// {encryptDomainId, baseCipherId} forms a unique tuple across encryption domains
+					dbgTrace.get().detail(
+					    getEncryptDbgTraceKey(ENCRYPT_DBG_TRACE_INSERT_PREFIX, item.encryptDomainId, item.encryptKeyId),
+					    "");
+				}
 			}
 		} catch (Error& e) {
 			if (!canReplyWith(e)) {
@@ -298,13 +351,16 @@ ACTOR Future<Void> getLatestCipherKeys(Reference<EncryptKeyProxyData> ekpProxyDa
 
 ACTOR Future<Void> refreshEncryptionKeysCore(Reference<EncryptKeyProxyData> ekpProxyData,
                                              KmsConnectorInterface kmsConnectorInf) {
+	state UID debugId = deterministicRandom()->randomUniqueID();
 
-	ASSERT(g_network->isSimulated());
-
-	TraceEvent("RefreshEKs_Start", ekpProxyData->myId).detail("KmsConnInf", kmsConnectorInf.id());
+	state TraceEvent t("RefreshEKs_Start", ekpProxyData->myId);
+	t.setMaxEventLength(SERVER_KNOBS->ENCRYPT_PROXY_MAX_DBG_TRACE_LENGTH);
+	t.detail("KmsConnInf", kmsConnectorInf.id());
+	t.detail("DebugId", debugId);
 
 	try {
 		KmsConnLookupEKsByDomainIdsReq req;
+		req.debugId = debugId;
 		req.encryptDomainIds.reserve(ekpProxyData->baseCipherDomainIdCache.size());
 
 		for (auto& item : ekpProxyData->baseCipherDomainIdCache) {
@@ -313,16 +369,20 @@ ACTOR Future<Void> refreshEncryptionKeysCore(Reference<EncryptKeyProxyData> ekpP
 		KmsConnLookupEKsByDomainIdsRep rep = wait(kmsConnectorInf.ekLookupByDomainIds.getReply(req));
 		for (auto& item : rep.cipherKeyDetails) {
 			ekpProxyData->insertIntoBaseDomainIdCache(item.encryptDomainId, item.encryptKeyId, item.encryptKey);
+			// {encryptDomainId, baseCipherId} forms a unique tuple across encryption domains
+			t.detail(getEncryptDbgTraceKey(ENCRYPT_DBG_TRACE_INSERT_PREFIX, item.encryptDomainId, item.encryptKeyId),
+			         "");
 		}
 
 		ekpProxyData->baseCipherKeysRefreshed += rep.cipherKeyDetails.size();
-		TraceEvent("RefreshEKs_Done", ekpProxyData->myId).detail("KeyCount", rep.cipherKeyDetails.size());
+
+		t.detail("nKeys", rep.cipherKeyDetails.size());
 	} catch (Error& e) {
 		if (!canReplyWith(e)) {
-			TraceEvent("RefreshEncryptionKeys_Error").error(e);
+			TraceEvent("RefreshEKs_Error").error(e);
 			throw e;
 		}
-		TraceEvent("RefreshEncryptionKeys").detail("ErrorCode", e.code());
+		TraceEvent("RefreshEKs").detail("ErrorCode", e.code());
 		++ekpProxyData->numEncryptionKeyRefreshErrors;
 	}
 

--- a/fdbserver/EncryptKeyProxyInterface.h
+++ b/fdbserver/EncryptKeyProxyInterface.h
@@ -125,6 +125,7 @@ struct EKPGetBaseCipherKeysByIdsRequest {
 	constexpr static FileIdentifier file_identifier = 4930263;
 	UID requesterID;
 	std::vector<std::pair<uint64_t, int64_t>> baseCipherIds;
+	Optional<UID> debugId;
 	ReplyPromise<EKPGetBaseCipherKeysByIdsReply> reply;
 
 	EKPGetBaseCipherKeysByIdsRequest() : requesterID(deterministicRandom()->randomUniqueID()) {}
@@ -133,7 +134,7 @@ struct EKPGetBaseCipherKeysByIdsRequest {
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, requesterID, baseCipherIds, reply);
+		serializer(ar, requesterID, baseCipherIds, debugId, reply);
 	}
 };
 
@@ -142,6 +143,7 @@ struct EKPGetLatestBaseCipherKeysReply {
 	Arena arena;
 	std::vector<EKPBaseCipherDetails> baseCipherDetails;
 	int numHits;
+	Optional<UID> debuId;
 	Optional<Error> error;
 
 	EKPGetLatestBaseCipherKeysReply() : numHits(0) {}
@@ -156,17 +158,17 @@ struct EKPGetLatestBaseCipherKeysReply {
 
 struct EKPGetLatestBaseCipherKeysRequest {
 	constexpr static FileIdentifier file_identifier = 1910123;
-	UID requesterID;
 	std::vector<uint64_t> encryptDomainIds;
+	Optional<UID> debugId;
 	ReplyPromise<EKPGetLatestBaseCipherKeysReply> reply;
 
-	EKPGetLatestBaseCipherKeysRequest() : requesterID(deterministicRandom()->randomUniqueID()) {}
-	explicit EKPGetLatestBaseCipherKeysRequest(UID uid, const std::vector<uint64_t>& ids)
-	  : requesterID(uid), encryptDomainIds(ids) {}
+	EKPGetLatestBaseCipherKeysRequest() {}
+	explicit EKPGetLatestBaseCipherKeysRequest(const std::vector<uint64_t>& ids, Optional<UID> dbgId)
+	  : encryptDomainIds(ids), debugId(dbgId) {}
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, requesterID, encryptDomainIds, reply);
+		serializer(ar, encryptDomainIds, debugId, reply);
 	}
 };
 

--- a/fdbserver/EncryptKeyProxyInterface.h
+++ b/fdbserver/EncryptKeyProxyInterface.h
@@ -143,7 +143,6 @@ struct EKPGetLatestBaseCipherKeysReply {
 	Arena arena;
 	std::vector<EKPBaseCipherDetails> baseCipherDetails;
 	int numHits;
-	Optional<UID> debuId;
 	Optional<Error> error;
 
 	EKPGetLatestBaseCipherKeysReply() : numHits(0) {}
@@ -163,8 +162,7 @@ struct EKPGetLatestBaseCipherKeysRequest {
 	ReplyPromise<EKPGetLatestBaseCipherKeysReply> reply;
 
 	EKPGetLatestBaseCipherKeysRequest() {}
-	explicit EKPGetLatestBaseCipherKeysRequest(const std::vector<uint64_t>& ids, Optional<UID> dbgId)
-	  : encryptDomainIds(ids), debugId(dbgId) {}
+	explicit EKPGetLatestBaseCipherKeysRequest(const std::vector<uint64_t>& ids) : encryptDomainIds(ids) {}
 
 	template <class Ar>
 	void serialize(Ar& ar) {

--- a/fdbserver/KmsConnectorInterface.h
+++ b/fdbserver/KmsConnectorInterface.h
@@ -101,16 +101,18 @@ struct KmsConnLookupEKsByKeyIdsRep {
 struct KmsConnLookupEKsByKeyIdsReq {
 	constexpr static FileIdentifier file_identifier = 6913396;
 	std::vector<std::pair<EncryptCipherBaseKeyId, EncryptCipherDomainId>> encryptKeyIds;
+	Optional<UID> debugId;
 	ReplyPromise<KmsConnLookupEKsByKeyIdsRep> reply;
 
 	KmsConnLookupEKsByKeyIdsReq() {}
 	explicit KmsConnLookupEKsByKeyIdsReq(
-	    const std::vector<std::pair<EncryptCipherBaseKeyId, EncryptCipherDomainId>>& keyIds)
-	  : encryptKeyIds(keyIds) {}
+	    const std::vector<std::pair<EncryptCipherBaseKeyId, EncryptCipherDomainId>>& keyIds,
+	    Optional<UID> dbgId)
+	  : encryptKeyIds(keyIds), debugId(dbgId) {}
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, encryptKeyIds, reply);
+		serializer(ar, encryptKeyIds, debugId, reply);
 	}
 };
 
@@ -130,14 +132,16 @@ struct KmsConnLookupEKsByDomainIdsRep {
 struct KmsConnLookupEKsByDomainIdsReq {
 	constexpr static FileIdentifier file_identifier = 9918682;
 	std::vector<EncryptCipherDomainId> encryptDomainIds;
+	Optional<UID> debugId;
 	ReplyPromise<KmsConnLookupEKsByDomainIdsRep> reply;
 
 	KmsConnLookupEKsByDomainIdsReq() {}
-	explicit KmsConnLookupEKsByDomainIdsReq(const std::vector<EncryptCipherDomainId>& ids) : encryptDomainIds(ids) {}
+	explicit KmsConnLookupEKsByDomainIdsReq(const std::vector<EncryptCipherDomainId>& ids, Optional<UID> dbgId)
+	  : encryptDomainIds(ids), debugId(dbgId) {}
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, encryptDomainIds, reply);
+		serializer(ar, encryptDomainIds, debugId, reply);
 	}
 };
 

--- a/fdbserver/RESTKmsConnector.h
+++ b/fdbserver/RESTKmsConnector.h
@@ -1,5 +1,5 @@
 /*
- * SimKmsConnector.actor.h
+ * RESTKmsConnector.actor.h
  *
  * This source file is part of the FoundationDB open source project
  *
@@ -18,22 +18,15 @@
  * limitations under the License.
  */
 
+#ifndef REST_KMS_CONNECTOR_H
+#define REST_KMS_CONNECTOR_H
 #pragma once
 
-#if defined(NO_INTELLISENSE) && !defined(FDBSERVER_SIMKMSCONNECTOR_ACTOR_G_H)
-#define FDBSERVER_SIMKMSCONNECTOR_ACTOR_G_H
-#include "fdbserver/SimKmsConnector.actor.g.h"
-#elif !defined(FDBSERVER_SIMKMSCONNECTOR_ACTOR_H)
-#define FDBSERVER_SIMKMSCONNECTOR_ACTOR_H
-
 #include "fdbserver/KmsConnector.h"
-#include "flow/BlobCipher.h"
 
-#include "flow/actorcompiler.h" // This must be the last #include.
-
-class SimKmsConnector : public KmsConnector {
+class RESTKmsConnector : public KmsConnector {
 public:
-	SimKmsConnector() = default;
+	RESTKmsConnector() = default;
 	Future<Void> connectorCore(KmsConnectorInterface interf);
 };
 

--- a/fdbserver/SimKmsConnector.h
+++ b/fdbserver/SimKmsConnector.h
@@ -1,0 +1,34 @@
+/*
+ * SimKmsConnector.actor.h
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2022 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SIM_KMS_CONNECTOR_H
+#define SIM_KMS_CONNECTOR_H
+#pragma once
+
+#include "fdbserver/KmsConnector.h"
+#include "flow/BlobCipher.h"
+
+class SimKmsConnector : public KmsConnector {
+public:
+	SimKmsConnector() = default;
+	Future<Void> connectorCore(KmsConnectorInterface interf);
+};
+
+#endif

--- a/fdbserver/workloads/EncryptKeyProxyTest.actor.cpp
+++ b/fdbserver/workloads/EncryptKeyProxyTest.actor.cpp
@@ -72,7 +72,11 @@ struct EncryptKeyProxyTestWorkload : TestWorkload {
 
 		state int nAttempts = 0;
 		loop {
-			EKPGetLatestBaseCipherKeysRequest req(deterministicRandom()->randomUniqueID(), self->domainIds);
+			EKPGetLatestBaseCipherKeysRequest req;
+			req.encryptDomainIds = self->domainIds;
+			if (deterministicRandom()->randomInt(0, 100) < 50) {
+				req.debugId = deterministicRandom()->randomUniqueID();
+			}
 			ErrorOr<EKPGetLatestBaseCipherKeysReply> rep = wait(self->ekpInf.getLatestBaseCipherKeys.tryGetReply(req));
 			if (rep.present()) {
 
@@ -82,7 +86,7 @@ struct EncryptKeyProxyTestWorkload : TestWorkload {
 				for (const uint64_t id : self->domainIds) {
 					bool found = false;
 					for (const auto& item : rep.get().baseCipherDetails) {
-						if (item.baseCipherId == id) {
+						if (item.encryptDomainId == id) {
 							found = true;
 							break;
 						}
@@ -131,7 +135,11 @@ struct EncryptKeyProxyTestWorkload : TestWorkload {
 			// assertions. However, in simulation runs, RPCs can be force failed to inject retries, hence, code leverage
 			// tryGetReply to ensure at-most once delivery of message, further, assertions are relaxed to account of
 			// cache warm-up due to retries.
-			EKPGetLatestBaseCipherKeysRequest req(deterministicRandom()->randomUniqueID(), self->domainIds);
+			EKPGetLatestBaseCipherKeysRequest req;
+			req.encryptDomainIds = self->domainIds;
+			if (deterministicRandom()->randomInt(0, 100) < 50) {
+				req.debugId = deterministicRandom()->randomUniqueID();
+			}
 			ErrorOr<EKPGetLatestBaseCipherKeysReply> rep = wait(self->ekpInf.getLatestBaseCipherKeys.tryGetReply(req));
 			if (rep.present()) {
 				ASSERT(!rep.get().error.present());
@@ -140,7 +148,7 @@ struct EncryptKeyProxyTestWorkload : TestWorkload {
 				for (const uint64_t id : self->domainIds) {
 					bool found = false;
 					for (const auto& item : rep.get().baseCipherDetails) {
-						if (item.baseCipherId == id) {
+						if (item.encryptDomainId == id) {
 							found = true;
 							break;
 						}
@@ -176,7 +184,11 @@ struct EncryptKeyProxyTestWorkload : TestWorkload {
 			self->domainIds.emplace_back(self->minDomainId + i);
 		}
 
-		EKPGetLatestBaseCipherKeysRequest req(deterministicRandom()->randomUniqueID(), self->domainIds);
+		EKPGetLatestBaseCipherKeysRequest req;
+		req.encryptDomainIds = self->domainIds;
+		if (deterministicRandom()->randomInt(0, 100) < 50) {
+			req.debugId = deterministicRandom()->randomUniqueID();
+		}
 		EKPGetLatestBaseCipherKeysReply rep = wait(self->ekpInf.getLatestBaseCipherKeys.getReply(req));
 
 		ASSERT(!rep.error.present());
@@ -184,7 +196,7 @@ struct EncryptKeyProxyTestWorkload : TestWorkload {
 		for (const uint64_t id : self->domainIds) {
 			bool found = false;
 			for (const auto& item : rep.baseCipherDetails) {
-				if (item.baseCipherId == id) {
+				if (item.encryptDomainId == id) {
 					found = true;
 					break;
 				}
@@ -205,6 +217,9 @@ struct EncryptKeyProxyTestWorkload : TestWorkload {
 			int nIds = deterministicRandom()->randomInt(1, self->cipherIds.size());
 
 			EKPGetBaseCipherKeysByIdsRequest req;
+			if (deterministicRandom()->randomInt(0, 100) < 50) {
+				req.debugId = deterministicRandom()->randomUniqueID();
+			}
 			for (int i = idx; i < nIds && i < self->cipherIds.size(); i++) {
 				req.baseCipherIds.emplace_back(std::make_pair(self->cipherIds[i], 1));
 			}

--- a/fdbserver/workloads/EncryptKeyProxyTest.actor.cpp
+++ b/fdbserver/workloads/EncryptKeyProxyTest.actor.cpp
@@ -212,7 +212,7 @@ struct EncryptKeyProxyTestWorkload : TestWorkload {
 		}
 
 		state int numIterations = deterministicRandom()->randomInt(512, 786);
-		for (; numIterations > 0; numIterations--) {
+		for (; numIterations > 0;) {
 			int idx = deterministicRandom()->randomInt(1, self->cipherIds.size());
 			int nIds = deterministicRandom()->randomInt(1, self->cipherIds.size());
 
@@ -223,6 +223,13 @@ struct EncryptKeyProxyTestWorkload : TestWorkload {
 			for (int i = idx; i < nIds && i < self->cipherIds.size(); i++) {
 				req.baseCipherIds.emplace_back(std::make_pair(self->cipherIds[i], 1));
 			}
+			if (req.baseCipherIds.empty()) {
+				// No keys to query; continue
+				continue;
+			} else {
+				numIterations--;
+			}
+
 			expectedHits = req.baseCipherIds.size();
 			EKPGetBaseCipherKeysByIdsReply rep = wait(self->ekpInf.getBaseCipherKeysByIds.getReply(req));
 

--- a/fdbserver/workloads/EncryptionOps.actor.cpp
+++ b/fdbserver/workloads/EncryptionOps.actor.cpp
@@ -226,7 +226,7 @@ struct EncryptionOpsWorkload : TestWorkload {
 		Reference<BlobCipherKey> cipherKey = cipherKeyCache->getCipherKey(domainId, baseCipherId, salt);
 
 		if (simCacheMiss) {
-			TraceEvent("SimKeyCacheMiss").detail("EncyrptDomainId", domainId).detail("BaseCipherId", baseCipherId);
+			TraceEvent("SimKeyCacheMiss").detail("EncryptDomainId", domainId).detail("BaseCipherId", baseCipherId);
 			// simulate KeyCache miss that may happen during decryption; insert a CipherKey with known 'salt'
 			cipherKeyCache->insertCipherKey(domainId,
 			                                baseCipherId,

--- a/flow/BlobCipher.cpp
+++ b/flow/BlobCipher.cpp
@@ -1175,7 +1175,7 @@ TEST_CASE("flow/BlobCipher") {
 		TraceEvent("MultiAuthMode_Done").log();
 	}
 
-	// Validate dropping encyrptDomainId cached keys
+	// Validate dropping encryptDomainId cached keys
 	const EncryptCipherDomainId candidate = deterministicRandom()->randomInt(minDomainId, maxDomainId);
 	cipherKeyCache->resetEncryptDomainId(candidate);
 	std::vector<Reference<BlobCipherKey>> cachedKeys = cipherKeyCache->getAllCiphers(candidate);

--- a/flow/CMakeLists.txt
+++ b/flow/CMakeLists.txt
@@ -19,6 +19,8 @@ set(FLOW_SRCS
   Error.cpp
   Error.h
   EventTypes.actor.h
+  EncryptUtils.h
+  EncryptUtils.cpp
   FastAlloc.cpp
   FastAlloc.h
   FastRef.h

--- a/flow/EncryptUtils.cpp
+++ b/flow/EncryptUtils.cpp
@@ -1,5 +1,5 @@
 /*
- * RESTKmsConnector.actor.h
+ * EncryptUtils.cpp
  *
  * This source file is part of the FoundationDB open source project
  *
@@ -18,20 +18,21 @@
  * limitations under the License.
  */
 
-#pragma once
+#include "flow/EncryptUtils.h"
+#include "flow/Trace.h"
 
-#if defined(NO_INTELLISENSE) && !defined(FDBSERVER_RESTKMSCONNECTOR_ACTOR_G_H)
-#define FDBSERVER_RESTKMSCONNECTOR_ACTOR_G_H
-#include "fdbserver/RESTKmsConnector.actor.g.h"
-#elif !defined(FDBSERVER_RESTKMSCONNECTOR_ACTOR_H)
-#define FDBSERVER_RESTKMSCONNECTOR_ACTOR_H
+#include <boost/format.hpp>
 
-#include "fdbserver/KmsConnector.h"
-
-class RESTKmsConnector : public KmsConnector {
-public:
-	RESTKmsConnector() = default;
-	Future<Void> connectorCore(KmsConnectorInterface interf);
-};
-
-#endif
+std::string getEncryptDbgTraceKey(std::string_view prefix,
+                                  EncryptCipherDomainId domainId,
+                                  Optional<EncryptCipherBaseKeyId> baseCipherId) {
+	// Construct the TraceEvent field key ensuring its uniqueness and compliance to TraceEvent field validator and log
+	// parsing tools
+	if (baseCipherId.present()) {
+		boost::format fmter("%s.%lld.%llu");
+		return boost::str(boost::format(fmter % prefix % domainId % baseCipherId.get()));
+	} else {
+		boost::format fmter("%s.%lld");
+		return boost::str(boost::format(fmter % prefix % domainId));
+	}
+}

--- a/flow/EncryptUtils.h
+++ b/flow/EncryptUtils.h
@@ -22,8 +22,12 @@
 #define ENCRYPT_UTILS_H
 #pragma once
 
+#include "flow/Arena.h"
+
 #include <cstdint>
 #include <limits>
+#include <string>
+#include <string_view>
 
 #define ENCRYPT_INVALID_DOMAIN_ID 0
 #define ENCRYPT_INVALID_CIPHER_KEY_ID 0
@@ -50,7 +54,7 @@ static_assert(EncryptCipherMode::ENCRYPT_CIPHER_MODE_LAST <= std::numeric_limits
 // EncryptionHeader authentication modes
 // 1. NONE - No 'authentication token' generation needed for EncryptionHeader i.e. no protection against header OR
 // cipherText 'tampering' and/or bit rot/flip corruptions.
-// 2. Single/Multi - Encyrption header would generate one or more 'authentication tokens' to protect the header against
+// 2. Single/Multi - Encryption header would generate one or more 'authentication tokens' to protect the header against
 // 'tempering' and/or bit rot/flip corruptions. Refer to BlobCipher.h for detailed usage recommendations.
 // 3. LAST - Invalid mode, used for static asserts.
 
@@ -64,4 +68,13 @@ typedef enum {
 static_assert(EncryptAuthTokenMode::ENCRYPT_HEADER_AUTH_TOKEN_LAST <= std::numeric_limits<uint8_t>::max(),
               "EncryptHeaderAuthToken value overflow");
 
+constexpr std::string_view ENCRYPT_DBG_TRACE_CACHED_PREFIX = "Chd";
+constexpr std::string_view ENCRYPT_DBG_TRACE_QUERY_PREFIX = "Qry";
+constexpr std::string_view ENCRYPT_DBG_TRACE_INSERT_PREFIX = "Ins";
+constexpr std::string_view ENCRYPT_DBG_TRACE_RESULT_PREFIX = "Res";
+
+// Utility interface to construct TraceEvent key for debugging
+std::string getEncryptDbgTraceKey(std::string_view prefix,
+                                  EncryptCipherDomainId domainId,
+                                  Optional<EncryptCipherBaseKeyId> baseCipherId = Optional<EncryptCipherBaseKeyId>());
 #endif

--- a/flow/IRandom.h
+++ b/flow/IRandom.h
@@ -90,6 +90,7 @@ public:
 	uint64_t second() const { return part[1]; }
 
 	static UID fromString(std::string const&);
+	static UID fromStringThrowsOnFailure(std::string const&);
 
 	template <class Ar>
 	void serialize_unversioned(

--- a/flow/flow.cpp
+++ b/flow/flow.cpp
@@ -130,6 +130,19 @@ UID UID::fromString(std::string const& s) {
 	return UID(a, b);
 }
 
+UID UID::fromStringThrowsOnFailure(std::string const& s) {
+	if (s.size() != 32) {
+		// invalid string size
+		throw operation_failed();
+	}
+	uint64_t a = 0, b = 0;
+	int r = sscanf(s.c_str(), "%16" SCNx64 "%16" SCNx64, &a, &b);
+	if (r != 2) {
+		throw operation_failed();
+	}
+	return UID(a, b);
+}
+
 std::string UID::shortString() const {
 	return format("%016llx", part[0]);
 }


### PR DESCRIPTION
Description

Proposed changes include:
1. Update EncryptKeyProxy API to embded Optional<UID> for debugging
   request execution.
2. Encryption participant FDB processes can set 'debugId' enabling
   tracing requests within FDB cluster processes and beyond.
3. The 'debugId' if available is embedded as part of 'request_json_payload'
   by RESTKmsConnector, enabling tracing request between FDB <--> KMS.
4. Fix EncryptKeyProxyTest which got broken due to recent changes.

Testing

Updated following test:
1. EncryptKeyProxy simulation test.
2. RESTKmsConnector simulation test.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
