### PR TITLE
fix unit test isRangeCoveredByBlob

### DIFF
--- a/fdbclient/BlobGranuleReader.actor.cpp
+++ b/fdbclient/BlobGranuleReader.actor.cpp
@@ -186,16 +186,12 @@ TEST_CASE("/fdbserver/blobgranule/isRangeCoveredByBlob") {
 		ASSERT(range.end == "key_b5"_sr);
 	}
 
-	// check unsorted chunks
-	{
-		Standalone<VectorRef<BlobGranuleChunkRef>> unsortedChunks(chunks);
-		testAddChunkRange("key_0"_sr, "key_a"_sr, unsortedChunks);
-		ASSERT(isRangeFullyCovered(KeyRangeRef("key_00"_sr, "key_01"_sr), unsortedChunks));
-	}
 	// check continued chunks
 	{
-		Standalone<VectorRef<BlobGranuleChunkRef>> continuedChunks(chunks);
+		Standalone<VectorRef<BlobGranuleChunkRef>> continuedChunks;
+		testAddChunkRange("key_a1"_sr, "key_a9"_sr, continuedChunks);
 		testAddChunkRange("key_a9"_sr, "key_b1"_sr, continuedChunks);
+		testAddChunkRange("key_b1"_sr, "key_b9"_sr, continuedChunks);
 		ASSERT(isRangeFullyCovered(KeyRangeRef("key_a1"_sr, "key_b9"_sr), continuedChunks) == false);
 	}
 	return Void();


### PR DESCRIPTION
we assume input of isRangeFullyCovered is sorted. so the unit test should be updated accordingly

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
