### PR TITLE
Call getTraceThreadId() before we enable allocation tracing

### DIFF
--- a/flow/Trace.cpp
+++ b/flow/Trace.cpp
@@ -1286,7 +1286,7 @@ thread_local bool BaseTraceEvent::networkThread = false;
 void BaseTraceEvent::setNetworkThread() {
 	if (!networkThread) {
 		if (FLOW_KNOBS->ALLOCATION_TRACING_ENABLED) {
-			// Ensure that threadID is initialized before we enable allocation tracing, otherwise it would
+			// Ensure that threadId is initialized before we enable allocation tracing, otherwise it would
 			// be initialized either by first normal usage of TraceEvent or by allocation tracing which is
 			// non-deterministic, and we could run into https://github.com/apple/foundationdb/issues/7872.
 			getTraceThreadId();

--- a/flow/Trace.cpp
+++ b/flow/Trace.cpp
@@ -1286,6 +1286,10 @@ thread_local bool BaseTraceEvent::networkThread = false;
 void BaseTraceEvent::setNetworkThread() {
 	if (!networkThread) {
 		if (FLOW_KNOBS->ALLOCATION_TRACING_ENABLED) {
+			// Ensure that threadID is initialized before we enable allocation tracing, otherwise it would
+			// be initialized either by first normal usage of TraceEvent or by allocation tracing which is
+			// non-deterministic, and we could run into https://github.com/apple/foundationdb/issues/7872.
+			getTraceThreadId();
 			--g_allocation_tracing_disabled;
 		}
 


### PR DESCRIPTION
This PR eliminates UnseedMismatch errors caused by allocation logging.

Fixes https://github.com/apple/foundationdb/issues/7872

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
