### PR TITLE
Fix RelocateData initialization bug because RelocateShard.dataMovementReason is not set

### DIFF
--- a/fdbserver/DDTeamCollection.actor.cpp
+++ b/fdbserver/DDTeamCollection.actor.cpp
@@ -949,9 +949,7 @@ public:
 								}
 							}
 
-							RelocateShard rs;
-							rs.keys = shards[i];
-							rs.priority = maxPriority;
+							RelocateShard rs(shards[i], maxPriority, RelocateReason::OTHER);
 
 							self->output.send(rs);
 							TraceEvent("SendRelocateToDDQueue", self->distributorId)

--- a/fdbserver/include/fdbserver/DataDistribution.actor.h
+++ b/fdbserver/include/fdbserver/DataDistribution.actor.h
@@ -36,7 +36,7 @@
 
 #include "flow/actorcompiler.h" // This must be the last #include.
 
-enum class RelocateReason { INVALID = -1, OTHER, REBALANCE_DISK, REBALANCE_READ };
+enum class RelocateReason { OTHER = 0, REBALANCE_DISK, REBALANCE_READ };
 
 // One-to-one relationship to the priority knobs
 enum class DataMovementReason {
@@ -59,10 +59,10 @@ enum class DataMovementReason {
 	TEAM_0_LEFT,
 	SPLIT_SHARD
 };
+extern int dataMovementPriority(DataMovementReason moveReason);
+extern DataMovementReason priorityToDataMovementReason(int priority);
 
 struct DDShardInfo;
-
-extern int dataMovementPriority(DataMovementReason moveReason);
 
 // Represents a data move in DD.
 struct DataMove {
@@ -95,7 +95,7 @@ struct RelocateShard {
 	RelocateReason reason;
 	DataMovementReason moveReason;
 	RelocateShard()
-	  : priority(0), cancelled(false), dataMoveId(anonymousShardId), reason(RelocateReason::INVALID),
+	  : priority(0), cancelled(false), dataMoveId(anonymousShardId), reason(RelocateReason::OTHER),
 	    moveReason(DataMovementReason::INVALID) {}
 	RelocateShard(KeyRange const& keys, DataMovementReason moveReason, RelocateReason reason)
 	  : keys(keys), cancelled(false), dataMoveId(anonymousShardId), reason(reason), moveReason(moveReason) {

--- a/fdbserver/include/fdbserver/DataDistribution.actor.h
+++ b/fdbserver/include/fdbserver/DataDistribution.actor.h
@@ -94,15 +94,24 @@ struct RelocateShard {
 	UID dataMoveId;
 	RelocateReason reason;
 	DataMovementReason moveReason;
+
+	// Initialization when define is a better practice. We should avoid assignment of member after definition.
+	// static RelocateShard emptyRelocateShard() { return {}; }
+
+	RelocateShard(KeyRange const& keys, DataMovementReason moveReason, RelocateReason reason)
+	  : keys(keys), priority(dataMovementPriority(moveReason)), cancelled(false), dataMoveId(anonymousShardId),
+	    reason(reason), moveReason(moveReason) {}
+
+	RelocateShard(KeyRange const& keys, int priority, RelocateReason reason)
+	  : keys(keys), priority(priority), cancelled(false), dataMoveId(anonymousShardId), reason(reason),
+	    moveReason(priorityToDataMovementReason(priority)) {}
+
+	bool isRestore() const { return this->dataMove != nullptr; }
+
+private:
 	RelocateShard()
 	  : priority(0), cancelled(false), dataMoveId(anonymousShardId), reason(RelocateReason::OTHER),
 	    moveReason(DataMovementReason::INVALID) {}
-	RelocateShard(KeyRange const& keys, DataMovementReason moveReason, RelocateReason reason)
-	  : keys(keys), cancelled(false), dataMoveId(anonymousShardId), reason(reason), moveReason(moveReason) {
-		priority = dataMovementPriority(moveReason);
-	}
-
-	bool isRestore() const { return this->dataMove != nullptr; }
 };
 
 struct IDataDistributionTeam {


### PR DESCRIPTION
The default constructor of RelocateShard [here](https://sourcegraph.com/github.com/apple/foundationdb/-/blob/fdbserver/DDTeamCollection.actor.cpp?L952) set `moveReason(DataMovementReason::INVALID)`, which causes the [wantsNewServers](https://sourcegraph.com/github.com/apple/foundationdb/-/blob/fdbserver/DataDistributionQueue.actor.cpp?L158) incorrect when priority = `TEAM_REDUNDANT`.

This PR 
* removes the default constructor of `RelocateShard` because it's erroneous when separating necessary member assignment and definition;
* removes `RelocateReason::INVALID` because it's always guaranteed valid;
* add check for data movement priority uniqueness because the current team tracker relies on that.

Pass 100k test.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
