### PR TITLE
(Snowflake7.1/simulation stream debug) add delayProcess buggify

### DIFF
--- a/fdbrpc/sim2.actor.cpp
+++ b/fdbrpc/sim2.actor.cpp
@@ -1651,11 +1651,11 @@ public:
 		if (process->startingClass == ProcessClass::TesterClass || process != currentProcess ||
 		    process->buggifyDelayCount > 7)
 			return;
-		static double poissonProbs[8] = { 0.3679, 0.3679, 0.1839, 0.0613, 0.0153, 0.0031, 0.0005, 0.0001 };
+		static constexpr double poissonProbs[8] = { 0.3679, 0.3679, 0.1839, 0.0613, 0.0153, 0.0031, 0.0005, 0.0001 };
 		double prob = poissonProbs[process->buggifyDelayCount];
 
 		if (deterministicRandom()->random01() < prob) {
-			double delaySec = deterministicRandom()->random01() * 10.0;
+			double delaySec = deterministicRandom()->random01() * 1.0;
 			TraceEvent("ProcessDelayed")
 			    .detail("ProcessInfo", process->toString())
 			    .detail("DelayFor", delaySec)

--- a/fdbrpc/sim2.actor.cpp
+++ b/fdbrpc/sim2.actor.cpp
@@ -1648,9 +1648,14 @@ public:
 	}
 
 	void delayProcess(ProcessInfo* process) override {
-		if (process->startingClass != ProcessClass::TesterClass && process == currentProcess &&
-		    BUGGIFY_WITH_PROB(0.15) && process->buggifyDelayCount < 3) {
-			double delaySec = deterministicRandom()->random01() * FLOW_KNOBS->MAX_BUGGIFIED_DELAY;
+		if (process->startingClass == ProcessClass::TesterClass || process != currentProcess ||
+		    process->buggifyDelayCount > 7)
+			return;
+		static double poissonProbs[8] = { 0.3679, 0.3679, 0.1839, 0.0613, 0.0153, 0.0031, 0.0005, 0.0001 };
+		double prob = poissonProbs[process->buggifyDelayCount];
+
+		if (deterministicRandom()->random01() < prob) {
+			double delaySec = deterministicRandom()->random01() * 10.0;
 			TraceEvent("ProcessDelayed")
 			    .detail("ProcessInfo", process->toString())
 			    .detail("DelayFor", delaySec)

--- a/fdbrpc/sim2.actor.cpp
+++ b/fdbrpc/sim2.actor.cpp
@@ -208,11 +208,11 @@ struct Sim2Conn final : IConnection, ReferenceCounted<Sim2Conn> {
 		                                      FLOW_KNOBS->MAX_CLOGGING_LATENCY * deterministicRandom()->random01());
 		sendBufSize = std::max<double>(deterministicRandom()->randomInt(0, 5000000), 25e6 * (latency + .002));
 		// options like clogging or bitsflip are disabled for stable connections
-		stableConnection = std::any_of(process->childs.begin(),
-		                               process->childs.end(),
+		stableConnection = std::any_of(process->children.begin(),
+		                               process->children.end(),
 		                               [&](ISimulator::ProcessInfo* child) { return child && child == peerProcess; }) ||
-		                   std::any_of(peerProcess->childs.begin(),
-		                               peerProcess->childs.end(),
+		                   std::any_of(peerProcess->children.begin(),
+		                               peerProcess->children.end(),
 		                               [&](ISimulator::ProcessInfo* child) { return child && child == process; });
 
 		TraceEvent("Sim2Connection")
@@ -409,7 +409,7 @@ private:
 	}
 
 	void rollRandomClose() {
-		// make sure connections between parenta and their childs are not closed
+		// make sure connections between parenta and their children are not closed
 		if (!stableConnection &&
 		    now() - g_simulator.lastConnectionFailure > g_simulator.connectionFailuresDisableDuration &&
 		    deterministicRandom()->random01() < .00001) {
@@ -1648,15 +1648,17 @@ public:
 	}
 
 	void delayProcess(ProcessInfo* process) override {
-		if (process->startingClass == ProcessClass::TesterClass || process != currentProcess ||
-		    process->buggifyDelayCount > 7)
+		if (process->isMachineProcess() || process->startingClass == ProcessClass::TesterClass ||
+		    process != currentProcess || process->buggifyDelayCount > 7)
 			return;
+
 		static constexpr double poissonProbs[8] = { 0.3679, 0.3679, 0.1839, 0.0613, 0.0153, 0.0031, 0.0005, 0.0001 };
 		double prob = poissonProbs[process->buggifyDelayCount];
 
 		if (deterministicRandom()->random01() < prob) {
 			double delaySec = deterministicRandom()->random01() * 1.0;
 			TraceEvent("ProcessDelayed")
+			    .detail("ProcessUID", process->uid)
 			    .detail("ProcessInfo", process->toString())
 			    .detail("DelayFor", delaySec)
 			    .detail("DelayCount", process->buggifyDelayCount);
@@ -2499,7 +2501,7 @@ ACTOR void doReboot(ISimulator::ProcessInfo* p, ISimulator::KillType kt) {
 		} else if (std::string(p->name) == "remote flow process") {
 			TraceEvent(SevDebug, "DoRebootFailed").detail("Name", p->name).detail("Address", p->address);
 			return;
-		} else if (p->getChilds().size()) {
+		} else if (p->getChildren().size()) {
 			TraceEvent(SevDebug, "DoRebootFailedOnParentProcess").detail("Address", p->address);
 			return;
 		}

--- a/fdbrpc/sim2.actor.cpp
+++ b/fdbrpc/sim2.actor.cpp
@@ -1055,20 +1055,12 @@ public:
 	bool checkRunnable() override { return net2->checkRunnable(); }
 
 #ifdef ENABLE_SAMPLING
-	ActorLineageSet& getActorLineageSet() override {
-		return actorLineageSet;
-	}
+	ActorLineageSet& getActorLineageSet() override { return actorLineageSet; }
 #endif
 
-	void stop() override {
-		isStopped = true;
-	}
-	void addStopCallback(std::function<void()> fn) override {
-		stopCallbacks.emplace_back(std::move(fn));
-	}
-	bool isSimulated() const override {
-		return true;
-	}
+	void stop() override { isStopped = true; }
+	void addStopCallback(std::function<void()> fn) override { stopCallbacks.emplace_back(std::move(fn)); }
+	bool isSimulated() const override { return true; }
 
 	struct SimThreadArgs {
 		THREAD_FUNC_RETURN (*func)(void*);
@@ -1213,9 +1205,7 @@ public:
 	}
 
 	// Implement ISimulator interface
-	void run() override {
-		runLoop(this);
-	}
+	void run() override { runLoop(this); }
 	ProcessInfo* newProcess(const char* name,
 	                        IPAddress ip,
 	                        uint16_t port,
@@ -2217,9 +2207,7 @@ public:
 		tasks.push(Task(time, taskID, taskCount++, getCurrentProcess(), std::move(signal)));
 		mutex.leave();
 	}
-	bool isOnMainThread() const override {
-		return net2->isOnMainThread();
-	}
+	bool isOnMainThread() const override { return net2->isOnMainThread(); }
 	Future<Void> onProcess(ISimulator::ProcessInfo* process, TaskPriority taskID) override {
 		return delay(0, taskID, process);
 	}
@@ -2229,9 +2217,7 @@ public:
 		return delay(0, taskID, process->machine->machineProcess);
 	}
 
-	ProtocolVersion protocolVersion() const override {
-		return getCurrentProcess()->protocolVersion;
-	}
+	ProtocolVersion protocolVersion() const override { return getCurrentProcess()->protocolVersion; }
 
 	// time is guarded by ISimulator::mutex. It is not necessary to guard reads on the main thread because
 	// time should only be modified from the main thread.

--- a/fdbrpc/simulator.h
+++ b/fdbrpc/simulator.h
@@ -90,7 +90,7 @@ public:
 
 		ProtocolVersion protocolVersion;
 
-		std::vector<ProcessInfo*> childs;
+		std::vector<ProcessInfo*> children;
 
 		ProcessInfo(const char* name,
 		            LocalityData locality,
@@ -122,7 +122,7 @@ public:
 			   << " fault_injection_p2:" << fault_injection_p2;
 			return ss.str();
 		}
-		std::vector<ProcessInfo*> const& getChilds() const { return childs; }
+		std::vector<ProcessInfo*> const& getChildren() const { return children; }
 
 		// Return true if the class type is suitable for stateful roles, such as tLog and StorageServer.
 		bool isAvailableClass() const {
@@ -167,6 +167,7 @@ public:
 				return false;
 			}
 		}
+		bool isMachineProcess() const { return strcmp(name, "Machine") == 0; }
 
 		Reference<IListener> getListener(const NetworkAddress& addr) const {
 			auto listener = listenerMap.find(addr);

--- a/fdbrpc/simulator.h
+++ b/fdbrpc/simulator.h
@@ -78,6 +78,8 @@ public:
 		bool rebooting;
 		std::vector<flowGlobalType> globals;
 
+		int buggifyDelayCount = 0;
+
 		INetworkConnections* network;
 
 		uint64_t fault_injection_r;

--- a/fdbrpc/simulator.h
+++ b/fdbrpc/simulator.h
@@ -252,6 +252,7 @@ public:
 	virtual void killProcess(ProcessInfo* machine, KillType) = 0;
 	virtual void rebootProcess(Optional<Standalone<StringRef>> zoneId, bool allProcesses) = 0;
 	virtual void rebootProcess(ProcessInfo* process, KillType kt) = 0;
+	virtual void delayProcess(ProcessInfo* process) = 0;
 	virtual void killInterface(NetworkAddress address, KillType) = 0;
 	virtual bool killMachine(Optional<Standalone<StringRef>> machineId,
 	                         KillType kt,

--- a/fdbrpc/simulator.h
+++ b/fdbrpc/simulator.h
@@ -78,7 +78,7 @@ public:
 		bool rebooting;
 		std::vector<flowGlobalType> globals;
 
-		int buggifyDelayCount = 0;
+		uint8_t buggifyDelayCount = 0;
 
 		INetworkConnections* network;
 

--- a/fdbserver/FDBExecHelper.actor.cpp
+++ b/fdbserver/FDBExecHelper.actor.cpp
@@ -187,7 +187,7 @@ ACTOR Future<int> spawnSimulated(std::vector<std::string> paramList,
 			}
 		}
 		if (role == "flowprocess" && !parentShutdown.isReady()) {
-			self->childs.push_back(child);
+			self->children.push_back(child);
 			state Future<Void> parentSSClosed = parent->onClosed();
 			FlowTransport::createInstance(false, 1, WLTOKEN_RESERVED_COUNT);
 			FlowTransport::transport().bind(child->address, child->address);


### PR DESCRIPTION
Delay all the tasks on a process for a while but not change the order.
Have to control the delay count otherwise 1 process might be delayed forever.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
