### PR TITLE
Fix incorrect deserialization of FdbClientLogEvents::Event

### DIFF
--- a/contrib/transaction_profiling_analyzer/transaction_profiling_analyzer.py
+++ b/contrib/transaction_profiling_analyzer/transaction_profiling_analyzer.py
@@ -194,7 +194,7 @@ class BaseInfo(object):
         if protocol_version >= PROTOCOL_VERSION_6_3:
             self.dc_id = bb.get_bytes_with_length()
         if protocol_version >= PROTOCOL_VERSION_7_1:
-            if bb.get_bytes(1):
+            if bb.get_bool():
                 self.tenant = bb.get_bytes_with_length()
 
 class GetVersionInfo(BaseInfo):


### PR DESCRIPTION
We're trying to interpret an Optional<TenantName> here, but the
python truthiness of self.get_bytes(1) is _always_ true, since it's
non-empty. We need to look at the _contents_ of that byte instead.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
