### PR TITLE
Do not block empty peeks while a disk queue is recovering in version vector.

### DIFF
--- a/fdbserver/TLogServer.actor.cpp
+++ b/fdbserver/TLogServer.actor.cpp
@@ -1784,9 +1784,11 @@ Future<Void> tLogPeekMessages(PromiseType replyPromise,
 
 	state Version poppedVer = poppedVersion(logData, reqTag);
 
+	auto tagData = logData->getTagData(reqTag);
+	bool tagRecovered = tagData && !tagData->unpoppedRecovered;
 	if (SERVER_KNOBS->ENABLE_VERSION_VECTOR && poppedVer <= reqBegin &&
 	    reqBegin > logData->persistentDataDurableVersion && !reqOnlySpilled && reqTag.locality >= 0 &&
-	    !reqReturnIfBlocked) {
+	    !reqReturnIfBlocked && tagRecovered) {
 		state double startTime = now();
 		// TODO (version vector) check if this should be included in "status details" json
 		// TODO (version vector) all tags may be too many, instead,  standard deviation?


### PR DESCRIPTION
tLogs cannot recover until versions up to the RV (for all tags) are peeked from the old log server, written to the SS, and then popped. While in that state, `tagData->unpoppedRecovered` is `true`. And even if no data is read from the old log server, the min popped version for all tags must be >= RV for the tLog to recover. Blocking empty message peeks shouldn't happen during this as it will elongate recovery time.

100K runs version vector enabled
`20220510-015744-henrylambright-9cac1bc064234fef`

