### PR TITLE
Assert that Arena's appear last in serializer calls

### DIFF
--- a/fdbclient/include/fdbclient/CommitProxyInterface.h
+++ b/fdbclient/include/fdbclient/CommitProxyInterface.h
@@ -197,7 +197,7 @@ struct CommitTransactionRequest : TimedRequest {
 	template <class Ar>
 	void serialize(Ar& ar) {
 		serializer(
-		    ar, transaction, reply, arena, flags, debugID, commitCostEstimation, tagSet, spanContext, tenantInfo);
+		    ar, transaction, reply, flags, debugID, commitCostEstimation, tagSet, spanContext, tenantInfo, arena);
 	}
 };
 
@@ -339,7 +339,7 @@ struct GetKeyServerLocationsReply {
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, results, resultsTssMapping, tenantEntry, arena, resultsTagMapping);
+		serializer(ar, results, resultsTssMapping, tenantEntry, resultsTagMapping, arena);
 	}
 };
 
@@ -543,7 +543,7 @@ struct ProxySnapRequest {
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, snapPayload, snapUID, reply, arena, debugID);
+		serializer(ar, snapPayload, snapUID, reply, debugID, arena);
 	}
 };
 

--- a/fdbclient/include/fdbclient/EncryptKeyProxyInterface.h
+++ b/fdbclient/include/fdbclient/EncryptKeyProxyInterface.h
@@ -132,7 +132,7 @@ struct EKPGetBaseCipherKeysByIdsReply {
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, arena, baseCipherDetails, numHits, error);
+		serializer(ar, baseCipherDetails, numHits, error, arena);
 	}
 };
 

--- a/fdbclient/include/fdbclient/StorageServerInterface.h
+++ b/fdbclient/include/fdbclient/StorageServerInterface.h
@@ -416,8 +416,8 @@ struct GetKeyValuesRequest : TimedRequest {
 		           spanContext,
 		           tenantInfo,
 		           options,
-		           arena,
-		           ssLatestCommitVersions);
+		           ssLatestCommitVersions,
+		           arena);
 	}
 };
 
@@ -474,9 +474,9 @@ struct GetMappedKeyValuesRequest : TimedRequest {
 		           spanContext,
 		           tenantInfo,
 		           options,
-		           arena,
 		           ssLatestCommitVersions,
-		           matchIndex);
+		           matchIndex,
+		           arena);
 	}
 };
 
@@ -539,8 +539,8 @@ struct GetKeyValuesStreamRequest {
 		           spanContext,
 		           tenantInfo,
 		           options,
-		           arena,
-		           ssLatestCommitVersions);
+		           ssLatestCommitVersions,
+		           arena);
 	}
 };
 
@@ -588,7 +588,7 @@ struct GetKeyRequest : TimedRequest {
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, sel, version, tags, reply, spanContext, tenantInfo, options, arena, ssLatestCommitVersions);
+		serializer(ar, sel, version, tags, reply, spanContext, tenantInfo, options, ssLatestCommitVersions, arena);
 	}
 };
 
@@ -758,7 +758,7 @@ struct SplitMetricsRequest {
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, keys, limits, used, estimated, isLastShard, reply, arena, minSplitBytes);
+		serializer(ar, keys, limits, used, estimated, isLastShard, reply, minSplitBytes, arena);
 	}
 };
 
@@ -1038,7 +1038,7 @@ struct OverlappingChangeFeedsReply {
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, feeds, arena, feedMetadataVersion);
+		serializer(ar, feeds, feedMetadataVersion, arena);
 	}
 };
 

--- a/fdbserver/include/fdbserver/DataDistributorInterface.h
+++ b/fdbserver/include/fdbserver/DataDistributorInterface.h
@@ -120,7 +120,7 @@ struct DistributorSnapRequest {
 
 	template <class Ar>
 	void serialize(Ar& ar) {
-		serializer(ar, snapPayload, snapUID, reply, arena, debugID);
+		serializer(ar, snapPayload, snapUID, reply, debugID, arena);
 	}
 };
 

--- a/fdbserver/include/fdbserver/ResolverInterface.h
+++ b/fdbserver/include/fdbserver/ResolverInterface.h
@@ -139,10 +139,10 @@ struct ResolveTransactionBatchRequest {
 		           transactions,
 		           txnStateTransactions,
 		           reply,
-		           arena,
 		           debugID,
 		           writtenTags,
-		           spanContext);
+		           spanContext,
+		           arena);
 	}
 };
 

--- a/fdbserver/include/fdbserver/TLogInterface.h
+++ b/fdbserver/include/fdbserver/TLogInterface.h
@@ -328,10 +328,10 @@ struct TLogCommitRequest {
 		           minKnownCommittedVersion,
 		           messages,
 		           reply,
-		           arena,
 		           debugID,
 		           tLogCount,
-		           spanContext);
+		           spanContext,
+		           arena);
 	}
 };
 

