### PR TITLE
Fix trace event error

### DIFF
--- a/fdbrpc/sim2.actor.cpp
+++ b/fdbrpc/sim2.actor.cpp
@@ -1828,7 +1828,7 @@ public:
 		                   (kt == RebootAndDelete) || (kt == RebootProcessAndDelete))) {
 
 			if (!canKillMachineWithBlobWorkers(machineId, kt, &kt)) {
-				TraceEvent("canKillMachineWithBlobWorkers")
+				TraceEvent("CanKillMachineWithBlobWorkers")
 				    .detail("MachineId", machineId)
 				    .detail("KillType", kt)
 				    .detail("OrigKillType", ktOrig);


### PR DESCRIPTION
Trace event name must be capitalized. This PR is to fix this error:
Trace event detail Type `canKillMachineWithBlobWorkers' is invalid 

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
