### PR TITLE
Make a new memory arena for Tuple::clear [release-7.1]

### DIFF
--- a/fdbclient/Tuple.h
+++ b/fdbclient/Tuple.h
@@ -63,7 +63,9 @@ struct Tuple {
 	size_t size() const { return offsets.size(); }
 	void reserve(size_t cap) { offsets.reserve(cap); }
 	void clear() {
-		data.clear();
+		// Make a new Standalone to use different memory so that
+		// previously returned objects from pack() are valid.
+		data = Standalone<VectorRef<uint8_t>>();
 		offsets.clear();
 	}
 	// Return a Tuple encoded raw string.


### PR DESCRIPTION
Cherrypick #8191

To avoid potential problem of invalidating contents of previously returned from pack() calls.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
