### PR TITLE
Targeted blob granules fault injection

### DIFF
--- a/fdbrpc/include/fdbrpc/simulator.h
+++ b/fdbrpc/include/fdbrpc/simulator.h
@@ -496,6 +496,8 @@ public:
 	bool allowStorageMigrationTypeChange = false;
 	double injectTargetedSSRestartTime = std::numeric_limits<double>::max();
 	double injectSSDelayTime = std::numeric_limits<double>::max();
+	double injectTargetedBMRestartTime = std::numeric_limits<double>::max();
+	double injectTargetedBWRestartTime = std::numeric_limits<double>::max();
 
 	std::unordered_map<Standalone<StringRef>, PrivateKey> authKeys;
 

--- a/fdbserver/BlobManager.actor.cpp
+++ b/fdbserver/BlobManager.actor.cpp
@@ -484,6 +484,19 @@ struct BlobManagerData : NonCopyable, ReferenceCounted<BlobManagerData> {
 		}
 		return false;
 	}
+
+	bool maybeInjectTargetedRestart() {
+		// inject a BW restart at most once per test
+		if (g_network->isSimulated() && !g_simulator->speedUpSimulation &&
+		    now() > g_simulator->injectTargetedBMRestartTime) {
+			CODE_PROBE(true, "Injecting BM targeted restart");
+			TraceEvent("SimBMInjectTargetedRestart", id);
+			g_simulator->injectTargetedBMRestartTime = std::numeric_limits<double>::max();
+			iAmReplaced.send(Void());
+			return true;
+		}
+		return false;
+	}
 };
 
 // Helper function for alignKeys().
@@ -848,7 +861,18 @@ ACTOR Future<Void> doRangeAssignment(Reference<BlobManagerData> bmData,
 			if (bmData->workersById.count(workerID.get()) == 0) {
 				throw no_more_servers();
 			}
-			wait(bmData->workersById[workerID.get()].assignBlobRangeRequest.getReply(req));
+			state Future<Void> assignFuture = bmData->workersById[workerID.get()].assignBlobRangeRequest.getReply(req);
+
+			if (BUGGIFY) {
+				// wait for request to actually send
+				wait(delay(0));
+				if (bmData->maybeInjectTargetedRestart()) {
+					throw blob_manager_replaced();
+				}
+			}
+
+			wait(assignFuture);
+
 			if (assignment.previousFailure.present()) {
 				// previous assign failed and this one succeeded
 				--bmData->stats.blockedAssignments;
@@ -1215,6 +1239,10 @@ ACTOR Future<Void> writeInitialGranuleMapping(Reference<BlobManagerData> bmData,
 			}
 		}
 		i += j;
+	}
+	if (BUGGIFY && bmData->maybeInjectTargetedRestart()) {
+		wait(delay(0)); // should be cancelled
+		ASSERT(false);
 	}
 	return Void();
 }
@@ -1654,6 +1682,11 @@ ACTOR Future<Void> reevaluateInitialSplit(Reference<BlobManagerData> bmData,
 		}
 	}
 
+	if (BUGGIFY && bmData->maybeInjectTargetedRestart()) {
+		wait(delay(0)); // should be cancelled
+		ASSERT(false);
+	}
+
 	// transaction committed, send updated range assignments. Even if there is only one range still, we need to revoke
 	// it and re-assign it to cancel the old granule and retry
 	CODE_PROBE(true, "BM successfully changed initial split too big");
