### PR TITLE
Change crashAndDie to abort instead of segv

### DIFF
--- a/flow/Platform.actor.cpp
+++ b/flow/Platform.actor.cpp
@@ -3653,6 +3653,7 @@ void registerCrashHandler() {
 	sigaction(SIGBUS, &action, nullptr);
 	sigaction(SIGUSR2, &action, nullptr);
 	sigaction(SIGTERM, &action, nullptr);
+	sigaction(SIGABRT, &action, nullptr);
 #else
 	// No crash handler for other platforms!
 #endif

--- a/flow/include/flow/Platform.h
+++ b/flow/include/flow/Platform.h
@@ -662,7 +662,7 @@ inline static void flushOutputStreams() {
 #error Missing symbol export
 #endif
 
-#define crashAndDie() (*(volatile int*)0 = 0)
+#define crashAndDie() std::abort()
 
 #ifdef _WIN32
 #define strcasecmp stricmp


### PR DESCRIPTION
This way we still terminate early when `--crash` is set, but folks
inspecting error reports don't get mislead and confuse assertion
failures with genuine memory errors.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
