### PR TITLE
Fix some spammy trace events (release-7.1)

### DIFF
--- a/fdbclient/GlobalConfig.actor.cpp
+++ b/fdbclient/GlobalConfig.actor.cpp
@@ -151,6 +151,18 @@ void GlobalConfig::erase(KeyRangeRef range) {
 	}
 }
 
+// Similar to tr.onError(), but doesn't require a DatabaseContext.
+struct Backoff {
+	Future<Void> onError() {
+		double currentBackoff = backoff;
+		backoff = std::min(backoff * CLIENT_KNOBS->BACKOFF_GROWTH_RATE, CLIENT_KNOBS->DEFAULT_MAX_BACKOFF);
+		return delay(currentBackoff * deterministicRandom()->random01());
+	}
+
+private:
+	double backoff = CLIENT_KNOBS->DEFAULT_BACKOFF;
+};
+
 // Older FDB versions used different keys for client profiling data. This
 // function performs a one-time migration of data in these keys to the new
 // global configuration key space.
@@ -158,6 +170,7 @@ ACTOR Future<Void> GlobalConfig::migrate(GlobalConfig* self) {
 	state Key migratedKey("\xff\x02/fdbClientInfo/migrated/"_sr);
 	state Reference<ReadYourWritesTransaction> tr;
 	try {
+		state Backoff backoff;
 		loop {
 			tr = makeReference<ReadYourWritesTransaction>(Database(Reference<DatabaseContext>::addRef(self->cx)));
 			tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
@@ -197,10 +210,11 @@ ACTOR Future<Void> GlobalConfig::migrate(GlobalConfig* self) {
 				// attempt this migration at the same time, sometimes resulting in
 				// aborts due to conflicts. Purposefully avoid retrying, making this
 				// migration best-effort.
-				TraceEvent(SevInfo, "GlobalConfig_RetryableMigrationError").error(e);
+				TraceEvent(SevInfo, "GlobalConfig_RetryableMigrationError").errorUnsuppressed(e).suppressFor(1.0);
 				wait(tr->onError(e));
 				tr.clear();
-				wait(delay(0));
+				// tr is cleared, so it won't backoff properly. Use custom backoff logic here.
+				wait(backoff.onError());
 			}
 		}
 	} catch (Error& e) {
@@ -215,6 +229,8 @@ ACTOR Future<Void> GlobalConfig::migrate(GlobalConfig* self) {
 ACTOR Future<Void> GlobalConfig::refresh(GlobalConfig* self) {
 	// TraceEvent trace(SevInfo, "GlobalConfig_Refresh");
 	self->erase(KeyRangeRef(""_sr, "\xff"_sr));
+
+	state Backoff backoff;
 
 	state Reference<ReadYourWritesTransaction> tr;
 	loop {
@@ -231,7 +247,8 @@ ACTOR Future<Void> GlobalConfig::refresh(GlobalConfig* self) {
 			TraceEvent("GlobalConfigRefreshError").errorUnsuppressed(e).suppressFor(1.0);
 			wait(tr->onError(e));
 			tr.clear();
-			wait(delay(0));
+			// tr is cleared, so it won't backoff properly. Use custom backoff logic here.
+			wait(backoff.onError());
 		}
 	}
 	return Void();

--- a/fdbserver/workloads/Cycle.actor.cpp
+++ b/fdbserver/workloads/Cycle.actor.cpp
@@ -49,7 +49,7 @@ struct CycleWorkload : TestWorkload {
 		actorCount = getOption(options, "actorsPerClient"_sr, transactionsPerSecond / 5);
 		nodeCount = getOption(options, "nodeCount"_sr, transactionsPerSecond * clientCount);
 		keyPrefix = unprintable(getOption(options, "keyPrefix"_sr, LiteralStringRef("")).toString());
-		traceParentProbability = getOption(options, "traceParentProbability "_sr, 0.01);
+		traceParentProbability = getOption(options, "traceParentProbability"_sr, 0.01);
 		minExpectedTransactionsPerSecond = transactionsPerSecond * getOption(options, "expectedRate"_sr, 0.7);
 	}
 
@@ -104,7 +104,7 @@ struct CycleWorkload : TestWorkload {
 				state double tstart = now();
 				state int r = deterministicRandom()->randomInt(0, self->nodeCount);
 				state Transaction tr(cx);
-				if (deterministicRandom()->random01() >= self->traceParentProbability) {
+				if (deterministicRandom()->random01() <= self->traceParentProbability) {
 					state Span span("CycleClient"_loc);
 					//TraceEvent("CycleTracingTransaction", span.context).log();
 					tr.setOption(FDBTransactionOptions::SPAN_PARENT,


### PR DESCRIPTION
Cherry pick https://github.com/apple/foundationdb/pull/7296 to release-7.1



Previously CycleTest was adding a parent span to 99% of transactions instead of the intended 1%, and some retry loops in GlobalConfig did not perform exponential backoff.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
