### PR TITLE
Disable fault injection for the TenantEntryCacheWorkload.

### DIFF
--- a/fdbserver/workloads/TenantEntryCacheWorkload.actor.cpp
+++ b/fdbserver/workloads/TenantEntryCacheWorkload.actor.cpp
@@ -305,7 +305,17 @@ struct TenantEntryCacheWorkload : TestWorkload {
 	}
 
 	std::string description() const override { return "TenantEntryCache"; }
+
+	// Disable all fault injections for this test. They sometimes
+	// lead to failures in the CacheRefresh test, which has a 20
+	// second timeout in which it expects cache refreshes to make
+	// progress.
+	void disableFailureInjectionWorkloads(std::set<std::string>& out) const override {
+		out.insert("all");
+	}
+
 	Future<bool> check(Database const& cx) override { return true; }
+
 	void getMetrics(std::vector<PerfMetric>& m) override {}
 };
 


### PR DESCRIPTION
The cache refresh test expected to make progress in 20 seconds. Failures can cause recoveries which blow this timeout. In its current form, this test is incomptible with agressive failure injection.

Replace this text with your description here...

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
