### PR TITLE
Refactor how tenant map entries are encoded and decoded

### DIFF
--- a/fdbclient/SystemData.cpp
+++ b/fdbclient/SystemData.cpp
@@ -1404,17 +1404,6 @@ BlobWorkerInterface decodeBlobWorkerListValue(ValueRef const& value) {
 	return interf;
 }
 
-Value encodeTenantEntry(TenantMapEntry const& tenantEntry) {
-	return ObjectWriter::toValue(tenantEntry, IncludeVersion());
-}
-
-TenantMapEntry decodeTenantEntry(ValueRef const& value) {
-	TenantMapEntry entry;
-	ObjectReader reader(value.begin(), IncludeVersion());
-	reader.deserialize(entry);
-	return entry;
-}
-
 const KeyRangeRef tenantMapKeys("\xff/tenantMap/"_sr, "\xff/tenantMap0"_sr);
 const KeyRef tenantMapPrefix = tenantMapKeys.begin;
 const KeyRef tenantMapPrivatePrefix = "\xff\xff/tenantMap/"_sr;

--- a/fdbclient/Tenant.cpp
+++ b/fdbclient/Tenant.cpp
@@ -54,12 +54,12 @@ TenantMapEntry::TenantMapEntry(int64_t id, KeyRef subspace) : id(id) {
 TEST_CASE("/fdbclient/TenantMapEntry/Serialization") {
 	TenantMapEntry entry1(1, ""_sr);
 	ASSERT(entry1.prefix == "\x00\x00\x00\x00\x00\x00\x00\x01"_sr);
-	TenantMapEntry entry2 = decodeTenantEntry(encodeTenantEntry(entry1));
+	TenantMapEntry entry2 = TenantMapEntry::decode(entry1.encode());
 	ASSERT(entry1.id == entry2.id && entry1.prefix == entry2.prefix);
 
 	TenantMapEntry entry3(std::numeric_limits<int64_t>::max(), "foo"_sr);
 	ASSERT(entry3.prefix == "foo\x7f\xff\xff\xff\xff\xff\xff\xff"_sr);
-	TenantMapEntry entry4 = decodeTenantEntry(encodeTenantEntry(entry3));
+	TenantMapEntry entry4 = TenantMapEntry::decode(entry3.encode());
 	ASSERT(entry3.id == entry4.id && entry3.prefix == entry4.prefix);
 
 	for (int i = 0; i < 100; ++i) {
@@ -78,7 +78,7 @@ TEST_CASE("/fdbclient/TenantMapEntry/Serialization") {
 		       entry.prefix.endsWith(StringRef(reinterpret_cast<uint8_t*>(&bigEndianId), 8)) &&
 		       entry.prefix.size() == subspaceLength + 8);
 
-		TenantMapEntry decodedEntry = decodeTenantEntry(encodeTenantEntry(entry));
+		TenantMapEntry decodedEntry = TenantMapEntry::decode(entry.encode());
 		ASSERT(decodedEntry.id == entry.id && decodedEntry.prefix == entry.prefix);
 	}
 

--- a/fdbclient/include/fdbclient/SystemData.h
+++ b/fdbclient/include/fdbclient/SystemData.h
@@ -631,9 +631,6 @@ extern const KeyRef tenantMapPrivatePrefix;
 extern const KeyRef tenantLastIdKey;
 extern const KeyRef tenantDataPrefixKey;
 
-Value encodeTenantEntry(TenantMapEntry const& tenantEntry);
-TenantMapEntry decodeTenantEntry(ValueRef const& value);
-
 #pragma clang diagnostic pop
 
 #endif

--- a/fdbclient/include/fdbclient/Tenant.h
+++ b/fdbclient/include/fdbclient/Tenant.h
@@ -47,6 +47,15 @@ public:
 	TenantMapEntry();
 	TenantMapEntry(int64_t id, KeyRef subspace);
 
+	Value encode() const { return ObjectWriter::toValue(*this, IncludeVersion(ProtocolVersion::withTenants())); }
+
+	static TenantMapEntry decode(ValueRef const& value) {
+		TenantMapEntry entry;
+		ObjectReader reader(value.begin(), IncludeVersion(ProtocolVersion::withTenants()));
+		reader.deserialize(entry);
+		return entry;
+	}
+
 	template <class Ar>
 	void serialize(Ar& ar) {
 		KeyRef subspace;

--- a/fdbclient/include/fdbclient/TenantManagement.actor.h
+++ b/fdbclient/include/fdbclient/TenantManagement.actor.h
@@ -40,7 +40,7 @@ Future<Optional<TenantMapEntry>> tryGetTenantTransaction(Transaction tr, TenantN
 
 	state typename transaction_future_type<Transaction, Optional<Value>>::type tenantFuture = tr->get(tenantMapKey);
 	Optional<Value> val = wait(safeThreadFutureToFuture(tenantFuture));
-	return val.map<TenantMapEntry>([](Optional<Value> v) { return decodeTenantEntry(v.get()); });
+	return val.map<TenantMapEntry>([](Optional<Value> v) { return TenantMapEntry::decode(v.get()); });
 }
 
 ACTOR template <class DB>
@@ -130,7 +130,7 @@ Future<std::pair<TenantMapEntry, bool>> createTenantTransaction(Transaction tr, 
 		throw tenant_prefix_allocator_conflict();
 	}
 
-	tr->set(tenantMapKey, encodeTenantEntry(newTenant));
+	tr->set(tenantMapKey, newTenant.encode());
 
 	return std::make_pair(newTenant, true);
 }
@@ -260,7 +260,7 @@ Future<std::map<TenantName, TenantMapEntry>> listTenantsTransaction(Transaction 
 
 	std::map<TenantName, TenantMapEntry> tenants;
 	for (auto kv : results) {
-		tenants[kv.key.removePrefix(tenantMapPrefix)] = decodeTenantEntry(kv.value);
+		tenants[kv.key.removePrefix(tenantMapPrefix)] = TenantMapEntry::decode(kv.value);
 	}
 
 	return tenants;

--- a/fdbserver/ApplyMetadataMutation.cpp
+++ b/fdbserver/ApplyMetadataMutation.cpp
@@ -639,7 +639,7 @@ private:
 			if (tenantMap) {
 				ASSERT(version != invalidVersion);
 				TenantName tenantName = m.param1.removePrefix(tenantMapPrefix);
-				TenantMapEntry tenantEntry = decodeTenantEntry(m.param2);
+				TenantMapEntry tenantEntry = TenantMapEntry::decode(m.param2);
 
 				TraceEvent("CommitProxyInsertTenant", dbgid).detail("Tenant", tenantName).detail("Version", version);
 				(*tenantMap)[tenantName] = tenantEntry;

--- a/fdbserver/BlobManager.actor.cpp
+++ b/fdbserver/BlobManager.actor.cpp
@@ -845,7 +845,7 @@ ACTOR Future<Void> monitorClientRanges(Reference<BlobManagerData> bmData) {
 					std::vector<Key> prefixes;
 					for (auto& it : tenantResults) {
 						TenantNameRef tenantName = it.key.removePrefix(tenantMapPrefix);
-						TenantMapEntry entry = decodeTenantEntry(it.value);
+						TenantMapEntry entry = TenantMapEntry::decode(it.value);
 						tenants.push_back(std::pair(tenantName, entry));
 						prefixes.push_back(entry.prefix);
 					}

--- a/fdbserver/BlobWorker.actor.cpp
+++ b/fdbserver/BlobWorker.actor.cpp
@@ -3198,7 +3198,7 @@ ACTOR Future<Void> monitorTenants(Reference<BlobWorkerData> bwData) {
 				for (auto& it : tenantResults) {
 					// FIXME: handle removing/moving tenants!
 					TenantNameRef tenantName = it.key.removePrefix(tenantMapPrefix);
-					TenantMapEntry entry = decodeTenantEntry(it.value);
+					TenantMapEntry entry = TenantMapEntry::decode(it.value);
 					tenants.push_back(std::pair(tenantName, entry));
 				}
 				bwData->tenantData.addTenants(tenants);

--- a/fdbserver/TenantCache.actor.cpp
+++ b/fdbserver/TenantCache.actor.cpp
@@ -48,7 +48,7 @@ public:
 
 			for (int i = 0; i < tenantList.size(); i++) {
 				TenantName tname = tenantList[i].key.removePrefix(tenantMapPrefix);
-				TenantMapEntry t = decodeTenantEntry(tenantList[i].value);
+				TenantMapEntry t = TenantMapEntry::decode(tenantList[i].value);
 
 				tenantCache->insert(tname, t);
 
@@ -86,7 +86,7 @@ public:
 
 				for (int i = 0; i < tenantList.size(); i++) {
 					TenantName tname = tenantList[i].key.removePrefix(tenantMapPrefix);
-					TenantMapEntry t = decodeTenantEntry(tenantList[i].value);
+					TenantMapEntry t = TenantMapEntry::decode(tenantList[i].value);
 
 					if (tenantCache->update(tname, t)) {
 						tenantListUpdated = true;

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -6946,7 +6946,7 @@ void StorageServer::insertTenant(TenantNameRef tenantName,
 		tenantMap.createNewVersion(version);
 		tenantPrefixIndex.createNewVersion(version);
 
-		TenantMapEntry tenantEntry = decodeTenantEntry(value);
+		TenantMapEntry tenantEntry = TenantMapEntry::decode(value);
 
 		tenantMap.insert(tenantName, tenantEntry);
 		tenantPrefixIndex.insert(tenantEntry.prefix, tenantName);
@@ -7789,7 +7789,7 @@ void StorageServerDisk::makeNewStorageServerDurable() {
 
 	auto view = data->tenantMap.atLatest();
 	for (auto itr = view.begin(); itr != view.end(); ++itr) {
-		storage->set(KeyValueRef(itr.key().withPrefix(persistTenantMapKeys.begin), encodeTenantEntry(*itr)));
+		storage->set(KeyValueRef(itr.key().withPrefix(persistTenantMapKeys.begin), itr->encode()));
 	}
 }
 
@@ -8270,7 +8270,7 @@ ACTOR Future<bool> restoreDurableState(StorageServer* data, IKeyValueStore* stor
 	for (tenantMapLoc = 0; tenantMapLoc < tenantMap.size(); tenantMapLoc++) {
 		auto const& result = tenantMap[tenantMapLoc];
 		TenantName tenantName = result.key.substr(persistTenantMapKeys.begin.size());
-		TenantMapEntry tenantEntry = decodeTenantEntry(result.value);
+		TenantMapEntry tenantEntry = TenantMapEntry::decode(result.value);
 
 		data->tenantMap.insert(tenantName, tenantEntry);
 		data->tenantPrefixIndex.insert(tenantEntry.prefix, tenantName);


### PR DESCRIPTION
This also adds a specific version to the encoding that matches the version this object was introduced (as is the only version used for it so far).

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
