### PR TITLE
Make envvar access in envvar-knob parsing cross-platform

### DIFF
--- a/fdbserver/fdbserver.actor.cpp
+++ b/fdbserver/fdbserver.actor.cpp
@@ -1114,7 +1114,7 @@ private:
 	CLIOptions() = default;
 
 	void parseEnvInternal() {
-		for (std::string knob : getEnvironmentKnobOptions()) {
+		for (const std::string& knob : getEnvironmentKnobOptions()) {
 			auto pos = knob.find_first_of("=");
 			if (pos == std::string::npos) {
 				fprintf(stderr,
@@ -2050,7 +2050,7 @@ int main(int argc, char* argv[]) {
 		}
 
 		std::string environmentKnobOptions;
-		for (std::string knobOption : getEnvironmentKnobOptions()) {
+		for (const std::string& knobOption : getEnvironmentKnobOptions()) {
 			environmentKnobOptions += knobOption + " ";
 		}
 		if (environmentKnobOptions.length()) {

--- a/flow/Platform.actor.cpp
+++ b/flow/Platform.actor.cpp
@@ -1956,7 +1956,6 @@ std::vector<std::string> getEnvironmentKnobOptions() {
 			knobOptions.emplace_back(candidate.substr(ENVKNOB_PREFIX_LEN));
 		e += (candidate.size() + 1);
 	}
-	return knonOptions;
 #else
 	char** e = nullptr;
 #ifdef __linux__
@@ -1972,8 +1971,8 @@ std::vector<std::string> getEnvironmentKnobOptions() {
 			knobOptions.emplace_back(envOption.substr(ENVKNOB_PREFIX_LEN));
 		}
 	}
-	return knobOptions;
 #endif
+	return knobOptions;
 }
 
 void setMemoryQuota(size_t limit) {

--- a/flow/Platform.actor.cpp
+++ b/flow/Platform.actor.cpp
@@ -66,6 +66,7 @@
 #include <direct.h>
 #include <pdh.h>
 #include <pdhmsg.h>
+#include <processenv.h>
 #pragma comment(lib, "pdh.lib")
 
 // for SHGetFolderPath

--- a/flow/Platform.actor.cpp
+++ b/flow/Platform.actor.cpp
@@ -1956,6 +1956,7 @@ std::vector<std::string> getEnvironmentKnobOptions() {
 			knobOptions.emplace_back(candidate.substr(ENVKNOB_PREFIX_LEN));
 		e += (candidate.size() + 1);
 	}
+	return knonOptions;
 #else
 	char** e = nullptr;
 #ifdef __linux__


### PR DESCRIPTION
Variable `environ` is defined for Linux, does not exist in Mac, is deprecated in Windows, and is breaking Mac build.
Adapt `Platform.actor.cpp:getEnvironmentKnobOptions()` accordingly.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
