### PR TITLE
Adding rocksdb compression and data size stats

### DIFF
--- a/fdbserver/KeyValueStoreRocksDB.actor.cpp
+++ b/fdbserver/KeyValueStoreRocksDB.actor.cpp
@@ -740,7 +740,8 @@ ACTOR Future<Void> rocksDBMetricLogger(UID id,
                                        std::shared_ptr<PerfContextMetrics> perfContextMetrics,
                                        rocksdb::DB* db,
                                        std::shared_ptr<ReadIteratorPool> readIterPool,
-                                       Counters* counters) {
+                                       Counters* counters,
+                                       CF cf) {
 	state std::vector<std::tuple<const char*, uint32_t, uint64_t>> tickerStats = {
 		{ "StallMicros", rocksdb::STALL_MICROS, 0 },
 		{ "BytesRead", rocksdb::BYTES_READ, 0 },
@@ -778,7 +779,7 @@ ACTOR Future<Void> rocksDBMetricLogger(UID id,
 		{ "CountIterSkippedKeys", rocksdb::NUMBER_ITER_SKIP, 0 },
 
 	};
-	state std::vector<std::pair<const char*, std::string>> propertyStats = {
+	state std::vector<std::pair<const char*, std::string>> intPropertyStats = {
 		{ "NumImmutableMemtables", rocksdb::DB::Properties::kNumImmutableMemTable },
 		{ "NumImmutableMemtablesFlushed", rocksdb::DB::Properties::kNumImmutableMemTableFlushed },
 		{ "IsMemtableFlushPending", rocksdb::DB::Properties::kMemTableFlushPending },
@@ -806,6 +807,14 @@ ACTOR Future<Void> rocksDBMetricLogger(UID id,
 		{ "LiveSstFilesSize", rocksdb::DB::Properties::kLiveSstFilesSize },
 	};
 
+	state std::vector<std::pair<const char*, std::string>> strPropertyStats = {
+		{ "LevelStats", rocksdb::DB::Properties::kLevelStats },
+	};
+
+	state std::vector<std::pair<const char*, std::string>> levelStrPropertyStats = {
+		{ "CompressionRatioAtLevel", rocksdb::DB::Properties::kCompressionRatioAtLevelPrefix },
+	};
+
 	state std::unordered_map<std::string, uint64_t> readIteratorPoolStats = {
 		{ "NumReadIteratorsCreated", 0 },
 		{ "NumTimesReadIteratorsReused", 0 },
@@ -815,19 +824,38 @@ ACTOR Future<Void> rocksDBMetricLogger(UID id,
 		wait(delay(SERVER_KNOBS->ROCKSDB_METRICS_DELAY));
 		TraceEvent e("RocksDBMetrics", id);
 		uint64_t stat;
-		for (auto& t : tickerStats) {
-			auto& [name, ticker, cum] = t;
+		for (auto& [name, ticker, cum] : tickerStats) {
 			stat = statistics->getTickerCount(ticker);
 			e.detail(name, stat - cum);
 			cum = stat;
 		}
 
-		for (auto& p : propertyStats) {
-			auto& [name, property] = p;
+		for (const auto& [name, property] : intPropertyStats) {
 			stat = 0;
 			// GetAggregatedIntProperty gets the aggregated int property from all column families.
 			ASSERT(db->GetAggregatedIntProperty(property, &stat));
 			e.detail(name, stat);
+		}
+
+		std::string propValue;
+		for (const auto& [name, property] : strPropertyStats) {
+			propValue = "";
+			ASSERT(db->GetProperty(cf, property, &propValue));
+			e.detail(name, propValue);
+		}
+
+		rocksdb::ColumnFamilyMetaData cf_meta_data;
+		db->GetColumnFamilyMetaData(cf, &cf_meta_data);
+		int numLevels = static_cast<int>(cf_meta_data.levels.size());
+		std::string levelProp;
+		for (const auto& [name, property] : levelStrPropertyStats) {
+			levelProp = "";
+			for (int level = 0; level < numLevels; level++) {
+				propValue = "";
+				ASSERT(db->GetProperty(cf, property + std::to_string(level), &propValue));
+				levelProp += std::to_string(level) + ":" + propValue + (level == numLevels - 1 ? "" : ",");
+			}
+			e.detail(name, levelProp);
 		}
 
 		stat = readIterPool->numReadIteratorsCreated();
@@ -983,13 +1011,13 @@ struct RocksDBKeyValueStore : IKeyValueStore {
 				// The current thread and main thread are same when the code runs in simulation.
 				// blockUntilReady() is getting the thread into deadlock state, so directly calling
 				// the metricsLogger.
-				a.metrics =
-				    rocksDBMetricLogger(id, options.statistics, perfContextMetrics, db, readIterPool, &a.counters) &&
-				    flowLockLogger(id, a.readLock, a.fetchLock) && refreshReadIteratorPool(readIterPool);
+				a.metrics = rocksDBMetricLogger(
+				                id, options.statistics, perfContextMetrics, db, readIterPool, &a.counters, cf) &&
+				            flowLockLogger(id, a.readLock, a.fetchLock) && refreshReadIteratorPool(readIterPool);
 			} else {
 				onMainThread([&] {
 					a.metrics = rocksDBMetricLogger(
-					                id, options.statistics, perfContextMetrics, db, readIterPool, &a.counters) &&
+					                id, options.statistics, perfContextMetrics, db, readIterPool, &a.counters, cf) &&
 					            flowLockLogger(id, a.readLock, a.fetchLock) && refreshReadIteratorPool(readIterPool);
 					return Future<bool>(true);
 				}).blockUntilReady();


### PR DESCRIPTION
Cherrypick #7551

Adding rocksdb compression and data size stats.

Test output:
"LevelStats":"Level Files Size(MB)\x0a--------------------\x0a 0 2 502\x0a 1 0 0\x0a 2 0 0\x0a 3 0 0\x0a 4 15 891\x0a 5 37 2101\x0a 6 206 12226\x0a",
"CompressionRatioAtLevel":"0:1.010337,1:-1.000000,2:-1.000000,3:-1.000000,4:1.011170,5:1.013587,6:1.012863,"

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
