### PR TITLE
Enable MATCHED and UNMATCHED mode for index prefetch

### DIFF
--- a/bindings/c/foundationdb/fdb_c.h
+++ b/bindings/c/foundationdb/fdb_c.h
@@ -160,6 +160,7 @@ typedef struct mappedkeyvalue {
 	 * take the shortcut. */
 	FDBGetRangeReqAndResult getRange;
 	unsigned char buffer[32];
+	fdb_bool_t boundaryAndExist;
 } FDBMappedKeyValue;
 
 #pragma pack(push, 4)

--- a/bindings/c/test/unit/unit_tests.cpp
+++ b/bindings/c/test/unit/unit_tests.cpp
@@ -181,8 +181,8 @@ struct GetMappedRangeResult {
 	                       std::string, // value
 	                       std::string, // begin
 	                       std::string, // end
-	                       std::vector<std::pair<std::string, std::string>> // range results
-	                       >>
+	                       std::vector<std::pair<std::string, std::string>>, // range results
+	                       fdb_bool_t>>
 	    mkvs;
 	// True if values remain in the key range requested.
 	bool more;
@@ -306,6 +306,7 @@ GetMappedRangeResult get_mapped_range(fdb::Transaction& tr,
 		auto value = extractString(mkv.value);
 		auto begin = extractString(mkv.getRange.begin.key);
 		auto end = extractString(mkv.getRange.end.key);
+		bool boundaryAndExist = mkv.boundaryAndExist;
 		//		std::cout << "key:" << key << " value:" << value << " begin:" << begin << " end:" << end << std::endl;
 
 		std::vector<std::pair<std::string, std::string>> range_results;
@@ -316,7 +317,7 @@ GetMappedRangeResult get_mapped_range(fdb::Transaction& tr,
 			range_results.emplace_back(k, v);
 			// std::cout << "[" << i << "]" << k << " -> " << v << std::endl;
 		}
-		result.mkvs.emplace_back(key, value, begin, end, range_results);
+		result.mkvs.emplace_back(key, value, begin, end, range_results, boundaryAndExist);
 	}
 	return result;
 }
