### PR TITLE
Validate subrange reads in simulation

### DIFF
--- a/fdbclient/SpecialKeySpace.actor.cpp
+++ b/fdbclient/SpecialKeySpace.actor.cpp
@@ -781,12 +781,12 @@ Future<RangeResult> ConflictingKeysImpl::getRange(ReadYourWritesTransaction* ryw
 		auto beginIter = krMapPtr->rangeContaining(kr.begin);
 		auto endIter = krMapPtr->rangeContaining(kr.end);
 
-		if (beginIter->begin() != kr.begin)
+		if (!kr.contains(beginIter->begin()) && beginIter != endIter)
 			++beginIter;
 		for (auto it = beginIter; it != endIter; ++it) {
 			result.push_back_deep(result.arena(), KeyValueRef(it->begin(), it->value()));
 		}
-		if (endIter->begin() != kr.end)
+		if (kr.contains(endIter->begin()))
 			result.push_back_deep(result.arena(), KeyValueRef(endIter->begin(), endIter->value()));
 	}
 	return result;
@@ -1856,7 +1856,7 @@ void CoordinatorsImpl::clear(ReadYourWritesTransaction* ryw, const KeyRef& key) 
 	    ryw, "coordinators", "Clear operation is meaningless thus forbidden for coordinators");
 }
 
