### PR TITLE
Disable CODE_PROBEs in StorageCache.actor.cpp

### DIFF
--- a/fdbserver/StorageCache.actor.cpp
+++ b/fdbserver/StorageCache.actor.cpp
@@ -282,7 +282,7 @@ public:
 	void checkChangeCounter(uint64_t oldCacheRangeChangeCounter, KeyRef const& key) {
 		if (oldCacheRangeChangeCounter != cacheRangeChangeCounter &&
 		    cachedRangeMap[key]->changeCounter > oldCacheRangeChangeCounter) {
-			CODE_PROBE(true, "CacheRange change during getValueQ");
+			// CODE_PROBE(true, "CacheRange change during getValueQ");
 			// TODO: should we throw the cold_cache_server() error here instead?
 			throw wrong_shard_server();
 		}
@@ -293,8 +293,8 @@ public:
 			auto sh = cachedRangeMap.intersectingRanges(keys);
 			for (auto i = sh.begin(); i != sh.end(); ++i)
 				if (i->value()->changeCounter > oldCacheRangeChangeCounter) {
-					CODE_PROBE(true, "CacheRange change during range operation");
-					// TODO: should we throw the cold_cache_server() error here instead?
+					// CODE_PROBE(true, "CacheRange change during range operation");
+					//  TODO: should we throw the cold_cache_server() error here instead?
 					throw wrong_shard_server();
 				}
 		}
