### PR TITLE
mako should be in packages/bin

### DIFF
--- a/bindings/c/CMakeLists.txt
+++ b/bindings/c/CMakeLists.txt
@@ -209,9 +209,20 @@ if(NOT WIN32)
   target_link_libraries(trace_partial_file_suffix_test PRIVATE fdb_c Threads::Threads flow doctest)
   target_link_libraries(disconnected_timeout_unit_tests PRIVATE fdb_c Threads::Threads doctest)
 
+  strip_debug_symbols(mako)
   # do not set RPATH for mako
   set_property(TARGET mako PROPERTY SKIP_BUILD_RPATH TRUE)
   target_link_libraries(mako PRIVATE fdb_c fdbclient fmt::fmt Threads::Threads fdb_cpp boost_target rapidjson)
+
+  # install mako
+  if(NOT OPEN_FOR_IDE)
+    if(GENERATE_DEBUG_PACKAGES)
+      fdb_install(TARGETS mako DESTINATION bin COMPONENT clients)
+    else()
+      add_custom_target(prepare_mako_install ALL DEPENDS strip_only_mako)
+      fdb_install(PROGRAMS ${CMAKE_BINARY_DIR}/packages/bin/mako DESTINATION bin COMPONENT clients)
+    endif()
+  endif()
 
   if(NOT OPEN_FOR_IDE)
     # Make sure that fdb_c.h is compatible with c90


### PR DESCRIPTION
This change adds `mako` to the `build/packages/bin` directory with all the other binaries when running `cpack`, which is useful for automation. 

As a side effect this adds `mako` to the `foundationdb-clients` packages. I'd like to get some feedback on whether or not this is desirable for other users or we should create a third package with tools, or just not package `mako` at all.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
