### PR TITLE
Add a limit to the number of tenants that can be created in a cluster

### DIFF
--- a/fdbclient/ClientKnobs.cpp
+++ b/fdbclient/ClientKnobs.cpp
@@ -22,6 +22,7 @@
 #include "fdbclient/FDBTypes.h"
 #include "fdbclient/SystemData.h"
 #include "fdbclient/Tenant.h"
+#include "flow/IRandom.h"
 #include "flow/UnitTest.h"
 
 #define init(...) KNOB_FN(__VA_ARGS__, INIT_ATOMIC_KNOB, INIT_KNOB)(__VA_ARGS__)
@@ -288,6 +289,9 @@ void ClientKnobs::initialize(Randomize randomize) {
 
 	init( CHANGE_QUORUM_BAD_STATE_RETRY_TIMES,        3 );
 	init( CHANGE_QUORUM_BAD_STATE_RETRY_DELAY,      2.0 );
+
+	// Tenants and Metacluster
+	init( MAX_TENANTS_PER_CLUSTER,                  1e6 ); if ( randomize && BUGGIFY ) MAX_TENANTS_PER_CLUSTER = deterministicRandom()->randomInt(20, 100);
 
 	// clang-format on
 }

--- a/fdbclient/include/fdbclient/ClientKnobs.h
+++ b/fdbclient/include/fdbclient/ClientKnobs.h
@@ -284,6 +284,9 @@ public:
 	int CHANGE_QUORUM_BAD_STATE_RETRY_TIMES;
 	double CHANGE_QUORUM_BAD_STATE_RETRY_DELAY;
 
+	// Tenants and Metacluster
+	int MAX_TENANTS_PER_CLUSTER;
+
 	ClientKnobs(Randomize randomize);
 	void initialize(Randomize randomize);
 };

--- a/fdbclient/include/fdbclient/Tenant.h
+++ b/fdbclient/include/fdbclient/Tenant.h
@@ -99,12 +99,13 @@ struct TenantMetadataSpecification {
 
 	KeyBackedObjectMap<TenantName, TenantMapEntry, decltype(IncludeVersion()), NullCodec> tenantMap;
 	KeyBackedProperty<int64_t> lastTenantId;
+	KeyBackedBinaryValue<int64_t> tenantCount;
 	KeyBackedSet<Tuple> tenantGroupTenantIndex;
 	KeyBackedObjectMap<TenantGroupName, TenantGroupEntry, decltype(IncludeVersion()), NullCodec> tenantGroupMap;
 
 	TenantMetadataSpecification(KeyRef subspace)
 	  : tenantMap(subspace.withSuffix("tenant/map/"_sr), IncludeVersion()),
-	    lastTenantId(subspace.withSuffix("tenant/lastId"_sr)),
+	    lastTenantId(subspace.withSuffix("tenant/lastId"_sr)), tenantCount(subspace.withSuffix("tenant/count"_sr)),
 	    tenantGroupTenantIndex(subspace.withSuffix("tenant/tenantGroup/tenantIndex/"_sr)),
 	    tenantGroupMap(subspace.withSuffix("tenant/tenantGroup/map/"_sr), IncludeVersion()) {}
 };
@@ -116,6 +117,7 @@ private:
 public:
 	static inline auto& tenantMap = instance.tenantMap;
 	static inline auto& lastTenantId = instance.lastTenantId;
+	static inline auto& tenantCount = instance.tenantCount;
 	static inline auto& tenantGroupTenantIndex = instance.tenantGroupTenantIndex;
 	static inline auto& tenantGroupMap = instance.tenantGroupMap;
 

