### PR TITLE
Set the default testharness config from environment

### DIFF
--- a/contrib/TestHarness2/test_harness/config.py
+++ b/contrib/TestHarness2/test_harness/config.py
@@ -234,7 +234,10 @@ class Config:
             assert type(None) != attr_type
             e = os.getenv(env_name)
             if e is not None:
-                self.__setattr__(attr, attr_type(e))
+                # Use the env var to supply the default value, so that if the
+                # environment variable is set and the corresponding command line
+                # flag is not, the environment variable has an effect.
+                self._config_map[attr].kwargs['default'] = attr_type(e)
 
     def build_arguments(self, parser: argparse.ArgumentParser):
         for val in self._config_map.values():


### PR DESCRIPTION
Previously setting the environment variable for an option with a default value
had no effect. Tested ad-hoc by submitting an ensemble with `--env
TH_INCLUDE_TEST_FILES='.*restarting.*'` and observing that only restart tests
were chosen.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
