### PR TITLE
Switch the log/pow base in randomSkewedUInt32() from M_E to 10.0

### DIFF
--- a/flow/DeterministicRandom.cpp
+++ b/flow/DeterministicRandom.cpp
@@ -94,10 +94,10 @@ uint64_t DeterministicRandom::randomUInt64() {
 
 uint32_t DeterministicRandom::randomSkewedUInt32(uint32_t min, uint32_t maxPlusOne) {
 	ASSERT(min < maxPlusOne);
-	std::uniform_real_distribution<double> distribution(std::log(std::max<double>(min, 1.0 / M_E)),
-	                                                    std::log(maxPlusOne));
+	std::uniform_real_distribution<double> distribution(std::log10(std::max<double>(min, 1.0 / 10.0)),
+	                                                    std::log10(maxPlusOne));
 	double exponent = distribution(random);
-	uint32_t value = static_cast<uint32_t>(std::pow(M_E, exponent));
+	uint32_t value = static_cast<uint32_t>(std::pow(10.0, exponent));
 	return std::max(std::min(value, maxPlusOne - 1), min);
 }
 


### PR DESCRIPTION
This precludes the need to #define _USE_MATH_DEFINES for MSVC, thereby fixing the ongoing Windows build failure.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
