### PR TITLE
 mako: Modify ddsketch json format by adding txn arg

### DIFF
--- a/bindings/c/test/mako/ddsketch.hpp
+++ b/bindings/c/test/mako/ddsketch.hpp
@@ -92,7 +92,9 @@ public:
 			assert(index >= 0 && index < int(buckets.size()));
 			if (buckets[index] == std::numeric_limits<uint32_t>::max()) {
 				std::cerr << "Terminating. "
-				          << "Bucket " << index << " has hit maximum threshold in DDSketch.";
+				          << "Maximum threshold for statistics collection hit "
+				          << "has hit maximum size." << std::endl;
+				std::cerr << "Consider increasing --sampling to a smaller value.";
 				std::exit(-1);
 			}
 			buckets[index]++;
@@ -179,6 +181,11 @@ public:
 		assert(fabs(errorGuarantee - anotherSketch.errorGuarantee) < EPS &&
 		       anotherSketch.buckets.size() == buckets.size());
 		for (size_t i = 0; i < anotherSketch.buckets.size(); i++) {
+			// Check for overflow
+			if ((buckets[i] > 0) && (anotherSketch.buckets[i] > std::numeric_limits<uint32_t>::max() - buckets[i])) {
+				std::cerr << "Overflow detected when merging sketches! Exiting..." << std::endl;
+				std::exit(-1);
+			}
 			buckets[i] += anotherSketch.buckets[i];
 		}
 		populationSize += anotherSketch.populationSize;

--- a/bindings/c/test/mako/ddsketch.hpp
+++ b/bindings/c/test/mako/ddsketch.hpp
@@ -92,9 +92,9 @@ public:
 			assert(index >= 0 && index < int(buckets.size()));
 			if (buckets[index] == std::numeric_limits<uint32_t>::max()) {
 				std::cerr << "Terminating. "
-				          << "Maximum threshold for statistics collection hit "
+				          << "Maximum threshold for statistics "
 				          << "has hit maximum size." << std::endl;
-				std::cerr << "Consider increasing --sampling to a smaller value.";
+				std::cerr << "Consider increasing --sampling to sample less frequently";
 				std::exit(-1);
 			}
 			buckets[index]++;

--- a/bindings/c/test/mako/ddsketch.hpp
+++ b/bindings/c/test/mako/ddsketch.hpp
@@ -20,6 +20,7 @@
 
 #ifndef DDSKETCH_H
 #define DDSKETCH_H
+#include <iostream>
 #include <iterator>
 #include <limits>
 #include <type_traits>
@@ -89,6 +90,11 @@ public:
 		} else {
 			int index = static_cast<Impl*>(this)->getIndex(sample);
 			assert(index >= 0 && index < int(buckets.size()));
+			if (buckets[index] == std::numeric_limits<uint32_t>::max()) {
+				std::cerr << "Terminating. "
+				          << "Bucket " << index << " has hit maximum threshold in DDSketch.";
+				std::exit(-1);
+			}
 			buckets[index]++;
 		}
 

--- a/bindings/c/test/mako/mako.cpp
+++ b/bindings/c/test/mako/mako.cpp
@@ -1907,7 +1907,11 @@ void printThreadStats(ThreadStatistics& final_stats, Arguments args, FILE* fp, b
 	}
 }
 
