### PR TITLE
Draft: Download and build zlib from source

### DIFF
--- a/cmake/CompileBoost.cmake
+++ b/cmake/CompileBoost.cmake
@@ -70,7 +70,7 @@ function(compile_boost)
     URL "https://boostorg.jfrog.io/artifactory/main/release/1.78.0/source/boost_1_78_0.tar.bz2"
     URL_HASH SHA256=8681f175d4bdb26c52222665793eef08490d7758529330f98d3b29dd0735bccc
     CONFIGURE_COMMAND ${BOOTSTRAP_COMMAND} ${BOOTSTRAP_ARGS} --with-libraries=${BOOTSTRAP_LIBRARIES} --with-toolset=${BOOST_TOOLSET}
-    BUILD_COMMAND ${B2_COMMAND} link=static ${COMPILE_BOOST_BUILD_ARGS} --prefix=${BOOST_INSTALL_DIR} -sZLIB_SOURCE=${ZLIB_SOURCE_DIR} ${USER_CONFIG_FLAG} install
+    BUILD_COMMAND ${B2_COMMAND} link=static cxxflags=-fPIC cflags=-fPIC ${COMPILE_BOOST_BUILD_ARGS} --prefix=${BOOST_INSTALL_DIR} -sZLIB_SOURCE=${ZLIB_SOURCE_DIR} ${USER_CONFIG_FLAG} install
     BUILD_IN_SOURCE ON
     INSTALL_COMMAND ""
     UPDATE_COMMAND ""

--- a/cmake/CompileBoost.cmake
+++ b/cmake/CompileBoost.cmake
@@ -53,6 +53,7 @@ function(compile_boost)
   set(USER_CONFIG_FLAG --user-config=${CMAKE_BINARY_DIR}/user-config.jam)
 
   # Download zlib
+  include(ExternalProject)
   set(ZLIB_SOURCE_DIR "${CMAKE_BINARY_DIR}/zlib")
   ExternalProject_add("${COMPILE_BOOST_TARGET}_zlib"
     URL "https://zlib.net/zlib-1.2.12.tar.gz"
@@ -64,7 +65,6 @@ function(compile_boost)
     LOG_DOWNLOAD ON)
 
   # Build boost
