### PR TITLE
Use faster `KeepRunning` loops in `flowbench`

### DIFF
--- a/flowbench/BenchEncrypt.cpp
+++ b/flowbench/BenchEncrypt.cpp
@@ -47,7 +47,7 @@ static void bench_encrypt(benchmark::State& state) {
 	auto key = StreamCipherKey::getGlobalCipherKey();
 	auto iv = getRandomIV();
 	auto data = getKey(bytes);
-	while (state.KeepRunning()) {
+	for (auto _ : state) {
 		for (int chunk = 0; chunk < chunks; ++chunk) {
 			benchmark::DoNotOptimize(encrypt(key, iv, data.begin() + chunk * chunkSize, chunkSize));
 		}
@@ -64,7 +64,7 @@ static void bench_decrypt(benchmark::State& state) {
 	auto iv = getRandomIV();
 	auto data = getKey(bytes);
 	auto encrypted = encrypt(key, iv, data.begin(), data.size());
-	while (state.KeepRunning()) {
+	for (auto _ : state) {
 		Arena arena;
 		DecryptionStreamCipher decryptor(key, iv);
 		for (int chunk = 0; chunk < chunks; ++chunk) {

--- a/flowbench/BenchHash.cpp
+++ b/flowbench/BenchHash.cpp
@@ -58,7 +58,7 @@ template <HashType hashType>
 static void bench_hash(benchmark::State& state) {
 	auto length = 1 << state.range(0);
 	auto key = getKey(length);
-	while (state.KeepRunning()) {
+	for (auto _ : state) {
 		hash<hashType>(key, length);
 	}
 	state.SetItemsProcessed(static_cast<long>(state.iterations()));

--- a/flowbench/BenchIterate.cpp
+++ b/flowbench/BenchIterate.cpp
@@ -50,7 +50,7 @@ static void bench_iterate(benchmark::State& state) {
 	auto kv = getKV(size, size);
 	ListImpl mutations;
 	populate(mutations, items, size, kv.key, kv.value);
-	while (state.KeepRunning()) {
+	for (auto _ : state) {
 		for (const auto& mutation : mutations) {
 			benchmark::DoNotOptimize(mutation);
 		}

--- a/flowbench/BenchMem.cpp
+++ b/flowbench/BenchMem.cpp
@@ -31,7 +31,7 @@ static void bench_memcmp(benchmark::State& state) {
 	memset(b2.get(), 0, kLength);
 	b2.get()[kLength - 1] = 1;
 
-	while (state.KeepRunning()) {
+	for (auto _ : state) {
 		benchmark::DoNotOptimize(memcmp(b1.get(), b2.get(), kLength));
 	}
 }
@@ -42,7 +42,7 @@ static void bench_memcpy(benchmark::State& state) {
 	std::unique_ptr<char[]> b2{ new char[kLength] };
 	memset(b1.get(), 0, kLength);
 
-	while (state.KeepRunning()) {
+	for (auto _ : state) {
 		benchmark::DoNotOptimize(memcpy(b2.get(), b1.get(), kLength));
 	}
 }

--- a/flowbench/BenchMetadataCheck.cpp
+++ b/flowbench/BenchMetadataCheck.cpp
@@ -39,7 +39,7 @@ static const std::array<MutationRef, 5> mutations = {
 
 static void bench_check_metadata1(benchmark::State& state) {
 	const auto& m = mutations[state.range(0)];
-	while (state.KeepRunning()) {
+	for (auto _ : state) {
 		benchmark::DoNotOptimize(KeyRangeRef(m.param1, m.param2).intersects(systemKeys));
 	}
 	state.SetItemsProcessed(static_cast<long>(state.iterations()));
@@ -47,7 +47,7 @@ static void bench_check_metadata1(benchmark::State& state) {
 
 static void bench_check_metadata2(benchmark::State& state) {
 	const auto& m = mutations[state.range(0)];
-	while (state.KeepRunning()) {
+	for (auto _ : state) {
 		benchmark::DoNotOptimize(m.param2.size() > 1 && m.param2[0] == systemKeys.begin[0]);
 	}
 	state.SetItemsProcessed(static_cast<long>(state.iterations()));

--- a/flowbench/BenchPopulate.cpp
+++ b/flowbench/BenchPopulate.cpp
@@ -35,7 +35,7 @@ static void bench_populate(benchmark::State& state) {
 	size_t items = state.range(0);
 	size_t size = state.range(1);
 	auto kv = getKV(size, size);
-	while (state.KeepRunning()) {
+	for (auto _ : state) {
 		Standalone<VectorRef<MutationRef>> mutations;
 		mutations.reserve(mutations.arena(), items);
 		for (int i = 0; i < items; ++i) {

--- a/flowbench/BenchRandom.cpp
+++ b/flowbench/BenchRandom.cpp
@@ -23,9 +23,8 @@
 #include "flow/IRandom.h"
 
 static void bench_random(benchmark::State& state) {
-	while (state.KeepRunning()) {
-		double r = deterministicRandom()->random01();
-		benchmark::DoNotOptimize(r);
+	for (auto _ : state) {
+		benchmark::DoNotOptimize(deterministicRandom()->random01());
 	}
 	state.SetItemsProcessed(static_cast<long>(state.iterations()));
 }

--- a/flowbench/BenchRef.cpp
+++ b/flowbench/BenchRef.cpp
@@ -71,7 +71,7 @@ struct Factory<RefType::FlowReferenceThreadSafe> {
 
 template <RefType refType>
 static void bench_ref_create_and_destroy(benchmark::State& state) {
-	while (state.KeepRunning()) {
+	for (auto _ : state) {
 		auto ptr = Factory<refType>::create();
 		benchmark::DoNotOptimize(ptr);
 		Factory<refType>::cleanup(ptr);
@@ -82,7 +82,7 @@ static void bench_ref_create_and_destroy(benchmark::State& state) {
 template <RefType refType>
 static void bench_ref_copy(benchmark::State& state) {
 	auto ptr = Factory<refType>::create();
-	while (state.KeepRunning()) {
+	for (auto _ : state) {
 		auto ptr2 = ptr;
 		benchmark::DoNotOptimize(ptr2);
 	}

--- a/flowbench/BenchTimer.cpp
+++ b/flowbench/BenchTimer.cpp
@@ -23,17 +23,15 @@
 #include "flow/Platform.h"
 
 static void bench_timer(benchmark::State& state) {
-	while (state.KeepRunning()) {
-		double time = timer();
-		benchmark::DoNotOptimize(time);
+	for (auto _ : state) {
+		benchmark::DoNotOptimize(timer());
 	}
 	state.SetItemsProcessed(static_cast<long>(state.iterations()));
 }
 
 static void bench_timer_monotonic(benchmark::State& state) {
-	while (state.KeepRunning()) {
-		double time = timer_monotonic();
-		benchmark::DoNotOptimize(time);
+	for (auto _ : state) {
+		benchmark::DoNotOptimize(timer_monotonic());
 	}
 	state.SetItemsProcessed(static_cast<long>(state.iterations()));
 }

--- a/flowbench/BenchVersionVector.cpp
+++ b/flowbench/BenchVersionVector.cpp
@@ -34,7 +34,7 @@ static void bench_vv_getdelta(benchmark::State& benchState) {
 
 	i = 0;
 	const int64_t numDeltas = benchState.range(1);
-	while (benchState.KeepRunning()) {
+	for (auto _ : benchState) {
 		vv.setVersion(Tag(0, i++), ++version);
 		i %= tags;
 

--- a/flowbench/BenchVersionVectorSerialization.cpp
+++ b/flowbench/BenchVersionVectorSerialization.cpp
@@ -41,7 +41,7 @@ static void bench_serializable_traits_version(benchmark::State& state) {
 
 	size_t size = 0;
 	VersionVector deserializedVV;
-	while (state.KeepRunning()) {
+	for (auto _ : state) {
 		Standalone<StringRef> msg = ObjectWriter::toValue(serializedVV, Unversioned());
 
 		// Capture the serialized buffer size.
@@ -71,7 +71,7 @@ static void bench_dynamic_size_traits_version(benchmark::State& state) {
 
 	size_t size = 0;
 	VersionVector deserializedVV;
-	while (state.KeepRunning()) {
+	for (auto _ : state) {
 		size = dynamic_size_traits<VersionVector>::size(serializedVV, context);
 
 		uint8_t* buf = context.allocate(size);


### PR DESCRIPTION
This is the pattern recommended by https://github.com/google/benchmark/blob/main/docs/user_guide.md#a-faster-keeprunning-loop.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
