### PR TITLE
Add versionstamp support in tuple

### DIFF
--- a/bindings/c/test/unit/unit_tests.cpp
+++ b/bindings/c/test/unit/unit_tests.cpp
@@ -992,6 +992,13 @@ GetMappedRangeResult getMappedIndexEntries(int beginId,
 	return getMappedIndexEntries(beginId, endId, tr, mapper, matchIndex);
 }
 
+TEST_CASE("tuble_support_versionstamp") {
+	// a random 12 bytes long StringRef as a versionstamp
+	StringRef vs = "\x01\x02\x03\x04\x05\x06\x07\x08\x09\x10\x11\x12"_sr;
+	const Tuple t = Tuple().append(prefix).append(RECORD).appendVersionstamp(vs).append("{K[3]}"_sr).append("{...}"_sr);
+	ASSERT(t.getVersionstamp(2).toString() == vs.toString());
+}
+
 TEST_CASE("fdb_transaction_get_mapped_range") {
 	const int TOTAL_RECORDS = 20;
 	fillInRecords(TOTAL_RECORDS);
@@ -1153,11 +1160,13 @@ void assertNotTuple(std::string str) {
 TEST_CASE("fdb_transaction_get_mapped_range_fail_on_mapper_not_tuple") {
 	// A string that cannot be parsed as tuple.
 	// "\x15:\x152\x15E\x15\x09\x15\x02\x02MySimpleRecord$repeater-version\x00\x15\x013\x00\x00\x00\x00\x1aU\x90\xba\x00\x00\x00\x02\x15\x04"
+	// should fail at \x35
+
 	std::string mapper = {
 		'\x15', ':',    '\x15', '2', '\x15', 'E',    '\x15', '\t',   '\x15', '\x02', '\x02', 'M',
 		'y',    'S',    'i',    'm', 'p',    'l',    'e',    'R',    'e',    'c',    'o',    'r',
 		'd',    '$',    'r',    'e', 'p',    'e',    'a',    't',    'e',    'r',    '-',    'v',
-		'e',    'r',    's',    'i', 'o',    'n',    '\x00', '\x15', '\x01', '3',    '\x00', '\x00',
+		'e',    'r',    's',    'i', 'o',    'n',    '\x00', '\x15', '\x01', '\x35', '\x00', '\x00',
 		'\x00', '\x00', '\x1a', 'U', '\x90', '\xba', '\x00', '\x00', '\x00', '\x02', '\x15', '\x04'
 	};
 	assertNotTuple(mapper);

--- a/bindings/c/test/unit/unit_tests.cpp
+++ b/bindings/c/test/unit/unit_tests.cpp
@@ -1012,8 +1012,8 @@ TEST_CASE("versionstamp_unit_test") {
 	ASSERT(batch == batchExpected);
 	ASSERT(batch2 == batchExpected);
 
-	int16_t client = vs.getClientWrittenNumber();
-	int16_t client2 = vs2.getClientWrittenNumber();
+	int16_t client = vs.getUserVersion();
+	int16_t client2 = vs2.getUserVersion();
 	int16_t clientExpected = (0x11 << 8) + 0x12;
 	ASSERT(client == clientExpected);
 	ASSERT(client2 == clientExpected);

--- a/bindings/c/test/unit/unit_tests.cpp
+++ b/bindings/c/test/unit/unit_tests.cpp
@@ -992,11 +992,40 @@ GetMappedRangeResult getMappedIndexEntries(int beginId,
 	return getMappedIndexEntries(beginId, endId, tr, mapper, matchIndex);
 }
 
-TEST_CASE("tuble_support_versionstamp") {
+TEST_CASE("tuple_support_versionstamp") {
 	// a random 12 bytes long StringRef as a versionstamp
 	StringRef vs = "\x01\x02\x03\x04\x05\x06\x07\x08\x09\x10\x11\x12"_sr;
+
 	const Tuple t = Tuple().append(prefix).append(RECORD).appendVersionstamp(vs).append("{K[3]}"_sr).append("{...}"_sr);
 	ASSERT(t.getVersionstamp(2).toString() == vs.toString());
+
+	// verify the round-way pack-unpack path for a Tuple containing a versionstamp
+	StringRef result1 = t.pack();
+	Tuple t2 = Tuple::unpack(result1);
+	StringRef result2 = t2.pack();
+	ASSERT(result1.toString() == result2.toString());
+}
+
+TEST_CASE("tuple_fail_to_append_truncated_versionstamp") {
+	// a truncated 11 bytes long StringRef as a versionstamp
+	StringRef truncatedVersionstamp = "\x01\x02\x03\x04\x05\x06\x07\x08\x09\x10\x11"_sr;
+	try {
+		Tuple().appendVersionstamp(truncatedVersionstamp).pack();
+	} catch (Error& e) {
+		return;
+	}
+	UNREACHABLE();
+}
+
+TEST_CASE("tuple_fail_to_append_longer_versionstamp") {
+	// a longer than expected 13 bytes long StringRef as a versionstamp
+	StringRef longerVersionstamp = "\x01\x02\x03\x04\x05\x06\x07\x08\x09\x10\x11\x12\x35"_sr;
+	try {
+		Tuple().appendVersionstamp(longerVersionstamp).pack();
+	} catch (Error& e) {
+		return;
+	}
+	UNREACHABLE();
 }
 
 TEST_CASE("fdb_transaction_get_mapped_range") {

--- a/bindings/c/test/unit/unit_tests.cpp
+++ b/bindings/c/test/unit/unit_tests.cpp
@@ -1006,15 +1006,15 @@ TEST_CASE("versionstamp_unit_test") {
 	ASSERT(version == versionExpected);
 	ASSERT(version2 == versionExpected);
 
-	int64_t batch = vs.getBatchNumber();
-	int64_t batch2 = vs2.getBatchNumber();
-	int64_t batchExpected = (0x09 << 8) + 0x10;
+	int16_t batch = vs.getBatchNumber();
+	int16_t batch2 = vs2.getBatchNumber();
+	int16_t batchExpected = (0x09 << 8) + 0x10;
 	ASSERT(batch == batchExpected);
 	ASSERT(batch2 == batchExpected);
 
-	int64_t client = vs.getClientWrittenNumber();
-	int64_t client2 = vs2.getClientWrittenNumber();
-	int64_t clientExpected = (0x11 << 8) + 0x12;
+	int16_t client = vs.getClientWrittenNumber();
+	int16_t client2 = vs2.getClientWrittenNumber();
+	int16_t clientExpected = (0x11 << 8) + 0x12;
 	ASSERT(client == clientExpected);
 	ASSERT(client2 == clientExpected);
 

--- a/bindings/c/test/unit/unit_tests.cpp
+++ b/bindings/c/test/unit/unit_tests.cpp
@@ -1012,11 +1012,11 @@ TEST_CASE("versionstamp_unit_test") {
 	ASSERT(batch == batchExpected);
 	ASSERT(batch2 == batchExpected);
 
-	int16_t client = vs.getUserVersion();
-	int16_t client2 = vs2.getUserVersion();
-	int16_t clientExpected = (0x11 << 8) + 0x12;
-	ASSERT(client == clientExpected);
-	ASSERT(client2 == clientExpected);
+	int16_t user = vs.getUserVersion();
+	int16_t user2 = vs2.getUserVersion();
+	int16_t userExpected = (0x11 << 8) + 0x12;
+	ASSERT(user == userExpected);
+	ASSERT(user2 == userExpected);
 
 	ASSERT(vs.size() == VERSIONSTAMP_TUPLE_SIZE);
 	ASSERT(vs2.size() == VERSIONSTAMP_TUPLE_SIZE);

--- a/bindings/flow/Tuple.cpp
+++ b/bindings/flow/Tuple.cpp
@@ -174,12 +174,11 @@ Tuple& Tuple::append(StringRef const& str, bool utf8) {
 	return *this;
 }
 
-Tuple& Tuple::appendVersionstamp(StringRef const& str) {
-	ASSERT_EQ(str.size(), VERSIONSTAMP_TUPLE_SIZE);
+Tuple& Tuple::appendVersionstamp(Versionstamp const& vs) {
 	offsets.push_back(data.size());
 
 	data.push_back(data.arena(), VERSIONSTAMP_96_CODE);
-	data.append(data.arena(), str.begin(), VERSIONSTAMP_TUPLE_SIZE);
+	data.append(data.arena(), vs.begin(), vs.size());
 
 	return *this;
 }
@@ -441,7 +440,7 @@ double Tuple::getDouble(size_t index) const {
 	return bigEndianDouble(swap);
 }
 
-Standalone<StringRef> Tuple::getVersionstamp(size_t index) const {
+Versionstamp Tuple::getVersionstamp(size_t index) const {
 	if (index >= offsets.size()) {
 		throw invalid_tuple_index();
 	}
@@ -451,7 +450,7 @@ Standalone<StringRef> Tuple::getVersionstamp(size_t index) const {
 		throw invalid_tuple_data_type();
 	}
 	size_t versionstampLength = VERSIONSTAMP_TUPLE_SIZE;
-	return StringRef(data.begin() + offsets[index] + 1, versionstampLength);
+	return Versionstamp(StringRef(data.begin() + offsets[index] + 1, versionstampLength));
 }
 
 Uuid Tuple::getUuid(size_t index) const {

--- a/bindings/flow/Tuple.h
+++ b/bindings/flow/Tuple.h
@@ -24,6 +24,7 @@
 #pragma once
 
 #include "bindings/flow/fdb_flow.h"
+#include "fdbclient/Versionstamp.h"
 
 namespace FDB {
 struct Uuid {
@@ -60,7 +61,7 @@ struct Tuple {
 	Tuple& append(Uuid);
 	Tuple& appendNested(Tuple const&);
 	Tuple& appendNull();
-	Tuple& appendVersionstamp(StringRef const& str);
+	Tuple& appendVersionstamp(Versionstamp const&);
 
 	StringRef pack() const { return StringRef(data.begin(), data.size()); }
 
@@ -76,7 +77,7 @@ struct Tuple {
 
 	ElementType getType(size_t index) const;
 	Standalone<StringRef> getString(size_t index) const;
-	Standalone<StringRef> getVersionstamp(size_t index) const;
+	Versionstamp getVersionstamp(size_t index) const;
 	int64_t getInt(size_t index) const;
 	bool getBool(size_t index) const;
 	float getFloat(size_t index) const;

--- a/bindings/flow/Tuple.h
+++ b/bindings/flow/Tuple.h
@@ -60,6 +60,7 @@ struct Tuple {
 	Tuple& append(Uuid);
 	Tuple& appendNested(Tuple const&);
 	Tuple& appendNull();
+	Tuple& appendVersionstamp(StringRef const& str);
 
 	StringRef pack() const { return StringRef(data.begin(), data.size()); }
 
@@ -68,13 +69,14 @@ struct Tuple {
 		return append(t);
 	}
 
-	enum ElementType { NULL_TYPE, INT, BYTES, UTF8, BOOL, FLOAT, DOUBLE, UUID, NESTED };
+	enum ElementType { NULL_TYPE, INT, BYTES, UTF8, BOOL, FLOAT, DOUBLE, UUID, NESTED, VERSIONSTAMP };
 
 	// this is number of elements, not length of data
 	size_t size() const { return offsets.size(); }
 
 	ElementType getType(size_t index) const;
 	Standalone<StringRef> getString(size_t index) const;
+	Standalone<StringRef> getVersionstamp(size_t index) const;
 	int64_t getInt(size_t index) const;
 	bool getBool(size_t index) const;
 	float getFloat(size_t index) const;
@@ -107,6 +109,7 @@ private:
 	static const uint8_t FALSE_CODE;
 	static const uint8_t TRUE_CODE;
 	static const uint8_t UUID_CODE;
+	static const uint8_t VERSIONSTAMP_96_CODE;
 
 	Tuple(const StringRef& data);
 	Tuple(Standalone<VectorRef<uint8_t>> data, std::vector<size_t> offsets);

--- a/bindings/flow/tester/Tester.actor.cpp
+++ b/bindings/flow/tester/Tester.actor.cpp
@@ -113,7 +113,11 @@ std::string tupleToString(Tuple const& tuple) {
 		} else if (type == Tuple::NESTED) {
 			str += tupleToString(tuple.getNested(i));
 		} else if (type == Tuple::VERSIONSTAMP) {
-			str += "\'" + tuple.getString(i).printable() + "\'";
+			Versionstamp versionstamp = tuple.getVersionstamp(i);
+			str += format("Transaction Version: '%ld', BatchNumber: '%hd', ClientWrittenNumber : '%hd'",
+			              versionstamp.getVersion(),
+			              versionstamp.getBatchNumber(),
+			              versionstamp.getClientWrittenNumber());
 		} else {
 			ASSERT(false);
 		}
@@ -1150,7 +1154,7 @@ struct TuplePackFunc : InstructionFunc {
 				} else if (type == Tuple::NESTED) {
 					tuple.appendNested(itemTuple.getNested(0));
 				} else if (type == Tuple::VERSIONSTAMP) {
-					tuple.appendVersionstamp(itemTuple.getString(0));
+					tuple.appendVersionstamp(Versionstamp(itemTuple.getString(0)));
 				} else {
 					ASSERT(false);
 				}
@@ -1231,7 +1235,7 @@ struct TupleRangeFunc : InstructionFunc {
 				} else if (type == Tuple::NESTED) {
 					tuple.appendNested(itemTuple.getNested(0));
 				} else if (type == Tuple::VERSIONSTAMP) {
-					tuple.appendVersionstamp(itemTuple.getString(0));
+					tuple.appendVersionstamp(Versionstamp(itemTuple.getString(0)));
 				} else {
 					ASSERT(false);
 				}

--- a/bindings/flow/tester/Tester.actor.cpp
+++ b/bindings/flow/tester/Tester.actor.cpp
@@ -114,10 +114,10 @@ std::string tupleToString(Tuple const& tuple) {
 			str += tupleToString(tuple.getNested(i));
 		} else if (type == Tuple::VERSIONSTAMP) {
 			Versionstamp versionstamp = tuple.getVersionstamp(i);
-			str += format("Transaction Version: '%ld', BatchNumber: '%hd', ClientWrittenNumber : '%hd'",
+			str += format("Transaction Version: '%ld', BatchNumber: '%hd', UserVersion : '%hd'",
 			              versionstamp.getVersion(),
 			              versionstamp.getBatchNumber(),
-			              versionstamp.getClientWrittenNumber());
+			              versionstamp.getUserVersion());
 		} else {
 			ASSERT(false);
 		}

--- a/bindings/flow/tester/Tester.actor.cpp
+++ b/bindings/flow/tester/Tester.actor.cpp
@@ -112,6 +112,8 @@ std::string tupleToString(Tuple const& tuple) {
 			str += format("%016llx%016llx", *(uint64_t*)u.getData().begin(), *(uint64_t*)(u.getData().begin() + 8));
 		} else if (type == Tuple::NESTED) {
 			str += tupleToString(tuple.getNested(i));
+		} else if (type == Tuple::VERSIONSTAMP) {
+			str += "\'" + tuple.getString(i).printable() + "\'";
 		} else {
 			ASSERT(false);
 		}
@@ -1147,6 +1149,8 @@ struct TuplePackFunc : InstructionFunc {
 					tuple << itemTuple.getUuid(0);
 				} else if (type == Tuple::NESTED) {
 					tuple.appendNested(itemTuple.getNested(0));
+				} else if (type == Tuple::VERSIONSTAMP) {
+					tuple.appendVersionstamp(itemTuple.getString(0));
 				} else {
 					ASSERT(false);
 				}
@@ -1226,6 +1230,8 @@ struct TupleRangeFunc : InstructionFunc {
 					tuple << itemTuple.getUuid(0);
 				} else if (type == Tuple::NESTED) {
 					tuple.appendNested(itemTuple.getNested(0));
+				} else if (type == Tuple::VERSIONSTAMP) {
+					tuple.appendVersionstamp(itemTuple.getString(0));
 				} else {
 					ASSERT(false);
 				}

--- a/fdbclient/CMakeLists.txt
+++ b/fdbclient/CMakeLists.txt
@@ -149,6 +149,8 @@ set(FDBCLIENT_SRCS
   VersionedMap.actor.h
   VersionedMap.h
   VersionedMap.cpp
+  Versionstamp.cpp
+  Versionstamp.h
   VersionVector.h
   VersionVector.cpp
   WellKnownEndpoints.h

--- a/fdbclient/GlobalConfig.actor.cpp
+++ b/fdbclient/GlobalConfig.actor.cpp
@@ -119,6 +119,8 @@ void GlobalConfig::insert(KeyRef key, ValueRef value) {
 			any = t.getFloat(0);
 		} else if (t.getType(0) == Tuple::ElementType::DOUBLE) {
 			any = t.getDouble(0);
+		} else if (t.getType(0) == Tuple::ElementType::VERSIONSTAMP) {
+			any = t.getVersionstamp(0);
 		} else {
 			ASSERT(false);
 		}

--- a/fdbclient/Tuple.cpp
+++ b/fdbclient/Tuple.cpp
@@ -21,7 +21,6 @@
 #include "fdbclient/Tuple.h"
 
 const uint8_t VERSIONSTAMP_96_CODE = 0x33;
-const size_t VERSIONSTAMP_TUPLE_SIZE = 12;
 
 // TODO: Many functions copied from bindings/flow/Tuple.cpp. Merge at some point.
 static float bigEndianFloat(float orig) {
@@ -104,12 +103,11 @@ Tuple& Tuple::append(Tuple const& tuple) {
 	return *this;
 }
 
-Tuple& Tuple::appendVersionstamp(StringRef const& str) {
-	ASSERT_EQ(str.size(), VERSIONSTAMP_TUPLE_SIZE);
+Tuple& Tuple::appendVersionstamp(Versionstamp const& vs) {
 	offsets.push_back(data.size());
 
 	data.push_back(data.arena(), VERSIONSTAMP_96_CODE);
-	data.append(data.arena(), str.begin(), VERSIONSTAMP_TUPLE_SIZE);
+	data.append(data.arena(), vs.begin(), vs.size());
 
 	return *this;
 }
@@ -378,7 +376,7 @@ double Tuple::getDouble(size_t index) const {
 	return bigEndianDouble(swap);
 }
 
-Standalone<StringRef> Tuple::getVersionstamp(size_t index) const {
+Versionstamp Tuple::getVersionstamp(size_t index) const {
 	if (index >= offsets.size()) {
 		throw invalid_tuple_index();
 	}
@@ -387,7 +385,7 @@ Standalone<StringRef> Tuple::getVersionstamp(size_t index) const {
 	if (code != VERSIONSTAMP_96_CODE) {
 		throw invalid_tuple_data_type();
 	}
-	return StringRef(data.begin() + offsets[index] + 1, VERSIONSTAMP_TUPLE_SIZE);
+	return Versionstamp(StringRef(data.begin() + offsets[index] + 1, VERSIONSTAMP_TUPLE_SIZE));
 }
 
 KeyRange Tuple::range(Tuple const& tuple) const {

--- a/fdbclient/Tuple.h
+++ b/fdbclient/Tuple.h
@@ -47,6 +47,7 @@ struct Tuple {
 	Tuple& appendFloat(float);
 	Tuple& appendDouble(double);
 	Tuple& appendNull();
+	Tuple& appendVersionstamp(StringRef const& str);
 
 	StringRef pack() const { return StringRef(data.begin(), data.size()); }
 
@@ -55,7 +56,7 @@ struct Tuple {
 		return append(t);
 	}
 
-	enum ElementType { NULL_TYPE, INT, BYTES, UTF8, BOOL, FLOAT, DOUBLE };
+	enum ElementType { NULL_TYPE, INT, BYTES, UTF8, BOOL, FLOAT, DOUBLE, VERSIONSTAMP };
 
 	// this is number of elements, not length of data
 	size_t size() const { return offsets.size(); }
@@ -68,6 +69,7 @@ struct Tuple {
 	StringRef subTupleRawString(size_t index) const;
 	ElementType getType(size_t index) const;
 	Standalone<StringRef> getString(size_t index) const;
+	Standalone<StringRef> getVersionstamp(size_t index) const;
 	int64_t getInt(size_t index, bool allow_incomplete = false) const;
 	bool getBool(size_t index) const;
 	float getFloat(size_t index) const;

--- a/fdbclient/Tuple.h
+++ b/fdbclient/Tuple.h
@@ -25,6 +25,7 @@
 
 #include "flow/flow.h"
 #include "fdbclient/FDBTypes.h"
+#include "fdbclient/Versionstamp.h"
 
 struct Tuple {
 	Tuple() {}
@@ -47,7 +48,7 @@ struct Tuple {
 	Tuple& appendFloat(float);
 	Tuple& appendDouble(double);
 	Tuple& appendNull();
-	Tuple& appendVersionstamp(StringRef const& str);
+	Tuple& appendVersionstamp(Versionstamp const&);
 
 	StringRef pack() const { return StringRef(data.begin(), data.size()); }
 
@@ -69,7 +70,7 @@ struct Tuple {
 	StringRef subTupleRawString(size_t index) const;
 	ElementType getType(size_t index) const;
 	Standalone<StringRef> getString(size_t index) const;
-	Standalone<StringRef> getVersionstamp(size_t index) const;
+	Versionstamp getVersionstamp(size_t index) const;
 	int64_t getInt(size_t index, bool allow_incomplete = false) const;
 	bool getBool(size_t index) const;
 	float getFloat(size_t index) const;

--- a/fdbclient/Versionstamp.cpp
+++ b/fdbclient/Versionstamp.cpp
@@ -15,12 +15,12 @@ int16_t Versionstamp::getBatchNumber() const {
 	return batchNumber;
 }
 
-int16_t Versionstamp::getClientWrittenNumber() const {
+int16_t Versionstamp::getUserVersion() const {
 	const uint8_t* begin = data.begin();
 	begin += 10;
-	int16_t clientWrittenNumber = *(int16_t*)(begin);
-	clientWrittenNumber = bigEndian16(clientWrittenNumber);
-	return clientWrittenNumber;
+	int16_t userVersion = *(int16_t*)(begin);
+	userVersion = bigEndian16(userVersion);
+	return userVersion;
 }
 
 const uint8_t* Versionstamp::begin() const {
@@ -40,5 +40,5 @@ size_t Versionstamp::size() const {
 
 bool Versionstamp::operator==(const Versionstamp& other) const {
 	return getVersion() == other.getVersion() && getBatchNumber() == other.getBatchNumber() &&
-	       getClientWrittenNumber() == other.getClientWrittenNumber();
+	       getUserVersion() == other.getUserVersion();
 }

--- a/fdbclient/Versionstamp.cpp
+++ b/fdbclient/Versionstamp.cpp
@@ -1,0 +1,44 @@
+#include "fdbclient/Versionstamp.h"
+
+Versionstamp::Versionstamp(StringRef str) {
+	if (str.size() != VERSIONSTAMP_TUPLE_SIZE) {
+		throw invalid_versionstamp_size();
+	}
+	data = str;
+}
+
+int16_t Versionstamp::getBatchNumber() const {
+	const uint8_t* begin = data.begin();
+	begin += 8;
+	int16_t batchNumber = *(int16_t*)(begin);
+	batchNumber = bigEndian16(batchNumber);
+	return batchNumber;
+}
+
+int16_t Versionstamp::getClientWrittenNumber() const {
+	const uint8_t* begin = data.begin();
+	begin += 10;
+	int16_t clientWrittenNumber = *(int16_t*)(begin);
+	clientWrittenNumber = bigEndian16(clientWrittenNumber);
+	return clientWrittenNumber;
+}
+
+const uint8_t* Versionstamp::begin() const {
+	return data.begin();
+}
+
+int64_t Versionstamp::getVersion() const {
+	const uint8_t* begin = data.begin();
+	int64_t version = *(int64_t*)begin;
+	version = bigEndian64(version);
+	return version;
+}
+
+size_t Versionstamp::size() const {
+	return VERSIONSTAMP_TUPLE_SIZE;
+}
+
+bool Versionstamp::operator==(const Versionstamp& other) const {
+	return getVersion() == other.getVersion() && getBatchNumber() == other.getBatchNumber() &&
+	       getClientWrittenNumber() == other.getClientWrittenNumber();
+}

--- a/fdbclient/Versionstamp.h
+++ b/fdbclient/Versionstamp.h
@@ -1,3 +1,23 @@
+/*
+ * Versionstamp.h
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2022 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #ifndef FDBCLIENT_VERSIONSTAMP_H
 #define FDBCLIENT_VERSIONSTAMP_H
 

--- a/fdbclient/Versionstamp.h
+++ b/fdbclient/Versionstamp.h
@@ -32,7 +32,7 @@ struct Versionstamp {
 
 	int64_t getVersion() const;
 	int16_t getBatchNumber() const;
-	int16_t getClientWrittenNumber() const;
+	int16_t getUserVersion() const;
 	size_t size() const;
 	const uint8_t* begin() const;
 	bool operator==(const Versionstamp&) const;

--- a/fdbclient/Versionstamp.h
+++ b/fdbclient/Versionstamp.h
@@ -1,0 +1,24 @@
+#ifndef FDBCLIENT_VERSIONSTAMP_H
+#define FDBCLIENT_VERSIONSTAMP_H
+
+#pragma once
+
+#include "flow/Arena.h"
+
+const size_t VERSIONSTAMP_TUPLE_SIZE = 12;
+
+struct Versionstamp {
+	Versionstamp(StringRef);
+
+	int64_t getVersion() const;
+	int16_t getBatchNumber() const;
+	int16_t getClientWrittenNumber() const;
+	size_t size() const;
+	const uint8_t* begin() const;
+	bool operator==(const Versionstamp&) const;
+
+private:
+	Standalone<StringRef> data;
+};
+
+#endif

--- a/flow/error_definitions.h
+++ b/flow/error_definitions.h
@@ -258,6 +258,7 @@ ERROR( directory_prefix_in_use, 2265, "Directory layer already has a conflicting
 ERROR( invalid_destination_directory, 2266, "Target directory is invalid" )
 ERROR( cannot_modify_root_directory, 2267, "Root directory cannot be modified" )
 ERROR( invalid_uuid_size, 2268, "UUID is not sixteen bytes");
+ERROR( invalid_versionstamp_size, 2269, "Versionstamp is not twlve bytes");
 
 // 2300 - backup and restore errors
 ERROR( backup_error, 2300, "Backup error")

--- a/flow/error_definitions.h
+++ b/flow/error_definitions.h
@@ -258,7 +258,7 @@ ERROR( directory_prefix_in_use, 2265, "Directory layer already has a conflicting
 ERROR( invalid_destination_directory, 2266, "Target directory is invalid" )
 ERROR( cannot_modify_root_directory, 2267, "Root directory cannot be modified" )
 ERROR( invalid_uuid_size, 2268, "UUID is not sixteen bytes");
-ERROR( invalid_versionstamp_size, 2269, "Versionstamp is not twlve bytes");
+ERROR( invalid_versionstamp_size, 2269, "Versionstamp is not exactly twelve bytes");
 
 // 2300 - backup and restore errors
 ERROR( backup_error, 2300, "Backup error")


### PR DESCRIPTION
20220602-175030-haofu-870e5182cde63faf

fa7b788fc013dee0b117a78bf95b4a3725d2cc90: 20220602-205400-haofu-48da98901d4da01b


# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
