### PR TITLE
Revert "Add snowflake-specific binaries folder for restart tests"

### DIFF
--- a/contrib/TestHarness/Program.cs
+++ b/contrib/TestHarness/Program.cs
@@ -323,10 +323,8 @@ namespace SummarizeTest
                         oldBinaryVersionLowerBound = "0.0.0";
                     }
                     string[] currentBinary = { fdbserverName };
-                    var snowflakePath = Path.Combine("/app", "deploy", "global_data", "snowflakeBinaries");
-                    string[] snowflakeBinaries = Directory.Exists(snowflakePath) ? Directory.GetFiles(snowflakePath) : Array.Empty<string>();
-
-                    IEnumerable<string> oldBinaries = Array.FindAll(Directory.GetFiles(oldBinaryFolder).Concat(snowflakeBinaries).ToArray(),
+                    IEnumerable<string> oldBinaries = Array.FindAll(
+                                                         Directory.GetFiles(oldBinaryFolder),
                                                          x => versionGreaterThanOrEqual(Path.GetFileName(x).Split('-').Last(), oldBinaryVersionLowerBound)
                                                            && versionLessThan(Path.GetFileName(x).Split('-').Last(), oldBinaryVersionUpperBound));
                     if (!lastFolderName.Contains("until_")) {


### PR DESCRIPTION
Reverts apple/foundationdb#7828

Temporarily revert until we apply snowflake-specific protocol version changes to the snowflake/release-71.2 branch