### PR TITLE
Ignore format commits in git blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,4 @@
+# clang-format the entire codebase
+df90cc89de67ea4748c8cadd18e6fc4ce7fda12e
+2c788c233db56ccec4ed90d7da31887487b9f3b7
+69508b980f3cc5aabea6322f292e53b07bb27544


### PR DESCRIPTION
Generally, when looking at `git blame`, I don't want to see format commits as they don't affect functionality.  `git blame` has a parameter to ignore a commit (see https://git-scm.com/docs/git-blame#Documentation/git-blame.txt---ignore-revltrevgt). The Github UI also [supports this feature](https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view). This PR adds the format changes from #4464 and #5497 to the set of ignored revisions in `git blame`.

Locally, the ignored revisions file must be manually specified with `--ignore-revs-file`:
```
git blame --ignore-revs-file .git-blame-ignore-revs <file>
```

or it can be set globally:
```
$ git config --global blame.ignoreRevsFile .git-blame-ignore-revs
```

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
