### PR TITLE
Fix a few places we weren't doing exponential backoff

### DIFF
--- a/fdbclient/DatabaseContext.h
+++ b/fdbclient/DatabaseContext.h
@@ -639,4 +639,16 @@ private:
 	    watchMap;
 };
 
+// Similar to tr.onError(), but doesn't require a DatabaseContext.
+struct Backoff {
+	Future<Void> onError() {
+		double currentBackoff = backoff;
+		backoff = std::min(backoff * CLIENT_KNOBS->BACKOFF_GROWTH_RATE, CLIENT_KNOBS->DEFAULT_MAX_BACKOFF);
+		return delay(currentBackoff * deterministicRandom()->random01());
+	}
+
+private:
+	double backoff = CLIENT_KNOBS->DEFAULT_BACKOFF;
+};
+
 #endif

--- a/fdbclient/GlobalConfig.actor.cpp
+++ b/fdbclient/GlobalConfig.actor.cpp
@@ -153,18 +153,6 @@ void GlobalConfig::erase(KeyRangeRef range) {
 	}
 }
 
-// Similar to tr.onError(), but doesn't require a DatabaseContext.
-struct Backoff {
-	Future<Void> onError() {
-		double currentBackoff = backoff;
-		backoff = std::min(backoff * CLIENT_KNOBS->BACKOFF_GROWTH_RATE, CLIENT_KNOBS->DEFAULT_MAX_BACKOFF);
-		return delay(currentBackoff * deterministicRandom()->random01());
-	}
-
-private:
-	double backoff = CLIENT_KNOBS->DEFAULT_BACKOFF;
-};
-
 // Older FDB versions used different keys for client profiling data. This
 // function performs a one-time migration of data in these keys to the new
 // global configuration key space.


### PR DESCRIPTION
We re-create the transaction every iteration of each of these retry
loops, so we need to manage exponential backoff here ourselves.

Closes #7301

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
