### PR TITLE
Encrypt  BlobGranule delta files

### DIFF
--- a/fdbclient/BlobGranuleFiles.cpp
+++ b/fdbclient/BlobGranuleFiles.cpp
@@ -1277,13 +1277,13 @@ RangeResult materializeBlobGranule(const BlobGranuleChunkRef& chunk,
 	}
 
 	if (snapshotData.present()) {
-		Optional<BlobGranuleCipherKeysCtx> cipherKeysCtx;
-		// Should this be an assert?
-		if (chunk.snapshotFile.present()) {
-			cipherKeysCtx = chunk.snapshotFile.get().cipherKeysCtx;
-		}
-		Arena snapshotArena = loadSnapshotFile(
-		    chunk.snapshotFile.get().filename, snapshotData.get(), requestRange, dataMap, cipherKeysCtx);
+		ASSERT(chunk.snapshotFile.present());
+
+		Arena snapshotArena = loadSnapshotFile(chunk.snapshotFile.get().filename,
+		                                       snapshotData.get(),
+		                                       requestRange,
+		                                       dataMap,
+		                                       chunk.snapshotFile.get().cipherKeysCtx);
 		arena.dependsOn(snapshotArena);
 	}
 
@@ -1839,9 +1839,7 @@ struct KeyValueGen {
 		return StringRef(ar, value);
 	}
 
