### PR TITLE
fdbmonitor: track parent process death for FreeBSD

### DIFF
--- a/fdbmonitor/fdbmonitor.cpp
+++ b/fdbmonitor/fdbmonitor.cpp
@@ -27,6 +27,8 @@
 
 #ifdef __linux__
 #include <sys/prctl.h>
+#elif defined(__FreeBSD__)
+#include <sys/procctl.h>
 #endif
 
 #include <sys/wait.h>
@@ -751,6 +753,10 @@ void start_process(Command* cmd, ProcessID id, uid_t uid, gid_t gid, int delay, 
 		signal(SIGHUP, SIG_DFL);
 		signal(SIGINT, SIG_DFL);
 		signal(SIGTERM, SIG_DFL);
+#ifdef __linux__
+		signal(SIGCHLD, SIG_DFL);
+#endif
+		sigprocmask(SIG_SETMASK, mask, nullptr);
 
 		/* All output in this block should be to stdout (for SevInfo messages) or stderr (for SevError messages) */
 		/* Using log_msg() or log_err() from the child will cause the logs to be written incorrectly */
@@ -780,13 +786,15 @@ void start_process(Command* cmd, ProcessID id, uid_t uid, gid_t gid, int delay, 
 		}
 
 #ifdef __linux__
-		signal(SIGCHLD, SIG_DFL);
-
-		sigprocmask(SIG_SETMASK, mask, nullptr);
-
 		/* death of our parent raises SIGHUP */
 		prctl(PR_SET_PDEATHSIG, SIGHUP);
 		if (getppid() == 1) /* parent already died before prctl */
+			exit(0);
+#elif defined(__FreeBSD__)
+		/* death of our parent raises SIGHUP */
+		const int sig = SIGHUP;
+		procctl(P_PID, 0, PROC_PDEATHSIG_CTL, (void*)&sig);
+		if (getppid() == 1) /* parent already died before procctl */
 			exit(0);
 #endif
 


### PR DESCRIPTION
Track parent process death for FreeBSD.

Before: When dbmonitor terminated, the children continued to work.
After: Children receive a SIGHUP signal and finish their work.

Also fixed sigprocmask() restore.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [x] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
