### PR TITLE
Fix a heap-use-after-free in PaxosConfigConsumer.actor.cpp (snowflake/release-7.1)

### DIFF
--- a/fdbclient/PaxosConfigTransaction.actor.cpp
+++ b/fdbclient/PaxosConfigTransaction.actor.cpp
@@ -44,13 +44,18 @@ class CommitQuorum {
 		} else if (failed >= ctis.size() / 2 + 1 && result.canBeSet()) {
 			// Rollforwards could cause a version that didn't have quorum to
 			// commit, so send commit_unknown_result instead of commit_failed.
-			result.sendError(commit_unknown_result());
+
+			// Calling sendError could delete this
+			auto local = this->result;
+			local.sendError(commit_unknown_result());
 		} else {
 			// Check if it is possible to ever receive quorum agreement
 			auto totalRequestsOutstanding = ctis.size() - (failed + successful + maybeCommitted);
 			if ((failed + totalRequestsOutstanding < ctis.size() / 2 + 1) &&
 			    (successful + totalRequestsOutstanding < ctis.size() / 2 + 1) && result.canBeSet()) {
-				result.sendError(commit_unknown_result());
+				// Calling sendError could delete this
+				auto local = this->result;
+				local.sendError(commit_unknown_result());
 			}
 		}
 	}
@@ -106,7 +111,7 @@ public:
 		}
 		return result.getFuture();
 	}
-	bool committed() const { return result.isSet(); }
+	bool committed() const { return result.isSet() && !result.isError(); }
 };
 
 class GetGenerationQuorum {
@@ -138,7 +143,9 @@ class GetGenerationQuorum {
 				} else if (self->maxAgreement + (self->ctis.size() - self->totalRepliesReceived) <
 				           (self->ctis.size() / 2 + 1)) {
 					if (!self->result.isError()) {
-						self->result.sendError(failed_to_reach_quorum());
+						// Calling sendError could delete self
+						auto local = self->result;
+						local.sendError(failed_to_reach_quorum());
 					}
 				}
 				break;
@@ -149,7 +156,9 @@ class GetGenerationQuorum {
 					++self->totalRepliesReceived;
 					if (self->totalRepliesReceived == self->ctis.size() && self->result.canBeSet() &&
 					    !self->result.isError()) {
-						self->result.sendError(failed_to_reach_quorum());
+						// Calling sendError could delete self
+						auto local = self->result;
+						local.sendError(failed_to_reach_quorum());
 					}
 					break;
 				} else {

--- a/fdbserver/PaxosConfigConsumer.actor.cpp
+++ b/fdbserver/PaxosConfigConsumer.actor.cpp
@@ -185,11 +185,15 @@ class GetCommittedVersionQuorum {
 			++self->totalRepliesReceived;
 			if (e.code() == error_code_version_already_compacted) {
 				if (self->quorumVersion.canBeSet()) {
-					self->quorumVersion.sendError(e);
+					// Calling sendError could delete self
+					auto local = self->quorumVersion;
+					local.sendError(e);
 				}
 			} else if (e.code() != error_code_timed_out && e.code() != error_code_broken_promise) {
 				if (self->quorumVersion.canBeSet()) {
-					self->quorumVersion.sendError(e);
+					// Calling sendError could delete self
+					auto local = self->quorumVersion;
+					local.sendError(e);
 				}
 			} else if (self->totalRepliesReceived == self->cfis.size() && self->quorumVersion.canBeSet() &&
 			           !self->quorumVersion.isError()) {
@@ -208,7 +212,10 @@ class GetCommittedVersionQuorum {
 				} else if (!self->quorumVersion.isSet()) {
 					// Otherwise, if a quorum agree on the committed version,
 					// some other occurred. Notify the caller of it.
-					self->quorumVersion.sendError(e);
+
+					// Calling sendError could delete self
+					auto local = self->quorumVersion;
+					local.sendError(e);
 				}
 			}
 		}


### PR DESCRIPTION
Cherry pick https://github.com/apple/foundationdb/pull/7244 to snowflake/release-7.1



Make a local copy of a promise before calling sendError, in case the sendError call results in that promise getting destroyed. Only one of these call sites actually manifested, but let's defensively make a copy for each of them.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
