### PR TITLE
fix token cache unit test

### DIFF
--- a/fdbrpc/TokenCache.actor.cpp
+++ b/fdbrpc/TokenCache.actor.cpp
@@ -13,6 +13,8 @@
 #include <list>
 #include <deque>
 
+#include "flow/actorcompiler.h" // has to be last include
+
 template <class Key, class Value>
 class LRUCache {
 public:
@@ -156,6 +158,7 @@ bool TokenCache::validate(TenantNameRef name, StringRef token) {
 	TraceEvent(SevWarn, "InvalidToken")                                                                                \
 	    .detail("From", peer)                                                                                          \
 	    .detail("Reason", reason)                                                                                      \
+	    .detail("CurrentTime", currentTime)                                                                            \
 	    .detail("Token", token.toStringRef(arena).toStringView())
 
 bool TokenCacheImpl::validateAndAdd(double currentTime, StringRef token, NetworkAddress const& peer) {
@@ -324,23 +327,25 @@ TEST_CASE("/fdbrpc/authz/TokenCache/BadTokens") {
 
 TEST_CASE("/fdbrpc/authz/TokenCache/GoodTokens") {
 	// Don't repeat because token expiry is at seconds granularity and sleeps are costly in unit tests
-	auto arena = Arena();
-	auto privateKey = mkcert::makeEcP256();
-	auto const pubKeyName = "somePublicKey"_sr;
+	state Arena arena;
+	state PrivateKey privateKey = mkcert::makeEcP256();
+	state StringRef pubKeyName = "somePublicKey"_sr;
+	state ScopeExit<std::function<void()>> publicKeyClearGuard(
+	    [pubKeyName = pubKeyName]() { FlowTransport::transport().removePublicKey(pubKeyName); });
+	state authz::jwt::TokenRef tokenSpec =
+	    authz::jwt::makeRandomTokenSpec(arena, *deterministicRandom(), authz::Algorithm::ES256);
+	state StringRef signedToken;
 	FlowTransport::transport().addPublicKey(pubKeyName, privateKey.toPublic());
-	auto publicKeyClearGuard = ScopeExit([pubKeyName]() { FlowTransport::transport().removePublicKey(pubKeyName); });
-	auto& rng = *deterministicRandom();
-	auto tokenSpec = authz::jwt::makeRandomTokenSpec(arena, rng, authz::Algorithm::ES256);
 	tokenSpec.expiresAtUnixTime = static_cast<uint64_t>(g_network->timer() + 2.0);
 	tokenSpec.keyId = pubKeyName;
-	auto signedToken = authz::jwt::signToken(arena, tokenSpec, privateKey);
+	signedToken = authz::jwt::signToken(arena, tokenSpec, privateKey);
 	if (!TokenCache::instance().validate(tokenSpec.tenants.get()[0], signedToken)) {
 		fmt::print("Unexpected failed token validation, token spec: {}, now: {}\n",
 		           tokenSpec.toStringRef(arena).toStringView(),
 		           g_network->timer());
 		ASSERT(false);
 	}
-	threadSleep(3.5);
+	wait(delay(3.5));
 	if (TokenCache::instance().validate(tokenSpec.tenants.get()[0], signedToken)) {
 		fmt::print(
 		    "Unexpected successful token validation after supposedly expiring in cache, token spec: {}, now: {}\n",

--- a/fdbrpc/TokenSign.cpp
+++ b/fdbrpc/TokenSign.cpp
@@ -460,7 +460,7 @@ TokenRef makeRandomTokenSpec(Arena& arena, IRandom& rng, Algorithm alg) {
 	for (auto i = 0; i < numAudience; i++)
 		aud[i] = genRandomAlphanumStringRef(arena, rng, MaxTenantNameLenPlus1);
 	ret.audience = VectorRef<StringRef>(aud, numAudience);
-	ret.issuedAtUnixTime = timer_int() / 1'000'000'000ul;
+	ret.issuedAtUnixTime = uint64_t(std::floor(g_network->timer()));
 	ret.notBeforeUnixTime = ret.issuedAtUnixTime.get();
 	ret.expiresAtUnixTime = ret.issuedAtUnixTime.get() + rng.randomInt(360, 1080 + 1);
 	auto numTenants = rng.randomInt(1, 3);


### PR DESCRIPTION
This unit test wasn't written for simulation, so it was consistently failing in joshua. This changes the test so it doesn't use non-deterministic functionality

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
