### PR TITLE
Enable ZSTD compression support

### DIFF
--- a/cmake/CompileBoost.cmake
+++ b/cmake/CompileBoost.cmake
@@ -57,19 +57,27 @@ function(compile_boost)
 
   # Build boost
   include(ExternalProject)
+
   set(BOOST_INSTALL_DIR "${CMAKE_BINARY_DIR}/boost_install")
   ExternalProject_add("${COMPILE_BOOST_TARGET}Project"
-    URL "https://boostorg.jfrog.io/artifactory/main/release/1.78.0/source/boost_1_78_0.tar.bz2"
-    URL_HASH SHA256=8681f175d4bdb26c52222665793eef08490d7758529330f98d3b29dd0735bccc
-    CONFIGURE_COMMAND ${BOOTSTRAP_COMMAND} ${BOOTSTRAP_ARGS} --with-libraries=${BOOTSTRAP_LIBRARIES} --with-toolset=${BOOST_TOOLSET}
-    BUILD_COMMAND ${B2_COMMAND} link=static ${COMPILE_BOOST_BUILD_ARGS} --prefix=${BOOST_INSTALL_DIR} ${USER_CONFIG_FLAG} install
-    BUILD_IN_SOURCE ON
-    INSTALL_COMMAND ""
-    UPDATE_COMMAND ""
-    BUILD_BYPRODUCTS "${BOOST_INSTALL_DIR}/boost/config.hpp"
-                     "${BOOST_INSTALL_DIR}/lib/libboost_context.a"
-                     "${BOOST_INSTALL_DIR}/lib/libboost_filesystem.a"
-                     "${BOOST_INSTALL_DIR}/lib/libboost_iostreams.a")
+    URL                "https://boostorg.jfrog.io/artifactory/main/release/1.78.0/source/boost_1_78_0.tar.bz2"
+    URL_HASH           SHA256=8681f175d4bdb26c52222665793eef08490d7758529330f98d3b29dd0735bccc
+    CONFIGURE_COMMAND  ${BOOTSTRAP_COMMAND}
+                       ${BOOTSTRAP_ARGS}
+                       --with-libraries=${BOOTSTRAP_LIBRARIES}
+                       --with-toolset=${BOOST_TOOLSET}
+    BUILD_COMMAND      ${B2_COMMAND}
+                       link=static
+                       ${COMPILE_BOOST_BUILD_ARGS}
+                       --prefix=${BOOST_INSTALL_DIR}
+                       ${USER_CONFIG_FLAG} install
+    BUILD_IN_SOURCE    ON
+    INSTALL_COMMAND    ""
+    UPDATE_COMMAND     ""
+    BUILD_BYPRODUCTS   "${BOOST_INSTALL_DIR}/boost/config.hpp"
+                       "${BOOST_INSTALL_DIR}/lib/libboost_context.a"
+                       "${BOOST_INSTALL_DIR}/lib/libboost_filesystem.a"
+                       "${BOOST_INSTALL_DIR}/lib/libboost_iostreams.a")
 
   add_library(${COMPILE_BOOST_TARGET}_context STATIC IMPORTED)
   add_dependencies(${COMPILE_BOOST_TARGET}_context ${COMPILE_BOOST_TARGET}Project)

--- a/cmake/CompileZstd.cmake
+++ b/cmake/CompileZstd.cmake
@@ -1,0 +1,23 @@
+# Compile zstd
+
+function(compile_zstd)
+
+  include(FetchContent)
+
+  set(ZSTD_SOURCE_DIR ${CMAKE_BINARY_DIR}/zstd)
+
+  FetchContent_Declare(
+    ZSTD
+    GIT_REPOSITORY https://github.com/facebook/zstd.git
+    GIT_TAG        v1.5.2
+    SOURCE_DIR     ${ZSTD_SOURCE_DIR}
+    BINARY_DIR     ${ZSTD_SOURCE_DIR}
+    SOURCE_SUBDIR  "build/cmake"
+  )
+
+  FetchContent_MakeAvailable(ZSTD)
+
+  add_library(ZSTD::ZSTD STATIC IMPORTED)
+  set_target_properties(ZSTD::ZSTD PROPERTIES IMPORTED_LOCATION "${CMAKE_BINARY_DIR}/lib/libzstd.a")
+  target_include_directories(ZSTD::ZSTD PUBLIC ${ZSTD_INCLUDE_DIRS})
+endfunction(compile_zstd)

