### PR TITLE
TLS certificate path should not be based on present working directory

### DIFF
--- a/documentation/sphinx/source/tls.rst
+++ b/documentation/sphinx/source/tls.rst
@@ -126,11 +126,11 @@ Default Values
 Certificate file default location
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The default behavior when the certificate or key file is not specified is to look for a file named ``fdb.pem`` system-dependent locations as follows:
+The default behavior when the certificate or key file is not specified is to look for files named ``cert.pem`` or  ``key.pem`` respectively, in system-dependent locations as follows:
 
-* Linux: ``/etc/foundationdb/fdb.pem``
-* macOS: ``/usr/local/etc/foundationdb/fdb.pem``
-* Windows: ``C:\ProgramData\foundationdb\fdb.pem``
+* Linux: ``/etc/foundationdb/cert.pem`` and ``/etc/foundationdb/key.pem``
+* macOS: ``/usr/local/etc/foundationdb/cert.pem`` and ``/usr/local/etc/foundationdb/key.pem``
+* Windows: ``C:\ProgramData\foundationdb\cert.pem`` and ``C:\ProgramData\foundationdb\key.pem``
 
 Default Peer Verification
 ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -214,9 +214,12 @@ Certificate creation
 
 If your organization already makes use of certificates for access control and securing communications, you should ask your security expert for organizational procedure for obtaining and verifying certificates. If the goal of enabling TLS is to make sure that only known machines can join or access the FoundationDB cluster and for securing communications, then creating your own certificates can serve these purposes.
 
-The following set of commands uses the OpenSSL command-line tools to create a self-signed certificate and private key. The certificate is then joined with the private key in the output ``fdb.pem`` file::
+The following set of commands uses the OpenSSL command-line tools to create a self-signed certificate and private key::
 
-  user@host:> openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout private.key -out cert.crt
+  user@host:> openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout key.pem -out cert.pem
+
+Optionally, the certificate can be joined with the private key as supplied as both certificate and key files::
+
   user@host:> cat cert.crt private.key > fdb.pem
 
 Peer verification

--- a/documentation/sphinx/source/tls.rst
+++ b/documentation/sphinx/source/tls.rst
@@ -126,7 +126,7 @@ Default Values
 Certificate file default location
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The default behavior when the certificate or key file is not specified is to look for a file named ``fdb.pem`` in the current working directory. If this file is not present, an attempt is made to load a file from a system-dependent location as follows:
+The default behavior when the certificate or key file is not specified is to look for a file named ``fdb.pem`` system-dependent locations as follows:
 
 * Linux: ``/etc/foundationdb/fdb.pem``
 * macOS: ``/usr/local/etc/foundationdb/fdb.pem``

--- a/flow/TLSConfig.actor.cpp
+++ b/flow/TLSConfig.actor.cpp
@@ -178,7 +178,7 @@ std::string TLSConfig::getCertificatePathSync() const {
 		return envCertPath;
 	}
 
-	const char* defaultCertFileName = "fdb.pem";
+	const char* defaultCertFileName = "cert.pem";
 	if (fileExists(joinPath(platform::getDefaultConfigPath(), defaultCertFileName))) {
 		return joinPath(platform::getDefaultConfigPath(), defaultCertFileName);
 	}
@@ -196,9 +196,9 @@ std::string TLSConfig::getKeyPathSync() const {
 		return envKeyPath;
 	}
 
-	const char* defaultCertFileName = "fdb.pem";
-	if (fileExists(joinPath(platform::getDefaultConfigPath(), defaultCertFileName))) {
-		return joinPath(platform::getDefaultConfigPath(), defaultCertFileName);
+	const char* defaultKeyFileName = "key.pem";
+	if (fileExists(joinPath(platform::getDefaultConfigPath(), defaultKeyFileName))) {
+		return joinPath(platform::getDefaultConfigPath(), defaultKeyFileName);
 	}
 
 	return std::string();

--- a/flow/TLSConfig.actor.cpp
+++ b/flow/TLSConfig.actor.cpp
@@ -179,10 +179,6 @@ std::string TLSConfig::getCertificatePathSync() const {
 	}
 
 	const char* defaultCertFileName = "fdb.pem";
-	if (fileExists(defaultCertFileName)) {
-		return defaultCertFileName;
-	}
-
 	if (fileExists(joinPath(platform::getDefaultConfigPath(), defaultCertFileName))) {
 		return joinPath(platform::getDefaultConfigPath(), defaultCertFileName);
 	}
@@ -201,10 +197,6 @@ std::string TLSConfig::getKeyPathSync() const {
 	}
 
 	const char* defaultCertFileName = "fdb.pem";
-	if (fileExists(defaultCertFileName)) {
-		return defaultCertFileName;
-	}
-
 	if (fileExists(joinPath(platform::getDefaultConfigPath(), defaultCertFileName))) {
 		return joinPath(platform::getDefaultConfigPath(), defaultCertFileName);
 	}

--- a/flow/include/flow/TLSConfig.actor.h
+++ b/flow/include/flow/TLSConfig.actor.h
@@ -182,7 +182,6 @@ public:
 
 	// Return the explicitly set path.
 	// If one was not set, return the path from the environment.
-	// (Cert and Key only) If neither exist, check for fdb.pem in cwd
 	// (Cert and Key only) If fdb.pem doesn't exist, check for it in default config dir
 	// Otherwise return the empty string.
 	// Theoretically, fileExists() can block, so these functions are labelled as synchronous

--- a/flow/include/flow/TLSConfig.actor.h
+++ b/flow/include/flow/TLSConfig.actor.h
@@ -182,7 +182,7 @@ public:
 
 	// Return the explicitly set path.
 	// If one was not set, return the path from the environment.
-	// (Cert and Key only) If fdb.pem doesn't exist, check for it in default config dir
+	// (Cert and Key only) If cert.pem or key.pem don't exist, check for them in default config dir
 	// Otherwise return the empty string.
 	// Theoretically, fileExists() can block, so these functions are labelled as synchronous
 	// TODO: make an easy to use Future<bool> fileExists, and port lots of code over to it.


### PR DESCRIPTION
I found it surprising that if I had a file named `fdb.pem` in my current directory that this pem file would be used by `fdbcli` rather than the default `/etc/foundationdb/fdb.pem`. This change makes it so that `/etc/foundationdb/fdb.pem` is the default unless another certificate is explicitly specified.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
