### PR TITLE
fix storage_metadata disappear because other attribution is missed

### DIFF
--- a/fdbserver/Status.actor.cpp
+++ b/fdbserver/Status.actor.cpp
@@ -487,6 +487,11 @@ struct RolesInfo {
 		double dataLagSeconds = -1.0;
 		obj["id"] = iface.id().shortString();
 		obj["role"] = role;
+		if (iface.metadata.present()) {
+			obj["storage_metadata"] = iface.metadata.get().toJSON();
+			// printf("%s\n", metadataObj.getJson().c_str());
+		}
+
 		try {
 			TraceEventFields const& storageMetrics = metrics.at("StorageMetrics");
 
@@ -594,14 +599,12 @@ struct RolesInfo {
 				}
 			}
 
-			if (iface.metadata.present()) {
-				obj["storage_metadata"] = iface.metadata.get().toJSON();
-				// printf("%s\n", metadataObj.getJson().c_str());
-			}
-
 		} catch (Error& e) {
 			if (e.code() != error_code_attribute_not_found)
 				throw e;
+			else {
+				TraceEvent(SevWarnAlways, "StorageServerStatusJson").error(e);
+			}
 		}
 
 		if (pDataLagSeconds) {


### PR DESCRIPTION
`if (iface.metadata.present()) {` guarantee `storage_metadata` won't throw `attribute_not_found()` it doesn't need to be in the `try..catch` block.
BTW, it seems like `BusiestReadTag` event removing the `TagCost` field causes the problem.
```
logs/trace.10.180.1.234.9800.1658963411.M9jyyK.0.1.xml:<Event Severity="10" Time="1658963565.378774" DateTime="2022-07-27T23:12:45Z" Type="BusiestReadTag" ID="6382b4324e520733" Elapsed="30" TotalSampledCost="4" Reported="0" ThreadID="12400470774736890218" Machine="10.180.1.234:9800" LogGroup="default" Roles="CC,CD,CP,DD,GP,MS,RK,RV,SS,TL" TrackLatestType="Original" />
```
# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
