### PR TITLE
Fix asan message detection

### DIFF
--- a/bindings/c/test/unit/unit_tests.cpp
+++ b/bindings/c/test/unit/unit_tests.cpp
@@ -2212,7 +2212,7 @@ TEST_CASE("special-key-space custom transaction ID") {
 		fdb_check(f1.get(&out_present, (const uint8_t**)&val, &vallen));
 
 		REQUIRE(out_present);
-		UID transaction_id = UID::fromString(std::string_view(val, vallen));
+		UID transaction_id = UID::fromString(std::string(val, vallen));
 		CHECK(transaction_id == randomTransactionID);
 		break;
 	}

--- a/bindings/c/test/unit/unit_tests.cpp
+++ b/bindings/c/test/unit/unit_tests.cpp
@@ -2212,7 +2212,7 @@ TEST_CASE("special-key-space custom transaction ID") {
 		fdb_check(f1.get(&out_present, (const uint8_t**)&val, &vallen));
 
 		REQUIRE(out_present);
-		UID transaction_id = UID::fromString(val);
+		UID transaction_id = UID::fromString(std::string_view(val, vallen));
 		CHECK(transaction_id == randomTransactionID);
 		break;
 	}

--- a/tests/TestRunner/tmp_cluster.py
+++ b/tests/TestRunner/tmp_cluster.py
@@ -177,9 +177,9 @@ if __name__ == "__main__":
         for line in sev40s:
             # When running ASAN we expect to see this message. Boost coroutine should be using the correct asan
             # annotations so that it shouldn't produce any false positives.
-            if line.endswith(
-                "WARNING: ASan doesn't fully support makecontext/swapcontext functions and may produce false "
-                "positives in some cases! "
+            if (
+                "WARNING: ASan doesn't fully support makecontext/swapcontext functions and may produce false positives in some cases!"
+                in line
             ):
                 continue
             print(">>>>>>>>>>>>>>>>>>>> Found severity 40 events - the test fails")


### PR DESCRIPTION
We want to suppress a specific asan message on stderr, and along the way it
seems to have changed somewhat. Update it.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
