### PR TITLE
Include symbols from fdb_c_internal.h to C bindings client library for Apple platform

### DIFF
--- a/bindings/c/CMakeLists.txt
+++ b/bindings/c/CMakeLists.txt
@@ -58,8 +58,9 @@ if(APPLE)
   add_custom_command(OUTPUT ${symbols}
     COMMAND $<TARGET_FILE:Python::Interpreter> ${CMAKE_CURRENT_SOURCE_DIR}/symbolify.py
         ${CMAKE_CURRENT_SOURCE_DIR}/foundationdb/fdb_c.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/foundationdb/fdb_c_internal.h
         ${symbols}
-    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/symbolify.py ${CMAKE_CURRENT_SOURCE_DIR}/foundationdb/fdb_c.h
+    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/symbolify.py ${CMAKE_CURRENT_SOURCE_DIR}/foundationdb/fdb_c.h ${CMAKE_CURRENT_SOURCE_DIR}/foundationdb/fdb_c_internal.h
     COMMENT "Generate exported_symbols_list")
   add_custom_target(exported_symbols_list DEPENDS ${symbols})
   add_dependencies(fdb_c exported_symbols_list)

--- a/bindings/c/symbolify.py
+++ b/bindings/c/symbolify.py
@@ -2,9 +2,13 @@ if __name__ == '__main__':
     import re
     import sys
     r = re.compile('DLLEXPORT[^(]*(fdb_[^(]*)[(]')
-    (fdb_c_h, symbols_file) = sys.argv[1:]
-    with open(fdb_c_h, 'r') as f:
-        symbols = sorted(set('_' + m.group(1) for m in r.finditer(f.read())))
+    header_files = sys.argv[1:-1]
+    symbols_file = sys.argv[-1]
+    symbols = set()
+    for header_file in header_files:
+        with open(header_file, 'r') as f:
+            symbols.update('_' + m.group(1) for m in r.finditer(f.read()))
+    symbols = sorted(symbols)
     with open(symbols_file, 'w') as f:
         f.write('\n'.join(symbols))
         f.write('\n')


### PR DESCRIPTION
Without symbols from `fdb_c_internal.h` being exported to client side `.so` library, the C API tests are failing, see: https://github.com/apple/foundationdb/issues/7291

This PR extends the Apple-platform specific extraction of symbols to include not only symbols from `fdb_c.h`, but also `fdb_c_internal.h`. 

Tested by running `ctest -R fdb_c_api_tests` which passes with this PR on Apple, but times out without it. 

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
