### PR TITLE
Remove unnecessary special key-space relaxed option in binding tenant management

### DIFF
--- a/bindings/java/src/main/com/apple/foundationdb/TenantManagement.java
+++ b/bindings/java/src/main/com/apple/foundationdb/TenantManagement.java
@@ -52,10 +52,6 @@ public class TenantManagement {
 	 * @param tenantName The name of the tenant. Can be any byte string that does not begin a 0xFF byte.
 	 */
 	public static void createTenant(Transaction tr, byte[] tenantName) {
-		if (FDB.instance().getAPIVersion() < 720) {
-			tr.options().setSpecialKeySpaceRelaxed();
-		}
-
 		tr.options().setSpecialKeySpaceEnableWrites();
 		tr.set(ByteArrayUtil.join(TENANT_MAP_PREFIX, tenantName), new byte[0]);
 	}
@@ -90,7 +86,6 @@ public class TenantManagement {
 		final AtomicBoolean checkedExistence = new AtomicBoolean(false);
 		final byte[] key = ByteArrayUtil.join(TENANT_MAP_PREFIX, tenantName);
 		return db.runAsync(tr -> {
-			tr.options().setSpecialKeySpaceRelaxed();
 			tr.options().setSpecialKeySpaceEnableWrites();
 			if(checkedExistence.get()) {
 				tr.set(key, new byte[0]);
@@ -138,10 +133,6 @@ public class TenantManagement {
 	 * @param tenantName The name of the tenant being deleted.
 	 */
 	public static void deleteTenant(Transaction tr, byte[] tenantName) {
-		if (FDB.instance().getAPIVersion() < 720) {
-			tr.options().setSpecialKeySpaceRelaxed();
-		}
-
 		tr.options().setSpecialKeySpaceEnableWrites();
 		tr.clear(ByteArrayUtil.join(TENANT_MAP_PREFIX, tenantName));
 	}
@@ -182,7 +173,6 @@ public class TenantManagement {
 		final AtomicBoolean checkedExistence = new AtomicBoolean(false);
 		final byte[] key = ByteArrayUtil.join(TENANT_MAP_PREFIX, tenantName);
 		return db.runAsync(tr -> {
-			tr.options().setSpecialKeySpaceRelaxed();
 			tr.options().setSpecialKeySpaceEnableWrites();
 			if(checkedExistence.get()) {
 				tr.clear(key);
@@ -248,12 +238,7 @@ public class TenantManagement {
 	 * and the value is the unprocessed JSON string containing the tenant's metadata
 	 */
 	public static CloseableAsyncIterator<KeyValue> listTenants(Database db, Tuple begin, Tuple end, int limit) {
-		Transaction tr = db.createTransaction();
-		if (FDB.instance().getAPIVersion() < 720) {
-			tr.options().setSpecialKeySpaceRelaxed();
-		}
-
-		return listTenants_internal(tr, begin.pack(), end.pack(), limit);
+		return listTenants_internal(db.createTransaction(), begin.pack(), end.pack(), limit);
 	}
 
 	private static CloseableAsyncIterator<KeyValue> listTenants_internal(Transaction tr, byte[] begin, byte[] end,

--- a/bindings/python/fdb/tenant_management.py
+++ b/bindings/python/fdb/tenant_management.py
@@ -23,7 +23,6 @@
 """Documentation for this API can be found at
 https://apple.github.io/foundationdb/api-python.html"""
 
-import fdb
 from fdb import impl as _impl
 
 _tenant_map_prefix = b'\xff\xff/management/tenant/map/'
@@ -53,9 +52,6 @@ def _check_tenant_existence(tr, key, existence_check_marker, force_maybe_commite
 # If the existence_check_marker is a non-empty list, then the existence check is skipped.
 @_impl.transactional
 def _create_tenant_impl(tr, tenant_name, existence_check_marker, force_existence_check_maybe_committed=False):
-    if fdb._version < 720:
-        tr.options.set_special_key_space_relaxed()
-
     tr.options.set_special_key_space_enable_writes()
     key = b'%s%s' % (_tenant_map_prefix, tenant_name)
 
@@ -74,9 +70,6 @@ def _create_tenant_impl(tr, tenant_name, existence_check_marker, force_existence
 # If the existence_check_marker is a non-empty list, then the existence check is skipped.
 @_impl.transactional
 def _delete_tenant_impl(tr, tenant_name, existence_check_marker, force_existence_check_maybe_committed=False):
-    if fdb._version < 720:
-        tr.options.set_special_key_space_relaxed()
-
     tr.options.set_special_key_space_enable_writes()
     key = b'%s%s' % (_tenant_map_prefix, tenant_name)
 
@@ -110,9 +103,6 @@ class FDBTenantList(object):
 # JSON strings of the tenant metadata
 @_impl.transactional
 def _list_tenants_impl(tr, begin, end, limit):
-    if fdb._version < 720:
-        tr.options.set_special_key_space_relaxed()
-
     tr.options.set_raw_access()
     begin_key = b'%s%s' % (_tenant_map_prefix, begin)
     end_key = b'%s%s' % (_tenant_map_prefix, end)

--- a/fdbclient/MultiVersionTransaction.actor.cpp
+++ b/fdbclient/MultiVersionTransaction.actor.cpp
@@ -2762,7 +2762,6 @@ ACTOR Future<std::string> updateClusterSharedStateMapImpl(MultiVersionApi* self,
 		state Reference<ITransaction> tr = db->createTransaction();
 		loop {
 			try {
-				tr->setOption(FDBTransactionOptions::SPECIAL_KEY_SPACE_RELAXED);
 				state ThreadFuture<Optional<Value>> clusterIdFuture = tr->get("\xff\xff/cluster_id"_sr);
 				Optional<Value> clusterIdVal = wait(safeThreadFutureToFuture(clusterIdFuture));
 				ASSERT(clusterIdVal.present());


### PR DESCRIPTION
These options were meant to aid the case where we are accessing a special key-space module in an old version that didn't have the module. We don't really need this, though, since the outcome of trying to access these keys in an unsupported version without the option is an error, and with the option it is likely a silent failure.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
