### PR TITLE
Repair Dead Data Center Outside Quiet Database

### DIFF
--- a/fdbserver/include/fdbserver/QuietDatabase.h
+++ b/fdbserver/include/fdbserver/QuietDatabase.h
@@ -50,6 +50,10 @@ Future<WorkerInterface> getMasterWorker(Database const& cx, Reference<AsyncVar<S
 Future<Void> repairDeadDatacenter(Database const& cx,
                                   Reference<AsyncVar<ServerDBInfo> const> const& dbInfo,
                                   std::string const& context);
+Future<Void> reconfigureAfter(Database const& cx,
+                              double const& time,
+                              Reference<AsyncVar<ServerDBInfo> const> const& dbInfo,
+                              std::string const& context);
 
 // Returns list of worker interfaces for available storage servers and the number of unavailable
 // storage servers

--- a/fdbserver/tester.actor.cpp
+++ b/fdbserver/tester.actor.cpp
@@ -1727,6 +1727,11 @@ ACTOR Future<Void> runTests(Reference<AsyncVar<Optional<struct ClusterController
 	}
 
 	state Future<Void> disabler = disableConnectionFailuresAfter(FLOW_KNOBS->SIM_SPEEDUP_AFTER_SECONDS, "Tester");
+	state Future<Void> repairDataCenter;
+	if (useDB) {
+		Future<Void> reconfigure = reconfigureAfter(cx, FLOW_KNOBS->SIM_SPEEDUP_AFTER_SECONDS, dbInfo, "Tester");
+		repairDataCenter = reconfigure;
+	}
 
 	// Change the configuration (and/or create the database) if necessary
 	printf("startingConfiguration:%s start\n", startingConfiguration.toString().c_str());

--- a/fdbserver/workloads/SnapTest.actor.cpp
+++ b/fdbserver/workloads/SnapTest.actor.cpp
@@ -235,7 +235,8 @@ public: // workload functions
 					wait(status);
 					break;
 				} catch (Error& e) {
-					if (e.code() == error_code_snap_log_anti_quorum_unsupported) {
+					if (e.code() == error_code_snap_log_anti_quorum_unsupported ||
+					    e.code() == error_code_snap_not_fully_recovered_unsupported) {
 						snapFailed = true;
 						break;
 					}

--- a/fdbserver/workloads/SnapTest.actor.cpp
+++ b/fdbserver/workloads/SnapTest.actor.cpp
@@ -120,6 +120,7 @@ public: // ctor & dtor
 		restartInfoLocation = getOption(options, "restartInfoLocation"_sr, "simfdb/restartInfo.ini"_sr).toString();
 		skipCheck = false;
 		retryLimit = getOption(options, "retryLimit"_sr, 5);
+		g_simulator->allowLogSetKills = false;
 	}
 
 public: // workload functions
@@ -235,8 +236,7 @@ public: // workload functions
 					wait(status);
 					break;
 				} catch (Error& e) {
-					if (e.code() == error_code_snap_log_anti_quorum_unsupported ||
-					    e.code() == error_code_snap_not_fully_recovered_unsupported) {
+					if (e.code() == error_code_snap_log_anti_quorum_unsupported) {
 						snapFailed = true;
 						break;
 					}


### PR DESCRIPTION
Currently certain workloads with attrition injected will fail because a repair is not performed on a dead (killed) data center until Quiet Database (end of the test) is called. This PR fixes this by repairing the dead data center after `SIM_SPEEDUP_AFTER_SECONDS`

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
