### PR TITLE
[snowflake/release-71.2] Allow rk throttle reason being UNSET in RkTagThrottleCollection::incrementBusyTagCount

### DIFF
--- a/fdbserver/RkTagThrottleCollection.cpp
+++ b/fdbserver/RkTagThrottleCollection.cpp
@@ -353,6 +353,7 @@ void RkTagThrottleCollection::incrementBusyTagCount(TagThrottledReason reason) {
 	} else if (reason == TagThrottledReason::BUSY_WRITE) {
 		++busyWriteTagCount;
 	} else {
-		ASSERT(false);
+		ASSERT(reason == TagThrottledReason::UNSET);
+		CODE_PROBE(true, "tag throttled reason is unset, probably because of upgrading");
 	}
 }


### PR DESCRIPTION
Cherry-pick #7948 

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
