### PR TITLE
Remove use of IKnobCollection in Tracing.actor.cpp

### DIFF
--- a/flow/Tracing.actor.cpp
+++ b/flow/Tracing.actor.cpp
@@ -22,7 +22,6 @@
 #include "flow/IRandom.h"
 #include "flow/UnitTest.h"
 #include "flow/Knobs.h"
-#include "fdbclient/IKnobCollection.h"
 #include "flow/network.h"
 #include <functional>
 #include <iomanip>
@@ -534,8 +533,8 @@ TEST_CASE("/flow/Tracing/AddAttributes") {
 	           SpanContext(deterministicRandom()->randomUniqueID(),
 	                       deterministicRandom()->randomUInt64(),
 	                       TraceFlags::sampled));
-	IKnobCollection::getMutableGlobalKnobCollection().setKnob("tracing_span_attributes_enabled",
-	                                                          KnobValueRef::create(bool{ true }));
+	bootstrapGlobalFlowKnobs.TRACING_SPAN_ATTRIBUTES_ENABLED = true;
+	FLOW_KNOBS = &bootstrapGlobalFlowKnobs;
 	auto arena = span1.arena;
 	span1.addAttribute(StringRef(arena, LiteralStringRef("foo")), StringRef(arena, LiteralStringRef("bar")));
 	span1.addAttribute(StringRef(arena, LiteralStringRef("operation")), StringRef(arena, LiteralStringRef("grv")));
@@ -654,8 +653,8 @@ std::string readMPString(uint8_t* index) {
 // Windows doesn't like lack of header and declaration of constructor for FastUDPTracer
 #ifndef WIN32
 TEST_CASE("/flow/Tracing/FastUDPMessagePackEncoding") {
-	IKnobCollection::getMutableGlobalKnobCollection().setKnob("tracing_span_attributes_enabled",
-	                                                          KnobValueRef::create(bool{ true }));
+	bootstrapGlobalFlowKnobs.TRACING_SPAN_ATTRIBUTES_ENABLED = true;
+	FLOW_KNOBS = &bootstrapGlobalFlowKnobs;
 	Span span1("encoded_span"_loc);
 	auto request = TraceRequest{ .buffer = std::make_unique<uint8_t[]>(kTraceBufferSize),
 		                         .data_size = 0,


### PR DESCRIPTION
directly access bootstrapGlobalFlowKnobs to enable span attributes for unit testing message pack serialization.

Tested with unit tests and correctness.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
