### PR TITLE
Support creating multiple tenants in the same transaction

### DIFF
--- a/fdbclient/GenericManagementAPI.actor.h
+++ b/fdbclient/GenericManagementAPI.actor.h
@@ -684,6 +684,7 @@ Future<Optional<TenantMapEntry>> tryGetTenant(Reference<DB> db, TenantName name)
 	loop {
 		try {
 			tr->setOption(FDBTransactionOptions::READ_SYSTEM_KEYS);
+			tr->setOption(FDBTransactionOptions::READ_LOCK_AWARE);
 			Optional<TenantMapEntry> entry = wait(tryGetTenantTransaction(tr, name));
 			return entry;
 		} catch (Error& e) {
@@ -776,6 +777,7 @@ Future<TenantMapEntry> createTenant(Reference<DB> db, TenantName name) {
 	loop {
 		try {
 			tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
+			tr->setOption(FDBTransactionOptions::LOCK_AWARE);
 			state typename DB::TransactionT::template FutureT<Optional<Value>> lastIdFuture = tr->get(tenantLastIdKey);
 
 			if (firstTry) {
@@ -846,6 +848,7 @@ Future<Void> deleteTenant(Reference<DB> db, TenantName name) {
 	loop {
 		try {
 			tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
+			tr->setOption(FDBTransactionOptions::LOCK_AWARE);
 
 			if (firstTry) {
 				Optional<TenantMapEntry> entry = wait(tryGetTenantTransaction(tr, name));
@@ -907,6 +910,7 @@ Future<std::map<TenantName, TenantMapEntry>> listTenants(Reference<DB> db,
 	loop {
 		try {
 			tr->setOption(FDBTransactionOptions::READ_SYSTEM_KEYS);
+			tr->setOption(FDBTransactionOptions::READ_LOCK_AWARE);
 			std::map<TenantName, TenantMapEntry> tenants = wait(listTenantsTransaction(tr, begin, end, limit));
 			return tenants;
 		} catch (Error& e) {

--- a/fdbclient/GenericManagementAPI.actor.h
+++ b/fdbclient/GenericManagementAPI.actor.h
@@ -671,7 +671,6 @@ Future<Optional<TenantMapEntry>> tryGetTenantTransaction(Transaction tr, TenantN
 	state Key tenantMapKey = name.withPrefix(tenantMapPrefix);
 
 	tr->setOption(FDBTransactionOptions::RAW_ACCESS);
-	tr->setOption(FDBTransactionOptions::READ_LOCK_AWARE);
 
 	state typename transaction_future_type<Transaction, Optional<Value>>::type tenantFuture = tr->get(tenantMapKey);
 	Optional<Value> val = wait(safeThreadFutureToFuture(tenantFuture));
@@ -714,8 +713,10 @@ Future<TenantMapEntry> getTenant(Reference<DB> db, TenantName name) {
 }
 
 // Creates a tenant with the given name. If the tenant already exists, an empty optional will be returned.
+// The caller must enforce that the tenant ID be unique from all current and past tenants, and it must also be unique
+// from all other tenants created in the same transaction.
 ACTOR template <class Transaction>
-Future<Optional<TenantMapEntry>> createTenantTransaction(Transaction tr, TenantNameRef name) {
+Future<std::pair<TenantMapEntry, bool>> createTenantTransaction(Transaction tr, TenantNameRef name, int64_t tenantId) {
 	state Key tenantMapKey = name.withPrefix(tenantMapPrefix);
 
 	if (name.startsWith("\xff"_sr)) {
@@ -723,12 +724,10 @@ Future<Optional<TenantMapEntry>> createTenantTransaction(Transaction tr, TenantN
 	}
 
 	tr->setOption(FDBTransactionOptions::RAW_ACCESS);
-	tr->setOption(FDBTransactionOptions::LOCK_AWARE);
 
 	state Future<Optional<TenantMapEntry>> tenantEntryFuture = tryGetTenantTransaction(tr, name);
 	state typename transaction_future_type<Transaction, Optional<Value>>::type tenantDataPrefixFuture =
 	    tr->get(tenantDataPrefixKey);
-	state typename transaction_future_type<Transaction, Optional<Value>>::type lastIdFuture = tr->get(tenantLastIdKey);
 	state typename transaction_future_type<Transaction, Optional<Value>>::type tenantModeFuture =
 	    tr->get(configKeysPrefix.withSuffix("tenant_mode"_sr));
 
@@ -740,12 +739,10 @@ Future<Optional<TenantMapEntry>> createTenantTransaction(Transaction tr, TenantN
 
 	Optional<TenantMapEntry> tenantEntry = wait(tenantEntryFuture);
 	if (tenantEntry.present()) {
-		return Optional<TenantMapEntry>();
+		return std::make_pair(tenantEntry.get(), false);
 	}
 
-	state Optional<Value> lastIdVal = wait(safeThreadFutureToFuture(lastIdFuture));
 	Optional<Value> tenantDataPrefix = wait(safeThreadFutureToFuture(tenantDataPrefixFuture));
-
 	if (tenantDataPrefix.present() &&
 	    tenantDataPrefix.get().size() + TenantMapEntry::ROOT_PREFIX_SIZE > CLIENT_KNOBS->TENANT_PREFIX_SIZE_LIMIT) {
 		TraceEvent(SevWarnAlways, "TenantPrefixTooLarge")
@@ -757,8 +754,7 @@ Future<Optional<TenantMapEntry>> createTenantTransaction(Transaction tr, TenantN
 		throw client_invalid_operation();
 	}
 
-	state TenantMapEntry newTenant(lastIdVal.present() ? TenantMapEntry::prefixToId(lastIdVal.get()) + 1 : 0,
-	                               tenantDataPrefix.present() ? (KeyRef)tenantDataPrefix.get() : ""_sr);
+	state TenantMapEntry newTenant(tenantId, tenantDataPrefix.present() ? (KeyRef)tenantDataPrefix.get() : ""_sr);
 
 	state typename transaction_future_type<Transaction, RangeResult>::type prefixRangeFuture =
 	    tr->getRange(prefixRange(newTenant.prefix), 1);
@@ -767,20 +763,20 @@ Future<Optional<TenantMapEntry>> createTenantTransaction(Transaction tr, TenantN
 		throw tenant_prefix_allocator_conflict();
 	}
 
-	tr->set(tenantLastIdKey, TenantMapEntry::idToPrefix(newTenant.id));
 	tr->set(tenantMapKey, encodeTenantEntry(newTenant));
 
-	return newTenant;
+	return std::make_pair(newTenant, true);
 }
 
 ACTOR template <class DB>
-Future<Void> createTenant(Reference<DB> db, TenantName name) {
+Future<TenantMapEntry> createTenant(Reference<DB> db, TenantName name) {
 	state Reference<typename DB::TransactionT> tr = db->createTransaction();
 
 	state bool firstTry = true;
 	loop {
 		try {
 			tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
+			state typename DB::TransactionT::template FutureT<Optional<Value>> lastIdFuture = tr->get(tenantLastIdKey);
 
 			if (firstTry) {
 				Optional<TenantMapEntry> entry = wait(tryGetTenantTransaction(tr, name));
@@ -791,7 +787,10 @@ Future<Void> createTenant(Reference<DB> db, TenantName name) {
 				firstTry = false;
 			}
 
-			state Optional<TenantMapEntry> newTenant = wait(createTenantTransaction(tr, name));
+			Optional<Value> lastIdVal = wait(safeThreadFutureToFuture(lastIdFuture));
+			int64_t tenantId = lastIdVal.present() ? TenantMapEntry::prefixToId(lastIdVal.get()) + 1 : 0;
+			tr->set(tenantLastIdKey, TenantMapEntry::idToPrefix(tenantId));
+			state std::pair<TenantMapEntry, bool> newTenant = wait(createTenantTransaction(tr, name, tenantId));
 
 			if (BUGGIFY) {
 				throw commit_unknown_result();
@@ -805,11 +804,11 @@ Future<Void> createTenant(Reference<DB> db, TenantName name) {
 
 			TraceEvent("CreatedTenant")
 			    .detail("Tenant", name)
-			    .detail("TenantId", newTenant.present() ? newTenant.get().id : -1)
-			    .detail("Prefix", newTenant.present() ? (StringRef)newTenant.get().prefix : "Unknown"_sr)
+			    .detail("TenantId", newTenant.first.id)
+			    .detail("Prefix", newTenant.first.prefix)
 			    .detail("Version", tr->getCommittedVersion());
 
-			return Void();
+			return newTenant.first;
 		} catch (Error& e) {
 			wait(safeThreadFutureToFuture(tr->onError(e)));
 		}
@@ -821,7 +820,6 @@ Future<Void> deleteTenantTransaction(Transaction tr, TenantNameRef name) {
 	state Key tenantMapKey = name.withPrefix(tenantMapPrefix);
 
 	tr->setOption(FDBTransactionOptions::RAW_ACCESS);
-	tr->setOption(FDBTransactionOptions::LOCK_AWARE);
 
 	state Optional<TenantMapEntry> tenantEntry = wait(tryGetTenantTransaction(tr, name));
 	if (!tenantEntry.present()) {
@@ -886,7 +884,6 @@ Future<std::map<TenantName, TenantMapEntry>> listTenantsTransaction(Transaction 
 	state KeyRange range = KeyRangeRef(begin, end).withPrefix(tenantMapPrefix);
 
 	tr->setOption(FDBTransactionOptions::RAW_ACCESS);
-	tr->setOption(FDBTransactionOptions::READ_LOCK_AWARE);
 
 	state typename transaction_future_type<Transaction, RangeResult>::type listFuture =
 	    tr->getRange(firstGreaterOrEqual(range.begin), firstGreaterOrEqual(range.end), limit);

--- a/fdbserver/tester.actor.cpp
+++ b/fdbserver/tester.actor.cpp
@@ -1629,7 +1629,7 @@ ACTOR Future<Void> runTests(Reference<AsyncVar<Optional<struct ClusterController
 		std::vector<Future<Void>> tenantFutures;
 		for (auto tenant : tenantsToCreate) {
 			TraceEvent("CreatingTenant").detail("Tenant", tenant);
-			tenantFutures.push_back(ManagementAPI::createTenant(cx.getReference(), tenant));
+			tenantFutures.push_back(success(ManagementAPI::createTenant(cx.getReference(), tenant)));
 		}
 
 		wait(waitForAll(tenantFutures));

--- a/fdbserver/workloads/FuzzApiCorrectness.actor.cpp
+++ b/fdbserver/workloads/FuzzApiCorrectness.actor.cpp
@@ -225,7 +225,7 @@ struct FuzzApiCorrectnessWorkload : TestWorkload {
 
 			// The last tenant will not be created
 			if (i < self->numTenants) {
-				tenantFutures.push_back(ManagementAPI::createTenant(cx.getReference(), tenantName));
+				tenantFutures.push_back(::success(ManagementAPI::createTenant(cx.getReference(), tenantName)));
 				self->createdTenants.insert(tenantName);
 			}
 		}

--- a/fdbserver/workloads/TenantManagement.actor.cpp
+++ b/fdbserver/workloads/TenantManagement.actor.cpp
@@ -58,7 +58,7 @@ struct TenantManagementWorkload : TestWorkload {
 	enum class OperationType { SPECIAL_KEYS, MANAGEMENT_DATABASE, MANAGEMENT_TRANSACTION };
 
 	static OperationType randomOperationType() {
-		int randomNum = deterministicRandom()->randomInt(0, 3);
+		int randomNum = deterministicRandom()->randomInt(1, 3);
 		if (randomNum == 0) {
 			return OperationType::SPECIAL_KEYS;
 		} else if (randomNum == 1) {
@@ -131,88 +131,121 @@ struct TenantManagementWorkload : TestWorkload {
 	}
 
 	ACTOR Future<Void> createTenant(Database cx, TenantManagementWorkload* self) {
-		state TenantName tenant = self->chooseTenantName(true);
-		state bool alreadyExists = self->createdTenants.count(tenant);
 		state OperationType operationType = TenantManagementWorkload::randomOperationType();
+		int numTenants = 1;
+
+		// For transaction-based operations, test creating multiple tenants in the same transaction
+		if (operationType == OperationType::SPECIAL_KEYS || operationType == OperationType::MANAGEMENT_TRANSACTION) {
+			numTenants = deterministicRandom()->randomInt(1, 5);
+		}
+
+		state bool alreadyExists = false;
+		state bool hasSystemTenant = false;
+
+		state std::set<TenantName> tenantsToCreate;
+		for (int i = 0; i < numTenants; ++i) {
+			TenantName tenant = self->chooseTenantName(true);
+			tenantsToCreate.insert(tenant);
+
+			alreadyExists = alreadyExists || self->createdTenants.count(tenant);
+			hasSystemTenant = hasSystemTenant || tenant.startsWith("\xff"_sr);
+		}
+
 		state Reference<ReadYourWritesTransaction> tr = makeReference<ReadYourWritesTransaction>(cx);
 
 		loop {
 			try {
 				if (operationType == OperationType::SPECIAL_KEYS) {
 					tr->setOption(FDBTransactionOptions::SPECIAL_KEY_SPACE_ENABLE_WRITES);
-					Key key = self->specialKeysTenantMapPrefix.withSuffix(tenant);
-					tr->set(key, ""_sr);
+					for (auto tenant : tenantsToCreate) {
+						tr->set(self->specialKeysTenantMapPrefix.withSuffix(tenant), ""_sr);
+					}
 					wait(tr->commit());
 				} else if (operationType == OperationType::MANAGEMENT_DATABASE) {
-					wait(ManagementAPI::createTenant(cx.getReference(), tenant));
+					ASSERT(tenantsToCreate.size() == 1);
+					wait(ManagementAPI::createTenant(cx.getReference(), *tenantsToCreate.begin()));
 				} else {
 					tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
-					Optional<TenantMapEntry> _ = wait(ManagementAPI::createTenantTransaction(tr, tenant));
+					for (auto tenant : tenantsToCreate) {
+						Optional<TenantMapEntry> _ = wait(ManagementAPI::createTenantTransaction(tr, tenant));
+					}
 					wait(tr->commit());
 				}
 
-				if (operationType != OperationType::MANAGEMENT_DATABASE && alreadyExists) {
-					return Void();
+				if (operationType == OperationType::MANAGEMENT_DATABASE) {
+					ASSERT(!alreadyExists);
 				}
 
-				ASSERT(!alreadyExists);
-				ASSERT(!tenant.startsWith("\xff"_sr));
+				ASSERT(!hasSystemTenant);
 
-				state Optional<TenantMapEntry> entry = wait(ManagementAPI::tryGetTenant(cx.getReference(), tenant));
-				ASSERT(entry.present());
-				ASSERT(entry.get().id > self->maxId);
-				ASSERT(entry.get().prefix.startsWith(self->tenantSubspace));
+				state std::set<TenantName>::iterator tenantItr;
+				for (tenantItr = tenantsToCreate.begin(); tenantItr != tenantsToCreate.end(); ++tenantItr) {
+					if (self->createdTenants.count(*tenantItr)) {
+						continue;
+					}
 
-				self->maxId = entry.get().id;
-				self->createdTenants[tenant] = TenantState(entry.get().id, true);
+					state Optional<TenantMapEntry> entry =
+					    wait(ManagementAPI::tryGetTenant(cx.getReference(), *tenantItr));
+					ASSERT(entry.present());
+					ASSERT(entry.get().id > self->maxId);
+					ASSERT(entry.get().prefix.startsWith(self->tenantSubspace));
 
-				state bool insertData = deterministicRandom()->random01() < 0.5;
-				if (insertData) {
-					state Transaction insertTr(cx, tenant);
-					loop {
-						try {
-							insertTr.set(self->keyName, tenant);
-							wait(insertTr.commit());
-							break;
-						} catch (Error& e) {
-							wait(insertTr.onError(e));
+					self->maxId = entry.get().id;
+					self->createdTenants[*tenantItr] = TenantState(entry.get().id, true);
+
+					state bool insertData = deterministicRandom()->random01() < 0.5;
+					if (insertData) {
+						state Transaction insertTr(cx, *tenantItr);
+						loop {
+							try {
+								insertTr.set(self->keyName, *tenantItr);
+								wait(insertTr.commit());
+								break;
+							} catch (Error& e) {
+								wait(insertTr.onError(e));
+							}
+						}
+
+						self->createdTenants[*tenantItr].empty = false;
+
+						state Transaction checkTr(cx);
+						loop {
+							try {
+								checkTr.setOption(FDBTransactionOptions::RAW_ACCESS);
+								Optional<Value> val = wait(checkTr.get(self->keyName.withPrefix(entry.get().prefix)));
+								ASSERT(val.present());
+								ASSERT(val.get() == *tenantItr);
+								break;
+							} catch (Error& e) {
+								wait(checkTr.onError(e));
+							}
 						}
 					}
 
-					self->createdTenants[tenant].empty = false;
-
-					state Transaction checkTr(cx);
-					loop {
-						try {
-							checkTr.setOption(FDBTransactionOptions::RAW_ACCESS);
-							Optional<Value> val = wait(checkTr.get(self->keyName.withPrefix(entry.get().prefix)));
-							ASSERT(val.present());
-							ASSERT(val.get() == tenant);
-							break;
-						} catch (Error& e) {
-							wait(checkTr.onError(e));
-						}
-					}
+					wait(self->checkTenant(cx, self, *tenantItr, self->createdTenants[*tenantItr]));
 				}
-
-				wait(self->checkTenant(cx, self, tenant, self->createdTenants[tenant]));
 				return Void();
 			} catch (Error& e) {
 				if (e.code() == error_code_invalid_tenant_name) {
-					ASSERT(tenant.startsWith("\xff"_sr));
+					ASSERT(hasSystemTenant);
 					return Void();
 				} else if (operationType == OperationType::MANAGEMENT_DATABASE) {
 					if (e.code() == error_code_tenant_already_exists) {
 						ASSERT(alreadyExists && operationType == OperationType::MANAGEMENT_DATABASE);
 					} else {
-						TraceEvent(SevError, "CreateTenantFailure").error(e).detail("TenantName", tenant);
+						ASSERT(tenantsToCreate.size() == 1);
+						TraceEvent(SevError, "CreateTenantFailure")
+						    .error(e)
+						    .detail("TenantName", *tenantsToCreate.begin());
 					}
 					return Void();
 				} else {
 					try {
 						wait(tr->onError(e));
 					} catch (Error& e) {
-						TraceEvent(SevError, "CreateTenantFailure").error(e).detail("TenantName", tenant);
+						for (auto tenant : tenantsToCreate) {
+							TraceEvent(SevError, "CreateTenantFailure").error(e).detail("TenantName", tenant);
+						}
 						return Void();
 					}
 				}


### PR DESCRIPTION
Resolves #7260.

This updates the `createTenantTransaction` function to take the tenant ID as a parameter rather than compute it itself. Update the special key-space tenant creation logic to generate a unique ID for each tenant being created.

Updated the tenant management test to detect the previous issue and verify the fix.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
