### PR TITLE
prevent int overflow

### DIFF
--- a/flow/include/flow/IRateControl.h
+++ b/flow/include/flow/IRateControl.h
@@ -58,7 +58,7 @@ public:
 			// prevent int overflow
 			m_budget = m_limit;
 		} else {
-			returnUnused(int(std::min(unused, double(m_limit))));
+			returnUnused(int(unused));
 		}
 		m_last_update = ts;
 		m_budget -= n;

--- a/flow/include/flow/IRateControl.h
+++ b/flow/include/flow/IRateControl.h
@@ -53,7 +53,13 @@ public:
 		// Replenish budget based on time since last update
 		double ts = now();
 		// returnUnused happens to do exactly what we want here
-		returnUnused((ts - m_last_update) / m_seconds * m_limit);
+		auto unused = double(m_limit) * (ts - m_last_update) / m_seconds;
+		if (unused >= double(std::numeric_limits<int>::max())) {
+			// prevent int overflow
+			m_budget = m_limit;
+		} else {
+			returnUnused(int(std::min(unused, double(m_limit))));
+		}
 		m_last_update = ts;
 		m_budget -= n;
 		// If budget is still >= 0 then it's safe to use the allowance right now.


### PR DESCRIPTION
UBSAN found a bug where this int could overflow (which is undefined behavior).

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
