### PR TITLE
Granule Purge Fixes

### DIFF
--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -9589,7 +9589,7 @@ ACTOR Future<Key> purgeBlobGranulesActor(Reference<DatabaseContext> db,
 	state bool loadedTenantPrefix = false;
 
 	// FIXME: implement force
-	if (!force) {
+	if (force) {
 		throw unsupported_operation();
 	}
 

--- a/fdbserver/BlobGranuleValidation.actor.cpp
+++ b/fdbserver/BlobGranuleValidation.actor.cpp
@@ -143,28 +143,32 @@ bool compareFDBAndBlob(RangeResult fdb,
 				}
 			}
 
-			printf("Chunks:\n");
-			for (auto& chunk : blob.second) {
-				printf("[%s - %s)\n", chunk.keyRange.begin.printable().c_str(), chunk.keyRange.end.printable().c_str());
-
-				printf("  SnapshotFile:\n    %s\n",
-				       chunk.snapshotFile.present() ? chunk.snapshotFile.get().toString().c_str() : "<none>");
-				printf("  DeltaFiles:\n");
-				for (auto& df : chunk.deltaFiles) {
-					printf("    %s\n", df.toString().c_str());
-				}
-				printf("  Deltas: (%d)", chunk.newDeltas.size());
-				if (chunk.newDeltas.size() > 0) {
-					fmt::print(" with version [{0} - {1}]",
-					           chunk.newDeltas[0].version,
-					           chunk.newDeltas[chunk.newDeltas.size() - 1].version);
-				}
-				fmt::print("  IncludedVersion: {}\n", chunk.includedVersion);
-			}
-			printf("\n");
+			printGranuleChunks(blob.second);
 		}
 	}
 	return correct;
