### PR TITLE
Blob granule summary implementation (in native client)

### DIFF
--- a/fdbclient/BlobGranuleCommon.cpp
+++ b/fdbclient/BlobGranuleCommon.cpp
@@ -1,0 +1,45 @@
+/*
+ * BlobGranuleCommon.cpp
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2022 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "fdbclient/BlobGranuleCommon.h"
+
+BlobGranuleSummaryRef summarizeGranuleChunk(Arena& ar, const BlobGranuleChunkRef& chunk) {
+	BlobGranuleSummaryRef summary;
+	ASSERT(chunk.snapshotFile.present());
+	ASSERT(chunk.snapshotVersion != invalidVersion);
+	ASSERT(chunk.includedVersion >= chunk.snapshotVersion);
+	ASSERT(chunk.newDeltas.empty());
+
+	if (chunk.tenantPrefix.present()) {
+		summary.keyRange = KeyRangeRef(ar, chunk.keyRange.removePrefix(chunk.tenantPrefix.get()));
+	} else {
+		summary.keyRange = KeyRangeRef(ar, chunk.keyRange);
+	}
+
+	summary.snapshotVersion = chunk.snapshotVersion;
+	summary.snapshotSize = chunk.snapshotFile.get().length;
+	summary.deltaVersion = chunk.includedVersion;
+	summary.deltaSize = 0;
+	for (auto& it : chunk.deltaFiles) {
+		summary.deltaSize += it.length;
+	}
+
+	return summary;
+}

--- a/fdbclient/ClientKnobs.cpp
+++ b/fdbclient/ClientKnobs.cpp
@@ -276,7 +276,7 @@ void ClientKnobs::initialize(Randomize randomize) {
 
 	// Blob granules
 	init( BG_MAX_GRANULE_PARALLELISM,                10 );
-	init( BG_TOO_MANY_GRANULES,                    1000 );
+	init( BG_TOO_MANY_GRANULES,                   10000 );
 
 	init( CHANGE_QUORUM_BAD_STATE_RETRY_TIMES,        3 );
 	init( CHANGE_QUORUM_BAD_STATE_RETRY_DELAY,      2.0 );

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -7714,7 +7714,11 @@ ACTOR Future<Standalone<VectorRef<BlobGranuleChunkRef>>> readBlobGranulesActor(
     KeyRange range,
     Version begin,
     Optional<Version> read,
-    Version* readVersionOut) { // read not present is "use transaction version"
+    Version* readVersionOut,
+    int chunkLimit,
+    bool summarize) { // read not present is "use transaction version"
+
+	ASSERT(chunkLimit > 0);
 
 	state RangeResult blobGranuleMapping;
 	state Key granuleStartKey;
@@ -7869,6 +7873,7 @@ ACTOR Future<Standalone<VectorRef<BlobGranuleChunkRef>>> readBlobGranulesActor(
 		req.readVersion = rv;
 		req.tenantInfo = self->getTenant().present() ? self->trState->getTenantInfo() : TenantInfo();
 		req.canCollapseBegin = true; // TODO make this a parameter once we support it
+		req.summarize = summarize;
 
 		std::vector<Reference<ReferencedInterface<BlobWorkerInterface>>> v;
 		v.push_back(
@@ -7939,6 +7944,12 @@ ACTOR Future<Standalone<VectorRef<BlobGranuleChunkRef>>> readBlobGranulesActor(
 							chunkEndKey = chunkEndKey.removePrefix(tenantPrefix.get());
 						}
 						keyRange = KeyRangeRef(std::min(chunkEndKey, keyRange.end), keyRange.end);
+						if (summarize && results.size() == chunkLimit) {
+							break;
+						}
+					}
+					if (summarize && results.size() == chunkLimit) {
+						break;
 					}
 				}
 				// if we detect that this blob worker fails, cancel the request, as otherwise load balance will
@@ -7987,7 +7998,32 @@ Future<Standalone<VectorRef<BlobGranuleChunkRef>>> Transaction::readBlobGranules
                                                                                  Version begin,
                                                                                  Optional<Version> readVersion,
                                                                                  Version* readVersionOut) {
-	return readBlobGranulesActor(this, range, begin, readVersion, readVersionOut);
+	return readBlobGranulesActor(
+	    this, range, begin, readVersion, readVersionOut, std::numeric_limits<int>::max(), false);
+}
+
+ACTOR Future<Standalone<VectorRef<BlobGranuleSummaryRef>>> summarizeBlobGranulesActor(Transaction* self,
+                                                                                      KeyRange range,
+                                                                                      Version summaryVersion,
+                                                                                      int rangeLimit) {
+	state Version readVersionOut;
+	Standalone<VectorRef<BlobGranuleChunkRef>> chunks =
+	    wait(readBlobGranulesActor(self, range, 0, summaryVersion, &readVersionOut, rangeLimit, true));
+	ASSERT(chunks.size() <= rangeLimit);
+	ASSERT(readVersionOut == summaryVersion);
+	Standalone<VectorRef<BlobGranuleSummaryRef>> summaries;
+	summaries.reserve(summaries.arena(), chunks.size());
+	for (auto& it : chunks) {
+		summaries.push_back(summaries.arena(), summarizeGranuleChunk(summaries.arena(), it));
+	}
+
+	return summaries;
+}
+
+Future<Standalone<VectorRef<BlobGranuleSummaryRef>>> Transaction::summarizeBlobGranules(const KeyRange& range,
+                                                                                        Version summaryVersion,
+                                                                                        int rangeLimit) {
+	return summarizeBlobGranulesActor(this, range, summaryVersion, rangeLimit);
 }
 
 ACTOR Future<Version> setPerpetualStorageWiggle(Database cx, bool enable, LockAware lockAware) {
@@ -8013,11 +8049,18 @@ ACTOR Future<Version> setPerpetualStorageWiggle(Database cx, bool enable, LockAw
 
 ACTOR Future<Version> checkBlobSubrange(Database db, KeyRange keyRange, Optional<Version> version) {
 	state Transaction tr(db);
-	state Version readVersionOut = invalidVersion;
 	loop {
 		try {
-			wait(success(tr.readBlobGranules(keyRange, 0, version, &readVersionOut)));
-			return readVersionOut;
+			state Version summaryVersion;
+			if (version.present()) {
+				summaryVersion = version.get();
+			} else {
+				wait(store(summaryVersion, tr.getReadVersion()));
+			}
+			// same properties as a read for validating granule is readable, just much less memory and network bandwidth
+			// used
+			wait(success(tr.summarizeBlobGranules(keyRange, summaryVersion, std::numeric_limits<int>::max())));
+			return summaryVersion;
 		} catch (Error& e) {
 			wait(tr.onError(e));
 		}

--- a/fdbclient/include/fdbclient/BlobGranuleCommon.h
+++ b/fdbclient/include/fdbclient/BlobGranuleCommon.h
@@ -233,6 +233,22 @@ struct BlobGranuleChunkRef {
 	}
 };
 
+struct BlobGranuleSummaryRef {
+	constexpr static FileIdentifier file_identifier = 9774587;
+	KeyRangeRef keyRange;
+	Version snapshotVersion;
+	int64_t snapshotSize;
+	Version deltaVersion;
+	int64_t deltaSize;
+
+	template <class Ar>
+	void serialize(Ar& ar) {
+		serializer(ar, keyRange, snapshotVersion, snapshotSize, deltaVersion, deltaSize);
+	}
+};
+
+BlobGranuleSummaryRef summarizeGranuleChunk(Arena& ar, const BlobGranuleChunkRef& chunk);
+
 enum BlobGranuleSplitState { Unknown = 0, Initialized = 1, Assigned = 2, Done = 3 };
 
 // Boundary metadata for each range indexed by the beginning of the range.

--- a/fdbclient/include/fdbclient/BlobWorkerCommon.h
+++ b/fdbclient/include/fdbclient/BlobWorkerCommon.h
@@ -30,7 +30,7 @@ struct BlobWorkerStats {
 	Counter deltaBytesWritten, snapshotBytesWritten;
 	Counter bytesReadFromFDBForInitialSnapshot;
 	Counter bytesReadFromS3ForCompaction;
-	Counter rangeAssignmentRequests, readRequests;
+	Counter rangeAssignmentRequests, readRequests, summaryReads;
 	Counter wrongShardServer;
 	Counter changeFeedInputBytes;
 	Counter readReqTotalFilesReturned;
@@ -75,8 +75,8 @@ struct BlobWorkerStats {
 	    bytesReadFromFDBForInitialSnapshot("BytesReadFromFDBForInitialSnapshot", cc),
 	    bytesReadFromS3ForCompaction("BytesReadFromS3ForCompaction", cc),
 	    rangeAssignmentRequests("RangeAssignmentRequests", cc), readRequests("ReadRequests", cc),
-	    wrongShardServer("WrongShardServer", cc), changeFeedInputBytes("ChangeFeedInputBytes", cc),
-	    readReqTotalFilesReturned("ReadReqTotalFilesReturned", cc),
+	    summaryReads("SummaryReads", cc), wrongShardServer("WrongShardServer", cc),
+	    changeFeedInputBytes("ChangeFeedInputBytes", cc), readReqTotalFilesReturned("ReadReqTotalFilesReturned", cc),
 	    readReqDeltaBytesReturned("ReadReqDeltaBytesReturned", cc), commitVersionChecks("CommitVersionChecks", cc),
 	    granuleUpdateErrors("GranuleUpdateErrors", cc), granuleRequestTimeouts("GranuleRequestTimeouts", cc),
 	    readRequestsWithBegin("ReadRequestsWithBegin", cc), readRequestsCollapsed("ReadRequestsCollapsed", cc),

--- a/fdbclient/include/fdbclient/BlobWorkerInterface.h
+++ b/fdbclient/include/fdbclient/BlobWorkerInterface.h
@@ -113,6 +113,7 @@ struct BlobGranuleFileRequest {
 	Version readVersion;
 	bool canCollapseBegin = true;
 	TenantInfo tenantInfo;
+	bool summarize = false;
 	ReplyPromise<BlobGranuleFileReply> reply;
 
 	BlobGranuleFileRequest() {}
@@ -121,7 +122,7 @@ struct BlobGranuleFileRequest {
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, keyRange, beginVersion, readVersion, canCollapseBegin, tenantInfo, reply, arena);
+		serializer(ar, keyRange, beginVersion, readVersion, canCollapseBegin, tenantInfo, summarize, reply, arena);
 	}
 };
 

--- a/fdbclient/include/fdbclient/NativeAPI.actor.h
+++ b/fdbclient/include/fdbclient/NativeAPI.actor.h
@@ -421,6 +421,10 @@ public:
 	                                                                    Optional<Version> readVersion,
 	                                                                    Version* readVersionOut = nullptr);
 
+	Future<Standalone<VectorRef<BlobGranuleSummaryRef>>> summarizeBlobGranules(const KeyRange& range,
+	                                                                           Version summaryVersion,
+	                                                                           int rangeLimit);
+
 	// If checkWriteConflictRanges is true, existing write conflict ranges will be searched for this key
 	void set(const KeyRef& key, const ValueRef& value, AddConflictRange = AddConflictRange::True);
 	void atomicOp(const KeyRef& key,

--- a/fdbserver/BlobGranuleValidation.actor.cpp
+++ b/fdbserver/BlobGranuleValidation.actor.cpp
@@ -212,3 +212,132 @@ ACTOR Future<Void> clearAndAwaitMerge(Database cx, KeyRange range) {
 		}
 	}
 }
+
+ACTOR Future<Standalone<VectorRef<BlobGranuleSummaryRef>>> getSummaries(Database cx,
+                                                                        KeyRange range,
+                                                                        Version summaryVersion,
+                                                                        Optional<TenantName> tenantName) {
+	state Transaction tr(cx, tenantName);
+	loop {
+		try {
+			Standalone<VectorRef<BlobGranuleSummaryRef>> summaries =
+			    wait(tr.summarizeBlobGranules(range, summaryVersion, 1000000));
+
+			fmt::print("Got {0} Summaries at {1} for [{2} - {3})\n",
+			           summaries.size(),
+			           summaryVersion,
+			           range.begin.printable(),
+			           range.end.printable());
+			for (auto& it : summaries) {
+				fmt::print("  [{0} - {1})\n", it.keyRange.begin.printable(), it.keyRange.end.printable());
+			}
+
+			// do some basic validation
+			ASSERT(!summaries.empty());
+			ASSERT(summaries.front().keyRange.begin == range.begin);
+			ASSERT(summaries.back().keyRange.end == range.end);
+
+			for (int i = 0; i < summaries.size() - 1; i++) {
+				ASSERT(summaries[i].keyRange.end == summaries[i + 1].keyRange.begin);
+			}
+
+			return summaries;
+		} catch (Error& e) {
+			wait(tr.onError(e));
+		}
+	}
+}
+
+ACTOR Future<Void> validateGranuleSummaries(Database cx,
+                                            KeyRange range,
+                                            Optional<TenantName> tenantName,
+                                            Promise<Void> testComplete) {
+	state Arena lastSummaryArena;
+	state KeyRangeMap<Optional<BlobGranuleSummaryRef>> lastSummary;
+	state Version lastSummaryVersion = invalidVersion;
+	state Transaction tr(cx, tenantName);
+	state int successCount = 0;
+	try {
+		loop {
+			// get grv and get latest summaries
+			state Version nextSummaryVersion;
+			tr.reset();
+			loop {
+				try {
+					wait(store(nextSummaryVersion, tr.getReadVersion()));
+					ASSERT(nextSummaryVersion >= lastSummaryVersion);
+					break;
+				} catch (Error& e) {
+					wait(tr.onError(e));
+				}
+			}
+
+			state Standalone<VectorRef<BlobGranuleSummaryRef>> nextSummary;
+			try {
+				wait(store(nextSummary, getSummaries(cx, range, nextSummaryVersion, tenantName)));
+			} catch (Error& e) {
+				if (e.code() == error_code_blob_granule_transaction_too_old) {
+					ASSERT(lastSummaryVersion == invalidVersion);
+
+					wait(delay(1.0));
+					continue;
+				} else {
+					throw e;
+				}
+			}
+
+			if (lastSummaryVersion != invalidVersion) {
+				CODE_PROBE(true, "comparing multiple summaries");
+				// diff with last summary ranges to ensure versions never decreased for any range
+				for (auto& it : nextSummary) {
+					auto lastSummaries = lastSummary.intersectingRanges(it.keyRange);
+					for (auto& itLast : lastSummaries) {
+
+						if (!itLast.cvalue().present()) {
+							ASSERT(lastSummaryVersion == invalidVersion);
+							continue;
+						}
+						auto& last = itLast.cvalue().get();
+
+						ASSERT(it.snapshotVersion >= last.snapshotVersion);
+						// same invariant isn't always true for delta version because of force flushing around granule
+						// merges
+						if (it.keyRange == itLast.range()) {
+							ASSERT(it.deltaVersion >= last.deltaVersion);
+							if (it.snapshotVersion == last.snapshotVersion) {
+								ASSERT(it.snapshotSize == last.snapshotSize);
+							}
+							if (it.snapshotVersion == last.snapshotVersion && it.deltaVersion == last.deltaVersion) {
+								ASSERT(it.snapshotSize == last.snapshotSize);
+								ASSERT(it.deltaSize == last.deltaSize);
+							} else if (it.snapshotVersion == last.snapshotVersion) {
+								ASSERT(it.deltaSize > last.deltaSize);
+							}
+							break;
+						}
+					}
+				}
+
+				if (!testComplete.canBeSet()) {
+					return Void();
+				}
+			}
+
+			successCount++;
+
+			lastSummaryArena = nextSummary.arena();
+			lastSummaryVersion = nextSummaryVersion;
+			lastSummary.insert(range, {});
+			for (auto& it : nextSummary) {
+				lastSummary.insert(it.keyRange, it);
+			}
+
+			wait(delayJittered(deterministicRandom()->randomInt(1, 10)));
+		}
+	} catch (Error& e) {
+		if (e.code() != error_code_operation_cancelled) {
+			TraceEvent(SevError, "UnexpectedErrorValidateGranuleSummaries").error(e);
+		}
+		throw e;
+	}
+}

--- a/fdbserver/BlobGranuleValidation.actor.cpp
+++ b/fdbserver/BlobGranuleValidation.actor.cpp
@@ -223,15 +223,6 @@ ACTOR Future<Standalone<VectorRef<BlobGranuleSummaryRef>>> getSummaries(Database
 			Standalone<VectorRef<BlobGranuleSummaryRef>> summaries =
 			    wait(tr.summarizeBlobGranules(range, summaryVersion, 1000000));
 
-			fmt::print("Got {0} Summaries at {1} for [{2} - {3})\n",
-			           summaries.size(),
-			           summaryVersion,
-			           range.begin.printable(),
-			           range.end.printable());
-			for (auto& it : summaries) {
-				fmt::print("  [{0} - {1})\n", it.keyRange.begin.printable(), it.keyRange.end.printable());
-			}
-
 			// do some basic validation
 			ASSERT(!summaries.empty());
 			ASSERT(summaries.front().keyRange.begin == range.begin);

--- a/fdbserver/include/fdbserver/BlobGranuleServerCommon.actor.h
+++ b/fdbserver/include/fdbserver/BlobGranuleServerCommon.actor.h
@@ -87,7 +87,8 @@ struct GranuleFiles {
 	              bool canCollapse,
 	              BlobGranuleChunkRef& chunk,
 	              Arena& replyArena,
-	              int64_t& deltaBytesCounter) const;
+	              int64_t& deltaBytesCounter,
+	              bool summarize) const;
 };
 
 // serialize change feed key as UID bytes, to use 16 bytes on disk

--- a/fdbserver/include/fdbserver/BlobGranuleValidation.actor.h
+++ b/fdbserver/include/fdbserver/BlobGranuleValidation.actor.h
@@ -55,6 +55,11 @@ void printGranuleChunks(const Standalone<VectorRef<BlobGranuleChunkRef>>& chunks
 
 ACTOR Future<Void> clearAndAwaitMerge(Database cx, KeyRange range);
 
+ACTOR Future<Void> validateGranuleSummaries(Database cx,
+                                            KeyRange range,
+                                            Optional<TenantName> tenantName,
+                                            Promise<Void> testComplete);
+
 #include "flow/unactorcompiler.h"
 
 #endif

--- a/fdbserver/workloads/BlobGranuleCorrectnessWorkload.actor.cpp
+++ b/fdbserver/workloads/BlobGranuleCorrectnessWorkload.actor.cpp
@@ -91,6 +91,9 @@ struct ThreadData : ReferenceCounted<ThreadData>, NonCopyable {
 	Promise<Void> firstWriteSuccessful;
 	Version minSuccessfulReadVersion = MAX_VERSION;
 
+	Future<Void> summaryClient;
+	Promise<Void> triggerSummaryComplete;
+
 	// stats
 	int64_t errors = 0;
 	int64_t mismatches = 0;
@@ -886,6 +889,7 @@ struct BlobGranuleCorrectnessWorkload : TestWorkload {
 		for (auto& it : directories) {
 			// Wait for blob worker to initialize snapshot before starting test for that range
 			Future<Void> start = waitFirstSnapshot(this, cx, it, true);
+			it->summaryClient = validateGranuleSummaries(cx, normalKeys, it->tenantName, it->triggerSummaryComplete);
 			clients.push_back(timeout(writeWorker(this, start, cx, it), testDuration, Void()));
 			clients.push_back(timeout(readWorker(this, start, cx, it), testDuration, Void()));
 		}
@@ -919,6 +923,9 @@ struct BlobGranuleCorrectnessWorkload : TestWorkload {
 	                                  BlobGranuleCorrectnessWorkload* self,
 	                                  Reference<ThreadData> threadData) {
 
+		if (threadData->triggerSummaryComplete.canBeSet()) {
+			threadData->triggerSummaryComplete.send(Void());
+		}
 		state bool result = true;
 		state int finalRowsValidated;
 		if (threadData->writeVersions.empty()) {
@@ -984,6 +991,9 @@ struct BlobGranuleCorrectnessWorkload : TestWorkload {
 			CODE_PROBE(true, "BGCorrectness clearing database and awaiting merge");
 			wait(clearAndAwaitMerge(cx, threadData->directoryRange));
 		}
+
+		// validate that summary completes without error
+		wait(threadData->summaryClient);
 
 		return result;
 	}


### PR DESCRIPTION
This PR introduces a new BlobGranuleSummary* client function that piggybacks on readBlobGranules to generate a much more concise metadata representation, that have several uses:

- for clients to reason about blob granule state
- to improve performance of the "verifyBlobGranules" native function/"blobrange check" fdbcli command, as it would previously run slowly and/or run out of memory for large clusters, as it was loading all mutations and filenames into memory on the client before discarding them

Passes 100k BlobGranule* correctness tests.

I will create the C api bindings in a follow-up PR.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
