### PR TITLE
update tag client cache on getKeyLocation

### DIFF
--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -2875,6 +2875,7 @@ ACTOR Future<KeyRangeLocationInfo> getKeyLocation_internal(Database cx,
 					auto locationInfo =
 					    cx->setCachedLocation(tenant, rep.tenantEntry, rep.results[0].first, rep.results[0].second);
 					updateTssMappings(cx, rep);
+					updateTagMappings(cx, rep);
 
 					return KeyRangeLocationInfo(
 					    rep.tenantEntry,


### PR DESCRIPTION
`getKeyLocation_internal` did not update the SSID->Tag cache when receiving results from the proxy's `GetKeyServerLocationsRequest` interface. This can result in `ssidTagMapping` not having information to populate the version vector, in turn resulting in the latest commit version used to fetch data from the SS. This caused waitForVersion to be entered, which can delay responses up to `BLOCKING_PEEK_TIMEOUT` (currently .4) seconds. If a specific workload from a client is being run this can be indefinite.

Tested running `mako` and verifying read latency fell back to baseline (non vv) levels.

`20220719-144218-henrylambright-bc617501d091b257 `

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
