### PR TITLE
Use key-backed types for tenants

### DIFF
--- a/bindings/python/tests/fdbcli_tests.py
+++ b/bindings/python/tests/fdbcli_tests.py
@@ -616,21 +616,23 @@ def tenants(logger):
 
     output = run_fdbcli_command('gettenant tenant')
     lines = output.split('\n')
-    assert len(lines) == 2
+    assert len(lines) == 3
     assert lines[0].strip().startswith('id: ')
     assert lines[1].strip().startswith('prefix: ')
+    assert lines[2].strip() == 'tenant state: ready'
 
     output = run_fdbcli_command('gettenant tenant JSON')
     json_output = json.loads(output, strict=False)
     assert(len(json_output) == 2)
     assert('tenant' in json_output)
     assert(json_output['type'] == 'success')
-    assert(len(json_output['tenant']) == 2)
+    assert(len(json_output['tenant']) == 3)
     assert('id' in json_output['tenant'])
     assert('prefix' in json_output['tenant'])
     assert(len(json_output['tenant']['prefix']) == 2)
     assert('base64' in json_output['tenant']['prefix'])
     assert('printable' in json_output['tenant']['prefix'])
+    assert(json_output['tenant']['tenant_state'] == 'ready')
 
     output = run_fdbcli_command('usetenant')
     assert output == 'Using the default tenant'

--- a/fdbcli/TenantCommands.actor.cpp
+++ b/fdbcli/TenantCommands.actor.cpp
@@ -69,14 +69,14 @@ ACTOR Future<bool> createTenantCommandActor(Reference<IDatabase> db, std::vector
 			state Error err(e);
 			if (e.code() == error_code_special_keys_api_failure) {
 				std::string errorMsgStr = wait(fdb_cli::getSpecialKeysFailureErrorMessage(tr));
-				fprintf(stderr, "ERROR: %s\n", errorMsgStr.c_str());
+				fmt::print(stderr, "ERROR: {}\n", errorMsgStr.c_str());
 				return false;
 			}
 			wait(safeThreadFutureToFuture(tr->onError(err)));
 		}
 	}
 
-	printf("The tenant `%s' has been created\n", printable(tokens[1]).c_str());
+	fmt::print("The tenant `{}' has been created\n", printable(tokens[1]).c_str());
 	return true;
 }
 
@@ -116,14 +116,14 @@ ACTOR Future<bool> deleteTenantCommandActor(Reference<IDatabase> db, std::vector
 			state Error err(e);
 			if (e.code() == error_code_special_keys_api_failure) {
 				std::string errorMsgStr = wait(fdb_cli::getSpecialKeysFailureErrorMessage(tr));
-				fprintf(stderr, "ERROR: %s\n", errorMsgStr.c_str());
+				fmt::print(stderr, "ERROR: {}\n", errorMsgStr.c_str());
 				return false;
 			}
 			wait(safeThreadFutureToFuture(tr->onError(err)));
 		}
 	}
 
-	printf("The tenant `%s' has been deleted\n", printable(tokens[1]).c_str());
+	fmt::print("The tenant `{}' has been deleted\n", printable(tokens[1]).c_str());
 	return true;
 }
 
