### PR TITLE
Make FDBCLI check coordinator :tls suffix

### DIFF
--- a/bindings/python/tests/fdbcli_tests.py
+++ b/bindings/python/tests/fdbcli_tests.py
@@ -7,6 +7,7 @@ import subprocess
 import logging
 import functools
 import json
+import tempfile
 import time
 import random
 from argparse import ArgumentParser, RawDescriptionHelpFormatter
@@ -770,6 +771,68 @@ def integer_options():
     assert lines[1].startswith('Committed')
     assert error_output == b''
 
+def tls_address_suffix():
+    # fdbcli shall prevent a non-TLS fdbcli run from connecting to an all-TLS cluster, and vice versa
+    preamble = 'eNW1yf1M:eNW1yf1M@'
+    def make_addr(port: int, tls: bool = False):
+        return "127.0.0.1:{}{}".format(port, ":tls" if tls else "")
+    testcases = [
+        # IsServerTLS, NumServerAddrs
+        (True, 1),
+        (False, 1),
+        (True, 3),
+        (False, 3),
+    ]
+    err_output_server_no_tls = "ERROR: fdbcli is configured with TLS, but none of the coordinators have TLS addresses."
+    err_output_server_tls = "ERROR: fdbcli is not configured with TLS, but all of the coordinators have TLS addresses."
+
+    # technically the contents of the certs and key files are not evaluated
+    # before tls-suffix check against tls configuration takes place,
+    # but we generate the certs and keys anyway to avoid
+    # imposing nuanced TLSConfig evaluation ordering requirement on the testcase
+    with tempfile.TemporaryDirectory() as tmpdir:
+        cert_file = tmpdir + "/client-cert.pem"
+        key_file = tmpdir + "/client-key.pem"
+        ca_file = tmpdir + "/server-ca.pem"
+        mkcert_process = subprocess.run([
+                args.build_dir + "/bin/mkcert",
+                "--server-chain-length", "1",
+                "--client-chain-length", "1",
+                "--server-cert-file", tmpdir + "/server-cert.pem",
+                "--client-cert-file", tmpdir + "/client-cert.pem",
+                "--server-key-file", tmpdir + "/server-key.pem",
+                "--client-key-file", tmpdir + "/client-key.pem",
+                "--server-ca-file", tmpdir + "/server-ca.pem",
+                "--client-ca-file", tmpdir + "/client-ca.pem",
+            ],
+            capture_output=True)
+        if mkcert_process.returncode != 0:
+            print("mkcert returned with code {}".format(mkcert_process.returncode))
+            print("Output:\n{}{}\n".format(
+                        mkcert_process.stdout.decode("utf8").strip(),
+                        mkcert_process.stderr.decode("utf8").strip()))
+            assert False
+        cluster_fn = tmpdir + "/fdb.cluster"
+        for testcase in testcases:
+            is_server_tls, num_server_addrs = testcase
+            with open(cluster_fn, "w") as fp:
+                fp.write(preamble + ",".join(
+                    [make_addr(port=4000 + addr_idx, tls=is_server_tls) for addr_idx in range(num_server_addrs)]))
+                fp.close()
+                tls_args = ["--tls-certificate-file",
+                            cert_file,
+                            "--tls-key-file",
+                            key_file,
+                            "--tls-ca-file",
+                            ca_file] if not is_server_tls else []
+                fdbcli_process = subprocess.run(command_template[:2] + [cluster_fn] + tls_args, capture_output=True)
+                assert fdbcli_process.returncode != 0
+                err_out = fdbcli_process.stderr.decode("utf8").strip()
+                if is_server_tls:
+                    assert err_out == err_output_server_tls, f"unexpected output: {err_out}"
+                else:
+                    assert err_out == err_output_server_no_tls, f"unexpected output: {err_out}"
+
 if __name__ == '__main__':
     parser = ArgumentParser(formatter_class=RawDescriptionHelpFormatter,
                             description="""
@@ -816,6 +879,7 @@ if __name__ == '__main__':
         tenants()
         versionepoch()
         integer_options()
+        tls_address_suffix()
     else:
         assert args.process_number > 1, "Process number should be positive"
         coordinators()

--- a/fdbcli/fdbcli.actor.cpp
+++ b/fdbcli/fdbcli.actor.cpp
@@ -1050,7 +1050,7 @@ Future<T> stopNetworkAfter(Future<T> what) {
 	}
 }
 
-ACTOR Future<int> cli(CLIOptions opt, LineNoise* plinenoise) {
+ACTOR Future<int> cli(CLIOptions opt, LineNoise* plinenoise, Reference<ClusterConnectionFile> ccf) {
 	state LineNoise& linenoise = *plinenoise;
 	state bool intrans = false;
 
@@ -1074,20 +1074,6 @@ ACTOR Future<int> cli(CLIOptions opt, LineNoise* plinenoise) {
 	state FdbOptions activeOptions;
 
 	state FdbOptions* options = &globalOptions;
-
-	state Reference<ClusterConnectionFile> ccf;
-
-	state std::pair<std::string, bool> resolvedClusterFile =
-	    ClusterConnectionFile::lookupClusterFileName(opt.clusterFile);
-	try {
-		ccf = makeReference<ClusterConnectionFile>(resolvedClusterFile.first);
-	} catch (Error& e) {
-		if (e.code() == error_code_operation_cancelled) {
-			throw;
-		}
-		fprintf(stderr, "%s\n", ClusterConnectionFile::getErrorString(resolvedClusterFile, e).c_str());
-		return 1;
-	}
 
 	// Ordinarily, this is done when the network is run. However, network thread should be set before TraceEvents are
 	// logged. This thread will eventually run the network, so call it now.
@@ -1987,7 +1973,7 @@ ACTOR Future<int> cli(CLIOptions opt, LineNoise* plinenoise) {
 	}
 }
 
-ACTOR Future<int> runCli(CLIOptions opt) {
+ACTOR Future<int> runCli(CLIOptions opt, Reference<ClusterConnectionFile> ccf) {
 	state LineNoise linenoise(
 	    [](std::string const& line, std::vector<std::string>& completions) { fdbcliCompCmd(line, completions); },
 	    [enabled = opt.cliHints](std::string const& line) -> LineNoise::Hint {
@@ -2051,7 +2037,7 @@ ACTOR Future<int> runCli(CLIOptions opt) {
 		    .GetLastError();
 	}
 
-	state int result = wait(cli(opt, &linenoise));
+	state int result = wait(cli(opt, &linenoise, ccf));
 
 	if (!historyFilename.empty()) {
 		try {
@@ -2071,6 +2057,33 @@ ACTOR Future<Void> timeExit(double duration) {
 	wait(delay(duration));
 	fprintf(stderr, "Specified timeout reached -- exiting...\n");
 	return Void();
+}
+
+const char* checkTlsConfigAgainstCoordAddrs(const ClusterConnectionString& ccs) {
+	// Resolve TLS config and inspect whether any of the certificate, key, ca bytes has been set
+	extern TLSConfig tlsConfig;
+	auto const loaded = tlsConfig.loadSync();
+	const bool tlsConfigured =
+	    !loaded.getCertificateBytes().empty() || !loaded.getKeyBytes().empty() || !loaded.getCABytes().empty();
+	int tlsAddrs = 0;
+	int totalAddrs = 0;
+	for (const auto& addr : ccs.coords) {
+		if (addr.isTLS())
+			tlsAddrs++;
+		totalAddrs++;
+	}
+	for (const auto& host : ccs.hostnames) {
+		if (host.isTLS)
+			tlsAddrs++;
+		totalAddrs++;
+	}
+	if (tlsConfigured && tlsAddrs == 0) {
+		return "fdbcli is configured with TLS, but none of the coordinators have TLS addresses.";
+	} else if (!tlsConfigured && tlsAddrs == totalAddrs) {
+		return "fdbcli is not configured with TLS, but all of the coordinators have TLS addresses.";
+	} else {
+		return nullptr;
+	}
 }
 
 int main(int argc, char** argv) {
@@ -2177,6 +2190,25 @@ int main(int argc, char** argv) {
 		return 0;
 	}
 
+	Reference<ClusterConnectionFile> ccf;
+	std::pair<std::string, bool> resolvedClusterFile = ClusterConnectionFile::lookupClusterFileName(opt.clusterFile);
+
+	try {
+		ccf = makeReference<ClusterConnectionFile>(resolvedClusterFile.first);
+	} catch (Error& e) {
+		if (e.code() == error_code_operation_cancelled) {
+			throw;
+		}
+		fprintf(stderr, "%s\n", ClusterConnectionFile::getErrorString(resolvedClusterFile, e).c_str());
+		return 1;
+	}
+
+	// Make sure that TLS configuration lines up with ":tls" prefix on coordinator addresses
+	if (auto errorMsg = checkTlsConfigAgainstCoordAddrs(ccf->getConnectionString())) {
+		fprintf(stderr, "ERROR: %s\n", errorMsg);
+		return 1;
+	}
+
 	try {
 		API->selectApiVersion(opt.apiVersion);
 		if (opt.useFutureProtocolVersion) {
@@ -2188,7 +2220,7 @@ int main(int argc, char** argv) {
 			return opt.exit_code;
 		}
 		Future<Void> memoryUsageMonitor = startMemoryUsageMonitor(opt.memLimit);
-		Future<int> cliFuture = runCli(opt);
+		Future<int> cliFuture = runCli(opt, ccf);
 		Future<Void> timeoutFuture = opt.exit_timeout ? timeExit(opt.exit_timeout) : Never();
 		auto f = stopNetworkAfter(success(cliFuture) || timeoutFuture);
 		API->runNetwork();


### PR DESCRIPTION
Currently `fdbcli` connects to coordinator even if client is TLS-enabled while coordinator address specified in cluster file is not, and vice versa.
Instead, let `fdbcli` check the `:tls` suffix in coordinator addresses before database connection takes place, only proceeding further if there is at least one coordinator address whose TLS suffix matches client's TLS configuration.
The necessary condition for "client has configured TLS" is that the dynamically resolved TLS configuration (`LoadedTLSConfig`) of `fdbcli`'s client instance holds non-empty string for at least one of the following fields: `certificateBytes`, `keyBytes`, or `caBytes`.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