--- a/fdbserver/TenantCache.actor.cpp
+++ b/fdbserver/TenantCache.actor.cpp
@@ -33,8 +33,8 @@ class TenantCacheImpl {
 
 		KeyBackedRangeResult<std::pair<TenantName, TenantMapEntry>> tenantList =
 		    wait(TenantMetadata::tenantMap.getRange(
-		        tr, Optional<TenantName>(), Optional<TenantName>(), CLIENT_KNOBS->TOO_MANY));
-		ASSERT(!tenantList.more && tenantList.results.size() < CLIENT_KNOBS->TOO_MANY);
+		        tr, Optional<TenantName>(), Optional<TenantName>(), CLIENT_KNOBS->MAX_TENANTS_PER_CLUSTER + 1));
+		ASSERT(tenantList.results.size() <= CLIENT_KNOBS->MAX_TENANTS_PER_CLUSTER && !tenantList.more);
 
 		return tenantList.results;
 	}

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -10127,7 +10127,8 @@ ACTOR Future<Void> initTenantMap(StorageServer* self) {
 			// when SSs store only the local tenants
 			KeyBackedRangeResult<std::pair<TenantName, TenantMapEntry>> entries =
 			    wait(TenantMetadata::tenantMap.getRange(
-			        tr, Optional<TenantName>(), Optional<TenantName>(), CLIENT_KNOBS->TOO_MANY));
+			        tr, Optional<TenantName>(), Optional<TenantName>(), CLIENT_KNOBS->MAX_TENANTS_PER_CLUSTER + 1));
+			ASSERT(entries.results.size() <= CLIENT_KNOBS->MAX_TENANTS_PER_CLUSTER && !entries.more);
 
 			TraceEvent("InitTenantMap", self->thisServerID)
 			    .detail("Version", version)

--- a/fdbserver/workloads/TenantManagementWorkload.actor.cpp
+++ b/fdbserver/workloads/TenantManagementWorkload.actor.cpp
@@ -20,7 +20,9 @@
 
 #include <cstdint>
 #include <limits>
+#include "fdbclient/ClientBooleanParams.h"
 #include "fdbclient/FDBOptions.g.h"
+#include "fdbclient/ReadYourWrites.h"
 #include "fdbclient/RunTransaction.actor.h"
 #include "fdbclient/TenantManagement.actor.h"
 #include "fdbclient/TenantSpecialKeys.actor.h"
