### PR TITLE
Changing hasIncompleteVersionstamp to use iteration rather than stream processing

### DIFF
--- a/bindings/java/src/main/com/apple/foundationdb/tuple/Tuple.java
+++ b/bindings/java/src/main/com/apple/foundationdb/tuple/Tuple.java
@@ -86,7 +86,7 @@ public class Tuple implements Comparable<Tuple>, Iterable<Object> {
 
 	private Tuple(List<Object> elements) {
 		this.elements = elements;
-		incompleteVersionstamp = TupleUtil.hasIncompleteVersionstamp(elements.stream());
+		incompleteVersionstamp = TupleUtil.hasIncompleteVersionstamp(elements);
 	}
 
 	/**
@@ -265,7 +265,7 @@ public class Tuple implements Comparable<Tuple>, Iterable<Object> {
 	 * @return a newly created {@code Tuple}
 	 */
 	public Tuple add(List<?> l) {
-		return new Tuple(this, l, TupleUtil.hasIncompleteVersionstamp(l.stream()));
+		return new Tuple(this, l, TupleUtil.hasIncompleteVersionstamp(l));
 	}
 
 	/**

--- a/bindings/java/src/main/com/apple/foundationdb/tuple/TupleUtil.java
+++ b/bindings/java/src/main/com/apple/foundationdb/tuple/TupleUtil.java
@@ -776,24 +776,23 @@ class TupleUtil {
 		return packedSize;
 	}
 
-	static boolean hasIncompleteVersionstamp(Stream<?> items) {
-		return items.anyMatch(item -> {
-			if(item == null) {
-				return false;
+	static boolean hasIncompleteVersionstamp(Collection<?> items){
+		boolean isComplete = true;
+		for(Object itm: items){
+			if(itm instanceof Versionstamp){
+				isComplete = ((Versionstamp)itm).isComplete();
+			}else if(itm instanceof Tuple){
+				isComplete = hasIncompleteVersionstamp(((Tuple)itm).getItems());
+			}else if(itm instanceof Collection<?>){
+				isComplete = hasIncompleteVersionstamp((Collection<?>)itm);
 			}
-			else if(item instanceof Versionstamp) {
-				return !((Versionstamp) item).isComplete();
+
+
+			if(!isComplete){
+				break;
 			}
-			else if(item instanceof Tuple) {
-				return hasIncompleteVersionstamp(((Tuple) item).stream());
-			}
-			else if(item instanceof Collection<?>) {
-				return hasIncompleteVersionstamp(((Collection<?>) item).stream());
-			}
-			else {
-				return false;
-			}
-		});
+		}
+		return !isComplete;
 	}
 
 	public static void main(String[] args) {


### PR DESCRIPTION
TupleUtil.hasIncompleteVersionstamp() uses stream processing, which can result in some additional copies and object creations. This switches over to an iteration loop which should only create an extra iterator() object.