### PR TITLE
Restoring checks after each step in upgrade test

### DIFF
--- a/bindings/c/CMakeLists.txt
+++ b/bindings/c/CMakeLists.txt
@@ -338,7 +338,7 @@ endif()
         COMMAND ${CMAKE_SOURCE_DIR}/tests/TestRunner/upgrade_test.py
             --build-dir ${CMAKE_BINARY_DIR}
             --test-file ${CMAKE_SOURCE_DIR}/bindings/c/test/apitester/tests/upgrade/MixedApiWorkloadMultiThr.toml
-            --upgrade-path "7.1.3" "7.2.0" "7.1.3"
+            --upgrade-path "7.1.3" "7.2.0"
             --process-number 3
           )
 

--- a/tests/TestRunner/upgrade_test.py
+++ b/tests/TestRunner/upgrade_test.py
@@ -468,8 +468,8 @@ class UpgradeTest:
                 else:
                     assert entry in self.used_versions, "Unexpected entry in the upgrade path: {}".format(entry)
                     self.upgrade_to(entry)
-            self.health_check()
-            self.progress_check()
+                self.health_check()
+                self.progress_check()
             os.write(self.ctrl_pipe, b"STOP\n")
         finally:
             os.close(self.ctrl_pipe)


### PR DESCRIPTION
My previous PR erroneously moved cluster health & progress checks out of the loop in the upgrade test:
https://github.com/apple/foundationdb/pull/7085

This PR is a fix, that restores the checks after each upgrade step.

The downgrade test to 7.1 has to be disabled, because the downgrade fix for 7.1 is not released yet. 

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
