### PR TITLE
Fix undefined behavior when retries is too large

### DIFF
--- a/fdbclient/PaxosConfigTransaction.actor.cpp
+++ b/fdbclient/PaxosConfigTransaction.actor.cpp
@@ -218,8 +218,8 @@ class GetGenerationQuorum {
 					if (self->coordinatorsChangedFuture.isReady()) {
 						throw coordinators_changed();
 					}
-					wait(delayJittered(
-					    std::clamp(0.005 * (1 << retries), 0.0, CLIENT_KNOBS->TIMEOUT_RETRY_UPPER_BOUND)));
+					wait(delayJittered(std::clamp(
+					    0.005 * (1 << std::min(retries, 30)), 0.0, CLIENT_KNOBS->TIMEOUT_RETRY_UPPER_BOUND)));
 					if (deterministicRandom()->random01() < 0.05) {
 						// Randomly inject a delay of at least the generation
 						// reply timeout, to try to prevent contention between


### PR DESCRIPTION
fdbclient/PaxosConfigTransaction.actor.cpp:221:77: runtime error: shift exponent 32 is too large for 32-bit type 'int'

I confirmed that `1 << 30` is not UB

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
