### PR TITLE
Make GlobalTagThrottlerTesting::monitorClientRates more lenient

### DIFF
--- a/fdbserver/GlobalTagThrottler.actor.cpp
+++ b/fdbserver/GlobalTagThrottler.actor.cpp
@@ -356,7 +356,7 @@ ACTOR static Future<Void> monitorClientRates(GlobalTagThrottler* globalTagThrott
 			    .detail("Tag", tag)
 			    .detail("CurrentTPSRate", currentTPSLimit.get())
 			    .detail("DesiredTPSRate", desiredTPSLimit);
-			if (abs(currentTPSLimit.get() - desiredTPSLimit) < 0.1) {
+			if (abs(currentTPSLimit.get() - desiredTPSLimit) < 1.0) {
 				if (++successes == 3) {
 					return Void();
 				}


### PR DESCRIPTION
This fixes some timeouts in the global tag throttling unit tests, by increasing the error tolerance for an "acceptable" equilibrium TPS limit from 0.1 to 1.0.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
