### PR TITLE
Fix some binding tester issues

### DIFF
--- a/bindings/java/src/test/com/apple/foundationdb/test/Context.java
+++ b/bindings/java/src/test/com/apple/foundationdb/test/Context.java
@@ -84,8 +84,8 @@ abstract class Context implements Runnable, AutoCloseable {
 		try {
 			executeOperations();
 		} catch(Throwable t) {
-			// EAT
 			t.printStackTrace();
+			System.exit(1);
 		}
 		while(children.size() > 0) {
 			//System.out.println("Shutting down...waiting on " + children.size() + " threads");
@@ -147,10 +147,11 @@ abstract class Context implements Runnable, AutoCloseable {
 	private static synchronized boolean newTransaction(Database db, Optional<Tenant> tenant, String trName, boolean allowReplace) {
 		TransactionState oldState = transactionMap.get(trName);
 		if (oldState != null) {
-			releaseTransaction(oldState.transaction);
-		}
-		else if (!allowReplace) {
-			return false;
+			if (allowReplace) {
+				releaseTransaction(oldState.transaction);
+			} else {
+				return false;
+			}
 		}
 
 		TransactionState newState = new TransactionState(createTransaction(db, tenant), tenant);

--- a/contrib/Joshua/scripts/bindingTestScript.sh
+++ b/contrib/Joshua/scripts/bindingTestScript.sh
@@ -83,6 +83,7 @@ fi
 # Stop the cluster
 if stopCluster; then
 	unset FDBSERVERID
+	trap - EXIT
 fi
 
 exit "${status}"

--- a/contrib/Joshua/scripts/localClusterStart.sh
+++ b/contrib/Joshua/scripts/localClusterStart.sh
@@ -210,7 +210,7 @@ function stopCluster
   then
     # Ensure that process is dead
     if ! kill -0 "${FDBSERVERID}" 2> /dev/null; then
-      log "Killed cluster (${FDBSERVERID}) via cli"
+      log "Killed cluster (${FDBSERVERID}) via cli" "${DEBUGLEVEL}"
     elif ! kill -9 "${FDBSERVERID}"; then
       log "Failed to kill FDB Server process (${FDBSERVERID}) via cli or kill command"
       let status="${status} + 1"


### PR DESCRIPTION
Fixes a few binding tester issues:

1. The Java binding tester would ignore some types of errors, allowing a test to succeed when it shouldn't have
2. The Java binding tester was incorrectly managing the transactions in a context
3. The binding tester script was attempting to stop the cluster twice, resulting in an error message the second time
4. There was an unnecessary output line being logged when the cluster is killed

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
