### PR TITLE
Add an option to disable kernel-aio in test harness

### DIFF
--- a/contrib/TestHarness2/test_harness/config.py
+++ b/contrib/TestHarness2/test_harness/config.py
@@ -141,6 +141,7 @@ class Config:
         self.old_binaries_path_args = {'help': 'Path to the directory containing the old fdb binaries'}
         self.tls_plugin_path: Path = Path('/app/deploy/runtime/.tls_5_1/FDBLibTLS.so')
         self.tls_plugin_path_args = {'help': 'Path to the tls plugin used for binaries < 5.2.0'}
+        self.disable_kaio: bool = False
         self.use_valgrind: bool = False
         self.use_valgrind_args = {'action': 'store_true'}
         self.buggify = BuggifyOption('random')

--- a/contrib/TestHarness2/test_harness/run.py
+++ b/contrib/TestHarness2/test_harness/run.py
@@ -351,6 +351,8 @@ class TestRun:
         if self.use_tls_plugin:
             command += ['--tls_plugin', str(config.tls_plugin_path)]
             env["FDB_TLS_PLUGIN"] = str(config.tls_plugin_path)
+        if config.disable_kaio:
+            command += ['--knob-disable-posix-kernel-aio=1']
         if Version.of_binary(self.binary) >= '7.1.0':
             command += ['-fi', 'on' if self.fault_injection_enabled else 'off']
         if self.restarting:


### PR DESCRIPTION
I'm using this for experimenting with criu: https://criu.org/Main_Page,
which doesn't support kernel aio.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
