### PR TITLE
Metacluster restore support for a data cluster

### DIFF
--- a/fdbcli/MetaclusterCommands.actor.cpp
+++ b/fdbcli/MetaclusterCommands.actor.cpp
@@ -494,14 +494,15 @@ std::vector<const char*> metaclusterHintGenerator(std::vector<StringRef> const& 
 
 CommandFactory metaclusterRegisterFactory(
     "metacluster",
-    CommandHelp("metacluster <create_experimental|decommission|register|remove|configure|list|get|status> [ARGS]",
-                "view and manage a metacluster",
-                "`create_experimental' and `decommission' set up or deconfigure a metacluster.\n"
-                "`register' and `remove' add and remove data clusters from the metacluster.\n"
-                "`configure' updates the configuration of a data cluster.\n"
-                "`list' prints a list of data clusters in the metacluster.\n"
-                "`get' prints the metadata for a particular data cluster.\n"
-                "`status' prints metacluster metadata.\n"),
+    CommandHelp(
+        "metacluster <create_experimental|decommission|register|remove|restore|configure|list|get|status> [ARGS]",
+        "view and manage a metacluster",
+        "`create_experimental' and `decommission' set up or deconfigure a metacluster.\n"
+        "`register' and `remove' add and remove data clusters from the metacluster.\n"
+        "`configure' updates the configuration of a data cluster.\n"
+        "`list' prints a list of data clusters in the metacluster.\n"
+        "`get' prints the metadata for a particular data cluster.\n"
+        "`status' prints metacluster metadata.\n"),
     &metaclusterGenerator,
     &metaclusterHintGenerator);
 

--- a/fdbcli/MetaclusterCommands.actor.cpp
+++ b/fdbcli/MetaclusterCommands.actor.cpp
@@ -478,6 +478,7 @@ CommandFactory metaclusterRegisterFactory(
         "`create_experimental' and `decommission' set up or deconfigure a metacluster.\n"
         "`register' and `remove' add and remove data clusters from the metacluster.\n"
         "`configure' updates the configuration of a data cluster.\n"
+        "`restore' restores the specified data cluster."
         "`list' prints a list of data clusters in the metacluster.\n"
         "`get' prints the metadata for a particular data cluster.\n"
         "`status' prints metacluster metadata.\n"),

--- a/fdbcli/MetaclusterCommands.actor.cpp
+++ b/fdbcli/MetaclusterCommands.actor.cpp
@@ -33,13 +33,16 @@
 
 namespace fdb_cli {
 
-Optional<std::pair<Optional<ClusterConnectionString>, Optional<DataClusterEntry>>>
-parseClusterConfiguration(std::vector<StringRef> const& tokens, DataClusterEntry const& defaults, int startIndex) {
+Optional<std::pair<Optional<ClusterConnectionString>, Optional<DataClusterEntry>>> parseClusterConfiguration(
+    std::vector<StringRef> const& tokens,
+    DataClusterEntry const& defaults,
+    int startIndex,
+    int endIndex) {
 	Optional<DataClusterEntry> entry;
 	Optional<ClusterConnectionString> connectionString;
 
 	std::set<std::string> usedParams;
-	for (int tokenNum = startIndex; tokenNum < tokens.size(); ++tokenNum) {
+	for (int tokenNum = startIndex; tokenNum < endIndex; ++tokenNum) {
 		StringRef token = tokens[tokenNum];
 		bool foundEquals;
 		StringRef param = token.eat("=", &foundEquals);
@@ -126,7 +129,7 @@ ACTOR Future<bool> metaclusterRegisterCommand(Reference<IDatabase> db, std::vect
 	}
 
 	DataClusterEntry defaultEntry;
-	auto config = parseClusterConfiguration(tokens, defaultEntry, 3);
+	auto config = parseClusterConfiguration(tokens, defaultEntry, 3, tokens.size());
 	if (!config.present()) {
 		return false;
 	} else if (!config.get().first.present()) {
@@ -158,25 +161,6 @@ ACTOR Future<bool> metaclusterRemoveCommand(Reference<IDatabase> db, std::vector
 	return true;
 }
 
-Optional<std::string> parseToken(StringRef token, const char* str) {
-	bool foundEquals;
-	StringRef param = token.eat("=", &foundEquals);
-	if (!foundEquals) {
-		fmt::print(stderr,
-		           "ERROR: invalid configuration string `{}'. String must specify a value using `='.\n",
-		           param.toString().c_str());
-		return Optional<std::string>();
-	}
-
-	if (!tokencmp(param, str)) {
-		fmt::print(
-		    stderr, "ERROR: invalid configuration string `{}'. Expected: `{}'.\n", param.toString().c_str(), str);
-		return Optional<std::string>();
-	}
-
-	return Optional<std::string>(token.toString());
-}
-
 // metacluster restore command
 ACTOR Future<bool> metaclusterRestoreCommand(Reference<IDatabase> db, std::vector<StringRef> tokens) {
 	if (tokens.size() < 4 || tokens.size() > 6) {
@@ -187,17 +171,20 @@ ACTOR Future<bool> metaclusterRestoreCommand(Reference<IDatabase> db, std::vecto
 	}
 
 	// connection string
-	ClusterConnectionString connectionString;
-	auto optVal = parseToken(tokens[3], "connection_string");
-	if (optVal.present()) {
-		connectionString = ClusterConnectionString(optVal.get());
+	DataClusterEntry defaultEntry;
+	auto config = parseClusterConfiguration(tokens, defaultEntry, 3, 4);
+	if (!config.present()) {
+		return false;
+	} else if (!config.get().first.present()) {
+		fmt::print(stderr, "ERROR: connection_string must be configured when registering a cluster.\n");
+		return false;
 	}
 
 	state bool restore_from_data_cluster = tokens.size() == 5;
 	if (restore_from_data_cluster) {
 		DataClusterEntry defaultEntry;
 		wait(MetaclusterAPI::restoreCluster(
-		    db, tokens[2], connectionString, defaultEntry, AddNewTenants::False, RemoveMissingTenants::True));
+		    db, tokens[2], config.get().first.get(), defaultEntry, AddNewTenants::False, RemoveMissingTenants::True));
 
 		fmt::print("The cluster `{}' has been restored\n", printable(tokens[2]).c_str());
 		return true;
@@ -226,7 +213,7 @@ ACTOR Future<bool> metaclusterConfigureCommand(Reference<IDatabase> db, std::vec
 				throw cluster_not_found();
 			}
 
-			auto config = parseClusterConfiguration(tokens, metadata.get().entry, 3);
+			auto config = parseClusterConfiguration(tokens, metadata.get().entry, 3, tokens.size());
 			if (!config.present()) {
 				return false;
 			}
@@ -446,11 +433,10 @@ std::vector<const char*> metaclusterHintGenerator(std::vector<StringRef> const& 
 		} else {
 			return {};
 		}
-	} else if (tokencmp(tokens[1], "restore") && tokens.size() < 4) {
+	} else if (tokencmp(tokens[1], "restore") && tokens.size() < 5) {
 		static std::vector<const char*> opts = { "<NAME>",
 			                                     "connection_string=<CONNECTION_STRING> ",
-			                                     "<add_new_tenants=[true|false]>",
-			                                     "<remove_missing_tenants=[true|false]>" };
+			                                     "[repopulate_from_data_cluster]" };
 		return std::vector<const char*>(opts.begin() + tokens.size() - 2, opts.end());
 	} else if (tokencmp(tokens[1], "configure")) {
 		static std::vector<const char*> opts = {

--- a/fdbcli/MetaclusterCommands.actor.cpp
+++ b/fdbcli/MetaclusterCommands.actor.cpp
@@ -158,6 +158,75 @@ ACTOR Future<bool> metaclusterRemoveCommand(Reference<IDatabase> db, std::vector
 	return true;
 }
 
+Optional<std::string> parseToken(StringRef token, const char* str) {
+	bool foundEquals;
+	StringRef param = token.eat("=", &foundEquals);
+	if (!foundEquals) {
+		fmt::print(stderr,
+		           "ERROR: invalid configuration string `{}'. String must specify a value using `='.\n",
+		           param.toString().c_str());
+		return Optional<std::string>();
+	}
+
+	if (!tokencmp(param, str)) {
+		fmt::print(
+		    stderr, "ERROR: invalid configuration string `{}'. Expected: `{}'.\n", param.toString().c_str(), str);
+		return Optional<std::string>();
+	}
+
+	return Optional<std::string>(token.toString());
+}
+
+// metacluster restore command
+ACTOR Future<bool> metaclusterRestoreCommand(Reference<IDatabase> db, std::vector<StringRef> tokens) {
+	if (tokens.size() < 4 || tokens.size() > 6) {
+		fmt::print("Usage: metacluster restore <NAME> connection_string=<CONNECTION_STRING>\n"
+		           "[<add_new_tenants=[true|false]>|<remove_missing_tenants=[true|false]>]\n\n");
+		fmt::print("Restore a data cluster.\n");
+		return false;
+	}
+
+	state ClusterNameRef clusterName = tokens[3];
+
+	// connection string
+	ClusterConnectionString connectionString;
+	auto optVal = parseToken(tokens[4], "connection_string");
+	if (optVal.present()) {
+		connectionString = ClusterConnectionString(optVal.get());
+	}
+
+	AddNewTenants addNewTenants(AddNewTenants::True);
+	if (tokens.size() > 4) {
+		optVal = parseToken(tokens[4], "add_new_tenants");
+		if (optVal.present()) {
+			if (optVal.get() == "true") {
+				addNewTenants = AddNewTenants::True;
+			} else {
+				addNewTenants = AddNewTenants::False;
+			}
+		}
+	}
+
+	RemoveMissingTenants removeMissingTenants(RemoveMissingTenants::True);
+	if (tokens.size() > 5) {
+		optVal = parseToken(tokens[4], "remove_missing_tenants");
+		if (optVal.present()) {
+			if (optVal.get() == "true") {
+				removeMissingTenants = RemoveMissingTenants::True;
+			} else {
+				removeMissingTenants = RemoveMissingTenants::False;
+			}
+		}
+	}
+
+	DataClusterEntry defaultEntry;
+	wait(MetaclusterAPI::restoreCluster(
+	    db, clusterName, connectionString, defaultEntry, addNewTenants, removeMissingTenants));
+
+	fmt::print("The cluster `{}' has been restored\n", printable(clusterName).c_str());
+	return true;
+}
+
 // metacluster configure command
 ACTOR Future<bool> metaclusterConfigureCommand(Reference<IDatabase> db, std::vector<StringRef> tokens) {
 	if (tokens.size() < 4) {
@@ -343,6 +412,8 @@ Future<bool> metaclusterCommand(Reference<IDatabase> db, std::vector<StringRef> 
 		return metaclusterRegisterCommand(db, tokens);
 	} else if (tokencmp(tokens[1], "remove")) {
 		return metaclusterRemoveCommand(db, tokens);
+	} else if (tokencmp(tokens[1], "restore")) {
+		return metaclusterRestoreCommand(db, tokens);
 	} else if (tokencmp(tokens[1], "configure")) {
 		return metaclusterConfigureCommand(db, tokens);
 	} else if (tokencmp(tokens[1], "list")) {
@@ -362,9 +433,8 @@ void metaclusterGenerator(const char* text,
                           std::vector<std::string>& lc,
                           std::vector<StringRef> const& tokens) {
 	if (tokens.size() == 1) {
-		const char* opts[] = {
-			"create_experimental", "decommission", "register", "remove", "configure", "list", "get", "status", nullptr
-		};
+		const char* opts[] = { "create_experimental", "decommission", "register", "remove", "restore",
+			                   "configure",           "list",         "get",      "status", nullptr };
 		arrayGenerator(text, line, opts, lc);
 	} else if (tokens.size() > 1 && (tokencmp(tokens[1], "register") || tokencmp(tokens[1], "configure"))) {
 		const char* opts[] = { "max_tenant_groups=", "connection_string=", nullptr };
@@ -378,7 +448,7 @@ void metaclusterGenerator(const char* text,
 
 std::vector<const char*> metaclusterHintGenerator(std::vector<StringRef> const& tokens, bool inArgument) {
 	if (tokens.size() == 1) {
-		return { "<create_experimental|decommission|register|remove|configure|list|get|status>", "[ARGS]" };
+		return { "<create_experimental|decommission|register|remove|restore|configure|list|get|status>", "[ARGS]" };
 	} else if (tokencmp(tokens[1], "create_experimental")) {
 		return { "<NAME>" };
 	} else if (tokencmp(tokens[1], "decommission")) {
@@ -398,6 +468,12 @@ std::vector<const char*> metaclusterHintGenerator(std::vector<StringRef> const& 
 		} else {
 			return {};
 		}
+	} else if (tokencmp(tokens[1], "restore") && tokens.size() < 4) {
+		static std::vector<const char*> opts = { "<NAME>",
+			                                     "connection_string=<CONNECTION_STRING> ",
+			                                     "<add_new_tenants=[true|false]>",
+			                                     "<remove_missing_tenants=[true|false]>" };
+		return std::vector<const char*>(opts.begin() + tokens.size() - 2, opts.end());
 	} else if (tokencmp(tokens[1], "configure")) {
 		static std::vector<const char*> opts = {
 			"<NAME>", "<max_tenant_groups=<NUM_GROUPS>|connection_string=<CONNECTION_STRING>>"

--- a/fdbclient/include/fdbclient/MetaclusterManagement.actor.h
+++ b/fdbclient/include/fdbclient/MetaclusterManagement.actor.h
@@ -1096,9 +1096,7 @@ struct RestoreClusterImpl {
 			                      updatedEntry);
 		}
 
-		TraceEvent("MarkedDataClusterRestoring")
-		    .detail("Name", self->ctx.clusterName.get())
-		    .detail("Version", tr->getCommittedVersion());
+		TraceEvent("MarkedDataClusterRestoring").detail("Name", self->ctx.clusterName.get());
 
 		return true;
 	}
@@ -1182,39 +1180,46 @@ struct RestoreClusterImpl {
 		return gotAllTenants;
 	}
 
-	ACTOR static Future<bool> getTenantsFromManagementCluster(RestoreClusterImpl* self, Reference<ITransaction> tr) {
-		TenantNameRef begin = ""_sr;
+	ACTOR static Future<std::pair<bool, TenantName>> getTenantsFromManagementCluster(RestoreClusterImpl* self,
+	                                                                                 Reference<ITransaction> tr,
+	                                                                                 TenantName initialTenantName) {
+		TenantNameRef begin = initialTenantName;
 		TenantNameRef end = "\xff\xff"_sr;
 		state Future<KeyBackedRangeResult<std::pair<TenantName, TenantMapEntry>>> tenantsFuture =
 		    ManagementClusterMetadata::tenantMetadata().tenantMap.getRange(
 		        tr, begin, end, CLIENT_KNOBS->MAX_TENANTS_PER_CLUSTER);
 		state KeyBackedRangeResult<std::pair<TenantName, TenantMapEntry>> tenants = wait(tenantsFuture);
 
+		state TenantName lastTenantNameRetrieved;
 		if (!tenants.results.empty()) {
 			for (auto t : tenants.results) {
 				self->mgmtClusterTenantMap.emplace(t.first, t.second);
+				lastTenantNameRetrieved = t.first;
 			}
 		}
 
-		return !tenants.more;
+		return std::pair<bool, TenantName>{ !tenants.more, lastTenantNameRetrieved };
 	}
 
-	ACTOR static Future<bool> getTenantIdNameIndexFromManagementCluster(RestoreClusterImpl* self,
-	                                                                    Reference<ITransaction> tr) {
-		uint64_t begin = 0;
+	ACTOR static Future<std::pair<bool, uint64_t>> getTenantIdNameIndexFromManagementCluster(RestoreClusterImpl* self,
+	                                                                                         Reference<ITransaction> tr,
+	                                                                                         uint64_t initialTenantId) {
+		uint64_t begin = initialTenantId;
 		uint64_t end = std::numeric_limits<uint64_t>::max();
 		state Future<KeyBackedRangeResult<std::pair<int64_t, TenantName>>> tenantsFuture =
 		    ManagementClusterMetadata::tenantMetadata().tenantIdIndex.getRange(
 		        tr, begin, end, CLIENT_KNOBS->MAX_TENANTS_PER_CLUSTER);
 		state KeyBackedRangeResult<std::pair<int64_t, TenantName>> tenants = wait(tenantsFuture);
 
+		state uint64_t lastTenantIdRetrieved;
 		if (!tenants.results.empty()) {
 			for (auto t : tenants.results) {
 				self->mgmtClusterTenantIdIndex.emplace(t.first, t.second);
+				lastTenantIdRetrieved = t.first;
 			}
 		}
 
-		return !tenants.more;
+		return std::pair<bool, uint64_t>{ !tenants.more, lastTenantIdRetrieved };
 	}
 
 	ACTOR static Future<bool> getTenantsFromManagementClusterForCurrentDataCluster(RestoreClusterImpl* self,
@@ -1238,22 +1243,38 @@ struct RestoreClusterImpl {
 
 	ACTOR static Future<bool> getAllTenantsFromManagementCluster(RestoreClusterImpl* self) {
 		// get all tenants across all data clusters
-		bool gotAllTenants =
-		    wait(self->ctx.runManagementTransaction([self = self](Reference<typename DB::TransactionT> tr) {
-			    return getTenantsFromManagementCluster(self, tr);
-		    }));
+		state TenantName beginRangeTenantName = ""_sr;
+		loop {
+			TenantName initialTenantName = beginRangeTenantName;
+			std::pair<bool, TenantName> tenantsItr = wait(self->ctx.runManagementTransaction(
+			    [self = self, initialTenantName](Reference<typename DB::TransactionT> tr) {
+				    return getTenantsFromManagementCluster(self, tr, initialTenantName);
+			    }));
 
-		if (!gotAllTenants) {
-			return false;
+			if (tenantsItr.first) {
+				// retrieved all the tenants
+				break;
+			} else {
+				// begin range from this tenant
+				beginRangeTenantName = tenantsItr.second;
+			}
 		}
 
-		bool gotAllTenants =
-		    wait(self->ctx.runManagementTransaction([self = self](Reference<typename DB::TransactionT> tr) {
-			    return getTenantIdNameIndexFromManagementCluster(self, tr);
-		    }));
+		state uint64_t beginRangeTenantId = 0;
+		loop {
+			uint64_t initialTenantId = beginRangeTenantId;
+			std::pair<bool, uint64_t> tenantsItr = wait(self->ctx.runManagementTransaction(
+			    [self = self, initialTenantId](Reference<typename DB::TransactionT> tr) {
+				    return getTenantIdNameIndexFromManagementCluster(self, tr, initialTenantId);
+			    }));
 
-		if (!gotAllTenants) {
-			return false;
+			if (tenantsItr.first) {
+				// retrieved all the tenants
+				break;
+			} else {
+				// begin range from this tenantId
+				beginRangeTenantId = tenantsItr.second;
+			}
 		}
 
 		// get tenants for the specific data cluster

--- a/fdbclient/include/fdbclient/MetaclusterManagement.actor.h
+++ b/fdbclient/include/fdbclient/MetaclusterManagement.actor.h
@@ -21,6 +21,7 @@
 #pragma once
 #include "fdbclient/CoordinationInterface.h"
 #include "fdbclient/FDBOptions.g.h"
+#include "fdbrpc/TenantName.h"
 #include "flow/IRandom.h"
 #include "flow/ThreadHelper.actor.h"
 #if defined(NO_INTELLISENSE) && !defined(FDBCLIENT_METACLUSTER_MANAGEMENT_ACTOR_G_H)
@@ -544,6 +545,8 @@ void updateClusterMetadata(Transaction tr,
 	if (updatedEntry.present()) {
 		if (previousMetadata.entry.clusterState == DataClusterState::REMOVING) {
 			throw cluster_removed();
+		} else if (previousMetadata.entry.clusterState == DataClusterState::RESTORING) {
+			throw cluster_restored();
 		}
 		ManagementClusterMetadata::dataClusters().set(tr, name, updatedEntry.get());
 		updateClusterCapacityIndex(tr, name, previousMetadata.entry, updatedEntry.get());
@@ -1051,111 +1054,277 @@ Future<Void> managementClusterRemoveTenantFromGroup(Transaction tr,
 	return Void();
 }
 
-ACTOR template <class Transaction>
-Future<Optional<DataClusterEntry>> restoreClusterTransaction(Transaction tr,
-                                                             ClusterName name,
-                                                             ClusterConnectionString connectionString,
-                                                             DataClusterEntry entry,
-                                                             AddNewTenants addNewTenants,
-                                                             RemoveMissingTenants removeMissingTenants) {
-	tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
+template <class DB>
+struct RestoreCluterImpl {
+	MetaclusterOperationContext<DB> ctx;
 
-	// pre-checks
-	wait(TenantAPI::checkTenantMode(tr, ClusterType::METACLUSTER_MANAGEMENT));
+	// Initialization parameters
+	ClusterName clusterName;
+	ClusterConnectionString connectionString;
+	DataClusterEntry clusterEntry;
+	AddNewTenants addNewTenants;
+	RemoveMissingTenants removeMissingTenants;
 
-	state Optional<DataClusterEntry> clusterEntry = wait(ManagementClusterMetadata::dataClusters.get(tr, name));
-	if (!clusterEntry.present()) {
-		// end if metacluter does not already know about this data cluster.
-	}
+	TenantName lastTenantName;
+	ClusterName lastClusterName;
 
-	Reference<IDatabase> dataClusterDb = wait(openDatabase(connectionString));
-	state Reference<ITransaction> dataClusterTr = dataClusterDb->createTransaction();
+	std::unordered_map<TenantName, TenantMapEntry> dataClusterTenantMap;
+	std::unordered_map<TenantName, TenantMapEntry> mgmtClusterTenantMap;
+	std::unordered_set<TenantNameRef> mgmtTenantSet;
 
-	state Optional<MetaclusterRegistrationEntry> existingRegistration =
-	    wait(MetaclusterMetadata::metaclusterRegistration.get(tr));
+	std::vector<std::pair<TenantName, TenantMapEntry>> addList;
+	std::vector<TenantNameRef> removeList;
 
-	// get all tenants in the mgmt cluster
-	KeyBackedRangeResult<std::pair<TenantName, TenantMapEntry>> mgmtCluterTenantsFuture =
-	    wait(ManagementClusterMetadata::tenantMetadata.tenantMap.getRange(
-	        tr, ""_sr, "\xff\xff"_sr, CLIENT_KNOBS->MAX_DATA_CLUSTERS * CLIENT_KNOBS->MAX_TENANTS_PER_CLUSTER));
-	std::vector<std::pair<TenantName, TenantMapEntry>> mgmtClusterExistingTenants = mgmtCluterTenantsFuture.results;
-	// convert to map
-	state std::unordered_map<TenantName, TenantMapEntry> mgmtClusterTenantMap;
-	for (auto t : mgmtClusterExistingTenants) {
-		mgmtClusterTenantMap.emplace(t.first, t.second);
-	}
+	RestoreCluterImpl(Reference<DB> managementDb,
+	                  ClusterName clusterName,
+	                  ClusterConnectionString connectionString,
+	                  DataClusterEntry clusterEntry,
+	                  AddNewTenants addNewTenants,
+	                  RemoveMissingTenants removeMissingTenants)
+	  : ctx(managementDb, clusterName), clusterName(clusterName), connectionString(connectionString),
+	    clusterEntry(clusterEntry), addNewTenants(addNewTenants), removeMissingTenants(removeMissingTenants) {}
 
-	// get tenants for the specific data cluster in the mgmt cluster
-	state std::pair<Tuple, Tuple> clusterTupleRange =
-	    std::make_pair(Tuple::makeTuple(name), Tuple::makeTuple(keyAfter(name)));
-	state KeyBackedRangeResult<Tuple> tenantEntries = wait(ManagementClusterMetadata::clusterTenantIndex.getRange(
-	    tr, clusterTupleRange.first, clusterTupleRange.second, CLIENT_KNOBS->MAX_TENANTS_PER_CLUSTER));
-	state std::vector<Tuple> mgmtTenants = tenantEntries.results;
-	// convert to set
-	state std::unordered_set<TenantNameRef> mgmtTenantSet;
-	for (auto t : mgmtTenants) {
-		ASSERT(t.getString(0) == name);
-		mgmtTenantSet.insert(t.getString(1));
-	}
+	ACTOR static Future<bool> markClusterRestoring(RestoreCluterImpl* self, Reference<typename DB::TransactionT> tr) {
+		if (self->ctx.dataClusterMetadata.get().entry.clusterState != DataClusterState::RESTORING) {
+			DataClusterEntry updatedEntry = self->ctx.dataClusterMetadata.get().entry;
+			updatedEntry.clusterState = DataClusterState::RESTORING;
 
-	// get tenants from the restoring data cluster
-	state std::vector<std::pair<TenantName, TenantMapEntry>> dataClusterExistingTenants = wait(
-	    TenantAPI::listTenantsTransaction(dataClusterTr, ""_sr, "\xff\xff"_sr, CLIENT_KNOBS->MAX_TENANTS_PER_CLUSTER));
-	// convert to map
-	state std::unordered_map<TenantName, TenantMapEntry> dataClusterTenantMap;
-	for (auto t : dataClusterExistingTenants) {
-		dataClusterTenantMap.emplace(t.first, t.second);
-	}
-
-	for (std::pair<TenantName, TenantMapEntry> t : dataClusterExistingTenants) {
-		// Check to ensure that the tenant is not assigned to another data cluster
-		auto itr = mgmtClusterTenantMap.find(t.first);
-		if ((itr != mgmtClusterTenantMap.end()) && itr->second.assignedCluster.present() &&
-		    itr->second.assignedCluster.get() != name) {
-			// error, fail the restore
-			// set error
-			return Optional<DataClusterEntry>();
+			updateClusterMetadata(tr,
+			                      self->ctx.clusterName.get(),
+			                      self->ctx.dataClusterMetadata.get(),
+			                      Optional<ClusterConnectionString>(self->connectionString),
+			                      updatedEntry);
 		}
 
-		if (mgmtTenantSet.find(t.first) == mgmtTenantSet.end()) {
-			if (addNewTenants == AddNewTenants::True) {
-				// Add the tenant to the tenantmap
-				ManagementClusterMetadata::tenantMetadata.tenantMap.set(tr, t.first, t.second);
+		TraceEvent("MarkedDataClusterRestoring")
+		    .detail("Name", self->ctx.clusterName.get())
+		    .detail("Version", tr->getCommittedVersion());
 
-				// Add the tenant to the cluster -> tenant index
-				ManagementClusterMetadata::clusterTenantIndex.insert(tr, Tuple::makeTuple(name, t.first));
+		return true;
+	}
 
-				// Add to the tenant group
-				ManagementClusterMetadata::tenantMetadata.tenantGroupTenantIndex.insert(
-				    tr, Tuple::makeTuple(t.second.tenantGroup.get(), t.first));
-			} else {
-				// error
+	ACTOR static Future<Void> markClusterReady(RestoreCluterImpl* self, Reference<typename DB::TransactionT> tr) {
+		if (self->ctx.dataClusterMetadata.get().entry.clusterState == DataClusterState::RESTORING) {
+			DataClusterEntry updatedEntry = self->ctx.dataClusterMetadata.get().entry;
+			updatedEntry.clusterState = DataClusterState::READY;
+
+			updateClusterMetadata(tr,
+			                      self->ctx.clusterName.get(),
+			                      self->ctx.dataClusterMetadata.get(),
+			                      Optional<ClusterConnectionString>(self->connectionString),
+			                      updatedEntry);
+		}
+
+		TraceEvent("MarkedDataClusterReady")
+		    .detail("Name", self->ctx.clusterName.get())
+		    .detail("Version", tr->getCommittedVersion());
+
+		return Void();
+	}
+
+	ACTOR static Future<bool> getTenantsFromDataCluster(RestoreCluterImpl* self, Reference<ITransaction> tr) {
+		TenantNameRef begin = self->lastTenantName;
+		TenantNameRef end = "\xff\xff"_sr;
+		state Future<KeyBackedRangeResult<std::pair<TenantName, TenantMapEntry>>> tenantsFuture =
+		    TenantMetadata::tenantMap().getRange(tr, begin, end, CLIENT_KNOBS->MAX_TENANTS_PER_CLUSTER);
+		state KeyBackedRangeResult<std::pair<TenantName, TenantMapEntry>> tenants = wait(tenantsFuture);
+
+		if (!tenants.results.empty()) {
+			for (auto t : tenants.results) {
+				self->dataClusterTenantMap.emplace(t.first, t.second);
+				self->lastTenantName = t.first;
 			}
 		}
+
+		return !tenants.more;
 	}
 
-	for (Tuple t : mgmtTenants) {
-		state TenantNameRef tenantName = t.getString(1);
-		if (dataClusterTenantMap.find(tenantName) == dataClusterTenantMap.end()) {
-			if (removeMissingTenants == RemoveMissingTenants::True) {
-				// Erase the tenant from the tenantmap
-				ManagementClusterMetadata::tenantMetadata.tenantMap.erase(tr, tenantName);
+	ACTOR static Future<Void> getAllTenantsFromDataCluster(RestoreCluterImpl* self) {
+		loop {
+			bool gotAllTenants = wait(self->ctx.runDataClusterTransaction(
+			    [self = self](Reference<ITransaction> tr) { return getTenantsFromDataCluster(self, tr); }));
 
-				// Remove the tenant from the cluster -> tenant index
-				ManagementClusterMetadata::clusterTenantIndex.erase(tr, Tuple::makeTuple(name, tenantName));
-
-				// Remove from the tenant group
-				state TenantMapEntry tenantEntry = wait(getTenantTransaction(tr, tenantName));
-				state DataClusterMetadata clusterMetadata1 = wait(getClusterTransaction(tr, name));
-				wait(managementClusterRemoveTenantFromGroup(tr, tenantName, tenantEntry, &clusterMetadata1));
-			} else {
-				// error
+			if (gotAllTenants) {
+				break;
 			}
 		}
+
+		return Void();
 	}
 
-	return Optional<DataClusterEntry>(entry);
-}
+	ACTOR static Future<bool> getTenantsFromMgmtCluster(RestoreCluterImpl* self, Reference<ITransaction> tr) {
+		TenantNameRef begin = self->lastTenantName;
+		TenantNameRef end = "\xff\xff"_sr;
+		state Future<KeyBackedRangeResult<std::pair<TenantName, TenantMapEntry>>> tenantsFuture =
+		    ManagementClusterMetadata::tenantMetadata().tenantMap.getRange(
+		        tr, begin, end, CLIENT_KNOBS->MAX_TENANTS_PER_CLUSTER);
+		state KeyBackedRangeResult<std::pair<TenantName, TenantMapEntry>> tenants = wait(tenantsFuture);
+
+		if (!tenants.results.empty()) {
+			for (auto t : tenants.results) {
+				self->mgmtClusterTenantMap.emplace(t.first, t.second);
+				self->lastTenantName = t.first;
+			}
+		}
+
+		return !tenants.more;
+	}
+
+	ACTOR static Future<bool> getTenantsFromMgmtClusterForCurrentDataCluster(RestoreCluterImpl* self,
+	                                                                         Reference<ITransaction> tr) {
+		std::pair<Tuple, Tuple> clusterTupleRange =
+		    std::make_pair(Tuple::makeTuple(self->lastClusterName), Tuple::makeTuple(keyAfter(self->clusterName)));
+		state Future<KeyBackedRangeResult<Tuple>> tenantEntriesFuture =
+		    ManagementClusterMetadata::clusterTenantIndex.getRange(
+		        tr, clusterTupleRange.first, clusterTupleRange.second, CLIENT_KNOBS->MAX_TENANTS_PER_CLUSTER);
+		state KeyBackedRangeResult<Tuple> tenantEntries = wait(tenantEntriesFuture);
+
+		if (!tenantEntries.results.empty()) {
+			for (auto t : tenantEntries.results) {
+				ASSERT(t.getString(0) == self->clusterName);
+				self->mgmtTenantSet.insert(t.getString(1));
+				// fix this ... not correct
+				self->lastClusterName = t.getString(0);
+			}
+		}
+
+		return !tenantEntries.more;
+	}
+
+	ACTOR static Future<Void> getAllTenantsFromMgmtCluster(RestoreCluterImpl* self) {
+		// get all tenants across all data clusters
+		self->lastClusterName = self->clusterName;
+		loop {
+			bool gotAllTenants =
+			    wait(self->ctx.runManagementTransaction([self = self](Reference<typename DB::TransactionT> tr) {
+				    return getTenantsFromMgmtCluster(self, tr);
+			    }));
+
+			if (gotAllTenants) {
+				break;
+			}
+		}
+
+		// get tenants for the specific data cluster
+		loop {
+			bool gotAllTenants =
+			    wait(self->ctx.runManagementTransaction([self = self](Reference<typename DB::TransactionT> tr) {
+				    return getTenantsFromMgmtClusterForCurrentDataCluster(self, tr);
+			    }));
+
+			if (gotAllTenants) {
+				break;
+			}
+		}
+
+		return Void();
+	}
+
+	ACTOR static Future<Void> addTenants(RestoreCluterImpl* self, Reference<typename DB::TransactionT> tr) {
+		for (auto t : self->addList) {
+			// Add the tenant to the tenantmap
+			ManagementClusterMetadata::tenantMetadata().tenantMap.set(tr, t.first, t.second);
+			// Add the tenant to the cluster -> tenant index
+			ManagementClusterMetadata::clusterTenantIndex.insert(tr, Tuple::makeTuple(self->clusterName, t.first));
+			// Add to the tenant group
+			ManagementClusterMetadata::tenantMetadata().tenantGroupTenantIndex.insert(
+			    tr, Tuple::makeTuple(t.second.tenantGroup.get(), t.first));
+		}
+
+		return Void();
+	}
+
+	ACTOR static Future<Void> removeTenants(RestoreCluterImpl* self, Reference<typename DB::TransactionT> tr) {
+		for (auto t : self->removeList) {
+			// Erase the tenant from the tenantmap
+			ManagementClusterMetadata::tenantMetadata().tenantMap.erase(tr, t);
+			// Remove the tenant from the cluster -> tenant index
+			ManagementClusterMetadata::clusterTenantIndex.erase(tr, Tuple::makeTuple(self->clusterName, t));
+		}
+
+		return Void();
+	}
+
+	ACTOR static Future<Void> run(RestoreCluterImpl* self) {
+		state bool clusterIsPresent;
+		// set state to restoring
+		try {
+			wait(store(clusterIsPresent,
+			           self->ctx.runManagementTransaction([self = self](Reference<typename DB::TransactionT> tr) {
+				           return markClusterRestoring(self, tr);
+			           })));
+		} catch (Error& e) {
+			// If the transaction retries after success or if we are trying a second time to restore the cluster, it
+			// will throw an error indicating that the restore has already started
+			if (e.code() == error_code_cluster_restored) {
+				clusterIsPresent = true;
+			} else {
+				throw;
+			}
+		}
+
+		if (clusterIsPresent) {
+			// get all the tenant information from the new data cluster
+			wait(getAllTenantsFromDataCluster(self));
+			// get all the tenant information for this data cluster from mgmt cluster
+			wait(getAllTenantsFromMgmtCluster(self));
+			// compare and build the add list and remove list
+
+			for (std::pair<TenantName, TenantMapEntry> t : self->dataClusterTenantMap) {
+				// Check to ensure that the tenant is not assigned to another data cluster
+				auto itr = self->mgmtClusterTenantMap.find(t.first);
+				if ((itr != self->mgmtClusterTenantMap.end()) && itr->second.assignedCluster.present() &&
+				    itr->second.assignedCluster.get() != self->clusterName) {
+					// error, fail the restore
+					// set error
+					// throw;
+				}
+
+				// build add list
+				if (self->mgmtTenantSet.find(t.first) == self->mgmtTenantSet.end()) {
+					if (self->addNewTenants == AddNewTenants::True) {
+						self->addList.push_back(t);
+					} else {
+						// error
+						// throw;
+					}
+				}
+			}
+
+			for (TenantNameRef t : self->mgmtTenantSet) {
+				if (self->dataClusterTenantMap.find(t) == self->dataClusterTenantMap.end()) {
+					if (self->removeMissingTenants == RemoveMissingTenants::True) {
+						self->removeList.push_back(t);
+					} else {
+						// error
+						// throw;
+					}
+				}
+			}
+
+			try {
+				wait(self->ctx.runManagementTransaction(
+				    [self = self](Reference<typename DB::TransactionT> tr) { return addTenants(self, tr); }));
+				wait(self->ctx.runManagementTransaction(
+				    [self = self](Reference<typename DB::TransactionT> tr) { return removeTenants(self, tr); }));
+			} catch (Error& e) {
+				throw;
+			}
+
+			// set to ready state
+			try {
+				wait(self->ctx.runManagementTransaction(
+				    [self = self](Reference<typename DB::TransactionT> tr) { return markClusterReady(self, tr); }));
+			} catch (Error& e) {
+				throw;
+			}
+		}
+
+		return Void();
+	}
+
+	Future<Void> run() { return run(this); }
+};
 
 ACTOR template <class DB>
 Future<Void> restoreCluster(Reference<DB> db,
@@ -1164,29 +1333,9 @@ Future<Void> restoreCluster(Reference<DB> db,
                             DataClusterEntry entry,
                             AddNewTenants addNewTenants,
                             RemoveMissingTenants removeMissingTenants) {
-	if (name.startsWith("\xff"_sr)) {
-		throw invalid_cluster_name();
-	}
-
-	state Reference<typename DB::TransactionT> tr = db->createTransaction();
-
-	loop {
-		try {
-			state Optional<DataClusterEntry> newCluster =
-			    wait(restoreClusterTransaction(tr, name, connectionString, entry, addNewTenants, removeMissingTenants));
-
-			wait(buggifiedCommit(tr, BUGGIFY));
-
-			TraceEvent("RestoredDataCluster")
-			    .detail("ClusterName", name)
-			    .detail("ClusterId", newCluster.present() ? newCluster.get().id : UID())
-			    .detail("Version", tr->getCommittedVersion());
-
-			return Void();
-		} catch (Error& e) {
-			wait(safeThreadFutureToFuture(tr->onError(e)));
-		}
-	}
+	state RestoreCluterImpl<DB> impl(db, name, connectionString, entry, addNewTenants, removeMissingTenants);
+	wait(impl.run());
+	return Void();
 }
 
 template <class DB>
@@ -1376,6 +1525,8 @@ struct CreateTenantImpl {
 		// then we fail with an error.
 		if (self->ctx.dataClusterMetadata.get().entry.clusterState == DataClusterState::REMOVING) {
 			throw cluster_removed();
+		} else if (self->ctx.dataClusterMetadata.get().entry.clusterState == DataClusterState::RESTORING) {
+			throw cluster_restored();
 		}
 
 		managementClusterAddTenantToGroup(

--- a/fdbclient/include/fdbclient/MetaclusterManagement.actor.h
+++ b/fdbclient/include/fdbclient/MetaclusterManagement.actor.h
@@ -22,6 +22,7 @@
 #include "fdbclient/CoordinationInterface.h"
 #include "fdbclient/FDBOptions.g.h"
 #include "fdbrpc/TenantName.h"
+#include "flow/FastRef.h"
 #include "flow/IRandom.h"
 #include "flow/ThreadHelper.actor.h"
 #if defined(NO_INTELLISENSE) && !defined(FDBCLIENT_METACLUSTER_MANAGEMENT_ACTOR_G_H)
@@ -1065,15 +1066,17 @@ struct RestoreClusterImpl {
 	AddNewTenants addNewTenants;
 	RemoveMissingTenants removeMissingTenants;
 
+	// Variables to track state during restore
 	TenantName lastTenantName;
 	ClusterName lastClusterName;
+	uint64_t tenantId;
+	TenantName tenantName;
+	TenantName tenantNewName;
 
+	// Tenant list from data and management clusters.
 	std::unordered_map<TenantName, TenantMapEntry> dataClusterTenantMap;
 	std::unordered_map<TenantName, TenantMapEntry> mgmtClusterTenantMap;
 	std::unordered_set<TenantNameRef> mgmtTenantSet;
-
-	std::vector<std::pair<TenantName, TenantMapEntry>> addList;
-	std::vector<TenantNameRef> removeList;
 
 	RestoreClusterImpl(Reference<DB> managementDb,
 	                   ClusterName clusterName,
@@ -1084,7 +1087,8 @@ struct RestoreClusterImpl {
 	  : ctx(managementDb, clusterName), clusterName(clusterName), connectionString(connectionString),
 	    clusterEntry(clusterEntry), addNewTenants(addNewTenants), removeMissingTenants(removeMissingTenants) {}
 
-	ACTOR static Future<bool> markClusterRestoring(RestoreClusterImpl* self, Reference<typename DB::TransactionT> tr) {
+	ACTOR static Future<bool> markClusterAsRestoring(RestoreClusterImpl* self,
+	                                                 Reference<typename DB::TransactionT> tr) {
 		if (self->ctx.dataClusterMetadata.get().entry.clusterState != DataClusterState::RESTORING) {
 			DataClusterEntry updatedEntry = self->ctx.dataClusterMetadata.get().entry;
 			updatedEntry.clusterState = DataClusterState::RESTORING;
@@ -1103,7 +1107,7 @@ struct RestoreClusterImpl {
 		return true;
 	}
 
-	ACTOR static Future<Void> markClusterReady(RestoreClusterImpl* self, Reference<typename DB::TransactionT> tr) {
+	ACTOR static Future<Void> markClusterAsReady(RestoreClusterImpl* self, Reference<typename DB::TransactionT> tr) {
 		if (self->ctx.dataClusterMetadata.get().entry.clusterState == DataClusterState::RESTORING) {
 			DataClusterEntry updatedEntry = self->ctx.dataClusterMetadata.get().entry;
 			updatedEntry.clusterState = DataClusterState::READY;
@@ -1119,6 +1123,19 @@ struct RestoreClusterImpl {
 		    .detail("Name", self->ctx.clusterName.get())
 		    .detail("Version", tr->getCommittedVersion());
 
+		return Void();
+	}
+
+	ACTOR static Future<Void> markManagementTenantAsError(RestoreClusterImpl* self,
+	                                                      Reference<typename DB::TransactionT> tr) {
+		state Optional<TenantMapEntry> tenantEntry = wait(tryGetTenantTransaction(tr, self->tenantName));
+
+		if (!tenantEntry.present()) {
+			return Void();
+		}
+
+		tenantEntry.get().tenantState = TenantState::ERROR;
+		ManagementClusterMetadata::tenantMetadata().tenantMap.set(tr, self->tenantName, tenantEntry.get());
 		return Void();
 	}
 
@@ -1152,7 +1169,7 @@ struct RestoreClusterImpl {
 		return Void();
 	}
 
-	ACTOR static Future<bool> getTenantsFromMgmtCluster(RestoreClusterImpl* self, Reference<ITransaction> tr) {
+	ACTOR static Future<bool> getTenantsFromManagementCluster(RestoreClusterImpl* self, Reference<ITransaction> tr) {
 		TenantNameRef begin = self->lastTenantName;
 		TenantNameRef end = "\xff\xff"_sr;
 		state Future<KeyBackedRangeResult<std::pair<TenantName, TenantMapEntry>>> tenantsFuture =
@@ -1170,8 +1187,8 @@ struct RestoreClusterImpl {
 		return !tenants.more;
 	}
 
-	ACTOR static Future<bool> getTenantsFromMgmtClusterForCurrentDataCluster(RestoreClusterImpl* self,
-	                                                                         Reference<ITransaction> tr) {
+	ACTOR static Future<bool> getTenantsFromManagementClusterForCurrentDataCluster(RestoreClusterImpl* self,
+	                                                                               Reference<ITransaction> tr) {
 		std::pair<Tuple, Tuple> clusterTupleRange =
 		    std::make_pair(Tuple::makeTuple(self->lastClusterName), Tuple::makeTuple(keyAfter(self->clusterName)));
 		state Future<KeyBackedRangeResult<Tuple>> tenantEntriesFuture =
@@ -1191,13 +1208,13 @@ struct RestoreClusterImpl {
 		return !tenantEntries.more;
 	}
 
-	ACTOR static Future<Void> getAllTenantsFromMgmtCluster(RestoreClusterImpl* self) {
+	ACTOR static Future<Void> getAllTenantsFromManagementCluster(RestoreClusterImpl* self) {
 		// get all tenants across all data clusters
 		self->lastClusterName = self->clusterName;
 		loop {
 			bool gotAllTenants =
 			    wait(self->ctx.runManagementTransaction([self = self](Reference<typename DB::TransactionT> tr) {
-				    return getTenantsFromMgmtCluster(self, tr);
+				    return getTenantsFromManagementCluster(self, tr);
 			    }));
 
 			if (gotAllTenants) {
@@ -1209,7 +1226,7 @@ struct RestoreClusterImpl {
 		loop {
 			bool gotAllTenants =
 			    wait(self->ctx.runManagementTransaction([self = self](Reference<typename DB::TransactionT> tr) {
-				    return getTenantsFromMgmtClusterForCurrentDataCluster(self, tr);
+				    return getTenantsFromManagementClusterForCurrentDataCluster(self, tr);
 			    }));
 
 			if (gotAllTenants) {
@@ -1220,101 +1237,110 @@ struct RestoreClusterImpl {
 		return Void();
 	}
 
-	ACTOR static Future<Void> addTenants(RestoreClusterImpl* self, Reference<typename DB::TransactionT> tr) {
-		for (auto t : self->addList) {
-			// Add the tenant to the tenantmap
-			ManagementClusterMetadata::tenantMetadata().tenantMap.set(tr, t.first, t.second);
-			// Add the tenant to the cluster -> tenant index
-			ManagementClusterMetadata::clusterTenantIndex.insert(tr, Tuple::makeTuple(self->clusterName, t.first));
-			// Add to the tenant group
-			ManagementClusterMetadata::tenantMetadata().tenantGroupTenantIndex.insert(
-			    tr, Tuple::makeTuple(t.second.tenantGroup.get(), t.first));
-		}
+	ACTOR static Future<Optional<TenantName>> lookupTenantInManagementClusterById(RestoreClusterImpl* self) {
+		Optional<TenantName> tenantName =
+		    wait(self->ctx.runManagementTransaction([self = self](Reference<typename DB::TransactionT> tr) {
+			    return ManagementClusterMetadata::tenantMetadata().tenantIdIndex.get(tr, self->tenantId);
+		    }));
 
+		return tenantName;
+	}
+
+	ACTOR static Future<Optional<TenantName>> lookupTenantInDataClusterById(RestoreClusterImpl* self) {
+		Optional<TenantName> tenantName =
+		    wait(self->ctx.runDataClusterTransaction([self = self](Reference<ITransaction> tr) {
+			    return TenantMetadata::tenantIdIndex().get(tr, self->tenantId);
+		    }));
+
+		return tenantName;
+	}
+
+	ACTOR static Future<Void> renameTenantOnDataCluster(RestoreClusterImpl* self) {
+		ASSERT(self->tenantId != -1);
+		wait(self->ctx.runDataClusterTransaction([self = self](Reference<ITransaction> tr) {
+			return TenantAPI::renameTenantTransaction(
+			    tr, self->tenantName, self->tenantNewName, self->tenantId, ClusterType::METACLUSTER_DATA);
+		}));
 		return Void();
 	}
 
-	ACTOR static Future<Void> removeTenants(RestoreClusterImpl* self, Reference<typename DB::TransactionT> tr) {
-		for (auto t : self->removeList) {
-			// Erase the tenant from the tenantmap
-			ManagementClusterMetadata::tenantMetadata().tenantMap.erase(tr, t);
-			// Remove the tenant from the cluster -> tenant index
-			ManagementClusterMetadata::clusterTenantIndex.erase(tr, Tuple::makeTuple(self->clusterName, t));
-		}
-
+	ACTOR static Future<Void> removeTenantFromDataCluster(RestoreClusterImpl* self) {
+		wait(self->ctx.runDataClusterTransaction([self = self](Reference<ITransaction> tr) {
+			return TenantAPI::deleteTenantTransaction(
+			    tr, self->tenantName, self->tenantId, ClusterType::METACLUSTER_DATA);
+		}));
 		return Void();
 	}
 
+	// This only supports the restore of an already registered data cluster, for now.
 	ACTOR static Future<Void> run(RestoreClusterImpl* self) {
-		state bool clusterIsPresent;
+		state bool clusterIsRestoring;
 		// set state to restoring
 		try {
-			wait(store(clusterIsPresent,
+			wait(store(clusterIsRestoring,
 			           self->ctx.runManagementTransaction([self = self](Reference<typename DB::TransactionT> tr) {
-				           return markClusterRestoring(self, tr);
+				           return markClusterAsRestoring(self, tr);
 			           })));
 		} catch (Error& e) {
 			// If the transaction retries after success or if we are trying a second time to restore the cluster, it
 			// will throw an error indicating that the restore has already started
 			if (e.code() == error_code_cluster_restored) {
-				clusterIsPresent = true;
+				clusterIsRestoring = true;
 			} else {
 				throw;
 			}
 		}
 
-		if (clusterIsPresent) {
-			// get all the tenant information from the new data cluster
+		if (!clusterIsRestoring) {
+			// get all the tenant information from the newly registered data cluster
 			wait(getAllTenantsFromDataCluster(self));
-			// get all the tenant information for this data cluster from mgmt cluster
-			wait(getAllTenantsFromMgmtCluster(self));
-			// compare and build the add list and remove list
+			// get all the tenant information for this data cluster from manangement cluster
+			wait(getAllTenantsFromManagementCluster(self));
 
-			for (std::pair<TenantName, TenantMapEntry> t : self->dataClusterTenantMap) {
-				// Check to ensure that the tenant is not assigned to another data cluster
-				auto itr = self->mgmtClusterTenantMap.find(t.first);
-				if ((itr != self->mgmtClusterTenantMap.end()) && itr->second.assignedCluster.present() &&
-				    itr->second.assignedCluster.get() != self->clusterName) {
-					// error, fail the restore
-					// set error
-					// throw;
-				}
+			state std::unordered_map<TenantName, TenantMapEntry>::iterator itr = self->dataClusterTenantMap.begin();
+			while (itr != self->dataClusterTenantMap.end()) {
 
-				// build add list
-				if (self->mgmtTenantSet.find(t.first) == self->mgmtTenantSet.end()) {
-					if (self->addNewTenants == AddNewTenants::True) {
-						self->addList.push_back(t);
-					} else {
-						// error
-						// throw;
-					}
-				}
-			}
+				state TenantName tenantNameOnDataCluster = itr->first;
+				state uint64_t tenantId = (itr->second).id;
+				self->tenantId = tenantId;
+				self->tenantName = tenantNameOnDataCluster;
 
-			for (TenantNameRef t : self->mgmtTenantSet) {
-				if (self->dataClusterTenantMap.find(t) == self->dataClusterTenantMap.end()) {
+				state Optional<TenantName> tenantNameOnMgmtCluster = wait(lookupTenantInManagementClusterById(self));
+				if (!tenantNameOnMgmtCluster.present()) {
+					// A tenant with this id is not found on the mgmt cluster.
 					if (self->removeMissingTenants == RemoveMissingTenants::True) {
-						self->removeList.push_back(t);
-					} else {
-						// error
-						// throw;
+						wait(removeTenantFromDataCluster(self));
+					}
+				} else {
+					// A tenant with this id is found on the manangement cluster.
+					if (tenantNameOnDataCluster.compare(tenantNameOnMgmtCluster.get()) != 0) {
+						// renamed
+						self->tenantNewName = tenantNameOnMgmtCluster.get();
+						wait(renameTenantOnDataCluster(self));
 					}
 				}
+
+				++itr;
 			}
 
-			try {
-				wait(self->ctx.runManagementTransaction(
-				    [self = self](Reference<typename DB::TransactionT> tr) { return addTenants(self, tr); }));
-				wait(self->ctx.runManagementTransaction(
-				    [self = self](Reference<typename DB::TransactionT> tr) { return removeTenants(self, tr); }));
-			} catch (Error& e) {
-				throw;
+			state std::unordered_set<TenantNameRef>::iterator setItr = self->mgmtTenantSet.begin();
+			while (setItr != self->mgmtTenantSet.end()) {
+				self->tenantId = self->mgmtClusterTenantMap[*setItr].id;
+				state Optional<TenantName> tNameOnDataCluster = wait(lookupTenantInDataClusterById(self));
+
+				if (!tNameOnDataCluster.present()) {
+					// Set Tenant in ERROR state
+					wait(self->ctx.runManagementTransaction([self = self](Reference<typename DB::TransactionT> tr) {
+						return markManagementTenantAsError(self, tr);
+					}));
+				}
+				++setItr;
 			}
 
-			// set to ready state
+			// set restored cluster to ready state
 			try {
 				wait(self->ctx.runManagementTransaction(
-				    [self = self](Reference<typename DB::TransactionT> tr) { return markClusterReady(self, tr); }));
+				    [self = self](Reference<typename DB::TransactionT> tr) { return markClusterAsReady(self, tr); }));
 			} catch (Error& e) {
 				throw;
 			}
@@ -1389,9 +1415,9 @@ struct CreateTenantImpl {
 				wait(self->ctx.setCluster(tr, existingEntry.get().assignedCluster.get()));
 				return true;
 			} else {
-				// The previous creation is permanently failed, so cleanup the tenant and create it again from scratch
-				// We don't need to remove it from the tenant map because we will overwrite the existing entry later in
-				// this transaction.
+				// The previous creation is permanently failed, so cleanup the tenant and create it again from
+				// scratch We don't need to remove it from the tenant map because we will overwrite the existing
+				// entry later in this transaction.
 				ManagementClusterMetadata::tenantMetadata().tenantIdIndex.erase(tr, existingEntry.get().id);
 				ManagementClusterMetadata::tenantMetadata().tenantCount.atomicOp(tr, -1, MutationRef::AddValue);
 				ManagementClusterMetadata::clusterTenantCount.atomicOp(

--- a/fdbclient/include/fdbclient/MetaclusterManagement.actor.h
+++ b/fdbclient/include/fdbclient/MetaclusterManagement.actor.h
@@ -548,7 +548,7 @@ void updateClusterMetadata(Transaction tr,
 		if (previousMetadata.entry.clusterState == DataClusterState::REMOVING) {
 			throw cluster_removed();
 		} else if (previousMetadata.entry.clusterState == DataClusterState::RESTORING) {
-			throw cluster_restored();
+			throw cluster_restoring();
 		}
 		ManagementClusterMetadata::dataClusters().set(tr, name, updatedEntry.get());
 		updateClusterCapacityIndex(tr, name, previousMetadata.entry, updatedEntry.get());
@@ -1327,7 +1327,7 @@ struct RestoreClusterImpl {
 		} catch (Error& e) {
 			// If the transaction retries after success or if we are trying a second time to restore the cluster, it
 			// will throw an error indicating that the restore has already started
-			if (e.code() == error_code_cluster_restored) {
+			if (e.code() == error_code_cluster_restoring) {
 				clusterIsRestoring = true;
 			} else {
 				throw;
@@ -1590,7 +1590,7 @@ struct CreateTenantImpl {
 		if (self->ctx.dataClusterMetadata.get().entry.clusterState == DataClusterState::REMOVING) {
 			throw cluster_removed();
 		} else if (self->ctx.dataClusterMetadata.get().entry.clusterState == DataClusterState::RESTORING) {
-			throw cluster_restored();
+			throw cluster_restoring();
 		}
 
 		managementClusterAddTenantToGroup(

--- a/fdbclient/include/fdbclient/MetaclusterManagement.actor.h
+++ b/fdbclient/include/fdbclient/MetaclusterManagement.actor.h
@@ -1140,10 +1140,8 @@ struct RestoreClusterImpl {
 		    TenantMetadata::tenantMap().getRange(tr, begin, end, CLIENT_KNOBS->MAX_TENANTS_PER_CLUSTER);
 		state KeyBackedRangeResult<std::pair<TenantName, TenantMapEntry>> tenants = wait(tenantsFuture);
 
-		if (!tenants.results.empty()) {
-			for (auto t : tenants.results) {
-				self->dataClusterTenantMap.emplace(t.first, t.second);
-			}
+		for (auto t : tenants.results) {
+			self->dataClusterTenantMap.emplace(t.first, t.second);
 		}
 
 		return !tenants.more;
@@ -1157,10 +1155,8 @@ struct RestoreClusterImpl {
 		    TenantMetadata::tenantIdIndex().getRange(tr, begin, end, CLIENT_KNOBS->MAX_TENANTS_PER_CLUSTER);
 		state KeyBackedRangeResult<std::pair<int64_t, TenantName>> tenants = wait(tenantsFuture);
 
-		if (!tenants.results.empty()) {
-			for (auto t : tenants.results) {
-				self->dataClusterTenantIdIndex.emplace(t.first, t.second);
-			}
+		for (auto t : tenants.results) {
+			self->dataClusterTenantIdIndex.emplace(t.first, t.second);
 		}
 
 		return !tenants.more;
@@ -1191,11 +1187,9 @@ struct RestoreClusterImpl {
 		state KeyBackedRangeResult<std::pair<TenantName, TenantMapEntry>> tenants = wait(tenantsFuture);
 
 		state TenantName lastTenantNameRetrieved;
-		if (!tenants.results.empty()) {
-			for (auto t : tenants.results) {
-				self->mgmtClusterTenantMap.emplace(t.first, t.second);
-				lastTenantNameRetrieved = t.first;
-			}
+		for (auto t : tenants.results) {
+			self->mgmtClusterTenantMap.emplace(t.first, t.second);
+			lastTenantNameRetrieved = t.first;
 		}
 
 		return std::pair<bool, TenantName>{ !tenants.more, lastTenantNameRetrieved };
@@ -1212,11 +1206,9 @@ struct RestoreClusterImpl {
 		state KeyBackedRangeResult<std::pair<int64_t, TenantName>> tenants = wait(tenantsFuture);
 
 		state uint64_t lastTenantIdRetrieved;
-		if (!tenants.results.empty()) {
-			for (auto t : tenants.results) {
-				self->mgmtClusterTenantIdIndex.emplace(t.first, t.second);
-				lastTenantIdRetrieved = t.first;
-			}
+		for (auto t : tenants.results) {
+			self->mgmtClusterTenantIdIndex.emplace(t.first, t.second);
+			lastTenantIdRetrieved = t.first;
 		}
 
 		return std::pair<bool, uint64_t>{ !tenants.more, lastTenantIdRetrieved };
@@ -1231,11 +1223,9 @@ struct RestoreClusterImpl {
 		        tr, clusterTupleRange.first, clusterTupleRange.second, CLIENT_KNOBS->MAX_TENANTS_PER_CLUSTER);
 		state KeyBackedRangeResult<Tuple> tenantEntries = wait(tenantEntriesFuture);
 
-		if (!tenantEntries.results.empty()) {
-			for (auto t : tenantEntries.results) {
-				ASSERT(t.getString(0) == self->clusterName);
-				self->mgmtTenantSet.insert(t.getString(1));
-			}
+		for (auto t : tenantEntries.results) {
+			ASSERT(t.getString(0) == self->clusterName);
+			self->mgmtTenantSet.insert(t.getString(1));
 		}
 
 		return !tenantEntries.more;
@@ -1256,7 +1246,7 @@ struct RestoreClusterImpl {
 				break;
 			} else {
 				// begin range from this tenant
-				beginRangeTenantName = tenantsItr.second;
+				beginRangeTenantName = keyAfter(tenantsItr.second);
 			}
 		}
 
@@ -1273,7 +1263,7 @@ struct RestoreClusterImpl {
 				break;
 			} else {
 				// begin range from this tenantId
-				beginRangeTenantId = tenantsItr.second;
+				beginRangeTenantId = tenantsItr.second + 1;
 			}
 		}
 

--- a/fdbclient/include/fdbclient/MetaclusterManagement.actor.h
+++ b/fdbclient/include/fdbclient/MetaclusterManagement.actor.h
@@ -1069,10 +1069,10 @@ struct RestoreClusterImpl {
 
 	// Tenant list from data and management clusters.
 	std::unordered_map<TenantName, TenantMapEntry> dataClusterTenantMap;
-	std::unordered_map<uint64_t, TenantName> dataClusterTenantIdIndex;
+	std::unordered_set<uint64_t> dataClusterTenantIdSet;
 	std::unordered_map<TenantName, TenantMapEntry> mgmtClusterTenantMap;
 	std::unordered_map<uint64_t, TenantName> mgmtClusterTenantIdIndex;
-	std::unordered_set<TenantNameRef> mgmtTenantSet;
+	std::unordered_set<TenantName> mgmtClusterTenantSetForCurrentDataCluster;
 
 	RestoreClusterImpl(Reference<DB> managementDb,
 	                   ClusterName clusterName,
@@ -1134,7 +1134,7 @@ struct RestoreClusterImpl {
 	}
 
 	ACTOR static Future<bool> getTenantsFromDataCluster(RestoreClusterImpl* self, Reference<ITransaction> tr) {
-		TenantNameRef begin = self->clusterName;
+		TenantNameRef begin = ""_sr;
 		TenantNameRef end = "\xff\xff"_sr;
 		state Future<KeyBackedRangeResult<std::pair<TenantName, TenantMapEntry>>> tenantsFuture =
 		    TenantMetadata::tenantMap().getRange(tr, begin, end, CLIENT_KNOBS->MAX_TENANTS_PER_CLUSTER);
@@ -1142,21 +1142,7 @@ struct RestoreClusterImpl {
 
 		for (auto t : tenants.results) {
 			self->dataClusterTenantMap.emplace(t.first, t.second);
-		}
-
-		return !tenants.more;
-	}
-
-	ACTOR static Future<bool> getTenantIdNameIndexFromDataCluster(RestoreClusterImpl* self,
-	                                                              Reference<ITransaction> tr) {
-		uint64_t begin = 0;
-		uint64_t end = std::numeric_limits<uint64_t>::max();
-		state Future<KeyBackedRangeResult<std::pair<int64_t, TenantName>>> tenantsFuture =
-		    TenantMetadata::tenantIdIndex().getRange(tr, begin, end, CLIENT_KNOBS->MAX_TENANTS_PER_CLUSTER);
-		state KeyBackedRangeResult<std::pair<int64_t, TenantName>> tenants = wait(tenantsFuture);
-
-		for (auto t : tenants.results) {
-			self->dataClusterTenantIdIndex.emplace(t.first, t.second);
+			self->dataClusterTenantIdSet.emplace(t.second.id);
 		}
 
 		return !tenants.more;
@@ -1165,13 +1151,6 @@ struct RestoreClusterImpl {
 	ACTOR static Future<bool> getAllTenantsFromDataCluster(RestoreClusterImpl* self) {
 		bool gotAllTenants = wait(self->ctx.runDataClusterTransaction(
 		    [self = self](Reference<ITransaction> tr) { return getTenantsFromDataCluster(self, tr); }));
-
-		if (!gotAllTenants) {
-			return false;
-		}
-
-		bool gotAllTenants = wait(self->ctx.runDataClusterTransaction(
-		    [self = self](Reference<ITransaction> tr) { return getTenantIdNameIndexFromDataCluster(self, tr); }));
 
 		return gotAllTenants;
 	}
@@ -1189,49 +1168,18 @@ struct RestoreClusterImpl {
 		state TenantName lastTenantNameRetrieved;
 		for (auto t : tenants.results) {
 			self->mgmtClusterTenantMap.emplace(t.first, t.second);
+			self->mgmtClusterTenantIdIndex.emplace(t.second.id, t.first);
+			if (t.second.assignedCluster.present() && self->clusterName.compare(t.second.assignedCluster.get()) == 0) {
+				self->mgmtClusterTenantSetForCurrentDataCluster.emplace(t.first);
+			}
+
 			lastTenantNameRetrieved = t.first;
 		}
 
 		return std::pair<bool, TenantName>{ !tenants.more, lastTenantNameRetrieved };
 	}
 
-	ACTOR static Future<std::pair<bool, uint64_t>> getTenantIdNameIndexFromManagementCluster(RestoreClusterImpl* self,
-	                                                                                         Reference<ITransaction> tr,
-	                                                                                         uint64_t initialTenantId) {
-		uint64_t begin = initialTenantId;
-		uint64_t end = std::numeric_limits<uint64_t>::max();
-		state Future<KeyBackedRangeResult<std::pair<int64_t, TenantName>>> tenantsFuture =
-		    ManagementClusterMetadata::tenantMetadata().tenantIdIndex.getRange(
-		        tr, begin, end, CLIENT_KNOBS->MAX_TENANTS_PER_CLUSTER);
-		state KeyBackedRangeResult<std::pair<int64_t, TenantName>> tenants = wait(tenantsFuture);
-
-		state uint64_t lastTenantIdRetrieved;
-		for (auto t : tenants.results) {
-			self->mgmtClusterTenantIdIndex.emplace(t.first, t.second);
-			lastTenantIdRetrieved = t.first;
-		}
-
-		return std::pair<bool, uint64_t>{ !tenants.more, lastTenantIdRetrieved };
-	}
-
-	ACTOR static Future<bool> getTenantsFromManagementClusterForCurrentDataCluster(RestoreClusterImpl* self,
-	                                                                               Reference<ITransaction> tr) {
-		std::pair<Tuple, Tuple> clusterTupleRange =
-		    std::make_pair(Tuple::makeTuple(self->clusterName), Tuple::makeTuple(keyAfter(self->clusterName)));
-		state Future<KeyBackedRangeResult<Tuple>> tenantEntriesFuture =
-		    ManagementClusterMetadata::clusterTenantIndex.getRange(
-		        tr, clusterTupleRange.first, clusterTupleRange.second, CLIENT_KNOBS->MAX_TENANTS_PER_CLUSTER);
-		state KeyBackedRangeResult<Tuple> tenantEntries = wait(tenantEntriesFuture);
-
-		for (auto t : tenantEntries.results) {
-			ASSERT(t.getString(0) == self->clusterName);
-			self->mgmtTenantSet.insert(t.getString(1));
-		}
-
-		return !tenantEntries.more;
-	}
-
-	ACTOR static Future<bool> getAllTenantsFromManagementCluster(RestoreClusterImpl* self) {
+	ACTOR static Future<Void> getAllTenantsFromManagementCluster(RestoreClusterImpl* self) {
 		// get all tenants across all data clusters
 		state TenantName beginRangeTenantName = ""_sr;
 		loop {
@@ -1241,39 +1189,15 @@ struct RestoreClusterImpl {
 				    return getTenantsFromManagementCluster(self, tr, initialTenantName);
 			    }));
 
-			if (tenantsItr.first) {
-				// retrieved all the tenants
-				break;
-			} else {
-				// begin range from this tenant
+			if (!tenantsItr.first) {
+				// Not all tenants retrieved yet. Begin next loop from this tenant.
 				beginRangeTenantName = keyAfter(tenantsItr.second);
-			}
-		}
-
-		state uint64_t beginRangeTenantId = 0;
-		loop {
-			uint64_t initialTenantId = beginRangeTenantId;
-			std::pair<bool, uint64_t> tenantsItr = wait(self->ctx.runManagementTransaction(
-			    [self = self, initialTenantId](Reference<typename DB::TransactionT> tr) {
-				    return getTenantIdNameIndexFromManagementCluster(self, tr, initialTenantId);
-			    }));
-
-			if (tenantsItr.first) {
-				// retrieved all the tenants
-				break;
 			} else {
-				// begin range from this tenantId
-				beginRangeTenantId = tenantsItr.second + 1;
+				break;
 			}
 		}
 
-		// get tenants for the specific data cluster
-		bool gotAllTenants =
-		    wait(self->ctx.runManagementTransaction([self = self](Reference<typename DB::TransactionT> tr) {
-			    return getTenantsFromManagementClusterForCurrentDataCluster(self, tr);
-		    }));
-
-		return gotAllTenants;
+		return Void();
 	}
 
 	// This only supports the restore of an already registered data cluster, for now.
@@ -1299,7 +1223,7 @@ struct RestoreClusterImpl {
 			// get all the tenant information from the newly registered data cluster
 			bool gotAllTenants = wait(getAllTenantsFromDataCluster(self));
 			// get all the tenant information for this data cluster from manangement cluster
-			bool gotAllTenants = wait(getAllTenantsFromManagementCluster(self));
+			wait(getAllTenantsFromManagementCluster(self));
 
 			state std::unordered_map<TenantName, TenantMapEntry>::iterator itr = self->dataClusterTenantMap.begin();
 			while (itr != self->dataClusterTenantMap.end()) {
@@ -1328,12 +1252,13 @@ struct RestoreClusterImpl {
 				++itr;
 			}
 
-			state std::unordered_set<TenantNameRef>::iterator setItr = self->mgmtTenantSet.begin();
-			while (setItr != self->mgmtTenantSet.end()) {
+			state std::unordered_set<TenantName>::iterator setItr =
+			    self->mgmtClusterTenantSetForCurrentDataCluster.begin();
+			while (setItr != self->mgmtClusterTenantSetForCurrentDataCluster.end()) {
 				TenantName tenantName = *setItr;
 				uint64_t tenantId = self->mgmtClusterTenantMap[tenantName].id;
 
-				if (self->dataClusterTenantIdIndex.find(tenantId) == self->dataClusterTenantIdIndex.end()) {
+				if (self->dataClusterTenantIdSet.find(tenantId) == self->dataClusterTenantIdSet.end()) {
 					// Set Tenant in ERROR state
 					wait(self->ctx.runManagementTransaction([tenantName](Reference<typename DB::TransactionT> tr) {
 						return markManagementTenantAsError(tr, tenantName);

--- a/fdbclient/include/fdbclient/MetaclusterManagement.actor.h
+++ b/fdbclient/include/fdbclient/MetaclusterManagement.actor.h
@@ -1067,14 +1067,6 @@ struct RestoreClusterImpl {
 	AddNewTenants addNewTenants;
 	RemoveMissingTenants removeMissingTenants;
 
-	// Variables to track state during restore
-	TenantName lastTenantName;
-	ClusterName lastClusterName;
-	uint64_t tenantId;
-	uint64_t lastTenantId;
-	TenantName tenantName;
-	TenantName tenantNewName;
-
 	// Tenant list from data and management clusters.
 	std::unordered_map<TenantName, TenantMapEntry> dataClusterTenantMap;
 	std::unordered_map<uint64_t, TenantName> dataClusterTenantIdIndex;
@@ -1130,21 +1122,21 @@ struct RestoreClusterImpl {
 		return Void();
 	}
 
-	ACTOR static Future<Void> markManagementTenantAsError(RestoreClusterImpl* self,
-	                                                      Reference<typename DB::TransactionT> tr) {
-		state Optional<TenantMapEntry> tenantEntry = wait(tryGetTenantTransaction(tr, self->tenantName));
+	ACTOR static Future<Void> markManagementTenantAsError(Reference<typename DB::TransactionT> tr,
+	                                                      TenantName tenantName) {
+		state Optional<TenantMapEntry> tenantEntry = wait(tryGetTenantTransaction(tr, tenantName));
 
 		if (!tenantEntry.present()) {
 			return Void();
 		}
 
 		tenantEntry.get().tenantState = TenantState::ERROR;
-		ManagementClusterMetadata::tenantMetadata().tenantMap.set(tr, self->tenantName, tenantEntry.get());
+		ManagementClusterMetadata::tenantMetadata().tenantMap.set(tr, tenantName, tenantEntry.get());
 		return Void();
 	}
 
 	ACTOR static Future<bool> getTenantsFromDataCluster(RestoreClusterImpl* self, Reference<ITransaction> tr) {
-		TenantNameRef begin = self->lastTenantName;
+		TenantNameRef begin = self->clusterName;
 		TenantNameRef end = "\xff\xff"_sr;
 		state Future<KeyBackedRangeResult<std::pair<TenantName, TenantMapEntry>>> tenantsFuture =
 		    TenantMetadata::tenantMap().getRange(tr, begin, end, CLIENT_KNOBS->MAX_TENANTS_PER_CLUSTER);
@@ -1153,7 +1145,6 @@ struct RestoreClusterImpl {
 		if (!tenants.results.empty()) {
 			for (auto t : tenants.results) {
 				self->dataClusterTenantMap.emplace(t.first, t.second);
-				self->lastTenantName = t.first;
 			}
 		}
 
@@ -1162,7 +1153,7 @@ struct RestoreClusterImpl {
 
 	ACTOR static Future<bool> getTenantIdNameIndexFromDataCluster(RestoreClusterImpl* self,
 	                                                              Reference<ITransaction> tr) {
-		uint64_t begin = self->lastTenantId;
+		uint64_t begin = 0;
 		uint64_t end = std::numeric_limits<uint64_t>::max();
 		state Future<KeyBackedRangeResult<std::pair<int64_t, TenantName>>> tenantsFuture =
 		    TenantMetadata::tenantIdIndex().getRange(tr, begin, end, CLIENT_KNOBS->MAX_TENANTS_PER_CLUSTER);
@@ -1171,37 +1162,28 @@ struct RestoreClusterImpl {
 		if (!tenants.results.empty()) {
 			for (auto t : tenants.results) {
 				self->dataClusterTenantIdIndex.emplace(t.first, t.second);
-				self->lastTenantId = t.first;
 			}
 		}
 
 		return !tenants.more;
 	}
 
-	ACTOR static Future<Void> getAllTenantsFromDataCluster(RestoreClusterImpl* self) {
-		loop {
-			bool gotAllTenants = wait(self->ctx.runDataClusterTransaction(
-			    [self = self](Reference<ITransaction> tr) { return getTenantsFromDataCluster(self, tr); }));
+	ACTOR static Future<bool> getAllTenantsFromDataCluster(RestoreClusterImpl* self) {
+		bool gotAllTenants = wait(self->ctx.runDataClusterTransaction(
+		    [self = self](Reference<ITransaction> tr) { return getTenantsFromDataCluster(self, tr); }));
 
-			if (gotAllTenants) {
-				break;
-			}
+		if (!gotAllTenants) {
+			return false;
 		}
 
-		loop {
-			bool gotAllTenants = wait(self->ctx.runDataClusterTransaction(
-			    [self = self](Reference<ITransaction> tr) { return getTenantIdNameIndexFromDataCluster(self, tr); }));
+		bool gotAllTenants = wait(self->ctx.runDataClusterTransaction(
+		    [self = self](Reference<ITransaction> tr) { return getTenantIdNameIndexFromDataCluster(self, tr); }));
 
-			if (gotAllTenants) {
-				break;
-			}
-		}
-
-		return Void();
+		return gotAllTenants;
 	}
 
 	ACTOR static Future<bool> getTenantsFromManagementCluster(RestoreClusterImpl* self, Reference<ITransaction> tr) {
-		TenantNameRef begin = self->lastTenantName;
+		TenantNameRef begin = ""_sr;
 		TenantNameRef end = "\xff\xff"_sr;
 		state Future<KeyBackedRangeResult<std::pair<TenantName, TenantMapEntry>>> tenantsFuture =
 		    ManagementClusterMetadata::tenantMetadata().tenantMap.getRange(
@@ -1211,7 +1193,6 @@ struct RestoreClusterImpl {
 		if (!tenants.results.empty()) {
 			for (auto t : tenants.results) {
 				self->mgmtClusterTenantMap.emplace(t.first, t.second);
-				self->lastTenantName = t.first;
 			}
 		}
 
@@ -1220,7 +1201,7 @@ struct RestoreClusterImpl {
 
 	ACTOR static Future<bool> getTenantIdNameIndexFromManagementCluster(RestoreClusterImpl* self,
 	                                                                    Reference<ITransaction> tr) {
-		uint64_t begin = self->lastTenantId;
+		uint64_t begin = 0;
 		uint64_t end = std::numeric_limits<uint64_t>::max();
 		state Future<KeyBackedRangeResult<std::pair<int64_t, TenantName>>> tenantsFuture =
 		    ManagementClusterMetadata::tenantMetadata().tenantIdIndex.getRange(
@@ -1230,7 +1211,6 @@ struct RestoreClusterImpl {
 		if (!tenants.results.empty()) {
 			for (auto t : tenants.results) {
 				self->mgmtClusterTenantIdIndex.emplace(t.first, t.second);
-				self->lastTenantId = t.first;
 			}
 		}
 
@@ -1240,7 +1220,7 @@ struct RestoreClusterImpl {
 	ACTOR static Future<bool> getTenantsFromManagementClusterForCurrentDataCluster(RestoreClusterImpl* self,
 	                                                                               Reference<ITransaction> tr) {
 		std::pair<Tuple, Tuple> clusterTupleRange =
-		    std::make_pair(Tuple::makeTuple(self->lastClusterName), Tuple::makeTuple(keyAfter(self->clusterName)));
+		    std::make_pair(Tuple::makeTuple(self->clusterName), Tuple::makeTuple(keyAfter(self->clusterName)));
 		state Future<KeyBackedRangeResult<Tuple>> tenantEntriesFuture =
 		    ManagementClusterMetadata::clusterTenantIndex.getRange(
 		        tr, clusterTupleRange.first, clusterTupleRange.second, CLIENT_KNOBS->MAX_TENANTS_PER_CLUSTER);
@@ -1250,69 +1230,39 @@ struct RestoreClusterImpl {
 			for (auto t : tenantEntries.results) {
 				ASSERT(t.getString(0) == self->clusterName);
 				self->mgmtTenantSet.insert(t.getString(1));
-				// fix this ... not correct
-				self->lastClusterName = t.getString(0);
 			}
 		}
 
 		return !tenantEntries.more;
 	}
 
-	ACTOR static Future<Void> getAllTenantsFromManagementCluster(RestoreClusterImpl* self) {
+	ACTOR static Future<bool> getAllTenantsFromManagementCluster(RestoreClusterImpl* self) {
 		// get all tenants across all data clusters
-		self->lastClusterName = self->clusterName;
-		loop {
-			bool gotAllTenants =
-			    wait(self->ctx.runManagementTransaction([self = self](Reference<typename DB::TransactionT> tr) {
-				    return getTenantsFromManagementCluster(self, tr);
-			    }));
+		bool gotAllTenants =
+		    wait(self->ctx.runManagementTransaction([self = self](Reference<typename DB::TransactionT> tr) {
+			    return getTenantsFromManagementCluster(self, tr);
+		    }));
 
-			if (gotAllTenants) {
-				break;
-			}
+		if (!gotAllTenants) {
+			return false;
 		}
 
-		loop {
-			bool gotAllTenants =
-			    wait(self->ctx.runManagementTransaction([self = self](Reference<typename DB::TransactionT> tr) {
-				    return getTenantIdNameIndexFromManagementCluster(self, tr);
-			    }));
+		bool gotAllTenants =
+		    wait(self->ctx.runManagementTransaction([self = self](Reference<typename DB::TransactionT> tr) {
+			    return getTenantIdNameIndexFromManagementCluster(self, tr);
+		    }));
 
-			if (gotAllTenants) {
-				break;
-			}
+		if (!gotAllTenants) {
+			return false;
 		}
 
 		// get tenants for the specific data cluster
-		loop {
-			bool gotAllTenants =
-			    wait(self->ctx.runManagementTransaction([self = self](Reference<typename DB::TransactionT> tr) {
-				    return getTenantsFromManagementClusterForCurrentDataCluster(self, tr);
-			    }));
+		bool gotAllTenants =
+		    wait(self->ctx.runManagementTransaction([self = self](Reference<typename DB::TransactionT> tr) {
+			    return getTenantsFromManagementClusterForCurrentDataCluster(self, tr);
+		    }));
 
-			if (gotAllTenants) {
-				break;
-			}
-		}
-
-		return Void();
-	}
-
-	ACTOR static Future<Void> renameTenantOnDataCluster(RestoreClusterImpl* self) {
-		ASSERT(self->tenantId != -1);
-		wait(self->ctx.runDataClusterTransaction([self = self](Reference<ITransaction> tr) {
-			return TenantAPI::renameTenantTransaction(
-			    tr, self->tenantName, self->tenantNewName, self->tenantId, ClusterType::METACLUSTER_DATA);
-		}));
-		return Void();
-	}
-
-	ACTOR static Future<Void> removeTenantFromDataCluster(RestoreClusterImpl* self) {
-		wait(self->ctx.runDataClusterTransaction([self = self](Reference<ITransaction> tr) {
-			return TenantAPI::deleteTenantTransaction(
-			    tr, self->tenantName, self->tenantId, ClusterType::METACLUSTER_DATA);
-		}));
-		return Void();
+		return gotAllTenants;
 	}
 
 	// This only supports the restore of an already registered data cluster, for now.
@@ -1336,27 +1286,32 @@ struct RestoreClusterImpl {
 
 		if (!clusterIsRestoring) {
 			// get all the tenant information from the newly registered data cluster
-			wait(getAllTenantsFromDataCluster(self));
+			bool gotAllTenants = wait(getAllTenantsFromDataCluster(self));
 			// get all the tenant information for this data cluster from manangement cluster
-			wait(getAllTenantsFromManagementCluster(self));
+			bool gotAllTenants = wait(getAllTenantsFromManagementCluster(self));
 
 			state std::unordered_map<TenantName, TenantMapEntry>::iterator itr = self->dataClusterTenantMap.begin();
 			while (itr != self->dataClusterTenantMap.end()) {
-
-				state TenantName tenantNameOnDataCluster = itr->first;
-				state uint64_t tenantId = (itr->second).id;
-				self->tenantId = tenantId;
-				self->tenantName = tenantNameOnDataCluster;
+				uint64_t tenantId = (itr->second).id;
+				TenantName tenantName = itr->first;
 
 				auto tenantNameOnMgmtCluster = self->mgmtClusterTenantIdIndex.find(tenantId);
 				if (tenantNameOnMgmtCluster == self->mgmtClusterTenantIdIndex.end()) {
+					// Delete
 					if (self->removeMissingTenants) {
-						wait(removeTenantFromDataCluster(self));
+						wait(self->ctx.runDataClusterTransaction([tenantName, tenantId](Reference<ITransaction> tr) {
+							return TenantAPI::deleteTenantTransaction(
+							    tr, tenantName, tenantId, ClusterType::METACLUSTER_DATA);
+						}));
 					}
-				} else if (tenantNameOnDataCluster.compare(self->mgmtClusterTenantIdIndex[tenantId]) != 0) {
-					// renamed
-					self->tenantNewName = self->mgmtClusterTenantIdIndex[tenantId];
-					wait(renameTenantOnDataCluster(self));
+				} else if (tenantName.compare(self->mgmtClusterTenantIdIndex[tenantId]) != 0) {
+					// Rename
+					TenantName tenantNewName = self->mgmtClusterTenantIdIndex[tenantId];
+					wait(self->ctx.runDataClusterTransaction(
+					    [tenantName, tenantNewName, tenantId](Reference<ITransaction> tr) {
+						    return TenantAPI::renameTenantTransaction(
+						        tr, tenantName, tenantNewName, tenantId, ClusterType::METACLUSTER_DATA);
+					    }));
 				}
 
 				++itr;
@@ -1364,12 +1319,13 @@ struct RestoreClusterImpl {
 
 			state std::unordered_set<TenantNameRef>::iterator setItr = self->mgmtTenantSet.begin();
 			while (setItr != self->mgmtTenantSet.end()) {
-				self->tenantId = self->mgmtClusterTenantMap[*setItr].id;
+				TenantName tenantName = *setItr;
+				uint64_t tenantId = self->mgmtClusterTenantMap[tenantName].id;
 
-				if (self->dataClusterTenantIdIndex.find(self->tenantId) == self->dataClusterTenantIdIndex.end()) {
+				if (self->dataClusterTenantIdIndex.find(tenantId) == self->dataClusterTenantIdIndex.end()) {
 					// Set Tenant in ERROR state
-					wait(self->ctx.runManagementTransaction([self = self](Reference<typename DB::TransactionT> tr) {
-						return markManagementTenantAsError(self, tr);
+					wait(self->ctx.runManagementTransaction([tenantName](Reference<typename DB::TransactionT> tr) {
+						return markManagementTenantAsError(tr, tenantName);
 					}));
 				}
 				++setItr;

--- a/fdbclient/include/fdbclient/MetaclusterManagement.actor.h
+++ b/fdbclient/include/fdbclient/MetaclusterManagement.actor.h
@@ -25,6 +25,7 @@
 #include "flow/FastRef.h"
 #include "flow/IRandom.h"
 #include "flow/ThreadHelper.actor.h"
+#include <limits>
 #if defined(NO_INTELLISENSE) && !defined(FDBCLIENT_METACLUSTER_MANAGEMENT_ACTOR_G_H)
 #define FDBCLIENT_METACLUSTER_MANAGEMENT_ACTOR_G_H
 #include "fdbclient/MetaclusterManagement.actor.g.h"
@@ -1070,12 +1071,15 @@ struct RestoreClusterImpl {
 	TenantName lastTenantName;
 	ClusterName lastClusterName;
 	uint64_t tenantId;
+	uint64_t lastTenantId;
 	TenantName tenantName;
 	TenantName tenantNewName;
 
 	// Tenant list from data and management clusters.
 	std::unordered_map<TenantName, TenantMapEntry> dataClusterTenantMap;
+	std::unordered_map<uint64_t, TenantName> dataClusterTenantIdIndex;
 	std::unordered_map<TenantName, TenantMapEntry> mgmtClusterTenantMap;
+	std::unordered_map<uint64_t, TenantName> mgmtClusterTenantIdIndex;
 	std::unordered_set<TenantNameRef> mgmtTenantSet;
 
 	RestoreClusterImpl(Reference<DB> managementDb,
@@ -1156,10 +1160,37 @@ struct RestoreClusterImpl {
 		return !tenants.more;
 	}
 
+	ACTOR static Future<bool> getTenantIdNameIndexFromDataCluster(RestoreClusterImpl* self,
+	                                                              Reference<ITransaction> tr) {
+		uint64_t begin = self->lastTenantId;
+		uint64_t end = std::numeric_limits<uint64_t>::max();
+		state Future<KeyBackedRangeResult<std::pair<int64_t, TenantName>>> tenantsFuture =
+		    TenantMetadata::tenantIdIndex().getRange(tr, begin, end, CLIENT_KNOBS->MAX_TENANTS_PER_CLUSTER);
+		state KeyBackedRangeResult<std::pair<int64_t, TenantName>> tenants = wait(tenantsFuture);
+
+		if (!tenants.results.empty()) {
+			for (auto t : tenants.results) {
+				self->dataClusterTenantIdIndex.emplace(t.first, t.second);
+				self->lastTenantId = t.first;
+			}
+		}
+
+		return !tenants.more;
+	}
+
 	ACTOR static Future<Void> getAllTenantsFromDataCluster(RestoreClusterImpl* self) {
 		loop {
 			bool gotAllTenants = wait(self->ctx.runDataClusterTransaction(
 			    [self = self](Reference<ITransaction> tr) { return getTenantsFromDataCluster(self, tr); }));
+
+			if (gotAllTenants) {
+				break;
+			}
+		}
+
+		loop {
+			bool gotAllTenants = wait(self->ctx.runDataClusterTransaction(
+			    [self = self](Reference<ITransaction> tr) { return getTenantIdNameIndexFromDataCluster(self, tr); }));
 
 			if (gotAllTenants) {
 				break;
@@ -1181,6 +1212,25 @@ struct RestoreClusterImpl {
 			for (auto t : tenants.results) {
 				self->mgmtClusterTenantMap.emplace(t.first, t.second);
 				self->lastTenantName = t.first;
+			}
+		}
+
+		return !tenants.more;
+	}
+
+	ACTOR static Future<bool> getTenantIdNameIndexFromManagementCluster(RestoreClusterImpl* self,
+	                                                                    Reference<ITransaction> tr) {
+		uint64_t begin = self->lastTenantId;
+		uint64_t end = std::numeric_limits<uint64_t>::max();
+		state Future<KeyBackedRangeResult<std::pair<int64_t, TenantName>>> tenantsFuture =
+		    ManagementClusterMetadata::tenantMetadata().tenantIdIndex.getRange(
+		        tr, begin, end, CLIENT_KNOBS->MAX_TENANTS_PER_CLUSTER);
+		state KeyBackedRangeResult<std::pair<int64_t, TenantName>> tenants = wait(tenantsFuture);
+
+		if (!tenants.results.empty()) {
+			for (auto t : tenants.results) {
+				self->mgmtClusterTenantIdIndex.emplace(t.first, t.second);
+				self->lastTenantId = t.first;
 			}
 		}
 
@@ -1222,6 +1272,17 @@ struct RestoreClusterImpl {
 			}
 		}
 
+		loop {
+			bool gotAllTenants =
+			    wait(self->ctx.runManagementTransaction([self = self](Reference<typename DB::TransactionT> tr) {
+				    return getTenantIdNameIndexFromManagementCluster(self, tr);
+			    }));
+
+			if (gotAllTenants) {
+				break;
+			}
+		}
+
 		// get tenants for the specific data cluster
 		loop {
 			bool gotAllTenants =
@@ -1235,24 +1296,6 @@ struct RestoreClusterImpl {
 		}
 
 		return Void();
-	}
-
-	ACTOR static Future<Optional<TenantName>> lookupTenantInManagementClusterById(RestoreClusterImpl* self) {
-		Optional<TenantName> tenantName =
-		    wait(self->ctx.runManagementTransaction([self = self](Reference<typename DB::TransactionT> tr) {
-			    return ManagementClusterMetadata::tenantMetadata().tenantIdIndex.get(tr, self->tenantId);
-		    }));
-
-		return tenantName;
-	}
-
-	ACTOR static Future<Optional<TenantName>> lookupTenantInDataClusterById(RestoreClusterImpl* self) {
-		Optional<TenantName> tenantName =
-		    wait(self->ctx.runDataClusterTransaction([self = self](Reference<ITransaction> tr) {
-			    return TenantMetadata::tenantIdIndex().get(tr, self->tenantId);
-		    }));
-
-		return tenantName;
 	}
 
 	ACTOR static Future<Void> renameTenantOnDataCluster(RestoreClusterImpl* self) {
@@ -1305,19 +1348,15 @@ struct RestoreClusterImpl {
 				self->tenantId = tenantId;
 				self->tenantName = tenantNameOnDataCluster;
 
-				state Optional<TenantName> tenantNameOnMgmtCluster = wait(lookupTenantInManagementClusterById(self));
-				if (!tenantNameOnMgmtCluster.present()) {
-					// A tenant with this id is not found on the mgmt cluster.
-					if (self->removeMissingTenants == RemoveMissingTenants::True) {
+				auto tenantNameOnMgmtCluster = self->mgmtClusterTenantIdIndex.find(tenantId);
+				if (tenantNameOnMgmtCluster == self->mgmtClusterTenantIdIndex.end()) {
+					if (self->removeMissingTenants) {
 						wait(removeTenantFromDataCluster(self));
 					}
-				} else {
-					// A tenant with this id is found on the manangement cluster.
-					if (tenantNameOnDataCluster.compare(tenantNameOnMgmtCluster.get()) != 0) {
-						// renamed
-						self->tenantNewName = tenantNameOnMgmtCluster.get();
-						wait(renameTenantOnDataCluster(self));
-					}
+				} else if (tenantNameOnDataCluster.compare(self->mgmtClusterTenantIdIndex[tenantId]) != 0) {
+					// renamed
+					self->tenantNewName = self->mgmtClusterTenantIdIndex[tenantId];
+					wait(renameTenantOnDataCluster(self));
 				}
 
 				++itr;
@@ -1326,9 +1365,8 @@ struct RestoreClusterImpl {
 			state std::unordered_set<TenantNameRef>::iterator setItr = self->mgmtTenantSet.begin();
 			while (setItr != self->mgmtTenantSet.end()) {
 				self->tenantId = self->mgmtClusterTenantMap[*setItr].id;
-				state Optional<TenantName> tNameOnDataCluster = wait(lookupTenantInDataClusterById(self));
 
-				if (!tNameOnDataCluster.present()) {
+				if (self->dataClusterTenantIdIndex.find(self->tenantId) == self->dataClusterTenantIdIndex.end()) {
 					// Set Tenant in ERROR state
 					wait(self->ctx.runManagementTransaction([self = self](Reference<typename DB::TransactionT> tr) {
 						return markManagementTenantAsError(self, tr);
@@ -1416,7 +1454,7 @@ struct CreateTenantImpl {
 				return true;
 			} else {
 				// The previous creation is permanently failed, so cleanup the tenant and create it again from
-				// scratch We don't need to remove it from the tenant map because we will overwrite the existing
+				// scratch. We don't need to remove it from the tenant map because we will overwrite the existing
 				// entry later in this transaction.
 				ManagementClusterMetadata::tenantMetadata().tenantIdIndex.erase(tr, existingEntry.get().id);
 				ManagementClusterMetadata::tenantMetadata().tenantCount.atomicOp(tr, -1, MutationRef::AddValue);

--- a/fdbclient/include/fdbclient/MetaclusterManagement.actor.h
+++ b/fdbclient/include/fdbclient/MetaclusterManagement.actor.h
@@ -19,6 +19,7 @@
  */
 
 #pragma once
+#include "fdbclient/CoordinationInterface.h"
 #include "fdbclient/FDBOptions.g.h"
 #include "flow/IRandom.h"
 #include "flow/ThreadHelper.actor.h"
@@ -690,18 +691,6 @@ Future<Void> registerCluster(Reference<DB> db,
 	return Void();
 }
 
-ACTOR template <class DB>
-Future<Void> restoreCluster(Reference<DB> db,
-                            ClusterName name,
-                            std::string connectionString,
-                            DataClusterEntry entry,
-                            AddNewTenants addNewTenants,
-                            RemoveMissingTenants removeMissingTenants) {
-	// TODO: add implementation
-	wait(delay(0.0));
-	return Void();
-}
-
 template <class DB>
 struct RemoveClusterImpl {
 	MetaclusterOperationContext<DB> ctx;
@@ -1060,6 +1049,144 @@ Future<Void> managementClusterRemoveTenantFromGroup(Transaction tr,
 	}
 
 	return Void();
+}
+
+ACTOR template <class Transaction>
+Future<Optional<DataClusterEntry>> restoreClusterTransaction(Transaction tr,
+                                                             ClusterName name,
+                                                             ClusterConnectionString connectionString,
+                                                             DataClusterEntry entry,
+                                                             AddNewTenants addNewTenants,
+                                                             RemoveMissingTenants removeMissingTenants) {
+	tr->setOption(FDBTransactionOptions::ACCESS_SYSTEM_KEYS);
+
+	// pre-checks
+	wait(TenantAPI::checkTenantMode(tr, ClusterType::METACLUSTER_MANAGEMENT));
+
+	state Optional<DataClusterEntry> clusterEntry = wait(ManagementClusterMetadata::dataClusters.get(tr, name));
+	if (!clusterEntry.present()) {
+		// end if metacluter does not already know about this data cluster.
+	}
+
+	Reference<IDatabase> dataClusterDb = wait(openDatabase(connectionString));
+	state Reference<ITransaction> dataClusterTr = dataClusterDb->createTransaction();
+
+	state Optional<MetaclusterRegistrationEntry> existingRegistration =
+	    wait(MetaclusterMetadata::metaclusterRegistration.get(tr));
+
+	// get all tenants in the mgmt cluster
+	KeyBackedRangeResult<std::pair<TenantName, TenantMapEntry>> mgmtCluterTenantsFuture =
+	    wait(ManagementClusterMetadata::tenantMetadata.tenantMap.getRange(
+	        tr, ""_sr, "\xff\xff"_sr, CLIENT_KNOBS->MAX_DATA_CLUSTERS * CLIENT_KNOBS->MAX_TENANTS_PER_CLUSTER));
+	std::vector<std::pair<TenantName, TenantMapEntry>> mgmtClusterExistingTenants = mgmtCluterTenantsFuture.results;
+	// convert to map
+	state std::unordered_map<TenantName, TenantMapEntry> mgmtClusterTenantMap;
+	for (auto t : mgmtClusterExistingTenants) {
+		mgmtClusterTenantMap.emplace(t.first, t.second);
+	}
+
+	// get tenants for the specific data cluster in the mgmt cluster
+	state std::pair<Tuple, Tuple> clusterTupleRange =
+	    std::make_pair(Tuple::makeTuple(name), Tuple::makeTuple(keyAfter(name)));
+	state KeyBackedRangeResult<Tuple> tenantEntries = wait(ManagementClusterMetadata::clusterTenantIndex.getRange(
+	    tr, clusterTupleRange.first, clusterTupleRange.second, CLIENT_KNOBS->MAX_TENANTS_PER_CLUSTER));
+	state std::vector<Tuple> mgmtTenants = tenantEntries.results;
+	// convert to set
+	state std::unordered_set<TenantNameRef> mgmtTenantSet;
+	for (auto t : mgmtTenants) {
+		ASSERT(t.getString(0) == name);
+		mgmtTenantSet.insert(t.getString(1));
+	}
+
+	// get tenants from the restoring data cluster
+	state std::vector<std::pair<TenantName, TenantMapEntry>> dataClusterExistingTenants = wait(
+	    TenantAPI::listTenantsTransaction(dataClusterTr, ""_sr, "\xff\xff"_sr, CLIENT_KNOBS->MAX_TENANTS_PER_CLUSTER));
+	// convert to map
+	state std::unordered_map<TenantName, TenantMapEntry> dataClusterTenantMap;
+	for (auto t : dataClusterExistingTenants) {
+		dataClusterTenantMap.emplace(t.first, t.second);
+	}
+
+	for (std::pair<TenantName, TenantMapEntry> t : dataClusterExistingTenants) {
+		// Check to ensure that the tenant is not assigned to another data cluster
+		auto itr = mgmtClusterTenantMap.find(t.first);
+		if ((itr != mgmtClusterTenantMap.end()) && itr->second.assignedCluster.present() &&
+		    itr->second.assignedCluster.get() != name) {
+			// error, fail the restore
+			// set error
+			return Optional<DataClusterEntry>();
+		}
+
+		if (mgmtTenantSet.find(t.first) == mgmtTenantSet.end()) {
+			if (addNewTenants == AddNewTenants::True) {
+				// Add the tenant to the tenantmap
+				ManagementClusterMetadata::tenantMetadata.tenantMap.set(tr, t.first, t.second);
+
+				// Add the tenant to the cluster -> tenant index
+				ManagementClusterMetadata::clusterTenantIndex.insert(tr, Tuple::makeTuple(name, t.first));
+
+				// Add to the tenant group
+				ManagementClusterMetadata::tenantMetadata.tenantGroupTenantIndex.insert(
+				    tr, Tuple::makeTuple(t.second.tenantGroup.get(), t.first));
+			} else {
+				// error
+			}
+		}
+	}
+
+	for (Tuple t : mgmtTenants) {
+		state TenantNameRef tenantName = t.getString(1);
+		if (dataClusterTenantMap.find(tenantName) == dataClusterTenantMap.end()) {
+			if (removeMissingTenants == RemoveMissingTenants::True) {
+				// Erase the tenant from the tenantmap
+				ManagementClusterMetadata::tenantMetadata.tenantMap.erase(tr, tenantName);
+
+				// Remove the tenant from the cluster -> tenant index
+				ManagementClusterMetadata::clusterTenantIndex.erase(tr, Tuple::makeTuple(name, tenantName));
+
+				// Remove from the tenant group
+				state TenantMapEntry tenantEntry = wait(getTenantTransaction(tr, tenantName));
+				state DataClusterMetadata clusterMetadata1 = wait(getClusterTransaction(tr, name));
+				wait(managementClusterRemoveTenantFromGroup(tr, tenantName, tenantEntry, &clusterMetadata1));
+			} else {
+				// error
+			}
+		}
+	}
+
+	return Optional<DataClusterEntry>(entry);
+}
+
+ACTOR template <class DB>
+Future<Void> restoreCluster(Reference<DB> db,
+                            ClusterName name,
+                            ClusterConnectionString connectionString,
+                            DataClusterEntry entry,
+                            AddNewTenants addNewTenants,
+                            RemoveMissingTenants removeMissingTenants) {
+	if (name.startsWith("\xff"_sr)) {
+		throw invalid_cluster_name();
+	}
+
+	state Reference<typename DB::TransactionT> tr = db->createTransaction();
+
+	loop {
+		try {
+			state Optional<DataClusterEntry> newCluster =
+			    wait(restoreClusterTransaction(tr, name, connectionString, entry, addNewTenants, removeMissingTenants));
+
+			wait(buggifiedCommit(tr, BUGGIFY));
+
+			TraceEvent("RestoredDataCluster")
+			    .detail("ClusterName", name)
+			    .detail("ClusterId", newCluster.present() ? newCluster.get().id : UID())
+			    .detail("Version", tr->getCommittedVersion());
+
+			return Void();
+		} catch (Error& e) {
+			wait(safeThreadFutureToFuture(tr->onError(e)));
+		}
+	}
 }
 
 template <class DB>

--- a/flow/include/flow/error_definitions.h
+++ b/flow/include/flow/error_definitions.h
@@ -253,7 +253,7 @@ ERROR( metacluster_no_capacity, 2166, "Metacluster does not have capacity to cre
 ERROR( management_cluster_invalid_access, 2167, "Standard transactions cannot be run against the management cluster" )
 ERROR( tenant_creation_permanently_failed, 2168, "The tenant creation did not complete in a timely manner and has permanently failed" )
 ERROR( cluster_removed, 2169, "The cluster is being removed from the metacluster" )
-ERROR( cluster_restored, 2170, "The cluster is being restored to the metacluster" )
+ERROR( cluster_restoring, 2170, "The cluster is being restored to the metacluster" )
 
 // 2200 - errors from bindings and official APIs
 ERROR( api_version_unset, 2200, "API version is not set" )

--- a/flow/include/flow/error_definitions.h
+++ b/flow/include/flow/error_definitions.h
@@ -253,6 +253,7 @@ ERROR( metacluster_no_capacity, 2166, "Metacluster does not have capacity to cre
 ERROR( management_cluster_invalid_access, 2167, "Standard transactions cannot be run against the management cluster" )
 ERROR( tenant_creation_permanently_failed, 2168, "The tenant creation did not complete in a timely manner and has permanently failed" )
 ERROR( cluster_removed, 2169, "The cluster is being removed from the metacluster" )
+ERROR( cluster_restored, 2170, "The cluster is being restored to the metacluster" )
 
 // 2200 - errors from bindings and official APIs
 ERROR( api_version_unset, 2200, "API version is not set" )


### PR DESCRIPTION
Metacluster restore support for a pre-registered data cluster.
This change adds the functionality to restore a data cluster that is already registered to the same metacluster. In this case, the tenantmap on the management cluster will be used as the source of truth -- so tenants that are on the data cluster but not on the management cluster will be deleted, and tenants that exist only on the management cluster will be put in ERROR state for the operator to take a manual action later.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
