### PR TITLE
Cherry pick pull request #7256

### DIFF
--- a/fdbserver/masterserver.actor.cpp
+++ b/fdbserver/masterserver.actor.cpp
@@ -301,18 +301,16 @@ ACTOR Future<Void> updateRecoveryData(Reference<MasterData> self) {
 	loop {
 		UpdateRecoveryDataRequest req = waitNext(self->myInterface.updateRecoveryData.getFuture());
 		TraceEvent("UpdateRecoveryData", self->dbgid)
-		    .detail("RecoveryTxnVersion", req.recoveryTransactionVersion)
-		    .detail("LastEpochEnd", req.lastEpochEnd)
+		    .detail("ReceivedRecoveryTxnVersion", req.recoveryTransactionVersion)
+		    .detail("ReceivedLastEpochEnd", req.lastEpochEnd)
+		    .detail("CurrentRecoveryTxnVersion", self->recoveryTransactionVersion)
+		    .detail("CurrentLastEpochEnd", self->lastEpochEnd)
 		    .detail("NumCommitProxies", req.commitProxies.size())
 		    .detail("VersionEpoch", req.versionEpoch);
 
-		if (self->recoveryTransactionVersion == invalidVersion ||
-		    req.recoveryTransactionVersion > self->recoveryTransactionVersion) {
-			self->recoveryTransactionVersion = req.recoveryTransactionVersion;
-		}
-		if (self->lastEpochEnd == invalidVersion || req.lastEpochEnd > self->lastEpochEnd) {
-			self->lastEpochEnd = req.lastEpochEnd;
-		}
+		self->recoveryTransactionVersion = req.recoveryTransactionVersion;
+		self->lastEpochEnd = req.lastEpochEnd;
+
 		if (req.commitProxies.size() > 0) {
 			self->lastCommitProxyVersionReplies.clear();
 


### PR DESCRIPTION
Merge pull request #7256 from sbodagala/main.

Make sequencer accept the recovery transaction version unconditionally.

Cluster controller could send multiple recovery transaction versions and not accepting them unconditionally could cause a discrepancy between the recovery transaction versions on the sequencer and the resolvers, resulting in a hung recovery (because the cluster controller wouldn't be able to commit the recovery transaction version).

NOTE: Found this issue on "release-7.1" branch with version vector enabled but I don't think this issue is in anyway related to the version vector logic.

Test that found this issue:

Branch: release-7.1
Commit: https://github.com/apple/foundationdb/commit/f58801f26f82be92e39b5d12fdb7aa0e66c1655f
Compiler: clang
Options: version vector enabled
Test: "build_output/bin/fdbserver -r simulation --crash -f /root/src/foundationdb/tests/fast/LowLatency.toml -b off -s 463720139"

Testing:
Simulation tests:
Clang build (with version vector disabled): 20220526-205523-sre-ffd9dc8ba4124bf8 (in progress).
Clang build (with version vector enabled): 20220526-211058-sre-109b4b237f962305 (in progress).


# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
