### PR TITLE
Add IP family argument to fdb-kubernetes-monitor

### DIFF
--- a/fdbkubernetesmonitor/api/config.go
+++ b/fdbkubernetesmonitor/api/config.go
@@ -69,7 +69,7 @@ type Argument struct {
 	Offset int `json:"offset,omitempty"`
 
 	// IPFamily provides the family to use for IPList type arguments.
-	IPFamily int `json:"ipFamily,omitEmpty"`
+	IPFamily int `json:"ipFamily,omitempty"`
 }
 
 // ArgumentType defines the types for arguments.
@@ -121,9 +121,9 @@ func (argument Argument) GenerateArgument(processNumber int, env map[string]stri
 		number = number + argument.Offset
 		return strconv.Itoa(number), nil
 	case EnvironmentArgumentType:
-		return argument.lookupEnv(env)
+		return argument.LookupEnv(env)
 	case IPListArgumentType:
-		envValue, err := argument.lookupEnv(env)
+		envValue, err := argument.LookupEnv(env)
 		if err != nil {
 			return "", err
 		}
@@ -153,7 +153,7 @@ func (argument Argument) GenerateArgument(processNumber int, env map[string]stri
 }
 
 // lookupEnv looks up the value for an argument from the environment.
-func (argument Argument) lookupEnv(env map[string]string) (string, error) {
+func (argument Argument) LookupEnv(env map[string]string) (string, error) {
 	var value string
 	var present bool
 	if env != nil {

--- a/fdbkubernetesmonitor/api/config_test.go
+++ b/fdbkubernetesmonitor/api/config_test.go
@@ -216,3 +216,120 @@ func TestGeneratingArgumentForIPList(t *testing.T) {
 		return
 	}
 }
+
+func TestLookupEnvForEnvironmentVariable(t *testing.T) {
+	argument := Argument{ArgumentType: EnvironmentArgumentType, Source: "FDB_ZONE_ID"}
+
+	result, err := argument.LookupEnv(map[string]string{"FDB_ZONE_ID": "zone1", "FDB_MACHINE_ID": "machine1"})
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	if result != "zone1" {
+		t.Logf("Expected result zone1, but got result %v", result)
+		t.Fail()
+		return
+	}
+
+	_, err = argument.LookupEnv(map[string]string{"FDB_MACHINE_ID": "machine1"})
+	if err == nil {
+		t.Logf("Expected error result, but did not get an error")
+		t.Fail()
+		return
+	}
+	expectedError := "missing environment variable FDB_ZONE_ID"
+	if err.Error() != expectedError {
+		t.Logf("Expected error %s, but got error %s", expectedError, err)
+		t.Fail()
+		return
+	}
+}
+
+func TestLookupEnvForIPList(t *testing.T) {
+	argument := Argument{ArgumentType: IPListArgumentType, Source: "FDB_PUBLIC_IP", IPFamily: 4}
+
+	result, err := argument.LookupEnv(map[string]string{"FDB_PUBLIC_IP": "127.0.0.1,::1"})
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	if result != "127.0.0.1" {
+		t.Logf("Expected result 127.0.0.1, but got result %v", result)
+		t.Fail()
+		return
+	}
+
+	result, err = argument.LookupEnv(map[string]string{"FDB_PUBLIC_IP": "::1,127.0.0.1"})
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	if result != "127.0.0.1" {
+		t.Logf("Expected result 127.0.0.1, but got result %v", result)
+		t.Fail()
+		return
+	}
+
+	argument.IPFamily = 6
+
+	result, err = argument.LookupEnv(map[string]string{"FDB_PUBLIC_IP": "127.0.0.1,::1"})
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	if result != "::1" {
+		t.Logf("Expected result ::1, but got result %v", result)
+		t.Fail()
+		return
+	}
+
+	result, err = argument.LookupEnv(map[string]string{"FDB_PUBLIC_IP": "::1,127.0.0.1"})
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	if result != "::1" {
+		t.Logf("Expected result ::1, but got result %v", result)
+		t.Fail()
+		return
+	}
+
+	result, err = argument.LookupEnv(map[string]string{"FDB_PUBLIC_IP": "bad,::1"})
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	if result != "::1" {
+		t.Logf("Expected result ::1, but got result %v", result)
+		t.Fail()
+		return
+	}
+
+	_, err = argument.LookupEnv(map[string]string{"FDB_PUBLIC_IP": "127.0.0.1"})
+	if err == nil {
+		t.Logf("Expected error, but did not get an error")
+		t.Fail()
+		return
+	}
+	expectedError := "could not find IP with family 6"
+	if err.Error() != expectedError {
+		t.Logf("Expected error %s, but got error %s", expectedError, err.Error())
+		t.Fail()
+		return
+	}
+
+	argument.IPFamily = 5
+
+	_, err = argument.LookupEnv(map[string]string{"FDB_PUBLIC_IP": "127.0.0.1"})
+	if err == nil {
+		t.Logf("Expected error, but did not get an error")
+		t.Fail()
+		return
+	}
+	expectedError = "unsupported IP family 5"
+	if err.Error() != expectedError {
+		t.Logf("Expected error %s, but got error %s", expectedError, err.Error())
+		t.Fail()
+		return
+	}
+}

--- a/fdbkubernetesmonitor/api/config_test.go
+++ b/fdbkubernetesmonitor/api/config_test.go
@@ -120,9 +120,98 @@ func TestGeneratingArgumentForEnvironmentVariable(t *testing.T) {
 		t.Fail()
 		return
 	}
-	expectedError := "Missing environment variable FDB_ZONE_ID"
+	expectedError := "missing environment variable FDB_ZONE_ID"
 	if err.Error() != expectedError {
 		t.Logf("Expected error %s, but got error %s", expectedError, err)
+		t.Fail()
+		return
+	}
+}
+
+func TestGeneratingArgumentForIPList(t *testing.T) {
+	argument := Argument{ArgumentType: IPListArgumentType, Source: "FDB_PUBLIC_IP", IPFamily: 4}
+
+	result, err := argument.GenerateArgument(1, map[string]string{"FDB_PUBLIC_IP": "127.0.0.1,::1"})
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	if result != "127.0.0.1" {
+		t.Logf("Expected result 127.0.0.1, but got result %v", result)
+		t.Fail()
+		return
+	}
+
+	result, err = argument.GenerateArgument(1, map[string]string{"FDB_PUBLIC_IP": "::1,127.0.0.1"})
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	if result != "127.0.0.1" {
+		t.Logf("Expected result 127.0.0.1, but got result %v", result)
+		t.Fail()
+		return
+	}
+
+	argument.IPFamily = 6
+
+	result, err = argument.GenerateArgument(1, map[string]string{"FDB_PUBLIC_IP": "127.0.0.1,::1"})
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	if result != "::1" {
+		t.Logf("Expected result ::1, but got result %v", result)
+		t.Fail()
+		return
+	}
+
+	result, err = argument.GenerateArgument(1, map[string]string{"FDB_PUBLIC_IP": "::1,127.0.0.1"})
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	if result != "::1" {
+		t.Logf("Expected result ::1, but got result %v", result)
+		t.Fail()
+		return
+	}
+
+	result, err = argument.GenerateArgument(1, map[string]string{"FDB_PUBLIC_IP": "bad,::1"})
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	if result != "::1" {
+		t.Logf("Expected result ::1, but got result %v", result)
+		t.Fail()
+		return
+	}
+
+	_, err = argument.GenerateArgument(1, map[string]string{"FDB_PUBLIC_IP": "127.0.0.1"})
+	if err == nil {
+		t.Logf("Expected error, but did not get an error")
+		t.Fail()
+		return
+	}
+	expectedError := "could not find IP with family 6"
+	if err.Error() != expectedError {
+		t.Logf("Expected error %s, but got error %s", expectedError, err.Error())
+		t.Fail()
+		return
+	}
+
+	argument.IPFamily = 5
+
+	_, err = argument.GenerateArgument(1, map[string]string{"FDB_PUBLIC_IP": "127.0.0.1"})
+	if err == nil {
+		t.Logf("Expected error, but did not get an error")
+		t.Fail()
+		return
+	}
+	expectedError = "unsupported IP family 5"
+	if err.Error() != expectedError {
+		t.Logf("Expected error %s, but got error %s", expectedError, err.Error())
 		t.Fail()
 		return
 	}


### PR DESCRIPTION
This is designed to support use cases on Kubernetes with a dual-stack network, where the IP comes as a list containing IPv4 and IPv6 addresses. This adds a new argument type to support selecting an IP address from a list, selecting the address with a specific IP family.

This is discussed in this issue on the operator: https://github.com/FoundationDB/fdb-kubernetes-operator/issues/1031

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
