### PR TITLE
Add database operation support to api tester, and use it for blob granule database functions

### DIFF
--- a/bindings/c/test/apitester/TesterBlobGranuleErrorsWorkload.cpp
+++ b/bindings/c/test/apitester/TesterBlobGranuleErrorsWorkload.cpp
@@ -30,6 +30,7 @@ public:
 	BlobGranuleErrorsWorkload(const WorkloadConfig& config) : ApiWorkload(config) {}
 
 private:
+	// FIXME: finish adding other op types
 	enum OpType {
 		OP_READ_NO_MATERIALIZE,
 		OP_READ_FILE_LOAD_ERROR,
@@ -78,7 +79,7 @@ private:
 				    seenReadSuccess = true;
 			    }
 			    if (err.code() != expectedError) {
-				    info(fmt::format("incorrect error. Expected {}, Got {}", err.code(), expectedError));
+				    info(fmt::format("incorrect error. Expected {}, Got {}", expectedError, err.code()));
 				    if (err.code() == error_code_blob_granule_transaction_too_old) {
 					    ASSERT(!seenReadSuccess);
 					    ctx->done();

--- a/bindings/c/test/apitester/TesterWorkload.h
+++ b/bindings/c/test/apitester/TesterWorkload.h
@@ -123,6 +123,14 @@ protected:
 		execTransaction(std::make_shared<TransactionFct>(start), cont, failOnError);
 	}
 
+	// Execute a transaction within the workload
+	void execDBOperation(std::shared_ptr<IDatabaseActor> tx, TTaskFct cont, bool failOnError = true);
+
+	// Execute a transaction within the workload, a convenience method for a tranasaction defined by a lambda function
+	void execDBOperation(TDBStartFct start, TTaskFct cont, bool failOnError = true) {
+		execDBOperation(std::make_shared<DatabaseFct>(start), cont, failOnError);
+	}
+
 	// Log an error message, increase error counter
 	void error(const std::string& msg);
 
@@ -164,6 +172,9 @@ protected:
 
 	// Number of completed transactions
 	std::atomic<int> numTxCompleted;
+
+	// Number of completed database operations
+	std::atomic<int> numDBOpsCompleted;
 };
 
 // Workload manager

--- a/bindings/c/test/fdb_api.hpp
+++ b/bindings/c/test/fdb_api.hpp
@@ -309,6 +309,7 @@ public:
 
 class Future {
 protected:
+	friend class Database;
 	friend class Transaction;
 	friend std::hash<Future>;
 	std::shared_ptr<native::FDBFuture> f;
@@ -706,6 +707,13 @@ public:
 		if (err)
 			throwError("Failed to create transaction: ", err);
 		return Transaction(tx_native);
+	}
+
+	TypedFuture<future_var::KeyRangeRefArray> listBlobbifiedRanges(KeyRef begin, KeyRef end, int rangeLimit) {
+		if (!db)
+			throw std::runtime_error("list_blobbified_ranges from null database");
+		return native::fdb_database_list_blobbified_ranges(
+		    db.get(), begin.data(), intSize(begin), end.data(), intSize(end), rangeLimit);
 	}
 };
 


### PR DESCRIPTION
I only added one blob granule database operation, as I mainly wanted to focus on getting the framework in the api tester right for doing database operations (it's basically a vastly simplified version of transactions, there's no retrying/committing/etc...). Once the framework is good I will add the other calls in a separate PR

Passes 100 fdb_c_api_tests_blob_granule tests

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
