### PR TITLE
[DD Testability] move takeMoveKeysLock to DDTxnProcessor

### DIFF
--- a/fdbserver/DDTeamCollection.actor.cpp
+++ b/fdbserver/DDTeamCollection.actor.cpp
@@ -3029,8 +3029,8 @@ public:
 					    .trackLatest(self->primary ? "TotalDataInFlight"
 					                               : "TotalDataInFlightRemote"); // This trace event's trackLatest
 					                                                             // lifetime is controlled by
-					// DataDistributorData::totalDataInFlightEventHolder or
-					// DataDistributorData::totalDataInFlightRemoteEventHolder.
+					// DataDistributor::totalDataInFlightEventHolder or
+					// DataDistributor::totalDataInFlightRemoteEventHolder.
 					// The track latest key we use here must match the key used in
 					// the holder.
 

--- a/fdbserver/DDTxnProcessor.actor.cpp
+++ b/fdbserver/DDTxnProcessor.actor.cpp
@@ -98,3 +98,7 @@ Future<std::vector<std::pair<StorageServerInterface, ProcessClass>>> DDTxnProces
 	Transaction tr(cx);
 	return NativeAPI::getServerListAndProcessClasses(&tr);
 }
+
+Future<MoveKeysLock> DDTxnProcessor::takeMoveKeysLock(UID ddId) const {
+	return ::takeMoveKeysLock(cx, ddId);
+}

--- a/fdbserver/DataDistributionQueue.actor.cpp
+++ b/fdbserver/DataDistributionQueue.actor.cpp
@@ -2315,7 +2315,7 @@ ACTOR Future<Void> dataDistributionQueue(Database cx,
 					    .detail("PriorityTeam0Left", self.priority_relocations[SERVER_KNOBS->PRIORITY_TEAM_0_LEFT])
 					    .detail("PrioritySplitShard", self.priority_relocations[SERVER_KNOBS->PRIORITY_SPLIT_SHARD])
 					    .trackLatest("MovingData"); // This trace event's trackLatest lifetime is controlled by
-					                                // DataDistributorData::movingDataEventHolder. The track latest
+					                                // DataDistributor::movingDataEventHolder. The track latest
 					                                // key we use here must match the key used in the holder.
 				}
 				when(wait(self.error.getFuture())) {} // Propagate errors from dataDistributionRelocator

--- a/fdbserver/include/fdbserver/DDTxnProcessor.h
+++ b/fdbserver/include/fdbserver/DDTxnProcessor.h
@@ -25,6 +25,11 @@
 #include "fdbserver/DataDistribution.actor.h"
 #include "fdbserver/MoveKeys.actor.h"
 
+/* Testability Contract:
+ * a. The DataDistributor has to use this interface to interact with data-plane (aka. run transaction), because the
+ * testability benefits from a mock implementation; b. Other control-plane roles should consider providing its own
+ * TxnProcessor interface to provide testability, for example, Ratekeeper.
+ * */
 class IDDTxnProcessor {
 public:
 	struct SourceServers {
@@ -38,7 +43,7 @@ public:
 
 	virtual ~IDDTxnProcessor() = default;
 
-	virtual Future<MoveKeysLock> takeMoveKeysLock(UID ddId) const { return MoveKeysLock(); }
+	[[nodiscard]] virtual Future<MoveKeysLock> takeMoveKeysLock(UID ddId) const { return MoveKeysLock(); }
 };
 
 class DDTxnProcessorImpl;

--- a/fdbserver/include/fdbserver/DDTxnProcessor.h
+++ b/fdbserver/include/fdbserver/DDTxnProcessor.h
@@ -23,6 +23,7 @@
 
 #include "fdbserver/Knobs.h"
 #include "fdbserver/DataDistribution.actor.h"
+#include "fdbserver/MoveKeys.actor.h"
 
 class IDDTxnProcessor {
 public:
@@ -36,6 +37,8 @@ public:
 	virtual Future<std::vector<std::pair<StorageServerInterface, ProcessClass>>> getServerListAndProcessClasses() = 0;
 
 	virtual ~IDDTxnProcessor() = default;
+
+	virtual Future<MoveKeysLock> takeMoveKeysLock(UID ddId) const { return MoveKeysLock(); }
 };
 
 class DDTxnProcessorImpl;
@@ -53,6 +56,8 @@ public:
 
 	// Call NativeAPI implementation directly
 	Future<std::vector<std::pair<StorageServerInterface, ProcessClass>>> getServerListAndProcessClasses() override;
+
+	Future<MoveKeysLock> takeMoveKeysLock(UID ddId) const override;
 };
 
 // run mock transaction

--- a/fdbserver/include/fdbserver/DataDistribution.actor.h
+++ b/fdbserver/include/fdbserver/DataDistribution.actor.h
@@ -26,6 +26,7 @@
 
 #include "fdbclient/NativeAPI.actor.h"
 #include "fdbclient/RunTransaction.actor.h"
+#include "fdbserver/DDTxnProcessor.h"
 #include "fdbserver/Knobs.h"
 #include "fdbserver/LogSystem.h"
 #include "fdbserver/MoveKeys.actor.h"


### PR DESCRIPTION
move one of the DD bootstrap step to txnProcessor.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
