### PR TITLE
Release 7.1: Cherry-pick version vector disable/enable restart tests

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -271,6 +271,9 @@ if(WITH_PYTHON)
   add_fdb_test(
     TEST_FILES restarting/from_7.1.0/ConfigureStorageMigrationTestRestart-1.toml
                restarting/from_7.1.0/ConfigureStorageMigrationTestRestart-2.toml)
+  add_fdb_test(
+    TEST_FILES restarting/from_7.1.0/VersionVectorDisableRestart-1.toml
+               restarting/from_7.1.0/VersionVectorDisableRestart-2.toml)
 
 
   add_fdb_test(TEST_FILES slow/ApiCorrectness.toml)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -274,6 +274,9 @@ if(WITH_PYTHON)
   add_fdb_test(
     TEST_FILES restarting/from_7.1.0/VersionVectorDisableRestart-1.toml
                restarting/from_7.1.0/VersionVectorDisableRestart-2.toml)
+  add_fdb_test(
+    TEST_FILES restarting/from_7.1.0/VersionVectorEnableRestart-1.toml
+               restarting/from_7.1.0/VersionVectorEnableRestart-2.toml)
 
 
   add_fdb_test(TEST_FILES slow/ApiCorrectness.toml)

--- a/tests/restarting/from_7.1.0/VersionVectorDisableRestart-1.toml
+++ b/tests/restarting/from_7.1.0/VersionVectorDisableRestart-1.toml
@@ -8,10 +8,27 @@ clearAfterTest=false
 
     [[test.workload]]
     testName='Cycle'
-    transactionsPerSecond=500.0
-    nodeCount=2500
-    testDuration=10.0
+    transactionsPerSecond=2500.0
+    nodeCount=1000
+    testDuration=30.0
     expectedRate=0
+    keyPrefix = 'cycle'
+
+    [[test.workload]]
+    testName = 'Cycle'
+    nodeCount = 1000
+    transactionsPerSecond = 2500.0
+    testDuration = 30.0
+    expectedRate = 0
+    keyPrefix = '!'
+
+    [[test.workload]]
+    testName = 'Cycle'
+    nodeCount = 1000
+    transactionsPerSecond = 2500.0
+    testDuration = 30.0
+    expectedRate = 0
+    keyPrefix = 'ZZZ'
 
     [[test.workload]]
     testName='RandomClogging'
@@ -39,4 +56,4 @@ clearAfterTest=false
     [[test.workload]]
     testName='SaveAndKill'
     restartInfoLocation='simfdb/restartInfo.ini'
-    testDuration=10.0
+    testDuration=60.0

--- a/tests/restarting/from_7.1.0/VersionVectorDisableRestart-1.toml
+++ b/tests/restarting/from_7.1.0/VersionVectorDisableRestart-1.toml
@@ -1,0 +1,42 @@
+[[knobs]]
+enable_version_vector = true
+enable_version_vector_tlog_unicast = true
+
+[[test]]
+testTitle='VersionVectorDowngrade'
+clearAfterTest=false
+
+    [[test.workload]]
+    testName='Cycle'
+    transactionsPerSecond=500.0
+    nodeCount=2500
+    testDuration=10.0
+    expectedRate=0
+
+    [[test.workload]]
+    testName='RandomClogging'
+    testDuration=10.0
+
+    [[test.workload]]
+    testName='Rollback'
+    meanDelay=10.0
+    testDuration=10.0
+
+    [[test.workload]]
+    testName='Attrition'
+    machinesToKill=10
+    machinesToLeave=3
+    reboot=true
+    testDuration=10.0
+
+    [[test.workload]]
+    testName='Attrition'
+    machinesToKill=10
+    machinesToLeave=3
+    reboot=true
+    testDuration=10.0
+
+    [[test.workload]]
+    testName='SaveAndKill'
+    restartInfoLocation='simfdb/restartInfo.ini'
+    testDuration=10.0

--- a/tests/restarting/from_7.1.0/VersionVectorDisableRestart-1.toml
+++ b/tests/restarting/from_7.1.0/VersionVectorDisableRestart-1.toml
@@ -1,6 +1,7 @@
 [[knobs]]
 enable_version_vector = true
 enable_version_vector_tlog_unicast = true
+proxy_use_resolver_private_mutations = true
 
 [[test]]
 testTitle='VersionVectorDowngrade'

--- a/tests/restarting/from_7.1.0/VersionVectorDisableRestart-2.toml
+++ b/tests/restarting/from_7.1.0/VersionVectorDisableRestart-2.toml
@@ -9,9 +9,26 @@ runSetup=false
     [[test.workload]]
     testName='Cycle'
     transactionsPerSecond=2500.0
-    nodeCount=2500
-    testDuration=10.0
+    nodeCount=1000
+    testDuration=30.0
     expectedRate=0
+    keyPrefix = 'cycle'
+
+    [[test.workload]]
+    testName = 'Cycle'
+    nodeCount = 1000
+    transactionsPerSecond = 2500.0
+    testDuration = 30.0
+    expectedRate = 0
+    keyPrefix = '!'
+
+    [[test.workload]]
+    testName = 'Cycle'
+    nodeCount = 1000
+    transactionsPerSecond = 2500.0
+    testDuration = 30.0
+    expectedRate = 0
+    keyPrefix = 'ZZZ'
 
     [[test.workload]]
     testName='RandomClogging'
@@ -34,4 +51,4 @@ runSetup=false
     machinesToKill=10
     machinesToLeave=3
     reboot=true
-    testDuration=10.0
+    testDuration=60.0