-  include(ExternalProject)
   set(BOOST_INSTALL_DIR "${CMAKE_BINARY_DIR}/boost_install")
   ExternalProject_add("${COMPILE_BOOST_TARGET}Project"
     URL "https://boostorg.jfrog.io/artifactory/main/release/1.78.0/source/boost_1_78_0.tar.bz2"

--- a/cmake/CompileBoost.cmake
+++ b/cmake/CompileBoost.cmake
@@ -55,7 +55,7 @@ function(compile_boost)
   # Download zlib
   include(ExternalProject)
   set(ZLIB_SOURCE_DIR "${CMAKE_BINARY_DIR}/zlib")
-  ExternalProject_add("${COMPILE_BOOST_TARGET}_zlib"
+  ExternalProject_add("${COMPILE_BOOST_TARGET}_zlib_source"
     URL "https://zlib.net/zlib-1.2.12.tar.gz"
     URL_HASH SHA256=91844808532e5ce316b3c010929493c0244f3d37593afd6de04f71821d5136d9
     SOURCE_DIR ${ZLIB_SOURCE_DIR}
@@ -77,7 +77,8 @@ function(compile_boost)
     BUILD_BYPRODUCTS "${BOOST_INSTALL_DIR}/boost/config.hpp"
                      "${BOOST_INSTALL_DIR}/lib/libboost_context.a"
                      "${BOOST_INSTALL_DIR}/lib/libboost_filesystem.a"
-                     "${BOOST_INSTALL_DIR}/lib/libboost_iostreams.a")
+                     "${BOOST_INSTALL_DIR}/lib/libboost_iostreams.a"
+                     "${BOOST_INSTALL_DIR}/lib/libboost_zlib.a")
 
   add_library(${COMPILE_BOOST_TARGET}_context STATIC IMPORTED)
   add_dependencies(${COMPILE_BOOST_TARGET}_context ${COMPILE_BOOST_TARGET}Project)
@@ -91,9 +92,13 @@ function(compile_boost)
   add_dependencies(${COMPILE_BOOST_TARGET}_iostreams ${COMPILE_BOOST_TARGET}Project)
   set_target_properties(${COMPILE_BOOST_TARGET}_iostreams PROPERTIES IMPORTED_LOCATION "${BOOST_INSTALL_DIR}/lib/libboost_iostreams.a")
 
+  add_library(${COMPILE_BOOST_TARGET}_zlib STATIC IMPORTED)
+  add_dependencies(${COMPILE_BOOST_TARGET}_zlib ${COMPILE_BOOST_TARGET}Project)
+  set_target_properties(${COMPILE_BOOST_TARGET}_zlib PROPERTIES IMPORTED_LOCATION "${BOOST_INSTALL_DIR}/lib/libboost_zlib.a")
+
   add_library(${COMPILE_BOOST_TARGET} INTERFACE)
   target_include_directories(${COMPILE_BOOST_TARGET} SYSTEM INTERFACE ${BOOST_INSTALL_DIR}/include)
-  target_link_libraries(${COMPILE_BOOST_TARGET} INTERFACE ${COMPILE_BOOST_TARGET}_context ${COMPILE_BOOST_TARGET}_filesystem ${COMPILE_BOOST_TARGET}_iostreams)
+  target_link_libraries(${COMPILE_BOOST_TARGET} INTERFACE ${COMPILE_BOOST_TARGET}_context ${COMPILE_BOOST_TARGET}_filesystem ${COMPILE_BOOST_TARGET}_iostreams ${COMPILE_BOOST_TARGET}_zlib)
 
 endfunction(compile_boost)
 

--- a/cmake/CompileBoost.cmake
+++ b/cmake/CompileBoost.cmake
@@ -52,6 +52,17 @@ function(compile_boost)
   configure_file(${CMAKE_SOURCE_DIR}/cmake/user-config.jam.cmake ${CMAKE_BINARY_DIR}/user-config.jam)
   set(USER_CONFIG_FLAG --user-config=${CMAKE_BINARY_DIR}/user-config.jam)
 
+  # Download zlib
+  set(ZLIB_SOURCE_DIR "${CMAKE_BINARY_DIR}/zlib")
+  ExternalProject_add("${COMPILE_BOOST_TARGET}_zlib"
+    URL "https://zlib.net/zlib-1.2.12.tar.gz"
+    URL_HASH SHA256=91844808532e5ce316b3c010929493c0244f3d37593afd6de04f71821d5136d9
+    SOURCE_DIR ${ZLIB_SOURCE_DIR}
+    CONFIGURE_COMMAND ""
+    BUILD_COMMAND ""
+    INSTALL_COMMAND ""
+    LOG_DOWNLOAD ON)
+
   # Build boost
   include(ExternalProject)
   set(BOOST_INSTALL_DIR "${CMAKE_BINARY_DIR}/boost_install")
@@ -59,7 +70,7 @@ function(compile_boost)
     URL "https://boostorg.jfrog.io/artifactory/main/release/1.78.0/source/boost_1_78_0.tar.bz2"
     URL_HASH SHA256=8681f175d4bdb26c52222665793eef08490d7758529330f98d3b29dd0735bccc
     CONFIGURE_COMMAND ${BOOTSTRAP_COMMAND} ${BOOTSTRAP_ARGS} --with-libraries=${BOOTSTRAP_LIBRARIES} --with-toolset=${BOOST_TOOLSET}
-    BUILD_COMMAND ${B2_COMMAND} link=static ${COMPILE_BOOST_BUILD_ARGS} --prefix=${BOOST_INSTALL_DIR} ${USER_CONFIG_FLAG} install
+    BUILD_COMMAND ${B2_COMMAND} link=static ${COMPILE_BOOST_BUILD_ARGS} --prefix=${BOOST_INSTALL_DIR} -sZLIB_SOURCE=${ZLIB_SOURCE_DIR} ${USER_CONFIG_FLAG} install
     BUILD_IN_SOURCE ON
     INSTALL_COMMAND ""
     UPDATE_COMMAND ""

--- a/fdbclient/BlobGranuleFiles.cpp
+++ b/fdbclient/BlobGranuleFiles.cpp
@@ -1259,11 +1259,7 @@ TEST_CASE("/blobgranule/files/snapshotFormatUnitTest") {
 
 	Optional<CompressionFilter> compressFilter;
 	if (deterministicRandom()->coinflip()) {
-#ifdef ZLIB_LIB_SUPPORTED
 		compressFilter = CompressionFilter::GZIP;
-#else
-		compressFilter = CompressionFilter::NONE;
-#endif
 	}
 	Value serialized = serializeChunkedSnapshot(data, targetChunks, compressFilter, cipherKeysCtx);
 

--- a/fdbclient/CMakeLists.txt
+++ b/fdbclient/CMakeLists.txt
@@ -71,13 +71,6 @@ if(WITH_AWS_BACKUP)
   include(awssdk)
 endif()
 
-find_package(ZLIB)
-if(ZLIB_FOUND)
-  add_compile_definitions(ZLIB_LIB_SUPPORTED)
-else()
-  message(STATUS "ZLIB package not found")
-endif()
-
 add_flow_target(STATIC_LIBRARY NAME fdbclient SRCS ${FDBCLIENT_SRCS} ADDL_SRCS ${options_srcs})
 target_include_directories(fdbclient PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include" "${CMAKE_CURRENT_BINARY_DIR}/include")
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/versions.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/include/fdbclient/versions.h)

--- a/fdbserver/CMakeLists.txt
+++ b/fdbserver/CMakeLists.txt
@@ -23,13 +23,6 @@ file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/workloads)
 
 add_flow_target(EXECUTABLE NAME fdbserver SRCS ${FDBSERVER_SRCS})
 
-find_package(ZLIB)
-if(ZLIB_FOUND)
-  add_compile_definitions(ZLIB_LIB_SUPPORTED)
-else()
-  message(STATUS "ZLIB package not found")
-endif()
-
 target_include_directories(fdbserver PRIVATE
   ${CMAKE_SOURCE_DIR}/bindings/c
   ${CMAKE_BINARY_DIR}/bindings/c

--- a/flow/CMakeLists.txt
+++ b/flow/CMakeLists.txt
@@ -24,14 +24,6 @@ add_flow_target(STATIC_LIBRARY NAME flow_sampling SRCS ${FLOW_SRCS})
 add_flow_target(LINK_TEST NAME flowlinktest SRCS ${FLOW_SRCS} LinkTest.cpp)
 target_link_libraries(flowlinktest PRIVATE flow stacktrace)
 
-find_package(ZLIB)
-if(ZLIB_FOUND)
-  add_compile_definitions(ZLIB_LIB_SUPPORTED)
-  target_link_libraries(flow PRIVATE ZLIB::ZLIB)
-else()
-  message(STATUS "ZLIB package not found")
-endif()
-
 foreach(ft flow flow_sampling flowlinktest)
   target_include_directories(${ft} PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include" "${CMAKE_CURRENT_BINARY_DIR}/include")
 

--- a/flow/CompressionUtils.cpp
+++ b/flow/CompressionUtils.cpp
@@ -25,9 +25,7 @@
 #include "flow/UnitTest.h"
 
 #include <boost/iostreams/copy.hpp>
-#ifdef ZLIB_LIB_SUPPORTED
 #include <boost/iostreams/filter/gzip.hpp>
-#endif
 #include <boost/iostreams/filtering_streambuf.hpp>
 #include <sstream>
 
@@ -37,11 +35,9 @@ StringRef CompressionUtils::compress(const CompressionFilter filter, const Strin
 	}
 
 	namespace bio = boost::iostreams;
-#ifdef ZLIB_LIB_SUPPORTED
 	if (filter == CompressionFilter::GZIP) {
 		return CompressionUtils::compress(filter, data, bio::gzip::default_compression, arena);
 	}
-#endif
 	throw not_implemented();
 }
 
@@ -57,11 +53,9 @@ StringRef CompressionUtils::compress(const CompressionFilter filter, const Strin
 	std::stringstream decomStream(data.toString());
 
 	bio::filtering_streambuf<bio::input> out;
-#ifdef ZLIB_LIB_SUPPORTED
 	if (filter == CompressionFilter::GZIP) {
 		out.push(bio::gzip_compressor(bio::gzip_params(level)));
 	}
-#endif
 	out.push(decomStream);
 	bio::copy(out, compStream);
 
@@ -80,11 +74,9 @@ StringRef CompressionUtils::decompress(const CompressionFilter filter, const Str
 	std::stringstream decompStream;
 
 	bio::filtering_streambuf<bio::input> out;
-#ifdef ZLIB_LIB_SUPPORTED
 	if (filter == CompressionFilter::GZIP) {
 		out.push(bio::gzip_decompressor());
 	}
-#endif
 	out.push(compStream);
 	bio::copy(out, decompStream);
 
@@ -111,7 +103,6 @@ TEST_CASE("/CompressionUtils/noCompression") {
 	return Void();
 }
 
-#ifdef ZLIB_LIB_SUPPORTED
 TEST_CASE("/CompressionUtils/gzipCompression") {
 	Arena arena;
 	const int size = deterministicRandom()->randomInt(512, 1024);
@@ -128,4 +119,3 @@ TEST_CASE("/CompressionUtils/gzipCompression") {
 
 	return Void();
 }
-#endif

--- a/flow/include/flow/CompressionUtils.h
+++ b/flow/include/flow/CompressionUtils.h
@@ -26,9 +26,7 @@
 
 enum class CompressionFilter {
 	NONE,
-#ifdef ZLIB_LIB_SUPPORTED
 	GZIP,
-#endif
 	LAST // Always the last member
 };
 
@@ -41,11 +39,9 @@ struct CompressionUtils {
 		if (filter == "NONE") {
 			return CompressionFilter::NONE;
 		}
-#ifdef ZLIB_LIB_SUPPORTED
 		else if (filter == "GZIP") {
 			return CompressionFilter::GZIP;
 		}
-#endif
 		else {
 			throw not_implemented();
 		}
@@ -55,11 +51,9 @@ struct CompressionUtils {
 		if (filter == CompressionFilter::NONE) {
 			return "NONE";
 		}
-#ifdef ZLIB_LIB_SUPPORTED
 		else if (filter == CompressionFilter::GZIP) {
 			return "GZP";
 		}
-#endif
 		else {
 			throw not_implemented();
 		}

--- a/flow/include/flow/CompressionUtils.h
+++ b/flow/include/flow/CompressionUtils.h
@@ -38,11 +38,9 @@ struct CompressionUtils {
 	static CompressionFilter fromFilterString(const std::string& filter) {
 		if (filter == "NONE") {
 			return CompressionFilter::NONE;
-		}
-		else if (filter == "GZIP") {
+		} else if (filter == "GZIP") {
 			return CompressionFilter::GZIP;
-		}
-		else {
+		} else {
 			throw not_implemented();
 		}
 	}
@@ -50,11 +48,9 @@ struct CompressionUtils {
 	static std::string toString(const CompressionFilter filter) {
 		if (filter == CompressionFilter::NONE) {
 			return "NONE";
-		}
-		else if (filter == CompressionFilter::GZIP) {
+		} else if (filter == CompressionFilter::GZIP) {
 			return "GZP";
-		}
-		else {
+		} else {
 			throw not_implemented();
 		}
 	}


### PR DESCRIPTION
Building zlib from source is important to make the build work with ASAN. Otherwise ASAN builds are failing:

```
2022-07-18 08:42:32  ld.lld: error: undefined symbol: boost::iostreams::zlib::default_compression
2022-07-18 08:42:32  >>> referenced by CompressionUtils.cpp:42 (../flow/CompressionUtils.cpp:42)
2022-07-18 08:42:32  >>>               flow/CMakeFiles/flowlinktest.dir/CompressionUtils.cpp.o:(CompressionUtils::compress(CompressionFilter, StringRef const&, Arena&))
2022-07-18 08:42:32  >>> referenced by CompressionUtils.cpp:42 (../flow/CompressionUtils.cpp:42)
2022-07-18 08:42:32  >>>               flow/CMakeFiles/flowlinktest.dir/CompressionUtils.cpp.o:(CompressionUtils::compress(CompressionFilter, StringRef const&, Arena&))
2022-07-18 08:42:32  >>> referenced by CompressionUtils.cpp:42 (../flow/CompressionUtils.cpp:42)
2022-07-18 08:42:32  >>>               flow/CMakeFiles/flowlinktest.dir/CompressionUtils.cpp.o:(CompressionUtils::compress(CompressionFilter, StringRef const&, Arena&))
2022-07-18 08:42:32  >>> referenced 6 more times
```

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
