### PR TITLE
KmsConnector implementation to support KMS driven CipherKey TTL

### DIFF
--- a/fdbserver/EncryptKeyProxy.actor.cpp
+++ b/fdbserver/EncryptKeyProxy.actor.cpp
@@ -441,7 +441,7 @@ ACTOR Future<Void> getLatestCipherKeys(Reference<EncryptKeyProxyData> ekpProxyDa
 	state std::vector<EKPBaseCipherDetails> cachedCipherDetails;
 	state EKPGetLatestBaseCipherKeysRequest latestKeysReq = req;
 	state EKPGetLatestBaseCipherKeysReply latestCipherReply;
-	state Arena& arena = latestKeysReq.arena;
+	state Arena& arena = latestCipherReply.arena;
 	state Optional<TraceEvent> dbgTrace =
 	    latestKeysReq.debugId.present() ? TraceEvent("GetByDomIds", ekpProxyData->myId) : Optional<TraceEvent>();
 

--- a/fdbserver/EncryptKeyProxyInterface.h
+++ b/fdbserver/EncryptKeyProxyInterface.h
@@ -32,6 +32,8 @@
 #include "flow/IRandom.h"
 #include "flow/network.h"
 
+#include <limits>
+
 struct EncryptKeyProxyInterface {
 	constexpr static FileIdentifier file_identifier = 1303419;
 	struct LocalityData locality;
@@ -101,14 +103,21 @@ struct EKPBaseCipherDetails {
 	int64_t encryptDomainId;
 	uint64_t baseCipherId;
 	StringRef baseCipherKey;
+	int64_t refreshAt;
+	int64_t expireAt;
 
-	EKPBaseCipherDetails() : encryptDomainId(0), baseCipherId(0), baseCipherKey(StringRef()) {}
+	EKPBaseCipherDetails()
+	  : encryptDomainId(0), baseCipherId(0), baseCipherKey(StringRef()), refreshAt(0), expireAt(-1) {}
 	explicit EKPBaseCipherDetails(int64_t dId, uint64_t id, StringRef key, Arena& arena)
-	  : encryptDomainId(dId), baseCipherId(id), baseCipherKey(StringRef(arena, key)) {}
+	  : encryptDomainId(dId), baseCipherId(id), baseCipherKey(StringRef(arena, key)),
+	    refreshAt(std::numeric_limits<int64_t>::max()), expireAt(std::numeric_limits<int64_t>::max()) {}
+	explicit EKPBaseCipherDetails(int64_t dId, uint64_t id, StringRef key, Arena& arena, int64_t refAt, int64_t expAt)
+	  : encryptDomainId(dId), baseCipherId(id), baseCipherKey(StringRef(arena, key)), refreshAt(refAt),
+	    expireAt(expAt) {}
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, encryptDomainId, baseCipherId, baseCipherKey);
+		serializer(ar, encryptDomainId, baseCipherId, baseCipherKey, refreshAt, expireAt);
 	}
 };
 

--- a/fdbserver/KmsConnectorInterface.h
+++ b/fdbserver/KmsConnectorInterface.h
@@ -82,6 +82,9 @@ struct EncryptCipherKeyDetails {
 	                                 StringRef key)
 	  : encryptDomainId(dId), encryptKeyId(keyId), encryptKey(StringRef(arena, key)),
 	    refreshAfterSec(Optional<int64_t>()), expireAfterSec(Optional<int64_t>()) {}
+	explicit EncryptCipherKeyDetails(EncryptCipherDomainId dId, EncryptCipherBaseKeyId keyId, StringRef key)
+	  : encryptDomainId(dId), encryptKeyId(keyId), encryptKey(key), refreshAfterSec(Optional<int64_t>()),
+	    expireAfterSec(Optional<int64_t>()) {}
 	explicit EncryptCipherKeyDetails(Arena& arena,
 	                                 EncryptCipherDomainId dId,
 	                                 EncryptCipherBaseKeyId keyId,
@@ -89,6 +92,13 @@ struct EncryptCipherKeyDetails {
 	                                 Optional<int64_t> refAfterSec,
 	                                 Optional<int64_t> expAfterSec)
 	  : encryptDomainId(dId), encryptKeyId(keyId), encryptKey(StringRef(arena, key)), refreshAfterSec(refAfterSec),
+	    expireAfterSec(expAfterSec) {}
+	explicit EncryptCipherKeyDetails(EncryptCipherDomainId dId,
+	                                 EncryptCipherBaseKeyId keyId,
+	                                 StringRef key,
+	                                 Optional<int64_t> refAfterSec,
+	                                 Optional<int64_t> expAfterSec)
+	  : encryptDomainId(dId), encryptKeyId(keyId), encryptKey(key), refreshAfterSec(refAfterSec),
 	    expireAfterSec(expAfterSec) {}
 
 	bool operator==(const EncryptCipherKeyDetails& toCompare) {
@@ -104,13 +114,14 @@ struct EncryptCipherKeyDetails {
 
 struct KmsConnLookupEKsByKeyIdsRep {
 	constexpr static FileIdentifier file_identifier = 2313778;
+	Arena arena;
 	VectorRef<EncryptCipherKeyDetails> cipherKeyDetails;
 
 	KmsConnLookupEKsByKeyIdsRep() {}
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, cipherKeyDetails);
+		serializer(ar, arena, cipherKeyDetails);
 	}
 };
 
@@ -157,13 +168,14 @@ struct KmsConnLookupEKsByKeyIdsReq {
 
 struct KmsConnLookupEKsByDomainIdsRep {
 	constexpr static FileIdentifier file_identifier = 3009025;
+	Arena arena;
 	VectorRef<EncryptCipherKeyDetails> cipherKeyDetails;
 
 	KmsConnLookupEKsByDomainIdsRep() {}
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, cipherKeyDetails);
+		serializer(ar, arena, cipherKeyDetails);
 	}
 };
 
