### PR TITLE
Add context for Transact, ReadTransact, LocalityGetBoundaryKeys for setting timeout

### DIFF
--- a/bindings/go/src/fdb/database.go
+++ b/bindings/go/src/fdb/database.go
@@ -174,9 +174,16 @@ func (d Database) transact(ctx context.Context, f func(Transaction) (interface{}
 		return nil, e
 	}
 
-	if deadline, ok := ctx.Deadline(); ok {
-		t := time.Until(deadline).Milliseconds()
-		tr.Options().SetTimeout(t)
+	if ctx != nil {
+		if deadline, ok := ctx.Deadline(); ok {
+			t := time.Until(deadline).Milliseconds()
+			_ = tr.Options().SetTimeout(t)
+		}
+
+		go func() {
+			<-ctx.Done()
+			tr.Cancel()
+		}()
 	}
 
 	wrapped := func() (ret interface{}, e error) {
@@ -233,9 +240,16 @@ func (d Database) readTransact(ctx context.Context, f func(ReadTransaction) (int
 		return nil, e
 	}
 
-	if deadline, ok := ctx.Deadline(); ok {
-		t := time.Until(deadline).Milliseconds()
-		tr.Options().SetTimeout(t)
+	if ctx != nil {
+		if deadline, ok := ctx.Deadline(); ok {
+			t := time.Until(deadline).Milliseconds()
+			_ = tr.Options().SetTimeout(t)
+		}
+
+		go func() {
+			<-ctx.Done()
+			tr.Cancel()
+		}()
 	}
 
 	wrapped := func() (ret interface{}, e error) {
@@ -285,9 +299,16 @@ func (d Database) localityGetBoundaryKeys(ctx context.Context, er ExactRange, li
 		return nil, e
 	}
 
-	if deadline, ok := ctx.Deadline(); ok {
-		t := time.Until(deadline).Milliseconds()
-		tr.Options().SetTimeout(t)
+	if ctx != nil {
+		if deadline, ok := ctx.Deadline(); ok {
+			t := time.Until(deadline).Milliseconds()
+			_ = tr.Options().SetTimeout(t)
+		}
+
+		go func() {
+			<-ctx.Done()
+			tr.Cancel()
+		}()
 	}
 
 	if readVersion != 0 {

--- a/bindings/go/src/fdb/database.go
+++ b/bindings/go/src/fdb/database.go
@@ -192,7 +192,14 @@ func (d Database) transact(ctx context.Context, f func(Transaction) (interface{}
 		ret, e = f(tr)
 
 		if e == nil {
-			e = tr.Commit().Get()
+			futureNil := tr.Commit()
+			go func() {
+				if ctx != nil {
+					<-ctx.Done()
+					futureNil.Cancel()
+				}
+			}()
+			e = futureNil.Get()
 		}
 
 		return
@@ -258,7 +265,14 @@ func (d Database) readTransact(ctx context.Context, f func(ReadTransaction) (int
 		ret, e = f(tr)
 
 		if e == nil {
-			e = tr.Commit().Get()
+			futureNil := tr.Commit()
+			go func() {
+				if ctx != nil {
+					<-ctx.Done()
+					futureNil.Cancel()
+				}
+			}()
+			e = futureNil.Get()
 		}
 
 		return


### PR DESCRIPTION
Added context for  `Transact, ReadTransact, LocalityGetBoundaryKeys` functions which is used just for setting request timeout. 
Timeout configuration via context in functions is more flexible than setting global DB request timeout.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
