### PR TITLE
Fix integer overflow in test from setting a range limit too large

### DIFF
--- a/fdbserver/include/fdbserver/workloads/MetaclusterConsistency.actor.h
+++ b/fdbserver/include/fdbserver/workloads/MetaclusterConsistency.actor.h
@@ -64,8 +64,9 @@ private:
 
 	ManagementClusterData managementMetadata;
 
-	static inline const int64_t metaclusterMaxTenants =
-	    CLIENT_KNOBS->MAX_DATA_CLUSTERS * CLIENT_KNOBS->MAX_TENANTS_PER_CLUSTER;
+	// Note: this check can only be run on metaclusters with a reasonable number of tenants, as should be
+	// the case with the current metacluster simulation workloads
+	static inline const int metaclusterMaxTenants = 10e6;
 
 	ACTOR static Future<Void> loadManagementClusterMetadata(MetaclusterConsistencyCheck* self) {
 		state Reference<typename DB::TransactionT> managementTr = self->managementDb->createTransaction();

--- a/fdbserver/include/fdbserver/workloads/TenantConsistency.actor.h
+++ b/fdbserver/include/fdbserver/workloads/TenantConsistency.actor.h
@@ -60,8 +60,9 @@ private:
 
 	TenantData metadata;
 
-	static inline const int64_t metaclusterMaxTenants =
-	    CLIENT_KNOBS->MAX_DATA_CLUSTERS * CLIENT_KNOBS->MAX_TENANTS_PER_CLUSTER;
+	// Note: this check can only be run on metaclusters with a reasonable number of tenants, as should be
+	// the case with the current metacluster simulation workloads
+	static inline const int metaclusterMaxTenants = 10e6;
 
 	ACTOR static Future<Void> loadTenantMetadata(TenantConsistencyCheck* self) {
 		state Reference<typename DB::TransactionT> tr = self->db->createTransaction();


### PR DESCRIPTION
The metacluster and tenant consistency checks were setting range limits with an `int64_t` that overflowed the int type that was expected. Update the limit to be much smaller.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
