### PR TITLE
Fix a type error when stderr is too large in test harness

### DIFF
--- a/contrib/TestHarness2/test_harness/config.py
+++ b/contrib/TestHarness2/test_harness/config.py
@@ -175,7 +175,7 @@ class Config:
         self.cov_include_files_args = {'help': 'Only consider coverage traces that originated in files matching regex'}
         self.cov_exclude_files: str = r'.^'
         self.cov_exclude_files_args = {'help': 'Ignore coverage traces that originated in files matching regex'}
-        self.max_stderr_bytes: int = 1000
+        self.max_stderr_bytes: int = 10000
         self.write_stats: bool = True
         self.read_stats: bool = True
         self.reproduce_prefix: str | None = None

--- a/contrib/TestHarness2/test_harness/summarize.py
+++ b/contrib/TestHarness2/test_harness/summarize.py
@@ -443,7 +443,7 @@ class Summary:
             if stderr_bytes > config.max_stderr_bytes:
                 child = SummaryTree('StdErrOutputTruncated')
                 child.attributes['Severity'] = self.stderr_severity
-                child.attributes['BytesRemaining'] = stderr_bytes - config.max_stderr_bytes
+                child.attributes['BytesRemaining'] = str(stderr_bytes - config.max_stderr_bytes)
                 self.out.append(child)
 
         self.out.attributes['Ok'] = '1' if self.ok() else '0'


### PR DESCRIPTION
Also increase the threshold. 10000 seems more appropriate for asan since
it prints a symbolized stack trace to stderr.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
