### PR TITLE
Remove testClass from restart tests

### DIFF
--- a/tests/restarting/from_7.0.0/UpgradeAndBackupRestore-1.toml
+++ b/tests/restarting/from_7.0.0/UpgradeAndBackupRestore-1.toml
@@ -1,4 +1,3 @@
-testClass = "Backup"
 storageEngineExcludeTypes=3
 
 [[test]]

--- a/tests/restarting/from_7.0.0/UpgradeAndBackupRestore-2.toml
+++ b/tests/restarting/from_7.0.0/UpgradeAndBackupRestore-2.toml
@@ -1,5 +1,3 @@
-testClass = "Backup"
-
 [[test]]
 testTitle = 'SecondCycleTest'
 simBackupAgents = 'BackupToFile'

--- a/tests/restarting/from_7.1.0/SnapCycleRestart-1.txt
+++ b/tests/restarting/from_7.1.0/SnapCycleRestart-1.txt
@@ -1,4 +1,3 @@
-testClass=SnapshotTest
 storageEngineExcludeTypes=[3, 4, 5]
 
 ;Take snap and do cycle test

--- a/tests/restarting/from_7.1.0/SnapCycleRestart-2.txt
+++ b/tests/restarting/from_7.1.0/SnapCycleRestart-2.txt
@@ -1,4 +1,3 @@
-testClass=SnapshotTest
 storageEngineExcludeTypes=[4, 5]
 buggify=off
 

--- a/tests/restarting/from_7.1.0/SnapIncrementalRestore-1.txt
+++ b/tests/restarting/from_7.1.0/SnapIncrementalRestore-1.txt
@@ -1,4 +1,3 @@
-testClass=SnapshotTest
 storageEngineExcludeTypes=[3, 4, 5]
 
 logAntiQuorum = 0

--- a/tests/restarting/from_7.1.0/SnapIncrementalRestore-2.txt
+++ b/tests/restarting/from_7.1.0/SnapIncrementalRestore-2.txt
@@ -1,4 +1,3 @@
-testClass=SnapshotTest
 storageEngineExcludeTypes=[4, 5]
 
 testTitle=RestoreBackup

--- a/tests/restarting/from_7.1.0/SnapTestAttrition-1.txt
+++ b/tests/restarting/from_7.1.0/SnapTestAttrition-1.txt
@@ -1,4 +1,3 @@
-testClass=SnapshotTest
 storageEngineExcludeTypes=[3, 4, 5]
 
 ;write 1000 Keys ending with even numbers

--- a/tests/restarting/from_7.1.0/SnapTestAttrition-2.txt
+++ b/tests/restarting/from_7.1.0/SnapTestAttrition-2.txt
@@ -1,4 +1,3 @@
-testClass=SnapshotTest
 storageEngineExcludeTypes=[4, 5]
 
 buggify=off

--- a/tests/restarting/from_7.1.0/SnapTestRestart-1.txt
+++ b/tests/restarting/from_7.1.0/SnapTestRestart-1.txt
@@ -1,4 +1,3 @@
-testClass=SnapshotTest
 storageEngineExcludeTypes=[3, 4, 5]
 
 ;write 1000 Keys ending with even numbers

--- a/tests/restarting/from_7.1.0/SnapTestRestart-2.txt
+++ b/tests/restarting/from_7.1.0/SnapTestRestart-2.txt
@@ -1,4 +1,3 @@
-testClass=SnapshotTest
 storageEngineExcludeTypes=[4, 5]
 
 buggify=off

--- a/tests/restarting/from_7.1.0/SnapTestSimpleRestart-1.txt
+++ b/tests/restarting/from_7.1.0/SnapTestSimpleRestart-1.txt
@@ -1,4 +1,3 @@
-testClass=SnapshotTest
 storageEngineExcludeTypes=[3, 4, 5]
 
 ;write 1000 Keys ending with even number

--- a/tests/restarting/from_7.1.0/SnapTestSimpleRestart-2.txt
+++ b/tests/restarting/from_7.1.0/SnapTestSimpleRestart-2.txt
@@ -1,4 +1,3 @@
-testClass=SnapshotTest
 storageEngineExcludeTypes=[4, 5]
 
 buggify=off


### PR DESCRIPTION
Old binaries don't understand the testClass field, so we can't have it
in test files old binaries might read. In the future we can have it for
7.2+

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
