### PR TITLE
Fix Valgrind Invalid read error

### DIFF
--- a/flow/include/flow/PriorityMultiLock.actor.h
+++ b/flow/include/flow/PriorityMultiLock.actor.h
@@ -126,8 +126,8 @@ public:
 				runners[i].cancel();
 			}
 		}
-		runners.clear();
 		brokenOnDestruct.sendError(broken_promise());
+		runners.clear();
 		waiting = 0;
 		priorities.clear();
 	}


### PR DESCRIPTION
RunnerActorState accesses memory that's been freed in PriorityMultiLock::kill().

Seed: `-f ./foundationdb/tests/rare/CycleRollbackClogged.toml -s 2396850462 -b off`
Commit: 430f6e967

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
