### PR TITLE
Improvements to `GlobalTagThrottler`

### DIFF
--- a/design/global-tag-throttling.md
+++ b/design/global-tag-throttling.md
@@ -1,0 +1,130 @@
+## Global Tag Throttling
+
+When the `GLOBAL_TAG_THROTTLING` knob is enabled, the ratekeeper will use the [transaction tagging feature](https://apple.github.io/foundationdb/transaction-tagging.html) to throttle tags according to the global tag throttling algorithm. This page describes the implementation of this algorithm.
+
+### Tag Quotas
+The global tag throttler bases throttling decisions on "quotas" provided by clients through the tag quota API. Each tag quota has four different components:
+
+* Reserved read quota
+* Reserved write quota
+* Total read quota
+* Total write quota
+
+The global tag throttler can not throttle tags to a throughput below the reserved quotas, and it cannot allow throughput to exceed the total quotas.
+
+### Cost
+The units for these quotas are computed as follows. The "cost" of a read operation is computed as:
+
+```
+readCost = bytesRead / SERVER_KNOBS->READ_COST_BYTE_FACTOR + 1;
+```
+
+The "cost" of a write operation is computed as:
+
+```
+writeCost = bytesWritten / CLIENT_KNOBS->WRITE_COST_BYTE_FACTOR + 1;
+```
+
+Here `bytesWritten` includes cleared bytes. The size of range clears is estimated at commit time.
+
+### Tuple Layer
+Tag quotas are stored inside of the system keyspace (with prefix `\xff/tagQuota/`). They are stored using the tuple layer, in a tuple of form: `(reservedReadQuota, totalReadQuota, reservedWriteQuota, totalWriteQuota)`. There is currently no custom code in the bindings for manipulating these system keys. However, in any language for which bindings are available, it is possible to use the tuple layer to manipulate tag quotas.
+
+### fdbcli
+The easiest way for an external client to interact with tag quotas is through `fdbcli`. To get the quota of a particular tag, run the following command:
+
+```
+fdbcli> get <tag> [reserved|total] [read|write]
+```
+
+To set the quota through `fdbcli`, run:
+
+```
+fdbcli> set <tag> [reserved|total] [read|write] <value>
+```
+
+### Limit Calculation
+The transaction budget that ratekeeper calculates and distributes to clients (via GRV proxies) for each tag is calculated based on several intermediate rate calculations, outlined in this section.
+
+* Reserved Rate: Based on reserved quota and the average transaction cost, a reserved TPS rate is computed for each tag.
+
+* Desired Rate: Based on total quota and the average transaction cost, a desired TPS rate is computed for each tag.
+
+* Limiting Rate: When a storage server is near saturation, tags contributing notably to the workload on this storage server will receive a limiting TPS rate, computed to relieve the workload on the storage server.
+
+* Target Rate: The target rate is the cluster-wide rate enforced by the global tag throttler. This rate is computed as:
+
+```
+targetTps = max(reservedTps, min(desiredTps, limitingTps));
+```
+
+* Per-Client Rate: While the target rate represents the cluster-wide desired throughput according to the global tag throttler, this budget must be shared across potentially many clients. Therefore, based on observed throughput from various clients, each client will receive an equal budget based on a per-client, per-tag rate computed by the global tag throttler. This rate is in the end what will be sent to clients to enforce throttling.
+
+## Implementation
+
+### Stat collection
+The transaction rates and costs of all transactions must be visible to the global tag throttler. Whenever a client tags a transaction, sampling is performed to determine whether to attach the tag to messages sent to storage servers and commit proxies.
+
+For read operations that are sampled (with probability `CLIENT_KNOBS->READ_TAG_SAMPLE_RATE`), read costs are aggregated on storage servers using the `TransactionTagCounter` class. This class tracks the busyness of the top-k tags affecting the storage server with read load (here `k` is determined by `SERVER_KNOBS->SS_THROTTLE_TAGS_TRACKED`). Storage servers periodically send per-tag read cost statistics to the ratekeeper through `StorageQueuingMetricsReply` messages.
+
+For write operations that are sampled (with probability `COMMIT_SAMPLE_COST`), write costs are aggregated on commit proxies in the `ProxyCommitData::ssTrTagCommitCost` object. Per-storage, per-tag write cost statistics are periodically sent from commit proxies to the ratekeeper through `ReportCommitCostEstimationRequest` messages.
+
+The ratekeeper tracks per-storage, per-tag cost statistics in the `GlobalTagThrottlerImpl::throughput` object.
+
+The ratekeeper must also track the rate of transactions performed with each tag. Each GRV proxy agreggates a per-tag counter of transactions started (without sampling). These are sent to the ratekeeper through `GetRateInfoRequest` messages. The global tag throttler then tracks per tag transaction rates in the `GlobalTagThrottlerImpl::tagStatistics` object.
+
+### Average Cost Calculation
+Quotas are expressed in terms of cost, but because throttling is enforced at the beginning of transactions, budgets need to be calculated in terms of transactions per second. To make this conversion, it is necessary to track the average cost of transactions (per-tag, and per-tag on a particular storage server).
+
+Both cost and transaction counters are smoothed using the `Smoother` class to provide stability over time. The "smoothing interval" can be modified through `SERVER_KNOBS->GLOBAL_TAG_THROTTLING_FOLDING_TIME`.
+
+### Reserved Rate Calculation
+The global tag throttler periodically reads reserved quotas from the system keyspace. Using these reserved quotas and the average cost of transactions with the given tag, a reserved TPS rate is computed. Read and write rates are aggregated as follows:
+
+```
+reservedTps = max(reservedReadTps, reservedWriteTps);
+```
+
+### Desired Rate Calculation
+Similar to reserved rate calculation, the total quota is read from the system key space. Then, using the average cost of transactions with the given tag, a desired TPS rate is computed. Read and write rates are aggregated as follows:
+
+```
+desiredTps = min(desiredReadTps, desiredWriteTps);
+```
+
+### Limiting Rate Calculation
+In addition to tag busyness statistics, the `StorageQueuingMetricsReply` messages sent from storage servers to the ratekeeper also contain metrics on the health of storage servers. The ratekeeper uses these metrics as part of its calculation of a global transaction rate (independent of tag throttling).
+
+The global tag throttler also makes use of these metrics to compute a "throttling ratio" for each storage server. This throttling ratio is computed in `StorageQueueInfo::getThrottlingRatio`. The global tag throttler uses the throttling ratio for each tracked storage server to compute a "limiting transaction rate" for each combination of storage server and tag.
+
+In the "healthy" case where no metrics are near saturation, the throttling ratio will be an empty `Optional<double>`, indicating that the storage server is not near saturation. If, on the other hand, the metrics indicate approaching saturation, the throttling ratio will be a number between 0 and 2 indicating the ratio of current throughput the storage server can serve. In this case, the global tag throttler looks at the current cost being served by the storage server, multiplies it by the throttling ratio, and computes a limiting cost for the storage server. Among all tags using significant resources on this storage server, this limiting cost is divided up according to the relative total quotas allocated to these tags. Next, a transaction limit is determined for each tag, based on how much the average transaction for the given tag affects the given storage server.
+
+These per-tag, per-storage limiting transaction rates are aggregated to compute per-tag limiting transaction rates:
+
+```
+limitingTps(tag) = min{limitingTps(tag, storage) : all storage servers}
+```
+
+If the throttling ratio is empty for all storage servers affected by a tag, then the per-tag, per-storage limiting TPS rate is also empty. In this case the target rate for this tag is simply the desired rate.
+
+If an individual zone is unhealthy, it may cause the throttling ratio for storage servers in that zone to shoot up. This should not be misinterpretted as a workload issue that requires active throttling. Therefore, the zone with the worst throttling ratios is ignored when computing the limiting transaction rate for a tag (similar to the calculation of the global transaction limit in `Ratekeeper::updateRate`).
+
+### Client Rate Calculation
+The smoothed per-client rate for each tag is tracked within `GlobalTagThrottlerImpl::PerTagStatistics`. Once a target rate has been computed, this is passed to `GlobalTagThrotterImpl::PerTagStatistics::updateAndGetPerClientRate` which adjusts the per-client rate. The per-client rate is meant to limit the busiest clients, so that at equilibrium, the per-client rate will remain constant and the sum of throughput from all clients will match the target rate.
+
+## Testing
+The `GlobalTagThrottling.toml` test provides a simple end-to-end test using the global tag throttler. Quotas are set using the internal tag quota API in the `GlobalTagThrottling` workload. This is run in parallel with the `ReadWrite` workload, which tags transactions. The number of `transaction_tag_throttled` errors is reported, along with the throughput, which should be roughly predictable based on the quota parameters chosen. 
+
+In addition to this end-to-end test, there is a suite of unit tests with the `/GlobalTagThrottler/` prefix. These tests run in a mock environment, with mock storage servers providing simulated storage queue statistics and tag busyness reports. Mock clients simulate workload on these mock storage servers, and get throttling feedback directly from a global tag throttler which is monitoring the mock storage servers.
+
+In each test, the `GlobalTagThrottlerTesting::monitor` function is used to periodically check whether or not a desired equilibrium state has been reached. If the desired state is reached and maintained for a sufficient period of time, the test passes. If the unit test is unable to reach this desired equilibrium state before a timeout, the test will fail. Commonly, the desired state is for the global tag throttler to report a client rate sufficiently close to the desired rate specified as an input to the `GlobalTagThrottlerTesting::rateIsNear` function.
+
+## Visibility
+
+### Tracing
+On the ratekeeper, every `SERVER_KNOBS->TAG_THROTTLE_PUSH_INTERVAL` seconds, the ratekeeper will call `GlobalTagThrottler::getClientRates`. At the end of the rate calculation for each tag, a trace event of type `GlobalTagThrottler_GotClientRate` is produced. This trace event reports the relevant inputs that went in to the rate calculation, and can be used for debugging.
+
+On storage servers, every `SERVER_KNOBS->TAG_MEASUREMENT_INTERVAL` seconds, there are `BusyReadTag` events for every tag that has sufficient read cost to be reported to the ratekeeper. Both cost and fractional busyness are reported.
+
+### Status
+For each storage server, the busiest read tag is reported in the full status output, along with its cost and fractional busyness. 

--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -673,7 +673,6 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( GLOBAL_TAG_THROTTLING,                               false );
 	init( GLOBAL_TAG_THROTTLING_MIN_RATE,                        1.0 );
 	init( GLOBAL_TAG_THROTTLING_FOLDING_TIME,                   10.0 );
-	init( GLOBAL_TAG_THROTTLING_TRACE_INTERVAL,                  5.0 );
 
 	//Storage Metrics
 	init( STORAGE_METRICS_AVERAGE_INTERVAL,                    120.0 );

--- a/fdbserver/GlobalTagThrottler.actor.cpp
+++ b/fdbserver/GlobalTagThrottler.actor.cpp
@@ -60,11 +60,6 @@
 // PerClient TPS: Because the target throughput must be shared across multiple clients, and all clients must
 //           be given the same limits, a per-client limit is calculated based on the current and target throughputs.
 
-namespace {
-enum class LimitType { RESERVED, TOTAL };
-enum class OpType { READ, WRITE };
-} // namespace
-
 class GlobalTagThrottlerImpl {
 	template <class K, class V>
 	static Optional<V> tryGet(std::unordered_map<K, V> const& m, K const& k) {
@@ -95,6 +90,9 @@ class GlobalTagThrottlerImpl {
 			return b;
 		}
 	}
+
+	enum class LimitType { RESERVED, TOTAL };
+	enum class OpType { READ, WRITE };
 
 	class ThroughputCounters {
 		Smoother readCost;
@@ -521,6 +519,11 @@ void GlobalTagThrottler::setQuota(TransactionTagRef tag, ThrottleApi::TagQuotaVa
 void GlobalTagThrottler::removeQuota(TransactionTagRef tag) {
 	return impl->removeQuota(tag);
 }
+
+namespace {
+enum class LimitType { RESERVED, TOTAL };
+enum class OpType { READ, WRITE };
+} // namespace
 
 namespace GlobalTagThrottlerTesting {
 

--- a/fdbserver/GlobalTagThrottler.actor.cpp
+++ b/fdbserver/GlobalTagThrottler.actor.cpp
@@ -141,11 +141,10 @@ class GlobalTagThrottlerImpl {
 
 		double getTransactionRate() const { return transactionCounter.smoothRate(); }
 
-		ClientTagThrottleLimits updateAndGetPerClientLimit(Optional<double> targetTps) {
-			auto newPerClientRate =
-			    std::max(SERVER_KNOBS->GLOBAL_TAG_THROTTLING_MIN_RATE,
-			             std::min(targetTps.get(),
-			                      (targetTps.get() / transactionCounter.smoothRate()) * perClientRate.smoothTotal()));
+		ClientTagThrottleLimits updateAndGetPerClientLimit(double targetTps) {
+			auto newPerClientRate = std::max(
+			    SERVER_KNOBS->GLOBAL_TAG_THROTTLING_MIN_RATE,
+			    std::min(targetTps, (targetTps / transactionCounter.smoothRate()) * perClientRate.smoothTotal()));
 			perClientRate.setTotal(newPerClientRate);
 			return ClientTagThrottleLimits(
 			    std::max(perClientRate.smoothTotal(), SERVER_KNOBS->GLOBAL_TAG_THROTTLING_MIN_RATE),

--- a/fdbserver/GlobalTagThrottler.actor.cpp
+++ b/fdbserver/GlobalTagThrottler.actor.cpp
@@ -179,6 +179,11 @@ class GlobalTagThrottlerImpl {
 		for (const auto& [id, _] : throughput) {
 			result += getCurrentCost(id, tag, opType).orDefault(0);
 		}
+		TraceEvent("GlobalTagThrottler_GetCurrentCost")
+		    .detail("Tag", printable(tag))
+		    .detail("Op", (opType == OpType::READ) ? "Read" : "Write")
+		    .detail("Cost", result);
+
 		return result;
 	}
 
@@ -210,6 +215,11 @@ class GlobalTagThrottlerImpl {
 			return 1.0;
 		}
 		auto const transactionRate = stats.get().getTransactionRate();
+		TraceEvent("GlobalTagThrottler_GetAverageTransactionCost")
+		    .detail("Tag", tag)
+		    .detail("OpType", (opType == OpType::READ) ? "Read" : "Write")
+		    .detail("TransactionRate", transactionRate)
+		    .detail("Cost", cost);
 		if (transactionRate == 0.0) {
 			return 1.0;
 		} else {

--- a/fdbserver/GlobalTagThrottler.actor.cpp
+++ b/fdbserver/GlobalTagThrottler.actor.cpp
@@ -369,7 +369,6 @@ class GlobalTagThrottlerImpl {
 					self->removeUnseenQuotas(tagsWithQuota);
 					++self->throttledTagChangeId;
 					wait(delay(5.0));
-					TraceEvent("GlobalTagThrottler_ChangeSignaled");
 					break;
 				} catch (Error& e) {
 					TraceEvent("GlobalTagThrottler_MonitoringChangesError", self->id).error(e);

--- a/fdbserver/GlobalTagThrottler.actor.cpp
+++ b/fdbserver/GlobalTagThrottler.actor.cpp
@@ -670,13 +670,13 @@ public:
 	}
 };
 
-ACTOR static Future<Void> runClient(GlobalTagThrottler* globalTagThrottler,
-                                    StorageServerCollection* storageServers,
-                                    TransactionTag tag,
-                                    double tpsRate,
-                                    double costPerTransaction,
-                                    OpType opType,
-                                    std::vector<int> storageServerIndices = std::vector<int>()) {
+ACTOR Future<Void> runClient(GlobalTagThrottler* globalTagThrottler,
+                             StorageServerCollection* storageServers,
+                             TransactionTag tag,
+                             double tpsRate,
+                             double costPerTransaction,
+                             OpType opType,
+                             std::vector<int> storageServerIndices = std::vector<int>()) {
 	loop {
 		auto tpsLimit = getTPSLimit(*globalTagThrottler, tag);
 		state double enforcedRate = tpsLimit.present() ? std::min<double>(tpsRate, tpsLimit.get()) : tpsRate;
@@ -726,8 +726,8 @@ bool rateIsNear(GlobalTagThrottler& globalTagThrottler, TransactionTag tag, Opti
 	}
 }
 
-ACTOR static Future<Void> updateGlobalTagThrottler(GlobalTagThrottler* globalTagThrottler,
-                                                   StorageServerCollection const* storageServers) {
+ACTOR Future<Void> updateGlobalTagThrottler(GlobalTagThrottler* globalTagThrottler,
+                                            StorageServerCollection const* storageServers) {
 	loop {
 		wait(delay(1.0));
 		auto const storageQueueInfos = storageServers->getStorageQueueInfos();

--- a/fdbserver/GlobalTagThrottler.actor.cpp
+++ b/fdbserver/GlobalTagThrottler.actor.cpp
@@ -84,7 +84,6 @@ class GlobalTagThrottlerImpl {
 			auto readLimit = getReadTPSLimit();
 			auto writeLimit = getWriteTPSLimit();
 
-			// TODO: Implement expiration logic
 			if (!readLimit.present() && !writeLimit.present()) {
 				return {};
 			} else {
@@ -162,8 +161,6 @@ class GlobalTagThrottlerImpl {
 					}
 
 					++self->throttledTagChangeId;
-					// FIXME: Should wait on watch instead
-					// wait(tr.watch(tagThrottleSignalKey));
 					wait(delay(5.0));
 					TraceEvent("GlobalTagThrottler_ChangeSignaled");
 					CODE_PROBE(true, "Global tag throttler detected quota changes");
@@ -211,7 +208,6 @@ public:
 		for (const auto& busyWriteTag : ss.busiestWriteTags) {
 			trackedTags[busyWriteTag.tag].updateWriteCostRate(ss.id, busyWriteTag.rate);
 		}
-		// TODO: Call ThrottleApi::throttleTags
 		return Void();
 	}
 

--- a/fdbserver/GlobalTagThrottler.actor.cpp
+++ b/fdbserver/GlobalTagThrottler.actor.cpp
@@ -381,9 +381,7 @@ class GlobalTagThrottlerImpl {
 public:
 	GlobalTagThrottlerImpl(Database db, UID id) : db(db), id(id) {}
 	Future<Void> monitorThrottlingChanges() { return monitorThrottlingChanges(this); }
-	void addRequests(TransactionTag tag, int count) {
-		tagStatistics[tag].addTransactions(static_cast<double>(count) / CLIENT_KNOBS->READ_TAG_SAMPLE_RATE);
-	}
+	void addRequests(TransactionTag tag, int count) { tagStatistics[tag].addTransactions(static_cast<double>(count)); }
 	uint64_t getThrottledTagChangeId() const { return throttledTagChangeId; }
 	PrioritizedTransactionTagMap<ClientTagThrottleLimits> getClientRates() {
 		PrioritizedTransactionTagMap<ClientTagThrottleLimits> result;

--- a/fdbserver/Status.actor.cpp
+++ b/fdbserver/Status.actor.cpp
@@ -549,23 +549,11 @@ struct RolesInfo {
 			TraceEventFields const& busiestReadTag = metrics.at("BusiestReadTag");
 			if (busiestReadTag.size()) {
 				int64_t tagCost = busiestReadTag.getInt64("TagCost");
-
 				if (tagCost > 0) {
 					JsonBuilderObject busiestReadTagObj;
-
-					int64_t totalSampledCost = busiestReadTag.getInt64("TotalSampledCost");
-					ASSERT(totalSampledCost > 0);
-
 					busiestReadTagObj["tag"] = busiestReadTag.getValue("Tag");
-					busiestReadTagObj["fractional_cost"] = (double)tagCost / totalSampledCost;
-
-					double elapsed = busiestReadTag.getDouble("Elapsed");
-					if (CLIENT_KNOBS->READ_TAG_SAMPLE_RATE > 0 && elapsed > 0) {
-						JsonBuilderObject estimatedCostObj;
-						estimatedCostObj["hz"] = tagCost / CLIENT_KNOBS->READ_TAG_SAMPLE_RATE / elapsed;
-						busiestReadTagObj["estimated_cost"] = estimatedCostObj;
-					}
-
+					busiestReadTagObj["cost"] = tagCost;
+					busiestReadTagObj["fractional_cost"] = busiestReadTag.getValue("FractionalBusyness");
 					obj["busiest_read_tag"] = busiestReadTagObj;
 				}
 			}

--- a/fdbserver/TransactionTagCounter.cpp
+++ b/fdbserver/TransactionTagCounter.cpp
@@ -117,15 +117,27 @@ public:
 		if (intervalStart > 0 && CLIENT_KNOBS->READ_TAG_SAMPLE_RATE > 0 && elapsed > 0) {
 			previousBusiestTags = topTags.getBusiestTags(elapsed, intervalTotalSampledCount);
 
-			TraceEvent("BusiestReadTag", thisServerID)
-			    .detail("TotalSampledCost", intervalTotalSampledCount)
-			    .detail("Reported", previousBusiestTags.size())
-			    .trackLatest(busiestReadTagEventHolder->trackingKey);
+			// For status, report the busiest tag:
+			if (previousBusiestTags.empty()) {
+				TraceEvent("BusiestReadTag", thisServerID).detail("TagCost", 0);
+			} else {
+				auto busiestTagInfo = previousBusiestTags[0];
+				for (int i = 1; i < previousBusiestTags.size(); ++i) {
+					auto const& tagInfo = previousBusiestTags[i];
+					if (tagInfo.rate > busiestTagInfo.rate) {
+						busiestTagInfo = tagInfo;
+					}
+				}
+				TraceEvent("BusiestReadTag", thisServerID)
+				    .detail("Tag", printable(busiestTagInfo.tag))
+				    .detail("TagCost", busiestTagInfo.rate)
+				    .detail("FractionalBusyness", busiestTagInfo.fractionalBusyness);
+			}
 
 			for (const auto& tagInfo : previousBusiestTags) {
 				TraceEvent("BusyReadTag", thisServerID)
 				    .detail("Tag", printable(tagInfo.tag))
-				    .detail("Rate", tagInfo.rate)
+				    .detail("TagCost", tagInfo.rate)
 				    .detail("FractionalBusyness", tagInfo.fractionalBusyness);
 			}
 		}

--- a/fdbserver/TransactionTagCounter.cpp
+++ b/fdbserver/TransactionTagCounter.cpp
@@ -118,12 +118,16 @@ public:
 			previousBusiestTags = topTags.getBusiestTags(elapsed, intervalTotalSampledCount);
 
 			TraceEvent("BusiestReadTag", thisServerID)
-			    .detail("Elapsed", elapsed)
-			    //.detail("Tag", printable(busiestTag))
-			    //.detail("TagCost", busiestTagCount)
 			    .detail("TotalSampledCost", intervalTotalSampledCount)
 			    .detail("Reported", previousBusiestTags.size())
 			    .trackLatest(busiestReadTagEventHolder->trackingKey);
+
+			for (const auto& tagInfo : previousBusiestTags) {
+				TraceEvent("BusyReadTag", thisServerID)
+				    .detail("Tag", printable(tagInfo.tag))
+				    .detail("Rate", tagInfo.rate)
+				    .detail("FractionalBusyness", tagInfo.fractionalBusyness);
+			}
 		}
 
 		intervalCounts.clear();

--- a/fdbserver/include/fdbserver/Ratekeeper.h
+++ b/fdbserver/include/fdbserver/Ratekeeper.h
@@ -73,6 +73,9 @@ public:
 	int64_t getDurabilityLag() const { return smoothLatestVersion.smoothTotal() - smoothDurableVersion.smoothTotal(); }
 	void update(StorageQueuingMetricsReply const&, Smoother& smoothTotalDurableBytes);
 	void addCommitCost(TransactionTagRef tagName, TransactionCommitCostEstimation const& cost);
+
+	// Determine the ratio (limit / current throughput) for throttling based on write queue size
+	Optional<double> getWriteQueueSizeLimitRatio(int64_t storageSpringBytes, int64_t storageTargetBytes) const;
 };
 
 struct TLogQueueInfo {

--- a/fdbserver/include/fdbserver/Ratekeeper.h
+++ b/fdbserver/include/fdbserver/Ratekeeper.h
@@ -75,7 +75,7 @@ public:
 	void addCommitCost(TransactionTagRef tagName, TransactionCommitCostEstimation const& cost);
 
 	// Determine the ratio (limit / current throughput) for throttling based on write queue size
-	Optional<double> getWriteQueueSizeLimitRatio(int64_t storageSpringBytes, int64_t storageTargetBytes) const;
+	Optional<double> getThrottlingRatio(int64_t storageTargetBytes, int64_t storageSpringBytes) const;
 };
 
 struct TLogQueueInfo {

--- a/fdbserver/include/fdbserver/TagThrottler.h
+++ b/fdbserver/include/fdbserver/TagThrottler.h
@@ -80,19 +80,21 @@ public:
 	Future<Void> monitorThrottlingChanges() override;
 	void addRequests(TransactionTag tag, int count) override;
 	uint64_t getThrottledTagChangeId() const override;
-	PrioritizedTransactionTagMap<ClientTagThrottleLimits> getClientRates() override;
+
 	int64_t autoThrottleCount() const override;
 	uint32_t busyReadTagCount() const override;
 	uint32_t busyWriteTagCount() const override;
 	int64_t manualThrottleCount() const override;
 	bool isAutoThrottlingEnabled() const override;
+
 	Future<Void> tryUpdateAutoThrottling(StorageQueueInfo const&) override;
+	PrioritizedTransactionTagMap<ClientTagThrottleLimits> getClientRates() override;
 
-	// Based on limiting storage queue size, set a ratio by which total throughput needs to be
+	// Based on limiting storage queue size, set a ratio by which total throughput on the storage server needs to be
 	// adjusted
-	void setThrottlingRatio(Optional<double>);
+	void setThrottlingRatio(UID storageServerId, Optional<double> ratio);
 
-	// testing only
+	// Testing only:
 public:
 	void setQuota(TransactionTagRef, ThrottleApi::TagQuotaValue const&);
 	void removeQuota(TransactionTagRef);

--- a/fdbserver/include/fdbserver/TagThrottler.h
+++ b/fdbserver/include/fdbserver/TagThrottler.h
@@ -91,4 +91,5 @@ public:
 	// testing only
 public:
 	void setQuota(TransactionTagRef, ThrottleApi::TagQuotaValue const&);
+	void removeQuota(TransactionTagRef);
 };

--- a/fdbserver/include/fdbserver/TagThrottler.h
+++ b/fdbserver/include/fdbserver/TagThrottler.h
@@ -90,10 +90,6 @@ public:
 	Future<Void> tryUpdateAutoThrottling(StorageQueueInfo const&) override;
 	PrioritizedTransactionTagMap<ClientTagThrottleLimits> getClientRates() override;
 
-	// Based on limiting storage queue size, set a ratio by which total throughput on the storage server needs to be
-	// adjusted
-	void setThrottlingRatio(UID storageServerId, Optional<double> ratio);
-
 	// Testing only:
 public:
 	void setQuota(TransactionTagRef, ThrottleApi::TagQuotaValue const&);

--- a/fdbserver/include/fdbserver/TagThrottler.h
+++ b/fdbserver/include/fdbserver/TagThrottler.h
@@ -88,6 +88,10 @@ public:
 	bool isAutoThrottlingEnabled() const override;
 	Future<Void> tryUpdateAutoThrottling(StorageQueueInfo const&) override;
 
+	// Based on limiting storage queue size, set a ratio by which total throughput needs to be
+	// adjusted
+	void setThrottlingRatio(Optional<double>);
+
 	// testing only
 public:
 	void setQuota(TransactionTagRef, ThrottleApi::TagQuotaValue const&);

--- a/fdbserver/workloads/GlobalTagThrottling.actor.cpp
+++ b/fdbserver/workloads/GlobalTagThrottling.actor.cpp
@@ -50,6 +50,7 @@ class GlobalTagThrottlingWorkload : public TestWorkload {
 				wait(tr->commit());
 				return Void();
 			} catch (Error& e) {
+				TraceEvent("GlobalTagThrottlingWorkload_SetupError").error(e);
 				wait(tr->onError(e));
 			}
 		};

--- a/fdbserver/workloads/ReadWrite.actor.cpp
+++ b/fdbserver/workloads/ReadWrite.actor.cpp
@@ -690,6 +690,10 @@ struct ReadWriteWorkload : ReadWriteCommon {
 
 						break;
 					} catch (Error& e) {
+						if (e.code() == error_code_tag_throttled) {
+							++self->transactionsTagThrottled;
+						}
+
 						self->transactionFailureMetric->errorCode = e.code();
 						self->transactionFailureMetric->log();
 


### PR DESCRIPTION
This pull request contains many improvements to the `GlobalTagThrottler`, initially introduced in https://github.com/apple/foundationdb/pull/7112. Among these improvements:

- Global tag throttler tracks more fine-grained metrics per storage server
- Tag quotas are now cleaned up properly when removed from the system keyspace
- Implemented `GlobalTagThrottler::busy*TagCount` methods
- Improved tracing
- A `/GlobalTagThrottling/` unit test suite is added (using a mock environment of clients, storage servers, and the global tag throttler)
- Several bug fixes uncovered by new unit test framework
- Documentation is added in comments and in `global-tag-throttling.md`

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
