### PR TITLE
Use correct transaction latency in async mako

### DIFF
--- a/bindings/c/test/mako/async.cpp
+++ b/bindings/c/test/mako/async.cpp
@@ -247,7 +247,7 @@ void ResumableStateForRunWorkload::onTransactionSuccess() {
 					const auto commit_latency = watch_commit.diff();
 					const auto tx_duration = watch_tx.diff();
 					stats.addLatency(OP_COMMIT, commit_latency);
-					stats.addLatency(OP_TRANSACTION, commit_latency);
+					stats.addLatency(OP_TRANSACTION, tx_duration);
 					sample_bins[OP_COMMIT].put(commit_latency);
 					sample_bins[OP_TRANSACTION].put(tx_duration);
 				}


### PR DESCRIPTION


Current mako is adding commit latencies as transaction latencies in ResumableStateForRunWorkload::onTransactionSuccess(). This change makes sure that the correct latencies for OP_TRANSACTION are being reported.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
