### PR TITLE
Allow build FoundationDB with zstd compression library

### DIFF
--- a/cmake/CompileZstd.cmake
+++ b/cmake/CompileZstd.cmake
@@ -4,20 +4,21 @@ function(compile_zstd)
 
   include(FetchContent)
 
-  set(ZSTD_SOURCE_DIR ${CMAKE_BINARY_DIR}/zstd)
-
-  FetchContent_Declare(
-    ZSTD
+  FetchContent_Declare(ZSTD
     GIT_REPOSITORY https://github.com/facebook/zstd.git
-    GIT_TAG        v1.5.2
-    SOURCE_DIR     ${ZSTD_SOURCE_DIR}
-    BINARY_DIR     ${ZSTD_SOURCE_DIR}
-    SOURCE_SUBDIR  "build/cmake"
+    GIT_TAG v1.5.2
+    SOURCE_SUBDIR "build/cmake"
   )
 
-  FetchContent_MakeAvailable(ZSTD)
+  FetchContent_GetProperties(ZSTD)
+  if (NOT zstd_POPULATED)
+    FetchContent_Populate(ZSTD)
 
-  add_library(ZSTD::ZSTD STATIC IMPORTED)
-  set_target_properties(ZSTD::ZSTD PROPERTIES IMPORTED_LOCATION "${CMAKE_BINARY_DIR}/lib/libzstd.a")
-  target_include_directories(ZSTD::ZSTD PUBLIC ${ZSTD_INCLUDE_DIRS})
+    add_subdirectory(${zstd_SOURCE_DIR}/build/cmake ${zstd_BINARY_DIR})
+    target_compile_options(zstd PRIVATE -Wno-array-bounds -Wno-tautological-compare)
+    target_compile_options(libzstd_static PRIVATE -Wno-array-bounds -Wno-tautological-compare)
+    target_compile_options(zstd-frugal PRIVATE -Wno-array-bounds -Wno-tautological-compare)
+  endif()
+
+  set(ZSTD_LIB_INCLUDE_DIR ${zstd_SOURCE_DIR}/lib PARENT_SCOPE)
 endfunction(compile_zstd)

--- a/cmake/CompileZstd.cmake
+++ b/cmake/CompileZstd.cmake
@@ -15,9 +15,12 @@ function(compile_zstd)
     FetchContent_Populate(ZSTD)
 
     add_subdirectory(${zstd_SOURCE_DIR}/build/cmake ${zstd_BINARY_DIR})
-    target_compile_options(zstd PRIVATE -Wno-array-bounds -Wno-tautological-compare)
-    target_compile_options(libzstd_static PRIVATE -Wno-array-bounds -Wno-tautological-compare)
-    target_compile_options(zstd-frugal PRIVATE -Wno-array-bounds -Wno-tautological-compare)
+
+    if (CLANG)
+      target_compile_options(zstd PRIVATE -Wno-array-bounds -Wno-tautological-compare)
+      target_compile_options(libzstd_static PRIVATE -Wno-array-bounds -Wno-tautological-compare)
+      target_compile_options(zstd-frugal PRIVATE -Wno-array-bounds -Wno-tautological-compare)
+    endif()
   endif()
 
   set(ZSTD_LIB_INCLUDE_DIR ${zstd_SOURCE_DIR}/lib PARENT_SCOPE)

--- a/contrib/boost_zstd/zstd.cpp
+++ b/contrib/boost_zstd/zstd.cpp
@@ -1,0 +1,166 @@
+// (C) Copyright Reimar Döffinger 2018.
+// Based on zstd.cpp by:
+// (C) Copyright Milan Svoboda 2008.
+// (C) Copyright Jonathan Turkanis 2003.
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt.)
+
+// See http://www.boost.org/libs/iostreams for documentation.
+
+// Define BOOST_IOSTREAMS_SOURCE so that <boost/iostreams/detail/config.hpp>
+// knows that we are building the library (possibly exporting code), rather
+// than using it (possibly importing code).
+#define BOOST_IOSTREAMS_SOURCE
+
+#include <zstd.h>
+
+#include <boost/throw_exception.hpp>
+#include <boost/iostreams/detail/config/dyn_link.hpp>
+#include <boost/iostreams/filter/zstd.hpp>
+
+namespace boost { namespace iostreams {
+
+namespace zstd {
+                    // Compression levels
+
+const uint32_t best_speed           = 1;
+const uint32_t best_compression     = 19;
+const uint32_t default_compression  = 3;
+
+                    // Status codes
+
+const int okay                 = 0;
+const int stream_end           = 1;
+
+                    // Flush codes
+
+const int finish               = 0;
+const int flush                = 1;
+const int run                  = 2;
+} // End namespace zstd.
+
+//------------------Implementation of zstd_error------------------------------//
+
+zstd_error::zstd_error(size_t error)
+    : BOOST_IOSTREAMS_FAILURE(ZSTD_getErrorName(error)), error_(error)
+    { }
+
+void zstd_error::check BOOST_PREVENT_MACRO_SUBSTITUTION(size_t error)
+{
+    if (ZSTD_isError(error))
+        boost::throw_exception(zstd_error(error));
+}
+
+//------------------Implementation of zstd_base-------------------------------//
+
+namespace detail {
+
+zstd_base::zstd_base()
+    : cstream_(ZSTD_createCStream()), dstream_(ZSTD_createDStream()), in_(new ZSTD_inBuffer), out_(new ZSTD_outBuffer), eof_(0)
+    { }
+
+zstd_base::~zstd_base()
+{
+    ZSTD_freeCStream(static_cast<ZSTD_CStream *>(cstream_));
+    ZSTD_freeDStream(static_cast<ZSTD_DStream *>(dstream_));
+    delete static_cast<ZSTD_inBuffer*>(in_);
+    delete static_cast<ZSTD_outBuffer*>(out_);
+}
+
+void zstd_base::before( const char*& src_begin, const char* src_end,
+                        char*& dest_begin, char* dest_end )
+{
+    ZSTD_inBuffer *in = static_cast<ZSTD_inBuffer *>(in_);
+    ZSTD_outBuffer *out = static_cast<ZSTD_outBuffer *>(out_);
+    in->src = src_begin;
+    in->size = static_cast<size_t>(src_end - src_begin);
+    in->pos = 0;
+    out->dst = dest_begin;
+    out->size = static_cast<size_t>(dest_end - dest_begin);
+    out->pos = 0;
+}
+
+void zstd_base::after(const char*& src_begin, char*& dest_begin, bool)
+{
+    ZSTD_inBuffer *in = static_cast<ZSTD_inBuffer *>(in_);
+    ZSTD_outBuffer *out = static_cast<ZSTD_outBuffer *>(out_);
+    src_begin = reinterpret_cast<const char*>(in->src) + in->pos;
+    dest_begin = reinterpret_cast<char*>(out->dst) + out->pos;
+}
+
+int zstd_base::deflate(int action)
+{
+    ZSTD_CStream *s = static_cast<ZSTD_CStream *>(cstream_);
+    ZSTD_inBuffer *in = static_cast<ZSTD_inBuffer *>(in_);
+    ZSTD_outBuffer *out = static_cast<ZSTD_outBuffer *>(out_);
+    // Ignore spurious extra calls.
+    // Note size > 0 will trigger an error in this case.
+    if (eof_ && in->size == 0) return zstd::stream_end;
+    size_t result = ZSTD_compressStream(s, out, in);
+    zstd_error::check BOOST_PREVENT_MACRO_SUBSTITUTION(result);
+    if (action != zstd::run)
+    {
+        result = action == zstd::finish ? ZSTD_endStream(s, out) : ZSTD_flushStream(s, out);
+        zstd_error::check BOOST_PREVENT_MACRO_SUBSTITUTION(result);
+        eof_ = action == zstd::finish && result == 0;
+        return result == 0 ? zstd::stream_end : zstd::okay;
+    }
+    return zstd::okay;
+}
+
+int zstd_base::inflate(int action)
+{
+    ZSTD_DStream *s = static_cast<ZSTD_DStream *>(dstream_);
+    ZSTD_inBuffer *in = static_cast<ZSTD_inBuffer *>(in_);
+    ZSTD_outBuffer *out = static_cast<ZSTD_outBuffer *>(out_);
+    // need loop since iostream code cannot handle short reads
+    do {
+        size_t result = ZSTD_decompressStream(s, out, in);
+        zstd_error::check BOOST_PREVENT_MACRO_SUBSTITUTION(result);
+    } while (in->pos < in->size && out->pos < out->size);
+    return action == zstd::finish && in->size == 0 && out->pos == 0 ? zstd::stream_end : zstd::okay;
+}
+
+void zstd_base::reset(bool compress, bool realloc)
+{
+    ZSTD_inBuffer *in = static_cast<ZSTD_inBuffer *>(in_);
+    ZSTD_outBuffer *out = static_cast<ZSTD_outBuffer *>(out_);
+    if (realloc)
+    {
+        memset(in, 0, sizeof(*in));
+        memset(out, 0, sizeof(*out));
+        eof_ = 0;
+
+        zstd_error::check BOOST_PREVENT_MACRO_SUBSTITUTION(
+            compress ?
+                ZSTD_initCStream(static_cast<ZSTD_CStream *>(cstream_), level) :
+                ZSTD_initDStream(static_cast<ZSTD_DStream *>(dstream_))
+        );
+    }
+}
+
+void zstd_base::do_init
+    ( const zstd_params& p, bool compress,
+      zstd::alloc_func, zstd::free_func,
+      void* )
+{
+    ZSTD_inBuffer *in = static_cast<ZSTD_inBuffer *>(in_);
+    ZSTD_outBuffer *out = static_cast<ZSTD_outBuffer *>(out_);
+
+    memset(in, 0, sizeof(*in));
+    memset(out, 0, sizeof(*out));
+    eof_ = 0;
+
+    level = p.level;
+    zstd_error::check BOOST_PREVENT_MACRO_SUBSTITUTION(
+        compress ?
+            ZSTD_initCStream(static_cast<ZSTD_CStream *>(cstream_), level) :
+            ZSTD_initDStream(static_cast<ZSTD_DStream *>(dstream_))
+    );
+}
+
+} // End namespace detail.
+
+//----------------------------------------------------------------------------//
+
+} } // End namespaces iostreams, boost.