-void loadSample(int pid_main, int op, std::vector<DDSketchMako>& data_points, int process_id, int thread_id) {
+void loadSample(int pid_main,
+                int op,
+                std::unordered_map<int, DDSketchMako>& data_points,
+                int process_id,
+                int thread_id) {
 	const auto dirname = fmt::format("{}{}", TEMP_DATA_STORE, pid_main);
 	const auto filename = getStatsFilename(dirname, process_id, thread_id, op);
 	std::ifstream fp{ filename };
@@ -2043,7 +2047,7 @@ void printReport(Arguments const& args,
 	fmt::print("\n\n");
 
 	// Get the sketches stored in file and merge them together
-	std::vector<DDSketchMako> data_points(MAX_OP);
+	std::unordered_map<int, DDSketchMako> data_points;
 	for (auto op = 0; op < MAX_OP; op++) {
 		for (auto i = 0; i < args.num_processes; i++) {
 
@@ -2305,7 +2309,7 @@ int main(int argc, char* argv[]) {
 	auto shm_access = shared_memory::Access(shm, args.num_processes, nthreads_for_shm);
 
 	/* initialize the shared memory */
-	shm_access.initMemory();
+	shm_access.initMemory(args);
 
 	/* get ready */
 	auto& shm_hdr = shm_access.header();

--- a/bindings/c/test/mako/mako.cpp
+++ b/bindings/c/test/mako/mako.cpp
@@ -1011,6 +1011,7 @@ int initArguments(Arguments& args) {
 	args.bg_materialize_files = false;
 	args.bg_file_path[0] = '\0';
 	args.distributed_tracer_client = 0;
+	args.txn_name[0] = '\0';
 	return 0;
 }
 
@@ -1297,6 +1298,7 @@ int parseArguments(int argc, char* argv[], Arguments& args) {
 			args.iteration = atoi(optarg);
 			break;
 		case 'x':
+			strcpy(args.txn_name, optarg);
 			rc = parseTransaction(args, optarg);
 			if (rc < 0)
 				return -1;

--- a/bindings/c/test/mako/mako.hpp
+++ b/bindings/c/test/mako/mako.hpp
@@ -121,6 +121,7 @@ struct WorkloadSpec {
 
 constexpr const int LOGGROUP_MAX = 256;
 constexpr const int KNOB_MAX = 256;
+constexpr const int TXN_NAME_MAX = 64;
 constexpr const int TAGPREFIXLENGTH_MAX = 8;
 constexpr const int NUM_CLUSTERS_MAX = 3;
 constexpr const int NUM_DATABASES_MAX = 10;
@@ -177,6 +178,7 @@ struct Arguments {
 	char report_files[MAX_REPORT_FILES][PATH_MAX];
 	int num_report_files;
 	int distributed_tracer_client;
+	char txn_name[TXN_NAME_MAX];
 };
 
 } // namespace mako

--- a/bindings/c/test/mako/shm.hpp
+++ b/bindings/c/test/mako/shm.hpp
@@ -24,6 +24,7 @@
 #include <atomic>
 #include <cassert>
 #include <cstdint>
+#include "mako/mako.hpp"
 #include "stats.hpp"
 
 /* shared memory */
@@ -75,11 +76,11 @@ public:
 
 	size_t size() const noexcept { return storageSize(num_processes, num_threads); }
 
-	void initMemory() noexcept {
+	void initMemory(const Arguments& args) noexcept {
 		new (&header()) Header{};
 		for (auto i = 0; i < num_processes; i++)
 			for (auto j = 0; j < num_threads; j++)
-				new (&statsSlot(i, j)) ThreadStatistics();
+				new (&statsSlot(i, j)) ThreadStatistics(args);
 	}
 
 	Header const& headerConst() const noexcept { return *static_cast<Header const*>(base); }


### PR DESCRIPTION
This changes will modify the way the ddsketch json is formed by creating an object with a key that is
    the string from the `--transaction` argument (ie` g8ui`). Multiple tests can now be contained in the same json.
    
    Ex:
```
    {
      "g8ui": {
         // data from g8ui
      },
      "grvgr16:1024": {
        // data from grvgr16:1024
      }
    }
```
 You can choose to output ddsketch from combining previous tests by passing `--stats_export_path <filename>`
    Ex:
    `mako -m report file1.json file.json --stats_export_path output.json`
    
If `file1.json` had` g8ui` and `file2.json` had `grvgr16:1024`, then output json would look like the format in the above example.

If you choose to not pass `--stats_export_path`, then it will simply print the output

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
