### PR TITLE
Guard a few uses of gsimulator.

### DIFF
--- a/FDBLibTLS/FDBLibTLSPolicy.cpp
+++ b/FDBLibTLS/FDBLibTLSPolicy.cpp
@@ -34,6 +34,7 @@
 #include <algorithm>
 #include <exception>
 #include <map>
+#include <stdexcept>
 #include <string>
 #include <vector>
 

--- a/FDBLibTLS/FDBLibTLSVerify.cpp
+++ b/FDBLibTLS/FDBLibTLSVerify.cpp
@@ -28,6 +28,7 @@
 #include <algorithm>
 #include <exception>
 #include <cstring>
+#include <stdexcept>
 
 static int hexValue(char c) {
 	static char const digits[] = "0123456789ABCDEF";

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -4308,7 +4308,7 @@ ACTOR Future<Void> getKeyValuesStreamQ(StorageServer* data, GetKeyValuesStreamRe
 
 				// Even if TSS mode is Disabled, this may be the second test in a restarting test where the first run
 				// had it enabled.
-				state int byteLimit = (BUGGIFY && g_simulator.tssMode == ISimulator::TSSMode::Disabled &&
+				state int byteLimit = (BUGGIFY && g_network->isSimulated() && g_simulator.tssMode == ISimulator::TSSMode::Disabled &&
 				                       !data->isTss() && !data->isSSWithTSSPair())
 				                          ? 1
 				                          : CLIENT_KNOBS->REPLY_BYTE_LIMIT;

--- a/fdbserver/workloads/WriteDuringRead.actor.cpp
+++ b/fdbserver/workloads/WriteDuringRead.actor.cpp
@@ -87,7 +87,7 @@ struct WriteDuringReadWorkload : TestWorkload {
 		TEST(adjacentKeys &&
 		     (nodes + minNode) > CLIENT_KNOBS->KEY_SIZE_LIMIT); // WriteDuringReadWorkload testing large keys
 
-		useExtraDB = g_simulator.extraDB != nullptr;
+		useExtraDB = g_network->isSimulated() && g_simulator.extraDB != nullptr;
 		if (useExtraDB) {
 			auto extraFile = makeReference<ClusterConnectionMemoryRecord>(*g_simulator.extraDB);
 			extraDB = Database::createDatabase(extraFile, -1);


### PR DESCRIPTION
Prevents crashes when running with buggification outside of simulation.
