### PR TITLE
fixup! Fix the XmlTraceLogFormatter

### DIFF
--- a/flow/XmlTraceLogFormatter.cpp
+++ b/flow/XmlTraceLogFormatter.cpp
@@ -20,7 +20,6 @@
 
 #include "flow/flow.h"
 #include "flow/XmlTraceLogFormatter.h"
-#include "flow/actorcompiler.h"
 
 void XmlTraceLogFormatter::addref() {
 	ReferenceCounted<XmlTraceLogFormatter>::addref();
@@ -43,7 +42,7 @@ const char* XmlTraceLogFormatter::getFooter() const {
 }
 
 void XmlTraceLogFormatter::escape(std::ostringstream& oss, std::string source) const {
-	loop {
+	for(;;) {
 		int index = source.find_first_of(std::string({ '&', '"', '<', '>', '\r', '\n', '\0' }));
 		if (index == source.npos) {
 			break;

--- a/flow/XmlTraceLogFormatter.cpp
+++ b/flow/XmlTraceLogFormatter.cpp
@@ -42,7 +42,7 @@ const char* XmlTraceLogFormatter::getFooter() const {
 }
 
 void XmlTraceLogFormatter::escape(std::ostringstream& oss, std::string source) const {
-	for(;;) {
+	for (;;) {
 		int index = source.find_first_of(std::string({ '&', '"', '<', '>', '\r', '\n', '\0' }));
 		if (index == source.npos) {
 			break;


### PR DESCRIPTION
The original escape process uses a `loop` while the code is actually not
an ACTOR. So the actorcompiler is not reacting. This causes the escape
not escaping the XML fields properly.


# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
