### PR TITLE
Fix a problem caused by missing state (release-7.1).

### DIFF
--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -6981,7 +6981,7 @@ ACTOR Future<ProtocolVersion> getClusterProtocolImpl(
 		} else {
 			state NetworkAddress coordinatorAddress;
 			if (coordinator->get().get().hostname.present()) {
-				Hostname h = coordinator->get().get().hostname.get();
+				state Hostname h = coordinator->get().get().hostname.get();
 				wait(store(coordinatorAddress, h.resolveWithRetry()));
 			} else {
 				coordinatorAddress = coordinator->get().get().getLeader.getEndpoint().getPrimaryAddress();


### PR DESCRIPTION
PR on main: #7479.

Without `state`, the code compiles to
```
if (coordinator->get().get().hostname.present())
{
	Hostname h = coordinator->get().get().hostname.get();
	StrictFuture<Void> __when_expr_1 = store(coordinatorAddress, h.resolveWithRetry());
	if (static_cast<GetClusterProtocolImplActor*>(this)->actor_wait_state < 0) return a_body1Catch1(actor_cancelled(), std::max(0, loopDepth - 1));
	if (__when_expr_1.isReady()) {
		if (__when_expr_1.isError()) return a_body1Catch1(__when_expr_1.getError(), std::max(0, loopDepth - 1));
		else return a_body1loopBody1when2(__when_expr_1.get(), loopDepth);
	};
	static_cast<GetClusterProtocolImplActor*>(this)->actor_wait_state = 2;"
	__when_expr_1.addCallbackAndClear(static_cast<ActorCallback< GetClusterProtocolImplActor, 1, Void >*>(static_cast<GetClusterProtocolImplActor*>(this)));
	loopDepth = 0;
}
```
`Hostname h` is destructed before the callback function is run, thus the resolved address can be unpredictible, sometimes has `tls` and can cause connection failures and further errors in k8s tests.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
