### PR TITLE
Link fdbcli with -rdynamic for ubsan builds (snowflake/release-71.2)

### DIFF
--- a/fdbcli/CMakeLists.txt
+++ b/fdbcli/CMakeLists.txt
@@ -3,6 +3,13 @@ fdb_find_sources(FDBCLI_SRCS)
 add_flow_target(EXECUTABLE NAME fdbcli SRCS ${FDBCLI_SRCS})
 target_include_directories(fdbcli PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/include" "${CMAKE_CURRENT_BINARY_DIR}/include")
 target_link_libraries(fdbcli PRIVATE fdbclient SimpleOpt)
+if (USE_UBSAN)
+  # The intent is to put typeinfo symbols in the dynamic symbol table so that
+  # the types in fdbcli and external libfdb_c clients agree for ubsan's vptr
+  # check. This would not be a good idea for the normal build, or if we ever
+  # start testing old libfdb_c's that are ubsan-instrumented.
+  target_link_options(fdbcli PRIVATE "-rdynamic")
+endif()
 
 if(NOT WIN32)
   target_link_libraries(fdbcli PRIVATE linenoise)


### PR DESCRIPTION
Cherry pick https://github.com/apple/foundationdb/pull/8033 to snowflake/release-71.2



Closes #7957

The intent is to put typeinfo symbols in the dynamic symbol table so that
the types in fdbcli and external libfdb_c clients agree for ubsan's vptr
check. This would not be a good idea for the normal build, or if we ever
start testing old libfdb_c's that are ubsan-instrumented.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
