### PR TITLE
Generate GNU compatible build-id for mockkms golang binary

### DIFF
--- a/contrib/mockkms/mock_kms.go
+++ b/contrib/mockkms/mock_kms.go
@@ -30,6 +30,7 @@ package main
 // 2. No cross-compilation support
 // 3. Limited `go tools` availability.
 // TODO: Replace with a better scheme if possible.
+
 import "C"
 
 import (

--- a/contrib/mockkms/mock_kms.go
+++ b/contrib/mockkms/mock_kms.go
@@ -24,6 +24,14 @@
 
 package main
 
+// Importing module enable .note.gnu.build-id insertion in the ELF executable.
+// Few drawbacks of the scheme are:
+// 1. Potentialy slower builds
+// 2. No cross-compilation support
+// 3. Limited `go tools` availability.
+// TODO: Replace with a better scheme if possible.
+import "C"
+
 import (
     "log"
     "math/rand"


### PR DESCRIPTION
Description

Generate GNU compatible build-id for mockkms golang binary
Leverate "cgo" to generate build-id

Testing

Debian package build, verified the GNU build-id

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
