### PR TITLE
Microbenchmark version vector serialization/deserialization code

### DIFF
--- a/fdbclient/include/fdbclient/VersionVector.h
+++ b/fdbclient/include/fdbclient/VersionVector.h
@@ -32,6 +32,7 @@
 static const int InvalidEncodedSize = 0;
 
 struct VersionVector {
+	constexpr static FileIdentifier file_identifier = 5253554;
 	friend struct serializable_traits<VersionVector>;
 	boost::container::flat_map<Tag, Version> versions; // An ordered map. (Note:
 	                                                   // changing this to an unordered

--- a/flowbench/BenchVersionVectorSerialization.cpp
+++ b/flowbench/BenchVersionVectorSerialization.cpp
@@ -1,0 +1,88 @@
+/*
+ * BenchVersionVector.cpp
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2022 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "flow/Arena.h"
+#include "benchmark/benchmark.h"
+#include "fdbclient/VersionVector.h"
+#include <cstdint>
+
+struct TestContextArena {
+	Arena& _arena;
+	Arena& arena() { return _arena; }
+	ProtocolVersion protocolVersion() const { return g_network->protocolVersion(); }
+	uint8_t* allocate(size_t size) { return new (_arena) uint8_t[size]; }
+};
+
+static void bench_serializable_traits_version(benchmark::State& state) {
+	int tagCount = state.range(0);
+
+	Version version = 100000;
+	VersionVector serializedVV(version);
+	for (int i = 0; i < tagCount; i++) {
+		serializedVV.setVersion(Tag(0, i), ++version);
+	}
+
+	size_t size = 0;
+	VersionVector deserializedVV;
+	while (state.KeepRunning()) {
+		Standalone<StringRef> msg = ObjectWriter::toValue(serializedVV, Unversioned());
+
+		// Capture the serialized buffer size.
+		state.PauseTiming();
+		size = msg.size();
+		state.ResumeTiming();
+
+		ObjectReader rd(msg.begin(), Unversioned());
+		rd.deserialize(deserializedVV);
+	}
+	ASSERT(serializedVV.compare(deserializedVV));
+	state.SetItemsProcessed(static_cast<long>(state.iterations()));
+	state.counters.insert({ { "Tags", tagCount }, { "Size", size } });
+}
+
+static void bench_dynamic_size_traits_version(benchmark::State& state) {
+	Arena arena;
+	TestContextArena context{ arena };
+
+	int tagCount = state.range(0);
+
+	Version version = 100000;
+	VersionVector serializedVV(version);
+	for (int i = 0; i < tagCount; i++) {
+		serializedVV.setVersion(Tag(0, i), ++version);
+	}
+
+	size_t size = 0;
+	VersionVector deserializedVV;
+	while (state.KeepRunning()) {
+		size = dynamic_size_traits<VersionVector>::size(serializedVV, context);
+
+		uint8_t* buf = context.allocate(size);
+		dynamic_size_traits<VersionVector>::save(buf, serializedVV, context);
+
+		dynamic_size_traits<VersionVector>::load(buf, size, deserializedVV, context);
+	}
+	ASSERT(serializedVV.compare(deserializedVV));
+	state.SetItemsProcessed(static_cast<long>(state.iterations()));
+	state.counters.insert({ { "Tags", tagCount }, { "Size", size } });
+}
+
+BENCHMARK(bench_serializable_traits_version)->Ranges({ { 1 << 4, 1 << 10 } })->ReportAggregatesOnly(true);
+BENCHMARK(bench_dynamic_size_traits_version)->Ranges({ { 1 << 4, 1 << 10 } })->ReportAggregatesOnly(true);


### PR DESCRIPTION
Add a google benchmark to measure the execution time of version vector serialization/deserialization code.

Version vector serialization/deserialization by using "serializable_traits" version of code:

-------------------------------------------------------------------------------------------------
Benchmark                                       Time             CPU   Iterations UserCounters...
-------------------------------------------------------------------------------------------------
bench_serializable_traits_version/16         1339 ns         1343 ns       522268 Size=104 Tags=16 items_per_second=744.681k/s
bench_serializable_traits_version/64         2370 ns         2375 ns       288902 Size=200 Tags=64 items_per_second=421k/s
bench_serializable_traits_version/512       29612 ns        29623 ns        23636 Size=2.12k Tags=512 items_per_second=33.758k/s
bench_serializable_traits_version/1024      64509 ns        64542 ns        10849 Size=4.168k Tags=1024 items_per_second=15.4937k/s

Version vector serialization/deserialization by using "dynamic_size_traits" version of code:

-------------------------------------------------------------------------------------------------
Benchmark                                       Time             CPU   Iterations UserCounters...
-------------------------------------------------------------------------------------------------
bench_dynamic_size_traits_version/16          430 ns          430 ns      1622535 Size=69 Tags=16 items_per_second=2.3267M/s
bench_dynamic_size_traits_version/64         1518 ns         1518 ns       455085 Size=165 Tags=64 items_per_second=658.942k/s
bench_dynamic_size_traits_version/512       30010 ns        30008 ns        23264 Size=2.085k Tags=512 items_per_second=33.3249k/s
bench_dynamic_size_traits_version/1024      66847 ns        66847 ns        10507 Size=4.133k Tags=1024 items_per_second=14.9596k/s

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
