### PR TITLE
Version correction fixes

### DIFF
--- a/bindings/python/tests/fdbcli_tests.py
+++ b/bindings/python/tests/fdbcli_tests.py
@@ -260,43 +260,31 @@ def suspend(logger):
     assert get_value_from_status_json(False, 'client', 'database_status', 'available')
 
 
-def extract_version_epoch(cli_output):
-    return int(cli_output.split("\n")[-1].split(" ")[-1])
-
-
 @enable_logging()
-def targetversion(logger):
-    version1 = run_fdbcli_command('targetversion getepoch')
+def versionepoch(logger):
+    version1 = run_fdbcli_command('versionepoch')
     assert version1 == "Version epoch is unset"
-    version2 = int(run_fdbcli_command('getversion'))
-    logger.debug("read version: {}".format(version2))
-    assert version2 >= 0
-    # set the version epoch to the default value
-    logger.debug("setting version epoch to default")
-    run_fdbcli_command('targetversion add 0')
-    # get the version epoch
-    versionepoch1 = extract_version_epoch(run_fdbcli_command('targetversion getepoch'))
-    logger.debug("version epoch: {}".format(versionepoch1))
-    # make sure the version increased
-    version3 = int(run_fdbcli_command('getversion'))
-    logger.debug("read version: {}".format(version3))
-    assert version3 >= version2
-    # slightly increase the version epoch
-    versionepoch2 = extract_version_epoch(run_fdbcli_command("targetversion setepoch {}".format(versionepoch1 + 1000000)))
-    logger.debug("version epoch: {}".format(versionepoch2))
-    assert versionepoch2 == versionepoch1 + 1000000
-    # slightly decrease the version epoch
-    versionepoch3 = extract_version_epoch(run_fdbcli_command("targetversion add {}".format(-1000000)))
-    logger.debug("version epoch: {}".format(versionepoch3))
-    assert versionepoch3 == versionepoch2 - 1000000 == versionepoch1
-    # the versions should still be increasing
-    version4 = int(run_fdbcli_command('getversion'))
-    logger.debug("read version: {}".format(version4))
-    assert version4 >= version3
-    # clear the version epoch and make sure it is now unset
-    run_fdbcli_command("targetversion clearepoch")
-    version5 = run_fdbcli_command('targetversion getepoch')
-    assert version5 == "Version epoch is unset"
+    version2 = run_fdbcli_command('versionepoch get')
+    assert version2 == "Version epoch is unset"
+    version3 = run_fdbcli_command('versionepoch commit')
+    assert version3 == "Must set the version epoch before committing it (see `versionepoch enable`)"
+    version4 = run_fdbcli_command('versionepoch enable')
+    assert version4 == "Version epoch enabled. Run `versionepoch commit` to irreversibly jump to the target version"
+    version5 = run_fdbcli_command('versionepoch get')
+    assert version5 == "Current version epoch is 0"
+    version6 = run_fdbcli_command('versionepoch set 10')
+    assert version6 == "Version epoch enabled. Run `versionepoch commit` to irreversibly jump to the target version"
+    version7 = run_fdbcli_command('versionepoch get')
+    assert version7 == "Current version epoch is 10"
+    run_fdbcli_command('versionepoch disable')
+    version8 = run_fdbcli_command('versionepoch get')
+    assert version8 == "Version epoch is unset"
+    version9 = run_fdbcli_command('versionepoch enable')
+    assert version9 == "Version epoch enabled. Run `versionepoch commit` to irreversibly jump to the target version"
+    version10 = run_fdbcli_command('versionepoch get')
+    assert version10 == "Current version epoch is 0"
+    version11 = run_fdbcli_command('versionepoch commit')
+    assert version11.startswith("Current read version is ")
 
 
 def get_value_from_status_json(retry, *args):
@@ -724,9 +712,7 @@ if __name__ == '__main__':
         throttle()
         triggerddteaminfolog()
         tenants()
-        # TODO: similar to advanceversion, this seems to cause some issues, so disable for now
-        # This must go last, otherwise the version advancement can mess with the other tests
-        # targetversion()
+        versionepoch()
     else:
         assert args.process_number > 1, "Process number should be positive"
         coordinators()

