### PR TITLE
Add build date and time to build_flags

### DIFF
--- a/fdbclient/BuildFlags.h.in
+++ b/fdbclient/BuildFlags.h.in
@@ -33,6 +33,9 @@
 #define C_VERSION_MINOR 0
 #endif
 
+const char* kDate = __DATE__;
+const char* kTime = __TIME__;
+
 // FDB info.
 const std::string kGitHash = "@CURRENT_GIT_VERSION_WNL@";
 const std::string kFdbVersion = "@FDB_VERSION@";
@@ -43,7 +46,7 @@ const std::string kArch = "@CMAKE_SYSTEM@";
 const std::string kCompiler = "@CMAKE_CXX_COMPILER_ID@";
 
 // Library versions.
-const std::string kBoostVersion = "@Boost_LIB_VERSION@";
+const std::string kBoostVersion = BOOST_LIB_VERSION;
 
 // Build info and flags.
 const std::string kCMakeVersion = "@CMAKE_VERSION@";
@@ -60,6 +63,9 @@ constexpr int kCppStandard = __cplusplus;
 std::string jsonBuildInformation() {
 	json_spirit::mValue json;	
 	JSONDoc doc(json);
+
+	doc.create("build_date") = kDate;
+	doc.create("build_time") = kTime;
 
 	doc.create("git_hash") = kGitHash;
 	doc.create("fdb_version") = kFdbVersion;


### PR DESCRIPTION
Also fixes the Boost lib version.

Example:

```
$ ./bin/fdbserver --build_flags
{
    "arch" : "Linux-5.4.117-58.216.amzn2.x86_64",
    "boost_version" : "1_78",
    "build_date" : "Aug 17 2022",
    "build_time" : "23:34:55",
    "ccache" : "OFF",
    "cmake_version" : "3.19.6",
    "compiler" : "Clang",
    "cpp_standard" : 201703,
    "fdb_version" : "7.2.0",
    "git_hash" : "",
    "glibc_version" : "2.17"
}
```

(the `git_hash` field is populated correctly for releases).

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
