### PR TITLE
Support snapshotting all stateful FDB processes, even if not recruited

### DIFF
--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -124,6 +124,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( SNAP_NETWORK_FAILURE_RETRY_LIMIT,                       10 );
 	init( MAX_STORAGE_SNAPSHOT_FAULT_TOLERANCE,                    1 );
 	init( MAX_COORDINATOR_SNAPSHOT_FAULT_TOLERANCE,                1 );
+	init( SNAPSHOT_ALL_STATEFUL_PROCESSES,                     false ); if ( randomize && BUGGIFY ) SNAPSHOT_ALL_STATEFUL_PROCESSES = true;
 
 	// Data distribution queue
 	init( HEALTH_POLL_TIME,                                      1.0 );

--- a/fdbclient/include/fdbclient/ServerKnobs.h
+++ b/fdbclient/include/fdbclient/ServerKnobs.h
@@ -629,6 +629,9 @@ public:
 	// Maximum number of coordinators a snapshot can fail to
 	// capture while still succeeding
 	int64_t MAX_COORDINATOR_SNAPSHOT_FAULT_TOLERANCE;
+	// if true, all processes with class "storage", "transaction" and "log" will be snapshotted even not recruited as
+	// the role
+	bool SNAPSHOT_ALL_STATEFUL_PROCESSES;
 
 	// Storage Metrics
 	double STORAGE_METRICS_AVERAGE_INTERVAL;


### PR DESCRIPTION
A very simple change to add a knob SNAPSHOT_ALL_STATEFUL_PROCESSES to snapshot all processes with the stateful class type(storage, log, transaction) even if they are not recruited

The change has no effect on simulation as in simulation, we simply copy data files under `simfdb/`,
processes snapshotted but without the data files will not trigger any difference.

In a real cluster, this will help provision disks for these processes in the restore.

Passes 100K correctness tests.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
