### PR TITLE
Initialize memory in new DoAppendIfFits unit test

### DIFF
--- a/fdbclient/Atomic.cpp
+++ b/fdbclient/Atomic.cpp
@@ -35,6 +35,8 @@ TEST_CASE("/Atomic/DoAppendIfFits") {
 	{
 		Value existingValue = makeString(CLIENT_KNOBS->VALUE_SIZE_LIMIT - 1, arena);
 		Value otherOperand = makeString(2, arena);
+		deterministicRandom()->randomBytes(mutateString(existingValue), existingValue.size());
+		deterministicRandom()->randomBytes(mutateString(otherOperand), otherOperand.size());
 		// Appended values cannot fit in result, should return existingValue
 		auto result = doAppendIfFits(existingValue, otherOperand, arena);
 		ASSERT(compare(existingValue, result) == 0);


### PR DESCRIPTION
This fixes a valgrind failure found in the nightly.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
