### PR TITLE
Avoid creating new RequestStream when retry.

### DIFF
--- a/fdbrpc/genericactors.actor.h
+++ b/fdbrpc/genericactors.actor.h
@@ -137,13 +137,11 @@ Future<REPLY_TYPE(Req)> retryGetReplyFromHostname(Req request, Hostname hostname
 	// Suitable for use with hostname, where RequestStream is NOT initialized yet.
 	// Not normally useful for endpoints initialized with NetworkAddress.
 	state double reconnetInterval = FLOW_KNOBS->HOSTNAME_RECONNECT_INIT_INTERVAL;
-	state RequestStream<Req>* to;
+	state std::unique_ptr<RequestStream<Req>> to;
 	loop {
 		NetworkAddress address = wait(hostname.resolveWithRetry());
-		if (to == nullptr) {
-			to = new RequestStream<Req>(Endpoint::wellKnown({ address }, token));
-		} else if (to->getEndpoint().getPrimaryAddress() != address) {
-			*to = RequestStream<Req>(Endpoint::wellKnown({ address }, token));
+		if (to == nullptr || to->getEndpoint().getPrimaryAddress() != address) {
+			to = std::make_unique<RequestStream<Req>>(Endpoint::wellKnown({ address }, token));
 		}
 		state ErrorOr<REPLY_TYPE(Req)> reply = wait(to->tryGetReply(request));
 		if (reply.isError()) {
@@ -171,13 +169,11 @@ Future<REPLY_TYPE(Req)> retryGetReplyFromHostname(Req request,
 	// Suitable for use with hostname, where RequestStream is NOT initialized yet.
 	// Not normally useful for endpoints initialized with NetworkAddress.
 	state double reconnetInterval = FLOW_KNOBS->HOSTNAME_RECONNECT_INIT_INTERVAL;
-	state RequestStream<Req>* to;
+	state std::unique_ptr<RequestStream<Req>> to;
 	loop {
 		NetworkAddress address = wait(hostname.resolveWithRetry());
-		if (to == nullptr) {
-			to = new RequestStream<Req>(Endpoint::wellKnown({ address }, token));
-		} else if (to->getEndpoint().getPrimaryAddress() != address) {
-			*to = RequestStream<Req>(Endpoint::wellKnown({ address }, token));
+		if (to == nullptr || to->getEndpoint().getPrimaryAddress() != address) {
+			to = std::make_unique<RequestStream<Req>>(Endpoint::wellKnown({ address }, token));
 		}
 		state ErrorOr<REPLY_TYPE(Req)> reply = wait(to->tryGetReply(request, taskID));
 		if (reply.isError()) {


### PR DESCRIPTION
Fixes #7223.

The root cause is every retry in retryGetReplyFromHostname() creates a new RequestStream, which will create a new peer. The RequestStream is destructed when the request is sent, so the peer is also destructed. In the next retry, this repeats again, without knowing the last connection failed. If connecting to the new peer always fail (which happens when the peer process is dead), workers will think themselves are bad, then BetterMasterExist will try to do a recovery.

This issue is verified by running 10k DataLossRecovery.toml tests with useHostname=true:
20220526-233811-renxuan-544bf28126431c6d           compressed=True data_size=32808384 duration=470292 ended=10000 fail=2 fail_fast=10 max_runs=10000 pass=9998 priority=100 remaining=0 runtime=0:30:32 sanity=False started=10044 stopped=20220527-000843 submitted=20220526-233811 timeout=5400 username=renxuan

Now with this fix, there are no failure in 100k DataLossRecovery.toml tests with useHostname=true:
20220527-051706-renxuan-4fbf20fbfef3b467           compressed=True data_size=32931256 duration=5086936 ended=100002 fail_fast=10 max_runs=100000 pass=100002 priority=100 remaining=0 runtime=0:48:59 sanity=False started=100138 stopped=20220527-060605 submitted=20220527-051706 timeout=5400 username=renxuan

Thanks @halfprice for investigating!

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
