### PR TITLE
Changing hasIncompleteVersionstamp to use iteration rather than stream processing [release-7.1]

### DIFF
--- a/bindings/java/src/main/com/apple/foundationdb/tuple/Tuple.java
+++ b/bindings/java/src/main/com/apple/foundationdb/tuple/Tuple.java
@@ -86,7 +86,7 @@ public class Tuple implements Comparable<Tuple>, Iterable<Object> {
 
 	private Tuple(List<Object> elements) {
 		this.elements = elements;
-		incompleteVersionstamp = TupleUtil.hasIncompleteVersionstamp(elements.stream());
+		incompleteVersionstamp = TupleUtil.hasIncompleteVersionstamp(elements);
 	}
 
 	/**
@@ -265,7 +265,7 @@ public class Tuple implements Comparable<Tuple>, Iterable<Object> {
 	 * @return a newly created {@code Tuple}
 	 */
 	public Tuple add(List<?> l) {
-		return new Tuple(this, l, TupleUtil.hasIncompleteVersionstamp(l.stream()));
+		return new Tuple(this, l, TupleUtil.hasIncompleteVersionstamp(l));
 	}
 
 	/**
@@ -481,6 +481,15 @@ public class Tuple implements Comparable<Tuple>, Iterable<Object> {
 	 */
 	public List<Object> getItems() {
 		return new ArrayList<>(elements);
+	}
+
+	/**
+	 * Gets the unserialized contents of this {@code Tuple} without copying into a new list.
+	 *
+	 * @return the elements that make up this {@code Tuple}.
+	 */
+	List<Object> getRawItems() {
+		return elements;
 	}
 
 	/**

--- a/bindings/java/src/main/com/apple/foundationdb/tuple/TupleUtil.java
+++ b/bindings/java/src/main/com/apple/foundationdb/tuple/TupleUtil.java
@@ -776,24 +776,26 @@ class TupleUtil {
 		return packedSize;
 	}
 
-	static boolean hasIncompleteVersionstamp(Stream<?> items) {
-		return items.anyMatch(item -> {
+	static boolean hasIncompleteVersionstamp(Collection<?> items) {
+		boolean hasIncompleteVersionstamp = false;
+		for (Object item: items) {
 			if(item == null) {
-				return false;
+				continue;
 			}
 			else if(item instanceof Versionstamp) {
-				return !((Versionstamp) item).isComplete();
+				hasIncompleteVersionstamp = !((Versionstamp) item).isComplete();
 			}
 			else if(item instanceof Tuple) {
-				return hasIncompleteVersionstamp(((Tuple) item).stream());
+				hasIncompleteVersionstamp = hasIncompleteVersionstamp(((Tuple) item).getRawItems());
 			}
 			else if(item instanceof Collection<?>) {
-				return hasIncompleteVersionstamp(((Collection<?>) item).stream());
+				hasIncompleteVersionstamp = hasIncompleteVersionstamp( (Collection<?>) item);
 			}
-			else {
-				return false;
+			if (hasIncompleteVersionstamp) {
+				return hasIncompleteVersionstamp;
 			}
-		});
+		};
+		return hasIncompleteVersionstamp;
 	}
 
 	public static void main(String[] args) {


### PR DESCRIPTION
Cherrypick #7552


# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
