### PR TITLE
Update TenantEntryCache workload refresh to handle fault injection

### DIFF
--- a/fdbserver/workloads/TenantEntryCacheWorkload.actor.cpp
+++ b/fdbserver/workloads/TenantEntryCacheWorkload.actor.cpp
@@ -219,14 +219,25 @@ struct TenantEntryCacheWorkload : TestWorkload {
 		ASSERT_EQ(cache->numRefreshByInit(), 1);
 		ASSERT_GE(cache->numCacheRefreshes(), 1);
 
-		int refreshWait =
-		    CLIENT_KNOBS->TENANT_ENTRY_CACHE_LIST_REFRESH_INTERVAL * 10; // initial delay + multiple refresh runs
-		wait(delay(refreshWait));
+		// Fault injection may cause delays in cluster recovery/availability, spin a loop to let cache refresh to
+		// trigger with a max wait of 5 mins; timed_out error is thrown if cache refresh isn't triggered.
 
-		// InitRefresh + multiple timer based invocations (at least 2 invocations of cache->refresh())
-		ASSERT_GE(cache->numCacheRefreshes(), 2);
+		state int64_t startTime = now();
+		state int64_t waitUntill = startTime + 300; // 5 mins max wait
+		loop {
+			// InitRefresh + multiple timer based invocations (at least 2 invocations of cache->refresh())
+			if (cache->numCacheRefreshes() >= 2) {
+				break;
+			}
 
-		TraceEvent("TestCacheRefreshEnd");
+			if (now() > waitUntill) {
+				throw timed_out();
+			}
+
+			wait(delay(CLIENT_KNOBS->TENANT_ENTRY_CACHE_LIST_REFRESH_INTERVAL));
+		}
+
+		TraceEvent("TestCacheRefreshEnd").detail("Elapsed", now() - startTime);
 		return Void();
 	}
 

--- a/fdbserver/workloads/TenantEntryCacheWorkload.actor.cpp
+++ b/fdbserver/workloads/TenantEntryCacheWorkload.actor.cpp
@@ -234,10 +234,11 @@ struct TenantEntryCacheWorkload : TestWorkload {
 				throw timed_out();
 			}
 
+			TraceEvent("TestCacheRefreshWait").detail("Elapsed", now() - startTime);
 			wait(delay(CLIENT_KNOBS->TENANT_ENTRY_CACHE_LIST_REFRESH_INTERVAL));
 		}
 
-		TraceEvent("TestCacheRefreshEnd").detail("Elapsed", now() - startTime);
+		TraceEvent("TestCacheRefreshEnd").detail("ElapsedTotal", now() - startTime);
 		return Void();
 	}
 


### PR DESCRIPTION
Description

Patch update TenantEntryCache::testCacheRefresh to better handle fault injection causing longer cluster recovery/availability delays. The test is modified to loop for a threshold time waiting for next round of tenantCache refresh cycle to happen. Otherwise throws 'timed_out' error.

Testing

devRunCorrectness - 100K (inprogress)

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
