### PR TITLE
Fix purge at latest racing with other checking threads at the end of BlobGranuleVerify

### DIFF
--- a/fdbserver/workloads/BlobGranuleVerifier.actor.cpp
+++ b/fdbserver/workloads/BlobGranuleVerifier.actor.cpp
@@ -1218,7 +1218,7 @@ struct BlobGranuleVerifierWorkload : TestWorkload {
 	}
 
 	Future<bool> check(Database const& cx) override {
-		if (clientId == 0 || !doForcePurge) {
+		if (clientId == 0 || (!doForcePurge && !purgeAtLatest)) {
 			return _check(cx, this);
 		}
 		return true;


### PR DESCRIPTION
Passes 10k BlobGranuleVerify* correctness

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
