### PR TITLE
Add DistributedTracerClient enum to mako.

### DIFF
--- a/bindings/c/test/mako/mako.cpp
+++ b/bindings/c/test/mako/mako.cpp
@@ -621,10 +621,10 @@ int workerProcessMain(Arguments const& args, int worker_id, shared_memory::Acces
 
 	/* enable distributed tracing */
 	switch (args.distributed_tracer_client) {
-	case 1:
+	case DistributedTracerClient::NETWORK_LOSSY:
 		err = network::setOptionNothrow(FDB_NET_OPTION_DISTRIBUTED_CLIENT_TRACER, BytesRef(toBytePtr("network_lossy")));
 		break;
-	case 2:
+	case DistributedTracerClient::LOG_FILE:
 		err = network::setOptionNothrow(FDB_NET_OPTION_DISTRIBUTED_CLIENT_TRACER, BytesRef(toBytePtr("log_file")));
 		break;
 	}
@@ -1259,11 +1259,11 @@ int parseArguments(int argc, char* argv[], Arguments& args) {
 			strncpy(args.bg_file_path, optarg, std::min(sizeof(args.bg_file_path), strlen(optarg) + 1));
 		case ARG_DISTRIBUTED_TRACER_CLIENT:
 			if (strcmp(optarg, "disabled") == 0) {
-				args.distributed_tracer_client = 0;
+				args.distributed_tracer_client = DistributedTracerClient::DISABLED;
 			} else if (strcmp(optarg, "network_lossy") == 0) {
-				args.distributed_tracer_client = 1;
+				args.distributed_tracer_client = DistributedTracerClient::NETWORK_LOSSY;
 			} else if (strcmp(optarg, "log_file") == 0) {
-				args.distributed_tracer_client = 2;
+				args.distributed_tracer_client = DistributedTracerClient::LOG_FILE;
 			} else {
 				args.distributed_tracer_client = -1;
 			}

--- a/bindings/c/test/mako/mako.hpp
+++ b/bindings/c/test/mako/mako.hpp
@@ -103,6 +103,8 @@ enum OpKind {
 
 enum TPSChangeTypes { TPS_SIN, TPS_SQUARE, TPS_PULSE };
 
+enum DistributedTracerClient { DISABLED, NETWORK_LOSSY, LOG_FILE };
+
 /* we set WorkloadSpec and Arguments only once in the master process,
  * and won't be touched by child processes.
  */


### PR DESCRIPTION
Per previous request from @sfc-gh-kmakino add an enum for configuration of Distributed Tracer client. Tested locally and with correctness runs.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
