### PR TITLE
Fixing sequential write optimization for blob granules

### DIFF
--- a/fdbserver/BlobWorker.actor.cpp
+++ b/fdbserver/BlobWorker.actor.cpp
@@ -2437,10 +2437,13 @@ ACTOR Future<Void> blobGranuleUpdateFiles(Reference<BlobWorkerData> bwData,
 					previousFuture = Future<BlobFileIndex>(BlobFileIndex());
 				}
 
+				// The last version included in the old change feed is startState.cfStartVersion - 1.
+				// So if the previous delta file did not include this version, and the new delta file does, the old
+				// change feed is considered complete.
 				Optional<std::pair<KeyRange, UID>> oldChangeFeedDataComplete;
 				if (startState.splitParentGranule.present() &&
-				    metadata->pendingDeltaVersion < startState.changeFeedStartVersion &&
-				    lastDeltaVersion >= startState.changeFeedStartVersion) {
+				    metadata->pendingDeltaVersion + 1 < startState.changeFeedStartVersion &&
+				    lastDeltaVersion + 1 >= startState.changeFeedStartVersion) {
 					oldChangeFeedDataComplete = startState.splitParentGranule.get();
 				}
 


### PR DESCRIPTION
Fixing off by one in refactor of original fix that broke original fix.

Passed 100k BlobGranule* correctness on snowflake/release-71.2, running 100k on main.
# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
