### PR TITLE
Init TLogPersistent storage for a sharedTLog

### DIFF
--- a/fdbserver/TLogServer.actor.cpp
+++ b/fdbserver/TLogServer.actor.cpp
@@ -2359,10 +2359,7 @@ ACTOR Future<Void> initPersistentState(TLogData* self, Reference<LogData> logDat
 	wait(self->persistentDataCommitLock.take());
 	state FlowLock::Releaser commitLockReleaser(self->persistentDataCommitLock);
 
-	// PERSIST: Initial setup of persistentData for a brand new tLog for a new database
 	state IKeyValueStore* storage = self->persistentData;
-	wait(storage->init());
-	storage->set(persistFormat);
 	storage->set(
 	    KeyValueRef(BinaryWriter::toValue(logData->logId, Unversioned()).withPrefix(persistCurrentVersionKeys.begin),
 	                BinaryWriter::toValue(logData->version.get(), Unversioned())));
@@ -2392,7 +2389,7 @@ ACTOR Future<Void> initPersistentState(TLogData* self, Reference<LogData> logDat
 		updatePersistentPopped(self, logData, logData->getTagData(tag));
 	}
 
-	TraceEvent("TLogInitCommit", logData->logId).log();
+	TraceEvent("TLogInitCommit", logData->logId);
 	wait(self->persistentData->commit());
 	return Void();
 }
@@ -2998,6 +2995,21 @@ ACTOR Future<Void> checkRecovered(TLogData* self) {
 	return Void();
 }
 
+ACTOR Future<Void> initPersistentStorage(TLogData* self) {
+	TraceEvent("TLogInitPersistentStorageStart", self->dbgid);
+
+	wait(self->persistentDataCommitLock.take());
+	state FlowLock::Releaser commitLockReleaser(self->persistentDataCommitLock);
+
+	// PERSIST: Initial setup of persistentData for a brand new tLog for a new database
+	state IKeyValueStore* storage = self->persistentData;
+	wait(storage->init());
+	storage->set(persistFormat);
+
+	TraceEvent("TLogInitPersistentStorageDone", self->dbgid);
+	return Void();
+}
+
 // Recovery persistent state of tLog from disk
 ACTOR Future<Void> restorePersistentState(TLogData* self,
                                           LocalityData locality,
@@ -3577,13 +3589,13 @@ ACTOR Future<Void> tLog(IKeyValueStore* persistentData,
 	state TLogData self(tlogId, workerID, persistentData, persistentQueue, db, degraded, folder);
 	state Future<Void> error = actorCollection(self.sharedActors.getFuture());
 
-	TraceEvent("SharedTlog", tlogId).log();
+	TraceEvent("SharedTlog", tlogId);
 	try {
 		try {
 			if (restoreFromDisk) {
 				wait(restorePersistentState(&self, locality, oldLog, recovered, tlogRequests));
 			} else {
-				wait(ioTimeoutError(checkEmptyQueue(&self) && checkRecovered(&self),
+				wait(ioTimeoutError(checkEmptyQueue(&self) && checkRecovered(&self) && initPersistentStorage(&self),
 				                    SERVER_KNOBS->TLOG_MAX_CREATE_DURATION));
 			}
 
@@ -3593,9 +3605,9 @@ ACTOR Future<Void> tLog(IKeyValueStore* persistentData,
 			if (recovered.canBeSet())
 				recovered.send(Void());
 
-			// if (!self.durableClusterId.isValid()) {
-			// 	self.sharedActors.send(updateDurableClusterID(&self));
-			// }
+			if (!self.durableClusterId.isValid()) {
+				self.sharedActors.send(updateDurableClusterID(&self));
+			}
 			self.sharedActors.send(commitQueue(&self));
 			self.sharedActors.send(updateStorageLoop(&self));
 			self.sharedActors.send(traceRole(Role::SHARED_TRANSACTION_LOG, tlogId));


### PR DESCRIPTION
Description

Patch updates the code to initialize TLogPersistent storage for a shared TLog independent of initializing persistentState for a versioned Tlog data. Approach allows initializing Tlog persistent storage as well as writing 'persistFormat' key for a shared TLog earlier in the TLog creation lifecycle.

Testing

devRunCorrectness - 100K

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
