### PR TITLE
Convert fdbcli tenant commands to a single command with subcommands

### DIFF
--- a/bindings/python/tests/fdbcli_tests.py
+++ b/bindings/python/tests/fdbcli_tests.py
@@ -593,38 +593,105 @@ def triggerddteaminfolog(logger):
     output = run_fdbcli_command('triggerddteaminfolog')
     assert output == 'Triggered team info logging in data distribution.'
 
+def setup_tenants(tenants):
+    command = '; '.join(['tenant create %s' % t for t in tenants])
+    run_fdbcli_command(command)
+
+def clear_database_and_tenants():
+    run_fdbcli_command('writemode on; option on SPECIAL_KEY_SPACE_ENABLE_WRITES; clearrange "" \\xff; clearrange \\xff\\xff/management/tenant/map/ \\xff\\xff/management/tenant/map0')
+
+def run_tenant_test(test_func):
+    test_func()
+    clear_database_and_tenants()
 
 @enable_logging()
-def tenants(logger):
-    output = run_fdbcli_command('listtenants')
-    assert output == 'The cluster has no tenants'
+def tenant_create(logger):
+    output1 = run_fdbcli_command('tenant create tenant')
+    assert output1 == 'The tenant `tenant\' has been created'
 
-    output = run_fdbcli_command('createtenant tenant')
-    assert output == 'The tenant `tenant\' has been created'
-
-    output = run_fdbcli_command('createtenant tenant2 tenant_group=tenant_group2')
+    output = run_fdbcli_command('tenant create tenant2 tenant_group=tenant_group2')
     assert output == 'The tenant `tenant2\' has been created'
 
-    output = run_fdbcli_command('listtenants')
+    output = run_fdbcli_command_and_get_error('tenant create tenant')
+    assert output == 'ERROR: A tenant with the given name already exists (2132)'
+
+@enable_logging()
+def tenant_delete(logger):
+    setup_tenants(['tenant', 'tenant2'])
+    run_fdbcli_command('writemode on; usetenant tenant2; set tenant_test value')
+
+    # delete a tenant while the fdbcli is using that tenant
+    process = subprocess.Popen(command_template[:-1], stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=fdbcli_env)
+    cmd_sequence = ['writemode on', 'usetenant tenant', 'tenant delete tenant', 'get tenant_test', 'defaulttenant', 'usetenant tenant']
+    output, error_output = process.communicate(input='\n'.join(cmd_sequence).encode())
+
+    lines = output.decode().strip().split('\n')[-6:]
+    error_lines = error_output.decode().strip().split('\n')[-2:]
+    assert lines[0] == 'Using tenant `tenant\''
+    assert lines[1] == 'The tenant `tenant\' has been deleted'
+    assert lines[2] == 'WARNING: the active tenant was deleted. Use the `usetenant\' or `defaulttenant\''
+    assert lines[3] == 'command to choose a new tenant.'
+    assert error_lines[0] == 'ERROR: Tenant does not exist (2131)'
+    assert lines[5] == 'Using the default tenant'
+    assert error_lines[1] == 'ERROR: Tenant `tenant\' does not exist'
+
+    # delete a non-empty tenant
+    process = subprocess.Popen(command_template[:-1], stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=fdbcli_env)
+    cmd_sequence = ['writemode on', 'tenant delete tenant2', 'usetenant tenant2', 'clear tenant_test', 'defaulttenant', 'tenant delete tenant2']
+    output, error_output = process.communicate(input='\n'.join(cmd_sequence).encode())
+
+    lines = output.decode().strip().split('\n')[-4:]
+    error_lines = error_output.decode().strip().split('\n')[-1:]
+    assert error_lines[0] == 'ERROR: Cannot delete a non-empty tenant (2133)'
+    assert lines[0] == 'Using tenant `tenant2\''
+    assert lines[1].startswith('Committed')
+    assert lines[2] == 'Using the default tenant'
+    assert lines[3] == 'The tenant `tenant2\' has been deleted'
+
+    # delete a non-existing tenant
+    output = run_fdbcli_command_and_get_error('tenant delete tenant')
+    assert output == 'ERROR: Tenant does not exist (2131)'
+
+@enable_logging()
+def tenant_list(logger):
+    output = run_fdbcli_command('tenant list')
+    assert output == 'The cluster has no tenants'
+
+    setup_tenants(['tenant', 'tenant2'])
+
+    output = run_fdbcli_command('tenant list')
     assert output == '1. tenant\n  2. tenant2'
 
-    output = run_fdbcli_command('listtenants a z 1')
+    output = run_fdbcli_command('tenant list a z 1')
     assert output == '1. tenant'
 
-    output = run_fdbcli_command('listtenants a tenant2')
+    output = run_fdbcli_command('tenant list a tenant2')
     assert output == '1. tenant'
 
-    output = run_fdbcli_command('listtenants tenant2 z')
+    output = run_fdbcli_command('tenant list tenant2 z')
     assert output == '1. tenant2'
 
-    output = run_fdbcli_command('gettenant tenant')
+    output = run_fdbcli_command('tenant list a b')
+    assert output == 'The cluster has no tenants in the specified range'
+
+    output = run_fdbcli_command_and_get_error('tenant list b a')
+    assert output == 'ERROR: end must be larger than begin'
+
+    output = run_fdbcli_command_and_get_error('tenant list a b 12x')
+    assert output == 'ERROR: invalid limit `12x\''
+
+@enable_logging()
+def tenant_get(logger):
+    setup_tenants(['tenant', 'tenant2 tenant_group=tenant_group2'])
+
+    output = run_fdbcli_command('tenant get tenant')
     lines = output.split('\n')
     assert len(lines) == 3
     assert lines[0].strip().startswith('id: ')
     assert lines[1].strip().startswith('prefix: ')
     assert lines[2].strip() == 'tenant state: ready'
 
-    output = run_fdbcli_command('gettenant tenant JSON')
+    output = run_fdbcli_command('tenant get tenant JSON')
     json_output = json.loads(output, strict=False)
     assert(len(json_output) == 2)
     assert('tenant' in json_output)
@@ -638,7 +705,7 @@ def tenants(logger):
     assert('printable' in json_output['tenant']['prefix'])
     assert(json_output['tenant']['tenant_state'] == 'ready')
 
-    output = run_fdbcli_command('gettenant tenant2')
+    output = run_fdbcli_command('tenant get tenant2')
     lines = output.split('\n')
     assert len(lines) == 4
     assert lines[0].strip().startswith('id: ')
