### PR TITLE
Fix duplicate (and broken) header macro FDBCLIENT_EVENTTYPES[S]_ACTOR…

### DIFF
--- a/fdbclient/include/fdbclient/EventTypes.actor.h
+++ b/fdbclient/include/fdbclient/EventTypes.actor.h
@@ -26,7 +26,7 @@
 #define FDBCLIENT_EVENTTYPES_ACTOR_G_H
 #include "fdbclient/EventTypes.actor.g.h"
 #elif !defined(FDBCLIENT_EVENTTYPES_ACTOR_H)
-#define FDBCLIENT_EVENTTYPESS_ACTOR_H
+#define FDBCLIENT_EVENTTYPES_ACTOR_H
 
 #include "flow/flow.h"
 #include "flow/TDMetric.actor.h"

--- a/flow/include/flow/EventTypes.actor.h
+++ b/flow/include/flow/EventTypes.actor.h
@@ -22,11 +22,11 @@
 
 // When actually compiled (NO_INTELLISENSE), include the generated version of this file.  In intellisense use the source
 // version.
-#if defined(NO_INTELLISENSE) && !defined(FDBCLIENT_EVENTTYPES_ACTOR_G_H)
-#define FDBCLIENT_EVENTTYPES_ACTOR_G_H
+#if defined(NO_INTELLISENSE) && !defined(FLOW_EVENTTYPES_ACTOR_G_H)
+#define FLOW_EVENTTYPES_ACTOR_G_H
 #include "flow/EventTypes.actor.g.h"
-#elif !defined(FDBCLIENT_EVENTTYPES_ACTOR_H)
-#define FDBCLIENT_EVENTTYPESS_ACTOR_H
+#elif !defined(FLOW_EVENTTYPES_ACTOR_H)
+#define FLOW_EVENTTYPES_ACTOR_H
 
 #include "flow/flow.h"
 #include "flow/TDMetric.actor.h"


### PR DESCRIPTION
…[_G]_H

The header macros for these files were incorrect.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
