### PR TITLE
Do not always try to figure out the sequencer locality

### DIFF
--- a/fdbserver/masterserver.actor.cpp
+++ b/fdbserver/masterserver.actor.cpp
@@ -117,8 +117,9 @@ struct MasterData : NonCopyable, ReferenceCounted<MasterData> {
 			forceRecovery = false;
 		}
 		balancer = resolutionBalancer.resolutionBalancing();
-		locality = myInterface.locality.dcId().present() ? std::stoi(myInterface.locality.dcId().get().toString())
-		                                                 : tagLocalityInvalid;
+		locality = (SERVER_KNOBS->ENABLE_VERSION_VECTOR_HA_OPTIMIZATION && myInterface.locality.dcId().present())
+		               ? std::stoi(myInterface.locality.dcId().get().toString())
+		               : tagLocalityInvalid;
 	}
 	~MasterData() = default;
 };


### PR DESCRIPTION
Do not try to figure out the sequencer locality if knob ENABLE_VERSION_VECTOR_HA_OPTIMIZATION is disabled.

NOTE: There is a bug in the code that figures out the sequencer locality, which will be addressed in a follow up PR.

Simulation tests:
Compiler: gcc.
Version vector disabled: 20220615-160758-sre-4d4401896450eb20 (in progress).

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
