### PR TITLE
Add check to avoid using memcpy with an invalid data pointer

### DIFF
--- a/flow/Arena.h
+++ b/flow/Arena.h
@@ -625,7 +625,9 @@ public:
 
 	// Copies string contents to dst and returns a pointer to the next byte after
 	uint8_t* copyTo(uint8_t* dst) const {
-		memcpy(dst, data, length);
+		if (length > 0) {
+			memcpy(dst, data, length);
+		}
 		return dst + length;
 	}
 


### PR DESCRIPTION
This checks the length of the data before calling memcpy to avoid the potential for calling `copyTo` on a `StringRef` that has an invalid data pointer and 0 length.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
