### PR TITLE
Encryption data at-rest new configuration cli input

### DIFF
--- a/fdbcli/ConfigureCommand.actor.cpp
+++ b/fdbcli/ConfigureCommand.actor.cpp
@@ -276,6 +276,10 @@ ACTOR Future<bool> configureCommandActor(Reference<IDatabase> db,
 		fprintf(stderr, "ERROR: A cluster cannot change its tenant mode while part of a metacluster.\n");
 		ret = false;
 		break;
+	case ConfigurationResult::ENCRYPTION_DATA_AT_REST_ALREADY_SET:
+		fprintf(stderr, "ERROR: A cluster cannot change its encryption_data_at_rest state after database creation.\n");
+		ret = false;
+		break;
 	default:
 		ASSERT(false);
 		ret = false;
@@ -309,6 +313,7 @@ void configureGenerator(const char* text,
 		                   "storage_migration_type=",
 		                   "tenant_mode=",
 		                   "blob_granules_enabled=",
+		                   "encryption_data_at_rest_mode=",
 		                   nullptr };
 	arrayGenerator(text, line, opts, lc);
 }
@@ -321,7 +326,8 @@ CommandFactory configureFactory(
         "commit_proxies=<COMMIT_PROXIES>|grv_proxies=<GRV_PROXIES>|logs=<LOGS>|resolvers=<RESOLVERS>>*|"
         "count=<TSS_COUNT>|perpetual_storage_wiggle=<WIGGLE_SPEED>|perpetual_storage_wiggle_locality="
         "<<LOCALITY_KEY>:<LOCALITY_VALUE>|0>|storage_migration_type={disabled|gradual|aggressive}"
-        "|tenant_mode={disabled|optional_experimental|required_experimental}|blob_granules_enabled={0|1}",
+        "|tenant_mode={disabled|optional_experimental|required_experimental}|blob_granules_enabled={0|1}"
+        "|encryption_data_at_rest_mode={none|aes_256_ctr}",
         "change the database configuration",
         "The `new' option, if present, initializes a new database with the given configuration rather than changing "
         "the configuration of an existing one. When used, both a redundancy mode and a storage engine must be "
@@ -355,6 +361,9 @@ CommandFactory configureFactory(
         "tenant_mode=<disabled|optional_experimental|required_experimental>: Sets the tenant mode for the cluster. If "
         "optional, then transactions can be run with or without specifying tenants. If required, all data must be "
         "accessed using tenants.\n\n"
+        "encryption_data_at_rest_mode=<node/aes_256_ctr>: Sets the cluster encryption data at-rest support for the "
+        "database. The configuration can be updated ONLY at the time of database creation and once set can't be "
+        "updated for the lifetime of the database.\n\n"
 
         "See the FoundationDB Administration Guide for more information."),
     &configureGenerator);

--- a/fdbcli/StatusCommand.actor.cpp
+++ b/fdbcli/StatusCommand.actor.cpp
@@ -442,6 +442,13 @@ void printStatus(StatusObjectReader statusObj,
 					outputString += "\n  Blob granules          - enabled";
 				}
 
+				outputString += "\n  Encryption data at-rest    - ";
+				if (statusObjConfig.get("encryption_data_at_rest_mode", strVal)) {
+					outputString += strVal;
+				} else {
+					outputString += "disabled";
+				}
+
 				outputString += "\n  Coordinators           - ";
 				if (statusObjConfig.get("coordinators_count", intVal)) {
 					outputString += std::to_string(intVal);

--- a/fdbclient/DatabaseConfiguration.cpp
+++ b/fdbclient/DatabaseConfiguration.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "fdbclient/DatabaseConfiguration.h"
+#include "fdbclient/FDBTypes.h"
 #include "fdbclient/SystemData.h"
 #include "flow/ITrace.h"
 #include "flow/Trace.h"
@@ -53,6 +54,7 @@ void DatabaseConfiguration::resetInternal() {
 	storageMigrationType = StorageMigrationType::DEFAULT;
 	blobGranulesEnabled = false;
 	tenantMode = TenantMode::DISABLED;
+	encryptionDataAtRestMode = EncryptionDataAtRestMode::DISABLED;
 }
 
 int toInt(ValueRef const& v) {
@@ -213,7 +215,8 @@ bool DatabaseConfiguration::isValid() const {
 	      (perpetualStorageWiggleSpeed == 0 || perpetualStorageWiggleSpeed == 1) &&
 	      isValidPerpetualStorageWiggleLocality(perpetualStorageWiggleLocality) &&
 	      storageMigrationType != StorageMigrationType::UNSET && tenantMode >= TenantMode::DISABLED &&
-	      tenantMode < TenantMode::END)) {
+	      tenantMode < TenantMode::END && encryptionDataAtRestMode >= EncryptionDataAtRestMode::DISABLED &&
+	      encryptionDataAtRestMode < EncryptionDataAtRestMode::END)) {
 		return false;
 	}
 	std::set<Key> dcIds;
@@ -413,6 +416,7 @@ StatusObject DatabaseConfiguration::toJSON(bool noPolicies) const {
 	result["storage_migration_type"] = storageMigrationType.toString();
 	result["blob_granules_enabled"] = (int32_t)blobGranulesEnabled;
 	result["tenant_mode"] = tenantMode.toString();
+	result["encryption_data_at_rest_mode"] = encryptionDataAtRestMode.toString();
 	return result;
 }
 
