### PR TITLE
fix heap-use-after-free caused by incorrect pair initialization

### DIFF
--- a/fdbserver/DataDistributionQueue.actor.cpp
+++ b/fdbserver/DataDistributionQueue.actor.cpp
@@ -69,7 +69,7 @@ inline bool isDataMovementForValleyFiller(DataMovementReason reason) {
 
 typedef std::map<DataMovementReason, int> DmReasonPriorityMapping;
 typedef std::map<int, DataMovementReason> PriorityDmReasonMapping;
-std::pair<const DmReasonPriorityMapping&, const PriorityDmReasonMapping&> buildPriorityMappings() {
+std::pair<const DmReasonPriorityMapping*, const PriorityDmReasonMapping*> buildPriorityMappings() {
 	static DmReasonPriorityMapping reasonPriority{
 		{ DataMovementReason::INVALID, -1 },
 		{ DataMovementReason::RECOVER_MOVE, SERVER_KNOBS->PRIORITY_RECOVER_MOVE },
@@ -103,17 +103,17 @@ std::pair<const DmReasonPriorityMapping&, const PriorityDmReasonMapping&> buildP
 		}
 	}
 
-	return std::make_pair(reasonPriority, priorityReason);
+	return std::make_pair(&reasonPriority, &priorityReason);
 }
 
 int dataMovementPriority(DataMovementReason reason) {
-	const auto& [reasonPriority, _] = buildPriorityMappings();
-	return reasonPriority.at(reason);
+	auto [reasonPriority, _] = buildPriorityMappings();
+	return reasonPriority->at(reason);
 }
 
 DataMovementReason priorityToDataMovementReason(int priority) {
-	const auto& [_, priorityReason] = buildPriorityMappings();
-	return priorityReason.at(priority);
+	auto [_, priorityReason] = buildPriorityMappings();
+	return priorityReason->at(priority);
 }
 
 struct RelocateData {


### PR DESCRIPTION
FIX #7841 
The old code wants to make a pair of references to the static objects, but the `make_pair` actually does a copy-by-value job. So the result the callers got is a const reference to a newly created object, which is destroyed before use. It wasn't caught by CI or normal Joshua Run, I guess because the compiler doing some optimization

The fix is to use pointers to the static objects, which is fine with copy-by-value.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
