### PR TITLE
LiteralStringRef removal

### DIFF
--- a/fdbcli/BlobKeyCommand.actor.cpp
+++ b/fdbcli/BlobKeyCommand.actor.cpp
@@ -174,7 +174,7 @@ ACTOR Future<bool> blobKeyCommandActor(Database localDb,
 		version = v;
 	}
 
-	if (key >= LiteralStringRef("\xff")) {
+	if (key >= "\xff"_sr) {
 		fmt::print("No blob history for system keyspace\n", key.printable());
 		return false;
 	} else {

--- a/fdbclient/BlobGranuleFiles.cpp
+++ b/fdbclient/BlobGranuleFiles.cpp
@@ -1672,23 +1672,13 @@ TEST_CASE("/blobgranule/files/applyDelta") {
 	printf("Testing blob granule delta applying\n");
 	Arena a;
 
-	// do this 2 phase arena creation of string refs instead of LiteralStringRef because there is no char* StringRef
-	// constructor, and valgrind might complain if the stringref data isn't in the arena
-	std::string sk_a = "A";
-	std::string sk_ab = "AB";
-	std::string sk_b = "B";
-	std::string sk_c = "C";
-	std::string sk_z = "Z";
-	std::string sval1 = "1";
-	std::string sval2 = "2";
-
-	StringRef k_a = StringRef(a, sk_a);
-	StringRef k_ab = StringRef(a, sk_ab);
-	StringRef k_b = StringRef(a, sk_b);
-	StringRef k_c = StringRef(a, sk_c);
-	StringRef k_z = StringRef(a, sk_z);
-	StringRef val1 = StringRef(a, sval1);
-	StringRef val2 = StringRef(a, sval2);
+	StringRef k_a = StringRef(a, "A"_sr);
+	StringRef k_ab = StringRef(a, "AB"_sr);
+	StringRef k_b = StringRef(a, "B"_sr);
+	StringRef k_c = StringRef(a, "C"_sr);
+	StringRef k_z = StringRef(a, "Z"_sr);
+	StringRef val1 = StringRef(a, "1"_sr);
+	StringRef val2 = StringRef(a, "2"_sr);
 
 	std::map<KeyRef, ValueRef> data;
 	data.insert({ k_a, val1 });

--- a/fdbclient/DatabaseBackupAgent.actor.cpp
+++ b/fdbclient/DatabaseBackupAgent.actor.cpp
@@ -79,9 +79,9 @@ public:
 	DRConfig(Reference<Task> task)
 	  : DRConfig(BinaryReader::fromStringRef<UID>(task->params[BackupAgentBase::keyConfigLogUid], Unversioned())) {}
 
-	KeyBackedBinaryValue<int64_t> rangeBytesWritten() { return configSpace.pack(LiteralStringRef(__FUNCTION__)); }
+	KeyBackedBinaryValue<int64_t> rangeBytesWritten() { return configSpace.pack(__FUNCTION__sr); }
 
-	KeyBackedBinaryValue<int64_t> logBytesWritten() { return configSpace.pack(LiteralStringRef(__FUNCTION__)); }
+	KeyBackedBinaryValue<int64_t> logBytesWritten() { return configSpace.pack(__FUNCTION__sr); }
 
 	void clear(Reference<ReadYourWritesTransaction> tr) { tr->clear(configSpace.range()); }
 
@@ -136,7 +136,7 @@ struct BackupRangeTaskFunc : TaskFuncBase {
 	static constexpr uint32_t version = 1;
 
 	static struct {
-		static TaskParam<int64_t> bytesWritten() { return LiteralStringRef(__FUNCTION__); }
+		static TaskParam<int64_t> bytesWritten() { return __FUNCTION__sr; }
 	} Params;
 
 	static const Key keyAddBackupRangeTasks;
@@ -704,7 +704,7 @@ struct CopyLogRangeTaskFunc : TaskFuncBase {
 	static constexpr uint32_t version = 1;
 
 	static struct {
-		static TaskParam<int64_t> bytesWritten() { return LiteralStringRef(__FUNCTION__); }
+		static TaskParam<int64_t> bytesWritten() { return __FUNCTION__sr; }
 	} Params;
 
 	static const Key keyNextBeginVersion;
@@ -1455,7 +1455,7 @@ struct OldCopyLogRangeTaskFunc : TaskFuncBase {
 	static constexpr uint32_t version = 1;
 
 	static struct {
-		static TaskParam<int64_t> bytesWritten() { return LiteralStringRef(__FUNCTION__); }
+		static TaskParam<int64_t> bytesWritten() { return __FUNCTION__sr; }
 	} Params;
 
 	static const Key keyNextBeginVersion;

--- a/fdbclient/FileBackupAgent.actor.cpp
+++ b/fdbclient/FileBackupAgent.actor.cpp
@@ -157,41 +157,37 @@ public:
 	RestoreConfig(UID uid = UID()) : KeyBackedConfig(fileRestorePrefixRange.begin, uid) {}
 	RestoreConfig(Reference<Task> task) : KeyBackedConfig(fileRestorePrefixRange.begin, task) {}
 
-	KeyBackedProperty<ERestoreState> stateEnum() { return configSpace.pack(LiteralStringRef(__FUNCTION__)); }
+	KeyBackedProperty<ERestoreState> stateEnum() { return configSpace.pack(__FUNCTION__sr); }
 	Future<StringRef> stateText(Reference<ReadYourWritesTransaction> tr) {
 		return map(stateEnum().getD(tr),
 		           [](ERestoreState s) -> StringRef { return FileBackupAgent::restoreStateText(s); });
 	}
-	KeyBackedProperty<Key> addPrefix() { return configSpace.pack(LiteralStringRef(__FUNCTION__)); }
-	KeyBackedProperty<Key> removePrefix() { return configSpace.pack(LiteralStringRef(__FUNCTION__)); }
-	KeyBackedProperty<bool> onlyApplyMutationLogs() { return configSpace.pack(LiteralStringRef(__FUNCTION__)); }
-	KeyBackedProperty<bool> inconsistentSnapshotOnly() { return configSpace.pack(LiteralStringRef(__FUNCTION__)); }
+	KeyBackedProperty<Key> addPrefix() { return configSpace.pack(__FUNCTION__sr); }
+	KeyBackedProperty<Key> removePrefix() { return configSpace.pack(__FUNCTION__sr); }
+	KeyBackedProperty<bool> onlyApplyMutationLogs() { return configSpace.pack(__FUNCTION__sr); }
+	KeyBackedProperty<bool> inconsistentSnapshotOnly() { return configSpace.pack(__FUNCTION__sr); }
 	// XXX: Remove restoreRange() once it is safe to remove. It has been changed to restoreRanges
-	KeyBackedProperty<KeyRange> restoreRange() { return configSpace.pack(LiteralStringRef(__FUNCTION__)); }
-	KeyBackedProperty<std::vector<KeyRange>> restoreRanges() {
-		return configSpace.pack(LiteralStringRef(__FUNCTION__));
-	}
-	KeyBackedProperty<Key> batchFuture() { return configSpace.pack(LiteralStringRef(__FUNCTION__)); }
-	KeyBackedProperty<Version> beginVersion() { return configSpace.pack(LiteralStringRef(__FUNCTION__)); }
-	KeyBackedProperty<Version> restoreVersion() { return configSpace.pack(LiteralStringRef(__FUNCTION__)); }
-	KeyBackedProperty<Version> firstConsistentVersion() { return configSpace.pack(LiteralStringRef(__FUNCTION__)); }
+	KeyBackedProperty<KeyRange> restoreRange() { return configSpace.pack(__FUNCTION__sr); }
+	KeyBackedProperty<std::vector<KeyRange>> restoreRanges() { return configSpace.pack(__FUNCTION__sr); }
+	KeyBackedProperty<Key> batchFuture() { return configSpace.pack(__FUNCTION__sr); }
+	KeyBackedProperty<Version> beginVersion() { return configSpace.pack(__FUNCTION__sr); }
+	KeyBackedProperty<Version> restoreVersion() { return configSpace.pack(__FUNCTION__sr); }
+	KeyBackedProperty<Version> firstConsistentVersion() { return configSpace.pack(__FUNCTION__sr); }
 
-	KeyBackedProperty<Reference<IBackupContainer>> sourceContainer() {
-		return configSpace.pack(LiteralStringRef(__FUNCTION__));
-	}
+	KeyBackedProperty<Reference<IBackupContainer>> sourceContainer() { return configSpace.pack(__FUNCTION__sr); }
 	// Get the source container as a bare URL, without creating a container instance
 	KeyBackedProperty<Value> sourceContainerURL() { return configSpace.pack("sourceContainer"_sr); }
 
 	// Total bytes written by all log and range restore tasks.
-	KeyBackedBinaryValue<int64_t> bytesWritten() { return configSpace.pack(LiteralStringRef(__FUNCTION__)); }
+	KeyBackedBinaryValue<int64_t> bytesWritten() { return configSpace.pack(__FUNCTION__sr); }
 	// File blocks that have had tasks created for them by the Dispatch task
-	KeyBackedBinaryValue<int64_t> filesBlocksDispatched() { return configSpace.pack(LiteralStringRef(__FUNCTION__)); }
+	KeyBackedBinaryValue<int64_t> filesBlocksDispatched() { return configSpace.pack(__FUNCTION__sr); }
 	// File blocks whose tasks have finished
-	KeyBackedBinaryValue<int64_t> fileBlocksFinished() { return configSpace.pack(LiteralStringRef(__FUNCTION__)); }
+	KeyBackedBinaryValue<int64_t> fileBlocksFinished() { return configSpace.pack(__FUNCTION__sr); }
 	// Total number of files in the fileMap
-	KeyBackedBinaryValue<int64_t> fileCount() { return configSpace.pack(LiteralStringRef(__FUNCTION__)); }
+	KeyBackedBinaryValue<int64_t> fileCount() { return configSpace.pack(__FUNCTION__sr); }
 	// Total number of file blocks in the fileMap
-	KeyBackedBinaryValue<int64_t> fileBlockCount() { return configSpace.pack(LiteralStringRef(__FUNCTION__)); }
+	KeyBackedBinaryValue<int64_t> fileBlockCount() { return configSpace.pack(__FUNCTION__sr); }
 
 	Future<std::vector<KeyRange>> getRestoreRangesOrDefault(Reference<ReadYourWritesTransaction> tr) {
 		return getRestoreRangesOrDefault_impl(this, tr);
@@ -234,7 +230,7 @@ public:
 	};
 
 	typedef KeyBackedSet<RestoreFile> FileSetT;
-	FileSetT fileSet() { return configSpace.pack(LiteralStringRef(__FUNCTION__)); }
+	FileSetT fileSet() { return configSpace.pack(__FUNCTION__sr); }
 
 	Future<bool> isRunnable(Reference<ReadYourWritesTransaction> tr) {
 		return map(stateEnum().getD(tr), [](ERestoreState s) -> bool {
@@ -1531,9 +1527,9 @@ struct BackupRangeTaskFunc : BackupTaskFuncBase {
 	static constexpr uint32_t version = 1;
 
 	static struct {
-		static TaskParam<Key> beginKey() { return LiteralStringRef(__FUNCTION__); }
-		static TaskParam<Key> endKey() { return LiteralStringRef(__FUNCTION__); }
-		static TaskParam<bool> addBackupRangeTasks() { return LiteralStringRef(__FUNCTION__); }
+		static TaskParam<Key> beginKey() { return __FUNCTION__sr; }
+		static TaskParam<Key> endKey() { return __FUNCTION__sr; }
+		static TaskParam<bool> addBackupRangeTasks() { return __FUNCTION__sr; }
 	} Params;
 
 	std::string toString(Reference<Task> task) const override {
@@ -1897,11 +1893,11 @@ struct BackupSnapshotDispatchTask : BackupTaskFuncBase {
 
 	static struct {
 		// Set by Execute, used by Finish
-		static TaskParam<int64_t> shardsBehind() { return LiteralStringRef(__FUNCTION__); }
+		static TaskParam<int64_t> shardsBehind() { return __FUNCTION__sr; }
 		// Set by Execute, used by Finish
-		static TaskParam<bool> snapshotFinished() { return LiteralStringRef(__FUNCTION__); }
+		static TaskParam<bool> snapshotFinished() { return __FUNCTION__sr; }
 		// Set by Execute, used by Finish
-		static TaskParam<Version> nextDispatchVersion() { return LiteralStringRef(__FUNCTION__); }
+		static TaskParam<Version> nextDispatchVersion() { return __FUNCTION__sr; }
 	} Params;
 
 	StringRef getName() const override { return name; };
@@ -2469,10 +2465,10 @@ struct BackupLogRangeTaskFunc : BackupTaskFuncBase {
 	static constexpr uint32_t version = 1;
 
 	static struct {
-		static TaskParam<bool> addBackupLogRangeTasks() { return LiteralStringRef(__FUNCTION__); }
-		static TaskParam<int64_t> fileSize() { return LiteralStringRef(__FUNCTION__); }
-		static TaskParam<Version> beginVersion() { return LiteralStringRef(__FUNCTION__); }
-		static TaskParam<Version> endVersion() { return LiteralStringRef(__FUNCTION__); }
+		static TaskParam<bool> addBackupLogRangeTasks() { return __FUNCTION__sr; }
+		static TaskParam<int64_t> fileSize() { return __FUNCTION__sr; }
+		static TaskParam<Version> beginVersion() { return __FUNCTION__sr; }
+		static TaskParam<Version> endVersion() { return __FUNCTION__sr; }
 	} Params;
 
 	StringRef getName() const override { return name; };
@@ -2710,9 +2706,9 @@ struct EraseLogRangeTaskFunc : BackupTaskFuncBase {
 	StringRef getName() const override { return name; };
 
 	static struct {
-		static TaskParam<Version> beginVersion() { return LiteralStringRef(__FUNCTION__); }
-		static TaskParam<Version> endVersion() { return LiteralStringRef(__FUNCTION__); }
-		static TaskParam<Key> destUidValue() { return LiteralStringRef(__FUNCTION__); }
+		static TaskParam<Version> beginVersion() { return __FUNCTION__sr; }
+		static TaskParam<Version> endVersion() { return __FUNCTION__sr; }
+		static TaskParam<Key> destUidValue() { return __FUNCTION__sr; }
 	} Params;
 
 	ACTOR static Future<Key> addTask(Reference<ReadYourWritesTransaction> tr,
@@ -2784,8 +2780,8 @@ struct BackupLogsDispatchTask : BackupTaskFuncBase {
 	static constexpr uint32_t version = 1;
 
 	static struct {
-		static TaskParam<Version> prevBeginVersion() { return LiteralStringRef(__FUNCTION__); }
-		static TaskParam<Version> beginVersion() { return LiteralStringRef(__FUNCTION__); }
+		static TaskParam<Version> prevBeginVersion() { return __FUNCTION__sr; }
+		static TaskParam<Version> beginVersion() { return __FUNCTION__sr; }
 	} Params;
 
 	ACTOR static Future<Void> _finish(Reference<ReadYourWritesTransaction> tr,
@@ -3013,7 +3009,7 @@ struct BackupSnapshotManifest : BackupTaskFuncBase {
 	static StringRef name;
 	static constexpr uint32_t version = 1;
 	static struct {
-		static TaskParam<Version> endVersion() { return LiteralStringRef(__FUNCTION__); }
+		static TaskParam<Version> endVersion() { return __FUNCTION__sr; }
 	} Params;
 
 	ACTOR static Future<Void> _execute(Database cx,
@@ -3212,7 +3208,7 @@ struct StartFullBackupTaskFunc : BackupTaskFuncBase {
 	static constexpr uint32_t version = 1;
 
 	static struct {
-		static TaskParam<Version> beginVersion() { return LiteralStringRef(__FUNCTION__); }
+		static TaskParam<Version> beginVersion() { return __FUNCTION__sr; }
 	} Params;
 
 	ACTOR static Future<Void> _execute(Database cx,
@@ -3455,9 +3451,9 @@ REGISTER_TASKFUNC(RestoreCompleteTaskFunc);
 
 struct RestoreFileTaskFuncBase : RestoreTaskFuncBase {
 	struct InputParams {
-		static TaskParam<RestoreFile> inputFile() { return LiteralStringRef(__FUNCTION__); }
-		static TaskParam<int64_t> readOffset() { return LiteralStringRef(__FUNCTION__); }
-		static TaskParam<int64_t> readLen() { return LiteralStringRef(__FUNCTION__); }
+		static TaskParam<RestoreFile> inputFile() { return __FUNCTION__sr; }
+		static TaskParam<int64_t> readOffset() { return __FUNCTION__sr; }
+		static TaskParam<int64_t> readLen() { return __FUNCTION__sr; }
 	} Params;
 
 	std::string toString(Reference<Task> task) const override {
@@ -3472,8 +3468,8 @@ struct RestoreRangeTaskFunc : RestoreFileTaskFuncBase {
 	static struct : InputParams {
 		// The range of data that the (possibly empty) data represented, which is set if it intersects the target
 		// restore range
-		static TaskParam<KeyRange> originalFileRange() { return LiteralStringRef(__FUNCTION__); }
-		static TaskParam<std::vector<KeyRange>> originalFileRanges() { return LiteralStringRef(__FUNCTION__); }
+		static TaskParam<KeyRange> originalFileRange() { return __FUNCTION__sr; }
+		static TaskParam<std::vector<KeyRange>> originalFileRanges() { return __FUNCTION__sr; }
 
 		static std::vector<KeyRange> getOriginalFileRanges(Reference<Task> task) {
 			if (originalFileRanges().exists(task)) {
@@ -4069,11 +4065,11 @@ struct RestoreDispatchTaskFunc : RestoreTaskFuncBase {
 	StringRef getName() const override { return name; };
 
 	static struct {
-		static TaskParam<Version> beginVersion() { return LiteralStringRef(__FUNCTION__); }
-		static TaskParam<std::string> beginFile() { return LiteralStringRef(__FUNCTION__); }
-		static TaskParam<int64_t> beginBlock() { return LiteralStringRef(__FUNCTION__); }
-		static TaskParam<int64_t> batchSize() { return LiteralStringRef(__FUNCTION__); }
-		static TaskParam<int64_t> remainingInBatch() { return LiteralStringRef(__FUNCTION__); }
+		static TaskParam<Version> beginVersion() { return __FUNCTION__sr; }
+		static TaskParam<std::string> beginFile() { return __FUNCTION__sr; }
+		static TaskParam<int64_t> beginBlock() { return __FUNCTION__sr; }
+		static TaskParam<int64_t> batchSize() { return __FUNCTION__sr; }
+		static TaskParam<int64_t> remainingInBatch() { return __FUNCTION__sr; }
 	} Params;
 
 	ACTOR static Future<Void> _finish(Reference<ReadYourWritesTransaction> tr,
@@ -4542,7 +4538,7 @@ struct StartFullRestoreTaskFunc : RestoreTaskFuncBase {
 	static constexpr uint32_t version = 1;
 
 	static struct {
-		static TaskParam<Version> firstVersion() { return LiteralStringRef(__FUNCTION__); }
+		static TaskParam<Version> firstVersion() { return __FUNCTION__sr; }
 	} Params;
 
 	// Find all files needed for the restore and save them in the RestoreConfig for the task.

--- a/fdbclient/MonitorLeader.actor.cpp
+++ b/fdbclient/MonitorLeader.actor.cpp
@@ -376,7 +376,7 @@ TEST_CASE("/fdbclient/MonitorLeader/parseConnectionString/fuzz") {
 				output += "#";
 				int charCount = deterministicRandom()->randomInt(0, 20);
 				for (int i = 0; i < charCount; i++) {
-					output += deterministicRandom()->randomChoice(LiteralStringRef("asdfzxcv123345:!@#$#$&()<\"\' \t"));
+					output += deterministicRandom()->randomChoice("asdfzxcv123345:!@#$#$&()<\"\' \t"_sr);
 				}
 				output += deterministicRandom()->randomChoice("\n\r"_sr);
 			}

--- a/fdbclient/ReadYourWrites.actor.cpp
+++ b/fdbclient/ReadYourWrites.actor.cpp
@@ -459,7 +459,7 @@ public:
 
 		if (!it.is_unreadable() && !it.is_unknown_range() && key.offset > 1) {
 			*readThroughEnd = true;
-			key.setKey(maxKey); // maxKey is a KeyRef, but points to a LiteralStringRef. TODO: how can we ASSERT this?
+			key.setKey(maxKey); // maxKey is a KeyRef, but points to a literal. TODO: how can we ASSERT this?
 			key.offset = 1;
 			return;
 		}

--- a/fdbclient/S3BlobStore.actor.cpp
+++ b/fdbclient/S3BlobStore.actor.cpp
@@ -98,7 +98,7 @@ S3BlobStoreEndpoint::BlobKnobs::BlobKnobs() {
 
 bool S3BlobStoreEndpoint::BlobKnobs::set(StringRef name, int value) {
 #define TRY_PARAM(n, sn)                                                                                               \
-	if (name == LiteralStringRef(#n) || name == LiteralStringRef(#sn)) {                                               \
+	if (name == #n || name == #sn) {                                                                                   \
 		n = value;                                                                                                     \
 		return true;                                                                                                   \
 	}

--- a/fdbclient/Schemas.cpp
+++ b/fdbclient/Schemas.cpp
@@ -602,7 +602,7 @@ const KeyRef JSONSchemas::statusSchema = R"statusSchema(
          }
       ],
 )statusSchema"
-                                                          R"statusSchema(
+                                         R"statusSchema(
       "recovery_state":{
          "seconds_since_last_recovered":1,
          "required_resolvers":1,

--- a/fdbclient/Schemas.cpp
+++ b/fdbclient/Schemas.cpp
@@ -21,7 +21,7 @@
 #include "fdbclient/Schemas.h"
 
 // NOTE: also change mr-status-json-schemas.rst.inc
-const KeyRef JSONSchemas::statusSchema = LiteralStringRef(R"statusSchema(
+const KeyRef JSONSchemas::statusSchema = R"statusSchema(
 {
    "cluster":{
       "storage_wiggler": {
@@ -1005,9 +1005,9 @@ const KeyRef JSONSchemas::statusSchema = LiteralStringRef(R"statusSchema(
          "up_to_date":true
       }
    }
-})statusSchema");
+})statusSchema"_sr;
 
-const KeyRef JSONSchemas::clusterConfigurationSchema = LiteralStringRef(R"configSchema(
+const KeyRef JSONSchemas::clusterConfigurationSchema = R"configSchema(
 {
     "create":{
     "$enum":[
@@ -1077,9 +1077,9 @@ const KeyRef JSONSchemas::clusterConfigurationSchema = LiteralStringRef(R"config
     "auto_logs":3,
     "commit_proxies":5,
     "grv_proxies":1
-})configSchema");
+})configSchema"_sr;
 
-const KeyRef JSONSchemas::latencyBandConfigurationSchema = LiteralStringRef(R"configSchema(
+const KeyRef JSONSchemas::latencyBandConfigurationSchema = R"configSchema(
 {
     "get_read_version":{
         "bands":[
@@ -1099,30 +1099,30 @@ const KeyRef JSONSchemas::latencyBandConfigurationSchema = LiteralStringRef(R"co
         ],
         "max_commit_bytes":0
     }
-})configSchema");
+})configSchema"_sr;
 
-const KeyRef JSONSchemas::dataDistributionStatsSchema = LiteralStringRef(R"""(
+const KeyRef JSONSchemas::dataDistributionStatsSchema = R"""(
 {
   "shard_bytes": 1947000
 }
-)""");
+)"""_sr;
 
-const KeyRef JSONSchemas::logHealthSchema = LiteralStringRef(R"""(
+const KeyRef JSONSchemas::logHealthSchema = R"""(
 {
   "log_queue": 156
 }
-)""");
+)"""_sr;
 
-const KeyRef JSONSchemas::storageHealthSchema = LiteralStringRef(R"""(
+const KeyRef JSONSchemas::storageHealthSchema = R"""(
 {
   "cpu_usage": 3.28629447047675,
   "disk_usage": 0.19997897369207954,
   "storage_durability_lag": 5050809,
   "storage_queue": 2030
 }
-)""");
+)"""_sr;
 
-const KeyRef JSONSchemas::aggregateHealthSchema = LiteralStringRef(R"""(
+const KeyRef JSONSchemas::aggregateHealthSchema = R"""(
 {
   "batch_limited": false,
   "limiting_storage_durability_lag": 5050809,
@@ -1132,12 +1132,12 @@ const KeyRef JSONSchemas::aggregateHealthSchema = LiteralStringRef(R"""(
   "worst_storage_queue": 2030,
   "worst_log_queue": 156
 }
-)""");
+)"""_sr;
 
-const KeyRef JSONSchemas::managementApiErrorSchema = LiteralStringRef(R"""(
+const KeyRef JSONSchemas::managementApiErrorSchema = R"""(
 {
    "retriable": false,
    "command": "exclude",
    "message": "The reason of the error"
 }
-)""");
+)"""_sr;

--- a/fdbclient/include/fdbclient/BackupAgent.actor.h
+++ b/fdbclient/include/fdbclient/BackupAgent.actor.h
@@ -143,7 +143,7 @@ public:
 		futureBucket = std::move(r.futureBucket);
 	}
 
-	KeyBackedProperty<Key> lastBackupTimestamp() { return config.pack(LiteralStringRef(__FUNCTION__)); }
+	KeyBackedProperty<Key> lastBackupTimestamp() { return config.pack(__FUNCTION__sr); }
 
 	Future<Void> run(Database cx, double pollDelay, int maxConcurrentTasks) {
 		return taskBucket->run(cx, futureBucket, std::make_shared<double const>(pollDelay), maxConcurrentTasks);
@@ -633,7 +633,7 @@ static inline Future<std::vector<KeyBackedTag>> getAllBackupTags(Reference<ReadY
 class KeyBackedConfig {
 public:
 	static struct {
-		static TaskParam<UID> uid() { return LiteralStringRef(__FUNCTION__); }
+		static TaskParam<UID> uid() { return __FUNCTION__sr; }
 	} TaskParams;
 
 	KeyBackedConfig(StringRef prefix, UID uid = UID())
@@ -666,7 +666,7 @@ public:
 		});
 	}
 
-	KeyBackedProperty<std::string> tag() { return configSpace.pack(LiteralStringRef(__FUNCTION__)); }
+	KeyBackedProperty<std::string> tag() { return configSpace.pack(__FUNCTION__sr); }
 
 	UID getUid() { return uid; }
 
@@ -675,12 +675,10 @@ public:
 	void clear(Reference<ReadYourWritesTransaction> tr) { tr->clear(configSpace.range()); }
 
 	// lastError is a pair of error message and timestamp expressed as an int64_t
-	KeyBackedProperty<std::pair<std::string, Version>> lastError() {
-		return configSpace.pack(LiteralStringRef(__FUNCTION__));
-	}
+	KeyBackedProperty<std::pair<std::string, Version>> lastError() { return configSpace.pack(__FUNCTION__sr); }
 
 	KeyBackedMap<int64_t, std::pair<std::string, Version>> lastErrorPerType() {
-		return configSpace.pack(LiteralStringRef(__FUNCTION__));
+		return configSpace.pack(__FUNCTION__sr);
 	}
 
 	// Updates the error per type map and the last error property
@@ -769,47 +767,41 @@ public:
 
 	// Map of range end boundaries to info about the backup file written for that range.
 	typedef KeyBackedMap<Key, RangeSlice> RangeFileMapT;
-	RangeFileMapT snapshotRangeFileMap() { return configSpace.pack(LiteralStringRef(__FUNCTION__)); }
+	RangeFileMapT snapshotRangeFileMap() { return configSpace.pack(__FUNCTION__sr); }
 
 	// Number of kv range files that were both committed to persistent storage AND inserted into
 	// the snapshotRangeFileMap.  Note that since insertions could replace 1 or more existing
 	// map entries this is not necessarily the number of entries currently in the map.
 	// This value exists to help with sizing of kv range folders for BackupContainers that
 	// require it.
-	KeyBackedBinaryValue<int64_t> snapshotRangeFileCount() { return configSpace.pack(LiteralStringRef(__FUNCTION__)); }
+	KeyBackedBinaryValue<int64_t> snapshotRangeFileCount() { return configSpace.pack(__FUNCTION__sr); }
 
 	// Coalesced set of ranges already dispatched for writing.
 	typedef KeyBackedMap<Key, bool> RangeDispatchMapT;
-	RangeDispatchMapT snapshotRangeDispatchMap() { return configSpace.pack(LiteralStringRef(__FUNCTION__)); }
+	RangeDispatchMapT snapshotRangeDispatchMap() { return configSpace.pack(__FUNCTION__sr); }
 
 	// Interval to use for the first (initial) snapshot.
-	KeyBackedProperty<int64_t> initialSnapshotIntervalSeconds() {
-		return configSpace.pack(LiteralStringRef(__FUNCTION__));
-	}
+	KeyBackedProperty<int64_t> initialSnapshotIntervalSeconds() { return configSpace.pack(__FUNCTION__sr); }
 
 	// Interval to use for determining the target end version for new snapshots
-	KeyBackedProperty<int64_t> snapshotIntervalSeconds() { return configSpace.pack(LiteralStringRef(__FUNCTION__)); }
+	KeyBackedProperty<int64_t> snapshotIntervalSeconds() { return configSpace.pack(__FUNCTION__sr); }
 
 	// When the current snapshot began
-	KeyBackedProperty<Version> snapshotBeginVersion() { return configSpace.pack(LiteralStringRef(__FUNCTION__)); }
+	KeyBackedProperty<Version> snapshotBeginVersion() { return configSpace.pack(__FUNCTION__sr); }
 
 	// When the current snapshot is desired to end.
 	// This can be changed at runtime to speed up or slow down a snapshot
-	KeyBackedProperty<Version> snapshotTargetEndVersion() { return configSpace.pack(LiteralStringRef(__FUNCTION__)); }
+	KeyBackedProperty<Version> snapshotTargetEndVersion() { return configSpace.pack(__FUNCTION__sr); }
 
-	KeyBackedProperty<int64_t> snapshotBatchSize() { return configSpace.pack(LiteralStringRef(__FUNCTION__)); }
+	KeyBackedProperty<int64_t> snapshotBatchSize() { return configSpace.pack(__FUNCTION__sr); }
 
-	KeyBackedProperty<Key> snapshotBatchFuture() { return configSpace.pack(LiteralStringRef(__FUNCTION__)); }
+	KeyBackedProperty<Key> snapshotBatchFuture() { return configSpace.pack(__FUNCTION__sr); }
 
-	KeyBackedProperty<Key> snapshotBatchDispatchDoneKey() { return configSpace.pack(LiteralStringRef(__FUNCTION__)); }
+	KeyBackedProperty<Key> snapshotBatchDispatchDoneKey() { return configSpace.pack(__FUNCTION__sr); }
 
-	KeyBackedProperty<int64_t> snapshotDispatchLastShardsBehind() {
-		return configSpace.pack(LiteralStringRef(__FUNCTION__));
-	}
+	KeyBackedProperty<int64_t> snapshotDispatchLastShardsBehind() { return configSpace.pack(__FUNCTION__sr); }
 
-	KeyBackedProperty<Version> snapshotDispatchLastVersion() {
-		return configSpace.pack(LiteralStringRef(__FUNCTION__));
-	}
+	KeyBackedProperty<Version> snapshotDispatchLastVersion() { return configSpace.pack(__FUNCTION__sr); }
 
 	Future<Void> initNewSnapshot(Reference<ReadYourWritesTransaction> tr, int64_t intervalSeconds = -1) {
 		BackupConfig& copy = *this; // Capture this by value instead of this ptr
@@ -843,56 +835,50 @@ public:
 		});
 	}
 
-	KeyBackedBinaryValue<int64_t> rangeBytesWritten() { return configSpace.pack(LiteralStringRef(__FUNCTION__)); }
+	KeyBackedBinaryValue<int64_t> rangeBytesWritten() { return configSpace.pack(__FUNCTION__sr); }
 
-	KeyBackedBinaryValue<int64_t> logBytesWritten() { return configSpace.pack(LiteralStringRef(__FUNCTION__)); }
+	KeyBackedBinaryValue<int64_t> logBytesWritten() { return configSpace.pack(__FUNCTION__sr); }
 
-	KeyBackedProperty<EBackupState> stateEnum() { return configSpace.pack(LiteralStringRef(__FUNCTION__)); }
+	KeyBackedProperty<EBackupState> stateEnum() { return configSpace.pack(__FUNCTION__sr); }
 
-	KeyBackedProperty<Reference<IBackupContainer>> backupContainer() {
-		return configSpace.pack(LiteralStringRef(__FUNCTION__));
-	}
+	KeyBackedProperty<Reference<IBackupContainer>> backupContainer() { return configSpace.pack(__FUNCTION__sr); }
 
 	// Set to true when all backup workers for saving mutation logs have been started.
-	KeyBackedProperty<bool> allWorkerStarted() { return configSpace.pack(LiteralStringRef(__FUNCTION__)); }
+	KeyBackedProperty<bool> allWorkerStarted() { return configSpace.pack(__FUNCTION__sr); }
 
 	// Each backup worker adds its (epoch, tag.id) to this property.
 	KeyBackedProperty<std::vector<std::pair<int64_t, int64_t>>> startedBackupWorkers() {
-		return configSpace.pack(LiteralStringRef(__FUNCTION__));
+		return configSpace.pack(__FUNCTION__sr);
 	}
 
 	// Set to true if backup worker is enabled.
-	KeyBackedProperty<bool> backupWorkerEnabled() { return configSpace.pack(LiteralStringRef(__FUNCTION__)); }
+	KeyBackedProperty<bool> backupWorkerEnabled() { return configSpace.pack(__FUNCTION__sr); }
 
 	// Set to true if partitioned log is enabled (only useful if backup worker is also enabled).
-	KeyBackedProperty<bool> partitionedLogEnabled() { return configSpace.pack(LiteralStringRef(__FUNCTION__)); }
+	KeyBackedProperty<bool> partitionedLogEnabled() { return configSpace.pack(__FUNCTION__sr); }
 
 	// Set to true if only requesting incremental backup without base snapshot.
-	KeyBackedProperty<bool> incrementalBackupOnly() { return configSpace.pack(LiteralStringRef(__FUNCTION__)); }
+	KeyBackedProperty<bool> incrementalBackupOnly() { return configSpace.pack(__FUNCTION__sr); }
 
 	// Latest version for which all prior versions have saved by backup workers.
-	KeyBackedProperty<Version> latestBackupWorkerSavedVersion() {
-		return configSpace.pack(LiteralStringRef(__FUNCTION__));
-	}
+	KeyBackedProperty<Version> latestBackupWorkerSavedVersion() { return configSpace.pack(__FUNCTION__sr); }
 
 	// Stop differntial logging if already started or don't start after completing KV ranges
-	KeyBackedProperty<bool> stopWhenDone() { return configSpace.pack(LiteralStringRef(__FUNCTION__)); }
+	KeyBackedProperty<bool> stopWhenDone() { return configSpace.pack(__FUNCTION__sr); }
 
 	// Enable snapshot backup file encryption
-	KeyBackedProperty<bool> enableSnapshotBackupEncryption() {
-		return configSpace.pack(LiteralStringRef(__FUNCTION__));
-	}
+	KeyBackedProperty<bool> enableSnapshotBackupEncryption() { return configSpace.pack(__FUNCTION__sr); }
 
 	// Latest version for which all prior versions have had their log copy tasks completed
-	KeyBackedProperty<Version> latestLogEndVersion() { return configSpace.pack(LiteralStringRef(__FUNCTION__)); }
+	KeyBackedProperty<Version> latestLogEndVersion() { return configSpace.pack(__FUNCTION__sr); }
 
 	// The end version of the last complete snapshot
-	KeyBackedProperty<Version> latestSnapshotEndVersion() { return configSpace.pack(LiteralStringRef(__FUNCTION__)); }
+	KeyBackedProperty<Version> latestSnapshotEndVersion() { return configSpace.pack(__FUNCTION__sr); }
 
 	// The end version of the first complete snapshot
-	KeyBackedProperty<Version> firstSnapshotEndVersion() { return configSpace.pack(LiteralStringRef(__FUNCTION__)); }
+	KeyBackedProperty<Version> firstSnapshotEndVersion() { return configSpace.pack(__FUNCTION__sr); }
 
-	KeyBackedProperty<Key> destUidValue() { return configSpace.pack(LiteralStringRef(__FUNCTION__)); }
+	KeyBackedProperty<Key> destUidValue() { return configSpace.pack(__FUNCTION__sr); }
 
 	Future<Optional<Version>> getLatestRestorableVersion(Reference<ReadYourWritesTransaction> tr) {
 		tr->setOption(FDBTransactionOptions::READ_SYSTEM_KEYS);
@@ -923,7 +909,7 @@ public:
 		           });
 	}
 
-	KeyBackedProperty<std::vector<KeyRange>> backupRanges() { return configSpace.pack(LiteralStringRef(__FUNCTION__)); }
+	KeyBackedProperty<std::vector<KeyRange>> backupRanges() { return configSpace.pack(__FUNCTION__sr); }
 
 	void startMutationLogs(Reference<ReadYourWritesTransaction> tr, KeyRangeRef backupRange, Key destUidValue) {
 		Key mutationLogsDestKey = destUidValue.withPrefix(backupLogKeys.begin);

--- a/fdbclient/include/fdbclient/TagThrottle.actor.h
+++ b/fdbclient/include/fdbclient/TagThrottle.actor.h
@@ -583,7 +583,7 @@ Future<Void> enableAuto(Reference<DB> db, bool enabled) {
 			    tr->get(tagThrottleAutoEnabledKey);
 			Optional<Value> value = wait(safeThreadFutureToFuture(valueF));
 			if (!value.present() || (enabled && value.get() != "1"_sr) || (!enabled && value.get() != "0"_sr)) {
-				tr->set(tagThrottleAutoEnabledKey, LiteralStringRef(enabled ? "1" : "0"));
+				tr->set(tagThrottleAutoEnabledKey, enabled ? "1"_sr : "0"_sr);
 				signalThrottleChange<typename DB::TransactionT>(tr);
 
 				wait(safeThreadFutureToFuture(tr->commit()));

--- a/fdbclient/include/fdbclient/TaskBucket.h
+++ b/fdbclient/include/fdbclient/TaskBucket.h
@@ -115,7 +115,7 @@ public:
 };
 
 struct ReservedTaskParams {
-	static TaskParam<Version> scheduledVersion() { return LiteralStringRef(__FUNCTION__); }
+	static TaskParam<Version> scheduledVersion() { return __FUNCTION__sr; }
 };
 
 class FutureBucket;

--- a/fdbclient/include/fdbclient/TaskBucket.h
+++ b/fdbclient/include/fdbclient/TaskBucket.h
@@ -481,7 +481,7 @@ struct TaskFuncBase : IDispatched<TaskFuncBase, Standalone<StringRef>, std::func
 #define REGISTER_TASKFUNC(TaskFunc) REGISTER_FACTORY(TaskFuncBase, TaskFunc, name)
 #define REGISTER_TASKFUNC_ALIAS(TaskFunc, Alias)                                                                       \
 	REGISTER_DISPATCHED_ALIAS(                                                                                         \
-	    TaskFunc, Alias, TaskFunc::name, StringRef(reinterpret_cast<const uint8_t*>(#Alias), sizeof(#Alias)))
+	    TaskFunc, Alias, TaskFunc::name, StringRef(reinterpret_cast<const uint8_t*>(#Alias), sizeof(#Alias) - 1))
 
 struct TaskCompletionKey {
 	Future<Key> get(Reference<ReadYourWritesTransaction> tr, Reference<TaskBucket> taskBucket);

--- a/fdbclient/include/fdbclient/TaskBucket.h
+++ b/fdbclient/include/fdbclient/TaskBucket.h
@@ -480,7 +480,8 @@ struct TaskFuncBase : IDispatched<TaskFuncBase, Standalone<StringRef>, std::func
 };
 #define REGISTER_TASKFUNC(TaskFunc) REGISTER_FACTORY(TaskFuncBase, TaskFunc, name)
 #define REGISTER_TASKFUNC_ALIAS(TaskFunc, Alias)                                                                       \
-	REGISTER_DISPATCHED_ALIAS(TaskFunc, Alias, TaskFunc::name, LiteralStringRef(#Alias))
+	REGISTER_DISPATCHED_ALIAS(                                                                                         \
+	    TaskFunc, Alias, TaskFunc::name, StringRef(reinterpret_cast<const uint8_t*>(#Alias), sizeof(#Alias)))
 
 struct TaskCompletionKey {
 	Future<Key> get(Reference<ReadYourWritesTransaction> tr, Reference<TaskBucket> taskBucket);

--- a/fdbrpc/FlowTests.actor.cpp
+++ b/fdbrpc/FlowTests.actor.cpp
@@ -48,7 +48,7 @@ TEST_CASE("/flow/actorcompiler/lineNumbers") {
 		}
 		break;
 	}
-	ASSERT(LiteralStringRef(__FILE__).endsWith("FlowTests.actor.cpp"_sr));
+	ASSERT(__FILE__sr.endsWith("FlowTests.actor.cpp"_sr));
 	return Void();
 }
 

--- a/fdbserver/Coordination.actor.cpp
+++ b/fdbserver/Coordination.actor.cpp
@@ -489,16 +489,16 @@ ACTOR Future<Void> leaderRegister(LeaderElectionRegInterface interf, Key key) {
 // Generation register values are stored without prefixing in the coordinated state, but always begin with an
 // alphanumeric character (they are always derived from a ClusterConnectionString key). Forwarding values are stored in
 // this range:
-const KeyRangeRef fwdKeys(LiteralStringRef("\xff"
-                                           "fwd"),
-                          LiteralStringRef("\xff"
-                                           "fwe"));
+const KeyRangeRef fwdKeys("\xff"
+                          "fwd"_sr,
+                          "\xff"
+                          "fwe"_sr);
 
 // The time when forwarding was last set is stored in this range:
-const KeyRangeRef fwdTimeKeys(LiteralStringRef("\xff"
-                                               "fwdTime"),
-                              LiteralStringRef("\xff"
-                                               "fwdTimf"));
+const KeyRangeRef fwdTimeKeys("\xff"
+                              "fwdTime"_sr,
+                              "\xff"
+                              "fwdTimf"_sr);
 struct LeaderRegisterCollection {
 	// SOMEDAY: Factor this into a generic tool?  Extend ActorCollection to support removal actions?  What?
 	ActorCollection actors;

--- a/fdbserver/KeyValueStoreRocksDB.actor.cpp
+++ b/fdbserver/KeyValueStoreRocksDB.actor.cpp
@@ -258,7 +258,7 @@ using DB = rocksdb::DB*;
 using CF = rocksdb::ColumnFamilyHandle*;
 
 #define PERSIST_PREFIX "\xff\xff"
-const KeyRef persistVersion = LiteralStringRef(PERSIST_PREFIX "Version");
+const KeyRef persistVersion = PERSIST_PREFIX "Version"_sr;
 const StringRef ROCKSDBSTORAGE_HISTOGRAM_GROUP = "RocksDBStorage"_sr;
 const StringRef ROCKSDB_COMMIT_LATENCY_HISTOGRAM = "RocksDBCommitLatency"_sr;
 const StringRef ROCKSDB_COMMIT_ACTION_HISTOGRAM = "RocksDBCommitAction"_sr;

--- a/fdbserver/RestoreCommon.actor.cpp
+++ b/fdbserver/RestoreCommon.actor.cpp
@@ -38,33 +38,33 @@
 // RestoreCommon.actor.cpp
 
 KeyBackedProperty<ERestoreState> RestoreConfigFR::stateEnum() {
-	return configSpace.pack(LiteralStringRef(__FUNCTION__));
+	return configSpace.pack(__FUNCTION__sr);
 }
 Future<StringRef> RestoreConfigFR::stateText(Reference<ReadYourWritesTransaction> tr) {
 	return map(stateEnum().getD(tr), [](ERestoreState s) -> StringRef { return FileBackupAgent::restoreStateText(s); });
 }
 KeyBackedProperty<Key> RestoreConfigFR::addPrefix() {
-	return configSpace.pack(LiteralStringRef(__FUNCTION__));
+	return configSpace.pack(__FUNCTION__sr);
 }
 KeyBackedProperty<Key> RestoreConfigFR::removePrefix() {
-	return configSpace.pack(LiteralStringRef(__FUNCTION__));
+	return configSpace.pack(__FUNCTION__sr);
 }
 // XXX: Remove restoreRange() once it is safe to remove. It has been changed to restoreRanges
 KeyBackedProperty<KeyRange> RestoreConfigFR::restoreRange() {
-	return configSpace.pack(LiteralStringRef(__FUNCTION__));
+	return configSpace.pack(__FUNCTION__sr);
 }
 KeyBackedProperty<std::vector<KeyRange>> RestoreConfigFR::restoreRanges() {
-	return configSpace.pack(LiteralStringRef(__FUNCTION__));
+	return configSpace.pack(__FUNCTION__sr);
 }
 KeyBackedProperty<Key> RestoreConfigFR::batchFuture() {
-	return configSpace.pack(LiteralStringRef(__FUNCTION__));
+	return configSpace.pack(__FUNCTION__sr);
 }
 KeyBackedProperty<Version> RestoreConfigFR::restoreVersion() {
-	return configSpace.pack(LiteralStringRef(__FUNCTION__));
+	return configSpace.pack(__FUNCTION__sr);
 }
 
 KeyBackedProperty<Reference<IBackupContainer>> RestoreConfigFR::sourceContainer() {
-	return configSpace.pack(LiteralStringRef(__FUNCTION__));
+	return configSpace.pack(__FUNCTION__sr);
 }
 // Get the source container as a bare URL, without creating a container instance
 KeyBackedProperty<Value> RestoreConfigFR::sourceContainerURL() {
@@ -73,23 +73,23 @@ KeyBackedProperty<Value> RestoreConfigFR::sourceContainerURL() {
 
 // Total bytes written by all log and range restore tasks.
 KeyBackedBinaryValue<int64_t> RestoreConfigFR::bytesWritten() {
-	return configSpace.pack(LiteralStringRef(__FUNCTION__));
+	return configSpace.pack(__FUNCTION__sr);
 }
 // File blocks that have had tasks created for them by the Dispatch task
 KeyBackedBinaryValue<int64_t> RestoreConfigFR::filesBlocksDispatched() {
-	return configSpace.pack(LiteralStringRef(__FUNCTION__));
+	return configSpace.pack(__FUNCTION__sr);
 }
 // File blocks whose tasks have finished
 KeyBackedBinaryValue<int64_t> RestoreConfigFR::fileBlocksFinished() {
-	return configSpace.pack(LiteralStringRef(__FUNCTION__));
+	return configSpace.pack(__FUNCTION__sr);
 }
 // Total number of files in the fileMap
 KeyBackedBinaryValue<int64_t> RestoreConfigFR::fileCount() {
-	return configSpace.pack(LiteralStringRef(__FUNCTION__));
+	return configSpace.pack(__FUNCTION__sr);
 }
 // Total number of file blocks in the fileMap
 KeyBackedBinaryValue<int64_t> RestoreConfigFR::fileBlockCount() {
-	return configSpace.pack(LiteralStringRef(__FUNCTION__));
+	return configSpace.pack(__FUNCTION__sr);
 }
 
 Future<std::vector<KeyRange>> RestoreConfigFR::getRestoreRangesOrDefault(Reference<ReadYourWritesTransaction> tr) {
@@ -108,7 +108,7 @@ ACTOR Future<std::vector<KeyRange>> RestoreConfigFR::getRestoreRangesOrDefault_i
 }
 
 KeyBackedSet<RestoreConfigFR::RestoreFile> RestoreConfigFR::fileSet() {
-	return configSpace.pack(LiteralStringRef(__FUNCTION__));
+	return configSpace.pack(__FUNCTION__sr);
 }
 
 Future<bool> RestoreConfigFR::isRunnable(Reference<ReadYourWritesTransaction> tr) {

--- a/fdbserver/TagThrottler.actor.cpp
+++ b/fdbserver/TagThrottler.actor.cpp
@@ -72,8 +72,7 @@ class TagThrottlerImpl {
 						}
 						self->autoThrottlingEnabled = SERVER_KNOBS->AUTO_TAG_THROTTLING_ENABLED;
 						if (!committed)
-							tr.set(tagThrottleAutoEnabledKey,
-							       LiteralStringRef(self->autoThrottlingEnabled ? "1" : "0"));
+							tr.set(tagThrottleAutoEnabledKey, self->autoThrottlingEnabled ? "1"_sr : "0"_sr);
 					}
 
 					RkTagThrottleCollection updatedTagThrottles;

--- a/fdbserver/VersionedBTree.actor.cpp
+++ b/fdbserver/VersionedBTree.actor.cpp
@@ -4202,7 +4202,6 @@ std::string toString(BTreeNodeLinkRef id) {
 	return std::string("BTreePageID") + toString(id.begin(), id.end());
 }
 
-#define STR(x) LiteralStringRef(x)
 struct RedwoodRecordRef {
 	typedef uint8_t byte;
 

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -185,15 +185,13 @@ static const KeyRangeRef persistTenantMapKeys = KeyRangeRef(PERSIST_PREFIX "TM/"
 // data keys are unmangled (but never start with PERSIST_PREFIX because they are always in allKeys)
 
 static const KeyRangeRef persistStorageServerShardKeys =
-    KeyRangeRef(PERSIST_PREFIX "StorageServerShard/"_sr,
-                PERSIST_PREFIX "StorageServerShard0"_sr);
+    KeyRangeRef(PERSIST_PREFIX "StorageServerShard/"_sr, PERSIST_PREFIX "StorageServerShard0"_sr);
 
 // Checkpoint related prefixes.
 static const KeyRangeRef persistCheckpointKeys =
     KeyRangeRef(PERSIST_PREFIX "Checkpoint/"_sr, PERSIST_PREFIX "Checkpoint0"_sr);
 static const KeyRangeRef persistPendingCheckpointKeys =
-    KeyRangeRef(PERSIST_PREFIX "PendingCheckpoint/"_sr,
-                PERSIST_PREFIX "PendingCheckpoint0"_sr);
+    KeyRangeRef(PERSIST_PREFIX "PendingCheckpoint/"_sr, PERSIST_PREFIX "PendingCheckpoint0"_sr);
 static const std::string rocksdbCheckpointDirPrefix = "/rockscheckpoints_";
 
 struct AddingShard : NonCopyable {

--- a/fdbserver/storageserver.actor.cpp
+++ b/fdbserver/storageserver.actor.cpp
@@ -159,46 +159,41 @@ FDB_DECLARE_BOOLEAN_PARAM(UnlimitedCommitBytes);
 FDB_DEFINE_BOOLEAN_PARAM(UnlimitedCommitBytes);
 
 // Immutable
-static const KeyValueRef persistFormat(LiteralStringRef(PERSIST_PREFIX "Format"), "FoundationDB/StorageServer/1/4"_sr);
-static const KeyValueRef persistShardAwareFormat(LiteralStringRef(PERSIST_PREFIX "Format"),
-                                                 "FoundationDB/StorageServer/1/5"_sr);
+static const KeyValueRef persistFormat(PERSIST_PREFIX "Format"_sr, "FoundationDB/StorageServer/1/4"_sr);
+static const KeyValueRef persistShardAwareFormat(PERSIST_PREFIX "Format"_sr, "FoundationDB/StorageServer/1/5"_sr);
 static const KeyRangeRef persistFormatReadableRange("FoundationDB/StorageServer/1/2"_sr,
                                                     "FoundationDB/StorageServer/1/6"_sr);
-static const KeyRef persistID = LiteralStringRef(PERSIST_PREFIX "ID");
-static const KeyRef persistTssPairID = LiteralStringRef(PERSIST_PREFIX "tssPairID");
-static const KeyRef persistSSPairID = LiteralStringRef(PERSIST_PREFIX "ssWithTSSPairID");
-static const KeyRef persistTssQuarantine = LiteralStringRef(PERSIST_PREFIX "tssQ");
-static const KeyRef persistClusterIdKey = LiteralStringRef(PERSIST_PREFIX "clusterId");
+static const KeyRef persistID = PERSIST_PREFIX "ID"_sr;
+static const KeyRef persistTssPairID = PERSIST_PREFIX "tssPairID"_sr;
+static const KeyRef persistSSPairID = PERSIST_PREFIX "ssWithTSSPairID"_sr;
+static const KeyRef persistTssQuarantine = PERSIST_PREFIX "tssQ"_sr;
+static const KeyRef persistClusterIdKey = PERSIST_PREFIX "clusterId"_sr;
 
 // (Potentially) change with the durable version or when fetchKeys completes
-static const KeyRef persistVersion = LiteralStringRef(PERSIST_PREFIX "Version");
+static const KeyRef persistVersion = PERSIST_PREFIX "Version"_sr;
 static const KeyRangeRef persistShardAssignedKeys =
-    KeyRangeRef(LiteralStringRef(PERSIST_PREFIX "ShardAssigned/"), LiteralStringRef(PERSIST_PREFIX "ShardAssigned0"));
+    KeyRangeRef(PERSIST_PREFIX "ShardAssigned/"_sr, PERSIST_PREFIX "ShardAssigned0"_sr);
 static const KeyRangeRef persistShardAvailableKeys =
-    KeyRangeRef(LiteralStringRef(PERSIST_PREFIX "ShardAvailable/"), LiteralStringRef(PERSIST_PREFIX "ShardAvailable0"));
-static const KeyRangeRef persistByteSampleKeys =
-    KeyRangeRef(LiteralStringRef(PERSIST_PREFIX "BS/"), LiteralStringRef(PERSIST_PREFIX "BS0"));
+    KeyRangeRef(PERSIST_PREFIX "ShardAvailable/"_sr, PERSIST_PREFIX "ShardAvailable0"_sr);
+static const KeyRangeRef persistByteSampleKeys = KeyRangeRef(PERSIST_PREFIX "BS/"_sr, PERSIST_PREFIX "BS0"_sr);
 static const KeyRangeRef persistByteSampleSampleKeys =
-    KeyRangeRef(LiteralStringRef(PERSIST_PREFIX "BS/" PERSIST_PREFIX "BS/"),
-                LiteralStringRef(PERSIST_PREFIX "BS/" PERSIST_PREFIX "BS0"));
-static const KeyRef persistLogProtocol = LiteralStringRef(PERSIST_PREFIX "LogProtocol");
-static const KeyRef persistPrimaryLocality = LiteralStringRef(PERSIST_PREFIX "PrimaryLocality");
-static const KeyRangeRef persistChangeFeedKeys =
-    KeyRangeRef(LiteralStringRef(PERSIST_PREFIX "CF/"), LiteralStringRef(PERSIST_PREFIX "CF0"));
-static const KeyRangeRef persistTenantMapKeys =
-    KeyRangeRef(LiteralStringRef(PERSIST_PREFIX "TM/"), LiteralStringRef(PERSIST_PREFIX "TM0"));
+    KeyRangeRef(PERSIST_PREFIX "BS/"_sr PERSIST_PREFIX "BS/"_sr, PERSIST_PREFIX "BS/"_sr PERSIST_PREFIX "BS0"_sr);
+static const KeyRef persistLogProtocol = PERSIST_PREFIX "LogProtocol"_sr;
+static const KeyRef persistPrimaryLocality = PERSIST_PREFIX "PrimaryLocality"_sr;
+static const KeyRangeRef persistChangeFeedKeys = KeyRangeRef(PERSIST_PREFIX "CF/"_sr, PERSIST_PREFIX "CF0"_sr);
+static const KeyRangeRef persistTenantMapKeys = KeyRangeRef(PERSIST_PREFIX "TM/"_sr, PERSIST_PREFIX "TM0"_sr);
 // data keys are unmangled (but never start with PERSIST_PREFIX because they are always in allKeys)
 
 static const KeyRangeRef persistStorageServerShardKeys =
-    KeyRangeRef(LiteralStringRef(PERSIST_PREFIX "StorageServerShard/"),
-                LiteralStringRef(PERSIST_PREFIX "StorageServerShard0"));
+    KeyRangeRef(PERSIST_PREFIX "StorageServerShard/"_sr,
+                PERSIST_PREFIX "StorageServerShard0"_sr);
 
 // Checkpoint related prefixes.
 static const KeyRangeRef persistCheckpointKeys =
-    KeyRangeRef(LiteralStringRef(PERSIST_PREFIX "Checkpoint/"), LiteralStringRef(PERSIST_PREFIX "Checkpoint0"));
+    KeyRangeRef(PERSIST_PREFIX "Checkpoint/"_sr, PERSIST_PREFIX "Checkpoint0"_sr);
 static const KeyRangeRef persistPendingCheckpointKeys =
-    KeyRangeRef(LiteralStringRef(PERSIST_PREFIX "PendingCheckpoint/"),
-                LiteralStringRef(PERSIST_PREFIX "PendingCheckpoint0"));
+    KeyRangeRef(PERSIST_PREFIX "PendingCheckpoint/"_sr,
+                PERSIST_PREFIX "PendingCheckpoint0"_sr);
 static const std::string rocksdbCheckpointDirPrefix = "/rockscheckpoints_";
 
 struct AddingShard : NonCopyable {

--- a/fdbserver/workloads/ApiCorrectness.actor.cpp
+++ b/fdbserver/workloads/ApiCorrectness.actor.cpp
@@ -35,7 +35,7 @@ struct ApiCorrectnessWorkload : ApiWorkload {
 private:
 // Enable to track the activity on a particular key
 #if CENABLED(0, NOT_IN_CLEAN)
-#define targetKey LiteralStringRef( ??? )
+#define targetKey "???"_sr
 
 	void debugKey(KeyRef key, std::string context) {
 		if (key == targetKey)

--- a/fdbserver/workloads/BulkSetup.actor.cpp
+++ b/fdbserver/workloads/BulkSetup.actor.cpp
@@ -35,7 +35,7 @@ struct BulkSetupWorkload : TestWorkload {
 	BulkSetupWorkload(WorkloadContext const& wcx) : TestWorkload(wcx) {
 		transactionsPerSecond = getOption(options, "transactionsPerSecond"_sr, 5000.0) / clientCount;
 		nodeCount = getOption(options, "nodeCount"_sr, transactionsPerSecond * clientCount);
-		keyPrefix = unprintable(getOption(options, "keyPrefix"_sr, LiteralStringRef("")).toString());
+		keyPrefix = unprintable(getOption(options, "keyPrefix"_sr, ""_sr).toString());
 		std::vector<std::string> tenants = getOption(options, "tenants"_sr, std::vector<std::string>());
 		for (std::string tenant : tenants) {
 			tenantNames.push_back(TenantName(tenant));

--- a/fdbserver/workloads/IDDTxnProcessorApiCorrectness.actor.cpp
+++ b/fdbserver/workloads/IDDTxnProcessorApiCorrectness.actor.cpp
@@ -65,7 +65,7 @@ struct IDDTxnProcessorApiWorkload : TestWorkload {
 
 	IDDTxnProcessorApiWorkload(WorkloadContext const& wcx) : TestWorkload(wcx), ddContext(UID()) {
 		enabled = !clientId && g_network->isSimulated(); // only do this on the "first" client
-		testDuration = getOption(options, LiteralStringRef("testDuration"), 10.0);
+		testDuration = getOption(options, "testDuration"_sr, 10.0);
 	}
 
 	std::string description() const override { return desc; }

--- a/fdbserver/workloads/TaskBucketCorrectness.actor.cpp
+++ b/fdbserver/workloads/TaskBucketCorrectness.actor.cpp
@@ -419,8 +419,8 @@ TEST_CASE("/fdbclient/TaskBucket/Subspace") {
 	t3.append(ghi);
 	printf("%d==========%s===%d\n", 13, printable(subspace_test5.pack(t3)).c_str(), subspace_test5.pack(t3).size());
 	ASSERT(subspace_test5.pack(t3) == subspace_test5.get(StringRef()).get(def).pack(ghi));
-	ASSERT(subspace_test5.pack(t3) == LiteralStringRef("abc\x01user\x00\x15\x7b\x01\x00\x01"
-	                                                   "def\x00\x01ghi\x00"));
+	ASSERT(subspace_test5.pack(t3) == "abc\x01user\x00\x15\x7b\x01\x00\x01"
+	                                  "def\x00\x01ghi\x00"_sr);
 
 	printf("%d==========%s===%d\n",
 	       14,

--- a/flow/Platform.actor.cpp
+++ b/flow/Platform.actor.cpp
@@ -4031,13 +4031,13 @@ TEST_CASE("/flow/Platform/getMemoryInfo") {
 
 	std::stringstream memInfoStream(memString);
 	linux_os::getMemoryInfo(request, memInfoStream);
-	ASSERT(request[LiteralStringRef("MemTotal:")] == 24733228);
-	ASSERT(request[LiteralStringRef("MemFree:")] == 2077580);
-	ASSERT(request[LiteralStringRef("MemAvailable:")] == 0);
-	ASSERT(request[LiteralStringRef("Buffers:")] == 266940);
-	ASSERT(request[LiteralStringRef("Cached:")] == 16798292);
-	ASSERT(request[LiteralStringRef("SwapTotal:")] == 25165820);
-	ASSERT(request[LiteralStringRef("SwapFree:")] == 23680228);
+	ASSERT(request["MemTotal:"_sr] == 24733228);
+	ASSERT(request["MemFree:"_sr] == 2077580);
+	ASSERT(request["MemAvailable:"_sr] == 0);
+	ASSERT(request["Buffers:"_sr] == 266940);
+	ASSERT(request["Cached:"_sr] == 16798292);
+	ASSERT(request["SwapTotal:"_sr] == 25165820);
+	ASSERT(request["SwapFree:"_sr] == 23680228);
 	for (auto& item : request) {
 		fmt::print("{}:{}\n", item.first.toString().c_str(), item.second);
 	}
@@ -4082,13 +4082,13 @@ TEST_CASE("/flow/Platform/getMemoryInfo") {
 
 	std::stringstream memInfoStream1(memString1);
 	linux_os::getMemoryInfo(request, memInfoStream1);
-	ASSERT(request[LiteralStringRef("MemTotal:")] == 31856496);
-	ASSERT(request[LiteralStringRef("MemFree:")] == 25492716);
-	ASSERT(request[LiteralStringRef("MemAvailable:")] == 28470756);
-	ASSERT(request[LiteralStringRef("Buffers:")] == 313644);
-	ASSERT(request[LiteralStringRef("Cached:")] == 2956444);
-	ASSERT(request[LiteralStringRef("SwapTotal:")] == 0);
-	ASSERT(request[LiteralStringRef("SwapFree:")] == 0);
+	ASSERT(request["MemTotal:"_sr] == 31856496);
+	ASSERT(request["MemFree:"_sr] == 25492716);
+	ASSERT(request["MemAvailable:"_sr] == 28470756);
+	ASSERT(request["Buffers:"_sr] == 313644);
+	ASSERT(request["Cached:"_sr] == 2956444);
+	ASSERT(request["SwapTotal:"_sr] == 0);
+	ASSERT(request["SwapFree:"_sr] == 0);
 	for (auto& item : request) {
 		fmt::print("{}:{}\n", item.first.toString().c_str(), item.second);
 	}

--- a/flow/README.md
+++ b/flow/README.md
@@ -538,7 +538,6 @@ convenience types for their `Standalone` versions (not a complete list):
 |        T         | Standalone<T> alias |
 |:----------------:|:-------------------:|
 | StringRef        | N/A                 |
-| LiteralStringRef | N/A                 |
 | KeyRef           | Key                 |
 | ValueRef         | Value               |
 | KeyValueRef      | KeyValue            |

--- a/flow/actorcompiler/ActorCompiler.cs
+++ b/flow/actorcompiler/ActorCompiler.cs
@@ -251,16 +251,16 @@ namespace actorcompiler
             lines = 0;
 
             writer.WriteLine(memberIndentStr + "template<> struct Descriptor<struct {0}> {{", descr.name);
-            writer.WriteLine(memberIndentStr + "\tstatic StringRef typeName() {{ return LiteralStringRef(\"{0}\"); }}", descr.name);
+            writer.WriteLine(memberIndentStr + "\tstatic StringRef typeName() {{ return \"{0}\"_sr; }}", descr.name);
             writer.WriteLine(memberIndentStr + "\ttypedef {0} type;", descr.name);
             lines += 3;
 
             foreach (var dec in descr.body)
             {
                 writer.WriteLine(memberIndentStr + "\tstruct {0}Descriptor {{", dec.name);
-                writer.WriteLine(memberIndentStr + "\t\tstatic StringRef name() {{ return LiteralStringRef(\"{0}\"); }}", dec.name);
-                writer.WriteLine(memberIndentStr + "\t\tstatic StringRef typeName() {{ return LiteralStringRef(\"{0}\"); }}", dec.type);
-                writer.WriteLine(memberIndentStr + "\t\tstatic StringRef comment() {{ return LiteralStringRef(\"{0}\"); }}", dec.comment);
+                writer.WriteLine(memberIndentStr + "\t\tstatic StringRef name() {{ return \"{0}\"_sr; }}", dec.name);
+                writer.WriteLine(memberIndentStr + "\t\tstatic StringRef typeName() {{ return \"{0}\"_sr; }}", dec.type);
+                writer.WriteLine(memberIndentStr + "\t\tstatic StringRef comment() {{ return \"{0}\"_sr; }}", dec.comment);
                 writer.WriteLine(memberIndentStr + "\t\ttypedef {0} type;", dec.type);
                 writer.WriteLine(memberIndentStr + "\t\tstatic inline type get({0}& from);", descr.name);
                 writer.WriteLine(memberIndentStr + "\t};");
@@ -1302,7 +1302,7 @@ namespace actorcompiler
             constructor.WriteLine("this->lineage.setActorName(\"{0}\");", actor.name);
             constructor.WriteLine("LineageScope _(&this->lineage);");
             constructor.WriteLine("#endif");
-            // constructor.WriteLine("getCurrentLineage()->modify(&StackLineage::actorName) = LiteralStringRef(\"{0}\");", actor.name);
+            // constructor.WriteLine("getCurrentLineage()->modify(&StackLineage::actorName) = \"{0}\"_sr;", actor.name);
             constructor.WriteLine("this->{0};", body.call());
             ProbeExit(constructor, actor.name);
             WriteFunction(writer, constructor, constructor.BodyText);

--- a/flow/include/flow/Arena.h
+++ b/flow/include/flow/Arena.h
@@ -731,8 +731,8 @@ struct Traceable<Standalone<T>> : std::conditional<Traceable<T>::value, std::tru
 	static std::string toString(const Standalone<T>& value) { return Traceable<T>::toString(value); }
 };
 
-#define __FILE__sr StringRef(reinterpret_cast<const uint8_t*>(__FILE__), sizeof(__FILE__))
-#define __FUNCTION__sr StringRef(reinterpret_cast<const uint8_t*>(__FUNCTION__), sizeof(__FUNCTION__))
+#define __FILE__sr StringRef(reinterpret_cast<const uint8_t*>(__FILE__), sizeof(__FILE__) - 1)
+#define __FUNCTION__sr StringRef(reinterpret_cast<const uint8_t*>(__FUNCTION__), sizeof(__FUNCTION__) - 1)
 
 template <>
 struct fmt::formatter<StringRef> : formatter<std::string_view> {

--- a/flow/include/flow/Arena.h
+++ b/flow/include/flow/Arena.h
@@ -740,6 +740,8 @@ StringRef LiteralStringRefHelper(const char* str) {
 }
 } // namespace literal_string_ref
 #define LiteralStringRef(str) literal_string_ref::LiteralStringRefHelper<decltype(str), sizeof(str)>(str)
+#define __FILE__sr StringRef(reinterpret_cast<const uint8_t*>(__FILE__), sizeof(__FILE__))
+#define __FUNCTION__sr StringRef(reinterpret_cast<const uint8_t*>(__FUNCTION__), sizeof(__FUNCTION__))
 
 template <>
 struct fmt::formatter<StringRef> : formatter<std::string_view> {

--- a/flow/include/flow/Arena.h
+++ b/flow/include/flow/Arena.h
@@ -832,6 +832,10 @@ inline bool operator==(const StringRef& lhs, const StringRef& rhs) {
 	ASSERT(lhs.size() >= 0);
 	return lhs.size() == rhs.size() && memcmp(lhs.begin(), rhs.begin(), static_cast<unsigned int>(lhs.size())) == 0;
 }
+template <int N>
+inline bool operator==(const StringRef& lhs, const char (&rhs)[N]) {
+	return lhs == StringRef(reinterpret_cast<const uint8_t*>(rhs), N);
+}
 inline bool operator<(const StringRef& lhs, const StringRef& rhs) {
 	if (std::min(lhs.size(), rhs.size()) > 0) {
 		int c = memcmp(lhs.begin(), rhs.begin(), std::min(lhs.size(), rhs.size()));

--- a/flow/include/flow/Arena.h
+++ b/flow/include/flow/Arena.h
@@ -731,15 +731,6 @@ struct Traceable<Standalone<T>> : std::conditional<Traceable<T>::value, std::tru
 	static std::string toString(const Standalone<T>& value) { return Traceable<T>::toString(value); }
 };
 
-namespace literal_string_ref {
-template <class T, int Size>
-StringRef LiteralStringRefHelper(const char* str) {
-	static_assert(std::is_same_v<T, const char(&)[Size]> || std::is_same_v<T, const char[Size]>,
-	              "Argument to LiteralStringRef must be a literal string");
-	return StringRef(reinterpret_cast<const uint8_t*>(str), Size - 1);
-}
-} // namespace literal_string_ref
-#define LiteralStringRef(str) literal_string_ref::LiteralStringRefHelper<decltype(str), sizeof(str)>(str)
 #define __FILE__sr StringRef(reinterpret_cast<const uint8_t*>(__FILE__), sizeof(__FILE__))
 #define __FUNCTION__sr StringRef(reinterpret_cast<const uint8_t*>(__FUNCTION__), sizeof(__FUNCTION__))
 

--- a/flow/include/flow/Arena.h
+++ b/flow/include/flow/Arena.h
@@ -825,7 +825,7 @@ inline bool operator==(const StringRef& lhs, const StringRef& rhs) {
 }
 template <int N>
 inline bool operator==(const StringRef& lhs, const char (&rhs)[N]) {
-	return lhs == StringRef(reinterpret_cast<const uint8_t*>(rhs), N);
+	return lhs == StringRef(reinterpret_cast<const uint8_t*>(rhs), N - 1);
 }
 inline bool operator<(const StringRef& lhs, const StringRef& rhs) {
 	if (std::min(lhs.size(), rhs.size()) > 0) {

--- a/flow/include/flow/TDMetric.actor.h
+++ b/flow/include/flow/TDMetric.actor.h
@@ -171,12 +171,12 @@ inline StringRef metricTypeName() {
 #define MAKE_TYPENAME(T, S)                                                                                            \
 	template <>                                                                                                        \
 	inline StringRef metricTypeName<T>() {                                                                             \
-		return LiteralStringRef(S);                                                                                    \
+		return S;                                                                                                      \
 	}
-MAKE_TYPENAME(bool, "Bool")
-MAKE_TYPENAME(int64_t, "Int64")
-MAKE_TYPENAME(double, "Double")
-MAKE_TYPENAME(Standalone<StringRef>, "String")
+MAKE_TYPENAME(bool, "Bool"_sr)
+MAKE_TYPENAME(int64_t, "Int64"_sr)
+MAKE_TYPENAME(double, "Double"_sr)
+MAKE_TYPENAME(Standalone<StringRef>, "String"_sr)
 #undef MAKE_TYPENAME
 
 struct BaseMetric;


### PR DESCRIPTION
This makes a variety of changes to usages of `LiteralStringRef`, culminating in the removal of `LiteralStringRef` altogether. Each commit handles a different class of usages that involve different solutions.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
