### PR TITLE
Clean up includes in actor header files

### DIFF
--- a/fdbclient/ClusterConnectionFile.h
+++ b/fdbclient/ClusterConnectionFile.h
@@ -23,7 +23,6 @@
 #define FDBCLIENT_CLUSTERCONNECTIONFILE_H
 
 #include "fdbclient/CoordinationInterface.h"
-#include "flow/actorcompiler.h" // has to be last include
 
 // An implementation of IClusterConnectionRecord backed by a file.
 class ClusterConnectionFile : public IClusterConnectionRecord, ReferenceCounted<ClusterConnectionFile>, NonCopyable {
@@ -72,5 +71,4 @@ private:
 	std::string filename;
 };
 
-#include "flow/unactorcompiler.h"
 #endif

--- a/fdbclient/GlobalConfig.actor.h
+++ b/fdbclient/GlobalConfig.actor.h
@@ -179,4 +179,6 @@ private:
 	std::unordered_map<KeyRef, std::function<void(std::optional<std::any>)>> callbacks;
 };
 
+#include "flow/unactorcompiler.h"
+
 #endif

--- a/fdbrpc/AsyncFileChaos.h
+++ b/fdbrpc/AsyncFileChaos.h
@@ -1,5 +1,5 @@
 /*
- * AsyncFileChaos.actor.h
+ * AsyncFileChaos.h
  *
  * This source file is part of the FoundationDB open source project
  *
@@ -18,13 +18,13 @@
  * limitations under the License.
  */
 
+#pragma once
+
 #include "flow/flow.h"
 #include "flow/serialize.h"
-#include "flow/genericactors.actor.h"
 #include "fdbrpc/IAsyncFile.h"
 #include "flow/network.h"
 #include "flow/ActorCollection.h"