@@ -194,6 +196,7 @@ struct TenantManagementWorkload : TestWorkload {
 		// True if any tenant group name starts with \xff
 		state bool hasSystemTenantGroup = false;
 
+		state int newTenants = 0;
 		state std::map<TenantName, TenantMapEntry> tenantsToCreate;
 		for (int i = 0; i < numTenants; ++i) {
 			TenantName tenant = self->chooseTenantName(true);
@@ -203,21 +206,39 @@ struct TenantManagementWorkload : TestWorkload {
 
 			TenantMapEntry entry;
 			entry.tenantGroup = self->chooseTenantGroup(true);
-			tenantsToCreate[tenant] = entry;
 
-			alreadyExists = alreadyExists || self->createdTenants.count(tenant);
+			if (self->createdTenants.count(tenant)) {
+				alreadyExists = true;
+			} else if (!tenantsToCreate.count(tenant)) {
+				++newTenants;
+			}
+
+			tenantsToCreate[tenant] = entry;
 			hasSystemTenant = hasSystemTenant || tenant.startsWith("\xff"_sr);
 			hasSystemTenantGroup = hasSystemTenantGroup || entry.tenantGroup.orDefault(""_sr).startsWith("\xff"_sr);
 		}
 
 		state Reference<ReadYourWritesTransaction> tr = makeReference<ReadYourWritesTransaction>(cx);
+		state int64_t minTenantCount = std::numeric_limits<int64_t>::max();
+		state int64_t finalTenantCount = 0;
 
 		loop {
 			try {
+				if (operationType != OperationType::MANAGEMENT_DATABASE) {
+					tr->setOption(FDBTransactionOptions::READ_SYSTEM_KEYS);
+					wait(store(finalTenantCount, TenantMetadata::tenantCount.getD(tr, Snapshot::False, 0)));
+					minTenantCount = std::min(finalTenantCount, minTenantCount);
+				}
+
 				wait(createImpl(cx, tr, tenantsToCreate, operationType, self));
 
 				if (operationType == OperationType::MANAGEMENT_DATABASE) {
 					ASSERT(!alreadyExists);
+				} else {
+					// Make sure that we had capacity to create the tenants. This cannot be validated for database
+					// operations because we cannot determine the tenant count in the same transaction that the tenant
+					// is created
+					ASSERT(minTenantCount + newTenants <= CLIENT_KNOBS->MAX_TENANTS_PER_CLUSTER);
 				}
 
 				// It is not legal to create a tenant or tenant group starting with \xff
@@ -293,6 +314,13 @@ struct TenantManagementWorkload : TestWorkload {
 					return Void();
 				} else if (e.code() == error_code_invalid_tenant_group_name) {
 					ASSERT(hasSystemTenantGroup);
+					return Void();
+				} else if (e.code() == error_code_cluster_no_capacity) {
+					// Confirm that we overshot our capacity. This check cannot be done for database operations
+					// because we cannot transactionally get the tenant count with the creation.
+					if (operationType != OperationType::MANAGEMENT_DATABASE) {
+						ASSERT(finalTenantCount + newTenants > CLIENT_KNOBS->MAX_TENANTS_PER_CLUSTER);
+					}
 					return Void();
 				}
 
@@ -972,6 +1000,26 @@ struct TenantManagementWorkload : TestWorkload {
 		return Void();
 	}
 
+	// Verify that the tenant count matches the actual number of tenants in the cluster and that we haven't created too
+	// many
+	ACTOR static Future<Void> checkTenantCount(Database cx) {
+		state Reference<ReadYourWritesTransaction> tr = cx->createTransaction();
+		loop {
+			try {
+				tr->setOption(FDBTransactionOptions::READ_SYSTEM_KEYS);
+				state int64_t tenantCount = wait(TenantMetadata::tenantCount.getD(tr, Snapshot::False, 0));
+				KeyBackedRangeResult<std::pair<TenantName, TenantMapEntry>> tenants =
+				    wait(TenantMetadata::tenantMap.getRange(tr, {}, {}, CLIENT_KNOBS->MAX_TENANTS_PER_CLUSTER + 1));
+
+				ASSERT(tenants.results.size() == tenantCount && !tenants.more);
+				ASSERT(tenantCount <= CLIENT_KNOBS->MAX_TENANTS_PER_CLUSTER);
+				return Void();
+			} catch (Error& e) {
+				wait(tr->onError(e));
+			}
+		}
+	}
+
 	// Verify that the set of tenants in the database matches our local state
 	ACTOR static Future<Void> compareTenants(Database cx, TenantManagementWorkload* self) {
 		state std::map<TenantName, TenantData>::iterator localItr = self->createdTenants.begin();
@@ -1092,6 +1140,10 @@ struct TenantManagementWorkload : TestWorkload {
 			} catch (Error& e) {
 				wait(tr.onError(e));
 			}
+		}
+
+		if (self->clientId == 0) {
+			wait(checkTenantCount(cx));
 		}
 
 		wait(compareTenants(cx, self) && compareTenantGroups(cx, self));

--- a/flow/include/flow/error_definitions.h
+++ b/flow/include/flow/error_definitions.h
@@ -235,6 +235,7 @@ ERROR( unknown_tenant, 2137, "Tenant is not available from this server" )
 ERROR( illegal_tenant_access, 2138, "Illegal tenant access" )
 ERROR( invalid_tenant_group_name, 2139, "Tenant group name cannot begin with \\xff" )
 ERROR( invalid_tenant_configuration, 2140, "Tenant configuration is invalid" )
+ERROR( cluster_no_capacity, 2141, "Cluster does not have capacity to perform the specified operation" )
 
 // 2200 - errors from bindings and official APIs
 ERROR( api_version_unset, 2200, "API version is not set" )


### PR DESCRIPTION
This change adds a knob that sets how many tenants can be in a cluster. When the number of tenants exceeds this amount, an error indicating the issue is raised.

This also adds a counter key for the number of tenants that is used to enforce the limit.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
