### PR TITLE
Fully qualify std::nullptr_t

### DIFF
--- a/fdbclient/Tuple.cpp
+++ b/fdbclient/Tuple.cpp
@@ -208,7 +208,7 @@ Tuple& Tuple::append(double value) {
 	return *this;
 }
 
-Tuple& Tuple::append(nullptr_t) {
+Tuple& Tuple::append(std::nullptr_t) {
 	offsets.push_back(data.size());
 	data.push_back(data.arena(), (uint8_t)'\x00');
 	return *this;


### PR DESCRIPTION
This happens to compile for some reason with libc++, but we don't open
the std namespace so we should fully qualify it.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
