### PR TITLE
Disable shard_encode_location_metadata

### DIFF
--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -164,7 +164,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( PRIORITY_ENFORCE_MOVE_OUT_OF_PHYSICAL_SHARD,           960 ); if( randomize && BUGGIFY ) PRIORITY_ENFORCE_MOVE_OUT_OF_PHYSICAL_SHARD = 360; // Set as the lowest priority
 
 	// Data distribution
-	init( SHARD_ENCODE_LOCATION_METADATA,                      false ); if( randomize && BUGGIFY )  SHARD_ENCODE_LOCATION_METADATA = true;
+	init( SHARD_ENCODE_LOCATION_METADATA,                      false );
 	init( ENABLE_DD_PHYSICAL_SHARD,                            false ); // EXPERIMENTAL; If true, SHARD_ENCODE_LOCATION_METADATA must be true; When true, optimization of data move between DCs is disabled
 	init( MAX_PHYSICAL_SHARD_BYTES,                        500000000 ); // 500 MB; for ENABLE_DD_PHYSICAL_SHARD; smaller leads to larger number of physicalShard per storage server
  	init( PHYSICAL_SHARD_METRICS_DELAY,                        300.0 ); // 300 seconds; for ENABLE_DD_PHYSICAL_SHARD


### PR DESCRIPTION
When SHARD_ENCODE_LOCATION_METADATA is enabled it is possible for a storage server to make a shard available that it never fetched, resulting in data corruption.

fdbserver -r simulation -f tests/restarting/from_7.0.0/UpgradeAndBackupRestore-1.toml -s 444088902 -b on
fdbserver -r simulation -f tests/restarting/from_7.0.0/UpgradeAndBackupRestore-2.toml -s 444088903 -b on --restarting
on f5dff14ab23091c286c95d9c0da8135a723d14e8 compiled with gcc

I tracked it down to see a ChangeServerKeysWithPhysicalShards message which assigns a shard to a storage server despite the fact that the storage server never fetched the range

The specific incorrect assignment:
{  "Severity": "5", "Time": "218.416799", "DateTime": "2022-08-31T03:19:40Z", "Type": "ChangeServerKeysWithPhysicalShards", "Machine": "2.0.1.3:1", "ID": "a4f0f064316a5600", "DataMoveID": "0000000000666666", "Range": "BeforeRestart3fe8a - \\xff\\x02/blog/qY\\xfc\\xe6w%sE|\\xf5\\x0d\\xb3\\xd4\\x8a\\xa5e\\x81\\x00\\x00\\x00\\x0047\\xd5", "NowAssigned": "1", "Version": "1321009173", "Context": "Update", "ThreadID": "28162026223729782", "LogGroup": "default", "Roles": "CC,CP,DD,GP,LR,RK,SS" }

One thing that my be related in that shard_encode_location_metadata is true for the first part of the restarting test, but false for the second part

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
