### PR TITLE
Remove durable cluster ID write

### DIFF
--- a/fdbserver/TLogServer.actor.cpp
+++ b/fdbserver/TLogServer.actor.cpp
@@ -3593,9 +3593,9 @@ ACTOR Future<Void> tLog(IKeyValueStore* persistentData,
 			if (recovered.canBeSet())
 				recovered.send(Void());
 
-			if (!self.durableClusterId.isValid()) {
-				self.sharedActors.send(updateDurableClusterID(&self));
-			}
+			// if (!self.durableClusterId.isValid()) {
+			// 	self.sharedActors.send(updateDurableClusterID(&self));
+			// }
 			self.sharedActors.send(commitQueue(&self));
 			self.sharedActors.send(updateStorageLoop(&self));
 			self.sharedActors.send(traceRole(Role::SHARED_TRANSACTION_LOG, tlogId));


### PR DESCRIPTION
TLogs initially write persistent data in `initPersistentState`, called from `tLogStart`. This is important because `restorePersistentState` checks for the existence of `persistFormat.key`. If it doesn't exist, it is expected that no other persistent state exists (ie `persistFormat.key` should be the first thing written and saved). However, `updateDurableClusterID` was writing to persistent state before `initPersistentState` was called, triggering https://github.com/apple/foundationdb/blob/f471f3da04415f04fe7b89b06e0c1029f7da8316/fdbserver/TLogServer.actor.cpp#L3065 in some correctness runs.

This PR is a temporary fix for #8200 to fix failing correctness. We expect to re-enable data loss protection in the future.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
