### PR TITLE
Fix ConflictingKeysImpl::getRange

### DIFF
--- a/fdbserver/workloads/ReportConflictingKeys.actor.cpp
+++ b/fdbserver/workloads/ReportConflictingKeys.actor.cpp
@@ -143,10 +143,14 @@ struct ReportConflictingKeysWorkload : TestWorkload {
 	void validateRandomGetRangeResults(KeyRangeMap<Value>& conflictingKeys, Reference<ReadYourWritesTransaction> tr) {
 		int loopTime = 10 * conflictingKeys.size();
 		for (int i = 0; i < loopTime; i++) {
-			// TODO: randomly choose the conflicting keys as the boundary to test
 			Key startKey =
 			    Key(deterministicRandom()->randomAlphaNumeric(deterministicRandom()->randomInt(1, keyBytes)));
 			Key endKey = Key(deterministicRandom()->randomAlphaNumeric(deterministicRandom()->randomInt(1, keyBytes)));
+			// randomly choose the underlying conflicting keys as the boundary to test
+			if (deterministicRandom()->random01() < 0.1)
+				startKey = conflictingKeys.rangeContaining(startKey).begin();
+			if (deterministicRandom()->random01() < 0.1)
+				endKey = conflictingKeys.rangeContaining(endKey).begin();
 			KeyRangeRef kr = startKey <= endKey ? KeyRangeRef(startKey, endKey) : KeyRangeRef(endKey, startKey);
 			Future<RangeResult> res = tr->getRange(kr.withPrefix(conflictingKeysRange.begin), CLIENT_KNOBS->TOO_MANY);
 			ASSERT(res.isReady());


### PR DESCRIPTION
This pr is fixing the specific bug in conflicting keys implementation.
Also add the random read tests for this implementation.

A more general test is pr #7597 

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
