### PR TITLE
Flush gcov coverage upon SIGTERM

### DIFF
--- a/cmake/ConfigureCompiler.cmake
+++ b/cmake/ConfigureCompiler.cmake
@@ -190,6 +190,7 @@ else()
   endif()
 
   if(USE_GCOV)
+    add_compile_options(--coverage)
     add_link_options(--coverage)
   endif()
 

--- a/flow/Platform.actor.cpp
+++ b/flow/Platform.actor.cpp
@@ -3589,7 +3589,7 @@ void crashHandler(int sig) {
 	//  but the idea is that we're about to crash anyway...
 	std::string backtrace = platform::get_backtrace();
 
-	bool error = (sig != SIGUSR2);
+	bool error = (sig != SIGUSR2 && sig != SIGTERM);
 
 	StreamCipherKey::cleanup();
 	StreamCipher::cleanup();
@@ -3604,6 +3604,10 @@ void crashHandler(int sig) {
 		}
 	}
 	flushTraceFileVoid();
+
+#ifdef USE_GCOV
+	__gcov_flush();
+#endif
 
 	fprintf(stderr, "SIGNAL: %s (%d)\n", strsignal(sig), sig);
 	fprintf(stderr, "Trace: %s\n", backtrace.c_str());
@@ -3646,6 +3650,7 @@ void registerCrashHandler() {
 	sigaction(SIGSEGV, &action, nullptr);
 	sigaction(SIGBUS, &action, nullptr);
 	sigaction(SIGUSR2, &action, nullptr);
+	sigaction(SIGTERM, &action, nullptr);
 #else
 	// No crash handler for other platforms!
 #endif

--- a/flow/Platform.actor.cpp
+++ b/flow/Platform.actor.cpp
@@ -3609,8 +3609,10 @@ void crashHandler(int sig) {
 	__gcov_flush();
 #endif
 
-	fprintf(stderr, "SIGNAL: %s (%d)\n", strsignal(sig), sig);
-	fprintf(stderr, "Trace: %s\n", backtrace.c_str());
+	if (error) {
+		fprintf(stderr, "SIGNAL: %s (%d)\n", strsignal(sig), sig);
+		fprintf(stderr, "Trace: %s\n", backtrace.c_str());
+	}
 
 	struct sigaction sa;
 	sa.sa_handler = SIG_DFL;

--- a/flow/Platform.actor.cpp
+++ b/flow/Platform.actor.cpp
@@ -3598,7 +3598,7 @@ void crashHandler(int sig) {
 	fprintf(error ? stderr : stdout, "SIGNAL: %s (%d)\n", strsignal(sig), sig);
 	if (error) {
 		fprintf(stderr, "Trace: %s\n", backtrace.c_str());
-  }
+	}
 
 	fflush(stdout);
 	{

--- a/flow/Platform.actor.cpp
+++ b/flow/Platform.actor.cpp
@@ -3595,6 +3595,11 @@ void crashHandler(int sig) {
 	StreamCipher::cleanup();
 	BlobCipherKeyCache::cleanup();
 
+	fprintf(error ? stderr : stdout, "SIGNAL: %s (%d)\n", strsignal(sig), sig);
+	if (error) {
+		fprintf(stderr, "Trace: %s\n", backtrace.c_str());
+  }
+
 	fflush(stdout);
 	{
 		TraceEvent te(error ? SevError : SevInfo, error ? "Crash" : "ProcessTerminated");
@@ -3608,11 +3613,6 @@ void crashHandler(int sig) {
 #ifdef USE_GCOV
 	__gcov_flush();
 #endif
-
-	if (error) {
-		fprintf(stderr, "SIGNAL: %s (%d)\n", strsignal(sig), sig);
-		fprintf(stderr, "Trace: %s\n", backtrace.c_str());
-	}
 
 	struct sigaction sa;
 	sa.sa_handler = SIG_DFL;


### PR DESCRIPTION
* Add SIGTERM to the list of signals upon which we flush process state.
* Add __gcov_flush to the list of things we do during flush.
* Add --coverage compile option when using GCOV (it's not enough to do it only during linking). 

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
