### PR TITLE
Conditional on context.isSampled in Span operator=().

### DIFF
--- a/fdbclient/Tracing.actor.cpp
+++ b/fdbclient/Tracing.actor.cpp
@@ -441,7 +441,7 @@ void openTracer(TracerType type) {
 ITracer::~ITracer() {}
 
 Span& Span::operator=(Span&& o) {
-	if (begin > 0.0 && o.context.isSampled() > 0) {
+	if (begin > 0.0 && context.isSampled()) {
 		end = g_network->now();
 		g_tracer->trace(*this);
 	}


### PR DESCRIPTION
In the `operator=` overload we need to check if the current span that is being
overwritten is eligible for serialization. If so we must send to the tracer
via the `g_tracer->trace(*this)` call. Previously we were incorrectly checking
the function argument `o`'s context for sampling. This resulted in lost traces
for the `NAPI:readVersionBatcher` spans.

Unit tested, Correctness tested, and manually verified using OTEL distributed tracing collector.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