@@ -646,7 +713,7 @@ def tenants(logger):
     assert lines[2].strip() == 'tenant state: ready'
     assert lines[3].strip() == 'tenant group: tenant_group2'
 
-    output = run_fdbcli_command('gettenant tenant2 JSON')
+    output = run_fdbcli_command('tenant get tenant2 JSON')
     json_output = json.loads(output, strict=False)
     assert(len(json_output) == 2)
     assert('tenant' in json_output)
@@ -661,35 +728,56 @@ def tenants(logger):
     assert('base64' in json_output['tenant']['tenant_group'])
     assert(json_output['tenant']['tenant_group']['printable'] == 'tenant_group2')
 
-    output = run_fdbcli_command('configuretenant tenant tenant_group=tenant_group1')
+@enable_logging()
+def tenant_configure(logger):
+    setup_tenants(['tenant'])
+
+    output = run_fdbcli_command('tenant configure tenant tenant_group=tenant_group1')
     assert output == 'The configuration for tenant `tenant\' has been updated'
 
-    output = run_fdbcli_command('gettenant tenant')
+    output = run_fdbcli_command('tenant get tenant')
     lines = output.split('\n')
     assert len(lines) == 4
     assert lines[3].strip() == 'tenant group: tenant_group1'
 
-    output = run_fdbcli_command('configuretenant tenant unset tenant_group')
+    output = run_fdbcli_command('tenant configure tenant unset tenant_group')
     assert output == 'The configuration for tenant `tenant\' has been updated'
 
-    output = run_fdbcli_command('gettenant tenant')
+    output = run_fdbcli_command('tenant get tenant')
     lines = output.split('\n')
     assert len(lines) == 3
 
-    output = run_fdbcli_command_and_get_error('configuretenant tenant tenant_group=tenant_group1 tenant_group=tenant_group2')
+    output = run_fdbcli_command_and_get_error('tenant configure tenant tenant_group=tenant_group1 tenant_group=tenant_group2')
     assert output == 'ERROR: configuration parameter `tenant_group\' specified more than once.'
 
-    output = run_fdbcli_command_and_get_error('configuretenant tenant unset')
+    output = run_fdbcli_command_and_get_error('tenant configure tenant unset')
     assert output == 'ERROR: `unset\' specified without a configuration parameter.'
 
-    output = run_fdbcli_command_and_get_error('configuretenant tenant unset tenant_group=tenant_group1')
+    output = run_fdbcli_command_and_get_error('tenant configure tenant unset tenant_group=tenant_group1')
     assert output == 'ERROR: unrecognized configuration parameter `tenant_group=tenant_group1\'.'
 
-    output = run_fdbcli_command_and_get_error('configuretenant tenant tenant_group')
+    output = run_fdbcli_command_and_get_error('tenant configure tenant tenant_group')
     assert output == 'ERROR: invalid configuration string `tenant_group\'. String must specify a value using `=\'.'
 
-    output = run_fdbcli_command_and_get_error('configuretenant tenant3 tenant_group=tenant_group1')
+    output = run_fdbcli_command_and_get_error('tenant configure tenant3 tenant_group=tenant_group1')
     assert output == 'ERROR: Tenant does not exist (2131)'
+
+@enable_logging()
+def tenant_rename(logger):
+    setup_tenants(['tenant', 'tenant2'])
+
+    output = run_fdbcli_command('tenant rename tenant tenant3')
+    assert output == 'The tenant `tenant\' has been renamed to `tenant3\''
+
+    output = run_fdbcli_command_and_get_error('tenant rename tenant tenant4')
+    assert output == 'ERROR: Tenant does not exist (2131)'
+
+    output = run_fdbcli_command_and_get_error('tenant rename tenant2 tenant3')
+    assert output == 'ERROR: A tenant with the given name already exists (2132)'
+
+@enable_logging()
+def tenant_usetenant(logger):
+    setup_tenants(['tenant', 'tenant2'])
 
     output = run_fdbcli_command('usetenant')
     assert output == 'Using the default tenant'
@@ -722,44 +810,50 @@ def tenants(logger):
     assert lines[3] == '`tenant_test\' is `tenant2\''
 
     process = subprocess.Popen(command_template[:-1], stdin=subprocess.PIPE, stdout=subprocess.PIPE, env=fdbcli_env)
-    cmd_sequence = ['usetenant tenant', 'get tenant_test', 'defaulttenant', 'get tenant_test']
+    cmd_sequence = ['usetenant tenant', 'get tenant_test', 'usetenant tenant2', 'get tenant_test', 'defaulttenant', 'get tenant_test']
     output, _ = process.communicate(input='\n'.join(cmd_sequence).encode())
 
-    lines = output.decode().strip().split('\n')[-4:]
+    lines = output.decode().strip().split('\n')[-6:]
     assert lines[0] == 'Using tenant `tenant\''
     assert lines[1] == '`tenant_test\' is `tenant\''
-    assert lines[2] == 'Using the default tenant'
-    assert lines[3] == '`tenant_test\' is `default_tenant\''
+    assert lines[2] == 'Using tenant `tenant2\''
+    assert lines[3] == '`tenant_test\' is `tenant2\''
+    assert lines[4] == 'Using the default tenant'
+    assert lines[5] == '`tenant_test\' is `default_tenant\''
 
-    process = subprocess.Popen(command_template[:-1], stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=fdbcli_env)
-    cmd_sequence = ['writemode on', 'usetenant tenant', 'clear tenant_test',
-                    'deletetenant tenant', 'get tenant_test', 'defaulttenant', 'usetenant tenant']
-    output, error_output = process.communicate(input='\n'.join(cmd_sequence).encode())
+@enable_logging()
+def tenant_old_commands(logger):
+    create_output = run_fdbcli_command('tenant create tenant')
+    list_output = run_fdbcli_command('tenant list')
+    get_output = run_fdbcli_command('tenant get tenant')
+    # Run the gettenant command here because the ID will be different in the second block
+    get_output_old = run_fdbcli_command('gettenant tenant')
+    configure_output = run_fdbcli_command('tenant configure tenant tenant_group=tenant_group1')
+    rename_output = run_fdbcli_command('tenant rename tenant tenant2')
+    delete_output = run_fdbcli_command('tenant delete tenant2')
 
