### PR TITLE
Make Tuple::pack return a Standalone<StringRef>

### DIFF
--- a/bindings/flow/Tuple.h
+++ b/bindings/flow/Tuple.h
@@ -63,7 +63,9 @@ struct Tuple {
 	Tuple& appendNull();
 	Tuple& appendVersionstamp(Versionstamp const&);
 
-	StringRef pack() const { return StringRef(data.begin(), data.size()); }
+	Standalone<StringRef> pack() const {
+		return Standalone<StringRef>(StringRef(data.begin(), data.size()), data.arena());
+	}
 
 	template <typename T>
 	Tuple& operator<<(T const& t) {

--- a/fdbclient/include/fdbclient/Tuple.h
+++ b/fdbclient/include/fdbclient/Tuple.h
@@ -56,7 +56,9 @@ struct Tuple {
 	Tuple& appendNull();
 	Tuple& append(Versionstamp const&);
 
-	StringRef pack() const { return StringRef(data.begin(), data.size()); }
+	Standalone<StringRef> pack() const {
+		return Standalone<StringRef>(StringRef(data.begin(), data.size()), data.arena());
+	}
 
 	template <typename T>
 	Tuple& operator<<(T const& t) {


### PR DESCRIPTION
This makes it less error-prone and more like other similar functions
like BinaryWriter::toValue

Closes #7748

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
