### PR TITLE
Cherry pick pull request #8393

### DIFF
--- a/fdbclient/DatabaseContext.h
+++ b/fdbclient/DatabaseContext.h
@@ -627,6 +627,12 @@ public:
 	// Adds or updates the specified (UID, Tag) pair in the tag mapping.
 	void addSSIdTagMapping(const UID& uid, const Tag& tag);
 
+	// Returns the latest commit version that mutated the specified storage server.
+	// @in ssid id of the storage server interface
+	// @out tag storage server's tag, if an entry exists for "ssid" in "ssidTagMapping"
+	// @out commitVersion latest commit version that mutated the storage server
+	void getLatestCommitVersionForSSID(const UID& ssid, Tag& tag, Version& commitVersion);
+
 	// Returns the latest commit versions that mutated the specified storage servers
 	/// @note returns the latest commit version for a storage server only if the latest
 	// commit version of that storage server is below the specified "readVersion".
@@ -634,6 +640,14 @@ public:
 	                             Version readVersion,
 	                             Reference<TransactionState> info,
 	                             VersionVector& latestCommitVersions);
+
+	// Returns the latest commit version that mutated the specified storage server.
+	// @note this is a lightweight version of "getLatestCommitVersions()", to be used
+	// when the state ("TransactionState") of the transaction that fetched the read
+	// version is not available.
+	void getLatestCommitVersion(const StorageServerInterface& ssi,
+	                            Version readVersion,
+	                            VersionVector& latestCommitVersion);
 
 	// used in template functions to create a transaction
 	using TransactionT = ReadYourWritesTransaction;

--- a/fdbserver/workloads/ConsistencyCheck.actor.cpp
+++ b/fdbserver/workloads/ConsistencyCheck.actor.cpp
@@ -539,6 +539,9 @@ struct ConsistencyCheckWorkload : TestWorkload {
 					state int j = 0;
 					for (j = 0; j < iter_ss.size(); j++) {
 						resetReply(req);
+						if (SERVER_KNOBS->ENABLE_VERSION_VECTOR) {
+							cx->getLatestCommitVersion(iter_ss[j], req.version, req.ssLatestCommitVersions);
+						}
 						keyValueFutures.push_back(iter_ss[j].getKeyValues.getReplyUnlessFailedFor(req, 2, 0));
 					}
 
@@ -776,6 +779,9 @@ struct ConsistencyCheckWorkload : TestWorkload {
 					state std::vector<Future<ErrorOr<GetKeyValuesReply>>> keyValueFutures;
 					for (const auto& kv : shards[i].second) {
 						resetReply(req);
+						if (SERVER_KNOBS->ENABLE_VERSION_VECTOR) {
+							cx->getLatestCommitVersion(kv, req.version, req.ssLatestCommitVersions);
+						}
 						keyValueFutures.push_back(kv.getKeyValues.getReplyUnlessFailedFor(req, 2, 0));
 					}
 
@@ -965,6 +971,9 @@ struct ConsistencyCheckWorkload : TestWorkload {
 					state std::vector<Future<ErrorOr<GetKeyValuesReply>>> keyValueFutures;
 					for (const auto& kv : shards[i].second) {
 						resetReply(req);
+                        if (SERVER_KNOBS->ENABLE_VERSION_VECTOR) {
+                            cx->getLatestCommitVersion(kv, req.version, req.ssLatestCommitVersions);
+                        }
 						keyValueFutures.push_back(kv.getKeyValues.getReplyUnlessFailedFor(req, 2, 0));
 					}
 
@@ -1338,6 +1347,9 @@ struct ConsistencyCheckWorkload : TestWorkload {
 						state int j = 0;
 						for (j = 0; j < storageServerInterfaces.size(); j++) {
 							resetReply(req);
+                            if (SERVER_KNOBS->ENABLE_VERSION_VECTOR) {
+                                cx->getLatestCommitVersion(storageServerInterfaces[j], req.version, req.ssLatestCommitVersions);
+                            }
 							keyValueFutures.push_back(
 							    storageServerInterfaces[j].getKeyValues.getReplyUnlessFailedFor(req, 2, 0));
 						}

--- a/fdbserver/workloads/ConsistencyCheck.actor.cpp
+++ b/fdbserver/workloads/ConsistencyCheck.actor.cpp
@@ -971,9 +971,9 @@ struct ConsistencyCheckWorkload : TestWorkload {
 					state std::vector<Future<ErrorOr<GetKeyValuesReply>>> keyValueFutures;
 					for (const auto& kv : shards[i].second) {
 						resetReply(req);
-                        if (SERVER_KNOBS->ENABLE_VERSION_VECTOR) {
-                            cx->getLatestCommitVersion(kv, req.version, req.ssLatestCommitVersions);
-                        }
+						if (SERVER_KNOBS->ENABLE_VERSION_VECTOR) {
+							cx->getLatestCommitVersion(kv, req.version, req.ssLatestCommitVersions);
+						}
 						keyValueFutures.push_back(kv.getKeyValues.getReplyUnlessFailedFor(req, 2, 0));
 					}
 
@@ -1347,9 +1347,10 @@ struct ConsistencyCheckWorkload : TestWorkload {
 						state int j = 0;
 						for (j = 0; j < storageServerInterfaces.size(); j++) {
 							resetReply(req);
-                            if (SERVER_KNOBS->ENABLE_VERSION_VECTOR) {
-                                cx->getLatestCommitVersion(storageServerInterfaces[j], req.version, req.ssLatestCommitVersions);
-                            }
+							if (SERVER_KNOBS->ENABLE_VERSION_VECTOR) {
+								cx->getLatestCommitVersion(
+								    storageServerInterfaces[j], req.version, req.ssLatestCommitVersions);
+							}
 							keyValueFutures.push_back(
 							    storageServerInterfaces[j].getKeyValues.getReplyUnlessFailedFor(req, 2, 0));
 						}


### PR DESCRIPTION
Version vector specific: Propagate the latest commit version, as part of the read request, when reading from a storage server.

Test that found this issue: Enabling version vector, with BLOCKING_PEEK_TIMEOUT set to 1.0sec, on "release-7.1" branch.
build_output/bin/fdbserver -r simulation --crash -f /root/src/foundationdb/tests/fast/MutationLogReaderCorrectness.toml -b on -s 152835360

Testing:

The above test succeeds with this change set.
Simulation tests:
Compiler: gcc.
With version vector disabled: 20221006-133758-sre-b80b9a256782a16e (no failures).
With version vector enabled: 20221006-134942-sre-15b91d7b6ca98d64 (shows a failure in MutationLogReaderCorrectness.toml, a crash after "TracedTooManyLines" trace event, the failure that I saw on "main" too, in the context of PR https://github.com/apple/foundationdb/pull/8393, so I don't think this failure should block this PR).

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
