### PR TITLE
Handling request_maybe_delivered in reply promise stream and injecting faults to make sure the code path is exercised

### DIFF
--- a/fdbserver/LogSystemPeekCursor.actor.cpp
+++ b/fdbserver/LogSystemPeekCursor.actor.cpp
@@ -382,7 +382,8 @@ ACTOR Future<Void> serverPeekStreamGetMore(ILogSystem::ServerPeekCursor* self, T
 			DebugLogTraceEvent(SevDebug, "SPC_GetMoreB_Error", self->randomID)
 			    .errorUnsuppressed(e)
 			    .detail("Tag", self->tag);
-			if (e.code() == error_code_connection_failed || e.code() == error_code_operation_obsolete) {
+			if (e.code() == error_code_connection_failed || e.code() == error_code_operation_obsolete ||
+			    e.code() == error_code_request_maybe_delivered) {
 				// NOTE: delay in order to avoid the endless retry loop block other tasks
 				self->peekReplyStream.reset();
 				wait(delay(0));

--- a/fdbserver/networktest.actor.cpp
+++ b/fdbserver/networktest.actor.cpp
@@ -193,7 +193,8 @@ ACTOR Future<Void> testClientStream(std::vector<NetworkTestInterface> interfs,
 				ASSERT(rep.index == j++);
 			}
 		} catch (Error& e) {
-			ASSERT(e.code() == error_code_end_of_stream || e.code() == error_code_connection_failed);
+			ASSERT(e.code() == error_code_end_of_stream || e.code() == error_code_connection_failed ||
+			       e.code() == error_code_request_maybe_delivered);
 		}
 		latency->tock(sample);
 		(*completed)++;


### PR DESCRIPTION
Per discovery of this error in change feeds in real cluster tests.
I added delay injection in change feeds to confirm that it hits this problem when waiting on failure monitors to become available, and then added buggified injecting of request_maybe_delivered and properly handled that error being thrown in all uses of ReplyPromiseStream.

Passes 100k BlobGranule* correctness, and 100k normal correctness with 1 unrelated error (GetMappedRange)

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
