### PR TITLE
Fix rare/CheckRelocation setup failure

### DIFF
--- a/fdbserver/include/fdbserver/workloads/BulkSetup.actor.h
+++ b/fdbserver/include/fdbserver/workloads/BulkSetup.actor.h
@@ -198,7 +198,8 @@ Future<Void> waitForLowInFlight(Database cx, T* workload) {
 				break;
 			}
 		} catch (Error& e) {
-			if (e.code() == error_code_attribute_not_found) {
+			if (e.code() == error_code_attribute_not_found ||
+			    (e.code() == error_code_timed_out && !timeout.isReady())) {
 				// DD may not be initialized yet and attribute "DataInFlight" can be missing
 				wait(delay(1.0));
 			} else {


### PR DESCRIPTION
To ignore timed_out error from `getDataInFlight()` calls.

Seed: `-f rare/CheckRelocation.toml -b on -s 614932376`
Commit: [982240c1c](https://github.com/apple/foundationdb/commit/982240c1c160443c24e27f778be2d5485ebde6e5)

10k CheckRelocation.toml tests passed. 20220921-034226-jzhou-35e2e3afdf61d81a

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