-    lines = output.decode().strip().split('\n')[-7:]
-    error_lines = error_output.decode().strip().split('\n')[-2:]
-    assert lines[0] == 'Using tenant `tenant\''
-    assert lines[1].startswith('Committed')
-    assert lines[2] == 'The tenant `tenant\' has been deleted'
-    assert lines[3] == 'WARNING: the active tenant was deleted. Use the `usetenant\' or `defaulttenant\''
-    assert lines[4] == 'command to choose a new tenant.'
-    assert error_lines[0] == 'ERROR: Tenant does not exist (2131)'
-    assert lines[6] == 'Using the default tenant'
-    assert error_lines[1] == 'ERROR: Tenant `tenant\' does not exist'
+    create_output_old = run_fdbcli_command('createtenant tenant')
+    list_output_old = run_fdbcli_command('listtenants')
+    configure_output_old = run_fdbcli_command('configuretenant tenant tenant_group=tenant_group1')
+    rename_output_old = run_fdbcli_command('renametenant tenant tenant2')
+    delete_output_old = run_fdbcli_command('deletetenant tenant2')
 
-    process = subprocess.Popen(command_template[:-1], stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=fdbcli_env)
-    cmd_sequence = ['writemode on', 'deletetenant tenant2', 'usetenant tenant2', 'clear tenant_test', 'defaulttenant', 'deletetenant tenant2']
-    output, error_output = process.communicate(input='\n'.join(cmd_sequence).encode())
+    assert create_output == create_output_old
+    assert list_output == list_output_old
+    assert get_output == get_output_old
+    assert configure_output == configure_output_old
+    assert rename_output == rename_output_old
+    assert delete_output == delete_output_old
 
-    lines = output.decode().strip().split('\n')[-4:]
-    error_lines = error_output.decode().strip().split('\n')[-1:]
-    assert error_lines[0] == 'ERROR: Cannot delete a non-empty tenant (2133)'
-    assert lines[0] == 'Using tenant `tenant2\''
-    assert lines[1].startswith('Committed')
-    assert lines[2] == 'Using the default tenant'
-    assert lines[3] == 'The tenant `tenant2\' has been deleted'
-
-    run_fdbcli_command('writemode on; clear tenant_test')
+def tenants():
+    run_tenant_test(tenant_create)
+    run_tenant_test(tenant_delete)
+    run_tenant_test(tenant_list)
+    run_tenant_test(tenant_get)
+    run_tenant_test(tenant_configure)
+    run_tenant_test(tenant_rename)
+    run_tenant_test(tenant_usetenant)
+    run_tenant_test(tenant_old_commands)
 
 def integer_options():
     process = subprocess.Popen(command_template[:-1], stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=fdbcli_env)

--- a/documentation/sphinx/source/command-line-interface.rst
+++ b/documentation/sphinx/source/command-line-interface.rst
@@ -153,26 +153,12 @@ If ``description=<DESC>`` is specified, the description field in the cluster fil
 
 For more information on setting the cluster description, see :ref:`configuration-setting-cluster-description`.
 
-createtenant
-------------
-
-The ``createtenant`` command is used to create new tenants in the cluster. Its syntax is ``createtenant <TENANT_NAME>``.
-
-The tenant name can be any byte string that does not begin with the ``\xff`` byte. If the tenant already exists, ``fdbcli`` will report an error.
-
 defaulttenant
 -------------
 
 The ``defaulttenant`` command configures ``fdbcli`` to run its commands without a tenant. This is the default behavior.
 
 The active tenant cannot be changed while a transaction (using ``begin``) is open.
-
-deletetenant
-------------
-
-The ``deletetenant`` command is used to delete tenants from the cluster. Its syntax is ``deletetenant <TENANT_NAME>``.
-
-In order to delete a tenant, it must be empty. To delete a tenant with data, first clear that data using the ``clear`` command. If the tenant does not exist, ``fdbcli`` will report an error.
 
 exclude
 -------
@@ -231,33 +217,8 @@ The ``getrangekeys`` command fetches keys in a range. Its syntax is ``getrangeke
 
 Note that :ref:`characters can be escaped <cli-escaping>` when specifying keys (or values) in ``fdbcli``.
 
-gettenant
----------
-
-The ``gettenant`` command fetches metadata for a given tenant and displays it. Its syntax is ``gettenant <TENANT_NAME> [JSON]``.
-
-Included in the output of this command are the ``id`` and ``prefix`` assigned to the tenant. If the tenant does not exist, ``fdbcli`` will report an error. If ``JSON`` is specified, then the output will be written as a JSON document::
-
-    {
-        "tenant": {
-            "id": 0,
-            "prefix": {
-              "base64": "AAAAAAAAAAU=",
-              "printable": "\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x05",
-            }
-        },
-        "type": "success"
-    }
-
-In the event of an error, the output will include an error message::
-
-    {
-        "error": "...",
-        "type": "error"
-    }
-
-    getversion
-    ----------
+getversion
+----------
 
 The ``getversion`` command fetches the current read version of the cluster or currently running transaction.
 
@@ -346,13 +307,6 @@ Attempts to kill all specified processes. Each address should include the IP and
 
 Attempts to kill all known processes in the cluster.
 
-listtenants
------------
-
-The ``listtenants`` command prints the names of tenants in the cluster. Its syntax is ``listtenants [BEGIN] [END] [LIMIT]``.
-
-By default, the ``listtenants`` command will print up to 100 entries from the entire range of tenants. A narrower sub-range can be printed using the optional ``[BEGIN]`` and ``[END]`` parameters, and the limit can be changed by specifying an integer ``[LIMIT]`` parameter.
-
 lock
 ----
 
@@ -417,13 +371,6 @@ heap
 
 Enables heap profiling for the specified process.
 
-renametenant
-------------
-
-The ``renametenant`` command can rename an existing tenant to a new name. Its syntax is ``renametenant <OLD_NAME> <NEW_NAME>``.
-
-This command requires that ``OLD_NAME`` is a tenant that already exists on the cluster, and that ``NEW_NAME`` is not already a name of a tenant in the cluster.
-
 reset
 -----
 
@@ -483,6 +430,97 @@ status json
 ``status json`` will provide the cluster status in its JSON format. For a detailed description of this format, see :doc:`mr-status`.
 
 .. _cli-throttle:
