### PR TITLE
[Release 7.1] Differentiate degraded peers and disconnected peers in gray failure

### DIFF
--- a/fdbserver/ClusterController.actor.cpp
+++ b/fdbserver/ClusterController.actor.cpp
@@ -2783,6 +2783,20 @@ TEST_CASE("/fdbserver/clustercontroller/updateWorkerHealth") {
 		ASSERT_EQ(health.degradedPeers[badPeer3].lastRefreshTime, previousRefreshTime);
 	}
 
+	// Create a `UpdateWorkerHealthRequest` with disconnected peers, which should update the bad peer's lastRefreshTime.
+	{
+		wait(delay(0.001));
+		UpdateWorkerHealthRequest req;
+		req.address = workerAddress;
+		req.disconnectedPeers.push_back(badPeer3);
+		data.updateWorkerHealth(req);
+		ASSERT(data.workerHealth.find(workerAddress) != data.workerHealth.end());
+		auto& health = data.workerHealth[workerAddress];
+		ASSERT_EQ(health.degradedPeers.size(), 3);
+		ASSERT(health.degradedPeers.find(badPeer3) != health.degradedPeers.end());
+		ASSERT_LT(health.degradedPeers[badPeer3].startTime, health.degradedPeers[badPeer3].lastRefreshTime);
+	}
+
 	return Void();
 }
 

--- a/fdbserver/ClusterController.actor.h
+++ b/fdbserver/ClusterController.actor.h
@@ -2934,7 +2934,7 @@ public:
 
 		auto& health = workerHealth[req.address];
 
