### PR TITLE
Remove unnecessary ReadYourWritesTransaction initialization (release-7.1)

### DIFF
--- a/fdbclient/ISingleThreadTransaction.cpp
+++ b/fdbclient/ISingleThreadTransaction.cpp
@@ -26,9 +26,14 @@
 
 ISingleThreadTransaction* ISingleThreadTransaction::allocateOnForeignThread(Type type) {
 	if (type == Type::RYW) {
-		auto tr = new ReadYourWritesTransaction;
+		// We only want to allocate memory for the transaction, not initialize
+		// the object, so use operator new instead of new. The RYWTransaction
+		// will get initialized on the main thread.
+		auto tr =
+		    (ReadYourWritesTransaction*)ReadYourWritesTransaction::operator new(sizeof(ReadYourWritesTransaction));
 		return tr;
 	} else if (type == Type::SIMPLE_CONFIG) {
+		// Configuration transaction objects expect to be initialized.
 		auto tr = new SimpleConfigTransaction;
 		return tr;
 	} else if (type == Type::PAXOS_CONFIG) {

--- a/fdbclient/ThreadSafeTransaction.cpp
+++ b/fdbclient/ThreadSafeTransaction.cpp
@@ -190,12 +190,20 @@ ThreadSafeTransaction::ThreadSafeTransaction(DatabaseContext* cx,
 	auto tr = this->tr = ISingleThreadTransaction::allocateOnForeignThread(type);
 	// No deferred error -- if the construction of the RYW transaction fails, we have no where to put it
 	onMainThreadVoid(
-	    [tr, cx, tenant]() {
+	    [tr, cx, type, tenant]() {
 		    cx->addref();
 		    if (tenant.present()) {
-			    tr->construct(Database(cx), tenant.get());
+			    if (type == ISingleThreadTransaction::Type::RYW) {
+				    new (tr) ReadYourWritesTransaction(Database(cx), tenant.get());
+			    } else {
+				    tr->construct(Database(cx), tenant.get());
+			    }
 		    } else {
-			    tr->construct(Database(cx));
+			    if (type == ISingleThreadTransaction::Type::RYW) {
+				    new (tr) ReadYourWritesTransaction(Database(cx));
+			    } else {
+				    tr->construct(Database(cx));
+			    }
 		    }
 	    },
 	    nullptr);


### PR DESCRIPTION
Cherry pick of #7364 to `release-7.1`.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