+
+tenant
+------
+
+The ``tenant`` command is used to view and manage the tenants in a cluster. The ``tenant`` command has the following subcommands:
+
+create
+^^^^^^
+
+``tenant create <NAME> [tenant_group=<TENANT_GROUP>]``
+
+Creates a new tenant in the cluster.
+
+``NAME`` - The desired name of the tenant. The name can be any byte string that does not begin with the ``\xff`` byte. 
+
+``TENANT_GROUP`` - The tenant group the tenant will be placed in.
+
+delete
+^^^^^^
+
+``tenant delete <NAME>``
+
+Deletes a tenant from the cluster. The tenant must be empty.
+
+``NAME`` - the name of the tenant to delete.
+
+list
+^^^^
+
+``tenant list [BEGIN] [END] [LIMIT]``
+
+Lists the tenants present in the cluster.
+
+``BEGIN`` - the first tenant to list. Defaults to the empty tenant name ``""``.
+
+``END`` - the exclusive end tenant to list. Defaults to ``\xff\xff``.
+
+``LIMIT`` - the number of tenants to list. Defaults to 100.
+
+get
+^^^
+
+``tenant get <NAME> [JSON]``
+
+Prints the metadata for a tenant.
+
+``NAME`` - the name of the tenant to print.
+
+``JSON`` - if specified, the output of the command will be printed in the form of a JSON string::
+
+    {
+        "tenant": {
+            "id": 0,
+            "prefix": {
+              "base64": "AAAAAAAAAAU=",
+              "printable": "\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x05",
+            }
+        },
+        "type": "success"
+    }
+
+In the event of an error, the JSON output will include an error message::
+
+    {
+        "error": "...",
+        "type": "error"
+    }
+
+configure
+^^^^^^^^^
+
+``tenant configure <TENANT_NAME> <[unset] tenant_group[=GROUP_NAME]>``
+
+Changes the configuration of a tenant.
+
+``TENANT_NAME`` - the name of the tenant to reconfigure.
+
+The following tenant fields can be configured:
+
+``tenant_group`` - changes the tenant group a tenant is assigned to. If ``unset`` is specified, the tenant will be configured to not be in a group. Otherwise, ``GROUP_NAME`` must be specified to the new group that the tenant should be made a member of.
+
+rename
+^^^^^^
+
+``tenant rename <OLD_NAME> <NEW_NAME>``
+
+Changes the name of an existing tenant.
+
+``OLD_NAME`` - the name of the tenant being renamed.
+
+``NEW_NAME`` - the desired name of the tenant. This name must not already be in use.
 
 throttle
 --------

--- a/fdbcli/TenantCommands.actor.cpp
+++ b/fdbcli/TenantCommands.actor.cpp
@@ -101,19 +101,22 @@ void applyConfigurationToSpecialKeys(Reference<ITransaction> tr,
 	}
 }
 
