### PR TITLE
Split Redwood page by tenant boundary

### DIFF
--- a/fdbserver/VersionedBTree.actor.cpp
+++ b/fdbserver/VersionedBTree.actor.cpp
@@ -6234,7 +6234,7 @@ private:
 		//
 		// There's another case. When encryption domain is enabled, we want to make sure the root node is encrypted
 		// using the default encryption domain. An indication that's not true is when the first record is not
-		// is enabled, and the root node is not encrypted using the default
+		// is using dbBegin as key.
 		while (records.size() > 1 ||
 		       records.front().getChildPage().size() > (BUGGIFY ? 1 : BTreeCommitHeader::maxRootPointerSize) ||
 		       records[0].key != dbBegin.key) {
@@ -8104,7 +8104,7 @@ public:
 			ASSERT(encryptionKeyProvider->expectedEncodingType() == EncodingType::AESEncryptionV1);
 			encodingType = EncodingType::AESEncryptionV1;
 			m_keyProvider = encryptionKeyProvider;
-		} else if (g_network->isSimulated() && logID.hash() % 2 == 0) {
+		} else if (BUGGIFY) {
 			// Simulation only. Deterministically enable encryption based on uid
 			encodingType = EncodingType::XOREncryption_TestOnly;
 			m_keyProvider = makeReference<XOREncryptionKeyProvider_TestOnly>(filename);

--- a/fdbserver/VersionedBTree.actor.cpp
+++ b/fdbserver/VersionedBTree.actor.cpp
@@ -4784,7 +4784,7 @@ struct DecodeBoundaryVerifier {
 	int boundaryPopulation = 0;
 	Reference<IPageEncryptionKeyProvider> keyProvider;
 
-	// Sample rate of pages to be scanned to verify if entries in the page meet domain prefix requirement.
+	// Sample rate of pages to be scanned to verify if all entries in the page meet domain prefix requirement.
 	double domainPrefixScanProbability = 0.01;
 	uint64_t domainPrefixScanCount = 0;
 
@@ -4833,16 +4833,21 @@ struct DecodeBoundaryVerifier {
 
 		if (domainId.present()) {
 			ASSERT(keyProvider && keyProvider->enableEncryptionDomain());
+			// Temporarily disabling the check, since if a tenant is removed, where the key provider
+			// would not find the domain, the data for the tenant may still be in Redwood and being read.
+			// TODO(yiwu): re-enable the check.
+			/*
 			if (domainId.get() != keyProvider->getDefaultEncryptionDomainId() &&
 			    !keyProvider->keyFitsInDomain(domainId.get(), lowerBound, false)) {
-				fprintf(stderr,
-				        "Page lower bound not in domain: %s %s, domain id %s, lower bound '%s'\n",
-				        ::toString(id).c_str(),
-				        ::toString(v).c_str(),
-				        ::toString(domainId).c_str(),
-				        lowerBound.printable().c_str());
-				return false;
+			    fprintf(stderr,
+			            "Page lower bound not in domain: %s %s, domain id %s, lower bound '%s'\n",
+			            ::toString(id).c_str(),
+			            ::toString(v).c_str(),
+			            ::toString(domainId).c_str(),
+			            lowerBound.printable().c_str());
+			    return false;
 			}
+			*/
 		}
 
 		auto& b = boundariesByPageID[id.front()][v];

--- a/fdbserver/VersionedBTree.actor.cpp
+++ b/fdbserver/VersionedBTree.actor.cpp
@@ -18,39 +18,40 @@
  * limitations under the License.
  */
 
-#include "fdbserver/WorkerInterface.actor.h"
-#include "flow/FastRef.h"
-#include "fmt/format.h"
+#include "fdbclient/CommitTransaction.h"
 #include "fdbclient/FDBTypes.h"
+#include "fdbclient/Tuple.h"
+#include "fdbrpc/ContinuousSample.h"
+#include "fdbrpc/simulator.h"
+#include "fdbserver/DeltaTree.h"
+#include "fdbserver/IKeyValueStore.h"
+#include "fdbserver/IPager.h"
 #include "fdbserver/Knobs.h"
+#include "fdbserver/WorkerInterface.actor.h"
+#include "flow/ActorCollection.h"
 #include "flow/Error.h"
+#include "flow/FastRef.h"
+#include "flow/flow.h"
+#include "flow/genericactors.actor.h"
+#include "flow/Histogram.h"
+#include "flow/IAsyncFile.h"
 #include "flow/IRandom.h"
 #include "flow/Knobs.h"
 #include "flow/ObjectSerializer.h"
-#include "flow/Trace.h"
-#include "flow/flow.h"
-#include "flow/Histogram.h"
-#include <limits>
-#include <random>
-#include "fdbrpc/ContinuousSample.h"
-#include "fdbrpc/simulator.h"
-#include "fdbserver/IPager.h"
-#include "fdbclient/Tuple.h"
 #include "flow/serialize.h"
-#include "flow/genericactors.actor.h"
+#include "flow/Trace.h"
 #include "flow/UnitTest.h"
-#include "flow/IAsyncFile.h"
-#include "flow/ActorCollection.h"
+#include "fmt/format.h"
+
+#include <boost/intrusive/list.hpp>
+#include <cinttypes>
+#include <limits>
 #include <map>
+#include <random>
 #include <string>
 #include <unordered_map>
 #include <vector>
-#include "fdbclient/CommitTransaction.h"
-#include "fdbserver/IKeyValueStore.h"
-#include "fdbserver/DeltaTree.h"
-#include <string.h>
-#include <cinttypes>
-#include <boost/intrusive/list.hpp>
+
 #include "flow/actorcompiler.h" // must be last include
 
 #define REDWOOD_DEBUG 0
@@ -4782,6 +4783,8 @@ struct DecodeBoundaryVerifier {
 	int boundarySampleSize = 1000;
 	int boundaryPopulation = 0;
 	Reference<IPageEncryptionKeyProvider> keyProvider;
+
+	// Sample rate of pages to be scanned to verify if entries in the page meet domain prefix requirement.
 	double domainPrefixScanProbability = 0.01;
 	uint64_t domainPrefixScanCount = 0;
 

--- a/fdbserver/VersionedBTree.actor.cpp
+++ b/fdbserver/VersionedBTree.actor.cpp
@@ -4896,7 +4896,10 @@ struct DecodeBoundaryVerifier {
 						        ::toString(v).c_str(),
 						        ::toString(domainId).c_str(),
 						        cursor.get().key.printable().c_str());
-						return false;
+						// Temporarily disabling the check, since if a tenant is removed, where the key provider
+						// would not find the domain, the data for the tenant may still be in Redwood and being read.
+						// TODO(yiwu): re-enable the check.
+						// return false;
 					}
 					cursor.moveNext();
 				}
@@ -11468,17 +11471,5 @@ TEST_CASE(":/redwood/performance/histograms") {
 	double elapsed_time_ms = std::chrono::duration<double, std::milli>(t_end - t_start).count();
 	std::cout << "Time needed to log 33 histograms (millisecond): " << elapsed_time_ms << std::endl;
 
-	{
-		ContinuousSample<uint32_t> s = ContinuousSample<uint32_t>(pow(10, 3));
-		auto t_start = std::chrono::high_resolution_clock::now();
-		ASSERT(uniform.size() == inputSize);
-		for (size_t i = 0; i < uniform.size(); i++) {
-			s.addSample(uniform[i]);
-		}
-		auto t_end = std::chrono::high_resolution_clock::now();
-		double elapsed_time_ms = std::chrono::duration<double, std::milli>(t_end - t_start).count();
-		std::cout << "size of input: " << uniform.size() << std::endl;
-		std::cout << "Time in millisecond: " << elapsed_time_ms << std::endl;
-	}
 	return Void();
 }

--- a/fdbserver/VersionedBTree.actor.cpp
+++ b/fdbserver/VersionedBTree.actor.cpp
@@ -6233,8 +6233,8 @@ private:
 		// size.
 		//
 		// There's another case. When encryption domain is enabled, we want to make sure the root node is encrypted
-		// using the default encryption domain. An indication that's not true is when the first record is not
-		// is using dbBegin as key.
+		// using the default encryption domain. An indication that's not true is when the first record is not using
+		// dbBegin as key.
 		while (records.size() > 1 ||
 		       records.front().getChildPage().size() > (BUGGIFY ? 1 : BTreeCommitHeader::maxRootPointerSize) ||
 		       records[0].key != dbBegin.key) {
@@ -8104,7 +8104,7 @@ public:
 			ASSERT(encryptionKeyProvider->expectedEncodingType() == EncodingType::AESEncryptionV1);
 			encodingType = EncodingType::AESEncryptionV1;
 			m_keyProvider = encryptionKeyProvider;
-		} else if (BUGGIFY) {
+		} else if (g_network->isSimulated() && logID.hash() % 2 == 0) {
 			// Simulation only. Deterministically enable encryption based on uid
 			encodingType = EncodingType::XOREncryption_TestOnly;
 			m_keyProvider = makeReference<XOREncryptionKeyProvider_TestOnly>(filename);


### PR DESCRIPTION
Redwood encrypt with page granularity. To do per-tenant encryption (i.e. each tenant are encrypted with different set of cipher keys), we need to split Redwood pages by tenant boundary. Moreover, it also needs to handle different tenant modes:
* tenantMode = disabled: do not split page by tenant, all data encrypt using default encryption domain.
* tenantMode = required: look at the prefix of the keys and split by tenant accordingly, and encrypt in tenant specific encryption domain accordingly.
* tenantMode = optional: some key ranges may not map to a tenant. In additional to looking at the key prefix, the key provider also query the tenant prefix index. For prefixes not found in the tenant prefix index, corresponding key should be encrypted using the default encryption domain.

The change also enforce data for each tenant forms a subtree, and key of the link to the subtree is exactly the tenant prefix.

This PR is building on top of #8172 and use the IPageEncryptionKeyProvider interface added there. Changes:
* In `writePages` and `splitPages`, query the key provider to split page accordingly.
* In `commitSubtree`, when doing in-place update (to both of leaf or internal page), check if the entry being insert belong to the same encryption domain as existing data of the page. If not, fallback to full page rebuild, where `writePages` will handle the page split.
* When updating the root, check if it is encrypted using non-default (i.e. tenant specific) domain. If so, add a redundant root node which will be encrypted with default encryption domain.

Tested with 100K run of `Lredwood/correctness/btree` unit test, where it uses `RandomEncryptionKeyProvider`, which is updated to support and generate random encryption domain with 4 byte domain prefixes. 

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
