### PR TITLE
(snowflake-7.1) Process should not crash when given invalid knob name

### DIFF
--- a/fdbclient/IKnobCollection.cpp
+++ b/fdbclient/IKnobCollection.cpp
@@ -109,7 +109,7 @@ void IKnobCollection::setupKnobs(const std::vector<std::pair<std::string, std::s
 				    .detail("Knob", printable(knobName))
 				    .detail("Value", printable(knobValueString));
 			} else if (e.code() == error_code_invalid_option) {
-				std::cerr << "WARNING: Invalid knob option '" << knobName << "'\n'";
+				std::cerr << "WARNING: Invalid knob option '" << knobName << "'\n";
 				TraceEvent(SevWarnAlways, "InvalidKnobName")
 				    .detail("Knob", printable(knobName))
 				    .detail("Value", printable(knobValueString));

--- a/fdbclient/IKnobCollection.cpp
+++ b/fdbclient/IKnobCollection.cpp
@@ -108,6 +108,11 @@ void IKnobCollection::setupKnobs(const std::vector<std::pair<std::string, std::s
 				TraceEvent(SevWarnAlways, "InvalidKnobValue")
 				    .detail("Knob", printable(knobName))
 				    .detail("Value", printable(knobValueString));
+			} else if (e.code() == error_code_invalid_option) {
+				std::cerr << "WARNING: Invalid knob option '" << knobName << "'\n'";
+				TraceEvent(SevWarnAlways, "InvalidKnobName")
+				    .detail("Knob", printable(knobName))
+				    .detail("Value", printable(knobValueString));
 			} else {
 				std::cerr << "ERROR: Failed to set knob option '" << knobName << "': " << e.what() << "\n";
 				TraceEvent(SevError, "FailedToSetKnob")

--- a/fdbserver/LocalConfiguration.actor.cpp
+++ b/fdbserver/LocalConfiguration.actor.cpp
@@ -127,18 +127,9 @@ class LocalConfigurationImpl {
 				} catch (Error& e) {
 					if (e.code() == error_code_invalid_option) {
 						TEST(true); // Attempted to manually set invalid knob option
-						if (!g_network->isSimulated()) {
-							fprintf(stderr, "WARNING: Unrecognized knob option '%s'\n", knobName.c_str());
-						}
 						TraceEvent(SevWarnAlways, "UnrecognizedKnobOption").detail("Knob", printable(knobName));
 					} else if (e.code() == error_code_invalid_option_value) {
 						TEST(true); // Invalid manually set knob value
-						if (!g_network->isSimulated()) {
-							fprintf(stderr,
-							        "WARNING: Invalid value '%s' for knob option '%s'\n",
-							        knobValueString.c_str(),
-							        knobName.c_str());
-						}
 						TraceEvent(SevWarnAlways, "InvalidKnobValue")
 						    .detail("Knob", printable(knobName))
 						    .detail("Value", printable(knobValueString));

--- a/tests/argument_parsing/test_argument_parsing.py
+++ b/tests/argument_parsing/test_argument_parsing.py
@@ -37,7 +37,7 @@ def is_unknown_option(output):
     return output.startswith('ERROR: unknown option')
 
 def is_unknown_knob(output):
-    return output.startswith('ERROR: Failed to set knob option')
+    return output.startswith('WARNING: Invalid knob option')
 
 def is_cli_usage(output):
     return output.startswith('FoundationDB CLI')


### PR DESCRIPTION
This backports https://github.com/apple/foundationdb/pull/7187.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
