### PR TITLE
Disable RocksDB storage engine in unit test TestConfig

### DIFF
--- a/fdbserver/SimulatedCluster.actor.cpp
+++ b/fdbserver/SimulatedCluster.actor.cpp
@@ -2607,6 +2607,10 @@ ACTOR void setupAndRun(std::string dataFolder,
 
 DatabaseConfiguration generateNormalDatabaseConfiguration(const BasicTestConfig& testConfig) {
 	TestConfig config(testConfig);
+	if (!rocksDBEnabled) {
+		config.storageEngineExcludeTypes.push_back(4);
+		config.storageEngineExcludeTypes.push_back(5);
+	}
 	SimulationConfig simConf(config);
 	return simConf.db;
 }


### PR DESCRIPTION
We were seeing unit test failures in simulation where RocksDB was being set as the storage engine when it was compile time disabled. One example:

Commit: `ff6514527cdc4988f38e2da5e54755a623dfeab8`
Seed: `72117743`
Buggify: `on`

The failing unit test creates a [new test configuration](https://github.com/apple/foundationdb/blob/03f1d13be343f7adbab33e3f0337fb0d7269ffb4/fdbserver/MockGlobalState.cpp#L94) which doesn't have `storageEngineExcludeTypes` set, meaning RocksDB was a valid option even if FDB was built without it.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
