### PR TITLE
Make EncryptKeyServer and KmsConnector API to be 'tenant' name aware

### DIFF
--- a/fdbserver/KmsConnectorInterface.h
+++ b/fdbserver/KmsConnectorInterface.h
@@ -98,21 +98,44 @@ struct KmsConnLookupEKsByKeyIdsRep {
 	}
 };
 
+struct KmsConnLookupKeyIdsReqInfo {
+	constexpr static FileIdentifier file_identifier = 3092256;
+	EncryptCipherDomainId domainId;
+	EncryptCipherBaseKeyId baseCipherId;
+	EncryptCipherDomainName domainName;
+
+	KmsConnLookupKeyIdsReqInfo() : domainId(ENCRYPT_INVALID_DOMAIN_ID), baseCipherId(ENCRYPT_INVALID_CIPHER_KEY_ID) {}
+	explicit KmsConnLookupKeyIdsReqInfo(const EncryptCipherDomainId dId,
+	                                    const EncryptCipherBaseKeyId bCId,
+	                                    StringRef name,
+	                                    Arena& arena)
+	  : domainId(dId), baseCipherId(bCId), domainName(StringRef(arena, name)) {}
+
+	bool operator==(const KmsConnLookupKeyIdsReqInfo& info) const {
+		return domainId == info.domainId && baseCipherId == info.baseCipherId &&
+		       (domainName.compare(info.domainName) == 0);
+	}
+
+	template <class Ar>
+	void serialize(Ar& ar) {
+		serializer(ar, domainId, baseCipherId, domainName);
+	}
+};
+
 struct KmsConnLookupEKsByKeyIdsReq {
 	constexpr static FileIdentifier file_identifier = 6913396;
-	std::vector<std::pair<EncryptCipherBaseKeyId, EncryptCipherDomainId>> encryptKeyIds;
+	Arena arena;
+	std::vector<KmsConnLookupKeyIdsReqInfo> encryptKeyInfos;
 	Optional<UID> debugId;
 	ReplyPromise<KmsConnLookupEKsByKeyIdsRep> reply;
 
 	KmsConnLookupEKsByKeyIdsReq() {}
-	explicit KmsConnLookupEKsByKeyIdsReq(
-	    const std::vector<std::pair<EncryptCipherBaseKeyId, EncryptCipherDomainId>>& keyIds,
-	    Optional<UID> dbgId)
-	  : encryptKeyIds(keyIds), debugId(dbgId) {}
+	explicit KmsConnLookupEKsByKeyIdsReq(const std::vector<KmsConnLookupKeyIdsReqInfo>& keyInfos, Optional<UID> dbgId)
+	  : encryptKeyInfos(keyInfos), debugId(dbgId) {}
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, encryptKeyIds, debugId, reply);
+		serializer(ar, arena, encryptKeyInfos, debugId, reply);
 	}
 };
 
@@ -129,19 +152,40 @@ struct KmsConnLookupEKsByDomainIdsRep {
 	}
 };
 
+struct KmsConnLookupDomainIdsReqInfo {
+	constexpr static FileIdentifier file_identifier = 8980149;
+	EncryptCipherDomainId domainId;
+	EncryptCipherDomainName domainName;
+
+	KmsConnLookupDomainIdsReqInfo() : domainId(ENCRYPT_INVALID_DOMAIN_ID) {}
+	explicit KmsConnLookupDomainIdsReqInfo(const EncryptCipherDomainId dId, StringRef name, Arena& arena)
+	  : domainId(dId), domainName(StringRef(arena, name)) {}
+
+	bool operator==(const KmsConnLookupDomainIdsReqInfo& info) const {
+		return domainId == info.domainId && (domainName.compare(info.domainName) == 0);
+	}
+
+	template <class Ar>
+	void serialize(Ar& ar) {
+		serializer(ar, domainId, domainName);
+	}
+};
+
 struct KmsConnLookupEKsByDomainIdsReq {
 	constexpr static FileIdentifier file_identifier = 9918682;
-	std::vector<EncryptCipherDomainId> encryptDomainIds;
+	Arena arena;
+	std::vector<KmsConnLookupDomainIdsReqInfo> encryptDomainInfos;
 	Optional<UID> debugId;
 	ReplyPromise<KmsConnLookupEKsByDomainIdsRep> reply;
 
 	KmsConnLookupEKsByDomainIdsReq() {}
-	explicit KmsConnLookupEKsByDomainIdsReq(const std::vector<EncryptCipherDomainId>& ids, Optional<UID> dbgId)
-	  : encryptDomainIds(ids), debugId(dbgId) {}
+	explicit KmsConnLookupEKsByDomainIdsReq(const std::vector<KmsConnLookupDomainIdsReqInfo>& infos,
+	                                        Optional<UID> dbgId)
+	  : encryptDomainInfos(infos), debugId(dbgId) {}
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, encryptDomainIds, debugId, reply);
+		serializer(ar, arena, encryptDomainInfos, debugId, reply);
 	}
 };
 

