### PR TITLE
Parse integer options in fdbcli rather than passing the bytes unparsed

### DIFF
--- a/bindings/python/tests/fdbcli_tests.py
+++ b/bindings/python/tests/fdbcli_tests.py
@@ -699,6 +699,15 @@ def tenants(logger):
 
     run_fdbcli_command('writemode on; clear tenant_test')
 
+def integer_options():
+    process = subprocess.Popen(command_template[:-1], stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=fdbcli_env)
+    cmd_sequence = ['option on TIMEOUT 1000', 'writemode on', 'clear foo']
+    output, error_output = process.communicate(input='\n'.join(cmd_sequence).encode())
+
+    lines = output.decode().strip().split('\n')[-2:]
+    assert lines[0] == 'Option enabled for all transactions'
+    assert lines[1].startswith('Committed')
+    assert error_output == b''
 
 if __name__ == '__main__':
     parser = ArgumentParser(formatter_class=RawDescriptionHelpFormatter,
@@ -745,6 +754,7 @@ if __name__ == '__main__':
         triggerddteaminfolog()
         tenants()
         versionepoch()
+        integer_options()
     else:
         assert args.process_number > 1, "Process number should be positive"
         coordinators()

--- a/documentation/sphinx/source/release-notes/release-notes-710.rst
+++ b/documentation/sphinx/source/release-notes/release-notes-710.rst
@@ -1,5 +1,3 @@
-.. _release-notes:
-
 #############
 Release Notes
 #############

--- a/documentation/sphinx/source/release-notes/release-notes-720.rst
+++ b/documentation/sphinx/source/release-notes/release-notes-720.rst
@@ -1,0 +1,58 @@
+.. _release-notes:
+
+#############
+Release Notes
+#############
+
+7.2.0
+======
+
+Features
+--------
+
+Performance
+-----------
+
+Reliability
+-----------
+
+Fixes
+-----
+
+* In ``fdbcli``, integer options are now expressed as integers rather than byte strings (e.g. ``option on TIMEOUT 1000``). `(PR #7571) <https://github.com/apple/foundationdb/pull/7571>`_
+
+Status
+------
+
+Bindings
+--------
+
+Other Changes
+-------------
+
+Earlier release notes
+---------------------
+* :doc:`7.1 (API Version 710) </release-notes/release-notes-710>`
+* :doc:`7.0 (API Version 700) </release-notes/release-notes-700>`
+* :doc:`6.3 (API Version 630) </release-notes/release-notes-630>`
+* :doc:`6.2 (API Version 620) </release-notes/release-notes-620>`
+* :doc:`6.1 (API Version 610) </release-notes/release-notes-610>`
+* :doc:`6.0 (API Version 600) </release-notes/release-notes-600>`
+* :doc:`5.2 (API Version 520) </release-notes/release-notes-520>`
+* :doc:`5.1 (API Version 510) </release-notes/release-notes-510>`
+* :doc:`5.0 (API Version 500) </release-notes/release-notes-500>`
+* :doc:`4.6 (API Version 460) </release-notes/release-notes-460>`
+* :doc:`4.5 (API Version 450) </release-notes/release-notes-450>`
+* :doc:`4.4 (API Version 440) </release-notes/release-notes-440>`
+* :doc:`4.3 (API Version 430) </release-notes/release-notes-430>`
+* :doc:`4.2 (API Version 420) </release-notes/release-notes-420>`
+* :doc:`4.1 (API Version 410) </release-notes/release-notes-410>`
+* :doc:`4.0 (API Version 400) </release-notes/release-notes-400>`
+* :doc:`3.0 (API Version 300) </release-notes/release-notes-300>`
+* :doc:`2.0 (API Version 200) </release-notes/release-notes-200>`
+* :doc:`1.0 (API Version 100) </release-notes/release-notes-100>`
+* :doc:`Beta 3 (API Version 23) </release-notes/release-notes-023>`
+* :doc:`Beta 2 (API Version 22) </release-notes/release-notes-022>`
+* :doc:`Beta 1 (API Version 21) </release-notes/release-notes-021>`
+* :doc:`Alpha 6 (API Version 16) </release-notes/release-notes-016>`
+* :doc:`Alpha 5 (API Version 14) </release-notes/release-notes-014>`

--- a/fdbcli/fdbcli.actor.cpp
+++ b/fdbcli/fdbcli.actor.cpp
@@ -201,9 +201,31 @@ private:
 	                          bool enabled,
 	                          Optional<StringRef> arg,
 	                          bool intrans) {
-		if (enabled && arg.present() != FDBTransactionOptions::optionInfo.getMustExist(option).hasParameter) {
-			fprintf(stderr, "ERROR: option %s a parameter\n", arg.present() ? "did not expect" : "expected");
-			throw invalid_option_value();
+		// If the parameter type is an int, we will extract into this variable and reference its memory with a StringRef
+		int64_t parsedInt = 0;
+
+		if (enabled) {
+			auto optionInfo = FDBTransactionOptions::optionInfo.getMustExist(option);
+			if (arg.present() != optionInfo.hasParameter) {
+				fprintf(stderr, "ERROR: option %s a parameter\n", arg.present() ? "did not expect" : "expected");
+				throw invalid_option_value();
+			}
+			if (arg.present() && optionInfo.paramType == FDBOptionInfo::ParamType::Int) {
+				try {
+					size_t nextIdx;
+					std::string value = arg.get().toString();
+					parsedInt = std::stoll(value, &nextIdx);
+					if (nextIdx != value.length()) {
+						fprintf(
+						    stderr, "ERROR: could not parse value `%s' as an integer\n", arg.get().toString().c_str());
+						throw invalid_option_value();
+					}
+					arg = StringRef(reinterpret_cast<uint8_t*>(&parsedInt), 8);
+				} catch (std::exception e) {
+					fprintf(stderr, "ERROR: could not parse value `%s' as an integer\n", arg.get().toString().c_str());
+					throw invalid_option_value();
+				}
+			}
 		}
 
 		if (intrans) {


### PR DESCRIPTION
This allows specifying the string `"1"` instead of `"\x01\x00\x00\x00\x00\x00\x00\x00"`.

Resolves #7526 

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