--- a/fdbcli/VersionEpochCommand.actor.cpp
+++ b/fdbcli/VersionEpochCommand.actor.cpp
@@ -158,7 +158,7 @@ ACTOR Future<bool> versionEpochCommandActor(Reference<IDatabase> db, Database cx
 
 CommandFactory versionEpochFactory(
     "versionepoch",
-    CommandHelp("versionepoch [<enable|commit|set|disable> [EPOCH]]",
+    CommandHelp("versionepoch [<enable|commit|get|set|disable> [EPOCH]]",
                 "Read or write the version epoch",
                 "If no arguments are specified, reports the offset between the expected version "
                 "and the actual version. Otherwise, enables, disables, or commits the version epoch. "

--- a/fdbclient/SpecialKeySpace.actor.cpp
+++ b/fdbclient/SpecialKeySpace.actor.cpp
@@ -1871,6 +1871,12 @@ Future<RangeResult> AdvanceVersionImpl::getRange(ReadYourWritesTransaction* ryw,
 }
 
 ACTOR static Future<Optional<std::string>> advanceVersionCommitActor(ReadYourWritesTransaction* ryw, Version v) {
+	Optional<Standalone<StringRef>> versionEpochValue = wait(ryw->getTransaction().get(versionEpochKey));
+	if (versionEpochValue.present()) {
+		return ManagementAPIError::toJsonString(
+		    false, "advanceversion", "Illegal to modify the version while the version epoch is enabled");
+	}
+
 	// Max version we can set for minRequiredCommitVersionKey,
 	// making sure the cluster can still be alive for 1000 years after the recovery
 	static const Version maxAllowedVerion =

--- a/fdbserver/masterserver.actor.cpp
+++ b/fdbserver/masterserver.actor.cpp
@@ -119,6 +119,28 @@ struct MasterData : NonCopyable, ReferenceCounted<MasterData> {
 	~MasterData() = default;
 };
 
+Version figureVersion(Version current,
+                      double now,
+                      Version reference,
+                      int64_t toAdd,
+                      double maxVersionRateModifier,
+                      int64_t maxVersionRateOffset) {
+	// Versions should roughly follow wall-clock time, based on the
+	// system clock of the current machine and an FDB-specific epoch.
+	// Calculate the expected version and determine whether we need to
+	// hand out versions faster or slower to stay in sync with the
+	// clock.
+	Version expected = now * SERVER_KNOBS->VERSIONS_PER_SECOND - reference;
+
+	// Attempt to jump directly to the expected version. But make
+	// sure that versions are still being handed out at a rate
+	// around VERSIONS_PER_SECOND. This rate is scaled depending on
+	// how far off the calculated version is from the expected
+	// version.
+	int64_t maxOffset = std::min(static_cast<int64_t>(toAdd * maxVersionRateModifier), maxVersionRateOffset);
+	return std::clamp(expected, current + toAdd - maxOffset, current + toAdd + maxOffset);
+}
+
 ACTOR Future<Void> getVersion(Reference<MasterData> self, GetCommitVersionRequest req) {
 	state Span span("M:getVersion"_loc, req.spanContext);
 	state std::map<UID, CommitProxyVersionReplies>::iterator proxyItr =
@@ -158,11 +180,6 @@ ACTOR Future<Void> getVersion(Reference<MasterData> self, GetCommitVersionReques
 				t1 = self->lastVersionTime;
 			}
 
-			// Versions should roughly follow wall-clock time, based on the
-			// system clock of the current machine and an FDB-specific epoch.
-			// Calculate the expected version and determine whether we need to
-			// hand out versions faster or slower to stay in sync with the
-			// clock.
 			Version toAdd =
 			    std::max<Version>(1,
 			                      std::min<Version>(SERVER_KNOBS->MAX_READ_TRANSACTION_LIFE_VERSIONS,
@@ -170,18 +187,12 @@ ACTOR Future<Void> getVersion(Reference<MasterData> self, GetCommitVersionReques
 
 			rep.prevVersion = self->version;
 			if (self->referenceVersion.present()) {
-				Version expected =
-				    g_network->timer() * SERVER_KNOBS->VERSIONS_PER_SECOND - self->referenceVersion.get();
-
-				// Attempt to jump directly to the expected version. But make
-				// sure that versions are still being handed out at a rate
-				// around VERSIONS_PER_SECOND. This rate is scaled depending on
-				// how far off the calculated version is from the expected
-				// version.
-				int64_t maxOffset = std::min(static_cast<int64_t>(toAdd * SERVER_KNOBS->MAX_VERSION_RATE_MODIFIER),
-				                             SERVER_KNOBS->MAX_VERSION_RATE_OFFSET);
-				self->version =
-				    std::clamp(expected, self->version + toAdd - maxOffset, self->version + toAdd + maxOffset);
+				self->version = figureVersion(self->version,
+				                              g_network->timer(),
+				                              self->referenceVersion.get(),
+				                              toAdd,
+				                              SERVER_KNOBS->MAX_VERSION_RATE_MODIFIER,
+				                              SERVER_KNOBS->MAX_VERSION_RATE_OFFSET);
 				ASSERT_GT(self->version, rep.prevVersion);
 			} else {
 				self->version = self->version + toAdd;
@@ -432,4 +443,45 @@ ACTOR Future<Void> masterServer(MasterInterface mi,
 		}
 		throw err;
 	}
+}
+
+TEST_CASE("/fdbserver/MasterServer/FigureVersion/Simple") {
+	ASSERT_EQ(
+	    figureVersion(0, 1.0, 0, 1e6, SERVER_KNOBS->MAX_VERSION_RATE_MODIFIER, SERVER_KNOBS->MAX_VERSION_RATE_OFFSET),
+	    1e6);
+	ASSERT_EQ(figureVersion(1e6, 1.5, 0, 100, 0.1, 1e6), 1000110);
+	ASSERT_EQ(figureVersion(1e6, 1.5, 0, 550000, 0.1, 1e6), 1500000);
+	return Void();
+}
+
+TEST_CASE("/fdbserver/MasterServer/FigureVersion/Small") {
+	// Should always advance by at least 1 version.
+	ASSERT_EQ(figureVersion(1e6, 2.0, 0, 1, 0.0001, 1e6), 1000001);
+	ASSERT_EQ(figureVersion(1e6, 0.0, 0, 1, 0.1, 1e6), 1000001);
+	return Void();
+}
+
+TEST_CASE("/fdbserver/MasterServer/FigureVersion/MaxOffset") {
+	ASSERT_EQ(figureVersion(1e6, 10.0, 0, 5e6, 0.1, 1e6), 6500000);
+	ASSERT_EQ(figureVersion(1e6, 20.0, 0, 15e6, 0.1, 1e6), 17e6);
+	return Void();
+}
+
+TEST_CASE("/fdbserver/MasterServer/FigureVersion/PositiveReferenceVersion") {
+	ASSERT_EQ(figureVersion(1e6, 3.0, 1e6, 1e6, 0.1, 1e6), 2e6);
+	ASSERT_EQ(figureVersion(1e6, 3.0, 1e6, 100, 0.1, 1e6), 1000110);
+	return Void();
+}
+
+TEST_CASE("/fdbserver/MasterServer/FigureVersion/NegativeReferenceVersion") {
+	ASSERT_EQ(figureVersion(0, 2.0, -1e6, 3e6, 0.1, 1e6), 3e6);
+	ASSERT_EQ(figureVersion(0, 2.0, -1e6, 5e5, 0.1, 1e6), 550000);
+	return Void();
+}
+
+TEST_CASE("/fdbserver/MasterServer/FigureVersion/Overflow") {
+	// The upper range used in std::clamp should overflow.
+	ASSERT_EQ(figureVersion(std::numeric_limits<Version>::max() - static_cast<Version>(1e6), 1.0, 0, 1e6, 0.1, 1e6),
+	          std::numeric_limits<Version>::max() - static_cast<Version>(1e6 * 0.1));
+	return Void();
 }


### PR DESCRIPTION
See the list of commits for details about each change. Responding to feedback from a version correction review session.

Remaining work:
* ~~Move buggification of version epoch out of `masterserver.actor.cpp`. This value must be set in the txnStateStore in order for QuietDatabase to be able to read it.~~ Will follow up on this when the backup/restore work is in progress, it isn't necessary until then.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
