### PR TITLE
Fix versionstamp in Tester (release-7.1)

### DIFF
--- a/bindings/flow/tester/Tester.actor.cpp
+++ b/bindings/flow/tester/Tester.actor.cpp
@@ -1154,7 +1154,7 @@ struct TuplePackFunc : InstructionFunc {
 				} else if (type == Tuple::NESTED) {
 					tuple.appendNested(itemTuple.getNested(0));
 				} else if (type == Tuple::VERSIONSTAMP) {
-					tuple.appendVersionstamp(Versionstamp(itemTuple.getString(0)));
+					tuple.appendVersionstamp(itemTuple.getVersionstamp(0));
 				} else {
 					ASSERT(false);
 				}
@@ -1235,7 +1235,7 @@ struct TupleRangeFunc : InstructionFunc {
 				} else if (type == Tuple::NESTED) {
 					tuple.appendNested(itemTuple.getNested(0));
 				} else if (type == Tuple::VERSIONSTAMP) {
-					tuple.appendVersionstamp(Versionstamp(itemTuple.getString(0)));
+					tuple.appendVersionstamp(itemTuple.getVersionstamp(0));
 				} else {
 					ASSERT(false);
 				}


### PR DESCRIPTION
backport https://github.com/apple/foundationdb/pull/7312

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
