### PR TITLE
Port fixes to split-failure-injection-workloads

### DIFF
--- a/fdbserver/include/fdbserver/workloads/workloads.actor.h
+++ b/fdbserver/include/fdbserver/workloads/workloads.actor.h
@@ -101,8 +101,8 @@ struct NoOptions {};
 struct FailureInjectionWorkload : TestWorkload {
 	FailureInjectionWorkload(WorkloadContext const&);
 	virtual ~FailureInjectionWorkload() {}
-	virtual bool add(DeterministicRandom& random, WorkloadRequest const& work, CompoundWorkload const& workload);
-	virtual void initFailureInjectionMode(DeterministicRandom& random, unsigned count);
+	virtual void initFailureInjectionMode(DeterministicRandom& random);
+	virtual bool shouldInject(DeterministicRandom& random, const WorkloadRequest& work, const unsigned count) const;
 
 	Future<Void> setupInjectionWorkload(Database const& cx, Future<Void> done);
 	Future<Void> startInjectionWorkload(Database const& cx, Future<Void> done);
@@ -137,6 +137,9 @@ struct CompoundWorkload : TestWorkload {
 	CompoundWorkload(WorkloadContext& wcx);
 	CompoundWorkload* add(Reference<TestWorkload>&& w);
 	void addFailureInjection(WorkloadRequest& work);
+	bool shouldInjectFailure(DeterministicRandom& random,
+	                         const WorkloadRequest& work,
+	                         Reference<FailureInjectionWorkload> failureInjection) const;
 
 	std::string description() const override;
 

--- a/fdbserver/workloads/DataLossRecovery.actor.cpp
+++ b/fdbserver/workloads/DataLossRecovery.actor.cpp
@@ -63,6 +63,8 @@ struct DataLossRecoveryWorkload : TestWorkload {
 
 	Future<Void> setup(Database const& cx) override { return Void(); }
 
+	void disableFailureInjectionWorkloads(std::set<std::string>& out) const override { out.insert("MoveKeysWorkload"); }
+
 	Future<Void> start(Database const& cx) override {
 		if (!enabled) {
 			return Void();

--- a/fdbserver/workloads/DiskFailureInjection.actor.cpp
+++ b/fdbserver/workloads/DiskFailureInjection.actor.cpp
@@ -66,7 +66,7 @@ struct DiskFailureInjectionWorkload : FailureInjectionWorkload {
 		periodicBroadcastInterval = getOption(options, "periodicBroadcastInterval"_sr, periodicBroadcastInterval);
 	}
 
-	void initFailureInjectionMode(DeterministicRandom& random, unsigned count) override { enabled = clientId == 0; }
+	void initFailureInjectionMode(DeterministicRandom& random) override { enabled = clientId == 0; }
 
 	std::string description() const override {
 		if (g_simulator == g_network)

--- a/fdbserver/workloads/PhysicalShardMove.actor.cpp
+++ b/fdbserver/workloads/PhysicalShardMove.actor.cpp
@@ -70,6 +70,8 @@ struct PhysicalShardMoveWorkLoad : TestWorkload {
 		return _start(this, cx);
 	}
 
+	void disableFailureInjectionWorkloads(std::set<std::string>& out) const override { out.insert("MoveKeysWorkload"); }
+
 	ACTOR Future<Void> _start(PhysicalShardMoveWorkLoad* self, Database cx) {
 		int ignore = wait(setDDMode(cx, 0));
 		state std::map<Key, Value> kvs({ { "TestKeyA"_sr, "TestValueA"_sr },

--- a/fdbserver/workloads/RandomClogging.actor.cpp
+++ b/fdbserver/workloads/RandomClogging.actor.cpp
@@ -43,23 +43,18 @@ struct RandomCloggingWorkload : FailureInjectionWorkload {
 		swizzleClog = getOption(options, "swizzle"_sr, swizzleClog);
 	}
 
-	bool add(DeterministicRandom& random, WorkloadRequest const& work, CompoundWorkload const& workload) override {
-		auto desc = description();
-		unsigned alreadyAdded = std::count_if(workload.workloads.begin(),
-		                                      workload.workloads.end(),
-		                                      [&desc](auto const& w) { return w->description() == desc; });
-		alreadyAdded += std::count_if(workload.failureInjection.begin(),
-		                              workload.failureInjection.end(),
-		                              [&desc](auto const& w) { return w->description() == desc; });
-		bool willAdd = work.useDatabase && 0.25 / (1 + alreadyAdded) > random.random01();
-		if (willAdd) {
-			enabled = this->clientId == 0;
-			scale = std::max(random.random01(), 0.1);
-			clogginess = std::max(random.random01(), 0.1);
-			swizzleClog = random.random01() < 0.3;
-			iterate = random.random01() < 0.5;
-		}
-		return willAdd;
+	bool shouldInject(DeterministicRandom& random,
+	                  const WorkloadRequest& work,
+	                  const unsigned alreadyAdded) const override {
+		return work.useDatabase && 0.25 / (1 + alreadyAdded) > random.random01();
+	}
+
+	void initFailureInjectionMode(DeterministicRandom& random) override {
+		enabled = this->clientId == 0;
+		scale = std::max(random.random01(), 0.1);
+		clogginess = std::max(random.random01(), 0.1);
+		swizzleClog = random.random01() < 0.3;
+		iterate = random.random01() < 0.5;
 	}
 
 	std::string description() const override {

--- a/fdbserver/workloads/Rollback.actor.cpp
+++ b/fdbserver/workloads/Rollback.actor.cpp
@@ -47,7 +47,7 @@ struct RollbackWorkload : FailureInjectionWorkload {
 		multiple = getOption(options, "multiple"_sr, multiple);
 	}
 
-	void initFailureInjectionMode(DeterministicRandom& random, unsigned count) override {
+	void initFailureInjectionMode(DeterministicRandom& random) override {
 		enabled = clientId == 0;
 		multiple = random.coinflip();
 		enableFailures = random.random01() < 0.2;

--- a/fdbserver/workloads/StorageServerCheckpointRestoreTest.actor.cpp
+++ b/fdbserver/workloads/StorageServerCheckpointRestoreTest.actor.cpp
@@ -67,6 +67,8 @@ struct SSCheckpointRestoreWorkload : TestWorkload {
 		return _start(this, cx);
 	}
 
+	void disableFailureInjectionWorkloads(std::set<std::string>& out) const override { out.insert("MoveKeysWorkload"); }
+
 	ACTOR Future<Void> _start(SSCheckpointRestoreWorkload* self, Database cx) {
 		state Key key = "TestKey"_sr;
 		state Key endKey = "TestKey0"_sr;


### PR DESCRIPTION
Port #8302 and #8298 

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
