### PR TITLE
Change some instances of `metacluster_no_capacity` to `cluster_no_capacity`

### DIFF
--- a/fdbclient/include/fdbclient/MetaclusterManagement.actor.h
+++ b/fdbclient/include/fdbclient/MetaclusterManagement.actor.h
@@ -1577,7 +1577,7 @@ struct ConfigureTenantImpl {
 		// Removing a tenant group is only possible if we have capacity for more groups on the current cluster
 		else if (!desiredGroup.present()) {
 			if (!self->ctx.dataClusterMetadata.get().entry.hasCapacity()) {
-				throw metacluster_no_capacity();
+				throw cluster_no_capacity();
 			}
 
 			wait(managementClusterRemoveTenantFromGroup(
@@ -1593,7 +1593,7 @@ struct ConfigureTenantImpl {
 		// If we are creating a new tenant group, we need to have capacity on the current cluster
 		if (!tenantGroupEntry.present()) {
 			if (!self->ctx.dataClusterMetadata.get().entry.hasCapacity()) {
-				throw metacluster_no_capacity();
+				throw cluster_no_capacity();
 			}
 			wait(managementClusterRemoveTenantFromGroup(
 			    tr, self->tenantName, tenantEntry, &self->ctx.dataClusterMetadata.get()));


### PR DESCRIPTION
When changing a tenant group in a cluster, the command can fail because the individual cluster has no extra capacity. If this happens, throw the `cluster_no_capacity` error.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
