### PR TITLE
Fix rocks clang build

### DIFF
--- a/cmake/CompileRocksDB.cmake
+++ b/cmake/CompileRocksDB.cmake
@@ -4,6 +4,12 @@ find_package(RocksDB 6.27.3)
 
 include(ExternalProject)
 
+if (USE_LIBCXX AND NOT APPLE)
+  set(ROCKS_CMAKE_CXX_FLAGS "-stdlib=libc++")
+else()
+  set(ROCKS_CMAKE_CXX_FLAGS "")
+endif()
+
 if (RocksDB_FOUND)
   ExternalProject_Add(rocksdb
     SOURCE_DIR "${RocksDB_ROOT}"
@@ -11,6 +17,7 @@ if (RocksDB_FOUND)
     CMAKE_ARGS -DUSE_RTTI=1 -DPORTABLE=${PORTABLE_ROCKSDB}
                -DCMAKE_CXX_STANDARD=${CMAKE_CXX_STANDARD}
                -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+               -DCMAKE_CXX_FLAGS=${ROCKS_CMAKE_CXX_FLAGS}
                -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
                -DFAIL_ON_WARNINGS=OFF
                -DWITH_GFLAGS=OFF
@@ -43,6 +50,7 @@ else()
     CMAKE_ARGS -DUSE_RTTI=1 -DPORTABLE=${PORTABLE_ROCKSDB}
                -DCMAKE_CXX_STANDARD=${CMAKE_CXX_STANDARD}
                -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+               -DCMAKE_CXX_FLAGS=${ROCKS_CMAKE_CXX_FLAGS}
                -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
                -DFAIL_ON_WARNINGS=OFF
                -DWITH_GFLAGS=OFF

--- a/cmake/CompileRocksDB.cmake
+++ b/cmake/CompileRocksDB.cmake
@@ -10,6 +10,12 @@ else()
   set(ROCKS_CMAKE_CXX_FLAGS "")
 endif()
 
+# Note:  If you find yourself reading this because you can't link to
+# a RocksDB shared library, or are having trouble with an executable
+# from the RocksDB build, consider passing through CMAKE_EXE_LINKER_FLAGS
+# and/or CMAKE_SHARED_LINKER_FLAGS.  As of this writing, we don't use
+# those build targets for anything.
+
 if (RocksDB_FOUND)
   ExternalProject_Add(rocksdb
     SOURCE_DIR "${RocksDB_ROOT}"

--- a/cmake/ConfigureCompiler.cmake
+++ b/cmake/ConfigureCompiler.cmake
@@ -130,21 +130,18 @@ else()
   endif()
 
   # check linker flags.
-  if (USE_LD STREQUAL "DEFAULT")
-    # Note:  Setting USE_LD = LD means "don't touch the linker settings", so we
-    # set USE_LD=LD on MacOS regardless of whether the compiler is Clang.
-    if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND NOT APPLE)
-      set(USE_LD "LLD")
-    else()
-      set(USE_LD "LD")
-    endif()
-  else()
-    if ((NOT (USE_LD STREQUAL "LD")) AND (NOT (USE_LD STREQUAL "GOLD")) AND (NOT (USE_LD STREQUAL "LLD")) AND (NOT (USE_LD STREQUAL "BFD")))
-      message (FATAL_ERROR "USE_LD must be set to DEFAULT, LD, BFD, GOLD, or LLD!")
-    endif()
+  if ((NOT (USE_LD STREQUAL "DEFAULT")) AND (NOT (USE_LD STREQUAL "LD")) AND (NOT (USE_LD STREQUAL "GOLD")) AND (NOT (USE_LD STREQUAL "LLD")) AND (NOT (USE_LD STREQUAL "BFD")))
+    message (FATAL_ERROR "USE_LD must be set to DEFAULT, LD, BFD, GOLD, or LLD!")
   endif()
 
-  # if USE_LD=LD, then we don't do anything, defaulting to whatever system
+  if (USE_LD STREQUAL "LD" AND (APPLE OR WIN32))
+    message (FATAL_ERROR "USE_LD must not be set to LD under MacOS or Windows.  (Set it to DEFAULT to get the old behavior)")
+  endif()
+
+  # if USE_LD=LD then we assume we're on Linux or some other platform that
+  # defaults to LD, and pretend it was set to DEFAULT.
+
+  # if USE_LD=DEFAULT then we don't do anything, defaulting to whatever system
   # linker is available (e.g. binutils doesn't normally exist on macOS, so this
   # implies the default xcode linker, and other distros may choose others by
   # default).

--- a/cmake/ConfigureCompiler.cmake
+++ b/cmake/ConfigureCompiler.cmake
@@ -131,7 +131,13 @@ else()
 
   # check linker flags.
   if (USE_LD STREQUAL "DEFAULT")
-    set(USE_LD "LD")
+    # Note:  Setting USE_LD = LD means "don't touch the linker settings", so we
+    # set USE_LD=LD on MacOS regardless of whether the compiler is Clang.
+    if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND NOT APPLE)
+      set(USE_LD "LLD")
+    else()
+      set(USE_LD "LD")
+    endif()
   else()
     if ((NOT (USE_LD STREQUAL "LD")) AND (NOT (USE_LD STREQUAL "GOLD")) AND (NOT (USE_LD STREQUAL "LLD")) AND (NOT (USE_LD STREQUAL "BFD")))
       message (FATAL_ERROR "USE_LD must be set to DEFAULT, LD, BFD, GOLD, or LLD!")


### PR DESCRIPTION
I tested this in our developer environment with `cmk` and `ccmk` after removing the following environment variables (these environment variables are not set by default in the developer container, but were inadvertently being set by something else):
```
  - USE_VALGRIND=0
  - USE_VALGRIND_FOR_CTEST=0
  - USE_WERROR=0
  - USE_GPERFTOOLS=0
  - CXX=/opt/rh/devtoolset-8/root/usr/bin/g++
  - CC=/opt/rh/devtoolset-8/root/usr/bin/gcc
  - USE_LD=DEFAULT
  - USE_LIBCXX=0
  - # CXX=/usr/local/bin/clang++
  - # CC=/usr/local/bin/clang
  - # USE_LD=LLD
  - # USE_LIBCXX=1
```
# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
