### PR TITLE
Include an addr2line backtrace with valgrind errors in test harness (snowflake/release-71.2)

### DIFF
--- a/contrib/TestHarness/Program.cs
+++ b/contrib/TestHarness/Program.cs
@@ -748,14 +748,14 @@ namespace SummarizeTest
 
         // Parses the valgrind XML file and returns a list of "what" tags for each error.
         //  All errors for which the "kind" tag starts with "Leak" are ignored
-        static string[] ParseValgrindOutput(string valgrindOutputFileName, bool traceToStdout)
+        static Tuple<string, string>[] ParseValgrindOutput(string valgrindOutputFileName, bool traceToStdout)
         {
             if (!traceToStdout)
             {
                 Console.WriteLine("Reading vXML file: " + valgrindOutputFileName);
             }
 
-            ISet<string> whats = new HashSet<string>();
+            ISet<Tuple<string, string>> whats = new HashSet<Tuple<string, string>>();
             XElement xdoc = XDocument.Load(valgrindOutputFileName).Element("valgrindoutput");
             foreach(var elem in xdoc.Elements()) {
                 if (elem.Name != "error")
@@ -763,7 +763,17 @@ namespace SummarizeTest
                 string kind = elem.Element("kind").Value;
                 if(kind.StartsWith("Leak"))
                     continue;
-                whats.Add(elem.Element("what").Value);
+                string backtrace = "";
+                XElement stack = elem.Element("stack");
+                foreach (XElement frame in stack.Elements()) {
+                    backtrace += " " + frame.Element("ip").Value.ToLower();
+                }
+
+                if (backtrace.Length > 0) {
+                    backtrace = "addr2line -e fdbserver.debug -p -C -f -i" + backtrace;
+                }
+
+                whats.Add(new Tuple<string, string>(elem.Element("what").Value, backtrace));
             }
             return whats.ToArray();
         }
@@ -1071,12 +1081,13 @@ namespace SummarizeTest
                 try
                 {
                     // If there are any errors reported "ok" will be set to false
-                    var whats = ParseValgrindOutput(valgrindOutputFileName, traceToStdout);
-                    foreach (var what in whats)
+                    var valgrindErrors = ParseValgrindOutput(valgrindOutputFileName, traceToStdout);
+                    foreach (var vError in valgrindErrors)
                     {
                         xout.Add(new XElement("ValgrindError",
                                 new XAttribute("Severity", (int)Magnesium.Severity.SevError),
-                                new XAttribute("What", what)));
+                                new XAttribute("What", vError.Item1),
+                                new XAttribute("Backtrace", vError.Item2)));
                         ok = false;
                         error = true;
                     }

--- a/contrib/TestHarness/Program.cs
+++ b/contrib/TestHarness/Program.cs
@@ -746,16 +746,28 @@ namespace SummarizeTest
             AppendToSummary(summaryFileName, xout);
         }
 
-        // Parses the valgrind XML file and returns a list of "what" tags for each error.
+        static string ParseValgrindStack(XElement stackElement) {
+            string backtrace = "";
+            foreach (XElement frame in stackElement.Elements()) {
+                backtrace += " " + frame.Element("ip").Value.ToLower();
+            }
+            if (backtrace.Length > 0) {
+                backtrace = "addr2line -e fdbserver.debug -p -C -f -i" + backtrace;
+            }
+
+            return backtrace;
+        }
+
+        // Parses the valgrind XML file and returns a list of error elements.
         //  All errors for which the "kind" tag starts with "Leak" are ignored
-        static Tuple<string, string>[] ParseValgrindOutput(string valgrindOutputFileName, bool traceToStdout)
+        static XElement[] ParseValgrindOutput(string valgrindOutputFileName, bool traceToStdout)
         {
             if (!traceToStdout)
             {
                 Console.WriteLine("Reading vXML file: " + valgrindOutputFileName);
             }
 
-            ISet<Tuple<string, string>> whats = new HashSet<Tuple<string, string>>();
+            IList<XElement> errors = new List<XElement>();
             XElement xdoc = XDocument.Load(valgrindOutputFileName).Element("valgrindoutput");
             foreach(var elem in xdoc.Elements()) {
                 if (elem.Name != "error")
@@ -763,19 +775,29 @@ namespace SummarizeTest
                 string kind = elem.Element("kind").Value;
                 if(kind.StartsWith("Leak"))
                     continue;
-                string backtrace = "";
-                XElement stack = elem.Element("stack");
-                foreach (XElement frame in stack.Elements()) {
-                    backtrace += " " + frame.Element("ip").Value.ToLower();
+
+                XElement errorElement = new XElement("ValgrindError",
+                                new XAttribute("Severity", (int)Magnesium.Severity.SevError));
+
+                int num = 1;
+                string suffix = "";
+                foreach (XElement sub in elem.Elements()) {
+                    if (sub.Name == "what") {
+                        errorElement.SetAttributeValue("What", sub.Value);
+                    } else if (sub.Name == "auxwhat") {
+                        suffix = "Aux" + num++;
+                        errorElement.SetAttributeValue("What" + suffix, sub.Value);
+                    } else if (sub.Name == "stack") {
+                        errorElement.SetAttributeValue("Backtrace" + suffix, ParseValgrindStack(sub));
+                    } else if (sub.Name == "origin") {
+                        errorElement.SetAttributeValue("WhatOrigin", sub.Element("what").Value);
+                        errorElement.SetAttributeValue("BacktraceOrigin", ParseValgrindStack(sub.Element("stack")));
+                    }
                 }
 
-                if (backtrace.Length > 0) {
-                    backtrace = "addr2line -e fdbserver.debug -p -C -f -i" + backtrace;
-                }
-
-                whats.Add(new Tuple<string, string>(elem.Element("what").Value, backtrace));
+                errors.Add(errorElement);
             }
-            return whats.ToArray();
+            return errors.ToArray();
         }
 
         delegate IEnumerable<Magnesium.Event> parseDelegate(System.IO.Stream stream, string file,
@@ -1084,10 +1106,7 @@ namespace SummarizeTest
                     var valgrindErrors = ParseValgrindOutput(valgrindOutputFileName, traceToStdout);
                     foreach (var vError in valgrindErrors)
                     {
-                        xout.Add(new XElement("ValgrindError",
-                                new XAttribute("Severity", (int)Magnesium.Severity.SevError),
-                                new XAttribute("What", vError.Item1),
-                                new XAttribute("Backtrace", vError.Item2)));
+                        xout.Add(vError);
                         ok = false;
                         error = true;
                     }


### PR DESCRIPTION
This is is a cherry-pick of #7944.

This generates an addr2line command that can be used to get a backtrace for a valgrind error reported by TestHarness. This still requires that you run a command with the tested binary, but it's easier that re-running the test itself.

Also, this helps provide more detail for non-deterministic valgrind errors (e.g. from noSim tests) that don't readily reproduce.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
