### PR TITLE
Don't pop every generation of old log router

### DIFF
--- a/fdbserver/TagPartitionedLogSystem.actor.h
+++ b/fdbserver/TagPartitionedLogSystem.actor.h
@@ -115,6 +115,10 @@ struct TagPartitionedLogSystem final : ILogSystem, ReferenceCounted<TagPartition
 	// sending a pop for anything less than durableKnownCommittedVersion for the TLog will be absurd.
 	std::map<std::pair<UID, Tag>, std::pair<Version, Version>> outstandingPops;
 
+	// Stores each <log router, tag> pair's last popped version. This is used to determine whether we need to pop an old
+	// generation log router.
+	std::map<std::pair<UID, Tag>, Version> logRouterLastPops;
+
 	Optional<PromiseStream<Future<Void>>> addActor;
 	ActorCollection popActors;
 	std::vector<OldLogData> oldLogData; // each element has the log info. in one old epoch.
@@ -246,7 +250,8 @@ struct TagPartitionedLogSystem final : ILogSystem, ReferenceCounted<TagPartition
 	ACTOR static Future<Void> popFromLog(TagPartitionedLogSystem* self,
 	                                     Reference<AsyncVar<OptionalInterface<TLogInterface>>> log,
 	                                     Tag tag,
-	                                     double time);
+	                                     double delayBeforePop,
+	                                     bool popLogRouter);
 
 	ACTOR static Future<Version> getPoppedFromTLog(Reference<AsyncVar<OptionalInterface<TLogInterface>>> log, Tag tag);
 


### PR DESCRIPTION
When there are many txn system generations, one pop from remote tlog to log routers will pop all log routers in all generations (if we have 20 generations, and 10 log routers, those are 200 pop requests generated, for every pop a remote tlog wants to do). This causes the remote tlogs and log routers get overloaded, which makes remote storage catching up even slower.

To solve this issue, we make the remote tlog to only pop the generation that it needs to pop, i.g., if a log router is in charge of version [v1, v2] for a tag, it will only pop that log router until v2 is popped.

Passed 100K joshua test: 20220519-210429-zhewu-lr-fix-5-07dcbd57bd4621d3    compressed=True data_size=32378869 duration=5492543 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=1:24:06 sanity=False started=100116 stopped=20220519-222835 submitted=20220519-210429 timeout=5400 username=zhewu-lr-fix-5

Experiments in a 100 machine cluster shows that the log router has reduced pop CPU. In this experiment, we deliberately generate 30 tlog generations.

Before fix (high pop CPU, blue line. Green line is priority 0):
<img width="2330" alt="Screen Shot 2022-05-20 at 8 59 13 AM" src="https://user-images.githubusercontent.com/9200652/169575800-91a98430-4e46-4540-8474-f998c10aa9d0.png">

After fix (low pop CPU, blue line. Green line is priority 0):
<img width="2332" alt="Screen Shot 2022-05-20 at 8 59 03 AM" src="https://user-images.githubusercontent.com/9200652/169575958-fa99e0bd-0619-4c7b-bfec-3d6d67bf8034.png">




# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
