### PR TITLE
Add missing dependencies for fdbservice

### DIFF
--- a/fdbservice/CMakeLists.txt
+++ b/fdbservice/CMakeLists.txt
@@ -1,4 +1,6 @@
 set(FDBSERVICE_SRCS FDBService.cpp ServiceBase.cpp)
 
 add_executable(fdbmonitor ${FDBSERVICE_SRCS})
-target_include_directories(fdmonitor ${CMAKE_SOURCE_DIR})
+
+target_include_directories(fdbmonitor PRIVATE ${CMAKE_BINARY_DIR}/flow/include ${CMAKE_BINARY_DIR}/fdbclient/include)
+add_dependencies(fdbmonitor fdbclient)


### PR DESCRIPTION
Fix Windows build broken by #7447 