### PR TITLE
Fix snapshotFormatUnitTest infinite loop

### DIFF
--- a/fdbclient/BlobGranuleFiles.cpp
+++ b/fdbclient/BlobGranuleFiles.cpp
@@ -783,6 +783,8 @@ TEST_CASE("/blobgranule/files/snapshotFormatUnitTest") {
 	std::unordered_set<std::string> usedKeys;
 	Standalone<GranuleSnapshot> data;
 	int totalDataBytes = 0;
+	const int maxKeyGenAttempts = 1000;
+	int nAttempts = 0;
 	while (totalDataBytes < targetDataBytes) {
 		int keySize = deterministicRandom()->randomInt(targetKeyLength / 2, targetKeyLength * 3 / 2);
 		keySize = std::min(keySize, uidSize);
@@ -799,6 +801,13 @@ TEST_CASE("/blobgranule/files/snapshotFormatUnitTest") {
 
 			data.push_back_deep(data.arena(), KeyValueRef(KeyRef(key), ValueRef(value)));
 			totalDataBytes += key.size() + value.size();
+			nAttempts = 0;
+		} else if (nAttempts > maxKeyGenAttempts) {
+			// KeySpace exhausted, avoid infinite loop
+			break;
+		} else {
+			// Keep exploring the KeySpace
+			nAttempts++;
 		}
 	}
 


### PR DESCRIPTION
Patch addresses an issue where loop generating random buffer
for the test might run in an infinite loop if KeySpace gets
exhausted but the 'targetBuffer' bytes aren't generated.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
