### PR TITLE
Limit BUILD_AWS_BACKUP to x86_64 for now

### DIFF
--- a/cmake/FDBComponents.cmake
+++ b/cmake/FDBComponents.cmake
@@ -232,7 +232,12 @@ set(COROUTINE_IMPL ${DEFAULT_COROUTINE_IMPL} CACHE STRING "Which coroutine imple
 
 set(BUILD_AWS_BACKUP OFF CACHE BOOL "Build AWS S3 SDK backup client")
 if (BUILD_AWS_BACKUP)
-  set(WITH_AWS_BACKUP ON)
+  if (CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
+    set(WITH_AWS_BACKUP ON)
+  else()
+    message(WARNING "BUILD_AWS_BACKUP set but ignored ${CMAKE_SYSTEM_PROCESSOR} is not supported yet")
+    set(WITH_AWS_BACKUP OFF)
+  endif()
 else()
   set(WITH_AWS_BACKUP OFF)
 endif()


### PR DESCRIPTION
With aarch64, in the current docker image, linking curl statically doesn't work yet.

This is the diagnostic:

```
fdbclient/awssdk-build/curl/lib/strerror.c:32:6: error: #error "strerror_r MUST be either POSIX, glibc or vxworks-style"
2022-09-22 16:05:30   #    error "strerror_r MUST be either POSIX, glibc or vxworks-style"
2022-09-22 16:05:30        ^~~~~
```

The root cause is that curl's cmake feature detection logic gets
confused since it can't build binaries that execute successfully with
the link flags it wants:

```
$ cc test.c -lssl
$ ./a.out
./a.out: error while loading shared libraries: libssl.so.1.1: cannot open shared object file: No such file or directory
```

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
