### PR TITLE
Fix heap use after free in metacluster management workload

### DIFF
--- a/fdbserver/workloads/MetaclusterManagementWorkload.actor.cpp
+++ b/fdbserver/workloads/MetaclusterManagementWorkload.actor.cpp
@@ -745,14 +745,14 @@ struct MetaclusterManagementWorkload : TestWorkload {
 			self->createdTenants[newTenantName] = tenantData->second;
 			self->createdTenants.erase(tenantData);
 
-			auto& dataDb = self->dataDbs[tenantData->second.cluster];
+			auto& dataDb = self->dataDbs[newEntry.assignedCluster.get()];
 			ASSERT(dataDb.registered);
 
 			dataDb.tenants.erase(tenant);
 			dataDb.tenants.insert(newTenantName);
 
-			if (tenantData->second.tenantGroup.present()) {
-				auto& tenantGroup = self->tenantGroups[tenantData->second.tenantGroup.get()];
+			if (newEntry.tenantGroup.present()) {
+				auto& tenantGroup = self->tenantGroups[newEntry.tenantGroup.get()];
 				tenantGroup.tenants.erase(tenant);
 				tenantGroup.tenants.insert(newTenantName);
 			} else {


### PR DESCRIPTION
Use different variables that already store the same data as an invalidated iterator

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
