### PR TITLE
fixup! Add a retry mechanism in changeQuorumChecker and changeQuorum

### DIFF
--- a/fdbclient/ClientKnobs.cpp
+++ b/fdbclient/ClientKnobs.cpp
@@ -287,6 +287,9 @@ void ClientKnobs::initialize(Randomize randomize) {
 	// Blob granules
 	init( BG_MAX_GRANULE_PARALLELISM,                10 );
 
+	init( CHANGE_QUORUM_BAD_STATE_RETRY_TIMES,        3 );
+	init( CHANGE_QUORUM_BAD_STATE_RETRY_DELAY,      2.0 );
+
 	// clang-format on
 }
 

--- a/fdbclient/ClientKnobs.h
+++ b/fdbclient/ClientKnobs.h
@@ -278,6 +278,13 @@ public:
 	// Blob Granules
 	int BG_MAX_GRANULE_PARALLELISM;
 
+	// The coordinator key/value in storage server might be inconsistent to the value stored in the cluster file.
+	// This might happen when a recovery is happening together with a cluster controller coordinator key change.
+	// During this process the database will be marked as "bad state" in changeQuorumChecker while later it will be
+	// available again. Using a backoffed retry when it happens.
+	int CHANGE_QUORUM_BAD_STATE_RETRY_TIMES;
+	double CHANGE_QUORUM_BAD_STATE_RETRY_DELAY;
+
 	ClientKnobs(Randomize randomize);
 	void initialize(Randomize randomize);
 };

--- a/fdbclient/ManagementAPI.actor.cpp
+++ b/fdbclient/ManagementAPI.actor.cpp
@@ -919,9 +919,7 @@ ACTOR Future<Optional<CoordinatorsResult>> changeQuorumChecker(Transaction* tr,
 
 	choose {
 		when(wait(waitForAll(leaderServers))) {}
-		when(wait(delay(5.0))) {
-			return CoordinatorsResult::COORDINATOR_UNREACHABLE;
-		}
+		when(wait(delay(5.0))) { return CoordinatorsResult::COORDINATOR_UNREACHABLE; }
 	}
 	tr->set(coordinatorsKey, conn->toString());
 	return Optional<CoordinatorsResult>();
@@ -1020,9 +1018,7 @@ ACTOR Future<CoordinatorsResult> changeQuorum(Database cx, Reference<IQuorumChan
 				                                           TaskPriority::CoordinationReply));
 			choose {
 				when(wait(waitForAll(leaderServers))) {}
-				when(wait(delay(5.0))) {
-					return CoordinatorsResult::COORDINATOR_UNREACHABLE;
-				}
+				when(wait(delay(5.0))) { return CoordinatorsResult::COORDINATOR_UNREACHABLE; }
 			}
 
 			tr.set(coordinatorsKey, newClusterConnectionString.toString());

--- a/fdbclient/ManagementAPI.actor.cpp
+++ b/fdbclient/ManagementAPI.actor.cpp
@@ -798,23 +798,60 @@ ACTOR Future<Optional<ClusterConnectionString>> getConnectionString(Database cx)
 	}
 }
 
