### PR TITLE
Use tls plugin for old binaries < 5.2.0

### DIFF
--- a/contrib/TestHarness2/test_harness/config.py
+++ b/contrib/TestHarness2/test_harness/config.py
@@ -139,6 +139,8 @@ class Config:
         self.max_errors_args = {'short_name': 'E'}
         self.old_binaries_path: Path = Path('/app/deploy/global_data/oldBinaries/')
         self.old_binaries_path_args = {'help': 'Path to the directory containing the old fdb binaries'}
+        self.tls_plugin_path: Path = Path('/app/deploy/runtime/.tls_5_1/FDBLibTLS.so')
+        self.tls_plugin_path_args = {'help': 'Path to the tls plugin used for binaries < 5.2.0'}
         self.use_valgrind: bool = False
         self.use_valgrind_args = {'action': 'store_true'}
         self.buggify = BuggifyOption('random')

--- a/fdbservice/FDBService.cpp
+++ b/fdbservice/FDBService.cpp
@@ -18,8 +18,8 @@
  * limitations under the License.
  */
 
-#include "fdbservice/ServiceBase.h"
-#include "fdbservice/ThreadPool.h"
+#include "ServiceBase.h"
+#include "ThreadPool.h"
 
 #include <iostream>
 #include <fstream>

--- a/fdbservice/ServiceBase.cpp
+++ b/fdbservice/ServiceBase.cpp
@@ -17,7 +17,7 @@
 \***************************************************************************/
 
 #pragma region Includes
-#include "fdbservice/ServiceBase.h"
+#include "ServiceBase.h"
 #include <assert.h>
 #include <strsafe.h>
 #pragma endregion


### PR DESCRIPTION
This fixes restart tests from old binaries < 5.2.0, which previously
were immediately crashing in a TLS codepath. This behavior was not
originally ported from the old test harness to the new test harness.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
