### PR TITLE
Report the unit tests being run in test harness's summarized output

### DIFF
--- a/contrib/TestHarness/Program.cs
+++ b/contrib/TestHarness/Program.cs
@@ -927,6 +927,10 @@ namespace SummarizeTest
                             {
                                 xout.Add(new XElement(ev.Type, new XAttribute("File", ev.Details.File), new XAttribute("Line", ev.Details.Line)));
                             }
+                            if (ev.Type == "RunningUnitTest") 
+                            {
+                                xout.Add(new XElement(ev.Type, new XAttribute("Name", ev.Details.Name), new XAttribute("File", ev.Details.File), new XAttribute("Line", ev.Details.Line)));
+                            }
                             if (ev.Type == "TestsExpectedToPass")
                                 testCount = int.Parse(ev.Details.Count);
                             if (ev.Type == "TestResults" && ev.Details.Passed == "1")

--- a/fdbserver/workloads/UnitTests.actor.cpp
+++ b/fdbserver/workloads/UnitTests.actor.cpp
@@ -142,6 +142,11 @@ struct UnitTestWorkload : TestWorkload {
 			state UnitTest* test = *t;
 			printf("Testing %s\n", test->name);
 
+			TraceEvent(SevInfo, "RunningUnitTest")
+			    .detail("Name", test->name)
+			    .detail("File", test->file)
+			    .detail("Line", test->line);
+
 			state Error result = success();
 			state double start_now = now();
 			state double start_timer = timer();


### PR DESCRIPTION
When unit tests are run in test harness, the summarized result does not include the unit test name(s) if the test crashes (e.g. because it hit an assert and `--crash` is used). As a result, it is necessary to rerun a failed unit test run to even determine what the failed test was and triage it.

This change causes unit tests to log a trace event for every unit test it attempts to run, and the test harness adds this data to the summarize output.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
