### PR TITLE
Refactor Docker setup for new binary location

### DIFF
--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -95,7 +95,7 @@ RUN for file in fdbserver fdbbackup fdbcli fdbmonitor; do \
     done
 
 # Setup all symlinks for the other binaries that are a copy of fdbbackup
-RUN for file in fdbdr fdbrestore fdbserver backup_agent dr_agent fastrestore_tool; do \
+RUN for file in fdbdr fdbrestore backup_agent dr_agent fastrestore_tool; do \
         ln -s /usr/bin/fdbbackup /usr/bin/$file; \
     done
 

--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -69,7 +69,7 @@ FROM base as foundationdb-base
 WORKDIR /tmp
 ARG FDB_VERSION=6.3.22
 ARG FDB_LIBRARY_VERSIONS="${FDB_VERSION}"
-ARG FDB_WEBSITE=https://www.foundationdb.org
+ARG FDB_WEBSITE=https://github.com/apple/foundationdb/releases/download
 
 RUN mkdir -p /var/fdb/{logs,tmp,lib} && \
     mkdir -p /usr/lib/fdb/multiversion && \
@@ -88,24 +88,29 @@ RUN groupadd --gid 4059 \
 COPY website /tmp/website/
 
 # Install FoundationDB Binaries
-RUN curl -Ls $FDB_WEBSITE/downloads/$FDB_VERSION/linux/fdb_$FDB_VERSION.tar.gz | tar zxf - --strip-components=1 && \
-    for file in fdbbackup fdbcli fdbdr fdbmonitor fdbrestore fdbserver backup_agent dr_agent fastrestore_tool; do \
+RUN for file in fdbserver fdbbackup fdbcli fdbmonitor; do \
+        curl --fail -Ls ${FDB_WEBSITE}/${FDB_VERSION}/$file.x86_64 -o $file; \
         chmod u+x $file; \
         mv $file /usr/bin; \
     done
 
+# Setup all symlinks for the other binaries that are a copy of fdbbackup
+RUN for file in fdbdr fdbrestore fdbserver backup_agent dr_agent fastrestore_tool; do \
+        ln -s /usr/bin/fdbbackup /usr/bin/$file; \
+    done
+
 # Install additional FoundationDB Client Libraries
 RUN for version in $FDB_LIBRARY_VERSIONS; do \
-    curl -Ls $FDB_WEBSITE/downloads/$version/linux/libfdb_c_$version.so -o /usr/lib/fdb/multiversion/libfdb_c_${version%.*}.so; \
+    curl --fail -Ls ${FDB_WEBSITE}/${version}/libfdb_c.x86_64.so -o /usr/lib/fdb/multiversion/libfdb_c_${version%.*}.so; \
     done
 
 # Install additional FoundationDB Client Libraries (for sidecar)
 RUN mkdir -p /var/fdb/lib && \
     for version in $FDB_LIBRARY_VERSIONS; do \
-    curl -Ls $FDB_WEBSITE/downloads/$version/linux/libfdb_c_$version.so -o /var/fdb/lib/libfdb_c_${version%.*}.so; \
+    curl --fail -Ls ${FDB_WEBSITE}/${version}/libfdb_c.x86_64.so -o /var/fdb/lib/libfdb_c_${version%.*}.so; \
     done
 
