### PR TITLE
Fix processDiskReadSeconds and processDiskWriteSeconds (release-7.1).

### DIFF
--- a/flow/Platform.actor.cpp
+++ b/flow/Platform.actor.cpp
@@ -1734,15 +1734,10 @@ SystemStatistics getSystemStatistics(std::string const& dataFolder,
 			    0,
 			    returnStats.elapsed -
 			        std::min<double>(returnStats.elapsed, (nowIOMilliSecs - (*statState)->lastIOMilliSecs) / 1000.0));
-			returnStats.processDiskReadSeconds = std::max<double>(
-			    0,
-			    returnStats.elapsed - std::min<double>(returnStats.elapsed,
-			                                           (nowReadMilliSecs - (*statState)->lastReadMilliSecs) / 1000.0));
+			returnStats.processDiskReadSeconds =
+			    std::min<double>(returnStats.elapsed, (nowReadMilliSecs - (*statState)->lastReadMilliSecs) / 1000.0);
 			returnStats.processDiskWriteSeconds =
-			    std::max<double>(0,
-			                     returnStats.elapsed -
-			                         std::min<double>(returnStats.elapsed,
-			                                          (nowWriteMilliSecs - (*statState)->lastWriteMilliSecs) / 1000.0));
+			    std::min<double>(returnStats.elapsed, (nowWriteMilliSecs - (*statState)->lastWriteMilliSecs) / 1000.0);
 			returnStats.processDiskRead = (nowReads - (*statState)->lastReads);
 			returnStats.processDiskWrite = (nowWrites - (*statState)->lastWrites);
 			returnStats.processDiskWriteSectors = (nowWriteSectors - (*statState)->lastWriteSectors);


### PR DESCRIPTION
PR on main: #7608.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
