### PR TITLE
Api Tester: print workload progress statistics in regular time intervals

### DIFF
--- a/bindings/c/test/apitester/TesterOptions.h
+++ b/bindings/c/test/apitester/TesterOptions.h
@@ -48,6 +48,7 @@ public:
 	int numClientThreads;
 	int numDatabases;
 	int numClients;
+	int statsIntervalMs = 0;
 	std::vector<std::pair<std::string, std::string>> knobs;
 	TestSpec testSpec;
 	std::string bgBasePath;

--- a/bindings/c/test/apitester/TesterScheduler.h
+++ b/bindings/c/test/apitester/TesterScheduler.h
@@ -33,6 +33,16 @@ using TTaskFct = std::function<void(void)>;
 extern const TTaskFct NO_OP_TASK;
 
 /**
+ * Handle to a scheduled timer
+ */
+class ITimer {
+public:
+	virtual ~ITimer() {}
+
+	virtual void cancel() = 0;
+};
+
+/**
  * Scheduler for asynchronous execution of tasks on a pool of threads
  */
 class IScheduler {
@@ -44,6 +54,9 @@ public:
 
 	// Schedule a task for asynchronous execution
 	virtual void schedule(TTaskFct task) = 0;
+
+	// Schedule a task to be executed with a given delay
+	virtual std::unique_ptr<ITimer> scheduleWithDelay(int delayMs, TTaskFct task) = 0;
 
 	// Gracefully stop the scheduler. Waits for already running tasks to be finish
 	virtual void stop() = 0;

--- a/bindings/c/test/apitester/TesterWorkload.cpp
+++ b/bindings/c/test/apitester/TesterWorkload.cpp
@@ -80,13 +80,17 @@ bool WorkloadConfig::getBoolOption(const std::string& name, bool defaultVal) con
 
 WorkloadBase::WorkloadBase(const WorkloadConfig& config)
   : manager(nullptr), tasksScheduled(0), numErrors(0), clientId(config.clientId), numClients(config.numClients),
-    failed(false) {
+    failed(false), numTxCompleted(0) {
 	maxErrors = config.getIntOption("maxErrors", 10);
 	workloadId = fmt::format("{}{}", config.name, clientId);
 }
 
 void WorkloadBase::init(WorkloadManager* manager) {
 	this->manager = manager;
+}
+
+void WorkloadBase::printStats() {
+	info(fmt::format("{} transactions completed", numTxCompleted.load()));
 }
 
 void WorkloadBase::schedule(TTaskFct task) {
@@ -106,6 +110,7 @@ void WorkloadBase::execTransaction(std::shared_ptr<ITransactionActor> tx, TTaskF
 	}
 	tasksScheduled++;
 	manager->txExecutor->execute(tx, [this, tx, cont, failOnError]() {
+		numTxCompleted++;
 		fdb_error_t err = tx->getErrorCode();
 		if (tx->getErrorCode() == error_code_success) {
 			cont();
@@ -198,6 +203,9 @@ void WorkloadManager::workloadDone(IWorkload* workload, bool failed) {
 	bool done = workloads.empty();
 	lock.unlock();
 	if (done) {
+		if (statsTimer) {
+			statsTimer->cancel();
+		}
 		scheduler->stop();
 	}
 }
@@ -239,6 +247,24 @@ void WorkloadManager::readControlInput(std::string pipeName) {
 		}
 		line.clear();
 	}
+}
+
+void WorkloadManager::schedulePrintStatistics(int timeIntervalMs) {
+	statsTimer = scheduler->scheduleWithDelay(timeIntervalMs, [this, timeIntervalMs]() {
+		for (auto workload : getActiveWorkloads()) {
+			workload->printStats();
+		}
+		this->schedulePrintStatistics(timeIntervalMs);
+	});
+}
+
+std::vector<std::shared_ptr<IWorkload>> WorkloadManager::getActiveWorkloads() {
+	std::unique_lock<std::mutex> lock(mutex);
+	std::vector<std::shared_ptr<IWorkload>> res;
+	for (auto iter : workloads) {
+		res.push_back(iter.second.ref);
+	}
+	return res;
 }
 
 void WorkloadManager::handleStopCommand() {

--- a/bindings/c/test/apitester/run_c_api_tests.py
+++ b/bindings/c/test/apitester/run_c_api_tests.py
@@ -30,6 +30,8 @@ import glob
 import random
 import string
 
+TESTER_STATS_INTERVAL_SEC = 5
+
 
 def random_string(len):
     return ''.join(random.choice(string.ascii_letters + string.digits) for i in range(len))
@@ -66,7 +68,8 @@ def dump_client_logs(log_dir):
 def run_tester(args, test_file):
     cmd = [args.tester_binary,
            "--cluster-file", args.cluster_file,
-           "--test-file", test_file]
+           "--test-file", test_file,
+           "--stats-interval", str(TESTER_STATS_INTERVAL_SEC*1000)]
     if args.external_client_library is not None:
         cmd += ["--external-client-library", args.external_client_library]
     if args.tmp_dir is not None:

--- a/tests/TestRunner/upgrade_test.py
+++ b/tests/TestRunner/upgrade_test.py
@@ -73,6 +73,7 @@ LOCAL_OLD_BINARY_REPO = "/opt/foundationdb/old/"
 CURRENT_VERSION = "7.2.0"
 HEALTH_CHECK_TIMEOUT_SEC = 5
 PROGRESS_CHECK_TIMEOUT_SEC = 30
+TESTER_STATS_INTERVAL_SEC = 5
 TRANSACTION_RETRY_LIMIT = 100
 MAX_DOWNLOAD_ATTEMPTS = 5
 RUN_WITH_GDB = False
@@ -398,6 +399,8 @@ class UpgradeTest:
                 self.tmp_dir,
                 "--transaction-retry-limit",
                 str(TRANSACTION_RETRY_LIMIT),
+                "--stats-interval",
+                str(TESTER_STATS_INTERVAL_SEC*1000)
             ]
             if RUN_WITH_GDB:
                 cmd_args = ["gdb", "-ex", "run", "--args"] + cmd_args


### PR DESCRIPTION
Introducing an option to Api Tester to enable printing workload statistics in regular intervals, so that in case of long running tests we can see if the tester is still alive and the workloads are making progress. 

The statistics is currently limited to the number of completed transactions, but the design allows defining workload-specific statistic dump if necessary. 

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