--- a/fdbserver/RESTKmsConnector.actor.cpp
+++ b/fdbserver/RESTKmsConnector.actor.cpp
@@ -40,6 +40,7 @@
 #include "flow/UnitTest.h"
 
 #include <boost/algorithm/string.hpp>
+#include <cstring>
 #include <memory>
 #include <queue>
 #include <sstream>
@@ -53,6 +54,7 @@ const char* BASE_CIPHER_ID_TAG = "base_cipher_id";
 const char* BASE_CIPHER_TAG = "baseCipher";
 const char* CIPHER_KEY_DETAILS_TAG = "cipher_key_details";
 const char* ENCRYPT_DOMAIN_ID_TAG = "encrypt_domain_id";
+const char* ENCRYPT_DOMAIN_NAME_TAG = "encrypt_domain_name";
 const char* ERROR_TAG = "error";
 const char* ERROR_MSG_TAG = "errMsg";
 const char* ERROR_CODE_TAG = "errCode";
@@ -271,9 +273,9 @@ void parseKmsResponse(Reference<RESTKmsConnectorCtx> ctx,
 	// response_json_payload {
 	//   "cipher_key_details" : [
 	//     {
-	//        "base_cipher_id" : <cipherKeyId>,
+	//        "base_cipher_id"    : <cipherKeyId>,
 	//        "encrypt_domain_id" : <domainId>,
-	//        "base_cipher" : <baseCipher>
+	//        "base_cipher"       : <baseCipher>
 	//     },
 	//     {
 	//         ....
@@ -438,8 +440,9 @@ StringRef getEncryptKeysByKeyIdsRequestBody(Reference<RESTKmsConnectorCtx> ctx,
 	//   "query_mode": "lookupByKeyId" / "lookupByDomainId"
 	//   "cipher_key_details" = [
 	//     {
-	//        "base_cipher_id" : <cipherKeyId>
-	//        "encrypt_domain_id" : <domainId>
+	//        "base_cipher_id"      : <cipherKeyId>
+	//        "encrypt_domain_id"   : <domainId>
+	//        "encrypt_domain_name" : <domainName>
 	//     },
 	//     {
 	//         ....
@@ -466,20 +469,26 @@ StringRef getEncryptKeysByKeyIdsRequestBody(Reference<RESTKmsConnectorCtx> ctx,
 
 	// Append 'cipher_key_details' as json array
 	rapidjson::Value keyIdDetails(rapidjson::kArrayType);
-	for (const auto& detail : req.encryptKeyIds) {
+	for (const auto& detail : req.encryptKeyInfos) {
 		rapidjson::Value keyIdDetail(rapidjson::kObjectType);
 
 		// Add 'base_cipher_id'
 		rapidjson::Value key(BASE_CIPHER_ID_TAG, doc.GetAllocator());
 		rapidjson::Value baseKeyId;
-		baseKeyId.SetUint64(detail.first);
+		baseKeyId.SetUint64(detail.baseCipherId);
 		keyIdDetail.AddMember(key, baseKeyId, doc.GetAllocator());
 
-		// Add 'encrypt_domainId'
+		// Add 'encrypt_domain_id'
 		key.SetString(ENCRYPT_DOMAIN_ID_TAG, doc.GetAllocator());
 		rapidjson::Value domainId;
-		domainId.SetInt64(detail.second);
+		domainId.SetInt64(detail.domainId);
 		keyIdDetail.AddMember(key, domainId, doc.GetAllocator());
+
+		// Add 'encrypt_domain_name'
+		key.SetString(ENCRYPT_DOMAIN_NAME_TAG, doc.GetAllocator());
+		rapidjson::Value domainName;
+		domainName.SetString(detail.domainName.toString().c_str(), detail.domainName.size(), doc.GetAllocator());
+		keyIdDetail.AddMember(key, domainName, doc.GetAllocator());
 
 		// push above object to the array
 		keyIdDetails.PushBack(keyIdDetail, doc.GetAllocator());
@@ -593,7 +602,8 @@ StringRef getEncryptKeysByDomainIdsRequestBody(Reference<RESTKmsConnectorCtx> ct
 	//   "query_mode": "lookupByKeyId" / "lookupByDomainId"
 	//   "cipher_key_details" = [
 	//     {
-	//        "encrypt_domainId" : <domainId>
+	//        "encrypt_domain_id"   : <domainId>
+	//        "encrypt_domain_name" : <domainName>
 	//     },
 	//     {
 	//         ....
@@ -620,13 +630,19 @@ StringRef getEncryptKeysByDomainIdsRequestBody(Reference<RESTKmsConnectorCtx> ct
 
 	// Append 'cipher_key_details' as json array
 	rapidjson::Value keyIdDetails(rapidjson::kArrayType);
-	for (const auto& detail : req.encryptDomainIds) {
+	for (const auto& detail : req.encryptDomainInfos) {
 		rapidjson::Value keyIdDetail(rapidjson::kObjectType);
 
 		rapidjson::Value key(ENCRYPT_DOMAIN_ID_TAG, doc.GetAllocator());
 		rapidjson::Value domainId;
-		domainId.SetInt64(detail);
+		domainId.SetInt64(detail.domainId);
 		keyIdDetail.AddMember(key, domainId, doc.GetAllocator());
+
+		// Add 'encrypt_domain_name'
+		key.SetString(ENCRYPT_DOMAIN_NAME_TAG, doc.GetAllocator());
+		rapidjson::Value domainName;
+		domainName.SetString(detail.domainName.toString().c_str(), detail.domainName.size(), doc.GetAllocator());
+		keyIdDetail.AddMember(key, domainName, doc.GetAllocator());
 
 		// push above object to the array
 		keyIdDetails.PushBack(keyIdDetail, doc.GetAllocator());
@@ -1041,7 +1057,10 @@ void testGetEncryptKeysByKeyIdsRequestBody(Reference<RESTKmsConnectorCtx> ctx, A
 	const int nKeys = deterministicRandom()->randomInt(7, 8);
 	for (int i = 1; i < nKeys; i++) {
 		EncryptCipherDomainId domainId = getRandomDomainId();
-		req.encryptKeyIds.push_back(std::make_pair(i, domainId));
+		EncryptCipherDomainName domainName = domainId < 0
+		                                         ? StringRef(arena, std::string(FDB_DEFAULT_ENCRYPT_DOMAIN_NAME))
+		                                         : StringRef(arena, std::to_string(domainId));
+		req.encryptKeyInfos.emplace_back(KmsConnLookupKeyIdsReqInfo(domainId, i, domainName, req.arena));
 		keyMap[i] = domainId;
 	}
 
@@ -1073,12 +1092,18 @@ void testGetEncryptKeysByKeyIdsRequestBody(Reference<RESTKmsConnectorCtx> ctx, A
 
 void testGetEncryptKeysByDomainIdsRequestBody(Reference<RESTKmsConnectorCtx> ctx, Arena arena) {
 	KmsConnLookupEKsByDomainIdsReq req;
-	std::unordered_set<EncryptCipherDomainId> domainIdsSet;
+	std::unordered_map<EncryptCipherDomainId, KmsConnLookupDomainIdsReqInfo> domainInfoMap;
 	const int nKeys = deterministicRandom()->randomInt(7, 25);
 	for (int i = 1; i < nKeys; i++) {
-		domainIdsSet.emplace(getRandomDomainId());
+		EncryptCipherDomainId domainId = getRandomDomainId();
+		EncryptCipherDomainName domainName = domainId < 0
+		                                         ? StringRef(arena, std::string(FDB_DEFAULT_ENCRYPT_DOMAIN_NAME))
+		                                         : StringRef(arena, std::to_string(domainId));
+		KmsConnLookupDomainIdsReqInfo reqInfo(domainId, domainName, req.arena);
+		if (domainInfoMap.insert({ domainId, reqInfo }).second) {
+			req.encryptDomainInfos.emplace_back(reqInfo);
+		}
 	}
-	req.encryptDomainIds.insert(req.encryptDomainIds.begin(), domainIdsSet.begin(), domainIdsSet.end());
 
 	bool refreshKmsUrls = deterministicRandom()->randomInt(0, 100) < 50;
 
@@ -1091,9 +1116,9 @@ void testGetEncryptKeysByDomainIdsRequestBody(Reference<RESTKmsConnectorCtx> ctx
 
 	std::vector<EncryptCipherKeyDetails> cipherDetails;
 	parseKmsResponse(ctx, httpResp, &arena, &cipherDetails);
-	ASSERT_EQ(domainIdsSet.size(), cipherDetails.size());
+	ASSERT_EQ(domainInfoMap.size(), cipherDetails.size());
 	for (const auto& detail : cipherDetails) {
-		ASSERT(domainIdsSet.find(detail.encryptDomainId) != domainIdsSet.end());
+		ASSERT(domainInfoMap.find(detail.encryptDomainId) != domainInfoMap.end());
 		ASSERT_EQ(detail.encryptKey.size(), sizeof(BASE_CIPHER_KEY_TEST));
 		ASSERT_EQ(memcmp(detail.encryptKey.begin(), &BASE_CIPHER_KEY_TEST[0], sizeof(BASE_CIPHER_KEY_TEST)), 0);
 	}

--- a/flow/EncryptUtils.cpp
+++ b/flow/EncryptUtils.cpp
@@ -19,20 +19,22 @@
  */
 
 #include "flow/EncryptUtils.h"
+
 #include "flow/Trace.h"
 
 #include <boost/format.hpp>
 
 std::string getEncryptDbgTraceKey(std::string_view prefix,
                                   EncryptCipherDomainId domainId,
+                                  StringRef domainName,
                                   Optional<EncryptCipherBaseKeyId> baseCipherId) {
 	// Construct the TraceEvent field key ensuring its uniqueness and compliance to TraceEvent field validator and log
 	// parsing tools
 	if (baseCipherId.present()) {
-		boost::format fmter("%s.%lld.%llu");
-		return boost::str(boost::format(fmter % prefix % domainId % baseCipherId.get()));
+		boost::format fmter("%s.%lld.%s.%llu");
+		return boost::str(boost::format(fmter % prefix % domainId % domainName.toString() % baseCipherId.get()));
 	} else {
-		boost::format fmter("%s.%lld");
-		return boost::str(boost::format(fmter % prefix % domainId));
+		boost::format fmter("%s.%lld.%s");
+		return boost::str(boost::format(fmter % prefix % domainId % domainName.toString()));
 	}
 }

--- a/flow/EncryptUtils.h
+++ b/flow/EncryptUtils.h
@@ -37,8 +37,10 @@
 
 #define SYSTEM_KEYSPACE_ENCRYPT_DOMAIN_ID -1
 #define ENCRYPT_HEADER_DOMAIN_ID -2
+#define FDB_DEFAULT_ENCRYPT_DOMAIN_NAME "FdbDefaultEncryptDomain"
 
 using EncryptCipherDomainId = int64_t;
+using EncryptCipherDomainName = StringRef;
 using EncryptCipherBaseKeyId = uint64_t;
 using EncryptCipherRandomSalt = uint64_t;
 
@@ -76,5 +78,7 @@ constexpr std::string_view ENCRYPT_DBG_TRACE_RESULT_PREFIX = "Res";
 // Utility interface to construct TraceEvent key for debugging
 std::string getEncryptDbgTraceKey(std::string_view prefix,
                                   EncryptCipherDomainId domainId,
+                                  StringRef domainName,
                                   Optional<EncryptCipherBaseKeyId> baseCipherId = Optional<EncryptCipherBaseKeyId>());
+
 #endif


### PR DESCRIPTION
Description

Major changes proposed include:
1. Update EncryptKeyServer APIs to be tenant aware.
2. Update KmsConnector APIs to be tenant aware

Client of above APIs such as: CP, SS and BlobWorker need to supply
encryption domain info that includes: tenantId and tenantName

Testing

1. Update EncryptKeyProxyTest
2. Update RESTKmsConnectorTest
3. Update SimKmsConnectorTest

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
