### PR TITLE
Fix heap-use-after-free in TenantAwareEncryptionKeyProvider

### DIFF
--- a/fdbserver/include/fdbserver/IPageEncryptionKeyProvider.actor.h
+++ b/fdbserver/include/fdbserver/IPageEncryptionKeyProvider.actor.h
@@ -384,7 +384,7 @@ private:
 			return FDB_DEFAULT_ENCRYPT_DOMAIN_NAME;
 		}
 		if (tenantPrefixIndex.isValid()) {
-			StringRef prefix = TenantMapEntry::idToPrefix(domainId);
+			Key prefix(TenantMapEntry::idToPrefix(domainId));
 			auto view = tenantPrefixIndex->atLatest();
 			auto itr = view.find(prefix);
 			if (itr != view.end()) {


### PR DESCRIPTION
`TenantMapEntry::idToPrefix` returns a `Key` which owns its own memory. Converting to `StringRef` will drop the ownership.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
