### PR TITLE
Fix build with AWS backup.

### DIFF
--- a/fdbclient/CMakeLists.txt
+++ b/fdbclient/CMakeLists.txt
@@ -71,7 +71,7 @@ if(WITH_AWS_BACKUP)
 
   set(FDBCLIENT_SRCS
     ${FDBCLIENT_SRCS}
-    FDBAWSCredentialsProvider.h)
+    include/fdbclient/FDBAWSCredentialsProvider.h)
 
   include(awssdk)
 endif()


### PR DESCRIPTION
Update reference to FDBAWSCredentialsProvider.h in CMakeLists.txt.

Tested by running cmake with -DBUILD_AWS_BACKUP=ON.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
