### PR TITLE
Arm64 related build fixes

### DIFF
--- a/bindings/c/test/unit/third_party/CMakeLists.txt
+++ b/bindings/c/test/unit/third_party/CMakeLists.txt
@@ -6,7 +6,7 @@ ExternalProject_Add(
     doctest
     PREFIX ${CMAKE_BINARY_DIR}/doctest
     GIT_REPOSITORY https://github.com/onqtam/doctest.git
-    GIT_TAG 8424be522357e68d8c6178375546bb0cf9d5f6b3 # v2.4.1
+    GIT_TAG 7b9885133108ae301ddd16e2651320f54cafeba7 # v2.4.8
     TIMEOUT 10
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ""

--- a/fdbbackup/FileDecoder.actor.cpp
+++ b/fdbbackup/FileDecoder.actor.cpp
@@ -428,7 +428,7 @@ public:
 					platform::createDirectory(path);
 				}
 			}
-			self->lfd = open(self->file.fileName.c_str(), O_WRONLY | O_CREAT | O_TRUNC);
+			self->lfd = open(self->file.fileName.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0600);
 			if (self->lfd == -1) {
 				TraceEvent(SevError, "OpenLocalFileFailed").detail("File", self->file.fileName);
 				throw platform_error();

--- a/flow/WriteOnlySet.actor.cpp
+++ b/flow/WriteOnlySet.actor.cpp
@@ -25,6 +25,7 @@
 
 #include <chrono>
 #include <random>
+#include <thread>
 #include "flow/actorcompiler.h" // has to be last include
 
 #ifdef ENABLE_SAMPLING


### PR DESCRIPTION
Fixes the following build issues on arm64 (Mac with an M1 processor):

Sleep_for() method not found in std::this_thread: 
```
FAILED: flow/CMakeFiles/flow_sampling.dir/WriteOnlySet.actor.g.cpp.o
/usr/bin/c++ -DBOOST_ERROR_CODE_HEADER_ONLY -DBOOST_SYSTEM_NO_DEPRECATED -DENABLE_SAMPLING -DNO_INTELLISENSE -I/foundationdb -I/build_output -isystem /build_output/boost_install/include -D_GLIBCXX_USE_NANOSLEEP -O3 -DNDEBUG -DCMAKE_BUILD -ggdb -fno-omit-frame-pointer -Wno-pragmas -Wno-attributes -Wno-error=format -Wunused-variable -Wno-deprecated -fvisibility=hidden -Wreturn-type -fPIC -march=armv8.2-a+crc+simd -DHAVE_OPENSSL -std=gnu++17 -MD -MT flow/CMakeFiles/flow_sampling.dir/WriteOnlySet.actor.g.cpp.o -MF flow/CMakeFiles/flow_sampling.dir/WriteOnlySet.actor.g.cpp.o.d -o flow/CMakeFiles/flow_sampling.dir/WriteOnlySet.actor.g.cpp.o -c /build_output/flow/WriteOnlySet.actor.g.cpp
/foundationdb/flow/WriteOnlySet.actor.cpp: In function 'void {anonymous}::testCopier(std::shared_ptr<WriteOnlySet<{anonymous}::TestObject, unsigned int, 128> >, std::chrono::seconds)':
/foundationdb/flow/WriteOnlySet.actor.cpp:213:35: error: 'sleep_for' is not a member of 'std::this_thread'
  213 |                 std::this_thread::sleep_for(std::chrono::milliseconds(10));
      |                                   ^~~~~~~~~
```

Open() call is missing the mode argument:
```
[1237/1385] Building CXX object fdbbackup/CMakeFiles/fdbdecode.dir/FileDecoder.actor.g.cpp.o
FAILED: fdbbackup/CMakeFiles/fdbdecode.dir/FileDecoder.actor.g.cpp.o
/usr/bin/c++ -DBOOST_ERROR_CODE_HEADER_ONLY -DBOOST_SYSTEM_NO_DEPRECATED -DNO_INTELLISENSE -I/foundationdb -I/build_output -I/foundationdb/contrib/fmt-8.1.1/include -isystem /build_output/boost_install/include -isystem /build_output/msgpackProject-prefix/src/msgpackProject/include -O3 -DNDEBUG -DCMAKE_BUILD -ggdb -fno-omit-frame-pointer -Wno-pragmas -Wno-attributes -Wno-error=format -Wunused-variable -Wno-deprecated -fvisibility=hidden -Wreturn-type -fPIC -march=armv8.2-a+crc+simd -DHAVE_OPENSSL -std=gnu++17 -MD -MT fdbbackup/CMakeFiles/fdbdecode.dir/FileDecoder.actor.g.cpp.o -MF fdbbackup/CMakeFiles/fdbdecode.dir/FileDecoder.actor.g.cpp.o.d -o fdbbackup/CMakeFiles/fdbdecode.dir/FileDecoder.actor.g.cpp.o -c /build_output/fdbbackup/FileDecoder.actor.g.cpp
In file included from /usr/include/fcntl.h:314,
                 from /foundationdb/fdbbackup/FileDecoder.actor.cpp:28:
In function 'int open(const char*, int, ...)',
    inlined from 'int file_converter::DecodeProgress::OpenFileImplActorState<OpenFileImplActor>::a_body1cont1(const Reference<IAsyncFile>&, int) [with OpenFileImplActor = file_converter::DecodeProgress::OpenFileImplActor]' at /foundationdb/fdbbackup/FileDecoder.actor.cpp:431:20:
/usr/include/aarch64-linux-gnu/bits/fcntl2.h:50:31: error: call to '__open_missing_mode' declared with attribute error: open with O_CREAT or O_TMPFILE in second argument needs 3 arguments
   50 |           __open_missing_mode ();
      |           ~~~~~~~~~~~~~~~~~~~~^~
```

SGISTKSZ no longer static in recent glibc (2.34+):

```
FAILED: bindings/c/CMakeFiles/fdb_c_setup_tests.dir/test/unit/setup_tests.cpp.o
/usr/bin/c++ -DBOOST_ERROR_CODE_HEADER_ONLY -DBOOST_SYSTEM_NO_DEPRECATED -DNO_INTELLISENSE -I/foundationdb -I/build_output -I/build_output/doctest/src/doctest/doctest -I/build_output/bindings/c -I/foundationdb/bindings/c -I/build_output/bindings/c/foundationdb -O3 -DNDEBUG -DCMAKE_BUILD -ggdb -fno-omit-frame-pointer -Wno-pragmas -Wno-attributes -Wno-error=format -Wunused-variable -Wno-deprecated -fvisibility=hidden -Wreturn-type -fPIC -march=armv8.2-a+crc+simd -DHAVE_OPENSSL -std=gnu++17 -MD -MT bindings/c/CMakeFiles/fdb_c_setup_tests.dir/test/unit/setup_tests.cpp.o -MF bindings/c/CMakeFiles/fdb_c_setup_tests.dir/test/unit/setup_tests.cpp.o.d -o bindings/c/CMakeFiles/fdb_c_setup_tests.dir/test/unit/setup_tests.cpp.o -c /foundationdb/bindings/c/test/unit/setup_tests.cpp
In file included from /foundationdb/bindings/c/test/unit/setup_tests.cpp:29:
/build_output/doctest/src/doctest/doctest/doctest.h:4084:47: error: size of array 'altStackMem' is not an integral constant-expression
 4084 |         static char             altStackMem[4 * SIGSTKSZ];
      |                                               ^
 ```

Built it with the Dockerfile in https://github.com/FoundationDB/fdb-build-support/pull/29/.

I pushed an image to DockerHub with the installed debs as `tigrisdata/foundationdb:7.2-snapshot`.

```
➜  ~ docker run -ti -v ~/packages:/packages --name release --platform linux/arm64/v8 ubuntu:latest
APSHOT_aarch64.deb/# dpkg -i /packages/foundationdb-clients_7.2.0-0.ae98f97aa.SNA
Selecting previously unselected package foundationdb-clients.
(Reading database ... 4389 files and directories currently installed.)
Preparing to unpack .../foundationdb-clients_7.2.0-0.ae98f97aa.SNAPSHOT_aarch64.deb ...
Unpacking foundationdb-clients (7.2.0) ...
Setting up foundationdb-clients (7.2.0) ...
Adding group `foundationdb' (GID 101) ...
Done.
Warning: The home dir /var/lib/foundationdb you specified can't be accessed: No such file or directory
Adding system user `foundationdb' (UID 101) ...
Adding new user `foundationdb' (UID 101) with group `foundationdb' ...
Not creating home directory `/var/lib/foundationdb'.
Processing triggers for libc-bin (2.35-0ubuntu3) ...
root@df507adec767:/# dpkg -i /packages/foundationdb-server_7.2.0-0.ae98f97aa.SNAPSHOT_aarch64.deb
Selecting previously unselected package foundationdb-server.
(Reading database ... 4412 files and directories currently installed.)
Preparing to unpack .../foundationdb-server_7.2.0-0.ae98f97aa.SNAPSHOT_aarch64.deb ...
Unpacking foundationdb-server (7.2.0) ...
Setting up foundationdb-server (7.2.0) ...
>>> configure new single memory
Database created
>>> status
Using cluster file `/etc/foundationdb/fdb.cluster'.

Unable to retrieve all status information.

Configuration:
  Redundancy mode        - single
  Storage engine         - memory-2
  Coordinators           - 1
  Usable Regions         - 1

Cluster:
  FoundationDB processes - 1
  Zones                  - unknown
  Machines               - 0
  Fault Tolerance        - 0 machines
  Server time            - 06/06/22 00:34:21

Data:
  Replication health     - (Re)initializing automatic data distribution
  Moving data            - unknown (initializing)
  Sum of key-value sizes - unknown
  Disk space used        - unknown

Operating space:
  Unable to retrieve operating space status

Workload:
  Read rate              - 0 Hz
  Write rate             - 0 Hz
  Transactions started   - 0 Hz
  Transactions committed - 0 Hz
  Conflict rate          - 0 Hz

Backup and DR:
  Running backups        - 0
  Running DRs            - 0

Client time: 06/06/22 00:34:21
```

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
