### PR TITLE
Add tenant support for database switching

### DIFF
--- a/tests/slow/DifferentClustersSameRV.toml
+++ b/tests/slow/DifferentClustersSameRV.toml
@@ -1,6 +1,5 @@
 [configuration]
 extraDatabaseMode = 'Single'
-allowDefaultTenant = false
 
 [[test]]
 testTitle = 'DifferentClustersSameRV'


### PR DESCRIPTION
When updating watches after a database switch, look up the tenant again to get the ID on the new cluster. Update the switching test to set up tenants properly.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
