### PR TITLE
Fix race conditions on closeTraceFile and flushTraceFileVoid

### DIFF
--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -2555,7 +2555,6 @@ void stopNetwork() {
 
 	TraceEvent("ClientStopNetwork").log();
 	g_network->stop();
-	closeTraceFile();
 }
 
 void DatabaseContext::updateProxies() {

--- a/fdbclient/ThreadSafeTransaction.cpp
+++ b/fdbclient/ThreadSafeTransaction.cpp
@@ -591,6 +591,7 @@ void ThreadSafeApi::runNetwork() {
 	}
 
 	TraceEvent("RunNetworkTerminating");
+	closeTraceFile();
 }
 
 void ThreadSafeApi::stopNetwork() {

--- a/flow/Trace.cpp
+++ b/flow/Trace.cpp
@@ -454,7 +454,9 @@ public:
 	}
 
 	ThreadFuture<Void> flush() {
-		traceEventThrottlerCache->poll();
+		if (TraceEvent::isNetworkThread()) {
+			traceEventThrottlerCache->poll();
+		}
 
 		MutexHolder hold(mutex);
 		bool roll = false;


### PR DESCRIPTION
**Fixing the call to closeTraceFile**

On the client side, the trace file was closed from a call to fdb_stop_network, which is usually called from an application thread other than the FDB network thread. After fdb_stop_network is called, the network thread may still continue executing scheduled tasks. We want to keep the trace file open, so that this pending activity is traced. Another problem is that trace file on the client side is initialized on demand on creation of the first database, so if there is a pending database creation task at the time of calling fdb_stop_network, it will attempt reinitializing the trace file and fail. 

The fix moves the closeTraceFile call from fdb_stop_network to the end of fdb_run_network. 

The problem is specific to the use of the client API, because FDB processes flush and close the trace file on exit, by calling flushAndExit. 

**Fixing the race condition in flushTraceFileVoid**

Event throttler is designed to run in the network thread only. The problem is that event throttler polling is called from the flushTraceFileVoid, which in turn can be called from any thread.

Fix adds an additional check to make sure that flushTraceFileVoid calls event throttler polling only when executed from the network thread.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