-#include "flow/actorcompiler.h"
 
 // template <class AsyncFileType>
 class AsyncFileChaos final : public IAsyncFile, public ReferenceCounted<AsyncFileChaos> {

--- a/fdbrpc/CMakeLists.txt
+++ b/fdbrpc/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(FDBRPC_SRCS
   AsyncFileCached.actor.h
+  AsyncFileChaos.h
   AsyncFileEIO.actor.h
   AsyncFileEncrypted.h
   AsyncFileKAIO.actor.h

--- a/fdbrpc/Net2FileSystem.cpp
+++ b/fdbrpc/Net2FileSystem.cpp
@@ -30,7 +30,7 @@
 #define FILESYSTEM_IMPL 1
 
 #include "fdbrpc/AsyncFileCached.actor.h"
-#include "fdbrpc/AsyncFileChaos.actor.h"
+#include "fdbrpc/AsyncFileChaos.h"
 #include "fdbrpc/AsyncFileEIO.actor.h"
 #include "fdbrpc/AsyncFileEncrypted.h"
 #include "fdbrpc/AsyncFileWinASIO.actor.h"

--- a/fdbrpc/sim2.actor.cpp
+++ b/fdbrpc/sim2.actor.cpp
@@ -39,7 +39,7 @@
 #include "fdbrpc/AsyncFileCached.actor.h"
 #include "fdbrpc/AsyncFileEncrypted.h"
 #include "fdbrpc/AsyncFileNonDurable.actor.h"
-#include "fdbrpc/AsyncFileChaos.actor.h"
+#include "fdbrpc/AsyncFileChaos.h"
 #include "flow/crc32c.h"
 #include "fdbrpc/TraceFileIO.h"
 #include "flow/FaultInjection.h"

--- a/fdbserver/BlobGranuleServerCommon.actor.h
+++ b/fdbserver/BlobGranuleServerCommon.actor.h
@@ -123,4 +123,6 @@ private:
 	Future<Void> collection;
 };
 
+#include "flow/unactorcompiler.h"
+
 #endif

--- a/fdbserver/BlobGranuleValidation.actor.h
+++ b/fdbserver/BlobGranuleValidation.actor.h
@@ -51,4 +51,6 @@ bool compareFDBAndBlob(RangeResult fdb,
                        Version v,
                        bool debug);
 
+#include "flow/unactorcompiler.h"
+
 #endif

--- a/fdbserver/DDTeamCollection.h
+++ b/fdbserver/DDTeamCollection.h
@@ -47,7 +47,6 @@
 #include "flow/BooleanParam.h"
 #include "flow/Trace.h"
 #include "flow/UnitTest.h"
-#include "flow/actorcompiler.h" // This must be the last #include.
 
 class TCTeamInfo;
 class TCMachineInfo;

--- a/fdbserver/QuietDatabase.h
+++ b/fdbserver/QuietDatabase.h
@@ -26,7 +26,6 @@
 #include "fdbclient/DatabaseContext.h" // for clone()
 #include "fdbserver/TesterInterface.actor.h"
 #include "fdbserver/WorkerInterface.actor.h"
-#include "flow/actorcompiler.h"
 
 Future<int64_t> getDataInFlight(Database const& cx, Reference<AsyncVar<struct ServerDBInfo> const> const&);
 Future<std::pair<int64_t, int64_t>> getTLogQueueInfo(Database const& cx,
@@ -54,5 +53,4 @@ getStorageWorkers(Database const& cx, Reference<AsyncVar<ServerDBInfo> const> co
 Future<std::vector<WorkerInterface>> getCoordWorkers(Database const& cx,
                                                      Reference<AsyncVar<ServerDBInfo> const> const& dbInfo);
 
-#include "flow/unactorcompiler.h"
 #endif

--- a/fdbserver/ResolutionBalancer.actor.h
+++ b/fdbserver/ResolutionBalancer.actor.h
@@ -33,6 +33,7 @@
 #include "flow/Arena.h"
 #include "flow/IRandom.h"
 #include "flow/genericactors.actor.h"
+#include "flow/actorcompiler.h" // must be last include
 
 struct ResolutionBalancer {
 	AsyncVar<Standalone<VectorRef<ResolverMoveRef>>> resolverChanges;

--- a/fdbserver/RestoreWorker.actor.h
+++ b/fdbserver/RestoreWorker.actor.h
@@ -40,6 +40,8 @@
 #include "fdbserver/RestoreApplier.actor.h"
 #include "fdbserver/RestoreWorkerInterface.actor.h"
 
+#include "flow/actorcompiler.h" // must be last include
+
 // Each restore worker (a process) is assigned for a role.
 // MAYBE Later: We will support multiple restore roles on a worker
 struct RestoreWorkerData : NonCopyable, public ReferenceCounted<RestoreWorkerData> {

--- a/fdbserver/RocksDBCheckpointUtils.actor.h
+++ b/fdbserver/RocksDBCheckpointUtils.actor.h
@@ -260,4 +260,7 @@ ICheckpointReader* newRocksDBCheckpointReader(const CheckpointMetaData& checkpoi
 RocksDBColumnFamilyCheckpoint getRocksCF(const CheckpointMetaData& checkpoint);
 
 RocksDBCheckpoint getRocksCheckpoint(const CheckpointMetaData& checkpoint);
+
+#include "flow/unactorcompiler.h"
+
 #endif

--- a/fdbserver/RoleLineage.actor.h
+++ b/fdbserver/RoleLineage.actor.h
@@ -64,4 +64,6 @@ Future<decltype(std::declval<Fun>()())> runInRole(Fun fun, ProcessClass::Cluster
 	return res;
 }
 
+#include "flow/unactorcompiler.h"
+
 #endif

--- a/fdbserver/ServerCheckpoint.actor.h
+++ b/fdbserver/ServerCheckpoint.actor.h
@@ -69,4 +69,7 @@ ACTOR Future<std::vector<CheckpointMetaData>> fetchCheckpoints(
     std::vector<CheckpointMetaData> initialStates,
     std::string dir,
     std::function<Future<Void>(const CheckpointMetaData&)> cFun = nullptr);
+
+#include "flow/unactorcompiler.h"
+
 #endif

--- a/fdbserver/workloads/ApiWorkload.h
+++ b/fdbserver/workloads/ApiWorkload.h
@@ -27,7 +27,6 @@
 #include "fdbclient/ReadYourWrites.h"
 #include "fdbclient/ThreadSafeTransaction.h"
 #include "fdbserver/workloads/MemoryKeyValueStore.h"
-#include "flow/actorcompiler.h"
 
 // an enumeration of apis being tested
 enum TransactionType { NATIVE, READ_YOUR_WRITES, THREAD_SAFE, MULTI_VERSION };
@@ -398,7 +397,5 @@ struct ApiWorkload : TestWorkload {
 	// Transaction type of the transaction factory above.
 	TransactionType transactionType;
 };
-
-#include "flow/unactorcompiler.h"
 
 #endif

--- a/fdbserver/workloads/AsyncFile.cpp
+++ b/fdbserver/workloads/AsyncFile.cpp
@@ -21,7 +21,6 @@
 #include "fdbserver/workloads/workloads.actor.h"
 #include "flow/ActorCollection.h"
 #include "fdbserver/workloads/AsyncFile.actor.h"
-#include "flow/actorcompiler.h"
 
 // class RandomByteGenerator
 


### PR DESCRIPTION
Whenever `flow/actorcompiler.h` is included in an actor header file, we should include `flow/unactorcompiler.h` at the end of the header file. Furthermore, `flow/actorcompiler.h` should be included if and only if the header file is an actor header file, and a header file should be an actor header file only if necessary (because actor keywords are used within the header file).

This PR fixes several instances throughout the code where the above rules are broken.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
