### PR TITLE
Fix heap-use-after-free in storage wiggler unit test

### DIFF
--- a/fdbserver/DDTeamCollection.actor.cpp
+++ b/fdbserver/DDTeamCollection.actor.cpp
@@ -5888,19 +5888,23 @@ TEST_CASE("/DataDistribution/StorageWiggler/NextIdWithMinAge") {
 		auto id = wiggler.getNextServerId();
 		ASSERT(id == correctResult[i]);
 	}
-	std::cout << "Finish Initial Check. Start test getNextWigglingServerID() loop...\n";
-	// test the getNextWigglingServerID() loop
-	state UID id = wait(DDTeamCollectionImpl::getNextWigglingServerID(Reference<StorageWiggler>::addRef(&wiggler)));
-	ASSERT(id == UID(1, 0));
+
+	{
+		std::cout << "Finish Initial Check. Start test getNextWigglingServerID() loop...\n";
+		// test the getNextWigglingServerID() loop
+		UID id = wait(DDTeamCollectionImpl::getNextWigglingServerID(Reference<StorageWiggler>::addRef(&wiggler)));
+		ASSERT(id == UID(1, 0));
+	}
 
 	std::cout << "Test after addServer() ...\n";
 	state Future<UID> nextFuture =
 	    DDTeamCollectionImpl::getNextWigglingServerID(Reference<StorageWiggler>::addRef(&wiggler));
+	ASSERT(!nextFuture.isReady());
 	startTime = now();
 	StorageMetadataType metadata(startTime + SERVER_KNOBS->DD_STORAGE_WIGGLE_MIN_SS_AGE_SEC + 100.0,
 	                             KeyValueStoreType::SSD_BTREE_V2);
 	wiggler.addServer(UID(5, 0), metadata);
-	ASSERT(!nextFuture.isReady() || now() - metadata.createdTime >= SERVER_KNOBS->DD_STORAGE_WIGGLE_MIN_SS_AGE_SEC);
+	ASSERT(!nextFuture.isReady());
 
 	std::cout << "Test after updateServer() ...\n";
 	StorageWiggler* ptr = &wiggler;
@@ -5911,8 +5915,8 @@ TEST_CASE("/DataDistribution/StorageWiggler/NextIdWithMinAge") {
 		                                            KeyValueStoreType::SSD_BTREE_V2));
 	    },
 	    delay(5.0)));
-	wait(store(id, nextFuture));
+	wait(success(nextFuture));
 
-	ASSERT(id == UID(5, 0));
+	ASSERT(nextFuture.get() == UID(5, 0));
 	return Void();
 }

--- a/fdbserver/DataDistribution.actor.cpp
+++ b/fdbserver/DataDistribution.actor.cpp
@@ -104,7 +104,7 @@ void DataMove::validateShard(const DDShardInfo& shard, KeyRangeRef range, int pr
 }
 
 Future<Void> StorageWiggler::onCheck() const {
-	return delay(MIN_ON_CHECK_DELAY_SEC) || pqCanCheck.onTrigger();
+	return delay(MIN_ON_CHECK_DELAY_SEC);
 }
 
 // add server to wiggling queue
@@ -133,7 +133,6 @@ void StorageWiggler::updateMetadata(const UID& serverId, const StorageMetadataTy
 		return;
 	}
 	wiggle_pq.update(handle, std::make_pair(metadata, serverId));
