### PR TITLE
Fix bug in resolveTCPEndpoint() when hostname resolving fails.

### DIFF
--- a/fdbclient/MonitorLeader.actor.cpp
+++ b/fdbclient/MonitorLeader.actor.cpp
@@ -624,10 +624,7 @@ ACTOR Future<MonitorLeaderInfo> monitorLeaderOneGeneration(Reference<IClusterCon
 
 			outSerializedLeaderInfo->set(leader.get().first.serializedInfo);
 		}
-		choose {
-			when(wait(nomineeChange.onTrigger())) { TraceEvent("MonitorLeaderChangeLoop1").log(); }
-			when(wait(allActors)) { TraceEvent("MonitorLeaderChangeLoop2").log(); }
-		}
+		wait(nomineeChange.onTrigger() || allActors);
 	}
 }
 

--- a/fdbclient/MonitorLeader.actor.cpp
+++ b/fdbclient/MonitorLeader.actor.cpp
@@ -552,7 +552,7 @@ Optional<std::pair<LeaderInfo, bool>> getLeader(const std::vector<Optional<Leade
 	          maskedNominees.end(),
 	          [](const std::pair<UID, int>& l, const std::pair<UID, int>& r) { return l.first < r.first; });
 
-	int bestCount = 0;
+	int bestCount = 1;
 	int bestIdx = 0;
 	int currentIdx = 0;
 	int curCount = 1;
@@ -560,17 +560,13 @@ Optional<std::pair<LeaderInfo, bool>> getLeader(const std::vector<Optional<Leade
 		if (maskedNominees[currentIdx].first == maskedNominees[i].first) {
 			curCount++;
 		} else {
-			if (curCount > bestCount) {
-				bestIdx = currentIdx;
-				bestCount = curCount;
-			}
 			currentIdx = i;
 			curCount = 1;
 		}
-	}
-	if (curCount > bestCount) {
-		bestIdx = currentIdx;
-		bestCount = curCount;
+		if (curCount > bestCount) {
+			bestIdx = currentIdx;
+			bestCount = curCount;
+		}
 	}
 
 	bool majority = bestCount >= nominees.size() / 2 + 1;
@@ -628,7 +624,10 @@ ACTOR Future<MonitorLeaderInfo> monitorLeaderOneGeneration(Reference<IClusterCon
 
 			outSerializedLeaderInfo->set(leader.get().first.serializedInfo);
 		}
-		wait(nomineeChange.onTrigger() || allActors);
+		choose {
+			when(wait(nomineeChange.onTrigger())) { TraceEvent("MonitorLeaderChangeLoop1").log(); }
+			when(wait(allActors)) { TraceEvent("MonitorLeaderChangeLoop2").log(); }
+		}
 	}
 }
 

--- a/fdbclient/ThreadSafeTransaction.cpp
+++ b/fdbclient/ThreadSafeTransaction.cpp
@@ -587,6 +587,7 @@ void ThreadSafeApi::runNetwork() {
 	}
 
 	if (runErr.present()) {
+		closeTraceFile();
 		throw runErr.get();
 	}
 

--- a/fdbrpc/genericactors.actor.h
+++ b/fdbrpc/genericactors.actor.h
@@ -78,11 +78,7 @@ Future<Void> tryInitializeRequestStream(RequestStream<Req>* stream, Hostname hos
 	if (!address.present()) {
 		return Void();
 	}
-	if (stream == nullptr) {
-		stream = new RequestStream<Req>(Endpoint::wellKnown({ address.get() }, token));
-	} else {
-		*stream = RequestStream<Req>(Endpoint::wellKnown({ address.get() }, token));
-	}
+	*stream = RequestStream<Req>(Endpoint::wellKnown({ address.get() }, token));
 	return Void();
 }
 

--- a/fdbrpc/genericactors.actor.h
+++ b/fdbrpc/genericactors.actor.h
@@ -78,6 +78,7 @@ Future<Void> tryInitializeRequestStream(RequestStream<Req>* stream, Hostname hos
 	if (!address.present()) {
 		return Void();
 	}
+	ASSERT(stream != nullptr);
 	*stream = RequestStream<Req>(Endpoint::wellKnown({ address.get() }, token));
 	return Void();
 }

