### PR TITLE
Fixed spacing in fdbcli status so dashes are aligned

### DIFF
--- a/fdbcli/StatusCommand.actor.cpp
+++ b/fdbcli/StatusCommand.actor.cpp
@@ -442,7 +442,7 @@ void printStatus(StatusObjectReader statusObj,
 					outputString += "\n  Blob granules          - enabled";
 				}
 
-				outputString += "\n  Encryption at-rest    - ";
+				outputString += "\n  Encryption at-rest     - ";
 				if (statusObjConfig.get("encryption_at_rest_mode", strVal)) {
 					outputString += strVal;
 				} else {


### PR DESCRIPTION
A spacing issue in fdbcli made this a bit harder to read

Before:
```Configuration:
  Redundancy mode        - single
  Storage engine         - ssd-2
  Blob granules          - enabled
  Encryption at-rest    - disabled
  Coordinators           - 1
  Usable Regions         - 1
```

After:
```Configuration:
  Redundancy mode        - single
  Storage engine         - ssd-2
  Blob granules          - enabled
  Encryption at-rest     - disabled
  Coordinators           - 1
  Usable Regions         - 1
```


# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
