### PR TITLE
Use a more standard encoding in the JSON metadata reported for tenants

### DIFF
--- a/bindings/python/tests/fdbcli_tests.py
+++ b/bindings/python/tests/fdbcli_tests.py
@@ -628,6 +628,9 @@ def tenants(logger):
     assert(len(json_output['tenant']) == 2)
     assert('id' in json_output['tenant'])
     assert('prefix' in json_output['tenant'])
+    assert(len(json_output['tenant']['prefix']) == 2)
+    assert('base64' in json_output['tenant']['prefix'])
+    assert('printable' in json_output['tenant']['prefix'])
 
     output = run_fdbcli_command('usetenant')
     assert output == 'Using the default tenant'

--- a/bindings/python/tests/tenant_tests.py
+++ b/bindings/python/tests/tenant_tests.py
@@ -21,6 +21,7 @@
 import fdb
 import sys
 import json
+import base64
 from fdb.tuple import pack
 
 if __name__ == '__main__':
@@ -65,11 +66,11 @@ def test_tenant_operations(db):
 
     t1_entry = tenant_list[0].value
     t1_json = json.loads(t1_entry)
-    p1 = t1_json['prefix'].encode('utf8')
+    p1 = base64.b64decode(t1_json['prefix']['base64'])
 
     t2_entry = tenant_list[1].value
     t2_json = json.loads(t2_entry)
-    p2 = t2_json['prefix'].encode('utf8')
+    p2 = base64.b64decode(t2_json['prefix']['base64'])
 
     tenant1 = db.open_tenant(b'tenant1')
     tenant2 = db.open_tenant(b'tenant2')
@@ -80,12 +81,12 @@ def test_tenant_operations(db):
 
     tenant1_entry = db[b'\xff\xff/management/tenant/map/tenant1']
     tenant1_json = json.loads(tenant1_entry)
-    prefix1 = tenant1_json['prefix'].encode('utf8')
+    prefix1 = base64.b64decode(tenant1_json['prefix']['base64'])
     assert prefix1 == p1
 
     tenant2_entry = db[b'\xff\xff/management/tenant/map/tenant2']
     tenant2_json = json.loads(tenant2_entry)
-    prefix2 = tenant2_json['prefix'].encode('utf8')
+    prefix2 = base64.b64decode(tenant2_json['prefix']['base64'])
     assert prefix2 == p2
 
     assert tenant1[b'tenant_test_key'] == b'tenant1'

--- a/documentation/sphinx/source/command-line-interface.rst
+++ b/documentation/sphinx/source/command-line-interface.rst
@@ -241,7 +241,10 @@ Included in the output of this command are the ``id`` and ``prefix`` assigned to
     {
         "tenant": {
             "id": 0,
-            "prefix": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
+            "prefix": {
+              "base64": "AAAAAAAAAAU=",
+              "printable": "\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x05",
+            }
         },
         "type": "success"
     }

--- a/fdbcli/TenantCommands.actor.cpp
+++ b/fdbcli/TenantCommands.actor.cpp
@@ -210,7 +210,7 @@ CommandFactory listTenantsFactory(
                 "The number of tenants to print can be specified using the [LIMIT] parameter, which defaults to 100."));
 
 // gettenant command
