### PR TITLE
Remove HostnameStatus and resolve trigger (release-7.1).

### DIFF
--- a/fdbrpc/genericactors.actor.h
+++ b/fdbrpc/genericactors.actor.h
@@ -101,7 +101,6 @@ Future<ErrorOr<REPLY_TYPE(Req)>> tryGetReplyFromHostname(Req request, Hostname h
 		resetReply(request);
 		if (reply.getError().code() == error_code_request_maybe_delivered) {
 			// Connection failure.
-			hostname.resetToUnresolved();
 			INetworkConnections::net()->removeCachedDNS(hostname.host, hostname.service);
 		}
 	}
@@ -126,7 +125,6 @@ Future<ErrorOr<REPLY_TYPE(Req)>> tryGetReplyFromHostname(Req request,
 		resetReply(request);
 		if (reply.getError().code() == error_code_request_maybe_delivered) {
 			// Connection failure.
-			hostname.resetToUnresolved();
 			INetworkConnections::net()->removeCachedDNS(hostname.host, hostname.service);
 		}
 	}
@@ -149,7 +147,6 @@ Future<REPLY_TYPE(Req)> retryGetReplyFromHostname(Req request, Hostname hostname
 				// Connection failure.
 				wait(delay(reconnetInterval));
 				reconnetInterval = std::min(2 * reconnetInterval, FLOW_KNOBS->HOSTNAME_RECONNECT_MAX_INTERVAL);
-				hostname.resetToUnresolved();
 				INetworkConnections::net()->removeCachedDNS(hostname.host, hostname.service);
 			} else {
 				throw reply.getError();
@@ -179,7 +176,6 @@ Future<REPLY_TYPE(Req)> retryGetReplyFromHostname(Req request,
 				// Connection failure.
 				wait(delay(reconnetInterval));
 				reconnetInterval = std::min(2 * reconnetInterval, FLOW_KNOBS->HOSTNAME_RECONNECT_MAX_INTERVAL);
-				hostname.resetToUnresolved();
 				INetworkConnections::net()->removeCachedDNS(hostname.host, hostname.service);
 			} else {
 				throw reply.getError();

--- a/flow/Hostname.actor.cpp
+++ b/flow/Hostname.actor.cpp
@@ -39,47 +39,19 @@ Hostname Hostname::parse(const std::string& s) {
 	return Hostname(f.substr(0, colonPos), f.substr(colonPos + 1), isTLS);
 }
 
-void Hostname::resetToUnresolved() {
-	if (status == Hostname::RESOLVED) {
-		status = UNRESOLVED;
-		resolvedAddress = Optional<NetworkAddress>();
-	}
-}
-
 ACTOR Future<Optional<NetworkAddress>> resolveImpl(Hostname* self) {
-	loop {
-		if (self->status == Hostname::UNRESOLVED) {
-			self->status = Hostname::RESOLVING;
-			try {
-				std::vector<NetworkAddress> addresses =
-				    wait(INetworkConnections::net()->resolveTCPEndpointWithDNSCache(self->host, self->service));
-				NetworkAddress address = addresses[deterministicRandom()->randomInt(0, addresses.size())];
-				address.flags = 0; // Reset the parsed address to public
-				address.fromHostname = NetworkAddressFromHostname::True;
-				if (self->isTLS) {
-					address.flags |= NetworkAddress::FLAG_TLS;
-				}
-				self->resolvedAddress = address;
-				self->status = Hostname::RESOLVED;
-				self->resolveFinish.trigger();
-				return self->resolvedAddress.get();
-			} catch (...) {
-				self->status = Hostname::UNRESOLVED;
-				self->resolveFinish.trigger();
-				self->resolvedAddress = Optional<NetworkAddress>();
-				return Optional<NetworkAddress>();
-			}
-		} else if (self->status == Hostname::RESOLVING) {
-			wait(self->resolveFinish.onTrigger());
-			if (self->status == Hostname::RESOLVED) {
-				return self->resolvedAddress.get();
-			}
-			// Otherwise, this means other threads failed on resolve, so here we go back to the loop and try to resolve
-			// again.
-		} else {
-			// status is RESOLVED, nothing to do.
-			return self->resolvedAddress.get();
+	try {
+		std::vector<NetworkAddress> addresses =
+		    wait(INetworkConnections::net()->resolveTCPEndpointWithDNSCache(self->host, self->service));
+		NetworkAddress address = addresses[deterministicRandom()->randomInt(0, addresses.size())];
+		address.flags = 0; // Reset the parsed address to public
+		address.fromHostname = NetworkAddressFromHostname::True;
+		if (self->isTLS) {
+			address.flags |= NetworkAddress::FLAG_TLS;
 		}
+		return address;
+	} catch (...) {
+		return Optional<NetworkAddress>();
 	}
 }
 
@@ -109,24 +81,19 @@ Future<NetworkAddress> Hostname::resolveWithRetry() {
 }
 
 Optional<NetworkAddress> Hostname::resolveBlocking() {
-	if (status != RESOLVED) {
-		try {
-			std::vector<NetworkAddress> addresses =
-			    INetworkConnections::net()->resolveTCPEndpointBlockingWithDNSCache(host, service);
-			NetworkAddress address = addresses[deterministicRandom()->randomInt(0, addresses.size())];
-			address.flags = 0; // Reset the parsed address to public
-			address.fromHostname = NetworkAddressFromHostname::True;
-			if (isTLS) {
-				address.flags |= NetworkAddress::FLAG_TLS;
-			}
-			resolvedAddress = address;
-			status = RESOLVED;
-		} catch (...) {
-			status = UNRESOLVED;
-			resolvedAddress = Optional<NetworkAddress>();
+	try {
+		std::vector<NetworkAddress> addresses =
+		    INetworkConnections::net()->resolveTCPEndpointBlockingWithDNSCache(host, service);
+		NetworkAddress address = addresses[deterministicRandom()->randomInt(0, addresses.size())];
+		address.flags = 0; // Reset the parsed address to public
+		address.fromHostname = NetworkAddressFromHostname::True;
+		if (isTLS) {
+			address.flags |= NetworkAddress::FLAG_TLS;
 		}
+		return address;
+	} catch (...) {
+		return Optional<NetworkAddress>();
 	}
-	return resolvedAddress;
 }
 
 TEST_CASE("/flow/Hostname/hostname") {
@@ -179,49 +146,36 @@ TEST_CASE("/flow/Hostname/hostname") {
 	ASSERT(!Hostname::isHostname(hn12s));
 	ASSERT(!Hostname::isHostname(hn13s));
 
-	ASSERT(hn1.status == Hostname::UNRESOLVED && !hn1.resolvedAddress.present());
-	ASSERT(hn2.status == Hostname::UNRESOLVED && !hn2.resolvedAddress.present());
-	ASSERT(hn3.status == Hostname::UNRESOLVED && !hn3.resolvedAddress.present());
-	ASSERT(hn4.status == Hostname::UNRESOLVED && !hn4.resolvedAddress.present());
+	state Optional<NetworkAddress> optionalAddress = wait(hn2.resolve());
+	ASSERT(!optionalAddress.present());
 
-	state Optional<NetworkAddress> emptyAddress = wait(hn2.resolve());
-	ASSERT(hn2.status == Hostname::UNRESOLVED && !hn2.resolvedAddress.present() && !emptyAddress.present());
+	optionalAddress = hn2.resolveBlocking();
+	ASSERT(!optionalAddress.present());
 
+	state NetworkAddress address;
 	try {
-		NetworkAddress _ = wait(timeoutError(hn2.resolveWithRetry(), 1));
+		wait(timeoutError(store(address, hn2.resolveWithRetry()), 1));
 	} catch (Error& e) {
 		ASSERT(e.code() == error_code_timed_out);
 	}
-	ASSERT(hn2.status == Hostname::UNRESOLVED && !hn2.resolvedAddress.present());
-
-	emptyAddress = hn2.resolveBlocking();
-	ASSERT(hn2.status == Hostname::UNRESOLVED && !hn2.resolvedAddress.present() && !emptyAddress.present());
+	ASSERT(address == NetworkAddress());
 
 	state NetworkAddress addressSource = NetworkAddress::parse("127.0.0.0:1234");
 	INetworkConnections::net()->addMockTCPEndpoint("host-name", "1234", { addressSource });
 
 	// Test resolve.
-	state Optional<NetworkAddress> optionalAddress = wait(hn2.resolve());
-	ASSERT(hn2.status == Hostname::RESOLVED);
-	ASSERT(hn2.resolvedAddress.get() == addressSource && optionalAddress.get() == addressSource);
+	wait(store(optionalAddress, hn2.resolve()));
+	ASSERT(optionalAddress.present() && optionalAddress.get() == addressSource);
+	optionalAddress = Optional<NetworkAddress>();
+
+	// Test resolveBlocking.
+	optionalAddress = hn2.resolveBlocking();
+	ASSERT(optionalAddress.present() && optionalAddress.get() == addressSource);
 	optionalAddress = Optional<NetworkAddress>();
 
 	// Test resolveWithRetry.
-	hn2.resetToUnresolved();
-	ASSERT(hn2.status == Hostname::UNRESOLVED && !hn2.resolvedAddress.present());
-
-	state NetworkAddress address = wait(hn2.resolveWithRetry());
-	ASSERT(hn2.status == Hostname::RESOLVED);
-	ASSERT(hn2.resolvedAddress.get() == addressSource && address == addressSource);
-
-	// Test resolveBlocking.
-	hn2.resetToUnresolved();
-	ASSERT(hn2.status == Hostname::UNRESOLVED && !hn2.resolvedAddress.present());
-
-	optionalAddress = hn2.resolveBlocking();
-	ASSERT(hn2.status == Hostname::RESOLVED);
-	ASSERT(hn2.resolvedAddress.get() == addressSource && optionalAddress.get() == addressSource);
-	optionalAddress = Optional<NetworkAddress>();
+	wait(store(address, hn2.resolveWithRetry()));
+	ASSERT(address == addressSource);
 
 	return Void();
 }

--- a/flow/Hostname.h
+++ b/flow/Hostname.h
@@ -33,16 +33,6 @@ struct Hostname {
 	Hostname(const std::string& host, const std::string& service, bool isTLS)
 	  : host(host), service(service), isTLS(isTLS) {}
 	Hostname() : host(""), service(""), isTLS(false) {}
-	Hostname(const Hostname& rhs) { operator=(rhs); }
-	Hostname& operator=(const Hostname& rhs) {
-		// Copy everything except AsyncTrigger resolveFinish.
-		host = rhs.host;
-		service = rhs.service;
-		isTLS = rhs.isTLS;
-		resolvedAddress = rhs.resolvedAddress;
-		status = rhs.status;
-		return *this;
-	}
 
 	bool operator==(const Hostname& r) const { return host == r.host && service == r.service && isTLS == r.isTLS; }
 	bool operator!=(const Hostname& r) const { return !(*this == r); }
@@ -72,20 +62,15 @@ struct Hostname {
 
 	std::string toString() const { return host + ":" + service + (isTLS ? ":tls" : ""); }
 
-	Optional<NetworkAddress> resolvedAddress;
-	enum HostnameStatus { UNRESOLVED, RESOLVING, RESOLVED };
 	// The resolve functions below use DNS cache.
 	Future<Optional<NetworkAddress>> resolve();
 	Future<NetworkAddress> resolveWithRetry();
 	Optional<NetworkAddress> resolveBlocking(); // This one should only be used when resolving asynchronously is
 	                                            // impossible. For all other cases, resolve() should be preferred.
-	void resetToUnresolved();
-	HostnameStatus status = UNRESOLVED;
-	AsyncTrigger resolveFinish;
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, host, service, isTLS, resolvedAddress, status);
+		serializer(ar, host, service, isTLS);
 	}
 };
 


### PR DESCRIPTION
They are no longer needed since we have coordinators DNS cache; and they are introducing complex crashes.

PR on main: #7140.
20220512-022453-renxuan-55abd010ef41ebd3           compressed=True data_size=31473630 duration=5110174 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=1:04:24 sanity=False started=100072 stopped=20220512-032917 submitted=20220512-022453 timeout=5400 username=renxuan

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