--- a/tests/restarting/from_7.1.0/VersionVectorDisableRestart-2.toml
+++ b/tests/restarting/from_7.1.0/VersionVectorDisableRestart-2.toml
@@ -1,0 +1,37 @@
+[[knobs]]
+enable_version_vector = false
+enable_version_vector_tlog_unicast = false
+
+[[test]]
+testTitle='VersionVectorDowngrade'
+runSetup=false
+
+    [[test.workload]]
+    testName='Cycle'
+    transactionsPerSecond=2500.0
+    nodeCount=2500
+    testDuration=10.0
+    expectedRate=0
+
+    [[test.workload]]
+    testName='RandomClogging'
+    testDuration=10.0
+
+    [[test.workload]]
+    testName='Rollback'
+    meanDelay=10.0
+    testDuration=10.0
+
+    [[test.workload]]
+    testName='Attrition'
+    machinesToKill=10
+    machinesToLeave=3
+    reboot=true
+    testDuration=10.0
+
+    [[test.workload]]
+    testName='Attrition'
+    machinesToKill=10
+    machinesToLeave=3
+    reboot=true
+    testDuration=10.0

--- a/tests/restarting/from_7.1.0/VersionVectorEnableRestart-1.toml
+++ b/tests/restarting/from_7.1.0/VersionVectorEnableRestart-1.toml
@@ -1,0 +1,59 @@
+[[knobs]]
+enable_version_vector = false
+enable_version_vector_tlog_unicast = false
+
+[[test]]
+testTitle='VersionVectorUpgrade'
+clearAfterTest=false
+
+    [[test.workload]]
+    testName='Cycle'
+    transactionsPerSecond=2500.0
+    nodeCount=1000
+    testDuration=30.0
+    expectedRate=0
+    keyPrefix = 'cycle'
+
+    [[test.workload]]
+    testName = 'Cycle'
+    nodeCount = 1000
+    transactionsPerSecond = 2500.0
+    testDuration = 30.0
+    expectedRate = 0
+    keyPrefix = '!'
+
+    [[test.workload]]
+    testName = 'Cycle'
+    nodeCount = 1000
+    transactionsPerSecond = 2500.0
+    testDuration = 30.0
+    expectedRate = 0
+    keyPrefix = 'ZZZ'
+
+    [[test.workload]]
+    testName='RandomClogging'
+    testDuration=10.0
+
+    [[test.workload]]
+    testName='Rollback'
+    meanDelay=10.0
+    testDuration=10.0
+
+    [[test.workload]]
+    testName='Attrition'
+    machinesToKill=10
+    machinesToLeave=3
+    reboot=true
+    testDuration=10.0
+
+    [[test.workload]]
+    testName='Attrition'
+    machinesToKill=10
+    machinesToLeave=3
+    reboot=true
+    testDuration=10.0
+
+    [[test.workload]]
+    testName='SaveAndKill'
+    restartInfoLocation='simfdb/restartInfo.ini'
+    testDuration=60.0

--- a/tests/restarting/from_7.1.0/VersionVectorEnableRestart-2.toml
+++ b/tests/restarting/from_7.1.0/VersionVectorEnableRestart-2.toml
@@ -1,0 +1,54 @@
+[[knobs]]
+enable_version_vector = true
+enable_version_vector_tlog_unicast = true
+
+[[test]]
+testTitle='VersionVectorUpgrade'
+runSetup=false
+
+    [[test.workload]]
+    testName='Cycle'
+    transactionsPerSecond=2500.0
+    nodeCount=1000
+    testDuration=30.0
+    expectedRate=0
+    keyPrefix = 'cycle'
+
+    [[test.workload]]
+    testName = 'Cycle'
+    nodeCount = 1000
+    transactionsPerSecond = 2500.0
+    testDuration = 30.0
+    expectedRate = 0
+    keyPrefix = '!'
+
+    [[test.workload]]
+    testName = 'Cycle'
+    nodeCount = 1000
+    transactionsPerSecond = 2500.0
+    testDuration = 30.0
+    expectedRate = 0
+    keyPrefix = 'ZZZ'
+
+    [[test.workload]]
+    testName='RandomClogging'
+    testDuration=10.0
+
+    [[test.workload]]
+    testName='Rollback'
+    meanDelay=10.0
+    testDuration=10.0
+
+    [[test.workload]]
+    testName='Attrition'
+    machinesToKill=10
+    machinesToLeave=3
+    reboot=true
+    testDuration=10.0
+
+    [[test.workload]]
+    testName='Attrition'
+    machinesToKill=10
+    machinesToLeave=3
+    reboot=true
+    testDuration=60.0

--- a/tests/restarting/from_7.1.0/VersionVectorEnableRestart-2.toml
+++ b/tests/restarting/from_7.1.0/VersionVectorEnableRestart-2.toml
@@ -1,6 +1,7 @@
 [[knobs]]
 enable_version_vector = true
 enable_version_vector_tlog_unicast = true
+proxy_use_resolver_private_mutations = true
 
 [[test]]
 testTitle='VersionVectorUpgrade'


### PR DESCRIPTION
Cherry-pick the following commits from the version vector branch (we somehow missed these commits when we merged that branch into "main"):

https://github.com/apple/foundationdb/commit/097c4de7270fa8089a85a308d146bbd9ddb51c7a
https://github.com/apple/foundationdb/commit/74e90d95ebce566b3ab2be51e19861c4165422e2
https://github.com/apple/foundationdb/commit/31aafc56d17428bec1a4bef84f0e6ed389f210e8
https://github.com/apple/foundationdb/commit/44eb2c916710612ccfbb7c86353c9cd3eac925ac

Testing:
Ran the version vector restart tests locally. No failures.
Simulation tests: 20220510-212616-sre-2a2b65ec51946640 (no failures).

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