-	KeyRef randomUsedKey() const {
-		return usedKeysList[deterministicRandom()->randomInt(0, usedKeysList.size())];
-	}
+	KeyRef randomUsedKey() const { return usedKeysList[deterministicRandom()->randomInt(0, usedKeysList.size())]; }
 
 	KeyRange randomKeyRange() const {
 		ASSERT(!usedKeysList.empty());
@@ -1966,7 +1964,7 @@ TEST_CASE("/blobgranule/files/snapshotFormatUnitTest") {
 	int targetChunks = deterministicRandom()->randomExp(0, 9);
 	int targetDataBytes = deterministicRandom()->randomExp(0, 25);
 	int targetChunkSize = targetDataBytes / targetChunks;
-	Standalone<StringRef> fnameRef = StringRef("test");
+	Standalone<StringRef> fnameRef = StringRef(std::string("test"));
 
 	Standalone<GranuleSnapshot> data = genSnapshot(kvGen, targetDataBytes);
 
@@ -2102,7 +2100,7 @@ Standalone<GranuleDeltas> genDeltas(KeyValueGen& kvGen, int targetBytes) {
 
 TEST_CASE("/blobgranule/files/deltaFormatUnitTest") {
 	KeyValueGen kvGen;
-	Standalone<StringRef> fileNameRef = StringRef("test");
+	Standalone<StringRef> fileNameRef = StringRef(std::string("test"));
 
 	int targetChunks = deterministicRandom()->randomExp(0, 8);
 	int targetDataBytes = deterministicRandom()->randomExp(0, 21);
@@ -2206,7 +2204,7 @@ void checkGranuleRead(const KeyValueGen& kvGen,
 
 TEST_CASE("/blobgranule/files/granuleReadUnitTest") {
 	KeyValueGen kvGen;
-	Standalone<StringRef> fileNameRef = StringRef("testSnap");
+	Standalone<StringRef> fileNameRef = StringRef(std::string("testSnap"));
 
 	int targetSnapshotChunks = deterministicRandom()->randomExp(0, 9);
 	int targetDeltaChunks = deterministicRandom()->randomExp(0, 8);

--- a/fdbclient/BlobGranuleFiles.cpp
+++ b/fdbclient/BlobGranuleFiles.cpp
@@ -26,6 +26,7 @@
 #include "fdbclient/Knobs.h"
 #include "fdbclient/SystemData.h" // for allKeys unit test - could remove
 
+#include "flow/Arena.h"
 #include "flow/BlobCipher.h"
 #include "flow/CompressionUtils.h"
 #include "flow/DeterministicRandom.h"
@@ -293,6 +294,7 @@ struct IndexBlockRef {
 		if (encryptHeaderRef.present()) {
 			CODE_PROBE(true, "reading encrypted chunked file");
 			ASSERT(cipherKeysCtx.present());
+
 			decrypt(cipherKeysCtx.get(), *this, arena);
 		} else {
 			TraceEvent("IndexBlockSize").detail("Sz", buffer.size());
@@ -656,10 +658,19 @@ Value serializeFileFromChunks(Standalone<IndexedBlobGranuleFile>& file,
 // TODO: this should probably be in actor file with yields? - move writing logic to separate actor file in server?
 // TODO: optimize memory copying
 // TODO: sanity check no oversized files
-Value serializeChunkedSnapshot(Standalone<GranuleSnapshot> snapshot,
+Value serializeChunkedSnapshot(const Standalone<StringRef>& fileNameRef,
+                               Standalone<GranuleSnapshot> snapshot,
                                int targetChunkBytes,
                                Optional<CompressionFilter> compressFilter,
                                Optional<BlobGranuleCipherKeysCtx> cipherKeysCtx) {
+
+	if (BG_ENCRYPT_COMPRESS_DEBUG) {
+		TraceEvent(SevDebug, "SerializeChunkedSnapshot")
+		    .detail("FileName", fileNameRef.toString())
+		    .detail("Encrypted", cipherKeysCtx.present())
+		    .detail("Compressed", compressFilter.present());
+	}
+
 	CODE_PROBE(compressFilter.present(), "serializing compressed snapshot file");
 	CODE_PROBE(cipherKeysCtx.present(), "serializing encrypted snapshot file");
 	Standalone<IndexedBlobGranuleFile> file;
@@ -717,11 +728,20 @@ Value serializeChunkedSnapshot(Standalone<GranuleSnapshot> snapshot,
 }
 
 // TODO: use redwood prefix trick to optimize cpu comparison
-static Arena loadSnapshotFile(const StringRef& snapshotData,
+static Arena loadSnapshotFile(const Standalone<StringRef>& fileName,
+                              const StringRef& snapshotData,
                               const KeyRangeRef& keyRange,
                               std::map<KeyRef, ValueRef>& dataMap,
                               Optional<BlobGranuleCipherKeysCtx> cipherKeysCtx) {
 	Arena rootArena;
+
+	if (BG_ENCRYPT_COMPRESS_DEBUG) {
+		TraceEvent(SevDebug, "LoadChunkedSnapshot")
+		    .detail("FileName", fileName.toString())
+		    .detail("RangeBegin", keyRange.begin.printable())
+		    .detail("RangeEnd", keyRange.end.printable())
+		    .detail("Encrypted", cipherKeysCtx.present());
+	}
 
 	Standalone<IndexedBlobGranuleFile> file = IndexedBlobGranuleFile::fromFileBytes(snapshotData, cipherKeysCtx);
 
@@ -879,11 +899,21 @@ void sortDeltasByKey(const Standalone<GranuleDeltas>& deltasByVersion,
 }
 
 // FIXME: Could maybe reduce duplicated code between this and chunkedSnapshot for chunking
-Value serializeChunkedDeltaFile(Standalone<GranuleDeltas> deltas,
+Value serializeChunkedDeltaFile(const Standalone<StringRef>& fileNameRef,
+                                Standalone<GranuleDeltas> deltas,
                                 const KeyRangeRef& fileRange,
                                 int chunkSize,
                                 Optional<CompressionFilter> compressFilter,
                                 Optional<BlobGranuleCipherKeysCtx> cipherKeysCtx) {
+	if (BG_ENCRYPT_COMPRESS_DEBUG) {
+		TraceEvent(SevDebug, "SerializeChunkedDelta")
+		    .detail("Filename", fileNameRef.toString())
+		    .detail("RangeBegin", fileRange.begin.printable())
+		    .detail("RangeEnd", fileRange.end.printable())
+		    .detail("Encrypted", cipherKeysCtx.present())
+		    .detail("Compressed", compressFilter.present());
+	}
+
 	CODE_PROBE(compressFilter.present(), "serializing compressed delta file");
 	CODE_PROBE(cipherKeysCtx.present(), "serializing encrypted delta file");
 	Standalone<IndexedBlobGranuleFile> file;
@@ -1066,12 +1096,22 @@ void applyDeltasSorted(const Standalone<VectorRef<ParsedDeltaBoundaryRef>>& sort
 
 // The arena owns the BoundaryDeltaRef struct data but the StringRef pointers point to data in deltaData, to avoid extra
 // copying
-Arena loadChunkedDeltaFile(const StringRef& deltaData,
+Arena loadChunkedDeltaFile(const Standalone<StringRef>& fileNameRef,
+                           const StringRef& deltaData,
                            const KeyRangeRef& keyRange,
                            Version beginVersion,
                            Version readVersion,
                            std::map<KeyRef, ValueRef>& dataMap,
                            Optional<BlobGranuleCipherKeysCtx> cipherKeysCtx) {
+
+	if (BG_ENCRYPT_COMPRESS_DEBUG) {
+		TraceEvent(SevDebug, "LoadChunkedDelta")
+		    .detail("FileName", fileNameRef.toString())
+		    .detail("RangeBegin", keyRange.begin.printable())
+		    .detail("RangeEnd", keyRange.end.printable())
+		    .detail("Encrypted", cipherKeysCtx.present());
+	}
+
 	Standalone<VectorRef<ParsedDeltaBoundaryRef>> deltas;
 	Standalone<IndexedBlobGranuleFile> file = IndexedBlobGranuleFile::fromFileBytes(deltaData, cipherKeysCtx);
 
@@ -1237,7 +1277,13 @@ RangeResult materializeBlobGranule(const BlobGranuleChunkRef& chunk,
 	}
 
 	if (snapshotData.present()) {
-		Arena snapshotArena = loadSnapshotFile(snapshotData.get(), requestRange, dataMap, chunk.cipherKeysCtx);
+		Optional<BlobGranuleCipherKeysCtx> cipherKeysCtx;
+		// Should this be an assert?
+		if (chunk.snapshotFile.present()) {
+			cipherKeysCtx = chunk.snapshotFile.get().cipherKeysCtx;
+		}
+		Arena snapshotArena = loadSnapshotFile(
+		    chunk.snapshotFile.get().filename, snapshotData.get(), requestRange, dataMap, cipherKeysCtx);
 		arena.dependsOn(snapshotArena);
 	}
 
@@ -1245,8 +1291,13 @@ RangeResult materializeBlobGranule(const BlobGranuleChunkRef& chunk,
 		fmt::print("Applying {} delta files\n", chunk.deltaFiles.size());
 	}
 	for (int deltaIdx = 0; deltaIdx < chunk.deltaFiles.size(); deltaIdx++) {
-		Arena deltaArena = loadChunkedDeltaFile(
-		    deltaFileData[deltaIdx], requestRange, beginVersion, readVersion, dataMap, chunk.cipherKeysCtx);
+		Arena deltaArena = loadChunkedDeltaFile(chunk.deltaFiles[deltaIdx].filename,
+		                                        deltaFileData[deltaIdx],
+		                                        requestRange,
+		                                        beginVersion,
+		                                        readVersion,
+		                                        dataMap,
+		                                        chunk.deltaFiles[deltaIdx].cipherKeysCtx);
 		arena.dependsOn(deltaArena);
 	}
 	if (BG_READ_DEBUG) {
@@ -1644,12 +1695,14 @@ TEST_CASE("/blobgranule/files/deltaAtVersion") {
 
 void checkSnapshotEmpty(const Value& serialized, Key begin, Key end, Optional<BlobGranuleCipherKeysCtx> cipherKeysCtx) {
 	std::map<KeyRef, ValueRef> result;
-	Arena ar = loadSnapshotFile(serialized, KeyRangeRef(begin, end), result, cipherKeysCtx);
+	Standalone<StringRef> fileNameRef = StringRef();
+	Arena ar = loadSnapshotFile(fileNameRef, serialized, KeyRangeRef(begin, end), result, cipherKeysCtx);
 	ASSERT(result.empty());
 }
 
 // endIdx is exclusive
-void checkSnapshotRead(const Standalone<GranuleSnapshot>& snapshot,
+void checkSnapshotRead(const Standalone<StringRef>& fileNameRef,
+                       const Standalone<GranuleSnapshot>& snapshot,
                        const Value& serialized,
                        int beginIdx,
                        int endIdx,
@@ -1661,7 +1714,7 @@ void checkSnapshotRead(const Standalone<GranuleSnapshot>& snapshot,
 	Key endKey = endIdx == snapshot.size() ? keyAfter(snapshot.back().key) : snapshot[endIdx].key;
 	KeyRangeRef range(beginKey, endKey);
 
-	Arena ar = loadSnapshotFile(serialized, range, result, cipherKeysCtx);
+	Arena ar = loadSnapshotFile(fileNameRef, serialized, range, result, cipherKeysCtx);
 
 	if (result.size() != endIdx - beginIdx) {
 		fmt::print("Read {0} rows != {1}\n", result.size(), endIdx - beginIdx);
@@ -1786,7 +1839,9 @@ struct KeyValueGen {
 		return StringRef(ar, value);
 	}
 
-	KeyRef randomUsedKey() const { return usedKeysList[deterministicRandom()->randomInt(0, usedKeysList.size())]; }
+	KeyRef randomUsedKey() const {
+		return usedKeysList[deterministicRandom()->randomInt(0, usedKeysList.size())];
+	}
 
 	KeyRange randomKeyRange() const {
 		ASSERT(!usedKeysList.empty());
@@ -1911,6 +1966,7 @@ TEST_CASE("/blobgranule/files/snapshotFormatUnitTest") {
 	int targetChunks = deterministicRandom()->randomExp(0, 9);
 	int targetDataBytes = deterministicRandom()->randomExp(0, 25);
 	int targetChunkSize = targetDataBytes / targetChunks;
+	Standalone<StringRef> fnameRef = StringRef("test");
 
 	Standalone<GranuleSnapshot> data = genSnapshot(kvGen, targetDataBytes);
 
@@ -1927,7 +1983,8 @@ TEST_CASE("/blobgranule/files/snapshotFormatUnitTest") {
 
 	fmt::print("Constructing snapshot with {0} rows, {1} chunks\n", data.size(), targetChunks);
 
-	Value serialized = serializeChunkedSnapshot(data, targetChunkSize, kvGen.compressFilter, kvGen.cipherKeys);
+	Value serialized =
+	    serializeChunkedSnapshot(fnameRef, data, targetChunkSize, kvGen.compressFilter, kvGen.cipherKeys);
 
 	fmt::print("Snapshot serialized! {0} bytes\n", serialized.size());
 
@@ -1938,7 +1995,7 @@ TEST_CASE("/blobgranule/files/snapshotFormatUnitTest") {
 
 	fmt::print("Initial read starting\n");
 
-	checkSnapshotRead(data, serialized, 0, data.size(), kvGen.cipherKeys);
+	checkSnapshotRead(fnameRef, data, serialized, 0, data.size(), kvGen.cipherKeys);
 
 	fmt::print("Initial read complete\n");
 
@@ -1947,7 +2004,7 @@ TEST_CASE("/blobgranule/files/snapshotFormatUnitTest") {
 			int width = deterministicRandom()->randomExp(0, maxExp);
 			ASSERT(width <= data.size());
 			int start = deterministicRandom()->randomInt(0, data.size() - width);
-			checkSnapshotRead(data, serialized, start, start + width, kvGen.cipherKeys);
+			checkSnapshotRead(fnameRef, data, serialized, start, start + width, kvGen.cipherKeys);
 		}
 
 		fmt::print("Doing empty checks\n");
@@ -1984,8 +2041,8 @@ void checkDeltaRead(const KeyValueGen& kvGen,
 	    deterministicRandom()->randomUniqueID(), deterministicRandom()->randomUniqueID(), readVersion, ".delta");
 	Standalone<BlobGranuleChunkRef> chunk;
 	// TODO need to add cipher keys meta
-	chunk.deltaFiles.emplace_back_deep(chunk.arena(), filename, 0, serialized->size(), serialized->size());
-	chunk.cipherKeysCtx = kvGen.cipherKeys;
+	chunk.deltaFiles.emplace_back_deep(
+	    chunk.arena(), filename, 0, serialized->size(), serialized->size(), kvGen.cipherKeys);
 	chunk.keyRange = kvGen.allRange;
 	chunk.includedVersion = readVersion;
 	chunk.snapshotVersion = invalidVersion;
@@ -2045,6 +2102,7 @@ Standalone<GranuleDeltas> genDeltas(KeyValueGen& kvGen, int targetBytes) {
 
 TEST_CASE("/blobgranule/files/deltaFormatUnitTest") {
 	KeyValueGen kvGen;
+	Standalone<StringRef> fileNameRef = StringRef("test");
 
 	int targetChunks = deterministicRandom()->randomExp(0, 8);
 	int targetDataBytes = deterministicRandom()->randomExp(0, 21);
@@ -2054,8 +2112,8 @@ TEST_CASE("/blobgranule/files/deltaFormatUnitTest") {
 	Standalone<GranuleDeltas> data = genDeltas(kvGen, targetDataBytes);
 
 	fmt::print("Deltas ({0})\n", data.size());
-	Value serialized =
-	    serializeChunkedDeltaFile(data, kvGen.allRange, targetChunkSize, kvGen.compressFilter, kvGen.cipherKeys);
+	Value serialized = serializeChunkedDeltaFile(
+	    fileNameRef, data, kvGen.allRange, targetChunkSize, kvGen.compressFilter, kvGen.cipherKeys);
 
 	// check whole file
 	checkDeltaRead(kvGen, kvGen.allRange, 0, data.back().version, data, &serialized);
@@ -2095,7 +2153,7 @@ void checkGranuleRead(const KeyValueGen& kvGen,
 		std::string snapshotFilename = randomBGFilename(
 		    deterministicRandom()->randomUniqueID(), deterministicRandom()->randomUniqueID(), 0, ".snapshot");
 		chunk.snapshotFile = BlobFilePointerRef(
-		    chunk.arena(), snapshotFilename, 0, serializedSnapshot.size(), serializedSnapshot.size());
+		    chunk.arena(), snapshotFilename, 0, serializedSnapshot.size(), serializedSnapshot.size(), kvGen.cipherKeys);
 	}
 	int deltaIdx = 0;
 	while (deltaIdx < serializedDeltas.size() && serializedDeltas[deltaIdx].first < beginVersion) {
@@ -2106,7 +2164,7 @@ void checkGranuleRead(const KeyValueGen& kvGen,
 		std::string deltaFilename = randomBGFilename(
 		    deterministicRandom()->randomUniqueID(), deterministicRandom()->randomUniqueID(), readVersion, ".delta");
 		size_t fsize = serializedDeltas[deltaIdx].second.size();
-		chunk.deltaFiles.emplace_back_deep(chunk.arena(), deltaFilename, 0, fsize, fsize);
+		chunk.deltaFiles.emplace_back_deep(chunk.arena(), deltaFilename, 0, fsize, fsize, kvGen.cipherKeys);
 		deltaPtrsVector.push_back(serializedDeltas[deltaIdx].second);
 
 		if (serializedDeltas[deltaIdx].first >= readVersion) {
@@ -2127,8 +2185,6 @@ void checkGranuleRead(const KeyValueGen& kvGen,
 		}
 	}
 
-	// TODO need to add cipher keys meta
-	chunk.cipherKeysCtx = kvGen.cipherKeys;
 	chunk.keyRange = kvGen.allRange;
 	chunk.includedVersion = readVersion;
 	chunk.snapshotVersion = (beginVersion == 0) ? 0 : invalidVersion;
@@ -2150,6 +2206,7 @@ void checkGranuleRead(const KeyValueGen& kvGen,
 
 TEST_CASE("/blobgranule/files/granuleReadUnitTest") {
 	KeyValueGen kvGen;
+	Standalone<StringRef> fileNameRef = StringRef("testSnap");
 
 	int targetSnapshotChunks = deterministicRandom()->randomExp(0, 9);
 	int targetDeltaChunks = deterministicRandom()->randomExp(0, 8);
@@ -2164,8 +2221,8 @@ TEST_CASE("/blobgranule/files/granuleReadUnitTest") {
 	Standalone<GranuleDeltas> deltaData = genDeltas(kvGen, targetDeltaBytes);
 	fmt::print("{0} snapshot rows and {1} deltas\n", snapshotData.size(), deltaData.size());
 
-	Value serializedSnapshot =
-	    serializeChunkedSnapshot(snapshotData, targetSnapshotChunkSize, kvGen.compressFilter, kvGen.cipherKeys);
+	Value serializedSnapshot = serializeChunkedSnapshot(
+	    fileNameRef, snapshotData, targetSnapshotChunkSize, kvGen.compressFilter, kvGen.cipherKeys);
 
 	// split deltas up across multiple files
 	int deltaFiles = std::min(deltaData.size(), deterministicRandom()->randomInt(1, 21));
@@ -2184,8 +2241,13 @@ TEST_CASE("/blobgranule/files/granuleReadUnitTest") {
 				// if it's the last set of deltas, sometimes make them the memory deltas instead
 				inMemoryDeltas = fileData;
 			} else {
-				Value serializedDelta = serializeChunkedDeltaFile(
-				    fileData, kvGen.allRange, targetDeltaChunkSize, kvGen.compressFilter, kvGen.cipherKeys);
+				Standalone<StringRef> fileNameRef = StringRef("delta" + std::to_string(i));
+				Value serializedDelta = serializeChunkedDeltaFile(fileNameRef,
+				                                                  fileData,
+				                                                  kvGen.allRange,
+				                                                  targetDeltaChunkSize,
+				                                                  kvGen.compressFilter,
+				                                                  kvGen.cipherKeys);
 				serializedDeltaFiles.emplace_back(fileData.back().version, serializedDelta);
 			}
 		}

--- a/fdbclient/include/fdbclient/BlobGranuleCommon.h
+++ b/fdbclient/include/fdbclient/BlobGranuleCommon.h
@@ -143,16 +143,11 @@ struct BlobGranuleCipherKeysMetaRef {
 	StringRef ivRef;
 
 	BlobGranuleCipherKeysMetaRef() {}
-	BlobGranuleCipherKeysMetaRef(Arena& to,
-	                             const EncryptCipherDomainId tDomainId,
-	                             const EncryptCipherBaseKeyId tBaseCipherId,
-	                             const EncryptCipherRandomSalt tSalt,
-	                             const EncryptCipherDomainId hDomainId,
-	                             const EncryptCipherBaseKeyId hBaseCipherId,
-	                             const EncryptCipherRandomSalt hSalt,
-	                             const std::string& ivStr)
-	  : textDomainId(tDomainId), textBaseCipherId(tBaseCipherId), textSalt(tSalt), headerDomainId(hDomainId),
-	    headerBaseCipherId(hBaseCipherId), headerSalt(hSalt), ivRef(StringRef(to, ivStr)) {}
+	BlobGranuleCipherKeysMetaRef(Arena& to, BlobGranuleCipherKeysMeta cipherKeysMeta)
+	  : textDomainId(cipherKeysMeta.textDomainId), textBaseCipherId(cipherKeysMeta.textBaseCipherId),
+	    textSalt(cipherKeysMeta.textSalt), headerDomainId(cipherKeysMeta.headerDomainId),
+	    headerBaseCipherId(cipherKeysMeta.headerBaseCipherId), headerSalt(cipherKeysMeta.headerSalt),
+	    ivRef(StringRef(to, cipherKeysMeta.ivStr)) {}
 
 	template <class Ar>
 	void serialize(Ar& ar) {
@@ -162,15 +157,30 @@ struct BlobGranuleCipherKeysMetaRef {
 
 struct BlobFilePointerRef {
 	constexpr static FileIdentifier file_identifier = 5253554;
+	// Serializable fields
 	StringRef filename;
 	int64_t offset;
 	int64_t length;
 	int64_t fullFileLength;
-	Optional<BlobGranuleCipherKeysMetaRef> cipherKeysMetaRef;
+	Optional<BlobGranuleCipherKeysCtx> cipherKeysCtx;
+
+	// Non-serializable fields
+	Optional<BlobGranuleCipherKeysMetaRef>
+	    cipherKeysMetaRef; // Placeholder to cache information sufficient to lookup encryption ciphers
 
 	BlobFilePointerRef() {}
+
 	BlobFilePointerRef(Arena& to, const std::string& filename, int64_t offset, int64_t length, int64_t fullFileLength)
 	  : filename(to, filename), offset(offset), length(length), fullFileLength(fullFileLength) {}
+
+	BlobFilePointerRef(Arena& to,
+	                   const std::string& filename,
+	                   int64_t offset,
+	                   int64_t length,
+	                   int64_t fullFileLength,
+	                   Optional<BlobGranuleCipherKeysCtx> ciphKeysCtx)
+	  : filename(to, filename), offset(offset), length(length), fullFileLength(fullFileLength),
+	    cipherKeysCtx(ciphKeysCtx) {}
 
 	BlobFilePointerRef(Arena& to,
 	                   const std::string& filename,
@@ -180,30 +190,23 @@ struct BlobFilePointerRef {
 	                   Optional<BlobGranuleCipherKeysMeta> ciphKeysMeta)
 	  : filename(to, filename), offset(offset), length(length), fullFileLength(fullFileLength) {
 		if (ciphKeysMeta.present()) {
-			cipherKeysMetaRef = BlobGranuleCipherKeysMetaRef(to,
-			                                                 ciphKeysMeta.get().textDomainId,
-			                                                 ciphKeysMeta.get().textBaseCipherId,
-			                                                 ciphKeysMeta.get().textSalt,
-			                                                 ciphKeysMeta.get().headerDomainId,
-			                                                 ciphKeysMeta.get().headerBaseCipherId,
-			                                                 ciphKeysMeta.get().headerSalt,
-			                                                 ciphKeysMeta.get().ivStr);
+			cipherKeysMetaRef = BlobGranuleCipherKeysMetaRef(to, ciphKeysMeta.get());
 		}
 	}
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, filename, offset, length, fullFileLength, cipherKeysMetaRef);
+		serializer(ar, filename, offset, length, fullFileLength, cipherKeysCtx);
 	}
 
 	std::string toString() const {
 		std::stringstream ss;
 		ss << filename.toString() << ":" << offset << ":" << length << ":" << fullFileLength;
-		if (cipherKeysMetaRef.present()) {
-			ss << ":CipherKeysMeta:TextCipher:" << cipherKeysMetaRef.get().textDomainId << ":"
-			   << cipherKeysMetaRef.get().textBaseCipherId << ":" << cipherKeysMetaRef.get().textSalt
-			   << ":HeaderCipher:" << cipherKeysMetaRef.get().headerDomainId << ":"
-			   << cipherKeysMetaRef.get().headerBaseCipherId << ":" << cipherKeysMetaRef.get().headerSalt;
+		if (cipherKeysCtx.present()) {
+			ss << ":CipherKeysCtx:TextCipher:" << cipherKeysCtx.get().textCipherKey.encryptDomainId << ":"
+			   << cipherKeysCtx.get().textCipherKey.baseCipherId << ":" << cipherKeysCtx.get().textCipherKey.salt
+			   << ":HeaderCipher:" << cipherKeysCtx.get().headerCipherKey.encryptDomainId << ":"
+			   << cipherKeysCtx.get().headerCipherKey.baseCipherId << ":" << cipherKeysCtx.get().headerCipherKey.salt;
 		}
 		return std::move(ss).str();
 	}
@@ -224,19 +227,10 @@ struct BlobGranuleChunkRef {
 	VectorRef<BlobFilePointerRef> deltaFiles;
 	GranuleDeltas newDeltas;
 	Optional<KeyRef> tenantPrefix;
-	Optional<BlobGranuleCipherKeysCtx> cipherKeysCtx;
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar,
-		           keyRange,
-		           includedVersion,
-		           snapshotVersion,
-		           snapshotFile,
-		           deltaFiles,
-		           newDeltas,
-		           tenantPrefix,
-		           cipherKeysCtx);
+		serializer(ar, keyRange, includedVersion, snapshotVersion, snapshotFile, deltaFiles, newDeltas, tenantPrefix);
 	}
 };
 

--- a/fdbclient/include/fdbclient/BlobGranuleFiles.h
+++ b/fdbclient/include/fdbclient/BlobGranuleFiles.h
@@ -26,12 +26,14 @@
 #include "fdbclient/BlobGranuleCommon.h"
 #include "flow/CompressionUtils.h"
 
-Value serializeChunkedSnapshot(Standalone<GranuleSnapshot> snapshot,
+Value serializeChunkedSnapshot(const Standalone<StringRef>& fileNameRef,
+                               Standalone<GranuleSnapshot> snapshot,
                                int chunkSize,
                                Optional<CompressionFilter> compressFilter,
                                Optional<BlobGranuleCipherKeysCtx> cipherKeysCtx = {});
 
-Value serializeChunkedDeltaFile(Standalone<GranuleDeltas> deltas,
+Value serializeChunkedDeltaFile(const Standalone<StringRef>& fileNameRef,
+                                Standalone<GranuleDeltas> deltas,
                                 const KeyRangeRef& fileRange,
                                 int chunkSize,
                                 Optional<CompressionFilter> compressFilter,

--- a/fdbserver/BlobWorker.actor.cpp
+++ b/fdbserver/BlobWorker.actor.cpp
@@ -352,29 +352,27 @@ ACTOR Future<BlobGranuleCipherKey> lookupCipherKey(Reference<BlobWorkerData> bwD
 	return BlobGranuleCipherKey::fromBlobCipherKey(cipherKeyMapItr->second, *arena);
 }
 
-ACTOR Future<BlobGranuleCipherKeysCtx> getGranuleCipherKeys(Reference<BlobWorkerData> bwData,
-                                                            BlobGranuleCipherKeysMetaRef cipherKeysMetaRef,
-                                                            Arena* arena) {
+ACTOR Future<BlobGranuleCipherKeysCtx> getGranuleCipherKeysImpl(Reference<BlobWorkerData> bwData,
+                                                                BlobCipherDetails textCipherDetails,
+                                                                BlobCipherDetails headerCipherDetails,
+                                                                StringRef ivRef,
+                                                                Arena* arena) {
 	state BlobGranuleCipherKeysCtx cipherKeysCtx;
 
 	// Fetch 'textCipher' key
-	state BlobCipherDetails textCipherDetails(
-	    cipherKeysMetaRef.textDomainId, cipherKeysMetaRef.textBaseCipherId, cipherKeysMetaRef.textSalt);
 	BlobGranuleCipherKey textCipherKey = wait(lookupCipherKey(bwData, textCipherDetails, arena));
 	cipherKeysCtx.textCipherKey = textCipherKey;
 
 	// Fetch 'headerCipher' key
-	state BlobCipherDetails headerCipherDetails(
-	    cipherKeysMetaRef.headerDomainId, cipherKeysMetaRef.headerBaseCipherId, cipherKeysMetaRef.headerSalt);
 	BlobGranuleCipherKey headerCipherKey = wait(lookupCipherKey(bwData, headerCipherDetails, arena));
 	cipherKeysCtx.headerCipherKey = headerCipherKey;
 
 	// Populate 'Intialization Vector'
-	ASSERT_EQ(cipherKeysMetaRef.ivRef.size(), AES_256_IV_LENGTH);
-	cipherKeysCtx.ivRef = StringRef(*arena, cipherKeysMetaRef.ivRef);
+	ASSERT_EQ(ivRef.size(), AES_256_IV_LENGTH);
+	cipherKeysCtx.ivRef = StringRef(*arena, ivRef);
 
 	if (BG_ENCRYPT_COMPRESS_DEBUG) {
-		TraceEvent("GetGranuleCipherKey")
+		TraceEvent(SevDebug, "GetGranuleCipherKey")
 		    .detail("TextDomainId", cipherKeysCtx.textCipherKey.encryptDomainId)
 		    .detail("TextBaseCipherId", cipherKeysCtx.textCipherKey.baseCipherId)
 		    .detail("TextSalt", cipherKeysCtx.textCipherKey.salt)
@@ -385,6 +383,32 @@ ACTOR Future<BlobGranuleCipherKeysCtx> getGranuleCipherKeys(Reference<BlobWorker
 	}
 
 	return cipherKeysCtx;
+}
+
+Future<BlobGranuleCipherKeysCtx> getGranuleCipherKeysFromKeysMeta(Reference<BlobWorkerData> bwData,
+                                                                  BlobGranuleCipherKeysMeta cipherKeysMeta,
+                                                                  Arena* arena) {
+	BlobCipherDetails textCipherDetails(
+	    cipherKeysMeta.textDomainId, cipherKeysMeta.textBaseCipherId, cipherKeysMeta.textSalt);
+
+	BlobCipherDetails headerCipherDetails(
+	    cipherKeysMeta.headerDomainId, cipherKeysMeta.headerBaseCipherId, cipherKeysMeta.headerSalt);
+
+	StringRef ivRef = StringRef(*arena, cipherKeysMeta.ivStr);
+
+	return getGranuleCipherKeysImpl(bwData, textCipherDetails, headerCipherDetails, ivRef, arena);
+}
+
+Future<BlobGranuleCipherKeysCtx> getGranuleCipherKeysFromKeysMetaRef(Reference<BlobWorkerData> bwData,
+                                                                     BlobGranuleCipherKeysMetaRef cipherKeysMetaRef,
+                                                                     Arena* arena) {
+	BlobCipherDetails textCipherDetails(
+	    cipherKeysMetaRef.textDomainId, cipherKeysMetaRef.textBaseCipherId, cipherKeysMetaRef.textSalt);
+
+	BlobCipherDetails headerCipherDetails(
+	    cipherKeysMetaRef.headerDomainId, cipherKeysMetaRef.headerBaseCipherId, cipherKeysMetaRef.headerSalt);
+
+	return getGranuleCipherKeysImpl(bwData, textCipherDetails, headerCipherDetails, cipherKeysMetaRef.ivRef, arena);
 }
 
 ACTOR Future<Void> readAndCheckGranuleLock(Reference<ReadYourWritesTransaction> tr,
@@ -605,17 +629,20 @@ ACTOR Future<BlobFileIndex> writeDeltaFile(Reference<BlobWorkerData> bwData,
 	state Optional<BlobGranuleCipherKeysCtx> cipherKeysCtx;
 	state Optional<BlobGranuleCipherKeysMeta> cipherKeysMeta;
 	state Arena arena;
-	// TODO support encryption, figure out proper state stuff
-	/*if (isBlobFileEncryptionSupported()) {
-	    BlobGranuleCipherKeysCtx ciphKeysCtx = wait(getLatestGranuleCipherKeys(bwData, keyRange, &arena));
-	    cipherKeysCtx = ciphKeysCtx;
-	    cipherKeysMeta = BlobGranuleCipherKeysCtx::toCipherKeysMeta(cipherKeysCtx.get());
-	}*/
 
-	Optional<CompressionFilter> compressFilter = getBlobFileCompressFilter();
+	if (isBlobFileEncryptionSupported()) {
+		BlobGranuleCipherKeysCtx ciphKeysCtx = wait(getLatestGranuleCipherKeys(bwData, keyRange, &arena));
+		cipherKeysCtx = std::move(ciphKeysCtx);
+		cipherKeysMeta = BlobGranuleCipherKeysCtx::toCipherKeysMeta(cipherKeysCtx.get());
+	}
 
-	state Value serialized = serializeChunkedDeltaFile(
-	    deltasToWrite, keyRange, SERVER_KNOBS->BG_DELTA_FILE_TARGET_CHUNK_BYTES, compressFilter, cipherKeysCtx);
+	state Optional<CompressionFilter> compressFilter = getBlobFileCompressFilter();
+	state Value serialized = serializeChunkedDeltaFile(StringRef(fileName),
+	                                                   deltasToWrite,
+	                                                   keyRange,
+	                                                   SERVER_KNOBS->BG_DELTA_FILE_TARGET_CHUNK_BYTES,
+	                                                   compressFilter,
+	                                                   cipherKeysCtx);
 	state size_t serializedSize = serialized.size();
 
 	// Free up deltasToWrite here to reduce memory
@@ -680,6 +707,14 @@ ACTOR Future<BlobFileIndex> writeDeltaFile(Reference<BlobWorkerData> bwData,
 				if (BUGGIFY_WITH_PROB(0.01)) {
 					wait(delay(deterministicRandom()->random01()));
 				}
+
+				if (BW_DEBUG) {
+					TraceEvent(SevDebug, "DeltaFileWritten")
+					    .detail("FileName", fname)
+					    .detail("Encrypted", cipherKeysCtx.present())
+					    .detail("Compressed", compressFilter.present());
+				}
+
 				// FIXME: change when we implement multiplexing
 				return BlobFileIndex(currentDeltaVersion, fname, 0, serializedSize, serializedSize, cipherKeysMeta);
 			} catch (Error& e) {
@@ -759,15 +794,19 @@ ACTOR Future<BlobFileIndex> writeSnapshot(Reference<BlobWorkerData> bwData,
 	state Optional<BlobGranuleCipherKeysCtx> cipherKeysCtx;
 	state Optional<BlobGranuleCipherKeysMeta> cipherKeysMeta;
 	state Arena arena;
+
 	if (isBlobFileEncryptionSupported()) {
 		BlobGranuleCipherKeysCtx ciphKeysCtx = wait(getLatestGranuleCipherKeys(bwData, keyRange, &arena));
-		cipherKeysCtx = ciphKeysCtx;
+		cipherKeysCtx = std::move(ciphKeysCtx);
 		cipherKeysMeta = BlobGranuleCipherKeysCtx::toCipherKeysMeta(cipherKeysCtx.get());
 	}
 
-	Optional<CompressionFilter> compressFilter = getBlobFileCompressFilter();
-	state Value serialized = serializeChunkedSnapshot(
-	    snapshot, SERVER_KNOBS->BG_SNAPSHOT_FILE_TARGET_CHUNK_BYTES, compressFilter, cipherKeysCtx);
+	state Optional<CompressionFilter> compressFilter = getBlobFileCompressFilter();
+	state Value serialized = serializeChunkedSnapshot(StringRef(fileName),
+	                                                  snapshot,
+	                                                  SERVER_KNOBS->BG_SNAPSHOT_FILE_TARGET_CHUNK_BYTES,
+	                                                  compressFilter,
+	                                                  cipherKeysCtx);
 	state size_t serializedSize = serialized.size();
 
 	// free snapshot to reduce memory
@@ -846,6 +885,13 @@ ACTOR Future<BlobFileIndex> writeSnapshot(Reference<BlobWorkerData> bwData,
 
 	if (BUGGIFY_WITH_PROB(0.1)) {
 		wait(delay(deterministicRandom()->random01()));
+	}
+
+	if (BW_DEBUG) {
+		TraceEvent(SevDebug, "SnapshotFileWritten")
+		    .detail("FileName", fileName)
+		    .detail("Encrypted", cipherKeysCtx.present())
+		    .detail("Compressed", compressFilter.present());
 	}
 
 	// FIXME: change when we implement multiplexing
@@ -975,33 +1021,51 @@ ACTOR Future<BlobFileIndex> compactFromBlob(Reference<BlobWorkerData> bwData,
 		}
 		ASSERT(snapshotVersion < version);
 
+		// TODO: optimization - batch 'encryption-key' lookup given the GranuleFile set is known
+		// FIXME: get cipher keys for delta as well!
+		state Optional<BlobGranuleCipherKeysCtx> snapCipherKeysCtx;
+		if (snapshotF.cipherKeysMeta.present()) {
+			ASSERT(isBlobFileEncryptionSupported());
+
+			BlobGranuleCipherKeysCtx keysCtx =
+			    wait(getGranuleCipherKeysFromKeysMeta(bwData, snapshotF.cipherKeysMeta.get(), &filenameArena));
+			snapCipherKeysCtx = std::move(keysCtx);
+		}
+
 		chunk.snapshotFile = BlobFilePointerRef(filenameArena,
 		                                        snapshotF.filename,
 		                                        snapshotF.offset,
 		                                        snapshotF.length,
 		                                        snapshotF.fullFileLength,
-		                                        snapshotF.cipherKeysMeta);
-
-		// TODO: optimization - batch 'encryption-key' lookup given the GranuleFile set is known
-		// FIXME: get cipher keys for delta as well!
-		if (chunk.snapshotFile.get().cipherKeysMetaRef.present()) {
-			ASSERT(isBlobFileEncryptionSupported());
-			BlobGranuleCipherKeysCtx cipherKeysCtx =
-			    wait(getGranuleCipherKeys(bwData, chunk.snapshotFile.get().cipherKeysMetaRef.get(), &filenameArena));
-			chunk.cipherKeysCtx = cipherKeysCtx;
-		}
+		                                        snapCipherKeysCtx);
 
 		compactBytesRead += snapshotF.length;
-		int deltaIdx = files.deltaFiles.size() - 1;
+		state int deltaIdx = files.deltaFiles.size() - 1;
 		while (deltaIdx >= 0 && files.deltaFiles[deltaIdx].version > snapshotVersion) {
 			deltaIdx--;
 		}
 		deltaIdx++;
-		Version lastDeltaVersion = snapshotVersion;
+		state Version lastDeltaVersion = snapshotVersion;
+		state BlobFileIndex deltaF;
 		while (deltaIdx < files.deltaFiles.size() && lastDeltaVersion < version) {
-			BlobFileIndex deltaF = files.deltaFiles[deltaIdx];
-			chunk.deltaFiles.emplace_back_deep(
-			    filenameArena, deltaF.filename, deltaF.offset, deltaF.length, deltaF.fullFileLength);
+			state Optional<BlobGranuleCipherKeysCtx> deltaCipherKeysCtx;
+
+			deltaF = files.deltaFiles[deltaIdx];
+
+			if (deltaF.cipherKeysMeta.present()) {
+				ASSERT(isBlobFileEncryptionSupported());
+
+				BlobGranuleCipherKeysCtx keysCtx =
+				    wait(getGranuleCipherKeysFromKeysMeta(bwData, deltaF.cipherKeysMeta.get(), &filenameArena));
+				deltaCipherKeysCtx = std::move(keysCtx);
+			}
+
+			chunk.deltaFiles.emplace_back_deep(filenameArena,
+			                                   deltaF.filename,
+			                                   deltaF.offset,
+			                                   deltaF.length,
+			                                   deltaF.fullFileLength,
+			                                   deltaCipherKeysCtx);
 			compactBytesRead += deltaF.length;
 			lastDeltaVersion = files.deltaFiles[deltaIdx].version;
 			deltaIdx++;
@@ -1118,9 +1182,13 @@ ACTOR Future<BlobFileIndex> checkSplitAndReSnapshot(Reference<BlobWorkerData> bw
 				// wait for manager stream to become ready, and send a message
 				loop {
 					choose {
-						when(wait(bwData->currentManagerStatusStream.get().onReady())) { break; }
+						when(wait(bwData->currentManagerStatusStream.get().onReady())) {
+							break;
+						}
 						when(wait(bwData->currentManagerStatusStream.onChange())) {}
-						when(wait(metadata->resumeSnapshot.getFuture())) { break; }
+						when(wait(metadata->resumeSnapshot.getFuture())) {
+							break;
+						}
 					}
 				}
 				if (metadata->resumeSnapshot.isSet()) {
@@ -1158,7 +1226,9 @@ ACTOR Future<BlobFileIndex> checkSplitAndReSnapshot(Reference<BlobWorkerData> bw
 		// manager change/no response
 		choose {
 			when(wait(bwData->currentManagerStatusStream.onChange())) {}
-			when(wait(metadata->resumeSnapshot.getFuture())) { break; }
+			when(wait(metadata->resumeSnapshot.getFuture())) {
+				break;
+			}
 			when(wait(delay(1.0))) {}
 		}
 
@@ -1232,8 +1302,12 @@ ACTOR Future<Void> granuleCheckMergeCandidate(Reference<BlobWorkerData> bwData,
 				// wait for manager stream to become ready, and send a message
 				loop {
 					choose {
-						when(wait(delay(std::max(0.0, sendTimeGiveUp - now())))) { break; }
-						when(wait(bwData->currentManagerStatusStream.get().onReady())) { break; }
+						when(wait(delay(std::max(0.0, sendTimeGiveUp - now())))) {
+							break;
+						}
+						when(wait(bwData->currentManagerStatusStream.get().onReady())) {
+							break;
+						}
 						when(wait(bwData->currentManagerStatusStream.onChange())) {}
 					}
 				}
@@ -1515,7 +1589,9 @@ ACTOR Future<Void> waitOnCFVersion(Reference<GranuleMetadata> metadata, Version 
 			                                 ? metadata->activeCFData.get()->whenAtLeast(waitVersion)
 			                                 : Never();
 			choose {
-				when(wait(atLeast)) { break; }
+				when(wait(atLeast)) {
+					break;
+				}
 				when(wait(metadata->activeCFData.onChange())) {}
 			}
 		} catch (Error& e) {
@@ -3061,7 +3137,9 @@ ACTOR Future<Void> doBlobGranuleFileRequest(Reference<BlobWorkerData> bwData, Bl
 
 			choose {
 				when(wait(metadata->readable.getFuture())) {}
-				when(wait(metadata->cancelled.getFuture())) { throw wrong_shard_server(); }
+				when(wait(metadata->cancelled.getFuture())) {
+					throw wrong_shard_server();
+				}
 			}
 
 			// in case both readable and cancelled are ready, check cancelled
@@ -3077,7 +3155,9 @@ ACTOR Future<Void> doBlobGranuleFileRequest(Reference<BlobWorkerData> bwData, Bl
 				if (metadata->historyLoaded.canBeSet()) {
 					choose {
 						when(wait(metadata->historyLoaded.getFuture())) {}
-						when(wait(metadata->cancelled.getFuture())) { throw wrong_shard_server(); }
+						when(wait(metadata->cancelled.getFuture())) {
+							throw wrong_shard_server();
+						}
 					}
 				}
 
@@ -3089,7 +3169,9 @@ ACTOR Future<Void> doBlobGranuleFileRequest(Reference<BlobWorkerData> bwData, Bl
 						when(GranuleFiles f = wait(finalChunks[chunkIdx].second)) {
 							rangeGranulePair.push_back(std::pair(finalChunks[chunkIdx].first, f));
 						}
-						when(wait(metadata->cancelled.getFuture())) { throw wrong_shard_server(); }
+						when(wait(metadata->cancelled.getFuture())) {
+							throw wrong_shard_server();
+						}
 					}
 
 					if (rangeGranulePair.back().second.snapshotFiles.empty()) {
@@ -3126,9 +3208,13 @@ ACTOR Future<Void> doBlobGranuleFileRequest(Reference<BlobWorkerData> bwData, Bl
 					// version on rollback
 					try {
 						choose {
-							when(wait(waitForVersionFuture)) { break; }
+							when(wait(waitForVersionFuture)) {
+								break;
+							}
 							when(wait(metadata->activeCFData.onChange())) {}
-							when(wait(metadata->cancelled.getFuture())) { throw wrong_shard_server(); }
+							when(wait(metadata->cancelled.getFuture())) {
+								throw wrong_shard_server();
+							}
 						}
 					} catch (Error& e) {
 						// We can get change feed cancelled from whenAtLeast. This means the change feed may
@@ -3193,12 +3279,44 @@ ACTOR Future<Void> doBlobGranuleFileRequest(Reference<BlobWorkerData> bwData, Bl
 					didCollapse = true;
 				}
 
-				// TODO: optimization - batch 'encryption-key' lookup given the GranuleFile set is known
-				state Future<BlobGranuleCipherKeysCtx> cipherKeysCtx;
-				if (chunk.snapshotFile.present() && chunk.snapshotFile.get().cipherKeysMetaRef.present()) {
-					ASSERT(isBlobFileEncryptionSupported());
-					cipherKeysCtx =
-					    getGranuleCipherKeys(bwData, chunk.snapshotFile.get().cipherKeysMetaRef.get(), &rep.arena);
+				// Invoke calls to populate 'EncryptionKeysCtx' for snapshot and/or deltaFiles asynchronously
+				state Optional<Future<BlobGranuleCipherKeysCtx>> snapCipherKeysCtx;
+				if (chunk.snapshotFile.present()) {
+					const bool encrypted = chunk.snapshotFile.get().cipherKeysMetaRef.present();
+
+					if (BW_DEBUG) {
+						TraceEvent("DoBlobGranuleFileRequestDelta_KeysCtxPrepare")
+						    .detail("FileName", chunk.snapshotFile.get().filename.toString())
+						    .detail("Encrypted", encrypted);
+					}
+
+					if (encrypted) {
+						ASSERT(isBlobFileEncryptionSupported());
+						ASSERT(!chunk.snapshotFile.get().cipherKeysCtx.present());
+
+						snapCipherKeysCtx = getGranuleCipherKeysFromKeysMetaRef(
+						    bwData, chunk.snapshotFile.get().cipherKeysMetaRef.get(), &rep.arena);
+					}
+				}
+				state std::unordered_map<int, Future<BlobGranuleCipherKeysCtx>> deltaCipherKeysCtxs;
+				for (int deltaIdx = 0; deltaIdx < chunk.deltaFiles.size(); deltaIdx++) {
+					const bool encrypted = chunk.deltaFiles[deltaIdx].cipherKeysMetaRef.present();
+
+					if (BW_DEBUG) {
+						TraceEvent("DoBlobGranuleFileRequestDelta_KeysCtxPrepare")
+						    .detail("FileName", chunk.deltaFiles[deltaIdx].filename.toString())
+						    .detail("Encrypted", encrypted);
+					}
+
+					if (encrypted) {
+						ASSERT(isBlobFileEncryptionSupported());
+						ASSERT(!chunk.deltaFiles[deltaIdx].cipherKeysCtx.present());
+
+						deltaCipherKeysCtxs.emplace(
+						    deltaIdx,
+						    getGranuleCipherKeysFromKeysMetaRef(
+						        bwData, chunk.deltaFiles[deltaIdx].cipherKeysMetaRef.get(), &rep.arena));
+					}
 				}
 
 				// FIXME: get cipher keys for delta files too!
@@ -3245,9 +3363,37 @@ ACTOR Future<Void> doBlobGranuleFileRequest(Reference<BlobWorkerData> bwData, Bl
 					}
 				}
 
-				if (chunk.snapshotFile.present() && chunk.snapshotFile.get().cipherKeysMetaRef.present()) {
-					BlobGranuleCipherKeysCtx ctx = wait(cipherKeysCtx);
-					chunk.cipherKeysCtx = std::move(ctx);
+				// Update EncryptionKeysCtx information for the chunk->snapshotFile
+				if (chunk.snapshotFile.present() && snapCipherKeysCtx.present()) {
+					ASSERT(chunk.snapshotFile.get().cipherKeysMetaRef.present());
+
+					BlobGranuleCipherKeysCtx keysCtx = wait(snapCipherKeysCtx.get());
+					chunk.snapshotFile.get().cipherKeysCtx = std::move(keysCtx);
+					// reclaim memory from non-serializable field
+					chunk.snapshotFile.get().cipherKeysMetaRef.reset();
+
+					if (BW_DEBUG) {
+						TraceEvent("DoBlobGranuleFileRequestSnap_KeysCtxDone")
+						    .detail("FileName", chunk.snapshotFile.get().filename.toString());
+					}
+				}
+
+				// Update EncryptionKeysCtx information for the chunk->deltaFiles
+				if (!deltaCipherKeysCtxs.empty()) {
+					ASSERT(!chunk.deltaFiles.empty());
+
+					state std::unordered_map<int, Future<BlobGranuleCipherKeysCtx>>::const_iterator itr;
+					for (itr = deltaCipherKeysCtxs.begin(); itr != deltaCipherKeysCtxs.end(); itr++) {
+						BlobGranuleCipherKeysCtx keysCtx = wait(itr->second);
+						chunk.deltaFiles[itr->first].cipherKeysCtx = std::move(keysCtx);
+						// reclaim memory from non-serializable field
+						chunk.deltaFiles[itr->first].cipherKeysMetaRef.reset();
+
+						if (BW_DEBUG) {
+							TraceEvent("DoBlobGranuleFileRequestDelta_KeysCtxDone")
+							    .detail("FileName", chunk.deltaFiles[itr->first].filename.toString());
+						}
+					}
 				}
 
 				rep.chunks.push_back(rep.arena, chunk);

--- a/fdbserver/include/fdbserver/BlobGranuleServerCommon.actor.h
+++ b/fdbserver/include/fdbserver/BlobGranuleServerCommon.actor.h
@@ -31,9 +31,12 @@
 #include "fdbclient/CommitTransaction.h"
 #include "fdbclient/FDBTypes.h"
 #include "fdbclient/Tenant.h"
+
 #include "fdbserver/ServerDBInfo.h"
-#include "flow/actorcompiler.h" // has to be last include
+
 #include "flow/flow.h"
+
+#include "flow/actorcompiler.h" // has to be last include
 
 struct GranuleHistory {
 	KeyRange range;


### PR DESCRIPTION
Description

Major changes proposed by the patch are:
1. Refactor code to allow caching of 'encryption key ctx' as part of
BlobFilePointerRef. The refactoring allows snapshot and/or delta files
to store their own file encryption context.
2. Enable BlobGranule delta file encryption/decryption semantics.

Testing

BlobGranuleCorrrectness & BlobGranuleCorrectnessClean
BlobGranuleFileUnitTestToml

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
