### PR TITLE
Cherry pick pull request #7529

### DIFF
--- a/fdbserver/ClusterRecovery.actor.cpp
+++ b/fdbserver/ClusterRecovery.actor.cpp
@@ -998,7 +998,8 @@ ACTOR Future<std::vector<Standalone<CommitTransactionRef>>> recruitEverything(
 	                                                                                self->lastEpochEnd,
 	                                                                                self->commitProxies,
 	                                                                                self->resolvers,
-	                                                                                self->versionEpoch))));
+	                                                                                self->versionEpoch,
+	                                                                                self->primaryLocality))));
 
 	return confChanges;
 }

--- a/fdbserver/MasterInterface.h
+++ b/fdbserver/MasterInterface.h
@@ -170,19 +170,29 @@ struct UpdateRecoveryDataRequest {
 	std::vector<ResolverInterface> resolvers;
 	Optional<int64_t> versionEpoch;
 	ReplyPromise<Void> reply;
+	int8_t primaryLocality;
 
 	UpdateRecoveryDataRequest() = default;
 	UpdateRecoveryDataRequest(Version recoveryTransactionVersion,
 	                          Version lastEpochEnd,
 	                          const std::vector<CommitProxyInterface>& commitProxies,
 	                          const std::vector<ResolverInterface>& resolvers,
-	                          Optional<int64_t> versionEpoch)
+	                          Optional<int64_t> versionEpoch,
+	                          int8_t primaryLocality)
 	  : recoveryTransactionVersion(recoveryTransactionVersion), lastEpochEnd(lastEpochEnd),
-	    commitProxies(commitProxies), resolvers(resolvers), versionEpoch(versionEpoch) {}
+	    commitProxies(commitProxies), resolvers(resolvers), versionEpoch(versionEpoch),
+	    primaryLocality(primaryLocality) {}
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, recoveryTransactionVersion, lastEpochEnd, commitProxies, resolvers, versionEpoch, reply);
+		serializer(ar,
+		           recoveryTransactionVersion,
+		           lastEpochEnd,
+		           commitProxies,
+		           resolvers,
+		           versionEpoch,
+		           reply,
+		           primaryLocality);
 	}
 };
 

--- a/fdbserver/masterserver.actor.cpp
+++ b/fdbserver/masterserver.actor.cpp
@@ -117,9 +117,7 @@ struct MasterData : NonCopyable, ReferenceCounted<MasterData> {
 			forceRecovery = false;
 		}
 		balancer = resolutionBalancer.resolutionBalancing();
-		locality = (SERVER_KNOBS->ENABLE_VERSION_VECTOR_HA_OPTIMIZATION && myInterface.locality.dcId().present())
-		               ? std::stoi(myInterface.locality.dcId().get().toString())
-		               : tagLocalityInvalid;
+		locality = tagLocalityInvalid;
 	}
 	~MasterData() = default;
 };
@@ -313,7 +311,8 @@ ACTOR Future<Void> updateRecoveryData(Reference<MasterData> self) {
 		    .detail("CurrentRecoveryTxnVersion", self->recoveryTransactionVersion)
 		    .detail("CurrentLastEpochEnd", self->lastEpochEnd)
 		    .detail("NumCommitProxies", req.commitProxies.size())
-		    .detail("VersionEpoch", req.versionEpoch);
+		    .detail("VersionEpoch", req.versionEpoch)
+		    .detail("PrimaryLocality", req.primaryLocality);
 
 		self->recoveryTransactionVersion = req.recoveryTransactionVersion;
 		self->lastEpochEnd = req.lastEpochEnd;
@@ -338,6 +337,8 @@ ACTOR Future<Void> updateRecoveryData(Reference<MasterData> self) {
 
 		self->resolutionBalancer.setCommitProxies(req.commitProxies);
 		self->resolutionBalancer.setResolvers(req.resolvers);
+
+		self->locality = req.primaryLocality;
 
 		req.reply.send(Void());
 	}


### PR DESCRIPTION
Merge pull request #7529 from sbodagala/main.

This is in the context of HA-related version vector optimization: propagate the locality of the primary region from ClusterController to the sequencer, rather than deriving it from "MasterInterface" on the sequencer (which is not correct).

Testing:
Simulation tests:
Compiler: gcc.
Version vector disabled: 20220707-091505-sre-f49dde440378fc4f (no failures).
Version vector enabled, knob ENABLE_VERSION_VECTOR_HA_OPTIMIZATION enabled: 20220707-092621-sre-b678a4cd14287395 (no failures).

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
