### PR TITLE
Add some helper functions to ClusterConnectionString and an improvement to StringRef.eat

### DIFF
--- a/fdbclient/include/fdbclient/CoordinationInterface.h
+++ b/fdbclient/include/fdbclient/CoordinationInterface.h
@@ -63,6 +63,8 @@ struct ClientLeaderRegInterface {
 //  - There is no address present more than once
 class ClusterConnectionString {
 public:
+	constexpr static FileIdentifier file_identifier = 13602011;
+
 	ClusterConnectionString() {}
 	ClusterConnectionString(const std::string& connectionString);
 	ClusterConnectionString(const std::vector<NetworkAddress>& coordinators, Key key);
@@ -84,9 +86,20 @@ public:
 	std::vector<NetworkAddress> coords;
 	std::vector<Hostname> hostnames;
 
+	bool operator==(const ClusterConnectionString& other) const noexcept {
+		return key == other.key && keyDesc == other.keyDesc && coords == other.coords && hostnames == other.hostnames;
+	}
+	bool operator!=(const ClusterConnectionString& other) const noexcept { return !(*this == other); }
+
 private:
 	void parseConnString();
 	Key key, keyDesc;
+
+public:
+	template <class Ar>
+	void serialize(Ar& ar) {
+		serializer(ar, coords, hostnames, key, keyDesc);
+	}
 };
 
 FDB_DECLARE_BOOLEAN_PARAM(ConnectionStringNeedsPersisted);

--- a/fdbclient/include/fdbclient/MultiVersionTransaction.h
+++ b/fdbclient/include/fdbclient/MultiVersionTransaction.h
@@ -650,8 +650,6 @@ private:
 	void setDefaultOptions(UniqueOrderedOptionList<FDBTransactionOptions> options);
 
 	std::vector<std::pair<FDBTransactionOptions::Option, Optional<Standalone<StringRef>>>> persistentOptions;
-
-	const Optional<TenantName> tenantName;
 };
 
 struct ClientDesc {

--- a/flow/Arena.cpp
+++ b/flow/Arena.cpp
@@ -774,3 +774,45 @@ TEST_CASE("/flow/Arena/Size") {
 
 	return Void();
 }
+
+TEST_CASE("flow/StringRef/eat") {
+	StringRef str = "test/case"_sr;
+	StringRef first = str.eat("/");
+	ASSERT(first == "test"_sr);
+	ASSERT(str == "case"_sr);
+
+	str = "test/case"_sr;
+	first = str.eat("/"_sr);
+	ASSERT(first == "test"_sr);
+	ASSERT(str == "case"_sr);
+
+	str = "testcase"_sr;
+	first = str.eat("/"_sr);
+	ASSERT(first == "testcase"_sr);
+	ASSERT(str == ""_sr);
+
+	str = "testcase/"_sr;
+	first = str.eat("/"_sr);
+	ASSERT(first == "testcase"_sr);
+	ASSERT(str == ""_sr);
+
+	str = "test/case/extra"_sr;
+	first = str.eat("/"_sr);
+	ASSERT(first == "test"_sr);
+	ASSERT(str == "case/extra"_sr);
+
+	bool hasSep;
+	str = "test/case"_sr;
+	first = str.eat("/"_sr, &hasSep);
+	ASSERT(hasSep);
+	ASSERT(first == "test"_sr);
+	ASSERT(str == "case"_sr);
+
+	str = "testcase"_sr;
+	first = str.eat("/", &hasSep);
+	ASSERT(!hasSep);
+	ASSERT(first == "testcase"_sr);
+	ASSERT(str == ""_sr);
+
+	return Void();
+}

--- a/flow/include/flow/Arena.h
+++ b/flow/include/flow/Arena.h
@@ -587,13 +587,19 @@ public:
 	}
 
 	// Removes bytes from begin up to and including the sep string, returns StringRef of the part before sep
-	StringRef eat(StringRef sep) {
+	StringRef eat(StringRef sep, bool* foundSep = nullptr) {
 		for (int i = 0, iend = size() - sep.size(); i <= iend; ++i) {
 			if (sep.compare(substr(i, sep.size())) == 0) {
+				if (foundSep) {
+					*foundSep = true;
+				}
 				StringRef token = substr(0, i);
 				*this = substr(i + sep.size());
 				return token;
 			}
+		}
+		if (foundSep) {
+			*foundSep = false;
 		}
 		return eat();
 	}
@@ -602,7 +608,9 @@ public:
 		*this = StringRef();
 		return r;
 	}
-	StringRef eat(const char* sep) { return eat(StringRef((const uint8_t*)sep, (int)strlen(sep))); }
+	StringRef eat(const char* sep, bool* foundSep = nullptr) {
+		return eat(StringRef((const uint8_t*)sep, (int)strlen(sep)), foundSep);
+	}
 	// Return StringRef of bytes from begin() up to but not including the first byte matching any byte in sep,
 	// and remove that sequence (including the sep byte) from *this
 	// Returns and removes all bytes from *this if no bytes within sep were found


### PR DESCRIPTION
* Add the ability for StringRef.eat to return whether a separator was found. 
* Add a serialize function and equality operators to ClusterConnectionString. 
* Remove unused variable.
# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