-		auto updateDegradedPeer = [&health, &currentTime](const NetworkAddress& degradedPeer) {
+		auto updateDegradedPeer = [&health, currentTime](const NetworkAddress& degradedPeer) {
 			auto it = health.degradedPeers.find(degradedPeer);
 			if (it == health.degradedPeers.end()) {
 				health.degradedPeers[degradedPeer] = { currentTime, currentTime };

--- a/fdbserver/ClusterController.actor.h
+++ b/fdbserver/ClusterController.actor.h
@@ -2934,14 +2934,23 @@ public:
 
 		auto& health = workerHealth[req.address];
 
-		// Update the worker's degradedPeers.
-		for (const auto& peer : req.degradedPeers) {
-			auto it = health.degradedPeers.find(peer);
+		auto updateDegradedPeer = [&health, &currentTime](const NetworkAddress& degradedPeer) {
+			auto it = health.degradedPeers.find(degradedPeer);
 			if (it == health.degradedPeers.end()) {
-				health.degradedPeers[peer] = { currentTime, currentTime };
-				continue;
+				health.degradedPeers[degradedPeer] = { currentTime, currentTime };
+				return;
 			}
 			it->second.lastRefreshTime = currentTime;
+		};
+
+		// Update the worker's degradedPeers.
+		for (const auto& peer : req.degradedPeers) {
+			updateDegradedPeer(peer);
+		}
+
+		// TODO(zhewu): add disconnected peers in worker health.
+		for (const auto& peer : req.disconnectedPeers) {
+			updateDegradedPeer(peer);
 		}
 	}
 

--- a/fdbserver/ClusterController.actor.h
+++ b/fdbserver/ClusterController.actor.h
@@ -2903,9 +2903,14 @@ public:
 		for (int i = 0; i < req.degradedPeers.size(); ++i) {
 			degradedPeersString += (i == 0 ? "" : " ") + req.degradedPeers[i].toString();
 		}
+		std::string disconnectedPeersString;
+		for (int i = 0; i < req.disconnectedPeers.size(); ++i) {
+			disconnectedPeersString += (i == 0 ? "" : " ") + req.disconnectedPeers[i].toString();
+		}
 		TraceEvent("ClusterControllerUpdateWorkerHealth")
 		    .detail("WorkerAddress", req.address)
-		    .detail("DegradedPeers", degradedPeersString);
+		    .detail("DegradedPeers", degradedPeersString)
+		    .detail("DisconnectedPeers", disconnectedPeersString);
 
 		double currentTime = now();
 
@@ -2914,6 +2919,11 @@ public:
 		if (workerHealth.find(req.address) == workerHealth.end()) {
 			workerHealth[req.address] = {};
 			for (const auto& degradedPeer : req.degradedPeers) {
+				workerHealth[req.address].degradedPeers[degradedPeer] = { currentTime, currentTime };
+			}
+
+			// TODO(zhewu): add disconnected peers in worker health.
+			for (const auto& degradedPeer : req.disconnectedPeers) {
 				workerHealth[req.address].degradedPeers[degradedPeer] = { currentTime, currentTime };
 			}
 

--- a/fdbserver/WorkerInterface.actor.h
+++ b/fdbserver/WorkerInterface.actor.h
@@ -498,13 +498,14 @@ struct UpdateWorkerHealthRequest {
 	constexpr static FileIdentifier file_identifier = 5789927;
 	NetworkAddress address;
 	std::vector<NetworkAddress> degradedPeers;
+	std::vector<NetworkAddress> disconnectedPeers;
 
 	template <class Ar>
 	void serialize(Ar& ar) {
 		if constexpr (!is_fb_function<Ar>) {
 			ASSERT(ar.protocolVersion().isValid());
 		}
-		serializer(ar, address, degradedPeers);
+		serializer(ar, address, degradedPeers, disconnectedPeers);
 	}
 };
 

--- a/fdbserver/worker.actor.cpp
+++ b/fdbserver/worker.actor.cpp
@@ -972,48 +972,74 @@ ACTOR Future<Void> healthMonitor(Reference<AsyncVar<Optional<ClusterControllerFu
 						continue;
 					}
 					bool degradedPeer = false;
+					bool disconnectedPeer = false;
 					if ((workerLocation == Primary && addressInDbAndPrimaryDc(address, dbInfo)) ||
 					    (workerLocation == Remote && addressInDbAndRemoteDc(address, dbInfo))) {
 						// Monitors intra DC latencies between servers that in the primary or remote DC's transaction
 						// systems. Note that currently we are not monitor storage servers, since lagging in storage
 						// servers today already can trigger server exclusion by data distributor.
 
-						if (peer->connectFailedCount >= SERVER_KNOBS->PEER_DEGRADATION_CONNECTION_FAILURE_COUNT ||
-						    peer->pingLatencies.percentile(SERVER_KNOBS->PEER_LATENCY_DEGRADATION_PERCENTILE) >
-						        SERVER_KNOBS->PEER_LATENCY_DEGRADATION_THRESHOLD ||
-						    peer->timeoutCount / (double)(peer->pingLatencies.getPopulationSize()) >
-						        SERVER_KNOBS->PEER_TIMEOUT_PERCENTAGE_DEGRADATION_THRESHOLD) {
+						if (peer->connectFailedCount >= SERVER_KNOBS->PEER_DEGRADATION_CONNECTION_FAILURE_COUNT) {
+							disconnectedPeer = true;
+						} else if (peer->pingLatencies.percentile(SERVER_KNOBS->PEER_LATENCY_DEGRADATION_PERCENTILE) >
+						               SERVER_KNOBS->PEER_LATENCY_DEGRADATION_THRESHOLD ||
+						           peer->timeoutCount / (double)(peer->pingLatencies.getPopulationSize()) >
+						               SERVER_KNOBS->PEER_TIMEOUT_PERCENTAGE_DEGRADATION_THRESHOLD) {
 							degradedPeer = true;
+						}
+						if (disconnectedPeer || degradedPeer) {
+							TraceEvent("HealthMonitorDetectDegradedPeer")
+							    .detail("Peer", address)
+							    .detail("Elapsed", now() - peer->lastLoggedTime)
+							    .detail("Disconnected", disconnectedPeer)
+							    .detail("MinLatency", peer->pingLatencies.min())
+							    .detail("MaxLatency", peer->pingLatencies.max())
+							    .detail("MeanLatency", peer->pingLatencies.mean())
+							    .detail("MedianLatency", peer->pingLatencies.median())
+							    .detail("CheckedPercentile", SERVER_KNOBS->PEER_LATENCY_DEGRADATION_PERCENTILE)
+							    .detail(
+							        "CheckedPercentileLatency",
+							        peer->pingLatencies.percentile(SERVER_KNOBS->PEER_LATENCY_DEGRADATION_PERCENTILE))
+							    .detail("PingCount", peer->pingLatencies.getPopulationSize())
+							    .detail("PingTimeoutCount", peer->timeoutCount)
+							    .detail("ConnectionFailureCount", peer->connectFailedCount);
 						}
 					} else if (workerLocation == Primary && addressInDbAndPrimarySatelliteDc(address, dbInfo)) {
 						// Monitors inter DC latencies between servers in primary and primary satellite DC. Note that
 						// TLog workers in primary satellite DC are on the critical path of serving a commit.
-						if (peer->connectFailedCount >= SERVER_KNOBS->PEER_DEGRADATION_CONNECTION_FAILURE_COUNT ||
-						    peer->pingLatencies.percentile(
-						        SERVER_KNOBS->PEER_LATENCY_DEGRADATION_PERCENTILE_SATELLITE) >
-						        SERVER_KNOBS->PEER_LATENCY_DEGRADATION_THRESHOLD_SATELLITE ||
-						    peer->timeoutCount / (double)(peer->pingLatencies.getPopulationSize()) >
-						        SERVER_KNOBS->PEER_TIMEOUT_PERCENTAGE_DEGRADATION_THRESHOLD) {
+						if (peer->connectFailedCount >= SERVER_KNOBS->PEER_DEGRADATION_CONNECTION_FAILURE_COUNT) {
+							disconnectedPeer = true;
+						} else if (peer->pingLatencies.percentile(
+						               SERVER_KNOBS->PEER_LATENCY_DEGRADATION_PERCENTILE_SATELLITE) >
+						               SERVER_KNOBS->PEER_LATENCY_DEGRADATION_THRESHOLD_SATELLITE ||
+						           peer->timeoutCount / (double)(peer->pingLatencies.getPopulationSize()) >
+						               SERVER_KNOBS->PEER_TIMEOUT_PERCENTAGE_DEGRADATION_THRESHOLD) {
 							degradedPeer = true;
+						}
+
+						if (disconnectedPeer || degradedPeer) {
+							TraceEvent("HealthMonitorDetectDegradedPeer")
+							    .detail("Peer", address)
+							    .detail("Elapsed", now() - peer->lastLoggedTime)
+							    .detail("Disconnected", disconnectedPeer)
+							    .detail("MinLatency", peer->pingLatencies.min())
+							    .detail("MaxLatency", peer->pingLatencies.max())
+							    .detail("MeanLatency", peer->pingLatencies.mean())
+							    .detail("MedianLatency", peer->pingLatencies.median())
+							    .detail("CheckedPercentile",
+							            SERVER_KNOBS->PEER_LATENCY_DEGRADATION_PERCENTILE_SATELLITE)
+							    .detail("CheckedPercentileLatency",
+							            peer->pingLatencies.percentile(
+							                SERVER_KNOBS->PEER_LATENCY_DEGRADATION_PERCENTILE_SATELLITE))
+							    .detail("PingCount", peer->pingLatencies.getPopulationSize())
+							    .detail("PingTimeoutCount", peer->timeoutCount)
+							    .detail("ConnectionFailureCount", peer->connectFailedCount);
 						}
 					}
 
-					if (degradedPeer) {
-						TraceEvent("HealthMonitorDetectDegradedPeer")
-						    .suppressFor(30)
-						    .detail("Peer", address)
-						    .detail("Elapsed", now() - peer->lastLoggedTime)
-						    .detail("MinLatency", peer->pingLatencies.min())
-						    .detail("MaxLatency", peer->pingLatencies.max())
-						    .detail("MeanLatency", peer->pingLatencies.mean())
-						    .detail("MedianLatency", peer->pingLatencies.median())
-						    .detail("CheckedPercentile", SERVER_KNOBS->PEER_LATENCY_DEGRADATION_PERCENTILE)
-						    .detail("CheckedPercentileLatency",
-						            peer->pingLatencies.percentile(SERVER_KNOBS->PEER_LATENCY_DEGRADATION_PERCENTILE))
-						    .detail("PingCount", peer->pingLatencies.getPopulationSize())
-						    .detail("PingTimeoutCount", peer->timeoutCount)
-						    .detail("ConnectionFailureCount", peer->connectFailedCount);
-
+					if (disconnectedPeer) {
+						req.disconnectedPeers.push_back(address);
+					} else if (degradedPeer) {
 						req.degradedPeers.push_back(address);
 					}
 				}
@@ -1034,13 +1060,13 @@ ACTOR Future<Void> healthMonitor(Reference<AsyncVar<Optional<ClusterControllerFu
 						    (workerLocation == Remote && addressInDbAndRemoteDc(address, dbInfo)) ||
 						    (workerLocation == Primary && addressInDbAndPrimarySatelliteDc(address, dbInfo))) {
 							TraceEvent("HealthMonitorDetectRecentClosedPeer").suppressFor(30).detail("Peer", address);
-							req.degradedPeers.push_back(address);
+							req.disconnectedPeers.push_back(address);
 						}
 					}
 				}
 			}
 
-			if (!req.degradedPeers.empty()) {
+			if (!req.disconnectedPeers.empty() || !req.degradedPeers.empty()) {
 				req.address = FlowTransport::transport().getLocalAddress();
 				ccInterface->get().get().updateWorkerHealth.send(req);
 			}


### PR DESCRIPTION
Cherry-pick #8352 

 20221003-170317-zhewu-pick-981b8544aac4decb        compressed=True data_size=31571291 duration=5265475 ended=100001 fail_fast=10 max_runs=100000 pass=100001 priority=100 remaining=0 runtime=1:09:26 sanity=False started=100170 stopped=20221003-181243 submitted=20221003-170317 timeout=5400 username=zhewu-pick

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
