### PR TITLE
Mako add distributed tracing client

### DIFF
--- a/bindings/c/test/mako/mako.cpp
+++ b/bindings/c/test/mako/mako.cpp
@@ -620,22 +620,19 @@ int workerProcessMain(Arguments const& args, int worker_id, shared_memory::Acces
 	selectApiVersion(args.api_version);
 
 	/* enable distributed tracing */
-	if (args.distributed_tracer_client > 0) {
-		switch (args.distributed_tracer_client) {
-		case 1:
-			err = network::setOptionNothrow(FDB_NET_OPTION_DISTRIBUTED_CLIENT_TRACER,
-			                                BytesRef(toBytePtr("network_lossy")));
-			break;
-		case 2:
-			err = network::setOptionNothrow(FDB_NET_OPTION_DISTRIBUTED_CLIENT_TRACER, BytesRef(toBytePtr("sim_end")));
-			break;
-		case 3:
-			err = network::setOptionNothrow(FDB_NET_OPTION_DISTRIBUTED_CLIENT_TRACER, BytesRef(toBytePtr("log_file")));
-			break;
-		}
-		if (err) {
-			logr.error("network::setOption(FDB_NET_OPTION_DISTRIBUTED_CLIENT_TRACER): {}", err.what());
-		}
+	switch (args.distributed_tracer_client) {
+	case 1:
+		err = network::setOptionNothrow(FDB_NET_OPTION_DISTRIBUTED_CLIENT_TRACER, BytesRef(toBytePtr("network_lossy")));
+		break;
+	case 2:
+		err = network::setOptionNothrow(FDB_NET_OPTION_DISTRIBUTED_CLIENT_TRACER, BytesRef(toBytePtr("sim_end")));
+		break;
+	case 3:
+		err = network::setOptionNothrow(FDB_NET_OPTION_DISTRIBUTED_CLIENT_TRACER, BytesRef(toBytePtr("log_file")));
+		break;
+	}
+	if (err) {
+		logr.error("network::setOption(FDB_NET_OPTION_DISTRIBUTED_CLIENT_TRACER): {}", err.what());
 	}
 
 	/* enable flatbuffers if specified */

--- a/bindings/c/test/mako/mako.cpp
+++ b/bindings/c/test/mako/mako.cpp
@@ -1016,9 +1016,8 @@ void usage() {
 	printf("%-24s %s\n",
 	       "    --bg_file_path=PATH",
 	       "Read blob granule files from the local filesystem at PATH and materialize the results.");
-	printf("%-24s %s\n",
-	       "    --distributed_tracer_client=CLIENT",
-	       "Specify client (disabled, network_lossy, log_file)");
+	printf(
+	    "%-24s %s\n", "    --distributed_tracer_client=CLIENT", "Specify client (disabled, network_lossy, log_file)");
 }
 
 /* parse benchmark paramters */

--- a/bindings/c/test/mako/mako.cpp
+++ b/bindings/c/test/mako/mako.cpp
@@ -625,9 +625,6 @@ int workerProcessMain(Arguments const& args, int worker_id, shared_memory::Acces
 		err = network::setOptionNothrow(FDB_NET_OPTION_DISTRIBUTED_CLIENT_TRACER, BytesRef(toBytePtr("network_lossy")));
 		break;
 	case 2:
-		err = network::setOptionNothrow(FDB_NET_OPTION_DISTRIBUTED_CLIENT_TRACER, BytesRef(toBytePtr("sim_end")));
-		break;
-	case 3:
 		err = network::setOptionNothrow(FDB_NET_OPTION_DISTRIBUTED_CLIENT_TRACER, BytesRef(toBytePtr("log_file")));
 		break;
 	}
@@ -1021,7 +1018,7 @@ void usage() {
 	       "Read blob granule files from the local filesystem at PATH and materialize the results.");
 	printf("%-24s %s\n",
 	       "    --distributed_tracer_client=CLIENT",
-	       "Specify client (disabled, log_file, network_lossy, sim_end)");
+	       "Specify client (disabled, network_lossy, log_file)");
 }
 
 /* parse benchmark paramters */
@@ -1266,10 +1263,8 @@ int parseArguments(int argc, char* argv[], Arguments& args) {
 				args.distributed_tracer_client = 0;
 			} else if (strcmp(optarg, "network_lossy") == 0) {
 				args.distributed_tracer_client = 1;
-			} else if (strcmp(optarg, "sim_end") == 0) {
-				args.distributed_tracer_client = 2;
 			} else if (strcmp(optarg, "log_file") == 0) {
-				args.distributed_tracer_client = 3;
+				args.distributed_tracer_client = 2;
 			} else {
 				args.distributed_tracer_client = -1;
 			}
@@ -1342,7 +1337,7 @@ int validateArguments(Arguments const& args) {
 		}
 	}
 	if (args.distributed_tracer_client < 0) {
-		logr.error("--disibuted_tracer_client must specify either (disabled, log_file, network_lossy, sim_end)");
+		logr.error("--disibuted_tracer_client must specify either (disabled, network_lossy, log_file)");
 		return -1;
 	}
 	return 0;

