### PR TITLE
Fix configuration section of ConfigureTestRestart-2.toml test file

### DIFF
--- a/fdbserver/SimulatedCluster.actor.cpp
+++ b/fdbserver/SimulatedCluster.actor.cpp
@@ -414,7 +414,6 @@ public:
 		    .add("allowDisablingTenants", &allowDisablingTenants)
 		    .add("allowCreatingTenants", &allowCreatingTenants)
 		    .add("randomlyRenameZoneId", &randomlyRenameZoneId)
-		    .add("randomlyRenameZoneId", &randomlyRenameZoneId)
 		    .add("injectTargetedSSRestart", &injectTargetedSSRestart)
 		    .add("injectSSDelay", &injectSSDelay);
 		try {

--- a/tests/restarting/from_7.1.0/ConfigureTestRestart-2.toml
+++ b/tests/restarting/from_7.1.0/ConfigureTestRestart-2.toml
@@ -1,4 +1,4 @@
-[[configuration]]
+[configuration]
 randomlyRenameZoneId=true
 
 [[test]]


### PR DESCRIPTION
Previously this section was being ignored because `toml::find(file, "configuration").is_table()` was false. This was causing a code probe for "Zone ID names altered in restart test" to be missed.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