@@ -1015,8 +1016,10 @@ TEST_CASE("fdb_transaction_get_mapped_range") {
 		CHECK(!result.more);
 
 		int id = beginId;
+		bool boundary;
 		for (int i = 0; i < expectSize; i++, id++) {
-			const auto& [key, value, begin, end, range_results] = result.mkvs[i];
+			boundary = i == 0 || i == expectSize - 1;
+			const auto& [key, value, begin, end, range_results, boundaryAndExist] = result.mkvs[i];
 			if (matchIndex == MATCH_INDEX_ALL || i == 0 || i == expectSize - 1) {
 				CHECK(indexEntryKey(id).compare(key) == 0);
 			} else if (matchIndex == MATCH_INDEX_MATCHED_ONLY) {
@@ -1032,6 +1035,10 @@ TEST_CASE("fdb_transaction_get_mapped_range") {
 			} else {
 				CHECK(EMPTY.compare(key) == 0);
 			}
+
+			// TODO: create tests to generate workloads with partial secondary results present
+			CHECK(boundaryAndExist == boundary);
+
 			CHECK(EMPTY.compare(value) == 0);
 			CHECK(range_results.size() == SPLIT_SIZE);
 			for (int split = 0; split < SPLIT_SIZE; split++) {

--- a/bindings/java/src/main/com/apple/foundationdb/FDBTransaction.java
+++ b/bindings/java/src/main/com/apple/foundationdb/FDBTransaction.java
@@ -35,6 +35,8 @@ class FDBTransaction extends NativeObjectWrapper implements Transaction, OptionC
 
 	static public final int MATCH_INDEX_ALL = 0;
 	static public final int MATCH_INDEX_NONE = 1;
+	static public final int MATCH_INDEX_MATCHED_ONLY = 2;
+	static public final int MATCH_INDEX_UNMATCHED_ONLY = 3;
 
 	private final Database database;
 	private final Executor executor;

--- a/fdbclient/FDBTypes.h
+++ b/fdbclient/FDBTypes.h
@@ -150,6 +150,8 @@ static const Tag cacheTag{ tagLocalitySpecial, 2 };
 
 const int MATCH_INDEX_ALL = 0;
 const int MATCH_INDEX_NONE = 1;
+const int MATCH_INDEX_MATCHED_ONLY = 2;
+const int MATCH_INDEX_UNMATCHED_ONLY = 3;
 
 enum { txsTagOld = -1, invalidTagOld = -100 };
 
@@ -762,9 +764,18 @@ struct MappedKeyValueRef : KeyValueRef {
 
 	MappedReqAndResultRef reqAndResult;
 
+	// boundary KVs are always returned so that caller can use it as a continuation,
+	// for non-boundary KV, it is always false.
+	// for boundary KV, it is true only when the secondary query succeeds(return non-empty).
+	// Note: only MATCH_INDEX_MATCHED_ONLY and MATCH_INDEX_UNMATCHED_ONLY modes can make use of it,
+	// to decide whether the boudnary is a match/unmatch.
+	// In the case of MATCH_INDEX_ALL and MATCH_INDEX_NONE, caller should not care if boundary has a match or not.
+	bool boundaryAndExist;
+
 	MappedKeyValueRef() = default;
 	MappedKeyValueRef(Arena& a, const MappedKeyValueRef& copyFrom) : KeyValueRef(a, copyFrom) {
 		const auto& reqAndResultCopyFrom = copyFrom.reqAndResult;
+		boundaryAndExist = copyFrom.boundaryAndExist;
 		if (std::holds_alternative<GetValueReqAndResultRef>(reqAndResultCopyFrom)) {
 			auto getValue = std::get<GetValueReqAndResultRef>(reqAndResultCopyFrom);
 			reqAndResult = GetValueReqAndResultRef(a, getValue);
@@ -778,7 +789,7 @@ struct MappedKeyValueRef : KeyValueRef {
 
 	bool operator==(const MappedKeyValueRef& rhs) const {
 		return static_cast<const KeyValueRef&>(*this) == static_cast<const KeyValueRef&>(rhs) &&
-		       reqAndResult == rhs.reqAndResult;
+		       reqAndResult == rhs.reqAndResult && boundaryAndExist == rhs.boundaryAndExist;
 	}
 	bool operator!=(const MappedKeyValueRef& rhs) const { return !(rhs == *this); }
 
@@ -788,7 +799,7 @@ struct MappedKeyValueRef : KeyValueRef {
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, ((KeyValueRef&)*this), reqAndResult);
+		serializer(ar, ((KeyValueRef&)*this), reqAndResult, boundaryAndExist);
 	}
 };
 

--- a/fdbclient/MultiVersionTransaction.h
+++ b/fdbclient/MultiVersionTransaction.h
@@ -80,6 +80,7 @@ struct FdbCApi : public ThreadSafeReferenceCounted<FdbCApi> {
 		 * and take the shortcut. */
 		FDBGetRangeReqAndResult getRange;
 		unsigned char buffer[32];
+		bool boundaryAndExist;
 	} FDBMappedKeyValue;
 
 #pragma pack(push, 4)

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -4082,7 +4082,7 @@ int64_t inline getRangeResultFamilyBytes(MappedRangeResultRef result) {
 	int64_t bytes = 0;
 	for (const MappedKeyValueRef& mappedKeyValue : result) {
 		bytes += mappedKeyValue.key.size() + mappedKeyValue.value.size();
-
+		bytes += sizeof(mappedKeyValue.boundaryAndExist);
 		auto& reqAndResult = mappedKeyValue.reqAndResult;
 		if (std::holds_alternative<GetValueReqAndResultRef>(reqAndResult)) {
 			auto getValue = std::get<GetValueReqAndResultRef>(reqAndResult);

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -3749,10 +3749,11 @@ ACTOR Future<GetMappedKeyValuesReply> mapKeyValues(StorageServer* data,
 	state int sz = input.data.size();
 	state int i = 0;
 	for (; i < sz; i++) {
-		KeyValueRef* it = &input.data[i];
+		state KeyValueRef* it = &input.data[i];
 		state MappedKeyValueRef kvm;
+		state bool isBoundary = i == 0 || i == sz - 1;
 		// need to keep the boundary, so that caller can use it as a continuation.
-		if ((i == 0 || i == sz - 1) || matchIndex == MATCH_INDEX_ALL) {
+		if (isBoundary || matchIndex == MATCH_INDEX_ALL) {
 			kvm.key = it->key;
 			kvm.value = it->value;
 		}
@@ -3768,11 +3769,19 @@ ACTOR Future<GetMappedKeyValuesReply> mapKeyValues(StorageServer* data,
 			// Use the mappedKey as the prefix of the range query.
 			GetRangeReqAndResultRef getRange =
 			    wait(quickGetKeyValues(data, mappedKey, input.version, &(result.arena), pOriginalReq));
+			if (!getRange.result.empty() && matchIndex == MATCH_INDEX_MATCHED_ONLY ||
+			    getRange.result.empty() && matchIndex == MATCH_INDEX_UNMATCHED_ONLY) {
+				kvm.key = it->key;
+				kvm.value = it->value;
+			}
+
+			kvm.boundaryAndExist = isBoundary && !getRange.result.empty();
 			kvm.reqAndResult = getRange;
 		} else {
 			GetValueReqAndResultRef getValue =
 			    wait(quickGetValue(data, mappedKey, input.version, &(result.arena), pOriginalReq));
 			kvm.reqAndResult = getValue;
+			kvm.boundaryAndExist = isBoundary && getValue.result.present();
 		}
 		result.data.push_back(result.arena, kvm);
 	}


### PR DESCRIPTION
MATCHED mode returns index entries whose secondary KVs are present,
UNMATCHED mode returns index entries whose secondary KVs are absent.

Note that the conflict read range of this txn is set in 2 steps:
* Set the conflict range for primary query according to request
* Set the conflict ranges for secondary queries according to responses.

As a result, conflicts of different match_index mode are taken care of.

20220513-211442-haofu-df127d6255b17a4b

20220516-221937-haofu-82e80c376836f21a

`This PR includes C binding changes, Java binding will come in a following PR.(it is ready and tested, just spliting into multiple PR)`

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
