### PR TITLE
Add restart test coverage from snowflake-specific binaries

### DIFF
--- a/contrib/TestHarness/Program.cs
+++ b/contrib/TestHarness/Program.cs
@@ -323,8 +323,10 @@ namespace SummarizeTest
                         oldBinaryVersionLowerBound = "0.0.0";
                     }
                     string[] currentBinary = { fdbserverName };
-                    IEnumerable<string> oldBinaries = Array.FindAll(
-                                                         Directory.GetFiles(oldBinaryFolder),
+                    var snowflakePath = Path.Combine("/app", "deploy", "global_data", "snowflakeBinaries");
+                    string[] snowflakeBinaries = Directory.Exists(snowflakePath) ? Directory.GetFiles(snowflakePath) : Array.Empty<string>();
+
+                    IEnumerable<string> oldBinaries = Array.FindAll(Directory.GetFiles(oldBinaryFolder).Concat(snowflakeBinaries).ToArray(),
                                                          x => versionGreaterThanOrEqual(Path.GetFileName(x).Split('-').Last(), oldBinaryVersionLowerBound)
                                                            && versionLessThan(Path.GetFileName(x).Split('-').Last(), oldBinaryVersionUpperBound));
                     if (!lastFolderName.Contains("until_")) {

--- a/contrib/TestHarness/Program.cs
+++ b/contrib/TestHarness/Program.cs
@@ -324,9 +324,9 @@ namespace SummarizeTest
                     }
                     string[] currentBinary = { fdbserverName };
                     var snowflakePath = Path.Combine("/app", "deploy", "global_data", "snowflakeBinaries");
-                    string[] snowflakeBinaries = Directory.Exists(snowflakePath) ? Directory.GetFiles(snowflakePath) : Array.Empty<string>();
+                    string[] candidateBinaries = Directory.Exists(snowflakePath) ? Directory.GetFiles(snowflakePath) : Directory.GetFiles(oldBinaryFolder);
 
-                    IEnumerable<string> oldBinaries = Array.FindAll(Directory.GetFiles(oldBinaryFolder).Concat(snowflakeBinaries).ToArray(),
+                    IEnumerable<string> oldBinaries = Array.FindAll(candidateBinaries,
                                                          x => versionGreaterThanOrEqual(Path.GetFileName(x).Split('-').Last(), oldBinaryVersionLowerBound)
                                                            && versionLessThan(Path.GetFileName(x).Split('-').Last(), oldBinaryVersionUpperBound));
                     if (!lastFolderName.Contains("until_")) {


### PR DESCRIPTION
Add snowflake-specific directory of old binaries as candidates for old binaries in restart tests, if that directory exists.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
