### PR TITLE
Fix a heap-use-after-free in a unit test

### DIFF
--- a/fdbserver/worker.actor.cpp
+++ b/fdbserver/worker.actor.cpp
@@ -2706,8 +2706,8 @@ ACTOR Future<Void> updateNewestSoftwareVersion(std::string folder,
 		    0600));
 
 		SWVersion swVersion(latestVersion, currentVersion, minCompatibleVersion);
-		auto s = swVersionValue(swVersion);
-		ErrorOr<Void> e = wait(errorOr(newVersionFile->write(s.toString().c_str(), s.size(), 0)));
+		state Standalone<StringRef> s = swVersionValue(swVersion);
+		ErrorOr<Void> e = wait(errorOr(newVersionFile->write(s.begin(), s.size(), 0)));
 		if (e.isError()) {
 			throw e.getError();
 		}

--- a/fdbserver/worker.actor.cpp
+++ b/fdbserver/worker.actor.cpp
@@ -2706,8 +2706,8 @@ ACTOR Future<Void> updateNewestSoftwareVersion(std::string folder,
 		    0600));
 
 		SWVersion swVersion(latestVersion, currentVersion, minCompatibleVersion);
-		state Standalone<StringRef> s = swVersionValue(swVersion);
-		ErrorOr<Void> e = wait(errorOr(newVersionFile->write(s.begin(), s.size(), 0)));
+		Value s = swVersionValue(swVersion);
+		ErrorOr<Void> e = wait(holdWhile(s, errorOr(newVersionFile->write(s.begin(), s.size(), 0))));
 		if (e.isError()) {
 			throw e.getError();
 		}


### PR DESCRIPTION
The data passed to IAsyncFile::write must remain valid until the future
is ready.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
