### PR TITLE
Extend the reboot interface to accept comma-delimited string

### DIFF
--- a/fdbcli/ExpensiveDataCheckCommand.actor.cpp
+++ b/fdbcli/ExpensiveDataCheckCommand.actor.cpp
@@ -18,6 +18,8 @@
  * limitations under the License.
  */
 
+#include "boost/algorithm/string.hpp"
+
 #include "fdbcli/fdbcli.actor.h"
 
 #include "fdbclient/FDBOptions.g.h"
@@ -40,8 +42,10 @@ ACTOR Future<bool> expensiveDataCheckCommandActor(
     std::vector<StringRef> tokens,
     std::map<Key, std::pair<Value, ClientLeaderRegInterface>>* address_interface) {
 	state bool result = true;
+	state std::string addressesStr;
 	if (tokens.size() == 1) {
 		// initialize worker interfaces
+		address_interface->clear();
 		wait(getWorkerInterfaces(tr, address_interface));
 	}
 	if (tokens.size() == 1 || tokencmp(tokens[1], "list")) {
@@ -57,20 +61,26 @@ ACTOR Future<bool> expensiveDataCheckCommandActor(
 		}
 		printf("\n");
 	} else if (tokencmp(tokens[1], "all")) {
-		state std::map<Key, std::pair<Value, ClientLeaderRegInterface>>::const_iterator it;
-		for (it = address_interface->cbegin(); it != address_interface->cend(); it++) {
-			int64_t checkRequestSent = wait(safeThreadFutureToFuture(db->rebootWorker(it->first, true, 0)));
-			if (!checkRequestSent) {
-				result = false;
-				fprintf(stderr, "ERROR: failed to send request to check process `%s'.\n", it->first.toString().c_str());
-			}
-		}
 		if (address_interface->size() == 0) {
 			fprintf(stderr,
 			        "ERROR: no processes to check. You must run the `expensive_data_check’ "
 			        "command before running `expensive_data_check all’.\n");
 		} else {
-			printf("Attempted to kill and check %zu processes\n", address_interface->size());
+			std::vector<std::string> addressesVec;
+			for (const auto& [address, _] : *address_interface) {
+				addressesVec.push_back(address.toString());
+			}
+			addressesStr = boost::algorithm::join(addressesVec, ",");
+			// make sure we only call the interface once to send requests in parallel
+			int64_t checkRequestsSent = wait(safeThreadFutureToFuture(db->rebootWorker(addressesStr, true, 0)));
+			if (!checkRequestsSent) {
+				result = false;
+				fprintf(stderr,
+				        "ERROR: failed to send requests to check all processes, please run the `expensive_data_check’ "
+				        "command again to fetch latest addresses.\n");
+			} else {
+				printf("Attempted to kill and check %zu processes\n", address_interface->size());
+			}
 		}
 	} else {
 		state int i;
@@ -83,15 +93,21 @@ ACTOR Future<bool> expensiveDataCheckCommandActor(
 		}
 
 		if (result) {
+			std::vector<std::string> addressesVec;
 			for (i = 1; i < tokens.size(); i++) {
-				int64_t checkRequestSent = wait(safeThreadFutureToFuture(db->rebootWorker(tokens[i], true, 0)));
-				if (!checkRequestSent) {
-					result = false;
-					fprintf(
-					    stderr, "ERROR: failed to send request to check process `%s'.\n", tokens[i].toString().c_str());
-				}
+				addressesVec.push_back(tokens[i].toString());
 			}
-			printf("Attempted to kill and check %zu processes\n", tokens.size() - 1);
+			addressesStr = boost::algorithm::join(addressesVec, ",");
+			int64_t checkRequestsSent = wait(safeThreadFutureToFuture(db->rebootWorker(addressesStr, true, 0)));
+			if (!checkRequestsSent) {
+				result = false;
+				fprintf(stderr,
+				        "ERROR: failed to send requests to check processes `%s', please run the `expensive_data_check’ "
+				        "command again to fetch latest addresses.\n",
+				        addressesStr.c_str());
+			} else {
+				printf("Attempted to kill and check %zu processes\n", tokens.size() - 1);
+			}
 		}
 	}
 	return result;

--- a/fdbcli/KillCommand.actor.cpp
+++ b/fdbcli/KillCommand.actor.cpp
@@ -18,6 +18,8 @@
  * limitations under the License.
  */
 
+#include "boost/algorithm/string.hpp"
+
 #include "fdbcli/fdbcli.actor.h"
 
 #include "fdbclient/FDBOptions.g.h"
@@ -37,8 +39,10 @@ ACTOR Future<bool> killCommandActor(Reference<IDatabase> db,
                                     std::map<Key, std::pair<Value, ClientLeaderRegInterface>>* address_interface) {
 	ASSERT(tokens.size() >= 1);
 	state bool result = true;
+	state std::string addressesStr;
 	if (tokens.size() == 1) {
 		// initialize worker interfaces
+		address_interface->clear();
 		wait(getWorkerInterfaces(tr, address_interface));
 	}
 	if (tokens.size() == 1 || tokencmp(tokens[1], "list")) {
@@ -54,21 +58,27 @@ ACTOR Future<bool> killCommandActor(Reference<IDatabase> db,
 		}
 		printf("\n");
 	} else if (tokencmp(tokens[1], "all")) {
-		state std::map<Key, std::pair<Value, ClientLeaderRegInterface>>::const_iterator it;
-		for (it = address_interface->cbegin(); it != address_interface->cend(); it++) {
-			int64_t killRequestSent = wait(safeThreadFutureToFuture(db->rebootWorker(it->first, false, 0)));
-			if (!killRequestSent) {
-				result = false;
-				fprintf(stderr, "ERROR: failed to send request to kill process `%s'.\n", it->first.toString().c_str());
-			}
-		}
 		if (address_interface->size() == 0) {
 			result = false;
 			fprintf(stderr,
 			        "ERROR: no processes to kill. You must run the `kill’ command before "
 			        "running `kill all’.\n");
 		} else {
-			printf("Attempted to kill %zu processes\n", address_interface->size());
+			std::vector<std::string> addressesVec;
+			for (const auto& [address, _] : *address_interface) {
+				addressesVec.push_back(address.toString());
+			}
+			addressesStr = boost::algorithm::join(addressesVec, ",");
+			// make sure we only call the interface once to send requests in parallel
+			int64_t killRequestsSent = wait(safeThreadFutureToFuture(db->rebootWorker(addressesStr, false, 0)));
+			if (!killRequestsSent) {
+				result = false;
+				fprintf(stderr,
+				        "ERROR: failed to send requests to all processes, please run the `kill’ command again to fetch "
+				        "latest addresses.\n");
+			} else {
+				printf("Attempted to kill %zu processes\n", address_interface->size());
+			}
 		}
 	} else {
 		state int i;
@@ -81,15 +91,21 @@ ACTOR Future<bool> killCommandActor(Reference<IDatabase> db,
 		}
 
 		if (result) {
+			std::vector<std::string> addressesVec;
 			for (i = 1; i < tokens.size(); i++) {
-				int64_t killRequestSent = wait(safeThreadFutureToFuture(db->rebootWorker(tokens[i], false, 0)));
-				if (!killRequestSent) {
-					result = false;
-					fprintf(
-					    stderr, "ERROR: failed to send request to kill process `%s'.\n", tokens[i].toString().c_str());
-				}
+				addressesVec.push_back(tokens[i].toString());
 			}
-			printf("Attempted to kill %zu processes\n", tokens.size() - 1);
+			addressesStr = boost::algorithm::join(addressesVec, ",");
+			int64_t killRequestsSent = wait(safeThreadFutureToFuture(db->rebootWorker(addressesStr, false, 0)));
+			if (!killRequestsSent) {
+				result = false;
+				fprintf(stderr,
+				        "ERROR: failed to send requests to kill processes `%s', please run the `kill’ command again to "
+				        "fetch latest addresses.\n",
+				        addressesStr.c_str());
+			} else {
+				printf("Attempted to kill %zu processes\n", tokens.size() - 1);
+			}
 		}
 	}
 	return result;

--- a/fdbclient/IClientApi.h
+++ b/fdbclient/IClientApi.h
@@ -153,7 +153,11 @@ public:
 	virtual void addref() = 0;
 	virtual void delref() = 0;
 
-	// Management API, attempt to kill or suspend a process, return 1 for request sent out, 0 for failure
+	// Management API, attempt to kill or suspend a process, return 1 for request being sent out, 0 for failure
+	// The address string can be extended to a comma-delimited string like <addr1>,<addr2>...,<addrN> to send reboot
+	// requests to multiple processes simultaneously
+	// If multiple addresses are provided, it returns 1 for requests being sent out to all provided addresses.
+	// On the contrary, if the client cannot connect to any of the given address, no requests will be sent out
 	virtual ThreadFuture<int64_t> rebootWorker(const StringRef& address, bool check, int duration) = 0;
 	// Management API, force the database to recover into DCID, causing the database to lose the most recently committed
 	// mutations


### PR DESCRIPTION
Fix issue #7147 by extending the `rebootWorker` interface to accept comma-delimited addresses string,
where the underlying implementation will send requests to multiple processes simultaneously.

This fixed all the sequential issues for `kill`, `suspend`, and `expensive_data_check` commands.

-------------
Testing: 
correctness 100K
ctest for fdbcli 100K
Manually tested the three commands to make sure it's happening as expected.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
