### PR TITLE
Work around flow trace's data race bug

### DIFF
--- a/flow/MkCertCli.cpp
+++ b/flow/MkCertCli.cpp
@@ -281,11 +281,12 @@ int main(int argc, char** argv) {
 		auto thread = std::thread([]() {
 			TraceEvent::setNetworkThread();
 			g_network->run();
+			flushTraceFileVoid();
 		});
 		auto cleanUpGuard = ScopeExit([&thread]() {
-			flushTraceFileVoid();
 			g_network->stop();
 			thread.join();
+			closeTraceFile();
 		});
 
 		serverArgs.transformPathToAbs();

--- a/flow/MkCertCli.cpp
+++ b/flow/MkCertCli.cpp
@@ -278,9 +278,7 @@ int main(int argc, char** argv) {
 		Error::init();
 		g_network = newNet2(TLSConfig());
 		openTraceFile(NetworkAddress(), 10 << 20, 10 << 20, ".", "mkcert");
-		auto thread = std::thread([]() {
-			g_network->run();
-		});
+		auto thread = std::thread([]() { g_network->run(); });
 		auto cleanUpGuard = ScopeExit([&thread]() {
 			g_network->stop();
 			thread.join();

--- a/flow/MkCertCli.cpp
+++ b/flow/MkCertCli.cpp
@@ -279,9 +279,7 @@ int main(int argc, char** argv) {
 		g_network = newNet2(TLSConfig());
 		openTraceFile(NetworkAddress(), 10 << 20, 10 << 20, ".", "mkcert");
 		auto thread = std::thread([]() {
-			TraceEvent::setNetworkThread();
 			g_network->run();
-			flushTraceFileVoid();
 		});
 		auto cleanUpGuard = ScopeExit([&thread]() {
 			g_network->stop();


### PR DESCRIPTION
BaseTraceEvent::setNetworkThread() and flushTraceFile[()|Void()]
has a long-standing race condition for traceEventThrottlerCache global
when flushTraceFileVoid() is not called from the network thread.

This race dates back to 2017 (commit hash 80e5fecfe2),
so before the race itself is fixed, work around the problem.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
