### PR TITLE
Update key backed types to support multiple transaction types and different codecs

### DIFF
--- a/fdbbackup/backup.actor.cpp
+++ b/fdbbackup/backup.actor.cpp
@@ -1920,11 +1920,11 @@ ACTOR Future<Void> submitBackup(Database db,
 
 		if (dryRun) {
 			state KeyBackedTag tag = makeBackupTag(tagName);
-			Optional<UidAndAbortedFlagT> uidFlag = wait(tag.get(db));
+			Optional<UidAndAbortedFlagT> uidFlag = wait(tag.get(db.getReference()));
 
 			if (uidFlag.present()) {
 				BackupConfig config(uidFlag.get().first);
-				EBackupState backupStatus = wait(config.stateEnum().getOrThrow(db));
+				EBackupState backupStatus = wait(config.stateEnum().getOrThrow(db.getReference()));
 
 				// Throw error if a backup is currently running until we support parallel backups
 				if (BackupAgentBase::isRunnable(backupStatus)) {
@@ -2883,7 +2883,7 @@ ACTOR Future<Void> modifyBackup(Database db, std::string tagName, BackupModifyOp
 			tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
 			tr->setOption(FDBTransactionOptions::LOCK_AWARE);
 
-			state Optional<UidAndAbortedFlagT> uidFlag = wait(tag.get(db));
+			state Optional<UidAndAbortedFlagT> uidFlag = wait(tag.get(db.getReference()));
 
 			if (!uidFlag.present()) {
 				fprintf(stderr, "No backup exists on tag '%s'\n", tagName.c_str());

--- a/fdbclient/FileBackupAgent.actor.cpp
+++ b/fdbclient/FileBackupAgent.actor.cpp
@@ -1221,7 +1221,7 @@ struct BackupRangeTaskFunc : BackupTaskFuncBase {
 
 		// Don't need to check keepRunning(task) here because we will do that while finishing each output file, but if
 		// bc is false then clearly the backup is no longer in progress
-		state Reference<IBackupContainer> bc = wait(backup.backupContainer().getD(cx));
+		state Reference<IBackupContainer> bc = wait(backup.backupContainer().getD(cx.getReference()));
 		if (!bc) {
 			return Void();
 		}
@@ -3617,8 +3617,8 @@ struct RestoreDispatchTaskFunc : RestoreTaskFuncBase {
 		// Get a batch of files.  We're targeting batchSize blocks being dispatched so query for batchSize files (each
 		// of which is 0 or more blocks).
 		state int taskBatchSize = BUGGIFY ? 1 : CLIENT_KNOBS->RESTORE_DISPATCH_ADDTASK_SIZE;
-		state RestoreConfig::FileSetT::Values files =
-		    wait(restore.fileSet().getRange(tr, { beginVersion, beginFile }, {}, taskBatchSize));
+		state RestoreConfig::FileSetT::Values files = wait(restore.fileSet().getRange(
+		    tr, Optional<RestoreConfig::RestoreFile>({ beginVersion, beginFile }), {}, taskBatchSize));
 
 		// allPartsDone will be set once all block tasks in the current batch are finished.
 		state Reference<TaskFuture> allPartsDone;
@@ -5497,7 +5497,7 @@ public:
 			}
 		}
 
-		Reference<IBackupContainer> bc = wait(backupConfig.backupContainer().getOrThrow(cx));
+		Reference<IBackupContainer> bc = wait(backupConfig.backupContainer().getOrThrow(cx.getReference()));
 
 		if (fastRestore) {
 			TraceEvent("AtomicParallelRestoreStartRestore").log();

--- a/fdbclient/FileBackupAgent.actor.cpp
+++ b/fdbclient/FileBackupAgent.actor.cpp
@@ -5434,7 +5434,7 @@ public:
 			try {
 				// We must get a commit version so add a conflict range that won't likely cause conflicts
 				// but will ensure that the transaction is actually submitted.
-				tr.addWriteConflictRange(backupConfig.snapshotRangeDispatchMap().space.range());
+				tr.addWriteConflictRange(backupConfig.snapshotRangeDispatchMap().subspace);
 				wait(lockDatabase(&tr, randomUid));
 				wait(tr.commit());
 				commitVersion = tr.getCommittedVersion();

--- a/fdbclient/include/fdbclient/FDBTypes.h
+++ b/fdbclient/include/fdbclient/FDBTypes.h
@@ -1509,4 +1509,16 @@ struct StorageWiggleValue {
 		serializer(ar, id);
 	}
 };
+
+// Can be used to identify types (e.g. IDatabase) that can be used to create transactions with a `createTransaction`
+// function
+template <typename, typename = void>
+struct transaction_creator_traits : std::false_type {};
+
+template <typename T>
+struct transaction_creator_traits<T, std::void_t<typename T::TransactionT>> : std::true_type {};
+
+template <typename T>
+constexpr bool is_transaction_creator = transaction_creator_traits<T>::value;
+
 #endif

--- a/fdbclient/include/fdbclient/KeyBackedTypes.h
+++ b/fdbclient/include/fdbclient/KeyBackedTypes.h
@@ -32,108 +32,110 @@
 #include "flow/genericactors.actor.h"
 #include "flow/serialize.h"
 
-// Codec is a utility struct to convert a type to and from a Tuple.  It is used by the template
-// classes below like KeyBackedProperty and KeyBackedMap to convert key parts and values
-// from various types to Value strings and back.
+// TupleCodec is a utility struct to convert a type to and from a value using Tuple encoding.
+// It is used by the template classes below like KeyBackedProperty and KeyBackedMap to convert
+// key parts and values from various types to Value strings and back.
 // New types can be supported either by writing a new specialization or adding these
 // methods to the type so that the default specialization can be used:
-//   static T T::unpack(Tuple const &t)
-//   Tuple T::pack() const
-// Since Codec is a struct, partial specialization can be used, such as the std::pair
+//   static T T::unpack(Standalone<StringRef> const& val)
+//   Standalone<StringRef> T::pack(T const& val) const
+// Since TupleCodec is a struct, partial specialization can be used, such as the std::pair
 // partial specialization below allowing any std::pair<T1,T2> where T1 and T2 are already
-// supported by Codec.
+// supported by TupleCodec.
 template <typename T>
-struct Codec {
-	static inline Tuple pack(T const& val) { return val.pack(); }
-	static inline T unpack(Tuple const& t) { return T::unpack(t); }
+struct TupleCodec {
+	static inline Standalone<StringRef> pack(T const& val) { return val.pack().pack(); }
+	static inline T unpack(Standalone<StringRef> const& val) { return T::unpack(Tuple::unpack(val)); }
 };
 
 // If T is Tuple then conversion is simple.
 template <>
-inline Tuple Codec<Tuple>::pack(Tuple const& val) {
-	return val;
+inline Standalone<StringRef> TupleCodec<Tuple>::pack(Tuple const& val) {
+	return val.pack();
 }
 template <>
-inline Tuple Codec<Tuple>::unpack(Tuple const& val) {
-	return val;
+inline Tuple TupleCodec<Tuple>::unpack(Standalone<StringRef> const& val) {
+	return Tuple::unpack(val);
 }
 
 template <>
-inline Tuple Codec<int64_t>::pack(int64_t const& val) {
-	return Tuple().append(val);
+inline Standalone<StringRef> TupleCodec<int64_t>::pack(int64_t const& val) {
+	return Tuple().append(val).pack();
 }
 template <>
-inline int64_t Codec<int64_t>::unpack(Tuple const& val) {
-	return val.getInt(0);
+inline int64_t TupleCodec<int64_t>::unpack(Standalone<StringRef> const& val) {
+	return Tuple::unpack(val).getInt(0);
 }
 
 template <>
-inline Tuple Codec<bool>::pack(bool const& val) {
-	return Tuple().append(val ? 1 : 0);
+inline Standalone<StringRef> TupleCodec<bool>::pack(bool const& val) {
+	return Tuple().append(val ? 1 : 0).pack();
 }
 template <>
-inline bool Codec<bool>::unpack(Tuple const& val) {
-	return val.getInt(0) == 1;
+inline bool TupleCodec<bool>::unpack(Standalone<StringRef> const& val) {
+	return Tuple::unpack(val).getInt(0) == 1;
 }
 
 template <>
-inline Tuple Codec<Standalone<StringRef>>::pack(Standalone<StringRef> const& val) {
-	return Tuple().append(val);
+inline Standalone<StringRef> TupleCodec<Standalone<StringRef>>::pack(Standalone<StringRef> const& val) {
+	return Tuple().append(val).pack();
 }
 template <>
-inline Standalone<StringRef> Codec<Standalone<StringRef>>::unpack(Tuple const& val) {
-	return val.getString(0);
+inline Standalone<StringRef> TupleCodec<Standalone<StringRef>>::unpack(Standalone<StringRef> const& val) {
+	return Tuple::unpack(val).getString(0);
 }
 
 template <>
-inline Tuple Codec<UID>::pack(UID const& val) {
-	return Codec<Standalone<StringRef>>::pack(BinaryWriter::toValue<UID>(val, Unversioned()));
+inline Standalone<StringRef> TupleCodec<UID>::pack(UID const& val) {
+	return TupleCodec<Standalone<StringRef>>::pack(BinaryWriter::toValue<UID>(val, Unversioned()));
 }
 template <>
-inline UID Codec<UID>::unpack(Tuple const& val) {
-	return BinaryReader::fromStringRef<UID>(Codec<Standalone<StringRef>>::unpack(val), Unversioned());
+inline UID TupleCodec<UID>::unpack(Standalone<StringRef> const& val) {
+	return BinaryReader::fromStringRef<UID>(TupleCodec<Standalone<StringRef>>::unpack(val), Unversioned());
 }
 
-// This is backward compatible with Codec<Standalone<StringRef>>
+// This is backward compatible with TupleCodec<Standalone<StringRef>>
 template <>
-inline Tuple Codec<std::string>::pack(std::string const& val) {
-	return Tuple().append(StringRef(val));
+inline Standalone<StringRef> TupleCodec<std::string>::pack(std::string const& val) {
+	return Tuple().append(StringRef(val)).pack();
 }
 template <>
-inline std::string Codec<std::string>::unpack(Tuple const& val) {
-	return val.getString(0).toString();
+inline std::string TupleCodec<std::string>::unpack(Standalone<StringRef> const& val) {
+	return Tuple::unpack(val).getString(0).toString();
 }
 
-// Partial specialization to cover all std::pairs as long as the component types are Codec compatible
+// Partial specialization to cover all std::pairs as long as the component types are TupleCodec compatible
 template <typename First, typename Second>
-struct Codec<std::pair<First, Second>> {
-	static Tuple pack(typename std::pair<First, Second> const& val) {
-		return Tuple().append(Codec<First>::pack(val.first)).append(Codec<Second>::pack(val.second));
+struct TupleCodec<std::pair<First, Second>> {
+	static Standalone<StringRef> pack(typename std::pair<First, Second> const& val) {
+		// Packing a concatenated tuple is the same as concatenating two packed tuples
+		return TupleCodec<First>::pack(val.first).withSuffix(TupleCodec<Second>::pack(val.second));
 	}
-	static std::pair<First, Second> unpack(Tuple const& t) {
+	static std::pair<First, Second> unpack(Standalone<StringRef> const& val) {
+		Tuple t = Tuple::unpack(val);
 		ASSERT(t.size() == 2);
-		return { Codec<First>::unpack(t.subTuple(0, 1)), Codec<Second>::unpack(t.subTuple(1, 2)) };
+		return { TupleCodec<First>::unpack(t.subTupleRawString(0)),
+			     TupleCodec<Second>::unpack(t.subTupleRawString(1)) };
 	}
 };
 
 template <typename T>
-struct Codec<std::vector<T>> {
-	static Tuple pack(typename std::vector<T> const& val) {
+struct TupleCodec<std::vector<T>> {
+	static Standalone<StringRef> pack(typename std::vector<T> const& val) {
 		Tuple t;
 		for (T item : val) {
-			Tuple itemTuple = Codec<T>::pack(item);
 			// fdbclient doesn't support nested tuples yet. For now, flatten the tuple into StringRef
-			t.append(itemTuple.pack());
+			t.append(TupleCodec<T>::pack(item));
 		}
-		return t;
+		return t.pack();
 	}
 
-	static std::vector<T> unpack(Tuple const& t) {
+	static std::vector<T> unpack(Standalone<StringRef> const& val) {
+		Tuple t = Tuple::unpack(val);
 		std::vector<T> v;
 
 		for (int i = 0; i < t.size(); i++) {
-			Tuple itemTuple = Tuple::unpack(t.getString(i));
-			v.push_back(Codec<T>::unpack(itemTuple));
+			v.push_back(TupleCodec<T>::unpack(t.getString(i)));
 		}
 
 		return v;
@@ -141,17 +143,18 @@ struct Codec<std::vector<T>> {
 };
 
 template <>
-inline Tuple Codec<KeyRange>::pack(KeyRange const& val) {
-	return Tuple().append(val.begin).append(val.end);
+inline Standalone<StringRef> TupleCodec<KeyRange>::pack(KeyRange const& val) {
+	return Tuple().append(val.begin).append(val.end).pack();
 }
 template <>
-inline KeyRange Codec<KeyRange>::unpack(Tuple const& val) {
-	return KeyRangeRef(val.getString(0), val.getString(1));
+inline KeyRange TupleCodec<KeyRange>::unpack(Standalone<StringRef> const& val) {
+	Tuple t = Tuple::unpack(val);
+	return KeyRangeRef(t.getString(0), t.getString(1));
 }
 
 // Convenient read/write access to a single value of type T stored at key
 // Even though 'this' is not actually mutated, methods that change the db key are not const.
-template <typename T>
+template <typename T, typename Codec = TupleCodec<T>>
 class KeyBackedProperty {
 public:
 	KeyBackedProperty(KeyRef key) : key(key) {}
@@ -165,7 +168,7 @@ public:
 		return holdWhile(getFuture,
 		                 map(safeThreadFutureToFuture(getFuture), [](Optional<Value> const& val) -> Optional<T> {
 			                 if (val.present())
-				                 return Codec<T>::unpack(Tuple::unpack(val.get()));
+				                 return Codec::unpack(val.get());
 			                 return {};
 		                 }));
 	}
@@ -228,7 +231,7 @@ public:
 
 	template <class Transaction>
 	typename std::enable_if<!is_transaction_creator<Transaction>, void>::type set(Transaction tr, T const& val) {
-		return tr->set(key, Codec<T>::pack(val).pack());
+		return tr->set(key, Codec::pack(val));
 	}
 
 	template <class DB>
@@ -249,7 +252,7 @@ public:
 	Key key;
 };
 
-// This is just like KeyBackedProperty but instead of using Codec for conversion to/from values it
+// This is just like KeyBackedProperty but instead of using a Codec for conversion to/from values it
 // uses BinaryReader and BinaryWriter.  This enables allows atomic ops with integer types, and also
 // allows reading and writing of existing keys which use BinaryReader/Writer.
 template <typename T>
@@ -295,10 +298,13 @@ public:
 
 // Convenient read/write access to a sorted map of KeyType to ValueType under prefix
 // Even though 'this' is not actually mutated, methods that change db keys are not const.
-template <typename _KeyType, typename _ValueType>
+template <typename _KeyType,
+          typename _ValueType,
+          typename KeyCodec = TupleCodec<_KeyType>,
+          typename ValueCodec = TupleCodec<_ValueType>>
 class KeyBackedMap {
 public:
-	KeyBackedMap(KeyRef prefix) : space(prefix) {}
+	KeyBackedMap(KeyRef prefix) : subspace(prefixRange(prefix)) {}
 
 	typedef _KeyType KeyType;
 	typedef _ValueType ValueType;
@@ -313,20 +319,20 @@ public:
 	                           int limit,
 	                           Snapshot snapshot = Snapshot::False,
 	                           Reverse reverse = Reverse::False) const {
-		Subspace s = space; // 'this' could be invalid inside lambda
+		Key prefix = subspace.begin; // 'this' could be invalid inside lambda
 
-		Key beginKey = begin.present() ? s.pack(Codec<KeyType>::pack(begin.get())) : s.range().begin;
-		Key endKey = end.present() ? s.pack(Codec<KeyType>::pack(end.get())) : s.range().end;
+		Key beginKey = begin.present() ? prefix.withSuffix(KeyCodec::pack(begin.get())) : subspace.begin;
+		Key endKey = end.present() ? prefix.withSuffix(KeyCodec::pack(end.get())) : subspace.end;
 
 		typename transaction_future_type<Transaction, RangeResult>::type getRangeFuture =
 		    tr->getRange(KeyRangeRef(beginKey, endKey), GetRangeLimits(limit), snapshot, reverse);
 
 		return holdWhile(getRangeFuture,
-		                 map(safeThreadFutureToFuture(getRangeFuture), [s](RangeResult const& kvs) -> PairsType {
+		                 map(safeThreadFutureToFuture(getRangeFuture), [prefix](RangeResult const& kvs) -> PairsType {
 			                 PairsType results;
 			                 for (int i = 0; i < kvs.size(); ++i) {
-				                 KeyType key = Codec<KeyType>::unpack(s.unpack(kvs[i].key));
-				                 ValueType val = Codec<ValueType>::unpack(Tuple::unpack(kvs[i].value));
+				                 KeyType key = KeyCodec::unpack(kvs[i].key.removePrefix(prefix));
+				                 ValueType val = ValueCodec::unpack(kvs[i].value);
 				                 results.push_back(PairType(key, val));
 			                 }
 			                 return results;
@@ -336,44 +342,47 @@ public:
 	template <class Transaction>
 	Future<Optional<ValueType>> get(Transaction tr, KeyType const& key, Snapshot snapshot = Snapshot::False) const {
 		typename transaction_future_type<Transaction, Optional<Value>>::type getFuture =
-		    tr->get(space.pack(Codec<KeyType>::pack(key)), snapshot);
+		    tr->get(subspace.begin.withSuffix(KeyCodec::pack(key)), snapshot);
 
 		return holdWhile(
 		    getFuture, map(safeThreadFutureToFuture(getFuture), [](Optional<Value> const& val) -> Optional<ValueType> {
 			    if (val.present())
-				    return Codec<ValueType>::unpack(Tuple::unpack(val.get()));
+				    return ValueCodec::unpack(val.get());
 			    return {};
 		    }));
 	}
 
 	// Returns a Property that can be get/set that represents key's entry in this this.
-	KeyBackedProperty<ValueType> getProperty(KeyType const& key) const { return space.pack(Codec<KeyType>::pack(key)); }
+	KeyBackedProperty<ValueType> getProperty(KeyType const& key) const {
+		return subspace.begin.withSuffix(KeyCodec::pack(key));
+	}
 
 	// Returns the expectedSize of the set key
 	template <class Transaction>
 	int set(Transaction tr, KeyType const& key, ValueType const& val) {
-		Key k = space.pack(Codec<KeyType>::pack(key));
-		Value v = Codec<ValueType>::pack(val).pack();
+		Key k = subspace.begin.withSuffix(KeyCodec::pack(key));
+		Value v = ValueCodec::pack(val);
 		tr->set(k, v);
 		return k.expectedSize() + v.expectedSize();
 	}
 
 	template <class Transaction>
 	void erase(Transaction tr, KeyType const& key) {
-		return tr->clear(space.pack(Codec<KeyType>::pack(key)));
+		return tr->clear(subspace.begin.withSuffix(KeyCodec::pack(key)));
 	}
 
 	template <class Transaction>
 	void erase(Transaction tr, KeyType const& begin, KeyType const& end) {
-		return tr->clear(KeyRangeRef(space.pack(Codec<KeyType>::pack(begin)), space.pack(Codec<KeyType>::pack(end))));
+		return tr->clear(KeyRangeRef(subspace.begin.withSuffix(KeyCodec::pack(begin)),
+		                             subspace.begin.withSuffix(KeyCodec::pack(end))));
 	}
 
 	template <class Transaction>
 	void clear(Transaction tr) {
-		return tr->clear(space.range());
+		return tr->clear(subspace);
 	}
 
-	Subspace space;
+	KeyRange subspace;
 };
 
 // Convenient read/write access to a single value of type T stored at key
@@ -480,10 +489,11 @@ public:
 // Convenient read/write access to a sorted map of KeyType to ValueType under key prefix
 // ValueType is encoded / decoded with ObjectWriter/ObjectReader
 // Even though 'this' is not actually mutated, methods that change db keys are not const.
-template <typename _KeyType, typename _ValueType, typename VersionOptions>
+template <typename _KeyType, typename _ValueType, typename VersionOptions, typename KeyCodec = TupleCodec<_KeyType>>
 class KeyBackedObjectMap {
 public:
-	KeyBackedObjectMap(KeyRef prefix, VersionOptions versionOptions) : space(prefix), versionOptions(versionOptions) {}
+	KeyBackedObjectMap(KeyRef prefix, VersionOptions versionOptions)
+	  : subspace(prefixRange(prefix)), versionOptions(versionOptions) {}
 
 	typedef _KeyType KeyType;
 	typedef _ValueType ValueType;
@@ -497,8 +507,8 @@ public:
 	                           int limit,
 	                           Snapshot snapshot = Snapshot::False,
 	                           Reverse reverse = Reverse::False) const {
-		Key beginKey = begin.present() ? space.pack(Codec<KeyType>::pack(begin.get())) : space.range().begin;
-		Key endKey = end.present() ? space.pack(Codec<KeyType>::pack(end.get())) : space.range().end;
+		Key beginKey = begin.present() ? subspace.begin.withSuffix(KeyCodec::pack(begin.get())) : subspace.begin;
+		Key endKey = end.present() ? subspace.begin.withSuffix(KeyCodec::pack(end.get())) : subspace.end;
 
 		typename transaction_future_type<Transaction, RangeResult>::type getRangeFuture =
 		    tr->getRange(KeyRangeRef(beginKey, endKey), GetRangeLimits(limit), snapshot, reverse);
@@ -508,7 +518,7 @@ public:
 		    map(safeThreadFutureToFuture(getRangeFuture), [self = *this](RangeResult const& kvs) -> PairsType {
 			    PairsType results;
 			    for (int i = 0; i < kvs.size(); ++i) {
-				    KeyType key = Codec<KeyType>::unpack(self.space.unpack(kvs[i].key));
+				    KeyType key = KeyCodec::unpack(kvs[i].key.removePrefix(self.subspace.begin));
 				    ValueType val = ObjectReader::fromStringRef<ValueType>(kvs[i].value, self.versionOptions);
 				    results.push_back(PairType(key, val));
 			    }
@@ -519,7 +529,7 @@ public:
 	template <class Transaction>
 	Future<Optional<ValueType>> get(Transaction tr, KeyType const& key, Snapshot snapshot = Snapshot::False) const {
 		typename transaction_future_type<Transaction, Optional<Value>>::type getFuture =
-		    tr->get(space.pack(Codec<KeyType>::pack(key)), snapshot);
+		    tr->get(subspace.begin.withSuffix(KeyCodec::pack(key)), snapshot);
 
 		return holdWhile(getFuture,
 		                 map(safeThreadFutureToFuture(getFuture),
@@ -532,46 +542,47 @@ public:
 
 	// Returns a Property that can be get/set that represents key's entry in this this.
 	KeyBackedObjectProperty<ValueType, VersionOptions> getProperty(KeyType const& key) const {
-		return KeyBackedObjectProperty<ValueType, VersionOptions>(space.pack(Codec<KeyType>::pack(key)),
+		return KeyBackedObjectProperty<ValueType, VersionOptions>(subspace.begin.withSuffix(KeyCodec::pack(key)),
 		                                                          versionOptions);
 	}
 
 	// Returns the expectedSize of the set key
 	template <class Transaction>
 	int set(Transaction tr, KeyType const& key, ValueType const& val) {
-		Key k = space.pack(Codec<KeyType>::pack(key));
+		Key k = subspace.begin.withSuffix(KeyCodec::pack(key));
 		Value v = ObjectWriter::toValue(val, versionOptions);
 		tr->set(k, v);
 		return k.expectedSize() + v.expectedSize();
 	}
 
-	Key serializeKey(KeyType const& key) { return space.pack(Codec<KeyType>::pack(key)); }
+	Key serializeKey(KeyType const& key) { return subspace.begin.withSuffix(KeyCodec::pack(key)); }
 
 	Value serializeValue(ValueType const& val) { return ObjectWriter::toValue(val, versionOptions); }
 
 	template <class Transaction>
 	void erase(Transaction tr, KeyType const& key) {
-		return tr->clear(space.pack(Codec<KeyType>::pack(key)));
+		return tr->clear(subspace.begin.withSuffix(KeyCodec::pack(key)));
 	}
 
 	template <class Transaction>
 	void erase(Transaction tr, KeyType const& begin, KeyType const& end) {
-		return tr->clear(KeyRangeRef(space.pack(Codec<KeyType>::pack(begin)), space.pack(Codec<KeyType>::pack(end))));
+		return tr->clear(KeyRangeRef(subspace.begin.withSuffix(KeyCodec::pack(begin)),
+		                             subspace.begin.withSuffix(KeyCodec::pack(end))));
 	}
 
 	template <class Transaction>
 	void clear(Transaction tr) {
-		return tr->clear(space.range());
+		return tr->clear(subspace);
 	}
 
-	Subspace space;
+	KeyRange subspace;
 	VersionOptions versionOptions;
 };
 
-template <typename _ValueType>
+template <typename _ValueType, typename Codec = TupleCodec<_ValueType>>
 class KeyBackedSet {
 public:
-	KeyBackedSet(KeyRef key) : space(key) {}
+	KeyBackedSet(KeyRef key) : subspace(prefixRange(key)) {}
 
 	typedef _ValueType ValueType;
 	typedef std::vector<ValueType> Values;
@@ -583,18 +594,18 @@ public:
 	                        int limit,
 	                        Snapshot snapshot = Snapshot::False,
 	                        Reverse reverse = Reverse::False) const {
-		Subspace s = space; // 'this' could be invalid inside lambda
-		Key beginKey = begin.present() ? s.pack(Codec<ValueType>::pack(begin.get())) : space.range().begin;
-		Key endKey = end.present() ? s.pack(Codec<ValueType>::pack(end.get())) : space.range().end;
+		Key prefix = subspace.begin; // 'this' could be invalid inside lambda
+		Key beginKey = begin.present() ? prefix.withSuffix(Codec::pack(begin.get())) : subspace.begin;
+		Key endKey = end.present() ? prefix.withSuffix(Codec::pack(end.get())) : subspace.end;
 
 		typename transaction_future_type<Transaction, RangeResult>::type getRangeFuture =
 		    tr->getRange(KeyRangeRef(beginKey, endKey), GetRangeLimits(limit), snapshot, reverse);
 
 		return holdWhile(getRangeFuture,
-		                 map(safeThreadFutureToFuture(getRangeFuture), [s](RangeResult const& kvs) -> Values {
+		                 map(safeThreadFutureToFuture(getRangeFuture), [prefix](RangeResult const& kvs) -> Values {
 			                 Values results;
 			                 for (int i = 0; i < kvs.size(); ++i) {
-				                 results.push_back(Codec<ValueType>::unpack(s.unpack(kvs[i].key)));
+				                 results.push_back(Codec::unpack(kvs[i].key.removePrefix(prefix)));
 			                 }
 			                 return results;
 		                 }));
@@ -603,7 +614,7 @@ public:
 	template <class Transaction>
 	Future<bool> exists(Transaction tr, ValueType const& val, Snapshot snapshot = Snapshot::False) const {
 		typename transaction_future_type<Transaction, Optional<Value>>::type getFuture =
-		    tr->get(space.pack(Codec<ValueType>::pack(val)), snapshot);
+		    tr->get(subspace.begin.withSuffix(Codec::pack(val)), snapshot);
 
 		return holdWhile(getFuture, map(safeThreadFutureToFuture(getFuture), [](Optional<Value> const& val) -> bool {
 			                 return val.present();
@@ -613,26 +624,26 @@ public:
 	// Returns the expectedSize of the set key
 	template <class Transaction>
 	int insert(Transaction tr, ValueType const& val) {
-		Key k = space.pack(Codec<ValueType>::pack(val));
+		Key k = subspace.begin.withSuffix(Codec::pack(val));
 		tr->set(k, StringRef());
 		return k.expectedSize();
 	}
 
 	template <class Transaction>
 	void erase(Transaction tr, ValueType const& val) {
-		return tr->clear(space.pack(Codec<ValueType>::pack(val)));
+		return tr->clear(subspace.begin.withSuffix(Codec::pack(val)));
 	}
 
 	template <class Transaction>
 	void erase(Transaction tr, ValueType const& begin, ValueType const& end) {
 		return tr->clear(
-		    KeyRangeRef(space.pack(Codec<ValueType>::pack(begin)), space.pack(Codec<ValueType>::pack(end))));
+		    KeyRangeRef(subspace.begin.withSuffix(Codec::pack(begin)), subspace.begin.withSuffix(Codec::pack(end))));
 	}
 
 	template <class Transaction>
 	void clear(Transaction tr) {
-		return tr->clear(space.range());
+		return tr->clear(subspace);
 	}
 
-	Subspace space;
+	KeyRange subspace;
 };

--- a/fdbclient/include/fdbclient/KeyBackedTypes.h
+++ b/fdbclient/include/fdbclient/KeyBackedTypes.h
@@ -25,7 +25,6 @@
 
 #include "fdbclient/GenericTransactionHelper.h"
 #include "fdbclient/IClientApi.h"
-#include "fdbclient/ReadYourWrites.h"
 #include "fdbclient/DatabaseContext.h"
 #include "fdbclient/Subspace.h"
 #include "flow/ObjectSerializer.h"
@@ -197,7 +196,7 @@ public:
 	typename std::enable_if<is_transaction_creator<DB>, Future<Optional<T>>>::type get(
 	    Reference<DB> db,
 	    Snapshot snapshot = Snapshot::False) const {
-		return runTransaction(db, [=, self = *this](Reference<ReadYourWritesTransaction> tr) {
+		return runTransaction(db, [=, self = *this](Reference<typename DB::TransactionT> tr) {
 			tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
 			tr->setOption(FDBTransactionOptions::LOCK_AWARE);
 
@@ -209,7 +208,7 @@ public:
 	typename std::enable_if<is_transaction_creator<DB>, Future<T>>::type getD(Reference<DB> db,
 	                                                                          Snapshot snapshot = Snapshot::False,
 	                                                                          T defaultValue = T()) const {
-		return runTransaction(db, [=, self = *this](Reference<ReadYourWritesTransaction> tr) {
+		return runTransaction(db, [=, self = *this](Reference<typename DB::TransactionT> tr) {
 			tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
 			tr->setOption(FDBTransactionOptions::LOCK_AWARE);
 
@@ -221,7 +220,7 @@ public:
 	typename std::enable_if<is_transaction_creator<DB>, Future<T>>::type getOrThrow(Reference<DB> db,
 	                                                                                Snapshot snapshot = Snapshot::False,
 	                                                                                Error err = key_not_found()) const {
-		return runTransaction(db, [=, self = *this](Reference<ReadYourWritesTransaction> tr) {
+		return runTransaction(db, [=, self = *this](Reference<typename DB::TransactionT> tr) {
 			tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
 			tr->setOption(FDBTransactionOptions::LOCK_AWARE);
 
@@ -236,7 +235,7 @@ public:
 
 	template <class DB>
 	typename std::enable_if<is_transaction_creator<DB>, Future<Void>>::type set(Reference<DB> db, T const& val) {
-		return runTransaction(db, [=, self = *this](Reference<ReadYourWritesTransaction> tr) {
+		return runTransaction(db, [=, self = *this](Reference<typename DB::TransactionT> tr) {
 			tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
 			tr->setOption(FDBTransactionOptions::LOCK_AWARE);
 			self->set(tr, val);
@@ -430,7 +429,7 @@ public:
 	typename std::enable_if<is_transaction_creator<DB>, Future<Optional<T>>>::type get(
 	    Reference<DB> db,
 	    Snapshot snapshot = Snapshot::False) const {
-		return runTransaction(db, [=, self = *this](Reference<ReadYourWritesTransaction> tr) {
+		return runTransaction(db, [=, self = *this](Reference<typename DB::TransactionT> tr) {
 			tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
 			tr->setOption(FDBTransactionOptions::LOCK_AWARE);
 
@@ -442,7 +441,7 @@ public:
 	typename std::enable_if<is_transaction_creator<DB>, Future<T>>::type getD(Reference<DB> db,
 	                                                                          Snapshot snapshot = Snapshot::False,
 	                                                                          T defaultValue = T()) const {
-		return runTransaction(db, [=, self = *this](Reference<ReadYourWritesTransaction> tr) {
+		return runTransaction(db, [=, self = *this](Reference<typename DB::TransactionT> tr) {
 			tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
 			tr->setOption(FDBTransactionOptions::LOCK_AWARE);
 
@@ -454,7 +453,7 @@ public:
 	typename std::enable_if<is_transaction_creator<DB>, Future<T>>::type getOrThrow(Reference<DB> db,
 	                                                                                Snapshot snapshot = Snapshot::False,
 	                                                                                Error err = key_not_found()) const {
-		return runTransaction(db, [=, self = *this](Reference<ReadYourWritesTransaction> tr) {
+		return runTransaction(db, [=, self = *this](Reference<typename DB::TransactionT> tr) {
 			tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
 			tr->setOption(FDBTransactionOptions::LOCK_AWARE);
 
@@ -469,7 +468,7 @@ public:
 
 	template <class DB>
 	typename std::enable_if<is_transaction_creator<DB>, Future<Void>>::type set(Reference<DB> db, T const& val) {
-		return runTransaction(db, [=, self = *this](Reference<ReadYourWritesTransaction> tr) {
+		return runTransaction(db, [=, self = *this](Reference<typename DB::TransactionT> tr) {
 			tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
 			tr->setOption(FDBTransactionOptions::LOCK_AWARE);
 			self.set(tr, val);

--- a/fdbclient/include/fdbclient/KeyBackedTypes.h
+++ b/fdbclient/include/fdbclient/KeyBackedTypes.h
@@ -23,8 +23,10 @@
 #include <utility>
 #include <vector>
 
+#include "fdbclient/GenericTransactionHelper.h"
 #include "fdbclient/IClientApi.h"
 #include "fdbclient/ReadYourWrites.h"
+#include "fdbclient/DatabaseContext.h"
 #include "fdbclient/Subspace.h"
 #include "flow/ObjectSerializer.h"
 #include "flow/genericactors.actor.h"
@@ -153,23 +155,32 @@ template <typename T>
 class KeyBackedProperty {
 public:
 	KeyBackedProperty(KeyRef key) : key(key) {}
-	Future<Optional<T>> get(Reference<ReadYourWritesTransaction> tr, Snapshot snapshot = Snapshot::False) const {
-		return map(tr->get(key, snapshot), [](Optional<Value> const& val) -> Optional<T> {
-			if (val.present())
-				return Codec<T>::unpack(Tuple::unpack(val.get()));
-			return {};
-		});
+
+	template <class Transaction>
+	typename std::enable_if<!is_transaction_creator<Transaction>, Future<Optional<T>>>::type get(
+	    Transaction tr,
+	    Snapshot snapshot = Snapshot::False) const {
+		typename transaction_future_type<Transaction, Optional<Value>>::type getFuture = tr->get(key, snapshot);
+
+		return holdWhile(getFuture,
+		                 map(safeThreadFutureToFuture(getFuture), [](Optional<Value> const& val) -> Optional<T> {
+			                 if (val.present())
+				                 return Codec<T>::unpack(Tuple::unpack(val.get()));
+			                 return {};
+		                 }));
 	}
+
 	// Get property's value or defaultValue if it doesn't exist
-	Future<T> getD(Reference<ReadYourWritesTransaction> tr,
-	               Snapshot snapshot = Snapshot::False,
-	               T defaultValue = T()) const {
+	template <class Transaction>
+	typename std::enable_if<!is_transaction_creator<Transaction>, Future<T>>::type
+	getD(Transaction tr, Snapshot snapshot = Snapshot::False, T defaultValue = T()) const {
 		return map(get(tr, snapshot), [=](Optional<T> val) -> T { return val.present() ? val.get() : defaultValue; });
 	}
+
 	// Get property's value or throw error if it doesn't exist
-	Future<T> getOrThrow(Reference<ReadYourWritesTransaction> tr,
-	                     Snapshot snapshot = Snapshot::False,
-	                     Error err = key_not_found()) const {
+	template <class Transaction>
+	typename std::enable_if<!is_transaction_creator<Transaction>, Future<T>>::type
+	getOrThrow(Transaction tr, Snapshot snapshot = Snapshot::False, Error err = key_not_found()) const {
 		return map(get(tr, snapshot), [=](Optional<T> val) -> T {
 			if (!val.present()) {
 				throw err;
@@ -179,8 +190,11 @@ public:
 		});
 	}
 
-	Future<Optional<T>> get(Database cx, Snapshot snapshot = Snapshot::False) const {
-		return runRYWTransaction(cx, [=, self = *this](Reference<ReadYourWritesTransaction> tr) {
+	template <class DB>
+	typename std::enable_if<is_transaction_creator<DB>, Future<Optional<T>>>::type get(
+	    Reference<DB> db,
+	    Snapshot snapshot = Snapshot::False) const {
+		return runTransaction(db, [=, self = *this](Reference<ReadYourWritesTransaction> tr) {
 			tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
 			tr->setOption(FDBTransactionOptions::LOCK_AWARE);
 
@@ -188,8 +202,11 @@ public:
 		});
 	}
 
-	Future<T> getD(Database cx, Snapshot snapshot = Snapshot::False, T defaultValue = T()) const {
-		return runRYWTransaction(cx, [=, self = *this](Reference<ReadYourWritesTransaction> tr) {
+	template <class DB>
+	typename std::enable_if<is_transaction_creator<DB>, Future<T>>::type getD(Reference<DB> db,
+	                                                                          Snapshot snapshot = Snapshot::False,
+	                                                                          T defaultValue = T()) const {
+		return runTransaction(db, [=, self = *this](Reference<ReadYourWritesTransaction> tr) {
 			tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
 			tr->setOption(FDBTransactionOptions::LOCK_AWARE);
 
@@ -197,8 +214,11 @@ public:
 		});
 	}
 
-	Future<T> getOrThrow(Database cx, Snapshot snapshot = Snapshot::False, Error err = key_not_found()) const {
-		return runRYWTransaction(cx, [=, self = *this](Reference<ReadYourWritesTransaction> tr) {
+	template <class DB>
+	typename std::enable_if<is_transaction_creator<DB>, Future<T>>::type getOrThrow(Reference<DB> db,
+	                                                                                Snapshot snapshot = Snapshot::False,
+	                                                                                Error err = key_not_found()) const {
+		return runTransaction(db, [=, self = *this](Reference<ReadYourWritesTransaction> tr) {
 			tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
 			tr->setOption(FDBTransactionOptions::LOCK_AWARE);
 
@@ -206,10 +226,14 @@ public:
 		});
 	}
 
-	void set(Reference<ReadYourWritesTransaction> tr, T const& val) { return tr->set(key, Codec<T>::pack(val).pack()); }
+	template <class Transaction>
+	typename std::enable_if<!is_transaction_creator<Transaction>, void>::type set(Transaction tr, T const& val) {
+		return tr->set(key, Codec<T>::pack(val).pack());
+	}
 
-	Future<Void> set(Database cx, T const& val) {
-		return runRYWTransaction(cx, [=, self = *this](Reference<ReadYourWritesTransaction> tr) {
+	template <class DB>
+	typename std::enable_if<is_transaction_creator<DB>, Future<Void>>::type set(Reference<DB> db, T const& val) {
+		return runTransaction(db, [=, self = *this](Reference<ReadYourWritesTransaction> tr) {
 			tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
 			tr->setOption(FDBTransactionOptions::LOCK_AWARE);
 			self->set(tr, val);
@@ -217,7 +241,11 @@ public:
 		});
 	}
 
-	void clear(Reference<ReadYourWritesTransaction> tr) { return tr->clear(key); }
+	template <class Transaction>
+	typename std::enable_if<!is_transaction_creator<Transaction>, void>::type clear(Transaction tr) {
+		return tr->clear(key);
+	}
+
 	Key key;
 };
 
@@ -228,27 +256,40 @@ template <typename T>
 class KeyBackedBinaryValue {
 public:
 	KeyBackedBinaryValue(KeyRef key) : key(key) {}
-	Future<Optional<T>> get(Reference<ReadYourWritesTransaction> tr, Snapshot snapshot = Snapshot::False) const {
-		return map(tr->get(key, snapshot), [](Optional<Value> const& val) -> Optional<T> {
-			if (val.present())
-				return BinaryReader::fromStringRef<T>(val.get(), Unversioned());
-			return {};
-		});
+
+	template <class Transaction>
+	Future<Optional<T>> get(Transaction tr, Snapshot snapshot = Snapshot::False) const {
+		typename transaction_future_type<Transaction, Optional<Value>>::type getFuture = tr->get(key, snapshot);
+
+		return holdWhile(getFuture,
+		                 map(safeThreadFutureToFuture(getFuture), [](Optional<Value> const& val) -> Optional<T> {
+			                 if (val.present())
+				                 return BinaryReader::fromStringRef<T>(val.get(), Unversioned());
+			                 return {};
+		                 }));
 	}
 	// Get property's value or defaultValue if it doesn't exist
-	Future<T> getD(Reference<ReadYourWritesTransaction> tr,
-	               Snapshot snapshot = Snapshot::False,
-	               T defaultValue = T()) const {
+	template <class Transaction>
+	Future<T> getD(Transaction tr, Snapshot snapshot = Snapshot::False, T defaultValue = T()) const {
 		return map(get(tr, Snapshot::False),
 		           [=](Optional<T> val) -> T { return val.present() ? val.get() : defaultValue; });
 	}
-	void set(Reference<ReadYourWritesTransaction> tr, T const& val) {
+
+	template <class Transaction>
+	void set(Transaction tr, T const& val) {
 		return tr->set(key, BinaryWriter::toValue<T>(val, Unversioned()));
 	}
-	void atomicOp(Reference<ReadYourWritesTransaction> tr, T const& val, MutationRef::Type type) {
+
+	template <class Transaction>
+	void atomicOp(Transaction tr, T const& val, MutationRef::Type type) {
 		return tr->atomicOp(key, BinaryWriter::toValue<T>(val, Unversioned()), type);
 	}
-	void clear(Reference<ReadYourWritesTransaction> tr) { return tr->clear(key); }
+
+	template <class Transaction>
+	void clear(Transaction tr) {
+		return tr->clear(key);
+	}
+
 	Key key;
 };
 
@@ -265,63 +306,72 @@ public:
 	typedef std::vector<PairType> PairsType;
 
 	// If end is not present one key past the end of the map is used.
-	Future<PairsType> getRange(Reference<ReadYourWritesTransaction> tr,
-	                           KeyType const& begin,
+	template <class Transaction>
+	Future<PairsType> getRange(Transaction tr,
+	                           Optional<KeyType> const& begin,
 	                           Optional<KeyType> const& end,
 	                           int limit,
 	                           Snapshot snapshot = Snapshot::False,
 	                           Reverse reverse = Reverse::False) const {
 		Subspace s = space; // 'this' could be invalid inside lambda
-		Key endKey = end.present() ? s.pack(Codec<KeyType>::pack(end.get())) : space.range().end;
-		return map(
-		    tr->getRange(
-		        KeyRangeRef(s.pack(Codec<KeyType>::pack(begin)), endKey), GetRangeLimits(limit), snapshot, reverse),
-		    [s](RangeResult const& kvs) -> PairsType {
-			    PairsType results;
-			    for (int i = 0; i < kvs.size(); ++i) {
-				    KeyType key = Codec<KeyType>::unpack(s.unpack(kvs[i].key));
-				    ValueType val = Codec<ValueType>::unpack(Tuple::unpack(kvs[i].value));
-				    results.push_back(PairType(key, val));
-			    }
-			    return results;
-		    });
+
+		Key beginKey = begin.present() ? s.pack(Codec<KeyType>::pack(begin.get())) : s.range().begin;
+		Key endKey = end.present() ? s.pack(Codec<KeyType>::pack(end.get())) : s.range().end;
+
+		typename transaction_future_type<Transaction, RangeResult>::type getRangeFuture =
+		    tr->getRange(KeyRangeRef(beginKey, endKey), GetRangeLimits(limit), snapshot, reverse);
+
+		return holdWhile(getRangeFuture,
+		                 map(safeThreadFutureToFuture(getRangeFuture), [s](RangeResult const& kvs) -> PairsType {
+			                 PairsType results;
+			                 for (int i = 0; i < kvs.size(); ++i) {
+				                 KeyType key = Codec<KeyType>::unpack(s.unpack(kvs[i].key));
+				                 ValueType val = Codec<ValueType>::unpack(Tuple::unpack(kvs[i].value));
+				                 results.push_back(PairType(key, val));
+			                 }
+			                 return results;
+		                 }));
 	}
 
-	Future<Optional<ValueType>> get(Reference<ReadYourWritesTransaction> tr,
-	                                KeyType const& key,
-	                                Snapshot snapshot = Snapshot::False) const {
-		return map(tr->get(space.pack(Codec<KeyType>::pack(key)), snapshot),
-		           [](Optional<Value> const& val) -> Optional<ValueType> {
-			           if (val.present())
-				           return Codec<ValueType>::unpack(Tuple::unpack(val.get()));
-			           return {};
-		           });
+	template <class Transaction>
+	Future<Optional<ValueType>> get(Transaction tr, KeyType const& key, Snapshot snapshot = Snapshot::False) const {
+		typename transaction_future_type<Transaction, Optional<Value>>::type getFuture =
+		    tr->get(space.pack(Codec<KeyType>::pack(key)), snapshot);
+
+		return holdWhile(
+		    getFuture, map(safeThreadFutureToFuture(getFuture), [](Optional<Value> const& val) -> Optional<ValueType> {
+			    if (val.present())
+				    return Codec<ValueType>::unpack(Tuple::unpack(val.get()));
+			    return {};
+		    }));
 	}
 
 	// Returns a Property that can be get/set that represents key's entry in this this.
 	KeyBackedProperty<ValueType> getProperty(KeyType const& key) const { return space.pack(Codec<KeyType>::pack(key)); }
 
 	// Returns the expectedSize of the set key
-	int set(Reference<ReadYourWritesTransaction> tr, KeyType const& key, ValueType const& val) {
+	template <class Transaction>
+	int set(Transaction tr, KeyType const& key, ValueType const& val) {
 		Key k = space.pack(Codec<KeyType>::pack(key));
 		Value v = Codec<ValueType>::pack(val).pack();
 		tr->set(k, v);
 		return k.expectedSize() + v.expectedSize();
 	}
 
-	void erase(Reference<ReadYourWritesTransaction> tr, KeyType const& key) {
+	template <class Transaction>
+	void erase(Transaction tr, KeyType const& key) {
 		return tr->clear(space.pack(Codec<KeyType>::pack(key)));
 	}
 
-	void erase(Reference<ITransaction> tr, KeyType const& key) {
-		return tr->clear(space.pack(Codec<KeyType>::pack(key)));
-	}
-
-	void erase(Reference<ReadYourWritesTransaction> tr, KeyType const& begin, KeyType const& end) {
+	template <class Transaction>
+	void erase(Transaction tr, KeyType const& begin, KeyType const& end) {
 		return tr->clear(KeyRangeRef(space.pack(Codec<KeyType>::pack(begin)), space.pack(Codec<KeyType>::pack(end))));
 	}
 
-	void clear(Reference<ReadYourWritesTransaction> tr) { return tr->clear(space.range()); }
+	template <class Transaction>
+	void clear(Transaction tr) {
+		return tr->clear(space.range());
+	}
 
 	Subspace space;
 };
@@ -332,25 +382,32 @@ template <typename T, typename VersionOptions>
 class KeyBackedObjectProperty {
 public:
 	KeyBackedObjectProperty(KeyRef key, VersionOptions versionOptions) : key(key), versionOptions(versionOptions) {}
-	Future<Optional<T>> get(Reference<ReadYourWritesTransaction> tr, Snapshot snapshot = Snapshot::False) const {
 
-		return map(tr->get(key, snapshot), [vo = versionOptions](Optional<Value> const& val) -> Optional<T> {
-			if (val.present())
-				return ObjectReader::fromStringRef<T>(val.get(), vo);
-			return {};
-		});
+	template <class Transaction>
+	typename std::enable_if<!is_transaction_creator<Transaction>, Future<Optional<T>>>::type get(
+	    Transaction tr,
+	    Snapshot snapshot = Snapshot::False) const {
+		typename transaction_future_type<Transaction, Optional<Value>>::type getFuture = tr->get(key, snapshot);
+
+		return holdWhile(
+		    getFuture,
+		    map(safeThreadFutureToFuture(getFuture), [vo = versionOptions](Optional<Value> const& val) -> Optional<T> {
+			    if (val.present())
+				    return ObjectReader::fromStringRef<T>(val.get(), vo);
+			    return {};
+		    }));
 	}
 
 	// Get property's value or defaultValue if it doesn't exist
-	Future<T> getD(Reference<ReadYourWritesTransaction> tr,
-	               Snapshot snapshot = Snapshot::False,
-	               T defaultValue = T()) const {
+	template <class Transaction>
+	typename std::enable_if<!is_transaction_creator<Transaction>, Future<T>>::type
+	getD(Transaction tr, Snapshot snapshot = Snapshot::False, T defaultValue = T()) const {
 		return map(get(tr, snapshot), [=](Optional<T> val) -> T { return val.present() ? val.get() : defaultValue; });
 	}
 	// Get property's value or throw error if it doesn't exist
-	Future<T> getOrThrow(Reference<ReadYourWritesTransaction> tr,
-	                     Snapshot snapshot = Snapshot::False,
-	                     Error err = key_not_found()) const {
+	template <class Transaction>
+	typename std::enable_if<!is_transaction_creator<Transaction>, Future<T>>::type
+	getOrThrow(Transaction tr, Snapshot snapshot = Snapshot::False, Error err = key_not_found()) const {
 		return map(get(tr, snapshot), [=](Optional<T> val) -> T {
 			if (!val.present()) {
 				throw err;
@@ -360,8 +417,11 @@ public:
 		});
 	}
 
-	Future<Optional<T>> get(Database cx, Snapshot snapshot = Snapshot::False) const {
-		return runRYWTransaction(cx, [=, self = *this](Reference<ReadYourWritesTransaction> tr) {
+	template <class DB>
+	typename std::enable_if<is_transaction_creator<DB>, Future<Optional<T>>>::type get(
+	    Reference<DB> db,
+	    Snapshot snapshot = Snapshot::False) const {
+		return runTransaction(db, [=, self = *this](Reference<ReadYourWritesTransaction> tr) {
 			tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
 			tr->setOption(FDBTransactionOptions::LOCK_AWARE);
 
@@ -369,8 +429,11 @@ public:
 		});
 	}
 
-	Future<T> getD(Database cx, Snapshot snapshot = Snapshot::False, T defaultValue = T()) const {
-		return runRYWTransaction(cx, [=, self = *this](Reference<ReadYourWritesTransaction> tr) {
+	template <class DB>
+	typename std::enable_if<is_transaction_creator<DB>, Future<T>>::type getD(Reference<DB> db,
+	                                                                          Snapshot snapshot = Snapshot::False,
+	                                                                          T defaultValue = T()) const {
+		return runTransaction(db, [=, self = *this](Reference<ReadYourWritesTransaction> tr) {
 			tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
 			tr->setOption(FDBTransactionOptions::LOCK_AWARE);
 
@@ -378,8 +441,11 @@ public:
 		});
 	}
 
-	Future<T> getOrThrow(Database cx, Snapshot snapshot = Snapshot::False, Error err = key_not_found()) const {
-		return runRYWTransaction(cx, [=, self = *this](Reference<ReadYourWritesTransaction> tr) {
+	template <class DB>
+	typename std::enable_if<is_transaction_creator<DB>, Future<T>>::type getOrThrow(Reference<DB> db,
+	                                                                                Snapshot snapshot = Snapshot::False,
+	                                                                                Error err = key_not_found()) const {
+		return runTransaction(db, [=, self = *this](Reference<ReadYourWritesTransaction> tr) {
 			tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
 			tr->setOption(FDBTransactionOptions::LOCK_AWARE);
 
@@ -387,12 +453,14 @@ public:
 		});
 	}
 
-	void set(Reference<ReadYourWritesTransaction> tr, T const& val) {
+	template <class Transaction>
+	typename std::enable_if<!is_transaction_creator<Transaction>, void>::type set(Transaction tr, T const& val) {
 		return tr->set(key, ObjectWriter::toValue(val, versionOptions));
 	}
 
-	Future<Void> set(Database cx, T const& val) {
-		return runRYWTransaction(cx, [=, self = *this](Reference<ReadYourWritesTransaction> tr) {
+	template <class DB>
+	typename std::enable_if<is_transaction_creator<DB>, Future<Void>>::type set(Reference<DB> db, T const& val) {
+		return runTransaction(db, [=, self = *this](Reference<ReadYourWritesTransaction> tr) {
 			tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
 			tr->setOption(FDBTransactionOptions::LOCK_AWARE);
 			self.set(tr, val);
@@ -400,7 +468,10 @@ public:
 		});
 	}
 
-	void clear(Reference<ReadYourWritesTransaction> tr) { return tr->clear(key); }
+	template <class Transaction>
+	typename std::enable_if<!is_transaction_creator<Transaction>, void>::type clear(Transaction tr) {
+		return tr->clear(key);
+	}
 
 	Key key;
 	VersionOptions versionOptions;
@@ -419,18 +490,22 @@ public:
 	typedef std::pair<KeyType, ValueType> PairType;
 	typedef std::vector<PairType> PairsType;
 
-	// If end is not present one key past the end of the map is used.
-	Future<PairsType> getRange(Reference<ReadYourWritesTransaction> tr,
-	                           KeyType const& begin,
+	template <class Transaction>
+	Future<PairsType> getRange(Transaction tr,
+	                           Optional<KeyType> const& begin,
 	                           Optional<KeyType> const& end,
 	                           int limit,
 	                           Snapshot snapshot = Snapshot::False,
 	                           Reverse reverse = Reverse::False) const {
+		Key beginKey = begin.present() ? space.pack(Codec<KeyType>::pack(begin.get())) : space.range().begin;
 		Key endKey = end.present() ? space.pack(Codec<KeyType>::pack(end.get())) : space.range().end;
-		return map(
-		    tr->getRange(
-		        KeyRangeRef(space.pack(Codec<KeyType>::pack(begin)), endKey), GetRangeLimits(limit), snapshot, reverse),
-		    [self = *this](RangeResult const& kvs) -> PairsType {
+
+		typename transaction_future_type<Transaction, RangeResult>::type getRangeFuture =
+		    tr->getRange(KeyRangeRef(beginKey, endKey), GetRangeLimits(limit), snapshot, reverse);
+
+		return holdWhile(
+		    getRangeFuture,
+		    map(safeThreadFutureToFuture(getRangeFuture), [self = *this](RangeResult const& kvs) -> PairsType {
 			    PairsType results;
 			    for (int i = 0; i < kvs.size(); ++i) {
 				    KeyType key = Codec<KeyType>::unpack(self.space.unpack(kvs[i].key));
@@ -438,18 +513,21 @@ public:
 				    results.push_back(PairType(key, val));
 			    }
 			    return results;
-		    });
+		    }));
 	}
 
-	Future<Optional<ValueType>> get(Reference<ReadYourWritesTransaction> tr,
-	                                KeyType const& key,
-	                                Snapshot snapshot = Snapshot::False) const {
-		return map(tr->get(space.pack(Codec<KeyType>::pack(key)), snapshot),
-		           [vo = versionOptions](Optional<Value> const& val) -> Optional<ValueType> {
-			           if (val.present())
-				           return ObjectReader::fromStringRef<ValueType>(val.get(), vo);
-			           return {};
-		           });
+	template <class Transaction>
+	Future<Optional<ValueType>> get(Transaction tr, KeyType const& key, Snapshot snapshot = Snapshot::False) const {
+		typename transaction_future_type<Transaction, Optional<Value>>::type getFuture =
+		    tr->get(space.pack(Codec<KeyType>::pack(key)), snapshot);
+
+		return holdWhile(getFuture,
+		                 map(safeThreadFutureToFuture(getFuture),
+		                     [vo = versionOptions](Optional<Value> const& val) -> Optional<ValueType> {
+			                     if (val.present())
+				                     return ObjectReader::fromStringRef<ValueType>(val.get(), vo);
+			                     return {};
+		                     }));
 	}
 
 	// Returns a Property that can be get/set that represents key's entry in this this.
@@ -459,7 +537,8 @@ public:
 	}
 
 	// Returns the expectedSize of the set key
-	int set(Reference<ReadYourWritesTransaction> tr, KeyType const& key, ValueType const& val) {
+	template <class Transaction>
+	int set(Transaction tr, KeyType const& key, ValueType const& val) {
 		Key k = space.pack(Codec<KeyType>::pack(key));
 		Value v = ObjectWriter::toValue(val, versionOptions);
 		tr->set(k, v);
@@ -470,19 +549,20 @@ public:
 
 	Value serializeValue(ValueType const& val) { return ObjectWriter::toValue(val, versionOptions); }
 
-	void erase(Reference<ReadYourWritesTransaction> tr, KeyType const& key) {
+	template <class Transaction>
+	void erase(Transaction tr, KeyType const& key) {
 		return tr->clear(space.pack(Codec<KeyType>::pack(key)));
 	}
 
-	void erase(Reference<ITransaction> tr, KeyType const& key) {
-		return tr->clear(space.pack(Codec<KeyType>::pack(key)));
-	}
-
-	void erase(Reference<ReadYourWritesTransaction> tr, KeyType const& begin, KeyType const& end) {
+	template <class Transaction>
+	void erase(Transaction tr, KeyType const& begin, KeyType const& end) {
 		return tr->clear(KeyRangeRef(space.pack(Codec<KeyType>::pack(begin)), space.pack(Codec<KeyType>::pack(end))));
 	}
 
-	void clear(Reference<ReadYourWritesTransaction> tr) { return tr->clear(space.range()); }
+	template <class Transaction>
+	void clear(Transaction tr) {
+		return tr->clear(space.range());
+	}
 
 	Subspace space;
 	VersionOptions versionOptions;
@@ -496,49 +576,63 @@ public:
 	typedef _ValueType ValueType;
 	typedef std::vector<ValueType> Values;
 
-	// If end is not present one key past the end of the map is used.
-	Future<Values> getRange(Reference<ReadYourWritesTransaction> tr,
-	                        ValueType const& begin,
+	template <class Transaction>
+	Future<Values> getRange(Transaction tr,
+	                        Optional<ValueType> const& begin,
 	                        Optional<ValueType> const& end,
 	                        int limit,
-	                        Snapshot snapshot = Snapshot::False) const {
+	                        Snapshot snapshot = Snapshot::False,
+	                        Reverse reverse = Reverse::False) const {
 		Subspace s = space; // 'this' could be invalid inside lambda
+		Key beginKey = begin.present() ? s.pack(Codec<ValueType>::pack(begin.get())) : space.range().begin;
 		Key endKey = end.present() ? s.pack(Codec<ValueType>::pack(end.get())) : space.range().end;
-		return map(
-		    tr->getRange(KeyRangeRef(s.pack(Codec<ValueType>::pack(begin)), endKey), GetRangeLimits(limit), snapshot),
-		    [s](RangeResult const& kvs) -> Values {
-			    Values results;
-			    for (int i = 0; i < kvs.size(); ++i) {
-				    results.push_back(Codec<ValueType>::unpack(s.unpack(kvs[i].key)));
-			    }
-			    return results;
-		    });
+
+		typename transaction_future_type<Transaction, RangeResult>::type getRangeFuture =
+		    tr->getRange(KeyRangeRef(beginKey, endKey), GetRangeLimits(limit), snapshot, reverse);
+
+		return holdWhile(getRangeFuture,
+		                 map(safeThreadFutureToFuture(getRangeFuture), [s](RangeResult const& kvs) -> Values {
+			                 Values results;
+			                 for (int i = 0; i < kvs.size(); ++i) {
+				                 results.push_back(Codec<ValueType>::unpack(s.unpack(kvs[i].key)));
+			                 }
+			                 return results;
+		                 }));
 	}
 
-	Future<bool> exists(Reference<ReadYourWritesTransaction> tr,
-	                    ValueType const& val,
-	                    Snapshot snapshot = Snapshot::False) const {
-		return map(tr->get(space.pack(Codec<ValueType>::pack(val)), snapshot),
-		           [](Optional<Value> const& val) -> bool { return val.present(); });
+	template <class Transaction>
+	Future<bool> exists(Transaction tr, ValueType const& val, Snapshot snapshot = Snapshot::False) const {
+		typename transaction_future_type<Transaction, Optional<Value>>::type getFuture =
+		    tr->get(space.pack(Codec<ValueType>::pack(val)), snapshot);
+
+		return holdWhile(getFuture, map(safeThreadFutureToFuture(getFuture), [](Optional<Value> const& val) -> bool {
+			                 return val.present();
+		                 }));
 	}
 
 	// Returns the expectedSize of the set key
-	int insert(Reference<ReadYourWritesTransaction> tr, ValueType const& val) {
+	template <class Transaction>
+	int insert(Transaction tr, ValueType const& val) {
 		Key k = space.pack(Codec<ValueType>::pack(val));
 		tr->set(k, StringRef());
 		return k.expectedSize();
 	}
 
-	void erase(Reference<ReadYourWritesTransaction> tr, ValueType const& val) {
+	template <class Transaction>
+	void erase(Transaction tr, ValueType const& val) {
 		return tr->clear(space.pack(Codec<ValueType>::pack(val)));
 	}
 
-	void erase(Reference<ReadYourWritesTransaction> tr, ValueType const& begin, ValueType const& end) {
+	template <class Transaction>
+	void erase(Transaction tr, ValueType const& begin, ValueType const& end) {
 		return tr->clear(
 		    KeyRangeRef(space.pack(Codec<ValueType>::pack(begin)), space.pack(Codec<ValueType>::pack(end))));
 	}
 
-	void clear(Reference<ReadYourWritesTransaction> tr) { return tr->clear(space.range()); }
+	template <class Transaction>
+	void clear(Transaction tr) {
+		return tr->clear(space.range());
+	}
 
 	Subspace space;
 };

--- a/fdbclient/include/fdbclient/RunTransaction.actor.h
+++ b/fdbclient/include/fdbclient/RunTransaction.actor.h
@@ -41,7 +41,7 @@ Future<decltype(std::declval<Function>()(Reference<ReadYourWritesTransaction>())
 	state Reference<ReadYourWritesTransaction> tr(new ReadYourWritesTransaction(cx));
 	loop {
 		try {
-			// func should be idempodent; otherwise, retry will get undefined result
+			// func should be idempotent; otherwise, retry will get undefined result
 			state decltype(std::declval<Function>()(Reference<ReadYourWritesTransaction>()).getValue()) result =
 			    wait(func(tr));
 			wait(tr->commit());
@@ -59,7 +59,7 @@ Future<decltype(std::declval<Function>()(Reference<typename DB::TransactionT>())
 	state Reference<typename DB::TransactionT> tr = db->createTransaction();
 	loop {
 		try {
-			// func should be idempodent; otherwise, retry will get undefined result
+			// func should be idempotent; otherwise, retry will get undefined result
 			state decltype(std::declval<Function>()(Reference<typename DB::TransactionT>()).getValue()) result =
 			    wait(func(tr));
 			wait(safeThreadFutureToFuture(tr->commit()));

--- a/fdbclient/include/fdbclient/TaskBucket.h
+++ b/fdbclient/include/fdbclient/TaskBucket.h
@@ -103,8 +103,8 @@ template <typename T>
 class TaskParam {
 public:
 	TaskParam(StringRef key) : key(key) {}
-	T get(Reference<Task> task) const { return Codec<T>::unpack(Tuple::unpack(task->params[key])); }
-	void set(Reference<Task> task, T const& val) const { task->params[key] = Codec<T>::pack(val).pack(); }
+	T get(Reference<Task> task) const { return TupleCodec<T>::unpack(task->params[key]); }
+	void set(Reference<Task> task, T const& val) const { task->params[key] = TupleCodec<T>::pack(val); }
 	bool exists(Reference<Task> task) const { return task->params.find(key) != task->params.end(); }
 	T getOrDefault(Reference<Task> task, const T defaultValue = T()) const {
 		if (!exists(task))

--- a/fdbserver/ApplyMetadataMutation.cpp
+++ b/fdbserver/ApplyMetadataMutation.cpp
@@ -405,8 +405,8 @@ private:
 		}
 
 		// Normally uses key backed map, so have to use same unpacking code here.
-		UID ssId = Codec<UID>::unpack(Tuple::unpack(m.param1.removePrefix(tssMappingKeys.begin)));
-		UID tssId = Codec<UID>::unpack(Tuple::unpack(m.param2));
+		UID ssId = TupleCodec<UID>::unpack(m.param1.removePrefix(tssMappingKeys.begin));
+		UID tssId = TupleCodec<UID>::unpack(m.param2);
 		if (!initialCommit) {
 			txnStateStore->set(KeyValueRef(m.param1, m.param2));
 		}
@@ -965,7 +965,7 @@ private:
 		ASSERT(rangeToClear.singleKeyRange());
 
 		// Normally uses key backed map, so have to use same unpacking code here.
-		UID ssId = Codec<UID>::unpack(Tuple::unpack(m.param1.removePrefix(tssMappingKeys.begin)));
+		UID ssId = TupleCodec<UID>::unpack(m.param1.removePrefix(tssMappingKeys.begin));
 		if (!initialCommit) {
 			txnStateStore->clear(rangeToClear);
 		}

--- a/fdbserver/BackupWorker.actor.cpp
+++ b/fdbserver/BackupWorker.actor.cpp
@@ -125,8 +125,8 @@ struct BackupData {
 		PerBackupInfo(BackupData* data, UID uid, Version v) : self(data), startVersion(v) {
 			// Open the container and get key ranges
 			BackupConfig config(uid);
-			container = config.backupContainer().get(data->cx);
-			ranges = config.backupRanges().get(data->cx);
+			container = config.backupContainer().get(data->cx.getReference());
+			ranges = config.backupRanges().get(data->cx.getReference());
 			if (self->backupEpoch == self->recruitedEpoch) {
 				// Only current epoch's worker update the number of backup workers.
 				updateWorker = _updateStartedWorkers(this, data, uid);

--- a/fdbserver/MoveKeys.actor.cpp
+++ b/fdbserver/MoveKeys.actor.cpp
@@ -1538,7 +1538,7 @@ void seedShardServers(Arena& arena, CommitTransactionRef& tr, std::vector<Storag
 			// THIS SHOULD NEVER BE ENABLED IN ANY NON-TESTING ENVIRONMENT
 			TraceEvent(SevError, "TSSIdentityMappingEnabled").log();
 			// hack key-backed map here since we can't really change CommitTransactionRef to a RYW transaction
-			Key uidRef = Codec<UID>::pack(s.id()).pack();
+			Key uidRef = TupleCodec<UID>::pack(s.id());
 			tr.set(arena, uidRef.withPrefix(tssMappingKeys.begin), uidRef);
 		}
 	}

--- a/fdbserver/RestoreApplier.actor.cpp
+++ b/fdbserver/RestoreApplier.actor.cpp
@@ -762,7 +762,7 @@ ACTOR static Future<Void> handleApplyToDBRequest(RestoreVersionBatchRequest req,
 
 		ASSERT(batchData->dbApplier.present());
 		ASSERT(!batchData->dbApplier.get().isError()); // writeMutationsToDB actor cannot have error.
-		                                               // We cannot blindly retry because it is not idempodent
+		                                               // We cannot blindly retry because it is not idempotent
 
 		wait(batchData->dbApplier.get());
 

--- a/fdbserver/TSSMappingUtil.actor.cpp
+++ b/fdbserver/TSSMappingUtil.actor.cpp
@@ -44,8 +44,8 @@ ACTOR Future<Void> readTSSMapping(Transaction* tr, std::map<UID, StorageServerIn
 	ASSERT(!mappingList.more && mappingList.size() < CLIENT_KNOBS->TOO_MANY);
 
 	for (auto& it : mappingList) {
-		state UID ssId = Codec<UID>::unpack(Tuple::unpack(it.key.removePrefix(tssMappingKeys.begin)));
-		UID tssId = Codec<UID>::unpack(Tuple::unpack(it.value));
+		state UID ssId = TupleCodec<UID>::unpack(it.key.removePrefix(tssMappingKeys.begin));
+		UID tssId = TupleCodec<UID>::unpack(it.value);
 		Optional<Value> v = wait(tr->get(serverListKeyFor(tssId)));
 		(*tssMapping)[ssId] = decodeServerListValue(v.get());
 	}

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -6887,12 +6887,12 @@ private:
 		} else if (m.param1.substr(1).startsWith(tssMappingKeys.begin) &&
 		           (m.type == MutationRef::SetValue || m.type == MutationRef::ClearRange)) {
 			if (!data->isTss()) {
-				UID ssId = Codec<UID>::unpack(Tuple::unpack(m.param1.substr(1).removePrefix(tssMappingKeys.begin)));
+				UID ssId = TupleCodec<UID>::unpack(m.param1.substr(1).removePrefix(tssMappingKeys.begin));
 				ASSERT(ssId == data->thisServerID);
 				// Add ss pair id change to mutation log to make durable
 				auto& mLV = data->addVersionToMutationLog(data->data().getLatestVersion());
 				if (m.type == MutationRef::SetValue) {
-					UID tssId = Codec<UID>::unpack(Tuple::unpack(m.param2));
+					UID tssId = TupleCodec<UID>::unpack(m.param2);
 					data->setSSWithTssPair(tssId);
 					data->addMutationToMutationLog(mLV,
 					                               MutationRef(MutationRef::SetValue,

--- a/fdbserver/workloads/BackupAndParallelRestoreCorrectness.actor.cpp
+++ b/fdbserver/workloads/BackupAndParallelRestoreCorrectness.actor.cpp
@@ -466,11 +466,11 @@ struct BackupAndParallelRestoreCorrectnessWorkload : TestWorkload {
 			    .detail("AbortAndRestartAfter", self->abortAndRestartAfter);
 
 			state KeyBackedTag keyBackedTag = makeBackupTag(self->backupTag.toString());
-			UidAndAbortedFlagT uidFlag = wait(keyBackedTag.getOrThrow(cx));
+			UidAndAbortedFlagT uidFlag = wait(keyBackedTag.getOrThrow(cx.getReference()));
 			state UID logUid = uidFlag.first;
-			state Key destUidValue = wait(BackupConfig(logUid).destUidValue().getD(cx));
+			state Key destUidValue = wait(BackupConfig(logUid).destUidValue().getD(cx.getReference()));
 			state Reference<IBackupContainer> lastBackupContainer =
-			    wait(BackupConfig(logUid).backupContainer().getD(cx));
+			    wait(BackupConfig(logUid).backupContainer().getD(cx.getReference()));
 
 			// Occasionally start yet another backup that might still be running when we restore
 			if (!self->locked && BUGGIFY) {

--- a/fdbserver/workloads/BackupCorrectness.actor.cpp
+++ b/fdbserver/workloads/BackupCorrectness.actor.cpp
@@ -513,11 +513,11 @@ struct BackupAndRestoreCorrectnessWorkload : TestWorkload {
 			    .detail("AbortAndRestartAfter", self->abortAndRestartAfter);
 
 			state KeyBackedTag keyBackedTag = makeBackupTag(self->backupTag.toString());
-			UidAndAbortedFlagT uidFlag = wait(keyBackedTag.getOrThrow(cx));
+			UidAndAbortedFlagT uidFlag = wait(keyBackedTag.getOrThrow(cx.getReference()));
 			state UID logUid = uidFlag.first;
-			state Key destUidValue = wait(BackupConfig(logUid).destUidValue().getD(cx));
+			state Key destUidValue = wait(BackupConfig(logUid).destUidValue().getD(cx.getReference()));
 			state Reference<IBackupContainer> lastBackupContainer =
-			    wait(BackupConfig(logUid).backupContainer().getD(cx));
+			    wait(BackupConfig(logUid).backupContainer().getD(cx.getReference()));
 
 			// Occasionally start yet another backup that might still be running when we restore
 			if (!self->locked && BUGGIFY) {


### PR DESCRIPTION
This updates all of the operations on key backed types to take a templated `Transaction` or `DB` variable. This lets us use the `IClientAPI` interfaces in addition to `ReadYourWrites`.

This also renames the `Codec` class to `TupleCodec` and then adds template parameters to each key backed type to allow one to choose the codec being used.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
