### PR TITLE
Make java binding work for prefetch match index modes.

### DIFF
--- a/bindings/java/fdbJNI.cpp
+++ b/bindings/java/fdbJNI.cpp
@@ -533,10 +533,14 @@ JNIEXPORT jobject JNICALL Java_com_apple_foundationdb_FutureMappedResults_Future
 		FDBMappedKeyValue kvm = kvms[i];
 		int kvm_count = kvm.getRange.m_size;
 
-		const int totalLengths = 4 + kvm_count * 2;
+		// now it has 5 field, key, value, getRange.begin, getRange.end, boundaryAndExist
+		// this needs to change if FDBMappedKeyValue definition is changed.
+		const int totalFieldFDBMappedKeyValue = 5;
+
+		const int totalLengths = totalFieldFDBMappedKeyValue + kvm_count * 2;
 
 		int totalBytes = kvm.key.key_length + kvm.value.key_length + kvm.getRange.begin.key.key_length +
-		                 kvm.getRange.end.key.key_length;
+		                 kvm.getRange.end.key.key_length + sizeof(kvm.boundaryAndExist);
 		for (int i = 0; i < kvm_count; i++) {
 			auto kv = kvm.getRange.data[i];
 			totalBytes += kv.key_length + kv.value_length;
@@ -580,6 +584,7 @@ JNIEXPORT jobject JNICALL Java_com_apple_foundationdb_FutureMappedResults_Future
 				cpBytesAndLength(pByte, pLength, kvm.value);
 				cpBytesAndLength(pByte, pLength, kvm.getRange.begin.key);
 				cpBytesAndLength(pByte, pLength, kvm.getRange.end.key);
+				cpBytesAndLengthInner(pByte, pLength, (uint8_t*)&(kvm.boundaryAndExist), sizeof(kvm.boundaryAndExist));
 				for (int kvm_i = 0; kvm_i < kvm_count; kvm_i++) {
 					auto kv = kvm.getRange.data[kvm_i];
 					cpBytesAndLengthInner(pByte, pLength, kv.key, kv.key_length);
@@ -588,6 +593,7 @@ JNIEXPORT jobject JNICALL Java_com_apple_foundationdb_FutureMappedResults_Future
 			}
 		}
 		// After native arrays are released
+		// call public static method MappedKeyValue::fromBytes()
 		jobject mkv = jenv->CallStaticObjectMethod(
 		    mapped_key_value_class, mapped_key_value_from_bytes, (jbyteArray)bytesArray, (jintArray)lengthArray);
 		if (jenv->ExceptionOccurred())

--- a/bindings/java/src/integration/com/apple/foundationdb/MappedRangeQueryIntegrationTest.java
+++ b/bindings/java/src/integration/com/apple/foundationdb/MappedRangeQueryIntegrationTest.java
@@ -208,7 +208,11 @@ class MappedRangeQueryIntegrationTest {
 					assertByteArrayEquals(indexEntryKey(id), mappedKeyValue.getKey());
 					assertByteArrayEquals(EMPTY, mappedKeyValue.getValue());
 					assertByteArrayEquals(indexEntryKey(id), mappedKeyValue.getKey());
-
+					if (id == begin || id == end - 1) {
+						Assertions.assertTrue(mappedKeyValue.getBoundaryAndExist());
+					} else {
+						Assertions.assertFalse(mappedKeyValue.getBoundaryAndExist());
+					}
 					byte[] prefix = recordKeyPrefix(id);
 					assertByteArrayEquals(prefix, mappedKeyValue.getRangeBegin());
 					prefix[prefix.length - 1] = (byte)0x01;

--- a/bindings/java/src/main/com/apple/foundationdb/FDBTransaction.java
+++ b/bindings/java/src/main/com/apple/foundationdb/FDBTransaction.java
@@ -358,7 +358,8 @@ class FDBTransaction extends NativeObjectWrapper implements Transaction, OptionC
 		if (mapper == null) {
 			throw new IllegalArgumentException("Mapper must be non-null");
 		}
-		return new MappedRangeQuery(FDBTransaction.this, false, begin, end, mapper, limit, reverse, mode, eventKeeper);
+		return new MappedRangeQuery(FDBTransaction.this, false, begin, end, mapper, limit, matchIndex, reverse, mode,
+		                            eventKeeper);
 	}
 
 	///////////////////
