### PR TITLE
Move TenantEntryCache to fdbclient

### DIFF
--- a/fdbclient/ClientKnobs.cpp
+++ b/fdbclient/ClientKnobs.cpp
@@ -290,7 +290,7 @@ void ClientKnobs::initialize(Randomize randomize) {
 	init( METACLUSTER_ASSIGNMENT_CLUSTERS_TO_CHECK,   5 ); if ( randomize && BUGGIFY ) METACLUSTER_ASSIGNMENT_CLUSTERS_TO_CHECK = 1;
 	init( METACLUSTER_ASSIGNMENT_FIRST_CHOICE_DELAY, 1.0 ); if ( randomize && BUGGIFY ) METACLUSTER_ASSIGNMENT_FIRST_CHOICE_DELAY = deterministicRandom()->random01() * 60;
 	init( METACLUSTER_ASSIGNMENT_AVAILABILITY_TIMEOUT, 10.0 ); if ( randomize && BUGGIFY ) METACLUSTER_ASSIGNMENT_AVAILABILITY_TIMEOUT = 1 + deterministicRandom()->random01() * 59;
-
+	init( TENANT_ENTRY_CACHE_LIST_REFRESH_INTERVAL,  2 ); if( randomize && BUGGIFY ) TENANT_ENTRY_CACHE_LIST_REFRESH_INTERVAL = deterministicRandom()->randomInt(1, 10);
 	// clang-format on
 }
 

--- a/fdbclient/include/fdbclient/ClientKnobs.h
+++ b/fdbclient/include/fdbclient/ClientKnobs.h
@@ -284,6 +284,7 @@ public:
 	int METACLUSTER_ASSIGNMENT_CLUSTERS_TO_CHECK;
 	double METACLUSTER_ASSIGNMENT_FIRST_CHOICE_DELAY;
 	double METACLUSTER_ASSIGNMENT_AVAILABILITY_TIMEOUT;
+	int TENANT_ENTRY_CACHE_LIST_REFRESH_INTERVAL; // How often the TenantEntryCache is refreshed
 
 	ClientKnobs(Randomize randomize);
 	void initialize(Randomize randomize);

--- a/fdbclient/include/fdbclient/TenantEntryCache.actor.h
+++ b/fdbclient/include/fdbclient/TenantEntryCache.actor.h
@@ -18,11 +18,11 @@
  * limitations under the License.
  */
 
-#if defined(NO_INTELLISENSE) && !defined(FDBSERVER_TENANTENTRYCACHE_ACTOR_G_H)
-#define FDBSERVER_TENANTENTRYCACHE_ACTOR_G_H
-#include "fdbserver/TenantEntryCache.actor.g.h"
-#elif !defined(FDBSERVER_TENANTENTRYCACHE_ACTOR_H)
-#define FDBSERVER_TENANTENTRYCACHE_ACTOR_H
+#if defined(NO_INTELLISENSE) && !defined(FDBCLIENT_TENANTENTRYCACHE_ACTOR_G_H)
+#define FDBCLIENT_TENANTENTRYCACHE_ACTOR_G_H
+#include "fdbclient/TenantEntryCache.actor.g.h"
+#elif !defined(FDBCLIENT_TENANTENTRYCACHE_ACTOR_H)
+#define FDBCLIENT_TENANTENTRYCACHE_ACTOR_H
 
 #pragma once
 
@@ -32,7 +32,7 @@
 #include "fdbclient/RunTransaction.actor.h"
 #include "fdbclient/Tenant.h"
 #include "fdbclient/TenantManagement.actor.h"
-#include "fdbserver/Knobs.h"
+#include "fdbclient/Knobs.h"
 #include "fdbrpc/TenantName.h"
 #include "flow/IndexedSet.h"
 
@@ -313,9 +313,9 @@ public:
 		TenantEntryCacheRefreshReason reason = TenantEntryCacheRefreshReason::PERIODIC_TASK;
 		if (refreshMode == TenantEntryCacheRefreshMode::PERIODIC_TASK) {
 			refresher = recurringAsync([&, reason]() { return refresh(reason); },
-			                           SERVER_KNOBS->TENANT_CACHE_LIST_REFRESH_INTERVAL, /* interval */
+			                           CLIENT_KNOBS->TENANT_ENTRY_CACHE_LIST_REFRESH_INTERVAL, /* interval */
 			                           true, /* absoluteIntervalDelay */
-			                           SERVER_KNOBS->TENANT_CACHE_LIST_REFRESH_INTERVAL, /* intialDelay */
+			                           CLIENT_KNOBS->TENANT_ENTRY_CACHE_LIST_REFRESH_INTERVAL, /* intialDelay */
 			                           TaskPriority::Worker);
 		}
 
@@ -387,4 +387,4 @@ public:
 };
 
 #include "flow/unactorcompiler.h"
-#endif // FDBSERVER_TENANTENTRYCACHE_ACTOR_H
+#endif // FDBCLIENT_TENANTENTRYCACHE_ACTOR_H

--- a/fdbserver/workloads/TenantEntryCacheWorkload.actor.cpp
+++ b/fdbserver/workloads/TenantEntryCacheWorkload.actor.cpp
@@ -22,8 +22,8 @@
 #include "fdbclient/NativeAPI.actor.h"
 #include "fdbclient/TenantManagement.actor.h"
 
-#include "fdbserver/Knobs.h"
-#include "fdbserver/TenantEntryCache.actor.h"
+#include "fdbclient/Knobs.h"
+#include "fdbclient/TenantEntryCache.actor.h"
 #include "fdbserver/workloads/workloads.actor.h"
 
 #include "flow/Error.h"
@@ -220,7 +220,7 @@ struct TenantEntryCacheWorkload : TestWorkload {
 		ASSERT_GE(cache->numCacheRefreshes(), 1);
 
 		int refreshWait =
-		    SERVER_KNOBS->TENANT_CACHE_LIST_REFRESH_INTERVAL * 10; // initial delay + multiple refresh runs
+		    CLIENT_KNOBS->TENANT_ENTRY_CACHE_LIST_REFRESH_INTERVAL * 10; // initial delay + multiple refresh runs
 		wait(delay(refreshWait));
 
 		// InitRefresh + multiple timer based invocations
@@ -277,7 +277,7 @@ struct TenantEntryCacheWorkload : TestWorkload {
 
 	Future<Void> setup(Database const& cx) override {
 		if (clientId == 0 && g_network->isSimulated() && BUGGIFY) {
-			IKnobCollection::getMutableGlobalKnobCollection().setKnob("tenant_cache_list_refresh_interval",
+			IKnobCollection::getMutableGlobalKnobCollection().setKnob("tenant_entry_cache_list_refresh_interval",
 			                                                          KnobValueRef::create(int{ 2 }));
 		}
 


### PR DESCRIPTION
BackupAgent will need to interact with the cache to fetch Tenant names given a tenant id for encryption, so moving this to the client . Tested correctness using existing TenantEntryCacheWorkload

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
