### PR TITLE
Fix UBSAN build when statically linking libcxx

### DIFF
--- a/bindings/c/CMakeLists.txt
+++ b/bindings/c/CMakeLists.txt
@@ -53,6 +53,15 @@ add_dependencies(fdb_c fdb_c_generated fdb_c_options)
 add_dependencies(fdbclient fdb_c_options)
 add_dependencies(fdbclient_sampling fdb_c_options)
 target_link_libraries(fdb_c PRIVATE $<BUILD_INTERFACE:fdbclient>)
+if(USE_UBSAN)
+  # The intent of this hack is to force c targets that depend on fdb_c to use
+  # c++ as their linker language. Otherwise you see undefined references to c++
+  # specific ubsan symbols.
+  add_library(force_cxx_linker STATIC IMPORTED)
+  set_property(TARGET force_cxx_linker PROPERTY IMPORTED_LOCATION /dev/null)
+  set_target_properties(force_cxx_linker PROPERTIES IMPORTED_LINK_INTERFACE_LANGUAGES CXX)
+  target_link_libraries(fdb_c PUBLIC $<BUILD_INTERFACE:force_cxx_linker>)
+endif()
 if(APPLE)
   set(symbols ${CMAKE_CURRENT_BINARY_DIR}/fdb_c.symbols)
   add_custom_command(OUTPUT ${symbols}

--- a/bindings/c/CMakeLists.txt
+++ b/bindings/c/CMakeLists.txt
@@ -76,7 +76,12 @@ if(APPLE)
   target_link_options(fdb_c PRIVATE "LINKER:-no_weak_exports,-exported_symbols_list,${symbols}")
 elseif(WIN32)
 else()
-  target_link_options(fdb_c PRIVATE "LINKER:--version-script=${CMAKE_CURRENT_SOURCE_DIR}/fdb_c.map,-z,nodelete,-z,noexecstack")
+  if (NOT USE_UBSAN)
+    # For ubsan we need to export type information for the vptr check to work.
+    # Otherwise we only want to export fdb symbols in the fdb c api.
+    target_link_options(fdb_c PRIVATE "LINKER:--version-script=${CMAKE_CURRENT_SOURCE_DIR}/fdb_c.map")
+  endif()
+  target_link_options(fdb_c PRIVATE "LINKER:-z,nodelete,-z,noexecstack")
 endif()
 target_include_directories(fdb_c PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>

--- a/fdbserver/KeyValueStoreMemory.actor.cpp
+++ b/fdbserver/KeyValueStoreMemory.actor.cpp
@@ -479,8 +479,12 @@ private:
 
 			uint8_t* plaintext = new uint8_t[sizeof(int) + v1.size() + v2.size()];
 			*(int*)plaintext = op;
-			memcpy(plaintext + sizeof(int), v1.begin(), v1.size());
-			memcpy(plaintext + sizeof(int) + v1.size(), v2.begin(), v2.size());
+			if (v1.size()) {
+				memcpy(plaintext + sizeof(int), v1.begin(), v1.size());
+			}
+			if (v2.size()) {
+				memcpy(plaintext + sizeof(int) + v1.size(), v2.begin(), v2.size());
+			}
 
 			ASSERT(cipherKeys.cipherTextKey.isValid());
 			ASSERT(cipherKeys.cipherHeaderKey.isValid());

--- a/fdbserver/TLogServer.actor.cpp
+++ b/fdbserver/TLogServer.actor.cpp
@@ -2221,6 +2221,10 @@ ACTOR Future<Void> commitQueue(TLogData* self) {
 				break;
 			}
 
+			if (logData->queueCommittedVersion.get() == std::numeric_limits<Version>::max()) {
+				break;
+			}
+
 			choose {
 				when(wait(logData->version.whenAtLeast(
 				    std::max(logData->queueCommittingVersion, logData->queueCommittedVersion.get()) + 1))) {


### PR DESCRIPTION
After this change, statically linking libcxx seems to work for UBSAN. Also fix a few instances of UB that are showing up in simulation frequently.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
