### PR TITLE
TLog KVS::init() and allow overlapping commits in Redwood in which the caller drops commit futures (Cherry-pick #8410 to snowflake/release-71.2)

### DIFF
--- a/fdbserver/OldTLogServer_4_6.actor.cpp
+++ b/fdbserver/OldTLogServer_4_6.actor.cpp
@@ -1635,6 +1635,7 @@ ACTOR Future<Void> tLog(IKeyValueStore* persistentData,
 	TraceEvent("SharedTlog", tlogId).detail("Version", "4.6");
 
 	try {
+		wait(ioTimeoutError(persistentData->init(), SERVER_KNOBS->TLOG_MAX_CREATE_DURATION));
 		wait(restorePersistentState(&self, locality));
 
 		self.sharedActors.send(cleanupPeekTrackers(&self));

--- a/fdbserver/OldTLogServer_6_0.actor.cpp
+++ b/fdbserver/OldTLogServer_6_0.actor.cpp
@@ -1682,7 +1682,6 @@ ACTOR Future<Void> initPersistentState(TLogData* self, Reference<LogData> logDat
 
 	// PERSIST: Initial setup of persistentData for a brand new tLog for a new database
 	state IKeyValueStore* storage = self->persistentData;
-	wait(ioTimeoutError(storage->init(), SERVER_KNOBS->TLOG_MAX_CREATE_DURATION));
 	storage->set(persistFormat);
 	storage->set(
 	    KeyValueRef(BinaryWriter::toValue(logData->logId, Unversioned()).withPrefix(persistCurrentVersionKeys.begin),
@@ -2301,7 +2300,6 @@ ACTOR Future<Void> restorePersistentState(TLogData* self,
 	TraceEvent("TLogRestorePersistentState", self->dbgid).log();
 
 	state IKeyValueStore* storage = self->persistentData;
-	wait(storage->init());
 	state Future<Optional<Value>> fFormat = storage->readValue(persistFormat.key);
 	state Future<RangeResult> fVers = storage->readRange(persistCurrentVersionKeys);
 	state Future<RangeResult> fKnownCommitted = storage->readRange(persistKnownCommittedVersionKeys);
@@ -2808,6 +2806,8 @@ ACTOR Future<Void> tLog(IKeyValueStore* persistentData,
 	TraceEvent("SharedTlog", tlogId).detail("Version", "6.0");
 
 	try {
+		wait(ioTimeoutError(persistentData->init(), SERVER_KNOBS->TLOG_MAX_CREATE_DURATION));
+
 		if (restoreFromDisk) {
 			wait(restorePersistentState(&self, locality, oldLog, recovered, tlogRequests));
 		} else {

--- a/fdbserver/OldTLogServer_6_2.actor.cpp
+++ b/fdbserver/OldTLogServer_6_2.actor.cpp
@@ -2124,7 +2124,6 @@ ACTOR Future<Void> initPersistentState(TLogData* self, Reference<LogData> logDat
 
 	// PERSIST: Initial setup of persistentData for a brand new tLog for a new database
 	state IKeyValueStore* storage = self->persistentData;
-	wait(storage->init());
 	storage->set(persistFormat);
 	storage->set(
 	    KeyValueRef(BinaryWriter::toValue(logData->logId, Unversioned()).withPrefix(persistCurrentVersionKeys.begin),
@@ -2766,7 +2765,6 @@ ACTOR Future<Void> restorePersistentState(TLogData* self,
 	TraceEvent("TLogRestorePersistentState", self->dbgid).log();
 
 	state IKeyValueStore* storage = self->persistentData;
-	wait(storage->init());
 	state Future<Optional<Value>> fFormat = storage->readValue(persistFormat.key);
 	state Future<Optional<Value>> fRecoveryLocation = storage->readValue(persistRecoveryLocationKey);
 	state Future<RangeResult> fVers = storage->readRange(persistCurrentVersionKeys);
@@ -3299,6 +3297,8 @@ ACTOR Future<Void> tLog(IKeyValueStore* persistentData,
 	TraceEvent("SharedTlog", tlogId).detail("Version", "6.2");
 
 	try {
+		wait(ioTimeoutError(persistentData->init(), SERVER_KNOBS->TLOG_MAX_CREATE_DURATION));
+
 		if (restoreFromDisk) {
 			wait(restorePersistentState(&self, locality, oldLog, recovered, tlogRequests));
 		} else {

--- a/fdbserver/VersionedBTree.actor.cpp
+++ b/fdbserver/VersionedBTree.actor.cpp
@@ -61,8 +61,8 @@ static double g_debugStart = 0;
 static FILE* g_debugStream = stdout;
 
 #define debug_printf_always(...)                                                                                       \
-	if (now() >= g_debugStart &&                                                                                       \
-	    (!g_network->getLocalAddress().isValid() || g_network->getLocalAddress() == g_debugAddress)) {                 \
+	if (now() >= g_debugStart && (!g_network->getLocalAddress().isValid() || !g_debugAddress.isValid() ||              \
+	                              g_network->getLocalAddress() == g_debugAddress)) {                                   \
 		std::string prefix = format("%s %f %04d ", g_network->getLocalAddress().toString().c_str(), now(), __LINE__);  \
 		std::string msg = format(__VA_ARGS__);                                                                         \
 		fputs(addPrefix(prefix, msg).c_str(), g_debugStream);                                                          \
@@ -5273,7 +5273,11 @@ public:
 		m_latestCommit.cancel();
 	}
 
-	Future<Void> commit(Version v) { return commit_impl(this, v); }
+	Future<Void> commit(Version v) {
+		// Replace latest commit with a new one which waits on the old one
+		m_latestCommit = commit_impl(this, v, m_latestCommit);
+		return m_latestCommit;
+	}
 
 	// Clear all btree data, allow pager remap to fully process its queue, and verify final
 	// page counts in pager and queues.
@@ -5548,6 +5552,7 @@ private:
 	struct CommitBatch {
 		Version readVersion;
 		Version writeVersion;
+		Version newOldestVersion;
 		std::unique_ptr<MutationBuffer> mutations;
 		int64_t mutationCount;
 		Reference<IPagerSnapshot> snapshot;
@@ -7239,7 +7244,7 @@ private:
 		}
 	}
 
-	ACTOR static Future<Void> commit_impl(VersionedBTree* self, Version writeVersion) {
+	ACTOR static Future<Void> commit_impl(VersionedBTree* self, Version writeVersion, Future<Void> previousCommit) {
 		// Take ownership of the current mutation buffer and make a new one
 		state CommitBatch batch;
 		batch.mutations = std::move(self->m_pBuffer);
@@ -7248,11 +7253,7 @@ private:
 		self->m_mutationCount = 0;
 
 		batch.writeVersion = writeVersion;
-
-		// Replace the lastCommit future with a new one and then wait on the old one
-		state Promise<Void> committed;
-		Future<Void> previousCommit = self->m_latestCommit;
-		self->m_latestCommit = committed.getFuture();
+		batch.newOldestVersion = self->m_newOldestVersion;
 
 		// Wait for the latest commit to be finished.
 		wait(previousCommit);
@@ -7262,20 +7263,19 @@ private:
 		if (writeVersion == self->m_pager->getLastCommittedVersion()) {
 			ASSERT(batch.mutationCount == 0);
 			debug_printf("%s: Empty commit at repeat version %" PRId64 "\n", self->m_name.c_str(), batch.writeVersion);
-			committed.send(Void());
 			return Void();
 		}
 
 		// For this commit, use the latest snapshot that was just committed.
 		batch.readVersion = self->m_pager->getLastCommittedVersion();
 
-		self->m_pager->setOldestReadableVersion(self->m_newOldestVersion);
+		self->m_pager->setOldestReadableVersion(batch.newOldestVersion);
 		debug_printf("%s: Beginning commit of version %" PRId64 ", read version %" PRId64
 		             ", new oldest version set to %" PRId64 "\n",
 		             self->m_name.c_str(),
 		             batch.writeVersion,
 		             batch.readVersion,
-		             self->m_newOldestVersion);
+		             batch.newOldestVersion);
 
 		batch.snapshot = self->m_pager->getReadSnapshot(batch.readVersion);
 
@@ -7333,7 +7333,6 @@ private:
 		++g_redwoodMetrics.metric.opCommit;
 		self->m_lazyClearActor = incrementalLazyClear(self);
 
-		committed.send(Void());
 		return Void();
 	}
 


### PR DESCRIPTION
#8410 

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
