### PR TITLE
cherry pick pr 7405 to 71 branch

### DIFF
--- a/fdbserver/LogSystemDiskQueueAdapter.actor.cpp
+++ b/fdbserver/LogSystemDiskQueueAdapter.actor.cpp
@@ -96,12 +96,19 @@ public:
 				    .detail("HasMessage", self->cursor->hasMessage())
 				    .detail("Version", self->cursor->version().version);
 
-				if (self->cursor->popped() != 0 || (!self->hasDiscardedData && BUGGIFY_WITH_PROB(0.01))) {
+				bool buggify = !self->hasDiscardedData && BUGGIFY_WITH_PROB(0.01);
+				if (self->cursor->popped() != 0 || buggify) {
+					TraceEvent(SevWarnAlways, "DiskQueueAdapterReset")
+					    .detail("Version", self->cursor->popped())
+					    .detail("PeekTypeSwitch", self->peekTypeSwitches % 3);
 					TEST(true); // disk adapter reset
-					TraceEvent(SevWarnAlways, "DiskQueueAdapterReset").detail("Version", self->cursor->popped());
+					if (self->cursor->popped() != 0) {
+						self->recoveryLoc = self->cursor->popped();
+					} else {
+						self->recoveryLoc = self->startLoc;
+					}
 					self->recoveryQueue.clear();
 					self->recoveryQueueDataSize = 0;
-					self->recoveryLoc = self->cursor->popped();
 					self->recoveryQueueLoc = self->recoveryLoc;
 					self->totalRecoveredBytes = 0;
 					if (self->peekTypeSwitches % 3 == 1) {

--- a/fdbserver/LogSystemDiskQueueAdapter.h
+++ b/fdbserver/LogSystemDiskQueueAdapter.h
@@ -61,8 +61,8 @@ public:
 	                          Version txsPoppedVersion,
 	                          bool recover)
 	  : peekLocality(peekLocality), peekTypeSwitches(0), enableRecovery(recover), logSystem(logSystem),
-	    recoveryLoc(txsPoppedVersion), recoveryQueueLoc(txsPoppedVersion), recoveryQueueDataSize(0), poppedUpTo(0),
-	    nextCommit(1), hasDiscardedData(false), totalRecoveredBytes(0) {
+	    startLoc(txsPoppedVersion), recoveryLoc(txsPoppedVersion), recoveryQueueLoc(txsPoppedVersion),
+	    recoveryQueueDataSize(0), poppedUpTo(0), nextCommit(1), hasDiscardedData(false), totalRecoveredBytes(0) {
 		if (enableRecovery) {
 			localityChanged = peekLocality ? peekLocality->onChange() : Never();
 			cursor = logSystem->peekTxs(UID(),
@@ -127,7 +127,7 @@ private:
 	// Recovery state (used while readNext() is being called repeatedly)
 	bool enableRecovery;
 	Reference<ILogSystem> logSystem;
-	Version recoveryLoc, recoveryQueueLoc;
+	Version startLoc, recoveryLoc, recoveryQueueLoc;
 	std::vector<Standalone<StringRef>> recoveryQueue;
 	int recoveryQueueDataSize;
 


### PR DESCRIPTION
Cherry pick PR `https://github.com/apple/foundationdb/pull/7405`

The transaction state store is recovered by peeking old tLogs starting at a particular version. On fault injection, this recovery can be restarted with a different starting version poppedver, which is a value returned by the tLog.

But the tLog may not have set this value. If it didn't , poppedver defaults to 0. The problem is 0 is arbitrary so may be invalid.

This PR just fixes fault injection to not change the starting range if the tLog did not supply one.

simulation test failure:

- A version range starting with 0 may include old epochs.
- To peek from an older epoch, the (peekall) logic selects a tLog that was recorded to have existed during that epoch (see TLogPeekAllAddingOld).
- Such a tLog may no longer be reachable (e.g. its DC was since powered off).
- Trying to peek from such a tLog will cause the cursor to hang.

Fixes
`-r simulation --logsize=4096MiB -f ./src/foundationdb/tests/fast/KillRegionCycle.toml -b on -s 917500915`

Joshua
`20220617-222513-henrylambright-a9fc9e75e685a680`

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