@@ -175,6 +187,8 @@ struct KmsConnLookupDomainIdsReqInfo {
 	KmsConnLookupDomainIdsReqInfo() : domainId(ENCRYPT_INVALID_DOMAIN_ID) {}
 	explicit KmsConnLookupDomainIdsReqInfo(Arena& arena, const EncryptCipherDomainId dId, StringRef name)
 	  : domainId(dId), domainName(StringRef(arena, name)) {}
+	explicit KmsConnLookupDomainIdsReqInfo(const EncryptCipherDomainId dId, StringRef name)
+	  : domainId(dId), domainName(name) {}
 
 	bool operator==(const KmsConnLookupDomainIdsReqInfo& info) const {
 		return domainId == info.domainId && (domainName.compare(info.domainName) == 0);

--- a/fdbserver/RESTKmsConnector.actor.cpp
+++ b/fdbserver/RESTKmsConnector.actor.cpp
@@ -55,6 +55,8 @@ const char* BASE_CIPHER_TAG = "baseCipher";
 const char* CIPHER_KEY_DETAILS_TAG = "cipher_key_details";
 const char* ENCRYPT_DOMAIN_ID_TAG = "encrypt_domain_id";
 const char* ENCRYPT_DOMAIN_NAME_TAG = "encrypt_domain_name";
+const char* CIPHER_KEY_REFRESH_AFTER_SEC = "refresh_after_sec";
+const char* CIPHER_KEY_EXPIRE_AFTER_SEC = "expire_after_sec";
 const char* ERROR_TAG = "error";
 const char* ERROR_MSG_TAG = "errMsg";
 const char* ERROR_CODE_TAG = "errCode";
@@ -83,11 +85,18 @@ bool canReplyWith(Error e) {
 	case error_code_io_error:
 	case error_code_operation_failed:
 	case error_code_value_too_large:
+	case error_code_timed_out:
+	case error_code_connection_failed:
 		return true;
 	default:
 		return false;
 	}
 }
+
+bool isKmsNotReachable(const int errCode) {
+	return errCode == error_code_timed_out || errCode == error_code_connection_failed;
+}
+
 } // namespace
 
 struct KmsUrlCtx {
@@ -267,7 +276,7 @@ ACTOR Future<Void> discoverKmsUrls(Reference<RESTKmsConnectorCtx> ctx, bool refr
 void parseKmsResponse(Reference<RESTKmsConnectorCtx> ctx,
                       Reference<HTTP::Response> resp,
                       Arena* arena,
-                      std::vector<EncryptCipherKeyDetails>* outCipherKeyDetails) {
+                      VectorRef<EncryptCipherKeyDetails>* outCipherKeyDetails) {
 	// Acceptable response payload json format:
 	//
 	// response_json_payload {
@@ -276,6 +285,8 @@ void parseKmsResponse(Reference<RESTKmsConnectorCtx> ctx,
 	//        "base_cipher_id"    : <cipherKeyId>,
 	//        "encrypt_domain_id" : <domainId>,
 	//        "base_cipher"       : <baseCipher>
+	//        "refresh_after_sec"   : <refreshCipherTimeInterval> (Optional)
+	//        "expire_after_sec"    : <expireCipherTimeInterval>  (Optional)
 	//     },
 	//     {
 	//         ....
@@ -329,13 +340,13 @@ void parseKmsResponse(Reference<RESTKmsConnectorCtx> ctx,
 
 	// Extract CipherKeyDetails
 	if (!doc.HasMember(CIPHER_KEY_DETAILS_TAG) || !doc[CIPHER_KEY_DETAILS_TAG].IsArray()) {
-		TraceEvent("ParseKmsResponse_FailureMissingCipherKeyDetails", ctx->uid).log();
+		TraceEvent(SevWarn, "ParseKmsResponse_FailureMissingCipherKeyDetails", ctx->uid).log();
 		throw operation_failed();
 	}
 
 	for (const auto& cipherDetail : doc[CIPHER_KEY_DETAILS_TAG].GetArray()) {
 		if (!cipherDetail.IsObject()) {
-			TraceEvent("ParseKmsResponse_FailureEncryptKeyDetailsNotObject", ctx->uid)
+			TraceEvent(SevWarn, "ParseKmsResponse_FailureEncryptKeyDetailsNotObject", ctx->uid)
 			    .detail("Type", cipherDetail.GetType());
 			throw operation_failed();
 		}
@@ -344,7 +355,7 @@ void parseKmsResponse(Reference<RESTKmsConnectorCtx> ctx,
 		const bool isBaseCipherPresent = cipherDetail.HasMember(BASE_CIPHER_TAG);
 		const bool isEncryptDomainIdPresent = cipherDetail.HasMember(ENCRYPT_DOMAIN_ID_TAG);
 		if (!isBaseCipherIdPresent || !isBaseCipherPresent || !isEncryptDomainIdPresent) {
-			TraceEvent("ParseKmsResponse_MalformedKeyDetail", ctx->uid)
+			TraceEvent(SevWarn, "ParseKmsResponse_MalformedKeyDetail", ctx->uid)
 			    .detail("BaseCipherIdPresent", isBaseCipherIdPresent)
 			    .detail("BaseCipherPresent", isBaseCipherPresent)
 			    .detail("EncryptDomainIdPresent", isEncryptDomainIdPresent);
@@ -354,10 +365,22 @@ void parseKmsResponse(Reference<RESTKmsConnectorCtx> ctx,
 		const int cipherKeyLen = cipherDetail[BASE_CIPHER_TAG].GetStringLength();
 		std::unique_ptr<uint8_t[]> cipherKey = std::make_unique<uint8_t[]>(cipherKeyLen);
 		memcpy(cipherKey.get(), cipherDetail[BASE_CIPHER_TAG].GetString(), cipherKeyLen);
-		outCipherKeyDetails->emplace_back(cipherDetail[ENCRYPT_DOMAIN_ID_TAG].GetInt64(),
-		                                  cipherDetail[BASE_CIPHER_ID_TAG].GetUint64(),
-		                                  StringRef(cipherKey.get(), cipherKeyLen),
-		                                  *arena);
+
+		// Extract cipher refresh and/or expiry interval if supplied
+		Optional<int64_t> refreshAfterSec = cipherDetail.HasMember(CIPHER_KEY_REFRESH_AFTER_SEC) &&
+		                                            cipherDetail[CIPHER_KEY_REFRESH_AFTER_SEC].GetInt64() > 0
+		                                        ? cipherDetail[CIPHER_KEY_REFRESH_AFTER_SEC].GetInt64()
+		                                        : Optional<int64_t>();
+		Optional<int64_t> expireAfterSec = cipherDetail.HasMember(CIPHER_KEY_EXPIRE_AFTER_SEC)
+		                                       ? cipherDetail[CIPHER_KEY_EXPIRE_AFTER_SEC].GetInt64()
+		                                       : Optional<int64_t>();
+
+		outCipherKeyDetails->emplace_back_deep(*arena,
+		                                       cipherDetail[ENCRYPT_DOMAIN_ID_TAG].GetInt64(),
+		                                       cipherDetail[BASE_CIPHER_ID_TAG].GetUint64(),
+		                                       StringRef(cipherKey.get(), cipherKeyLen),
+		                                       refreshAfterSec,
+		                                       expireAfterSec);
 	}
 
 	if (doc.HasMember(KMS_URLS_TAG)) {
@@ -519,7 +542,7 @@ ACTOR
 Future<Void> fetchEncryptionKeys_impl(Reference<RESTKmsConnectorCtx> ctx,
                                       StringRef requestBodyRef,
                                       Arena* arena,
-                                      std::vector<EncryptCipherKeyDetails>* outCipherKeyDetails) {
+                                      VectorRef<EncryptCipherKeyDetails>* outCipherKeyDetails) {
 	state Reference<HTTP::Response> resp;
 
 	// Follow 2-phase scheme:
@@ -558,14 +581,18 @@ Future<Void> fetchEncryptionKeys_impl(Reference<RESTKmsConnectorCtx> ctx,
 					TraceEvent("FetchEncryptionKeys_Success", ctx->uid).detail("KmsUrl", curUrl->url);
 					return Void();
 				} catch (Error& e) {
-					TraceEvent("FetchEncryptionKeys_RespParseFailure").error(e);
+					TraceEvent(SevWarn, "FetchEncryptionKeys_RespParseFailure").error(e);
 					curUrl->nResponseParseFailures++;
 					// attempt to fetch encryption details from next KmsUrl
 				}
 			} catch (Error& e) {
 				TraceEvent("FetchEncryptionKeys_Failed", ctx->uid).error(e);
 				curUrl->nFailedResponses++;
-				// attempt to fetch encryption details from next KmsUrl
+				if (pass > 1 && isKmsNotReachable(e.code())) {
+					throw e;
+				} else {
+					// attempt to fetch encryption details from next KmsUrl
+				}
 			}
 		}
 
@@ -585,9 +612,9 @@ ACTOR Future<KmsConnLookupEKsByKeyIdsRep> fetchEncryptionKeysByKeyIds(Reference<
 	bool refreshKmsUrls = shouldRefreshKmsUrls(ctx);
 	std::string requestBody;
 
-	StringRef requestBodyRef = getEncryptKeysByKeyIdsRequestBody(ctx, req, refreshKmsUrls, reply.arena);
+	StringRef requestBodyRef = getEncryptKeysByKeyIdsRequestBody(ctx, req, refreshKmsUrls, req.arena);
 
-	wait(fetchEncryptionKeys_impl(ctx, requestBodyRef, &reply.arena, &reply.cipherKeyDetails));
+	wait(fetchEncryptionKeys_impl(ctx, requestBodyRef, &req.arena, &reply.cipherKeyDetails));
 
 	return reply;
 }
@@ -673,9 +700,9 @@ ACTOR Future<KmsConnLookupEKsByDomainIdsRep> fetchEncryptionKeysByDomainIds(Refe
                                                                             KmsConnLookupEKsByDomainIdsReq req) {
 	state KmsConnLookupEKsByDomainIdsRep reply;
 	bool refreshKmsUrls = shouldRefreshKmsUrls(ctx);
-	StringRef requestBodyRef = getEncryptKeysByDomainIdsRequestBody(ctx, req, refreshKmsUrls, reply.arena);
+	StringRef requestBodyRef = getEncryptKeysByDomainIdsRequestBody(ctx, req, refreshKmsUrls, req.arena);
 
-	wait(fetchEncryptionKeys_impl(ctx, requestBodyRef, &reply.arena, &reply.cipherKeyDetails));
+	wait(fetchEncryptionKeys_impl(ctx, requestBodyRef, &req.arena, &reply.cipherKeyDetails));
 
 	return reply;
 }
@@ -1025,6 +1052,19 @@ void getFakeKmsResponse(StringRef jsonReqRef, const bool baseCipherIdPresent, Re
 		baseCipher.SetString((char*)&BASE_CIPHER_KEY_TEST[0], sizeof(BASE_CIPHER_KEY_TEST), resDoc.GetAllocator());
 		keyDetail.AddMember(key, baseCipher, resDoc.GetAllocator());
 
+		if (deterministicRandom()->randomInt(0, 100) < 50) {
+			key.SetString(CIPHER_KEY_REFRESH_AFTER_SEC, resDoc.GetAllocator());
+			rapidjson::Value refreshInterval;
+			refreshInterval.SetInt64(10);
+			keyDetail.AddMember(key, refreshInterval, resDoc.GetAllocator());
+		}
+		if (deterministicRandom()->randomInt(0, 100) < 50) {
+			key.SetString(CIPHER_KEY_EXPIRE_AFTER_SEC, resDoc.GetAllocator());
+			rapidjson::Value expireInterval;
+			deterministicRandom()->randomInt(0, 100) < 50 ? expireInterval.SetInt64(10) : expireInterval.SetInt64(-1);
+			keyDetail.AddMember(key, expireInterval, resDoc.GetAllocator());
+		}
+
 		cipherKeyDetails.PushBack(keyDetail, resDoc.GetAllocator());
 	}
 	rapidjson::Value memberKey(CIPHER_KEY_DETAILS_TAG, resDoc.GetAllocator());
@@ -1065,7 +1105,7 @@ void testGetEncryptKeysByKeyIdsRequestBody(Reference<RESTKmsConnectorCtx> ctx, A
 		EncryptCipherDomainName domainName = domainId < 0
 		                                         ? StringRef(arena, std::string(FDB_DEFAULT_ENCRYPT_DOMAIN_NAME))
 		                                         : StringRef(arena, std::to_string(domainId));
-		req.encryptKeyInfos.emplace_back(KmsConnLookupKeyIdsReqInfo(domainId, i, domainName, req.arena));
+		req.encryptKeyInfos.emplace_back_deep(req.arena, domainId, i, domainName);
 		keyMap[i] = domainId;
 	}
 
@@ -1081,7 +1121,7 @@ void testGetEncryptKeysByKeyIdsRequestBody(Reference<RESTKmsConnectorCtx> ctx, A
 	getFakeKmsResponse(requestBodyRef, true, httpResp);
 	TraceEvent("FetchKeysByKeyIds", ctx->uid).setMaxFieldLength(100000).detail("HttpRespStr", httpResp->content);
 
-	std::vector<EncryptCipherKeyDetails> cipherDetails;
+	VectorRef<EncryptCipherKeyDetails> cipherDetails;
 	parseKmsResponse(ctx, httpResp, &arena, &cipherDetails);
 	ASSERT_EQ(cipherDetails.size(), keyMap.size());
 	for (const auto& detail : cipherDetails) {
@@ -1104,9 +1144,9 @@ void testGetEncryptKeysByDomainIdsRequestBody(Reference<RESTKmsConnectorCtx> ctx
 		EncryptCipherDomainName domainName = domainId < 0
 		                                         ? StringRef(arena, std::string(FDB_DEFAULT_ENCRYPT_DOMAIN_NAME))
 		                                         : StringRef(arena, std::to_string(domainId));
-		KmsConnLookupDomainIdsReqInfo reqInfo(domainId, domainName, req.arena);
+		KmsConnLookupDomainIdsReqInfo reqInfo(req.arena, domainId, domainName);
 		if (domainInfoMap.insert({ domainId, reqInfo }).second) {
-			req.encryptDomainInfos.emplace_back(reqInfo);
+			req.encryptDomainInfos.push_back(req.arena, reqInfo);
 		}
 	}
 
@@ -1119,7 +1159,7 @@ void testGetEncryptKeysByDomainIdsRequestBody(Reference<RESTKmsConnectorCtx> ctx
 	getFakeKmsResponse(jsonReqRef, false, httpResp);
 	TraceEvent("FetchKeysByDomainIds", ctx->uid).detail("HttpRespStr", httpResp->content);
 
-	std::vector<EncryptCipherKeyDetails> cipherDetails;
+	VectorRef<EncryptCipherKeyDetails> cipherDetails;
 	parseKmsResponse(ctx, httpResp, &arena, &cipherDetails);
 	ASSERT_EQ(domainInfoMap.size(), cipherDetails.size());
 	for (const auto& detail : cipherDetails) {
@@ -1134,7 +1174,7 @@ void testGetEncryptKeysByDomainIdsRequestBody(Reference<RESTKmsConnectorCtx> ctx
 
 void testMissingCipherDetailsTag(Reference<RESTKmsConnectorCtx> ctx) {
 	Arena arena;
-	std::vector<EncryptCipherKeyDetails> cipherDetails;
+	VectorRef<EncryptCipherKeyDetails> cipherDetails;
 
 	rapidjson::Document doc;
 	doc.SetObject();
@@ -1161,7 +1201,7 @@ void testMissingCipherDetailsTag(Reference<RESTKmsConnectorCtx> ctx) {
 
 void testMalformedCipherDetails(Reference<RESTKmsConnectorCtx> ctx) {
 	Arena arena;
-	std::vector<EncryptCipherKeyDetails> cipherDetails;
+	VectorRef<EncryptCipherKeyDetails> cipherDetails;
 
 	rapidjson::Document doc;
 	doc.SetObject();
@@ -1188,7 +1228,7 @@ void testMalformedCipherDetails(Reference<RESTKmsConnectorCtx> ctx) {
 
 void testMalfromedCipherDetailObj(Reference<RESTKmsConnectorCtx> ctx) {
 	Arena arena;
-	std::vector<EncryptCipherKeyDetails> cipherDetails;
+	VectorRef<EncryptCipherKeyDetails> cipherDetails;
 
 	rapidjson::Document doc;
 	doc.SetObject();
@@ -1220,7 +1260,7 @@ void testMalfromedCipherDetailObj(Reference<RESTKmsConnectorCtx> ctx) {
 
 void testKMSErrorResponse(Reference<RESTKmsConnectorCtx> ctx) {
 	Arena arena;
-	std::vector<EncryptCipherKeyDetails> cipherDetails;
+	VectorRef<EncryptCipherKeyDetails> cipherDetails;
 
 	rapidjson::Document doc;
 	doc.SetObject();

--- a/fdbserver/RESTKmsConnector.actor.cpp
+++ b/fdbserver/RESTKmsConnector.actor.cpp
@@ -614,7 +614,7 @@ ACTOR Future<KmsConnLookupEKsByKeyIdsRep> fetchEncryptionKeysByKeyIds(Reference<
 
 	StringRef requestBodyRef = getEncryptKeysByKeyIdsRequestBody(ctx, req, refreshKmsUrls, req.arena);
 
-	wait(fetchEncryptionKeys_impl(ctx, requestBodyRef, &req.arena, &reply.cipherKeyDetails));
+	wait(fetchEncryptionKeys_impl(ctx, requestBodyRef, &reply.arena, &reply.cipherKeyDetails));
 
 	return reply;
 }
@@ -702,7 +702,7 @@ ACTOR Future<KmsConnLookupEKsByDomainIdsRep> fetchEncryptionKeysByDomainIds(Refe
 	bool refreshKmsUrls = shouldRefreshKmsUrls(ctx);
 	StringRef requestBodyRef = getEncryptKeysByDomainIdsRequestBody(ctx, req, refreshKmsUrls, req.arena);
 
-	wait(fetchEncryptionKeys_impl(ctx, requestBodyRef, &req.arena, &reply.cipherKeyDetails));
+	wait(fetchEncryptionKeys_impl(ctx, requestBodyRef, &reply.arena, &reply.cipherKeyDetails));
 
 	return reply;
 }

--- a/fdbserver/RESTKmsConnector.actor.cpp
+++ b/fdbserver/RESTKmsConnector.actor.cpp
@@ -1052,16 +1052,16 @@ void getFakeKmsResponse(StringRef jsonReqRef, const bool baseCipherIdPresent, Re
 		baseCipher.SetString((char*)&BASE_CIPHER_KEY_TEST[0], sizeof(BASE_CIPHER_KEY_TEST), resDoc.GetAllocator());
 		keyDetail.AddMember(key, baseCipher, resDoc.GetAllocator());
 
-		if (deterministicRandom()->randomInt(0, 100) < 50) {
+		if (deterministicRandom()->coinflip()) {
 			key.SetString(CIPHER_KEY_REFRESH_AFTER_SEC, resDoc.GetAllocator());
 			rapidjson::Value refreshInterval;
 			refreshInterval.SetInt64(10);
 			keyDetail.AddMember(key, refreshInterval, resDoc.GetAllocator());
 		}
-		if (deterministicRandom()->randomInt(0, 100) < 50) {
+		if (deterministicRandom()->coinflip()) {
 			key.SetString(CIPHER_KEY_EXPIRE_AFTER_SEC, resDoc.GetAllocator());
 			rapidjson::Value expireInterval;
-			deterministicRandom()->randomInt(0, 100) < 50 ? expireInterval.SetInt64(10) : expireInterval.SetInt64(-1);
+			deterministicRandom()->coinflip() ? expireInterval.SetInt64(10) : expireInterval.SetInt64(-1);
 			keyDetail.AddMember(key, expireInterval, resDoc.GetAllocator());
 		}
 
@@ -1109,8 +1109,8 @@ void testGetEncryptKeysByKeyIdsRequestBody(Reference<RESTKmsConnectorCtx> ctx, A
 		keyMap[i] = domainId;
 	}
 
-	bool refreshKmsUrls = deterministicRandom()->randomInt(0, 100) < 50;
-	if (deterministicRandom()->randomInt(0, 100) < 40) {
+	bool refreshKmsUrls = deterministicRandom()->coinflip();
+	if (deterministicRandom()->coinflip()) {
 		req.debugId = deterministicRandom()->randomUniqueID();
 	}
 
@@ -1150,7 +1150,7 @@ void testGetEncryptKeysByDomainIdsRequestBody(Reference<RESTKmsConnectorCtx> ctx
 		}
 	}
 
-	bool refreshKmsUrls = deterministicRandom()->randomInt(0, 100) < 50;
+	bool refreshKmsUrls = deterministicRandom()->coinflip();
 
 	StringRef jsonReqRef = getEncryptKeysByDomainIdsRequestBody(ctx, req, refreshKmsUrls, arena);
 	TraceEvent("FetchKeysByDomainIds", ctx->uid).detail("JsonReqStr", jsonReqRef.toString());

--- a/fdbserver/SimKmsConnector.actor.cpp
+++ b/fdbserver/SimKmsConnector.actor.cpp
@@ -32,7 +32,9 @@
 #include "flow/FastRef.h"
 #include "flow/IRandom.h"
 #include "flow/ITrace.h"
+#include "flow/Knobs.h"
 #include "flow/Trace.h"
+#include "flow/flow.h"
 #include "flow/network.h"
 #include "flow/UnitTest.h"
 
@@ -73,6 +75,22 @@ struct SimKmsConnectorContext : NonCopyable, ReferenceCounted<SimKmsConnectorCon
 	}
 };
 
+namespace {
+Optional<int64_t> getRefreshInterval(int64_t now, int64_t defaultTtl) {
+	if (BUGGIFY) {
+		return Optional<int64_t>(now + defaultTtl);
+	}
+	return Optional<int64_t>();
+}
+
+Optional<int64_t> getExpireInterval(Optional<int64_t> refTS) {
+	if (BUGGIFY) {
+		return Optional<int64_t>(-1);
+	}
+	return refTS;
+}
+} // namespace
+
 ACTOR Future<Void> ekLookupByIds(Reference<SimKmsConnectorContext> ctx,
                                  KmsConnectorInterface interf,
                                  KmsConnLookupEKsByKeyIdsReq req) {
@@ -90,8 +108,8 @@ ACTOR Future<Void> ekLookupByIds(Reference<SimKmsConnectorContext> ctx,
 	for (const auto& item : req.encryptKeyInfos) {
 		const auto& itr = ctx->simEncryptKeyStore.find(item.baseCipherId);
 		if (itr != ctx->simEncryptKeyStore.end()) {
-			rep.cipherKeyDetails.emplace_back(
-			    item.domainId, itr->first, StringRef(rep.arena, itr->second.get()->key), rep.arena);
+			rep.cipherKeyDetails.emplace_back_deep(
+			    req.arena, item.domainId, itr->first, StringRef(itr->second.get()->key));
 
 			if (dbgKIdTrace.present()) {
 				// {encryptDomainId, baseCipherId} forms a unique tuple across encryption domains
@@ -127,11 +145,17 @@ ACTOR Future<Void> ekLookupByDomainIds(Reference<SimKmsConnectorContext> ctx,
 	// Map encryptionDomainId to corresponding EncryptKeyCtx element using a modulo operation. This
 	// would mean multiple domains gets mapped to the same encryption key which is fine, the
 	// EncryptKeyStore guarantees that keyId -> plaintext encryptKey mapping is idempotent.
+	int64_t currTS = (int64_t)now();
+	// Fetch default TTL to avoid BUGGIFY giving different value per invocation causing refTS > expTS
+	int64_t defaultTtl = FLOW_KNOBS->ENCRYPT_CIPHER_KEY_CACHE_TTL;
+	Optional<int64_t> refAtTS = getRefreshInterval(currTS, defaultTtl);
+	Optional<int64_t> expAtTS = getExpireInterval(refAtTS);
 	for (const auto& info : req.encryptDomainInfos) {
 		EncryptCipherBaseKeyId keyId = 1 + abs(info.domainId) % SERVER_KNOBS->SIM_KMS_MAX_KEYS;
 		const auto& itr = ctx->simEncryptKeyStore.find(keyId);
 		if (itr != ctx->simEncryptKeyStore.end()) {
-			rep.cipherKeyDetails.emplace_back(info.domainId, keyId, StringRef(itr->second.get()->key), rep.arena);
+			rep.cipherKeyDetails.emplace_back_deep(
+			    req.arena, info.domainId, keyId, StringRef(itr->second.get()->key), refAtTS, expAtTS);
 			if (dbgDIdTrace.present()) {
 				// {encryptId, baseCipherId} forms a unique tuple across encryption domains
 				dbgDIdTrace.get().detail(
@@ -263,8 +287,7 @@ ACTOR Future<Void> testRunWorkload(KmsConnectorInterface inf, uint32_t nEncrypti
 			// domainIdsReq.encryptDomainIds.push_back(i);
 			EncryptCipherDomainId domainId = i;
 			EncryptCipherDomainName domainName = StringRef(std::to_string(domainId));
-			domainIdsReq.encryptDomainInfos.emplace_back(
-			    KmsConnLookupDomainIdsReqInfo(i, domainName, domainIdsReq.arena));
+			domainIdsReq.encryptDomainInfos.emplace_back_deep(domainIdsReq.arena, i, domainName);
 		}
 		KmsConnLookupEKsByDomainIdsRep domainIdsRep = wait(inf.ekLookupByDomainIds.getReply(domainIdsReq));
 		for (auto& element : domainIdsRep.cipherKeyDetails) {
@@ -285,8 +308,8 @@ ACTOR Future<Void> testRunWorkload(KmsConnectorInterface inf, uint32_t nEncrypti
 
 		state KmsConnLookupEKsByKeyIdsReq keyIdsReq;
 		for (const auto& item : idsToLookup) {
-			keyIdsReq.encryptKeyInfos.emplace_back(KmsConnLookupKeyIdsReqInfo(
-			    item.second, item.first, StringRef(std::to_string(item.second)), keyIdsReq.arena));
+			keyIdsReq.encryptKeyInfos.emplace_back_deep(
+			    keyIdsReq.arena, item.second, item.first, StringRef(std::to_string(item.second)));
 		}
 		state KmsConnLookupEKsByKeyIdsRep keyIdsReply = wait(inf.ekLookupByIds.getReply(keyIdsReq));
 		/* TraceEvent("Lookup")
@@ -302,8 +325,8 @@ ACTOR Future<Void> testRunWorkload(KmsConnectorInterface inf, uint32_t nEncrypti
 	{
 		// Verify unknown key access returns the error
 		state KmsConnLookupEKsByKeyIdsReq req;
-		req.encryptKeyInfos.emplace_back(KmsConnLookupKeyIdsReqInfo(
-		    1, maxEncryptionKeys + 1, StringRef(std::to_string(maxEncryptionKeys)), req.arena));
+		req.encryptKeyInfos.emplace_back_deep(
+		    req.arena, 1, maxEncryptionKeys + 1, StringRef(std::to_string(maxEncryptionKeys)));
 		try {
 			KmsConnLookupEKsByKeyIdsRep reply = wait(inf.ekLookupByIds.getReply(req));
 		} catch (Error& e) {

--- a/fdbserver/SimKmsConnector.actor.cpp
+++ b/fdbserver/SimKmsConnector.actor.cpp
@@ -109,7 +109,7 @@ ACTOR Future<Void> ekLookupByIds(Reference<SimKmsConnectorContext> ctx,
 		const auto& itr = ctx->simEncryptKeyStore.find(item.baseCipherId);
 		if (itr != ctx->simEncryptKeyStore.end()) {
 			rep.cipherKeyDetails.emplace_back_deep(
-			    req.arena, item.domainId, itr->first, StringRef(itr->second.get()->key));
+			    rep.arena, item.domainId, itr->first, StringRef(itr->second.get()->key));
 
 			if (dbgKIdTrace.present()) {
 				// {encryptDomainId, baseCipherId} forms a unique tuple across encryption domains

--- a/fdbserver/SimKmsConnector.actor.cpp
+++ b/fdbserver/SimKmsConnector.actor.cpp
@@ -286,8 +286,8 @@ ACTOR Future<Void> testRunWorkload(KmsConnectorInterface inf, uint32_t nEncrypti
 		for (i = 0; i < maxDomainIds; i++) {
 			// domainIdsReq.encryptDomainIds.push_back(i);
 			EncryptCipherDomainId domainId = i;
-			EncryptCipherDomainName domainName = StringRef(std::to_string(domainId));
-			domainIdsReq.encryptDomainInfos.emplace_back_deep(domainIdsReq.arena, i, domainName);
+			EncryptCipherDomainName domainName = StringRef(domainIdsReq.arena, std::to_string(domainId));
+			domainIdsReq.encryptDomainInfos.emplace_back(domainIdsReq.arena, i, domainName);
 		}
 		KmsConnLookupEKsByDomainIdsRep domainIdsRep = wait(inf.ekLookupByDomainIds.getReply(domainIdsReq));
 		for (auto& element : domainIdsRep.cipherKeyDetails) {
@@ -326,7 +326,7 @@ ACTOR Future<Void> testRunWorkload(KmsConnectorInterface inf, uint32_t nEncrypti
 		// Verify unknown key access returns the error
 		state KmsConnLookupEKsByKeyIdsReq req;
 		req.encryptKeyInfos.emplace_back_deep(
-		    req.arena, 1, maxEncryptionKeys + 1, StringRef(std::to_string(maxEncryptionKeys)));
+		    req.arena, 1, maxEncryptionKeys + 1, StringRef(req.arena, std::to_string(maxEncryptionKeys)));
 		try {
 			KmsConnLookupEKsByKeyIdsRep reply = wait(inf.ekLookupByIds.getReply(req));
 		} catch (Error& e) {

--- a/fdbserver/workloads/EncryptKeyProxyTest.actor.cpp
+++ b/fdbserver/workloads/EncryptKeyProxyTest.actor.cpp
@@ -78,9 +78,9 @@ struct EncryptKeyProxyTestWorkload : TestWorkload {
 		loop {
 			EKPGetLatestBaseCipherKeysRequest req;
 			req.encryptDomainInfos = self->domainInfos;
-			if (deterministicRandom()->randomInt(0, 100) < 50) {
-				req.debugId = deterministicRandom()->randomUniqueID();
-			}
+			// if (deterministicRandom()->randomInt(0, 100) < 50) {
+			req.debugId = deterministicRandom()->randomUniqueID();
+			//}
 			ErrorOr<EKPGetLatestBaseCipherKeysReply> rep = wait(self->ekpInf.getLatestBaseCipherKeys.tryGetReply(req));
 			if (rep.present()) {
 

--- a/flow/EncryptUtils.cpp
+++ b/flow/EncryptUtils.cpp
@@ -19,7 +19,6 @@
  */
 
 #include "flow/EncryptUtils.h"
-
 #include "flow/Trace.h"
 
 #include <boost/format.hpp>
@@ -37,4 +36,17 @@ std::string getEncryptDbgTraceKey(std::string_view prefix,
 		boost::format fmter("%s.%lld.%s");
 		return boost::str(boost::format(fmter % prefix % domainId % domainName.toString()));
 	}
+}
+
+std::string getEncryptDbgTraceKeyWithTS(std::string_view prefix,
+                                        EncryptCipherDomainId domainId,
+                                        StringRef domainName,
+                                        EncryptCipherBaseKeyId baseCipherId,
+                                        int64_t refAfterTS,
+                                        int64_t expAfterTS) {
+	// Construct the TraceEvent field key ensuring its uniqueness and compliance to TraceEvent field validator and log
+	// parsing tools
+	boost::format fmter("%s.%lld.%s.%llu.%lld.%lld");
+	return boost::str(
+	    boost::format(fmter % prefix % domainId % domainName.toString() % baseCipherId % refAfterTS % expAfterTS));
 }

--- a/flow/EncryptUtils.h
+++ b/flow/EncryptUtils.h
@@ -82,4 +82,11 @@ std::string getEncryptDbgTraceKey(std::string_view prefix,
                                   StringRef domainName,
                                   Optional<EncryptCipherBaseKeyId> baseCipherId = Optional<EncryptCipherBaseKeyId>());
 
+std::string getEncryptDbgTraceKeyWithTS(std::string_view prefix,
+                                        EncryptCipherDomainId domainId,
+                                        StringRef domainName,
+                                        EncryptCipherBaseKeyId baseCipherId,
+                                        int64_t refAfterTS,
+                                        int64_t expAfterTS);
+
 #endif


### PR DESCRIPTION
Description

KMS CipherKeys can be of two types:
1. Revocable CipherKeys: having a finite lifetime, after which the CipherKey
shouldn't be used by the FDB.
2. Non-revocable CipherKeys: ciphers are not revocable, however, FDB would
still want to refresh ciphers to support KMS cipher rotation feature.

Patch proposes following change to incorporate support for above defined cipher-key
types:
1. Extend KmsConnector response to include optional 'refreshAfter' & 'expireAfter'
time intervals. EncryptKeyProxy (EKP) cache would define corresponding absolute refresh &
expiry timestamp for a given cipherKey. On an event of transient KMS connectivity outage,
a caller of EKP API for a non-revocable key should continue using cached cipherKey until
it expires.
2. Simplify KmsConnector API arena handling by using VectorRef to represent component
structs and manage associated memory allocation/lifetime.

Testing

1. EncryptKeyProxyTest
2. RESTKmsConnectorTest
3. SimKmsConnectorTest

Put description here...

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