@@ -463,7 +464,8 @@ class FDBTransaction extends NativeObjectWrapper implements Transaction, OptionC
 	protected FutureMappedResults getMappedRange_internal(KeySelector begin, KeySelector end,
 	                                                      byte[] mapper, // Nullable
 	                                                      int rowLimit, int targetBytes, int streamingMode,
-	                                                      int iteration, boolean isSnapshot, boolean reverse) {
+	                                                      int iteration, boolean isSnapshot, boolean reverse,
+	                                                      int matchIndex) {
 		if (eventKeeper != null) {
 			eventKeeper.increment(Events.JNI_CALL);
 		}
@@ -476,7 +478,7 @@ class FDBTransaction extends NativeObjectWrapper implements Transaction, OptionC
 			return new FutureMappedResults(
 			    Transaction_getMappedRange(getPtr(), begin.getKey(), begin.orEqual(), begin.getOffset(), end.getKey(),
 			                               end.orEqual(), end.getOffset(), mapper, rowLimit, targetBytes, streamingMode,
-			                               iteration, MATCH_INDEX_ALL, isSnapshot, reverse),
+			                               iteration, matchIndex, isSnapshot, reverse),
 			    FDB.instance().isDirectBufferQueriesEnabled(), executor, eventKeeper);
 		} finally {
 			pointerReadLock.unlock();

--- a/bindings/java/src/main/com/apple/foundationdb/MappedRangeQuery.java
+++ b/bindings/java/src/main/com/apple/foundationdb/MappedRangeQuery.java
@@ -53,18 +53,21 @@ class MappedRangeQuery implements AsyncIterable<MappedKeyValue> {
 	private final byte[] mapper; // Nonnull
 	private final boolean snapshot;
 	private final int rowLimit;
+	private final int matchIndex;
 	private final boolean reverse;
 	private final StreamingMode streamingMode;
 	private final EventKeeper eventKeeper;
 
 	MappedRangeQuery(FDBTransaction transaction, boolean isSnapshot, KeySelector begin, KeySelector end, byte[] mapper,
-	                 int rowLimit, boolean reverse, StreamingMode streamingMode, EventKeeper eventKeeper) {
+	                 int rowLimit, int matchIndex, boolean reverse, StreamingMode streamingMode,
+	                 EventKeeper eventKeeper) {
 		this.tr = transaction;
 		this.begin = begin;
 		this.end = end;
 		this.mapper = mapper;
 		this.snapshot = isSnapshot;
 		this.rowLimit = rowLimit;
+		this.matchIndex = matchIndex;
 		this.reverse = reverse;
 		this.streamingMode = streamingMode;
 		this.eventKeeper = eventKeeper;
@@ -88,14 +91,14 @@ class MappedRangeQuery implements AsyncIterable<MappedKeyValue> {
 
 			FutureMappedResults range =
 			    tr.getMappedRange_internal(this.begin, this.end, this.mapper, this.rowLimit, 0,
-			                               StreamingMode.EXACT.code(), 1, this.snapshot, this.reverse);
+			                               StreamingMode.EXACT.code(), 1, this.snapshot, this.reverse, this.matchIndex);
 			return range.thenApply(result -> result.get().values).whenComplete((result, e) -> range.close());
 		}
 
 		// If the streaming mode is not EXACT, simply collect the results of an
 		// iteration into a list
 		return AsyncUtil.collect(
-		    new MappedRangeQuery(tr, snapshot, begin, end, mapper, rowLimit, reverse, mode, eventKeeper),
+		    new MappedRangeQuery(tr, snapshot, begin, end, mapper, rowLimit, matchIndex, reverse, mode, eventKeeper),
 		    tr.getExecutor());
 	}
 
@@ -106,7 +109,7 @@ class MappedRangeQuery implements AsyncIterable<MappedKeyValue> {
 	 */
 	@Override
 	public AsyncRangeIterator iterator() {
-		return new AsyncRangeIterator(this.rowLimit, this.reverse, this.streamingMode);
+		return new AsyncRangeIterator(this.rowLimit, this.matchIndex, this.reverse, this.streamingMode);
 	}
 
 	private class AsyncRangeIterator implements AsyncIterator<MappedKeyValue> {
@@ -114,6 +117,7 @@ class MappedRangeQuery implements AsyncIterable<MappedKeyValue> {
 		private final boolean rowsLimited;
 		private final boolean reverse;
 		private final StreamingMode streamingMode;
+		private final int matchIndex;
 
 		// There is the chance for parallelism in the two "chunks" for fetched data
 		private MappedRangeResult chunk = null;
@@ -131,12 +135,13 @@ class MappedRangeQuery implements AsyncIterable<MappedKeyValue> {
 		private CompletableFuture<Boolean> nextFuture;
 		private boolean isCancelled = false;
 
-		private AsyncRangeIterator(int rowLimit, boolean reverse, StreamingMode streamingMode) {
+		private AsyncRangeIterator(int rowLimit, int matchIndex, boolean reverse, StreamingMode streamingMode) {
 			this.begin = MappedRangeQuery.this.begin;
 			this.end = MappedRangeQuery.this.end;
 			this.rowsLimited = rowLimit != 0;
 			this.rowsRemaining = rowLimit;
 			this.reverse = reverse;
+			this.matchIndex = matchIndex;
 			this.streamingMode = streamingMode;
 
 			startNextFetch();
@@ -217,8 +222,9 @@ class MappedRangeQuery implements AsyncIterable<MappedKeyValue> {
 
 			nextFuture = new CompletableFuture<>();
 			final long sTime = System.nanoTime();
-			fetchingChunk = tr.getMappedRange_internal(begin, end, mapper, rowsLimited ? rowsRemaining : 0, 0,
-			                                           streamingMode.code(), ++iteration, snapshot, reverse);
+			fetchingChunk =
+			    tr.getMappedRange_internal(begin, end, mapper, rowsLimited ? rowsRemaining : 0, 0, streamingMode.code(),
+			                               ++iteration, snapshot, reverse, matchIndex);
 
 			BiConsumer<MappedRangeResultInfo, Throwable> cons = new FetchComplete(fetchingChunk, nextFuture);
 			if (eventKeeper != null) {

--- a/bindings/java/src/main/com/apple/foundationdb/MappedRangeResultDirectBufferIterator.java
+++ b/bindings/java/src/main/com/apple/foundationdb/MappedRangeResultDirectBufferIterator.java
@@ -52,7 +52,7 @@ class MappedRangeResultDirectBufferIterator extends DirectBufferIterator impleme
 		final byte[] rangeBegin = getString();
 		final byte[] rangeEnd = getString();
 		final byte[] boundaryAndExistBytes = getString();
-		final boolean boundaryAndExist = ByteBuffer.wrap(boundaryAndExistBytes).getInt() == 1 ? true : false;
+		final int boundaryAndExist = ByteBuffer.wrap(boundaryAndExistBytes).getInt();
 		final int rangeResultSize = byteBuffer.getInt();
 		List<KeyValue> rangeResult = new ArrayList();
 		for (int i = 0; i < rangeResultSize; i++) {

--- a/bindings/java/src/main/com/apple/foundationdb/MappedRangeResultDirectBufferIterator.java
+++ b/bindings/java/src/main/com/apple/foundationdb/MappedRangeResultDirectBufferIterator.java
@@ -51,6 +51,8 @@ class MappedRangeResultDirectBufferIterator extends DirectBufferIterator impleme
 		final byte[] value = getString();
 		final byte[] rangeBegin = getString();
 		final byte[] rangeEnd = getString();
+		final byte[] boundaryAndExistBytes = getString();
+		final boolean boundaryAndExist = ByteBuffer.wrap(boundaryAndExistBytes).getInt() == 1 ? true : false;
 		final int rangeResultSize = byteBuffer.getInt();
 		List<KeyValue> rangeResult = new ArrayList();
 		for (int i = 0; i < rangeResultSize; i++) {
@@ -59,7 +61,7 @@ class MappedRangeResultDirectBufferIterator extends DirectBufferIterator impleme
 			rangeResult.add(new KeyValue(k, v));
 		}
 		current += 1;
-		return new MappedKeyValue(key, value, rangeBegin, rangeEnd, rangeResult);
+		return new MappedKeyValue(key, value, rangeBegin, rangeEnd, rangeResult, boundaryAndExist);
 	}
 
 	private byte[] getString() {


### PR DESCRIPTION
a follow up PR to add java binding parts of https://github.com/apple/foundationdb/pull/7162

It adds boundaryAndExist in return value, so that caller can see
whether a boundary index is orphan or not.

Put description here...

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
