### PR TITLE
Reenable status json for dynamic knobs and add a unit test

### DIFF
--- a/fdbserver/ConfigBroadcaster.actor.cpp
+++ b/fdbserver/ConfigBroadcaster.actor.cpp
@@ -465,6 +465,7 @@ public:
 			                       [compactionVersion](const auto& va) { return va.version > compactionVersion; });
 			annotationHistory.erase(annotationHistory.begin(), it);
 		}
+		lastCompactedVersion = compactionVersion;
 	}
 
 	Future<Void> getError() const { return consumerFuture || actors.getResult(); }

--- a/fdbserver/PaxosConfigConsumer.actor.cpp
+++ b/fdbserver/PaxosConfigConsumer.actor.cpp
@@ -328,6 +328,7 @@ class PaxosConfigConsumerImpl {
 			}
 			try {
 				wait(timeoutError(waitForAll(compactionRequests), 1.0));
+				broadcaster->compact(compactionVersion);
 			} catch (Error& e) {
 				TraceEvent(SevWarn, "ErrorSendingCompactionRequest").error(e);
 			}

--- a/fdbserver/Status.actor.cpp
+++ b/fdbserver/Status.actor.cpp
@@ -3125,12 +3125,10 @@ ACTOR Future<StatusReply> clusterGetStatus(
 				statusObj["workload"] = workerStatuses[1];
 
 			statusObj["layers"] = workerStatuses[2];
-			/*
 			if (configBroadcaster) {
-			    // TODO: Read from coordinators for more up-to-date config database status?
-			    statusObj["configuration_database"] = configBroadcaster->getStatus();
+				// TODO: Read from coordinators for more up-to-date config database status?
+				statusObj["configuration_database"] = configBroadcaster->getStatus();
 			}
-			*/
 
 			// Add qos section if it was populated
 			if (!qos.empty())


### PR DESCRIPTION
The configuration database report will look something like this in status json:

```
"configuration_database" : {
    "commits" : [
        {
            "description" : "second test description",
            "timestamp" : 1655170000,
            "version" : 9
        }
    ],
    "last_compacted_version" : 0,
    "most_recent_version" : 9,
    "mutations" : [
        {
            "config_class" : "",
            "knob_name" : "min_trace_severity",
            "knob_value" : "int:5",
            "version" : 1
        },
        {
            "config_class" : "",
            "knob_name" : "min_trace_severity",
            "knob_value" : "int:5",
            "version" : 2
        },
        {
            "config_class" : "az-1",
            "knob_name" : "min_trace_severity",
            "knob_value" : "int:5",
            "version" : 3
        },
        {
            "config_class" : "az-1",
            "knob_name" : "min_trace_severity",
            "knob_value" : "int:5",
            "version" : 4
        }
    ],
    "snapshot" : {
        "" : {
            "min_trace_severity" : "int:5"
        },
        "az-1" : {
            "min_trace_severity" : "int:5"
        }
    }
},
```

This PR re-enables reporting in status json and adds a unit test to ensure we are reporting the correct values. I also uncovered a bug where we weren't updating the last compacted version on the broadcaster correctly.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
