### PR TITLE
[cherry-pick]: Extend DBCoreState to store EncryptionAtRest status

### DIFF
--- a/fdbserver/include/fdbserver/DBCoreState.h
+++ b/fdbserver/include/fdbserver/DBCoreState.h
@@ -200,8 +200,7 @@ struct DBCoreState {
 			           tLogs[0].tLogWriteAntiQuorum,
 			           recoveryCount,
 			           tLogs[0].tLogReplicationFactor,
-			           logSystemType,
-			           encryptionAtRestMode);
+			           logSystemType);
 			tLogs[0].tLogVersion = TLogVersion::V2;
 
 			uint64_t tLocalitySize = (uint64_t)tLogs[0].tLogLocalities.size();


### PR DESCRIPTION
Description

Patch updates DBCoreState to include `encryptionAtRestMode` stored in co-ordinators. The change only extends DBCoreState, however, the value wouldn't get serialized as the 'CoordinateState' writer (ReusableCoordiantedState) protocol version is left at DBCoreState. Approach assists in playing nice with downgrades, the subsequent release would bump up writer protocol version to support 'EncryptionAtRest' protocol version compatibility.

Testing

devRunCorrectness - 100K (20221008-030233-ahusain-foundationdb-10d28b2123e6838b)

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