-// createtenant command
-ACTOR Future<bool> createTenantCommandActor(Reference<IDatabase> db, std::vector<StringRef> tokens) {
-	if (tokens.size() < 2 || tokens.size() > 3) {
-		printUsage(tokens[0]);
+// tenant create command
+ACTOR Future<bool> tenantCreateCommand(Reference<IDatabase> db, std::vector<StringRef> tokens) {
+	if (tokens.size() < 3 || tokens.size() > 4) {
+		fmt::print("Usage: tenant create <NAME> [tenant_group=<TENANT_GROUP>]\n\n");
+		fmt::print("Creates a new tenant in the cluster with the specified name.\n");
+		fmt::print("An optional group can be specified that will require this tenant\n");
+		fmt::print("to be placed on the same cluster as other tenants in the same group.\n");
 		return false;
 	}
 
-	state Key tenantNameKey = tenantMapSpecialKeyRange.begin.withSuffix(tokens[1]);
+	state Key tenantNameKey = tenantMapSpecialKeyRange.begin.withSuffix(tokens[2]);
 	state Reference<ITransaction> tr = db->createTransaction();
 	state bool doneExistenceCheck = false;
 
 	state Optional<std::map<Standalone<StringRef>, Optional<Value>>> configuration =
-	    parseTenantConfiguration(tokens, 2, false);
+	    parseTenantConfiguration(tokens, 3, false);
 
 	if (!configuration.present()) {
 		return false;
@@ -129,7 +132,7 @@ ACTOR Future<bool> createTenantCommandActor(Reference<IDatabase> db, std::vector
 				for (auto const& [name, value] : configuration.get()) {
 					tenantEntry.configure(name, value);
 				}
-				wait(MetaclusterAPI::createTenant(db, tokens[1], tenantEntry));
+				wait(MetaclusterAPI::createTenant(db, tokens[2], tenantEntry));
 			} else {
 				if (!doneExistenceCheck) {
 					// Hold the reference to the standalone's memory
@@ -142,7 +145,7 @@ ACTOR Future<bool> createTenantCommandActor(Reference<IDatabase> db, std::vector
 				}
 
 				tr->set(tenantNameKey, ValueRef());
-				applyConfigurationToSpecialKeys(tr, tokens[1], configuration.get());
+				applyConfigurationToSpecialKeys(tr, tokens[2], configuration.get());
 				wait(safeThreadFutureToFuture(tr->commit()));
 			}
 
@@ -158,25 +161,20 @@ ACTOR Future<bool> createTenantCommandActor(Reference<IDatabase> db, std::vector
 		}
 	}
 
-	fmt::print("The tenant `{}' has been created\n", printable(tokens[1]).c_str());
+	fmt::print("The tenant `{}' has been created\n", printable(tokens[2]).c_str());
 	return true;
 }
 
-CommandFactory createTenantFactory(
-    "createtenant",
-    CommandHelp("createtenant <TENANT_NAME> [tenant_group=<TENANT_GROUP>]",
-                "creates a new tenant in the cluster",
-                "Creates a new tenant in the cluster with the specified name. An optional group can be specified"
-                "that will require this tenant to be placed on the same cluster as other tenants in the same group."));
-
-// deletetenant command
-ACTOR Future<bool> deleteTenantCommandActor(Reference<IDatabase> db, std::vector<StringRef> tokens) {
-	if (tokens.size() != 2) {
-		printUsage(tokens[0]);
+// tenant delete command
+ACTOR Future<bool> tenantDeleteCommand(Reference<IDatabase> db, std::vector<StringRef> tokens) {
+	if (tokens.size() != 3) {
+		fmt::print("Usage: tenant delete <NAME>\n\n");
+		fmt::print("Deletes a tenant from the cluster.\n");
+		fmt::print("Deletion will be allowed only if the specified tenant contains no data.\n");
 		return false;
 	}
 
-	state Key tenantNameKey = tenantMapSpecialKeyRange.begin.withSuffix(tokens[1]);
+	state Key tenantNameKey = tenantMapSpecialKeyRange.begin.withSuffix(tokens[2]);
 	state Reference<ITransaction> tr = db->createTransaction();
 	state bool doneExistenceCheck = false;
 
@@ -186,7 +184,7 @@ ACTOR Future<bool> deleteTenantCommandActor(Reference<IDatabase> db, std::vector
 			tr->setOption(FDBTransactionOptions::READ_SYSTEM_KEYS);
 			state ClusterType clusterType = wait(TenantAPI::getClusterType(tr));
 			if (clusterType == ClusterType::METACLUSTER_MANAGEMENT) {
-				wait(MetaclusterAPI::deleteTenant(db, tokens[1]));
+				wait(MetaclusterAPI::deleteTenant(db, tokens[2]));
 			} else {
 				if (!doneExistenceCheck) {
 					// Hold the reference to the standalone's memory
@@ -214,21 +212,17 @@ ACTOR Future<bool> deleteTenantCommandActor(Reference<IDatabase> db, std::vector
 		}
 	}
 
-	fmt::print("The tenant `{}' has been deleted\n", printable(tokens[1]).c_str());
+	fmt::print("The tenant `{}' has been deleted\n", printable(tokens[2]).c_str());
 	return true;
 }
 
-CommandFactory deleteTenantFactory(
-    "deletetenant",
-    CommandHelp(
-        "deletetenant <TENANT_NAME>",
-        "deletes a tenant from the cluster",
-        "Deletes a tenant from the cluster. Deletion will be allowed only if the specified tenant contains no data."));
-
-// listtenants command
-ACTOR Future<bool> listTenantsCommandActor(Reference<IDatabase> db, std::vector<StringRef> tokens) {
-	if (tokens.size() > 4) {
-		printUsage(tokens[0]);
+// tenant list command
+ACTOR Future<bool> tenantListCommand(Reference<IDatabase> db, std::vector<StringRef> tokens) {
+	if (tokens.size() > 5) {
+		fmt::print("Usage: tenant list [BEGIN] [END] [LIMIT]\n\n");
+		fmt::print("Lists the tenants in a cluster.\n");
+		fmt::print("Only tenants in the range BEGIN - END will be printed.\n");
+		fmt::print("An optional LIMIT can be specified to limit the number of results (default 100).\n");
 		return false;
 	}
 
@@ -236,20 +230,20 @@ ACTOR Future<bool> listTenantsCommandActor(Reference<IDatabase> db, std::vector<
 	state StringRef endTenant = "\xff\xff"_sr;
 	state int limit = 100;
 
-	if (tokens.size() >= 2) {
-		beginTenant = tokens[1];
-	}
 	if (tokens.size() >= 3) {
-		endTenant = tokens[2];
+		beginTenant = tokens[2];
+	}
+	if (tokens.size() >= 4) {
+		endTenant = tokens[3];
 		if (endTenant <= beginTenant) {
 			fmt::print(stderr, "ERROR: end must be larger than begin");
 			return false;
 		}
 	}
-	if (tokens.size() == 4) {
+	if (tokens.size() == 5) {
 		int n = 0;
-		if (sscanf(tokens[3].toString().c_str(), "%d%n", &limit, &n) != 1 || n != tokens[3].size() || limit <= 0) {
-			fmt::print(stderr, "ERROR: invalid limit `{}'\n", tokens[3].toString().c_str());
+		if (sscanf(tokens[4].toString().c_str(), "%d%n", &limit, &n) != 1 || n != tokens[4].size() || limit <= 0) {
+			fmt::print(stderr, "ERROR: invalid limit `{}'\n", tokens[4].toString().c_str());
 			return false;
 		}
 	}
@@ -280,7 +274,7 @@ ACTOR Future<bool> listTenantsCommandActor(Reference<IDatabase> db, std::vector<
 			}
 
 			if (tenantNames.empty()) {
-				if (tokens.size() == 1) {
+				if (tokens.size() == 2) {
 					fmt::print("The cluster has no tenants\n");
 				} else {
 					fmt::print("The cluster has no tenants in the specified range\n");
@@ -305,22 +299,17 @@ ACTOR Future<bool> listTenantsCommandActor(Reference<IDatabase> db, std::vector<
 	}
 }
 
-CommandFactory listTenantsFactory(
-    "listtenants",
-    CommandHelp("listtenants [BEGIN] [END] [LIMIT]",
-                "print a list of tenants in the cluster",
-                "Print a list of tenants in the cluster. Only tenants in the range [BEGIN] - [END] will be printed. "
-                "The number of tenants to print can be specified using the [LIMIT] parameter, which defaults to 100."));
-
-// gettenant command
-ACTOR Future<bool> getTenantCommandActor(Reference<IDatabase> db, std::vector<StringRef> tokens) {
-	if (tokens.size() < 2 || tokens.size() > 3 || (tokens.size() == 3 && tokens[2] != "JSON"_sr)) {
-		printUsage(tokens[0]);
+// tenant get command
+ACTOR Future<bool> tenantGetCommand(Reference<IDatabase> db, std::vector<StringRef> tokens) {
+	if (tokens.size() < 3 || tokens.size() > 4 || (tokens.size() == 4 && tokens[3] != "JSON"_sr)) {
+		fmt::print("Usage: tenant get <NAME> [JSON]\n\n");
+		fmt::print("Prints metadata associated with the given tenant.\n");
+		fmt::print("If JSON is specified, then the output will be in JSON format.\n");
 		return false;
 	}
 
-	state bool useJson = tokens.size() == 3;
-	state Key tenantNameKey = tenantMapSpecialKeyRange.begin.withSuffix(tokens[1]);
+	state bool useJson = tokens.size() == 4;
+	state Key tenantNameKey = tenantMapSpecialKeyRange.begin.withSuffix(tokens[2]);
 	state Reference<ITransaction> tr = db->createTransaction();
 
 	loop {
@@ -329,7 +318,7 @@ ACTOR Future<bool> getTenantCommandActor(Reference<IDatabase> db, std::vector<St
 			state ClusterType clusterType = wait(TenantAPI::getClusterType(tr));
 			state std::string tenantJson;
 			if (clusterType == ClusterType::METACLUSTER_MANAGEMENT) {
-				TenantMapEntry entry = wait(MetaclusterAPI::getTenantTransaction(tr, tokens[1]));
+				TenantMapEntry entry = wait(MetaclusterAPI::getTenantTransaction(tr, tokens[2]));
 				tenantJson = entry.toJson();
 			} else {
 				// Hold the reference to the standalone's memory
@@ -409,21 +398,19 @@ ACTOR Future<bool> getTenantCommandActor(Reference<IDatabase> db, std::vector<St
 	}
 }
 
-CommandFactory getTenantFactory(
-    "gettenant",
-    CommandHelp("gettenant <TENANT_NAME> [JSON]",
-                "prints the metadata for a tenant",
-                "Prints the metadata for a tenant. If JSON is specified, then the output will be in JSON format."));
-
-// configuretenant command
-ACTOR Future<bool> configureTenantCommandActor(Reference<IDatabase> db, std::vector<StringRef> tokens) {
-	if (tokens.size() < 3) {
-		printUsage(tokens[0]);
+// tenant configure command
+ACTOR Future<bool> tenantConfigureCommand(Reference<IDatabase> db, std::vector<StringRef> tokens) {
+	if (tokens.size() < 4) {
+		fmt::print("Usage: tenant configure <TENANT_NAME> <[unset] tenant_group[=<GROUP_NAME>]> ...\n\n");
+		fmt::print("Updates the configuration for a tenant.\n");
+		fmt::print("Use `tenant_group=<GROUP_NAME>' to change the tenant group that a\n");
+		fmt::print("tenant is assigned to or `unset tenant_group' to remove a tenant from\n");
+		fmt::print("its tenant group.");
 		return false;
 	}
 
 	state Optional<std::map<Standalone<StringRef>, Optional<Value>>> configuration =
-	    parseTenantConfiguration(tokens, 2, true);
+	    parseTenantConfiguration(tokens, 3, true);
 
 	if (!configuration.present()) {
 		return false;
@@ -438,9 +425,9 @@ ACTOR Future<bool> configureTenantCommandActor(Reference<IDatabase> db, std::vec
 			ClusterType clusterType = wait(TenantAPI::getClusterType(tr));
 			if (clusterType == ClusterType::METACLUSTER_MANAGEMENT) {
 				TenantMapEntry tenantEntry;
-				wait(MetaclusterAPI::configureTenant(db, tokens[1], configuration.get()));
+				wait(MetaclusterAPI::configureTenant(db, tokens[2], configuration.get()));
 			} else {
-				applyConfigurationToSpecialKeys(tr, tokens[1], configuration.get());
+				applyConfigurationToSpecialKeys(tr, tokens[2], configuration.get());
 				wait(safeThreadFutureToFuture(tr->commit()));
 			}
 			break;
@@ -455,16 +442,9 @@ ACTOR Future<bool> configureTenantCommandActor(Reference<IDatabase> db, std::vec
 		}
 	}
 
-	fmt::print("The configuration for tenant `{}' has been updated\n", printable(tokens[1]).c_str());
+	fmt::print("The configuration for tenant `{}' has been updated\n", printable(tokens[2]).c_str());
 	return true;
 }
-
-CommandFactory configureTenantFactory(
-    "configuretenant",
-    CommandHelp("configuretenant <TENANT_NAME> <[unset] tenant_group[=<GROUP_NAME>]> ...",
-                "updates the configuration for a tenant",
-                "Updates the configuration for a tenant. Use `tenant_group=<GROUP_NAME>' to change the tenant group "
-                "that a tenant is assigned to or `unset tenant_group' to remove a tenant from its tenant group."));
 
 // Helper function to extract tenant ID from json metadata string
 int64_t getTenantId(Value metadata) {
@@ -476,16 +456,18 @@ int64_t getTenantId(Value metadata) {
 	return id;
 }
 
-// renametenant command
-ACTOR Future<bool> renameTenantCommandActor(Reference<IDatabase> db, std::vector<StringRef> tokens) {
-	if (tokens.size() != 3) {
-		printUsage(tokens[0]);
+// tenant rename command
+ACTOR Future<bool> tenantRenameCommand(Reference<IDatabase> db, std::vector<StringRef> tokens) {
+	if (tokens.size() != 4) {
+		fmt::print("Usage: tenant rename <OLD_NAME> <NEW_NAME>\n\n");
+		fmt::print("Renames a tenant in the cluster. The old name must exist and the new\n");
+		fmt::print("name must not exist in the cluster.\n");
 		return false;
 	}
 	state Reference<ITransaction> tr = db->createTransaction();
-	state Key tenantRenameKey = tenantRenameSpecialKeyRange.begin.withSuffix(tokens[1]);
-	state Key tenantOldNameKey = tenantMapSpecialKeyRange.begin.withSuffix(tokens[1]);
-	state Key tenantNewNameKey = tenantMapSpecialKeyRange.begin.withSuffix(tokens[2]);
+	state Key tenantRenameKey = tenantRenameSpecialKeyRange.begin.withSuffix(tokens[2]);
+	state Key tenantOldNameKey = tenantMapSpecialKeyRange.begin.withSuffix(tokens[2]);
+	state Key tenantNewNameKey = tenantMapSpecialKeyRange.begin.withSuffix(tokens[3]);
 	state bool firstTry = true;
 	state int64_t id = -1;
 	loop {
@@ -494,7 +476,7 @@ ACTOR Future<bool> renameTenantCommandActor(Reference<IDatabase> db, std::vector
 			tr->setOption(FDBTransactionOptions::READ_SYSTEM_KEYS);
 			state ClusterType clusterType = wait(TenantAPI::getClusterType(tr));
 			if (clusterType == ClusterType::METACLUSTER_MANAGEMENT) {
-				wait(MetaclusterAPI::renameTenant(db, tokens[1], tokens[2]));
+				wait(MetaclusterAPI::renameTenant(db, tokens[2], tokens[3]));
 			} else {
 				// Hold the reference to the standalone's memory
 				state ThreadFuture<Optional<Value>> oldEntryFuture = tr->get(tenantOldNameKey);
@@ -534,7 +516,7 @@ ACTOR Future<bool> renameTenantCommandActor(Reference<IDatabase> db, std::vector
 						throw tenant_not_found();
 					}
 				}
-				tr->set(tenantRenameKey, tokens[2]);
+				tr->set(tenantRenameKey, tokens[3]);
 				wait(safeThreadFutureToFuture(tr->commit()));
 			}
 			break;
@@ -550,14 +532,118 @@ ACTOR Future<bool> renameTenantCommandActor(Reference<IDatabase> db, std::vector
 	}
 
 	fmt::print(
-	    "The tenant `{}' has been renamed to `{}'\n", printable(tokens[1]).c_str(), printable(tokens[2]).c_str());
+	    "The tenant `{}' has been renamed to `{}'\n", printable(tokens[2]).c_str(), printable(tokens[3]).c_str());
 	return true;
 }
 
-CommandFactory renameTenantFactory(
-    "renametenant",
-    CommandHelp(
-        "renametenant <OLD_NAME> <NEW_NAME>",
-        "renames a tenant in the cluster",
-        "Renames a tenant in the cluster. The old name must exist and the new name must not exist in the cluster."));
+// tenant command
+Future<bool> tenantCommand(Reference<IDatabase> db, std::vector<StringRef> tokens) {
+	if (tokens.size() == 1) {
+		printUsage(tokens[0]);
+		return true;
+	} else if (tokencmp(tokens[1], "create")) {
+		return tenantCreateCommand(db, tokens);
+	} else if (tokencmp(tokens[1], "delete")) {
+		return tenantDeleteCommand(db, tokens);
+	} else if (tokencmp(tokens[1], "list")) {
+		return tenantListCommand(db, tokens);
+	} else if (tokencmp(tokens[1], "get")) {
+		return tenantGetCommand(db, tokens);
+	} else if (tokencmp(tokens[1], "configure")) {
+		return tenantConfigureCommand(db, tokens);
+	} else if (tokencmp(tokens[1], "rename")) {
+		return tenantRenameCommand(db, tokens);
+	} else {
+		printUsage(tokens[0]);
+		return true;
+	}
+}
+
+Future<bool> tenantCommandForwarder(Reference<IDatabase> db, std::vector<StringRef> tokens) {
+	ASSERT(!tokens.empty() && (tokens[0].endsWith("tenant"_sr) || tokens[0].endsWith("tenants"_sr)));
+	std::vector<StringRef> forwardedTokens = { "tenant"_sr,
+		                                       tokens[0].endsWith("tenant"_sr) ? tokens[0].removeSuffix("tenant"_sr)
+		                                                                       : tokens[0].removeSuffix("tenants"_sr) };
+	for (int i = 1; i < tokens.size(); ++i) {
+		forwardedTokens.push_back(tokens[i]);
+	}
+
+	return tenantCommand(db, forwardedTokens);
+} // namespace fdb_cli
+
+void tenantGenerator(const char* text,
+                     const char* line,
+                     std::vector<std::string>& lc,
+                     std::vector<StringRef> const& tokens) {
+	if (tokens.size() == 1) {
+		const char* opts[] = { "create", "delete", "list", "get", "configure", "rename", nullptr };
+		arrayGenerator(text, line, opts, lc);
+	} else if (tokens.size() == 3 && tokencmp(tokens[1], "create")) {
+		const char* opts[] = { "tenant_group=", nullptr };
+		arrayGenerator(text, line, opts, lc);
+	} else if (tokens.size() == 3 && tokencmp(tokens[1], "get")) {
+		const char* opts[] = { "JSON", nullptr };
+		arrayGenerator(text, line, opts, lc);
+	} else if (tokencmp(tokens[1], "configure")) {
+		if (tokens.size() == 3) {
+			const char* opts[] = { "tenant_group=", "unset", nullptr };
+			arrayGenerator(text, line, opts, lc);
+		} else if (tokens.size() == 4 && tokencmp(tokens[3], "unset")) {
+			const char* opts[] = { "tenant_group", nullptr };
+			arrayGenerator(text, line, opts, lc);
+		}
+	}
+}
+
+std::vector<const char*> tenantHintGenerator(std::vector<StringRef> const& tokens, bool inArgument) {
+	if (tokens.size() == 1) {
+		return { "<create|delete|list|get|configure|rename>", "[ARGS]" };
+	} else if (tokencmp(tokens[1], "create") && tokens.size() < 4) {
+		static std::vector<const char*> opts = { "<NAME> [tenant_group=<TENANT_GROUP>]" };
+		return std::vector<const char*>(opts.begin() + tokens.size() - 2, opts.end());
+	} else if (tokencmp(tokens[1], "delete") && tokens.size() < 3) {
+		static std::vector<const char*> opts = { "<NAME>" };
+		return std::vector<const char*>(opts.begin() + tokens.size() - 2, opts.end());
+	} else if (tokencmp(tokens[1], "list") && tokens.size() < 5) {
+		static std::vector<const char*> opts = { "[BEGIN]", "[END]", "[LIMIT]" };
+		return std::vector<const char*>(opts.begin() + tokens.size() - 2, opts.end());
+	} else if (tokencmp(tokens[1], "get") && tokens.size() < 4) {
+		static std::vector<const char*> opts = { "<NAME>", "[JSON]" };
+		return std::vector<const char*>(opts.begin() + tokens.size() - 2, opts.end());
+	} else if (tokencmp(tokens[1], "configure")) {
+		if (tokens.size() < 4) {
+			static std::vector<const char*> opts = { "<TENANT_NAME>", "<[unset] tenant_group[=<GROUP_NAME>]>" };
+			return std::vector<const char*>(opts.begin() + tokens.size() - 2, opts.end());
+		} else if (tokens.size() == 4 && tokencmp(tokens[3], "unset")) {
+			static std::vector<const char*> opts = { "<tenant_group[=<GROUP_NAME>]>" };
+			return std::vector<const char*>(opts.begin() + tokens.size() - 4, opts.end());
+		}
+		return {};
+	} else if (tokencmp(tokens[1], "rename") && tokens.size() < 4) {
+		static std::vector<const char*> opts = { "<OLD_NAME>", "<NEW_NAME>" };
+		return std::vector<const char*>(opts.begin() + tokens.size() - 2, opts.end());
+	} else {
+		return {};
+	}
+}
+
+CommandFactory tenantRegisterFactory("tenant",
+                                     CommandHelp("tenant <create|delete|list|get|configure|rename> [ARGS]",
+                                                 "view and manage tenants in a cluster or metacluster",
+                                                 "`create' and `delete' add and remove tenants from the cluster.\n"
+                                                 "`list' prints a list of tenants in the cluster.\n"
+                                                 "`get' prints the metadata for a particular tenant.\n"
+                                                 "`configure' modifies the configuration for a tenant.\n"
+                                                 "`rename' changes the name of a tenant.\n"),
+                                     &tenantGenerator,
+                                     &tenantHintGenerator);
+
+// Generate hidden commands for the old versions of the tenant commands
+CommandFactory createTenantFactory("createtenant");
+CommandFactory deleteTenantFactory("deletetenant");
+CommandFactory listTenantsFactory("listtenants");
+CommandFactory getTenantFactory("gettenant");
+CommandFactory configureTenantFactory("configuretenant");
+CommandFactory renameTenantFactory("renametenant");
+
 } // namespace fdb_cli

--- a/fdbcli/fdbcli.actor.cpp
+++ b/fdbcli/fdbcli.actor.cpp
@@ -1878,50 +1878,27 @@ ACTOR Future<int> cli(CLIOptions opt, LineNoise* plinenoise, Reference<ClusterCo
 					continue;
 				}
 
-				if (tokencmp(tokens[0], "createtenant")) {
-					bool _result = wait(makeInterruptable(createTenantCommandActor(db, tokens)));
-					if (!_result)
+				if (tokencmp(tokens[0], "tenant")) {
+					bool _result = wait(makeInterruptable(tenantCommand(db, tokens)));
+					if (!_result) {
 						is_error = true;
-					continue;
-				}
-
-				if (tokencmp(tokens[0], "deletetenant")) {
-					bool _result = wait(makeInterruptable(deleteTenantCommandActor(db, tokens)));
-					if (!_result)
-						is_error = true;
-					else if (tenantName.present() && tokens[1] == tenantName.get()) {
+					} else if (tokens.size() >= 3 && tenantName.present() && tokencmp(tokens[1], "delete") &&
+					           tokens[2] == tenantName.get()) {
 						printAtCol("WARNING: the active tenant was deleted. Use the `usetenant' or `defaulttenant' "
 						           "command to choose a new tenant.\n",
 						           80);
 					}
+
 					continue;
 				}
 
-				if (tokencmp(tokens[0], "listtenants")) {
-					bool _result = wait(makeInterruptable(listTenantsCommandActor(db, tokens)));
-					if (!_result)
+				if (tokencmp(tokens[0], "createtenant") || tokencmp(tokens[0], "deletetenant") ||
+				    tokencmp(tokens[0], "listtenants") || tokencmp(tokens[0], "gettenant") ||
+				    tokencmp(tokens[0], "configuretenant") || tokencmp(tokens[0], "renametenant")) {
+					bool _result = wait(makeInterruptable(tenantCommandForwarder(db, tokens)));
+					if (!_result) {
 						is_error = true;
-					continue;
-				}
-
-				if (tokencmp(tokens[0], "gettenant")) {
-					bool _result = wait(makeInterruptable(getTenantCommandActor(db, tokens)));
-					if (!_result)
-						is_error = true;
-					continue;
-				}
-
-				if (tokencmp(tokens[0], "configuretenant")) {
-					bool _result = wait(makeInterruptable(configureTenantCommandActor(db, tokens)));
-					if (!_result)
-						is_error = true;
-					continue;
-				}
-
-				if (tokencmp(tokens[0], "renametenant")) {
-					bool _result = wait(makeInterruptable(renameTenantCommandActor(db, tokens)));
-					if (!_result)
-						is_error = true;
+					}
 					continue;
 				}
 

--- a/fdbcli/include/fdbcli/fdbcli.actor.h
+++ b/fdbcli/include/fdbcli/fdbcli.actor.h
@@ -160,8 +160,6 @@ ACTOR Future<bool> configureCommandActor(Reference<IDatabase> db,
                                          std::vector<StringRef> tokens,
                                          LineNoise* linenoise,
                                          Future<Void> warn);
-// configuretenant command
-ACTOR Future<bool> configureTenantCommandActor(Reference<IDatabase> db, std::vector<StringRef> tokens);
 // consistency command
 ACTOR Future<bool> consistencyCheckCommandActor(Reference<ITransaction> tr,
                                                 std::vector<StringRef> tokens,
@@ -170,12 +168,8 @@ ACTOR Future<bool> consistencyCheckCommandActor(Reference<ITransaction> tr,
 ACTOR Future<bool> consistencyScanCommandActor(Database localDb, std::vector<StringRef> tokens);
 // coordinators command
 ACTOR Future<bool> coordinatorsCommandActor(Reference<IDatabase> db, std::vector<StringRef> tokens);
-// createtenant command
-ACTOR Future<bool> createTenantCommandActor(Reference<IDatabase> db, std::vector<StringRef> tokens);
 // datadistribution command
 ACTOR Future<bool> dataDistributionCommandActor(Reference<IDatabase> db, std::vector<StringRef> tokens);
-// deletetenant command
-ACTOR Future<bool> deleteTenantCommandActor(Reference<IDatabase> db, std::vector<StringRef> tokens);
 // exclude command
 ACTOR Future<bool> excludeCommandActor(Reference<IDatabase> db, std::vector<StringRef> tokens, Future<Void> warn);
 // expensive_data_check command
@@ -191,8 +185,6 @@ ACTOR Future<bool> fileConfigureCommandActor(Reference<IDatabase> db,
                                              bool force);
 // force_recovery_with_data_loss command
 ACTOR Future<bool> forceRecoveryWithDataLossCommandActor(Reference<IDatabase> db, std::vector<StringRef> tokens);
-// gettenant command
-ACTOR Future<bool> getTenantCommandActor(Reference<IDatabase> db, std::vector<StringRef> tokens);
 // include command
 ACTOR Future<bool> includeCommandActor(Reference<IDatabase> db, std::vector<StringRef> tokens);
 // kill command
@@ -200,8 +192,6 @@ ACTOR Future<bool> killCommandActor(Reference<IDatabase> db,
                                     Reference<ITransaction> tr,
                                     std::vector<StringRef> tokens,
                                     std::map<Key, std::pair<Value, ClientLeaderRegInterface>>* address_interface);
-// listtenants command
-ACTOR Future<bool> listTenantsCommandActor(Reference<IDatabase> db, std::vector<StringRef> tokens);
 // lock/unlock command
 ACTOR Future<bool> lockCommandActor(Reference<IDatabase> db, std::vector<StringRef> tokens);
 ACTOR Future<bool> unlockDatabaseActor(Reference<IDatabase> db, UID uid);
@@ -229,8 +219,6 @@ ACTOR Future<bool> profileCommandActor(Database db,
                                        Reference<ITransaction> tr,
                                        std::vector<StringRef> tokens,
                                        bool intrans);
-// renametenant command
-ACTOR Future<bool> renameTenantCommandActor(Reference<IDatabase> db, std::vector<StringRef> tokens);
 // quota command
 ACTOR Future<bool> quotaCommandActor(Reference<IDatabase> db, std::vector<StringRef> tokens);
 // setclass command
@@ -247,6 +235,10 @@ ACTOR Future<bool> suspendCommandActor(Reference<IDatabase> db,
                                        Reference<ITransaction> tr,
                                        std::vector<StringRef> tokens,
                                        std::map<Key, std::pair<Value, ClientLeaderRegInterface>>* address_interface);
+// tenant command
+Future<bool> tenantCommand(Reference<IDatabase> db, std::vector<StringRef> tokens);
+// tenant command compatibility layer
+Future<bool> tenantCommandForwarder(Reference<IDatabase> db, std::vector<StringRef> tokens);
 // throttle command
 ACTOR Future<bool> throttleCommandActor(Reference<IDatabase> db, std::vector<StringRef> tokens);
 // triggerteaminfolog command


### PR DESCRIPTION
For example, `createtenant` becomes `tenant create`.

This also updates the tenant fdbcli tests to be split into multiple functions.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
