### PR TITLE
parameterizing min split size instead of hardcoding it to min_shard_bytes

### DIFF
--- a/fdbclient/DatabaseContext.h
+++ b/fdbclient/DatabaseContext.h
@@ -307,10 +307,12 @@ public:
 	Future<Void> splitStorageMetricsStream(PromiseStream<Key> const& resultsStream,
 	                                       KeyRange const& keys,
 	                                       StorageMetrics const& limit,
-	                                       StorageMetrics const& estimated);
+	                                       StorageMetrics const& estimated,
+	                                       Optional<int> const& minSplitBytes = {});
 	Future<Standalone<VectorRef<KeyRef>>> splitStorageMetrics(KeyRange const& keys,
 	                                                          StorageMetrics const& limit,
-	                                                          StorageMetrics const& estimated);
+	                                                          StorageMetrics const& estimated,
+	                                                          Optional<int> const& minSplitBytes = {});
 
 	Future<Standalone<VectorRef<ReadHotRangeWithMetrics>>> getReadHotRanges(KeyRange const& keys);
 

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -7885,7 +7885,8 @@ ACTOR Future<Void> splitStorageMetricsStream(PromiseStream<Key> resultStream,
                                              Database cx,
                                              KeyRange keys,
                                              StorageMetrics limit,
-                                             StorageMetrics estimated) {
+                                             StorageMetrics estimated,
+                                             Optional<int> minSplitBytes) {
 	state Span span("NAPI:SplitStorageMetricsStream"_loc);
 	state Key beginKey = keys.begin;
 	state Key globalLastKey = beginKey;
@@ -7916,7 +7917,8 @@ ACTOR Future<Void> splitStorageMetricsStream(PromiseStream<Key> resultStream,
 				                        limit,
 				                        localUsed,
 				                        estimated,
-				                        i == locations.size() - 1 && keys.end <= locations.back().range.end);
+				                        i == locations.size() - 1 && keys.end <= locations.back().range.end,
+				                        minSplitBytes);
 				SplitMetricsReply res = wait(loadBalance(locations[i].locations->locations(),
 				                                         &StorageServerInterface::splitMetrics,
 				                                         req,
@@ -7979,15 +7981,17 @@ ACTOR Future<Void> splitStorageMetricsStream(PromiseStream<Key> resultStream,
 Future<Void> DatabaseContext::splitStorageMetricsStream(const PromiseStream<Key>& resultStream,
                                                         KeyRange const& keys,
                                                         StorageMetrics const& limit,
-                                                        StorageMetrics const& estimated) {
+                                                        StorageMetrics const& estimated,
+                                                        Optional<int> const& minSplitBytes) {
 	return ::splitStorageMetricsStream(
-	    resultStream, Database(Reference<DatabaseContext>::addRef(this)), keys, limit, estimated);
+	    resultStream, Database(Reference<DatabaseContext>::addRef(this)), keys, limit, estimated, minSplitBytes);
 }
 
 ACTOR Future<Standalone<VectorRef<KeyRef>>> splitStorageMetrics(Database cx,
                                                                 KeyRange keys,
                                                                 StorageMetrics limit,
-                                                                StorageMetrics estimated) {
+                                                                StorageMetrics estimated,
+                                                                Optional<int> minSplitBytes) {
 	state Span span("NAPI:SplitStorageMetrics"_loc);
 	loop {
 		state std::vector<KeyRangeLocationInfo> locations =
@@ -8016,7 +8020,8 @@ ACTOR Future<Standalone<VectorRef<KeyRef>>> splitStorageMetrics(Database cx,
 
 				state int i = 0;
 				for (; i < locations.size(); i++) {
-					SplitMetricsRequest req(locations[i].range, limit, used, estimated, i == locations.size() - 1);
+					SplitMetricsRequest req(
+					    locations[i].range, limit, used, estimated, i == locations.size() - 1, minSplitBytes);
 					SplitMetricsReply res = wait(loadBalance(locations[i].locations->locations(),
 					                                         &StorageServerInterface::splitMetrics,
 					                                         req,
@@ -8060,8 +8065,10 @@ ACTOR Future<Standalone<VectorRef<KeyRef>>> splitStorageMetrics(Database cx,
 
 Future<Standalone<VectorRef<KeyRef>>> DatabaseContext::splitStorageMetrics(KeyRange const& keys,
                                                                            StorageMetrics const& limit,
-                                                                           StorageMetrics const& estimated) {
-	return ::splitStorageMetrics(Database(Reference<DatabaseContext>::addRef(this)), keys, limit, estimated);
+                                                                           StorageMetrics const& estimated,
+                                                                           Optional<int> const& minSplitBytes) {
+	return ::splitStorageMetrics(
+	    Database(Reference<DatabaseContext>::addRef(this)), keys, limit, estimated, minSplitBytes);
 }
 
 void Transaction::checkDeferredError() const {

--- a/fdbclient/StorageServerInterface.h
+++ b/fdbclient/StorageServerInterface.h
@@ -716,18 +716,21 @@ struct SplitMetricsRequest {
 	StorageMetrics estimated;
 	bool isLastShard;
 	ReplyPromise<SplitMetricsReply> reply;
+	Optional<int> minSplitBytes;
 
 	SplitMetricsRequest() {}
 	SplitMetricsRequest(KeyRangeRef const& keys,
 	                    StorageMetrics const& limits,
 	                    StorageMetrics const& used,
 	                    StorageMetrics const& estimated,
-	                    bool isLastShard)
-	  : keys(arena, keys), limits(limits), used(used), estimated(estimated), isLastShard(isLastShard) {}
+	                    bool isLastShard,
+	                    Optional<int> minSplitBytes)
+	  : keys(arena, keys), limits(limits), used(used), estimated(estimated), isLastShard(isLastShard),
+	    minSplitBytes(minSplitBytes) {}
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, keys, limits, used, estimated, isLastShard, reply, arena);
+		serializer(ar, keys, limits, used, estimated, isLastShard, reply, arena, minSplitBytes);
 	}
 };
 

--- a/fdbserver/BlobManager.actor.cpp
+++ b/fdbserver/BlobManager.actor.cpp
@@ -354,8 +354,9 @@ ACTOR Future<Standalone<VectorRef<KeyRef>>> splitRange(Reference<BlobManagerData
 
 			state PromiseStream<Key> resultStream;
 			state Standalone<VectorRef<KeyRef>> keys;
-			state Future<Void> streamFuture =
-			    bmData->db->splitStorageMetricsStream(resultStream, range, splitMetrics, estimated);
+			// SplitMetrics.bytes / 3 as min split size because of same splitThreshold logic above.
+			state Future<Void> streamFuture = bmData->db->splitStorageMetricsStream(
+			    resultStream, range, splitMetrics, estimated, splitMetrics.bytes / 3);
 			loop {
 				try {
 					Key k = waitNext(resultStream.getFuture());

--- a/fdbserver/DataDistributionTracker.actor.cpp
+++ b/fdbserver/DataDistributionTracker.actor.cpp
@@ -380,7 +380,7 @@ ACTOR Future<Standalone<VectorRef<KeyRef>>> getSplitKeys(DataDistributionTracker
 		state Transaction tr(self->cx);
 		try {
 			Standalone<VectorRef<KeyRef>> keys =
-			    wait(self->cx->splitStorageMetrics(splitRange, splitMetrics, estimated));
+			    wait(self->cx->splitStorageMetrics(splitRange, splitMetrics, estimated, SERVER_KNOBS->MIN_SHARD_BYTES));
 			return keys;
 		} catch (Error& e) {
 			wait(tr.onError(e));

--- a/fdbserver/StorageMetrics.h
+++ b/fdbserver/StorageMetrics.h
@@ -357,6 +357,7 @@ struct StorageServerMetrics {
 	}
 
 	void splitMetrics(SplitMetricsRequest req) const {
+		int minSplitBytes = req.minSplitBytes.present() ? req.minSplitBytes.get() : SERVER_KNOBS->MIN_SHARD_BYTES;
 		try {
 			SplitMetricsReply reply;
 			KeyRef lastKey = req.keys.begin;
@@ -364,10 +365,10 @@ struct StorageServerMetrics {
 			StorageMetrics estimated = req.estimated;
 			StorageMetrics remaining = getMetrics(req.keys) + used;
 
-			//TraceEvent("SplitMetrics").detail("Begin", req.keys.begin).detail("End", req.keys.end).detail("Remaining", remaining.bytes).detail("Used", used.bytes);
+			//TraceEvent("SplitMetrics").detail("Begin", req.keys.begin).detail("End", req.keys.end).detail("Remaining", remaining.bytes).detail("Used", used.bytes).detail("MinSplitBytes", minSplitBytes);
 
 			while (true) {
-				if (remaining.bytes < 2 * SERVER_KNOBS->MIN_SHARD_BYTES)
+				if (remaining.bytes < 2 * minSplitBytes)
 					break;
 				KeyRef key = req.keys.end;
 				bool hasUsed = used.bytes != 0 || used.bytesPerKSecond != 0 || used.iosPerKSecond != 0;
@@ -382,10 +383,9 @@ struct StorageServerMetrics {
 				                  lastKey,
 				                  key,
 				                  hasUsed);
-				if (used.bytes < SERVER_KNOBS->MIN_SHARD_BYTES)
-					key = std::max(key,
-					               byteSample.splitEstimate(KeyRangeRef(lastKey, req.keys.end),
-					                                        SERVER_KNOBS->MIN_SHARD_BYTES - used.bytes));
+				if (used.bytes < minSplitBytes)
+					key = std::max(
+					    key, byteSample.splitEstimate(KeyRangeRef(lastKey, req.keys.end), minSplitBytes - used.bytes));
 				key = getSplitKey(remaining.iosPerKSecond,
 				                  estimated.iosPerKSecond,
 				                  req.limits.iosPerKSecond,


### PR DESCRIPTION
MIN_SHARD_BYTES was hardcoded as the min split size, which made StorageMetrics not useful for anything trying to calculate metrics that isn't a shard.

Passed 10k BlobGranule* correctness, everywhere else has the same default value.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
