### PR TITLE
Test loop profiler using API Tester

### DIFF
--- a/bindings/c/test/apitester/TesterOptions.h
+++ b/bindings/c/test/apitester/TesterOptions.h
@@ -51,7 +51,6 @@ public:
 	int numClients;
 	int numTenants = -1;
 	int statsIntervalMs = 0;
-	std::vector<std::pair<std::string, std::string>> knobs;
 	TestSpec testSpec;
 	std::string bgBasePath;
 	std::string tlsCertFile;

--- a/bindings/c/test/apitester/TesterTestSpec.h
+++ b/bindings/c/test/apitester/TesterTestSpec.h
@@ -56,6 +56,9 @@ struct TestSpec {
 	// rather than on the main thread of the local FDB client library
 	bool fdbCallbacksOnExternalThreads = false;
 
+	// Enable Flow loop profiling (for slow tasks & thread saturation)
+	bool runLoopProfiler = false;
+
 	// Execute each transaction in a separate database instance
 	bool databasePerTransaction = false;
 
@@ -85,6 +88,10 @@ struct TestSpec {
 	// Number of tenants (a random number in the [min,max] range)
 	int minTenants = 0;
 	int maxTenants = 0;
+
+	// Overridden knob values
+	using KnobKeyValues = std::vector<std::pair<std::string, std::string>>;
+	KnobKeyValues knobs;
 
 	// List of workloads with their options
 	std::vector<WorkloadSpec> workloads;

--- a/bindings/c/test/apitester/tests/CApiRunLoopProfiler.toml
+++ b/bindings/c/test/apitester/tests/CApiRunLoopProfiler.toml
@@ -1,0 +1,27 @@
+[[test]]
+title = 'Test run loop profiler'
+multiThreaded = true
+buggify = true
+runLoopProfiler = true
+minFdbThreads = 8
+maxFdbThreads = 8
+minDatabases = 8
+maxDatabases = 8
+minClientThreads = 16
+maxClientThreads = 16
+minClients = 32
+maxClients = 32
+
+    [[test.workload]]
+    name = 'ApiCorrectness'
+    minKeyLength = 1
+	maxKeyLength = 64
+	minValueLength = 1
+	maxValueLength = 1000
+	maxKeysPerTransaction = 50
+	initialSize = 100
+	numRandomOperations = 100
+	readExistingKeysRatio = 0.9
+
+[[knobs]]
+run_loop_profiling_interval=0.001

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -2699,6 +2699,11 @@ void stopNetwork() {
 		throw network_not_setup();
 
 	TraceEvent("ClientStopNetwork").log();
+
+	if (networkOptions.traceDirectory.present() && networkOptions.runLoopProfilingEnabled) {
+		stopRunLoopProfiler();
+	}
+
 	g_network->stop();
 }
 

--- a/flow/include/flow/Platform.h
+++ b/flow/include/flow/Platform.h
@@ -815,6 +815,7 @@ void registerCrashHandlerCallback(void (*f)());
 void registerCrashHandler();
 
 void setupRunLoopProfiler();
+void stopRunLoopProfiler();
 EXTERNC void setProfilingEnabled(int enabled);
 
 // Use _exit() or criticalError(), not exit()


### PR DESCRIPTION
Adding a test that reproduces the deadlock caused by mallocs in the signal handler triggered by the loop profiler. 

The test  is not deterministic, so it sometime succeeds. For me it failed about 80% of times.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
