### PR TITLE
blob granule - tenant integration

### DIFF
--- a/fdbclient/BlobGranuleCommon.h
+++ b/fdbclient/BlobGranuleCommon.h
@@ -82,6 +82,7 @@ struct BlobGranuleChunkRef {
 	Optional<BlobFilePointerRef> snapshotFile; // not set if it's an incremental read
 	VectorRef<BlobFilePointerRef> deltaFiles;
 	GranuleDeltas newDeltas;
+	Optional<StringRef> tenantPrefix;
 
 	template <class Ar>
 	void serialize(Ar& ar) {

--- a/fdbclient/BlobGranuleCommon.h
+++ b/fdbclient/BlobGranuleCommon.h
@@ -86,7 +86,7 @@ struct BlobGranuleChunkRef {
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, keyRange, includedVersion, snapshotVersion, snapshotFile, deltaFiles, newDeltas);
+		serializer(ar, keyRange, includedVersion, snapshotVersion, snapshotFile, deltaFiles, newDeltas, tenantPrefix);
 	}
 };
 

--- a/fdbclient/BlobGranuleCommon.h
+++ b/fdbclient/BlobGranuleCommon.h
@@ -82,7 +82,7 @@ struct BlobGranuleChunkRef {
 	Optional<BlobFilePointerRef> snapshotFile; // not set if it's an incremental read
 	VectorRef<BlobFilePointerRef> deltaFiles;
 	GranuleDeltas newDeltas;
-	Optional<StringRef> tenantPrefix;
+	Optional<KeyRef> tenantPrefix;
 
 	template <class Ar>
 	void serialize(Ar& ar) {

--- a/fdbclient/BlobGranuleFiles.cpp
+++ b/fdbclient/BlobGranuleFiles.cpp
@@ -203,8 +203,7 @@ RangeResult materializeBlobGranule(const BlobGranuleChunkRef& chunk,
 	Version lastFileEndVersion = invalidVersion;
 	KeyRange requestRange;
 	if (chunk.tenantPrefix.present()) {
-		requestRange = KeyRangeRef(keyRange.begin.withPrefix(chunk.tenantPrefix.get()),
-		                           keyRange.end.withPrefix(chunk.tenantPrefix.get()));
+		requestRange = keyRange.withPrefix(chunk.tenantPrefix.get());
 	} else {
 		requestRange = keyRange;
 	}

--- a/fdbclient/BlobGranuleFiles.cpp
+++ b/fdbclient/BlobGranuleFiles.cpp
@@ -222,7 +222,10 @@ RangeResult materializeBlobGranule(const BlobGranuleChunkRef& chunk,
 
 	RangeResult ret;
 	for (auto& it : dataMap) {
-		ret.push_back_deep(ret.arena(), KeyValueRef(it.first, it.second));
+		ret.push_back_deep(
+		    ret.arena(),
+		    KeyValueRef(chunk.tenantPrefix.present() ? it.first.removePrefix(chunk.tenantPrefix.get()) : it.first,
+		                it.second));
 	}
 
 	return ret;

--- a/fdbclient/BlobWorkerInterface.h
+++ b/fdbclient/BlobWorkerInterface.h
@@ -26,6 +26,7 @@
 #include "fdbclient/FDBTypes.h"
 #include "fdbrpc/fdbrpc.h"
 #include "fdbrpc/Locality.h"
+#include "fdbclient/StorageServerInterface.h" // for TenantInfo - should we refactor that elsewhere?
 
 struct BlobWorkerInterface {
 	constexpr static FileIdentifier file_identifier = 8358753;
@@ -104,13 +105,14 @@ struct BlobGranuleFileRequest {
 	Version beginVersion = 0;
 	Version readVersion;
 	bool canCollapseBegin = true;
+	TenantInfo tenantInfo;
 	ReplyPromise<BlobGranuleFileReply> reply;
 
 	BlobGranuleFileRequest() {}
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, keyRange, beginVersion, readVersion, canCollapseBegin, reply, arena);
+		serializer(ar, keyRange, beginVersion, readVersion, canCollapseBegin, tenantInfo, reply, arena);
 	}
 };
 

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -7476,6 +7476,27 @@ ACTOR Future<Standalone<VectorRef<KeyRef>>> getRangeSplitPoints(Reference<Transa
 	}
 }
 
+// kind of a hack, but necessary to work around needing to access system keys in a tenant-enabled transaction
+ACTOR Future<TenantMapEntry> blobGranuleGetTenantEntry(Transaction* self, Key rangeStartKey) {
+	Optional<KeyRangeLocationInfo> cachedLocationInfo =
+	    self->trState->cx->getCachedLocation(self->getTenant().get(), rangeStartKey, Reverse::False);
+	if (!cachedLocationInfo.present()) {
+		KeyRangeLocationInfo l = wait(getKeyLocation_internal(self->trState->cx,
+		                                                      self->getTenant().get(),
+		                                                      rangeStartKey,
+		                                                      self->trState->spanContext,
+		                                                      self->trState->debugID,
+		                                                      self->trState->useProvisionalProxies,
+		                                                      Reverse::False,
+		                                                      latestVersion));
+		self->trState->tenantId = l.tenantEntry.id;
+		return l.tenantEntry;
+	} else {
+		self->trState->tenantId = cachedLocationInfo.get().tenantEntry.id;
+		return cachedLocationInfo.get().tenantEntry;
+	}
+}
+
 Future<Standalone<VectorRef<KeyRef>>> Transaction::getRangeSplitPoints(KeyRange const& keys, int64_t chunkSize) {
 	return ::getRangeSplitPoints(
 	    trState, keys, chunkSize, readVersion.isValid() && readVersion.isReady() ? readVersion.get() : latestVersion);
@@ -7537,6 +7558,7 @@ ACTOR Future<Standalone<VectorRef<BlobGranuleChunkRef>>> readBlobGranulesActor(
 	state UID workerId;
 	state int i;
 	state Version rv;
+	state Optional<Key> tenantPrefix;
 
 	state Standalone<VectorRef<BlobGranuleChunkRef>> results;
 	state double startTime = now();
@@ -7547,14 +7569,46 @@ ACTOR Future<Standalone<VectorRef<BlobGranuleChunkRef>>> readBlobGranulesActor(
 		Version _end = wait(self->getReadVersion());
 		rv = _end;
 	}
-	self->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
+
 	// Right now just read whole blob range assignments from DB
 	// FIXME: eventually we probably want to cache this and invalidate similarly to storage servers.
 	// Cache misses could still read from the DB, or we could add it to the Transaction State Store and
 	// have proxies serve it from memory.
-	RangeResult _bgMapping =
-	    wait(krmGetRanges(self, blobGranuleMappingKeys.begin, keyRange, 1000, GetRangeLimits::BYTE_LIMIT_UNLIMITED));
-	blobGranuleMapping = _bgMapping;
+	if (BG_REQUEST_DEBUG) {
+		fmt::print("Doing blob granule request [{0} - {1}) @ {2}{3}\n",
+		           range.begin.printable(),
+		           range.end.printable(),
+		           rv,
+		           self->getTenant().present() ? " for tenant " + self->getTenant().get().printable() : "");
+	}
+
+	if (self->getTenant().present()) {
+		// have to bypass tenant to read system key space, and add tenant prefix to part of mapping
+		TenantMapEntry tenantEntry = wait(blobGranuleGetTenantEntry(self, range.begin));
+		tenantPrefix = tenantEntry.prefix;
+		Standalone<StringRef> mappingPrefix = tenantEntry.prefix.withPrefix(blobGranuleMappingKeys.begin);
+
+		// basically krmGetRange, but enable it to not use tenant without RAW_ACCESS by doing manual getRange with
+		// UseTenant::False
+		GetRangeLimits limits(1000);
+		limits.minRows = 2;
+		RangeResult rawMapping = wait(getRange(self->trState,
+		                                       self->getReadVersion(),
+		                                       lastLessOrEqual(keyRange.begin.withPrefix(mappingPrefix)),
+		                                       firstGreaterThan(keyRange.end.withPrefix(mappingPrefix)),
+		                                       limits,
+		                                       Reverse::False,
+		                                       UseTenant::False));
+		// strip off mapping prefix
+		Standalone<StringRef> prefix =
+		    StringRef(blobGranuleMappingKeys.begin.toString() + tenantPrefix.get().toString());
+		blobGranuleMapping = krmDecodeRanges(prefix, range, rawMapping);
+	} else {
+		self->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
+		wait(store(
+		    blobGranuleMapping,
+		    krmGetRanges(self, blobGranuleMappingKeys.begin, keyRange, 1000, GetRangeLimits::BYTE_LIMIT_UNLIMITED)));
+	}
 	if (blobGranuleMapping.more) {
 		if (BG_REQUEST_DEBUG) {
 			fmt::print(
@@ -7565,10 +7619,7 @@ ACTOR Future<Standalone<VectorRef<BlobGranuleChunkRef>>> readBlobGranulesActor(
 	}
 	ASSERT(!blobGranuleMapping.more && blobGranuleMapping.size() < CLIENT_KNOBS->TOO_MANY);
 
-	if (blobGranuleMapping.size() == 0) {
-		if (BG_REQUEST_DEBUG) {
-			printf("no blob worker assignments yet\n");
-		}
+	if (blobGranuleMapping.size() < 2) {
 		throw blob_granule_transaction_too_old();
 	}
 
@@ -7605,7 +7656,15 @@ ACTOR Future<Standalone<VectorRef<BlobGranuleChunkRef>>> readBlobGranulesActor(
 		}
 
 		if (!self->trState->cx->blobWorker_interf.count(workerId)) {
-			Optional<Value> workerInterface = wait(self->get(blobWorkerListKeyFor(workerId)));
+			state Optional<Value> workerInterface;
+			if (self->getTenant().present()) {
+				// again, have to bypass system keys and tenant requirements
+				wait(store(
+				    workerInterface,
+				    getValue(self->trState, blobWorkerListKeyFor(workerId), self->getReadVersion(), UseTenant::False)));
+			} else {
+				wait(store(workerInterface, self->get(blobWorkerListKeyFor(workerId))));
+			}
 			// from the time the mapping was read from the db, the associated blob worker
 			// could have died and so its interface wouldn't be present as part of the blobWorkerList
 			// we persist in the db. So throw wrong_shard_server to get the new mapping
@@ -7643,7 +7702,7 @@ ACTOR Future<Standalone<VectorRef<BlobGranuleChunkRef>>> readBlobGranulesActor(
 		req.keyRange = KeyRangeRef(StringRef(req.arena, granuleStartKey), StringRef(req.arena, granuleEndKey));
 		req.beginVersion = begin;
 		req.readVersion = rv;
-		req.tenantInfo = self->trState->getTenantInfo();
+		req.tenantInfo = self->getTenant().present() ? self->trState->getTenantInfo() : TenantInfo();
 		req.canCollapseBegin = true; // TODO make this a parameter once we support it
 
 		std::vector<Reference<ReferencedInterface<BlobWorkerInterface>>> v;
@@ -7668,6 +7727,7 @@ ACTOR Future<Standalone<VectorRef<BlobGranuleChunkRef>>> readBlobGranulesActor(
 						           rv,
 						           workerId.toString());
 					}
+					ASSERT(!rep.chunks.empty());
 					results.arena().dependsOn(rep.arena);
 					for (auto& chunk : rep.chunks) {
 						if (BG_REQUEST_DEBUG) {
@@ -7687,10 +7747,22 @@ ACTOR Future<Standalone<VectorRef<BlobGranuleChunkRef>>> readBlobGranulesActor(
 								           chunk.newDeltas[chunk.newDeltas.size() - 1].version);
 							}
 							fmt::print("  IncludedVersion: {0}\n\n\n", chunk.includedVersion);
+							if (chunk.tenantPrefix.present()) {
+								fmt::print("  TenantPrefix: {0}\n", chunk.tenantPrefix.get().printable());
+							}
+						}
+
+						ASSERT(chunk.tenantPrefix.present() == tenantPrefix.present());
+						if (chunk.tenantPrefix.present()) {
+							ASSERT(chunk.tenantPrefix.get() == tenantPrefix.get());
 						}
 
 						results.push_back(results.arena(), chunk);
-						keyRange = KeyRangeRef(std::min(chunk.keyRange.end, keyRange.end), keyRange.end);
+						StringRef chunkEndKey = chunk.keyRange.end;
+						if (tenantPrefix.present()) {
+							chunkEndKey = chunkEndKey.removePrefix(tenantPrefix.get());
+						}
+						keyRange = KeyRangeRef(std::min(chunkEndKey, keyRange.end), keyRange.end);
 					}
 				}
 				// if we detect that this blob worker fails, cancel the request, as otherwise load balance will

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -6570,7 +6570,7 @@ void Transaction::setOption(FDBTransactionOptions::Option option, Optional<Strin
 		validateOptionValueNotPresent(value);
 		if (trState->hasTenant()) {
 			Error e = invalid_option();
-			TraceEvent(SevError, "TenantTransactionRawAccess").error(e).detail("Tenant", trState->tenant());
+			TraceEvent(SevWarn, "TenantTransactionRawAccess").error(e).detail("Tenant", trState->tenant());
 			throw e;
 		}
 		trState->options.rawAccess = true;

--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -864,6 +864,8 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 
 	// Blob granlues
 	init( BG_URL,               isSimulated ? "file://fdbblob/" : "" ); // TODO: store in system key space or something, eventually
+	// BlobGranuleVerify* simulation tests use blobRangeKeys, BlobGranuleCorrectness* use tenant, default in real clusters is tenant
+	init( BG_RANGE_SOURCE,                                  "tenant" );
 	init( BG_SNAPSHOT_FILE_TARGET_BYTES,                    10000000 ); if( buggifySmallShards ) BG_SNAPSHOT_FILE_TARGET_BYTES = 100000; else if (simulationMediumShards || (randomize && BUGGIFY) ) BG_SNAPSHOT_FILE_TARGET_BYTES = 1000000; 
 	init( BG_DELTA_BYTES_BEFORE_COMPACT, BG_SNAPSHOT_FILE_TARGET_BYTES/2 );
 	init( BG_DELTA_FILE_TARGET_BYTES,   BG_DELTA_BYTES_BEFORE_COMPACT/10 );

--- a/fdbclient/ServerKnobs.h
+++ b/fdbclient/ServerKnobs.h
@@ -833,6 +833,8 @@ public:
 	// FIXME: configure url with database configuration instead of knob eventually
 	std::string BG_URL;
 
+	// whether to use blobRangeKeys or tenants for blob granule range sources
+	std::string BG_RANGE_SOURCE;
 	int BG_SNAPSHOT_FILE_TARGET_BYTES;
 	int BG_DELTA_FILE_TARGET_BYTES;
 	int BG_DELTA_BYTES_BEFORE_COMPACT;

--- a/fdbrpc/FlowTransport.actor.cpp
+++ b/fdbrpc/FlowTransport.actor.cpp
@@ -299,7 +299,7 @@ public:
 		setAddressList(addressList); // force the recaching of the string.
 	}
 	Standalone<StringRef> getLocalAddressAsString() const { return cachedStr; }
-	operator NetworkAddressList const &() { return addressList; }
+	operator NetworkAddressList const& () { return addressList; }
 
 private:
 	NetworkAddressList addressList;

--- a/fdbrpc/FlowTransport.actor.cpp
+++ b/fdbrpc/FlowTransport.actor.cpp
@@ -299,7 +299,7 @@ public:
 		setAddressList(addressList); // force the recaching of the string.
 	}
 	Standalone<StringRef> getLocalAddressAsString() const { return cachedStr; }
-	operator NetworkAddressList const&() { return addressList; }
+	operator NetworkAddressList const &() { return addressList; }
 
 private:
 	NetworkAddressList addressList;

--- a/fdbrpc/FlowTransport.actor.cpp
+++ b/fdbrpc/FlowTransport.actor.cpp
@@ -299,7 +299,7 @@ public:
 		setAddressList(addressList); // force the recaching of the string.
 	}
 	Standalone<StringRef> getLocalAddressAsString() const { return cachedStr; }
-	operator NetworkAddressList const& () { return addressList; }
+	operator NetworkAddressList const&() { return addressList; }
 
 private:
 	NetworkAddressList addressList;

--- a/fdbserver/BlobGranuleValidation.actor.cpp
+++ b/fdbserver/BlobGranuleValidation.actor.cpp
@@ -64,10 +64,11 @@ ACTOR Future<std::pair<RangeResult, Standalone<VectorRef<BlobGranuleChunkRef>>>>
     Reference<BackupContainerFileSystem> bstore,
     KeyRange range,
     Version beginVersion,
-    Version readVersion) {
+    Version readVersion,
+    Optional<TenantName> tenantName) {
 	state RangeResult out;
 	state Standalone<VectorRef<BlobGranuleChunkRef>> chunks;
-	state Transaction tr(cx);
+	state Transaction tr(cx, tenantName);
 
 	loop {
 		try {
@@ -81,6 +82,7 @@ ACTOR Future<std::pair<RangeResult, Standalone<VectorRef<BlobGranuleChunkRef>>>>
 	}
 
 	for (const BlobGranuleChunkRef& chunk : chunks) {
+		ASSERT(chunk.tenantPrefix.present() == tenantName.present());
 		RangeResult chunkRows = wait(readBlobGranule(chunk, range, beginVersion, readVersion, bstore));
 		out.arena().dependsOn(chunkRows.arena());
 		out.append(out.arena(), chunkRows.begin(), chunkRows.size());

--- a/fdbserver/BlobGranuleValidation.actor.cpp
+++ b/fdbserver/BlobGranuleValidation.actor.cpp
@@ -28,6 +28,7 @@ ACTOR Future<std::pair<RangeResult, Version>> readFromFDB(Database cx, KeyRange 
 	state Transaction tr(cx);
 	state KeyRange currentRange = range;
 	loop {
+		tr.setOption(FDBTransactionOptions::RAW_ACCESS);
 		try {
 			state RangeResult r = wait(tr.getRange(currentRange, CLIENT_KNOBS->TOO_MANY));
 			Version grv = wait(tr.getReadVersion());

--- a/fdbserver/BlobGranuleValidation.actor.h
+++ b/fdbserver/BlobGranuleValidation.actor.h
@@ -40,7 +40,8 @@ ACTOR Future<std::pair<RangeResult, Standalone<VectorRef<BlobGranuleChunkRef>>>>
     Reference<BackupContainerFileSystem> bstore,
     KeyRange range,
     Version beginVersion,
-    Version readVersion);
+    Version readVersion,
+    Optional<TenantName> tenantName = Optional<TenantName>());
 
 ACTOR Future<std::pair<RangeResult, Version>> readFromFDB(Database cx, KeyRange range);
 

--- a/fdbserver/BlobWorker.actor.cpp
+++ b/fdbserver/BlobWorker.actor.cpp
@@ -2215,13 +2215,14 @@ ACTOR Future<Void> doBlobGranuleFileRequest(Reference<BlobWorkerData> bwData, Bl
 			ASSERT(tenantEntry->second.id == req.tenantInfo.tenantId);
 			tenantPrefix = tenantEntry->second.prefix;
 		} else {
+			TEST(true); // Blob worker unknown tenant
 			// FIXME - better way. Wait on retry here, or just have better model for tenant metadata?
 			// Just throw wrong_shard_server and make the client retry and assume we load it later
 			TraceEvent(SevDebug, "BlobWorkerRequestUnknownTenant", bwData->id)
 			    .suppressFor(5.0)
 			    .detail("TenantName", req.tenantInfo.name.get())
 			    .detail("TenantId", req.tenantInfo.tenantId);
-			throw wrong_shard_server();
+			throw unknown_tenant();
 		}
 		req.keyRange = KeyRangeRef(req.keyRange.begin.withPrefix(tenantPrefix.get(), req.arena),
 		                           req.keyRange.end.withPrefix(tenantPrefix.get(), req.arena));

--- a/fdbserver/BlobWorker.actor.cpp
+++ b/fdbserver/BlobWorker.actor.cpp
@@ -35,6 +35,7 @@
 #include "fdbclient/ManagementAPI.actor.h"
 #include "fdbclient/NativeAPI.actor.h"
 #include "fdbclient/Notified.h"
+#include "fdbclient/Tenant.h"
 #include "fdbserver/Knobs.h"
 #include "fdbserver/BlobGranuleServerCommon.actor.h"
 #include "fdbserver/MutationTracking.h"
@@ -155,6 +156,16 @@ struct GranuleHistoryEntry : NonCopyable, ReferenceCounted<GranuleHistoryEntry> 
 	  : range(range), granuleID(granuleID), startVersion(startVersion), endVersion(endVersion) {}
 };
 
+// TODO: does this need to be versioned like SS has?
+struct GranuleTenantData : NonCopyable, ReferenceCounted<GranuleTenantData> {
+	TenantName name;
+	TenantMapEntry entry;
+	// TODO add other useful stuff like per-tenant blob connection, if necessary
+
+	GranuleTenantData() {}
+	GranuleTenantData(TenantName name, TenantMapEntry entry) : name(name), entry(entry) {}
+};
+
 struct BlobWorkerData : NonCopyable, ReferenceCounted<BlobWorkerData> {
 	UID id;
 	Database db;
@@ -173,6 +184,8 @@ struct BlobWorkerData : NonCopyable, ReferenceCounted<BlobWorkerData> {
 	// logic
 	Reference<BackupContainerFileSystem> bstore;
 	KeyRangeMap<GranuleRangeMetadata> granuleMetadata;
+	KeyRangeMap<Reference<GranuleTenantData>> tenantData;
+	std::unordered_map<int64_t, TenantMapEntry> tenantInfoById;
 
 	// contains the history of completed granules before the existing ones. Maps to the latest one, and has
 	// back-pointers to earlier granules
@@ -2194,6 +2207,25 @@ ACTOR Future<Void> doBlobGranuleFileRequest(Reference<BlobWorkerData> bwData, Bl
 		}
 	}
 
+	state Optional<Key> tenantPrefix;
+	if (req.tenantInfo.name.present()) {
+		ASSERT(req.tenantInfo.tenantId != TenantInfo::INVALID_TENANT);
+		auto tenantEntry = bwData->tenantInfoById.find(req.tenantInfo.tenantId);
+		if (tenantEntry != bwData->tenantInfoById.end()) {
+			tenantPrefix = tenantEntry->second.prefix;
+		} else {
+			// FIXME - better way. Wait on retry here, or just have better model for tenant metadata?
+			// Just throw wrong_shard_server and make the client retry and assume we load it later
+			TraceEvent(SevDebug, "BlobWorkerRequestUnknownTenant", bwData->id)
+			    .suppressFor(5.0)
+			    .detail("TenantName", req.tenantInfo.name.get())
+			    .detail("TenantId", req.tenantInfo.tenantId);
+			throw wrong_shard_server();
+		}
+		req.keyRange = KeyRangeRef(req.keyRange.begin.withPrefix(tenantPrefix.get(), req.arena),
+		                           req.keyRange.end.withPrefix(tenantPrefix.get(), req.arena));
+	}
+
 	state bool didCollapse = false;
 	try {
 		// TODO remove requirement for canCollapseBegin once we implement early replying
@@ -2203,6 +2235,10 @@ ACTOR Future<Void> doBlobGranuleFileRequest(Reference<BlobWorkerData> bwData, Bl
 		}
 		state BlobGranuleFileReply rep;
 		state std::vector<Reference<GranuleMetadata>> granules;
+
+		if (tenantPrefix.present()) {
+			rep.arena.dependsOn(tenantPrefix.get().arena());
+		}
 
 		auto checkRanges = bwData->granuleMetadata.intersectingRanges(req.keyRange);
 		// check for gaps as errors and copy references to granule metadata before yielding or doing any
@@ -2403,7 +2439,16 @@ ACTOR Future<Void> doBlobGranuleFileRequest(Reference<BlobWorkerData> bwData, Bl
 			BlobGranuleChunkRef chunk;
 			// TODO change with early reply
 			chunk.includedVersion = req.readVersion;
-			chunk.keyRange = KeyRangeRef(StringRef(rep.arena, chunkRange.begin), StringRef(rep.arena, chunkRange.end));
+			// compiler doesn't like this
+			// chunk.tenantPrefix = tenantPrefix;
+			if (tenantPrefix.present()) {
+				chunk.keyRange = KeyRangeRef(StringRef(rep.arena, chunkRange.begin.removePrefix(tenantPrefix.get())),
+				                             StringRef(rep.arena, chunkRange.end).removePrefix(tenantPrefix.get()));
+				chunk.tenantPrefix = Optional<StringRef>(tenantPrefix.get());
+			} else {
+				chunk.keyRange =
+				    KeyRangeRef(StringRef(rep.arena, chunkRange.begin), StringRef(rep.arena, chunkRange.end));
+			}
 
 			int64_t deltaBytes = 0;
 			chunkFiles.getFiles(
@@ -3079,6 +3124,56 @@ ACTOR Future<Void> runGRVChecks(Reference<BlobWorkerData> bwData) {
 			++bwData->stats.commitVersionChecks;
 		} catch (Error& e) {
 			wait(tr.onError(e));
+		}
+	}
+}
+
+// FIXME: better way to do this?
+// monitor system keyspace for new tenants
+ACTOR Future<Void> monitorTenants(Reference<BlobWorkerData> bwData) {
+	loop {
+		state Reference<ReadYourWritesTransaction> tr = makeReference<ReadYourWritesTransaction>(bwData->db);
+		loop {
+			try {
+				tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
+				tr->setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
+				state RangeResult tenantResults;
+				wait(store(tenantResults, tr->getRange(tenantMapKeys, CLIENT_KNOBS->TOO_MANY)));
+				ASSERT_WE_THINK(!tenantResults.more && tenantResults.size() < CLIENT_KNOBS->TOO_MANY);
+				if (tenantResults.more || tenantResults.size() >= CLIENT_KNOBS->TOO_MANY) {
+					TraceEvent(SevError, "BlobWorkerTooManyTenants", bwData->id)
+					    .detail("TenantCount", tenantResults.size());
+					wait(delay(600));
+					if (bwData->fatalError.canBeSet()) {
+						bwData->fatalError.sendError(internal_error());
+					}
+					throw internal_error();
+				}
+
+				for (auto& it : tenantResults) {
+					// FIXME: handle removing/moving tenants!
+					StringRef tenantName = it.key.removePrefix(tenantMapPrefix);
+					TenantMapEntry entry = decodeTenantEntry(it.value);
+
+					if (bwData->tenantInfoById.insert({ entry.id, entry }).second) {
+						if (BW_DEBUG) {
+							fmt::print("BW {0} found new tenant {1}: {2} {3}\n",
+							           bwData->id.shortString().substr(0, 5),
+							           tenantName.printable(),
+							           entry.id,
+							           entry.prefix.printable());
+						}
+						bwData->tenantData.insert(KeyRangeRef(entry.prefix, entry.prefix.withSuffix(normalKeys.end)),
+						                          makeReference<GranuleTenantData>(tenantName, entry));
+					}
+				}
+
+				state Future<Void> watchChange = tr->watch(tenantLastIdKey);
+				wait(tr->commit());
+				wait(watchChange);
+			} catch (Error& e) {
+				wait(tr->onError(e));
+			}
 		}
 	}
 }

--- a/fdbserver/BlobWorker.actor.cpp
+++ b/fdbserver/BlobWorker.actor.cpp
@@ -720,6 +720,8 @@ ACTOR Future<BlobFileIndex> dumpInitialSnapshotFromFDB(Reference<BlobWorkerData>
 
 	loop {
 		tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
+		// FIXME: proper tenant support in Blob Worker
+		tr->setOption(FDBTransactionOptions::RAW_ACCESS);
 		try {
 			Version rv = wait(tr->getReadVersion());
 			readVersion = rv;

--- a/fdbserver/SimulatedCluster.actor.cpp
+++ b/fdbserver/SimulatedCluster.actor.cpp
@@ -2386,8 +2386,7 @@ ACTOR void setupAndRun(std::string dataFolder,
 	// Disable the default tenant in backup and DR tests for now. This is because backup does not currently duplicate
 	// the tenant map and related state.
 	// TODO: reenable when backup/DR or BlobGranule supports tenants.
-	if (std::string_view(testFile).find("Backup") != std::string_view::npos ||
-	    std::string_view(testFile).find("BlobGranule") != std::string_view::npos || testConfig.extraDB != 0) {
+	if (std::string_view(testFile).find("Backup") != std::string_view::npos || testConfig.extraDB != 0) {
 		allowDefaultTenant = false;
 	}
 

--- a/tests/fast/BlobGranuleVerifyAtomicOps.toml
+++ b/tests/fast/BlobGranuleVerifyAtomicOps.toml
@@ -4,6 +4,9 @@ allowDefaultTenant = false
 # FIXME: re-enable rocks at some point
 storageEngineExcludeTypes = [4]
 
+[[knobs]]
+bg_range_source = "blobRangeKeys"
+
 [[test]]
 testTitle = 'BlobGranuleVerifyAtomicOps'
 

--- a/tests/fast/BlobGranuleVerifyAtomicOps.toml
+++ b/tests/fast/BlobGranuleVerifyAtomicOps.toml
@@ -1,5 +1,6 @@
 [configuration]
 blobGranulesEnabled = true 
+allowDefaultTenant = false
 # FIXME: re-enable rocks at some point
 storageEngineExcludeTypes = [4]
 

--- a/tests/fast/BlobGranuleVerifyCycle.toml
+++ b/tests/fast/BlobGranuleVerifyCycle.toml
@@ -4,6 +4,9 @@ allowDefaultTenant = false
 # FIXME: re-enable rocks at some point
 storageEngineExcludeTypes = [4]
 
+[[knobs]]
+bg_range_source = "blobRangeKeys"
+
 [[test]]
 testTitle = 'BlobGranuleVerifyCycle'
 

--- a/tests/fast/BlobGranuleVerifyCycle.toml
+++ b/tests/fast/BlobGranuleVerifyCycle.toml
@@ -1,5 +1,6 @@
 [configuration]
 blobGranulesEnabled = true 
+allowDefaultTenant = false
 # FIXME: re-enable rocks at some point
 storageEngineExcludeTypes = [4]
 

--- a/tests/fast/BlobGranuleVerifySmall.toml
+++ b/tests/fast/BlobGranuleVerifySmall.toml
@@ -1,5 +1,6 @@
 [configuration]
 blobGranulesEnabled = true 
+allowDefaultTenant = false
 # FIXME: exclude redwood because WriteDuringRead can write massive KV pairs and we don't chunk change feed data on disk yet
 # FIXME: re-enable rocks at some point
 storageEngineExcludeTypes = [3, 4] 

--- a/tests/fast/BlobGranuleVerifySmall.toml
+++ b/tests/fast/BlobGranuleVerifySmall.toml
@@ -5,6 +5,9 @@ allowDefaultTenant = false
 # FIXME: re-enable rocks at some point
 storageEngineExcludeTypes = [3, 4] 
 
+[[knobs]]
+bg_range_source = "blobRangeKeys"
+
 [[test]]
 testTitle = 'BlobGranuleVerifySmall'
 

--- a/tests/fast/BlobGranuleVerifySmallClean.toml
+++ b/tests/fast/BlobGranuleVerifySmallClean.toml
@@ -5,6 +5,9 @@ allowDefaultTenant = false
 # FIXME: re-enable rocks at some point
 storageEngineExcludeTypes = [3, 4]
 
+[[knobs]]
+bg_range_source = "blobRangeKeys"
+
 [[test]]
 testTitle = 'BlobGranuleVerifySmallClean'
 

--- a/tests/fast/BlobGranuleVerifySmallClean.toml
+++ b/tests/fast/BlobGranuleVerifySmallClean.toml
@@ -1,5 +1,6 @@
 [configuration]
 blobGranulesEnabled = true
+allowDefaultTenant = false
 # FIXME: exclude redwood because WriteDuringRead can write massive KV pairs and we don't chunk change feed data on disk yet
 # FIXME: re-enable rocks at some point
 storageEngineExcludeTypes = [3, 4]

--- a/tests/slow/BlobGranuleCorrectness.toml
+++ b/tests/slow/BlobGranuleCorrectness.toml
@@ -1,8 +1,12 @@
 [configuration]
 blobGranulesEnabled = true 
 allowDefaultTenant = false
+allowDisablingTenants = false
 # FIXME: re-enable rocks at some point
 storageEngineExcludeTypes = [4]
+
+[[knobs]]
+bg_range_source = "tenant"
 
 [[test]]
 testTitle = 'BlobGranuleCorrectness'

--- a/tests/slow/BlobGranuleCorrectness.toml
+++ b/tests/slow/BlobGranuleCorrectness.toml
@@ -1,5 +1,6 @@
 [configuration]
 blobGranulesEnabled = true 
+allowDefaultTenant = false
 # FIXME: re-enable rocks at some point
 storageEngineExcludeTypes = [4]
 

--- a/tests/slow/BlobGranuleCorrectnessClean.toml
+++ b/tests/slow/BlobGranuleCorrectnessClean.toml
@@ -1,8 +1,12 @@
 [configuration]
 blobGranulesEnabled = true 
 allowDefaultTenant = false
+allowDisablingTenants = false
 # FIXME: re-enable rocks at some point
 storageEngineExcludeTypes = [4]
+
+[[knobs]]
+bg_range_source = "tenant"
 
 [[test]]
 testTitle = 'BlobGranuleCorrectness'

--- a/tests/slow/BlobGranuleCorrectnessClean.toml
+++ b/tests/slow/BlobGranuleCorrectnessClean.toml
@@ -1,5 +1,6 @@
 [configuration]
 blobGranulesEnabled = true 
+allowDefaultTenant = false
 # FIXME: re-enable rocks at some point
 storageEngineExcludeTypes = [4]
 

--- a/tests/slow/BlobGranuleVerifyBalance.toml
+++ b/tests/slow/BlobGranuleVerifyBalance.toml
@@ -4,6 +4,9 @@ allowDefaultTenant = false
 # FIXME: re-enable rocks at some point
 storageEngineExcludeTypes = [4]
 
+[[knobs]]
+bg_range_source = "blobRangeKeys"
+
 [[test]]
 testTitle = 'BlobGranuleVerifyBalance'
 

--- a/tests/slow/BlobGranuleVerifyBalance.toml
+++ b/tests/slow/BlobGranuleVerifyBalance.toml
@@ -1,5 +1,6 @@
 [configuration]
 blobGranulesEnabled = true
+allowDefaultTenant = false
 # FIXME: re-enable rocks at some point
 storageEngineExcludeTypes = [4]
 

--- a/tests/slow/BlobGranuleVerifyBalanceClean.toml
+++ b/tests/slow/BlobGranuleVerifyBalanceClean.toml
@@ -1,5 +1,6 @@
 [configuration]
 blobGranulesEnabled = true
+allowDefaultTenant = false
 # FIXME: re-enable rocks at some point
 storageEngineExcludeTypes = [4]
 

--- a/tests/slow/BlobGranuleVerifyBalanceClean.toml
+++ b/tests/slow/BlobGranuleVerifyBalanceClean.toml
@@ -4,6 +4,9 @@ allowDefaultTenant = false
 # FIXME: re-enable rocks at some point
 storageEngineExcludeTypes = [4]
 
+[[knobs]]
+bg_range_source = "blobRangeKeys"
+
 [[test]]
 testTitle = 'BlobGranuleVerifyBalanceClean'
 

--- a/tests/slow/BlobGranuleVerifyLarge.toml
+++ b/tests/slow/BlobGranuleVerifyLarge.toml
@@ -4,6 +4,9 @@ allowDefaultTenant = false
 # FIXME: re-enable rocks at some point
 storageEngineExcludeTypes = [4]
 
+[[knobs]]
+bg_range_source = "blobRangeKeys"
+
 [[test]]
 testTitle = 'BlobGranuleVerifyLarge'
 

--- a/tests/slow/BlobGranuleVerifyLarge.toml
+++ b/tests/slow/BlobGranuleVerifyLarge.toml
@@ -1,5 +1,6 @@
 [configuration]
 blobGranulesEnabled = true 
+allowDefaultTenant = false
 # FIXME: re-enable rocks at some point
 storageEngineExcludeTypes = [4]
 

--- a/tests/slow/BlobGranuleVerifyLargeClean.toml
+++ b/tests/slow/BlobGranuleVerifyLargeClean.toml
@@ -4,6 +4,9 @@ allowDefaultTenant = false
 # FIXME: re-enable rocks at some point
 storageEngineExcludeTypes = [4]
 
+[[knobs]]
+bg_range_source = "blobRangeKeys"
+
 [[test]]
 testTitle = 'BlobGranuleVerifyLargeClean'
 

--- a/tests/slow/BlobGranuleVerifyLargeClean.toml
+++ b/tests/slow/BlobGranuleVerifyLargeClean.toml
@@ -1,5 +1,6 @@
 [configuration]
 blobGranulesEnabled = true 
+allowDefaultTenant = false
 # FIXME: re-enable rocks at some point
 storageEngineExcludeTypes = [4]
 


### PR DESCRIPTION
- Enable blob granules to use tenants as a source of ranges to blobbify
- Change blob granules to respect tenant boundaries
- Changed blob workers to handle tenants for read requests like SS does
- Change BlobGranuleCorrectness* to exclusively use tenants

My mechanism for tracking the tenant boundaries in the blob manager and worker was a bit hacky, but it works for now.

Passed 10k BlobGranuleVerify* (no tenants) and 10k BlobGranuleCorrectness* (with tenants).

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