@@ -663,7 +663,7 @@ Key findKey(StorageCacheData* data, KeySelectorRef sel, Version version, KeyRang
 	// If we get only one result in the reverse direction as a result of the data being too large, we could get stuck in
 	// a loop
 	if (more && !forward && rep.data.size() == 1) {
-		CODE_PROBE(true, "Reverse key selector returned only one result in range read");
+		// CODE_PROBE(true, "Reverse key selector returned only one result in range read");
 		maxBytes = std::numeric_limits<int>::max();
 		GetKeyValuesReply rep2 =
 		    readRange(data, version, KeyRangeRef(range.begin, keyAfter(sel.getKey())), -2, &maxBytes);
@@ -686,7 +686,7 @@ Key findKey(StorageCacheData* data, KeySelectorRef sel, Version version, KeyRang
 			*pOffset = -*pOffset;
 
 		if (more) {
-			CODE_PROBE(true, "Key selector read range had more results");
+			// CODE_PROBE(true, "Key selector read range had more results");
 
 			ASSERT(rep.data.size());
 			Key returnKey = forward ? keyAfter(rep.data.back().key) : rep.data.back().key;
@@ -780,11 +780,11 @@ ACTOR Future<Void> getKeyValues(StorageCacheData* data, GetKeyValuesRequest req)
 		// cachedKeyRange is the end the last actual key returned must be from this cachedKeyRange. A begin offset of 1
 		// is also OK because then either begin is past end or equal to end (so the result is definitely empty)
 		if ((offset1 && offset1 != 1) || (offset2 && offset2 != 1)) {
-			CODE_PROBE(true, "wrong_cache_server due to offset");
-			// We could detect when offset1 takes us off the beginning of the database or offset2 takes us off the end,
-			// and return a clipped range rather than an error (since that is what the NativeAPI.getRange will do anyway
-			// via its "slow path"), but we would have to add some flags to the response to encode whether we went off
-			// the beginning and the end, since it needs that information.
+			// CODE_PROBE(true, "wrong_cache_server due to offset");
+			//  We could detect when offset1 takes us off the beginning of the database or offset2 takes us off the end,
+			//  and return a clipped range rather than an error (since that is what the NativeAPI.getRange will do
+			//  anyway via its "slow path"), but we would have to add some flags to the response to encode whether we
+			//  went off the beginning and the end, since it needs that information.
 			//TraceEvent(SevDebug, "WrongCacheRangeServer2", data->thisServerID).detail("Begin", req.begin.toString()).detail("End", req.end.toString()).detail("Version", version).
 			// detail("CacheRangeBegin", cachedKeyRange.begin).detail("CacheRangeEnd", cachedKeyRange.end).detail("In",
 			// "getKeyValues>checkOffsets"). detail("BeginKey", begin).detail("EndKey", end).detail("BeginOffset",
@@ -944,7 +944,7 @@ bool expandMutation(MutationRef& m, StorageCacheData::VersionedData const& data,
 		if (it != data.atLatest().end() && it->isValue() && it.key() == m.param1)
 			oldVal = it->getValue();
 		else if (it != data.atLatest().end() && it->isClearTo() && it->getEndKey() > m.param1) {
-			CODE_PROBE(true, "Atomic op right after a clear.");
+			// CODE_PROBE(true, "Atomic op right after a clear.");
 		}
 
 		switch (m.type) {
@@ -1074,7 +1074,7 @@ void splitMutation(StorageCacheData* data, KeyRangeMap<T>& map, MutationRef cons
 }
 
 void rollback(StorageCacheData* data, Version rollbackVersion, Version nextVersion) {
-	CODE_PROBE(true, "call to cacheRange rollback");
+	// CODE_PROBE(true, "call to cacheRange rollback");
 	// FIXME: enable when debugKeyRange is active
 	// debugKeyRange("Rollback", rollbackVersion, allKeys);
 
@@ -1282,7 +1282,7 @@ ACTOR Future<Void> fetchKeys(StorageCacheData* data, AddingCacheRange* cacheRang
 			lastAvailable = std::max(lastAvailable, r->value());
 
 		if (lastAvailable != invalidVersion && lastAvailable >= data->oldestVersion.get()) {
-			CODE_PROBE(true, "wait for oldest version");
+			// CODE_PROBE(true, "wait for oldest version");
 			wait(data->oldestVersion.whenAtLeast(lastAvailable + 1));
 		}
 
@@ -1321,7 +1321,7 @@ ACTOR Future<Void> fetchKeys(StorageCacheData* data, AddingCacheRange* cacheRang
 
 		loop {
 			try {
-				CODE_PROBE(true, "Fetching keys for transferred cacheRange");
+				// CODE_PROBE(true, "Fetching keys for transferred cacheRange");
 
 				state RangeResult this_block =
 				    wait(tryFetchRange(data->cx,
@@ -1385,7 +1385,7 @@ ACTOR Future<Void> fetchKeys(StorageCacheData* data, AddingCacheRange* cacheRang
 				    .suppressFor(1.0)
 				    .detail("FKID", interval.pairID);
 				if (e.code() == error_code_transaction_too_old) {
-					CODE_PROBE(true, "A storage server has forgotten the history data we are fetching");
+					// CODE_PROBE(true, "A storage server has forgotten the history data we are fetching");
 					Version lastFV = fetchVersion;
 					fetchVersion = data->version.get();
 					isTooOld = false;
@@ -1412,9 +1412,9 @@ ACTOR Future<Void> fetchKeys(StorageCacheData* data, AddingCacheRange* cacheRang
 						    .detail("E", data->version.get());
 					}
 				} else if (e.code() == error_code_future_version || e.code() == error_code_process_behind) {
-					CODE_PROBE(true,
-					           "fetchKeys got future_version or process_behind, so there must be a huge storage lag "
-					           "somewhere.  Keep trying.");
+					// CODE_PROBE(true,
+					//           "fetchKeys got future_version or process_behind, so there must be a huge storage lag "
+					//           "somewhere.  Keep trying.");
 				} else {
 					throw;
 				}
@@ -1474,7 +1474,7 @@ ACTOR Future<Void> fetchKeys(StorageCacheData* data, AddingCacheRange* cacheRang
 		}
 
 		int startSize = batch->changes.size();
-		CODE_PROBE(startSize, "Adding fetch data to a batch which already has changes");
+		// CODE_PROBE(startSize, "Adding fetch data to a batch which already has changes");
 		batch->changes.resize(batch->changes.size() + cacheRange->updates.size());
 
 		// FIXME: pass the deque back rather than copy the data
@@ -1637,7 +1637,7 @@ void cacheWarmup(StorageCacheData* data, const KeyRangeRef& keys, bool nowAssign
 		else {
 			ASSERT(ranges[i].value->adding);
 			data->addCacheRange(CacheRangeInfo::newAdding(data, ranges[i]));
-			CODE_PROBE(true, "cacheWarmup reFetchKeys");
+			// CODE_PROBE(true, "cacheWarmup reFetchKeys");
 		}
 	}
 
@@ -1776,7 +1776,7 @@ private:
 			br >> rollbackVersion;
 
 			if (rollbackVersion < fromVersion && rollbackVersion > data->oldestVersion.get()) {
-				CODE_PROBE(true, "CacheRangeApplyPrivateData cacheRange rollback");
+				// CODE_PROBE(true, "CacheRangeApplyPrivateData cacheRange rollback");
 				TraceEvent(SevWarn, "Rollback", data->thisServerID)
 				    .detail("FromVersion", fromVersion)
 				    .detail("ToVersion", rollbackVersion)
@@ -2014,7 +2014,7 @@ ACTOR Future<Void> pullAsyncData(StorageCacheData* data) {
 					SpanContextMessage scm;
 					reader >> scm;
 				} else if (reader.protocolVersion().hasOTELSpanContext() && OTELSpanContextMessage::isNextIn(reader)) {
-					CODE_PROBE(true, "StorageCache reading OTELSpanContextMessage");
+					// CODE_PROBE(true, "StorageCache reading OTELSpanContextMessage");
 					OTELSpanContextMessage oscm;
 					reader >> oscm;
 				} else {


### PR DESCRIPTION
This feature is currently not enabled or being tested, so we do not expect the code probes in `StorageCache.actor.cpp` to be hit. This PR comments out the code probes so that we see a more accurate picture of the intended code coverage in a Joshua ensemble.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