--- a/cmake/user-config.jam.cmake
+++ b/cmake/user-config.jam.cmake
@@ -1,1 +1,2 @@
 using @BOOST_TOOLSET@ : : @BOOST_CXX_COMPILER@ : @BOOST_ADDITIONAL_COMPILE_OPTIONS@ ;
+using zstd : 1.5.2 : <include>/@CMAKE_BINARY_DIR@/zstd/lib <search>/@CMAKE_BINARY_DIR@/lib ;

--- a/fdbclient/BlobGranuleFiles.cpp
+++ b/fdbclient/BlobGranuleFiles.cpp
@@ -2061,17 +2061,7 @@ struct KeyValueGen {
 			cipherKeys = getCipherKeysCtx(ar);
 		}
 		if (deterministicRandom()->coinflip()) {
-			std::vector<CompressionFilter> filters;
-			filters.insert(
-			    filters.end(), CompressionUtils::supportedFilters.begin(), CompressionUtils::supportedFilters.end());
-
-			ASSERT_GE(filters.size(), 1);
-			if (filters.size() == 1) {
-				compressFilter = filters[0];
-			} else {
-				int idx = deterministicRandom()->randomInt(0, filters.size());
-				compressFilter = filters[idx];
-			}
+			compressFilter = CompressionUtils::getRandomFilter();
 		}
 	}
 

--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -921,7 +921,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 
 	// encrypt key proxy
 	init( ENABLE_BLOB_GRANULE_COMPRESSION,                     false ); if ( randomize && BUGGIFY ) { ENABLE_BLOB_GRANULE_COMPRESSION = deterministicRandom()->coinflip(); }
-	init( BLOB_GRANULE_COMPRESSION_FILTER,                    "ZSTD" ); if ( randomize && BUGGIFY ) { BLOB_GRANULE_COMPRESSION_FILTER = "NONE"; }
+	init( BLOB_GRANULE_COMPRESSION_FILTER,                    "NONE" ); if ( randomize && BUGGIFY ) { BLOB_GRANULE_COMPRESSION_FILTER = "NONE"; }
 
 	// KMS connector type
 	init( KMS_CONNECTOR_TYPE,                     "RESTKmsConnector" );

--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "fdbclient/ServerKnobs.h"
+#include "flow/CompressionUtils.h"
 #include "flow/IRandom.h"
 #include "flow/flow.h"
 
@@ -921,7 +922,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 
 	// encrypt key proxy
 	init( ENABLE_BLOB_GRANULE_COMPRESSION,                     false ); if ( randomize && BUGGIFY ) { ENABLE_BLOB_GRANULE_COMPRESSION = deterministicRandom()->coinflip(); }
-	init( BLOB_GRANULE_COMPRESSION_FILTER,                    "NONE" ); if ( randomize && BUGGIFY ) { BLOB_GRANULE_COMPRESSION_FILTER = "NONE"; }
+	init( BLOB_GRANULE_COMPRESSION_FILTER,                    "NONE" ); if ( randomize && BUGGIFY ) { BLOB_GRANULE_COMPRESSION_FILTER = CompressionUtils::toString(CompressionUtils::getRandomFilter()); }
 
 	// KMS connector type
 	init( KMS_CONNECTOR_TYPE,                     "RESTKmsConnector" );