-ACTOR Future<Optional<CoordinatorsResult>> changeQuorumChecker(Transaction* tr,
-                                                               ClusterConnectionString* conn,
-                                                               std::string newName) {
+namespace {
+
+ACTOR Future<Optional<ClusterConnectionString>> getClusterConnectionStringFromStorageServer(Transaction* tr) {
+
 	tr->setOption(FDBTransactionOptions::LOCK_AWARE);
 	tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
 	tr->setOption(FDBTransactionOptions::USE_PROVISIONAL_PROXIES);
 	tr->setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
-	Optional<Value> currentKey = wait(tr->get(coordinatorsKey));
 
-	if (!currentKey.present())
-		return CoordinatorsResult::BAD_DATABASE_STATE; // Someone deleted this key entirely?
+	state int retryTimes = 0;
+	loop {
+		if (retryTimes >= CLIENT_KNOBS->CHANGE_QUORUM_BAD_STATE_RETRY_TIMES) {
+			return Optional<ClusterConnectionString>();
+		}
 
-	state ClusterConnectionString old(currentKey.get().toString());
-	if (tr->getDatabase()->getConnectionRecord() &&
-	    old.clusterKeyName().toString() !=
-	        tr->getDatabase()->getConnectionRecord()->getConnectionString().clusterKeyName())
-		return CoordinatorsResult::BAD_DATABASE_STATE; // Someone changed the "name" of the database??
+		Version readVersion = wait(tr->getReadVersion());
+		state Optional<Value> currentKey = wait(tr->get(coordinatorsKey));
+
+		if (!currentKey.present()) {
+			// Someone deleted this key entirely?
+			++retryTimes;
+			wait(delay(CLIENT_KNOBS->CHANGE_QUORUM_BAD_STATE_RETRY_DELAY));
+			continue;
+		}
+
+		state ClusterConnectionString clusterConnectionString(currentKey.get().toString());
+		if (tr->getDatabase()->getConnectionRecord() &&
+		    clusterConnectionString.clusterKeyName().toString() !=
+		        tr->getDatabase()->getConnectionRecord()->getConnectionString().clusterKeyName()) {
+			// Someone changed the "name" of the database??
+			++retryTimes;
+			wait(delay(CLIENT_KNOBS->CHANGE_QUORUM_BAD_STATE_RETRY_DELAY));
+			continue;
+		}
+
+		return clusterConnectionString;
+	}
+}
+
+} // namespace
+
+ACTOR Future<Optional<CoordinatorsResult>> changeQuorumChecker(Transaction* tr,
+                                                               ClusterConnectionString* conn,
+                                                               std::string newName) {
+
+	state Optional<ClusterConnectionString> clusterConnectionStringOptional =
+	    wait(getClusterConnectionStringFromStorageServer(tr));
+
+	if (!clusterConnectionStringOptional.present()) {
+		return CoordinatorsResult::BAD_DATABASE_STATE;
+	}
+
+	// The cluster connection string stored in the storage server
+	state ClusterConnectionString old = clusterConnectionStringOptional.get();
 
 	if (conn->hostnames.size() + conn->coords.size() == 0) {
 		conn->hostnames = old.hostnames;
@@ -882,7 +919,9 @@ ACTOR Future<Optional<CoordinatorsResult>> changeQuorumChecker(Transaction* tr,
 
 	choose {
 		when(wait(waitForAll(leaderServers))) {}
-		when(wait(delay(5.0))) { return CoordinatorsResult::COORDINATOR_UNREACHABLE; }
+		when(wait(delay(5.0))) {
+			return CoordinatorsResult::COORDINATOR_UNREACHABLE;
+		}
 	}
 	tr->set(coordinatorsKey, conn->toString());
 	return Optional<CoordinatorsResult>();
@@ -896,28 +935,26 @@ ACTOR Future<CoordinatorsResult> changeQuorum(Database cx, Reference<IQuorumChan
 
 	loop {
 		try {
-			tr.setOption(FDBTransactionOptions::LOCK_AWARE);
-			tr.setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
-			tr.setOption(FDBTransactionOptions::USE_PROVISIONAL_PROXIES);
-			tr.setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
-			Optional<Value> currentKey = wait(tr.get(coordinatorsKey));
+			state Optional<ClusterConnectionString> clusterConnectionStringOptional =
+			    wait(getClusterConnectionStringFromStorageServer(&tr));
 
-			if (!currentKey.present())
-				return CoordinatorsResult::BAD_DATABASE_STATE; // Someone deleted this key entirely?
+			if (!clusterConnectionStringOptional.present()) {
+				return CoordinatorsResult::BAD_DATABASE_STATE;
+			}
 
-			state ClusterConnectionString old(currentKey.get().toString());
-			if (cx->getConnectionRecord() &&
-			    old.clusterKeyName().toString() != cx->getConnectionRecord()->getConnectionString().clusterKeyName())
-				return CoordinatorsResult::BAD_DATABASE_STATE; // Someone changed the "name" of the database??
+			// The cluster connection string stored in the storage server
+			state ClusterConnectionString oldClusterConnectionString = clusterConnectionStringOptional.get();
+			state Key oldClusterKeyName = oldClusterConnectionString.clusterKeyName();
 
-			state std::vector<NetworkAddress> oldCoordinators = wait(old.tryResolveHostnames());
+			state std::vector<NetworkAddress> oldCoordinators = wait(oldClusterConnectionString.tryResolveHostnames());
 			state CoordinatorsResult result = CoordinatorsResult::SUCCESS;
 			if (!desiredCoordinators.size()) {
-				std::vector<NetworkAddress> _desiredCoordinators = wait(change->getDesiredCoordinators(
-				    &tr,
-				    oldCoordinators,
-				    Reference<ClusterConnectionMemoryRecord>(new ClusterConnectionMemoryRecord(old)),
-				    result));
+				std::vector<NetworkAddress> _desiredCoordinators = wait(
+				    change->getDesiredCoordinators(&tr,
+				                                   oldCoordinators,
+				                                   Reference<ClusterConnectionMemoryRecord>(
+				                                       new ClusterConnectionMemoryRecord(oldClusterConnectionString)),
+				                                   result));
 				desiredCoordinators = _desiredCoordinators;
 			}
 
@@ -937,13 +974,14 @@ ACTOR Future<CoordinatorsResult> changeQuorum(Database cx, Reference<IQuorumChan
 
 			std::string newName = change->getDesiredClusterKeyName();
 			if (newName.empty())
-				newName = old.clusterKeyName().toString();
+				newName = oldClusterKeyName.toString();
 
-			if (oldCoordinators == desiredCoordinators && old.clusterKeyName() == newName)
+			if (oldCoordinators == desiredCoordinators && oldClusterKeyName == newName)
 				return retries ? CoordinatorsResult::SUCCESS : CoordinatorsResult::SAME_NETWORK_ADDRESSES;
 
-			state ClusterConnectionString conn(
+			state ClusterConnectionString newClusterConnectionString(
 			    desiredCoordinators, StringRef(newName + ':' + deterministicRandom()->randomAlphaNumeric(32)));
+			state Key newClusterKeyName = newClusterConnectionString.clusterKeyName();
 
 			if (g_network->isSimulated()) {
 				for (int i = 0; i < (desiredCoordinators.size() / 2) + 1; i++) {
@@ -958,19 +996,22 @@ ACTOR Future<CoordinatorsResult> changeQuorum(Database cx, Reference<IQuorumChan
 				}
 			}
 
-			TraceEvent("AttemptingQuorumChange").detail("FromCS", old.toString()).detail("ToCS", conn.toString());
-			TEST(old.clusterKeyName() != conn.clusterKeyName()); // Quorum change with new name
-			TEST(old.clusterKeyName() == conn.clusterKeyName()); // Quorum change with unchanged name
+			TraceEvent("AttemptingQuorumChange")
+			    .detail("FromCS", oldClusterConnectionString.toString())
+			    .detail("ToCS", newClusterConnectionString.toString());
+			TEST(oldClusterKeyName != newClusterKeyName); // Quorum change with new name
+			TEST(oldClusterKeyName == newClusterKeyName); // Quorum change with unchanged name
 
 			state std::vector<Future<Optional<LeaderInfo>>> leaderServers;
-			state ClientCoordinators coord(
-			    Reference<ClusterConnectionMemoryRecord>(new ClusterConnectionMemoryRecord(conn)));
+			state ClientCoordinators coord(Reference<ClusterConnectionMemoryRecord>(
+			    new ClusterConnectionMemoryRecord(newClusterConnectionString)));
 			// check if allowed to modify the cluster descriptor
 			if (!change->getDesiredClusterKeyName().empty()) {
 				CheckDescriptorMutableReply mutabilityReply =
 				    wait(coord.clientLeaderServers[0].checkDescriptorMutable.getReply(CheckDescriptorMutableRequest()));
-				if (!mutabilityReply.isMutable)
+				if (!mutabilityReply.isMutable) {
 					return CoordinatorsResult::BAD_DATABASE_STATE;
+				}
 			}
 			leaderServers.reserve(coord.clientLeaderServers.size());
 			for (int i = 0; i < coord.clientLeaderServers.size(); i++)
@@ -979,10 +1020,12 @@ ACTOR Future<CoordinatorsResult> changeQuorum(Database cx, Reference<IQuorumChan
 				                                           TaskPriority::CoordinationReply));
 			choose {
 				when(wait(waitForAll(leaderServers))) {}
-				when(wait(delay(5.0))) { return CoordinatorsResult::COORDINATOR_UNREACHABLE; }
+				when(wait(delay(5.0))) {
+					return CoordinatorsResult::COORDINATOR_UNREACHABLE;
+				}
 			}
 
-			tr.set(coordinatorsKey, conn.toString());
+			tr.set(coordinatorsKey, newClusterConnectionString.toString());
 
 			wait(tr.commit());
 			ASSERT(false); // commit should fail, but the value has changed


### PR DESCRIPTION
This is to fix an issue when recovery and change coordinator key happens together. The issue will occur when:

1. Recovery starts
2. Coordinator key change transaction started
3. During the recovery the coordinator key is read from cluster file and stored in the storage server
4. The cluster controller received `ChangeCoordiatorsRequest`, and updated the cluster name with the new value.

At this stage, the value related to coordinator key in storage server and
the worker is inconsistent.

5. changeQuorumChecker is called, which will verify such consistency. Since they are different, the call is returning failure and the caller, which could be a TEST_CASE, fails.

This is a rare race issue, and it is also noticed that when the recovery/coordinator key change process is done, the database is in a proper state which allows changeQuorumChecker behave properly. In this case, a retry mechanism should be sufficiently fix corresponding test failures.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
