### PR TITLE
Cherry pick pr7531 - Change VersionVectorTagUpdates to LatencySample.

### DIFF
--- a/fdbserver/masterserver.actor.cpp
+++ b/fdbserver/masterserver.actor.cpp
@@ -72,8 +72,6 @@ struct MasterData : NonCopyable, ReferenceCounted<MasterData> {
 	Counter getCommitVersionRequests;
 	Counter getLiveCommittedVersionRequests;
 	Counter reportLiveCommittedVersionRequests;
-	// This counter gives an estimate of the number of non-empty peeks that storage servers
-	// should do from tlogs (in the worst case, ignoring blocking peek timeouts).
 	LatencySample versionVectorTagUpdates;
 	Counter waitForPrevCommitRequests;
 	Counter nonWaitForPrevCommitRequests;
@@ -100,9 +98,9 @@ struct MasterData : NonCopyable, ReferenceCounted<MasterData> {
 	    getLiveCommittedVersionRequests("GetLiveCommittedVersionRequests", cc),
 	    reportLiveCommittedVersionRequests("ReportLiveCommittedVersionRequests", cc),
 	    versionVectorTagUpdates("VersionVectorTagUpdates",
-                                    dbgid,
-                                    SERVER_KNOBS->LATENCY_METRICS_LOGGING_INTERVAL,
-                                    SERVER_KNOBS->LATENCY_SAMPLE_SIZE),
+	                            dbgid,
+	                            SERVER_KNOBS->LATENCY_METRICS_LOGGING_INTERVAL,
+	                            SERVER_KNOBS->LATENCY_SAMPLE_SIZE),
 	    waitForPrevCommitRequests("WaitForPrevCommitRequests", cc),
 	    nonWaitForPrevCommitRequests("NonWaitForPrevCommitRequests", cc),
 	    versionVectorSizeOnCVReply("VersionVectorSizeOnCVReply",


### PR DESCRIPTION
Cherry pick PR 7531

Change `VersionVectorTagUpdates` to `LatencySample`, so it gives meaning information on the number of tags modified in the version vector over intervals of time.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