@@ -1941,6 +1974,11 @@ ACTOR Future<Void> maybeSplitRange(Reference<BlobManagerData> bmData,
 
 			wait(tr->commit());
 
+			if (BUGGIFY && bmData->maybeInjectTargetedRestart()) {
+				wait(delay(0)); // should be cancelled
+				ASSERT(false);
+			}
+
 			// Update BlobGranuleMergeBoundary in-memory state.
 			for (auto it = splitPoints.boundaries.begin(); it != splitPoints.boundaries.end(); it++) {
 				bmData->mergeBoundaries[it->first] = it->second;
@@ -2218,6 +2256,11 @@ ACTOR Future<std::pair<UID, Version>> persistMergeGranulesStart(Reference<BlobMa
 
 			wait(tr->commit());
 
+			if (BUGGIFY && bmData->maybeInjectTargetedRestart()) {
+				wait(delay(0)); // should be cancelled
+				ASSERT(false);
+			}
+
 			Version mergeVersion = tr->getCommittedVersion();
 			if (BM_DEBUG) {
 				fmt::print("Granule merge intent persisted [{0} - {1}): {2} @ {3}!\n",
@@ -2377,6 +2420,12 @@ ACTOR Future<bool> persistMergeGranulesDone(Reference<BlobManagerData> bmData,
 				           tr->getCommittedVersion());
 			}
 			CODE_PROBE(true, "Granule merge complete");
+
+			if (BUGGIFY && bmData->maybeInjectTargetedRestart()) {
+				wait(delay(0)); // should be cancelled
+				ASSERT(false);
+			}
+
 			return true;
 		} catch (Error& e) {
 			wait(tr->onError(e));
@@ -3672,6 +3721,10 @@ ACTOR Future<Void> recoverBlobManager(Reference<BlobManagerData> bmData) {
 		}
 	}
 
+	if (BUGGIFY && bmData->maybeInjectTargetedRestart()) {
+		throw blob_manager_replaced();
+	}
+
 	// Get set of workers again. Some could have died after reporting assignments
 	std::unordered_set<UID> endingWorkers;
 	for (auto& it : bmData->workersById) {
@@ -3759,6 +3812,10 @@ ACTOR Future<Void> recoverBlobManager(Reference<BlobManagerData> bmData) {
 
 	ASSERT(bmData->doneRecovering.canBeSet());
 	bmData->doneRecovering.send(Void());
+
+	if (BUGGIFY && bmData->maybeInjectTargetedRestart()) {
+		throw blob_manager_replaced();
+	}
 
 	return Void();
 }
@@ -4464,6 +4521,12 @@ ACTOR Future<Void> purgeRange(Reference<BlobManagerData> self, KeyRangeRef range
 				// instead cover whole of intersecting granules at begin/end
 				wait(krmSetRangeCoalescing(&tr, blobGranuleForcePurgedKeys.begin, range, normalKeys, "1"_sr));
 				wait(tr.commit());
+
+				if (BUGGIFY && self->maybeInjectTargetedRestart()) {
+					wait(delay(0)); // should be cancelled
+					ASSERT(false);
+				}
+
 				break;
 			} catch (Error& e) {
 				wait(tr.onError(e));
@@ -4760,6 +4823,10 @@ ACTOR Future<Void> purgeRange(Reference<BlobManagerData> self, KeyRangeRef range
 			fmt::print("BM {0}: About to fully delete granule {1}\n", self->epoch, granuleId.toString());
 		}
 		wait(fullyDeleteGranule(self, granuleId, historyKey, purgeVersion, keyRange, mergeChildId, force));
+		if (BUGGIFY && self->maybeInjectTargetedRestart()) {
+			wait(delay(0)); // should be cancelled
+			ASSERT(false);
+		}
 	}
 
 	if (BM_PURGE_DEBUG) {

--- a/fdbserver/BlobWorker.actor.cpp
+++ b/fdbserver/BlobWorker.actor.cpp
@@ -199,6 +199,7 @@ struct BlobWorkerData : NonCopyable, ReferenceCounted<BlobWorkerData> {
 	Promise<Void> doGRVCheck;
 	NotifiedVersion grvVersion;
 	Promise<Void> fatalError;
+	Promise<Void> simInjectFailure;
 
 	Reference<FlowLock> initialSnapshotLock;
 	Reference<FlowLock> resnapshotLock;
@@ -291,6 +292,19 @@ struct BlobWorkerData : NonCopyable, ReferenceCounted<BlobWorkerData> {
 		stats.estimatedMaxResidentMemory = stats.lastResidentMemory + totalExtra;
 
 		return stats.estimatedMaxResidentMemory >= memoryFullThreshold;
+	}
+
+	bool maybeInjectTargetedRestart() {
+		// inject a BW restart at most once per test
+		if (g_network->isSimulated() && !g_simulator->speedUpSimulation &&
+		    now() > g_simulator->injectTargetedBWRestartTime) {
+			CODE_PROBE(true, "Injecting BW targeted restart");
+			TraceEvent("SimBWInjectTargetedRestart", id);
+			g_simulator->injectTargetedBWRestartTime = std::numeric_limits<double>::max();
+			simInjectFailure.send(Void());
+			return true;
+		}
+		return false;
 	}
 };
 
@@ -780,6 +794,11 @@ ACTOR Future<BlobFileIndex> writeDeltaFile(Reference<BlobWorkerData> bwData,
 					    tr->getCommittedVersion());
 				}
 
+				if (BUGGIFY && bwData->maybeInjectTargetedRestart()) {
+					wait(delay(0)); // should be cancelled
+					ASSERT(false);
+				}
+
 				if (BUGGIFY_WITH_PROB(0.01)) {
 					wait(delay(deterministicRandom()->random01()));
 				}
@@ -1007,6 +1026,11 @@ ACTOR Future<BlobFileIndex> writeSnapshot(Reference<BlobWorkerData> bwData,
 		    .detail("Compressed", compressFilter.present());
 	}
 
+	if (BUGGIFY && bwData->maybeInjectTargetedRestart()) {
+		wait(delay(0)); // should be cancelled
+		ASSERT(false);
+	}
+
 	// FIXME: change when we implement multiplexing
 	return BlobFileIndex(version, fname, 0, serializedSize, serializedSize, cipherKeysMeta);
 }
@@ -1056,6 +1080,11 @@ ACTOR Future<BlobFileIndex> dumpInitialSnapshotFromFDB(Reference<BlobWorkerData>
 			    .detail("Granule", metadata->keyRange)
 			    .detail("Version", readVersion);
 			DEBUG_KEY_RANGE("BlobWorkerFDBSnapshot", readVersion, metadata->keyRange, bwData->id);
+
+			if (BUGGIFY && bwData->maybeInjectTargetedRestart()) {
+				wait(delay(0)); // should be cancelled
+				ASSERT(false);
+			}
 
 			// initial snapshot is committed in fdb, we can pop the change feed up to this version
 			inFlightPops->push_back(bwData->db->popChangeFeedMutations(cfKey, readVersion + 1));
@@ -1443,6 +1472,10 @@ ACTOR Future<Void> reevaluateInitialSplit(Reference<BlobWorkerData> bwData,
 			                         seqno);
 			reply.proposedSplitKey = proposedSplitKey;
 			bwData->currentManagerStatusStream.get().send(reply);
+			if (BUGGIFY && bwData->maybeInjectTargetedRestart()) {
+				wait(delay(0)); // should be cancelled
+				ASSERT(false);
+			}
 			// if a new manager appears, also tell it about this granule being splittable, or retry after a certain
 			// amount of time of not hearing back
 			wait(success(timeout(bwData->currentManagerStatusStream.onChange(), 10.0)));
@@ -4009,6 +4042,11 @@ ACTOR Future<GranuleStartState> openGranule(Reference<BlobWorkerData> bwData, As
 				openEv.detail("SplitParentGranuleID", info.splitParentGranule.get().second);
 			}
 
+			if (BUGGIFY && bwData->maybeInjectTargetedRestart()) {
+				wait(delay(0)); // should be cancelled
+				ASSERT(false);
+			}
+
 			return info;
 		} catch (Error& e) {
 			if (e.code() == error_code_granule_assignment_conflict) {
@@ -4951,7 +4989,7 @@ ACTOR Future<Void> blobWorker(BlobWorkerInterface bwInterf,
 				ASSERT(false);
 				throw internal_error();
 			}
-			when(wait(selfRemoved)) {
+			when(wait(selfRemoved || self->simInjectFailure.getFuture())) {
 				if (BW_DEBUG) {
 					printf("Blob worker detected removal. Exiting...\n");
 				}

--- a/fdbserver/SimulatedCluster.actor.cpp
+++ b/fdbserver/SimulatedCluster.actor.cpp
@@ -2452,6 +2452,14 @@ ACTOR void setupAndRun(std::string dataFolder,
 		g_simulator->injectSSDelayTime = 60.0 + 240.0 * deterministicRandom()->random01();
 	}
 
+	if (deterministicRandom()->random01() < 0.25) {
+		g_simulator->injectTargetedBMRestartTime = 60.0 + 340.0 * deterministicRandom()->random01();
+	}
+
+	if (deterministicRandom()->random01() < 0.25) {
+		g_simulator->injectTargetedBWRestartTime = 60.0 + 340.0 * deterministicRandom()->random01();
+	}
+
 	// Build simulator allow list
 	allowList.addTrustedSubnet("0.0.0.0/2"sv);
 	allowList.addTrustedSubnet("abcd::/16"sv);


### PR DESCRIPTION
Added targeted fault and chaos injection to blob granules to improve test coverage.
Passed 100k BlobGranule* correctness on main and 250k on snowflake/release-71.2, except for 1 unrelated failure.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
