### PR TITLE
General GlobalConfig fixes

### DIFF
--- a/fdbclient/GlobalConfig.actor.cpp
+++ b/fdbclient/GlobalConfig.actor.cpp
@@ -155,45 +155,56 @@ void GlobalConfig::erase(KeyRangeRef range) {
 // function performs a one-time migration of data in these keys to the new
 // global configuration key space.
 ACTOR Future<Void> GlobalConfig::migrate(GlobalConfig* self) {
-	state Reference<ReadYourWritesTransaction> tr = makeReference<ReadYourWritesTransaction>(self->cx);
-	tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
-
-	state Key migratedKey("\xff\x02/fdbClientInfo/migrated/"_sr);
-	state Optional<Value> migrated = wait(tr->get(migratedKey));
-	if (migrated.present()) {
-		// Already performed migration.
-		return Void();
-	}
-
-	state Optional<Value> sampleRate = wait(tr->get(Key("\xff\x02/fdbClientInfo/client_txn_sample_rate/"_sr)));
-	state Optional<Value> sizeLimit = wait(tr->get(Key("\xff\x02/fdbClientInfo/client_txn_size_limit/"_sr)));
-
+	state Reference<ReadYourWritesTransaction> tr;
 	try {
-		tr->setOption(FDBTransactionOptions::SPECIAL_KEY_SPACE_ENABLE_WRITES);
-		// The value doesn't matter too much, as long as the key is set.
-		tr->set(migratedKey.contents(), "1"_sr);
-		if (sampleRate.present()) {
-			const double sampleRateDbl =
-			    BinaryReader::fromStringRef<double>(sampleRate.get().contents(), Unversioned());
-			Tuple rate = Tuple().appendDouble(sampleRateDbl);
-			tr->set(GlobalConfig::prefixedKey(fdbClientInfoTxnSampleRate), rate.pack());
-		}
-		if (sizeLimit.present()) {
-			const int64_t sizeLimitInt =
-			    BinaryReader::fromStringRef<int64_t>(sizeLimit.get().contents(), Unversioned());
-			Tuple size = Tuple().append(sizeLimitInt);
-			tr->set(GlobalConfig::prefixedKey(fdbClientInfoTxnSizeLimit), size.pack());
-		}
+		loop {
+			tr = makeReference<ReadYourWritesTransaction>(Database(Reference<DatabaseContext>::addRef(self->cx)));
+			wait(delay(0));
+			tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
 
-		wait(tr->commit());
+			try {
+				state Key migratedKey("\xff\x02/fdbClientInfo/migrated/"_sr);
+				state Optional<Value> migrated = wait(tr->get(migratedKey));
+				if (migrated.present()) {
+					// Already performed migration.
+					return Void();
+				}
+
+				state Optional<Value> sampleRate =
+				    wait(tr->get(Key("\xff\x02/fdbClientInfo/client_txn_sample_rate/"_sr)));
+				state Optional<Value> sizeLimit =
+				    wait(tr->get(Key("\xff\x02/fdbClientInfo/client_txn_size_limit/"_sr)));
+
+				tr->setOption(FDBTransactionOptions::SPECIAL_KEY_SPACE_ENABLE_WRITES);
+				// The value doesn't matter too much, as long as the key is set.
+				tr->set(migratedKey.contents(), "1"_sr);
+				if (sampleRate.present()) {
+					const double sampleRateDbl =
+					    BinaryReader::fromStringRef<double>(sampleRate.get().contents(), Unversioned());
+					Tuple rate = Tuple().appendDouble(sampleRateDbl);
+					tr->set(GlobalConfig::prefixedKey(fdbClientInfoTxnSampleRate), rate.pack());
+				}
+				if (sizeLimit.present()) {
+					const int64_t sizeLimitInt =
+					    BinaryReader::fromStringRef<int64_t>(sizeLimit.get().contents(), Unversioned());
+					Tuple size = Tuple().append(sizeLimitInt);
+					tr->set(GlobalConfig::prefixedKey(fdbClientInfoTxnSizeLimit), size.pack());
+				}
+
+				wait(tr->commit());
+				break;
+			} catch (Error& e) {
+				// If multiple fdbserver processes are started at once, they will all
+				// attempt this migration at the same time, sometimes resulting in
+				// aborts due to conflicts. Purposefully avoid retrying, making this
+				// migration best-effort.
+				TraceEvent(SevInfo, "GlobalConfig_MigrationError").detail("What", e.what());
+				wait(tr->onError(e));
+			}
+		}
 	} catch (Error& e) {
-		// If multiple fdbserver processes are started at once, they will all
-		// attempt this migration at the same time, sometimes resulting in
-		// aborts due to conflicts. Purposefully avoid retrying, making this
-		// migration best-effort.
-		TraceEvent(SevInfo, "GlobalConfig_MigrationError").detail("What", e.what());
+		// Catch non-retryable errors (and do nothing).
 	}
-
 	return Void();
 }
 
@@ -203,12 +214,20 @@ ACTOR Future<Void> GlobalConfig::refresh(GlobalConfig* self) {
 	// TraceEvent trace(SevInfo, "GlobalConfig_Refresh");
 	self->erase(KeyRangeRef(""_sr, "\xff"_sr));
 
-	Transaction tr(self->cx);
-	tr.setOption(FDBTransactionOptions::READ_SYSTEM_KEYS);
-	RangeResult result = wait(tr.getRange(globalConfigDataKeys, CLIENT_KNOBS->TOO_MANY));
-	for (const auto& kv : result) {
-		KeyRef systemKey = kv.key.removePrefix(globalConfigKeysPrefix);
-		self->insert(systemKey, kv.value);
+	state Transaction tr(self->cx);
+	loop {
+		try {
+			tr.setOption(FDBTransactionOptions::READ_SYSTEM_KEYS);
+			RangeResult result = wait(tr.getRange(globalConfigDataKeys, CLIENT_KNOBS->TOO_MANY));
+			for (const auto& kv : result) {
+				KeyRef systemKey = kv.key.removePrefix(globalConfigKeysPrefix);
+				self->insert(systemKey, kv.value);
+			}
+			break;
+		} catch (Error& e) {
+			TraceEvent("GlobalConfigRefreshError").errorUnsuppressed(e).suppressFor(1.0);
+			wait(tr.onError(e));
+		}
 	}
 	return Void();
 }

--- a/fdbclient/GlobalConfig.actor.cpp
+++ b/fdbclient/GlobalConfig.actor.cpp
@@ -37,7 +37,7 @@ const KeyRef transactionTagSampleCost = LiteralStringRef("config/transaction_tag
 const KeyRef samplingFrequency = LiteralStringRef("visibility/sampling/frequency");
 const KeyRef samplingWindow = LiteralStringRef("visibility/sampling/window");
 
-GlobalConfig::GlobalConfig(const Database& cx) : cx(cx), lastUpdate(0) {}
+GlobalConfig::GlobalConfig(DatabaseContext* cx) : cx(cx), lastUpdate(0) {}
 
 void GlobalConfig::applyChanges(Transaction& tr,
                                 const VectorRef<KeyValueRef>& insertions,
@@ -214,11 +214,13 @@ ACTOR Future<Void> GlobalConfig::refresh(GlobalConfig* self) {
 	// TraceEvent trace(SevInfo, "GlobalConfig_Refresh");
 	self->erase(KeyRangeRef(""_sr, "\xff"_sr));
 
-	state Transaction tr(self->cx);
+	state Reference<ReadYourWritesTransaction> tr;
 	loop {
 		try {
-			tr.setOption(FDBTransactionOptions::READ_SYSTEM_KEYS);
-			RangeResult result = wait(tr.getRange(globalConfigDataKeys, CLIENT_KNOBS->TOO_MANY));
+			tr = makeReference<ReadYourWritesTransaction>(Database(Reference<DatabaseContext>::addRef(self->cx)));
+			wait(delay(0));
+			tr->setOption(FDBTransactionOptions::READ_SYSTEM_KEYS);
+			RangeResult result = wait(tr->getRange(globalConfigDataKeys, CLIENT_KNOBS->TOO_MANY));
 			for (const auto& kv : result) {
 				KeyRef systemKey = kv.key.removePrefix(globalConfigKeysPrefix);
 				self->insert(systemKey, kv.value);
@@ -226,7 +228,7 @@ ACTOR Future<Void> GlobalConfig::refresh(GlobalConfig* self) {
 			break;
 		} catch (Error& e) {
 			TraceEvent("GlobalConfigRefreshError").errorUnsuppressed(e).suppressFor(1.0);
-			wait(tr.onError(e));
+			wait(tr->onError(e));
 		}
 	}
 	return Void();

--- a/fdbclient/GlobalConfig.actor.h
+++ b/fdbclient/GlobalConfig.actor.h
@@ -66,9 +66,9 @@ struct ConfigValue : ReferenceCounted<ConfigValue> {
 
 class GlobalConfig : NonCopyable {
 public:
-	// Requires a database object to allow global configuration to run
+	// Requires a database pointer to allow global configuration to run
 	// transactions on the database.
-	explicit GlobalConfig(const Database& cx);
+	explicit GlobalConfig(DatabaseContext* cx);
 
 	// Requires an AsyncVar object to watch for changes on. The ClientDBInfo pointer
 	// should point to a ClientDBInfo object which will contain the updated
@@ -167,7 +167,7 @@ private:
 	ACTOR static Future<Void> refresh(GlobalConfig* self);
 	ACTOR static Future<Void> updater(GlobalConfig* self, const ClientDBInfo* dbInfo);
 
-	Database cx;
+	DatabaseContext* cx;
 	AsyncTrigger dbInfoChanged;
 	Future<Void> _forward;
 	Future<Void> _updater;

--- a/fdbclient/GlobalConfig.actor.h
+++ b/fdbclient/GlobalConfig.actor.h
@@ -33,7 +33,6 @@
 #include <unordered_map>
 
 #include "fdbclient/CommitProxyInterface.h"
-#include "fdbclient/DatabaseContext.h"
 #include "fdbclient/GlobalConfig.h"
 #include "fdbclient/ReadYourWrites.h"
 

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -1483,7 +1483,7 @@ DatabaseContext::DatabaseContext(Reference<AsyncVar<Reference<IClusterConnection
 	cacheListMonitor = monitorCacheList(this);
 
 	smoothMidShardSize.reset(CLIENT_KNOBS->INIT_MID_SHARD_BYTES);
-	globalConfig = std::make_unique<GlobalConfig>(Database(this));
+	globalConfig = std::make_unique<GlobalConfig>(this);
 
 	if (apiVersionAtLeast(710)) {
 		registerSpecialKeysImpl(


### PR DESCRIPTION
This PR contains three [GlobalConfig](https://github.com/apple/foundationdb/wiki/Global-Configuration-Framework) fixes:

* Adds a transaction retry loop to GlobalConfig transactions (from #7079)
* Fixes a reference cycle with `DatabaseContext` and `GlobalConfig` smart pointers (from #7127)
* Fixes an issue where GlobalConfig would not be initialized on a newly cloned `Database` object

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
