### PR TITLE
scaling back ChangeFeedOperationsMove to avoid TraceTooManyLines

### DIFF
--- a/tests/fast/ChangeFeedOperations.toml
+++ b/tests/fast/ChangeFeedOperations.toml
@@ -1,8 +1,6 @@
 [configuration]
 allowDefaultTenant = false
 
-# TODO add failure events, and then add a version that also supports randomMoveKeys
-
 [[test]]
 testTitle = 'ChangeFeedOperationsTest'
 

--- a/tests/fast/ChangeFeedOperationsMove.toml
+++ b/tests/fast/ChangeFeedOperationsMove.toml
@@ -1,39 +1,37 @@
 [configuration]
 allowDefaultTenant = false
 
-# TODO add failure events, and then add a version that also supports randomMoveKeys
-
 [[test]]
 testTitle = 'ChangeFeedOperationsTest'
 
     [[test.workload]]
     testName = 'ChangeFeedOperations'
-    testDuration = 60.0
+    testDuration = 30.0
 
     [[test.workload]]
     testName = 'RandomMoveKeys'
-    testDuration = 60.0
+    testDuration = 30.0
 
     [[test.workload]]
     testName = 'RandomClogging'
-    testDuration = 60.0
+    testDuration = 30.0
 
     [[test.workload]]
     testName = 'Rollback'
-    meanDelay = 60.0
-    testDuration = 60.0
+    meanDelay = 30.0
+    testDuration = 30.0
 
     [[test.workload]]
     testName = 'Attrition'
     machinesToKill = 10
     machinesToLeave = 3
     reboot = true
-    testDuration = 60.0
+    testDuration = 30.0
 
     [[test.workload]]
     testName = 'Attrition'
     machinesToKill = 10
     machinesToLeave = 3
     reboot = true
-    testDuration = 60.0
+    testDuration = 30.0
 


### PR DESCRIPTION
Test was occasionally hitting TraceTooManyLines just due to a huge number of data moves and private mutations generated by those moves.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
