### PR TITLE
Set timeout on Authz TLS unit test

### DIFF
--- a/fdbrpc/tests/CMakeLists.txt
+++ b/fdbrpc/tests/CMakeLists.txt
@@ -4,5 +4,6 @@ if(NOT WIN32)
   if(NOT OPEN_FOR_IDE)
     add_test(NAME authorization_tls_unittest
       COMMAND $<TARGET_FILE:authz_tls_unittest>)
+    set_tests_properties(authorization_tls_unittest PROPERTIES TIMEOUT 120)
   endif()
 endif()


### PR DESCRIPTION
What seems like a TSAN-induced crash is causing the test to hang.
Set a timeout to prevent it from blocking rest of the test runs.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
