### PR TITLE
Update ctest_to_joshua to work with new ctests

### DIFF
--- a/bindings/c/CMakeLists.txt
+++ b/bindings/c/CMakeLists.txt
@@ -454,7 +454,9 @@ if (NOT WIN32 AND NOT APPLE AND NOT OPEN_FOR_IDE)
   add_test(NAME fdb_c_shim_library_tests
     COMMAND $<TARGET_FILE:Python::Interpreter> ${CMAKE_CURRENT_SOURCE_DIR}/test/fdb_c_shim_tests.py
           --build-dir ${CMAKE_BINARY_DIR}
-          --source-dir ${CMAKE_SOURCE_DIR}
+          --unit-tests-bin $<TARGET_FILE:fdb_c_shim_unit_tests>
+          --api-tester-bin $<TARGET_FILE:fdb_c_shim_api_tester>
+          --api-test-dir ${CMAKE_SOURCE_DIR}/bindings/c/test/apitester/tests
           )
 
 endif() # End Linux only

--- a/bindings/c/test/fdb_c_shim_tests.py
+++ b/bindings/c/test/fdb_c_shim_tests.py
@@ -87,11 +87,11 @@ class FdbCShimTests:
         self.build_dir = Path(args.build_dir).resolve()
         assert self.build_dir.exists(), "{} does not exist".format(args.build_dir)
         assert self.build_dir.is_dir(), "{} is not a directory".format(args.build_dir)
-        self.unit_tests_bin = args.unit_tests_bin
+        self.unit_tests_bin = Path(args.unit_tests_bin).resolve()
         assert self.unit_tests_bin.exists(), "{} does not exist".format(self.unit_tests_bin)
-        self.api_tester_bin = args.api_tester_bin
+        self.api_tester_bin = Path(args.api_tester_bin).resolve()
         assert self.api_tester_bin.exists(), "{} does not exist".format(self.api_tests_bin)
-        self.api_test_dir = args.api_test_dir
+        self.api_test_dir = Path(args.api_test_dir).resolve()
         assert self.api_test_dir.exists(), "{} does not exist".format(self.api_test_dir)
         self.downloader = FdbBinaryDownloader(args.build_dir)
         # binary downloads are currently available only for x86_64

--- a/bindings/c/test/fdb_c_shim_tests.py
+++ b/bindings/c/test/fdb_c_shim_tests.py
@@ -87,14 +87,12 @@ class FdbCShimTests:
         self.build_dir = Path(args.build_dir).resolve()
         assert self.build_dir.exists(), "{} does not exist".format(args.build_dir)
         assert self.build_dir.is_dir(), "{} is not a directory".format(args.build_dir)
-        self.source_dir = Path(args.source_dir).resolve()
-        assert self.source_dir.exists(), "{} does not exist".format(args.source_dir)
-        assert self.source_dir.is_dir(), "{} is not a directory".format(args.source_dir)
-        self.api_tester_bin = self.build_dir.joinpath("bin", "fdb_c_shim_api_tester")
-        assert self.api_tester_bin.exists(), "{} does not exist".format(self.api_tester_bin)
-        self.unit_tests_bin = self.build_dir.joinpath("bin", "fdb_c_shim_unit_tests")
+        self.unit_tests_bin = args.unit_tests_bin
         assert self.unit_tests_bin.exists(), "{} does not exist".format(self.unit_tests_bin)
-        self.api_test_dir = self.source_dir.joinpath("bindings", "c", "test", "apitester", "tests")
+        self.api_tester_bin = args.api_tester_bin
+        assert self.api_tester_bin.exists(), "{} does not exist".format(self.api_tests_bin)
+        self.api_test_dir = args.api_test_dir
+        assert self.api_test_dir.exists(), "{} does not exist".format(self.api_test_dir)
         self.downloader = FdbBinaryDownloader(args.build_dir)
         # binary downloads are currently available only for x86_64
         self.platform = platform.machine()
@@ -196,13 +194,12 @@ if __name__ == "__main__":
         help="FDB build directory",
         required=True,
     )
-    parser.add_argument(
-        "--source-dir",
-        "-s",
-        metavar="SOURCE_DIRECTORY",
-        help="FDB source directory",
-        required=True,
-    )
+    parser.add_argument('--unit-tests-bin', type=str,
+                        help='Path to the fdb_c_shim_unit_tests executable.')
+    parser.add_argument('--api-tester-bin', type=str,
+                        help='Path to the fdb_c_shim_api_tester executable.')
+    parser.add_argument('--api-test-dir', type=str,
+                        help='Path to a directory with api test definitions.')
     args = parser.parse_args()
     test = FdbCShimTests(args)
     test.run_tests()

--- a/contrib/ctest_to_joshua.py
+++ b/contrib/ctest_to_joshua.py
@@ -119,6 +119,7 @@ Unknown arguments are forwarded to ctest, so you may use -R to filter tests e.g.
     joshua_builder.add_arg(os.path.join(args.build_dir, "bin/fdbcli"))
     joshua_builder.add_arg(os.path.join(args.build_dir, "bin/fdbmonitor"))
     joshua_builder.add_arg(os.path.join(args.build_dir, "bin/fdbserver"))
+    joshua_builder.add_arg(os.path.join(args.build_dir, "bin/mkcert"))
     if platform.system() == "Darwin":
         joshua_builder.add_arg(os.path.join(args.build_dir, "lib/libfdb_c.dylib"))
     else:

--- a/contrib/ctest_to_joshua.py
+++ b/contrib/ctest_to_joshua.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 from argparse import ArgumentParser
 import glob
 import io
@@ -31,11 +33,15 @@ class JoshuaBuilder:
         if os.path.exists(arg):
             if not os.path.relpath(arg, self.build_dir).startswith(".."):
                 relpath = "build/" + os.path.relpath(arg, self.build_dir)
-                self.files[arg] = relpath
+                # Avoid packaging the full build directory.
+                if relpath != "build/.":
+                    self.files[arg] = relpath
                 return relpath
             elif not os.path.relpath(arg, self.src_dir).startswith(".."):
                 relpath = "src/" + os.path.relpath(arg, self.src_dir)
-                self.files[arg] = relpath
+                # Avoid packaging the full source directory.
+                if relpath != "src/.":
+                    self.files[arg] = relpath
                 return relpath
             elif os.access(arg, os.X_OK):
                 # Hope it's on the path
@@ -61,8 +67,7 @@ class JoshuaBuilder:
     def write_tarball(self, output, joshua_test):
         with tarfile.open(output, "w:gz") as tar:
             for file, arcfile in self.files.items():
-                if not os.path.isdir(file):
-                    self._add_file(tar, file, arcfile)
+                self._add_file(tar, file, arcfile)
             tarinfo = tarfile.TarInfo("joshua_test")
             tarinfo.mode = 0o755
             joshua_bytes = joshua_test.encode("utf-8")


### PR DESCRIPTION
* Package inferred directories to the resulting tarball in ctest_to_joshua (except for the root source and build directories). This allows the API tests (which specify the workloads as a directory containing the workload specification files) to now work. 
* Add bin/mkcert which is used by some tests.
* Rewrite fdb_c_shim_tests.py to specify its dependencies on command line. 

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