-RUN curl -Ls $FDB_WEBSITE/downloads/$FDB_VERSION/linux/libfdb_c_$FDB_VERSION.so -o /usr/lib/libfdb_c.so
+RUN curl -Ls $FDB_WEBSITE/$FDB_VERSION/libfdb_c.x86_64.so -o /usr/lib/libfdb_c.so
 
 RUN rm -rf /tmp/*
 WORKDIR /

--- a/packaging/docker/Dockerfile.eks
+++ b/packaging/docker/Dockerfile.eks
@@ -104,7 +104,7 @@ RUN for file in fdbserver fdbbackup fdbcli fdbmonitor; do \
     done
 
 # Setup all symlinks for the other binaries that are a copy of fdbbackup
-RUN for file in fdbdr fdbrestore fdbserver backup_agent dr_agent fastrestore_tool; do \
+RUN for file in fdbdr fdbrestore backup_agent dr_agent fastrestore_tool; do \
         ln -s /usr/bin/fdbbackup /usr/bin/$file; \
     done
 

--- a/packaging/docker/Dockerfile.eks
+++ b/packaging/docker/Dockerfile.eks
@@ -78,7 +78,7 @@ FROM base as foundationdb-base
 WORKDIR /tmp
 ARG FDB_VERSION=6.3.22
 ARG FDB_LIBRARY_VERSIONS="${FDB_VERSION}"
-ARG FDB_WEBSITE=https://www.foundationdb.org
+ARG FDB_WEBSITE=https://github.com/apple/foundationdb/releases/download
 
 RUN mkdir -p /var/fdb/{logs,tmp,lib} && \
     mkdir -p /usr/lib/fdb/multiversion && \
@@ -97,24 +97,29 @@ RUN groupadd --gid 4059 \
 COPY website /tmp/website/
 
 # Install FoundationDB Binaries
-RUN curl -Ls $FDB_WEBSITE/downloads/$FDB_VERSION/linux/fdb_$FDB_VERSION.tar.gz | tar zxf - --strip-components=1 && \
-    for file in fdbbackup fdbcli fdbdr fdbmonitor fdbrestore fdbserver backup_agent dr_agent fastrestore_tool; do \
+RUN for file in fdbserver fdbbackup fdbcli fdbmonitor; do \
+        curl --fail -Ls ${FDB_WEBSITE}/${FDB_VERSION}/$file.x86_64 -o $file; \
         chmod u+x $file; \
         mv $file /usr/bin; \
     done
 
+# Setup all symlinks for the other binaries that are a copy of fdbbackup
+RUN for file in fdbdr fdbrestore fdbserver backup_agent dr_agent fastrestore_tool; do \
+        ln -s /usr/bin/fdbbackup /usr/bin/$file; \
+    done
+
 # Install additional FoundationDB Client Libraries
 RUN for version in $FDB_LIBRARY_VERSIONS; do \
-    curl -Ls $FDB_WEBSITE/downloads/$version/linux/libfdb_c_$version.so -o /usr/lib/fdb/multiversion/libfdb_c_${version%.*}.so; \
+    curl --fail -Ls ${FDB_WEBSITE}/${version}/libfdb_c.x86_64.so -o /usr/lib/fdb/multiversion/libfdb_c_${version%.*}.so; \
     done
 
 # Install additional FoundationDB Client Libraries (for sidecar)
 RUN mkdir -p /var/fdb/lib && \
     for version in $FDB_LIBRARY_VERSIONS; do \
-    curl -Ls $FDB_WEBSITE/downloads/$version/linux/libfdb_c_$version.so -o /var/fdb/lib/libfdb_c_${version%.*}.so; \
+    curl --fail -Ls ${FDB_WEBSITE}/${version}/libfdb_c.x86_64.so -o /var/fdb/lib/libfdb_c_${version%.*}.so; \
     done
 
-RUN curl -Ls $FDB_WEBSITE/downloads/$FDB_VERSION/linux/libfdb_c_$FDB_VERSION.so -o /usr/lib/libfdb_c.so
+RUN curl -Ls $FDB_WEBSITE/$FDB_VERSION/libfdb_c.x86_64.so -o /usr/lib/libfdb_c.so
 
 RUN rm -rf /tmp/*
 WORKDIR /

--- a/packaging/docker/build-images.sh
+++ b/packaging/docker/build-images.sh
@@ -40,7 +40,7 @@ function create_fake_website_directory() {
             curl -Ls "${artifactory_base_url}/${fdb_version}/release/api/foundationdb-binaries-${fdb_version}-linux.tar.gz" | tar -xzf -
             # Add the x86_64 to all binaries
             for file in "${fdb_binaries[@]}"; do
-                mv -pr "${file}" "${file}.x86_64"
+                mv "${file}" "${file}.x86_64"
             done
             ;;
         "stripped_artifactory")

--- a/packaging/docker/build-images.sh
+++ b/packaging/docker/build-images.sh
@@ -197,12 +197,12 @@ logg "STARTING ${0}"
 echo "${blue}################################################################################${reset}"
 
 ################################################################################
-# The intent of this script is to build the set of docker images needed to run
-# FoundationDB in kubernetes from binaries that are not available the website:
-# https://foundationdb.org/downloads
+# The intent of this script is to build the set of Docker images needed to run
+# FoundationDB in Kubernetes from binaries that are not available the website:
+# https://github.com/apple/foundationdb/releases/download
 #
-# The docker file itself will pull released binaries from the foundationdb
-# website. If the intent is to build images for an already released version of
+# The Docker file itself will pull released binaries from GitHub releases.
+# If the intent is to build images for an already released version of
 # FoundationDB, a simple docker build command will work.
 #
 # This script has enough stupid built into it that trying to come up with a set

--- a/packaging/docker/build-images.sh
+++ b/packaging/docker/build-images.sh
@@ -73,13 +73,12 @@ function create_fake_website_directory() {
     # symlinks and the binaries tarball
     ############################################################################
     logg "FETCHING CLIENT LIBRARY"
-    destination_directory="${website_directory}/${version}"
-    destination_filename="libfdb_c.x86_64.so"
-
     case "${stripped_binaries_and_from_where}" in
         "unstripped_artifactory")
             for version in "${fdb_library_versions[@]}"; do
                 logg "FETCHING ${version} CLIENT LIBRARY"
+                destination_directory="${website_directory}/${version}"
+                destination_filename="libfdb_c.x86_64.so"
                 mkdir -p "${destination_directory}"
                 pushd "${destination_directory}" || exit 127
                 curl -Ls "${artifactory_base_url}/${version}/release/api/fdb-server-${version}-linux.tar.gz" | tar -xzf - ./lib/libfdb_c.so --strip-components 2
@@ -91,18 +90,22 @@ function create_fake_website_directory() {
         "stripped_artifactory")
             for version in "${fdb_library_versions[@]}"; do
                 logg "FETCHING ${version} CLIENT LIBRARY"
+                destination_directory="${website_directory}/${version}"
+                destination_filename="libfdb_c.x86_64.so"
                 mkdir -p "${destination_directory}"
-                curl -Ls "${artifactory_base_url}/${version}/release/files/linux/lib/libfdb_c.so" -o "${destination_directory}/${destination_filename}"
-                chmod 755 "${destination_directory}/${destination_filename}"
+                pushd "${destination_directory}" || exit 127
+                curl -Ls "${artifactory_base_url}/${version}/release/files/linux/lib/libfdb_c.so" -o "${destination_filename}"
+                chmod 755 "${destination_filename}"
+                popd || exit 128
             done
             ;;
         "unstripped_local")
             logg "COPYING UNSTRIPPED CLIENT LIBRARY"
-            cp -pr "${build_output_directory}/lib/libfdb_c.so" "${destination_directory}/${destination_filename}"
+            cp -pr "${build_output_directory}/lib/libfdb_c.so" "${website_directory}/${fdb_version}/libfdb_c.x86_64.so"
             ;;
         "stripped_local")
             logg "COPYING STRIPPED CLIENT LIBRARY"
-            cp -pr "${build_output_directory}/packages/lib/libfdb_c.so" "${destination_directory}/${destination_filename}"
+            cp -pr "${build_output_directory}/packages/lib/libfdb_c.so" "${website_directory}/${fdb_version}/libfdb_c.x86_64.so"
             ;;
     esac
     # override fdb_website variable that is passed to Docker build


### PR DESCRIPTION
This allows users to use the docker images without any modification. The changes are made to reflect that binaries are now hosted on GitHub. 

I build the image locally with the following command:

```bash
docker build -t foundationdb/foundationdb-kubernetes:7.1.5-local --target fdb-kubernetes-monitor --build-arg FDB_VERSION=7.1.5 --build-arg FDB_LIBRARY_VERSIONS="7.1.5 6.3.24 6.2.30" -f packaging/docker/Dockerfile .
```

I will run an additional test for the `build-images.sh` script.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [x] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
