### PR TITLE
coordinatorsKey should not always store IP addresses (release-7.1).

### DIFF
--- a/fdbclient/AutoPublicAddress.cpp
+++ b/fdbclient/AutoPublicAddress.cpp
@@ -31,7 +31,7 @@
 // Determine public IP address by calling the first available coordinator.
 // If fail connecting all coordinators, throw bind_failed().
 IPAddress determinePublicIPAutomatically(ClusterConnectionString& ccs) {
-	int size = ccs.coordinators().size() + ccs.hostnames.size();
+	int size = ccs.coords.size() + ccs.hostnames.size();
 	int index = 0;
 	loop {
 		try {
@@ -42,10 +42,10 @@ IPAddress determinePublicIPAutomatically(ClusterConnectionString& ccs) {
 
 			NetworkAddress coordAddr;
 			// Try coords first, because they don't need to be resolved.
-			if (index < ccs.coordinators().size()) {
-				coordAddr = ccs.coordinators()[index];
+			if (index < ccs.coords.size()) {
+				coordAddr = ccs.coords[index];
 			} else {
-				Hostname& h = ccs.hostnames[index - ccs.coordinators().size()];
+				Hostname& h = ccs.hostnames[index - ccs.coords.size()];
 				Optional<NetworkAddress> resolvedAddr = h.resolveBlocking();
 				if (!resolvedAddr.present()) {
 					throw lookup_failed();

--- a/fdbclient/CoordinationInterface.h
+++ b/fdbclient/CoordinationInterface.h
@@ -66,7 +66,6 @@ public:
 	ClusterConnectionString(const std::vector<NetworkAddress>& coordinators, Key key);
 	ClusterConnectionString(const std::vector<Hostname>& hosts, Key key);
 
-	std::vector<NetworkAddress> const& coordinators() const { return coords; }
 	Key clusterKey() const { return key; }
 	Key clusterKeyName() const {
 		return keyDesc;

--- a/fdbclient/ManagementAPI.actor.cpp
+++ b/fdbclient/ManagementAPI.actor.cpp
@@ -813,12 +813,12 @@ ACTOR Future<Optional<CoordinatorsResult>> changeQuorumChecker(Transaction* tr,
 	        tr->getDatabase()->getConnectionRecord()->getConnectionString().clusterKeyName())
 		return CoordinatorsResult::BAD_DATABASE_STATE; // Someone changed the "name" of the database??
 
-	if (conn->hostnames.size() + conn->coordinators().size() == 0) {
+	if (conn->hostnames.size() + conn->coords.size() == 0) {
 		conn->hostnames = old.hostnames;
 		conn->coords = old.coords;
 	}
 	std::vector<NetworkAddress> desiredCoordinators = wait(conn->tryResolveHostnames());
-	if (desiredCoordinators.size() != conn->hostnames.size() + conn->coordinators().size()) {
+	if (desiredCoordinators.size() != conn->hostnames.size() + conn->coords.size()) {
 		return CoordinatorsResult::COORDINATOR_UNREACHABLE;
 	}
 

--- a/fdbclient/ManagementAPI.actor.cpp
+++ b/fdbclient/ManagementAPI.actor.cpp
@@ -796,8 +796,8 @@ ACTOR Future<Optional<ClusterConnectionString>> getConnectionString(Database cx)
 }
 
 ACTOR Future<Optional<CoordinatorsResult>> changeQuorumChecker(Transaction* tr,
-                                                               Reference<IQuorumChange> change,
-                                                               std::vector<NetworkAddress> desiredCoordinators) {
+                                                               ClusterConnectionString* conn,
+                                                               std::string newName) {
 	tr->setOption(FDBTransactionOptions::LOCK_AWARE);
 	tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
 	tr->setOption(FDBTransactionOptions::USE_PROVISIONAL_PROXIES);
@@ -813,34 +813,27 @@ ACTOR Future<Optional<CoordinatorsResult>> changeQuorumChecker(Transaction* tr,
 	        tr->getDatabase()->getConnectionRecord()->getConnectionString().clusterKeyName())
 		return CoordinatorsResult::BAD_DATABASE_STATE; // Someone changed the "name" of the database??
 
-	state std::vector<NetworkAddress> oldCoordinators = wait(old.tryResolveHostnames());
-	state CoordinatorsResult result = CoordinatorsResult::SUCCESS;
-	if (!desiredCoordinators.size()) {
-		std::vector<NetworkAddress> _desiredCoordinators = wait(change->getDesiredCoordinators(
-		    tr,
-		    oldCoordinators,
-		    Reference<ClusterConnectionMemoryRecord>(new ClusterConnectionMemoryRecord(old)),
-		    result));
-		desiredCoordinators = _desiredCoordinators;
+	if (conn->hostnames.size() + conn->coordinators().size() == 0) {
+		conn->hostnames = old.hostnames;
+		conn->coords = old.coords;
+	}
+	std::vector<NetworkAddress> desiredCoordinators = wait(conn->tryResolveHostnames());
+	if (desiredCoordinators.size() != conn->hostnames.size() + conn->coordinators().size()) {
+		return CoordinatorsResult::COORDINATOR_UNREACHABLE;
 	}
 
-	if (result != CoordinatorsResult::SUCCESS)
-		return result;
-
-	if (!desiredCoordinators.size())
-		return CoordinatorsResult::INVALID_NETWORK_ADDRESSES;
-
-	std::sort(desiredCoordinators.begin(), desiredCoordinators.end());
-
-	std::string newName = change->getDesiredClusterKeyName();
-	if (newName.empty())
+	if (newName.empty()) {
 		newName = old.clusterKeyName().toString();
-
-	if (oldCoordinators == desiredCoordinators && old.clusterKeyName() == newName)
+	}
+	std::sort(conn->hostnames.begin(), conn->hostnames.end());
+	std::sort(conn->coords.begin(), conn->coords.end());
+	std::sort(old.hostnames.begin(), old.hostnames.end());
+	std::sort(old.coords.begin(), old.coords.end());
+	if (conn->hostnames == old.hostnames && conn->hostnames == old.hostnames && old.clusterKeyName() == newName) {
 		return CoordinatorsResult::SAME_NETWORK_ADDRESSES;
+	}
 
-	state ClusterConnectionString conn(desiredCoordinators,
-	                                   StringRef(newName + ':' + deterministicRandom()->randomAlphaNumeric(32)));
+	conn->parseKey(newName + ':' + deterministicRandom()->randomAlphaNumeric(32));
 
 	if (g_network->isSimulated()) {
 		int i = 0;
@@ -865,19 +858,27 @@ ACTOR Future<Optional<CoordinatorsResult>> changeQuorumChecker(Transaction* tr,
 	}
 
 	std::vector<Future<Optional<LeaderInfo>>> leaderServers;
-	ClientCoordinators coord(Reference<ClusterConnectionMemoryRecord>(new ClusterConnectionMemoryRecord(conn)));
+	ClientCoordinators coord(Reference<ClusterConnectionMemoryRecord>(new ClusterConnectionMemoryRecord(*conn)));
 
 	leaderServers.reserve(coord.clientLeaderServers.size());
-	for (int i = 0; i < coord.clientLeaderServers.size(); i++)
-		leaderServers.push_back(retryBrokenPromise(coord.clientLeaderServers[i].getLeader,
-		                                           GetLeaderRequest(coord.clusterKey, UID()),
-		                                           TaskPriority::CoordinationReply));
+	for (int i = 0; i < coord.clientLeaderServers.size(); i++) {
+		if (coord.clientLeaderServers[i].hostname.present()) {
+			leaderServers.push_back(retryGetReplyFromHostname(GetLeaderRequest(coord.clusterKey, UID()),
+			                                                  coord.clientLeaderServers[i].hostname.get(),
+			                                                  WLTOKEN_CLIENTLEADERREG_GETLEADER,
+			                                                  TaskPriority::CoordinationReply));
+		} else {
+			leaderServers.push_back(retryBrokenPromise(coord.clientLeaderServers[i].getLeader,
+			                                           GetLeaderRequest(coord.clusterKey, UID()),
+			                                           TaskPriority::CoordinationReply));
+		}
+	}
 
 	choose {
 		when(wait(waitForAll(leaderServers))) {}
 		when(wait(delay(5.0))) { return CoordinatorsResult::COORDINATOR_UNREACHABLE; }
 	}
-	tr->set(coordinatorsKey, conn.toString());
+	tr->set(coordinatorsKey, conn->toString());
 	return Optional<CoordinatorsResult>();
 }
 
@@ -1059,11 +1060,29 @@ struct AutoQuorumChange final : IQuorumChange {
 	                                       Reference<IClusterConnectionRecord> ccr,
 	                                       int desiredCount,
 	                                       std::set<AddressExclusion>* excluded) {
+		ClusterConnectionString cs = ccr->getConnectionString();
+		if (oldCoordinators.size() != cs.hostnames.size() + cs.coords.size()) {
+			return false;
+		}
+
 		// Are there enough coordinators for the redundancy level?
 		if (oldCoordinators.size() < desiredCount)
 			return false;
 		if (oldCoordinators.size() % 2 != 1)
 			return false;
+
+		// Check exclusions
+		for (auto& c : oldCoordinators) {
+			if (addressExcluded(*excluded, c))
+				return false;
+		}
+
+		// Check locality
+		// FIXME: Actual locality!
+		std::sort(oldCoordinators.begin(), oldCoordinators.end());
+		for (int i = 1; i < oldCoordinators.size(); i++)
+			if (oldCoordinators[i - 1].ip == oldCoordinators[i].ip)
+				return false; // Multiple coordinators share an IP
 
 		// Check availability
 		ClientCoordinators coord(ccr);
@@ -1091,19 +1110,6 @@ struct AutoQuorumChange final : IQuorumChange {
 				return false; // Coordinator doesn't know about this database?
 			}
 		}
-
-		// Check exclusions
-		for (auto& c : oldCoordinators) {
-			if (addressExcluded(*excluded, c))
-				return false;
-		}
-
-		// Check locality
-		// FIXME: Actual locality!
-		std::sort(oldCoordinators.begin(), oldCoordinators.end());
-		for (int i = 1; i < oldCoordinators.size(); i++)
-			if (oldCoordinators[i - 1].ip == oldCoordinators[i].ip)
-				return false; // Multiple coordinators share an IP
 
 		return true; // The status quo seems fine
 	}
@@ -1146,8 +1152,10 @@ struct AutoQuorumChange final : IQuorumChange {
 
 		if (checkAcceptable) {
 			bool ok = wait(isAcceptable(self.getPtr(), tr, oldCoordinators, ccr, desiredCount, &excluded));
-			if (ok)
+			if (ok) {
+				*err = CoordinatorsResult::SAME_NETWORK_ADDRESSES;
 				return oldCoordinators;
+			}
 		}
 
 		std::vector<NetworkAddress> chosen;

--- a/fdbclient/ManagementAPI.actor.cpp
+++ b/fdbclient/ManagementAPI.actor.cpp
@@ -829,7 +829,7 @@ ACTOR Future<Optional<CoordinatorsResult>> changeQuorumChecker(Transaction* tr,
 	std::sort(conn->coords.begin(), conn->coords.end());
 	std::sort(old.hostnames.begin(), old.hostnames.end());
 	std::sort(old.coords.begin(), old.coords.end());
-	if (conn->hostnames == old.hostnames && conn->hostnames == old.hostnames && old.clusterKeyName() == newName) {
+	if (conn->hostnames == old.hostnames && conn->coords == old.coords && old.clusterKeyName() == newName) {
 		return CoordinatorsResult::SAME_NETWORK_ADDRESSES;
 	}
 

--- a/fdbclient/ManagementAPI.actor.h
+++ b/fdbclient/ManagementAPI.actor.h
@@ -55,8 +55,8 @@ struct IQuorumChange : ReferenceCounted<IQuorumChange> {
 
 // Change to use the given set of coordination servers
 ACTOR Future<Optional<CoordinatorsResult>> changeQuorumChecker(Transaction* tr,
-                                                               Reference<IQuorumChange> change,
-                                                               std::vector<NetworkAddress> desiredCoordinators);
+                                                               ClusterConnectionString* conn,
+                                                               std::string newName);
 ACTOR Future<CoordinatorsResult> changeQuorum(Database cx, Reference<IQuorumChange> change);
 Reference<IQuorumChange> autoQuorumChange(int desired = -1);
 Reference<IQuorumChange> noQuorumChange();

--- a/fdbclient/ManagementAPI.actor.h
+++ b/fdbclient/ManagementAPI.actor.h
@@ -59,8 +59,6 @@ ACTOR Future<Optional<CoordinatorsResult>> changeQuorumChecker(Transaction* tr,
                                                                std::string newName);
 ACTOR Future<CoordinatorsResult> changeQuorum(Database cx, Reference<IQuorumChange> change);
 Reference<IQuorumChange> autoQuorumChange(int desired = -1);
-Reference<IQuorumChange> noQuorumChange();
-Reference<IQuorumChange> specifiedQuorumChange(std::vector<NetworkAddress> const&);
 Reference<IQuorumChange> nameQuorumChange(std::string const& name, Reference<IQuorumChange> const& other);
 
 // Exclude the given set of servers from use as state servers.  Returns as soon as the change is durable, without

--- a/fdbclient/MonitorLeader.actor.cpp
+++ b/fdbclient/MonitorLeader.actor.cpp
@@ -301,7 +301,7 @@ TEST_CASE("/fdbclient/MonitorLeader/PartialResolve") {
 	INetworkConnections::net()->addMockTCPEndpoint(hn, port, { address });
 
 	ClusterConnectionString cs(connectionString);
-	state std::vector<NetworkAddress> allCoordinators = wait(cs.tryResolveHostnames());
+	std::vector<NetworkAddress> allCoordinators = wait(cs.tryResolveHostnames());
 	ASSERT(allCoordinators.size() == 1 &&
 	       std::find(allCoordinators.begin(), allCoordinators.end(), address) != allCoordinators.end());
 

--- a/fdbclient/MonitorLeader.actor.cpp
+++ b/fdbclient/MonitorLeader.actor.cpp
@@ -250,7 +250,7 @@ TEST_CASE("/fdbclient/MonitorLeader/ConnectionString/hostname") {
 
 		ClusterConnectionString cs(hostnames, LiteralStringRef("TestCluster:0"));
 		ASSERT(cs.hostnames.size() == 2);
-		ASSERT(cs.coordinators().size() == 0);
+		ASSERT(cs.coords.size() == 0);
 		ASSERT(cs.toString() == connectionString);
 	}
 
@@ -460,7 +460,7 @@ ClientCoordinators::ClientCoordinators(Reference<IClusterConnectionRecord> ccr) 
 	for (auto h : cs.hostnames) {
 		clientLeaderServers.push_back(ClientLeaderRegInterface(h));
 	}
-	for (auto s : cs.coordinators()) {
+	for (auto s : cs.coords) {
 		clientLeaderServers.push_back(ClientLeaderRegInterface(s));
 	}
 }
@@ -866,7 +866,7 @@ ACTOR Future<MonitorLeaderInfo> monitorProxiesOneGeneration(
     Reference<ReferencedObject<Standalone<VectorRef<ClientVersionRef>>>> supportedVersions,
     Key traceLogGroup) {
 	state ClusterConnectionString cs = info.intermediateConnRecord->getConnectionString();
-	state int coordinatorsSize = cs.hostnames.size() + cs.coordinators().size();
+	state int coordinatorsSize = cs.hostnames.size() + cs.coords.size();
 	state int index = 0;
 	state int successIndex = 0;
 	state Optional<double> incorrectTime;
@@ -880,7 +880,7 @@ ACTOR Future<MonitorLeaderInfo> monitorProxiesOneGeneration(
 	for (const auto& h : cs.hostnames) {
 		clientLeaderServers.push_back(ClientLeaderRegInterface(h));
 	}
-	for (const auto& c : cs.coordinators()) {
+	for (const auto& c : cs.coords) {
 		clientLeaderServers.push_back(ClientLeaderRegInterface(c));
 	}
 
@@ -894,7 +894,7 @@ ACTOR Future<MonitorLeaderInfo> monitorProxiesOneGeneration(
 
 		req.clusterKey = cs.clusterKey();
 		req.hostnames = cs.hostnames;
-		req.coordinators = cs.coordinators();
+		req.coordinators = cs.coords;
 		req.knownClientInfoID = clientInfo->get().id;
 		req.supportedVersions = supportedVersions->get();
 		req.traceLogGroup = traceLogGroup;

--- a/fdbclient/PaxosConfigTransaction.actor.cpp
+++ b/fdbclient/PaxosConfigTransaction.actor.cpp
@@ -409,11 +409,11 @@ public:
 
 	PaxosConfigTransactionImpl(Database const& cx) : cx(cx) {
 		const ClusterConnectionString& cs = cx->getConnectionRecord()->getConnectionString();
-		ctis.reserve(cs.hostnames.size() + cs.coordinators().size());
+		ctis.reserve(cs.hostnames.size() + cs.coords.size());
 		for (const auto& h : cs.hostnames) {
 			ctis.emplace_back(h);
 		}
-		for (const auto& c : cs.coordinators()) {
+		for (const auto& c : cs.coords) {
 			ctis.emplace_back(c);
 		}
 		getGenerationQuorum = GetGenerationQuorum{ ctis };

--- a/fdbclient/SimpleConfigTransaction.actor.cpp
+++ b/fdbclient/SimpleConfigTransaction.actor.cpp
@@ -162,8 +162,8 @@ class SimpleConfigTransactionImpl {
 public:
 	SimpleConfigTransactionImpl(Database const& cx) : cx(cx) {
 		const ClusterConnectionString& cs = cx->getConnectionRecord()->getConnectionString();
-		if (cs.coordinators().size()) {
-			std::vector<NetworkAddress> coordinators = cs.coordinators();
+		if (cs.coords.size()) {
+			std::vector<NetworkAddress> coordinators = cs.coords;
 			std::sort(coordinators.begin(), coordinators.end());
 			cti = ConfigTransactionInterface(coordinators[0]);
 		} else {

--- a/fdbclient/SpecialKeySpace.actor.cpp
+++ b/fdbclient/SpecialKeySpace.actor.cpp
@@ -1674,7 +1674,6 @@ Future<RangeResult> CoordinatorsImpl::getRange(ReadYourWritesTransaction* ryw,
 }
 
 ACTOR static Future<Optional<std::string>> coordinatorsCommitActor(ReadYourWritesTransaction* ryw, KeyRangeRef kr) {
-	state Reference<IQuorumChange> change;
 	state ClusterConnectionString conn; // We don't care about the Key here.
 	state std::vector<std::string> process_address_or_hostname_strs;
 	state Optional<std::string> msg;

--- a/fdbserver/Coordination.actor.cpp
+++ b/fdbserver/Coordination.actor.cpp
@@ -104,7 +104,7 @@ ServerCoordinators::ServerCoordinators(Reference<IClusterConnectionRecord> ccr) 
 		stateServers.emplace_back(h);
 		configServers.emplace_back(h);
 	}
-	for (auto s : cs.coordinators()) {
+	for (auto s : cs.coords) {
 		leaderElectionServers.emplace_back(s);
 		stateServers.emplace_back(s);
 		configServers.emplace_back(s);

--- a/fdbserver/fdbserver.actor.cpp
+++ b/fdbserver/fdbserver.actor.cpp
@@ -855,7 +855,7 @@ std::pair<NetworkAddressList, NetworkAddressList> buildNetworkAddresses(
 	NetworkAddressList listenNetworkAddresses;
 
 	std::vector<Hostname>& hostnames = connectionRecord.getConnectionString().hostnames;
-	const std::vector<NetworkAddress>& coords = connectionRecord.getConnectionString().coordinators();
+	const std::vector<NetworkAddress>& coords = connectionRecord.getConnectionString().coords;
 	ASSERT(hostnames.size() + coords.size() > 0);
 
 	for (int ii = 0; ii < publicAddressStrs.size(); ++ii) {

--- a/fdbserver/worker.actor.cpp
+++ b/fdbserver/worker.actor.cpp
@@ -2670,7 +2670,7 @@ ACTOR Future<MonitorLeaderInfo> monitorLeaderWithDelayedCandidacyImplOneGenerati
     Reference<AsyncVar<Value>> result,
     MonitorLeaderInfo info) {
 	ClusterConnectionString cs = info.intermediateConnRecord->getConnectionString();
-	state int coordinatorsSize = cs.hostnames.size() + cs.coordinators().size();
+	state int coordinatorsSize = cs.hostnames.size() + cs.coords.size();
 	state ElectionResultRequest request;
 	state int index = 0;
 	state int successIndex = 0;
@@ -2680,14 +2680,14 @@ ACTOR Future<MonitorLeaderInfo> monitorLeaderWithDelayedCandidacyImplOneGenerati
 	for (const auto& h : cs.hostnames) {
 		leaderElectionServers.push_back(LeaderElectionRegInterface(h));
 	}
-	for (const auto& c : cs.coordinators()) {
+	for (const auto& c : cs.coords) {
 		leaderElectionServers.push_back(LeaderElectionRegInterface(c));
 	}
 	deterministicRandom()->randomShuffle(leaderElectionServers);
 
 	request.key = cs.clusterKey();
 	request.hostnames = cs.hostnames;
-	request.coordinators = cs.coordinators();
+	request.coordinators = cs.coords;
 
 	loop {
 		LeaderElectionRegInterface interf = leaderElectionServers[index];

--- a/fdbserver/workloads/SpecialKeySpaceCorrectness.actor.cpp
+++ b/fdbserver/workloads/SpecialKeySpaceCorrectness.actor.cpp
@@ -1080,8 +1080,7 @@ struct SpecialKeySpaceCorrectnessWorkload : TestWorkload {
 					ClusterConnectionString csNew(res.get().toString());
 					// verify the cluster decription
 					ASSERT(new_cluster_description == csNew.clusterKeyName().toString());
-					ASSERT(csNew.hostnames.size() + csNew.coords.size() ==
-					       old_coordinators_processes.size() + 1);
+					ASSERT(csNew.hostnames.size() + csNew.coords.size() == old_coordinators_processes.size() + 1);
 					std::vector<NetworkAddress> newCoordinators = wait(csNew.tryResolveHostnames());
 					// verify the coordinators' addresses
 					for (const auto& network_address : newCoordinators) {

--- a/fdbserver/workloads/SpecialKeySpaceCorrectness.actor.cpp
+++ b/fdbserver/workloads/SpecialKeySpaceCorrectness.actor.cpp
@@ -956,7 +956,7 @@ struct SpecialKeySpaceCorrectnessWorkload : TestWorkload {
 				state std::vector<std::string> process_addresses;
 				boost::split(
 				    process_addresses, coordinator_processes_key.get().toString(), [](char c) { return c == ','; });
-				ASSERT(process_addresses.size() == cs.coordinators().size() + cs.hostnames.size());
+				ASSERT(process_addresses.size() == cs.coords.size() + cs.hostnames.size());
 				// compare the coordinator process network addresses one by one
 				std::vector<NetworkAddress> coordinators = wait(cs.tryResolveHostnames());
 				for (const auto& network_address : coordinators) {
@@ -1080,7 +1080,7 @@ struct SpecialKeySpaceCorrectnessWorkload : TestWorkload {
 					ClusterConnectionString csNew(res.get().toString());
 					// verify the cluster decription
 					ASSERT(new_cluster_description == csNew.clusterKeyName().toString());
-					ASSERT(csNew.hostnames.size() + csNew.coordinators().size() ==
+					ASSERT(csNew.hostnames.size() + csNew.coords.size() ==
 					       old_coordinators_processes.size() + 1);
 					std::vector<NetworkAddress> newCoordinators = wait(csNew.tryResolveHostnames());
 					// verify the coordinators' addresses

--- a/flow/Net2.actor.cpp
+++ b/flow/Net2.actor.cpp
@@ -1856,35 +1856,34 @@ ACTOR static Future<std::vector<NetworkAddress>> resolveTCPEndpoint_impl(Net2* s
 	Promise<std::vector<NetworkAddress>> promise;
 	state Future<std::vector<NetworkAddress>> result = promise.getFuture();
 
-	tcpResolver.async_resolve(tcp::resolver::query(host, service),
-	                          [=](const boost::system::error_code& ec, tcp::resolver::iterator iter) {
-		                          if (ec) {
-			                          self->dnsCache.remove(host, service);
-			                          promise.sendError(lookup_failed());
-			                          return;
-		                          }
+	tcpResolver.async_resolve(host, service, [=](const boost::system::error_code& ec, tcp::resolver::iterator iter) {
+		if (ec) {
+			self->dnsCache.remove(host, service);
+			promise.sendError(lookup_failed());
+			return;
+		}
 
-		                          std::vector<NetworkAddress> addrs;
+		std::vector<NetworkAddress> addrs;
 
-		                          tcp::resolver::iterator end;
-		                          while (iter != end) {
-			                          auto endpoint = iter->endpoint();
-			                          auto addr = endpoint.address();
-			                          if (addr.is_v6()) {
-				                          addrs.emplace_back(IPAddress(addr.to_v6().to_bytes()), endpoint.port());
-			                          } else {
-				                          addrs.emplace_back(addr.to_v4().to_ulong(), endpoint.port());
-			                          }
-			                          ++iter;
-		                          }
+		tcp::resolver::iterator end;
+		while (iter != end) {
+			auto endpoint = iter->endpoint();
+			auto addr = endpoint.address();
+			if (addr.is_v6()) {
+				addrs.emplace_back(IPAddress(addr.to_v6().to_bytes()), endpoint.port());
+			} else {
+				addrs.emplace_back(addr.to_v4().to_ulong(), endpoint.port());
+			}
+			++iter;
+		}
 
-		                          if (addrs.empty()) {
-			                          self->dnsCache.remove(host, service);
-			                          promise.sendError(lookup_failed());
-		                          } else {
-			                          promise.send(addrs);
-		                          }
-	                          });
+		if (addrs.empty()) {
+			self->dnsCache.remove(host, service);
+			promise.sendError(lookup_failed());
+		} else {
+			promise.send(addrs);
+		}
+	});
 
 	wait(ready(result));
 	tcpResolver.cancel();


### PR DESCRIPTION
PR on main: #7204.

Currently, when we do a commit of coordinator change, we are always converting hostnames to IP addresses and store the converted results in coordinatorsKey (\xff/coordinators). This result in ForwardRequest also sending IP addresses, and receivers will update their cluster files with IPs, then we lose the dynamic IP feature.

20220520-064954-renxuan-cc1823b4dbede152           compressed=True data_size=31492695 duration=5119224 ended=100001 fail=1 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=0:48:20 sanity=False started=100110 stopped=20220520-073814 submitted=20220520-064954 timeout=5400 username=renxuan

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
