### PR TITLE
ANSI C syntax mandates declare functions without parameters with void in parameters list. K&R syntax is obsolete.

### DIFF
--- a/bindings/c/foundationdb/fdb_c.h
+++ b/bindings/c/foundationdb/fdb_c.h
@@ -84,12 +84,12 @@ DLLEXPORT WARN_UNUSED_RESULT fdb_error_t fdb_network_set_option(FDBNetworkOption
                                                                 int value_length);
 
 #if FDB_API_VERSION >= 14
-DLLEXPORT WARN_UNUSED_RESULT fdb_error_t fdb_setup_network();
+DLLEXPORT WARN_UNUSED_RESULT fdb_error_t fdb_setup_network(void);
 #endif
 
-DLLEXPORT WARN_UNUSED_RESULT fdb_error_t fdb_run_network();
+DLLEXPORT WARN_UNUSED_RESULT fdb_error_t fdb_run_network(void);
 
-DLLEXPORT WARN_UNUSED_RESULT fdb_error_t fdb_stop_network();
+DLLEXPORT WARN_UNUSED_RESULT fdb_error_t fdb_stop_network(void);
 
 DLLEXPORT WARN_UNUSED_RESULT fdb_error_t fdb_add_network_thread_completion_hook(void (*hook)(void*),
                                                                                 void* hook_parameter);
@@ -548,8 +548,8 @@ DLLEXPORT WARN_UNUSED_RESULT FDBFuture* fdb_transaction_summarize_blob_granules(
 
 DLLEXPORT WARN_UNUSED_RESULT fdb_error_t fdb_select_api_version_impl(int runtime_version, int header_version);
 
-DLLEXPORT int fdb_get_max_api_version();
-DLLEXPORT const char* fdb_get_client_version();
+DLLEXPORT int fdb_get_max_api_version(void);
+DLLEXPORT const char* fdb_get_client_version(void);
 
 /* LEGACY API VERSIONS */
 


### PR DESCRIPTION
There was an [discussion](https://discourse.llvm.org/t/rfc-enabling-wstrict-prototypes-by-default-in-c/60521) in clang mailing list about -Wstrict-prototypes flag. In Clang 15 compiler flag -Wstrict-prototypes was [enable by default](https://releases.llvm.org/15.0.0/tools/clang/docs/DiagnosticsReference.html#wstrict-prototypes) so without these changes compiler will produce an error:
```
FAILED: bindings/c/CMakeFiles/fdb_c90_test.dir/test/fdb_c90_test.c.o 
/usr/local/bin/clang -DBOOST_ERROR_CODE_HEADER_ONLY -DBOOST_SYSTEM_NO_DEPRECATED -DNO_INTELLISENSE -Ibindings/c -I/home/src/foundationdb/bindings/c -Ibindings/c/foundationdb -O3 -DNDEBUG -DCMAKE_BUILD -ggdb -fno-omit-frame-pointer -mavx -Wall -Wextra -Wredundant-move -Wpessimizing-move -Woverloaded-virtual -Wshift-sign-overflow -Wno-sign-compare -Wno-undefined-var-template -Wno-unknown-warning-option -Wno-unused-parameter -Wno-constant-logical-operand -Wno-deprecated-copy -Wno-delete-non-abstract-non-virtual-dtor -Wno-range-loop-construct -Wno-reorder-ctor -Wno-unused-command-line-argument -Wno-error=format -Wunused-variable -Wno-deprecated -fvisibility=hidden -Wreturn-type -fPIC -DHAVE_OPENSSL -Wpedantic -Werror -std=gnu90 -MD -MT bindings/c/CMakeFiles/fdb_c90_test.dir/test/fdb_c90_test.c.o -MF bindings/c/CMakeFiles/fdb_c90_test.dir/test/fdb_c90_test.c.o.d -o bindings/c/CMakeFiles/fdb_c90_test.dir/test/fdb_c90_test.c.o -c /home/src/foundationdb/bindings/c/test/fdb_c90_test.c
In file included from /home/src/foundationdb/bindings/c/test/fdb_c90_test.c:2:
/home/src/foundationdb/bindings/c/foundationdb/fdb_c.h:87:59: error: a function declaration without a prototype is deprecated in all versions of C [-Werror,-Wstrict-prototypes]
DLLEXPORT WARN_UNUSED_RESULT fdb_error_t fdb_setup_network();
                                                          ^
                                                           void
/home/src/foundationdb/bindings/c/foundationdb/fdb_c.h:90:57: error: a function declaration without a prototype is deprecated in all versions of C [-Werror,-Wstrict-prototypes]
DLLEXPORT WARN_UNUSED_RESULT fdb_error_t fdb_run_network();
                                                        ^
                                                         void
/home/src/foundationdb/bindings/c/foundationdb/fdb_c.h:92:58: error: a function declaration without a prototype is deprecated in all versions of C [-Werror,-Wstrict-prototypes]
DLLEXPORT WARN_UNUSED_RESULT fdb_error_t fdb_stop_network();
                                                         ^
                                                          void
/home/src/foundationdb/bindings/c/foundationdb/fdb_c.h:551:38: error: a function declaration without a prototype is deprecated in all versions of C [-Werror,-Wstrict-prototypes]
DLLEXPORT int fdb_get_max_api_version();
                                     ^
                                      void
/home/src/foundationdb/bindings/c/foundationdb/fdb_c.h:552:45: error: a function declaration without a prototype is deprecated in all versions of C [-Werror,-Wstrict-prototypes]
DLLEXPORT const char* fdb_get_client_version();
                                            ^
                                             void
5 errors generated.
```

So lets follow to the current ANSI C syntax and use void in empty parameters lists for C bindings.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