-ACTOR Future<bool> getTenantCommandActor(Reference<IDatabase> db, std::vector<StringRef> tokens) {
+ACTOR Future<bool> getTenantCommandActor(Reference<IDatabase> db, std::vector<StringRef> tokens, int apiVersion) {
 	if (tokens.size() < 2 || tokens.size() > 3 || (tokens.size() == 3 && tokens[2] != "JSON"_sr)) {
 		printUsage(tokens[0]);
 		return false;
@@ -243,11 +243,16 @@ ACTOR Future<bool> getTenantCommandActor(Reference<IDatabase> db, std::vector<St
 
 				int64_t id;
 				std::string prefix;
+
 				doc.get("id", id);
-				doc.get("prefix", prefix);
+				if (apiVersion >= 720) {
+					doc.get("prefix.printable", prefix);
+				} else {
+					doc.get("prefix", prefix);
+				}
 
 				printf("  id: %" PRId64 "\n", id);
-				printf("  prefix: %s\n", printable(prefix).c_str());
+				printf("  prefix: %s\n", prefix.c_str());
 			}
 
 			return true;

--- a/fdbcli/fdbcli.actor.cpp
+++ b/fdbcli/fdbcli.actor.cpp
@@ -882,7 +882,7 @@ struct CLIOptions {
 	std::vector<std::pair<std::string, std::string>> knobs;
 
 	// api version, using the latest version by default
-	int api_version = FDB_API_VERSION;
+	int apiVersion = FDB_API_VERSION;
 
 	CLIOptions(int argc, char* argv[]) {
 		program_name = argv[0];
@@ -927,11 +927,11 @@ struct CLIOptions {
 			break;
 		case OPT_API_VERSION: {
 			char* endptr;
-			api_version = strtoul((char*)args.OptionArg(), &endptr, 10);
+			apiVersion = strtoul((char*)args.OptionArg(), &endptr, 10);
 			if (*endptr != '\0') {
 				fprintf(stderr, "ERROR: invalid client version %s\n", args.OptionArg());
 				return 1;
-			} else if (api_version < 700 || api_version > FDB_API_VERSION) {
+			} else if (apiVersion < 700 || apiVersion > FDB_API_VERSION) {
 				// multi-version fdbcli only available after 7.0
 				fprintf(stderr,
 				        "ERROR: api version %s is not supported. (Min: 700, Max: %d)\n",
@@ -1113,7 +1113,7 @@ ACTOR Future<int> cli(CLIOptions opt, LineNoise* plinenoise) {
 	TraceEvent::setNetworkThread();
 
 	try {
-		localDb = Database::createDatabase(ccf, opt.api_version, IsInternal::False);
+		localDb = Database::createDatabase(ccf, opt.apiVersion, IsInternal::False);
 		if (!opt.exec.present()) {
 			printf("Using cluster file `%s'.\n", ccf->getLocation().c_str());
 		}
@@ -1934,7 +1934,7 @@ ACTOR Future<int> cli(CLIOptions opt, LineNoise* plinenoise) {
 				}
 
 				if (tokencmp(tokens[0], "gettenant")) {
-					bool _result = wait(makeInterruptable(getTenantCommandActor(db, tokens)));
+					bool _result = wait(makeInterruptable(getTenantCommandActor(db, tokens, opt.apiVersion)));
 					if (!_result)
 						is_error = true;
 					continue;
@@ -2171,7 +2171,7 @@ int main(int argc, char** argv) {
 	}
 
 	try {
-		API->selectApiVersion(opt.api_version);
+		API->selectApiVersion(opt.apiVersion);
 		API->setupNetwork();
 		opt.setupKnobs();
 		if (opt.exit_code != -1) {

--- a/fdbcli/include/fdbcli/fdbcli.actor.h
+++ b/fdbcli/include/fdbcli/fdbcli.actor.h
@@ -185,7 +185,7 @@ ACTOR Future<bool> fileConfigureCommandActor(Reference<IDatabase> db,
 // force_recovery_with_data_loss command
 ACTOR Future<bool> forceRecoveryWithDataLossCommandActor(Reference<IDatabase> db, std::vector<StringRef> tokens);
 // gettenant command
-ACTOR Future<bool> getTenantCommandActor(Reference<IDatabase> db, std::vector<StringRef> tokens);
+ACTOR Future<bool> getTenantCommandActor(Reference<IDatabase> db, std::vector<StringRef> tokens, int apiVersion);
 // include command
 ACTOR Future<bool> includeCommandActor(Reference<IDatabase> db, std::vector<StringRef> tokens);
 // kill command

--- a/fdbclient/include/fdbclient/libb64/decode.h
+++ b/fdbclient/include/fdbclient/libb64/decode.h
@@ -48,6 +48,14 @@ struct decoder {
 		delete[] code;
 		delete[] plaintext;
 	}
+
+	static std::string from_string(std::string s) {
+		std::stringstream in(s);
+		std::stringstream out;
+		decoder dec;
+		dec.decode(in, out);
+		return out.str();
+	}
 };
 
 } // namespace base64


### PR DESCRIPTION
The previous encoded used raw bytes presented as a unicode string, but this could is not standard and could not be decoded by some JSON libraries.

Now, the prefix is presented as an object with two fields: a base64 encoding of the binary string and a printable representation.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
