### PR TITLE
flow: allow for patch version to be set again for protocol version

### DIFF
--- a/flow/ProtocolVersion.h.cmake
+++ b/flow/ProtocolVersion.h.cmake
@@ -38,7 +38,7 @@ constexpr uint64_t futureProtocolVersionValue = @FDB_PV_FUTURE_VERSION@;
 
 // The first check second expression version doesn't need to change because it's just for earlier protocol versions.
 #define PROTOCOL_VERSION_FEATURE(v, x)                                                                                 \
-	static_assert((v & 0xF0FFFFLL) == 0 || v < 0x0FDB00B071000000LL, "Unexpected feature protocol version");           \
+	static_assert((v & 0xFFFFLL) == 0 || v < 0x0FDB00B071000000LL, "Unexpected feature protocol version");             \
 	static_assert(v <= defaultProtocolVersionValue, "Feature protocol version too large");                             \
 	struct x {                                                                                                         \
 		static constexpr uint64_t protocolVersion = v;                                                                 \


### PR DESCRIPTION
While only major and minor version matters for fdb releases regarding
protocol version, this makes testing a little bit easier.

Replace this text with your description here...

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [x] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