--- a/flow/flat_buffers.cpp
+++ b/flow/flat_buffers.cpp
@@ -473,13 +473,13 @@ TEST_CASE("/flow/FlatBuffers/VectorRef") {
 				vec.push_back(arena, str);
 			}
 			ObjectWriter writer(Unversioned());
-			writer.serialize(FileIdentifierFor<decltype(vec)>::value, arena, vec);
+			writer.serialize(FileIdentifierFor<decltype(vec)>::value, vec);
 			serializedVector = StringRef(readerArena, writer.toStringRef());
 		}
 		ArenaObjectReader reader(readerArena, serializedVector, Unversioned());
-		// The VectorRef and Arena arguments are intentionally in a different order from the serialize call above.
+		// The Arena argument is intentionally missing from the serialize call above.
 		// Arenas need to get serialized after any Ref types whose memory they own. In order for schema evolution to be
-		// possible, it needs to be okay to reorder an Arena so that it appears after a newly added Ref type. For this
+		// possible, it needs to be okay to move/add an Arena so that it appears after a newly added Ref type. For this
 		// reason, Arenas are ignored by the wire protocol entirely. We test that behavior here.
 		reader.deserialize(FileIdentifierFor<decltype(outVec)>::value, outVec, vecArena);
 	}

--- a/flow/include/flow/Arena.h
+++ b/flow/include/flow/Arena.h
@@ -366,6 +366,8 @@ class Standalone : private Arena, public T {
 public:
 	using RefType = T;
 
+	constexpr static auto fb_must_appear_last = false;
+
 	// T must have no destructor
 	Arena& arena() { return *(Arena*)this; }
 	const Arena& arena() const { return *(const Arena*)this; }

--- a/flow/include/flow/Arena.h
+++ b/flow/include/flow/Arena.h
@@ -100,6 +100,7 @@ FDB_DECLARE_BOOLEAN_PARAM(FastInaccurateEstimate);
 // memory is freed by deleting the entire Arena at once. See flow/README.md for details on using Arenas.
 class Arena {
 public:
+	constexpr static auto fb_must_appear_last = true;
 	Arena();
 	explicit Arena(size_t reservedSize);
 	//~Arena();

--- a/flow/include/flow/ObjectSerializerTraits.h
+++ b/flow/include/flow/ObjectSerializerTraits.h
@@ -37,11 +37,6 @@ struct is_fb_function_t<T, typename std::enable_if<T::is_fb_visitor>::type> : st
 template <class T>
 constexpr bool is_fb_function = is_fb_function_t<T>::value;
 
-template <class Visitor, class... Items>
-typename std::enable_if<is_fb_function<Visitor>, void>::type serializer(Visitor& visitor, Items&... items) {
-	visitor(items...);
-}
-
 template <class... Ts>
 struct pack {};
 
@@ -60,6 +55,41 @@ struct index_impl<0, pack<T, Ts...>> {
 
 template <int i, class Pack>
 using index_t = typename index_impl<i, Pack>::type;
+
+template <class T, typename = void>
+struct fb_must_appear_last_t : std::false_type {};
+
+template <class T>
+struct fb_must_appear_last_t<T, typename std::enable_if<T::fb_must_appear_last>::type> : std::true_type {};
+
+template <class T>
+constexpr bool fb_must_appear_last = fb_must_appear_last_t<T>::value;
+
+namespace detail {
+template <class Item, class... Items>
+constexpr bool appears_last_property_helper(pack<Item, Items...>) {
+	if constexpr (sizeof...(Items) == 0) {
+		return true;
+	} else {
+		return !fb_must_appear_last<Item> && appears_last_property_helper(pack<Items...>{});
+	}
+}
+template <class... Items>
+constexpr bool appears_last_property(pack<Items...>) {
+	if constexpr (sizeof...(Items) == 0) {
+		return true;
+	} else {
+		return appears_last_property_helper(pack<Items...>{});
+	}
+}
+} // namespace detail
+
+template <class Visitor, class... Items>
+typename std::enable_if<is_fb_function<Visitor>, void>::type serializer(Visitor& visitor, Items&... items) {
+	static_assert(detail::appears_last_property(pack<Items...>{}),
+	              "An argument to a serializer call that must appear last (Arena?) does not appear last");
+	visitor(items...);
+}
 
 template <class T, typename = void>
 struct scalar_traits : std::false_type {

--- a/flow/include/flow/ObjectSerializerTraits.h
+++ b/flow/include/flow/ObjectSerializerTraits.h
@@ -60,7 +60,8 @@ template <class T, typename = void>
 struct fb_must_appear_last_t : std::false_type {};
 
 template <class T>
-struct fb_must_appear_last_t<T, typename std::enable_if<T::fb_must_appear_last>::type> : std::true_type {};
+struct fb_must_appear_last_t<T, typename std::enable_if<T::fb_must_appear_last>::type>
+  : std::conditional_t<T::fb_must_appear_last, std::true_type, std::false_type> {};
 
 template <class T>
 constexpr bool fb_must_appear_last = fb_must_appear_last_t<T>::value;

--- a/flow/include/flow/ObjectSerializerTraits.h
+++ b/flow/include/flow/ObjectSerializerTraits.h
@@ -66,28 +66,26 @@ struct fb_must_appear_last_t<T, typename std::enable_if<T::fb_must_appear_last>:
 template <class T>
 constexpr bool fb_must_appear_last = fb_must_appear_last_t<T>::value;
 
-namespace detail {
 template <class Item, class... Items>
-constexpr bool appears_last_property_helper(pack<Item, Items...>) {
+constexpr bool fb_appears_last_property_helper(pack<Item, Items...>) {
 	if constexpr (sizeof...(Items) == 0) {
 		return true;
 	} else {
-		return !fb_must_appear_last<Item> && appears_last_property_helper(pack<Items...>{});
+		return !fb_must_appear_last<Item> && fb_appears_last_property_helper(pack<Items...>{});
 	}
 }
 template <class... Items>
-constexpr bool appears_last_property(pack<Items...>) {
+constexpr bool fb_appears_last_property(pack<Items...>) {
 	if constexpr (sizeof...(Items) == 0) {
 		return true;
 	} else {
-		return appears_last_property_helper(pack<Items...>{});
+		return fb_appears_last_property_helper(pack<Items...>{});
 	}
 }
-} // namespace detail
 
 template <class Visitor, class... Items>
 typename std::enable_if<is_fb_function<Visitor>, void>::type serializer(Visitor& visitor, Items&... items) {
-	static_assert(detail::appears_last_property(pack<Items...>{}),
+	static_assert(fb_appears_last_property(pack<Items...>{}),
 	              "An argument to a serializer call that must appear last (Arena?) does not appear last");
 	visitor(items...);
 }

--- a/flow/include/flow/serialize.h
+++ b/flow/include/flow/serialize.h
@@ -91,7 +91,7 @@ inline typename Archive::READER& operator>>(Archive& ar, Item& item) {
 
 template <class Archive, class Item, class... Items>
 typename Archive::WRITER& serializer(Archive& ar, const Item& item, const Items&... items) {
-	static_assert(detail::appears_last_property(pack<Item, Items...>{}),
+	static_assert(fb_appears_last_property(pack<Item, Items...>{}),
 	              "An argument to a serializer call that must appear last (Arena?) does not appear last");
 	save(ar, item);
 	if constexpr (sizeof...(Items) > 0) {
@@ -102,7 +102,7 @@ typename Archive::WRITER& serializer(Archive& ar, const Item& item, const Items&
 
 template <class Archive, class Item, class... Items>
 typename Archive::READER& serializer(Archive& ar, Item& item, Items&... items) {
-	static_assert(detail::appears_last_property(pack<Item, Items...>{}),
+	static_assert(fb_appears_last_property(pack<Item, Items...>{}),
 	              "An argument to a serializer call that must appear last (Arena?) does not appear last");
 	load(ar, item);
 	if constexpr (sizeof...(Items) > 0) {

--- a/flow/include/flow/serialize.h
+++ b/flow/include/flow/serialize.h
@@ -91,6 +91,8 @@ inline typename Archive::READER& operator>>(Archive& ar, Item& item) {
 
 template <class Archive, class Item, class... Items>
 typename Archive::WRITER& serializer(Archive& ar, const Item& item, const Items&... items) {
+	static_assert(detail::appears_last_property(pack<Item, Items...>{}),
+	              "An argument to a serializer call that must appear last (Arena?) does not appear last");
 	save(ar, item);
 	if constexpr (sizeof...(Items) > 0) {
 		serializer(ar, items...);
@@ -100,6 +102,8 @@ typename Archive::WRITER& serializer(Archive& ar, const Item& item, const Items&
 
 template <class Archive, class Item, class... Items>
 typename Archive::READER& serializer(Archive& ar, Item& item, Items&... items) {
+	static_assert(detail::appears_last_property(pack<Item, Items...>{}),
+	              "An argument to a serializer call that must appear last (Arena?) does not appear last");
 	load(ar, item);
 	if constexpr (sizeof...(Items) > 0) {
 		serializer(ar, items...);


### PR DESCRIPTION
- Assert that arena's appear last in serializer calls
- Fix all occurrences of Arena's not appearing last in serializer call

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
