### PR TITLE
Fix base64 decoder bug

### DIFF
--- a/contrib/libb64/cdecode.c
+++ b/contrib/libb64/cdecode.c
@@ -12,9 +12,9 @@ int base64_decode_value(int value_in) {
 		                            -1, -1, 0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15, 16, 17,
 		                            18, 19, 20, 21, 22, 23, 24, 25, -1, -1, -1, -1, -1, -1, 26, 27, 28, 29, 30, 31,
 		                            32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51 };
-	static const int decoding_size = sizeof(decoding);
+	static const int decoding_size = sizeof(decoding) / sizeof(decoding[0]);
 	value_in -= 43;
-	if (value_in < 0 || value_in > decoding_size)
+	if (value_in < 0 || value_in >= decoding_size)
 		return -1;
 	return decoding[value_in];
 }

--- a/contrib/libb64/cdecode.c
+++ b/contrib/libb64/cdecode.c
@@ -7,16 +7,16 @@ For details, see http://sourceforge.net/projects/libb64
 
 #include "libb64/cdecode.h"
 
-int base64_decode_value(char value_in) {
-	static const char decoding[] = { 62, -1, -1, -1, 63, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, -1, -1, -1, -2, -1,
-		                             -1, -1, 0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15, 16, 17,
-		                             18, 19, 20, 21, 22, 23, 24, 25, -1, -1, -1, -1, -1, -1, 26, 27, 28, 29, 30, 31,
-		                             32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51 };
-	static const char decoding_size = sizeof(decoding);
+int base64_decode_value(int value_in) {
+	static const int decoding[] = { 62, -1, -1, -1, 63, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, -1, -1, -1, -2, -1,
+		                            -1, -1, 0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15, 16, 17,
+		                            18, 19, 20, 21, 22, 23, 24, 25, -1, -1, -1, -1, -1, -1, 26, 27, 28, 29, 30, 31,
+		                            32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51 };
+	static const int decoding_size = sizeof(decoding);
 	value_in -= 43;
 	if (value_in < 0 || value_in > decoding_size)
 		return -1;
-	return decoding[(int)value_in];
+	return decoding[value_in];
 }
 
 void base64_init_decodestate(base64_decodestate* state_in) {
@@ -27,7 +27,7 @@ void base64_init_decodestate(base64_decodestate* state_in) {
 int base64_decode_block(const char* code_in, const int length_in, char* plaintext_out, base64_decodestate* state_in) {
 	const char* codechar = code_in;
 	char* plainchar = plaintext_out;
-	char fragment;
+	int fragment = 0;
 
 	*plainchar = state_in->plainchar;
 
@@ -40,9 +40,9 @@ int base64_decode_block(const char* code_in, const int length_in, char* plaintex
 					state_in->plainchar = *plainchar;
 					return plainchar - plaintext_out;
 				}
-				fragment = (char)base64_decode_value(*codechar++);
+				fragment = base64_decode_value(*codechar++);
 			} while (fragment < 0);
-			*plainchar = (fragment & 0x03f) << 2;
+			*plainchar = (char)((fragment & 0x03f) << 2);
 		case step_b:
 			do {
 				if (codechar == code_in + length_in) {
@@ -50,10 +50,10 @@ int base64_decode_block(const char* code_in, const int length_in, char* plaintex
 					state_in->plainchar = *plainchar;
 					return plainchar - plaintext_out;
 				}
-				fragment = (char)base64_decode_value(*codechar++);
+				fragment = base64_decode_value(*codechar++);
 			} while (fragment < 0);
-			*plainchar++ |= (fragment & 0x030) >> 4;
-			*plainchar = (fragment & 0x00f) << 4;
+			*plainchar++ |= (char)((fragment & 0x030) >> 4);
+			*plainchar = (char)((fragment & 0x00f) << 4);
 		case step_c:
 			do {
 				if (codechar == code_in + length_in) {
@@ -61,10 +61,10 @@ int base64_decode_block(const char* code_in, const int length_in, char* plaintex
 					state_in->plainchar = *plainchar;
 					return plainchar - plaintext_out;
 				}
-				fragment = (char)base64_decode_value(*codechar++);
+				fragment = base64_decode_value(*codechar++);
 			} while (fragment < 0);
-			*plainchar++ |= (fragment & 0x03c) >> 2;
-			*plainchar = (fragment & 0x003) << 6;
+			*plainchar++ |= (char)((fragment & 0x03c) >> 2);
+			*plainchar = (char)((fragment & 0x003) << 6);
 		case step_d:
 			do {
 				if (codechar == code_in + length_in) {
@@ -72,9 +72,9 @@ int base64_decode_block(const char* code_in, const int length_in, char* plaintex
 					state_in->plainchar = *plainchar;
 					return plainchar - plaintext_out;
 				}
-				fragment = (char)base64_decode_value(*codechar++);
+				fragment = base64_decode_value(*codechar++);
 			} while (fragment < 0);
-			*plainchar++ |= (fragment & 0x03f);
+			*plainchar++ |= (char)((fragment & 0x03f));
 		}
 	}
 	/* control should not reach here */

--- a/contrib/libb64/include/libb64/cdecode.h
+++ b/contrib/libb64/include/libb64/cdecode.h
@@ -17,7 +17,7 @@ typedef struct {
 
 void base64_init_decodestate(base64_decodestate* state_in);
 
-int base64_decode_value(char value_in);
+int base64_decode_value(int value_in);
 
 int base64_decode_block(const char* code_in, const int length_in, char* plaintext_out, base64_decodestate* state_in);
 

--- a/fdbclient/Tenant.cpp
+++ b/fdbclient/Tenant.cpp
@@ -23,6 +23,8 @@
 #include "fdbclient/Tenant.h"
 #include "fdbrpc/TenantInfo.h"
 #include "flow/BooleanParam.h"
+#include "flow/IRandom.h"
+#include "libb64/decode.h"
 #include "libb64/encode.h"
 #include "flow/ApiVersion.h"
 #include "flow/UnitTest.h"
@@ -184,6 +186,24 @@ TenantMetadataSpecification& TenantMetadata::instance() {
 Key TenantMetadata::tenantMapPrivatePrefix() {
 	static Key _prefix = "\xff"_sr.withSuffix(tenantMap().subspace.begin);
 	return _prefix;
+}
+
+TEST_CASE("/fdbclient/libb64/base64decoder") {
+	Standalone<StringRef> buf = makeString(100);
+	for (int i = 0; i < 1000; ++i) {
+		int length = deterministicRandom()->randomInt(0, 100);
+		deterministicRandom()->randomBytes(mutateString(buf), length);
+
+		StringRef str = buf.substr(0, length);
+		std::string encodedStr = base64::encoder::from_string(str.toString());
+		// Remove trailing newline
+		encodedStr.resize(encodedStr.size() - 1);
+
+		std::string decodedStr = base64::decoder::from_string(encodedStr);
+		ASSERT(decodedStr == str.toString());
+	}
+
+	return Void();
 }
 
 TEST_CASE("/fdbclient/TenantMapEntry/Serialization") {


### PR DESCRIPTION
The base64 decoder we use (libb64) was assuming that the char type is signed, which is not guaranteed to be the case. When it isn't, the decoder produced incorrect results.

This changes the arithmetic being done to use int types and only converts to char when putting the result into the output string.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
