### PR TITLE
Safely remove fdb_transaction_get_range_and_flat_map (release-7.1)

### DIFF
--- a/bindings/c/fdb_c.cpp
+++ b/bindings/c/fdb_c.cpp
@@ -672,27 +672,6 @@ extern "C" DLLEXPORT FDBFuture* fdb_transaction_get_mapped_range(FDBTransaction*
 	                    .extractPtr());
 }
 
-FDBFuture* fdb_transaction_get_range_and_flat_map_v709(FDBTransaction* tr,
-                                                       uint8_t const* begin_key_name,
-                                                       int begin_key_name_length,
-                                                       fdb_bool_t begin_or_equal,
-                                                       int begin_offset,
-                                                       uint8_t const* end_key_name,
-                                                       int end_key_name_length,
-                                                       fdb_bool_t end_or_equal,
-                                                       int end_offset,
-                                                       uint8_t const* mapper_name,
-                                                       int mapper_name_length,
-                                                       int limit,
-                                                       int target_bytes,
-                                                       FDBStreamingMode mode,
-                                                       int iteration,
-                                                       fdb_bool_t snapshot,
-                                                       fdb_bool_t reverse) {
-	fprintf(stderr, "GetRangeAndFlatMap is removed from 7.0. Please upgrade to 7.1 and use GetMappedRange\n");
-	abort();
-}
-
 FDBFuture* fdb_transaction_get_range_selector_v13(FDBTransaction* tr,
                                                   uint8_t const* begin_key_name,
                                                   int begin_key_name_length,
@@ -926,7 +905,6 @@ extern "C" DLLEXPORT fdb_error_t fdb_select_api_version_impl(int runtime_version
 	// WARNING: use caution when implementing removed functions by calling public API functions. This can lead to
 	// undesired behavior when using the multi-version API. Instead, it is better to have both the removed and public
 	// functions call an internal implementation function. See fdb_create_database_impl for an example.
-	FDB_API_REMOVED(fdb_transaction_get_range_and_flat_map, 710);
 	FDB_API_REMOVED(fdb_future_get_version, 620);
 	FDB_API_REMOVED(fdb_create_cluster, 610);
 	FDB_API_REMOVED(fdb_cluster_create_database, 610);

--- a/documentation/sphinx/source/administration.rst
+++ b/documentation/sphinx/source/administration.rst
@@ -762,6 +762,11 @@ You can now remove old client library versions from your clients. This is only t
 Version-specific notes on upgrading
 ===================================
 
+Upgrading to 7.1.x
+--------------------
+
+Upgrades to 7.1.0 or later will break any client using ``fdb_transaction_get_range_and_flat_map``, as it is removed in version 7.1.0.
+
 Upgrading from 6.2.x
 --------------------
 

--- a/documentation/sphinx/source/api-version-upgrade-guide.rst
+++ b/documentation/sphinx/source/api-version-upgrade-guide.rst
@@ -17,6 +17,8 @@ API version 710
 General
 -------
 
+* ``fdb_transaction_get_range_and_flat_map`` API is replaced by ``fdb_transaction_get_mapped_range`` in version 710. The function ``fdb_transaction_get_range_and_flat_map`` is not supported in any API version.
+
 .. _api-version-upgrade-guide-700:
 
 API version 700


### PR DESCRIPTION
backporting https://github.com/apple/foundationdb/pull/7314

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
