### PR TITLE
Set FDB_CLUSTER_FILE for command_line_argument_test

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -388,6 +388,7 @@ if(WITH_PYTHON)
       NAME command_line_argument_test
       COMMAND ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/tests/argument_parsing/test_argument_parsing.py ${CMAKE_BINARY_DIR}
     )
+    set_tests_properties(command_line_argument_test PROPERTIES ENVIRONMENT "FDB_CLUSTER_FILE=${CMAKE_BINARY_DIR}/fdb.cluster")
   endif()
 
   verify_testing()


### PR DESCRIPTION
Previously, you would see the following in command_line_argument_test:

```
Traceback (most recent call last):
  File "/home/jenkins/fdb/extra/long/path/to/work/around/strange/cpack/debug/rpm/behavior/tests/argument_parsing/test_argument_parsing.py", line 113, in <module>
    test_fdbcli(args.build_dir)
  File "/home/jenkins/fdb/extra/long/path/to/work/around/strange/cpack/debug/rpm/behavior/tests/argument_parsing/test_argument_parsing.py", line 79, in test_fdbcli
    check(is_unknown_knob(run_command(command, ["--knob-fake-knob", "foo"])))
  File "/home/jenkins/fdb/extra/long/path/to/work/around/strange/cpack/debug/rpm/behavior/tests/argument_parsing/test_argument_parsing.py", line 30, in check
    assert condition, "Command output:\n" + last_command_output
AssertionError: Command output:
Unable to read cluster file `./fdb.cluster' or `/etc/foundationdb/fdb.cluster' and FDB_CLUSTER_FILE unset: 1515 No cluster file found in current directory or default location
```

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
