### PR TITLE
Add Encryption Flag to TenantMapEntry

### DIFF
--- a/fdbclient/include/fdbclient/Tenant.h
+++ b/fdbclient/include/fdbclient/Tenant.h
@@ -37,12 +37,13 @@ struct TenantMapEntry {
 
 	int64_t id;
 	Key prefix;
+	bool encrypted;
 
 	constexpr static int PREFIX_SIZE = sizeof(id);
 
 public:
 	TenantMapEntry();
-	TenantMapEntry(int64_t id);
+	TenantMapEntry(int64_t id, bool encrypted);
 
 	Value encode() const { return ObjectWriter::toValue(*this, IncludeVersion(ProtocolVersion::withTenants())); }
 
@@ -55,7 +56,7 @@ public:
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, id);
+		serializer(ar, id, encrypted);
 		if constexpr (Ar::isDeserializing) {
 			if (id >= 0) {
 				prefix = idToPrefix(id);

--- a/fdbclient/include/fdbclient/Tenant.h
+++ b/fdbclient/include/fdbclient/Tenant.h
@@ -37,7 +37,7 @@ struct TenantMapEntry {
 
 	int64_t id;
 	Key prefix;
-	// indicates whether the current tenant entry is encrypted
+	// indicates whether the tenant is encrypted
 	bool encrypted;
 
 	constexpr static int PREFIX_SIZE = sizeof(id);

--- a/fdbclient/include/fdbclient/Tenant.h
+++ b/fdbclient/include/fdbclient/Tenant.h
@@ -37,6 +37,7 @@ struct TenantMapEntry {
 
 	int64_t id;
 	Key prefix;
+	// indicates whether the current tenant entry is encrypted
 	bool encrypted;
 
 	constexpr static int PREFIX_SIZE = sizeof(id);

--- a/fdbclient/include/fdbclient/TenantManagement.actor.h
+++ b/fdbclient/include/fdbclient/TenantManagement.actor.h
@@ -108,7 +108,8 @@ Future<std::pair<TenantMapEntry, bool>> createTenantTransaction(Transaction tr, 
 		return std::make_pair(tenantEntry.get(), false);
 	}
 
-	state TenantMapEntry newTenant(tenantId);
+	// TODO: Pass in the actual encrypted value here once implemented in the client
+	state TenantMapEntry newTenant(tenantId, false);
 
 	state typename transaction_future_type<Transaction, RangeResult>::type prefixRangeFuture =
 	    tr->getRange(prefixRange(newTenant.prefix), 1);

--- a/fdbclient/include/fdbclient/TenantSpecialKeys.actor.h
+++ b/fdbclient/include/fdbclient/TenantSpecialKeys.actor.h
@@ -126,8 +126,9 @@ private:
 
 		std::vector<Future<Void>> createFutures;
 		for (auto tenant : tenants) {
+			// TODO: need to pass actual value of encrypted here
 			createFutures.push_back(
-			    success(TenantAPI::createTenantTransaction(&ryw->getTransaction(), tenant, nextId++)));
+			    success(TenantAPI::createTenantTransaction(&ryw->getTransaction(), tenant, nextId++, false)));
 		}
 
 		ryw->getTransaction().set(tenantLastIdKey, TenantMapEntry::idToPrefix(nextId - 1));

--- a/fdbserver/TenantCache.actor.cpp
+++ b/fdbserver/TenantCache.actor.cpp
@@ -220,7 +220,7 @@ public:
 
 		for (uint16_t i = 0; i < tenantCount; i++) {
 			TenantName tenantName(format("%s_%08d", "ddtc_test_tenant", tenantNumber + i));
-			TenantMapEntry tenant(tenantNumber + i);
+			TenantMapEntry tenant(tenantNumber + i, false);
 
 			tenantCache.insert(tenantName, tenant);
 		}
@@ -248,7 +248,7 @@ public:
 
 		for (uint16_t i = 0; i < tenantCount; i++) {
 			TenantName tenantName(format("%s_%08d", "ddtc_test_tenant", tenantNumber + i));
-			TenantMapEntry tenant(tenantNumber + i);
+			TenantMapEntry tenant(tenantNumber + i, false);
 
 			tenantCache.insert(tenantName, tenant);
 		}
@@ -262,7 +262,7 @@ public:
 
 			if (tenantOrdinal % staleTenantFraction != 0) {
 				TenantName tenantName(format("%s_%08d", "ddtc_test_tenant", tenantOrdinal));
-				TenantMapEntry tenant(tenantOrdinal);
+				TenantMapEntry tenant(tenantOrdinal, false);
 				bool newTenant = tenantCache.update(tenantName, tenant);
 				ASSERT(!newTenant);
 				keepCount++;

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -3992,11 +3992,11 @@ bool rangeIntersectsAnyTenant(TenantPrefixIndex& prefixIndex, KeyRangeRef range,
 }
 
 TEST_CASE("/fdbserver/storageserver/rangeIntersectsAnyTenant") {
-	std::map<TenantName, TenantMapEntry> entries = { std::make_pair("tenant0"_sr, TenantMapEntry(0)),
-		                                             std::make_pair("tenant2"_sr, TenantMapEntry(2)),
-		                                             std::make_pair("tenant3"_sr, TenantMapEntry(3)),
-		                                             std::make_pair("tenant4"_sr, TenantMapEntry(4)),
-		                                             std::make_pair("tenant6"_sr, TenantMapEntry(6)) };
+	std::map<TenantName, TenantMapEntry> entries = { std::make_pair("tenant0"_sr, TenantMapEntry(0, false)),
+		                                             std::make_pair("tenant2"_sr, TenantMapEntry(2, false)),
+		                                             std::make_pair("tenant3"_sr, TenantMapEntry(3, false)),
+		                                             std::make_pair("tenant4"_sr, TenantMapEntry(4, true)),
+		                                             std::make_pair("tenant6"_sr, TenantMapEntry(6, true)) };
 	TenantPrefixIndex index;
 	index.createNewVersion(1);
 	for (auto entry : entries) {

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -3992,11 +3992,13 @@ bool rangeIntersectsAnyTenant(TenantPrefixIndex& prefixIndex, KeyRangeRef range,
 }
 
 TEST_CASE("/fdbserver/storageserver/rangeIntersectsAnyTenant") {
-	std::map<TenantName, TenantMapEntry> entries = { std::make_pair("tenant0"_sr, TenantMapEntry(0, false)),
-		                                             std::make_pair("tenant2"_sr, TenantMapEntry(2, false)),
-		                                             std::make_pair("tenant3"_sr, TenantMapEntry(3, false)),
-		                                             std::make_pair("tenant4"_sr, TenantMapEntry(4, true)),
-		                                             std::make_pair("tenant6"_sr, TenantMapEntry(6, true)) };
+	std::map<TenantName, TenantMapEntry> entries = {
+		std::make_pair("tenant0"_sr, TenantMapEntry(0, deterministicRandom()->coinflip())),
+		std::make_pair("tenant2"_sr, TenantMapEntry(2, deterministicRandom()->coinflip())),
+		std::make_pair("tenant3"_sr, TenantMapEntry(3, deterministicRandom()->coinflip())),
+		std::make_pair("tenant4"_sr, TenantMapEntry(4, deterministicRandom()->coinflip())),
+		std::make_pair("tenant6"_sr, TenantMapEntry(6, deterministicRandom()->coinflip()))
+	};
 	TenantPrefixIndex index;
 	index.createNewVersion(1);
 	for (auto entry : entries) {

--- a/fdbserver/tester.actor.cpp
+++ b/fdbserver/tester.actor.cpp
@@ -1634,7 +1634,7 @@ ACTOR Future<Void> runTests(Reference<AsyncVar<Optional<struct ClusterController
 		std::vector<Future<Void>> tenantFutures;
 		for (auto tenant : tenantsToCreate) {
 			TraceEvent("CreatingTenant").detail("Tenant", tenant);
-			tenantFutures.push_back(success(TenantAPI::createTenant(cx.getReference(), tenant)));
+			tenantFutures.push_back(success(TenantAPI::createTenant(cx.getReference(), tenant, false)));
 		}
 
 		wait(waitForAll(tenantFutures));

--- a/fdbserver/workloads/BlobGranuleCorrectnessWorkload.actor.cpp
+++ b/fdbserver/workloads/BlobGranuleCorrectnessWorkload.actor.cpp
@@ -212,7 +212,7 @@ struct BlobGranuleCorrectnessWorkload : TestWorkload {
 			fmt::print("Setting up blob granule range for tenant {0}\n", name.printable());
 		}
 
-		TenantMapEntry entry = wait(TenantAPI::createTenant(cx.getReference(), name));
+		TenantMapEntry entry = wait(TenantAPI::createTenant(cx.getReference(), name, false));
 
 		if (BGW_DEBUG) {
 			fmt::print("Set up blob granule range for tenant {0}: {1}\n", name.printable(), entry.prefix.printable());

--- a/fdbserver/workloads/FuzzApiCorrectness.actor.cpp
+++ b/fdbserver/workloads/FuzzApiCorrectness.actor.cpp
@@ -226,7 +226,7 @@ struct FuzzApiCorrectnessWorkload : TestWorkload {
 
 			// The last tenant will not be created
 			if (i < self->numTenants) {
-				tenantFutures.push_back(::success(TenantAPI::createTenant(cx.getReference(), tenantName)));
+				tenantFutures.push_back(::success(TenantAPI::createTenant(cx.getReference(), tenantName, false)));
 				self->createdTenants.insert(tenantName);
 			}
 		}

--- a/fdbserver/workloads/TenantManagementWorkload.actor.cpp
+++ b/fdbserver/workloads/TenantManagementWorkload.actor.cpp
@@ -399,7 +399,9 @@ struct TenantManagementWorkload : TestWorkload {
 		std::string prefix;
 		std::string base64Prefix;
 		std::string printablePrefix;
+		bool encrypted;
 		jsonDoc.get("id", id);
+		jsonDoc.get("encrypted", encrypted);
 		jsonDoc.get("prefix.base64", base64Prefix);
 		jsonDoc.get("prefix.printable", printablePrefix);
 
@@ -407,7 +409,7 @@ struct TenantManagementWorkload : TestWorkload {
 		ASSERT(prefix == unprintable(printablePrefix));
 
 		Key prefixKey = KeyRef(prefix);
-		TenantMapEntry entry(id);
+		TenantMapEntry entry(id, encrypted);
 
 		ASSERT(entry.prefix == prefixKey);
 		return entry;


### PR DESCRIPTION
Add a bool to TenantMapEntry that indicates whether the current tenant is encrypted or not. Once we make the necessary changes in metacluster we can populate this value accurately

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
