### PR TITLE
Fix storageEngineExcludeTypes format in test specs

### DIFF
--- a/tests/restarting/from_7.0.0/UpgradeAndBackupRestore-1.toml
+++ b/tests/restarting/from_7.0.0/UpgradeAndBackupRestore-1.toml
@@ -1,4 +1,5 @@
-storageEngineExcludeTypes=3
+[configuration]
+storageEngineExcludeTypes=[3]
 
 [[test]]
 testTitle = 'SubmitBackup'

--- a/tests/restarting/from_7.1.0/ConfigureStorageMigrationTestRestart-1.toml
+++ b/tests/restarting/from_7.1.0/ConfigureStorageMigrationTestRestart-1.toml
@@ -1,5 +1,6 @@
 [configuration]
 extraMachineCountDC = 2
+storageEngineExcludeTypes = [3]
 
 [[test]]
 testTitle = 'CloggedConfigureDatabaseTest'

--- a/tests/restarting/from_7.1.0/ConfigureTestRestart-1.toml
+++ b/tests/restarting/from_7.1.0/ConfigureTestRestart-1.toml
@@ -1,3 +1,6 @@
+[configuration]
+storageEngineExcludeTypes = [3]
+
 [[test]]
 testTitle='CloggedConfigureDatabaseTest'
 clearAfterTest=false

--- a/tests/restarting/from_7.1.0/SnapCycleRestart-1.txt
+++ b/tests/restarting/from_7.1.0/SnapCycleRestart-1.txt
@@ -1,4 +1,4 @@
-storageEngineExcludeTypes=[3, 4, 5]
+storageEngineExcludeTypes=3,4,5
 
 ;Take snap and do cycle test
 testTitle=SnapCyclePre

--- a/tests/restarting/from_7.1.0/SnapCycleRestart-2.txt
+++ b/tests/restarting/from_7.1.0/SnapCycleRestart-2.txt
@@ -1,4 +1,4 @@
-storageEngineExcludeTypes=[4, 5]
+storageEngineExcludeTypes=4,5
 buggify=off
 
 testTitle=SnapCycleRestore

--- a/tests/restarting/from_7.1.0/SnapIncrementalRestore-1.txt
+++ b/tests/restarting/from_7.1.0/SnapIncrementalRestore-1.txt
@@ -1,4 +1,4 @@
-storageEngineExcludeTypes=[3, 4, 5]
+storageEngineExcludeTypes=3,4,5
 
 logAntiQuorum = 0
 

--- a/tests/restarting/from_7.1.0/SnapIncrementalRestore-2.txt
+++ b/tests/restarting/from_7.1.0/SnapIncrementalRestore-2.txt
@@ -1,4 +1,4 @@
-storageEngineExcludeTypes=[4, 5]
+storageEngineExcludeTypes=4,5
 
 testTitle=RestoreBackup
 simBackupAgents=BackupToFile

--- a/tests/restarting/from_7.1.0/SnapTestAttrition-1.txt
+++ b/tests/restarting/from_7.1.0/SnapTestAttrition-1.txt
@@ -1,4 +1,4 @@
-storageEngineExcludeTypes=[3, 4, 5]
+storageEngineExcludeTypes=3,4,5
 
 ;write 1000 Keys ending with even numbers
 testTitle=SnapTestPre

--- a/tests/restarting/from_7.1.0/SnapTestAttrition-2.txt
+++ b/tests/restarting/from_7.1.0/SnapTestAttrition-2.txt
@@ -1,4 +1,4 @@
-storageEngineExcludeTypes=[4, 5]
+storageEngineExcludeTypes=4,5
 
 buggify=off
 

--- a/tests/restarting/from_7.1.0/SnapTestRestart-1.txt
+++ b/tests/restarting/from_7.1.0/SnapTestRestart-1.txt
@@ -1,4 +1,4 @@
-storageEngineExcludeTypes=[3, 4, 5]
+storageEngineExcludeTypes=3,4,5
 
 ;write 1000 Keys ending with even numbers
 testTitle=SnapTestPre

--- a/tests/restarting/from_7.1.0/SnapTestRestart-2.txt
+++ b/tests/restarting/from_7.1.0/SnapTestRestart-2.txt
@@ -1,4 +1,4 @@
-storageEngineExcludeTypes=[4, 5]
+storageEngineExcludeTypes=4,5
 
 buggify=off
 

--- a/tests/restarting/from_7.1.0/SnapTestSimpleRestart-1.txt
+++ b/tests/restarting/from_7.1.0/SnapTestSimpleRestart-1.txt
@@ -1,4 +1,4 @@
-storageEngineExcludeTypes=[3, 4, 5]
+storageEngineExcludeTypes=3,4,5
 
 ;write 1000 Keys ending with even number
 testTitle=SnapSimplePre

--- a/tests/restarting/from_7.1.0/SnapTestSimpleRestart-2.txt
+++ b/tests/restarting/from_7.1.0/SnapTestSimpleRestart-2.txt
@@ -1,4 +1,4 @@
-storageEngineExcludeTypes=[4, 5]
+storageEngineExcludeTypes=4,5
 
 buggify=off
 

--- a/tests/restarting/from_7.1.0/VersionVectorDisableRestart-1.toml
+++ b/tests/restarting/from_7.1.0/VersionVectorDisableRestart-1.toml
@@ -1,3 +1,5 @@
+storageEngineExcludeTypes=3
+
 [[knobs]]
 enable_version_vector = true
 enable_version_vector_tlog_unicast = true

--- a/tests/restarting/from_7.1.0/VersionVectorDisableRestart-1.toml
+++ b/tests/restarting/from_7.1.0/VersionVectorDisableRestart-1.toml
@@ -1,4 +1,5 @@
-storageEngineExcludeTypes=3
+[configuration]
+storageEngineExcludeTypes = [3]
 
 [[knobs]]
 enable_version_vector = true

--- a/tests/restarting/from_7.1.0/VersionVectorEnableRestart-1.toml
+++ b/tests/restarting/from_7.1.0/VersionVectorEnableRestart-1.toml
@@ -1,4 +1,5 @@
-storageEngineExcludeTypes=3
+[configuration]
+storageEngineExcludeTypes = [3]
 
 [[knobs]]
 enable_version_vector = false

--- a/tests/restarting/from_7.1.0/VersionVectorEnableRestart-1.toml
+++ b/tests/restarting/from_7.1.0/VersionVectorEnableRestart-1.toml
@@ -1,3 +1,5 @@
+storageEngineExcludeTypes=3
+
 [[knobs]]
 enable_version_vector = false
 enable_version_vector_tlog_unicast = false

--- a/tests/restarting/to_7.1.0/ConfigureStorageMigrationTestRestart-1.toml
+++ b/tests/restarting/to_7.1.0/ConfigureStorageMigrationTestRestart-1.toml
@@ -3,7 +3,7 @@ extraMachineCountDC = 2
 maxTLogVersion=6
 disableHostname=true
 disableEncryption=true
-storageEngineExcludeTypes=[4]
+storageEngineExcludeTypes=[3,4]
 
 [[test]]
 testTitle = 'CloggedConfigureDatabaseTest'


### PR DESCRIPTION
For .txt test specs the format for `storageEngineExcludeTypes` should be `=3,4,5` instead of `=[3, 4, 5]`

Also temporarily disable Redwood from 7.1.0 restart tests.

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
