### PR TITLE
Guarantee that IS_ARM_MAC is set in flow/CMakeLists.txt

### DIFF
--- a/flow/CMakeLists.txt
+++ b/flow/CMakeLists.txt
@@ -38,6 +38,11 @@ target_link_libraries(flowlinktest PRIVATE flow stacktrace)
 #  message(STATUS "ZLIB package not found")
 #endif()
 
+set(IS_ARM_MAC NO)
+if(APPLE AND CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64")
+  set(IS_ARM_MAC YES)
+endif()
+
 # TODO: Limit ZSTD availability to CLANG, for gcc resolve library link ordering
 if (CLANG AND NOT IS_ARM_MAC)
   include(CompileZstd)


### PR DESCRIPTION
Apparently it wasn't guaranteed before. Not sure how it fixed my local
build in the previous PR (#8338).

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
