### PR TITLE
Fix bug in reverse range reads causing larger than desired conflict ranges

### DIFF
--- a/fdbclient/ReadYourWrites.actor.cpp
+++ b/fdbclient/ReadYourWrites.actor.cpp
@@ -253,6 +253,8 @@ public:
 
 		if (read.begin.getKey() < read.end.getKey()) {
 			rangeBegin = read.begin.getKey();
+			// If the end offset is 1 (first greater than / first greater or equal) or more, then no changes to the
+			// range after the returned results can change the outcome.
 			rangeEnd = read.end.offset > 0 && result.more ? read.begin.getKey() : read.end.getKey();
 		} else {
 			rangeBegin = read.end.getKey();
@@ -289,7 +291,9 @@ public:
 		bool endInArena = false;
 
 		if (read.begin.getKey() < read.end.getKey()) {
-			rangeBegin = read.begin.offset <= 0 && result.more ? read.end.getKey() : read.begin.getKey();
+			// If the begin offset is 1 (first greater than / first greater or equal) or less, then no changes to the
+			// range prior to the returned results can change the outcome.
+			rangeBegin = read.begin.offset <= 1 && result.more ? read.end.getKey() : read.begin.getKey();
 			rangeEnd = read.end.getKey();
 		} else {
 			rangeBegin = read.end.getKey();

--- a/fdbserver/workloads/ConflictRange.actor.cpp
+++ b/fdbserver/workloads/ConflictRange.actor.cpp
@@ -80,6 +80,7 @@ struct ConflictRangeWorkload : TestWorkload {
 		state int offsetA;
 		state int offsetB;
 		state int randomLimit;
+		state Reverse reverse = Reverse::False;
 		state bool randomSets = false;
 		state std::set<int> insertedSet;
 		state RangeResult originalResults;
@@ -159,10 +160,13 @@ struct ConflictRangeWorkload : TestWorkload {
 					offsetA = deterministicRandom()->randomInt(-1 * self->maxOffset, self->maxOffset);
 					offsetB = deterministicRandom()->randomInt(-1 * self->maxOffset, self->maxOffset);
 					randomLimit = deterministicRandom()->randomInt(1, self->maxKeySpace);
+					reverse.set(deterministicRandom()->coinflip());
 
 					RangeResult res = wait(tr1.getRange(KeySelectorRef(StringRef(myKeyA), onEqualA, offsetA),
 					                                    KeySelectorRef(StringRef(myKeyB), onEqualB, offsetB),
-					                                    randomLimit));
+					                                    randomLimit,
+					                                    Snapshot::False,
+					                                    reverse));
 					if (res.size()) {
 						originalResults = res;
 						break;
@@ -225,13 +229,17 @@ struct ConflictRangeWorkload : TestWorkload {
 						                         StringRef(format("%010d", clearedEnd))));
 						RangeResult res = wait(trRYOW.getRange(KeySelectorRef(StringRef(myKeyA), onEqualA, offsetA),
 						                                       KeySelectorRef(StringRef(myKeyB), onEqualB, offsetB),
-						                                       randomLimit));
+						                                       randomLimit,
+						                                       Snapshot::False,
+						                                       reverse));
 						wait(trRYOW.commit());
 					} else {
 						tr3.clear(StringRef(format("%010d", self->maxKeySpace + 1)));
 						RangeResult res = wait(tr3.getRange(KeySelectorRef(StringRef(myKeyA), onEqualA, offsetA),
 						                                    KeySelectorRef(StringRef(myKeyB), onEqualB, offsetB),
-						                                    randomLimit));
+						                                    randomLimit,
+						                                    Snapshot::False,
+						                                    reverse));
 						wait(tr3.commit());
 					}
 				} catch (Error& e) {
@@ -252,7 +260,9 @@ struct ConflictRangeWorkload : TestWorkload {
 
 					RangeResult res = wait(tr4.getRange(KeySelectorRef(StringRef(myKeyA), onEqualA, offsetA),
 					                                    KeySelectorRef(StringRef(myKeyB), onEqualB, offsetB),
-					                                    randomLimit));
+					                                    randomLimit,
+					                                    Snapshot::False,
+					                                    reverse));
 					++self->withConflicts;
 
 					if (res.size() == originalResults.size()) {
@@ -261,20 +271,27 @@ struct ConflictRangeWorkload : TestWorkload {
 								throw not_committed();
 
 						// Discard known cases where conflicts do not change the results
-						if (originalResults.size() == randomLimit && offsetB <= 0) {
-							// Hit limit but end offset goes backwards, so changes could effect results even though in
-							// this instance they did not
+						if (originalResults.size() == randomLimit &&
+						    ((offsetB <= 0 && !reverse) || (offsetA > 1 && reverse))) {
+							// Hit limit but end offset goes into the range, so changes could effect results even though
+							// in this instance they did not
 							throw not_committed();
 						}
 
-						if (originalResults[originalResults.size() - 1].key >= sentinelKey) {
+						KeyRef smallestResult = originalResults[0].key;
+						KeyRef largestResult = originalResults[originalResults.size() - 1].key;
+						if (reverse) {
+							std::swap(smallestResult, largestResult);
+						}
+
+						if (largestResult >= sentinelKey) {
 							// Results go into server keyspace, so if a key selector does not fully resolve offset, a
 							// change won't effect results
 							throw not_committed();
 						}
 
-						if ((originalResults[0].key == firstElement ||
-						     originalResults[0].key == StringRef(format("%010d", *(insertedSet.begin())))) &&
+						if ((smallestResult == firstElement ||
+						     smallestResult == StringRef(format("%010d", *(insertedSet.begin())))) &&
 						    offsetA < 0) {
 							// Results return the first element, and the begin offset is negative, so if a key selector
 							// does not fully resolve the offset, a change won't effect results
@@ -308,6 +325,7 @@ struct ConflictRangeWorkload : TestWorkload {
 						    .detail("OffsetA", offsetA)
 						    .detail("OffsetB", offsetB)
 						    .detail("RandomLimit", randomLimit)
+						    .detail("Reverse", reverse)
 						    .detail("Size", originalResults.size())
 						    .detail("Results", keyStr1)
 						    .detail("Original", keyStr2);
@@ -328,7 +346,9 @@ struct ConflictRangeWorkload : TestWorkload {
 					// If the commit is successful, check that the result matches the first execution.
 					RangeResult res = wait(tr4.getRange(KeySelectorRef(StringRef(myKeyA), onEqualA, offsetA),
 					                                    KeySelectorRef(StringRef(myKeyB), onEqualB, offsetB),
-					                                    randomLimit));
+					                                    randomLimit,
+					                                    Snapshot::False,
+					                                    reverse));
 					++self->withoutConflicts;
 
 					if (res.size() == originalResults.size()) {
@@ -366,6 +386,7 @@ struct ConflictRangeWorkload : TestWorkload {
 						    .detail("OffsetA", offsetA)
 						    .detail("OffsetB", offsetB)
 						    .detail("RandomLimit", randomLimit)
+						    .detail("Reverse", reverse)
 						    .detail("Size", originalResults.size())
 						    .detail("Results", keyStr1)
 						    .detail("Original", keyStr2);


### PR DESCRIPTION
An off-by-one error in the RYW reverse range read logic caused us to generate a larger than expected conflict range in some cases. In particular, if the begin key selector was firstGreaterThan(<key>) or firstGreaterOrEqual(<key>) (the latter being the default), then the entire range between the begin and end key would be part of the conflict set. This was true even if a limit was specified that caused the range to terminate early.

The reason for this was because we need to include the entire range if the begin key selector resolves into the range. For example, if our begin key selector was firstGreaterThan(<key>) + 1, then changes anywhere in that range could impact our results when the key selector is resolved. This is not true when using just firstGreaterThan or firstGreaterOrEqual, though, and so we can use a more limited conflict range in this case.

Also updated a conflict range test to check for this property.

Resolves #7317 

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
