### PR TITLE
Add support for returning a more flag from key backed types' range reads

### DIFF
--- a/fdbclient/FileBackupAgent.actor.cpp
+++ b/fdbclient/FileBackupAgent.actor.cpp
@@ -123,9 +123,9 @@ ACTOR Future<std::vector<KeyBackedTag>> TagUidMap::getAll_impl(TagUidMap* tagsMa
                                                                Reference<ReadYourWritesTransaction> tr,
                                                                Snapshot snapshot) {
 	state Key prefix = tagsMap->prefix; // Copying it here as tagsMap lifetime is not tied to this actor
-	TagMap::PairsType tagPairs = wait(tagsMap->getRange(tr, std::string(), {}, 1e6, snapshot));
+	TagMap::RangeResultType tagPairs = wait(tagsMap->getRange(tr, std::string(), {}, 1e6, snapshot));
 	std::vector<KeyBackedTag> results;
-	for (auto& p : tagPairs)
+	for (auto& p : tagPairs.results)
 		results.push_back(KeyBackedTag(p.first, prefix));
 	return results;
 }
@@ -1564,18 +1564,22 @@ struct BackupSnapshotDispatchTask : BackupTaskFuncBase {
 				tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
 				tr->setOption(FDBTransactionOptions::LOCK_AWARE);
 
-				state Future<std::vector<std::pair<Key, bool>>> bounds = config.snapshotRangeDispatchMap().getRange(
-				    tr, beginKey, keyAfter(normalKeys.end), CLIENT_KNOBS->TOO_MANY);
+				state Future<BackupConfig::RangeDispatchMapT::RangeResultType> bounds =
+				    config.snapshotRangeDispatchMap().getRange(
+				        tr, beginKey, keyAfter(normalKeys.end), CLIENT_KNOBS->TOO_MANY);
 				wait(success(bounds) && taskBucket->keepRunning(tr, task) &&
 				     store(recentReadVersion, tr->getReadVersion()));
 
-				if (bounds.get().empty())
+				if (!bounds.get().results.empty()) {
+					dispatchBoundaries.reserve(dispatchBoundaries.size() + bounds.get().results.size());
+					dispatchBoundaries.insert(
+					    dispatchBoundaries.end(), bounds.get().results.begin(), bounds.get().results.end());
+				}
+
+				if (!bounds.get().more)
 					break;
 
-				dispatchBoundaries.reserve(dispatchBoundaries.size() + bounds.get().size());
-				dispatchBoundaries.insert(dispatchBoundaries.end(), bounds.get().begin(), bounds.get().end());
-
-				beginKey = keyAfter(bounds.get().back().first);
+				beginKey = keyAfter(bounds.get().results.back().first);
 				tr->reset();
 			} catch (Error& e) {
 				wait(tr->onError(e));
@@ -2543,17 +2547,17 @@ struct BackupSnapshotManifest : BackupTaskFuncBase {
 					wait(store(bc, config.backupContainer().getOrThrow(tr)));
 				}
 
-				BackupConfig::RangeFileMapT::PairsType rangeresults =
+				BackupConfig::RangeFileMapT::RangeResultType rangeresults =
 				    wait(config.snapshotRangeFileMap().getRange(tr, startKey, {}, batchSize));
 
-				for (auto& p : rangeresults) {
+				for (auto& p : rangeresults.results) {
 					localmap.insert(p);
 				}
 
-				if (rangeresults.size() < batchSize)
+				if (!rangeresults.more)
 					break;
 
-				startKey = keyAfter(rangeresults.back().first);
+				startKey = keyAfter(rangeresults.results.back().first);
 				tr->reset();
 			} catch (Error& e) {
 				wait(tr->onError(e));
@@ -3617,7 +3621,7 @@ struct RestoreDispatchTaskFunc : RestoreTaskFuncBase {
 		// Get a batch of files.  We're targeting batchSize blocks being dispatched so query for batchSize files (each
 		// of which is 0 or more blocks).
 		state int taskBatchSize = BUGGIFY ? 1 : CLIENT_KNOBS->RESTORE_DISPATCH_ADDTASK_SIZE;
-		state RestoreConfig::FileSetT::Values files = wait(restore.fileSet().getRange(
+		state RestoreConfig::FileSetT::RangeResultType files = wait(restore.fileSet().getRange(
 		    tr, Optional<RestoreConfig::RestoreFile>({ beginVersion, beginFile }), {}, taskBatchSize));
 
 		// allPartsDone will be set once all block tasks in the current batch are finished.
@@ -3636,7 +3640,7 @@ struct RestoreDispatchTaskFunc : RestoreTaskFuncBase {
 		}
 
 		// If there were no files to load then this batch is done and restore is almost done.
-		if (files.size() == 0) {
+		if (files.results.size() == 0) {
 			// If adding to existing batch then blocks could be in progress so create a new Dispatch task that waits for
 			// them to finish
 			if (addingToExistingBatch) {
@@ -3714,13 +3718,13 @@ struct RestoreDispatchTaskFunc : RestoreTaskFuncBase {
 		// blocks per Dispatch task and target batchSize total per batch but a batch must end on a complete version
 		// boundary so exceed the limit if necessary to reach the end of a version of files.
 		state std::vector<Future<Key>> addTaskFutures;
-		state Version endVersion = files[0].version;
+		state Version endVersion = files.results[0].version;
 		state int blocksDispatched = 0;
 		state int64_t beginBlock = Params.beginBlock().getOrDefault(task);
 		state int i = 0;
 
-		for (; i < files.size(); ++i) {
-			RestoreConfig::RestoreFile& f = files[i];
+		for (; i < files.results.size(); ++i) {
+			RestoreConfig::RestoreFile& f = files.results[i];
 
 			// Here we are "between versions" (prior to adding the first block of the first file of a new version) so
 			// this is an opportunity to end the current dispatch batch (which must end on a version boundary) if the
@@ -5057,11 +5061,11 @@ public:
 						doc.setKey("CurrentSnapshot", snapshot);
 					}
 
-					KeyBackedMap<int64_t, std::pair<std::string, Version>>::PairsType errors =
+					KeyBackedMap<int64_t, std::pair<std::string, Version>>::RangeResultType errors =
 					    wait(config.lastErrorPerType().getRange(
 					        tr, 0, std::numeric_limits<int>::max(), CLIENT_KNOBS->TOO_MANY));
 					JsonBuilderArray errorList;
-					for (auto& e : errors) {
+					for (auto& e : errors.results) {
 						std::string msg = e.second.first;
 						Version ver = e.second.second;
 
@@ -5209,13 +5213,13 @@ public:
 
 					// Append the errors, if requested
 					if (showErrors) {
-						KeyBackedMap<int64_t, std::pair<std::string, Version>>::PairsType errors =
+						KeyBackedMap<int64_t, std::pair<std::string, Version>>::RangeResultType errors =
 						    wait(config.lastErrorPerType().getRange(
 						        tr, 0, std::numeric_limits<int>::max(), CLIENT_KNOBS->TOO_MANY));
 						std::string recentErrors;
 						std::string pastErrors;
 
-						for (auto& e : errors) {
+						for (auto& e : errors.results) {
 							Version v = e.second.second;
 							std::string msg = format(
 							    "%s ago : %s\n",

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -7948,7 +7948,8 @@ ACTOR Future<std::vector<std::pair<UID, StorageWiggleValue>>> readStorageWiggleV
 	state KeyBackedObjectMap<UID, StorageWiggleValue, decltype(IncludeVersion())> metadataMap(readKey,
 	                                                                                          IncludeVersion());
 	state Reference<ReadYourWritesTransaction> tr(new ReadYourWritesTransaction(cx));
-	state std::vector<std::pair<UID, StorageWiggleValue>> res;
+	state KeyBackedRangeResult<std::pair<UID, StorageWiggleValue>> res;
+
 	// read the wiggling pairs
 	loop {
 		try {
@@ -7964,7 +7965,7 @@ ACTOR Future<std::vector<std::pair<UID, StorageWiggleValue>>> readStorageWiggleV
 			wait(tr->onError(e));
 		}
 	}
-	return res;
+	return res.results;
 }
 
 ACTOR Future<Void> splitStorageMetricsStream(PromiseStream<Key> resultStream,

--- a/fdbserver/TSSMappingUtil.actor.cpp
+++ b/fdbserver/TSSMappingUtil.actor.cpp
@@ -26,14 +26,15 @@
 ACTOR Future<Void> readTSSMappingRYW(Reference<ReadYourWritesTransaction> tr,
                                      std::map<UID, StorageServerInterface>* tssMapping) {
 	KeyBackedMap<UID, UID> tssMapDB = KeyBackedMap<UID, UID>(tssMappingKeys.begin);
-	state std::vector<std::pair<UID, UID>> uidMapping =
+	state KeyBackedMap<UID, UID>::RangeResultType uidMapping =
 	    wait(tssMapDB.getRange(tr, UID(), Optional<UID>(), CLIENT_KNOBS->TOO_MANY));
-	ASSERT(uidMapping.size() < CLIENT_KNOBS->TOO_MANY);
+	ASSERT(uidMapping.results.size() < CLIENT_KNOBS->TOO_MANY);
 
 	state std::map<UID, StorageServerInterface> mapping;
-	for (auto& it : uidMapping) {
-		state UID ssId = it.first;
-		Optional<Value> v = wait(tr->get(serverListKeyFor(it.second)));
+	state std::vector<std::pair<UID, UID>>::iterator mapItr;
+	for (mapItr = uidMapping.results.begin(); mapItr != uidMapping.results.end(); ++mapItr) {
+		state UID ssId = mapItr->first;
+		Optional<Value> v = wait(tr->get(serverListKeyFor(mapItr->second)));
 		(*tssMapping)[ssId] = decodeServerListValue(v.get());
 	}
 	return Void();

--- a/fdbserver/workloads/TimeKeeperCorrectness.actor.cpp
+++ b/fdbserver/workloads/TimeKeeperCorrectness.actor.cpp
@@ -79,23 +79,23 @@ struct TimeKeeperCorrectnessWorkload : TestWorkload {
 				tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
 				tr->setOption(FDBTransactionOptions::LOCK_AWARE);
 
-				std::vector<std::pair<int64_t, Version>> allItems =
+				KeyBackedRangeResult<std::pair<int64_t, Version>> allItems =
 				    wait(dbTimeKeeper.getRange(tr, 0, Optional<int64_t>(), self->inMemTimeKeeper.size() + 2));
 
-				if (allItems.size() > SERVER_KNOBS->TIME_KEEPER_MAX_ENTRIES + 1) {
+				if (allItems.results.size() > SERVER_KNOBS->TIME_KEEPER_MAX_ENTRIES + 1) {
 					TraceEvent(SevError, "TKCorrectness_TooManyEntries")
 					    .detail("Expected", SERVER_KNOBS->TIME_KEEPER_MAX_ENTRIES + 1)
-					    .detail("Found", allItems.size());
+					    .detail("Found", allItems.results.size());
 					return false;
 				}
 
-				if (allItems.size() < self->testDuration / SERVER_KNOBS->TIME_KEEPER_DELAY) {
+				if (allItems.results.size() < self->testDuration / SERVER_KNOBS->TIME_KEEPER_DELAY) {
 					TraceEvent(SevWarnAlways, "TKCorrectness_TooFewEntries")
 					    .detail("Expected", self->testDuration / SERVER_KNOBS->TIME_KEEPER_DELAY)
-					    .detail("Found", allItems.size());
+					    .detail("Found", allItems.results.size());
 				}
 
-				for (auto item : allItems) {
+				for (auto item : allItems.results) {
 					auto it = self->inMemTimeKeeper.lower_bound(item.first);
 					if (it == self->inMemTimeKeeper.end()) {
 						continue;


### PR DESCRIPTION
This returns a struct from range reads in key-backed types that includes both the results and a boolean more flag.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
