### PR TITLE
Ensure nullptr is not passed to memcpy

### DIFF
--- a/fdbclient/FileBackupAgent.actor.cpp
+++ b/fdbclient/FileBackupAgent.actor.cpp
@@ -682,9 +682,11 @@ struct EncryptedRangeFileWriter : public IRangeFileWriter {
 	}
 
 	static void copyToBuffer(EncryptedRangeFileWriter* self, const void* src, size_t size) {
-		std::memcpy(self->wPtr, src, size);
-		self->wPtr += size;
-		ASSERT(currentBufferSize(self) <= self->blockSize);
+		if (src) {
+			std::memcpy(self->wPtr, src, size);
+			self->wPtr += size;
+			ASSERT(currentBufferSize(self) <= self->blockSize);
+		}
 	}
 
 	static void appendStringRefWithLenToBuffer(EncryptedRangeFileWriter* self, StringRef* s) {

--- a/fdbclient/FileBackupAgent.actor.cpp
+++ b/fdbclient/FileBackupAgent.actor.cpp
@@ -682,7 +682,7 @@ struct EncryptedRangeFileWriter : public IRangeFileWriter {
 	}
 
 	static void copyToBuffer(EncryptedRangeFileWriter* self, const void* src, size_t size) {
-		if (src) {
+		if (size > 0) {
 			std::memcpy(self->wPtr, src, size);
 			self->wPtr += size;
 			ASSERT(currentBufferSize(self) <= self->blockSize);


### PR DESCRIPTION
Fixes UBSAN failures

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
