### PR TITLE
Disable authz integration test for sanitizer builds (snowflake/release-71.2)

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -397,7 +397,7 @@ if(WITH_PYTHON)
     endif()
   endif()
 
-  if (NOT WIN32)
+  if (NOT OPEN_FOR_IDE AND NOT WIN32 AND NOT USE_SANITIZER)
     # setup venv for testing token-based authorization
     if (APPLE)
       set(ld_env_name "DYLD_LIBRARY_PATH")
@@ -423,12 +423,10 @@ if(WITH_PYTHON)
     set_tests_properties(authorization_venv_setup PROPERTIES FIXTURES_SETUP authz_virtual_env TIMEOUT 60)
 
     set(authz_script_dir ${CMAKE_SOURCE_DIR}/tests/authorization)
-    set(authz_test_cmd "")
-    string(APPEND authz_test_cmd "${authz_venv_activate} && ")
-    string(APPEND authz_test_cmd "pytest ${authz_script_dir}/authz_test.py -rA --build-dir ${CMAKE_BINARY_DIR} -vvv")
+    set(authz_test_cmd "${authz_venv_activate} && pytest ${authz_script_dir}/authz_test.py -rA --build-dir ${CMAKE_BINARY_DIR} -vvv")
     add_test(
       NAME token_based_tenant_authorization
-      WORKING_DIRECTORY ${authz_script_dir}
+      WORKING_DIRECTORY ${authz_venv_dir}
       COMMAND bash -c ${authz_test_cmd})
     set_tests_properties(token_based_tenant_authorization PROPERTIES ENVIRONMENT "PYTHONPATH=${CMAKE_SOURCE_DIR}/tests/TestRunner;${ld_env_name}=${CMAKE_BINARY_DIR}/lib")
     set_tests_properties(token_based_tenant_authorization PROPERTIES FIXTURES_REQUIRED authz_virtual_env)


### PR DESCRIPTION
Cherry pick https://github.com/apple/foundationdb/pull/8283 to snowflake/release-71.2



Language bindings do not work well with sanitizer instrumentation


# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
