### PR TITLE
Add `/Atomic/DoAppendIfFits` unit test

### DIFF
--- a/fdbclient/Atomic.cpp
+++ b/fdbclient/Atomic.cpp
@@ -1,0 +1,45 @@
+/*
+ * Atomic.cpp
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2022 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "fdbclient/Atomic.h"
+#include "flow/Arena.h"
+#include "flow/UnitTest.h"
+
+void forceLinkAtomicTests() {}
+
+TEST_CASE("/Atomic/DoAppendIfFits") {
+	Arena arena;
+	{
+		Value existingValue = ValueRef(arena, "existing"_sr);
+		Value otherOperand = ValueRef(arena, "other"_sr);
+		auto result = doAppendIfFits(existingValue, otherOperand, arena);
+		ASSERT(compare("existingother"_sr, result) == 0);
+	}
+	{
+		Value existingValue = makeString(CLIENT_KNOBS->VALUE_SIZE_LIMIT - 1, arena);
+		Value otherOperand = makeString(2, arena);
+		// Appended values cannot fit in result, should return existingValue
+		auto result = doAppendIfFits(existingValue, otherOperand, arena);
+		ASSERT(compare(existingValue, result) == 0);
+	}
+	return Void();
+}
+
+// TODO: Add more unit tests for atomic operations defined in Atomic.h

--- a/fdbclient/include/fdbclient/Atomic.h
+++ b/fdbclient/include/fdbclient/Atomic.h
@@ -120,7 +120,7 @@ inline ValueRef doAppendIfFits(const Optional<ValueRef>& existingValueOptional,
 	if (!otherOperand.size())
 		return existingValue;
 	if (existingValue.size() + otherOperand.size() > CLIENT_KNOBS->VALUE_SIZE_LIMIT) {
-		CODE_PROBE(true, "AppendIfFIts resulted in truncation");
+		CODE_PROBE(true, "AppendIfFits resulted in truncation");
 		return existingValue;
 	}
 

--- a/fdbserver/workloads/UnitTests.actor.cpp
+++ b/fdbserver/workloads/UnitTests.actor.cpp
@@ -42,6 +42,7 @@ void forceLinkRESTClientTests();
 void forceLinkRESTUtilsTests();
 void forceLinkRESTKmsConnectorTest();
 void forceLinkCompressionUtilsTest();
+void forceLinkAtomicTests();
 
 struct UnitTestWorkload : TestWorkload {
 	bool enabled;
@@ -85,7 +86,7 @@ struct UnitTestWorkload : TestWorkload {
 		forceLinkMemcpyTests();
 		forceLinkMemcpyPerfTests();
 		forceLinkStreamCipherTests();
-		void forceLinkBlobCipherTests();
+		forceLinkBlobCipherTests();
 		forceLinkParallelStreamTests();
 		forceLinkSimExternalConnectionTests();
 		forceLinkMutationLogReaderTests();
@@ -98,6 +99,7 @@ struct UnitTestWorkload : TestWorkload {
 		forceLinkRESTUtilsTests();
 		forceLinkRESTKmsConnectorTest();
 		forceLinkCompressionUtilsTest();
+		forceLinkAtomicTests();
 	}
 
 	std::string description() const override { return "UnitTests"; }


### PR DESCRIPTION
This hits the previously rarely-hit code probe for "AppendIfFits resulted in truncation". In the future, more unit tests should be added for the atomic operations.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
