### PR TITLE
In gray failure, ignore max degradation degree for a disconnected worker.

### DIFF
--- a/fdbserver/ClusterController.actor.cpp
+++ b/fdbserver/ClusterController.actor.cpp
@@ -2651,6 +2651,8 @@ ACTOR Future<Void> workerHealthMonitor(ClusterControllerData* self) {
 						if (self->recentRecoveryCountDueToHealth() < SERVER_KNOBS->CC_MAX_HEALTH_RECOVERY_COUNT) {
 							self->recentHealthTriggeredRecoveryTime.push(now());
 							self->excludedDegradedServers = self->degradationInfo.degradedServers;
+							self->excludedDegradedServers.insert(self->degradationInfo.disconnectedServers.begin(),
+							                                     self->degradationInfo.disconnectedServers.end());
 							TraceEvent("DegradedServerDetectedAndTriggerRecovery")
 							    .detail("RecentRecoveryCountDueToHealth", self->recentRecoveryCountDueToHealth());
 							self->db.forceMasterFailure.trigger();

--- a/fdbserver/ClusterController.actor.cpp
+++ b/fdbserver/ClusterController.actor.cpp
@@ -2950,6 +2950,8 @@ TEST_CASE("/fdbserver/clustercontroller/updateWorkerHealth") {
 		req.address = workerAddress;
 		req.degradedPeers.push_back(badPeer1);
 		req.degradedPeers.push_back(badPeer2);
+		req.disconnectedPeers.push_back(badPeer1);
+		req.disconnectedPeers.push_back(badPeer2);
 		data.updateWorkerHealth(req);
 		ASSERT(data.workerHealth.find(workerAddress) != data.workerHealth.end());
 		auto& health = data.workerHealth[workerAddress];
@@ -2958,6 +2960,11 @@ TEST_CASE("/fdbserver/clustercontroller/updateWorkerHealth") {
 		ASSERT_EQ(health.degradedPeers[badPeer1].startTime, health.degradedPeers[badPeer1].lastRefreshTime);
 		ASSERT(health.degradedPeers.find(badPeer2) != health.degradedPeers.end());
 		ASSERT_EQ(health.degradedPeers[badPeer2].startTime, health.degradedPeers[badPeer2].lastRefreshTime);
+		ASSERT_EQ(health.disconnectedPeers.size(), 2);
+		ASSERT(health.disconnectedPeers.find(badPeer1) != health.disconnectedPeers.end());
+		ASSERT_EQ(health.disconnectedPeers[badPeer1].startTime, health.disconnectedPeers[badPeer1].lastRefreshTime);
+		ASSERT(health.disconnectedPeers.find(badPeer2) != health.disconnectedPeers.end());
+		ASSERT_EQ(health.disconnectedPeers[badPeer2].startTime, health.disconnectedPeers[badPeer2].lastRefreshTime);
 	}
 
 	// Create a `UpdateWorkerHealthRequest` with two bad peers, one from the previous test and a new one.
@@ -2972,6 +2979,8 @@ TEST_CASE("/fdbserver/clustercontroller/updateWorkerHealth") {
 		req.address = workerAddress;
 		req.degradedPeers.push_back(badPeer1);
 		req.degradedPeers.push_back(badPeer3);
+		req.disconnectedPeers.push_back(badPeer1);
+		req.disconnectedPeers.push_back(badPeer3);
 		data.updateWorkerHealth(req);
 		ASSERT(data.workerHealth.find(workerAddress) != data.workerHealth.end());
 		auto& health = data.workerHealth[workerAddress];
@@ -2983,6 +2992,15 @@ TEST_CASE("/fdbserver/clustercontroller/updateWorkerHealth") {
 		ASSERT_EQ(health.degradedPeers[badPeer2].startTime, health.degradedPeers[badPeer1].startTime);
 		ASSERT(health.degradedPeers.find(badPeer3) != health.degradedPeers.end());
 		ASSERT_EQ(health.degradedPeers[badPeer3].startTime, health.degradedPeers[badPeer3].lastRefreshTime);
+		ASSERT_EQ(health.disconnectedPeers.size(), 3);
+		ASSERT(health.disconnectedPeers.find(badPeer1) != health.disconnectedPeers.end());
+		ASSERT_LT(health.disconnectedPeers[badPeer1].startTime, health.disconnectedPeers[badPeer1].lastRefreshTime);
+		ASSERT(health.disconnectedPeers.find(badPeer2) != health.disconnectedPeers.end());
+		ASSERT_EQ(health.disconnectedPeers[badPeer2].startTime, health.disconnectedPeers[badPeer2].lastRefreshTime);
+		ASSERT_EQ(health.disconnectedPeers[badPeer2].startTime, health.disconnectedPeers[badPeer1].startTime);
+		ASSERT(health.disconnectedPeers.find(badPeer3) != health.disconnectedPeers.end());
+		ASSERT_EQ(health.disconnectedPeers[badPeer3].startTime, health.disconnectedPeers[badPeer3].lastRefreshTime);
+
 		previousStartTime = health.degradedPeers[badPeer3].startTime;
 		previousRefreshTime = health.degradedPeers[badPeer3].lastRefreshTime;
 	}
@@ -3000,20 +3018,10 @@ TEST_CASE("/fdbserver/clustercontroller/updateWorkerHealth") {
 		ASSERT(health.degradedPeers.find(badPeer3) != health.degradedPeers.end());
 		ASSERT_EQ(health.degradedPeers[badPeer3].startTime, previousStartTime);
 		ASSERT_EQ(health.degradedPeers[badPeer3].lastRefreshTime, previousRefreshTime);
-	}
-
-	// Create a `UpdateWorkerHealthRequest` with disconnected peers, which should update the bad peer's lastRefreshTime.
-	{
-		wait(delay(0.001));
-		UpdateWorkerHealthRequest req;
-		req.address = workerAddress;
-		req.disconnectedPeers.push_back(badPeer3);
-		data.updateWorkerHealth(req);
-		ASSERT(data.workerHealth.find(workerAddress) != data.workerHealth.end());
-		auto& health = data.workerHealth[workerAddress];
-		ASSERT_EQ(health.degradedPeers.size(), 3);
-		ASSERT(health.degradedPeers.find(badPeer3) != health.degradedPeers.end());
-		ASSERT_LT(health.degradedPeers[badPeer3].startTime, health.degradedPeers[badPeer3].lastRefreshTime);
+		ASSERT_EQ(health.disconnectedPeers.size(), 3);
+		ASSERT(health.disconnectedPeers.find(badPeer3) != health.disconnectedPeers.end());
+		ASSERT_EQ(health.disconnectedPeers[badPeer3].startTime, previousStartTime);
+		ASSERT_EQ(health.disconnectedPeers[badPeer3].lastRefreshTime, previousRefreshTime);
 	}
 
 	return Void();
@@ -3029,11 +3037,14 @@ TEST_CASE("/fdbserver/clustercontroller/updateRecoveredWorkers") {
 	NetworkAddress worker2(IPAddress(0x11111111), 1);
 	NetworkAddress badPeer1(IPAddress(0x02020202), 1);
 	NetworkAddress badPeer2(IPAddress(0x03030303), 1);
+	NetworkAddress disconnectedPeer3(IPAddress(0x04040404), 1);
 
 	// Create following test scenario:
 	// 	 worker1 -> badPeer1 active
 	// 	 worker1 -> badPeer2 recovered
+	//   worker1 -> disconnectedPeer3 active
 	// 	 worker2 -> badPeer2 recovered
+	//   worker2 -> disconnectedPeer3 recovered
 	data.workerHealth[worker1].degradedPeers[badPeer1] = {
 		now() - SERVER_KNOBS->CC_DEGRADED_LINK_EXPIRATION_INTERVAL - 1, now()
 	};
@@ -3041,7 +3052,14 @@ TEST_CASE("/fdbserver/clustercontroller/updateRecoveredWorkers") {
 		now() - SERVER_KNOBS->CC_DEGRADED_LINK_EXPIRATION_INTERVAL - 1,
 		now() - SERVER_KNOBS->CC_DEGRADED_LINK_EXPIRATION_INTERVAL - 1
 	};
+	data.workerHealth[worker1].degradedPeers[disconnectedPeer3] = {
+		now() - SERVER_KNOBS->CC_DEGRADED_LINK_EXPIRATION_INTERVAL - 1, now()
+	};
 	data.workerHealth[worker2].degradedPeers[badPeer2] = {
+		now() - SERVER_KNOBS->CC_DEGRADED_LINK_EXPIRATION_INTERVAL - 1,
+		now() - SERVER_KNOBS->CC_DEGRADED_LINK_EXPIRATION_INTERVAL - 1
+	};
+	data.workerHealth[worker2].degradedPeers[disconnectedPeer3] = {
 		now() - SERVER_KNOBS->CC_DEGRADED_LINK_EXPIRATION_INTERVAL - 1,
 		now() - SERVER_KNOBS->CC_DEGRADED_LINK_EXPIRATION_INTERVAL - 1
 	};
@@ -3051,6 +3069,8 @@ TEST_CASE("/fdbserver/clustercontroller/updateRecoveredWorkers") {
 	ASSERT(data.workerHealth.find(worker1) != data.workerHealth.end());
 	ASSERT(data.workerHealth[worker1].degradedPeers.find(badPeer1) != data.workerHealth[worker1].degradedPeers.end());
 	ASSERT(data.workerHealth[worker1].degradedPeers.find(badPeer2) == data.workerHealth[worker1].degradedPeers.end());
+	ASSERT(data.workerHealth[worker1].degradedPeers.find(disconnectedPeer3) !=
+	       data.workerHealth[worker1].degradedPeers.end());
 	ASSERT(data.workerHealth.find(worker2) == data.workerHealth.end());
 
 	return Void();
@@ -3072,6 +3092,7 @@ TEST_CASE("/fdbserver/clustercontroller/getDegradationInfo") {
 	// cluster controller.
 	{
 		data.workerHealth[worker].degradedPeers[badPeer1] = { now(), now() };
+		data.workerHealth[worker].disconnectedPeers[badPeer2] = { now(), now() };
 		ASSERT(data.getDegradationInfo().degradedServers.empty());
 		data.workerHealth.clear();
 	}
@@ -3084,6 +3105,19 @@ TEST_CASE("/fdbserver/clustercontroller/getDegradationInfo") {
 		auto degradationInfo = data.getDegradationInfo();
 		ASSERT(degradationInfo.degradedServers.size() == 1);
 		ASSERT(degradationInfo.degradedServers.find(badPeer1) != degradationInfo.degradedServers.end());
+		ASSERT(degradationInfo.disconnectedServers.empty());
+		data.workerHealth.clear();
+	}
+
+	// Test that when there is only one reported disconnected link, getDegradationInfo can return correct
+	// degraded server.
+	{
+		data.workerHealth[worker].disconnectedPeers[badPeer1] = { now() - SERVER_KNOBS->CC_MIN_DEGRADATION_INTERVAL - 1,
+			                                                      now() };
+		auto degradationInfo = data.getDegradationInfo();
+		ASSERT(degradationInfo.disconnectedServers.size() == 1);
+		ASSERT(degradationInfo.disconnectedServers.find(badPeer1) != degradationInfo.disconnectedServers.end());
+		ASSERT(degradationInfo.degradedServers.empty());
 		data.workerHealth.clear();
 	}
 
@@ -3093,16 +3127,25 @@ TEST_CASE("/fdbserver/clustercontroller/getDegradationInfo") {
 			                                                  now() };
 		data.workerHealth[badPeer1].degradedPeers[worker] = { now() - SERVER_KNOBS->CC_MIN_DEGRADATION_INTERVAL - 1,
 			                                                  now() };
+		data.workerHealth[worker].disconnectedPeers[badPeer2] = { now() - SERVER_KNOBS->CC_MIN_DEGRADATION_INTERVAL - 1,
+			                                                      now() };
+		data.workerHealth[badPeer2].disconnectedPeers[worker] = { now() - SERVER_KNOBS->CC_MIN_DEGRADATION_INTERVAL - 1,
+			                                                      now() };
 		auto degradationInfo = data.getDegradationInfo();
 		ASSERT(degradationInfo.degradedServers.size() == 1);
 		ASSERT(degradationInfo.degradedServers.find(worker) != degradationInfo.degradedServers.end() ||
 		       degradationInfo.degradedServers.find(badPeer1) != degradationInfo.degradedServers.end());
+		ASSERT(degradationInfo.disconnectedServers.size() == 1);
+		ASSERT(degradationInfo.disconnectedServers.find(worker) != degradationInfo.disconnectedServers.end() ||
+		       degradationInfo.disconnectedServers.find(badPeer2) != degradationInfo.disconnectedServers.end());
 		data.workerHealth.clear();
 	}
 
 	// Test that if B complains A and C complains A, A is selected as degraded server instead of B or C.
 	{
 		ASSERT(SERVER_KNOBS->CC_DEGRADED_PEER_DEGREE_TO_EXCLUDE < 4);
+
+		// test for both degraded peers and disconnected peers.
 		data.workerHealth[worker].degradedPeers[badPeer1] = { now() - SERVER_KNOBS->CC_MIN_DEGRADATION_INTERVAL - 1,
 			                                                  now() };
 		data.workerHealth[badPeer1].degradedPeers[worker] = { now() - SERVER_KNOBS->CC_MIN_DEGRADATION_INTERVAL - 1,
@@ -3111,9 +3154,19 @@ TEST_CASE("/fdbserver/clustercontroller/getDegradationInfo") {
 			                                                  now() };
 		data.workerHealth[badPeer2].degradedPeers[worker] = { now() - SERVER_KNOBS->CC_MIN_DEGRADATION_INTERVAL - 1,
 			                                                  now() };
+		data.workerHealth[worker].disconnectedPeers[badPeer3] = { now() - SERVER_KNOBS->CC_MIN_DEGRADATION_INTERVAL - 1,
+			                                                      now() };
+		data.workerHealth[badPeer3].disconnectedPeers[worker] = { now() - SERVER_KNOBS->CC_MIN_DEGRADATION_INTERVAL - 1,
+			                                                      now() };
+		data.workerHealth[worker].disconnectedPeers[badPeer4] = { now() - SERVER_KNOBS->CC_MIN_DEGRADATION_INTERVAL - 1,
+			                                                      now() };
+		data.workerHealth[badPeer4].disconnectedPeers[worker] = { now() - SERVER_KNOBS->CC_MIN_DEGRADATION_INTERVAL - 1,
+			                                                      now() };
 		auto degradationInfo = data.getDegradationInfo();
 		ASSERT(degradationInfo.degradedServers.size() == 1);
 		ASSERT(degradationInfo.degradedServers.find(worker) != degradationInfo.degradedServers.end());
+		ASSERT(degradationInfo.disconnectedServers.size() == 1);
+		ASSERT(degradationInfo.disconnectedServers.find(worker) != degradationInfo.disconnectedServers.end());
 		data.workerHealth.clear();
 	}
 
@@ -3129,6 +3182,23 @@ TEST_CASE("/fdbserver/clustercontroller/getDegradationInfo") {
 		data.workerHealth[badPeer4].degradedPeers[worker] = { now() - SERVER_KNOBS->CC_MIN_DEGRADATION_INTERVAL - 1,
 			                                                  now() };
 		ASSERT(data.getDegradationInfo().degradedServers.empty());
+		data.workerHealth.clear();
+	}
+
+	// Test that CC_DEGRADED_PEER_DEGREE_TO_EXCLUDE doesn't affect disconnectedServers calculation.
+	{
+		ASSERT(SERVER_KNOBS->CC_DEGRADED_PEER_DEGREE_TO_EXCLUDE < 4);
+		data.workerHealth[badPeer1].disconnectedPeers[worker] = { now() - SERVER_KNOBS->CC_MIN_DEGRADATION_INTERVAL - 1,
+			                                                      now() };
+		data.workerHealth[badPeer2].disconnectedPeers[worker] = { now() - SERVER_KNOBS->CC_MIN_DEGRADATION_INTERVAL - 1,
+			                                                      now() };
+		data.workerHealth[badPeer3].disconnectedPeers[worker] = { now() - SERVER_KNOBS->CC_MIN_DEGRADATION_INTERVAL - 1,
+			                                                      now() };
+		data.workerHealth[badPeer4].disconnectedPeers[worker] = { now() - SERVER_KNOBS->CC_MIN_DEGRADATION_INTERVAL - 1,
+			                                                      now() };
+		ASSERT(data.getDegradationInfo().disconnectedServers.size() == 1);
+		ASSERT(data.getDegradationInfo().disconnectedServers.find(worker) !=
+		       data.getDegradationInfo().disconnectedServers.end());
 		data.workerHealth.clear();
 	}
 
@@ -3253,40 +3323,65 @@ TEST_CASE("/fdbserver/clustercontroller/shouldTriggerRecoveryDueToDegradedServer
 	data.degradationInfo.degradedServers.insert(master);
 	ASSERT(data.shouldTriggerRecoveryDueToDegradedServers());
 	data.degradationInfo.degradedServers.clear();
+	data.degradationInfo.disconnectedServers.insert(master);
+	ASSERT(data.shouldTriggerRecoveryDueToDegradedServers());
+	data.degradationInfo.disconnectedServers.clear();
 
 	// Trigger recovery when primary TLog is degraded.
 	data.degradationInfo.degradedServers.insert(tlog);
 	ASSERT(data.shouldTriggerRecoveryDueToDegradedServers());
 	data.degradationInfo.degradedServers.clear();
+	data.degradationInfo.disconnectedServers.insert(tlog);
+	ASSERT(data.shouldTriggerRecoveryDueToDegradedServers());
+	data.degradationInfo.disconnectedServers.clear();
 
 	// No recovery when satellite Tlog is degraded.
 	data.degradationInfo.degradedServers.insert(satelliteTlog);
 	ASSERT(!data.shouldTriggerRecoveryDueToDegradedServers());
 	data.degradationInfo.degradedServers.clear();
+	data.degradationInfo.disconnectedServers.insert(satelliteTlog);
+	ASSERT(!data.shouldTriggerRecoveryDueToDegradedServers());
+	data.degradationInfo.disconnectedServers.clear();
 
 	// No recovery when remote tlog is degraded.
 	data.degradationInfo.degradedServers.insert(remoteTlog);
 	ASSERT(!data.shouldTriggerRecoveryDueToDegradedServers());
 	data.degradationInfo.degradedServers.clear();
+	data.degradationInfo.disconnectedServers.insert(remoteTlog);
+	ASSERT(!data.shouldTriggerRecoveryDueToDegradedServers());
+	data.degradationInfo.disconnectedServers.clear();
 
 	// No recovery when log router is degraded.
 	data.degradationInfo.degradedServers.insert(logRouter);
 	ASSERT(!data.shouldTriggerRecoveryDueToDegradedServers());
 	data.degradationInfo.degradedServers.clear();
+	data.degradationInfo.disconnectedServers.insert(logRouter);
+	ASSERT(!data.shouldTriggerRecoveryDueToDegradedServers());
+	data.degradationInfo.disconnectedServers.clear();
 
 	// No recovery when backup worker is degraded.
 	data.degradationInfo.degradedServers.insert(backup);
 	ASSERT(!data.shouldTriggerRecoveryDueToDegradedServers());
 	data.degradationInfo.degradedServers.clear();
+	data.degradationInfo.disconnectedServers.insert(backup);
+	ASSERT(!data.shouldTriggerRecoveryDueToDegradedServers());
+	data.degradationInfo.disconnectedServers.clear();
 
 	// Trigger recovery when proxy is degraded.
 	data.degradationInfo.degradedServers.insert(proxy);
 	ASSERT(data.shouldTriggerRecoveryDueToDegradedServers());
 	data.degradationInfo.degradedServers.clear();
+	data.degradationInfo.disconnectedServers.insert(proxy);
+	ASSERT(data.shouldTriggerRecoveryDueToDegradedServers());
+	data.degradationInfo.disconnectedServers.clear();
 
 	// Trigger recovery when resolver is degraded.
 	data.degradationInfo.degradedServers.insert(resolver);
 	ASSERT(data.shouldTriggerRecoveryDueToDegradedServers());
+	data.degradationInfo.degradedServers.clear();
+	data.degradationInfo.disconnectedServers.insert(resolver);
+	ASSERT(data.shouldTriggerRecoveryDueToDegradedServers());
+	data.degradationInfo.disconnectedServers.clear();
 
 	return Void();
 }
@@ -3367,6 +3462,9 @@ TEST_CASE("/fdbserver/clustercontroller/shouldTriggerFailoverDueToDegradedServer
 	data.degradationInfo.degradedServers.insert(master);
 	ASSERT(!data.shouldTriggerFailoverDueToDegradedServers());
 	data.degradationInfo.degradedServers.clear();
+	data.degradationInfo.disconnectedServers.insert(master);
+	ASSERT(!data.shouldTriggerFailoverDueToDegradedServers());
+	data.degradationInfo.disconnectedServers.clear();
 
 	// Trigger failover when enough servers in the txn system are degraded.
 	data.degradationInfo.degradedServers.insert(master);
@@ -3374,6 +3472,13 @@ TEST_CASE("/fdbserver/clustercontroller/shouldTriggerFailoverDueToDegradedServer
 	data.degradationInfo.degradedServers.insert(proxy);
 	data.degradationInfo.degradedServers.insert(proxy2);
 	data.degradationInfo.degradedServers.insert(resolver);
+	ASSERT(data.shouldTriggerFailoverDueToDegradedServers());
+	data.degradationInfo.degradedServers.clear();
+	data.degradationInfo.disconnectedServers.insert(master);
+	data.degradationInfo.disconnectedServers.insert(tlog);
+	data.degradationInfo.disconnectedServers.insert(proxy);
+	data.degradationInfo.disconnectedServers.insert(proxy2);
+	data.degradationInfo.disconnectedServers.insert(resolver);
 	ASSERT(data.shouldTriggerFailoverDueToDegradedServers());
 
 	// No failover when usable region is 1.
@@ -3385,6 +3490,9 @@ TEST_CASE("/fdbserver/clustercontroller/shouldTriggerFailoverDueToDegradedServer
 	data.degradationInfo.degradedServers.insert(remoteTlog);
 	ASSERT(!data.shouldTriggerFailoverDueToDegradedServers());
 	data.degradationInfo.degradedServers.clear();
+	data.degradationInfo.disconnectedServers.insert(remoteTlog);
+	ASSERT(!data.shouldTriggerFailoverDueToDegradedServers());
+	data.degradationInfo.disconnectedServers.clear();
 
 	// No failover when some are not from transaction system
 	data.degradationInfo.degradedServers.insert(NetworkAddress(IPAddress(0x13131313), 1));
@@ -3405,6 +3513,9 @@ TEST_CASE("/fdbserver/clustercontroller/shouldTriggerFailoverDueToDegradedServer
 	data.degradationInfo.degradedServers.insert(remoteTlog);
 	ASSERT(!data.shouldTriggerFailoverDueToDegradedServers());
 	data.degradationInfo.degradedServers.clear();
+	data.degradationInfo.disconnectedServers.insert(remoteTlog);
+	ASSERT(!data.shouldTriggerFailoverDueToDegradedServers());
+	data.degradationInfo.disconnectedServers.clear();
 
 	return Void();
 }

--- a/fdbserver/ClusterController.actor.cpp
+++ b/fdbserver/ClusterController.actor.cpp
@@ -2617,23 +2617,31 @@ ACTOR Future<Void> workerHealthMonitor(ClusterControllerData* self) {
 
 			self->degradationInfo = self->getDegradationInfo();
 
-			// Compare `self->degradedServers` with `self->excludedDegradedServers` and remove those that have
+			// Compare `self->degradationInfo` with `self->excludedDegradedServers` and remove those that have
 			// recovered.
 			for (auto it = self->excludedDegradedServers.begin(); it != self->excludedDegradedServers.end();) {
-				if (self->degradationInfo.degradedServers.find(*it) == self->degradationInfo.degradedServers.end()) {
+				if (self->degradationInfo.degradedServers.find(*it) == self->degradationInfo.degradedServers.end() &&
+				    self->degradationInfo.disconnectedServers.find(*it) ==
+				        self->degradationInfo.disconnectedServers.end()) {
 					self->excludedDegradedServers.erase(it++);
 				} else {
 					++it;
 				}
 			}
 
-			if (!self->degradationInfo.degradedServers.empty() || self->degradationInfo.degradedSatellite) {
+			if (!self->degradationInfo.degradedServers.empty() || !self->degradationInfo.disconnectedServers.empty() ||
+			    self->degradationInfo.degradedSatellite) {
 				std::string degradedServerString;
 				for (const auto& server : self->degradationInfo.degradedServers) {
 					degradedServerString += server.toString() + " ";
 				}
+				std::string disconnectedServerString;
+				for (const auto& server : self->degradationInfo.disconnectedServers) {
+					disconnectedServerString += server.toString() + " ";
+				}
 				TraceEvent("ClusterControllerHealthMonitor")
 				    .detail("DegradedServers", degradedServerString)
+				    .detail("DisconnectedServers", disconnectedServerString)
 				    .detail("DegradedSatellite", self->degradationInfo.degradedSatellite);
 
 				// Check if the cluster controller should trigger a recovery to exclude any degraded servers from

--- a/fdbserver/include/fdbserver/ClusterController.actor.h
+++ b/fdbserver/include/fdbserver/ClusterController.actor.h
@@ -2965,9 +2965,8 @@ public:
 				workerHealth[req.address].degradedPeers[degradedPeer] = { currentTime, currentTime };
 			}
 
-			// TODO(zhewu): add disconnected peers in worker health.
 			for (const auto& degradedPeer : req.disconnectedPeers) {
-				workerHealth[req.address].degradedPeers[degradedPeer] = { currentTime, currentTime };
+				workerHealth[req.address].disconnectedPeers[degradedPeer] = { currentTime, currentTime };
 			}
 
 			return;
@@ -2977,23 +2976,24 @@ public:
 
 		auto& health = workerHealth[req.address];
 
-		auto updateDegradedPeer = [&health, currentTime](const NetworkAddress& degradedPeer) {
-			auto it = health.degradedPeers.find(degradedPeer);
-			if (it == health.degradedPeers.end()) {
-				health.degradedPeers[degradedPeer] = { currentTime, currentTime };
-				return;
-			}
-			it->second.lastRefreshTime = currentTime;
-		};
-
 		// Update the worker's degradedPeers.
 		for (const auto& peer : req.degradedPeers) {
-			updateDegradedPeer(peer);
+			auto it = health.degradedPeers.find(peer);
+			if (it == health.degradedPeers.end()) {
+				health.degradedPeers[peer] = { currentTime, currentTime };
+				continue;
+			}
+			it->second.lastRefreshTime = currentTime;
 		}
 
-		// TODO(zhewu): add disconnected peers in worker health.
+		// Update the worker's disconnectedPeers.
 		for (const auto& peer : req.disconnectedPeers) {
-			updateDegradedPeer(peer);
+			auto it = health.disconnectedPeers.find(peer);
+			if (it == health.disconnectedPeers.end()) {
+				health.disconnectedPeers[peer] = { currentTime, currentTime };
+				continue;
+			}
+			it->second.lastRefreshTime = currentTime;
 		}
 	}
 
@@ -3009,10 +3009,18 @@ public:
 					++it;
 				}
 			}
+			for (auto it = health.disconnectedPeers.begin(); it != health.disconnectedPeers.end();) {
+				if (currentTime - it->second.lastRefreshTime > SERVER_KNOBS->CC_DEGRADED_LINK_EXPIRATION_INTERVAL) {
+					TraceEvent("WorkerPeerHealthRecovered").detail("Worker", workerAddress).detail("Peer", it->first);
+					health.disconnectedPeers.erase(it++);
+				} else {
+					++it;
+				}
+			}
 		}
 
 		for (auto it = workerHealth.begin(); it != workerHealth.end();) {
-			if (it->second.degradedPeers.empty()) {
+			if (it->second.degradedPeers.empty() && it->second.disconnectedPeers.empty()) {
 				TraceEvent("WorkerAllPeerHealthRecovered").detail("Worker", it->first);
 				workerHealth.erase(it++);
 			} else {
@@ -3025,6 +3033,7 @@ public:
 		std::unordered_set<NetworkAddress>
 		    degradedServers; // The servers that the cluster controller is considered as degraded. The servers in this
 		                     // list are not excluded unless they are added to `excludedDegradedServers`.
+		std::unordered_set<NetworkAddress> disconnectedServers;
 
 		bool degradedSatellite = false; // Indicates that the entire satellite DC is degraded.
 	};
@@ -3035,6 +3044,7 @@ public:
 
 		// Build a map keyed by measured degraded peer. This map gives the info that who complains a particular server.
 		std::unordered_map<NetworkAddress, std::unordered_set<NetworkAddress>> degradedLinkDst2Src;
+		std::unordered_map<NetworkAddress, std::unordered_set<NetworkAddress>> disconnectedLinkDst2Src;
 		double currentTime = now();
 		for (const auto& [server, health] : workerHealth) {
 			for (const auto& [degradedPeer, times] : health.degradedPeers) {
@@ -3044,6 +3054,13 @@ public:
 				}
 				degradedLinkDst2Src[degradedPeer].insert(server);
 			}
+			for (const auto& [disconnectedPeer, times] : health.disconnectedPeers) {
+				if (currentTime - times.startTime < SERVER_KNOBS->CC_MIN_DEGRADATION_INTERVAL) {
+					// This degraded link is not long enough to be considered as degraded.
+					continue;
+				}
+				disconnectedLinkDst2Src[disconnectedPeer].insert(server);
+			}
 		}
 
 		// Sort degraded peers based on the number of workers complaining about it.
@@ -3052,6 +3069,12 @@ public:
 			count2DegradedPeer.push_back({ complainers.size(), degradedPeer });
 		}
 		std::sort(count2DegradedPeer.begin(), count2DegradedPeer.end(), std::greater<>());
+
+		std::vector<std::pair<int, NetworkAddress>> count2DisconnectedPeer;
+		for (const auto& [disconnectedPeer, complainers] : disconnectedLinkDst2Src) {
+			count2DisconnectedPeer.push_back({ complainers.size(), disconnectedPeer });
+		}
+		std::sort(count2DisconnectedPeer.begin(), count2DisconnectedPeer.end(), std::greater<>());
 
 		// Go through all reported degraded peers by decreasing order of the number of complainers. For a particular
 		// degraded peer, if a complainer has already be considered as degraded, we skip the current examine degraded
@@ -3081,9 +3104,25 @@ public:
 			}
 		}
 
+		DegradationInfo currentDegradationInfo;
+		for (const auto& [complainerCount, badServer] : count2DisconnectedPeer) {
+			for (const auto& complainer : disconnectedLinkDst2Src[badServer]) {
+				if (currentDegradationInfo.disconnectedServers.find(complainer) ==
+				    currentDegradationInfo.disconnectedServers.end()) {
+					currentDegradationInfo.disconnectedServers.insert(badServer);
+					break;
+				}
+			}
+
+			if (SERVER_KNOBS->CC_ENABLE_ENTIRE_SATELLITE_MONITORING &&
+			    addressInDbAndPrimarySatelliteDc(badServer, db.serverInfo) &&
+			    complainerCount >= SERVER_KNOBS->CC_SATELLITE_DEGRADATION_MIN_COMPLAINER) {
+				++satelliteBadServerCount;
+			}
+		}
+
 		// For degraded server that are complained by more than SERVER_KNOBS->CC_DEGRADED_PEER_DEGREE_TO_EXCLUDE, we
 		// don't know if it is a hot server, or the network is bad. We remove from the returned degraded server list.
-		DegradationInfo currentDegradationInfo;
 		for (const auto& badServer : currentDegradedServers) {
 			if (degradedLinkDst2Src[badServer].size() <= SERVER_KNOBS->CC_DEGRADED_PEER_DEGREE_TO_EXCLUDE) {
 				currentDegradationInfo.degradedServers.insert(badServer);
@@ -3101,43 +3140,48 @@ public:
 
 	// Whether the transaction system (in primary DC if in HA setting) contains degraded servers.
 	bool transactionSystemContainsDegradedServers() {
-		const ServerDBInfo dbi = db.serverInfo->get();
-		for (const auto& excludedServer : degradationInfo.degradedServers) {
-			if (dbi.master.addresses().contains(excludedServer)) {
-				return true;
-			}
-
-			for (auto& logSet : dbi.logSystemConfig.tLogs) {
-				if (!logSet.isLocal || logSet.locality == tagLocalitySatellite) {
-					continue;
+		const ServerDBInfo& dbi = db.serverInfo->get();
+		auto transactionWorkerInList = [&dbi](const std::unordered_set<NetworkAddress>& serverList) -> bool {
+			for (const auto& server : serverList) {
+				if (dbi.master.addresses().contains(server)) {
+					return true;
 				}
-				for (const auto& tlog : logSet.tLogs) {
-					if (tlog.present() && tlog.interf().addresses().contains(excludedServer)) {
+
+				for (const auto& logSet : dbi.logSystemConfig.tLogs) {
+					if (!logSet.isLocal || logSet.locality == tagLocalitySatellite) {
+						continue;
+					}
+					for (const auto& tlog : logSet.tLogs) {
+						if (tlog.present() && tlog.interf().addresses().contains(server)) {
+							return true;
+						}
+					}
+				}
+
+				for (const auto& proxy : dbi.client.grvProxies) {
+					if (proxy.addresses().contains(server)) {
+						return true;
+					}
+				}
+
+				for (const auto& proxy : dbi.client.commitProxies) {
+					if (proxy.addresses().contains(server)) {
+						return true;
+					}
+				}
+
+				for (const auto& resolver : dbi.resolvers) {
+					if (resolver.addresses().contains(server)) {
 						return true;
 					}
 				}
 			}
 
-			for (auto& proxy : dbi.client.grvProxies) {
-				if (proxy.addresses().contains(excludedServer)) {
-					return true;
-				}
-			}
+			return false;
+		};
 
-			for (auto& proxy : dbi.client.commitProxies) {
-				if (proxy.addresses().contains(excludedServer)) {
-					return true;
-				}
-			}
-
-			for (auto& resolver : dbi.resolvers) {
-				if (resolver.addresses().contains(excludedServer)) {
-					return true;
-				}
-			}
-		}
-
-		return false;
+		return transactionWorkerInList(degradationInfo.degradedServers) ||
+		       transactionWorkerInList(degradationInfo.disconnectedServers);
 	}
 
 	// Whether transaction system in the remote DC, e.g. log router and tlogs in the remote DC, contains degraded
@@ -3148,6 +3192,12 @@ public:
 		}
 
 		for (const auto& excludedServer : degradationInfo.degradedServers) {
+			if (addressInDbAndRemoteDc(excludedServer, db.serverInfo)) {
+				return true;
+			}
+		}
+
+		for (const auto& excludedServer : degradationInfo.disconnectedServers) {
 			if (addressInDbAndRemoteDc(excludedServer, db.serverInfo)) {
 				return true;
 			}
@@ -3185,7 +3235,8 @@ public:
 	// Returns true when the cluster controller should trigger a recovery due to degraded servers used in the
 	// transaction system in the primary data center.
 	bool shouldTriggerRecoveryDueToDegradedServers() {
-		if (degradationInfo.degradedServers.size() > SERVER_KNOBS->CC_MAX_EXCLUSION_DUE_TO_HEALTH) {
+		if (degradationInfo.degradedServers.size() + degradationInfo.disconnectedServers.size() >
+		    SERVER_KNOBS->CC_MAX_EXCLUSION_DUE_TO_HEALTH) {
 			return false;
 		}
 
@@ -3316,6 +3367,7 @@ public:
 			double lastRefreshTime = 0;
 		};
 		std::unordered_map<NetworkAddress, DegradedTimes> degradedPeers;
+		std::unordered_map<NetworkAddress, DegradedTimes> disconnectedPeers;
 
 		// TODO(zhewu): Include disk and CPU signals.
 	};

--- a/fdbserver/include/fdbserver/ClusterController.actor.h
+++ b/fdbserver/include/fdbserver/ClusterController.actor.h
@@ -3033,7 +3033,8 @@ public:
 		std::unordered_set<NetworkAddress>
 		    degradedServers; // The servers that the cluster controller is considered as degraded. The servers in this
 		                     // list are not excluded unless they are added to `excludedDegradedServers`.
-		std::unordered_set<NetworkAddress> disconnectedServers; // Similar to the above list, but the servers experiencing connection issue.
+		std::unordered_set<NetworkAddress>
+		    disconnectedServers; // Similar to the above list, but the servers experiencing connection issue.
 
 		bool degradedSatellite = false; // Indicates that the entire satellite DC is degraded.
 	};

--- a/fdbserver/include/fdbserver/ClusterController.actor.h
+++ b/fdbserver/include/fdbserver/ClusterController.actor.h
@@ -3275,8 +3275,9 @@ public:
 			return true;
 		}
 
-		if (degradationInfo.degradedServers.size() < SERVER_KNOBS->CC_FAILOVER_DUE_TO_HEALTH_MIN_DEGRADATION ||
-		    degradationInfo.degradedServers.size() > SERVER_KNOBS->CC_FAILOVER_DUE_TO_HEALTH_MAX_DEGRADATION) {
+		int degradedServerSize = degradationInfo.degradedServers.size() + degradationInfo.disconnectedServers.size();
+		if (degradedServerSize < SERVER_KNOBS->CC_FAILOVER_DUE_TO_HEALTH_MIN_DEGRADATION ||
+		    degradedServerSize > SERVER_KNOBS->CC_FAILOVER_DUE_TO_HEALTH_MAX_DEGRADATION) {
 			return false;
 		}
 

--- a/fdbserver/include/fdbserver/ClusterController.actor.h
+++ b/fdbserver/include/fdbserver/ClusterController.actor.h
@@ -3033,7 +3033,7 @@ public:
 		std::unordered_set<NetworkAddress>
 		    degradedServers; // The servers that the cluster controller is considered as degraded. The servers in this
 		                     // list are not excluded unless they are added to `excludedDegradedServers`.
-		std::unordered_set<NetworkAddress> disconnectedServers;
+		std::unordered_set<NetworkAddress> disconnectedServers; // Similar to the above list, but the servers experiencing connection issue.
 
 		bool degradedSatellite = false; // Indicates that the entire satellite DC is degraded.
 	};


### PR DESCRIPTION
Different from peers with high latency (we try to ignore a common bad server with many other server complaining high latencies), when a worker is disconnected (despite how many servers are complaining about it), we should exclude it from the active transaction system.

20221004-203602-zhewu-disconnect-40f49f826673d2be

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