+}
+
+void printGranuleChunks(const Standalone<VectorRef<BlobGranuleChunkRef>>& chunks) {
+	printf("Chunks:\n");
+	for (auto& chunk : chunks) {
+		printf("[%s - %s)\n", chunk.keyRange.begin.printable().c_str(), chunk.keyRange.end.printable().c_str());
+
+		printf("  SnapshotFile:\n    %s\n",
+		       chunk.snapshotFile.present() ? chunk.snapshotFile.get().toString().c_str() : "<none>");
+		printf("  DeltaFiles:\n");
+		for (auto& df : chunk.deltaFiles) {
+			printf("    %s\n", df.toString().c_str());
+		}
+		printf("  Deltas: (%d)", chunk.newDeltas.size());
+		if (chunk.newDeltas.size() > 0) {
+			fmt::print(" with version [{0} - {1}]",
+			           chunk.newDeltas[0].version,
+			           chunk.newDeltas[chunk.newDeltas.size() - 1].version);
+		}
+		fmt::print("  IncludedVersion: {}\n", chunk.includedVersion);
+	}
+	printf("\n");
 }
 
 ACTOR Future<Void> clearAndAwaitMerge(Database cx, KeyRange range) {

--- a/fdbserver/BlobManager.actor.cpp
+++ b/fdbserver/BlobManager.actor.cpp
@@ -3242,6 +3242,8 @@ ACTOR Future<Void> fullyDeleteGranule(Reference<BlobManagerData> self,
 	++self->stats.granulesFullyPurged;
 	self->stats.filesPurged += filesToDelete.size();
 
+	CODE_PROBE(true, "full granule purged");
+
 	return Void();
 }
 
@@ -3356,6 +3358,8 @@ ACTOR Future<Void> partiallyDeleteGranule(Reference<BlobManagerData> self,
 
 	++self->stats.granulesPartiallyPurged;
 	self->stats.filesPurged += filesToDelete.size();
+
+	CODE_PROBE(true, " partial granule purged");
 
 	return Void();
 }
@@ -3601,6 +3605,8 @@ ACTOR Future<Void> purgeRange(Reference<BlobManagerData> self, KeyRangeRef range
 	    .detail("PurgeVersion", purgeVersion)
 	    .detail("Force", force);
 
+	CODE_PROBE(true, "range purge complete");
+
 	++self->stats.purgesProcessed;
 	return Void();
 }
@@ -3651,6 +3657,7 @@ ACTOR Future<Void> monitorPurgeKeys(Reference<BlobManagerData> self) {
 				// TODO: replace 10000 with a knob
 				state RangeResult purgeIntents = wait(tr->getRange(blobGranulePurgeKeys, BUGGIFY ? 1 : 10000));
 				if (purgeIntents.size()) {
+					CODE_PROBE(true, "BM found purges to process");
 					int rangeIdx = 0;
 					for (; rangeIdx < purgeIntents.size(); ++rangeIdx) {
 						Version purgeVersion;
@@ -3728,6 +3735,8 @@ ACTOR Future<Void> monitorPurgeKeys(Reference<BlobManagerData> self) {
 		if (BM_DEBUG) {
 			printf("Done clearing current set of purge intents.\n");
 		}
+
+		CODE_PROBE(true, "BM finished processing purge intents");
 	}
 }
 

--- a/fdbserver/include/fdbserver/BlobGranuleValidation.actor.h
+++ b/fdbserver/include/fdbserver/BlobGranuleValidation.actor.h
@@ -51,6 +51,8 @@ bool compareFDBAndBlob(RangeResult fdb,
                        Version v,
                        bool debug);
 
+void printGranuleChunks(const Standalone<VectorRef<BlobGranuleChunkRef>>& chunks);
+
 ACTOR Future<Void> clearAndAwaitMerge(Database cx, KeyRange range);
 
 #include "flow/unactorcompiler.h"

--- a/fdbserver/workloads/BlobGranuleVerifier.actor.cpp
+++ b/fdbserver/workloads/BlobGranuleVerifier.actor.cpp
@@ -310,8 +310,11 @@ struct BlobGranuleVerifierWorkload : TestWorkload {
 					if (doPurging) {
 						wait(self->killBlobWorkers(cx, self));
 						if (BGV_DEBUG) {
-								fmt::print("BGV Reading post-purge [{0} - {1}) @ {2}\n", oldRead.range.begin.printable(), oldRead.range.end.printable(), prevPurgeVersion);
-							}
+							fmt::print("BGV Reading post-purge [{0} - {1}) @ {2}\n",
+							           oldRead.range.begin.printable(),
+							           oldRead.range.end.printable(),
+							           prevPurgeVersion);
+						}
 						// ensure purge version exactly is still readable
 						std::pair<RangeResult, Standalone<VectorRef<BlobGranuleChunkRef>>> versionRead1 =
 						    wait(readFromBlob(cx, self->bstore, oldRead.range, 0, prevPurgeVersion));
@@ -326,7 +329,10 @@ struct BlobGranuleVerifierWorkload : TestWorkload {
 								minSnapshotVersion = std::min(minSnapshotVersion, it.snapshotVersion);
 							}
 							if (BGV_DEBUG) {
-								fmt::print("BGV Reading post-purge again [{0} - {1}) @ {2}\n", oldRead.range.begin.printable(), oldRead.range.end.printable(), minSnapshotVersion - 1);
+								fmt::print("BGV Reading post-purge again [{0} - {1}) @ {2}\n",
+								           oldRead.range.begin.printable(),
+								           oldRead.range.end.printable(),
+								           minSnapshotVersion - 1);
 							}
 							std::pair<RangeResult, Standalone<VectorRef<BlobGranuleChunkRef>>> versionRead2 =
 							    wait(readFromBlob(cx, self->bstore, oldRead.range, 0, minSnapshotVersion - 1));


### PR DESCRIPTION
Collection of several bug fixes and testing improvements to granule purging. Still not correctness clean so enablePurging is still turned off for merge

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
