### PR TITLE
Add STORAGE_SERVER_REBOOT_ON_IO_TIMEOUT knob to reboot SS on io_timeout

### DIFF
--- a/fdbclient/ServerKnobs.cpp
+++ b/fdbclient/ServerKnobs.cpp
@@ -802,6 +802,7 @@ void ServerKnobs::initialize(Randomize randomize, ClientKnobs* clientKnobs, IsSi
 	init( PEER_TIMEOUT_PERCENTAGE_DEGRADATION_THRESHOLD,         0.1 );
 	init( PEER_DEGRADATION_CONNECTION_FAILURE_COUNT,               1 );
 	init( WORKER_HEALTH_REPORT_RECENT_DESTROYED_PEER,           true );
+	init( STORAGE_SERVER_REBOOT_ON_IO_TIMEOUT,                 false ); if ( randomize && BUGGIFY ) STORAGE_SERVER_REBOOT_ON_IO_TIMEOUT = true;
 
 	// Test harness
 	init( WORKER_POLL_DELAY,                                     1.0 );

--- a/fdbclient/include/fdbclient/ServerKnobs.h
+++ b/fdbclient/include/fdbclient/ServerKnobs.h
@@ -763,6 +763,12 @@ public:
 	bool WORKER_HEALTH_REPORT_RECENT_DESTROYED_PEER; // When enabled, the worker's health monitor also report any recent
 	                                                 // destroyed peers who are part of the transaction system to
 	                                                 // cluster controller.
+	bool STORAGE_SERVER_REBOOT_ON_IO_TIMEOUT; // When enabled, storage server's worker will crash on io_timeout error;
+                                               // this allows fdbmonitor to restart the worker and recreate the same SS.
+                                               // When SS can be temporarily throttled by infrastructure, e.g, k8s,
+                                               // Enabling this can reduce toil of manually restarting the SS.
+                                               // Enable with caution: If io_timeout is caused by disk failure, we won't
+                                               // want to restart the SS, which increases risk of data corruption.
 
 	// Test harness
 	double WORKER_POLL_DELAY;

--- a/fdbclient/include/fdbclient/ServerKnobs.h
+++ b/fdbclient/include/fdbclient/ServerKnobs.h
@@ -764,11 +764,11 @@ public:
 	                                                 // destroyed peers who are part of the transaction system to
 	                                                 // cluster controller.
 	bool STORAGE_SERVER_REBOOT_ON_IO_TIMEOUT; // When enabled, storage server's worker will crash on io_timeout error;
-                                               // this allows fdbmonitor to restart the worker and recreate the same SS.
-                                               // When SS can be temporarily throttled by infrastructure, e.g, k8s,
-                                               // Enabling this can reduce toil of manually restarting the SS.
-                                               // Enable with caution: If io_timeout is caused by disk failure, we won't
-                                               // want to restart the SS, which increases risk of data corruption.
+	                                          // this allows fdbmonitor to restart the worker and recreate the same SS.
+	                                          // When SS can be temporarily throttled by infrastructure, e.g, k8s,
+	                                          // Enabling this can reduce toil of manually restarting the SS.
+	                                          // Enable with caution: If io_timeout is caused by disk failure, we won't
+	                                          // want to restart the SS, which increases risk of data corruption.
 
 	// Test harness
 	double WORKER_POLL_DELAY;

--- a/fdbserver/worker.actor.cpp
+++ b/fdbserver/worker.actor.cpp
@@ -271,7 +271,9 @@ ACTOR Future<Void> workerHandleErrors(FutureStream<ErrorInfo> errors) {
 
 			if (err.error.code() == error_code_please_reboot ||
 			    (err.role == Role::SHARED_TRANSACTION_LOG &&
-			     (err.error.code() == error_code_io_error || err.error.code() == error_code_io_timeout)))
+				  (err.error.code() == error_code_io_error || err.error.code() == error_code_io_timeout)) ||
+                (SERVER_KNOBS->STORAGE_SERVER_REBOOT_ON_IO_TIMEOUT && err.role == Role::STORAGE_SERVER &&
+                 err.error.code() == error_code_io_timeout))
 				throw err.error;
 		}
 	}

--- a/fdbserver/worker.actor.cpp
+++ b/fdbserver/worker.actor.cpp
@@ -271,9 +271,9 @@ ACTOR Future<Void> workerHandleErrors(FutureStream<ErrorInfo> errors) {
 
 			if (err.error.code() == error_code_please_reboot ||
 			    (err.role == Role::SHARED_TRANSACTION_LOG &&
-				  (err.error.code() == error_code_io_error || err.error.code() == error_code_io_timeout)) ||
-                (SERVER_KNOBS->STORAGE_SERVER_REBOOT_ON_IO_TIMEOUT && err.role == Role::STORAGE_SERVER &&
-                 err.error.code() == error_code_io_timeout))
+			     (err.error.code() == error_code_io_error || err.error.code() == error_code_io_timeout)) ||
+			    (SERVER_KNOBS->STORAGE_SERVER_REBOOT_ON_IO_TIMEOUT && err.role == Role::STORAGE_SERVER &&
+			     err.error.code() == error_code_io_timeout))
 				throw err.error;
 		}
 	}


### PR DESCRIPTION
Introduce STORAGE_SERVER_REBOOT_ON_IO_TIMEOUT knob to control SS behavior at io_timeout errors. 

When enabled, storage server's worker will crash on io_timeout error; this allows fdbmonitor to restart the worker and recreate the same SS.

**When will this new behavior be helpful?**
 SS can be temporarily throttled by infrastructure, e.g, k8s. Without this knob, the current behavior is that SS will stop running silently, which results to less SSes in a cluster. SRE will need to manually restart the worker process to restart the SS. The manual process introduces later latency in recovering the SS and the longer latency may likely cause high SS lag and cause DD to exclude the SS.  Enabling this can reduce toil of manually restarting the SS and hopefully reduce the amount of unnecessary data movement in handling the io_timeout in this particular scenario.

**Enable with caution**: If io_timeout is caused by disk failure, we won't want to restart the SS, which increases risk of data corruption.

**Test**: Only tested with simulation. It's a bit hard to trigger the throttling scenario in k8s that only targets a small set of SSes. We are still working on the real-cluster perf testing.