### PR TITLE
Make sequencer aware of the locality of the primary region

### DIFF
--- a/fdbserver/ClusterRecovery.actor.cpp
+++ b/fdbserver/ClusterRecovery.actor.cpp
@@ -999,7 +999,8 @@ ACTOR Future<std::vector<Standalone<CommitTransactionRef>>> recruitEverything(
 	                                                                                self->lastEpochEnd,
 	                                                                                self->commitProxies,
 	                                                                                self->resolvers,
-	                                                                                self->versionEpoch))));
+	                                                                                self->versionEpoch,
+	                                                                                self->primaryLocality))));
 
 	return confChanges;
 }

--- a/fdbserver/include/fdbserver/MasterInterface.h
+++ b/fdbserver/include/fdbserver/MasterInterface.h
@@ -170,19 +170,29 @@ struct UpdateRecoveryDataRequest {
 	std::vector<ResolverInterface> resolvers;
 	Optional<int64_t> versionEpoch;
 	ReplyPromise<Void> reply;
+	int8_t primaryLocality;
 
 	UpdateRecoveryDataRequest() = default;
 	UpdateRecoveryDataRequest(Version recoveryTransactionVersion,
 	                          Version lastEpochEnd,
 	                          const std::vector<CommitProxyInterface>& commitProxies,
 	                          const std::vector<ResolverInterface>& resolvers,
-	                          Optional<int64_t> versionEpoch)
+	                          Optional<int64_t> versionEpoch,
+	                          int8_t primaryLocality)
 	  : recoveryTransactionVersion(recoveryTransactionVersion), lastEpochEnd(lastEpochEnd),
-	    commitProxies(commitProxies), resolvers(resolvers), versionEpoch(versionEpoch) {}
+	    commitProxies(commitProxies), resolvers(resolvers), versionEpoch(versionEpoch),
+	    primaryLocality(primaryLocality) {}
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, recoveryTransactionVersion, lastEpochEnd, commitProxies, resolvers, versionEpoch, reply);
+		serializer(ar,
+		           recoveryTransactionVersion,
+		           lastEpochEnd,
+		           commitProxies,
+		           resolvers,
+		           versionEpoch,
+		           reply,
+		           primaryLocality);
 	}
 };
 


### PR DESCRIPTION
This is in the context of HA-related version vector optimization: propagate the locality of the primary region from ClusterController to the sequencer, rather than deriving it from "MasterInterface" on the sequencer (which is not correct). 

Testing:
Simulation tests:
Compiler: gcc.
Version vector disabled: 20220706-102147-sre-f3f7f09b7eac8fd9 (no failures).
Version vector enabled, knob ENABLE_VERSION_VECTOR_HA_OPTIMIZATION enabled: 20220706-103407-sre-180fb8af27a15e6d (no failures).

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