-	pqCanCheck.trigger();
 }
 
 bool StorageWiggler::eligible(const UID& serverId, const StorageMetadataType& metadata) const {

--- a/fdbserver/include/fdbserver/DataDistribution.actor.h
+++ b/fdbserver/include/fdbserver/DataDistribution.actor.h
@@ -483,11 +483,6 @@ struct StorageWiggleMetrics {
 
 struct StorageWiggler : ReferenceCounted<StorageWiggler> {
 	static constexpr double MIN_ON_CHECK_DELAY_SEC = 5.0;
-
-private:
-	mutable Debouncer pqCanCheck{ MIN_ON_CHECK_DELAY_SEC };
-
-public:
 	enum State : uint8_t { INVALID = 0, RUN = 1, PAUSE = 2 };
 
 	DDTeamCollection const* teamCollection;

--- a/tests/rare/SpecificUnitTests.toml
+++ b/tests/rare/SpecificUnitTests.toml
@@ -7,4 +7,4 @@ startDelay = 0
     [[test.workload]]
     testName = 'UnitTests'
     maxTestCases = 1
-    testsMatching = '/DataDistribution'
+    testsMatching = '/DataDistribution/StorageWiggler'


### PR DESCRIPTION
This bug comes from the unit test actor state is destroyed, then the inner worker in `Debouncer` tried to access the destroyed future object. Now it's a unit test-only bug, but to avoid the same code pattern causing the same problem, and the `Debouncer` doesn't bring obvious benefit compared to periodically checking, in this PR I remove it from the storage wiggler.

pass 100k ASAN test

```
=================================================================
==24==ERROR: AddressSanitizer: heap-use-after-free on address 0x6150003be340 at pc 0x00000317d2df bp 0x7ffe3811b7d0 sp 0x7ffe3811b7c8
READ of size 8 at 0x6150003be340 thread T0
    #0 0x317d2de in Promise<Void>::getFuture() const /mnt/ephemeral/xwang/readawareFdb/flow/include/flow/flow.h:909:3
    #1 0x317d2de in AsyncVar<Void>::onChange() const /mnt/ephemeral/xwang/readawareFdb/flow/include/flow/genericactors.actor.h:686:52
    #2 0x317d2de in Debouncer::DebounceWorkerActorState<Debouncer::DebounceWorkerActor>::a_body1loopBody1(int) /mnt/ephemeral/xwang/readawareFdb/flow/include/flow/genericactors.actor.h:748:50
    #3 0x317e6d3 in Debouncer::DebounceWorkerActorState<Debouncer::DebounceWorkerActor>::a_body1loopHead1(int) /mnt/ephemeral/xwang/build/readawareFdb.linux.clang.x86_64/flow/include/flow/genericactors.actor.g.h:8357:49
    #4 0x317e6d3 in Debouncer::DebounceWorkerActorState<Debouncer::DebounceWorkerActor>::a_body1loopBody1cont2(int) /mnt/ephemeral/xwang/build/readawareFdb.linux.clang.x86_64/flow/include/flow/genericactors.actor.g.h:8463:30
    #5 0x317e6d3 in Debouncer::DebounceWorkerActorState<Debouncer::DebounceWorkerActor>::a_body1loopBody1cont1break1(int) /mnt/ephemeral/xwang/build/readawareFdb.linux.clang.x86_64/flow/include/flow/genericactors.actor.g.h:8499:11
    #6 0x31803fe in Debouncer::DebounceWorkerActorState<Debouncer::DebounceWorkerActor>::a_body1loopBody1cont1loopBody1when2(Void const&, int) /mnt/ephemeral/xwang/build/readawareFdb.linux.clang.x86_64/flow/include/flow/genericactors.actor.g.h:8529:10
    #7 0x31803fe in Debouncer::DebounceWorkerActorState<Debouncer::DebounceWorkerActor>::a_callback_fire(ActorCallback<Debouncer::DebounceWorkerActor, 2, Void>*, Void const&) /mnt/ephemeral/xwang/build/readawareFdb.linux.clang.x86_64/flow/include/flow/genericactors.actor.g.h:8596:4
    #8 0x2353dff in void SAV<Void>::send<Void>(Void&&) /mnt/ephemeral/xwang/readawareFdb/flow/include/flow/flow.h:655:23
    #9 0xc6c9266 in void Promise<Void>::send<Void>(Void&&) const /mnt/ephemeral/xwang/readawareFdb/flow/include/flow/flow.h:901:8
    #10 0xc6c9266 in Sim2::execTask(Sim2::Task&) /mnt/ephemeral/xwang/readawareFdb/fdbrpc/sim2.actor.cpp:2246:14
    #11 0xc6c85f6 in Sim2::runLoop(Sim2*) /mnt/ephemeral/xwang/readawareFdb/fdbrpc/sim2.actor.cpp:1227:10
    #12 0x72036da in main /mnt/ephemeral/xwang/readawareFdb/fdbserver/fdbserver.actor.cpp:2198:16
    #13 0x7fe56e586554 in __libc_start_main (/lib64/libc.so.6+0x22554)
    #14 0x21e2028 in _start (/mnt/ephemeral/xwang/build/readawareFdb.linux.clang.x86_64/bin/fdbserver+0x21e2028)

0x6150003be340 is located 192 bytes inside of 512-byte region [0x6150003be280,0x6150003be480)
freed by thread T0 here:
    #0 0x2290d6d in operator delete[](void*) /tmp/llvm-project/compiler-rt/lib/asan/asan_new_delete.cpp:155:3
    #1 0x46cf1d8 in (anonymous namespace)::FlowTestCase5873ActorState<(anonymous namespace)::FlowTestCase5873Actor>::a_callback_fire(ActorCallback<(anonymous namespace)::FlowTestCase5873Actor, 2, Void>*, Void const&) /mnt/ephemeral/xwang/build/readawareFdb.linux.clang.x86_64/fdbserver/DDTeamCollection.actor.g.cpp:31598:4
    #2 0x46cf1d8 in ActorCallback<(anonymous namespace)::FlowTestCase5873Actor, 2, Void>::fire(Void const&) /mnt/ephemeral/xwang/readawareFdb/flow/include/flow/flow.h:1313:34
    #3 0x46d4c7f in SAV<Void>::finishSendAndDelPromiseRef() /mnt/ephemeral/xwang/readawareFdb/flow/include/flow/flow.h:689:23
    #4 0x46d4c7f in (anonymous namespace)::MapActorState<UID, Future<Void> store<UID>(UID&, Future<UID>)::'lambda'(UID const&), (anonymous namespace)::MapActor<UID, Future<Void> store<UID>(UID&, Future<UID>)::'lambda'(UID const&)> >::a_body1cont1(UID const&, int) /mnt/ephemeral/xwang/build/readawareFdb.linux.clang.x86_64/flow/include/flow/genericactors.actor.g.h:6113:33
    #5 0x46d4c7f in (anonymous namespace)::MapActorState<UID, Future<Void> store<UID>(UID&, Future<UID>)::'lambda'(UID const&), (anonymous namespace)::MapActor<UID, Future<Void> store<UID>(UID&, Future<UID>)::'lambda'(UID const&)> >::a_body1when1(UID const&, int) /mnt/ephemeral/xwang/build/readawareFdb.linux.clang.x86_64/flow/include/flow/genericactors.actor.g.h:6132:15
    #6 0x46d46ff in (anonymous namespace)::MapActorState<UID, Future<Void> store<UID>(UID&, Future<UID>)::'lambda'(UID const&), (anonymous namespace)::MapActor<UID, Future<Void> store<UID>(UID&, Future<UID>)::'lambda'(UID const&)> >::a_callback_fire(ActorCallback<(anonymous namespace)::MapActor<UID, Future<Void> store<UID>(UID&, Future<UID>)::'lambda'(UID const&)>, 0, UID>*, UID const&) /mnt/ephemeral/xwang/build/readawareFdb.linux.clang.x86_64/flow/include/flow/genericactors.actor.g.h:6153:4
    #7 0x46d46ff in ActorCallback<(anonymous namespace)::MapActor<UID, Future<Void> store<UID>(UID&, Future<UID>)::'lambda'(UID const&)>, 0, UID>::fire(UID const&) /mnt/ephemeral/xwang/readawareFdb/flow/include/flow/flow.h:1313:34
    #8 0x480d89c in SAV<UID>::finishSendAndDelPromiseRef() /mnt/ephemeral/xwang/readawareFdb/flow/include/flow/flow.h:689:23
    #9 0x480d89c in DDTeamCollectionImpl::GetNextWigglingServerIDActorState<DDTeamCollectionImpl::GetNextWigglingServerIDActor>::a_body1loopBody1cont1(int) /mnt/ephemeral/xwang/build/readawareFdb.linux.clang.x86_64/fdbserver/DDTeamCollection.actor.g.cpp:20202:53
    #10 0x480cc9c in DDTeamCollectionImpl::GetNextWigglingServerIDActorState<DDTeamCollectionImpl::GetNextWigglingServerIDActor>::a_body1loopBody1(int) /mnt/ephemeral/xwang/build/readawareFdb.linux.clang.x86_64/fdbserver/DDTeamCollection.actor.g.cpp:20162:16
    #11 0x480f82c in DDTeamCollectionImpl::GetNextWigglingServerIDActorState<DDTeamCollectionImpl::GetNextWigglingServerIDActor>::a_body1loopHead1(int) /mnt/ephemeral/xwang/build/readawareFdb.linux.clang.x86_64/fdbserver/DDTeamCollection.actor.g.cpp:20136:49
    #12 0x480f82c in DDTeamCollectionImpl::GetNextWigglingServerIDActorState<DDTeamCollectionImpl::GetNextWigglingServerIDActor>::a_body1loopBody1cont2(Void const&, int) /mnt/ephemeral/xwang/build/readawareFdb.linux.clang.x86_64/fdbserver/DDTeamCollection.actor.g.cpp:20209:10
    #13 0x480f82c in DDTeamCollectionImpl::GetNextWigglingServerIDActorState<DDTeamCollectionImpl::GetNextWigglingServerIDActor>::a_body1loopBody1when1(Void const&, int) /mnt/ephemeral/xwang/build/readawareFdb.linux.clang.x86_64/fdbserver/DDTeamCollection.actor.g.cpp:20221:15
    #14 0x480f82c in DDTeamCollectionImpl::GetNextWigglingServerIDActorState<DDTeamCollectionImpl::GetNextWigglingServerIDActor>::a_callback_fire(ActorCallback<DDTeamCollectionImpl::GetNextWigglingServerIDActor, 0, Void>*, Void const&) /mnt/ephemeral/xwang/build/readawareFdb.linux.clang.x86_64/fdbserver/DDTeamCollection.actor.g.cpp:20242:4
    #15 0x260312f in SAV<Void>::finishSendAndDelPromiseRef() /mnt/ephemeral/xwang/readawareFdb/flow/include/flow/flow.h:689:23
    #16 0x260312f in (anonymous namespace)::ChooseActorActorState<Void, (anonymous namespace)::ChooseActorActor<Void> >::a_body1when2(Void const&, int) /mnt/ephemeral/xwang/build/readawareFdb.linux.clang.x86_64/flow/include/flow/genericactors.actor.g.h:14129:41
    #17 0x260312f in (anonymous namespace)::ChooseActorActorState<Void, (anonymous namespace)::ChooseActorActor<Void> >::a_callback_fire(ActorCallback<(anonymous namespace)::ChooseActorActor<Void>, 1, Void>*, Void const&) /mnt/ephemeral/xwang/build/readawareFdb.linux.clang.x86_64/flow/include/flow/genericactors.actor.g.h:14203:4
    #18 0x260312f in ActorCallback<(anonymous namespace)::ChooseActorActor<Void>, 1, Void>::fire(Void const&) /mnt/ephemeral/xwang/readawareFdb/flow/include/flow/flow.h:1313:34
    #19 0x317e37f in void SAV<Void>::send<Void>(Void&&) /mnt/ephemeral/xwang/readawareFdb/flow/include/flow/flow.h:655:23
    #20 0x317e37f in void Promise<Void>::send<Void>(Void&&) const /mnt/ephemeral/xwang/readawareFdb/flow/include/flow/flow.h:901:8
    #21 0x317e37f in AsyncVar<Void>::setUnconditional(Void const&) /mnt/ephemeral/xwang/readawareFdb/flow/include/flow/genericactors.actor.h:695:5
    #22 0x317e37f in Debouncer::DebounceWorkerActorState<Debouncer::DebounceWorkerActor>::a_body1loopBody1cont2(int) /mnt/ephemeral/xwang/readawareFdb/flow/include/flow/genericactors.actor.h:755:16
    #23 0x317e37f in Debouncer::DebounceWorkerActorState<Debouncer::DebounceWorkerActor>::a_body1loopBody1cont1break1(int) /mnt/ephemeral/xwang/build/readawareFdb.linux.clang.x86_64/flow/include/flow/genericactors.actor.g.h:8499:11
    #24 0x31803fe in Debouncer::DebounceWorkerActorState<Debouncer::DebounceWorkerActor>::a_body1loopBody1cont1loopBody1when2(Void const&, int) /mnt/ephemeral/xwang/build/readawareFdb.linux.clang.x86_64/flow/include/flow/genericactors.actor.g.h:8529:10
    #25 0x31803fe in Debouncer::DebounceWorkerActorState<Debouncer::DebounceWorkerActor>::a_callback_fire(ActorCallback<Debouncer::DebounceWorkerActor, 2, Void>*, Void const&) /mnt/ephemeral/xwang/build/readawareFdb.linux.clang.x86_64/flow/include/flow/genericactors.actor.g.h:8596:4
    #26 0x2353dff in void SAV<Void>::send<Void>(Void&&) /mnt/ephemeral/xwang/readawareFdb/flow/include/flow/flow.h:655:23
    #27 0xc6c9266 in void Promise<Void>::send<Void>(Void&&) const /mnt/ephemeral/xwang/readawareFdb/flow/include/flow/flow.h:901:8
    #28 0xc6c9266 in Sim2::execTask(Sim2::Task&) /mnt/ephemeral/xwang/readawareFdb/fdbrpc/sim2.actor.cpp:2246:14
    #29 0xc6c85f6 in Sim2::runLoop(Sim2*) /mnt/ephemeral/xwang/readawareFdb/fdbrpc/sim2.actor.cpp:1227:10
    #30 0x72036da in main /mnt/ephemeral/xwang/readawareFdb/fdbserver/fdbserver.actor.cpp:2198:16
    #31 0x7fe56e586554 in __libc_start_main (/lib64/libc.so.6+0x22554)

previously allocated by thread T0 here:
    #0 0x229051d in operator new[](unsigned long) /tmp/llvm-project/compiler-rt/lib/asan/asan_new_delete.cpp:98:3
    #1 0x463affd in FastAllocated<(anonymous namespace)::FlowTestCase5873Actor>::operator new(unsigned long) /mnt/ephemeral/xwang/readawareFdb/flow/include/flow/FastAlloc.h:220:14
    #2 0x463affd in flowTestCase5873(UnitTestParameters const&) /mnt/ephemeral/xwang/readawareFdb/fdbserver/DDTeamCollection.actor.cpp:5873:22
    #3 0x9bf88c6 in UnitTestWorkload::RunUnitTestsActorState<UnitTestWorkload::RunUnitTestsActor>::a_body1loopBody1(int) /mnt/ephemeral/xwang/readawareFdb/fdbserver/workloads/UnitTests.actor.cpp:156:39
    #4 0x9bf703b in UnitTestWorkload::RunUnitTestsActorState<UnitTestWorkload::RunUnitTestsActor>::a_body1loopHead1(int) /mnt/ephemeral/xwang/build/readawareFdb.linux.clang.x86_64/fdbserver/workloads/UnitTests.actor.g.cpp:226:49
    #5 0x9bf703b in UnitTestWorkload::RunUnitTestsActorState<UnitTestWorkload::RunUnitTestsActor>::a_body1(int) /mnt/ephemeral/xwang/build/readawareFdb.linux.clang.x86_64/fdbserver/workloads/UnitTests.actor.g.cpp:193:16
    #6 0x9bf53bf in UnitTestWorkload::RunUnitTestsActor::RunUnitTestsActor(UnitTestWorkload* const&) /mnt/ephemeral/xwang/build/readawareFdb.linux.clang.x86_64/fdbserver/workloads/UnitTests.actor.g.cpp:461:9
    #7 0x9bf53bf in UnitTestWorkload::runUnitTests(UnitTestWorkload* const&) /mnt/ephemeral/xwang/readawareFdb/fdbserver/workloads/UnitTests.actor.cpp:118:26
    #8 0x9bf53bf in UnitTestWorkload::start(Database const&) /mnt/ephemeral/xwang/readawareFdb/fdbserver/workloads/UnitTests.actor.cpp:106:11
    #9 0x7848cb7 in (anonymous namespace)::RunWorkloadAsyncActorState<(anonymous namespace)::RunWorkloadAsyncActor>::a_body1loopBody1when2(ReplyPromise<Void>&&, int) /mnt/ephemeral/xwang/readawareFdb/fdbserver/tester.actor.cpp:609:50
    #10 0x783d347 in (anonymous namespace)::RunWorkloadAsyncActorState<(anonymous namespace)::RunWorkloadAsyncActor>::a_callback_fire(ActorSingleCallback<(anonymous namespace)::RunWorkloadAsyncActor, 1, ReplyPromise<Void> >*, ReplyPromise<Void>&&) /mnt/ephemeral/xwang/build/readawareFdb.linux.clang.x86_64/fdbserver/tester.actor.g.cpp:3665:4
    #11 0x783d347 in ActorSingleCallback<(anonymous namespace)::RunWorkloadAsyncActor, 1, ReplyPromise<Void> >::fire(ReplyPromise<Void>&&) /mnt/ephemeral/xwang/readawareFdb/flow/include/flow/flow.h:1335:34
    #12 0x24315da in void NotifiedQueue<ReplyPromise<Void> >::send<ReplyPromise<Void> >(ReplyPromise<Void>&&) /mnt/ephemeral/xwang/readawareFdb/flow/include/flow/flow.h:1004:29
    #13 0x24315da in NetNotifiedQueue<ReplyPromise<Void>, false>::receive(ArenaObjectReader&) /mnt/ephemeral/xwang/readawareFdb/fdbrpc/include/fdbrpc/fdbrpc.h:693:10
    #14 0xc2eb656 in (anonymous namespace)::DeliverActorState<(anonymous namespace)::DeliverActor>::a_body1cont1(int) /mnt/ephemeral/xwang/readawareFdb/fdbrpc/FlowTransport.actor.cpp:1037:15
    #15 0xc2ea30d in (anonymous namespace)::DeliverActorState<(anonymous namespace)::DeliverActor>::a_body1cont2(Void const&, int) /mnt/ephemeral/xwang/build/readawareFdb.linux.clang.x86_64/fdbrpc/FlowTransport.actor.g.cpp:4328:15
    #16 0xc2ea30d in (anonymous namespace)::DeliverActorState<(anonymous namespace)::DeliverActor>::a_body1when1(Void const&, int) /mnt/ephemeral/xwang/build/readawareFdb.linux.clang.x86_64/fdbrpc/FlowTransport.actor.g.cpp:4340:15
    #17 0xc2ea30d in (anonymous namespace)::DeliverActorState<(anonymous namespace)::DeliverActor>::a_callback_fire(ActorCallback<(anonymous namespace)::DeliverActor, 0, Void>*, Void const&) /mnt/ephemeral/xwang/build/readawareFdb.linux.clang.x86_64/fdbrpc/FlowTransport.actor.g.cpp:4361:4
    #18 0xc2ea30d in ActorCallback<(anonymous namespace)::DeliverActor, 0, Void>::fire(Void const&) /mnt/ephemeral/xwang/readawareFdb/flow/include/flow/flow.h:1313:34
    #19 0x2353dff in void SAV<Void>::send<Void>(Void&&) /mnt/ephemeral/xwang/readawareFdb/flow/include/flow/flow.h:655:23
    #20 0xc6c9266 in void Promise<Void>::send<Void>(Void&&) const /mnt/ephemeral/xwang/readawareFdb/flow/include/flow/flow.h:901:8
    #21 0xc6c9266 in Sim2::execTask(Sim2::Task&) /mnt/ephemeral/xwang/readawareFdb/fdbrpc/sim2.actor.cpp:2246:14
    #22 0xc6c85f6 in Sim2::runLoop(Sim2*) /mnt/ephemeral/xwang/readawareFdb/fdbrpc/sim2.actor.cpp:1227:10
    #23 0x72036da in main /mnt/ephemeral/xwang/readawareFdb/fdbserver/fdbserver.actor.cpp:2198:16
    #24 0x7fe56e586554 in __libc_start_main (/lib64/libc.so.6+0x22554)

SUMMARY: AddressSanitizer: heap-use-after-free /mnt/ephemeral/xwang/readawareFdb/flow/include/flow/flow.h:909:3 in Promise<Void>::getFuture() const
Shadow bytes around the buggy address:
  0x0c2a8006fc10: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c2a8006fc20: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c2a8006fc30: fd fd fd fd fd fd fd fd fd fd fd fd fa fa fa fa
  0x0c2a8006fc40: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c2a8006fc50: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
=>0x0c2a8006fc60: fd fd fd fd fd fd fd fd[fd]fd fd fd fd fd fd fd
  0x0c2a8006fc70: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c2a8006fc80: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c2a8006fc90: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c2a8006fca0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0c2a8006fcb0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==24==ABORTING

```

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