@@ -151,14 +151,14 @@ ACTOR Future<bool> listTenantsCommandActor(Reference<IDatabase> db, std::vector<
 	if (tokens.size() >= 3) {
 		endTenant = tokens[2];
 		if (endTenant <= beginTenant) {
-			fprintf(stderr, "ERROR: end must be larger than begin");
+			fmt::print(stderr, "ERROR: end must be larger than begin");
 			return false;
 		}
 	}
 	if (tokens.size() == 4) {
 		int n = 0;
 		if (sscanf(tokens[3].toString().c_str(), "%d%n", &limit, &n) != 1 || n != tokens[3].size()) {
-			fprintf(stderr, "ERROR: invalid limit %s\n", tokens[3].toString().c_str());
+			fmt::print(stderr, "ERROR: invalid limit {}\n", tokens[3].toString().c_str());
 			return false;
 		}
 	}
@@ -176,17 +176,17 @@ ACTOR Future<bool> listTenantsCommandActor(Reference<IDatabase> db, std::vector<
 
 			if (tenants.empty()) {
 				if (tokens.size() == 1) {
-					printf("The cluster has no tenants\n");
+					fmt::print("The cluster has no tenants\n");
 				} else {
-					printf("The cluster has no tenants in the specified range\n");
+					fmt::print("The cluster has no tenants in the specified range\n");
 				}
 			}
 
 			int index = 0;
 			for (auto tenant : tenants) {
-				printf("  %d. %s\n",
-				       ++index,
-				       printable(tenant.key.removePrefix(fdb_cli::tenantSpecialKeyRange.begin)).c_str());
+				fmt::print("  {}. {}\n",
+				           ++index,
+				           printable(tenant.key.removePrefix(fdb_cli::tenantSpecialKeyRange.begin)).c_str());
 			}
 
 			return true;
@@ -194,7 +194,7 @@ ACTOR Future<bool> listTenantsCommandActor(Reference<IDatabase> db, std::vector<
 			state Error err(e);
 			if (e.code() == error_code_special_keys_api_failure) {
 				std::string errorMsgStr = wait(fdb_cli::getSpecialKeysFailureErrorMessage(tr));
-				fprintf(stderr, "ERROR: %s\n", errorMsgStr.c_str());
+				fmt::print(stderr, "ERROR: {}\n", errorMsgStr.c_str());
 				return false;
 			}
 			wait(safeThreadFutureToFuture(tr->onError(err)));
@@ -236,23 +236,29 @@ ACTOR Future<bool> getTenantCommandActor(Reference<IDatabase> db, std::vector<St
 				json_spirit::mObject resultObj;
 				resultObj["tenant"] = jsonObject;
 				resultObj["type"] = "success";
-				printf("%s\n",
-				       json_spirit::write_string(json_spirit::mValue(resultObj), json_spirit::pretty_print).c_str());
+				fmt::print(
+				    "{}\n",
+				    json_spirit::write_string(json_spirit::mValue(resultObj), json_spirit::pretty_print).c_str());
 			} else {
 				JSONDoc doc(jsonObject);
 
 				int64_t id;
 				std::string prefix;
+				std::string tenantState;
 
 				doc.get("id", id);
+
 				if (apiVersion >= 720) {
 					doc.get("prefix.printable", prefix);
 				} else {
 					doc.get("prefix", prefix);
 				}
 
-				printf("  id: %" PRId64 "\n", id);
-				printf("  prefix: %s\n", prefix.c_str());
+				doc.get("tenant_state", tenantState);
+
+				fmt::print("  id: {}\n", id);
+				fmt::print("  prefix: {}\n", printable(prefix).c_str());
+				fmt::print("  tenant state: {}\n", printable(tenantState).c_str());
 			}
 
 			return true;
@@ -274,11 +280,11 @@ ACTOR Future<bool> getTenantCommandActor(Reference<IDatabase> db, std::vector<St
 					json_spirit::mObject resultObj;
 					resultObj["type"] = "error";
 					resultObj["error"] = errorStr;
-					printf(
-					    "%s\n",
+					fmt::print(
+					    "{}\n",
 					    json_spirit::write_string(json_spirit::mValue(resultObj), json_spirit::pretty_print).c_str());
 				} else {
-					fprintf(stderr, "ERROR: %s\n", errorStr.c_str());
+					fmt::print(stderr, "ERROR: {}\n", errorStr.c_str());
 				}
 
 				return false;
@@ -301,7 +307,8 @@ ACTOR Future<bool> renameTenantCommandActor(Reference<IDatabase> db, std::vector
 	}
 	wait(safeThreadFutureToFuture(TenantAPI::renameTenant(db, tokens[1], tokens[2])));
 
-	printf("The tenant `%s' has been renamed to `%s'\n", printable(tokens[1]).c_str(), printable(tokens[2]).c_str());
+	fmt::print(
+	    "The tenant `{}' has been renamed to `{}'\n", printable(tokens[1]).c_str(), printable(tokens[2]).c_str());
 	return true;
 }
 

--- a/fdbclient/include/fdbclient/SystemData.h
+++ b/fdbclient/include/fdbclient/SystemData.h
@@ -679,12 +679,6 @@ UID decodeBlobWorkerListKey(KeyRef const& key);
 const Value blobWorkerListValue(BlobWorkerInterface const& interface);
 BlobWorkerInterface decodeBlobWorkerListValue(ValueRef const& value);
 
-// State for the tenant map
-extern const KeyRangeRef tenantMapKeys;
-extern const KeyRef tenantMapPrefix;
-extern const KeyRef tenantMapPrivatePrefix;
-extern const KeyRef tenantLastIdKey;
-
 // Storage quota per tenant
 // "\xff/storageQuota/[[tenantName]]" := "[[quota]]"
 extern const KeyRangeRef storageQuotaKeys;

--- a/fdbclient/include/fdbclient/Tenant.h
+++ b/fdbclient/include/fdbclient/Tenant.h
@@ -23,11 +23,14 @@
 #pragma once
 
 #include "fdbclient/FDBTypes.h"
+#include "fdbclient/KeyBackedTypes.h"
 #include "fdbclient/VersionedMap.h"
 #include "flow/flat_buffers.h"
 
 typedef StringRef TenantNameRef;
 typedef Standalone<TenantNameRef> TenantName;
+
+enum class TenantState { REGISTERING, READY, REMOVING, UPDATING_CONFIGURATION, ERROR };
 
 struct TenantMapEntry {
 	constexpr static FileIdentifier file_identifier = 12247338;
@@ -35,33 +38,63 @@ struct TenantMapEntry {
 	static Key idToPrefix(int64_t id);
 	static int64_t prefixToId(KeyRef prefix);
 
-	int64_t id;
+	static std::string tenantStateToString(TenantState tenantState);
+	static TenantState stringToTenantState(std::string stateStr);
+
+	int64_t id = -1;
 	Key prefix;
+	TenantState tenantState = TenantState::READY;
 
 	constexpr static int PREFIX_SIZE = sizeof(id);
 
 public:
 	TenantMapEntry();
-	TenantMapEntry(int64_t id);
+	TenantMapEntry(int64_t id, TenantState tenantState);
+
+	void setId(int64_t id);
+	std::string toJson(int apiVersion) const;
 
 	Value encode() const { return ObjectWriter::toValue(*this, IncludeVersion(ProtocolVersion::withTenants())); }
 
 	static TenantMapEntry decode(ValueRef const& value) {
 		TenantMapEntry entry;
-		ObjectReader reader(value.begin(), IncludeVersion(ProtocolVersion::withTenants()));
+		ObjectReader reader(value.begin(), IncludeVersion());
 		reader.deserialize(entry);
 		return entry;
 	}
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, id);
+		serializer(ar, id, tenantState);
 		if constexpr (Ar::isDeserializing) {
 			if (id >= 0) {
 				prefix = idToPrefix(id);
 			}
+			ASSERT(tenantState >= TenantState::REGISTERING && tenantState <= TenantState::ERROR);
 		}
 	}
+};
+
+struct TenantMetadataSpecification {
+	static KeyRef subspace;
+
+	KeyBackedObjectMap<TenantName, TenantMapEntry, decltype(IncludeVersion()), NullCodec> tenantMap;
+	KeyBackedProperty<int64_t> lastTenantId;
+
+	TenantMetadataSpecification(KeyRef subspace)
+	  : tenantMap(subspace.withSuffix("tenant/map/"_sr), IncludeVersion(ProtocolVersion::withTenants())),
+	    lastTenantId(subspace.withSuffix("tenant/lastId"_sr)) {}
+};
+
+struct TenantMetadata {
+private:
+	static inline TenantMetadataSpecification instance = TenantMetadataSpecification("\xff/"_sr);
+
+public:
+	static inline auto& tenantMap = instance.tenantMap;
+	static inline auto& lastTenantId = instance.lastTenantId;
+
+	static inline Key tenantMapPrivatePrefix = "\xff"_sr.withSuffix(tenantMap.subspace.begin);
 };
 
 typedef VersionedMap<TenantName, TenantMapEntry> TenantMap;

--- a/fdbclient/include/fdbclient/TenantManagement.actor.h
+++ b/fdbclient/include/fdbclient/TenantManagement.actor.h
@@ -33,15 +33,11 @@
 #include "flow/actorcompiler.h" // has to be last include
 
 namespace TenantAPI {
-ACTOR template <class Transaction>
+
+template <class Transaction>
 Future<Optional<TenantMapEntry>> tryGetTenantTransaction(Transaction tr, TenantName name) {
-	state Key tenantMapKey = name.withPrefix(tenantMapPrefix);
-
 	tr->setOption(FDBTransactionOptions::RAW_ACCESS);
-
-	state typename transaction_future_type<Transaction, Optional<Value>>::type tenantFuture = tr->get(tenantMapKey);
-	Optional<Value> val = wait(safeThreadFutureToFuture(tenantFuture));
-	return val.map<TenantMapEntry>([](Optional<Value> v) { return TenantMapEntry::decode(v.get()); });
+	return TenantMetadata::tenantMap.get(tr, name);
 }
 
 ACTOR template <class DB>
@@ -80,12 +76,28 @@ Future<TenantMapEntry> getTenant(Reference<DB> db, TenantName name) {
 	return entry.get();
 }
 
-// Creates a tenant with the given name. If the tenant already exists, an empty optional will be returned.
-// The caller must enforce that the tenant ID be unique from all current and past tenants, and it must also be unique
-// from all other tenants created in the same transaction.
 ACTOR template <class Transaction>
-Future<std::pair<TenantMapEntry, bool>> createTenantTransaction(Transaction tr, TenantNameRef name, int64_t tenantId) {
-	state Key tenantMapKey = name.withPrefix(tenantMapPrefix);
+Future<Void> checkTenantMode(Transaction tr) {
+	state typename transaction_future_type<Transaction, Optional<Value>>::type tenantModeFuture =
+	    tr->get(configKeysPrefix.withSuffix("tenant_mode"_sr));
+
+	Optional<Value> tenantModeValue = wait(safeThreadFutureToFuture(tenantModeFuture));
+
+	TenantMode tenantMode = TenantMode::fromValue(tenantModeValue.castTo<ValueRef>());
+	if (tenantMode == TenantMode::DISABLED) {
+		throw tenants_disabled();
+	}
+
+	return Void();
+}
+
+// Creates a tenant with the given name. If the tenant already exists, the boolean return parameter will be false
+// and the existing entry will be returned. If the tenant cannot be created, then the optional will be empty.
+ACTOR template <class Transaction>
+Future<std::pair<Optional<TenantMapEntry>, bool>> createTenantTransaction(Transaction tr,
+                                                                          TenantNameRef name,
+                                                                          TenantMapEntry tenantEntry) {
+	ASSERT(tenantEntry.id >= 0);
 
 	if (name.startsWith("\xff"_sr)) {
 		throw invalid_tenant_name();
@@ -93,40 +105,32 @@ Future<std::pair<TenantMapEntry, bool>> createTenantTransaction(Transaction tr, 
 
 	tr->setOption(FDBTransactionOptions::RAW_ACCESS);
 
-	state Future<Optional<TenantMapEntry>> tenantEntryFuture = tryGetTenantTransaction(tr, name);
-	state typename transaction_future_type<Transaction, Optional<Value>>::type tenantModeFuture =
-	    tr->get(configKeysPrefix.withSuffix("tenant_mode"_sr));
+	state Future<Optional<TenantMapEntry>> existingEntryFuture = tryGetTenantTransaction(tr, name);
+	wait(checkTenantMode(tr));
 
-	Optional<Value> tenantMode = wait(safeThreadFutureToFuture(tenantModeFuture));
-
-	if (!tenantMode.present() || tenantMode.get() == StringRef(format("%d", TenantMode::DISABLED))) {
-		throw tenants_disabled();
+	Optional<TenantMapEntry> existingEntry = wait(existingEntryFuture);
+	if (existingEntry.present()) {
+		return std::make_pair(existingEntry.get(), false);
 	}
-
-	Optional<TenantMapEntry> tenantEntry = wait(tenantEntryFuture);
-	if (tenantEntry.present()) {
-		return std::make_pair(tenantEntry.get(), false);
-	}
-
-	state TenantMapEntry newTenant(tenantId);
 
 	state typename transaction_future_type<Transaction, RangeResult>::type prefixRangeFuture =
-	    tr->getRange(prefixRange(newTenant.prefix), 1);
+	    tr->getRange(prefixRange(tenantEntry.prefix), 1);
+
 	RangeResult contents = wait(safeThreadFutureToFuture(prefixRangeFuture));
 	if (!contents.empty()) {
 		throw tenant_prefix_allocator_conflict();
 	}
 
-	tr->set(tenantMapKey, newTenant.encode());
+	tenantEntry.tenantState = TenantState::READY;
+	TenantMetadata::tenantMap.set(tr, name, tenantEntry);
 
-	return std::make_pair(newTenant, true);
+	return std::make_pair(tenantEntry, true);
 }
 
 ACTOR template <class Transaction>
 Future<int64_t> getNextTenantId(Transaction tr) {
-	state typename transaction_future_type<Transaction, Optional<Value>>::type lastIdFuture = tr->get(tenantLastIdKey);
-	Optional<Value> lastIdVal = wait(safeThreadFutureToFuture(lastIdFuture));
-	int64_t tenantId = lastIdVal.present() ? TenantMapEntry::prefixToId(lastIdVal.get()) + 1 : 0;
+	Optional<int64_t> lastId = wait(TenantMetadata::lastTenantId.get(tr));
+	int64_t tenantId = lastId.orDefault(-1) + 1;
 	if (BUGGIFY) {
 		tenantId += deterministicRandom()->randomSkewedUInt32(1, 1e9);
 	}
@@ -134,37 +138,52 @@ Future<int64_t> getNextTenantId(Transaction tr) {
 }
 
 ACTOR template <class DB>
-Future<TenantMapEntry> createTenant(Reference<DB> db, TenantName name) {
+Future<Optional<TenantMapEntry>> createTenant(Reference<DB> db,
+                                              TenantName name,
+                                              TenantMapEntry tenantEntry = TenantMapEntry()) {
 	state Reference<typename DB::TransactionT> tr = db->createTransaction();
 
-	state bool firstTry = true;
+	state bool checkExistence = true;
+	state bool generateTenantId = tenantEntry.id < 0;
+
 	loop {
 		try {
 			tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
 			tr->setOption(FDBTransactionOptions::LOCK_AWARE);
 
-			state Future<int64_t> tenantIdFuture = getNextTenantId(tr);
+			state Future<int64_t> tenantIdFuture;
+			if (generateTenantId) {
+				tenantIdFuture = getNextTenantId(tr);
+			}
 
-			if (firstTry) {
+			if (checkExistence) {
 				Optional<TenantMapEntry> entry = wait(tryGetTenantTransaction(tr, name));
 				if (entry.present()) {
 					throw tenant_already_exists();
 				}
 
-				firstTry = false;
+				checkExistence = false;
 			}
 
-			int64_t tenantId = wait(tenantIdFuture);
-			tr->set(tenantLastIdKey, TenantMapEntry::idToPrefix(tenantId));
-			state std::pair<TenantMapEntry, bool> newTenant = wait(createTenantTransaction(tr, name, tenantId));
+			if (generateTenantId) {
+				int64_t tenantId = wait(tenantIdFuture);
+				tenantEntry.setId(tenantId);
+				TenantMetadata::lastTenantId.set(tr, tenantId);
+			}
 
-			wait(buggifiedCommit(tr, BUGGIFY_WITH_PROB(0.1)));
+			state std::pair<Optional<TenantMapEntry>, bool> newTenant =
+			    wait(createTenantTransaction(tr, name, tenantEntry));
 
-			TraceEvent("CreatedTenant")
-			    .detail("Tenant", name)
-			    .detail("TenantId", newTenant.first.id)
-			    .detail("Prefix", newTenant.first.prefix)
-			    .detail("Version", tr->getCommittedVersion());
+			if (newTenant.second) {
+				ASSERT(newTenant.first.present());
+				wait(buggifiedCommit(tr, BUGGIFY_WITH_PROB(0.1)));
+
+				TraceEvent("CreatedTenant")
+				    .detail("Tenant", name)
+				    .detail("TenantId", newTenant.first.get().id)
+				    .detail("Prefix", newTenant.first.get().prefix)
+				    .detail("Version", tr->getCommittedVersion());
+			}
 
 			return newTenant.first;
 		} catch (Error& e) {
@@ -174,48 +193,50 @@ Future<TenantMapEntry> createTenant(Reference<DB> db, TenantName name) {
 }
 
 ACTOR template <class Transaction>
-Future<Void> deleteTenantTransaction(Transaction tr, TenantNameRef name) {
-	state Key tenantMapKey = name.withPrefix(tenantMapPrefix);
-
+Future<Void> deleteTenantTransaction(Transaction tr,
+                                     TenantNameRef name,
+                                     Optional<int64_t> tenantId = Optional<int64_t>()) {
 	tr->setOption(FDBTransactionOptions::RAW_ACCESS);
 
-	state Optional<TenantMapEntry> tenantEntry = wait(tryGetTenantTransaction(tr, name));
-	if (!tenantEntry.present()) {
-		return Void();
-	}
+	state Future<Optional<TenantMapEntry>> tenantEntryFuture = tryGetTenantTransaction(tr, name);
+	wait(checkTenantMode(tr));
 
-	state typename transaction_future_type<Transaction, RangeResult>::type prefixRangeFuture =
-	    tr->getRange(prefixRange(tenantEntry.get().prefix), 1);
-	RangeResult contents = wait(safeThreadFutureToFuture(prefixRangeFuture));
-	if (!contents.empty()) {
-		throw tenant_not_empty();
-	}
+	state Optional<TenantMapEntry> tenantEntry = wait(tenantEntryFuture);
+	if (tenantEntry.present() && (!tenantId.present() || tenantEntry.get().id == tenantId.get())) {
+		state typename transaction_future_type<Transaction, RangeResult>::type prefixRangeFuture =
+		    tr->getRange(prefixRange(tenantEntry.get().prefix), 1);
 
-	tr->clear(tenantMapKey);
+		RangeResult contents = wait(safeThreadFutureToFuture(prefixRangeFuture));
+		if (!contents.empty()) {
+			throw tenant_not_empty();
+		}
+
+		TenantMetadata::tenantMap.erase(tr, name);
+	}
 
 	return Void();
 }
 
 ACTOR template <class DB>
-Future<Void> deleteTenant(Reference<DB> db, TenantName name) {
+Future<Void> deleteTenant(Reference<DB> db, TenantName name, Optional<int64_t> tenantId = Optional<int64_t>()) {
 	state Reference<typename DB::TransactionT> tr = db->createTransaction();
 
-	state bool firstTry = true;
+	state bool checkExistence = true;
 	loop {
 		try {
 			tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
 			tr->setOption(FDBTransactionOptions::LOCK_AWARE);
 
-			if (firstTry) {
+			if (checkExistence) {
 				Optional<TenantMapEntry> entry = wait(tryGetTenantTransaction(tr, name));
 				if (!entry.present()) {
 					throw tenant_not_found();
 				}
 
-				firstTry = false;
+				checkExistence = false;
 			}
 
-			wait(deleteTenantTransaction(tr, name));
+			wait(deleteTenantTransaction(tr, name, tenantId));
 			wait(buggifiedCommit(tr, BUGGIFY_WITH_PROB(0.1)));
 
 			TraceEvent("DeletedTenant").detail("Tenant", name).detail("Version", tr->getCommittedVersion());
@@ -227,38 +248,31 @@ Future<Void> deleteTenant(Reference<DB> db, TenantName name) {
 }
 
 ACTOR template <class Transaction>
-Future<std::map<TenantName, TenantMapEntry>> listTenantsTransaction(Transaction tr,
-                                                                    TenantNameRef begin,
-                                                                    TenantNameRef end,
-                                                                    int limit) {
-	state KeyRange range = KeyRangeRef(begin, end).withPrefix(tenantMapPrefix);
-
+Future<std::vector<std::pair<TenantName, TenantMapEntry>>> listTenantsTransaction(Transaction tr,
+                                                                                  TenantNameRef begin,
+                                                                                  TenantNameRef end,
+                                                                                  int limit) {
 	tr->setOption(FDBTransactionOptions::RAW_ACCESS);
 
-	state typename transaction_future_type<Transaction, RangeResult>::type listFuture =
-	    tr->getRange(firstGreaterOrEqual(range.begin), firstGreaterOrEqual(range.end), limit);
-	RangeResult results = wait(safeThreadFutureToFuture(listFuture));
+	KeyBackedRangeResult<std::pair<TenantName, TenantMapEntry>> results =
+	    wait(TenantMetadata::tenantMap.getRange(tr, begin, end, limit));
 
-	std::map<TenantName, TenantMapEntry> tenants;
-	for (auto kv : results) {
-		tenants[kv.key.removePrefix(tenantMapPrefix)] = TenantMapEntry::decode(kv.value);
-	}
-
-	return tenants;
+	return results.results;
 }
 
 ACTOR template <class DB>
-Future<std::map<TenantName, TenantMapEntry>> listTenants(Reference<DB> db,
-                                                         TenantName begin,
-                                                         TenantName end,
-                                                         int limit) {
+Future<std::vector<std::pair<TenantName, TenantMapEntry>>> listTenants(Reference<DB> db,
+                                                                       TenantName begin,
+                                                                       TenantName end,
+                                                                       int limit) {
 	state Reference<typename DB::TransactionT> tr = db->createTransaction();
 
 	loop {
 		try {
 			tr->setOption(FDBTransactionOptions::READ_SYSTEM_KEYS);
 			tr->setOption(FDBTransactionOptions::READ_LOCK_AWARE);
-			std::map<TenantName, TenantMapEntry> tenants = wait(listTenantsTransaction(tr, begin, end, limit));
+			std::vector<std::pair<TenantName, TenantMapEntry>> tenants =
+			    wait(listTenantsTransaction(tr, begin, end, limit));
 			return tenants;
 		} catch (Error& e) {
 			wait(safeThreadFutureToFuture(tr->onError(e)));
@@ -270,8 +284,6 @@ ACTOR template <class DB>
 Future<Void> renameTenant(Reference<DB> db, TenantName oldName, TenantName newName) {
 	state Reference<typename DB::TransactionT> tr = db->createTransaction();
 
-	state Key oldNameKey = oldName.withPrefix(tenantMapPrefix);
-	state Key newNameKey = newName.withPrefix(tenantMapPrefix);
 	state bool firstTry = true;
 	state int64_t id;
 	loop {
@@ -314,8 +326,10 @@ Future<Void> renameTenant(Reference<DB> db, TenantName oldName, TenantName newNa
 					throw tenant_not_found();
 				}
 			}
-			tr->clear(oldNameKey);
-			tr->set(newNameKey, oldEntry.get().encode());
+
+			TenantMetadata::tenantMap.erase(tr, oldName);
+			TenantMetadata::tenantMap.set(tr, newName, oldEntry.get());
+
 			wait(safeThreadFutureToFuture(tr->commit()));
 			TraceEvent("RenameTenantSuccess").detail("OldName", oldName).detail("NewName", newName);
 			return Void();

--- a/fdbclient/include/fdbclient/TenantManagement.actor.h
+++ b/fdbclient/include/fdbclient/TenantManagement.actor.h
@@ -192,6 +192,10 @@ Future<Optional<TenantMapEntry>> createTenant(Reference<DB> db,
 	}
 }
 
+// Deletes the tenant with the given name. If tenantId is specified, the tenant being deleted must also have the same
+// ID. If no matching tenant is found, this function returns without deleting anything. This behavior allows the
+// function to be used idempotently: if the transaction is retried after having succeeded, it will see that the tenant
+// is absent (or optionally created with a new ID) and do nothing.
 ACTOR template <class Transaction>
 Future<Void> deleteTenantTransaction(Transaction tr,
                                      TenantNameRef name,
@@ -217,6 +221,8 @@ Future<Void> deleteTenantTransaction(Transaction tr,
 	return Void();
 }
 
+// Deletes the tenant with the given name. If tenantId is specified, the tenant being deleted must also have the same
+// ID.
 ACTOR template <class DB>
 Future<Void> deleteTenant(Reference<DB> db, TenantName name, Optional<int64_t> tenantId = Optional<int64_t>()) {
 	state Reference<typename DB::TransactionT> tr = db->createTransaction();
@@ -228,9 +234,12 @@ Future<Void> deleteTenant(Reference<DB> db, TenantName name, Optional<int64_t> t
 			tr->setOption(FDBTransactionOptions::LOCK_AWARE);
 
 			if (checkExistence) {
-				Optional<TenantMapEntry> entry = wait(tryGetTenantTransaction(tr, name));
-				if (!entry.present()) {
-					throw tenant_not_found();
+				TenantMapEntry entry = wait(getTenantTransaction(tr, name));
+
+				// If an ID wasn't specified, use the current ID. This way we cannot inadvertently delete
+				// multiple tenants if this transaction retries.
+				if (!tenantId.present()) {
+					tenantId = entry.id;
 				}
 
 				checkExistence = false;

--- a/fdbclient/include/fdbclient/TenantSpecialKeys.actor.h
+++ b/fdbclient/include/fdbclient/TenantSpecialKeys.actor.h
@@ -71,27 +71,12 @@ private:
 	                                        KeyRangeRef kr,
 	                                        RangeResult* results,
 	                                        GetRangeLimits limitsHint) {
-		std::map<TenantName, TenantMapEntry> tenants =
+		std::vector<std::pair<TenantName, TenantMapEntry>> tenants =
 		    wait(TenantAPI::listTenantsTransaction(&ryw->getTransaction(), kr.begin, kr.end, limitsHint.rows));
 
 		for (auto tenant : tenants) {
-			json_spirit::mObject tenantEntry;
-			tenantEntry["id"] = tenant.second.id;
-			if (ryw->getDatabase()->apiVersionAtLeast(720)) {
-				json_spirit::mObject prefixObject;
-				std::string encodedPrefix = base64::encoder::from_string(tenant.second.prefix.toString());
-				// Remove trailing newline
-				encodedPrefix.resize(encodedPrefix.size() - 1);
-
-				prefixObject["base64"] = encodedPrefix;
-				prefixObject["printable"] = printable(tenant.second.prefix);
-				tenantEntry["prefix"] = prefixObject;
-			} else {
-				// This is not a standard encoding in JSON, and some libraries may not be able to easily decode it
-				tenantEntry["prefix"] = tenant.second.prefix.toString();
-			}
-			std::string tenantEntryString = json_spirit::write_string(json_spirit::mValue(tenantEntry));
-			ValueRef tenantEntryBytes(results->arena(), tenantEntryString);
+			std::string jsonString = tenant.second.toJson(ryw->getDatabase()->apiVersion);
+			ValueRef tenantEntryBytes(results->arena(), jsonString);
 			results->push_back(results->arena(),
 			                   KeyValueRef(withTenantMapPrefix(tenant.first, results->arena()), tenantEntryBytes));
 		}
@@ -126,11 +111,12 @@ private:
 
 		std::vector<Future<Void>> createFutures;
 		for (auto tenant : tenants) {
+			state TenantMapEntry tenantEntry(nextId++, TenantState::READY);
 			createFutures.push_back(
-			    success(TenantAPI::createTenantTransaction(&ryw->getTransaction(), tenant, nextId++)));
+			    success(TenantAPI::createTenantTransaction(&ryw->getTransaction(), tenant, tenantEntry)));
 		}
 
-		ryw->getTransaction().set(tenantLastIdKey, TenantMapEntry::idToPrefix(nextId - 1));
+		TenantMetadata::lastTenantId.set(&ryw->getTransaction(), nextId - 1);
 		wait(waitForAll(createFutures));
 		return Void();
 	}
@@ -138,7 +124,7 @@ private:
 	ACTOR static Future<Void> deleteTenantRange(ReadYourWritesTransaction* ryw,
 	                                            TenantName beginTenant,
 	                                            TenantName endTenant) {
-		state std::map<TenantName, TenantMapEntry> tenants = wait(
+		state std::vector<std::pair<TenantName, TenantMapEntry>> tenants = wait(
 		    TenantAPI::listTenantsTransaction(&ryw->getTransaction(), beginTenant, endTenant, CLIENT_KNOBS->TOO_MANY));
 
 		if (tenants.size() == CLIENT_KNOBS->TOO_MANY) {

--- a/fdbserver/ApplyMetadataMutation.cpp
+++ b/fdbserver/ApplyMetadataMutation.cpp
@@ -650,10 +650,11 @@ private:
 	}
 
 	void checkSetTenantMapPrefix(MutationRef m) {
-		if (m.param1.startsWith(tenantMapPrefix)) {
+		KeyRef prefix = TenantMetadata::tenantMap.subspace.begin;
+		if (m.param1.startsWith(prefix)) {
 			if (tenantMap) {
 				ASSERT(version != invalidVersion);
-				TenantName tenantName = m.param1.removePrefix(tenantMapPrefix);
+				TenantName tenantName = m.param1.removePrefix(prefix);
 				TenantMapEntry tenantEntry = TenantMapEntry::decode(m.param2);
 
 				TraceEvent("CommitProxyInsertTenant", dbgid).detail("Tenant", tenantName).detail("Version", version);
@@ -1028,13 +1029,14 @@ private:
 	}
 
 	void checkClearTenantMapPrefix(KeyRangeRef range) {
-		if (tenantMapKeys.intersects(range)) {
+		KeyRangeRef subspace = TenantMetadata::tenantMap.subspace;
+		if (subspace.intersects(range)) {
 			if (tenantMap) {
 				ASSERT(version != invalidVersion);
 
-				StringRef startTenant = std::max(range.begin, tenantMapPrefix).removePrefix(tenantMapPrefix);
-				StringRef endTenant = (range.end.startsWith(tenantMapPrefix) ? range.end : tenantMapKeys.end)
-				                          .removePrefix(tenantMapPrefix);
+				StringRef startTenant = std::max(range.begin, subspace.begin).removePrefix(subspace.begin);
+				StringRef endTenant =
+				    range.end.startsWith(subspace.begin) ? range.end.removePrefix(subspace.begin) : "\xff\xff"_sr;
 
 				TraceEvent("CommitProxyEraseTenants", dbgid)
 				    .detail("BeginTenant", startTenant)

--- a/fdbserver/BlobWorker.actor.cpp
+++ b/fdbserver/BlobWorker.actor.cpp
@@ -3981,12 +3981,14 @@ ACTOR Future<Void> monitorTenants(Reference<BlobWorkerData> bwData) {
 			try {
 				tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
 				tr->setOption(FDBTransactionOptions::PRIORITY_SYSTEM_IMMEDIATE);
-				state RangeResult tenantResults;
-				wait(store(tenantResults, tr->getRange(tenantMapKeys, CLIENT_KNOBS->TOO_MANY)));
-				ASSERT_WE_THINK(!tenantResults.more && tenantResults.size() < CLIENT_KNOBS->TOO_MANY);
-				if (tenantResults.more || tenantResults.size() >= CLIENT_KNOBS->TOO_MANY) {
+				state KeyBackedRangeResult<std::pair<TenantName, TenantMapEntry>> tenantResults;
+				wait(store(tenantResults,
+				           TenantMetadata::tenantMap.getRange(
+				               tr, Optional<TenantName>(), Optional<TenantName>(), CLIENT_KNOBS->TOO_MANY)));
+				ASSERT_WE_THINK(!tenantResults.more && tenantResults.results.size() < CLIENT_KNOBS->TOO_MANY);
+				if (tenantResults.more || tenantResults.results.size() >= CLIENT_KNOBS->TOO_MANY) {
 					TraceEvent(SevError, "BlobWorkerTooManyTenants", bwData->id)
-					    .detail("TenantCount", tenantResults.size());
+					    .detail("TenantCount", tenantResults.results.size());
 					wait(delay(600));
 					if (bwData->fatalError.canBeSet()) {
 						bwData->fatalError.sendError(internal_error());
@@ -3995,15 +3997,13 @@ ACTOR Future<Void> monitorTenants(Reference<BlobWorkerData> bwData) {
 				}
 
 				std::vector<std::pair<TenantName, TenantMapEntry>> tenants;
-				for (auto& it : tenantResults) {
+				for (auto& it : tenantResults.results) {
 					// FIXME: handle removing/moving tenants!
-					TenantNameRef tenantName = it.key.removePrefix(tenantMapPrefix);
-					TenantMapEntry entry = TenantMapEntry::decode(it.value);
-					tenants.push_back(std::pair(tenantName, entry));
+					tenants.push_back(std::pair(it.first, it.second));
 				}
 				bwData->tenantData.addTenants(tenants);
 
-				state Future<Void> watchChange = tr->watch(tenantLastIdKey);
+				state Future<Void> watchChange = tr->watch(TenantMetadata::lastTenantId.key);
 				wait(tr->commit());
 				wait(watchChange);
 				tr->reset();

--- a/fdbserver/TenantCache.actor.cpp
+++ b/fdbserver/TenantCache.actor.cpp
@@ -26,15 +26,17 @@
 
 class TenantCacheImpl {
 
-	ACTOR static Future<RangeResult> getTenantList(TenantCache* tenantCache, Transaction* tr) {
+	ACTOR static Future<std::vector<std::pair<TenantName, TenantMapEntry>>> getTenantList(TenantCache* tenantCache,
+	                                                                                      Transaction* tr) {
 		tr->setOption(FDBTransactionOptions::READ_SYSTEM_KEYS);
 		tr->setOption(FDBTransactionOptions::READ_LOCK_AWARE);
 
-		state Future<RangeResult> tenantList = tr->getRange(tenantMapKeys, CLIENT_KNOBS->TOO_MANY);
-		wait(success(tenantList));
-		ASSERT(!tenantList.get().more && tenantList.get().size() < CLIENT_KNOBS->TOO_MANY);
+		KeyBackedRangeResult<std::pair<TenantName, TenantMapEntry>> tenantList =
+		    wait(TenantMetadata::tenantMap.getRange(
+		        tr, Optional<TenantName>(), Optional<TenantName>(), CLIENT_KNOBS->TOO_MANY));
+		ASSERT(!tenantList.more && tenantList.results.size() < CLIENT_KNOBS->TOO_MANY);
 
-		return tenantList.get();
+		return tenantList.results;
 	}
 
 public:
@@ -44,18 +46,15 @@ public:
 		TraceEvent(SevInfo, "BuildingTenantCache", tenantCache->id()).log();
 
 		try {
-			state RangeResult tenantList = wait(getTenantList(tenantCache, &tr));
+			state std::vector<std::pair<TenantName, TenantMapEntry>> tenantList = wait(getTenantList(tenantCache, &tr));
 
 			for (int i = 0; i < tenantList.size(); i++) {
-				TenantName tname = tenantList[i].key.removePrefix(tenantMapPrefix);
-				TenantMapEntry t = TenantMapEntry::decode(tenantList[i].value);
-
-				tenantCache->insert(tname, t);
+				tenantCache->insert(tenantList[i].first, tenantList[i].second);
 
 				TraceEvent(SevInfo, "TenantFound", tenantCache->id())
-				    .detail("TenantName", tname)
-				    .detail("TenantID", t.id)
-				    .detail("TenantPrefix", t.prefix);
+				    .detail("TenantName", tenantList[i].first)
+				    .detail("TenantID", tenantList[i].second.id)
+				    .detail("TenantPrefix", tenantList[i].second.prefix);
 			}
 		} catch (Error& e) {
 			wait(tr.onError(e));
@@ -79,16 +78,14 @@ public:
 					TraceEvent(SevWarn, "TenantListRefreshDelay", tenantCache->id()).log();
 				}
 
-				state RangeResult tenantList = wait(getTenantList(tenantCache, &tr));
+				state std::vector<std::pair<TenantName, TenantMapEntry>> tenantList =
+				    wait(getTenantList(tenantCache, &tr));
 
 				tenantCache->startRefresh();
 				bool tenantListUpdated = false;
 
 				for (int i = 0; i < tenantList.size(); i++) {
-					TenantName tname = tenantList[i].key.removePrefix(tenantMapPrefix);
-					TenantMapEntry t = TenantMapEntry::decode(tenantList[i].value);
-
-					if (tenantCache->update(tname, t)) {
+					if (tenantCache->update(tenantList[i].first, tenantList[i].second)) {
 						tenantListUpdated = true;
 					}
 				}
@@ -220,7 +217,7 @@ public:
 
 		for (uint16_t i = 0; i < tenantCount; i++) {
 			TenantName tenantName(format("%s_%08d", "ddtc_test_tenant", tenantNumber + i));
-			TenantMapEntry tenant(tenantNumber + i);
+			TenantMapEntry tenant(tenantNumber + i, TenantState::READY);
 
 			tenantCache.insert(tenantName, tenant);
 		}
@@ -248,7 +245,7 @@ public:
 
 		for (uint16_t i = 0; i < tenantCount; i++) {
 			TenantName tenantName(format("%s_%08d", "ddtc_test_tenant", tenantNumber + i));
-			TenantMapEntry tenant(tenantNumber + i);
+			TenantMapEntry tenant(tenantNumber + i, TenantState::READY);
 
 			tenantCache.insert(tenantName, tenant);
 		}
@@ -262,7 +259,7 @@ public:
 
 			if (tenantOrdinal % staleTenantFraction != 0) {
 				TenantName tenantName(format("%s_%08d", "ddtc_test_tenant", tenantOrdinal));
-				TenantMapEntry tenant(tenantOrdinal);
+				TenantMapEntry tenant(tenantOrdinal, TenantState::READY);
 				bool newTenant = tenantCache.update(tenantName, tenant);
 				ASSERT(!newTenant);
 				keepCount++;

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -580,7 +580,8 @@ public:
 	void clearWatchMetadata();
 
 	// tenant map operations
-	void insertTenant(TenantNameRef tenantName, ValueRef value, Version version, bool insertIntoMutationLog);
+	bool insertTenant(TenantNameRef tenantName, TenantMapEntry tenantEntry, Version version);
+	void insertTenant(TenantNameRef tenantName, ValueRef value, Version version);
 	void clearTenants(TenantNameRef startTenant, TenantNameRef endTenant, Version version);
 
 	Optional<TenantMapEntry> getTenantEntry(Version version, TenantInfo tenant);
@@ -3992,11 +3993,13 @@ bool rangeIntersectsAnyTenant(TenantPrefixIndex& prefixIndex, KeyRangeRef range,
 }
 
 TEST_CASE("/fdbserver/storageserver/rangeIntersectsAnyTenant") {
-	std::map<TenantName, TenantMapEntry> entries = { std::make_pair("tenant0"_sr, TenantMapEntry(0)),
-		                                             std::make_pair("tenant2"_sr, TenantMapEntry(2)),
-		                                             std::make_pair("tenant3"_sr, TenantMapEntry(3)),
-		                                             std::make_pair("tenant4"_sr, TenantMapEntry(4)),
-		                                             std::make_pair("tenant6"_sr, TenantMapEntry(6)) };
+	std::map<TenantName, TenantMapEntry> entries = {
+		std::make_pair("tenant0"_sr, TenantMapEntry(0, TenantState::READY)),
+		std::make_pair("tenant2"_sr, TenantMapEntry(2, TenantState::READY)),
+		std::make_pair("tenant3"_sr, TenantMapEntry(3, TenantState::READY)),
+		std::make_pair("tenant4"_sr, TenantMapEntry(4, TenantState::READY)),
+		std::make_pair("tenant6"_sr, TenantMapEntry(6, TenantState::READY))
+	};
 	TenantPrefixIndex index;
 	index.createNewVersion(1);
 	for (auto entry : entries) {
@@ -6945,12 +6948,13 @@ private:
 				}
 			}
 		} else if ((m.type == MutationRef::SetValue || m.type == MutationRef::ClearRange) &&
-		           m.param1.startsWith(tenantMapPrivatePrefix)) {
+		           m.param1.startsWith(TenantMetadata::tenantMapPrivatePrefix)) {
 			if (m.type == MutationRef::SetValue) {
-				data->insertTenant(m.param1.removePrefix(tenantMapPrivatePrefix), m.param2, currentVersion, true);
+				data->insertTenant(
+				    m.param1.removePrefix(TenantMetadata::tenantMapPrivatePrefix), m.param2, currentVersion);
 			} else if (m.type == MutationRef::ClearRange) {
-				data->clearTenants(m.param1.removePrefix(tenantMapPrivatePrefix),
-				                   m.param2.removePrefix(tenantMapPrivatePrefix),
+				data->clearTenants(m.param1.removePrefix(TenantMetadata::tenantMapPrivatePrefix),
+				                   m.param2.removePrefix(TenantMetadata::tenantMapPrivatePrefix),
 				                   currentVersion);
 			}
 		} else if (m.param1.substr(1).startsWith(tssMappingKeys.begin) &&
@@ -7045,26 +7049,26 @@ private:
 	}
 };
 
-void StorageServer::insertTenant(TenantNameRef tenantName,
-                                 ValueRef value,
-                                 Version version,
-                                 bool insertIntoMutationLog) {
+bool StorageServer::insertTenant(TenantNameRef tenantName, TenantMapEntry tenantEntry, Version version) {
 	if (version >= tenantMap.getLatestVersion()) {
 		tenantMap.createNewVersion(version);
 		tenantPrefixIndex.createNewVersion(version);
 
-		TenantMapEntry tenantEntry = TenantMapEntry::decode(value);
-
 		tenantMap.insert(tenantName, tenantEntry);
 		tenantPrefixIndex.insert(tenantEntry.prefix, tenantName);
 
-		if (insertIntoMutationLog) {
-			auto& mLV = addVersionToMutationLog(version);
-			addMutationToMutationLog(
-			    mLV, MutationRef(MutationRef::SetValue, tenantName.withPrefix(persistTenantMapKeys.begin), value));
-		}
-
 		TraceEvent("InsertTenant", thisServerID).detail("Tenant", tenantName).detail("Version", version);
+		return true;
+	} else {
+		return false;
+	}
+}
+
+void StorageServer::insertTenant(TenantNameRef tenantName, ValueRef value, Version version) {
+	if (insertTenant(tenantName, TenantMapEntry::decode(value), version)) {
+		auto& mLV = addVersionToMutationLog(version);
+		addMutationToMutationLog(
+		    mLV, MutationRef(MutationRef::SetValue, tenantName.withPrefix(persistTenantMapKeys.begin), value));
 	}
 }
 
@@ -9257,14 +9261,16 @@ ACTOR Future<Void> initTenantMap(StorageServer* self) {
 			state Version version = wait(tr->getReadVersion());
 			// This limits the number of tenants, but eventually we shouldn't need to do this at all
 			// when SSs store only the local tenants
-			RangeResult entries = wait(tr->getRange(tenantMapKeys, CLIENT_KNOBS->TOO_MANY));
+			KeyBackedRangeResult<std::pair<TenantName, TenantMapEntry>> entries =
+			    wait(TenantMetadata::tenantMap.getRange(
+			        tr, Optional<TenantName>(), Optional<TenantName>(), CLIENT_KNOBS->TOO_MANY));
 
 			TraceEvent("InitTenantMap", self->thisServerID)
 			    .detail("Version", version)
-			    .detail("NumTenants", entries.size());
+			    .detail("NumTenants", entries.results.size());
 
-			for (auto kv : entries) {
-				self->insertTenant(kv.key.removePrefix(tenantMapPrefix), kv.value, version, false);
+			for (auto entry : entries.results) {
+				self->insertTenant(entry.first, entry.second, version);
 			}
 			break;
 		} catch (Error& e) {

--- a/fdbserver/workloads/BlobGranuleCorrectnessWorkload.actor.cpp
+++ b/fdbserver/workloads/BlobGranuleCorrectnessWorkload.actor.cpp
@@ -212,13 +212,15 @@ struct BlobGranuleCorrectnessWorkload : TestWorkload {
 			fmt::print("Setting up blob granule range for tenant {0}\n", name.printable());
 		}
 
-		TenantMapEntry entry = wait(TenantAPI::createTenant(cx.getReference(), name));
+		Optional<TenantMapEntry> entry = wait(TenantAPI::createTenant(cx.getReference(), name));
+		ASSERT(entry.present());
 
 		if (BGW_DEBUG) {
-			fmt::print("Set up blob granule range for tenant {0}: {1}\n", name.printable(), entry.prefix.printable());
+			fmt::print(
+			    "Set up blob granule range for tenant {0}: {1}\n", name.printable(), entry.get().prefix.printable());
 		}
 
-		return entry;
+		return entry.get();
 	}
 
 	std::string description() const override { return "BlobGranuleCorrectnessWorkload"; }

--- a/fdbserver/workloads/TenantManagementWorkload.actor.cpp
+++ b/fdbserver/workloads/TenantManagementWorkload.actor.cpp
@@ -33,15 +33,15 @@
 #include "flow/actorcompiler.h" // This must be the last #include.
 
 struct TenantManagementWorkload : TestWorkload {
-	struct TenantState {
+	struct TenantData {
 		int64_t id;
 		bool empty;
 
-		TenantState() : id(-1), empty(true) {}
-		TenantState(int64_t id, bool empty) : id(id), empty(empty) {}
+		TenantData() : id(-1), empty(true) {}
+		TenantData(int64_t id, bool empty) : id(id), empty(empty) {}
 	};
 
-	std::map<TenantName, TenantState> createdTenants;
+	std::map<TenantName, TenantData> createdTenants;
 	int64_t maxId = -1;
 
 	const Key keyName = "key"_sr;
@@ -149,9 +149,10 @@ struct TenantManagementWorkload : TestWorkload {
 
 					std::vector<Future<Void>> createFutures;
 					for (auto tenant : tenantsToCreate) {
-						createFutures.push_back(success(TenantAPI::createTenantTransaction(tr, tenant, nextId++)));
+						TenantMapEntry tenantEntry(nextId++, TenantState::READY);
+						createFutures.push_back(success(TenantAPI::createTenantTransaction(tr, tenant, tenantEntry)));
 					}
-					tr->set(tenantLastIdKey, TenantMapEntry::idToPrefix(nextId - 1));
+					TenantMetadata::lastTenantId.set(tr, nextId - 1);
 					wait(waitForAll(createFutures));
 					wait(tr->commit());
 				}
@@ -173,7 +174,7 @@ struct TenantManagementWorkload : TestWorkload {
 					ASSERT(entry.get().id > self->maxId);
 
 					self->maxId = entry.get().id;
-					self->createdTenants[*tenantItr] = TenantState(entry.get().id, true);
+					self->createdTenants[*tenantItr] = TenantData(entry.get().id, true);
 
 					state bool insertData = deterministicRandom()->random01() < 0.5;
 					if (insertData) {
@@ -369,12 +370,12 @@ struct TenantManagementWorkload : TestWorkload {
 	ACTOR Future<Void> checkTenant(Database cx,
 	                               TenantManagementWorkload* self,
 	                               TenantName tenant,
-	                               TenantState tenantState) {
+	                               TenantData tenantData) {
 		state Transaction tr(cx, tenant);
 		loop {
 			try {
 				state RangeResult result = wait(tr.getRange(KeyRangeRef(""_sr, "\xff"_sr), 2));
-				if (tenantState.empty) {
+				if (tenantData.empty) {
 					ASSERT(result.size() == 0);
 				} else {
 					ASSERT(result.size() == 1);
@@ -407,7 +408,7 @@ struct TenantManagementWorkload : TestWorkload {
 		ASSERT(prefix == unprintable(printablePrefix));
 
 		Key prefixKey = KeyRef(prefix);
-		TenantMapEntry entry(id);
+		TenantMapEntry entry(id, TenantState::READY);
 
 		ASSERT(entry.prefix == prefixKey);
 		return entry;
@@ -417,7 +418,7 @@ struct TenantManagementWorkload : TestWorkload {
 		state TenantName tenant = self->chooseTenantName(true);
 		auto itr = self->createdTenants.find(tenant);
 		state bool alreadyExists = itr != self->createdTenants.end();
-		state TenantState tenantState = itr->second;
+		state TenantData tenantData = itr->second;
 		state OperationType operationType = TenantManagementWorkload::randomOperationType();
 		state Reference<ReadYourWritesTransaction> tr = makeReference<ReadYourWritesTransaction>(cx);
 
@@ -440,8 +441,8 @@ struct TenantManagementWorkload : TestWorkload {
 					entry = _entry;
 				}
 				ASSERT(alreadyExists);
-				ASSERT(entry.id == tenantState.id);
-				wait(self->checkTenant(cx, self, tenant, tenantState));
+				ASSERT(entry.id == tenantData.id);
+				wait(self->checkTenant(cx, self, tenant, tenantData));
 				return Void();
 			} catch (Error& e) {
 				state bool retry = true;
@@ -480,21 +481,21 @@ struct TenantManagementWorkload : TestWorkload {
 
 		loop {
 			try {
-				state std::map<TenantName, TenantMapEntry> tenants;
+				state std::vector<std::pair<TenantName, TenantMapEntry>> tenants;
 				if (operationType == OperationType::SPECIAL_KEYS) {
 					KeyRange range = KeyRangeRef(beginTenant, endTenant).withPrefix(self->specialKeysTenantMapPrefix);
 					RangeResult results = wait(tr->getRange(range, limit));
 					for (auto result : results) {
-						tenants[result.key.removePrefix(self->specialKeysTenantMapPrefix)] =
-						    TenantManagementWorkload::jsonToTenantMapEntry(result.value);
+						tenants.push_back(std::make_pair(result.key.removePrefix(self->specialKeysTenantMapPrefix),
+						                                 TenantManagementWorkload::jsonToTenantMapEntry(result.value)));
 					}
 				} else if (operationType == OperationType::MANAGEMENT_DATABASE) {
-					std::map<TenantName, TenantMapEntry> _tenants =
+					std::vector<std::pair<TenantName, TenantMapEntry>> _tenants =
 					    wait(TenantAPI::listTenants(cx.getReference(), beginTenant, endTenant, limit));
 					tenants = _tenants;
 				} else {
 					tr->setOption(FDBTransactionOptions::READ_SYSTEM_KEYS);
-					std::map<TenantName, TenantMapEntry> _tenants =
+					std::vector<std::pair<TenantName, TenantMapEntry>> _tenants =
 					    wait(TenantAPI::listTenantsTransaction(tr, beginTenant, endTenant, limit));
 					tenants = _tenants;
 				}
@@ -580,10 +581,10 @@ struct TenantManagementWorkload : TestWorkload {
 					ASSERT(newTenantEntry.present());
 
 					// Update Internal Tenant Map and check for correctness
-					TenantState tState = self->createdTenants[oldTenantName];
-					self->createdTenants[newTenantName] = tState;
+					TenantData tData = self->createdTenants[oldTenantName];
+					self->createdTenants[newTenantName] = tData;
 					self->createdTenants.erase(oldTenantName);
-					if (!tState.empty) {
+					if (!tData.empty) {
 						state Transaction insertTr(cx, newTenantName);
 						loop {
 							try {
@@ -657,13 +658,13 @@ struct TenantManagementWorkload : TestWorkload {
 			}
 		}
 
-		state std::map<TenantName, TenantState>::iterator itr = self->createdTenants.begin();
+		state std::map<TenantName, TenantData>::iterator itr = self->createdTenants.begin();
 		state std::vector<Future<Void>> checkTenants;
 		state TenantName beginTenant = ""_sr.withPrefix(self->localTenantNamePrefix);
 		state TenantName endTenant = "\xff\xff"_sr.withPrefix(self->localTenantNamePrefix);
 
 		loop {
-			std::map<TenantName, TenantMapEntry> tenants =
+			std::vector<std::pair<TenantName, TenantMapEntry>> tenants =
 			    wait(TenantAPI::listTenants(cx.getReference(), beginTenant, endTenant, 1000));
 
 			TenantNameRef lastTenant;


### PR DESCRIPTION
This also adds a new `TenantState` field that will be used in the future metacluster work and does some other refactoring.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