@@ -643,6 +647,9 @@ bool DatabaseConfiguration::setInternal(KeyRef key, ValueRef value) {
 	} else if (ck == LiteralStringRef("blob_granules_enabled")) {
 		parse((&type), value);
 		blobGranulesEnabled = (type != 0);
+	} else if (ck == LiteralStringRef("encryption_data_at_rest_mode")) {
+		parse((&type), value);
+		encryptionDataAtRestMode = EncryptionDataAtRestMode::fromValue(value);
 	} else {
 		return false;
 	}

--- a/fdbclient/Schemas.cpp
+++ b/fdbclient/Schemas.cpp
@@ -848,6 +848,11 @@ const KeyRef JSONSchemas::statusSchema = LiteralStringRef(R"statusSchema(
              "disabled",
              "optional_experimental",
              "required_experimental"
+         ]},
+         "encryption_data_at_rest_mode": {
+             "$enum":[
+             "disabled",
+             "aes_256_ctr"
          ]}
       },
       "data":{

--- a/fdbclient/include/fdbclient/DatabaseConfiguration.h
+++ b/fdbclient/include/fdbclient/DatabaseConfiguration.h
@@ -254,7 +254,11 @@ struct DatabaseConfiguration {
 
 	// Blob Granules
 	bool blobGranulesEnabled;
+
 	TenantMode tenantMode;
+
+	// Encryption data at-rest mode
+	EncryptionDataAtRestMode encryptionDataAtRestMode;
 
 	// Excluded servers (no state should be here)
 	bool isExcludedServer(NetworkAddressList) const;

--- a/fdbclient/include/fdbclient/FDBTypes.h
+++ b/fdbclient/include/fdbclient/FDBTypes.h
@@ -1392,6 +1392,55 @@ struct TenantMode {
 	uint32_t mode;
 };
 
+struct EncryptionDataAtRestMode {
+	// These enumerated values are stored in the database configuration, so can NEVER be changed.  Only add new ones
+	// just before END.
+	enum Mode { DISABLED = 0, AES_256_CTR = 1, END = 2 };
+
+	EncryptionDataAtRestMode() : mode(DISABLED) {}
+	EncryptionDataAtRestMode(Mode mode) : mode(mode) {
+		if ((uint32_t)mode >= END) {
+			this->mode = DISABLED;
+		}
+	}
+	operator Mode() const { return Mode(mode); }
+
+	template <class Ar>
+	void serialize(Ar& ar) {
+		serializer(ar, mode);
+	}
+
+	std::string toString() const {
+		switch (mode) {
+		case DISABLED:
+			return "none";
+		case AES_256_CTR:
+			return "aes_256_ctr";
+		default:
+			ASSERT(false);
+		}
+		return "";
+	}
+
+	Value toValue() const { return ValueRef(format("%d", (int)mode)); }
+
+	static EncryptionDataAtRestMode fromValue(Optional<ValueRef> val) {
+		if (!val.present()) {
+			return DISABLED;
+		}
+
+		// A failed parsing returns 0 (DISABLED)
+		int num = atoi(val.get().toString().c_str());
+		if (num < 0 || num >= END) {
+			return DISABLED;
+		}
+
+		return static_cast<Mode>(num);
+	}
+
+	uint32_t mode;
+};
+
 typedef StringRef ClusterNameRef;
 typedef Standalone<ClusterNameRef> ClusterName;
 

--- a/fdbclient/include/fdbclient/GenericManagementAPI.actor.h
+++ b/fdbclient/include/fdbclient/GenericManagementAPI.actor.h
@@ -70,7 +70,8 @@ enum class ConfigurationResult {
 	SUCCESS_WARN_SHARDED_ROCKSDB_EXPERIMENTAL,
 	DATABASE_CREATED_WARN_ROCKSDB_EXPERIMENTAL,
 	DATABASE_CREATED_WARN_SHARDED_ROCKSDB_EXPERIMENTAL,
-	DATABASE_IS_REGISTERED
+	DATABASE_IS_REGISTERED,
+	ENCRYPTION_DATA_AT_REST_ALREADY_SET
 };
 
 enum class CoordinatorsResult {
@@ -484,6 +485,12 @@ Future<ConfigurationResult> changeConfig(Reference<DB> db, std::map<std::string,
 						if (metaclusterRegistration.present()) {
 							return ConfigurationResult::DATABASE_IS_REGISTERED;
 						}
+					}
+
+					if (newConfig.encryptionDataAtRestMode != oldConfig.encryptionDataAtRestMode) {
+						// encryption_data_at_rest configuration is applied at the time of new database creation.
+						// This configuration can't be updated after database creation.
+						return ConfigurationResult::ENCRYPTION_DATA_AT_REST_ALREADY_SET;
 					}
 				}
 			}


### PR DESCRIPTION
Description

Patch proposesUpdate fdbcli to enable 'encryption_data_at_rest_mode'
configuration input.

For now, the associated database configuration isn't introduced,
however, once done, the configuration can ONLY be applied during
database creation and will be immutable afterwards

Testing

devCorrectness - 100K

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