-CoordinatorsAutoImpl::CoordinatorsAutoImpl(KeyRangeRef kr) : SpecialKeyRangeReadImpl(kr) {}
+CoordinatorsAutoImpl::CoordinatorsAutoImpl(KeyRangeRef kr) : SpecialKeyRangeAsyncImpl(kr) {}
 
 ACTOR static Future<RangeResult> CoordinatorsAutoImplActor(ReadYourWritesTransaction* ryw, KeyRangeRef kr) {
 	state RangeResult res;

--- a/fdbclient/SpecialKeySpace.actor.cpp
+++ b/fdbclient/SpecialKeySpace.actor.cpp
@@ -2784,6 +2784,8 @@ ACTOR Future<Void> validateSpecialSubrangeRead(ReadYourWritesTransaction* ryw,
 	// Generate expected result. Linear time is ok here since we're in simulation, and there's a benefit to keeping this
 	// simple (as we're using it as an test oracle)
 	state RangeResult expectedResult;
+	// The reverse parameter should be the same as for the original read, so if
+	// reverse is true then the results are _already_ in reverse order.
 	for (const auto& kr : result) {
 		if (kr.key >= keys[0] && kr.key < keys[1]) {
 			expectedResult.push_back(expectedResult.arena(), kr);

--- a/fdbclient/SpecialKeySpace.actor.cpp
+++ b/fdbclient/SpecialKeySpace.actor.cpp
@@ -314,103 +314,13 @@ ACTOR Future<RangeResult> SpecialKeySpace::checkRYWValid(SpecialKeySpace* sks,
                                                          GetRangeLimits limits,
                                                          Reverse reverse) {
 	ASSERT(ryw);
-	Future<RangeResult> resultFuture =
-	    g_network->isSimulated() && deterministicRandom()->coinflip()
-	        ? SpecialKeySpace::getRangeAndValidate(sks, ryw, begin, end, limits, reverse)
-	        : SpecialKeySpace::getRangeAggregationActor(sks, ryw, begin, end, limits, reverse);
 	choose {
-		when(RangeResult result = wait(resultFuture)) { return result; }
+		when(RangeResult result =
+		         wait(SpecialKeySpace::getRangeAggregationActor(sks, ryw, begin, end, limits, reverse))) {
+			return result;
+		}
 		when(wait(ryw->resetFuture())) { throw internal_error(); }
 	}
-}
-
-ACTOR Future<RangeResult> SpecialKeySpace::getRangeAndValidate(SpecialKeySpace* sks,
-                                                               ReadYourWritesTransaction* ryw,
-                                                               KeySelector begin,
-                                                               KeySelector end,
-                                                               GetRangeLimits limits,
-                                                               Reverse reverse) {
-	// As long as we supply the same cache, we should be able to read subranges and get the expected results.
-	state Optional<RangeResult> localCache;
-
-	state RangeResult result =
-	    wait(SpecialKeySpace::getRangeAggregationActor(sks, ryw, begin, end, limits, reverse, &localCache));
-
-	if (!result.size()) {
-		RangeResult result2 =
-		    wait(SpecialKeySpace::getRangeAggregationActor(sks, ryw, begin, end, limits, reverse, &localCache));
-		ASSERT(result == result2);
-		return result;
-	}
-
-	if (reverse) {
-		ASSERT(std::is_sorted(result.begin(), result.end(), KeyValueRef::OrderByKeyBack{}));
-	} else {
-		ASSERT(std::is_sorted(result.begin(), result.end(), KeyValueRef::OrderByKey{}));
-	}
-
-	// Generate a keyrange where we can determine the expected result based solely on the previous readrange, and whose
-	// boundaries may or may not be keys in result.
-	std::vector<Key> candidateKeys;
-	if (reverse) {
-		for (int i = result.size() - 1; i >= 0; --i) {
-			candidateKeys.emplace_back(result[i].key);
-			if (i - 1 >= 0) {
-				candidateKeys.emplace_back(keyBetween(KeyRangeRef(result[i].key, result[i - 1].key)));
-			}
-		}
-	} else {
-		for (int i = 0; i < result.size(); ++i) {
-			candidateKeys.emplace_back(result[i].key);
-			if (i + 1 < result.size()) {
-				candidateKeys.emplace_back(keyBetween(KeyRangeRef(result[i].key, result[i + 1].key)));
-			}
-		}
-	}
-	std::sort(candidateKeys.begin(), candidateKeys.end());
-	int originalSize = candidateKeys.size();
-	// Add more candidate keys so that we might read a range between two adjacent result keys.
-	for (int i = 0; i < originalSize - 1; ++i) {
-		candidateKeys.emplace_back(keyBetween(KeyRangeRef(candidateKeys[i], candidateKeys[i + 1])));
-	}
-	std::vector<Key> keys;
-	keys = { deterministicRandom()->randomChoice(candidateKeys), deterministicRandom()->randomChoice(candidateKeys) };
-	std::sort(keys.begin(), keys.end());
-	state KeySelector testBegin = firstGreaterOrEqual(keys[0]);
-	state KeySelector testEnd = firstGreaterOrEqual(keys[1]);
-
-	// Generate expected result. Linear time is ok here since we're in simulation, and there's a benefit to keeping this
-	// simple (as we're using it as an test oracle)
-	state RangeResult expectedResult;
-	for (const auto& kr : result) {
-		if (kr.key >= keys[0] && kr.key < keys[1]) {
-			expectedResult.push_back(expectedResult.arena(), kr);
-		}
-	}
-
-	// Test
-	RangeResult testResult =
-	    wait(SpecialKeySpace::getRangeAggregationActor(sks, ryw, testBegin, testEnd, limits, reverse, &localCache));
-	if (testResult != expectedResult) {
-		fmt::print("Reverse: {}\n", reverse);
-		fmt::print("Original range: [{}, {})\n", begin.toString(), end.toString());
-		fmt::print("Original result:\n");
-		for (const auto& kr : result) {
-			fmt::print("	{} -> {}\n", kr.key.printable(), kr.value.printable());
-		}
-		fmt::print("Test range: [{}, {})\n", testBegin.getKey().printable(), testEnd.getKey().printable());
-		fmt::print("Expected:\n");
-		for (const auto& kr : expectedResult) {
-			fmt::print("	{} -> {}\n", kr.key.printable(), kr.value.printable());
-		}
-		fmt::print("Got:\n");
-		for (const auto& kr : testResult) {
-			fmt::print("	{} -> {}\n", kr.key.printable(), kr.value.printable());
-		}
-		ASSERT(testResult == expectedResult);
-	}
-
-	return result;
 }
 
 ACTOR Future<RangeResult> SpecialKeySpace::getRangeAggregationActor(SpecialKeySpace* sks,
@@ -418,8 +328,7 @@ ACTOR Future<RangeResult> SpecialKeySpace::getRangeAggregationActor(SpecialKeySp
                                                                     KeySelector begin,
                                                                     KeySelector end,
                                                                     GetRangeLimits limits,
-                                                                    Reverse reverse,
-                                                                    Optional<RangeResult>* cache) {
+                                                                    Reverse reverse) {
 	// This function handles ranges which cover more than one keyrange and aggregates all results
 	// KeySelector, GetRangeLimits and reverse are all handled here
 	state RangeResult result;
@@ -429,26 +338,17 @@ ACTOR Future<RangeResult> SpecialKeySpace::getRangeAggregationActor(SpecialKeySp
 	state int actualEndOffset;
 	state KeyRangeRef moduleBoundary;
 	// used to cache result from potential first read
-	state Optional<RangeResult> localCache;
-	state bool forceUseCache = cache != nullptr;
-	if (!cache) {
-		cache = &localCache;
-	}
+	state Optional<RangeResult> cache;
 
 	if (ryw->specialKeySpaceRelaxed()) {
 		moduleBoundary = sks->range;
 	} else {
 		auto beginIter = sks->getModules().rangeContaining(begin.getKey());
 		if (beginIter->begin() <= end.getKey() && end.getKey() <= beginIter->end()) {
-			if (beginIter->value() == SpecialKeySpace::MODULE::UNKNOWN) {
-				TraceEvent("SpecialKeySpaceNoModuleFound")
-				    .detail("Begin", begin.toString())
-				    .detail("End", end.toString())
-				    .backtrace();
+			if (beginIter->value() == SpecialKeySpace::MODULE::UNKNOWN)
 				throw special_keys_no_module_found();
-			} else {
+			else
 				moduleBoundary = beginIter->range();
-			}
 		} else {
 			TraceEvent(SevInfo, "SpecialKeyCrossModuleRead")
 			    .detail("Begin", begin)
@@ -459,8 +359,8 @@ ACTOR Future<RangeResult> SpecialKeySpace::getRangeAggregationActor(SpecialKeySp
 		}
 	}
 
-	wait(normalizeKeySelectorActor(sks, ryw, &begin, moduleBoundary, &actualBeginOffset, &result, cache));
-	wait(normalizeKeySelectorActor(sks, ryw, &end, moduleBoundary, &actualEndOffset, &result, cache));
+	wait(normalizeKeySelectorActor(sks, ryw, &begin, moduleBoundary, &actualBeginOffset, &result, &cache));
+	wait(normalizeKeySelectorActor(sks, ryw, &end, moduleBoundary, &actualEndOffset, &result, &cache));
 	// Handle all corner cases like what RYW does
 	// return if range inverted
 	if (actualBeginOffset >= actualEndOffset && begin.getKey() >= end.getKey()) {
@@ -485,9 +385,9 @@ ACTOR Future<RangeResult> SpecialKeySpace::getRangeAggregationActor(SpecialKeySp
 			KeyRangeRef kr = iter->range();
 			KeyRef keyStart = kr.contains(begin.getKey()) ? begin.getKey() : kr.begin;
 			KeyRef keyEnd = kr.contains(end.getKey()) ? end.getKey() : kr.end;
-			if (iter->value()->isAsync() && (cache->present() || forceUseCache)) {
+			if (iter->value()->isAsync() && cache.present()) {
 				const SpecialKeyRangeAsyncImpl* ptr = dynamic_cast<const SpecialKeyRangeAsyncImpl*>(iter->value());
-				RangeResult pairs_ = wait(ptr->getRange(ryw, KeyRangeRef(keyStart, keyEnd), limits, cache));
+				RangeResult pairs_ = wait(ptr->getRange(ryw, KeyRangeRef(keyStart, keyEnd), limits, &cache));
 				pairs = pairs_;
 			} else {
 				RangeResult pairs_ = wait(iter->value()->getRange(ryw, KeyRangeRef(keyStart, keyEnd), limits));
@@ -516,9 +416,9 @@ ACTOR Future<RangeResult> SpecialKeySpace::getRangeAggregationActor(SpecialKeySp
 			KeyRangeRef kr = iter->range();
 			KeyRef keyStart = kr.contains(begin.getKey()) ? begin.getKey() : kr.begin;
 			KeyRef keyEnd = kr.contains(end.getKey()) ? end.getKey() : kr.end;
-			if (iter->value()->isAsync() && (cache->present() || forceUseCache)) {
+			if (iter->value()->isAsync() && cache.present()) {
 				const SpecialKeyRangeAsyncImpl* ptr = dynamic_cast<const SpecialKeyRangeAsyncImpl*>(iter->value());
-				RangeResult pairs_ = wait(ptr->getRange(ryw, KeyRangeRef(keyStart, keyEnd), limits, cache));
+				RangeResult pairs_ = wait(ptr->getRange(ryw, KeyRangeRef(keyStart, keyEnd), limits, &cache));
 				pairs = pairs_;
 			} else {
 				RangeResult pairs_ = wait(iter->value()->getRange(ryw, KeyRangeRef(keyStart, keyEnd), limits));
@@ -1856,7 +1756,7 @@ void CoordinatorsImpl::clear(ReadYourWritesTransaction* ryw, const KeyRef& key) 
 	    ryw, "coordinators", "Clear operation is meaningless thus forbidden for coordinators");
 }
 
-CoordinatorsAutoImpl::CoordinatorsAutoImpl(KeyRangeRef kr) : SpecialKeyRangeAsyncImpl(kr) {}
+CoordinatorsAutoImpl::CoordinatorsAutoImpl(KeyRangeRef kr) : SpecialKeyRangeReadImpl(kr) {}
 
 ACTOR static Future<RangeResult> CoordinatorsAutoImplActor(ReadYourWritesTransaction* ryw, KeyRangeRef kr) {
 	state RangeResult res;
@@ -2831,4 +2731,84 @@ Key FailedLocalitiesRangeImpl::encode(const KeyRef& key) const {
 Future<Optional<std::string>> FailedLocalitiesRangeImpl::commit(ReadYourWritesTransaction* ryw) {
 	// exclude locality with failed option as true.
 	return excludeLocalityCommitActor(ryw, true);
+}
+
+ACTOR Future<Void> validateSpecialSubrangeRead(ReadYourWritesTransaction* ryw,
+                                               KeySelector begin,
+                                               KeySelector end,
+                                               GetRangeLimits limits,
+                                               Reverse reverse,
+                                               RangeResult result) {
+	if (!result.size()) {
+		RangeResult testResult = wait(ryw->getRange(begin, end, limits, Snapshot::True, reverse));
+		ASSERT(testResult == result);
+		return Void();
+	}
+
+	if (reverse) {
+		ASSERT(std::is_sorted(result.begin(), result.end(), KeyValueRef::OrderByKeyBack{}));
+	} else {
+		ASSERT(std::is_sorted(result.begin(), result.end(), KeyValueRef::OrderByKey{}));
+	}
+
+	// Generate a keyrange where we can determine the expected result based solely on the previous readrange, and whose
+	// boundaries may or may not be keys in result.
+	std::vector<Key> candidateKeys;
+	if (reverse) {
+		for (int i = result.size() - 1; i >= 0; --i) {
+			candidateKeys.emplace_back(result[i].key);
+			if (i - 1 >= 0) {
+				candidateKeys.emplace_back(keyBetween(KeyRangeRef(result[i].key, result[i - 1].key)));
+			}
+		}
+	} else {
+		for (int i = 0; i < result.size(); ++i) {
+			candidateKeys.emplace_back(result[i].key);
+			if (i + 1 < result.size()) {
+				candidateKeys.emplace_back(keyBetween(KeyRangeRef(result[i].key, result[i + 1].key)));
+			}
+		}
+	}
+	std::sort(candidateKeys.begin(), candidateKeys.end());
+	int originalSize = candidateKeys.size();
+	// Add more candidate keys so that we might read a range between two adjacent result keys.
+	for (int i = 0; i < originalSize - 1; ++i) {
+		candidateKeys.emplace_back(keyBetween(KeyRangeRef(candidateKeys[i], candidateKeys[i + 1])));
+	}
+	std::vector<Key> keys;
+	keys = { deterministicRandom()->randomChoice(candidateKeys), deterministicRandom()->randomChoice(candidateKeys) };
+	std::sort(keys.begin(), keys.end());
+	state KeySelector testBegin = firstGreaterOrEqual(keys[0]);
+	state KeySelector testEnd = firstGreaterOrEqual(keys[1]);
+
+	// Generate expected result. Linear time is ok here since we're in simulation, and there's a benefit to keeping this
+	// simple (as we're using it as an test oracle)
+	state RangeResult expectedResult;
+	for (const auto& kr : result) {
+		if (kr.key >= keys[0] && kr.key < keys[1]) {
+			expectedResult.push_back(expectedResult.arena(), kr);
+		}
+	}
+
+	// Test
+	RangeResult testResult = wait(ryw->getRange(testBegin, testEnd, limits, Snapshot::True, reverse));
+	if (testResult != expectedResult) {
+		fmt::print("Reverse: {}\n", reverse);
+		fmt::print("Original range: [{}, {})\n", begin.toString(), end.toString());
+		fmt::print("Original result:\n");
+		for (const auto& kr : result) {
+			fmt::print("	{} -> {}\n", kr.key.printable(), kr.value.printable());
+		}
+		fmt::print("Test range: [{}, {})\n", testBegin.getKey().printable(), testEnd.getKey().printable());
+		fmt::print("Expected:\n");
+		for (const auto& kr : expectedResult) {
+			fmt::print("	{} -> {}\n", kr.key.printable(), kr.value.printable());
+		}
+		fmt::print("Got:\n");
+		for (const auto& kr : testResult) {
+			fmt::print("	{} -> {}\n", kr.key.printable(), kr.value.printable());
+		}
+		ASSERT(testResult == expectedResult);
+	}
+	return Void();
 }

--- a/fdbclient/include/fdbclient/FDBTypes.h
+++ b/fdbclient/include/fdbclient/FDBTypes.h
@@ -310,7 +310,7 @@ struct KeyRangeRef {
 	KeyRangeRef() {}
 	KeyRangeRef(const KeyRef& begin, const KeyRef& end) : begin(begin), end(end) {
 		if (begin > end) {
-			TraceEvent("InvertedRange").detail("Begin", begin).detail("End", end);
+			TraceEvent("InvertedRange").detail("Begin", begin).detail("End", end).backtrace();
 			throw inverted_range();
 		}
 	}
@@ -366,7 +366,7 @@ struct KeyRangeRef {
 		}
 
 		if (begin > end) {
-			TraceEvent("InvertedRange").detail("Begin", begin).detail("End", end);
+			TraceEvent("InvertedRange").detail("Begin", begin).detail("End", end).backtrace();
 			throw inverted_range();
 		};
 	}

--- a/fdbclient/include/fdbclient/FDBTypes.h
+++ b/fdbclient/include/fdbclient/FDBTypes.h
@@ -310,7 +310,7 @@ struct KeyRangeRef {
 	KeyRangeRef() {}
 	KeyRangeRef(const KeyRef& begin, const KeyRef& end) : begin(begin), end(end) {
 		if (begin > end) {
-			TraceEvent("InvertedRange").detail("Begin", begin).detail("End", end).backtrace();
+			TraceEvent("InvertedRange").detail("Begin", begin).detail("End", end);
 			throw inverted_range();
 		}
 	}
@@ -366,7 +366,7 @@ struct KeyRangeRef {
 		}
 
 		if (begin > end) {
-			TraceEvent("InvertedRange").detail("Begin", begin).detail("End", end).backtrace();
+			TraceEvent("InvertedRange").detail("Begin", begin).detail("End", end);
 			throw inverted_range();
 		};
 	}

--- a/fdbclient/include/fdbclient/SpecialKeySpace.actor.h
+++ b/fdbclient/include/fdbclient/SpecialKeySpace.actor.h
@@ -467,7 +467,7 @@ public:
 	void clear(ReadYourWritesTransaction* ryw, const KeyRef& key) override;
 };
 
-class CoordinatorsAutoImpl : public SpecialKeyRangeReadImpl {
+class CoordinatorsAutoImpl : public SpecialKeyRangeAsyncImpl {
 public:
 	explicit CoordinatorsAutoImpl(KeyRangeRef kr);
 	Future<RangeResult> getRange(ReadYourWritesTransaction* ryw,

--- a/fdbclient/include/fdbclient/SpecialKeySpace.actor.h
+++ b/fdbclient/include/fdbclient/SpecialKeySpace.actor.h
@@ -242,12 +242,19 @@ private:
 	                                               KeySelector end,
 	                                               GetRangeLimits limits,
 	                                               Reverse reverse);
+	ACTOR static Future<RangeResult> getRangeAndValidate(SpecialKeySpace* sks,
+	                                                     ReadYourWritesTransaction* ryw,
+	                                                     KeySelector begin,
+	                                                     KeySelector end,
+	                                                     GetRangeLimits limits,
+	                                                     Reverse reverse);
 	ACTOR static Future<RangeResult> getRangeAggregationActor(SpecialKeySpace* sks,
 	                                                          ReadYourWritesTransaction* ryw,
 	                                                          KeySelector begin,
 	                                                          KeySelector end,
 	                                                          GetRangeLimits limits,
-	                                                          Reverse reverse);
+	                                                          Reverse reverse,
+	                                                          Optional<RangeResult>* cache = nullptr);
 
 	KeyRangeMap<SpecialKeyRangeReadImpl*> readImpls;
 	KeyRangeMap<SpecialKeySpace::MODULE> modules;

--- a/fdbclient/include/fdbclient/SpecialKeySpace.actor.h
+++ b/fdbclient/include/fdbclient/SpecialKeySpace.actor.h
@@ -242,19 +242,12 @@ private:
 	                                               KeySelector end,
 	                                               GetRangeLimits limits,
 	                                               Reverse reverse);
-	ACTOR static Future<RangeResult> getRangeAndValidate(SpecialKeySpace* sks,
-	                                                     ReadYourWritesTransaction* ryw,
-	                                                     KeySelector begin,
-	                                                     KeySelector end,
-	                                                     GetRangeLimits limits,
-	                                                     Reverse reverse);
 	ACTOR static Future<RangeResult> getRangeAggregationActor(SpecialKeySpace* sks,
 	                                                          ReadYourWritesTransaction* ryw,
 	                                                          KeySelector begin,
 	                                                          KeySelector end,
 	                                                          GetRangeLimits limits,
-	                                                          Reverse reverse,
-	                                                          Optional<RangeResult>* cache = nullptr);
+	                                                          Reverse reverse);
 
 	KeyRangeMap<SpecialKeyRangeReadImpl*> readImpls;
 	KeyRangeMap<SpecialKeySpace::MODULE> modules;
@@ -467,7 +460,7 @@ public:
 	void clear(ReadYourWritesTransaction* ryw, const KeyRef& key) override;
 };
 
-class CoordinatorsAutoImpl : public SpecialKeyRangeAsyncImpl {
+class CoordinatorsAutoImpl : public SpecialKeyRangeReadImpl {
 public:
 	explicit CoordinatorsAutoImpl(KeyRangeRef kr);
 	Future<RangeResult> getRange(ReadYourWritesTransaction* ryw,
@@ -545,6 +538,13 @@ public:
 	                             GetRangeLimits limitsHint) const override;
 	Future<Optional<std::string>> commit(ReadYourWritesTransaction* ryw) override;
 };
+
+ACTOR Future<Void> validateSpecialSubrangeRead(ReadYourWritesTransaction* ryw,
+                                               KeySelector begin,
+                                               KeySelector end,
+                                               GetRangeLimits limits,
+                                               Reverse reverse,
+                                               RangeResult result);
 
 #include "flow/unactorcompiler.h"
 #endif

--- a/fdbclient/include/fdbclient/SpecialKeySpace.actor.h
+++ b/fdbclient/include/fdbclient/SpecialKeySpace.actor.h
@@ -539,6 +539,9 @@ public:
 	Future<Optional<std::string>> commit(ReadYourWritesTransaction* ryw) override;
 };
 
+// If the underlying set of key-value pairs of a key space is not changing, then we expect repeating a read to give the
+// same result. Additionally, we can generate the expected result of any read if that read is reading a subrange. This
+// actor performs a read of an arbitrary subrange of [begin, end) and validates the results.
 ACTOR Future<Void> validateSpecialSubrangeRead(ReadYourWritesTransaction* ryw,
                                                KeySelector begin,
                                                KeySelector end,

--- a/fdbserver/workloads/ReportConflictingKeys.actor.cpp
+++ b/fdbserver/workloads/ReportConflictingKeys.actor.cpp
@@ -192,8 +192,15 @@ struct ReportConflictingKeysWorkload : TestWorkload {
 					                LiteralStringRef("\xff\xff").withPrefix(conflictingKeysRange.begin));
 					// The getRange here using the special key prefix "\xff\xff/transaction/conflicting_keys/" happens
 					// locally Thus, the error handling is not needed here
-					Future<RangeResult> conflictingKeyRangesFuture = tr2->getRange(ckr, CLIENT_KNOBS->TOO_MANY);
+					state Future<RangeResult> conflictingKeyRangesFuture = tr2->getRange(ckr, CLIENT_KNOBS->TOO_MANY);
 					ASSERT(conflictingKeyRangesFuture.isReady());
+
+					wait(validateSpecialSubrangeRead(tr2.getPtr(),
+					                                 firstGreaterOrEqual(ckr.begin),
+					                                 firstGreaterOrEqual(ckr.end),
+					                                 GetRangeLimits(),
+					                                 Reverse::False,
+					                                 conflictingKeyRangesFuture.get()));
 
 					tr2 = makeReference<ReadYourWritesTransaction>(cx);
 


### PR DESCRIPTION
We need test coverage of reading subranges within special key space modules, as
there was a bug that could only manifest if you read a subrange of the
conflicting keys module.

- Add a utility that provides validation to special key space subrange reads in simulation
- Fix bugs turned up by validating subrange reads

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
