### PR TITLE
Include an addr2line backtrace with valgrind errors in test harness

### DIFF
--- a/contrib/TestHarness/Program.cs
+++ b/contrib/TestHarness/Program.cs
@@ -747,16 +747,28 @@ namespace SummarizeTest
             AppendToSummary(summaryFileName, xout);
         }
 
-        // Parses the valgrind XML file and returns a list of "what" tags for each error.
+        static string ParseValgrindStack(XElement stackElement) {
+            string backtrace = "";
+            foreach (XElement frame in stackElement.Elements()) {
+                backtrace += " " + frame.Element("ip").Value.ToLower();
+            }
+            if (backtrace.Length > 0) {
+                backtrace = "addr2line -e fdbserver.debug -p -C -f -i" + backtrace;
+            }
+
+            return backtrace;
+        }
+
+        // Parses the valgrind XML file and returns a list of error elements.
         //  All errors for which the "kind" tag starts with "Leak" are ignored
-        static Tuple<string, string>[] ParseValgrindOutput(string valgrindOutputFileName, bool traceToStdout)
+        static XElement[] ParseValgrindOutput(string valgrindOutputFileName, bool traceToStdout)
         {
             if (!traceToStdout)
             {
                 Console.WriteLine("Reading vXML file: " + valgrindOutputFileName);
             }
 
-            ISet<Tuple<string, string>> whats = new HashSet<Tuple<string, string>>();
+            IList<XElement> errors = new List<XElement>();
             XElement xdoc = XDocument.Load(valgrindOutputFileName).Element("valgrindoutput");
             foreach(var elem in xdoc.Elements()) {
                 if (elem.Name != "error")
@@ -764,19 +776,29 @@ namespace SummarizeTest
                 string kind = elem.Element("kind").Value;
                 if(kind.StartsWith("Leak"))
                     continue;
-                string backtrace = "";
-                XElement stack = elem.Element("stack");
-                foreach (XElement frame in stack.Elements()) {
-                    backtrace += " " + frame.Element("ip").Value.ToLower();
+
+                XElement errorElement = new XElement("ValgrindError",
+                                new XAttribute("Severity", (int)Magnesium.Severity.SevError));
+
+                int num = 1;
+                string suffix = "";
+                foreach (XElement sub in elem.Elements()) {
+                    if (sub.Name == "what") {
+                        errorElement.SetAttributeValue("What", sub.Value);
+                    } else if (sub.Name == "auxwhat") {
+                        suffix = "Aux" + num++;
+                        errorElement.SetAttributeValue("What" + suffix, sub.Value);
+                    } else if (sub.Name == "stack") {
+                        errorElement.SetAttributeValue("Backtrace" + suffix, ParseValgrindStack(sub));
+                    } else if (sub.Name == "origin") {
+                        errorElement.SetAttributeValue("WhatOrigin", sub.Element("what").Value);
+                        errorElement.SetAttributeValue("BacktraceOrigin", ParseValgrindStack(sub.Element("stack")));
+                    }
                 }
 
-                if (backtrace.Length > 0) {
-                    backtrace = "addr2line -e fdbserver.debug -p -C -f -i" + backtrace;
-                }
-
-                whats.Add(new Tuple<string, string>(elem.Element("what").Value, backtrace));
+                errors.Add(errorElement);
             }
-            return whats.ToArray();
+            return errors.ToArray();
         }
 
         delegate IEnumerable<Magnesium.Event> parseDelegate(System.IO.Stream stream, string file,
@@ -1085,10 +1107,7 @@ namespace SummarizeTest
                     var valgrindErrors = ParseValgrindOutput(valgrindOutputFileName, traceToStdout);
                     foreach (var vError in valgrindErrors)
                     {
-                        xout.Add(new XElement("ValgrindError",
-                                new XAttribute("Severity", (int)Magnesium.Severity.SevError),
-                                new XAttribute("What", vError.Item1),
-                                new XAttribute("Backtrace", vError.Item2)));
+                        xout.Add(vError);
                         ok = false;
                         error = true;
                     }


### PR DESCRIPTION
This generates an `addr2line` command that can be used to get a backtrace for a valgrind error reported by TestHarness. This still requires that you run a command with the tested binary, but it's easier that re-running the test itself.

Also, this helps provide more detail for non-deterministic valgrind errors (e.g. from noSim tests) that don't readily reproduce.

Example output:

```
<ValgrindError 
     Severity="40" 
     What="Invalid read of size 4" 
     Backtrace="addr2line -e fdbserver.debug -p -C -f -i 0x39ff57b 0x2e98341 0x2e99d31 0x2e9a1b6 0x22f4b83 0x22f4dd2 0x23091ac 0x2309cf0 0x230a728 0x230ac40 0x232146e 0x2321a67" 
     WhatAux1="Address 0x84ac920 is 0 bytes inside a block of size 4 free'd" 
     BacktraceAux1="addr2line -e fdbserver.debug -p -C -f -i 0x69b8897 0x39ff57a 0x2e98341 0x2e99d31 0x2e9a1b6 0x22f4b83 0x22f4dd2 0x23091ac 0x2309cf0 0x230a728 0x230ac40 0x232146e" 
     WhatAux2="Block was alloc'd at" 
     BacktraceAux2="addr2line -e fdbserver.debug -p -C -f -i 0x69b5fdd 0x3cfb597 0x39ff564 0x2e98341 0x2e99d31 0x2e9a1b6 0x22f4b83 0x22f4dd2 0x23091ac 0x2309cf0 0x230a728 0x230ac40" 
 />
```

Same output using our pretty-printing tools:

```
"Errors" : [
      {
         "Backtrace" : "addr2line -e fdbserver.debug -p -C -f -i 0x39ff57b 0x2e98341 0x2e99d31 0x2e9a1b6 0x22f4b83 0x22f4dd2 0x23091ac 0x2309cf0 0x230a728 0x230ac40 0x232146e 0x2321a67",
         "BacktraceAux1" : "addr2line -e fdbserver.debug -p -C -f -i 0x69b8897 0x39ff57a 0x2e98341 0x2e99d31 0x2e9a1b6 0x22f4b83 0x22f4dd2 0x23091ac 0x2309cf0 0x230a728 0x230ac40 0x232146e",
         "BacktraceAux2" : "addr2line -e fdbserver.debug -p -C -f -i 0x69b5fdd 0x3cfb597 0x39ff564 0x2e98341 0x2e99d31 0x2e9a1b6 0x22f4b83 0x22f4dd2 0x23091ac 0x2309cf0 0x230a728 0x230ac40",
         "Severity" : "40",
         "Type" : "ValgrindError",
         "What" : "Invalid read of size 4",
         "WhatAux1" : "Address 0x84ac920 is 0 bytes inside a block of size 4 free'd",
         "WhatAux2" : "Block was alloc'd at"
      }
   ]
```

Note that formerly, the errors list would be limited to one error of each type and I think would be unordered. It is now ordered and includes all encountered valgrind errors. If that is undesirable, we could try to limit how many errors appear.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