--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -921,7 +921,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 
 	// encrypt key proxy
 	init( ENABLE_BLOB_GRANULE_COMPRESSION,                     false ); if ( randomize && BUGGIFY ) { ENABLE_BLOB_GRANULE_COMPRESSION = deterministicRandom()->coinflip(); }
-	init( BLOB_GRANULE_COMPRESSION_FILTER,                    "NONE" );
+	init( BLOB_GRANULE_COMPRESSION_FILTER,                    "ZSTD" ); if ( randomize && BUGGIFY ) { BLOB_GRANULE_COMPRESSION_FILTER = "NONE"; }
 
 	// KMS connector type
 	init( KMS_CONNECTOR_TYPE,                     "RESTKmsConnector" );

--- a/flow/CMakeLists.txt
+++ b/flow/CMakeLists.txt
@@ -38,9 +38,13 @@ target_link_libraries(flowlinktest PRIVATE flow stacktrace)
 #  message(STATUS "ZLIB package not found")
 #endif()
 
-include(CompileZstd)
-compile_zstd()
-target_link_libraries(flow PUBLIC ZSTD::ZSTD)
+# TODO: Limit ZSTD availability to CLANG, for gcc resolve library link ordering
+if (CLANG)
+  include(CompileZstd)
+  compile_zstd()
+  target_link_libraries(flow PUBLIC ZSTD::ZSTD)
+  target_compile_definitions(flow PUBLIC ZSTD_LIB_SUPPORTED)
+endif()
 
 foreach(ft flow flow_sampling flowlinktest)
   target_include_directories(${ft} PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include" "${CMAKE_CURRENT_BINARY_DIR}/include")

--- a/flow/CMakeLists.txt
+++ b/flow/CMakeLists.txt
@@ -38,6 +38,10 @@ target_link_libraries(flowlinktest PRIVATE flow stacktrace)
 #  message(STATUS "ZLIB package not found")
 #endif()
 
+include(CompileZstd)
+compile_zstd()
+target_link_libraries(flow PUBLIC ZSTD::ZSTD)
+
 foreach(ft flow flow_sampling flowlinktest)
   target_include_directories(${ft} PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include" "${CMAKE_CURRENT_BINARY_DIR}/include")
 

--- a/flow/CompressionUtils.cpp
+++ b/flow/CompressionUtils.cpp
@@ -177,7 +177,7 @@ TEST_CASE("/CompressionUtils/zstdCompression") {
 	return Void();
 }
 
-TEST_CASE("/CompressionUtils/gzipCompression2") {
+TEST_CASE("/CompressionUtils/zstdCompression2") {
 	testCompression2(CompressionFilter::ZSTD);
 	TraceEvent("ZstdCompression2Done");
 

--- a/flow/CompressionUtils.cpp
+++ b/flow/CompressionUtils.cpp
@@ -162,6 +162,25 @@ int CompressionUtils::getDefaultCompressionLevel(CompressionFilter filter) {
 	throw internal_error(); // We should never get here
 }
 
+CompressionFilter CompressionUtils::getRandomFilter() {
+	ASSERT_GE(supportedFilters.size(), 1);
+	std::vector<CompressionFilter> filters;
+	filters.insert(filters.end(), CompressionUtils::supportedFilters.begin(), CompressionUtils::supportedFilters.end());
+
+	ASSERT_GE(filters.size(), 1);
+
+	CompressionFilter res;
+	if (filters.size() == 1) {
+		res = filters[0];
+	} else {
+		int idx = deterministicRandom()->randomInt(0, filters.size());
+		res = filters[idx];
+	}
+
+	ASSERT(supportedFilters.find(res) != supportedFilters.end());
+	return res;
+}
+
 // Only used to link unit tests
 void forceLinkCompressionUtilsTest() {}
 

--- a/flow/include/flow/CompressionUtils.h
+++ b/flow/include/flow/CompressionUtils.h
@@ -29,6 +29,7 @@ enum class CompressionFilter {
 #ifdef ZLIB_LIB_SUPPORTED
 	GZIP,
 #endif
+	ZSTD,
 	LAST // Always the last member
 };
 
@@ -46,7 +47,9 @@ struct CompressionUtils {
 			return CompressionFilter::GZIP;
 		}
 #endif
-		else {
+		else if (filter == "ZSTD") {
+			return CompressionFilter::ZSTD;
+		} else {
 			throw not_implemented();
 		}
 	}
@@ -60,7 +63,9 @@ struct CompressionUtils {
 			return "GZP";
 		}
 #endif
-		else {
+		else if (filter == CompressionFilter::ZSTD) {
+			return "ZSTD";
+		} else {
 			throw not_implemented();
 		}
 	}

--- a/flow/include/flow/CompressionUtils.h
+++ b/flow/include/flow/CompressionUtils.h
@@ -39,6 +39,7 @@ struct CompressionUtils {
 	static StringRef decompress(const CompressionFilter filter, const StringRef& data, Arena& arena);
 
 	static int getDefaultCompressionLevel(CompressionFilter filter);
+	static CompressionFilter getRandomFilter();
 
 	static CompressionFilter fromFilterString(const std::string& filter) {
 		if (filter == "NONE") {

--- a/flow/include/flow/CompressionUtils.h
+++ b/flow/include/flow/CompressionUtils.h
@@ -24,11 +24,11 @@
 
 #include "flow/Arena.h"
 
+#include <unordered_set>
+
 enum class CompressionFilter {
 	NONE,
-#ifdef ZLIB_LIB_SUPPORTED
 	GZIP,
-#endif
 	ZSTD,
 	LAST // Always the last member
 };
@@ -38,16 +38,14 @@ struct CompressionUtils {
 	static StringRef compress(const CompressionFilter filter, const StringRef& data, int level, Arena& arena);
 	static StringRef decompress(const CompressionFilter filter, const StringRef& data, Arena& arena);
 
+	static int getDefaultCompressionLevel(CompressionFilter filter);
+
 	static CompressionFilter fromFilterString(const std::string& filter) {
 		if (filter == "NONE") {
 			return CompressionFilter::NONE;
-		}
-#ifdef ZLIB_LIB_SUPPORTED
-		else if (filter == "GZIP") {
+		} else if (filter == "GZIP") {
 			return CompressionFilter::GZIP;
-		}
-#endif
-		else if (filter == "ZSTD") {
+		} else if (filter == "ZSTD") {
 			return CompressionFilter::ZSTD;
 		} else {
 			throw not_implemented();
@@ -57,18 +55,22 @@ struct CompressionUtils {
 	static std::string toString(const CompressionFilter filter) {
 		if (filter == CompressionFilter::NONE) {
 			return "NONE";
-		}
-#ifdef ZLIB_LIB_SUPPORTED
-		else if (filter == CompressionFilter::GZIP) {
+		} else if (filter == CompressionFilter::GZIP) {
 			return "GZP";
-		}
-#endif
-		else if (filter == CompressionFilter::ZSTD) {
+		} else if (filter == CompressionFilter::ZSTD) {
 			return "ZSTD";
 		} else {
 			throw not_implemented();
 		}
 	}
+
+	static void checkFilterSupported(const CompressionFilter filter) {
+		if (CompressionUtils::supportedFilters.find(filter) == CompressionUtils::supportedFilters.end()) {
+			throw not_implemented();
+		}
+	}
+
+	static std::unordered_set<CompressionFilter> supportedFilters;
 };
 
 #endif // FLOW_COMPRRESSION_UTILS_H


### PR DESCRIPTION
Description

Patch proposes changes to enable ZSTD dirven compression/decompression
support. Major changes include:
1. Update CMake to build/install v1.5.2 (latest stable release) of ZSTD
2. Update CompressionFilter to support ZTSD compressor/decompressor

NOTE: ZSTD availability is limited to CLANG compiler for now. 

Testing

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
