### PR TITLE
When an incompatible connection is closed, clear the state that prevents us from sending messages on it

### DIFF
--- a/fdbrpc/FlowTransport.actor.cpp
+++ b/fdbrpc/FlowTransport.actor.cpp
@@ -816,6 +816,9 @@ ACTOR Future<Void> connectionKeeper(Reference<Peer> self,
 				    .errorUnsuppressed(e)
 				    .suppressFor(1.0)
 				    .detail("PeerAddr", self->destination);
+
+				// Since the connection has closed, we need to check the protocol version the next time we connect
+				self->incompatibleProtocolVersionNewer = false;
 			}
 
 			if (self->destination.isPublic() &&


### PR DESCRIPTION
When downgrading a cluster, it was possible for a `Peer` object on the destination version to be held open through the downgrade. Before the downgrade, the `Peer` would have marked the connection as incompatible and would stop sending messages to it. After the downgrade, that state would persist and it would continue refusing to send messages even though the remote endpoint is compatible.

With this change, the state marking the connection as ineligible for messages is cleared when an incompatible connection is closed.

Passed 10K correctness. Also passes downgrade testing when applied to 7.0 and 7.1.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
