### PR TITLE
Fix the kill/suspend/expensive_data_check commands to not send requests sequentially

### DIFF
--- a/bindings/c/fdb_c.cpp
+++ b/bindings/c/fdb_c.cpp
@@ -408,6 +408,10 @@ extern "C" DLLEXPORT fdb_error_t fdb_database_create_transaction(FDBDatabase* d,
 	                 *out_transaction = (FDBTransaction*)tr.extractPtr(););
 }
 
+extern "C" DLLEXPORT FDBFuture* fdb_database_fetch_worker_interfaces(FDBDatabase* db) {
+	return (FDBFuture*)(DB(db)->fetchWorkerInterfaces()).extractPtr();
+}
+
 extern "C" DLLEXPORT FDBFuture* fdb_database_reboot_worker(FDBDatabase* db,
                                                            uint8_t const* address,
                                                            int address_length,

--- a/bindings/c/foundationdb/fdb_c.h
+++ b/bindings/c/foundationdb/fdb_c.h
@@ -279,6 +279,8 @@ DLLEXPORT WARN_UNUSED_RESULT fdb_error_t fdb_database_open_tenant(FDBDatabase* d
 DLLEXPORT WARN_UNUSED_RESULT fdb_error_t fdb_database_create_transaction(FDBDatabase* d,
                                                                          FDBTransaction** out_transaction);
 
+DLLEXPORT WARN_UNUSED_RESULT FDBFuture* fdb_database_fetch_worker_interfaces(FDBDatabase* db);
+
 DLLEXPORT WARN_UNUSED_RESULT FDBFuture* fdb_database_reboot_worker(FDBDatabase* db,
                                                                    uint8_t const* address,
                                                                    int address_length,

--- a/bindings/c/test/unit/fdb_api.cpp
+++ b/bindings/c/test/unit/fdb_api.cpp
@@ -78,6 +78,12 @@ void Future::cancel() {
 	return fdb_future_get_string_array(future_, out_strings, out_count);
 }
 
+// KeyArrayFuture
+
+[[nodiscard]] fdb_error_t KeyArrayFuture::get(const FDBKey** out_keys, int* out_count) {
+	return fdb_future_get_key_array(future_, out_keys, out_count);
+}
+
 // KeyRangeArrayFuture
 
 [[nodiscard]] fdb_error_t KeyRangeArrayFuture::get(const FDBKeyRange** out_keyranges, int* out_count) {
@@ -110,6 +116,11 @@ Result::~Result() {
 }
 
 // Database
+
+KeyArrayFuture Database::fetch_worker_interfaces(FDBDatabase* db) {
+	return KeyArrayFuture(fdb_database_fetch_worker_interfaces(db));
+}
+
 Int64Future Database::reboot_worker(FDBDatabase* db,
                                     const uint8_t* address,
                                     int address_length,

--- a/bindings/c/test/unit/fdb_api.hpp
+++ b/bindings/c/test/unit/fdb_api.hpp
@@ -124,6 +124,19 @@ private:
 	StringArrayFuture(FDBFuture* f) : Future(f) {}
 };
 
+class KeyArrayFuture : public Future {
+public:
+	// Call this function instead of fdb_future_get_key_array when using
+	// the KeyArrayFuture type. It's behavior is identical to
+	// fdb_future_get_key_array.
+	fdb_error_t get(const FDBKey** out_keys, int* out_count);
+
+private:
+	friend class Transaction;
+	friend class Database;
+	KeyArrayFuture(FDBFuture* f) : Future(f) {}
+};
+
 class KeyValueArrayFuture : public Future {
 public:
 	// Call this function instead of fdb_future_get_keyvalue_array when using
@@ -191,6 +204,7 @@ private:
 // Wrapper around FDBDatabase, providing database-level API
 class Database final {
 public:
+	static KeyArrayFuture fetch_worker_interfaces(FDBDatabase* db);
 	static Int64Future reboot_worker(FDBDatabase* db,
 	                                 const uint8_t* address,
 	                                 int address_length,

--- a/bindings/flow/fdb_flow.h
+++ b/bindings/flow/fdb_flow.h
@@ -140,6 +140,7 @@ public:
 	virtual ~Database(){};
 	virtual Reference<Transaction> createTransaction() = 0;
 	virtual void setDatabaseOption(FDBDatabaseOption option, Optional<StringRef> value = Optional<StringRef>()) = 0;
+	virtual Future<Standalone<VectorRef<KeyRef>>> fetchWorkerInterfaces() = 0;
 	virtual Future<int64_t> rebootWorker(const StringRef& address, bool check = false, int duration = 0) = 0;
 	virtual Future<Void> forceRecoveryWithDataLoss(const StringRef& dcid) = 0;
 	virtual Future<Void> createSnapshot(const StringRef& uid, const StringRef& snap_command) = 0;

--- a/fdbcli/ExpensiveDataCheckCommand.actor.cpp
+++ b/fdbcli/ExpensiveDataCheckCommand.actor.cpp
@@ -34,48 +34,55 @@ namespace fdb_cli {
 // The command is used to send a data check request to the specified process
 // The check request is accomplished by rebooting the process
 
-ACTOR Future<bool> expensiveDataCheckCommandActor(
-    Reference<IDatabase> db,
-    Reference<ITransaction> tr,
-    std::vector<StringRef> tokens,
-    std::map<Key, std::pair<Value, ClientLeaderRegInterface>>* address_interface) {
+ACTOR Future<bool> expensiveDataCheckCommandActor(Reference<IDatabase> db,
+                                                  Reference<ITransaction> tr,
+                                                  std::vector<StringRef> tokens,
+                                                  std::set<std::string>* addresses) {
 	state bool result = true;
+	state std::vector<Future<int64_t>> futures;
+	state int i;
 	if (tokens.size() == 1) {
-		// initialize worker interfaces
-		wait(getWorkerInterfaces(tr, address_interface));
+		wait(fetchAndUpdateWorkerInterfaces(db, addresses));
 	}
 	if (tokens.size() == 1 || tokencmp(tokens[1], "list")) {
-		if (address_interface->size() == 0) {
+		if (addresses->size() == 0) {
 			printf("\nNo addresses can be checked.\n");
-		} else if (address_interface->size() == 1) {
+		} else if (addresses->size() == 1) {
 			printf("\nThe following address can be checked:\n");
 		} else {
-			printf("\nThe following %zu addresses can be checked:\n", address_interface->size());
+			printf("\nThe following %zu addresses can be checked:\n", addresses->size());
 		}
-		for (auto it : *address_interface) {
-			printf("%s\n", printable(it.first).c_str());
+		for (const auto& addr : *addresses) {
+			printf("%s\n", printable(addr).c_str());
 		}
 		printf("\n");
 	} else if (tokencmp(tokens[1], "all")) {
-		state std::map<Key, std::pair<Value, ClientLeaderRegInterface>>::const_iterator it;
-		for (it = address_interface->cbegin(); it != address_interface->cend(); it++) {
-			int64_t checkRequestSent = wait(safeThreadFutureToFuture(db->rebootWorker(it->first, true, 0)));
-			if (!checkRequestSent) {
-				result = false;
-				fprintf(stderr, "ERROR: failed to send request to check process `%s'.\n", it->first.toString().c_str());
-			}
+		state std::set<std::string>::iterator it;
+		for (it = addresses->begin(); it != addresses->end(); ++it) {
+			futures.push_back(safeThreadFutureToFuture(db->rebootWorker(*it, true, 0)));
 		}
-		if (address_interface->size() == 0) {
+		wait(waitForAll(futures));
+		i = 0;
+		it = addresses->begin();
+		while (i < futures.size()) {
+			if (!futures[i].get()) {
+				result = false;
+				fprintf(stderr, "ERROR: failed to send request to check process `%s'.\n", it->c_str());
+			}
+			i++;
+			++it;
+		}
+
+		if (addresses->size() == 0) {
 			fprintf(stderr,
 			        "ERROR: no processes to check. You must run the `expensive_data_check’ "
 			        "command before running `expensive_data_check all’.\n");
 		} else {
-			printf("Attempted to kill and check %zu processes\n", address_interface->size());
+			printf("Attempted to kill and check %zu processes\n", addresses->size());
 		}
 	} else {
-		state int i;
 		for (i = 1; i < tokens.size(); i++) {
-			if (!address_interface->count(tokens[i])) {
+			if (addresses->find(tokens[i].toString()) == addresses->end()) {
 				fprintf(stderr, "ERROR: process `%s' not recognized.\n", printable(tokens[i]).c_str());
 				result = false;
 				break;
@@ -84,11 +91,15 @@ ACTOR Future<bool> expensiveDataCheckCommandActor(
 
 		if (result) {
 			for (i = 1; i < tokens.size(); i++) {
-				int64_t checkRequestSent = wait(safeThreadFutureToFuture(db->rebootWorker(tokens[i], true, 0)));
-				if (!checkRequestSent) {
+				futures.push_back(safeThreadFutureToFuture(db->rebootWorker(tokens[i], true, 0)));
+			}
+			wait(waitForAll(futures));
+			for (i = 0; i < futures.size(); i++) {
+				if (!futures[i].get()) {
 					result = false;
-					fprintf(
-					    stderr, "ERROR: failed to send request to check process `%s'.\n", tokens[i].toString().c_str());
+					fprintf(stderr,
+					        "ERROR: failed to send request to check process `%s'.\n",
+					        tokens[i + 1].toString().c_str());
 				}
 			}
 			printf("Attempted to kill and check %zu processes\n", tokens.size() - 1);

--- a/fdbcli/fdbcli.actor.cpp
+++ b/fdbcli/fdbcli.actor.cpp
@@ -1060,7 +1060,7 @@ ACTOR Future<int> cli(CLIOptions opt, LineNoise* plinenoise) {
 
 	state bool writeMode = false;
 
-	state std::map<Key, std::pair<Value, ClientLeaderRegInterface>> address_interface;
+	state std::set<std::string> workerAddresses;
 
 	state FdbOptions globalOptions;
 	state FdbOptions activeOptions;
@@ -1544,68 +1544,15 @@ ACTOR Future<int> cli(CLIOptions opt, LineNoise* plinenoise) {
 
 				if (tokencmp(tokens[0], "kill")) {
 					getTransaction(db, managementTenant, tr, options, intrans);
-					if (tokens.size() == 1) {
-						state ThreadFuture<RangeResult> wInterfF =
-						    tr->getRange(KeyRangeRef(LiteralStringRef("\xff\xff/worker_interfaces/"),
-						                             LiteralStringRef("\xff\xff/worker_interfaces0")),
-						                 CLIENT_KNOBS->TOO_MANY);
-						RangeResult kvs = wait(makeInterruptable(safeThreadFutureToFuture(wInterfF)));
-						ASSERT(!kvs.more);
-						auto connectLock = makeReference<FlowLock>(CLIENT_KNOBS->CLI_CONNECT_PARALLELISM);
-						std::vector<Future<Void>> addInterfs;
-						for (auto it : kvs) {
-							addInterfs.push_back(addInterface(&address_interface, connectLock, it));
-						}
-						wait(waitForAll(addInterfs));
-					}
-					if (tokens.size() == 1 || tokencmp(tokens[1], "list")) {
-						if (address_interface.size() == 0) {
-							printf("\nNo addresses can be killed.\n");
-						} else if (address_interface.size() == 1) {
-							printf("\nThe following address can be killed:\n");
-						} else {
-							printf("\nThe following %zu addresses can be killed:\n", address_interface.size());
-						}
-						for (auto it : address_interface) {
-							printf("%s\n", printable(it.first).c_str());
-						}
-						printf("\n");
-					} else if (tokencmp(tokens[1], "all")) {
-						for (auto it : address_interface) {
-							BinaryReader::fromStringRef<ClientWorkerInterface>(it.second.first, IncludeVersion())
-							    .reboot.send(RebootRequest());
-						}
-						if (address_interface.size() == 0) {
-							fprintf(stderr,
-							        "ERROR: no processes to kill. You must run the `kill’ command before "
-							        "running `kill all’.\n");
-						} else {
-							printf("Attempted to kill %zu processes\n", address_interface.size());
-						}
-					} else {
-						for (int i = 1; i < tokens.size(); i++) {
-							if (!address_interface.count(tokens[i])) {
-								fprintf(stderr, "ERROR: process `%s' not recognized.\n", printable(tokens[i]).c_str());
-								is_error = true;
-								break;
-							}
-						}
-
-						if (!is_error) {
-							for (int i = 1; i < tokens.size(); i++) {
-								BinaryReader::fromStringRef<ClientWorkerInterface>(address_interface[tokens[i]].first,
-								                                                   IncludeVersion())
-								    .reboot.send(RebootRequest());
-							}
-							printf("Attempted to kill %zu processes\n", tokens.size() - 1);
-						}
-					}
+					bool _result = wait(makeInterruptable(killCommandActor(db, tr, tokens, &workerAddresses)));
+					if (!_result)
+						is_error = true;
 					continue;
 				}
 
 				if (tokencmp(tokens[0], "suspend")) {
 					getTransaction(db, managementTenant, tr, options, intrans);
-					bool _result = wait(makeInterruptable(suspendCommandActor(db, tr, tokens, &address_interface)));
+					bool _result = wait(makeInterruptable(suspendCommandActor(db, tr, tokens, &workerAddresses)));
 					if (!_result)
 						is_error = true;
 					continue;
@@ -1644,7 +1591,7 @@ ACTOR Future<int> cli(CLIOptions opt, LineNoise* plinenoise) {
 				if (tokencmp(tokens[0], "expensive_data_check")) {
 					getTransaction(db, managementTenant, tr, options, intrans);
 					bool _result =
-					    wait(makeInterruptable(expensiveDataCheckCommandActor(db, tr, tokens, &address_interface)));
+					    wait(makeInterruptable(expensiveDataCheckCommandActor(db, tr, tokens, &workerAddresses)));
 					if (!_result)
 						is_error = true;
 					continue;

--- a/fdbclient/DatabaseContext.h
+++ b/fdbclient/DatabaseContext.h
@@ -357,6 +357,8 @@ public:
 	Future<Void> connectionFileChanged();
 	IsSwitchable switchable{ false };
 
+	// Management API, fetch and save worker interfaces in the database object, return a list of workers' addresses
+	Future<Standalone<VectorRef<StringRef>>> fetchWorkerInterfaces();
 	// Management API, Attempt to kill or suspend a process, return 1 for request sent out, 0 for failure
 	Future<int64_t> rebootWorker(StringRef address, bool check = false, int duration = 0);
 	// Management API, force the database to recover into DCID, causing the database to lose the most recently committed
@@ -631,6 +633,7 @@ public:
 
 	std::unique_ptr<GlobalConfig> globalConfig;
 	EventCacheHolder connectToDatabaseEventCacheHolder;
+	Optional<std::map<Key, std::pair<Value, ClientLeaderRegInterface>>> addressInterfaces;
 
 private:
 	std::unordered_map<std::pair<int64_t, Key>, Reference<WatchMetadata>, boost::hash<std::pair<int64_t, Key>>>

--- a/fdbclient/IClientApi.h
+++ b/fdbclient/IClientApi.h
@@ -153,6 +153,8 @@ public:
 	virtual void addref() = 0;
 	virtual void delref() = 0;
 
+	// Management API, fetch and save worker interfaces in the database object, return a list of workers' addresses
+	virtual ThreadFuture<Standalone<VectorRef<KeyRef>>> fetchWorkerInterfaces() = 0;
 	// Management API, attempt to kill or suspend a process, return 1 for request sent out, 0 for failure
 	virtual ThreadFuture<int64_t> rebootWorker(const StringRef& address, bool check, int duration) = 0;
 	// Management API, force the database to recover into DCID, causing the database to lose the most recently committed

--- a/fdbclient/MultiVersionTransaction.h
+++ b/fdbclient/MultiVersionTransaction.h
@@ -139,6 +139,7 @@ struct FdbCApi : public ThreadSafeReferenceCounted<FdbCApi> {
 	                                 uint8_t const* value,
 	                                 int valueLength);
 	void (*databaseDestroy)(FDBDatabase* database);
+	FDBFuture* (*databaseFetchWorkerInterfaces)(FDBDatabase* database);
 	FDBFuture* (*databaseRebootWorker)(FDBDatabase* database,
 	                                   uint8_t const* address,
 	                                   int addressLength,
@@ -448,6 +449,7 @@ public:
 	void addref() override { ThreadSafeReferenceCounted<DLDatabase>::addref(); }
 	void delref() override { ThreadSafeReferenceCounted<DLDatabase>::delref(); }
 
+	ThreadFuture<Standalone<VectorRef<KeyRef>>> fetchWorkerInterfaces() override;
 	ThreadFuture<int64_t> rebootWorker(const StringRef& address, bool check, int duration) override;
 	ThreadFuture<Void> forceRecoveryWithDataLoss(const StringRef& dcid) override;
 	ThreadFuture<Void> createSnapshot(const StringRef& uid, const StringRef& snapshot_command) override;
@@ -732,6 +734,7 @@ public:
 	// For internal use in testing
 	static Reference<IDatabase> debugCreateFromExistingDatabase(Reference<IDatabase> db);
 
+	ThreadFuture<Standalone<VectorRef<KeyRef>>> fetchWorkerInterfaces() override;
 	ThreadFuture<int64_t> rebootWorker(const StringRef& address, bool check, int duration) override;
 	ThreadFuture<Void> forceRecoveryWithDataLoss(const StringRef& dcid) override;
 	ThreadFuture<Void> createSnapshot(const StringRef& uid, const StringRef& snapshot_command) override;

--- a/fdbclient/ThreadSafeTransaction.cpp
+++ b/fdbclient/ThreadSafeTransaction.cpp
@@ -81,6 +81,11 @@ void ThreadSafeDatabase::setOption(FDBDatabaseOptions::Option option, Optional<S
 	    &db->deferredError);
 }
 
+ThreadFuture<Standalone<VectorRef<KeyRef>>> ThreadSafeDatabase::fetchWorkerInterfaces() {
+	DatabaseContext* db = this->db;
+	return onMainThread([db]() -> Future<Standalone<VectorRef<KeyRef>>> { return db->fetchWorkerInterfaces(); });
+}
+
 ThreadFuture<int64_t> ThreadSafeDatabase::rebootWorker(const StringRef& address, bool check, int duration) {
 	DatabaseContext* db = this->db;
 	Key addressKey = address;

--- a/fdbclient/ThreadSafeTransaction.h
+++ b/fdbclient/ThreadSafeTransaction.h
@@ -55,6 +55,7 @@ public:
 	void addref() override { ThreadSafeReferenceCounted<ThreadSafeDatabase>::addref(); }
 	void delref() override { ThreadSafeReferenceCounted<ThreadSafeDatabase>::delref(); }
 
+	ThreadFuture<Standalone<VectorRef<KeyRef>>> fetchWorkerInterfaces() override;
 	ThreadFuture<int64_t> rebootWorker(const StringRef& address, bool check, int duration) override;
 	ThreadFuture<Void> forceRecoveryWithDataLoss(const StringRef& dcid) override;
 	ThreadFuture<Void> createSnapshot(const StringRef& uid, const StringRef& snapshot_command) override;


### PR DESCRIPTION
The fix for issue #7147  where _killall_ is sending requests sequentially.

To avoid fetching worker interfaces every time in the `rebootWorker` call,
added a new interface `fetchWorkerInterfaces` that fetches worker interfaces and is saved in the database object.

The issue before was the database needs to have the interface every time to send a reboot request,
now we save a map inside the database object to avoid that call.

Thus, the user needs to call `fetchWorkerInterfaces` first to call `rebootWorker`, which is the existing pattern.

-----------------

Added a call for  `fetchWorkerInterfaces` in fdb_c_unit_tests, `TEST_CASE("fdb_database_reboot_worker")` .

-----------------

Added a fdbcli test, `killall`, to make sure in a local cluster with 5 processes,
after `killall`, there's only one recovery happened.
This is tested by using the generation number from `status json`.
The assumption is one recovery will increase the generation number by 2.

Verified by running the ctest 10K times.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
