### PR TITLE
Make a new memory arena for Tuple::clear

### DIFF
--- a/fdbclient/include/fdbclient/Tuple.h
+++ b/fdbclient/include/fdbclient/Tuple.h
@@ -71,7 +71,9 @@ struct Tuple {
 	size_t size() const { return offsets.size(); }
 	void reserve(size_t cap) { offsets.reserve(cap); }
 	void clear() {
-		data.clear();
+		// Make a new Standalone to use different memory so that
+		// previously returned objects from pack() are valid.
+		data = Standalone<VectorRef<uint8_t>>();
 		offsets.clear();
 	}
 	// Return a Tuple encoded raw string.


### PR DESCRIPTION
To avoid potential problem of invalidating contents that were previously returned from `pack()` calls.

Found from #8187

20220915-201113-jzhou-b4183eebf82d2079

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
