### PR TITLE
Cherry pick pull request #7318

### DIFF
--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -44,6 +44,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	MAX_COMMIT_BATCH_INTERVAL = std::min(MAX_COMMIT_BATCH_INTERVAL, MAX_READ_TRANSACTION_LIFE_VERSIONS/double(2*VERSIONS_PER_SECOND)); // Ensure that the proxy commits 2 times every MAX_READ_TRANSACTION_LIFE_VERSIONS, otherwise the master will not give out versions fast enough
 	init( MAX_VERSION_RATE_MODIFIER,                             0.1 );
 	init( MAX_VERSION_RATE_OFFSET,               VERSIONS_PER_SECOND ); // If the calculated version is more than this amount away from the expected version, it will be clamped to this value. This prevents huge version jumps.
+	init( ENABLE_VERSION_VECTOR_HA_OPTIMIZATION,               false );
 
 	// TLogs
 	init( TLOG_TIMEOUT,                                          0.4 ); //cannot buggify because of availability

--- a/fdbclient/ServerKnobs.h
+++ b/fdbclient/ServerKnobs.h
@@ -44,6 +44,7 @@ public:
 	                                  // often, so that versions always advance smoothly
 	double MAX_VERSION_RATE_MODIFIER;
 	int64_t MAX_VERSION_RATE_OFFSET;
+	bool ENABLE_VERSION_VECTOR_HA_OPTIMIZATION;
 
 	// TLogs
 	bool PEEK_USING_STREAMING;

--- a/fdbclient/VersionVector.h
+++ b/fdbclient/VersionVector.h
@@ -55,11 +55,14 @@ public:
 		maxVersion = version;
 	}
 
-	void setVersion(const std::set<Tag>& tags, Version version) {
+	void setVersion(const std::set<Tag>& tags, Version version, int8_t localityFilter = tagLocalityInvalid) {
 		ASSERT(version > maxVersion);
 		for (auto& tag : tags) {
 			ASSERT(tag != invalidTag);
-			versions[tag] = version;
+			ASSERT(tag.locality > tagLocalityInvalid);
+			if (localityFilter == tagLocalityInvalid || tag.locality == localityFilter) {
+				versions[tag] = version;
+			}
 		}
 		maxVersion = version;
 	}

--- a/fdbserver/masterserver.actor.cpp
+++ b/fdbserver/masterserver.actor.cpp
@@ -66,6 +66,8 @@ struct MasterData : NonCopyable, ReferenceCounted<MasterData> {
 	// up-to-date in the presence of key range splits/merges.
 	VersionVector ssVersionVector;
 
+	int8_t locality; // sequencer locality
+
 	CounterCollection cc;
 	Counter getCommitVersionRequests;
 	Counter getLiveCommittedVersionRequests;
@@ -115,6 +117,8 @@ struct MasterData : NonCopyable, ReferenceCounted<MasterData> {
 			forceRecovery = false;
 		}
 		balancer = resolutionBalancer.resolutionBalancing();
+		locality = myInterface.locality.dcId().present() ? std::stoi(myInterface.locality.dcId().get().toString())
+		                                                 : tagLocalityInvalid;
 	}
 	~MasterData() = default;
 };
@@ -230,7 +234,9 @@ void updateLiveCommittedVersion(Reference<MasterData> self, ReportRawCommittedVe
 	if (req.version > self->liveCommittedVersion.get()) {
 		if (SERVER_KNOBS->ENABLE_VERSION_VECTOR && req.writtenTags.present()) {
 			// TraceEvent("Received ReportRawCommittedVersionRequest").detail("Version",req.version);
-			self->ssVersionVector.setVersion(req.writtenTags.get(), req.version);
+			int8_t primaryLocality =
+			    SERVER_KNOBS->ENABLE_VERSION_VECTOR_HA_OPTIMIZATION ? self->locality : tagLocalityInvalid;
+			self->ssVersionVector.setVersion(req.writtenTags.get(), req.version, primaryLocality);
 			self->versionVectorTagUpdates += req.writtenTags.get().size();
 		}
 		auto curTime = now();


### PR DESCRIPTION
Merge pull request #7318 from sbodagala/main

Introduce a knob that will control the placement of the commit versions of remote storage servers in version vector. This optimization will help reduce the size of version vector in HA configuration. Disable this knob by default.

NOTE: We are not sure at this point whether we will need this optimization or not. We will know more once we start testing the version vector feature in a production size HA cluster.

Testing:

Simulation tests (compiler: gcc):

Version vector disabled: 20220608-213356-sre-0b89a5f0493c7850 (no failures).

Version vector enabled and the new knob enabled: 20220608-221535-sre-ece66a74c9f412a1 (shows a failure in "ParallelRestoreNewBackupWriteDuringReadAtomicRestore.toml", not sure if that failure is related to this change set or not). Started another run: 20220609-142538-sre-ece66a74c9f412a1 (don't see any new failures in this run).

Version vector enabled and the new knob disabled: 20220609-150716-sre-4854b654269f8c70 (no failures).

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
