### PR TITLE
Make parse errors of command-line knobs stop the program rather than …

### DIFF
--- a/fdbclient/IKnobCollection.cpp
+++ b/fdbclient/IKnobCollection.cpp
@@ -103,16 +103,19 @@ void IKnobCollection::setupKnobs(const std::vector<std::pair<std::string, std::s
 			g_knobs.setKnob(knobName, knobValue);
 		} catch (Error& e) {
 			if (e.code() == error_code_invalid_option_value) {
-				std::cerr << "WARNING: Invalid value '" << knobValueString << "' for knob option '" << knobName
-				          << "'\n";
-				TraceEvent(SevWarnAlways, "InvalidKnobValue")
+				std::cerr << "ERROR: Invalid value '" << knobValueString << "' for knob option '" << knobName << "'\n";
+				TraceEvent(SevError, "InvalidKnobValue")
+				    .errorUnsuppressed(e)
 				    .detail("Knob", printable(knobName))
 				    .detail("Value", printable(knobValueString));
+				throw e;
 			} else if (e.code() == error_code_invalid_option) {
-				std::cerr << "WARNING: Invalid knob option '" << knobName << "'\n";
-				TraceEvent(SevWarnAlways, "InvalidKnobName")
+				std::cerr << "ERROR: Invalid knob option '" << knobName << "'\n";
+				TraceEvent(SevError, "InvalidKnobName")
+				    .errorUnsuppressed(e)
 				    .detail("Knob", printable(knobName))
 				    .detail("Value", printable(knobValueString));
+				throw e;
 			} else {
 				std::cerr << "ERROR: Failed to set knob option '" << knobName << "': " << e.what() << "\n";
 				TraceEvent(SevError, "FailedToSetKnob")

--- a/tests/argument_parsing/test_argument_parsing.py
+++ b/tests/argument_parsing/test_argument_parsing.py
@@ -45,8 +45,10 @@ def is_unknown_option(output):
 
 
 def is_unknown_knob(output):
-    return output.startswith("WARNING: Invalid knob option")
+    return output.startswith("ERROR: Invalid knob option")
 
+def is_invalid_knob_value(output):
+    return output.startswith("ERROR: Invalid value")
 
 def is_cli_usage(output):
     return output.startswith("FoundationDB CLI")
@@ -61,6 +63,7 @@ def test_fdbserver(build_dir):
     check(not is_unknown_option(run_command(command, ["--cluster_file", "foo"])))
 
     check(is_unknown_knob(run_command(command, ["--knob-fake-knob", "foo"])))
+    check(is_invalid_knob_value(run_command(command, ["--knob_commit_batches_mem_bytes_hard_limit", "4GiB"])))
 
     check(not is_unknown_knob(run_command(command, ["--knob-min-trace-severity", "5"])))
     check(not is_unknown_knob(run_command(command, ["--knob-min_trace_severity", "5"])))


### PR DESCRIPTION
…emit a warning.

FDB binaries currently emit a warning to stderr as well as the logs when they encounter command-line options for
* knobs which don't exist, and
* knob values which fail to parse. They then proceed as if the command-line argument had never been provided.

FDB servers are often managed by automation, and no one sees warnings in the logs or stderr unless they go looking for them. This means that a typo in the name of a knob will result in a server running without the knob setting its operator meant to set. Similarly, an attempt to specify a memory limit as a knob value using command suffixes, e.g. '4GiB', will also fail, but the server will proceed with the default value of that knob, contrary to the operator's intention.

I believe the safer option is to fail hard when we don't understand command-line arguments, rather than emit a warning and proceed. Running with unexpecetd knob values can lead to failures which are difficult to diagnose. Whereas failing immediately at program start is straightforward to remedy.

New behavior:
$ bin/fdbserver --knob_commit_batches_mem_bytes_hard_limit=4GiB
ERROR: Invalid value '4GiB' for knob option 'commit_batches_mem_bytes_hard_limit'
Error: Option set with an invalid value

Replace this text with your description here...

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
