### PR TITLE
Fix `CompoundWorkload::check` method

### DIFF
--- a/fdbserver/tester.actor.cpp
+++ b/fdbserver/tester.actor.cpp
@@ -350,7 +350,7 @@ Future<bool> CompoundWorkload::check(Database const& cx) {
 			        .detail("Name", workloadName)
 			        .detail("Remaining", *wCount)
 			        .detail("Phase", "End");
-			    return true;
+			    return ret;
 		    },
 		    workload.check(cx));
 	};


### PR DESCRIPTION
Previously this method would always return `true`, regardless of the results of the component checks.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