--- a/contrib/boost_zstd/zstd.cpp
+++ b/contrib/boost_zstd/zstd.cpp
@@ -18,37 +18,35 @@
 #include <boost/iostreams/detail/config/dyn_link.hpp>
 #include <boost/iostreams/filter/zstd.hpp>
 
-namespace boost { namespace iostreams {
+namespace boost {
+namespace iostreams {
 
 namespace zstd {
-                    // Compression levels
+// Compression levels
 
-const uint32_t best_speed           = 1;
-const uint32_t best_compression     = 19;
-const uint32_t default_compression  = 3;
+const uint32_t best_speed = 1;
+const uint32_t best_compression = 19;
+const uint32_t default_compression = 3;
 
-                    // Status codes
+// Status codes
 
-const int okay                 = 0;
-const int stream_end           = 1;
+const int okay = 0;
+const int stream_end = 1;
 
-                    // Flush codes
+// Flush codes
 
-const int finish               = 0;
-const int flush                = 1;
-const int run                  = 2;
+const int finish = 0;
+const int flush = 1;
+const int run = 2;
 } // End namespace zstd.
 
 //------------------Implementation of zstd_error------------------------------//
 
-zstd_error::zstd_error(size_t error)
-    : BOOST_IOSTREAMS_FAILURE(ZSTD_getErrorName(error)), error_(error)
-    { }
+zstd_error::zstd_error(size_t error) : BOOST_IOSTREAMS_FAILURE(ZSTD_getErrorName(error)), error_(error) {}
 
-void zstd_error::check BOOST_PREVENT_MACRO_SUBSTITUTION(size_t error)
-{
-    if (ZSTD_isError(error))
-        boost::throw_exception(zstd_error(error));
+void zstd_error::check BOOST_PREVENT_MACRO_SUBSTITUTION(size_t error) {
+	if (ZSTD_isError(error))
+		boost::throw_exception(zstd_error(error));
 }
 
 //------------------Implementation of zstd_base-------------------------------//
@@ -56,111 +54,96 @@ void zstd_error::check BOOST_PREVENT_MACRO_SUBSTITUTION(size_t error)
 namespace detail {
 
 zstd_base::zstd_base()
-    : cstream_(ZSTD_createCStream()), dstream_(ZSTD_createDStream()), in_(new ZSTD_inBuffer), out_(new ZSTD_outBuffer), eof_(0)
-    { }
+  : cstream_(ZSTD_createCStream()), dstream_(ZSTD_createDStream()), in_(new ZSTD_inBuffer), out_(new ZSTD_outBuffer),
+    eof_(0) {}
 
-zstd_base::~zstd_base()
-{
-    ZSTD_freeCStream(static_cast<ZSTD_CStream *>(cstream_));
-    ZSTD_freeDStream(static_cast<ZSTD_DStream *>(dstream_));
-    delete static_cast<ZSTD_inBuffer*>(in_);
-    delete static_cast<ZSTD_outBuffer*>(out_);
+zstd_base::~zstd_base() {
+	ZSTD_freeCStream(static_cast<ZSTD_CStream*>(cstream_));
+	ZSTD_freeDStream(static_cast<ZSTD_DStream*>(dstream_));
+	delete static_cast<ZSTD_inBuffer*>(in_);
+	delete static_cast<ZSTD_outBuffer*>(out_);
 }
 
-void zstd_base::before( const char*& src_begin, const char* src_end,
-                        char*& dest_begin, char* dest_end )
-{
-    ZSTD_inBuffer *in = static_cast<ZSTD_inBuffer *>(in_);
-    ZSTD_outBuffer *out = static_cast<ZSTD_outBuffer *>(out_);
-    in->src = src_begin;
-    in->size = static_cast<size_t>(src_end - src_begin);
-    in->pos = 0;
-    out->dst = dest_begin;
-    out->size = static_cast<size_t>(dest_end - dest_begin);
-    out->pos = 0;
+void zstd_base::before(const char*& src_begin, const char* src_end, char*& dest_begin, char* dest_end) {
+	ZSTD_inBuffer* in = static_cast<ZSTD_inBuffer*>(in_);
+	ZSTD_outBuffer* out = static_cast<ZSTD_outBuffer*>(out_);
+	in->src = src_begin;
+	in->size = static_cast<size_t>(src_end - src_begin);
+	in->pos = 0;
+	out->dst = dest_begin;
+	out->size = static_cast<size_t>(dest_end - dest_begin);
+	out->pos = 0;
 }
 
-void zstd_base::after(const char*& src_begin, char*& dest_begin, bool)
-{
-    ZSTD_inBuffer *in = static_cast<ZSTD_inBuffer *>(in_);
-    ZSTD_outBuffer *out = static_cast<ZSTD_outBuffer *>(out_);
-    src_begin = reinterpret_cast<const char*>(in->src) + in->pos;
-    dest_begin = reinterpret_cast<char*>(out->dst) + out->pos;
+void zstd_base::after(const char*& src_begin, char*& dest_begin, bool) {
+	ZSTD_inBuffer* in = static_cast<ZSTD_inBuffer*>(in_);
+	ZSTD_outBuffer* out = static_cast<ZSTD_outBuffer*>(out_);
+	src_begin = reinterpret_cast<const char*>(in->src) + in->pos;
+	dest_begin = reinterpret_cast<char*>(out->dst) + out->pos;
 }
 
-int zstd_base::deflate(int action)
-{
-    ZSTD_CStream *s = static_cast<ZSTD_CStream *>(cstream_);
-    ZSTD_inBuffer *in = static_cast<ZSTD_inBuffer *>(in_);
-    ZSTD_outBuffer *out = static_cast<ZSTD_outBuffer *>(out_);
-    // Ignore spurious extra calls.
-    // Note size > 0 will trigger an error in this case.
-    if (eof_ && in->size == 0) return zstd::stream_end;
-    size_t result = ZSTD_compressStream(s, out, in);
-    zstd_error::check BOOST_PREVENT_MACRO_SUBSTITUTION(result);
-    if (action != zstd::run)
-    {
-        result = action == zstd::finish ? ZSTD_endStream(s, out) : ZSTD_flushStream(s, out);
-        zstd_error::check BOOST_PREVENT_MACRO_SUBSTITUTION(result);
-        eof_ = action == zstd::finish && result == 0;
-        return result == 0 ? zstd::stream_end : zstd::okay;
-    }
-    return zstd::okay;
+int zstd_base::deflate(int action) {
+	ZSTD_CStream* s = static_cast<ZSTD_CStream*>(cstream_);
+	ZSTD_inBuffer* in = static_cast<ZSTD_inBuffer*>(in_);
+	ZSTD_outBuffer* out = static_cast<ZSTD_outBuffer*>(out_);
+	// Ignore spurious extra calls.
+	// Note size > 0 will trigger an error in this case.
+	if (eof_ && in->size == 0)
+		return zstd::stream_end;
+	size_t result = ZSTD_compressStream(s, out, in);
+	zstd_error::check BOOST_PREVENT_MACRO_SUBSTITUTION(result);
+	if (action != zstd::run) {
+		result = action == zstd::finish ? ZSTD_endStream(s, out) : ZSTD_flushStream(s, out);
+		zstd_error::check BOOST_PREVENT_MACRO_SUBSTITUTION(result);
+		eof_ = action == zstd::finish && result == 0;
+		return result == 0 ? zstd::stream_end : zstd::okay;
+	}
+	return zstd::okay;
 }
 
-int zstd_base::inflate(int action)
-{
-    ZSTD_DStream *s = static_cast<ZSTD_DStream *>(dstream_);
-    ZSTD_inBuffer *in = static_cast<ZSTD_inBuffer *>(in_);
-    ZSTD_outBuffer *out = static_cast<ZSTD_outBuffer *>(out_);
-    // need loop since iostream code cannot handle short reads
-    do {
-        size_t result = ZSTD_decompressStream(s, out, in);
-        zstd_error::check BOOST_PREVENT_MACRO_SUBSTITUTION(result);
-    } while (in->pos < in->size && out->pos < out->size);
-    return action == zstd::finish && in->size == 0 && out->pos == 0 ? zstd::stream_end : zstd::okay;
+int zstd_base::inflate(int action) {
+	ZSTD_DStream* s = static_cast<ZSTD_DStream*>(dstream_);
+	ZSTD_inBuffer* in = static_cast<ZSTD_inBuffer*>(in_);
+	ZSTD_outBuffer* out = static_cast<ZSTD_outBuffer*>(out_);
+	// need loop since iostream code cannot handle short reads
+	do {
+		size_t result = ZSTD_decompressStream(s, out, in);
+		zstd_error::check BOOST_PREVENT_MACRO_SUBSTITUTION(result);
+	} while (in->pos < in->size && out->pos < out->size);
+	return action == zstd::finish && in->size == 0 && out->pos == 0 ? zstd::stream_end : zstd::okay;
 }
 
-void zstd_base::reset(bool compress, bool realloc)
-{
-    ZSTD_inBuffer *in = static_cast<ZSTD_inBuffer *>(in_);
-    ZSTD_outBuffer *out = static_cast<ZSTD_outBuffer *>(out_);
-    if (realloc)
-    {
-        memset(in, 0, sizeof(*in));
-        memset(out, 0, sizeof(*out));
-        eof_ = 0;
+void zstd_base::reset(bool compress, bool realloc) {
+	ZSTD_inBuffer* in = static_cast<ZSTD_inBuffer*>(in_);
+	ZSTD_outBuffer* out = static_cast<ZSTD_outBuffer*>(out_);
+	if (realloc) {
+		memset(in, 0, sizeof(*in));
+		memset(out, 0, sizeof(*out));
+		eof_ = 0;
 
-        zstd_error::check BOOST_PREVENT_MACRO_SUBSTITUTION(
-            compress ?
-                ZSTD_initCStream(static_cast<ZSTD_CStream *>(cstream_), level) :
-                ZSTD_initDStream(static_cast<ZSTD_DStream *>(dstream_))
-        );
-    }
+		zstd_error::check BOOST_PREVENT_MACRO_SUBSTITUTION(
+		    compress ? ZSTD_initCStream(static_cast<ZSTD_CStream*>(cstream_), level)
+		             : ZSTD_initDStream(static_cast<ZSTD_DStream*>(dstream_)));
+	}
 }
 
-void zstd_base::do_init
-    ( const zstd_params& p, bool compress,
-      zstd::alloc_func, zstd::free_func,
-      void* )
-{
-    ZSTD_inBuffer *in = static_cast<ZSTD_inBuffer *>(in_);
-    ZSTD_outBuffer *out = static_cast<ZSTD_outBuffer *>(out_);
+void zstd_base::do_init(const zstd_params& p, bool compress, zstd::alloc_func, zstd::free_func, void*) {
+	ZSTD_inBuffer* in = static_cast<ZSTD_inBuffer*>(in_);
+	ZSTD_outBuffer* out = static_cast<ZSTD_outBuffer*>(out_);
 
-    memset(in, 0, sizeof(*in));
-    memset(out, 0, sizeof(*out));
-    eof_ = 0;
+	memset(in, 0, sizeof(*in));
+	memset(out, 0, sizeof(*out));
+	eof_ = 0;
 
-    level = p.level;
-    zstd_error::check BOOST_PREVENT_MACRO_SUBSTITUTION(
-        compress ?
-            ZSTD_initCStream(static_cast<ZSTD_CStream *>(cstream_), level) :
-            ZSTD_initDStream(static_cast<ZSTD_DStream *>(dstream_))
-    );
+	level = p.level;
+	zstd_error::check BOOST_PREVENT_MACRO_SUBSTITUTION(
+	    compress ? ZSTD_initCStream(static_cast<ZSTD_CStream*>(cstream_), level)
+	             : ZSTD_initDStream(static_cast<ZSTD_DStream*>(dstream_)));
 }
 
 } // End namespace detail.
 
 //----------------------------------------------------------------------------//
 
-} } // End namespaces iostreams, boost.
+} // namespace iostreams
+} // namespace boost

--- a/flow/CMakeLists.txt
+++ b/flow/CMakeLists.txt
@@ -1,6 +1,15 @@
 find_package(Threads REQUIRED)
 
+option(FLOW_USE_ZSTD "Enable zstd compression in flow" OFF)
+
 fdb_find_sources(FLOW_SRCS)
+
+if (FLOW_USE_ZSTD)
+  # NOTE: To enable boost::iostreams with zstd library support, manually add
+  # zstd.cpp to source files is required. Ref:
+  #   https://www.boost.org/doc/libs/1_79_0/libs/iostreams/doc/installation.html
+  list(APPEND FLOW_SRCS ../contrib/boost_zstd/zstd.cpp)
+endif()
 
 # Remove files with `main` defined so we can create a link test executable.
 list(REMOVE_ITEM FLOW_SRCS TLSTest.cpp)
@@ -23,6 +32,14 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config.h.cmake ${CMAKE_CURRENT_BINARY
 add_flow_target(STATIC_LIBRARY NAME flow SRCS ${FLOW_SRCS})
 add_flow_target(STATIC_LIBRARY NAME flow_sampling SRCS ${FLOW_SRCS})
 
+if (FLOW_USE_ZSTD)
+  include(CompileZstd)
+  compile_zstd()
+
+  target_link_libraries(flow PRIVATE libzstd_static)
+  target_compile_definitions(flow PUBLIC ZSTD_LIB_SUPPORTED)
+endif()
+
 # When creating a static or shared library, undefined symbols will be ignored.
 # Since we want to ensure no symbols from other modules are used, create an
 # executable so the linker will throw errors if it can't find the declaration
@@ -43,16 +60,11 @@ if(APPLE AND CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64")
     set(IS_ARM_MAC YES)
 endif()
 
-# TODO: Limit ZSTD availability to CLANG, for gcc resolve library link ordering
-if(CLANG AND NOT IS_ARM_MAC)
-    include(CompileZstd)
-    compile_zstd()
-    target_link_libraries(flow PUBLIC ZSTD::ZSTD)
-    target_compile_definitions(flow PUBLIC ZSTD_LIB_SUPPORTED)
-endif()
-
 foreach(ft flow flow_sampling flowlinktest)
     target_include_directories(${ft} PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include" "${CMAKE_CURRENT_BINARY_DIR}/include")
+    if (FLOW_USE_ZSTD)
+        target_include_directories(${ft} PRIVATE SYSTEM ${ZSTD_LIB_INCLUDE_DIR})
+    endif()
 
     target_link_libraries(${ft} PRIVATE stacktrace)
     target_link_libraries(${ft} PUBLIC fmt::fmt SimpleOpt crc32)


### PR DESCRIPTION
With this patch, a new option, FLOW_USE_ZSTD, is introduced. If turned ON, flow will compile with zstd compression library.

This is tested in the Okteto environment using both gcc and clang compilation set.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
