### PR TITLE
Avoid `cluster_version_changed` errors on startup when using the MVC

### DIFF
--- a/fdbclient/DisconnectedTransaction.actor.cpp
+++ b/fdbclient/DisconnectedTransaction.actor.cpp
@@ -1,0 +1,391 @@
+/*
+ * DisconnectedTransaction.actor.cpp
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2022 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifdef ADDRESS_SANITIZER
+#include <sanitizer/lsan_interface.h>
+#endif
+
+#include "fdbclient/DisconnectedTransaction.h"
+#include "fdbclient/FDBOptions.g.h"
+#include "fdbclient/FDBTypes.h"
+#include "fdbclient/MultiVersionAssignmentVars.h"
+#include "fdbclient/MultiVersionTransaction.h"
+#include "fdbclient/VersionVector.h"
+
+#include "flow/network.h"
+#include "flow/UnitTest.h"
+
+#include "flow/actorcompiler.h" // This must be the last #include.
+
+#ifdef FDBCLIENT_NATIVEAPI_ACTOR_H
+#error "MVC should not depend on the Native API"
+#endif
+
+DisconnectedTransaction::DisconnectedTransaction(Optional<TenantName> tenant)
+  : startTime(timer_monotonic()), timeoutTsav(new ThreadSingleAssignmentVar<Void>()), tenant(tenant) {}
+
+DisconnectedTransaction::~DisconnectedTransaction() {
+	// timeoutTsav->trySendError(transaction_cancelled());
+}
+
+void DisconnectedTransaction::cancel() {
+	storeOperation(&ITransaction::cancel);
+}
+
+void DisconnectedTransaction::setVersion(Version v) {
+	storeOperation(&ITransaction::setVersion, std::forward<Version>(v));
+}
+
+ThreadFuture<Version> DisconnectedTransaction::getReadVersion() {
+	return storeOperation(&ITransaction::getReadVersion);
+}
+
+ThreadFuture<Optional<Value>> DisconnectedTransaction::get(const KeyRef& key, bool snapshot) {
+	return storeOperation(&ITransaction::get, key, std::forward<bool>(snapshot));
+}
+
+ThreadFuture<Key> DisconnectedTransaction::getKey(const KeySelectorRef& key, bool snapshot) {
+	return storeOperation(&ITransaction::getKey, key, std::forward<bool>(snapshot));
+}
+
+ThreadFuture<RangeResult> DisconnectedTransaction::getRange(const KeySelectorRef& begin,
+                                                            const KeySelectorRef& end,
+                                                            int limit,
+                                                            bool snapshot,
+                                                            bool reverse) {
+	return storeOperation<RangeResult>(&ITransaction::getRange,
+	                                   begin,
+	                                   end,
+	                                   std::forward<int>(limit),
+	                                   std::forward<bool>(snapshot),
+	                                   std::forward<bool>(reverse));
+}
+
+ThreadFuture<RangeResult> DisconnectedTransaction::getRange(const KeySelectorRef& begin,
+                                                            const KeySelectorRef& end,
+                                                            GetRangeLimits limits,
+                                                            bool snapshot,
+                                                            bool reverse) {
+	return storeOperation<RangeResult>(&ITransaction::getRange,
+	                                   begin,
+	                                   end,
+	                                   std::forward<GetRangeLimits>(limits),
+	                                   std::forward<bool>(snapshot),
+	                                   std::forward<bool>(reverse));
+}
+
+ThreadFuture<RangeResult> DisconnectedTransaction::getRange(const KeyRangeRef& keys,
+                                                            int limit,
+                                                            bool snapshot,
+                                                            bool reverse) {
+	return storeOperation<RangeResult>(&ITransaction::getRange,
+	                                   keys,
+	                                   std::forward<int>(limit),
+	                                   std::forward<bool>(snapshot),
+	                                   std::forward<bool>(reverse));
+}
+
+ThreadFuture<RangeResult> DisconnectedTransaction::getRange(const KeyRangeRef& keys,
+                                                            GetRangeLimits limits,
+                                                            bool snapshot,
+                                                            bool reverse) {
+	return storeOperation<RangeResult>(&ITransaction::getRange,
+	                                   keys,
+	                                   std::forward<GetRangeLimits>(limits),
+	                                   std::forward<bool>(snapshot),
+	                                   std::forward<bool>(reverse));
+}
+
+ThreadFuture<MappedRangeResult> DisconnectedTransaction::getMappedRange(const KeySelectorRef& begin,
+                                                                        const KeySelectorRef& end,
+                                                                        const StringRef& mapper,
+                                                                        GetRangeLimits limits,
+                                                                        int matchIndex,
+                                                                        bool snapshot,
+                                                                        bool reverse) {
+	return storeOperation(&ITransaction::getMappedRange,
+	                      begin,
+	                      end,
+	                      mapper,
+	                      std::forward<GetRangeLimits>(limits),
+	                      std::forward<int>(matchIndex),
+	                      std::forward<bool>(snapshot),
+	                      std::forward<bool>(reverse));
+}
+
+ThreadFuture<Standalone<VectorRef<const char*>>> DisconnectedTransaction::getAddressesForKey(const KeyRef& key) {
+	return storeOperation(&ITransaction::getAddressesForKey, key);
+}
+
+ThreadFuture<Standalone<StringRef>> DisconnectedTransaction::getVersionstamp() {
+	return storeOperation(&ITransaction::getVersionstamp);
+}
+
+void DisconnectedTransaction::addReadConflictRange(const KeyRangeRef& keys) {
+	storeOperation(&ITransaction::addReadConflictRange, keys);
+}
+
+ThreadFuture<int64_t> DisconnectedTransaction::getEstimatedRangeSizeBytes(const KeyRangeRef& keys) {
+	return storeOperation(&ITransaction::getEstimatedRangeSizeBytes, keys);
+}
+
+ThreadFuture<Standalone<VectorRef<KeyRef>>> DisconnectedTransaction::getRangeSplitPoints(const KeyRangeRef& range,
+                                                                                         int64_t chunkSize) {
+	return storeOperation(&ITransaction::getRangeSplitPoints, range, std::forward<int64_t>(chunkSize));
+}
+
+ThreadFuture<Standalone<VectorRef<KeyRangeRef>>> DisconnectedTransaction::getBlobGranuleRanges(
+    const KeyRangeRef& keyRange,
+    int rangeLimit) {
+	return storeOperation(&ITransaction::getBlobGranuleRanges, keyRange, std::forward<int>(rangeLimit));
+}
+
+ThreadResult<RangeResult> DisconnectedTransaction::readBlobGranules(const KeyRangeRef& keyRange,
+                                                                    Version beginVersion,
+                                                                    Optional<Version> readVersion,
+                                                                    ReadBlobGranuleContext granuleContext) {
+	return storeOperation(&ITransaction::readBlobGranules,
+	                      keyRange,
+	                      std::forward<Version>(beginVersion),
+	                      std::forward<Optional<Version>>(readVersion),
+	                      std::forward<ReadBlobGranuleContext>(granuleContext));
+}
+
+void DisconnectedTransaction::atomicOp(const KeyRef& key, const ValueRef& value, uint32_t operationType) {
+	storeOperation(&ITransaction::atomicOp, key, value, std::forward<uint32_t>(operationType));
+}
+
+void DisconnectedTransaction::set(const KeyRef& key, const ValueRef& value) {
+	storeOperation(&ITransaction::set, key, value);
+}
+
+void DisconnectedTransaction::clear(const KeyRef& begin, const KeyRef& end) {
+	storeOperation(&ITransaction::clear, begin, end);
+}
+
+void DisconnectedTransaction::clear(const KeyRangeRef& range) {
+	storeOperation(&ITransaction::clear, range);
+}
+
+void DisconnectedTransaction::clear(const KeyRef& key) {
+	storeOperation(&ITransaction::clear, key);
+}
+
+ThreadFuture<Void> DisconnectedTransaction::watch(const KeyRef& key) {
+	return storeOperation(&ITransaction::watch, key);
+}
+
+void DisconnectedTransaction::addWriteConflictRange(const KeyRangeRef& keys) {
+	storeOperation(&ITransaction::addWriteConflictRange, keys);
+}
+
+ThreadFuture<Void> DisconnectedTransaction::commit() {
+	return storeOperation(&ITransaction::commit);
+}
+
+Version DisconnectedTransaction::getCommittedVersion() {
+	return invalidVersion;
+}
+
+ThreadFuture<VersionVector> DisconnectedTransaction::getVersionVector() {
+	return storeOperation(&ITransaction::getVersionVector);
+}
+
+ThreadFuture<SpanContext> DisconnectedTransaction::getSpanContext() {
+	return storeOperation(&ITransaction::getSpanContext);
+}
+
+ThreadFuture<int64_t> DisconnectedTransaction::getApproximateSize() {
+	return storeOperation(&ITransaction::getApproximateSize);
+}
+
+void DisconnectedTransaction::setOption(FDBTransactionOptions::Option option, Optional<StringRef> value) {
+	if (option == FDBTransactionOptions::TIMEOUT) {
+		setTimeout(value);
+	}
+
+	return storeOperation(&ITransaction::setOption,
+	                      std::forward<FDBTransactionOptions::Option>(option),
+	                      std::forward<Optional<StringRef>>(value));
+}
+
+ThreadFuture<Void> DisconnectedTransaction::onError(Error const& e) {
+	return storeOperation(&ITransaction::onError, std::forward<const Error&>(e));
+}
+
+void DisconnectedTransaction::reset() {
+	operations.clear();
+
+	startTime = timer_monotonic();
+	Reference<ThreadSingleAssignmentVar<Void>> prevTimeoutTsav;
+	ThreadFuture<Void> prevTimeout;
+
+	{ // lock scope
+		ThreadSpinLockHolder holder(timeoutLock);
+
+		prevTimeoutTsav = timeoutTsav;
+		timeoutTsav = makeReference<ThreadSingleAssignmentVar<Void>>();
+
+		prevTimeout = currentTimeout;
+		currentTimeout = ThreadFuture<Void>();
+	}
+
+	// Cancel any outstanding operations if they don't have an underlying transaction object to cancel them
+	prevTimeoutTsav->trySendError(transaction_cancelled());
+	if (prevTimeout.isValid()) {
+		prevTimeout.cancel();
+	}
+}
+
+Optional<TenantName> DisconnectedTransaction::getTenant() {
+	return tenant;
+}
+
+bool DisconnectedTransaction::isValid() {
+	return false;
+}
+
+// Waits for the specified duration and signals the assignment variable. This will be canceled if a new timeout is set,
+// in which case the tsav will not be signaled.
+ACTOR Future<Void> timeoutImpl(Reference<ThreadSingleAssignmentVar<Void>> tsav, double duration) {
+	wait(delay(duration));
+	tsav->trySend(Void());
+	return Void();
+}
+
+// Configure a timeout based on the options set for this transaction. This timeout only applies
+// if we don't have an underlying database object to connect with.
+void DisconnectedTransaction::setTimeout(Optional<StringRef> value) {
+	double timeoutDuration = extractIntOption(value, 0, std::numeric_limits<int>::max()) / 1000.0;
+
+	ThreadFuture<Void> prevTimeout;
+	double transactionStartTime = startTime;
+
+	{ // lock scope
+		ThreadSpinLockHolder holder(timeoutLock);
+
+		Reference<ThreadSingleAssignmentVar<Void>> tsav = timeoutTsav;
+		ThreadFuture<Void> newTimeout = onMainThread([transactionStartTime, tsav, timeoutDuration]() {
+			return timeoutImpl(tsav, timeoutDuration - std::max(0.0, now() - transactionStartTime));
+		});
+
+		prevTimeout = currentTimeout;
+		currentTimeout = newTimeout;
+	}
+
+	// Cancel the previous timeout now that we have a new one. This means that changing the timeout
+	// affects in-flight operations, which is consistent with the behavior in RYW.
+	if (prevTimeout.isValid()) {
+		prevTimeout.cancel();
+	}
+}
+
+// Creates a ThreadFuture<T> that will signal an error if the transaction times out.
+ThreadFuture<Void> DisconnectedTransaction::makeTimeout() {
+	ThreadFuture<Void> f;
+
+	{ // lock scope
+		ThreadSpinLockHolder holder(timeoutLock);
+
+		// Our ThreadFuture holds a reference to this TSAV,
+		// but the ThreadFuture does not increment the ref count
+		timeoutTsav->addref();
+		f = ThreadFuture<Void>(timeoutTsav.getPtr());
+	}
+
+	return f;
+}
+
+void DisconnectedTransaction::replay(Reference<ITransaction> tr) {
+	mutex.enter();
+	std::vector<std::function<void(Reference<ITransaction>)>> opsToApply = operations;
+	mutex.leave();
+
+	for (auto f : opsToApply) {
+		f(tr);
+	}
+}
+
+template <class... Args>
+void DisconnectedTransaction::storeOperation(void (ITransaction::*func)(Args...), Args&&... args) {
+	auto copiedArgs = std::make_tuple(copyRefType(arena, args)...);
+	MutexHolder holder(mutex);
+	operations.push_back([copiedArgs, func](Reference<ITransaction> tr) {
+		std::apply([tr, func](Args... a) { (tr.getPtr()->*func)(std::forward<Args>(a)...); }, copiedArgs);
+	});
+}
+
+template <class T, class... Args>
+ThreadFuture<T> DisconnectedTransaction::storeOperation(ThreadFuture<T> (ITransaction::*func)(Args...),
+                                                        Args&&... args) {
+	Reference<ThreadSingleAssignmentVar<T>> sav = makeReference<ThreadSingleAssignmentVar<T>>();
+
+	ThreadFuture<T> f(sav.getPtr());
+	sav->addref();
+
+	auto copiedArgs = std::make_tuple(copyRefType(arena, args)...);
+
+	{
+		MutexHolder holder(mutex);
+		operations.push_back([copiedArgs, func, sav](Reference<ITransaction> tr) {
+			ThreadFuture<T> result = std::apply(
+			    [tr, func](Args... a) { return (tr.getPtr()->*func)(std::forward<Args>(a)...); }, copiedArgs);
+			mapThreadFuture<T, T>(result, [sav](ErrorOr<T> val) {
+				if (val.isError()) {
+					sav->sendError(val.getError());
+				} else {
+					sav->send(val.get());
+				}
+
+				return val;
+			});
+		});
+	}
+
+	return abortableFuture(f, makeTimeout(), error_code_transaction_timed_out);
+}
+
+template <class T, class... Args>
+ThreadResult<T> DisconnectedTransaction::storeOperation(ThreadResult<T> (ITransaction::*func)(Args...),
+                                                        Args&&... args) {
+	try {
+		Reference<ThreadSingleAssignmentVar<T>> sav;
+
+		ThreadFuture<T> f(sav.getPtr());
+		sav->addref();
+
+		auto copiedArgs = std::make_tuple(copyRefType(arena, args)...);
+
+		{
+			MutexHolder holder(mutex);
+			operations.push_back([copiedArgs, func](Reference<ITransaction> tr) {
+				ThreadResult<T> result = std::apply(
+				    [tr, func](Args... a) { return (tr.getPtr()->*func)(std::forward<Args>(a)...); }, copiedArgs);
+			});
+		}
+
+		f = abortableFuture(f, makeTimeout(), error_code_transaction_timed_out);
+		f.blockUntilReadyCheckOnMainThread();
+
+		return ThreadResult<T>(sav.extractPtr());
+	} catch (Error& e) {
+		return ThreadResult<T>(e);
+	}
+}

--- a/fdbclient/FDBOptions.cpp
+++ b/fdbclient/FDBOptions.cpp
@@ -1,0 +1,51 @@
+/*
+ * FDBOptions.cpp
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2022 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <string>
+#include <list>
+#include <map>
+
+#include "fdbclient/FDBOptions.h"
+
+void validateOptionValuePresent(Optional<StringRef> value) {
+	if (!value.present()) {
+		throw invalid_option_value();
+	}
+}
+
+void validateOptionValueNotPresent(Optional<StringRef> value) {
+	if (value.present() && value.get().size() > 0) {
+		throw invalid_option_value();
+	}
+}
+
+int64_t extractIntOption(Optional<StringRef> value, int64_t minValue, int64_t maxValue) {
+	validateOptionValuePresent(value);
+	if (value.get().size() != 8) {
+		throw invalid_option_value();
+	}
+
+	int64_t passed = *((int64_t*)(value.get().begin()));
+	if (passed > maxValue || passed < minValue) {
+		throw invalid_option_value();
+	}
+
+	return passed;
+}

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -468,18 +468,6 @@ void DatabaseContext::validateVersion(Version version) const {
 	ASSERT(version > 0 || version == latestVersion);
 }
 
-void validateOptionValuePresent(Optional<StringRef> value) {
-	if (!value.present()) {
-		throw invalid_option_value();
-	}
-}
-
-void validateOptionValueNotPresent(Optional<StringRef> value) {
-	if (value.present() && value.get().size() > 0) {
-		throw invalid_option_value();
-	}
-}
-
 void dumpMutations(const MutationListRef& mutations) {
 	for (auto m = mutations.begin(); m; ++m) {
 		switch (m->type) {
@@ -1989,28 +1977,6 @@ bool DatabaseContext::sampleOnCost(uint64_t cost) const {
 	if (sampleCost <= 0)
 		return false;
 	return deterministicRandom()->random01() <= (double)cost / sampleCost;
-}
-
-int64_t extractIntOption(Optional<StringRef> value, int64_t minValue, int64_t maxValue) {
-	validateOptionValuePresent(value);
-	if (value.get().size() != 8) {
-		throw invalid_option_value();
-	}
-
-	int64_t passed = *((int64_t*)(value.get().begin()));
-	if (passed > maxValue || passed < minValue) {
-		throw invalid_option_value();
-	}
-
-	return passed;
-}
-
-uint64_t extractHexOption(StringRef value) {
-	char* end;
-	uint64_t id = strtoull(value.toString().c_str(), &end, 16);
-	if (*end)
-		throw invalid_option_value();
-	return id;
 }
 
 void DatabaseContext::setOption(FDBDatabaseOptions::Option option, Optional<StringRef> value) {

--- a/fdbclient/ThreadSafeTransaction.cpp
+++ b/fdbclient/ThreadSafeTransaction.cpp
@@ -399,7 +399,7 @@ ThreadFuture<Standalone<VectorRef<KeyRangeRef>>> ThreadSafeTransaction::getBlobG
 ThreadResult<RangeResult> ThreadSafeTransaction::readBlobGranules(const KeyRangeRef& keyRange,
                                                                   Version beginVersion,
                                                                   Optional<Version> readVersion,
-                                                                  ReadBlobGranuleContext granule_context) {
+                                                                  ReadBlobGranuleContext granuleContext) {
 	// FIXME: prevent from calling this from another main thread!
 
 	ISingleThreadTransaction* tr = this->tr;
@@ -423,10 +423,10 @@ ThreadResult<RangeResult> ThreadSafeTransaction::readBlobGranules(const KeyRange
 	Standalone<VectorRef<BlobGranuleChunkRef>> files = getFilesFuture.get();
 
 	// do this work off of fdb network threads for performance!
-	if (granule_context.debugNoMaterialize) {
+	if (granuleContext.debugNoMaterialize) {
 		return ThreadResult<RangeResult>(blob_granule_not_materialized());
 	} else {
-		return loadAndMaterializeBlobGranules(files, keyRange, beginVersion, readVersionOut, granule_context);
+		return loadAndMaterializeBlobGranules(files, keyRange, beginVersion, readVersionOut, granuleContext);
 	}
 }
 

--- a/fdbclient/include/fdbclient/DisconnectedTransaction.h
+++ b/fdbclient/include/fdbclient/DisconnectedTransaction.h
@@ -1,0 +1,149 @@
+/*
+ * DisconnectedTransaction.h
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2022 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FDBCLIENT_DISCONNECTEDTRANSACTION_H
+#define FDBCLIENT_DISCONNECTEDTRANSACTION_H
+#pragma once
+
+#include "fdbclient/FDBOptions.g.h"
+#include "fdbclient/FDBTypes.h"
+#include "fdbclient/IClientApi.h"
+
+class DisconnectedTransaction : public ITransaction, ThreadSafeReferenceCounted<DisconnectedTransaction> {
+public:
+	DisconnectedTransaction(Optional<TenantName> tenant);
+	~DisconnectedTransaction() override;
+
+	void cancel() override;
+	void setVersion(Version v) override;
+	ThreadFuture<Version> getReadVersion() override;
+
+	ThreadFuture<Optional<Value>> get(const KeyRef& key, bool snapshot = false) override;
+	ThreadFuture<Key> getKey(const KeySelectorRef& key, bool snapshot = false) override;
+	ThreadFuture<RangeResult> getRange(const KeySelectorRef& begin,
+	                                   const KeySelectorRef& end,
+	                                   int limit,
+	                                   bool snapshot = false,
+	                                   bool reverse = false) override;
+	ThreadFuture<RangeResult> getRange(const KeySelectorRef& begin,
+	                                   const KeySelectorRef& end,
+	                                   GetRangeLimits limits,
+	                                   bool snapshot = false,
+	                                   bool reverse = false) override;
+	ThreadFuture<RangeResult> getRange(const KeyRangeRef& keys,
+	                                   int limit,
+	                                   bool snapshot = false,
+	                                   bool reverse = false) override;
+	ThreadFuture<RangeResult> getRange(const KeyRangeRef& keys,
+	                                   GetRangeLimits limits,
+	                                   bool snapshot = false,
+	                                   bool reverse = false) override;
+	ThreadFuture<MappedRangeResult> getMappedRange(const KeySelectorRef& begin,
+	                                               const KeySelectorRef& end,
+	                                               const StringRef& mapper,
+	                                               GetRangeLimits limits,
+	                                               int matchIndex,
+	                                               bool snapshot,
+	                                               bool reverse) override;
+	ThreadFuture<Standalone<VectorRef<const char*>>> getAddressesForKey(const KeyRef& key) override;
+	ThreadFuture<Standalone<StringRef>> getVersionstamp() override;
+
+	void addReadConflictRange(const KeyRangeRef& keys) override;
+	ThreadFuture<int64_t> getEstimatedRangeSizeBytes(const KeyRangeRef& keys) override;
+
+	ThreadFuture<Standalone<VectorRef<KeyRef>>> getRangeSplitPoints(const KeyRangeRef& range,
+	                                                                int64_t chunkSize) override;
+	ThreadFuture<Standalone<VectorRef<KeyRangeRef>>> getBlobGranuleRanges(const KeyRangeRef& keyRange,
+	                                                                      int rangeLimit) override;
+
+	ThreadResult<RangeResult> readBlobGranules(const KeyRangeRef& keyRange,
+	                                           Version beginVersion,
+	                                           Optional<Version> readVersion,
+	                                           ReadBlobGranuleContext granuleContext) override;
+
+	void atomicOp(const KeyRef& key, const ValueRef& value, uint32_t operationType) override;
+	void set(const KeyRef& key, const ValueRef& value) override;
+	void clear(const KeyRef& begin, const KeyRef& end) override;
+	void clear(const KeyRangeRef& range) override;
+	void clear(const KeyRef& key) override;
+
+	ThreadFuture<Void> watch(const KeyRef& key) override;
+
+	void addWriteConflictRange(const KeyRangeRef& keys) override;
+
+	ThreadFuture<Void> commit() override;
+	Version getCommittedVersion() override;
+	ThreadFuture<VersionVector> getVersionVector() override;
+	ThreadFuture<SpanContext> getSpanContext() override;
+	ThreadFuture<int64_t> getApproximateSize() override;
+
+	void setOption(FDBTransactionOptions::Option option, Optional<StringRef> value = Optional<StringRef>()) override;
+
+	ThreadFuture<Void> onError(Error const& e) override;
+	void reset() override;
+
+	Optional<TenantName> getTenant() override;
+
+	void addref() override { ThreadSafeReferenceCounted<DisconnectedTransaction>::addref(); }
+	void delref() override { ThreadSafeReferenceCounted<DisconnectedTransaction>::delref(); }
+
+	// return true if the underlying transaction pointer is not empty
+	bool isValid() override;
+
+	bool isReplayable() override { return true; }
+	void replay(Reference<ITransaction> tr) override;
+
+private:
+	// The time when the MultiVersionTransaction was last created or reset
+	std::atomic<double> startTime;
+
+	// A lock that needs to be held if using timeoutTsav or currentTimeout
+	ThreadSpinLock timeoutLock;
+
+	// A single assignment var (i.e. promise) that gets set with an error when the timeout elapses or the transaction
+	// is reset or destroyed.
+	Reference<ThreadSingleAssignmentVar<Void>> timeoutTsav;
+
+	// A reference to the current actor waiting for the timeout. This actor will set the timeoutTsav promise.
+	ThreadFuture<Void> currentTimeout;
+
+	// Configure a timeout based on the options set for this transaction. This timeout only applies
+	// if we don't have an underlying database object to connect with.
+	void setTimeout(Optional<StringRef> value);
+
+	// Creates a ThreadFuture that will be set (to Void) when the transaction times out.
+	ThreadFuture<Void> makeTimeout();
+
+	template <class... Args>
+	void storeOperation(void (ITransaction::*func)(Args...), Args&&... args);
+
+	template <class T, class... Args>
+	ThreadFuture<T> storeOperation(ThreadFuture<T> (ITransaction::*func)(Args...), Args&&... args);
+
+	template <class T, class... Args>
+	ThreadResult<T> storeOperation(ThreadResult<T> (ITransaction::*func)(Args...), Args&&... args);
+
+	Arena arena;
+	Mutex mutex;
+	std::vector<std::function<void(Reference<ITransaction>)>> operations;
+	Optional<TenantName> tenant;
+};
+
+#endif

--- a/fdbclient/include/fdbclient/FDBOptions.h
+++ b/fdbclient/include/fdbclient/FDBOptions.h
@@ -113,4 +113,11 @@ public:
 	type::optionInfo.insert(                                                                                           \
 	    var, FDBOptionInfo(name, comment, parameterComment, hasParameter, hidden, persistent, defaultFor, paramType));
 
+void validateOptionValuePresent(Optional<StringRef> value);
+void validateOptionValueNotPresent(Optional<StringRef> value);
+
+int64_t extractIntOption(Optional<StringRef> value,
+                         int64_t minValue = std::numeric_limits<int64_t>::min(),
+                         int64_t maxValue = std::numeric_limits<int64_t>::max());
+
 #endif

--- a/fdbclient/include/fdbclient/IClientApi.h
+++ b/fdbclient/include/fdbclient/IClientApi.h
@@ -122,6 +122,9 @@ public:
 	virtual bool isValid() { return true; }
 
 	virtual Optional<TenantName> getTenant() = 0;
+
+	virtual bool isReplayable() { return false; }
+	virtual void replay(Reference<ITransaction> tr) { ASSERT(false); }
 };
 
 class ITenant {

--- a/fdbclient/include/fdbclient/NativeAPI.actor.h
+++ b/fdbclient/include/fdbclient/NativeAPI.actor.h
@@ -55,9 +55,6 @@ void addref(DatabaseContext* ptr);
 template <>
 void delref(DatabaseContext* ptr);
 
-void validateOptionValuePresent(Optional<StringRef> value);
-void validateOptionValueNotPresent(Optional<StringRef> value);
-
 void enableClientInfoLogging();
 
 struct NetworkOptions {
@@ -519,10 +516,6 @@ ACTOR Future<Standalone<VectorRef<DDMetricsRef>>> waitDataDistributionMetricsLis
                                                                                   int shardLimit);
 
 std::string unprintable(const std::string&);
-
-int64_t extractIntOption(Optional<StringRef> value,
-                         int64_t minValue = std::numeric_limits<int64_t>::min(),
-                         int64_t maxValue = std::numeric_limits<int64_t>::max());
 
 // Takes a snapshot of the cluster, specifically the following persistent
 // states: coordinator, TLog and storage state


### PR DESCRIPTION
This is a proof-of-concept for an idea I had to avoid the `cluster_version_changed` error that happens on startup when connecting with the MVC. Rather than forcing you to re-run the transaction, this uses a new `DisconnectedTransaction` class to buffer up the intended operations and apply them when the connection is established.

It has not been tested in any way.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
