### PR TITLE
Fix: Decommissioning a metacluster could fail if some global state fields were set

### DIFF
--- a/fdbserver/workloads/MetaclusterManagementWorkload.actor.cpp
+++ b/fdbserver/workloads/MetaclusterManagementWorkload.actor.cpp
@@ -567,6 +567,42 @@ struct MetaclusterManagementWorkload : TestWorkload {
 		return Void();
 	}
 
+	ACTOR static Future<Void> decommissionMetacluster(MetaclusterManagementWorkload* self) {
+		state Reference<ITransaction> tr = self->managementDb->createTransaction();
+
+		state bool deleteTenants = deterministicRandom()->coinflip();
+
+		if (deleteTenants) {
+			state std::vector<std::pair<TenantName, TenantMapEntry>> tenants =
+			    wait(MetaclusterAPI::listTenants(self->managementDb, ""_sr, "\xff\xff"_sr, 10e6));
+
+			state std::vector<Future<Void>> deleteTenantFutures;
+			for (auto [tenantName, tenantMapEntry] : tenants) {
+				deleteTenantFutures.push_back(MetaclusterAPI::deleteTenant(self->managementDb, tenantName));
+			}
+
+			wait(waitForAll(deleteTenantFutures));
+		}
+
+		state std::map<ClusterName, DataClusterMetadata> dataClusters = wait(
+		    MetaclusterAPI::listClusters(self->managementDb, ""_sr, "\xff\xff"_sr, CLIENT_KNOBS->MAX_DATA_CLUSTERS));
+
+		std::vector<Future<Void>> removeClusterFutures;
+		for (auto [clusterName, clusterMetadata] : dataClusters) {
+			removeClusterFutures.push_back(
+			    MetaclusterAPI::removeCluster(self->managementDb, clusterName, !deleteTenants));
+		}
+
+		wait(waitForAll(removeClusterFutures));
+		wait(MetaclusterAPI::decommissionMetacluster(self->managementDb));
+
+		Optional<MetaclusterRegistrationEntry> entry =
+		    wait(MetaclusterMetadata::metaclusterRegistration().get(self->managementDb));
+		ASSERT(!entry.present());
+
+		return Void();
+	}
+
 	Future<bool> check(Database const& cx) override {
 		if (clientId == 0) {
 			return _check(this);
@@ -596,6 +632,8 @@ struct MetaclusterManagementWorkload : TestWorkload {
 			dataClusterChecks.push_back(checkDataCluster(self, clusterName, dataClusterData));
 		}
 		wait(waitForAll(dataClusterChecks));
+
+		wait(decommissionMetacluster(self));
 
 		return true;
 	}

--- a/fdbserver/workloads/MetaclusterManagementWorkload.actor.cpp
+++ b/fdbserver/workloads/MetaclusterManagementWorkload.actor.cpp
@@ -259,7 +259,6 @@ struct MetaclusterManagementWorkload : TestWorkload {
 			for (auto localItr = self->dataDbs.find(clusterName1);
 			     localItr != self->dataDbs.find(clusterName2) && count < limit;
 			     ++localItr) {
-				fmt::print("Checking cluster {} {}\n", printable(localItr->first), localItr->second.registered);
 				if (localItr->second.registered) {
 					ASSERT(resultItr != clusterList.end());
 					ASSERT(resultItr->first == localItr->first);

--- a/tests/slow/MetaclusterManagement.toml
+++ b/tests/slow/MetaclusterManagement.toml
@@ -3,7 +3,7 @@ allowDefaultTenant = false
 allowDisablingTenants = false
 allowCreatingTenants = false
 extraDatabaseMode = 'Multiple'
-extraDatabaseCount = 10
+extraDatabaseCount = 5
 
 [[test]]
 testTitle = 'MetaclusterManagementTest'


### PR DESCRIPTION
Also update the metacluster management workload to decommission the metacluster at the end.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
