### PR TITLE
Add StorageEngine type to StorageMetrics trace events

### DIFF
--- a/fdbclient/include/fdbclient/FDBTypes.h
+++ b/fdbclient/include/fdbclient/FDBTypes.h
@@ -841,13 +841,13 @@ struct KeyValueStoreType {
 	// Only add new ones just before END.
 	// SS storeType is END before the storageServerInterface is initialized.
 	enum StoreType {
-		SSD_BTREE_V1,
-		MEMORY,
-		SSD_BTREE_V2,
-		SSD_REDWOOD_V1,
-		MEMORY_RADIXTREE,
-		SSD_ROCKSDB_V1,
-		SSD_SHARDED_ROCKSDB,
+		SSD_BTREE_V1 = 0,
+		MEMORY = 1,
+		SSD_BTREE_V2 = 2,
+		SSD_REDWOOD_V1 = 3,
+		MEMORY_RADIXTREE = 4,
+		SSD_ROCKSDB_V1 = 5,
+		SSD_SHARDED_ROCKSDB = 6,
 		END
 	};
 

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -8671,6 +8671,7 @@ ACTOR Future<Void> metricsCore(StorageServer* self, StorageServerInterface ssi) 
 	                               &self->counters.cc,
 	                               self->thisServerID.toString() + "/StorageMetrics",
 	                               [self = self](TraceEvent& te) {
+		                               te.detail("StorageEngine", self->storage.getKeyValueStoreType().toString());
 		                               te.detail("Tag", self->tag.toString());
 		                               StorageBytes sb = self->storage.getStorageBytes();
 		                               te.detail("KvstoreBytesUsed", sb.used);


### PR DESCRIPTION
Add StorageEngine type to StorageMetrics trace events.
Also hardcoded storage engine types as they must not change.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
