### PR TITLE
Log a backtrace before throwing serialization_failed [release-7.1]

### DIFF
--- a/fdbrpc/FlowTransport.actor.cpp
+++ b/fdbrpc/FlowTransport.actor.cpp
@@ -399,6 +399,7 @@ struct ConnectPacket {
 		serializer(ar, connectPacketLength);
 		if (connectPacketLength > sizeof(ConnectPacket) - sizeof(connectPacketLength)) {
 			ASSERT(!g_network->isSimulated());
+			TraceEvent("SerializationFailed").backtrace();
 			throw serialization_failed();
 		}
 

--- a/fdbrpc/FlowTransport.actor.cpp
+++ b/fdbrpc/FlowTransport.actor.cpp
@@ -399,7 +399,7 @@ struct ConnectPacket {
 		serializer(ar, connectPacketLength);
 		if (connectPacketLength > sizeof(ConnectPacket) - sizeof(connectPacketLength)) {
 			ASSERT(!g_network->isSimulated());
-			TraceEvent("SerializationFailed").backtrace();
+			TraceEvent("SerializationFailed").detail("PacketLength", connectPacketLength).backtrace();
 			throw serialization_failed();
 		}
 

--- a/flow/serialize.cpp
+++ b/flow/serialize.cpp
@@ -25,6 +25,7 @@
 _AssumeVersion::_AssumeVersion(ProtocolVersion version) : v(version) {
 	if (!version.isValid()) {
 		ASSERT(!g_network->isSimulated());
+		TraceEvent("SerializationFailed").backtrace();
 		throw serialization_failed();
 	}
 }
@@ -34,6 +35,7 @@ const void* BinaryReader::readBytes(int bytes) {
 	const char* e = b + bytes;
 	if (e > end) {
 		ASSERT(!g_network->isSimulated());
+		TraceEvent("SerializationFailed").backtrace();
 		throw serialization_failed();
 	}
 	begin = e;

--- a/flow/serialize.cpp
+++ b/flow/serialize.cpp
@@ -35,7 +35,7 @@ const void* BinaryReader::readBytes(int bytes) {
 	const char* e = b + bytes;
 	if (e > end) {
 		ASSERT(!g_network->isSimulated());
-		TraceEvent("SerializationFailed").backtrace();
+		TraceEvent("SerializationFailed").detail("Bytes", bytes).detail("Diff", e - end).backtrace();
 		throw serialization_failed();
 	}
 	begin = e;


### PR DESCRIPTION
Cherrypick #7146

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
