### PR TITLE
Fix client upgrade from pre-7.0 versions after replacing all coordinators

### DIFF
--- a/bindings/c/CMakeLists.txt
+++ b/bindings/c/CMakeLists.txt
@@ -352,15 +352,25 @@ endif()
               --redundancy double
             )
 
-    add_test(NAME fdb_c_wiggle_and_upgrade
+    add_test(NAME fdb_c_wiggle_and_upgrade_latest
           COMMAND ${CMAKE_SOURCE_DIR}/tests/TestRunner/upgrade_test.py
               --build-dir ${CMAKE_BINARY_DIR}
               --test-file ${CMAKE_SOURCE_DIR}/bindings/c/test/apitester/tests/upgrade/MixedApiWorkloadMultiThr.toml
-              --upgrade-path "7.0.0" "wiggle" "7.2.0"
+              --upgrade-path "7.1.5" "wiggle" "7.2.0"
               --disable-log-dump
               --process-number 3
               --redundancy double
             )
+
+    add_test(NAME fdb_c_wiggle_and_upgrade_63
+      COMMAND ${CMAKE_SOURCE_DIR}/tests/TestRunner/upgrade_test.py
+          --build-dir ${CMAKE_BINARY_DIR}
+          --test-file ${CMAKE_SOURCE_DIR}/bindings/c/test/apitester/tests/upgrade/MixedApiWorkloadMultiThr.toml
+          --upgrade-path "6.3.24" "wiggle" "7.0.0"
+          --disable-log-dump
+          --process-number 3
+          --redundancy double
+        )
 
   endif()
 

--- a/fdbclient/IClientApi.h
+++ b/fdbclient/IClientApi.h
@@ -193,6 +193,11 @@ public:
 
 	virtual Reference<IDatabase> createDatabase(const char* clusterFilePath) = 0;
 
+	virtual Reference<IDatabase> createLocalVersionMonitorDatabase(const char* clusterFilePath) {
+		// The method is implemented only by the local client
+		throw internal_error();
+	}
+
 	virtual void addNetworkThreadCompletionHook(void (*hook)(void*), void* hookParameter) = 0;
 };
 

--- a/fdbclient/LocalClientAPI.h
+++ b/fdbclient/LocalClientAPI.h
@@ -25,4 +25,5 @@
 #include "fdbclient/IClientApi.h"
 
 IClientApi* getLocalClientAPI();
+
 #endif

--- a/fdbclient/MonitorLeader.h
+++ b/fdbclient/MonitorLeader.h
@@ -85,7 +85,8 @@ Future<Void> monitorProxies(
     Reference<AsyncVar<ClientDBInfo>> const& clientInfo,
     Reference<AsyncVar<Optional<ClientLeaderRegInterface>>> const& coordinator,
     Reference<ReferencedObject<Standalone<VectorRef<ClientVersionRef>>>> const& supportedVersions,
-    Key const& traceLogGroup);
+    Key const& traceLogGroup,
+    bool const& monitorClusterFileChanges);
 
 void shrinkProxyList(ClientDBInfo& ni,
                      std::vector<UID>& lastCommitProxyUIDs,

--- a/fdbclient/MultiVersionTransaction.actor.cpp
+++ b/fdbclient/MultiVersionTransaction.actor.cpp
@@ -1702,7 +1702,8 @@ void MultiVersionDatabase::DatabaseState::updateDatabase(Reference<IDatabase> ne
 		} else {
 			// For older clients that don't have an API to get the protocol version, we have to monitor it locally
 			try {
-				versionMonitorDb = MultiVersionApi::api->getLocalClient()->api->createDatabase(clusterFilePath.c_str());
+				versionMonitorDb = MultiVersionApi::api->getLocalClient()->api->createLocalVersionMonitorDatabase(
+				    clusterFilePath.c_str());
 			} catch (Error& e) {
 				// We can't create a new database to monitor the cluster version. This means we will continue using the
 				// previous one, which should hopefully continue to work.
@@ -1715,7 +1716,8 @@ void MultiVersionDatabase::DatabaseState::updateDatabase(Reference<IDatabase> ne
 		// We don't have a database connection, so use the local client to monitor the protocol version
 		db = Reference<IDatabase>();
 		try {
-			versionMonitorDb = MultiVersionApi::api->getLocalClient()->api->createDatabase(clusterFilePath.c_str());
+			versionMonitorDb =
+			    MultiVersionApi::api->getLocalClient()->api->createLocalVersionMonitorDatabase(clusterFilePath.c_str());
 		} catch (Error& e) {
 			// We can't create a new database to monitor the cluster version. This means we will continue using the
 			// previous one, which should hopefully continue to work.

--- a/fdbclient/NativeAPI.actor.h
+++ b/fdbclient/NativeAPI.actor.h
@@ -91,7 +91,8 @@ public:
 	                               int apiVersion,
 	                               IsInternal internal = IsInternal::True,
 	                               LocalityData const& clientLocality = LocalityData(),
-	                               DatabaseContext* preallocatedDb = nullptr);
+	                               DatabaseContext* preallocatedDb = nullptr,
+	                               bool monitorClusterFileChanges = false);
 
 	static Database createDatabase(std::string connFileName,
 	                               int apiVersion,

--- a/fdbclient/ThreadSafeTransaction.h
+++ b/fdbclient/ThreadSafeTransaction.h
@@ -72,7 +72,7 @@ private:
 	DatabaseContext* db;
 
 public: // Internal use only
-	ThreadSafeDatabase(std::string connFilename, int apiVersion);
+	ThreadSafeDatabase(std::string connFilename, int apiVersion, bool monitorClusterFileChanges);
 	ThreadSafeDatabase(DatabaseContext* db) : db(db) {}
 	DatabaseContext* unsafeGetPtr() const { return db; }
 };
@@ -208,6 +208,8 @@ public:
 	void stopNetwork() override;
 
 	Reference<IDatabase> createDatabase(const char* clusterFilePath) override;
+
+	Reference<IDatabase> createLocalVersionMonitorDatabase(const char* clusterFilePath) override;
 
 	void addNetworkThreadCompletionHook(void (*hook)(void*), void* hookParameter) override;
 


### PR DESCRIPTION
FDB 6.3 and older do not provide a stable endpoint for retrieving the protocol version of the cluster. So a 6.3 database connection cannot be used for monitoring cluster version changes. Therefore, the Multi-Version Client (MVC) monitors protocol version change using the local client. The problem is that the local client is not compatible with the cluster it is monitoring, so it does not get notified about coordinator changes. Consequently, if all coordinators of the cluster get replaced, the local client fails to get notified about cluster version changes.

The idea of the fix is to let the local client monitor the cluster file contents that are changed by the external client and so get updated after coordinator changes. Such cluster file monitoring is enabled only in the case the MVC is using the local client for version monitoring. 

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