--- a/flow/Net2.actor.cpp
+++ b/flow/Net2.actor.cpp
@@ -1852,36 +1852,42 @@ ACTOR static Future<std::vector<NetworkAddress>> resolveTCPEndpoint_impl(Net2* s
 	Promise<std::vector<NetworkAddress>> promise;
 	state Future<std::vector<NetworkAddress>> result = promise.getFuture();
 
-	tcpResolver.async_resolve(host, service, [=](const boost::system::error_code& ec, tcp::resolver::iterator iter) {
-		if (ec) {
+	tcpResolver.async_resolve(
+	    host, service, [promise](const boost::system::error_code& ec, tcp::resolver::iterator iter) {
+		    if (ec) {
+			    promise.sendError(lookup_failed());
+			    return;
+		    }
+
+		    std::vector<NetworkAddress> addrs;
+
+		    tcp::resolver::iterator end;
+		    while (iter != end) {
+			    auto endpoint = iter->endpoint();
+			    auto addr = endpoint.address();
+			    if (addr.is_v6()) {
+				    addrs.emplace_back(IPAddress(addr.to_v6().to_bytes()), endpoint.port());
+			    } else {
+				    addrs.emplace_back(addr.to_v4().to_ulong(), endpoint.port());
+			    }
+			    ++iter;
+		    }
+
+		    if (addrs.empty()) {
+			    promise.sendError(lookup_failed());
+		    } else {
+			    promise.send(addrs);
+		    }
+	    });
+
+	try {
+		wait(ready(result));
+	} catch (Error& e) {
+		if (e.code() == error_code_lookup_failed) {
 			self->dnsCache.remove(host, service);
-			promise.sendError(lookup_failed());
-			return;
 		}
-
-		std::vector<NetworkAddress> addrs;
-
-		tcp::resolver::iterator end;
-		while (iter != end) {
-			auto endpoint = iter->endpoint();
-			auto addr = endpoint.address();
-			if (addr.is_v6()) {
-				addrs.emplace_back(IPAddress(addr.to_v6().to_bytes()), endpoint.port());
-			} else {
-				addrs.emplace_back(addr.to_v4().to_ulong(), endpoint.port());
-			}
-			++iter;
-		}
-
-		if (addrs.empty()) {
-			self->dnsCache.remove(host, service);
-			promise.sendError(lookup_failed());
-		} else {
-			promise.send(addrs);
-		}
-	});
-
-	wait(ready(result));
+		throw e;
+	}
 	tcpResolver.cancel();
 	std::vector<NetworkAddress> ret = result.get();
 	self->dnsCache.add(host, service, ret);


### PR DESCRIPTION
In k8s tests, we observed `Unhandled error in FoundationDB network thread: An unknown error occurred (4000)`. Digging into trace events, we see either std::bad_alloc or basic_string::_S_create exception.

The root cause of the bug is, member variables are not capture in lambda, thus, `host` and `service` are not captured. This somehow successfully compile, but throws std::bad_alloc or basic_string::_S_create exceptions when we call `host+":"+service` in dnsCache.remove(), which happens when hostname resolving fails.

In this PR, we also added 2 minor improvements:1
1. Improve the bestCount algorithm in getLeader(). In the existing implementation, if the moninees are [0,1,1,2,2], we will choose 1 as the leader; however, if the nominees are [0,1], the chosen leader will be 1, being an exception to normal cases and our expectation that if two nominees have the same frequency, the one with lower id will be the leader;
2. Remove an unnecessary new statement. `stream` will never be a nullptr.

20220614-001808-renxuan-507a3bb2c23d11a2           compressed=True data_size=33559500 duration=2903374 ended=100000 fail_fast=10 max_runs=100000 pass=100000 priority=100 remaining=0 runtime=0:20:00 sanity=False started=100092 stopped=20220614-003808 submitted=20220614-001808 timeout=5400 username=renxuan

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
