### PR TITLE
Change the special key space correctness workload to hit code probe

### DIFF
--- a/fdbclient/SpecialKeySpace.actor.cpp
+++ b/fdbclient/SpecialKeySpace.actor.cpp
@@ -475,7 +475,7 @@ Future<RangeResult> SpecialKeySpace::getRange(ReadYourWritesTransaction* ryw,
 	if (!limits.isValid())
 		return range_limits_invalid();
 	if (limits.isReached()) {
-		CODE_PROBE(true, "read limit 0");
+		CODE_PROBE(true, "Special Key Space range read limit 0");
 		return RangeResult();
 	}
 	// make sure orEqual == false

--- a/fdbserver/workloads/SpecialKeySpaceCorrectness.actor.cpp
+++ b/fdbserver/workloads/SpecialKeySpaceCorrectness.actor.cpp
@@ -289,13 +289,17 @@ struct SpecialKeySpaceCorrectnessWorkload : TestWorkload {
 
 	GetRangeLimits randomLimits() {
 		// TODO : fix knobs for row_unlimited
-		int rowLimits = deterministicRandom()->randomInt(1, keysCount.getValue() + 1);
+		int rowLimits = deterministicRandom()->randomInt(0, keysCount.getValue() + 1);
 		// The largest key's bytes is longest prefix bytes + 1(for '/') + generated key bytes
 		// 8 here refers to bytes of KeyValueRef
 		int byteLimits = deterministicRandom()->randomInt(
 		    1, keysCount.getValue() * (keyBytes + (rangeCount + 1) + valBytes + 8) + 1);
 
-		return GetRangeLimits(rowLimits, byteLimits);
+		auto limit = GetRangeLimits(rowLimits, byteLimits);
+		// minRows is always initilized to 1
+		if (limit.rows == 0)
+			limit.minRows = 0;
+		return limit;
 	}
 
 	ACTOR Future<Void> testSpecialKeySpaceErrors(Database cx_, SpecialKeySpaceCorrectnessWorkload* self) {


### PR DESCRIPTION
Let the special key space correctness workload to generate limit=0
and hit the code probe in simulation tests.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
