### PR TITLE
Fix Python binding's fdb_c lookup

### DIFF
--- a/bindings/python/fdb/impl.py
+++ b/bindings/python/fdb/impl.py
@@ -1359,7 +1359,7 @@ else:
     except:
         # The system python on OS X can't find the library installed to /usr/local/lib if SIP is enabled
         # find_library does find the location in /usr/local/lib, so if the above fails fallback to using it
-        lib_path = ctypes.util.find_library(capi_name)
+        lib_path = ctypes.util.find_library("fdb_c")
         if lib_path is not None:
             try:
                 _capi = ctypes.CDLL(lib_path)


### PR DESCRIPTION
All python documentations indicate you shouldn't put prefixes like 'lib' or suffixes like '.so', '.dll', or '.dylib' in argument to ctypes.util.find_library(), unlike ctypes.CDLL() which demands an exact file name. I suppose this case hasn't been tested.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
