### PR TITLE
Fix: tenant creation in metacluster failure

### DIFF
--- a/fdbclient/include/fdbclient/MetaclusterManagement.actor.h
+++ b/fdbclient/include/fdbclient/MetaclusterManagement.actor.h
@@ -1075,13 +1075,12 @@ struct CreateTenantImpl {
 		state Optional<TenantMapEntry> existingEntry = wait(tryGetTenantTransaction(tr, self->tenantName));
 		if (existingEntry.present()) {
 			if (!existingEntry.get().matchesConfiguration(self->tenantEntry) ||
-			    (self->replaceExistingTenantId.present() &&
-			     existingEntry.get().id != self->replaceExistingTenantId.get()) ||
 			    existingEntry.get().tenantState != TenantState::REGISTERING) {
-				// The tenant already exists and is either completely created, has a different
-				// configuration, or is a different tenant than the one we intend to replace
+				// The tenant already exists and is either completely created or has a different
+				// configuration
 				throw tenant_already_exists();
-			} else if (!self->replaceExistingTenantId.present()) {
+			} else if (!self->replaceExistingTenantId.present() ||
+			           self->replaceExistingTenantId.get() != existingEntry.get().id) {
 				// The tenant creation has already started, so resume where we left off
 				self->tenantEntry = existingEntry.get();
 				ASSERT(existingEntry.get().assignedCluster.present());

--- a/fdbclient/include/fdbclient/MetaclusterManagement.actor.h
+++ b/fdbclient/include/fdbclient/MetaclusterManagement.actor.h
@@ -1104,6 +1104,8 @@ struct CreateTenantImpl {
 				wait(managementClusterRemoveTenantFromGroup(
 				    tr, self->tenantName, existingEntry.get(), &previousAssignedClusterMetadata));
 			}
+		} else if (self->replaceExistingTenantId.present()) {
+			throw tenant_removed();
 		}
 
 		return false;

--- a/fdbserver/workloads/TenantManagementConcurrencyWorkload.actor.cpp
+++ b/fdbserver/workloads/TenantManagementConcurrencyWorkload.actor.cpp
@@ -251,14 +251,13 @@ struct TenantManagementConcurrencyWorkload : TestWorkload {
 				Optional<Void> result = wait(timeout(configureImpl(self, tenant, configParams), 30));
 
 				if (result.present()) {
-					fmt::print("Delete tenant success: {}\n", printable(tenant));
 					break;
 				}
 			}
 
 			return Void();
 		} catch (Error& e) {
-			if (e.code() != error_code_tenant_not_found) {
+			if (e.code() != error_code_tenant_not_found && e.code() != error_code_invalid_tenant_state) {
 				TraceEvent(SevError, "ConfigureTenantFailure").error(e).detail("TenantName", tenant);
 			}
 			return Void();
@@ -271,7 +270,7 @@ struct TenantManagementConcurrencyWorkload : TestWorkload {
 
 		// Run a random sequence of tenant management operations for the duration of the test
 		while (now() < start + self->testDuration) {
-			state int operation = deterministicRandom()->randomInt(0, 2);
+			state int operation = deterministicRandom()->randomInt(0, 3);
 			if (operation == 0) {
 				wait(createTenant(self));
 			} else if (operation == 1) {


### PR DESCRIPTION
In a metacluster, if a tenant creation on the data cluster permanently fails (because the tombstones have been cleaned up past its ID), it would retry the creation from the beginning. If that retry failed with a commit unknown result but actually committed, then the whole creation would fail out with a tenant already exists error and leave the management cluster in an inconsistent state. This happened because on retry, the operation would only succeed if the existing tenant matched the ID of the permanently failed creation.

The fix is to allow the create operation to work with any ID (so long as the configuration matches), exactly like it does before the data cluster failure. If the ID does match the failed ID, only then do we invoke the special replacement logic.

This also updates the tenant management concurrency test to include the configuration operation.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
