### PR TITLE
Fix database shared state update on upgrades (fixes upgrades from 7.1 to 7.2)

### DIFF
--- a/bindings/c/CMakeLists.txt
+++ b/bindings/c/CMakeLists.txt
@@ -334,6 +334,14 @@ endif()
             --process-number 3
           )
 
+    add_test(NAME fdb_c_upgrade_multi_threaded_710api
+        COMMAND ${CMAKE_SOURCE_DIR}/tests/TestRunner/upgrade_test.py
+            --build-dir ${CMAKE_BINARY_DIR}
+            --test-file ${CMAKE_SOURCE_DIR}/bindings/c/test/apitester/tests/upgrade/MixedApiWorkloadMultiThr.toml
+            --upgrade-path "7.1.3" "7.2.0" "7.1.3"
+            --process-number 3
+          )
+
     add_test(NAME fdb_c_cluster_wiggle
           COMMAND ${CMAKE_SOURCE_DIR}/tests/TestRunner/upgrade_test.py
               --build-dir ${CMAKE_BINARY_DIR}

--- a/fdbclient/MultiVersionTransaction.h
+++ b/fdbclient/MultiVersionTransaction.h
@@ -861,8 +861,10 @@ public:
 
 	bool callbackOnMainThread;
 	bool localClientDisabled;
-	ThreadFuture<Void> updateClusterSharedStateMap(std::string clusterFilePath, Reference<IDatabase> db);
-	void clearClusterSharedStateMapEntry(std::string clusterFilePath);
+	ThreadFuture<Void> updateClusterSharedStateMap(std::string clusterFilePath,
+	                                               ProtocolVersion dbProtocolVersion,
+	                                               Reference<IDatabase> db);
+	void clearClusterSharedStateMapEntry(std::string clusterFilePath, ProtocolVersion dbProtocolVersion);
 
 	static bool apiVersionAtLeast(int minVersion);
 
@@ -888,7 +890,11 @@ private:
 	std::map<std::string, std::vector<Reference<ClientInfo>>> externalClients;
 	// Map of clusterFilePath -> DatabaseSharedState pointer Future
 	// Upon cluster version upgrade, clear the map entry for that cluster
-	std::map<std::string, ThreadFuture<DatabaseSharedState*>> clusterSharedStateMap;
+	struct SharedStateInfo {
+		ThreadFuture<DatabaseSharedState*> sharedStateFuture;
+		ProtocolVersion protocolVersion;
+	};
+	std::map<std::string, SharedStateInfo> clusterSharedStateMap;
 
 	bool networkStartSetup;
 	volatile bool networkSetup;


### PR DESCRIPTION
Upgrades from 7.1 to 7.2 were failing in scenarios using shared database state, i.e. whenever there are multiple Database objects on the same cluster. On an upgrade, the database object clears the shared database state from a global map. In case of multiple database instances, it can happen that  at first one of the database instances clear the old map entry and create a new one, then another database instance gets upgraded and clears the new entry from the map. This caused inconsistency in reference counting of the new map entry, and possibly access to stale memory.

The fix keeps track of the protocol version of the shared database state stored in the global map. A database instance can clear the shared state from the map if the entry exists and it matches its protocol version before the upgrade. As a result the first upgraded database instance clear the entry, and all the other instances skip that step. 

This change fixes upgrades from 7.1.3 to 7.2.0 and back with API version 710 (i.e. state sharing enabled), thus a corresponding regression test is added.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
