### PR TITLE
Validate subrange reads in simulation (#7597) (release-7.0)

### DIFF
--- a/fdbclient/SpecialKeySpace.actor.cpp
+++ b/fdbclient/SpecialKeySpace.actor.cpp
@@ -2289,10 +2289,10 @@ ACTOR Future<Void> validateSpecialSubrangeRead(ReadYourWritesTransaction* ryw,
                                                KeySelector begin,
                                                KeySelector end,
                                                GetRangeLimits limits,
-                                               Reverse reverse,
+                                               bool reverse,
                                                RangeResult result) {
 	if (!result.size()) {
-		RangeResult testResult = wait(ryw->getRange(begin, end, limits, Snapshot::True, reverse));
+		RangeResult testResult = wait(ryw->getRange(begin, end, limits, true, reverse));
 		ASSERT(testResult == result);
 		return Void();
 	}
@@ -2345,24 +2345,7 @@ ACTOR Future<Void> validateSpecialSubrangeRead(ReadYourWritesTransaction* ryw,
 	}
 
 	// Test
-	RangeResult testResult = wait(ryw->getRange(testBegin, testEnd, limits, Snapshot::True, reverse));
-	if (testResult != expectedResult) {
-		fmt::print("Reverse: {}\n", reverse);
-		fmt::print("Original range: [{}, {})\n", begin.toString(), end.toString());
-		fmt::print("Original result:\n");
-		for (const auto& kr : result) {
-			fmt::print("	{} -> {}\n", kr.key.printable(), kr.value.printable());
-		}
-		fmt::print("Test range: [{}, {})\n", testBegin.getKey().printable(), testEnd.getKey().printable());
-		fmt::print("Expected:\n");
-		for (const auto& kr : expectedResult) {
-			fmt::print("	{} -> {}\n", kr.key.printable(), kr.value.printable());
-		}
-		fmt::print("Got:\n");
-		for (const auto& kr : testResult) {
-			fmt::print("	{} -> {}\n", kr.key.printable(), kr.value.printable());
-		}
-		ASSERT(testResult == expectedResult);
-	}
+	RangeResult testResult = wait(ryw->getRange(testBegin, testEnd, limits, true, reverse));
+	ASSERT(testResult == expectedResult);
 	return Void();
 }

--- a/fdbclient/SpecialKeySpace.actor.h
+++ b/fdbclient/SpecialKeySpace.actor.h
@@ -421,5 +421,15 @@ public:
 	Future<Optional<std::string>> commit(ReadYourWritesTransaction* ryw) override;
 };
 
+// If the underlying set of key-value pairs of a key space is not changing, then we expect repeating a read to give the
+// same result. Additionally, we can generate the expected result of any read if that read is reading a subrange. This
+// actor performs a read of an arbitrary subrange of [begin, end) and validates the results.
+ACTOR Future<Void> validateSpecialSubrangeRead(ReadYourWritesTransaction* ryw,
+                                               KeySelector begin,
+                                               KeySelector end,
+                                               GetRangeLimits limits,
+                                               Reverse reverse,
+                                               RangeResult result);
+
 #include "flow/unactorcompiler.h"
 #endif

--- a/fdbclient/SpecialKeySpace.actor.h
+++ b/fdbclient/SpecialKeySpace.actor.h
@@ -428,7 +428,7 @@ ACTOR Future<Void> validateSpecialSubrangeRead(ReadYourWritesTransaction* ryw,
                                                KeySelector begin,
                                                KeySelector end,
                                                GetRangeLimits limits,
-                                               Reverse reverse,
+                                               bool reverse,
                                                RangeResult result);
 
 #include "flow/unactorcompiler.h"

--- a/fdbserver/workloads/ReportConflictingKeys.actor.cpp
+++ b/fdbserver/workloads/ReportConflictingKeys.actor.cpp
@@ -192,8 +192,15 @@ struct ReportConflictingKeysWorkload : TestWorkload {
 					                LiteralStringRef("\xff\xff").withPrefix(conflictingKeysRange.begin));
 					// The getRange here using the special key prefix "\xff\xff/transaction/conflicting_keys/" happens
 					// locally Thus, the error handling is not needed here
-					Future<RangeResult> conflictingKeyRangesFuture = tr2->getRange(ckr, CLIENT_KNOBS->TOO_MANY);
+					state Future<RangeResult> conflictingKeyRangesFuture = tr2->getRange(ckr, CLIENT_KNOBS->TOO_MANY);
 					ASSERT(conflictingKeyRangesFuture.isReady());
+
+					wait(validateSpecialSubrangeRead(tr2.getPtr(),
+					                                 firstGreaterOrEqual(ckr.begin),
+					                                 firstGreaterOrEqual(ckr.end),
+					                                 GetRangeLimits(),
+					                                 Reverse::False,
+					                                 conflictingKeyRangesFuture.get()));
 
 					tr2 = makeReference<ReadYourWritesTransaction>(cx);
 

--- a/fdbserver/workloads/ReportConflictingKeys.actor.cpp
+++ b/fdbserver/workloads/ReportConflictingKeys.actor.cpp
@@ -199,7 +199,7 @@ struct ReportConflictingKeysWorkload : TestWorkload {
 					                                 firstGreaterOrEqual(ckr.begin),
 					                                 firstGreaterOrEqual(ckr.end),
 					                                 GetRangeLimits(),
-					                                 Reverse::False,
+					                                 false,
 					                                 conflictingKeyRangesFuture.get()));
 
 					tr2 = makeReference<ReadYourWritesTransaction>(cx);


### PR DESCRIPTION
Cherry-pick the bug fix #7597 

- remove `fmt::print`
- `Reverse::False` and `Snapshot::True` to boolean

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [x] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [x] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
