### PR TITLE
Switching char* to std::string for ProcessInfo to have it own memory (valgrind errors)

### DIFF
--- a/fdbrpc/sim2.actor.cpp
+++ b/fdbrpc/sim2.actor.cpp
@@ -106,14 +106,14 @@ void ISimulator::displayWorkers() const {
 		for (auto& processInfo : machineRecord.second) {
 			printf("                  %9s %-10s%-13s%-8s %-6s %-9s %-8s %-48s %-40s\n",
 			       processInfo->address.toString().c_str(),
-			       processInfo->name,
+			       processInfo->name.c_str(),
 			       processInfo->startingClass.toString().c_str(),
 			       (processInfo->isExcluded() ? "True" : "False"),
 			       (processInfo->failed ? "True" : "False"),
 			       (processInfo->rebooting ? "True" : "False"),
 			       (processInfo->isCleared() ? "True" : "False"),
 			       getRoles(processInfo->address).c_str(),
-			       processInfo->dataFolder);
+			       processInfo->dataFolder.c_str());
 		}
 	}
 
@@ -1588,7 +1588,7 @@ public:
 			    .detail("Protected", protectedAddresses.count(machine->address))
 			    .backtrace();
 			// This will remove all the "tracked" messages that came from the machine being killed
-			if (std::string(machine->name) != "remote flow process")
+			if (machine->name != "remote flow process")
 				latestEventCache.clear();
 			machine->failed = true;
 		} else if (kt == InjectFaults) {
@@ -1618,7 +1618,7 @@ public:
 			ASSERT(false);
 		}
 		ASSERT(!protectedAddresses.count(machine->address) || machine->rebooting ||
-		       std::string(machine->name) == "remote flow process");
+		       machine->name == "remote flow process");
 	}
 	void rebootProcess(ProcessInfo* process, KillType kt) override {
 		if (kt == RebootProcessAndDelete && protectedAddresses.count(process->address)) {
@@ -2465,7 +2465,7 @@ ACTOR void doReboot(ISimulator::ProcessInfo* p, ISimulator::KillType kt) {
 			    .detail("Rebooting", p->rebooting)
 			    .detail("Reliable", p->isReliable());
 			return;
-		} else if (std::string(p->name) == "remote flow process") {
+		} else if (p->name == "remote flow process") {
 			TraceEvent(SevDebug, "DoRebootFailed").detail("Name", p->name).detail("Address", p->address);
 			return;
 		} else if (p->getChilds().size()) {

--- a/fdbrpc/simulator.h
+++ b/fdbrpc/simulator.h
@@ -59,9 +59,9 @@ public:
 	struct MachineInfo;
 
 	struct ProcessInfo : NonCopyable {
-		const char* name;
-		const char* coordinationFolder;
-		const char* dataFolder;
+		std::string name;
+		std::string coordinationFolder;
+		std::string dataFolder;
 		MachineInfo* machine;
 		NetworkAddressList addresses;
 		NetworkAddress address;
@@ -182,7 +182,7 @@ public:
 		std::string toString() const {
 			return format(
 			    "name: %s address: %s zone: %s datahall: %s class: %s excluded: %d cleared: %d",
-			    name,
+			    name.c_str(),
 			    formatIpPort(addresses.address.ip, addresses.address.port).c_str(),
 			    (locality.zoneId().present() ? locality.zoneId().get().printable().c_str() : "[unset]"),
 			    (locality.dataHallId().present() ? locality.dataHallId().get().printable().c_str() : "[unset]"),

--- a/fdbserver/FDBExecHelper.actor.cpp
+++ b/fdbserver/FDBExecHelper.actor.cpp
@@ -160,16 +160,17 @@ ACTOR Future<int> spawnSimulated(std::vector<std::string> paramList,
 		}
 	}
 	state int result = 0;
-	child = g_pSimulator->newProcess("remote flow process",
-	                                 self->address.ip,
-	                                 0,
-	                                 self->address.isTLS(),
-	                                 self->addresses.secondaryAddress.present() ? 2 : 1,
-	                                 self->locality,
-	                                 ProcessClass(ProcessClass::UnsetClass, ProcessClass::AutoSource),
-	                                 self->dataFolder,
-	                                 self->coordinationFolder, // do we need to customize this coordination folder path?
-	                                 self->protocolVersion);
+	child = g_pSimulator->newProcess(
+	    "remote flow process",
+	    self->address.ip,
+	    0,
+	    self->address.isTLS(),
+	    self->addresses.secondaryAddress.present() ? 2 : 1,
+	    self->locality,
+	    ProcessClass(ProcessClass::UnsetClass, ProcessClass::AutoSource),
+	    self->dataFolder.c_str(),
+	    self->coordinationFolder.c_str(), // do we need to customize this coordination folder path?
+	    self->protocolVersion);
 	wait(g_pSimulator->onProcess(child));
 	state Future<ISimulator::KillType> onShutdown = child->onShutdown();
 	state Future<ISimulator::KillType> parentShutdown = self->onShutdown();

--- a/fdbserver/tester.actor.cpp
+++ b/fdbserver/tester.actor.cpp
@@ -480,7 +480,7 @@ void printSimulatedTopology() {
 		printf("%sAddress: %s\n", indent.c_str(), p->address.toString().c_str());
 		indent += "  ";
 		printf("%sClass: %s\n", indent.c_str(), p->startingClass.toString().c_str());
-		printf("%sName: %s\n", indent.c_str(), p->name);
+		printf("%sName: %s\n", indent.c_str(), p->name.c_str());
 	}
 }
 

--- a/fdbserver/workloads/ClientWorkload.actor.cpp
+++ b/fdbserver/workloads/ClientWorkload.actor.cpp
@@ -72,7 +72,7 @@ class WorkloadProcessState {
 		                                            locality,
 		                                            ProcessClass(ProcessClass::TesterClass, ProcessClass::AutoSource),
 		                                            dataFolder.c_str(),
-		                                            parent->coordinationFolder,
+		                                            parent->coordinationFolder.c_str(),
 		                                            parent->protocolVersion);
 		self->childProcess->excludeFromRestarts = true;
 		wait(g_simulator.onProcess(self->childProcess, TaskPriority::DefaultYield));

--- a/fdbserver/workloads/SaveAndKill.actor.cpp
+++ b/fdbserver/workloads/SaveAndKill.actor.cpp
@@ -72,13 +72,13 @@ struct SaveAndKillWorkload : TestWorkload {
 		std::map<std::string, ISimulator::ProcessInfo*> allProcessesMap;
 		for (const auto& [_, process] : rebootingProcesses) {
 			if (allProcessesMap.find(process->dataFolder) == allProcessesMap.end() &&
-			    std::string(process->name) != "remote flow process") {
+			    process->name != "remote flow process") {
 				allProcessesMap[process->dataFolder] = process;
 			}
 		}
 		for (const auto& process : processes) {
 			if (allProcessesMap.find(process->dataFolder) == allProcessesMap.end() &&
-			    std::string(process->name) != "remote flow process") {
+			    process->name != "remote flow process") {
 				allProcessesMap[process->dataFolder] = process;
 			}
 		}
@@ -106,18 +106,22 @@ struct SaveAndKillWorkload : TestWorkload {
 					ini.SetValue(machineIdString,
 					             format("ipAddr%d", process->address.port - 1).c_str(),
 					             process->address.ip.toString().c_str());
-					ini.SetValue(machineIdString, format("%d", process->address.port - 1).c_str(), process->dataFolder);
 					ini.SetValue(
-					    machineIdString, format("c%d", process->address.port - 1).c_str(), process->coordinationFolder);
+					    machineIdString, format("%d", process->address.port - 1).c_str(), process->dataFolder.c_str());
+					ini.SetValue(machineIdString,
+					             format("c%d", process->address.port - 1).c_str(),
+					             process->coordinationFolder.c_str());
 					j++;
 				} else {
 					ini.SetValue(machineIdString,
 					             format("ipAddr%d", process->address.port - 1).c_str(),
 					             process->address.ip.toString().c_str());
 					int oldValue = machines.find(machineId)->second;
-					ini.SetValue(machineIdString, format("%d", process->address.port - 1).c_str(), process->dataFolder);
 					ini.SetValue(
-					    machineIdString, format("c%d", process->address.port - 1).c_str(), process->coordinationFolder);
+					    machineIdString, format("%d", process->address.port - 1).c_str(), process->dataFolder.c_str());
+					ini.SetValue(machineIdString,
+					             format("c%d", process->address.port - 1).c_str(),
+					             process->coordinationFolder.c_str());
 					machines.erase(machines.find(machineId));
 					machines.insert(std::pair<std::string, int>(machineId, oldValue + 1));
 				}


### PR DESCRIPTION
Fixes #7175 
I suspect, but have not confirmed, that the reason this used to work may be the jmalloc changes?
Either way, accessing these char* fields in the save and kill workload was accessing freed memory, and changing ProcessInfo to have ownership of the memory fixed it.

Sampled several of the previous nightly valgrind failures and they all pass now after this change.
Valgrind ensemble fails 1/1000 tests.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