--- a/bindings/c/test/mako/mako.cpp
+++ b/bindings/c/test/mako/mako.cpp
@@ -619,6 +619,25 @@ int workerProcessMain(Arguments const& args, int worker_id, shared_memory::Acces
 
 	selectApiVersion(args.api_version);
 
+	/* enable distributed tracing */
+	if (args.distributed_tracer_client > 0) {
+		switch (args.distributed_tracer_client) {
+		case 1:
+			err = network::setOptionNothrow(FDB_NET_OPTION_DISTRIBUTED_CLIENT_TRACER,
+			                                BytesRef(toBytePtr("network_lossy")));
+			break;
+		case 2:
+			err = network::setOptionNothrow(FDB_NET_OPTION_DISTRIBUTED_CLIENT_TRACER, BytesRef(toBytePtr("sim_end")));
+			break;
+		case 3:
+			err = network::setOptionNothrow(FDB_NET_OPTION_DISTRIBUTED_CLIENT_TRACER, BytesRef(toBytePtr("log_file")));
+			break;
+		}
+		if (err) {
+			logr.error("network::setOption(FDB_NET_OPTION_DISTRIBUTED_CLIENT_TRACER): {}", err.what());
+		}
+	}
+
 	/* enable flatbuffers if specified */
 	if (args.flatbuffers) {
 #ifdef FDB_NET_OPTION_USE_FLATBUFFERS
@@ -824,6 +843,7 @@ int initArguments(Arguments& args) {
 	args.json_output_path[0] = '\0';
 	args.bg_materialize_files = false;
 	args.bg_file_path[0] = '\0';
+	args.distributed_tracer_client = 0;
 	return 0;
 }
 
@@ -1002,6 +1022,9 @@ void usage() {
 	printf("%-24s %s\n",
 	       "    --bg_file_path=PATH",
 	       "Read blob granule files from the local filesystem at PATH and materialize the results.");
+	printf("%-24s %s\n",
+	       "    --distributed_tracer_client=CLIENT",
+	       "Specify client (disabled, log_file, network_lossy, sim_end)");
 }
 
 /* parse benchmark paramters */
@@ -1053,6 +1076,7 @@ int parseArguments(int argc, char* argv[], Arguments& args) {
 			{ "disable_ryw", no_argument, NULL, ARG_DISABLE_RYW },
 			{ "json_report", optional_argument, NULL, ARG_JSON_REPORT },
 			{ "bg_file_path", required_argument, NULL, ARG_BG_FILE_PATH },
+			{ "distributed_tracer_client", required_argument, NULL, ARG_DISTRIBUTED_TRACER_CLIENT },
 			{ NULL, 0, NULL, 0 }
 		};
 		idx = 0;
@@ -1240,6 +1264,19 @@ int parseArguments(int argc, char* argv[], Arguments& args) {
 		case ARG_BG_FILE_PATH:
 			args.bg_materialize_files = true;
 			strncpy(args.bg_file_path, optarg, std::min(sizeof(args.bg_file_path), strlen(optarg) + 1));
+		case ARG_DISTRIBUTED_TRACER_CLIENT:
+			if (strcmp(optarg, "disabled") == 0) {
+				args.distributed_tracer_client = 0;
+			} else if (strcmp(optarg, "network_lossy") == 0) {
+				args.distributed_tracer_client = 1;
+			} else if (strcmp(optarg, "sim_end") == 0) {
+				args.distributed_tracer_client = 2;
+			} else if (strcmp(optarg, "log_file") == 0) {
+				args.distributed_tracer_client = 3;
+			} else {
+				args.distributed_tracer_client = -1;
+			}
+			break;
 		}
 	}
 
@@ -1306,6 +1343,10 @@ int validateArguments(Arguments const& args) {
 			logr.error("--txntagging must be a non-negative integer");
 			return -1;
 		}
+	}
+	if (args.distributed_tracer_client < 0) {
+		logr.error("--disibuted_tracer_client must specify either (disabled, log_file, network_lossy, sim_end)");
+		return -1;
 	}
 	return 0;
 }

--- a/bindings/c/test/mako/mako.hpp
+++ b/bindings/c/test/mako/mako.hpp
@@ -72,7 +72,8 @@ enum ArgKind {
 	ARG_DISABLE_RYW,
 	ARG_CLIENT_THREADS_PER_VERSION,
 	ARG_JSON_REPORT,
-	ARG_BG_FILE_PATH // if blob granule files are stored locally, mako will read and materialize them if this is set
+	ARG_BG_FILE_PATH, // if blob granule files are stored locally, mako will read and materialize them if this is set
+	ARG_DISTRIBUTED_TRACER_CLIENT
 };
 
 constexpr const int OP_COUNT = 0;
@@ -161,6 +162,7 @@ struct Arguments {
 	char json_output_path[PATH_MAX];
 	bool bg_materialize_files;
 	char bg_file_path[PATH_MAX];
+	int distributed_tracer_client;
 };
 
 } // namespace mako


### PR DESCRIPTION
Add support for specifying distributed client tracer in Mako.
    
Introduces a new command line option --distributed_tracer_client. Defaults to disabled, user may specify
disabled, log_file, network_lossy, or sim_end.
    
Tested locally and verified with distributed tracing receiver. Note: We use a simple integer here to denote tracer type rather directly using the TracerType enum in flow/Tracing.h. Including Tracing.h pulls in FDBTypes.h and results in conflicts with several classes, including `Database`.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
