### PR TITLE
Backups: Azure: Issue 7570: Check existance of container before creation attempt

### DIFF
--- a/fdbclient/azure_backup/BackupContainerAzureBlobStore.actor.cpp
+++ b/fdbclient/azure_backup/BackupContainerAzureBlobStore.actor.cpp
@@ -333,7 +333,10 @@ Future<Void> BackupContainerAzureBlobStore::create() {
 	TraceEvent(SevDebug, "BCAzureBlobStoreCreateContainer").detail("ContainerName", containerName);
 	Future<Void> createContainerFuture =
 	    asyncTaskThread.execAsync([containerName = this->containerName, client = this->client] {
-		    waitAzureFuture(client->create_container(containerName), "create_container");
+		    auto outcome = client->get_container_properties(containerName).get();
+		    if (!outcome.success()) {
+			    waitAzureFuture(client->create_container(containerName), "create_container");
+		    }
 		    return Void();
 	    });
 	Future<Void> encryptionSetupFuture = usesEncryption() ? encryptionSetupComplete() : Void();


### PR DESCRIPTION
The code adds a workaround for a Segfault appearing deep inside the azure sdk. The code checks for the existence of a
container before attempting creation. This is related to issue https://github.com/apple/foundationdb/issues/7570

Please note this code is enabled only when -DBUILD_AZURE_BACKUP=ON is turned on via cmake.

Release branches vs Master/main

Master has the affected file inside a subdirectory azure_backup. Release 7.1 branch (the release I am using) has the same file in the parent directory. I will be making a separate pull request for Release 7.1 and Release 7.2 branch.
# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
