### PR TITLE
client_tmp_dir needs a unique code in bindings.

### DIFF
--- a/bindings/go/src/fdb/generated.go
+++ b/bindings/go/src/fdb/generated.go
@@ -289,7 +289,7 @@ func (o NetworkOptions) SetDistributedClientTracer(param string) error {
 //
 // Parameter: Client directory for temporary files. 
 func (o NetworkOptions) SetClientTmpDir(param string) error {
-	return o.setOpt(90, []byte(param))
+	return o.setOpt(91, []byte(param))
 }
 
 // Set the size of the client location cache. Raising this value can boost performance in very large databases where clients access data in a near-random pattern. Defaults to 100000.

--- a/fdbclient/vexillographer/fdb.options
+++ b/fdbclient/vexillographer/fdb.options
@@ -134,7 +134,7 @@ description is not currently required but encouraged.
     <Option name="distributed_client_tracer" code="90"
             paramType="String" paramDescription="Distributed tracer type. Choose from none, log_file, or network_lossy"
             description="Set a tracer to run on the client. Should be set to the same value as the tracer set on the server." />
-    <Option name="client_tmp_dir" code="90"
+    <Option name="client_tmp_dir" code="91"
             paramType="String" paramDescription="Client directory for temporary files. "
             description="Sets the directory for storing temporary files created by FDB client, such as temporary copies of client libraries. Defaults to /tmp" />
     <Option name="supported_client_versions" code="1000"


### PR DESCRIPTION
Duplicate code caused distributed_client_tracer to break.

Testing: Correctness and manual testing via Mako.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
